### PR TITLE
Fix compile error on base>=4.8

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -37,7 +37,7 @@ import qualified Data.Map as Map -- hiding (singleton, null, empty)
 import Data.Set (Set)
 import qualified Data.Set as Set -- hiding (singleton, null, empty)
 import Data.Typeable (Typeable)
-import Data.Foldable
+import Data.Foldable (Foldable)
 import Data.Traversable
 import Data.IORef
 


### PR DESCRIPTION
Error:

```
src/full/Agda/TypeChecking/Monad/Base.hs:1337:46: error:
    Ambiguous occurrence ‘null’
    It could refer to either ‘Agda.Utils.Null.null’,
                             imported from ‘Agda.Utils.Null’ at src/full/Agda/TypeChecking/Monad/Base.hs:92:1-22
                             (and originally defined at src/full/Agda/Utils/Null.hs:49:3-20)
                          or ‘Data.Foldable.null’,
                             imported from ‘Data.Foldable’ at src/full/Agda/TypeChecking/Monad/Base.hs:40:1-20
```

Witnessed on e.g. https://travis-ci.org/agda/agda/jobs/136470226#L1236-L1242,
coming from f8c8f049497d929973b36bed7c71ed3ceec7bf64.

In fact, it seems Agda.Utils.Null is subsumed by newer versions of Foldable and
could be refactored together with them, but that's a separate issue (and one can
decide whether to do that or not).
