### PR TITLE
instead of complaining about goal markers being read-only delete the …

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1389,8 +1389,13 @@ modified."
       (delete-overlay ol))
      ((or (< beg (+ (overlay-start ol) 2))
           (> end (- (overlay-end ol) 2)))
-      (unless inhibit-read-only
-        (signal 'text-read-only nil))))))
+      (when (listp buffer-undo-list)
+        (push (list 'apply 0 (overlay-start ol) (overlay-end ol)
+                    'move-overlay ol (overlay-start ol) (overlay-end ol))
+              buffer-undo-list))
+      (goto-char (overlay-start ol))
+      (delete-char (- (overlay-end ol) (overlay-start ol)))
+      (delete-overlay ol)))))
 
 (defun agda2-update (old-g new-txt)
   "Update the goal OLD-G.


### PR DESCRIPTION
…whole goal.

I'm new to elisp so I don't know if this is up to standard.
