### PR TITLE
Add --html-highlight support for the HTML backend

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -186,6 +186,7 @@ library
                 , time >= 1.5.0.1 && < 1.9
                 , unordered-containers >= 0.2.5.0 && < 0.3
                 , uri-encode >= 1.5.0.4 && < 1.6
+                , split >= 0.2.0.0 && < 0.2.3.4
 
   -- In hTags the mtl library must be compiled with the version of
   -- transformers shipped with GHC, so we use that version in Agda (see,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,17 @@ Pragmas and options
   written using `--omega-in-omega` is still compatible with normal
   universe-polymorphic code and can be used in such files.
 
+* New option `--html-highlight=[code,all]`.
+
+  The option `--html-highlight=code` makes the HTML-backend generate
+  files with: no HTML footer/header, Agda codes highlighted and
+  other parts as-is.
+
+  This makes it possible to use an ordinary markdown processor
+  to render the generated HTML.
+
+  The old and default behaviour is still `--html-highlight=all`.
+
 * Option `--irrelevant-projections` is now off by default and
   not considered `--safe` any longer.
   Reason: There are consistency issues that may be systemic

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -77,6 +77,10 @@ Generating highlighted source code
       Set URL of the CSS file used by the HTML files to
       :samp:`{URL}` (can be relative)
 
+:samp:`--html-highlight=[code,all]`
+      Whether to highlight non-Agda code as comments in
+      generated HTML files (see :ref: `generating-html`)
+
 :samp:`--dependency-graph={FILE}`
       Generate a Dot_ file :samp:`{FILE}`
       with a module dependency graph

--- a/doc/user-manual/tools/generating-html.rst
+++ b/doc/user-manual/tools/generating-html.rst
@@ -15,14 +15,31 @@ You can change the way in which the code is highlighted by providing
 your own CSS file instead of the :download:`default, included one
 <../../../src/data/Agda.css>` (use the ``--css`` option).
 
+If you're using Literate Agda with markdown or reStructedText and you
+want to highlight your Agda codes with Agda's HTML backend and render
+the rest of the content (let's call it "literate" part for convenience)
+with some another renderer, you can use the ``--html-highlight=code``
+option, which makes the Agda compiler:
+
+- not wrapping the literate part into ``<a class="Background">`` tags
+- not wrapping the generated document with a ``<html>`` tag,
+  which means you'll have to specify the CSS location somewhere else,
+  like ``<link rel="stylesheet" type="text/css" href="Agda.css">``
+- converting paired ``<a class="Markup">`` tags into
+  ``<pre class="agda-code">`` tags that wrap the complete Agda code
+  block below
+
 Options
 -------
 
-:samp:`--html-dir {directory}`
+:samp:`--html-dir={directory}`
   Changes the directory where the output is placed to
   :samp:`{directory}`. Default: ``html``.
 
-:samp:`--css {URL}`
+:samp:`--css={URL}`
   The CSS_ file used by the HTML files (:samp:`{URL}` can be relative).
+
+:samp:`--html-highlight=[code,all]`
+  Highlight Agda code only or everything in the generated HTML files.
 
 .. _CSS:  https://www.w3.org/Style/CSS/

--- a/src/data/Agda.css
+++ b/src/data/Agda.css
@@ -1,5 +1,7 @@
 /* Aspects. */
 .Comment       { color: #B22222 }
+.Background    {}
+.Markup        { color: #000000 }
 .Keyword       { color: #CD6600 }
 .String        { color: #B22222 }
 .Number        { color: #A020F0 }

--- a/src/data/emacs-mode/agda2-highlight.el
+++ b/src/data/emacs-mode/agda2-highlight.el
@@ -369,6 +369,8 @@ If `agda2-highlight-face-groups' is nil."
 (defvar agda2-highlight-faces
   '((keyword                . agda2-highlight-keyword-face)
     (comment                . font-lock-comment-face)
+    (background             . font-lock-comment-face)
+    (markup                 . font-lock-comment-face)
     (string                 . agda2-highlight-string-face)
     (number                 . agda2-highlight-number-face)
     (symbol                 . agda2-highlight-symbol-face)
@@ -429,6 +431,9 @@ The aspects currently recognised are the following:
 `unsolvedconstraint'     Unsolved constraints, not connected to meta
                            variables.
 `unsolvedmeta'           Unsolved meta variables.
+`background'             Non-Agda code contents in literate mode.
+`markup'                 Delimiters to separate the Agda code blocks
+                           from other contents
 `comment'                Comments.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -437,7 +437,8 @@ tokenHighlighting = merge . map tokenToCFile
   tokenToCFile (T.TokLiteral (L.LitQName  r _)) = aToF String r
   tokenToCFile (T.TokLiteral (L.LitMeta r _ _)) = aToF String r
   tokenToCFile (T.TokComment (i, _))            = aToF Comment (P.getRange i)
-  tokenToCFile (T.TokTeX (i, _))                = aToF Comment (P.getRange i)
+  tokenToCFile (T.TokTeX (i, _))                = aToF Background (P.getRange i)
+  tokenToCFile (T.TokMarkup (i, _))             = aToF Markup (P.getRange i)
   tokenToCFile (T.TokId {})                     = mempty
   tokenToCFile (T.TokQId {})                    = mempty
   tokenToCFile (T.TokString (i,s))

--- a/src/full/Agda/Interaction/Highlighting/LaTeX.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX.hs
@@ -473,6 +473,8 @@ processCode toks' = do
       Number            -> s
       Symbol            -> s
       PrimitiveType     -> s
+      Background        -> s
+      Markup            -> s
       Name Nothing isOp -> fromAspect (Name (Just Postulate) isOp)
         -- At the time of writing the case above can be encountered in
         -- --only-scope-checking mode, for instance for the token "Size"

--- a/src/full/Agda/Interaction/Highlighting/Precise.hs
+++ b/src/full/Agda/Interaction/Highlighting/Precise.hs
@@ -72,6 +72,10 @@ data Aspect
   | Symbol                     -- ^ Symbols like forall, =, ->, etc.
   | PrimitiveType              -- ^ Things like Set and Prop.
   | Name (Maybe NameKind) Bool -- ^ Is the name an operator part?
+  | Background                 -- ^ Non-code contents in literate Agda
+  | Markup
+    -- ^ Delimiters used to separate the Agda code blocks from the
+    -- other contents in literate Agda
     deriving (Eq, Show)
 
 -- | @NameKind@s are figured out during scope checking.

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -109,6 +109,7 @@ data CommandLineOptions = Options
   , optGenerateVimFile  :: Bool
   , optGenerateLaTeX    :: Bool
   , optGenerateHTML     :: Bool
+  , optHTMLOnlyCode     :: Bool
   , optDependencyGraph  :: Maybe FilePath
   , optLaTeXDir         :: FilePath
   , optHTMLDir          :: FilePath
@@ -212,6 +213,7 @@ defaultOptions = Options
   , optGenerateVimFile  = False
   , optGenerateLaTeX    = False
   , optGenerateHTML     = False
+  , optHTMLOnlyCode     = False
   , optDependencyGraph  = Nothing
   , optLaTeXDir         = defaultLaTeXDir
   , optHTMLDir          = defaultHTMLDir
@@ -573,6 +575,12 @@ compileDirFlag f o = return $ o { optCompileDir = Just f }
 htmlFlag :: Flag CommandLineOptions
 htmlFlag o = return $ o { optGenerateHTML = True }
 
+htmlHighlightFlag :: String -> Flag CommandLineOptions
+htmlHighlightFlag "code" o = return $ o { optHTMLOnlyCode = True  }
+htmlHighlightFlag "all"  o = return $ o { optHTMLOnlyCode = False }
+htmlHighlightFlag opt    o = throwError $ "Invalid option <" ++ opt
+  ++ ">, expected <all> or <code>"
+
 dependencyGraphFlag :: FilePath -> Flag CommandLineOptions
 dependencyGraphFlag f o = return $ o { optDependencyGraph = Just f }
 
@@ -660,6 +668,8 @@ standardOptions =
                      defaultHTMLDir ++ ")")
     , Option []     ["css"] (ReqArg cssFlag "URL")
                     "the CSS file used by the HTML files (can be relative)"
+    , Option []     ["html-highlight"] (ReqArg htmlHighlightFlag "[code,all]")
+                    "whether to highlight only the code parts (code) or the file as a whole (all)"
     , Option []     ["dependency-graph"] (ReqArg dependencyGraphFlag "FILE")
                     "generate a Dot file with a module dependency graph"
     , Option []     ["ignore-interfaces"] (NoArg ignoreInterfacesFlag)

--- a/src/full/Agda/Syntax/Parser.hs
+++ b/src/full/Agda/Syntax/Parser.hs
@@ -121,7 +121,7 @@ parseLiterateWithComments p layers = do
   return$ concat [ case m of
                        Left t -> [t]
                        Right (Layer Comment interval s) -> [TokTeX (interval, s)]
-                       Right (Layer Markup _ _) -> []
+                       Right (Layer Markup interval s) -> [TokMarkup (interval, s)]
                        Right (Layer Code _ _) -> []
                    | m <- terms ]
 

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1967,6 +1967,7 @@ mkName (i, s) = do
               TokSetN{}     -> "a type universe"
               TokPropN{}    -> "a prop universe"
               TokTeX{}      -> __IMPOSSIBLE__  -- used by the LaTeX backend only
+              TokMarkup{}   -> __IMPOSSIBLE__  -- ditto
               TokComment{}  -> __IMPOSSIBLE__
               TokDummy{}    -> __IMPOSSIBLE__
               TokEOF{}      -> __IMPOSSIBLE__

--- a/src/full/Agda/Syntax/Parser/Tokens.hs
+++ b/src/full/Agda/Syntax/Parser/Tokens.hs
@@ -71,6 +71,7 @@ data Token
         | TokSetN (Interval, Integer)
         | TokPropN (Interval, Integer)
         | TokTeX (Interval, String)
+        | TokMarkup (Interval, String)
         | TokComment (Interval, String)
         | TokDummy      -- Dummy token to make Happy not complain
                         -- about overlapping cases.
@@ -87,6 +88,7 @@ instance HasRange Token where
   getRange (TokSetN (i, _))    = getRange i
   getRange (TokPropN (i, _))   = getRange i
   getRange (TokTeX (i, _))     = getRange i
+  getRange (TokMarkup (i, _))  = getRange i
   getRange (TokComment (i, _)) = getRange i
   getRange TokDummy            = noRange
   getRange TokEOF              = noRange

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
@@ -49,6 +49,8 @@ instance EmbPrj HP.Aspect where
   icod_ HP.Symbol        = icodeN' HP.Symbol
   icod_ HP.PrimitiveType = icodeN 6 ()
   icod_ (HP.Name mk b)   = icodeN 7 HP.Name mk b
+  icod_ HP.Background    = icodeN 8 ()
+  icod_ HP.Markup        = icodeN 9 ()
 
   value = vcase valu where
     valu [0]        = valuN HP.Comment
@@ -59,6 +61,8 @@ instance EmbPrj HP.Aspect where
     valu []         = valuN HP.Symbol
     valu [6]        = valuN HP.PrimitiveType
     valu [7, mk, b] = valuN HP.Name mk b
+    valu [8]        = valuN HP.Background
+    valu [9]        = valuN HP.Markup
     valu _          = malformed
 
 instance EmbPrj HP.OtherAspect where

--- a/test/Internal/Interaction/Highlighting/Precise.hs
+++ b/test/Internal/Interaction/Highlighting/Precise.hs
@@ -111,6 +111,8 @@ instance CoArbitrary Aspect where
   coarbitrary PrimitiveType = variant 6
   coarbitrary (Name nk b)   =
     variant 7 . maybeCoGen coarbitrary nk . coarbitrary b
+  coarbitrary Background    = variant 8
+  coarbitrary Markup        = variant 9
 
 instance Arbitrary NameKind where
   arbitrary = oneof $ [liftM Constructor arbitrary] ++

--- a/test/LaTeXAndHTML/Tests.hs
+++ b/test/LaTeXAndHTML/Tests.hs
@@ -139,12 +139,15 @@ mkLaTeXOrHTMLTest k agdaBin inp =
     extraFlags <- if flagFileExists
                   then lines <$> readFile flagFile
                   else return []
-    let agdaArgs = flags outDir ++
-                   [ "-i" ++ testDir
-                   , inp
-                   , "--ignore-interfaces"
-                   , "--no-libraries"
-                   ] ++ extraFlags
+    let agdaArgs' = flags outDir ++
+                    [ "-i" ++ testDir
+                    , inp
+                    , "--ignore-interfaces"
+                    , "--no-libraries"
+                    ] ++ extraFlags
+    let agdaArgs = if takeFileName inp == "MdPreserveLit.lagda.md"
+                   then "--html-highlight=code" : agdaArgs'
+                   else agdaArgs'
     res@(ret, _, _) <- PT.readProcessWithExitCode agdaBin agdaArgs T.empty
     if ret /= ExitSuccess then
       return $ AgdaFailed res

--- a/test/LaTeXAndHTML/succeed/AccidentalSpacesAfterBeginCode.html
+++ b/test/LaTeXAndHTML/succeed/AccidentalSpacesAfterBeginCode.html
@@ -1,13 +1,13 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>AccidentalSpacesAfterBeginCode</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>AccidentalSpacesAfterBeginCode</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}     
+</a><a id="63" class="Markup">\begin{code}     </a>
 <a id="81" class="Keyword">module</a> <a id="88" href="AccidentalSpacesAfterBeginCode.html" class="Module">AccidentalSpacesAfterBeginCode</a> <a id="119" class="Keyword">where</a>
-\end{code}<a id="135" class="Comment">
+<a id="125" class="Markup">\end{code}</a><a id="135" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/AccidentalSpacesBeforeEndCode.html
+++ b/test/LaTeXAndHTML/succeed/AccidentalSpacesBeforeEndCode.html
@@ -1,13 +1,13 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>AccidentalSpacesBeforeEndCode</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>AccidentalSpacesBeforeEndCode</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Keyword">module</a> <a id="83" href="AccidentalSpacesBeforeEndCode.html" class="Module">AccidentalSpacesBeforeEndCode</a> <a id="113" class="Keyword">where</a>
-  \end{code}<a id="131" class="Comment">
+  <a id="121" class="Markup">\end{code}</a><a id="131" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/EscapedTeXComment.html
+++ b/test/LaTeXAndHTML/succeed/EscapedTeXComment.html
@@ -1,13 +1,13 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>EscapedTeXComment</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>EscapedTeXComment</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-100\% postulated: </a>\begin{code}
+100\% postulated: </a><a id="81" class="Markup">\begin{code}</a>
 <a id="94" class="Keyword">postulate</a> <a id="A"></a><a id="104" href="EscapedTeXComment.html#104" class="Postulate">A</a> <a id="106" class="Symbol">:</a> <a id="108" class="PrimitiveType">Set</a>
-\end{code}<a id="122" class="Comment">
+<a id="112" class="Markup">\end{code}</a><a id="122" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Grapheme-clusters-with-pragma.html
+++ b/test/LaTeXAndHTML/succeed/Grapheme-clusters-with-pragma.html
@@ -1,27 +1,27 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Grapheme-clusters-with-pragma</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Grapheme-clusters-with-pragma</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 % Make sure that cluster counting is activated.
-</a>\begin{code}[hide]
+</a><a id="93" class="Markup">\begin{code}[hide]</a>
   <a id="114" class="Symbol">{-#</a> <a id="118" class="Keyword">OPTIONS</a> <a id="126" class="Option">--count-clusters</a> <a id="143" class="Symbol">#-}</a>
-\end{code}<a id="157" class="Comment">
+<a id="147" class="Markup">\end{code}</a><a id="157" class="Background">
 
 \begin{document}
 
 \AgdaPostulate{A} and \AgdaPostulate{B} should be aligned:
-</a>\begin{code}
+</a><a id="236" class="Markup">\begin{code}</a>
   <a id="251" class="Keyword">postulate</a>
     <a id="+̲+̲+̲+̲+̲+̲"></a><a id="265" href="Grapheme-clusters-with-pragma.html#265" class="Postulate">+̲+̲+̲+̲+̲+̲</a>  <a id="A"></a><a id="279" href="Grapheme-clusters-with-pragma.html#279" class="Postulate">A</a>
             <a id="B"></a><a id="293" href="Grapheme-clusters-with-pragma.html#293" class="Postulate">B</a> <a id="295" class="Symbol">:</a> <a id="297" class="PrimitiveType">Set</a>
-\end{code}<a id="311" class="Comment">
+<a id="301" class="Markup">\end{code}</a><a id="311" class="Background">
 
 The two \AgdaKeyword{field} keywords should not be aligned:
-</a>\begin{code}
+</a><a id="373" class="Markup">\begin{code}</a>
   <a id="388" class="Keyword">record</a> <a id="+̲"></a><a id="395" href="Grapheme-clusters-with-pragma.html#395" class="Record">+̲</a> <a id="398" class="Symbol">:</a> <a id="400" class="PrimitiveType">Set₁</a> <a id="405" class="Keyword">where</a>  <a id="412" class="Keyword">field</a> <a id="+̲.C"></a><a id="418" href="Grapheme-clusters-with-pragma.html#418" class="Field">C</a> <a id="420" class="Symbol">:</a> <a id="422" class="PrimitiveType">Set</a>
                           <a id="452" class="Keyword">field</a> <a id="+̲.D"></a><a id="458" href="Grapheme-clusters-with-pragma.html#458" class="Field">D</a> <a id="460" class="Symbol">:</a> <a id="462" class="PrimitiveType">Set</a>
-\end{code}<a id="476" class="Comment">
+<a id="466" class="Markup">\end{code}</a><a id="476" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Grapheme-clusters.html
+++ b/test/LaTeXAndHTML/succeed/Grapheme-clusters.html
@@ -1,22 +1,22 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Grapheme-clusters</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Grapheme-clusters</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
 \AgdaPostulate{A} and \AgdaPostulate{B} should be aligned:
-</a>\begin{code}
+</a><a id="122" class="Markup">\begin{code}</a>
   <a id="137" class="Keyword">postulate</a>
     <a id="+̲+̲+̲+̲+̲+̲"></a><a id="151" href="Grapheme-clusters.html#151" class="Postulate">+̲+̲+̲+̲+̲+̲</a>  <a id="A"></a><a id="165" href="Grapheme-clusters.html#165" class="Postulate">A</a>
             <a id="B"></a><a id="179" href="Grapheme-clusters.html#179" class="Postulate">B</a> <a id="181" class="Symbol">:</a> <a id="183" class="PrimitiveType">Set</a>
-\end{code}<a id="197" class="Comment">
+<a id="187" class="Markup">\end{code}</a><a id="197" class="Background">
 
 The two \AgdaKeyword{field} keywords should not be aligned:
-</a>\begin{code}
+</a><a id="259" class="Markup">\begin{code}</a>
   <a id="274" class="Keyword">record</a> <a id="+̲"></a><a id="281" href="Grapheme-clusters.html#281" class="Record">+̲</a> <a id="284" class="Symbol">:</a> <a id="286" class="PrimitiveType">Set₁</a> <a id="291" class="Keyword">where</a>  <a id="298" class="Keyword">field</a> <a id="+̲.C"></a><a id="304" href="Grapheme-clusters.html#304" class="Field">C</a> <a id="306" class="Symbol">:</a> <a id="308" class="PrimitiveType">Set</a>
                           <a id="338" class="Keyword">field</a> <a id="+̲.D"></a><a id="344" href="Grapheme-clusters.html#344" class="Field">D</a> <a id="346" class="Symbol">:</a> <a id="348" class="PrimitiveType">Set</a>
-\end{code}<a id="362" class="Comment">
+<a id="352" class="Markup">\end{code}</a><a id="362" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Indenting.html
+++ b/test/LaTeXAndHTML/succeed/Indenting.html
@@ -1,15 +1,15 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Indenting</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Indenting</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Keyword">data</a> <a id="Nat"></a><a id="81" href="Indenting.html#81" class="Datatype">Nat</a> <a id="85" class="Symbol">:</a> <a id="87" class="PrimitiveType">Set</a> <a id="91" class="Keyword">where</a>
   <a id="Nat.zero"></a><a id="99" href="Indenting.html#99" class="InductiveConstructor">zero</a> <a id="104" class="Symbol">:</a> <a id="106" href="Indenting.html#81" class="Datatype">Nat</a>
   <a id="Nat.suc"></a><a id="112" href="Indenting.html#112" class="InductiveConstructor">suc</a> <a id="116" class="Symbol">:</a> <a id="118" href="Indenting.html#81" class="Datatype">Nat</a> <a id="122" class="Symbol">-&gt;</a> <a id="125" href="Indenting.html#81" class="Datatype">Nat</a>
-\end{code}<a id="139" class="Comment">
+<a id="129" class="Markup">\end{code}</a><a id="139" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Indenting2.html
+++ b/test/LaTeXAndHTML/succeed/Indenting2.html
@@ -1,15 +1,15 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Indenting2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Indenting2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Keyword">data</a> <a id="Nat"></a><a id="81" href="Indenting2.html#81" class="Datatype">Nat</a> <a id="85" class="Symbol">:</a> <a id="87" class="PrimitiveType">Set</a> <a id="91" class="Keyword">where</a>
   <a id="Nat.zero"></a><a id="99" href="Indenting2.html#99" class="InductiveConstructor">zero</a>  <a id="105" class="Symbol">:</a> <a id="107" href="Indenting2.html#81" class="Datatype">Nat</a>
   <a id="Nat.suc"></a><a id="113" href="Indenting2.html#113" class="InductiveConstructor">suc</a>   <a id="119" class="Symbol">:</a> <a id="121" href="Indenting2.html#81" class="Datatype">Nat</a> <a id="125" class="Symbol">-&gt;</a> <a id="128" href="Indenting2.html#81" class="Datatype">Nat</a>
-\end{code}<a id="142" class="Comment">
+<a id="132" class="Markup">\end{code}</a><a id="142" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Indenting3.html
+++ b/test/LaTeXAndHTML/succeed/Indenting3.html
@@ -1,11 +1,11 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Indenting3</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Indenting3</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Keyword">record</a> <a id="Sigma"></a><a id="83" href="Indenting3.html#83" class="Record">Sigma</a> <a id="89" class="Symbol">(</a><a id="90" href="Indenting3.html#90" class="Bound">A</a> <a id="92" class="Symbol">:</a> <a id="94" class="PrimitiveType">Set</a><a id="97" class="Symbol">)</a> <a id="99" class="Symbol">(</a><a id="100" href="Indenting3.html#100" class="Bound">B</a> <a id="102" class="Symbol">:</a> <a id="104" href="Indenting3.html#90" class="Bound">A</a> <a id="106" class="Symbol">→</a> <a id="108" class="PrimitiveType">Set</a><a id="111" class="Symbol">)</a> <a id="113" class="Symbol">:</a> <a id="115" class="PrimitiveType">Set</a> <a id="119" class="Keyword">where</a>
   <a id="127" class="Keyword">constructor</a> <a id="Sigma._,_"></a><a id="139" href="Indenting3.html#139" class="InductiveConstructor Operator">_,_</a>
   <a id="145" class="Keyword">field</a>
@@ -13,7 +13,7 @@
     <a id="Sigma.proj₂"></a><a id="169" href="Indenting3.html#169" class="Field">proj₂</a> <a id="175" class="Symbol">:</a> <a id="177" href="Indenting3.html#100" class="Bound">B</a> <a id="179" href="Indenting3.html#155" class="Field">proj₁</a>
 
 <a id="186" class="Keyword">open</a> <a id="191" href="Indenting3.html#83" class="Module">Sigma</a> <a id="197" class="Keyword">public</a>
-\end{code}<a id="214" class="Comment">
+<a id="204" class="Markup">\end{code}</a><a id="214" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Indenting4.html
+++ b/test/LaTeXAndHTML/succeed/Indenting4.html
@@ -1,18 +1,18 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Indenting4</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Indenting4</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Keyword">module</a> <a id="83" href="Indenting4.html" class="Module">Indenting4</a> <a id="94" class="Keyword">where</a>
-\end{code}<a id="110" class="Comment">
+<a id="100" class="Markup">\end{code}</a><a id="110" class="Background">
 
-</a>\begin{code}
+</a><a id="112" class="Markup">\begin{code}</a>
   <a id="Pow"></a><a id="127" href="Indenting4.html#127" class="Function">Pow</a> <a id="131" class="Symbol">:</a> <a id="133" class="PrimitiveType">Set</a> <a id="137" class="Symbol">→</a> <a id="139" class="PrimitiveType">Set₁</a>
   <a id="146" href="Indenting4.html#127" class="Function">Pow</a> <a id="150" href="Indenting4.html#150" class="Bound">X</a> <a id="152" class="Symbol">=</a> <a id="154" href="Indenting4.html#150" class="Bound">X</a> <a id="156" class="Symbol">→</a> <a id="158" class="PrimitiveType">Set</a>
-\end{code}<a id="172" class="Comment">
+<a id="162" class="Markup">\end{code}</a><a id="172" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Indenting5.html
+++ b/test/LaTeXAndHTML/succeed/Indenting5.html
@@ -1,11 +1,11 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Indenting5</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Indenting5</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Keyword">record</a> <a id="Sigma"></a><a id="83" href="Indenting5.html#83" class="Record">Sigma</a> <a id="89" class="Symbol">(</a><a id="90" href="Indenting5.html#90" class="Bound">A</a> <a id="92" class="Symbol">:</a> <a id="94" class="PrimitiveType">Set</a><a id="97" class="Symbol">)</a> <a id="99" class="Symbol">(</a><a id="100" href="Indenting5.html#100" class="Bound">B</a> <a id="102" class="Symbol">:</a> <a id="104" href="Indenting5.html#90" class="Bound">A</a> <a id="106" class="Symbol">→</a> <a id="108" class="PrimitiveType">Set</a><a id="111" class="Symbol">)</a> <a id="113" class="Symbol">:</a> <a id="115" class="PrimitiveType">Set</a> <a id="119" class="Keyword">where</a>
   <a id="127" class="Keyword">constructor</a> <a id="Sigma._,_"></a><a id="139" href="Indenting5.html#139" class="InductiveConstructor Operator">_,_</a>
   <a id="145" class="Keyword">field</a>
@@ -13,7 +13,7 @@
     <a id="Sigma.proj₂"></a><a id="169" href="Indenting5.html#169" class="Field">proj₂</a> <a id="175" class="Symbol">:</a> <a id="177" href="Indenting5.html#100" class="Bound">B</a> <a id="179" href="Indenting5.html#155" class="Field">proj₁</a>
 
 <a id="186" class="Keyword">open</a> <a id="191" href="Indenting5.html#83" class="Module">Sigma</a> <a id="197" class="Keyword">public</a>
-\end{code}<a id="214" class="Comment">
+<a id="204" class="Markup">\end{code}</a><a id="214" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Indenting6.html
+++ b/test/LaTeXAndHTML/succeed/Indenting6.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Indenting6</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Indenting6</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 \begin{document}
 
-</a>\begin{code}
+</a><a id="61" class="Markup">\begin{code}</a>
 <a id="74" class="Keyword">record</a> <a id="Sigma"></a><a id="81" href="Indenting6.html#81" class="Record">Sigma</a> <a id="87" class="Symbol">(</a><a id="88" href="Indenting6.html#88" class="Bound">A</a> <a id="90" class="Symbol">:</a> <a id="92" class="PrimitiveType">Set</a><a id="95" class="Symbol">)</a> <a id="97" class="Symbol">(</a><a id="98" href="Indenting6.html#98" class="Bound">B</a> <a id="100" class="Symbol">:</a> <a id="102" href="Indenting6.html#88" class="Bound">A</a> <a id="104" class="Symbol">→</a> <a id="106" class="PrimitiveType">Set</a><a id="109" class="Symbol">)</a> <a id="111" class="Symbol">:</a> <a id="113" class="PrimitiveType">Set</a> <a id="117" class="Keyword">where</a>
   <a id="125" class="Keyword">constructor</a> <a id="Sigma._,_"></a><a id="137" href="Indenting6.html#137" class="InductiveConstructor Operator">_,_</a>
   <a id="143" class="Keyword">field</a>
@@ -11,14 +11,14 @@
     <a id="Sigma.proj₂"></a><a id="167" href="Indenting6.html#167" class="Field">proj₂</a> <a id="173" class="Symbol">:</a> <a id="175" href="Indenting6.html#98" class="Bound">B</a> <a id="177" href="Indenting6.html#153" class="Field">proj₁</a>
 
 <a id="184" class="Keyword">open</a> <a id="189" href="Indenting6.html#81" class="Module">Sigma</a> <a id="195" class="Keyword">public</a>
-\end{code}<a id="212" class="Comment">
+<a id="202" class="Markup">\end{code}</a><a id="212" class="Background">
 
-</a>\begin{code}
+</a><a id="214" class="Markup">\begin{code}</a>
 <a id="227" class="Keyword">record</a> <a id="Equiv"></a><a id="234" href="Indenting6.html#234" class="Record">Equiv</a> <a id="240" class="Symbol">(</a><a id="241" href="Indenting6.html#241" class="Bound">X</a> <a id="243" href="Indenting6.html#243" class="Bound">Y</a> <a id="245" class="Symbol">:</a> <a id="247" class="PrimitiveType">Set</a><a id="250" class="Symbol">)</a> <a id="252" class="Symbol">:</a> <a id="254" class="PrimitiveType">Set</a> <a id="258" class="Keyword">where</a>
   <a id="266" class="Keyword">field</a>
     <a id="Equiv.to"></a><a id="276" href="Indenting6.html#276" class="Field">to</a>    <a id="282" class="Symbol">:</a> <a id="284" href="Indenting6.html#241" class="Bound">X</a> <a id="286" class="Symbol">→</a> <a id="288" href="Indenting6.html#243" class="Bound">Y</a>
     <a id="Equiv.from"></a><a id="294" href="Indenting6.html#294" class="Field">from</a>  <a id="300" class="Symbol">:</a> <a id="302" href="Indenting6.html#243" class="Bound">Y</a> <a id="304" class="Symbol">→</a> <a id="306" href="Indenting6.html#241" class="Bound">X</a>
-\end{code}<a id="318" class="Comment">
+<a id="308" class="Markup">\end{code}</a><a id="318" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Indenting7.html
+++ b/test/LaTeXAndHTML/succeed/Indenting7.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Indenting7</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Indenting7</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 \begin{document}
 
-</a>\begin{code}
+</a><a id="61" class="Markup">\begin{code}</a>
 <a id="74" class="Keyword">module</a> <a id="81" href="Indenting7.html" class="Module">Indenting7</a> <a id="92" class="Keyword">where</a>
 
   <a id="101" class="Keyword">module</a> <a id="A₁"></a><a id="108" href="Indenting7.html#108" class="Module">A₁</a> <a id="111" class="Keyword">where</a>
@@ -28,7 +28,7 @@
       <a id="406" class="Keyword">module</a> <a id="C₆"></a><a id="413" href="Indenting7.html#413" class="Module">C₆</a> <a id="416" class="Keyword">where</a>
     <a id="426" class="Keyword">module</a> <a id="B₄"></a><a id="433" href="Indenting7.html#433" class="Module">B₄</a> <a id="436" class="Keyword">where</a>
   <a id="444" class="Keyword">module</a> <a id="A₄"></a><a id="451" href="Indenting7.html#451" class="Module">A₄</a> <a id="454" class="Keyword">where</a>
-\end{code}<a id="470" class="Comment">
+<a id="460" class="Markup">\end{code}</a><a id="470" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/IndentingContainer.html
+++ b/test/LaTeXAndHTML/succeed/IndentingContainer.html
@@ -1,11 +1,11 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>IndentingContainer</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>IndentingContainer</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Keyword">record</a> <a id="Sigma"></a><a id="83" href="IndentingContainer.html#83" class="Record">Sigma</a> <a id="89" class="Symbol">(</a><a id="90" href="IndentingContainer.html#90" class="Bound">A</a> <a id="92" class="Symbol">:</a> <a id="94" class="PrimitiveType">Set</a><a id="97" class="Symbol">)</a> <a id="99" class="Symbol">(</a><a id="100" href="IndentingContainer.html#100" class="Bound">B</a> <a id="102" class="Symbol">:</a> <a id="104" href="IndentingContainer.html#90" class="Bound">A</a> <a id="106" class="Symbol">→</a> <a id="108" class="PrimitiveType">Set</a><a id="111" class="Symbol">)</a> <a id="113" class="Symbol">:</a> <a id="115" class="PrimitiveType">Set</a> <a id="119" class="Keyword">where</a>
   <a id="127" class="Keyword">constructor</a> <a id="Sigma._,_"></a><a id="139" href="IndentingContainer.html#139" class="InductiveConstructor Operator">_,_</a>
   <a id="145" class="Keyword">field</a>
@@ -13,22 +13,22 @@
     <a id="Sigma.proj₂"></a><a id="169" href="IndentingContainer.html#169" class="Field">proj₂</a> <a id="175" class="Symbol">:</a> <a id="177" href="IndentingContainer.html#100" class="Bound">B</a> <a id="179" href="IndentingContainer.html#155" class="Field">proj₁</a>
 
 <a id="186" class="Keyword">open</a> <a id="191" href="IndentingContainer.html#83" class="Module">Sigma</a> <a id="197" class="Keyword">public</a>
-\end{code}<a id="214" class="Comment">
+<a id="204" class="Markup">\end{code}</a><a id="214" class="Background">
 
-</a>\begin{code}
+</a><a id="216" class="Markup">\begin{code}</a>
 <a id="uncurry"></a><a id="229" href="IndentingContainer.html#229" class="Function">uncurry</a> <a id="237" class="Symbol">:</a> <a id="239" class="Symbol">{</a><a id="240" href="IndentingContainer.html#240" class="Bound">A</a> <a id="242" class="Symbol">:</a> <a id="244" class="PrimitiveType">Set</a><a id="247" class="Symbol">}</a> <a id="249" class="Symbol">{</a><a id="250" href="IndentingContainer.html#250" class="Bound">B</a> <a id="252" class="Symbol">:</a> <a id="254" href="IndentingContainer.html#240" class="Bound">A</a> <a id="256" class="Symbol">→</a> <a id="258" class="PrimitiveType">Set</a><a id="261" class="Symbol">}</a> <a id="263" class="Symbol">{</a><a id="264" href="IndentingContainer.html#264" class="Bound">C</a> <a id="266" class="Symbol">:</a> <a id="268" href="IndentingContainer.html#83" class="Record">Sigma</a> <a id="274" href="IndentingContainer.html#240" class="Bound">A</a> <a id="276" href="IndentingContainer.html#250" class="Bound">B</a> <a id="278" class="Symbol">→</a> <a id="280" class="PrimitiveType">Set</a><a id="283" class="Symbol">}</a> <a id="285" class="Symbol">→</a>
           <a id="297" class="Symbol">((</a><a id="299" href="IndentingContainer.html#299" class="Bound">x</a> <a id="301" class="Symbol">:</a> <a id="303" href="IndentingContainer.html#240" class="Bound">A</a><a id="304" class="Symbol">)</a> <a id="306" class="Symbol">→</a> <a id="308" class="Symbol">(</a><a id="309" href="IndentingContainer.html#309" class="Bound">y</a> <a id="311" class="Symbol">:</a> <a id="313" href="IndentingContainer.html#250" class="Bound">B</a> <a id="315" href="IndentingContainer.html#299" class="Bound">x</a><a id="316" class="Symbol">)</a> <a id="318" class="Symbol">→</a> <a id="320" href="IndentingContainer.html#264" class="Bound">C</a> <a id="322" class="Symbol">(</a><a id="323" href="IndentingContainer.html#299" class="Bound">x</a> <a id="325" href="IndentingContainer.html#139" class="InductiveConstructor Operator">,</a> <a id="327" href="IndentingContainer.html#309" class="Bound">y</a><a id="328" class="Symbol">))</a> <a id="331" class="Symbol">→</a>
           <a id="343" class="Symbol">((</a><a id="345" href="IndentingContainer.html#345" class="Bound">p</a> <a id="347" class="Symbol">:</a> <a id="349" href="IndentingContainer.html#83" class="Record">Sigma</a> <a id="355" href="IndentingContainer.html#240" class="Bound">A</a> <a id="357" href="IndentingContainer.html#250" class="Bound">B</a><a id="358" class="Symbol">)</a> <a id="360" class="Symbol">→</a> <a id="362" href="IndentingContainer.html#264" class="Bound">C</a> <a id="364" href="IndentingContainer.html#345" class="Bound">p</a><a id="365" class="Symbol">)</a>
 <a id="367" href="IndentingContainer.html#229" class="Function">uncurry</a> <a id="375" href="IndentingContainer.html#375" class="Bound">f</a> <a id="377" class="Symbol">(</a><a id="378" href="IndentingContainer.html#378" class="Bound">x</a> <a id="380" href="IndentingContainer.html#139" class="InductiveConstructor Operator">,</a> <a id="382" href="IndentingContainer.html#382" class="Bound">y</a><a id="383" class="Symbol">)</a> <a id="385" class="Symbol">=</a> <a id="387" href="IndentingContainer.html#375" class="Bound">f</a> <a id="389" href="IndentingContainer.html#378" class="Bound">x</a> <a id="391" href="IndentingContainer.html#382" class="Bound">y</a>
-\end{code}<a id="403" class="Comment">
+<a id="393" class="Markup">\end{code}</a><a id="403" class="Background">
 
-</a>\begin{code}
+</a><a id="405" class="Markup">\begin{code}</a>
 <a id="418" class="Keyword">record</a> <a id="Container"></a><a id="425" href="IndentingContainer.html#425" class="Record">Container</a> <a id="435" class="Symbol">:</a> <a id="437" class="PrimitiveType">Set₁</a> <a id="442" class="Keyword">where</a>
   <a id="450" class="Keyword">constructor</a> <a id="Container._◃_"></a><a id="462" href="IndentingContainer.html#462" class="InductiveConstructor Operator">_◃_</a>
   <a id="468" class="Keyword">field</a>
     <a id="Container.Parameter"></a><a id="478" href="IndentingContainer.html#478" class="Field">Parameter</a> <a id="488" class="Symbol">:</a> <a id="490" class="PrimitiveType">Set</a>
     <a id="Container.Arity"></a><a id="498" href="IndentingContainer.html#498" class="Field">Arity</a> <a id="504" class="Symbol">:</a> <a id="506" href="IndentingContainer.html#478" class="Field">Parameter</a> <a id="516" class="Symbol">→</a> <a id="518" class="PrimitiveType">Set</a>
-\end{code}<a id="532" class="Comment">
+<a id="522" class="Markup">\end{code}</a><a id="532" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/InfixDeclaration.html
+++ b/test/LaTeXAndHTML/succeed/InfixDeclaration.html
@@ -1,10 +1,10 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>InfixDeclaration</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>InfixDeclaration</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="62" class="Markup">\begin{code}</a>
 <a id="75" class="Keyword">module</a> <a id="82" href="InfixDeclaration.html" class="Module">InfixDeclaration</a> <a id="99" class="Keyword">where</a>
 
 <a id="106" class="Keyword">infix</a> <a id="112" class="Number">5</a> <a id="114" href="InfixDeclaration.html#130" class="Datatype Operator">_&gt;&gt;_</a> <a id="119" href="InfixDeclaration.html#152" class="Datatype Operator">_&lt;&lt;_</a>
@@ -12,26 +12,26 @@
 <a id="125" class="Keyword">data</a> <a id="_&gt;&gt;_"></a><a id="130" href="InfixDeclaration.html#130" class="Datatype Operator">_&gt;&gt;_</a> <a id="135" class="Symbol">:</a> <a id="137" class="PrimitiveType">Set</a> <a id="141" class="Keyword">where</a>
 <a id="147" class="Keyword">data</a> <a id="_&lt;&lt;_"></a><a id="152" href="InfixDeclaration.html#152" class="Datatype Operator">_&lt;&lt;_</a> <a id="157" class="Symbol">:</a> <a id="159" class="PrimitiveType">Set</a> <a id="163" class="Keyword">where</a>
 
-\end{code}<a id="180" class="Comment">
+<a id="170" class="Markup">\end{code}</a><a id="180" class="Background">
 
 Let&#39;s try some infix declaration with surrounding text.
 
-</a>\begin{code}
+</a><a id="239" class="Markup">\begin{code}</a>
 <a id="252" class="Keyword">module</a> <a id="SurroundingText"></a><a id="259" href="InfixDeclaration.html#259" class="Module">SurroundingText</a> <a id="275" class="Keyword">where</a>
 
-\end{code}<a id="292" class="Comment">
+<a id="282" class="Markup">\end{code}</a><a id="292" class="Background">
 
 In the following, we declare the fixity of two operators.
 
-</a>\begin{code}
+</a><a id="353" class="Markup">\begin{code}</a>
   <a id="368" class="Keyword">infix</a> <a id="374" class="Number">5</a> <a id="376" href="InfixDeclaration.html#492" class="Postulate Operator">_+_</a> <a id="380" href="InfixDeclaration.html#496" class="Postulate Operator">_*_</a>
-\end{code}<a id="394" class="Comment">
+<a id="384" class="Markup">\end{code}</a><a id="394" class="Background">
 
 A fixity declaration can preceed the actual declaration of the names.
 
-</a>\begin{code}
+</a><a id="467" class="Markup">\begin{code}</a>
   <a id="482" class="Keyword">postulate</a> <a id="SurroundingText._+_"></a><a id="492" href="InfixDeclaration.html#492" class="Postulate Operator">_+_</a> <a id="SurroundingText._*_"></a><a id="496" href="InfixDeclaration.html#496" class="Postulate Operator">_*_</a> <a id="500" class="Symbol">:</a> <a id="502" class="PrimitiveType">Set</a>
-\end{code}<a id="516" class="Comment">
+<a id="506" class="Markup">\end{code}</a><a id="516" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Inline.html
+++ b/test/LaTeXAndHTML/succeed/Inline.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Inline</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Inline</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
@@ -7,25 +7,25 @@
 
 Assume that we are given a type
 %
-</a>\begin{code}[hide]
+</a><a id="97" class="Markup">\begin{code}[hide]</a>
   <a id="118" class="Keyword">module</a> <a id="125" href="Inline.html" class="Module">_</a> <a id="127" class="Symbol">(</a>
-\end{code}<a id="139" class="Comment">
-</a>\begin{code}[inline]
+<a id="129" class="Markup">\end{code}</a><a id="139" class="Background">
+</a><a id="140" class="Markup">\begin{code}[inline]</a>
     <a id="165" href="Inline.html#165" class="Bound">A</a> <a id="167" class="Symbol">:</a> <a id="169" class="PrimitiveType">Set</a>
-\end{code}<a id="183" class="Comment">
-</a>\begin{code}[hide]
+<a id="173" class="Markup">\end{code}</a><a id="183" class="Background">
+</a><a id="184" class="Markup">\begin{code}[hide]</a>
     <a id="207" class="Symbol">)</a> <a id="209" class="Symbol">(</a>
-\end{code}<a id="221" class="Comment">
+<a id="211" class="Markup">\end{code}</a><a id="221" class="Background">
 %
 ,
 and that a function
 %
-</a>\begin{code}[inline*]
+</a><a id="248" class="Markup">\begin{code}[inline*]</a>
     <a id="274" href="Inline.html#274" class="Bound">F</a> <a id="276" class="Symbol">:</a> <a id="278" class="PrimitiveType">Set</a> <a id="282" class="Symbol">→</a> <a id="284" class="PrimitiveType">Set</a> <a id="288" class="Symbol">→</a> <a id="290" class="PrimitiveType">Set</a> <a id="294" class="Symbol">→</a> <a id="296" class="PrimitiveType">Set</a>
-\end{code}<a id="310" class="Comment">
-</a>\begin{code}[hide]
+<a id="300" class="Markup">\end{code}</a><a id="310" class="Background">
+</a><a id="311" class="Markup">\begin{code}[hide]</a>
     <a id="334" class="Symbol">)</a> <a id="336" class="Keyword">where</a>
-\end{code}<a id="352" class="Comment">
+<a id="342" class="Markup">\end{code}</a><a id="352" class="Background">
 %
 is also given.
 

--- a/test/LaTeXAndHTML/succeed/Issue1053.html
+++ b/test/LaTeXAndHTML/succeed/Issue1053.html
@@ -1,15 +1,15 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue1053</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue1053</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 \begin{document}
 
-</a>\begin{code}
+</a><a id="61" class="Markup">\begin{code}</a>
 <a id="id"></a><a id="74" href="Issue1053.html#74" class="Function">id</a> <a id="77" class="Symbol">:</a> <a id="79" class="Symbol">{</a><a id="80" href="Issue1053.html#80" class="Bound">A</a> <a id="82" class="Symbol">:</a> <a id="84" class="PrimitiveType">Set</a><a id="87" class="Symbol">}</a> <a id="89" class="Symbol">→</a> <a id="91" href="Issue1053.html#80" class="Bound">A</a> <a id="93" class="Symbol">→</a> <a id="95" href="Issue1053.html#80" class="Bound">A</a>
 <a id="97" href="Issue1053.html#74" class="Function">id</a> <a id="100" class="Symbol">{</a><a id="101" class="Argument">A</a> <a id="103" class="Symbol">=</a> <a id="105" href="Issue1053.html#105" class="Bound">A</a><a id="106" class="Symbol">}</a> <a id="108" href="Issue1053.html#108" class="Bound">x</a> <a id="110" class="Symbol">=</a> <a id="112" href="Issue1053.html#108" class="Bound">x</a>
 
 <a id="foo"></a><a id="115" href="Issue1053.html#115" class="Function">foo</a> <a id="119" class="Symbol">:</a> <a id="121" class="Symbol">(</a><a id="122" href="Issue1053.html#122" class="Bound">A</a> <a id="124" class="Symbol">:</a> <a id="126" class="PrimitiveType">Set</a><a id="129" class="Symbol">)</a> <a id="131" class="Symbol">→</a> <a id="133" href="Issue1053.html#122" class="Bound">A</a> <a id="135" class="Symbol">→</a> <a id="137" href="Issue1053.html#122" class="Bound">A</a>
 <a id="139" href="Issue1053.html#115" class="Function">foo</a> <a id="143" href="Issue1053.html#143" class="Bound">B</a> <a id="145" href="Issue1053.html#145" class="Bound">x</a> <a id="147" class="Symbol">=</a> <a id="149" href="Issue1053.html#74" class="Function">id</a> <a id="152" class="Symbol">{</a><a id="153" class="Argument">A</a> <a id="155" class="Symbol">=</a> <a id="157" href="Issue1053.html#143" class="Bound">B</a><a id="158" class="Symbol">}</a> <a id="160" href="Issue1053.html#145" class="Bound">x</a>
-\end{code}<a id="172" class="Comment">
+<a id="162" class="Markup">\end{code}</a><a id="172" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue1062.html
+++ b/test/LaTeXAndHTML/succeed/Issue1062.html
@@ -1,11 +1,11 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue1062</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\nonstopmode
+<html><head><meta charset="utf-8"><title>Issue1062</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\nonstopmode
 \documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
-</a>\begin{code}
+</a><a id="75" class="Markup">\begin{code}</a>
 
 <a id="89" class="Symbol">{-#</a> <a id="93" class="Keyword">OPTIONS</a> <a id="101" class="Option">--copatterns</a> <a id="114" class="Option">--sized-types</a> <a id="128" class="Symbol">#-}</a>
 
@@ -67,7 +67,7 @@
 <a id="1333" href="Issue1062.html#563" class="Field">head</a>  <a id="1339" class="Symbol">(</a><a id="1340" href="Issue1062.html#1195" class="Function">unfold⁺</a> <a id="1348" href="Issue1062.html#1348" class="Bound">step</a> <a id="1353" href="Issue1062.html#1353" class="Bound">s</a><a id="1354" class="Symbol">)</a> <a id="1356" class="Symbol">=</a>  <a id="1359" href="Issue1062.html#1016" class="Field">head</a> <a id="1364" class="Symbol">(</a><a id="1365" href="Issue1062.html#410" class="Field">fst</a> <a id="1369" class="Symbol">(</a><a id="1370" href="Issue1062.html#1348" class="Bound">step</a> <a id="1375" href="Issue1062.html#1353" class="Bound">s</a><a id="1376" class="Symbol">))</a>
 <a id="1379" href="Issue1062.html#577" class="Field">tail</a>  <a id="1385" class="Symbol">(</a><a id="1386" href="Issue1062.html#1195" class="Function">unfold⁺</a> <a id="1394" href="Issue1062.html#1394" class="Bound">step</a> <a id="1399" href="Issue1062.html#1399" class="Bound">s</a><a id="1400" class="Symbol">)</a> <a id="1402" class="Symbol">=</a>  <a id="1405" class="Keyword">let</a>  <a id="1410" class="Symbol">((_</a> <a id="1414" href="Issue1062.html#1000" class="InductiveConstructor Operator">∷</a> <a id="1416" href="Issue1062.html#1416" class="Bound">l</a><a id="1417" class="Symbol">)</a> <a id="1419" href="Issue1062.html#394" class="InductiveConstructor Operator">,</a> <a id="1421" href="Issue1062.html#1421" class="Bound">s′</a><a id="1423" class="Symbol">)</a> <a id="1425" class="Symbol">=</a> <a id="1427" href="Issue1062.html#1394" class="Bound">step</a> <a id="1432" href="Issue1062.html#1399" class="Bound">s</a>
                           <a id="1460" class="Keyword">in</a>   <a id="1465" href="Issue1062.html#1416" class="Bound">l</a> <a id="1467" href="Issue1062.html#787" class="Function Operator">++ˢ</a> <a id="1471" href="Issue1062.html#1195" class="Function">unfold⁺</a> <a id="1479" href="Issue1062.html#1394" class="Bound">step</a> <a id="1484" href="Issue1062.html#1421" class="Bound">s′</a>
-\end{code}<a id="1497" class="Comment">
+<a id="1487" class="Markup">\end{code}</a><a id="1497" class="Background">
 Problem: The ∷ in the last let statement is not colored with constructor color.
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue1241.html
+++ b/test/LaTeXAndHTML/succeed/Issue1241.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue1241</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue1241</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
@@ -9,12 +9,12 @@
 
 This is the actual test.
 
-</a>\begin{code}
+</a><a id="101" class="Markup">\begin{code}</a>
 <a id="114" class="Keyword">module</a> <a id="121" href="Issue1241.html" class="Module">_</a> <a id="123" class="Keyword">where</a>
 
 <a id="130" class="Keyword">postulate</a>
   <a id="IsThisCorrectlyLaTeXed"></a><a id="142" href="Issue1241.html#142" class="Postulate">IsThisCorrectlyLaTeXed</a> <a id="165" class="Symbol">:</a> <a id="167" class="PrimitiveType">Set</a>
-\end{code}<a id="181" class="Comment">
+<a id="171" class="Markup">\end{code}</a><a id="181" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue1618.html
+++ b/test/LaTeXAndHTML/succeed/Issue1618.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue1618</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue1618</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{1ex}
 \begin{document}
 The let should be properly aligned in the following code:
 
-</a>\begin{code}
+</a><a id="173" class="Markup">\begin{code}</a>
 <a id="id"></a><a id="186" href="Issue1618.html#186" class="Function">id</a> <a id="189" class="Symbol">:</a> <a id="191" class="Symbol">(</a><a id="192" href="Issue1618.html#192" class="Bound">A</a> <a id="194" class="Symbol">:</a> <a id="196" class="PrimitiveType">Set</a><a id="199" class="Symbol">)</a> <a id="201" class="Symbol">→</a> <a id="203" href="Issue1618.html#192" class="Bound">A</a> <a id="205" class="Symbol">→</a> <a id="207" href="Issue1618.html#192" class="Bound">A</a>
 <a id="209" href="Issue1618.html#186" class="Function">id</a> <a id="212" href="Issue1618.html#212" class="Bound">A</a> <a id="214" class="Symbol">=</a>
   <a id="218" class="Keyword">let</a>
@@ -16,12 +16,12 @@ The let should be properly aligned in the following code:
   <a id="267" class="Keyword">where</a>
     <a id="277" href="Issue1618.html#277" class="Function">B</a> <a id="279" class="Symbol">:</a> <a id="281" class="PrimitiveType">Set</a>
     <a id="289" href="Issue1618.html#277" class="Function">B</a> <a id="291" class="Symbol">=</a> <a id="293" href="Issue1618.html#212" class="Bound">A</a>
-\end{code}<a id="305" class="Comment">
+<a id="295" class="Markup">\end{code}</a><a id="305" class="Background">
 
 This should also work if the new block is following after the
 keyword, as opposed to on a new line.
 
-</a>\begin{code}
+</a><a id="408" class="Markup">\begin{code}</a>
 <a id="di"></a><a id="421" href="Issue1618.html#421" class="Function">di</a> <a id="424" class="Symbol">:</a> <a id="426" class="Symbol">(</a><a id="427" href="Issue1618.html#427" class="Bound">A</a> <a id="429" class="Symbol">:</a> <a id="431" class="PrimitiveType">Set</a><a id="434" class="Symbol">)</a> <a id="436" class="Symbol">→</a> <a id="438" href="Issue1618.html#427" class="Bound">A</a> <a id="440" class="Symbol">→</a> <a id="442" href="Issue1618.html#427" class="Bound">A</a>
 <a id="444" href="Issue1618.html#421" class="Function">di</a> <a id="447" href="Issue1618.html#447" class="Bound">A</a> <a id="449" class="Symbol">=</a>
   <a id="453" class="Keyword">let</a>  <a id="458" href="Issue1618.html#458" class="Bound">id&#39;</a> <a id="462" class="Symbol">:</a> <a id="464" href="Issue1618.html#509" class="Function">B</a> <a id="466" class="Symbol">→</a> <a id="468" href="Issue1618.html#509" class="Function">B</a>
@@ -29,6 +29,6 @@ keyword, as opposed to on a new line.
   <a id="493" class="Keyword">in</a> <a id="496" href="Issue1618.html#458" class="Bound">id&#39;</a>
   <a id="502" class="Keyword">where</a>  <a id="509" href="Issue1618.html#509" class="Function">B</a> <a id="511" class="Symbol">:</a> <a id="513" class="PrimitiveType">Set</a>
          <a id="526" href="Issue1618.html#509" class="Function">B</a> <a id="528" class="Symbol">=</a> <a id="530" href="Issue1618.html#447" class="Bound">A</a>
-\end{code}<a id="542" class="Comment">
+<a id="532" class="Markup">\end{code}</a><a id="542" class="Background">
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2019.html
+++ b/test/LaTeXAndHTML/succeed/Issue2019.html
@@ -1,27 +1,27 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2019</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2019</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="62" class="Markup">\begin{code}</a>
 <a id="75" class="Comment">-- We use non-standard spaces between the name of the term and the</a>
 <a id="142" class="Comment">-- colon.</a>
 <a id="152" class="Keyword">postulate</a>
   <a id="s00A0"></a><a id="164" href="Issue2019.html#164" class="Postulate">s00A0</a> <a id="170" class="Symbol">:</a> <a id="172" class="PrimitiveType">Set</a>  <a id="177" class="Comment">-- NO-BREAK SPACE        (&quot;\ &quot; with Agda input method)</a>
   <a id="s2004"></a><a id="234" href="Issue2019.html#234" class="Postulate">s2004</a> <a id="240" class="Symbol">:</a> <a id="242" class="PrimitiveType">Set</a>  <a id="247" class="Comment">-- THREE-PER-EM SPACE    (&quot;\;&quot; with Agda input method)</a>
   <a id="s202F"></a><a id="304" href="Issue2019.html#304" class="Postulate">s202F</a> <a id="310" class="Symbol">:</a> <a id="312" class="PrimitiveType">Set</a>  <a id="317" class="Comment">-- NARROW NO-BREAK SPACE (&quot;\,&quot; with Agda input method)</a>
-\end{code}<a id="382" class="Comment">
+<a id="372" class="Markup">\end{code}</a><a id="382" class="Background">
 
 % Various whitespace characters: &quot;    &quot;.
-</a>\begin{code}
+</a><a id="425" class="Markup">\begin{code}</a>
 <a id="438" class="Keyword">open</a> <a id="443" class="Keyword">import</a> <a id="450" href="Agda.Builtin.String.html" class="Module">Agda.Builtin.String</a>
 
 <a id="471" class="Comment">-- Various whitespace characters: &quot;    &quot;.</a>
 
 <a id="various-whitespace-characters"></a><a id="514" href="Issue2019.html#514" class="Function">various-whitespace-characters</a> <a id="544" class="Symbol">:</a> <a id="546" href="Agda.Builtin.String.html#174" class="Postulate">String</a>
 <a id="553" href="Issue2019.html#514" class="Function">various-whitespace-characters</a> <a id="583" class="Symbol">=</a> <a id="585" class="String">&quot;    &quot;</a>
-\end{code}<a id="602" class="Comment">
+<a id="592" class="Markup">\end{code}</a><a id="602" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2077-1.html
+++ b/test/LaTeXAndHTML/succeed/Issue2077-1.html
@@ -1,13 +1,13 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2077-1</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2077-1</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 
 \begin{document}
 
 \AgdaHide{
-Blip</a>\begin{code}
+Blip</a><a id="77" class="Markup">\begin{code}</a>
 <a id="90" class="Keyword">postulate</a> <a id="A"></a><a id="100" href="Issue2077-1.html#100" class="Postulate">A</a> <a id="102" class="Symbol">:</a> <a id="104" class="PrimitiveType">Set</a>
-\end{code}<a id="118" class="Comment">}Blop
+<a id="108" class="Markup">\end{code}</a><a id="118" class="Background">}Blop
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2077-2.html
+++ b/test/LaTeXAndHTML/succeed/Issue2077-2.html
@@ -1,13 +1,13 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2077-2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2077-2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 
 \begin{document}
 
 \AgdaHide{
-</a>\begin{code}
+</a><a id="73" class="Markup">\begin{code}</a>
 <a id="86" class="Keyword">postulate</a> <a id="A"></a><a id="96" href="Issue2077-2.html#96" class="Postulate">A</a> <a id="98" class="Symbol">:</a> <a id="100" class="PrimitiveType">Set</a>
-\end{code}<a id="114" class="Comment">}
+<a id="104" class="Markup">\end{code}</a><a id="114" class="Background">}
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2400-1.html
+++ b/test/LaTeXAndHTML/succeed/Issue2400-1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2400-1</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2400-1</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 

--- a/test/LaTeXAndHTML/succeed/Issue2401.html
+++ b/test/LaTeXAndHTML/succeed/Issue2401.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2401</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">% The example below is, modulo a small change, due to Andrés
+<html><head><meta charset="utf-8"><title>Issue2401</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">% The example below is, modulo a small change, due to Andrés
 % Sicard-Ramírez.
 
 \documentclass{article}
@@ -9,7 +9,7 @@
 \begin{document}
 
 av
-</a>\begin{code}
+</a><a id="146" class="Markup">\begin{code}</a>
   <a id="161" class="Keyword">module</a> <a id="168" href="Issue2401.html" class="Module">Issue2401</a> <a id="178" class="Keyword">where</a>
 
     <a id="189" class="Keyword">data</a> <a id="Bool"></a><a id="194" href="Issue2401.html#194" class="Datatype">Bool</a> <a id="199" class="Symbol">:</a> <a id="201" class="PrimitiveType">Set</a> <a id="205" class="Keyword">where</a>
@@ -18,7 +18,7 @@ av
       <a id="Bool.dunno"></a><a id="255" href="Issue2401.html#255" class="InductiveConstructor">dunno</a> <a id="261" class="Symbol">:</a> <a id="263" href="Issue2401.html#194" class="Datatype">Bool</a>
       <a id="Bool.aa"></a><a id="274" href="Issue2401.html#274" class="InductiveConstructor">aa</a>    <a id="280" class="Symbol">:</a> <a id="282" class="Comment">{- \end{code} -}</a> <a id="299" href="Issue2401.html#194" class="Datatype">Bool</a>
 
-\end{code}<a id="315" class="Comment">
+<a id="305" class="Markup">\end{code}</a><a id="315" class="Background">
 bleh
 
 \end{document}</a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2445.html
+++ b/test/LaTeXAndHTML/succeed/Issue2445.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2445</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2445</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="44" class="Markup">\begin{code}</a>
 <a id="57" class="Keyword">module</a> <a id="64" href="Issue2445.html" class="Module">_</a> <a id="66" class="Keyword">where</a>
 <a id="72" class="Keyword">module</a> <a id="79" href="Issue2445.html#79" class="Module">_</a> <a id="81" class="Keyword">where</a>
 <a id="87" class="Keyword">module</a> <a id="94" href="Issue2445.html#94" class="Module">_</a> <a id="96" class="Keyword">where</a>
@@ -804,7 +804,7 @@
 <a id="12012" class="Keyword">module</a> <a id="12019" href="Issue2445.html#12019" class="Module">_</a> <a id="12021" class="Keyword">where</a>
 <a id="12027" class="Keyword">module</a> <a id="12034" href="Issue2445.html#12034" class="Module">_</a> <a id="12036" class="Keyword">where</a>
 <a id="12042" class="Keyword">module</a> <a id="12049" href="Issue2445.html#12049" class="Module">_</a> <a id="12051" class="Keyword">where</a>
-\end{code}<a id="12067" class="Comment">
+<a id="12057" class="Markup">\end{code}</a><a id="12067" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2474-2.html
+++ b/test/LaTeXAndHTML/succeed/Issue2474-2.html
@@ -1,10 +1,10 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2474-2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2474-2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 \begin{document}
 
-</a>\begin{code}
+</a><a id="61" class="Markup">\begin{code}</a>
 <a id="74" class="Keyword">import</a> <a id="81" href="Issue2474.html" class="Module">Issue2474</a>
-\end{code}<a id="101" class="Comment">
+<a id="91" class="Markup">\end{code}</a><a id="101" class="Background">
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2474.html
+++ b/test/LaTeXAndHTML/succeed/Issue2474.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2474</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2474</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 \begin{document}
 
-</a>\begin{code}
+</a><a id="61" class="Markup">\begin{code}</a>
 <a id="74" class="Symbol">{-#</a> <a id="78" class="Keyword">OPTIONS</a> <a id="86" class="Option">--allow-unsolved-metas</a> <a id="109" class="Symbol">#-}</a>
 
 <a id="114" class="Keyword">postulate</a>
@@ -11,6 +11,6 @@
 
 <a id="A"></a><a id="147" href="Issue2474.html#147" class="Function">A</a> <a id="149" class="Symbol">:</a> <a id="151" class="PrimitiveType">Set</a>
 <a id="155" href="Issue2474.html#147" class="Function">A</a> <a id="157" class="Symbol">=</a> <a id="159" href="Issue2474.html#126" class="UnsolvedMeta Postulate">F</a>
-\end{code}<a id="171" class="Comment">
+<a id="161" class="Markup">\end{code}</a><a id="171" class="Background">
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2536.html
+++ b/test/LaTeXAndHTML/succeed/Issue2536.html
@@ -1,16 +1,16 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2536</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\nonstopmode
+<html><head><meta charset="utf-8"><title>Issue2536</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\nonstopmode
 \documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="76" class="Markup">\begin{code}</a>
 <a id="89" class="Keyword">module</a> <a id="96" href="Issue2536.html" class="Module">_</a> <a id="98" class="Keyword">where</a>
 <a id="id"></a><a id="104" href="Issue2536.html#104" class="Function">id</a> <a id="107" class="Symbol">:</a> <a id="109" class="Symbol">{</a><a id="110" href="Issue2536.html#110" class="Bound">A</a> <a id="112" class="Symbol">:</a> <a id="114" class="PrimitiveType">Set</a><a id="117" class="Symbol">}</a> <a id="119" class="Symbol">→</a> <a id="121" href="Issue2536.html#110" class="Bound">A</a> <a id="123" class="Symbol">→</a> <a id="125" href="Issue2536.html#110" class="Bound">A</a>
 <a id="127" href="Issue2536.html#104" class="Function">id</a> <a id="130" href="Issue2536.html#130" class="Bound">x</a> <a id="132" class="Symbol">=</a> <a id="134" href="Issue2536.html#130" class="Bound">x</a>
-\end{code}<a id="146" class="Comment">
+<a id="136" class="Markup">\end{code}</a><a id="146" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2588.html
+++ b/test/LaTeXAndHTML/succeed/Issue2588.html
@@ -1,16 +1,16 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2588</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2588</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Keyword">module</a> <a id="83" href="Issue2588.html" class="Module">Issue2588</a> <a id="93" class="Keyword">where</a>
 
 <a id="100" class="Comment">{-
 -}</a>
-\end{code}<a id="116" class="Comment">
+<a id="106" class="Markup">\end{code}</a><a id="116" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2623.html
+++ b/test/LaTeXAndHTML/succeed/Issue2623.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2623</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2623</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
@@ -9,20 +9,20 @@
 
 \noindent Text.
 \AgdaHide{
-</a>\begin{code}
+</a><a id="109" class="Markup">\begin{code}</a>
   <a id="124" class="Keyword">mutual</a>
-\end{code}<a id="141" class="Comment">}
-</a>\begin{code}
+<a id="131" class="Markup">\end{code}</a><a id="141" class="Background">}
+</a><a id="143" class="Markup">\begin{code}</a>
     <a id="160" class="Keyword">postulate</a> <a id="A"></a><a id="170" href="Issue2623.html#170" class="Postulate">A</a> <a id="172" class="Symbol">:</a> <a id="174" class="PrimitiveType">Set</a>
-\end{code}<a id="188" class="Comment">
+<a id="178" class="Markup">\end{code}</a><a id="188" class="Background">
 More text.
 \begin{AgdaMultiCode}
-</a>\begin{code}
+</a><a id="222" class="Markup">\begin{code}</a>
   <a id="237" class="Keyword">mutual</a>
-\end{code}<a id="254" class="Comment">
-</a>\begin{code}
+<a id="244" class="Markup">\end{code}</a><a id="254" class="Background">
+</a><a id="255" class="Markup">\begin{code}</a>
     <a id="272" class="Keyword">postulate</a> <a id="B"></a><a id="282" href="Issue2623.html#282" class="Postulate">B</a> <a id="284" class="Symbol">:</a> <a id="286" class="PrimitiveType">Set</a>
-\end{code}<a id="300" class="Comment">
+<a id="290" class="Markup">\end{code}</a><a id="300" class="Background">
 \end{AgdaMultiCode}
 Even more text.
 

--- a/test/LaTeXAndHTML/succeed/Issue2733-1.html
+++ b/test/LaTeXAndHTML/succeed/Issue2733-1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2733-1</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2733-1</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
@@ -9,12 +9,12 @@ No indentation should be inserted before \AgdaKeyword{postulate} or
 the last occurrence of \AgdaPrimitiveType{Set}, and the last
 occurrence of \AgdaPrimitiveType{Set} should be aligned with the
 penultimate occurrence of \AgdaPrimitiveType{Set}:
-</a>\begin{code}
+</a><a id="308" class="Markup">\begin{code}</a>
   <a id="323" class="Keyword">postulate</a>
     <a id="A"></a><a id="337" href="Issue2733-1.html#337" class="Postulate">A</a>  <a id="340" class="Symbol">:</a> <a id="342" class="PrimitiveType">Set</a>
     <a id="B"></a><a id="350" href="Issue2733-1.html#350" class="Postulate">B</a>  <a id="353" class="Symbol">:</a> <a id="355" class="PrimitiveType">Set</a> <a id="359" class="Symbol">→</a>
          <a id="370" class="PrimitiveType">Set</a>
-\end{code}<a id="384" class="Comment">
+<a id="374" class="Markup">\end{code}</a><a id="384" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2733-2.html
+++ b/test/LaTeXAndHTML/succeed/Issue2733-2.html
@@ -1,24 +1,24 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2733-2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2733-2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
 \begin{AgdaAlign}
-</a>\begin{code}
+</a><a id="81" class="Markup">\begin{code}</a>
 <a id="94" class="Keyword">module</a> <a id="101" href="Issue2733-2.html" class="Module">Issue2733-2</a> <a id="113" class="Keyword">where</a>
-\end{code}<a id="129" class="Comment">
+<a id="119" class="Markup">\end{code}</a><a id="129" class="Background">
 
 Indentation should be inserted before \AgdaKeyword{postulate}, but not
 before the last occurrence of \AgdaPrimitiveType{Set}, which should be
 aligned with the penultimate occurrence of \AgdaPrimitiveType{Set}:
-</a>\begin{code}
+</a><a id="341" class="Markup">\begin{code}</a>
   <a id="356" class="Keyword">postulate</a>
     <a id="A"></a><a id="370" href="Issue2733-2.html#370" class="Postulate">A</a>  <a id="373" class="Symbol">:</a> <a id="375" class="PrimitiveType">Set</a>
     <a id="B"></a><a id="383" href="Issue2733-2.html#383" class="Postulate">B</a>  <a id="386" class="Symbol">:</a> <a id="388" class="PrimitiveType">Set</a> <a id="392" class="Symbol">→</a>
          <a id="403" class="PrimitiveType">Set</a>
-\end{code}<a id="417" class="Comment">
+<a id="407" class="Markup">\end{code}</a><a id="417" class="Background">
 \end{AgdaAlign}
 
 \end{document}

--- a/test/LaTeXAndHTML/succeed/Issue2734.html
+++ b/test/LaTeXAndHTML/succeed/Issue2734.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2734</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2734</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
@@ -10,12 +10,12 @@
 \thispagestyle{empty}
 
 Text.
-</a>\begin{code}
+</a><a id="139" class="Markup">\begin{code}</a>
   <a id="154" class="Keyword">postulate</a>
     <a id="A"></a><a id="168" href="Issue2734.html#168" class="Postulate">A</a>  <a id="171" class="Symbol">:</a> <a id="173" class="PrimitiveType">Set</a>
 
     <a id="B"></a><a id="182" href="Issue2734.html#182" class="Postulate">B</a>  <a id="185" class="Symbol">:</a> <a id="187" class="PrimitiveType">Set</a>
-\end{code}<a id="201" class="Comment">
+<a id="191" class="Markup">\end{code}</a><a id="201" class="Background">
 More text.
 
 \end{document}

--- a/test/LaTeXAndHTML/succeed/Issue2740-1.html
+++ b/test/LaTeXAndHTML/succeed/Issue2740-1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2740-1</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2740-1</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
@@ -8,9 +8,9 @@
 \begin{document}
 
 \noindent Beginning of line.
-</a>\begin{code}
+</a><a id="111" class="Markup">\begin{code}</a>
 <a id="124" class="Keyword">postulate</a> <a id="A"></a><a id="134" href="Issue2740-1.html#134" class="Postulate">A</a> <a id="136" class="Symbol">:</a> <a id="138" class="PrimitiveType">Set</a>
-\end{code}<a id="152" class="Comment">
+<a id="142" class="Markup">\end{code}</a><a id="152" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2740-2.html
+++ b/test/LaTeXAndHTML/succeed/Issue2740-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2740-2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2740-2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
@@ -8,9 +8,9 @@
 \begin{document}
 
 \noindent Beginning of line.
-</a>\begin{code}
+</a><a id="111" class="Markup">\begin{code}</a>
   <a id="126" class="Keyword">postulate</a> <a id="A"></a><a id="136" href="Issue2740-2.html#136" class="Postulate">A</a> <a id="138" class="Symbol">:</a> <a id="140" class="PrimitiveType">Set</a>
-\end{code}<a id="154" class="Comment">
+<a id="144" class="Markup">\end{code}</a><a id="154" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue2744.html
+++ b/test/LaTeXAndHTML/succeed/Issue2744.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue2744</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue2744</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
@@ -7,67 +7,67 @@
 
 \noindent Before.
 \begin{AgdaMultiCode}
-</a>\begin{code}[hide]
+</a><a id="103" class="Markup">\begin{code}[hide]</a>
   <a id="124" class="Keyword">postulate</a>
-\end{code}<a id="144" class="Comment">
-</a>\begin{code}
+<a id="134" class="Markup">\end{code}</a><a id="144" class="Background">
+</a><a id="145" class="Markup">\begin{code}</a>
     <a id="A"></a><a id="162" href="Issue2744.html#162" class="Postulate">A</a>    <a id="167" class="Symbol">:</a> <a id="169" class="PrimitiveType">Set</a>
-\end{code}<a id="183" class="Comment">
-</a>\begin{code}
+<a id="173" class="Markup">\end{code}</a><a id="183" class="Background">
+</a><a id="184" class="Markup">\begin{code}</a>
     <a id="BBB"></a><a id="201" href="Issue2744.html#201" class="Postulate">BBB</a>  <a id="206" class="Symbol">:</a> <a id="208" class="PrimitiveType">Set</a>
-\end{code}<a id="222" class="Comment">
+<a id="212" class="Markup">\end{code}</a><a id="222" class="Background">
 \end{AgdaMultiCode}
 After.
 
 \noindent Before.
 \begin{AgdaAlign}
-</a>\begin{code}
+</a><a id="287" class="Markup">\begin{code}</a>
   <a id="302" class="Keyword">postulate</a>
     <a id="C"></a><a id="316" href="Issue2744.html#316" class="Postulate">C</a> <a id="318" class="Symbol">:</a> <a id="320" class="PrimitiveType">Set</a>
-\end{code}<a id="334" class="Comment">
-</a>\begin{code}[hide]
+<a id="324" class="Markup">\end{code}</a><a id="334" class="Background">
+</a><a id="335" class="Markup">\begin{code}[hide]</a>
     <a id="D"></a><a id="358" href="Issue2744.html#358" class="Postulate">D</a> <a id="360" class="Symbol">:</a> <a id="362" class="PrimitiveType">Set</a>
-\end{code}<a id="376" class="Comment">
-</a>\begin{code}
+<a id="366" class="Markup">\end{code}</a><a id="376" class="Background">
+</a><a id="377" class="Markup">\begin{code}</a>
     <a id="E"></a><a id="394" href="Issue2744.html#394" class="Postulate">E</a> <a id="396" class="Symbol">:</a> <a id="398" class="PrimitiveType">Set</a>
-\end{code}<a id="412" class="Comment">
+<a id="402" class="Markup">\end{code}</a><a id="412" class="Background">
 \end{AgdaAlign}
 After.
 
 \noindent Before.
 \begin{AgdaAlign}
-</a>\begin{code}
+</a><a id="473" class="Markup">\begin{code}</a>
   <a id="488" class="Keyword">postulate</a>
     <a id="F"></a><a id="502" href="Issue2744.html#502" class="Postulate">F</a> <a id="504" class="Symbol">:</a> <a id="506" class="PrimitiveType">Set</a>
-\end{code}<a id="520" class="Comment">
+<a id="510" class="Markup">\end{code}</a><a id="520" class="Background">
 In between.
 \begin{AgdaSuppressSpace}
-</a>\begin{code}
+</a><a id="559" class="Markup">\begin{code}</a>
   <a id="574" class="Keyword">postulate</a>
     <a id="G"></a><a id="588" href="Issue2744.html#588" class="Postulate">G</a> <a id="590" class="Symbol">:</a> <a id="592" class="PrimitiveType">Set</a>
-\end{code}<a id="606" class="Comment">
-</a>\begin{code}[hide]
+<a id="596" class="Markup">\end{code}</a><a id="606" class="Background">
+</a><a id="607" class="Markup">\begin{code}[hide]</a>
   <a id="628" class="Keyword">postulate</a>
-\end{code}<a id="648" class="Comment">
-</a>\begin{code}
+<a id="638" class="Markup">\end{code}</a><a id="648" class="Background">
+</a><a id="649" class="Markup">\begin{code}</a>
     <a id="H"></a><a id="666" href="Issue2744.html#666" class="Postulate">H</a> <a id="668" class="Symbol">:</a> <a id="670" class="PrimitiveType">Set</a>
-\end{code}<a id="684" class="Comment">
+<a id="674" class="Markup">\end{code}</a><a id="684" class="Background">
 \end{AgdaSuppressSpace}
 \end{AgdaAlign}
 After.
 
 \noindent Before.
 \begin{AgdaMultiCode}
-</a>\begin{code}
+</a><a id="773" class="Markup">\begin{code}</a>
   <a id="788" class="Keyword">postulate</a>
     <a id="!_!"></a><a id="802" href="Issue2744.html#802" class="Postulate Operator">!_!</a>    <a id="809" class="Symbol">:</a> <a id="811" class="PrimitiveType">Set</a> <a id="815" class="Symbol">→</a> <a id="817" class="PrimitiveType">Set</a>
-\end{code}<a id="831" class="Comment">
-</a>\begin{code}[hide]
+<a id="821" class="Markup">\end{code}</a><a id="831" class="Background">
+</a><a id="832" class="Markup">\begin{code}[hide]</a>
   <a id="853" class="Keyword">postulate</a>
-\end{code}<a id="873" class="Comment">
-</a>\begin{code}
+<a id="863" class="Markup">\end{code}</a><a id="873" class="Background">
+</a><a id="874" class="Markup">\begin{code}</a>
     <a id="&lt;!_!&gt;"></a><a id="891" href="Issue2744.html#891" class="Postulate Operator">&lt;!_!&gt;</a>  <a id="898" class="Symbol">:</a> <a id="900" class="PrimitiveType">Set</a> <a id="904" class="Symbol">→</a> <a id="906" class="PrimitiveType">Set</a>
-\end{code}<a id="920" class="Comment">
+<a id="910" class="Markup">\end{code}</a><a id="920" class="Background">
 \end{AgdaMultiCode}
 After.
 

--- a/test/LaTeXAndHTML/succeed/Issue3322.html
+++ b/test/LaTeXAndHTML/succeed/Issue3322.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue3322</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">% Nisse, 2018-10-26
+<html><head><meta charset="utf-8"><title>Issue3322</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">% Nisse, 2018-10-26
 % Testing that record field are already highlighted by scope checker.
 
 \documentclass{article}
@@ -23,7 +23,7 @@
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="553" class="Markup">\begin{code}</a>
 <a id="566" class="Keyword">record</a> <a id="R"></a><a id="573" href="Issue3322.html#573" class="Record">R</a> <a id="575" class="Symbol">:</a> <a id="577" class="PrimitiveType">Set₂</a> <a id="582" class="Keyword">where</a>
   <a id="590" class="Keyword">field</a>
     <a id="R.⊥"></a><a id="600" href="Issue3322.html#600" class="Field">⊥</a> <a id="602" class="Symbol">:</a> <a id="604" class="PrimitiveType">Set₁</a>
@@ -31,7 +31,7 @@
 <a id="r"></a><a id="610" href="Issue3322.html#610" class="Function">r</a> <a id="612" class="Symbol">:</a> <a id="614" href="Issue3322.html#573" class="Record">R</a>
 
 <a id="617" href="Issue3322.html#610" class="Function">r</a> <a id="619" class="Symbol">=</a> <a id="621" class="Keyword">record</a> <a id="628" class="Symbol">{</a> <a id="630" href="Issue3322.html#600" class="Field">⊥</a> <a id="632" class="Symbol">=</a> <a id="634" class="PrimitiveType">Set</a> <a id="638" class="Symbol">}</a>
-\end{code}<a id="650" class="Comment">
+<a id="640" class="Markup">\end{code}</a><a id="650" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Issue982.html
+++ b/test/LaTeXAndHTML/succeed/Issue982.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Issue982</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Issue982</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
@@ -7,7 +7,7 @@
 
 %\renewcommand{\AgdaIndent}{\;\;}
 
-</a>\begin{code}
+</a><a id="98" class="Markup">\begin{code}</a>
 <a id="111" class="Keyword">record</a> <a id="Sigma"></a><a id="118" href="Issue982.html#118" class="Record">Sigma</a> <a id="124" class="Symbol">(</a><a id="125" href="Issue982.html#125" class="Bound">A</a> <a id="127" class="Symbol">:</a> <a id="129" class="PrimitiveType">Set</a><a id="132" class="Symbol">)</a> <a id="134" class="Symbol">(</a><a id="135" href="Issue982.html#135" class="Bound">B</a> <a id="137" class="Symbol">:</a> <a id="139" href="Issue982.html#125" class="Bound">A</a> <a id="141" class="Symbol">→</a> <a id="143" class="PrimitiveType">Set</a><a id="146" class="Symbol">)</a> <a id="148" class="Symbol">:</a> <a id="150" class="PrimitiveType">Set</a> <a id="154" class="Keyword">where</a>
   <a id="162" class="Keyword">constructor</a> <a id="Sigma._,_"></a><a id="174" href="Issue982.html#174" class="InductiveConstructor Operator">_,_</a>
   <a id="180" class="Keyword">field</a>
@@ -15,14 +15,14 @@
     <a id="Sigma.proj₂"></a><a id="204" href="Issue982.html#204" class="Field">proj₂</a> <a id="210" class="Symbol">:</a> <a id="212" href="Issue982.html#135" class="Bound">B</a> <a id="214" href="Issue982.html#190" class="Field">proj₁</a>
 
 <a id="221" class="Keyword">open</a> <a id="226" href="Issue982.html#118" class="Module">Sigma</a> <a id="232" class="Keyword">public</a>
-\end{code}<a id="249" class="Comment">
+<a id="239" class="Markup">\end{code}</a><a id="249" class="Background">
 
-</a>\begin{code}
+</a><a id="251" class="Markup">\begin{code}</a>
 <a id="uncurry"></a><a id="264" href="Issue982.html#264" class="Function">uncurry</a> <a id="272" class="Symbol">:</a> <a id="274" class="Symbol">{</a><a id="275" href="Issue982.html#275" class="Bound">A</a> <a id="277" class="Symbol">:</a> <a id="279" class="PrimitiveType">Set</a><a id="282" class="Symbol">}</a> <a id="284" class="Symbol">{</a><a id="285" href="Issue982.html#285" class="Bound">B</a> <a id="287" class="Symbol">:</a> <a id="289" href="Issue982.html#275" class="Bound">A</a> <a id="291" class="Symbol">→</a> <a id="293" class="PrimitiveType">Set</a><a id="296" class="Symbol">}</a> <a id="298" class="Symbol">{</a><a id="299" href="Issue982.html#299" class="Bound">C</a> <a id="301" class="Symbol">:</a> <a id="303" href="Issue982.html#118" class="Record">Sigma</a> <a id="309" href="Issue982.html#275" class="Bound">A</a> <a id="311" href="Issue982.html#285" class="Bound">B</a> <a id="313" class="Symbol">→</a> <a id="315" class="PrimitiveType">Set</a><a id="318" class="Symbol">}</a> <a id="320" class="Symbol">→</a>
           <a id="332" class="Symbol">((</a><a id="334" href="Issue982.html#334" class="Bound">x</a> <a id="336" class="Symbol">:</a> <a id="338" href="Issue982.html#275" class="Bound">A</a><a id="339" class="Symbol">)</a> <a id="341" class="Symbol">→</a> <a id="343" class="Symbol">(</a><a id="344" href="Issue982.html#344" class="Bound">y</a> <a id="346" class="Symbol">:</a> <a id="348" href="Issue982.html#285" class="Bound">B</a> <a id="350" href="Issue982.html#334" class="Bound">x</a><a id="351" class="Symbol">)</a> <a id="353" class="Symbol">→</a> <a id="355" href="Issue982.html#299" class="Bound">C</a> <a id="357" class="Symbol">(</a><a id="358" href="Issue982.html#334" class="Bound">x</a> <a id="360" href="Issue982.html#174" class="InductiveConstructor Operator">,</a> <a id="362" href="Issue982.html#344" class="Bound">y</a><a id="363" class="Symbol">))</a> <a id="366" class="Symbol">→</a>
           <a id="378" class="Symbol">((</a><a id="380" href="Issue982.html#380" class="Bound">p</a> <a id="382" class="Symbol">:</a> <a id="384" href="Issue982.html#118" class="Record">Sigma</a> <a id="390" href="Issue982.html#275" class="Bound">A</a> <a id="392" href="Issue982.html#285" class="Bound">B</a><a id="393" class="Symbol">)</a> <a id="395" class="Symbol">→</a> <a id="397" href="Issue982.html#299" class="Bound">C</a> <a id="399" href="Issue982.html#380" class="Bound">p</a><a id="400" class="Symbol">)</a>
 <a id="402" href="Issue982.html#264" class="Function">uncurry</a> <a id="410" href="Issue982.html#410" class="Bound">f</a> <a id="412" class="Symbol">(</a><a id="413" href="Issue982.html#413" class="Bound">x</a> <a id="415" href="Issue982.html#174" class="InductiveConstructor Operator">,</a> <a id="417" href="Issue982.html#417" class="Bound">y</a><a id="418" class="Symbol">)</a> <a id="420" class="Symbol">=</a> <a id="422" href="Issue982.html#410" class="Bound">f</a> <a id="424" href="Issue982.html#413" class="Bound">x</a> <a id="426" href="Issue982.html#417" class="Bound">y</a>
-\end{code}<a id="438" class="Comment">
+<a id="428" class="Markup">\end{code}</a><a id="438" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/LaTeX-succeed.html
+++ b/test/LaTeXAndHTML/succeed/LaTeX-succeed.html
@@ -1,17 +1,17 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>LaTeX-succeed</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>LaTeX-succeed</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
 \AgdaHide{
-</a>\begin{code}
+</a><a id="74" class="Markup">\begin{code}</a>
 <a id="87" class="Keyword">module</a> <a id="94" href="LaTeX-succeed.html" class="Module">LaTeX-succeed</a> <a id="108" class="Keyword">where</a>
-\end{code}<a id="124" class="Comment">
+<a id="114" class="Markup">\end{code}</a><a id="124" class="Background">
 }
 
-</a>\begin{code}
+</a><a id="128" class="Markup">\begin{code}</a>
 <a id="141" class="Keyword">data</a> <a id="Bool"></a><a id="146" href="LaTeX-succeed.html#146" class="Datatype">Bool</a> <a id="151" class="Symbol">:</a> <a id="153" class="PrimitiveType">Set</a> <a id="157" class="Keyword">where</a>
   <a id="Bool.true"></a><a id="165" href="LaTeX-succeed.html#165" class="InductiveConstructor">true</a>   <a id="172" class="Symbol">:</a> <a id="174" href="LaTeX-succeed.html#146" class="Datatype">Bool</a>
   <a id="Bool.false"></a><a id="181" href="LaTeX-succeed.html#181" class="InductiveConstructor">false</a>  <a id="188" class="Symbol">:</a> <a id="190" href="LaTeX-succeed.html#146" class="Datatype">Bool</a>
@@ -35,9 +35,9 @@
 <a id="514" href="LaTeX-succeed.html#450" class="Function">alignment</a>     <a id="528" class="Number">1</a>  <a id="531" class="Number">2</a>  <a id="534" class="Number">3</a>  <a id="537" class="Number">4</a>  <a id="540" class="Symbol">=</a>  <a id="543" class="Number">5</a>
 <a id="545" href="LaTeX-succeed.html#450" class="Function">alignment</a>        <a id="562" class="Number">2</a>  <a id="565" class="Number">3</a>  <a id="568" class="Number">4</a>  <a id="571" class="Number">5</a>     <a id="577" class="Symbol">=</a> <a id="579" class="Number">6</a>
 <a id="581" href="LaTeX-succeed.html#450" class="CatchallClause Function">alignment</a><a id="590" class="CatchallClause">           </a><a id="601" class="CatchallClause Symbol">_</a><a id="602" class="CatchallClause">  </a><a id="604" class="CatchallClause Symbol">_</a><a id="605" class="CatchallClause">  </a><a id="607" class="CatchallClause Symbol">_</a><a id="608" class="CatchallClause">  </a><a id="610" class="CatchallClause Symbol">_</a>  <a id="613" class="Symbol">=</a> <a id="615" class="Number">0</a>
-\end{code}<a id="627" class="Comment">
+<a id="617" class="Markup">\end{code}</a><a id="627" class="Background">
 
-</a>\begin{code}
+</a><a id="629" class="Markup">\begin{code}</a>
 <a id="642" class="Keyword">data</a> <a id="⊥"></a><a id="647" href="LaTeX-succeed.html#647" class="Datatype">⊥</a> <a id="649" class="Symbol">:</a> <a id="651" class="PrimitiveType">Set</a> <a id="655" class="Keyword">where</a>
 
 <a id="662" class="Keyword">record</a> <a id="R"></a><a id="669" href="LaTeX-succeed.html#669" class="Record">R</a> <a id="671" class="Symbol">:</a> <a id="673" class="PrimitiveType">Set₁</a> <a id="678" class="Keyword">where</a>
@@ -50,9 +50,9 @@
     <a id="R′.h"></a><a id="766" href="LaTeX-succeed.html#766" class="Field">h</a>  <a id="769" class="Symbol">:</a> <a id="771" class="PrimitiveType">Set</a>
     <a id="R′.j"></a><a id="779" href="LaTeX-succeed.html#779" class="Field">j</a>  <a id="782" class="Symbol">:</a> <a id="784" class="PrimitiveType">Set</a>
     <a id="R′.r"></a><a id="792" href="LaTeX-succeed.html#792" class="Field">r</a>  <a id="795" class="Symbol">:</a> <a id="797" href="LaTeX-succeed.html#669" class="Record">R</a>
-\end{code}<a id="809" class="Comment">
+<a id="799" class="Markup">\end{code}</a><a id="809" class="Background">
 
-</a>\begin{code}
+</a><a id="811" class="Markup">\begin{code}</a>
 <a id="824" class="Keyword">module</a> <a id="M"></a><a id="831" href="LaTeX-succeed.html#831" class="Module">M</a> <a id="833" class="Keyword">where</a>
   <a id="M.r′"></a><a id="841" href="LaTeX-succeed.html#841" class="Function">r′</a> <a id="844" class="Symbol">:</a> <a id="846" class="Symbol">∀</a> <a id="848" class="Symbol">{</a><a id="849" href="LaTeX-succeed.html#849" class="Bound">A</a> <a id="851" href="LaTeX-succeed.html#851" class="Bound">B</a> <a id="853" class="Symbol">:</a> <a id="855" class="PrimitiveType">Set</a><a id="858" class="Symbol">}</a> <a id="860" class="Symbol">→</a> <a id="862" href="LaTeX-succeed.html#726" class="Record">R′</a> <a id="865" href="LaTeX-succeed.html#849" class="Bound">A</a> <a id="867" href="LaTeX-succeed.html#851" class="Bound">B</a>
   <a id="871" href="LaTeX-succeed.html#841" class="Function">r′</a> <a id="874" class="Symbol">=</a> <a id="876" class="Keyword">record</a>
@@ -63,11 +63,11 @@
         <a id="951" class="Symbol">;</a> <a id="953" href="LaTeX-succeed.html#709" class="Field">g</a>  <a id="956" class="Symbol">=</a> <a id="958" href="LaTeX-succeed.html#647" class="Datatype">⊥</a>
         <a id="968" class="Symbol">}</a>
     <a id="974" class="Symbol">}</a>
-\end{code}<a id="986" class="Comment">
+<a id="976" class="Markup">\end{code}</a><a id="986" class="Background">
 
 Andreas, 2018-04-03: The following two modules test the highlighting of projection patterns.
 
-</a>\begin{code}
+</a><a id="1082" class="Markup">\begin{code}</a>
 <a id="1095" class="Keyword">module</a> <a id="QualifiedProjectionPatterns"></a><a id="1102" href="LaTeX-succeed.html#1102" class="Module">QualifiedProjectionPatterns</a> <a id="1130" class="Keyword">where</a>
 
   <a id="QualifiedProjectionPatterns.r"></a><a id="1139" href="LaTeX-succeed.html#1139" class="Function">r</a> <a id="1141" class="Symbol">:</a> <a id="1143" href="LaTeX-succeed.html#669" class="Record">R</a>
@@ -78,9 +78,9 @@ Andreas, 2018-04-03: The following two modules test the highlighting of projecti
   <a id="1194" href="LaTeX-succeed.html#766" class="Field">R′.h</a> <a id="1199" href="LaTeX-succeed.html#1177" class="Function">r′</a> <a id="1202" class="Symbol">=</a> <a id="1204" href="LaTeX-succeed.html#647" class="Datatype">⊥</a>
   <a id="1208" href="LaTeX-succeed.html#779" class="Field">R′.j</a> <a id="1213" href="LaTeX-succeed.html#1177" class="Function">r′</a> <a id="1216" class="Symbol">=</a> <a id="1218" href="LaTeX-succeed.html#146" class="Datatype">Bool</a> <a id="1223" class="Symbol">→</a> <a id="1225" href="LaTeX-succeed.html#146" class="Datatype">Bool</a>
   <a id="1232" href="LaTeX-succeed.html#792" class="Field">R′.r</a> <a id="1237" href="LaTeX-succeed.html#1177" class="Function">r′</a> <a id="1240" class="Symbol">=</a> <a id="1242" href="LaTeX-succeed.html#1139" class="Function">r</a>
-\end{code}<a id="1254" class="Comment">
+<a id="1244" class="Markup">\end{code}</a><a id="1254" class="Background">
 
-</a>\begin{code}
+</a><a id="1256" class="Markup">\begin{code}</a>
 <a id="1269" class="Keyword">module</a> <a id="UnqualifiedProjectionPatterns"></a><a id="1276" href="LaTeX-succeed.html#1276" class="Module">UnqualifiedProjectionPatterns</a> <a id="1306" class="Keyword">where</a>
   <a id="1314" class="Keyword">open</a> <a id="1319" href="LaTeX-succeed.html#669" class="Module">R</a><a id="1320" class="Symbol">;</a> <a id="1322" class="Keyword">open</a> <a id="1327" href="LaTeX-succeed.html#726" class="Module">R′</a>
 
@@ -92,7 +92,7 @@ Andreas, 2018-04-03: The following two modules test the highlighting of projecti
   <a id="1387" href="LaTeX-succeed.html#766" class="Field">h</a> <a id="1389" href="LaTeX-succeed.html#1370" class="Function">r′</a> <a id="1392" class="Symbol">=</a> <a id="1394" href="LaTeX-succeed.html#647" class="Datatype">⊥</a>
   <a id="1398" href="LaTeX-succeed.html#779" class="Field">j</a> <a id="1400" href="LaTeX-succeed.html#1370" class="Function">r′</a> <a id="1403" class="Symbol">=</a> <a id="1405" href="LaTeX-succeed.html#146" class="Datatype">Bool</a> <a id="1410" class="Symbol">→</a> <a id="1412" href="LaTeX-succeed.html#146" class="Datatype">Bool</a>
   <a id="1419" href="LaTeX-succeed.html#792" class="Field">r</a> <a id="1421" href="LaTeX-succeed.html#1370" class="Function">r′</a> <a id="1424" class="Symbol">=</a> <a id="1426" href="LaTeX-succeed.html#1333" class="Function">r₀</a>
-\end{code}<a id="1439" class="Comment">
+<a id="1429" class="Markup">\end{code}</a><a id="1439" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Legacy-AgdaIndent.html
+++ b/test/LaTeXAndHTML/succeed/Legacy-AgdaIndent.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Legacy-AgdaIndent</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Legacy-AgdaIndent</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
@@ -8,10 +8,10 @@
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="162" class="Markup">\begin{code}</a>
 <a id="175" class="Keyword">postulate</a>
   <a id="Whatever"></a><a id="187" href="Legacy-AgdaIndent.html#187" class="Postulate">Whatever</a> <a id="196" class="Symbol">:</a> <a id="198" class="PrimitiveType">Set</a>
-\end{code}<a id="212" class="Comment">
+<a id="202" class="Markup">\end{code}</a><a id="212" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Less-extra-indentation.html
+++ b/test/LaTeXAndHTML/succeed/Less-extra-indentation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Less-extra-indentation</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Less-extra-indentation</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
@@ -12,135 +12,135 @@
 \begin{document}
 
 \noindent Control:
-</a>\begin{code}
+</a><a id="198" class="Markup">\begin{code}</a>
   <a id="213" href="Less-extra-indentation.html#213" class="Function">_</a> <a id="215" class="Symbol">:</a> <a id="217" class="PrimitiveType">Set₁</a>
   <a id="224" class="Symbol">_</a> <a id="226" class="Symbol">=</a> <a id="228" class="PrimitiveType">Set</a>
-\end{code}<a id="242" class="Comment">
+<a id="232" class="Markup">\end{code}</a><a id="242" class="Background">
 
 \noindent No extra indentation (alignment):
-</a>\begin{code}[hide]
+</a><a id="288" class="Markup">\begin{code}[hide]</a>
   <a id="309" href="Less-extra-indentation.html#309" class="Function">_</a> <a id="311" class="Symbol">:</a> <a id="313" class="PrimitiveType">Set₁</a>
   <a id="320" class="Symbol">_</a> <a id="322" class="Symbol">=</a>
-\end{code}<a id="334" class="Comment">
-</a>\begin{code}
+<a id="324" class="Markup">\end{code}</a><a id="334" class="Background">
+</a><a id="335" class="Markup">\begin{code}</a>
     <a id="352" class="PrimitiveType">Set</a>
-\end{code}<a id="366" class="Comment">
+<a id="356" class="Markup">\end{code}</a><a id="366" class="Background">
 
 \noindent No extra indentation (indentation):
-</a>\begin{code}[hide]
+</a><a id="414" class="Markup">\begin{code}[hide]</a>
   <a id="435" href="Less-extra-indentation.html#435" class="Function">_</a> <a id="437" class="Symbol">:</a> <a id="439" class="PrimitiveType">Set₁</a>
   <a id="446" class="Symbol">_</a> <a id="448" class="Symbol">=</a>
-\end{code}<a id="460" class="Comment">
-</a>\begin{code}
+<a id="450" class="Markup">\end{code}</a><a id="460" class="Background">
+</a><a id="461" class="Markup">\begin{code}</a>
      <a id="479" class="PrimitiveType">Set</a>
-\end{code}<a id="493" class="Comment">
+<a id="483" class="Markup">\end{code}</a><a id="493" class="Background">
 
 \noindent No extra indentation (alignment):
-</a>\begin{code}[hide]
+</a><a id="539" class="Markup">\begin{code}[hide]</a>
   <a id="560" class="Keyword">postulate</a>
     <a id="574" href="Less-extra-indentation.html#574" class="Postulate">_</a> <a id="576" class="Symbol">:</a>
-\end{code}<a id="588" class="Comment">
-</a>\begin{code}
+<a id="578" class="Markup">\end{code}</a><a id="588" class="Background">
+</a><a id="589" class="Markup">\begin{code}</a>
       <a id="608" class="PrimitiveType">Set</a>
-\end{code}<a id="622" class="Comment">
+<a id="612" class="Markup">\end{code}</a><a id="622" class="Background">
 
 \noindent No extra indentation (indentation):
-</a>\begin{code}[hide]
+</a><a id="670" class="Markup">\begin{code}[hide]</a>
   <a id="691" class="Keyword">postulate</a>
     <a id="705" href="Less-extra-indentation.html#705" class="Postulate">_</a> <a id="707" class="Symbol">:</a>
-\end{code}<a id="719" class="Comment">
-</a>\begin{code}
+<a id="709" class="Markup">\end{code}</a><a id="719" class="Background">
+</a><a id="720" class="Markup">\begin{code}</a>
        <a id="740" class="PrimitiveType">Set</a>
-\end{code}<a id="754" class="Comment">
+<a id="744" class="Markup">\end{code}</a><a id="754" class="Background">
 
 \noindent No extra indentation (alignment, \texttt{AgdaMultiCode}):
 \begin{AgdaMultiCode}
-</a>\begin{code}[hide]
+</a><a id="846" class="Markup">\begin{code}[hide]</a>
   <a id="867" href="Less-extra-indentation.html#867" class="Function">_</a> <a id="869" class="Symbol">:</a> <a id="871" class="PrimitiveType">Set₁</a>
   <a id="878" class="Symbol">_</a> <a id="880" class="Symbol">=</a>
-\end{code}<a id="892" class="Comment">
-</a>\begin{code}
+<a id="882" class="Markup">\end{code}</a><a id="892" class="Background">
+</a><a id="893" class="Markup">\begin{code}</a>
     <a id="910" class="PrimitiveType">Set</a>
-\end{code}<a id="924" class="Comment">
-</a>\begin{code}[hide]
+<a id="914" class="Markup">\end{code}</a><a id="924" class="Background">
+</a><a id="925" class="Markup">\begin{code}[hide]</a>
   <a id="946" href="Less-extra-indentation.html#946" class="Function">_</a> <a id="948" class="Symbol">:</a> <a id="950" class="PrimitiveType">Set₁</a>
   <a id="957" class="Symbol">_</a> <a id="959" class="Symbol">=</a>
-\end{code}<a id="971" class="Comment">
-</a>\begin{code}
+<a id="961" class="Markup">\end{code}</a><a id="971" class="Background">
+</a><a id="972" class="Markup">\begin{code}</a>
     <a id="989" class="PrimitiveType">Set</a>
-\end{code}<a id="1003" class="Comment">
+<a id="993" class="Markup">\end{code}</a><a id="1003" class="Background">
 \end{AgdaMultiCode}
 
 \noindent Extra indentation (indentation, \texttt{AgdaMultiCode}):
 \begin{AgdaMultiCode}
-</a>\begin{code}[hide]
+</a><a id="1114" class="Markup">\begin{code}[hide]</a>
   <a id="1135" href="Less-extra-indentation.html#1135" class="Function">_</a> <a id="1137" class="Symbol">:</a> <a id="1139" class="PrimitiveType">Set₁</a>
   <a id="1146" class="Symbol">_</a> <a id="1148" class="Symbol">=</a>
-\end{code}<a id="1160" class="Comment">
-</a>\begin{code}
+<a id="1150" class="Markup">\end{code}</a><a id="1160" class="Background">
+</a><a id="1161" class="Markup">\begin{code}</a>
      <a id="1179" class="PrimitiveType">Set</a>
-\end{code}<a id="1193" class="Comment">
-</a>\begin{code}[hide]
+<a id="1183" class="Markup">\end{code}</a><a id="1193" class="Background">
+</a><a id="1194" class="Markup">\begin{code}[hide]</a>
   <a id="1215" href="Less-extra-indentation.html#1215" class="Function">_</a> <a id="1217" class="Symbol">:</a> <a id="1219" class="PrimitiveType">Set₁</a>
   <a id="1226" class="Symbol">_</a> <a id="1228" class="Symbol">=</a>
-\end{code}<a id="1240" class="Comment">
-</a>\begin{code}
+<a id="1230" class="Markup">\end{code}</a><a id="1240" class="Background">
+</a><a id="1241" class="Markup">\begin{code}</a>
      <a id="1259" class="PrimitiveType">Set</a>
-\end{code}<a id="1273" class="Comment">
+<a id="1263" class="Markup">\end{code}</a><a id="1273" class="Background">
 \end{AgdaMultiCode}
 
 \noindent No extra indentation (alignment, \texttt{AgdaMultiCode}):
 \begin{AgdaMultiCode}
-</a>\begin{code}[hide]
+</a><a id="1385" class="Markup">\begin{code}[hide]</a>
   <a id="1406" class="Keyword">postulate</a>
     <a id="1420" href="Less-extra-indentation.html#1420" class="Postulate">_</a> <a id="1422" class="Symbol">:</a>
-\end{code}<a id="1434" class="Comment">
-</a>\begin{code}
+<a id="1424" class="Markup">\end{code}</a><a id="1434" class="Background">
+</a><a id="1435" class="Markup">\begin{code}</a>
       <a id="1454" class="PrimitiveType">Set</a>
-\end{code}<a id="1468" class="Comment">
-</a>\begin{code}[hide]
+<a id="1458" class="Markup">\end{code}</a><a id="1468" class="Background">
+</a><a id="1469" class="Markup">\begin{code}[hide]</a>
   <a id="1490" class="Keyword">postulate</a>
     <a id="1504" href="Less-extra-indentation.html#1504" class="Postulate">_</a> <a id="1506" class="Symbol">:</a>
-\end{code}<a id="1518" class="Comment">
-</a>\begin{code}
+<a id="1508" class="Markup">\end{code}</a><a id="1518" class="Background">
+</a><a id="1519" class="Markup">\begin{code}</a>
       <a id="1538" class="PrimitiveType">Set</a>
-\end{code}<a id="1552" class="Comment">
+<a id="1542" class="Markup">\end{code}</a><a id="1552" class="Background">
 \end{AgdaMultiCode}
 
 \noindent Extra indentation (indentation, \texttt{AgdaMultiCode}):
 \begin{AgdaMultiCode}
-</a>\begin{code}[hide]
+</a><a id="1663" class="Markup">\begin{code}[hide]</a>
   <a id="1684" class="Keyword">postulate</a>
     <a id="1698" href="Less-extra-indentation.html#1698" class="Postulate">_</a> <a id="1700" class="Symbol">:</a>
-\end{code}<a id="1712" class="Comment">
-</a>\begin{code}
+<a id="1702" class="Markup">\end{code}</a><a id="1712" class="Background">
+</a><a id="1713" class="Markup">\begin{code}</a>
        <a id="1733" class="PrimitiveType">Set</a>
-\end{code}<a id="1747" class="Comment">
-</a>\begin{code}[hide]
+<a id="1737" class="Markup">\end{code}</a><a id="1747" class="Background">
+</a><a id="1748" class="Markup">\begin{code}[hide]</a>
   <a id="1769" class="Keyword">postulate</a>
     <a id="1783" href="Less-extra-indentation.html#1783" class="Postulate">_</a> <a id="1785" class="Symbol">:</a>
-\end{code}<a id="1797" class="Comment">
-</a>\begin{code}
+<a id="1787" class="Markup">\end{code}</a><a id="1797" class="Background">
+</a><a id="1798" class="Markup">\begin{code}</a>
        <a id="1818" class="PrimitiveType">Set</a>
-\end{code}<a id="1832" class="Comment">
+<a id="1822" class="Markup">\end{code}</a><a id="1832" class="Background">
 \end{AgdaMultiCode}
 
 \noindent Extra indentation (indentation, \texttt{AgdaMultiCode}):
 \begin{AgdaMultiCode}
-</a>\begin{code}[hide]
+</a><a id="1943" class="Markup">\begin{code}[hide]</a>
   <a id="1964" class="Keyword">postulate</a>
     <a id="Aaa"></a><a id="1978" href="Less-extra-indentation.html#1978" class="Postulate">Aaa</a> <a id="1982" class="Symbol">:</a>
-\end{code}<a id="1994" class="Comment">
-</a>\begin{code}
+<a id="1984" class="Markup">\end{code}</a><a id="1994" class="Background">
+</a><a id="1995" class="Markup">\begin{code}</a>
       <a id="2014" class="PrimitiveType">Set</a>
-\end{code}<a id="2028" class="Comment">
-</a>\begin{code}[hide]
+<a id="2018" class="Markup">\end{code}</a><a id="2028" class="Background">
+</a><a id="2029" class="Markup">\begin{code}[hide]</a>
   <a id="2050" class="Keyword">postulate</a>
     <a id="Bbb"></a><a id="2064" href="Less-extra-indentation.html#2064" class="Postulate">Bbb</a> <a id="2068" class="Symbol">:</a>
-\end{code}<a id="2080" class="Comment">
-</a>\begin{code}
+<a id="2070" class="Markup">\end{code}</a><a id="2080" class="Background">
+</a><a id="2081" class="Markup">\begin{code}</a>
       <a id="2100" class="PrimitiveType">Set</a>
-\end{code}<a id="2114" class="Comment">
+<a id="2104" class="Markup">\end{code}</a><a id="2114" class="Background">
 \end{AgdaMultiCode}
 
 \end{document}

--- a/test/LaTeXAndHTML/succeed/Links.html
+++ b/test/LaTeXAndHTML/succeed/Links.html
@@ -1,16 +1,16 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Links</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Links</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{hyperref}
 \usepackage[links]{agda}
 \begin{document}
 
 \AgdaTarget{ℕ}
 \AgdaTarget{zero}
-</a>\begin{code}
+</a><a id="123" class="Markup">\begin{code}</a>
 <a id="136" class="Keyword">data</a> <a id="ℕ"></a><a id="141" href="Links.html#141" class="Datatype">ℕ</a> <a id="143" class="Symbol">:</a> <a id="145" class="PrimitiveType">Set</a> <a id="149" class="Keyword">where</a>
   <a id="ℕ.zero"></a><a id="157" href="Links.html#157" class="InductiveConstructor">zero</a>  <a id="163" class="Symbol">:</a> <a id="165" href="Links.html#141" class="Datatype">ℕ</a>
   <a id="ℕ.suc"></a><a id="169" href="Links.html#169" class="InductiveConstructor">suc</a>   <a id="175" class="Symbol">:</a> <a id="177" href="Links.html#141" class="Datatype">ℕ</a> <a id="179" class="Symbol">→</a> <a id="181" href="Links.html#141" class="Datatype">ℕ</a>
-\end{code}<a id="193" class="Comment">
+<a id="183" class="Markup">\end{code}</a><a id="193" class="Background">
 
 See next page for how to define \AgdaFunction{two} (doesn&#39;t turn into a
 link because the target hasn&#39;t been defined yet). We could do it
@@ -20,10 +20,10 @@ manually though; \hyperlink{two}{\AgdaDatatype{two}}.
 
 \AgdaTarget{two}
 \hypertarget{two}{}
-</a>\begin{code}
+</a><a id="434" class="Markup">\begin{code}</a>
 <a id="two"></a><a id="447" href="Links.html#447" class="Function">two</a> <a id="451" class="Symbol">:</a> <a id="453" href="Links.html#141" class="Datatype">ℕ</a>
 <a id="455" href="Links.html#447" class="Function">two</a> <a id="459" class="Symbol">=</a> <a id="461" href="Links.html#169" class="InductiveConstructor">suc</a> <a id="465" class="Symbol">(</a><a id="466" href="Links.html#169" class="InductiveConstructor">suc</a> <a id="470" href="Links.html#157" class="InductiveConstructor">zero</a><a id="474" class="Symbol">)</a>
-\end{code}<a id="486" class="Comment">
+<a id="476" class="Markup">\end{code}</a><a id="486" class="Background">
 
 \AgdaInductiveConstructor{zero} is of type
 \AgdaDatatype{ℕ}. \AgdaInductiveConstructor{suc} has not been defined to
@@ -34,20 +34,20 @@ be a target so it doesn&#39;t turn into a link.
 Now that the target for \AgdaFunction{two} has been defined the link
 works automatically.
 
-</a>\begin{code}
+</a><a id="750" class="Markup">\begin{code}</a>
 <a id="763" class="Keyword">data</a> <a id="Bool"></a><a id="768" href="Links.html#768" class="Datatype">Bool</a> <a id="773" class="Symbol">:</a> <a id="775" class="PrimitiveType">Set</a> <a id="779" class="Keyword">where</a>
   <a id="Bool.true"></a><a id="787" href="Links.html#787" class="InductiveConstructor">true</a> <a id="Bool.false"></a><a id="792" href="Links.html#792" class="InductiveConstructor">false</a> <a id="798" class="Symbol">:</a> <a id="800" href="Links.html#768" class="Datatype">Bool</a>
-\end{code}<a id="815" class="Comment">
+<a id="805" class="Markup">\end{code}</a><a id="815" class="Background">
 
 The AgdaTarget command takes a list as input, enabling several targets
 to be specified as follows:
 
 \AgdaTarget{if, then, else, if\_then\_else\_}
-</a>\begin{code}
+</a><a id="963" class="Markup">\begin{code}</a>
 <a id="if_then_else_"></a><a id="976" href="Links.html#976" class="Function Operator">if_then_else_</a> <a id="990" class="Symbol">:</a> <a id="992" class="Symbol">{</a><a id="993" href="Links.html#993" class="Bound">A</a> <a id="995" class="Symbol">:</a> <a id="997" class="PrimitiveType">Set</a><a id="1000" class="Symbol">}</a> <a id="1002" class="Symbol">→</a> <a id="1004" href="Links.html#768" class="Datatype">Bool</a> <a id="1009" class="Symbol">→</a> <a id="1011" href="Links.html#993" class="Bound">A</a> <a id="1013" class="Symbol">→</a> <a id="1015" href="Links.html#993" class="Bound">A</a> <a id="1017" class="Symbol">→</a> <a id="1019" href="Links.html#993" class="Bound">A</a>
 <a id="1021" href="Links.html#976" class="Function Operator">if</a> <a id="1024" href="Links.html#787" class="InductiveConstructor">true</a> <a id="1029" href="Links.html#976" class="Function Operator">then</a> <a id="1034" href="Links.html#1034" class="Bound">t</a> <a id="1036" href="Links.html#976" class="Function Operator">else</a> <a id="1041" href="Links.html#1041" class="Bound">f</a> <a id="1043" class="Symbol">=</a> <a id="1045" href="Links.html#1034" class="Bound">t</a>
 <a id="1047" href="Links.html#976" class="Function Operator">if</a> <a id="1050" href="Links.html#792" class="InductiveConstructor">false</a> <a id="1056" href="Links.html#976" class="Function Operator">then</a> <a id="1061" href="Links.html#1061" class="Bound">t</a> <a id="1063" href="Links.html#976" class="Function Operator">else</a> <a id="1068" href="Links.html#1068" class="Bound">f</a> <a id="1070" class="Symbol">=</a> <a id="1072" href="Links.html#1068" class="Bound">f</a>
-\end{code}<a id="1084" class="Comment">
+<a id="1074" class="Markup">\end{code}</a><a id="1084" class="Background">
 
 \newpage
 

--- a/test/LaTeXAndHTML/succeed/MdMultiLanguage.html
+++ b/test/LaTeXAndHTML/succeed/MdMultiLanguage.html
@@ -1,17 +1,17 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>MdMultiLanguage</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">&lt;!--
-</a>```
-<a id="10" class="Keyword">module</a> <a id="17" href="MdMultiLanguage.html" class="Module">MdMultiLanguage</a> <a id="33" class="Keyword">where</a>
-```
-<a id="43" class="Comment">--&gt;
+<html><head><meta charset="utf-8"><title>MdMultiLanguage</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">&lt;!--
+</a><a id="6" class="Markup">```
+</a><a id="10" class="Keyword">module</a> <a id="17" href="MdMultiLanguage.html" class="Module">MdMultiLanguage</a> <a id="33" class="Keyword">where</a>
+<a id="39" class="Markup">```
+</a><a id="43" class="Background">--&gt;
 
   ```haskell
 a :: Bool
 a = True
 ```
 
-     </a>```
-<a id="94" class="Keyword">data</a> <a id="Bool"></a><a id="99" href="MdMultiLanguage.html#99" class="Datatype">Bool</a> <a id="104" class="Symbol">:</a> <a id="106" class="PrimitiveType">Set</a> <a id="110" class="Keyword">where</a>
+     </a><a id="90" class="Markup">```
+</a><a id="94" class="Keyword">data</a> <a id="Bool"></a><a id="99" href="MdMultiLanguage.html#99" class="Datatype">Bool</a> <a id="104" class="Symbol">:</a> <a id="106" class="PrimitiveType">Set</a> <a id="110" class="Keyword">where</a>
     <a id="Bool.true"></a><a id="120" href="MdMultiLanguage.html#120" class="InductiveConstructor">true</a> <a id="125" class="Symbol">:</a> <a id="127" href="MdMultiLanguage.html#99" class="Datatype">Bool</a>
     <a id="Bool.false"></a><a id="136" href="MdMultiLanguage.html#136" class="InductiveConstructor">false</a> <a id="142" class="Symbol">:</a> <a id="144" href="MdMultiLanguage.html#99" class="Datatype">Bool</a>
     <a id="Bool.aa"></a><a id="153" href="MdMultiLanguage.html#153" class="InductiveConstructor">aa</a> <a id="156" class="Symbol">:</a> <a id="158" class="Comment">{- ``` -}</a> <a id="168" href="MdMultiLanguage.html#99" class="Datatype">Bool</a>
@@ -19,12 +19,12 @@ a = True
 <a id="a"></a><a id="174" href="MdMultiLanguage.html#174" class="Function">a</a> <a id="176" class="Symbol">:</a> <a id="178" href="MdMultiLanguage.html#99" class="Datatype">Bool</a>
 <a id="183" href="MdMultiLanguage.html#174" class="Function">a</a> <a id="185" class="Symbol">=</a> <a id="187" href="MdMultiLanguage.html#120" class="InductiveConstructor">true</a>
 
-```
-<a id="197" class="Comment">
+<a id="193" class="Markup">```
+</a><a id="197" class="Background">
 This is also parsed:
 
-</a>```agda
-  <a id="230" class="Keyword">module</a> <a id="MdQuotedDelim"></a><a id="237" href="MdMultiLanguage.html#237" class="Module">MdQuotedDelim</a> <a id="251" class="Keyword">where</a>
+</a><a id="220" class="Markup">```agda
+</a>  <a id="230" class="Keyword">module</a> <a id="MdQuotedDelim"></a><a id="237" href="MdMultiLanguage.html#237" class="Module">MdQuotedDelim</a> <a id="251" class="Keyword">where</a>
 
         <a id="266" class="Keyword">data</a> <a id="MdQuotedDelim.Bool’"></a><a id="271" href="MdMultiLanguage.html#271" class="Datatype">Bool’</a> <a id="277" class="Symbol">:</a> <a id="279" class="PrimitiveType">Set</a> <a id="283" class="Keyword">where</a>
             <a id="MdQuotedDelim.Bool’.true"></a><a id="301" href="MdMultiLanguage.html#301" class="InductiveConstructor">true</a> <a id="306" class="Symbol">:</a> <a id="308" href="MdMultiLanguage.html#271" class="Datatype">Bool’</a>
@@ -33,8 +33,8 @@ This is also parsed:
 
         <a id="MdQuotedDelim.a’"></a><a id="382" href="MdMultiLanguage.html#382" class="Function">a’</a> <a id="385" class="Symbol">:</a> <a id="387" href="MdMultiLanguage.html#271" class="Datatype">Bool’</a>
         <a id="401" href="MdMultiLanguage.html#382" class="Function">a’</a> <a id="404" class="Symbol">=</a> <a id="406" href="MdMultiLanguage.html#352" class="InductiveConstructor">aa</a>
-  ```
-<a id="415" class="Comment">
+<a id="409" class="Markup">  ```
+</a><a id="415" class="Background">
 * This one is not:
 
     a : Set
@@ -43,8 +43,8 @@ This is also parsed:
 
 * But this one is:
 
-  </a>```
-<a id="b"></a><a id="490" href="MdMultiLanguage.html#490" class="Function">b</a> <a id="492" class="Symbol">:</a> <a id="494" href="MdMultiLanguage.html#99" class="Datatype">Bool</a>
+  </a><a id="486" class="Markup">```
+</a><a id="b"></a><a id="490" href="MdMultiLanguage.html#490" class="Function">b</a> <a id="492" class="Symbol">:</a> <a id="494" href="MdMultiLanguage.html#99" class="Datatype">Bool</a>
 <a id="499" href="MdMultiLanguage.html#490" class="Function">b</a> <a id="501" class="Symbol">=</a> <a id="503" href="MdMultiLanguage.html#136" class="InductiveConstructor">false</a>
- ```
-</pre></body></html>
+<a id="509" class="Markup"> ```
+</a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/MdOneLine.html
+++ b/test/LaTeXAndHTML/succeed/MdOneLine.html
@@ -1,3 +1,3 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>MdOneLine</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">Hello, this is ``` postulate Truth : Set </a>```
-</pre></body></html>
+<html><head><meta charset="utf-8"><title>MdOneLine</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">Hello, this is ``` postulate Truth : Set </a><a id="42" class="Markup">```
+</a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/MdQuotedDelim.html
+++ b/test/LaTeXAndHTML/succeed/MdQuotedDelim.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>MdQuotedDelim</title><link rel="stylesheet" href="Agda.css"></head><body><pre>```
-  <a id="7" class="Keyword">module</a> <a id="14" href="MdQuotedDelim.html" class="Module">MdQuotedDelim</a> <a id="28" class="Keyword">where</a>
+<html><head><meta charset="utf-8"><title>MdQuotedDelim</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Markup">```
+</a>  <a id="7" class="Keyword">module</a> <a id="14" href="MdQuotedDelim.html" class="Module">MdQuotedDelim</a> <a id="28" class="Keyword">where</a>
 
         <a id="43" class="Keyword">data</a> <a id="Bool"></a><a id="48" href="MdQuotedDelim.html#48" class="Datatype">Bool</a> <a id="53" class="Symbol">:</a> <a id="55" class="PrimitiveType">Set</a> <a id="59" class="Keyword">where</a>
             <a id="Bool.true"></a><a id="77" href="MdQuotedDelim.html#77" class="InductiveConstructor">true</a> <a id="82" class="Symbol">:</a> <a id="84" href="MdQuotedDelim.html#48" class="Datatype">Bool</a>
@@ -9,5 +9,5 @@
 
         <a id="a"></a><a id="155" href="MdQuotedDelim.html#155" class="Function">a</a> <a id="157" class="Symbol">:</a> <a id="159" href="MdQuotedDelim.html#48" class="Datatype">Bool</a>
         <a id="172" href="MdQuotedDelim.html#155" class="Function">a</a> <a id="174" class="Symbol">=</a> <a id="176" href="MdQuotedDelim.html#77" class="InductiveConstructor">true</a>
-```
-</pre></body></html>
+<a id="181" class="Markup">```
+</a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Multiline.html
+++ b/test/LaTeXAndHTML/succeed/Multiline.html
@@ -1,13 +1,13 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Multiline</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Multiline</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 \begin{document}
-</a>\begin{code}
+</a><a id="60" class="Markup">\begin{code}</a>
 <a id="73" class="Keyword">open</a> <a id="78" class="Keyword">import</a> <a id="85" href="Agda.Builtin.String.html" class="Module">Agda.Builtin.String</a>
 
 <a id="argh"></a><a id="106" href="Multiline.html#106" class="Function">argh</a> <a id="111" class="Symbol">:</a> <a id="113" href="Agda.Builtin.String.html#174" class="Postulate">String</a>
 <a id="120" href="Multiline.html#106" class="Function">argh</a> <a id="125" class="Symbol">=</a>  <a id="128" class="String">&quot;Hello,\
         \World!&quot;</a>
-\end{code}<a id="164" class="Comment">
+<a id="154" class="Markup">\end{code}</a><a id="164" class="Background">
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/NoNewLinesVsNewLines.html
+++ b/test/LaTeXAndHTML/succeed/NoNewLinesVsNewLines.html
@@ -1,19 +1,19 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>NoNewLinesVsNewLines</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>NoNewLinesVsNewLines</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Keyword">module</a> <a id="83" href="NoNewLinesVsNewLines.html" class="Module">NoNewLinesVsNewLines</a> <a id="104" class="Keyword">where</a>
-\end{code}<a id="120" class="Comment">
+<a id="110" class="Markup">\end{code}</a><a id="120" class="Background">
 
-</a>\begin{code}
+</a><a id="122" class="Markup">\begin{code}</a>
 
 <a id="136" class="Keyword">module</a> <a id="Test2"></a><a id="143" href="NoNewLinesVsNewLines.html#143" class="Module">Test2</a> <a id="149" class="Keyword">where</a>
 
-\end{code}<a id="166" class="Comment">
+<a id="156" class="Markup">\end{code}</a><a id="166" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/OneSpaceIndent.html
+++ b/test/LaTeXAndHTML/succeed/OneSpaceIndent.html
@@ -1,31 +1,31 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>OneSpaceIndent</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>OneSpaceIndent</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 
 \begin{document}
 
 \AgdaHide{
-</a>\begin{code}
+</a><a id="73" class="Markup">\begin{code}</a>
 <a id="86" class="Keyword">module</a> <a id="93" href="OneSpaceIndent.html" class="Module">OneSpaceIndent</a> <a id="108" class="Keyword">where</a>
-\end{code}<a id="124" class="Comment">
+<a id="114" class="Markup">\end{code}</a><a id="124" class="Background">
 }
 
 \section{Syntax}
 Text1
 
 \AgdaHide{
-</a>\begin{code}
+</a><a id="163" class="Markup">\begin{code}</a>
 <a id="176" class="Keyword">module</a> <a id="Defs"></a><a id="183" href="OneSpaceIndent.html#183" class="Module">Defs</a> <a id="188" class="Keyword">where</a>
 
  <a id="196" class="Keyword">postulate</a>
-\end{code}<a id="216" class="Comment">
+<a id="206" class="Markup">\end{code}</a><a id="216" class="Background">
 }
 
 Text2
 
-</a>\begin{code}
+</a><a id="227" class="Markup">\begin{code}</a>
   <a id="Defs.Base"></a><a id="242" href="OneSpaceIndent.html#242" class="Postulate">Base</a> <a id="247" class="Symbol">:</a> <a id="249" class="PrimitiveType">Set</a>
-\end{code}<a id="263" class="Comment">
+<a id="253" class="Markup">\end{code}</a><a id="263" class="Background">
 
 Text3
 \end{document}

--- a/test/LaTeXAndHTML/succeed/Options.html
+++ b/test/LaTeXAndHTML/succeed/Options.html
@@ -1,14 +1,14 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Options</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Options</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Symbol">{-#</a> <a id="80" class="Keyword">OPTIONS</a>  <a id="89" class="Option">--no-positivity-check</a>
              <a id="124" class="Option">--no-termination-check</a> <a id="147" class="Symbol">#-}</a>
-\end{code}<a id="161" class="Comment">
+<a id="151" class="Markup">\end{code}</a><a id="161" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/PatternSynonyms.html
+++ b/test/LaTeXAndHTML/succeed/PatternSynonyms.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>PatternSynonyms</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>PatternSynonyms</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 \begin{document}
 
-</a>\begin{code}
+</a><a id="61" class="Markup">\begin{code}</a>
 <a id="74" class="Keyword">data</a> <a id="Nat"></a><a id="79" href="PatternSynonyms.html#79" class="Datatype">Nat</a> <a id="83" class="Symbol">:</a> <a id="85" class="PrimitiveType">Set</a> <a id="89" class="Keyword">where</a>
   <a id="Nat.zero"></a><a id="97" href="PatternSynonyms.html#97" class="InductiveConstructor">zero</a> <a id="102" class="Symbol">:</a> <a id="104" href="PatternSynonyms.html#79" class="Datatype">Nat</a>
   <a id="Nat.suc"></a><a id="110" href="PatternSynonyms.html#110" class="InductiveConstructor">suc</a> <a id="114" class="Symbol">:</a> <a id="116" href="PatternSynonyms.html#79" class="Datatype">Nat</a> <a id="120" class="Symbol">→</a> <a id="122" href="PatternSynonyms.html#79" class="Datatype">Nat</a>
@@ -12,7 +12,7 @@
 <a id="158" class="Keyword">pattern</a> <a id="three"></a><a id="166" href="PatternSynonyms.html#166" class="InductiveConstructor">three</a> <a id="172" class="Symbol">=</a> <a id="174" href="PatternSynonyms.html#110" class="InductiveConstructor">suc</a> <a id="178" href="PatternSynonyms.html#135" class="InductiveConstructor">two</a>
 
 <a id="183" class="Keyword">data</a> <a id="Bot"></a><a id="188" href="PatternSynonyms.html#188" class="Datatype">Bot</a> <a id="192" class="Symbol">:</a> <a id="194" class="PrimitiveType">Set</a> <a id="198" class="Keyword">where</a>
-\end{code}<a id="214" class="Comment">
+<a id="204" class="Markup">\end{code}</a><a id="214" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/PatternSynonyms2.html
+++ b/test/LaTeXAndHTML/succeed/PatternSynonyms2.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>PatternSynonyms2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>PatternSynonyms2</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 \begin{document}
 
-</a>\begin{code}
+</a><a id="61" class="Markup">\begin{code}</a>
 <a id="74" class="Keyword">data</a> <a id="Nat"></a><a id="79" href="PatternSynonyms2.html#79" class="Datatype">Nat</a> <a id="83" class="Symbol">:</a> <a id="85" class="PrimitiveType">Set</a> <a id="89" class="Keyword">where</a>
   <a id="Nat.zero"></a><a id="97" href="PatternSynonyms2.html#97" class="InductiveConstructor">zero</a> <a id="102" class="Symbol">:</a> <a id="104" href="PatternSynonyms2.html#79" class="Datatype">Nat</a>
   <a id="Nat.suc"></a><a id="110" href="PatternSynonyms2.html#110" class="InductiveConstructor">suc</a> <a id="114" class="Symbol">:</a> <a id="116" href="PatternSynonyms2.html#79" class="Datatype">Nat</a> <a id="120" class="Symbol">→</a> <a id="122" href="PatternSynonyms2.html#79" class="Datatype">Nat</a>
@@ -14,7 +14,7 @@
   <a id="178" class="Keyword">pattern</a> <a id="186" href="PatternSynonyms2.html#186" class="InductiveConstructor">three</a> <a id="192" class="Symbol">=</a> <a id="194" href="PatternSynonyms2.html#110" class="InductiveConstructor">suc</a> <a id="198" href="PatternSynonyms2.html#153" class="InductiveConstructor">two</a>
 
 <a id="203" class="Keyword">data</a> <a id="Bot"></a><a id="208" href="PatternSynonyms2.html#208" class="Datatype">Bot</a> <a id="212" class="Symbol">:</a> <a id="214" class="PrimitiveType">Set</a> <a id="218" class="Keyword">where</a>
-\end{code}<a id="234" class="Comment">
+<a id="224" class="Markup">\end{code}</a><a id="234" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/PatternSynonyms3.html
+++ b/test/LaTeXAndHTML/succeed/PatternSynonyms3.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>PatternSynonyms3</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>PatternSynonyms3</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 \begin{document}
 
-</a>\begin{code}
+</a><a id="61" class="Markup">\begin{code}</a>
 <a id="74" class="Keyword">data</a> <a id="Nat"></a><a id="79" href="PatternSynonyms3.html#79" class="Datatype">Nat</a> <a id="83" class="Symbol">:</a> <a id="85" class="PrimitiveType">Set</a> <a id="89" class="Keyword">where</a>
   <a id="Nat.zero"></a><a id="97" href="PatternSynonyms3.html#97" class="InductiveConstructor">zero</a> <a id="102" class="Symbol">:</a> <a id="104" href="PatternSynonyms3.html#79" class="Datatype">Nat</a>
   <a id="Nat.suc"></a><a id="110" href="PatternSynonyms3.html#110" class="InductiveConstructor">suc</a> <a id="114" class="Symbol">:</a> <a id="116" href="PatternSynonyms3.html#79" class="Datatype">Nat</a> <a id="120" class="Symbol">→</a> <a id="122" href="PatternSynonyms3.html#79" class="Datatype">Nat</a>
@@ -15,7 +15,7 @@
 <a id="209" class="Keyword">pattern</a> <a id="five"></a><a id="217" href="PatternSynonyms3.html#217" class="InductiveConstructor">five</a>  <a id="223" class="Symbol">=</a> <a id="225" href="PatternSynonyms3.html#110" class="InductiveConstructor">suc</a> <a id="229" href="PatternSynonyms3.html#190" class="InductiveConstructor">four</a>
 
 <a id="235" class="Keyword">data</a> <a id="Bot"></a><a id="240" href="PatternSynonyms3.html#240" class="Datatype">Bot</a> <a id="244" class="Symbol">:</a> <a id="246" class="PrimitiveType">Set</a> <a id="250" class="Keyword">where</a>
-\end{code}<a id="266" class="Comment">
+<a id="256" class="Markup">\end{code}</a><a id="266" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/QuickLaTeX.html
+++ b/test/LaTeXAndHTML/succeed/QuickLaTeX.html
@@ -1,11 +1,11 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>QuickLaTeX</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>QuickLaTeX</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Symbol">{-#</a> <a id="80" class="Keyword">BUILTIN</a> SIZE <a id="Size"></a><a id="93" href="QuickLaTeX.html#93" class="Postulate">Size</a> <a id="98" class="Symbol">#-}</a>
 
 <a id="103" class="Keyword">record</a> <a id="Sigma"></a><a id="110" href="QuickLaTeX.html#110" class="Record">Sigma</a> <a id="116" class="Symbol">(</a><a id="117" href="QuickLaTeX.html#117" class="Bound">A</a> <a id="119" class="Symbol">:</a> <a id="121" class="PrimitiveType">Set</a><a id="124" class="Symbol">)</a> <a id="126" class="Symbol">(</a><a id="127" href="QuickLaTeX.html#127" class="Bound">B</a> <a id="129" class="Symbol">:</a> <a id="131" href="QuickLaTeX.html#117" class="Bound">A</a> <a id="133" class="Symbol">→</a> <a id="135" class="PrimitiveType">Set</a><a id="138" class="Symbol">)</a> <a id="140" class="Symbol">:</a> <a id="142" class="PrimitiveType">Set</a> <a id="146" class="Keyword">where</a>
@@ -20,7 +20,7 @@
 
 <a id="f"></a><a id="253" href="QuickLaTeX.html#253" class="Function">f</a> <a id="255" class="Symbol">:</a> <a id="257" class="Symbol">{</a><a id="258" href="QuickLaTeX.html#258" class="Bound">A</a> <a id="260" class="Symbol">:</a> <a id="262" class="PrimitiveType">Set</a><a id="265" class="Symbol">}</a> <a id="267" class="Symbol">{</a><a id="268" href="QuickLaTeX.html#268" class="Bound">B</a> <a id="270" class="Symbol">:</a> <a id="272" href="QuickLaTeX.html#258" class="Bound">A</a> <a id="274" class="Symbol">→</a> <a id="276" class="PrimitiveType">Set</a><a id="279" class="Symbol">}</a> <a id="281" class="Symbol">(</a><a id="282" href="QuickLaTeX.html#282" class="Bound">x</a> <a id="284" class="Symbol">:</a> <a id="286" href="QuickLaTeX.html#258" class="Bound">A</a><a id="287" class="Symbol">)</a> <a id="289" class="Symbol">→</a> <a id="291" href="QuickLaTeX.html#268" class="Bound">B</a> <a id="293" href="QuickLaTeX.html#282" class="Bound">x</a> <a id="295" class="Symbol">→</a> <a id="297" href="QuickLaTeX.html#110" class="Record">Sigma</a> <a id="303" href="QuickLaTeX.html#258" class="Bound">A</a> <a id="305" href="QuickLaTeX.html#268" class="Bound">B</a>
 <a id="307" href="QuickLaTeX.html#253" class="Function">f</a> <a id="309" class="Symbol">=</a> <a id="311" href="QuickLaTeX.html#180" class="CoinductiveConstructor">c</a>
-\end{code}<a id="323" class="Comment">
+<a id="313" class="Markup">\end{code}</a><a id="323" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Relative-indentation.html
+++ b/test/LaTeXAndHTML/succeed/Relative-indentation.html
@@ -1,113 +1,113 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Relative-indentation</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Relative-indentation</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 <a id="76" class="Keyword">postulate</a>
   <a id="A"></a><a id="88" href="Relative-indentation.html#88" class="Postulate">A</a>  <a id="B"></a><a id="91" href="Relative-indentation.html#91" class="Postulate">B</a>
       <a id="C"></a><a id="99" href="Relative-indentation.html#99" class="Postulate">C</a> <a id="101" class="Symbol">:</a> <a id="103" class="PrimitiveType">Set</a>
-\end{code}<a id="117" class="Comment">
+<a id="107" class="Markup">\end{code}</a><a id="117" class="Background">
 
-</a>\begin{code}
+</a><a id="119" class="Markup">\begin{code}</a>
 <a id="132" class="Keyword">postulate</a>
   <a id="D"></a><a id="144" href="Relative-indentation.html#144" class="Postulate">D</a>  <a id="E"></a><a id="147" href="Relative-indentation.html#147" class="Postulate">E</a>
 
       <a id="F"></a><a id="156" href="Relative-indentation.html#156" class="Postulate">F</a> <a id="158" class="Symbol">:</a> <a id="160" class="PrimitiveType">Set</a>
-\end{code}<a id="174" class="Comment">
+<a id="164" class="Markup">\end{code}</a><a id="174" class="Background">
 
-</a>\begin{code}
+</a><a id="176" class="Markup">\begin{code}</a>
 <a id="189" class="Keyword">postulate</a>
   <a id="G"></a><a id="201" href="Relative-indentation.html#201" class="Postulate">G</a>  <a id="H"></a><a id="204" href="Relative-indentation.html#204" class="Postulate">H</a>  <a id="207" class="Symbol">:</a> <a id="209" class="PrimitiveType">Set</a>
   <a id="I"></a><a id="215" href="Relative-indentation.html#215" class="Postulate">I</a>
       <a id="J"></a><a id="223" href="Relative-indentation.html#223" class="Postulate">J</a> <a id="225" class="Symbol">:</a> <a id="227" class="PrimitiveType">Set</a>
-\end{code}<a id="241" class="Comment">
+<a id="231" class="Markup">\end{code}</a><a id="241" class="Background">
 
 \begin{AgdaMultiCode}
-</a>\begin{code}
+</a><a id="265" class="Markup">\begin{code}</a>
 <a id="278" class="Keyword">postulate</a>
   <a id="K"></a><a id="290" href="Relative-indentation.html#290" class="Postulate">K</a>  <a id="L"></a><a id="293" href="Relative-indentation.html#293" class="Postulate">L</a>
-\end{code}<a id="305" class="Comment">
-</a>\begin{code}
+<a id="295" class="Markup">\end{code}</a><a id="305" class="Background">
+</a><a id="306" class="Markup">\begin{code}</a>
       <a id="M"></a><a id="325" href="Relative-indentation.html#325" class="Postulate">M</a> <a id="327" class="Symbol">:</a> <a id="329" class="PrimitiveType">Set</a>
-\end{code}<a id="343" class="Comment">
+<a id="333" class="Markup">\end{code}</a><a id="343" class="Background">
 \end{AgdaMultiCode}
 
-</a>\begin{code}
+</a><a id="365" class="Markup">\begin{code}</a>
 <a id="378" class="Keyword">record</a> <a id="R"></a><a id="385" href="Relative-indentation.html#385" class="Record">R</a> <a id="387" class="Symbol">:</a> <a id="389" class="PrimitiveType">Set₁</a> <a id="394" class="Keyword">where</a>
   <a id="402" class="Keyword">field</a> <a id="R.N"></a><a id="408" href="Relative-indentation.html#408" class="Field">N</a> <a id="410" class="Symbol">:</a>
             <a id="424" class="PrimitiveType">Set</a>
-\end{code}<a id="438" class="Comment">
+<a id="428" class="Markup">\end{code}</a><a id="438" class="Background">
 
 % There is (and should be) trailing whitespace at the end of some
 % lines below.
 
 \begin{AgdaAlign}
-text </a>\begin{code}        
+text </a><a id="545" class="Markup">\begin{code}        </a>
 <a id="566" class="Keyword">module</a> <a id="573" href="Relative-indentation.html#573" class="Module">_</a> <a id="575" class="Keyword">where</a>
-\end{code}<a id="591" class="Comment"> more text
-    also text  </a>\begin{code}
+<a id="581" class="Markup">\end{code}</a><a id="591" class="Background"> more text
+    also text  </a><a id="617" class="Markup">\begin{code}</a>
     <a id="634" class="Keyword">postulate</a> <a id="644" href="Relative-indentation.html#644" class="Postulate">O</a> <a id="646" class="Symbol">:</a> <a id="648" class="PrimitiveType">Set</a>  
-  \end{code}<a id="666" class="Comment"> text again
+  <a id="656" class="Markup">\end{code}</a><a id="666" class="Background"> text again
 
- text          </a>\begin{code}            
+ text          </a><a id="694" class="Markup">\begin{code}            </a>
     <a id="723" class="Keyword">postulate</a> <a id="733" href="Relative-indentation.html#733" class="Postulate">o</a> <a id="735" class="Symbol">:</a> <a id="737" href="Relative-indentation.html#644" class="Postulate">O</a>    
-  \end{code}<a id="755" class="Comment">   text             
+  <a id="745" class="Markup">\end{code}</a><a id="755" class="Background">   text             
 \end{AgdaAlign}
 
-</a>\begin{code}
+</a><a id="793" class="Markup">\begin{code}</a>
 <a id="806" class="Keyword">postulate</a>
  <a id="P"></a><a id="817" href="Relative-indentation.html#817" class="Postulate">P</a> <a id="819" class="Symbol">:</a> <a id="821" class="PrimitiveType">Set</a>
-\end{code}<a id="835" class="Comment">
+<a id="825" class="Markup">\end{code}</a><a id="835" class="Background">
 
-</a>\begin{code}
+</a><a id="837" class="Markup">\begin{code}</a>
 <a id="850" class="Keyword">module</a> <a id="857" href="Relative-indentation.html#857" class="Module">_</a> <a id="859" class="Keyword">where</a>
  <a id="866" class="Keyword">postulate</a>
   <a id="878" href="Relative-indentation.html#878" class="Postulate">Q</a> <a id="880" class="Symbol">:</a> <a id="882" class="PrimitiveType">Set</a>
-\end{code}<a id="896" class="Comment">
+<a id="886" class="Markup">\end{code}</a><a id="896" class="Background">
 
-</a>\begin{code}
+</a><a id="898" class="Markup">\begin{code}</a>
 <a id="911" class="Keyword">module</a> <a id="918" href="Relative-indentation.html#918" class="Module">_</a> <a id="920" class="Keyword">where</a>
          <a id="935" class="Keyword">postulate</a>
           <a id="955" href="Relative-indentation.html#955" class="Postulate">S</a> <a id="957" class="Symbol">:</a> <a id="959" class="PrimitiveType">Set</a>
-\end{code}<a id="973" class="Comment">
+<a id="963" class="Markup">\end{code}</a><a id="973" class="Background">
 
 \begin{AgdaMultiCode}
-</a>\begin{code}
+</a><a id="997" class="Markup">\begin{code}</a>
 <a id="1010" class="Keyword">module</a> <a id="1017" href="Relative-indentation.html#1017" class="Module">_</a> <a id="1019" class="Keyword">where</a>
-\end{code}<a id="1035" class="Comment">
-</a>\begin{code}
+<a id="1025" class="Markup">\end{code}</a><a id="1035" class="Background">
+</a><a id="1036" class="Markup">\begin{code}</a>
   <a id="1051" class="Keyword">postulate</a> <a id="1061" href="Relative-indentation.html#1061" class="Postulate">T</a> <a id="1063" class="Symbol">:</a> <a id="1065" class="PrimitiveType">Set</a>
             <a id="1081" href="Relative-indentation.html#1081" class="Postulate">U</a> <a id="1083" class="Symbol">:</a> <a id="1085" class="PrimitiveType">Set</a>
-\end{code}<a id="1099" class="Comment">
+<a id="1089" class="Markup">\end{code}</a><a id="1099" class="Background">
 \end{AgdaMultiCode}
 
 \begin{AgdaSuppressSpace}
-</a>\begin{code}
+</a><a id="1147" class="Markup">\begin{code}</a>
 <a id="1160" class="Keyword">module</a> <a id="1167" href="Relative-indentation.html#1167" class="Module">_</a> <a id="1169" class="Keyword">where</a>
-\end{code}<a id="1185" class="Comment">
-</a>\begin{code}
+<a id="1175" class="Markup">\end{code}</a><a id="1185" class="Background">
+</a><a id="1186" class="Markup">\begin{code}</a>
   <a id="1201" class="Keyword">postulate</a> <a id="1211" href="Relative-indentation.html#1211" class="Postulate">V</a> <a id="1213" class="Symbol">:</a> <a id="1215" class="PrimitiveType">Set</a>
             <a id="1231" href="Relative-indentation.html#1231" class="Postulate">W</a> <a id="1233" class="Symbol">:</a> <a id="1235" class="PrimitiveType">Set</a>
-\end{code}<a id="1249" class="Comment">
+<a id="1239" class="Markup">\end{code}</a><a id="1249" class="Background">
 \end{AgdaSuppressSpace}
 
-</a>\begin{code}
+</a><a id="1275" class="Markup">\begin{code}</a>
 <a id="X"></a><a id="1288" href="Relative-indentation.html#1288" class="Function">X</a> <a id="1290" class="Symbol">:</a> <a id="1292" class="PrimitiveType">Set₁</a>
 <a id="1297" href="Relative-indentation.html#1288" class="Function">X</a> <a id="1299" class="Symbol">=</a>
   <a id="1303" class="PrimitiveType">Set</a>
-\end{code}<a id="1317" class="Comment">
+<a id="1307" class="Markup">\end{code}</a><a id="1317" class="Background">
 
-</a>\begin{code}
+</a><a id="1319" class="Markup">\begin{code}</a>
 <a id="Y"></a><a id="1332" href="Relative-indentation.html#1332" class="Function">Y</a> <a id="1334" class="Symbol">:</a> <a id="1336" class="PrimitiveType">Set₁</a>
 <a id="1341" href="Relative-indentation.html#1332" class="Function">Y</a> <a id="1343" class="Symbol">=</a>       <a id="1351" class="PrimitiveType">Set</a>
 
 <a id="Zzzzzzzzz"></a><a id="1356" href="Relative-indentation.html#1356" class="Function">Zzzzzzzzz</a> <a id="1366" class="Symbol">:</a> <a id="1368" class="PrimitiveType">Set</a> <a id="1372" class="Symbol">→</a> <a id="1374" class="PrimitiveType">Set</a>
 <a id="1378" href="Relative-indentation.html#1356" class="Function">Zzzzzzzzz</a> <a id="1388" href="Relative-indentation.html#1388" class="Bound">X</a>
           <a id="1400" class="Symbol">=</a> <a id="1402" href="Relative-indentation.html#1388" class="Bound">X</a>
-\end{code}<a id="1414" class="Comment">
+<a id="1404" class="Markup">\end{code}</a><a id="1414" class="Background">
 
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/RsTQuotedDelim.html
+++ b/test/LaTeXAndHTML/succeed/RsTQuotedDelim.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>RsTQuotedDelim</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">av
-</a>::
-  <a id="9" class="Keyword">module</a> <a id="16" href="RsTQuotedDelim.html" class="Module">RsTQuotedDelim</a> <a id="31" class="Keyword">where</a>
+<html><head><meta charset="utf-8"><title>RsTQuotedDelim</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">av
+</a><a id="4" class="Markup">::
+</a>  <a id="9" class="Keyword">module</a> <a id="16" href="RsTQuotedDelim.html" class="Module">RsTQuotedDelim</a> <a id="31" class="Keyword">where</a>
 
        <a id="45" class="Keyword">data</a> <a id="Bool"></a><a id="50" href="RsTQuotedDelim.html#50" class="Datatype">Bool</a> <a id="55" class="Symbol">:</a> <a id="57" class="PrimitiveType">Set</a> <a id="61" class="Keyword">where</a>
         <a id="Bool.true"></a><a id="75" href="RsTQuotedDelim.html#75" class="InductiveConstructor">true</a> <a id="80" class="Symbol">:</a> <a id="82" href="RsTQuotedDelim.html#50" class="Datatype">Bool</a>
@@ -9,7 +9,7 @@
         <a id="Bool.dunno"></a><a id="116" href="RsTQuotedDelim.html#116" class="InductiveConstructor">dunno</a> <a id="122" class="Symbol">:</a> <a id="124" href="RsTQuotedDelim.html#50" class="Datatype">Bool</a>
         <a id="Bool.aa"></a><a id="137" href="RsTQuotedDelim.html#137" class="InductiveConstructor">aa</a> <a id="140" class="Symbol">:</a> <a id="142" class="Comment">{- :: -}</a> <a id="151" href="RsTQuotedDelim.html#50" class="Datatype">Bool</a>
 
-<a id="157" class="Comment">blip :: blop
+<a id="157" class="Background">blip :: blop
 
        a : Bool
        a = bb

--- a/test/LaTeXAndHTML/succeed/Tag.html
+++ b/test/LaTeXAndHTML/succeed/Tag.html
@@ -1,11 +1,11 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Tag</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Tag</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage[references]{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="75" class="Markup">\begin{code}</a>
 <a id="88" class="Keyword">module</a> <a id="95" href="Tag.html" class="Module">Tag</a> <a id="99" class="Keyword">where</a>
 
 <a id="106" class="Keyword">module</a> <a id="Apa"></a><a id="113" href="Tag.html#113" class="Module">Apa</a> <a id="117" class="Keyword">where</a>
@@ -26,7 +26,7 @@
 <a id="262" class="Keyword">postulate</a>
   <a id="α"></a><a id="274" href="Tag.html#274" class="Postulate">α</a>   <a id="278" class="Symbol">:</a> <a id="280" class="PrimitiveType">Set</a>
   <a id="_∘_"></a><a id="286" href="Tag.html#286" class="Postulate Operator">_∘_</a> <a id="290" class="Symbol">:</a> <a id="292" class="PrimitiveType">Set</a>
-\end{code}<a id="306" class="Comment">
+<a id="296" class="Markup">\end{code}</a><a id="306" class="Background">
 
 \begin{tabular}{ll}
   Name &amp; Test \\

--- a/test/LaTeXAndHTML/succeed/TeXExtension.html
+++ b/test/LaTeXAndHTML/succeed/TeXExtension.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>TeXExtension</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>TeXExtension</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 
 \begin{document}
 
 Foo
 
-</a>\begin{code}
+</a><a id="67" class="Markup">\begin{code}</a>
 
 <a id="81" class="Keyword">module</a> <a id="88" href="TeXExtension.html" class="Module">TeXExtension</a> <a id="101" class="Keyword">where</a>
 
@@ -17,7 +17,7 @@ Foo
   <a id="b"></a><a id="168" href="TeXExtension.html#168" class="Function">b</a> <a id="170" class="Symbol">:</a> <a id="172" href="TeXExtension.html#115" class="Datatype">Bool</a>
   <a id="179" href="TeXExtension.html#168" class="Function">b</a> <a id="181" class="Symbol">=</a> <a id="183" href="TeXExtension.html#152" class="InductiveConstructor">false</a>
 
-\end{code}<a id="200" class="Comment">
+<a id="190" class="Markup">\end{code}</a><a id="200" class="Background">
 
   c : Bool
   c = broccoli

--- a/test/LaTeXAndHTML/succeed/ThreeNewLines.html
+++ b/test/LaTeXAndHTML/succeed/ThreeNewLines.html
@@ -1,16 +1,16 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>ThreeNewLines</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>ThreeNewLines</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 
 \begin{document}
 
-</a>\begin{code}
+</a><a id="63" class="Markup">\begin{code}</a>
 
 
 <a id="78" class="Keyword">module</a> <a id="85" href="ThreeNewLines.html" class="Module">ThreeNewLines</a> <a id="99" class="Keyword">where</a>
 
 
-\end{code}<a id="117" class="Comment">
+<a id="107" class="Markup">\end{code}</a><a id="117" class="Background">
 \end{document}
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Trailing-whitespace.html
+++ b/test/LaTeXAndHTML/succeed/Trailing-whitespace.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>Trailing-whitespace</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>Trailing-whitespace</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 
 \usepackage{agda}
 \AgdaNoSpaceAroundCode{}
@@ -7,51 +7,51 @@
 \begin{document}
 
 \hrule
-</a>\begin{code}
+</a><a id="95" class="Markup">\begin{code}</a>
 <a id="108" class="Keyword">postulate</a>
   
   <a id="A"></a><a id="123" href="Trailing-whitespace.html#123" class="Postulate">A</a> <a id="125" class="Symbol">:</a> <a id="127" class="PrimitiveType">Set</a>  
   <a id="B"></a><a id="135" href="Trailing-whitespace.html#135" class="Postulate">B</a> <a id="137" class="Symbol">:</a> <a id="139" class="PrimitiveType">Set</a>  
-\end{code}<a id="155" class="Comment">
+<a id="145" class="Markup">\end{code}</a><a id="155" class="Background">
 \hrule
-</a>\begin{code}
+</a><a id="163" class="Markup">\begin{code}</a>
   
-\end{code}<a id="189" class="Comment">
+<a id="179" class="Markup">\end{code}</a><a id="189" class="Background">
 \hrule
-</a>\begin{code}
+</a><a id="197" class="Markup">\begin{code}</a>
 
-\end{code}<a id="221" class="Comment">
+<a id="211" class="Markup">\end{code}</a><a id="221" class="Background">
 \hrule
-</a>\begin{code}
-\end{code}<a id="252" class="Comment">
+</a><a id="229" class="Markup">\begin{code}</a>
+<a id="242" class="Markup">\end{code}</a><a id="252" class="Background">
 \hrule
-</a>\begin{code}  
-  \end{code}<a id="287" class="Comment">
+</a><a id="260" class="Markup">\begin{code}  </a>
+  <a id="277" class="Markup">\end{code}</a><a id="287" class="Background">
 \hrule
-  </a>\begin{code}  
-\end{code}<a id="322" class="Comment">
+  </a><a id="297" class="Markup">\begin{code}  </a>
+<a id="312" class="Markup">\end{code}</a><a id="322" class="Background">
 \hrule
-  </a>\begin{code}  
-    \end{code}<a id="361" class="Comment">
+  </a><a id="332" class="Markup">\begin{code}  </a>
+    <a id="351" class="Markup">\end{code}</a><a id="361" class="Background">
 \hrule
-</a>\begin{code}
+</a><a id="369" class="Markup">\begin{code}</a>
 <a id="382" class="Keyword">module</a> <a id="389" href="Trailing-whitespace.html#389" class="Module">_</a> <a id="391" class="Keyword">where</a>
-\end{code}<a id="407" class="Comment">
-</a>\begin{code}
+<a id="397" class="Markup">\end{code}</a><a id="407" class="Background">
+</a><a id="408" class="Markup">\begin{code}</a>
   
   <a id="426" class="Keyword">postulate</a>
     <a id="440" href="Trailing-whitespace.html#440" class="Postulate">C</a> <a id="442" class="Symbol">:</a> <a id="444" class="PrimitiveType">Set</a>
-\end{code}<a id="458" class="Comment">
+<a id="448" class="Markup">\end{code}</a><a id="458" class="Background">
 \hrule
 \begin{AgdaAlign}
-</a>\begin{code}
+</a><a id="484" class="Markup">\begin{code}</a>
 <a id="497" class="Keyword">postulate</a>
   <a id="F"></a><a id="509" href="Trailing-whitespace.html#509" class="Postulate">F</a>  <a id="512" class="Symbol">:</a> <a id="514" class="PrimitiveType">Set</a> <a id="518" class="Symbol">→</a> <a id="520" class="PrimitiveType">Set</a>
   <a id="X"></a><a id="526" href="Trailing-whitespace.html#526" class="Postulate">X</a>  <a id="529" class="Symbol">:</a> <a id="531" href="Trailing-whitespace.html#509" class="Postulate">F</a>  
-\end{code}<a id="545" class="Comment">
-</a>\begin{code}
+<a id="535" class="Markup">\end{code}</a><a id="545" class="Background">
+</a><a id="546" class="Markup">\begin{code}</a>
           <a id="569" href="Trailing-whitespace.html#123" class="Postulate">A</a>
-\end{code}<a id="581" class="Comment">
+<a id="571" class="Markup">\end{code}</a><a id="581" class="Background">
 \end{AgdaAlign}
 \hrule
 

--- a/test/LaTeXAndHTML/succeed/TrailingColon.html
+++ b/test/LaTeXAndHTML/succeed/TrailingColon.html
@@ -1,11 +1,11 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>TrailingColon</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">Queso!
+<html><head><meta charset="utf-8"><title>TrailingColon</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">Queso!
 
 aaa
 
 ..
-</a>  ::
-    <a id="26" class="Keyword">module</a> <a id="33" href="TrailingColon.html" class="Module">TrailingColon</a> <a id="47" class="Keyword">where</a>
+</a><a id="17" class="Markup">  ::
+</a>    <a id="26" class="Keyword">module</a> <a id="33" href="TrailingColon.html" class="Module">TrailingColon</a> <a id="47" class="Keyword">where</a>
 
         <a id="62" class="Keyword">data</a> <a id="Bool"></a><a id="67" href="TrailingColon.html#67" class="Datatype">Bool</a> <a id="72" class="Symbol">:</a> <a id="74" class="PrimitiveType">Set</a> <a id="78" class="Keyword">where</a>
             <a id="Bool.true"></a><a id="96" href="TrailingColon.html#96" class="InductiveConstructor">true</a> <a id="101" class="Symbol">:</a> <a id="103" href="TrailingColon.html#67" class="Datatype">Bool</a>
@@ -15,19 +15,19 @@ aaa
         <a id="a"></a><a id="164" href="TrailingColon.html#164" class="Function">a</a> <a id="166" class="Symbol">:</a> <a id="168" href="TrailingColon.html#67" class="Datatype">Bool</a>
         <a id="181" href="TrailingColon.html#164" class="Function">a</a> <a id="183" class="Symbol">=</a> <a id="185" href="TrailingColon.html#96" class="InductiveConstructor">true</a>
 
-<a id="191" class="Comment">Tomate
+<a id="191" class="Background">Tomate
 bleh
 bli
 
-</a>::
-        <a id="b"></a><a id="219" href="TrailingColon.html#219" class="Function">b</a> <a id="221" class="Symbol">:</a> <a id="223" href="TrailingColon.html#67" class="Datatype">Bool</a>
+</a><a id="208" class="Markup">::
+</a>        <a id="b"></a><a id="219" href="TrailingColon.html#219" class="Function">b</a> <a id="221" class="Symbol">:</a> <a id="223" href="TrailingColon.html#67" class="Datatype">Bool</a>
         <a id="236" href="TrailingColon.html#219" class="Function">b</a> <a id="238" class="Symbol">=</a> <a id="240" href="TrailingColon.html#120" class="InductiveConstructor">false</a>
 
 
-<a id="248" class="Comment">for example:</a>:
+<a id="248" class="Background">for example:</a><a id="260" class="Markup">:
 
-        <a id="c"></a><a id="271" href="TrailingColon.html#271" class="Function">c</a> <a id="273" class="Symbol">:</a> <a id="275" href="TrailingColon.html#67" class="Datatype">Bool</a>
+</a>        <a id="c"></a><a id="271" href="TrailingColon.html#271" class="Function">c</a> <a id="273" class="Symbol">:</a> <a id="275" href="TrailingColon.html#67" class="Datatype">Bool</a>
         <a id="288" href="TrailingColon.html#271" class="Function">c</a> <a id="290" class="Symbol">=</a> <a id="292" href="TrailingColon.html#145" class="InductiveConstructor">aa</a>
 
-<a id="296" class="Comment">and that&#39;s all, folks
+<a id="296" class="Background">and that&#39;s all, folks
 </a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/UnicodeInput.html
+++ b/test/LaTeXAndHTML/succeed/UnicodeInput.html
@@ -1,14 +1,14 @@
 <!DOCTYPE HTML>
-<html><head><meta charset="utf-8"><title>UnicodeInput</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Comment">\documentclass{article}
+<html><head><meta charset="utf-8"><title>UnicodeInput</title><link rel="stylesheet" href="Agda.css"></head><body><pre><a id="1" class="Background">\documentclass{article}
 \usepackage{agda}
 \begin{document}
 
-</a>\begin{code}
+</a><a id="61" class="Markup">\begin{code}</a>
 <a id="74" class="Keyword">data</a> <a id="αβγδεζθικλμνξρστυφχψω"></a><a id="79" href="UnicodeInput.html#79" class="Datatype">αβγδεζθικλμνξρστυφχψω</a> <a id="101" class="Symbol">:</a> <a id="103" class="PrimitiveType">Set₁</a> <a id="108" class="Keyword">where</a>
 
 <a id="115" class="Keyword">postulate</a>
   <a id="→⇒⇛⇉⇄↦⇨↠⇀⇁"></a><a id="127" href="UnicodeInput.html#127" class="Postulate">→⇒⇛⇉⇄↦⇨↠⇀⇁</a> <a id="138" class="Symbol">:</a> <a id="140" class="PrimitiveType">Set</a>
-\end{code}<a id="154" class="Comment">
+<a id="144" class="Markup">\end{code}</a><a id="154" class="Background">
 
 \[
 ∀X [ ∅ ∉ X ⇒ ∃f:X ⟶  ⋃ X\ ∀A ∈ X (f(A) ∈ A) ]

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -26,9 +26,9 @@ clean=/usr/bin/env bash $(shell pwd)/clean.sh $(sed)
 
 # Construct the list of tests to carry out.
 # Andreas, 2017-04-24 ls -t: sort by newest first
-AgdaFiles=$(shell ls -t *agda)
-OutFiles=$(patsubst %.lagda,%.out,$(patsubst %.agda,%.out,$(AgdaFiles)))
-Tests=$(patsubst %.lagda,%.cmp,$(patsubst %.agda,%.cmp,$(AgdaFiles)))
+AgdaFiles=$(shell ls -t *agda *lagda.md)
+OutFiles=$(patsubst %.lagda,%.out,$(patsubst %.agda,%.out,$(patsubst %.lagda.md,%,$(AgdaFiles))))
+Tests=$(patsubst %.lagda,%.cmp,$(patsubst %.agda,%.cmp,$(patsubst %.lagda.md,%,$(AgdaFiles))))
 
 default : $(Tests)
 
@@ -57,7 +57,7 @@ run_test=if test -f $*.in; \
          | $(sed) "s/top_command/IOTCM currentFile None Indirect/g" \
          | $(sed) "s/goal_command \\([0-9]\+\\) (\\([^)]\+\\)) \\(\"[^\"]*\"\\)/IOTCM currentFile None Indirect (\\2 \\1 noRange \\3)/g" \
          | $(sed) "s/goal_command \\([0-9]\+\\) \\([^ ]\+\\) \\(\"[^\"]*\"\\)/IOTCM currentFile None Indirect (\\2 \\1 noRange \\3)/g" \
-         | $(sed) "s/currentFile/\"$(wildcard $*.agda $*.lagda)\"/g" \
+         | $(sed) "s/currentFile/\"$(wildcard $*.agda $*.lagda $*.lagda.md)\"/g" \
          | $(AGDA_BIN) -v0 -i . -i .. --interaction --ignore-interfaces --no-default-libraries $(RTS_$*) \
            2>&1 | $(filter) ; \
     elif test -f $*.hs; \

--- a/test/interaction/Token-highlighting-literate.out
+++ b/test/interaction/Token-highlighting-literate.out
@@ -1,1 +1,1 @@
-(agda2-highlight-add-annotations 'remove '(1 27 (comment) t) '(27 28 (comment) t) '(28 39 (comment) t) '(39 40 (comment) t) '(53 62 (keyword) t) '(65 66 (symbol) t) '(67 70 (primitivetype) t) '(81 82 (comment) t))
+(agda2-highlight-add-annotations 'remove '(1 27 (background) t) '(27 28 (background) t) '(28 39 (background) t) '(39 40 (background) t) '(40 52 (markup) t) '(53 62 (keyword) t) '(65 66 (symbol) t) '(67 70 (primitivetype) t) '(71 81 (markup) t) '(81 82 (background) t))


### PR DESCRIPTION
Signed-off-by: ice1000 <ice1000kotlin@foxmail.com>

This can close #3137 which is originally my little suggestion.

I know I didn't add tests, examples, etc. That's because I'm not very sure about how to add tests.
A list of what I've done here:

+ Added the command line option, default value, help message for it
+ Tested with a simple `.agda` file with some comments, no `<a>` generated for them
+ Haddockumented the new parameters

Suggestions with instructions or examples are welcomed!