### PR TITLE
[ new ] Syntax sugar - idiom brackets for Alternative from SHE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,29 @@ Language
   one wakes up all constraints mentioning the given meta-variables,
   and then tries to solve all awake constraints.
 
+### Syntax
+
+* Idiom brackets
+
+  Idiom brackets can accommodate none or multiple applications separated by a vertical bar `|`
+  if there are two additional operations
+  ```agda
+  empty : ∀ {A} → F A
+  _<|>_ : ∀ {A} → F A → F A → F A
+  ```
+  i.e. an Alternative type class in Haskell.
+  As usual, the new idiom brackets desugar before scope checking.
+
+  Idiom brackets with multiple applications
+  ```agda
+  (| e₁ a₁ .. aₙ | e₂ a₁ .. aₘ | .. | eₖ a₁ .. aₗ |)
+  ```
+  expand to (assuming right associative `_<|>_`)
+  ```agda
+  (pure e₁ <*> a₁ <*> .. <*> aₙ) <|> ((pure e₂ <*> a₁ <*> .. <*> aₘ) <|> (pure eₖ <*> a₁ <*> .. <*> aₗ))
+  ```
+  Idiom brackets with no application `(|)` or `⦇⦈` are equivalent to `empty`.
+
 Release notes for Agda version 2.6.0.1
 ======================================
 

--- a/doc/user-manual/language/syntactic-sugar.lagda.rst
+++ b/doc/user-manual/language/syntactic-sugar.lagda.rst
@@ -309,6 +309,36 @@ desugars to
 
   pure if_then_else_ <*> a <*> b <*> c
 
+Idiom brackets also support none or multiple applications. If the applicative
+functor has an additional binary operation
+
+.. code-block:: agda
+
+  _<|>_ : ∀ {A B} → F A → F A → F A
+
+then idiom brackets support multiple applications separated by a vertical bar ``|``, i.e.
+
+.. code-block:: agda
+
+  (| e₁ a₁ .. aₙ | e₂ a₁ .. aₘ | .. | eₖ a₁ .. aₗ |)
+
+which expands to (assuming right associative ``_<|>_``)
+
+.. code-block:: agda
+
+  (pure e₁ <*> a₁ <*> .. <*> aₙ) <|> ((pure e₂ <*> a₁ <*> .. <*> aₘ) <|> (pure eₖ <*> a₁ <*> .. <*> aₗ))
+
+Idiom brackets without any application ``(|)`` or ``⦇⦈`` expend to ``empty`` if
+
+.. code-block:: agda
+
+  empty :  ∀ {A} → F A
+
+is in scope. An applicative functor with ``empty`` and ``_<|>_`` is typically
+called ``Alternative``.
+
+Note that ``pure``, ``_<*>_``, and ``_<|>_`` need not be in scope to use ``(|)``.
+
 Limitations:
 
 - Binding syntax and operator sections cannot appear immediately inside

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -148,7 +148,7 @@ data Expr
   | RecUpdate Range Expr [FieldAssignment]     -- ^ ex: @record e {x = a; y = b}@
   | Let Range [Declaration] (Maybe Expr)       -- ^ ex: @let Ds in e@, missing body when parsing do-notation let
   | Paren Range Expr                           -- ^ ex: @(e)@
-  | IdiomBrackets Range Expr                   -- ^ ex: @(| e |)@
+  | IdiomBrackets Range [Expr]                 -- ^ ex: @(| e1 | e2 | .. | en |)@ or @(|)@
   | DoBlock Range [DoStmt]                     -- ^ ex: @do x <- m1; m2@
   | Absurd Range                               -- ^ ex: @()@ or @{}@, only in patterns
   | As Range Name Expr                         -- ^ ex: @x\@p@, only in patterns
@@ -215,7 +215,7 @@ mkBoundName_ :: Name -> BoundName
 mkBoundName_ x = mkBoundName x noFixity'
 
 mkBoundName :: Name -> Fixity' -> BoundName
-mkBoundName x f = BName x f
+mkBoundName = BName
 
 -- | A typed binding.
 
@@ -488,7 +488,7 @@ appView e =
   case e of
     App r e1 e2     -> vApp (appView e1) e2
     RawApp _ (e:es) -> AppView e $ map arg es
-    _               ->  AppView e []
+    _               -> AppView e []
   where
     vApp (AppView e es) arg = AppView e (es ++ [arg])
 
@@ -813,7 +813,7 @@ instance KillRange Expr where
   killRange (RecUpdate _ e ne)   = killRange2 (RecUpdate noRange) e ne
   killRange (Let _ d e)          = killRange2 (Let noRange) d e
   killRange (Paren _ e)          = killRange1 (Paren noRange) e
