### PR TITLE
as per issue https://github.com/agda/agda/issues/426, first cut at tr…

### DIFF
--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -220,7 +220,10 @@ handleCommand wrap onFail cmd = handleNastyErrors $ wrap $ do
     catchErr :: CommandM a -> (TCErr -> CommandM a) -> CommandM a
     catchErr m h = do
       s       <- get
-      (x, s') <- lift $ do disableDestructiveUpdate (runStateT m s)
+      (x, s') <- lift $ do {-disableDestructiveUpdate -} (runStateT m s)
+        --- disable destructive update to allow emacs mode agda to have
+        --- lazy evaluation strategy rather than normal order
+        --- see ticket https://github.com/agda/agda/issues/426
          `catchError_` \ e ->
            runStateT (h e) s
       put s'


### PR DESCRIPTION
…ying out enabling lazy evaluation in emacs agda-mode.

The long term solution is probably expose this choice as a cabal level build configure that then uses CPP in this module or something.

opening this PR as a discussion point for ticket https://github.com/agda/agda/issues/426 
