### PR TITLE
Keep track of std-lib as a git submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ src/full/Agda/Syntax/Parser/Lexer.hs
 src/full/Agda/Syntax/Parser/Parser.hs
 src/full/tags
 src/full/TAGS
-std-lib
 test/compiler/Main
 test/epic/RunTests
 test/epic/tests/bin/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "std-lib"]
+	path = std-lib
+	url = https://github.com/agda/agda-stdlib
+	branch = 2.4.2.5

--- a/HACKING
+++ b/HACKING
@@ -1,4 +1,4 @@
-Working with Git (from 2014-06-15)
+Working with Git (from 2013-06-15)
 
 * Maintenance branches.
 
@@ -141,6 +141,43 @@ Working with Git (from 2014-06-15)
     git reset --hard
 
     exit $status
+
+Standard library submodule
+
+* A large part of the test suite involves the standard library.
+  Each version of Agda is deemed compatible with a corresponding version of the
+  standard library.
+
+* Each commit in the main agda repository has a reference to a branch and a
+  commit in the standard library repository. The tests are run using this
+  referenced version of the standard library.
+
+  + The file `/.gitmodules` contains the URL of the standard library
+    repository and the name of the branch.
+
+  + The path `/std-lib` is treated by git as a file containing the hash of the
+    referenced commit.
+
+* To obtain the referenced version of the standard library, run:
+    make std-lib
+
+* To obtain and install the referenced version of the standard library, run:
+    make up-to-date-std-lib
+
+* To obtain and install  the newest version of the standard library for the
+  referenced branch, run:
+    make fast-forward-std-lib
+
+  If the new version of the standard library also passes all tests, you can
+  have the repository point to it:
+    git add std-lib
+    git commit
+
+* The standard library is tracked as a git submodule, which means that the
+  `/std-lib` subdirectory will appear as a git repository in detached-head
+  state.
+
+  See: https://www.git-scm.com/book/en/v2/Git-Tools-Submodules
 
 Testing and documentation
 

--- a/HACKING
+++ b/HACKING
@@ -174,8 +174,14 @@ Standard library submodule
     git commit
 
 * The standard library is tracked as a git submodule, which means that the
-  `/std-lib` subdirectory will appear as a git repository in detached-head
+  `/std-lib` subdirectory will appear as a git repository in a detached-HEAD
   state.
+
+  To avoid this, you may run, inside the submodule directory:
+    git checkout <branch name>
+
+  and then, from the root directory:
+    git submodule update --remote [--merge|--rebase]
 
   See: https://www.git-scm.com/book/en/v2/Git-Tools-Submodules
 

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,6 @@ SHELL=bash
 # Profiling verbosity for library-test
 PROFVERB=7
 
-# Agda standard library branch.
-STD_LIB_BRANCH = 2.4.2.5
-
 # Various paths and commands
 
 TOP=.
@@ -162,18 +159,11 @@ latex-test :
 
 .PHONY : std-lib
 std-lib :
-	if [ ! -d $@ ]; then \
-	   git clone https://github.com/agda/agda-stdlib.git \
-	       --branch $(STD_LIB_BRANCH) --single-branch $@; \
-	fi
+	git submodule update --init --remote std-lib
 
 .PHONY : up-to-date-std-lib
-up-to-date-std-lib : std-lib
-	@(cd std-lib && \
-	  git fetch && \
-          git checkout $(STD_LIB_BRANCH) && \
-          git merge origin/$(STD_LIB_BRANCH) && \
-	  make setup)
+up-to-date-std-lib :
+	git submodule update --init --remote std-lib
 
 .PHONY : library-test
 library-test : # up-to-date-std-lib

--- a/Makefile
+++ b/Makefile
@@ -163,9 +163,13 @@ std-lib :
 
 .PHONY : up-to-date-std-lib
 up-to-date-std-lib :
-	@(git submodule update --init --remote std-lib && \
-	  cd std-lib && \
-	  make setup)
+	git submodule update --init std-lib
+	@(cd std-lib && make setup)
+
+.PHONY : fast-forward-std-lib
+fast-forward-std-lib :
+	git submodule update --init --remote std-lib
+	@(cd std-lib && make setup)
 
 .PHONY : library-test
 library-test : # up-to-date-std-lib

--- a/Makefile
+++ b/Makefile
@@ -159,11 +159,11 @@ latex-test :
 
 .PHONY : std-lib
 std-lib :
-	git submodule update --init --remote std-lib
+	git submodule update --init std-lib
 
 .PHONY : up-to-date-std-lib
 up-to-date-std-lib :
-	@(git submodule update --init --remote std-lib && \
+	@(git submodule update --init std-lib && \
 	  cd std-lib && \
 	  make setup)
 

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ std-lib :
 
 .PHONY : up-to-date-std-lib
 up-to-date-std-lib :
-	@(git submodule update --init std-lib && \
+	@(git submodule update --init --remote std-lib && \
 	  cd std-lib && \
 	  make setup)
 

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,9 @@ std-lib :
 
 .PHONY : up-to-date-std-lib
 up-to-date-std-lib :
-	git submodule update --init --remote std-lib
+	@(git submodule update --init --remote std-lib && \
+	  cd std-lib && \
+	  make setup)
 
 .PHONY : library-test
 library-test : # up-to-date-std-lib

--- a/notes/agda-maintenance-releases
+++ b/notes/agda-maintenance-releases
@@ -129,9 +129,16 @@ followed:
 * Create a new branch in the standard library repository from the
   VERSION branch called NEWVERSION.
 
-* Update in the Makefile the STD_LIB_BRANCH variable:
+* Update the git submodule branch, by running the following at the root
+  of the main repository:
 
-    STD_LIB_BRANCH = NEWVERSION
+    git config -f .gitmodules submodule.std-lib.branch NEWVERSION
+    git submodule sync
+    git submodule update --init --remote std-lib
+
+  Remember to add the new reference to the index before committing:
+
+    git add std-lib
 
 * Push all changes and merge into 'master' branch (requires Git >= 1.8.3).
 


### PR DESCRIPTION
A git submodule is a reference to another git repository from
a parent repository. The reference is a specific directory in the
repository, where the submodule `lives`.

In our case, the parent is agda/agda, and the submodule is
agda/agda-stdlib.  The submodule lives in the directory /std-lib .

Each commit A in the parent repository references a specific commit B of the
child repository. In our case, the commit referenced should be the version
of the standard library that is supposed to work with the contents of
the parent repository.

The parent repository also contains a `.gitmodules` file in the root,
which specifies a URL and branch name for the submodule.

To initalize and update the submodule, you may use the usual `std-lib`
and `up-to-date-stdlib` rules in the Makefile.

After updating the standard library, you may run …

```
git add std-lib
git commit
```

… from the root to make the repository point to the new version.

Finally, note that the std-lib branch is now specified in the
`.gitmodules` file in the root, and not in the Makefile.

If you change the branch, run …

```
git submodule sync
```

… afterwards to update the contents of the `std-lib` directory to
those of the new branch.
