### PR TITLE
[ resp ] Include the interaction callback in TCM

### DIFF
--- a/src/full/Agda/Interaction/EmacsTop.hs
+++ b/src/full/Agda/Interaction/EmacsTop.hs
@@ -30,7 +30,7 @@ import Agda.VersionCommit
 --   'mimicGHCi' reads the Emacs frontend commands from stdin,
 --   interprets them and print the result into stdout.
 mimicGHCi :: TCM () -> TCM ()
-mimicGHCi = repl (mapM_ print <=< lispifyResponse) "Agda2> "
+mimicGHCi = repl (liftIO . mapM_ print <=< liftIO . lispifyResponse) "Agda2> "
 
 -- | Given strings of goals, warnings and errors, return a pair of the
 --   body and the title for the info buffer

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -27,7 +27,7 @@ import Agda.VersionCommit
 --   interprets them, and outputs JSON-encoded strings. into stdout.
 
 jsonREPL :: TCM () -> TCM ()
-jsonREPL = repl (BS.putStrLn <=< jsonifyResponse) "JSON> "
+jsonREPL = repl (liftIO . BS.putStrLn <=< liftIO . jsonifyResponse) "JSON> "
 
 instance ToJSON Status where
   toJSON status = object

--- a/src/full/Agda/Interaction/Response.hs
+++ b/src/full/Agda/Interaction/Response.hs
@@ -139,7 +139,7 @@ data GiveResult
 --      closure of the 'InteractionOutputCallback' function.
 --      (suitable for intra-process communication).
 
-type InteractionOutputCallback = Response -> IO ()
+type InteractionOutputCallback = Response -> TCM ()
 
 -- | The default 'InteractionOutputCallback' function prints certain
 -- things to stdout (other things generate internal errors).

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -43,7 +43,7 @@ instance (MonadIO m) => MonadDebug (TCMT m) where
 
   displayDebugMessage n s = liftTCM $ do
     cb <- gets $ stInteractionOutputCallback . stPersistentState
-    liftIO $ cb (Resp_RunningInfo n s)
+    cb (Resp_RunningInfo n s)
 
   formatDebugMessage k n d = liftTCM $
     show <$> d `catchError` \ err ->

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -356,7 +356,7 @@ getInteractionOutputCallback
 
 appInteractionOutputCallback :: Response -> TCM ()
 appInteractionOutputCallback r
-  = getInteractionOutputCallback >>= \ cb -> liftIO $ cb r
+  = getInteractionOutputCallback >>= \ cb -> cb r
 
 setInteractionOutputCallback :: InteractionOutputCallback -> TCM ()
 setInteractionOutputCallback cb


### PR DESCRIPTION
The datatype `Response` are made and assembled inside TCM,
before being converted into Lisp or JSON in the IO monad.

```
  +-----------------------------------------------------+
  | IO                                                  |
  |  +----------------+                  lispify        |
  |  | TCM            |                +--------> Lisp  |
  |  |  Interaction ----> Response ----|                |
  |  |                |                +--------> JSON  |
  |  +----------------+                  jsonify        |
  |                                                     |
  +-----------------------------------------------------+
```

However, many of the information carried by `Response` are formatted as
Strings in TCM (for Emacs consumpiton). This makes it diffucult for
other editors to analyse and reconstruct those information.

And it seems like those strings can ONLY be assembled and formatted in
TCM because there are too many states that has to be accessed on demand.
(see `PrettyTCM` for example).

One solution is to specialise `Reponse`. Let everyone decide what they
want to encode inside TCM. But I don't think this is a good idea :|

```
  +-----------------------------------------------------+
  | IO                                                  |
  |  +----------------+                                 |
  |  | TCM            |                 lispify         |
  |  |  Interaction +---> LispResponse +--------> Lisp  |
  |  |              | |                                 |
  |  |              | |                 jsonify         |
  |  |              +---> JSONResponse +--------> JSON  |
  |  |                |                                 |
  |  +----------------+                                 |
  |                                                     |
  +-----------------------------------------------------+
```

Another way is to simply extend the scope of TCM to cover the formatting
process like this:

```
  +-----------------------------------------------------+
  | TCM                                                 |
  |                                      lispify        |
  |                                    +--------> Lisp  |
  |     Interaction ----> Response ----|                |
  |                                    +--------> JSON  |
  |                                      jsonify        |
  |                                                     |
  +-----------------------------------------------------+
```
This PR implements the latter solution because I think it looks more
reasonable, and it's also surprisingly easy to implement.
Only 5 lines of code is modified and the impact on the codebase is
minimum.

---

I guess the reason why the lispify process was done in the IO monad in
the first place is that, we want to prevent it from messing with the
states inside TCM ?
I think perhaps we can prevent that from happening but also being able
to access those states by wrapping it in another reader-only monad,
but I'm not sure if it's worth it.

```
  +-------------------+---------------------------------+
  | TCM               | TCM' (read-only)                |
  |                   |                  lispify        |
  |                   |                +--------> Lisp  |
  |     Interaction ----> Response ----|                |
  |                   |                +--------> JSON  |
  |                   |                  jsonify        |
  |                   |                                 |
  +-----------------------+-----------------------------+
```