### PR TITLE
[ #3986 ] turn off contravariant subtyping

### DIFF
--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -657,7 +657,11 @@ compareAtom cmp t m n =
               reportSDoc "tc.conv.fun" 20 $ nest 2 $ vcat
                 [ "t1 =" <+> prettyTCM t1
                 , "t2 =" <+> prettyTCM t2 ]
-              compareDom cmp dom2 dom1 b1 b2 errH errR $
+              -- Andreas, 2019-08-14, issue #3986
+              -- Turn off contravariant subtyping as it leads to wrong
+              -- Modality in Arg.
+              -- compareDom cmp dom2 dom1 b1 b2 errH errR $
+              compareDom CmpEq dom2 dom1 b1 b2 errH errR $
                 compareType cmp (absBody b1) (absBody b2)
             where
             errH = typeError $ UnequalHiding t1 t2

--- a/test/Fail/CoinductiveBuiltinList.err
+++ b/test/Fail/CoinductiveBuiltinList.err
@@ -1,3 +1,3 @@
 CoinductiveBuiltinList.agda:9,18-22
-List A !=< ∞ (List A)
+List A != ∞ (List A)
 when checking that the expression _∷_ has type A → List A → List A

--- a/test/Fail/CoinductiveBuiltinNatural.err
+++ b/test/Fail/CoinductiveBuiltinNatural.err
@@ -1,3 +1,3 @@
 CoinductiveBuiltinNatural.agda:9,21-22
-ℕ !=< ∞ ℕ
+ℕ != ∞ ℕ
 when checking that the expression suc has type ℕ → ℕ

--- a/test/Fail/Issue1523a.agda
+++ b/test/Fail/Issue1523a.agda
@@ -11,8 +11,8 @@ data Nat (i : Size) : Set where
 fix : ∀ {C : Size → Set}
   → (∀{i} → (∀ {j : Size< i} → Nat j -> C j) → Nat i → C i)
   → ∀{i} → Nat i → C i
-fix t zero    = t (fix t) zero
-fix t (suc n) = t (fix t) (suc n)
+fix t zero    = t (λ m → fix t m) zero
+fix t (suc n) = t (λ m → fix t m) (suc n)
 
 case : ∀ {i} {C : Set} (n : Nat i) (z : C) (s : ∀ {j : Size< i} → Nat j → C) → C
 case zero    z s = z

--- a/test/Fail/Issue1692.err
+++ b/test/Fail/Issue1692.err
@@ -1,4 +1,4 @@
 Issue1692.agda:30,24-29
-v₁ !=< v₂ of type (Value k₂)
+v₁ != v₂ of type (Value k₂)
 when checking that the expression t₂→t₁ has type
 _k_51 ∼ _v_52 ∈ node k₂ v₁ → _k_51 ∼ _v_52 ∈ node k₂ v₂

--- a/test/Fail/Issue1946-5.err
+++ b/test/Fail/Issue1946-5.err
@@ -1,8 +1,5 @@
-Issue1946-5.agda:22,1-23,29
-Termination checking failed for the following functions:
-  inh
-Problematic calls:
-  λ { .force → ∞ , inh }
-    (at Issue1946-5.agda:23,7-29)
-  inh
-    (at Issue1946-5.agda:23,24-27)
+Issue1946-5.agda:20,1-24
+i != ∞ of type Size
+when checking that the type
+(i : Size) (x : T i) → Σ (Size< i) T → ⊥ of the generated with
+function is well-formed

--- a/test/Fail/Issue2170.agda
+++ b/test/Fail/Issue2170.agda
@@ -29,7 +29,7 @@ open Irr
 -- each of its fields, which is used to produce a DontCare.
 
 bizarre : Irr (Σ (Bool → Irr Bool) (λ i → Σ (Irr Bool → Bool) (λ u → (a : Bool) → u (i a) ≡ a)))
-bizarre = irr (irr , unirr , λ a → refl)  -- Should not pass
+bizarre = irr ((λ a → irr a) , (λ i → unirr i) , λ a → refl)  -- Should not pass
 
 -- Expected error:
 -- .(a) != a of type Bool

--- a/test/Fail/Issue2170.err
+++ b/test/Fail/Issue2170.err
@@ -1,3 +1,3 @@
-Issue2170.agda:32,36-40
+Issue2170.agda:32,56-60
 .(a) !=< a of type Bool
 when checking that the expression refl has type .(a) ≡ a

--- a/test/Fail/Issue2993.err
+++ b/test/Fail/Issue2993.err
@@ -21,7 +21,7 @@ Failed to solve the following constraints:
     applicativeComp :
       {F G : Set → Set} ⦃ _ : Applicative F ⦄ ⦃ _ : Applicative G ⦄ →
       Applicative (F o G)
-  [242, 243] F₁ B₁ =< _F_166 _B_164 
+  [242, 243] F₁ B₁ = _F_166 _B_164 
   [242] _F_166 (Vec _B_164 n) =< F₁ (Vec B₁ n) 
   [222] F B =< _F_160 _B_152 
   [227] _F_160 (Vec _B_152 n₁) =< F (Vec B n₁) 

--- a/test/Fail/Issue399.err
+++ b/test/Fail/Issue399.err
@@ -1,11 +1,11 @@
 Failed to solve the following constraints:
-  [42, 43] _9 (m = Maybe) (mzero = mymaybemzero) =< Maybe a 
-  [42, 44] _12 (m = Maybe) (mzero = mymaybemzero) =< Maybe a 
+  [42, 43] _9 (m = Maybe) (mzero = mymaybemzero) = Maybe a 
+  [42, 44] _12 (m = Maybe) (mzero = mymaybemzero) = Maybe a 
   piSort (_7 (m = Maybe) (mzero = mymaybemzero)) (λ _ → Set) = Set
   piSort (_10 (m = Maybe) (mzero = mymaybemzero)) (λ _ → Set) = Set
   _10 (m = Maybe) (mzero = mymaybemzero) = Set
   _7 (m = Maybe) (mzero = mymaybemzero) = Set
-  [37, 38] _4 (m = Maybe) =< Maybe a 
+  [37, 38] _4 (m = Maybe) = Maybe a 
   piSort (_2 (m = Maybe)) (λ _ → Set) = Set
   _2 (m = Maybe) = Set
   Set (Agda.Primitive.lsuc _a_30) = _0

--- a/test/Succeed/Issue1523a.agda
+++ b/test/Succeed/Issue1523a.agda
@@ -11,8 +11,8 @@ data Nat (i : Size) : Set where
 fix : ∀ {C : Size → Set}
   → (∀{i} → (∀ {j : Size< i} → Nat j -> C j) → Nat i → C i)
   → ∀{i} → Nat i → C i
-fix t zero    = t (fix t) zero
-fix t (suc n) = t (fix t) (suc n)
+fix t zero    = t (λ m → fix t m) zero
+fix t (suc n) = t (λ m → fix t m) (suc n)
 
 case : ∀ {i} {C : Set} (n : Nat i) (z : C) (s : ∀ {j : Size< i} → Nat j → C) → C
 case zero    z s = z

--- a/test/Succeed/Issue2429-subtyping.agda
+++ b/test/Succeed/Issue2429-subtyping.agda
@@ -5,7 +5,7 @@
 -- Where a function is expected, we can put one which does not use its argument.
 
 id : ∀{A B : Set} → (.A → B) → A → B
-id f = f
+id f a = f a
 
 test : ∀{A B : Set} → (.A → B) → A → B
 test f = λ .a → f a

--- a/test/Succeed/RelevanceSubtyping.agda
+++ b/test/Succeed/RelevanceSubtyping.agda
@@ -5,6 +5,7 @@ module RelevanceSubtyping where
 one : {A B : Set} → (.A → B) → A → B
 one f x = f x
 
--- this type-checks because of subtyping
-one' : {A B : Set} → (.A → B) → A → B
-one' f = f
+-- Andreas, 2019-08-14, no longer, because of issue #3986
+-- -- this type-checks because of subtyping
+-- one' : {A B : Set} → (.A → B) → A → B
+-- one' f = f

--- a/test/Succeed/SizedCoinductiveRecords.agda
+++ b/test/Succeed/SizedCoinductiveRecords.agda
@@ -40,7 +40,7 @@ Bounded : Size → Set
 Bounded i = (j : Size< i) → Empty {j}
 
 contra : {i : Size}{j : Size< i} → Bounded i → Bounded j
-contra k = k
+contra k i = k i
 
 -- sized naturals
 
@@ -145,7 +145,7 @@ module STREAM where
   anti s = s
 
   anti' : {A : Set}{i : Size}{j : Size< i} → (Stream A {j} → A) → (Stream A {i} → A)
-  anti' f = f
+  anti' f s = f s
 
 -- Spanning tree
 


### PR DESCRIPTION
Turning off contravariant subtyping is a brutal fix for #3986.

Introduces regressions for sized types and irrelevance. Some of these can be fixed by manual eta-expansion.

Some of the test cases can maybe be recovered by extending the `coerce` function to get coercive subtyping.  However, we do not want to eta-expand eagerly during conversion, just in case we need it for subtyping.  This means that coercive subtyping would be a bit more complicated to implement, with eta-expansion only when needed.