### PR TITLE
Use Semigroup/Prelude.<> vs PrettyPrint.<>

### DIFF
--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -24,7 +24,6 @@ import Control.Monad.State
 import Control.Monad.Trans.Maybe
 
 import qualified Data.List as List
-import Data.Functor
 import Data.Maybe
 
 import Data.Map (Map)

--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -25,7 +25,7 @@ import Agda.Interaction.Imports
 import Agda.Interaction.Options
 
 import Agda.TypeChecking.Monad
-import Agda.TypeChecking.Pretty hiding ((<>))
+import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
@@ -35,7 +35,7 @@ import qualified Agda.Utils.HashMap as HMap
 import Agda.Utils.Lens
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
-import Agda.Utils.Pretty hiding ((<>))
+import Agda.Utils.Pretty
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 
 module Agda.Compiler.MAlonzo.Compiler where
 

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -2,10 +2,6 @@
 
 module Agda.Compiler.MAlonzo.Compiler where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ((<>))
-#endif
-
 import Control.Monad.Reader hiding (mapM_, forM_, mapM, forM, sequence)
 import Control.Monad.State  hiding (mapM_, forM_, mapM, forM, sequence)
 
@@ -254,11 +250,11 @@ definition kit (Defn NonStrict _ _  _ _ _ _ _ _) = __IMPOSSIBLE__
 -}
 definition _env _isMain Defn{defArgInfo = info, defName = q} | not $ usableModality info = do
   reportSDoc "compile.ghc.definition" 10 $
-    "Not compiling" <+> prettyTCM q <> "."
+    ("Not compiling" <+> prettyTCM q) <> "."
   return []
 definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
   reportSDoc "compile.ghc.definition" 10 $ vcat
-    [ "Compiling" <+> prettyTCM q <> ":"
+    [ ("Compiling" <+> prettyTCM q) <> ":"
     , nest 2 $ text (show d)
     ]
   pragma <- getHaskellPragma q

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -9,10 +9,6 @@ module Agda.Compiler.MAlonzo.HaskellTypes
   , hsTelApproximation, hsTelApproximation'
   ) where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ((<>))
-#endif
-
 import Control.Monad (zipWithM)
 import Data.Maybe (fromMaybe)
 import Data.List (intercalate)
@@ -198,7 +194,7 @@ haskellType q = do
           Pi a b  -> underAbstraction a b $ \b -> hsForall <$> getHsVar 0 <*> underPars (n - 1) b
           _       -> __IMPOSSIBLE__
   ty <- underPars np $ defType def
-  reportSDoc "tc.pragma.compile" 10 $ ("Haskell type for" <+> prettyTCM q <> ":") <?> pretty ty
+  reportSDoc "tc.pragma.compile" 10 $ (("Haskell type for" <+> prettyTCM q) <> ":") <?> pretty ty
   return ty
 
 checkConstructorCount :: QName -> [QName] -> [HaskellCode] -> TCM ()

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 
 -- | Translating Agda types to Haskell types. Used to ensure that imported
 --   Haskell functions have the right type.

--- a/src/full/Agda/Compiler/MAlonzo/Pretty.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Pretty.hs
@@ -6,10 +6,6 @@
 
 module Agda.Compiler.MAlonzo.Pretty where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ((<>))
-#endif
-
 import Data.Generics.Geniplate
 import qualified Agda.Utils.Haskell.Syntax as HS
 import Text.PrettyPrint (empty)
@@ -129,7 +125,7 @@ instance Pretty HS.Type where
     case t of
       HS.TyForall xs t ->
         mparens (pr > 0) $
-          sep [ "forall" <+> fsep (map pretty xs) <> "."
+          sep [ ("forall" <+> fsep (map pretty xs)) <> "."
               , nest 2 $ pretty t ]
       HS.TyFun a b ->
         mparens (pr > 4) $

--- a/src/full/Agda/Compiler/MAlonzo/Pretty.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Pretty.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 
 ------------------------------------------------------------------------
 -- Pretty-printing of Haskell modules

--- a/src/full/Agda/Compiler/Treeless/Erase.hs
+++ b/src/full/Agda/Compiler/Treeless/Erase.hs
@@ -22,7 +22,7 @@ import Agda.TypeChecking.Monad.Builtin
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Datatypes
-import Agda.TypeChecking.Pretty hiding ((<>))
+import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Primitive
 
 import {-# SOURCE #-} Agda.Compiler.Backend

--- a/src/full/Agda/Interaction/EmacsCommand.hs
+++ b/src/full/Agda/Interaction/EmacsCommand.hs
@@ -14,10 +14,6 @@ module Agda.Interaction.EmacsCommand
   , displayRunningInfo
   ) where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ((<>))
-#endif
-
 import qualified Data.List as List
 
 import Agda.Utils.Pretty

--- a/src/full/Agda/Interaction/EmacsCommand.hs
+++ b/src/full/Agda/Interaction/EmacsCommand.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 
 ------------------------------------------------------------------------
 -- | Code for instructing Emacs to do things

--- a/src/full/Agda/Interaction/Highlighting/HTML.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML.hs
@@ -19,7 +19,7 @@ import Control.Monad
 import Control.Monad.Trans
 
 import Data.Function
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 import Data.Foldable (toList, concatMap)
 import Data.Maybe
 import qualified Data.IntMap as IntMap
@@ -61,7 +61,7 @@ import Agda.Utils.FileName (filePath)
 import Agda.Utils.Function
 import Agda.Utils.Lens
 import qualified Agda.Utils.IO.UTF8 as UTF8
-import Agda.Utils.Pretty hiding ((<>))
+import Agda.Utils.Pretty
 import Agda.Utils.Tuple
 
 import Agda.Utils.Impossible

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -472,7 +472,7 @@ checkOptionsCompatible current imported importedModule = flip execStateT True $ 
     implies :: Bool -> Bool -> Bool
     p `implies` q = p <= q
 
-    showOptions opts = P.prettyList (map (\ (o, n) -> P.text n P.<> ": " P.<+> (P.pretty $ o opts))
+    showOptions opts = P.prettyList (map (\ (o, n) -> (P.text n <> ": ") P.<+> (P.pretty $ o opts))
                                  (coinfectiveOptions ++ infectiveOptions))
 
 -- | Check whether interface file exists and is in cache
@@ -900,10 +900,10 @@ createInterface file mname isMain msi =
       -- Grabbing warnings and unsolved metas to highlight them
       warnings <- getAllWarnings AllWarnings
       unless (null warnings) $ reportSDoc "import.iface.create" 20 $
-        "collected warnings: " P.<> prettyTCM warnings
+        "collected warnings: " <> prettyTCM warnings
       unsolved <- getAllUnsolved
       unless (null unsolved) $ reportSDoc "import.iface.create" 20 $
-        "collected unsolved: " P.<> prettyTCM unsolved
+        "collected unsolved: " <> prettyTCM unsolved
       let warningInfo = compress $ foldMap warningHighlighting $ unsolved ++ warnings
 
       stSyntaxInfo `modifyTCLens` \inf -> (inf `mappend` toks) `mappend` warningInfo

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -28,7 +28,7 @@ import qualified Data.List as List
 import Data.Maybe
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 import Data.Traversable (Traversable)
 import qualified Data.Traversable as Trav
 
@@ -97,7 +97,7 @@ import Agda.Utils.Maybe
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import Agda.Utils.Pretty as P
+import Agda.Utils.Pretty
 import Agda.Utils.String
 import Agda.Utils.Time
 import Agda.Utils.Tuple
@@ -1462,7 +1462,7 @@ prettyContext norm rev ii = B.withInteractionId ii $ do
       | n == x                 = prettyShow x
       | isInScope n == InScope = prettyShow n ++ " = " ++ prettyShow x
       | otherwise              = prettyShow x
-    prettyCtxType e nis = ":" <+> (e P.<> notInScopeMarker nis)
+    prettyCtxType e nis = ":" <+> (e <> notInScopeMarker nis)
     notInScopeMarker nis = case isInScope nis of
       C.InScope    -> ""
       C.NotInScope -> "  (not in scope)"

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -9,10 +9,6 @@ module Agda.Syntax.Abstract.Name
   , IsNoName(..)
   ) where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ((<>))
-#endif
-
 import Control.DeepSeq
 
 import Data.Foldable (Foldable)

--- a/src/full/Agda/Syntax/Abstract/Pattern.hs
+++ b/src/full/Agda/Syntax/Abstract/Pattern.hs
@@ -15,8 +15,6 @@ import Control.Monad.Identity
 import Control.Applicative (Applicative, liftA2)
 
 import Data.Foldable (Foldable, foldMap)
-import Data.Functor
-
 import Data.Traversable (Traversable, traverse)
 
 import Data.Maybe

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -29,7 +29,7 @@ import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.PartialOrd
 import Agda.Utils.POMonoid
-import Agda.Utils.Pretty hiding ((<>))
+import Agda.Utils.Pretty
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -86,7 +86,7 @@ import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import qualified Agda.Utils.Pretty as Pretty
-import Agda.Utils.Pretty hiding ((<>))
+import Agda.Utils.Pretty
 import Agda.Utils.Singleton
 import Agda.Utils.Three
 import Agda.Utils.Tuple

--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -8,10 +8,6 @@
 -}
 module Agda.Syntax.Concrete.Name where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ((<>))
