### PR TITLE
Fix #3588 Use unambiguous name in introTactic

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -861,6 +861,9 @@ introTactic pmLambda ii = do
     conName [p] = [ c | I.ConP c _ _ <- [namedArg p] ]
     conName _   = __IMPOSSIBLE__
 
+    showUnambiguousConName v =
+       render <$> pretty <$> runAbsToCon (lookupQName AmbiguousNothing $ I.conName v)
+
     showTCM :: PrettyTCM a => a -> TCM String
     showTCM v = render <$> prettyTCM v
 
@@ -896,7 +899,8 @@ introTactic pmLambda ii = do
       r <- splitLast CoInductive tel pat
       case r of
         Left err -> return []
-        Right cov -> mapM showTCM $ concatMap (conName . scPats) $ splitClauses cov
+        Right cov ->
+           mapM showUnambiguousConName $ concatMap (conName . scPats) $ splitClauses cov
 
     introRec :: QName -> TCM [String]
     introRec d = do

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -22,6 +22,7 @@ module Agda.Syntax.Translation.AbstractToConcrete
     , preserveInteractionIds
     , AbsToCon, Env
     , noTakenNames
+    , lookupQName
     ) where
 
 import Prelude hiding (null)

--- a/test/interaction/Issue3588.out
+++ b/test/interaction/Issue3588.out
@@ -4,7 +4,7 @@
 (agda2-status-action "")
 (agda2-info-action "*All Goals*" "?0 : P D.c " nil)
 ((last . 1) . (agda2-goals-action '(0)))
-(agda2-give-action 0 "c")
+(agda2-give-action 0 "M.c")
 (agda2-status-action "")
 (agda2-info-action "*All Done*" "" nil)
 ((last . 1) . (agda2-goals-action '()))


### PR DESCRIPTION
This issue attempts to resolve #3588 by not allowing ambiguous constructor names in `introTactic`. Since `give_gen` appears to determine a suitably qualified name anyways, it seems to me like it does not have any effect in the interaction (I suppose `introTactic` could even return the fully qualified name).

I think what was happening before was that `introTactic` returned the expression "c" since it was an OK name for the expression when allowing ambiguous constructors, and `give_gen` didn't have the necessary context to know which "c" to use.

Also noticed that the result was `M.c` rather than `P.c`, not sure if that matters but it does typecheck at least.