### PR TITLE
[travis] Cache additional directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -215,14 +215,14 @@ install:
   - |
     if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
        _cabal_verb_prefix=''
-       if [[ "$(cabal --version)" = *"version 2."* ]]; then
+       if [[ "$(cabal --version)" = *"version 2."[4-9]* ]]; then
          _cabal_verb_prefix=v1-
        fi
        _cabal_pkgs="$(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --force-reinstalls --reinstall --dry-run)" || return 1
        echo "Packages: {"
        echo ${_cabal_pkgs}
        echo "}"
-       travis_retry cabal fetch $(sed -e 1,2d -e "s|(latest[^)]*)||g" << "${_cabal_pkgs}") &&
+       travis_retry cabal fetch $(sed -e '1,2d' -e 's|(latest[^)]*)||g' <<< "${_cabal_pkgs}") &&
        make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls' install-bin
     elif [[ $TEST = "STACKAGE" ]]; then
          stack build $ARGS --no-terminal --only-dependencies;

--- a/.travis.yml
+++ b/.travis.yml
@@ -212,13 +212,18 @@ install:
 
 # We are using `make CABAL_OPTS...` because we are including the
 # options to `cabal install` set up in the `Makefile`.
-  - if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
-       _cabal_verb_prefix='';
+  - |
+    if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
+       _cabal_verb_prefix=''
        if [[ "$(cabal --version)" = *"version 2."* ]]; then
-         _cabal_verb_prefix=v1-;
-       fi;
-       travis_retry cabal fetch $(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --reinstall --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g") &&
-       make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls' install-bin;
+         _cabal_verb_prefix=v1-
+       fi
+       _cabal_pkgs="$(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --reinstall --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g")" || return $?
+       echo "Packages: {"
+       echo ${_cabal_pkgs}
+       echo "}"
+       travis_retry cabal fetch ${_cabal_pkgs} &&
+       make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls' install-bin
     elif [[ $TEST = "STACKAGE" ]]; then
          stack build $ARGS --no-terminal --only-dependencies;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -218,12 +218,11 @@ install:
        if [[ "$(cabal --version)" = *"version 2."* ]]; then
          _cabal_verb_prefix=v1-
        fi
-       _cabal_pkgs="$(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --reinstall --dry-run)"
+       _cabal_pkgs="$(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --force-reinstalls --reinstall --dry-run)" || return 1
        echo "Packages: {"
        echo ${_cabal_pkgs}
        echo "}"
-       return 1
-       travis_retry cabal fetch ${_cabal_pkgs} &&
+       travis_retry cabal fetch $(sed -e 1,2d -e "s|(latest[^)]*)||g" << "${_cabal_pkgs}") &&
        make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls' install-bin
     elif [[ $TEST = "STACKAGE" ]]; then
          stack build $ARGS --no-terminal --only-dependencies;

--- a/.travis.yml
+++ b/.travis.yml
@@ -218,11 +218,12 @@ install:
        if [[ "$(cabal --version)" = *"version 2."[4-9]* ]]; then
          _cabal_verb_prefix=v1-
        fi
-       _cabal_pkgs="$(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --force-reinstalls --reinstall --dry-run)" || return 1
+       _cabal_pkgs="$(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --force-reinstalls --reinstall --dry-run)"
+       _cabal_pkgs_sc=$?
        echo "Packages: {"
        echo ${_cabal_pkgs}
        echo "}"
-       travis_retry cabal fetch $(sed -e '1,2d' -e 's|(latest[^)]*)||g' <<< "${_cabal_pkgs}") &&
+       [ ${_cabal_pkgs_sc} -eq 0 ] || return ${_cabal_pkgs_sc}
        make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls' install-bin
     elif [[ $TEST = "STACKAGE" ]]; then
          stack build $ARGS --no-terminal --only-dependencies;

--- a/.travis.yml
+++ b/.travis.yml
@@ -217,7 +217,7 @@ install:
        if [[ "$(cabal --version)" = *"version 2."* ]]; then
          _cabal_verb_prefix=v1-;
        fi;
