### PR TITLE
Fixed #2546: test Agda files from last week first

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -632,6 +632,7 @@ test-suite agda-tests
                 , tasty-silver >= 3.1.8 && < 3.2
                 , temporary >= 1.2.0.3 && < 1.3
                 , text >= 0.11.3.1 && < 1.3
+                , unix-compat >= 0.4.3.1 && < 0.5
   if impl(ghc < 7.8)
     -- provide System.Environment.setEnv for pre-GHC7.6
     build-depends:  setenv >= 0.1.1.3 && < 0.2

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -3,6 +3,7 @@
 
 module Utils where
 
+import Data.Ord
 import Data.Text (Text)
 import qualified Data.Text as T
 import System.Exit
@@ -19,6 +20,8 @@ import System.FilePath
 import qualified System.FilePath.Find as Find
 import System.FilePath.GlobPattern
 import System.Directory
+import System.PosixCompat.Time (epochTime)
+import System.PosixCompat.Files (modificationTime)
 
 import qualified Data.ByteString as BS
 
@@ -64,7 +67,7 @@ getEnvVar v =
 hasAgdaExtension :: FilePath -> Bool
 hasAgdaExtension = isJust . dropAgdaExtension'
 
-data SearchMode = Rec | NonRec
+data SearchMode = Rec | NonRec deriving (Eq)
 
 dropAgdaExtension' :: FilePath -> Maybe FilePath
 dropAgdaExtension' p =  stripExtension ".agda" p
@@ -86,13 +89,50 @@ dropAgdaExtension p =
 dropAgdaOrOtherExtension :: FilePath -> FilePath
 dropAgdaOrOtherExtension = fromMaybe <$> dropExtension <*> dropAgdaExtension'
 
+-- | Find (non)recursively all Agda files in the given directory
+--   and order them alphabetically, with the exception that
+--   the ones from the last week come first, ordered by age (youngest first).
+--   This heuristic should run the interesting tests first.
 getAgdaFilesInDir :: SearchMode -> FilePath -> IO [FilePath]
-getAgdaFilesInDir rec dir =
-  sort <$>
-    case rec of
-      Rec -> Find.find (pure True) (hasAgdaExtension <$> Find.filePath) dir
-      NonRec -> map (dir </>) . filter hasAgdaExtension <$>
-                  getDirectoryContents dir
+getAgdaFilesInDir recurse dir = do
+  now <- epochTime
+  -- Andreas, 2017-04-29 issue #2546
+  -- We take first the new test cases, then the rest.
+  -- Both groups are ordered alphabetically,
+  -- but for the first group, the younger ones come first.
+  let order :: Find.FileInfo -> Find.FileInfo -> Ordering
+      order = comparing $ \ info ->
+        let age = now - modificationTime (Find.infoStatus info) in
+        -- Building a tuple for lexicographic comparison:
+        ( Down $  -- This Down reverses the usual order Nothing < Just
+            if age > consideredNew then Nothing else Just $
+              Down age -- This Down reverses the effect of the first Down
+        , Find.infoPath info
+        )
+      -- Test cases from up to one week ago are considered new.
+      consideredNew = 7 * 24 * 60 * 60
+      -- If @recurse /= Rec@ don't go into subdirectories
+      recP = pure (recurse == Rec) Find.||? Find.depth Find.<? 1
+  map Find.infoPath  . sortBy order <$>
+    findWithInfo recP (hasAgdaExtension <$> Find.filePath) dir
+
+
+-- | Search a directory recursively, with recursion controlled by a
+--   'RecursionPredicate'.  Lazily return a unsorted list of all files
+--   matching the given 'FilterPredicate'.  Any errors that occur are
+--   ignored, with warnings printed to 'stderr'.
+findWithInfo
+  :: Find.RecursionPredicate  -- ^ Control recursion into subdirectories.
+  -> Find.FilterPredicate     -- ^ Decide whether a file appears in the result.
+  -> FilePath                 -- ^ Directory to start searching.
+  -> IO [Find.FileInfo]       -- ^ Files that matched the 'FilterPredicate'.
+findWithInfo recurse filt dir = Find.fold recurse act [] dir
+  where
+  -- Add file to list front when it matches the filter
+  act :: [Find.FileInfo] -> Find.FileInfo -> [Find.FileInfo]
+  act fs f
+    | Find.evalClause filt f = f:fs
+    | otherwise = fs
 
 -- | An Agda file path as test name
 asTestName :: FilePath -> FilePath -> String


### PR DESCRIPTION
When retrieving test Agda files, return first the ones from last week.

Testing on travis before merging.