### PR TITLE
[ #3736 ] Add MetaToNat and its injectivity proof

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -73,6 +73,7 @@ data-files:         Agda.css
                     lib/prim/Agda/Builtin/List.agda
                     lib/prim/Agda/Builtin/Nat.agda
                     lib/prim/Agda/Builtin/Reflection.agda
+                    lib/prim/Agda/Builtin/Reflection/Properties.agda
                     lib/prim/Agda/Builtin/Sigma.agda
                     lib/prim/Agda/Builtin/Size.agda
                     lib/prim/Agda/Builtin/Strict.agda

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -79,6 +79,7 @@ primitive
   primMetaEquality : Meta → Meta → Bool
   primMetaLess     : Meta → Meta → Bool
   primShowMeta     : Meta → String
+  primMetaToNat    : Meta → Nat
 
 -- Arguments --
 

--- a/src/data/lib/prim/Agda/Builtin/Reflection/Properties.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection/Properties.agda
@@ -1,0 +1,10 @@
+{-# OPTIONS --without-K --safe --no-sized-types --no-guardedness #-}
+
+module Agda.Builtin.Reflection.Properties where
+
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Equality
+
+primitive
+
+  primMetaToNatInjective : ∀ a b → primMetaToNat a ≡ primMetaToNat b → a ≡ b

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -248,6 +248,8 @@ primBody s = maybe unimplemented (fromRight (hsVarUQ . HS.Ident) <$>) $
   , "primMetaEquality"    |-> rel "(==)" "Integer"
   , "primMetaLess"        |-> rel "(<)" "Integer"
   , "primShowMeta"        |-> return "\\ x -> Data.Text.pack (\"_\" ++ show (x :: Integer))"
+  , "primMetaToNat"       |-> return "(id :: Integer -> Integer)"
+  , "primMetaToNatInjective" |-> return "erased"
 
   -- Seq
   , "primForce"      |-> return "\\ _ _ _ _ x f -> f $! x"

--- a/src/full/Agda/Interaction/Options/Lenses.hs
+++ b/src/full/Agda/Interaction/Options/Lenses.hs
@@ -161,6 +161,7 @@ builtinModulesWithSafePostulates =
   , "Agda" </> "Builtin" </> "List.agda"
   , "Agda" </> "Builtin" </> "Nat.agda"
   , "Agda" </> "Builtin" </> "Reflection.agda"
+  , "Agda" </> "Builtin" </> "Reflection" </> "Properties.agda"
   , "Agda" </> "Builtin" </> "Sigma.agda"
   , "Agda" </> "Builtin" </> "Size.agda"
   , "Agda" </> "Builtin" </> "Strict.agda"

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -1568,6 +1568,13 @@ mkPrimInjective a b qn = do
       Con{} -> redReturn $ refl t
       _     -> return $ NoReduction $ map notReduced ts
 
+primMetaToNatInjective :: TCM PrimitiveImpl
+primMetaToNatInjective = do
+  meta  <- primType (undefined :: MetaId)
+  nat   <- primType (undefined :: Nat)
+  toNat <- primFunName <$> getPrimitive "primMetaToNat"
+  mkPrimInjective meta nat toNat
+
 primCharToNatInjective :: TCM PrimitiveImpl
 primCharToNatInjective = do
   char  <- primType (undefined :: Char)
@@ -2091,6 +2098,8 @@ primitiveFunctions = Map.fromList
   , "primMetaEquality"    |-> mkPrimFun2 ((==) :: Rel MetaId)
   , "primMetaLess"        |-> mkPrimFun2 ((<) :: Rel MetaId)
   , "primShowMeta"        |-> mkPrimFun1 (Str . prettyShow :: MetaId -> Str)
+  , "primMetaToNat"       |-> mkPrimFun1 (fromIntegral . metaId :: MetaId -> Nat)
+  , "primMetaToNatInjective" |-> primMetaToNatInjective
   , "primIMin"            |-> primIMin'
   , "primIMax"            |-> primIMax'
   , "primINeg"            |-> primINeg'


### PR DESCRIPTION
Add two primitives 
```agda
primMetaToNat          : Meta → Nat
primMetaToNatInjective : ∀ a b → primMetaToNat a ≡ primMetaToNat b → a ≡ b
```
in order to define a decidable propositional equality for `Meta`, since `MetaId` is internally just a natural number: 

https://github.com/agda/agda/blob/dd7ce5bf14356b8980d085b8eb448c0ed3c34d98/src/full/Agda/Syntax/Common.hs#L1332-L1336