### PR TITLE
Reflection literals

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -406,6 +406,7 @@ library
                     Agda.TypeChecking.Monad.Base
                     Agda.TypeChecking.Monad.Benchmark
                     Agda.TypeChecking.Monad.Builtin
+                    Agda.TypeChecking.Monad.Builtin.ConstructorForm
                     Agda.TypeChecking.Monad.Caching
                     Agda.TypeChecking.Monad.Closure
                     Agda.TypeChecking.Monad.Constraints

--- a/src/data/JS/agda-rts.js
+++ b/src/data/JS/agda-rts.js
@@ -11,6 +11,9 @@ exports.primIntegerFromString = function(x) {
 exports.primShowInteger = function(x) {
   return x.toString();
 };
+exports.primShowNat = function(x) {
+  return x.toString();
+};
 
 exports.uprimIntegerPlus = function(x,y) {
   return x.add(y);

--- a/src/full/Agda/Auto/Convert.hs
+++ b/src/full/Agda/Auto/Convert.hs
@@ -30,7 +30,7 @@ import Agda.TypeChecking.Telescope (piApplyM)
 import qualified Agda.TypeChecking.Substitute as I (absBody)
 import Agda.TypeChecking.Reduce (normalise, instantiate)
 import Agda.TypeChecking.EtaContract (etaContract)
-import Agda.TypeChecking.Monad.Builtin (constructorForm)
+import Agda.TypeChecking.Monad.Builtin.ConstructorForm (constructorForm)
 import Agda.TypeChecking.Free as Free (freeIn)
 
 import Agda.Interaction.MakeCase (getClauseZipperForIP)

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -30,7 +30,7 @@ import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Internal
   ( Name, Type
   , arity, nameFixity )
-import Agda.Syntax.Literal ( Literal(..) )
+import Agda.Syntax.Literal ( Literal'(..), Literal )
 import Agda.Syntax.Fixity
 import qualified Agda.Syntax.Treeless as T
 

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -468,6 +468,7 @@ literal l = case l of
   (LitChar   _ x) -> Char    x
   (LitQName  _ x) -> litqname x
   LitMeta{}       -> __IMPOSSIBLE__
+  LitTerm{}       -> __IMPOSSIBLE__
 
 litqname :: QName -> Exp
 litqname q =

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -541,6 +541,7 @@ primitives = Set.fromList
   , "primNatMinus"
   , "primShowFloat"
   , "primShowInteger"
+  , "primShowNat"
   , "primSin"
   , "primCos"
   , "primTan"

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -683,6 +683,7 @@ hslit l = case l of LitNat    _ x -> HS.Int    x
                     LitQName  _ x -> __IMPOSSIBLE__
                     LitString _ _ -> __IMPOSSIBLE__
                     LitMeta{}     -> __IMPOSSIBLE__
+                    LitTerm{}     -> __IMPOSSIBLE__
 
 litString :: String -> HS.Exp
 litString s =

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -654,6 +654,7 @@ literal l = case l of
   LitFloat  _ x   -> floatExp x "Double"
   LitQName  _ x   -> litqname x
   LitString _ s   -> litString s
+  LitTerm _ q     -> __IMPOSSIBLE__
   _               -> l'
   where
     l'    = HS.Lit $ hslit l

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -405,7 +405,7 @@ substTerm term = normaliseStatic term >>= \ term ->
       C.TLam <$>
         local (\e -> e { ccCxt = 0 : (shift 1 $ ccCxt e) })
           (substTerm $ I.unAbs ab)
-    I.Lit l -> return $ C.TLit l
+    I.Lit l -> return $ C.TLit (fmap (\ _ -> __IMPOSSIBLE__) l) -- Should be impossible
     I.Level _ -> return C.TUnit
     I.Def q es -> do
       let args = fromMaybe __IMPOSSIBLE__ $ I.allApplyElims es

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -26,6 +26,7 @@ import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records (getRecordConstructor)
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
+import Agda.TypeChecking.Quote
 
 import Agda.Compiler.Treeless.AsPatterns
 import Agda.Compiler.Treeless.Builtin
@@ -405,7 +406,8 @@ substTerm term = normaliseStatic term >>= \ term ->
       C.TLam <$>
         local (\e -> e { ccCxt = 0 : (shift 1 $ ccCxt e) })
           (substTerm $ I.unAbs ab)
-    I.Lit l -> return $ C.TLit (fmap (\ _ -> __IMPOSSIBLE__) l) -- Should be impossible
+    I.Lit (LitTerm _ q) -> substTerm =<< lift (quoteTerm $ quotedTerm q)
+    I.Lit l -> return $ C.TLit (fmap (\ _ -> __IMPOSSIBLE__) l)
     I.Level _ -> return C.TUnit
     I.Def q es -> do
       let args = fromMaybe __IMPOSSIBLE__ $ I.allApplyElims es

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -459,7 +459,7 @@ instance Reify Constraint (OutputConstraint Expr Expr) where
               t1 <- reify t1
               return $ PostponedCheckArgs m' (map (namedThing . unArg) args) t0 t1
             CheckProjAppToKnownPrincipalArg cmp e _ _ _ t _ _ _ -> TypedAssign m' e <$> reify t
-            DoQuoteTerm cmp v t -> do
+            DoQuoteTerm cmp v _vt t -> do
               tm <- A.App defaultAppInfo_ (A.QuoteTerm exprNoRange) . defaultNamedArg <$> reify v
               OfType tm <$> reify t
           Open{}  -> __IMPOSSIBLE__

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -456,6 +456,7 @@ tokenHighlighting = merge . map tokenToCFile
   tokenToCFile (T.TokLiteral (L.LitChar   r _)) = aToF String r
   tokenToCFile (T.TokLiteral (L.LitQName  r _)) = aToF String r
   tokenToCFile (T.TokLiteral (L.LitMeta r _ _)) = aToF String r
+  tokenToCFile (T.TokLiteral (L.LitTerm _ v))   = absurd v
   tokenToCFile (T.TokComment (i, _))            = aToF Comment (getRange i)
   tokenToCFile (T.TokTeX (i, _))                = aToF Background (getRange i)
   tokenToCFile (T.TokMarkup (i, _))             = aToF Markup (getRange i)

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -156,6 +156,7 @@ instance ExprLike Expr where
       PatternSyn{}            -> pure e0
       Tactic ei e xs ys       -> Tactic ei <$> recurse e <*> recurse xs <*> recurse ys
       Macro{}                 -> pure e0
+      Trusted{}               -> pure e0
 
   foldExpr f e =
     case e of
@@ -191,6 +192,7 @@ instance ExprLike Expr where
       Unquote{}            -> m
       Tactic _ e xs ys     -> m `mappend` fold e `mappend` fold xs `mappend` fold ys
       DontCare e           -> m `mappend` fold e
+      Trusted{}            -> m
    where
      m    = f e
      fold = foldExpr f
@@ -230,6 +232,7 @@ instance ExprLike Expr where
       DontCare e              -> f =<< DontCare <$> trav e
       PatternSyn{}            -> f e
       Macro{}                 -> f e
+      Trusted{}               -> f e
 
 instance ExprLike a => ExprLike (Arg a)     where
 instance ExprLike a => ExprLike (Maybe a)   where

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -213,9 +213,9 @@ data Term = Var {-# UNPACK #-} !Int Elims -- ^ @x es@ neutral
   deriving (Data, Show)
 
 data QuotedTerm = QuotedTerm
-  { quotedType       :: Type
+  { quotedType       :: Maybe Type
   , quotedTerm       :: Term
-  , quotedCheckpoint :: CheckpointId
+  , quotedCheckpoint :: Maybe CheckpointId
   } deriving (Data, Show)
 
 type ConInfo = ConOrigin

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -180,6 +180,9 @@ instance NamesIn DisplayTerm where
     DDot v           -> namesIn v
     DTerm v          -> namesIn v
 
+instance NamesIn QuotedTerm where
+  namesIn q = namesIn (quotedTerm q, quotedType q)
+
 -- Pattern synonym stuff --
 
 newtype PSyn = PSyn A.PatternSynDefn

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -7,6 +7,7 @@ module Agda.Syntax.Internal.Names where
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Void
 
 import Agda.Syntax.Common
 import Agda.Syntax.Literal
@@ -37,6 +38,9 @@ instance NamesIn a => NamesIn (Abs a)                where
 instance NamesIn a => NamesIn (WithArity a)          where
 instance NamesIn a => NamesIn (Tele a)               where
 instance NamesIn a => NamesIn (C.FieldAssignment' a) where
+
+instance NamesIn Void where
+  namesIn _ = Set.empty
 
 instance (NamesIn a, NamesIn b) => NamesIn (a, b) where
   namesIn (x, y) = Set.union (namesIn x) (namesIn y)
@@ -144,7 +148,7 @@ instance NamesIn LevelAtom where
     UnreducedLevel v -> namesIn v
 
 -- For QName literals!
-instance NamesIn Literal where
+instance NamesIn t => NamesIn (Literal' t) where
   namesIn l = case l of
     LitNat{}      -> Set.empty
     LitWord64{}   -> Set.empty
@@ -153,6 +157,7 @@ instance NamesIn Literal where
     LitFloat{}    -> Set.empty
     LitQName _  x -> namesIn x
     LitMeta{}     -> Set.empty
+    LitTerm _ t   -> namesIn t
 
 instance NamesIn a => NamesIn (Elim' a) where
   namesIn (Apply arg) = namesIn arg

--- a/src/full/Agda/Syntax/Internal/Pattern.hs
+++ b/src/full/Agda/Syntax/Internal/Pattern.hs
@@ -9,6 +9,7 @@ import Control.Monad.State
 import Data.Maybe
 import Data.Monoid
 import qualified Data.List as List
+import Data.Void
 
 import Agda.Syntax.Common
 import Agda.Syntax.Abstract (IsProjP(..))
@@ -160,7 +161,7 @@ patternToElim (Arg ai (ConP c cpi ps)) = Apply $ Arg ai $ Con c ci $
 patternToElim (Arg ai (DefP o q ps)) = Apply $ Arg ai $ Def q $
       map (patternToElim . fmap namedThing) ps
 patternToElim (Arg ai (DotP o t)   ) = Apply $ Arg ai t
-patternToElim (Arg ai (LitP l)     ) = Apply $ Arg ai $ Lit l
+patternToElim (Arg ai (LitP l)     ) = Apply $ Arg ai $ Lit (vacuous l)
 patternToElim (Arg ai (ProjP o dest)) = Proj o dest
 patternToElim (Arg ai (IApplyP o t u x)) = IApply t u $ var $ dbPatVarIndex x
 

--- a/src/full/Agda/Syntax/Literal.hs
+++ b/src/full/Agda/Syntax/Literal.hs
@@ -5,6 +5,7 @@ module Agda.Syntax.Literal where
 import Control.DeepSeq
 import Data.Char
 import Data.Word
+import Data.Void
 
 import Data.Data (Data)
 
@@ -16,14 +17,16 @@ import Agda.Syntax.Abstract.Name
 import Agda.Utils.Pretty
 import Agda.Utils.FileName
 
-data Literal = LitNat    Range !Integer
-             | LitWord64 Range !Word64
-             | LitFloat  Range !Double
-             | LitString Range String
-             | LitChar   Range !Char
-             | LitQName  Range QName
-             | LitMeta   Range AbsolutePath MetaId
-  deriving Data
+data Literal' t = LitNat    Range !Integer
+                | LitWord64 Range !Word64
+                | LitFloat  Range !Double
+                | LitString Range String
+                | LitChar   Range !Char
+                | LitQName  Range QName
+                | LitMeta   Range AbsolutePath MetaId
+  deriving (Data, Functor)
+
+type Literal = Literal' Void
 
 instance Show Literal where
   showsPrec p l = showParen (p > 9) $ case l of

--- a/src/full/Agda/Syntax/Reflected.hs
+++ b/src/full/Agda/Syntax/Reflected.hs
@@ -6,6 +6,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Literal
 import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Internal (Dom)
+import qualified Agda.Syntax.Internal as I
 
 type Args       = [Arg Term]
 
@@ -29,6 +30,7 @@ data Term = Var Int Elims
           | Pi (Dom Type) (Abs Type)
           | Sort Sort
           | Lit Literal
+          | Trusted I.QuotedTerm
           | Unknown
   deriving (Show)
 

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -843,6 +843,8 @@ instance ToConcrete A.Expr C.Expr where
        where r = getRange e
     toConcrete (A.PatternSyn n) = C.Ident <$> toConcrete (headAmbQ n)
 
+    toConcrete A.Trusted{} = __IMPOSSIBLE__
+
 makeDomainFree :: A.LamBinding -> A.LamBinding
 makeDomainFree b@(A.DomainFull (A.TBind _ tac [x] t)) =
   case unScope t of

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -843,7 +843,7 @@ instance ToConcrete A.Expr C.Expr where
        where r = getRange e
     toConcrete (A.PatternSyn n) = C.Ident <$> toConcrete (headAmbQ n)
 
-    toConcrete A.Trusted{} = __IMPOSSIBLE__
+    toConcrete (A.Trusted q) = return $ C.Lit $ LitString noRange (show $ pretty q)
 
 makeDomainFree :: A.LamBinding -> A.LamBinding
 makeDomainFree b@(A.DomainFull (A.TBind _ tac [x] t)) =

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1007,6 +1007,7 @@ instance BlankVars A.Expr where
     A.DontCare v           -> A.DontCare $ blank bound v
     A.PatternSyn {}        -> e
     A.Macro {}             -> e
+    A.Trusted {}           -> e
 
 instance BlankVars A.ModuleName where
   blank bound = id

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -45,7 +45,6 @@ import Agda.Syntax.Info as Info
 import Agda.Syntax.Abstract as A hiding (Binder)
 import qualified Agda.Syntax.Abstract as A
 import Agda.Syntax.Abstract.Pattern
-import Agda.Syntax.Abstract.Pretty
 import Agda.Syntax.Internal as I
 import Agda.Syntax.Scope.Base (inverseScopeLookupName)
 
@@ -247,12 +246,6 @@ reifyDisplayFormP f ps wps = do
         -- Andreas, 2014-06-11:
         -- Are we sure that @d@ did not use @var i@ otherwise?
         (f', ps', wps') <- displayLHS ps d
-        reportSDoc "reify.display" 70 $ do
-          doc <- prettyA $ SpineLHS empty f' (ps' ++ wps' ++ wps)
-          return $ vcat
-            [ "rewritten lhs to"
-            , "  lhs' = " <+> doc
-            ]
         reifyDisplayFormP f' ps' (wps' ++ wps)
       _ -> do
         reportSLn "reify.display" 70 $ "display form absent or not valid as lhs"

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -145,6 +145,7 @@ instance ToAbstract Term Expr where
     R.Meta x es    -> toAbstract (A.Underscore info, es)
       where info = emptyMetaInfo{ metaNumber = Just x }
     R.Unknown      -> return $ Underscore emptyMetaInfo
+    R.Trusted q -> pure $ A.Trusted q
 
 mkDef :: HasConstInfo m => QName -> m A.Expr
 mkDef f =

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -52,6 +52,7 @@ import Agda.TypeChecking.Datatypes
 import Agda.TypeChecking.Functions
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Builtin.ConstructorForm
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records -- (isRecordConstructor, isInductiveRecord)
 import Agda.TypeChecking.Reduce (reduce, normalise, instantiate, instantiateFull)

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -574,7 +574,7 @@ instance TermToPattern Term DeBruijnPattern where
     DontCare t  -> termToPattern t -- OR: __IMPOSSIBLE__  -- removed by stripAllProjections
     -- Leaves.
     Var i []    -> varP . (`DBPatVar` i) . prettyShow <$> nameOfBV i
-    Lit l       -> return $ LitP (fmap (\ _ -> __IMPOSSIBLE__) l) -- TODO: not impossible
+    Lit l       -> return $ LitP (fmap (\ _ -> __IMPOSSIBLE__) l)
     Dummy s _   -> __IMPOSSIBLE_VERBOSE__ s
     t           -> return $ dotP t
 

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -10,6 +10,7 @@ import Data.Maybe
 import qualified Data.Map as Map
 import Data.List (nubBy)
 import Data.Function
+import Data.Void
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
@@ -364,7 +365,7 @@ expandCatchAlls single n cs =
             -- TODO Andrea: might need these to sometimes be IApply?
             conPArgs = map (fmap ($> varP "_")) qs'
             conArgs  = zipWith (\ q' i -> q' $> var i) qs' $ downFrom m
-        LitP l -> Cl (ps0 ++ [q $> LitP l] ++ ps1) (substBody n' 0 (Lit l) b)
+        LitP l -> Cl (ps0 ++ [q $> LitP l] ++ ps1) (substBody n' 0 (Lit $ vacuous l) b)
         DefP o d qs' -> Cl (ps0 ++ [q $> DefP o d conPArgs] ++ ps1)
                             (substBody n' m (Def d (map Apply conArgs)) b)
           where

--- a/src/full/Agda/TypeChecking/CompiledClause/Match.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Match.hs
@@ -117,7 +117,8 @@ match' ((c, es, patch) : stack) = do
                 catchAllFrame stack = maybe stack (\c -> (c, es', patch) : stack) (catchAllBranch bs)
                 -- If our argument is @Lit l@, we push @litFrame l@ onto the stack.
                 litFrame l stack =
-                  case Map.lookup l (litBranches bs) of
+                  let l' = fmap (\ _ -> __IMPOSSIBLE__) l in -- TODO: not impossible?
+                  case Map.lookup l' (litBranches bs) of
                     Nothing -> stack
                     Just cc -> (cc, es0 ++ es1, patchLit) : stack
                 -- If our argument (or its constructor form) is @Con c ci vs@

--- a/src/full/Agda/TypeChecking/CompiledClause/Match.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Match.hs
@@ -5,6 +5,7 @@ import qualified Data.Map as Map
 
 import Agda.Syntax.Internal
 import Agda.Syntax.Common
+import Agda.Syntax.Literal
 
 import Agda.TypeChecking.CompiledClause
 import Agda.TypeChecking.Monad
@@ -116,8 +117,9 @@ match' ((c, es, patch) : stack) = do
                 -- if a catch-all clause exists, put it on the stack
                 catchAllFrame stack = maybe stack (\c -> (c, es', patch) : stack) (catchAllBranch bs)
                 -- If our argument is @Lit l@, we push @litFrame l@ onto the stack.
+                litFrame LitTerm{} stack = stack  -- No literal patterns for quoted term literals
                 litFrame l stack =
-                  let l' = fmap (\ _ -> __IMPOSSIBLE__) l in -- TODO: not impossible?
+                  let l' = fmap (\ _ -> __IMPOSSIBLE__) l in
                   case Map.lookup l' (litBranches bs) of
                     Nothing -> stack
                     Just cc -> (cc, es0 ++ es1, patchLit) : stack

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -285,7 +285,7 @@ checkTypeCheckingProblem p = case p of
   CheckProjAppToKnownPrincipalArg cmp e o ds args t k v0 pt ->
     checkProjAppToKnownPrincipalArg cmp e o ds args t k v0 pt
   CheckLambda cmp args body target -> checkPostponedLambda cmp args body target
-  DoQuoteTerm cmp et t           -> doQuoteTerm cmp et t
+  DoQuoteTerm cmp et ety t         -> doQuoteTerm cmp et ety t
 
 debugConstraints :: TCM ()
 debugConstraints = verboseS "tc.constr" 50 $ do

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -18,6 +18,7 @@ import Agda.Syntax.Translation.InternalToAbstract (reify)
 
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Builtin.ConstructorForm
 import Agda.TypeChecking.MetaVars
 import Agda.TypeChecking.MetaVars.Occurs (killArgs,PruneResult(..),rigidVarsNotContainedIn)
 import Agda.TypeChecking.Names

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -26,6 +26,7 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Void
 
 import Agda.Syntax.Common
 import Agda.Syntax.Position
@@ -1324,7 +1325,7 @@ split' checkEmpty ind allowPartialCover fixtarget
           liftTCM $ dontAssignMetas $ tryConversion $ equalType (unDom t) t'
         unless typeOk $ throwError . NotADatatype =<< do liftTCM $ buildClosure (unDom t)
         ns <- forM plits $ \lit -> do
-          let delta2' = subst 0 (Lit lit) delta2
+          let delta2' = subst 0 (Lit $ vacuous lit) delta2
               delta'  = delta1 `abstract` delta2'
               rho     = liftS x $ consS (LitP lit) idS
               ps'     = applySubst rho ps

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -463,15 +463,16 @@ unDotP (DotP o v) = reduce v >>= \case
   Con c _ vs -> do
     let ps = map (fmap $ unnamed . DotP o) $ fromMaybe __IMPOSSIBLE__ $ allApplyElims vs
     return $ ConP c noConPatternInfo ps
-  Lit l -> return $ LitP l
+  Lit l -> return $ LitP (fmap (\ _ -> __IMPOSSIBLE__) l) -- TODO: not impossible?
   v     -> return $ dotP v
 unDotP p = return p
 
 isLitP :: (MonadReduce m, HasBuiltins m) => Pattern' a -> m (Maybe Literal)
 isLitP (LitP l) = return $ Just l
 isLitP (DotP _ u) = reduce u >>= \case
-  Lit l -> return $ Just l
-  _     -> return $ Nothing
+  Lit LitTerm{} -> return Nothing
+  Lit l         -> return $ Just $ fmap (\ _ -> __IMPOSSIBLE__) l
+  _             -> return $ Nothing
 isLitP (ConP c ci []) = do
   Con zero _ [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinZero
   if | c == zero -> return $ Just $ LitNat (getRange c) 0

--- a/src/full/Agda/TypeChecking/Datatypes.hs
+++ b/src/full/Agda/TypeChecking/Datatypes.hs
@@ -10,7 +10,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Internal
 
 import Agda.TypeChecking.Monad
-import Agda.TypeChecking.Monad.Builtin (constructorForm)
+import Agda.TypeChecking.Monad.Builtin.ConstructorForm (constructorForm)
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Pretty

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -14,6 +14,7 @@ import qualified Data.Set as Set
 import Data.Maybe
 import Data.Traversable hiding (for)
 import Data.Semigroup ((<>))
+import Data.Void
 
 import qualified Agda.Syntax.Abstract.Name as A
 import Agda.Syntax.Common
@@ -398,7 +399,7 @@ invertFunction cmp blk (Inv f blkArgs hdMap) hd fallback err success = do
     metaPat (IApplyP{})      = nextMeta
     metaPat (ConP c mt args) = Con c (fromConPatternInfo mt) . map Apply <$> metaArgs args
     metaPat (DefP o q args)  = Def q . map Apply <$> metaArgs args
-    metaPat (LitP l)         = return $ Lit l
+    metaPat (LitP l)         = return $ Lit $ vacuous l
     metaPat ProjP{}          = __IMPOSSIBLE__
 
 forcePiUsingInjectivity :: Type -> TCM Type

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -23,6 +23,7 @@ import Agda.Syntax.Internal.Pattern
 
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Builtin.ConstructorForm
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Reduce
 import {-# SOURCE #-} Agda.TypeChecking.MetaVars

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -1,6 +1,8 @@
 
 module Agda.TypeChecking.Level where
 
+import Control.Monad.Fail (MonadFail)
+
 import Data.Maybe
 import qualified Data.List as List
 import Data.Traversable (traverse)
@@ -25,7 +27,7 @@ levelSucFunction :: TCM (Term -> Term)
 levelSucFunction = apply1 <$> primLevelSuc
 
 -- | Raises an error if no level kit is available.
-requireLevels :: HasBuiltins m => m LevelKit
+requireLevels :: (MonadFail m, HasBuiltins m) => m LevelKit
 requireLevels = builtinLevelKit
 
 -- | Checks whether level kit is fully available.
@@ -43,13 +45,13 @@ haveLevels = caseMaybeM (allJustM $ map getBuiltin' levelBuiltins)
 
 {-# SPECIALIZE unLevel :: Term -> TCM Term #-}
 {-# SPECIALIZE unLevel :: Term -> ReduceM Term #-}
-unLevel :: (HasBuiltins m) => Term -> m Term
+unLevel :: (MonadFail m, HasBuiltins m) => Term -> m Term
 unLevel (Level l)  = reallyUnLevelView l
 unLevel v = return v
 
 {-# SPECIALIZE reallyUnLevelView :: Level -> TCM Term #-}
 {-# SPECIALIZE reallyUnLevelView :: Level -> ReduceM Term #-}
-reallyUnLevelView :: (HasBuiltins m) => Level -> m Term
+reallyUnLevelView :: (MonadFail m, HasBuiltins m) => Level -> m Term
 reallyUnLevelView nv = do
   suc <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelSuc
   zer <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelZero

--- a/src/full/Agda/TypeChecking/Level.hs-boot
+++ b/src/full/Agda/TypeChecking/Level.hs-boot
@@ -1,7 +1,8 @@
 
 module Agda.TypeChecking.Level where
 
+import Control.Monad.Fail (MonadFail)
 import Agda.TypeChecking.Monad.Builtin (HasBuiltins)
 import Agda.Syntax.Internal
 
-reallyUnLevelView :: (HasBuiltins m) => Level -> m Term
+reallyUnLevelView :: (MonadFail m, HasBuiltins m) => Level -> m Term

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -417,7 +417,7 @@ postponeTypeCheckingProblem_ p = do
     unblock (CheckArgs _ _ _ t _ _)   = unblockedTester t  -- The type of the head of the application.
     unblock (CheckProjAppToKnownPrincipalArg _ _ _ _ _ _ _ _ t) = unblockedTester t -- The type of the principal argument
     unblock (CheckLambda _ _ _ t)     = unblockedTester t
-    unblock (DoQuoteTerm _ _ _)       = __IMPOSSIBLE__     -- also quoteTerm problems
+    unblock DoQuoteTerm{}             = __IMPOSSIBLE__     -- also quoteTerm problems
 
 -- | Create a postponed type checking problem @e : t@ that waits for conditon
 --   @unblock@.  A new meta is created in the current context that has as
@@ -458,7 +458,7 @@ problemType (CheckExpr _ _ t         ) = t
 problemType (CheckArgs _ _ _ _ t _ )   = t  -- The target type of the application.
 problemType (CheckProjAppToKnownPrincipalArg _ _ _ _ _ t _ _ _) = t -- The target type of the application
 problemType (CheckLambda _ _ _ t     ) = t
-problemType (DoQuoteTerm _ _ t)        = t
+problemType (DoQuoteTerm _ _ _ t)      = t
 
 -- | Eta expand metavariables listening on the current meta.
 etaExpandListeners :: MetaId -> TCM ()

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -735,15 +735,6 @@ instance Pretty ProblemId where
 instance HasFresh ProblemId where
   freshLens = stFreshProblemId
 
-newtype CheckpointId = CheckpointId Int
-  deriving (Data, Eq, Ord, Enum, Real, Integral, Num)
-
-instance Show CheckpointId where
-  show (CheckpointId n) = show n
-
-instance Pretty CheckpointId where
-  pretty (CheckpointId n) = pretty n
-
 instance HasFresh CheckpointId where
   freshLens = stFreshCheckpointId
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1234,7 +1234,7 @@ data TypeCheckingProblem
     --     @(λ (x y : Fin _) → e) : (x : Fin n) → ?@
     --   we want to postpone @(λ (y : Fin n) → e) : ?@ where @Fin n@
     --   is a 'Type' rather than an 'A.Expr'.
-  | DoQuoteTerm Comparison Term Type -- ^ Quote the given term and check type against `Term`
+  | DoQuoteTerm Comparison Term Type Type -- ^ Quote the given term (of given type) and check second type against `Term`
 
 instance Show MetaInstantiation where
   show (InstV tel t) = "InstV " ++ show tel ++ " (" ++ show t ++ ")"

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -11,6 +11,7 @@ import qualified Control.Concurrent as C
 import qualified Control.Exception as E
 
 import qualified Control.Monad.Fail as Fail
+import Control.Monad.Fail (MonadFail)
 
 import Control.Monad.State
 import Control.Monad.Reader
@@ -3527,7 +3528,7 @@ instance Monad ReduceM where
   fail = Fail.fail
 #endif
 
-instance Fail.MonadFail ReduceM where
+instance MonadFail ReduceM where
   fail = error
 
 instance ReadTCState ReduceM where
@@ -3574,7 +3575,7 @@ instance HasOptions ReduceM where
     cl <- stPersistentOptions . stPersistentState <$> getTCState
     return $ cl{ optPragmaOptions = p }
 
-class ( Applicative m
+class ( MonadFail m
       , MonadTCEnv m
       , ReadTCState m
       , HasOptions m
@@ -3810,7 +3811,7 @@ instance MonadIO m => Monad (TCMT m) where
     fail   = Fail.fail
 #endif
 
-instance MonadIO m => Fail.MonadFail (TCMT m) where
+instance MonadIO m => MonadFail (TCMT m) where
   fail = internalError
 
 instance MonadIO m => MonadIO (TCMT m) where

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -69,6 +69,7 @@ litType l = case l of
   LitString _ _ -> el <$> primString
   LitQName _ _  -> el <$> primQName
   LitMeta _ _ _ -> el <$> primAgdaMeta
+  LitTerm _ _   -> el <$> primAgdaTerm
   where
     el t = El (mkType 0) t
 

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -57,7 +57,7 @@ instance (HasBuiltins m, Monoid w) => HasBuiltins (WriterT w m) where
 
 litType
   :: (HasBuiltins m, MonadError TCErr m, MonadTCEnv m, ReadTCState m)
-  => Literal -> m Type
+  => Literal' t -> m Type
 litType l = case l of
   LitNat _ n    -> do
     _ <- primZero

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
@@ -4,15 +4,11 @@ module Agda.TypeChecking.Monad.Builtin where
 import Control.Monad.Reader
 import Control.Monad.State
 
-import qualified Control.Monad.Fail as Fail
 import Control.Monad.IO.Class (MonadIO)
 
 import Agda.TypeChecking.Monad.Base (TCMT, Builtin, PrimFun)
 
-class ( Functor m
-      , Applicative m
-      , Fail.MonadFail m
-      ) => HasBuiltins m where
+class Monad m => HasBuiltins m where
   getBuiltinThing :: String -> m (Maybe (Builtin PrimFun))
 
 instance HasBuiltins m => HasBuiltins (ReaderT e m)

--- a/src/full/Agda/TypeChecking/Monad/Builtin/ConstructorForm.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin/ConstructorForm.hs
@@ -1,0 +1,313 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-- | Revealing the top-level layer of constructors of literals (natural numbers and quoted terms).
+module Agda.TypeChecking.Monad.Builtin.ConstructorForm
+  ( constructorForm
+  , constructorForm'
+  , QuotedTermKit
+  , getQuotedTermKit
+  , quotedTermConstructorForm
+  ) where
+
+import Control.Monad.Reader
+import Control.Monad.Trans
+import Control.Monad.Trans.Maybe
+
+import qualified Data.HashMap.Strict as HMap
+import Data.Maybe
+import Data.Void
+
+import Agda.Syntax.Common
+import Agda.Syntax.Literal
+import Agda.Syntax.Position
+import Agda.Syntax.Internal
+import Agda.Syntax.Internal.Pattern
+
+import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Signature
+import Agda.TypeChecking.CompiledClause
+import Agda.TypeChecking.DropArgs
+import Agda.TypeChecking.Substitute
+
+import Agda.Utils.FileName
+import Agda.Utils.Impossible
+import Agda.Utils.Lens
+import Agda.Utils.Maybe
+import Agda.Utils.Size
+
+-- | Rewrite a literal to constructor form if possible.
+constructorForm :: (HasBuiltins m, MonadTCEnv m, ReadTCState m) => Term -> m Term
+constructorForm v =
+  case v of
+    Lit (LitNat r n)
+      | n == 0    -> fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinZero
+      | n > 0     -> do
+        suc <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSuc
+        return $ suc `apply1` Lit (LitNat r $ n - 1)
+      | otherwise -> pure v
+    Lit (LitTerm _ q) -> quotedTermConstructorFormM q
+    _ -> pure v
+
+-- | Caution: Only does natural numbers!
+constructorForm' :: Applicative m => m Term -> m Term -> Term -> m Term
+constructorForm' pZero pSuc v =
+  case v of
+    Lit (LitNat r n)
+      | n == 0    -> pZero
+      | n > 0     -> (`apply1` Lit (LitNat r $ n - 1)) <$> pSuc
+      | otherwise -> pure v
+    _ -> pure v
+
+data QuotedTermKit = QuotedTermKit
+  { qkitCurrentFile                           :: AbsolutePath
+  , qkitLevels                                :: LevelKit
+  , qkitState                                 :: TCState
+  , qkitEnv                                   :: TCEnv
+  , qkitHidden, qkitInstance, qkitVisible
+  , qkitRelevant, qkitIrrelevant
+  , qkitArg, qkitAbs, qkitArgInfo
+  , qkitNil, qkitCons
+  , qkitVar, qkitDef, qkitCon, qkitMeta
+  , qkitLam, qkitPatLam, qkitPi, qkitSort
+  , qkitLit, qkitUnknown
+  , qkitSortSet, qkitSortLit, qkitSortUnknown
+  , qkitVarP, qkitConP, qkitLitP, qkitProjP
+  , qkitDotP, qkitAbsurdP
+  , qkitLitNat, qkitLitWord64
+  , qkitLitFloat, qkitLitChar
+  , qkitLitString, qkitLitQName, qkitLitMeta
+  , qkitClause, qkitAbsurdClause              :: Term
+  }
+
+getQuotedTermKit :: (HasBuiltins m, MonadTCEnv m, ReadTCState m) => m (Maybe QuotedTermKit)
+getQuotedTermKit = runMaybeT $ do
+  qkitCurrentFile  <- fromMaybe __IMPOSSIBLE__ <$> asksTC envCurrentPath
+  qkitState        <- lift getTCState
+  qkitEnv          <- lift askTC
+  qkitLevels       <- MaybeT builtinLevelKit'
+  qkitHidden       <- getB builtinHidden
+  qkitInstance     <- getB builtinInstance
+  qkitVisible      <- getB builtinVisible
+  qkitRelevant     <- getB builtinRelevant
+  qkitIrrelevant   <- getB builtinIrrelevant
+  qkitArg          <- getB builtinArgArg
+  qkitArgInfo      <- getB builtinArgArgInfo
+  qkitAbs          <- getB builtinAbsAbs
+  qkitNil          <- getB builtinNil
+  qkitCons         <- getB builtinCons
+  qkitVar          <- getB builtinAgdaTermVar
+  qkitDef          <- getB builtinAgdaTermDef
+  qkitCon          <- getB builtinAgdaTermCon
+  qkitMeta         <- getB builtinAgdaTermMeta
+  qkitLam          <- getB builtinAgdaTermLam
+  qkitPatLam       <- getB builtinAgdaTermExtLam
+  qkitPi           <- getB builtinAgdaTermPi
+  qkitSort         <- getB builtinAgdaTermSort
+  qkitLit          <- getB builtinAgdaTermLit
+  qkitUnknown      <- getB builtinAgdaTermUnsupported
+  qkitSortLit      <- getB builtinAgdaSortLit
+  qkitSortSet      <- getB builtinAgdaSortSet
+  qkitSortUnknown  <- getB builtinAgdaSortUnsupported
+  qkitVarP         <- getB builtinAgdaPatVar
+  qkitConP         <- getB builtinAgdaPatCon
+  qkitLitP         <- getB builtinAgdaPatLit
+  qkitProjP        <- getB builtinAgdaPatProj
+  qkitDotP         <- getB builtinAgdaPatDot
+  qkitAbsurdP      <- getB builtinAgdaPatAbsurd
+  qkitLitNat       <- getB builtinAgdaLitNat
+  qkitLitWord64    <- getB builtinAgdaLitWord64
+  qkitLitFloat     <- getB builtinAgdaLitFloat
+  qkitLitChar      <- getB builtinAgdaLitChar
+  qkitLitString    <- getB builtinAgdaLitString
+  qkitLitQName     <- getB builtinAgdaLitQName
+  qkitLitMeta      <- getB builtinAgdaLitMeta
+  qkitClause       <- getB builtinAgdaClauseClause
+  qkitAbsurdClause <- getB builtinAgdaClauseAbsurd
+  pure QuotedTermKit{..}
+  where
+    getB b = MaybeT $ getBuiltin' b
+
+-- | Do one level of quoting, revealing the top-level reflected constructor.
+quotedTermConstructorFormM :: (HasBuiltins m, MonadTCEnv m, ReadTCState m) => QuotedTerm -> m Term
+quotedTermConstructorFormM q =
+  caseMaybeM getQuotedTermKit
+             __IMPOSSIBLE__ $ \ kit ->
+    pure $ quotedTermConstructorForm kit q
+
+newtype QuoteKitM a = QuoteKitM { unQuoteKitM :: Reader QuotedTermKit a }
+  deriving (Functor, Applicative, Monad)
+
+instance ReadTCState QuoteKitM where
+  getTCState = QuoteKitM $ asks qkitState
+  locallyTCState l f (QuoteKitM m) = QuoteKitM $ local (\ q -> q { qkitState = over l f (qkitState q) }) m
+
+instance MonadTCEnv QuoteKitM where
+  askTC = QuoteKitM $ asks qkitEnv
+  localTC f (QuoteKitM m) = QuoteKitM $ local (\ q -> q { qkitEnv = f (qkitEnv q) }) m
+
+quotedTermConstructorForm :: QuotedTermKit -> QuotedTerm -> Term
+quotedTermConstructorForm kit@QuotedTermKit{..} q = quoteTerm (quotedTerm q)
+  where
+    runQ :: QuoteKitM a -> a
+    runQ m = runReader (unQuoteKitM m) kit
+
+    constInfo = flip HMap.lookup defs
+      where
+        defs  = HMap.union (qkitState ^. (stSignature . sigDefinitions))
+                           (qkitState ^. (stSignature . sigDefinitions))
+
+    quoteTerm v = case unSpine v of
+
+      Def f es     ->
+        case constInfo f of
+          Just defn ->
+            case defn of
+              -- Pattern lambda
+              Defn{theDef = Function{funExtLam = Just (ExtLamInfo m _), funClauses = cs}}
+                | not $ null conOrProjPars -> __IMPOSSIBLE__ -- A pattern lambda should not have any extra parameters!
+                | otherwise                ->
+                  qkitPatLam $* [list $ map (quoteClause . (`applyE` pars)) cs, quoteArgs args]
+                where
+                  n            = size $ runQ $ lookupSection m
+                  (pars, args) = splitAt n es
+              Defn{theDef = Function{funCompiled = Just Fail, funClauses = [cl]}} ->
+                -- Absurd lambda. See also corresponding code in InternalToAbstract.
+                let n = length (namedClausePats cl) - 1 in
+                qkitPatLam $* [list [quoteClause $ dropArgs n cl],
+                               quoteArgs $ drop n es]
+              _ -> qkitDef $* [litName f, list $ drop n $ conOrProjPars ++ quoteArgs' es]
+                where
+                  n = runQ $ getDefFreeVars f
+            where
+              -- #2220: remember to restore dropped parameters
+              conOrProjPars = quoteParams defn
+          Nothing -> qkitDef $* [litName f, quoteArgs es]
+
+      Con ch ci es
+        | isJust $ allApplyElims es -> qkitCon $* [litName c, args]
+        | otherwise                 -> qkitUnknown
+        where
+          c         = conName ch
+          Just cDef = constInfo c
+          n         = runQ $ getDefFreeVars c
+          args      = list $ drop n $ quoteParams cDef ++ quoteArgs' es
+
+      Var x es     -> qkitVar  $* [Lit (LitNat noRange $ fromIntegral x), quoteArgs es]
+      MetaV m es   -> qkitMeta $* [Lit (LitMeta noRange qkitCurrentFile m), quoteArgs es]
+      Lit l        -> quoteLit l
+      Lam h b      -> qkitLam  $* [quoteHiding (getHiding h), quoteAbs quoteTerm b]
+      Pi a b       -> qkitPi   $* [quoteDom (quoteType <$> a), quoteAbs quoteType b]
+      Sort s       -> qkitSort $* [quoteSort s]
+      Level l      -> quoteTerm (unlevelWithKit qkitLevels l)
+      DontCare t   -> qkitUnknown
+      Dummy{}      -> __IMPOSSIBLE__
+
+    quoteType = quoteTerm . unEl
+
+    quoteHiding :: Hiding -> Term
+    quoteHiding Hidden     = qkitHidden
+    quoteHiding Instance{} = qkitInstance
+    quoteHiding NotHidden  = qkitVisible
+
+    quoteRelevance :: Relevance -> Term
+    quoteRelevance Relevant   = qkitRelevant
+    quoteRelevance Irrelevant = qkitIrrelevant
+    quoteRelevance NonStrict  = qkitRelevant
+
+    -- TODO: quote Quanity
+    quoteArgInfo :: ArgInfo -> Term
+    quoteArgInfo (ArgInfo h m _ _) =
+      qkitArgInfo $* [quoteHiding h, quoteRelevance (getRelevance m)]
+
+    quoteArg :: Arg Term -> Term
+    quoteArg (Arg info t) = qkitArg $* [quoteArgInfo info, t]
+
+    quoteDom :: Dom Term -> Term
+    quoteDom Dom{domInfo = info, unDom = t} = qkitArg $* [quoteArgInfo info, t]
+
+    quoteAbs :: Subst t a => (a -> Term) -> Abs a -> Term
+    quoteAbs q (Abs s t)   = qkitAbs $* [Lit (LitString noRange s), q t]
+    quoteAbs q (NoAbs s t) = qkitAbs $* [Lit (LitString noRange s), q (raise 1 t)]
+
+    quoteArgs :: Elims -> Term
+    quoteArgs = list . quoteArgs'
+
+    quoteArgs' :: Elims -> [Term]
+    quoteArgs' es = map (quoteArg . fmap quoted) vs
+      where vs = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
+
+    quoteLit :: Literal' QuotedTerm -> Term
+    quoteLit l@LitNat{}    = qkitLit $$ (qkitLitNat    $$ Lit l)
+    quoteLit l@LitWord64{} = qkitLit $$ (qkitLitWord64 $$ Lit l)
+    quoteLit l@LitFloat{}  = qkitLit $$ (qkitLitFloat  $$ Lit l)
+    quoteLit l@LitChar{}   = qkitLit $$ (qkitLitChar   $$ Lit l)
+    quoteLit l@LitString{} = qkitLit $$ (qkitLitString $$ Lit l)
+    quoteLit l@LitQName{}  = qkitLit $$ (qkitLitQName  $$ Lit l)
+    quoteLit l@LitMeta {}  = qkitLit $$ (qkitLitMeta   $$ Lit l)
+    quoteLit (LitTerm _ q) = quoteTerm $ quoteTerm $ quotedTerm q
+
+    quoteSortLevelTerm :: Level -> Term
+    quoteSortLevelTerm (Max [])              = qkitSortLit $$ Lit (LitNat noRange 0)
+    quoteSortLevelTerm (Max [ClosedLevel n]) = qkitSortLit $$ Lit (LitNat noRange n)
+    quoteSortLevelTerm l                     = qkitSortSet $$ quoteTerm (unlevelWithKit qkitLevels l)
+
+    quoteSort :: Sort -> Term
+    quoteSort (Type t)     = quoteSortLevelTerm t
+    quoteSort Prop{}       = qkitSortUnknown
+    quoteSort Inf          = qkitSortUnknown
+    quoteSort SizeUniv     = qkitSortUnknown
+    quoteSort PiSort{}     = qkitSortUnknown
+    quoteSort UnivSort{}   = qkitSortUnknown
+    quoteSort (MetaS x es) = quoteTerm $ MetaV x es
+    quoteSort (DefS d es)  = quoteTerm $ Def d es
+    quoteSort DummyS{}     =__IMPOSSIBLE__
+
+    quotePats :: [NamedArg DeBruijnPattern] -> Term
+    quotePats ps = list $ map (quoteArg . fmap (quotePat . namedThing)) ps
+
+    quotePat :: DeBruijnPattern -> Term
+    quotePat p
+     | patternOrigin p == Just PatOAbsurd = qkitAbsurdP
+    quotePat (VarP o x)        = qkitVarP $$ litString (dbPatVarName x)
+    quotePat (DotP _ _)        = qkitDotP
+    quotePat (ConP c _ ps)     = qkitConP $* [litName (conName c), quotePats ps]
+    quotePat (LitP l)          = qkitLitP $$ quoteLit (vacuous l)
+    quotePat (ProjP _ x)       = qkitProjP $$ litName x
+    quotePat (IApplyP o t u x) = qkitDotP   -- TODO!
+    quotePat DefP{}            = __IMPOSSIBLE__
+
+    litString = Lit . LitString noRange
+    litName   = Lit . LitQName  noRange
+    litNat    = Lit . LitNat    noRange
+
+    quoteClause :: Clause -> Term
+    quoteClause cl@Clause{namedClausePats = ps, clauseBody = body} =
+      case body of
+        Nothing -> qkitAbsurdClause $$ quotePats ps
+        Just b  -> qkitClause $* [quotePats ps, quoteTerm v]
+          where
+            perm = fromMaybe __IMPOSSIBLE__ $ dbPatPerm' False ps -- Dot patterns don't count (#2203)
+            v    = applySubst (renamingR perm) b
+
+    quoteParams :: Definition -> [Term]
+    quoteParams def = map (quoteArg . (qkitUnknown <$) . argFromDom) $ take np $ telToList tel
+      where
+        np = case theDef def of
+               Constructor{ conPars = np }        -> np
+               Function{ funProjection = Just p } -> projIndex p - 1
+               _                                  -> 0
+        TelV tel _ = telView' (defType def)
+
+    list :: [Term] -> Term
+    list = foldr (\ a as -> qkitCons $* [a, as]) qkitNil
+
+    ($*) :: Apply a => a -> [Term] -> a
+    ($*) = applys
+
+    ($$) :: Apply a => a -> Term -> a
+    ($$) = apply1
+
+    quoted :: Term -> Term
+    quoted v = Lit $ LitTerm noRange $ QuotedTerm Nothing v Nothing
+
+

--- a/src/full/Agda/TypeChecking/Monad/Builtin/ConstructorForm.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin/ConstructorForm.hs
@@ -6,6 +6,7 @@ module Agda.TypeChecking.Monad.Builtin.ConstructorForm
   , QuotedTermKit
   , getQuotedTermKit
   , quotedTermConstructorForm
+  , quotedTermConstructorFormM
   ) where
 
 import Control.Monad.Reader
@@ -154,7 +155,7 @@ quotedTermConstructorForm kit@QuotedTermKit{..} q = quoteTerm (quotedTerm q)
     constInfo = flip HMap.lookup defs
       where
         defs  = HMap.union (qkitState ^. (stSignature . sigDefinitions))
-                           (qkitState ^. (stSignature . sigDefinitions))
+                           (qkitState ^. (stImports   . sigDefinitions))
 
     quoteTerm v = case unSpine v of
 

--- a/src/full/Agda/TypeChecking/Monad/Builtin/ConstructorForm.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin/ConstructorForm.hs
@@ -302,4 +302,3 @@ quotedTermConstructorForm kit@QuotedTermKit{..} q = quoteTerm (quotedTerm q)
     quoted :: Term -> Term
     quoted v = Lit $ LitTerm noRange $ QuotedTerm Nothing v Nothing
 
-

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -176,7 +176,7 @@ getMetaContextArgs MetaVar{ mvPermutation = p } = do
   return $ permute (takeP (length args) p) args
 
 -- | Given a meta, return the type applied to the current context.
-getMetaTypeInContext :: (MonadFail m, MonadTCEnv m, ReadTCState m, MonadReduce m)
+getMetaTypeInContext :: (MonadTCEnv m, ReadTCState m, MonadReduce m)
                      => MetaId -> m Type
 getMetaTypeInContext m = do
   mv@MetaVar{ mvJudgement = j } <- lookupMeta m

--- a/src/full/Agda/TypeChecking/Patterns/Internal.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Internal.hs
@@ -37,7 +37,7 @@ instance (DeBruijn (Pattern' a)) => TermToPattern Term (Pattern' a) where
     -- Constructors.
     Con c _ args -> ConP c noConPatternInfo . map (fmap unnamed) <$> termToPattern (fromMaybe __IMPOSSIBLE__ $ allApplyElims args)
     Var i []    -> return $ deBruijnVar i
-    Lit l       -> return $ LitP l
+    Lit l       -> return $ LitP $ fmap (\ _ -> __IMPOSSIBLE__) l   -- TODO: expand quoted term literals?
     t           -> return $ dotP t
 
 dotPatternsToPatterns :: forall a. (DeBruijn (Pattern' a))

--- a/src/full/Agda/TypeChecking/Patterns/Internal.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Internal.hs
@@ -38,7 +38,7 @@ instance (DeBruijn (Pattern' a)) => TermToPattern Term (Pattern' a) where
     -- Constructors.
     Con c _ args -> ConP c noConPatternInfo . map (fmap unnamed) <$> termToPattern (fromMaybe __IMPOSSIBLE__ $ allApplyElims args)
     Var i []    -> return $ deBruijnVar i
-    Lit l       -> return $ LitP $ fmap (\ _ -> __IMPOSSIBLE__) l   -- TODO: expand quoted term literals?
+    Lit l       -> return $ LitP $ fmap (\ _ -> __IMPOSSIBLE__) l
     t           -> return $ dotP t
 
 dotPatternsToPatterns :: forall a. (DeBruijn (Pattern' a))

--- a/src/full/Agda/TypeChecking/Patterns/Internal.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Internal.hs
@@ -15,6 +15,7 @@ import Agda.Syntax.Internal.Pattern
 
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Builtin.ConstructorForm
 import Agda.TypeChecking.Reduce (reduce)
 import Agda.TypeChecking.Substitute.DeBruijn
 

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -10,6 +10,7 @@ import Prelude hiding (null)
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import Data.Traversable (traverse)
+import qualified Data.Void as Void
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
@@ -214,9 +215,10 @@ matchPattern p u = case (p, u) of
   (LitP l , arg@(Arg _ v)) -> do
     w <- reduceB' v
     let arg' = arg $> ignoreBlocking w
+        lp   = Void.vacuous l  -- TODO: constructorForm?
     case w of
       NotBlocked _ (Lit l')
-          | l == l'            -> return (Yes YesSimplification empty , arg')
+          | lp == l'           -> return (Yes YesSimplification empty , arg')
           | otherwise          -> return (No                          , arg')
       NotBlocked _ (MetaV x _) -> return (DontKnow $ Blocked x ()     , arg')
       Blocked x _              -> return (DontKnow $ Blocked x ()     , arg')

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -215,7 +215,7 @@ matchPattern p u = case (p, u) of
   (LitP l , arg@(Arg _ v)) -> do
     w <- reduceB' v
     let arg' = arg $> ignoreBlocking w
-        lp   = Void.vacuous l  -- TODO: constructorForm?
+        lp   = Void.vacuous l
     case w of
       NotBlocked _ (Lit l')
           | lp == l'           -> return (Yes YesSimplification empty , arg')

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -16,6 +16,7 @@ import qualified Data.Set as Set
 import Data.Maybe
 import Data.String
 import Data.Semigroup (Semigroup((<>)))
+import Data.Void
 
 import Agda.Syntax.Position
 import Agda.Syntax.Common
@@ -151,7 +152,6 @@ instance PrettyTCM Bool        where prettyTCM = pretty
 instance PrettyTCM C.Name      where prettyTCM = pretty
 instance PrettyTCM C.QName     where prettyTCM = pretty
 instance PrettyTCM Comparison  where prettyTCM = pretty
-instance PrettyTCM Literal     where prettyTCM = pretty
 instance PrettyTCM Nat         where prettyTCM = pretty
 instance PrettyTCM ProblemId   where prettyTCM = pretty
 instance PrettyTCM Range       where prettyTCM = pretty
@@ -159,11 +159,18 @@ instance PrettyTCM CheckpointId where prettyTCM = pretty
 -- instance PrettyTCM Interval where prettyTCM = pretty
 -- instance PrettyTCM Position where prettyTCM = pretty
 
+instance PrettyTCM t => PrettyTCM (Literal' t) where
+  prettyTCM (LitTerm _ t) = prettyTCM t
+  prettyTCM l = pretty (fmap (\ _ -> __IMPOSSIBLE__) l :: Literal)
+
 instance PrettyTCM a => PrettyTCM (Closure a) where
   prettyTCM cl = enterClosure cl prettyTCM
 
 instance PrettyTCM a => PrettyTCM [a] where
   prettyTCM = prettyList . map prettyTCM
+
+instance PrettyTCM Void where
+  prettyTCM _ = __IMPOSSIBLE__
 
 instance (PrettyTCM a, PrettyTCM b) => PrettyTCM (a,b) where
   prettyTCM (a, b) = parens $ prettyTCM a <> comma <> prettyTCM b
@@ -182,6 +189,8 @@ instance PrettyTCM Level        where prettyTCM = prettyA <=< reify . Level
 instance PrettyTCM Permutation  where prettyTCM = text . show
 instance PrettyTCM Polarity     where prettyTCM = text . show
 instance PrettyTCM IsForced     where prettyTCM = text . show
+
+instance PrettyTCM QuotedTerm   where prettyTCM = prettyA <=< reify
 
 prettyR
   :: (R.ToAbstract r a, PrettyTCM a, MonadPretty m, MonadError TCErr m)

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -134,8 +134,7 @@ punctuate d ds = zipWith (<>) ds (replicate n d ++ [pure empty])
 ---------------------------------------------------------------------------
 
 type MonadPretty m =
-  ( MonadReify m
-  , MonadAbsToCon m
+  ( MonadAbsToCon m
   , IsString (m Doc)
   , Null (m Doc)
   , Semigroup (m Doc)

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -378,7 +378,7 @@ instance PrettyTCM TypeCheckingProblem where
           ":?"
         , prettyTCM t
         ]
-  prettyTCM (DoQuoteTerm _ v _) = do
+  prettyTCM (DoQuoteTerm _ v _ _) = do
     e <- reify v
     prettyTCM (A.App A.defaultAppInfo_ (A.QuoteTerm A.exprNoRange) (defaultNamedArg e))
 

--- a/src/full/Agda/TypeChecking/Pretty.hs-boot
+++ b/src/full/Agda/TypeChecking/Pretty.hs-boot
@@ -26,21 +26,18 @@ sep, fsep, hsep, vcat :: Monad m => [m Doc] -> m Doc
 -- Inlining definitions of MonadReify and MonadAbsToCon to avoid
 -- having to import them
 type MonadPretty m =
-  ( ( MonadReduce m
-    , MonadAddContext m
-    , MonadInteractionPoints m
-    , MonadFresh NameId m
-    , HasConstInfo m
-    , HasOptions m
-    , HasBuiltins m
-    , MonadDebug m
-    )
-  , ( MonadTCEnv m
+  ( ( MonadTCEnv m
     , ReadTCState m
     , MonadStConcreteNames m
-    , HasOptions m
-    , HasBuiltins m
-    , MonadDebug m
+    , ( MonadReduce m
+      , MonadAddContext m
+      , MonadInteractionPoints m
+      , MonadFresh NameId m
+      , HasConstInfo m
+      , HasOptions m
+      , HasBuiltins m
+      , MonadDebug m
+      )
     )
   , IsString (m Doc)
   , Null (m Doc)

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -360,7 +360,7 @@ fromReducedTerm f = return $ \t -> do
         Just x  -> return $ YesReduction NoSimplification x
         Nothing -> return $ NoReduction (reduced b)
 
-fromLiteral :: (Literal -> Maybe a) -> TCM (FromTermFunction a)
+fromLiteral :: (ILiteral -> Maybe a) -> TCM (FromTermFunction a)
 fromLiteral f = fromReducedTerm $ \t -> case t of
     Lit lit -> f lit
     _       -> Nothing

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -782,7 +782,7 @@ primitiveFunctions = Map.fromList
   , "primCharToNat"          |-> mkPrimFun1 (fromIntegral . fromEnum :: Char -> Nat)
   , "primCharToNatInjective" |-> primCharToNatInjective
   , "primNatToChar"          |-> mkPrimFun1 (toEnum . fromIntegral . (`mod` 0x110000)  :: Nat -> Char)
-  , "primShowChar"           |-> mkPrimFun1 (Str . prettyShow . LitChar noRange)
+  , "primShowChar"           |-> mkPrimFun1 (Str . prettyShow . (LitChar noRange :: Char -> Literal))
 
   -- String functions
   , "primStringToList"          |-> mkPrimFun1 unStr
@@ -790,7 +790,7 @@ primitiveFunctions = Map.fromList
   , "primStringFromList"        |-> mkPrimFun1 Str
   , "primStringAppend"          |-> mkPrimFun2 (\s1 s2 -> Str $ unStr s1 ++ unStr s2)
   , "primStringEquality"        |-> mkPrimFun2 ((==) :: Rel Str)
-  , "primShowString"            |-> mkPrimFun1 (Str . prettyShow . LitString noRange . unStr)
+  , "primShowString"            |-> mkPrimFun1 (Str . prettyShow . (LitString noRange :: String -> Literal) . unStr)
 
   -- Other stuff
   , "primEraseEquality"   |-> primEraseEquality

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -60,7 +60,7 @@ hPi', nPi' :: (MonadFail m, MonadAddContext m, MonadDebug m)
 hPi' s a b = hPi s a (bind' s b)
 nPi' s a b = nPi s a (bind' s b)
 
-pPi' :: (MonadAddContext m, HasBuiltins m, MonadDebug m)
+pPi' :: (MonadFail m, MonadAddContext m, HasBuiltins m, MonadDebug m)
      => String -> NamesT m Term -> (NamesT m Term -> NamesT m Type) -> NamesT m Type
 pPi' n phi b = toFinitePi <$> nPi' n (elInf $ cl isOne <@> phi) b
  where
@@ -193,7 +193,7 @@ data SigmaKit = SigmaKit
   }
   deriving (Eq,Show)
 
-getSigmaKit :: (HasBuiltins m, HasConstInfo m) => m (Maybe SigmaKit)
+getSigmaKit :: (MonadFail m, HasBuiltins m, HasConstInfo m) => m (Maybe SigmaKit)
 getSigmaKit = do
   ms <- getBuiltinName' builtinSigma
   case ms of

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -23,6 +23,7 @@ import Agda.TypeChecking.Names
 import Agda.TypeChecking.Primitive.Base
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Builtin.ConstructorForm
 
 import Agda.TypeChecking.Free
 import Agda.TypeChecking.Substitute

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -5,6 +5,7 @@ module Agda.TypeChecking.Primitive.Cubical where
 import Prelude hiding (null, (!!))
 
 import Control.Monad
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.Trans ( lift )
 
 import Data.Either ( partitionEithers )
@@ -410,7 +411,8 @@ instance Reduce a => Reduce (FamilyOrNot a) where
 --
 -- The point of this is that gcomp does not produce any empty
 -- systems (if phi = 0 it will reduce to "forward A 0 u".
-mkGComp :: HasBuiltins m => String -> NamesT m (NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term)
+mkGComp :: (MonadFail m, HasBuiltins m) =>
+           String -> NamesT m (NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term)
 mkGComp s = do
   let getTermLocal = getTerm s
   tPOr <- getTermLocal "primPOr"

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -5,6 +5,7 @@ import Control.Arrow ((&&&))
 import Control.Monad
 
 import Data.Maybe (fromMaybe)
+import Data.Void
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal as I
@@ -119,6 +120,7 @@ quotingKit = do
       quoteLit l@LitString{} = litString !@! Lit l
       quoteLit l@LitQName{}  = litQName  !@! Lit l
       quoteLit l@LitMeta {}  = litMeta   !@! Lit l
+      quoteLit (LitTerm _ t) = absurd t   -- for now
 
       -- We keep no ranges in the quoted term, so the equality on terms
       -- is only on the structure.

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -112,7 +112,7 @@ quotingKit = do
       quoteArgInfo (ArgInfo h m _ _) =
         arginfo !@ quoteHiding h @@ quoteRelevance (getRelevance m)
 
-      quoteLit :: Literal -> ReduceM Term
+      quoteLit :: Literal' QuotedTerm -> ReduceM Term
       quoteLit l@LitNat{}    = litNat    !@! Lit l
       quoteLit l@LitWord64{} = litWord64 !@! Lit l
       quoteLit l@LitFloat{}  = litFloat  !@! Lit l
@@ -120,7 +120,7 @@ quotingKit = do
       quoteLit l@LitString{} = litString !@! Lit l
       quoteLit l@LitQName{}  = litQName  !@! Lit l
       quoteLit l@LitMeta {}  = litMeta   !@! Lit l
-      quoteLit (LitTerm _ t) = absurd t   -- for now
+      quoteLit (LitTerm _ t) = quoteTerm (quotedTerm t)
 
       -- We keep no ranges in the quoted term, so the equality on terms
       -- is only on the structure.
@@ -155,7 +155,7 @@ quotingKit = do
       quotePat (VarP o x)        = varP !@! quoteString (dbPatVarName x)
       quotePat (DotP _ _)        = pure dotP
       quotePat (ConP c _ ps)     = conP !@ quoteQName (conName c) @@ quotePats ps
-      quotePat (LitP l)          = litP !@ quoteLit l
+      quotePat (LitP l)          = litP !@ quoteLit (vacuous l)
       quotePat (ProjP _ x)       = projP !@ quoteQName x
       quotePat (IApplyP o t u x) = pure unsupported
       quotePat DefP{}            = pure unsupported

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -293,7 +293,7 @@ quoteTerm v = do
 makeQuotedTerm :: Type -> Term -> TCM Term
 makeQuotedTerm a v = inFreshModuleIfFreeParams $ do
   cp <- viewTC eCurrentCheckpoint
-  return $ Lit $ LitTerm noRange $ QuotedTerm a v cp
+  return $ Lit $ LitTerm noRange $ QuotedTerm (Just a) v (Just cp)
 
 makeQuotedType :: Type -> TCM Term
 makeQuotedType (El s a) = makeQuotedTerm (sort s) a

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -290,10 +290,13 @@ quoteTerm v = do
   kit <- quotingKit
   runReduceM (quoteTermWithKit kit v)
 
-makeQuotedTerm :: Term -> Type -> TCM Term
-makeQuotedTerm v a = inFreshModuleIfFreeParams $ do
+makeQuotedTerm :: Type -> Term -> TCM Term
+makeQuotedTerm a v = inFreshModuleIfFreeParams $ do
   cp <- viewTC eCurrentCheckpoint
   return $ Lit $ LitTerm noRange $ QuotedTerm a v cp
+
+makeQuotedType :: Type -> TCM Term
+makeQuotedType (El s a) = makeQuotedTerm (sort s) a
 
 quoteType :: Type -> TCM Term
 quoteType v = do

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -290,6 +290,11 @@ quoteTerm v = do
   kit <- quotingKit
   runReduceM (quoteTermWithKit kit v)
 
+makeQuotedTerm :: Term -> Type -> TCM Term
+makeQuotedTerm v a = inFreshModuleIfFreeParams $ do
+  cp <- viewTC eCurrentCheckpoint
+  return $ Lit $ LitTerm noRange $ QuotedTerm a v cp
+
 quoteType :: Type -> TCM Term
 quoteType v = do
   kit <- quotingKit

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -157,8 +157,8 @@ quotingKit = do
       quotePat (ConP c _ ps)     = conP !@ quoteQName (conName c) @@ quotePats ps
       quotePat (LitP l)          = litP !@ quoteLit (vacuous l)
       quotePat (ProjP _ x)       = projP !@ quoteQName x
-      quotePat (IApplyP o t u x) = pure unsupported
-      quotePat DefP{}            = pure unsupported
+      quotePat (IApplyP o t u x) = pure dotP    -- TODO
+      quotePat DefP{}            = __IMPOSSIBLE__
 
       quoteClause :: Clause -> ReduceM Term
       quoteClause cl@Clause{namedClausePats = ps, clauseBody = body} =

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -4,8 +4,8 @@
 
 module Agda.TypeChecking.Reduce where
 
-import Prelude hiding (mapM)
-import Control.Monad.Reader hiding (mapM)
+import Control.Monad.Fail (MonadFail)
+import Control.Monad.Reader
 
 import Data.List ((\\))
 import Data.Maybe
@@ -247,7 +247,7 @@ instance Instantiate EqualityView where
 ---------------------------------------------------------------------------
 
 class IsMeta a where
-  isMeta :: HasBuiltins m => a -> m (Maybe MetaId)
+  isMeta :: (MonadFail m, HasBuiltins m) => a -> m (Maybe MetaId)
 
 instance IsMeta Term where
   isMeta (MetaV m _) = return $ Just m

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -28,7 +28,7 @@ import Agda.TypeChecking.Monad hiding ( enterClosure, isInstantiatedMeta
                                       , getConstInfo
                                       , lookupMeta )
 import qualified Agda.TypeChecking.Monad as TCM
-import Agda.TypeChecking.Monad.Builtin hiding (getPrimitive, constructorForm)
+import Agda.TypeChecking.Monad.Builtin hiding (getPrimitive)
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.CompiledClause
 import Agda.TypeChecking.EtaContract

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -769,7 +769,7 @@ unusedPointer = Pure (Closure (Value $ notBlocked ())
 --   'getConstInfo' function, a couple of flags (allow non-terminating function unfolding, and
 --   whether rewriting is enabled), and a term to reduce. The result is the weak-head normal form of
 --   the term with an attached blocking tag.
-reduceTm :: ReduceEnv -> BuiltinEnv -> Maybe QuotedTermKit -> (QName -> CompactDef) -> Normalisation -> ReductionFlags -> Term -> Blocked Term
+reduceTm :: ReduceEnv -> BuiltinEnv -> QuotedTermKit -> (QName -> CompactDef) -> Normalisation -> ReductionFlags -> Term -> Blocked Term
 reduceTm rEnv bEnv qkit !constInfo normalisation ReductionFlags{..} =
     compileAndRun . traceDoc "-- fast reduce --"
   where
@@ -784,12 +784,8 @@ reduceTm rEnv bEnv qkit !constInfo normalisation ReductionFlags{..} =
     callByNeed     = envCallByNeed (redEnv rEnv)
     iview          = runReduce intervalView'
 
-    constrForm =
-      case qkit of
-        Nothing  -> id
-        Just kit -> \ case
-          Lit (LitTerm _ q) -> quotedTermConstructorForm kit q
-          t                 -> t
+    constrForm (Lit (LitTerm _ q)) = quotedTermConstructorForm qkit q
+    constrForm t                   = t
 
     runReduce :: ReduceM a -> a
     runReduce m = unReduceM m rEnv

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -24,7 +24,8 @@ import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad hiding
   ( enterClosure, isInstantiatedMeta, verboseS, typeOfConst, lookupMeta, lookupMeta' )
-import Agda.TypeChecking.Monad.Builtin hiding ( constructorForm )
+import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Builtin.ConstructorForm
 import Agda.TypeChecking.Substitute
 
 import Agda.Utils.Functor
@@ -37,12 +38,6 @@ import Agda.Utils.Impossible
 instance HasBuiltins ReduceM where
   getBuiltinThing b = liftM2 mplus (Map.lookup b <$> useR stLocalBuiltins)
                                    (Map.lookup b <$> useR stImportedBuiltins)
-
-constructorForm :: HasBuiltins m => Term -> m Term
-constructorForm v = do
-  mz <- getBuiltin' builtinZero
-  ms <- getBuiltin' builtinSuc
-  return $ fromMaybe v $ constructorForm' mz ms v
 
 enterClosure :: LensClosure a c => c -> (a -> ReduceM b) -> ReduceM b
 enterClosure c | Closure _sig env scope cps x <- c ^. lensClosure = \case

--- a/src/full/Agda/TypeChecking/Rewriting/Clause.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Clause.hs
@@ -3,6 +3,7 @@
 module Agda.TypeChecking.Rewriting.Clause where
 
 import Data.Maybe
+import Data.Void
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
@@ -65,7 +66,7 @@ instance ToNLPat (Arg DeBruijnPattern) (Elim' NLPat) where
     VarP _ x        -> app $ PVar (dbPatVarIndex x) []
     DotP _ u        -> app $ PTerm u
     ConP c _ ps     -> app $ PDef (conName c) $ toNLPat ps
-    LitP l          -> app $ PTerm $ Lit l
+    LitP l          -> app $ PTerm $ Lit $ vacuous l
     ProjP o f       -> Proj o f
     IApplyP _ u v x -> IApply (PTerm u) (PTerm v) $ PVar (dbPatVarIndex x) []
     DefP _ f ps     -> app $ PDef f $ toNLPat ps

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -304,9 +304,9 @@ inferHead e = do
     A.QuestionMark i ii -> inferMeta (newQuestionMark ii) i
     A.Underscore i   -> inferMeta (newValueMeta RunMetaOccursCheck) i
     A.Trusted q -> do
-      msub <- checkpointSubstitution' (quotedCheckpoint q)
-      case msub of
-        Just IdS -> return $ (applyE $ quotedTerm q, quotedType q)
+      msub <- maybe (pure Nothing) checkpointSubstitution' (quotedCheckpoint q)
+      case (msub, quotedType q) of
+        (Just IdS, Just a) -> return $ (applyE $ quotedTerm q, a)
         _        -> do
           (term, t) <- inferExpr =<< toAbstract_ =<< unquoteTerm =<< quoteTerm (quotedTerm q)
           return (applyE term, t)

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -214,7 +214,7 @@ checkApplication cmp hd args e t = postponeInstanceConstraints $ do
 
 -- | Precondition: @Application hd args = appView e@.
 inferApplication :: ExpandHidden -> A.Expr -> A.Args -> A.Expr -> TCM (Term, Type)
-inferApplication exh hd args e | not (defOrVar hd) = do
+inferApplication exh hd args e | not (inferrableHead hd) = do
   t <- workOnTypes $ newTypeMeta_
   v <- checkExpr' CmpEq e t
   return (v, t)

--- a/src/full/Agda/TypeChecking/Rules/Display.hs
+++ b/src/full/Agda/TypeChecking/Rules/Display.hs
@@ -2,6 +2,7 @@
 module Agda.TypeChecking.Rules.Display (checkDisplayPragma) where
 
 import Data.Maybe
+import Data.Void
 
 import qualified Agda.Syntax.Abstract as A
 import Agda.Syntax.Abstract.Views
@@ -77,7 +78,7 @@ patternToTerm p ret =
     A.DefP _ fs ps
       | Just f <- getUnambiguous fs -> pappToTerm f (Def f . map Apply) ps ret
       | otherwise                   -> ambigErr "DefP" fs
-    A.LitP l                        -> ret 0 (Lit l)
+    A.LitP l                        -> ret 0 (Lit $ vacuous l)
     A.WildP _                       -> bindWild $ ret 1 (Var 0 [])
     _                               -> do
       doc <- prettyA p
@@ -102,7 +103,7 @@ exprToTerm e =
     A.Var x  -> fst <$> getVarInfo x
     A.Def f  -> pure $ Def f []
     A.Con c  -> pure $ Con (ConHead (headAmbQ c) Inductive []) ConOCon [] -- Don't care too much about ambiguity here
-    A.Lit l  -> pure $ Lit l
+    A.Lit l  -> pure $ Lit $ vacuous l
     A.App _ e arg  -> apply <$> exprToTerm e <*> ((:[]) . inheritHiding arg <$> exprToTerm (namedArg arg))
 
     A.Proj _ f -> pure $ Def (headAmbQ f) []   -- only for printing so we don't have to worry too much here

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -11,6 +11,7 @@ module Agda.TypeChecking.Rules.LHS
 import Prelude hiding ( mapM, null, sequence )
 
 import Data.Maybe
+import Data.Void
 
 import Control.Arrow (left)
 import Control.Monad
@@ -251,7 +252,7 @@ updateProblemEqs eqs = do
 
           _ -> return [eq]
 
-      Lit l | A.LitP l' <- p , l == l' -> return []
+      Lit l | A.LitP l' <- p , l == vacuous l' -> return []
 
       _ | A.EqualP{} <- p -> do
         itisone <- liftTCM primItIsOne
@@ -1147,7 +1148,7 @@ checkLHS mf = updateModality checkLHS_ where
              -> Literal       -- ^ The literal written by the user
              -> ExceptT TCErr tcm (LHSState a)
     splitLit delta1 dom@Dom{domInfo = info, unDom = a} adelta2 lit = do
-      let delta2 = absApp adelta2 (Lit lit)
+      let delta2 = absApp adelta2 (Lit $ vacuous lit)
           delta' = abstract delta1 delta2
           rho    = singletonS (size delta2) (LitP lit)
           -- Andreas, 2015-06-13 Literals are closed, so no need to raise them!

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -70,6 +70,7 @@ import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Primitive hiding (Nat)
 import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Builtin.ConstructorForm
 
 import {-# SOURCE #-} Agda.TypeChecking.Rules.Term (checkExpr)
 import Agda.TypeChecking.Rules.LHS.Problem

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -463,8 +463,8 @@ data UnifyStep
   | LitConflict
     { litConflictAt      :: Int
     , litType            :: Type
-    , litConflictLeft    :: Literal
-    , litConflictRight   :: Literal
+    , litConflictLeft    :: ILiteral
+    , litConflictRight   :: ILiteral
     }
   | StripSizeSuc
     { stripAt            :: Int

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -122,7 +122,7 @@ import Agda.Syntax.Literal
 
 import Agda.TypeChecking.Monad
 import qualified Agda.TypeChecking.Monad.Benchmark as Bench
-import Agda.TypeChecking.Monad.Builtin (constructorForm)
+import Agda.TypeChecking.Monad.Builtin.ConstructorForm (constructorForm)
 import Agda.TypeChecking.Conversion -- equalTerm
 import Agda.TypeChecking.Constraints
 import Agda.TypeChecking.Datatypes

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1473,6 +1473,7 @@ inferrableHead :: A.Expr -> Bool
 inferrableHead A.Var{} = True
 inferrableHead A.Def{} = True
 inferrableHead A.Proj{} = True
+inferrableHead A.Trusted{} = True
 inferrableHead (A.ScopedExpr _ e) = inferrableHead e
 inferrableHead _     = False
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1281,7 +1281,7 @@ unquoteTactic tac hole goal = do
   reportSDoc "tc.term.tactic" 40 $ sep
     [ "Running tactic" <+> prettyTCM tac
     , nest 2 $ "on" <+> prettyTCM hole <+> ":" <+> prettyTCM goal ]
-  ok  <- runUnquoteM $ unquoteTCM tac hole
+  ok  <- runUnquoteM $ unquoteTCM tac hole goal
   case ok of
     Left (BlockedOnMeta oldState x) -> do
       putTC oldState

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1469,18 +1469,18 @@ inferExpr' exh e = traceCall (InferExpr e) $ do
     ]
   inferApplication exh hd args e
 
-defOrVar :: A.Expr -> Bool
-defOrVar A.Var{} = True
-defOrVar A.Def{} = True
-defOrVar A.Proj{} = True
-defOrVar (A.ScopedExpr _ e) = defOrVar e
-defOrVar _     = False
+inferrableHead :: A.Expr -> Bool
+inferrableHead A.Var{} = True
+inferrableHead A.Def{} = True
+inferrableHead A.Proj{} = True
+inferrableHead (A.ScopedExpr _ e) = inferrableHead e
+inferrableHead _     = False
 
 -- | Used to check aliases @f = e@.
 --   Switches off 'ExpandLast' for the checking of top-level application.
 checkDontExpandLast :: Comparison -> A.Expr -> Type -> TCM Term
 checkDontExpandLast cmp e t = case e of
-  _ | Application hd args <- appView e,  defOrVar hd ->
+  _ | Application hd args <- appView e,  inferrableHead hd ->
     traceCall (CheckExprCall cmp e t) $ localScope $ dontExpandLast $ do
       checkApplication cmp hd args e t
   _ -> checkExpr' cmp e t -- note that checkExpr always sets ExpandLast

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -11,6 +11,7 @@ import Data.Either (partitionEithers, lefts)
 import Data.Monoid (mappend)
 import qualified Data.List as List
 import qualified Data.Map as Map
+import Data.Void
 
 import Agda.Interaction.Options
 import Agda.Interaction.Highlighting.Generate (disambiguateRecordFields)
@@ -961,7 +962,7 @@ checkRecordUpdate cmp ei recexpr fs e t = do
 checkLiteral :: Literal -> Type -> TCM Term
 checkLiteral lit t = do
   t' <- litType lit
-  coerce CmpEq (Lit lit) t' t
+  coerce CmpEq (Lit $ vacuous lit) t' t
 
 ---------------------------------------------------------------------------
 -- * Terms

--- a/src/full/Agda/TypeChecking/Rules/Term.hs-boot
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs-boot
@@ -14,5 +14,5 @@ inferExpr :: A.Expr -> TCM (Term, Type)
 
 checkPostponedLambda :: Comparison -> Arg ([WithHiding Name], Maybe Type) -> A.Expr -> Type -> TCM Term
 
-doQuoteTerm :: Comparison -> Term -> Type -> TCM Term
+doQuoteTerm :: Comparison -> Term -> Type -> Type -> TCM Term
 unquoteTactic :: Term -> Term -> Type -> TCM ()

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -62,7 +62,7 @@ import Agda.Utils.Except
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20190824 * 10 + 0
+currentInterfaceVersion = 20190911 * 10 + 0
 
 -- | Encodes something. To ensure relocatability file paths in
 -- positions are replaced with module names.

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -62,7 +62,7 @@ import Agda.Utils.Except
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20190911 * 10 + 0
+currentInterfaceVersion = 20190913 * 10 + 0
 
 -- | Encodes something. To ensure relocatability file paths in
 -- positions are replaced with module names.

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -601,7 +601,7 @@ instance EmbPrj ProjOrigin where
   value 2 = return ProjSystem
   value _ = malformed
 
-instance EmbPrj Agda.Syntax.Literal.Literal where
+instance EmbPrj t => EmbPrj (Agda.Syntax.Literal.Literal' t) where
   icod_ (LitNat    a b)   = icodeN' LitNat a b
   icod_ (LitFloat  a b)   = icodeN 1 LitFloat a b
   icod_ (LitString a b)   = icodeN 2 LitString a b
@@ -609,6 +609,7 @@ instance EmbPrj Agda.Syntax.Literal.Literal where
   icod_ (LitQName  a b)   = icodeN 5 LitQName a b
   icod_ (LitMeta   a b c) = icodeN 6 LitMeta a b c
   icod_ (LitWord64 a b)   = icodeN 7 LitWord64 a b
+  icod_ (LitTerm   a b)   = icodeN 8 LitTerm a b
 
   value = vcase valu where
     valu [a, b]       = valuN LitNat    a b
@@ -618,6 +619,7 @@ instance EmbPrj Agda.Syntax.Literal.Literal where
     valu [5, a, b]    = valuN LitQName  a b
     valu [6, a, b, c] = valuN LitMeta   a b c
     valu [7, a, b]    = valuN LitWord64 a b
+    valu [8, a, b]    = valuN LitTerm   a b
     valu _            = malformed
 
 instance EmbPrj IsAbstract where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -109,6 +109,11 @@ instance EmbPrj I.Term where
     valu [9, a]    = valuN Level a
     valu _         = malformed
 
+instance EmbPrj QuotedTerm where
+  icod_ (QuotedTerm a b c) = icodeN' QuotedTerm a b c
+
+  value = valueN QuotedTerm
+
 instance EmbPrj Level where
   icod_ (Max a) = icodeN' Max a
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -111,9 +111,9 @@ instance EmbPrj I.Term where
     valu _            = malformed
 
 instance EmbPrj QuotedTerm where
-  icod_ q = icodeN' (quotedTerm q)
+  icod_ q = icodeN' (\ v -> QuotedTerm Nothing v Nothing) (quotedTerm q)
 
-  value = valueN $ \ v -> QuotedTerm Nothing v Nothing
+  value = valueN (\ v -> QuotedTerm Nothing v Nothing)
 
 instance EmbPrj Level where
   icod_ (Max a) = icodeN' Max a

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -90,29 +90,30 @@ instance EmbPrj I.Term where
   icod_ (Def      a b) = icodeN 3 Def a b
   icod_ (Con    a b c) = icodeN 4 Con a b c
   icod_ (Pi       a b) = icodeN 5 Pi a b
-  icod_ (Sort     a  ) = icodeN 7 Sort a
-  icod_ (MetaV    a b) = __IMPOSSIBLE__
+  icod_ (Sort     a  ) = icodeN 6 Sort a
+  icod_ (MetaV    a b) = icodeN 7 MetaV a b
   icod_ (DontCare a  ) = icodeN 8 DontCare a
   icod_ (Level    a  ) = icodeN 9 Level a
   icod_ (Dummy s _)    = __IMPOSSIBLE__
 
   value = vcase valu where
-    valu [a]       = valuN var   a
-    valu [0, a, b] = valuN Var   a b
-    valu [1, a, b] = valuN Lam   a b
-    valu [2, a]    = valuN Lit   a
-    valu [3, a, b] = valuN Def   a b
+    valu [a]          = valuN var   a
+    valu [0, a, b]    = valuN Var   a b
+    valu [1, a, b]    = valuN Lam   a b
+    valu [2, a]       = valuN Lit   a
+    valu [3, a, b]    = valuN Def   a b
     valu [4, a, b, c] = valuN Con a b c
-    valu [5, a, b] = valuN Pi    a b
-    valu [7, a]    = valuN Sort  a
-    valu [8, a]    = valuN DontCare a
-    valu [9, a]    = valuN Level a
-    valu _         = malformed
+    valu [5, a, b]    = valuN Pi    a b
+    valu [6, a]       = valuN Sort  a
+    valu [7, a, b]    = valuN MetaV a b
+    valu [8, a]       = valuN DontCare a
+    valu [9, a]       = valuN Level a
+    valu _            = malformed
 
 instance EmbPrj QuotedTerm where
-  icod_ (QuotedTerm a b c) = icodeN' QuotedTerm a b c
+  icod_ q = icodeN' (quotedTerm q)
 
-  value = valueN QuotedTerm
+  value = valueN $ \ v -> QuotedTerm Nothing v Nothing
 
 instance EmbPrj Level where
   icod_ (Max a) = icodeN' Max a

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -4,6 +4,7 @@ module Agda.TypeChecking.SizedTypes where
 
 import Prelude hiding (null)
 
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.Writer
 
 import qualified Data.Foldable as Fold
@@ -189,7 +190,8 @@ isBounded i = do
 --   expressing the bound.
 --   In @boundedSizeMetaHook v tel a@, @tel@ includes the current context.
 boundedSizeMetaHook
-  :: ( MonadConstraint m
+  :: ( MonadFail m
+     , MonadConstraint m
      , MonadTCEnv m
      , ReadTCState m
      , MonadAddContext m

--- a/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
@@ -50,6 +50,7 @@ module Agda.TypeChecking.SizedTypes.Solve where
 
 import Prelude hiding (null)
 
+import Control.Monad.Fail (MonadFail)
 import Control.Monad hiding (forM, forM_)
 import Control.Monad.Trans.Maybe
 
@@ -784,7 +785,7 @@ sizeExpr u = do
       _        -> Nothing
 
 -- | Turn a de size expression into a term.
-unSizeExpr :: HasBuiltins m => DBSizeExpr -> m Term
+unSizeExpr :: (MonadFail m, HasBuiltins m) => DBSizeExpr -> m Term
 unSizeExpr a =
   case a of
     Infty         -> fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSizeInf

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1285,6 +1285,9 @@ instance Eq a => Eq (Pattern' a) where
   DefP _ f ps     == DefP _ g qs       = f == g && ps == qs
   _               == _                 = False
 
+instance Eq QuotedTerm where
+  QuotedTerm a u i == QuotedTerm b v j = (a, u, i) == (b, v, j)
+
 instance Ord Term where
   Var a b    `compare` Var x y    = compare x a `thenCmp` compare b y -- sort de Bruijn indices down (#2765)
   Var{}      `compare` _          = LT
@@ -1317,6 +1320,9 @@ instance Ord Term where
   DontCare{} `compare` _          = LT
   _          `compare` DontCare{} = GT
   Dummy{}    `compare` Dummy{}    = EQ
+
+instance Ord QuotedTerm where
+  QuotedTerm a u i `compare` QuotedTerm b v j = (a, u, i) `compare` (b, v, j)
 
 -- Andreas, 2017-10-04, issue #2775, ignore irrelevant arguments during with-abstraction.
 --

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -415,6 +415,8 @@ instance Unquote R.Term where
           mkPi a (R.Abs "_" b) = R.Pi a (R.Abs (pickName (unDom a)) b)
           mkPi a b = R.Pi a b
 
+      Lit (LitTerm _ q) -> return $ R.Trusted q
+
       Con{} -> __IMPOSSIBLE__
       Lit{} -> __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "term" t
@@ -455,6 +457,13 @@ instance Unquote R.Clause where
           __IMPOSSIBLE__
       Con c _ _ -> __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "clause" t
+
+unquoteTerm :: Term -> TCM R.Term
+unquoteTerm t = do
+  r <- runUnquoteM (unquote t)
+  case r of
+    Left err     -> typeError $ UnquoteFailed err
+    Right (r, _) -> pure r
 
 -- Unquoting TCM computations ---------------------------------------------
 

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -10,6 +10,7 @@ import qualified Data.List as List
 import Data.Maybe
 import Data.Foldable ( foldrM )
 import Data.Traversable ( traverse )
+import Data.Void
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal as I
@@ -490,8 +491,8 @@ stripWithClausePatterns cxtNames parent f t delta qs npars perm ps = do
            mismatch
 
         LitP lit -> case namedArg p of
-          A.LitP lit' | lit == lit' -> recurse $ Lit lit
-          A.WildP{}                 -> recurse $ Lit lit
+          A.LitP lit' | lit == lit' -> recurse $ Lit $ vacuous lit
+          A.WildP{}                 -> recurse $ Lit $ vacuous lit
 
           p@(A.PatternSynP pi' c' [ps']) -> do
              reportSDoc "impossible" 10 $
@@ -703,5 +704,5 @@ patsToElims = map $ toElim . fmap namedThing
       DotP PatOVar{} t@(Var i []) -> DTerm t
       DotP o t    -> DDot   $ t
       ConP c cpi ps -> DCon c (fromConPatternInfo cpi) $ toTerms ps
-      LitP l      -> DTerm  $ Lit l
+      LitP l      -> DTerm  $ Lit $ vacuous l
       DefP o q ps -> DDef q $ map Apply $ toTerms ps

--- a/src/full/Agda/Utils/Pretty.hs
+++ b/src/full/Agda/Utils/Pretty.hs
@@ -10,7 +10,7 @@ module Agda.Utils.Pretty
 
 import Data.Int ( Int32 )
 import Data.Data (Data(..))
-
+import Data.Void
 
 import qualified Text.PrettyPrint as P
 import Text.PrettyPrint hiding (TextDetails(Str), empty, (<>))
@@ -57,6 +57,9 @@ instance Pretty Char where
 
 instance Pretty Doc where
   pretty = id
+
+instance Pretty Void where
+  pretty = text . show
 
 instance Pretty () where
   pretty _ = P.empty

--- a/test/Compiler/simple/CompileQuoteLit.agda
+++ b/test/Compiler/simple/CompileQuoteLit.agda
@@ -1,0 +1,101 @@
+module CompileQuoteLit where
+
+open import Agda.Primitive
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Bool
+open import Agda.Builtin.List
+open import Agda.Builtin.String renaming (primStringAppend to infixr 6 _&_)
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Reflection renaming (bindTC to infixl 4 _>>=_)
+open import Agda.Builtin.IO
+
+variable
+  ℓ : Level
+  A : Set ℓ
+
+par : String → String
+par s = "(" & s & ")"
+
+showList′ : (A → String) → List A → String
+showList′ _ [] = "]"
+showList′ f (x ∷ []) = f x & "]"
+showList′ f (x ∷ xs) = f x & ", " & showList′ f xs
+
+showList : (A → String) → List A → String
+showList f xs = "[" & showList′ f xs
+
+{-# TERMINATING #-}
+showArgs : (A → String) → List (Arg A) → String
+showArg : (A → String) → Arg A → String
+showLit : Literal → String
+showAbs : Abs Term → String
+showSort : Sort → String
+showClauses : List Clause → String
+
+show : Term → String
+show (var x args) = par ("var " & primShowNat x & " " & showArgs show args)
+show (con c args) = par ("con " & primShowQName c & " " & showArgs show args)
+show (def f args) = par ("def " & primShowQName f & " " & showArgs show args)
+show (lam v t) = par ("λ " & showAbs t)
+show (pat-lam cs args) = par ("patlam " & showClauses cs & " " & showArgs show args)
+show (pi a b) = par ("Π " & showArg show a & " " & showAbs b)
+show (agda-sort s) = par ("sort " & showSort s)
+show (lit l) = par ("lit " & showLit l)
+show (meta x x₁) = "meta"
+show unknown = "unknown"
+
+showSort (set t) = par ("set " & show t)
+showSort (lit n) = par ("lit " & primShowNat n)
+showSort unknown = "unknown"
+
+showLit (nat n) = par ("nat " & primShowNat n)
+showLit (word64 n) = "word64"
+showLit (float x) = "float"
+showLit (char c) = "char"
+showLit (string s) = par ("string " & primShowString s)
+showLit (name x) = "name"
+showLit (meta x) = "meta"
+
+showAbs (abs s t) = s & " → " & show t
+
+showArgInfo : ArgInfo → String → String
+showArgInfo (arg-info visible _) s = s
+showArgInfo (arg-info hidden _) s = "{" & s & "}"
+showArgInfo (arg-info instance′ _) s = "⦃ " & s & " ⦄"
+
+showArg f (arg h x) = showArgInfo h (f x)
+showArgs f = showList (showArg f)
+
+showPat : Pattern → String
+showPat (con c ps) = par ("con " & primShowQName c & " " & showArgs showPat ps)
+showPat dot = "dot"
+showPat (var s) = par ("var " & primShowString s)
+showPat (lit l) = par ("lit " & showLit l)
+showPat (proj f) = par ("proj " & primShowQName f)
+showPat absurd = "()"
+
+showClause : Clause → String
+showClause (clause ps t) = par ("clause " & showArgs showPat ps & " " & show t)
+showClause (absurd-clause ps) = par ("absurd-clause " & showArgs showPat ps)
+
+showClauses = showList showClause
+
+macro
+  q : A → Term → TC ⊤
+  q x hole = do
+    `x  ← quoteTC x
+    ``x ← quoteTC `x
+    unify hole ``x
+
+postulate
+  putStrLn : String → IO ⊤
+{-# FOREIGN GHC import Data.Text.IO #-}
+{-# COMPILE GHC putStrLn = Data.Text.IO.putStrLn #-}
+{-# COMPILE JS putStrLn = function (x) { return function(cb) { process.stdout.write(x + "\n"); cb(0); }; } #-}
+
+some-term : Term
+some-term = q (1 + 2)
+
+main : IO ⊤
+main = putStrLn (show some-term)

--- a/test/Compiler/simple/CompileQuoteLit.out
+++ b/test/Compiler/simple/CompileQuoteLit.out
@@ -1,0 +1,5 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > (def Agda.Builtin.Nat._+_ [(lit (nat 1)), (lit (nat 2))])
+out >

--- a/test/Fail/Issue1280.agda
+++ b/test/Fail/Issue1280.agda
@@ -23,7 +23,6 @@ data Foo (A : Set) : Set where
 ok : Foo Nat
 ok = unquote (give (quoteTerm (foo {Nat})))
 
--- This shouldn't type-check. The term `bad` is type-checked because
--- the implicit argument of `foo` is missing when using quoteTerm.
+-- This shouldn't type-check.
 bad : Foo Bool
 bad = unquote (give (quoteTerm (foo {Nat})))

--- a/test/Fail/Issue1280.err
+++ b/test/Fail/Issue1280.err
@@ -1,0 +1,3 @@
+Issue1280.agda:28,7-45
+Nat !=< Bool of type Set
+when checking that the expression foo has type Foo Bool

--- a/test/Fail/TacticFail.err
+++ b/test/Fail/TacticFail.err
@@ -1,4 +1,4 @@
 TacticFail.agda:22,7-14
-Surprisingly the failTactic failed to prove (z : P ≡ NP) → ⊥
+Surprisingly the failTactic failed to prove P ≡ NP → ⊥
 when checking that the expression unquote proveIt has type
 P ≡ NP → ⊥

--- a/test/Internal/TypeChecking/Generators.hs
+++ b/test/Internal/TypeChecking/Generators.hs
@@ -245,7 +245,7 @@ instance GenC Integer where
 instance GenC Word64 where
   genC _ = arbitrary
 
-instance GenC Literal where
+instance GenC (Literal' t) where
   genC conf = oneof (concat $ zipWith gen useLits
               [ uncurry LitNat    <$> genC conf
               , uncurry LitWord64 <$> genC conf
@@ -401,7 +401,7 @@ instance ShrinkC ConName ConHead where
   shrinkC conf (ConName (ConHead{conName = c})) = map (\ c -> ConHead c Inductive []) $ takeWhile (/= c) $ tcConstructorNames conf
   noShrink = unConName
 
-instance ShrinkC Literal Literal where
+instance ShrinkC (Literal' t) (Literal' t) where
   shrinkC _ (LitNat _ 0) = []
   shrinkC conf l         = LitNat noRange 0 : case l of
       LitNat    r n -> LitNat    r <$> shrink n

--- a/test/Internal/TypeChecking/Generators.hs
+++ b/test/Internal/TypeChecking/Generators.hs
@@ -411,6 +411,7 @@ instance ShrinkC Literal Literal where
       LitFloat  r x -> LitFloat  r <$> shrink x
       LitQName  r x -> []
       LitMeta{}     -> []
+      LitTerm{}     -> []
   noShrink = id
 
 instance ShrinkC Char Char where

--- a/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
+++ b/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
@@ -197,6 +197,7 @@ postulate
   inferType     : Term → TC Type
   checkType     : Term → Type → TC Term
   normalise     : Term → TC Term
+  reduce        : Term → TC Term
   catchTC       : ∀ {a} {A : Set a} → TC A → TC A → TC A
   quoteTC       : ∀ {a} {A : Set a} → A → TC Term
   unquoteTC     : ∀ {a} {A : Set a} → Term → TC A
@@ -210,6 +211,8 @@ postulate
   getDefinition : Name → TC Definition
   blockOnMeta   : ∀ {a} {A : Set a} → Meta → TC A
   commitTC      : TC ⊤
+  isMacro       : Name → TC Bool
+  solveConstraintsMentioning : List Meta → TC ⊤
 
 {-# BUILTIN AGDATCM              TC            #-}
 {-# BUILTIN AGDATCMRETURN        returnTC      #-}
@@ -219,6 +222,7 @@ postulate
 {-# BUILTIN AGDATCMINFERTYPE     inferType     #-}
 {-# BUILTIN AGDATCMCHECKTYPE     checkType     #-}
 {-# BUILTIN AGDATCMNORMALISE     normalise     #-}
+{-# BUILTIN AGDATCMREDUCE        reduce        #-}
 {-# BUILTIN AGDATCMCATCHERROR    catchTC       #-}
 {-# BUILTIN AGDATCMQUOTETERM     quoteTC       #-}
 {-# BUILTIN AGDATCMUNQUOTETERM   unquoteTC     #-}
@@ -232,6 +236,8 @@ postulate
 {-# BUILTIN AGDATCMGETDEFINITION getDefinition #-}
 {-# BUILTIN AGDATCMBLOCKONMETA   blockOnMeta   #-}
 {-# BUILTIN AGDATCMCOMMIT        commitTC      #-}
+{-# BUILTIN AGDATCMISMACRO       isMacro       #-}
+{-# BUILTIN AGDATCMSOLVECONSTRAINTSMENTIONING solveConstraintsMentioning #-}
 
 -- The code below used to be rejected, but it was accepted if the code
 -- above was placed in a separate module.

--- a/test/Succeed/ReflectionLiterals.agda
+++ b/test/Succeed/ReflectionLiterals.agda
@@ -1,0 +1,37 @@
+module ReflectionLiterals where
+
+open import Agda.Primitive
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+open import Agda.Builtin.List
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Reflection renaming (bindTC to infixl 4 _>>=_)
+
+variable
+  ℓ : Level
+  A : Set ℓ
+
+_>>_ : {A B : Set} → TC A → TC B → TC B
+m >> m' = m >>= λ _ → m'
+
+inception : Nat → Term → TC Term
+inception zero    t = returnTC t
+inception (suc n) t = quoteTC t >>= inception n
+
+unception : Nat → Term → TC Term
+unception zero    t = returnTC t
+unception (suc n) t = unquoteTC t >>= unception n
+
+quoteN : {A : Set} → Nat → A → TC Term
+quoteN n x = quoteTC x >>= inception n >>= unception n
+
+macro
+  incept : {A : Set} → Nat → A → Term → TC ⊤
+  incept n x hole = quoteN n x >>= unify hole
+
+-- This blows up at level 4 without reflection literals.
+test : List Nat
+test = incept 500 (1 ∷ 2 ∷ [])
+
+check : test ≡ 1 ∷ 2 ∷ []
+check = refl

--- a/test/interaction/Issue2368.out
+++ b/test/interaction/Issue2368.out
@@ -10,5 +10,5 @@
 ((last . 1) . (agda2-goals-action '(0 2)))
 (agda2-give-action 2 "Term")
 (agda2-status-action "")
-(agda2-info-action "*All Goals, Errors*" "?0 : Term → Term → TC Agda.Builtin.Unit.⊤ _6 : Set → Set → Set [ at Issue2368.agda:12,7-33 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: unquote (?0 (def (quote foo) (arg (arg-info visible relevant) (def (quote Term) Agda.Builtin.List.List.[]) Agda.Builtin.List.List.∷ arg (arg-info visible relevant) (def (quote Term) Agda.Builtin.List.List.[]) Agda.Builtin.List.List.∷ Agda.Builtin.List.List.[]))) " nil)
+(agda2-info-action "*All Goals, Errors*" "?0 : Term → Term → TC Agda.Builtin.Unit.⊤ _6 : Set → Set → Set [ at Issue2368.agda:12,7-33 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: unquote (?0 (quoteTerm (foo Term Term))) " nil)
 ((last . 1) . (agda2-goals-action '(0)))

--- a/test/interaction/Issue3831.out
+++ b/test/interaction/Issue3831.out
@@ -18,6 +18,6 @@
 (agda2-info-action "*Error*" "1,10-17 1 when checking that the expression unquote (test3 n) has type _134 (n = n) (m = m)" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")
-(agda2-info-action "*Error*" "We reached a program point we did not want to reach. Location of the error: src/full/Agda/TypeChecking/Unquote.hs:664 " nil)
+(agda2-info-action "*Error*" "We reached a program point we did not want to reach. Location of the error: src/full/Agda/TypeChecking/Unquote.hs:675 " nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")


### PR DESCRIPTION
When quoting a term, instead of building the abstract syntax eagerly we just return a "term literal" (new `LitTerm` constructor in `Literal`). This carries the term, its type and checkpoint. Unquoting the term in the same checkpoint is a no-op.

This could potentially speed up some tactics a lot (although I don't yet have an example of a reasonable tactic that is now much faster).