### PR TITLE
fix haddock markup

### DIFF
--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -305,8 +305,8 @@ data Interaction' range
                         B.Rewrite
                         String
 
--- | Shows all the top-level names in scope which mention all the given
--- identifiers in their type.
+    -- | Shows all the top-level names in scope which mention all the given
+    -- identifiers in their type.
   | Cmd_search_about_toplevel B.Rewrite String
 
   | Cmd_solveAll


### PR DESCRIPTION
Detected on haddock-2.16/ghc-7.10:
src/full/Agda/Interaction/InteractionTop.hs:310:3:
    parse error on input ‘|’

Signed-off-by: Sergei Trofimovich <siarheit@google.com>