### PR TITLE
[ fix #3415 ] Implement "ghcomp" for cubical mode

### DIFF
--- a/src/data/lib/prim/Agda/Builtin/Cubical/Glue.agda
+++ b/src/data/lib/prim/Agda/Builtin/Cubical/Glue.agda
@@ -69,12 +69,17 @@ A ≃ B = Σ (A → B) \ f → (isEquiv f)
 equivFun : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} → A ≃ B → A → B
 equivFun e = fst e
 
+-- Improved version of equivProof compared to Lemma 5 in CCHM. We put
+-- the (φ = i0) face in contr' making it be definitionally c in this
+-- case. This makes the computational behavior better, in particular
+-- for transp in Glue.
 equivProof : ∀ {la lt} (T : Set la) (A : Set lt) → (w : T ≃ A) → (a : A)
             → ∀ ψ → (Partial ψ (fiber (w .fst) a)) → fiber (w .fst) a
 equivProof A B w a ψ fb = contr' {A = fiber (w .fst) a} (w .snd .equiv-proof a) ψ fb
   where
     contr' : ∀ {ℓ} {A : Set ℓ} → isContr A → (φ : I) → (u : Partial φ A) → A
-    contr' {A = A} (c , p) φ u = hcomp (λ i o → p (u o) i) c
+    contr' {A = A} (c , p) φ u = hcomp (λ i → λ { (φ = i1) → p (u 1=1) i
+                                                ; (φ = i0) → c }) c
 
 
 {-# BUILTIN EQUIV      _≃_        #-}

--- a/src/data/lib/prim/Agda/Builtin/Cubical/Glue.agda
+++ b/src/data/lib/prim/Agda/Builtin/Cubical/Glue.agda
@@ -74,7 +74,7 @@ equivFun e = fst e
 -- case. This makes the computational behavior better, in particular
 -- for transp in Glue.
 equivProof : ∀ {la lt} (T : Set la) (A : Set lt) → (w : T ≃ A) → (a : A)
-            → ∀ ψ → (Partial ψ (fiber (w .fst) a)) → fiber (w .fst) a
+           → ∀ ψ → (Partial ψ (fiber (w .fst) a)) → fiber (w .fst) a
 equivProof A B w a ψ fb = contr' {A = fiber (w .fst) a} (w .snd .equiv-proof a) ψ fb
   where
     contr' : ∀ {ℓ} {A : Set ℓ} → isContr A → (φ : I) → (u : Partial φ A) → A

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -970,11 +970,25 @@ primTransHComp cmd ts nelims = do
           -- compute "forall. phi"
           forallphi = pure tForall <@> phi
 
-          -- TODO: "ghcomp"
+          -- Without "ghcomp" we're computing:
+          --
+          -- comp^i A [ psi -> a0, forallphi -> e.1 tf ] a0
+          --
+          -- So for "ghcomp" we should compute:
+          --
+          -- comp^i A [ psi \/ (~ psi /\ ~ forallphi) -> a0, forallphi -> e.1 tf ] a0
+
+          -- compute the formula for "ghcomp"
+          ghcomppsi =
+              pure tIMax <@> psi
+                         <@> pure tIMin <@> (pure tINeg <@> psi)
+                                        <@> (pure tINeg <@> forallphi)
+
+          -- a1 with "ghcomp" inlined
           a1 = comp la bA
-                 (pure tIMax <@> psi <@> forallphi)
+                 (pure tIMax <@> ghcomppsi <@> forallphi)
                  (lam "i" $ \ i -> pure tPOr <#> (la <@> i)
-                                             <@> psi
+                                             <@> ghcomppsi
                                              <@> forallphi
                                              <@> (ilam "o" $ \ a -> bA <@> i)
                                              <@> (ilam "o" $ \ _ -> a0)

--- a/test/Succeed/Issue3415.agda
+++ b/test/Succeed/Issue3415.agda
@@ -1,0 +1,32 @@
+-- Verify that issue 3415 has been fixed by checking that the
+-- computation rule for univalence holds up to a trivial transport (it
+-- used to only hold up to a more complicated argument).
+{-# OPTIONS --cubical #-}
+module Issue3415 where
+
+open import Agda.Primitive.Cubical public
+open import Agda.Builtin.Cubical.Path public
+open import Agda.Builtin.Cubical.Glue public
+open import Agda.Builtin.Sigma public
+
+idIsEquiv : ∀ {ℓ} (A : Set ℓ) → isEquiv (λ (x : A) → x)
+equiv-proof (idIsEquiv A) y =
+  ((y , λ _ → y) , λ z i → z .snd (primINeg i)
+  , λ j → z .snd (primIMax (primINeg i) j))
+
+idEquiv : ∀ {ℓ} (A : Set ℓ) → A ≃ A
+idEquiv A = ((λ x → x) , idIsEquiv A)
+
+ua : ∀ {ℓ} {A B : Set ℓ} → A ≃ B → A ≡ B
+ua {A = A} {B = B} e i =
+  primGlue B (λ { (i = i0) → A ; (i = i1) → B })
+             (λ { (i = i0) → e ; (i = i1) → (idEquiv B) })
+
+transport : ∀ {ℓ} {A B : Set ℓ} → A ≡ B → A → B
+transport p a = primTransp (λ i → p i) i0 a
+
+transportRefl : ∀ {ℓ}  {A : Set ℓ} → (x : A) → transport (λ _ → A) x ≡ x
+transportRefl {A = A} x i = primTransp (λ _ → A) i x
+
+uaβ : ∀ {ℓ} {A B : Set ℓ} (e : A ≃ B) (x : A) → transport (ua e) x ≡ e .fst x
+uaβ e x = transportRefl (e .fst x)


### PR DESCRIPTION
This PR fixes https://github.com/agda/agda/issues/3415 by modifying the way transp for Glue types work. It seems to work very well and I managed to simplify various things in the agda/cubical library: https://github.com/agda/cubical/pull/54.

This PR breaks the test for issue #3399 (https://github.com/agda/agda/blob/master/test/Succeed/Issue3399.agda). If I understand that test correctly it is comparing transp for Glue with the old comp for Glue code. As I've now changed transp for Glue it is not surprising that it doesn't compute exactly like the old comp. We could either move the test file to Fail or I could try to prove the equality up to a path instead of requiring that it holds definitionally.  However I think @Saizan might want to remove the old comp code completely, so it might not be worth it to try to fix the test. 