### PR TITLE
[ warning ] user defined warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -383,6 +383,14 @@ Pragmas and options
 
   Disables automatic inlining of `f`.
 
+* New pragma WARNING_ON_USAGE
+
+  ```
+  {-# WARNING_ON_USAGE QName Message #}
+  ```
+
+  Prints Message whenever QName is used.
+
 Emacs mode
 ----------
 

--- a/doc/user-manual/language/pragmas.lagda.rst
+++ b/doc/user-manual/language/pragmas.lagda.rst
@@ -42,6 +42,8 @@ Index of pragmas
 
 * :ref:`NOINLINE <inline_pragma>`
 
+* :ref:`WARNING_ON_USAGE <warning_pragma>`
+
 See also :ref:`command-line-pragmas`.
 
 .. _inline_pragma:
@@ -75,3 +77,26 @@ Example::
 
   {-# INLINE _o_ #-} -- force inlining
 
+
+.. _warning_pragma:
+
+The ``WARNING_ON_USAGE`` pragma
+_______________________________________
+
+A library author can use a ``WARNING_ON_USAGE`` pragma to attach to a defined
+name a warning to be raised whenever this name is used.
+
+This would typically be used to declare a name 'DEPRECATED' and advise the
+end-user to port their code before the feature is dropped.
+
+Example::
+
+  -- The new name for the identity
+  id : {A : Set} → A → A
+  id x = x
+
+  -- The deprecated name
+  λx→x = id
+
+  -- The warning
+  {-# WARNING_ON_USAGE λx→x "DEPRECATED: Use `id` instead of `λx→x`" #-}

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -581,6 +581,7 @@ warningHighlighting w = case tcWarning w of
   SafeFlagPolarity           -> mempty
   DeprecationWarning{}       -> mempty
   NicifierIssue{}            -> mempty
+  UserWarning{}              -> mempty
 
 -- | Generate syntax highlighting for termination errors.
 

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -136,6 +136,7 @@ data WarningName
   | SafeFlagPrimTrustMe_
   | SafeFlagNoPositivityCheck_
   | SafeFlagPolarity_
+  | UserWarning_
   deriving (Eq, Ord, Show, Read, Enum, Bounded)
 
 -- | The flag corresponding to a warning is precisely the name of the constructor
@@ -228,3 +229,4 @@ warningNameDescription w = case w of
   SafeFlagPrimTrustMe_             -> "`primTrustMe' usages with the safe flag."
   SafeFlagNoPositivityCheck_       -> "`NO_POSITIVITY_CHECK' pragmas with the safe flag."
   SafeFlagPolarity_                -> "`POLARITY' pragmas with the safe flag."
+  UserWarning_                     -> "User-defined warning added using the 'WARNING_ON_USAGE' pragma."

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -416,6 +416,8 @@ data Pragma
   | TerminationCheckPragma    Range (TerminationCheck Name)
     -- ^ Applies to the following function (and all that are mutually recursive with it)
     --   or to the functions in the following mutual block.
+  | WarningOnUsage            Range QName String
+    -- ^ Applies to the named function
   | CatchallPragma            Range
     -- ^ Applies to the following function clause.
   | DisplayPragma             Range Pattern Expr
@@ -673,6 +675,7 @@ instance HasRange Pragma where
   getRange (ImpossiblePragma r)              = r
   getRange (EtaPragma r _)                   = r
   getRange (TerminationCheckPragma r _)      = r
+  getRange (WarningOnUsage r _ _)            = r
   getRange (CatchallPragma r)                = r
   getRange (DisplayPragma r _ _)             = r
   getRange (NoPositivityCheckPragma r)       = r
@@ -865,6 +868,7 @@ instance KillRange Pragma where
   killRange (ForeignPragma _ b s)             = ForeignPragma noRange b s
   killRange (ImpossiblePragma _)              = ImpossiblePragma noRange
   killRange (TerminationCheckPragma _ t)      = TerminationCheckPragma noRange (killRange t)
+  killRange (WarningOnUsage _ nm str)         = WarningOnUsage noRange nm str
   killRange (CatchallPragma _)                = CatchallPragma noRange
   killRange (DisplayPragma _ lhs rhs)         = killRange2 (DisplayPragma noRange) lhs rhs
   killRange (EtaPragma _ q)                   = killRange1 (EtaPragma noRange) q
@@ -1003,6 +1007,7 @@ instance NFData Pragma where
   rnf (ImpossiblePragma _)              = ()
   rnf (EtaPragma _ a)                   = rnf a
   rnf (TerminationCheckPragma _ a)      = rnf a
+  rnf (WarningOnUsage _ a b)            = rnf a `seq` rnf b
   rnf (CatchallPragma _)                = ()
   rnf (DisplayPragma _ a b)             = rnf a `seq` rnf b
   rnf (NoPositivityCheckPragma _)       = ()

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -550,6 +550,7 @@ instance Pretty Pragma where
         NonTerminating         -> text "NON_TERMINATING"
         Terminating            -> text "TERMINATING"
         TerminationMeasure _ x -> hsep $ [text "MEASURE", pretty x]
+    pretty (WarningOnUsage _ nm str) = hsep [ text "WARNING_ON_USAGE", pretty nm, text str ]
     pretty (CatchallPragma _) = text "CATCHALL"
     pretty (DisplayPragma _ lhs rhs) = text "DISPLAY" <+> sep [ pretty lhs <+> text "=", nest 2 $ pretty rhs ]
     pretty (NoPositivityCheckPragma _) = text "NO_POSITIVITY_CHECK"

--- a/src/full/Agda/Syntax/Parser/Lexer.x
+++ b/src/full/Agda/Syntax/Parser/Lexer.x
@@ -82,11 +82,11 @@ tokens :-
 <pragma_>   "COMPILED_JS"              { keyword KwCOMPILED_JS }
 <pragma_>   "COMPILED_TYPE"            { keyword KwCOMPILED_TYPE }
 <pragma_>   "COMPILED_UHC"             { keyword KwCOMPILED_UHC }
-<pragma_>   "COMPILE"                  { keyword KwCOMPILE }
+<pragma_>   "COMPILE"                  { endWith $ beginWith fpragma $ keyword KwCOMPILE }
 <pragma_>   "FOREIGN"                  { endWith $ beginWith fpragma $ keyword KwFOREIGN }
 <pragma_>   "DISPLAY"                  { keyword KwDISPLAY }
 <pragma_>   "ETA"                      { keyword KwETA }
-<pragma_>   "HASKELL"                  { keyword KwHASKELL }
+<pragma_>   "HASKELL"                  { endWith $ beginWith fpragma $ keyword KwHASKELL }
 <pragma_>   "IMPORT"                   { keyword KwIMPORT }
 <pragma_>   "IMPORT_UHC"               { keyword KwIMPORT_UHC }
 <pragma_>   "IMPOSSIBLE"               { keyword KwIMPOSSIBLE }
@@ -104,7 +104,8 @@ tokens :-
 <pragma_>   "STATIC"                   { keyword KwSTATIC }
 <pragma_>   "TERMINATING"              { keyword KwTERMINATING }
 <pragma_>   "WARNING_ON_USAGE"         { keyword KwWARNING_ON_USAGE }
-<pragma_,fpragma_> . # [ $white ] +    { withInterval $ TokString }
+<pragma_>   . # [ $white \" ] +        { withInterval $ TokString } -- we recognise string literals in pragmas
+<fpragma_>  . # [ $white ] +           { withInterval $ TokString }
 
 -- Comments
     -- We need to rule out pragmas here. Usually longest match would take
@@ -230,7 +231,7 @@ tokens :-
 
 -- Literals
 <0,code> \'             { litChar }
-<0,code> \"             { litString }
+<0,code,pragma_> \"     { litString }
 <0,code> @integer       { literal LitNat }
 <0,code> @float         { literal LitFloat }
 

--- a/src/full/Agda/Syntax/Parser/Lexer.x
+++ b/src/full/Agda/Syntax/Parser/Lexer.x
@@ -103,6 +103,7 @@ tokens :-
 <pragma_>   "REWRITE"                  { keyword KwREWRITE }
 <pragma_>   "STATIC"                   { keyword KwSTATIC }
 <pragma_>   "TERMINATING"              { keyword KwTERMINATING }
+<pragma_>   "WARNING_ON_USAGE"         { keyword KwWARNING_ON_USAGE }
 <pragma_,fpragma_> . # [ $white ] +    { withInterval $ TokString }
 
 -- Comments

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -169,6 +169,7 @@ import Agda.Utils.Impossible
     'NON_TERMINATING'         { TokKeyword KwNON_TERMINATING $$ }
     'OPTIONS'                 { TokKeyword KwOPTIONS $$ }
     'POLARITY'                { TokKeyword KwPOLARITY $$ }
+    'WARNING_ON_USAGE'        { TokKeyword KwWARNING_ON_USAGE $$ }
     'REWRITE'                 { TokKeyword KwREWRITE $$ }
     'STATIC'                  { TokKeyword KwSTATIC $$ }
     'TERMINATING'             { TokKeyword KwTERMINATING $$ }
@@ -306,6 +307,7 @@ Token
     | 'REWRITE'                 { TokKeyword KwREWRITE $1 }
     | 'STATIC'                  { TokKeyword KwSTATIC $1 }
     | 'TERMINATING'             { TokKeyword KwTERMINATING $1 }
+    | 'WARNING_ON_USAGE'        { TokKeyword KwWARNING_ON_USAGE $1 }
 
     | setN                      { TokSetN $1 }
     | tex                       { TokTeX $1 }
@@ -1475,6 +1477,7 @@ DeclarationPragma
   | TerminatingPragma        { $1 }
   | NonTerminatingPragma     { $1 }
   | NoTerminationCheckPragma { $1 }
+  | WarningOnUsagePragma     { $1 }
   | MeasurePragma            { $1 }
   | CatchallPragma           { $1 }
   | DisplayPragma            { $1 }
@@ -1640,6 +1643,11 @@ PolarityPragma
   : '{-#' 'POLARITY' PragmaName Polarities '#-}'
     { let (rs, occs) = unzip (reverse $4) in
       PolarityPragma (getRange ($1,$2,$3,rs,$5)) $3 occs }
+
+WarningOnUsagePragma :: { Pragma }
+WarningOnUsagePragma
+  : '{-#' 'WARNING_ON_USAGE' PragmaQName PragmaStrings '#-}'
+  {  WarningOnUsage (getRange ($1,$2,$3,$5)) $3 (unwords $4) }
 
 -- Possibly empty list of polarities. Reversed.
 Polarities :: { [(Range, Occurrence)] }

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1646,8 +1646,12 @@ PolarityPragma
 
 WarningOnUsagePragma :: { Pragma }
 WarningOnUsagePragma
-  : '{-#' 'WARNING_ON_USAGE' PragmaQName PragmaStrings '#-}'
-  {  WarningOnUsage (getRange ($1,$2,$3,$5)) $3 (unwords $4) }
+  : '{-#' 'WARNING_ON_USAGE' PragmaQName literal '#-}'
+  {%  case $4 of
+        { LitString r str -> return $ WarningOnUsage (getRange ($1,$2,$3,r,$5)) $3 str
+        ; _ -> parseError "Expected string literal"
+        }
+  }
 
 -- Possibly empty list of polarities. Reversed.
 Polarities :: { [(Range, Occurrence)] }

--- a/src/full/Agda/Syntax/Parser/Tokens.hs
+++ b/src/full/Agda/Syntax/Parser/Tokens.hs
@@ -25,6 +25,7 @@ data Keyword
         | KwIMPORT | KwIMPORT_UHC | KwIMPOSSIBLE | KwSTATIC | KwINJECTIVE | KwINLINE | KwNOINLINE
         | KwETA
         | KwNO_TERMINATION_CHECK | KwTERMINATING | KwNON_TERMINATING
+        | KwWARNING_ON_USAGE
         | KwMEASURE | KwDISPLAY
         | KwREWRITE
         | KwQuoteGoal | KwQuoteContext | KwQuote | KwQuoteTerm

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -462,7 +462,7 @@ zipScope fd fm fs s1 s2 =
                zipWith' (,) (scopeNameSpaces s1) (scopeNameSpaces s2)
          , assert (nsid == nsid')
          ]
-     , scopeImports = Map.union (scopeImports s1) (scopeImports s2)
+     , scopeImports  = (Map.union `on` scopeImports)  s1 s2
      }
   where
     assert True  = True

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -218,6 +218,8 @@ prettyWarning wng = liftTCM $ case wng of
 
     NicifierIssue w -> sayWhere (getRange w) $ pretty w
 
+    UserWarning str -> text str
+
 prettyTCWarnings :: [TCWarning] -> TCM String
 prettyTCWarnings = fmap (unlines . intersperse "") . prettyTCWarnings'
 
@@ -281,6 +283,7 @@ applyFlagsToTCWarnings ifs ws = do
           SafeFlagPolarity             -> True
           DeprecationWarning{}         -> True
           NicifierIssue{}              -> True
+          UserWarning{}                -> True
 
   return $ sfp ++ filter (cleanUp . tcWarning) ws
 

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1289,11 +1289,12 @@ instance InstantiateFull Clause where
 
 instance InstantiateFull Interface where
     instantiateFull' (Interface h ms mod scope inside
-                               sig display b foreignCode
+                               sig display userwarn b foreignCode
                                highlighting pragmas patsyns warnings) =
         Interface h ms mod scope inside
             <$> instantiateFull' sig
             <*> instantiateFull' display
