### PR TITLE
[ Fix #3697 ] Making hcomp/transp for record/data more robust.

### DIFF
--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -978,7 +978,7 @@ telFromList :: ListTel -> Telescope
 telFromList = telFromList' id
 
 -- | Convert a telescope to its list form.
-telToList :: Telescope -> ListTel
+telToList :: Tele (Dom t) -> [Dom (ArgName,t)]
 telToList EmptyTel                    = []
 telToList (ExtendTel arg (Abs x tel)) = fmap (x,) arg : telToList tel
 telToList (ExtendTel _    NoAbs{}   ) = __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NondecreasingIndentation #-}
 
 module Agda.TypeChecking.Rules.Data where
 
@@ -6,6 +7,8 @@ import Control.Monad
 
 import Data.List (genericTake)
 import Data.Maybe (fromMaybe, catMaybes, isJust)
+import Control.Monad.Trans.Maybe
+import Control.Monad.Trans
 import Data.Set (Set)
 import qualified Data.Set as Set
 
@@ -340,10 +343,9 @@ defineCompData d con params names fsT t boundary = do
     , builtinPOr
     , builtinItIsOne
     ]
-  sortsOk <- sortOk t `and2M` allM (map unDom (flattenTel fsT)) sortOkField
-  if not sortsOk || not (all isJust required) then return $ emptyCompKit else do
+  if not (all isJust required) then return $ emptyCompKit else do
     hcomp  <- whenDefined (null boundary) [builtinHComp,builtinTrans] (defineTranspOrHCompD DoHComp  d con params names fsT t boundary)
