### PR TITLE
Fix 3676: sort failed candidates by error message precision

### DIFF
--- a/test/Fail/InstanceErrorMessageMultiple.err
+++ b/test/Fail/InstanceErrorMessageMultiple.err
@@ -1,4 +1,4 @@
-InstanceErrorMessageMultiple.agda:32,16-17
+InstanceErrorMessageMultiple.agda:32,22-26
 No instance of type Semiring Nat was found in scope.
 - ringNat′ was ruled out because
   InstanceErrorMessageMultiple.agda:32,22-26

--- a/test/Fail/Issue3676.agda
+++ b/test/Fail/Issue3676.agda
@@ -1,0 +1,26 @@
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Sigma
+
+record Monad (M : Set → Set) : Set₁ where
+  field
+    return : {A : Set} → A → M A
+    _>>=_  : {A B : Set} → M A → (A → M B) → M B
+
+open Monad ⦃ … ⦄
+
+postulate
+  F G : Set → Set
+
+instance
+
+  postulate
+    G-monad : Monad G
+    F-monad : Monad F
+
+f : Σ Nat (λ _ → Nat) → F Nat
+f p = do
+  m , n ← return p
+  return (m n)
+
+-- Should jump to `m n` and list the F-monad candidate error first.

--- a/test/Fail/Issue3676.err
+++ b/test/Fail/Issue3676.err
@@ -1,0 +1,12 @@
+Issue3676.agda:24,11-12
+No instance of type Monad _M_16 was found in scope.
+- F-monad was ruled out because
+  Issue3676.agda:24,11-12
+  Nat should be a function type, but it isn't
+  when checking that n is a valid argument to a function of type Nat
+- G-monad was ruled out because
+  Issue3676.agda:23,11-19
+  G (Σ Nat (λ _ → Nat)) !=< F _A_14 of type Set
+  when checking that the expression return p has type F _A_14
+when checking that p is a valid argument to a function of type
+{M : Set → Set} ⦃ r : Monad M ⦄ {A : Set} → A → M A


### PR DESCRIPTION
 and jump to the most precise error

tag #3676 