### PR TITLE
[ fix #2486 ] Fix foreign data inheritance problem.

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/Misc.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Misc.hs
@@ -84,10 +84,7 @@ conhqn :: QName -> TCM HS.QName
 conhqn q = do
     cq  <- canonicalName q
     def <- getConstInfo cq
-    cname <- xhqn "C" cq  -- Do this even if it has custom compiledHaskell code
-                          -- to make sure we get the import.
-    caseMaybeM (getHaskellConstructor cq) (return cname) $ \ hsCon ->
-      return $ hsName hsCon
+    xhqn "C" cq
 
 -- qualify name s by the module of builtin b
 bltQual :: String -> String -> TCM HS.QName

--- a/src/full/Agda/Compiler/MAlonzo/Pretty.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Pretty.hs
@@ -65,6 +65,7 @@ instance Pretty HS.Decl where
       sep [ hsep (punctuate comma (map pretty fs)) <+> text "::"
           , nest 2 $ pretty t ]
     HS.FunBind ms -> vcat $ map pretty ms
+    HS.PatSyn p1 p2 -> sep [ text "pattern" <+> pretty p1 <+> text "=" <+> pretty p2 ]
     HS.FakeDecl s -> text s
 
 instance Pretty HS.ConDecl where

--- a/src/full/Agda/Utils/Haskell/Syntax.hs
+++ b/src/full/Agda/Utils/Haskell/Syntax.hs
@@ -20,6 +20,7 @@ data Decl = TypeDecl Name [TyVarBind] Type
           | DataDecl DataOrNew Name [TyVarBind] [ConDecl] [Deriving]
           | TypeSig [Name] Type
           | FunBind [Match]
+          | PatSyn Pat Pat
           | FakeDecl String
   deriving (Eq)
 

--- a/test/Compiler/simple/Issue2486.agda
+++ b/test/Compiler/simple/Issue2486.agda
@@ -1,0 +1,15 @@
+module Issue2486 where
+
+open import Common.Prelude
+open import Issue2486.Import
+
+f : MyList String → String
+f [] = "sdf"
+f (x :: _) = x
+
+xs : MyList String
+xs = "sdfg" :: []
+
+main : IO Unit
+main =
+  putStrLn (f xs)

--- a/test/Compiler/simple/Issue2486.options
+++ b/test/Compiler/simple/Issue2486.options
@@ -1,0 +1,1 @@
+TestOptions {forCompilers = [(MAlonzo, CompilerOptions {extraAgdaArgs = []})], runtimeOptions = [], executeProg = True}

--- a/test/Compiler/simple/Issue2486.out
+++ b/test/Compiler/simple/Issue2486.out
@@ -1,0 +1,5 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > sdfg
+out >

--- a/test/Compiler/simple/Issue2486/Haskell.agda
+++ b/test/Compiler/simple/Issue2486/Haskell.agda
@@ -1,0 +1,7 @@
+module Issue2486.Haskell where
+
+{-# FOREIGN GHC
+
+data MyList a = Nil | Cons a (MyList a)
+
+#-}

--- a/test/Compiler/simple/Issue2486/Import.agda
+++ b/test/Compiler/simple/Issue2486/Import.agda
@@ -1,0 +1,11 @@
+module Issue2486.Import where
+
+open import Issue2486.Haskell
+
+{-# FOREIGN GHC import qualified MAlonzo.Code.Issue2486.Haskell #-}
+
+data MyList (A : Set) : Set where
+  [] : MyList A
+  _::_ : A → MyList A → MyList A
+
+{-# COMPILE GHC MyList = data MAlonzo.Code.Issue2486.Haskell.MyList ( MAlonzo.Code.Issue2486.Haskell.Nil | MAlonzo.Code.Issue2486.Haskell.Cons ) #-}


### PR DESCRIPTION
Testing on travis...

Encode compiled data constructors as pattern synonyms. This lets us
export compiled data constructors like normal plain Agda constructors
and avoids the need for transitively inheriting Haskell import
statements.