### PR TITLE
[ refactor ] Refactor Level representation and constraint solver

### DIFF
--- a/src/full/Agda/Auto/Convert.hs
+++ b/src/full/Agda/Auto/Convert.hs
@@ -383,7 +383,7 @@ instance Conversion TOM I.Term (MExp O) where
         x' <- convert x
         y' <- convert y
         return $ NotM $ Pi Nothing (getHiding info) (Free.freeIn 0 y) x' (Abs (Id name) y')
-      I.Sort (I.Type (I.Max l [])) -> return $ NotM $ Sort $ Set $ fromIntegral l
+      I.Sort (I.Type (I.ClosedLevel l)) -> return $ NotM $ Sort $ Set $ fromIntegral l
       I.Sort _ -> return $ NotM $ Sort UnknownSort
       I.Dummy{}-> return $ NotM $ Sort UnknownSort
       t@I.MetaV{} -> do

--- a/src/full/Agda/Auto/Convert.hs
+++ b/src/full/Agda/Auto/Convert.hs
@@ -383,7 +383,7 @@ instance Conversion TOM I.Term (MExp O) where
         x' <- convert x
         y' <- convert y
         return $ NotM $ Pi Nothing (getHiding info) (Free.freeIn 0 y) x' (Abs (Id name) y')
-      I.Sort (I.Type (I.Max [I.ClosedLevel l])) -> return $ NotM $ Sort $ Set $ fromIntegral l
+      I.Sort (I.Type (I.Max l [])) -> return $ NotM $ Sort $ Set $ fromIntegral l
       I.Sort _ -> return $ NotM $ Sort UnknownSort
       I.Dummy{}-> return $ NotM $ Sort UnknownSort
       t@I.MetaV{} -> do
@@ -422,7 +422,7 @@ fmExp :: I.MetaId -> I.Term -> Bool
 fmExp m (I.Var _ as) = fmExps m $ I.argsFromElims as
 fmExp m (I.Lam _ b) = fmExp m (I.unAbs b)
 fmExp m (I.Lit _) = False
-fmExp m (I.Level (I.Max as)) = any (fmLevel m) as
+fmExp m (I.Level (I.Max _ as)) = any (fmLevel m) as
 fmExp m (I.Def _ as) = fmExps m $ I.argsFromElims as
 fmExp m (I.Con _ ci as) = fmExps m $ I.argsFromElims as
 fmExp m (I.Pi x y)  = fmType m (I.unDom x) || fmType m (I.unAbs y)
@@ -436,7 +436,6 @@ fmExps m [] = False
 fmExps m (a : as) = fmExp m (Cm.unArg a) || fmExps m as
 
 fmLevel :: I.MetaId -> I.PlusLevel -> Bool
-fmLevel m I.ClosedLevel{} = False
 fmLevel m (I.Plus _ l) = case l of
   I.MetaLevel m' _   -> m == m'
   I.NeutralLevel _ v -> fmExp m v

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -308,8 +308,7 @@ data Sort' t
 type Sort = Sort' Term
 
 -- | A level is a maximum expression of a closed level and 0..n
---   'PlusLevel' expressions each of which is a number or an atom plus
---   a number.
+--   'PlusLevel' expressions each of which is an atom plus a number.
 data Level' t = Max Integer [PlusLevel' t]
   deriving (Show, Data)
 

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -307,18 +307,15 @@ data Sort' t
 
 type Sort = Sort' Term
 
--- | A level is a maximum expression of 0..n 'PlusLevel' expressions
---   each of which is a number or an atom plus a number.
---
---   The empty maximum is the canonical representation for level 0.
-newtype Level' t = Max [PlusLevel' t]
+-- | A level is a maximum expression of a closed level and 0..n
+--   'PlusLevel' expressions each of which is a number or an atom plus
+--   a number.
+data Level' t = Max Integer [PlusLevel' t]
   deriving (Show, Data)
 
 type Level = Level' Term
 
-data PlusLevel' t
-  = ClosedLevel Integer     -- ^ @n@, to represent @Setₙ@.
-  | Plus Integer (LevelAtom' t)  -- ^ @n + ℓ@.
+data PlusLevel' t = Plus Integer (LevelAtom' t)  -- ^ @n + ℓ@.
   deriving (Show, Data)
 
 type PlusLevel = PlusLevel' Term
@@ -884,8 +881,15 @@ dummyDom file line = defaultDom $ dummyType file line
 __DUMMY_DOM__ :: HasCallStack => Dom Type
 __DUMMY_DOM__ = withFileAndLine' (freezeCallStack callStack) dummyDom
 
+-- | Constant level @n@
+closedLevel :: Integer -> Level
+closedLevel n = Max n []
+
+atomicLevel :: LevelAtom -> Level
+atomicLevel a = Max 0 [ Plus 0 a ]
+
 unreducedLevel :: Term -> Level
-unreducedLevel v = Max [ Plus 0 $ UnreducedLevel v ]
+unreducedLevel v = atomicLevel $ UnreducedLevel v
 
 -- | Top sort (Set\omega).
 topSort :: Type
@@ -895,22 +899,24 @@ sort :: Sort -> Type
 sort s = El (UnivSort s) $ Sort s
 
 varSort :: Int -> Sort
-varSort n = Type $ Max [Plus 0 $ NeutralLevel mempty $ var n]
+varSort n = Type $ atomicLevel $ NeutralLevel mempty $ var n
 
 tmSort :: Term -> Sort
-tmSort t = Type $ Max [Plus 0 $ UnreducedLevel t]
+tmSort t = Type $ unreducedLevel t
+
+-- | Given a constant @m@ and level @l@, compute @m + l@
+levelPlus :: Integer -> Level -> Level
+levelPlus m (Max n as) = Max (m + n) $ map pplus as
+  where pplus (Plus n l) = Plus (m + n) l
 
 levelSuc :: Level -> Level
-levelSuc (Max []) = Max [ClosedLevel 1]
-levelSuc (Max as) = Max $ map inc as
-  where inc (ClosedLevel n) = ClosedLevel (n + 1)
-        inc (Plus n l)      = Plus (n + 1) l
+levelSuc = levelPlus 1
 
 mkType :: Integer -> Sort
-mkType n = Type $ Max [ClosedLevel n | n > 0]
+mkType n = Type $ closedLevel n
 
 mkProp :: Integer -> Sort
-mkProp n = Prop $ Max [ClosedLevel n | n > 0]
+mkProp n = Prop $ closedLevel n
 
 isSort :: Term -> Maybe Sort
 isSort v = case v of
@@ -1229,10 +1235,9 @@ instance TermSize Sort where
     DummyS{}   -> 1
 
 instance TermSize Level where
-  tsize (Max as) = 1 + tsize as
+  tsize (Max _ as) = 1 + tsize as
 
 instance TermSize PlusLevel where
-  tsize (ClosedLevel _) = 1
   tsize (Plus _ a)      = tsize a
 
 instance TermSize LevelAtom where
@@ -1271,10 +1276,9 @@ instance KillRange Term where
     Dummy{}     -> v
 
 instance KillRange Level where
-  killRange (Max as) = killRange1 Max as
+  killRange (Max n as) = killRange1 (Max n) as
 
 instance KillRange PlusLevel where
-  killRange l@ClosedLevel{} = l
   killRange (Plus n l) = killRange1 (Plus n) l
 
 instance KillRange LevelAtom where
@@ -1418,21 +1422,22 @@ instance Pretty a => Pretty (Tele (Dom a)) where
       telToList EmptyTel = []
       telToList (ExtendTel a tel) = (absName tel, a) : telToList (unAbs tel)
 
+prettyPrecLevelSucs :: Int -> Integer -> (Int -> Doc) -> Doc
+prettyPrecLevelSucs p 0 d = d p
+prettyPrecLevelSucs p n d = mparens (p > 9) $ "lsuc" <+> prettyPrecLevelSucs 10 (n - 1) d
+
 instance Pretty Level where
-  prettyPrec p (Max as) =
+  prettyPrec p (Max n as) =
     case as of
-      []  -> prettyPrec p (ClosedLevel 0 :: PlusLevel)
-      [a] -> prettyPrec p a
-      _   -> mparens (p > 9) $ List.foldr1 (\a b -> "lub" <+> a <+> b) $ map (prettyPrec 10) as
+      []  -> prettyN
+      [a] | n == 0 -> prettyPrec p a
+      _   -> mparens (p > 9) $ List.foldr1 (\a b -> "lub" <+> a <+> b) $
+        [ prettyN | n > 0 ] ++ map (prettyPrec 10) as
+    where
+      prettyN = prettyPrecLevelSucs p n (const "lzero")
 
 instance Pretty PlusLevel where
-  prettyPrec p l =
-    case l of
-      ClosedLevel n -> sucs p n $ const "lzero"
-      Plus n a      -> sucs p n $ \p -> prettyPrec p a
-    where
-      sucs p 0 d = d p
-      sucs p n d = mparens (p > 9) $ "lsuc" <+> sucs 10 (n - 1) d
+  prettyPrec p (Plus n a) = prettyPrecLevelSucs p n $ \p -> prettyPrec p a
 
 instance Pretty LevelAtom where
   prettyPrec p a =
@@ -1445,11 +1450,11 @@ instance Pretty LevelAtom where
 instance Pretty Sort where
   prettyPrec p s =
     case s of
-      Type (Max []) -> "Set"
-      Type (Max [ClosedLevel n]) -> text $ "Set" ++ show n
+      Type (Max 0 []) -> "Set"
+      Type (Max n []) -> text $ "Set" ++ show n
       Type l -> mparens (p > 9) $ "Set" <+> prettyPrec 10 l
-      Prop (Max []) -> "Prop"
-      Prop (Max [ClosedLevel n]) -> text $ "Prop" ++ show n
+      Prop (Max 0 []) -> "Prop"
+      Prop (Max n []) -> text $ "Prop" ++ show n
       Prop l -> mparens (p > 9) $ "Prop" <+> prettyPrec 10 l
       Inf -> "Setω"
       SizeUniv -> "SizeUniv"
@@ -1527,10 +1532,9 @@ instance NFData Sort where
     DummyS _   -> ()
 
 instance NFData Level where
-  rnf (Max as) = rnf as
+  rnf (Max n as) = rnf (n, as)
 
 instance NFData PlusLevel where
-  rnf (ClosedLevel n) = rnf n
   rnf (Plus n l) = rnf (n, l)
 
 instance NFData LevelAtom where

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE UndecidableInstances       #-}  -- because of shortcomings of FunctionalDependencies
 
@@ -881,8 +882,8 @@ __DUMMY_DOM__ :: HasCallStack => Dom Type
 __DUMMY_DOM__ = withFileAndLine' (freezeCallStack callStack) dummyDom
 
 -- | Constant level @n@
-closedLevel :: Integer -> Level
-closedLevel n = Max n []
+pattern ClosedLevel :: Integer -> Level
+pattern ClosedLevel n = Max n []
 
 atomicLevel :: LevelAtom -> Level
 atomicLevel a = Max 0 [ Plus 0 a ]
@@ -912,10 +913,10 @@ levelSuc :: Level -> Level
 levelSuc = levelPlus 1
 
 mkType :: Integer -> Sort
-mkType n = Type $ closedLevel n
+mkType n = Type $ ClosedLevel n
 
 mkProp :: Integer -> Sort
