### PR TITLE
[ fixed #3886 ] by adding origin to Quantity

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Attribute.hs
+++ b/src/full/Agda/Syntax/Concrete/Attribute.hs
@@ -15,6 +15,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Concrete.Name
 import Agda.Syntax.Concrete (Expr(..))
 import Agda.Syntax.Concrete.Pretty
+import Agda.Syntax.Position
 
 import Agda.Utils.Pretty (prettyShow)
 
@@ -27,6 +28,24 @@ data Attribute
   | QuantityAttribute  Quantity
   | TacticAttribute Expr
   deriving (Show)
+
+instance HasRange Attribute where
+  getRange = \case
+    RelevanceAttribute r -> getRange r
+    QuantityAttribute q  -> getRange q
+    TacticAttribute e    -> getRange e
+
+instance SetRange Attribute where
+  setRange r = \case
+    RelevanceAttribute a -> RelevanceAttribute $ setRange r a
+    QuantityAttribute q  -> QuantityAttribute  $ setRange r q
+    TacticAttribute e    -> TacticAttribute e  -- -- $ setRange r e -- SetRange Expr not yet implemented
+
+instance KillRange Attribute where
+  killRange = \case
+    RelevanceAttribute a -> RelevanceAttribute $ killRange a
+    QuantityAttribute q  -> QuantityAttribute  $ killRange q
+    TacticAttribute e    -> TacticAttribute    $ killRange e
 
 -- | (Conjunctive constraint.)
 
@@ -44,12 +63,21 @@ relevanceAttributeTable = concat
 -- | Modifiers for 'Quantity'.
 
 quantityAttributeTable :: [(String, Quantity)]
-quantityAttributeTable = concat
-  [ map (, Quantity0) [ "0", "erased" ] -- , "static", "compile-time" ]
-  , map (, Quantityω) [ "ω", "plenty" ] -- , "dynamic", "runtime", "unrestricted", "abundant" ]
-  -- , map (, Quantity1)  [ "1", "linear" ]
-  -- , map (, Quantity01) [ "01", "affine" ]
+quantityAttributeTable =
+  [ ("0"      , Quantity0 $ Q0       noRange)
+  , ("erased" , Quantity0 $ Q0Erased noRange)
+  -- TODO: linearity
+  -- , ("1"      , Quantity1 $ Q1       noRange)
+  -- , ("linear" , Quantity1 $ Q1Linear noRange)
+  , ("ω"      , Quantityω $ Qω       noRange)
+  , ("plenty" , Quantityω $ QωPlenty noRange)
   ]
+-- quantityAttributeTable = concat
+--   [ map (, Quantity0) [ "0", "erased" ] -- , "static", "compile-time" ]
+--   , map (, Quantityω) [ "ω", "plenty" ] -- , "dynamic", "runtime", "unrestricted", "abundant" ]
+--   -- , map (, Quantity1)  [ "1", "linear" ]
+--   -- , map (, Quantity01) [ "01", "affine" ]
+--   ]
 
 -- | Concrete syntax for all attributes.
 
@@ -68,7 +96,7 @@ stringToAttribute = (`Map.lookup` attributesMap)
 
 exprToAttribute :: Expr -> Maybe Attribute
 exprToAttribute (Paren _ (RawApp _ [Tactic _ t []])) = Just $ TacticAttribute t
-exprToAttribute e = stringToAttribute $ prettyShow e
+exprToAttribute e = setRange (getRange e) $ stringToAttribute $ prettyShow e
 
 -- | Setting an attribute (in e.g. an 'Arg').  Overwrites previous value.
 
@@ -101,7 +129,7 @@ setPristineRelevance r a
 
 setPristineQuantity :: (LensQuantity a) => Quantity -> a -> Maybe a
 setPristineQuantity q a
-  | getQuantity a == defaultQuantity = Just $ setQuantity q a
+  | noUserQuantity a = Just $ setQuantity q a
   | otherwise = Nothing
 
 -- | Setting an unset attribute (to e.g. an 'Arg').
@@ -143,4 +171,3 @@ quantityAttributes = filter $ isJust . isQuantityAttribute
 
 tacticAttributes :: [Attribute] -> [Attribute]
 tacticAttributes = filter $ isJust . isTacticAttribute
