### PR TITLE
Support `~/` instead of `$HOME/` as prefix (#1978)

### DIFF
--- a/src/full/Agda/Utils/Environment.hs
+++ b/src/full/Agda/Utils/Environment.hs
@@ -5,34 +5,42 @@ module Agda.Utils.Environment ( expandEnvironmentVariables ) where
 import Data.Char
 import Data.Maybe
 import System.Environment
+import System.Directory ( getHomeDirectory )
 
 expandEnvironmentVariables :: String -> IO String
 expandEnvironmentVariables s = do
   env <- getEnvironment
-  return $ expandVars env s
+  home <- getHomeDirectory
+  return $ expandVars home env s
 
-expandVars :: [(String, String)] -> String -> String
-expandVars env s = concatMap repl $ tokens s
+expandVars :: String -> [(String, String)] -> String -> String
+expandVars home env s = concatMap repl $ tokens s
   where
+    repl Home = home ++ "/"
     repl (Var x) = fromMaybe "" $ lookup x env
     repl (Str s) = s
 
-data Token = Var String | Str String
+data Token = Home | Var String | Str String
   deriving (Eq, Show)
 
 tokens :: String -> [Token]
-tokens s =
-  case s of
-    '$' : '$' : s -> cons '$' $ tokens s
-    '$' : s@(c : _) | isAlpha c -> Var x : tokens s'
-      where (x, s') = span isAlphaNum s
-    '$' : '{' : s ->
-      case break (== '}') s of
-        (x, '}' : s) -> Var x : tokens s
-        _            -> [Str $ "${" ++ s] -- abort on unterminated '{'
-    c : s -> cons c $ tokens s
-    ""    -> []
+tokens s = case s of
+  '~' : '/' : s -> Home : tokens' s
+  '\\' : '~' : s -> cons '~' $ tokens' s
+  _ -> tokens' s
   where
+    tokens' :: String -> [Token]
+    tokens' s =
+      case s of
+        '$' : '$' : s -> cons '$' $ tokens' s
+        '$' : s@(c : _) | isAlpha c -> Var x : tokens' s'
+          where (x, s') = span isAlphaNum s
+        '$' : '{' : s ->
+          case break (== '}') s of
+            (x, '}' : s) -> Var x : tokens' s
+            _            -> [Str $ "${" ++ s] -- abort on unterminated '{'
+        c : s -> cons c $ tokens' s
+        ""    -> []
     cons c (Str s : ts) = Str (c : s) : ts
     cons c ts           = Str [c] : ts
 


### PR DESCRIPTION
Fix #1978.

This code is only used in src/full/Agda/Interaction/Library.hs, so this change should cause no unintended effects elsewhere; and supporting `~/` as prefix whenever `$HOME` is supported probably makes sense. For simplicity we don't support `~userName/`.

For extra bonus, this expansion of `~/` should work on Windows, thanks to
[getHomeDirectory](http://hackage.haskell.org/package/directory-1.2.2.0/docs/System-Directory.html#v:getHomeDirectory).

Caveat for extremely geeky users: `~/.agda` doesn't work on Windows.

Unlike I'd have guessed, on Windows `~/.agda` will typically not point to the Agda directory; `~/Application Data/agda` is more likely to point there, depending on the Windows version and on [getAppUserDataDirectory](http://hackage.haskell.org/package/directory-1.2.2.0/docs/System-Directory.html#v:getHomeDirectory).

Hopefully nobody need make ~/.agda/libraries portable across Windows and *x.