-#endif
-
 import Control.DeepSeq
 
 import Data.ByteString.Char8 (ByteString)

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -13,7 +13,6 @@ import Prelude hiding ( null )
 #endif
 
 import Data.IORef
-import Data.Functor
 import Data.Maybe
 import qualified Data.Strict.Maybe as Strict
 

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -6,11 +6,7 @@
 -}
 module Agda.Syntax.Concrete.Pretty where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Data.IORef
 import Data.Maybe
@@ -149,7 +145,7 @@ prettyRelevance a d =
   if render d == "_" then d else pretty (getRelevance a) <> d
 
 instance (Pretty a, Pretty b) => Pretty (a, b) where
-    pretty (a, b) = parens $ pretty a <> comma <+> pretty b
+    pretty (a, b) = parens $ (pretty a <> comma) <+> pretty b
 
 instance Pretty (ThingWithFixity Name) where
     pretty (ThingWithFixity n _) = pretty n

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-{-# LANGUAGE CPP #-}
 
 {-| Pretty printer for the concrete syntax.
 -}

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -44,8 +44,7 @@ import Agda.Utils.NonemptyList
 import Agda.Utils.Null
 import Agda.Utils.Permutation
 import Agda.Utils.Size
-import qualified Agda.Utils.Pretty as P
-import Agda.Utils.Pretty hiding ((<>))
+import Agda.Utils.Pretty
 import Agda.Utils.Tuple
 
 import Agda.Utils.Impossible
@@ -1364,7 +1363,7 @@ instance Pretty a => Pretty (Substitution' a) where
     pr p rho = case rho of
       IdS              -> "idS"
       EmptyS err       -> "emptyS"
-      t :# rho         -> mparens (p > 2) $ sep [ pr 2 rho P.<> ",", prettyPrec 3 t ]
+      t :# rho         -> mparens (p > 2) $ sep [ pr 2 rho <> ",", prettyPrec 3 t ]
       Strengthen _ rho -> mparens (p > 9) $ "strS" <+> pr 10 rho
       Wk n rho         -> mparens (p > 9) $ text ("wkS " ++ show n) <+> pr 10 rho
       Lift n rho       -> mparens (p > 9) $ text ("liftS " ++ show n) <+> pr 10 rho
@@ -1475,7 +1474,7 @@ instance Pretty DBPatVar where
 
 instance Pretty a => Pretty (Pattern' a) where
   prettyPrec n (VarP _o x)   = prettyPrec n x
-  prettyPrec _ (DotP _o t)   = "." P.<> prettyPrec 10 t
+  prettyPrec _ (DotP _o t)   = "." <> prettyPrec 10 t
   prettyPrec n (ConP c i nps)= mparens (n > 0 && not (null nps)) $
     pretty (conName c) <+> fsep (map (prettyPrec 10) ps)
     where ps = map (fmap namedThing) nps

--- a/src/full/Agda/Syntax/Internal/SanityCheck.hs
+++ b/src/full/Agda/Syntax/Internal/SanityCheck.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -- | Sanity checking for internal syntax. Mostly checking variable scoping.
 module Agda.Syntax.Internal.SanityCheck where
 

--- a/src/full/Agda/Syntax/Internal/SanityCheck.hs
+++ b/src/full/Agda/Syntax/Internal/SanityCheck.hs
@@ -2,10 +2,6 @@
 -- | Sanity checking for internal syntax. Mostly checking variable scoping.
 module Agda.Syntax.Internal.SanityCheck where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ((<>))
-#endif
-
 import Control.Monad
 import qualified Data.IntSet as Set
 

--- a/src/full/Agda/Syntax/Parser/Monad.hs
+++ b/src/full/Agda/Syntax/Parser/Monad.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 

--- a/src/full/Agda/Syntax/Parser/Monad.hs
+++ b/src/full/Agda/Syntax/Parser/Monad.hs
@@ -32,10 +32,6 @@ module Agda.Syntax.Parser.Monad
     )
     where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ((<>))
-#endif
-
 import Control.Exception (catch, displayException)
 import Data.Int
 
@@ -183,17 +179,17 @@ instance Show ParseError where
 
 instance Pretty ParseError where
   pretty ParseError{errPos,errSrcFile,errMsg,errPrevToken,errInput} = vcat
-      [ pretty (errPos { srcFile = errSrcFile }) <> colon <+>
+      [ (pretty (errPos { srcFile = errSrcFile }) <> colon) <+>
         text errMsg
       , text $ errPrevToken ++ "<ERROR>"
       , text $ take 30 errInput ++ "..."
       ]
   pretty OverlappingTokensError{errRange} = vcat
-      [ pretty errRange <> colon <+>
+      [ (pretty errRange <> colon) <+>
         "Multi-line comment spans one or more literate text blocks."
       ]
   pretty InvalidExtensionError{errPath,errValidExts} = vcat
-      [ pretty errPath <> colon <+>
+      [ (pretty errPath <> colon) <+>
         "Unsupported extension."
       , "Supported extensions are:" <+> prettyList_ errValidExts
       ]
@@ -217,7 +213,7 @@ instance Show ParseWarning where
 
 instance Pretty ParseWarning where
   pretty OverlappingTokensWarning{warnRange} = vcat
-      [ pretty warnRange <> colon <+>
+      [ (pretty warnRange <> colon) <+>
         "Multi-line comment spans one or more literate text blocks."
       ]
 instance HasRange ParseWarning where

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -27,7 +27,6 @@ module Agda.Syntax.Parser.Parser (
 import Control.Monad
 
 import Data.Char
-import Data.Functor
 import Data.List
 import Data.Maybe
 import Data.Monoid

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -66,11 +66,7 @@ module Agda.Syntax.Position
   , interleaveRanges
   ) where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Control.Applicative hiding (empty)
 import Control.Monad

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE GADTs              #-}
 

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -6,11 +6,7 @@
 -}
 module Agda.Syntax.Scope.Base where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Control.Arrow (first, second, (***))
 import Control.Applicative hiding (empty)

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE UndecidableInstances   #-}
-{-# LANGUAGE CPP                    #-}
 
 -- {-# OPTIONS -fwarn-unused-binds #-}
 

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-| Translation from "Agda.Syntax.Concrete" to "Agda.Syntax.Abstract". Involves scope analysis,

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -20,11 +20,7 @@ module Agda.Syntax.Translation.ConcreteToAbstract
     , PatName, APatName
     ) where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), mapM, null )
-#else
 import Prelude hiding ( mapM, null )
-#endif
 
 import Control.Applicative
 import Control.Arrow (second)

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Utils.Permutation
-import Agda.Utils.Pretty hiding ((<>))
+import Agda.Utils.Pretty
 import Agda.Utils.Singleton
 import Agda.Utils.Size
 import Agda.Utils.Tuple

--- a/src/full/Agda/Termination/CallGraph.hs
+++ b/src/full/Agda/Termination/CallGraph.hs
@@ -43,7 +43,7 @@ import Agda.Utils.Function
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Utils.PartialOrd
-import Agda.Utils.Pretty hiding ((<>))
+import Agda.Utils.Pretty
 import Agda.Utils.Singleton
 import Agda.Utils.Tuple
 

--- a/src/full/Agda/Termination/CallMatrix.hs
+++ b/src/full/Agda/Termination/CallMatrix.hs
@@ -24,7 +24,7 @@ import qualified Agda.Utils.Favorites as Fav
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Utils.PartialOrd
-import Agda.Utils.Pretty hiding ((<>))
+import Agda.Utils.Pretty
 import Agda.Utils.Singleton
 
 ------------------------------------------------------------------------

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -39,7 +39,7 @@ import Agda.Termination.RecCheck (anyDefs)
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Benchmark
 import Agda.TypeChecking.Monad.Builtin
-import Agda.TypeChecking.Pretty hiding ((<>))
+import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -18,11 +18,7 @@ module Agda.Termination.TermCheck
     , Result
     ) where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Control.Applicative hiding (empty)
 import Control.Monad.Reader

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ImplicitParams             #-}

--- a/src/full/Agda/TypeChecking/CheckInternal.hs-boot
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs-boot
@@ -1,5 +1,4 @@
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE CPP            #-}
 
 module Agda.TypeChecking.CheckInternal where
 

--- a/src/full/Agda/TypeChecking/CompiledClause.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause.hs
@@ -26,7 +26,7 @@ import Agda.Syntax.Literal
 import Agda.Syntax.Position
 
 import Agda.Utils.Null
-import Agda.Utils.Pretty hiding ((<>))
+import Agda.Utils.Pretty
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
-{-# LANGUAGE CPP                      #-}
 
 module Agda.TypeChecking.Conversion where
 

--- a/src/full/Agda/TypeChecking/Conversion.hs-boot
+++ b/src/full/Agda/TypeChecking/Conversion.hs-boot
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 
 module Agda.TypeChecking.Conversion where
 

--- a/src/full/Agda/TypeChecking/Conversion/Pure.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Pure.hs
@@ -7,7 +7,7 @@ import Control.Monad.Fail (MonadFail)
 import Control.Monad.Trans.Maybe
 import Control.Monad.State
 
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 import Data.String
 
 import Agda.Syntax.Common
@@ -61,6 +61,9 @@ deriving instance ReadTCState     m => ReadTCState     (PureConversionT m)
 deriving instance MonadReduce     m => MonadReduce     (PureConversionT m)
 deriving instance MonadAddContext m => MonadAddContext (PureConversionT m)
 deriving instance MonadDebug      m => MonadDebug      (PureConversionT m)
+
+instance (Monad m, Semigroup a) => Semigroup (PureConversionT m a) where
+  d1 <> d2 = (<>) <$> d1 <*> d2
 
 instance (IsString a, Monad m) => IsString (PureConversionT m a) where
   fromString s = return (fromString s)

--- a/src/full/Agda/TypeChecking/Conversion/Pure.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Pure.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Agda.TypeChecking.Conversion.Pure where

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -36,7 +36,6 @@ import Agda.TypeChecking.Substitute
 import Agda.Utils.Null
 import Agda.Utils.Permutation
 import Agda.Utils.Pretty ( Pretty(..), text, (<+>), cat , prettyList_ )
-import qualified Agda.Utils.Pretty as P
 import Agda.Utils.Size
 import Agda.Utils.List
 import Agda.Utils.Monad
@@ -76,10 +75,10 @@ data SplitPatVar = SplitPatVar
 
 instance Pretty SplitPatVar where
   prettyPrec _ x =
-    (text $ patVarNameToString (splitPatVarName x)) P.<>
-    (text $ "@" ++ show (splitPatVarIndex x)) P.<>
+    (text $ patVarNameToString (splitPatVarName x)) <>
+    (text $ "@" ++ show (splitPatVarIndex x)) <>
     (ifNull (splitExcludedLits x) empty $ \lits ->
-      "\\{" P.<> prettyList_ lits P.<> "}")
+      "\\{" <> prettyList_ lits <> "}")
 
 instance PrettyTCM SplitPatVar where
   prettyTCM = prettyTCM . var . splitPatVarIndex

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -17,11 +17,7 @@ module Agda.TypeChecking.Errors
   , stringTCErr
   ) where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Control.Monad.Reader
 import Control.Monad.State
@@ -1088,7 +1084,7 @@ instance PrettyTCM TypeError where
           , vcat $ map f xs
           ]
       where
-        f (x, fs) = pretty x <> ": " <+> fsep (map pretty fs)
+        f (x, fs) = (pretty x <> ": ") <+> fsep (map pretty fs)
 
     MultiplePolarityPragmas xs -> fsep $
       pwords "Multiple polarity pragmas for" ++ map pretty xs
@@ -1220,7 +1216,7 @@ instance PrettyTCM SplitError where
     CannotCreateMissingClause f cl msg t -> fsep (
       pwords "Cannot generate inferred clause for" ++ [prettyTCM f <> "."] ++
       pwords "Case to handle:") $$ nest 2 (vcat $ [display cl])
-                                $$ (pure msg <+> enterClosure t displayAbs <> ".")
+                                $$ ((pure msg <+> enterClosure t displayAbs) <> ".")
         where
         displayAbs (Abs x t) = addContext x $ prettyTCM t
         displayAbs (NoAbs x t) = prettyTCM t

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -80,7 +80,7 @@ import Agda.TypeChecking.Records
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
-import Agda.TypeChecking.Pretty hiding ((<>))
+import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Telescope
 
 import Agda.Utils.Function

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -29,7 +29,7 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Primitive
 import {-# SOURCE #-} Agda.TypeChecking.MetaVars
 import {-# SOURCE #-} Agda.TypeChecking.Conversion
-import Agda.TypeChecking.Pretty hiding ((<>))
+import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Constraints
 import Agda.TypeChecking.Polarity
 import Agda.TypeChecking.Warnings

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 module Agda.TypeChecking.InstanceArguments

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -8,10 +8,6 @@ module Agda.TypeChecking.InstanceArguments
   , postponeInstanceConstraints
   ) where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ((<>))
-#endif
-
 import Control.Applicative hiding (empty)
 import Control.Monad.Reader
 import Control.Monad.State
@@ -472,11 +468,11 @@ checkCandidates m t cands =
                   case sol of
                     MetaV m' _ | m == m' ->
                       reportSDoc "tc.instance" 15 $
-                        sep [ "instance search: maybe solution for" <+> prettyTCM m <> ":"
+                        sep [ ("instance search: maybe solution for" <+> prettyTCM m) <> ":"
                             , nest 2 $ prettyTCM v ]
                     _ ->
                       reportSDoc "tc.instance" 15 $
-                        sep [ "instance search: found solution for" <+> prettyTCM m <> ":"
+                        sep [ ("instance search: found solution for" <+> prettyTCM m) <> ":"
                             , nest 2 $ prettyTCM sol ]
 
             do solveAwakeConstraints' True

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -99,8 +99,7 @@ import Agda.Utils.Monad
 import Agda.Utils.NonemptyList
 import Agda.Utils.Null
 import Agda.Utils.Permutation
-import Agda.Utils.Pretty hiding ((<>))
-import qualified Agda.Utils.Pretty as P
+import Agda.Utils.Pretty
 import Agda.Utils.Singleton
 import Agda.Utils.Functor
 import Agda.Utils.Function
@@ -1423,7 +1422,7 @@ instance Pretty DisplayTerm where
   prettyPrec p v =
     case v of
       DTerm v          -> prettyPrec p v
-      DDot v           -> "." P.<> prettyPrec 10 v
+      DDot v           -> "." <> prettyPrec 10 v
       DDef f es        -> pretty f `pApp` es
       DCon c _ vs      -> pretty (conName c) `pApp` map Apply vs
       DWithApp h ws es ->

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 
 module Agda.TypeChecking.Monad.Builtin where
 

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns         #-}
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Check that a datatype is strictly positive.

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -5,11 +5,7 @@
 -- | Check that a datatype is strictly positive.
 module Agda.TypeChecking.Positivity where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Control.Applicative hiding (empty)
 import Control.DeepSeq
@@ -612,11 +608,11 @@ buildOccurrenceGraph qs =
       occs <- computeOccurrences' q
 
       reportSDoc "tc.pos.occs" 40 $
-        ("Occurrences in" <+> prettyTCM q <> ":")
+        (("Occurrences in" <+> prettyTCM q) <> ":")
           $+$
         (nest 2 $ vcat $
            map (\(i, n) ->
-                   text (show i) <> ":" <+> text (show n) <+>
+                   (text (show i) <> ":") <+> text (show n) <+>
                    "occurrences") $
            List.sortBy (compare `on` snd) $
            Map.toList (flatten occs))
@@ -632,7 +628,7 @@ buildOccurrenceGraph qs =
            map (\e ->
                    let Edge o w = Graph.label e in
                    prettyTCM (Graph.source e) <+>
-                   "-[" <+> return (P.pretty o) <> "," <+>
+                   "-[" <+> (return (P.pretty o) <> ",") <+>
                                  return (P.pretty w) <+> "]->" <+>
                    prettyTCM (Graph.target e))
                es)
@@ -756,7 +752,7 @@ computeEdges muts q ob =
 instance Pretty Node where
   pretty = \case
     DefNode q   -> P.pretty q
-    ArgNode q i -> P.pretty q P.<> P.text ("." ++ show i)
+    ArgNode q i -> P.pretty q <> P.text ("." ++ show i)
 
 instance PrettyTCM Node where
   prettyTCM = return . P.pretty
@@ -786,11 +782,11 @@ instance PrettyTCM (Seq OccursWhere) where
       prettyOWs []  = __IMPOSSIBLE__
       prettyOWs [o] = do
         (s, d) <- prettyOW o
-        return (s, d P.<> ".")
+        return (s, d <> ".")
       prettyOWs (o:os) = do
         (s1, d1) <- prettyOW  o
         (s2, d2) <- prettyOWs os
-        return (s1, d1 P.<> "," P.<+> "which" P.<+> P.text s2 P.$$ d2)
+        return (s1, d1 <> ("," P.<+> "which" P.<+> P.text s2 P.$$ d2))
 
       prettyOW :: MonadPretty m => OccursWhere -> m (String, Doc)
       prettyOW (OccursWhere _ cs ws)
@@ -798,7 +794,7 @@ instance PrettyTCM (Seq OccursWhere) where
         | otherwise = do
             (s, d1) <- prettyWs ws
             (_, d2) <- prettyWs cs
-            return (s, d1 P.$$ "(" P.<> d2 P.<> ")")
+            return (s, d1 P.$$ "(" <> d2 <> ")")
 
       prettyWs :: MonadPretty m => Seq Where -> m (String, Doc)
       prettyWs ws = case Fold.toList ws of

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Agda.TypeChecking.Pretty

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -1,16 +1,6 @@
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- To define <>, we need to add with GHC >= 8.4
---
---   import Prelude hiding ((<>))
---
--- but using that gives warnings and doesn't silence -Wsemigroup in
--- some versions of GHC.
-#if __GLASGOW_HASKELL__ < 804
-{-# OPTIONS_GHC -Wno-semigroup #-}
-#endif
-
 module Agda.TypeChecking.Pretty
     ( module Agda.TypeChecking.Pretty
     -- This re-export can be removed once <GHC-8.4 is dropped.

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -11,13 +11,13 @@
 {-# OPTIONS_GHC -Wno-semigroup #-}
 #endif
 
-module Agda.TypeChecking.Pretty where
+module Agda.TypeChecking.Pretty
+    ( module Agda.TypeChecking.Pretty
+    -- This re-export can be removed once <GHC-8.4 is dropped.
+    , module Data.Semigroup
+    ) where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Control.Applicative hiding (empty)
 import Control.Monad
@@ -28,6 +28,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Maybe
 import Data.String
+import Data.Semigroup (Semigroup((<>)))
 
 import Agda.Syntax.Position
 import Agda.Syntax.Common
@@ -107,13 +108,12 @@ vcat ds = P.vcat <$> sequence ds
 hang :: Applicative m => m Doc -> Int -> m Doc -> m Doc
 hang p n q = P.hang <$> p <*> pure n <*> q
 
-infixl 6 <>, <+>, <?>
+infixl 6 <+>, <?>
 infixl 5 $$, $+$
 
-($$), ($+$), (<>), (<+>), (<?>) :: Applicative m => m Doc -> m Doc -> m Doc
+($$), ($+$), (<+>), (<?>) :: Applicative m => m Doc -> m Doc -> m Doc
 d1 $$ d2  = (P.$$) <$> d1 <*> d2
 d1 $+$ d2 = (P.$+$) <$> d1 <*> d2
-d1 <> d2  = (P.<>) <$> d1 <*> d2
 d1 <+> d2 = (P.<+>) <$> d1 <*> d2
 d1 <?> d2 = (P.<?>) <$> d1 <*> d2
 
@@ -130,14 +130,14 @@ pshow :: (Applicative m, Show a) => a -> m Doc
 pshow = pure . P.pshow
 
 -- | Comma-separated list in brackets.
-prettyList :: Monad m => [m Doc] -> m Doc
+prettyList :: (Monad m, Semigroup (m Doc)) => [m Doc] -> m Doc
 prettyList ds = P.pretty <$> sequence ds
 
 -- | 'prettyList' without the brackets.
-prettyList_ :: Monad m => [m Doc] -> m Doc
+prettyList_ :: (Monad m, Semigroup (m Doc)) => [m Doc] -> m Doc
 prettyList_ ds = fsep $ punctuate comma ds
 
-punctuate :: Applicative m => m Doc -> [m Doc] -> [m Doc]
+punctuate :: (Applicative m, Semigroup (m Doc)) => m Doc -> [m Doc] -> [m Doc]
 punctuate _ [] = []
 punctuate d ds = zipWith (<>) ds (replicate n d ++ [pure empty])
   where
@@ -152,6 +152,7 @@ type MonadPretty m =
   , MonadAbsToCon m
   , IsString (m Doc)
   , Null (m Doc)
+  , Semigroup (m Doc)
   )
 
 class PrettyTCM a where
@@ -226,7 +227,7 @@ instance PrettyTCM MetaId where
     pretty $ NamedMeta mn x
 
 instance PrettyTCM a => PrettyTCM (Blocked a) where
-  prettyTCM (Blocked x a) = "[" <+> prettyTCM a <+> "]" <> text (P.prettyShow x)
+  prettyTCM (Blocked x a) = ("[" <+> prettyTCM a <+> "]") <> text (P.prettyShow x)
   prettyTCM (NotBlocked _ x) = prettyTCM x
 
 instance (Reify a e, ToConcrete e c, P.Pretty c) => PrettyTCM (Named_ a) where
@@ -336,7 +337,7 @@ instance PrettyTCM Constraint where
         HasBiggerSort a -> "Has bigger sort:" <+> prettyTCM a
         HasPTSRule a b -> "Has PTS rule:" <+> case b of
           NoAbs _ b -> prettyTCM (a,b)
-          Abs x b   -> "(" <> prettyTCM a <+> "," <+> addContext x (prettyTCM b) <> ")"
+          Abs x b   -> "(" <> (prettyTCM a <+> "," <+> addContext x (prettyTCM b)) <> ")"
         UnquoteTactic _ v _ _ -> do
           e <- reify v
           prettyTCM (A.App A.defaultAppInfo_ (A.Unquote A.exprNoRange) (defaultNamedArg e))
@@ -447,7 +448,7 @@ instance PrettyTCM NLPat where
     text ("λ " ++ absName u ++ " →") <+>
     (addContext (absName u) $ prettyTCM $ absBody u)
   prettyTCM (PPi a b)   = parens $
-    text ("(" ++ absName b ++ " :") <+> prettyTCM (unDom a) <> ") →" <+>
+    text ("(" ++ absName b ++ " :") <+> (prettyTCM (unDom a) <> ") →") <+>
     (addContext (absName b) $ prettyTCM $ unAbs b)
   prettyTCM (PBoundVar i []) = prettyTCM (var i)
   prettyTCM (PBoundVar i es) = parens $ prettyTCM (var i) <+> fsep (map prettyTCM es)

--- a/src/full/Agda/TypeChecking/Pretty.hs-boot
+++ b/src/full/Agda/TypeChecking/Pretty.hs-boot
@@ -3,6 +3,7 @@
 module Agda.TypeChecking.Pretty where
 
 import Data.String (IsString)
+import Data.Semigroup (Semigroup)
 
 import Agda.Syntax.Common (NameId)
 import Agda.Syntax.Internal
@@ -21,7 +22,7 @@ import Agda.Utils.Pretty (Doc)
 
 text                  :: Monad m => String -> m Doc
 sep, fsep, hsep, vcat :: Monad m => [m Doc] -> m Doc
-($$), (<>), (<+>)     :: Applicative m => m Doc -> m Doc -> m Doc
+($$), (<+>)           :: Applicative m => m Doc -> m Doc -> m Doc
 
 -- Inlining definitions of MonadReify and MonadAbsToCon to avoid
 -- having to import them
@@ -44,6 +45,7 @@ type MonadPretty m =
     )
   , IsString (m Doc)
   , Null (m Doc)
+  , Semigroup (m Doc)
   )
 
 class PrettyTCM a where

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -2,11 +2,7 @@
 
 module Agda.TypeChecking.Pretty.Call where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Agda.Syntax.Abstract as A
 import Agda.Syntax.Abstract.Views
@@ -43,7 +39,7 @@ instance PrettyTCM CallInfo where
         r    = callInfoRange c
     if null $ P.pretty r
       then call
-      else call $$ nest 2 ("(at" <+> prettyTCM r <> ")")
+      else call $$ nest 2 ("(at" <+> prettyTCM r) <> ")"
 
 instance PrettyTCM Call where
   prettyTCM c = withContextPrecedence TopCtx $ case c of

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 
 module Agda.TypeChecking.Pretty.Call where
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 
 module Agda.TypeChecking.Pretty.Warning where
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -2,11 +2,7 @@
 
 module Agda.TypeChecking.Pretty.Warning where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Data.Function
 import qualified Data.Set as Set

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -1,14 +1,10 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveFoldable             #-}
 {-# LANGUAGE DeriveTraversable          #-}
-{-# LANGUAGE NondecreasingIndentation #-}
-
-#if __GLASGOW_HASKELL__ >= 802
-{-# OPTIONS -Wno-simplifiable-class-constraints #-}
-#endif
+{-# LANGUAGE NondecreasingIndentation   #-}
+{-# LANGUAGE MonoLocalBinds             #-}
 
 {-| Primitive functions, such as addition on builtin integers.
 -}
@@ -1370,7 +1366,7 @@ primComp = do
             (redReturn =<<) . runNamesT [] $ do
               comp <- do
                 let
-                  ineg j = pure tINeg <@> j
+                  ineg j = (pure tINeg <@> j) :: TCMT IO Term
                   imax i j = pure tIMax <@> i <@> j
                 let forward la bA r u = pure tTrans <#> (lam "i" $ \ i -> la <@> (i `imax` r))
                                                     <@> (lam "i" $ \ i -> bA <@> (i `imax` r))

--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -619,8 +619,8 @@ type Changes = [Change]
 
 instance Pretty (Kind -> Nat) where
   pretty f =
-    "(VarPat:" P.<+> P.text (show $ f VarPat) P.<+>
-    "DotPat:"  P.<+> P.text (show $ f DotPat) P.<> ")"
+    ("(VarPat:" P.<+> P.text (show $ f VarPat) P.<+>
+    "DotPat:"  P.<+> P.text (show $ f DotPat)) <> ")"
 
 instance PrettyTCM (Kind -> Nat) where
   prettyTCM = return . pretty

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -4,10 +4,6 @@
 
 module Agda.TypeChecking.Records where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ((<>))
-#endif
-
 import Control.Monad
 import Control.Monad.Reader
 import Control.Monad.Trans.Maybe
@@ -246,7 +242,7 @@ getDefType f t = do
   -- if @f@ is not a projection (like) function, @a@ is the correct type
       fallback = return $ Just a
   reportSDoc "tc.deftype" 20 $ vcat
-    [ "definition f = " <> prettyTCM f <+> text ("  -- raw: " ++ prettyShow f)
+    [ ("definition f = " <> prettyTCM f) <+> text ("  -- raw: " ++ prettyShow f)
     , "has type   a = " <> prettyTCM a
     , "principal  t = " <> prettyTCM t
     ]

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
 

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -85,7 +85,7 @@ import Agda.Utils.Memo
 import Agda.Utils.Null (empty)
 import Agda.Utils.Function
 import Agda.Utils.Functor
-import Agda.Utils.Pretty hiding ((<>))
+import Agda.Utils.Pretty
 import Agda.Utils.Size
 import Agda.Utils.Zipper
 

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 module Agda.TypeChecking.Rules.Application

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -9,11 +9,7 @@ module Agda.TypeChecking.Rules.Application
   , checkProjAppToKnownPrincipalArg
   ) where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Control.Arrow (first, second)
 import Control.Monad.Trans
@@ -1113,10 +1109,10 @@ checkSharpApplication e t c args = do
       def <- theDef <$> getConstInfo c'
       vcat $
         [ "The coinductive wrapper"
-        , nest 2 $ prettyTCM rel <> prettyTCM c' <+> ":"
+        , nest 2 $ prettyTCM rel <> (prettyTCM c' <+> ":")
         , nest 4 $ prettyTCM t
         , nest 2 $ prettyA clause
-        , "The definition is" <+> text (show $ funDelayed def) <>
+        , ("The definition is" <+> text (show $ funDelayed def)) <>
           "."
         ]
     return c'

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -3,11 +3,7 @@
 
 module Agda.TypeChecking.Rules.Decl where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Control.Monad
 import Control.Monad.Reader
@@ -247,10 +243,10 @@ checkDecl d = setCurrentRange d $ do
       A.Axiom A.NoFunSig i defaultArgInfo Nothing x t
 
     check x i m = Bench.billTo [Bench.Definition x] $ do
-      reportSDoc "tc.decl" 5 $ "Checking" <+> prettyTCM x <> "."
+      reportSDoc "tc.decl" 5 $ ("Checking" <+> prettyTCM x) <> "."
       reportSLn "tc.decl.abstract" 25 $ show (Info.defAbstract i)
       r <- abstract (Info.defAbstract i) m
-      reportSDoc "tc.decl" 5 $ "Checked" <+> prettyTCM x <> "."
+      reportSDoc "tc.decl" 5 $ ("Checked" <+> prettyTCM x) <> "."
       return r
 
     isAbstract = fmap Info.defAbstract (A.getDefInfo d) == Just AbstractDef
@@ -581,7 +577,7 @@ checkAxiom' gentel funSig i info0 mp x e = whenAbstractFreezeMetasAfter i $ do
 
   reportSDoc "tc.decl.ax" 10 $ sep
     [ text $ "checked type signature"
-    , nest 2 $ prettyTCM rel <> prettyTCM x <+> ":" <+> prettyTCM t
+    , nest 2 $ (prettyTCM rel <> prettyTCM x) <+> ":" <+> prettyTCM t
     , nest 2 $ "of sort " <+> prettyTCM (getSort t)
     ]
 
@@ -728,7 +724,7 @@ checkMutual i ds = inMutualBlock $ \ blockId -> do
 
   verboseS "tc.decl.mutual" 20 $ do
     reportSDoc "tc.decl.mutual" 20 $ vcat $
-      ("Checking mutual block" <+> text (show blockId) <> ":") :
+      (("Checking mutual block" <+> text (show blockId)) <> ":") :
       map (nest 2 . prettyA) ds
 
   insertMutualBlockInfo blockId i

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 module Agda.TypeChecking.Rules.Decl where

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 module Agda.TypeChecking.Rules.Def where

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -3,11 +3,7 @@
 
 module Agda.TypeChecking.Rules.Def where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), mapM, null )
-#else
 import Prelude hiding ( mapM, null )
-#endif
 
 import Control.Arrow ((***),first,second)
 import Control.Monad.State hiding (forM, mapM)
@@ -49,8 +45,7 @@ import Agda.TypeChecking.Inlining
 import Agda.TypeChecking.MetaVars
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Patterns.Abstract (expandPatternSynonyms)
-import Agda.TypeChecking.Pretty hiding ((<>))
-import qualified Agda.TypeChecking.Pretty as Pr
+import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Free
 import Agda.TypeChecking.CheckInternal
@@ -808,7 +803,7 @@ checkRHS i x aps t lhsResult@(LHSResult _ delta ps absurdPat trhs _ _asb _) rhs0
                    strippedPats rhs'' outerWhere False
         reportSDoc "tc.rewrite" 60 $ vcat
           [ "rewrite"
-          , "  rhs' = " Pr.<> (text . show) rhs'
+          , "  rhs' = " <> (text . show) rhs'
           ]
         checkWithRHS x qname t lhsResult [withExpr] [withType] [cl]
 

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -10,11 +10,7 @@ module Agda.TypeChecking.Rules.LHS
   , checkSortOfSplitVar
   ) where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), mapM, null, sequence )
-#else
 import Prelude hiding ( mapM, null, sequence )
-#endif
 
 import Data.Maybe
 
@@ -1574,7 +1570,7 @@ disambiguateProjection h ambD@(AmbQ ds) b = do
   where
     showDisamb (d,_) =
       let r = head $ filter (noRange /=) $ map nameBindingSite $ reverse $ mnameToList $ qnameModule d
-      in  (pretty =<< dropTopLevelModule d) <+> "(introduced at " <> prettyTCM r <> ")"
+      in  (pretty =<< dropTopLevelModule d) <+> ("(introduced at " <> prettyTCM r <> ")")
 
     notRecord = wrongProj $ headNe ds
 
@@ -1690,7 +1686,7 @@ disambiguateConstructor ambC@(AmbQ cs) d pars = do
   where
     showDisamb (c0,_,_) =
       let r = head $ filter (noRange /=) $ map nameBindingSite $ reverse $ mnameToList $ qnameModule c0
-      in  (pretty =<< dropTopLevelModule c0) <+> "(introduced at " <> prettyTCM r <> ")"
+      in  (pretty =<< dropTopLevelModule c0) <+> ("(introduced at " <> prettyTCM r <> ")")
 
     abstractConstructor c = softTypeError $
       AbstractConstructorNotInScope c

--- a/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
@@ -30,7 +30,7 @@ import Agda.TypeChecking.Monad (TCM)
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Reduce
 import qualified Agda.TypeChecking.Pretty as P
-import Agda.TypeChecking.Pretty hiding ((<>))
+import Agda.TypeChecking.Pretty
 
 import Agda.Utils.Lens
 import Agda.Utils.List
@@ -254,7 +254,7 @@ instance PrettyTCM ProblemEq where
 
 instance PrettyTCM AsBinding where
   prettyTCM (AsB x v a) =
-    sep [ prettyTCM x P.<> "@" P.<> parens (prettyTCM v)
+    sep [ prettyTCM x <> "@" <> parens (prettyTCM v)
         , nest 2 $ ":" <+> prettyTCM a
         ]
 

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -142,7 +142,7 @@ import Agda.TypeChecking.Irrelevance
 import Agda.TypeChecking.Level (reallyUnLevelView)
 import Agda.TypeChecking.Reduce
 import qualified Agda.TypeChecking.Patterns.Match as Match
-import Agda.TypeChecking.Pretty hiding ((<>))
+import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.SizedTypes (compareSizes)
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -3,11 +3,7 @@
 
 module Agda.TypeChecking.Rules.Term where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Control.Monad.Trans
 import Control.Monad.Trans.Maybe
@@ -564,7 +560,7 @@ checkAbsurdLambda cmp i h e t = do
           -- is added as irrelevant
           rel <- asksTC envRelevance
           reportSDoc "tc.term.absurd" 10 $ vcat
-            [ "Adding absurd function" <+> prettyTCM rel <> prettyTCM aux
+            [ ("Adding absurd function" <+> prettyTCM rel) <> prettyTCM aux
             , nest 2 $ "of type" <+> prettyTCM t'
             ]
           addConstant aux $
@@ -612,8 +608,8 @@ checkExtendedLambda cmp i di qname cs e t = do
      let info = setRelevance rel defaultArgInfo
 
      reportSDoc "tc.term.exlam" 20 $
-       text (show $ A.defAbstract di) <+>
-       "extended lambda's implementation \"" <> prettyTCM qname <>
+       (text (show $ A.defAbstract di) <+>
+       "extended lambda's implementation \"") <> prettyTCM qname <>
        "\" has type: " $$ prettyTCM t -- <+> " where clauses: " <+> text (show cs)
      args     <- getContextArgs
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 module Agda.TypeChecking.Rules.Term where

--- a/src/full/Agda/TypeChecking/SizedTypes/Syntax.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Syntax.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoMonomorphismRestriction  #-}
 {-# LANGUAGE UndecidableInstances       #-}

--- a/src/full/Agda/TypeChecking/SizedTypes/Syntax.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Syntax.hs
@@ -7,11 +7,7 @@
 
 module Agda.TypeChecking.SizedTypes.Syntax where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null )
-#else
 import Prelude hiding ( null )
-#endif
 
 import Data.Maybe
 import Data.Foldable (Foldable)

--- a/src/full/Agda/TypeChecking/SizedTypes/WarshallSolver.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/WarshallSolver.hs
@@ -3,11 +3,7 @@
 
 module Agda.TypeChecking.SizedTypes.WarshallSolver where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), null, truncate )
-#else
 import Prelude hiding ( null, truncate )
-#endif
 
 import Control.Applicative hiding (Const, empty)
 import Control.Monad

--- a/src/full/Agda/TypeChecking/SizedTypes/WarshallSolver.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/WarshallSolver.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 
 module Agda.TypeChecking.SizedTypes.WarshallSolver where

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -23,7 +23,7 @@ import Data.Function
 import qualified Data.List as List
 import Data.Map (Map)
 import Data.Maybe
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 
 import Debug.Trace (trace)
 import Language.Haskell.TH.Syntax (thenCmp) -- lexicographic combination of Ordering

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -20,7 +20,6 @@ module Agda.TypeChecking.Substitute
 
 import Control.Arrow (first, second)
 import Data.Function
-import Data.Functor
 import qualified Data.List as List
 import Data.Map (Map)
 import Data.Maybe

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -2,10 +2,6 @@
 
 module Agda.TypeChecking.Unquote where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ((<>))
-#endif
-
 import Control.Arrow (first, second)
 import Control.Monad.State
 import Control.Monad.Reader

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP               #-}
 
 module Agda.TypeChecking.Unquote where
 

--- a/src/full/Agda/Utils/Cluster.hs
+++ b/src/full/Agda/Utils/Cluster.hs
@@ -13,7 +13,6 @@ import Control.Monad
 import Data.Equivalence.Monad (runEquivM, equateAll, classDesc)
 
 import Data.Char
-import Data.Functor
 import qualified Data.IntMap as IntMap
 import Data.Semigroup
 

--- a/src/full/Agda/Utils/Functor.hs
+++ b/src/full/Agda/Utils/Functor.hs
@@ -1,20 +1,25 @@
-{-# LANGUAGE CPP #-}
-
 -- | Utilities for functors.
 
 module Agda.Utils.Functor
-  ( module Agda.Utils.Functor
-  , (<$>)  -- from Data.Functor
-  , ($>)   -- from Data.Functor
-#if MIN_VERSION_base(4,11,0)
-  , (<&>)  -- from Data.Functor
-#endif
+  ( (<.>)
+  , for
+  , Decoration(traverseF, distributeF)
+  , dmap
+  , dget
+  -- From Data.Functor:
+  , (<$>)
+  , ($>)
+  -- Defined identically as in Data.Functor.
+  -- Should be simply re-exported (vs redefined) once
+  -- MIN_VERSION_base >= 4.11.0.0
+  -- At time of this writing, we support 4.9.0.0.
+  , (<&>)
   )
   where
 
 import Control.Applicative ( Const(Const), getConst )
 
-import Data.Functor
+import Data.Functor ((<$>), ($>))
 import Data.Functor.Identity
 import Data.Functor.Compose
 import Data.Functor.Classes
@@ -30,13 +35,11 @@ infixr 9 <.>
 for :: Functor m => m a -> (a -> b) -> m b
 for = flip fmap
 
-#if !MIN_VERSION_base(4,11,0)
 infixl 1 <&>
 
 -- | Infix version of 'for'.
 (<&>) :: Functor m => m a -> (a -> b) -> m b
 (<&>) = for
-#endif
 
 -- | A decoration is a functor that is traversable into any functor.
 --

--- a/src/full/Agda/Utils/Functor.hs
+++ b/src/full/Agda/Utils/Functor.hs
@@ -33,13 +33,15 @@ infixr 9 <.>
 -- | The true pure @for@ loop.
 --   'Data.Traversable.for' is a misnomer, it should be @forA@.
 for :: Functor m => m a -> (a -> b) -> m b
-for = flip fmap
+for a b = fmap b a
+{-# INLINE for #-}
 
 infixl 1 <&>
 
 -- | Infix version of 'for'.
 (<&>) :: Functor m => m a -> (a -> b) -> m b
-(<&>) = for
+(<&>) a b = fmap b a
+{-# INLINE (<&>) #-}
 
 -- | A decoration is a functor that is traversable into any functor.
 --

--- a/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- | Directed graphs (can of course simulate undirected graphs).

--- a/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -68,11 +68,7 @@ module Agda.Utils.Graph.AdjacencyMap.Unidirectional
   )
   where
 
-#if MIN_VERSION_base(4,11,0)
-import Prelude hiding ( (<>), lookup, null, unzip )
-#else
 import Prelude hiding ( lookup, null, unzip )
-#endif
 
 import Control.Applicative hiding (empty)
 import Control.Monad
@@ -170,7 +166,7 @@ data Edge n e = Edge
 
 instance (Pretty n, Pretty e) => Pretty (Edge n e) where
   pretty (Edge s t e) =
-    pretty s <+> "--(" <> pretty e <> ")-->" <+> pretty t
+    pretty s <+> ("--(" <> pretty e <> ")-->") <+> pretty t
 
 ------------------------------------------------------------------------
 -- Queries

--- a/src/full/Agda/Utils/Pretty.hs
+++ b/src/full/Agda/Utils/Pretty.hs
@@ -4,6 +4,8 @@
 module Agda.Utils.Pretty
     ( module Agda.Utils.Pretty
     , module Text.PrettyPrint
+    -- This re-export can be removed once <GHC-8.4 is dropped.
+    , module Data.Semigroup
     ) where
 
 import Data.Int ( Int32 )
@@ -11,7 +13,8 @@ import Data.Data (Data(..))
 import qualified Data.Map as Map
 
 import qualified Text.PrettyPrint as P
-import Text.PrettyPrint hiding (TextDetails(Str), empty)
+import Text.PrettyPrint hiding (TextDetails(Str), empty, (<>))
+import Data.Semigroup ((<>))
 
 import Agda.Utils.NonemptyList
 import Agda.Utils.Size

--- a/src/full/Agda/Utils/Trie.hs
+++ b/src/full/Agda/Utils/Trie.hs
@@ -18,7 +18,6 @@ import qualified Prelude
 
 import Control.Monad
 import Data.Function
-import Data.Functor
 import Data.Foldable (Foldable)
 import qualified Data.Maybe as Lazy
 import Data.Map.Strict (Map)


### PR DESCRIPTION
This is part of an effort to reduce the `LANGUAGE CPP` except where strictly necessary.
~This PR *should not be merged* before #3589 as I don't want to cause trouble for that PR. But I'd like to get input on this set of changes (and get CI to double-check them).~

This change reduces the number of `LANGUAGE CPP` files to only a few in the main codebase:

  * Windows:
    * `src/full/Agda/Utils/FileName.hs` (specializing a case-sensitive file search for Windows)
    * `src/full/Agda/TypeChecking/Serialise/Base.hs` (specializing a hash map implementation for Windows)
  * Debug:
    * `src/full/Agda/Syntax/Concrete/Operators/Parser/Monad.hs` (using `ParserWithGrammar` v. `Parser` for `DEBUG`)
  * Cluster-Counting:
    * `src/full/Agda/Interaction/Highlighting/LaTeX.hs`
    * `src/full/Agda/Interaction/Options.hs`

-----

Using Prelude's `Semigroup.(<>)` on pretty printing [is defined as the same function as `PrettyPrint.<>`](https://hackage.haskell.org/package/pretty-1.1.3.6/docs/src/Text.PrettyPrint.HughesPJ.html#line-133), with the important difference that it is left associative (infixl) instead of the Prelude's right associative (infixr) definition.

See: https://www.haskell.org/pipermail/libraries/2011-November/017066.html

This becomes slightly awkward when combining with `<+>`, but seems to be a worthwhile trade-off. (Alternatively, we could redefine `<+>` to be infixr also to remove the ambiguity; but that seemed to be slightly more heavy-handed for a first pass).

Note that some elements of this are redundant once <GHC-8.4 support is dropped. The `import Monoid hiding ((<>))` can be unhidden, and re-exporting `Semigroup((<>))` is unnecessary in 8.4 and above. For additional information, see: https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode