### PR TITLE
(Not for review) - Delete .agdai files before running compiler tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -358,7 +358,7 @@ script:
     fi
 
   - if [[ $TEST = "MAIN" ]]; then
-       make AGDA_TESTS_OPTIONS="-j${PARALLEL_TESTS} --hide-successes" BUILD_DIR=$BUILD_DIR compiler-test;
+       make AGDA_TESTS_OPTIONS="--hide-successes" BUILD_DIR=$BUILD_DIR compiler-test;
     fi
 
   - if [[ $TEST = "MAIN" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,9 @@ compiler-test :
 	@echo "======================================================================"
 	@echo "========================== Compiler tests ============================"
 	@echo "======================================================================"
-	@AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Compiler
+	@echo "Clearing old *.agdai files"
+	@find test/ -type f -name '*.agdai' -print -delete
+	AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Compiler
 
 .PHONY : api-test
 api-test :


### PR DESCRIPTION
This is just to test something on CI. Testing a hunch related to #3732 and the recent build issues.

I can't seem to repro on my machine; nobody seems to be able to. It's possible that there's something unique about Travis (e.g. timing or something related to the filesystem), or people are just running the tests differently, but let's see if clearing the `.agdai` files makes a difference.