### PR TITLE
Warn about known and persistent bugs with Arch Linux packages

### DIFF
--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -71,6 +71,8 @@ The following prebuilt packages are available:
 
 * `Agda standard library <https://www.archlinux.org/packages/community/x86_64/agda-stdlib/>`_
 
+However, due to significant packaging bugs [such as this](https://bugs.archlinux.org/task/61904?project=5&string=agda), you might want to use alternative installation methods.
+
 Debian / Ubuntu
 ---------------
 


### PR DESCRIPTION
After the n-th time some user run into this bug on Freenode's `#agda` IRC channel, I think a warning might be in order. This wording is one option.