### PR TITLE
Debug refactor

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -355,6 +355,7 @@ library
                     Agda.TypeChecking.Monad.Closure
                     Agda.TypeChecking.Monad.Constraints
                     Agda.TypeChecking.Monad.Context
+                    Agda.TypeChecking.Monad.Debug
                     Agda.TypeChecking.Monad.Env
                     Agda.TypeChecking.Monad.Imports
                     Agda.TypeChecking.Monad.Local

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -38,7 +38,8 @@ import Agda.TypeChecking.Substitute ( absBody )
 import Agda.TypeChecking.Level ( reallyUnLevelView )
 import Agda.TypeChecking.Monad hiding (Global, Local)
 import Agda.TypeChecking.Monad.Builtin
-import Agda.TypeChecking.Monad.Options ( setCommandLineOptions, reportSLn )
+import Agda.TypeChecking.Monad.Debug ( reportSLn )
+import Agda.TypeChecking.Monad.Options ( setCommandLineOptions )
 import Agda.TypeChecking.Reduce ( instantiateFull, normalise )
 import Agda.TypeChecking.Substitute (TelV(..))
 import Agda.TypeChecking.Telescope

--- a/src/full/Agda/Interaction/EmacsTop.hs
+++ b/src/full/Agda/Interaction/EmacsTop.hs
@@ -46,7 +46,7 @@ mimicGHCi setup = do
       hSetEncoding  stdin  utf8
 
     setInteractionOutputCallback $
-        liftIO . mapM_ print <=< lispifyResponse
+        mapM_ print <=< lispifyResponse
 
     commands <- liftIO $ initialiseCommandQueue readCommand
 
@@ -120,9 +120,9 @@ formatWarningsAndErrors g w e = (body, title)
 
 -- | Convert Response to an elisp value for the interactive emacs frontend.
 
-lispifyResponse :: Response -> TCM [Lisp String]
-lispifyResponse (Resp_HighlightingInfo info modFile) =
-  (:[]) <$> lispifyHighlightingInfo info modFile
+lispifyResponse :: Response -> IO [Lisp String]
+lispifyResponse (Resp_HighlightingInfo info method modFile) =
+  (:[]) <$> lispifyHighlightingInfo info method modFile
 lispifyResponse (Resp_DisplayInfo info) = return $ case info of
     Info_CompilationOk w e -> f body "*Compilation result*"
       where (body, _) = formatWarningsAndErrors "The module was successfully compiled.\n" w e -- abusing the goals field since we ignore the title

--- a/src/full/Agda/Interaction/Highlighting/Emacs.hs
+++ b/src/full/Agda/Interaction/Highlighting/Emacs.hs
@@ -81,12 +81,12 @@ showAspects modFile (r, m) = L $
 
 lispifyHighlightingInfo
   :: HighlightingInfo
+  -> HighlightingMethod
   -> ModuleToSource
      -- ^ Must contain a mapping for every definition site's module.
-  -> TCM (Lisp String)
-lispifyHighlightingInfo h modFile = do
-  method <- envHighlightingMethod <$> ask
-  liftIO $ case ranges h of
+  -> IO (Lisp String)
+lispifyHighlightingInfo h method modFile = do
+  case ranges h of
     _             | method == Direct                   -> direct
     ((_, mi) : _) | otherAspects mi == [TypeChecks] ||
                     mi == mempty                       -> direct

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -113,12 +113,13 @@ highlightAsTypeChecked rPre r m
 printHighlightingInfo :: MonadTCM tcm => HighlightingInfo -> tcm ()
 printHighlightingInfo x = do
   modToSrc <- use stModuleToSource
+  method   <- view eHighlightingMethod
   liftTCM $ reportSLn "highlighting" 50 $
     "Printing highlighting info:\n" ++ show x ++ "\n" ++
     "  modToSrc = " ++ show modToSrc
   unless (null $ ranges x) $ do
     liftTCM $ appInteractionOutputCallback $
-        Resp_HighlightingInfo x modToSrc
+        Resp_HighlightingInfo x method modToSrc
 
 -- | Highlighting levels.
 

--- a/src/full/Agda/Interaction/Response.hs
+++ b/src/full/Agda/Interaction/Response.hs
@@ -33,7 +33,7 @@ import Agda.Utils.Impossible
 --   so the user can have timely response even during long computations.
 
 data Response
-    = Resp_HighlightingInfo HighlightingInfo ModuleToSource
+    = Resp_HighlightingInfo HighlightingInfo HighlightingMethod ModuleToSource
     | Resp_Status Status
     | Resp_JumpToError FilePath Int32
     | Resp_InteractionPoints [InteractionId]
@@ -123,7 +123,7 @@ data GiveResult
 --      closure of the 'InteractionOutputCallback' function.
 --      (suitable for intra-process communication).
 
-type InteractionOutputCallback = Response -> TCM ()
+type InteractionOutputCallback = Response -> IO ()
 
 -- | The default 'InteractionOutputCallback' function prints certain
 -- things to stdout (other things generate internal errors).

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -48,6 +48,7 @@ import Agda.Syntax.Scope.Monad
 
 import Agda.TypeChecking.Monad.Base (typeError, TypeError(..), LHSOrPatSyn(..))
 import qualified Agda.TypeChecking.Monad.Benchmark as Bench
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.State (getScope)
 import Agda.TypeChecking.Monad.Options
 

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -31,6 +31,7 @@ import Agda.Syntax.Concrete as C
 import Agda.Syntax.Scope.Base
 
 import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.State
 import Agda.TypeChecking.Monad.Options
 

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -51,6 +51,7 @@ import Agda.Syntax.Scope.Base
 
 import Agda.TypeChecking.Monad.State (getScope)
 import Agda.TypeChecking.Monad.Base  (TCM, NamedMeta(..), stBuiltinThings, BuiltinThings, Builtin(..))
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Options
 
 import qualified Agda.Utils.AssocList as AssocList

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -61,6 +61,7 @@ import Agda.TypeChecking.Monad.Builtin
 import Agda.TypeChecking.Monad.Trace (traceCall, setCurrentRange)
 import Agda.TypeChecking.Monad.State
 import Agda.TypeChecking.Monad.MetaVars (registerInteractionPoint)
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Options
 import Agda.TypeChecking.Monad.Env (insideDotPattern, isInsideDotPattern)
 import Agda.TypeChecking.Rules.Builtin (isUntypedBuiltin, bindUntypedBuiltin)

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -188,7 +188,7 @@ class (Functor m, Monad m) => MonadTer m where
 -- | Termination monad.
 
 newtype TerM a = TerM { terM :: ReaderT TerEnv TCM a }
-  deriving (Functor, Applicative, Monad, MonadBench Phase, HasOptions)
+  deriving (Functor, Applicative, Monad, MonadBench Phase, HasOptions, MonadDebug)
 
 instance MonadTer TerM where
   terAsk     = TerM $ ask

