### PR TITLE
[ fix ]  `make install-bin` with stack.yaml compiles Agda only once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,26 +84,18 @@ quick-install-bin : ensure-hash-is-correct
 quicker-install-bin : ensure-hash-is-correct
 	$(QUICK_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --ghc-options=-O0
 
-# Install Agda using Stack
-.PHONY : stack-install-bin
-stack-install-bin :
-	stack build Agda:exe:agda \
-		--flag Agda:enable-cluster-counting \
-		--no-haddock \
-		--no-library-profiling
-
 # The Stack version of `Cabal install --enable-test`
-.PHONY : stack-install-test
-stack-install-test :
-	stack build Agda:test:agda-tests \
-		--no-run-tests \
+.PHONY : stack-install-bin
+stack-install-bin:
+	stack build Agda \
+		--test \
 		--flag Agda:enable-cluster-counting \
 		--no-haddock \
 		--no-library-profiling
 
 # Copy the artefacts built by Stack as if they were build by Cabal.
 .PHONY : stack-copy-artefacts
-stack-copy-artefacts : stack-install-bin stack-install-test
+stack-copy-artefacts : stack-install-bin
 	mkdir -p $(BUILD_DIR)/build/
 	cp -r $(shell stack path --dist-dir)/build $(BUILD_DIR)
 
@@ -111,11 +103,10 @@ stack-copy-artefacts : stack-install-bin stack-install-test
 
 install-bin : ensure-hash-is-correct
 ifneq ("$(wildcard stack.yaml)","") # if `stack.yaml` exists
-	@echo ""===================== Installing using Stack =============================""
-	$(MAKE) stack-install-bin
-	$(MAKE) stack-install-test
-	$(MAKE) stack-copy-artefacts
+	@echo "===================== Installing using Stack ============================="
+	time $(MAKE) stack-copy-artefacts
 else
+	@echo "===================== Installing using Cabal ============================="
 	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS)
 endif
 


### PR DESCRIPTION
**Problem.** The target `install-bin` with `stack.yaml` present often (or always?) builds Agda 4 times:

1. once by `stack-install-bin`
2. once by `stack-install-test`
3. twice by `stack-copy-artefacts`

I am not sure why `stack` rebuilds Agda even when the target is the component `Agda:test:agda-tests` and the component `Agda:exe:agda` has been built. 

**Solution.** Just build the test suite altogether. 