### PR TITLE
Implement #2671: allow nullary extended lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,28 @@ Language
   before the illegal declarations, or move them inside the
   existing module.
 
+* Pattern matching lambdas (also known as extended lambdas) can now be
+  nullary, mirroring the behaviour for ordinary function definitions.
+  [Issue [#2671](https://github.com/agda/agda/issues/2671)]
+
+  This is useful for case splitting on the result inside an
+  expression: given
+  ```agda
+  record _×_ (A B : Set) : Set where
+    field
+      π₁ : A
+      π₂ : B
+  open _×_
+  ```
+  one may case split on the result (C-c C-c RET) in a hole
+  ```agda
+    λ { → {!!}}
+  ```
+  of type A × B to produce
+  ```agda
+    λ { .π₁ → {!!} ; .π₂ → {!!}}  
+  ```
+
 Emacs mode
 ----------
 

--- a/test/Succeed/NullaryExtendedLambda.agda
+++ b/test/Succeed/NullaryExtendedLambda.agda
@@ -1,0 +1,11 @@
+-- Christian Sattler, 2017-08-05
+-- Nullary extended lambdas are useful in the interaction mode
+-- for case splitting on the result inside an expression.
+module NullaryExtendedLambda where
+
+f : {A : Set} → A → A
+f a = λ { → a }
+
+g : {A : Set} → A → A
+g a = λ where
+  → a


### PR DESCRIPTION
I don't know if there is anything that depends on extended lambdas being non-nullary. Even though I would find that unlikely, someone more knowledgeable needs to confirm this.

All tests pass.