--- a/src/full/Agda/TypeChecking/CompiledClause/Match.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Match.hs
@@ -12,7 +12,7 @@ import Agda.Syntax.Internal
 import Agda.Syntax.Common
 
 import Agda.TypeChecking.CompiledClause
-import Agda.TypeChecking.Monad hiding (reportSDoc, reportSLn)
+import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Reduce.Monad as RedM
@@ -174,6 +174,7 @@ match' [] = {- new line here since __IMPOSSIBLE__ does not like the ' in match' 
     pds <- getPartialDefs
     if f `elem` pds
     then return (NoReduction $ NotBlocked MissingClauses [])
-    else traceSLn "impossible" 10
-           ("Incomplete pattern matching when applying " ++ show f)
-           __IMPOSSIBLE__
+    else do
+      reportSLn "impossible" 10
+        ("Incomplete pattern matching when applying " ++ show f)
+      __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -49,6 +49,7 @@ import Agda.Syntax.Scope.Base
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Closure
 import Agda.TypeChecking.Monad.Context
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Options
 import Agda.TypeChecking.Monad.Builtin
 import Agda.TypeChecking.Monad.State

--- a/src/full/Agda/TypeChecking/Functions.hs
+++ b/src/full/Agda/TypeChecking/Functions.hs
@@ -12,6 +12,7 @@ import Agda.Syntax.Internal
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Context
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Options
 import Agda.TypeChecking.Level
 import Agda.TypeChecking.Pretty

--- a/src/full/Agda/TypeChecking/Monad.hs
+++ b/src/full/Agda/TypeChecking/Monad.hs
@@ -3,6 +3,7 @@ module Agda.TypeChecking.Monad
     , module Agda.TypeChecking.Monad.Closure
     , module Agda.TypeChecking.Monad.Constraints
     , module Agda.TypeChecking.Monad.Context
+    , module Agda.TypeChecking.Monad.Debug
     , module Agda.TypeChecking.Monad.Env
     , module Agda.TypeChecking.Monad.Imports
     , module Agda.TypeChecking.Monad.Local
@@ -23,6 +24,7 @@ import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Closure
 import Agda.TypeChecking.Monad.Constraints
 import Agda.TypeChecking.Monad.Context
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Env
 import Agda.TypeChecking.Monad.Imports
 import Agda.TypeChecking.Monad.Local

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2800,7 +2800,7 @@ class (Functor m, Applicative m, Monad m) => MonadDebug m where
 instance (MonadIO m) => MonadDebug (TCMT m) where
   displayDebugMessage n s = liftTCM $ do
     cb <- gets $ stInteractionOutputCallback . stPersistentState
-    cb (Resp_RunningInfo n s)
+    liftIO $ cb (Resp_RunningInfo n s)
 
 instance MonadDebug m => MonadDebug (ExceptT e m) where
   displayDebugMessage n s = lift $ displayDebugMessage n s

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1254,7 +1254,7 @@ data RewriteRule = RewriteRule
                              --   where @≡@ is the rewrite relation.
   , rewContext :: Telescope  -- ^ @Γ@.
   , rewHead    :: QName      -- ^ @f@.
-  , rewPats    :: PElims     -- ^ @Γ ⊢ ps  : t@.
+  , rewPats    :: PElims     -- ^ @Γ ⊢ f ps : t@.
   , rewRHS     :: Term       -- ^ @Γ ⊢ rhs : t@.
   , rewType    :: Type       -- ^ @Γ ⊢ t@.
   }

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2791,37 +2791,6 @@ instance (HasOptions m, Monoid w) => HasOptions (WriterT w m) where
   commandLineOptions = lift commandLineOptions
 
 -----------------------------------------------------------------------------
--- * Printing debug messages
------------------------------------------------------------------------------
-
-class (Functor m, Applicative m, Monad m) => MonadDebug m where
-  displayDebugMessage :: Int -> String -> m ()
-
-instance (MonadIO m) => MonadDebug (TCMT m) where
-  displayDebugMessage n s = liftTCM $ do
-    cb <- gets $ stInteractionOutputCallback . stPersistentState
-    liftIO $ cb (Resp_RunningInfo n s)
-
-instance MonadDebug m => MonadDebug (ExceptT e m) where
-  displayDebugMessage n s = lift $ displayDebugMessage n s
-
-instance MonadDebug m => MonadDebug (ListT m) where
-  displayDebugMessage n s = lift $ displayDebugMessage n s
-
-instance MonadDebug m => MonadDebug (MaybeT m) where
-  displayDebugMessage n s = lift $ displayDebugMessage n s
-
-instance MonadDebug m => MonadDebug (ReaderT r m) where
-  displayDebugMessage n s = lift $ displayDebugMessage n s
-
-instance MonadDebug m => MonadDebug (StateT s m) where
-  displayDebugMessage n s = lift $ displayDebugMessage n s
-
-instance (MonadDebug m, Monoid w) => MonadDebug (WriterT w m) where
-  displayDebugMessage n s = lift $ displayDebugMessage n s
-
-
------------------------------------------------------------------------------
 -- * The reduce monad
 -----------------------------------------------------------------------------
 
