### PR TITLE
Remove extra space around tagged `\Agda*{}` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -474,6 +474,9 @@ LaTeX backend
   now correctly highlighted in the LaTeX backend (and the HTML one).
   [Issue [#2474](https://github.com/agda/agda/issues/2474)]
 
+* `postprocess-latex.pl` does not add extra spaces around tagged `\Agda*{}`
+  commands anymore.
+
 Release notes for Agda version 2.5.3
 ====================================
 

--- a/src/data/postprocess-latex.pl
+++ b/src/data/postprocess-latex.pl
@@ -16,7 +16,7 @@ while (<>) {
      my $arg = $3;
      my $tag = "$tag_prefix-$3" =~ s/\\_/$underscore/gr;
 
-     $_ = "\n%<*$tag>\n$cmd\{$arg\}\n%</$tag>\n";
+     $_ = "%\n%<*$tag>\n$cmd\{$arg\}%\n%</$tag>\n";
    |gxe;
 
   print;


### PR DESCRIPTION
Currently the substitution produces the following output:

    \AgdaSymbol{(}
    %<*AgdaTag-suc>
    \AgdaInductiveConstructor{suc}
    %</AgdaTag-suc>

This results in the following output being generated:

    ( suc

`\Agda*{}` commands that are not tagged do not have this extra space
around them. We avoid this by appending % comments to the tagged
commands and the commands that precede them.