### PR TITLE
Fix 3672: prune unsolved metas that are not generalized over

### DIFF
--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -21,6 +21,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Concrete.Name (LensInScope(..))
 import Agda.Syntax.Position
 import Agda.Syntax.Internal
+import Agda.Syntax.Internal.Generic
 import Agda.Syntax.Literal
 import Agda.Syntax.Scope.Monad (bindVariable)
 import Agda.Syntax.Scope.Base (Binder(..))
@@ -223,10 +224,14 @@ computeGeneralization genRecMeta nameMap allmetas = postponeInstanceConstraints 
       _ -> __IMPOSSIBLE__
 
   let (alsoGeneralize, reallyDontGeneralize) = partition (`Set.member` inherited) $ map fst nongeneralizableOpen
-      generalizeOver = map fst generalizableOpen ++ alsoGeneralize
+      generalizeOver   = map fst generalizableOpen ++ alsoGeneralize
+      shouldGeneralize = (`Set.member` Set.fromList generalizeOver)
 
-  -- Sort metas in dependency order
-  sortedMetas <- sortMetas generalizeOver
+  -- Sort metas in dependency order. Include open metas that we are not
+  -- generalizing over, since they will need to be pruned appropriately (see
+  -- Issue 3672).
+  allSortedMetas <- sortMetas (generalizeOver ++ reallyDontGeneralize)
+  let sortedMetas = filter shouldGeneralize allSortedMetas
 
   let dropCxt err = updateContext (strengthenS err 1) (drop 1)
 
@@ -257,8 +262,17 @@ computeGeneralization genRecMeta nameMap allmetas = postponeInstanceConstraints 
           HasType{ jMetaType = t } = mvJudgement mv
       return [(Arg info $ miNameSuggestion $ mvInfo mv, piApply t args)]
   let genTel = buildGeneralizeTel genRecCon teleTypes
+
   reportSDoc "tc.generalize" 40 $ vcat
     [ text "genTel =" <+> prettyTCM genTel ]
