### PR TITLE
[ new ] Add support for compiling literate Org documents

### DIFF
--- a/doc/user-manual/tools/literate-programming.rst
+++ b/doc/user-manual/tools/literate-programming.rst
@@ -128,10 +128,33 @@ HTML or LaTeX using PanDoc_.
   difficulty of interpreting their indentation level with respect to
   the rest of the file.
 
+Literate Org
+------------
+
+Files ending in :file:`.lagda.org` are interpreted as literate
+Org_ files. Code blocks are surrounded by two lines including only
+```#+begin_src agda2``` and ```#+end_src``` (case insensitive).
+
+.. code-block:: text
+
+    This line is ordinary text, which is ignored by Agda.
+
+    #+begin_src agda2
+    module Whatever where
+    -- Agda code goes here
+    #+end_src
+
+    Another non-code line.
+
+* Code blocks which should be ignored by Agda, but rendered in the
+  final document may be placed in source blocks without the ``agda2``
+  label.
+
 
 .. _TeX: http://tug.org/
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _Markdown: https://daringfireball.net/projects/markdown/
+.. _Org: https://orgmode.org
 
 .. _lhs2TeX: https://www.andres-loeh.de/lhs2tex/
 .. _Sphinx: http://www.sphinx-doc.org/en/stable/

--- a/src/full/Agda/Interaction/Highlighting/HTML.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML.hs
@@ -86,6 +86,7 @@ highlightOnlyCode HighlightCode _ = True
 highlightOnlyCode HighlightAuto AgdaFileType = False
 highlightOnlyCode HighlightAuto MdFileType   = True
 highlightOnlyCode HighlightAuto RstFileType  = True
+highlightOnlyCode HighlightAuto OrgFileType  = True
 highlightOnlyCode HighlightAuto TexFileType  = False
 
 -- | Determine the generated file extension
@@ -98,6 +99,7 @@ highlightedFileExt hh ft
       MdFileType   -> "md"
       RstFileType  -> "rst"
       TexFileType  -> "tex"
+      OrgFileType  -> "org"
 
 -- | Generates HTML files from all the sources which have been
 --   visited during the type checking phase.
@@ -265,6 +267,7 @@ code onlyCode fileType = mconcat . if onlyCode
          AgdaFileType -> map mkHtml
          -- Any points for using this option?
          TexFileType  -> map mkMd . chunksOf 2 . splitByMarkup
+         OrgFileType  -> map mkOrg . splitByMarkup
   else map mkHtml
   where
   trd (_, _, a) = a
@@ -300,6 +303,13 @@ code onlyCode fileType = mconcat . if onlyCode
                   ]
       go [a]    = work <$> a
       go _      = __IMPOSSIBLE__
+
+  mkOrg :: [TokenInfo] -> Html
+  mkOrg = mconcat . map go
+    where
+      go token@(_, s, mi) = if aspect mi == Just Background
+        then preEscapedToHtml s
+        else mkHtml token
 
   -- | Put anchors that enable referencing that token.
   --   We put a fail safe numeric anchor (file position) for internal references

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -50,7 +50,7 @@ instance KillRange Delayed where
 -- * File type
 ---------------------------------------------------------------------------
 
-data FileType = AgdaFileType | MdFileType | RstFileType | TexFileType
+data FileType = AgdaFileType | MdFileType | RstFileType | TexFileType | OrgFileType
   deriving (Data, Eq, Ord)
 
 instance Pretty FileType where
@@ -61,6 +61,7 @@ instance Show FileType where
   show MdFileType   = "Markdown"
   show RstFileType  = "ReStructedText"
   show TexFileType  = "LaTeX"
+  show OrgFileType  = "org-mode"
 
 ---------------------------------------------------------------------------
 -- * Eta-equality

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -158,12 +158,14 @@ instance EmbPrj FileType where
   icod_ MdFileType   = icodeN 0 IsRecord
   icod_ RstFileType  = icodeN 1 IsRecord
   icod_ TexFileType  = icodeN 2 IsRecord
