### PR TITLE
Allow function spaces {{A}} -> B and {A} -> B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@ Language
 
 ### Syntax
 
+* Implicit non-dependent function spaces `{A} → B` and `{{A}} → B` are now supported.
+
 * Idiom brackets
 
   Idiom brackets can accommodate none or multiple applications separated by a vertical bar `|`

--- a/doc/user-manual/language/implicit-arguments.lagda.rst
+++ b/doc/user-manual/language/implicit-arguments.lagda.rst
@@ -4,6 +4,8 @@
   module language.implicit-arguments (A B : Set) (C : A → Set) where
 
   open import Agda.Builtin.Equality
+  open import Agda.Builtin.Unit using (⊤)
+  open import Agda.Builtin.Nat using (Nat; zero; suc)
 
   _is-the-same-as_ = _≡_
 
@@ -60,7 +62,7 @@ Another example:
 Note how the first argument to ``_==_`` is left implicit.
 Similarly, we may leave out the implicit arguments ``A``, ``x``, and ``y`` in an
 application of ``subst``.
-To give an implicit argument explicitly, enclose in curly braces.
+To give an implicit argument explicitly, enclose it in curly braces.
 The following two expressions are equivalent:
 
 ..
@@ -196,6 +198,31 @@ The ``∀`` (or ``forall``) syntax for function types also has implicit variants
   ① = refl
   ② = refl
   ③ = refl
+
+
+In very special situations it makes sense to declare *unnamed* hidden arguments
+``{A} → B``.  In the following ``example``, the hidden argument to ``scons`` of type
+``zero ≤ zero`` can be solved by η-expansion, since this type reduces to ``⊤``.
+
+..
+  ::
+  module UnnamedImplicit where
+
+::
+
+    data ⊥ : Set where
+
+    _≤_ : Nat → Nat → Set
+    zero ≤ _      = ⊤
+    suc m ≤ zero  = ⊥
+    suc m ≤ suc n = m ≤ n
+
+    data SList (bound : Nat) : Set where
+      []    : SList bound
+      scons : (head : Nat) → {head ≤ bound} → (tail : SList head) → SList bound
+
+    example : SList zero
+    example = scons zero []
 
 There are no restrictions on when a function space can be implicit.
 Internally, explicit and implicit function spaces are treated in the same way.

--- a/doc/user-manual/language/instance-arguments.lagda.rst
+++ b/doc/user-manual/language/instance-arguments.lagda.rst
@@ -99,14 +99,11 @@ given explicitly. The above definition is equivalent to
 A very useful function that exploits this is the function ``it`` which lets you
 apply instance resolution to solve an arbitrary goal::
 
-  it : ∀ {a} {A : Set a} {{_ : A}} → A
+  it : ∀ {a} {A : Set a} → {{A}} → A
   it {{x}} = x
 
-Note that instance arguments in types are always named, but the name can be ``_``:
-
-.. code-block:: agda
-
-  _==_ : {A : Set} → {{Eq A}} → A → A → Bool    -- INVALID
+As the last example shows, the name of the instance argument can be
+omitted in the type signature:
 
 ..
   ::
