### PR TITLE
[ refactor ] Remove unused imports with an empty import list

### DIFF
--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -11,7 +11,7 @@ import Data.IORef
 import System.IO.Unsafe
 
 import Agda.Syntax.Concrete.Name (TopLevelModuleName)
-import Agda.Syntax.Concrete.Pretty ()
+import Agda.Syntax.Concrete.Pretty () --instance only
 import Agda.Syntax.Abstract.Name
 import Agda.Utils.Benchmark (MonadBench(..))
 import qualified Agda.Utils.Benchmark as B

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -52,7 +52,6 @@ import Agda.Utils.Functor
 import Agda.Utils.IndexedList
 import Agda.Utils.Lens
 import Agda.Utils.Monad
-import Agda.Utils.Pretty ()
 
 import Agda.Compiler.ToTreeless
 import Agda.Compiler.Common

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -26,7 +26,7 @@ import Agda.TypeChecking.Telescope
 
 import Agda.Compiler.MAlonzo.Pragmas
 import Agda.Compiler.MAlonzo.Misc
-import Agda.Compiler.MAlonzo.Pretty ()
+import Agda.Compiler.MAlonzo.Pretty () --instance only
 
 import qualified Agda.Utils.Haskell.Syntax as HS
 import Agda.Utils.Except

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -31,7 +31,6 @@ import Agda.Compiler.Treeless.AsPatterns
 import Agda.Compiler.Treeless.Builtin
 import Agda.Compiler.Treeless.Erase
 import Agda.Compiler.Treeless.Identity
-import Agda.Compiler.Treeless.Pretty ()
 import Agda.Compiler.Treeless.Simplify
 import Agda.Compiler.Treeless.Uncase
 import Agda.Compiler.Treeless.Unused

--- a/src/full/Agda/Compiler/Treeless/Builtin.hs
+++ b/src/full/Agda/Compiler/Treeless/Builtin.hs
@@ -26,7 +26,7 @@ import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin
 
-import Agda.Compiler.Treeless.Subst ()
+import Agda.Compiler.Treeless.Subst () --instance only
 import Agda.Utils.Impossible
 
 

--- a/src/full/Agda/Compiler/Treeless/Compare.hs
+++ b/src/full/Agda/Compiler/Treeless/Compare.hs
@@ -2,7 +2,7 @@ module Agda.Compiler.Treeless.Compare (equalTerms) where
 
 import Agda.Syntax.Treeless
 import Agda.TypeChecking.Substitute
-import Agda.Compiler.Treeless.Subst ()
+import Agda.Compiler.Treeless.Subst () --instance only
 
 equalTerms :: TTerm -> TTerm -> Bool
 equalTerms u v =

--- a/src/full/Agda/Compiler/Treeless/EliminateDefaults.hs
+++ b/src/full/Agda/Compiler/Treeless/EliminateDefaults.hs
@@ -10,7 +10,7 @@ import Agda.Syntax.Treeless
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute
 
-import Agda.Compiler.Treeless.Subst ()
+import Agda.Compiler.Treeless.Subst () --instance only
 
 eliminateCaseDefaults :: TTerm -> TCM TTerm
 eliminateCaseDefaults = tr

--- a/src/full/Agda/Compiler/Treeless/Simplify.hs
+++ b/src/full/Agda/Compiler/Treeless/Simplify.hs
@@ -18,7 +18,6 @@ import Agda.Compiler.Treeless.Compare
 
 import Agda.Utils.List
 import Agda.Utils.Maybe
-import Agda.Utils.Pretty ()
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/Compiler/Treeless/Unused.hs
+++ b/src/full/Agda/Compiler/Treeless/Unused.hs
@@ -10,8 +10,7 @@ import Agda.Syntax.Treeless
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute
 
-import Agda.Compiler.Treeless.Subst ()
-import Agda.Compiler.Treeless.Pretty ()
+import Agda.Compiler.Treeless.Pretty () --instance only
 
 import Agda.Utils.Pretty (prettyShow)
 

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -40,7 +40,6 @@ import Agda.Syntax.Position
 import Agda.Syntax.Parser
 import Agda.Syntax.Common
 import Agda.Syntax.Concrete as C