+            <*> return userwarn
             <*> instantiateFull' b
             <*> return foreignCode
             <*> return highlighting

--- a/src/full/Agda/TypeChecking/Serialise/Instances.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances.hs
@@ -13,8 +13,9 @@ import Agda.TypeChecking.Serialise.Instances.Internal ()
 import Agda.TypeChecking.Serialise.Instances.Errors ()
 
 instance EmbPrj Interface where
-  icod_ (Interface a b c d e f g h i j k l m) = icodeN' Interface a b c d e f g h i j k l m
+  icod_ (Interface a b c d e f g h i j k l m n) = icodeN' Interface a b c d e f g h i j k l m n
 
   value = vcase valu where
-    valu [a, b, c, d, e, f, g, h, i, j, k, l, m] = valuN Interface a b c d e f g h i j k l m
-    valu _                                       = malformed
+    valu [a, b, c, d, e, f, g, h, i, j, k, l, m, n] =
+      valuN Interface a b c d e f g h i j k l m n
+    valu _ = malformed

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -57,6 +57,7 @@ instance EmbPrj Warning where
   icod_ (DeprecationWarning a b c)   = icodeN 6 DeprecationWarning a b c
   icod_ (NicifierIssue a)            = icodeN 7 NicifierIssue a
   icod_ (InversionDepthReached a)    = icodeN 8 InversionDepthReached a
