### PR TITLE
[ travis ] Trying to bypass connectivity issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -221,7 +221,7 @@ install:
 # N.B. that we use the `--force-reinstalls` option [Issue 1520].
 
   - if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
-       travis_retry cabal fetch `cabal install --dependencies-only --force-reinstalls --dry-run | sed 1,2d` &&
+       travis_retry cabal fetch `cabal install --dependencies-only --force-reinstalls --dry-run | sed 1,2d | sed "s|(latest: [0-9\.]*)||g"` &&
        make CABAL_OPTS='--only-dependencies --force-reinstalls' install-bin;
     elif [[ $TEST = "STACKAGE" ]]; then
        if [[ $MANUAL_INSTALL_BUILD_TOOLS = "YES" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -221,7 +221,7 @@ install:
 # N.B. that we use the `--force-reinstalls` option [Issue 1520].
 
   - if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
-       travis_retry cabal fetch `cabal install --dependencies-only --force-reinstalls --dry-run | sed 1,2d | sed "s|(latest: [0-9\.]*)||g"` &&
+       travis_retry cabal fetch `cabal install --dependencies-only --force-reinstalls --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g"` &&
        make CABAL_OPTS='--only-dependencies --force-reinstalls' install-bin;
     elif [[ $TEST = "STACKAGE" ]]; then
        if [[ $MANUAL_INSTALL_BUILD_TOOLS = "YES" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -181,15 +181,17 @@ install:
        haddock --version &&
        emacs --version &&
        export PARALLEL_TESTS=2 &&
-       cabal update &&
+       travis_retry cabal update &&
        sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config &&
        cat $HOME/.cabal/config &&
        if [[ $CABAL_VER = "1.18" ]]; then
+          travis_retry cabal fetch cabal-install &&
           cabal install cabal-install;
        fi &&
        export PATH=$HOME/.cabal/bin:$PATH &&
        cabal --version &&
-       cabal update &&
+       travis_retry cabal update &&
+       travis_retry cabal fetch cpphs-1.20.8 &&
        cabal install cpphs-1.20.8 &&
        cpphs --version;
     fi
@@ -219,6 +221,7 @@ install:
 # N.B. that we use the `--force-reinstalls` option [Issue 1520].
 
   - if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
+       travis_retry cabal fetch `cabal install --dependencies-only --force-reinstalls --dry-run | sed 1,2d` &&
        make CABAL_OPTS='--only-dependencies --force-reinstalls' install-bin;
     elif [[ $TEST = "STACKAGE" ]]; then
        if [[ $MANUAL_INSTALL_BUILD_TOOLS = "YES" ]]; then
@@ -265,7 +268,7 @@ install:
        export NODE_DIR=node-${NODE_VERSION}-linux-x64 &&
        export NODE_TARBALL=${NODE_DIR}.tar.xz &&
        cd $HOME &&
-       wget https://nodejs.org/download/release/${NODE_VERSION}/${NODE_TARBALL} &&
+       travis_retry wget https://nodejs.org/download/release/${NODE_VERSION}/${NODE_TARBALL} &&
        tar xJf ${NODE_TARBALL} &&
        export PATH=${HOME}/${NODE_DIR}/bin:$PATH &&
        cd $AGDA_HOME &&


### PR DESCRIPTION
Everytime something needs to be fetched over the network, we use
`travis_retry` so that connectivity issues do not make the builds
fail needlessly.

Instead of using `travis_retry` on `cabal install` directly (which
would restart the build when legitimate build errors appear), we
proceed in two steps: `cabal fetch` first and `cabal install` second.

The sed trick has been taken from:
https://stackoverflow.com/questions/28182292/cabal-fetch-dependencies-for-current-package