### PR TITLE
Issue 3903

### DIFF
--- a/benchmark/std-lib/Any.agda
+++ b/benchmark/std-lib/Any.agda
@@ -24,7 +24,7 @@ import Data.Product.Function.Dependent.Propositional as Σ
 open import Data.Sum as Sum using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Data.Sum.Relation.Pointwise
 open import Data.Sum.Function.Propositional using (_⊎-cong_)
-open import Function
+open import Function hiding (_↔_; _⇔_)
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Equivalence as Eq using (_⇔_; module Equivalence)
 open import Function.Inverse as Inv using (_↔_; module Inverse)

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -60,11 +60,12 @@ module Agda.TypeChecking.Forcing where
 import Control.Arrow (first)
 import Control.Monad
 import Control.Monad.Trans.Maybe
-import Control.Monad.Writer (WriterT(..), tell)
+import Control.Monad.Writer (WriterT(..), tell, lift)
 import Data.Foldable as Fold hiding (any)
 import Data.Maybe
 import Data.List ((\\))
 import Data.Function (on)
+import Data.Monoid
 
 import Agda.Interaction.Options
 
@@ -234,29 +235,47 @@ forceTranslateTelescope delta qs = do
 rebindForcedPattern :: [NamedArg DeBruijnPattern] -> DeBruijnPattern -> TCM [NamedArg DeBruijnPattern]
 rebindForcedPattern ps toRebind = do
   reportSDoc "tc.force" 50 $ hsep ["rebinding", pretty toRebind, "in"] <?> pretty ps