+
+  -- Now we need to prune the unsolved metas to make sure they respect the new
+  -- dependencies (#3672). Also update interaction points to point to pruned metas.
+  let inscope (ii, InteractionPoint{ipMeta = Just x})
+        | IntSet.member (metaId x) allmetas = [(x, ii)]
+      inscope _ = []
+  ips <- Map.fromList . concatMap inscope . Map.toList <$> useTC stInteractionPoints
+  pruneUnsolvedMetas genRecName genRecCon genTel genRecFields ips shouldGeneralize allSortedMetas
 
   -- Fill in the missing details of the telescope record.
   dropCxt __IMPOSSIBLE__ $ fillInGenRecordDetails genRecName genRecCon genRecFields genRecMeta genTel
@@ -267,140 +281,224 @@ computeGeneralization genRecMeta nameMap allmetas = postponeInstanceConstraints 
   -- value packing up the generalized variables for the genTel variable.
   let sub = unpackSub genRecCon (map (argInfo . fst) teleTypes) (length teleTypes)
 
-  -- Finally eta-expand the GenTel record in non-generalized open metas. When
-  -- we do also update interaction points to refer to the eta-expanded meta
-  -- (#3340).
+  return (genTel, telNames, sub)
 
-  let inscope (ii, InteractionPoint{ipMeta = Just x})
-        | IntSet.member (metaId x) allmetas = [(x, ii)]
-      inscope _ = []
-  ips <- Map.fromList . concatMap inscope . Map.toList <$> useTC stInteractionPoints
+-- | Prune unsolved metas (#3672). The input includes also the generalized metas and is sorted in
+-- dependency order. The telescope is the generalized telescope.
+pruneUnsolvedMetas :: QName -> ConHead -> Telescope -> [QName] -> Map MetaId InteractionId -> (MetaId -> Bool) -> [MetaId] -> TCM ()
+pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints isGeneralized metas
+  | all isGeneralized metas = return ()
+  | otherwise               = prune [] genTel metas
+  where
+    prune _ _ [] = return ()
+    prune cxt tel (m : ms) | not (isGeneralized m) = do
+      pruneMeta (telFromList $ reverse cxt) m
+      prune cxt tel ms
+    prune cxt (ExtendTel a tel) (m : ms) = prune (fmap (x,) a : cxt) (unAbs tel) ms
+      where x = absName tel
+    prune _ _ _ = __IMPOSSIBLE__
 
-  cp  <- viewTC eCurrentCheckpoint
-  forM_ reallyDontGeneralize $ \ x -> do
-    mv <- lookupMeta x
-    when (isOpenMeta $ mvInstantiation mv) $ enterClosure (miClosRange $ mvInfo mv) $ \ _ -> do
+    sub = unpackSub genRecCon $ map getArgInfo $ telToList genTel
+
+    pruneMeta _Θ x = do
+      cp <- viewTC eCurrentCheckpoint
+      mv <- lookupMeta x
+      -- The reason we are doing all this inside the closure of x is so that if x is an interaction
+      -- meta we get the right context for the pruned interaction meta.
+      enterClosure (miClosRange $ mvInfo mv) $ \ _ ->
+        -- If x is a blocked term we shouldn't instantiate it.
+        whenM (not <$> isBlockedTerm x) $
+        -- If we can't find the generalized record, it's already been pruned and we don't have to do
+        -- anything.
+        whenJustM (findGenRec mv) $ \ i -> do
+
+        reportSDoc "tc.generalize.prune" 30 $ vcat
+          [ "pruning"
+          , nest 2 $ prettyTCM (mvJudgement mv)
+          , nest 2 $ "GenRecTel is var" <+> pretty i ]
+
+        _ΓrΔ <- getContextTelescope
+        let (_Γ, _Δ) = (telFromList gs, telFromList ds)
+              where (gs, _ : ds) = splitAt (size _ΓrΔ - i - 1) (telToList _ΓrΔ)
+
+        -- Get the type of x. By doing this here we let the checkpoint machinery sort out the
+        _A <- case mvJudgement mv of
+                IsSort{}  -> return Nothing
+                HasType{} -> Just <$> getMetaTypeInContext x
+
+        -- We have
+        --   Γ  (r : GenTel) Δ         current context
+        --   Γ₀ (r : GenTel)           top context
+        --   Γ₀ ⊢ Θ                    prefix of the generalized telescope currently in scope
+        --   Γ (r : GenTel) Δ ⊢ x : A  the meta to prune
+
+        -- Get the substitution from the point of generalization to the current context. This always
+        -- succeeds since if the meta depends on GenTel it must have been created inside the
+        -- generalization:
+        --   Γ (r : GenTel) Δ ⊢ δ : Γ₀ (r : GenTel)
+        δ <- checkpointSubstitution cp
+
+        -- v is x applied to the context variables
+        v <- case _A of
+               Nothing -> Sort . MetaS x . map Apply <$> getMetaContextArgs mv
+               Just{}  -> MetaV x . map Apply <$> getMetaContextArgs mv
+
+        -- Now ultimately we want to create the fresh meta in the context
+        --   Γ Θγ Δσ where Γ    ⊢ γ : Γ₀
+        --                 Γ Θγ ⊢ σ : Γ (r : GenTel)
+        -- σ is the unpacking substitution (which is polymorphic in Γ)
+        let σ   = sub (size _Θ)
+            --    Γ <- Γ (r : GenTel) Δ <- Γ₀ (r : GenTel) <- Γ₀
+            γ   = strengthenS __IMPOSSIBLE__ (i + 1) `composeS` δ `composeS` raiseS 1
+            _Θγ = applySubst γ _Θ
+            _Δσ = applySubst σ _Δ
+
+        -- The substitution into the new context is simply lifting σ over Δ:
+        --   Γ Θγ Δσ ⊢ lift i σ : Γ (r : GenTel) Δ
+        let ρ  = liftS i σ
+            -- We also need ρ⁻¹, which is a lot easier to construct.
+            ρ' = liftS i $ [ Var 0 [Proj ProjSystem fld] | fld <- reverse $ take (size _Θ) $ genRecFields ] ++# raiseS 1
+
+        reportSDoc "tc.generalize.prune" 30 $ nest 2 $ vcat
+          [ "Γ   =" <+> pretty _Γ
+          , "Θ   =" <+> pretty _Θ
+          , "Δ   =" <+> pretty _Δ
+          , "σ   =" <+> pretty σ
+          , "γ   =" <+> pretty γ
+          , "δ   =" <+> pretty δ
+          , "ρ⁻¹ =" <+> pretty ρ'
+          , "Θγ  =" <+> pretty _Θγ
+          , "Δσ  =" <+> pretty _Δσ
+          ]
+
+        -- When updating the context we also need to pick names for the variables. Get them from the
+        -- current context and generate fresh ones for the generalized variables in Θ.
+        (newCxt, rΘ) <- do
+          (rΔ, _ : rΓ) <- splitAt i <$> getContext
+          let setName = traverse $ \ (s, ty) -> (,ty) <$> freshName_ s
+          rΘ <- mapM setName $ reverse $ telToList _Θγ
+          let rΔσ = zipWith (\ name dom -> first (const name) <$> dom)
+                            (map (fst . unDom) rΔ)
+                            (reverse $ telToList _Δσ)
+          return (rΔσ ++ rΘ ++ rΓ, rΘ)
+
+        -- Now we can enter the new context and create our meta variable.
+        (y, u) <- updateContext ρ (const newCxt) $ localScope $ do
+
+          -- First, we add the named variables to the scope, to allow
+          -- them to be used in holes (#3341).
+          addNamedVariablesToScope rΘ
+
+          -- Now we can create the new meta
+          case _A of
+            Nothing -> do
+              s @ (MetaS y _) <- newSortMeta
+              return (y, Sort s)
+            Just _A -> do
+              let _Aρ = applySubst ρ _A
+              (y, u) <- newNamedValueMeta DontRunMetaOccursCheck
+                                          (miNameSuggestion $ mvInfo mv) _Aρ
+              return (y, u)
+
+        -- Finally we solve x := yρ⁻¹. The reason for solving it this way instead of xρ := y is that
+        -- ρ contains dummy terms for the variables that are not in scope.
+        -- If x has been instantiated by some constraint unblocked by previous pruning or
+        -- generalization, use equalTerm instead of assigning to x. If this fails (see
+        -- test/Fail/Issue3655b.agda for a test case), we need to give an error. This can happen if
+        -- there are dependencies between generalized variables that are hidden by constraints and
+        -- the dependency sorting happens to pick the wrong order. For instance, if we have
+        --    α : Nat   (unsolved meta)
+        --    t : F α   (named variable)
+        --    n : Nat   (named variable)
+        -- and a constraint F α == F n, where F does some pattern matching preventing the constraint
+        -- to be solved when n is still a meta. If t appears before n in the type these will be sorted
+        -- as α, t, n, but we will solve α := n before we get to the pruning here. It's good that we
+        -- solve first though, because that means we can give a more informative error message than
+        -- the "Cannot instantiate..." we would otherwise get.
+        let uρ' = applySubst ρ' u
+        reportSDoc "tc.generalize.prune" 80 $ vcat
+          [ "solving"
+          , nest 2 $ sep [ pretty v   <+> "=="
+                         , pretty uρ' <+> ":" ] ]
+        let isOpen = isOpenMeta $ mvInstantiation mv
+            getArgs v = case v of
+                Sort (MetaS _ es) -> unApply es
+                MetaV _ es        -> unApply es
+                _                 -> __IMPOSSIBLE__
+              where unApply es = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
+            unwrapSort (Sort s) = s
+            unwrapSort _        = __IMPOSSIBLE__
+            solve = case _A of
+              _ | isOpen -> assign DirEq x (getArgs v) uρ'
+              Nothing    -> equalSort (unwrapSort v) (unwrapSort uρ')
+              Just _A    -> equalTerm _A v uρ'
+        noConstraints solve `catchError` niceError x v
+
+        -- If x is a hole, update the hole to point to y instead. Note that
+        -- holes never point to blocked metas.
+        whenJust (Map.lookup x interactionPoints) (`connectInteractionPoint` y)
+
+    findGenRec :: MetaVariable -> TCM (Maybe Int)
+    findGenRec mv = do
       cxt <- instantiateFull =<< getContext
       let notPruned = [ i | i <- permute (takeP (length cxt) $ mvPermutation mv) $
                                  reverse $ zipWith const [0..] cxt ]
-      case [ i | (i, Dom{unDom = (_, El _ (Def q _))}) <- zip [(0::Int)..] cxt,
+      case [ i | (i, Dom{unDom = (_, El _ (Def q _))}) <- zip [0..] cxt,
                  q == genRecName, elem i notPruned ] of
-        []    -> return ()
+        []    -> return Nothing
         _:_:_ -> __IMPOSSIBLE__
-        [i] -> do
-          -- Get the substitution from the point of generalization to the current
-          -- context. This always succeeds since if the meta depends on GenTel
-          -- it must have been created inside the generalization.
-          δ <- checkpointSubstitution cp
+        [i]   -> return (Just i)
 
-          reportSDoc "tc.generalize.eta" 30 $ vcat
-            [ "eta expanding GenRec in"
-            , nest 2 $ prettyTCM (mvJudgement mv)
-            , nest 2 $ "GenRecTel is var" <+> pretty i ]
+    niceError x u err = do
+      u <- instantiateFull u
+      let err' = case err of
+                   TypeError{tcErrClosErr = cl} ->
+                     -- Remove the 'when' part from the error since it's most like the same as ours.
+                     err{ tcErrClosErr = cl{ clEnv = (clEnv cl) { envCall = Nothing } } }
+                   _ -> err
+          telList = telToList genTel
+          names   = map (fst . unDom) telList
+          late    = map (fst . unDom) $ filter (elem x . allMetas) telList
+          projs (Proj _ q)
+            | elem q genRecFields = Set.fromList [x | Just x <- [getGeneralizedFieldName q]]
+          projs _                 = Set.empty
+          early = Set.toList $ flip foldTerm u $ \ case
+                  Var _ es   -> foldMap projs es
+                  Def _ es   -> foldMap projs es
+                  MetaV _ es -> foldMap projs es
+                  _          -> Set.empty
+          commas []       = __IMPOSSIBLE__
+          commas [x]      = x
+          commas [x, y]   = x ++ ", and " ++ y
+          commas (x : xs) = x ++ ", " ++ commas xs
+          cause = "There were unsolved constraints that obscured the " ++
+                  "dependencies between the generalized variables."
+          solution = "The most reliable solution is to provide enough information to make the dependencies " ++
+                     "clear, but simply mentioning the variables in the right order should also work."
+          order = sep [ fwords "Dependency analysis suggested this (likely incorrect) order:",
+                        nest 2 $ fwords (unwords names) ]
+          guess = "After constraint solving it looks like " ++ commas late ++ " actually depend" ++ s ++
+                  " on " ++ commas early
+            where
+              s | length late == 1 = "s"
+                | otherwise        = ""
+      genericDocError =<< vcat
+        [ fwords $ "Variable generalization failed."
+        , nest 2 $ sep ["- Probable cause", nest 4 $ fwords cause]
+        , nest 2 $ sep ["- Suggestion", nest 4 $ fwords solution]
+        , nest 2 $ sep $ ["- Further information"
+                         , nest 2 $ "-" <+> order ] ++
+                         [ nest 2 $ "-" <+> fwords guess | not (null late), not (null early) ] ++
+                         [ nest 2 $ "-" <+> sep [ fwords "The dependency I error is", prettyTCM err' ] ]
+        ]
 
-          -- So we have
-          --   Γ (r : GenTel) Δ ⊢ x : A  and
-          --   Γ (r : GenTel) Δ ⊢ δ : Γ₀ (r : GenTel)
-          -- where |Δ| = i and r has not been pruned.
-          a <- case mvJudgement mv of
-                 IsSort{}  -> return Nothing
-                 HasType{} -> Just <$> getMetaTypeInContext x
-
-          -- v is x applied to the context variables
-          v <- MetaV x . map Apply <$> getMetaContextArgs mv
-
-          -- Now we want to compute a substitution
-          --   Γ Θ ⊢ σ : Γ (r : GenTel)
-          -- eta expanding the GenTel (actually this is just 'sub', since 'sub'
-          -- is polymorphic in Γ)
-          let σ = sub
-
-          -- We also need Θ, which is genTel but in Γ instead of Γ₀. We don't
-          -- have a substitution from Γ to Γ₀ so we have rebuild the telescope.
-          let name = traverse $ \ (s, ty) -> (,ty) <$> freshName_ s
-              -- Γ₀ (r : GenTel) ⊢ teleTypes
-              -- and we need something in Γ (r : GenTel)
-              -- The teleTypes should not depend on Δ, so we can apply δ and
-              -- strenghten:
-              -- Γ (r : GenTel) ⊢ γ : Γ₀ (r : GenTel)
-              γ = composeS (strengthenS __IMPOSSIBLE__ i) δ
-          theta <- mapM name $ telToList $ buildGeneralizeTel genRecCon $ applySubst γ teleTypes
-
-          -- We can get into the unpacked context by lifting with i:
-          --   Γ Θ Δσ ⊢ ρ : Γ (r : GenTel) Δ
-          let ρ = liftS i σ
-              -- we need to perform the same operation on the 'Context'
-              expand cxt = deltaRσ ++ thetaR ++ gammaR
-                where
-                  (deltaR, _ : gammaR) = splitAt i cxt
-                  thetaR = reverse theta
-                  -- Remember that deltaR is a list and not a telescope. We
-                  -- need to manage lifting manually.
-                  deltaRσ = go (length deltaR - 1) deltaR
-                    where
-                      -- Γ (r : GenTel) Δ₁ ⊢ x, where |Δ₁| = i
-                      -- Γ Θ Δ₁σ ⊢ liftS i σ : Γ (r : GenTel) Δ₁
-                      go i (x : xs) = applySubst (liftS i σ) x : go (i - 1) xs
-                      go _ []       = []
-
-          -- We don't need it, but for documentation purposes here is the
-          -- inverse of ρ:
-          -- Γ (r : GenTel) Δ ⊢ ρ⁻¹ : Γ Θ Δρ
-          let ρinv = liftS i $ [ Var 0 [Proj ProjSystem fld] | fld <- reverse $ genRecFields ] ++# raiseS 1
-
-          reportSDoc "tc.generalize.eta" 50 $ nest 2 $ vcat
-            [ "ρ ∘ ρ⁻¹ =" <+> pretty (composeS ρ ρinv)
-            , "ρ⁻¹ ∘ ρ =" <+> pretty (composeS ρinv ρ) ]
-
-          -- #3519: don't leak the fresh meta if we didn't expand
-          speculateTCState_ $ updateContext ρ expand $ do
-            reportSDoc "tc.generalize.eta" 30 $ nest 2 $
-              "new context:" <+> (inTopContext . prettyTCM =<< getContextTelescope)
-            -- In this context we create a fresh meta Γ Θ Δσ ⊢ y : Aρ
-            (y, u) <- localScope $ do
-
-              -- First, we add the named variables to the scope, to allow
-              -- them to be used in holes (#3341).
-              forM_ theta $ \ Dom{ unDom = (x, _) } -> do
-                -- Recognize named variables by lack of '.' (TODO: hacky!)
-                reportSLn "tc.generalize.eta.scope" 40 $ "Adding (or not) " ++ show (nameConcrete x) ++ " to the scope"
-                when ('.' `notElem` show (nameConcrete x)) $ do
-                  reportSLn "tc.generalize.eta.scope" 40 "  (added)"
-                  bindVariable LambdaBound (nameConcrete x) x
-
-              case a of
-                Nothing -> do
-                  s@(MetaS y _) <- newSortMeta
-                  return (y, Sort s)
-                Just a  -> newNamedValueMeta DontRunMetaOccursCheck
-                                             (miNameSuggestion $ mvInfo mv)
-                                             (applySubst ρ a)
-
-            -- Finally we solve xρ := y. Meta assignment is smart enough to
-            -- treat the GenRec constructor application produced by ρ as a
-            -- Miller pattern.
-            let MetaV _ es = applySubst ρ v
-                Just vs    = allApplyElims es
-
-            reportSDoc "tc.generalize.eta" 30 $ nest 2 $
-              hsep ["assigning", prettyTCM (MetaV x es), ":=", prettyTCM u]
-
-            -- This fails if x is a blocked term. We leave those alone.
-            do  assign DirEq x vs u
-                -- If x is a hole, update the hole to point to y instead. Note that
-                -- holes never point to blocked metas.
-                whenJust (Map.lookup x ips) (`connectInteractionPoint` y)
-                return SpeculateCommit
-
-              `catchError_` \ case
-                PatternErr{} -> do
-                  reportSDoc "tc.generalize.eta" 20 $ nest 2 $
-                    "Skipping eta expansion of blocked term meta" <+> pretty (MetaV x es)
-                  return SpeculateAbort  -- roll back state changes
-                err -> throwError err
-
-
-  return (genTel, telNames, sub)
+    addNamedVariablesToScope cxt =
+      forM_ cxt $ \ Dom{ unDom = (x, _) } -> do
+        -- Recognize named variables by lack of '.' (TODO: hacky!)
+        reportSLn "tc.generalize.eta.scope" 40 $ "Adding (or not) " ++ show (nameConcrete x) ++ " to the scope"
+        when ('.' `notElem` show (nameConcrete x)) $ do
+          reportSLn "tc.generalize.eta.scope" 40 "  (added)"
+          bindVariable LambdaBound (nameConcrete x) x
 
 -- | Create a substition from a context where the i first record fields are variables to a context
 --   where you have a single variable of the record type. Packs up the field variables in a record
@@ -506,12 +604,20 @@ createGenValue x = do
 sortMetas :: [MetaId] -> TCM [MetaId]
 sortMetas metas = do
   metaGraph <- fmap concat $ forM metas $ \ m -> do
-                  deps <- nub . filter (`elem` metas) . allMetas <$> (instantiateFull =<< getMetaType m)
+                  deps <- nub . filter (`elem` metas) . allMetas <$> getType m
                   return [ (m, m') | m' <- deps ]
 
   caseMaybe (Graph.topSort metas metaGraph)
             (typeError GeneralizeCyclicDependency)
             return
+
+  where
+    -- Sort metas don't have types, but we still want to sort them.
+    getType m = do
+      mv <- lookupMeta m
+      case mvJudgement mv of
+        IsSort{}                 -> return Nothing
+        HasType{ jMetaType = t } -> Just <$> instantiateFull t
 
 -- | Create a not-yet correct record type for the generalized telescope. It's not yet correct since
 --   we haven't computed the telescope yet, and we need the record type to do it.

--- a/test/Fail/Issue3340.err
+++ b/test/Fail/Issue3340.err
@@ -6,5 +6,5 @@ Failed to solve the following constraints:
   _45 := λ genTel → f y [blocked on problem 22]
 Unsolved metas at the following locations:
   Issue3340.agda:12,22-25
-  Issue3340.agda:12,8-25
+  Issue3340.agda:12,16-17
   Issue3340.agda:13,13-17

--- a/test/Fail/Issue3340.err
+++ b/test/Fail/Issue3340.err
@@ -1,7 +1,7 @@
 Failed to solve the following constraints:
   _49 := λ {x.A.ℓ} {x.A} {x} {f.P.ℓ} {f} → refl
-    [blocked on problem 29]
-  [29, 33] f x = _48 : _f.P_47 x
+    [blocked on problem 31]
+  [31, 35] f x = _48 : _f.P_47 x
   [22] _f.P_47 y =< _f.P_47 x : Set f.P.ℓ
   _45 := λ genTel → f y [blocked on problem 22]
 Unsolved metas at the following locations:

--- a/test/Fail/Issue3401.err
+++ b/test/Fail/Issue3401.err
@@ -3,7 +3,6 @@ Failed to solve the following constraints:
   _20 := λ {I} genTel → v [blocked on problem 11]
 Unsolved metas at the following locations:
   Issue3401.agda:12,7-8
-  Issue3401.agda:12,5-8
   Issue3401.agda:12,5-6
 Unsolved interaction metas at the following locations:
   Issue3401.agda:13,5-9

--- a/test/Fail/Issue3655b.agda
+++ b/test/Fail/Issue3655b.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+open import Agda.Builtin.Bool
+
+postulate
+  A : Set
+
+F : Bool → Set
+F true  = A
+F false = A
+
+data D {b : Bool} (x : F b) : Set where
+
+variable
+  b : Bool
+  x : F b
+
+postulate
+  f : D x → (P : F b → Set) → P x

--- a/test/Fail/Issue3655b.err
+++ b/test/Fail/Issue3655b.err
@@ -1,4 +1,4 @@
-Issue3655b.agda:19,7-34
+Issue3655b.agda:19,9-10
 Variable generalization failed.
   - Probable cause
       There were unsolved constraints that obscured the dependencies
@@ -11,7 +11,7 @@ Variable generalization failed.
     - Dependency analysis suggested this (likely incorrect) order: x b
     - After constraint solving it looks like x actually depends on b
     - The dependency I error is
-      Issue3655b.agda:19,7-34
+      Issue3655b.agda:19,9-10
       Cannot instantiate the metavariable _22 to solution b since it
       contains the variable genTel which is not in scope of the
       metavariable or irrelevant in the metavariable but relevant in the

--- a/test/Fail/Issue3655b.err
+++ b/test/Fail/Issue3655b.err
@@ -1,0 +1,20 @@
+Issue3655b.agda:19,7-34
+Variable generalization failed.
+  - Probable cause
+      There were unsolved constraints that obscured the dependencies
+      between the generalized variables.
+  - Suggestion
+      The most reliable solution is to provide enough information to make
+      the dependencies clear, but simply mentioning the variables in the
+      right order should also work.
+  - Further information
+    - Dependency analysis suggested this (likely incorrect) order: x b
+    - After constraint solving it looks like x actually depends on b
+    - The dependency I error is
+      Issue3655b.agda:19,7-34
+      Cannot instantiate the metavariable _22 to solution b since it
+      contains the variable genTel which is not in scope of the
+      metavariable or irrelevant in the metavariable but relevant in the
+      solution
+when checking that the expression D x → (P : F b → Set) → P x has
+type _9

--- a/test/Fail/Issue3672b.agda
+++ b/test/Fail/Issue3672b.agda
@@ -1,0 +1,33 @@
+
+open import Agda.Primitive
+
+_∘_ : ∀ {a b c}
+        {A : Set a} {B : A → Set b} {C : {x : A} → B x → Set c} →
+      (∀ {x} (y : B x) → C y) → (g : (x : A) → B x) →
+      ((x : A) → C (g x))
+f ∘ g = λ x → f (g x)
+
+data D {a} (A : Set a) : Set a where
+  d : D A → D A
+
+data E {a} (A : Set a) : Set a where
+  e : A → E A
+
+F : ∀ {a} {A : Set a} → A → D A → Set a
+F x (d ys) = E (F x ys)
+
+G : ∀ {a} {A : Set a} → D A → D A → Set a
+G xs ys = ∀ x → F x xs → F x ys
+
+postulate
+  H : ∀ {a} {A : Set a} {xs ys : D A} → G xs ys → Set
+
+variable
+  a  : Level
+  A  : Set a
+  P  : A → Set a
+  x  : A
+  xs : D A
+
+postulate
+  h : {f : G xs xs} (_ : P x) → F x xs → H (λ _ → e ∘ f _)

--- a/test/Fail/Issue3672b.err
+++ b/test/Fail/Issue3672b.err
@@ -1,0 +1,4 @@
+Unsolved metas at the following locations:
+  Issue3672b.agda:33,42-43
+  Issue3672b.agda:33,14-16
+  Issue3672b.agda:33,57-58

--- a/test/Succeed/Issue3672.agda
+++ b/test/Succeed/Issue3672.agda
@@ -1,0 +1,35 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+data C (A : Set) : Set where
+  c : (x : A) → C A
+
+data D : Set where
+
+data E (A : Set) : Set where
+  e : A → E A
+
+postulate
+  F : {A : Set} → A → Set
+
+G : {A : Set} → C A → Set
+G (c x) = E (F x)
+
+postulate
+  H : {A : Set} → (A → Set) → C A → Set
+  f : {A : Set} {P : A → Set} {y : C A} → H P y → (x : A) → G y → P x
+  g : {A : Set} {y : C A} {P : A → Set} → ((x : A) → G y → P x) → H P y
+
+variable
+  A : Set
+  P : A → Set
+  x : A
+  y : C A
+
+postulate
+  h : {p : ∀ x → G y → P x} → (∀ x (g : G y) → F (p x g)) → F (g p)
+
+id : (A : Set) → A → A
+id _ x = x
+
+-- i : (h : H P y) → (∀ x (g : G y) → F (f h x g)) → F (g (f h))
+-- i x y = id (F (g (f x))) (h y)

--- a/test/Succeed/Issue3673.agda
+++ b/test/Succeed/Issue3673.agda
@@ -1,0 +1,23 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+postulate
+  A : Set
+
+data Unit : Set where
+  unit : Unit
+
+F : Unit → Set
+F unit = A
+
+postulate
+  P : {A : Set} → A → Set
+  Q : ∀ {x} → F x → Set
+  f : ∀ {x} {y : F x} (z : Q y) → P z
+
+variable
+  x : Unit
+  y : F x
+
+g : (z : Q y) → P z
+g z with f z
+... | p = p


### PR DESCRIPTION
Tag #3672.

Previously we only eta expanded the generalized variable record in the metas (#3340),
but we need to also repect dependencies.

Also fixes #3655 (again) and fixes #3673 both of which are this same issue.