+  icod_ OrgFileType  = icodeN 3 IsRecord
 
   value = vcase $ \case
     []  -> valuN AgdaFileType
     [0] -> valuN MdFileType
     [1] -> valuN RstFileType
     [2] -> valuN TexFileType
+    [3] -> valuN OrgFileType
     _   -> malformed
 
 instance EmbPrj DataOrRecord where

--- a/test/LaTeXAndHTML/succeed/Org.html
+++ b/test/LaTeXAndHTML/succeed/Org.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html><head><meta charset="utf-8"><title>Org</title><link rel="stylesheet" href="Agda.css"></head><body><pre class="Agda"><a id="1" class="Background">* Org mode
+
+- A list item!
+- Another1
+
+</a><a id="40" class="Markup">#+begin_src agda2
+</a><a id="58" class="Keyword">module</a> <a id="65" href="Org.html" class="Module">Org</a> <a id="69" class="Keyword">where</a>
+
+<a id="76" class="Keyword">data</a> <a id="Bool"></a><a id="81" href="Org.html#81" class="Datatype">Bool</a> <a id="86" class="Symbol">:</a> <a id="88" class="PrimitiveType">Set</a> <a id="92" class="Keyword">where</a>
+<a id="98" class="Markup">#+end_src
+</a><a id="108" class="Background">
+Some prose.
+Some more code.
+
+</a><a id="138" class="Markup">#+begin_src agda2
+</a>  <a id="Bool.true"></a><a id="158" href="Org.html#158" class="InductiveConstructor">true</a>  <a id="164" class="Symbol">:</a> <a id="166" href="Org.html#81" class="Datatype">Bool</a>
+  <a id="Bool.false"></a><a id="173" href="Org.html#173" class="InductiveConstructor">false</a> <a id="179" class="Symbol">:</a> <a id="181" href="Org.html#81" class="Datatype">Bool</a>
+<a id="186" class="Markup">#+end_src
+</a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/Org.lagda.org
+++ b/test/LaTeXAndHTML/succeed/Org.lagda.org
@@ -1,0 +1,18 @@
+* Org mode
+
+- A list item!
+- Another1
+
+#+begin_src agda2
+module Org where
+
+data Bool : Set where
+#+end_src
+
+Some prose.
+Some more code.
+
+#+begin_src agda2
+  true  : Bool
+  false : Bool
+#+end_src

