### PR TITLE
ignore .stack-work directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .*.sw[a-p]
 .*.vim
 .cabal-sandbox/
+.stack-work/
 .DS_Store
 .sw[a-p]
 *.agdai


### PR DESCRIPTION
after build with stack, it will generate a `.stack-work` directory, maybe we should put it in the ignore file?
