### PR TITLE
[ re #3949 ] new option --local-interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ Installation and infrastructure
 
 * Removed support for GHC 7.10.3.
 
-* Interface files are now written in directory _build/VERSION/agda/ at
+* Interface files are now written in directory `_build/VERSION/agda/` at
   the project root (the closest enclosing directory where an .agda-lib
   file is present). If there is no project root then the interface file
   is written alongside the module it corresponds to.
+  The flag `--local-interfaces` forces Agda to revert back to storing
+  interface files alongside module files no matter what.
 
 API
 ----

--- a/Setup.hs
+++ b/Setup.hs
@@ -70,7 +70,10 @@ buildHook' pd lbi hooks flags = do
     removeFile fullpathi `catch` handleExists
 
     putStrLn $ "... " ++ fullpath
-    ok <- rawSystem' ddir agda [ "--no-libraries", "-Werror", fullpath, "-v0" ]
+    ok <- rawSystem' ddir agda [ "--no-libraries", "--local-interfaces"
+                               , "-Werror"
+                               , fullpath, "-v0"
+                               ]
     case ok of
       ExitSuccess   -> return ()
       ExitFailure _ -> die $ "Error: Failed to typecheck " ++ fullpath ++ "!"

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -107,6 +107,11 @@ Imports and libraries
       Ignore *all* interface files, including builtin and primitive
       modules; only use this if you know what you are doing!
 
+:samp:`--local-interfaces`
+      Read and write interface files next to the Agda files they
+      correspond to (i.e. do not attempt to regroup them in a
+      :samp:`_build/` directory at the project's root).
+
 :samp:`--include-path={DIR} -i={DIR}`
       Look for imports in
       :samp:`{DIR}`

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -382,7 +382,7 @@ getInterface' x isMain msi =
                      Just si -> return $ hashText (siSource si)
         ifaceH  <- case cached of
             Nothing -> do
-              mifile <- liftIO $ toIFile file
+              mifile <- toIFile file
               fmap fst <$> getInterfaceFileHashes mifile
             Just i  -> return $ Just $ iSourceHash i
         let unchanged = Just sourceH == ifaceH
@@ -512,7 +512,7 @@ getStoredInterface x file isMain msi = do
   -- Examine the hash of the interface file. If it is different from the
   -- stored version (in stDecodedModules), or if there is no stored version,
   -- read and decode it. Otherwise use the stored version.
-  ifile <- liftIO $ toIFile file
+  ifile <- toIFile file
   let ifp = filePath ifile
   h <- fmap snd <$> getInterfaceFileHashes ifile
   mm <- getDecodedModule x
@@ -982,7 +982,7 @@ createInterface file mname isMain msi =
         reportSLn "import.iface.create" 7 "Actually calling writeInterface."
         -- The file was successfully type-checked (and no warnings were
         -- encountered), so the interface should be written out.
-        ifile <- liftIO $ toIFile file
+        ifile <- toIFile file
         writeInterface ifile i
     reportSLn "import.iface.create" 7 "Finished (or skipped) writing to interface file."
 

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -116,6 +116,7 @@ data CommandLineOptions = Options
   , optCSSFile          :: Maybe FilePath
   , optIgnoreInterfaces :: Bool
   , optIgnoreAllInterfaces :: Bool
+  , optLocalInterfaces     :: Bool
   , optPragmaOptions    :: PragmaOptions
   , optOnlyScopeChecking :: Bool
     -- ^ Should the top-level module only be scope-checked, and not
@@ -229,6 +230,7 @@ defaultOptions = Options
   , optCSSFile          = Nothing
   , optIgnoreInterfaces = False
   , optIgnoreAllInterfaces = False
+  , optLocalInterfaces     = False
   , optPragmaOptions    = defaultPragmaOptions
   , optOnlyScopeChecking = False
   , optWithCompiler      = Nothing
@@ -509,6 +511,9 @@ ignoreInterfacesFlag o = return $ o { optIgnoreInterfaces = True }
 
 ignoreAllInterfacesFlag :: Flag CommandLineOptions
 ignoreAllInterfacesFlag o = return $ o { optIgnoreAllInterfaces = True }
+
+localInterfacesFlag :: Flag CommandLineOptions
+localInterfacesFlag o = return $ o { optLocalInterfaces = True }
 
 allowUnsolvedFlag :: Flag PragmaOptions
 allowUnsolvedFlag o = do
@@ -816,6 +821,8 @@ standardOptions =
                     "generate a Dot file with a module dependency graph"
     , Option []     ["ignore-interfaces"] (NoArg ignoreInterfacesFlag)
                     "ignore interface files (re-type check everything)"
+    , Option []     ["local-interfaces"] (NoArg localInterfacesFlag)
+                    "put interface files next to the Agda files they correspond to"
     , Option ['i']  ["include-path"] (ReqArg includeFlag "DIR")
                     "look for imports in DIR"
     , Option ['l']  ["library"] (ReqArg libraryFlag "LIB")


### PR DESCRIPTION
If we want to revert back to writing the interface files alongside
the module ones, we can call Agda with --local-interfaces.