### PR TITLE
Add git commit information to version info

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -140,6 +140,7 @@ library
                 , equivalence >= 0.2.5 && < 0.4
                 , filepath >= 1.3.0.1 && < 1.5
                 , geniplate-mirror >= 0.6.0.6 && < 0.8
+                , gitrev >= 1.2 && < 2.0
                 -- hashable 1.2.0.10 makes library-test 10x
                 -- slower. The issue was fixed in hashable 1.2.1.0.
                 -- https://github.com/tibbe/hashable/issues/57.

--- a/doc/release-notes/2-5-2.md
+++ b/doc/release-notes/2-5-2.md
@@ -78,6 +78,10 @@ Installation and infrastructure
   - `--no-libraries`: Don't use any `.agda-lib` files (the previous behaviour
     of `--no-default-libraries`).
 
+* If `agda` was built in a `git` repository, then the `--version` flag
+  will display the hash of the commit used, and whether there where 
+  uncommited changes in the tree.
+
 Language
 --------
 

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-| Agda main module.
 -}
@@ -8,6 +9,8 @@ import Control.Monad.State
 import Control.Applicative
 
 import Data.Maybe
+
+import Development.GitRev
 
 import System.Environment
 import System.Exit
@@ -160,8 +163,22 @@ printUsage = do
 
 -- | Print version information.
 printVersion :: IO ()
-printVersion =
+printVersion = do
   putStrLn $ "Agda version " ++ version
+  forM_ commitInfo $ \info ->
+    putStrLn $ "Built from " ++ info
+
+-- | Information about current git commit, generated at compile time
+commitInfo :: Maybe String
+commitInfo = case $(gitHash) of
+  "UNKNOWN" -> Nothing
+  hash      -> Just $ concat [ hash, dirty, "\n"
+                             , "  + Branch: ", $(gitBranch)
+                             , "  + Commit date: ", $(gitCommitDate), "\n"
+                             ]
+  where
+    dirty | $(gitDirty) = " (uncommitted files present)"
+          | otherwise   = ""
 
 -- | What to do for bad options.
 optionError :: String -> IO ()


### PR DESCRIPTION
Displays such a message:

```
Agda version 2.6.0
Built from 0c2e34a7e899859e8d6b8924d93dca5a496415b1 (uncommitted files present)
  + Commit date: Fri Oct 14 11:18:31 2016 +0200
  + Branch: git-commit-in-version
```
