### PR TITLE
[ cubical, doc, re #3539 ] Document the cubical mode properly

### DIFF
--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -148,7 +148,7 @@ elements, respectively.
 
 The core idea of Homotopy Type Theory and Univalent Foundations is a
 correspondence between paths (as in topology) and (proof-relevant)
-equality (as in Martin-Löf's identity type). This correspondence is
+equalities (as in Martin-Löf's identity type). This correspondence is
 taken very literally in Cubical Agda where a path in a type ``A`` is
 represented like a function out of the interval, ``I → A``. A
 path type is in fact a special case of the more general built-in

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -590,10 +590,10 @@ pattern-matching:
 ::
 
   t2c : Torus → S¹ × S¹
-  t2c point        = ( base , base )
-  t2c (line1 i)    = ( loop i , base )
-  t2c (line2 j)    = ( base , loop j )
-  t2c (square i j) = ( loop i , loop j )
+  t2c point        = (base   , base)
+  t2c (line1 i)    = (loop i , base)
+  t2c (line2 j)    = (base   , loop j)
+  t2c (square i j) = (loop i , loop j)
 
   c2t : S¹ × S¹ → Torus
   c2t (base   , base)   = point

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -538,8 +538,8 @@ follows:
   ua {_} {A} {B} e i = Glue B (λ { (i = i0) → (A , e)
                                  ; (i = i1) → (B , idEquiv B) })
 
-The idea is that we glue on ``A`` to ``B`` when ``i = i0`` using ``e``
-and ``B`` to itself when ``i = i1`` using the identity
+The idea is that we glue ``A`` together with ``B`` when ``i = i0``
+using ``e`` and ``B`` with itself when ``i = i1`` using the identity
 equivalence. This hence gives us the key part of univalence: a
 function for turning equivalences into paths. The other part of
 univalence is that this map itself is an equivalence which follows

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -275,10 +275,14 @@ when such an ``r`` should be thought of as being in the image of
 
 Using this we introduce a type of partial elements called ``Partial φ
 A``, this is a special version of ``IsOne φ → A`` with a more
-extensional judgmental equality. The idea is that ``Partial φ A`` is
-the type of cubes in ``A`` that are only defined when ``IsOne φ``.
-There is also a dependent version of this called ``PartialP φ A``
-which allows ``A`` to be defined only when ``IsOne φ``.
+extensional judgmental equality (two elements of ``Partial φ A`` are
+considered equal if they represent the same subcube, so the faces of
+the cubes can for example be given in different order and the two
+elements will still be considered the same). The idea is that
+``Partial φ A`` is the type of cubes in ``A`` that are only defined
+when ``IsOne φ``.  There is also a dependent version of this called
+``PartialP φ A`` which allows ``A`` to be defined only when ``IsOne
+φ``.
 
 .. code-block:: agda
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -736,9 +736,9 @@ However, even though this interface exists it is still recommended
 that one uses the cubical identity types unless one really need ``J``
 to compute on ``refl``. The reason for this is that the syntax for
 path types does not work for the identity types, making many proofs
-more involved as the only way to reason about them is using ``J``
-(furthermore, the path types satisfy many useful definitional
-equalities that the identity types don't).
+more involved as the only way to reason about them is using ``J``.
+Furthermore, the path types satisfy many useful definitional
+equalities that the identity types don't.
 
 References
 ----------

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -142,12 +142,12 @@ example, the following is not valid:
   refl : ∀ {a} {A : Set a} {x : A} → Path x x
   refl {x = x} = λ (i : I) → x
 
-A ``Path``` is in fact a special case of the more general built-in
+A ``Path`` is in fact a special case of the more general built-in
 heterogeneous path type:
 
 .. code-block:: agda
-                
-   -- PathP : ∀ {ℓ} (A : I → Set ℓ) → A i0 → A i1 → Set ℓ
+
+   PathP : ∀ {ℓ} (A : I → Set ℓ) → A i0 → A i1 → Set ℓ
 
    -- Non dependent path types
    Path : ∀ {ℓ} (A : Set ℓ) → A → A → Set ℓ
@@ -161,13 +161,18 @@ i → A) x y`` gets printed as ``x ≡ y`` when ``A`` does not mention
 By mapping out of more elements of the interval we can define squares,
 cubes, and higher cubes in Agda, making the type theory "cubical".
 
-For example a Square in A is built out of 4 points and 4 lines:
+For example a square in ``A`` is built out of 4 points and 4 lines:
 
-  Square : ∀ {ℓ} {A : Set ℓ} {a0 a1 b0 b1 : A} → a0 ≡ a1 → b0 ≡ b1 → a0 ≡ b0 → a1 ≡ b1 → Set ℓ
+.. code-block:: agda
+
+  Square : ∀ {ℓ} {A : Set ℓ} {a0 a1 b0 b1 : A} →
+             a0 ≡ a1 → b0 ≡ b1 → a0 ≡ b0 → a1 ≡ b1 → Set ℓ
   Square p q r s = PathP (λ i → p i ≡ q i) r s
 
 Viewing equalities as functions out of the interval makes it possible
 to do a lot of equality reasoning in a very direct way:
+
+.. code-block:: agda
 
   sym : ∀ {ℓ} {A : Set} {x y : A} → x ≡ y → y ≡ x
   sym p = λ i → p (~ i)
@@ -180,6 +185,8 @@ to do a lot of equality reasoning in a very direct way:
 Because of the way functions compute these satisfy some new
 definitional equalities:
 
+.. code-block:: agda
+
   sym sym = id
   cong refl = refl
   cong (f o g) = cong f o cong g
@@ -187,6 +194,8 @@ definitional equalities:
 that are not available in standard Agda. Furthermore, path types lets
 us prove new things are not true provable in standard Agda, for
 example function extensionality (pointwise equal functions are equal):
+
+.. code-block:: agda
 
   funExt : ∀ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} {f g : (x : A) → B x} →
              ((x : A) → f x ≡ g x) → f ≡ g
@@ -208,10 +217,15 @@ extensional judgmental equality. There is also a dependent version
 version called ``PartialP r A`` which allows ``A`` to be defined only
 when ``IsOne r``. The types of these are:
 
+.. code-block:: agda
+
   Partial : ∀ {ℓ} → I → Set ℓ → Setω
+
   PartialP : ∀ {ℓ} → (φ : I) → Partial φ (Set ℓ) → Setω
 
 Partial elements are introduced by pattern matching:
+
+.. code-block:: agda
 
   sys : ∀ i → Partial (i ∨ ~ i) Set₁
   sys i (i = i0) = Set
@@ -220,11 +234,15 @@ Partial elements are introduced by pattern matching:
 It also works with pattern matching lambdas:
 http://wiki.portal.chalmers.se/agda/pmwiki.php?n=ReferenceManual.PatternMatchingLambdas
 
+.. code-block:: agda
+
   sys' : ∀ i → Partial (i ∨ ~ i) Set₁
   sys' i = λ { (i = i0) → Set
              ; (i = i1) → Set → Set }
 
 When the cases overlap they must agree:
+
+.. code-block:: agda
 
   sys2 : ∀ i j → Partial (i ∨ (i ∧ j)) Set₁
   sys2 i j = λ { (i = i1)          → Set
@@ -232,27 +250,34 @@ When the cases overlap they must agree:
 
 Furthermore ``IsOne i0`` is actually absurd
 
+.. code-block:: agda
+
   sys3 : Partial i0 Set₁
   sys3 = λ { () }
 
-
 There are cubical subtypes as in CCHM:
+
+.. code-block:: agda
 
   _[_↦_] : ∀ {ℓ} (A : Set ℓ) (r : I) (u : Partial r A) → Setω
   A [ r ↦ u ] = Sub A r u
 
 Any element ``u : A`` can be seen as an element of ``A [ r ↦ u ]``
-which agrees with ``u`` on r:
+which agrees with ``u`` on ``r``:
+
+.. code-block:: agda
 
   inc : ∀ {ℓ} {A : Set ℓ} {r : I} (u : A) → A [ r ↦ (λ _ → u) ]
 
 One can also forget that an element agrees with ``u`` on ``r``:
 
+.. code-block:: agda
+
   ouc : ∀ {ℓ} {A : Set ℓ} {r : I} {u : Partial r A} → A [ r ↦ u ] → A
 
 
-Kan operations (transp and hcomp)
----------------------------------
+Kan operations (``transp`` and ``hcomp``)
+-----------------------------------------
 
 While path types are great for reasoning about equality they don't
 natively let us transport or compose, which in particular means that
@@ -260,12 +285,16 @@ we cannot prove the induction principle for paths. In order to remedy
 this we also have a builtin (generalized) transport operation and
 homogeneous composition. The transport operation is generalized in the
 sense that it lets us specify where the operation is the identity
-function 
+function
+
+.. code-block:: agda
 
   transp : ∀ {ℓ} (A : I → Set ℓ) (φ : I) (a : A i0) → A i1
 
-When calling "transp A φ a" Agda makes sure that "A" is constant on
-"φ". This lets us define normal transport as
+When calling ``transp A φ a`` Agda makes sure that ``A`` is constant
+on ``φ``. This lets us define regular transport as
+
+.. code-block:: agda
 
   transport : {A B : Set ℓ} → A ≡ B → A → B
   transport p a = transp (λ i → p i) i0 a
@@ -273,9 +302,11 @@ When calling "transp A φ a" Agda makes sure that "A" is constant on
 Combining the transport operation with the min operation lets us
 define path induction:
 
-module _ (P : ∀ y → x ≡ y → Set ℓ') (d : P x refl) where
-  J : (p : x ≡ y) → P y p
-  J p = transport (λ i → P (p i) (λ j → p (i ∧ j))) d
+.. code-block:: agda
+
+  module _ (P : ∀ y → x ≡ y → Set ℓ') (d : P x refl) where
+    J : (p : x ≡ y) → P y p
+    J p = transport (λ i → P (p i) (λ j → p (i ∧ j))) d
 
 One subtle difference between this and the propositional equality type
 of Agda is that the computation rule does not hold definitionally. If
@@ -283,32 +314,40 @@ the eliminator is defined using pattern-matching as in the standard
 library this holds, however as transport in a constant family is only
 the identity function up to a path we have to prove:
 
+.. code-block:: agda
+
   transportRefl : (x : A) → transport refl x ≡ x
   transportRefl {A = A} x i = transp (λ _ → A) i x
-  
+
   JRefl : J refl ≡ d
   JRefl = transportRefl d
 
 The homogeneous composition operations generalizes binary composition
-of paths so that we can compose multiple composable cubes. 
+of paths so that we can compose multiple composable cubes.
+
+.. code-block:: agda
 
   hcomp : ∀ {ℓ} {A : Set ℓ} {φ : I} (u : I → Partial φ A) (a : A) → A
 
-When calling "hcomp A φ u a" Agda makes sure that "a" agrees with "u
-i0" on "φ". The idea is that ``a`` is the base of the composition
-problem and ``u`` specify the sides of the problem so that we get an
-open higher dimensional cube (maybe with some sides missing) where the
-side opposite of ``a`` is missing. The ``hcomp`` operation then gives
-us the missing side of the cube. For example binary composition of
-paths can be written as
+When calling ``hcomp {φ = φ} u a`` Agda makes sure that ``a`` agrees
+with ``u i0`` on ``φ``. The idea is that ``a`` is the base of the
+composition problem and ``u`` specify the sides of the problem so that
+we get an open higher dimensional cube (maybe with some sides missing)
+where the side opposite of ``a`` is missing. The ``hcomp`` operation
+then gives us the missing side of the cube. For example binary
+composition of paths can be written as
+
+.. code-block:: agda
 
   compPath : x ≡ y → y ≡ z → x ≡ z
   compPath p q i =
     hcomp (λ j → \ { (i = i0) → p i0
                    ; (i = i1) → q j }) (p i)
 
-Given p : Path A x y and q : Path A y z the composite of the two paths
+Given ``p : x ≡ y`` and ``q : y ≡ z`` the composite of the two paths
 is obtained from a composition of this open square:
+
+.. code-block::
 
           x   -   -   -   - > z
           ^                   ^
@@ -322,13 +361,15 @@ is obtained from a composition of this open square:
                    p i
 
 The composition is the dashed line at the top of the square. The
-direction i goes left-to-right and j goes down-to-up. As we are
-constructing a path from x to z we have ``i : I`` in the context
-already which is why we have to put ``p i`` as bottom. The direction j
-that we are doing the composition in is abstracted in the first
-argument to ``hcomp``.
+direction ``i`` goes left-to-right and ``j`` goes down-to-up. As we
+are constructing a path from ``x`` to ``z`` we have ``i : I`` in the
+context already which is why we have to put ``p i`` as bottom. The
+direction ``j`` that we are doing the composition in is abstracted in
+the first argument to ``hcomp``.
 
 We can also define homogeneous filling of cubes as
+
+.. code-block:: agda
 
   hfill : {A : Set ℓ}
           {φ : I}
@@ -341,7 +382,8 @@ We can also define homogeneous filling of cubes as
                    ; (i = i0) → ouc u0 })
           (ouc u0)
 
-When i is i0 this is u0 and when i is i1 this is hcomp.
+When ``i`` is ``i0`` this is ``u0`` and when ``i`` is ``i1`` this is
+``hcomp``.
 
 
 Glue types
@@ -352,19 +394,33 @@ types. These lets us turn equivalences between types into paths. An
 equivalence of types ``A`` and ``B`` is defined as a map ``f : A → B``
 such that its fibers are contractible.
 
-  fiber
-  isContr
-  isEquiv
+.. code-block:: agda
+
+  fiber : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) (y : B) → Set (ℓ-max ℓ ℓ')
+  fiber {A = A} f y = Σ[ x ∈ A ] f x ≡ y
+
+  isContr : ∀ {ℓ} → Set ℓ → Set ℓ
+  isContr A = Σ[ x ∈ A ] (∀ y → x ≡ y)
+
+  record isEquiv {ℓ} {A : Set ℓ} {B : Set ℓ'} (f : A → B) : Set (ℓ-max ℓ ℓ') where
+    field
+      equiv-proof : (y : B) → isContr (fiber f y)
+
+  _≃_ : ∀ {ℓ} (A : Set ℓ) (B : Set ℓ') → Set (ℓ-max ℓ ℓ')
+  A ≃ B = Σ[ f ∈ (A → B) ] (isEquiv f)
 
 As everything has to work up to higher dimensions the Glue types take
 a partial family of types that are equivalent to the base type:
+
+.. code-block:: agda
 
   Glue : ∀ (A : Set ℓ) {φ : I}
          → (Te : Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A))
          → Set ℓ'
 
-
 These come with a constructor and eliminator:
+
+.. code-block:: agda
 
          glue         -- ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I} {T : Partial φ (Set ℓ')}
                                          -- → {e : PartialP φ (λ o → T o ≃ A)}
@@ -375,15 +431,20 @@ These come with a constructor and eliminator:
 
 Using Glue types we can turn an equivalence of types into a path as follows:
 
-ua : ∀ {A B : Set ℓ} → A ≃ B → A ≡ B
-ua {A = A} {B = B} e i = Glue B (λ { (i = i0) → (A , e)
-                                   ; (i = i1) → (B , idEquiv B) })
+.. code-block:: agda
 
-The idea is that we glue on A at when i is i0 using e and B when i is
-i1 using the identity equivalence. This hence gives us the key part of
-univalence: equivalences are paths. The other part of univalence is
-that this map itself is an equivalence which follows from the
-computation rule for ua:
+  ua : ∀ {A B : Set ℓ} → A ≃ B → A ≡ B
+  ua {A = A} {B = B} e i = Glue B (λ { (i = i0) → (A , e)
+                                     ; (i = i1) → (B , idEquiv B) })
+
+The idea is that we glue on ``A`` to ``B`` when ``i`` is ``i0`` using
+``e`` and ``B`` when ``i`` is ``i1`` using the identity
+equivalence. This hence gives us the key part of univalence:
+equivalences are paths. The other part of univalence is that this map
+itself is an equivalence which follows from the computation rule for
+ua:
+
+.. code-block:: agda
 
   uaβ : ∀ {ℓ} {A B : Set ℓ} (e : A ≃ B) (x : A) → transport (ua e) x ≡ e .fst x
   uaβ e x = transportRefl (e .fst x)
@@ -401,6 +462,8 @@ Cubical Agda also lets us directly define higher inductive types as
 datatypes with path constructors. For example the circle and torus can
 be defined as:
 
+.. code-block:: agda
+
   data S¹ : Set where
     base : S¹
     loop : base ≡ base
@@ -413,7 +476,9 @@ be defined as:
 
 Functions out of higher inductive types can then be defined by
 pattern-matching:
-    
+
+.. code-block:: agda
+
   t2c : Torus → S¹ × S¹
   t2c point        = ( base , base )
   t2c (line1 i)    = ( loop i , base )
@@ -427,7 +492,10 @@ pattern-matching:
   c2t (loop i , loop j) = square i j
 
 When giving the cases for the path and square constructors we have to
-make sure that the function maps the boundary to the right things. For instance if we would do:
+make sure that the function maps the boundary to the right things. For
+instance if we would do:
+
+.. code-block:: agda
 
   c2t' : S¹ × S¹ → Torus
   c2t' (base   , base)   = point
@@ -440,7 +508,9 @@ the last case does not match up with the expected boundary of the
 square constructor).
 
 These compute judgmentally:
-  
+
+.. code-block:: agda
+
   c2t-t2c : ∀ (t : Torus) → c2t (t2c t) ≡ t
   c2t-t2c point        = refl
   c2t-t2c (line1 _)    = refl
@@ -455,13 +525,16 @@ These compute judgmentally:
 
 By turning this isomorphism into an equivalence we get a direct proof
 that the Torus is equal to two circles:
-  
+
+.. code-block:: agda
+
   Torus≡S¹×S¹ : Torus ≡ S¹ × S¹
   Torus≡S¹×S¹ = isoToPath (iso t2c c2t t2c-c2t c2t-t2c)
 
-
 Cubical Agda also supports parametrized and recursive HITs. For
 example propositional truncation is defined as:
+
+.. code-block:: agda
 
   data ∥_∥ {ℓ} (A : Set ℓ) : Set ℓ where
     ∣_∣ : A → ∥ A ∥

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -20,7 +20,9 @@
           ; equiv-proof
           ; _≃_
           ; primGlue )
+
   open import Agda.Builtin.Sigma public
+  open import Agda.Builtin.Bool public
 
   infix 2 Σ-syntax
 
@@ -59,7 +61,7 @@ The cubical mode adds the following features to Agda:
 
 1. An interval type and path types
 2. Generalized transport (``transp``)
-3. Partial elements and systems
+3. Partial elements
 4. Homogeneous composition (``hcomp``)
 5. Glue types
 6. Higher inductive types
@@ -303,8 +305,8 @@ generalize binary composition of paths to n-ary composition of higher
 dimensional cubes.
 
 
-Partial elements and systems
-----------------------------
+Partial elements
+----------------
 
 In order to describe the homogeneous composition operations we need to
 be able to write partially specified n-dimensional cubes (i.e. cubes
@@ -336,35 +338,37 @@ Partial elements are introduced using pattern matching:
 
 ::
 
-  sys : ∀ i → Partial (i ∨ ~ i) Set₁
-  sys i (i = i0) = Set
-  sys i (i = i1) = Set → Set
+  partialBool : ∀ i → Partial (i ∨ ~ i) Bool
+  partialBool i (i = i0) = true
+  partialBool i (i = i1) = false
 
-The term ``sys`` is hence only defined when ``IsOne (i ∨ ~ i)``, that
-is, when ``(i = i0) ∨ (i = i1)``. Terms of type ``Partial φ A`` can
-also be introduced using pattern matching lambdas
+The term ``partialBool`` should be thought of a boolean with different
+values when ``(i = i0)`` and ``(i = i1)``. Terms of type ``Partial φ
+A`` can also be introduced using pattern matching lambdas
 (http://wiki.portal.chalmers.se/agda/pmwiki.php?n=ReferenceManual.PatternMatchingLambdas).
 
 ::
 
-  sys' : ∀ i → Partial (i ∨ ~ i) Set₁
-  sys' i = λ { (i = i0) → Set
-             ; (i = i1) → Set → Set }
+  partialBool' : ∀ i → Partial (i ∨ ~ i) Bool
+  partialBool' i = λ { (i = i0) → true
+                     ; (i = i1) → false }
 
-When the cases overlap they must agree:
+When the cases overlap they must agree (note that the order of the
+cases doesn't have to match the interval formula exactly):
 
 ::
 
-  sys2 : ∀ i j → Partial (i ∨ (i ∧ j)) Set₁
-  sys2 i j = λ { (i = i1)          → Set
-               ; (i = i1) (j = i1) → Set }
+  partialBool'' : ∀ i j → Partial (~ i ∨ i ∨ (i ∧ j)) Bool
+  partialBool'' i j = λ { (i = i1)          → true
+                        ; (i = i1) (j = i1) → true
+                        ; (i = i0)          → false }
 
 Furthermore ``IsOne i0`` is actually absurd
 
 ::
 
-  sys3 : Partial i0 Set₁
-  sys3 = λ { () }
+  empty : {A : Set} → Partial i0 A
+  empty = λ { () }
 
 Cubical Agda also has cubical subtypes as in the CCHM type theory:
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -434,7 +434,7 @@ this open square:
                p i
 
 In the drawing the direction ``i`` goes left-to-right and ``j`` goes
-down-to-up. As we are constructing a path from ``x`` to ``z`` along
+bottom-to-top. As we are constructing a path from ``x`` to ``z`` along
 ``i`` we have ``i : I`` in the context already and we put ``p i`` as
 bottom. The direction ``j`` that we are doing the composition in is
 abstracted in the first argument to ``hcomp``.

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -334,7 +334,7 @@ when ``IsOne φ``.  There is also a dependent version of this called
 
   PartialP : ∀ {ℓ} → (φ : I) → Partial φ (Set ℓ) → Setω
 
-Partial elements are introduced using pattern matching:
+There is a new form of pattern matching that can be used to introduce partial elements:
 
 ::
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -227,7 +227,7 @@ Transport
 ---------
 
 While path types are great for reasoning about equality they don't let
-us transport along paths between types or even compose path, which in
+us transport along paths between types or even compose paths, which in
 particular means that we cannot yet prove the induction principle for
 paths. In order to remedy this we also have a built-in (generalized)
 transport operation and homogeneous composition operations. The

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -197,17 +197,19 @@ are equal):
 Partial elements and systems
 ----------------------------
 
-Path types lets us specify n-dimensional cubes, it is also useful to
-be able to specify subcubes. Given an element of the interval ``r :
+In order to describe the homogenous composition operations we need to
+be able to write partially specified n-dimensional cubes (i.e. cubes
+where some faces are missing). Given an element of the interval ``r :
 I`` there is a predicate ``IsOne`` which represents the constraint ``r
-= i1``. This comes with a proof that ``ì1`` is actually ``i1`` called
-``1=1 : IsOne i1``.
+= i1``. This comes with a proof that ``i1`` is equal to ``i1`` called
+``1=1 : IsOne i1``. We use the letter ``φ`` when such an ``r`` should
+be thought of as being in the image of ``IsOne``.
 
-Using this we introduce a type of partial elements called ``Partial r
-a``, this is a special version of ``IsOne r → A`` with a more
+Using this we introduce a type of partial elements called ``Partial φ
+A``, this is a special version of ``IsOne φ → A`` with a more
 extensional judgmental equality. There is also a dependent version
-version called ``PartialP r A`` which allows ``A`` to be defined only
-when ``IsOne r``. The types of these are:
+version called ``PartialP φ A`` which allows ``A`` to be defined only
+when ``IsOne φ``. The types of these are:
 
 .. code-block:: agda
 
@@ -251,21 +253,21 @@ There are cubical subtypes as in CCHM:
 
 .. code-block:: agda
 
-  _[_↦_] : ∀ {ℓ} (A : Set ℓ) (r : I) (u : Partial r A) → Setω
-  A [ r ↦ u ] = Sub A r u
+  _[_↦_] : ∀ {ℓ} (A : Set ℓ) (φ : I) (u : Partial φ A) → Setω
+  A [ φ ↦ u ] = Sub A φ u
 
-Any element ``u : A`` can be seen as an element of ``A [ r ↦ u ]``
-which agrees with ``u`` on ``r``:
-
-.. code-block:: agda
-
-  inc : ∀ {ℓ} {A : Set ℓ} {r : I} (u : A) → A [ r ↦ (λ _ → u) ]
-
-One can also forget that an element agrees with ``u`` on ``r``:
+Any element ``u : A`` can be seen as an element of ``A [ φ ↦ u ]``
+which agrees with ``u`` on ``φ``:
 
 .. code-block:: agda
 
-  ouc : ∀ {ℓ} {A : Set ℓ} {r : I} {u : Partial r A} → A [ r ↦ u ] → A
+  inc : ∀ {ℓ} {A : Set ℓ} {φ : I} (u : A) → A [ φ ↦ (λ _ → u) ]
+
+One can also forget that an element agrees with ``u`` on ``φ``:
+
+.. code-block:: agda
+
+  ouc : ∀ {ℓ} {A : Set ℓ} {φ : I} {u : Partial φ A} → A [ φ ↦ u ] → A
 
 
 Kan operations (``transp`` and ``hcomp``)

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -509,31 +509,25 @@ inverse): https://github.com/agda/cubical/blob/master/Cubical/Foundations/Isomor
 As everything has to work up to higher dimensions the Glue types take
 a partial family of types that are equivalent to the base type ``A``:
 
-.. code-block:: agda
+::
 
-  primGlue : ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I} (T : Partial φ (Set ℓ'))
-           → (e : PartialP φ (λ o → T o ≃ A)) → Set ℓ'
+  Glue : ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I}
+       → Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A) → Set ℓ'
+
+..
+  ::
+
+  Glue A Te = primGlue A (λ x → Te x .fst) (λ x → Te x .snd)
 
 These come with a constructor and eliminator:
 
 .. code-block:: agda
 
-  glue : ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I} {T : Partial φ (Set ℓ')}
-           {e : PartialP φ (λ o → T o ≃ A)}
-         → PartialP φ T → A → primGlue A T e
+  glue : ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I} {Te : Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A)}
+       → PartialP φ T → A → Glue A Te
 
-  unglue : ∀ {ℓ ℓ'} {A : Set ℓ} (φ : I) {T : Partial φ (Set ℓ')}
-             {e : PartialP φ (λ o → T o ≃ A)} → primGlue A T e → A
-
-In the cubical library we uncurry the Glue types to make them more
-pleasant to use:
-
-::
-
-  Glue : ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I}
-         → (Te : Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A))
-         → Set ℓ'
-  Glue A Te = primGlue A (λ x → Te x .fst) (λ x → Te x .snd)
+  unglue : ∀ {ℓ ℓ'} {A : Set ℓ} (φ : I) {Te : Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A)}
+         → Glue A Te → A
 
 Using Glue types we can turn an equivalence of types into a path as
 follows:
@@ -895,6 +889,16 @@ The Glue types are exported by ``Agda.Builtin.Cubical.Glue``:
   -- pathToEquiv proves that transport is an equivalence (for details
   -- see Agda.Builtin.Cubical.Glue). This is needed internally.
   {-# BUILTIN PATHTOEQUIV pathToEquiv #-}
+
+Note that the Glue types are uncurried in ``agda/cubical`` to make
+them more pleasant to use:
+
+.. code-block:: agda
+
+  Glue : ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I}
+       → (Te : Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A))
+       → Set ℓ'
+  Glue A Te = primGlue A (λ x → Te x .fst) (λ x → Te x .snd)
 
 The ``Agda.Builtin.Cubical.Id`` exports the cubical identity types:
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -198,24 +198,25 @@ are equal):
 Transport
 ---------
 
-While path types are great for reasoning about equality they don't
-natively let us transport or compose, which in particular means that
-we cannot prove the induction principle for paths. In order to remedy
-this we also have a builtin (generalized) transport operation and
-homogeneous composition. The transport operation is generalized in the
-sense that it lets us specify where the operation is the identity
-function
+While path types are great for reasoning about equality they don't let
+us transport along paths between types or even compose path, which in
+particular means that we cannot prove the induction principle for
+paths yet. In order to remedy this we also have a builtin
+(generalized) transport operation and homogeneous composition. The
+transport operation is generalized in the sense that it lets us
+specify where the operation is the identity function
 
 .. code-block:: agda
 
   transp : ∀ {ℓ} (A : I → Set ℓ) (φ : I) (a : A i0) → A i1
 
 When calling ``transp A φ a`` Agda makes sure that ``A`` is constant
-on ``φ``. This lets us define regular transport as
+on ``φ`` so that ``transp A i1 a`` is ``a`` definitionally. This lets
+us define regular transport as
 
 .. code-block:: agda
 
-  transport : {A B : Set ℓ} → A ≡ B → A → B
+  transport : ∀ {ℓ} {A B : Set ℓ} → A ≡ B → A → B
   transport p a = transp (λ i → p i) i0 a
 
 Combining the transport operation with the min operation lets us
@@ -223,9 +224,8 @@ define path induction:
 
 .. code-block:: agda
 
-  module _ (P : ∀ y → x ≡ y → Set ℓ') (d : P x refl) where
-    J : (p : x ≡ y) → P y p
-    J p = transport (λ i → P (p i) (λ j → p (i ∧ j))) d
+  J : ∀ {ℓ} {A : Set ℓ} {x : A} (P : ∀ y → x ≡ y → Set ℓ) (d : P x refl) {y : A} (p : x ≡ y) → P y p
+  J P d p = transport (λ i → P (p i) (λ j → p (i ∧ j))) d
 
 One subtle difference between this and the propositional equality type
 of Agda is that the computation rule does not hold definitionally. If
@@ -235,11 +235,11 @@ the identity function up to a path we have to prove:
 
 .. code-block:: agda
 
-  transportRefl : (x : A) → transport refl x ≡ x
+  transportRefl : ∀ {ℓ} {A : Set ℓ} (x : A) → transport refl x ≡ x
   transportRefl {A = A} x i = transp (λ _ → A) i x
 
-  JRefl : J refl ≡ d
-  JRefl = transportRefl d
+  JRefl : ∀ {ℓ} {A : Set ℓ} {x : A} (P : ∀ y → x ≡ y → Set ℓ) (d : P x refl) → J P d refl ≡ d
+  JRefl P d = transportRefl d
 
 Internally in Agda the ``transp`` operations reduce by cases on the
 type, so for Sigma types they are computed pointwise and for dependent

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -219,7 +219,7 @@ us define regular transport as
   transport : ∀ {ℓ} {A B : Set ℓ} → A ≡ B → A → B
   transport p a = transp (λ i → p i) i0 a
 
-Combining the transport operation with the min operation lets us
+Combining the transport operation with the min operation then lets us
 define path induction:
 
 .. code-block:: agda
@@ -231,7 +231,8 @@ One subtle difference between this and the propositional equality type
 of Agda is that the computation rule does not hold definitionally. If
 the eliminator is defined using pattern-matching as in the standard
 library this holds, however as transport in a constant family is only
-the identity function up to a path we have to prove:
+the identity function up to a path we have to prove the computation
+rule up to a path:
 
 .. code-block:: agda
 
@@ -241,12 +242,12 @@ the identity function up to a path we have to prove:
   JRefl : ∀ {ℓ} {A : Set ℓ} {x : A} (P : ∀ y → x ≡ y → Set ℓ) (d : P x refl) → J P d refl ≡ d
   JRefl P d = transportRefl d
 
-Internally in Agda the ``transp`` operations reduce by cases on the
-type, so for Sigma types they are computed pointwise and for dependent
-function types they use a direct back-and-forth algorithm (because of
-contravariance). For Path types it is not yet possible to provide the
-computation rules as we need some way to track the end-points of the
-path after transporting. For this we introduce the homogeneous
+Internally in Agda the ``transp`` operations computes by cases on the
+type, for example for Sigma types they are computed pointwise. For
+Path types it is however not yet possible to provide the computation
+rule as we need some way to keep track the end-points of the path
+after transporting it. Furthermore, this must work for arbitrary
+higher dimensional cubes. For this we introduce the homogeneous
 composition operations that generalize binary composition of paths to
 n-ary composition of higher dimensional cubes.
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -94,7 +94,7 @@ details of Agda's library management see :ref:`package-system`.
 
 Expert users who doesn't want to rely on ``agda/cubical`` can just add
 the relevant import statements at the top of their file (for details
-for experts see :ref:`primitives-ref`). However, for beginners it is
+see :ref:`primitives-ref`). However, for beginners it is
 recommended that one uses at least the core part of the
 ``agda/cubical`` library.
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -77,12 +77,9 @@ Elements of the interval form a `De Morgan algebra
 
 .. code-block:: agda
 
-    max, min : I → I → I
-    max i j = i ∨ j
-    min i j = i ∧ j
+  _∧_, _∨_ : I → I → I
 
-    neg : I → I
-    neg i = ~ i
+  ~_ : I → I
 
 All the properties of de Morgan algebras hold definitionally. The
 endpoints of the interval ``i0`` and ``i1`` are the bottom and top
@@ -317,9 +314,10 @@ There are cubical subtypes as in CCHM:
   _[_↦_] : ∀ {ℓ} (A : Set ℓ) (φ : I) (u : Partial φ A) → Setω
   A [ φ ↦ u ] = Sub A φ u
 
-A term ``v : A [ φ ↦ u ]`` is of type ``A`` and when ``IsOne φ`` it
-must be definitionally equal to ``u``. Any term ``u : A`` can be seen
-as an term of ``A [ φ ↦ u ]`` which agrees with ``u`` on ``φ``:
+A term ``v : A [ φ ↦ u ]`` is of type ``v : A`` and when ``IsOne φ``
+it must be definitionally equal to ``u : A``. Any term ``u : A`` can
+be seen as an term of ``A [ φ ↦ u ]`` which agrees with itself on
+``φ``:
 
 .. code-block:: agda
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -739,6 +739,16 @@ which computes properly.
            ; ∥∥-induction    -- Dependent elimination.
            )
 
+In order to get access to only the HoTT/UF primitives start a file as
+follows:
+
+.. code-block:: agda
+
+  {-# OPTIONS --cubical #-}
+  module MyModule where
+
+  open import Cubical.Core.HoTT-UF
+
 However, even though this interface exists it is still recommended
 that one uses the cubical identity types unless one really need ``J``
 to compute on ``refl``. The reason for this is that the syntax for

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -325,7 +325,7 @@ as an term of ``A [ φ ↦ u ]`` which agrees with ``u`` on ``φ``:
 
   inc : ∀ {ℓ} {A : Set ℓ} {φ : I} (u : A) → A [ φ ↦ (λ _ → u) ]
 
-One can also forget that an element agrees with ``u`` on ``φ``:
+One can also forget that a partial element agrees with ``u`` on ``φ``:
 
 .. code-block:: agda
 
@@ -343,13 +343,13 @@ of paths so that we can compose multiple composable cubes.
 
 .. code-block:: agda
 
-  hcomp : ∀ {ℓ} {A : Set ℓ} {φ : I} (u : I → Partial φ A) (a : A) → A
+  hcomp : ∀ {ℓ} {A : Set ℓ} {φ : I} (u : I → Partial φ A) (u0 : A) → A
 
-When calling ``hcomp {φ = φ} u a`` Agda makes sure that ``a`` agrees
-with ``u i0`` on ``φ``. The idea is that ``a`` is the base of the
+When calling ``hcomp {φ = φ} u u0`` Agda makes sure that ``u0`` agrees
+with ``u i0`` on ``φ``. The idea is that ``u0`` is the base of the
 composition problem and ``u`` specify the sides of the problem so that
 we get an open higher dimensional cube (maybe with some sides missing)
-where the side opposite of ``a`` is missing. The ``hcomp`` operation
+where the side opposite of ``u0`` is missing. The ``hcomp`` operation
 then gives us the missing side of the cube. For example binary
 composition of paths can be written as
 
@@ -375,10 +375,10 @@ this open square:
                p i
 
 In the drawing the direction ``i`` goes left-to-right and ``j`` goes
-down-to-up. As we are constructing a path from ``x`` to ``z`` we have
-``i : I`` in the context already which is why we have to put ``p i``
-as bottom. The direction ``j`` that we are doing the composition in is
-abstracted in the first argument to ``hcomp``.
+down-to-up. As we are constructing a path from ``x`` to ``z`` along
+``i`` we have ``i : I`` in the context already which is why we have to
+put ``p i`` as bottom. The direction ``j`` that we are doing the
+composition in is abstracted in the first argument to ``hcomp``.
 
 We can also define homogeneous filling of cubes as
 
@@ -396,10 +396,9 @@ We can also define homogeneous filling of cubes as
           (ouc u0)
 
 When ``i`` is ``i0`` this is ``u0`` and when ``i`` is ``i1`` this is
-``hcomp``.
-
-This gives a direct cubical proof that composing a path ``p`` with
-``refl`` is ``p``
+``hcomp``. This can hence be seen as giving us the interior of an open
+square. In the special case of the square above the filler gives us a
+direct cubical proof that composing ``p`` with ``refl`` is ``p``
 
 .. code-block:: agda
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -232,9 +232,21 @@ specify where it is the identity function
 
   transp : ∀ {ℓ} (A : I → Set ℓ) (r : I) (a : A i0) → A i1
 
-When calling ``transp A r a`` Agda makes sure that ``A`` is constant
-on ``r`` so that ``transp A i1 a`` is definitionally ``a``. This lets
-us define regular transport as
+There is an additional side condition to be satisfied for ``transp A r
+a`` to type-check, which is that ``A`` has to be *constant* on
+``r``. This means that ``A`` should be a constant function whenever
+the constraint ``r = i1`` is satisfied.  This side condition is
+vacuously true when ``r`` is ``i0``, so there is nothing to check when
+writing ``transp A i0 a``. However when ``r`` is equal to `i1` the
+``transp`` function will compute as the identity function
+
+.. code-block:: agda
+
+   transp A i1 a = a
+
+and this requires ``A`` to be constant for it to be well-typed.
+
+We can use `transp` to define regular transport:
 
 ::
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -314,7 +314,7 @@ where some faces are missing). Given an element of the interval ``r :
 I`` there is a predicate ``IsOne`` which represents the constraint ``r
 = i1``. This comes with a proof that ``i1`` is in fact equal to ``i1``
 called ``1=1 : IsOne i1``. We use Greek letters like ``φ`` or ``ψ``
-when such an ``r`` should be thought of as being in the image of
+when such an ``r`` should be thought of as being in the domain of
 ``IsOne``.
 
 Using this we introduce a type of partial elements called ``Partial φ

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -133,29 +133,16 @@ elements, respectively.
 
 .. code-block:: agda
 
-  module interval-equations (i j : I) where
-    data _≡_ (i : I) : I → Setω where
-      reflI : i ≡ i
-
-    infix 10 _≡_
-
-    p₁ : i0 ∨ i    ≡ i
-    p₂ : i  ∨ i1   ≡ i1
-    p₃ : i  ∨ j    ≡ j ∨ i
-    p₄ : i  ∧ j    ≡ j ∧ i
-    p₅ : ~ (~ i)   ≡ i
-    p₆ : i0        ≡ ~ i1
-    p₇ : ~ (i ∨ j) ≡ ~ i ∧ ~ j
-    p₈ : ~ (i ∧ j) ≡ ~ i ∨ ~ j
-
-    p₁ = reflI
-    p₂ = reflI
-    p₃ = reflI
-    p₄ = reflI
-    p₅ = reflI
-    p₆ = reflI
-    p₇ = reflI
-    p₈ = reflI
+    i0 ∨ i    = i
+    i  ∨ i1   = i1
+    i  ∨ j    = j ∨ i
+    i0 ∧ i    = i0
+    i1 ∧ i    = i
+    i  ∧ j    = j ∧ i
+    ~ (~ i)   = i
+    i0        = ~ i1
+    ~ (i ∨ j) = ~ i ∧ ~ j
+    ~ (i ∧ j) = ~ i ∨ ~ j
 
 The core idea of Homotopy Type Theory and Univalent Foundations is a
 correspondence between paths (as in topology) and (proof-relevant)

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -133,7 +133,8 @@ heterogeneous path types:
 The central notion of equality in Cubical Agda is hence heterogeneous
 (which is sometimes called "John Major equality"). To define paths we
 use λ-abstractions and to apply them we use regular application.  For
-example, this is the definition of the constant path:
+example, this is the definition of the constant path (or proof of
+reflexivity):
 
 .. code-block:: agda
 
@@ -221,8 +222,8 @@ us define regular transport as
   transport : ∀ {ℓ} {A B : Set ℓ} → A ≡ B → A → B
   transport p a = transp (λ i → p i) i0 a
 
-Combining the transport and min operations then lets us define path
-induction:
+By combining the transport and min operations we can define the
+induction principle for paths:
 
 .. code-block:: agda
 
@@ -231,14 +232,14 @@ induction:
       → P y p
   J P d p = transport (λ i → P (p i) (λ j → p (i ∧ j))) d
 
-One subtle difference between this and the propositional equality type
-of Agda is that the computation rule for ``J`` does not hold
+One subtle difference between paths and the propositional equality
+type of Agda is that the computation rule for ``J`` does not hold
 definitionally. If ``J`` is defined using pattern-matching as in the
 standard library then this holds, however as the path types are not
 inductively defined this does not hold for the above definition of
 ``J``. In particular, transport in a constant family is only the
-identity function up to a path from which we can prove the computation
-rule up to a path:
+identity function up to a path which implies that the computation rule
+for ``J`` only holds up to a path:
 
 .. code-block:: agda
 
@@ -246,13 +247,13 @@ rule up to a path:
   transportRefl {A = A} x i = transp (λ _ → A) i x
 
   JRefl : ∀ {ℓ} {A : Set ℓ} {x : A} (P : ∀ y → x ≡ y → Set ℓ)
-            (d : P x refl) → J P d refl ≡ d
+           (d : P x refl) → J P d refl ≡ d
   JRefl P d = transportRefl d
 
-Internally in Agda the ``transp`` operations computes by cases on the
+Internally in Agda the ``transp`` operation computes by cases on the
 type, so for example for Sigma types it is computed elementwise. For
-Path types it is however not yet possible to provide the computation
-rule as we need some way to keep track the endpoints of the path after
+path types it is however not yet possible to provide the computation
+rule as we need some way to remember the endpoints of the path after
 transporting it. Furthermore, this must work for arbitrary higher
 dimensional cubes (as we can iterate the path types). For this we
 introduce the "homogeneous composition operations" (``hcomp``) that
@@ -285,7 +286,7 @@ which allows ``A`` to be defined only when ``IsOne φ``.
 
   PartialP : ∀ {ℓ} → (φ : I) → Partial φ (Set ℓ) → Setω
 
-Partial elements are introduced by pattern matching:
+Partial elements are introduced using pattern matching:
 
 .. code-block:: agda
 
@@ -293,10 +294,10 @@ Partial elements are introduced by pattern matching:
   sys i (i = i0) = Set
   sys i (i = i1) = Set → Set
 
-The term ``sys`` is hence only defined when ``IsOne (i ∨ ~ i)`` which
-is when ``(i = i0) ∨ (i = i1)``. Terms of type ``Partial`` can also be
-introduced using pattern matching lambdas:
-http://wiki.portal.chalmers.se/agda/pmwiki.php?n=ReferenceManual.PatternMatchingLambdas
+The term ``sys`` is hence only defined when ``IsOne (i ∨ ~ i)``, that
+is, when ``(i = i0) ∨ (i = i1)``. Terms of type ``Partial φ A`` can
+also be introduced using pattern matching lambdas
+(http://wiki.portal.chalmers.se/agda/pmwiki.php?n=ReferenceManual.PatternMatchingLambdas).
 
 .. code-block:: agda
 
@@ -319,7 +320,7 @@ Furthermore ``IsOne i0`` is actually absurd
   sys3 : Partial i0 Set₁
   sys3 = λ { () }
 
-There are cubical subtypes as in the CCHM system:
+Cubical Agda also has cubical subtypes as in the CCHM type theory:
 
 .. code-block:: agda
 
@@ -405,17 +406,17 @@ We can also define homogeneous filling of cubes as
 
 When ``i`` is ``i0`` this is ``u0`` and when ``i`` is ``i1`` this is
 ``hcomp``. This can hence be seen as giving us the interior of an open
-box. In the special case of the square above the filler gives us a
-direct cubical proof that composing ``p`` with ``refl`` is ``p``
+box. In the special case of the square above ``hfill`` gives us a
+direct cubical proof that composing ``p`` with ``refl`` is ``p``.
 
 .. code-block:: agda
 
   compPathRefl : ∀ {ℓ} {A : Set ℓ} {x y : A} (p : x ≡ y) → compPath p refl ≡ p
   compPathRefl {x = x} {y = y} p j i =
     hfill (λ _ → λ { (i = i0) → x
-                   ; (i = i1) → y })
-          (inc (p i))
-          (~ j)
+                  ; (i = i1) → y })
+         (inc (p i))
+         (~ j)
 
 
 Glue types
@@ -423,8 +424,8 @@ Glue types
 
 In order to be able to prove the univalence theorem we also have to
 add "Glue types". These lets us turn equivalences between types into
-paths. An equivalence of types ``A`` and ``B`` is defined as a map ``f
-: A → B`` such that its fibers are contractible.
+paths between types. An equivalence of types ``A`` and ``B`` is
+defined as a map ``f : A → B`` such that its fibers are contractible.
 
 .. code-block:: agda
 
@@ -451,7 +452,7 @@ a partial family of types that are equivalent to the base type ``A``:
 .. code-block:: agda
 
   primGlue : ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I} (T : Partial φ (Set ℓ'))
-         → (e : PartialP φ (λ o → T o ≃ A)) → Set ℓ'
+           → (e : PartialP φ (λ o → T o ≃ A)) → Set ℓ'
 
 These come with a constructor and eliminator:
 
@@ -464,7 +465,7 @@ These come with a constructor and eliminator:
   unglue : ∀ {ℓ ℓ'} {A : Set ℓ} (φ : I) {T : Partial φ (Set ℓ')}
              {e : PartialP φ (λ o → T o ≃ A)} → primGlue A T e → A
 
-In the standard library we uncurry the Glue types to make them more
+In the cubical library we uncurry the Glue types to make them more
 pleasant to use:
 
 .. code-block:: agda
@@ -496,10 +497,10 @@ from the computation rule for ``ua``:
   uaβ e x = transportRefl (e .fst x)
 
 Transporting along the path that we get from applying ``ua`` to an
-equivalence is the same as applying the equivalence. This is what
-makes it possible to use the univalence axiom computationally in
-Cubical Agda: we can package our equivalences as paths, do equality
-reasoning using these paths, and in the end transport along the path
+equivalence is hence the same as applying the equivalence. This is
+what makes it possible to use the univalence axiom computationally in
+Cubical Agda: we can package up our equivalences as paths, do equality
+reasoning using these paths, and in the end transport along the paths
 in order to compute with them.
 
 For more results about Glue types and univalence see
@@ -514,8 +515,8 @@ Higher inductive types
 ----------------------
 
 Cubical Agda also lets us directly define higher inductive types as
-datatypes with path constructors. For example the circle and torus can
-be defined as:
+datatypes with path constructors. For example the circle and `torus
+<https://en.wikipedia.org/wiki/Torus>`_ can be defined as:
 
 .. code-block:: agda
 
@@ -529,7 +530,7 @@ be defined as:
     line2 : point ≡ point
     square : PathP (λ i → line1 i ≡ line1 i) line2 line2
 
-Functions out of higher inductive types can then be defined by
+Functions out of higher inductive types can then be defined using
 pattern-matching:
 
 .. code-block:: agda
@@ -547,20 +548,21 @@ pattern-matching:
   c2t (loop i , loop j) = square i j
 
 When giving the cases for the path and square constructors we have to
-make sure that the function maps the boundary to the right things. For
-instance the following definition does not pass Agda's typechecker (as
+make sure that the function maps the boundary to the right thing. For
+instance the following definition does not pass Agda's typechecker as
 the boundary of the last case does not match up with the expected
-boundary of the square constructor).
+boundary of the square constructor.
 
 .. code-block:: agda
 
-  c2t' : S¹ × S¹ → Torus
-  c2t' (base   , base)   = point
-  c2t' (loop i , base)   = line2 i
-  c2t' (base   , loop j) = line1 j
-  c2t' (loop i , loop j) = square i j
+  c2t_bad : S¹ × S¹ → Torus
+  c2t_bad (base   , base)   = point
+  c2t_bad (loop i , base)   = line2 i
+  c2t_bad (base   , loop j) = line1 j
+  c2t_bad (loop i , loop j) = square i j
 
-These function compute judgmentally, for all constructors:
+Functions defined by pattern-matching on higher inductive types
+compute definitionally, for all constructors.
 
 .. code-block:: agda
 
@@ -577,7 +579,7 @@ These function compute judgmentally, for all constructors:
   t2c-c2t (loop _ , loop _) = refl
 
 By turning this isomorphism into an equivalence we get a direct proof
-that the Torus is equal to two circles:
+that the torus is equal to two circles.
 
 .. code-block:: agda
 
@@ -600,27 +602,27 @@ is defined as:
     Pprop (recPropTrunc Pprop f x) (recPropTrunc Pprop f y) i
 
 For many more examples of higher inductive types see:
-https://github.com/agda/cubical/tree/master/Cubical/HITs
+https://github.com/agda/cubical/tree/master/Cubical/HITs.
 
 Cubical identity types and computational HoTT/UF
 ------------------------------------------------
 
 As mentioned above the computation rule for ``J`` does not hold
-definitionally for path types. Cubical Agda fixes this by introducing
-a Cubical Identity type. The
+definitionally for path types. Cubical Agda solves this by introducing
+a cubical identity type. The
 https://github.com/agda/cubical/blob/master/Cubical/Core/Id.agda file
 exports all of the primitives for this type, including the notation
 ``_≡_`` and a ``J`` eliminator that computes definitionally on
 ``refl``.
 
-The Cubical Identity type and the path type are equivalent, so all of
-the results for one can be transported to the other (using
-univalence). Using this we provide an interface to HoTT/UF in
+The cubical identity type and the path type are equivalent, so all of
+the results for one can be transported to the other one (using
+univalence). Using this we have implemented an interface to HoTT/UF in
 https://github.com/agda/cubical/blob/master/Cubical/Core/HoTT-UF.agda
-which provides the user with all of the primitives of Homotopy Type
-Theory and Univalent Foundations implemented using Cubical primitives
+which provides the user with the key primitives of Homotopy Type
+Theory and Univalent Foundations implemented using cubical primitives
 under the hood. This hence gives an axiom free version of HoTT/UF
-which computes properly:
+which computes properly.
 
 .. code-block:: agda
 
@@ -628,7 +630,7 @@ which computes properly:
 
   open import Cubical.Core.Id public
      using ( _≡_            -- The identity type.
-           ; refl           -- Unfortunately, pattern matching on refl is not available.
+           ; refl            -- Unfortunately, pattern matching on refl is not available.
            ; J              -- Until it is, you have to use the induction principle J.
 
            ; transport      -- As in the HoTT Book.

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -69,16 +69,32 @@ There is a standard ``agda/cubical`` library for Cubical Agda
 available at https://github.com/agda/cubical. This documentation uses
 the naming conventions of this library, for a detailed list of all of
 the built-in Cubical Agda files and primitives see
-:ref:`primitives-ref`.
+:ref:`primitives-ref`. The main design choices of the core part of the
+library are explained in
+https://homotopytypetheory.org/2018/12/06/cubical-agda/.
 
-The main design choices of the core part of the library are explained
-in https://homotopytypetheory.org/2018/12/06/cubical-agda/.
+The recommended way to get access to the Cubical primitives is to add
+the following to the top of a file (this assumes that the
+``agda/cubical`` library is installed and visible to Agda).
 
-In order to get access to the Cubical Agda primitives one should
-either import
-https://github.com/agda/cubical/blob/master/Cubical/Core/Everything.agda
-or add the relevant import statements from the top of that file (for
-details for experts see :ref:`primitives-ref`). For beginners it is
+.. code-block:: agda
+
+  {-# OPTIONS --cubical #-}
+  module MyModule where
+
+  open import Cubical.Core.Everything
+
+For detailed install instructions for ``agda/cubical`` see:
+https://github.com/agda/cubical/blob/master/INSTALL.md. In order to
+make this library visible to Agda add
+``/path/to/cubical/cubical.agda-lib`` to ``.agda/libraries`` and
+``cubical`` to ``.agda/defaults`` (where ``path/to`` is the absolute
+path to where the ``agda/cubical`` library has been installed). For
+details of Agda's library management see :ref:`package-system`.
+
+Expert users who doesn't want to rely on ``agda/cubical`` can just add
+the relevant import statements at the top of their file (for details
+for experts see :ref:`primitives-ref`). However, for beginners it is
 recommended that one uses at least the core part of the
 ``agda/cubical`` library.
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -141,8 +141,7 @@ represented like a function out of the interval, ``I → A``. In fact a
 path type is in fact a special case of the more general built-in
 heterogeneous path types:
 
-..
-  ::
+::
 
   -- PathP : ∀ {ℓ} (A : I → Set ℓ) → A i0 → A i1 → Set ℓ
 
@@ -156,8 +155,7 @@ use λ-abstractions and to apply them we use regular application.  For
 example, this is the definition of the constant path (or proof of
 reflexivity):
 
-..
-  ::
+::
 
   refl : ∀ {ℓ} {A : Set ℓ} {x : A} → Path A x x
   refl {x = x} = λ i → x
@@ -176,8 +174,7 @@ i → A) x y`` gets printed as ``x ≡ y`` when ``A`` does not mention
 higher cubes in Agda, making the type theory cubical. For example a
 square in ``A`` is built out of 4 points and 4 lines:
 
-..
-  ::
+::
 
   Square : ∀ {ℓ} {A : Set ℓ} {x0 x1 y0 y1 : A} →
              x0 ≡ x1 → y0 ≡ y1 → x0 ≡ y0 → x1 ≡ y1 → Set ℓ
@@ -186,8 +183,7 @@ square in ``A`` is built out of 4 points and 4 lines:
 Viewing equalities as functions out of the interval makes it possible
 to do a lot of equality reasoning in a very direct way:
 
-..
-  ::
+::
 
   sym : ∀ {ℓ} {A : Set ℓ} {x y : A} → x ≡ y → y ≡ x
   sym p = λ i → p (~ i)
@@ -199,8 +195,7 @@ to do a lot of equality reasoning in a very direct way:
 Because of the way functions compute these satisfy some new
 definitional equalities compared to the standard Agda definitions:
 
-..
-  ::
+::
 
   symInv : ∀ {ℓ} {A : Set ℓ} {x y : A} (p : x ≡ y) → sym (sym p) ≡ p
   symInv p = refl
@@ -216,8 +211,7 @@ Path types also lets us prove new things are not provable in standard
 Agda, for example function extensionality (pointwise equal functions
 are equal) has an extremely simple proof:
 
-..
-  ::
+::
 
   funExt : ∀ {ℓ} {A : Set ℓ} {B : A → Set ℓ} {f g : (x : A) → B x} →
              ((x : A) → f x ≡ g x) → f ≡ g
@@ -242,8 +236,7 @@ When calling ``transp A r a`` Agda makes sure that ``A`` is constant
 on ``r`` so that ``transp A i1 a`` is definitionally ``a``. This lets
 us define regular transport as
 
-..
-  ::
+::
 
   transport : ∀ {ℓ} {A B : Set ℓ} → A ≡ B → A → B
   transport p a = transp (λ i → p i) i0 a
@@ -251,8 +244,7 @@ us define regular transport as
 By combining the transport and min operations we can define the
 induction principle for paths:
 
-..
-  ::
+::
 
   J : ∀ {ℓ} {A : Set ℓ} {x : A} (P : ∀ y → x ≡ y → Set ℓ)
         (d : P x refl) {y : A} (p : x ≡ y)
@@ -268,8 +260,7 @@ inductively defined this does not hold for the above definition of
 identity function up to a path which implies that the computation rule
 for ``J`` only holds up to a path:
 
-..
-  ::
+::
 
   transportRefl : ∀ {ℓ} {A : Set ℓ} (x : A) → transport refl x ≡ x
   transportRefl {A = A} x i = transp (λ _ → A) i x
@@ -320,8 +311,7 @@ when ``IsOne φ``.  There is also a dependent version of this called
 
 Partial elements are introduced using pattern matching:
 
-..
-  ::
+::
 
   sys : ∀ i → Partial (i ∨ ~ i) Set₁
   sys i (i = i0) = Set
@@ -332,8 +322,7 @@ is, when ``(i = i0) ∨ (i = i1)``. Terms of type ``Partial φ A`` can
 also be introduced using pattern matching lambdas
 (http://wiki.portal.chalmers.se/agda/pmwiki.php?n=ReferenceManual.PatternMatchingLambdas).
 
-..
-  ::
+::
 
   sys' : ∀ i → Partial (i ∨ ~ i) Set₁
   sys' i = λ { (i = i0) → Set
@@ -341,8 +330,7 @@ also be introduced using pattern matching lambdas
 
 When the cases overlap they must agree:
 
-..
-  ::
+::
 
   sys2 : ∀ i j → Partial (i ∨ (i ∧ j)) Set₁
   sys2 i j = λ { (i = i1)          → Set
@@ -350,16 +338,14 @@ When the cases overlap they must agree:
 
 Furthermore ``IsOne i0`` is actually absurd
 
-..
-  ::
+::
 
   sys3 : Partial i0 Set₁
   sys3 = λ { () }
 
 Cubical Agda also has cubical subtypes as in the CCHM type theory:
 
-..
-  ::
+::
 
   _[_↦_] : ∀ {ℓ} (A : Set ℓ) (φ : I) (u : Partial φ A) → Setω
   A [ φ ↦ u ] = Sub A φ u
@@ -401,8 +387,7 @@ opposite of ``u0`` is missing. The ``hcomp`` operation then gives us
 the missing side of the cube. For example binary composition of paths
 can be written as:
 
-..
-  ::
+::
 
   compPath : ∀ {ℓ} {A : Set ℓ} {x y z : A} → x ≡ y → y ≡ z → x ≡ z
   compPath {x = x} p q i =
@@ -432,8 +417,7 @@ abstracted in the first argument to ``hcomp``.
 
 We can also define homogeneous filling of cubes as
 
-..
-  ::
+::
 
   hfill : ∀ {ℓ} {A : Set ℓ} {φ : I}
           (u : ∀ i → Partial φ A) (u0 : A [ φ ↦ u i0 ])
@@ -448,8 +432,7 @@ When ``i`` is ``i0`` this is ``u0`` and when ``i`` is ``i1`` this is
 box. In the special case of the square above ``hfill`` gives us a
 direct cubical proof that composing ``p`` with ``refl`` is ``p``.
 
-..
-  ::
+::
 
   compPathRefl : ∀ {ℓ} {A : Set ℓ} {x y : A} (p : x ≡ y) → compPath p refl ≡ p
   compPathRefl {x = x} {y = y} p j i =
@@ -484,8 +467,7 @@ defined as a map ``f : A → B`` such that its fibers are contractible.
 
 The simplest example of an equivalence is the identity function.
 
-..
-  ::
+::
 
   idfun : ∀ {ℓ} → (A : Set ℓ) → A → A
   idfun _ x = x
@@ -524,8 +506,7 @@ These come with a constructor and eliminator:
 In the cubical library we uncurry the Glue types to make them more
 pleasant to use:
 
-..
-  ::
+::
 
   Glue : ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I}
          → (Te : Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A))
@@ -535,8 +516,7 @@ pleasant to use:
 Using Glue types we can turn an equivalence of types into a path as
 follows:
 
-..
-  ::
+::
 
   ua : ∀ {ℓ} {A B : Set ℓ} → A ≃ B → A ≡ B
   ua {_} {A} {B} e i = Glue B (λ { (i = i0) → (A , e)
@@ -549,8 +529,7 @@ function for turning equivalences into paths. The other part of
 univalence is that this map itself is an equivalence which follows
 from the computation rule for ``ua``:
 
-..
-  ::
+::
 
   uaβ : ∀ {ℓ} {A B : Set ℓ} (e : A ≃ B) (x : A) → transport (ua e) x ≡ e .fst x
   uaβ e x = transportRefl (e .fst x)
@@ -577,8 +556,7 @@ Cubical Agda also lets us directly define higher inductive types as
 datatypes with path constructors. For example the circle and `torus
 <https://en.wikipedia.org/wiki/Torus>`_ can be defined as:
 
-..
-  ::
+::
 
   data S¹ : Set where
     base : S¹
@@ -593,8 +571,7 @@ datatypes with path constructors. For example the circle and `torus
 Functions out of higher inductive types can then be defined using
 pattern-matching:
 
-..
-  ::
+::
 
   t2c : Torus → S¹ × S¹
   t2c point        = ( base , base )
@@ -625,8 +602,7 @@ boundary of the square constructor.
 Functions defined by pattern-matching on higher inductive types
 compute definitionally, for all constructors.
 
-..
-  ::
+::
 
   c2t-t2c : ∀ (t : Torus) → c2t (t2c t) ≡ t
   c2t-t2c point        = refl
@@ -652,8 +628,7 @@ Cubical Agda also supports parameterized and recursive higher
 inductive types, for example propositional truncation (squash types)
 is defined as:
 
-..
-  ::
+::
 
   data ∥_∥ {ℓ} (A : Set ℓ) : Set ℓ where
     ∣_∣ : A → ∥ A ∥

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -21,7 +21,9 @@ Cubical Type Theory in Agda
 
 As of version 2.6.0 Agda has a cubical mode which extends Agda with a
 variety of features from Cubical Type Theory. In particular,
-computational univalence and higher inductive types. The version of
+computational univalence and higher inductive types which hence gives
+computational meaning to `Homotopy Type Theory and Univalent
+Foundations <https://homotopytypetheory.org/>`_. The version of
 Cubical Type Theory that Agda implements is a variation of `CCHM`_
 where the Kan composition operations are decomposed into homogeneous
 composition and generalized transport. This is what makes the general
@@ -113,11 +115,11 @@ elements, respectively
     p₈ = reflI
 
 
-The core idea of Homotopy Type Theory is a correspondence between
-paths and (proof-relevant) equality. This is taken very literally in
-Cubical Agda where a path in a type ``A`` is like a function out of
-the interval, ``I → A``. A ``Path`` is in fact a special case of the
-more general built-in heterogeneous path type:
+The core idea of Homotopy Type Theory and Univalent Foundations is a
+correspondence between paths and (proof-relevant) equality. This is
+taken very literally in Cubical Agda where a path in a type ``A`` is
+like a function out of the interval, ``I → A``. A ``Path`` is in fact
+a special case of the more general built-in heterogeneous path type:
 
 .. code-block:: agda
 
@@ -127,8 +129,9 @@ more general built-in heterogeneous path type:
    Path : ∀ {ℓ} (A : Set ℓ) → A → A → Set ℓ
    Path A a b = PathP (λ _ → A) a b
 
-To define paths we use λ-abstractions and to apply them we use regular
-application. For example, this is the definition of the constant path:
+The central notion of equality is hence heterogeneous. To define paths
+we use λ-abstractions and to apply them we use regular application.
+For example, this is the definition of the constant path:
 
 .. code-block:: agda
 
@@ -161,10 +164,10 @@ to do a lot of equality reasoning in a very direct way:
 
 .. code-block:: agda
 
-  sym : ∀ {A : Set} {x y : A} → x ≡ y → y ≡ x
+  sym : ∀ {ℓ} {A : Set ℓ} {x y : A} → x ≡ y → y ≡ x
   sym p = λ i → p (~ i)
 
-  cong : ∀ {A : Set} {x y : A} {B : A → Set} (f : (a : A) → B a) (p : x ≡ y)
+  cong : ∀ {ℓ} {A : Set ℓ} {x y : A} {B : A → Set ℓ} (f : (a : A) → B a) (p : x ≡ y)
          → PathP (λ i → B (p i)) (f x) (f y)
   cong f p i = f (p i)
 
@@ -173,15 +176,15 @@ definitional equalities compard to the Agda standard library:
 
 .. code-block:: agda
 
-  symK : ∀ {A : Set} {x y : A} (p : x ≡ y) → sym (sym p) ≡ p
-  symK p = refl
+  symInv : ∀ {ℓ} {A : Set ℓ} {x y : A} (p : x ≡ y) → sym (sym p) ≡ p
+  symInv p = refl
 
-  cong1 : ∀ {A : Set} {x y : A} (p : x ≡ y) → cong (λ a → a) p ≡ p
-  cong1 p = refl
+  congId : ∀ {ℓ} {A : Set ℓ} {x y : A} (p : x ≡ y) → cong (λ a → a) p ≡ p
+  congId p = refl
 
-  congcomp : ∀ {A B C : Set} (f : A → B) (g : B → C) {x y : A} (p : x ≡ y) →
+  congComp : ∀ {ℓ} {A B C : Set ℓ} (f : A → B) (g : B → C) {x y : A} (p : x ≡ y) →
                cong (λ a → g (f a)) p ≡ cong g (cong f p)
-  congcomp f g p = refl
+  congComp f g p = refl
 
 Path types also lets us prove new things are not provable in standard
 Agda, for example function extensionality (pointwise equal functions

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -187,7 +187,7 @@ definitional equalities compared to the standard Agda definitions:
 
 Path types also lets us prove new things are not provable in standard
 Agda, for example function extensionality (pointwise equal functions
-are equal):
+are equal) has an extremely simple proof:
 
 .. code-block:: agda
 
@@ -200,9 +200,9 @@ Transport
 
 While path types are great for reasoning about equality they don't let
 us transport along paths between types or even compose path, which in
-particular means that we cannot prove the induction principle for
-paths yet. In order to remedy this we also have a builtin
-(generalized) transport operation and homogeneous composition. The
+particular means that we cannot yet prove the induction principle for
+paths. In order to remedy this we also have a builtin (generalized)
+transport operation and homogeneous composition operations. The
 transport operation is generalized in the sense that it lets us
 specify where the operation is the identity function
 
@@ -211,7 +211,7 @@ specify where the operation is the identity function
   transp : ∀ {ℓ} (A : I → Set ℓ) (φ : I) (a : A i0) → A i1
 
 When calling ``transp A φ a`` Agda makes sure that ``A`` is constant
-on ``φ`` so that ``transp A i1 a`` is ``a`` definitionally. This lets
+on ``φ`` so that ``transp A i1 a`` is definitionall ``a``. This lets
 us define regular transport as
 
 .. code-block:: agda
@@ -219,12 +219,14 @@ us define regular transport as
   transport : ∀ {ℓ} {A B : Set ℓ} → A ≡ B → A → B
   transport p a = transp (λ i → p i) i0 a
 
-Combining the transport operation with the min operation then lets us
-define path induction:
+Combining the transport and min operations then lets us define path
+induction:
 
 .. code-block:: agda
 
-  J : ∀ {ℓ} {A : Set ℓ} {x : A} (P : ∀ y → x ≡ y → Set ℓ) (d : P x refl) {y : A} (p : x ≡ y) → P y p
+  J : ∀ {ℓ} {A : Set ℓ} {x : A} (P : ∀ y → x ≡ y → Set ℓ)
+        (d : P x refl) {y : A} (p : x ≡ y)
+      → P y p
   J P d p = transport (λ i → P (p i) (λ j → p (i ∧ j))) d
 
 One subtle difference between this and the propositional equality type
@@ -239,16 +241,17 @@ rule up to a path:
   transportRefl : ∀ {ℓ} {A : Set ℓ} (x : A) → transport refl x ≡ x
   transportRefl {A = A} x i = transp (λ _ → A) i x
 
-  JRefl : ∀ {ℓ} {A : Set ℓ} {x : A} (P : ∀ y → x ≡ y → Set ℓ) (d : P x refl) → J P d refl ≡ d
+  JRefl : ∀ {ℓ} {A : Set ℓ} {x : A} (P : ∀ y → x ≡ y → Set ℓ)
+            (d : P x refl) → J P d refl ≡ d
   JRefl P d = transportRefl d
 
 Internally in Agda the ``transp`` operations computes by cases on the
-type, for example for Sigma types they are computed pointwise. For
+type, so for example for Sigma types it is computed elementwise. For
 Path types it is however not yet possible to provide the computation
-rule as we need some way to keep track the end-points of the path
-after transporting it. Furthermore, this must work for arbitrary
-higher dimensional cubes. For this we introduce the homogeneous
-composition operations that generalize binary composition of paths to
+rule as we need some way to keep track the endpoints of the path after
+transporting it. Furthermore, this must work for arbitrary higher
+dimensional cubes. For this we introduce the "homogeneous composition"
+operations (``hcomp``) that generalize binary composition of paths to
 n-ary composition of higher dimensional cubes.
 
 
@@ -260,8 +263,8 @@ be able to write partially specified n-dimensional cubes (i.e. cubes
 where some faces are missing). Given an element of the interval ``r :
 I`` there is a predicate ``IsOne`` which represents the constraint ``r
 = i1``. This comes with a proof that ``i1`` is equal to ``i1`` called
-``1=1 : IsOne i1``. We use the letter ``φ`` when such an ``r`` should
-be thought of as being in the image of ``IsOne``.
+``1=1 : IsOne i1``. We use the Greek letters like ``φ`` when such an
+``r`` should be thought of as being in the image of ``IsOne``.
 
 Using this we introduce a type of partial elements called ``Partial φ
 A``, this is a special version of ``IsOne φ → A`` with a more
@@ -314,8 +317,9 @@ There are cubical subtypes as in CCHM:
   _[_↦_] : ∀ {ℓ} (A : Set ℓ) (φ : I) (u : Partial φ A) → Setω
   A [ φ ↦ u ] = Sub A φ u
 
-Any element ``u : A`` can be seen as an element of ``A [ φ ↦ u ]``
-which agrees with ``u`` on ``φ``:
+A term ``v : A [ φ ↦ u ]`` is of type ``A`` and when ``IsOne φ`` it
+must be definitionally equal to ``u``. Any term ``u : A`` can be seen
+as an term of ``A [ φ ↦ u ]`` which agrees with ``u`` on ``φ``:
 
 .. code-block:: agda
 
@@ -329,6 +333,7 @@ One can also forget that an element agrees with ``u`` on ``φ``:
 
 With all of this cubical infrastructure we can now describe the
 ``hcomp`` operations.
+
 
 Homogeneous composition
 -----------------------

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -162,7 +162,7 @@ The core idea of Homotopy Type Theory and Univalent Foundations is a
 correspondence between paths (as in topology) and (proof-relevant)
 equality (as in Martin-Löf's identity type). This correspondence is
 taken very literally in Cubical Agda where a path in a type ``A`` is
-represented like a function out of the interval, ``I → A``. In fact a
+represented like a function out of the interval, ``I → A``. A
 path type is in fact a special case of the more general built-in
 heterogeneous path types:
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -4,10 +4,13 @@
   module language.cubical where
 
   open import Agda.Primitive.Cubical
-                         renaming (primIMax to _∨_;
-                                   primIMin to _∧_;
-                                   primINeg to ~_)
-
+                         renaming ( primIMin to _∧_
+                                  ; primIMax to _∨_
+                                  ; primINeg to ~_
+                                  ; isOneEmpty to empty
+                                  ; primHComp to hcomp
+                                  ; primTransp to transp
+                                  ; itIsOne to 1=1 )
   open import Agda.Builtin.Cubical.Path renaming (_≡_ to Path)
 
 .. _cubical:
@@ -16,45 +19,60 @@
 Cubical Type Theory in Agda
 ***************************
 
-Cubical Type Theory `Cohen et al., Cubical`_ is implemented in Agda (beta version).
+As of 2.6.0 Agda has a cubical mode which extends Agda with a variety
+of features from Cubical Type Theory. In particular, computational
+univalence and higher inductive types.
 
-To use cubical type theory, you need to run Agda with the ``--cubical`` command-line-option.
-You can also write ``{-# OPTIONS --cubical #-}`` at the top of the file.
+The version of Cubical Type Theory that Agda implements is a variation
+of `CCHM, Cubical`_ where the Kan composition operations are
+decomposed into homogeneous composition and generalized
+transport. This what makes a general schema for higher inductive types
+work, following `CHM, Cubical`_.
 
-To define paths, use λ abstractions. For example, this is the definition of the constant path:
+To use cubical type theory, you need to run Agda with the
+``--cubical`` command-line-option. You can also write ``{-#
+OPTIONS --cubical #-}`` at the top of the file.
 
-..
-  ::
-  module refl-example where
+The cubical mode adds the following features to Agda:
 
-::
+1. An interval and path types
+2. Partial elements and systems
+3. Kan operations (hcomp and transp)
+4. Glue types
+5. Cubical identity types
+6. Higher inductive types
 
-    refl : ∀ {a} {A : Set a} {x : A} → Path x x
-    refl {x = x} = λ i → x
 
-Although they use the same syntax, a path is not a function.
-For example, the following is not valid:
+There is a library for Cubical Agda available at:
+https://github.com/agda/cubical
 
-.. code-block:: agda
+The main design choices of the core part of the library are explained
+in: https://homotopytypetheory.org/2018/12/06/cubical-agda/
 
-  refl : ∀ {a} {A : Set a} {x : A} → Path x x
-  refl {x = x} = λ (i : _) → x
+In order to use Cubical Agda one should either import
+https://github.com/agda/cubical/blob/master/Cubical/Core/Primitives.agda
+or add the relevant import statements from the top of that file.
 
--------------------------
-The interval type (``I``)
--------------------------
 
-The variable ``i`` in the definition of ``refl`` has type ``I``, which
-topologically corresponds to the `real unit interval <https://en.wikipedia.org/wiki/Unit_interval>`_.
-In a closed context, there are only two values of type ``I``: the two
-ends of the interval, ``i0`` and ``i1``::
+The interval and path types
+---------------------------
+
+The key idea of cubical type theory is to add an interval type ``I :
+Setω`` (the reason this is in ``Setω`` is because it doesn't support
+the Kan operations).
+
+A variable ``i : I`` intuitively corresponds to a point the `real unit
+interval <https://en.wikipedia.org/wiki/Unit_interval>`_. In a closed
+context, there are only two values of type ``I``: the two endpoints of
+the interval, ``i0`` and ``i1``::
 
   a b : I
   a = i0
   b = i1
 
-Elements of the interval form a `De Morgan algebra <https://en.wikipedia.org/wiki/De_Morgan_algebra>`_,
-with minimum (``∧``), maximum (``∨``) and negation (``~``).
+Elements of the interval form a `De Morgan algebra
+<https://en.wikipedia.org/wiki/De_Morgan_algebra>`_, with minimum
+(``∧``), maximum (``∨``) and negation (``~``).
 
 .. code-block:: agda
 
@@ -72,8 +90,9 @@ with minimum (``∧``), maximum (``∨``) and negation (``~``).
     min = i ∧ j
     neg = ~ i
 
-All the properties of de Morgan algebras hold definitionally. The ends
-of the interval ``i0`` and ``i1`` are the bottom and top elements, respectively
+All the properties of de Morgan algebras hold definitionally. The
+endpoints of the interval ``i0`` and ``i1`` are the bottom and top
+elements, respectively
 
 .. code-block:: agda
 
@@ -97,10 +116,450 @@ of the interval ``i0`` and ``i1`` are the bottom and top elements, respectively
     p₇ = reflI
     p₈ = reflI
 
+
+
+The core idea of homotopy type theory is a correspondence between
+paths and (proof-relevant) equality. This is taken very literally in
+Cubical Type Theory where a path in a type ``A`` is defined as a
+function out of the interval, ``I → A``. To define paths we hence use
+λ-abstractions. For example, this is the definition of the constant
+path:
+
+..
+  ::
+  module refl-example where
+
+::
+
+    refl : ∀ {a} {A : Set a} {x : A} → Path x x
+    refl {x = x} = λ i → x
+
+Although they use the same syntax, a path is not a function. For
+example, the following is not valid:
+
+.. code-block:: agda
+
+  refl : ∀ {a} {A : Set a} {x : A} → Path x x
+  refl {x = x} = λ (i : I) → x
+
+A ``Path``` is in fact a special case of the more general built-in
+heterogeneous path type:
+
+.. code-block:: agda
+                
+   -- PathP : ∀ {ℓ} (A : I → Set ℓ) → A i0 → A i1 → Set ℓ
+
+   -- Non dependent path types
+   Path : ∀ {ℓ} (A : Set ℓ) → A → A → Set ℓ
+   Path A a b = PathP (λ _ → A) a b
+
+
+Because of the intuitions that paths correspond to equality ``PathP (λ
+i → A) x y`` gets printed as ``x ≡ y`` when ``A`` does not mention
+``i``.
+
+By mapping out of more elements of the interval we can define squares,
+cubes, and higher cubes in Agda, making the type theory "cubical".
+
+Viewing equalities as functions out of the interval makes it possible
+to do a lot of equality reasoning in a very direct way:
+
+  sym : ∀ {ℓ} {A : Set} {x y : A} → x ≡ y → y ≡ x
+  sym p = λ i → p (~ i)
+
+  cong : ∀ {ℓ} {A : Set} {x y : A} {B : A → Set ℓ'}
+           (f : (a : A) → B a) (p : x ≡ y)
+         → PathP (λ i → B (p i)) (f x) (f y)
+  cong f p = λ i → f (p i)
+
+Because of the way functions compute these satisfy some new
+definitional equalities:
+
+  sym sym = id
+  cong refl = refl
+  cong (f o g) = cong f o cong g
+
+that are not available in standard Agda. Furthermore, path types lets
+us prove new things are not true provable in standard Agda, for
+example function extensionality (pointwise equal functions are equal):
+
+  funExt : ∀ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} {f g : (x : A) → B x} →
+             ((x : A) → f x ≡ g x) → f ≡ g
+  funExt p i x = p x i
+
+
+Partial elements and systems
+----------------------------
+
+
+
+-- * @IsOne r@ represents the constraint "r = i1".
+-- Often we will use "φ" for elements of I, when we intend to use them
+-- with IsOne (or Partial[P]).
+-- IsOne : I → Setω
+
+-- i1 is indeed equal to i1.
+-- 1=1 : IsOne i1
+
+
+-- * Types of partial elements, and their dependent version.
+
+-- "Partial φ A" is a special version of "IsOne φ → A" with a more
+-- extensional judgmental equality.
+-- "PartialP φ A" allows "A" to be defined only on "φ".
+
+-- Partial : ∀ {ℓ} → I → Set ℓ → Setω
+-- PartialP : ∀ {ℓ} → (φ : I) → Partial φ (Set ℓ) → Setω
+
+-- Partial elements are introduced by pattern matching with (r = i0)
+-- or (r = i1) constraints, like so:
+
+private
+  sys : ∀ i → Partial (i ∨ ~ i) Set₁
+  sys i (i = i0) = Set
+  sys i (i = i1) = Set → Set
+
+  -- It also works with pattern matching lambdas:
+  --  http://wiki.portal.chalmers.se/agda/pmwiki.php?n=ReferenceManual.PatternMatchingLambdas
+  sys' : ∀ i → Partial (i ∨ ~ i) Set₁
+  sys' i = λ { (i = i0) → Set
+             ; (i = i1) → Set → Set
+             }
+
+  -- When the cases overlap they must agree.
+  sys2 : ∀ i j → Partial (i ∨ (i ∧ j)) Set₁
+  sys2 i j = λ { (i = i1)          → Set
+               ; (i = i1) (j = i1) → Set
+               }
+
+  -- (i0 = i1) is actually absurd.
+  sys3 : Partial i0 Set₁
+  sys3 = λ { () }
+
+
+-- * There are cubical subtypes as in CCHM. Note that these are not
+-- fibrant (hence in Setω):
+
+_[_↦_] : ∀ {ℓ} (A : Set ℓ) (φ : I) (u : Partial φ A) → Agda.Primitive.Setω
+A [ φ ↦ u ] = Sub A φ u
+
+infix 4 _[_↦_]
+
+-- Any element u : A can be seen as an element of A [ φ ↦ u ] which
+-- agrees with u on φ:
+
+-- inc : ∀ {ℓ} {A : Set ℓ} {φ} (u : A) → A [ φ ↦ (λ _ → u) ]
+
+-- One can also forget that an element agrees with u on φ:
+
+ouc : ∀ {ℓ} {A : Set ℓ} {φ : I} {u : Partial φ A} → A [ φ ↦ u ] → A
+ouc = primSubOut
+
+
+Kan operations (hcomp and transp)
+---------------------------------
+
+
+-- * Generalized transport and homogeneous composition [CHM 18].
+
+-- When calling "transp A φ a" Agda makes sure that "A" is constant on "φ".
+-- transp : ∀ {ℓ} (A : I → Set ℓ) (φ : I) (a : A i0) → A i1
+
+-- When calling "hcomp A φ u a" Agda makes sure that "a" agrees with "u i0" on "φ".
+-- hcomp : ∀ {ℓ} {A : Set ℓ} {φ : I} (u : I → Partial φ A) (a : A) → A
+
+private
+  variable
+    ℓ  : Level
+    ℓ′ : I → Level
+
+-- Homogeneous filling
+hfill : {A : Set ℓ}
+        {φ : I}
+        (u : ∀ i → Partial φ A)
+        (u0 : A [ φ ↦ u i0 ])
+        -----------------------
+        (i : I) → A
+hfill {φ = φ} u u0 i =
+  hcomp (λ j → λ { (φ = i1) → u (i ∧ j) 1=1
+                 ; (i = i0) → ouc u0 })
+        (ouc u0)
+
+-- Heterogeneous composition defined as in CHM
+comp : (A : ∀ i → Set (ℓ′ i))
+       {φ : I}
+       (u : ∀ i → Partial φ (A i))
+       (u0 : A i0 [ φ ↦ u i0 ])
+     → ---------------------------
+       A i1
+comp A {φ = φ} u u0 =
+  hcomp (λ i → λ { (φ = i1) → transp (λ j → A (i ∨ j)) i (u _ 1=1) })
+        (transp A i0 (ouc u0))
+
+-- Heterogeneous filling defined using comp
+fill : (A : ∀ i → Set (ℓ′ i))
+       {φ : I}
+       (u : ∀ i → Partial φ (A i))
+       (u0 : A i0 [ φ ↦ u i0 ])
+       ---------------------------
+       (i : I) → A i
+fill A {φ = φ} u u0 i =
+  comp (λ j → A (i ∧ j))
+       (λ j → λ { (φ = i1) → u (i ∧ j) 1=1
+                ; (i = i0) → ouc u0 })
+       (inc {φ = φ ∨ (~ i)} (ouc {φ = φ} u0))
+
+-- Direct definition of transport filler, note that we have to
+-- explicitly tell Agda that the type is constant (like in CHM)
+transpFill : {A : Set ℓ}
+             (φ : I)
+             (A : (i : I) → Set ℓ [ φ ↦ (λ _ → A) ])
+             (u0 : ouc (A i0))
+           → --------------------------------------
+             PathP (λ i → ouc (A i)) u0 (transp (λ i → ouc (A i)) φ u0)
+transpFill φ A u0 i = transp (λ j → ouc (A (i ∧ j))) (~ i ∨ φ) u0
+
+
+Glue types
+----------
+
+
+open import Agda.Builtin.Cubical.Glue public
+  using ( isEquiv       -- ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) → Set (ℓ ⊔ ℓ')
+
+        ; equiv-proof   -- ∀ (y : B) → isContr (fiber f y)
+
+        ; _≃_           -- ∀ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') → Set (ℓ ⊔ ℓ')
+
+        ; equivFun      -- ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} → A ≃ B → A → B
+
+        ; equivProof    -- ∀ {ℓ ℓ'} (T : Set ℓ) (A : Set ℓ') (w : T ≃ A) (a : A) φ →
+                        -- Partial φ (fiber (equivFun w) a) → fiber (equivFun w) a
+
+        ; primGlue      -- ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I} (T : Partial φ (Set ℓ'))
+                        -- → (e : PartialP φ (λ o → T o ≃ A)) → Set ℓ'
+
+        ; prim^unglue   -- ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I} {T : Partial φ (Set ℓ')}
+                        -- → {e : PartialP φ (λ o → T o ≃ A)} → primGlue A T e → A
+
+        -- The ∀ operation on I. This is commented out as it is not currently used for anything
+        -- ; primFaceForall -- (I → I) → I
+        )
+  renaming ( prim^glue   to glue         -- ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I} {T : Partial φ (Set ℓ')}
+                                         -- → {e : PartialP φ (λ o → T o ≃ A)}
+                                         -- → PartialP φ T → A → primGlue A T e
+
+           ; pathToEquiv to lineToEquiv  -- ∀ {ℓ : → Level} (P : (i : I) → Set (ℓ i)) → P i0 ≃ P i1
+           )
+
+private
+  variable
+    ℓ ℓ' : Level
+
+fiber : ∀ {A : Set ℓ} {B : Set ℓ'} (f : A → B) (y : B) → Set (ℓ-max ℓ ℓ')
+fiber {A = A} f y = Σ[ x ∈ A ] f x ≡ y
+
+equivIsEquiv : ∀ {A : Set ℓ} {B : Set ℓ'} (e : A ≃ B) → isEquiv (equivFun e)
+equivIsEquiv e = snd e
+
+equivCtr : ∀ {A : Set ℓ} {B : Set ℓ'} (e : A ≃ B) (y : B) → fiber (equivFun e) y
+equivCtr e y = e .snd .equiv-proof y .fst
+
+equivCtrPath : ∀ {A : Set ℓ} {B : Set ℓ'} (e : A ≃ B) (y : B) →
+  (v : fiber (equivFun e) y) → Path _ (equivCtr e y) v
+equivCtrPath e y = e .snd .equiv-proof y .snd
+
+-- Uncurry Glue to make it more pleasant to use
+Glue : ∀ (A : Set ℓ) {φ : I}
+       → (Te : Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A))
+       → Set ℓ'
+Glue A Te = primGlue A (λ x → Te x .fst) (λ x → Te x .snd)
+
+-- Make the φ argument of prim^unglue explicit
+unglue : ∀ {A : Set ℓ} (φ : I) {T : Partial φ (Set ℓ')}
+           {e : PartialP φ (λ o → T o ≃ A)} → primGlue A T e → A
+unglue φ = prim^unglue {φ = φ}
+
+-- The identity equivalence
+idfun : ∀ {ℓ} → (A : Set ℓ) → A → A
+idfun _ x = x
+
+idIsEquiv : ∀ (A : Set ℓ) → isEquiv (idfun A)
+equiv-proof (idIsEquiv A) y =
+  ((y , refl) , λ z i → z .snd (~ i) , λ j → z .snd (~ i ∨ j))
+
+idEquiv : ∀ (A : Set ℓ) → A ≃ A
+idEquiv A = (idfun A , idIsEquiv A)
+
+-- The ua constant
+ua : ∀ {A B : Set ℓ} → A ≃ B → A ≡ B
+ua {A = A} {B = B} e i = Glue B (λ { (i = i0) → (A , e)
+                                   ; (i = i1) → (B , idEquiv B) })
+
+
+-- Proof of univalence using that unglue is an equivalence:
+
+-- unglue is an equivalence
+unglueIsEquiv : ∀ (A : Set ℓ) (φ : I)
+                (f : PartialP φ (λ o → Σ[ T ∈ Set ℓ ] T ≃ A)) →
+                isEquiv {A = Glue A f} (unglue φ)
+equiv-proof (unglueIsEquiv A φ f) = λ (b : A) →
+  let u : I → Partial φ A
+      u i = λ{ (φ = i1) → equivCtr (f 1=1 .snd) b .snd (~ i) }
+      ctr : fiber (unglue φ) b
+      ctr = ( glue (λ { (φ = i1) → equivCtr (f 1=1 .snd) b .fst }) (hcomp u b)
+            , λ j → hfill u (inc b) (~ j))
+  in ( ctr
+     , λ (v : fiber (unglue φ) b) i →
+         let u' : I → Partial (φ ∨ ~ i ∨ i) A
+             u' j = λ { (φ = i1) → equivCtrPath (f 1=1 .snd) b v i .snd (~ j)
+                      ; (i = i0) → hfill u (inc b) j
+                      ; (i = i1) → v .snd (~ j) }
+         in ( glue (λ { (φ = i1) → equivCtrPath (f 1=1 .snd) b v i .fst }) (hcomp u' b)
+            , λ j → hfill u' (inc b) (~ j)))
+
+-- Any partial family of equivalences can be extended to a total one
+-- from Glue [ φ ↦ (T,f) ] A to A
+unglueEquiv : ∀ (A : Set ℓ) (φ : I)
+              (f : PartialP φ (λ o → Σ[ T ∈ Set ℓ ] T ≃ A)) →
+              (Glue A f) ≃ A
+unglueEquiv A φ f = ( unglue φ , unglueIsEquiv A φ f )
+
+
+-- The following is a formulation of univalence proposed by Martín Escardó:
+-- https://groups.google.com/forum/#!msg/homotopytypetheory/HfCB_b-PNEU/Ibb48LvUMeUJ
+-- See also Theorem 5.8.4 of the HoTT Book.
+--
+-- The reason we have this formulation in the core library and not the
+-- standard one is that this one is more direct to prove using that
+-- unglue is an equivalence. The standard formulation can be found in
+-- Cubical/Basics/Univalence.
+--
+EquivContr : ∀ (A : Set ℓ) → isContr (Σ[ T ∈ Set ℓ ] T ≃ A)
+EquivContr {ℓ = ℓ} A =
+  ( ( A , idEquiv A)
+  , λ w i → let f : PartialP (~ i ∨ i) (λ x → Σ[ T ∈ Set ℓ ] T ≃ A)
+                f = λ { (i = i0) → A , idEquiv A ; (i = i1) → w }
+            in ( Glue A f , unglueEquiv _ _ f) )
+
+
+Cubical identity types
+----------------------
+
+
+open import Agda.Builtin.Cubical.Id public
+  renaming ( conid to ⟨_,_⟩
+           -- TODO: should the user really be able to access these two?
+           ; primIdFace to faceId  -- ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → I
+           ; primIdPath to pathId  -- ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → Path A x y
+
+           ; primIdElim to elimId  -- ∀ {ℓ ℓ'} {A : Set ℓ} {x : A}
+                                   -- (P : ∀ (y : A) → x ≡ y → Set ℓ')
+                                   -- (h : ∀ (φ : I) (y : A [ φ ↦ (λ _ → x) ])
+                                   --        (w : (Path _ x (ouc y)) [ φ ↦ (λ { (φ = i1) → λ _ → x}) ] ) →
+                                   --        P (ouc y) ⟨ φ , ouc w ⟩) →
+                                   -- {y : A} (w' : x ≡ y) → P y w'
+           )
+
+-- Version of the constructor for Id where the y is also
+-- explicit. This is sometimes useful when it is needed for
+-- typechecking (see JId below).
+conId : ∀ {x : A} φ (y : A [ φ ↦ (λ _ → x) ])
+          (w : (Path _ x (ouc y)) [ φ ↦ (λ { (φ = i1) → λ _ → x}) ]) →
+          x ≡ ouc y
+conId φ _ w = ⟨ φ , ouc w ⟩
+
+-- Reflexivity
+refl : ∀ {x : A} → x ≡ x
+refl {x = x} = ⟨ i1 , (λ _ → x) ⟩
+
+
+-- Definition of J for Id
+module _ {x : A} (P : ∀ (y : A) → Id x y → Set ℓ') (d : P x refl) where
+  J : ∀ {y : A} (w : x ≡ y) → P y w
+  J {y = y} = elimId P (λ φ y w → comp (λ i → P _ (conId (φ ∨ ~ i) (inc (ouc w i))
+                                                                   (inc (λ j → ouc w (i ∧ j)))))
+                                       (λ i → λ { (φ = i1) → d}) (inc d)) {y = y}
+
+  -- Check that J of refl is the identity function
+  Jdefeq : Path _ (J refl) d
+  Jdefeq _ = d
+
+
+Higher inductive types
+----------------------
+
+
+data S¹ : Set where
+  base : S¹
+  loop : base ≡ base
+
+
+  
+data Torus : Set where
+  point : Torus
+  line1 : point ≡ point
+  line2 : point ≡ point
+  square : PathP (λ i → line1 i ≡ line1 i) line2 line2
+
+t2c : Torus → S¹ × S¹
+t2c point        = ( base , base )
+t2c (line1 i)    = ( loop i , base )
+t2c (line2 j)    = ( base , loop j )
+t2c (square i j) = ( loop i , loop j )
+
+c2t : S¹ × S¹ → Torus
+c2t (base   , base)   = point
+c2t (loop i , base)   = line1 i
+c2t (base   , loop j) = line2 j
+c2t (loop i , loop j) = square i j
+
+c2t-t2c : ∀ (t : Torus) → c2t (t2c t) ≡ t
+c2t-t2c point        = refl
+c2t-t2c (line1 _)    = refl
+c2t-t2c (line2 _)    = refl
+c2t-t2c (square _ _) = refl
+
+t2c-c2t : ∀ (p : S¹ × S¹) → t2c (c2t p) ≡ p
+t2c-c2t (base   , base)   = refl
+t2c-c2t (base   , loop _) = refl
+t2c-c2t (loop _ , base)   = refl
+t2c-c2t (loop _ , loop _) = refl
+
+Torus≡S¹×S¹ : Torus ≡ S¹ × S¹
+Torus≡S¹×S¹ = isoToPath (iso t2c c2t t2c-c2t c2t-t2c)
+
+ΩTorus : Set
+ΩTorus = point ≡ point
+
+
+
+data ∥_∥ {ℓ} (A : Set ℓ) : Set ℓ where
+  ∣_∣ : A → ∥ A ∥
+  squash : ∀ (x y : ∥ A ∥) → x ≡ y
+
+private
+  variable
+    ℓ : Level
+    A : Set ℓ
+
+recPropTrunc : ∀ {P : Set ℓ} → isProp P → (A → P) → ∥ A ∥ → P
+recPropTrunc Pprop f ∣ x ∣          = f x
+recPropTrunc Pprop f (squash x y i) =
+  Pprop (recPropTrunc Pprop f x) (recPropTrunc Pprop f y) i
+
+
 ----------
 References
 ----------
 
-.. _`Cohen et al., Cubical`:
+.. _`CCHM, Cubical`:
 
-   Cyril Cohen, Thierry Coquand, Simon Huber and Anders Mörtberg; `“Cubical Type Theory: a constructive interpretation of the univalence axiom” <http://www.cse.chalmers.se/~simonhu/papers/cubicaltt.pdf>`_.
+  Cyril Cohen, Thierry Coquand, Simon Huber and Anders Mörtberg;
+  `“Cubical Type Theory: a constructive interpretation of the
+  univalence axiom” <https://arxiv.org/abs/1611.02108>`_.
+
+.. _`CHM, Cubical`:
+
+  Thierry Coquand, Simon Huber, Anders Mörtberg; `"On Higher Inductive
+  Types in Cubical Type Theory" <https://arxiv.org/abs/1802.01170>`_.

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -419,7 +419,7 @@ When calling ``hcomp {φ = φ} u u0`` Agda makes sure that ``u0`` agrees
 with ``u i0`` on ``φ``. The idea is that ``u0`` is the base and ``u``
 specifies the sides of an open box. This is hence an open (higher
 dimensional) cube where the side opposite of ``u0`` is missing. The
-``hcomp`` operation then gives us the missing side opposite ove
+``hcomp`` operation then gives us the missing side opposite of
 ``u0``. For example binary composition of paths can be written as:
 
 ::

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -19,18 +19,17 @@
 Cubical Type Theory in Agda
 ***************************
 
-As of 2.6.0 Agda has a cubical mode which extends Agda with a variety
-of features from Cubical Type Theory. In particular, computational
-univalence and higher inductive types.
+As of version 2.6.0 Agda has a cubical mode which extends Agda with a
+variety of features from Cubical Type Theory. In particular,
+computational univalence and higher inductive types. The version of
+Cubical Type Theory that Agda implements is a variation of `CCHM`_
+where the Kan composition operations are decomposed into homogeneous
+composition and generalized transport. This is what makes the general
+schema for higher inductive types work, following `CHM`_.
 
-The version of Cubical Type Theory that Agda implements is a variation
-of `CCHM`_ where the Kan composition operations are decomposed into
-homogeneous composition and generalized transport. This is what makes
-the general schema for higher inductive types work, following `CHM`_.
-
-To use cubical type theory, you need to run Agda with the
-``--cubical`` command-line-option or put ``{-# OPTIONS --cubical #-}``
-at the top of the file.
+To use the cubical mode Agda needs to be run with the ``--cubical``
+command-line-option or with ``{-# OPTIONS --cubical #-}`` at the top
+of the file.
 
 The cubical mode adds the following features to Agda:
 
@@ -58,7 +57,7 @@ https://github.com/Saizan/cubical-demo/.
 The interval and path types
 ---------------------------
 
-The key idea of cubical type theory is to add an interval type ``I :
+The key idea of Cubical Type Theory is to add an interval type ``I :
 Setω`` (the reason this is in ``Setω`` is because it doesn't support
 the Kan operations). A variable ``i : I`` intuitively corresponds to a
 point the `real unit interval
@@ -75,6 +74,7 @@ Elements of the interval form a `De Morgan algebra
 (``∧``), maximum (``∨``) and negation (``~``).
 
 .. code-block:: agda
+
     max, min : I → I → I
     max i j = i ∨ j
     min i j = i ∧ j
@@ -87,6 +87,7 @@ endpoints of the interval ``i0`` and ``i1`` are the bottom and top
 elements, respectively
 
 .. code-block:: agda
+
   module interval-equations (i j : I) where
     data _≡_ (i : I) : I → Set where
       reflI : i ≡ i
@@ -112,8 +113,7 @@ elements, respectively
     p₈ = reflI
 
 
-
-The core idea of homotopy type theory is a correspondence between
+The core idea of Homotopy Type Theory is a correspondence between
 paths and (proof-relevant) equality. This is taken very literally in
 Cubical Agda where a path in a type ``A`` is like a function out of
 the interval, ``I → A``. A ``Path`` is in fact a special case of the

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -344,8 +344,7 @@ Partial elements are introduced using pattern matching:
 
 The term ``partialBool`` should be thought of a boolean with different
 values when ``(i = i0)`` and ``(i = i1)``. Terms of type ``Partial φ
-A`` can also be introduced using pattern matching lambdas
-(http://wiki.portal.chalmers.se/agda/pmwiki.php?n=ReferenceManual.PatternMatchingLambdas).
+A`` can also be introduced using a :ref:`pattern-lambda`.
 
 ::
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -663,11 +663,12 @@ which computes properly:
            ; ∥∥-induction    -- Dependent elimination.
            )
 
-However, even though this interface exists it is recommended that one
-uses the cubical primitives unless one really need ``J`` to compute on
-``refl``. The reason for this is that the syntax for path types does
-not work for the identity types, making many proofs more involved as
-the only way to reason about the identity types are using ``J``.
+However, even though this interface exists it is still recommended
+that one uses the cubical primitives unless one really need ``J`` to
+compute on ``refl``. The reason for this is that the syntax for path
+types does not work for the identity types, making many proofs more
+involved as the only way to reason about the identity types is using
+``J``.
            
 ----------
 References

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -92,7 +92,7 @@ make this library visible to Agda add
 path to where the ``agda/cubical`` library has been installed). For
 details of Agda's library management see :ref:`package-system`.
 
-Expert users who doesn't want to rely on ``agda/cubical`` can just add
+Expert users who do not want to rely on ``agda/cubical`` can just add
 the relevant import statements at the top of their file (for details
 see :ref:`primitives-ref`). However, for beginners it is
 recommended that one uses at least the core part of the

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -376,9 +376,10 @@ Cubical Agda also has cubical subtypes as in the CCHM type theory:
   _[_↦_] : ∀ {ℓ} (A : Set ℓ) (φ : I) (u : Partial φ A) → Setω
   A [ φ ↦ u ] = Sub A φ u
 
-A term ``v : A [ φ ↦ u ]`` is of type ``A`` and when ``IsOne φ`` it
-must be definitionally equal to ``u : A``. Any term ``u : A`` can be
-seen as an term of ``A [ φ ↦ u ]`` which agrees with itself on ``φ``:
+A term ``v : A [ φ ↦ u ]`` should be thought of as a term of type
+``A`` which is definitionally equal to ``u : A`` when ``IsOne φ`` is
+satisfied. Any term ``u : A`` can be seen as an term of ``A [ φ ↦ u
+]`` which agrees with itself on ``φ``:
 
 .. code-block:: agda
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -131,7 +131,7 @@ heterogeneous path types:
    Path A a b = PathP (λ _ → A) a b
 
 The central notion of equality in Cubical Agda is hence heterogeneous
-(which is sometimes called "John Major equality"). To define paths we
+equality (in the sense of ``PathOver`` in HoTT). To define paths we
 use λ-abstractions and to apply them we use regular application.  For
 example, this is the definition of the constant path (or proof of
 reflexivity):

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -342,7 +342,7 @@ There is a new form of pattern matching that can be used to introduce partial el
   partialBool i (i = i0) = true
   partialBool i (i = i1) = false
 
-The term ``partialBool`` should be thought of a boolean with different
+The term ``partialBool i`` should be thought of a boolean with different
 values when ``(i = i0)`` and ``(i = i1)``. Terms of type ``Partial φ
 A`` can also be introduced using a :ref:`pattern-lambda`.
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -675,7 +675,7 @@ compute on ``refl``. The reason for this is that the syntax for path
 types does not work for the identity types, making many proofs more
 involved as the only way to reason about the identity types is using
 ``J``.
-           
+
 ----------
 References
 ----------

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -80,7 +80,6 @@ the following to the top of a file (this assumes that the
 .. code-block:: agda
 
   {-# OPTIONS --cubical #-}
-  module MyModule where
 
   open import Cubical.Core.Everything
 
@@ -745,7 +744,6 @@ follows:
 .. code-block:: agda
 
   {-# OPTIONS --cubical #-}
-  module MyModule where
 
   open import Cubical.Core.HoTT-UF
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -380,7 +380,7 @@ Pictorially we are given ``p : x ≡ y`` and ``q : y ≡ z``, and the
 composite of the two paths is obtained by computing the missing lid of
 this open square:
 
-.. code-block::
+.. code-block:: text
 
           x             z
           ^             ^

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -1,5 +1,6 @@
 ..
   ::
+
   {-# OPTIONS --cubical #-}
   module language.cubical where
 
@@ -35,20 +36,20 @@
 
 .. _cubical:
 
-***************************
-Cubical Type Theory in Agda
-***************************
+*******
+Cubical
+*******
 
-As of version 2.6.0 Agda has a cubical mode which extends Agda with a
-variety of features from Cubical Type Theory. In particular,
-computational univalence and higher inductive types which hence gives
-computational meaning to `Homotopy Type Theory and Univalent
-Foundations <https://homotopytypetheory.org/>`_. The version of
-Cubical Type Theory that Agda implements is a variation of the `CCHM`_
-Cubical Type Theory where the Kan composition operations are
-decomposed into homogeneous composition and generalized
-transport. This is what makes the general schema for higher inductive
-types work, following the `CHM`_ paper.
+The Cubical mode extends Agda with a variety of features from Cubical
+Type Theory. In particular, computational univalence and higher
+inductive types which hence gives computational meaning to `Homotopy
+Type Theory and Univalent Foundations
+<https://homotopytypetheory.org/>`_. The version of Cubical Type
+Theory that Agda implements is a variation of the `CCHM`_ Cubical Type
+Theory where the Kan composition operations are decomposed into
+homogeneous composition and generalized transport. This is what makes
+the general schema for higher inductive types work, following the
+`CHM`_ paper.
 
 To use the cubical mode Agda needs to be run with the ``--cubical``
 command-line-option or with ``{-# OPTIONS --cubical #-}`` at the top
@@ -56,34 +57,42 @@ of the file.
 
 The cubical mode adds the following features to Agda:
 
-1. An interval ``I`` type and path types
-2. Partial elements and systems
-3. Kan operations (``transp`` and ``hcomp``)
-4. ``Glue`` types
-5. Higher inductive types
-6. Cubical identity types
+1. An interval type and path types
+2. Generalized transport (``transp``)
+3. Partial elements and systems
+4. Homogeneous composition (``hcomp``)
+5. Glue types
+6. Higher inductive types
+7. Cubical identity types
 
-There is a standard library for Cubical Agda available at
-https://github.com/agda/cubical.
+There is a standard ``agda/cubical`` library for Cubical Agda
+available at https://github.com/agda/cubical. This documentation uses
+the naming conventions of this library, for a detailed list of all of
+the built-in Cubical Agda files and primitives see
+:ref:`primitives-ref`.
 
 The main design choices of the core part of the library are explained
 in https://homotopytypetheory.org/2018/12/06/cubical-agda/.
 
 In order to get access to the Cubical Agda primitives one should
 either import
-https://github.com/agda/cubical/blob/master/Cubical/Core/Primitives.agda
-or add the relevant import statements from the top of that file.
+https://github.com/agda/cubical/blob/master/Cubical/Core/Everything.agda
+or add the relevant import statements from the top of that file (for
+details for experts see :ref:`primitives-ref`). For beginners it is
+recommended that one uses at least the core part of the
+``agda/cubical`` library.
 
 There is also an older version of the library available at
-https://github.com/Saizan/cubical-demo/.
+https://github.com/Saizan/cubical-demo/. However this is relying on
+deprecated features and is not recommended to use.
 
 The interval and path types
 ---------------------------
 
 The key idea of Cubical Type Theory is to add an interval type ``I :
 Setω`` (the reason this is in ``Setω`` is because it doesn't support
-the Kan operations). A variable ``i : I`` intuitively corresponds to a
-point the `real unit interval
+the ``transp`` and ``hcomp`` operations). A variable ``i : I``
+intuitively corresponds to a point the `real unit interval
 <https://en.wikipedia.org/wiki/Unit_interval>`_. In an empty context,
 there are only two values of type ``I``: the two endpoints of the
 interval, ``i0`` and ``i1``.
@@ -105,7 +114,7 @@ Elements of the interval form a `De Morgan algebra
 
 All the properties of De Morgan algebras hold definitionally. The
 endpoints of the interval ``i0`` and ``i1`` are the bottom and top
-elements, respectively
+elements, respectively.
 
 .. code-block:: agda
 
@@ -226,7 +235,7 @@ particular means that we cannot yet prove the induction principle for
 paths. In order to remedy this we also have a built-in (generalized)
 transport operation and homogeneous composition operations. The
 transport operation is generalized in the sense that it lets us
-specify where it is the identity function
+specify where it is the identity function.
 
 .. code-block:: agda
 
@@ -237,16 +246,16 @@ a`` to type-check, which is that ``A`` has to be *constant* on
 ``r``. This means that ``A`` should be a constant function whenever
 the constraint ``r = i1`` is satisfied.  This side condition is
 vacuously true when ``r`` is ``i0``, so there is nothing to check when
-writing ``transp A i0 a``. However when ``r`` is equal to `i1` the
-``transp`` function will compute as the identity function
+writing ``transp A i0 a``. However when ``r`` is equal to ``i1`` the
+``transp`` function will compute as the identity function.
 
 .. code-block:: agda
 
    transp A i1 a = a
 
-and this requires ``A`` to be constant for it to be well-typed.
+This requires ``A`` to be constant for it to be well-typed.
 
-We can use `transp` to define regular transport:
+We can use ``transp`` to define regular transport:
 
 ::
 
@@ -266,8 +275,8 @@ induction principle for paths:
 One subtle difference between paths and the propositional equality
 type of Agda is that the computation rule for ``J`` does not hold
 definitionally. If ``J`` is defined using pattern-matching as in the
-standard library then this holds, however as the path types are not
-inductively defined this does not hold for the above definition of
+Agda standard library then this holds, however as the path types are
+not inductively defined this does not hold for the above definition of
 ``J``. In particular, transport in a constant family is only the
 identity function up to a path which implies that the computation rule
 for ``J`` only holds up to a path:
@@ -282,9 +291,9 @@ for ``J`` only holds up to a path:
   JRefl P d = transportRefl d
 
 Internally in Agda the ``transp`` operation computes by cases on the
-type, so for example for Sigma types it is computed elementwise. For
-path types it is however not yet possible to provide the computation
-rule as we need some way to remember the endpoints of the path after
+type, so for example for Σ-types it is computed elementwise. For path
+types it is however not yet possible to provide the computation rule
+as we need some way to remember the endpoints of the path after
 transporting it. Furthermore, this must work for arbitrary higher
 dimensional cubes (as we can iterate the path types). For this we
 introduce the "homogeneous composition operations" (``hcomp``) that
@@ -362,10 +371,9 @@ Cubical Agda also has cubical subtypes as in the CCHM type theory:
   _[_↦_] : ∀ {ℓ} (A : Set ℓ) (φ : I) (u : Partial φ A) → Setω
   A [ φ ↦ u ] = Sub A φ u
 
-A term ``v : A [ φ ↦ u ]`` is of type ``v : A`` and when ``IsOne φ``
-it must be definitionally equal to ``u : A``. Any term ``u : A`` can
-be seen as an term of ``A [ φ ↦ u ]`` which agrees with itself on
-``φ``:
+A term ``v : A [ φ ↦ u ]`` is of type ``A`` and when ``IsOne φ`` it
+must be definitionally equal to ``u : A``. Any term ``u : A`` can be
+seen as an term of ``A [ φ ↦ u ]`` which agrees with itself on ``φ``:
 
 .. code-block:: agda
 
@@ -394,18 +402,16 @@ of paths so that we can compose multiple composable cubes.
 When calling ``hcomp {φ = φ} u u0`` Agda makes sure that ``u0`` agrees
 with ``u i0`` on ``φ``. The idea is that ``u0`` is the base and ``u``
 specifies the sides of an open box. This is hence an open (higher
-dimensional) cube (maybe with some sides missing) where the side
-opposite of ``u0`` is missing. The ``hcomp`` operation then gives us
-the missing side of the cube. For example binary composition of paths
-can be written as:
+dimensional) cube where the side opposite of ``u0`` is missing. The
+``hcomp`` operation then gives us the missing side opposite ove
+``u0``. For example binary composition of paths can be written as:
 
 ::
 
   compPath : ∀ {ℓ} {A : Set ℓ} {x y z : A} → x ≡ y → y ≡ z → x ≡ z
-  compPath {x = x} p q i =
-    hcomp (λ j → λ { (i = i0) → x
-                   ; (i = i1) → q j })
-          (p i)
+  compPath {x = x} p q i = hcomp (λ j → λ { (i = i0) → x
+                                          ; (i = i1) → q j })
+                                 (p i)
 
 Pictorially we are given ``p : x ≡ y`` and ``q : y ≡ z``, and the
 composite of the two paths is obtained by computing the missing lid of
@@ -434,31 +440,29 @@ We can also define homogeneous filling of cubes as
   hfill : ∀ {ℓ} {A : Set ℓ} {φ : I}
           (u : ∀ i → Partial φ A) (u0 : A [ φ ↦ u i0 ])
           (i : I) → A
-  hfill {φ = φ} u u0 i =
-    hcomp (λ j → λ { (φ = i1) → u (i ∧ j) 1=1
-                   ; (i = i0) → ouc u0 })
-          (ouc u0)
+  hfill {φ = φ} u u0 i = hcomp (λ j → λ { (φ = i1) → u (i ∧ j) 1=1
+                                        ; (i = i0) → ouc u0 })
+                               (ouc u0)
 
 When ``i`` is ``i0`` this is ``u0`` and when ``i`` is ``i1`` this is
-``hcomp``. This can hence be seen as giving us the interior of an open
-box. In the special case of the square above ``hfill`` gives us a
+``hcomp u u0``. This can hence be seen as giving us the interior of an
+open box. In the special case of the square above ``hfill`` gives us a
 direct cubical proof that composing ``p`` with ``refl`` is ``p``.
 
 ::
 
   compPathRefl : ∀ {ℓ} {A : Set ℓ} {x y : A} (p : x ≡ y) → compPath p refl ≡ p
-  compPathRefl {x = x} {y = y} p j i =
-    hfill (λ _ → λ { (i = i0) → x
-                  ; (i = i1) → y })
-         (inc (p i))
-         (~ j)
+  compPathRefl {x = x} {y = y} p j i = hfill (λ _ → λ { (i = i0) → x
+                                                      ; (i = i1) → y })
+                                             (inc (p i))
+                                             (~ j)
 
 
 Glue types
 ----------
 
 In order to be able to prove the univalence theorem we also have to
-add "Glue types". These lets us turn equivalences between types into
+add "Glue" types. These lets us turn equivalences between types into
 paths between types. An equivalence of types ``A`` and ``B`` is
 defined as a map ``f : A → B`` such that its fibers are contractible.
 
@@ -534,8 +538,8 @@ follows:
   ua {_} {A} {B} e i = Glue B (λ { (i = i0) → (A , e)
                                  ; (i = i1) → (B , idEquiv B) })
 
-The idea is that we glue on ``A`` to ``B`` when ``i`` is ``i0`` using
-``e`` and ``B`` to itself when ``i`` is ``i1`` using the identity
+The idea is that we glue on ``A`` to ``B`` when ``i = i0`` using ``e``
+and ``B`` to itself when ``i = i1`` using the identity
 equivalence. This hence gives us the key part of univalence: a
 function for turning equivalences into paths. The other part of
 univalence is that this map itself is an equivalence which follows
@@ -551,7 +555,7 @@ equivalence is hence the same as applying the equivalence. This is
 what makes it possible to use the univalence axiom computationally in
 Cubical Agda: we can package up our equivalences as paths, do equality
 reasoning using these paths, and in the end transport along the paths
-in order to compute with them.
+in order to compute with the equivalences.
 
 For more results about Glue types and univalence see
 https://github.com/agda/cubical/blob/master/Cubical/Core/Glue.agda and
@@ -601,7 +605,8 @@ When giving the cases for the path and square constructors we have to
 make sure that the function maps the boundary to the right thing. For
 instance the following definition does not pass Agda's typechecker as
 the boundary of the last case does not match up with the expected
-boundary of the square constructor.
+boundary of the square constructor (as the ``line1`` and ``line2``
+cases are mixed up).
 
 .. code-block:: agda
 
@@ -719,13 +724,13 @@ which computes properly.
            )
 
 However, even though this interface exists it is still recommended
-that one uses the cubical primitives unless one really need ``J`` to
-compute on ``refl``. The reason for this is that the syntax for path
-types does not work for the identity types, making many proofs more
-involved as the only way to reason about the identity types is using
-``J``.
+that one uses the cubical identity types unless one really need ``J``
+to compute on ``refl``. The reason for this is that the syntax for
+path types does not work for the identity types, making many proofs
+more involved as the only way to reason about them is using ``J``
+(furthermore, the path types satisfy many useful definitional
+equalities that the identity types don't).
 
-----------
 References
 ----------
 
@@ -739,3 +744,168 @@ References
 
   Thierry Coquand, Simon Huber, Anders Mörtberg; `"On Higher Inductive
   Types in Cubical Type Theory" <https://arxiv.org/abs/1802.01170>`_.
+
+
+.. _primitives-ref:
+
+Appendix: Cubical Agda primitives
+---------------------------------
+
+The Cubical Agda primitives and internals are exported by a series of
+files found in the ``lib/prim/Agda/Builtin/Cubical`` directory of
+Agda. The ``agda/cubical`` library exports all of these primitives
+with the names used throughout this document. Experts might find it
+useful to know what is actually exported as there are quite a few
+primitives available that are not really exported by ``agda/cubical``,
+so the goal of this section is to list the contents of these
+files. However, for regular users and beginners the ``agda/cubical``
+library should be sufficient and this section can safely be ignored.
+
+The key file with primitives is ``Agda.Primitive.Cubical``. It exports
+the following ``BUILTIN``, primitives and postulates:
+
+.. code-block:: agda
+
+  {-# BUILTIN INTERVAL I    #-} -- I : Setω
+  {-# BUILTIN IZERO    i0   #-}
+  {-# BUILTIN IONE     i1   #-}
+
+  infix 30 primINeg
+  infixr 20 primIMin primIMax
+
+  primitive
+    primIMin : I → I → I   -- _∧_
+    primIMax : I → I → I   -- _∨_
+    primINeg : I → I       -- ~_
+
+  {-# BUILTIN ISONE IsOne #-} -- IsOne : I → Setω
+
+  postulate
+    itIsOne : IsOne i1     -- 1=1
+    IsOne1  : ∀ i j → IsOne i → IsOne (primIMax i j)
+    IsOne2  : ∀ i j → IsOne j → IsOne (primIMax i j)
+
+  {-# BUILTIN ITISONE      itIsOne  #-}
+  {-# BUILTIN ISONE1       IsOne1   #-}
+  {-# BUILTIN ISONE2       IsOne2   #-}
+  {-# BUILTIN PARTIAL      Partial  #-}
+  {-# BUILTIN PARTIALP     PartialP #-}
+
+  postulate
+    isOneEmpty : ∀ {a} {A : Partial i0 (Set a)} → PartialP i0 A
+  {-# BUILTIN ISONEEMPTY isOneEmpty #-}
+
+  primitive
+    primPOr : ∀ {a} (i j : I) {A : Partial (primIMax i j) (Set a)}
+            → PartialP i (λ z → A (IsOne1 i j z)) → PartialP j (λ z → A (IsOne2 i j z))
+            → PartialP (primIMax i j) A
+
+    -- Computes in terms of primHComp and primTransp
+    primComp : ∀ {a} (A : (i : I) → Set (a i)) (φ : I) → (∀ i → Partial φ (A i)) → (a : A i0) → A i1
+
+  syntax primPOr p q u t = [ p ↦ u , q ↦ t ]
+
+  primitive
+    primTransp : ∀ {a} (A : (i : I) → Set (a i)) (φ : I) → (a : A i0) → A i1
+    primHComp : ∀ {a} {A : Set a} {φ : I} → (∀ i → Partial φ A) → A → A
+
+The Path types are exported by ``Agda.Builtin.Cubical.Path``:
+
+.. code-block:: agda
+
+  postulate
+    PathP : ∀ {ℓ} (A : I → Set ℓ) → A i0 → A i1 → Set ℓ
+
+  {-# BUILTIN PATHP        PathP     #-}
+
+  infix 4 _≡_
+  _≡_ : ∀ {ℓ} {A : Set ℓ} → A → A → Set ℓ
+  _≡_ {A = A} = PathP (λ _ → A)
+
+  {-# BUILTIN PATH         _≡_     #-}
+
+The Cubical subtypes are exported by ``Agda.Builtin.Cubical.Sub``:
+
+.. code-block:: agda
+
+  {-# BUILTIN SUB Sub #-}
+
+  postulate
+    inc : ∀ {ℓ} {A : Set ℓ} {φ} (x : A) → Sub A φ (λ _ → x)
+
+  {-# BUILTIN SUBIN inc #-}
+
+  primitive
+    primSubOut : ∀ {ℓ} {A : Set ℓ} {φ : I} {u : Partial φ A} → Sub _ φ u → A
+
+The Glue types are exported by ``Agda.Builtin.Cubical.Glue``:
+
+.. code-block:: agda
+
+  record isEquiv {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) : Set (ℓ ⊔ ℓ') where
+    field
+      equiv-proof : (y : B) → isContr (fiber f y)
+  infix 4 _≃_
+
+  _≃_ : ∀ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') → Set (ℓ ⊔ ℓ')
+  A ≃ B = Σ (A → B) \ f → (isEquiv f)
+
+  equivFun : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} → A ≃ B → A → B
+  equivFun e = fst e
+
+  equivProof : ∀ {la lt} (T : Set la) (A : Set lt) → (w : T ≃ A) → (a : A)
+             → ∀ ψ → (Partial ψ (fiber (w .fst) a)) → fiber (w .fst) a
+  equivProof A B w a ψ fb = contr' {A = fiber (w .fst) a} (w .snd .equiv-proof a) ψ fb
+    where
+      contr' : ∀ {ℓ} {A : Set ℓ} → isContr A → (φ : I) → (u : Partial φ A) → A
+      contr' {A = A} (c , p) φ u = hcomp (λ i → λ { (φ = i1) → p (u 1=1) i
+                                                  ; (φ = i0) → c }) c
+
+  {-# BUILTIN EQUIV      _≃_        #-}
+  {-# BUILTIN EQUIVFUN   equivFun   #-}
+  {-# BUILTIN EQUIVPROOF equivProof #-}
+
+  primitive
+    primGlue    : ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I}
+      → (T : Partial φ (Set ℓ')) → (e : PartialP φ (λ o → T o ≃ A))
+      → Set ℓ'
+    prim^glue   : ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I}
+      → {T : Partial φ (Set ℓ')} → {e : PartialP φ (λ o → T o ≃ A)}
+      → PartialP φ T → A → primGlue A T e
+    prim^unglue : ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I}
+      → {T : Partial φ (Set ℓ')} → {e : PartialP φ (λ o → T o ≃ A)}
+      → primGlue A T e → A
+    primFaceForall : (I → I) → I
+
+  -- pathToEquiv proves that transport is an equivalence (for details
+  -- see Agda.Builtin.Cubical.Glue). This is needed internally.
+  {-# BUILTIN PATHTOEQUIV pathToEquiv #-}
+
+The ``Agda.Builtin.Cubical.Id`` exports the cubical identity types:
+
+.. code-block:: agda
+
+  postulate
+    Id : ∀ {ℓ} {A : Set ℓ} → A → A → Set ℓ
+
+  {-# BUILTIN ID           Id       #-}
+  {-# BUILTIN CONID        conid    #-}
+
+  primitive
+    primDepIMin : _
+    primIdFace : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → I
+    primIdPath : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → x ≡ y
+
+  primitive
+    primIdJ : ∀ {ℓ ℓ'} {A : Set ℓ} {x : A} (P : ∀ y → Id x y → Set ℓ') →
+                P x (conid i1 (λ i → x)) → ∀ {y} (p : Id x y) → P y p
+
+
+  primitive
+    primIdElim : ∀ {a c} {A : Set a} {x : A}
+                   (C : (y : A) → Id x y → Set c) →
+                   ((φ : I) (y : A [ φ ↦ (λ _ → x) ])
+                    (w : (x ≡ ouc y) [ φ ↦ (λ { (φ = i1) → \ _ → x}) ]) →
+                    C (ouc y) (conid φ (ouc w))) →
+                   {y : A} (p : Id x y) → C y p
+

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -362,7 +362,7 @@ of paths so that we can compose multiple composable cubes.
 
 When calling ``hcomp {φ = φ} u u0`` Agda makes sure that ``u0`` agrees
 with ``u i0`` on ``φ``. The idea is that ``u0`` is the base and ``u``
-specify the sides of an open box. This is hence an open (higher
+specifies the sides of an open box. This is hence an open (higher
 dimensional) cube (maybe with some sides missing) where the side
 opposite of ``u0`` is missing. The ``hcomp`` operation then gives us
 the missing side of the cube. For example binary composition of paths

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -24,35 +24,36 @@ of features from Cubical Type Theory. In particular, computational
 univalence and higher inductive types.
 
 The version of Cubical Type Theory that Agda implements is a variation
-of `CCHM, Cubical`_ where the Kan composition operations are
-decomposed into homogeneous composition and generalized
-transport. This what makes a general schema for higher inductive types
-work, following `CHM, Cubical`_.
+of `CCHM`_ where the Kan composition operations are decomposed into
+homogeneous composition and generalized transport. This is what makes
+the general schema for higher inductive types work, following `CHM`_.
 
 To use cubical type theory, you need to run Agda with the
-``--cubical`` command-line-option. You can also write ``{-#
-OPTIONS --cubical #-}`` at the top of the file.
+``--cubical`` command-line-option or put ``{-# OPTIONS --cubical #-}``
+at the top of the file.
 
 The cubical mode adds the following features to Agda:
 
-1. An interval and path types
+1. An interval ``I`` type and path types
 2. Partial elements and systems
-3. Kan operations (transp and hcomp)
-4. Glue types
-5. Cubical identity types
-6. Higher inductive types
+3. Kan operations (``transp`` and ``hcomp``)
+4. ``Glue`` types
+5. Higher inductive types
+6. Cubical identity types
 
-
-There is a library for Cubical Agda available at:
-https://github.com/agda/cubical
+There is a standard library for Cubical Agda available at
+https://github.com/agda/cubical.
 
 The main design choices of the core part of the library are explained
-in: https://homotopytypetheory.org/2018/12/06/cubical-agda/
+in https://homotopytypetheory.org/2018/12/06/cubical-agda/.
 
-In order to use Cubical Agda one should either import
+In order to get access to the Cubical Agda primitives one should
+either import
 https://github.com/agda/cubical/blob/master/Cubical/Core/Primitives.agda
 or add the relevant import statements from the top of that file.
 
+There is also an older version of the library available at
+https://github.com/Saizan/cubical-demo/.
 
 The interval and path types
 ---------------------------
@@ -573,13 +574,13 @@ explicitly.
 References
 ----------
 
-.. _`CCHM, Cubical`:
+.. _`CCHM`:
 
   Cyril Cohen, Thierry Coquand, Simon Huber and Anders Mörtberg;
   `“Cubical Type Theory: a constructive interpretation of the
   univalence axiom” <https://arxiv.org/abs/1611.02108>`_.
 
-.. _`CHM, Cubical`:
+.. _`CHM`:
 
   Thierry Coquand, Simon Huber, Anders Mörtberg; `"On Higher Inductive
   Types in Cubical Type Theory" <https://arxiv.org/abs/1802.01170>`_.

--- a/doc/user-manual/unicode-symbols-sphinx.tex.txt
+++ b/doc/user-manual/unicode-symbols-sphinx.tex.txt
@@ -176,6 +176,7 @@
 \DeclareUnicodeCharacter{220F}{{\tiny \ensuremath{\prod}}}  % Symbol ∏
 \DeclareUnicodeCharacter{2211}{\ensuremath{\sum}}           % Symbol ∑
 \DeclareUnicodeCharacter{2218}{\ensuremath{\circ}}          % Symbol ∘
+\DeclareUnicodeCharacter{2219}{\ensuremath{\bullet}}        % Symbol ∙
 \DeclareUnicodeCharacter{221E}{\ensuremath{\infty}}         % Symbol ∞
 \DeclareUnicodeCharacter{2223}{\ensuremath{\mid}}           % Symbol ∣
 \DeclareUnicodeCharacter{2225}{\ensuremath{\parallel}}      % Symbol ∥


### PR DESCRIPTION
This is a first step towards resolving https://github.com/agda/agda/issues/3539. Comments from non-experts on Cubical Agda are especially welcome.

To see what the documentation looks like when rendered properly see: https://github.com/mortberg/agda/blob/cubicaldoc/doc/user-manual/language/cubical.lagda.rst

I suspect that this file is supposed to typecheck somehow (as it is a `.lagda` file...), but I don't know how to run Agda on it so it surely doesn't at the moment. Instructions for how to do this would be most welcome.