-import Agda.Syntax.Concrete.Pretty ()
 import Agda.Syntax.Abstract as A
 import Agda.Syntax.Abstract.Pretty
 import Agda.Syntax.Info (mkDefInfo)

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -12,7 +12,6 @@ import Agda.Interaction.Response as R
 import Agda.Interaction.Highlighting.JSON
 import Agda.Syntax.Common
 import Agda.TypeChecking.Monad
-import Agda.Utils.Pretty ()
 
 ----------------------------------
 

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -11,8 +11,6 @@ import System.Environment
 import System.Exit
 import System.Console.GetOpt
 
-import Agda.Syntax.Concrete.Pretty ()
-
 import Agda.Interaction.CommandLine
 import Agda.Interaction.Options
 import Agda.Interaction.Options.Help (Help (..))

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -24,19 +24,14 @@ import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Set (Set)
 import Data.Void
-
 import Data.Data (Data)
 import Data.Monoid (mappend)
 
 import Agda.Syntax.Concrete (FieldAssignment'(..), exprFieldA)--, HoleContent'(..))
 import qualified Agda.Syntax.Concrete as C
-import Agda.Syntax.Concrete.Pretty ()
-
 import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Abstract.Name as A (QNamed)
-
 import qualified Agda.Syntax.Internal as I
-
 import Agda.Syntax.Common
 import Agda.Syntax.Info
 import Agda.Syntax.Literal

--- a/src/full/Agda/Syntax/Abstract/Pretty.hs
+++ b/src/full/Agda/Syntax/Abstract/Pretty.hs
@@ -1,7 +1,6 @@
 
 module Agda.Syntax.Abstract.Pretty where
 
-import Agda.Syntax.Concrete.Pretty ()
 import Agda.Syntax.Fixity
 import Agda.Syntax.Translation.AbstractToConcrete
 import Agda.Utils.Pretty

--- a/src/full/Agda/Syntax/Concrete/Attribute.hs
+++ b/src/full/Agda/Syntax/Concrete/Attribute.hs
@@ -13,7 +13,7 @@ import Data.Maybe
 
 import Agda.Syntax.Common
 import Agda.Syntax.Concrete (Expr(..))
-import Agda.Syntax.Concrete.Pretty ()
+import Agda.Syntax.Concrete.Pretty () --instance only
 import Agda.Syntax.Position
 
 import Agda.Utils.Pretty (prettyShow)

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -65,7 +65,7 @@ import qualified Agda.Syntax.Common as Common
 import Agda.Syntax.Position
 import Agda.Syntax.Fixity
 import Agda.Syntax.Notation
-import Agda.Syntax.Concrete.Pretty ()
+import Agda.Syntax.Concrete.Pretty () --instance only
 import Agda.Syntax.Concrete.Fixity
 
 import Agda.Interaction.Options.Warnings

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -32,7 +32,6 @@ import qualified Data.Set as Set
 import Data.Traversable (traverse)
 import qualified Data.Traversable as Trav
 
-import Agda.Syntax.Concrete.Pretty ()
 import Agda.Syntax.Common
 import Agda.Syntax.Concrete hiding (appView)
 import Agda.Syntax.Concrete.Operators.Parser

--- a/src/full/Agda/Syntax/Parser.hs
+++ b/src/full/Agda/Syntax/Parser.hs
@@ -50,7 +50,6 @@ import Agda.Utils.Except
 import Agda.Utils.FileName
 import Agda.Utils.IO.UTF8 (readTextFile)
 import qualified Agda.Utils.Maybe.Strict as Strict
-import Agda.Utils.Pretty ()
 
 ------------------------------------------------------------------------
 -- Wrapping parse results

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -41,7 +41,6 @@ import Agda.Syntax.Parser.Tokens
 import Agda.Syntax.Concrete as C
 import Agda.Syntax.Concrete.Attribute
 import Agda.Syntax.Concrete.Pattern
-import Agda.Syntax.Concrete.Pretty ()
 import Agda.Syntax.Common
 import Agda.Syntax.Fixity
 import Agda.Syntax.Notation

--- a/src/full/Agda/TypeChecking/CompiledClause/Match.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Match.hs
@@ -8,7 +8,6 @@ import Agda.Syntax.Common
 
 import Agda.TypeChecking.CompiledClause
 import Agda.TypeChecking.Monad
-import Agda.TypeChecking.Pretty ()
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Reduce.Monad as RedM
 import Agda.TypeChecking.Substitute

