### PR TITLE
[ refactor / cabal ] Remove DataKind from Agda.cabal

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -614,7 +614,7 @@ library
   default-language: Haskell2010
 
   default-extensions: ConstraintKinds
-                    , DataKinds
+--                    , DataKinds
                     , DefaultSignatures
                     , DeriveFoldable
                     , DeriveFunctor

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP       #-}
+{-# LANGUAGE DataKinds #-}
 
 module Agda.Interaction.Options
     ( CommandLineOptions(..)

--- a/src/full/Agda/Syntax/Concrete/Operators/Parser.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators/Parser.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs        #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds    #-}
 
 module Agda.Syntax.Concrete.Operators.Parser where
 

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Agda.TypeChecking.Serialise.Base where

--- a/src/full/Agda/Utils/IndexedList.hs
+++ b/src/full/Agda/Utils/IndexedList.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
 
 module Agda.Utils.IndexedList where
 

--- a/src/full/Agda/Utils/TypeLevel.hs
+++ b/src/full/Agda/Utils/TypeLevel.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs                #-}
+{-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}

--- a/src/full/Agda/Utils/TypeLits.hs
+++ b/src/full/Agda/Utils/TypeLits.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds      #-}
 {-# LANGUAGE GADTs          #-}
 
 

--- a/src/full/Agda/Utils/WithDefault.hs
+++ b/src/full/Agda/Utils/WithDefault.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds      #-}
 
 -- | Potentially uninitialised Booleans
 


### PR DESCRIPTION
Only enabling DataKind locally makes compile time slightly shorter on my machine, so try it with Travis CI. 