### PR TITLE
[ haddock ] Fix haddock formatting

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -206,23 +206,23 @@ data DeclarationWarning
   | EmptyPostulate Range  -- ^ Empty @postulate@ block.
   | EmptyPrivate Range    -- ^ Empty @private@   block.
   | InvalidCatchallPragma Range
-      -- ^ A {-# CATCHALL #-} pragma
+      -- ^ A {-\# CATCHALL \#-} pragma
       --   that does not precede a function clause.
   | InvalidNoPositivityCheckPragma Range
-      -- ^ A {-# NO_POSITIVITY_CHECK #-} pragma
+      -- ^ A {-\# NO_POSITIVITY_CHECK \#-} pragma
       --   that does not apply to any data or record type.
   | InvalidNoUniverseCheckPragma Range
-      -- ^ A {-# NO_UNIVERSE_CHECK #-} pragma
+      -- ^ A {-\# NO_UNIVERSE_CHECK \#-} pragma
       --   that does not apply to a data or record type.
   | InvalidTerminationCheckPragma Range
-      -- ^ A {-# TERMINATING #-} and {-# NON_TERMINATING #-} pragma
+      -- ^ A {-\# TERMINATING \#-} and {-\# NON_TERMINATING \#-} pragma
       --   that does not apply to any function.
   | MissingDefinitions [Name]
   | NotAllowedInMutual Range String
   | PolarityPragmasButNotPostulates [Name]
   | PragmaNoTerminationCheck Range
-  -- ^ Pragma @{-# NO_TERMINATION_CHECK #-}@ has been replaced
-  --   by @{-# TERMINATING #-}@ and @{-# NON_TERMINATING #-}@.
+  -- ^ Pragma @{-\# NO_TERMINATION_CHECK \#-}@ has been replaced
+  --   by @{-\# TERMINATING \#-}@ and @{-\# NON_TERMINATING \#-}@.
   | UnknownFixityInMixfixDecl [Name]
   | UnknownNamesInFixityDecl [Name]
   | UnknownNamesInPolarityPragmas [Name]

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -176,7 +176,7 @@ data PreScopeState = PreScopeState
     -- ^ Display forms added by someone else to imported identifiers
   , stPreImportedInstanceDefs :: !InstanceTable
   , stPreForeignCode        :: !(Map BackendName [ForeignCode])
-    -- ^ @{-# FOREIGN #-}@ code that should be included in the compiled output.
+    -- ^ @{-\# FOREIGN \#-}@ code that should be included in the compiled output.
     -- Does not include code for imported modules.
   , stPreFreshInteractionId :: !InteractionId
   , stPreImportedUserWarnings :: !(Map A.QName String)
@@ -2615,7 +2615,7 @@ data Warning
   | OldBuiltin               String String
     -- ^ In `OldBuiltin old new`, the BUILTIN old has been replaced by new
   | EmptyRewritePragma
-    -- ^ If the user wrote just @{-# REWRITE #-}@.
+    -- ^ If the user wrote just @{-\# REWRITE \#-}@.
   | UselessPublic
     -- ^ If the user opens a module public before the module header.
     --   (See issue #2377.)

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -124,7 +124,7 @@ addClauses q cls = do
 mkPragma :: String -> TCM CompilerPragma
 mkPragma s = CompilerPragma <$> getCurrentRange <*> pure s
 
--- | Add a compiler pragma `{-# COMPILE <backend> <name> <text> #-}`
+-- | Add a compiler pragma `{-\# COMPILE <backend> <name> <text> \#-}`
 addPragma :: BackendName -> QName -> String -> TCM ()
 addPragma b q s = modifySignature . updateDefinition q . addCompilerPragma b =<< mkPragma s
 

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -7,13 +7,13 @@
 --
 --   The user specifies a relation symbol by the pragma
 --   @
---       {-# BUILTIN REWRITE rel #-}
+--       {-\# BUILTIN REWRITE rel \#-}
 --   @
 --   where @rel@ should be of type @Δ → (lhs rhs : A) → Set i@.
 --
 --   Then the user can add rewrite rules by the pragma
 --   @
---       {-# REWRITE q #-}
+--       {-\# REWRITE q \#-}
 --   @
 --   where @q@ should be a closed term of type @Γ → rel us lhs rhs@.
 --


### PR DESCRIPTION
Seems that haddock is hiding contents between two `#`s:

![image](https://user-images.githubusercontent.com/16398479/46912384-4360ab00-cf42-11e8-8fed-8ef1c10c0c48.png)
![image](https://user-images.githubusercontent.com/16398479/46912387-465b9b80-cf42-11e8-8947-b4858983ba4a.png)

This is making the generated haddock look weird.

I did a search with `grep -irnE "\-\-[^\n\]+{-#" src/full` and added backslash before all the `#`s in the `{-# #-}` structures in the haddocks.