### PR TITLE
Fixing issue #4159

### DIFF
--- a/src/full/Agda/TypeChecking/MetaVars.hs-boot
+++ b/src/full/Agda/TypeChecking/MetaVars.hs-boot
@@ -3,7 +3,13 @@ module Agda.TypeChecking.MetaVars where
 import Agda.Syntax.Common           ( Arg )
 import Agda.Syntax.Internal         ( MetaId, Term, Type, Args, Dom, Abs, Telescope, Sort )
 import Agda.TypeChecking.Monad.Base ( TCM, RunMetaOccursCheck, Comparison, CompareAs, CompareDirection )
-import Agda.TypeChecking.Monad.MetaVars (MonadMetaSolver)
+import Agda.TypeChecking.Monad.MetaVars   ( MonadMetaSolver )
+
+-- Imports for expandProjectedVars:
+-- import Agda.Syntax.Internal.Generic       ( TermLike )
+import Agda.TypeChecking.Pretty           ( PrettyTCM )
+-- import Agda.TypeChecking.Reduce           ( Reduce )
+import Agda.TypeChecking.Substitute.Class ( Subst )
 
 instance MonadMetaSolver TCM
 
@@ -20,3 +26,19 @@ newNamedValueMeta':: MonadMetaSolver m => RunMetaOccursCheck -> String -> Compar
 newTelMeta        :: MonadMetaSolver m => Telescope -> m Args
 newSortMeta       :: TCM Sort
 checkMetaInst     :: MetaId -> TCM ()
+
+-- Definitions for expandProjectedVars:
+
+class    NoProjectedVar a
+instance NoProjectedVar Term
+instance NoProjectedVar a => NoProjectedVar (Arg a)
+instance NoProjectedVar a => NoProjectedVar [a]
+
+class    ReduceAndEtaContract a
+instance ReduceAndEtaContract Term
+instance ReduceAndEtaContract a => ReduceAndEtaContract (Arg a)
+instance ReduceAndEtaContract a => ReduceAndEtaContract [a]
+
+expandProjectedVars :: ( Show a, PrettyTCM a, NoProjectedVar a, ReduceAndEtaContract a
+                       , PrettyTCM b, Subst Term b
+                       ) => a -> b -> (Bool -> a -> b -> TCM c) -> TCM c

--- a/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
@@ -116,7 +116,15 @@ data DefaultToInfty
 solveSizeConstraints :: DefaultToInfty -> TCM ()
 solveSizeConstraints flag =  do
 
-  -- 1. Take out the size constraints normalised.
+  -- 0. Try to solve size equality constraints.
+
+  sizeTest <- isSizeTypeTest
+  let sizeEqConstraint = S.mkIsSizeConstraint sizeTest (== CmpEq) . theConstraint
+  wakeConstraints' $ return . sizeEqConstraint
+  solveSomeAwakeConstraints sizeEqConstraint False  -- True = even if already solving constraints
+
+  -- 1. Take out the size inequality constraints normalised.
+  -- TODO: take all constraints and turn equalities to pair of inequalities?
 
   cs0 <- mapM (mapClosure normalise) =<< S.takeSizeConstraints (== CmpLeq)
     -- NOTE: this deletes the size constraints from the constraint set!

--- a/test/Fail/Issue3340.err
+++ b/test/Fail/Issue3340.err
@@ -1,7 +1,2 @@
-Failed to solve the following constraints:
-  [31, 35] f x = _48 : _f.P_47 x
-  [22] _f.P_47 y =< _f.P_47 x 
 Unsolved metas at the following locations:
-  Issue3340.agda:12,22-25
   Issue3340.agda:12,16-17
-  Issue3340.agda:13,13-17

