### PR TITLE
[ refactoring ] Eta-expansion of clauses.

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -358,6 +358,7 @@ library
                     Agda.TypeChecking.DropArgs
                     Agda.TypeChecking.Empty
                     Agda.TypeChecking.EtaContract
+                    Agda.TypeChecking.EtaExpand
                     Agda.TypeChecking.Errors
                     Agda.TypeChecking.Free
                     Agda.TypeChecking.Free.Lazy

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -19,7 +19,6 @@ module Agda.Termination.TermCheck
 import Prelude hiding (null)
 
 import Control.Applicative hiding (empty)
-import Control.Arrow (first)
 import Control.Monad.Reader
 import Control.Monad.State
 
@@ -52,6 +51,7 @@ import qualified Agda.Termination.Termination  as Term
 import Agda.Termination.RecCheck
 import Agda.Termination.Inlining
 
+import Agda.TypeChecking.EtaExpand
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Reduce (reduce, normalise, instantiate, instantiateFull)
@@ -623,63 +623,6 @@ termClause' clause = do
             , nest 2 $ text "rhs:" <+> prettyTCM v
             ]
 
--- | Expand a clause to the maximal arity, by inserting
---   variable patterns and applying the body to variables.
-
---   Fixes issue #2376.
---   Replaces 'introHiddenLambdas'.
---   See, e.g., test/Succeed/SizedTypesExtendedLambda.agda.
-etaExpandClause :: MonadTCM tcm => Clause -> tcm Clause
-etaExpandClause clause = liftTCM $ do
-  case clause of
-    Clause range ctel ps body        Nothing  catchall -> return clause
-
-    Clause range ctel ps Nothing     (Just t) catchall -> return clause
-    Clause range ctel ps (Just body) (Just t) catchall -> do
-
-      -- Get the telescope to expand the clause with.
-      TelV tel0 t' <- telView $ unArg t
-
-      -- If the rhs has lambdas, harvest the names of the bound variables.
-      let xs   = peekLambdas body
-      let ltel = useNames xs $ telToList tel0
-      let tel  = telFromList ltel
-      let n    = size tel
-      unless (n == size tel0) __IMPOSSIBLE__  -- useNames should not drop anything
-      -- Join with lhs telescope, extend patterns and apply body.
-      -- NB: no need to raise ctel!
-      let ctel' = telFromList $ telToList ctel ++ ltel
-          ps'   = raise n ps ++ teleNamedArgs tel
-          body' = raise n body `apply` teleArgs tel
-      reportSDoc "term.clause.expand" 30 $ inTopContext $ vcat
-        [ text "etaExpandClause"
-        , text "  body    = " <+> (addContext tel0 $ prettyTCM body)
-        , text "  xs      = " <+> text (show xs)
-        , text "  new tel = " <+> prettyTCM ctel'
-        ]
-      return $ Clause range ctel' ps' (Just body') (Just (t $> t')) catchall
-  where
-    -- Get all initial lambdas of the body.
-    peekLambdas :: Term -> [Arg ArgName]
-    peekLambdas v =
-      case ignoreSharing v of
-        Lam info b -> Arg info (absName b) : peekLambdas (unAbs b)
-        _ -> []
-
-    -- Use the names of the first argument, and set the Origin all other
-    -- parts of the telescope to Inserted.
-    -- The first list of arguments is a subset of the telescope.
-    -- Thus, if compared pointwise, if the hiding does not match,
-    -- it means we skipped an element of the telescope.
-    useNames :: [Arg ArgName] -> ListTel -> ListTel
-    useNames []     tel       = map (setOrigin Inserted) tel
-    useNames (_:_)  []        = __IMPOSSIBLE__
-    useNames (x:xs) (dom:tel)
-      | getHiding x == getHiding dom =
-          -- set the ArgName of the dom
-          fmap (first $ const $ unArg x) dom : useNames xs tel
-      | otherwise =
-          setOrigin Inserted dom : useNames (x:xs) tel
 
 -- | Extract recursive calls from expressions.
 class ExtractCalls a where