-  killRange (IdiomBrackets _ e)  = killRange1 (IdiomBrackets noRange) e
+  killRange (IdiomBrackets _ es) = killRange1 (IdiomBrackets noRange) es
   killRange (DoBlock _ ss)       = killRange1 (DoBlock noRange) ss
   killRange (Absurd _)           = Absurd noRange
   killRange (As _ n e)           = killRange2 (As noRange) n e

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -133,7 +133,7 @@ instance ExprLike Expr where
      RecUpdate r e es   -> f $ RecUpdate r (mapE e)   $ mapE es
      Let r ds e         -> f $ Let r       (mapE ds)  $ mapE e
      Paren r e          -> f $ Paren r                $ mapE e
-     IdiomBrackets r e  -> f $ IdiomBrackets r        $ mapE e
+     IdiomBrackets r es -> f $ IdiomBrackets r        $ mapE es
      DoBlock r ss       -> f $ DoBlock r              $ mapE ss
      Absurd{}           -> f $ e0
      As r x e           -> f $ As r x                 $ mapE e

--- a/src/full/Agda/Syntax/IdiomBrackets.hs
+++ b/src/full/Agda/Syntax/IdiomBrackets.hs
@@ -1,4 +1,4 @@
-module Agda.Syntax.IdiomBrackets (parseIdiomBrackets) where
+module Agda.Syntax.IdiomBrackets (parseIdiomBracketsSeq) where
 
 import Control.Monad
 
@@ -6,6 +6,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Position
 import Agda.Syntax.Concrete
 import Agda.Syntax.Concrete.Operators
+import Agda.Syntax.Concrete.Pretty ( leftIdiomBrkt, rightIdiomBrkt )
 
 import Agda.Syntax.Scope.Base
 import Agda.Syntax.Scope.Monad
@@ -13,11 +14,24 @@ import Agda.TypeChecking.Monad
 
 import Agda.Utils.Pretty ( prettyShow )
 
+parseIdiomBracketsSeq :: Range -> [Expr] -> ScopeM Expr
+parseIdiomBracketsSeq r es = do
+  let qEmpty = QName $ Name noRange InScope [Id "empty"]
+      qPlus  = QName $ Name noRange InScope [Hole, Id "<|>", Hole]
+      ePlus a b = App r (App r (Ident qPlus) (defaultNamedArg a)) (defaultNamedArg b)
+  case es of
+    []       -> ensureInScope qEmpty >> return (Ident qEmpty)
+    [e]      -> parseIdiomBrackets r e
+    es@(_:_) -> do
+      ensureInScope qPlus
+      es' <- mapM (parseIdiomBrackets r) es
+      return $ foldr1 ePlus es'
+
 parseIdiomBrackets :: Range -> Expr -> ScopeM Expr
 parseIdiomBrackets r e = do
   let qPure = QName $ Name noRange InScope [Id "pure"]
       qAp   = QName $ Name noRange InScope [Hole, Id "<*>", Hole]
-      ePure = App r (Ident qPure) . defaultNamedArg
+      ePure   = App r (Ident qPure) . defaultNamedArg
       eAp a b = App r (App r (Ident qAp) (defaultNamedArg a)) (defaultNamedArg b)
   mapM_ ensureInScope [qPure, qAp]
   case e of
@@ -34,8 +48,8 @@ appViewM e =
     _               -> return [e]
   where
     onlyVisible a
-      | defaultNamedArg () == (fmap (() <$) a) = return $ namedArg a
-      | otherwise = genericError $ "Only regular arguments are allowed in idiom brackets (no implicit or instance arguments)"
+      | defaultNamedArg () == fmap (() <$) a = return $ namedArg a
+      | otherwise = genericError "Only regular arguments are allowed in idiom brackets (no implicit or instance arguments)"
     noPlaceholder Placeholder{}       = genericError "Naked sections are not allowed in idiom brackets"
     noPlaceholder (NoPlaceholder _ x) = return x
 
@@ -47,5 +61,5 @@ ensureInScope q = do
   r <- resolveName q
   case r of
     UnknownName -> genericError $
-      prettyShow q ++ " needs to be in scope to use idiom brackets (| ... |)"
+      prettyShow q ++ " needs to be in scope to use idiom brackets " ++ prettyShow leftIdiomBrkt ++ " ... " ++ prettyShow rightIdiomBrkt
     _ -> return ()

