### PR TITLE
Fixed #2363: with-clause pattern _ abbreviates any parent pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 Release notes for Agda version 2.5.3
 ====================================
 
+Language
+--------
+
+* With-clause patterns can be replaced by _
+  [Issue [#2363](https://github.com/agda/agda/issues/2363)].
+  Example:
+  ```agda
+    test : Nat → Set
+    test zero    with zero
+    test _       | _ = Nat
+    test (suc x) with zero
+    test _       | _ = Nat
+  ```
+  We do not have to spell out the pattern of the parent clause
+  (`zero` / `suc x`) in the with-clause if we do not need the
+  pattern variables.  Note that `x` is not in scope in the
+  with-clause!
+
 Compiler backends
 -----------------
 

--- a/test/Succeed/WithClauseUnderscore.agda
+++ b/test/Succeed/WithClauseUnderscore.agda
@@ -1,0 +1,35 @@
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Char
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+char : Char → Set
+char 'A' with 'O'
+char _ | _ = Char
+char _ = Char
+
+lit : Nat → Set
+lit 5 with 0
+lit _ | _ = Nat
+lit _ = Nat
+
+con : Nat → Set
+con zero    with zero
+con _       | _ = Nat
+con (suc x) with zero
+con _       | _ = Nat
+
+record R : Set where
+  coinductive -- disallow matching
+  field f : Bool
+
+data P (r : R) : Set where
+  isTrue : R.f r ≡ true → P r
+
+data True : (b : Bool) →  Set where
+  true! : True true
+
+test : (r : R) (p : P r) → True (R.f r)
+test r (isTrue p) with R.f r
+test _ _           | true = true!  -- underscore instead of (isTrue _)
+test _ (isTrue ()) | false


### PR DESCRIPTION
This is a (backwards-compatible) language change, thus, comes as a PR.  It makes the following type-check, by alleviating the user of repeating a parent patterns in the with-clause.
```agda
open import Agda.Builtin.Bool
open import Agda.Builtin.Char
open import Agda.Builtin.Nat
open import Agda.Builtin.Equality

char : Char → Set
char 'A' with 'O'
char _ | _ = Char
char _ = Char

lit : Nat → Set
lit 5 with 0
lit _ | _ = Nat
lit _ = Nat

con : Nat → Set
con zero    with zero
con _       | _ = Nat
con (suc x) with zero
con _       | _ = Nat

record R : Set where
  coinductive -- disallow matching
  field f : Bool

data P (r : R) : Set where
  isTrue : R.f r ≡ true → P r

data True : (b : Bool) →  Set where
  true! : True true

test : (r : R) (p : P r) → True (R.f r)
test r (isTrue p) with R.f r
test _ _           | true = true!  -- underscore instead of (isTrue _)
test _ (isTrue ()) | false
```