### PR TITLE
[ fix #3678 ] Be more careful about shadowing in toConcreteName

### DIFF
--- a/test/interaction/Issue3678.agda
+++ b/test/interaction/Issue3678.agda
@@ -1,0 +1,13 @@
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Equality
+
+postulate
+  A : Set
+  B : A → Set
+  a : A
+
+Pi : (A → Set) → Set
+Pi B = {x : A} → B x
+
+foo : Pi \ y →  Σ (B y) \ _ → Pi \ z → Σ (y ≡ a → B z) \ _ → B y → B z → A
+foo = {!!} , (\ { refl → {!!} }) , {!!}

--- a/test/interaction/Issue3678.in
+++ b/test/interaction/Issue3678.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 2 (cmd_context AsIs) ""

--- a/test/interaction/Issue3678.out
+++ b/test/interaction/Issue3678.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : B x ?1 : B x ?2 : B x₁ → B x₂ → A " nil)
+((last . 1) . (agda2-goals-action '(0 1 2)))
+(agda2-status-action "")
+(agda2-info-action "*Context*" "x₁ : A (not in scope) x₂ : A (not in scope)" nil)


### PR DESCRIPTION
This fixes the issue by also checking names of inserted variables when checking for shadowing names in `toConcreteName`. Unfortunately, since the `takenVarNames` are stored as a set instead of a list, sometimes this also means we rename variables when not strictly necessary. For example, in the test case **both** occurrences of `x` are renamed (to `x₁` and `x₂` respectively). 