### PR TITLE
New reflection primitive 'runSpeculative'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1062,6 +1062,17 @@ Language
   ["blocking"](https://github.com/agda/agda/blob/4900ef5fc61776381f3a5e9c94ef776375e9e1f1/src/full/Agda/TypeChecking/Monad/Constraints.hs#L160-L174)
   constraints.
 
+* New TC primitive: `runSpeculative` [Issue
+  [#3346](https://github.com/agda/agda/issues/3346)]
+
+  ```
+    runSpeculative : ∀ {a} {A : Set a} → TC (Σ A λ _ → Bool) → TC A
+  ```
+
+  The computation `runSpeculative m` runs `m` and either keeps the new
+  TC state (if the second component is `true`) or resets to the old TC
+  state (if it is `false`).
+
 Pragmas and options
 -------------------
 

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -382,6 +382,11 @@ following primitive operations::
     -- "blocking" constraints.
     noConstraints : ∀ {a} {A : Set a} → TC A → TC A
 
+    -- Run the given TC action and return the first component. Resets to
+    -- the old TC state if the second component is 'false', or keep the
+    -- new TC state if it is 'true'.
+    runSpeculative : ∀ {a} {A : Set a} → TC (Σ A λ _ → Bool) → TC A
+
   {-# BUILTIN AGDATCMUNIFY              unify              #-}
   {-# BUILTIN AGDATCMTYPEERROR          typeError          #-}
   {-# BUILTIN AGDATCMBLOCKONMETA        blockOnMeta        #-}
@@ -406,6 +411,7 @@ following primitive operations::
   {-# BUILTIN AGDATCMWITHNORMALISATION  withNormalisation  #-}
   {-# BUILTIN AGDATCMDEBUGPRINT         debugPrint         #-}
   {-# BUILTIN AGDATCMNOCONSTRAINTS      noConstraints      #-}
+  {-# BUILTIN AGDATCMRUNSPECULATIVE     runSpeculative     #-}
 
 Metaprogramming
 ---------------

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -11,6 +11,7 @@ open import Agda.Builtin.String
 open import Agda.Builtin.Char
 open import Agda.Builtin.Float
 open import Agda.Builtin.Int
+open import Agda.Builtin.Sigma
 
 -- Names --
 
@@ -275,6 +276,11 @@ postulate
   -- "blocking" constraints.
   noConstraints : ∀ {a} {A : Set a} → TC A → TC A
 
+  -- Run the given TC action and return the first component. Resets to
+  -- the old TC state if the second component is 'false', or keep the
+  -- new TC state if it is 'true'.
+  runSpeculative : ∀ {a} {A : Set a} → TC (Σ A λ _ → Bool) → TC A
+
 {-# BUILTIN AGDATCM              TC            #-}
 {-# BUILTIN AGDATCMRETURN        returnTC      #-}
 {-# BUILTIN AGDATCMBIND          bindTC        #-}
@@ -302,3 +308,4 @@ postulate
 {-# BUILTIN AGDATCMWITHNORMALISATION withNormalisation #-}
 {-# BUILTIN AGDATCMDEBUGPRINT    debugPrint    #-}
 {-# BUILTIN AGDATCMNOCONSTRAINTS noConstraints #-}
+{-# BUILTIN AGDATCMRUNSPECULATIVE runSpeculative #-}

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -59,7 +59,8 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinAgdaTCMQuoteTerm, builtinAgdaTCMUnquoteTerm,
   builtinAgdaTCMBlockOnMeta, builtinAgdaTCMCommit, builtinAgdaTCMIsMacro,
   builtinAgdaTCMWithNormalisation, builtinAgdaTCMDebugPrint,
-  builtinAgdaTCMNoConstraints
+  builtinAgdaTCMNoConstraints,
+  builtinAgdaTCMRunSpeculative
   :: String
 
 builtinNat                           = "NATURAL"
@@ -237,6 +238,7 @@ builtinAgdaTCMIsMacro       = "AGDATCMISMACRO"
 builtinAgdaTCMWithNormalisation = "AGDATCMWITHNORMALISATION"
 builtinAgdaTCMDebugPrint = "AGDATCMDEBUGPRINT"
 builtinAgdaTCMNoConstraints = "AGDATCMNOCONSTRAINTS"
+builtinAgdaTCMRunSpeculative = "AGDATCMRUNSPECULATIVE"
 
 -- | Builtins that come without a definition in Agda syntax.
 --   These are giving names to Agda internal concepts which
@@ -272,4 +274,3 @@ sizeBuiltins =
   , builtinSizeInf
   , builtinSizeMax
   ]
-

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -201,7 +201,8 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primAgdaTCMQuoteTerm, primAgdaTCMUnquoteTerm,
     primAgdaTCMBlockOnMeta, primAgdaTCMCommit, primAgdaTCMIsMacro,
     primAgdaTCMWithNormalisation, primAgdaTCMDebugPrint,
-    primAgdaTCMNoConstraints
+    primAgdaTCMNoConstraints,
+    primAgdaTCMRunSpeculative
     :: TCM Term
 
 primInteger      = getBuiltin builtinInteger
@@ -377,6 +378,7 @@ primAgdaTCMIsMacro            = getBuiltin builtinAgdaTCMIsMacro
 primAgdaTCMWithNormalisation  = getBuiltin builtinAgdaTCMWithNormalisation
 primAgdaTCMDebugPrint         = getBuiltin builtinAgdaTCMDebugPrint
 primAgdaTCMNoConstraints      = getBuiltin builtinAgdaTCMNoConstraints
+primAgdaTCMRunSpeculative     = getBuiltin builtinAgdaTCMRunSpeculative
 
 -- | The coinductive primitives.
 

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -350,6 +350,8 @@ coreBuiltins =
   , builtinAgdaTCMWithNormalisation  |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tbool --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMDebugPrint         |-> builtinPostulate (tstring --> tnat --> tlist terrorpart --> tTCM_ primUnit)
   , builtinAgdaTCMNoConstraints      |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+  , builtinAgdaTCMRunSpeculative     |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
+                                                           tTCM 1 (primSigma <#> varM 1 <#> primLevelZero <@> varM 0 <@> (Lam defaultArgInfo . Abs "_" <$> primBool)) --> tTCM 1 (varM 0))
   ]
   where
         (|->) = BuiltinInfo

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -508,6 +508,7 @@ evalTCM v = do
              , (f `isDef` primAgdaTCMBlockOnMeta, uqFun1 tcBlockOnMeta u)
              , (f `isDef` primAgdaTCMDebugPrint,  tcFun3 tcDebugPrint l a u)
              , (f `isDef` primAgdaTCMNoConstraints, tcNoConstraints (unElim u))
+             , (f `isDef` primAgdaTCMRunSpeculative, tcRunSpeculative (unElim u))
              ]
              failEval
     I.Def f [_, _, u, v] ->
@@ -734,3 +735,19 @@ evalTCM v = do
       let i = mkDefInfo (nameConcrete $ qnameName x) noFixity' PublicAccess ConcreteDef noRange
       checkFunDef NotDelayed i x cs
       primUnitUnit
+
+    tcRunSpeculative :: Term -> UnquoteM Term
+    tcRunSpeculative mu = do
+      oldState <- getTC
+      u <- reduce =<< evalTCM mu
+      true  <- liftTCM primTrue
+      false <- liftTCM primFalse
+      case u of
+        Con _ _ [Apply (Arg { unArg = x }), Apply (Arg { unArg = b0 })] -> do
+          b <- reduce b0
+          if | b == true  -> return x
+             | b == false -> putTC oldState >> return x
+             | otherwise  -> liftTCM $ typeError . GenericDocError =<<
+                 "Should be 'true' or 'false': " <+> prettyTCM b
+        _ -> liftTCM $ typeError . GenericDocError =<<
+          "Should be a pair: " <+> prettyTCM u

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -740,14 +740,9 @@ evalTCM v = do
     tcRunSpeculative mu = do
       oldState <- getTC
       u <- reduce =<< evalTCM mu
-      true  <- liftTCM primTrue
-      false <- liftTCM primFalse
       case u of
-        Con _ _ [Apply (Arg { unArg = x }), Apply (Arg { unArg = b0 })] -> do
-          b <- reduce b0
-          if | b == true  -> return x
-             | b == false -> putTC oldState >> return x
-             | otherwise  -> liftTCM $ typeError . GenericDocError =<<
-                 "Should be 'true' or 'false': " <+> prettyTCM b
+        Con _ _ [Apply (Arg { unArg = x }), Apply (Arg { unArg = b })] -> do
+          unlessM (unquote b) $ putTC oldState
+          return x
         _ -> liftTCM $ typeError . GenericDocError =<<
           "Should be a pair: " <+> prettyTCM u

--- a/test/Succeed/ReflectionRunSpeculative.agda
+++ b/test/Succeed/ReflectionRunSpeculative.agda
@@ -1,0 +1,37 @@
+
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.List
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Reflection renaming (returnTC to return; bindTC to _>>=_)
+
+_>>_ : ∀ {a} {b} {A : Set a} {B : Set b}
+     → TC A → TC B → TC B
+x >> y = x >>= λ _ → y
+
+macro
+  false-oh-no-actually-true : Term → TC ⊤
+  false-oh-no-actually-true goal = do
+    runSpeculative (do
+      unify goal (con (quote false) [])
+      return (tt , false))
+    unify goal (con (quote true) [])
+
+  false-yes-really-false : Term → TC ⊤
+  false-yes-really-false goal =
+    runSpeculative (do
+      unify goal (con (quote false) [])
+      return (tt , true))
+
+test₁ : Bool
+test₁ = false-oh-no-actually-true
+
+_ : test₁ ≡ true
+_ = refl
+
+test₂ : Bool
+test₂ = false-yes-really-false
+
+_ : test₂ ≡ false
+_ = refl


### PR DESCRIPTION
Since the release is taking its time I would like to include the following new primitive which I have been using for a while for my WIP tactics library (https://github.com/jespercockx/ataca). It doesn't touch any existing code so it's unlikely to break anything, and it would allow other people to more easily experiment with tactics in Agda too.