### PR TITLE
Stackage LTS with ghc-8.4 and async-2.2 released

### DIFF
--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -1,47 +1,4 @@
-resolver: ghc-8.4.3
-
-extra-deps:
-- async-2.2.1
-- EdisonCore-1.3.2.1
-- data-hash-0.2.0.1
-- equivalence-0.3.2
-- geniplate-mirror-0.7.6
-- EdisonAPI-1.3.1
-- QuickCheck-2.11.3
-- STMonadTrans-0.4.3
-- blaze-html-0.9.0.1
-- boxes-0.1.5
-- edit-distance-0.2.2.1
-- gitrev-1.3.1
-- hashable-1.2.7.0
-- hashtables-1.2.3.0
-- ieee754-0.8.0
-- murmur-hash-0.1.0.9
-- regex-tdfa-1.2.3
-- strict-0.3.2
-- transformers-compat-0.6.0.6
-- unordered-containers-0.2.9.0
-- uri-encode-1.5.0.5
-- zlib-0.6.2
-- base-compat-0.9.3
-- blaze-builder-0.4.1.0
-- blaze-markup-0.8.2.0
-- network-uri-2.6.1.0
-- primitive-0.6.3.0
-- random-1.1
-- regex-base-0.93.2
-- split-0.2.3.3
-- tf-random-0.5
-- utf8-string-1.0.1.1
-- vector-0.12.0.1
-- cpphs-1.20.8
-- old-locale-1.0.0.7
-- old-time-1.1.0.3
-- polyparse-1.12
-- alex-3.2.4
-- happy-1.19.9
-- text-icu-0.7.0.1
-
+resolver: lts-12.0
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
[Announcement](https://www.stackage.org/blog/2018/07/announce-lts-12) on the Stackage blog.