### PR TITLE
generalize (second version)

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -458,6 +458,7 @@ library
                     Agda.Utils.Function
                     Agda.Utils.Geniplate
                     Agda.Utils.Graph.AdjacencyMap.Unidirectional
+                    Agda.Utils.Graph.TopSort
                     Agda.Utils.Hash
                     Agda.Utils.HashMap
                     Agda.Utils.Haskell.Syntax

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -481,6 +481,7 @@ nameKinds hlLevel decl = do
   declToKind (A.ScopedDecl {})      = id
   declToKind (A.Open {})            = id
   declToKind (A.PatternSynDef q _ _) = insert q (Constructor Common.Inductive)
+  declToKind (A.Generalize _ _ _ q _)  = insert q Postulate
   declToKind (A.FunDef  _ q _ _)     = insert q Function
   declToKind (A.UnquoteDecl _ _ qs _) = foldr (\ q f -> insert q Function . f) id qs
   declToKind (A.UnquoteDef _ qs _)    = foldr (\ q f -> insert q Function . f) id qs
@@ -650,6 +651,7 @@ printUnsolvedInfo = do
 computeUnsolvedMetaWarnings :: TCM File
 computeUnsolvedMetaWarnings = do
   is <- getInteractionMetas
+  gs <- getGeneralizeMetas
 
   -- We don't want to highlight blocked terms, since
   --   * there is always at least one proper meta responsible for the blocking
@@ -657,7 +659,7 @@ computeUnsolvedMetaWarnings = do
   let notBlocked m = not <$> isBlockedTerm m
   ms <- filterM notBlocked =<< getOpenMetas
 
-  rs <- mapM getMetaRange (ms \\ is)
+  rs <- mapM getMetaRange ((ms \\ is) \\ gs)
   return $ metasHighlighting rs
 
 metasHighlighting :: [P.Range] -> File

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -51,6 +51,7 @@ import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Primitive
 import Agda.TypeChecking.Pretty as P
 import Agda.TypeChecking.DeadCode
+import Agda.TypeChecking.Rules.Decl ( filterGeneralizables )
 import qualified Agda.TypeChecking.Monad.Benchmark as Bench
 
 import Agda.TheTypeChecker
@@ -726,6 +727,9 @@ createInterface file mname isMain = Bench.billTo [Bench.TopModule mname] $
         Bench.billTo [Bench.Typing] $ mapM_ checkDeclCached ds `finally_` cacheCurrentLog
         reportSLn "import.iface.create" 7 $ "Finished type checking."
 
+    filterGeneralizables
+
+
     -- Ulf, 2013-11-09: Since we're rethrowing the error, leave it up to the
     -- code that handles that error to reset the state.
     -- Ulf, 2013-11-13: Errors are now caught and highlighted in InteractionTop.
@@ -856,7 +860,8 @@ getUnsolvedMetas :: TCM [Range]
 getUnsolvedMetas = do
   openMetas            <- getOpenMetas
   interactionMetas     <- getInteractionMetas
-  getUniqueMetasRanges (openMetas List.\\ interactionMetas)
+  generalizeMetas      <- getGeneralizeMetas
+  getUniqueMetasRanges ((openMetas List.\\ interactionMetas) List.\\ generalizeMetas)
 
 getAllUnsolved :: TCM [TCWarning]
 getAllUnsolved = do

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -1054,7 +1054,8 @@ showOpenMetas = do
   -- Show unsolved implicit arguments simplified.
   unsolvedNotOK <- not . optAllowUnsolved <$> pragmaOptions
   hms <- (guard unsolvedNotOK >>) <$> B.typesOfHiddenMetas B.Simplified
-  dh <- mapM showA' hms
+  gs <- getGeneralizeMetas
+  dh <- mapM showA' $ filter (flip List.notElem gs . nmid . metaId) hms
   return $ di ++ dh
   where
     metaId (B.OfType i _) = i
@@ -1389,6 +1390,7 @@ whyInScope s = display_info . Info_WhyInScope =<< do
         pKind ConName        = TCP.text "constructor"
         pKind FldName        = TCP.text "record field"
         pKind PatternSynName = TCP.text "pattern synonym"
+        pKind GeneralizeName = TCP.text "generalizable variable"
         pKind MacroName      = TCP.text "macro name"
         pKind QuotableName   = TCP.text "quotable name"
 

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -152,6 +152,7 @@ data PragmaOptions = PragmaOptions
   , optExactSplit                :: Bool
   , optEta                       :: Bool
   , optRewriting                 :: Bool  -- ^ Can rewrite rules be added and used?
+  , optGeneralize                :: Bool
   , optPostfixProjections        :: Bool
       -- ^ Should system generated projections 'ProjSystem' be printed
       --   postfix (True) or prefix (False).
@@ -239,6 +240,7 @@ defaultPragmaOptions = PragmaOptions
   , optExactSplit                = False
   , optEta                       = True
   , optRewriting                 = False
+  , optGeneralize                = False
   , optPostfixProjections        = False
   , optInstanceSearchDepth       = 500
   , optInversionMaxDepth         = 50
@@ -471,6 +473,9 @@ noExactSplitFlag o = return $ o { optExactSplit = False }
 rewritingFlag :: Flag PragmaOptions
 rewritingFlag o = return $ o { optRewriting = True }
 
+generalizeFlag :: Flag PragmaOptions
+generalizeFlag o = return $ o { optGeneralize = True }
+
 postfixProjectionsFlag :: Flag PragmaOptions
 postfixProjectionsFlag o = return $ o { optPostfixProjections = True }
 
@@ -671,6 +676,8 @@ pragmaOptions =
                     "default records to no-eta-equality"
     , Option []     ["rewriting"] (NoArg rewritingFlag)
                     "enable declaration and use of REWRITE rules"
