### PR TITLE
Import orphan instances from base-orphans

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -71,6 +71,7 @@ library
   build-depends:
     array >= 0.4.0.0 && < 0.6
     , base >= 4.5.0.0 && < 4.9
+    , base-orphans >= 0.1 && < 0.4
     , binary >= 0.6 && < 0.8
     , boxes >= 0.1.3 && < 0.2
     -- NFData ByteString is only available from bytestring >= 0.10

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -1,10 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if __GLASGOW_HASKELL__ <= 706
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE StandaloneDeriving #-}
-#endif
-
 module Agda.Interaction.Options
     ( CommandLineOptions(..)
     , PragmaOptions(..)
@@ -34,6 +27,7 @@ module Agda.Interaction.Options
     ) where
 
 import Control.Monad            ( when )
+import Data.Orphans             ()
 import Data.Maybe               ( isJust )
 import Data.List                ( isSuffixOf , intercalate )
 import System.Console.GetOpt    ( getOpt, usageInfo, ArgOrder(ReturnInOrder)
@@ -62,12 +56,6 @@ isLiterate :: FilePath -> Bool
 isLiterate file = ".lagda" `isSuffixOf` file
 
 -- OptDescr is a Functor --------------------------------------------------
-
--- base-4.7 defines these
-#if !(MIN_VERSION_base(4,7,0))
-deriving instance Functor OptDescr
-deriving instance Functor ArgDescr
-#endif
 
 type Verbosity = Trie String Int
 

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -28,6 +28,7 @@ import Data.Function
 import qualified Data.List as List
 import Data.Maybe
 import Data.Monoid
+import Data.Orphans ()
 import Data.Traversable
 import Data.Typeable (Typeable)
 
@@ -947,10 +948,6 @@ class TermSize a where
   termSize = getSum . tsize
 
   tsize :: a -> Sum Int
-
-#if !MIN_VERSION_base(4,7,0)
-deriving instance Num a => Num (Sum a)
-#endif
 
 instance (Foldable t, TermSize a) => TermSize (t a) where
   tsize = foldMap tsize


### PR DESCRIPTION
This pull request replaces `Agda`'s orphan instances (`Functor OptDescr`, `Functor ArgDescr`, and `Num (Sum a)`) with ones exported from the `base-orphans` library. This helps mitigate the possibility of other dependencies defining these orphan instances and causing instance conflicts on old versions of GHC.