### PR TITLE
Compile Agda:exe with -threaded like the tests are

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -649,7 +649,7 @@ executable agda
   -- However, we sometimes recommend people to use +RTS to control
   -- Agda's memory usage, so we want this functionality enabled by
   -- default.
-  ghc-options:  -rtsopts
+  ghc-options: -threaded -rtsopts
 
 executable agda-mode
   hs-source-dirs:   src/agda-mode


### PR DESCRIPTION
This is the only flag different between the `library` and `test-suite`. I believe this difference causes unnecessary recompilation with Stack (I see lots of "flags changed" triggers) because the intermediate files (`.o` etc) are shared between the two targets.

The `-threaded` flag in `test-suite` was added with the initial introduction of the tests (842fce3bd17f3c8e42394bbcd1597), and was kept thereafter. I can't find evidence in the git logs that omitting `-threaded` from the `library` itself was a conscious decision, though it's possible that there are reasons I'm not familiar with.