### PR TITLE
[ test suite ] remove orphaned .err files from test/Fail

### DIFF
--- a/test/Fail/CopatternCheckingNYI.err
+++ b/test/Fail/CopatternCheckingNYI.err
@@ -1,6 +1,0 @@
-
-Termination checking failed for the following functions:
-  alternate
-Problematic calls:
-  tail alternate
-    (at CopatternCheckingNYI.agda:19,32-41)

--- a/test/Fail/InductiveAndCoinductiveConstructors.err
+++ b/test/Fail/InductiveAndCoinductiveConstructors.err
@@ -1,7 +1,0 @@
-InductiveAndCoinductiveConstructors.agda:62,25-66
-.InductiveAndCoinductiveConstructors.♯-4 xs ls !=
-.InductiveAndCoinductiveConstructors.♯-3 xs ls of type
-∞ (WHNF (stream (stream unit)))
-when checking that the expression
-lemma xs (↓ ♯ (ls ≺ snd (label xs ls))) has type
-⟦ fst (label xs ls) ⟧ ≈ ⟦ xs ⟧

--- a/test/Fail/Issue1028.err
+++ b/test/Fail/Issue1028.err
@@ -1,3 +1,0 @@
-Issue1028.agda:5,7-7,15
-Could not parse the left-hand side F X
-when scope checking let F X = X in F Set

--- a/test/Fail/Issue138.err
+++ b/test/Fail/Issue138.err
@@ -1,2 +1,0 @@
-Issue138.agda:6,3-25
-Record types are not allowed in mutual blocks

--- a/test/Fail/Issue292b.err
+++ b/test/Fail/Issue292b.err
@@ -1,4 +1,0 @@
-Issue292b.agda:38,1-20
-ff ≅ tt should be empty, but that's not obvious to me
-when checking that the clause ¬pbool2 (ff , ()) has type
-¬ P (D false)

--- a/test/Fail/Issue473.err
+++ b/test/Fail/Issue473.err
@@ -1,3 +1,0 @@
-Issue473.agda:31,4-8
-zero != fst p of type Nat
-when checking that the pattern zero has type Zero (fst p)

--- a/test/Fail/Issue501.err
+++ b/test/Fail/Issue501.err
@@ -1,7 +1,0 @@
-Issue501.agda:37,24-29
-I'm not sure if there should be a case for the constructor ⟨_⟩,
-because I get stuck when trying to solve the following unification
-problems (inferred index ≟ expected index):
-  _45 k ≟ _46 k
-when checking that the pattern ⟨ x ⟩ has type
-(_44 k := _45 k) (_46 k)

--- a/test/Fail/Issue882a.err
+++ b/test/Fail/Issue882a.err
@@ -1,2 +1,0 @@
-Unsolved metas at the following locations:
-  Issue882a.agda:41,29-33

--- a/test/Fail/Issue985.err
+++ b/test/Fail/Issue985.err
@@ -1,9 +1,0 @@
-Issue985.agda:80,5-44
-I'm not sure if there should be a case for the constructor
-lookupZero, because I get stuck when trying to solve the following
-unification problems (inferred index ≟ expected index):
-  len Γ₁ ≟ x
-  Γ₁ , a₁ ≟ Γ , a
-  a₁ ≟ type
-  zero ≟ index
-when checking the definition of contra

--- a/test/Fail/NonRecursiveCoinductiveRecord.err
+++ b/test/Fail/NonRecursiveCoinductiveRecord.err
@@ -1,2 +1,0 @@
-NonRecursiveCoinductiveRecord.agda:10,3-14
-Only recursive records can be coinductive

--- a/test/Fail/Sections-13.err
+++ b/test/Fail/Sections-13.err
@@ -1,8 +1,0 @@
-Sections-13.agda:4,1-14
-Could not parse the left-hand side m test_test n
-Operators used in the grammar:
-  test_test (infix operator, unrelated) [_test_test_ (Sections-13.agda:3,1-12)]
-(the treatment of operators has changed, so code that used to parse
-may have to be changed)
-when scope checking the left-hand side m test_test n in the
-definition of _test_test_

--- a/test/Fail/TeXSpanningComment.tex.err
+++ b/test/Fail/TeXSpanningComment.tex.err
@@ -1,3 +1,0 @@
-user error (Multiline token in literate file spans multiple code
-blocks
-TeXSpanningComment.tex.lagda:2,3-6,7)

--- a/test/Fail/WhyWeNeedUntypedLambda.err
+++ b/test/Fail/WhyWeNeedUntypedLambda.err
@@ -1,5 +1,0 @@
-WhyWeNeedUntypedLambda.agda:14,22-26
-((x : _13 k) → _13 k) != ({A : Set} → A → A) because one is an
-implicit function type and the other is an explicit function type
-when checking that the expression refl has type
-((x : _13 k) → _13 k) == ({A : Set} → A → A)


### PR DESCRIPTION
I found these by diffing .err and .agda file lists and then did basic check that their continuing existence was indeed an oversight. Whether their respective .agda was removed, moved to succeed/bugs or simply renamed (as is the case with TeXSpanningComment.tex.err), they all point to no longer existing agda code