### PR TITLE
User manual: fixes a broken link to Stump's precompiled Agda for Windows

### DIFF
--- a/doc/user-manual/getting-started/prerequisites.rst
+++ b/doc/user-manual/getting-started/prerequisites.rst
@@ -46,4 +46,4 @@ Installing Emacs under Windows
 ==============================
 
 A precompiled version of Emacs 24.3, with the necessary mathematical
-fonts, is available at http://homepage.cs.uiowa.edu/~astump/agda/ .
+fonts, is available at http://www.cs.uiowa.edu/~astump/agda.


### PR DESCRIPTION
In the user manual, this patch fixes a broken link to Stump's precompiled Agda for Windows.