--- a/src/full/Agda/Syntax/Parser/LexActions.hs
+++ b/src/full/Agda/Syntax/Parser/LexActions.hs
@@ -94,6 +94,7 @@ postToken (TokId (r, "\x2983")) = TokSymbol SymDoubleOpenBrace r
 postToken (TokId (r, "\x2984")) = TokSymbol SymDoubleCloseBrace r
 postToken (TokId (r, "\x2987")) = TokSymbol SymOpenIdiomBracket r
 postToken (TokId (r, "\x2988")) = TokSymbol SymCloseIdiomBracket r
+postToken (TokId (r, "\x2987\x2988")) = TokSymbol SymEmptyIdiomBracket r
 postToken (TokId (r, "\x2200")) = TokKeyword KwForall r
 postToken (TokId (r, s))
   | set == "Set" && all isSub n = TokSetN (r, readSubscript n)

--- a/src/full/Agda/Syntax/Parser/Lexer.x
+++ b/src/full/Agda/Syntax/Parser/Lexer.x
@@ -207,6 +207,7 @@ tokens :-
 <0,code> "|"            { symbol SymBar }
 <0,code> "(|" /[$white] { symbol SymOpenIdiomBracket }
 <0,code> "|)"           { symbol SymCloseIdiomBracket }
+<0,code> "(|)"          { symbol SymEmptyIdiomBracket }
 <0,code> "("            { symbol SymOpenParen }
 <0,code> ")"            { symbol SymCloseParen }
 <0,code> "->"           { symbol SymArrow }

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -191,6 +191,7 @@ import Agda.Utils.Impossible
     ')'                       { TokSymbol SymCloseParen $$ }
     '(|'                      { TokSymbol SymOpenIdiomBracket $$ }
     '|)'                      { TokSymbol SymCloseIdiomBracket $$ }
+    '(|)'                     { TokSymbol SymEmptyIdiomBracket $$ }
     '{{'                      { TokSymbol SymDoubleOpenBrace $$ }
     '}}'                      { TokSymbol SymDoubleCloseBrace $$ }
     '{'                       { TokSymbol SymOpenBrace $$ }
@@ -320,6 +321,7 @@ Token
     | ')'                       { TokSymbol SymCloseParen $1 }
     | '(|'                      { TokSymbol SymOpenIdiomBracket $1 }
     | '|)'                      { TokSymbol SymCloseIdiomBracket $1 }
+    | '(|)'                     { TokSymbol SymEmptyIdiomBracket $1 }
     | '{{'                      { TokSymbol SymDoubleOpenBrace $1 }
     | '}}'                      { TokSymbol SymDoubleCloseBrace $1 }
     | '{'                       { TokSymbol SymOpenBrace $1 }
@@ -581,11 +583,11 @@ PragmaStrings :: { [String] }
 PragmaStrings
     : {- empty -}           { [] }
     | string PragmaStrings  { snd $1 : $2 }
-
+{- Unused
 PragmaString :: { String }
 PragmaString
     : string { snd $1 }
-
+-}
 Strings :: { [(Interval, String)] }
 Strings : {- empty -}    { [] }
         | string Strings { $1 : $2 }
@@ -721,7 +723,8 @@ Expr3NoCurly
     | setN                              { SetN (getRange (fst $1)) (snd $1) }
     | propN                             { PropN (getRange (fst $1)) (snd $1) }
     | '{{' Expr DoubleCloseBrace        { InstanceArg (getRange ($1,$2,$3)) (maybeNamed $2) }
-    | '(|' Expr '|)'                    { IdiomBrackets (getRange ($1,$2,$3)) $2 }
+    | '(|' WithExprs '|)'               { IdiomBrackets (getRange ($1,$2,$3)) $2 }
+    | '(|)'                             { IdiomBrackets (getRange $1) [] }
     | '(' ')'                           { Absurd (fuseRange $1 $2) }
     | '{{' DoubleCloseBrace             { let r = fuseRange $1 $2 in InstanceArg r $ unnamed $ Absurd r }
     | Id '@' Expr3                      { As (getRange ($1,$2,$3)) $1 $3 }

--- a/src/full/Agda/Syntax/Parser/Tokens.hs
+++ b/src/full/Agda/Syntax/Parser/Tokens.hs
@@ -44,7 +44,7 @@ data Symbol
         | SymColon | SymArrow | SymEqual | SymLambda
         | SymUnderscore | SymQuestionMark   | SymAs
         | SymOpenParen        | SymCloseParen
