### PR TITLE
Keep covering clauses of function definitions

### DIFF
--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -228,6 +228,9 @@ data PragmaOptions = PragmaOptions
   , optShowIdentitySubstitutions :: Bool
     -- ^ Show identity substitutions when pretty-printing terms
     --   (i.e. always show all arguments of a metavariable)
+  , optKeepCoveringClauses       :: Bool
+    -- ^ Do not discard clauses constructed by the coverage checker
+    --   (needed for some external backends)
   }
   deriving (Show, Eq, Generic)
 
@@ -344,6 +347,7 @@ defaultPragmaOptions = PragmaOptions
   , optSaveMetas                 = Default
   , optShowIdentitySubstitutions = False
   , optLoadPrimitives            = True
+  , optKeepCoveringClauses       = False
   }
 
 type OptM = Except String
@@ -885,6 +889,10 @@ integerArgument flag s = maybe usage return $ readMaybe s
   where
   usage = throwError $ "option '" ++ flag ++ "' requires an integer argument"
 
+keepCoveringClausesFlag :: Flag PragmaOptions
+keepCoveringClausesFlag o = return $ o { optKeepCoveringClauses = True }
+
+
 standardOptions :: [OptDescr (Flag CommandLineOptions)]
 standardOptions =
     [ Option ['V']  ["version"] (NoArg versionFlag)
@@ -1120,6 +1128,8 @@ pragmaOptions =
                     "save meta-variables"
     , Option []     ["no-save-metas"] (NoArg $ saveMetas False)
                     "do not save meta-variables (the default)"
+    , Option []     ["keep-covering-clauses"] (NoArg keepCoveringClausesFlag)
+                    "do not discard covering clauses (required for some external backends)"
     ]
 
 -- | Pragma options of previous versions of Agda.

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -157,8 +157,8 @@ coverageCheck f t cs = do
   -- Storing the covering clauses so that checkIApplyConfluence_ can
   -- find them later.
   -- Andreas, 2019-03-27, only needed when --cubical
-  whenM (isJust . optCubical <$> pragmaOptions) $ do
-    modifySignature $ updateDefinition f $ updateTheDef $ updateCovering $ const qss
+  -- Jesper, 2019-07-11, also useful for backends, so keep anyways
+  modifySignature $ updateDefinition f $ updateTheDef $ updateCovering $ const qss
 
 
   -- filter out the missing clauses that are absurd.

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -157,8 +157,10 @@ coverageCheck f t cs = do
   -- Storing the covering clauses so that checkIApplyConfluence_ can
   -- find them later.
   -- Andreas, 2019-03-27, only needed when --cubical
-  -- Jesper, 2019-07-11, also useful for backends, so keep anyways
-  modifySignature $ updateDefinition f $ updateTheDef $ updateCovering $ const qss
+  -- Jesper, 2022-10-18, also needed for some backends, so keep when flag says so
+  opts <- pragmaOptions
+  when (isJust (optCubical opts) || optKeepCoveringClauses opts) $
+    modifySignature $ updateDefinition f $ updateTheDef $ updateCovering $ const qss
 
 
   -- filter out the missing clauses that are absurd.

--- a/src/full/Agda/TypeChecking/IApplyConfluence.hs
+++ b/src/full/Agda/TypeChecking/IApplyConfluence.hs
@@ -55,8 +55,6 @@ checkIApplyConfluence_ f = whenM (isJust . optCubical <$> pragmaOptions) $ do
       reportSDoc "tc.cover.iapply" 10 $ text "length cls =" <+> pretty (length cls)
       when (null cls && any (not . null . iApplyVars . namedClausePats) cls') $
         __IMPOSSIBLE__
-      modifySignature $ updateDefinition f $ updateTheDef
-        $ updateCovering (const [])
 
       traceCall (CheckFunDefCall (getRange f) f [] False) $
         forM_ cls $ checkIApplyConfluence f

--- a/src/full/Agda/TypeChecking/IApplyConfluence.hs
+++ b/src/full/Agda/TypeChecking/IApplyConfluence.hs
@@ -55,6 +55,9 @@ checkIApplyConfluence_ f = whenM (isJust . optCubical <$> pragmaOptions) $ do
       reportSDoc "tc.cover.iapply" 10 $ text "length cls =" <+> pretty (length cls)
       when (null cls && any (not . null . iApplyVars . namedClausePats) cls') $
         __IMPOSSIBLE__
+      unlessM (optKeepCoveringClauses <$> pragmaOptions) $
+        modifySignature $ updateDefinition f $ updateTheDef
+          $ updateCovering (const [])
 
       traceCall (CheckFunDefCall (getRange f) f [] False) $
         forM_ cls $ checkIApplyConfluence f

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -272,12 +272,12 @@ instance EmbPrj Doc where
 
 instance EmbPrj PragmaOptions where
   icod_ = \case
-    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ->
-      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff
+    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg ->
+      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg
 
   value = vcase $ \case
-    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx, yy, zz, aaa, bbb, ccc, ddd, eee, fff] ->
-      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff
+    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx, yy, zz, aaa, bbb, ccc, ddd, eee, fff, ggg] ->
+      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg
     _ -> malformed
 
 instance EmbPrj ProfileOptions where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -369,9 +369,7 @@ instance EmbPrj EtaEquality where
 
 instance EmbPrj Defn where
   icod_ (Axiom       a)                                 = icodeN 0 Axiom a
-  icod_ (Function    a b s t (_:_) c d e f g h i j k)   = __IMPOSSIBLE__
-  icod_ (Function    a b s t []    c d e f g h i j k)   =
-    icodeN 1 (\ a b s -> Function a b s t []) a b s c d e f g h i j k
+  icod_ (Function    a b s t u c d e f g h i j k)       = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k
   icod_ (Datatype    a b c d e f g h i j)               = icodeN 2 Datatype a b c d e f g h i j
   icod_ (Record      a b c d e f g h i j k l m)         = icodeN 3 Record a b c d e f g h i j k l m
   icod_ (Constructor a b c d e f g h i j)               = icodeN 4 Constructor a b c d e f g h i j
@@ -383,7 +381,7 @@ instance EmbPrj Defn where
 
   value = vcase valu where
     valu [0, a]                                     = valuN Axiom a
-    valu [1, a, b, s, c, d, e, f, g, h, i, j, k]    = valuN (\ a b s -> Function a b s Nothing []) a b s c d e f g h i j k
+    valu [1, a, b, s, u, c, d, e, f, g, h, i, j, k] = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k
     valu [2, a, b, c, d, e, f, g, h, i, j]          = valuN Datatype a b c d e f g h i j
     valu [3, a, b, c, d, e, f, g, h, i, j, k, l, m] = valuN Record   a b c d e f g h i j k l m
     valu [4, a, b, c, d, e, f, g, h, i, j]          = valuN Constructor a b c d e f g h i j


### PR DESCRIPTION
Currently, we only keep the covering clauses for checking IApply confluence, but they would also be useful to keep for use by backends (e.g. the Dedukti backend that @GuillaumeGen is working on). This PR changes Agda so it keeps the covering clauses and stores them in the interface for later use.

Can be merged after Travis succeeds.