### PR TITLE
[ #4189 ] bring back qualified record constructors

### DIFF
--- a/test/Fail/Issue4189.err
+++ b/test/Fail/Issue4189.err
@@ -1,9 +1,0 @@
-Issue4189.agda:15,17-38
-The module Unit doesn't export the following: tt
-when scope checking the declaration
-  module Unit = ⊤ renaming (tt to unit)
-Issue4189.agda:20,7-11
-Not in scope:
-  ⊤.tt at Issue4189.agda:20,7-11
-    (did you mean 'tt'?)
-when scope checking ⊤.tt

--- a/test/Succeed/Issue282.agda
+++ b/test/Succeed/Issue282.agda
@@ -5,7 +5,7 @@ module Works where
   record R : Set where
     constructor c
 
-  -- foo = R.c  -- Andreas, 2019-11-11, #4189, no more qualified record constructors
+  foo = R.c  -- Andreas, 2019-11-11, #4189, no more qualified record constructors
 
 module Doesn't_work where
 
@@ -14,7 +14,7 @@ module Doesn't_work where
     record R : Set where
       constructor c
 
-  -- foo = R.c  -- Andreas, 2019-11-11, #4189, no more qualified record constructors
+  foo = R.c  -- Andreas, 2019-11-11, #4189, no more qualified record constructors
 
 -- Bug.agda:17,9-12
 -- Not in scope:

--- a/test/Succeed/Issue4189.agda
+++ b/test/Succeed/Issue4189.agda
@@ -7,6 +7,10 @@
 -- Thus, a record constructor does not live in the record module
 -- any more.
 
+-- However, it still lives in the namespace aspect of the record module
+-- that does not depend on the module parameters (like open public).
+-- Thus, we can still use qualified record constructors.
+
 -- {-# OPTIONS -v tc.mod.apply:100 #-}
 
 record ⊤ : Set where
@@ -14,9 +18,9 @@ record ⊤ : Set where
 
 module Unit = ⊤ renaming (tt to unit)
   -- WAS: internal error
-  -- NOW: warning about tt not being in scope
 
 tt′ : ⊤
 tt′ = ⊤.tt
-  -- WAS: success
-  -- NOW: Not in scope: ⊤.tt
+
+test : ⊤
+test = Unit.unit

--- a/test/Succeed/QualifiedConstructors.agda
+++ b/test/Succeed/QualifiedConstructors.agda
@@ -16,7 +16,7 @@ record Suc : Set where
   constructor suc
   field n : Nat₁
 
--- one₃ = Suc.suc zero₁  -- removed feature, see #4189
+one₃ = Suc.suc zero₁  -- removed feature, see #4189
 
 pred : Suc → Nat₁
 pred s = Suc.n s


### PR DESCRIPTION
Bring back qualified record constructors, but leave the `OnlyQualified` hack in Hades.

We now exploit the "open public" feature of modules that let's us have
names in modules that ignore the record parameters.

Technically, we simply link the concrete constructor name inside the
record module to its definition in the parent module.

Maybe this is how the feature should have been implemented in the first place.