@@ -2909,7 +2878,6 @@ class ( Applicative tcm, MonadIO tcm
       , MonadReader TCEnv tcm
       , MonadState TCState tcm
       , HasOptions tcm
-      , MonadDebug tcm
       ) => MonadTCM tcm where
     liftTCM :: TCM a -> tcm a
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -62,7 +62,7 @@ import {-# SOURCE #-} Agda.Compiler.Backend
 -- import {-# SOURCE #-} Agda.Interaction.FindFile
 import Agda.Interaction.Options
 import Agda.Interaction.Response
-  (InteractionOutputCallback, defaultInteractionOutputCallback)
+  (InteractionOutputCallback, defaultInteractionOutputCallback, Response(..))
 import Agda.Interaction.Highlighting.Precise
   (CompressedFile, HighlightingInfo)
 
@@ -2791,6 +2791,37 @@ instance (HasOptions m, Monoid w) => HasOptions (WriterT w m) where
   commandLineOptions = lift commandLineOptions
 
 -----------------------------------------------------------------------------
+-- * Printing debug messages
+-----------------------------------------------------------------------------
+
+class (Functor m, Applicative m, Monad m) => MonadDebug m where
+  displayDebugMessage :: Int -> String -> m ()
+
+instance (MonadIO m) => MonadDebug (TCMT m) where
+  displayDebugMessage n s = liftTCM $ do
+    cb <- gets $ stInteractionOutputCallback . stPersistentState
+    cb (Resp_RunningInfo n s)
+
+instance MonadDebug m => MonadDebug (ExceptT e m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+instance MonadDebug m => MonadDebug (ListT m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+instance MonadDebug m => MonadDebug (MaybeT m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+instance MonadDebug m => MonadDebug (ReaderT r m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+instance MonadDebug m => MonadDebug (StateT s m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+instance (MonadDebug m, Monoid w) => MonadDebug (WriterT w m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+
+-----------------------------------------------------------------------------
 -- * The reduce monad
 -----------------------------------------------------------------------------
 
@@ -2878,6 +2909,7 @@ class ( Applicative tcm, MonadIO tcm
       , MonadReader TCEnv tcm
       , MonadState TCState tcm
       , HasOptions tcm
+      , MonadDebug tcm
       ) => MonadTCM tcm where
     liftTCM :: TCM a -> tcm a
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs-boot
@@ -8,6 +8,7 @@ import Data.Map (Map)
 import Agda.Syntax.Concrete.Name (TopLevelModuleName)
 import Agda.Utils.FileName (AbsolutePath)
 
+data HighlightingMethod
 data TCEnv
 data TCState
 newtype TCMT m a = TCM { unTCM :: IORef TCState -> TCEnv -> m a }

--- a/src/full/Agda/TypeChecking/Monad/Benchmark.hs
+++ b/src/full/Agda/TypeChecking/Monad/Benchmark.hs
@@ -15,6 +15,7 @@ import Prelude hiding (print)
 import Agda.Benchmarking
 
 import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Debug
 import{-# SOURCE #-} Agda.TypeChecking.Monad.Options
 
 import qualified Agda.Utils.Benchmark as B

--- a/src/full/Agda/TypeChecking/Monad/Caching.hs
+++ b/src/full/Agda/TypeChecking/Monad/Caching.hs
@@ -23,6 +23,7 @@ import qualified Data.Map as Map
 import Agda.Syntax.Common
 
 import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Options
 
 import Agda.Utils.Lens

--- a/src/full/Agda/TypeChecking/Monad/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Monad/Constraints.hs
@@ -13,6 +13,7 @@ import qualified Data.Set as Set
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Closure
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Options
 
 import Agda.Utils.Lens

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -125,9 +125,9 @@ weakenModuleParameters n = updateModuleParameters (raiseS n)
 --   This is ok for instance if we are outside module @m@
 --   (in which case we have to supply all module parameters to any
 --   symbol defined within @m@ we want to refer).
-getModuleParameterSub :: MonadTCM tcm => ModuleName -> tcm Substitution
+getModuleParameterSub :: (Functor m, ReadTCState m) => ModuleName -> m Substitution
 getModuleParameterSub m = do
-  r <- use stModuleParameters
+  r <- (^. stModuleParameters) <$> getTCState
   case Map.lookup m r of
     Nothing -> return IdS
     Just mp -> return $ mpSubstitution mp

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -21,6 +21,7 @@ import Agda.Syntax.Internal
 import Agda.Syntax.Scope.Monad (getLocalVars, setLocalVars)
 
 import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Monad.Open
 import Agda.TypeChecking.Monad.Options
@@ -85,7 +86,8 @@ withModuleParameters mp ret = do
 
 -- | Apply a substitution to all module parameters.
 
-updateModuleParameters :: MonadTCM tcm => Substitution -> tcm a -> tcm a
+updateModuleParameters :: (MonadTCM tcm, MonadDebug tcm)
+                       => Substitution -> tcm a -> tcm a
 updateModuleParameters sub ret = do
   pm <- use stModuleParameters
   let showMP pref mps = intercalate "\n" $
@@ -114,7 +116,8 @@ updateModuleParameters sub ret = do
 -- | Since the @ModuleParamDict@ is relative to the current context,
 --   this function should be called everytime the context is extended.
 --
-weakenModuleParameters :: MonadTCM tcm => Nat -> tcm a -> tcm a
+weakenModuleParameters :: (MonadTCM tcm, MonadDebug tcm)
+                       => Nat -> tcm a -> tcm a
 weakenModuleParameters n = updateModuleParameters (raiseS n)
 
 -- | Get substitution @Γ ⊢ ρ : Γm@ where @Γ@ is the current context
@@ -165,7 +168,8 @@ class AddContext b where
 --   the current context, we need to weaken it when we
 --   extend the context.  This function takes care of that.
 --
-addContext' :: (MonadTCM tcm, AddContext b) => b -> tcm a -> tcm a
+addContext' :: (MonadTCM tcm, MonadDebug tcm, AddContext b)
+            => b -> tcm a -> tcm a
 addContext' cxt = addContext cxt . weakenModuleParameters (contextSize cxt)
 
 #if __GLASGOW_HASKELL__ >= 710

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE CPP #-}
+
+module Agda.TypeChecking.Monad.Debug where
+
+import Control.Applicative
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Trans.Maybe
+import Control.Monad.Writer
+
+import Data.Maybe
+import Data.Semigroup (Semigroup, Monoid, (<>), mempty, mappend, Any(..))
+import Data.Traversable
+
+import {-# SOURCE #-} Agda.TypeChecking.Errors
+import Agda.TypeChecking.Monad.Base
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Options
+
+import Agda.Interaction.Response
+
+import Agda.Utils.Except
+import Agda.Utils.Lens
+import Agda.Utils.List
+import Agda.Utils.ListT
+import Agda.Utils.Maybe
+import Agda.Utils.Monad
+import Agda.Utils.Pretty
+
+#include "undefined.h"
+import Agda.Utils.Impossible
+
+class (Functor m, Applicative m, Monad m) => MonadDebug m where
+  displayDebugMessage :: Int -> String -> m ()
+
+instance (MonadIO m) => MonadDebug (TCMT m) where
+  displayDebugMessage n s = liftTCM $ do
+    cb <- gets $ stInteractionOutputCallback . stPersistentState
+    liftIO $ cb (Resp_RunningInfo n s)
+
+instance MonadDebug m => MonadDebug (ExceptT e m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+instance MonadDebug m => MonadDebug (ListT m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+instance MonadDebug m => MonadDebug (MaybeT m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+instance MonadDebug m => MonadDebug (ReaderT r m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+instance MonadDebug m => MonadDebug (StateT s m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+instance (MonadDebug m, Monoid w) => MonadDebug (WriterT w m) where
+  displayDebugMessage n s = lift $ displayDebugMessage n s
+
+-- | Conditionally print debug string.
+{-# SPECIALIZE reportS :: VerboseKey -> Int -> String -> TCM () #-}
+reportS :: (HasOptions m, MonadDebug m)
+        => VerboseKey -> Int -> String -> m ()
+reportS k n s = verboseS k n $ displayDebugMessage n s
+
+-- | Conditionally println debug string.
+{-# SPECIALIZE reportSLn :: VerboseKey -> Int -> String -> TCM () #-}
+reportSLn :: (HasOptions m, MonadDebug m)
+          => VerboseKey -> Int -> String -> m ()
+reportSLn k n s = verboseS k n $
+  displayDebugMessage n (s ++ "\n")
+
+-- | Conditionally render debug 'Doc' and print it.
+{-# SPECIALIZE reportSDoc :: VerboseKey -> Int -> TCM Doc -> TCM () #-}
+reportSDoc :: MonadTCM tcm => VerboseKey -> Int -> TCM Doc -> tcm ()
+reportSDoc k n d = liftTCM $ verboseS k n $ do
+  displayDebugMessage n . (++ "\n") . show =<< do
+    d `catchError` \ err ->
+      (\ s -> (sep $ map text
+                 [ "Printing debug message"
+                 , k  ++ ":" ++show n
+                 , "failed due to error:" ]) $$
+              (nest 2 $ text s)) <$> prettyError err
+
+-- | Print brackets around debug messages issued by a computation.
+{-# SPECIALIZE verboseBracket :: VerboseKey -> Int -> String -> TCM a -> TCM a #-}
+verboseBracket :: (HasOptions m, MonadDebug m, MonadError err m)
+               => VerboseKey -> Int -> String -> m a -> m a
+verboseBracket k n s m = ifNotM (hasVerbosity k n) m $ {- else -} do
+  displayDebugMessage n $ "{ " ++ s ++ "\n"
+  m `finally` displayDebugMessage n "}\n"

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs-boot
@@ -10,6 +10,7 @@ import Agda.Utils.Pretty
 
 class (Functor m, Applicative m, Monad m) => MonadDebug m where
   displayDebugMessage :: Int -> String -> m ()
+  formatDebugMessage  :: VerboseKey -> Int -> TCM Doc -> m String
 
 instance (MonadIO m) => MonadDebug (TCMT m)
 
@@ -17,5 +18,6 @@ reportS :: (HasOptions m, MonadDebug m)
         => VerboseKey -> Int -> String -> m ()
 reportSLn :: (HasOptions m, MonadDebug m)
           => VerboseKey -> Int -> String -> m ()
-reportSDoc :: MonadTCM tcm => VerboseKey -> Int -> TCM Doc -> tcm ()
+reportSDoc :: (HasOptions m, MonadDebug m)
+           => VerboseKey -> Int -> TCM Doc -> m ()
 

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs-boot
@@ -1,0 +1,21 @@
+module Agda.TypeChecking.Monad.Debug where
+
+import Control.Applicative
+import Control.Monad.IO.Class (MonadIO)
+
+import Agda.TypeChecking.Monad.Base
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Options
+
+import Agda.Utils.Pretty
+
+class (Functor m, Applicative m, Monad m) => MonadDebug m where
+  displayDebugMessage :: Int -> String -> m ()
+
+instance (MonadIO m) => MonadDebug (TCMT m)
+
+reportS :: (HasOptions m, MonadDebug m)
+        => VerboseKey -> Int -> String -> m ()
+reportSLn :: (HasOptions m, MonadDebug m)
+          => VerboseKey -> Int -> String -> m ()
+reportSDoc :: MonadTCM tcm => VerboseKey -> Int -> TCM Doc -> tcm ()
+

--- a/src/full/Agda/TypeChecking/Monad/Local.hs
+++ b/src/full/Agda/TypeChecking/Monad/Local.hs
@@ -9,6 +9,7 @@ import Agda.Syntax.Internal
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Context
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Env
 import Agda.TypeChecking.Monad.Options
 import Agda.TypeChecking.Free

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -25,7 +25,7 @@ import Agda.Syntax.Scope.Base
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Trace
 import Agda.TypeChecking.Monad.Closure
-import Agda.TypeChecking.Monad.Options (reportSLn)
+import Agda.TypeChecking.Monad.Debug (reportSLn)
 import Agda.TypeChecking.Monad.Context
 import Agda.TypeChecking.Substitute
 import {-# SOURCE #-} Agda.TypeChecking.Telescope

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -376,15 +376,6 @@ hasExactVerbosity k n =
 whenExactVerbosity :: MonadTCM tcm => VerboseKey -> Int -> tcm () -> tcm ()
 whenExactVerbosity k n = whenM $ liftTCM $ hasExactVerbosity k n
 
--- | Displays a debug message in a suitable way.
-{-# SPECIALIZE displayDebugMessage :: Int -> String -> TCM () #-}
-displayDebugMessage :: MonadTCM tcm
-  => Int     -- ^ The message's debug level.
-  -> String  -- ^ Message.
-  -> tcm ()
-displayDebugMessage n s = liftTCM $
-  appInteractionOutputCallback (Resp_RunningInfo n s)
-
 -- | Run a computation if a certain verbosity level is activated.
 --
 --   Precondition: The level must be non-negative.
@@ -396,12 +387,14 @@ verboseS k n action = whenM (hasVerbosity k n) action
 
 -- | Conditionally print debug string.
 {-# SPECIALIZE reportS :: VerboseKey -> Int -> String -> TCM () #-}
-reportS :: MonadTCM tcm => VerboseKey -> Int -> String -> tcm ()
-reportS k n s = liftTCM $ verboseS k n $ displayDebugMessage n s
+reportS :: (HasOptions m, MonadDebug m)
+        => VerboseKey -> Int -> String -> m ()
+reportS k n s = verboseS k n $ displayDebugMessage n s
 
 -- | Conditionally println debug string.
 {-# SPECIALIZE reportSLn :: VerboseKey -> Int -> String -> TCM () #-}
-reportSLn :: MonadTCM tcm => VerboseKey -> Int -> String -> tcm ()
+reportSLn :: (HasOptions m, MonadDebug m)
+          => VerboseKey -> Int -> String -> m ()
 reportSLn k n s = verboseS k n $
   displayDebugMessage n (s ++ "\n")
 
@@ -419,7 +412,8 @@ reportSDoc k n d = liftTCM $ verboseS k n $ do
 
 -- | Print brackets around debug messages issued by a computation.
 {-# SPECIALIZE verboseBracket :: VerboseKey -> Int -> String -> TCM a -> TCM a #-}
-verboseBracket :: MonadTCM tcm => VerboseKey -> Int -> String -> TCM a -> tcm a
-verboseBracket k n s m = liftTCM $ ifNotM (hasVerbosity k n) m $ {- else -} do
+verboseBracket :: (HasOptions m, MonadDebug m, MonadError err m)
+               => VerboseKey -> Int -> String -> m a -> m a
+verboseBracket k n s m = ifNotM (hasVerbosity k n) m $ {- else -} do
   displayDebugMessage n $ "{ " ++ s ++ "\n"
   m `finally` displayDebugMessage n "}\n"

--- a/src/full/Agda/TypeChecking/Monad/Options.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs-boot
@@ -14,6 +14,3 @@ type VerboseKey = String
 
 hasVerbosity :: HasOptions m => VerboseKey -> Int -> m Bool
 verboseS :: HasOptions m => VerboseKey -> Int -> m () -> m ()
-reportSLn :: (HasOptions m, MonadDebug m)
-          => VerboseKey -> Int -> String -> m ()
-reportSDoc :: MonadTCM tcm => VerboseKey -> Int -> TCM Doc -> tcm ()

--- a/src/full/Agda/TypeChecking/Monad/Options.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs-boot
@@ -14,5 +14,6 @@ type VerboseKey = String
 
 hasVerbosity :: HasOptions m => VerboseKey -> Int -> m Bool
 verboseS :: HasOptions m => VerboseKey -> Int -> m () -> m ()
-reportSLn :: MonadTCM tcm => VerboseKey -> Int -> String -> tcm ()
+reportSLn :: (HasOptions m, MonadDebug m)
+          => VerboseKey -> Int -> String -> m ()
 reportSDoc :: MonadTCM tcm => VerboseKey -> Int -> TCM Doc -> tcm ()

--- a/src/full/Agda/TypeChecking/Monad/Sharing.hs
+++ b/src/full/Agda/TypeChecking/Monad/Sharing.hs
@@ -10,6 +10,7 @@ import Data.Traversable
 
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Options
 import Agda.Utils.Monad
 

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -28,6 +28,7 @@ import Agda.Syntax.Position
 import Agda.Syntax.Treeless (Compiled(..), TTerm)
 
 import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Context
 import Agda.TypeChecking.Monad.Options
 import Agda.TypeChecking.Monad.Env

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -771,7 +771,9 @@ getCurrentModuleFreeVars = size <$> (lookupSection =<< currentModule)
 getDefFreeVars :: (Functor m, Applicative m, ReadTCState m, MonadReader TCEnv m) => QName -> m Nat
 getDefFreeVars = getModuleFreeVars . qnameModule
 
-freeVarsToApply :: QName -> TCM Args
+freeVarsToApply :: (Functor m, HasConstInfo m, HasOptions m,
+                    ReadTCState m, MonadReader TCEnv m, MonadDebug m)
+                => QName -> m Args
 freeVarsToApply q = do
   vs <- moduleParamsToApply $ qnameModule q
   t <- defType <$> getConstInfo q
@@ -780,7 +782,8 @@ freeVarsToApply q = do
 
 {-# SPECIALIZE getModuleFreeVars :: ModuleName -> TCM Nat #-}
 {-# SPECIALIZE getModuleFreeVars :: ModuleName -> ReduceM Nat #-}
-getModuleFreeVars :: (Functor m, Applicative m, ReadTCState m, MonadReader TCEnv m) => ModuleName -> m Nat
+getModuleFreeVars :: (Functor m, Applicative m, MonadReader TCEnv m, ReadTCState m)
+                  => ModuleName -> m Nat
 getModuleFreeVars m = do
   m0   <- commonParentModule m <$> currentModule
   (+) <$> getAnonymousVariables m <*> (size <$> lookupSection m0)
@@ -799,7 +802,9 @@ getModuleFreeVars m = do
 --        module M₃ Θ where
 --          ... M₁.M₂.f [insert Γ raised by Θ]
 --   @
-moduleParamsToApply :: ModuleName -> TCM Args
+moduleParamsToApply :: (Functor m, Applicative m, HasOptions m,
+                        MonadReader TCEnv m, ReadTCState m, MonadDebug m)
+                    => ModuleName -> m Args
 moduleParamsToApply m = do
   -- Get the correct number of free variables (correctly raised) of @m@.
 

--- a/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
@@ -14,6 +14,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Internal
 
 import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Options
 import Agda.TypeChecking.Monad.Builtin
 import Agda.TypeChecking.Monad.State

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -33,6 +33,7 @@ import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Internal
 
 import Agda.TypeChecking.Monad.Base
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Options
 import Agda.TypeChecking.Positivity.Occurrence
 import Agda.TypeChecking.CompiledClause

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -352,7 +352,7 @@ getInteractionOutputCallback
 
 appInteractionOutputCallback :: Response -> TCM ()
 appInteractionOutputCallback r
-  = getInteractionOutputCallback >>= \ cb -> cb r
+  = getInteractionOutputCallback >>= \ cb -> liftIO $ cb r
 
 setInteractionOutputCallback :: InteractionOutputCallback -> TCM ()
 setInteractionOutputCallback cb

--- a/src/full/Agda/TypeChecking/Monad/Statistics.hs
+++ b/src/full/Agda/TypeChecking/Monad/Statistics.hs
@@ -11,6 +11,7 @@ import qualified Text.PrettyPrint.Boxes as Boxes
 import Agda.Syntax.Concrete.Name as C
 
 import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Options
 
 import Agda.Utils.Lens

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -136,14 +136,14 @@ matchCopatterns :: [NamedArg DeBruijnPattern]
                 -> [Elim]
                 -> ReduceM (Match Term, [Elim])
 matchCopatterns ps vs = do
-  traceSDoc "tc.match" 50
+  traceSDocM "tc.match" 50
     (vcat [ text "matchCopatterns"
           , nest 2 $ text "ps =" <+> fsep (punctuate comma $ map (prettyTCM . namedArg) ps)
           , nest 2 $ text "vs =" <+> fsep (punctuate comma $ map prettyTCM vs)
-          ]) $ do
-     -- Buggy, see issue 1124:
-     -- mapFst mconcat . unzip <$> zipWithM' (matchCopattern . namedArg) ps vs
-     foldMatch (matchCopattern . namedArg) ps vs
+          ])
+  -- Buggy, see issue 1124:
+  -- mapFst mconcat . unzip <$> zipWithM' (matchCopattern . namedArg) ps vs
+  foldMatch (matchCopattern . namedArg) ps vs
 
 -- | Match a single copattern.
 matchCopattern :: DeBruijnPattern
@@ -162,15 +162,15 @@ matchPatterns :: [NamedArg DeBruijnPattern]
               -> [Arg Term]
               -> ReduceM (Match Term, [Arg Term])
 matchPatterns ps vs = do
-  traceSDoc "tc.match" 50
+  traceSDocM "tc.match" 50
     (vcat [ text "matchPatterns"
           , nest 2 $ text "ps =" <+> fsep (punctuate comma $ map (text . show) ps)
           , nest 2 $ text "vs =" <+> fsep (punctuate comma $ map prettyTCM vs)
-          ]) $ do
-     -- Buggy, see issue 1124:
-     -- (ms,vs) <- unzip <$> zipWithM' (matchPattern . namedArg) ps vs
-     -- return (mconcat ms, vs)
-     foldMatch (matchPattern . namedArg) ps vs
+          ])
+  -- Buggy, see issue 1124:
+  -- (ms,vs) <- unzip <$> zipWithM' (matchPattern . namedArg) ps vs
+  -- return (mconcat ms, vs)
+  foldMatch (matchPattern . namedArg) ps vs
 
 -- | Match a single pattern.
 matchPattern :: DeBruijnPattern

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -19,7 +19,7 @@ import Agda.Syntax.Internal
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Reduce.Monad
 import Agda.TypeChecking.Substitute
-import Agda.TypeChecking.Monad hiding (reportSDoc)
+import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records
 import Agda.TypeChecking.Datatypes
@@ -136,7 +136,7 @@ matchCopatterns :: [NamedArg DeBruijnPattern]
                 -> [Elim]
                 -> ReduceM (Match Term, [Elim])
 matchCopatterns ps vs = do
-  traceSDocM "tc.match" 50
+  reportSDoc "tc.match" 50
     (vcat [ text "matchCopatterns"
           , nest 2 $ text "ps =" <+> fsep (punctuate comma $ map (prettyTCM . namedArg) ps)
           , nest 2 $ text "vs =" <+> fsep (punctuate comma $ map prettyTCM vs)
@@ -162,7 +162,7 @@ matchPatterns :: [NamedArg DeBruijnPattern]
               -> [Arg Term]
               -> ReduceM (Match Term, [Arg Term])
 matchPatterns ps vs = do
-  traceSDocM "tc.match" 50
+  reportSDoc "tc.match" 50
     (vcat [ text "matchPatterns"
           , nest 2 $ text "ps =" <+> fsep (punctuate comma $ map (text . show) ps)
           , nest 2 $ text "vs =" <+> fsep (punctuate comma $ map prettyTCM vs)

--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -564,7 +564,7 @@ translateRecordPatterns clause = do
 
 newtype RecPatM a = RecPatM (TCMT (ReaderT Nat (StateT Nat IO)) a)
   deriving (Functor, Applicative, Monad,
-            MonadIO, MonadTCM, HasOptions,
+            MonadIO, MonadTCM, HasOptions, MonadDebug,
             MonadReader TCEnv, MonadState TCState)
 
 -- | Runs a computation in the 'RecPatM' monad.

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -499,16 +499,16 @@ unfoldDefinitionStep unfoldDelayed v0 f es =
       debugReduce ev = verboseS "tc.reduce" 90 $ do
         case ev of
           NoReduction v -> do
-            traceSDocM "tc.reduce" 90 $ vcat
+            reportSDoc "tc.reduce" 90 $ vcat
               [ text "*** tried to reduce " <+> prettyTCM f
               , text "    es =  " <+> sep (map (prettyTCM . ignoreReduced) es)
               -- , text "*** tried to reduce " <+> prettyTCM vfull
               , text "    stuck on" <+> prettyTCM (ignoreBlocking v)
               ]
           YesReduction _simpl v -> do
-            traceSDocM "tc.reduce"  90 $ text "*** reduced definition: " <+> prettyTCM f
-            traceSDocM "tc.reduce"  95 $ text "    result" <+> prettyTCM v
-            traceSDocM "tc.reduce" 100 $ text "    raw   " <+> text (show v)
+            reportSDoc "tc.reduce"  90 $ text "*** reduced definition: " <+> prettyTCM f
+            reportSDoc "tc.reduce"  95 $ text "    result" <+> prettyTCM v
+            reportSDoc "tc.reduce" 100 $ text "    raw   " <+> text (show v)
 
 -- | Reduce a non-primitive definition if it is a copy linking to another def.
 reduceDefCopy :: QName -> Elims -> TCM (Reduced () Term)
@@ -541,7 +541,7 @@ reduceHead' v = do -- ignoreAbstractMode $ do
 
   -- first, possibly rewrite literal v to constructor form
   v <- constructorForm v
-  traceSDocM "tc.inj.reduce" 30 (text "reduceHead" <+> prettyTCM v)
+  reportSDoc "tc.inj.reduce" 30 (text "reduceHead" <+> prettyTCM v)
   case ignoreSharing v of
     Def f es -> do
 
@@ -689,7 +689,7 @@ instance Simplify Term where
       Def f vs   -> do
         let keepGoing simp v = return (simp, notBlocked v)
         (simpl, v) <- unfoldDefinition' False keepGoing (Def f []) f vs
-        traceSDocM "tc.simplify'" 20 (
+        reportSDoc "tc.simplify'" 20 (
           text ("simplify': unfolding definition returns " ++ show simpl)
             <+> prettyTCM (ignoreBlocking v))
         case simpl of

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -541,7 +541,7 @@ reduceHead' v = do -- ignoreAbstractMode $ do
 
   -- first, possibly rewrite literal v to constructor form
   v <- constructorForm v
-  traceSDoc "tc.inj.reduce" 30 (text "reduceHead" <+> prettyTCM v) $ do
+  traceSDocM "tc.inj.reduce" 30 (text "reduceHead" <+> prettyTCM v)
   case ignoreSharing v of
     Def f es -> do
 
@@ -689,9 +689,9 @@ instance Simplify Term where
       Def f vs   -> do
         let keepGoing simp v = return (simp, notBlocked v)
         (simpl, v) <- unfoldDefinition' False keepGoing (Def f []) f vs
-        traceSDoc "tc.simplify'" 20 (
+        traceSDocM "tc.simplify'" 20 (
           text ("simplify': unfolding definition returns " ++ show simpl)
-            <+> prettyTCM (ignoreBlocking v)) $ do
+            <+> prettyTCM (ignoreBlocking v))
         case simpl of
           YesSimplification -> simplifyBlocked' v -- Dangerous, but if @simpl@ then @v /= Def f vs@
           NoSimplification  -> Def f <$> simplify' vs

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -547,10 +547,10 @@ reduceHead' v = do -- ignoreAbstractMode $ do
 
       abstractMode <- envAbstractMode <$> ask
       isAbstract <- treatAbstractly f
-      traceSLn "tc.inj.reduce" 50 (
+      reportSLn "tc.inj.reduce" 50 (
         "reduceHead: we are in " ++ show abstractMode++ "; " ++ show f ++
         " is treated " ++ if isAbstract then "abstractly" else "concretely"
-        ) $ do
+        )
       let v0  = Def f []
           red = unfoldDefinitionE False reduceHead' v0 f es
       def <- theDef <$> getConstInfo f
@@ -561,7 +561,7 @@ reduceHead' v = do -- ignoreAbstractMode $ do
         -- type checker loop here on non-terminating functions.
         -- see test/fail/TerminationInfiniteRecord
         Function{ funClauses = [ _ ], funDelayed = NotDelayed, funTerminates = Just True } -> do
-          traceSLn "tc.inj.reduce" 50 ("reduceHead: head " ++ show f ++ " is Function") $ do
+          reportSLn "tc.inj.reduce" 50 ("reduceHead: head " ++ show f ++ " is Function")
           red
         Datatype{ dataClause = Just _ } -> red
         Record{ recClause = Just _ }    -> red

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -531,6 +531,7 @@ reduceTm env !constInfo allowNonTerminating hasRewriting zero suc = reduceB' 0
           pds <- getPartialDefs
           if f `elem` pds
           then return (NoReduction $ NotBlocked MissingClauses es)
-          else traceSLn "impossible" 10
-                 ("Incomplete pattern matching when applying " ++ show f)
-                 __IMPOSSIBLE__
+          else do
+            reportSLn "impossible" 10
+              ("Incomplete pattern matching when applying " ++ show f)
+            __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -9,7 +9,6 @@ module Agda.TypeChecking.Reduce.Monad
   , getConstInfo
   , isInstantiatedMeta
   , lookupMeta
-  , traceSDoc, traceSDocM
   , askR, applyWhenVerboseS
   ) where
 
@@ -133,22 +132,6 @@ isInstantiatedMeta i = do
 {-# SPECIALIZE applyWhenVerboseS :: VerboseKey -> Int -> (ReduceM a -> ReduceM a) -> ReduceM a-> ReduceM a #-}
 applyWhenVerboseS :: HasOptions m => VerboseKey -> Int -> (m a -> m a) -> m a -> m a
 applyWhenVerboseS k n f a = ifM (hasVerbosity k n) (f a) a
-
-traceSDocM :: VerboseKey -> Int -> TCM Doc -> ReduceM ()
-traceSDocM k n doc = traceSDoc k n doc $ return ()
-
-traceSDoc :: VerboseKey -> Int -> TCM Doc -> ReduceM a -> ReduceM a
-traceSDoc k n doc = applyWhenVerboseS k n $ \ cont -> do
-  ReduceEnv env st <- askR
-  unsafePerformIO $ do
-    _ <- runTCM env st $ reportSDoc k n doc
-    return cont
-
--- traceSDoc :: VerboseKey -> Int -> TCM Doc -> ReduceM a -> ReduceM a
--- traceSDoc k n doc = verboseS k n $ ReduceM $ do
---   ReduceEnv env st <- ask
---   -- return $! unsafePerformIO $ do print . fst =<< runTCM env st doc
---   trace (show $ fst $ unsafePerformIO $ runTCM env st doc) $ return ()
 
 instance MonadDebug ReduceM where
 

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -151,11 +151,18 @@ traceSDoc k n doc = applyWhenVerboseS k n $ \ cont -> do
 --   trace (show $ fst $ unsafePerformIO $ runTCM env st doc) $ return ()
 
 instance MonadDebug ReduceM where
+
   displayDebugMessage n s = do
     ReduceEnv env st <- askR
     unsafePerformIO $ do
       _ <- runTCM env st $ displayDebugMessage n s
       return $ return ()
+
+  formatDebugMessage k n d = do
+    ReduceEnv env st <- askR
+    unsafePerformIO $ do
+      (s , _) <- runTCM env st $ formatDebugMessage k n d
+      return $ return s
 
 instance HasConstInfo ReduceM where
   getRewriteRulesFor = defaultGetRewriteRulesFor (gets id)

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -9,7 +9,7 @@ module Agda.TypeChecking.Reduce.Monad
   , getConstInfo
   , isInstantiatedMeta
   , lookupMeta
-  , traceSLn, traceSDoc, traceSDocM
+  , traceSDoc, traceSDocM
   , askR, applyWhenVerboseS
   ) where
 
@@ -149,13 +149,6 @@ traceSDoc k n doc = applyWhenVerboseS k n $ \ cont -> do
 --   ReduceEnv env st <- ask
 --   -- return $! unsafePerformIO $ do print . fst =<< runTCM env st doc
 --   trace (show $ fst $ unsafePerformIO $ runTCM env st doc) $ return ()
-
-traceSLn :: VerboseKey -> Int -> String -> ReduceM a -> ReduceM a
-traceSLn k n s = applyWhenVerboseS k n $ \ cont -> do
-  ReduceEnv env st <- askR
-  unsafePerformIO $ do
-    _ <- runTCM env st $ reportSLn k n s
-    return cont
 
 instance MonadDebug ReduceM where
   displayDebugMessage n s = do

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -157,6 +157,13 @@ traceSLn k n s = applyWhenVerboseS k n $ \ cont -> do
     _ <- runTCM env st $ reportSLn k n s
     return cont
 
+instance MonadDebug ReduceM where
+  displayDebugMessage n s = do
+    ReduceEnv env st <- askR
+    unsafePerformIO $ do
+      _ <- runTCM env st $ displayDebugMessage n s
+      return $ return ()
+
 instance HasConstInfo ReduceM where
   getRewriteRulesFor = defaultGetRewriteRulesFor (gets id)
   getConstInfo q = ReduceM $ \(ReduceEnv env st) ->

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -330,7 +330,7 @@ rewriteWith :: Maybe Type
             -> Elims
             -> ReduceM (Either (Blocked Term) Term)
 rewriteWith mt v rew@(RewriteRule q gamma _ ps rhs b) es = do
-  Red.traceSDocM "rewriting" 75 (sep
+  reportSDoc "rewriting" 75 (sep
     [ text "attempting to rewrite term " <+> prettyTCM (v `applyE` es)
     , text " with rule " <+> prettyTCM rew
     ])
@@ -339,7 +339,7 @@ rewriteWith mt v rew@(RewriteRule q gamma _ ps rhs b) es = do
     Left block -> return $ Left $ block $> v `applyE` es -- TODO: remember reductions
     Right sub  -> do
       let v' = applySubst sub rhs
-      Red.traceSDocM "rewriting" 70 (sep
+      reportSDoc "rewriting" 70 (sep
         [ text "rewrote " <+> prettyTCM (v `applyE` es)
         , text " to " <+> prettyTCM v'
         ])

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -330,19 +330,20 @@ rewriteWith :: Maybe Type
             -> Elims
             -> ReduceM (Either (Blocked Term) Term)
 rewriteWith mt v rew@(RewriteRule q gamma _ ps rhs b) es = do
-  Red.traceSDoc "rewriting" 75 (sep
+  Red.traceSDocM "rewriting" 75 (sep
     [ text "attempting to rewrite term " <+> prettyTCM (v `applyE` es)
     , text " with rule " <+> prettyTCM rew
-    ]) $ do
-    result <- nonLinMatch gamma ps es
-    case result of
-      Left block -> return $ Left $ block $> v `applyE` es -- TODO: remember reductions
-      Right sub  -> do
-        let v' = applySubst sub rhs
-        Red.traceSDoc "rewriting" 70 (sep
-          [ text "rewrote " <+> prettyTCM (v `applyE` es)
-          , text " to " <+> prettyTCM v'
-          ]) $ return $ Right v'
+    ])
+  result <- nonLinMatch gamma ps es
+  case result of
+    Left block -> return $ Left $ block $> v `applyE` es -- TODO: remember reductions
+    Right sub  -> do
+      let v' = applySubst sub rhs
+      Red.traceSDocM "rewriting" 70 (sep
+        [ text "rewrote " <+> prettyTCM (v `applyE` es)
+        , text " to " <+> prettyTCM v'
+        ])
+      return $ Right v'
 
     {- OLD CODE:
     -- Freeze all metas, remember which one where not frozen before.

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -200,11 +200,6 @@ runNLM nlm = do
     Left block -> return $ Left block
     Right _    -> return $ Right out
 
-traceSDocNLM :: VerboseKey -> Int -> TCM Doc -> NLM a -> NLM a
-traceSDocNLM k n doc = applyWhenVerboseS k n $ \ cont -> do
-  ReduceEnv env st <- liftRed askR
-  trace (show $ fst $ unsafePerformIO $ runTCM env st doc) cont
-
 matchingBlocked :: Blocked_ -> NLM ()
 matchingBlocked = throwError
 
@@ -220,10 +215,10 @@ tellSub r i v = do
       | otherwise       -> whenJustM (liftRed $ equal v v') matchingBlocked
 
 tellEq :: Telescope -> Telescope -> Term -> Term -> NLM ()
-tellEq gamma k u v =
-  traceSDocNLM "rewriting" 60 (sep
+tellEq gamma k u v = do
+  liftRed $ traceSDocM "rewriting" 60 (sep
                [ text "adding equality between" <+> addContext (gamma `abstract` k) (prettyTCM u)
-               , text " and " <+> addContext k (prettyTCM v) ]) $ do
+               , text " and " <+> addContext k (prettyTCM v) ])
   nlmEqs %= (PostponedEquation k u v:)
 
 type Sub = IntMap (Relevance, Term)
@@ -264,9 +259,9 @@ instance Match a b => Match (Elim' a) (Elim' b) where
      (Apply p, Apply v) -> let r' = r `composeRelevance` getRelevance p
                            in  match r' gamma k p v
      (Proj _ x, Proj _ y) -> if x == y then return () else
-                             traceSDocNLM "rewriting" 80 (sep
+                             liftRed (traceSDocM "rewriting" 80 (sep
                                [ text "mismatch between projections " <+> prettyTCM x
-                               , text " and " <+> prettyTCM y ]) mzero
+                               , text " and " <+> prettyTCM y ])) >> mzero
      (Apply{}, Proj{} ) -> __IMPOSSIBLE__
      (Proj{} , Apply{}) -> __IMPOSSIBLE__
 
@@ -299,26 +294,28 @@ instance Match NLPat Term where
         v = ignoreBlocking vb
         prettyPat  = addContext (gamma `abstract` k) (prettyTCM (raisePatVars n p))
         prettyTerm = addContext k (prettyTCM v)
-    traceSDocNLM "rewriting" 100 (sep
+    liftRed $ traceSDocM "rewriting" 100 (sep
       [ text "matching" <+> prettyPat
-      , text "with" <+> prettyTerm]) $ do
+      , text "with" <+> prettyTerm])
     let yes = return ()
-        no msg =
-          traceSDocNLM "rewriting" 80 (sep
+        no msg = do
+          liftRed $ traceSDocM "rewriting" 80 (sep
             [ text "mismatch between" <+> prettyPat
             , text " and " <+> prettyTerm
-            , msg ]) $ matchingBlocked b
-        block b' =
-          traceSDocNLM "rewriting" 80 (sep
+            , msg ])
+          matchingBlocked b
+        block b' = do
+          liftRed $ traceSDocM "rewriting" 80 (sep
             [ text "matching blocked on meta"
-            , text (show b) ]) $ matchingBlocked (b `mappend` b')
+            , text (show b) ])
+          matchingBlocked (b `mappend` b')
     case p of
       PWild  -> yes
       PVar id i bvs -> do
         -- If the variable is still bound by the current context, we cannot
         -- instantiate it so it has to match on the nose (see Issue 1652).
         ctx <- zip <$> getContextNames <*> getContextId
-        traceSDocNLM "rewriting" 90 (text "Current context:" <+> (prettyTCM ctx)) $ do
+        liftRed $ traceSDocM "rewriting" 90 (text "Current context:" <+> (prettyTCM ctx))
         cid <- getContextId
         case (maybe Nothing (\i -> elemIndex i cid) id) of
           Just j -> if v == Var (j+n) (map (Apply . fmap var) bvs)
@@ -439,17 +436,17 @@ checkPostponedEquations sub eqs = forM' eqs $
 -- main function
 nonLinMatch :: (Match a b) => Telescope -> a -> b -> ReduceM (Either Blocked_ Substitution)
 nonLinMatch gamma p v = do
-  let no msg b = traceSDoc "rewriting" 80 (sep
+  let no msg b = traceSDocM "rewriting" 80 (sep
                    [ text "matching failed during" <+> text msg
-                   , text "blocking: " <+> text (show b) ]) $ return (Left b)
+                   , text "blocking: " <+> text (show b) ]) >> return (Left b)
   caseEitherM (runNLM $ match Relevant gamma EmptyTel p v) (no "matching") $ \ s -> do
     let sub = makeSubstitution gamma $ s^.nlmSub
         eqs = s^.nlmEqs
-    traceSDoc "rewriting" 90 (text $ "sub = " ++ show sub) $ do
-      ok <- checkPostponedEquations sub eqs
-      case ok of
-        Nothing -> return $ Right sub
-        Just b  -> no "checking of postponed equations" b
+    traceSDocM "rewriting" 90 (text $ "sub = " ++ show sub)
+    ok <- checkPostponedEquations sub eqs
+    case ok of
+      Nothing -> return $ Right sub
+      Just b  -> no "checking of postponed equations" b
 
 -- | Untyped βη-equality, does not handle things like empty record types.
 --   Returns `Nothing` if the terms are equal, or `Just b` if the terms are not
@@ -464,11 +461,12 @@ equal u v = do
       block = caseMaybe (headMaybe metas)
                 (NotBlocked ReallyNotBlocked ())
                 (\m -> Blocked m ())
-  if ok then return Nothing else
-    traceSDoc "rewriting" 80 (sep
+  if ok then return Nothing else do
+    traceSDocM "rewriting" 80 (sep
       [ text "mismatch between " <+> prettyTCM u
       , text " and " <+> prettyTCM v
-      ]) $ return $ Just block
+      ])
+    return $ Just block
 
 -- | Normalise the given term but also preserve blocking tags
 --   TODO: implement a more efficient version of this.


### PR DESCRIPTION
This is work in progress on generalizing debug statements to work in `ReduceM` and other monads (and maybe pure code as well).

So far, it seems that it should be possible to bring debugging in `TCM` and `ReduceM` under a common interface (let's call it `MonadDebug`) but for pure code we'll need a more limited `trace`-based approach.