### PR TITLE
2-level type theory

### DIFF
--- a/src/data/lib/prim/Agda/Primitive.agda
+++ b/src/data/lib/prim/Agda/Primitive.agda
@@ -31,3 +31,4 @@ postulate
 {-# BUILTIN LEVELMAX  _⊔_   #-}
 
 {-# BUILTIN SETOMEGA Setω #-}
+{-# BUILTIN STRICTSET SSet #-}

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -165,6 +165,7 @@ primBody s = maybe unimplemented (fromRight (hsVarUQ . HS.Ident) <$>) $
 
   -- Sorts
   , "primSetOmega"    |-> return "()"
+  , "primStrictSet"   |-> return "\\ _ -> ()"
 
   -- Natural number functions
   , "primNatPlus"      |-> binNat "(+)"

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -26,7 +26,7 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinInf, builtinSharp, builtinFlat,
   builtinEquality, builtinRefl, builtinRewrite, builtinLevelMax,
   builtinLevel, builtinLevelZero, builtinLevelSuc,
-  builtinSetOmega,
+  builtinSetOmega, builtinStrictSet,
   builtinFromNat, builtinFromNeg, builtinFromString,
   builtinQName, builtinAgdaSort, builtinAgdaSortSet, builtinAgdaSortLit,
   builtinAgdaSortUnsupported,
@@ -145,6 +145,7 @@ builtinLevel                             = "LEVEL"
 builtinLevelZero                         = "LEVELZERO"
 builtinLevelSuc                          = "LEVELSUC"
 builtinSetOmega                          = "SETOMEGA"
+builtinStrictSet                         = "STRICTSET"
 builtinFromNat                           = "FROMNAT"
 builtinFromNeg                           = "FROMNEG"
 builtinFromString                        = "FROMSTRING"
@@ -270,6 +271,7 @@ builtinsNoDef =
   , builtinIZero
   , builtinIOne
   , builtinSetOmega
+  , builtinStrictSet
   ]
 
 sizeBuiltins :: [String]

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -292,6 +292,7 @@ type Telescope = Tele (Dom Type)
 data Sort' t
   = Type (Level' t)  -- ^ @Set ℓ@.
   | Prop (Level' t)  -- ^ @Prop ℓ@.
+  | SSet (Level' t)  -- ^ @SSet ℓ@.
   | Inf         -- ^ @Setω@.
   | SizeUniv    -- ^ @SizeUniv@, a sort inhabited by type @Size@.
   | PiSort (Dom' t (Type'' t t)) (Abs (Sort' t)) -- ^ Sort of the pi type.
@@ -1220,6 +1221,7 @@ instance TermSize Sort where
   tsize s = case s of
     Type l    -> 1 + tsize l
     Prop l    -> 1 + tsize l
+    SSet l    -> 1 + tsize l
     Inf       -> 1
     SizeUniv  -> 1
     PiSort a s -> 1 + tsize a + tsize s
@@ -1292,6 +1294,7 @@ instance KillRange Sort where
     SizeUniv   -> SizeUniv
     Type a     -> killRange1 Type a
     Prop a     -> killRange1 Prop a
+    SSet a     -> killRange1 SSet a
     PiSort a s -> killRange2 PiSort a s
     UnivSort s -> killRange1 UnivSort s
     MetaS x es -> killRange1 (MetaS x) es
@@ -1451,6 +1454,7 @@ instance Pretty Sort where
       Prop (Max []) -> "Prop"
       Prop (Max [ClosedLevel n]) -> text $ "Prop" ++ show n
       Prop l -> mparens (p > 9) $ "Prop" <+> prettyPrec 10 l
+      SSet l -> mparens (p > 9) $ "SSet" <+> prettyPrec 10 l
       Inf -> "Setω"
       SizeUniv -> "SizeUniv"
       PiSort a b -> mparens (p > 9) $
@@ -1518,6 +1522,7 @@ instance NFData Sort where
   rnf s = case s of
     Type l   -> rnf l
     Prop l   -> rnf l
+    SSet l   -> rnf l
     Inf      -> ()
     SizeUniv -> ()
     PiSort a b -> rnf (a, unAbs b)

--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -79,6 +79,7 @@ instance GetDefs Sort where
   getDefs s = case s of
     Type l    -> getDefs l
     Prop l    -> getDefs l
+    SSet l    -> getDefs l
     Inf       -> return ()
     SizeUniv  -> return ()
     PiSort a s  -> getDefs a >> getDefs s

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -143,6 +143,7 @@ instance TermLike Sort where
   traverseTermM f s = case s of
     Type l     -> Type <$> traverseTermM f l
     Prop l     -> Prop <$> traverseTermM f l
+    SSet l     -> SSet <$> traverseTermM f l
     Inf        -> pure s
     SizeUniv   -> pure s
     PiSort a b -> PiSort   <$> traverseTermM f a <*> traverseTermM f b
@@ -154,6 +155,7 @@ instance TermLike Sort where
   foldTerm f s = case s of
     Type l     -> foldTerm f l
     Prop l     -> foldTerm f l
+    SSet l     -> foldTerm f l
     Inf        -> mempty
     SizeUniv   -> mempty
     PiSort a b -> foldTerm f a <> foldTerm f b

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -107,6 +107,7 @@ instance NamesIn Sort where
   namesIn s = case s of
     Type l   -> namesIn l
     Prop l   -> namesIn l
+    SSet l   -> namesIn l
     Inf      -> Set.empty
     SizeUniv -> Set.empty
     PiSort a b -> namesIn (a, b)

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1252,6 +1252,10 @@ instance Reify Sort Expr where
         I.Prop a -> do
           a <- reify a
           return $ A.App defaultAppInfo_ (A.Prop noExprInfo 0) (defaultNamedArg a)
+        I.SSet a  -> do
+          I.Def sset [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinStrictSet
+          a <- reify a
+          return $ A.App defaultAppInfo_ (A.Def sset) (defaultNamedArg a)
         I.Inf       -> do
           I.Def inf [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSetOmega
           return $ A.Def inf

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -676,6 +676,7 @@ instance ExtractCalls Sort where
       SizeUniv   -> return empty
       Type t     -> terUnguarded $ extract t  -- no guarded levels
       Prop t     -> terUnguarded $ extract t
+      SSet t     -> terUnguarded $ extract t
       PiSort a s -> extract (a, s)
       UnivSort s -> extract s
       MetaS x es -> return empty

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -172,6 +172,7 @@ instance AbsTerm Sort where
   absTerm u s = case s of
     Type n     -> Type $ absS n
     Prop n     -> Prop $ absS n
+    SSet n     -> SSet $ absS n
     Inf        -> Inf
     SizeUniv   -> SizeUniv
     PiSort a s -> PiSort (absS a) (absS s)
@@ -267,6 +268,7 @@ instance EqualSy Sort where
   equalSy = curry $ \case
     (Type l    , Type l'     ) -> equalSy l l'
     (Prop l    , Prop l'     ) -> equalSy l l'
+    (SSet l    , SSet l'     ) -> equalSy l l'
     (Inf       , Inf         ) -> True
     (SizeUniv  , SizeUniv    ) -> True
     (PiSort a b, PiSort a' b') -> equalSy a a' && equalSy b b'

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -400,6 +400,7 @@ checkSort action s =
   case s of
     Type l   -> Type <$> checkLevel action l
     Prop l   -> Prop <$> checkLevel action l
+    SSet l   -> SSet <$> checkLevel action l
     Inf      -> return Inf
     SizeUniv -> return SizeUniv
     PiSort dom s2 -> do

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1169,9 +1169,20 @@ leqSort s1 s2 = (catchConstraint (SortCmp CmpLeq s1 s2) :: m () -> m ()) $ do
       -- Likewise for @Prop@
       (Prop a  , Prop b  ) -> leqLevel a b
 
+      -- Likewise for @SSet@
+      (SSet a  , SSet b  ) -> leqLevel a b
+
       -- @Prop l@ is below @Set l@
       (Prop a  , Type b  ) -> leqLevel a b
       (Type a  , Prop b  ) -> no
+
+      -- @Set l@ is below @SSet l@
+      (Type a  , SSet b  ) -> leqLevel a b
+      (SSet a  , Type b  ) -> no
+
+      -- @Prop l@ is below @SSet l@
+      (Prop a  , SSet b  ) -> leqLevel a b
+      (SSet a  , Prop b  ) -> no
 
       -- Setω is the top sort
       (_       , Inf     ) -> yes
@@ -1187,6 +1198,7 @@ leqSort s1 s2 = (catchConstraint (SortCmp CmpLeq s1 s2) :: m () -> m ()) $ do
       -- SizeUniv is unrelated to any @Set l@ or @Prop l@
       (SizeUniv, Type{}  ) -> no
       (SizeUniv, Prop{}  ) -> no
+      (SizeUniv, SSet{}  ) -> no
 
       -- If the first sort rigidly depends on a variable and the second
       -- sort does not mention this variable, the second sort must be Inf.
@@ -1550,6 +1562,7 @@ equalSort s1 s2 = do
             (Type a     , Type b     ) -> equalLevel a b
             (SizeUniv   , SizeUniv   ) -> yes
             (Prop a     , Prop b     ) -> equalLevel a b
+            (SSet a     , SSet b     ) -> equalLevel a b
             (Inf        , Inf        ) -> yes
 
             -- if --type-in-type is enabled, Setω is equal to any Set ℓ (see #3439)

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -1078,7 +1078,11 @@ computeNeighbourhood delta1 n delta2 d pars ixs hix tel ps cps c = do
          TelV dtel dt <- telView dtype
          return $ abstract (mapCohesion updCoh <$> dtel) dt
 
-  r <- unifyIndices
+  withKIfStrict <- addContext delta1 $ reduce (getSort dtype) >>= \case
+    SSet{} -> return $ locallyTC eSplitOnStrict $ const True
+    _      -> return id
+
+  r <- withKIfStrict $ unifyIndices
          delta1Gamma
          flex
          (raise (size gamma) dtype)

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -545,6 +545,7 @@ instance Free Sort where
     case s of
       Type a     -> freeVars' a
       Prop a     -> freeVars' a
+      SSet a     -> freeVars' a
       Inf        -> mempty
       SizeUniv   -> mempty
       PiSort a s -> underFlexRig (Flexible mempty) (freeVars' $ unDom a) `mappend`

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -78,6 +78,7 @@ instance PrecomputeFreeVars Sort where
     case s of
       Type a     -> Type <$> precomputeFreeVars a
       Prop a     -> Prop <$> precomputeFreeVars a
+      SSet a     -> SSet <$> precomputeFreeVars a
       Inf        -> pure s
       SizeUniv   -> pure s
       PiSort a s -> uncurry PiSort <$> precomputeFreeVars (a, s)

--- a/src/full/Agda/TypeChecking/Free/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Free/Reduce.hs
@@ -151,6 +151,7 @@ instance ForceNotFree Sort where
   forceNotFree' s = case s of
     Type l     -> Type     <$> forceNotFree' l
     Prop l     -> Prop     <$> forceNotFree' l
+    SSet l     -> SSet     <$> forceNotFree' l
     PiSort a b -> PiSort   <$> forceNotFree' a <*> forceNotFree' b
     UnivSort s -> UnivSort <$> forceNotFree' s
     MetaS x es -> MetaS x  <$> forceNotFree' es

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -321,6 +321,7 @@ instance UsableRelevance Sort where
   usableRel rel s = case s of
     Type l -> usableRel rel l
     Prop l -> usableRel rel l
+    SSet l -> usableRel rel l
     Inf    -> return True
     SizeUniv -> return True
     PiSort a s -> usableRel rel (a,s)
@@ -487,3 +488,15 @@ isPropM a = reduce (getSort a) <&> \case
 
 isIrrelevantOrPropM :: (LensRelevance a, LensSort a, MonadReduce m) => a -> m Bool
 isIrrelevantOrPropM x = return (isIrrelevant x) `or2M` isPropM x
+
+-- * Fibrant types
+
+-- | Is a type fibrant (i.e. not a SSet)?
+
+isFibrant :: (LensSort a, MonadReduce m) => a -> m Bool
+isFibrant a = reduce (getSort a) <&> \case
+  Type{}     -> True
+  Prop{}     -> True
+  Inf{}      -> True
+  SizeUniv{} -> True
+  _          -> False

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -51,6 +51,7 @@ instance MentionsMeta Sort where
   mentionsMetas xs s = case s of
     Type l     -> mentionsMetas xs l
     Prop l     -> mentionsMetas xs l
+    SSet l     -> mentionsMetas xs l
     Inf        -> False
     SizeUniv   -> False
     PiSort a s -> mentionsMetas xs (a, s)

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -509,6 +509,7 @@ instance Occurs Sort where
         return $ PiSort a' s2'
       Type a     -> Type <$> occurs a
       Prop a     -> Prop <$> occurs a
+      SSet a     -> SSet <$> occurs a
       s@Inf      -> return s
       s@SizeUniv -> return s
       UnivSort s -> UnivSort <$> do flexibly $ occurs s
@@ -526,6 +527,7 @@ instance Occurs Sort where
       PiSort a s -> metaOccurs m (a,s)
       Type a     -> metaOccurs m a
       Prop a     -> metaOccurs m a
+      SSet a     -> metaOccurs m a
       Inf        -> return ()
       SizeUniv   -> return ()
       UnivSort s -> metaOccurs m s
@@ -739,6 +741,7 @@ instance AnyRigid Sort where
     case s of
       Type l     -> anyRigid f l
       Prop l     -> anyRigid f l
+      SSet l     -> anyRigid f l
       Inf        -> return False
       SizeUniv   -> return False
       PiSort a s -> return False

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2566,6 +2566,11 @@ data TCEnv =
                 -- Then runtime-irrelevant things are usable.
                 -- Other value: @Quantity1@, runtime relevant.
                 -- @Quantityω@ is not allowed here, see Bob Atkey, LiCS 2018.
+          , envSplitOnStrict       :: Bool
+                -- ^ Are we currently case-splitting on a strict
+                --   datatype (i.e. in SSet)? If yes, the
+                --   pattern-matching unifier will solve reflexive
+                --   equations even --without-K.
           , envDisplayFormsEnabled :: Bool
                 -- ^ Sometimes we want to disable display forms.
           , envRange :: Range
@@ -2681,6 +2686,7 @@ initEnv = TCEnv { envContext             = []
   -- can only look into abstract things in an abstract
   -- definition (which sets 'AbstractMode').
                 , envModality               = mempty
+                , envSplitOnStrict          = False
                 , envDisplayFormsEnabled    = True
                 , envRange                  = noRange
                 , envHighlightingRange      = noRange
@@ -2795,6 +2801,9 @@ eRelevance = eModality . lModRelevance
 
 eQuantity :: Lens' Quantity TCEnv
 eQuantity = eModality . lModQuantity
+
+eSplitOnStrict :: Lens' Bool TCEnv
+eSplitOnStrict f e = f (envSplitOnStrict e) <&> \ x -> e { envSplitOnStrict = x }
 
 eDisplayFormsEnabled :: Lens' Bool TCEnv
 eDisplayFormsEnabled f e = f (envDisplayFormsEnabled e) <&> \ x -> e { envDisplayFormsEnabled = x }

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -182,7 +182,7 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primEquality, primRefl,
     primRewrite, -- Name of rewrite relation
     primLevel, primLevelZero, primLevelSuc, primLevelMax,
-    primSetOmega,
+    primSetOmega, primStrictSet,
     primFromNat, primFromNeg, primFromString,
     -- builtins for reflection:
     primQName, primArgInfo, primArgArgInfo, primArg, primArgArg, primAbs, primAbsAbs, primAgdaTerm, primAgdaTermVar,
@@ -294,6 +294,7 @@ primLevelZero                         = getBuiltin builtinLevelZero
 primLevelSuc                          = getBuiltin builtinLevelSuc
 primLevelMax                          = getBuiltin builtinLevelMax
 primSetOmega                          = getBuiltin builtinSetOmega
+primStrictSet                         = getBuiltin builtinStrictSet
 primFromNat                           = getBuiltin builtinFromNat
 primFromNeg                           = getBuiltin builtinFromNeg
 primFromString                        = getBuiltin builtinFromString

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -593,6 +593,13 @@ mkPrimSetOmega = do
   let t = sort $ UnivSort Inf
   return $ PrimImpl t $ primFun __IMPOSSIBLE__ 0 $ \_ -> redReturn $ Sort Inf
 
+mkPrimStrictSet :: TCM PrimitiveImpl
+mkPrimStrictSet = do
+  t <- nPi "ℓ" (el primLevel) (pure $ sort $ SSet $ Max [Plus 1 $ NeutralLevel mempty $ var 0])
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 1 $ \ ~[a] -> do
+    l <- levelView' $ unArg a
+    redReturn $ Sort $ SSet l
+
 mkPrimFun1TCM :: (FromTerm a, ToTerm b, TermLike b) =>
                  TCM Type -> (a -> ReduceM b) -> TCM PrimitiveImpl
 mkPrimFun1TCM mt f = do
@@ -735,6 +742,7 @@ primitiveFunctions = Map.fromList
 
   -- Sorts
   , "primSetOmega"        |-> mkPrimSetOmega
+  , "primStrictSet"       |-> mkPrimStrictSet
 
   -- Floating point functions
   , "primNatToFloat"      |-> mkPrimFun1 (fromIntegral    :: Nat -> Double)

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -12,6 +12,7 @@ import Agda.TypeChecking.Monad.Context
 import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Names
 import {-# SOURCE #-} Agda.TypeChecking.Primitive
+import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Reduce ( reduce )
 import Agda.TypeChecking.Monad.Signature
 import Agda.TypeChecking.Substitute
@@ -156,7 +157,9 @@ domH = setHiding Hidden . defaultDom
 
 lookupPrimitiveFunction :: String -> TCM PrimitiveImpl
 lookupPrimitiveFunction x =
-  fromMaybe (typeError $ NoSuchPrimitiveFunction x)
+  fromMaybe (do
+                reportSDoc "tc.prim" 20 $ "Lookup of primitive function" <+> text x <+> "failed"
+                typeError $ NoSuchPrimitiveFunction x)
             (Map.lookup x primitiveFunctions)
 
 lookupPrimitiveFunctionQ :: QName -> TCM (String, PrimitiveImpl)

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -130,6 +130,7 @@ quotingKit = do
       quoteSort :: Sort -> ReduceM Term
       quoteSort (Type t) = quoteSortLevelTerm t
       quoteSort Prop{}   = pure unsupportedSort
+      quoteSort SSet{}   = pure unsupportedSort
       quoteSort Inf      = pure unsupportedSort
       quoteSort SizeUniv = pure unsupportedSort
       quoteSort PiSort{} = pure unsupportedSort

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -309,6 +309,7 @@ instance Reduce Sort where
           caseMaybe (univSort' ui s') (return $ UnivSort s') reduce'
         Prop s'    -> Prop <$> reduce' s'
         Type s'    -> Type <$> reduce' s'
+        SSet s'    -> SSet <$> reduce' s'
         Inf        -> return Inf
         SizeUniv   -> return SizeUniv
         MetaS x es -> return s
@@ -857,6 +858,7 @@ instance Simplify Sort where
           univSort ui <$> simplify' s
         Type s     -> Type <$> simplify' s
         Prop s     -> Prop <$> simplify' s
+        SSet s     -> SSet <$> simplify' s
         Inf        -> return s
         SizeUniv   -> return s
         MetaS x es -> MetaS x <$> simplify' es
@@ -1002,6 +1004,7 @@ instance Normalise Sort where
           univSort ui <$> normalise' s
         Prop s     -> Prop <$> normalise' s
         Type s     -> Type <$> normalise' s
+        SSet s     -> SSet <$> normalise' s
         Inf        -> return Inf
         SizeUniv   -> return SizeUniv
         MetaS x es -> return s
@@ -1178,6 +1181,7 @@ instance InstantiateFull Sort where
         case s of
             Type n     -> Type <$> instantiateFull' n
             Prop n     -> Prop <$> instantiateFull' n
+            SSet n     -> SSet <$> instantiateFull' n
             PiSort a s -> piSort <$> instantiateFull' a <*> instantiateFull' s
             UnivSort s -> do
               ui <- univInf

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -553,6 +553,7 @@ instance AllHoles Sort where
   allHoles _ = \case
     Type l       -> fmap Type <$> allHoles_ l
     Prop l       -> fmap Prop <$> allHoles_ l
+    SSet l       -> fmap SSet <$> allHoles_ l
     Inf          -> empty
     SizeUniv     -> empty
     PiSort s1 s2 -> __IMPOSSIBLE__
@@ -635,6 +636,7 @@ instance MetasToVars Sort where
   metasToVars = \case
     Type l     -> Type     <$> metasToVars l
     Prop l     -> Prop     <$> metasToVars l
+    SSet l     -> SSet     <$> metasToVars l
     Inf        -> pure Inf
     SizeUniv   -> pure SizeUniv
     PiSort s t -> PiSort   <$> metasToVars s <*> metasToVars t

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -84,6 +84,7 @@ instance PatternFrom () Sort NLPSort where
     case s of
       Type l   -> PType <$> patternFrom r k () l
       Prop l   -> PProp <$> patternFrom r k () l
+      SSet l   -> __IMPOSSIBLE__
       Inf      -> return PInf
       SizeUniv -> return PSizeUniv
       PiSort _ _ -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -311,6 +311,7 @@ coreBuiltins =
   , (builtinLevelSuc                         |-> BuiltinPrim "primLevelSuc" (const $ return ()))
   , (builtinLevelMax                         |-> BuiltinPrim "primLevelMax" verifyMax)
   , (builtinSetOmega                         |-> BuiltinPrim "primSetOmega" (const $ return ()))
+  , (builtinStrictSet                        |-> BuiltinPrim "primStrictSet" (const $ return ()))
   , (builtinAgdaClause                       |-> BuiltinData tset [builtinAgdaClauseClause, builtinAgdaClauseAbsurd])
   , (builtinAgdaClauseClause                 |-> BuiltinDataCons (tlist (targ tpat) --> tterm --> tclause))
   , (builtinAgdaClauseAbsurd                 |-> BuiltinDataCons (tlist (targ tpat) --> tclause))

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -652,8 +652,11 @@ checkPrimitive i x e =
           , "primLevelSuc"
           , "primLevelMax"
           , "primSetOmega"
+          , "primStrictSet"
           ]
-    when (name `elem` builtinPrimitives) $ typeError $ NoSuchPrimitiveFunction name
+    when (name `elem` builtinPrimitives) $ do
+      reportSDoc "tc.prim" 20 $ text name <+> "is a BUILTIN, not a primitive!"
+      typeError $ NoSuchPrimitiveFunction name
     t <- isType_ e
     noConstraints $ equalType t t'
     let s  = prettyShow $ qnameName x

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -838,9 +838,11 @@ unifyStep s Deletion{ deleteAt = k , deleteType = a , deleteLeft = u , deleteRig
     isReflexive <- liftTCM $ addContext (varTel s) $ tryCatch $ do
       dontAssignMetas $ noConstraints $ equalTerm a u v
     withoutK <- liftTCM withoutKOption
+    splitOnStrict <- asksTC envSplitOnStrict
     case isReflexive of
       Just err     -> return $ DontKnow []
-      _ | withoutK -> return $ DontKnow [UnifyReflexiveEq (varTel s) a u]
+      _ | withoutK && not splitOnStrict
+                   -> return $ DontKnow [UnifyReflexiveEq (varTel s) a u]
       _            -> do
         let (s', sigma) = solveEq k u s
         tellUnifyProof sigma

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -62,7 +62,7 @@ import Agda.Utils.Except
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20190824 * 10 + 0
+currentInterfaceVersion = 20190914 * 10 + 0
 
 -- | Encodes something. To ensure relocatability file paths in
 -- positions are replaced with module names.

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -139,22 +139,24 @@ instance EmbPrj LevelAtom where
 instance EmbPrj I.Sort where
   icod_ (Type  a  ) = icodeN 0 Type a
   icod_ (Prop  a  ) = icodeN 1 Prop a
-  icod_ SizeUniv    = icodeN 2 SizeUniv
-  icod_ Inf         = icodeN 3 Inf
-  icod_ (PiSort a b) = icodeN 4 PiSort a b
-  icod_ (UnivSort a) = icodeN 5 UnivSort a
+  icod_ (SSet  a  ) = icodeN 2 SSet a
+  icod_ SizeUniv    = icodeN 3 SizeUniv
+  icod_ Inf         = icodeN 4 Inf
+  icod_ (PiSort a b) = icodeN 5 PiSort a b
+  icod_ (UnivSort a) = icodeN 6 UnivSort a
   icod_ (MetaS a b)  = __IMPOSSIBLE__
-  icod_ (DefS a b)   = icodeN 6 DefS a b
+  icod_ (DefS a b)   = icodeN 7 DefS a b
   icod_ (DummyS s)   = __IMPOSSIBLE__
 
   value = vcase valu where
     valu [0, a]    = valuN Type  a
     valu [1, a]    = valuN Prop  a
-    valu [2]       = valuN SizeUniv
-    valu [3]       = valuN Inf
-    valu [4, a, b] = valuN PiSort a b
-    valu [5, a]    = valuN UnivSort a
-    valu [6, a, b] = valuN DefS a b
+    valu [2, a]    = valuN SSet  a
+    valu [3]       = valuN SizeUniv
+    valu [4]       = valuN Inf
+    valu [5, a, b] = valuN PiSort a b
+    valu [6, a]    = valuN UnivSort a
+    valu [7, a, b] = valuN DefS a b
     valu _         = malformed
 
 instance EmbPrj DisplayForm where

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -802,6 +802,7 @@ instance (Coercible a Term, Subst t a) => Subst t (Sort' a) where
   applySubst rho s = case s of
     Type n     -> Type $ sub n
     Prop n     -> Prop $ sub n
+    SSet n     -> SSet $ sub n
     Inf        -> Inf
     SizeUniv   -> SizeUniv
     PiSort a s2 -> coerce $ piSort (coerce $ sub a) (coerce $ sub s2)
@@ -1379,6 +1380,7 @@ instance (Subst t a, Ord a) => Ord (Elim' a) where
 univSort' :: Maybe Sort -> Sort -> Maybe Sort
 univSort' univInf (Type l) = Just $ Type $ levelSuc l
 univSort' univInf (Prop l) = Just $ Type $ levelSuc l
+univSort' univInf (SSet l) = Just $ SSet $ levelSuc l
 univSort' univInf Inf      = univInf
 univSort' univInf s        = Nothing
 
@@ -1403,6 +1405,9 @@ funSort' a b = case (getSort a, b) of
   (Prop (Max as) , Type (Max bs)) -> Just $ Type $ levelMax $ as ++ bs
   (Type (Max as) , Prop (Max bs)) -> Just $ Prop $ levelMax $ as ++ bs
   (Prop (Max as) , Prop (Max bs)) -> Just $ Prop $ levelMax $ as ++ bs
+  (SSet (Max as) , SSet (Max bs)) -> Just $ SSet $ levelMax $ as ++ bs
+  (Type (Max as) , SSet (Max bs)) -> Just $ SSet $ levelMax $ as ++ bs
+  (SSet (Max as) , Type (Max bs)) -> Just $ SSet $ levelMax $ as ++ bs
   (a             , b            ) -> Nothing
 
 funSort :: Dom Type -> Sort -> Sort

--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -137,6 +137,7 @@ instance SynEq Sort where
       (UnivSort a, UnivSort a') -> UnivSort <$$> synEq a a'
       (SizeUniv, SizeUniv  ) -> pure2 s
       (Prop l  , Prop l'   ) -> Prop <$$> synEq l l'
+      (SSet l  , SSet l'   ) -> SSet <$$> synEq l l'
       (Inf     , Inf       ) -> pure2 s
       (MetaS x es , MetaS x' es') | x == x' -> MetaS x <$$> synEq es es'
       (DefS  d es , DefS  d' es') | d == d' -> DefS d  <$$> synEq es es'

--- a/test/Succeed/SST.agda
+++ b/test/Succeed/SST.agda
@@ -1,0 +1,180 @@
+-- Construction of the four functions SST, SK, SK⃗, and αₖ from
+-- "Extending Homotopy Type Theory with Strict Equality" by Thorsten
+-- Altenkirch, Paolo Capriotti, Nicolai Kraus (2016)
+-- (https://arxiv.org/abs/1604.03799).
+
+{-# OPTIONS --without-K --rewriting #-}
+
+open import Agda.Primitive
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Sigma
+
+variable
+  ℓ ℓ′ ℓ₁ ℓ₂ ℓ₃ : Level
+  A B C : Set ℓ
+  x y z : A
+
+infix 4 _≡ₛ_ _≡ₛₛ_
+data _≡ₛ_ {A : Set ℓ} (x : A) : A → SSet ℓ where
+  instance
+    refl : x ≡ₛ x
+
+data _≡ₛₛ_ {A : SSet ℓ} (x : A) : A → SSet ℓ where
+  instance
+    refl : x ≡ₛₛ x
+
+UIPₛ : {A : Set ℓ} {x y : A} {e₁ e₂ : x ≡ₛ y} → e₁ ≡ₛₛ e₂
+UIPₛ {e₁ = refl} {e₂ = refl} = refl
+
+{-# BUILTIN REWRITE _≡ₛₛ_ #-}
+
+sym : x ≡ₛ y → y ≡ₛ x
+sym refl = refl
+
+trans : x ≡ₛ y → y ≡ₛ z → x ≡ₛ z
+trans refl refl = refl
+
+infixr 10 _≡⟨_⟩ₛ_
+_≡⟨_⟩ₛ_ : {A : Set ℓ} (x : A) {y z : A} → x ≡ₛ y → y ≡ₛ z → x ≡ₛ z
+x ≡⟨ refl ⟩ₛ refl = refl
+
+infix 15 _∎ₛ
+_∎ₛ : {A : Set ℓ} (x : A) → x ≡ₛ x
+x ∎ₛ = refl
+
+transport : {A : Set ℓ} (P : A → Set ℓ′) {x y : A} → x ≡ₛ y → P x → P y
+transport P refl p = p
+
+transport-merge : {A : Set ℓ} {P : A → Set ℓ′} {x y z : A}
+                  {e₁ : x ≡ₛ y} {e₂ : y ≡ₛ z} {p : P x}
+                → transport P e₂ (transport P e₁ p) ≡ₛ transport P (trans e₁ e₂) p
+transport-merge {e₁ = refl} {e₂ = refl} = refl
+
+transport-pi : {A : Set ℓ₁} {B : Set ℓ₂} {C : A → B → Set ℓ₃}
+             → {x₁ x₂ : A} {e : x₁ ≡ₛ x₂} {f : (y : B) → C x₁ y} {y : B}
+             → transport (λ x → (y : B) → C x y) e f y ≡ₛ transport (λ x → C x y) e (f y)
+transport-pi {e = refl} = refl
+
+cong : (f : A → B) {x₁ x₂ : A} → x₁ ≡ₛ x₂ → f x₁ ≡ₛ f x₂
+cong f refl = refl
+
+cong₂ : {A : Set ℓ} {B : A → Set ℓ′} (f : (x : A) → B x → C)
+      → {x₁ x₂ : A} {y₁ : B x₁} {y₂ : B x₂}
+      → (p : x₁ ≡ₛ x₂) (q : transport B p y₁ ≡ₛ y₂)
+      → f x₁ y₁ ≡ₛ f x₂ y₂
+cong₂ f refl refl = refl
+
+transport-cong : {f : A → B} {P : B → Set ℓ} {x₁ x₂ : A} {e : x₁ ≡ₛ x₂} {p : P (f x₁)}
+               → transport (λ x → P (f x)) e p ≡ₛ transport P (cong f e) p
+transport-cong {e = refl} = refl
+
+cong-transport : {A : Set ℓ} {P : A → Set ℓ′} {x y : A} {e₁ e₂ : x ≡ₛ y} {p : P x}
+               → e₁ ≡ₛₛ e₂ → transport P e₁ p ≡ₛ transport P e₂ p
+cong-transport refl = refl
+
+postulate
+  funextₛ : {A : Set ℓ} {B : A → Set ℓ′} {f g : (x : A) → B x}
+          → (∀ x → f x ≡ₛ g x) → f ≡ₛ g
+
+data sNat : SSet lzero where
+  zero : sNat
+  suc  : sNat → sNat
+
+variable
+  k l m n : sNat
+
+postulate
+  Nat→sNat : Nat → sNat
+  zero→szero : Nat→sNat zero ≡ₛₛ zero
+  suc→ssuc : ∀ n → Nat→sNat (suc n) ≡ₛₛ suc (Nat→sNat n)
+
+{-# REWRITE zero→szero #-}
+{-# REWRITE suc→ssuc #-}
+
+data ⊥ {ℓ} : Set ℓ where
+
+record ⊤ {ℓ} : Set ℓ where
+  constructor ∗
+
+data _⊎_ (A B : Set ℓ) : Set ℓ where
+  inl : A → A ⊎ B
+  inr : B → A ⊎ B
+
+{-# NO_UNIVERSE_CHECK #-}
+data Fin : sNat → Set where
+  fzero : Fin (suc n)
+  fsuc  : Fin n → Fin (suc n)
+
+{-# NO_UNIVERSE_CHECK #-}
+data _<ⁿ_ : Fin n → Fin n → Set where
+  z<s : fzero <ⁿ fsuc x
+  s<s : x <ⁿ y → fsuc x <ⁿ fsuc y
+
+isIncr : (Fin k → Fin l) → Set
+isIncr f = ∀ {x} {y} → x <ⁿ y → f x <ⁿ f y
+
+Δ₊ : (i j : sNat) → Set
+Δ₊ i j = Σ (Fin i → Fin j) isIncr
+
+_∘_ : Δ₊ l m → Δ₊ k l → Δ₊ k m
+(f , f-incr) ∘ (g , g-incr) = (λ x → f (g x)) , λ p → f-incr (g-incr p)
+
+∘-assoc : ∀ {k l m n} {f : Δ₊ k l} {g : Δ₊ l m} {h : Δ₊ m n}
+        → (h ∘ g) ∘ f ≡ₛ h ∘ (g ∘ f)
+∘-assoc = refl
+
+SST : sNat → Set₁
+SK : (k : sNat) → SST k → sNat → Set
+SK⃗ : (k : sNat) (X : SST k) {m n : sNat} (f : Δ₊ m n) → SK k X n → SK k X m
+α : (k : sNat) {l m n : sNat} (X : SST k) (f : Δ₊ l m) (g : Δ₊ m n)
+  → (x : SK k X n) → SK⃗ k X (g ∘ f) x ≡ₛ SK⃗ k X f (SK⃗ k X g x)
+
+SST zero = ⊤
+SST (suc k) = Σ (SST k) λ X → (SK k X (suc k) → Set)
+
+SK zero X n = ⊤
+SK (suc k) (X , Y) n = Σ (SK k X n) λ x → (f : Δ₊ (suc k) n) → Y (SK⃗ k X f x)
+
+SK⃗ zero X f = λ x → x
+SK⃗ (suc k) (X , Y) f (x , h) = SK⃗ k X f x , λ g →
+  let h[f∘g] : Y (SK⃗ k X (f ∘ g) x)
+      h[f∘g] = h (f ∘ g)
+      αₖ : SK⃗ k X (f ∘ g) x ≡ₛ SK⃗ k X g (SK⃗ k X f x)
+      αₖ = α k X g f x
+  in transport Y αₖ h[f∘g]
+
+α zero X f g x    = refl
+α (suc k) {l} {m} {n} (X , Y) f g (x , y) =
+  cong₂ _,_ (α k X f g x) (funextₛ λ h →
+
+    transport (λ z → (f′ : Δ₊ (suc k) l) → Y (SK⃗ k X f′ z)) (α k X f g x)
+      (λ g′ → transport Y (α k X g′ (g ∘ f) x) (y ((g ∘ f) ∘ g′))) h
+
+      ≡⟨ transport-pi {B = Δ₊ (suc k) l} {C = λ z f′ → Y (SK⃗ k X f′ z)} {e = α k X f g x} ⟩ₛ
+
+    transport (λ z → Y (SK⃗ k X h z)) (α k X f g x)
+      (transport Y (α k X h (g ∘ f) x) (y ((g ∘ f) ∘ h)))
+
+      ≡⟨ transport-cong {f = SK⃗ k X h} {P = Y} {e = α k X f g x} ⟩ₛ
+
+    transport Y (cong (SK⃗ k X h) (α k X f g x))
+      (transport Y (α k X h (g ∘ f) x) (y ((g ∘ f) ∘ h)))
+
+      ≡⟨ transport-merge {P = Y} {e₂ = cong (SK⃗ k X h) (α k X f g x)} {p = y ((g ∘ f) ∘ h)} ⟩ₛ
+
+    transport Y (trans (α k X h (g ∘ f) x) (cong (SK⃗ k X h) (α k X f g x))) (y ((g ∘ f) ∘ h))
+
+      ≡⟨ cong-transport {P = Y}
+           {e₁ = trans (α k X h (g ∘ f) x) (cong (SK⃗ k X h) (α k X f g x))}
+           {e₂ = trans (α k X (f ∘ h) g x) (α k X h f (SK⃗ k X g x))}
+           {p = y (g ∘ (f ∘ h))} UIPₛ ⟩ₛ
+
+    transport Y (trans (α k X (f ∘ h) g x) (α k X h f (SK⃗ k X g x))) (y (g ∘ (f ∘ h)))
+
+      ≡⟨ sym (transport-merge {e₂ = α k X h f (SK⃗ k X g x)} {p = y (g ∘ (f ∘ h))}) ⟩ₛ
+
+    transport Y (α k X h f (SK⃗ k X g x)) (transport Y (α k X (f ∘ h) g x) (y (g ∘ (f ∘ h))))
+      ∎ₛ
+
+  )


### PR DESCRIPTION
This is an experiment to implement 2-level type theory, based on the paper "Extending Homotopy Type Theory with Strict Equality" by Thorsten Altenkirch, Paolo Capriotti, Nicolai Kraus (2016) (https://arxiv.org/abs/1604.03799). My goal was partially to appease Thorsten, and partially for my own curiosity. So far I have implemented a new sort SSet of strict sets, and used it to implement the central construction in the paper (needed to construct semi-simplicial sets).

The goal of opening this PR is mainly to gauge if there is a more general interest in adding this feature to Agda, given the fact that to me its purpose feels rather niche. If there is such interested, I could be persuaded to extend the support for SSet a bit further.