### PR TITLE
Adds JSON support 

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -131,7 +131,7 @@ library
   if os(windows)
     build-depends:  Win32 >= 2.3.1.0 && < 2.7
 
-  build-depends:  aeson >= 1.3 && < 2.0
+  build-depends:  aeson >= 0.11.3.0 && < 1.5
                 , array >= 0.5.1.0 && < 0.6
                 , async >= 2.2 && < 2.3
                 , base >= 4.8.0.0 && < 4.13

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -255,6 +255,7 @@ library
                     Agda.Interaction.EmacsTop
                     Agda.Interaction.JSONTop
                     Agda.Interaction.FindFile
+                    Agda.Interaction.Highlighting.Common
                     Agda.Interaction.Highlighting.Dot
                     Agda.Interaction.Highlighting.Emacs
                     Agda.Interaction.Highlighting.Generate

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -252,6 +252,7 @@ library
                     Agda.Interaction.CommandLine
                     Agda.Interaction.EmacsCommand
                     Agda.Interaction.EmacsTop
+                    Agda.Interaction.JSONTop
                     Agda.Interaction.FindFile
                     Agda.Interaction.Highlighting.Dot
                     Agda.Interaction.Highlighting.Emacs

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -131,7 +131,8 @@ library
   if os(windows)
     build-depends:  Win32 >= 2.3.1.0 && < 2.7
 
-  build-depends:  array >= 0.5.1.0 && < 0.6
+  build-depends:  aeson >= 1.3 && < 2.0
+                , array >= 0.5.1.0 && < 0.6
                 , async >= 2.2 && < 2.3
                 , base >= 4.8.0.0 && < 4.13
                 , binary >= 0.7.3.0 && < 0.9

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -482,6 +482,7 @@ library
                     Agda.Utils.IO
                     Agda.Utils.IO.Binary
                     Agda.Utils.IO.Directory
+                    Agda.Utils.IO.TempFile
                     Agda.Utils.IO.UTF8
                     Agda.Utils.IORef
                     Agda.Utils.Lens

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -259,6 +259,7 @@ library
                     Agda.Interaction.Highlighting.Emacs
                     Agda.Interaction.Highlighting.Generate
                     Agda.Interaction.Highlighting.HTML
+                    Agda.Interaction.Highlighting.JSON
                     Agda.Interaction.Highlighting.Precise
                     Agda.Interaction.Highlighting.Range
                     Agda.Interaction.Highlighting.Vim

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -248,6 +248,7 @@ library
                     Agda.Compiler.Treeless.Uncase
                     Agda.Compiler.Treeless.Unused
                     Agda.ImpossibleTest
+                    Agda.Interaction.AgdaTop
                     Agda.Interaction.BasicOps
                     Agda.Interaction.SearchAbout
                     Agda.Interaction.CommandLine

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -27,6 +27,10 @@ General options
       For use with the Emacs mode (no need to invoke
       yourself)
 
+:samp:`--interaction`
+    For use with other editors such as Atom (no need to invoke
+    yourself)
+
 Compilation
 ~~~~~~~~~~~
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -27,7 +27,7 @@ General options
       For use with the Emacs mode (no need to invoke
       yourself)
 
-:samp:`--interaction`
+:samp:`--interaction-json`
     For use with other editors such as Atom (no need to invoke
     yourself)
 

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -152,6 +152,7 @@ backendInteraction backends _ check = do
       err flag = genericError $ "Cannot mix --" ++ flag ++ " and backends (" ++ List.intercalate ", " backendNames ++ ")"
   when (optInteractive     opts) $ err "interactive"
   when (optGHCiInteraction opts) $ err "interaction"
+  when (optJSONInteraction opts) $ err "interaction-json"
   mi     <- check
 
   -- reset warnings