--- a/test/Succeed/Generalize.agda
+++ b/test/Succeed/Generalize.agda
@@ -98,3 +98,29 @@ postulate   Π[]     : Π a B ∘ᵀ σ ≡ Π (a ∘ᵗ σ) (B ∘ᵀ σ ↑ El
 postulate   app     : Tm Γ (Π a B) → Tm (Γ ▹ El a) B
 postulate   app[]   : app t ∘ᵗ (σ ↑ El a) ≡ app (t ∘ᵗ σ)
 {-# REWRITE app[] #-}
+
+
+---------------------------------------------------------------------
+-- Andreas, 2019-11-17, issue #4159:  Generalize over size variables.
+
+open import Agda.Builtin.Size
+
+data Foo : Size → Set where
+  foo : ∀ i → Foo i → Foo (↑ i)
+
+postulate
+  P : (i : Size) (A : Foo i) → Set
+
+variable
+  i : Size
+  F : Foo i
+  p : P i F
+
+-- Problem was:
+-- Size constraint solver could not deal with generated constraint:
+--
+--   ?i (gentel .field-i) ≤ (gentel .field-i)
+--
+-- Works now by expanding the record variable gentel in the context
+-- of this constraint.  This mechanism was previously only available
+-- in the 'assign' procedure that solves equational meta constraints.

--- a/test/interaction/Issue1353.out
+++ b/test/interaction/Issue1353.out
@@ -3,7 +3,7 @@
 (agda2-highlight-clear)
 (agda2-verbose "Found interaction point ConcreteDef ?0 : (Pow I) ")
 (agda2-status-action "ShowImplicit")
-(agda2-info-action "*All Goals, Errors*" "?0 : Pow I _X_241 : Set [ at Issue1353.agda:89,60-65 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: [378] X (input Ω {i} p a) =< _X_241 {Ψ = X} {X = i} (m = (input Ω {i} p a)) [380, 382] _X_241 {Ψ = X} {X = i} (m = (input Ψ {i} p₁ a)) =< X (input Ψ {i} p₁ a) " nil)
+(agda2-info-action "*All Goals, Errors*" "?0 : Pow I _X_241 : Set [ at Issue1353.agda:89,60-65 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: [378] X (input(Ω) {i} p a) =< _X_241 {I = I} {Ψ = X} {X = i} (m = (input(Ω) {i} p a)) [380, 382] _X_241 {I = I} {Ψ = X} {X = i} (m = (input(Ψ) {i} p a)) =< X (input(Ψ) {i} p a) " nil)
 ((last . 1) . (agda2-goals-action '(0)))
 (agda2-give-action 0 "X")
 (agda2-status-action "ShowImplicit")


### PR DESCRIPTION
- [ fixed #4159 ] by uncurrying metas in addConstraint

Adding constraints will now simplify constraints in assignment form
where the meta is applied to some projected variables.  E.g.

    r : record { f : A } |- X (r .f) = rhs

will be replaced by

    "(r .f)" : A |- X "(r .f)" = [ record { f = "(r .f)" } / r ] rhs

Here "(r .f)" is a name for a new variable created for the field f of r.

This mechanism (expandProjectedVars) was already at work in
MetaVars.assign, but not available for size constraints.  In particular,
this mechanism is needed for the generalization feature which uses a
variable of record type to store all the generalized variables.

As a consequence of this change, constraints displayed to the user will
sometimes have the funny generated variable names which try to mimic the
term they represent.

At the moment, there is still a doubtful implementation of the
substitution, inherited from the current implementation of this
expandProjectedVars feature:  The new constraint lives in the context

    inTopContext $ addContextTel tel

where tel represents the new context.  This should be replaced by

    updateContext <subst> (const tel)

to be safe with checkpoints and parameter substitution.  However, the
API for contexts does not accept a telescope here, and there is no
function to turn a telescope into a context.

Either such a function has to be provided (but note that the CxtIds are
then not preserved!) or the expandProjectedVars mechanism has to be
changed to work with context instead of telescopes.

- [ #4159 ] solveSizeConstraints: attempt to solve CmpEq first

This is supposedly an improvedment of the size solver:  If there are
size equality constraints, don't just ignore them, but try to solve them
via the MetaVars.assign procedure.

If that does not work, they are ignored.
TODO: maybe turn them into a pair of inequality constraints?

- [ #4159 ] postfix names for the variables created by expandProjectedVar

If --postfix-projections is on, the new variables will be named

    "(r .f)"

instead of:

    "f(r)"
