### PR TITLE
[ fix #3965 ] Highlight unreachable clauses separately

### DIFF
--- a/src/data/Agda.css
+++ b/src/data/Agda.css
@@ -31,6 +31,7 @@
 .Agda .IncompletePattern  { color: black; background: #F5DEB3        }
 .Agda .Error              { color: red;   text-decoration: underline }
 .Agda .TypeChecks         { color: black; background: #ADD8E6        }
+.Agda .Deadcode           { color: black; background: #808080        }
 
 /* Standard attributes. */
 .Agda a { text-decoration: none }

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -618,6 +618,8 @@ warningHighlighting :: TCWarning -> File
 warningHighlighting w = case tcWarning w of
   TerminationIssue terrs     -> terminationErrorHighlighting terrs
   NotStrictlyPositive d ocs  -> positivityErrorHighlighting d ocs
+  -- #3965 highlight each unreachable clause independently: they
+  -- may be interleaved with actually reachable clauses!
   UnreachableClauses _ rs    -> Fold.foldMap deadcodeHighlighting rs
   CoverageIssue{}            -> coverageErrorHighlighting $ getRange w
   CoverageNoExactSplit{}     -> catchallHighlighting $ getRange w

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -618,7 +618,7 @@ warningHighlighting :: TCWarning -> File
 warningHighlighting w = case tcWarning w of
   TerminationIssue terrs     -> terminationErrorHighlighting terrs
   NotStrictlyPositive d ocs  -> positivityErrorHighlighting d ocs
-  UnreachableClauses{}       -> deadcodeHighlighting $ getRange w
+  UnreachableClauses _ rs    -> Fold.foldMap deadcodeHighlighting rs
   CoverageIssue{}            -> coverageErrorHighlighting $ getRange w
   CoverageNoExactSplit{}     -> catchallHighlighting $ getRange w
   UnsolvedConstraints cs     -> constraintsHighlighting cs

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -268,8 +268,8 @@ coverageCheck f t cs = do
   unless (null is) $ do
     -- Warn about unreachable clauses.
     let unreached = filter ((Just True ==) . clauseUnreachable) cs1
-    setCurrentRange (map clauseFullRange unreached) $
-      warning $ UnreachableClauses f $ map namedClausePats unreached
+    let ranges    = map clauseFullRange unreached
+    setCurrentRange ranges $ warning $ UnreachableClauses f ranges
 
   -- report a warning if there are clauses that are not preserved as
   -- definitional equalities and --exact-split is enabled

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2816,7 +2816,9 @@ instance Free Candidate where
 data Warning
   = NicifierIssue            DeclarationWarning
   | TerminationIssue         [TerminationError]
-  | UnreachableClauses       QName [[NamedArg DeBruijnPattern]]
+  | UnreachableClauses       QName [Range]
+  -- ^ `UnreachableClauses f rs` means that the clauses in `f` whose ranges are rs
+  --   are unreachable
   | CoverageIssue            QName [(Telescope, [NamedArg DeBruijnPattern])]
   -- ^ `CoverageIssue f pss` means that `pss` are not covered in `f`
   | CoverageNoExactSplit     QName [Clause]

--- a/test/LaTeXAndHTML/succeed/Issue3965.agda
+++ b/test/LaTeXAndHTML/succeed/Issue3965.agda
@@ -1,0 +1,20 @@
+open import Agda.Builtin.Nat
+
+f : Nat → Nat
+f 0 = zero
+f 0 = 0        -- All                      -- But Only
+f (suc n) = n  -- These
+f 0 = 0        -- Lines                    -- These Two
+               -- Used to be highlighted   -- Should be!
+
+
+g : Nat → Nat
+g 0 = zero
+g 0     -- The highlihting should still
+  = 0   -- span multiple lines if the clause does
+g (suc n) = n
+g 0     -- Even
+        -- With
+        -- A Lot
+   = 0  -- Of Empty Lines in between
+

--- a/test/LaTeXAndHTML/succeed/Issue3965.html
+++ b/test/LaTeXAndHTML/succeed/Issue3965.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html><head><meta charset="utf-8"><title>Issue3965</title><link rel="stylesheet" href="Agda.css"></head><body><pre class="Agda"><a id="1" class="Keyword">open</a> <a id="6" class="Keyword">import</a> <a id="13" href="Agda.Builtin.Nat.html" class="Module">Agda.Builtin.Nat</a>
+
+<a id="f"></a><a id="31" href="Issue3965.html#31" class="Function">f</a> <a id="33" class="Symbol">:</a> <a id="35" href="Agda.Builtin.Nat.html#165" class="Datatype">Nat</a> <a id="39" class="Symbol">→</a> <a id="41" href="Agda.Builtin.Nat.html#165" class="Datatype">Nat</a>
+<a id="45" href="Issue3965.html#31" class="Function">f</a> <a id="47" class="Number">0</a> <a id="49" class="Symbol">=</a> <a id="51" href="Agda.Builtin.Nat.html#183" class="InductiveConstructor">zero</a>
+<a id="56" href="Issue3965.html#31" class="Deadcode Function">f</a><a id="57" class="Deadcode"> </a><a id="58" class="Deadcode Number">0</a><a id="59" class="Deadcode"> </a><a id="60" class="Deadcode Symbol">=</a><a id="61" class="Deadcode"> </a><a id="62" class="Deadcode Number">0</a>        <a id="71" class="Comment">-- All                      -- But Only</a>
+<a id="111" href="Issue3965.html#31" class="Function">f</a> <a id="113" class="Symbol">(</a><a id="114" href="Agda.Builtin.Nat.html#196" class="InductiveConstructor">suc</a> <a id="118" href="Issue3965.html#118" class="Bound">n</a><a id="119" class="Symbol">)</a> <a id="121" class="Symbol">=</a> <a id="123" href="Issue3965.html#118" class="Bound">n</a>  <a id="126" class="Comment">-- These</a>
+<a id="135" href="Issue3965.html#31" class="Deadcode Function">f</a><a id="136" class="Deadcode"> </a><a id="137" class="Deadcode Number">0</a><a id="138" class="Deadcode"> </a><a id="139" class="Deadcode Symbol">=</a><a id="140" class="Deadcode"> </a><a id="141" class="Deadcode Number">0</a>        <a id="150" class="Comment">-- Lines                    -- These Two</a>
+               <a id="206" class="Comment">-- Used to be highlighted   -- Should be!</a>
+
+
+<a id="g"></a><a id="250" href="Issue3965.html#250" class="Function">g</a> <a id="252" class="Symbol">:</a> <a id="254" href="Agda.Builtin.Nat.html#165" class="Datatype">Nat</a> <a id="258" class="Symbol">→</a> <a id="260" href="Agda.Builtin.Nat.html#165" class="Datatype">Nat</a>
+<a id="264" href="Issue3965.html#250" class="Function">g</a> <a id="266" class="Number">0</a> <a id="268" class="Symbol">=</a> <a id="270" href="Agda.Builtin.Nat.html#183" class="InductiveConstructor">zero</a>
+<a id="275" href="Issue3965.html#250" class="Deadcode Function">g</a><a id="276" class="Deadcode"> </a><a id="277" class="Deadcode Number">0</a><a id="278" class="Deadcode">     </a><a id="283" class="Deadcode Comment">-- The highlihting should still</a><a id="314" class="Deadcode">
+  </a><a id="317" class="Deadcode Symbol">=</a><a id="318" class="Deadcode"> </a><a id="319" class="Deadcode Number">0</a>   <a id="323" class="Comment">-- span multiple lines if the clause does</a>
+<a id="365" href="Issue3965.html#250" class="Function">g</a> <a id="367" class="Symbol">(</a><a id="368" href="Agda.Builtin.Nat.html#196" class="InductiveConstructor">suc</a> <a id="372" href="Issue3965.html#372" class="Bound">n</a><a id="373" class="Symbol">)</a> <a id="375" class="Symbol">=</a> <a id="377" href="Issue3965.html#372" class="Bound">n</a>
+<a id="379" href="Issue3965.html#250" class="Deadcode Function">g</a><a id="380" class="Deadcode"> </a><a id="381" class="Deadcode Number">0</a><a id="382" class="Deadcode">     </a><a id="387" class="Deadcode Comment">-- Even</a><a id="394" class="Deadcode">
+        </a><a id="403" class="Deadcode Comment">-- With</a><a id="410" class="Deadcode">
+        </a><a id="419" class="Deadcode Comment">-- A Lot</a><a id="427" class="Deadcode">
+   </a><a id="431" class="Deadcode Symbol">=</a><a id="432" class="Deadcode"> </a><a id="433" class="Deadcode Number">0</a>  <a id="436" class="Comment">-- Of Empty Lines in between</a>
+
+</pre></body></html>


### PR DESCRIPTION
Added bonus: Deacode aspect in the css file.