### PR TITLE
More specific css rules for Agda.css

### DIFF
--- a/src/data/Agda.css
+++ b/src/data/Agda.css
@@ -1,35 +1,35 @@
 /* Aspects. */
-.Comment       { color: #B22222 }
-.Background    {}
-.Markup        { color: #000000 }
-.Keyword       { color: #CD6600 }
-.String        { color: #B22222 }
-.Number        { color: #A020F0 }
-.Symbol        { color: #404040 }
-.PrimitiveType { color: #0000CD }
-.Pragma        { color: black   }
-.Operator      {}
+.agda-code .Comment       { color: #B22222 }
+.agda-code .Background    {}
+.agda-code .Markup        { color: #000000 }
+.agda-code .Keyword       { color: #CD6600 }
+.agda-code .String        { color: #B22222 }
+.agda-code .Number        { color: #A020F0 }
+.agda-code .Symbol        { color: #404040 }
+.agda-code .PrimitiveType { color: #0000CD }
+.agda-code .Pragma        { color: black   }
+.agda-code .Operator      {}
 
 /* NameKinds. */
-.Bound                  { color: black   }
-.InductiveConstructor   { color: #008B00 }
-.CoinductiveConstructor { color: #8B7500 }
-.Datatype               { color: #0000CD }
-.Field                  { color: #EE1289 }
-.Function               { color: #0000CD }
-.Module                 { color: #A020F0 }
-.Postulate              { color: #0000CD }
-.Primitive              { color: #0000CD }
-.Record                 { color: #0000CD }
+.agda-code .Bound                  { color: black   }
+.agda-code .InductiveConstructor   { color: #008B00 }
+.agda-code .CoinductiveConstructor { color: #8B7500 }
+.agda-code .Datatype               { color: #0000CD }
+.agda-code .Field                  { color: #EE1289 }
+.agda-code .Function               { color: #0000CD }
+.agda-code .Module                 { color: #A020F0 }
+.agda-code .Postulate              { color: #0000CD }
+.agda-code .Primitive              { color: #0000CD }
+.agda-code .Record                 { color: #0000CD }
 
 /* OtherAspects. */
-.DottedPattern      {}
-.UnsolvedMeta       { color: black; background: yellow         }
-.UnsolvedConstraint { color: black; background: yellow         }
-.TerminationProblem { color: black; background: #FFA07A        }
-.IncompletePattern  { color: black; background: #F5DEB3        }
-.Error              { color: red;   text-decoration: underline }
-.TypeChecks         { color: black; background: #ADD8E6        }
+.agda-code .DottedPattern      {}
+.agda-code .UnsolvedMeta       { color: black; background: yellow         }
+.agda-code .UnsolvedConstraint { color: black; background: yellow         }
+.agda-code .TerminationProblem { color: black; background: #FFA07A        }
+.agda-code .IncompletePattern  { color: black; background: #F5DEB3        }
+.agda-code .Error              { color: red;   text-decoration: underline }
+.agda-code .TypeChecks         { color: black; background: #ADD8E6        }
 
 /* Standard attributes. */
 a { text-decoration: none }


### PR DESCRIPTION
I'm trying to create a slideshow using `agda --html` + `pandoc` + `reveal.js`. However, the default theme for reveal.js colors gives a color to all `<a>...</a>` elements, which (apparently) takes precedence over the code coloring from `Agda.css` according to the [CSS specificity rules](https://www.w3schools.com/css/css_specificity.asp) I found a way to fix it by adding the extra  class `.agda-code` to all rules in `Agda.css`, which doubles the specificity.

Does someone know a better way to fix this problem? If not, I propose we change the official `Agda.css` so it works 'out-of-the-box'.