### PR TITLE
Require agda2-mode in emacs config-file

### DIFF
--- a/src/agda-mode/Main.hs
+++ b/src/agda-mode/Main.hs
@@ -147,6 +147,7 @@ setupString files = unlines
   , "(load-file (let ((coding-system-for-read 'utf-8))"
   , "                (shell-command-to-string \""
                         ++ identifier files ++ "\")))"
+  , "(require 'agda2-mode)"
   ]
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
My motivation for this is that I want to use Agda's input method without first having to enable the major-mode. Requiring `agda2-mode` in my `init.el` seems to achieve this.

I've only tested this by manual modification of my own emacs configuration file.