### PR TITLE
[ Fixed #1692 ] With-abstraction also in types of variables used in with-expressions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,41 @@ Pragmas and options
 * Termination pragmas are not allowed inside `where` clauses
   [Issue 1137].
 
+Type checking
+=============
+
+* `with`-abstraction is more agressive, abstracts also in types of
+  variables that are used in the `with`-expressions, unless they are
+  also used in the types of the `with`-expressions. [Issue 1692]
+
+  Example:
+
+  ```agda
+    test : (f : (x : A) → a ≡ x) (b : A) → b ≡ a
+    test f b with a | f b
+    test f b | .b | refl = f b
+  ```
+
+  Previously, `with` would not abstract in types of variables that
+  appear in the `with`-expressions, in this case, both `f` and `b`,
+  leaving their types unchanged.
+  Now, it tries to abstract in `f`, as only `b` appears in the types of
+  the `with`-expressions which are `A` (of `a`) and `a ≡ b` (of `f b`).
+  As a result, the type of `f` changes to `(x : A) → b ≡ x` and the
+  type of the goal to `b ≡ b` (as previously).
+
+  This also affects `rewrite`, which is implemented in terms of
+  `with`.
+
+  ```agda
+    test : (f : (x : A) → a ≡ x) (b : A) → b ≡ a
+    test f b rewrite f b = f b
+  ```
+
+  As the new `with` is not fully backwards-compatible, some parts of
+  your Agda developments using `with` or `rewrite` might need
+  maintenance.
+
 Fixed issues
 ============
 

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -519,7 +519,7 @@ checkClause t c@(A.Clause (A.SpineLHS i x aps withPats) rhs0 wh) = do
 
                     -- Andreas, 2013-02-26 separate msgs to see which goes wrong
                     reportSDoc "tc.with.top" 20 $
-                      text "    with arguments" <+> do escapeContext (size delta) $ addContext delta1 $ prettyList (map prettyTCM vs)
+                      text "    with arguments" <+> do escapeContext (size delta) $ addContext delta1 $ addContext delta2 $ prettyList (map prettyTCM vs)
                     reportSDoc "tc.with.top" 20 $
                       text "             types" <+> do escapeContext (size delta) $ addContext delta1 $ prettyList (map prettyTCM as)
                     reportSDoc "tc.with.top" 20 $
@@ -567,7 +567,7 @@ checkWithFunction (WithFunction f aux t delta1 delta2 vs as b qs perm' perm fina
       , text "delta2 =" <+> addCtxTel delta1 (prettyTCM delta2)
       , text "t      =" <+> prettyTCM t
       , text "as     =" <+> addCtxTel delta1 (prettyTCM as)
-      , text "vs     =" <+> addCtxTel delta1 (prettyTCM vs)
+      , text "vs     =" <+> do addCtxTel delta1 $ addCtxTel delta2 $ prettyTCM vs
       , text "b      =" <+> do addCtxTel delta1 $ addCtxTel delta2 $ prettyTCM b
       , text "qs     =" <+> text (show qs)
       , text "perm'  =" <+> text (show perm')

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE TupleSections #-}
 
 module Agda.TypeChecking.With where
 
@@ -102,7 +103,7 @@ splitTelForWith
 splitTelForWith delta t as vs = let
     -- Split the telescope into the part needed to type the with arguments
     -- and all the other stuff
-    fv = allFreeVars (vs, as)
+    fv = allFreeVars as
     SplitTel delta1 delta2 perm = splitTelescope fv delta
 
     -- Δ₁Δ₂ ⊢ π : Δ
@@ -117,35 +118,113 @@ splitTelForWith delta t as vs = let
     -- and Δ₁ ⊢ as'
     as' = applySubst rhopi as
     -- and Δ₁ ⊢ vs' : as'
-    vs' = applySubst rhopi vs
+    vs' = applySubst pi vs
 
   in (delta1, delta2, perm, t', as', vs')
 
 
-withFunctionType :: Telescope -> [Term] -> [Type] -> Telescope -> Type -> TCM Type
-withFunctionType delta1 vs as delta2 b = {-dontEtaContractImplicit $-} do
-  (vas, b) <- addCtxTel delta1 $ do
-    reportSLn "tc.with.abstract" 20 $ "preparing for with-abstraction"
+-- | Abstract with-expressions @vs@ to generate type for with-helper function.
+
+withFunctionType
+  :: Telescope  -- ^ @Δ₁@                       context for types of with types.
+  -> [Term]     -- ^ @Δ₁,Δ₂ ⊢ vs : raise Δ₂ as@  with-expressions.
+  -> [Type]     -- ^ @Δ₁ ⊢ as@                  types of with-expressions.
+  -> Telescope  -- ^ @Δ₁ ⊢ Δ₂@                  context extension to type with-expressions.
+  -> Type       -- ^ @Δ₁,Δ₂ ⊢ b@                type of rhs.
+  -> TCM Type   -- ^ @Δ₁ → wtel → Δ₂′ → b′@ such that
+    -- @[vs/wtel]wtel = as@ and
+    -- @[vs/wtel]Δ₂′ = Δ₂@ and
+    -- @[vs/wtel]b′ = b@.
+
+withFunctionType delta1 vs as delta2 b = addCtxTel delta1 $ do
+
+  -- Normalize and η-contract the types @as@ of the with-expressions.
+
+  reportSLn "tc.with.abstract" 20 $ "preparing for with-abstraction"
+  as <- etaContract =<< normalise as
+  reportSDoc "tc.with.abstract" 20 $ text "  as = " <+> prettyTCM as
+
+  -- Normalize and η-contract the type @b@ of the rhs and the types @delta2@
+  -- of the pattern variables not mentioned in @as@.
+
+  d2b <- return $ telePi_ delta2 b
+  reportSDoc "tc.with.abstract" 30 $ text "normalizing d2b = " <+> prettyTCM d2b
+  d2b  <- normalise d2b
+  reportSDoc "tc.with.abstract" 30 $ text "eta-contracting d2b = " <+> prettyTCM d2b
+  d2b  <- etaContract d2b
+  reportSDoc "tc.with.abstract" 20 $ text "  d2b  = " <+> prettyTCM d2b
+  let n2 = size delta2
+  TelV delta2 b <- telViewUpTo n2 d2b
+
+  addContext delta2 $ do
+
+    -- Normalize and η-contract the with-expressions @vs@.
+
     vs <- etaContract =<< normalise vs
     reportSDoc "tc.with.abstract" 20 $ text "  vs = " <+> prettyTCM vs
-    as <- etaContract =<< normalise as
-    reportSDoc "tc.with.abstract" 20 $ text "  as = " <+> prettyTCM as
-    b <- return $ telePi_ delta2 b
-    reportSDoc "tc.with.abstract" 30 $ text "normalizing b = " <+> prettyTCM b
-    b  <- normalise b
-    reportSDoc "tc.with.abstract" 30 $ text "eta-contracting b = " <+> prettyTCM b
-    b  <- etaContract b
-    reportSDoc "tc.with.abstract" 20 $ text "  b  = " <+> prettyTCM b
     reportSDoc "tc.with.abstract" 40 $
       sep [ text "abstracting"
           , nest 2 $ vcat $
-            [ text "vs = " <+> prettyTCM vs
-            , text "as = " <+> prettyTCM as
-            , text "b  = " <+> prettyTCM b ]
+            [ text "vs     = " <+> prettyTCM vs
+            , text "as     = " <+> escapeContext n2 (prettyTCM as)
+            , text "delta2 = " <+> escapeContext n2 (prettyTCM delta2)
+            , text "b      = " <+> prettyTCM b ]
           ]
     reportSLn "tc.with.abstract" 50 $ "  raw vs = " ++ show vs ++ "\n  raw b  = " ++ show b
-    return (zip vs as, b)
-  return $ telePi_ delta1 $ foldr (uncurry piAbstractTerm) b vas
+
+    -- Abstract in @b@ and in @as@, generating @wtel@ and @b'@.
+    -----------------------------------------------------------
+
+    -- Δ₁, Δ₂ ⊢ wtel0
+    -- Δ₁, Δ₂, wtel0 ⊢ b0
+    let TelV wtel0 b0 = telView'UpTo (size as) $
+          foldr (uncurry piAbstractTerm) b $ zip vs $ raise n2 as
+
+    -- We know the types in wtel0 (abstracted versions of @as@) do not depend on Δ₂.
+    -- Δ₁ ⊢ wtel
+    let wtel = applySubst (strengthenS __IMPOSSIBLE__ n2) wtel0
+
+    -- Δ₁, Δ₂, wtel ⊢ ρ : Δ₁, wtel, Δ₂
+    let m = n2 + size wtel
+    let rho = (map var $ [n2..m-1] ++ [0..n2-1]) ++# raiseS m
+
+    -- Using ρ, swap the variables of wtel and Δ₂ to get
+    -- Δ₁, wtel, Δ₂ ⊢ b'
+    let b' = applySubst rho b0
+
+    -- Abstract in @Δ₂@ to get @Δ₁, wtel ⊢ Δ₂′@.
+    ------------------------------------------
+
+    -- Δ₁, Δ₂ ⊢ Δ₂flat
+    let delta2flat = flattenTel delta2
+
+    let abstrvs t = foldl (flip abstractTerm) t $ zipWith raise [0..] vs
+    -- Δ₁, Δ₂, wtel ⊢ Δ₂abs
+    let delta2abs = abstrvs delta2flat
+
+    -- Δ₁, wtel, Δ₂ ⊢ Δ₂flat'
+    let delta2flat' = applySubst rho delta2abs
+
+    -- Δ₁, wtel ⊢ Δ₂′
+    let delta2' = unflattenTel (teleNames delta2) delta2flat'
+
+    -- Assemble final type of with-function.
+    ----------------------------------------
+
+    let ty = telePi_ delta1 $ telePi_ wtel $ telePi_ delta2' b'
+    reportSDoc "tc.with.abstract" 20 $ sep $
+      [ text "finished with-abstraction"
+      , text "  wtel0       = " <+> prettyTCM wtel0
+      , text "  wtel        = " <+> do escapeContext n2 $ prettyTCM wtel
+      , text "  b0          = " <+> addContext wtel (prettyTCM b0)
+      , text "  b'          = " <+> do escapeContext n2 $ addContext wtel $ addContext delta2 $ prettyTCM b'
+      , text "  delta2flat  = " <+> prettyTCM delta2flat
+      , text "  delta2flat' = " <+> do addContext wtel $ prettyTCM delta2flat'
+      , text "  delta2'     = " <+> do escapeContext n2 $ addContext wtel $ prettyTCM delta2'
+      , text "  ty          = " <+> do escapeContext n2 $ escapeContext (size delta1) $ prettyTCM delta2'
+      ]
+    return ty
+
 
 -- | Compute the clauses for the with-function given the original patterns.
 buildWithFunction

--- a/test/Fail/DebugWith.err
+++ b/test/Fail/DebugWith.err
@@ -6,36 +6,39 @@ delta  = (trash1 : Trash) (b : A) (trash2 : Trash)
 vs     = [f b]
 as     = [P b]
 perm   = x0,x1,x2,x3,x4 -> x0,x1,x2,x3,x4
-delta1 = (b : A) (f : (x : A) → P x)
-delta2 = (trash1 : Trash) (trash2 : Trash) (trash3 : Trash)
-perm'  = x0,x1,x2,x3,x4 -> x1,x3,x0,x2,x4
-fPerm  = x0,x1,x2,x3,x4 -> x1,x3,x0,x2,x4
+delta1 = (b : A)
+delta2 = (trash1 : Trash) (trash2 : Trash) (f : (x : A) → P x)
+         (trash3 : Trash)
+perm'  = x0,x1,x2,x3,x4 -> x1,x0,x2,x3,x4
+fPerm  = x0,x1,x2,x3,x4 -> x1,x0,x2,x3,x4
     with arguments [f b]
              types [P b]
-with function call .DebugWith.with-17 b f (f b) trash1 trash2
+with function call .DebugWith.with-17 b (f b) trash1 trash2 f
                    trash3
            context (trash1 : Trash) (b : A) (trash2 : Trash)
                    (f : (x : A) → P x) (trash3 : Trash)
              delta (trash1 : Trash) (b : A) (trash2 : Trash)
                    (f : (x : A) → P x) (trash3 : Trash)
               body [h0 h1 h2 h3 h4]
-                   .DebugWith.with-17 h1 h3 (h3 h1) h0 h2 h4
+                   .DebugWith.with-17 h1 (h3 h1) h0 h2 h3 h4
 checkWithFunction
-  delta1 = (b : A) (f : (x : A) → P x)
-  delta2 = (trash1 : Trash) (trash2 : Trash) (trash3 : Trash)
+  delta1 = (b : A)
+  delta2 = (trash1 : Trash) (trash2 : Trash) (f : (x : A) → P x)
+           (trash3 : Trash)
   t      = Trash → A → Trash → ((x : A) → P x) → Trash → Set
   as     = [P b]
   vs     = [f b]
   b      = Set
   qs     = [[]r(trash1 = VarP "trash1"),[]r(b = VarP "b"),[]r(trash2 = VarP "trash2"),[]r(f = VarP "f"),[]r(trash3 = VarP "trash3")]
-  perm'  = x0,x1,x2,x3,x4 -> x1,x3,x0,x2,x4
+  perm'  = x0,x1,x2,x3,x4 -> x1,x0,x2,x3,x4
   perm   = x0,x1,x2,x3,x4 -> x0,x1,x2,x3,x4
-  fperm   = x0,x1,x2,x3,x4 -> x1,x3,x0,x2,x4
+  fperm  = x0,x1,x2,x3,x4 -> x1,x0,x2,x3,x4
 created with display form
-Display 6 [@0, @0, @0, @0, @0, @0] test @2 @5 @1 @4 @0 | @3
+Display 6 [@0, @0, @0, @0, @0, @0] test @3 @5 @2 @1 @0 | @4
 added with function .DebugWith.with-17 of type
-  (b : A) (f : (x : A) → P x) →
-  P b → (trash1 trash2 trash3 : Trash) → Set
+  (b : A) (w : P b) (trash1 trash2 : Trash) (f : (x : A) → P x)
+  (trash3 : Trash) →
+  Set
   -|
 DebugWith.agda:15,11-23
 Trash !=< Set of type Set

--- a/test/Fail/Issue1075.err
+++ b/test/Fail/Issue1075.err
@@ -11,7 +11,7 @@ Problematic calls:
   cut⁻ pfΓ pf (x₁ ∷ LA) refl
   (cut⁺ pfΓ (record {}) (x ∷ []) (V ∷ []) N₁ ∷ LExp) (Sp ∷ LExp')
     (at Issue1075.agda:364,3-7)
-  cut⁻ pfΓ (pf₁ , pf) (A ∷ []) refl (?0 Γ' LA- x x₁ pfΓ pf LT pf₁ Sp)
+  cut⁻ pfΓ (pf₁ , pf) (A ∷ []) refl (?0 Γ' LA- x₁ pfΓ pf LT pf₁ x Sp)
   (rsubst-v Γ' pfΓ pf LA- LT Sp ∷ [])
     (at Issue1075.agda:383,3-7)
   cut⁺ pfΓ (proj₂ pf) (A ∷ []) (V ∷ []) N

--- a/test/Fail/MagicWith.err
+++ b/test/Fail/MagicWith.err
@@ -1,5 +1,5 @@
 MagicWith.agda:35,1-36,16
 fst p != w of type Nat
 when checking that the type
-(p : Nat × IsZero) (w : Nat) → F w (snd p) of the generated with
+(w : Nat) (p : Nat × IsZero) → F w (snd p) of the generated with
 function is well-formed

--- a/test/Succeed/Issue1692.agda
+++ b/test/Succeed/Issue1692.agda
@@ -1,0 +1,60 @@
+-- Andreas, 2015-11-18, issue 1692 reported by m0davis
+
+-- {-# OPTIONS -v tc.with.top:20 #-}
+
+open import Common.Level
+open import Common.Equality
+open import Common.Product
+
+postulate
+  Key   : Set
+  Value : Key → Set
+  anyOf : ∀{A : Set} → A → A → A
+
+data Tree : Set where
+  node : (k : Key) (v : Value k) → Tree
+
+data _∼_∈_ ( k : Key ) ( v : Value k ) : Tree → Set where
+  here :  k ∼ v ∈ node k v
+
+postulate
+  k₁≡k₂ : ∀ ( k₁ k₂ : Key ) → k₁ ≡ k₂
+  ∈→v₁≡v₂ : ∀ { k } { v₁ v₂ : Value k } → k ∼ v₁ ∈ node k v₂ → v₁ ≡ v₂
+
+lem : ( t₁ t₂ : Tree )
+      ( t₁→t₂ : ∀ {k} {v : Value k} → k ∼ v ∈ t₁ → k ∼ v ∈ t₂ )
+      ( t₂→t₁ : ∀ {k} {v : Value k} → k ∼ v ∈ t₂ → k ∼ v ∈ t₁ ) →
+      ∃ λ t → ∀ {k} {v : Value k} → k ∼ v ∈ t → k ∼ v ∈ t
+lem (node k₁ v₁) (node k₂ v₂) t₁→t₂ t₂→t₁ rewrite k₁≡k₂ k₁ k₂
+     | ∈→v₁≡v₂ (t₁→t₂ here) -- equivalent to v₂ ≡ v₁
+     = _ , anyOf t₁→t₂ t₂→t₁
+
+-- PROBLEM WAS:
+
+-- When the second rewrite expression is commented-out, then we get the following types:
+   {-
+     t₂→t₁    : {k : Key} {v : Value k} →
+                k ∼ v ∈ node k₂ v₂ → k ∼ v ∈ node k₂ v₁
+     t₁→t₂    : {k : Key} {v : Value k} →
+                k ∼ v ∈ node k₂ v₁ → k ∼ v ∈ node k₂ v₂
+   -}
+-- With both rewrite expressions, we get:
+   {-
+     t₂→t₁    : {k : Key} {v : Value k} →
+                k ∼ v ∈ node k₂ v₂ → k ∼ v ∈ node k₂ v₂
+     t₁→t₂    : {k : Key} {v : Value k} →
+                k ∼ v ∈ node k₂ v₁ → k ∼ v ∈ node k₂ v₂
+   -}
+-- The unexpected behavior here is that v₁ has been rewritten to v₂ in t₂→t₁ but not in t₁→t₂.
+
+-- Should be symmetric now, test case passes.
+
+-- Dual case:
+
+lem′ : ( t₁ t₂ : Tree )
+      ( t₁→t₂ : ∀ {k} {v : Value k} → k ∼ v ∈ t₁ → k ∼ v ∈ t₂ )
+      ( t₂→t₁ : ∀ {k} {v : Value k} → k ∼ v ∈ t₂ → k ∼ v ∈ t₁ ) →
+      ∃ λ t → ∀ {k} {v : Value k} → k ∼ v ∈ t → k ∼ v ∈ t
+lem′ (node k₁ v₁) (node k₂ v₂) t₁→t₂ t₂→t₁ rewrite k₁≡k₂ k₁ k₂
+     | ∈→v₁≡v₂ (t₂→t₁ here) -- equivalent to v₁ ≡ v₂
+     = _ , anyOf t₁→t₂ t₂→t₁

--- a/test/Succeed/Issue1692a.agda
+++ b/test/Succeed/Issue1692a.agda
@@ -1,0 +1,35 @@
+-- Andreas, 2015-11-19 Issue 1692
+-- With-abstract also in types of variables mentioned in with-expressions
+-- unless they are also mentioned in the types of the with-expressions.
+
+-- {-# OPTIONS -v tc.with:40 #-}
+
+open import Common.Equality
+
+postulate
+  A : Set
+  a : A
+
+test : (dummy : A) (f : ∀ x → a ≡ x) (b : A) → b ≡ a
+test dummy f b rewrite f b = f b
+
+-- WAS:
+-- The `a` is not with-abstracted in the type of `f`, as `f` occurs
+-- in the rewrite expression `f b : a ≡ b`.
+
+-- NOW: with abstracts also in type of f, changing it to (f : ∀ x → b ≡ x)
+
+test-with : (f : ∀ x → a ≡ x) (b : A) → b ≡ a
+test-with f b with a | f b
+test-with f b | .b | refl = f b
+
+-- WAS:
+
+-- Manually, we can construct what `magic with` DID not do:
+-- abstract `a` also in the type of `f`, even though `f` is part of the
+-- rewrite expression.
+bla : (f : ∀ x → a ≡ x) (b : A) → b ≡ a
+bla f b = aux b a (f b) f
+  where
+    aux : (b w : A) (p : w ≡ b) (f : ∀ x → w ≡ x) → b ≡ w
+    aux b .b refl f = f b

--- a/test/Succeed/RewriteAndWhere.agda
+++ b/test/Succeed/RewriteAndWhere.agda
@@ -1,3 +1,5 @@
+-- {-# OPTIONS -v tc.with:40 #-}
+
 module RewriteAndWhere where
 
 open import Common.Equality
@@ -22,7 +24,6 @@ mutual
   good₂ : (a b : ℕ) → a ≡ b → b ≡ a
   good₂ a b eq = aux a b a eq
 
-
 bad : (a b : ℕ) → a ≡ b → b ≡ a
 bad a b eq rewrite eq = foo
   where
@@ -36,3 +37,8 @@ bad a b eq rewrite eq = foo
     --   where
     --     bar : a ≡ a
     --     bar = refl
+
+-- Andreas, 2015-11-18 added test during exploration of issue 1692.
+test : (a b : ℕ) → a ≡ b → b ≡ a
+test a b eq with a | eq
+test a b eq | .b | refl = eq

--- a/test/lib-succeed/Issue846/DivModUtils.agda
+++ b/test/lib-succeed/Issue846/DivModUtils.agda
@@ -95,12 +95,16 @@ mod-lemma : ∀ x d (r : Fin (suc d)) → (toℕ r + x * suc d) mod suc d ≡ r
 mod-lemma x d r rewrite divMod-lemma x d r = refl
 
 
-mod-suc : ∀ n → n mod 7 ≡ zero → suc n mod 7 ≡ suc zero
-mod-suc n eq with n | n divMod 7
-mod-suc n refl | .(q * suc 6) | result q .zero refl = mod-lemma q 6 (suc zero)
+mod-suc : ∀ n
+  →     n mod 7 ≡     zero
+  → suc n mod 7 ≡ suc zero
+mod-suc n eq with n divMod 7
+mod-suc .(q * 7) refl | result q .zero refl = mod-lemma q 6 (suc zero)
 
 
-mod-pred : ∀ n →  suc n mod 7 ≡ suc zero → n mod 7 ≡ zero
+mod-pred : ∀ n
+  →  suc n mod 7 ≡ suc zero
+  →      n mod 7 ≡     zero
 mod-pred n eq with n divMod 7
 mod-pred .(toℕ r + q * 7) eq | result q r refl with toℕ r ≤? 5
 mod-pred .(toℕ r + q * 7) eq | result q r refl | yes p  = toℕ-injective eq4


### PR DESCRIPTION
This commit is making `with` more agressive and hopefully more intuitive (at least it removes the stumbling block reported in issue #1692).

The change is not fully backwards compatible.  However, the breakage should be small. Nothing broke for the std-lib. Only a single test case broke, which uses `with` on a function argument (a variable):
https://github.com/agda/agda/blob/master/test/lib-succeed/Issue846/DivModUtils.agda#L99
The breakage was easy to fix, the new `with` is simpler: the `with` on the variable could be removed.

Please check the amount of breakage on your Agda developments and report back on https://github.com/agda/agda/issues/1692
This let's me evaluate whether this commit can go into the maintenance version or not (in case the breakage is too big).
