### PR TITLE
Bump Python version for doc CI test to 3.5. Fixes build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,6 +144,8 @@ matrix:
             - hvr-ghc
 
     - env: TEST=doc
+      language: python
+      python: "3.5"
       addons:
         apt:
           packages:
@@ -266,7 +268,7 @@ install:
 # `$HOME/.local/bin`.
 
   - if [[ $TEST = "doc" ]]; then
-       pip install --user -r doc/user-manual/requirements.txt &&
+       pip install -r doc/user-manual/requirements.txt &&
        export PATH=$HOME/.local/bin:$PATH;
     fi
 


### PR DESCRIPTION
Checking if Python 3 will build the documentation correctly, as readthedocs does.