+    , Option []     ["generalize"] (NoArg generalizeFlag)
+                    "enable automatic generalization of predefined variable bindings"
     , Option []     ["postfix-projections"] (NoArg postfixProjectionsFlag)
                     "make postfix projection notation the default"
     , Option []     ["instance-search-depth"] (ReqArg instanceDepthFlag "N")

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -22,6 +22,7 @@ import Data.Map (Map)
 import Data.Maybe
 import Data.Sequence (Seq, (<|), (><))
 import qualified Data.Sequence as Seq
+import qualified Data.Set as Set
 import Data.Traversable
 import Data.Void
 
@@ -98,6 +99,7 @@ data Expr
   | AbsurdLam ExprInfo Hiding          -- ^ @λ()@ or @λ{}@.
   | ExtendedLam ExprInfo DefInfo QName [Clause]
   | Pi   ExprInfo Telescope Expr       -- ^ Dependent function space @Γ → A@.
+  | Generalized (Set.Set QName) Expr   -- ^ Like a Pi, but the ordering is not known
   | Fun  ExprInfo (Arg Expr) Expr      -- ^ Non-dependent function space.
   | Set  ExprInfo Integer              -- ^ @Set@, @Set1@, @Set2@, ...
   | Prop ExprInfo                      -- ^ @Prop@
@@ -115,6 +117,12 @@ data Expr
                                        -- ^ @tactic e x1 .. xn | y1 | .. | yn@
   | DontCare Expr                      -- ^ For printing @DontCare@ from @Syntax.Internal@.
   deriving (Data, Show)
+
+-- | Smart constructor for Generalized
+generalized :: Set.Set QName -> Expr -> Expr
+generalized s e
+    | Set.null s = e
+    | otherwise = Generalized s e
 
 -- | Record field assignment @f = e@.
 type Assign  = FieldAssignment' Expr
@@ -152,6 +160,7 @@ instance Pretty ScopeCopyInfo where
 
 data Declaration
   = Axiom      Axiom DefInfo ArgInfo (Maybe [Occurrence]) QName Expr
+  | Generalize (Set.Set QName) DefInfo ArgInfo QName Expr
     -- ^ Type signature (can be irrelevant, but not hidden).
     --
     -- The fourth argument contains an optional assignment of
@@ -188,6 +197,7 @@ class GetDefInfo a where
 
 instance GetDefInfo Declaration where
   getDefInfo (Axiom _ i _ _ _ _)    = Just i
+  getDefInfo (Generalize _ i _ _ _) = Just i
   getDefInfo (Field i _ _)          = Just i
   getDefInfo (Primitive i _ _)      = Just i
   getDefInfo (ScopedDecl _ (d:_))   = getDefInfo d
@@ -249,6 +259,7 @@ data LetBinding
   | LetDeclaredVariable BindName
     -- ^ Only used for highlighting. Refers to the first occurrence of
     -- @x@ in @let x : A; x = e@.
+--  | LetGeneralize DefInfo ArgInfo Expr
   deriving (Data, Show, Eq)
 
 
@@ -509,6 +520,7 @@ instance Eq Expr where
   AbsurdLam a1 b1         == AbsurdLam a2 b2         = (a1, b1) == (a2, b2)
   ExtendedLam a1 b1 c1 d1 == ExtendedLam a2 b2 c2 d2 = (a1, b1, c1, d1) == (a2, b2, c2, d2)
   Pi a1 b1 c1             == Pi a2 b2 c2             = (a1, b1, c1) == (a2, b2, c2)
+  Generalized a1 b1       == Generalized a2 b2       = (a1, b1) == (a2, b2)
   Fun a1 b1 c1            == Fun a2 b2 c2            = (a1, b1, c1) == (a2, b2, c2)
   Set a1 b1               == Set a2 b2               = (a1, b1) == (a2, b2)
   Prop a1                 == Prop a2                 = a1 == a2
@@ -532,6 +544,7 @@ instance Eq Declaration where
   ScopedDecl _ a1                == ScopedDecl _ a2                = a1 == a2
 
   Axiom a1 b1 c1 d1 e1 f1        == Axiom a2 b2 c2 d2 e2 f2        = (a1, b1, c1, d1, e1, f1) == (a2, b2, c2, d2, e2, f2)
+  Generalize a1 b1 c1 d1 e1      == Generalize a2 b2 c2 d2 e2      = (a1, b1, c1, d1, e1) == (a2, b2, c2, d2, e2)
   Field a1 b1 c1                 == Field a2 b2 c2                 = (a1, b1, c1) == (a2, b2, c2)
   Primitive a1 b1 c1             == Primitive a2 b2 c2             = (a1, b1, c1) == (a2, b2, c2)
   Mutual a1 b1                   == Mutual a2 b2                   = (a1, b1) == (a2, b2)
@@ -591,6 +604,7 @@ instance HasRange Expr where
     getRange (AbsurdLam i _)       = getRange i
     getRange (ExtendedLam i _ _ _) = getRange i
     getRange (Pi i _ _)            = getRange i
+    getRange (Generalized _ x)     = getRange x
     getRange (Fun i _ _)           = getRange i
     getRange (Set i _)             = getRange i
     getRange (Prop i)              = getRange i
@@ -611,6 +625,7 @@ instance HasRange Expr where
 
 instance HasRange Declaration where
     getRange (Axiom    _ i _ _ _ _  ) = getRange i
+    getRange (Generalize _ i _ _ _)   = getRange i
     getRange (Field      i _ _      ) = getRange i
     getRange (Mutual     i _        ) = getRange i
     getRange (Section    i _ _ _    ) = getRange i
@@ -714,6 +729,7 @@ instance KillRange Expr where
   killRange (AbsurdLam i h)        = killRange2 AbsurdLam i h
   killRange (ExtendedLam i n d ps) = killRange4 ExtendedLam i n d ps
   killRange (Pi i a b)             = killRange3 Pi i a b
+  killRange (Generalized s x)      = killRange1 (Generalized s) x
   killRange (Fun i a b)            = killRange3 Fun i a b
   killRange (Set i n)              = killRange2 Set i n
   killRange (Prop i)               = killRange1 Prop i
