### PR TITLE
[ new ] Primitive show function for Nat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ Language
 
   These can be used to define safe decidable propositional equality, see issue [agda-stdlib#698](https://github.com/agda/agda-stdlib/issues/698).
 
+* New Primitive for showing Natural numbers:
+
+  ```agda
+  primShowNat : Nat → String
+  ```
+
+  placed in Agda.Builtin.String.
+
 * New primitives for asking Agda to try to solve constraints [[Issue
   #3791](https://github.com/agda/agda/issues/3791)]:
 

--- a/src/data/lib/prim/Agda/Builtin/String.agda
+++ b/src/data/lib/prim/Agda/Builtin/String.agda
@@ -5,6 +5,7 @@ module Agda.Builtin.String where
 open import Agda.Builtin.Bool
 open import Agda.Builtin.List
 open import Agda.Builtin.Char
+open import Agda.Builtin.Nat using (Nat)
 
 postulate String : Set
 {-# BUILTIN STRING String #-}
@@ -16,6 +17,7 @@ primitive
   primStringEquality : String → String → Bool
   primShowChar       : Char → String
   primShowString     : String → String
+  primShowNat        : Nat → String
 
 {-# COMPILE JS primStringToList = function(x) { return x.split(""); } #-}
 {-# COMPILE JS primStringFromList = function(x) { return x.join(""); } #-}

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -178,6 +178,7 @@ primBody s = maybe unimplemented (fromRight (hsVarUQ . HS.Ident) <$>) $
   , "primNatModSucAux" |-> binNat4 "(\\ k m n j -> if n > j then mod (n - j - 1) (m + 1) else (k + n))"
   , "primNatEquality"  |-> relNat "(==)"
   , "primNatLess"      |-> relNat "(<)"
+  , "primShowNat"      |-> return "(Data.Text.pack . show :: Integer -> Data.Text.Text)"
 
   -- Machine word functions
   , "primWord64ToNat"   |-> return "MAlonzo.RTE.word64ToNat"

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -742,6 +742,7 @@ primitiveFunctions = Map.fromList
       in mkPrimFun4 aux
   , "primNatEquality"     |-> mkPrimFun2 ((==) :: Rel Nat)
   , "primNatLess"         |-> mkPrimFun2 ((<)  :: Rel Nat)
+  , "primShowNat"         |-> mkPrimFun1 (Str . show :: Nat -> Str)
 
   -- Machine words
   , "primWord64ToNat"     |-> mkPrimFun1 (fromIntegral :: Word64 -> Nat)

--- a/test/LaTeXAndHTML/succeed/Issue2019.html
+++ b/test/LaTeXAndHTML/succeed/Issue2019.html
@@ -19,7 +19,7 @@
 
 <a id="471" class="Comment">-- Various whitespace characters: &quot;    &quot;.</a>
 
-<a id="various-whitespace-characters"></a><a id="514" href="Issue2019.html#514" class="Function">various-whitespace-characters</a> <a id="544" class="Symbol">:</a> <a id="546" href="Agda.Builtin.String.html#206" class="Postulate">String</a>
+<a id="various-whitespace-characters"></a><a id="514" href="Issue2019.html#514" class="Function">various-whitespace-characters</a> <a id="544" class="Symbol">:</a> <a id="546" href="Agda.Builtin.String.html#247" class="Postulate">String</a>
 <a id="553" href="Issue2019.html#514" class="Function">various-whitespace-characters</a> <a id="583" class="Symbol">=</a> <a id="585" class="String">&quot;    &quot;</a>
 <a id="592" class="Markup">\end{code}</a><a id="602" class="Background">
 

--- a/test/LaTeXAndHTML/succeed/MdDontHighlightCode.html
+++ b/test/LaTeXAndHTML/succeed/MdDontHighlightCode.html
@@ -23,7 +23,7 @@
 &gt; You are making light of us, are you not? What do you call yourself?
 
 </a><a id="422" class="Markup">```agda
-</a>      <a id="TenDesires.Marisa.name"></a><a id="436" href="MdDontHighlightCode.html#436" class="Field">name</a> <a id="441" class="Symbol">:</a> <a id="443" href="Agda.Builtin.String.html#206" class="Postulate">String</a>
+</a>      <a id="TenDesires.Marisa.name"></a><a id="436" href="MdDontHighlightCode.html#436" class="Field">name</a> <a id="441" class="Symbol">:</a> <a id="443" href="Agda.Builtin.String.html#247" class="Postulate">String</a>
 <a id="450" class="Markup">```
 </a><a id="454" class="Background">
 ### Marisa

--- a/test/LaTeXAndHTML/succeed/Multiline.html
+++ b/test/LaTeXAndHTML/succeed/Multiline.html
@@ -5,7 +5,7 @@
 </a><a id="60" class="Markup">\begin{code}</a>
 <a id="73" class="Keyword">open</a> <a id="78" class="Keyword">import</a> <a id="85" href="Agda.Builtin.String.html" class="Module">Agda.Builtin.String</a>
 
-<a id="argh"></a><a id="106" href="Multiline.html#106" class="Function">argh</a> <a id="111" class="Symbol">:</a> <a id="113" href="Agda.Builtin.String.html#206" class="Postulate">String</a>
+<a id="argh"></a><a id="106" href="Multiline.html#106" class="Function">argh</a> <a id="111" class="Symbol">:</a> <a id="113" href="Agda.Builtin.String.html#247" class="Postulate">String</a>
 <a id="120" href="Multiline.html#106" class="Function">argh</a> <a id="125" class="Symbol">=</a>  <a id="128" class="String">&quot;Hello,\
         \World!&quot;</a>
 <a id="154" class="Markup">\end{code}</a><a id="164" class="Background">


### PR DESCRIPTION
Add a `show` function for natural functions for convenience. 

Nat is used in `Reflection` as the de Bruijn indices, but there is no easy way to show a Nat without loading the official standard library.  