### PR TITLE
Use --force-reinstalls to install shelltestrunner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -390,7 +390,7 @@ script:
     fi
 
   - if [[ $TEST = "MAIN" ]]; then
-       cabal install -v0 --ghc-option=-w shelltestrunner &&
+       cabal install -v0 --ghc-option=-w --force-reinstalls shelltestrunner &&
        make test-size-solver;
     fi
 


### PR DESCRIPTION
I am not able to reproduce the cabal failure, so I have to try it here ..