### PR TITLE
Run compiler tests against JS backend with Node.js

### DIFF
--- a/src/data/lib/prim/Agda/Builtin/List.agda
+++ b/src/data/lib/prim/Agda/Builtin/List.agda
@@ -15,3 +15,9 @@ data List {a} (A : Set a) : Set a where
 
 {-# COMPILED_DATA List MAlonzo.Code.Agda.Builtin.List.AgdaList [] (:) #-}
 {-# COMPILED_DATA_UHC List __LIST__ __NIL__ __CONS__ #-}
+
+{-# COMPILED_JS List function(x,v) {
+  if (x.length < 1) { return v["[]"](); } else { return v["_∷_"](x.slice(0,1), x.slice(1)); }
+} #-}
+{-# COMPILED_JS [] Array() #-}
+{-# COMPILED_JS _∷_ function (x) { return function(y) { return Array(x).concat(y); }; } #-}

--- a/src/data/lib/prim/Agda/Builtin/String.agda
+++ b/src/data/lib/prim/Agda/Builtin/String.agda
@@ -16,3 +16,10 @@ primitive
   primStringEquality : String → String → Bool
   primShowChar       : Char → String
   primShowString     : String → String
+
+{-# COMPILED_JS primStringToList function(x) { return x.split(""); } #-}
+{-# COMPILED_JS primStringFromList function(x) { return x.join(""); } #-}
+{-# COMPILED_JS primStringAppend function(x) { return function(y) { return x+y; }; } #-}
+{-# COMPILED_JS primStringEquality function(x) { return function(y) { return x===y; }; } #-}
+{-# COMPILED_JS primShowChar function(x) { return x; } #-}
+{-# COMPILED_JS primShowString function(x) { return x; } #-}

--- a/src/full/Agda/Compiler/JS/Pretty.hs
+++ b/src/full/Agda/Compiler/JS/Pretty.hs
@@ -111,8 +111,6 @@ exports n i lss (Export ls e : es) | otherwise =
 
 instance Pretty Module where
   pretty n i (Module m es) =
-    "define([" ++ intercalate "," ("\"exports\"" : map modname js) ++ "]," ++
-    "function(" ++ intercalate "," ("exports" : pretties n i js) ++ ") {" ++ br (i+1) ++
-    exports n (i+1) (singleton []) es ++
-    "});" ++ br i
-      where js = toList (globals es)
+    unlines ["var " ++ pretty n (i+1) e ++ " = require(" ++ modname e ++ ");"
+            | e <- js] ++ br i ++ exports n i (singleton []) es
+    where js = toList (globals es)

--- a/test/Common/IO.agda
+++ b/test/Common/IO.agda
@@ -20,6 +20,15 @@ postulate
 {-# COMPILED_EPIC _>>=_ (u1 : Unit, u2 : Unit, x : Any, f : Any) -> Any = iobind(x,f) #-}
 {-# COMPILED_UHC return (\_ _ x -> UHC.Agda.Builtins.primReturn x) #-}
 {-# COMPILED_UHC _>>=_ (\_ _ _ _ x y -> UHC.Agda.Builtins.primBind x y) #-}
+{-# COMPILED_JS return
+    function(u0) { return function(u1) { return function(x) { return x; }; }; } #-}
+-- JS implementation of _>>=_ uses y.apply() instead of y() to prevent the JS
+-- backend from removing the value x.
+{-# COMPILED_JS _>>=_
+  function(u0) { return function(u1) { return function(u2) { return function(u3) {
+    return function(x) { return function(y) { return y.apply(this, Array(x)); }; };
+  }; }; }; }
+#-}
 
 
 {-# IMPORT Data.Text.IO #-}
@@ -30,6 +39,7 @@ postulate
 {-# COMPILED putStr Data.Text.IO.putStr #-}
 {-# COMPILED_EPIC putStr (a : String, u : Unit) -> Unit = foreign Int "wputStr" (a : String); primUnit #-}
 {-# COMPILED_UHC putStr (UHC.Agda.Builtins.primPutStr) #-}
+{-# COMPILED_JS putStr function (x) { return process.stdout.write(x); } #-}
 
 
 printChar : Char -> IO Unit

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -18,6 +18,7 @@ import Data.Monoid
 import Data.List
 import System.IO.Temp
 import System.FilePath
+import System.Environment (setEnv)
 import System.Exit
 import System.Process.Text as PT
 
@@ -41,11 +42,11 @@ data ExecResult
     { result :: ProgramResult }
   deriving (Show, Read, Eq)
 
-data Compiler = MAlonzo | UHC
+data Compiler = MAlonzo | UHC | JS
   deriving (Show, Read, Eq)
 
 enabledCompilers :: [Compiler]
-enabledCompilers = [ MAlonzo, UHC ]
+enabledCompilers = [ MAlonzo, UHC, JS ]
 
 data CompilerOptions
   = CompilerOptions
@@ -77,6 +78,10 @@ disabledTests =
 #if !defined(UHC_BACKEND)
   , RFInclude "Compiler/UHC/"
 #endif
+  -- JS backend tests are whitelisted for now
+  , RFInclude "Compiler/JS/.*"
+  , RFExclude "Compiler/JS/simple/HelloWorld"
+  , RFExclude "Compiler/JS/simple/String$"
   ]
 
 tests :: IO TestTree
@@ -104,6 +109,7 @@ simpleTests comp = do
   where compArgs :: Compiler -> AgdaArgs
         compArgs UHC = []
         compArgs MAlonzo = ghcArgsAsAgdaArgs ["-itest/"]
+        compArgs JS = []
 
 -- The Compiler tests using the standard library are horribly
 -- slow at the moment (1min or more per test case).
@@ -146,6 +152,7 @@ specialTests MAlonzo = do
             -- ignore stderr, as there may be some GHC warnings in it
             return $ ExecutedProg (ret, out <> sout, err)
 specialTests UHC = return Nothing
+specialTests JS = return Nothing
 
 ghcArgsAsAgdaArgs :: GHCArgs -> AgdaArgs
 ghcArgsAsAgdaArgs = map f
@@ -164,8 +171,14 @@ agdaRunProgGoldenTest dir comp extraArgs inp opts =
           inp' <- maybe T.empty decodeUtf8 <$> readFileMaybe inpFile
           -- now run the new program
           let exec = getExecForComp comp compDir inpFile
-          (ret, out', err') <- PT.readProcessWithExitCode exec (runtimeOptions opts) inp'
-          return $ ExecutedProg (ret, out <> out', err <> err')
+          case comp of
+            JS -> do
+              setEnv "NODE_PATH" compDir
+              (ret, out', err') <- PT.readProcessWithExitCode "node" [exec] inp'
+              return $ ExecutedProg (ret, out <> out', err <> err')
+            _ -> do
+              (ret, out', err') <- PT.readProcessWithExitCode exec (runtimeOptions opts) inp'
+              return $ ExecutedProg (ret, out <> out', err <> err')
         else
           return CompileSucceeded
         )
@@ -207,6 +220,7 @@ agdaRunProgGoldenTest1 dir comp extraArgs inp opts cont
             let uhcBinArg = maybe [] (\x -> ["--uhc-bin", x]) uhc
             -- TODO remove the memory arg again, as soon as we fixed the memory leak
             return $ ["--uhc"] ++ uhcBinArg ++ ["+RTS", "-K50m", "-RTS"]
+        argsForComp JS = return ["--js"]
 
 readOptions :: FilePath -- file name of the agda file
     -> IO TestOptions
@@ -224,6 +238,7 @@ cleanUpOptions = filter clean
 
 -- gets the generated executable path
 getExecForComp :: Compiler -> FilePath -> FilePath -> FilePath
+getExecForComp JS compDir inpFile = compDir </> ("jAgda." ++ (takeFileName $ dropAgdaOrOtherExtension inpFile) ++ ".js")
 getExecForComp _ compDir inpFile = compDir </> (takeFileName $ dropAgdaOrOtherExtension inpFile)
 
 printExecResult :: ExecResult -> T.Text


### PR DESCRIPTION
For context, see issue #1627. This is a small attempt at making it possible to run the compiler tests against the JS backend.
## 
- JS backend now generates Node-compatible modules (Common.js) instead of AMD modules. This is a backwards-incompatible change, but at the moment the JS backend does not seem to work very well anyway. If you want to use the generated modules in the browser, you need to process them with a tool like [Browserify](http://browserify.org).
- I've provided `COMPILED_JS` annotations for String and List primitives to make the test case `String.agda` pass. Primitives for something like Int probably need a bit more thought, so I've ignored them for now.
- The JS tests are whitelisted for now, because most of them are broken due to the lack of JS primitives and JS backend bugs. Once more tests pass, the broken ones could be blacklisted.

The code uses very basic features of Node, so I believe it should work with even ancient versions of Node.
