### PR TITLE
User manual: updates the Emacs version in Stump's Agda bundle for Windows

### DIFF
--- a/doc/user-manual/getting-started/prerequisites.rst
+++ b/doc/user-manual/getting-started/prerequisites.rst
@@ -45,5 +45,5 @@ hopefully enable the ``--count-clusters`` flag by giving the
 Installing Emacs under Windows
 ==============================
 
-A precompiled version of Emacs 24.3, with the necessary mathematical
+A precompiled version of Emacs 26.1, with the necessary mathematical
 fonts, is available at http://www.cs.uiowa.edu/~astump/agda.


### PR DESCRIPTION
In the user manual, this patch updates the Emacs version in Stump's Agda bundle for Windows. Stump confirmed this version with his department's IT staff that builds the bundle.