--- a/src/full/Agda/TypeChecking/EtaExpand.hs
+++ b/src/full/Agda/TypeChecking/EtaExpand.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE CPP #-}
+
+module Agda.TypeChecking.EtaExpand
+  ( etaExpandClause ) where
+
+import Control.Arrow ( first )
+
+import Agda.Syntax.Common
+import Agda.Syntax.Internal
+
+import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Context
+import Agda.TypeChecking.Monad.Options
+import Agda.TypeChecking.Pretty
+import Agda.TypeChecking.Substitute
+import Agda.TypeChecking.Telescope
+
+import Agda.Utils.Impossible
+import Agda.Utils.Functor ( ($>) )
+import Agda.Utils.Monad
+import Agda.Utils.Size
+
+#include "undefined.h"
+
+-- | Expand a clause to the maximal arity, by inserting variable
+--   patterns and applying the body to variables.
+
+--  Fixes issue #2376.
+--  Replaces 'introHiddenLambdas'.
+--  See, e.g., test/Succeed/SizedTypesExtendedLambda.agda.
+
+--  This is used instead of special treatment of lambdas
+--  (which was unsound: Issue #121)
+
+etaExpandClause :: MonadTCM tcm => Clause -> tcm Clause
+etaExpandClause clause = liftTCM $ do
+  case clause of
+    Clause range ctel ps body        Nothing  catchall -> return clause
+
+    Clause range ctel ps Nothing     (Just t) catchall -> return clause
+    Clause range ctel ps (Just body) (Just t) catchall -> do
+
+      -- Get the telescope to expand the clause with.
+      TelV tel0 t' <- telView $ unArg t
+
+      -- If the rhs has lambdas, harvest the names of the bound variables.
+      let xs   = peekLambdas body
+      let ltel = useNames xs $ telToList tel0
+      let tel  = telFromList ltel
+      let n    = size tel
+      unless (n == size tel0) __IMPOSSIBLE__  -- useNames should not drop anything
+      -- Join with lhs telescope, extend patterns and apply body.
+      -- NB: no need to raise ctel!
+      let ctel' = telFromList $ telToList ctel ++ ltel
+          ps'   = raise n ps ++ teleNamedArgs tel
+          body' = raise n body `apply` teleArgs tel
+      reportSDoc "term.clause.expand" 30 $ inTopContext $ vcat
+        [ text "etaExpandClause"
+        , text "  body    = " <+> (addContext tel0 $ prettyTCM body)
+        , text "  xs      = " <+> text (show xs)
+        , text "  new tel = " <+> prettyTCM ctel'
+        ]
+      return $ Clause range ctel' ps' (Just body') (Just (t $> t')) catchall
+  where
+    -- Get all initial lambdas of the body.
+    peekLambdas :: Term -> [Arg ArgName]
+    peekLambdas v =
+      case ignoreSharing v of
+        Lam info b -> Arg info (absName b) : peekLambdas (unAbs b)
+        _ -> []
+
+    -- Use the names of the first argument, and set the Origin all other
+    -- parts of the telescope to Inserted.
+    -- The first list of arguments is a subset of the telescope.
+    -- Thus, if compared pointwise, if the hiding does not match,
+    -- it means we skipped an element of the telescope.
+    useNames :: [Arg ArgName] -> ListTel -> ListTel
+    useNames []     tel       = map (setOrigin Inserted) tel
+    useNames (_:_)  []        = __IMPOSSIBLE__
+    useNames (x:xs) (dom:tel)
+      | getHiding x == getHiding dom =
+          -- set the ArgName of the dom
+          fmap (first $ const $ unArg x) dom : useNames xs tel
+      | otherwise =
+          setOrigin Inserted dom : useNames (x:xs) tel

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -34,6 +34,7 @@ import Agda.Syntax.Position (fuseRange, Range, HasRange(..), noRange)
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
 import Agda.TypeChecking.Datatypes (isDataOrRecordType, DataOrRecord(..))
+import Agda.TypeChecking.EtaExpand
 import Agda.TypeChecking.Records
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin (primInf, CoinductionKit(..), coinductionKit)
@@ -564,8 +565,7 @@ computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do
       <+> prettyTCM cur
   OccursAs (InDefOf q) <$> case theDef def of
     Function{funClauses = cs} -> do
-      n  <- getDefArity def
-      cs <- map (etaExpandClause n) <$> instantiateFull cs
+      cs <- mapM etaExpandClause =<< instantiateFull cs
       Concat . zipWith (OccursAs . InClause) [0..] <$>
         mapM (getOccurrences []) cs
     Datatype{dataClause = Just c} -> getOccurrences [] =<< instantiateFull c
@@ -597,30 +597,6 @@ computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do
     Axiom{}       -> return emptyOB
     Primitive{}   -> return emptyOB
     AbstractDefn  -> __IMPOSSIBLE__
-
--- | Eta expand a clause to have the given number of variables.
---   Warning: doesn't put correct types in telescope!
---   This is used instead of special treatment of lambdas
---   (which was unsound: issue 121)
-etaExpandClause :: Nat -> Clause -> Clause
-etaExpandClause n c
-  | m <= 0    = c
-  | otherwise = c
-      { namedClausePats = raise m (namedClausePats c) ++
-                          map (\i -> defaultArg $ namedDBVarP i underscore) (downFrom m)
-      , clauseBody      = liftBody m $ clauseBody c
-      , clauseTel       = telFromList $
-          telToList (clauseTel c) ++ (replicate m $ (underscore,) <$> dummyDom)
-          -- dummyDom, not __IMPOSSIBLE__, because of debug printing.
-      }
-  where
-    m = n - genericLength (namedClausePats c)
-
-    vars = map (defaultArg . var) $ downFrom m
---    vars = reverse [ defaultArg $ var i | i <- [0..m - 1] ]
-
-    liftBody m (Just v) = Just $ raise m v `apply` vars
-    liftBody m Nothing  = Nothing
 
 -- Building the occurrence graph ------------------------------------------
 


### PR DESCRIPTION
After commit ab655419f2d9e0e35b153b0ab0e6cc4fb4cf12e5 there were two functions which eta-expanded one clause. I removed the incomplete one (according to the source code documentation).

Request feedback: Should I keep the `etaExpandClause` function in a separate module? If not, into which module should I add it?
