### PR TITLE
Documentation: fixes grammar in the section on record types

### DIFF
--- a/doc/user-manual/language/record-types.lagda.rst
+++ b/doc/user-manual/language/record-types.lagda.rst
@@ -118,7 +118,7 @@ Record values are constructed by giving a value for each record field:
 
    record { <fieldname1> = <term1> ; <fieldname2> = <term2> ; ... }
 
-where the types of the terms matches the types of the fields. If a
+where the types of the terms match the types of the fields. If a
 constructor ``<constructorname>`` has been declared for the record,
 this can also be written
 
@@ -143,7 +143,7 @@ Records can also be constructed by :ref:`updating other records
 Building records from modules
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``record { <fields> }`` syntax also accept module names. Fields
+The ``record { <fields> }`` syntax also accepts module names. Fields
 are defined using the corresponding definitions from the given module.
 For instance assuming this record type R and module M:
 


### PR DESCRIPTION
This patch fixes grammar in the section on record types in the user manual.