### PR TITLE
[ fix #3338 ] defer axiom generation for lone signatures

### DIFF
--- a/test/Fail/Issue3338.agda
+++ b/test/Fail/Issue3338.agda
@@ -1,0 +1,11 @@
+postulate
+  R : Set → Set1
+  r : {X : Set} {{ _ : R X }} → X → Set
+  A : Set
+  a : A
+
+instance
+  RI : R A
+  -- RI = {!!} -- uncommenting lets instance resolution succeed
+
+foo : r a

--- a/test/Fail/Issue3338.err
+++ b/test/Fail/Issue3338.err
@@ -1,0 +1,3 @@
+Issue3338.agda:8,3-5
+The following names are declared but not accompanied by a
+definition: RI, foo


### PR DESCRIPTION
If a lone signature is in an instance block, it will first be made
`nice` and *then* modified to be marked as an instance argument.
If we pre-generate axioms at the point of nicification of signatures
then we miss out on that extra info.

Solution: revert back to storing the minimum amount of information
in `DataRecOrFun` and use the `NiceDeclaration` the lone signature
has been turned into as a template for our `Axiom`.