-        | SymOpenIdiomBracket | SymCloseIdiomBracket
+        | SymOpenIdiomBracket | SymCloseIdiomBracket | SymEmptyIdiomBracket
         | SymDoubleOpenBrace  | SymDoubleCloseBrace
         | SymOpenBrace        | SymCloseBrace
         | SymOpenVirtualBrace | SymCloseVirtualBrace

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -914,8 +914,8 @@ instance ToAbstract C.Expr A.Expr where
       C.Paren _ e -> toAbstractCtx TopCtx e
 
   -- Idiom brackets
-      C.IdiomBrackets r e ->
-        toAbstractCtx TopCtx =<< parseIdiomBrackets r e
+      C.IdiomBrackets r es ->
+        toAbstractCtx TopCtx =<< parseIdiomBracketsSeq r es
 
   -- Do notation
       C.DoBlock r ss ->

--- a/test/Fail/IdiomBracketsImplicit.err
+++ b/test/Fail/IdiomBracketsImplicit.err
@@ -1,4 +1,4 @@
 IdiomBracketsImplicit.agda:22,15-37
 Only regular arguments are allowed in idiom brackets (no implicit
 or instance arguments)
-when scope checking (| _∷_ {n = n} a as |)
+when scope checking ⦇ _∷_ {n = n} a as ⦈

--- a/test/Fail/IdiomBracketsNotInScope.err
+++ b/test/Fail/IdiomBracketsNotInScope.err
@@ -1,3 +1,3 @@
 IdiomBracketsNotInScope.agda:12,10-21
-_<*>_ needs to be in scope to use idiom brackets (| ... |)
-when scope checking (| suc a |)
+_<*>_ needs to be in scope to use idiom brackets ⦇ ... ⦈
+when scope checking ⦇ suc a ⦈

--- a/test/Succeed/IdiomBrackets.agda
+++ b/test/Succeed/IdiomBrackets.agda
@@ -2,6 +2,7 @@
 module _ where
 
 open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
 
 module Postulates where
 
@@ -11,6 +12,8 @@ module Postulates where
     F     : Set → Set
     pure  : ∀ {A} → A → F A
     _<*>_ : ∀ {A B} → F (A → B) → F A → F B
+    _<|>_ : ∀ {A} → F A → F A → F A
+    empty : ∀ {A} → F A
 
   test₀ : F Nat → F Nat → F Nat
   test₀ a b = (| a + b |)
@@ -27,6 +30,19 @@ module Postulates where
   -- Spaces are required! (Issue #2186)
   test₄ : Nat → Nat
   test₄ |n| = suc (|n| + |n|)
+
+  -- Alternative
+  test₅ : F Nat → F Nat
+  test₅ a = (| suc a | a + a |)
+
+  test₆ : F Nat → F Nat
+  test₆ |n| = (| |n| + |n| | |n| * |n| | 3 |)
+
+  test₇ : ∀ a → test₆ a ≡ ((pure _+_ <*> a <*> a) <|> ((pure _*_ <*> a <*> a) <|> pure 3))
+  test₇ a = refl
+
+  test₈ : F Nat
+  test₈ = (|)
 
 module Params {F : Set → Set}
               (pure : ∀ {A} → A → F A)


### PR DESCRIPTION
This PR is an extension of idiom brackets based on [SHE](https://personal.cis.strath.ac.uk/conor.mcbride/pub/she/idiom.html) which allows you to use ~~Applicative~~ `Alternative` within the idiom brackets. For example, if `_<|>_` is defined, then you can write 

```agda
_ = (| just 3 + nothing | just 4 + just 5 |)
```
or using the unicode variant

```agda
_ = ⦇ just 3 + nothing | just 4 + just 5 ⦈
```
for `⦇ just 3 + nothing ⦈ <|> ⦇ just 4 + just 5 ⦈`.

If the alternative operation `_<|>_` is right associative, then

```
_ = (| nothing + just 2 | just 1 + nothing | just 2 + just 3 |)
```

is equivalent to `⦇ nothing + just 2 ⦈ <|> (⦇ just 1 + nothing ⦈ <|> ⦇ just 2 + just 3 ⦈) `. 

If `empty` is defined, then you can write `(|)` which was forbidden to use as an identifier. There is no special syntax for the unicode version, since `⦇⦈` can just be defined as a synonym of `(|)`:

```agda
⦇⦈ = (|)
``` 

However, I am not sure what name should be used for `empty`. It has been used in the standard library for other purpose, and I guess it has been used by other people. Maybe `aempty` for applicative empty? 

If this extension appears interesting or useful to you, please review the PR. Thanks! 

~~PS. I will update the CHANGELOG and user manual if approved.~~
Updated. 