@@ -734,6 +750,7 @@ instance KillRange Expr where
 
 instance KillRange Declaration where
   killRange (Axiom    p i a b c d     ) = killRange4 (\i a c d -> Axiom p i a b c d) i a c d
+  killRange (Generalize s i j x e     ) = killRange4 (Generalize s) i j x e
   killRange (Field      i a b         ) = killRange3 Field      i a b
   killRange (Mutual     i a           ) = killRange2 Mutual     i a
   killRange (Section    i a b c       ) = killRange4 Section    i a b c
@@ -855,6 +872,7 @@ instance AllNames QName where
 
 instance AllNames Declaration where
   allNames (Axiom   _ _ _ _ q _)      = Seq.singleton q
+  allNames (Generalize _ _ _ q _)     = Seq.singleton q
   allNames (Field     _   q _)        = Seq.singleton q
   allNames (Primitive _   q _)        = Seq.singleton q
   allNames (Mutual     _ defs)        = allNames defs
@@ -900,6 +918,7 @@ instance AllNames Expr where
   allNames AbsurdLam{}             = Seq.empty
   allNames (ExtendedLam _ _ q cls) = q <| allNames cls
   allNames (Pi _ tel e)            = allNames tel >< allNames e
+  allNames (Generalized s e)       = Seq.fromList (Set.toList s) >< allNames e  -- TODO: or just (allNames e)?
   allNames (Fun _ e1 e2)           = allNames e1 >< allNames e2
   allNames Set{}                   = Seq.empty
   allNames Prop{}                  = Seq.empty
@@ -979,6 +998,7 @@ instance NameToExpr AbstractName where
   nameExpr d = mk (anameKind d) $ anameName d
     where
     mk DefName        x = Def x
+    mk GeneralizeName x = Def x
     mk FldName        x = Proj ProjSystem $ unambiguous x
     mk ConName        x = Con $ unambiguous x
     mk PatternSynName x = PatternSyn $ unambiguous x
