### PR TITLE
Compile stdlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -366,10 +366,15 @@ script:
        make BUILD_DIR=$BUILD_DIR benchmark-without-logs;
     fi
 
+  - if [[ $TEST = "MAIN" ]]; then
+       make AGDA_TESTS_OPTIONS="-j${PARALLEL_TESTS} --hide-successes" TASTY_ANSI_TRICKS=false BUILD_DIR=$BUILD_DIR compiler-test;
+    fi
+
   # Andreas, 2019-08-20: disable compiler test on ghc 8.0 since it takes too long,
   # making the whole travis run fail.
+  # Ulf, 2019-08-29: only disable the stdlib compiler test
   - if [[ $TEST = "MAIN" && $GHC_VER != "8.0.2" ]]; then
-       make AGDA_TESTS_OPTIONS="-j${PARALLEL_TESTS} --hide-successes" TASTY_ANSI_TRICKS=false BUILD_DIR=$BUILD_DIR compiler-test;
+       make AGDA_TESTS_OPTIONS="-j${PARALLEL_TESTS} --hide-successes" TASTY_ANSI_TRICKS=false BUILD_DIR=$BUILD_DIR stdlib-compiler-test;
     fi
 
   - if [[ $TEST = "MAIN" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ QUICK_CABAL_INSTALL = $(CABAL_INSTALL_HELPER) --builddir=$(QUICK_BUILD_DIR)
 QUICK_STACK_BUILD_WORK_DIR = .stack-work-quick
 QUICK_STACK_BUILD = $(STACK_BUILD) \
 										--ghc-options=-O0 \
-										--work-dir=$(QUICK_STACK_BUILD_WORK_DIR) 
+										--work-dir=$(QUICK_STACK_BUILD_WORK_DIR)
 
 SLOW_CABAL_INSTALL_OPTS = --builddir=$(BUILD_DIR) --enable-tests
 CABAL_INSTALL           = $(CABAL_INSTALL_HELPER) \
@@ -219,7 +219,7 @@ TAGS :
 quick : install-O0-bin quicktest
 
 .PHONY : test
-test : check-whitespace succeed fail bugs interaction examples library-test interactive latex-html-test api-test internal-tests benchmark-without-logs compiler-test lib-succeed lib-interaction user-manual-test test-size-solver
+test : check-whitespace succeed fail bugs interaction examples library-test interactive latex-html-test api-test internal-tests benchmark-without-logs compiler-test stdlib-compiler-test lib-succeed lib-interaction user-manual-test test-size-solver
 
 .PHONY : quicktest
 quicktest : succeed fail
@@ -351,7 +351,14 @@ compiler-test :
 	@echo "======================================================================"
 	@echo "========================== Compiler tests ============================"
 	@echo "======================================================================"
-	@AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Compiler
+	@AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Compiler --regex-exclude AllStdLib
+
+.PHONY : stdlib-compiler-test
+stdlib-compiler-test :
+	@echo "======================================================================"
+	@echo "================== Standard Library Compiler tests ==================="
+	@echo "======================================================================"
+	@AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include AllStdLib
 
 .PHONY : api-test
 api-test :

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -127,7 +127,7 @@ stdlibTests comp = do
 
   let rtsOptions :: [String]
 -- See Issue #3792.
-      rtsOptions = [ "+RTS", "-H2G", "-M3G", "-RTS" ]
+      rtsOptions = [ "+RTS", "-H2G", "-M4G", "-RTS" ]
 
   tests' <- forM inps $ \inp -> do
     opts <- readOptions inp

--- a/test/Compiler/with-stdlib/AllStdLib.options
+++ b/test/Compiler/with-stdlib/AllStdLib.options
@@ -1,4 +1,4 @@
 TestOptions
-  { forCompilers   = [(MAlonzo, CompilerOptions {extraAgdaArgs = ["--no-ignore-interfaces", "--ghc-flag=-j3"]})]
+  { forCompilers   = [(MAlonzo, CompilerOptions {extraAgdaArgs = ["--no-ignore-interfaces", "--ghc-flag=-j2"]})]
   , runtimeOptions = []
   , executeProg    = True }


### PR DESCRIPTION
Attempt to fix Travis failures on stdlib compile.

- Run stdlib compiler test separately from other compiler tests
- Give it more memory (3G -> 4G)
- Change ghc options to -j2 instead of -j3