### PR TITLE
[ #3266 ] hashFile -> hashTextFile

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -22,6 +22,7 @@ default : ac \
           regexp-talk \
           relocatable-interfaces \
           simplelib \
+          uptodate \
           view \
 
 agda = $(AGDA_BIN)
@@ -171,6 +172,14 @@ relocatable-interfaces : relocatable/originals/*.agda
 				# ...and skips one of the modules (A).
 	@[ `grep "^ *Loading" relocatable/copies/output | wc -l` = 1 ]
 	@rm -rf relocatable/copies
+
+.PHONY : uptodate
+uptodate : uptodate/*.agda
+	@$(echo) "Testing that already imported modules are up-to-date" # despite having DOS line-endings
+	@$(agda) -v5 --ignore-interfaces -iuptodate --no-libraries uptodate/A.agda > uptodate/output
+	@cat uptodate/output
+	@[ `grep "C is up-to-date" uptodate/output | wc -l` = 1 ]
+	@rm -f uptodate/output
 
 .PHONY : malformed-interfaces
 malformed-interfaces : malformed/Empty.agda

--- a/examples/uptodate/A.agda
+++ b/examples/uptodate/A.agda
@@ -1,0 +1,4 @@
+module A where
+
+import B
+import C

--- a/examples/uptodate/B.agda
+++ b/examples/uptodate/B.agda
@@ -1,0 +1,3 @@
+module B where
+
+import C

--- a/examples/uptodate/C.agda
+++ b/examples/uptodate/C.agda
@@ -1,0 +1,1 @@
+module C where

--- a/examples/uptodate/C.agda
+++ b/examples/uptodate/C.agda
@@ -1,1 +1,14 @@
+-- This module contains various line-ending characters in order
+-- to test that they don't affect module source hash calculation.
 module C where
+-- CR ----
+-- LF --
+--
+-- CRLF --
+--
+-- LFCR --
+--
+-- FF ----
+-- NEXT LINE ----
+-- LINE SEPARATOR -- --
+-- PARAGRAPH SEPARATOR -- --

--- a/src/fix-agda-whitespace/FixWhitespace.hs
+++ b/src/fix-agda-whitespace/FixWhitespace.hs
@@ -49,6 +49,7 @@ validDir base =
     map (\d -> filePath /=? base </> d)
         [ "_darcs", ".git", "std-lib", "test/bugs"
         , "test/Succeed/LineEndings"
+        , "examples/uptodate"
         ])
 
 -- Andreas (24 Sep 2014).

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -362,7 +362,7 @@ getInterface' x isMain msi = do
           -- If it's cached ignoreInterfaces has no effect;
           -- to avoid typechecking a file more than once.
         sourceH <- case msi of
-                     Nothing -> liftIO $ hashFile file
+                     Nothing -> liftIO $ hashTextFile file
                      Just si -> return $ hashText (siSource si)
         ifaceH  <-
           case cached of

--- a/src/full/Agda/Utils/Hash.hs
+++ b/src/full/Agda/Utils/Hash.hs
@@ -14,16 +14,17 @@ import Data.Text.Lazy (Text)
 import qualified Data.Text.Lazy as T
 
 import Agda.Utils.FileName
+import Agda.Utils.IO.UTF8 (readTextFile)
 
 type Hash = Word64
 
 hashByteString :: ByteString -> Hash
 hashByteString = H.asWord64 . B.foldl' (\h b -> H.combine h (H.hashWord8 b)) (H.hashWord8 0)
 
-hashFile :: AbsolutePath -> IO Hash
-hashFile file = do
-  s <- B.readFile (filePath file)
-  return $ hashByteString s
+hashTextFile :: AbsolutePath -> IO Hash
+hashTextFile file = do
+  s <- readTextFile (filePath file)
+  return $ hashText s
 
 -- | Hashes a piece of 'Text'.
 


### PR DESCRIPTION
Text files should be hashed with hashText in order to ignore line-endings.