### PR TITLE
[hlint cleanup] Remove redundant imports

### DIFF
--- a/src/full/Agda/Auto/Auto.hs
+++ b/src/full/Agda/Auto/Auto.hs
@@ -19,8 +19,6 @@ import qualified Data.Traversable as Trav
 import Agda.Utils.Permutation (permute, takeP)
 import Agda.TypeChecking.Monad hiding (withCurrentModule)
 import Agda.TypeChecking.Telescope
-
-import Agda.Syntax.Common (Hiding(..))
 import qualified Agda.Syntax.Abstract as A
 import Agda.Syntax.Abstract.Pretty (prettyA)
 import qualified Agda.Syntax.Concrete.Name as C

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -17,7 +17,6 @@ import System.FilePath ( splitFileName, (</>) )
 
 import Agda.Interaction.FindFile ( findFile, findInterfaceFile )
 import Agda.Interaction.Imports ( isNewerThan )
-import Agda.Interaction.Options ( optCompileDir )
 import Agda.Syntax.Common ( Nat, unArg, namedArg, NameId(..) )
 import Agda.Syntax.Concrete.Name ( projectRoot , isNoName )
 import Agda.Syntax.Abstract.Name
@@ -32,14 +31,13 @@ import Agda.Syntax.Position
 import Agda.Syntax.Literal ( Literal(..) )
 import Agda.Syntax.Fixity
 import qualified Agda.Syntax.Treeless as T
-import Agda.TypeChecking.Substitute ( absBody )
+import Agda.TypeChecking.Substitute (absBody, TelV(..))
 import Agda.TypeChecking.Level ( reallyUnLevelView )
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin
 import Agda.TypeChecking.Monad.Debug ( reportSLn )
 import Agda.TypeChecking.Monad.Options ( setCommandLineOptions )
 import Agda.TypeChecking.Reduce ( instantiateFull, normalise )
-import Agda.TypeChecking.Substitute (TelV(..))
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Pretty
 import Agda.Utils.FileName ( filePath )

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -32,8 +32,6 @@ import Agda.Compiler.Treeless.Pretty
 import Agda.Compiler.Treeless.Unused
 import Agda.Compiler.Treeless.AsPatterns
 import Agda.Compiler.Treeless.Identity
-
-import Agda.Syntax.Common
 import Agda.TypeChecking.Monad as TCM
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -37,11 +37,11 @@ import qualified Data.Set as Set
 import qualified Data.Text.Lazy as T
 import Data.Void
 
-import Agda.Interaction.Response (Response(Resp_HighlightingInfo))
+import Agda.Interaction.Response
+       (Response(Resp_HighlightingInfo),
+        RemoveTokenBasedHighlighting(KeepHighlighting))
 import Agda.Interaction.Highlighting.Precise
 import Agda.Interaction.Highlighting.Range
-import Agda.Interaction.Response
-  (RemoveTokenBasedHighlighting(KeepHighlighting))
 
 import qualified Agda.TypeChecking.Errors as E
 import Agda.TypeChecking.MetaVars (isBlockedTerm)

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -18,7 +18,6 @@ import qualified Data.Map as Map
 import qualified Data.List as List
 import qualified Data.Set as Set
 import qualified Data.Foldable as Fold (toList)
-import qualified Data.List as List
 import Data.Maybe
 import Data.Monoid (mempty, mappend)
 import Data.Map (Map)

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -41,7 +41,6 @@ import Data.Bifunctor ( first )
 import Data.Function
 import qualified Data.List as List
 import Data.Maybe
-import System.Directory ( getAppUserDataDirectory )
 import System.Directory
 import System.FilePath
 import System.Environment

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -48,7 +48,6 @@ import Agda.VersionCommit
 import qualified Agda.Utils.Benchmark as UtilsBench
 import Agda.Utils.Except ( MonadError(catchError, throwError) )
 import Agda.Utils.Impossible
-import Agda.Utils.Lens
 
 
 builtinBackends :: [Backend]

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -38,7 +38,6 @@ import Data.Monoid
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Map (Map)
-import qualified Data.Map as Map
 import Data.Traversable (traverse)
 import Data.Void
 import Data.List (sortBy)

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -73,7 +73,7 @@ import Agda.TypeChecking.Patterns.Abstract (expandPatternSynonyms)
 import Agda.TypeChecking.Pretty hiding (pretty, prettyA)
 import Agda.TypeChecking.Warnings
 
