### PR TITLE
[ emacs ] Alternative color scheme for dark themes

### DIFF
--- a/src/data/emacs-mode/agda2-highlight.el
+++ b/src/data/emacs-mode/agda2-highlight.el
@@ -233,17 +233,26 @@ If `agda2-highlight-face-groups' is nil."
   :group 'agda2-highlight)
 
 (defface agda2-highlight-keyword-face
-  '((t (:foreground "DarkOrange3")))
+  '((((background light))
+     (:foreground "DarkOrange3"))
+    (((background dark))
+     (:foreground "#FF9932")))
   "The face used for keywords."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-string-face
-  '((t (:foreground "firebrick")))
+  '((((background light))
+     (:foreground "firebrick"))
+    (((background dark))
+     (:foreground "#DD4D4D")))
   "The face used for strings."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-number-face
-  '((t (:foreground "purple")))
+  '((((background light))
+     (:foreground "purple"))
+    (((background dark))
+     (:foreground "#9010E0")))
   "The face used for numbers."
   :group 'agda2-highlight-faces)
 
@@ -256,7 +265,10 @@ If `agda2-highlight-face-groups' is nil."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-primitive-type-face
-  '((t (:foreground "medium blue")))
+  '((((background light))
+     (:foreground "medium blue"))
+    (((background dark))
+     (:foreground "#8080FF")))
   "The face used for primitive types (like Set and Prop)."
   :group 'agda2-highlight-faces)
 
@@ -271,37 +283,58 @@ If `agda2-highlight-face-groups' is nil."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-inductive-constructor-face
-  '((t (:foreground "green4")))
+  '((((background light))
+     :foreground "green4")
+    (((background dark))
+     :foreground "#29CC29"))
   "The face used for inductive constructors."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-coinductive-constructor-face
-  '((t (:foreground "gold4")))
+  '((((background light))
+     :foreground "gold4")
+    (((background dark))
+     :foreground "#FFEA75"))
   "The face used for coinductive constructors."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-datatype-face
-  '((t (:foreground "medium blue")))
+  '((((background light))
+     (:foreground "medium blue"))
+    (((background dark))
+     (:foreground "#8080FF")))
   "The face used for datatypes."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-field-face
-  '((t (:foreground "DeepPink2")))
+  '((((background light))
+     (:foreground "DeepPink2"))
+    (((background dark))
+     (:foreground "#F570B7")))
   "The face used for record fields."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-function-face
-  '((t (:foreground "medium blue")))
+  '((((background light))
+     (:foreground "medium blue"))
+    (((background dark))
+     (:foreground "#8080FF")))
   "The face used for functions."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-module-face
-  '((t (:foreground "purple")))
+  '((((background light))
+     (:foreground "purple"))
+    (((background dark))
+     (:foreground "#CD80FF")))
   "The face used for module names."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-postulate-face
-  '((t (:foreground "medium blue")))
+  '((((background light))
+     (:foreground "medium blue"))
+    (((background dark))
+     (:foreground "#8080FF")))
   "The face used for postulates."
   :group 'agda2-highlight-faces)
 
@@ -311,17 +344,26 @@ If `agda2-highlight-face-groups' is nil."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-primitive-face
-  '((t (:foreground "medium blue")))
+  '((((background light))
+     (:foreground "medium blue"))
+    (((background dark))
+     (:foreground "#8080FF")))
   "The face used for primitive functions."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-macro-face
-  '((t (:foreground "aquamarine4")))
+  '((((background light))
+     (:foreground "aquamarine4"))
+    (((background dark))
+     (:foreground "#73BAA2")))
   "The face used for macros."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-record-face
-  '((t (:foreground "medium blue")))
+  '((((background light))
+     (:foreground "medium blue"))
+    (((background dark))
+     (:foreground "#8080FF")))
   "The face used for record types."
   :group 'agda2-highlight-faces)
 
@@ -336,53 +378,82 @@ If `agda2-highlight-face-groups' is nil."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-error-face
-  '((t (:foreground "red" :underline t)))
+  '((((background light))
+     (:foreground "red" :underline t))
+    (((background dark))
+     (:foreground "#FF0000" :underline t)))
   "The face used for errors."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-unsolved-meta-face
-  '((t (:background "yellow")))
+  '((((background light))
+     (:background "yellow"))
+    (((background dark))
+     (:background "#806B00")))
   "The face used for unsolved meta variables."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-unsolved-constraint-face
-  '((t (:background "yellow")))
+  '((((background light))
+     (:background "yellow"))
+    (((background dark))
+     (:background "#806B00")))
   "The face used for unsolved constraints which are not connected to metas."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-termination-problem-face
-  '((t (:background "light salmon")))
+  '((((background light))
+     (:background "light salmon"))
+    (((background dark))
+     (:background "#802400")))
   "The face used for termination problems."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-positivity-problem-face
-  '((t (:background "peru")))
+  '((((background light))
+     (:background "peru"))
+    (((background dark))
+     (:background "#803F00")))
   "The face used for positivity problems."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-deadcode-face
-  '((t (:background "dark gray")))
+  '((((background light))
+     (:background "dark gray"))
+    (((background dark))
+     (:background "#808080")))
   "The face used for dead code (unreachable clauses, etc.)."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-coverage-problem-face
-  '((t (:background "wheat")))
+  '((((background light))
+     (:background "wheat"))
+    (((background dark))
+     (:background "#805300")))
   "The face used for coverage problems."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-catchall-clause-face
-  '((t (:background "white smoke")))
+  '((((background light))
+     (:background "white smoke"))
+    (((background dark))
+     (:background "#404040")))
   "The face used for catchall clauses."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-confluence-problem-face
-  '((t (:background "pink")))
+  '((((background light))
+     (:background "pink"))
+    (((background dark))
+     (:background "#800080")))
   "The face used for confluence problems."
   :group 'agda2-highlight-faces)
 
 (defface agda2-highlight-typechecks-face
-  '((t (:background "light blue"
-        :foreground "black")))
+  '((((background light))
+     (:background "light blue" :foreground "black"))
+    (((background dark))
+     (:background "#006080" :foreground "white")))
   "The face used for code which is being type-checked."
   :group 'agda2-highlight-faces)
 


### PR DESCRIPTION
For a while I wished there was a dark theme for Agda syntax in emacs, so now I decided to make one myself. It is activated automatically when you switch to a dark theme (using `M-x customize-theme`, I'm using `deeper-blue` for the screenshot). I tried to pick colors that are easy on the eyes and not too far from their counterparts in the light scheme. Any nitpicking on the choice of colors is welcome.

![Screenshot from 2019-06-10 21-15-25](https://user-images.githubusercontent.com/2910371/59220699-db905c00-8bc5-11e9-9661-eb95f1622441.png)

Note that some colors are defined by the theme rather than by Agda, e.g. the colors for comments and interactive holes.