### PR TITLE
[doc] update footer to new year

### DIFF
--- a/doc/user-manual/conf.py
+++ b/doc/user-manual/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Agda'
-copyright = u'''2005-2018 remains with the authors.
+copyright = u'''2005–2019 remains with the authors.
 Agda 2 was originally written by Ulf Norell,
 partially based on code from Agda 1 by Catarina Coquand and Makoto Takeyama,
 and from Agdalight by Ulf Norell and Andreas Abel.


### PR DESCRIPTION
I updated `2018` to `2019` and in the same go changed the ASCII hyphen into a proper Unicode en dash.