-       travis_retry cabal fetch $(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --force-reinstalls --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g") &&
+       travis_retry cabal fetch $(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --reinstall --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g") &&
        make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls' install-bin;
     elif [[ $TEST = "STACKAGE" ]]; then
          stack build $ARGS --no-terminal --only-dependencies;

--- a/.travis.yml
+++ b/.travis.yml
@@ -224,6 +224,11 @@ install:
        echo ${_cabal_pkgs}
        echo "}"
        [ ${_cabal_pkgs_sc} -eq 0 ] || return ${_cabal_pkgs_sc}
+       # "All the requested packages are already installed: Use --reinstall if you want to reinstall anyway"
+       # Happens even with --reinstall and --force-reinstalls because who knows.
+       if [[ "${_cabal_pkgs}" != "All the requested packages are already installed"* ]]; then
+         travis_retry cabal fetch $(sed -e '1,2d' -e 's|(latest[^)]*)||g' <<< "${_cabal_pkgs}") || return $?
+       fi
        make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls' install-bin
     elif [[ $TEST = "STACKAGE" ]]; then
          stack build $ARGS --no-terminal --only-dependencies;

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,17 @@ sudo: required
 
 cache:
   directories:
-  - $HOME/.stack
+    - $HOME/.ghc
+    - $HOME/.cabal
+    - $HOME/.stack
+    - $TRAVIS_BUILD_DIR/.stack-work
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -rfv $TRAVIS_BUILD_DIR/.stack-work/logs
+  # ^ Consider tar'ing up the package index before caching, as done here:
+  # https://github.com/haskell-suite/haskell-src-exts/blob/e0f2aa86d68b993f0a81633af467dc550b3e7270/.travis.yml
+  # Not doing that now because it looks complicated and would need to be adapted for Stack as well.
 
 ##############################################################################
 # Required Ubuntu packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -218,10 +218,11 @@ install:
        if [[ "$(cabal --version)" = *"version 2."* ]]; then
          _cabal_verb_prefix=v1-
        fi
-       _cabal_pkgs="$(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --reinstall --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g")" || return $?
+       _cabal_pkgs="$(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --reinstall --dry-run)"
        echo "Packages: {"
        echo ${_cabal_pkgs}
        echo "}"
+       return 1
        travis_retry cabal fetch ${_cabal_pkgs} &&
        make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls' install-bin
     elif [[ $TEST = "STACKAGE" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -289,9 +289,7 @@ install:
 ##############################################################################
 # Some tests
 
-# ASR (2016-09-17). Running the following tests, which use stack, here
-# instead of in the `script` section is faster because Agda's
-# dependencies are not installed again.
+script:
 
 ##############################################################################
 # We test on Stackage the default and non-default Agda flags.
@@ -309,11 +307,6 @@ install:
        stack clean $ARGS &&
        travis_wait 30 stack build $ARGS --no-terminal --flag Agda:cpphs --flag Agda:debug --flag Agda:enable-cluster-counting;
     fi
-
-##############################################################################
-script:
-
-##############################################################################
 
   - if [[ $TEST = "MAIN" ]]; then
        make check-whitespace;

--- a/.travis.yml
+++ b/.travis.yml
@@ -213,7 +213,11 @@ install:
 # We are using `make CABAL_OPTS...` because we are including the
 # options to `cabal install` set up in the `Makefile`.
   - if [[ $TEST = "MAIN" || $TEST = "HADDOCK" ]]; then
-       travis_retry cabal fetch `cabal install --dependencies-only --enable-tests --force-reinstalls --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g"` &&
+       _cabal_verb_prefix='';
+       if [[ "$(cabal --version)" = *"version 2."* ]]; then
+         _cabal_verb_prefix=v1-;
+       fi;
+       travis_retry cabal fetch $(cabal ${_cabal_verb_prefix}install --dependencies-only --enable-tests --force-reinstalls --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g") &&
        make CABAL_OPTS='-v0 --only-dependencies --force-reinstalls' install-bin;
     elif [[ $TEST = "STACKAGE" ]]; then
          stack build $ARGS --no-terminal --only-dependencies;


### PR DESCRIPTION
The path list was taken from Stack's suggested set here: https://github.com/commercialhaskell/stack/blob/bbfefa49e0960f6ac368a6e4dfc4dbbc192a3944/doc/travis-complex.yml#L17-L23

Travis documentation on caching here: https://docs.travis-ci.com/user/caching/

The caches are specific to each branch/PR and to each job within it, so the blast radius of caching issues should be very small.

It is possible that aggressive caching could cause problems, if, for example, a dependency builds badly at some point, or if something goes wrong with GHC/stack's/cabal's dirtiness detection. The fact that Stack's repo includes these as their example gives me some confidence, though, and if it does cause problems the cache can be easily cleared. (Go here: https://travis-ci.org/agda/agda/caches)

It's possible it would be a good idea to clean them up more or tar them up, as they do here: https://github.com/haskell-suite/haskell-src-exts/blob/e0f2aa86d68b993f0a81633af467dc550b3e7270/.travis.yml But I haven't looked into that. It would depend on how big those caches turn out to be.