### PR TITLE
[ fix #4046 ] Get rid of codata definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,9 @@ Language
   fails = Foo.foo
   ```
 
+* `codata` definitions have been removed from the concrete syntax
+  Previously they got accepted syntactically, but resulted in errors.
+
 ### Modalities
 
 * New Flat Modality

--- a/doc/user-manual/language/lexical-structure.lagda.rst
+++ b/doc/user-manual/language/lexical-structure.lagda.rst
@@ -36,7 +36,6 @@ keywords
 
   ``=`` ``|`` ``->`` ``→`` ``:`` ``?`` ``\`` ``λ``
   :ref:`∀ <notational-conventions>` ``..`` ``...`` ``abstract``
-  ``codata`` :ref:`coinductive <copatterns-coinductive-records>`
   ``constructor`` ``data`` :ref:`do <do-notation>` ``eta-equality`` ``field``
   :ref:`forall <notational-conventions>` ``hiding`` ``import`` ``in``
   ``inductive`` ``infix`` ``infixl`` ``infixr`` ``instance`` ``let``

--- a/doc/user-manual/tools/auto.rst
+++ b/doc/user-manual/tools/auto.rst
@@ -208,9 +208,6 @@ Limitations
 * Case split mode sometimes gives a unnecessarily complex RHS for some
   clause when the solution consists of several clauses.
 
-* The special constraints that apply to ``codata`` are not respected
-  by Agsy. Agsy treats ``codata`` just like ``data``.
-
 * Agsy has universe subtyping, so sometimes suggests solutions not
   accepted by Agda.
 

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -321,17 +321,17 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
         ccscov <- constructorCoverageCode q (np + ni) cs ty hsCons
         cds <- mapM compiledcondecl cs
         let result = concat $
-              [ tvaldecl q (dataInduction d) (np + ni) [] (Just __IMPOSSIBLE__)
+              [ tvaldecl q Inductive (np + ni) [] (Just __IMPOSSIBLE__)
               , [ compiledTypeSynonym q ty np ]
               , cds
               , ccscov
               ]
         return result
       Datatype{ dataPars = np, dataIxs = ni, dataClause = cl,
-                dataCons = cs, dataInduction = ind } -> do
+                dataCons = cs } -> do
         computeErasedConstructorArgs q
-        cds <- mapM (flip condecl ind) cs
-        return $ tvaldecl q ind (np + ni) cds cl
+        cds <- mapM (flip condecl Inductive) cs
+        return $ tvaldecl q Inductive (np + ni) cds cl
       Constructor{} -> return []
       GeneralizableVar{} -> return []
       Record{ recPars = np, recClause = cl, recConHead = con,

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -389,9 +389,9 @@ data Declaration
   | Generalize Range [TypeSignature] -- ^ Variables to be generalized, can be hidden and/or irrelevant.
   | Field Range [FieldSignature]
   | FunClause LHS RHS WhereClause Bool
-  | DataSig     Range Induction Name [LamBinding] Expr -- ^ lone data signature in mutual block
-  | Data        Range Induction Name [LamBinding] Expr [TypeSignatureOrInstanceBlock]
-  | DataDef     Range Induction Name [LamBinding] [TypeSignatureOrInstanceBlock]
+  | DataSig     Range Name [LamBinding] Expr -- ^ lone data signature in mutual block
+  | Data        Range Name [LamBinding] Expr [TypeSignatureOrInstanceBlock]
+  | DataDef     Range Name [LamBinding] [TypeSignatureOrInstanceBlock]
   | RecordSig   Range Name [LamBinding] Expr -- ^ lone record signature in mutual block
   | RecordDef   Range Name (Maybe (Ranged Induction)) (Maybe HasEta) (Maybe (Name, IsInstance)) [LamBinding] [Declaration]
   | Record      Range Name (Maybe (Ranged Induction)) (Maybe HasEta) (Maybe (Name, IsInstance)) [LamBinding] Expr [Declaration]
@@ -745,9 +745,9 @@ instance HasRange Declaration where
   getRange (FieldSig _ _ x t)      = fuseRange x t
   getRange (Field r _)             = r
   getRange (FunClause lhs rhs wh _) = fuseRange lhs rhs `fuseRange` wh
-  getRange (DataSig r _ _ _ _)     = r
-  getRange (Data r _ _ _ _ _)      = r
-  getRange (DataDef r _ _ _ _)     = r
+  getRange (DataSig r _ _ _)       = r
+  getRange (Data r _ _ _ _)        = r
+  getRange (DataDef r _ _ _)       = r
   getRange (RecordSig r _ _ _)     = r
   getRange (RecordDef r _ _ _ _ _ _) = r
   getRange (Record r _ _ _ _ _ _ _)  = r
@@ -883,9 +883,9 @@ instance KillRange Declaration where
   killRange (Generalize r ds )      = killRange1 (Generalize noRange) ds
   killRange (Field r fs)            = killRange1 (Field noRange) fs
   killRange (FunClause l r w ca)    = killRange4 FunClause l r w ca
-  killRange (DataSig _ i n l e)     = killRange4 (DataSig noRange) i n l e
-  killRange (Data _ i n l e c)      = killRange4 (Data noRange i) n l e c
-  killRange (DataDef _ i n l c)     = killRange3 (DataDef noRange i) n l c
+  killRange (DataSig _ n l e)       = killRange3 (DataSig noRange) n l e
+  killRange (Data _ n l e c)        = killRange4 (Data noRange) n l e c
+  killRange (DataDef _ n l c)       = killRange3 (DataDef noRange) n l c
   killRange (RecordSig _ n l e)     = killRange3 (RecordSig noRange) n l e
   killRange (RecordDef _ n mi mb mn k d) = killRange6 (RecordDef noRange) n mi mb mn k d
   killRange (Record _ n mi mb mn k e d)  = killRange7 (Record noRange) n mi mb mn k e d
@@ -1095,9 +1095,9 @@ instance NFData Declaration where
   rnf (Generalize _ a)        = rnf a
   rnf (Field _ fs)            = rnf fs
   rnf (FunClause a b c d)     = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
-  rnf (DataSig _ a b c d)     = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
-  rnf (Data _ a b c d e)      = rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e
-  rnf (DataDef _ a b c d)     = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
+  rnf (DataSig _ a b c)       = rnf a `seq` rnf b `seq` rnf c
+  rnf (Data _ a b c d)        = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
+  rnf (DataDef _ a b c)       = rnf a `seq` rnf b `seq` rnf c
   rnf (RecordSig _ a b c)     = rnf a `seq` rnf b `seq` rnf c
   rnf (RecordDef _ a b c d e f) = rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f
   rnf (Record _ a b c d e f g)  = rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f `seq` rnf g

--- a/src/full/Agda/Syntax/Concrete/Fixity.hs
+++ b/src/full/Agda/Syntax/Concrete/Fixity.hs
@@ -211,9 +211,9 @@ declaredNames d = case d of
     | IdentP (QName x) <- removeSingletonRawAppP p
                        -> declaresName x
   FunClause{}          -> mempty
-  DataSig _ _ x _ _    -> declaresName x
-  DataDef _ _ _ _ cs   -> foldMap declaredNames cs
-  Data _ _ x _ _ cs    -> declaresName x <> foldMap declaredNames cs
+  DataSig _ x _ _      -> declaresName x
+  DataDef _ _ _ cs     -> foldMap declaredNames cs
+  Data _ x _ _ cs      -> declaresName x <> foldMap declaredNames cs
   RecordSig _ x _ _    -> declaresName x
   RecordDef _ x _ _ c _ _ -> declaresNames $     foldMap (:[]) (fst <$> c)
   Record _ x _ _ c _ _ _  -> declaresNames $ x : foldMap (:[]) (fst <$> c)

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -208,9 +208,9 @@ instance ExprLike Declaration where
      FieldSig i t n e          -> FieldSig i (mapE t) n (mapE e)
      Field r fs                -> Field r                              $ map (mapExpr f) fs
      FunClause lhs rhs wh ca   -> FunClause (mapE lhs) (mapE rhs) (mapE wh) (mapE ca)
-     DataSig r ind x bs e      -> DataSig r ind x (mapE bs)            $ mapE e
-     DataDef r ind n bs cs     -> DataDef r ind n (mapE bs)            $ mapE cs
-     Data r ind n bs e cs      -> Data r ind n (mapE bs) (mapE e)      $ mapE cs
+     DataSig r x bs e          -> DataSig r x (mapE bs)                $ mapE e
+     DataDef r n bs cs         -> DataDef r n (mapE bs)                $ mapE cs
+     Data r n bs e cs          -> Data r n (mapE bs) (mapE e)          $ mapE cs
      RecordSig r ind bs e      -> RecordSig r ind (mapE bs)            $ mapE e
      RecordDef r n ind eta c tel ds -> RecordDef r n ind eta c (mapE tel) $ mapE ds
      Record r n ind eta c tel e ds  -> Record r n ind eta c (mapE tel) (mapE e) $ mapE ds

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -475,7 +475,7 @@ instance Pretty Declaration where
                 sep [ pretty lhs
                     , nest 2 $ pretty rhs
                     ] $$ nest 2 (pretty wh)
-            DataSig _ ind x tel e ->
+            DataSig _ x tel e ->
                 sep [ hsep  [ "data"
                             , pretty x
                             , fcat (map pretty tel)
@@ -485,7 +485,7 @@ instance Pretty Declaration where
                             , pretty e
                             ]
                     ]
-            Data _ ind x tel e cs ->
+            Data _ x tel e cs ->
                 sep [ hsep  [ "data"
                             , pretty x
                             , fcat (map pretty tel)
@@ -496,7 +496,7 @@ instance Pretty Declaration where
                             , "where"
                             ]
                     ] $$ nest 2 (vcat $ map pretty cs)
-            DataDef _ ind x tel cs ->
+            DataDef _ x tel cs ->
                 sep [ hsep  [ "data"
                             , pretty x
                             , fcat (map pretty tel)

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1213,20 +1213,16 @@ RHS : '=' Expr      { JustRHS (RHS $2) }
 -- Data declaration. Can be local.
 Data :: { Declaration }
 Data : 'data' Id TypedUntypedBindings ':' Expr 'where'
-            Declarations0       { Data (getRange ($1,$2,$3,$4,$5,$6,$7)) Inductive $2 $3 $5 $7 }
-     | 'codata' Id TypedUntypedBindings ':' Expr 'where'
-            Declarations0       { Data (getRange ($1,$2,$3,$4,$5,$6,$7)) CoInductive $2 $3 $5 $7 }
+            Declarations0       { Data (getRange ($1,$2,$3,$4,$5,$6,$7)) $2 $3 $5 $7 }
 
   -- New cases when we already had a DataSig.  Then one can omit the sort.
      | 'data' Id TypedUntypedBindings 'where'
-            Declarations0       { DataDef (getRange ($1,$2,$3,$4,$5)) Inductive $2 $3 $5 }
-     | 'codata' Id TypedUntypedBindings 'where'
-            Declarations0       { DataDef (getRange ($1,$2,$3,$4,$5)) CoInductive $2 $3 $5 }
+            Declarations0       { DataDef (getRange ($1,$2,$3,$4,$5)) $2 $3 $5 }
 
 -- Data type signature. Found in mutual blocks.
 DataSig :: { Declaration }
 DataSig : 'data' Id TypedUntypedBindings ':' Expr
-  { DataSig (getRange ($1,$2,$3,$4,$5)) Inductive $2 $3 $5 }
+  { DataSig (getRange ($1,$2,$3,$4,$5)) $2 $3 $5 }
 
 -- Andreas, 2012-03-16:  The Expr3NoCurly instead of Id in everything
 -- following 'record' is to remove the (harmless) shift/reduce conflict

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -932,8 +932,8 @@ instance ToConcrete A.WhereDeclarations WhereClause where
 mergeSigAndDef :: [C.Declaration] -> [C.Declaration]
 mergeSigAndDef (C.RecordSig _ x bs e : C.RecordDef r y ind eta c _ fs : ds)
   | x == y = C.Record r y ind eta c bs e fs : mergeSigAndDef ds
-mergeSigAndDef (C.DataSig _ _ x bs e : C.DataDef r i y _ cs : ds)
-  | x == y = C.Data r i y bs e cs : mergeSigAndDef ds
+mergeSigAndDef (C.DataSig _ x bs e : C.DataDef r y _ cs : ds)
+  | x == y = C.Data r y bs e cs : mergeSigAndDef ds
 mergeSigAndDef (d : ds) = d : mergeSigAndDef ds
 mergeSigAndDef [] = []
 
@@ -1057,13 +1057,13 @@ instance ToConcrete A.Declaration [C.Declaration] where
     bindToConcrete (A.generalizeTel bs) $ \ tel' -> do
       x' <- unsafeQNameToName <$> toConcrete x
       t' <- toConcreteTop t
-      return [ C.DataSig (getRange i) Inductive x' (map C.DomainFull tel') t' ]
+      return [ C.DataSig (getRange i) x' (map C.DomainFull tel') t' ]
 
   toConcrete (A.DataDef i x uc bs cs) =
     withAbstractPrivate i $
     bindToConcrete (map makeDomainFree $ dataDefParams bs) $ \ tel' -> do
       (x',cs') <- first unsafeQNameToName <$> toConcrete (x, map Constr cs)
-      return [ C.DataDef (getRange i) Inductive x' tel' cs' ]
+      return [ C.DataDef (getRange i) x' tel' cs' ]
 
   toConcrete (A.RecSig i x bs t) =
     withAbstractPrivate i $

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -902,9 +902,7 @@ isDatatype ind at = do
       let ~(Just args) = allApplyElims es
       def <- liftTCM $ theDef <$> getConstInfo d
       case def of
-        Datatype{dataPars = np, dataCons = cs, dataInduction = i}
-          | i == CoInductive && ind /= CoInductive ->
-              throw CoinductiveDatatype
+        Datatype{dataPars = np, dataCons = cs}
           | otherwise -> do
               let (ps, is) = splitAt np args
               return (IsData, d, ps, is, cs, not $ null (dataPathCons def))

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1934,7 +1934,6 @@ data Defn = Axiom -- ^ Postulate
           | Datatype
             { dataPars           :: Nat            -- ^ Number of parameters.
             , dataIxs            :: Nat            -- ^ Number of indices.
-            , dataInduction      :: Induction      -- ^ @data@ or @codata@ (legacy).
             , dataClause         :: (Maybe Clause) -- ^ This might be in an instantiated module.
             , dataCons           :: [QName]
               -- ^ Constructor names , ordered according to the order of their definition.
@@ -2053,7 +2052,6 @@ instance Pretty Defn where
     "Datatype {" <?> vcat
       [ "dataPars       =" <?> pshow dataPars
       , "dataIxs        =" <?> pshow dataIxs
-      , "dataInduction  =" <?> pshow dataInduction
       , "dataClause     =" <?> pretty dataClause
       , "dataCons       =" <?> pshow dataCons
       , "dataSort       =" <?> pretty dataSort
@@ -4218,7 +4216,7 @@ instance KillRange Defn where
       AbstractDefn{} -> __IMPOSSIBLE__ -- only returned by 'getConstInfo'!
       Function cls comp ct tt covering inv mut isAbs delayed proj flags term extlam with ->
         killRange14 Function cls comp ct tt covering inv mut isAbs delayed proj flags term extlam with
-      Datatype a b c d e f g h i     -> killRange8 Datatype a b c d e f g h i
+      Datatype a b c d e f g h       -> killRange7 Datatype a b c d e f g h
       Record a b c d e f g h i j k   -> killRange11 Record a b c d e f g h i j k
       Constructor a b c d e f g h i j-> killRange10 Constructor a b c d e f g h i j
       Primitive a b c d e            -> killRange5 Primitive a b c d e

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -612,7 +612,7 @@ whatInduction c = liftTCM $ do
   mz <- getBuiltinName' builtinIZero
   mo <- getBuiltinName' builtinIOne
   case def of
-    Datatype{ dataInduction = i } -> return i
+    Datatype{}                    -> return Inductive
     Record{} | not (recRecursive def) -> return Inductive
     Record{ recInduction = i    } -> return $ fromMaybe Inductive i
     Constructor{ conInd = i }     -> return i

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -553,7 +553,7 @@ inductiveCheck b n t = do
       def <- getConstInfo q
       let yes = return (q, def)
       case theDef def of
-        Datatype { dataInduction = Inductive, dataCons = cs }
+        Datatype { dataCons = cs }
           | length cs == n -> yes
           | otherwise      -> no
         Record { recInduction = ind } | n == 1 && ind /= Just CoInductive -> yes
@@ -930,7 +930,6 @@ bindBuiltinNoDef b q = inTopContext $ do
         def = Datatype
               { dataPars       = 0
               , dataIxs        = 0
-              , dataInduction  = Inductive
               , dataClause     = Nothing
               , dataCons       = []     -- Constructors are added later
               , dataSort       = Inf

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -140,7 +140,6 @@ checkDataDef i name uc (A.DataDefParams gpars ps) cs =
             let dataDef = Datatype
                   { dataPars       = npars
                   , dataIxs        = nofIxs
-                  , dataInduction  = Inductive
                   , dataClause     = Nothing
                   , dataCons       = []     -- Constructors are added later
                   , dataSort       = s
@@ -1217,8 +1216,7 @@ isCoinductive t = do
         Axiom       {} -> return (Just False)
         DataOrRecSig{} -> return Nothing
         Function    {} -> return Nothing
-        Datatype    { dataInduction = CoInductive } -> return (Just True)
-        Datatype    { dataInduction = Inductive   } -> return (Just False)
+        Datatype    {} -> return (Just False)
         Record      {  recInduction = Just CoInductive } -> return (Just True)
         Record      {  recInduction = _                } -> return (Just False)
         GeneralizableVar{} -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -330,7 +330,7 @@ instance EmbPrj Defn where
   icod_ (Function    a b s t (_:_) c d e f g h i j k)   = __IMPOSSIBLE__
   icod_ (Function    a b s t []    c d e f g h i j k)   =
     icodeN 1 (\ a b s -> Function a b s t []) a b s c d e f g h i j k
-  icod_ (Datatype    a b c d e f g h i)                 = icodeN 2 Datatype a b c d e f g h i
+  icod_ (Datatype    a b c d e f g h)                   = icodeN 2 Datatype a b c d e f g h
   icod_ (Record      a b c d e f g h i j k)             = icodeN 3 Record a b c d e f g h i j k
   icod_ (Constructor a b c d e f g h i j)               = icodeN 4 Constructor a b c d e f g h i j
   icod_ (Primitive   a b c d e)                         = icodeN 5 Primitive a b c d e
@@ -341,7 +341,7 @@ instance EmbPrj Defn where
   value = vcase valu where
     valu [0]                                        = valuN Axiom
     valu [1, a, b, s, c, d, e, f, g, h, i, j, k]    = valuN (\ a b s -> Function a b s Nothing []) a b s c d e f g h i j k
-    valu [2, a, b, c, d, e, f, g, h, i]             = valuN Datatype a b c d e f g h i
+    valu [2, a, b, c, d, e, f, g, h]                = valuN Datatype a b c d e f g h
     valu [3, a, b, c, d, e, f, g, h, i, j, k]       = valuN Record  a b c d e f g h i j k
     valu [4, a, b, c, d, e, f, g, h, i, j]          = valuN Constructor a b c d e f g h i j
     valu [5, a, b, c, d, e]                         = valuN Primitive   a b c d e

--- a/test/Fail/Codata.agda
+++ b/test/Fail/Codata.agda
@@ -1,3 +1,0 @@
-module Codata where
-
-codata D : Set where

--- a/test/Fail/Codata.err
+++ b/test/Fail/Codata.err
@@ -1,2 +1,0 @@
-Codata.agda:3,1-21
-The codata construction has been removed. Use the INFINITY builtin instead.


### PR DESCRIPTION
Reviewers, which of the below need cleanups?

There is still one hit with `git grep -i CoData` in need of cleaning up.
- [ ] This comment **needs an update** `src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs:60:-- codata ∞ {a} (A : Set a) : Set a where`

Hints, suggestions welcome. Encouragement about the general direction too :-)
@gallais, we talked about the parser at ICFP, maybe you can have a look (or suggest someone else).

Fixes #4046.