### PR TITLE
[ fix #2284 ] warn about duplicate names in lambdas too

### DIFF
--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -702,7 +702,10 @@ toAbstractDot prec e = do
 toAbstractLam :: Range -> [C.LamBinding] -> C.Expr -> Precedence -> ScopeM A.Expr
 toAbstractLam r bs e ctx = do
   -- Translate the binders
+  lvars0 <- getLocalVars
   localToAbstract (map (C.DomainFull . makeDomainFull) bs) $ \ bs -> do
+    lvars1 <- getLocalVars
+    checkNoShadowing lvars0 lvars1
     -- Translate the body
     e <- toAbstractCtx ctx e
     -- We have at least one binder.  Get first @b@ and rest @bs@.

--- a/test/Succeed/Issue2284.agda
+++ b/test/Succeed/Issue2284.agda
@@ -1,0 +1,4 @@
+{-# OPTIONS -WShadowingInTelescope #-}
+
+bad : Set → Set → Set
+bad = λ x x → x

--- a/test/Succeed/Issue2284.warn
+++ b/test/Succeed/Issue2284.warn
@@ -1,0 +1,9 @@
+Issue2284.agda:4,9-12
+Shadowing in telescope, repeated variable names: x
+when scope checking λ x x → x
+
+———— All done; warnings encountered ————————————————————————
+
+Issue2284.agda:4,9-12
+Shadowing in telescope, repeated variable names: x
+when scope checking λ x x → x


### PR DESCRIPTION
Warn about duplicate names in lambdas.