### PR TITLE
[ refactor ] Remove unused top-level bindings

### DIFF
--- a/src/full/Agda/Compiler/Treeless/Pretty.hs
+++ b/src/full/Agda/Compiler/Treeless/Pretty.hs
@@ -22,8 +22,9 @@ data PEnv = PEnv { pPrec :: Int
 
 type P = Reader PEnv
 
-withName :: (String -> P a) -> P a
-withName k = withNames 1 $ \[x] -> k x
+--UNUSED Liang-Ting Chen 2019-07-16
+--withName :: (String -> P a) -> P a
+--withName k = withNames 1 $ \[x] -> k x
 
 withNames :: Int -> ([String] -> P a) -> P a
 withNames n k = do

--- a/src/full/Agda/Interaction/Highlighting/LaTeX.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX.hs
@@ -317,10 +317,8 @@ output item = do
 -- Polytable, http://www.ctan.org/pkg/polytable, is used for code
 -- alignment, similar to lhs2TeX's approach.
 
-nl, beginCode, endCode :: Text
-nl        = "%\n"
-beginCode = "\\begin{code}"
-endCode   = "\\end{code}"
+nl :: Text
+nl = "%\n"
 
 -- | A command that is used when two tokens are put next to each other
 -- in the same column.

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -135,8 +135,9 @@ type LibM = ExceptT Doc (WriterT [LibWarning] IO)
 warnings :: MonadWriter [Either LibError LibWarning] m => [LibWarning] -> m ()
 warnings = tell . map Right
 
-warning :: MonadWriter [Either LibError LibWarning] m => LibWarning -> m ()
-warning = warnings . pure
+-- UNUSED Liang-Ting Chen 2019-07-16
+--warning :: MonadWriter [Either LibError LibWarning] m => LibWarning -> m ()
+--warning = warnings . pure
 
 raiseErrors' :: MonadWriter [Either LibError LibWarning] m => [LibError'] -> m ()
 raiseErrors' = tell . map (Left . (LibError Nothing))

--- a/src/full/Agda/Interaction/Library/Parse.hs
+++ b/src/full/Agda/Interaction/Library/Parse.hs
@@ -65,7 +65,7 @@ type GenericFile = [GenericEntry]
 
 data GenericEntry = GenericEntry
   { geHeader  :: String   -- ^ E.g. field name.    @trim@med.
-  , geContent :: [String] -- ^ E.g. field content. @trim@med.
+  , _geContent :: [String] -- ^ E.g. field content. @trim@med.
   }
 
 -- | Library file field format format [sic!].

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -577,8 +577,9 @@ dontUniverseCheckFlag o = return $ o { optUniverseCheck = False }
 omegaInOmegaFlag :: Flag PragmaOptions
 omegaInOmegaFlag o = return $ o { optOmegaInOmega = True }
 
-etaFlag :: Flag PragmaOptions
-etaFlag o = return $ o { optEta = True }
+--UNUSED Liang-Ting Chen 2019-07-16
+--etaFlag :: Flag PragmaOptions
+--etaFlag o = return $ o { optEta = True }
 
 noEtaFlag :: Flag PragmaOptions
 noEtaFlag o = return $ o { optEta = False }
@@ -611,8 +612,9 @@ noUniversePolymorphismFlag  o = return $ o { optUniversePolymorphism = False }
 noForcingFlag :: Flag PragmaOptions
 noForcingFlag o = return $ o { optForcing = False }
 
-noProjectionLikeFlag :: Flag PragmaOptions
-noProjectionLikeFlag o = return $ o { optProjectionLike = False }
+--UNUSED Liang-Ting Chen 2019-07-16
+--noProjectionLikeFlag :: Flag PragmaOptions
+--noProjectionLikeFlag o = return $ o { optProjectionLike = False }
 
 withKFlag :: Flag PragmaOptions
 withKFlag o = return $ o { optWithoutK = Value False }

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -106,14 +106,15 @@ nameFieldA f r = f (_nameFieldA r) <&> \x -> r { _nameFieldA = x }
 exprFieldA :: Lens' a (FieldAssignment' a)
 exprFieldA f r = f (_exprFieldA r) <&> \x -> r { _exprFieldA = x }
 
-qnameModA :: Lens' QName ModuleAssignment
-qnameModA f r = f (_qnameModA r) <&> \x -> r { _qnameModA = x }
-
-exprModA :: Lens' [Expr] ModuleAssignment
-exprModA f r = f (_exprModA r) <&> \x -> r { _exprModA = x }
-
-importDirModA :: Lens' ImportDirective ModuleAssignment
-importDirModA f r = f (_importDirModA r) <&> \x -> r { _importDirModA = x }
+-- UNUSED Liang-Ting Chen 2019-07-16
+--qnameModA :: Lens' QName ModuleAssignment
+--qnameModA f r = f (_qnameModA r) <&> \x -> r { _qnameModA = x }
+--
+--exprModA :: Lens' [Expr] ModuleAssignment
+--exprModA f r = f (_exprModA r) <&> \x -> r { _exprModA = x }
+--
+--importDirModA :: Lens' ImportDirective ModuleAssignment
+--importDirModA f r = f (_importDirModA r) <&> \x -> r { _importDirModA = x }
 
 -- | Concrete expressions. Should represent exactly what the user wrote.
 data Expr

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -458,13 +458,13 @@ data InMutual
 
 data DataRecOrFun
   = DataName