-    transp <- whenDefined True [builtinTrans]              (defineTranspOrHCompD DoTransp d con params names fsT t boundary)
+    transp <- whenDefined True            [builtinTrans]              (defineTranspOrHCompD DoTransp d con params names fsT t boundary)
     return $ CompKit
       { nameOfTransp = transp
       , nameOfHComp  = hcomp
@@ -354,10 +356,12 @@ defineCompData d con params names fsT t boundary = do
     withArgInfo tel = zipWith Arg (map domInfo . telToList $ tel)
     defineTranspOrHCompD cmd d con params names fsT t boundary
       = do
-      ((theName, gamma , ty, _cl_types , bodies), theSub) <-
-        (case cmd of DoTransp -> defineTranspForFields' (guard (not $ null boundary) >> (Just $ Con con ConOSystem $ teleElims fsT boundary))
-                     ; DoHComp -> defineHCompForFields)
-          (\ t p -> apply (Def p []) [argN t]) d params fsT (map argN names) t
+      let project = (\ t p -> apply (Def p []) [argN t])
+      stuff <- defineTranspOrHCompForFields cmd
+                 (guard (not $ null boundary) >> (Just $ Con con ConOSystem $ teleElims fsT boundary))
+                 project d params fsT (map argN names) t
+      caseMaybe stuff (return Nothing) $ \ ((theName, gamma , ty, _cl_types , bodies), theSub) -> do
+
       iz <- primIZero
       body <- do
         case cmd of
@@ -537,18 +541,6 @@ defineCompData d con params names fsT t boundary = do
       xs <- mapM getTerm' xs
       if all isJust xs then m else return Nothing
 
-    sortOk :: Type -> TCM Bool
-    sortOk a = reduce (getSort a) >>= \case
-      Type{} -> return True
-      _      -> return False
-
-    sortOkField :: Type -> TCM Bool
-    sortOkField a = reduce (getSort a) >>= \case
-      Type{} -> return True
-      -- fields might be elements of the interval
-      Inf    -> return True
-      _      -> return False
-
 -- Andrea: TODO handle Irrelevant fields somehow.
 defineProjections :: QName      -- datatype name
                   -> ConHead
@@ -606,29 +598,88 @@ freshAbstractQName'_ :: String -> TCM QName
 freshAbstractQName'_ s = freshAbstractQName noFixity' (C.Name noRange C.InScope [C.Id $ s])
 
 
-defineTranspForFields
-  :: (Term -> QName -> Term) -- ^ how to apply a "projection" to a term
-  -> QName       -- ^ some name, e.g. record name
-  -> Telescope   -- ^ param types Δ
-  -> Telescope   -- ^ fields' types Δ ⊢ Φ
-  -> [Arg QName] -- ^ fields' names
-  -> Type        -- ^ record type Δ ⊢ T
-  -> TCM ((QName, Telescope, Type, [Dom Type], [Term]), Substitution)
-defineTranspForFields = defineTranspForFields' Nothing
+-- * Special cases of Type
+-----------------------------------------------------------
+
+-- | A @Type@ with sort @Type l@
+--   Such a type supports both hcomp and transp.
+data LType = LEl Level Term deriving (Eq,Show)
+
+fromLType :: LType -> Type
+fromLType (LEl l t) = El (Type l) t
+
+lTypeLevel :: LType -> Level
+lTypeLevel (LEl l t) = l
+
+toLType :: MonadReduce m => Type -> m (Maybe LType)
+toLType ty = do
+  sort <- reduce $ getSort ty
+  case sort of
+    Type l -> return $ Just $ LEl l (unEl ty)
+    _      -> return $ Nothing
+
+instance Subst Term LType where
+  applySubst rho (LEl l t) = LEl (applySubst rho l) (applySubst rho t)
+
+-- | A @Type@ that either has sort @Type l@ or is a closed definition.
+--   Such a type supports some version of transp.
+--   In particular we want to allow the Interval as a @ClosedType@.
+data CType = ClosedType QName | LType LType deriving (Eq,Show)
+
+fromCType :: CType -> Type
+fromCType (ClosedType q) = El Inf (Def q [])
+fromCType (LType t) = fromLType t
+
+toCType :: MonadReduce m => Type -> m (Maybe CType)
+toCType ty = do
+  sort <- reduce $ getSort ty
+  case sort of
+    Type l -> return $ Just $ LType (LEl l (unEl ty))
+    Inf    -> do
+      t <- reduce (unEl ty)
+      case t of
+        Def q [] -> return $ Just $ ClosedType q
+        _        -> return $ Nothing
+    _      -> return $ Nothing
+
+instance Subst Term CType where
+  applySubst rho t@ClosedType{} = t
+  applySubst rho (LType t) = LType $ applySubst rho t
 
 
--- invariant: resulting tel Γ is such that Γ = ... , (φ : I), (a0 : ...)
---            where a0 has type matching the arguments of primTrans.
-defineTranspForFields'
-  :: (Maybe Term)                    -- ^ PathCons, Δ.Φ ⊢ u : R δ
+defineTranspOrHCompForFields
+  :: TranspOrHComp
+  -> (Maybe Term)            -- ^ PathCons, Δ.Φ ⊢ u : R δ
   -> (Term -> QName -> Term) -- ^ how to apply a "projection" to a term
   -> QName       -- ^ some name, e.g. record name
   -> Telescope   -- ^ param types Δ
   -> Telescope   -- ^ fields' types Δ ⊢ Φ
   -> [Arg QName] -- ^ fields' names
   -> Type        -- ^ record type Δ ⊢ T
+  -> TCM (Maybe ((QName, Telescope, Type, [Dom Type], [Term]), Substitution))
+defineTranspOrHCompForFields cmd pathCons project name params fsT fns rect =
+   case cmd of
+       DoTransp -> runMaybeT $ do
+         fsT' <- traverse (traverse (MaybeT . toCType)) fsT
+         lift $ defineTranspForFields pathCons project name params fsT' fns rect
+       DoHComp -> runMaybeT $ do
+         fsT' <- traverse (traverse (MaybeT . toLType)) fsT
+         rect' <- MaybeT $ toLType rect
+         lift $ defineHCompForFields project name params fsT' fns rect'
+
+
+-- invariant: resulting tel Γ is such that Γ = ... , (φ : I), (a0 : ...)
+--            where a0 has type matching the arguments of primTrans.
+defineTranspForFields
+  :: (Maybe Term)            -- ^ PathCons, Δ.Φ ⊢ u : R δ
+  -> (Term -> QName -> Term) -- ^ how to apply a "projection" to a term
+  -> QName       -- ^ some name, e.g. record name
+  -> Telescope   -- ^ param types Δ
+  -> Tele (Dom CType)   -- ^ fields' types Δ ⊢ Φ
+  -> [Arg QName] -- ^ fields' names
+  -> Type        -- ^ record type Δ ⊢ T
   -> TCM ((QName, Telescope, Type, [Dom Type], [Term]), Substitution)
-defineTranspForFields' pathCons applyProj name params fsT fns rect = do
+defineTranspForFields pathCons applyProj name params fsT fns rect = do
   interval <- elInf primInterval
   let deltaI = expTelescope interval params
   iz <- primIZero
@@ -702,7 +753,7 @@ defineTranspForFields' pathCons applyProj name params fsT fns rect = do
       (tel,theta,the_phi,the_u0, the_fields) =
         case pathCons of
           -- (δ : Δ).Φ ⊢ u : R δ
-          Just u -> (abstract gamma' (d0 `applySubst` fsT) -- Ξ = δ : Δ^I, φ : F, _ : Φ[δ i0]
+          Just u -> (abstract gamma' (d0 `applySubst` fmap (fmap fromCType) fsT) -- Ξ = δ : Δ^I, φ : F, _ : Φ[δ i0]
                     , (liftS (size fsT) d0 `applySubst` u) `consS` raiseS (size fsT)
                     , raise (size fsT) (var 0)
                     , (liftS (size fsT) d0 `applySubst` u)
@@ -718,11 +769,11 @@ defineTranspForFields' pathCons applyProj name params fsT fns rect = do
       -- .. ⊢ field : filled_ty' i0
       mkBody (field, filled_ty') = do
         let
-          filled_ty = lam_i $ (unEl . unDom) filled_ty'
+          filled_ty = lam_i $ (unEl . fromCType . unDom) filled_ty'
           -- Γ ⊢ l : I -> Level of filled_ty
-        sort <- reduce $ getSort $ unDom filled_ty'
-        case sort of
-          Type l -> do
+        -- sort <- reduce $ getSort $ unDom filled_ty'
+        case unDom filled_ty' of
+          LType (LEl l _) -> do
             let lvl = lam_i $ Level l
             return $ runNames [] $ do
              lvl <- open lvl
@@ -731,11 +782,10 @@ defineTranspForFields' pathCons applyProj name params fsT fns rect = do
                                  <@> phi
                                  <@> field
           -- interval arg
-          Inf  ->
+          ClosedType{}  ->
             return $ runNames [] $ do
             [field] <- mapM open [field]
             field
-          _ -> __IMPOSSIBLE__
 
   let
         -- ' Ξ , i : I ⊢ τ = [(\ j → δ (i ∧ j)), φ ∨ ~ i, u] : Ξ
@@ -764,7 +814,7 @@ defineTranspForFields' pathCons applyProj name params fsT fns rect = do
   let
     -- Ξ, i : I ⊢ ... : Δ.Φ
     theSubst = reverse (tau `applySubst` bodys) ++# (liftS 1 (raiseS (size tel - size deltaI)) `composeS` sub params)
-  return $ ((theName, tel, theta `applySubst` rtype, clause_types, bodys), theSubst)
+  return $ ((theName, tel, theta `applySubst` rtype, map (fmap fromCType) clause_types, bodys), theSubst)
   where
     -- record type in 'exponentiated' context
     -- (params : Δ^I), i : I |- T[params i]
@@ -788,9 +838,9 @@ defineHCompForFields
   :: (Term -> QName -> Term) -- ^ how to apply a "projection" to a term
   -> QName       -- ^ some name, e.g. record name
   -> Telescope   -- ^ param types Δ
-  -> Telescope   -- ^ fields' types Δ ⊢ Φ
+  -> Tele (Dom LType)   -- ^ fields' types Δ ⊢ Φ
   -> [Arg QName] -- ^ fields' names
-  -> Type        -- ^ record type (δ : Δ) ⊢ R[δ]
+  -> LType        -- ^ record type (δ : Δ) ⊢ R[δ]
   -> TCM ((QName, Telescope, Type, [Dom Type], [Term]),Substitution)
 defineHCompForFields applyProj name params fsT fns rect = do
   interval <- elInf primInterval
@@ -815,14 +865,14 @@ defineHCompForFields applyProj name params fsT fns rect = do
   reportSLn "hcomp.rec" 5 $ ("Generated name: " ++ show theName ++ " " ++ showQNameId theName)
 
   theType <- (abstract delta <$>) $ runNamesT [] $ do
-              rect <- open rect
+              rect <- open $ fromLType rect
               nPi' "phi" (elInf $ cl primInterval) $ \ phi ->
                (nPi' "i" (elInf $ cl primInterval) $ \ i ->
                 pPi' "o" phi $ \ _ -> rect) -->
                rect --> rect
 
   reportSDoc "hcomp.rec" 20 $ prettyTCM theType
-  reportSDoc "hcomp.rec" 60 $ text $ "sort = " ++ show (getSort rect)
+  reportSDoc "hcomp.rec" 60 $ text $ "sort = " ++ show (lTypeLevel rect)
 
   noMutualBlock $ addConstant theName $ (defaultDefn defaultArgInfo theName theType
     (emptyFunction { funTerminates = Just True }))
@@ -834,7 +884,7 @@ defineHCompForFields applyProj name params fsT fns rect = do
   let -- Γ ⊢ R δ
       drect_gamma = raiseS (size gamma - size delta) `applySubst` rect
 
-  reportSDoc "hcomp.rec" 60 $ text $ "sort = " ++ show (getSort drect_gamma)
+  reportSDoc "hcomp.rec" 60 $ text $ "sort = " ++ show (lTypeLevel drect_gamma)
 
   let
 
@@ -850,8 +900,8 @@ defineHCompForFields applyProj name params fsT fns rect = do
 
       -- ' (δ, φ, u, u0) : Γ ⊢ fillR Γ : (i : I) → rtype[ δ ↦ (\ j → δ (i ∧ j))]
       fillTerm = runNames [] $ do
-        rect <- open                           $ unEl    drect_gamma
-        lvl  <- open . (\ (Type l) -> Level l) $ getSort drect_gamma
+        rect <- open . unEl  . fromLType  $ drect_gamma
+        lvl  <- open . Level . lTypeLevel $ drect_gamma
         params     <- mapM open $ take (size delta) $ teleArgs gamma
         [phi,w,w0] <- mapM open [the_phi,the_u,the_u0]
         -- (δ : Δ, φ : I, w : .., w0 : R δ) ⊢
@@ -902,9 +952,9 @@ defineHCompForFields applyProj name params fsT fns rect = do
       mkBody (fname, filled_ty') = do
         let
           proj t = (`applyProj` unArg fname) <$> t
-          filled_ty = Lam defaultArgInfo (Abs "i" $ (unEl . unDom) filled_ty')
+          filled_ty = Lam defaultArgInfo (Abs "i" $ (unEl . fromLType . unDom) filled_ty')
           -- Γ ⊢ l : I -> Level of filled_ty
-        Type l <- reduce $ getSort $ unDom filled_ty'
+        l <- reduce $ lTypeLevel $ unDom filled_ty'
         let lvl = Lam defaultArgInfo (Abs "i" $ Level l)
         return $ runNames [] $ do
              lvl <- open lvl
@@ -917,10 +967,10 @@ defineHCompForFields applyProj name params fsT fns rect = do
                   (lam "i" $ \ i -> lam "o" $ \ o -> proj $ w <@> i <@> o) -- TODO wait for phi = 1
                   (proj w0)
 
-  reportSDoc "hcomp.rec" 60 $ text $ "filled_types sorts:" ++ show (map (getSort . unDom) filled_types)
+  reportSDoc "hcomp.rec" 60 $ text $ "filled_types sorts:" ++ show (map (getSort . fromLType . unDom) filled_types)
 
   bodys <- mapM mkBody (zip fns filled_types)
-  return $ ((theName, gamma, rtype, clause_types, bodys),IdS)
+  return $ ((theName, gamma, rtype, map (fmap fromLType) clause_types, bodys),IdS)
 
 
 getGeneralizedParameters :: Set Name -> QName -> TCM [Maybe Name]

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NondecreasingIndentation   #-}
 
 module Agda.TypeChecking.Rules.Record where
 
@@ -34,7 +35,7 @@ import Agda.TypeChecking.CompiledClause (hasProjectionPatterns)
 import Agda.TypeChecking.CompiledClause.Compile
 
 import Agda.TypeChecking.Rules.Data ( getGeneralizedParameters, bindGeneralizedParameters, bindParameters, fitsIn, forceSort,
-                                      defineCompData, defineTranspForFields, defineHCompForFields )
+                                      defineCompData, defineTranspOrHCompForFields )
 import Agda.TypeChecking.Rules.Term ( isType_ )
 import {-# SOURCE #-} Agda.TypeChecking.Rules.Decl (checkDecl)
 
@@ -373,9 +374,8 @@ defineCompKitR name params fsT fns rect = do
         ]
   reportSDoc "tc.rec.cxt" 30 $ prettyTCM params
   reportSDoc "tc.rec.cxt" 30 $ prettyTCM fsT
-  reportSDoc "tc.rec.cxt" 30 $ text $ show rect
-  sortsOk <- allM (rect : map unDom (flattenTel fsT)) sortOk
-  if not $ sortsOk && all isJust required then return $ emptyCompKit else do
+  reportSDoc "tc.rec.cxt" 30 $ pretty rect
+  if not $ all isJust required then return $ emptyCompKit else do
     transp <- whenDefined [builtinTrans]              (defineTranspOrHCompR DoTransp name params fsT fns rect)
     hcomp  <- whenDefined [builtinTrans,builtinHComp] (defineTranspOrHCompR DoHComp name params fsT fns rect)
     return $ CompKit
@@ -386,10 +386,6 @@ defineCompKitR name params fsT fns rect = do
     whenDefined xs m = do
       xs <- mapM getTerm' xs
       if all isJust xs then m else return Nothing
-    sortOk :: Type -> TCM Bool
-    sortOk a = reduce (getSort a) >>= \case
-      Type{} -> return True
-      _      -> return False
 
 
 defineTranspOrHCompR ::
@@ -401,10 +397,10 @@ defineTranspOrHCompR ::
   -> Type        -- ^ record type Δ ⊢ T
   -> TCM (Maybe QName)
 defineTranspOrHCompR cmd name params fsT fns rect = do
-  (theName, gamma, rtype, clause_types, bodies) <- fst <$>
-    (case cmd of DoTransp -> defineTranspForFields; DoHComp -> defineHCompForFields)
-       (\ t fn -> t `applyE` [Proj ProjSystem fn]) name params fsT fns rect
+  let project = (\ t fn -> t `applyE` [Proj ProjSystem fn])
+  stuff <- fmap fst <$> defineTranspOrHCompForFields cmd Nothing project name params fsT fns rect
 
+  caseMaybe stuff (return Nothing) $ \ (theName, gamma, rtype, clause_types, bodies) -> do
   -- phi = 1 clause
   c' <- do
            io <- primIOne

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -36,9 +36,11 @@ import qualified Agda.Utils.VarSet as VarSet
 import Agda.Utils.Impossible
 
 -- | Flatten telescope: (Γ : Tel) -> [Type Γ]
-flattenTel :: Telescope -> [Dom Type]
+flattenTel :: Subst t a => Tele (Dom a) -> [Dom a]
 flattenTel EmptyTel          = []
 flattenTel (ExtendTel a tel) = raise (size tel + 1) a : flattenTel (absBody tel)
+
+{-# SPECIALIZE flattenTel :: Telescope -> [Dom Type] #-}
 
 -- | Order a flattened telescope in the correct dependeny order: Γ ->
 --   Permutation (Γ -> Γ~)
@@ -75,7 +77,7 @@ teleNames = map (fst . unDom) . telToList
 teleArgNames :: Telescope -> [Arg ArgName]
 teleArgNames = map (argFromDom . fmap fst) . telToList
 
-teleArgs :: (DeBruijn a) => Telescope -> [Arg a]
+teleArgs :: (DeBruijn a) => Tele (Dom t) -> [Arg a]
 teleArgs tel =
   [ Arg info (deBruijnVar i)
   | (i, Dom {domInfo = info, unDom = (n,_)}) <- zip (downFrom $ size l) l ]

--- a/test/Succeed/Issue3697.agda
+++ b/test/Succeed/Issue3697.agda
@@ -1,0 +1,27 @@
+{-# OPTIONS --type-in-type #-}
+
+open import Agda.Primitive using (Setω)
+
+-- No panic should be triggered
+
+data A : Setω where
+
+record B' : Set where
+  field
+    theA : A
+
+data B : Set where
+  b : A → B
+
+data C : Set where
+  c : Setω → C
+
+
+data C' : Setω where
+  c : Setω → C'
+
+
+record C'' : Setω where
+  field
+    theSet : Setω
+    thefield : theSet


### PR DESCRIPTION
`LType` and `CType` now witness the required conditions on
universes/types.