### PR TITLE
[ travis ] wait up to 20min for compiler-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -355,7 +355,7 @@ script:
     fi
 
   - if [[ $TEST = "MAIN" ]]; then
-       make AGDA_TESTS_OPTIONS="-j${PARALLEL_TESTS} --hide-successes" BUILD_DIR=$BUILD_DIR compiler-test;
+       travis_wait 20 make AGDA_TESTS_OPTIONS="-j${PARALLEL_TESTS} --hide-successes" BUILD_DIR=$BUILD_DIR compiler-test;
     fi
 
   - if [[ $TEST = "MAIN" ]]; then


### PR DESCRIPTION
Hopefully this should prevent TEST=MAIN GHC_VER=8.0.2 from timing
out like it has been doing for the past builds.