### PR TITLE
[ doc ] Use Python 3.4; CHANGELOG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,7 +145,7 @@ matrix:
 
     - env: TEST=doc
       language: python
-      python: "3.5"
+      python: "3.4"
       addons:
         apt:
           packages:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,9 @@ Installation and infrastructure
 
 * Added support for GHC 8.0.1.
 
+* Documentation is now built with Python 3.4, the same version used
+  by `readthedocs.org`.
+
 Bug fixes
 =========
 

--- a/HACKING
+++ b/HACKING
@@ -313,6 +313,8 @@ Testing and documentation
 
 * To build the user manual locally, you need to install
   the following dependencies:
+    - Python 3.4
+
     - Sphinx and sphinx-rtd-theme
 
         pip install --user -r doc/user-manual/requirements.txt


### PR DESCRIPTION
We use Python 3.4 for the "doc" continuous-integration build. This is the same that `readthedocs.org` uses.

Python 2.7 may count the length of some unicode characters differently, which leads to syntax errors when rendering tables from reStructuredText.