-import Agda.Interaction.FindFile (checkModuleName)
+import Agda.Interaction.FindFile (checkModuleName, rootNameModule)
 -- import Agda.Interaction.Imports  -- for type-checking in ghci
 import {-# SOURCE #-} Agda.Interaction.Imports (scopeCheckImport)
 import Agda.Interaction.Options
@@ -95,7 +95,6 @@ import Agda.Utils.Null
 import qualified Agda.Utils.Pretty as P
 import Agda.Utils.Pretty (render, Pretty, pretty, prettyShow)
 import Agda.Utils.Tuple
-import Agda.Interaction.FindFile ( rootNameModule )
 
 import Agda.Utils.Impossible
 import Agda.ImpossibleTest (impossibleTest)

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -81,7 +81,6 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Pretty
-import Agda.TypeChecking.Telescope
 
 import Agda.Utils.Function
 import Agda.Utils.PartialOrd

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -28,8 +28,6 @@ import Agda.Interaction.Options
 import qualified Agda.Interaction.Options.Lenses as Lens
 import Agda.Interaction.Response
 import Agda.Interaction.Library
-
-import Agda.Utils.Except ( MonadError(catchError) )
 import Agda.Utils.FileName
 import Agda.Utils.Maybe
 import Agda.Utils.Monad

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -51,7 +51,6 @@ import Agda.TypeChecking.Coverage.SplitTree
 import {-# SOURCE #-} Agda.TypeChecking.CompiledClause.Compile
 import {-# SOURCE #-} Agda.TypeChecking.Polarity
 import {-# SOURCE #-} Agda.TypeChecking.ProjectionLike
-import Agda.TypeChecking.Monad.Builtin
 
 import Agda.Utils.Either
 import Agda.Utils.Except ( ExceptT )

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -31,7 +31,6 @@ import qualified Agda.Syntax.Translation.ReflectedToAbstract as R
 import qualified Agda.Syntax.Reflected as R
 import qualified Agda.Syntax.Abstract as A
 import qualified Agda.Syntax.Concrete as C
-import qualified Agda.Syntax.Reflected as R
 import qualified Agda.Syntax.Abstract.Pretty as AP
 import Agda.Syntax.Concrete.Pretty (bracesAndSemicolons)
 import qualified Agda.Syntax.Concrete.Pretty as CP

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -24,7 +24,6 @@ import qualified Data.Set as Set
 import Data.Maybe
 import Data.Monoid
 import Data.Traversable (traverse)
-import Data.Monoid (mempty)
 import Data.Word
 
 import Agda.Interaction.Options

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -58,8 +58,6 @@ import Data.IORef
 import Data.STRef
 import Data.Char
 
-import Debug.Trace (trace)
-
 import Agda.Syntax.Internal
 import Agda.Syntax.Common
 import Agda.Syntax.Position

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -88,8 +88,6 @@ import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Utils.Singleton
 import Agda.Utils.Size
-import Agda.Utils.Lens
-import qualified Agda.Utils.HashMap as HMap
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -36,7 +36,6 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
-import Data.Monoid
 import qualified Data.Set as Set
 import Data.Set (Set)
 

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -49,7 +49,6 @@ import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Primitive
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin
-import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Rules.Def

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -62,7 +62,6 @@ import Agda.TypeChecking.Rewriting
 import Agda.TypeChecking.SizedTypes.Solve
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
-import Agda.TypeChecking.Unquote
 import Agda.TypeChecking.Warnings
 
 import Agda.TypeChecking.Rules.Application

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -47,7 +47,6 @@ import Agda.Syntax.Literal
 import Agda.Syntax.Position
 
 import Agda.TypeChecking.Monad
-import Agda.TypeChecking.Monad.Builtin (litType, constructorForm)
 
 import qualified Agda.TypeChecking.Monad.Benchmark as Bench
 import Agda.TypeChecking.Conversion

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -151,7 +151,6 @@ import Agda.TypeChecking.Free.Reduce
 import Agda.TypeChecking.Records
 import Agda.TypeChecking.MetaVars (newArgsMetaCtx)
 import Agda.TypeChecking.EtaContract
-import Agda.Interaction.Options (optInjectiveTypeConstructors)
 
 import Agda.TypeChecking.Rules.LHS.Problem
 -- import Agda.TypeChecking.SyntacticEquality

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -35,7 +35,6 @@ import Agda.Syntax.Position
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
 import qualified Agda.Syntax.Abstract as A
-import Agda.Syntax.Position (Range)
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Options (typeInType)


### PR DESCRIPTION
Applied via:
```
hlint \
  --only 'Use fewer imports' \
  --json \
  --serialise\
  src/ test/ \
  | jq -r '.[] | .file' \
  | sort -u \
  | tee /dev/stderr \
  | tr '\n' '\0' \
  | xargs -0 -n1 hlint --verbose --refactor --refactor-options='-i -XLambdaCase -XMultiWayIf -XRankNTypes'
```
(That rigamarole is just because `hlint` can't refactor more than one file at a time…)

Note that this is not the same thing as minimal imports or even unused imports. Just imports that are duplicated.