--- a/test/LaTeXAndHTML/succeed/OrgMultipleLanguages.html
+++ b/test/LaTeXAndHTML/succeed/OrgMultipleLanguages.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML>
+<html><head><meta charset="utf-8"><title>OrgMultipleLanguages</title><link rel="stylesheet" href="Agda.css"></head><body><pre class="Agda"><a id="1" class="Background">* Org mode with multiple languages
+
+** Have some Agda!
+
+</a><a id="57" class="Markup">#+begin_src agda2
+</a><a id="75" class="Keyword">module</a> <a id="82" href="OrgMultipleLanguages.html" class="Module">OrgMultipleLanguages</a> <a id="103" class="Keyword">where</a>
+
+<a id="110" class="Keyword">data</a> <a id="Bool"></a><a id="115" href="OrgMultipleLanguages.html#115" class="Datatype">Bool</a> <a id="120" class="Symbol">:</a> <a id="122" class="PrimitiveType">Set</a> <a id="126" class="Keyword">where</a>
+  <a id="Bool.true"></a><a id="134" href="OrgMultipleLanguages.html#134" class="InductiveConstructor">true</a>  <a id="140" class="Symbol">:</a> <a id="142" href="OrgMultipleLanguages.html#115" class="Datatype">Bool</a>
+  <a id="Bool.false"></a><a id="149" href="OrgMultipleLanguages.html#149" class="InductiveConstructor">false</a> <a id="155" class="Symbol">:</a> <a id="157" href="OrgMultipleLanguages.html#115" class="Datatype">Bool</a>
+<a id="162" class="Markup">#+end_src
+</a><a id="172" class="Background">
+
+** Have some Haskell!
+
+#+begin_src haskell
+main = putStrLn &quot;Hello!&quot;
+#+end_src
+
+** Have some elisp
+
+#+begin_src elisp
+(message &quot;Hello!&quot;)
+#+end_src
+
+** Invalid (ignored) Agda
+
+#+begin_src agda2-foo
+module Wrong where
+#+end_src
+
+#+begin_src agda
+module Wrong where
+#+end_src
+</a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/OrgMultipleLanguages.lagda.org
+++ b/test/LaTeXAndHTML/succeed/OrgMultipleLanguages.lagda.org
@@ -1,0 +1,34 @@
+* Org mode with multiple languages
+
+** Have some Agda!
+
+#+begin_src agda2
+module OrgMultipleLanguages where
+
+data Bool : Set where
+  true  : Bool
+  false : Bool
+#+end_src
+
+
+** Have some Haskell!
+
+#+begin_src haskell
+main = putStrLn "Hello!"
+#+end_src
+
+** Have some elisp
+
+#+begin_src elisp
+(message "Hello!")
+#+end_src
+
+** Invalid (ignored) Agda
+
+#+begin_src agda2-foo
+module Wrong where
+#+end_src
+
+#+begin_src agda
+module Wrong where
+#+end_src

--- a/test/LaTeXAndHTML/succeed/OrgTangle.html
+++ b/test/LaTeXAndHTML/succeed/OrgTangle.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html><head><meta charset="utf-8"><title>OrgTangle</title><link rel="stylesheet" href="Agda.css"></head><body><pre class="Agda"><a id="1" class="Background">* Org tangle
+
+</a><a id="15" class="Markup">#+begin_src agda2 :tangle OrgTangle.agda
+</a><a id="56" class="Keyword">module</a> <a id="63" href="OrgTangle.html" class="Module">OrgTangle</a> <a id="73" class="Keyword">where</a>
+
+<a id="80" class="Keyword">data</a> <a id="Bool"></a><a id="85" href="OrgTangle.html#85" class="Datatype">Bool</a> <a id="90" class="Symbol">:</a> <a id="92" class="PrimitiveType">Set</a> <a id="96" class="Keyword">where</a>
+  <a id="Bool.true"></a><a id="104" href="OrgTangle.html#104" class="InductiveConstructor">true</a>  <a id="110" class="Symbol">:</a> <a id="112" href="OrgTangle.html#85" class="Datatype">Bool</a>
+  <a id="Bool.false"></a><a id="119" href="OrgTangle.html#119" class="InductiveConstructor">false</a> <a id="125" class="Symbol">:</a> <a id="127" href="OrgTangle.html#85" class="Datatype">Bool</a>
+<a id="132" class="Markup">#+end_src
+</a></pre></body></html>

--- a/test/LaTeXAndHTML/succeed/OrgTangle.lagda.org
+++ b/test/LaTeXAndHTML/succeed/OrgTangle.lagda.org
@@ -1,0 +1,9 @@
+* Org tangle
+
+#+begin_src agda2 :tangle OrgTangle.agda
+module OrgTangle where
+
+data Bool : Set where
+  true  : Bool
+  false : Bool
+#+end_src

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -75,6 +75,7 @@ dropAgdaExtension' p =  stripExtension ".agda" p
                         <|> stripExtension ".lagda.tex" p
                         <|> stripExtension ".lagda.rst" p
                         <|> stripExtension ".lagda.md" p
+                        <|> stripExtension ".lagda.org" p
 #if !MIN_VERSION_filepath(1,4,1)
   where
     stripExtension :: String -> FilePath -> Maybe FilePath