-mkProp n = Prop $ closedLevel n
+mkProp n = Prop $ ClosedLevel n
 
 isSort :: Term -> Maybe Sort
 isSort v = case v of
@@ -1449,11 +1450,11 @@ instance Pretty LevelAtom where
 instance Pretty Sort where
   prettyPrec p s =
     case s of
-      Type (Max 0 []) -> "Set"
-      Type (Max n []) -> text $ "Set" ++ show n
+      Type (ClosedLevel 0) -> "Set"
+      Type (ClosedLevel n) -> text $ "Set" ++ show n
       Type l -> mparens (p > 9) $ "Set" <+> prettyPrec 10 l
-      Prop (Max 0 []) -> "Prop"
-      Prop (Max n []) -> text $ "Prop" ++ show n
+      Prop (ClosedLevel 0) -> "Prop"
+      Prop (ClosedLevel n) -> text $ "Prop" ++ show n
       Prop l -> mparens (p > 9) $ "Prop" <+> prettyPrec 10 l
       Inf -> "Setω"
       SizeUniv -> "SizeUniv"

--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -88,10 +88,9 @@ instance GetDefs Sort where
     DummyS{}    -> return ()
 
 instance GetDefs Level where
-  getDefs (Max ls) = getDefs ls
+  getDefs (Max _ ls) = getDefs ls
 
 instance GetDefs PlusLevel where
-  getDefs ClosedLevel{} = return ()
   getDefs (Plus _ l)    = getDefs l
 
 instance GetDefs LevelAtom where

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -113,15 +113,12 @@ instance TermLike Term where
     Dummy{}     -> mempty
 
 instance TermLike Level where
-  traverseTermM f (Max as) = Max <$> traverseTermM f as
-  foldTerm f      (Max as) = foldTerm f as
+  traverseTermM f (Max n as) = Max n <$> traverseTermM f as
+  foldTerm f      (Max n as) = foldTerm f as
 
 instance TermLike PlusLevel where
-  traverseTermM f l = case l of
-    ClosedLevel{} -> return l
-    Plus n l      -> Plus n <$> traverseTermM f l
-  foldTerm f ClosedLevel{} = mempty
-  foldTerm f (Plus _ l)    = foldTerm f l
+  traverseTermM f (Plus n l) = Plus n <$> traverseTermM f l
+  foldTerm f (Plus _ l)      = foldTerm f l
 
 instance TermLike LevelAtom where
   traverseTermM f l = case l of

--- a/src/full/Agda/Syntax/Internal/MetaVars.hs
+++ b/src/full/Agda/Syntax/Internal/MetaVars.hs
@@ -18,9 +18,8 @@ allMetas singl = foldTerm metas
   metas (Level l)   = levelMetas l
   metas _           = mempty
 
-  levelMetas (Max as) = foldMap plusLevelMetas as
+  levelMetas (Max _ as) = foldMap plusLevelMetas as
 
-  plusLevelMetas ClosedLevel{} = mempty
   plusLevelMetas (Plus _ l)    = levelAtomMetas l
 
   levelAtomMetas (MetaLevel m _) = singl m

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -130,11 +130,10 @@ instance NamesIn Term where
     Dummy{}      -> Set.empty
 
 instance NamesIn Level where
-  namesIn (Max ls) = namesIn ls
+  namesIn (Max _ ls) = namesIn ls
 
 instance NamesIn PlusLevel where
-  namesIn ClosedLevel{} = Set.empty
-  namesIn (Plus _ l)    = namesIn l
+  namesIn (Plus _ l) = namesIn l
 
 instance NamesIn LevelAtom where
   namesIn l = case l of

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1242,11 +1242,11 @@ instance Reify Sort Expr where
     reify s = do
       s <- instantiateFull s
       case s of
-        I.Type (I.Max n [])              -> return $ A.Set noExprInfo n
+        I.Type (I.ClosedLevel n) -> return $ A.Set noExprInfo n
         I.Type a -> do
           a <- reify a
           return $ A.App defaultAppInfo_ (A.Set noExprInfo 0) (defaultNamedArg a)
-        I.Prop (I.Max n [])              -> return $ A.Prop noExprInfo n
+        I.Prop (I.ClosedLevel n) -> return $ A.Prop noExprInfo n
         I.Prop a -> do
           a <- reify a
           return $ A.App defaultAppInfo_ (A.Prop noExprInfo 0) (defaultNamedArg a)

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1242,13 +1242,11 @@ instance Reify Sort Expr where
     reify s = do
       s <- instantiateFull s
       case s of
-        I.Type (I.Max [])                -> return $ A.Set noExprInfo 0
-        I.Type (I.Max [I.ClosedLevel n]) -> return $ A.Set noExprInfo n
+        I.Type (I.Max n [])              -> return $ A.Set noExprInfo n
         I.Type a -> do
           a <- reify a
           return $ A.App defaultAppInfo_ (A.Set noExprInfo 0) (defaultNamedArg a)
-        I.Prop (I.Max [])                -> return $ A.Prop noExprInfo 0
-        I.Prop (I.Max [I.ClosedLevel n]) -> return $ A.Prop noExprInfo n
+        I.Prop (I.Max n [])              -> return $ A.Prop noExprInfo n
         I.Prop a -> do
           a <- reify a
           return $ A.App defaultAppInfo_ (A.Prop noExprInfo 0) (defaultNamedArg a)

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -920,11 +920,11 @@ instance ExtractCalls Term where
 
 -- | Extract recursive calls from level expressions.
 
-deriving instance ExtractCalls Level
+instance ExtractCalls Level where
+  extract (Max n as) = extract as
 
 instance ExtractCalls PlusLevel where
-  extract (ClosedLevel n) = return $ mempty
-  extract (Plus n l)      = extract l
+  extract (Plus n l) = extract l
 
 instance ExtractCalls LevelAtom where
   extract (MetaLevel x es)   = extract es

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -182,10 +182,9 @@ instance AbsTerm Sort where
     where absS x = absTerm u x
 
 instance AbsTerm Level where
-  absTerm u (Max as) = Max $ absTerm u as
+  absTerm u (Max n as) = Max n $ absTerm u as
 
 instance AbsTerm PlusLevel where
-  absTerm u l@ClosedLevel{} = l
   absTerm u (Plus n l) = Plus n $ absTerm u l
 
 instance AbsTerm LevelAtom where
@@ -252,13 +251,10 @@ instance EqualSy Term where
     _ -> False
 
 instance EqualSy Level where
