### PR TITLE
Fix build with mtl-2.1.3.1 or earlier

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -8,7 +8,6 @@ import Data.Maybe
 
 import Control.Applicative
 import Control.Monad hiding (mapM)
-import Control.Monad.Except hiding (mapM)
 import Control.Monad.State hiding (mapM)
 
 import Data.Traversable
@@ -49,6 +48,7 @@ import Agda.TypeChecking.Rules.LHS.Implicit
 import Agda.TypeChecking.Rules.LHS.Instantiate
 import Agda.TypeChecking.Rules.Data
 
+import Agda.Utils.Except (MonadError(..))
 import Agda.Utils.Functor (($>))
 import Agda.Utils.ListT
 import Agda.Utils.Monad


### PR DESCRIPTION
Currently, `Agda.TypeChecking.Rules.LHS` imports `Control.Monad.Except`, which is a module only available on `mtl-2.2.1` or later. The file is only importing `Control.Monad.Except` to get `catchError` and `throwError` anyway, which reside in `Agda.Utils.Except`.