### PR TITLE
Replace intro/elim of Glue with computation rules

### DIFF
--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -529,15 +529,15 @@ a partial family of types that are equivalent to the base type ``A``:
 
   Glue A Te = primGlue A (λ x → Te x .fst) (λ x → Te x .snd)
 
-These come with a constructor and eliminator:
+These come with two computation rules, which hold definitionally:
 
 .. code-block:: agda
 
-  glue : ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I} {Te : Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A)}
-       → PartialP φ T → A → Glue A Te
+  glueβ₀ : ∀ {ℓ ℓ'} {A : Set ℓ} → {T₀ T₁ : Σ[ T ∈ Set ℓ' ] T ≃ A} →
+    Glue {φ = i0} A (λ {(i = i0) -> T₀ ; (i = i1) → T₁}) ≡ T₀ .fst
 
-  unglue : ∀ {ℓ ℓ'} {A : Set ℓ} (φ : I) {Te : Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A)}
-         → Glue A Te → A
+  glueβ₁ : ∀ {ℓ ℓ'} {A : Set ℓ} → {T₀ T₁ : Σ[ T ∈ Set ℓ' ] T ≃ A} →
+    Glue {φ = i1} A (λ {(i = i0) -> T₀ ; (i = i1) → T₁}) ≡ T₁ .fst
 
 Using Glue types we can turn an equivalence of types into a path as
 follows:


### PR DESCRIPTION
I am trying to understand cubical, and from what I can tell the definition of `ua` that follows `Glue` only makes sense if `Glue` computes in the way I have described, so perhaps this was what was meant to be written here? the `glue` and `unglue` rules aren't actually used in this file after their definition.

Note I haven't actually used cubical so I don't know if what I have written is true