### PR TITLE
Add cabal sandbox files, .DS_Store to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 .*.sw[a-p]
 .*.vim
+.cabal-sandbox/
+.DS_Store
 .sw[a-p]
 *.agdai
 *.hi
@@ -14,6 +16,7 @@
 agda-ffi/dist
 agda-stdlib
 autom4te.cache
+cabal.sandbox.config
 config.log
 config.status
 configure


### PR DESCRIPTION
Add .cabal-sandbox directory and cabal.sandbox.config to ease using a cabal sandbox in the agda directory.

Add .DS_Store which Mac Finder creates automatically.
