### PR TITLE
Add "bump agda2-mode-pkg.el" to release docs

### DIFF
--- a/notes/agda-releases
+++ b/notes/agda-releases
@@ -14,6 +14,7 @@ followed:
       doc/user-manual/conf.py
       mk/versions.mk
       src/data/emacs-mode/agda2-mode.el
+      src/data/emacs-mode/agda2-mode-pkg.el
       src/size-solver/size-solver.cabal
       test/interaction/Issue1244a.out
       test/interaction/Issue1244b.out

--- a/notes/agda-releases-candidates
+++ b/notes/agda-releases-candidates
@@ -11,6 +11,7 @@ following procedure can be followed:
       doc/user-manual/conf.py
       mk/versions.mk
       src/data/emacs-mode/agda2-mode.el
+      src/data/emacs-mode/agda2-mode-pkg.el
       src/size-solver/size-solver.cabal
       test/interaction/Issue1244a.out
       test/interaction/Issue1244b.out

--- a/notes/agda-stable-releases
+++ b/notes/agda-stable-releases
@@ -25,6 +25,7 @@ be followed:
     /doc/user-manual/conf.py (twice)
     mk/versions.mk
     src/data/emacs-mode/agda2-mode.el
+    src/data/emacs-mode/agda2-mode-pkg.el
     src/size-solver/size-solver.cabal
     test/interaction/Issue1244a.out
     test/interaction/Issue1244b.out

--- a/notes/agda-stable-releases-candidates
+++ b/notes/agda-stable-releases-candidates
@@ -23,6 +23,7 @@ the following procedure can be followed:
     /doc/user-manual/conf.py
     mk/versions.mk
     src/data/emacs-mode/agda2-mode.el
+    src/data/emacs-mode/agda2-mode-pkg.el
     src/size-solver/size-solver.cabal
     test/interaction/Issue1244a.out
     test/interaction/Issue1244b.out


### PR DESCRIPTION
Fix #2032. Revised from https://github.com/agda/agda/pull/2454 onto the right branch.