### PR TITLE
[ Stack ] Allow users to build, develop and test using Stack

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -373,6 +373,27 @@ Cabal stuff
 
   cabal repl --ghc-options=-Wwarn
 
+
+Developing with Stack
+---------------------
+
+At the time of writing, the whole dev stack of Agda is still centered around
+tools like Cabal and Makefile.
+
+To replace Cabal with Stack, you will only have to make a copy of stack.yaml
+from stack-dev-8.4.3.yaml.
+
+    cp stack-dev-8.4.3.yaml stack.yaml
+
+And that's pretty much all of it!
+You can proceed to build the project and run tests like you would before:
+
+    make install-bin test
+
+To run ghci:
+
+    stack repl
+
 Documentation
 -------------
 

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ check-whitespace : build-fix-agda-whitespace
 
 .PHONY : build-fix-agda-whitespace
 build-fix-agda-whitespace :
-ifeq ("$(wildcard $(stack.yaml))","")
+ifneq ("$(wildcard stack.yaml)","") # if `stack.yaml` exists
 	stack build fix-agda-whitespace
 	mkdir -p $(FAW_PATH)/dist/build/fix-agda-whitespace/
 	cp $(shell stack path --local-install-root)/bin/fix-agda-whitespace $(FAW_BIN)

--- a/src/size-solver/Makefile
+++ b/src/size-solver/Makefile
@@ -7,10 +7,19 @@ CABAL_CMD=cabal
 
 .PHONY : install-bin
 install-bin :
+ifneq ("$(wildcard ../../stack.yaml)","") # if `stack.yaml` exists
+	stack build size-solver
+	mkdir -p dist/build/size-solver
+	cp $(shell stack path --local-install-root)/bin/size-solver dist/build/size-solver/size-solver
+else
 	$(CABAL_CMD) install
+endif
 
 # Tested with shelltestrunner 1.9.
 .PHONY : test
 test :
+ifneq ("$(wildcard ../../stack.yaml)","") # if `stack.yaml` exists
+	stack install shelltestrunner
+endif
 	shelltest --color --precise test/succeed.test
 	shelltest --color --precise test/fail.test

--- a/stack-dev-8.4.3.yaml
+++ b/stack-dev-8.4.3.yaml
@@ -1,0 +1,9 @@
+resolver: lts-12.0
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+- 'src/fix-agda-whitespace'
+
+extra-deps:
+- temporary-1.2.1.1

--- a/stack-dev-8.4.3.yaml
+++ b/stack-dev-8.4.3.yaml
@@ -4,6 +4,7 @@ resolver: lts-12.0
 packages:
 - '.'
 - 'src/fix-agda-whitespace'
+- 'src/size-solver'
 
 extra-deps:
 - temporary-1.2.1.1

--- a/test/api/Makefile
+++ b/test/api/Makefile
@@ -11,7 +11,11 @@ all : Issue1168.api PrettyInterface.api ScopeFromInterface.api
 
 %.api : %.agdai %.hs
 	$(eval tmpdir = $(shell mktemp -d /tmp/api-test.XXXX))
+ifneq ("$(wildcard ../../stack.yaml)","") # if `stack.yaml` exists
+	stack ghc -- -Wall -Werror -o $(tmpdir)/$* $*.hs
+else
 	ghc -Wall -Werror -package Agda-$(VERSION) -o $(tmpdir)/$* $*.hs
+endif
 	$(tmpdir)/$*
 	rm -r $(tmpdir)
 


### PR DESCRIPTION
## Problem

I had a hard time building and testing Agda because there are some dependency problems (mainly because of `cpphs`) that couldn't be solved with Cabal. 

## Solution

Replace Cabal with Stack whenever we need to build something, and pretend that it's built by Cabal so that nothing is broken.

Note that:
1. **The whole workflow should remain the same as before**
2. **Cabal is still the defaulted way of building stuff**

To signal the Makefiles to use Stack instead of Cabal, a copy of `stack.yaml` needs to be placed at the root directory. Take the `Makefile` of the `size-solver` for example, this is how it works:
```makefile
.PHONY : install-bin
install-bin :
ifneq ("$(wildcard ../../stack.yaml)","") # if `stack.yaml` exists
	stack build size-solver
	mkdir -p dist/build/size-solver
	cp $(shell stack path --local-install-root)/bin/size-solver dist/build/size-solver/size-solver
else
	$(CABAL_CMD) install
endif
```

## How to use it

I don't want to mess with the existing array of `stack.yaml` files, so this pull request also comes a new file called `stack-dev-8.4.3.yaml`.
The user should copy it to `stack.yaml` to signal the Makefiles.

```bash
cp stack-dev-8.4.3.yaml stack.yaml
```

And everything else should work the same:

```
make install-bin test
```

To open the REPL:

```
stack repl
```
