### PR TITLE
[ refactor ] Replace Queue from Edison by Sequence

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -167,7 +167,6 @@ library
                 , data-hash >= 0.2.0.0 && < 0.3
                 , deepseq >= 1.4.2.0 && < 1.5
                 , directory >= 1.2.6.2 && < 1.4
-                , EdisonCore >= 1.3.1.1 && < 1.4
                 , edit-distance >= 0.2.1.2 && < 0.3
                 , equivalence >= 0.3.2 && < 0.4
                 -- exceptions-0.8 instead of 0.10 because of stack


### PR DESCRIPTION
Following @UlfNorell's advice in #3725, I am replacing queues provided by `EdisonCore` with finger trees provided by `containers` and removing `EdisonCore` from the package dependency.

P.S. It is intriguing that Agda has its own graph module. Isn't Erwig's [fgl](https://github.com/haskell/fgl) sufficient? Disclaimer: I didn't really check. 