@@ -1022,6 +1042,9 @@ patternToExpr (WithP r p)         = __IMPOSSIBLE__
 
 type PatternSynDefn = ([Arg Name], Pattern' Void)
 type PatternSynDefns = Map QName PatternSynDefn
+
+type GeneralizableDefn = (Set.Set QName, Arg Expr)
+type GeneralizableDefns = Map QName GeneralizableDefn
 
 lambdaLiftExpr :: [Name] -> Expr -> Expr
 lambdaLiftExpr []     e = e
@@ -1073,6 +1096,7 @@ instance SubstExpr Expr where
     AbsurdLam i h         -> e
     ExtendedLam i di n cs -> __IMPOSSIBLE__   -- Maybe later...
     Pi   i t e            -> Pi i (substExpr s t) (substExpr s e)
+    Generalized ns e      -> Generalized ns (substExpr s e)
     Fun  i ae e           -> Fun i (substExpr s ae) (substExpr s e)
     Set  i n              -> e
     Prop i                -> e

--- a/src/full/Agda/Syntax/Abstract/Copatterns.hs
+++ b/src/full/Agda/Syntax/Abstract/Copatterns.hs
@@ -276,6 +276,7 @@ instance Rename Expr where
       AbsurdLam{}           -> e
       ExtendedLam i i' n cs -> ExtendedLam i i' n (rename rho cs)
       Pi i tel e            -> Pi i (rename rho tel) (rename rho e)
+      Generalized s e       -> Generalized s (rename rho e)
       Fun i a e             -> Fun i (rename rho a) (rename rho e)
       Set{}                 -> e
       Prop{}                -> e

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -143,6 +143,7 @@ instance ExprLike Expr where
       AbsurdLam{}             -> pure e0
       ExtendedLam ei di x cls -> ExtendedLam ei di x <$> recurse cls
       Pi ei tel e             -> Pi ei <$> recurse tel <*> recurse e
+      Generalized  s e        -> Generalized s <$> recurse e
       Fun ei arg e            -> Fun ei <$> recurse arg <*> recurse e
       Set{}                   -> pure e0
       Prop{}                  -> pure e0
@@ -179,6 +180,7 @@ instance ExprLike Expr where
       AbsurdLam{}          -> m
       ExtendedLam _ _ _ cs -> m `mappend` fold cs
       Pi _ tel e           -> m `mappend` fold tel `mappend` fold e
+      Generalized _ e      -> m `mappend` fold e
       Fun _ e e'           -> m `mappend` fold e `mappend` fold e'
       Set{}                -> m
       Prop{}               -> m
@@ -215,6 +217,7 @@ instance ExprLike Expr where
       AbsurdLam{}             -> f e
       ExtendedLam ei di x cls -> f =<< ExtendedLam ei di x <$> trav cls
       Pi ei tel e             -> f =<< Pi ei <$> trav tel <*> trav e
+      Generalized s e         -> f =<< Generalized s <$> trav e
       Fun ei arg e            -> f =<< Fun ei <$> trav arg <*> trav e
       Set{}                   -> f e
       Prop{}                  -> f e
@@ -376,6 +379,7 @@ instance ExprLike Declaration where
   recurseExpr f d =
     case d of
       Axiom a d i mp x e        -> Axiom a d i mp x <$> rec e
+      Generalize s i j x e      -> Generalize s i j x <$> rec e
       Field i x e               -> Field i x <$> rec e
       Primitive i x e           -> Primitive i x <$> rec e
       Mutual i ds               -> Mutual i <$> rec ds

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -149,6 +149,7 @@ instance ExprLike Expr where
      DontCare e         -> f $ DontCare               $ mapE e
      Equal{}            -> f $ e0
      Ellipsis{}         -> f $ e0
+     Generalized e      -> f $ Generalized            $ mapE e
    where mapE e = mapExpr f e
 
 instance ExprLike FieldAssignment where
@@ -201,6 +202,7 @@ instance ExprLike ModuleApplication where
 instance ExprLike Declaration where
   mapExpr f e0 = case e0 of
      TypeSig ai x e            -> TypeSig ai x                         $ mapE e
+     Generalize ai x e         -> Generalize ai x                      $ mapE e
      Field i x e               -> Field i x                            $ mapE e
      FunClause lhs rhs wh ca   -> FunClause (mapE lhs) (mapE rhs) (mapE wh) (mapE ca)
      DataSig r ind x bs e      -> DataSig r ind x (mapE bs)            $ mapE e

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -243,6 +243,7 @@ instance Pretty Expr where
             DontCare e -> text "." <> parens (pretty e)
             Equal _ a b -> pretty a <+> text "=" <+> pretty b
             Ellipsis _  -> text "..."
+            Generalized e -> pretty e
         where
           absurd NotHidden  = text "()"
           absurd Instance{} = text "{{}}"
@@ -377,6 +378,7 @@ instance Pretty Declaration where
                 sep [ prettyRelevance i $ pretty x <+> text ":"
                     , nest 2 $ pretty e
                     ]
+            Generalize i x e -> text "generalize" <+> pretty (TypeSig i x e)
             Field inst x (Arg i e) ->
                 sep [ text "field"
                     , nest 2 $ mkInst inst $ mkOverlap i $

--- a/src/full/Agda/Syntax/Parser/Lexer.x
+++ b/src/full/Agda/Syntax/Parser/Lexer.x
@@ -189,6 +189,7 @@ tokens :-
 <0,code> tactic         { keyword KwTactic }
 <0,code> syntax         { keyword KwSyntax }
 <0,code> pattern        { keyword KwPatternSyn }
+<0,code> generalize     { keyword KwGeneralize }
 
 -- The parser is responsible to put the lexer in the imp_dir_ state when it
 -- expects an import directive keyword. This means that if you run the

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -103,6 +103,7 @@ import Agda.Utils.Impossible
     'eta-equality'            { TokKeyword KwEta $$ }
     'field'                   { TokKeyword KwField $$ }
     'forall'                  { TokKeyword KwForall $$ }
+    'generalize'              { TokKeyword KwGeneralize $$ }
     'hiding'                  { TokKeyword KwHiding $$ }
     'import'                  { TokKeyword KwImport $$ }
     'in'                      { TokKeyword KwIn $$ }
@@ -238,6 +239,7 @@ Token
     | 'eta-equality'            { TokKeyword KwEta $1 }
     | 'field'                   { TokKeyword KwField $1 }
     | 'forall'                  { TokKeyword KwForall $1 }
+    | 'generalize'              { TokKeyword KwGeneralize $1 }
     | 'hiding'                  { TokKeyword KwHiding $1 }
     | 'import'                  { TokKeyword KwImport $1 }
     | 'in'                      { TokKeyword KwIn $1 }
@@ -1127,6 +1129,7 @@ Declaration
     | Record        { [$1] }
     | RecordSig     { [$1] }  -- lone record signature in mutual block
     | Infix         { [$1] }
+    | Generalize    {  $1  }
     | Mutual        { [$1] }
     | Abstract      { [$1] }
     | Private       { [$1] }
@@ -1151,14 +1154,14 @@ Declaration
 -- Type signatures of the form "n1 n2 n3 ... : Type", with at least
 -- one bound name.
 TypeSigs :: { [Declaration] }
-TypeSigs : SpaceIds ':' Expr { map (\ x -> TypeSig defaultArgInfo x $3) $1 }
+TypeSigs : SpaceIds ':' Expr { map (\ x -> typeSig defaultArgInfo x $3) $1 }
 
 -- A variant of TypeSigs where any sub-sequence of names can be marked
 -- as hidden or irrelevant using braces and dots:
 -- {n1 .n2} n3 .n4 {n5} .{n6 n7} ... : Type.
 ArgTypeSigs :: { [Arg Declaration] }
 ArgTypeSigs
-  : ArgIds ':' Expr { map (fmap (\ x -> TypeSig defaultArgInfo x $3)) $1 }
+  : ArgIds ':' Expr { map (fmap (\ x -> typeSig defaultArgInfo x $3)) $1 }
   | 'overlap' ArgIds ':' Expr {%
       let setOverlap x =
             case getHiding x of
@@ -1166,7 +1169,7 @@ ArgTypeSigs
               _          ->
                 parseErrorAt (fromJust $ rStart' $ getRange $1)
                              "The 'overlap' keyword only applies to instance fields (fields marked with {{ }})"
-      in T.traverse (setOverlap . fmap (\ x -> TypeSig defaultArgInfo x $4)) $2 }
+      in T.traverse (setOverlap . fmap (\ x -> typeSig defaultArgInfo x $4)) $2 }
   | 'instance' ArgTypeSignatures {
     let
       setInstance (TypeSig info x t) = TypeSig (makeInstance info) x t
@@ -1240,6 +1243,13 @@ Fields : 'field' ArgTypeSignatures
                            _          -> NotInstanceDef
                 toField (Arg info (TypeSig info' x t)) = Field (inst info') x (Arg info t)
               in map toField $2 }
+
+-- Variable declarations for automatic generalization
+Generalize :: { [Declaration] }
+Generalize : 'generalize' ArgTypeSignatures
+            { let
+                toGeneralize (Arg info (TypeSig _ x t)) = Generalize info x t
+              in map toGeneralize $2 }
 
 -- Mutually recursive declarations.
 Mutual :: { Declaration }
@@ -2163,7 +2173,7 @@ funClauseOrTypeSigs lhs mrhs wh = do
         LHS _ _ (_:_) -> parseError "Illegal: with in type signature"
         LHS _ (_:_) _ -> parseError "Illegal: rewrite in type signature"
         LHS p _ _ | hasWithPatterns p -> parseError "Illegal: with patterns in type signature"
-        LHS p [] []  -> map (\ (x, y) -> TypeSig x y e) <$> patternToNames p
+        LHS p [] []  -> map (\ (x, y) -> typeSig x y e) <$> patternToNames p
       _ -> parseError "A type signature cannot have a where clause"
 
 parseDisplayPragma :: Range -> Position -> String -> Parser Pragma
@@ -2172,5 +2182,8 @@ parseDisplayPragma r pos s =
     ParseOk s [FunClause (LHS lhs [] []) (RHS rhs) NoWhere ca] | null (parseInp s) ->
       return $ DisplayPragma r lhs rhs
     _ -> parseError "Invalid DISPLAY pragma. Should have form {-# DISPLAY LHS = RHS #-}."
+
+typeSig :: ArgInfo -> Name -> Expr -> Declaration
+typeSig i n e = TypeSig i n (Generalized e)
 
 }

--- a/src/full/Agda/Syntax/Parser/Tokens.hs
+++ b/src/full/Agda/Syntax/Parser/Tokens.hs
@@ -32,12 +32,13 @@ data Keyword
         | KwUnquote | KwUnquoteDecl | KwUnquoteDef
         | KwSyntax
         | KwPatternSyn | KwTactic | KwCATCHALL
+        | KwGeneralize
         | KwNO_POSITIVITY_CHECK | KwPOLARITY
     deriving (Eq, Show)
 
 layoutKeywords :: [Keyword]
 layoutKeywords =
-    [ KwLet, KwWhere, KwDo, KwPostulate, KwMutual, KwAbstract, KwPrivate, KwInstance, KwMacro, KwPrimitive, KwField ]
+    [ KwLet, KwWhere, KwDo, KwPostulate, KwMutual, KwAbstract, KwPrivate, KwInstance, KwMacro, KwPrimitive, KwField, KwGeneralize ]
 
 data Symbol
         = SymDot | SymSemi | SymVirtualSemi | SymBar

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -245,6 +245,7 @@ data KindOfName
   | FldName        -- ^ Record field name.
   | DefName        -- ^ Ordinary defined name.
   | PatternSynName -- ^ Name of a pattern synonym.
+  | GeneralizeName -- ^ Name to be generalized
   | MacroName      -- ^ Name of a macro
   | QuotableName   -- ^ A name that can only be quoted.
   deriving (Eq, Show, Data, Enum, Bounded)

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -574,6 +574,8 @@ instance ToConcrete A.Expr C.Expr where
         piTel (A.Pi _ tel e) = (tel ++) -*- id $ piTel e
         piTel e              = ([], e)
 
+    toConcrete (A.Generalized _ e) = C.Generalized <$> toConcrete e
+
     toConcrete (A.Fun i a b) =
         bracket piBrackets
         $ do a' <- toConcreteCtx (if irr then DotPatternCtx else FunctionSpaceDomainCtx) a
@@ -833,6 +835,13 @@ instance ToConcrete A.Declaration [C.Declaration] where
            Nothing   -> []
            Just occs -> [C.Pragma (PolarityPragma noRange x' occs)]) ++
         [C.Postulate (getRange i) [C.TypeSig info x' t']]
+
+  toConcrete (A.Generalize s i j x t) = do
+    x' <- unsafeQNameToName <$> toConcrete x
+    withAbstractPrivate i $
+      withInfixDecl i x'  $ do
+      t' <- toConcreteTop t
+      return [C.Generalize j x' $ C.Generalized t']
 
   toConcrete (A.Field i x t) = do
     x' <- unsafeQNameToName <$> toConcrete x

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -824,6 +824,7 @@ instance BlankVars A.Expr where
     A.ExtendedLam i d f cs -> A.ExtendedLam i d f $ blank bound cs
     A.Pi i tel e           -> let bound' = varsBoundIn tel `Set.union` bound
                               in  uncurry (A.Pi i) $ blank bound' (tel, e)
+    A.Generalized {}       -> __IMPOSSIBLE__
     A.Fun i a b            -> uncurry (A.Fun i) $ blank bound (a, b)
     A.Set _ _              -> e
     A.Prop _               -> e

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -126,7 +126,8 @@ termDecl' d = case d of
     A.Pragma {}           -> return mempty
     A.Open {}             -> return mempty
     A.PatternSynDef {}    -> return mempty
-        -- open and pattern synonym defs are just artifacts from the concrete syntax
+    A.Generalize {}       -> return mempty
+        -- open, pattern synonym and generalize defs are just artifacts from the concrete syntax
     A.ScopedDecl scope ds -> {- withScope_ scope $ -} termDecls ds
         -- scope is irrelevant as we are termination checking Syntax.Internal
     A.RecSig{}            -> return mempty

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -372,6 +372,10 @@ errorString err = case err of
   ModuleNameDoesntMatchFileName {}         -> "ModuleNameDoesntMatchFileName"
   NeedOptionCopatterns{}                   -> "NeedOptionCopatterns"
   NeedOptionRewriting{}                    -> "NeedOptionRewriting"
+  NeedOptionGeneralize{}                   -> "NeedOptionGeneralize"
+  GeneralizeNotSupportedHere{}             -> "GeneralizeNotSupportedHere"
+  GeneralizeCyclicDependency{}             -> "GeneralizeCyclicDependency"
+  GeneralizeUnsolvedMeta{}                 -> "GeneralizeUnsolvedMeta"
   NoBindingForBuiltin{}                    -> "NoBindingForBuiltin"
   NoParseForApplication{}                  -> "NoParseForApplication"
   NoParseForLHS{}                          -> "NoParseForLHS"
@@ -1252,6 +1256,18 @@ instance PrettyTCM TypeError where
 
     NeedOptionRewriting  -> fsep $
       pwords "Option --rewriting needed to add and use rewrite rules"
+
+    NeedOptionGeneralize -> fsep $
+      pwords "Option --generalize needed to add and use generalize rules"
+
+    GeneralizeNotSupportedHere x -> fsep $
+      pwords $ "Generalizable variable " ++ show x ++ " is not supported here"
+
+    GeneralizeCyclicDependency -> fsep $
+      pwords "Cyclic dependency between generalized variables"
+
+    GeneralizeUnsolvedMeta -> fsep $
+      pwords "Unsolved meta not generalized"
 
     NonFatalErrors ws -> foldr1 ($$) $ fmap prettyTCM ws
 

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -364,6 +364,11 @@ withMetaInfo :: Closure Range -> TCM a -> TCM a
 withMetaInfo mI cont = enterClosure mI $ \ r ->
   setCurrentRange r cont
 
+-- | Get all metas that correspond to generalizable variables.
+getGeneralizeMetas :: TCM [MetaId]
+getGeneralizeMetas =
+  concatMap (Map.keys . snd) . Map.elems <$> use stGeneralizableMetas
+
 getInstantiatedMetas :: TCM [MetaId]
 getInstantiatedMetas = do
     store <- getMetaStore

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -28,7 +28,7 @@ import Agda.Interaction.Response
 import Agda.Syntax.Common
 import Agda.Syntax.Scope.Base
 import qualified Agda.Syntax.Concrete.Name as C
-import Agda.Syntax.Abstract (PatternSynDefn, PatternSynDefns)
+import Agda.Syntax.Abstract (PatternSynDefn, PatternSynDefns, GeneralizableDefn, GeneralizableDefns)
 import Agda.Syntax.Abstract.PatternSynonyms
 import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Internal

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -19,6 +19,7 @@ import Data.Either (partitionEithers)
 import Data.Monoid (mappend)
 import qualified Data.List as List
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 
 import Agda.Interaction.Options
 import Agda.Interaction.Highlighting.Generate (storeDisambiguatedName)
@@ -39,6 +40,7 @@ import Agda.Syntax.Scope.Base ( ThingsInScope, AbstractName
 import Agda.Syntax.Scope.Monad (getNamedScope)
 import Agda.Syntax.Translation.InternalToAbstract (reify)
 
+import Agda.TypeChecking.Abstract
 import Agda.TypeChecking.CompiledClause
 import Agda.TypeChecking.Constraints
 import Agda.TypeChecking.Conversion
@@ -86,6 +88,7 @@ import Agda.Utils.NonemptyList
 import Agda.Utils.Pretty ( prettyShow )
 import qualified Agda.Utils.Pretty as P
 import Agda.Utils.Size
+import qualified Agda.Utils.Graph.TopSort as Graph
 import Agda.Utils.Tuple
 
 #include "undefined.h"
@@ -889,6 +892,19 @@ checkExpr e t0 =
                    , nest 2 $ text "cxt =" <+> (prettyTCM =<< getContextTelescope)
                    ]
             coerce v (sort s) t
+
+        A.Generalized s e -> do
+            (t0, t') <- checkGeneralized s $ isType_ e
+            noFunctionsIntoSize t0 t'
+            let s = getSort t'
+                v = unEl t'
+            when (s == Inf) $ reportSDoc "tc.term.sort" 20 $
+              vcat [ text ("reduced to omega:")
+                   , nest 2 $ text "t   =" <+> prettyTCM t'
+                   , nest 2 $ text "cxt =" <+> (prettyTCM =<< getContextTelescope)
+                   ]
+            coerce v (sort s) t
+
         A.Fun _ (Arg info a) b -> do
             a' <- isType_ a
             b' <- isType_ b
@@ -1064,6 +1080,80 @@ unquoteTactic tac hole goal k = do
         postponeTypeCheckingProblem (UnquoteTactic tac hole goal) unblock
     Left err -> typeError $ UnquoteFailed err
     Right _ -> k
+
+---------------------------------------------------------------------------
+-- * Generalized identifiers
+---------------------------------------------------------------------------
+
+type NameOrMeta = Either MetaId QName
+
+checkGeneralized :: Set.Set QName -> TCM Type -> TCM (Type, Type)
+checkGeneralized s m = do
+    ropt <- optGeneralize <$> pragmaOptions
+    unless ropt $ typeError NeedOptionGeneralize
+    t <- disableDestructiveUpdate m
+    ((extra, vs), ms) <- collectNames mempty $ Set.toList s
+    let metas = List.nub [ mi | Left mi <- extra ++ concatMap (\(a,b)->[a,b]) vs ]
+    vsm <- fmap concat $ forM metas $ \mi ->
+        (\me -> [(Left mi, Left de) | de <- me, de `elem` metas]) . allMetas <$> (getMetaType mi >>= instantiateFull)
+    reportSDoc "tc.decl.ax" 50 $ text $ "dependencies " ++ show (extra, vs, vsm)
+    case Graph.topSort extra $ vs ++ vsm of
+      Nothing -> typeError GeneralizeCyclicDependency
+      Just sorted -> do
+        reportSDoc "tc.decl.ax" 50 $ text $ "topSort " ++ show sorted
+        t <- reduce =<< instantiateFull t
+        t' <- addVars t $ reverse sorted
+        modifyMetaStore (ms `mappend`)
+        unless (List.null $ allMetas t') $ typeError GeneralizeUnsolvedMeta
+        forM_ [n | Left n <- sorted, Map.notMember n ms] $ \n ->
+            modifyMetaStore $ flip Map.adjust n $ \me ->
+                me {mvInstantiation = InstV [] (error ("meta var " ++ show n ++ " was generalized"))} -- TODO
+        pure (t, t')
+  where
+    -- find dependent open metas
+    findMetas mi Open = pure [mi]
+    findMetas _ (InstV _ t) = fmap concat $ instantiateFull t >>= \t ->
+        forM (allMetas t) (\mi -> findMetas mi =<< (mvInstantiation <$> lookupMeta mi))
+    findMetas _ _ = pure []
+
+    collectNames :: Set.Set QName -> [QName]
+                 -> TCM (([NameOrMeta], [(NameOrMeta, NameOrMeta)]), MetaStore)
+    collectNames _ [] = return mempty
+    collectNames acc (n: ns)
+        | n `Set.member` acc = collectNames acc ns
+        | otherwise = do
+            ((se, _), metas) <- fromMaybe __IMPOSSIBLE__ . Map.lookup n <$> use stGeneralizableMetas
+            mopen <- fmap concat $ forM (Map.keys metas) $ \mi ->
+                findMetas mi =<< (mvInstantiation <$> lookupMeta mi)
+            let more = Set.toList se
+            ((([Right n], ((,) (Right n) <$> ((Left <$> mopen) ++ (Right <$> more)))), metas) `mappend`)
+                <$> collectNames (Set.insert n acc) (more ++ ns)
+
+    addVars t [] = return t
+    addVars t (Left n: ns) = do
+        me <- lookupMeta n
+        ty <- getMetaType n
+        let nas = miNameSuggestion $ mvInfo me
+        addTheVar (defaultArgInfo {argInfoHiding = Hidden, argInfoOrigin = Inserted})
+                  (if List.null nas then "Meta" else nas)
+                  (MetaV n []) ty t ns
+    addVars t (Right n: ns) = do
+        ((_, info), _) <- fromMaybe __IMPOSSIBLE__ . Map.lookup n <$> use stGeneralizableMetas
+        i <- getConstInfo n
+        addTheVar info (last $ C.nameStringParts $ nameConcrete $ qnameName n) (Def n []) (defType i) t ns
+
+    addTheVar info n v ty t ns = do
+        vs <- getContextArgs
+        ty <- reduce =<< instantiateFull =<< piApplyM ty vs
+        v <- reduce $ apply v vs
+        t' <- mkPi (Dom info (n, ty)) <$> abstractType ty v t
+        reportSDoc "tc.decl.gen" 20 $ vcat
+            [ text $ "generalize "
+            , text $ prettyShow t
+            , text "  to  "
+            , text $ prettyShow t'
+            ]
+        addVars t' ns
 
 ---------------------------------------------------------------------------
 -- * Meta variables

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -92,6 +92,7 @@ instance EmbPrj KindOfName where
   icod_ PatternSynName = icodeN 3 PatternSynName
   icod_ QuotableName   = icodeN 4 QuotableName
   icod_ MacroName      = icodeN 5 MacroName
+  icod_ GeneralizeName = icodeN 6 GeneralizeName
 
   value = vcase valu where
     valu []  = valuN DefName
@@ -100,6 +101,7 @@ instance EmbPrj KindOfName where
     valu [3] = valuN PatternSynName
     valu [4] = valuN QuotableName
     valu [5] = valuN MacroName
+    valu [6] = valuN GeneralizeName
     valu _   = malformed
 
 instance EmbPrj Binder where

--- a/src/full/Agda/Utils/Graph/TopSort.hs
+++ b/src/full/Agda/Utils/Graph/TopSort.hs
@@ -1,0 +1,41 @@
+{-# language ViewPatterns #-}
+module Agda.Utils.Graph.TopSort
+    ( topSort
+    ) where
+
+import Data.List
+import Data.Maybe
+import Data.Function
+import qualified Data.Set as Set
+import qualified Data.Map as Map
+import Control.Arrow
+
+mergeBy :: (a -> a -> Bool) -> [a] -> [a] -> [a]
+mergeBy _ [] xs = xs
+mergeBy _ xs [] = xs
+mergeBy f (x:xs) (y:ys)
+    | f x y = x: mergeBy f xs (y:ys)
+    | otherwise = y: mergeBy f (x:xs) ys
+
+-- | topoligical sort with smallest-numbered available vertex first
+-- | input: nodes, edges
+-- | output is Nothing if the graph is not a DAG
+topSort :: Ord n => [n] -> [(n, n)] -> Maybe [n]
+topSort nodes edges = mergeBy (<) nodes' <$> g m is
+  where
+    g m []
+        | Map.null m = Just []
+        | otherwise = Nothing
+    g m ((n, Set.toList -> cs): ns)
+        = (n:) <$> g m' (mergeBy ((<) `on` fst) ns [(c, s) | c<-cs, (0, s) <- maybeToList $ Map.lookup c m'])
+      where
+        m' = foldr (Map.adjust $ first (+(-1))) (Map.delete n m) cs
+
+    is = map (second snd) . filter ((==0) . fst . snd) $ Map.toList m
+
+    nodes' = Set.toList $ Set.fromList nodes `Set.difference` Set.fromList (concatMap (\(a,b)->[a,b]) edges)
+
+    m = foldr f mempty $ nub edges
+    f (b, a)
+        = Map.alter (Just . maybe (1, mempty) (first (+1))) b
+        . Map.alter (Just . maybe (0, Set.singleton b) (second $ Set.insert b)) a

--- a/test/Succeed/Generalize.agda
+++ b/test/Succeed/Generalize.agda
@@ -1,0 +1,100 @@
+{-# OPTIONS --without-K --rewriting --generalize #-}
+
+module Generalize where
+
+data _≡_ {ℓ}{A : Set ℓ} (x : A) : A → Set ℓ where
+  refl : x ≡ x
+
+infix 4 _≡_
+
+{-# BUILTIN REWRITE _≡_ #-}
+
+------------------------------------------------------------------
+
+postulate   Con     :                       Set
+postulate   Ty      : (Γ : Con) →           Set
+postulate   Tms     : (Γ Δ : Con) →         Set
+postulate   Tm      : (Γ : Con)(A : Ty Γ) → Set
+
+------------------------------------------------------------------
+
+generalize  {Γ Δ Θ} :              Con
+postulate   •       :              Con       -- • is \bub
+postulate   _▹_     : ∀ Γ → Ty Γ → Con       -- ▹ is \tw2
+infixl 5    _▹_
+
+generalize  {A B C} :                  Ty _
+postulate   _∘ᵀ_    : Ty Δ → Tms Γ Δ → Ty Γ
+infixl 6    _∘ᵀ_
+
+generalize  {σ δ ν} :                                 Tms _ _
+postulate   _∘_     : Tms Θ Δ → Tms Γ Θ →             Tms Γ Δ
+infixr 7    _∘_
+postulate   id      :                                 Tms Γ Γ
+postulate   ε       :                                 Tms Γ •
+postulate   _,_     : (σ : Tms Γ Δ) → Tm Γ (A ∘ᵀ σ) → Tms Γ (Δ ▹ A)
+infixl 5    _,_
+postulate   π₁      : Tms Γ (Δ ▹ A) →                 Tms Γ Δ
+
+generalize  {t u v} :                          Tm _ _
+postulate   π₂      : (σ : Tms Γ (Δ ▹ A)) →    Tm Γ (A ∘ᵀ π₁ σ)
+postulate   _∘ᵗ_    : Tm Δ A → (σ : Tms Γ Δ) → Tm Γ (A ∘ᵀ σ)
+infixl 6    _∘ᵗ_
+
+postulate   ass     :   (σ ∘ δ) ∘ ν ≡ σ ∘ δ ∘ ν
+{-# REWRITE ass #-}
+postulate   idl     :        id ∘ δ ≡ δ
+{-# REWRITE idl #-}
+postulate   idr     :        δ ∘ id ≡ δ
+{-# REWRITE idr #-}
+postulate   εη      :             δ ≡ ε  -- can't rewrite, so we specialize this in the next two cases
+postulate   εηid    :            id ≡ ε
+{-# REWRITE εηid #-}
+postulate   εη∘     :         ε ∘ δ ≡ ε
+{-# REWRITE εη∘ #-}
+postulate   ,β₁     :    π₁ (δ , t) ≡ δ
+{-# REWRITE ,β₁ #-}
+postulate   ,β₂     :    π₂ (δ , t) ≡ t
+{-# REWRITE ,β₂ #-}
+postulate   ,η      : (π₁ δ , π₂ δ) ≡ δ
+{-# REWRITE ,η #-}
+postulate   [id]ᵀ   :       A ∘ᵀ id ≡ A
+{-# REWRITE [id]ᵀ #-}
+postulate   [∘]ᵀ    :   A ∘ᵀ δ ∘ᵀ σ ≡ A ∘ᵀ δ ∘ σ
+{-# REWRITE [∘]ᵀ #-}
+postulate   ,∘      :   (δ , t) ∘ σ ≡ δ ∘ σ , t ∘ᵗ σ
+{-# REWRITE ,∘ #-}
+
+postulate   [∘]ᵗ    :   t ∘ᵗ σ ∘ᵗ δ ≡ t ∘ᵗ σ ∘ δ
+{-# REWRITE [∘]ᵗ #-}
+postulate   π₁∘     :      π₁ δ ∘ σ ≡ π₁ (δ ∘ σ)
+{-# REWRITE π₁∘ #-}
+postulate   π₂∘     :     π₂ δ ∘ᵗ σ ≡ π₂ (δ ∘ σ)
+{-# REWRITE π₂∘ #-}
+postulate   ∘id     :       t ∘ᵗ id ≡ t
+{-# REWRITE ∘id #-}
+
+_↑_ : ∀ σ A → Tms (Γ ▹ A ∘ᵀ σ) (Δ ▹ A)
+σ ↑ A = σ ∘ π₁ id , π₂ id
+
+⟨_⟩ : Tm Γ A → Tms Γ (Γ ▹ A)
+⟨ t ⟩ = id , t
+
+------------------------------------------------------------------
+
+postulate   U       : Ty Γ
+generalize  {a b c} : Tm _ U
+postulate   El      : Tm Γ U → Ty Γ
+postulate   U[]     : U ∘ᵀ σ ≡ U
+{-# REWRITE U[] #-}
+postulate   El[]    : El a ∘ᵀ σ ≡ El (a ∘ᵗ σ)
+{-# REWRITE El[] #-}
+
+------------------------------------------------------------------
+
+postulate   Π       : (a : Tm Γ U) → Ty (Γ ▹ El a) → Ty Γ
+postulate   Π[]     : Π a B ∘ᵀ σ ≡ Π (a ∘ᵗ σ) (B ∘ᵀ σ ↑ El a)
+{-# REWRITE Π[] #-}
+postulate   app     : Tm Γ (Π a B) → Tm (Γ ▹ El a) B
+postulate   app[]   : app t ∘ᵗ (σ ↑ El a) ≡ app (t ∘ᵗ σ)
+{-# REWRITE app[] #-}

--- a/test/Succeed/GeneralizeIssue1.agda
+++ b/test/Succeed/GeneralizeIssue1.agda
@@ -1,0 +1,7 @@
+{-# OPTIONS --generalize #-}
+
+generalize
+  S : Set
+
+data D (A : Set) : Set1 where
+  d : S → D A

--- a/test/Succeed/GeneralizeIssue1.warn
+++ b/test/Succeed/GeneralizeIssue1.warn
@@ -1,0 +1,6 @@
+AGDA_UNEXPECTED_FAIL
+
+ret > ExitFailure 1
+out > An internal error has occurred. Please report this as a bug.
+out > Location of the error: src/full/Agda/TypeChecking/Telescope.hs:323
+out >


### PR DESCRIPTION
Second version of 'generalize'

TODO:

- documentation in `doc/release-notes`
- more tests

Known bugs & limitations:

- bug: generalizable variables escape their scope
- more robust implementation: Currently the metavariables in the types of generalizable variables are solved during type inference, and later these metavariables are reset to unsolved state. Better would be to add fresh metavariables each time.
- The generalized type should be build up from outside to inside, adding outer bindings first. Currently it is done in the other way around, so metavariables are solved before the generalization begins, but not solved during the generalization. See <https://lists.chalmers.se/pipermail/agda/2018/010188.html>
- feature request: support generalize in the rhs <https://github.com/divipp/agda/issues/4>
- feature request: export generalizable variables
- other bugs: <https://github.com/divipp/agda/issues>
