### PR TITLE
Add stack.yaml files for GHC 7.8.4 and 7.10.3. Closes #2693.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,14 @@ matrix:
           sources:
             - hvr-ghc
 
+    - env: TEST=STACKAGE GHC_VER=7.10.3 BUILD=STACK ARGS="--stack-yaml stack-7.10.3.yaml --system-ghc"
+      addons:
+        apt:
+          packages:
+            - ghc-7.10.3
+          sources:
+            - hvr-ghc
+
     # Since `stack haddock` compiles Agda but `cabal haddock` does
     # not, this test is faster using `BUILD=CABAL` [Issue #2188].
     - env: TEST=HADDOCK GHC_VER=8.2.1 BUILD=CABAL CABAL_VER=2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
           sources:
             - hvr-ghc
 
-    - env: TEST=STACKAGE GHC_VER=8.0.2 BUILD=STACK ARGS="--stack-yaml stack-8.0.2.yaml --system-ghc" CPPHS_MANUAL_INSTALL=NO
+    - env: TEST=STACKAGE GHC_VER=8.0.2 BUILD=STACK ARGS="--stack-yaml stack-8.0.2.yaml --system-ghc" MANUAL_INSTALL_BUILD_TOOLS=NO
       addons:
         apt:
           packages:
@@ -95,7 +95,7 @@ matrix:
           sources:
             - hvr-ghc
 
-    - env: TEST=STACKAGE GHC_VER=7.10.3 BUILD=STACK ARGS="--stack-yaml stack-7.10.3.yaml --system-ghc" CPPHS_MANUAL_INSTALL=YES
+    - env: TEST=STACKAGE GHC_VER=7.10.3 BUILD=STACK ARGS="--stack-yaml stack-7.10.3.yaml --system-ghc" MANUAL_INSTALL_BUILD_TOOLS=YES
       addons:
         apt:
           packages:
@@ -103,7 +103,7 @@ matrix:
           sources:
             - hvr-ghc
     
-    - env: TEST=STACKAGE GHC_VER=7.8.4 BUILD=STACK ARGS="--stack-yaml stack-7.8.4.yaml --system-ghc" CPPHS_MANUAL_INSTALL=YES
+    - env: TEST=STACKAGE GHC_VER=7.8.4 BUILD=STACK ARGS="--stack-yaml stack-7.8.4.yaml --system-ghc" MANUAL_INSTALL_BUILD_TOOLS=YES
       addons:
         apt:
           packages:
@@ -209,16 +209,17 @@ install:
 
 # TODO (2016-02-21): Split the long lines (`\` doesn't work).
 
-# We have to manually install `cpphs` for older snapshots because `stack` does not
-# install build tools outside the assigned snapshot. [Issue commercialhaskell/stack #595]
+# We have to manually install `alex` and `cpphs` for older snapshots
+# because `stack` refuses to install build tools outside the designated
+# snapshot. [Issue commercialhaskell/stack #595]
 
 # N.B. that we use the `--force-reinstalls` option [Issue 1520].
 
   - if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
        make CABAL_OPTS='--only-dependencies --force-reinstalls' install-bin;
     elif [[ $TEST = "STACKAGE" ]]; then
-       if [[ $CPPHS_MANUAL_INSTALL = "YES" ]]; then
-           stack install $ARGS cpphs;
+       if [[ $MANUAL_INSTALL_BUILD_TOOLS = "YES" ]]; then
+           stack install $ARGS alex cpphs;
        fi;
        stack build $ARGS --no-terminal --only-dependencies;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -210,8 +210,11 @@ install:
 # TODO (2016-02-21): Split the long lines (`\` doesn't work).
 
 # We have to manually install `alex`, `cpphs` and possibly `happy`