-    { kindPosCheck :: PositivityCheck
-    , kindUniCheck :: UniverseCheck
+    { _kindPosCheck :: PositivityCheck
+    , _kindUniCheck :: UniverseCheck
     }
     -- ^ Name of a data type
   | RecName
-    { kindPosCheck :: PositivityCheck
-    , kindUniCheck :: UniverseCheck
+    { _kindPosCheck :: PositivityCheck
+    , _kindUniCheck :: UniverseCheck
     }
     -- ^ Name of a record type
   | FunName TerminationCheck

--- a/src/full/Agda/Syntax/Concrete/Fixity.hs
+++ b/src/full/Agda/Syntax/Concrete/Fixity.hs
@@ -176,7 +176,7 @@ fixitiesAndPolarities' = foldMap $ \ d -> case d of
   UnquoteDef  {}  -> mempty
   Pragma      {}  -> mempty
 
-data DeclaredNames = DeclaredNames { allNames, postulates, privateNames :: Set Name }
+data DeclaredNames = DeclaredNames { _allNames, _postulates, _privateNames :: Set Name }
 
 instance Semigroup DeclaredNames where
   DeclaredNames xs ps as <> DeclaredNames ys qs bs =

--- a/src/full/Agda/Syntax/Parser/LookAhead.hs
+++ b/src/full/Agda/Syntax/Parser/LookAhead.hs
@@ -33,7 +33,7 @@ import Agda.Syntax.Parser.Monad
     'AlexInput', wrapped around the 'Parser' monad.
 -}
 newtype LookAhead a =
-    LookAhead { unLookAhead :: ReaderT ErrorFunction
+    LookAhead { _unLookAhead :: ReaderT ErrorFunction
                                        (StateT AlexInput Parser) a
               }
     deriving (Functor, Applicative, Monad)

--- a/src/full/Agda/Syntax/Parser/Monad.hs
+++ b/src/full/Agda/Syntax/Parser/Monad.hs
@@ -56,7 +56,7 @@ import Agda.Utils.Impossible
  --------------------------------------------------------------------------}
 
 -- | The parse monad.
-newtype Parser a = P { runP :: StateT ParseState (Either ParseError) a }
+newtype Parser a = P { _runP :: StateT ParseState (Either ParseError) a }
   deriving (Functor, Applicative, Monad, MonadState ParseState, MonadError ParseError)
 
 -- | The parser state. Contains everything the parser and the lexer could ever
@@ -288,8 +288,9 @@ getParseInterval = do
 getLexState :: Parser [LexState]
 getLexState = parseLexState <$> get
 
-setLexState :: [LexState] -> Parser ()
-setLexState ls = modify $ \ s -> s { parseLexState = ls }
+-- UNUSED Liang-Ting Chen 2019-07-16
+--setLexState :: [LexState] -> Parser ()
+--setLexState ls = modify $ \ s -> s { parseLexState = ls }
 
 modifyLexState :: ([LexState] -> [LexState]) -> Parser ()
 modifyLexState f = modify $ \ s -> s { parseLexState = f (parseLexState s) }

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -117,9 +117,9 @@ notAValidLetBinding d = typeError $ NotAValidLetBinding d
 {--------------------------------------------------------------------------
     Helpers
  --------------------------------------------------------------------------}
-
-annotateDecl :: ScopeM A.Declaration -> ScopeM A.Declaration
-annotateDecl m = annotateDecls $ (:[]) <$> m
+--UNUSED Liang-Ting Chen 2019-07-16
+--annotateDecl :: ScopeM A.Declaration -> ScopeM A.Declaration
+--annotateDecl m = annotateDecls $ (:[]) <$> m
 
 annotateDecls :: ScopeM [A.Declaration] -> ScopeM A.Declaration
 annotateDecls m = do
@@ -152,10 +152,10 @@ noDotorEqPattern err = dot
       A.PatternSynP i c args -> A.PatternSynP i c <$> (traverse $ traverse $ traverse dot) args
       A.RecP i fs            -> A.RecP i <$> (traverse $ traverse dot) fs
       A.WithP i p            -> A.WithP i <$> dot p
-
--- | Make sure that there are no dot patterns (WAS: called on pattern synonyms).
-noDotPattern :: String -> A.Pattern' e -> ScopeM (A.Pattern' Void)
-noDotPattern err = traverse $ const $ genericError err
+--UNUSED Liang-Ting Chen 2019-07-16
+---- | Make sure that there are no dot patterns (WAS: called on pattern synonyms).
+--noDotPattern :: String -> A.Pattern' e -> ScopeM (A.Pattern' Void)
+--noDotPattern err = traverse $ const $ genericError err
 
 newtype RecordConstructorType = RecordConstructorType [C.Declaration]
 
@@ -441,22 +441,24 @@ toAbstractCtx :: ToAbstract concrete abstract =>
                  Precedence -> concrete -> ScopeM abstract
 toAbstractCtx ctx c = withContextPrecedence ctx $ toAbstract c
 
-toAbstractTopCtx :: ToAbstract c a => c -> ScopeM a
-toAbstractTopCtx = toAbstractCtx TopCtx
+--UNUSED Liang-Ting Chen 2019-07-16
+--toAbstractTopCtx :: ToAbstract c a => c -> ScopeM a
+--toAbstractTopCtx = toAbstractCtx TopCtx
 
 toAbstractHiding :: (LensHiding h, ToAbstract c a) => h -> c -> ScopeM a
 toAbstractHiding h | visible h = toAbstract -- don't change precedence if visible
 toAbstractHiding _             = toAbstractCtx TopCtx
 
-setContextCPS :: Precedence -> (a -> ScopeM b) ->
-                 ((a -> ScopeM b) -> ScopeM b) -> ScopeM b
-setContextCPS p ret f = do
-  old <- useScope scopePrecedence
-  withContextPrecedence p $ f $ \ x -> setContextPrecedence old >> ret x
-
-localToAbstractCtx :: ToAbstract concrete abstract =>
-                     Precedence -> concrete -> (abstract -> ScopeM a) -> ScopeM a
-localToAbstractCtx ctx c ret = setContextCPS ctx ret (localToAbstract c)
+--UNUSED Liang-Ting Chen 2019-07-16
+--setContextCPS :: Precedence -> (a -> ScopeM b) ->
+--                 ((a -> ScopeM b) -> ScopeM b) -> ScopeM b
+--setContextCPS p ret f = do
+--  old <- useScope scopePrecedence
+--  withContextPrecedence p $ f $ \ x -> setContextPrecedence old >> ret x
+--
+--localToAbstractCtx :: ToAbstract concrete abstract =>
+--                     Precedence -> concrete -> (abstract -> ScopeM a) -> ScopeM a
+--localToAbstractCtx ctx c ret = setContextCPS ctx ret (localToAbstract c)
 
 -- | This operation does not affect the scope, i.e. the original scope
 --   is restored upon completion.
@@ -492,8 +494,8 @@ instance ToAbstract c a => ToAbstract (Maybe c) (Maybe a) where
 -- Names ------------------------------------------------------------------
 
 data NewName a = NewName
