### PR TITLE
Bump base-orphans upper version bounds

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -117,7 +117,7 @@ library
     , zlib >= 0.4.0.1 && < 0.6.1
 
   if impl(ghc < 7.8)
-    build-depends: base-orphans >= 0.3.1 && < 0.4
+    build-depends: base-orphans >= 0.3.1 && < 0.5
 
   build-tools:
     alex >= 3.1.0 && < 3.2


### PR DESCRIPTION
This allows `Agda` to build with the latest version of `base-orphans` (the only difference is that `base-orphans-0.4` removes `Generic` instances, which doesn't affect `Agda`).

If you want to get `Agda` [into Stackage](https://github.com/fpco/stackage/pull/520), this will need to be fixed at some point, so here it is. :)