### PR TITLE
[ fix #3696 ] AgdaAny should be poly-kinded

### DIFF
--- a/src/data/MAlonzo/src/MAlonzo/RTE.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP       #-}
+{-# LANGUAGE PolyKinds #-}
+
 module MAlonzo.RTE where
 
 import Unsafe.Coerce
@@ -147,5 +149,5 @@ lt64 = (<)
 
 -- Support for musical coinduction.
 
-data Inf a            = Sharp { flat :: a }
-type Infinity level a = Inf a
+data Inf                   a = Sharp { flat :: a }
+type Infinity (level :: *) a = Inf a

--- a/test/Compiler/simple/HOAny.agda
+++ b/test/Compiler/simple/HOAny.agda
@@ -1,0 +1,36 @@
+module HOAny where
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Bool
+
+data Wrapper (M : Set → Set) : Set where
+  mnat  : M Nat → Wrapper M
+  mbool : M Bool → Wrapper M
+
+{-# FOREIGN GHC data AgdaWrapper m = Mnat (m Integer) | Mbool (m Bool) #-}
+{-# COMPILE GHC Wrapper = data AgdaWrapper (Mnat | Mbool) #-}
+
+map : ∀ {M N} → (∀ {n} → M n → N n) → Wrapper M → Wrapper N
+map f (mnat mn)  = mnat (f mn)
+map f (mbool mb) = mbool (f mb)
+
+-- Higher-order use of Any in the compiled code:
+
+-- data AgdaWrapper m = Mnat (m Integer) | Mbool (m Bool)
+
+-- map ::
+--  (() -> ()) ->
+--  (() -> ()) ->
+--  (() -> AgdaAny -> AgdaAny) -> AgdaWrapper AgdaAny -> AgdaWrapper AgdaAny
+
+-- WAS:
+-- The expected kind to AgdaWrapper's argument is * -> *
+-- but AgdaAny's kind is *
+
+-- WANT: SUCCESS
+-- made possible by making AgdaAny poly-kinded
+
+open import Common.Prelude
+
+main : IO Unit
+main = putStrLn ""

--- a/test/Compiler/simple/HOAny.out
+++ b/test/Compiler/simple/HOAny.out
@@ -1,0 +1,5 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out >
+out >


### PR DESCRIPTION
Had to explicitly set the kind of `level` in `Infinity` otherwise it would also
be poly-kinded and then we would get an error when compiling Issue2909-2.