-  ps' <- go $ zip (repeat NotForced) ps
-  reportSDoc "tc.force" 50 $ nest 2 $ hsep ["result:", pretty ps']
-  return ps'
+  (ps', Sum count) <- runWriterT $ go $ zip (repeat NotForced) ps
+  case count of
+    0 -> __IMPOSSIBLE__   -- Unforcing should not fail
+    1 -> do
+      reportSDoc "tc.force" 50 $ nest 2 $ hsep ["result:", pretty ps']
+      return ps'
+    _ ->
+      genericDocError =<< sep [ fwords "Uh oh. I can't figure out where to move the forced pattern"
+                              , prettyTCM toRebind <> "."
+                              , fwords "See [Issue 3903](https://github.com/agda/agda/issues/3903)." ]
   where
     targetDotP = patternToTerm toRebind
 
-    go [] = __IMPOSSIBLE__ -- unforcing cannot fail
+    rebindingVar = case toRebind of
+                     VarP{} -> True
+                     _      -> False
+
+    go [] = return []
     go ((Forced,    p) : ps) = (p :) <$> go ps
     go ((NotForced, p) : ps) | namedArg p `rebinds` toRebind
                              = return $ p : map snd ps
     go ((NotForced, p) : ps) = -- (#3544) A previous rebinding might have already rebound our pattern
       case namedArg p of
         VarP{}   -> (p :) <$> go ps
-        DotP _ v -> mkPat v >>= \ case
-          Nothing -> (p :) <$> go ps
-          Just q' -> return $ fmap (q' <$) p : map snd ps
+        DotP _ v -> lift (mkPat v) >>= \ case
+          Nothing -> do
+            (p :) <$> go ps
+          Just q' -> do
+            tell 1
+            -- Issue 3903: It's ok if there are multiple candidates for rebinding a plain variable. It's
+            -- only when there's an actual match that it's crucial to pick the right one.
+            let p' = fmap (q' <$) p
+            if rebindingVar then return (p' : map snd ps)
+                            else (p' :) <$> go ps
         ConP c i qs -> do
-          fqs <- withForced c qs
+          fqs <- lift $ withForced c qs
           qps <- go (fqs ++ ps)
           let (qs', ps') = splitAt (length qs) qps
           return $ fmap (ConP c i qs' <$) p : ps'
         DefP o q qs -> do
-          fs <- defForced <$> getConstInfo q
+          fs <- lift $ defForced <$> getConstInfo q
           fqs <- return $ zip (fs ++ repeat NotForced) qs
           qps <- go (fqs ++ ps)
           let (qs', ps') = splitAt (length qs) qps

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -78,7 +78,7 @@ import Agda.TypeChecking.Records
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
-import Agda.TypeChecking.Pretty
+import Agda.TypeChecking.Pretty hiding ((<>))
 
 import Agda.Utils.Functor
 import Agda.Utils.List

--- a/test/Bugs/Issue3544.agda
+++ b/test/Bugs/Issue3544.agda
@@ -1,4 +1,7 @@
 
+-- Fails (gracefully) after #3903 damage control.
+-- Should succeed once #3903 is fixed properly.
+
 data Nat : Set where
   succ : Nat → Nat
 

--- a/test/Bugs/Issue3544.err
+++ b/test/Bugs/Issue3544.err
@@ -1,0 +1,10 @@
+AGDA_FAILURE
+
+ret > ExitFailure 1
+out > Issue3544.agda:25,1-56
+out > Uh oh. I can't figure out where to move the forced pattern
+out > (zero @0).
+out > See [Issue 3903](https://github.com/agda/agda/issues/3903).
+out > when checking the clause left hand side
+out > error n g s (vtyp g' (zero x) (succ n' (piv (zero y))))
+out >

--- a/test/Bugs/Issue3903.agda
+++ b/test/Bugs/Issue3903.agda
@@ -1,0 +1,38 @@
+
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.IO
+open import Agda.Builtin.String
+
+postulate
+  putStr : String → IO ⊤
+
+{-# FOREIGN GHC import qualified Data.Text.IO #-}
+{-# COMPILE GHC putStr = Data.Text.IO.putStr #-}
+
+data Sing : Nat → Set where
+  sing : Sing zero
+
+data Vec : Nat → Set where
+  nil : Vec zero
+  cons : ∀ n → Vec n → Vec (suc n)
+
+isTailNil : ∀ m n → Sing m → Vec n → Bool
+isTailNil .0 .1 sing (cons zero v) = true  -- two `zero`s are buried in the dot patterns, which to resurrect?
+isTailNil _ _ _ _ = false
+
+shouldBeFalse = isTailNil 0 2 sing (cons 1 (cons 0 nil))
+
+isFalse : false ≡ shouldBeFalse
+isFalse = refl
+
+magic : false ≡ true → String
+magic ()
+
+f : (b : Bool) → false ≡ b → String
+f false eq = "Phew!"
+f true  eq = magic eq
+
+main = putStr (f shouldBeFalse refl)

--- a/test/Bugs/Issue3903.err
+++ b/test/Bugs/Issue3903.err
@@ -1,0 +1,10 @@
+AGDA_FAILURE
+
+ret > ExitFailure 1
+out > Issue3903.agda:23,1-35
+out > Uh oh. I can't figure out where to move the forced pattern
+out > (zero).
+out > See [Issue 3903](https://github.com/agda/agda/issues/3903).
+out > when checking the clause left hand side
+out > isTailNil .0 .1 sing (cons zero v)
+out >

--- a/test/Bugs/Issue3930.agda
+++ b/test/Bugs/Issue3930.agda
@@ -1,0 +1,36 @@
+
+module _ where
+
+  data Nat : Set where
+    zero : Nat
+    suc : Nat → Nat
+  {-# BUILTIN NATURAL Nat #-}
+
+  _+_ : (m n : Nat) → Nat
+  zero + n = n
+  suc m + n = suc (m + n)
+
+  data Th : (m n : Nat) → Set where
+    os : ∀ {m n} → Th m n → Th (suc m) (suc n)
+
+  Fin : Nat → Set
+  Fin = Th (suc zero)
+
+  infixl 6 _++_
+  infix 4 _≈M_
+
+  postulate
+    U : Set
+    RCtx : Nat → Set
+    _++_ : ∀ {m n} → RCtx m → RCtx n → RCtx (n + m)
+    El : U → RCtx (suc zero)
+    _≈M_ : ∀ {n} (Δ0 Δ1 : RCtx n) → Set
+
+  infix 4 _⊢l-var_
+
+  data _⊢l-var_ : ∀ {n} (Δi : RCtx n) (i : Fin n) → Set where
+    os : ∀ {n} {e : Th zero n} {Δ Δπ π} (iq : Δπ ≈M (Δ ++ El π)) →
+         Δπ ⊢l-var os e
+
+  ⊢l-var-sub : ∀ {n Δ} {i : Fin n} → Δ ⊢l-var i → Set
+  ⊢l-var-sub (os iq) = Nat

--- a/test/Bugs/Issue3930.err
+++ b/test/Bugs/Issue3930.err
@@ -1,0 +1,6 @@
+AGDA_FAILURE
+
+ret > ExitFailure 1
+out > An internal error has occurred. Please report this as a bug.
+out > Location of the error: src/full/Agda/TypeChecking/Forcing.hs:240
+out >


### PR DESCRIPTION
Reduces impact of 3903 by throwing an error instead of picking the wrong site to move a forced pattern to. Requires modest changes to the std-lib. See https://github.com/agda/agda-stdlib/pull/865.