### PR TITLE
Updated nix installation instructions.

### DIFF
--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -35,14 +35,13 @@ will pull in emacs-agda-mode and ghc-Agda-devel.
 NixOS
 -----
 
-Agda is part of the Nixpkgs collection that is used by http://nixos.org/nixos. To install Agda, type:
+Agda is part of the Nixpkgs collection that is used by http://nixos.org/nixos. To install Agda and agda-mode for emacs, type:
 
 .. code-block:: bash
 
-  nix-env -iA haskellPackages.Agda
+  nix-env -f "<nixpkgs>" -iA haskellPackages.Agda
 
-If you’re just interested in the library, you can also install the library without the executable.
-Neither the emacs mode nor the Agda standard library are currently installed automatically, though.
+If you’re just interested in the library, you can also install the library without the executable. The Agda standard library is currently not installed automatically.
 
 OS X
 ----


### PR DESCRIPTION
See: https://github.com/agda/agda/pull/2342

Nix now hides haskellPackages unless you explicitly include the nixpkgs expression. As such the current nix instructions won't work as is.

https://nixos.org/nixpkgs/manual/#users-guide-to-the-haskell-infrastructure

Nix package now installs agda-mode as well, see "agda-mode" here:

https://raw.githubusercontent.com/NixOS/nixpkgs/master/pkgs/development/haskell-modules/hackage-packages.nix