--- a/src/full/Agda/TypeChecking/Coverage/SplitTree.hs
+++ b/src/full/Agda/TypeChecking/Coverage/SplitTree.hs
@@ -18,7 +18,7 @@ import Data.Data (Data)
 
 import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Common
-import Agda.Syntax.Concrete.Pretty ()
+import Agda.Syntax.Concrete.Pretty () --instance only
 import Agda.Syntax.Literal
 import Agda.Syntax.Position
 

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -8,7 +8,7 @@ import Agda.Syntax.Internal.Generic
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Free
 import Agda.TypeChecking.Monad
-import Agda.TypeChecking.Reduce.Monad ()
+import Agda.TypeChecking.Reduce.Monad () --instance only
 import {-# SOURCE #-} Agda.TypeChecking.Records
 import {-# SOURCE #-} Agda.TypeChecking.Datatypes
 import Agda.Utils.Monad

--- a/src/full/Agda/TypeChecking/IApplyConfluence.hs
+++ b/src/full/Agda/TypeChecking/IApplyConfluence.hs
@@ -24,7 +24,6 @@ import Agda.TypeChecking.Telescope.Path
 
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import Agda.Utils.Pretty ()
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -23,7 +23,7 @@ import Agda.Syntax.Internal as I
 import Agda.Syntax.Internal.MetaVars
 import Agda.Syntax.Scope.Base (isNameInScope)
 
-import Agda.TypeChecking.Errors ()
+import Agda.TypeChecking.Errors () --instance only
 import Agda.TypeChecking.Implicit (implicitArgs)
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -10,7 +10,6 @@ import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Reduce
-import Agda.TypeChecking.Reduce.Monad ()
 import Agda.TypeChecking.Monad.Builtin
 
 import Agda.Utils.Maybe ( caseMaybeM, allJustM )

--- a/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
@@ -15,7 +15,6 @@ import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Builtin
 import Agda.TypeChecking.Monad.State
 import Agda.TypeChecking.Positivity.Occurrence
-import Agda.TypeChecking.Substitute ()
 
 import Agda.Utils.Except ( MonadError(catchError) )
 import Agda.Utils.List

--- a/src/full/Agda/TypeChecking/Names.hs
+++ b/src/full/Agda/TypeChecking/Names.hs
@@ -31,7 +31,6 @@ import Data.List
 
 import Agda.Syntax.Common hiding (Nat)
 import Agda.Syntax.Internal
-import Agda.Syntax.Concrete.Pretty ()
 
 import Agda.TypeChecking.Monad hiding (getConstInfo, typeOfConst)
 import Agda.TypeChecking.Monad.Builtin

--- a/src/full/Agda/TypeChecking/Patterns/Internal.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Internal.hs
@@ -18,8 +18,6 @@ import Agda.TypeChecking.Monad.Builtin
 import Agda.TypeChecking.Reduce (reduce)
 import Agda.TypeChecking.Substitute.DeBruijn
 
-import Agda.Utils.Pretty ()
-
 import Agda.Utils.Impossible
 
 -- | Convert a term (from a dot pattern) to a DeBruijn pattern.

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -11,7 +11,7 @@ import Agda.TypeChecking.Monad.Base
 import {-# SOURCE #-} Agda.TypeChecking.Errors
 import Agda.TypeChecking.Monad.MetaVars
 import Agda.TypeChecking.Monad.Options
-import Agda.TypeChecking.Positivity ()
+import Agda.TypeChecking.Positivity () --instance only
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Pretty.Call
 

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -25,7 +25,6 @@ import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Generic (TermLike(..))
 import Agda.Syntax.Internal.MetaVars
 import Agda.Syntax.Literal
-import Agda.Syntax.Concrete.Pretty ()
 import Agda.Syntax.Fixity
 
 import Agda.TypeChecking.Monad hiding (getConstInfo, typeOfConst)

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -23,7 +23,7 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Reduce
-import Agda.TypeChecking.Reduce.Monad ()
+import Agda.TypeChecking.Reduce.Monad () --instance only
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -30,7 +30,7 @@ import Agda.TypeChecking.Substitute
 import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.Monad
-import Agda.Utils.Pretty ()
+import Agda.Utils.Pretty () --instance only
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -45,7 +45,7 @@ import qualified Codec.Compression.GZip as G
 import qualified Agda.TypeChecking.Monad.Benchmark as Bench
 
 import Agda.TypeChecking.Serialise.Base
-import Agda.TypeChecking.Serialise.Instances ()
+import Agda.TypeChecking.Serialise.Instances () --instance only
 
 import Agda.TypeChecking.Monad
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances.hs
@@ -5,11 +5,11 @@ module Agda.TypeChecking.Serialise.Instances () where
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Serialise.Base
-import Agda.TypeChecking.Serialise.Instances.Abstract ()
-import Agda.TypeChecking.Serialise.Instances.Common ()
-import Agda.TypeChecking.Serialise.Instances.Compilers ()
+--import Agda.TypeChecking.Serialise.Instances.Abstract ()
+--import Agda.TypeChecking.Serialise.Instances.Common ()
+--import Agda.TypeChecking.Serialise.Instances.Compilers ()
 import Agda.TypeChecking.Serialise.Instances.Highlighting ()
-import Agda.TypeChecking.Serialise.Instances.Internal ()
+--import Agda.TypeChecking.Serialise.Instances.Internal ()
 import Agda.TypeChecking.Serialise.Instances.Errors ()
 
 instance EmbPrj Interface where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -13,9 +13,7 @@ import Agda.Syntax.Scope.Base
 import Agda.Syntax.Fixity
 
 import Agda.TypeChecking.Serialise.Base
-import Agda.TypeChecking.Serialise.Instances.Common ()
-
-
+import Agda.TypeChecking.Serialise.Instances.Common () --instance only
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -5,9 +5,8 @@ module Agda.TypeChecking.Serialise.Instances.Errors where
 import Control.Monad
 
 import Agda.TypeChecking.Serialise.Base
-import Agda.TypeChecking.Serialise.Instances.Common ()
-import Agda.TypeChecking.Serialise.Instances.Internal ()
-import Agda.TypeChecking.Serialise.Instances.Abstract ()
+import Agda.TypeChecking.Serialise.Instances.Internal () --instance only
+import Agda.TypeChecking.Serialise.Instances.Abstract () --instance only
 
 import Agda.Syntax.Concrete.Definitions (DeclarationWarning(..))
 import Agda.TypeChecking.Monad.Base

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
@@ -6,7 +6,7 @@ import qualified Agda.Interaction.Highlighting.Range   as HR
 import qualified Agda.Interaction.Highlighting.Precise as HP
 
 import Agda.TypeChecking.Serialise.Base
-import Agda.TypeChecking.Serialise.Instances.Common ()
+import Agda.TypeChecking.Serialise.Instances.Common () --instance only
 
 instance EmbPrj HR.Range where
   icod_ (HR.Range a b) = icodeN' HR.Range a b

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -7,8 +7,7 @@ import Agda.Syntax.Internal as I
 import Agda.Syntax.Position as P
 
 import Agda.TypeChecking.Serialise.Base
-import Agda.TypeChecking.Serialise.Instances.Common ()
-import Agda.TypeChecking.Serialise.Instances.Compilers ()
+import Agda.TypeChecking.Serialise.Instances.Compilers () --instance only
 
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.CompiledClause

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -25,9 +25,9 @@ import Control.Monad
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 
-import {-# SOURCE #-} Agda.TypeChecking.Constraints ()
+import {-# SOURCE #-} Agda.TypeChecking.Constraints () -- instance only
 import {-# SOURCE #-} Agda.TypeChecking.Conversion
-import {-# SOURCE #-} Agda.TypeChecking.MetaVars ()
+import {-# SOURCE #-} Agda.TypeChecking.MetaVars () -- instance only
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Constraints (addConstraint, MonadConstraint)

--- a/src/full/Agda/Utils/Bag.hs
+++ b/src/full/Agda/Utils/Bag.hs
@@ -5,17 +5,13 @@ module Agda.Utils.Bag where
 
 import Prelude hiding (null, map)
 
-
-import Text.Show.Functions ()
+import Text.Show.Functions () -- instance only
 
 import Data.Foldable (Foldable(foldMap))
-
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Semigroup
-
-
 
 import Agda.Utils.Functor
 

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -11,8 +11,6 @@ import Data.Maybe
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
-import Text.Show.Functions ()
-
 import qualified Agda.Utils.Bag as Bag
 
 import Agda.Utils.Tuple


### PR DESCRIPTION
Any import with an empty import list now has a comment `--instance only` if it is the case. Otherwise, they are removed. 