### PR TITLE
[travis] Build with -j2 for stack and cabal jobs options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -188,7 +188,7 @@ install:
        emacs --version &&
        export PARALLEL_TESTS=${NUM_CORES} &&
        travis_retry cabal update &&
-       sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config &&
+       sed -i "s/^jobs:.*\$/jobs: ${NUM_CORES}/" $HOME/.cabal/config &&
        cat $HOME/.cabal/config &&
        export PATH=$HOME/.cabal/bin:$PATH &&
        travis_retry cabal update &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,7 +177,8 @@ install:
   # https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
   - export NUM_CORES=2
 
-  - if [[ $BUILD = "CABAL" ]]; then
+  - |
+    if [[ $BUILD = "CABAL" ]]; then
        echo "*** Cabal version ***" &&
        cabal --version &&
        echo "*** GHC version ***" &&
@@ -188,7 +189,7 @@ install:
        emacs --version &&
        export PARALLEL_TESTS=${NUM_CORES} &&
        travis_retry cabal update &&
-       sed -i "s/^jobs:.*\$/jobs: ${NUM_CORES}/" $HOME/.cabal/config &&
+       sed -i $(printf 's/^jobs:.*$/jobs: %s/' ${NUM_CORES}) $HOME/.cabal/config &&
        cat $HOME/.cabal/config &&
        export PATH=$HOME/.cabal/bin:$PATH &&
        travis_retry cabal update &&
@@ -227,7 +228,7 @@ install:
        travis_retry cabal fetch `cabal install --dependencies-only --enable-tests --force-reinstalls --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g"` &&
        make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls' install-bin;
     elif [[ $TEST = "STACKAGE" ]]; then
-       stack build $ARGS --no-terminal --only-dependencies ${AGDA_STACK_BUILD_FLAGS};
+       stack build -j${NUM_CORES} $ARGS --no-terminal --only-dependencies ${AGDA_STACK_BUILD_FLAGS};
     fi
 
 ##############################################################################
@@ -307,7 +308,7 @@ install:
 ##############################################################################
 
   - if [[ $TEST = "STACKAGE" ]]; then
-       travis_wait 30 stack build $ARGS --no-terminal ${AGDA_STACK_BUILD_FLAGS};
+       travis_wait 30 stack build -j${NUM_CORES} $ARGS --no-terminal ${AGDA_STACK_BUILD_FLAGS};
     fi
 
 ##############################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -224,11 +224,18 @@ install:
 
 # We are using `make CABAL_OPTS...` because we are including the
 # options to `cabal install` set up in the `Makefile`.
-  - if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
-       travis_retry cabal fetch `cabal install --dependencies-only --enable-tests --force-reinstalls --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g"` &&
-       make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls --build-log=/dev/stdout' install-bin;
+  - |
+    if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
+       travis_retry cabal fetch `cabal install --dependencies-only --enable-tests --force-reinstalls --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g"` || return 1
+       set -x
+       _cabal_build_log="$(mktemp --tmpdir cabal-deps-XXXXX.log)"
+       make CABAL_OPTS="-v0 --only-dependencies --force-reinstalls --build-log=${_cabal_build_log}" install-bin &
+       _cabal_pid=$!
+       tail --pid=${_cabal_pid} -F "${_cabal_build_log}" || return $?
+       wait ${_cabal_pid}
+       set +x
     elif [[ $TEST = "STACKAGE" ]]; then
-       stack build -j${NUM_CORES} $ARGS --no-terminal --only-dependencies ${AGDA_STACK_BUILD_FLAGS};
+       stack build -j${NUM_CORES} $ARGS --no-terminal --only-dependencies ${AGDA_STACK_BUILD_FLAGS}
     fi
 
 ##############################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -226,7 +226,7 @@ install:
 # options to `cabal install` set up in the `Makefile`.
   - if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
        travis_retry cabal fetch `cabal install --dependencies-only --enable-tests --force-reinstalls --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g"` &&
-       make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls' install-bin;
+       make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls --build-log=/dev/stdout' install-bin;
     elif [[ $TEST = "STACKAGE" ]]; then
        stack build -j${NUM_CORES} $ARGS --no-terminal --only-dependencies ${AGDA_STACK_BUILD_FLAGS};
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,6 +174,9 @@ install:
   # a `sed` script (from https://github.com/hvr/multi-ghc-travis) for
   # commenting out `jobs: $ncpus` in the Cabal configuration file.
 
+  # https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
+  - export NUM_CORES=2
+
   - if [[ $BUILD = "CABAL" ]]; then
        echo "*** Cabal version ***" &&
        cabal --version &&
@@ -183,7 +186,7 @@ install:
        haddock --version &&
        echo "*** Emacs version ***" &&
        emacs --version &&
-       export PARALLEL_TESTS=2 &&
+       export PARALLEL_TESTS=${NUM_CORES} &&
        travis_retry cabal update &&
        sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config &&
        cat $HOME/.cabal/config &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -189,7 +189,7 @@ install:
        emacs --version &&
        export PARALLEL_TESTS=${NUM_CORES} &&
        travis_retry cabal update &&
-       sed -i $(printf 's/^jobs:.*$/jobs: %s/' ${NUM_CORES}) $HOME/.cabal/config &&
+       sed -i "$(printf 's/^jobs:.*$/jobs: %s/' ${NUM_CORES})" $HOME/.cabal/config &&
        cat $HOME/.cabal/config &&
        export PATH=$HOME/.cabal/bin:$PATH &&
        travis_retry cabal update &&


### PR DESCRIPTION
Stack was building with no parallel jobs. Cabal's tests were, but the Cabal config's default job count options were cleared out. Based on the Travis docs, these could benefit from running with `-j2`, the actual number of cores available to each job.