### PR TITLE
Show relevant constraints below goal type and context

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -551,8 +551,11 @@ instance (ToConcrete a c, ToConcrete b d) =>
   toConcrete (OfType' e t) = OfType' <$> toConcrete e <*> toConcreteCtx TopCtx t
 
 getConstraints :: TCM [OutputForm C.Expr C.Expr]
-getConstraints = liftTCM $ do
-    cs <- M.getAllConstraints
+getConstraints = getConstraints' $ const True
+
+getConstraints' :: (ProblemConstraint -> Bool) -> TCM [OutputForm C.Expr C.Expr]
+getConstraints' f = liftTCM $ do
+    cs <- filter f <$> M.getAllConstraints
     cs <- forM cs $ \c -> do
             cl <- reify c
             enterClosure cl abstractToConcrete_

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -42,6 +42,7 @@ import qualified Agda.TypeChecking.Monad as TM
 import qualified Agda.TypeChecking.Pretty as TCP
 import Agda.TypeChecking.Rules.Term (checkExpr, isType_)
 import Agda.TypeChecking.Errors
+import Agda.TypeChecking.MetaVars.Mention
 
 import Agda.Syntax.Fixity
 import Agda.Syntax.Position
@@ -1485,12 +1486,18 @@ cmd_goal_type_context_and doc norm ii _ _ = display_info . Info_GoalType =<< do
   lift $ do
     goal <- B.withInteractionId ii $ prettyTypeOfMeta norm ii
     ctx  <- prettyContext norm True ii
-    return $ vcat
+    m    <- lookupInteractionId ii
+    constr <- vcat . map pretty <$> B.getConstraints' (mentionsMeta m)
+    let constrDoc = ifNull constr [] $ \constr ->
+          [ text $ delimiter "Constraints"
+          , constr
+          ]
+    return $ vcat $
       [ "Goal:" <+> goal
       , doc
       , text (replicate 60 '\x2014')
       , ctx
-      ]
+      ] ++ constrDoc
 
 -- | Shows all the top-level names in the given module, along with
 -- their types.

--- a/test/interaction/GoalConstraints.agda
+++ b/test/interaction/GoalConstraints.agda
@@ -1,0 +1,13 @@
+{-# OPTIONS --cubical #-}
+
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Cubical.Path
+
+data Interval : Set where
+  left right : Interval
+  path : left ≡ right
+
+swap : Interval → Interval
+swap left = right
+swap right = left
+swap (path i) = {!!}

--- a/test/interaction/GoalConstraints.in
+++ b/test/interaction/GoalConstraints.in
@@ -1,0 +1,3 @@
+top_command    (cmd_load currentFile [])
+goal_command 0 (cmd_goal_type_context Normalised) ""
+

--- a/test/interaction/GoalConstraints.out
+++ b/test/interaction/GoalConstraints.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals, Errors*" "?0 : Interval ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: right = ?0 (i = i0) : Interval left = ?0 (i = i1) : Interval " nil)
+((last . 1) . (agda2-goals-action '(0)))
+(agda2-status-action "")
+(agda2-info-action "*Goal type etc.*" "Goal: Interval ———————————————————————————————————————————————————————————— i : I ———— Constraints ——————————————————————————————————————————— right = (?0 (i = i0)) : Interval left = (?0 (i = i1)) : Interval" nil)

--- a/test/interaction/Issue1944-1-i.out
+++ b/test/interaction/Issue1944-1-i.out
@@ -9,7 +9,7 @@
 (agda2-status-action "")
 (agda2-info-action "*Normal Form*" "a" nil)
 (agda2-status-action "")
-(agda2-info-action "*Goal type etc.*" "Goal: A Have: A ———————————————————————————————————————————————————————————— a : A A : Set" nil)
+(agda2-info-action "*Goal type etc.*" "Goal: A Have: A ———————————————————————————————————————————————————————————— a : A A : Set ———— Constraints ——————————————————————————————————————————— _36 := f ? :? _32" nil)
 cannot read: IOTCM "Issue1944-1-i.agda" None Indirect (Cmd_compute IgnoreAbstract 1 noRange "\ r -> f (t r)")
 cannot read: IOTCM "Issue1944-1-i.agda" None Indirect (Cmd_goal_type_context_infer Normalised 1 noRange "\ r -> f (t r)")
 (agda2-give-action 2 "x")


### PR DESCRIPTION
I get annoyed endlessly by the fact that "show goal type and context" doesn't show any constraints. This is especially annoying for HITs in cubical agda. This patch just gathers all the constraints that mention the goal meta and displays them below the context.

I'm not sure if it is a good idea to *always* display the constraints as I do here, maybe there should be an extra flag and/or prefix to the goal commands to turn them on or off.