### PR TITLE
Add unicode syntax for idiom brackets.

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -512,6 +512,9 @@ order for the change to take effect."
   ("lbag" . ("⟅"))
   ("rbag" . ("⟆"))
 
+  ("(|" . ("⦇"))
+  ("|)" . ("⦈"))
+
   ;; Primes.
 
   ("'" . ,(agda-input-to-string-list "′″‴⁗"))

--- a/src/full/Agda/Syntax/Parser/LexActions.hs
+++ b/src/full/Agda/Syntax/Parser/LexActions.hs
@@ -72,6 +72,8 @@ postToken (TokId (r, "\x2026")) = TokSymbol SymEllipsis r
 postToken (TokId (r, "\x2192")) = TokSymbol SymArrow r
 postToken (TokId (r, "\x2983")) = TokSymbol SymDoubleOpenBrace r
 postToken (TokId (r, "\x2984")) = TokSymbol SymDoubleCloseBrace r
+postToken (TokId (r, "\x2987")) = TokSymbol SymOpenIdiomBracket r
+postToken (TokId (r, "\x2988")) = TokSymbol SymCloseIdiomBracket r
 postToken (TokId (r, "\x2200")) = TokKeyword KwForall r
 postToken (TokId (r, s))
   | set == "Set" && all isSub n = TokSetN (r, readSubscript n)


### PR DESCRIPTION
Hi all,

I was very pleased to see idiom brackets added to the latest version. This is just a pull request that adds unicode syntax for the idiom brackets, much as the double-brace syntax already has a unicode equivalent. 

I used the symbols from Z-notation:
- U+2987 ⦇ Z NOTATION LEFT IMAGE BRACKET
- U+2988 ⦈ Z NOTATION RIGHT IMAGE BRACKET

These two symbols are the closest to the ASCII concatenation of (| and |) that I could find. I've tested the notation in an editor with the PragmataPro font and it looks good. These symbols were also not previously available in the agda-input method, so it's highly unlikely that there exists any Agda code that uses them -- this is pretty safe syntax to steal. 

I also naturally added shortcuts to the agda-input method, `\(|` for  ⦇ and `\|)` for ⦈. 

Another option, if preferred, is to use the "white parentheses" symbols, or "banana brackets" ⦅ ⦆. These appear a bit more "bracket-y", but I feel like double-parentheses syntax is more appropriate for these (rather than `(||)`), and they don't scream "idiom brackets" to me for some reason. 

A third option is to use the original brackets used in the paper ⟦ ⟧, but these are already available in the agda input method, and widely used to mean "semantics" in various senses, so we probably  want to avoid that.

Another thing I'd like to discuss is adding support for Alternative (for some reason Alternative isn't in the standard library, but MonadPlus is). I suspect we may be able to reuse the pipe character for that. But that's a discussion for another time.