@@ -114,7 +111,7 @@ Note that instance arguments in types are always named, but the name can be ``_`
 
 ::
 
-     _==_ : {A : Set} {{_ : Eq A}} → A → A → Bool  -- VALID
+     _==_ : {A : Set} → {{Eq A}} → A → A → Bool
 
 ..
   ::
@@ -170,8 +167,8 @@ This will bring into scope
 
 ::
 
-    mempty : ∀ {a} {A : Set a} {{_ : Monoid A}} → A
-    _<>_   : ∀ {a} {A : Set a} {{_ : Monoid A}} → A → A → A
+    mempty : ∀ {a} {A : Set a} → {{Monoid A}} → A
+    _<>_   : ∀ {a} {A : Set a} → {{Monoid A}} → A → A → A
 
 ..
   ::
@@ -190,7 +187,7 @@ the module application is desugared. If defined by hand, ``mempty`` would be
 ::
 
 
-    mempty : ∀ {a} {A : Set a} {{_ : Monoid A}} → A
+    mempty : ∀ {a} {A : Set a} → {{Monoid A}} → A
     mempty {{mon}} = Monoid.mempty mon
 
 Although record types are a natural fit for Haskell-style type
@@ -239,7 +236,7 @@ cannot be declared for types in the context.
 You can define local instances in let-expressions in the same way as a
 top-level instance. For example::
 
-  mconcat : ∀ {a} {A : Set a} {{_ : Monoid A}} → List A → A
+  mconcat : ∀ {a} {A : Set a} → {{Monoid A}} → List A → A
   mconcat [] = mempty
   mconcat (x ∷ xs) = x <> mconcat xs
 
@@ -266,7 +263,7 @@ recursively during instance resolution. For instance,
     open Eq {{...}} public
 
     instance
-      eqList : ∀ {a} {A : Set a} {{_ : Eq A}} → Eq (List A)
+      eqList : ∀ {a} {A : Set a} → {{Eq A}} → Eq (List A)
       _==_ {{eqList}} []       []       = true
       _==_ {{eqList}} (x ∷ xs) (y ∷ ys) = x == y && xs == ys
       _==_ {{eqList}} _        _        = false
@@ -287,7 +284,7 @@ and return the solution ``eqList {{eqNat}}``.
 .. note::
    At the moment there is no termination check on instances, so it is possible
    to construct non-sensical instances like
-   ``loop : ∀ {a} {A : Set a} {{_ : Eq A}} → Eq A``.
+   ``loop : ∀ {a} {A : Set a} → {{Eq A}} → Eq A``.
    To prevent looping in cases like this, the search depth of instance search
    is limited, and once the maximum depth is reached, a type error will be
    thrown. You can set the maximum depth using the ``--instance-search-depth``
@@ -370,7 +367,7 @@ natural number and gives back a ``Fin n`` (the type of naturals smaller than
     zero : ∀ {n} → Fin (suc n)
     suc  : ∀ {n} → Fin n → Fin (suc n)
 
-  mkFin : ∀ {n} (m : Nat) {{_ : suc m - n ≡ 0}} → Fin n
+  mkFin : ∀ {n} (m : Nat) → {{suc m - n ≡ 0}} → Fin n
   mkFin {zero}  m {{}}
   mkFin {suc n} zero    = zero
   mkFin {suc n} (suc m) = suc (mkFin m)
@@ -410,7 +407,7 @@ goal when given appropriate arguments, hence instance search fails.
   data _∈_ {A : Set} (x : A) : List A → Set where
     instance
       zero : ∀ {xs} → x ∈ x ∷ xs
-      suc  : ∀ {y xs} {{_ : x ∈ xs}} → x ∈ y ∷ xs
+      suc  : ∀ {y xs} → {{x ∈ xs}} → x ∈ y ∷ xs
 
   ex₁ : 1 ∈ 1 ∷ 2 ∷ 3 ∷ 4 ∷ []
   ex₁ = it  -- overlapping instances
@@ -466,7 +463,7 @@ are equal, and comparing ``y`` and ``y₁`` makes sense.
 An ``Eq`` instance for ``Σ`` can be defined as follows::
 
     instance
-      eqΣ : ∀ {a b} {A : Set a} {B : A → Set b} {{_ : Eq A}} {{_ : ∀ {x} → Eq (B x)}} → Eq (Σ A B)
+      eqΣ : ∀ {a b} {A : Set a} {B : A → Set b} → {{Eq A}} → {{∀ {x} → Eq (B x)}} → Eq (Σ A B)
       _==_ {{eqΣ}} (x , y) (x₁ , y₁) with x == x₁
       _==_ {{eqΣ}} (x , y) (x₁ , y₁)    | nothing = nothing
       _==_ {{eqΣ}} (x , y) (.x , y₁)    | just refl with y == y₁

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -632,9 +632,9 @@ Expr :: { Expr }
 Expr
   : TeleArrow Expr                      { Pi $1 $2 }
   | Application3 '->' Expr              { Fun (getRange ($1,$2,$3))
-                                              (defaultArg $ RawApp (getRange $1) $1)
+                                              (defaultArg $ rawAppUnlessSingleton (getRange $1) $1)
                                               $3 }
-  | Attributes1 Application3 '->' Expr  {% applyAttrs $1 (defaultArg $ RawApp (getRange ($1,$2)) $2) <&> \ dom ->
+  | Attributes1 Application3 '->' Expr  {% applyAttrs $1 (defaultArg $ rawAppUnlessSingleton (getRange ($1,$2)) $2) <&> \ dom ->
                                              Fun (getRange ($1,$2,$3,$4)) dom $4 }
   | Expr1 '=' Expr                      { Equal (getRange ($1, $2, $3)) $1 $3 }
   | Expr1 %prec LOWEST                  { $1 }
@@ -1977,6 +1977,15 @@ isName s (_,s')
 -- | Build a forall pi (forall x y z -> ...)
 forallPi :: [LamBinding] -> Expr -> Expr
 forallPi bs e = Pi (map addType bs) e
+
+-- | Builds a 'RawApp' from 'Range' and 'Expr' list, unless the list
+-- is a single expression.  In the latter case, just the 'Expr' is
+-- returned.
+rawAppUnlessSingleton :: Range -> [Expr] -> Expr
+rawAppUnlessSingleton r = \case
+  []  -> __IMPOSSIBLE__
+  [e] -> e
+  es  -> RawApp r es
 
 -- | Converts lambda bindings to typed bindings.
 addType :: LamBinding -> TypedBinding

--- a/test/Succeed/Issue3901.agda
+++ b/test/Succeed/Issue3901.agda
@@ -1,0 +1,33 @@
+-- Andreas, 2019-07-15, issue #3901, requested by msuperdock
+--
+-- Allow function spaces  {A} → B  and  {{A}} → B.
+
+postulate
+  A B : Set
+  foo : {{A}} → B
+  bar : {A} → B
+
+-- Original feature request:
+
+open import Agda.Builtin.Unit using (⊤; tt)
+
+data ⊥ : Set where
+
+data Nat : Set where
+  zero : Nat
+  suc  : Nat → Nat
+
+_≤_ : Nat → Nat → Set
+zero ≤ _      = ⊤
+suc m ≤ zero  = ⊥
+suc m ≤ suc n = m ≤ n
+
+data SList (bound : Nat) : Set where
+  []    : SList bound
+  scons : (head : Nat)
+        → {head ≤ bound}       -- here: anonymous binding
+        → (tail : SList head)
+        → SList bound
+
+xs : SList zero
+xs = scons zero []


### PR DESCRIPTION
This implements feature request #3901.
It turned out that the grammar already supported these function spaces, the fixes to Parser.y are minimal.