--- a/test/interaction/Issue2224.out
+++ b/test/interaction/Issue2224.out
@@ -1,4 +1,4 @@
 Issue2224WrongExtension.agda.tex:1,1-1
 Issue2224WrongExtension.agda.tex: Unsupported extension.
 Supported extensions are: .agda, .lagda, .lagda.rst, .lagda.tex,
-.lagda.md
+.lagda.md, .lagda.org


### PR DESCRIPTION
[Org](https://orgmode.org) documents are a popular choice for Emacs users. These documents allow for [source blocks](https://orgmode.org/manual/Working-with-source-code.html).

This commit adds support for literate Agda files with the extension`.lagda.org`.

Some due diligence:

```
~/s/agda> grep 'OrgFileType' -r src
src/full/Agda/TypeChecking/Serialise/Instances/Common.hs:  icod_ OrgFileType  = icodeN 3 IsRecord
src/full/Agda/TypeChecking/Serialise/Instances/Common.hs:    [3] -> valuN OrgFileType
src/full/Agda/Syntax/Common.hs:data FileType = AgdaFileType | MdFileType | RstFileType | TexFileType | OrgFileType
src/full/Agda/Syntax/Common.hs:  show OrgFileType  = "org-mode"
src/full/Agda/Syntax/Parser/Literate.hs:    , (".org", (literateOrg, OrgFileType))
src/full/Agda/Interaction/Highlighting/HTML.hs:highlightOnlyCode HighlightAuto OrgFileType  = True
src/full/Agda/Interaction/Highlighting/HTML.hs:      OrgFileType  -> "org"
src/full/Agda/Interaction/Highlighting/HTML.hs:         OrgFileType  -> map mkOrg
~/s/agda> grep 'MdFileType' -r src
src/full/Agda/TypeChecking/Serialise/Instances/Common.hs:  icod_ MdFileType   = icodeN 0 IsRecord
src/full/Agda/TypeChecking/Serialise/Instances/Common.hs:    [0] -> valuN MdFileType
src/full/Agda/Syntax/Common.hs:data FileType = AgdaFileType | MdFileType | RstFileType | TexFileType | OrgFileType
src/full/Agda/Syntax/Common.hs:  show MdFileType   = "Markdown"
src/full/Agda/Syntax/Parser/Literate.hs:    , (".md",  (literateMd,  MdFileType ))
src/full/Agda/Interaction/Highlighting/HTML.hs:highlightOnlyCode HighlightAuto MdFileType   = True
src/full/Agda/Interaction/Highlighting/HTML.hs:      MdFileType   -> "md"
src/full/Agda/Interaction/Highlighting/HTML.hs:         MdFileType   -> map mkMd . chunksOf 2 . splitByMarkup
```

test_org.lagda.org:

```
#+TITLE: Sample org-mode with Agda!

#+begin_src agda2 :tangle yes
module test_org where

open import Data.List hiding (sum)
open import Data.Nat
open import IO
#+end_src

* Administrivia

This file demonstrates Agda's new support for compiling Org documents!

* Non-Agda code

#+begin_src haskell
main = putStrLn "Hello!"
#+end_src

* Code!

#+begin_src agda2
sum : List ℕ → ℕ
sum [] = 0
sum (x ∷ xs) = x + sum xs

main = run (putStrLn "Hello!")
#+end_src
```

```
emily@violet ~/s/agda> ./dist/dist-sandbox-d54e9136/build/agda/agda --html --compile test_org.lagda.org
Warning: HTML is currently generated for ALL files which can be
reached from the given module, including library files.

...
Generating HTML for test_org (html/test_org.html).
Calling: ghc -O -o /Users/emily/src/agda/test_org -Werror -i/Users/emily/src/agda -main-is MAlonzo.Code.Qtest_org /Users/emily/src/agda/MAlonzo/Code/Qtest_org.hs --make -fwarn-incomplete-patterns -fno-warn-overlapping-patterns
Linking /Users/emily/src/agda/test_org ...
~/s/agda> ./test_org
Hello!
```