### PR TITLE
[ fixed #2192 ] Fixed `primShowFloat 1.0` on the JS backend (again).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -291,6 +291,22 @@ install:
     fi
 
 ##############################################################################
+# Installing a recent version of Node (see Issue #2192)
+
+  - if [[ $TEST = "MAIN" ]]; then
+       export AGDA_HOME=`pwd` &&
+       export NODE_VERSION=v0.11.16 &&
+       export NODE_DIR=node-${NODE_VERSION}-linux-x64 &&
+       export NODE_TARBALL=${NODE_DIR}.tar.gz &&
+       cd $HOME &&
+       wget https://nodejs.org/download/release/${NODE_VERSION}/${NODE_TARBALL} &&
+       tar xf ${NODE_TARBALL} &&
+       export PATH=${HOME}/${NODE_DIR}/bin:$PATH; &&
+       cd $AGDA_HOME &&
+       node --version;
+    fi
+
+##############################################################################
 # Some tests
 
 # ASR (2016-09-17). Running the following tests, which use stack, here

--- a/.travis.yml
+++ b/.travis.yml
@@ -301,7 +301,7 @@ install:
        cd $HOME &&
        wget https://nodejs.org/download/release/${NODE_VERSION}/${NODE_TARBALL} &&
        tar xf ${NODE_TARBALL} &&
-       export PATH=${HOME}/${NODE_DIR}/bin:$PATH; &&
+       export PATH=${HOME}/${NODE_DIR}/bin:$PATH &&
        cd $AGDA_HOME &&
        node --version;
     fi

--- a/src/data/JS/agda-rts.js
+++ b/src/data/JS/agda-rts.js
@@ -45,7 +45,13 @@ exports.primNatMinus = function(x) {
 // Floats
 
 exports.primShowFloat = function(x) {
-  return x.toString();
+  // See Issue #2192.
+  if (Number.isInteger(x)) {
+    var a = x.toString();
+    return (a + ".0");
+  } else {
+    return x.toString();
+  }
 };
 
 exports.primFloatEquality = function(x) {

--- a/test/Compiler/simple/Floats.agda
+++ b/test/Compiler/simple/Floats.agda
@@ -35,6 +35,7 @@ main : IO Unit
 main =
   putStr "123.4 = " ,, print 123.4 ,,
   putStr "-42.9 = " ,, print -42.9 ,,
+  putStr "1.0   = " ,, print 1.0 ,,
   putStr "NaN   = " ,, print NaN   ,,
   putStr "Inf   = " ,, print Inf   ,,
   putStr "-Inf  = " ,, print -Inf  ,,

--- a/test/Compiler/simple/Floats.out
+++ b/test/Compiler/simple/Floats.out
@@ -3,6 +3,7 @@ EXECUTED_PROGRAM
 ret > ExitSuccess
 out > 123.4 = 123.4
 out > -42.9 = -42.9
+out > 1.0   = 1.0
 out > NaN   = NaN
 out > Inf   = Infinity
 out > -Inf  = -Infinity

--- a/test/Compiler/simple/FloatsJSFails.agda
+++ b/test/Compiler/simple/FloatsJSFails.agda
@@ -27,8 +27,6 @@ Inf = 1.0 / 0.0
 
 main : IO Unit
 main =
-  -- Issue #2192.
-  putStr "1.0  = " ,, print 1.0 ,,
   -- Issues #2169 and #2192.
   putStr "-0.0 = " ,, print -0.0  ,,
 

--- a/test/Compiler/simple/FloatsJSFails.out
+++ b/test/Compiler/simple/FloatsJSFails.out
@@ -1,7 +1,6 @@
 EXECUTED_PROGRAM
 
 ret > ExitSuccess
-out > 1.0  = 1.0
 out > -0.0 = -0.0
 out > NaN < -5.0  = true
 out >


### PR DESCRIPTION
The fix includes the installation of Node v0.11.16 on Travis.
