### PR TITLE
[ fixed #3943 ] now printing terms in unification problems {_} = {_}

### DIFF
--- a/test/Fail/Issue1406.err
+++ b/test/Fail/Issue1406.err
@@ -2,6 +2,6 @@ Issue1406.agda:33,24-28
 I'm not sure if there should be a case for the constructor refl,
 because I get stuck when trying to solve the following unification
 problems (inferred index ≟ expected index):
-  {_} ≟ {_}
+  {SING F} ≟ {SING F₁}
   sing F ≟ sing F₁
 when checking that the pattern refl has type HEq (sing F) (sing F₁)

--- a/test/Fail/Issue1435-helper.err
+++ b/test/Fail/Issue1435-helper.err
@@ -2,6 +2,6 @@ Issue1435-helper.agda:28,29-33
 I'm not sure if there should be a case for the constructor refl,
 because I get stuck when trying to solve the following unification
 problems (inferred index ≟ expected index):
-  {_} ≟ {_}
+  {C (Box A)} ≟ {C (Box B)}
   c₁ A ≟ c₁ B
 when checking that the pattern refl has type c₁ A ≅ c₁ B

--- a/test/Fail/Issue1982.err
+++ b/test/Fail/Issue1982.err
@@ -2,6 +2,6 @@ Issue1982.agda:29,19-23
 I'm not sure if there should be a case for the constructor up,
 because I get stuck when trying to solve the following unification
 problems (inferred index ≟ expected index):
-  {_} ≟ {_}
+  {suc (suc n)} ≟ {_n_99}
   (! t) ∶ (t ∶ A) ≟ A₁
 when checking that the pattern up j has type True Γ A

--- a/test/Fail/Issue199.err
+++ b/test/Fail/Issue199.err
@@ -2,6 +2,6 @@ Issue199.agda:11,6-9
 I'm not sure if there should be a case for the constructor p,
 because I get stuck when trying to solve the following unification
 problems (inferred index ≟ expected index):
-  {_} ≟ {_}
+  {D} ≟ {_T_13}
   d ≟ _15
 when checking that the pattern p _ has type P _15

--- a/test/Fail/Issue2621.err
+++ b/test/Fail/Issue2621.err
@@ -2,7 +2,7 @@ Issue2621.agda:17,13-15
 I'm not sure if there should be a case for the constructor [],
 because I get stuck when trying to solve the following unification
 problems (inferred index ≟ expected index):
-  {_} ≟ {_}
+  {zero} ≟ {_k_61 (R = R) (h = h)}
   [] ≟ a
   [] ≟ b
 when checking that the pattern [] has type All₂ R a b

--- a/test/Fail/LevelUnification.err
+++ b/test/Fail/LevelUnification.err
@@ -2,7 +2,7 @@ LevelUnification.agda:12,20-24
 I'm not sure if there should be a case for the constructor refl,
 because I get stuck when trying to solve the following unification
 problems (inferred index ≟ expected index):
-  {_} ≟ {_}
-  {_} ≟ {_}
+  {lsuc a} ≟ {lsuc b}
+  {A} ≟ {B}
   x ≟ y
 when checking that the pattern refl has type x ≡ y

--- a/test/interaction/Issue2621.out
+++ b/test/interaction/Issue2621.out
@@ -4,7 +4,7 @@
 (agda2-status-action "")
 (agda2-info-action "*All Goals*" "?0 : b ≡ c _k_61 : ℕ [ at Issue2621.agda:16,70-76 ] " nil)
 ((last . 1) . (agda2-goals-action '(0)))
-(agda2-info-action "*Error*" "Issue2621.agda:17,23-30 I'm not sure if there should be a case for the constructor [], because I get stuck when trying to solve the following unification problems (inferred index ≟ expected index): {_} ≟ {_} [] ≟ a₁ [] ≟ b₁ when checking that the expression ? has type b ≡ c" nil)
+(agda2-info-action "*Error*" "Issue2621.agda:17,23-30 I'm not sure if there should be a case for the constructor [], because I get stuck when trying to solve the following unification problems (inferred index ≟ expected index): {zero} ≟ {_k_61 (R = R₁) (h = h₁)} [] ≟ a₁ [] ≟ b₁ when checking that the expression ? has type b ≡ c" nil)
 ((last . 3) . (agda2-maybe-goto '("Issue2621.agda" . 620)))
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")


### PR DESCRIPTION
In the changed error messages there is more clutter, but there might be
interesting mismatches in hidden indices.