### PR TITLE
Js backend small improvements

### DIFF
--- a/doc/user-manual/tools/compilers.lagda.rst
+++ b/doc/user-manual/tools/compilers.lagda.rst
@@ -90,7 +90,13 @@ The backend can be invoked from the command line using the flag
 
 .. code-block:: bash
 
-  agda --js [--compile-dir=<DIR>] <FILE>.agda
+  agda --js [--js-optimize] [--js-minify] [--compile-dir=<DIR>] <FILE>.agda
+
+The ``--js-optimize`` flag makes the generated JavaScript code
+typically faster and less readable.
+
+The ``--js-minify`` flag makes the generated JavaScript code
+smaller and less readable.
 
 
 Optimizations

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -1,7 +1,6 @@
 module Agda.Compiler.JS.Compiler where
 
 import Prelude hiding ( null, writeFile )
-
 import Control.Monad.Trans
 
 import Data.Char ( isSpace )
@@ -32,10 +31,12 @@ import qualified Agda.Syntax.Treeless as T
 
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Reduce ( instantiateFull )
+import Agda.TypeChecking.Substitute as TC ( TelV(..), raise, subst )
 import Agda.TypeChecking.Pretty
-
+import Agda.Utils.Function ( iterate' )
+import Agda.Utils.List ( headWithDefault )
 import Agda.Utils.Maybe
-import Agda.Utils.Monad ( ifM )
+import Agda.Utils.Monad ( ifM, when )
 import Agda.Utils.Pretty (prettyShow)
 import qualified Agda.Utils.Pretty as P
 import Agda.Utils.IO.Directory
@@ -46,11 +47,13 @@ import Agda.Compiler.ToTreeless
 import Agda.Compiler.Treeless.EliminateDefaults
 import Agda.Compiler.Treeless.EliminateLiteralPatterns
 import Agda.Compiler.Treeless.GuardsToPrims
+import Agda.Compiler.Treeless.Erase ( computeErasedConstructorArgs )
+import Agda.Compiler.Treeless.Subst ()
 import Agda.Compiler.Backend (Backend(..), Backend'(..), Recompile(..))
 
 import Agda.Compiler.JS.Syntax
-  ( Exp(Self,Local,Global,Undefined,String,Char,Integer,Double,Lambda,Object,Apply,Lookup,If,BinOp,PlainJS),
-    LocalId(LocalId), GlobalId(GlobalId), MemberId(MemberId), Export(Export), Module(Module),
+  ( Exp(Self,Local,Global,Undefined,Null,String,Char,Integer,Double,Lambda,Object,Array,Apply,Lookup,If,BinOp,PlainJS),
+    LocalId(LocalId), GlobalId(GlobalId), MemberId(MemberId,MemberIndex), Export(Export), Module(Module), Comment(Comment),
     modName, expName, uses )
 import Agda.Compiler.JS.Substitution
   ( curriedLambda, curriedApply, emp, apply )
@@ -65,7 +68,7 @@ import Agda.Utils.Impossible (__IMPOSSIBLE__)
 jsBackend :: Backend
 jsBackend = Backend jsBackend'
 
-jsBackend' :: Backend' JSOptions JSOptions JSModuleEnv () (Maybe Export)
+jsBackend' :: Backend' JSOptions JSOptions JSModuleEnv Module (Maybe Export)
 jsBackend' = Backend'
   { backendName           = jsBackendName
   , backendVersion        = Nothing
@@ -89,39 +92,57 @@ jsBackend' = Backend'
 --- Options ---
 
 data JSOptions = JSOptions
-  { optJSCompile :: Bool }
+  { optJSCompile :: Bool
+  , optJSOptimize :: Bool
+  , optJSMinify :: Bool
+  }
 
 defaultJSOptions :: JSOptions
 defaultJSOptions = JSOptions
-  { optJSCompile = False }
+  { optJSCompile = False
+  , optJSOptimize = False
+  , optJSMinify = False
+  }
 
 jsCommandLineFlags :: [OptDescr (Flag JSOptions)]
 jsCommandLineFlags =
     [ Option [] ["js"] (NoArg enable) "compile program using the JS backend"
+    , Option [] ["js-optimize"] (NoArg enableOpt) "turn on optimizations during JS code generation"
+    -- Minification is described at https://en.wikipedia.org/wiki/Minification_(programming)
+    , Option [] ["js-minify"] (NoArg enableMin) "minify generated JS code"
     ]
   where
     enable o = pure o{ optJSCompile = True }
+    enableOpt o = pure o{ optJSOptimize = True }
+    enableMin o = pure o{ optJSMinify = True }
 
 --- Top-level compilation ---
 
 jsPreCompile :: JSOptions -> TCM JSOptions
 jsPreCompile opts = return opts
 
-jsPostCompile :: JSOptions -> IsMain -> a -> TCM ()
-jsPostCompile _ _ _ = copyRTEModules
+jsPostCompile :: JSOptions -> IsMain -> Map.Map ModuleName Module -> TCM ()
+jsPostCompile _opts _ _ms = copyRTEModules
+
+mergeModules :: Map.Map ModuleName Module -> [(GlobalId, Export)]
+mergeModules ms
+    = [ (jsMod n, e)
+      | (n, Module _ _ es _) <- Map.toList ms
+      , e <- es
+      ]
 
 --- Module compilation ---
 
 type JSModuleEnv = Maybe CoinductionKit
 
-jsPreModule :: JSOptions -> IsMain -> ModuleName -> FilePath -> TCM (Recompile JSModuleEnv ())
-jsPreModule _ _ m ifile = ifM uptodate noComp yesComp
+jsPreModule :: JSOptions -> IsMain -> ModuleName -> FilePath -> TCM (Recompile JSModuleEnv Module)
+jsPreModule _opts _ m ifile = ifM uptodate noComp yesComp
   where
     uptodate = liftIO =<< isNewerThan <$> outFile_ <*> pure ifile
 
     noComp = do
       reportSLn "compile.js" 2 . (++ " : no compilation is needed.") . prettyShow =<< curMName
-      return $ Skip ()
+      return $ Skip __IMPOSSIBLE__
 
     yesComp = do
       m   <- prettyShow <$> curMName
@@ -129,19 +150,21 @@ jsPreModule _ _ m ifile = ifM uptodate noComp yesComp
       reportSLn "compile.js" 1 $ repl [m, ifile, out] "Compiling <<0>> in <<1>> to <<2>>"
       Recompile <$> coinductionKit
 
-jsPostModule :: JSOptions -> JSModuleEnv -> IsMain -> ModuleName -> [Maybe Export] -> TCM ()
-jsPostModule _ _ isMain _ defs = do
+jsPostModule :: JSOptions -> JSModuleEnv -> IsMain -> ModuleName -> [Maybe Export] -> TCM Module
+jsPostModule opts _ isMain _ defs = do
   m             <- jsMod <$> curMName
   is            <- map (jsMod . fst) . iImportedModules <$> curIF
   let es = catMaybes defs
-  writeModule $ Module m is (reorder es) main
+      mod = Module m is (reorder es) main
+  writeModule (optJSMinify opts) mod
+  return mod
   where
     main = case isMain of
       IsMain  -> Just $ Apply (Lookup Self $ MemberId "main") [Lambda 1 emp]
       NotMain -> Nothing
 
 jsCompileDef :: JSOptions -> JSModuleEnv -> IsMain -> Definition -> TCM (Maybe Export)
-jsCompileDef _ kit _isMain def = definition kit (defName def, def)
+jsCompileDef opts kit _isMain def = definition (opts, kit) (defName def, def)
 
 --------------------------------------------------
 -- Naming
@@ -239,6 +262,7 @@ insertAfter us e (f : fs) | otherwise =
 -- Main compiling clauses
 --------------------------------------------------
 
+{- dead code
 curModule :: IsMain -> TCM Module
 curModule isMain = do
   kit <- coinductionKit
@@ -250,8 +274,10 @@ curModule isMain = do
     main = case isMain of
       IsMain -> Just $ Apply (Lookup Self $ MemberId "main") [Lambda 1 emp]
       NotMain -> Nothing
+-}
+type EnvWithOpts = (JSOptions, JSModuleEnv)
 
-definition :: Maybe CoinductionKit -> (QName,Definition) -> TCM (Maybe Export)
+definition :: EnvWithOpts -> (QName,Definition) -> TCM (Maybe Export)
 definition kit (q,d) = do
   reportSDoc "compile.js" 10 $ "compiling def:" <+> prettyTCM q
   (_,ls) <- global q
@@ -277,14 +303,14 @@ defJSDef def =
   where
     dropEquals = dropWhile $ \ c -> isSpace c || c == '='
 
-definition' :: Maybe CoinductionKit -> QName -> Definition -> Type -> [MemberId] -> TCM (Maybe Export)
+definition' :: EnvWithOpts -> QName -> Definition -> Type -> [MemberId] -> TCM (Maybe Export)
 definition' kit q d t ls = do
   checkCompilerPragmas q
   case theDef d of
     -- coinduction
-    Constructor{} | Just q == (nameOfSharp <$> kit) -> do
+    Constructor{} | Just q == (nameOfSharp <$> snd kit) -> do
       return Nothing
-    Function{} | Just q == (nameOfFlat <$> kit) -> do
+    Function{} | Just q == (nameOfFlat <$> snd kit) -> do
       ret $ Lambda 1 $ Apply (Lookup (local 0) flatName) []
 
     DataOrRecSig{} -> __IMPOSSIBLE__
@@ -299,11 +325,26 @@ definition' kit q d t ls = do
 
       reportSDoc "compile.js" 5 $ "compiling fun:" <+> prettyTCM q
       caseMaybeM (toTreeless T.EagerEvaluation q) (pure Nothing) $ \ treeless -> do
+        used <- getCompiledArgUse q
         funBody <- eliminateCaseDefaults =<<
           eliminateLiteralPatterns
           (convertGuards treeless)
         reportSDoc "compile.js" 30 $ " compiled treeless fun:" <+> pretty funBody
-        funBody' <- compileTerm funBody
+
+        let (body, given) = lamView funBody
+              where
+                lamView :: T.TTerm -> (T.TTerm, Int)
+                lamView (T.TLam t) = (+1) <$> lamView t
+                lamView t = (t, 0)
+
+            -- number of eta expanded args
+            etaN = length $ dropWhile id $ reverse $ drop given used
+
+        funBody' <- compileTerm kit
+                  $ iterate' (given + etaN - length (filter not used)) T.TLam
+                  $ eraseLocalVars (map not used)
+                  $ T.mkTApp (raise etaN body) (T.TVar <$> [etaN-1, etaN-2 .. 0])
+
         reportSDoc "compile.js" 30 $ " compiled JS fun:" <+> (text . show) funBody'
         return $ Just $ Export ls funBody'
 
@@ -312,38 +353,44 @@ definition' kit q d t ls = do
     Primitive{} | Just e <- defJSDef d -> plainJS e
     Primitive{} | otherwise -> ret Undefined
 
-    Datatype{} -> ret emp
-    Record{} -> return Nothing
+    Datatype{} -> do
+        computeErasedConstructorArgs q
+        ret emp
+    Record{} -> do
+        computeErasedConstructorArgs q
+        return Nothing
 
     Constructor{} | Just e <- defJSDef d -> plainJS e
-    Constructor{conData = p, conPars = nc} | otherwise -> do
-      let np = (arity t - nc)
+    Constructor{conData = p, conPars = nc} -> do
+      let np = arity t - nc
+      erased <- getErasedConArgs q
+      let nargs = np - length (filter id erased)
+          args = [ Local $ LocalId $ nargs - i | i <- [0 .. nargs-1] ]
       d <- getConstInfo p
       case theDef d of
-        Record { recFields = flds } ->
-          ret (curriedLambda np (Object (fromList
-            ( (last ls , Lambda 1
-                 (Apply (Lookup (Local (LocalId 0)) (last ls))
-                   [ Local (LocalId (np - i)) | i <- [0 .. np-1] ]))
-            : (zip [ jsMember (qnameName (unDom fld)) | fld <- flds ]
-                 [ Local (LocalId (np - i)) | i <- [1 .. np] ])))))
-        _ ->
-          ret (curriedLambda (np + 1)
-            (Apply (Lookup (Local (LocalId 0)) (last ls))
-              [ Local (LocalId (np - i)) | i <- [0 .. np-1] ]))
+        Record { recFields = flds } -> ret $ curriedLambda nargs $
+          if optJSOptimize (fst kit)
+            then Lambda 1 $ Apply (Local (LocalId 0)) args
+            else Object $ fromList [ (last ls, Lambda 1 $ Apply (Lookup (Local (LocalId 0)) $ last ls) args) ]
+        dt ->
+          ret $ curriedLambda (nargs + 1) $ Apply (Lookup (Local (LocalId 0)) index) args
+          where
+            index | Datatype{} <- dt
+                  , optJSOptimize (fst kit)
+                  , cs <- defConstructors dt
+                  = headWithDefault __IMPOSSIBLE__
+                      [MemberIndex i (mkComment $ last ls) | (i, x) <- zip [0..] cs, x == q]
+                  | otherwise = last ls
+            mkComment (MemberId s) = Comment s
+            mkComment _ = mempty
 
     AbstractDefn{} -> __IMPOSSIBLE__
   where
     ret = return . Just . Export ls
     plainJS = return . Just . Export ls . PlainJS
 
-compileTerm :: T.TTerm -> TCM Exp
-compileTerm t = do
-  kit <- coinductionKit
-  compileTerm' kit t
-
-compileTerm' :: Maybe CoinductionKit -> T.TTerm -> TCM Exp
-compileTerm' kit t = go t
+compileTerm :: EnvWithOpts -> T.TTerm -> TCM Exp
+compileTerm kit t = go t
   where
     go :: T.TTerm -> TCM Exp
     go t = case t of
@@ -355,7 +402,7 @@ compileTerm' kit t = go t
           Datatype {} -> return (String "*")
           Record {} -> return (String "*")
           _ -> qname q
-      T.TApp (T.TCon q) [x] | Just q == (nameOfSharp <$> kit) -> do
+      T.TApp (T.TCon q) [x] | Just q == (nameOfSharp <$> snd kit) -> do
         x <- go x
         let evalThunk = unlines
               [ "function() {"
@@ -369,7 +416,20 @@ compileTerm' kit t = go t
         return $ Object $ Map.fromList
           [(flatName, PlainJS evalThunk)
           ,(MemberId "__flat_helper", Lambda 0 x)]
-      T.TApp t xs -> curriedApply <$> go t <*> mapM go xs
+      T.TApp t' xs | Just f <- getDef t' -> do
+        used <- either getCompiledArgUse (\x -> fmap (map not) $ getErasedConArgs x) f
+        let given = length xs
+
+            -- number of eta expanded args
+            etaN = length $ dropWhile id $ reverse $ drop given used
+
+            xs' = xs ++ (T.TVar <$> [etaN-1, etaN-2 .. 0])
+            args = [ t | (t, True) <- zip xs' $ used ++ repeat True ]
+
+        curriedLambda etaN <$> (curriedApply <$> go (raise etaN t') <*> mapM go args)
+
+      T.TApp t xs -> do
+            curriedApply <$> go t <*> mapM go xs
       T.TLam t -> Lambda 1 <$> go t
       -- TODO This is not a lazy let, but it should be...
       T.TLet t e -> apply <$> (Lambda 1 <$> go e) <*> traverse go [t]
@@ -379,14 +439,20 @@ compileTerm' kit t = go t
         qname q
       T.TCase sc ct def alts | T.CTData dt <- T.caseType ct -> do
         dt <- getConstInfo dt
-        alts' <- traverse compileAlt alts
-        let obj = Object $ Map.fromList alts'
+        alts' <- traverse (compileAlt kit) alts
+        let cs  = defConstructors $ theDef dt
+            obj = Object $ Map.fromList [(snd x, y) | (x, y) <- alts']
+            arr = mkArray [headWithDefault (mempty, Null) [(Comment s, y) | ((c', MemberId s), y) <- alts', c' == c] | c <- cs]
         case (theDef dt, defJSDef dt) of
           (_, Just e) -> do
             return $ apply (PlainJS e) [Local (LocalId sc), obj]
+          (Record{}, _) | optJSOptimize (fst kit) -> do
+            return $ apply (Local $ LocalId sc) [snd $ headWithDefault __IMPOSSIBLE__ alts']
           (Record{}, _) -> do
             memId <- visitorName $ recCon $ theDef dt
             return $ apply (Lookup (Local $ LocalId sc) memId) [obj]
+          (Datatype{}, _) | optJSOptimize (fst kit) -> do
+            return $ curriedApply (Local (LocalId sc)) [arr]
           (Datatype{}, _) -> do
             return $ curriedApply (Local (LocalId sc)) [obj]
           _ -> __IMPOSSIBLE__
@@ -399,7 +465,16 @@ compileTerm' kit t = go t
       T.TError T.TUnreachable -> return Undefined
       T.TCoerce t -> go t
 
-    unit = return $ Integer 0
+    getDef (T.TDef f) = Just (Left f)
+    getDef (T.TCon c) = Just (Right c)
+    getDef (T.TCoerce x) = getDef x
+    getDef _ = Nothing
+
+    unit = return Null
+
+    mkArray xs
+        | 2 * length (filter ((==Null) . snd) xs) <= length xs = Array xs
+        | otherwise = Object $ Map.fromList [(MemberIndex i c, x) | (i, (c, x)) <- zip [0..] xs, x /= Null]
 
 compilePrim :: T.TPrim -> Exp
 compilePrim p =
@@ -432,13 +507,20 @@ compilePrim p =
         primEq   = curriedLambda 2 $ BinOp (local 1) "===" (local 0)
 
 
-compileAlt :: T.TAlt -> TCM (MemberId, Exp)
-compileAlt a = case a of
+compileAlt :: EnvWithOpts -> T.TAlt -> TCM ((QName, MemberId), Exp)
+compileAlt kit a = case a of
   T.TACon con ar body -> do
+    erased <- getErasedConArgs con
+    let nargs = ar - length (filter id erased)
     memId <- visitorName con
-    body <- Lambda ar <$> compileTerm body
-    return (memId, body)
+    body <- Lambda nargs <$> compileTerm kit (eraseLocalVars erased body)
+    return ((con, memId), body)
   _ -> __IMPOSSIBLE__
+
+eraseLocalVars :: [Bool] -> T.TTerm -> T.TTerm
+eraseLocalVars [] x = x
+eraseLocalVars (False: es) x = eraseLocalVars es x
+eraseLocalVars (True: es) x = eraseLocalVars es (TC.subst (length es) T.TErased x)
 
 visitorName :: QName -> TCM MemberId
 visitorName q = do (m,ls) <- global q; return (last ls)
@@ -493,10 +575,10 @@ litqname q =
 -- Writing out an ECMAScript module
 --------------------------------------------------
 
-writeModule :: Module -> TCM ()
-writeModule m = do
+writeModule :: Bool -> Module -> TCM ()
+writeModule minify m = do
   out <- outFile (modName m)
-  liftIO (writeFile out (JSPretty.pretty 0 0 m))
+  liftIO (writeFile out (JSPretty.prettyShow minify m))
 
 outFile :: GlobalId -> TCM FilePath
 outFile m = do

--- a/src/full/Agda/Compiler/JS/Pretty.hs
+++ b/src/full/Agda/Compiler/JS/Pretty.hs
@@ -1,25 +1,158 @@
 module Agda.Compiler.JS.Pretty where
 
-import Prelude hiding ( null )
 import Data.Char ( isAsciiLower, isAsciiUpper, isDigit )
 import Data.List ( intercalate )
+import Data.String ( IsString (fromString) )
+import Data.Semigroup ( Semigroup, (<>) )
 import Data.Set ( Set, toList, singleton, insert, member )
 import qualified Data.Set as Set
-import Data.Map ( Map, toAscList, empty, null )
+import Data.Map ( Map, toAscList )
 
 import Agda.Syntax.Common ( Nat )
 import Agda.Utils.Hash
+import Agda.Utils.List ( indexWithDefault )
+import Agda.Utils.Impossible
 
 import Agda.Compiler.JS.Syntax hiding (exports)
 
 -- Pretty-print a lambda-calculus expression as ECMAScript.
 
--- Since ECMAScript is C-like rather than Haskell-like, it's easier to
--- do the pretty-printing directly than use the Pretty library, which
--- assumes Haskell-like indentation.
+--- The indentation combinators of the pretty library does not fit C-like languages
+--- like ECMAScript.
+--- A simple pretty printer is implemented with a better `indent` and punctuation compaction.
+---
+--- More explanation:
+---
+--- I have struggled with different pretty printers, and at the end it was much easier
+--- to implement and use this ~100 SLOC code pretty printer library.
+--- It produces really better quality indentation than I could achieve with the
+--  standard pretty printers.
+--- This library code is only used in this module, and it is specialized to pretty
+--- print JavaScript code for the Agda backend, so I think its best place is in this module.
+data Doc
+    = Doc String
+    | Indent Int Doc
+    | Group Doc
+    | Beside Doc Doc
+    | Above Doc Doc
+    | Enclose Doc Doc Doc
+    | Space
+    | Empty
 
-br :: Int -> String
-br i = "\n" ++ replicate (2*i) ' '
+minifiedCodeLinesLength :: Int
+minifiedCodeLinesLength = 500
+
+render :: Bool -> Doc -> String
+render minify = intercalate "\n" . joinLines . map (uncurry mkIndent) . go 0
+  where
+    joinLines :: [String] -> [String]
+    joinLines = if minify then chunks 0 [] else id
+      where
+        chunks len acc [] = [concat (reverse acc)]
+        chunks len acc (s: ss)
+            | len + n <= minifiedCodeLinesLength = chunks (len + n) (s: acc) ss
+            | otherwise = concat (reverse acc): chunks n [s] ss
+          where
+            n = length s
+
+    joinBy f [x] (y: ys) = f x y ++ ys
+    joinBy f (x:xs) ys = x: joinBy f xs ys
+    joinBy f xs ys = xs ++ ys
+
+    mkIndent n s | minify = s
+    mkIndent n "" = ""
+    mkIndent n s = replicate n ' ' ++ s
+
+    overlay (i, s) (j, s') | all punctuation (s ++ s') && n > 0 = [(i, s ++ mkIndent n s')]
+      where n = j - (i + length s)
+    overlay (j, s') (i, s) | all punctuation (s ++ s') && n > 0 = [(i, s' ++ mkIndent n s)]
+      where n = j - (i + length s)
+    overlay a b = [a, b]
+
+    punctuation = (`elem` ("(){}[];:, " :: String))
+
+    go i Space = if minify then [] else [(i, " ")]
+    go i Empty = []
+    go i (Doc s) = [(i, s)]
+    go i (Beside d d') = joinBy (\(i, s) (_, s') -> [(i, s ++ s')]) (go i d) (go i d')
+    go i (Above d d') = joinBy overlay (go i d) (go i d')
+    go i (Indent j d) = go (i+j) d
+    go i (Enclose open close d) = go i $ Group $ Above open $ Above d close
+    go i (Group d)
+        | size ss < 40 = compact ss
+        | otherwise    = ss
+      where
+        ss = go i d
+        size = sum . map (length . snd)
+        compact [] = []
+        compact ((i, x): xs) = [(i, x ++ concatMap snd xs)]
+
+instance IsString Doc where
+    fromString = Doc
+
+instance Semigroup Doc where
+    Empty <> d = d
+    d <> Empty = d
+    d <> d' = Beside d d'
+
+instance Monoid Doc where
+    mempty = Empty
+    mappend = (<>)
+
+infixl 5 $+$
+
+($+$) :: Doc -> Doc -> Doc
+Empty $+$ d = d
+d $+$ Empty = d
+d $+$ d' = Above d d'
+
+text :: String -> Doc
+text = Doc
+
+group :: Doc -> Doc
+group = Group
+
+indentBy :: Int -> Doc -> Doc
+indentBy i Empty = Empty
+indentBy i (Indent j d) = Indent (i+j) d
+indentBy i d = Indent i d
+
+enclose :: Doc -> Doc -> Doc -> Doc
+enclose open close (Enclose o c d) = Enclose (open <> o) (c <> close) d
+enclose open close (Indent _ (Enclose o c d)) = Enclose (open <> o) (c <> close) d
+enclose open close d = Enclose open close d
+
+----------------------------------------------------------------------------------------------
+
+space :: Doc
+space = Space
+
+indent :: Doc -> Doc
+indent = indentBy 2
+
+hcat :: [Doc] -> Doc
+hcat = foldr (<>) mempty
+
+vcat :: [Doc] -> Doc
+vcat = foldr ($+$) mempty
+
+punctuate :: Doc -> [Doc] -> Doc
+punctuate _ []     = mempty
+punctuate p (x:xs) = indent $ vcat $ go x xs
+                   where go y []     = [y]
+                         go y (z:zs) = (y <> p) : go z zs
+
+parens, brackets, braces :: Doc -> Doc
+parens   = enclose "(" ")"
+brackets = enclose "[" "]"
+braces   = enclose "{" "}"
+
+-- | Apply 'parens' to 'Doc' if boolean is true.
+mparens :: Bool -> Doc -> Doc
+mparens True  d = parens d
+mparens False d = d
+
+----------------------------------------------------------------------------------------------
 
 unescape :: Char -> String
 unescape '"'      = "\\\""
@@ -30,106 +163,109 @@ unescape '\x2028' = "\\u2028"
 unescape '\x2029' = "\\u2029"
 unescape c        = [c]
 
-unescapes :: String -> String
-unescapes s = concatMap unescape s
+unescapes :: String -> Doc
+unescapes s = text $ concatMap unescape s
 
--- pretty n i e pretty-prints e, under n levels of de Bruijn binding,
--- with i levels of indentation.
+-- pretty (n,b) i e pretty-prints e, under n levels of de Bruijn binding
+--   if b is true then the output is minified
 
 class Pretty a where
-    pretty :: Nat -> Int -> a -> String
+    pretty :: (Nat, Bool) -> a -> Doc
+
+prettyShow :: Pretty a => Bool -> a -> String
+prettyShow minify = render minify . pretty (0, minify)
 
 instance (Pretty a, Pretty b) => Pretty (a,b) where
-  pretty n i (x,y) = pretty n i x ++ ": " ++ pretty n (i+1) y
+  pretty n (x,y) = pretty n x <> ":" <> space <> pretty n y
 
 -- Pretty-print collections
 
 class Pretties a where
-    pretties :: Nat -> Int -> a -> [String]
+    pretties :: (Nat, Bool) -> a -> [Doc]
 
 instance Pretty a => Pretties [a] where
-  pretties n i = map (pretty n i)
+  pretties n = map (pretty n)
 
 instance (Pretty a, Pretty b) => Pretties (Map a b) where
-  pretties n i o = pretties n i (toAscList o)
+  pretties n o = pretties n (toAscList o)
 
 -- Pretty print identifiers
 
 instance Pretty LocalId where
-  pretty n i (LocalId x) = "x" ++ show (n - x - 1)
+  pretty (n, _) (LocalId x) = text $ indexWithDefault __IMPOSSIBLE__ vars (n - x - 1)
+    where
+      vars = ("": map show [0..]) >>= \s -> map (:s) ['a'..'z']
 
 instance Pretty GlobalId where
-  pretty n i (GlobalId m) = variableName $ intercalate "_" m
+  pretty n (GlobalId m) = text $ variableName $ intercalate "_" m
 
 instance Pretty MemberId where
-  pretty n i (MemberId s) = "\"" ++ unescapes s ++ "\""
+  pretty _ (MemberId s) = "\"" <> unescapes s <> "\""
+  pretty n (MemberIndex i comment) = text (show i) <> pretty n comment
+
+instance Pretty Comment where
+  pretty _ (Comment "") = mempty
+  pretty (_, True) _ = mempty
+  pretty _ (Comment s) = text $ "/* " ++ s ++ " */"
 
 -- Pretty print expressions
 
 instance Pretty Exp where
-  pretty n i (Self)                 = "exports"
-  pretty n i (Local x)              = pretty n i x
-  pretty n i (Global m)             = pretty n i m
-  pretty n i (Undefined)            = "undefined"
-  pretty n i (String s)             = "\"" ++ unescapes s ++ "\""
-  pretty n i (Char c)               = "\"" ++ unescape c ++ "\""
-  pretty n i (Integer x)            = "agdaRTS.primIntegerFromString(\"" ++ show x ++ "\")"
-  pretty n i (Double x)             = show x
-  pretty n i (Lambda x e)           =
-    "function (" ++
-      intercalate ", " (pretties (n+x) i (map LocalId [x-1, x-2 .. 0])) ++
-    ") " ++ block (n+x) i e
-  pretty n i (Object o) | null o    = "{}"
-  pretty n i (Object o) | otherwise =
-    "{" ++ br (i+1) ++ intercalate ("," ++ br (i+1)) (pretties n i o) ++ br i ++ "}"
-  pretty n i (Apply f es)           = pretty n i f ++ "(" ++ intercalate ", " (pretties n i es) ++ ")"
-  pretty n i (Lookup e l)           = pretty n i e ++ "[" ++ pretty n i l ++ "]"
-  pretty n i (If e f g)             =
-    "(" ++ pretty n i e ++ "? " ++ pretty n i f ++ ": " ++ pretty n i g ++ ")"
-  pretty n i (PreOp op e)           = "(" ++ op ++ " " ++ pretty n i e ++ ")"
-  pretty n i (BinOp e op f)         = "(" ++ pretty n i e ++ " " ++ op ++ " " ++ pretty n i f ++ ")"
-  pretty n i (Const c)              = c
-  pretty n i (PlainJS js)           = "(" ++ js ++ ")"
+  pretty n (Self)            = "exports"
+  pretty n (Local x)         = pretty n x
+  pretty n (Global m)        = pretty n m
+  pretty n (Undefined)       = "undefined"
+  pretty n (Null)            = "null"
+  pretty n (String s)        = "\"" <> unescapes s <> "\""
+  pretty n (Char c)          = "\"" <> unescapes [c] <> "\""
+  pretty n (Integer x)       = "agdaRTS.primIntegerFromString(\"" <> text (show x) <> "\")"
+  pretty n (Double x)        = text $ show x
+  pretty (n, min) (Lambda x e) =
+    mparens (x /= 1) (punctuate "," (pretties (n+x, min) (map LocalId [x-1, x-2 .. 0]))) <>
+    space <> "=>" <> space <> block (n+x, min) e
+  pretty n (Object o)        = braces $ punctuate "," $ pretties n o
+  pretty n (Array es)        = brackets $ punctuate "," [pretty n c <> pretty n e | (c, e) <- es]
+  pretty n (Apply f es)      = pretty n f <> parens (punctuate "," $ pretties n es)
+  pretty n (Lookup e l)      = pretty n e <> brackets (pretty n l)
+  pretty n (If e f g)        = parens $ pretty n e <> "?" <> space <> pretty n f <> ":" <> space <> pretty n g
+  pretty n (PreOp op e)      = parens $ text op <> " " <> pretty n e
+  pretty n (BinOp e op f)    = parens $ pretty n e <> " " <> text op <> " " <> pretty n f
+  pretty n (Const c)         = text c
+  pretty n (PlainJS js)      = text js
 
-block :: Nat -> Int -> Exp -> String
-block n i (If e f g) = "{" ++ br (i+1) ++ block' n (i+1) (If e f g) ++ br i ++ "}"
-block n i e          = "{" ++ br (i+1) ++ "return " ++ pretty n (i+1) e ++ ";" ++ br i ++ "}"
+block :: (Nat, Bool) -> Exp -> Doc
+block n e = mparens (doNest e) $ pretty n e
+  where
+    doNest Object{} = True
+    doNest _ = False
 
-block' :: Nat -> Int -> Exp -> String
-block' n i (If e f g) = "if (" ++ pretty n i e ++ ") " ++ block n i f ++ " else " ++ block' n i g
-block' n i e          = block n i e
+modname :: GlobalId -> Doc
+modname (GlobalId ms) = text $ "\"" ++ intercalate "." ms ++ "\""
 
-modname :: GlobalId -> String
-modname (GlobalId ms) = "\"" ++ intercalate "." ms ++ "\""
+exports :: (Nat, Bool) -> Set [MemberId] -> [Export] -> Doc
+exports n lss [] = ""
+exports n lss (Export ls e : es) | member (init ls) lss =
+  "exports" <> hcat (map brackets (pretties n ls)) <> space <> "=" <> space <> indent (pretty n e) <> ";" $+$
+  exports n (insert ls lss) es
+exports n lss (Export ls e : es) | otherwise =
+  exports n lss (Export (init ls) (Object mempty) : Export ls e : es)
 
-exports :: Nat -> Int -> Set [MemberId] -> [Export] -> String
-exports n i lss [] = ""
-exports n i lss (Export ls e : es) | member (init ls) lss = concat
-  [ "exports["
-  , intercalate "][" (pretties n i ls)
-  , "] = "
-  , pretty n (i+1) e
-  , ";"
-  , br i
-  , exports n i (insert ls lss) es
-  ]
-exports n i lss (Export ls e : es) | otherwise =
-  exports n i lss (Export (init ls) (Object empty) : Export ls e : es)
+instance Pretty [(GlobalId, Export)] where
+  pretty n es
+    = vcat [ pretty n g <> hcat (map brackets (pretties n ls)) <> space <> "=" <> space <> indent (pretty n e) <> ";"
+           | (g, Export ls e) <- es ]
 
 instance Pretty Module where
-  pretty n i mod@(Module m is es ex) = concat
-    [ imports
-    , br i
-    , exports n i (singleton []) es
-    , br i
-    , maybe "" (pretty n i) ex
-    ]
+  pretty n (Module m is es ex) =
+    imports
+      $+$ exports n (singleton []) es
+      $+$ maybe "" (pretty n) ex
     where
-      imports = unlines $
-            ["var agdaRTS = require(\"agda-rts\");"] ++
-            ["var " ++ pretty n (i+1) e ++ " = require(" ++ modname e ++ ");"
-            | e <- toList (Set.fromList is `Set.union` globals mod)
-            ]
+      js = toList (globals es <> Set.fromList is)
+      imports = vcat $
+            ["var agdaRTS" <> space <> "=" <> space <> "require(\"agda-rts\");"] ++
+            ["var " <> indent (pretty n e) <> space <> "=" <> space <> "require(" <> modname e <> ");"
+            | e <- js]
 
 variableName :: String -> String
 variableName s = if isValidJSIdent s then "z_" ++ s else "h_" ++ show (hashString s)

--- a/src/full/Agda/Compiler/JS/Syntax.hs
+++ b/src/full/Agda/Compiler/JS/Syntax.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Agda.Compiler.JS.Syntax where
 
 import Data.Map (Map)
-
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Semigroup ( Semigroup )
 
 import Agda.Syntax.Common ( Nat )
 
@@ -17,12 +18,14 @@ data Exp =
   Local LocalId |
   Global GlobalId |
   Undefined |
+  Null |
   String String |
   Char Char |
   Integer Integer |
   Double Double |
   Lambda Nat Exp |
   Object (Map MemberId Exp) |
+  Array [(Comment, Exp)] |
   Apply Exp [Exp] |
   Lookup Exp MemberId |
   If Exp Exp Exp |
@@ -30,7 +33,7 @@ data Exp =
   PreOp String Exp |
   Const String |
   PlainJS String -- ^ Arbitrary JS code.
-  deriving Show
+  deriving (Show, Eq)
 
 -- Local identifiers are named by De Bruijn indices.
 -- Global identifiers are named by string lists.
@@ -42,8 +45,16 @@ newtype LocalId = LocalId Nat
 newtype GlobalId = GlobalId [String]
   deriving (Eq, Ord, Show)
 
-newtype MemberId = MemberId String
+data MemberId
+    = MemberId String
+    | MemberIndex Int Comment
   deriving (Eq, Ord, Show)
+
+newtype Comment = Comment String
+  deriving (Show, Semigroup, Monoid)
+
+instance Eq Comment where _ == _ = True
+instance Ord Comment where compare _ _ = EQ
 
 -- The top-level compilation unit is a module, which names
 -- the GId of its exports, and a list of definitions
@@ -79,8 +90,12 @@ instance (Uses a, Uses b) => Uses (a, b) where
 instance (Uses a, Uses b, Uses c) => Uses (a, b, c) where
   uses (a, b, c) = uses a `Set.union` uses b `Set.union` uses c
 
+instance Uses Comment where
+  uses _ = Set.empty
+
 instance Uses Exp where
   uses (Object o)     = uses o
+  uses (Array es)     = uses es
   uses (Apply e es)   = uses (e, es)
   uses (Lookup e l)   = uses' e [l] where
       uses' Self         ls = Set.singleton ls
@@ -112,10 +127,14 @@ instance (Globals a, Globals b) => Globals (a, b) where
 instance (Globals a, Globals b, Globals c) => Globals (a, b, c) where
   globals (a, b, c) = globals a `Set.union` globals b `Set.union` globals c
 
+instance Globals Comment where
+  globals _ = Set.empty
+
 instance Globals Exp where
   globals (Global i) = Set.singleton i
   globals (Lambda n e) = globals e
   globals (Object o) = globals o
+  globals (Array es) = globals es
   globals (Apply e es) = globals (e, es)
   globals (Lookup e l) = globals e
   globals (If e f g) = globals (e, f, g)


### PR DESCRIPTION
Use `null` instead of `agdaRTS.primIntegerFromString("0"))` for irrelevant arguments in the js backend.
    
Advantages:
    
- easier to read the generated code (relevant for debugging js code)
- one can distinguish the natural number 0 from ereased arguments in the  generated js code
- saves space
  For example, for a 24kb Agda source code ([1])
  it saves
  - 19.5% on js code
  - 2.8% on gzipped js code
  - 6.5% on minified js code
  - 0.9% on minified and gzipped js code
    
Drawbacks: no known drawbacks
    
[1]: https://github.com/divipp/frp_agda
