### PR TITLE
[ fix #2610 ] Build directory for version specific agdai files

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -489,6 +489,7 @@ library
                     Agda.TypeChecking.Warnings
                     Agda.TypeChecking.With
                     Agda.Utils.AffineHole
+                    Agda.Utils.Applicative
                     Agda.Utils.AssocList
                     Agda.Utils.Bag
                     Agda.Utils.Benchmark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Installation and infrastructure
 
 * Removed support for GHC 7.10.3.
 
+* Interface files are now written in directory _build/VERSION/agda/ at
+  the project root (the closest enclosing directory where an .agda-lib
+  file is present). If there is no project root then the interface file
+  is written alongside the module it corresponds to.
+
 API
 ----
 * Removed module `Agda.Utils.HashMap`. It only re-exported `Data.HashMap.Strict`

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -227,7 +227,7 @@ compilerMain backend isMain0 i = inCompilerEnv i $ do
 
 compileModule :: Backend' opts env menv mod def -> env -> IsMain -> Interface -> TCM mod
 compileModule backend env isMain i = do
-  ifile <- maybe __IMPOSSIBLE__ filePath <$>
+  ifile <- maybe __IMPOSSIBLE__ (filePath . intFilePath) <$>
             (findInterfaceFile . toTopLevelModuleName =<< curMName)
   r <- preModule backend env isMain (iModuleName i) ifile
   case r of

--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -145,7 +145,7 @@ inCompilerEnv mainI cont = do
       Nothing  -> do
         -- The default output directory is the project root.
         let tm = toTopLevelModuleName $ iModuleName mainI
-        f <- findFile tm
+        f <- srcFilePath <$> findFile tm
         return $ filePath $ C.projectRoot f tm
     setCommandLineOptions $
       opts { optCompileDir = Just compileDir }

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -7,10 +7,11 @@
 ------------------------------------------------------------------------
 
 module Agda.Interaction.FindFile
-  ( toIFile
+  ( SourceFile(..), InterfaceFile(intFilePath)
+  , toIFile, mkInterfaceFile
   , FindError(..), findErrorToTypeError
   , findFile, findFile', findFile''
-  , findInterfaceFile
+  , findInterfaceFile', findInterfaceFile
   , checkModuleName
   , moduleName
   , rootNameModule
@@ -26,6 +27,8 @@ import Data.Maybe (catMaybes)
 import qualified Data.Map as Map
 import System.FilePath
 
+import Agda.Interaction.Library ( findProjectRoot )
+
 import Agda.Syntax.Concrete
 import Agda.Syntax.Parser
 import Agda.Syntax.Parser.Literate (literateExtsShortList)
@@ -37,17 +40,45 @@ import qualified Agda.TypeChecking.Monad.Benchmark as Bench
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Options (getIncludeDirs)
 import Agda.TypeChecking.Warnings (runPM)
 
+import Agda.Utils.Applicative ( (?$>) )
 import Agda.Utils.Except
 import Agda.Utils.FileName
 import Agda.Utils.List ( stripSuffix )
-
 import Agda.Utils.Impossible
+import Agda.Version ( version )
+
+-- | Type aliases for source files and interface files.
+--   We may only produce one of these if we know for sure that the file
+--   does exist. We can always output an @AbsolutePath@ if we are not sure.
+
+-- TODO: do not export @SourceFile@ and force users to check the
+-- @AbsolutePath@ does exist.
+newtype SourceFile    = SourceFile    { srcFilePath :: AbsolutePath } deriving (Eq)
+newtype InterfaceFile = InterfaceFile { intFilePath :: AbsolutePath }
+
+-- | Makes an interface file from an AbsolutePath candidate.
+--   If the file does not exist, then fail by returning @Nothing@.
+
+mkInterfaceFile
+  :: AbsolutePath             -- ^ Path to the candidate interface file
+  -> IO (Maybe InterfaceFile) -- ^ Interface file iff it exists
+mkInterfaceFile fp = do
+  ex <- doesFileExistCaseSensitive $ filePath fp
+  pure (ex ?$> InterfaceFile fp)
 
 -- | Converts an Agda file name to the corresponding interface file
--- name.
+--   name. Note that we do not guarantee that the file exists.
 
-toIFile :: AbsolutePath -> AbsolutePath
-toIFile = replaceModuleExtension ".agdai"
+toIFile :: SourceFile -> IO AbsolutePath
+toIFile (SourceFile src) = do
+  let fp = filePath src
+  mroot <- findProjectRoot (takeDirectory fp)
+  pure $ replaceModuleExtension ".agdai" $ case mroot of
+    Nothing   -> src
+    Just root ->
+      let buildDir = root </> "_build" </> version
+          fileName = makeRelative root fp
+      in mkAbsolute $ buildDir </> fileName
 
 replaceModuleExtension :: String -> AbsolutePath -> AbsolutePath
 replaceModuleExtension ext@('.':_) = mkAbsolute . (++ ext) .  dropAgdaExtension . filePath
@@ -58,10 +89,10 @@ replaceModuleExtension ext = replaceModuleExtension ('.':ext)
 -- Invariant: All paths are absolute.
 
 data FindError
-  = NotFound [AbsolutePath]
+  = NotFound [SourceFile]
     -- ^ The file was not found. It should have had one of the given
     -- file names.
-  | Ambiguous [AbsolutePath]
+  | Ambiguous [SourceFile]
     -- ^ Several matching files were found.
     --
     -- Invariant: The list of matching files has at least two
@@ -71,16 +102,16 @@ data FindError
 -- converts a 'FindError' to a 'TypeError'.
 
 findErrorToTypeError :: TopLevelModuleName -> FindError -> TypeError
-findErrorToTypeError m (NotFound  files) = FileNotFound m files
+findErrorToTypeError m (NotFound  files) = FileNotFound m (map srcFilePath files)
 findErrorToTypeError m (Ambiguous files) =
-  AmbiguousTopLevelModuleName m files
+  AmbiguousTopLevelModuleName m (map srcFilePath files)
 
 -- | Finds the source file corresponding to a given top-level module
 -- name. The returned paths are absolute.
 --
 -- Raises an error if the file cannot be found.
 
-findFile :: TopLevelModuleName -> TCM AbsolutePath
+findFile :: TopLevelModuleName -> TCM SourceFile
 findFile m = do
   mf <- findFile' m
   case mf of
@@ -91,7 +122,7 @@ findFile m = do
 --   module name. The returned paths are absolute.
 --
 --   SIDE EFFECT:  Updates 'stModuleToSource'.
-findFile' :: TopLevelModuleName -> TCM (Either FindError AbsolutePath)
+findFile' :: TopLevelModuleName -> TCM (Either FindError SourceFile)
 findFile' m = do
     dirs         <- getIncludeDirs
     modFile      <- useTC stModuleToSource
@@ -107,38 +138,45 @@ findFile''
   -> TopLevelModuleName
   -> ModuleToSource
   -- ^ Cached invocations of 'findFile'''. An updated copy is returned.
-  -> IO (Either FindError AbsolutePath, ModuleToSource)
+  -> IO (Either FindError SourceFile, ModuleToSource)
 findFile'' dirs m modFile =
   case Map.lookup m modFile of
-    Just f  -> return (Right f, modFile)
+    Just f  -> return (Right (SourceFile f), modFile)
     Nothing -> do
-      files <- fileList acceptableFileExts
+      files          <- fileList acceptableFileExts
       filesShortList <- fileList parseFileExtsShortList
-      existingFiles <-
-        liftIO $ filterM (doesFileExistCaseSensitive . filePath) files
+      existingFiles  <-
+        liftIO $ filterM (doesFileExistCaseSensitive . filePath . srcFilePath) files
       return $ case List.nub existingFiles of
         []     -> (Left (NotFound filesShortList), modFile)
-        [file] -> (Right file, Map.insert m file modFile)
+        [file] -> (Right file, Map.insert m (srcFilePath file) modFile)
         files  -> (Left (Ambiguous existingFiles), modFile)
   where
-    fileList exts = mapM absolute
+    fileList exts = mapM (fmap SourceFile . absolute)
                     [ filePath dir </> file
                     | dir  <- dirs
                     , file <- map (moduleNameToFileName m) exts
                     ]
 
 -- | Finds the interface file corresponding to a given top-level
--- module name. The returned paths are absolute.
+-- module file. The returned paths are absolute.
+--
+-- Raises 'Nothing' if the the interface file cannot be found.
+
+findInterfaceFile'
+  :: SourceFile                 -- ^ Path to the source file
+  -> TCM (Maybe InterfaceFile)  -- ^ Maybe path to the interface file
+findInterfaceFile' fp = liftIO $ mkInterfaceFile =<< toIFile fp
+
+-- | Finds the interface file corresponding to a given top-level
+-- module file. The returned paths are absolute.
 --
 -- Raises an error if the source file cannot be found, and returns
 -- 'Nothing' if the source file can be found but not the interface
 -- file.
 
-findInterfaceFile :: TopLevelModuleName -> TCM (Maybe AbsolutePath)
-findInterfaceFile m = do
-  f  <- toIFile <$> findFile m
-  ex <- liftIO $ doesFileExistCaseSensitive $ filePath f
-  return $ if ex then Just f else Nothing
+findInterfaceFile :: TopLevelModuleName -> TCM (Maybe InterfaceFile)
+findInterfaceFile m = findInterfaceFile' =<< findFile m
 
 -- | Ensures that the module name matches the file name. The file
 -- corresponding to the module name (according to the include path)
@@ -147,23 +185,24 @@ findInterfaceFile m = do
 checkModuleName
   :: TopLevelModuleName
      -- ^ The name of the module.
-  -> AbsolutePath
+  -> SourceFile
      -- ^ The file from which it was loaded.
   -> Maybe TopLevelModuleName
      -- ^ The expected name, coming from an import statement.
   -> TCM ()
-checkModuleName name file mexpected =
+checkModuleName name (SourceFile file) mexpected =
   findFile' name >>= \case
 
     Left (NotFound files)  -> typeError $
       case mexpected of
-        Nothing       -> ModuleNameDoesntMatchFileName name files
+        Nothing -> ModuleNameDoesntMatchFileName name (map srcFilePath files)
         Just expected -> ModuleNameUnexpected name expected
 
     Left (Ambiguous files) -> typeError $
-      AmbiguousTopLevelModuleName name files
+      AmbiguousTopLevelModuleName name (map srcFilePath files)
 
-    Right file' -> do
+    Right src -> do
+      let file' = srcFilePath src
       file <- liftIO $ absolute (filePath file)
       if file === file' then
         return ()

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -76,7 +76,7 @@ toIFile (SourceFile src) = do
   pure $ replaceModuleExtension ".agdai" $ case mroot of
     Nothing   -> src
     Just root ->
-      let buildDir = root </> "_build" </> version
+      let buildDir = root </> "_build" </> version </> "agda"
           fileName = makeRelative root fp
       in mkAbsolute $ buildDir </> fileName
 

--- a/src/full/Agda/Interaction/Highlighting/LaTeX.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX.hs
@@ -612,7 +612,7 @@ generateLaTeX i = do
   dir <- case O.optGHCiInteraction options of
     False -> return $ O.optLaTeXDir options
     True  -> do
-      sourceFile <- Find.findFile mod
+      sourceFile <- Find.srcFilePath <$> Find.findFile mod
       return $ filePath (projectRoot sourceFile mod)
                  </> O.optLaTeXDir options
   liftIO $ createDirectoryIfMissing True dir
@@ -632,7 +632,7 @@ generateLaTeX i = do
       liftIO $ copyFile styFile (dir </> defaultStyFile)
 
   let outPath = modToFile mod
-  inAbsPath <- liftM filePath (Find.findFile mod)
+  inAbsPath <- liftM filePath (Find.srcFilePath <$> Find.findFile mod)
 
   liftIO $ do
     latex <- E.encodeUtf8 `fmap`

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -49,15 +49,14 @@ import qualified Agda.TypeChecking.Monad.Benchmark as Bench
 
 import Agda.TheTypeChecker
 
-import Agda.Interaction.FindFile
-import {-# SOURCE #-} Agda.Interaction.EmacsTop (showGoals)
 import Agda.Interaction.BasicOps (getGoals)
+import {-# SOURCE #-} Agda.Interaction.EmacsTop (showGoals)
+import Agda.Interaction.FindFile
+import Agda.Interaction.Highlighting.Generate
+import Agda.Interaction.Highlighting.Precise  ( compress )
+import Agda.Interaction.Highlighting.Vim
 import Agda.Interaction.Options
 import qualified Agda.Interaction.Options.Lenses as Lens
-import Agda.Interaction.Highlighting.Precise
-  (compress)
-import Agda.Interaction.Highlighting.Generate
-import Agda.Interaction.Highlighting.Vim
 import Agda.Interaction.Response
   (RemoveTokenBasedHighlighting(KeepHighlighting))
 
@@ -86,8 +85,8 @@ data SourceInfo = SourceInfo
 
 -- | Computes a 'SourceInfo' record for the given file.
 
-sourceInfo :: AbsolutePath -> TCM SourceInfo
-sourceInfo f = Bench.billTo [Bench.Parsing] $ do
+sourceInfo :: SourceFile -> TCM SourceInfo
+sourceInfo (SourceFile f) = Bench.billTo [Bench.Parsing] $ do
   source                <- runPM $ readFilePM f
   (parsedMod, fileType) <- runPM $
                            parseFile moduleParser f $ T.unpack source
@@ -265,7 +264,7 @@ alreadyVisited x isMain currentOptions getIface = do
 --   complete interface is returned.
 
 typeCheckMain
-  :: AbsolutePath
+  :: SourceFile
      -- ^ The path to the file.
   -> Mode
      -- ^ Should the file be type-checked, or only scope-checked?
@@ -288,7 +287,7 @@ typeCheckMain f mode si = do
     -- We don't want to generate highlighting information for Agda.Primitive.
     withHighlightingLevel None $ withoutOptionsChecking $
       forM_ (Set.map (libdirPrim </>) Lens.primitiveModules) $ \f -> do
-        let file = mkAbsolute f
+        let file = SourceFile $ mkAbsolute f
         si <- sourceInfo file
         checkModuleName' (siModuleName si) file
         _ <- getInterface_ (siModuleName si) (Just si)
@@ -373,16 +372,18 @@ getInterface' x isMain msi =
 
       uptodate <- Bench.billTo [Bench.Import] $ do
         ignore <- (ignoreInterfaces `and2M`
-                    (not <$> Lens.isBuiltinModule (filePath file)))
+                    (not <$> Lens.isBuiltinModule (filePath $ srcFilePath file)))
                   `or2M` ignoreAllInterfaces
         cached <- runMaybeT $ isCached x file
           -- If it's cached ignoreInterfaces has no effect;
           -- to avoid typechecking a file more than once.
         sourceH <- case msi of
-                     Nothing -> liftIO $ hashTextFile file
+                     Nothing -> liftIO $ hashTextFile (srcFilePath file)
                      Just si -> return $ hashText (siSource si)
         ifaceH  <- case cached of
-            Nothing -> fmap fst <$> getInterfaceFileHashes (filePath $ toIFile file)
+            Nothing -> do
+              mifile <- liftIO $ toIFile file
+              fmap fst <$> getInterfaceFileHashes mifile
             Just i  -> return $ Just $ iSourceHash i
         let unchanged = Just sourceH == ifaceH
         return $ unchanged && (not ignore || isJust cached)
@@ -408,7 +409,7 @@ getInterface' x isMain msi =
       unless (topLevelName == x) $
         -- Andreas, 2014-03-27 This check is now done in the scope checker.
         -- checkModuleName topLevelName file
-        typeError $ OverlappingProjects file topLevelName x
+        typeError $ OverlappingProjects (srcFilePath file) topLevelName x
 
       visited <- isVisited x
       reportSLn "import.iface" 5 $ if visited then "  We've been here. Don't merge."
@@ -472,21 +473,18 @@ checkOptionsCompatible current imported importedModule = flip execStateT True $ 
 isCached
   :: C.TopLevelModuleName
      -- ^ Module name of file we process.
-  -> AbsolutePath
+  -> SourceFile
      -- ^ File we process.
   -> MaybeT TCM Interface
 
 isCached x file = do
-  let ifile = filePath $ toIFile file
-
-  -- Make sure the file exists in the case sensitive spelling.
-  guardM $ liftIO $ doesFileExistCaseSensitive ifile
+  ifile <- MaybeT $ findInterfaceFile' file
 
   -- Check that we have cached the module.
   mi <- MaybeT $ getDecodedModule x
 
   -- Check that the interface file exists and return its hash.
-  h  <- MaybeT $ fmap snd <$> getInterfaceFileHashes ifile
+  h  <- MaybeT $ fmap snd <$> getInterfaceFileHashes' ifile
 
   -- Make sure the hashes match.
   guard $ iFullHash mi == h
@@ -498,7 +496,7 @@ isCached x file = do
 getStoredInterface
   :: C.TopLevelModuleName
      -- ^ Module name of file we process.
-  -> AbsolutePath
+  -> SourceFile
      -- ^ File we process.
   -> MainInterface
   -> Maybe SourceInfo
@@ -506,6 +504,7 @@ getStoredInterface
   -> TCM (Bool, (Interface, MaybeWarnings))
      -- ^ @Bool@ is: do we have to merge the interface?
 getStoredInterface x file isMain msi = do
+  let fp = filePath $ srcFilePath file
   -- If something goes wrong (interface outdated etc.)
   -- we revert to fresh type checking.
   let fallback = typeCheck x file isMain msi
@@ -513,7 +512,8 @@ getStoredInterface x file isMain msi = do
   -- Examine the hash of the interface file. If it is different from the
   -- stored version (in stDecodedModules), or if there is no stored version,
   -- read and decode it. Otherwise use the stored version.
-  let ifile = filePath $ toIFile file
+  ifile <- liftIO $ toIFile file
+  let ifp = filePath ifile
   h <- fmap snd <$> getInterfaceFileHashes ifile
   mm <- getDecodedModule x
   (cached, mi) <- Bench.billTo [Bench.Deserialization] $ case mm of
@@ -523,13 +523,13 @@ getStoredInterface x file isMain msi = do
         dropDecodedModule x
         reportSLn "import.iface" 50 $ "  cached hash = " ++ show (iFullHash mi)
         reportSLn "import.iface" 50 $ "  stored hash = " ++ show h
-        reportSLn "import.iface" 5 $ "  file is newer, re-reading " ++ ifile
+        reportSLn "import.iface" 5 $ "  file is newer, re-reading " ++ ifp
         (False,) <$> readInterface ifile
       else do
-        reportSLn "import.iface" 5 $ "  using stored version of " ++ ifile
+        reportSLn "import.iface" 5 $ "  using stored version of " ++ ifp
         return (True, Just mi)
     Nothing -> do
-      reportSLn "import.iface" 5 $ "  no stored version, reading " ++ ifile
+      reportSLn "import.iface" 5 $ "  no stored version, reading " ++ ifp
       (False,) <$> readInterface ifile
 
   -- Check that it's the right version
@@ -549,14 +549,19 @@ getStoredInterface x file isMain msi = do
       -- Check that options that matter haven't changed compared to
       -- current options (issue #2487)
       optionsChanged <-ifM ((not <$> asksTC envCheckOptionConsistency) `or2M`
-                            Lens.isBuiltinModule (filePath file))
+                            Lens.isBuiltinModule fp)
                        {-then-} (return False) {-else-} $ do
         currentOptions <- useTC stPragmaOptions
         let disagreements =
               [ optName | (opt, optName) <- restartOptions,
                           opt currentOptions /= opt (iOptionsUsed i) ]
         if null disagreements then return False else do
-          reportSLn "import.iface.options" 4 $ "  Changes in the following options in " ++ prettyShow (filePath file) ++ ", re-typechecking: "  ++ prettyShow disagreements
+          reportSLn "import.iface.options" 4 $ concat
+            [ "  Changes in the following options in "
+            , prettyShow fp
+            , ", re-typechecking: "
+            , prettyShow disagreements
+            ]
           return True
 
       if optionsChanged then fallback else do
@@ -568,9 +573,9 @@ getStoredInterface x file isMain msi = do
           then fallback
           else do
             unless cached $ do
-              chaseMsg "Loading " x $ Just ifile
+              chaseMsg "Loading " x $ Just ifp
               -- print imported warnings
-              let ws = filter ((Strict.Just file ==) . tcWarningOrigin) (iWarnings i)
+              let ws = filter ((Strict.Just (srcFilePath file) ==) . tcWarningOrigin) (iWarnings i)
               unless (null ws) $ reportSDoc "warning" 1 $ P.vcat $ P.prettyTCM <$> ws
 
             return (False, (i, NoWarnings))
@@ -585,7 +590,7 @@ getStoredInterface x file isMain msi = do
 typeCheck
   :: C.TopLevelModuleName
      -- ^ Module name of file we process.
-  -> AbsolutePath
+  -> SourceFile
      -- ^ File we process.
   -> MainInterface
   -> Maybe SourceInfo
@@ -593,15 +598,16 @@ typeCheck
   -> TCM (Bool, (Interface, MaybeWarnings))
      -- ^ @Bool@ is: do we have to merge the interface?
 typeCheck x file isMain msi = do
+  let fp = filePath $ srcFilePath file
   unless (includeStateChanges isMain) cleanCachedLog
   let checkMsg = case isMain of
                    MainInterface ScopeCheck -> "Reading "
                    _                        -> "Checking"
       withMsgs = bracket_
-       (chaseMsg checkMsg x $ Just $ filePath file)
+       (chaseMsg checkMsg x $ Just fp)
        (const $ do ws <- getAllWarnings AllWarnings
                    let classified = classifyWarnings ws
-                   let wa' = filter ((Strict.Just file ==) . tcWarningOrigin) (tcWarnings classified)
+                   let wa' = filter ((Strict.Just (srcFilePath file) ==) . tcWarningOrigin) (tcWarnings classified)
                    unless (null wa') $
                      reportSDoc "warning" 1 $ P.vcat $ P.prettyTCM <$> wa'
                    when (null (nonFatalErrors classified)) $ chaseMsg "Finished" x Nothing)
@@ -698,19 +704,27 @@ chaseMsg kind x file = do
 
 highlightFromInterface
   :: Interface
-  -> AbsolutePath
+  -> SourceFile
      -- ^ The corresponding file.
   -> TCM ()
 highlightFromInterface i file = do
   reportSLn "import.iface" 5 $
-    "Generating syntax info for " ++ filePath file ++
+    "Generating syntax info for " ++ filePath (srcFilePath file) ++
     " (read from interface)."
   printHighlightingInfo KeepHighlighting (iHighlighting i)
 
-readInterface :: FilePath -> TCM (Maybe Interface)
-readInterface file = do
+-- | Read interface file corresponding to a module.
+
+readInterface :: AbsolutePath -> TCM (Maybe Interface)
+readInterface file = runMaybeT $ do
+  ifile <- MaybeT $ liftIO $ mkInterfaceFile file
+  MaybeT $ readInterface' ifile
+
+readInterface' :: InterfaceFile -> TCM (Maybe Interface)
+readInterface' file = do
+    let ifp = filePath $ intFilePath file
     -- Decode the interface file
-    (s, close) <- liftIO $ readBinaryFile' file
+    (s, close) <- liftIO $ readBinaryFile' ifp
     do  mi <- liftIO . E.evaluate =<< decodeInterface s
 
         -- Close the file. Note
@@ -736,9 +750,10 @@ readInterface file = do
 
 -- | Writes the given interface to the given file.
 
-writeInterface :: FilePath -> Interface -> TCM ()
-writeInterface file i = do
-    reportSLn "import.iface.write" 5  $ "Writing interface file " ++ file ++ "."
+writeInterface :: AbsolutePath -> Interface -> TCM ()
+writeInterface file i = let fp = filePath file in do
+    reportSLn "import.iface.write" 5  $
+      "Writing interface file " ++ fp ++ "."
     -- Andreas, 2015-07-13
     -- After QName memoization (AIM XXI), scope serialization might be cheap enough.
     -- -- Andreas, Makoto, 2014-10-18 AIM XX:
@@ -750,14 +765,14 @@ writeInterface file i = do
     -- i <- return $
     --   i { iInsideScope  = removePrivates $ iInsideScope i
     --     }
-    encodeFile file i
+    encodeFile fp i
     reportSLn "import.iface.write" 5 "Wrote interface file."
     reportSLn "import.iface.write" 50 $ "  hash = " ++ show (iFullHash i)
   `catchError` \e -> do
     reportSLn "" 1 $
-      "Failed to write interface " ++ file ++ "."
+      "Failed to write interface " ++ fp ++ "."
     liftIO $
-      whenM (doesFileExist file) $ removeFile file
+      whenM (doesFileExist fp) $ removeFile fp
     throwError e
 
 removePrivates :: ScopeInfo -> ScopeInfo
@@ -779,14 +794,14 @@ concreteOptionsToOptionPragmas p = do
 -- information.
 
 createInterface
-  :: AbsolutePath          -- ^ The file to type check.
+  :: SourceFile            -- ^ The file to type check.
   -> C.TopLevelModuleName  -- ^ The expected module name.
   -> MainInterface         -- ^ Are we dealing with the main module?
   -> Maybe SourceInfo      -- ^ Optional information about the source code.
   -> TCM (Interface, MaybeWarnings)
 createInterface file mname isMain msi =
   Bench.billTo [Bench.TopModule mname] $
-  localTC (\e -> e { envCurrentPath = Just file }) $ do
+  localTC (\e -> e { envCurrentPath = Just (srcFilePath file) }) $ do
 
     reportSLn "import.iface.create" 5 $
       "Creating interface for " ++ prettyShow mname ++ "."
@@ -805,7 +820,7 @@ createInterface file mname isMain msi =
     modFile       <- useTC stModuleToSource
     fileTokenInfo <- Bench.billTo [Bench.Highlighting] $
                        generateTokenInfoFromSource
-                         file (T.unpack source)
+                         (srcFilePath file) (T.unpack source)
     stTokens `setTCLens` fileTokenInfo
 
     options <- concreteOptionsToOptionPragmas pragmas
@@ -815,7 +830,7 @@ createInterface file mname isMain msi =
     -- Scope checking.
     reportSLn "import.iface.create" 7 "Starting scope checking."
     topLevel <- Bench.billTo [Bench.Scoping] $
-      concreteToAbstract_ (TopLevel file mname top)
+      concreteToAbstract_ (TopLevel (srcFilePath file) mname top)
     reportSLn "import.iface.create" 7 "Finished scope checking."
 
     let ds    = topLevelDecls topLevel
@@ -898,7 +913,7 @@ createInterface file mname isMain msi =
 
       whenM (optGenerateVimFile <$> commandLineOptions) $
         -- Generate Vim file.
-        withScope_ scope $ generateVimFile $ filePath file
+        withScope_ scope $ generateVimFile $ filePath $ srcFilePath $ file
     reportSLn "import.iface.create" 7 "Finished highlighting from type info."
 
     setScope scope
@@ -967,7 +982,7 @@ createInterface file mname isMain msi =
         reportSLn "import.iface.create" 7 "Actually calling writeInterface."
         -- The file was successfully type-checked (and no warnings were
         -- encountered), so the interface should be written out.
-        let ifile = filePath $ toIFile file
+        ifile <- liftIO $ toIFile file
         writeInterface ifile i
     reportSLn "import.iface.create" 7 "Finished (or skipped) writing to interface file."
 
@@ -1135,14 +1150,20 @@ buildInterface source fileType topLevel pragmas = do
     return i
 
 -- | Returns (iSourceHash, iFullHash)
-getInterfaceFileHashes :: FilePath -> TCM (Maybe (Hash, Hash))
-getInterfaceFileHashes ifile = do
-  exist <- liftIO $ doesFileExist ifile
-  if not exist then return Nothing else do
-    (s, close) <- liftIO $ readBinaryFile' ifile
-    let hs = decodeHashes s
-    liftIO $ maybe 0 (uncurry (+)) hs `seq` close
-    return hs
+--   We do not need to check that the file exist because we only
+--   accept @InterfaceFile@ as an input and not arbitrary @AbsolutePath@!
+getInterfaceFileHashes :: AbsolutePath -> TCM (Maybe (Hash, Hash))
+getInterfaceFileHashes fp = runMaybeT $ do
+  mifile <- MaybeT $ liftIO $ mkInterfaceFile fp
+  MaybeT $ getInterfaceFileHashes' mifile
+
+getInterfaceFileHashes' :: InterfaceFile -> TCM (Maybe (Hash, Hash))
+getInterfaceFileHashes' fp = do
+  let ifile = filePath $ intFilePath fp
+  (s, close) <- liftIO $ readBinaryFile' ifile
+  let hs = decodeHashes s
+  liftIO $ maybe 0 (uncurry (+)) hs `seq` close
+  return hs
 
 moduleHash :: ModuleName -> TCM Hash
 moduleHash m = iFullHash <$> getInterface m

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -18,6 +18,7 @@ import Agda.Interaction.Monad
 import Agda.Interaction.EmacsTop (mimicGHCi)
 import Agda.Interaction.JSONTop (jsonREPL)
 import Agda.Interaction.Imports (MaybeWarnings'(..))
+import Agda.Interaction.FindFile ( SourceFile(SourceFile) )
 import qualified Agda.Interaction.Imports as Imp
 import qualified Agda.Interaction.Highlighting.Dot as Dot
 import qualified Agda.Interaction.Highlighting.LaTeX as LaTeX
@@ -128,7 +129,7 @@ runAgdaWithOptions backends generateHTML interaction progName opts
                      then Imp.ScopeCheck
                      else Imp.TypeCheck
 
-          file    <- getInputFile
+          file    <- SourceFile <$> getInputFile
           (i, mw) <- Imp.typeCheckMain file mode =<< Imp.sourceInfo file
 
           -- An interface is only generated if the mode is

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -71,7 +71,7 @@ import Agda.TypeChecking.Patterns.Abstract (expandPatternSynonyms)
 import Agda.TypeChecking.Pretty hiding (pretty, prettyA)
 import Agda.TypeChecking.Warnings
 
-import Agda.Interaction.FindFile (checkModuleName, rootNameModule)
+import Agda.Interaction.FindFile (checkModuleName, rootNameModule, SourceFile(SourceFile))
 -- import Agda.Interaction.Imports  -- for type-checking in ghci
 import {-# SOURCE #-} Agda.Interaction.Imports (scopeCheckImport)
 import Agda.Interaction.Options
@@ -1217,7 +1217,7 @@ instance ToAbstract (TopLevel [C.Declaration]) TopLevelInfo where
                 -- We need to check the module name against the file name here.
                 -- Otherwise one could sneak in a lie and confuse the scope
                 -- checker.
-                  checkModuleName (C.toTopLevelModuleName m0) file $ Just expectedMName
+                  checkModuleName (C.toTopLevelModuleName m0) (SourceFile file) $ Just expectedMName
                   return m0
           setTopLevelModule m
           am           <- toAbstract (NewModuleQName m)

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -22,6 +22,9 @@ module Agda.TypeChecking.Serialise
   )
   where
 
+import System.Directory ( createDirectoryIfMissing )
+import System.FilePath ( takeDirectory )
+
 import Control.Arrow (second)
 import Control.DeepSeq
 import qualified Control.Exception as E
@@ -201,7 +204,10 @@ encodeInterface i = L.append hashes <$> encode i
 -- positions are replaced with module names.
 
 encodeFile :: FilePath -> Interface -> TCM ()
-encodeFile f i = liftIO . L.writeFile f =<< encodeInterface i
+encodeFile f i = do
+  bs <- encodeInterface i
+  liftIO $ createDirectoryIfMissing True (takeDirectory f)
+  liftIO $ L.writeFile f bs
 
 -- | Decodes something. The result depends on the include path.
 --

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -201,7 +201,7 @@ instance EmbPrj AbsolutePath where
     modify $ \s -> s { modFile = mf }
     case r of
       Left err -> throwError $ findErrorToTypeError m err
-      Right f  -> return f
+      Right f  -> return (srcFilePath f)
 
 instance EmbPrj a => EmbPrj (Position' a) where
   icod_ (P.Pn file pos line col) = icodeN' P.Pn file pos line col

--- a/src/full/Agda/Utils/Applicative.hs
+++ b/src/full/Agda/Utils/Applicative.hs
@@ -1,0 +1,15 @@
+module Agda.Utils.Applicative
+       ( (?*>)
+       , (?$>)
+       )
+       where
+
+import Control.Applicative
+
+-- | Guard: return the action @f@ only if the boolean is @True@
+(?*>) :: Alternative f => Bool -> f a -> f a
+b ?*> f = if b then f else empty
+
+-- | Guard: return the value @a@ only if the boolean is @True@
+(?$>) :: Alternative f => Bool -> a -> f a
+b ?$> a = b ?*> pure a

--- a/test/api/Issue1168.hs
+++ b/test/api/Issue1168.hs
@@ -11,10 +11,14 @@ import System.Exit            ( exitSuccess )
 ------------------------------------------------------------------------------
 -- Agda library imports
 
-import Agda.Interaction.Imports        ( readInterface )
+import Agda.Interaction.FindFile       ( SourceFile(..), findInterfaceFile' )
+import Agda.Interaction.Imports        ( readInterface' )
 import Agda.Interaction.Options        ( defaultOptions )
 import Agda.TypeChecking.Monad.Base    ( Interface, runTCMTop, TCErr )
 import Agda.TypeChecking.Monad.Options ( setCommandLineOptions )
+import Agda.Utils.FileName
+import Agda.Utils.Impossible
+import Agda.Utils.Maybe
 
 ------------------------------------------------------------------------------
 
@@ -22,7 +26,9 @@ main :: IO ()
 main = do
   r :: Either TCErr (Maybe Interface) <- liftIO $ runTCMTop $
     do setCommandLineOptions defaultOptions
-       readInterface "Issue1168.agdai"
+       src   <- liftIO $ SourceFile <$> absolute "Issue1168.agda"
+       ifile <- findInterfaceFile' src
+       readInterface' $ fromMaybe __IMPOSSIBLE__ ifile
 
   case r of
     Right (Just _) -> exitSuccess

--- a/test/api/PrettyInterface.hs
+++ b/test/api/PrettyInterface.hs
@@ -14,6 +14,7 @@ import qualified Data.HashMap.Strict as HashMap
 ------------------------------------------------------------------------------
 -- Agda library imports
 
+import Agda.Interaction.FindFile ( SourceFile(..) )
 import Agda.Interaction.Imports ( typeCheckMain, Mode(TypeCheck), sourceInfo )
 import Agda.Interaction.Options ( defaultOptions )
 
@@ -37,7 +38,7 @@ main = do
 mainTCM :: TCM ()
 mainTCM = do
   setCommandLineOptions defaultOptions
-  f <- liftIO $ absolute "PrettyInterface.agda"
+  f <- liftIO $ SourceFile <$> absolute "PrettyInterface.agda"
   (i, _mw) <- typeCheckMain f TypeCheck =<< sourceInfo f
   compilerMain i
 

--- a/test/interaction/Debug.out
+++ b/test/interaction/Debug.out
@@ -2,7 +2,7 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 (agda2-verbose "Building interface... ")
-(agda2-verbose "Writing interface file Debug.agdai. ")
+(agda2-verbose "Writing interface file _build/2.6.1/Debug.agdai. ")
 (agda2-verbose "Wrote interface file. ")
 (agda2-verbose "Accumulated statistics. ")
 (agda2-verbose "Finished Debug. ")

--- a/test/interaction/Debug.out
+++ b/test/interaction/Debug.out
@@ -2,7 +2,7 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 (agda2-verbose "Building interface... ")
-(agda2-verbose "Writing interface file _build/2.6.1/Debug.agdai. ")
+(agda2-verbose "Writing interface file _build/2.6.1/agda/Debug.agdai. ")
 (agda2-verbose "Wrote interface file. ")
 (agda2-verbose "Accumulated statistics. ")
 (agda2-verbose "Finished Debug. ")

--- a/test/interaction/Issue1232.hs
+++ b/test/interaction/Issue1232.hs
@@ -3,6 +3,7 @@
 import System.Directory
 
 import RunAgda
+import Agda.Version
 
 file       = "Issue1232.agda"
 firstCode  = "import Issue1232.List"
@@ -33,6 +34,6 @@ main = runAgda [ "--no-libraries"
 
   -- Clean up.
   writeUTF8File file "\n"
-  removeFile $ file ++ "i"
+  removeFile $ concat [ "_build/", version, "/", file, "i" ]
 
   return ()

--- a/test/interaction/Issue1232.hs
+++ b/test/interaction/Issue1232.hs
@@ -34,6 +34,6 @@ main = runAgda [ "--no-libraries"
 
   -- Clean up.
   writeUTF8File file "\n"
-  removeFile $ concat [ "_build/", version, "/", file, "i" ]
+  removeFile $ concat [ "_build/", version, "/agda/", file, "i" ]
 
   return ()

--- a/test/interaction/Issue720.hs
+++ b/test/interaction/Issue720.hs
@@ -7,7 +7,7 @@ import RunAgda
 import Agda.Version
 
 file          = "Issue720.agda"
-interfaceFile = concat [ "_build/", version, "/", file, "i" ]
+interfaceFile = concat [ "_build/", version, "/agda/", file, "i" ]
 
 main :: IO ()
 main = runAgda ["--no-libraries"] $ \(AgdaCommands { .. }) -> do

--- a/test/interaction/Issue720.hs
+++ b/test/interaction/Issue720.hs
@@ -4,9 +4,10 @@ import Control.Monad
 import System.Directory
 
 import RunAgda
+import Agda.Version
 
 file          = "Issue720.agda"
-interfaceFile = file ++ "i"
+interfaceFile = concat [ "_build/", version, "/", file, "i" ]
 
 main :: IO ()
 main = runAgda ["--no-libraries"] $ \(AgdaCommands { .. }) -> do

--- a/test/interaction/Issue983.hs
+++ b/test/interaction/Issue983.hs
@@ -3,6 +3,7 @@
 import System.Directory
 
 import RunAgda
+import Agda.Version
 
 top     = "Issue983"
 topFile = top ++ ".agda"
@@ -40,6 +41,6 @@ main = runAgda ["--no-libraries"] $ \(AgdaCommands { .. }) -> do
   echoUntilPrompt
 
   -- Clean up.
-  mapM_ removeFile [libFile, libFile ++ "i", badFile]
+  mapM_ removeFile [libFile, concat [ "_build/", version, "/", libFile, "i" ], badFile]
 
   return ()

--- a/test/interaction/Issue983.hs
+++ b/test/interaction/Issue983.hs
@@ -41,6 +41,6 @@ main = runAgda ["--no-libraries"] $ \(AgdaCommands { .. }) -> do
   echoUntilPrompt
 
   -- Clean up.
-  mapM_ removeFile [libFile, concat [ "_build/", version, "/", libFile, "i" ], badFile]
+  mapM_ removeFile [libFile, concat [ "_build/", version, "/agda/", libFile, "i" ], badFile]
 
   return ()

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -36,6 +36,7 @@ Tests=$(patsubst %.lagda,%.cmp,$(patsubst %.agda,%.cmp,$(AgdaFiles)))
 default : $(Tests)
 
 export TMPDIR=highlighting-tmp
+export BUILDDIR=_build/
 
 # Filter out absolute pathes, make all whitespace equal, remove
 # "Linking..." messages since GHC 7.0 doesn't have them.
@@ -156,4 +157,4 @@ $(Tests) : %.cmp : %.out
 			fi; \
 	 fi
 	@$(cleanup_$*)
-	@rm -rf $(TMPDIR)
+	@rm -rf $(TMPDIR) $(BUILDDIR)


### PR DESCRIPTION
If an .agda file is part of a project with an identifiable root
(i.e. if there is an agda-lib file in any of the directories above it)
then we create a _build/VERSION directory at that root and we
write the .agdai file storing its interface in it.

If it does not have an identifiable root then we simply store the
.agdai interface file alongside the file itself.

Additional refactoring: disambiguating between AbsolutePath standing
for source files and the ones standing for interface files.