### PR TITLE
Add Cabal support to hTags

### DIFF
--- a/src/full/Makefile
+++ b/src/full/Makefile
@@ -88,7 +88,7 @@ debug_loc :
 
 hTags=../hTags/dist/build/hTags/hTags
 hTags_include=$(BUILD_DIR)/build/autogen/cabal_macros.h ./undefined.h
-hTags_flags=-i $(BUILD_DIR)/build/autogen/cabal_macros.h -I ./
+hTags_flags=-i $(BUILD_DIR)/build/autogen/cabal_macros.h -I ./ --cabal ../../Agda.cabal
 
 $(hTags) : $(wildcard ../hTags/*.hs)
 	$(MAKE) -C ../hTags

--- a/src/hTags/Main.hs
+++ b/src/hTags/Main.hs
@@ -3,11 +3,13 @@
 
 module Main where
 
+import Control.Arrow ((&&&))
 import Control.Applicative
 import Control.Exception
 import Control.Monad
 import Control.Monad.Trans
 import Data.Char
+import qualified Data.Traversable as T
 import Data.List
 import Data.Maybe
 import System.Environment
@@ -29,8 +31,14 @@ import ErrUtils
 import StringBuffer
 import SrcLoc
 import Outputable
-import DynFlags (opt_P, sOpt_P)
+import DynFlags (opt_P, sOpt_P, parseDynamicFilePragma)
 import GhcMonad (GhcT(..), Ghc(..))
+
+import Language.Haskell.Extension as LHE
+import Distribution.PackageDescription.Configuration (flattenPackageDescription)
+import Distribution.PackageDescription hiding (options)
+import qualified Distribution.PackageDescription.Parse as PkgDescParse
+import Distribution.PackageDescription.Parse hiding (ParseResult)
 
 import Tags
 
@@ -83,9 +91,39 @@ runCmd cmd = do
   (_, h, _, _) <- runInteractiveCommand cmd
   hGetContents h
 
+-- XXX This is a quick hack; it will certainly work if the language description
+-- is not conditional. Otherwise we'll need to figure out both the flags and the
+-- build configuration to call `finalizePackageDescriptionSource`.
+configurePackageDescription ::
+  GenericPackageDescription -> PackageDescription
+configurePackageDescription = flattenPackageDescription
+
+extractLangSettings ::
+  GenericPackageDescription
+  -> ([Extension], Maybe LHE.Language)
+extractLangSettings gpd =
+  fromMaybe ([], Nothing) $
+    (defaultExtensions &&& defaultLanguage) . libBuildInfo <$> (library . configurePackageDescription) gpd
+
+extToOpt :: Extension -> String
+extToOpt (UnknownExtension e) = "-X" ++ e
+extToOpt (EnableExtension e)  = "-X" ++ show e
+extToOpt (DisableExtension e) = "-XNo" ++ show e
+
+langToOpt :: LHE.Language -> String
+langToOpt l = "-X" ++ show l
+
+cabalConfToOpts :: GenericPackageDescription -> [String]
+cabalConfToOpts desc = langOpts ++ extOpts
+  where
+    (exts, maybeLang) = extractLangSettings desc
+    extOpts = map extToOpt exts
+    langOpts = langToOpt <$> maybeToList maybeLang
+
 main :: IO ()
 main = do
   opts <- getOptions
+  pkgDesc <- T.mapM (readPackageDescription minBound) $ optCabalPath opts
   let go | optHelp opts = do
             printUsage stdout
             exitSuccess
@@ -93,14 +131,16 @@ main = do
             top : _ <- lines <$> runCmd "ghc --print-libdir"
             ts <- runGhc (Just top) $ do
               dynFlags <- getSessionDynFlags
-              setSessionDynFlags $
-                dynFlags {
-                  settings = (settings dynFlags) {
-                    sOpt_P = concatMap (\i -> [i, "-include"]) (optIncludes opts) ++
-                             opt_P dynFlags
-                    },
-                  includePaths = optIncludePath opts ++ includePaths dynFlags
-                  }
+              let dynFlags' =
+                    dynFlags {
+                    settings = (settings dynFlags) {
+                        sOpt_P = concatMap (\i -> [i, "-include"]) (optIncludes opts) ++
+                                 opt_P dynFlags
+                        }
+                    , includePaths = optIncludePath opts ++ includePaths dynFlags
+                    }
+              (dynFlags'', _, _) <- parseDynamicFilePragma dynFlags' $ map noLoc $ concatMap cabalConfToOpts (maybeToList pkgDesc)
+              setSessionDynFlags dynFlags''
               mapM (\f -> liftM2 ((,,) f) (liftIO $ Strict.readFile f)
                                           (goFile f)) $
                          optFiles opts
@@ -137,6 +177,7 @@ data Options = Options
   , optIncludes    :: [FilePath]
   , optFiles       :: [FilePath]
   , optIncludePath :: [FilePath]
+  , optCabalPath   :: Maybe FilePath
   }
 
 defaultOptions :: [FilePath] -> Options
@@ -149,6 +190,7 @@ defaultOptions files = Options
   , optIncludes    = []
   , optFiles       = files
   , optIncludePath = []
+  , optCabalPath   = Nothing
   }
 
 options :: [OptDescr (Options -> Options)]
@@ -158,6 +200,7 @@ options =
   , Option ['e'] ["etags"]   (OptArg setETagsFile "FILE") "Generate etags (default file=TAGS)"
   , Option ['i'] ["include"] (ReqArg addInclude   "FILE") "File to #include"
   , Option ['I'] []          (ReqArg addIncludePath "DIRECTORY") "Directory in the include path"
+  , Option []    ["cabal"]   (ReqArg addCabal "CABAL FILE") "Cabal configuration to load additional language options from (library options are used)"
   ]
   where
     setHelp             o = o { optHelp        = True }
@@ -167,3 +210,4 @@ options =
     setETagsFile   file o = o { optETagsFile   = fromMaybe "TAGS" file, optETags = True }
     addInclude     file o = o { optIncludes    = file : optIncludes o }
     addIncludePath dir  o = o { optIncludePath = dir : optIncludePath o}
+    addCabal       file o = o { optCabalPath   = Just file }

--- a/src/hTags/hTags.cabal
+++ b/src/hTags/hTags.cabal
@@ -19,6 +19,14 @@ executable hTags
                 , ghc >= 7.6.3 && < 8.1
                 , process >= 1.1.0.2 && < 1.5
                 , strict >= 0.3.2 && < 0.4
+                -- Most APIs we use are unchanged since 1.10, except for
+                -- Exception in Language.Haskell.Extension. Compare:
+                -- http://hackage.haskell.org/package/Cabal-1.10.2.0/docs/Language-Haskell-Extension.html
+                -- http://hackage.haskell.org/package/Cabal-1.12.0/docs/Language-Haskell-Extension.html
+                --
+                -- We must still support 1.16.0 since GHC 7.6.3 was built using
+                -- that.
+                , Cabal >= 1.12.0 && < 1.26
 
     -- Since we are using GHC as a library and transformers 0.3.0.0
     -- was shipped as a *base* library of GHC 7.8.*, we must use a

--- a/src/hTags/hTags.cabal
+++ b/src/hTags/hTags.cabal
@@ -10,6 +10,7 @@ tested-with: GHC == 7.6.3
 
 executable hTags
   main-is: Main.hs
+  other-modules: Tags
 
   build-depends:  base >= 4.6.0.1 && < 4.10
                 , directory >= 1.2.0.1 && < 1.3


### PR DESCRIPTION
This PR is required to fix #1942. It extends the bundled hTags to parse `default-language` and `default-extensions`; otherwise, those extensions would be enabled when using GHC for compiling, but not when using it to produce tags (as in `hTags`).

This code uses the Cabal API to parse a cabal file (in particular, the library section), but the used code does not handle conditionals well. Fixing that appears a nontrivial project, and restricting global flags to unconditional ones appears viable for the future, too.
