### PR TITLE
[ emacs ] Literate texts are not comments

### DIFF
--- a/src/data/emacs-mode/agda2-highlight.el
+++ b/src/data/emacs-mode/agda2-highlight.el
@@ -460,8 +460,8 @@ If `agda2-highlight-face-groups' is nil."
 (defvar agda2-highlight-faces
   '((keyword                . agda2-highlight-keyword-face)
     (comment                . font-lock-comment-face)
-    (background             . font-lock-comment-face)
-    (markup                 . font-lock-comment-face)
+    (background             . default)
+    (markup                 . font-lock-comment-delimiter-face)
     (string                 . agda2-highlight-string-face)
     (number                 . agda2-highlight-number-face)
     (symbol                 . agda2-highlight-symbol-face)


### PR DESCRIPTION
For some emacs themes, the default highlighting for comments is grey-ish, which is (kind of) hard to read. They're doing this intentionally because they don't want comments to be too explicit comparing to codes.

For literate agda, the background text should not be hard to read. They are normal text, so using the default highlight should be fine.