### PR TITLE
Update stack config to match most recent lts

### DIFF
--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -1,5 +1,7 @@
-resolver: lts-9.12
+resolver: lts-9.14
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
+extra-deps:
+- 'QuickCheck-2.10.1'


### PR DESCRIPTION
Also adds QuickCheck as an explicit dependency. The current one in
lts-7.14 is incompatible with the one requested by the test-sutie.