### PR TITLE
Make emacs-mode delete til end of line on C-c C-c

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -926,10 +926,11 @@ Assumes that <clause> = {!<variables>!} is on one line."
 (defun agda2-make-case-action (newcls)
   "Replace the line at point with new clauses NEWCLS and reload."
   (agda2-forget-all-goals);; we reload later anyway.
-  (let* ((p0 (goto-char (+ (current-indentation) (line-beginning-position))))
+  (let* ((p0 (point))
+	 (p1 (goto-char (+ (current-indentation) (line-beginning-position))))
          (indent (current-column))
          cl)
-    (delete-region p0 (line-end-position))
+    (delete-region p1 (line-end-position))
     (while (setq cl (pop newcls))
       (insert cl)
       (if newcls (insert "\n" (make-string indent ?  ))))

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -926,18 +926,14 @@ Assumes that <clause> = {!<variables>!} is on one line."
 (defun agda2-make-case-action (newcls)
   "Replace the line at point with new clauses NEWCLS and reload."
   (agda2-forget-all-goals);; we reload later anyway.
-  (let* ((p0 (point))
-         ;; (p1 (goto-char (agda2-decl-beginning)))
-         (p1 (goto-char (+ (current-indentation) (line-beginning-position))))
+  (let* ((p0 (goto-char (+ (current-indentation) (line-beginning-position))))
          (indent (current-column))
          cl)
-    (goto-char p0)
-    (re-search-forward "!}" (line-end-position) 'noerr)
-    (delete-region p1 (point))
+    (delete-region p0 (line-end-position))
     (while (setq cl (pop newcls))
       (insert cl)
       (if newcls (insert "\n" (make-string indent ?  ))))
-    (goto-char p1))
+    (goto-char p0))
   (agda2-load))
 
 (defun agda2-make-case-action-extendlam (newcls)


### PR DESCRIPTION
This change deletes the line where a case split occurs before inserting the lines.

Tests: 

```agda
module case where
open import Data.Nat

f : ℕ → ℕ → ℕ
f x y = ({!!})

h : ℕ → ℕ
h z = f {!!} {!!}

g : ℕ → ℕ
g v = g' v
  where
    g' : ℕ → ℕ
    g' v' = ({!!})
```

Splitting on hole `{x}0`, `{z}1`, and `{v'}3` produces

```agda
module case where
open import Data.Nat

f : ℕ → ℕ → ℕ
f zero y = ({!!})
f (suc x) y = ({!!})

h : ℕ → ℕ
h zero = f {!!} {!!}
h (suc z) = f {!!} {!!}

g : ℕ → ℕ
g v = g' v
  where
    g' : ℕ → ℕ
    g' zero = ({!!})
    g' (suc v') = ({!!})
```