### PR TITLE
[ refactor ] TCM is now a MonadTCEnv and MonadTCState

### DIFF
--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -92,7 +92,7 @@ data Recompile menv mod = Recompile menv | Skip mod
 
 callBackend :: String -> IsMain -> Interface -> TCM ()
 callBackend name iMain i = do
-  backends <- use stBackends
+  backends <- useTC stBackends
   case [ b | b@(Backend b') <- backends, backendName b' == name ] of
     Backend b : _ -> compilerMain b iMain i
     []            -> genericError $
@@ -156,7 +156,7 @@ backendInteraction backends _ check = do
   mi     <- check
 
   -- reset warnings
-  stTCWarnings .= []
+  stTCWarnings `setTCLens` []
 
   noMain <- optCompileNoMain <$> pragmaOptions
   let isMain | noMain    = NotMain

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -166,7 +166,7 @@ ghcPreModule _ m ifile = ifM uptodate noComp yesComp
       m   <- show . A.mnameToConcrete <$> curMName
       out <- outFile_
       reportSLn "compile.ghc" 1 $ repl [m, ifile, out] "Compiling <<0>> in <<1>> to <<2>>"
-      stImportedModules .= Set.empty  -- we use stImportedModules to accumulate the required Haskell imports
+      stImportedModules `setTCLens` Set.empty  -- we use stImportedModules to accumulate the required Haskell imports
       return (Recompile ())
 
 ghcPostModule :: GHCOptions -> GHCModuleEnv -> IsMain -> ModuleName -> [[HS.Decl]] -> TCM IsMain
@@ -215,7 +215,7 @@ imports = (hsImps ++) <$> imps where
   decl m = HS.ImportDecl m True Nothing
 
   mnames :: TCM [ModuleName]
-  mnames = Set.elems <$> use stImportedModules
+  mnames = Set.elems <$> useTC stImportedModules
 
   uniq :: [HS.ModuleName] -> [HS.ModuleName]
   uniq = List.map head . List.group . List.sort

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -115,7 +115,7 @@ importsForPrim =
 xForPrim :: [(String, TCM [a])] -> TCM [a]
 xForPrim table = do
   qs <- HMap.keys <$> curDefs
-  bs <- toList <$> gets stBuiltinThings
+  bs <- toList <$> getsTC stBuiltinThings
   let getName (Builtin (Def q _))    = q
       getName (Builtin (Con q _ _))  = conName q
       getName (Builtin (Lam _ b))    = getName (Builtin $ unAbs b)

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -122,7 +122,7 @@ giveExpr force mii mi e = do
         v <- checkExpr e t'
         case mvInstantiation mv of
 
-          InstV xs v' -> unlessM ((Irrelevant ==) <$> asks envRelevance) $ do
+          InstV xs v' -> unlessM ((Irrelevant ==) <$> asksTC envRelevance) $ do
             reportSDoc "interaction.give" 20 $ TP.sep
               [ TP.text "meta was already set to value v' = " TP.<+> prettyTCM v'
                 TP.<+> TP.text " with free variables " TP.<+> return (fsep $ map pretty xs)
@@ -169,7 +169,7 @@ redoChecks (Just ii) = do
     IPNoClause -> return ()
     IPClause f _ _ -> do
       mb <- mutualBlockOf f
-      terErrs <- local (\ e -> e { envMutualBlock = Just mb }) $ termMutual []
+      terErrs <- localTC (\ e -> e { envMutualBlock = Just mb }) $ termMutual []
       unless (null terErrs) $ warning $ TerminationIssue terErrs
   -- TODO redo positivity check!
 
@@ -657,7 +657,7 @@ metaHelperType norm ii rng s = case words s of
       TelV atel _ <- telView a
       let arity = size atel
           (delta1, delta2, _, a', as', vs') = splitTelForWith tel a (map OtherType as) vs
-      a <- local (\e -> e { envPrintDomainFreePi = True }) $ do
+      a <- localTC (\e -> e { envPrintDomainFreePi = True }) $ do
         reify =<< cleanupType arity args =<< normalForm norm =<< fst <$> withFunctionType delta1 vs' as' delta2 a'
       reportSDoc "interaction.helper" 10 $ TP.vcat
         [ TP.text "generating helper function"
@@ -770,7 +770,7 @@ contextOfMeta ii norm = do
         mkLet (x, lb) = do
           (tm, !dom) <- getOpen lb
           return $ (,) x <$> dom
-    letVars <- mapM mkLet . Map.toDescList =<< asks envLetBindings
+    letVars <- mapM mkLet . Map.toDescList =<< asksTC envLetBindings
     mapMaybe visible . reverse <$> mapM out (letVars ++ localVars)
   where visible (OfType x y) | not (isNoName x) = Just (OfType' x y)
                              | otherwise        = Nothing
@@ -903,7 +903,7 @@ introTactic pmLambda ii = do
 atTopLevel :: TCM a -> TCM a
 atTopLevel m = inConcreteMode $ do
   let err = typeError $ GenericError "The file has not been loaded yet."
-  caseMaybeM (use stCurrentModule) err $ \ current -> do
+  caseMaybeM (useTC stCurrentModule) err $ \ current -> do
     caseMaybeM (getVisitedModule $ toTopLevelModuleName current) __IMPOSSIBLE__ $ \ mi -> do
       let scope = iInsideScope $ miInterface mi
       tel <- lookupSection current
@@ -944,8 +944,8 @@ atTopLevel m = inConcreteMode $ do
           addContext gamma $ do
             -- We're going inside the top-level module, so we have to set the
             -- checkpoint for it and all its submodules to the new checkpoint.
-            cp <- view eCurrentCheckpoint
-            stModuleCheckpoints %= fmap (const cp)
+            cp <- viewTC eCurrentCheckpoint
+            stModuleCheckpoints `modifyTCLens` fmap (const cp)
             m
 
 -- | Parse a name.

--- a/src/full/Agda/Interaction/CommandLine.hs
+++ b/src/full/Agda/Interaction/CommandLine.hs
@@ -52,7 +52,7 @@ interaction prompt cmds eval = loop
     where
         go (Return x)       = return x
         go Continue         = loop
-        go (ContinueIn env) = local (const env) loop
+        go (ContinueIn env) = localTC (const env) loop
 
         loop =
             do  ms <- readline prompt
@@ -101,7 +101,7 @@ interactionLoop doTypeCheck =
             [ "quit"        |>  \_ -> return $ Return ()
             , "?"           |>  \_ -> continueAfter $ liftIO $ help commands
             , "reload"      |>  \_ -> do reload
-                                         ContinueIn <$> ask
+                                         ContinueIn <$> askTC
             , "constraints" |> \args -> continueAfter $ showConstraints args
             , "Context"     |> \args -> continueAfter $ showContext args
             , "give"        |> \args -> continueAfter $ giveMeta args
@@ -125,7 +125,7 @@ continueAfter m = withCurrentFile $ do
 withCurrentFile :: TCM a -> TCM a
 withCurrentFile cont = do
   mpath <- getInputFile'
-  local (\ e -> e { envCurrentPath = mpath }) cont
+  localTC (\ e -> e { envCurrentPath = mpath }) cont
 
 loadFile :: TCM () -> [String] -> TCM ()
 loadFile reload [file] = do

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -100,9 +100,9 @@ findFile m = do
 findFile' :: TopLevelModuleName -> TCM (Either FindError AbsolutePath)
 findFile' m = do
     dirs         <- getIncludeDirs
-    modFile      <- use stModuleToSource
+    modFile      <- useTC stModuleToSource
     (r, modFile) <- liftIO $ findFile'' dirs m modFile
-    stModuleToSource .= modFile
+    stModuleToSource `setTCLens` modFile
     return r
 
 -- | A variant of 'findFile'' which does not require 'TCM'.

--- a/src/full/Agda/Interaction/Highlighting/HTML.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML.hs
@@ -52,7 +52,7 @@ import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Common
 import Agda.Syntax.Abstract.Name (ModuleName)
 
-import Agda.TypeChecking.Monad (TCM)
+import Agda.TypeChecking.Monad (TCM, useTC)
 import qualified Agda.TypeChecking.Monad as TCM
 
 import Agda.Utils.FileName (filePath)
@@ -134,7 +134,7 @@ generatePage
   -> C.TopLevelModuleName  -- ^ Module to be highlighted.
   -> TCM ()
 generatePage renderpage dir mod = do
-  f <- fromMaybe __IMPOSSIBLE__ . Map.lookup mod <$> use TCM.stModuleToSource
+  f <- fromMaybe __IMPOSSIBLE__ . Map.lookup mod <$> useTC TCM.stModuleToSource
   contents <- liftIO $ UTF8.readTextFile $ filePath f
   css      <- fromMaybe defaultCSSFile . optCSSFile <$>
                 TCM.commandLineOptions

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -162,16 +162,16 @@ type CommandM = StateT CommandState TCM
 localStateCommandM :: CommandM a -> CommandM a
 localStateCommandM m = do
   cSt <- get
-  tcSt <- lift $ get
+  tcSt <- getTC
   x <- m
-  lift $ put tcSt
+  putTC tcSt
   put cSt
   return x
 
 -- | Restore 'TCState', do not touch 'CommandState'.
 
 liftLocalState :: TCM a -> CommandM a
-liftLocalState = lift . localState
+liftLocalState = lift . localTCState
 
 -- | Build an opposite action to 'lift' for state monads.
 
@@ -186,11 +186,22 @@ revLift run lift f = do
     put st
     return a
 
+revLiftTC
+    :: MonadTCState m
+    => (forall c . m c -> TCState -> k (c, TCState))  -- ^ run
+    -> (forall b . k b -> m b)                        -- ^ lift
+    -> (forall x . (m a -> k x) -> k x) -> m a        -- ^ reverse lift in double negative position
+revLiftTC run lift f = do
+    st <- getTC
+    (a, st) <- lift $ f (`run` st)
+    putTC st
+    return a
+
 -- | Opposite of 'liftIO' for 'CommandM'.
 --   Use only if main errors are already catched.
 
 commandMToIO :: (forall x . (CommandM a -> IO x) -> IO x) -> CommandM a
-commandMToIO ci_i = revLift runStateT lift $ \ct -> revLift runSafeTCM liftIO $ ci_i . (. ct)
+commandMToIO ci_i = revLift runStateT lift $ \ct -> revLiftTC runSafeTCM liftIO $ ci_i . (. ct)
 
 -- | Lift a TCM action transformer to a CommandM action transformer.
 
@@ -246,7 +257,7 @@ handleCommand_ = handleCommand id (return ())
 
 handleCommand :: (forall a. CommandM a -> CommandM a) -> CommandM () -> CommandM () -> CommandM ()
 handleCommand wrap onFail cmd = handleNastyErrors $ wrap $ do
-    oldState <- lift get
+    oldState <- getTC
 
     -- -- Andreas, 2016-11-18 OLD CODE:
     -- -- onFail and handleErr are executed in "new" command state (not TCState).
@@ -264,9 +275,9 @@ handleCommand wrap onFail cmd = handleNastyErrors $ wrap $ do
       -- Andreas, 2016-11-18, issue #2174
       -- Reset TCState after error is handled, to get rid of metas created during failed command
       lift $ do
-        newPersistentState <- use lensPersistentState
-        put oldState
-        lensPersistentState .= newPersistentState
+        newPersistentState <- useTC lensPersistentState
+        putTC oldState
+        lensPersistentState `setTCLens` newPersistentState
 
   where
     -- Preserves state so we can do unsolved meta highlighting
@@ -305,8 +316,8 @@ handleCommand wrap onFail cmd = handleNastyErrors $ wrap $ do
         meta    <- lift $ computeUnsolvedMetaWarnings
         constr  <- lift $ computeUnsolvedConstraints
         err     <- lift $ errorHighlighting e
-        modFile <- lift $ use stModuleToSource
-        method  <- lift $ view eHighlightingMethod
+        modFile <- lift $ useTC stModuleToSource
+        method  <- lift $ viewTC eHighlightingMethod
         let info = compress $ mconcat $
                      -- Errors take precedence over unsolved things.
                      err : if unsolvedNotOK then [meta, constr] else []
@@ -317,7 +328,7 @@ handleCommand wrap onFail cmd = handleNastyErrors $ wrap $ do
                                             : filter (not . null) s2
                                             ++ [delimiter "Error"]
         let str     = if null s2 then strErr else strWarn ++ "\n" ++ strErr
-        x <- lift $ optShowImplicit <$> use stPragmaOptions
+        x <- lift $ optShowImplicit <$> useTC stPragmaOptions
         unless (null s1) $ mapM_ putResponse $
             [ Resp_DisplayInfo $ Info_Error str ] ++
             tellEmacsToJumpToError (getRange e) ++
@@ -396,17 +407,17 @@ nextCommand =
 maybeAbort :: CommandM () -> CommandM ()
 maybeAbort c = do
   commandState <- get
-  tcState      <- lift get
-  tcEnv        <- lift ask
+  tcState      <- getTC
+  tcEnv        <- askTC
   result       <- liftIO $ race
                     (runTCM tcEnv tcState $ runStateT c commandState)
                     (waitForAbort $ commandQueue commandState)
   case result of
     Left (((), commandState), tcState) -> do
-      lift $ put tcState
+      putTC tcState
       put commandState
     Right () -> do
-      lift $ put $ initState
+      putTC $ initState
         { stPersistentState = stPersistentState tcState
         , stPreScopeState   =
             (stPreScopeState initState)
@@ -829,7 +840,7 @@ interpret ToggleImplicitArgs = do
              ps { optShowImplicit = not $ optShowImplicit ps } }
 
 interpret (Cmd_load_highlighting_info source) = do
-  l <- envHighlightingLevel <$> ask
+  l <- asksTC envHighlightingLevel
   when (l /= None) $ do
     -- Make sure that the include directories have
     -- been set.
@@ -851,15 +862,15 @@ interpret (Cmd_load_highlighting_info source) = do
               sourceH <- liftIO $ hashFile absSource
               if sourceH == iSourceHash (miInterface mi)
                then do
-                modFile <- use stModuleToSource
-                method  <- view eHighlightingMethod
+                modFile <- useTC stModuleToSource
+                method  <- viewTC eHighlightingMethod
                 return $ Just (iHighlighting $ miInterface mi, method, modFile)
                else
                 return Nothing
     mapM_ putResponse resp
 
 interpret (Cmd_tokenHighlighting source remove) = do
-  info <- do l <- envHighlightingLevel <$> ask
+  info <- do l <- asksTC envHighlightingLevel
              if l == None
                then return Nothing
                else do
@@ -876,7 +887,7 @@ interpret (Cmd_tokenHighlighting source remove) = do
     Nothing   -> return ()
 
 interpret (Cmd_highlight ii rng s) = do
-  l <- envHighlightingLevel <$> ask
+  l <- asksTC envHighlightingLevel
   when (l /= None) $ do
     scope <- getOldInteractionScope ii
     removeOldInteractionScope ii
@@ -926,7 +937,7 @@ interpret (Cmd_auto ii rng s) = do
   -- Andreas, 2014-07-05 Issue 1226:
   -- Save the state to have access to even those interaction ids
   -- that Auto solves (since Auto gives the solution right away).
-  st <- lift $ get
+  st <- getTC
   (time , res) <- maybeTimed $ lift $ Auto.auto ii rng s
   case autoProgress res of
    Solutions sols -> do
@@ -936,7 +947,7 @@ interpret (Cmd_auto ii rng s) = do
       -- For highlighting, Resp_GiveAction needs to access
       -- the @oldInteractionScope@s of the interaction points solved by Auto.
       -- We dig them out from the state before Auto was invoked.
-      insertOldInteractionScope ii =<< liftLocalState (put st >> getInteractionScope ii)
+      insertOldInteractionScope ii =<< liftLocalState (putTC st >> getInteractionScope ii)
       -- Andreas, 2014-07-07: NOT TRUE:
       -- -- Andreas, 2014-07-05: The following should be obsolete,
       -- -- as Auto has removed the interaction points already:
@@ -1077,7 +1088,7 @@ interpretWarnings = do
 solveInstantiatedGoals :: B.Rewrite -> Maybe InteractionId -> CommandM ()
 solveInstantiatedGoals norm mii = do
   -- Andreas, 2016-10-23 issue #2280: throw away meta elims.
-  out <- lift $ local (\ e -> e { envPrintMetasBare = True }) $ do
+  out <- lift $ localTC (\ e -> e { envPrintMetasBare = True }) $ do
     sip <- B.getSolvedInteractionPoints False norm
            -- only solve metas which have a proper instantiation, i.e., not another meta
     maybe id (\ ii -> filter ((ii ==) . fst)) mii <$> mapM prt sip
@@ -1136,9 +1147,9 @@ cmd_load' file argv unsolvedOK mode cmd = do
                    | otherwise = CurrentDir
 
     -- Forget the previous "current file" and interaction points.
-    modify $ \st -> st { theInteractionPoints = []
-                       , theCurrentFile       = Nothing
-                       }
+    modify $ \ st -> st { theInteractionPoints = []
+                        , theCurrentFile       = Nothing
+                        }
 
     t <- liftIO $ getModificationTime file
 
@@ -1184,7 +1195,7 @@ cmd_load' file argv unsolvedOK mode cmd = do
 withCurrentFile :: CommandM a -> CommandM a
 withCurrentFile m = do
   mfile <- fmap fst <$> gets theCurrentFile
-  local (\ e -> e { envCurrentPath = mfile }) m
+  localTC (\ e -> e { envCurrentPath = mfile }) m
 
 -- | Available backends.
 
@@ -1273,7 +1284,7 @@ give_gen force ii rng s0 giveRefine = do
     -- the highlighting is moved together with the text when the hole goes away.
     -- To make it work for refine we'd have to adjust the ranges.
     when literally $ lift $ do
-      l <- envHighlightingLevel <$> ask
+      l <- asksTC envHighlightingLevel
       when (l /= None) $ do
         printHighlightingInfo KeepHighlighting =<<
           generateTokenInfoFromString rng s
@@ -1294,7 +1305,7 @@ give_gen force ii rng s0 giveRefine = do
 
 highlightExpr :: A.Expr -> TCM ()
 highlightExpr e =
-  local (\e -> e { envModuleNestingLevel = 0
+  localTC (\e -> e { envModuleNestingLevel = 0
                  , envHighlightingLevel  = NonInteractive
                  , envHighlightingMethod = Direct }) $
     generateAndPrintSyntaxInfo decl Full True

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -97,7 +97,7 @@ parseVariables f tel ii rng ss = do
        , text $ "function's fvs  = " ++ show fv
        , text $ "number of locals= " ++ show nlocals
        , text "context         =" <+> do inTopContext $ prettyTCM cxt
-       , text "checkpoints     =" <+> do (text . show) =<< asks envCheckpoints
+       , text "checkpoints     =" <+> do (text . show) =<< asksTC envCheckpoints
        ]
 
     -- Resolve each string to a variable.
@@ -318,7 +318,7 @@ makeCase hole rng s = withInteractionId hole $ do
   -- In this case, we refuse to split, as this might lose the refinements.
   checkClauseIsClean :: IPClause -> TCM ()
   checkClauseIsClean ipCl = do
-    sips <- filter ipSolved . Map.elems <$> use stInteractionPoints
+    sips <- filter ipSolved . Map.elems <$> useTC stInteractionPoints
     when (List.any ((== ipCl) . ipClause) sips) $
       typeError $ GenericError $ "Cannot split as clause rhs has been refined.  Please reload"
 

--- a/src/full/Agda/Interaction/Options/Lenses.hs
+++ b/src/full/Agda/Interaction/Options/Lenses.hs
@@ -41,7 +41,7 @@ instance LensPragmaOptions TCState where
   lensPragmaOptions = stPragmaOptions
 
 modifyPragmaOptions :: (PragmaOptions -> PragmaOptions) -> TCM ()
-modifyPragmaOptions = modify . mapPragmaOptions
+modifyPragmaOptions = modifyTC . mapPragmaOptions
 
 ---------------------------------------------------------------------------
 -- ** Verbosity in the local pragma options
@@ -65,10 +65,10 @@ instance LensVerbosity TCState where
   mapVerbosity = mapPragmaOptions . mapVerbosity
 
 modifyVerbosity :: (Verbosity -> Verbosity) -> TCM ()
-modifyVerbosity = modify . mapVerbosity
+modifyVerbosity = modifyTC . mapVerbosity
 
 putVerbosity :: Verbosity -> TCM ()
-putVerbosity = modify . setVerbosity
+putVerbosity = modifyTC . setVerbosity
 
 ---------------------------------------------------------------------------
 -- * Command line options
@@ -92,7 +92,7 @@ instance LensCommandLineOptions TCState where
   mapCommandLineOptions = updatePersistentState . mapCommandLineOptions
 
 modifyCommandLineOptions :: (CommandLineOptions -> CommandLineOptions) -> TCM ()
-modifyCommandLineOptions = modify . mapCommandLineOptions
+modifyCommandLineOptions = modifyTC . mapCommandLineOptions
 
 ---------------------------------------------------------------------------
 -- ** Safe mode
@@ -126,10 +126,10 @@ instance LensSafeMode TCState where
   mapSafeMode = mapCommandLineOptions . mapSafeMode
 
 modifySafeMode :: (SafeMode -> SafeMode) -> TCM ()
-modifySafeMode = modify . mapSafeMode
+modifySafeMode = modifyTC . mapSafeMode
 
 putSafeMode :: SafeMode -> TCM ()
-putSafeMode = modify . setSafeMode
+putSafeMode = modifyTC . setSafeMode
 
 
 ---------------------------------------------------------------------------
@@ -170,16 +170,16 @@ instance LensIncludePaths TCState where
   mapAbsoluteIncludePaths = mapCommandLineOptions . mapAbsoluteIncludePaths
 
 modifyIncludePaths :: ([FilePath] -> [FilePath]) -> TCM ()
-modifyIncludePaths = modify . mapIncludePaths
+modifyIncludePaths = modifyTC . mapIncludePaths
 
 putIncludePaths :: [FilePath] -> TCM ()
-putIncludePaths = modify . setIncludePaths
+putIncludePaths = modifyTC . setIncludePaths
 
 modifyAbsoluteIncludePaths :: ([AbsolutePath] -> [AbsolutePath]) -> TCM ()
-modifyAbsoluteIncludePaths = modify . mapAbsoluteIncludePaths
+modifyAbsoluteIncludePaths = modifyTC . mapAbsoluteIncludePaths
 
 putAbsoluteIncludePaths :: [AbsolutePath] -> TCM ()
-putAbsoluteIncludePaths = modify . setAbsoluteIncludePaths
+putAbsoluteIncludePaths = modifyTC . setAbsoluteIncludePaths
 
 ---------------------------------------------------------------------------
 -- ** Include directories
@@ -212,7 +212,7 @@ instance LensPersistentVerbosity TCState where
   mapPersistentVerbosity = mapCommandLineOptions . mapPersistentVerbosity
 
 modifyPersistentVerbosity :: (PersistentVerbosity -> PersistentVerbosity) -> TCM ()
-modifyPersistentVerbosity = modify . mapPersistentVerbosity
+modifyPersistentVerbosity = modifyTC . mapPersistentVerbosity
 
 putPersistentVerbosity :: PersistentVerbosity -> TCM ()
-putPersistentVerbosity = modify . setPersistentVerbosity
+putPersistentVerbosity = modifyTC . setPersistentVerbosity

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -68,7 +68,7 @@ runAgda' backends = runTCMPrettyErrors $ do
   case opts of
     Left  err        -> liftIO $ optionError err
     Right (bs, opts) -> do
-      stBackends .= bs
+      setTCLens stBackends bs
       let enabled (Backend b) = isEnabled b (options b)
           bs' = filter enabled bs
       () <$ runAgdaWithOptions backends generateHTML (interaction bs') progName opts
@@ -121,7 +121,7 @@ runAgdaWithOptions backends generateHTML interaction progName opts
             Bench.print
 
             -- Print accumulated statistics.
-            printStatistics 1 Nothing =<< use lensAccumStatistics
+            printStatistics 1 Nothing =<< useTC lensAccumStatistics
   where
     checkFile = Just <$> do
       when (optInteractive opts) $ liftIO $ putStr splashScreen

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -173,7 +173,7 @@ termMutual names0 = ifNotM (optTerminationCheck <$> pragmaOptions) (return mempt
   -- Get set of mutually defined names from the TCM.
   -- This includes local and auxiliary functions introduced
   -- during type-checking.
-  mid <- fromMaybe __IMPOSSIBLE__ <$> asks envMutualBlock
+  mid <- fromMaybe __IMPOSSIBLE__ <$> asksTC envMutualBlock
   mutualBlock <- lookupMutualBlock mid
   let allNames = filter (not . isAbsurdLambdaName) $ Set.elems $ mutualNames mutualBlock
       names    = if null names0 then allNames else names0

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -122,9 +122,9 @@ abstractTerm a u@Con{} b v = do
         case isPrefixOf u' v of
           Nothing -> return v
           Just es -> do -- Check that the types match.
-            s <- get
+            s <- getTC
             do  disableDestructiveUpdate (noConstraints $ equalType a' b)
-                put s
+                putTC s
                 return $ Def hole (raise (m - n) args ++ es)
               `catchError` \ _ -> do
                 reportSDoc "tc.abstract.ill-typed" 50 $

--- a/src/full/Agda/TypeChecking/CompiledClause/Match.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Match.hs
@@ -66,7 +66,7 @@ type Stack = [Frame]
 match' :: Stack -> ReduceM (Reduced (Blocked Elims) Term)
 match' ((c, es, patch) : stack) = do
   let no blocking es = return $ NoReduction $ blocking $ patch $ map ignoreReduced es
-      yes t          = flip YesReduction t <$> asks envSimplification
+      yes t          = flip YesReduction t <$> asksTC envSimplification
 
   do
 
@@ -191,7 +191,7 @@ match' ((c, es, patch) : stack) = do
 
 -- If we reach the empty stack, then pattern matching was incomplete
 match' [] = {- new line here since __IMPOSSIBLE__ does not like the ' in match' -}
-  caseMaybeM (asks envAppDef) __IMPOSSIBLE__ $ \ f -> do
+  caseMaybeM (asksTC envAppDef) __IMPOSSIBLE__ $ \ f -> do
     pds <- getPartialDefs
     if f `elem` pds
     then return (NoReduction $ NotBlocked MissingClauses [])

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -55,7 +55,7 @@ catchConstraint c v = liftTCM $
 
 addConstraint :: Constraint -> TCM ()
 addConstraint c = do
-    pids <- asks envActiveProblems
+    pids <- asksTC envActiveProblems
     reportSDoc "tc.constr.add" 20 $ hsep
       [ text "adding constraint"
       , text (show $ Set.toList pids)
@@ -161,7 +161,7 @@ solveAwakeConstraints' force = do
      -- solveSizeConstraints -- Andreas, 2012-09-27 attacks size constrs too early
      -- Ulf, 2016-12-06: Don't inherit problems here! Stored constraints
      -- already contain all their dependencies.
-     locally eActiveProblems (const Set.empty) solve
+     locallyTC eActiveProblems (const Set.empty) solve
   where
     solve = do
       reportSDoc "tc.constr.solve" 10 $ hsep [ text "Solving awake constraints."
@@ -175,7 +175,7 @@ solveConstraint :: Constraint -> TCM ()
 solveConstraint c = do
     verboseS "profile.constraints" 10 $ liftTCM $ tick "attempted-constraints"
     verboseBracket "tc.constr.solve" 20 "solving constraint" $ do
-      pids <- asks envActiveProblems
+      pids <- asksTC envActiveProblems
       reportSDoc "tc.constr.solve" 20 $ text (show $ Set.toList pids) <+> prettyTCM c
       solveConstraint_ c
 
@@ -240,8 +240,8 @@ checkTypeCheckingProblem p = case p of
 
 debugConstraints :: TCM ()
 debugConstraints = verboseS "tc.constr" 50 $ do
-  awake    <- use stAwakeConstraints
-  sleeping <- use stSleepingConstraints
+  awake    <- useTC stAwakeConstraints
+  sleeping <- useTC stSleepingConstraints
   reportSDoc "" 0 $ vcat
     [ text "Current constraints"
     , nest 2 $ vcat [ text "awake " <+> vcat (map prettyTCM awake)

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -165,7 +165,7 @@ coverageCheck f t cs = do
   reportSLn "tc.cover.top" 30 $ "coverageCheck: getting checkpoints"
 
   -- TODO: does this make sense? Why are we weakening by n - fv?
-  checkpoints <- applySubst (raiseS (n - fv)) <$> view eCheckpoints
+  checkpoints <- applySubst (raiseS (n - fv)) <$> viewTC eCheckpoints
 
       -- construct the initial split clause
   let sc = SClause gamma xs idS checkpoints $ Just $ defaultArg a
@@ -419,7 +419,7 @@ inferMissingClause
 inferMissingClause f (SClause tel ps _ cps (Just t)) = setCurrentRange f $ do
   reportSDoc "tc.cover.infer" 20 $ addContext tel $ text "Trying to infer right-hand side of type" <+> prettyTCM t
   cl <- addContext tel
-        $ locally eCheckpoints (const cps)
+        $ locallyTC eCheckpoints (const cps)
         $ checkpoint IdS $ do    -- introduce a fresh checkpoint
     (_x, rhs) <- case getHiding t of
                   Instance{} -> newIFSMeta "" (unArg t)

--- a/src/full/Agda/TypeChecking/DisplayForm.hs
+++ b/src/full/Agda/TypeChecking/DisplayForm.hs
@@ -61,7 +61,7 @@ displayForm q es = do
   else do
     -- Display debug info about the @Open@s.
     verboseS "tc.display.top" 100 $ unlessDebugPrinting $ do
-      cps <- view eCheckpoints
+      cps <- viewTC eCheckpoints
       cxt <- getContextTelescope
       reportSDoc "tc.display.top" 100 $ return $ vcat
         [ text "displayForm for" <+> pretty q

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -475,8 +475,8 @@ instance PrettyTCM TCErr where
     -- Andreas, 2014-03-23
     -- This use of localState seems ok since we do not collect
     -- Benchmark info during printing errors.
-    TypeError s e -> localState $ do
-      put s
+    TypeError s e -> localTCState $ do
+      putTC s
       sayWhen (envRange $ clEnv e) (envCall $ clEnv e) $ prettyTCM e
     Exception r s     -> sayWhere r $ return s
     IOException _ r e -> sayWhere r $ fwords $ show e
@@ -501,7 +501,7 @@ dropTopLevelModule q = ($ q) <$> topLevelModuleDropper
 -- | Produces a function which drops the filename component of the qualified name.
 topLevelModuleDropper :: TCM (QName -> QName)
 topLevelModuleDropper = do
-  caseMaybeM (asks envCurrentPath) (return id) $ \ f -> do
+  caseMaybeM (asksTC envCurrentPath) (return id) $ \ f -> do
   m <- fromMaybe __IMPOSSIBLE__ <$> lookupModuleFromSource f
   return $ dropTopLevelModule' $ size m
 

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -55,12 +55,12 @@ binAppView t = case t of
 -- | Contracts all eta-redexes it sees without reducing.
 {-# SPECIALIZE etaContract :: TermLike a => a -> TCM a #-}
 {-# SPECIALIZE etaContract :: TermLike a => a -> ReduceM a #-}
-etaContract :: (MonadReader TCEnv m, HasConstInfo m, HasOptions m, TermLike a) => a -> m a
+etaContract :: (MonadTCEnv m, HasConstInfo m, HasOptions m, TermLike a) => a -> m a
 etaContract = traverseTermM etaOnce
 
 {-# SPECIALIZE etaOnce :: Term -> TCM Term #-}
 {-# SPECIALIZE etaOnce :: Term -> ReduceM Term #-}
-etaOnce :: (MonadReader TCEnv m, HasConstInfo m, HasOptions m) => Term -> m Term
+etaOnce :: (MonadTCEnv m, HasConstInfo m, HasOptions m) => Term -> m Term
 etaOnce v = case v of
   -- Andreas, 2012-11-18: this call to reportSDoc seems to cost me 2%
   -- performance on the std-lib
@@ -75,7 +75,7 @@ etaOnce v = case v of
   v -> return v
 
 -- | If record constructor, call eta-contraction function.
-etaCon :: (MonadReader TCEnv m, HasConstInfo m, HasOptions m)
+etaCon :: (MonadTCEnv m, HasConstInfo m, HasOptions m)
   => ConHead  -- ^ Constructor name @c@.
   -> ConInfo  -- ^ Constructor info @ci@.
   -> Args     -- ^ Constructor arguments @args@.
@@ -91,7 +91,7 @@ etaCon c ci args cont = ignoreAbstractMode $ do
     cont r c ci args
 
 -- | Try to contract a lambda-abstraction @Lam i (Abs x b)@.
-etaLam :: (MonadReader TCEnv m, HasConstInfo m, HasOptions m)
+etaLam :: (MonadTCEnv m, HasConstInfo m, HasOptions m)
   => ArgInfo  -- ^ Info @i@ of the 'Lam'.
   -> ArgName  -- ^ Name @x@ of the abstraction.
   -> Term     -- ^ Body ('Term') @b@ of the 'Abs'.

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -99,7 +99,7 @@ successful).  This way, we do not duplicate work.
 -}
 
 modifyOccursCheckDefs :: (Set QName -> Set QName) -> TCM ()
-modifyOccursCheckDefs f = stOccursCheckDefs %= f
+modifyOccursCheckDefs f = stOccursCheckDefs `modifyTCLens` f
 
 -- | Set the names of definitions to be looked at
 --   to the defs in the current mutual block.
@@ -113,7 +113,7 @@ initOccursCheck mv = modifyOccursCheckDefs . const =<<
    else do
      reportSLn "tc.meta.occurs" 20 $
        "initOccursCheck: we look into the following definitions:"
-     mb <- asks envMutualBlock
+     mb <- asksTC envMutualBlock
      case mb of
        Nothing -> do
          reportSLn "tc.meta.occurs" 20 $ "(none)"
@@ -126,7 +126,7 @@ initOccursCheck mv = modifyOccursCheckDefs . const =<<
 
 -- | Is a def in the list of stuff to be checked?
 defNeedsChecking :: QName -> TCM Bool
-defNeedsChecking d = Set.member d <$> use stOccursCheckDefs
+defNeedsChecking d = Set.member d <$> useTC stOccursCheckDefs
 
 -- | Remove a def from the list of defs to be looked at.
 tallyDef :: QName -> TCM ()
@@ -728,7 +728,7 @@ killArgs kills _
   | not (or kills) = return NothingToPrune  -- nothing to kill
 killArgs kills m = do
   mv <- lookupMeta m
-  allowAssign <- asks envAssignMetas
+  allowAssign <- asksTC envAssignMetas
   if mvFrozen mv == Frozen || not allowAssign then return PrunedNothing else do
       -- Andreas 2011-04-26, we allow pruning in MetaV and MetaS
       let a = jMetaType $ mvJudgement mv

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -436,10 +436,10 @@ stLocalUserWarnings f s =
   f (stPreLocalUserWarnings (stPreScopeState s)) <&>
   \ x -> s {stPreScopeState = (stPreScopeState s) {stPreLocalUserWarnings = x}}
 
-getUserWarnings :: MonadState TCState m => m (Map A.QName String)
+getUserWarnings :: MonadTCState m => m (Map A.QName String)
 getUserWarnings = do
-  iuw <- use stImportedUserWarnings
-  luw <- use stLocalUserWarnings
+  iuw <- useTC stImportedUserWarnings
+  luw <- useTC stLocalUserWarnings
   return $ iuw `Map.union` luw
 
 stBackends :: Lens' [Backend] TCState
@@ -594,11 +594,11 @@ nextFresh s =
   let !c = s^.freshLens
   in (c, set freshLens (nextFresh' c) s)
 
-fresh :: (HasFresh i, MonadState TCState m) => m i
+fresh :: (HasFresh i, MonadTCState m) => m i
 fresh =
-    do  !s <- get
+    do  !s <- getTC
         let (!c , !s') = nextFresh s
-        put s'
+        putTC s'
         return c
 
 instance HasFresh MetaId where
@@ -651,22 +651,22 @@ instance Pretty CheckpointId where
 instance HasFresh CheckpointId where
   freshLens = stFreshCheckpointId
 
-freshName :: MonadState TCState m => Range -> String -> m Name
+freshName :: MonadTCState m => Range -> String -> m Name
 freshName r s = do
   i <- fresh
   return $ mkName r i s
 
-freshNoName :: MonadState TCState m => Range -> m Name
+freshNoName :: MonadTCState m => Range -> m Name
 freshNoName r =
     do  i <- fresh
         return $ Name i (C.NoName noRange i) r noFixity'
 
-freshNoName_ :: MonadState TCState m => m Name
+freshNoName_ :: MonadTCState m => m Name
 freshNoName_ = freshNoName noRange
 
 -- | Create a fresh name from @a@.
 class FreshName a where
-  freshName_ :: MonadState TCState m => a -> m Name
+  freshName_ :: MonadTCState m => a -> m Name
 
 instance FreshName (Range, String) where
   freshName_ = uncurry freshName
@@ -706,7 +706,7 @@ sourceToModule =
   Map.fromList
      .  List.map (\(m, f) -> (f, m))
      .  Map.toList
-    <$> use stModuleToSource
+    <$> useTC stModuleToSource
 
 -- | Lookup an 'AbsolutePath' in 'sourceToModule'.
 --
@@ -714,7 +714,7 @@ sourceToModule =
 
 lookupModuleFromSource :: AbsolutePath -> TCM (Maybe TopLevelModuleName)
 lookupModuleFromSource f =
-  fmap fst . List.find ((f ==) . snd) . Map.toList <$> use stModuleToSource
+  fmap fst . List.find ((f ==) . snd) . Map.toList <$> useTC stModuleToSource
 
 ---------------------------------------------------------------------------
 -- ** Interface
@@ -816,10 +816,10 @@ instance HasRange a => HasRange (Closure a) where
 
 buildClosure :: a -> TCM (Closure a)
 buildClosure x = do
-    env   <- ask
-    sig   <- use stSignature
-    scope <- use stScope
-    cps   <- use stModuleCheckpoints
+    env   <- askTC
+    sig   <- useTC stSignature
+    scope <- useTC stScope
+    cps   <- useTC stModuleCheckpoints
     return $ Closure sig env scope cps x
 
 ---------------------------------------------------------------------------
@@ -2192,7 +2192,7 @@ data HighlightingMethod
 ifTopLevelAndHighlightingLevelIsOr ::
   MonadTCM tcm => HighlightingLevel -> Bool -> tcm () -> tcm ()
 ifTopLevelAndHighlightingLevelIsOr l b m = do
-  e <- ask
+  e <- askTC
   when (envModuleNestingLevel e == 0 &&
         (envHighlightingLevel e >= l || b))
        m
@@ -2379,7 +2379,7 @@ initEnv = TCEnv { envContext             = []
                 }
 
 disableDestructiveUpdate :: TCM a -> TCM a
-disableDestructiveUpdate = local $ \e -> e { envAllowDestructiveUpdate = False }
+disableDestructiveUpdate = localTC $ \e -> e { envAllowDestructiveUpdate = False }
 
 data UnquoteFlags = UnquoteFlags
   { _unquoteNormalise :: Bool }
@@ -3029,11 +3029,11 @@ class (Functor m, Applicative m, Monad m) => HasOptions m where
   commandLineOptions :: m CommandLineOptions
 
 instance MonadIO m => HasOptions (TCMT m) where
-  pragmaOptions = use stPragmaOptions
+  pragmaOptions = useTC stPragmaOptions
 
   commandLineOptions = do
-    p  <- use stPragmaOptions
-    cl <- stPersistentOptions . stPersistentState <$> get
+    p  <- useTC stPragmaOptions
+    cl <- stPersistentOptions . stPersistentState <$> getTC
     return $ cl { optPragmaOptions = p }
 
 instance HasOptions m => HasOptions (ExceptT e m) where
@@ -3123,19 +3123,19 @@ instance ReadTCState ReduceM where
 
 runReduceM :: ReduceM a -> TCM a
 runReduceM m = do
-  e <- ask
-  s <- get
+  e <- askTC
+  s <- getTC
   return $! unReduceM m (ReduceEnv e s)
 
 runReduceF :: (a -> ReduceM b) -> TCM (a -> b)
 runReduceF f = do
-  e <- ask
-  s <- get
+  e <- askTC
+  s <- getTC
   return $ \x -> unReduceM (f x) (ReduceEnv e s)
 
-instance MonadReader TCEnv ReduceM where
-  ask   = ReduceM redEnv
-  local = onReduceEnv . mapRedEnv
+instance MonadTCEnv ReduceM where
+  askTC   = ReduceM redEnv
+  localTC = onReduceEnv . mapRedEnv
 
 useR :: (ReadTCState m) => Lens' a TCState -> m a
 useR l = (^.l) <$> getTCState
@@ -3154,7 +3154,7 @@ instance HasOptions ReduceM where
     return $ cl{ optPragmaOptions = p }
 
 class ( Applicative m
-      , MonadReader TCEnv m
+      , MonadTCEnv m
       , ReadTCState m
       , HasOptions m
       ) => MonadReduce m where
@@ -3169,42 +3169,180 @@ instance MonadReduce m => MonadReduce (ListT m) where
 instance MonadReduce m => MonadReduce (ExceptT err m) where
   liftReduce = lift . liftReduce
 
+instance MonadReduce m => MonadReduce (ReaderT r m) where
+  liftReduce = lift . liftReduce
+
 instance (Monoid w, MonadReduce m) => MonadReduce (WriterT w m) where
   liftReduce = lift . liftReduce
 
-instance (MonadReduce m) => MonadReduce (StateT w m) where
+instance MonadReduce m => MonadReduce (StateT w m) where
   liftReduce = lift . liftReduce
 
 instance MonadReduce ReduceM where
   liftReduce = id
 
 ---------------------------------------------------------------------------
+-- * Monad with read-only 'TCEnv'
+---------------------------------------------------------------------------
+
+-- | @MonadTCEnv@ made into its own dedicated service class.
+--   This allows us to use 'MonadReader' for 'ReaderT' extensions of @TCM@.
+class Monad m => MonadTCEnv m where
+  askTC   :: m TCEnv
+  localTC :: (TCEnv -> TCEnv) -> m a -> m a
+
+instance MonadTCEnv m => MonadTCEnv (MaybeT m) where
+  askTC   = lift askTC
+  localTC = mapMaybeT . localTC
+
+instance MonadTCEnv m => MonadTCEnv (ListT m) where
+  askTC   = lift askTC
+  localTC = mapListT . localTC
+
+instance MonadTCEnv m => MonadTCEnv (ExceptT err m) where
+  askTC   = lift askTC
+  localTC = mapExceptT . localTC
+
+instance MonadTCEnv m => MonadTCEnv (ReaderT r m) where
+  askTC   = lift askTC
+  localTC = mapReaderT . localTC
+
+instance (Monoid w, MonadTCEnv m) => MonadTCEnv (WriterT w m) where
+  askTC   = lift askTC
+  localTC = mapWriterT . localTC
+
+instance MonadTCEnv m => MonadTCEnv (StateT s m) where
+  askTC   = lift askTC
+  localTC = mapStateT . localTC
+
+asksTC :: MonadTCEnv m => (TCEnv -> a) -> m a
+asksTC f = f <$> askTC
+
+viewTC :: MonadTCEnv m => Lens' a TCEnv -> m a
+viewTC l = asksTC (^. l)
+
+-- | Modify the lens-indicated part of the @TCEnv@ in a subcomputation.
+locallyTC :: MonadTCEnv m => Lens' a TCEnv -> (a -> a) -> m b -> m b
+locallyTC l = localTC . over l
+
+---------------------------------------------------------------------------
+-- * Monad with mutable 'TCState'
+---------------------------------------------------------------------------
+
+-- | @MonadTCState@ made into its own dedicated service class.
+--   This allows us to use 'MonadState' for 'StateT' extensions of @TCM@.
+class Monad m => MonadTCState m where
+  getTC :: m TCState
+  putTC :: TCState -> m ()
+  modifyTC :: (TCState -> TCState) -> m ()
+
+  {-# MINIMAL getTC, (putTC | modifyTC) #-}
+  putTC      = modifyTC . const
+  modifyTC f = putTC . f =<< getTC
+
+instance MonadTCState m => MonadTCState (MaybeT m) where
+  getTC    = lift getTC
+  putTC    = lift . putTC
+  modifyTC = lift . modifyTC
+
+instance MonadTCState m => MonadTCState (ListT m) where
+  getTC    = lift getTC
+  putTC    = lift . putTC
+  modifyTC = lift . modifyTC
+
+instance MonadTCState m => MonadTCState (ExceptT err m) where
+  getTC    = lift getTC
+  putTC    = lift . putTC
+  modifyTC = lift . modifyTC
+
+instance MonadTCState m => MonadTCState (ReaderT r m) where
+  getTC    = lift getTC
+  putTC    = lift . putTC
+  modifyTC = lift . modifyTC
+
+instance (Monoid w, MonadTCState m) => MonadTCState (WriterT w m) where
+  getTC    = lift getTC
+  putTC    = lift . putTC
+  modifyTC = lift . modifyTC
+
+instance MonadTCState m => MonadTCState (StateT s m) where
+  getTC    = lift getTC
+  putTC    = lift . putTC
+  modifyTC = lift . modifyTC
+
+-- ** @TCState@ accessors (no lenses)
+
+getsTC :: MonadTCState m => (TCState -> a) -> m a
+getsTC f = f <$> getTC
+
+-- | A variant of 'modifyTC' in which the computation is strict in the
+-- new state.
+modifyTC' :: MonadTCState m => (TCState -> TCState) -> m ()
+modifyTC' f = do
+  s' <- getTC
+  putTC $! f s'
+
+-- SEE TC.Monad.State
+-- -- | Restore the 'TCState' after computation.
+-- localTCState :: MonadTCState m => m a -> m a
+-- localTCState = bracket_ getTC putTC
+
+-- ** @TCState@ accessors via lenses
+
+useTC :: MonadTCState m => Lens' a TCState -> m a
+useTC l = do
+  !x <- getsTC (^. l)
+  return x
+
+-- | Overwrite the part of the 'TCState' focused on by the lens.
+setTCLens :: MonadTCState m => Lens' a TCState -> a -> m ()
+setTCLens l = modifyTC . set l
+
+-- | Modify the part of the 'TCState' focused on by the lens.
+modifyTCLens :: MonadTCState m => Lens' a TCState -> (a -> a) -> m ()
+modifyTCLens l = modifyTC . over l
+
+-- | Modify a part of the state monadically.
+modifyTCLensM :: MonadTCState m => Lens' a TCState -> (a -> m a) -> m ()
+modifyTCLensM l f = putTC =<< l f =<< getTC
+
+-- | Modify the lens-indicated part of the 'TCState' locally.
+locallyTCState :: MonadTCState m => Lens' a TCState -> (a -> a) -> m b -> m b
+locallyTCState l f k = do
+  old <- useTC l
+  modifyTCLens l f
+  x <- k
+  setTCLens l old
+  return x
+
+
+---------------------------------------------------------------------------
 -- * Type checking monad transformer
 ---------------------------------------------------------------------------
 
+-- | The type checking monad transformer.
+-- Adds readonly 'TCEnv' and mutable 'TCState'.
 newtype TCMT m a = TCM { unTCM :: IORef TCState -> TCEnv -> m a }
 
--- TODO: make dedicated MonadTCEnv and MonadTCState service classes
+instance MonadIO m => MonadTCEnv (TCMT m) where
+  askTC             = TCM $ \ _ e -> return e
+  localTC f (TCM m) = TCM $ \ s e -> m s (f e)
 
-instance MonadIO m => MonadReader TCEnv (TCMT m) where
-  ask = TCM $ \s e -> return e
-  local f (TCM m) = TCM $ \s e -> m s (f e)
-
-instance MonadIO m => MonadState TCState (TCMT m) where
-  get   = TCM $ \s _ -> liftIO (readIORef s)
-  put s = TCM $ \r _ -> liftIO (writeIORef r s)
+instance MonadIO m => MonadTCState (TCMT m) where
+  getTC   = TCM $ \ r _e -> liftIO (readIORef r)
+  putTC s = TCM $ \ r _e -> liftIO (writeIORef r s)
 
 type TCM = TCMT IO
 
 class ( Applicative tcm, MonadIO tcm
-      , MonadReader TCEnv tcm
-      , MonadState TCState tcm
+      , MonadTCEnv tcm
+      , MonadTCState tcm
       , HasOptions tcm
       ) => MonadTCM tcm where
     liftTCM :: TCM a -> tcm a
 
 instance MonadIO m => ReadTCState (TCMT m) where
-  getTCState = get
+  getTCState = getTC
   withTCState f m = __IMPOSSIBLE__ -- should probably not be used
 
 instance MonadError TCErr (TCMT IO) where
@@ -3277,15 +3415,11 @@ instance MonadTCM tcm => MonadTCM (ExceptT err tcm) where
 instance (Monoid w, MonadTCM tcm) => MonadTCM (WriterT w tcm) where
   liftTCM = lift . liftTCM
 
-{- The following is not possible since MonadTCM needs to be a
--- MonadState TCState and a MonadReader TCEnv
-
 instance (MonadTCM tcm) => MonadTCM (StateT s tcm) where
   liftTCM = lift . liftTCM
 
 instance (MonadTCM tcm) => MonadTCM (ReaderT r tcm) where
   liftTCM = lift . liftTCM
--}
 
 instance MonadTrans TCMT where
     lift m = TCM $ \_ _ -> m
@@ -3384,7 +3518,7 @@ typeError err = liftTCM $ throwError =<< typeError_ err
 
 {-# SPECIALIZE typeError_ :: TypeError -> TCM TCErr #-}
 typeError_ :: MonadTCM tcm => TypeError -> tcm TCErr
-typeError_ err = liftTCM $ TypeError <$> get <*> buildClosure err
+typeError_ err = liftTCM $ TypeError <$> getTC <*> buildClosure err
 
 -- | Running the type checking monad (most general form).
 {-# SPECIALIZE runTCM :: TCEnv -> TCState -> TCM a -> IO (a, TCState) #-}
@@ -3412,9 +3546,9 @@ runSafeTCM m st = runTCM initEnv st m `E.catch` (\ (e :: TCErr) -> __IMPOSSIBLE_
 -- runSafeTCM m st = either__IMPOSSIBLE__ return <$> do
 --     -- Errors must be impossible.
 --     runTCM $ do
---         put st
+--         putTC st
 --         a <- m
---         st <- get
+--         st <- getTC
 --         return (a, st)
 
 -- | Runs the given computation in a separate thread, with /a copy/ of
@@ -3432,8 +3566,8 @@ runSafeTCM m st = runTCM initEnv st m `E.catch` (\ (e :: TCErr) -> __IMPOSSIBLE_
 
 forkTCM :: TCM a -> TCM ()
 forkTCM m = do
-  s <- get
-  e <- ask
+  s <- getTC
+  e <- askTC
   liftIO $ void $ C.forkIO $ void $ runTCM e s m
 
 

--- a/src/full/Agda/TypeChecking/Monad/Closure.hs
+++ b/src/full/Agda/TypeChecking/Monad/Closure.hs
@@ -10,9 +10,9 @@ import Agda.Utils.Lens
 
 enterClosure :: Closure a -> (a -> TCM b) -> TCM b
 enterClosure (Closure sig env scope cps x) k = do
-  isDbg <- view eIsDebugPrinting
+  isDbg <- viewTC eIsDebugPrinting
   withScope_ scope
-    $ locallyState stModuleCheckpoints (const cps)
+    $ locallyTCState stModuleCheckpoints (const cps)
     $ withEnv env{ envIsDebugPrinting = isDbg }
     $ k x
 

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -38,7 +38,7 @@ import Agda.Utils.Impossible
 -- | Modify a 'Context' in a computation.
 {-# SPECIALIZE modifyContext :: (Context -> Context) -> TCM a -> TCM a #-}
 modifyContext :: MonadTCM tcm => (Context -> Context) -> tcm a -> tcm a
-modifyContext f = local $ \e -> e { envContext = f $ envContext e }
+modifyContext f = localTC $ \e -> e { envContext = f $ envContext e }
 
 -- | Change to top (=empty) context. Resets the checkpoints.
 {-# SPECIALIZE inTopContext :: TCM a -> TCM a #-}
@@ -47,8 +47,8 @@ safeInTopContext cont = do
   locals <- liftTCM $ getLocalVars
   liftTCM $ setLocalVars []
   a <- modifyContext (const [])
-        $ locally eCurrentCheckpoint (const 0)
-        $ locally eCheckpoints (const $ Map.singleton 0 IdS) cont
+        $ locallyTC eCurrentCheckpoint (const 0)
+        $ locallyTC eCheckpoints (const $ Map.singleton 0 IdS) cont
   liftTCM $ setLocalVars locals
   return a
 
@@ -77,12 +77,12 @@ escapeContext n = modifyContext $ drop n
 checkpoint :: (MonadDebug tcm, MonadTCM tcm) => Substitution -> tcm a -> tcm a
 checkpoint sub k = do
   unlessDebugPrinting $ reportSLn "tc.cxt.checkpoint" 105 $ "New checkpoint {"
-  old     <- view eCurrentCheckpoint
-  oldMods <- use  stModuleCheckpoints
+  old     <- viewTC eCurrentCheckpoint
+  oldMods <- useTC  stModuleCheckpoints
   chkpt <- fresh
   unlessDebugPrinting $ verboseS "tc.cxt.checkpoint" 105 $ do
     cxt <- getContextTelescope
-    cps <- view eCheckpoints
+    cps <- viewTC eCheckpoints
     let cps' = Map.insert chkpt IdS $ fmap (applySubst sub) cps
         prCps cps = vcat [ pshow c <+> text ": " <+> pretty s | (c, s) <- Map.toList cps ]
     reportSDoc "tc.cxt.checkpoint" 105 $ return $ nest 2 $ vcat
@@ -93,18 +93,18 @@ checkpoint sub k = do
       , text "old substs =" <+> prCps cps
       , text "new substs =" <?> prCps cps'
       ]
-  x <- flip local k $ \ env -> env
+  x <- flip localTC k $ \ env -> env
     { envCurrentCheckpoint = chkpt
     , envCheckpoints       = Map.insert chkpt IdS $
                               fmap (applySubst sub) (envCheckpoints env)
     }
-  newMods <- use stModuleCheckpoints
+  newMods <- useTC stModuleCheckpoints
   -- Set the checkpoint for introduced modules to the old checkpoint when the
   -- new one goes out of scope. #2897: This isn't actually sound for modules
   -- created under refined parent parameters, but as long as those modules
   -- aren't named we shouldn't look at the checkpoint. The right thing to do
   -- would be to not store these modules in the checkpoint map, but todo..
-  stModuleCheckpoints .= Map.union oldMods (old <$ Map.difference newMods oldMods)
+  stModuleCheckpoints `setTCLens` Map.union oldMods (old <$ Map.difference newMods oldMods)
   unlessDebugPrinting $ reportSLn "tc.cxt.checkpoint" 105 "}"
   return x
 
@@ -114,9 +114,9 @@ updateContext :: (MonadDebug tcm, MonadTCM tcm) => Substitution -> (Context -> C
 updateContext sub f = modifyContext f . checkpoint sub
 
 -- | Get the substitution from the context at a given checkpoint to the current context.
-checkpointSubstitution :: MonadReader TCEnv tcm => CheckpointId -> tcm Substitution
+checkpointSubstitution :: MonadTCEnv tcm => CheckpointId -> tcm Substitution
 checkpointSubstitution chkpt =
-  caseMaybeM (view (eCheckpoints . key chkpt)) __IMPOSSIBLE__ return
+  caseMaybeM (viewTC (eCheckpoints . key chkpt)) __IMPOSSIBLE__ return
 
 -- | Get substitution @Γ ⊢ ρ : Γm@ where @Γ@ is the current context
 --   and @Γm@ is the module parameter telescope of module @m@.
@@ -126,7 +126,7 @@ checkpointSubstitution chkpt =
 --   This is ok for instance if we are outside module @m@ (in which case we
 --   have to supply all module parameters to any symbol defined within @m@ we
 --   want to refer).
-getModuleParameterSub :: (MonadReader TCEnv m, ReadTCState m) => ModuleName -> m Substitution
+getModuleParameterSub :: (MonadTCEnv m, ReadTCState m) => ModuleName -> m Substitution
 getModuleParameterSub m = do
   mcp <- (^. stModuleCheckpoints . key m) <$> getTCState
   maybe (return IdS) checkpointSubstitution mcp
@@ -260,7 +260,7 @@ underAbstraction_ = underAbstraction __DUMMY_DOM__
 
 getLetBindings :: MonadTCM tcm => tcm [(Name,(Term,Dom Type))]
 getLetBindings = do
-  bs <- asks envLetBindings
+  bs <- asksTC envLetBindings
   forM (Map.toList bs) $ \ (n,o) -> (,) n <$> getOpen o
 
 -- | Add a let bound variable
@@ -268,7 +268,7 @@ getLetBindings = do
 addLetBinding' :: MonadTCM tcm => Name -> Term -> Dom Type -> tcm a -> tcm a
 addLetBinding' x v t ret = do
     vt <- liftTCM $ makeOpen (v, t)
-    flip local ret $ \e -> e { envLetBindings = Map.insert x vt $ envLetBindings e }
+    flip localTC ret $ \e -> e { envLetBindings = Map.insert x vt $ envLetBindings e }
 
 -- | Add a let bound variable
 {-# SPECIALIZE addLetBinding :: ArgInfo -> Name -> Term -> Type -> TCM a -> TCM a #-}
@@ -280,39 +280,39 @@ addLetBinding info x v t0 ret = addLetBinding' x v (defaultArgDom info t0) ret
 
 -- | Get the current context.
 {-# SPECIALIZE getContext :: TCM [Dom (Name, Type)] #-}
-getContext :: MonadReader TCEnv m => m [Dom (Name, Type)]
-getContext = asks envContext
+getContext :: MonadTCEnv m => m [Dom (Name, Type)]
+getContext = asksTC envContext
 
 -- | Get the size of the current context.
 {-# SPECIALIZE getContextSize :: TCM Nat #-}
-getContextSize :: (Applicative m, MonadReader TCEnv m) => m Nat
-getContextSize = length <$> asks envContext
+getContextSize :: (Applicative m, MonadTCEnv m) => m Nat
+getContextSize = length <$> asksTC envContext
 
 -- | Generate @[var (n - 1), ..., var 0]@ for all declarations in the context.
 {-# SPECIALIZE getContextArgs :: TCM Args #-}
-getContextArgs :: (Applicative m, MonadReader TCEnv m) => m Args
+getContextArgs :: (Applicative m, MonadTCEnv m) => m Args
 getContextArgs = reverse . zipWith mkArg [0..] <$> getContext
   where mkArg i dom = var i <$ argFromDom dom
 
 -- | Generate @[var (n - 1), ..., var 0]@ for all declarations in the context.
 {-# SPECIALIZE getContextTerms :: TCM [Term] #-}
-getContextTerms :: (Applicative m, MonadReader TCEnv m) => m [Term]
+getContextTerms :: (Applicative m, MonadTCEnv m) => m [Term]
 getContextTerms = map var . downFrom <$> getContextSize
 
 -- | Get the current context as a 'Telescope'.
 {-# SPECIALIZE getContextTelescope :: TCM Telescope #-}
-getContextTelescope :: (Applicative m, MonadReader TCEnv m) => m Telescope
+getContextTelescope :: (Applicative m, MonadTCEnv m) => m Telescope
 getContextTelescope = telFromList' nameToArgName . reverse <$> getContext
 
 -- | Get the names of all declarations in the context.
 {-# SPECIALIZE getContextNames :: TCM [Name] #-}
-getContextNames :: (Applicative m, MonadReader TCEnv m) => m [Name]
+getContextNames :: (Applicative m, MonadTCEnv m) => m [Name]
 getContextNames = map (fst . unDom) <$> getContext
 
 -- | get type of bound variable (i.e. deBruijn index)
 --
 {-# SPECIALIZE lookupBV :: Nat -> TCM (Dom (Name, Type)) #-}
-lookupBV :: MonadReader TCEnv m => Nat -> m (Dom (Name, Type))
+lookupBV :: MonadTCEnv m => Nat -> m (Dom (Name, Type))
 lookupBV n = do
   ctx <- getContext
   let failure = fail $ "de Bruijn index out of scope: " ++ show n ++
@@ -320,25 +320,25 @@ lookupBV n = do
   maybe failure (return . fmap (raise $ n + 1)) $ ctx !!! n
 
 {-# SPECIALIZE typeOfBV' :: Nat -> TCM (Dom Type) #-}
-typeOfBV' :: (Applicative m, MonadReader TCEnv m) => Nat -> m (Dom Type)
+typeOfBV' :: (Applicative m, MonadTCEnv m) => Nat -> m (Dom Type)
 typeOfBV' n = fmap snd <$> lookupBV n
 
 {-# SPECIALIZE typeOfBV :: Nat -> TCM Type #-}
-typeOfBV :: (Applicative m, MonadReader TCEnv m) => Nat -> m Type
+typeOfBV :: (Applicative m, MonadTCEnv m) => Nat -> m Type
 typeOfBV i = unDom <$> typeOfBV' i
 
 {-# SPECIALIZE nameOfBV :: Nat -> TCM Name #-}
-nameOfBV :: (Applicative m, MonadReader TCEnv m) => Nat -> m Name
+nameOfBV :: (Applicative m, MonadTCEnv m) => Nat -> m Name
 nameOfBV n = fst . unDom <$> lookupBV n
 
 -- | Get the term corresponding to a named variable. If it is a lambda bound
 --   variable the deBruijn index is returned and if it is a let bound variable
 --   its definition is returned.
 {-# SPECIALIZE getVarInfo :: Name -> TCM (Term, Dom Type) #-}
-getVarInfo :: MonadReader TCEnv m => Name -> m (Term, Dom Type)
+getVarInfo :: MonadTCEnv m => Name -> m (Term, Dom Type)
 getVarInfo x =
     do  ctx <- getContext
-        def <- asks envLetBindings
+        def <- asksTC envLetBindings
         case List.findIndex ((==x) . fst . unDom) ctx of
             Just n -> do
                 t <- typeOfBV' n

--- a/src/full/Agda/TypeChecking/Monad/Context.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs-boot
@@ -7,4 +7,4 @@ import Control.Monad.Reader
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad.Base
 
-checkpointSubstitution :: MonadReader TCEnv tcm => CheckpointId -> tcm Substitution
+checkpointSubstitution :: MonadTCEnv tcm => CheckpointId -> tcm Substitution

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -42,7 +42,7 @@ class (Functor m, Applicative m, Monad m) => MonadDebug m where
 instance (MonadIO m) => MonadDebug (TCMT m) where
 
   displayDebugMessage n s = liftTCM $ do
-    cb <- gets $ stInteractionOutputCallback . stPersistentState
+    cb <- getsTC $ stInteractionOutputCallback . stPersistentState
     cb (Resp_RunningInfo n s)
 
   formatDebugMessage k n d = liftTCM $
@@ -79,26 +79,26 @@ instance (MonadDebug m, Monoid w) => MonadDebug (WriterT w m) where
 
 -- | Conditionally print debug string.
 {-# SPECIALIZE reportS :: VerboseKey -> Int -> String -> TCM () #-}
-reportS :: (HasOptions m, MonadDebug m, MonadReader TCEnv m)
+reportS :: (HasOptions m, MonadDebug m, MonadTCEnv m)
         => VerboseKey -> Int -> String -> m ()
 reportS k n s = verboseS k n $ displayDebugMessage n s
 
 -- | Conditionally println debug string.
 {-# SPECIALIZE reportSLn :: VerboseKey -> Int -> String -> TCM () #-}
-reportSLn :: (HasOptions m, MonadDebug m, MonadReader TCEnv m)
+reportSLn :: (HasOptions m, MonadDebug m, MonadTCEnv m)
           => VerboseKey -> Int -> String -> m ()
 reportSLn k n s = verboseS k n $
   displayDebugMessage n (s ++ "\n")
 
 -- | Conditionally render debug 'Doc' and print it.
 {-# SPECIALIZE reportSDoc :: VerboseKey -> Int -> TCM Doc -> TCM () #-}
-reportSDoc :: (HasOptions m, MonadDebug m, MonadReader TCEnv m)
+reportSDoc :: (HasOptions m, MonadDebug m, MonadTCEnv m)
            => VerboseKey -> Int -> TCM Doc -> m ()
 reportSDoc k n d = verboseS k n $ do
-  displayDebugMessage n . (++ "\n") =<< formatDebugMessage k n (locally eIsDebugPrinting (const True) d)
+  displayDebugMessage n . (++ "\n") =<< formatDebugMessage k n (locallyTC eIsDebugPrinting (const True) d)
 
 unlessDebugPrinting :: MonadTCM m => m () -> m ()
-unlessDebugPrinting = unlessM (asks envIsDebugPrinting)
+unlessDebugPrinting = unlessM (asksTC envIsDebugPrinting)
 
 traceSLn :: (HasOptions m, MonadDebug m)
          => VerboseKey -> Int -> String -> m a -> m a
@@ -109,7 +109,7 @@ traceSLn k n s cont = ifNotM (hasVerbosity k n) cont $ {- else -} do
 traceSDoc :: (HasOptions m, MonadDebug m)
           => VerboseKey -> Int -> TCM Doc -> m a -> m a
 traceSDoc k n d cont = ifNotM (hasVerbosity k n) cont $ {- else -} do
-  s <- formatDebugMessage k n $ locally eIsDebugPrinting (const True) d
+  s <- formatDebugMessage k n $ locallyTC eIsDebugPrinting (const True) d
   traceDebugMessage n (s ++ "\n") cont
 
 -- | Print brackets around debug messages issued by a computation.

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs-boot
@@ -19,10 +19,10 @@ class (Functor m, Applicative m, Monad m) => MonadDebug m where
 
 instance (MonadIO m) => MonadDebug (TCMT m)
 
-reportS :: (HasOptions m, MonadDebug m, MonadReader TCEnv m)
+reportS :: (HasOptions m, MonadDebug m, MonadTCEnv m)
         => VerboseKey -> Int -> String -> m ()
-reportSLn :: (HasOptions m, MonadDebug m, MonadReader TCEnv m)
+reportSLn :: (HasOptions m, MonadDebug m, MonadTCEnv m)
           => VerboseKey -> Int -> String -> m ()
-reportSDoc :: (HasOptions m, MonadDebug m, MonadReader TCEnv m)
+reportSDoc :: (HasOptions m, MonadDebug m, MonadTCEnv m)
            => VerboseKey -> Int -> TCM Doc -> m ()
 

--- a/src/full/Agda/TypeChecking/Monad/Env.hs
+++ b/src/full/Agda/TypeChecking/Monad/Env.hs
@@ -13,31 +13,30 @@ import Agda.TypeChecking.Monad.Base
 -- | Get the name of the current module, if any.
 {-# SPECIALIZE currentModule :: TCM ModuleName #-}
 {-# SPECIALIZE currentModule :: ReduceM ModuleName #-}
-currentModule :: MonadReader TCEnv m => m ModuleName
-currentModule = asks envCurrentModule
+currentModule :: MonadTCEnv m => m ModuleName
+currentModule = asksTC envCurrentModule
 
 -- | Set the name of the current module.
 withCurrentModule :: ModuleName -> TCM a -> TCM a
 withCurrentModule m =
-    local $ \e -> e { envCurrentModule = m }
+    localTC $ \ e -> e { envCurrentModule = m }
 
 -- | Get the number of variables bound by anonymous modules.
 {-# SPECIALIZE getAnonymousVariables :: ModuleName -> TCM Nat #-}
 {-# SPECIALIZE getAnonymousVariables :: ModuleName -> ReduceM Nat #-}
-getAnonymousVariables :: MonadReader TCEnv m => ModuleName -> m Nat
+getAnonymousVariables :: MonadTCEnv m => ModuleName -> m Nat
 getAnonymousVariables m = do
-  ms <- asks envAnonymousModules
+  ms <- asksTC envAnonymousModules
   return $ sum [ n | (m', n) <- ms, mnameToList m' `List.isPrefixOf` mnameToList m ]
 
 -- | Add variables bound by an anonymous module.
 withAnonymousModule :: ModuleName -> Nat -> TCM a -> TCM a
 withAnonymousModule m n =
-  local $ \e -> e { envAnonymousModules   = (m, n) : envAnonymousModules e
-                  }
+  localTC $ \ e -> e { envAnonymousModules = (m, n) : envAnonymousModules e }
 
 -- | Set the current environment to the given
 withEnv :: TCEnv -> TCM a -> TCM a
-withEnv env = local $ \ env0 -> env
+withEnv env = localTC $ \ env0 -> env
   -- Keep persistent settings
   { envAllowDestructiveUpdate = envAllowDestructiveUpdate env0
   , envPrintMetasBare         = envPrintMetasBare env0
@@ -45,38 +44,38 @@ withEnv env = local $ \ env0 -> env
 
 -- | Get the current environment
 getEnv :: TCM TCEnv
-getEnv = ask
+getEnv = askTC
 
 -- | Increases the module nesting level by one in the given
 -- computation.
 withIncreasedModuleNestingLevel :: TCM a -> TCM a
 withIncreasedModuleNestingLevel =
-  local (\e -> e { envModuleNestingLevel =
-                     envModuleNestingLevel e + 1 })
+  localTC $ \ e -> e { envModuleNestingLevel =
+                       envModuleNestingLevel e + 1 }
 
 -- | Set highlighting level
 withHighlightingLevel :: HighlightingLevel -> TCM a -> TCM a
-withHighlightingLevel h = local $ \e -> e { envHighlightingLevel = h }
+withHighlightingLevel h = localTC $ \ e -> e { envHighlightingLevel = h }
 
 -- | Restore setting for 'ExpandLast' to default.
 doExpandLast :: TCM a -> TCM a
-doExpandLast = local $ \ e -> e { envExpandLast = ExpandLast }
+doExpandLast = localTC $ \ e -> e { envExpandLast = ExpandLast }
 
 dontExpandLast :: TCM a -> TCM a
-dontExpandLast = local $ \ e -> e { envExpandLast = DontExpandLast }
+dontExpandLast = localTC $ \ e -> e { envExpandLast = DontExpandLast }
 
 -- | If the reduced did a proper match (constructor or literal pattern),
 --   then record this as simplification step.
 {-# SPECIALIZE performedSimplification :: TCM a -> TCM a #-}
-performedSimplification :: MonadReader TCEnv m => m a -> m a
-performedSimplification = local $ \ e -> e { envSimplification = YesSimplification }
+performedSimplification :: MonadTCEnv m => m a -> m a
+performedSimplification = localTC $ \ e -> e { envSimplification = YesSimplification }
 
 {-# SPECIALIZE performedSimplification' :: Simplification -> TCM a -> TCM a #-}
-performedSimplification' :: MonadReader TCEnv m => Simplification -> m a -> m a
-performedSimplification' simpl = local $ \ e -> e { envSimplification = simpl `mappend` envSimplification e }
+performedSimplification' :: MonadTCEnv m => Simplification -> m a -> m a
+performedSimplification' simpl = localTC $ \ e -> e { envSimplification = simpl `mappend` envSimplification e }
 
-getSimplification :: MonadReader TCEnv m => m Simplification
-getSimplification = asks envSimplification
+getSimplification :: MonadTCEnv m => m Simplification
+getSimplification = asksTC envSimplification
 
 -- * Controlling reduction.
 
@@ -85,7 +84,7 @@ updateAllowedReductions :: (AllowedReductions -> AllowedReductions) -> TCEnv -> 
 updateAllowedReductions f e = e { envAllowedReductions = f (envAllowedReductions e) }
 
 modifyAllowedReductions :: (AllowedReductions -> AllowedReductions) -> TCM a -> TCM a
-modifyAllowedReductions = local . updateAllowedReductions
+modifyAllowedReductions = localTC . updateAllowedReductions
 
 putAllowedReductions :: AllowedReductions -> TCM a -> TCM a
 putAllowedReductions = modifyAllowedReductions . const
@@ -105,12 +104,12 @@ allowNonTerminatingReductions = putAllowedReductions $ [NonTerminatingReductions
 -- * Concerning 'envInsideDotPattern'
 
 insideDotPattern :: TCM a -> TCM a
-insideDotPattern = local $ \e -> e { envInsideDotPattern = True }
+insideDotPattern = localTC $ \ e -> e { envInsideDotPattern = True }
 
 isInsideDotPattern :: TCM Bool
-isInsideDotPattern = asks envInsideDotPattern
+isInsideDotPattern = asksTC envInsideDotPattern
 
 -- | Don't use call-by-need evaluation for the given computation.
 callByName :: TCM a -> TCM a
-callByName = local $ \ e -> e { envCallByNeed = False }
+callByName = localTC $ \ e -> e { envCallByNeed = False }
 

--- a/src/full/Agda/TypeChecking/Monad/Imports.hs
+++ b/src/full/Agda/TypeChecking/Monad/Imports.hs
@@ -20,52 +20,51 @@ import Agda.Utils.Monad
 import Agda.Utils.Impossible
 
 addImport :: ModuleName -> TCM ()
-addImport m =
-    stImportedModules %= Set.insert m
+addImport m = modifyTCLens stImportedModules $ Set.insert m
 
 addImportCycleCheck :: C.TopLevelModuleName -> TCM a -> TCM a
 addImportCycleCheck m =
-    local $ \e -> e { envImportPath = m : envImportPath e }
+    localTC $ \e -> e { envImportPath = m : envImportPath e }
 
 getImports :: TCM (Set ModuleName)
-getImports = use stImportedModules
+getImports = useTC stImportedModules
 
 isImported :: ModuleName -> TCM Bool
 isImported m = Set.member m <$> getImports
 
 getImportPath :: TCM [C.TopLevelModuleName]
-getImportPath = asks envImportPath
+getImportPath = asksTC envImportPath
 
 visitModule :: ModuleInfo -> TCM ()
 visitModule mi =
-  stVisitedModules %=
+  modifyTCLens stVisitedModules $
     Map.insert (toTopLevelModuleName $ iModuleName $ miInterface mi) mi
 
 setVisitedModules :: VisitedModules -> TCM ()
-setVisitedModules ms = stVisitedModules .= ms
+setVisitedModules ms = setTCLens stVisitedModules ms
 
 getVisitedModules :: TCM VisitedModules
-getVisitedModules = use stVisitedModules
+getVisitedModules = useTC stVisitedModules
 
 isVisited :: C.TopLevelModuleName -> TCM Bool
-isVisited x = Map.member x <$> use stVisitedModules
+isVisited x = Map.member x <$> useTC stVisitedModules
 
 getVisitedModule :: C.TopLevelModuleName
                  -> TCM (Maybe ModuleInfo)
-getVisitedModule x = Map.lookup x <$> use stVisitedModules
+getVisitedModule x = Map.lookup x <$> useTC stVisitedModules
 
 getDecodedModules :: TCM DecodedModules
-getDecodedModules = stDecodedModules . stPersistentState <$> get
+getDecodedModules = stDecodedModules . stPersistentState <$> getTC
 
 setDecodedModules :: DecodedModules -> TCM ()
-setDecodedModules ms = modify $ \s ->
+setDecodedModules ms = modifyTC $ \s ->
   s { stPersistentState = (stPersistentState s) { stDecodedModules = ms } }
 
 getDecodedModule :: C.TopLevelModuleName -> TCM (Maybe Interface)
-getDecodedModule x = Map.lookup x . stDecodedModules . stPersistentState <$> get
+getDecodedModule x = Map.lookup x . stDecodedModules . stPersistentState <$> getTC
 
 storeDecodedModule :: Interface -> TCM ()
-storeDecodedModule i = modify $ \s ->
+storeDecodedModule i = modifyTC $ \s ->
   s { stPersistentState =
         (stPersistentState s) { stDecodedModules =
           Map.insert (toTopLevelModuleName $ iModuleName i) i $
@@ -74,7 +73,7 @@ storeDecodedModule i = modify $ \s ->
   }
 
 dropDecodedModule :: C.TopLevelModuleName -> TCM ()
-dropDecodedModule x = modify $ \s ->
+dropDecodedModule x = modifyTC $ \s ->
   s { stPersistentState =
         (stPersistentState s) { stDecodedModules =
                                   Map.delete x $ stDecodedModules $ stPersistentState s
@@ -82,7 +81,7 @@ dropDecodedModule x = modify $ \s ->
   }
 
 withImportPath :: [C.TopLevelModuleName] -> TCM a -> TCM a
-withImportPath path = local $ \e -> e { envImportPath = path }
+withImportPath path = localTC $ \e -> e { envImportPath = path }
 
 -- | Assumes that the first module in the import path is the module we are
 --   worried about.

--- a/src/full/Agda/TypeChecking/Monad/Mutual.hs
+++ b/src/full/Agda/TypeChecking/Monad/Mutual.hs
@@ -21,17 +21,17 @@ import Agda.Utils.Null
 import Agda.Utils.Pretty ( prettyShow )
 
 noMutualBlock :: TCM a -> TCM a
-noMutualBlock = local $ \e -> e { envMutualBlock = Nothing }
+noMutualBlock = localTC $ \e -> e { envMutualBlock = Nothing }
 
 -- | Pass the current mutual block id
 --   or create a new mutual block if we are not already inside on.
 inMutualBlock :: (MutualId -> TCM a) -> TCM a
 inMutualBlock m = do
-  mi <- asks envMutualBlock
+  mi <- asksTC envMutualBlock
   case mi of
     Nothing -> do
       i <- fresh
-      local (\ e -> e { envMutualBlock = Just i }) $ m i
+      localTC (\ e -> e { envMutualBlock = Just i }) $ m i
     -- Don't create a new mutual block if we're already inside one.
     Just i -> m i
 
@@ -39,7 +39,7 @@ inMutualBlock m = do
 --   possibly overwriting the existing one.
 
 setMutualBlockInfo :: MutualId -> Info.MutualInfo -> TCM ()
-setMutualBlockInfo mi info = stMutualBlocks %= Map.alter f mi
+setMutualBlockInfo mi info = stMutualBlocks `modifyTCLens` Map.alter f mi
   where
   f Nothing                   = Just $ MutualBlock info empty
   f (Just (MutualBlock _ xs)) = Just $ MutualBlock info xs
@@ -47,7 +47,7 @@ setMutualBlockInfo mi info = stMutualBlocks %= Map.alter f mi
 -- | Set the mutual block info for a block if non-existing.
 
 insertMutualBlockInfo :: MutualId -> Info.MutualInfo -> TCM ()
-insertMutualBlockInfo mi info = stMutualBlocks %= Map.alter f mi
+insertMutualBlockInfo mi info = stMutualBlocks `modifyTCLens` Map.alter f mi
   where
   f Nothing = Just $ MutualBlock info empty
   f (Just mb@(MutualBlock info0 xs))
@@ -58,8 +58,8 @@ insertMutualBlockInfo mi info = stMutualBlocks %= Map.alter f mi
 
 setMutualBlock :: MutualId -> QName -> TCM ()
 setMutualBlock i x = do
-  stMutualBlocks %= Map.alter f i
-  stSignature    %= updateDefinition x (\ defn -> defn { defMutual = i })
+  stMutualBlocks `modifyTCLens` Map.alter f i
+  stSignature    `modifyTCLens` updateDefinition x (\ defn -> defn { defMutual = i })
   where
   f Nothing                    = Just $ MutualBlock empty $ Set.singleton x
   f (Just (MutualBlock mi xs)) = Just $ MutualBlock mi $ Set.insert x xs
@@ -67,11 +67,11 @@ setMutualBlock i x = do
 -- | Get the current mutual block, if any, otherwise a fresh mutual
 -- block is returned.
 currentOrFreshMutualBlock :: TCM MutualId
-currentOrFreshMutualBlock = maybe fresh return =<< asks envMutualBlock
+currentOrFreshMutualBlock = maybe fresh return =<< asksTC envMutualBlock
 
 lookupMutualBlock :: MutualId -> TCM MutualBlock
 lookupMutualBlock mi = do
-  mbs <- use stMutualBlocks
+  mbs <- useTC stMutualBlocks
   case Map.lookup mi mbs of
     Just mb -> return mb
     Nothing -> return empty -- can end up here if we ask for the current mutual block and there is none
@@ -79,7 +79,7 @@ lookupMutualBlock mi = do
 -- | Reverse lookup of a mutual block id for a names.
 mutualBlockOf :: QName -> TCM MutualId
 mutualBlockOf x = do
-  mb <- Map.toList <$> use stMutualBlocks
+  mb <- Map.toList <$> useTC stMutualBlocks
   case filter (Set.member x . mutualNames . snd) mb of
     (i, _) : _ -> return i
     _          -> fail $ "No mutual block for " ++ prettyShow x

--- a/src/full/Agda/TypeChecking/Monad/Open.hs
+++ b/src/full/Agda/TypeChecking/Monad/Open.hs
@@ -24,20 +24,20 @@ import Agda.Utils.Except ( MonadError(catchError) )
 -- | Create an open term in the current context.
 makeOpen :: a -> TCM (Open a)
 makeOpen x = do
-    cp <- view eCurrentCheckpoint
+    cp <- viewTC eCurrentCheckpoint
     return $ OpenThing cp x
 
 -- | Extract the value from an open term. The checkpoint at which it was
 --   created must be in scope.
-getOpen :: (Subst Term a, MonadReader TCEnv m) => Open a -> m a
+getOpen :: (Subst Term a, MonadTCEnv m) => Open a -> m a
 getOpen (OpenThing cp x) = do
   sub <- checkpointSubstitution cp
   return $ applySubst sub x
 
 -- | Extract the value from an open term. Returns `Nothing` if the checkpoint
 --   at which it was created is not in scope.
-tryGetOpen :: (Subst Term a, MonadReader TCEnv m) => Open a -> m (Maybe a)
-tryGetOpen (OpenThing cp x) = fmap (`applySubst` x) <$> view (eCheckpoints . key cp)
+tryGetOpen :: (Subst Term a, MonadTCEnv m) => Open a -> m (Maybe a)
+tryGetOpen (OpenThing cp x) = fmap (`applySubst` x) <$> viewTC (eCheckpoints . key cp)
 
 -- | An 'Open' is closed if it has checkpoint 0.
 isClosed :: Open a -> Bool

--- a/src/full/Agda/TypeChecking/Monad/Options.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs-boot
@@ -10,6 +10,6 @@ getIncludeDirs :: TCM [AbsolutePath]
 type VerboseKey = String
 
 hasVerbosity :: HasOptions m => VerboseKey -> Int -> m Bool
-verboseS :: (MonadReader TCEnv m, HasOptions m) => VerboseKey -> Int -> m () -> m ()
+verboseS :: (MonadTCEnv m, HasOptions m) => VerboseKey -> Int -> m () -> m ()
 
 enableCaching :: TCM Bool

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -224,8 +224,8 @@ addSection m = do
 -- | Sets the checkpoint for the given module to the current checkpoint.
 setModuleCheckpoint :: ModuleName -> TCM ()
 setModuleCheckpoint m = do
-  chkpt <- view eCurrentCheckpoint
-  stModuleCheckpoints %= Map.insert m chkpt
+  chkpt <- viewTC eCurrentCheckpoint
+  stModuleCheckpoints `modifyTCLens` Map.insert m chkpt
 
 -- | Get a section.
 --
@@ -561,18 +561,18 @@ addDisplayForm x df = do
   let add = updateDefinition x $ \ def -> def{ defDisplay = d : defDisplay def }
   ifM (isLocal x)
     {-then-} (modifySignature add)
-    {-else-} (stImportsDisplayForms %= HMap.insertWith (++) x [d])
+    {-else-} (stImportsDisplayForms `modifyTCLens` HMap.insertWith (++) x [d])
   whenM (hasLoopingDisplayForm x) $
     typeError . GenericDocError $ text "Cannot add recursive display form for" <+> pretty x
 
 isLocal :: QName -> TCM Bool
-isLocal x = HMap.member x <$> use (stSignature . sigDefinitions)
+isLocal x = HMap.member x <$> useTC (stSignature . sigDefinitions)
 
 getDisplayForms :: QName -> TCM [LocalDisplayForm]
 getDisplayForms q = do
   ds  <- either (const []) defDisplay <$> getConstInfo' q
-  ds1 <- HMap.lookupDefault [] q <$> use stImportsDisplayForms
-  ds2 <- HMap.lookupDefault [] q <$> use stImportedDisplayForms
+  ds1 <- HMap.lookupDefault [] q <$> useTC stImportsDisplayForms
+  ds2 <- HMap.lookupDefault [] q <$> useTC stImportedDisplayForms
   ifM (isLocal q) (return $ ds ++ ds1 ++ ds2)
                   (return $ ds1 ++ ds ++ ds2)
 
@@ -653,7 +653,7 @@ sigError f a = \case
   SigUnknown s -> f s
   SigAbstract  -> a
 
-class (Functor m, Applicative m, Monad m, HasOptions m, MonadDebug m, MonadReader TCEnv m) => HasConstInfo m where
+class (Functor m, Applicative m, Monad m, HasOptions m, MonadDebug m, MonadTCEnv m) => HasConstInfo m where
   -- | Lookup the definition of a name. The result is a closed thing, all free
   --   variables have been abstracted over.
   getConstInfo :: QName -> m Definition
@@ -686,10 +686,10 @@ getOriginalProjection :: HasConstInfo m => QName -> m QName
 getOriginalProjection q = projOrig . fromMaybe __IMPOSSIBLE__ <$> isProjection q
 
 instance HasConstInfo (TCMT IO) where
-  getRewriteRulesFor = defaultGetRewriteRulesFor get
+  getRewriteRulesFor = defaultGetRewriteRulesFor getTC
   getConstInfo' q = do
-    st  <- get
-    env <- ask
+    st  <- getTC
+    env <- askTC
     defaultGetConstInfo st env q
   getConstInfo q = getConstInfo' q >>= \case
       Right d -> return d
@@ -697,7 +697,7 @@ instance HasConstInfo (TCMT IO) where
       Left SigAbstract      -> notInScope $ qnameToConcrete q
 
 defaultGetConstInfo
-  :: (HasOptions m, MonadDebug m, MonadReader TCEnv m)
+  :: (HasOptions m, MonadDebug m, MonadTCEnv m)
   => TCState -> TCEnv -> QName -> m (Either SigError Definition)
 defaultGetConstInfo st env q = do
     let defs  = st^.(stSignature . sigDefinitions)
@@ -730,6 +730,10 @@ instance HasConstInfo m => HasConstInfo (MaybeT m) where
   getRewriteRulesFor = lift . getRewriteRulesFor
 
 instance HasConstInfo m => HasConstInfo (ExceptT err m) where
+  getConstInfo' = lift . getConstInfo'
+  getRewriteRulesFor = lift . getRewriteRulesFor
+
+instance HasConstInfo m => HasConstInfo (ReaderT r m) where
   getConstInfo' = lift . getConstInfo'
   getRewriteRulesFor = lift . getRewriteRulesFor
 
@@ -874,11 +878,11 @@ getDefModule f = do
 -- | Compute the number of free variables of a defined name. This is the sum of
 --   number of parameters shared with the current module and the number of
 --   anonymous variables (if the name comes from a let-bound module).
-getDefFreeVars :: (Functor m, Applicative m, ReadTCState m, MonadReader TCEnv m) => QName -> m Nat
+getDefFreeVars :: (Functor m, Applicative m, ReadTCState m, MonadTCEnv m) => QName -> m Nat
 getDefFreeVars = getModuleFreeVars . qnameModule
 
 freeVarsToApply :: (Functor m, HasConstInfo m, HasOptions m,
-                    ReadTCState m, MonadReader TCEnv m, MonadDebug m)
+                    ReadTCState m, MonadTCEnv m, MonadDebug m)
                 => QName -> m Args
 freeVarsToApply q = do
   vs <- moduleParamsToApply $ qnameModule q
@@ -889,7 +893,7 @@ freeVarsToApply q = do
 
 {-# SPECIALIZE getModuleFreeVars :: ModuleName -> TCM Nat #-}
 {-# SPECIALIZE getModuleFreeVars :: ModuleName -> ReduceM Nat #-}
-getModuleFreeVars :: (Functor m, Applicative m, MonadReader TCEnv m, ReadTCState m)
+getModuleFreeVars :: (Functor m, Applicative m, MonadTCEnv m, ReadTCState m)
                   => ModuleName -> m Nat
 getModuleFreeVars m = do
   m0   <- commonParentModule m <$> currentModule
@@ -910,7 +914,7 @@ getModuleFreeVars m = do
 --          ... M₁.M₂.f [insert Γ raised by Θ]
 --   @
 moduleParamsToApply :: (Functor m, Applicative m, HasOptions m,
-                        MonadReader TCEnv m, ReadTCState m, MonadDebug m)
+                        MonadTCEnv m, ReadTCState m, MonadDebug m)
                     => ModuleName -> m Args
 moduleParamsToApply m = do
   -- Get the correct number of free variables (correctly raised) of @m@.
@@ -967,7 +971,7 @@ inFreshModuleIfFreeParams k = do
 {-# SPECIALIZE instantiateDef :: Definition -> TCM Definition #-}
 instantiateDef
   :: ( Functor m, HasConstInfo m, HasOptions m
-     , ReadTCState m, MonadReader TCEnv m, MonadDebug m )
+     , ReadTCState m, MonadTCEnv m, MonadDebug m )
   => Definition -> m Definition
 instantiateDef d = do
   vs  <- freeVarsToApply $ defName d
@@ -980,7 +984,7 @@ instantiateDef d = do
   return $ d `apply` vs
 
 instantiateRewriteRule :: (Functor m, HasConstInfo m, HasOptions m,
-                           ReadTCState m, MonadReader TCEnv m, MonadDebug m)
+                           ReadTCState m, MonadTCEnv m, MonadDebug m)
                        => RewriteRule -> m RewriteRule
 instantiateRewriteRule rew = do
   traceSLn "rewriting" 95 ("instantiating rewrite rule " ++ show (rewName rew) ++ " to the local context.") $ do
@@ -991,7 +995,7 @@ instantiateRewriteRule rew = do
   return rew'
 
 instantiateRewriteRules :: (Functor m, HasConstInfo m, HasOptions m,
-                            ReadTCState m, MonadReader TCEnv m, MonadDebug m)
+                            ReadTCState m, MonadTCEnv m, MonadDebug m)
                         => RewriteRules -> m RewriteRules
 instantiateRewriteRules = mapM instantiateRewriteRule
 
@@ -1022,20 +1026,20 @@ makeAbstract d =
 
 -- | Enter abstract mode. Abstract definition in the current module are transparent.
 {-# SPECIALIZE inAbstractMode :: TCM a -> TCM a #-}
-inAbstractMode :: MonadReader TCEnv m => m a -> m a
-inAbstractMode = local $ \e -> e { envAbstractMode = AbstractMode,
+inAbstractMode :: MonadTCEnv m => m a -> m a
+inAbstractMode = localTC $ \e -> e { envAbstractMode = AbstractMode,
                                    envAllowDestructiveUpdate = False }
                                     -- Allowing destructive updates when seeing through
                                     -- abstract may break the abstraction.
 
 -- | Not in abstract mode. All abstract definitions are opaque.
 {-# SPECIALIZE inConcreteMode :: TCM a -> TCM a #-}
-inConcreteMode :: MonadReader TCEnv m => m a -> m a
-inConcreteMode = local $ \e -> e { envAbstractMode = ConcreteMode }
+inConcreteMode :: MonadTCEnv m => m a -> m a
+inConcreteMode = localTC $ \e -> e { envAbstractMode = ConcreteMode }
 
 -- | Ignore abstract mode. All abstract definitions are transparent.
-ignoreAbstractMode :: MonadReader TCEnv m => m a -> m a
-ignoreAbstractMode = local $ \e -> e { envAbstractMode = IgnoreAbstractMode,
+ignoreAbstractMode :: MonadTCEnv m => m a -> m a
+ignoreAbstractMode = localTC $ \e -> e { envAbstractMode = IgnoreAbstractMode,
                                        envAllowDestructiveUpdate = False }
                                        -- Allowing destructive updates when ignoring
                                        -- abstract may break the abstraction.
@@ -1043,7 +1047,7 @@ ignoreAbstractMode = local $ \e -> e { envAbstractMode = IgnoreAbstractMode,
 -- | Enter concrete or abstract mode depending on whether the given identifier
 --   is concrete or abstract.
 {-# SPECIALIZE inConcreteOrAbstractMode :: QName -> (Definition -> TCM a) -> TCM a #-}
-inConcreteOrAbstractMode :: (MonadReader TCEnv m, HasConstInfo m) => QName -> (Definition -> m a) -> m a
+inConcreteOrAbstractMode :: (MonadTCEnv m, HasConstInfo m) => QName -> (Definition -> m a) -> m a
 inConcreteOrAbstractMode q cont = do
   -- Andreas, 2015-07-01: If we do not ignoreAbstractMode here,
   -- we will get ConcreteDef for abstract things, as they are turned into axioms.
@@ -1055,8 +1059,8 @@ inConcreteOrAbstractMode q cont = do
 -- | Check whether a name might have to be treated abstractly (either if we're
 --   'inAbstractMode' or it's not a local name). Returns true for things not
 --   declared abstract as well, but for those 'makeAbstract' will have no effect.
-treatAbstractly :: MonadReader TCEnv m => QName -> m Bool
-treatAbstractly q = asks $ treatAbstractly' q
+treatAbstractly :: MonadTCEnv m => QName -> m Bool
+treatAbstractly q = asksTC $ treatAbstractly' q
 
 -- | Andreas, 2015-07-01:
 --   If the @current@ module is a weak suffix of the identifier module,
@@ -1083,7 +1087,7 @@ treatAbstractly' q env = case envAbstractMode env of
 {-# SPECIALIZE typeOfConst :: QName -> TCM Type #-}
 typeOfConst
   :: ( Functor m, HasConstInfo m, HasOptions m
-     , ReadTCState m, MonadReader TCEnv m, MonadDebug m )
+     , ReadTCState m, MonadTCEnv m, MonadDebug m )
   => QName -> m Type
 typeOfConst q = defType <$> (instantiateDef =<< getConstInfo q)
 

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
@@ -5,13 +5,18 @@ import Control.Monad.Reader
 
 import Agda.Syntax.Abstract.Name (QName)
 import Agda.Syntax.Internal (ModuleName, Telescope)
-import Agda.TypeChecking.Monad.Base (TCM, ReadTCState, HasOptions, TCEnv, Definition, RewriteRules)
+
+import Agda.TypeChecking.Monad.Base
+  ( TCM, ReadTCState, HasOptions, TCEnv, MonadTCEnv
+  , Definition, RewriteRules
+  )
 import Agda.TypeChecking.Monad.Debug (MonadDebug)
+
 import Agda.Utils.Pretty (prettyShow)
 
 data SigError = SigUnknown String | SigAbstract
 
-class (Functor m, Applicative m, Monad m, HasOptions m, MonadDebug m, MonadReader TCEnv m) => HasConstInfo m where
+class (Functor m, Applicative m, Monad m, HasOptions m, MonadDebug m, MonadTCEnv m) => HasConstInfo m where
   getConstInfo :: QName -> m Definition
   getConstInfo q = getConstInfo' q >>= \case
       Right d -> return d

--- a/src/full/Agda/TypeChecking/Monad/Statistics.hs
+++ b/src/full/Agda/TypeChecking/Monad/Statistics.hs
@@ -23,11 +23,11 @@ import Agda.Utils.String
 
 -- | Get the statistics.
 getStatistics :: TCM Statistics
-getStatistics = use stStatistics
+getStatistics = useTC stStatistics
 
 -- | Modify the statistics via given function.
 modifyStatistics :: (Statistics -> Statistics) -> TCM ()
-modifyStatistics f = stStatistics %= f
+modifyStatistics f = stStatistics `modifyTCLens` f
 
 -- | Increase specified counter by @1@.
 tick :: String -> TCM ()

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -57,21 +57,21 @@ traceCall mkCall m = do
   -- -- outside the current file
   verboseS "check.ranges" 90 $
     Strict.whenJust (rangeFile callRange) $ \f -> do
-      currentFile <- asks envCurrentPath
+      currentFile <- asksTC envCurrentPath
       when (currentFile /= Just f) $ do
         reportSLn "check.ranges" 90 $
           prettyShow call ++
           " is setting the current range to " ++ show callRange ++
           " which is outside of the current file " ++ show currentFile
   cl <- liftTCM $ buildClosure call
-  let trace = local $ foldr (.) id $
+  let trace = localTC $ foldr (.) id $
         [ \e -> e { envCall = Just cl } | interestingCall cl ] ++
         [ \e -> e { envHighlightingRange = callRange }
           | callRange /= noRange && highlightCall call || isNoHighlighting call ] ++
         [ \e -> e { envRange = callRange } | callRange /= noRange ]
-  wrap <- ifM (do l <- envHighlightingLevel <$> ask
+  wrap <- ifM (do l <- envHighlightingLevel <$> askTC
                   return (l == Interactive && highlightCall call))
-              (do oldRange <- envHighlightingRange <$> ask
+              (do oldRange <- envHighlightingRange <$> askTC
                   return $ highlightAsTypeChecked oldRange callRange)
               (return id)
   wrap $ trace m
@@ -113,7 +113,7 @@ traceCall mkCall m = do
   isNoHighlighting _                = False
 
 getCurrentRange :: (MonadTCM tcm, MonadDebug tcm) => tcm Range
-getCurrentRange = asks envRange
+getCurrentRange = asksTC envRange
 
 -- | Sets the current range (for error messages etc.) to the range
 --   of the given object, if it has a range (i.e., its range is not 'noRange').

--- a/src/full/Agda/TypeChecking/Names.hs
+++ b/src/full/Agda/TypeChecking/Names.hs
@@ -76,9 +76,12 @@ instance HasBuiltins m => HasBuiltins (NamesT m) where
   getBuiltinThing b = lift $ getBuiltinThing b
 
 newtype NamesT m a = NamesT { unName :: ReaderT Names m a }
-  deriving (Functor, Applicative, Monad, MonadTrans, MonadIO, HasOptions, MonadDebug)
+  deriving ( Functor, Applicative, Monad
+           , MonadTrans, MonadState s
+           , MonadIO, HasOptions, MonadDebug
+           , MonadTCEnv, MonadTCState, MonadTCM )
 
-deriving instance MonadState s m => MonadState s (NamesT m)
+-- deriving instance MonadState s m => MonadState s (NamesT m)
 
 type Names = [String]
 
@@ -154,10 +157,3 @@ ilam :: Monad m
     => ArgName -> (NamesT m Term -> NamesT m Term) -> NamesT m Term
 ilam n f = glam (setRelevance Irrelevant defaultArgInfo) n f
 
-
-instance MonadTCM m => MonadTCM (NamesT m) where
-   liftTCM = lift . liftTCM
-
-instance MonadReader r m => MonadReader r (NamesT m) where
-  ask = lift ask
-  local f (NamesT m) = NamesT $ mapReaderT (local f) m

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -577,8 +577,8 @@ computeOccurrences' :: QName -> TCM OccurrencesBuilder
 computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do
   reportSDoc "tc.pos" 25 $ do
     let a = defAbstract def
-    m <- asks envAbstractMode
-    cur <- asks envCurrentModule
+    m <- asksTC envAbstractMode
+    cur <- asksTC envCurrentModule
     text "computeOccurrences" <+> prettyTCM q <+> text (show a) <+> text (show m)
       <+> prettyTCM cur
   OccursAs (InDefOf q) <$> case theDef def of

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -146,7 +146,7 @@ instance ToTerm Str     where toTerm = return $ Lit . LitString noRange . unStr
 instance ToTerm QName   where toTerm = return $ Lit . LitQName noRange
 instance ToTerm MetaId  where
   toTerm = do
-    file <- fromMaybe __IMPOSSIBLE__ <$> asks TCM.envCurrentPath
+    file <- fromMaybe __IMPOSSIBLE__ <$> asksTC TCM.envCurrentPath
     return $ Lit . LitMeta noRange file
 
 instance ToTerm Integer where

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -55,7 +55,7 @@ data QuotingKit = QuotingKit
 
 quotingKit :: TCM QuotingKit
 quotingKit = do
-  currentFile     <- fromMaybe __IMPOSSIBLE__ <$> asks envCurrentPath
+  currentFile     <- fromMaybe __IMPOSSIBLE__ <$> asksTC envCurrentPath
   hidden          <- primHidden
   instanceH       <- primInstance
   visible         <- primVisible

--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -578,7 +578,7 @@ translateRecordPatterns clause = do
 newtype RecPatM a = RecPatM (TCMT (ReaderT Nat (StateT Nat IO)) a)
   deriving (Functor, Applicative, Monad,
             MonadIO, MonadTCM, HasOptions, MonadDebug,
-            MonadReader TCEnv, MonadState TCState)
+            MonadTCEnv, MonadTCState)
 
 -- | Runs a computation in the 'RecPatM' monad.
 

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -136,8 +136,8 @@ recordFieldNames = map (fmap (nameConcrete . qnameName)) . recFields
 -- | Find all records with at least the given fields.
 findPossibleRecords :: [C.Name] -> TCM [QName]
 findPossibleRecords fields = do
-  defs  <- HMap.elems <$> use (stSignature . sigDefinitions)
-  idefs <- HMap.elems <$> use (stImports   . sigDefinitions)
+  defs  <- HMap.elems <$> useTC (stSignature . sigDefinitions)
+  idefs <- HMap.elems <$> useTC (stImports   . sigDefinitions)
   return $ cands defs ++ cands idefs
   where
     cands defs = [ defName d | d <- defs, possible d ]
@@ -569,11 +569,11 @@ etaExpandRecord' forceEta r pars u = do
   (tel, _, _, args) <- etaExpandRecord'_ forceEta r pars def u
   return (tel, args)
 
-etaExpandRecord_ :: (MonadReader TCEnv m, HasOptions m, MonadDebug m)
+etaExpandRecord_ :: (MonadTCEnv m, HasOptions m, MonadDebug m)
                  => QName -> Args -> Defn -> Term -> m (Telescope, ConHead, ConInfo, Args)
 etaExpandRecord_ = etaExpandRecord'_ False
 
-etaExpandRecord'_ :: (MonadReader TCEnv m, HasOptions m, MonadDebug m)
+etaExpandRecord'_ :: (MonadTCEnv m, HasOptions m, MonadDebug m)
                   => Bool -> QName -> Args -> Defn -> Term -> m (Telescope, ConHead, ConInfo, Args)
 etaExpandRecord'_ forceEta r pars def u = do
   let Record{ recConHead     = con

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -403,7 +403,7 @@ fastReduce' norm v = do
   trustme <- fmap primFunName <$> getPrimitive' "primTrustMe"
   let bEnv = BuiltinEnv { bZero = zero, bSuc = suc, bTrue = true, bFalse = false, bRefl = refl,
                           bPrimForce = force, bPrimTrustMe = trustme }
-  allowedReductions <- asks envAllowedReductions
+  allowedReductions <- asksTC envAllowedReductions
   rwr <- optRewriting <$> pragmaOptions
   constInfo <- unKleisli $ \f -> do
     info <- getConstInfo f

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -78,12 +78,12 @@ withFreshName_ = withFreshName noRange
 
 addCtx :: (MonadReduce m) => Name -> Dom Type -> m a -> m a
 addCtx x a ret = do
-  ctx <- asks $ map (fst . unDom) . envContext
+  ctx <- asksTC $ map (fst . unDom) . envContext
   let x' = unshadowedName ctx x
       ce = (x',) <$> a
-  oldChkpt <- view eCurrentCheckpoint
+  oldChkpt <- viewTC eCurrentCheckpoint
   withFreshR $ \ chkpt ->
-    local (\e -> e { envContext = ce : envContext e
+    localTC (\e -> e { envContext = ce : envContext e
                    , envCurrentCheckpoint = chkpt
                    , envCheckpoints = Map.insert chkpt IdS $
                                         fmap (raise 1) (envCheckpoints e)

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -871,7 +871,7 @@ checkLHS mf st@(LHSState tel ip problem target psplit) = updateRelevance $ do
   if isSolvedProblem problem then
     liftTCM $ (problem ^. problemCont) st
   else do
-    unlessM (optPatternMatching <$> gets getPragmaOptions) $
+    unlessM (optPatternMatching <$> getsTC getPragmaOptions) $
       unless (problemAllVariables problem) $
         typeError $ GenericError $ "Pattern matching is disabled"
 
@@ -1646,7 +1646,7 @@ checkSortOfSplitVar a = do
   infOk <- optOmegaInOmega <$> pragmaOptions
   liftTCM (reduce $ getSort a) >>= \case
     Type{} -> return ()
-    Prop{} -> asks envRelevance >>= \case
+    Prop{} -> asksTC envRelevance >>= \case
       Irrelevant -> return ()
       _          -> softTypeError $ GenericError
         "Cannot split on datatype in Prop unless target is irrelevant"

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -299,7 +299,7 @@ checkPath b@(Arg info (A.TBind _ xs' typ)) body ty = do
         rhs' = subst 0 iOne  v
     let t = Lam info $ Abs (nameToArgName x) v
     let btyp i = El s (unArg typ `apply` [argN i])
-    locally eRange (const noRange) $ blockTerm ty $ traceCall (SetRange $ getRange body) $ do
+    locallyTC eRange (const noRange) $ blockTerm ty $ traceCall (SetRange $ getRange body) $ do
       equalTerm (btyp iZero) lhs' (unArg lhs)
       equalTerm (btyp iOne) rhs' (unArg rhs)
       return t
@@ -508,7 +508,7 @@ checkAbsurdLambda cmp i h e t = do
           aux <- qualify top <$> freshName_ (getRange i, absurdLambdaName)
           -- if we are in irrelevant position, the helper function
           -- is added as irrelevant
-          rel <- asks envRelevance
+          rel <- asksTC envRelevance
           reportSDoc "tc.term.absurd" 10 $ vcat
             [ text "Adding absurd function" <+> prettyTCM rel <> prettyTCM aux
             , nest 2 $ text "of type" <+> prettyTCM t'
@@ -553,7 +553,7 @@ checkExtendedLambda cmp i di qname cs e t = do
    t <- instantiateFull t
    ifBlockedType t (\ m t' -> postponeTypeCheckingProblem_ $ CheckExpr cmp e t') $ \ _ t -> do
      j   <- currentOrFreshMutualBlock
-     rel <- asks envRelevance
+     rel <- asksTC envRelevance
      let info = setRelevance rel defaultArgInfo
 
      reportSDoc "tc.term.exlam" 20 $
@@ -601,14 +601,14 @@ catchIlltypedPatternBlockedOnMeta m handle = do
 
   -- Andreas, 2016-07-13, issue 2028.
   -- Save the state to rollback the changes to the signature.
-  st <- get
+  st <- getTC
 
   m `catchError` \ err -> do
 
     let reraise = throwError err
 
     x <- maybe reraise return =<< case err of
-      TypeError s cl -> localState $ put s >> do
+      TypeError s cl -> localTCState $ putTC s >> do
         enterClosure cl $ \case
           IlltypedPattern p a -> isBlockedType a
           SplitError (UnificationStuck c tel us vs _) -> do
@@ -630,7 +630,7 @@ catchIlltypedPatternBlockedOnMeta m handle = do
     -- 2. We added a constant without definition.
     -- In fact, they are not so harmless, see issue 2028!
     -- Thus, reset the state!
-    put st
+    putTC st
 
     -- The meta might not be known in the reset state, as it could have been created
     -- somewhere on the way to the type error.
@@ -1006,7 +1006,7 @@ checkExpr' cmp e t0 =
         A.RecUpdate ei recexpr fs -> checkRecordUpdate cmp ei recexpr fs e t
 
         A.DontCare e -> -- resurrect vars
-          ifM ((Irrelevant ==) <$> asks envRelevance)
+          ifM ((Irrelevant ==) <$> asksTC envRelevance)
             (dontCare <$> do applyRelevanceToContext Irrelevant $ checkExpr' cmp e t)
             (internalError "DontCare may only appear in irrelevant contexts")
 
@@ -1158,7 +1158,7 @@ unquoteTactic tac hole goal k = do
   ok  <- runUnquoteM $ unquoteTCM tac hole
   case ok of
     Left (BlockedOnMeta oldState x) -> do
-      put oldState
+      putTC oldState
       mi <- Map.lookup x <$> getMetaStore
       (r, unblock) <- case mi of
         Nothing -> do -- fresh meta: need to block on something else!
@@ -1419,7 +1419,7 @@ checkLetBinding b@(A.LetPatBind i p e) ret =
       , nest 2 $ vcat
         [ text "p (A) =" <+> prettyA p
         , text "t     =" <+> prettyTCM t
-        , text "cxtRel=" <+> do pretty =<< asks envRelevance
+        , text "cxtRel=" <+> do pretty =<< asksTC envRelevance
         ]
       ]
     fvs <- getContextSize
@@ -1431,7 +1431,7 @@ checkLetBinding b@(A.LetPatBind i p e) ret =
       reportSDoc "tc.term.let.pattern" 20 $ nest 2 $ vcat
         [ text "p (I) =" <+> prettyTCM p
         , text "delta =" <+> prettyTCM delta
-        , text "cxtRel=" <+> do pretty =<< asks envRelevance
+        , text "cxtRel=" <+> do pretty =<< asksTC envRelevance
         ]
       reportSDoc "tc.term.let.pattern" 80 $ nest 2 $ vcat
         [ text "p (I) =" <+> (text . show) p

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -144,7 +144,7 @@ encode a = do
 
 decode :: EmbPrj a => L.ByteString -> TCM (Maybe a)
 decode s = do
-  mf   <- use stModuleToSource
+  mf   <- useTC stModuleToSource
   incs <- getIncludeDirs
 
   -- Note that B.runGetState and G.decompress can raise errors if the
@@ -174,7 +174,7 @@ decode s = do
 
   case mf of
     Nothing -> return ()
-    Just mf -> stModuleToSource .= mf
+    Just mf -> stModuleToSource `setTCLens` mf
 
   case r of
     Right x   -> return (Just x)

--- a/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
@@ -321,11 +321,11 @@ castConstraintToCurrentContext :: Closure TCM.Constraint -> MaybeT TCM TCM.Const
 castConstraintToCurrentContext cl = do
   -- The checkpoint of the contraint
   let cp = envCurrentCheckpoint $ clEnv cl
-  sigma <- caseMaybeM (view $ eCheckpoints . key cp)
+  sigma <- caseMaybeM (viewTC $ eCheckpoints . key cp)
           (do
             -- We are not in a descendant of the constraint checkpoint.
             -- Here be dragons!!
-            gamma <- asks envContext -- The target context
+            gamma <- asksTC envContext -- The target context
             let findInGamma (Dom {unDom = (x, t)}) =
                   -- match by name (hazardous)
                   -- This is one of the seven deadly sins (not respecting alpha).
@@ -549,7 +549,7 @@ solveCluster flag ccs = do
               reportSDoc "tc.size.solve" 30 $
                 prettyTCM (MetaV m []) <+> text "is frozen, cannot set it to ∞"
               return False
-        ifM (isFrozen m `or2M` do not <$> asks envAssignMetas) no $ {-else-} do
+        ifM (isFrozen m `or2M` do not <$> asksTC envAssignMetas) no $ {-else-} do
           reportSDoc "tc.size.solve" 20 $
             text "solution " <+> prettyTCM (MetaV m []) <+>
             text " := "      <+> prettyTCM inf

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -34,8 +34,8 @@ genericNonFatalError = warning . GenericNonFatalError
 {-# SPECIALIZE warning_ :: Warning -> TCM TCWarning #-}
 warning_ :: MonadTCM tcm => Warning -> tcm TCWarning
 warning_ w = do
-  r <- view eRange
-  c <- view eCall
+  r <- viewTC eRange
+  c <- viewTC eCall
   b <- liftTCM areWeCaching
   -- NicifierIssues print their own error locations in their list of
   -- issues (but we might need to keep the overall range `r` for
@@ -66,7 +66,7 @@ warnings ws = do
     tcwarn <- warning_ w'
     if wmode ^. warn2Error
     then typeError $ NonFatalErrors [tcwarn]
-    else stTCWarnings %= add w' tcwarn
+    else stTCWarnings `modifyTCLens` add w' tcwarn
 
 {-# SPECIALIZE warning :: Warning -> TCM () #-}
 warning :: MonadTCM tcm => Warning -> tcm ()

--- a/src/full/Agda/Utils/ListT.hs
+++ b/src/full/Agda/Utils/ListT.hs
@@ -23,6 +23,10 @@ import Agda.Utils.Maybe
 newtype ListT m a = ListT { runListT :: m (Maybe (a, ListT m a)) }
   deriving (Functor)
 
+-- | Boilerplate function to lift 'MonadReader' through the 'ListT' transformer.
+mapListT :: (m (Maybe (a, ListT m a)) -> n (Maybe (b, ListT n b))) -> ListT m a -> ListT n b
+mapListT f = ListT . f . runListT
+
 -- * List operations
 
 -- | The empty lazy list.


### PR DESCRIPTION
This PR has the following effect:
`TCM` is now a `MonadTCEnv` and `MonadTCState`, and no longer a `MonadReader TCEnv` nor a `MonadState TCState`.
Dedicated state accessor are defined, mostly with suffix `TC`, e.g.,`askTC`, `localTC`, `getTC`, `putTC`, `modifyTC`, `useTC`, `locallyTC` etc.

The advantage of this long awaited refactoring is that we can now painlessly stack state and reader monads on top of `TCM` and use `MonadReader` and `MonadState` for the new state components.

Created a PR for testing on travis.