+  icod_ (UserWarning a)              = icodeN 9 UserWarning a
 
   value = vcase valu where
       valu [0, a, b]    = valuN UnreachableClauses a b
@@ -68,6 +69,7 @@ instance EmbPrj Warning where
       valu [6, a, b, c] = valuN DeprecationWarning a b c
       valu [7, a]       = valuN NicifierIssue a
       valu [8, a]       = valuN InversionDepthReached a
+      valu [9, a]       = valuN UserWarning a
       valu _ = malformed
 
 instance EmbPrj DeclarationWarning where

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -98,6 +98,7 @@ classifyWarning w = case w of
   DeprecationWarning{}       -> AllWarnings
   NicifierIssue{}            -> AllWarnings
   InversionDepthReached{}    -> AllWarnings
+  UserWarning{}              -> AllWarnings
   TerminationIssue{}         -> ErrorWarnings
   CoverageIssue{}            -> ErrorWarnings
   CoverageNoExactSplit{}     -> ErrorWarnings

--- a/test/Succeed/WarningOnUsage.agda
+++ b/test/Succeed/WarningOnUsage.agda
@@ -1,0 +1,17 @@
+module WarningOnUsage where
+
+id : {A : Set} → A → A
+id x = x
+
+
+
+-- Deprecated names
+
+λx→x = id
+
+{-# WARNING_ON_USAGE λx→x DEPRECATED: Use `id` instead of `λx→x` #-}
+
+open import Agda.Builtin.Equality
+
+_ : {A : Set} {x : A} → λx→x x ≡ x
+_ = refl

--- a/test/Succeed/WarningOnUsage.agda
+++ b/test/Succeed/WarningOnUsage.agda
@@ -9,7 +9,7 @@ id x = x
 
 λx→x = id
 
-{-# WARNING_ON_USAGE λx→x DEPRECATED: Use `id` instead of `λx→x` #-}
+{-# WARNING_ON_USAGE λx→x "DEPRECATED: Use `id` instead of `λx→x`" #-}
 
 open import Agda.Builtin.Equality
 

--- a/test/Succeed/WarningOnUsage.warn
+++ b/test/Succeed/WarningOnUsage.warn
@@ -1,0 +1,9 @@
+WarningOnUsage.agda:16,25-29
+DEPRECATED: Use 'id' instead of 'λx→x'
+when scope checking λx→x
+
+———— All done; warnings encountered ————————————————————————
+
+WarningOnUsage.agda:16,25-29
+DEPRECATED: Use 'id' instead of 'λx→x'
+when scope checking λx→x

--- a/test/Succeed/WarningOnUsage2.agda
+++ b/test/Succeed/WarningOnUsage2.agda
@@ -1,0 +1,5 @@
+module WarningOnUsage2 where
+
+open import WarningOnUsage
+
+λx→x₂ = λx→x

--- a/test/Succeed/WarningOnUsage2.warn
+++ b/test/Succeed/WarningOnUsage2.warn
@@ -1,0 +1,16 @@
+WarningOnUsage.agda:16,25-29
+DEPRECATED: Use 'id' instead of 'λx→x'
+when scope checking λx→x
+WarningOnUsage2.agda:5,9-13
+DEPRECATED: Use 'id' instead of 'λx→x'
+when scope checking λx→x
+
+———— All done; warnings encountered ————————————————————————
+
+WarningOnUsage.agda:16,25-29
+DEPRECATED: Use 'id' instead of 'λx→x'
+when scope checking λx→x
+
+WarningOnUsage2.agda:5,9-13
+DEPRECATED: Use 'id' instead of 'λx→x'
+when scope checking λx→x


### PR DESCRIPTION
{-# WARNING_ON_USAGE QName Message #-} displays the Message whenever
QName is used. This would typically be used to deprecate a function
in favour of a more modern / idiomatic replacement.