-# for older snapshots because `stack` refuses to install build tools
-# outside the designated snapshot. [Issue commercialhaskell/stack #595]
+# for older snapshots because `stack` seems to have trouble installing
+# build tools for those snapshots.  Note that the version of `cpphs`
+# is currently specified in the yaml files.
+#
+# See https://github.com/commercialhaskell/stack/issues/595.
 
 # N.B. that we use the `--force-reinstalls` option [Issue 1520].
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -209,9 +209,9 @@ install:
 
 # TODO (2016-02-21): Split the long lines (`\` doesn't work).
 
-# We have to manually install `alex` and `cpphs` for older snapshots
-# because `stack` refuses to install build tools outside the designated
-# snapshot. [Issue commercialhaskell/stack #595]
+# We have to manually install `alex`, `cpphs` and possibly `happy`
+# for older snapshots because `stack` refuses to install build tools
+# outside the designated snapshot. [Issue commercialhaskell/stack #595]
 
 # N.B. that we use the `--force-reinstalls` option [Issue 1520].
 
@@ -219,7 +219,7 @@ install:
        make CABAL_OPTS='--only-dependencies --force-reinstalls' install-bin;
     elif [[ $TEST = "STACKAGE" ]]; then
        if [[ $MANUAL_INSTALL_BUILD_TOOLS = "YES" ]]; then
-           stack install $ARGS alex cpphs;
+           stack install $ARGS alex cpphs happy;
        fi;
        stack build $ARGS --no-terminal --only-dependencies;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -220,7 +220,7 @@ install:
        if [[ $CPPHS_MANUAL_INSTALL = "YES" ]]; then
            stack install $ARGS cpphs;
        fi;
-       stack build $ARGS --no-terminal --test --only-dependencies;
+       stack build $ARGS --no-terminal --only-dependencies;
     fi
 
 ##############################################################################
@@ -287,8 +287,8 @@ install:
 # N.B. that this test is not include in the Makefile tests.
 
   - if [[ $TEST = "STACKAGE" ]]; then
-       stack build $ARGS --no-terminal --test --no-run-tests &&
-       stack build $ARGS --no-terminal --test --no-run-tests --flag Agda:-cpphs --flag Agda:debug --flag Agda:enable-cluster-counting;
+       stack build $ARGS --no-terminal &&
+       stack build $ARGS --no-terminal --flag Agda:-cpphs --flag Agda:debug --flag Agda:enable-cluster-counting;
     fi
 
 ##############################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
           sources:
             - hvr-ghc
 
-    - env: TEST=STACKAGE GHC_VER=8.0.2 BUILD=STACK ARGS="--stack-yaml stack-8.0.2.yaml --system-ghc"
+    - env: TEST=STACKAGE GHC_VER=8.0.2 BUILD=STACK ARGS="--stack-yaml stack-8.0.2.yaml --system-ghc" CPPHS_MANUAL_INSTALL=NO
       addons:
         apt:
           packages:
@@ -95,7 +95,7 @@ matrix:
           sources:
             - hvr-ghc
 
-    - env: TEST=STACKAGE GHC_VER=7.10.3 BUILD=STACK ARGS="--stack-yaml stack-7.10.3.yaml --system-ghc"
+    - env: TEST=STACKAGE GHC_VER=7.10.3 BUILD=STACK ARGS="--stack-yaml stack-7.10.3.yaml --system-ghc" CPPHS_MANUAL_INSTALL=YES
       addons:
         apt:
           packages:
@@ -201,12 +201,18 @@ install:
 
 # TODO (2016-02-21): Split the long lines (`\` doesn't work).
 
+# We have to manually install `cpphs` for older snapshots because `stack` does not
+# install build tools outside the assigned snapshot. [Issue commercialhaskell/stack #595]
+
 # N.B. that we use the `--force-reinstalls` option [Issue 1520].
 
   - if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
        make CABAL_OPTS='--only-dependencies --force-reinstalls' install-bin;
     elif [[ $TEST = "STACKAGE" ]]; then
