### PR TITLE
[ refactor ] Removed obsolete `Error` type class

### DIFF
--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -58,6 +58,7 @@ import Agda.Utils.Except
   )
 
 import Agda.Utils.FileName      ( absolute, AbsolutePath, filePath )
+import Agda.Utils.Maybe         ( readMaybe )
 import Agda.Utils.Monad         ( ifM, readM )
 import Agda.Utils.List          ( groupOn, wordsBy )
 import Agda.Utils.String        ( indent )

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -66,8 +66,7 @@ import Agda.Interaction.Highlighting.Precise
   (CompressedFile, HighlightingInfo)
 
 import Agda.Utils.Except
-  ( Error(strMsg)
-  , ExceptT
+  ( ExceptT
   , MonadError(catchError, throwError)
   , runExceptT
   )
@@ -2683,9 +2682,6 @@ data TCErr
       --   Raised for pattern violations during unification ('assignV')
       --   but also in other situations where we want to backtrack.
   deriving (Typeable)
-
-instance Error TCErr where
-  strMsg = Exception noRange . text . strMsg
 
 instance Show TCErr where
   show (TypeError _ e)     = show (envRange $ clEnv e) ++ ": " ++ show (clValue e)

--- a/src/full/Agda/Utils/Except.hs
+++ b/src/full/Agda/Utils/Except.hs
@@ -4,8 +4,7 @@
 ------------------------------------------------------------------------------
 
 module Agda.Utils.Except
-  ( Error(noMsg, strMsg)
-  , ExceptT
+  ( ExceptT
   , mapExceptT
   , mkExceptT
   , MonadError(catchError, throwError)
@@ -21,17 +20,3 @@ import Control.Monad.Except
 -- @ExceptT@.
 mkExceptT :: m (Either e a) -> ExceptT e m a
 mkExceptT = ExceptT
-
--- | Error class for backward compatibility (from
--- Control.Monad.Trans.Error in transformers 0.3.0.0).
-
-class Error a where
-  noMsg  :: a
-  strMsg :: String -> a
-
-  noMsg    = strMsg ""
-  strMsg _ = noMsg
-
--- | A string can be thrown as an error.
-instance Error String where
-  strMsg = id

--- a/src/full/Agda/Utils/Maybe.hs
+++ b/src/full/Agda/Utils/Maybe.hs
@@ -100,3 +100,10 @@ allJustM = runMaybeT . mapM MaybeT
 -- allJustM []         = return $ Just []
 -- allJustM (mm : mms) = caseMaybeM mm (return Nothing) $ \ a ->
 --   fmap (a:) <$> allJust mms
+
+-- * Read.
+
+readMaybe :: Read a => String -> Maybe a
+readMaybe s = case reads s of
+                [(x,"")] -> Just x
+                _        -> Nothing

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -18,11 +18,7 @@ import Data.Traversable as Trav hiding (for, sequence)
 import Data.Foldable as Fold
 import Data.Maybe
 
-import Agda.Utils.Except
-  ( Error(strMsg)
-  , MonadError(catchError, throwError)
-  )
-
+import Agda.Utils.Except ( MonadError(catchError, throwError) )
 import Agda.Utils.List
 
 #include "undefined.h"
@@ -182,12 +178,12 @@ localState = bracket_ get put
 
 -- Read -------------------------------------------------------------------
 
-readM :: (Error e, MonadError e m, Read a) => String -> m a
+-- For throwing an error other than 'String' use
+-- 'Agda.Utils.Maybe.readMaybe'.
+readM :: (MonadError String m, Read a) => String -> m a
 readM s = case reads s of
-            [(x,"")]    -> return x
-            _           ->
-              throwError $ strMsg $ "readM: parse error string " ++ s
-
+            [(x,"")] -> return x
+            _        -> throwError $ "readM: parse error string " ++ s
 
 -- RETIRED STUFF ----------------------------------------------------------
 


### PR DESCRIPTION
For removing the obsolete [`Error`](https://github.com/agda/agda/blob/4935902d52cdd189aa558447d20e4f029cfefc90/src/full/Agda/Utils/Except.hs#L28-L33) type class, I specialised the function [`readM`](https://github.com/agda/agda/blob/4935902d52cdd189aa558447d20e4f029cfefc90/src/full/Agda/Utils/Monad.hs#L185) from 

  ```
  readM :: (Error e, MonadError e m, Read a) => String -> m a
  ```

  to

  ```
  readM :: (MonadError String m, Read a) => String -> m a
  ```

Any objection about this change?
