### PR TITLE
[ new ] Added a new option --no-dot-patterns

### DIFF
--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -173,6 +173,7 @@ data PragmaOptions = PragmaOptions
   , optPostfixProjections        :: Bool
       -- ^ Should system generated projections 'ProjSystem' be printed
       --   postfix (True) or prefix (False).
+  , optDotPatterns               :: Bool  -- ^ Are dot patterns in use?
   , optInstanceSearchDepth       :: Int
   , optSafe                      :: Bool
   , optWarningMode               :: WarningMode
@@ -262,6 +263,7 @@ defaultPragmaOptions = PragmaOptions
   , optEta                       = True
   , optRewriting                 = False
   , optPostfixProjections        = False
+  , optDotPatterns               = True
   , optInstanceSearchDepth       = 500
   , optSafe                      = False
   , optWarningMode               = fromJust $ lookup defaultWarningMode warningModes
@@ -491,6 +493,12 @@ rewritingFlag o = return $ o { optRewriting = True }
 postfixProjectionsFlag :: Flag PragmaOptions
 postfixProjectionsFlag o = return $ o { optPostfixProjections = True }
 
+dotPatternsFlag :: Flag PragmaOptions
+dotPatternsFlag o = return $ o { optDotPatterns = True }
+
+noDotPatternsFlag :: Flag PragmaOptions
+noDotPatternsFlag o = return $ o { optDotPatterns = False }
+
 instanceDepthFlag :: String -> Flag PragmaOptions
 instanceDepthFlag s o = do
   d <- integerArgument "--instance-search-depth" s
@@ -688,6 +696,10 @@ pragmaOptions =
                     "enable declaration and use of REWRITE rules"
     , Option []     ["postfix-projections"] (NoArg postfixProjectionsFlag)
                     "make postfix projection notation the default"
+    , Option []     ["dot-patterns"] (NoArg dotPatternsFlag)
+                    "enable the use of dot patterns (default)"
+    , Option []     ["no-dot-patterns"] (NoArg noDotPatternsFlag)
+                    "disable the use of dot patterns"
     , Option []     ["instance-search-depth"] (ReqArg instanceDepthFlag "N")
                     "set instance search depth to N (default: 500)"
     , Option []     ["safe"] (NoArg safeFlag)

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2154,7 +2154,9 @@ instance ToAbstract C.Pattern (A.Pattern' C.Expr) where
         where
             info = PatRange r
     -- we have to do dot patterns at the end
-    toAbstract p0@(C.DotP r o e) = return $ A.DotP info o e
+    toAbstract p0@(C.DotP r o e) = ifM (optDotPatterns <$> pragmaOptions)
+      {-then-} (return $ A.DotP info o e)
+      {-else-} (setCurrentRange r $ genericError "dot patterns are disabled.")
         where info = PatRange r
     toAbstract p0@(C.AbsurdP r) = return $ A.AbsurdP info
         where info = PatRange r


### PR DESCRIPTION
Now it is possible to avoid using dot patterns entirely, so there should be an option to not generate any dot patterns from case splitting. For example:
```agda
{-# OPTIONS --no-dot-patterns #-}

open import Agda.Builtin.Nat

data Vec (A : Set) : Nat → Set where
  [] : Vec A 0
  cons : (n : Nat) → A → Vec A n → Vec A (suc n)

concat : {A : Set} (m n : Nat) → Vec A m → Vec A n → Vec A (m + n)
concat m n xs ys = {!!}
```
Case splitting on `xs` produces:
```agda
concat : {A : Set} (m n : Nat) → Vec A m → Vec A n → Vec A (m + n)
concat m n [] ys = {!!}
concat m n (cons n₁ x xs) ys = {!!}
```
TODO:

- [ ] better error message for dot patterns when `--no-dot-patterns`
- [ ] test cases
- [ ] release notes
- [ ] allow variables to occur non-linearly as long as all but one can be dotted