### PR TITLE
[ fix #3879 ] Resugar fewer pattern synonyms

### DIFF
--- a/test/interaction/Issue3879.agda
+++ b/test/interaction/Issue3879.agda
@@ -1,0 +1,11 @@
+module Issue3879 where
+
+open import Issue3879.Fin    using (Fin ; zero ; suc)
+open import Agda.Builtin.Nat using (Nat ; zero ; suc)
+
+foo : Nat → Nat → Nat
+foo zero m = {!!}
+foo (suc n) m = {!!}
+
+-- WAS: case-splitting on m produces Issue3879.Fin.0F patterns
+-- WANT: unqualified 0F is not in scope: do not resugar!

--- a/test/interaction/Issue3879.in
+++ b/test/interaction/Issue3879.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 0 cmd_make_case "m"

--- a/test/interaction/Issue3879.out
+++ b/test/interaction/Issue3879.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : Nat ?1 : Nat " nil)
+((last . 1) . (agda2-goals-action '(0 1)))
+((last . 2) . (agda2-make-case-action '("foo zero zero = ?" "foo zero (suc m) = ?")))
+((last . 1) . (agda2-goals-action '(0 1)))

--- a/test/interaction/Issue3879/Fin.agda
+++ b/test/interaction/Issue3879/Fin.agda
@@ -1,0 +1,9 @@
+module Issue3879.Fin where
+
+open import Agda.Builtin.Nat
+
+data Fin : Nat → Set where
+  zero : ∀ {n} → Fin (suc n)
+  suc  : ∀ {n} → Fin n → Fin (suc n)
+
+pattern 0F = zero


### PR DESCRIPTION
Only resugar pattern synonyms with an unqualified concrete name in
scope.