--- a/src/full/Agda/Interaction/AgdaTop.hs
+++ b/src/full/Agda/Interaction/AgdaTop.hs
@@ -1,0 +1,77 @@
+-- {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Agda.Interaction.AgdaTop
+    ( repl
+    ) where
+
+import Control.Monad.State
+import Data.Char
+import System.IO
+
+import Agda.Interaction.Response as R
+import Agda.Interaction.InteractionTop
+import Agda.Interaction.Options
+import Agda.TypeChecking.Monad
+import qualified Agda.TypeChecking.Monad.Benchmark as Bench
+import Agda.Utils.Maybe
+
+----------------------------------
+
+-- | 'repl' is a fake ghci interpreter for both the Emacs the JSON frontend
+repl :: InteractionOutputCallback -> String -> TCM () -> TCM ()
+repl callback prompt setup = do
+    liftIO $ do
+      hSetBuffering stdout LineBuffering
+      hSetBuffering stdin  LineBuffering
+      hSetEncoding  stdout utf8
+      hSetEncoding  stdin  utf8
+
+    setInteractionOutputCallback callback
+
+    commands <- liftIO $ initialiseCommandQueue readCommand
+
+    handleCommand_ (lift setup) `evalStateT` initCommandState commands
+
+    opts <- commandLineOptions
+    _ <- interact' `runStateT`
+           (initCommandState commands)
+             { optionsOnReload = opts{ optAbsoluteIncludePaths = [] } }
+    return ()
+  where
+  interact' :: CommandM ()
+  interact' = do
+    Bench.reset
+    done <- Bench.billTo [] $ do
+
+      liftIO $ do
+        putStr prompt
+        hFlush stdout
+      c <- nextCommand
+      case c of
+        Done      -> return True -- Done.
+        Error s   -> liftIO (putStrLn s) >> return False
+        Command c -> do
+          maybeAbort (runInteraction c)
+          return False
+
+    lift Bench.print
+    unless done interact'
+
+  -- Reads the next command from stdin.
+
+  readCommand :: IO Command
+  readCommand = do
+    done <- isEOF
+    if done then
+      return Done
+    else do
+      r <- getLine
+      _ <- return $! length r     -- force to read the full input line
+      case dropWhile isSpace r of
+        ""          -> readCommand
+        ('-':'-':_) -> readCommand
+        _           -> case listToMaybe $ reads r of
+          Just (x, "")  -> return $ Command x
+          Just (_, rem) -> return $ Error $ "not consumed: " ++ rem
+          _             -> return $ Error $ "cannot read: " ++ r

--- a/src/full/Agda/Interaction/EmacsTop.hs
+++ b/src/full/Agda/Interaction/EmacsTop.hs
@@ -3,30 +3,22 @@
 module Agda.Interaction.EmacsTop
     ( mimicGHCi
     ) where
+
 import Control.Monad.State
-
-import Data.Char
 import qualified Data.List as List
-import Data.Maybe
 
-import System.IO
-
-import Agda.Utils.Monad
 import Agda.Utils.Maybe
 import Agda.Utils.Pretty
 import Agda.Utils.String
 
 import Agda.Syntax.Common
-
 import Agda.TypeChecking.Monad
-import qualified Agda.TypeChecking.Monad.Benchmark as Bench
 
+import Agda.Interaction.AgdaTop
 import Agda.Interaction.Response as R
-import Agda.Interaction.InteractionTop
 import Agda.Interaction.EmacsCommand hiding (putResponse)
 import Agda.Interaction.Highlighting.Emacs
 import Agda.Interaction.Highlighting.Precise (TokenBased(..))
-import Agda.Interaction.Options
 
 import Agda.VersionCommit
 
@@ -37,64 +29,8 @@ import Agda.VersionCommit
 --
 --   'mimicGHCi' reads the Emacs frontend commands from stdin,
 --   interprets them and print the result into stdout.
-
 mimicGHCi :: TCM () -> TCM ()
-mimicGHCi setup = do
-    liftIO $ do
-      hSetBuffering stdout LineBuffering
-      hSetBuffering stdin  LineBuffering
-      hSetEncoding  stdout utf8
-      hSetEncoding  stdin  utf8
-
-    setInteractionOutputCallback $
-        mapM_ print <=< lispifyResponse
-
-    commands <- liftIO $ initialiseCommandQueue readCommand
-
-    handleCommand_ (lift setup) `evalStateT` initCommandState commands
-
-    opts <- commandLineOptions
-    _ <- interact' `runStateT`
-           (initCommandState commands)
-             { optionsOnReload = opts{ optAbsoluteIncludePaths = [] } }
-    return ()
-  where
-  interact' :: CommandM ()
-  interact' = do
-    Bench.reset
-    done <- Bench.billTo [] $ do
-
-      liftIO $ do
-        putStr "Agda2> "
-        hFlush stdout
-      c <- nextCommand
-      case c of
-        Done      -> return True -- Done.
-        Error s   -> liftIO (putStrLn s) >> return False
-        Command c -> do
-          maybeAbort (runInteraction c)
-          return False
-
-    lift Bench.print
-    unless done interact'
-
-  -- Reads the next command from stdin.
-
-  readCommand :: IO Command
-  readCommand = do
-    done <- isEOF
-    if done then
-      return Done
-    else do
-      r <- getLine
-      _ <- return $! length r     -- force to read the full input line
-      case dropWhile isSpace r of
-        ""          -> readCommand
-        ('-':'-':_) -> readCommand
-        _           -> case listToMaybe $ reads r of
-          Just (x, "")  -> return $ Command x
-          Just (_, rem) -> return $ Error $ "not consumed: " ++ rem
-          _             -> return $ Error $ "cannot read: " ++ r
+mimicGHCi = repl (mapM_ print <=< lispifyResponse) "Agda2> "
 
 -- | Given strings of goals, warnings and errors, return a pair of the
 --   body and the title for the info buffer

--- a/src/full/Agda/Interaction/Highlighting/Common.hs
+++ b/src/full/Agda/Interaction/Highlighting/Common.hs
@@ -1,0 +1,57 @@
+-- | Common syntax highlighting functions for Emacs and JSON
+
+module Agda.Interaction.Highlighting.Common
+  ( toAtoms
+  , chooseHighlightingMethod
+  , writeToTempFile
+  ) where
+
+import Agda.Interaction.Highlighting.Precise
+import Agda.Syntax.Common
+import Agda.TypeChecking.Monad (HighlightingMethod(..))
+import qualified Agda.Utils.IO.UTF8 as UTF8
+
+import qualified Control.Exception as E
+import Data.Maybe (maybeToList)
+import Data.Char (toLower)
+import qualified System.Directory as D
+import qualified System.IO as IO
+
+-- | Converts the 'aspect' and 'otherAspects' fields to strings that are
+-- friendly to editors.
+toAtoms :: Aspects -> [String]
+toAtoms m = map toAtom (otherAspects m) ++ toAtoms' (aspect m)
+  where
+  toAtom :: Show a => a -> String
+  toAtom = map toLower . show
+
+  kindToAtom (Constructor Inductive)   = "inductiveconstructor"
+  kindToAtom (Constructor CoInductive) = "coinductiveconstructor"
+  kindToAtom k                         = toAtom k
+
+  toAtoms' Nothing               = []
+  toAtoms' (Just (Name mKind op)) =
+    map kindToAtom (maybeToList mKind) ++ opAtom
+    where opAtom | op        = ["operator"]
+                 | otherwise = []
+  toAtoms' (Just a) = [toAtom a]
+
+-- | Creates a temporary file, writes some stuff, and returns the filepath
+writeToTempFile :: String -> IO FilePath
+writeToTempFile content = do
+  dir      <- D.getTemporaryDirectory
+  filepath <- E.bracket (IO.openTempFile dir "agda2-mode") (IO.hClose . snd) $ \ (filepath, handle) -> do
+    UTF8.hPutStr handle content
+    return filepath
+  return filepath
+
+-- | Choose which method to use based on HighlightingInfo and HighlightingMethod
+chooseHighlightingMethod
+  :: HighlightingInfo
+  -> HighlightingMethod
+  -> HighlightingMethod
+chooseHighlightingMethod info method = case ranges info of
+  _             | method == Direct                   -> Direct
+  ((_, mi) : _) | otherAspects mi == [TypeChecks] ||
+                  mi == mempty                       -> Direct
+  _                                                  -> Indirect

--- a/src/full/Agda/Interaction/Highlighting/Common.hs
+++ b/src/full/Agda/Interaction/Highlighting/Common.hs
@@ -3,19 +3,13 @@
 module Agda.Interaction.Highlighting.Common
   ( toAtoms
   , chooseHighlightingMethod
-  , writeToTempFile
   ) where
 
 import Agda.Interaction.Highlighting.Precise
 import Agda.Syntax.Common
 import Agda.TypeChecking.Monad (HighlightingMethod(..))
-import qualified Agda.Utils.IO.UTF8 as UTF8
-
-import qualified Control.Exception as E
 import Data.Maybe (maybeToList)
 import Data.Char (toLower)
-import qualified System.Directory as D
-import qualified System.IO as IO
 
 -- | Converts the 'aspect' and 'otherAspects' fields to strings that are
 -- friendly to editors.
@@ -35,15 +29,6 @@ toAtoms m = map toAtom (otherAspects m) ++ toAtoms' (aspect m)
     where opAtom | op        = ["operator"]
                  | otherwise = []
   toAtoms' (Just a) = [toAtom a]
-
--- | Creates a temporary file, writes some stuff, and returns the filepath
-writeToTempFile :: String -> IO FilePath
-writeToTempFile content = do
-  dir      <- D.getTemporaryDirectory
-  filepath <- E.bracket (IO.openTempFile dir "agda2-mode") (IO.hClose . snd) $ \ (filepath, handle) -> do
-    UTF8.hPutStr handle content
-    return filepath
-  return filepath
 
 -- | Choose which method to use based on HighlightingInfo and HighlightingMethod
 chooseHighlightingMethod

--- a/src/full/Agda/Interaction/Highlighting/Emacs.hs
+++ b/src/full/Agda/Interaction/Highlighting/Emacs.hs
@@ -7,51 +7,23 @@ module Agda.Interaction.Highlighting.Emacs
   , lispifyTokenBased
   ) where
 
