### PR TITLE
Simplify and consolidate GHC version conditions

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -227,7 +227,7 @@ library
 
   -- ASR (2018-09-14). We add the dependency on the filemanip library
   -- due to Issue #3225.
-  if impl(ghc >= 7.10) && impl(ghc < 8.0)
+  if impl(ghc < 8.0)
     build-depends:   transformers == 0.4.2.0
                    , filemanip >= 0.3.6.2 && < 0.4
 
@@ -579,33 +579,32 @@ library
   if impl(ghc >= 8.0)
     ghc-options: -Wunrecognised-warning-flags
 
-  if impl(ghc >= 7.10)
-    ghc-options: -fwarn-deprecated-flags
-                 -fwarn-deriving-typeable
-                 -fwarn-dodgy-exports
-                 -fwarn-dodgy-foreign-imports
-                 -fwarn-dodgy-imports
-                 -fwarn-duplicate-exports
-                 -fwarn-empty-enumerations
-                 -fwarn-hi-shadowing
-                 -fwarn-identities
-                 -fwarn-incomplete-patterns
-                 -fwarn-inline-rule-shadowing
-                 -fwarn-missing-fields
-                 -fwarn-missing-methods
-                 -fwarn-missing-signatures
-                 -fwarn-tabs
-                 -fwarn-typed-holes
-                 -fwarn-overflowed-literals
-                 -fwarn-overlapping-patterns
-                 -fwarn-unrecognised-pragmas
-                 -fwarn-unticked-promoted-constructors
-                 -fwarn-unused-do-bind
-                 -fwarn-warnings-deprecations
-                 -fwarn-wrong-do-bind
+  ghc-options: -fwarn-deprecated-flags
+               -fwarn-deriving-typeable
+               -fwarn-dodgy-exports
+               -fwarn-dodgy-foreign-imports
+               -fwarn-dodgy-imports
+               -fwarn-duplicate-exports
+               -fwarn-empty-enumerations
+               -fwarn-hi-shadowing
+               -fwarn-identities
+               -fwarn-incomplete-patterns
+               -fwarn-inline-rule-shadowing
+               -fwarn-missing-fields
+               -fwarn-missing-methods
+               -fwarn-missing-signatures
+               -fwarn-tabs
+               -fwarn-typed-holes
+               -fwarn-overflowed-literals
+               -fwarn-overlapping-patterns
+               -fwarn-unrecognised-pragmas
+               -fwarn-unticked-promoted-constructors
+               -fwarn-unused-do-bind
+               -fwarn-warnings-deprecations
+               -fwarn-wrong-do-bind
 
   -- These options will be removed in GHC 8.0.1.
-  if impl(ghc >= 7.10) && impl(ghc < 8.0)
+  if impl(ghc < 8.0)
     ghc-options: -fwarn-context-quantification
                  -fwarn-duplicate-constraints
                  -fwarn-pointless-pragmas
@@ -668,13 +667,12 @@ executable agda
                   -- except for the prelude.
                 , base >= 4.8.0.0 && < 6
   default-language: Haskell2010
