### PR TITLE
Allow Unicode ellipsis character for ellipsis token.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@
 
 Important changes since 2.4.2.2:
 
+* Unicode ellipsis character is allowed for the ellipsis token ... in `with` expressions.
+
 Installation and infrastructure
 ===============================
 

--- a/src/full/Agda/Syntax/Parser/LexActions.hs
+++ b/src/full/Agda/Syntax/Parser/LexActions.hs
@@ -69,6 +69,7 @@ lexToken =
 
 postToken :: Token -> Token
 postToken (TokId (r, "\x03bb")) = TokSymbol SymLambda r
+postToken (TokId (r, "\x2026")) = TokSymbol SymEllipsis r
 postToken (TokId (r, "\x2192")) = TokSymbol SymArrow r
 postToken (TokId (r, "\x2983")) = TokSymbol SymDoubleOpenBrace r
 postToken (TokId (r, "\x2984")) = TokSymbol SymDoubleCloseBrace r

--- a/test/succeed/UnicodeEllipsis.agda
+++ b/test/succeed/UnicodeEllipsis.agda
@@ -1,0 +1,6 @@
+
+module UnicodeEllipsis where
+
+f : {A B : Set} → (A → B) → A → B
+f g a with g a
+… | x = x


### PR DESCRIPTION
Agda seems to allow, and even prefer, Unicode characters when available. The Unicode ellipsis character U+2026 seemed to be a gap in that space. It's a simple addition to the lexer.