### PR TITLE
[ fix #3932 ] Add loneSig checkpoint

### DIFF
--- a/test/Fail/Issue3932-2.agda
+++ b/test/Fail/Issue3932-2.agda
@@ -1,0 +1,7 @@
+data Unit : Set where
+  tt : Unit
+
+f : Unit
+
+mutual
+  f = tt

--- a/test/Fail/Issue3932-2.err
+++ b/test/Fail/Issue3932-2.err
@@ -1,0 +1,8 @@
+Issue3932-2.agda:4,1-2
+The following names are declared but not accompanied by a
+definition: f
+Issue3932-2.agda:7,3-4
+Multiple definitions of f. Previous definition at
+Issue3932-2.agda:4,1-2
+when scope checking the declaration
+  f : _

--- a/test/Succeed/lonesig.agda
+++ b/test/Succeed/lonesig.agda
@@ -1,0 +1,13 @@
+f : Set → Set
+
+module _ (A : Set) where
+
+  mutual
+
+    g : Set
+    g = h
+
+    h : Set
+    h = A
+
+f = g


### PR DESCRIPTION
If we leave some of the `loneSigs` in the state before calling `mkOldMutual`,
we run the risk of attaching isolated definitions to the wrong toplevel declaration!