### PR TITLE
Documentation: Agda is available from Debian stable

### DIFF
--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -76,7 +76,7 @@ However, due to significant packaging bugs [such as this](https://bugs.archlinux
 Debian / Ubuntu
 ---------------
 
-Prebuilt packages are available for Debian testing/unstable and Ubuntu from Karmic onwards. To install:
+Prebuilt packages are available for Debian and Ubuntu from Karmic onwards. To install:
 
 .. code-block:: bash
 
@@ -84,7 +84,7 @@ Prebuilt packages are available for Debian testing/unstable and Ubuntu from Karm
 
 This should install Agda and the Emacs mode.
 
-The standard library is available in Debian testing/unstable and Ubuntu from Lucid onwards. To install:
+The standard library is available in Debian and Ubuntu from Lucid onwards. To install:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Agda has been available as an official Debian package at least for a few years now. This patch removing the "testing/unstable" remark in the Getting Started part of the documentation in a reference to Debian.