### PR TITLE
Add agda2-mode-pkg.el

### DIFF
--- a/src/data/emacs-mode/agda2-mode-pkg.el
+++ b/src/data/emacs-mode/agda2-mode-pkg.el
@@ -1,0 +1,2 @@
+(define-package "agda2-mode" "2.5.1"
+  "interactive development for Agda, a dependently typed functional programming language")


### PR DESCRIPTION
This is the first step towards installing the Emacs mode using the new
package.el package manager, rather than an ad-hoc installation of lisp
files.
