### PR TITLE
Keep track of std-lib as a git submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ src/full/Agda/Syntax/Parser/Lexer.hs
 src/full/Agda/Syntax/Parser/Parser.hs
 src/full/tags
 src/full/TAGS
-std-lib
 test/compiler/Main
 test/epic/RunTests
 test/epic/tests/bin/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "std-lib"]
+	path = std-lib
+	url = https://github.com/agda/agda-stdlib
+	branch = master

--- a/Makefile
+++ b/Makefile
@@ -161,16 +161,11 @@ latex-html-test :
 
 .PHONY : std-lib
 std-lib :
-	if [ ! -d $@ ]; then \
-	   git clone https://github.com/agda/agda-stdlib.git \
-	             --single-branch $@; \
-	fi
+	git submodule init -- std-lib
 
 .PHONY : up-to-date-std-lib
-up-to-date-std-lib : std-lib
-	@(cd std-lib && \
-	  git fetch && git checkout master && git merge origin/master && \
-	  make setup)
+up-to-date-std-lib :
+	git submodule update --init --remote std-lib
 
 .PHONY : library-test
 library-test : # up-to-date-std-lib


### PR DESCRIPTION
A git submodule is a reference to another git repository from
a parent repository. The reference is a specific directory in the
repository, where the submodule "lives".

In our case, the parent is agda/agda, and the submodule is
agda/agda-stdlib.  The submodule lives in the directory /std-lib .

Each commit A in the parent repository references a specific commit B of the
child repository. In our case, the commit referenced should be the version
of the standard library that is supposed to work with the contents of
the parent repository.

The parent repository also contains a `.gitmodule` file in the root,
which specifies a URL and branch name for the submodule.

To initalize and update the submodule, you may use the usual `std-lib`
and `up-to-date-std-lib` rules in the Makefile.

After updating the submodule, you may run …

```
git add std-lib
git commit
```

from the root to make the repository point to the new version of the
standard library.
