### PR TITLE
Add `stack.yaml` for 2.5.1

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ resolver: lts-6.2
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
-#- test/
-#- src/fix-agda-whitespace/
-#- src/hTags/
-#- src/size-solver/
+- src/fix-agda-whitespace/
+- src/hTags/
+- src/size-solver/
+#- test/ #Dead

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,9 @@
+resolver: lts-6.2
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+#- test/
+#- src/fix-agda-whitespace/
+#- src/hTags/
+#- src/size-solver/


### PR DESCRIPTION
This is the first step to fix #2005. As one would expect, this config works not just for 2.5.1, but also for 2.5-stable and (it seems) for `master` (well, it configures but doesn't build for me, but that's a separate issue).

Possible further steps:
- allow building other projects with `stack`, even though they're mostly intended for `Agda` developers.
- extend continuous integration with an additional config for `stack` — it should be easy enough (examples abound), the only problem is that _you_ risk getting build failures for stuff I should maintain. If you're fine with pinging me then, that's no problem, if that's too much trouble I'd have to think of sth. else.
