### PR TITLE
[ .travis ] Added `group: edge`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ dist: trusty
 # Explicitly request sudo-enabled virtual environments [Issue #1992].
 sudo: required
 
+# Suggested by Travis for testing the updates to Trusty 14.04 images.
+group: edge
+
 cache:
   directories:
   - $HOME/.cabal


### PR DESCRIPTION
Travis suggested [here](http://mailchi.mp/travis-ci/we-are-updating-all-our-ubuntu-trusty-1404-images-this-wednesday) add `group: edge` for testing the updates to Trusty 14.04 images. I created this PR for testing those updates.