-

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -306,8 +306,7 @@ instance (HasRange a, HasRange b, HasRange c, HasRange d, HasRange e, HasRange f
     getRange (x,y,z,w,v,u,t) = getRange (x,(y,(z,(w,(v,(u,t))))))
 
 instance HasRange a => HasRange (Maybe a) where
-    getRange Nothing  = noRange
-    getRange (Just a) = getRange a
+    getRange = maybe noRange getRange
 
 instance (HasRange a, HasRange b) => HasRange (Either a b) where
     getRange = either getRange getRange
@@ -322,6 +321,9 @@ instance SetRange Range where
   setRange = const
 
 instance SetRange a => SetRange [a] where
+  setRange r = fmap $ setRange r
+
+instance SetRange a => SetRange (Maybe a) where
   setRange r = fmap $ setRange r
 
 -- | Killing the range of an object sets all range information to 'noRange'.

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1294,9 +1294,9 @@ instance Verbalize Relevance where
 
 instance Verbalize Quantity where
   verbalize = \case
-    Quantity0 -> "erased"
-    Quantity1 -> "linear"
-    Quantityω -> "unrestricted"
+    Quantity0{} -> "erased"
+    Quantity1{} -> "linear"
+    Quantityω{} -> "unrestricted"
 
 -- | Indefinite article.
 data Indefinite a = Indefinite a

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -120,8 +120,11 @@ computeForcingAnnotations c t =
       -- the type. Also the argument shouldn't be irrelevant, since in that
       -- case it isn't really forced.
       isForced :: Modality -> Nat -> Bool
-      isForced m i = getRelevance m /= Irrelevant &&
-                     any (\ (m', j) -> i == j && m' `moreUsableModality` m) xs
+      isForced m i = and
+        [ noUserQuantity m              -- User can disable forcing by giving quantity explicitly.
+        , getRelevance m /= Irrelevant
+        , any (\ (m', j) -> i == j && m' `moreUsableModality` m) xs
+        ]
       forcedArgs =
         [ if isForced m i then Forced else NotForced
         | (i, m) <- zip (downFrom n) $ map getModality (telToList tel)

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -216,8 +216,12 @@ data VarOcc' a = VarOcc
   { varFlexRig   :: FlexRig' a
   , varModality  :: Modality
   }
-  deriving (Eq, Show)
+  deriving (Show)
 type VarOcc = VarOcc' MetaSet
+
+-- | Equality up to origin.
+instance Eq a => Eq (VarOcc' a) where
+  VarOcc fr m == VarOcc fr' m' = fr == fr' && sameModality m m'
 
 instance LensModality (VarOcc' a) where
   getModality = varModality
@@ -256,13 +260,13 @@ instance Semigroup a => Semigroup (VarOcc' a) where
 --   This is also the absorptive element for 'composeVarOcc', if we ignore
 --   the 'MetaSet' in 'Flexible'.
 instance (Semigroup a, Monoid a) => Monoid (VarOcc' a) where
-  mempty  = VarOcc (Flexible mempty) $ Modality Irrelevant Quantity0
+  mempty  = VarOcc (Flexible mempty) $ Modality Irrelevant zeroQuantity
   mappend = (<>)
 
 -- | The absorptive element of variable occurrence under aggregation:
 --   strongly rigid, relevant.
 topVarOcc :: VarOcc' a
-topVarOcc = VarOcc StronglyRigid $ Modality Relevant Quantityω
+topVarOcc = VarOcc StronglyRigid $ Modality Relevant topQuantity
 
 -- | First argument is the outer occurrence (context) and second is the inner.
 --   This multiplicative operation is to modify an occurrence under a context.
@@ -271,7 +275,7 @@ composeVarOcc (VarOcc o m) (VarOcc o' m') = VarOcc (composeFlexRig o o') (m <> m
   -- We use the multipicative modality monoid (composition).
 
 oneVarOcc :: VarOcc' a
-oneVarOcc = VarOcc Unguarded $ Modality Relevant Quantity1
+oneVarOcc = VarOcc Unguarded $ Modality Relevant $ Quantity1 mempty
 
 ---------------------------------------------------------------------------
 -- * Storing variable occurrences (semimodule).

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -120,7 +120,7 @@ workOnTypes cont = do
 workOnTypes' :: (MonadTCEnv m) => Bool -> m a -> m a
 workOnTypes' experimental
   = modifyContext (map $ mapRelevance f)
-  . applyQuantityToContext Quantity0
+  . applyQuantityToContext zeroQuantity
   . typeLevelReductions
   . localTC (\ e -> e { envWorkingOnTypes = True })
   where
@@ -178,7 +178,7 @@ applyRelevanceToContextFunBody thing cont =
 applyQuantityToContext :: (MonadTCEnv tcm, LensQuantity q) => q -> tcm a -> tcm a
 applyQuantityToContext thing =
   case getQuantity thing of
-    Quantity1 -> id
+    Quantity1{} -> id
     q         -> applyQuantityToContextOnly   q
                . applyQuantityToJudgementOnly q
 
@@ -254,7 +254,7 @@ applyModalityToContextFunBody thing cont = do
 wakeIrrelevantVars :: (MonadTCEnv tcm) => tcm a -> tcm a
 wakeIrrelevantVars
   = applyRelevanceToContextOnly Irrelevant
-  . applyQuantityToContextOnly  Quantity0
+  . applyQuantityToContextOnly  zeroQuantity
 
 -- | Check whether something can be used in a position of the given relevance.
 --

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2570,7 +2570,7 @@ initEnv = TCEnv { envContext             = []
   -- The initial mode should be 'ConcreteMode', ensuring you
   -- can only look into abstract things in an abstract
   -- definition (which sets 'AbstractMode').
-                , envModality               = Modality Relevant Quantity1
+                , envModality               = Modality Relevant $ Quantity1 mempty
                 , envDisplayFormsEnabled    = True
                 , envRange                  = noRange
                 , envHighlightingRange      = noRange

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -253,15 +253,10 @@ instance PrettyTCM A.TypedBinding where
   prettyTCM = prettyA
 
 instance PrettyTCM Relevance where
-  prettyTCM Irrelevant = "."
-  prettyTCM NonStrict  = ".."
-  prettyTCM Relevant   = empty
+  prettyTCM = pretty
 
 instance PrettyTCM Quantity where
-  prettyTCM = \case
-    Quantity0 -> "@0"
-    Quantity1 -> "@1"
-    Quantityω -> empty
+  prettyTCM = pretty
 
 instance PrettyTCM Modality where
   prettyTCM mod = hsep

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -365,7 +365,7 @@ checkRelevance' x def = do
 checkQuantity' :: QName -> Definition -> TCM (Maybe TypeError)
 checkQuantity' x def = do
   case getQuantity def of
-    Quantityω -> return Nothing -- Abundant definitions can be used in any context.
+    Quantityω{} -> return Nothing -- Abundant definitions can be used in any context.
     dq -> do
       q <- asksTC getQuantity
       reportSDoc "tc.irr" 50 $ vcat

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -566,8 +566,8 @@ checkAxiom' gentel funSig i info0 mp x e = whenAbstractFreezeMetasAfter i $ do
   -- Andreas, 2019-06-17  also for erasure (issue #3855).
   rel <- max (getRelevance info0) <$> asksTC getRelevance
   q   <- asksTC getQuantity <&> \case
-    Quantity0 -> Quantity0
-    _         -> getQuantity info0
+    q@Quantity0{} -> q
+    _ -> getQuantity info0
   let mod  = Modality rel q
   let info = setModality mod info0
   (genParams, npars, t) <- workOnTypes $ case gentel of

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -882,7 +882,7 @@ unifyStep s Solution{ solutionAt   = k
   --
   -- Jesper, Andreas, 2018-10-17: the quantity of the equation is morally
   -- always @Quantity0@, since the indices of the data type are runtime erased.
-  -- This, we need not change the quantity of the solution.
+  -- Thus, we need not change the quantity of the solution.
   let eqrel  = getRelevance dom
       varmod = getModality dom'
       mod    = applyUnless (NonStrict `moreRelevant` eqrel) (setRelevance eqrel)

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -306,7 +306,7 @@ checkTypedBindings lamOrPi (A.TBind r tac xs' e) ret = do
         modEnv LamNotPi = workOnTypes
         modEnv _        = id
         modMod PiNotLam xp = (if xp then mapRelevance irrToNonStrict else id)
-                           . (setQuantity Quantityω)
+                           . (setQuantity topQuantity)
         modMod _        _  = id
 checkTypedBindings lamOrPi (A.TLet _ lbs) ret = do
     checkLetBindings lbs (ret EmptyTel)
@@ -474,14 +474,14 @@ lambdaIrrelevanceCheck dom info
 lambdaQuantityCheck :: LensQuantity dom => dom -> ArgInfo -> TCM ArgInfo
 lambdaQuantityCheck dom info
     -- Case: no specific user annotation: use quantity of function type
-  | getQuantity info == defaultQuantity = return $ setQuantity (getQuantity dom) info
+  | noUserQuantity info = return $ setQuantity (getQuantity dom) info
     -- Case: explicit user annotation is taken seriously
   | otherwise = do
       let qPi  = getQuantity dom  -- quantity of function type
       let qLam = getQuantity info -- quantity of lambda
-      unless (moreQuantity qPi qLam) $ do
-        -- the expected use qPi cannot be unrestricted
-        when (qPi == Quantityω) __IMPOSSIBLE__
+      unless (qPi `moreQuantity` qLam) $ do
+        -- the expected use qPi cannot be unrestricted then
+        when (hasQuantityω qPi) __IMPOSSIBLE__
         typeError WrongQuantityInLambda
       return info
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -60,7 +60,7 @@ import Agda.Utils.Except
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20190626 * 10 + 0
+currentInterfaceVersion = 20190704 * 10 + 0
 
 -- | Encodes something. To ensure relocatability file paths in
 -- positions are replaced with module names.

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -465,15 +465,64 @@ instance EmbPrj Hiding where
   value 3 = return (Instance YesOverlap)
   value _ = malformed
 
-instance EmbPrj Quantity where
-  icod_ Quantity0 = return 0
-  icod_ Quantity1 = return 1
-  icod_ Quantityω = return 2
+instance EmbPrj Q0Origin where
+  icod_ = \case
+    Q0Inferred -> return 0
+    Q0 _       -> return 1
+    Q0Erased _ -> return 2
 
-  value 0 = return Quantity0
-  value 1 = return Quantity1
-  value 2 = return Quantityω
-  value _ = malformed
+  value = \case
+    0 -> return $ Q0Inferred
+    1 -> return $ Q0       noRange
+    2 -> return $ Q0Erased noRange
+    _ -> malformed
+
+instance EmbPrj Q1Origin where
+  icod_ = \case
+    Q1Inferred -> return 0
+    Q1 _       -> return 1
+    Q1Linear _ -> return 2
+
+  value = \case
+    0 -> return $ Q1Inferred
+    1 -> return $ Q1       noRange
+    2 -> return $ Q1Linear noRange
+    _ -> malformed
+
+instance EmbPrj QωOrigin where
+  icod_ = \case
+    QωInferred -> return 0
+    Qω _       -> return 1
+    QωPlenty _ -> return 2
+
+  value = \case
+    0 -> return $ QωInferred
+    1 -> return $ Qω       noRange
+    2 -> return $ QωPlenty noRange
+    _ -> malformed
+
+instance EmbPrj Quantity where
+  icod_ = \case
+    Quantity0 a -> icodeN 0 Quantity0 a
+    Quantity1 a -> icodeN 1 Quantity1 a
+    Quantityω a -> icodeN'  Quantityω a  -- default quantity, shorter code
+
+  value = vcase $ \case
+    [0, a] -> valuN Quantity0 a
+    [1, a] -> valuN Quantity1 a
+    [a]    -> valuN Quantityω a
+    _      -> malformed
+
+-- -- ALT: forget quantity origin when serializing?
+-- instance EmbPrj Quantity where
+--   icod_ Quantity0 = return 0
+--   icod_ Quantity1 = return 1
+--   icod_ Quantityω = return 2
+
+--   value 0 = return Quantity0
+--   value 1 = return Quantity1
+--   value 2 = return Quantityω
+--   value _ = malformed
 
 instance EmbPrj Modality where
   icod_ (Modality a b) = icodeN' Modality a b

--- a/test/Compiler/simple/Issue3886.agda
+++ b/test/Compiler/simple/Issue3886.agda
@@ -1,0 +1,42 @@
+-- Andreas, 2019-07-04, issue #3886
+-- Override forcing with explicit quantity attributes.
+
+open import Common.Prelude
+
+pattern [_] x = x ∷ []
+
+module _ {a} {A : Set a} where
+
+  variable
+    x y z : A
+    @0 xs ys zs : List A
+
+  data FSet : List A → Set a where
+    ∅   : FSet []
+    _∪_ : FSet xs → FSet ys → FSet (xs ++ ys)
+    sg  : (@ω x : A) → FSet [ x ]
+    -- x is forced here, but this is not wanted.
+    -- With an explicit quantity attribute we tell the forcing machinery not to erase x.
+
+  -- Since xs is erased, we cannot get x from sg x : FSet xs (with xs = [ x ])
+  -- unless x is retained in sg x.
+  elements : {@0 xs : List A} → FSet xs → List A
+  elements ∅       = []
+  elements (s ∪ t) = elements s ++ elements t
+  elements (sg x)  = [ x ]
+
+-- ERROR WAS:
+-- Variable x is declared erased, so it cannot be used here
+-- when checking that the expression x has type A
+
+mySet = (sg 1 ∪ sg 2) ∪ (sg 3 ∪ sg 4)
+
+sum : List Nat → Nat
+sum [] = 0
+sum (n ∷ ns) = n + sum ns
+
+test = elements mySet
+
+main = printNat (sum (elements mySet))
+
+-- Should print 10.

--- a/test/Compiler/simple/Issue3886.out
+++ b/test/Compiler/simple/Issue3886.out
@@ -1,0 +1,4 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > 10

--- a/test/Fail/Erasure-Lambda-Wrong-Attribute.err
+++ b/test/Fail/Erasure-Lambda-Wrong-Attribute.err
@@ -1,3 +1,4 @@
-Erasure-Lambda-Wrong-Attribute.agda:7,34-35
-Variable y is declared erased, so it cannot be used here
-when checking that the expression y has type _B_7
+Erasure-Lambda-Wrong-Attribute.agda:7,23-35
+Incorrect quantity annotation in lambda
+when checking that the expression λ (@ω y) → y has type
+@0 _A_6 → _B_7

--- a/test/Fail/Issue1886-modality.err
+++ b/test/Fail/Issue1886-modality.err
@@ -1,3 +1,3 @@
 Issue1886-modality.agda:7,17-18
-Unexpected modality/relevance annotation in @0 A
+Unexpected modality/relevance annotation in (@erased A)
 when checking the definition of D

--- a/test/Fail/Issue3323q.err
+++ b/test/Fail/Issue3323q.err
@@ -1,3 +1,3 @@
 Issue3323q.agda:10,12-13
-Unexpected modality/relevance annotation in @0 b
+Unexpected modality/relevance annotation in (@0 b)
 when checking the definition of T

--- a/test/Internal/Syntax/Common.hs
+++ b/test/Internal/Syntax/Common.hs
@@ -5,6 +5,7 @@ module Internal.Syntax.Common ( tests ) where
 import Control.Applicative
 
 import Agda.Syntax.Common
+import Agda.Syntax.Position ( noRange )
 
 import Internal.Helpers
 
@@ -15,9 +16,44 @@ instance CoArbitrary Modality
 instance Arbitrary Modality where
   arbitrary = liftA2 Modality arbitrary arbitrary
 
+instance CoArbitrary Q0Origin where
+  coarbitrary = \case
+    Q0Inferred -> variant 0
+    Q0{}       -> variant 1
+    Q0Erased{} -> variant 2
+
+instance CoArbitrary Q1Origin where
+  coarbitrary = \case
+    Q1Inferred -> variant 0
+    Q1{}       -> variant 1
+    Q1Linear{} -> variant 2
+
+instance CoArbitrary QωOrigin where
+  coarbitrary = \case
+    QωInferred -> variant 0
+    Qω{}       -> variant 1
+    QωPlenty{} -> variant 2
+
+instance Arbitrary Q0Origin where
+  arbitrary = elements [ Q0Inferred, Q0 noRange, Q0Erased noRange ]
+
+instance Arbitrary Q1Origin where
+  arbitrary = elements [ Q1Inferred, Q1 noRange, Q1Linear noRange ]
+
+instance Arbitrary QωOrigin where
+  arbitrary = elements [ QωInferred, Qω noRange, QωPlenty noRange ]
+
 instance CoArbitrary Quantity
 instance Arbitrary Quantity where
-  arbitrary = elements [minBound..maxBound]
+  arbitrary = elements [ Quantity0 mempty, Quantity1 mempty, Quantityω mempty ]
+  -- Andreas, 2019-07-04, TODO:
+  -- The monoid laws hold only modulo origin information.
+  -- Thus, we generate here only origin-free quantities.
+  -- arbitrary = oneof
+  --   [ Quantity0 <$> arbitrary
+  --   , Quantity1 <$> arbitrary
+  --   , Quantityω <$> arbitrary
+  --   ]
 
 instance CoArbitrary Relevance
 instance Arbitrary Relevance where

--- a/test/interaction/UnderappliedConstructor.out
+++ b/test/interaction/UnderappliedConstructor.out
@@ -2,14 +2,14 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 conApp: constructor UnderappliedConstructor.R.conR with fields
-Arg {argInfo = ArgInfo {argInfoHiding = NotHidden, argInfoModality = Modality {modRelevance = Relevant, modQuantity = Quantityω}, argInfoOrigin = UserWritten, argInfoFreeVariables = UnknownFVs}, unArg = UnderappliedConstructor.R.A}
-Arg {argInfo = ArgInfo {argInfoHiding = NotHidden, argInfoModality = Modality {modRelevance = Relevant, modQuantity = Quantityω}, argInfoOrigin = UserWritten, argInfoFreeVariables = UnknownFVs}, unArg = UnderappliedConstructor.R.B}
+Arg {argInfo = ArgInfo {argInfoHiding = NotHidden, argInfoModality = Modality {modRelevance = Relevant, modQuantity = Quantityω QωInferred}, argInfoOrigin = UserWritten, argInfoFreeVariables = UnknownFVs}, unArg = UnderappliedConstructor.R.A}
+Arg {argInfo = ArgInfo {argInfoHiding = NotHidden, argInfoModality = Modality {modRelevance = Relevant, modQuantity = Quantityω QωInferred}, argInfoOrigin = UserWritten, argInfoFreeVariables = UnknownFVs}, unArg = UnderappliedConstructor.R.B}
 and args
 Agda.Builtin.Bool.Bool
 projected by UnderappliedConstructor.R.B
 conApp: constructor UnderappliedConstructor.R.conR with fields
-Arg {argInfo = ArgInfo {argInfoHiding = NotHidden, argInfoModality = Modality {modRelevance = Relevant, modQuantity = Quantityω}, argInfoOrigin = UserWritten, argInfoFreeVariables = UnknownFVs}, unArg = UnderappliedConstructor.R.A}
-Arg {argInfo = ArgInfo {argInfoHiding = NotHidden, argInfoModality = Modality {modRelevance = Relevant, modQuantity = Quantityω}, argInfoOrigin = UserWritten, argInfoFreeVariables = UnknownFVs}, unArg = UnderappliedConstructor.R.B}
+Arg {argInfo = ArgInfo {argInfoHiding = NotHidden, argInfoModality = Modality {modRelevance = Relevant, modQuantity = Quantityω QωInferred}, argInfoOrigin = UserWritten, argInfoFreeVariables = UnknownFVs}, unArg = UnderappliedConstructor.R.A}
+Arg {argInfo = ArgInfo {argInfoHiding = NotHidden, argInfoModality = Modality {modRelevance = Relevant, modQuantity = Quantityω QωInferred}, argInfoOrigin = UserWritten, argInfoFreeVariables = UnknownFVs}, unArg = UnderappliedConstructor.R.B}
 and args
 Agda.Builtin.Bool.Bool
 projected by UnderappliedConstructor.R.B


### PR DESCRIPTION
The user can override the forcing analysis by giving explicit quantities.
PR for travis ci only, don't merge!
Comments welcome nevertheless.