### PR TITLE
User manual: FFI - clarify what type is the reference about and add punctuation

### DIFF
--- a/doc/user-manual/language/foreign-function-interface.lagda.rst
+++ b/doc/user-manual/language/foreign-function-interface.lagda.rst
@@ -237,7 +237,7 @@ Level-polymorphic types
 polymorphic functions. Since Haskell does not have universe levels the Agda
 type will have more arguments than the corresponding Haskell type. This can be solved
 by defining a Haskell type synonym with the appropriate number of phantom
-arguments. For instance
+arguments. For instance:
 
 ::
 

--- a/doc/user-manual/language/foreign-function-interface.lagda.rst
+++ b/doc/user-manual/language/foreign-function-interface.lagda.rst
@@ -235,7 +235,7 @@ Level-polymorphic types
 
 :ref:`Level-polymorphic types <universe-levels>` face a similar problem to
 polymorphic functions. Since Haskell does not have universe levels the Agda
-type will have more arguments than the corresponding type. This can be solved
+type will have more arguments than the corresponding Haskell type. This can be solved
 by defining a Haskell type synonym with the appropriate number of phantom
 arguments. For instance
 


### PR DESCRIPTION
In the user manual in the section on the foreign function interface, this pull request clarifies what type a reference is about (a Haskell type rather than an Agda type). Furthermore, it adds a colon at the end of the same paragraph before a code snippet.