+import Agda.Interaction.Highlighting.Common
 import Agda.Interaction.Highlighting.Precise
-import Agda.Interaction.Highlighting.Range
+import Agda.Interaction.Highlighting.Range (Range(..))
 import Agda.Interaction.EmacsCommand
 import Agda.Interaction.Response
-import Agda.Syntax.Common
-import Agda.TypeChecking.Monad
-  (TCM, envHighlightingMethod, HighlightingMethod(..), ModuleToSource)
-import Agda.Utils.FileName
-import qualified Agda.Utils.IO.UTF8 as UTF8
-import Agda.Utils.String
+import Agda.TypeChecking.Monad (HighlightingMethod(..), ModuleToSource)
+import Agda.Utils.FileName (filePath)
+import Agda.Utils.String (quote)
 
-import qualified Control.Exception as E
-import Control.Monad.Reader
-import Data.Char
 import qualified Data.Map as Map
 import Data.Maybe
-import Data.Monoid
-import qualified System.Directory as D
-import qualified System.IO as IO
 
 #include "undefined.h"
 import Agda.Utils.Impossible
 
 ------------------------------------------------------------------------
 -- Read/show functions
-
--- | Converts the 'aspect' and 'otherAspects' fields to atoms readable
--- by the Emacs interface.
-
-toAtoms :: Aspects -> [String]
-toAtoms m = map toAtom (otherAspects m) ++ toAtoms' (aspect m)
-  where
-  toAtom :: Show a => a -> String
-  toAtom = map toLower . show
-
-  kindToAtom (Constructor Inductive)   = "inductiveconstructor"
-  kindToAtom (Constructor CoInductive) = "coinductiveconstructor"
-  kindToAtom k                         = toAtom k
-
-  toAtoms' Nothing               = []
-  toAtoms' (Just (Name mKind op)) =
-    map kindToAtom (maybeToList mKind) ++ opAtom
-    where opAtom | op        = ["operator"]
-                 | otherwise = []
-  toAtoms' (Just a) = [toAtom a]
 
 -- | Shows meta information in such a way that it can easily be read
 -- by Emacs.
