### PR TITLE
Emacs auto-mode for literate agda files

### DIFF
--- a/src/data/emacs-mode/agda2.el
+++ b/src/data/emacs-mode/agda2.el
@@ -9,7 +9,7 @@
 
 (autoload 'agda2-mode "agda2-mode"
   "Major mode for editing Agda files (version ≥ 2)." t)
-(add-to-list 'auto-mode-alist '("\\.l?agda\\'" . agda2-mode))
-(modify-coding-system-alist 'file "\\.l?agda\\'" 'utf-8)
+(add-to-list 'auto-mode-alist '("\\.\\(l?agda\\|lagda\\.\\(tex\\|rst\\|md\\)\\)\\'" . agda2-mode))
+(modify-coding-system-alist 'file "\\.\\(l?agda\\|lagda\\.\\(tex\\|rst\\|md\\)\\)\\'" 'utf-8)
 
 (provide 'agda2)


### PR DESCRIPTION
Extends the list of file endings that Emacs considers Agda files.
List of file endings taken from https://agda.readthedocs.io/en/v2.5.3/tools/literate-programming.html
I have tested that all these file endings are assigned the right mode and have tested for a few false positives.