### PR TITLE
Telescope.hs: fix haddock markup:

### DIFF
--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -225,9 +225,9 @@ instantiateTelescope
   :: Telescope -- ^ ⊢ Γ
   -> Int       -- ^ Γ ⊢ var k : A
   -> Term      -- ^ Γ ⊢ u : A
-  -> Maybe (Telescope,           -- ^ ⊢ Γ'
-            PatternSubstitution, -- ^ Γ' ⊢ σ : Γ
-            Permutation)         -- ^ Γ  ⊢ flipP ρ : Γ'
+  -> Maybe (Telescope,           -- ⊢ Γ'
+            PatternSubstitution, -- Γ' ⊢ σ : Γ
+            Permutation)         -- Γ  ⊢ flipP ρ : Γ'
 instantiateTelescope tel k u = guard ok $> (tel', sigma, rho)
   where
     names = teleNames tel


### PR DESCRIPTION
Haddock does not support docstrings for
individual unnamed tuple fields:
  src/full/Agda/TypeChecking/Telescope.hs:228:34:
    parse error on input ‘-- ^ ⊢ Γ'’

Signed-off-by: Sergei Trofimovich siarheit@google.com