@@ -103,27 +75,24 @@ lispifyHighlightingInfo
   -> ModuleToSource
      -- ^ Must contain a mapping for every definition site's module.
   -> IO (Lisp String)
-lispifyHighlightingInfo h remove method modFile = do
-  case ranges h of
-    _             | method == Direct                   -> direct
-    ((_, mi) : _) | otherAspects mi == [TypeChecks] ||
-                    mi == mempty                       -> direct
-    _                                                  -> indirect
+lispifyHighlightingInfo h remove method modFile =
+  case chooseHighlightingMethod h method of
+    Direct   -> direct
+    Indirect -> indirect
   where
-  info     = (case remove of
+  info :: [Lisp String]
+  info = (case remove of
                 RemoveHighlighting -> A "remove"
                 KeepHighlighting   -> A "nil") :
              map (showAspects modFile) (ranges h)
 
-  direct   = return $ L (A "agda2-highlight-add-annotations" :
+  direct :: IO (Lisp String)
+  direct = return $ L (A "agda2-highlight-add-annotations" :
                          map Q info)
 
+  indirect :: IO (Lisp String)
   indirect = do
-    dir <- D.getTemporaryDirectory
-    f   <- E.bracket (IO.openTempFile dir "agda2-mode")
-                     (IO.hClose . snd) $ \ (f, h) -> do
-             UTF8.hPutStr h (show $ L info)
-             return f
+    filepath <- writeToTempFile (show $ L info)
     return $ L [ A "agda2-highlight-load-and-delete-action"
-               , A (quote f)
+               , A (quote filepath)
                ]

--- a/src/full/Agda/Interaction/Highlighting/Emacs.hs
+++ b/src/full/Agda/Interaction/Highlighting/Emacs.hs
@@ -14,6 +14,7 @@ import Agda.Interaction.EmacsCommand
 import Agda.Interaction.Response
 import Agda.TypeChecking.Monad (HighlightingMethod(..), ModuleToSource)
 import Agda.Utils.FileName (filePath)
+import Agda.Utils.IO.TempFile (writeToTempFile)
 import Agda.Utils.String (quote)
 
 import qualified Data.Map as Map

--- a/src/full/Agda/Interaction/Highlighting/JSON.hs
+++ b/src/full/Agda/Interaction/Highlighting/JSON.hs
@@ -11,6 +11,7 @@ import Agda.Interaction.Highlighting.Range (Range(..))
 import Agda.Interaction.Response
 import Agda.TypeChecking.Monad (HighlightingMethod(..), ModuleToSource)
 import Agda.Utils.FileName (filePath)
+import Agda.Utils.IO.TempFile (writeToTempFile)
 
 import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as BS

--- a/src/full/Agda/Interaction/Highlighting/JSON.hs
+++ b/src/full/Agda/Interaction/Highlighting/JSON.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Functions which give precise syntax highlighting info in JSON format.
+
+module Agda.Interaction.Highlighting.JSON (jsonifyHighlightingInfo) where
+
+import Agda.Interaction.Highlighting.Precise hiding (String)
+import Agda.Interaction.Highlighting.Range
+import Agda.Interaction.EmacsCommand
+import Agda.Interaction.Response
+import Agda.Syntax.Common
+import Agda.TypeChecking.Monad
+  (TCM, envHighlightingMethod, HighlightingMethod(..), ModuleToSource)
+import Agda.Utils.FileName
+import qualified Agda.Utils.IO.UTF8 as UTF8
+import Agda.Utils.String
+
+import qualified Control.Exception as E
+import Control.Monad.Reader
+import Data.Aeson
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy.Char8 as BS
+import Data.Char
+import qualified Data.Map as Map
+import Data.Maybe
+import Data.Monoid
+import qualified System.Directory as D
+import qualified System.IO as IO
+
+#include "undefined.h"
+import Agda.Utils.Impossible
+
+------------------------------------------------------------------------
+-- Read/show functions
+
+-- | Converts the 'aspect' and 'otherAspects' fields to atoms
+toAtoms :: Aspects -> [String]
+toAtoms m = map toAtom (otherAspects m) ++ toAtoms' (aspect m)
+  where
+  toAtom :: Show a => a -> String
+  toAtom = map toLower . show
+
+  kindToAtom (Constructor Inductive)   = "inductiveconstructor"
+  kindToAtom (Constructor CoInductive) = "coinductiveconstructor"
+  kindToAtom k                         = toAtom k
+
+  toAtoms' Nothing               = []
+  toAtoms' (Just (Name mKind op)) =
+    map kindToAtom (maybeToList mKind) ++ opAtom
+    where opAtom | op        = ["operator"]
+                 | otherwise = []
+  toAtoms' (Just a) = [toAtom a]
+
+-- | Encode meta information into a JSON Value
+showAspects
+  :: ModuleToSource
+     -- ^ Must contain a mapping for the definition site's module, if any.
+  -> (Range, Aspects) -> Value
+showAspects modFile (range, aspect) = object
+  [ "range" .= [from range, to range]
+  , "atoms" .= toAtoms aspect
+  , "tokenBased" .= tokenBased aspect
+  , "note" .= note aspect
+  , "definitionSite" .= fmap defSite (definitionSite aspect)
+  ]
+  where
+    defSite (DefinitionSite mdl position _ _) = object
+      [ "filepath" .= filePath (Map.findWithDefault __IMPOSSIBLE__ mdl modFile)
+      , "position" .= position
+      ]
+
+instance ToJSON TokenBased where
+    toJSON TokenBased = String "TokenBased"
+    toJSON NotOnlyTokenBased = String "NotOnlyTokenBased"
+
+-- | Turns syntax highlighting information into a JSON value
+jsonifyHighlightingInfo
+  :: HighlightingInfo
+  -> RemoveTokenBasedHighlighting
+  -> HighlightingMethod
+  -> ModuleToSource
+     -- ^ Must contain a mapping for every definition site's module.
+  -> IO Value
+jsonifyHighlightingInfo info remove method modFile = do
+  case ranges info of
+    _             | method == Direct                   -> direct
+    ((_, mi) : _) | otherAspects mi == [TypeChecks] ||
+                    mi == mempty                       -> direct
+    _                                                  -> indirect
+  where
+    result :: Value
+    result = object
+      [ "remove" .= case remove of
+          RemoveHighlighting -> True
+          KeepHighlighting -> False
+      , "payload" .= map (showAspects modFile) (ranges info)
+      ]
+
+    direct :: IO Value
+    direct = return $ object
+      [ "kind"   .= String "HighlightingInfo"
+      , "direct" .= True
+      , "info"   .= result
+      ]
+
+    indirect :: IO Value
+    indirect = do
+      dir      <- D.getTemporaryDirectory
+      filepath <- E.bracket (IO.openTempFile dir "agda2-mode") (IO.hClose . snd) $ \ (filepath, handle) -> do
+        UTF8.hPutStr handle (BS.unpack (encode result))
+        return filepath
+      return $ object
+        [ "kind"     .= String "HighlightingInfo"
+        , "direct"   .= False
+        , "filepath" .= filepath
+        ]

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -76,7 +76,10 @@ instance ToJSON DisplayInfo where
   toJSON (Info_InferredType doc) = object [ "kind" .= String "InferredType", "payload" .= render doc ]
   toJSON (Info_Context doc) = object [ "kind" .= String "Context", "payload" .= render doc ]
   toJSON (Info_HelperFunction doc) = object [ "kind" .= String "HelperFunction", "payload" .= render doc ]
-  toJSON Info_Version = object [ "kind" .= String "Version" ]
+  toJSON Info_Version = object
+    [ "kind" .= String "Version"
+    , "version" .= (("Agda version " ++ versionWithCommitInfo) :: String)
+    ]
 
 -- | Convert Response to an JSON value for interactive editor frontends.
 jsonifyResponse :: Response -> IO ByteString

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -1,0 +1,215 @@
+-- {-# LANGUAGE CPP #-}
+
+module Agda.Interaction.JSONTop
+    ( jsonREPL
+    ) where
+import Control.Monad.State
+
+import Data.Char
+import qualified Data.List as List
+import Data.Maybe
+
+import System.IO
+
+import Agda.Utils.Monad
+import Agda.Utils.Maybe
+import Agda.Utils.Pretty
+import Agda.Utils.String
+
+import Agda.Syntax.Common
+
+import Agda.TypeChecking.Monad
+import qualified Agda.TypeChecking.Monad.Benchmark as Bench
+
+import Agda.Interaction.Response as R
+import Agda.Interaction.InteractionTop
+import Agda.Interaction.EmacsCommand hiding (putResponse)
+import Agda.Interaction.Highlighting.Emacs
+import Agda.Interaction.Highlighting.Precise (TokenBased(..))
+import Agda.Interaction.Options
+
+import Agda.VersionCommit
+
+----------------------------------
+
+-- | 'mimicGHCi' is a fake ghci interpreter for the Emacs frontend
+--   and for interaction tests.
+--
+--   'mimicGHCi' reads the Emacs frontend commands from stdin,
+--   interprets them and print the result into stdout.
+
+jsonREPL :: TCM () -> TCM ()
+jsonREPL setup = do
+    liftIO $ do
+      hSetBuffering stdout LineBuffering
+      hSetBuffering stdin  LineBuffering
+      hSetEncoding  stdout utf8
+      hSetEncoding  stdin  utf8
+
+    setInteractionOutputCallback $
+        mapM_ print <=< lispifyResponse
+
+    commands <- liftIO $ initialiseCommandQueue readCommand
+
+    handleCommand_ (lift setup) `evalStateT` initCommandState commands
+
+    opts <- commandLineOptions
+    _ <- interact' `runStateT`
+           (initCommandState commands)
+             { optionsOnReload = opts{ optAbsoluteIncludePaths = [] } }
+    return ()
+  where
+  interact' :: CommandM ()
+  interact' = do
+    Bench.reset
+    done <- Bench.billTo [] $ do
+
+      liftIO $ do
+        putStr "JSON> "
+        hFlush stdout
+      c <- nextCommand
+      case c of
+        Done      -> return True -- Done.
+        Error s   -> liftIO (putStrLn s) >> return False
+        Command c -> do
+          maybeAbort (runInteraction c)
+          return False
+
+    lift Bench.print
+    unless done interact'
+
+  -- Reads the next command from stdin.
+
+  readCommand :: IO Command
+  readCommand = do
+    done <- isEOF
+    if done then
+      return Done
+    else do
+      r <- getLine
+      _ <- return $! length r     -- force to read the full input line
+      case dropWhile isSpace r of
+        ""          -> readCommand
+        ('-':'-':_) -> readCommand
+        _           -> case listToMaybe $ reads r of
+          Just (x, "")  -> return $ Command x
+          Just (_, rem) -> return $ Error $ "not consumed: " ++ rem
+          _             -> return $ Error $ "cannot read: " ++ r
+
+-- | Given strings of goals, warnings and errors, return a pair of the
+--   body and the title for the info buffer
+formatWarningsAndErrors :: String -> String -> String -> (String, String)
+formatWarningsAndErrors g w e = (body, title)
+  where
+    isG = not $ null g
+    isW = not $ null w
+    isE = not $ null e
+    title = List.intercalate "," $ catMaybes
+              [ " Goals"    <$ guard isG
+              , " Warnings" <$ guard isW
+              , " Errors"   <$ guard isE
+              , " Done"     <$ guard (not (isG || isW || isE))
+              ]
+
+    body = List.intercalate "\n" $ catMaybes
+             [ g                    <$ guard isG
+             , delimiter "Warnings" <$ guard (isW && (isG || isE))
+             , w                    <$ guard isW
+             , delimiter "Errors"   <$ guard (isE && (isG || isW))
+             , e                    <$ guard isE
+             ]
+
+-- | Convert Response to an elisp value for the interactive emacs frontend.
+
+lispifyResponse :: Response -> IO [Lisp String]
+lispifyResponse (Resp_HighlightingInfo info remove method modFile) =
+  (:[]) <$> lispifyHighlightingInfo info remove method modFile
+lispifyResponse (Resp_DisplayInfo info) = return $ case info of
+    Info_CompilationOk w e -> f body "*Compilation result*"
+      where (body, _) = formatWarningsAndErrors "The module was successfully compiled.\n" w e -- abusing the goals field since we ignore the title
+    Info_Constraints s -> f s "*Constraints*"
+    Info_AllGoalsWarnings g w e -> f body ("*All" ++ title ++ "*")
+      where (body, title) = formatWarningsAndErrors g w e
+    Info_Auto s -> f s "*Auto*"
+    Info_Error s -> f s "*Error*"
+    -- FNF: if Info_Warning comes back into use, the above should be
+    -- clearWarning : f s "*Error*"
+    --Info_Warning s -> [ display_warning "*Errors*" s ] -- FNF: currently unused
+    Info_Time s -> f (render s) "*Time*"
+    Info_NormalForm s -> f (render s) "*Normal Form*"   -- show?
+    Info_InferredType s -> f (render s) "*Inferred Type*"
+    Info_CurrentGoal s -> f (render s) "*Current Goal*"
+    Info_GoalType s -> f (render s) "*Goal type etc.*"
+    Info_ModuleContents s -> f (render s) "*Module contents*"
+    Info_SearchAbout s -> f (render s) "*Search About*"
+    Info_WhyInScope s -> f (render s) "*Scope Info*"
+    Info_Context s -> f (render s) "*Context*"
+    Info_HelperFunction s -> [ L [ A "agda2-info-action-and-copy"
+                                 , A $ quote "*Helper function*"
+                                 , A $ quote (render s ++ "\n")
+                                 , A "nil"
+                                 ]
+                             ]
+    Info_Intro s -> f (render s) "*Intro*"
+    Info_Version -> f ("Agda version " ++ versionWithCommitInfo) "*Agda Version*"
+  where f content bufname = [ display_info' False bufname content ]
+lispifyResponse (Resp_ClearHighlighting tokenBased) =
+  return [ L $ A "agda2-highlight-clear" :
+               case tokenBased of
+                 NotOnlyTokenBased -> []
+                 TokenBased        ->
+                   [ Q (lispifyTokenBased tokenBased) ]
+         ]
+lispifyResponse Resp_DoneAborting = return [ L [ A "agda2-abort-done" ] ]
+lispifyResponse Resp_ClearRunningInfo = return [ clearRunningInfo ]
+-- FNF: if Info_Warning comes back into use, the above should be
+-- return [ clearRunningInfo, clearWarning ]
+lispifyResponse (Resp_RunningInfo n s)
+  | n <= 1    = return [ displayRunningInfo s ]
+  | otherwise = return [ L [A "agda2-verbose", A (quote s)] ]
+lispifyResponse (Resp_Status s)
+    = return [ L [ A "agda2-status-action"
+                 , A (quote $ List.intercalate "," $ catMaybes [checked, showImpl])
+                 ]
+             ]
+  where
+    checked  = boolToMaybe (sChecked               s) "Checked"
+    showImpl = boolToMaybe (sShowImplicitArguments s) "ShowImplicit"
+
+lispifyResponse (Resp_JumpToError f p) = return
+  [ lastTag 3 $
+      L [ A "agda2-maybe-goto", Q $ L [A (quote f), A ".", A (show p)] ]
+  ]
+lispifyResponse (Resp_InteractionPoints is) = return
+  [ lastTag 1 $
+      L [A "agda2-goals-action", Q $ L $ map showNumIId is]
+  ]
+lispifyResponse (Resp_GiveAction ii s)
+    = return [ L [ A "agda2-give-action", showNumIId ii, A s' ] ]
+  where
+    s' = case s of
+        Give_String str -> quote str
+        Give_Paren      -> "'paren"
+        Give_NoParen    -> "'no-paren"
+lispifyResponse (Resp_MakeCase variant pcs) = return
+  [ lastTag 2 $ L [ A cmd, Q $ L $ map (A . quote) pcs ] ]
+  where
+  cmd = case variant of
+    R.Function       -> "agda2-make-case-action"
+    R.ExtendedLambda -> "agda2-make-case-action-extendlam"
+lispifyResponse (Resp_SolveAll ps) = return
+  [ lastTag 2 $
+      L [ A "agda2-solveAll-action", Q . L $ concatMap prn ps ]
+  ]
+  where
+    prn (ii,e)= [showNumIId ii, A $ quote $ show e]
+
+-- | Adds a \"last\" tag to a response.
+
+lastTag :: Integer -> Lisp String -> Lisp String
+lastTag n r = Cons (Cons (A "last") (A $ show n)) r
+
+-- | Show an iteraction point identifier as an elisp expression.
+
+showNumIId :: InteractionId -> Lisp String
+showNumIId = A . tail . show

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -298,10 +298,8 @@ type Flag opts = opts -> OptM opts
 
 checkOpts :: Flag CommandLineOptions
 checkOpts opts
-  | not (matches [optGHCiInteraction, isJust . optInputFile] <= 1) =
-      throwError "Choose at most one: input file or --interaction.\n"
-  | not (matches [optJSONInteraction, isJust . optInputFile] <= 1) =
-      throwError "Choose at most one: input file or --interaction-json.\n"
+  | not (matches [optGHCiInteraction, optJSONInteraction, isJust . optInputFile] <= 1) =
+      throwError "Choose at most one: input file, --interactive, or --interaction-json.\n"
   | or [ p opts && matches ps > 1 | (p, ps) <- exclusive ] =
       throwError exclusiveMessage
   | otherwise = return opts

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -106,6 +106,7 @@ data CommandLineOptions = Options
   , optShowHelp         :: Maybe Help
   , optInteractive      :: Bool
   , optGHCiInteraction  :: Bool
+  , optJSONInteraction  :: Bool
   , optOptimSmashing    :: Bool
   , optCompileDir       :: Maybe FilePath
   -- ^ In the absence of a path the project root is used.
@@ -209,6 +210,7 @@ defaultOptions = Options
   , optShowHelp         = Nothing
   , optInteractive      = False
   , optGHCiInteraction  = False
+  , optJSONInteraction  = False
   , optOptimSmashing    = True
   , optCompileDir       = Nothing
   , optGenerateVimFile  = False
@@ -298,6 +300,8 @@ checkOpts :: Flag CommandLineOptions
 checkOpts opts
   | not (matches [optGHCiInteraction, isJust . optInputFile] <= 1) =
       throwError "Choose at most one: input file or --interaction.\n"
+  | not (matches [optJSONInteraction, isJust . optInputFile] <= 1) =
+      throwError "Choose at most one: input file or --interaction-json.\n"
   | or [ p opts && matches ps > 1 | (p, ps) <- exclusive ] =
       throwError exclusiveMessage
   | otherwise = return opts
@@ -322,10 +326,13 @@ checkOpts opts
     , ( optGHCiInteraction
       , optGenerateLaTeX : atMostOne
       )
+    , ( optJSONInteraction
+      , optGenerateLaTeX : atMostOne
+      )
     ]
 
   exclusiveMessage = unlines $
-    [ "The options --interactive, --interaction and"
+    [ "The options --interactive, --interaction, --interaction-json and"
     , "--only-scope-checking cannot be combined with each other or"
     , "with --html or --dependency-graph. Furthermore"
     , "--interactive and --interaction cannot be combined with"
@@ -413,6 +420,9 @@ asciiOnlyFlag o = do
 
 ghciInteractionFlag :: Flag CommandLineOptions
 ghciInteractionFlag o = return $ o { optGHCiInteraction = True }
+
+jsonInteractionFlag :: Flag CommandLineOptions
+jsonInteractionFlag o = return $ o { optJSONInteraction = True }
 
 vimFlag :: Flag CommandLineOptions
 vimFlag o = return $ o { optGenerateVimFile = True }
@@ -610,6 +620,8 @@ standardOptions =
                     "start in interactive mode"
     , Option []     ["interaction"] (NoArg ghciInteractionFlag)
                     "for use with the Emacs mode"
+    , Option []     ["interaction-json"] (NoArg jsonInteractionFlag)
+                    "for use with other editors such as Atom"
 
     , Option []     ["compile-dir"] (ReqArg compileDirFlag "DIR")
                     ("directory for compiler output (default: the project root)")

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -21,6 +21,7 @@ import Agda.Interaction.Options
 import Agda.Interaction.Options.Help (Help (..))
 import Agda.Interaction.Monad
 import Agda.Interaction.EmacsTop (mimicGHCi)
+import Agda.Interaction.JSONTop (jsonREPL)
 import Agda.Interaction.Imports (MaybeWarnings'(..))
 import qualified Agda.Interaction.Imports as Imp
 import qualified Agda.Interaction.Highlighting.Dot as Dot
@@ -78,10 +79,12 @@ defaultInteraction :: CommandLineOptions -> TCM (Maybe Interface) -> TCM ()
 defaultInteraction opts
   | i         = runIM . interactionLoop
   | ghci      = mimicGHCi . (failIfInt =<<)
+  | json      = jsonREPL . (failIfInt =<<)
   | otherwise = (() <$)
   where
     i    = optInteractive     opts
     ghci = optGHCiInteraction opts
+    json = optJSONInteraction opts
 
     failIfInt Nothing  = return ()
     failIfInt (Just _) = __IMPOSSIBLE__
@@ -101,6 +104,7 @@ runAgdaWithOptions backends generateHTML interaction progName opts
       | isNothing (optInputFile opts)
           && not (optInteractive opts)
           && not (optGHCiInteraction opts)
+          && not (optJSONInteraction opts)
                             = Nothing <$ liftIO (printUsage backends GeneralHelp)
       | otherwise           = do
           -- Main function.

--- a/src/full/Agda/Utils/IO/TempFile.hs
+++ b/src/full/Agda/Utils/IO/TempFile.hs
@@ -1,0 +1,19 @@
+-- | Common syntax highlighting functions for Emacs and JSON
+
+module Agda.Utils.IO.TempFile
+  ( writeToTempFile
+  ) where
+
+import qualified Agda.Utils.IO.UTF8 as UTF8
+
+import qualified Control.Exception as E
+import qualified System.Directory as D
+import qualified System.IO as IO
+
+-- | Creates a temporary file, writes some stuff, and returns the filepath
+writeToTempFile :: String -> IO FilePath
+writeToTempFile content = do
+  dir      <- D.getTemporaryDirectory
+  E.bracket (IO.openTempFile dir "agda2-mode") (IO.hClose . snd) $ \ (filepath, handle) -> do
+    UTF8.hPutStr handle content
+    return filepath

--- a/test/Fail/Interaction-and-input-file.err
+++ b/test/Fail/Interaction-and-input-file.err
@@ -1,3 +1,3 @@
-Error: Choose at most one: input file or --interaction.
+Error: Choose at most one: input file, --interactive, or --interaction-json.
 
 Run 'agda --help' for help on command line options.

--- a/test/Fail/Safe-flag-only-scope-checking-1.err
+++ b/test/Fail/Safe-flag-only-scope-checking-1.err
@@ -1,5 +1,5 @@
-The options --interactive, --interaction and --only-scope-checking
-cannot be combined with each other or with --html or
---dependency-graph. Furthermore --interactive and --interaction
-cannot be combined with --latex, and --only-scope-checking cannot
-be combined with --safe or --vim.
+The options --interactive, --interaction, --interaction-json and
+--only-scope-checking cannot be combined with each other or with
+--html or --dependency-graph. Furthermore --interactive and
+--interaction cannot be combined with --latex, and
+--only-scope-checking cannot be combined with --safe or --vim.

--- a/test/Fail/Safe-flag-only-scope-checking-2.err
+++ b/test/Fail/Safe-flag-only-scope-checking-2.err
@@ -1,4 +1,4 @@
-Error: The options --interactive, --interaction and
+Error: The options --interactive, --interaction, --interaction-json and
 --only-scope-checking cannot be combined with each other or
 with --html or --dependency-graph. Furthermore
 --interactive and --interaction cannot be combined with


### PR DESCRIPTION
This PR adds a new flag `--interaction-json` for Agda to **output interactions in JSON format**.

----

Emacs was the sole editor for interacting with Agda, but things have changed as people are also trying to interact with Agda with other editors such as [*Atom (agda-mode)*](https://github.com/banacorn/agda-mode) and [*Vim (agda-vim)*](https://github.com/derekelkins/agda-vim).

To interact with Agda, an editor would have to 
1. send a request in the format of some Haskell data value (`IOTCM`) to Agda. (*easy*)
2. receive several responses in the format of **Emacs Lisp** from Agda. (*hard!!!!*)

AFAIK the protocol is not officially documented. It takes quite some effort to [reverse engineer](https://github.com/banacorn/agda-mode/wiki/Conversations-between-Agda-&-agda-mode) and emulate such a protocol, and deciphering those Emacs Lisp messages was the most tricky part.

----

This PR:
* adds a new module `Agda.Interaction.JSONTop` as the counterpart of `Agda.Interaction.EmacsTop` as suggested by @nad in https://github.com/agda/agda/issues/3113#issuecomment-395373758.
* adds `Aeson` as a dependency for JSON encoding support.
* modifies some other files to enable the `--interaction-json` flag.