-         stack build $ARGS --no-terminal --test --only-dependencies;
+       if [[ $CPPHS_MANUAL_INSTALL = "YES" ]]; then
+           stack install $ARGS cpphs;
+       fi;
+       stack build $ARGS --no-terminal --test --only-dependencies;
     fi
 
 ##############################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,14 @@ matrix:
             - ghc-7.10.3
           sources:
             - hvr-ghc
+    
+    - env: TEST=STACKAGE GHC_VER=7.8.4 BUILD=STACK ARGS="--stack-yaml stack-7.8.4.yaml --system-ghc" CPPHS_MANUAL_INSTALL=YES
+      addons:
+        apt:
+          packages:
+            - ghc-7.8.4
+          sources:
+            - hvr-ghc
 
     # Since `stack haddock` compiles Agda but `cabal haddock` does
     # not, this test is faster using `BUILD=CABAL` [Issue #2188].

--- a/.travis.yml
+++ b/.travis.yml
@@ -219,7 +219,7 @@ install:
        make CABAL_OPTS='--only-dependencies --force-reinstalls' install-bin;
     elif [[ $TEST = "STACKAGE" ]]; then
        if [[ $MANUAL_INSTALL_BUILD_TOOLS = "YES" ]]; then
-           stack install $ARGS alex cpphs happy;
+           stack install $ARGS --no-terminal alex cpphs happy;
        fi;
        stack build $ARGS --no-terminal --only-dependencies;
     fi

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -40,6 +40,8 @@ tested-with:        GHC == 7.8.4
 extra-source-files: CHANGELOG.md
                     README.md
                     src/full/undefined.h
+                    stack-7.8.4.yaml
+                    stack-7.10.3.yaml
                     stack-8.0.2.yaml
 
 data-dir:           src/data

--- a/stack-7.10.3.yaml
+++ b/stack-7.10.3.yaml
@@ -1,0 +1,11 @@
+resolver: lts-6.35
+
+extra-deps:
+- STMonadTrans-0.4.3
+- cpphs-1.20.8
+- equivalence-0.3.2
+- unix-compat-0.4.3.1
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'

--- a/stack-7.10.3.yaml
+++ b/stack-7.10.3.yaml
@@ -4,7 +4,6 @@ extra-deps:
 - STMonadTrans-0.4.3
 - cpphs-1.20.8
 - equivalence-0.3.2
-- unix-compat-0.4.3.1
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-7.8.4.yaml
+++ b/stack-7.8.4.yaml
@@ -12,6 +12,7 @@ extra-deps:
 - STMonadTrans-0.4.3
 - binary-0.7.2.1
 - boxes-0.1.4
+- cpphs-1.20.8
 - data-hash-0.2.0.1
 - equivalence-0.3.2
 - fail-4.9.0.0

--- a/stack-7.8.4.yaml
+++ b/stack-7.8.4.yaml
@@ -1,0 +1,34 @@
+resolver: lts-2.22
+
+flags:
+  QuickCheck:
+    base4: true
+    base4point8: false
+
+extra-deps:
+- EdisonAPI-1.3.1
+- EdisonCore-1.3.1.1
+- QuickCheck-2.8.2
+- STMonadTrans-0.4.3
+- binary-0.7.2.1
+- boxes-0.1.4
+- data-hash-0.2.0.1
+- equivalence-0.3.2
+- fail-4.9.0.0
+- geniplate-mirror-0.7.5
+- gitrev-1.2.0
+- haskeline-0.7.1.3
+- ieee754-0.7.8
+- monadplus-1.4.2
+- mtl-2.2.1
+- murmur-hash-0.1.0.9
+- regex-tdfa-1.2.2
+- regex-tdfa-text-1.0.0.3
+- semigroups-0.18
+- transformers-0.4.2.0
+- transformers-compat-0.4.0.4
+- void-0.7.1
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'


### PR DESCRIPTION
Still waiting for the travis jobs, and the one for 7.10.3 seems to work. Checking the one for 7.8.4 now.

This will fix #2693.