### PR TITLE
Fix build with GHC 8.0.2

### DIFF
--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP                       #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE NoMonoLocalBinds          #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 
 module Agda.Syntax.Abstract.Views where
@@ -95,8 +97,8 @@ deepUnscopeDecl d                                = [deepUnscope d]
 class ExprLike a where
   -- | The first expression is pre-traversal, the second one post-traversal.
   recurseExpr :: (Applicative m) => (Expr -> m Expr -> m Expr) -> a -> m a
-  default recurseExpr :: (Traversable f, Applicative m)
-                      => (Expr -> m Expr -> m Expr) -> f a -> m (f a)
+  default recurseExpr :: (Traversable f, ExprLike a', a ~ f a', Applicative m)
+                      => (Expr -> m Expr -> m Expr) -> a -> m a
   recurseExpr = traverse . recurseExpr
 
   foldExpr :: Monoid m => (Expr -> m) -> a -> m

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE GADTs               #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Preprocess 'Agda.Syntax.Concrete.Declaration's, producing 'NiceDeclaration's.
@@ -1210,8 +1211,7 @@ niceDeclarations ds = do
 
 class MakeAbstract a where
   mkAbstract :: Updater a
-  -- default mkAbstract :: (Traversable f, MakeAbstract a) => Updater (f a)
-  default mkAbstract :: (Traversable f) => Updater (f a)
+  default mkAbstract :: (Traversable f, MakeAbstract a', a ~ f a') => Updater a
   mkAbstract = traverse mkAbstract
 
 instance MakeAbstract a => MakeAbstract [a] where
@@ -1277,8 +1277,7 @@ instance MakeAbstract WhereClause where
 
 class MakePrivate a where
   mkPrivate :: Origin -> Updater a
-  -- default mkPrivate :: (Traversable f, MakePrivate a) => Updater (f a)
-  default mkPrivate :: (Traversable f) => Origin -> Updater (f a)
+  default mkPrivate :: (Traversable f, MakePrivate a', a ~ f a') => Origin -> Updater a
   mkPrivate o = traverse $ mkPrivate o
 
 instance MakePrivate a => MakePrivate [a] where


### PR DESCRIPTION
Agda has symptoms of code that was pointed out in [GHC Trac #12784](https://ghc.haskell.org/trac/ghc/ticket/12784#comment:13), and as a result, Agda fails to build with GHC 8.0.2. This PR fixes the situation by reworking some default type signatures so that they are more correct w.r.t. their type variables.