### PR TITLE
[WIP] Allow for fixity re-assignment when importing operator 

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -331,6 +331,7 @@ library
                     Agda.Syntax.DoNotation
                     Agda.Syntax.Fixity
                     Agda.Syntax.IdiomBrackets
+                    Agda.Syntax.ImportDirective
                     Agda.Syntax.Info
                     Agda.Syntax.Internal
                     Agda.Syntax.Internal.Defs

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -41,6 +41,7 @@ import Agda.Syntax.Abstract.Name as A (QNamed)
 import qualified Agda.Syntax.Internal as I
 
 import Agda.Syntax.Common
+import Agda.Syntax.ImportDirective
 import Agda.Syntax.Info
 import Agda.Syntax.Fixity ( Fixity' )
 import Agda.Syntax.Literal

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -67,6 +67,7 @@ import Data.Data (Data)
 import Agda.Syntax.Position
 import Agda.Syntax.Common
 import Agda.Syntax.Fixity
+import Agda.Syntax.ImportDirective
 import Agda.Syntax.Notation
 import Agda.Syntax.Literal
 

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -20,6 +20,7 @@ import qualified Data.Strict.Maybe as Strict
 import Agda.Syntax.Common
 import Agda.Syntax.Concrete
 import Agda.Syntax.Fixity
+import Agda.Syntax.ImportDirective
 import Agda.Syntax.Notation
 import Agda.Syntax.Position
 

--- a/src/full/Agda/Syntax/ImportDirective.hs
+++ b/src/full/Agda/Syntax/ImportDirective.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DeriveDataTypeable         #-}
+
+module Agda.Syntax.ImportDirective where
+
+import Control.DeepSeq
+import Data.Data (Data)
+
+import Agda.Syntax.Common
+import Agda.Syntax.Fixity
+import Agda.Syntax.Position
+
+-----------------------------------------------------------------------------
+-- * Import directive
+-----------------------------------------------------------------------------
+
+-- | The things you are allowed to say when you shuffle names between name
+--   spaces (i.e. in @import@, @namespace@, or @open@ declarations).
+data ImportDirective' n m = ImportDirective
+  { importDirRange :: Range
+  , using          :: Using' n m
+  , hiding         :: [ImportedName' n m]
+  , impRenaming    :: [Renaming' n m]
+  , publicOpen     :: Bool -- ^ Only for @open@. Exports the opened names from the current module.
+  }
+  deriving (Data, Eq)
+
+data Renaming' n m = Renaming
+  { renFrom    :: ImportedName' n m
+    -- ^ Rename from this name.
+  , renTo      :: ImportedName' n m
+    -- ^ To this one.  Must be same kind as 'renFrom'.
+  , renToRange :: Range
+    -- ^ The range of the \"to\" keyword.  Retained for highlighting purposes.
+  , fixity :: Maybe Fixity
+  }
+  deriving (Data, Eq)
+
+-- | Default is directive is @private@ (use everything, but do not export).
+defaultImportDir :: ImportDirective' n m
+defaultImportDir = ImportDirective noRange UseEverything [] [] False
+
+isDefaultImportDir :: ImportDirective' n m -> Bool
+isDefaultImportDir (ImportDirective _ UseEverything [] [] False) = True
+isDefaultImportDir _                                             = False
+
+-- ** HasRange instances
+
+instance (HasRange a, HasRange b) => HasRange (Renaming' a b) where
+  getRange r = getRange (renFrom r, renTo r)
+
+
+instance (HasRange a, HasRange b) => HasRange (ImportDirective' a b) where
+  getRange = importDirRange
+
+
+-- ** KillRange instances
+
+instance (KillRange a, KillRange b) => KillRange (Renaming' a b) where
+  killRange (Renaming i n _ f) = killRange2 (\i n -> Renaming i n noRange f) i n
+
+instance (KillRange a, KillRange b) => KillRange (ImportDirective' a b) where
+  killRange (ImportDirective _ u h r p) =
+    killRange3 (\u h r -> ImportDirective noRange u h r p) u h r
+
+-- ** NFData instances
+
+-- | Ranges are not forced.
+
+instance (NFData a, NFData b) => NFData (Renaming' a b) where
+  rnf (Renaming a b _ _) = rnf a `seq` rnf b
+
+instance (NFData a, NFData b) => NFData (ImportDirective' a b) where
+  rnf (ImportDirective _ a b c _) = rnf a `seq` rnf b `seq` rnf c
+

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -46,6 +46,7 @@ import Agda.Syntax.Concrete.Pattern
 import Agda.Syntax.Concrete.Pretty ()
 import Agda.Syntax.Common
 import Agda.Syntax.Fixity
+import Agda.Syntax.ImportDirective
 import Agda.Syntax.Notation
 import Agda.Syntax.Literal
 
@@ -1095,9 +1096,16 @@ Renamings
     : Renaming ';' Renamings    { $1 : $3 }
     | Renaming                  { [$1] }
 
+Fixity :: { Fixity }
+Fixity
+    : 'infix'  Int { Fixity (getRange $1) (Related $2) NonAssoc }
+    | 'infixl' Int { Fixity (getRange $1) (Related $2) LeftAssoc }
+    | 'infixr' Int { Fixity (getRange $1) (Related $2) RightAssoc }
+
 Renaming :: { Renaming }
 Renaming
-    : ImportName_ 'to' Id { Renaming $1 (setImportedName $1 $3) (getRange $2) }
+    : ImportName_ 'to' Id { Renaming $1 (setImportedName $1 $3) (getRange $2) Nothing }
+    | ImportName_ 'to' Fixity Id { Renaming $1 (setImportedName $1 $4) (getRange $2) (Just $3) }
 
 -- We need a special imported name here, since we have to trigger
 -- the imp_dir state exactly one token before the 'to'

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -34,6 +34,7 @@ import Agda.Benchmarking
 import Agda.Syntax.Position
 import Agda.Syntax.Common
 import Agda.Syntax.Fixity
+import Agda.Syntax.ImportDirective
 import Agda.Syntax.Abstract.Name as A
 import Agda.Syntax.Concrete.Name as C
 import qualified Agda.Syntax.Concrete as C
@@ -659,8 +660,8 @@ applyImportDirective dir s = mergeScope usedOrHidden renamed
                            id
       where
         (drho, mrho) = partitionEithers $ for rho $ \case
-          Renaming (ImportedName   x) (ImportedName   y) _ -> Left  (x,y)
-          Renaming (ImportedModule x) (ImportedModule y) _ -> Right (x,y)
+          Renaming (ImportedName   x) (ImportedName   y) _ _ -> Left  (x,y)
+          Renaming (ImportedModule x) (ImportedModule y) _ _ -> Right (x,y)
           _ -> __IMPOSSIBLE__
 
         ren r x = fromMaybe x $ lookup x r

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -25,6 +25,7 @@ import Data.Traversable hiding (for)
 import Agda.Syntax.Common
 import Agda.Syntax.Position
 import Agda.Syntax.Fixity
+import Agda.Syntax.ImportDirective
 import Agda.Syntax.Abstract.Name as A
 import qualified Agda.Syntax.Abstract as A
 import Agda.Syntax.Abstract (ScopeCopyInfo(..), initCopyInfo)
@@ -649,10 +650,10 @@ applyImportDirectiveM m (ImportDirective rng usn' hdn' ren' public) scope = do
         addExtra f@(ImportedName y) | elem y extra = [f, ImportedModule y]
         addExtra m = [m]
 
-        extraRenaming r@(Renaming from to rng) =
+        extraRenaming r@(Renaming from to rng i) =
           case (from, to) of
             (ImportedName y, ImportedName z) | elem y extra ->
-              [r, Renaming (ImportedModule y) (ImportedModule z) rng]
+              [r, Renaming (ImportedModule y) (ImportedModule z) rng i]
             _ -> [r]
 
     -- | Names and modules (abstract) in scope before the import.
@@ -715,8 +716,8 @@ mapRenaming
   -> [ImportedName' (n1,n2) (m1,m2)]  -- ^ Translation of 'rento'   names and module names.
   -> Renaming' n1 m1  -- ^ Renaming before translation (1).
   -> Renaming' n2 m2  -- ^ Renaming after  translation (2).
-mapRenaming src tgt (Renaming from to r) =
-  Renaming (lookupImportedName from src) (lookupImportedName to tgt) r
+mapRenaming src tgt (Renaming from to r i) =
+  Renaming (lookupImportedName from src) (lookupImportedName to tgt) r i
 
 data OpenKind = LetOpenModule | TopOpenModule
 

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -45,6 +45,7 @@ import Data.List (sortBy)
 import Agda.Syntax.Common
 import Agda.Syntax.Position
 import Agda.Syntax.Literal
+import Agda.Syntax.ImportDirective
 import Agda.Syntax.Info as A
 import Agda.Syntax.Internal (MetaId(..))
 import qualified Agda.Syntax.Internal as I

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -52,6 +52,7 @@ import qualified Agda.Syntax.Internal as I
 import Agda.Syntax.Position
 import Agda.Syntax.Literal
 import Agda.Syntax.Common
+import Agda.Syntax.ImportDirective
 import Agda.Syntax.Info
 import Agda.Syntax.Concrete.Definitions as C
 import Agda.Syntax.Fixity

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -39,6 +39,7 @@ import Agda.Interaction.Options
 import Agda.Interaction.Options.Warnings
 import Agda.Syntax.Common
 import Agda.Syntax.Fixity
+import Agda.Syntax.ImportDirective
 import Agda.Syntax.Notation
 import Agda.Syntax.Position
 import qualified Agda.Syntax.Info as A

--- a/test/Succeed/ChangeFixity.agda
+++ b/test/Succeed/ChangeFixity.agda
@@ -1,0 +1,20 @@
+module ChangeFixity where
+
+postulate
+  A : Set
+  B : Set
+  result : B
+
+module Product where
+  infixr 4 _×_
+  _×_ : A → B → B
+  a × b = b
+
+  infixr 3 _,_
+  _,_ : A → A → B
+  a , b = result
+
+open Product using (_×_) renaming (_,_ to infixr 5 _∷_)
+
+solution : A → B
+solution a = a × a ∷ a


### PR DESCRIPTION
I made an update to the syntax to support rebinding fixity as suggested here: https://github.com/agda/agda/issues/3574#issuecomment-465054848, although I haven't yet figured out how to implement the feature.

Two questions:

1. Is this syntax (and feature, in general) acceptable in terms of the language design? I.e would a working implementation PR be merged?

2. Could anyone with some knowledge of the internals indicate a good starting point on the implementation? I made an attempt in `fixitiesAndPolarities'` but it seems like that's not the correct place.