### PR TITLE
Fix for #3655

### DIFF
--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -93,7 +93,7 @@ instance TermLike Term where
     MetaV m xs  -> f =<< MetaV m <$> traverseTermM f xs
     Level l     -> f =<< Level <$> traverseTermM f l
     Lit _       -> f t
-    Sort _      -> f t
+    Sort s      -> f =<< Sort <$> traverseTermM f s
     DontCare mv -> f =<< DontCare <$> traverseTermM f mv
     Dummy{}     -> f t
 
@@ -106,7 +106,7 @@ instance TermLike Term where
     MetaV m xs  -> foldTerm f xs
     Level l     -> foldTerm f l
     Lit _       -> mempty
-    Sort _      -> mempty
+    Sort s      -> foldTerm f s
     DontCare mv -> foldTerm f mv
     Dummy{}     -> mempty
 
@@ -136,6 +136,29 @@ instance TermLike LevelAtom where
 instance TermLike Type where
   traverseTermM f (El s t) = El s <$> traverseTermM f t
   foldTerm f (El s t) = foldTerm f t
+
+instance TermLike Sort where
+  traverseTermM f s = case s of
+    Type l     -> Type <$> traverseTermM f l
+    Prop l     -> Prop <$> traverseTermM f l
+    Inf        -> pure s
+    SizeUniv   -> pure s
+    PiSort a b -> PiSort   <$> traverseTermM f a <*> traverseTermM f b
+    UnivSort a -> UnivSort <$> traverseTermM f a
+    MetaS x es -> MetaS x  <$> traverseTermM f es
+    DefS q es  -> DefS q   <$> traverseTermM f es
+    DummyS{}   -> pure s
+
+  foldTerm f s = case s of
+    Type l     -> foldTerm f l
+    Prop l     -> foldTerm f l
+    Inf        -> mempty
+    SizeUniv   -> mempty
+    PiSort a b -> foldTerm f a <> foldTerm f b
+    UnivSort a -> foldTerm f a
+    MetaS _ es -> foldTerm f es
+    DefS _ es  -> foldTerm f es
+    DummyS{}   -> mempty
 
 instance TermLike EqualityView where
 

--- a/test/Succeed/Issue3655.agda
+++ b/test/Succeed/Issue3655.agda
@@ -1,0 +1,18 @@
+
+open import Agda.Primitive
+
+postulate
+  F : (a : Level) → Set a → Set a
+  P : (a : Level) (A : Set a) → F a A → Set a
+  p : (a : Level) (A : Set a) (x : F a A) → P a A x
+  Q : (a : Level) (A : Set a) → A → Set a
+
+variable
+  a : Level
+  A : Set a
+
+postulate
+  q : (x : F _ A) → Q a _ (p a A x)
+
+q' : {a : Level} {A : Set a} (x : F a A) → Q a (P a A x) (p a A x)
+q' {a} {A} = q {a} {A}


### PR DESCRIPTION
tag #3655 

Generalised argument dependency analysis was thrown off by `allMetas` not looking into sorts. It's strange that this hasn't shown up before now.