-  { newBinder   :: Binder -- what kind of binder?
-  , newName     :: a
+  { _newBinder   :: Binder -- what kind of binder?
+  , _newName     :: a
   }
 
 data OldQName     = OldQName C.QName (Maybe (Set A.Name))
@@ -655,22 +657,22 @@ instance ToAbstract OldModuleName A.ModuleName where
     amodName <$> resolveModule q
 
 -- Expressions ------------------------------------------------------------
-
--- | Peel off 'C.HiddenArg' and represent it as an 'NamedArg'.
-mkNamedArg :: C.Expr -> NamedArg C.Expr
-mkNamedArg (C.HiddenArg   _ e) = Arg (hide         defaultArgInfo) e
-mkNamedArg (C.InstanceArg _ e) = Arg (makeInstance defaultArgInfo) e
-mkNamedArg e                   = Arg defaultArgInfo $ unnamed e
+--UNUSED Liang-Ting Chen 2019-07-16
+---- | Peel off 'C.HiddenArg' and represent it as an 'NamedArg'.
+--mkNamedArg :: C.Expr -> NamedArg C.Expr
+--mkNamedArg (C.HiddenArg   _ e) = Arg (hide         defaultArgInfo) e
+--mkNamedArg (C.InstanceArg _ e) = Arg (makeInstance defaultArgInfo) e
+--mkNamedArg e                   = Arg defaultArgInfo $ unnamed e
 
 -- | Peel off 'C.HiddenArg' and represent it as an 'Arg', throwing away any name.
 mkArg' :: ArgInfo -> C.Expr -> Arg C.Expr
 mkArg' info (C.HiddenArg   _ e) = Arg (hide         info) $ namedThing e
 mkArg' info (C.InstanceArg _ e) = Arg (makeInstance info) $ namedThing e
 mkArg' info e                   = Arg (setHiding NotHidden info) e
-
--- | By default, arguments are @Relevant@.
-mkArg :: C.Expr -> Arg C.Expr
-mkArg e = mkArg' defaultArgInfo e
+--UNUSED Liang-Ting 2019-07-16
+---- | By default, arguments are @Relevant@.
+--mkArg :: C.Expr -> Arg C.Expr
+--mkArg e = mkArg' defaultArgInfo e
 
 inferParenPreference :: C.Expr -> ParenPreference
 inferParenPreference C.Paren{} = PreferParen
@@ -1415,10 +1417,11 @@ instance ToAbstract LetDef [A.LetBinding] where
             where i' = ExprRange (fuseRange i e)
         lambda _ _ = notAValidLetBinding d
 
-newtype Blind a = Blind { unBlind :: a }
-
-instance ToAbstract (Blind a) (Blind a) where
-  toAbstract = return
+--UNUSED Liang-Ting Chen 2019-07-16
+--newtype Blind a = Blind { unBlind :: a }
+--
+--instance ToAbstract (Blind a) (Blind a) where
+--  toAbstract = return
 
 instance ToAbstract NiceDeclaration A.Declaration where
 
@@ -2179,12 +2182,12 @@ whereToAbstract r whname whds inner = do
   return (x, A.WhereDecls (am <$ whname) ds)
 
 data RightHandSide = RightHandSide
-  { rhsRewriteEqn :: [C.RewriteEqn]    -- ^ @rewrite e@ (many)
-  , rhsWithExpr   :: [C.WithExpr]      -- ^ @with e@ (many)
-  , rhsSubclauses :: [ScopeM C.Clause] -- ^ the subclauses spawned by a with (monadic because we need to reset the local vars before checking these clauses)
-  , rhs           :: C.RHS
-  , rhsWhereName  :: Maybe (C.Name, Access)  -- ^ The name of the @where@ module (if any).
-  , rhsWhereDecls :: [C.Declaration]         -- ^ The contents of the @where@ module.
+  { _rhsRewriteEqn :: [C.RewriteEqn]    -- ^ @rewrite e@ (many)
+  , _rhsWithExpr   :: [C.WithExpr]      -- ^ @with e@ (many)
+  , _rhsSubclauses :: [ScopeM C.Clause] -- ^ the subclauses spawned by a with (monadic because we need to reset the local vars before checking these clauses)
+  , _rhs           :: C.RHS
+  , _rhsWhereName  :: Maybe (C.Name, Access)  -- ^ The name of the @where@ module (if any).
+  , _rhsWhereDecls :: [C.Declaration]         -- ^ The contents of the @where@ module.
   }
 
 data AbstractRHS

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -84,10 +84,10 @@ reifyUnblocked t = locallyTCState stInstantiateBlocking (const True) $ reify t
 
 
 -- Composition of reified applications ------------------------------------
-
--- | Drops hidden arguments unless --show-implicit.
-napps :: Expr -> [NamedArg Expr] -> TCM Expr
-napps e = nelims e . map I.Apply
+--UNUSED Liang-Ting 2019-07-16
+---- | Drops hidden arguments unless --show-implicit.
+--napps :: Expr -> [NamedArg Expr] -> TCM Expr
+--napps e = nelims e . map I.Apply
 
 -- | Drops hidden arguments unless --show-implicit.
 apps :: MonadReify m => Expr -> [Arg Expr] -> m Expr
@@ -811,7 +811,7 @@ data NamedClause = NamedClause QName Bool I.Clause
 
 -- The Monoid instance for Data.Map doesn't require that the values are a
 -- monoid.
-newtype MonoidMap k v = MonoidMap { unMonoidMap :: Map.Map k v }
+newtype MonoidMap k v = MonoidMap { _unMonoidMap :: Map.Map k v }
 
 instance (Ord k, Monoid v) => Semigroup (MonoidMap k v) where
   MonoidMap m1 <> MonoidMap m2 = MonoidMap (Map.unionWith mappend m1 m2)

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -996,11 +996,11 @@ compareArgs es = do
 --   off, if inductive.
 --
 --   UNUSED
-annotatePatsWithUseSizeLt :: [DeBruijnPattern] -> TerM [(Bool,DeBruijnPattern)]
-annotatePatsWithUseSizeLt = loop where
-  loop [] = return []
-  loop (p@(ProjP _ q) : pats) = ((False,p) :) <$> do projUseSizeLt q $ loop pats
-  loop (p : pats) = (\ b ps -> (b,p) : ps) <$> terGetUseSizeLt <*> loop pats
+--annotatePatsWithUseSizeLt :: [DeBruijnPattern] -> TerM [(Bool,DeBruijnPattern)]
+--annotatePatsWithUseSizeLt = loop where
+--  loop [] = return []
+--  loop (p@(ProjP _ q) : pats) = ((False,p) :) <$> do projUseSizeLt q $ loop pats
+--  loop (p : pats) = (\ b ps -> (b,p) : ps) <$> terGetUseSizeLt <*> loop pats
 
 
 -- | @compareElim e dbpat@
@@ -1092,17 +1092,17 @@ composeGuardedness _ _ = __IMPOSSIBLE__
 offsetFromConstructor :: MonadTCM tcm => QName -> tcm Int
 offsetFromConstructor c = maybe 1 (const 0) <$> do
   liftTCM $ isRecordConstructor c
-
--- | Compute the proper subpatterns of a 'DeBruijnPattern'.
-subPatterns :: DeBruijnPattern -> [DeBruijnPattern]
-subPatterns = foldPattern $ \case
-  ConP _ _ ps -> map namedArg ps
-  DefP _ _ ps -> map namedArg ps -- TODO check semantics
-  VarP _ _    -> mempty
-  LitP _      -> mempty
-  DotP _ _    -> mempty
-  ProjP _ _   -> mempty
-  IApplyP{}   -> mempty
+--UNUSED Liang-Ting 2019-07-16
+---- | Compute the proper subpatterns of a 'DeBruijnPattern'.
+--subPatterns :: DeBruijnPattern -> [DeBruijnPattern]
+--subPatterns = foldPattern $ \case
+--  ConP _ _ ps -> map namedArg ps
+--  DefP _ _ ps -> map namedArg ps -- TODO check semantics
+--  VarP _ _    -> mempty
+--  LitP _      -> mempty
+--  DotP _ _    -> mempty
+--  ProjP _ _   -> mempty
+--  IApplyP{}   -> mempty
 
 
 compareTerm :: Term -> Masked DeBruijnPattern -> TerM Order

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -251,16 +251,16 @@ checkSpine action a self es t = do
   ((v, v'), t') <- inferSpine' action a self self es
   t' <- reduce t'
   v' <$ coerceSize subtype v t' t
-
-checkArgs
-  :: (MonadCheckInternal m)
-  => Action m
-  -> Type      -- ^ Type of the head.
-  -> Term      -- ^ The head.
-  -> Args      -- ^ The arguments.
-  -> Type      -- ^ Expected type of the application.
-  -> m Term    -- ^ The application after modification by the @Action@.
-checkArgs action a self vs t = checkSpine action a self (map Apply vs) t
+--UNUSED Liang-Ting Chen 2019-07-16
+--checkArgs
+--  :: (MonadCheckInternal m)
+--  => Action m
+--  -> Type      -- ^ Type of the head.
+--  -> Term      -- ^ The head.
+--  -> Args      -- ^ The arguments.
+--  -> Type      -- ^ Expected type of the application.
+--  -> m Term    -- ^ The application after modification by the @Action@.
+--checkArgs action a self vs t = checkSpine action a self (map Apply vs) t
 
 -- | @checkArgInfo actual expected@.
 --

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -236,14 +236,14 @@ blockedOnProjection = return $ Block (BlockedOnProj False) []
 
 blockedOnApplication :: Monad m => ApplyOrIApply -> m (Match a)
 blockedOnApplication b = return $ Block (BlockedOnApply b) []
-
--- | Lens for 'blockingVarCons'.
-mapBlockingVarCons :: ([ConHead] -> [ConHead]) -> BlockingVar -> BlockingVar
-mapBlockingVarCons f b = b { blockingVarCons = f (blockingVarCons b) }
-
--- | Lens for 'blockingVarLits'.
-mapBlockingVarLits :: ([Literal] -> [Literal]) -> BlockingVar -> BlockingVar
-mapBlockingVarLits f b = b { blockingVarLits = f (blockingVarLits b) }
+--UNUSED Liang-Ting Chen 2019-07-16
+---- | Lens for 'blockingVarCons'.
+--mapBlockingVarCons :: ([ConHead] -> [ConHead]) -> BlockingVar -> BlockingVar
+--mapBlockingVarCons f b = b { blockingVarCons = f (blockingVarCons b) }
+--
+---- | Lens for 'blockingVarLits'.
+--mapBlockingVarLits :: ([Literal] -> [Literal]) -> BlockingVar -> BlockingVar
+--mapBlockingVarLits f b = b { blockingVarLits = f (blockingVarLits b) }
 
 setBlockingVarOverlap :: BlockingVar -> BlockingVar
 setBlockingVarOverlap = \x -> x { blockingVarOverlap = True }

--- a/src/full/Agda/TypeChecking/Free.hs
+++ b/src/full/Agda/TypeChecking/Free.hs
@@ -225,8 +225,9 @@ freeIn = freeIn' IgnoreNot
 freeInIgnoringSorts :: Free a => Nat -> a -> Bool
 freeInIgnoringSorts = freeIn' IgnoreAll
 
-freeInIgnoringSortAnn :: Free a => Nat -> a -> Bool
-freeInIgnoringSortAnn = freeIn' IgnoreInAnnotations
+-- UNUSED Liang-Ting Chen 2019-07-16
+--freeInIgnoringSortAnn :: Free a => Nat -> a -> Bool
+--freeInIgnoringSortAnn = freeIn' IgnoreInAnnotations
 
 -- | Is the variable bound by the abstraction actually used?
 isBinderUsed :: Free a => Abs a -> Bool
@@ -296,29 +297,31 @@ unguardedVars = filterVarMap $ \case
   VarOcc Unguarded _ -> True
   _ -> False
 
--- | Ordinary rigid variables, e.g., in arguments of variables or functions.
-weaklyRigidVars :: VarMap -> VarSet
-weaklyRigidVars = filterVarMap $ \case
-  VarOcc WeaklyRigid _ -> True
-  _ -> False
+-- UNUSED Liang-Ting Chen 2019-07-16
+---- | Ordinary rigid variables, e.g., in arguments of variables or functions.
+--weaklyRigidVars :: VarMap -> VarSet
+--weaklyRigidVars = filterVarMap $ \case
+--  VarOcc WeaklyRigid _ -> True
+--  _ -> False
 
 -- | Rigid variables: either strongly rigid, unguarded, or weakly rigid.
 rigidVars :: VarMap -> VarSet
 rigidVars = filterVarMap $ \case
   VarOcc o _ -> o `elem` [ WeaklyRigid, Unguarded, StronglyRigid ]
 
+-- UNUSED Liang-Ting Chen 2019-07-16
 -- | Variables occuring in arguments of metas.
 --   These are only potentially free, depending how the meta variable is instantiated.
 --   The set contains the id's of the meta variables that this variable is an argument to.
-flexibleVars :: VarMap -> IntMap MetaSet
-flexibleVars (VarMap m) = (`IntMap.mapMaybe` m) $ \case
-  VarOcc (Flexible ms) _ -> Just ms
-  _ -> Nothing
-
--- | Variables in irrelevant arguments and under a @DontCare@, i.e.,
---   in irrelevant positions.
-irrelevantVars :: VarMap -> VarSet
-irrelevantVars = filterVarMap isIrrelevant
+--flexibleVars :: VarMap -> IntMap MetaSet
+--flexibleVars (VarMap m) = (`IntMap.mapMaybe` m) $ \case
+--  VarOcc (Flexible ms) _ -> Just ms
+--  _ -> Nothing
+--
+---- | Variables in irrelevant arguments and under a @DontCare@, i.e.,
+----   in irrelevant positions.
+--irrelevantVars :: VarMap -> VarSet
+--irrelevantVars = filterVarMap isIrrelevant
 
 allVars :: VarMap -> VarSet
 allVars = IntMap.keysSet . theVarMap

--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -90,11 +90,12 @@ recordPatternToProjections p =
 conjColumns :: [[Bool]] -> [Bool]
 conjColumns =  foldl1 (zipWith (&&))
 
--- | @insertColumn i a m@ inserts a column before the @i@th column in
---   matrix @m@ and fills it with value @a@.
-insertColumn :: Int -> a -> [[a]] -> [[a]]
-insertColumn i a rows = map ins rows where
-  ins row = let (init, last) = splitAt i row in init ++ a : last
+-- UNUSED Liang-Ting 2019-07-16
+---- | @insertColumn i a m@ inserts a column before the @i@th column in
+----   matrix @m@ and fills it with value @a@.
+--insertColumn :: Int -> a -> [[a]] -> [[a]]
+--insertColumn i a rows = map ins rows where
+--  ins row = let (init, last) = splitAt i row in init ++ a : last
 
 {- UNUSED
 -- | @cutColumn i m@ removes the @i@th column from matrix @m@.
@@ -108,13 +109,14 @@ cutColumns :: Int -> Int -> [[a]] -> ([[a]], [[a]])
 cutColumns i n rows = unzip (map (cutSublist i n) rows)
 -}
 
--- | @cutSublist i n xs = (xs', ys, xs'')@ cuts out a sublist @ys@
---   of width @n@ from @xs@, starting at column @i@.
-cutSublist :: Int -> Int -> [a] -> ([a], [a], [a])
-cutSublist i n row =
-  let (init, rest) = splitAt i row
-      (mid , last) = splitAt n rest
-  in  (init, mid, last)
+-- UNUSED Liang-Ting 2019-07-16
+---- | @cutSublist i n xs = (xs', ys, xs'')@ cuts out a sublist @ys@
+----   of width @n@ from @xs@, starting at column @i@.
+--cutSublist :: Int -> Int -> [a] -> ([a], [a], [a])
+--cutSublist i n row =
+--  let (init, rest) = splitAt i row
+--      (mid , last) = splitAt n rest
+--  in  (init, mid, last)
 
 getEtaAndArity :: SplitTag -> TCM (Bool, Nat)
 getEtaAndArity (SplitCon c) =
@@ -231,113 +233,113 @@ recordExpressionsToCopatterns = \case
         _ -> return cc
     cc@Done{} -> return cc
 
--- | @replaceByProjections i projs cc@ replaces variables @i..i+n-1@
---   (counted from left) by projections @projs_1 i .. projs_n i@.
+-- UNUSED Liang-Ting Chen 2019-07-16
+---- | @replaceByProjections i projs cc@ replaces variables @i..i+n-1@
+----   (counted from left) by projections @projs_1 i .. projs_n i@.
+----
+----   If @n==0@, we matched on a zero-field record, which means that
+----   we are actually introduce a new variable, increasing split
+----   positions greater or equal to @i@ by one.
+----   Otherwise, we have to lower
+----
+--replaceByProjections :: Arg Int -> [QName] -> CompiledClauses -> CompiledClauses
+--replaceByProjections (Arg ai i) projs cc =
+--  let n = length projs
 --
---   If @n==0@, we matched on a zero-field record, which means that
---   we are actually introduce a new variable, increasing split
---   positions greater or equal to @i@ by one.
---   Otherwise, we have to lower
+--      loop :: Int -> CompiledClauses -> CompiledClauses
+--      loop i cc = case cc of
+--        Case j cs
 --
-replaceByProjections :: Arg Int -> [QName] -> CompiledClauses -> CompiledClauses
-replaceByProjections (Arg ai i) projs cc =
-  let n = length projs
+--        -- if j < i, we leave j untouched, but we increase i by the number
+--        -- of variables replacing j in the branches
+--          | unArg j < i -> Case j $ loops i cs
+--
+--        -- if j >= i then we shrink j by (n-1)
+--          | otherwise   -> Case (j <&> \ k -> k - (n-1)) $ fmap (loop i) cs
+--
+--        Done xs v ->
+--        -- we have to delete (n-1) variables from xs
+--        -- and instantiate v suitably with the projections
+--          let (xs0,xs1,xs2)     = cutSublist i n xs
+--              names | null xs1  = ["r"]
+--                    | otherwise = map unArg xs1
+--              x                 = Arg ai $ foldr1 appendArgNames names
+--              xs'               = xs0 ++ x : xs2
+--              us                = map (\ p -> Var 0 [Proj ProjSystem p]) (reverse projs)
+--              -- go from level (i + n - 1) to index (subtract from |xs|-1)
+--              index             = length xs - (i + n)
+--          in  Done xs' $ applySubst (liftS (length xs2) $ us ++# raiseS 1) v
+--          -- The body is NOT guarded by lambdas!
+--          -- WRONG: underLambdas i (flip apply) (map defaultArg us) v
+--
+--        Fail -> Fail
+--
+--      loops :: Int -> Case CompiledClauses -> Case CompiledClauses
+--      loops i bs@Branches{ conBranches    = conMap
+--                         , litBranches    = litMap
+--                         , catchAllBranch = catchAll } =
+--        bs{ conBranches    = fmap (\ (WithArity n c) -> WithArity n $ loop (i + n - 1) c) conMap
+--          , litBranches    = fmap (loop (i - 1)) litMap
+--          , catchAllBranch = fmap (loop i) catchAll
+--          }
+--  in  loop i cc
 
-      loop :: Int -> CompiledClauses -> CompiledClauses
-      loop i cc = case cc of
-        Case j cs
-
-        -- if j < i, we leave j untouched, but we increase i by the number
-        -- of variables replacing j in the branches
-          | unArg j < i -> Case j $ loops i cs
-
-        -- if j >= i then we shrink j by (n-1)
-          | otherwise   -> Case (j <&> \ k -> k - (n-1)) $ fmap (loop i) cs
-
-        Done xs v ->
-        -- we have to delete (n-1) variables from xs
-        -- and instantiate v suitably with the projections
-          let (xs0,xs1,xs2)     = cutSublist i n xs
-              names | null xs1  = ["r"]
-                    | otherwise = map unArg xs1
-              x                 = Arg ai $ foldr1 appendArgNames names
-              xs'               = xs0 ++ x : xs2
-              us                = map (\ p -> Var 0 [Proj ProjSystem p]) (reverse projs)
-              -- go from level (i + n - 1) to index (subtract from |xs|-1)
-              index             = length xs - (i + n)
-          in  Done xs' $ applySubst (liftS (length xs2) $ us ++# raiseS 1) v
-          -- The body is NOT guarded by lambdas!
-          -- WRONG: underLambdas i (flip apply) (map defaultArg us) v
-
-        Fail -> Fail
-
-      loops :: Int -> Case CompiledClauses -> Case CompiledClauses
-      loops i bs@Branches{ conBranches    = conMap
-                         , litBranches    = litMap
-                         , catchAllBranch = catchAll } =
-        bs{ conBranches    = fmap (\ (WithArity n c) -> WithArity n $ loop (i + n - 1) c) conMap
-          , litBranches    = fmap (loop (i - 1)) litMap
-          , catchAllBranch = fmap (loop i) catchAll
-          }
-  in  loop i cc
-
--- | Check if a split is on a record constructor, and return the projections
---   if yes.
-isRecordCase :: Case c -> TCM (Maybe ([QName], c))
-isRecordCase (Branches { conBranches = conMap
-                       , litBranches = litMap
-                       , catchAllBranch = Nothing })
-  | Map.null litMap
-  , [(con, WithArity _ br)] <- Map.toList conMap = do
-    isRC <- isRecordConstructor con
-    case isRC of
-      Just (r, Record { recFields = fs }) -> return $ Just (map unArg fs, br)
-      Just (r, _) -> __IMPOSSIBLE__
-      Nothing -> return Nothing
-isRecordCase _ = return Nothing
+-- UNUSED Liang-Ting 2019-07-16
+---- | Check if a split is on a record constructor, and return the projections
+----   if yes.
+--isRecordCase :: Case c -> TCM (Maybe ([QName], c))
+--isRecordCase (Branches { conBranches = conMap
+--                       , litBranches = litMap
+--                       , catchAllBranch = Nothing })
+--  | Map.null litMap
+--  , [(con, WithArity _ br)] <- Map.toList conMap = do
+--    isRC <- isRecordConstructor con
+--    case isRC of
+--      Just (r, Record { recFields = fs }) -> return $ Just (map unArg fs, br)
+--      Just (r, _) -> __IMPOSSIBLE__
+--      Nothing -> return Nothing
+--isRecordCase _ = return Nothing
 
 ---------------------------------------------------------------------------
 -- * Record pattern translation for split trees
 ---------------------------------------------------------------------------
-
--- | Split tree annotation.
-data RecordSplitNode = RecordSplitNode
-  { splitTag           :: SplitTag
-                                 -- ^ Constructor name/literal for this branch.
-  , splitArity         :: Int    -- ^ Arity of the constructor.
-  , splitRecordPattern :: Bool   -- ^ Should we translate this split away?
-  }
+--UNUSED Liang-Ting Chen 2019-07-16
+---- | Split tree annotation.
+--data RecordSplitNode = RecordSplitNode
+--  { _splitTag           :: SplitTag -- ^ Constructor name/literal for this branch.
+--  , _splitArity         :: Int      -- ^ Arity of the constructor.
+--  , _splitRecordPattern :: Bool     -- ^ Should we translate this split away?
+--  }
 
 -- | Split tree annotated for record pattern translation.
-type RecordSplitTree  = SplitTree' RecordSplitNode
-type RecordSplitTrees = SplitTrees' RecordSplitNode
+--type RecordSplitTree  = SplitTree' RecordSplitNode
+--type RecordSplitTrees = SplitTrees' RecordSplitNode
 
-
-
--- | Bottom-up procedure to annotate split tree.
-recordSplitTree :: SplitTree -> TCM RecordSplitTree
-recordSplitTree t = snd <$> loop t
-  where
-
-    loop :: SplitTree -> TCM ([Bool], RecordSplitTree)
-    loop t = case t of
-      SplittingDone n -> return (replicate n True, SplittingDone n)
-      SplitAt i ts    -> do
-        (xs, ts) <- loops (unArg i) ts
-        return (xs, SplitAt i ts)
-
-    loops :: Int -> SplitTrees -> TCM ([Bool], RecordSplitTrees)
-    loops i ts = do
-      (xss, ts) <- unzip <$> do
-        forM ts $ \ (c, t) -> do
-          (xs, t) <- loop t
-          (isRC, n) <- getEtaAndArity c
-          let (xs0, rest) = splitAt i xs
-              (xs1, xs2)  = splitAt n rest
-              x           = isRC && and xs1
-              xs'         = xs0 ++ x : xs2
-          return (xs, (RecordSplitNode c n x, t))
-      return (foldl1 (zipWith (&&)) xss, ts)
+--UNUSED Liang-Ting Chen 2019-07-16
+---- | Bottom-up procedure to annotate split tree.
+--recordSplitTree :: SplitTree -> TCM RecordSplitTree
+--recordSplitTree t = snd <$> loop t
+--  where
+--
+--    loop :: SplitTree -> TCM ([Bool], RecordSplitTree)
+--    loop t = case t of
+--      SplittingDone n -> return (replicate n True, SplittingDone n)
+--      SplitAt i ts    -> do
+--        (xs, ts) <- loops (unArg i) ts
+--        return (xs, SplitAt i ts)
+--
+--    loops :: Int -> SplitTrees -> TCM ([Bool], RecordSplitTrees)
+--    loops i ts = do
+--      (xss, ts) <- unzip <$> do
+--        forM ts $ \ (c, t) -> do
+--          (xs, t) <- loop t
+--          (isRC, n) <- getEtaAndArity c
+--          let (xs0, rest) = splitAt i xs
+--              (xs1, xs2)  = splitAt n rest
+--              x           = isRC && and xs1
+--              xs'         = xs0 ++ x : xs2
+--          return (xs, (RecordSplitNode c n x, t))
+--      return (foldl1 (zipWith (&&)) xss, ts)
 
 -- | Bottom-up procedure to record-pattern-translate split tree.
 translateSplitTree :: SplitTree -> TCM SplitTree

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -291,13 +291,14 @@ data FastCase c = FBranches
     -- ^ (if True) In case of non-canonical argument use catchAllBranch.
   }
 
-noBranches :: FastCase a
-noBranches = FBranches{ fprojPatterns   = False
-                      , fconBranches    = Map.empty
-                      , fsucBranch      = Nothing
-                      , flitBranches    = Map.empty
-                      , fcatchAllBranch = Nothing
-                      , ffallThrough    = False }
+--UNUSED Liang-Ting Chen 2019-07-16
+--noBranches :: FastCase a
+--noBranches = FBranches{ fprojPatterns   = False
+--                      , fconBranches    = Map.empty
+--                      , fsucBranch      = Nothing
+--                      , flitBranches    = Map.empty
+--                      , fcatchAllBranch = Nothing
+--                      , ffallThrough    = False }
 
 -- | Case tree with bodies.
 
@@ -502,9 +503,9 @@ newtype Env s = Env [Pointer s]
 
 emptyEnv :: Env s
 emptyEnv = Env []
-
-isEmptyEnv :: Env s -> Bool
-isEmptyEnv (Env xs) = null xs
+--UNUSED Liang-Ting Chen 2019-07-16
+--isEmptyEnv :: Env s -> Bool
+--isEmptyEnv (Env xs) = null xs
 
 envSize :: Env s -> Int
 envSize (Env xs) = length xs

--- a/src/full/Agda/TypeChecking/Rules/Display.hs
+++ b/src/full/Agda/TypeChecking/Rules/Display.hs
@@ -25,10 +25,11 @@ checkDisplayPragma f ps e = do
   reportSLn "tc.display.pragma" 20 $ "Adding display form for " ++ show f ++ "\n  " ++ show df
   addDisplayForm f df
 
--- Compute a left-hand side for a display form. Inserts implicits, but no type
--- checking so does the wrong thing if implicitness is computed. Binds variables.
-displayLHS :: Telescope -> [NamedArg A.Pattern] -> (Int -> [Term] -> TCM a) -> TCM a
-displayLHS tel ps ret = patternsToTerms tel ps $ \n vs -> ret n (map unArg vs)
+--UNUSED Liang-Ting 2019-07-16
+---- Compute a left-hand side for a display form. Inserts implicits, but no type
+---- checking so does the wrong thing if implicitness is computed. Binds variables.
+--displayLHS :: Telescope -> [NamedArg A.Pattern] -> (Int -> [Term] -> TCM a) -> TCM a
+--displayLHS tel ps ret = patternsToTerms tel ps $ \n vs -> ret n (map unArg vs)
 
 patternsToTerms :: Telescope -> [NamedArg A.Pattern] -> (Int -> Args -> TCM a) -> TCM a
 patternsToTerms _ [] ret = ret 0 []

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -89,13 +89,13 @@ import Agda.Utils.Singleton
 import Agda.Utils.Size
 
 import Agda.Utils.Impossible
-
--- | Compute the set of flexible patterns in a list of patterns. The result is
---   the deBruijn indices of the flexible patterns.
-flexiblePatterns :: [NamedArg A.Pattern] -> TCM FlexibleVars
-flexiblePatterns nps = do
-  forMaybeM (zip (downFrom $ length nps) nps) $ \ (i, Arg ai p) -> do
-    runMaybeT $ (\ f -> FlexibleVar (getHiding ai) (getOrigin ai) f (Just i) i) <$> maybeFlexiblePattern p
+--UNUSED Liang-Ting Chen 2019-07-16
+---- | Compute the set of flexible patterns in a list of patterns. The result is
+----   the deBruijn indices of the flexible patterns.
+--flexiblePatterns :: [NamedArg A.Pattern] -> TCM FlexibleVars
+--flexiblePatterns nps = do
+--  forMaybeM (zip (downFrom $ length nps) nps) $ \ (i, Arg ai p) -> do
+--    runMaybeT $ (\ f -> FlexibleVar (getHiding ai) (getOrigin ai) f (Just i) i) <$> maybeFlexiblePattern p
 
 -- | A pattern is flexible if it is dotted or implicit, or a record pattern
 --   with only flexible subpatterns.

--- a/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
@@ -222,8 +222,9 @@ lhsProblem f p = f (_lhsProblem p) <&> \x -> p {_lhsProblem = x}
 lhsTarget :: Lens' (Arg Type) (LHSState a)
 lhsTarget f p = f (_lhsTarget p) <&> \x -> p {_lhsTarget = x}
 
-lhsPartialSplit :: Lens' [Maybe Int] (LHSState a)
-lhsPartialSplit f p = f (_lhsPartialSplit p) <&> \x -> p {_lhsPartialSplit = x}
+-- UNUSED Liang-Ting Chen 2019-07-16
+--lhsPartialSplit :: Lens' [Maybe Int] (LHSState a)
+--lhsPartialSplit f p = f (_lhsPartialSplit p) <&> \x -> p {_lhsPartialSplit = x}
 
 instance Subst Term (Problem a) where
   applySubst rho (Problem eqs rps cont) = Problem (applySubst rho eqs) rps cont

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -207,9 +207,9 @@ unifyIndices tel flex a us vs = liftTCM $ Bench.billTo [Bench.Typing, Bench.Chec
 ----------------------------------------------------
 
 data Equality = Equal
-  { eqType  :: Dom Type
-  , eqLeft  :: Term
-  , eqRight :: Term
+  { _eqType  :: Dom Type
+  , _eqLeft  :: Term
+  , _eqRight :: Term
   }
 
 instance Reduce Equality where
@@ -238,18 +238,20 @@ data UnifyState = UState
 
 lensVarTel   :: Lens' Telescope UnifyState
 lensVarTel   f s = f (varTel s) <&> \ tel -> s { varTel = tel }
-
-lensFlexVars :: Lens' FlexibleVars UnifyState
-lensFlexVars f s = f (flexVars s) <&> \ flex -> s { flexVars = flex }
+--UNUSED Liang-Ting Chen 2019-07-16
+--lensFlexVars :: Lens' FlexibleVars UnifyState
+--lensFlexVars f s = f (flexVars s) <&> \ flex -> s { flexVars = flex }
 
 lensEqTel    :: Lens' Telescope UnifyState
 lensEqTel    f s = f (eqTel s) <&> \ x -> s { eqTel = x }
 
-lensEqLHS    :: Lens' Args UnifyState
-lensEqLHS    f s = f (eqLHS s) <&> \ x -> s { eqLHS = x }
+--UNUSED Liang-Ting Chen 2019-07-16
+--lensEqLHS    :: Lens' Args UnifyState
+--lensEqLHS    f s = f (eqLHS s) <&> \ x -> s { eqLHS = x }
 
-lensEqRHS    :: Lens' Args UnifyState
-lensEqRHS    f s = f (eqRHS s) <&> \ x -> s { eqRHS = x }
+--UNUSED Liang-Ting Chen 2019-07-16
+--lensEqRHS    :: Lens' Args UnifyState
+--lensEqRHS    f s = f (eqRHS s) <&> \ x -> s { eqRHS = x }
 
 instance Reduce UnifyState where
   reduce' (UState var flex eq lhs rhs) =
@@ -259,8 +261,9 @@ instance Reduce UnifyState where
            <*> reduce' lhs
            <*> reduce' rhs
 
-reduceEqTel :: UnifyState -> TCM UnifyState
-reduceEqTel = lensEqTel reduce
+--UNUSED Liang-Ting Chen 2019-07-16
+--reduceEqTel :: UnifyState -> TCM UnifyState
+--reduceEqTel = lensEqTel reduce
 
 instance Normalise UnifyState where
   normalise' (UState var flex eq lhs rhs) =
@@ -324,21 +327,22 @@ getEqualityUnraised k UState { eqTel = eqs, eqLHS = lhs, eqRHS = rhs } =
           (unArg $ indexWithDefault __IMPOSSIBLE__ lhs k)
           (unArg $ indexWithDefault __IMPOSSIBLE__ rhs k)
 
-getEqInfo :: Int -> UnifyState -> ArgInfo
-getEqInfo k UState { eqTel = eqs } =
-  domInfo $ indexWithDefault __IMPOSSIBLE__ (telToList eqs) k
-
--- | Add a list of equations to the front of the equation telescope
-addEqs :: Telescope -> [Arg Term] -> [Arg Term] -> UnifyState -> UnifyState
-addEqs tel us vs s =
-  s { eqTel = tel `abstract` eqTel s
-    , eqLHS = us ++ eqLHS s
-    , eqRHS = vs ++ eqRHS s
-    }
-  where k = size tel
-
-addEq :: Type -> Arg Term -> Arg Term -> UnifyState -> UnifyState
-addEq a u v = addEqs (ExtendTel (defaultDom a) (Abs underscore EmptyTel)) [u] [v]
+--UNUSED Liang-Ting Chen 2019-07-16
+--getEqInfo :: Int -> UnifyState -> ArgInfo
+--getEqInfo k UState { eqTel = eqs } =
+--  domInfo $ indexWithDefault __IMPOSSIBLE__ (telToList eqs) k
+--
+---- | Add a list of equations to the front of the equation telescope
+--addEqs :: Telescope -> [Arg Term] -> [Arg Term] -> UnifyState -> UnifyState
+--addEqs tel us vs s =
+--  s { eqTel = tel `abstract` eqTel s
+--    , eqLHS = us ++ eqLHS s
+--    , eqRHS = vs ++ eqRHS s
+--    }
+--  where k = size tel
+--
+--addEq :: Type -> Arg Term -> Arg Term -> UnifyState -> UnifyState
+--addEq a u v = addEqs (ExtendTel (defaultDom a) (Abs underscore EmptyTel)) [u] [v]
 
 
 
@@ -391,19 +395,20 @@ solveEq k u s = (,sigma) $ s
     n     = eqCount s
     sigma = liftS (n-k-1) $ consS (dotP u') idS
 
--- | Simplify the k'th equation with the given value (which can depend on other
---   equation variables). Returns Nothing if there is a cycle.
-simplifyEq :: Int -> Term -> UnifyState -> Maybe (UnifyState, PatternSubstitution)
-simplifyEq k u s = case instantiateTelescope (eqTel s) k u of
-  Nothing -> Nothing
-  Just (tel' , sigma , rho) -> Just $ (,sigma) $ UState
-    { varTel   = varTel s
-    , flexVars = flexVars s
-    , eqTel    = tel'
-    , eqLHS    = permute rho $ eqLHS s
-    , eqRHS    = permute rho $ eqRHS s
-    }
-
+--UNUSED Liang-Ting Chen 2019-07-16
+---- | Simplify the k'th equation with the given value (which can depend on other
+----   equation variables). Returns Nothing if there is a cycle.
+--simplifyEq :: Int -> Term -> UnifyState -> Maybe (UnifyState, PatternSubstitution)
+--simplifyEq k u s = case instantiateTelescope (eqTel s) k u of
+--  Nothing -> Nothing
+--  Just (tel' , sigma , rho) -> Just $ (,sigma) $ UState
+--    { varTel   = varTel s
+--    , flexVars = flexVars s
+--    , eqTel    = tel'
+--    , eqLHS    = permute rho $ eqLHS s
+--    , eqRHS    = permute rho $ eqRHS s
+--    }
+--
 ----------------------------------------------------
 -- Unification strategies
 ----------------------------------------------------
@@ -547,10 +552,11 @@ instance PrettyTCM UnifyStep where
 
 type UnifyStrategy = UnifyState -> ListT TCM UnifyStep
 
-leftToRightStrategy :: UnifyStrategy
-leftToRightStrategy s =
-    msum (for [0..n-1] $ \k -> completeStrategyAt k s)
-  where n = size $ eqTel s
+--UNUSED Liang-Ting Chen 2019-07-16
+--leftToRightStrategy :: UnifyStrategy
+--leftToRightStrategy s =
+--    msum (for [0..n-1] $ \k -> completeStrategyAt k s)
+--  where n = size $ eqTel s
 
 rightToLeftStrategy :: UnifyStrategy
 rightToLeftStrategy s =
@@ -789,8 +795,8 @@ skipIrrelevantStrategy k s = do
 ----------------------------------------------------
 
 data UnifyLogEntry
-  = UnificationDone  UnifyState
-  | UnificationStep  UnifyState UnifyStep
+  = UnificationStep  UnifyState UnifyStep
+--  | UnificationDone  UnifyState -- unused?
 
 type UnifyLog = [UnifyLogEntry]
 

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -19,7 +19,7 @@ import qualified Data.List as List
 import Data.Maybe ( catMaybes )
 import Data.Semigroup ( Semigroup, (<>) )
 
-import Control.Monad ( guard, forM, unless )
+import Control.Monad ( forM, unless )
 import Control.Monad.Reader ( ReaderT )
 import Control.Monad.State ( StateT )
 import Control.Monad.Trans ( lift )
@@ -91,13 +91,14 @@ warning_ w = do
   p <- sayWhen r' c $ prettyTCM w
   return $ TCWarning r w p b
 
--- | @applyWarningMode@ filters out the warnings the user has not requested
--- Users are not allowed to ignore non-fatal errors.
-
-applyWarningMode :: WarningMode -> Warning -> Maybe Warning
-applyWarningMode wm w = case classifyWarning w of
-  ErrorWarnings -> Just w
-  AllWarnings   -> w <$ guard (Set.member (warningName w) $ wm ^. warningSet)
+-- UNUSED Liang-Ting Chen 2019-07-16
+---- | @applyWarningMode@ filters out the warnings the user has not requested
+---- Users are not allowed to ignore non-fatal errors.
+--
+--applyWarningMode :: WarningMode -> Warning -> Maybe Warning
+--applyWarningMode wm w = case classifyWarning w of
+--  ErrorWarnings -> Just w
+--  AllWarnings   -> w <$ guard (Set.member (warningName w) $ wm ^. warningSet)
 
 {-# SPECIALIZE warnings :: [Warning] -> TCM () #-}
 warnings :: MonadWarning m => [Warning] -> m ()

--- a/src/full/Agda/Utils/FileName.hs
+++ b/src/full/Agda/Utils/FileName.hs
@@ -71,9 +71,10 @@ rootPath = joinDrive "C:" [pathSeparator]
 rootPath = [pathSeparator]
 #endif
 
--- | maps @/bla/bla/bla/foo.bar.xxx@ to @foo.bar@.
-rootName :: AbsolutePath -> String
-rootName = dropExtension . snd . splitFileName . filePath
+-- UNUSED Linag-Ting Chen 2019-07-16
+---- | maps @/bla/bla/bla/foo.bar.xxx@ to @foo.bar@.
+--rootName :: AbsolutePath -> String
+--rootName = dropExtension . snd . splitFileName . filePath
 
 -- | Makes the path absolute.
 --

--- a/src/full/Agda/Utils/Parser/MemoisedCPS.hs
+++ b/src/full/Agda/Utils/Parser/MemoisedCPS.hs
@@ -66,8 +66,8 @@ type Cont k r tok b a = Pos -> a -> M k r tok b [b]
 -- | Memoised values.
 
 data Value k r tok b = Value
-  { results       :: !(IntMap [r])
-  , continuations :: [Cont k r tok b r]
+  { _results       :: !(IntMap [r])
+  , _continuations :: [Cont k r tok b r]
   }
 
 -- | The parser type.


### PR DESCRIPTION
Except record field accessor functions, unused top-level bindings are commented out. 

As for accessor functions, they are prefixed by an underscore `_`. 