-  equalSy (Max vs) (Max vs') = equalSy vs vs'
+  equalSy (Max n vs) (Max n' vs') = n == n' && equalSy vs vs'
 
 instance EqualSy PlusLevel where
-  equalSy = curry $ \case
-    (ClosedLevel n, ClosedLevel n') -> n == n'
-    (Plus n v     , Plus n' v'    ) -> n == n' && equalSy v v'
-    _ -> False
+  equalSy (Plus n v) (Plus n' v') = n == n' && equalSy v v'
 
 instance EqualSy LevelAtom where
   equalSy = equalSy `on` unLevelAtom

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -433,9 +433,8 @@ checkSort action s =
 
 -- | Check if level is well-formed.
 checkLevel :: (MonadCheckInternal m) => Action m -> Level -> m Level
-checkLevel action (Max ls) = Max <$> mapM checkPlusLevel ls
+checkLevel action (Max n ls) = Max n <$> mapM checkPlusLevel ls
   where
-    checkPlusLevel l@ClosedLevel{} = return l
     checkPlusLevel (Plus k l)      = Plus k <$> checkLevelAtom l
 
     checkLevelAtom l = do

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -5,6 +5,7 @@ module Agda.TypeChecking.Conversion where
 import Control.Monad
 import Control.Monad.Fail (MonadFail)
 
+import Data.Function
 import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -47,6 +48,7 @@ import Agda.Utils.Except ( MonadError(catchError, throwError) )
 import Agda.Utils.Functor
 import Agda.Utils.Monad
 import Agda.Utils.Maybe
+import Agda.Utils.NonemptyList
 import Agda.Utils.Permutation
 import Agda.Utils.Size
 import Agda.Utils.Tuple
@@ -1181,8 +1183,8 @@ leqSort s1 s2 = (catchConstraint (SortCmp CmpLeq s1 s2) :: m () -> m ()) $ do
       -- @SizeUniv@ and @Prop0@ are bottom sorts.
       -- So is @Set0@ if @Prop@ is not enabled.
       (_       , SizeUniv) -> equalSort s1 s2
-      (_       , Prop (Max [])) -> equalSort s1 s2
-      (_       , Type (Max []))
+      (_       , Prop (Max 0 [])) -> equalSort s1 s2
+      (_       , Type (Max 0 []))
         | not propEnabled  -> equalSort s1 s2
 
       -- SizeUniv is unrelated to any @Set l@ or @Prop l@
@@ -1233,84 +1235,82 @@ leqLevel a b = do
     -- Andreas, 2016-09-28
     -- If we have to postpone a constraint, then its simplified form!
     leqView :: MonadConversion m => Level -> Level -> m ()
-    leqView a@(Max as) b@(Max bs) = catchConstraint (LevelCmp CmpLeq a b) $ do
-      reportSDoc "tc.conv.nat" 30 $
+    leqView a b = catchConstraint (LevelCmp CmpLeq a b) $ do
+      reportSDoc "tc.conv.level" 30 $
         "compareLevelView" <+>
           sep [ pretty a <+> "=<"
               , pretty b ]
       cumulativity <- optCumulativity <$> pragmaOptions
-      wrap $ case (as, bs) of
+      reportSDoc "tc.conv.level" 40 $
+        "compareLevelView" <+>
+          sep [ prettyList_ (map (pretty . unSingleLevel) $ toList $ levelMaxView a)
+              , "=<"
+              , prettyList_ (map (pretty . unSingleLevel) $ toList $ levelMaxView b)
+              ]
+      wrap $ case (levelMaxView a, levelMaxView b) of
 
         -- same term
-        _ | as == bs -> ok
+        _ | a == b -> ok
 
         -- 0 ≤ any
-        ([], _) -> ok
+        (SingleClosed 0 :! [] , _) -> ok
 
-        -- as ≤ 0
-        (as, [])              -> sequence_ [ equalLevel' (Max [a]) (Max []) | a <- as ]
-        (as, [ClosedLevel 0]) -> sequence_ [ equalLevel' (Max [a]) (Max []) | a <- as ]
-           -- Andreas, 2016-09-28, @[ClosedLevel 0]@ is possible if we come from case
-           -- "reduce constants" where we run @subtr@ on both sides.
-           -- See test/Succeed/LevelMetaLeqZero.agda.
+        -- any ≤ 0
+        (as , SingleClosed 0 :! []) ->
+          sequence_ [ equalLevel (unSingleLevel a') (closedLevel 0) | a' <- toList as ]
 
-        -- as ≤ [b]
-        (as@(_:_:_), [b]) -> sequence_ [ leqView (Max [a]) (Max [b]) | a <- as ]
+        -- closed ≤ closed
+        (SingleClosed m :! [], SingleClosed n :! []) -> if m <= n then ok else notok
+
+        -- closed ≤ b
+        (SingleClosed m :! [] , _)
+          | m <= levelLowerBound b -> ok
+
+        -- as ≤ neutral/closed
+        (as, bs)
+          | all neutralOrClosed bs , levelLowerBound a > levelLowerBound b -> notok
+
+        -- ⊔ as ≤ single
+        (as@(_:!_:_), b :! []) ->
+          sequence_ [ leqView (unSingleLevel a') (unSingleLevel b) | a' <- toList as ]
 
         -- reduce constants
-        (as, bs) | minN > 0 -> leqView (Max $ map (subtr minN) as) (Max $ map (subtr minN) bs)
-          where
-            ns = map constant as
-            ms = map constant bs
-            minN = minimum (ns ++ ms)
+        (as, bs)
+          | let minN = min (fst $ levelPlusView a) (fst $ levelPlusView b)
+                a'   = fromMaybe __IMPOSSIBLE__ $ subLevel minN a
+                b'   = fromMaybe __IMPOSSIBLE__ $ subLevel minN b
+          , minN > 0 -> leqView a' b'
 
         -- remove subsumed
         -- Andreas, 2014-04-07: This is ok if we do not go back to equalLevel
         (as, bs)
-          | not $ null subsumed -> leqView (Max $ as List.\\ subsumed) (Max bs)
+          | (subsumed@(_:_) , as') <- List.partition isSubsumed (toList as)
+          -> leqView (unSingleLevels as') b
           where
-            subsumed = [ a | a@(Plus m l) <- as, n <- findN l, m <= n ]
-            -- @findN a@ finds the unique(?) term @Plus n a@ in @bs@, if any.
-            -- Andreas, 2014-04-07 Why must there be a unique term?
-            findN a = case [ n | Plus n b <- bs, b == a ] of
-                        [n] -> [n]
-                        _   -> []
+            isSubsumed a = any (`subsumes` a) (toList bs)
 
-        -- Andreas, 2012-10-02 raise error on unsolvable constraint
-        ([ClosedLevel n], [ClosedLevel m]) -> if n <= m then ok else notok
-
-        -- closed ≤ bs
-        ([ClosedLevel n], bs)
-          | n <= maximum (map constant bs) -> ok
-
-        -- as ≤ neutral
-        (as, bs)
-          | neutralB && maxA > maxB -> notok
-          | neutralB && neutralA && all findN as -> ok
-          where
-            maxA = maximum $ map constant as
-            maxB = maximum $ map constant bs
-            neutralA = all neutral as
-            neutralB = all neutral bs
-            findN a = case [ n | b@(Plus n _) <- bs, unneutral b == unneutral a ] of
-                        [n] -> constant a <= n
-                        _   -> False
+            subsumes :: SingleLevel -> SingleLevel -> Bool
+            subsumes (SingleClosed m)        (SingleClosed n)        = m >= n
+            subsumes (SinglePlus (Plus m _)) (SingleClosed n)        = m >= n
+            subsumes (SinglePlus (Plus m a)) (SinglePlus (Plus n b)) = a == b && m >= n
+            subsumes _ _ = False
 
         -- as ≤ _l x₁ .. xₙ
         -- We can solve _l := λ x₁ .. xₙ -> as ⊔ (_l' x₁ .. xₙ)
         -- (where _l' is a new metavariable)
-        (as , [Plus 0 (MetaLevel x es)]) | cumulativity -> do
-          m <- lookupMeta x
-          x' <- case mvJudgement m of
+        (as , SinglePlus (Plus 0 (MetaLevel x es)) :! []) | cumulativity -> do
+          mv <- lookupMeta x
+          x' <- case mvJudgement mv of
             IsSort{} -> __IMPOSSIBLE__
             HasType _ cmp t -> do
               TelV tel t' <- telView t
-              newMeta Instantiable (mvInfo m) normalMetaPriority (idP $ size tel) $ HasType () cmp t
+              newMeta Instantiable (mvInfo mv) normalMetaPriority (idP $ size tel) $ HasType () cmp t
           reportSDoc "tc.conv.level" 20 $ fsep
             [ "attempting to solve" , prettyTCM (MetaV x es) , "to the maximum of"
             , prettyTCM (Level a) , "and the fresh meta" , prettyTCM (MetaV x' es)
             ]
-          equalLevel b $ levelMax $ Plus 0 (MetaLevel x' es) : as
+          equalLevel b $ levelLub a (atomicLevel $ MetaLevel x' es)
+
 
         -- Andreas, 2016-09-28: This simplification loses the solution lzero.
         -- Thus, it is invalid.
@@ -1334,29 +1334,9 @@ leqLevel a b = do
             TypeError{} -> notok
             _           -> throwError e
 
-        maybeok True = ok
-        maybeok False = postpone
-
-        neutral (Plus _ NeutralLevel{}) = True
-        neutral _                       = False
-
-        meta (Plus _ MetaLevel{}) = True
-        meta _                    = False
-
-        unneutral (Plus _ (NeutralLevel _ v)) = v
-        unneutral _ = __IMPOSSIBLE__
-
-        constant (ClosedLevel n) = n
-        constant (Plus n _)      = n
-
-        subtr m (ClosedLevel n) = ClosedLevel (n - m)
-        subtr m (Plus n l)      = Plus (n - m) l
-
---     choice []     = patternViolation
---     choice (m:ms) = noConstraints m `catchError` \_ -> choice ms
---       case e of
---         PatternErr{} -> choice ms
---         _            -> throwError e
+        neutralOrClosed (SingleClosed _)                     = True
+        neutralOrClosed (SinglePlus (Plus _ NeutralLevel{})) = True
+        neutralOrClosed _                                    = False
 
 equalLevel :: MonadConversion m => Level -> Level -> m ()
 equalLevel a b = do
@@ -1372,11 +1352,7 @@ equalLevel' a b = do
     check a b
   where
     check :: Level -> Level -> m ()
-    check a@(Max as) b@(Max bs) = do
-      -- Jesper, 2014-02-02 remove terms that certainly do not contribute
-      -- to the maximum
-      as <- return $ [ a | a <- as, not $ a `isStrictlySubsumedBy` bs ]
-      bs <- return $ [ b | b <- bs, not $ b `isStrictlySubsumedBy` as ]
+    check a b = do
       -- Andreas, 2013-10-31 remove common terms (that don't contain metas!)
       -- THAT's actually UNSOUND when metas are instantiated, because
       --     max a b == max a c  does not imply  b == c
@@ -1385,82 +1361,87 @@ equalLevel' a b = do
       -- let cs = Set.filter (not . hasMeta) $ Set.intersection as bs
       -- as <- return $ Set.toList $ as Set.\\ cs
       -- bs <- return $ Set.toList $ bs Set.\\ cs
-      as <- return $ List.sort $ closed0 as
-      bs <- return $ List.sort $ closed0 bs
       reportSDoc "tc.conv.level" 40 $
         sep [ "equalLevel"
             , vcat [ nest 2 $ sep [ prettyTCM a <+> "=="
                                   , prettyTCM b
                                   ]
-                   , "reduced"
-                   , nest 2 $ sep [ prettyTCM (Max as) <+> "=="
-                                  , prettyTCM (Max bs)
-                                  ]
                    ]
             ]
       reportSDoc "tc.conv.level" 50 $
         sep [ text "equalLevel"
-            , vcat [ nest 2 $ sep [ pretty (Max as) <+> "=="
-                                  , pretty (Max bs)
+            , vcat [ nest 2 $ sep [ prettyList_ (map (pretty . unSingleLevel) $ toList $ levelMaxView a)
+                                  , "=="
+                                  , prettyList_ (map (pretty . unSingleLevel) $ toList $ levelMaxView b)
                                   ]
                    ]
             ]
-      case (as, bs) of
-        _ | as == bs -> ok
-          | any isBlocked (as ++ bs) -> do
-              lvl <- levelType
-              addConstraint $ ValueCmp CmpEq (AsTermsOf lvl) (Level a) (Level b)
+      case (levelMaxView a, levelMaxView b) of
+
+        -- equal levels
+        _ | a == b -> ok
 
         -- closed == closed
-        ([ClosedLevel n], [ClosedLevel m])
-          | n == m    -> ok
+        (SingleClosed m :! [], SingleClosed n :! [])
+          | m == n    -> ok
           | otherwise -> notok
 
         -- closed == neutral
-        ([ClosedLevel{}], _) | any isNeutral bs -> notok
-        (_, [ClosedLevel{}]) | any isNeutral as -> notok
+        (SingleClosed m :! [] , bs) | any isNeutral bs -> notok
+        (as , SingleClosed n :! []) | any isNeutral as -> notok
 
-        -- 0 == any
-        ([ClosedLevel 0], bs@(_:_:_)) -> sequence_ [ equalLevel' (Max []) (Max [b]) | b <- bs ]
-        (as@(_:_:_), [ClosedLevel 0]) -> sequence_ [ equalLevel' (Max [a]) (Max []) | a <- as ]
-        -- Andreas, 2014-04-07 Why should the following be ok?
-        --   X (suc a)  could be different from  X (suc (suc a))
-        -- -- Same meta
-        -- ([Plus n (MetaLevel x _)], [Plus m (MetaLevel y _)])
-        --   | n == m && x == y -> ok
+        -- closed == b
+        (SingleClosed m :! [] , _) | m < levelLowerBound b -> notok
+        (_ , SingleClosed n :! []) | n < levelLowerBound a -> notok
+
+        -- 0 == a ⊔ b
+        (SingleClosed 0 :! [] , bs@(_:!_:_)) ->
+          sequence_ [ equalLevel' (closedLevel 0) (unSingleLevel b') | b' <- toList bs ]
+        (as@(_:!_:_) , SingleClosed 0 :! []) ->
+          sequence_ [ equalLevel' (unSingleLevel a') (closedLevel 0) | a' <- toList as ]
+
+        -- Jesper, 2014-02-02 remove terms that certainly do not contribute
+        -- to the maximum
+        (as , bs)
+          | (subsumed@(_:_),as') <- List.partition (`isStrictlySubsumedBy` bs) (toList as)
+          -> equalLevel' (unSingleLevels as') b
+        (as , bs)
+          | (subsumed@(_:_),bs') <- List.partition (`isStrictlySubsumedBy` as) (toList bs)
+          -> equalLevel' a (unSingleLevels bs')
 
         -- meta == any
-        ([Plus n (MetaLevel x as)], _)
+        (SinglePlus (Plus k (MetaLevel x as)) :! [] , bs)
           | any (isThisMeta x) bs -> postpone
-        (_, [Plus n (MetaLevel x bs)])
+        (as , SinglePlus (Plus k (MetaLevel x bs)) :! [])
           | any (isThisMeta x) as -> postpone
-        ([Plus n (MetaLevel x as')], [Plus m (MetaLevel y bs')])
-            -- lexicographic comparison intended!
-          | (n, y) < (m, x)            -> meta n x as' bs
-          | otherwise                  -> meta m y bs' as
-        ([Plus n (MetaLevel x as')],_) -> meta n x as' bs
-        (_,[Plus m (MetaLevel y bs')]) -> meta m y bs' as
-
-        -- any other metas
-        -- Andreas, 2013-10-31: There could be metas in neutral levels (see Issue 930).
-        -- Should not we postpone there as well?  Yes!
-        _ | any hasMeta (as ++ bs) -> postpone
+        (SinglePlus (Plus k (MetaLevel x as')) :! [] , SinglePlus (Plus l (MetaLevel y bs')) :! [])
+          -- there is only a potential choice when k == l
+          | k == l -> if
+              | y < x     -> meta x as' $ atomicLevel $ MetaLevel y bs'
+              | otherwise -> meta y bs' $ atomicLevel $ MetaLevel x as'
+        (SinglePlus (Plus k (MetaLevel x as')) :! [] , _)
+          | Just b' <- subLevel k b -> meta x as' b'
+        (_ , SinglePlus (Plus l (MetaLevel y bs')) :! [])
+          | Just a' <- subLevel l a -> meta y bs' a'
 
         -- neutral/closed == neutral/closed
-        _ | all isNeutralOrClosed (as ++ bs) -> do
-          reportSLn "tc.conv.level" 60 $ "equalLevel: all are neutral or closed"
-          if length as == length bs
-            then zipWithM_ (\a b -> [a] =!= [b]) as bs
-            else postpone
+        (as , bs)
+          | all isNeutralOrClosed (toList as ++ toList bs)
+          -- Andreas, 2013-10-31: There could be metas in neutral levels (see Issue 930).
+          -- Should not we postpone there as well?  Yes!
+          , not (any hasMeta (toList as ++ toList bs))
+          , length as == length bs -> do
+              reportSLn "tc.conv.level" 60 $ "equalLevel: all are neutral or closed"
+              zipWithM_ ((===) `on` levelTm . unSingleLevel) (toList as) (toList bs)
 
         -- more cases?
-        _ -> postpone
+        _ | noMetas (Level a , Level b) -> notok
+          | otherwise                   -> postpone
 
       where
-        a === b   = unlessM typeInType $ do
-            lvl <- levelType
-            equalAtom (AsTermsOf lvl) a b
-        as =!= bs = levelTm (Max as) === levelTm (Max bs)
+        a === b = unlessM typeInType $ do
+          lvl <- levelType
+          equalAtom (AsTermsOf lvl) a b
 
         ok       = return ()
         notok    = unlessM typeInType notOk
@@ -1469,15 +1450,11 @@ equalLevel' a b = do
           reportSDoc "tc.conv.level" 30 $ hang "postponing:" 2 $ hang (pretty a <+> "==") 0 (pretty b)
           patternViolation
 
-        closed0 [] = [ClosedLevel 0]
-        closed0 as = as
-
-        -- perform assignment (Plus n (MetaLevel x as)) := bs
-        meta n x as bs = do
+        -- perform assignment (MetaLevel x as) := b
+        meta x as b = do
           reportSLn "tc.meta.level" 30 $ "Assigning meta level"
-          reportSDoc "tc.meta.level" 50 $ "meta" <+> sep [prettyList $ map pretty as, prettyList $ map pretty bs]
-          bs' <- mapM (subtr n) bs
-          assignE DirEq x as (levelTm (Max bs')) (===) -- fallback: check equality as atoms
+          reportSDoc "tc.meta.level" 50 $ "meta" <+> sep [prettyList $ map pretty as, pretty b]
+          assignE DirEq x as (levelTm b) (===) -- fallback: check equality as atoms
 
         -- Make sure to give a sensible error message
         wrap m = m `catchError` \err ->
@@ -1485,43 +1462,29 @@ equalLevel' a b = do
             TypeError{} -> notok
             _           -> throwError err
 
-        subtr n (ClosedLevel m)
-          | m >= n    = return $ ClosedLevel (m - n)
-          | otherwise = ifM typeInType (return $ ClosedLevel 0) $ notOk
-        subtr n (Plus m a)
-          | m >= n    = return $ Plus (m - n) a
-        subtr _ (Plus _ BlockedLevel{}) = postpone
-        subtr _ (Plus _ MetaLevel{})    = postpone
-        subtr _ (Plus _ NeutralLevel{}) = postpone
-        subtr _ (Plus _ UnreducedLevel{}) = __IMPOSSIBLE__
+        isNeutral (SinglePlus (Plus _ NeutralLevel{})) = True
+        isNeutral _                                    = False
 
-        isNeutral (Plus _ NeutralLevel{}) = True
-        isNeutral _                       = False
+        isNeutralOrClosed (SingleClosed _)                     = True
+        isNeutralOrClosed (SinglePlus (Plus _ NeutralLevel{})) = True
+        isNeutralOrClosed _                                    = False
 
-        isClosed ClosedLevel{} = True
-        isClosed _             = False
+        hasMeta (SinglePlus a) = case a of
+          Plus _ MetaLevel{}        -> True
+          Plus _ (BlockedLevel _ v) -> isJust $ firstMeta v
+          Plus _ (NeutralLevel _ v) -> isJust $ firstMeta v
+          Plus _ (UnreducedLevel v) -> isJust $ firstMeta v
+        hasMeta (SingleClosed _) = False
 
-        isNeutralOrClosed l = isClosed l || isNeutral l
+        isThisMeta x (SinglePlus (Plus _ (MetaLevel y _))) = x == y
+        isThisMeta _ _                                     = False
 
-        isBlocked (Plus _ BlockedLevel{}) = True
-        isBlocked _                       = False
+        x `isStrictlySubsumedBy` ys = any (`strictlySubsumes` x) ys
 
-        hasMeta ClosedLevel{}               = False
-        hasMeta (Plus _ MetaLevel{})        = True
-        hasMeta (Plus _ (BlockedLevel _ v)) = isJust $ firstMeta v
-        hasMeta (Plus _ (NeutralLevel _ v)) = isJust $ firstMeta v
-        hasMeta (Plus _ (UnreducedLevel v)) = isJust $ firstMeta v
-
-        isThisMeta x (Plus _ (MetaLevel y _)) = x == y
-        isThisMeta _ _                      = False
-
-        constant (ClosedLevel n) = n
-        constant (Plus n _)      = n
-
-        (ClosedLevel m) `isStrictlySubsumedBy` [] = m == 0
-        (ClosedLevel m) `isStrictlySubsumedBy` ys = m < maximum (map constant ys)
-        (Plus m x)      `isStrictlySubsumedBy` ys = not $ null $
-          [ n | Plus n y <- ys, x == y, m < n ]
+        SingleClosed m        `strictlySubsumes` SingleClosed n        = m > n
+        SinglePlus (Plus m a) `strictlySubsumes` SingleClosed n        = m > n
+        SinglePlus (Plus m a) `strictlySubsumes` SinglePlus (Plus n b) = a == b && m > n
+        _                     `strictlySubsumes` _                     = False
 
 
 -- | Check that the first sort equal to the second.
@@ -1580,13 +1543,13 @@ equalSort s1 s2 = do
             -- if @PiSort a b == Set0@, then @b == Set0@
             -- we use this fact to solve metas in @b@,
             -- hopefully allowing the @PiSort@ to reduce.
-            (Type (Max []) , PiSort a b   )
+            (Type (Max 0 []) , PiSort a b     )
               | not propEnabled             -> piSortEqualsBottom set0 a b
-            (PiSort a b    , Type (Max []))
+            (PiSort a b      , Type (Max 0 []))
               | not propEnabled             -> piSortEqualsBottom set0 a b
 
-            (Prop (Max []) , PiSort a b   ) -> piSortEqualsBottom prop0 a b
-            (PiSort a b    , Prop (Max [])) -> piSortEqualsBottom prop0 a b
+            (Prop (Max 0 []) , PiSort a b     ) -> piSortEqualsBottom prop0 a b
+            (PiSort a b      , Prop (Max 0 [])) -> piSortEqualsBottom prop0 a b
 
             -- @PiSort a b == SizeUniv@ iff @b == SizeUniv@
             (SizeUniv   , PiSort a b ) ->
@@ -1596,10 +1559,10 @@ equalSort s1 s2 = do
 
             -- @Prop0@ and @SizeUniv@ don't contain any universes,
             -- so they cannot be a UnivSort
-            (Prop (Max []) , UnivSort s )   -> no
-            (UnivSort s    , Prop (Max [])) -> no
-            (SizeUniv      , UnivSort s )   -> no
-            (UnivSort s    , SizeUniv   )   -> no
+            (Prop (Max 0 []) , UnivSort s )     -> no
+            (UnivSort s      , Prop (Max 0 [])) -> no
+            (SizeUniv        , UnivSort s )     -> no
+            (UnivSort s      , SizeUniv   )     -> no
 
             -- PiSort and UnivSort could compute later, so we postpone
             (PiSort{}   , _          ) -> synEq
@@ -1622,8 +1585,8 @@ equalSort s1 s2 = do
         reportSDoc "tc.meta.sort" 50 $ "meta" <+> sep [pretty x, prettyList $ map pretty es, pretty s]
         assignE DirEq x es (Sort s) __IMPOSSIBLE__
 
-      set0 = Type $ Max []
-      prop0 = Prop $ Max []
+      set0 = mkType 0
+      prop0 = mkProp 0
 
       -- equate @piSort a b@ to @s0@, which is assumed to be a (closed) bottom sort
       -- i.e. @piSort a b == s0@ implies @b == s0@.

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1257,7 +1257,7 @@ leqLevel a b = do
 
         -- any ≤ 0
         (as , SingleClosed 0 :! []) ->
-          sequence_ [ equalLevel (unSingleLevel a') (closedLevel 0) | a' <- toList as ]
+          sequence_ [ equalLevel (unSingleLevel a') (ClosedLevel 0) | a' <- toList as ]
 
         -- closed ≤ closed
         (SingleClosed m :! [], SingleClosed n :! []) -> if m <= n then ok else notok
@@ -1396,9 +1396,9 @@ equalLevel' a b = do
 
         -- 0 == a ⊔ b
         (SingleClosed 0 :! [] , bs@(_:!_:_)) ->
-          sequence_ [ equalLevel' (closedLevel 0) (unSingleLevel b') | b' <- toList bs ]
+          sequence_ [ equalLevel' (ClosedLevel 0) (unSingleLevel b') | b' <- toList bs ]
         (as@(_:!_:_) , SingleClosed 0 :! []) ->
-          sequence_ [ equalLevel' (unSingleLevel a') (closedLevel 0) | a' <- toList as ]
+          sequence_ [ equalLevel' (unSingleLevel a') (ClosedLevel 0) | a' <- toList as ]
 
         -- Jesper, 2014-02-02 remove terms that certainly do not contribute
         -- to the maximum
@@ -1543,13 +1543,13 @@ equalSort s1 s2 = do
             -- if @PiSort a b == Set0@, then @b == Set0@
             -- we use this fact to solve metas in @b@,
             -- hopefully allowing the @PiSort@ to reduce.
-            (Type (Max 0 []) , PiSort a b     )
+            (Type (ClosedLevel 0) , PiSort a b     )
               | not propEnabled             -> piSortEqualsBottom set0 a b
-            (PiSort a b      , Type (Max 0 []))
+            (PiSort a b           , Type (ClosedLevel 0))
               | not propEnabled             -> piSortEqualsBottom set0 a b
 
-            (Prop (Max 0 []) , PiSort a b     ) -> piSortEqualsBottom prop0 a b
-            (PiSort a b      , Prop (Max 0 [])) -> piSortEqualsBottom prop0 a b
+            (Prop (ClosedLevel 0) , PiSort a b     ) -> piSortEqualsBottom prop0 a b
+            (PiSort a b           , Prop (ClosedLevel 0)) -> piSortEqualsBottom prop0 a b
 
             -- @PiSort a b == SizeUniv@ iff @b == SizeUniv@
             (SizeUniv   , PiSort a b ) ->
@@ -1559,8 +1559,8 @@ equalSort s1 s2 = do
 
             -- @Prop0@ and @SizeUniv@ don't contain any universes,
             -- so they cannot be a UnivSort
-            (Prop (Max 0 []) , UnivSort s )     -> no
-            (UnivSort s      , Prop (Max 0 [])) -> no
+            (Prop (ClosedLevel 0) , UnivSort s )     -> no
+            (UnivSort s           , Prop (ClosedLevel 0)) -> no
             (SizeUniv        , UnivSort s )     -> no
             (UnivSort s      , SizeUniv   )     -> no
 

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -112,7 +112,7 @@ etaLam i x b = do
     isVar0 _ (Var 0 [])               = True
     -- Andreas, 2016-01-08 If --type-in-type, all levels are equal.
     isVar0 True Level{}               = True
-    isVar0 tyty (Level (Max [Plus 0 l])) = case l of
+    isVar0 tyty (Level (Max 0 [Plus 0 l])) = case l of
       NeutralLevel _ v -> isVar0 tyty v
       UnreducedLevel v -> isVar0 tyty v
       BlockedLevel{}   -> False

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -555,10 +555,9 @@ instance Free Sort where
       DummyS{}   -> mempty
 
 instance Free Level where
-  freeVars' (Max as) = freeVars' as
+  freeVars' (Max _ as) = freeVars' as
 
 instance Free PlusLevel where
-  freeVars' ClosedLevel{} = mempty
   freeVars' (Plus _ l)    = freeVars' l
 
 instance Free LevelAtom where

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -87,10 +87,9 @@ instance PrecomputeFreeVars Sort where
       DummyS{}   -> pure s
 
 instance PrecomputeFreeVars Level where
-  precomputeFreeVars (Max ls) = Max <$> precomputeFreeVars ls
+  precomputeFreeVars (Max n ls) = Max n <$> precomputeFreeVars ls
 
 instance PrecomputeFreeVars PlusLevel where
-  precomputeFreeVars l@ClosedLevel{} = pure l
   precomputeFreeVars (Plus n l) = Plus n <$> precomputeFreeVars l
 
 instance PrecomputeFreeVars LevelAtom where

--- a/src/full/Agda/TypeChecking/Free/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Free/Reduce.hs
@@ -130,12 +130,10 @@ instance ForceNotFree Term where
     Dummy{}    -> return t
 
 instance ForceNotFree Level where
-  forceNotFree' (Max as) = Max <$> forceNotFree' as
+  forceNotFree' (Max m as) = Max m <$> forceNotFree' as
 
 instance ForceNotFree PlusLevel where
-  forceNotFree' l = case l of
-    ClosedLevel{} -> return l
-    Plus k a      -> Plus k <$> forceNotFree' a
+  forceNotFree' (Plus k a) = Plus k <$> forceNotFree' a
 
 instance ForceNotFree LevelAtom where
   forceNotFree' l = case l of

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -330,11 +330,10 @@ instance UsableRelevance Sort where
     DummyS{} -> return True
 
 instance UsableRelevance Level where
-  usableRel rel (Max ls) = usableRel rel ls
+  usableRel rel (Max _ ls) = usableRel rel ls
 
 instance UsableRelevance PlusLevel where
-  usableRel rel ClosedLevel{} = return True
-  usableRel rel (Plus _ l)    = usableRel rel l
+  usableRel rel (Plus _ l) = usableRel rel l
 
 instance UsableRelevance LevelAtom where
   usableRel rel l = case l of
@@ -436,7 +435,7 @@ instance UsableModality Sort where
   --   DummyS{} -> return True
 
 instance UsableModality Level where
-  usableMod mod (Max ls) = usableRel (getRelevance mod) ls
+  usableMod mod (Max _ ls) = usableRel (getRelevance mod) ls
 
 -- instance UsableModality PlusLevel where
 --   usableMod mod ClosedLevel{} = return True

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -7,6 +7,8 @@ import Data.Traversable (traverse)
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
+
+import Agda.TypeChecking.Free.Lazy
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Reduce
@@ -14,6 +16,8 @@ import Agda.TypeChecking.Monad.Builtin
 
 import Agda.Utils.Maybe ( caseMaybeM, allJustM )
 import Agda.Utils.Monad ( tryMaybe )
+import Agda.Utils.NonemptyList
+import Agda.Utils.Singleton
 
 import Agda.Utils.Impossible
 
@@ -91,22 +95,21 @@ reallyUnLevelView nv = do
   suc <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelSuc
   zer <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelZero
   case nv of
-    Max []              -> return zer
-    Max [Plus 0 a]      -> return $ unLevelAtom a
-    Max [a]             -> do
-      return $ unPlusV zer (apply1 suc) a
-    _ -> (`unlevelWithKit` nv) <$> builtinLevelKit
+    Max n []       -> return $ unConstV zer (apply1 suc) n
+    Max 0 [a]      -> return $ unPlusV (apply1 suc) a
+    _              -> (`unlevelWithKit` nv) <$> builtinLevelKit
 
 unlevelWithKit :: LevelKit -> Level -> Term
-unlevelWithKit LevelKit{ lvlZero = zer, lvlSuc = suc, lvlMax = max } (Max as) =
-  case map (unPlusV zer suc) as of
-    [a] -> a
-    []  -> zer
-    as  -> foldl1 max as
+unlevelWithKit LevelKit{ lvlZero = zer, lvlSuc = suc, lvlMax = max } = \case
+  Max m []  -> unConstV zer suc m
+  Max 0 [a] -> unPlusV suc a
+  Max m as  -> foldl1 max $ [ unConstV zer suc m | m > 0 ] ++ map (unPlusV suc) as
 
-unPlusV :: Term -> (Term -> Term) -> PlusLevel -> Term
-unPlusV zer suc (ClosedLevel n) = foldr (.) id (List.genericReplicate n suc) zer
-unPlusV _   suc (Plus n a)      = foldr (.) id (List.genericReplicate n suc) (unLevelAtom a)
+unConstV :: Term -> (Term -> Term) -> Integer -> Term
+unConstV zer suc n = foldr (.) id (List.genericReplicate n suc) zer
+
+unPlusV :: (Term -> Term) -> PlusLevel -> Term
+unPlusV suc (Plus n a) = foldr (.) id (List.genericReplicate n suc) (unLevelAtom a)
 
 maybePrimCon :: TCM Term -> TCM (Maybe ConHead)
 maybePrimCon prim = tryMaybe $ do
@@ -137,9 +140,9 @@ levelView' a = do
         case a of
           Level l -> return l
           Def s [Apply arg]
-            | s == lsuc  -> inc <$> view (unArg arg)
+            | s == lsuc  -> levelSuc <$> view (unArg arg)
           Def z []
-            | z == lzero -> return $ closed 0
+            | z == lzero -> return $ closedLevel 0
           Def m [Apply arg1, Apply arg2]
             | m == lmax  -> levelLub <$> view (unArg arg1) <*> view (unArg arg2)
           _              -> mkAtom a
@@ -149,27 +152,69 @@ levelView' a = do
     mkAtom a = do
       b <- reduceB a
       return $ case b of
-        NotBlocked _ (MetaV m as) -> atom $ MetaLevel m as
-        NotBlocked r _            -> atom $ NeutralLevel r $ ignoreBlocking b
-        Blocked m _               -> atom $ BlockedLevel m $ ignoreBlocking b
+        NotBlocked _ (MetaV m as) -> atomicLevel $ MetaLevel m as
+        NotBlocked r _            -> atomicLevel $ NeutralLevel r $ ignoreBlocking b
+        Blocked m _               -> atomicLevel $ BlockedLevel m $ ignoreBlocking b
 
-    atom a = Max [Plus 0 a]
+-- | Given a level @l@, find the maximum constant @n@ such that @l = n + l'@
+levelPlusView :: Level -> (Integer, Level)
+levelPlusView (Max 0 []) = (0 , Max 0 [])
+levelPlusView (Max 0 as@(_:_)) = (minN , Max 0 (map sub as))
+  where
+    minN = minimum [ n | Plus n _ <- as ]
+    sub (Plus n a) = Plus (n - minN) a
+levelPlusView (Max n as) = (minN , Max (n - minN) (map sub as))
+  where
+    minN = minimum $ n : [ n' | Plus n' _ <- as ]
+    sub (Plus n' a) = Plus (n' - minN) a
 
-    closed n = Max [ClosedLevel n | n > 0]
+-- | Given a level @l@, find the biggest constant @n@ such that @n <= l@
+levelLowerBound :: Level -> Integer
+levelLowerBound (Max m as) = maximum $ m : [n | Plus n _ <- as]
 
-    inc (Max as) = Max $ map inc' as
-      where
-        inc' (ClosedLevel n) = ClosedLevel $ n + 1
-        inc' (Plus n a)    = Plus (n + 1) a
-
-levelLub :: Level -> Level -> Level
-levelLub (Max as) (Max bs) = levelMax $ as ++ bs
-
+-- | Given a constant @n@ and a level @l@, find the level @l'@ such
+--   that @l = n + l'@ (or Nothing if there is no such level).
 subLevel :: Integer -> Level -> Maybe Level
-subLevel n (Max ls) = Max <$> traverse sub ls
+subLevel n (Max m ls)
+  | m == 0    = Max 0 <$> traverse sub ls
+  | m >= n    = Max (m - n) <$> traverse sub ls
+  | otherwise = Nothing
   where
     sub :: PlusLevel -> Maybe PlusLevel
-    sub (ClosedLevel j) | j >= n    = Just $ ClosedLevel $ j - n
-                        | otherwise = Nothing
-    sub (Plus j l)      | j >= n    = Just $ Plus (j - n) l
-                        | otherwise = Nothing
+    sub (Plus j l) | j >= n    = Just $ Plus (j - n) l
+                   | otherwise = Nothing
+
+
+-- | A @SingleLevel@ is a @Level@ that cannot be further decomposed as
+--   a maximum @a ⊔ b@.
+data SingleLevel = SingleClosed Integer | SinglePlus PlusLevel
+  deriving (Eq, Show)
+
+unSingleLevel :: SingleLevel -> Level
+unSingleLevel (SingleClosed m) = Max m []
+unSingleLevel (SinglePlus a)   = Max 0 [a]
+
+-- | Return the maximum of the given @SingleLevel@s
+unSingleLevels :: [SingleLevel] -> Level
+unSingleLevels ls = levelMax n as
+  where
+    n = maximum $ 0 : [m | SingleClosed m <- ls]
+    as = [a | SinglePlus a <- ls]
+
+levelMaxView :: Level -> NonemptyList SingleLevel
+levelMaxView (Max n [])     = singleton $ SingleClosed n
+levelMaxView (Max 0 (a:as)) = SinglePlus a :! map SinglePlus as
+levelMaxView (Max n as)     = SingleClosed n :! map SinglePlus as
+
+singleLevelView :: Level -> Maybe SingleLevel
+singleLevelView l = case levelMaxView l of
+  s :! [] -> Just s
+  _       -> Nothing
+
+instance Subst Term SingleLevel where
+  applySubst sub (SingleClosed m) = SingleClosed m
+  applySubst sub (SinglePlus a)   = SinglePlus $ applySubst sub a
+
+instance Free SingleLevel where
+  freeVars' (SingleClosed m) = mempty
+  freeVars' (SinglePlus a)   = freeVars' a

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -142,7 +142,7 @@ levelView' a = do
           Def s [Apply arg]
             | s == lsuc  -> levelSuc <$> view (unArg arg)
           Def z []
-            | z == lzero -> return $ closedLevel 0
+            | z == lzero -> return $ ClosedLevel 0
           Def m [Apply arg1, Apply arg2]
             | m == lmax  -> levelLub <$> view (unArg arg1) <*> view (unArg arg2)
           _              -> mkAtom a

--- a/src/full/Agda/TypeChecking/Level/Solve.hs
+++ b/src/full/Agda/TypeChecking/Level/Solve.hs
@@ -27,7 +27,7 @@ defaultOpenLevelsToZero = do
     if | all (`isUpperBoundFor` x) cs -> do
            m <- lookupMeta x
            TelV tel t <- telView =<< metaType x
-           addContext tel $ assignV DirEq x (teleArgs tel) $ Level (Max 0 [])
+           addContext tel $ assignV DirEq x (teleArgs tel) $ Level (ClosedLevel 0)
            return True
          `catchError` \_ -> return False
        | otherwise -> return False

--- a/src/full/Agda/TypeChecking/Level/Solve.hs
+++ b/src/full/Agda/TypeChecking/Level/Solve.hs
@@ -27,7 +27,7 @@ defaultOpenLevelsToZero = do
     if | all (`isUpperBoundFor` x) cs -> do
            m <- lookupMeta x
            TelV tel t <- telView =<< metaType x
-           addContext tel $ assignV DirEq x (teleArgs tel) $ Level (Max [])
+           addContext tel $ assignV DirEq x (teleArgs tel) $ Level (Max 0 [])
            return True
          `catchError` \_ -> return False
        | otherwise -> return False

--- a/src/full/Agda/TypeChecking/LevelConstraints.hs
+++ b/src/full/Agda/TypeChecking/LevelConstraints.hs
@@ -7,8 +7,10 @@ import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Free
-import Agda.Utils.Impossible
+import Agda.TypeChecking.Level
 
+import Agda.Utils.Impossible
+import Agda.Utils.NonemptyList
 
 -- | @simplifyLevelConstraint c cs@ turns an @c@ into an equality
 --   constraint if it is an inequality constraint and the reverse
@@ -23,11 +25,12 @@ simplifyLevelConstraint new old =
     Just eqs -> map simpl eqs
     Nothing  -> [new]
   where
-    simpl (a :=< b) | any (matchLeq (b :=< a)) leqs = LevelCmp CmpEq  (Max [a]) (Max [b])
-                    | otherwise                     = LevelCmp CmpLeq (Max [a]) (Max [b])
+    simpl (a :=< b)
+      | any (matchLeq (b :=< a)) leqs = LevelCmp CmpEq  (unSingleLevel a) (unSingleLevel b)
+      | otherwise                     = LevelCmp CmpLeq (unSingleLevel a) (unSingleLevel b)
     leqs = concat $ mapMaybe inequalities old
 
-data Leq = PlusLevel :=< PlusLevel
+data Leq = SingleLevel :=< SingleLevel
   deriving (Show, Eq)
 
 -- | Check if two inequality constraints are the same up to variable renaming.
@@ -48,21 +51,26 @@ matchLeq (a :=< b) (c :=< d)
           | y == y'   = Var x [] :# go (y + 1) ren
           | otherwise = Strengthen __IMPOSSIBLE__ $ go (y + 1) ren0
 
--- | Turn a level constraint into a list of level inequalities, if possible.
+-- | Turn a level constraint into a list of inequalities between
+--   single levels, if possible.
 
 inequalities :: Constraint -> Maybe [Leq]
 
-inequalities (LevelCmp CmpLeq (Max as) (Max [b])) = Just $ map (:=< b) as  -- Andreas, 2016-09-28
+inequalities (LevelCmp CmpLeq a b)
+  | Just b' <- singleLevelView b = Just $ map (:=< b') $ toList $ levelMaxView a
+  -- Andreas, 2016-09-28
   -- Why was this most natural case missing?
   -- See test/Succeed/LevelLeqGeq.agda for where it is useful!
 
 -- These are very special cases only, in no way complete:
-inequalities (LevelCmp CmpEq (Max as) (Max [b])) =
-  case break (== b) as of
-    (as0, _ : as1) -> Just [ a :=< b | a <- as0 ++ as1 ]
+inequalities (LevelCmp CmpEq a b)
+  | Just a' <- singleLevelView a =
+  case break (== a') (toList $ levelMaxView b) of
+    (bs0, _ : bs1) -> Just [ b' :=< a' | b' <- bs0 ++ bs1 ]
     _              -> Nothing
-inequalities (LevelCmp CmpEq (Max [b]) (Max as)) =
-  case break (== b) as of
-    (as0, _ : as1) -> Just [ a :=< b | a <- as0 ++ as1 ]
+inequalities (LevelCmp CmpEq a b)
+  | Just b' <- singleLevelView b =
+  case break (== b') (toList $ levelMaxView a) of
+    (as0, _ : as1) -> Just [ a' :=< b' | a' <- as0 ++ as1 ]
     _              -> Nothing
 inequalities _ = Nothing

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -570,7 +570,7 @@ etaExpandMetaTCM kinds m = whenM (asksTC envAssignMetas `and2M` isEtaExpandable 
               reportSLn "tc.meta.eta" 20 $ "Expanding level meta to 0 (type-in-type)"
               -- Andreas, 2012-03-30: No need for occurrence check etc.
               -- we directly assign the solution for the meta
-              noConstraints $ assignTerm m (telToArgs tel) $ Level $ closedLevel 0
+              noConstraints $ assignTerm m (telToArgs tel) $ Level $ ClosedLevel 0
            ) $ {- else -} dontExpand
           _ -> dontExpand
 

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -570,7 +570,7 @@ etaExpandMetaTCM kinds m = whenM (asksTC envAssignMetas `and2M` isEtaExpandable 
               reportSLn "tc.meta.eta" 20 $ "Expanding level meta to 0 (type-in-type)"
               -- Andreas, 2012-03-30: No need for occurrence check etc.
               -- we directly assign the solution for the meta
-              noConstraints $ assignTerm m (telToArgs tel) (Level $ Max [])
+              noConstraints $ assignTerm m (telToArgs tel) $ Level $ closedLevel 0
            ) $ {- else -} dontExpand
           _ -> dontExpand
 

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -31,10 +31,9 @@ instance MentionsMeta Term where
       mm v = mentionsMetas xs v
 
 instance MentionsMeta Level where
-  mentionsMetas xs (Max as) = mentionsMetas xs as
+  mentionsMetas xs (Max _ as) = mentionsMetas xs as
 
 instance MentionsMeta PlusLevel where
-  mentionsMetas xs ClosedLevel{} = False
   mentionsMetas xs (Plus _ a) = mentionsMetas xs a
 
 instance MentionsMeta LevelAtom where

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -465,15 +465,14 @@ instance Occurs Clause where
   metaOccurs m = metaOccurs m . clauseBody
 
 instance Occurs Level where
-  occurs (Max as) = Max <$> occurs as
+  occurs (Max n as) = Max n <$> occurs as
 
-  metaOccurs m (Max as) = metaOccurs m as
+  metaOccurs m (Max _ as) = metaOccurs m as
 
 instance Occurs PlusLevel where
-  occurs l@ClosedLevel{} = return l
   occurs (Plus n l) = Plus n <$> occurs l
-  metaOccurs m ClosedLevel{} = return ()
-  metaOccurs m (Plus n l)    = metaOccurs m l
+
+  metaOccurs m (Plus n l) = metaOccurs m l
 
 instance Occurs LevelAtom where
   occurs l = do
@@ -748,10 +747,9 @@ instance AnyRigid Sort where
       DummyS{}   -> return False
 
 instance AnyRigid Level where
-  anyRigid f (Max ls) = anyRigid f ls
+  anyRigid f (Max _ ls) = anyRigid f ls
 
 instance AnyRigid PlusLevel where
-  anyRigid f ClosedLevel{} = return False
   anyRigid f (Plus _ l)    = anyRigid f l
 
 instance AnyRigid LevelAtom where

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -204,7 +204,8 @@ instance IsInstantiatedMeta Term where
       _          -> __IMPOSSIBLE__
 
 instance IsInstantiatedMeta Level where
-  isInstantiatedMeta (Max ls) = isInstantiatedMeta ls
+  isInstantiatedMeta (Max n ls) | n == 0 = isInstantiatedMeta ls
+  isInstantiatedMeta _ = __IMPOSSIBLE__
 
 instance IsInstantiatedMeta PlusLevel where
   isInstantiatedMeta (Plus n l) | n == 0 = isInstantiatedMeta l
@@ -611,11 +612,10 @@ instance UnFreezeMeta Sort where
   unfreezeMeta _             = return ()
 
 instance UnFreezeMeta Level where
-  unfreezeMeta (Max ls)      = unfreezeMeta ls
+  unfreezeMeta (Max _ ls)      = unfreezeMeta ls
 
 instance UnFreezeMeta PlusLevel where
   unfreezeMeta (Plus _ a)    = unfreezeMeta a
-  unfreezeMeta ClosedLevel{} = return ()
 
 instance UnFreezeMeta LevelAtom where
   unfreezeMeta (MetaLevel x _)    = unfreezeMeta x

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -368,10 +368,9 @@ instance HasPolarity Term where
     Dummy{}    -> return []
 
 instance HasPolarity Level where
-  polarities i (Max as) = polarities i as
+  polarities i (Max _ as) = polarities i as
 
 instance HasPolarity PlusLevel where
-  polarities i ClosedLevel{} = return []
   polarities i (Plus _ l) = polarities i l
 
 instance HasPolarity LevelAtom where

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -456,11 +456,10 @@ instance ComputeOccurrences Term where
     Dummy{}      -> mempty
 
 instance ComputeOccurrences Level where
-  occurrences (Max as) = occurrences as
+  occurrences (Max _ as) = occurrences as
 
 instance ComputeOccurrences PlusLevel where
-  occurrences ClosedLevel{} = mempty
-  occurrences (Plus _ l)    = occurrences l
+  occurrences (Plus _ l) = occurrences l
 
 instance ComputeOccurrences LevelAtom where
   occurrences = occurrences . unLevelAtom

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -129,7 +129,7 @@ class ToTerm a where
 
 instance ToTerm Nat     where toTerm = return $ Lit . LitNat noRange . toInteger
 instance ToTerm Word64  where toTerm = return $ Lit . LitWord64 noRange
-instance ToTerm Lvl     where toTerm = return $ Level . Max . (:[]) . ClosedLevel . unLvl
+instance ToTerm Lvl     where toTerm = return $ Level . closedLevel . unLvl
 instance ToTerm Double  where toTerm = return $ Lit . LitFloat noRange
 instance ToTerm Char    where toTerm = return $ Lit . LitChar noRange
 instance ToTerm Str     where toTerm = return $ Lit . LitString noRange . unStr
@@ -279,8 +279,8 @@ instance FromTerm Word64 where
 
 instance FromTerm Lvl where
   fromTerm = fromReducedTerm $ \l -> case l of
-    Level (Max [ClosedLevel n]) -> Just $ Lvl n
-    _                           -> Nothing
+    Level (Max n []) -> Just $ Lvl n
+    _                -> Nothing
 
 instance FromTerm Double where
   fromTerm = fromLiteral $ \l -> case l of
@@ -371,7 +371,7 @@ mkPrimInjective :: Type -> Type -> QName -> TCM PrimitiveImpl
 mkPrimInjective a b qn = do
   -- Define the type
   eqName <- primEqualityName
-  let lvl0     = Max []
+  let lvl0     = closedLevel 0
   let eq a t u = El (Type lvl0) <$> pure (Def eqName []) <#> pure (Level lvl0)
                                 <#> pure (unEl a) <@> t <@> u
   let f    = pure (Def qn [])
@@ -571,7 +571,7 @@ primForceLemma = do
 mkPrimLevelZero :: TCM PrimitiveImpl
 mkPrimLevelZero = do
   t <- primType (undefined :: Lvl)
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 0 $ \_ -> redReturn $ Level $ Max []
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 0 $ \_ -> redReturn $ Level $ closedLevel 0
 
 mkPrimLevelSuc :: TCM PrimitiveImpl
 mkPrimLevelSuc = do
@@ -584,9 +584,9 @@ mkPrimLevelMax :: TCM PrimitiveImpl
 mkPrimLevelMax = do
   t <- primType (max :: Op Lvl)
   return $ PrimImpl t $ primFun __IMPOSSIBLE__ 2 $ \ ~[a, b] -> do
-    Max as <- levelView' $ unArg a
-    Max bs <- levelView' $ unArg b
-    redReturn $ Level $ levelMax $ as ++ bs
+    a' <- levelView' $ unArg a
+    b' <- levelView' $ unArg b
+    redReturn $ Level $ levelLub a' b'
 
 mkPrimSetOmega :: TCM PrimitiveImpl
 mkPrimSetOmega = do

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -129,7 +129,7 @@ class ToTerm a where
 
 instance ToTerm Nat     where toTerm = return $ Lit . LitNat noRange . toInteger
 instance ToTerm Word64  where toTerm = return $ Lit . LitWord64 noRange
-instance ToTerm Lvl     where toTerm = return $ Level . closedLevel . unLvl
+instance ToTerm Lvl     where toTerm = return $ Level . ClosedLevel . unLvl
 instance ToTerm Double  where toTerm = return $ Lit . LitFloat noRange
 instance ToTerm Char    where toTerm = return $ Lit . LitChar noRange
 instance ToTerm Str     where toTerm = return $ Lit . LitString noRange . unStr
@@ -279,8 +279,8 @@ instance FromTerm Word64 where
 
 instance FromTerm Lvl where
   fromTerm = fromReducedTerm $ \l -> case l of
-    Level (Max n []) -> Just $ Lvl n
-    _                -> Nothing
+    Level (ClosedLevel n) -> Just $ Lvl n
+    _                     -> Nothing
 
 instance FromTerm Double where
   fromTerm = fromLiteral $ \l -> case l of
@@ -371,7 +371,7 @@ mkPrimInjective :: Type -> Type -> QName -> TCM PrimitiveImpl
 mkPrimInjective a b qn = do
   -- Define the type
   eqName <- primEqualityName
-  let lvl0     = closedLevel 0
+  let lvl0     = ClosedLevel 0
   let eq a t u = El (Type lvl0) <$> pure (Def eqName []) <#> pure (Level lvl0)
                                 <#> pure (unEl a) <@> t <@> u
   let f    = pure (Def qn [])
@@ -571,7 +571,7 @@ primForceLemma = do
 mkPrimLevelZero :: TCM PrimitiveImpl
 mkPrimLevelZero = do
   t <- primType (undefined :: Lvl)
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 0 $ \_ -> redReturn $ Level $ closedLevel 0
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 0 $ \_ -> redReturn $ Level $ ClosedLevel 0
 
 mkPrimLevelSuc :: TCM PrimitiveImpl
 mkPrimLevelSuc = do

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -123,9 +123,8 @@ quotingKit = do
       -- We keep no ranges in the quoted term, so the equality on terms
       -- is only on the structure.
       quoteSortLevelTerm :: Level -> ReduceM Term
-      quoteSortLevelTerm (Max [])              = setLit !@! Lit (LitNat noRange 0)
-      quoteSortLevelTerm (Max [ClosedLevel n]) = setLit !@! Lit (LitNat noRange n)
-      quoteSortLevelTerm l                     = set !@ quoteTerm (unlevelWithKit lkit l)
+      quoteSortLevelTerm (Max n []) = setLit !@! Lit (LitNat noRange n)
+      quoteSortLevelTerm l          = set !@ quoteTerm (unlevelWithKit lkit l)
 
       quoteSort :: Sort -> ReduceM Term
       quoteSort (Type t) = quoteSortLevelTerm t

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -123,8 +123,8 @@ quotingKit = do
       -- We keep no ranges in the quoted term, so the equality on terms
       -- is only on the structure.
       quoteSortLevelTerm :: Level -> ReduceM Term
-      quoteSortLevelTerm (Max n []) = setLit !@! Lit (LitNat noRange n)
-      quoteSortLevelTerm l          = set !@ quoteTerm (unlevelWithKit lkit l)
+      quoteSortLevelTerm (ClosedLevel n) = setLit !@! Lit (LitNat noRange n)
+      quoteSortLevelTerm l               = set !@ quoteTerm (unlevelWithKit lkit l)
 
       quoteSort :: Sort -> ReduceM Term
       quoteSort (Type t) = quoteSortLevelTerm t

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -121,10 +121,9 @@ instance Instantiate Term where
   instantiate' t = return t
 
 instance Instantiate Level where
-  instantiate' (Max as) = levelMax <$> instantiate' as
+  instantiate' (Max m as) = levelMax m <$> instantiate' as
 
 instance Instantiate PlusLevel where
-  instantiate' l@ClosedLevel{} = return l
   instantiate' (Plus n a) = Plus n <$> instantiate' a
 
 instance Instantiate LevelAtom where
@@ -321,11 +320,10 @@ instance Reduce Elim where
   reduce' (IApply x y v) = IApply <$> reduce' x <*> reduce' y <*> reduce' v
 
 instance Reduce Level where
-  reduce'  (Max as) = levelMax <$> mapM reduce' as
-  reduceB' (Max as) = fmap levelMax . traverse id <$> traverse reduceB' as
+  reduce'  (Max m as) = levelMax m <$> mapM reduce' as
+  reduceB' (Max m as) = fmap (levelMax m) . traverse id <$> traverse reduceB' as
 
 instance Reduce PlusLevel where
-  reduceB' l@ClosedLevel{} = return $ notBlocked l
   reduceB' (Plus n l) = fmap (Plus n) <$> reduceB' l
 
 instance Reduce LevelAtom where
@@ -864,10 +862,9 @@ instance Simplify Sort where
         DummyS{}   -> return s
 
 instance Simplify Level where
-  simplify' (Max as) = levelMax <$> simplify' as
+  simplify' (Max m as) = levelMax m <$> simplify' as
 
 instance Simplify PlusLevel where
-  simplify' l@ClosedLevel{} = return l
   simplify' (Plus n l) = Plus n <$> simplify' l
 
 instance Simplify LevelAtom where
@@ -1034,10 +1031,9 @@ instance Normalise Elim where
   normalise' (IApply x y v) = IApply <$> normalise' x <*> normalise' y <*> normalise' v
 
 instance Normalise Level where
-  normalise' (Max as) = levelMax <$> normalise' as
+  normalise' (Max m as) = levelMax m <$> normalise' as
 
 instance Normalise PlusLevel where
-  normalise' l@ClosedLevel{} = return l
   normalise' (Plus n l) = Plus n <$> normalise' l
 
 instance Normalise LevelAtom where
@@ -1210,10 +1206,9 @@ instance InstantiateFull Term where
           Dummy{}     -> return v
 
 instance InstantiateFull Level where
-  instantiateFull' (Max as) = levelMax <$> instantiateFull' as
+  instantiateFull' (Max m as) = levelMax m <$> instantiateFull' as
 
 instance InstantiateFull PlusLevel where
-  instantiateFull' l@ClosedLevel{} = return l
   instantiateFull' (Plus n l) = Plus n <$> instantiateFull' l
 
 instance InstantiateFull LevelAtom where

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -565,7 +565,7 @@ instance AllHoles Sort where
 
 instance AllHoles Level where
   type PType Level = ()
-  allHoles _ (Max ls) = fmap Max <$> allHoles_ ls
+  allHoles _ (Max n ls) = fmap (Max n) <$> allHoles_ ls
 
 instance AllHoles [PlusLevel] where
   type PType [PlusLevel] = ()
@@ -576,7 +576,6 @@ instance AllHoles [PlusLevel] where
 
 instance AllHoles PlusLevel where
   type PType PlusLevel = ()
-  allHoles _ (ClosedLevel n) = empty
   allHoles _ (Plus n l) = fmap (Plus n) <$> allHoles_ l
 
 instance AllHoles LevelAtom where
@@ -644,11 +643,10 @@ instance MetasToVars Sort where
     DummyS s   -> pure $ DummyS s
 
 instance MetasToVars Level where
-  metasToVars (Max ls) = Max <$> metasToVars ls
+  metasToVars (Max n ls) = Max n <$> metasToVars ls
 
 instance MetasToVars PlusLevel where
-  metasToVars (ClosedLevel n) = pure $ ClosedLevel n
-  metasToVars (Plus n x)      = Plus n <$> metasToVars x
+  metasToVars (Plus n x) = Plus n <$> metasToVars x
 
 instance MetasToVars LevelAtom where
   metasToVars = \case

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -62,7 +62,7 @@ import Agda.Utils.Except
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20190824 * 10 + 0
+currentInterfaceVersion = 20190917 * 10 + 0
 
 -- | Encodes something. To ensure relocatability file paths in
 -- positions are replaced with module names.

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -110,18 +110,14 @@ instance EmbPrj I.Term where
     valu _         = malformed
 
 instance EmbPrj Level where
-  icod_ (Max a) = icodeN' Max a
+  icod_ (Max a b) = icodeN' Max a b
 
   value = valueN Max
 
 instance EmbPrj PlusLevel where
-  icod_ (ClosedLevel a) = icodeN' ClosedLevel a
-  icod_ (Plus a b)      = icodeN' Plus a b
+  icod_ (Plus a b) = icodeN' Plus a b
 
-  value = vcase valu where
-    valu [a]    = valuN ClosedLevel a
-    valu [a, b] = valuN Plus a b
-    valu _      = malformed
+  value = valueN Plus
 
 instance EmbPrj LevelAtom where
   icod_ (NeutralLevel r a) = icodeN' (NeutralLevel r) a

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -812,10 +812,9 @@ instance (Coercible a Term, Subst t a) => Subst t (Sort' a) where
     where sub x = applySubst rho x
 
 instance Subst t a => Subst t (Level' a) where
-  applySubst rho (Max as) = Max $ applySubst rho as
+  applySubst rho (Max n as) = Max n $ applySubst rho as
 
 instance Subst t a => Subst t (PlusLevel' a) where
-  applySubst rho l@ClosedLevel{} = l
   applySubst rho (Plus n l) = Plus n $ applySubst rho l
 
 instance Subst t a => Subst t (LevelAtom' a) where
@@ -1241,11 +1240,8 @@ deriving instance Eq CompareAs
 deriving instance Eq Section
 
 instance Ord PlusLevel where
-  compare ClosedLevel{} Plus{}            = LT
-  compare Plus{} ClosedLevel{}            = GT
-  compare (ClosedLevel n) (ClosedLevel m) = compare n m
   -- Compare on the atom first. Makes most sense for levelMax.
-  compare (Plus n a) (Plus m b)           = compare (a,n) (b,m)
+  compare (Plus n a) (Plus m b) = compare (a,n) (b,m)
 
 instance Eq LevelAtom where
   (==) = (==) `on` unLevelAtom
@@ -1397,12 +1393,12 @@ funSort' :: Dom Type -> Sort -> Maybe Sort
 funSort' a b = case (getSort a, b) of
   (Inf           , _            ) -> Just Inf
   (_             , Inf          ) -> Just Inf
-  (Type (Max as) , Type (Max bs)) -> Just $ Type $ levelMax $ as ++ bs
+  (Type a , Type b) -> Just $ Type $ levelLub a b
   (SizeUniv      , b            ) -> Just b
   (_             , SizeUniv     ) -> Just SizeUniv
-  (Prop (Max as) , Type (Max bs)) -> Just $ Type $ levelMax $ as ++ bs
-  (Type (Max as) , Prop (Max bs)) -> Just $ Prop $ levelMax $ as ++ bs
-  (Prop (Max as) , Prop (Max bs)) -> Just $ Prop $ levelMax $ as ++ bs
+  (Prop a , Type b) -> Just $ Type $ levelLub a b
+  (Type a , Prop b) -> Just $ Prop $ levelLub a b
+  (Prop a , Prop b) -> Just $ Prop $ levelLub a b
   (a             , b            ) -> Nothing
 
 funSort :: Dom Type -> Sort -> Sort
@@ -1455,66 +1451,62 @@ piSort a b = fromMaybe (PiSort a b) $ piSort' a b
 -- * Level stuff
 ---------------------------------------------------------------------------
 
-levelMax :: [PlusLevel] -> Level
-levelMax as0 = Max $ ns ++ List.sort bs
+-- ^ Computes @n0 ⊔ a₁ ⊔ a₂ ⊔ ... ⊔ aₙ@ and return its canonical form.
+levelMax :: Integer -> [PlusLevel] -> Level
+levelMax n0 as0 = Max n as
   where
-    as = Prelude.concatMap expand as0
-    -- ns is empty or a singleton
-    ns = case [ n | ClosedLevel n <- as, n > 0 ] of
-      []  -> []
-      ns  -> [ ClosedLevel n | let n = Prelude.maximum ns, n > greatestB ]
-    bs = subsume [ b | b@Plus{} <- as ]
-    greatestB | null bs   = 0
-              | otherwise = Prelude.maximum [ n | Plus n _ <- bs ]
+    -- step 1: flatten nested @Level@ expressions in @LevelAtom@s
+    Max n1 as1 = expandLevel $ Max n0 as0
+    -- step 2: remove subsumed @PlusLevel@s
+    as2       = removeSubsumed as1
+    -- step 3: sort remaining @PlusLevel@s
+    as        = List.sort as2
+    -- step 4: set constant to 0 if it is subsumed by one of the @PlusLevel@s
+    greatestB = Prelude.maximum $ 0 : [ n | Plus n _ <- as ]
+    n | n1 > greatestB = n1
+      | otherwise      = 0
 
-    expand l@ClosedLevel{} = [l]
-    expand (Plus n l) = map (plus n) $ expand0 $ expandAtom l
+    lmax :: Integer -> [PlusLevel] -> [Level] -> Level
+    lmax m as []              = Max m as
+    lmax m as (Max n bs : ls) = lmax (max m n) (bs ++ as) ls
 
-    expand0 [] = [ClosedLevel 0]
-    expand0 as = as
+    expandLevel :: Level -> Level
+    expandLevel (Max m as) = lmax m [] $ map expandPlus as
 
+    expandPlus :: PlusLevel -> Level
+    expandPlus (Plus m l) = levelPlus m $ expandAtom l
+
+    expandAtom :: LevelAtom -> Level
     expandAtom l = case l of
       BlockedLevel _ v -> expandTm v
       NeutralLevel _ v -> expandTm v
       UnreducedLevel v -> expandTm v
-      MetaLevel{}      -> [Plus 0 l]
+      MetaLevel{}      -> Max 0 [Plus 0 l]
       where
-        expandTm v = case v of
-          Level (Max as)       -> as
-          Sort (Type (Max as)) -> as
-          _                    -> [Plus 0 l]
+        expandTm (Level l)       = expandLevel l
+        expandTm (Sort (Type l)) = expandLevel l -- TODO: get rid of this horrible hack!
+        expandTm v               = Max 0 [Plus 0 l]
 
-    plus n (ClosedLevel m) = ClosedLevel (n + m)
-    plus n (Plus m l)      = Plus (n + m) l
-
-    subsume (ClosedLevel{} : _) = __IMPOSSIBLE__
-    subsume [] = []
-    subsume (Plus n a : bs)
-      | not $ null ns = subsume bs
-      | otherwise     = Plus n a : subsume [ b | b@(Plus _ a') <- bs, a /= a' ]
+    removeSubsumed [] = []
+    removeSubsumed (Plus n a : bs)
+      | not $ null ns = removeSubsumed bs
+      | otherwise     = Plus n a : removeSubsumed [ b | b@(Plus _ a') <- bs, a /= a' ]
       where
-        ns = [ m | Plus m a'  <- bs, a == a', m > n ]
+        ns = [ m | Plus m a' <- bs, a == a', m > n ]
+
+-- | Given two levels @a@ and @b@, compute @a ⊔ b@ and return its
+--   canonical form.
+levelLub :: Level -> Level -> Level
+levelLub (Max m as) (Max n bs) = levelMax (max m n) $ as ++ bs
 
 levelTm :: Level -> Term
 levelTm l =
   case l of
-    Max [Plus 0 l] -> unLevelAtom l
-    _              -> Level l
+    Max 0 [Plus 0 l] -> unLevelAtom l
+    _                -> Level l
 
 unLevelAtom :: LevelAtom -> Term
 unLevelAtom (MetaLevel x es)   = MetaV x es
 unLevelAtom (NeutralLevel _ v) = v
 unLevelAtom (UnreducedLevel v) = v
 unLevelAtom (BlockedLevel _ v) = v
-
-levelSucView :: Level -> Maybe Level
-levelSucView (Max []) = Nothing
-levelSucView (Max as) = Max <$> traverse atomPred as
-  where
-    atomPred :: PlusLevel -> Maybe PlusLevel
-    atomPred (ClosedLevel n)
-      | n > 0     = Just $ ClosedLevel (n-1)
-      | otherwise = Nothing
-    atomPred (Plus n l)
-      | n > 0     = Just $ Plus (n-1) l
-      | otherwise = Nothing

--- a/src/full/Agda/TypeChecking/Substitute/DeBruijn.hs
+++ b/src/full/Agda/TypeChecking/Substitute/DeBruijn.hs
@@ -46,10 +46,10 @@ instance DeBruijn PlusLevel where
       _ -> Nothing
 
 instance DeBruijn Level where
-  deBruijnVar i = Max [deBruijnVar i]
+  deBruijnVar i = Max 0 [deBruijnVar i]
   deBruijnView l =
     case l of
-      Max [p] -> deBruijnView p
+      Max 0 [p] -> deBruijnView p
       _ -> Nothing
 
 instance DeBruijn DBPatVar where

--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -100,14 +100,14 @@ instance SynEq Term where
       _                                    -> inequal (v, v')
 
 instance SynEq Level where
-  synEq (Max vs) (Max vs') = levelMax <$$> synEq vs vs'
+  synEq l@(Max n vs) l'@(Max n' vs')
+    | n == n'   = levelMax n <$$> synEq vs vs'
+    | otherwise = inequal (l, l')
 
 instance SynEq PlusLevel where
-  synEq l l' = do
-    case (l, l') of
-      (ClosedLevel v, ClosedLevel v') | v == v' -> pure2 l
-      (Plus n v,      Plus n' v')     | n == n' -> Plus n <$$> synEq v v'
-      _ -> inequal (l, l')
+  synEq l@(Plus n v) l'@(Plus n' v')
+    | n == n'   = Plus n <$$> synEq v v'
+    | otherwise = inequal (l, l')
 
 instance SynEq LevelAtom where
   synEq l l' = do

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -530,7 +530,7 @@ evalTCM v = do
       if norm then normalise v else instantiateFull v
 
     mkT l a = El s a
-      where s = Type $ Max [Plus 0 $ UnreducedLevel l]
+      where s = Type $ Max 0 [Plus 0 $ UnreducedLevel l]
 
     -- Don't catch Unquote errors!
     tcCatchError :: Term -> Term -> UnquoteM Term

--- a/test/Internal/TypeChecking/Free.hs
+++ b/test/Internal/TypeChecking/Free.hs
@@ -347,13 +347,13 @@ prop_isSemimodule_withVarOcc2_not_a_counterexample =
 -- Sample term, TODO: expand to unit test.
 
 ty :: Term
-ty = Pi (defaultDom ab) $ Abs "x" $ El (Type $ Max []) $ var 5
+ty = Pi (defaultDom ab) $ Abs "x" $ El (Type $ Max 0 []) $ var 5
   where
-    a  = El (Prop $ Max []) $
+    a  = El (Prop $ Max 0 []) $
            var 4
-    b  = El (Type $ Max []) $
-           Sort $ Type $ Max []
-    ab = El (Type $ Max [ClosedLevel 1]) $
+    b  = El (Type $ Max 0 []) $
+           Sort $ Type $ Max 0 []
+    ab = El (Type $ Max 1 []) $
            Pi (defaultDom a) (Abs "x" b)
 
 ------------------------------------------------------------------------

--- a/test/interaction/Issue3428.out
+++ b/test/interaction/Issue3428.out
@@ -6,5 +6,5 @@
 ((last . 1) . (agda2-goals-action '(0)))
 (agda2-give-action 0 "∀ B → B")
 (agda2-status-action "")
-(agda2-info-action "*All Goals, Errors*" "Sort _6 [ at 1,7-8 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: Has bigger sort: _6 piSort (univSort _6) (λ _ → _6) =< Set ℓ univSort (piSort (univSort _6) (λ _ → _6)) = Set (Agda.Primitive.lsuc ℓ) piSort (univSort _6) (λ _ → _6) = Set ℓ " nil)
+(agda2-info-action "*All Goals, Errors*" "Sort _6 [ at 1,7-8 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: piSort (univSort _6) (λ _ → _6) =< Set ℓ Has bigger sort: _6 univSort (piSort (univSort _6) (λ _ → _6)) = Set (Agda.Primitive.lsuc ℓ) piSort (univSort _6) (λ _ → _6) = Set ℓ " nil)
 ((last . 1) . (agda2-goals-action '()))


### PR DESCRIPTION
This PR provides a new internal representation of universe levels where the `ClosedLevel` constructor of `LevelPlus` has been removed, and the constant level is instead integrated into the `Max` constructor of `Level`. In the process, I also refactored the constraint solver for levels and added several utility functions.