-  if impl(ghc >= 7)
-    -- If someone installs Agda with the setuid bit set, then the
-    -- presence of +RTS may be a security problem (see GHC bug #3910).
-    -- However, we sometimes recommend people to use +RTS to control
-    -- Agda's memory usage, so we want this functionality enabled by
-    -- default.
-    ghc-options:  -rtsopts
+  -- If someone installs Agda with the setuid bit set, then the
+  -- presence of +RTS may be a security problem (see GHC bug #3910).
+  -- However, we sometimes recommend people to use +RTS to control
+  -- Agda's memory usage, so we want this functionality enabled by
+  -- default.
+  ghc-options:  -rtsopts
 
 executable agda-mode
   hs-source-dirs:   src/agda-mode
@@ -836,33 +834,32 @@ test-suite agda-tests
   if impl(ghc >= 8.0)
     ghc-options: -Wunrecognised-warning-flags
 
-  if impl(ghc >= 7.10)
-    ghc-options: -fwarn-deprecated-flags
-                 -fwarn-deriving-typeable
-                 -fwarn-dodgy-exports
-                 -fwarn-dodgy-foreign-imports
-                 -fwarn-dodgy-imports
-                 -fwarn-duplicate-exports
-                 -fwarn-empty-enumerations
-                 -fwarn-hi-shadowing
-                 -fwarn-identities
-                 -fwarn-incomplete-patterns
-                 -fwarn-inline-rule-shadowing
-                 -fwarn-missing-fields
-                 -fwarn-missing-methods
-                 -fwarn-missing-signatures
-                 -fwarn-tabs
-                 -fwarn-typed-holes
-                 -fwarn-overflowed-literals
-                 -fwarn-overlapping-patterns
-                 -fwarn-unrecognised-pragmas
-                 -fwarn-unticked-promoted-constructors
-                 -fwarn-unused-do-bind
-                 -fwarn-warnings-deprecations
-                 -fwarn-wrong-do-bind
+  ghc-options: -fwarn-deprecated-flags
+               -fwarn-deriving-typeable
+               -fwarn-dodgy-exports
+               -fwarn-dodgy-foreign-imports
+               -fwarn-dodgy-imports
+               -fwarn-duplicate-exports
+               -fwarn-empty-enumerations
+               -fwarn-hi-shadowing
+               -fwarn-identities
+               -fwarn-incomplete-patterns
+               -fwarn-inline-rule-shadowing
+               -fwarn-missing-fields
+               -fwarn-missing-methods
+               -fwarn-missing-signatures
+               -fwarn-tabs
+               -fwarn-typed-holes
+               -fwarn-overflowed-literals
+               -fwarn-overlapping-patterns
+               -fwarn-unrecognised-pragmas
+               -fwarn-unticked-promoted-constructors
+               -fwarn-unused-do-bind
+               -fwarn-warnings-deprecations
+               -fwarn-wrong-do-bind
 
   -- These options will be removed in GHC 8.0.1.
-  if impl(ghc >= 7.10) && impl(ghc < 8.0)
+  if impl(ghc < 8.0)
     ghc-options: -fwarn-context-quantification
                  -fwarn-duplicate-constraints
                  -fwarn-pointless-pragmas

--- a/Setup.hs
+++ b/Setup.hs
@@ -8,7 +8,7 @@ import Distribution.PackageDescription
 -- ASR (2019-01-10): The Cabal macro @MIN_VERSION_Cabal@ is avaliable
 -- from Cabal_>_1.24 so this macro is not supported with the
 -- "standard" GHC 7.10.3 which is shipped with Cabal 1.22.5.0.
-#if __GLASGOW_HASKELL__ > 710
+#if __GLASGOW_HASKELL__ >= 800
 #if MIN_VERSION_Cabal(2,3,0)
 import Distribution.System ( buildPlatform )
 #endif
@@ -84,7 +84,7 @@ agdaExeExtension :: String
 -- ASR (2019-01-10): The Cabal macro @MIN_VERSION_Cabal@ is avaliable
 -- from Cabal_>_1.24 so this macro is not supported with the
 -- "standard" GHC 7.10.3 which is shipped with Cabal 1.22.5.0.
-#if __GLASGOW_HASKELL__ > 710
+#if __GLASGOW_HASKELL__ >= 800
 #if MIN_VERSION_Cabal(2,3,0)
 agdaExeExtension = exeExtension buildPlatform
 #else

--- a/src/data/MAlonzo/src/MAlonzo/RTE.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE.hs
@@ -4,7 +4,7 @@
 module MAlonzo.RTE where
 
 import Unsafe.Coerce
-#if __GLASGOW_HASKELL__ >= 802
+#if __GLASGOW_HASKELL__ >= 800
 import qualified GHC.Exts as GHC (Any)
 #else
 import qualified GHC.Prim as GHC (Any)

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -12,10 +12,6 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.IntSet as IntSet
 
-#if __GLASGOW_HASKELL__ <= 708
-import Data.Traversable ( traverse )
-#endif
-
 import Agda.Syntax.Abstract.Views (isSet)
 import Agda.Syntax.Common
 import Agda.Syntax.Internal

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3624,7 +3624,7 @@ instance MonadIO m => Monad (TCMT m) where
     return = pure
     (>>=)  = bindTCMT
     (>>)   = (*>)
-#if __GLASGOW_HASKELL__ == 710
+#if __GLASGOW_HASKELL__ < 800
     fail   = internalError
 #else
     fail   = Fail.fail

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -35,7 +35,7 @@ import Agda.Utils.Impossible
 
 class ( Functor m
       , Applicative m
-#if __GLASGOW_HASKELL__ == 710
+#if __GLASGOW_HASKELL__ < 800
       , Monad m
 #else
       , Fail.MonadFail m

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -636,7 +636,7 @@ sigError f a = \case
 
 class ( Functor m
       , Applicative m
-#if __GLASGOW_HASKELL__ == 710
+#if __GLASGOW_HASKELL__ < 800
       , Monad m
 #else
       , Fail.MonadFail m

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
@@ -23,7 +23,7 @@ data SigError = SigUnknown String | SigAbstract
 
 class ( Functor m
       , Applicative m
-#if __GLASGOW_HASKELL__ == 710
+#if __GLASGOW_HASKELL__ < 800
       , Monad m
 #else
       , Fail.MonadFail m

--- a/src/full/Agda/TypeChecking/Names.hs
+++ b/src/full/Agda/TypeChecking/Names.hs
@@ -130,12 +130,7 @@ cl' = pure
 cl :: Monad m => m a -> NamesT m a
 cl = lift
 
-open :: ( Monad m
-#if __GLASGOW_HASKELL__ <= 708
-        , Applicative m
-#endif
-        , Subst t a
-        ) => a -> NamesT m (NamesT m a)
+open :: (Monad m, Subst t a) => a -> NamesT m (NamesT m a)
 open a = do
   ctx <- NamesT ask
   pure $ inCxt ctx a
@@ -146,9 +141,6 @@ bind' n f = do
   (NamesT . local (n:) . unName $ f (inCxt (n:cxt) (deBruijnVar 0)))
 
 bind :: ( Monad m
-#if __GLASGOW_HASKELL__ <= 708
-        , Functor m
-#endif
         , Subst t' b
         , DeBruijn b
         , Subst t a
@@ -157,11 +149,7 @@ bind :: ( Monad m
         ArgName -> (NamesT m b -> NamesT m a) -> NamesT m (Abs a)
 bind n f = Abs n <$> bind' n f
 
-#if __GLASGOW_HASKELL__ <= 708
-glam :: (Functor m, Monad m)
-#else
 glam :: Monad m
-#endif
      => ArgInfo -> ArgName -> (NamesT m Term -> NamesT m Term) -> NamesT m Term
 glam info n f = Lam info <$> bind n f
 
@@ -170,18 +158,10 @@ glamN :: (Functor m, Monad m) =>
 glamN [] f = f $ pure []
 glamN (Arg i n:ns) f = glam i n $ \ x -> glamN ns (\ xs -> f ((:) <$> (Arg i <$> x) <*> xs))
 
-#if __GLASGOW_HASKELL__ <= 708
-lam :: (Functor m, Monad m)
-#else
 lam :: Monad m
-#endif
     => ArgName -> (NamesT m Term -> NamesT m Term) -> NamesT m Term
 lam n f = glam defaultArgInfo n f
 
-#if __GLASGOW_HASKELL__ <= 708
-ilam :: (Functor m, Monad m)
-#else
 ilam :: Monad m
-#endif
     => ArgName -> (NamesT m Term -> NamesT m Term) -> NamesT m Term
 ilam n f = glam (setRelevance Irrelevant defaultArgInfo) n f

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -1882,12 +1882,7 @@ pPi' n phi b = toFinitePi <$> nPi' n (elInf $ cl (liftTCM primIsOne) <@> phi) b
    toFinitePi (El s (Pi d b)) = El s $ Pi (setRelevance Irrelevant $ d { domFinite = True }) b
    toFinitePi _               = __IMPOSSIBLE__
 
-#if __GLASGOW_HASKELL__ <= 708
-el' :: (Functor m, Applicative m, Monad m)
-#else
-el' :: Monad m
-#endif
-    => m Term -> m Term -> m Type
+el' :: Monad m => m Term -> m Term -> m Type
 el' l a = El <$> (tmSort <$> l) <*> a
 
 elInf :: Functor m => m Term -> m Type

--- a/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
@@ -3,10 +3,6 @@
 
 module Agda.TypeChecking.Rules.LHS.ProblemRest where
 
-#if __GLASGOW_HASKELL__ <= 708
-import Data.Functor ( (<$), (<$>) )
-#endif
-
 import Control.Arrow (first, second)
 import Control.Monad
 

--- a/src/full/Makefile
+++ b/src/full/Makefile
@@ -91,10 +91,7 @@ hTags=../hTags/dist/build/hTags/hTags
 CABAL_MACROS=$(BUILD_DIR)/build/autogen/cabal_macros.h
 
 # See Issue #2419.
-ifeq "$(GHC_VERSION)" "7.8"
-hTags_include = $(CABAL_MACROS) ./undefined.h
-hTags_flags   = -i $(CABAL_MACROS) -I ./ --cabal ../../Agda.cabal
-else ifeq "$(GHC_VERSION)" "7.10"
+ifeq "$(GHC_VERSION)" "7.10"
 hTags_include = $(CABAL_MACROS) ./undefined.h
 hTags_flags   = -i $(CABAL_MACROS) -I ./ --cabal ../../Agda.cabal
 else


### PR DESCRIPTION
This is intended to be a non-breaking, no-op, cleanup change. More info in the commit comments.

In summary, this consolidates Cabal and build macro conditions that check for effectively the same GHC version ranges.

For example, "strictly after 7.10" means the same as "8.0 or above" because there were no GHC releases in between.

Some checks referring to 7.08 were redundant, since support had been removed for that version. Checks for "7.10 and above" are also redundant, because that's currently the minimum required version.

This is motivated by work on (but does not itself cause) #3719.