### PR TITLE
Use GitHub Actions to test compilation settings

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -1,0 +1,26 @@
+name: stack
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ghc-ver: [8.8.1, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        additional-flags: [ "--flag Agda:cpphs --flag Agda:debug" , "" ]
+    env:
+      ARGS: "--stack-yaml stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc --fast"
+      FLAGS: "${{ matrix.additional-flags }} --flag Agda:enable-cluster-counting"
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: ${{ matrix.ghc-ver }}
+    - name: Install dependencies
+      run: |
+        echo Build with ${ARGS}
+        stack build ${ARGS} ${FLAGS} --only-dependencies
+    - name: Build
+      run: |
+        stack build ${ARGS} ${FLAGS}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       matrix:
         ghc-ver: [8.8.1, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
-        additional-flags: [ "--flag Agda:cpphs --flag Agda:debug" , "" ]
     env:
       ARGS: "--stack-yaml stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc --fast"
-      FLAGS: "${{ matrix.additional-flags }} --flag Agda:enable-cluster-counting"
+      FLAGS_1: "--flag Agda:enable-cluster-counting --flag Agda:cpphs --flag Agda:debug"
+      FLAGS_2: "--flag Agda:enable-cluster-counting"
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-haskell@v1
@@ -19,8 +19,8 @@ jobs:
         ghc-version: ${{ matrix.ghc-ver }}
     - name: Install dependencies
       run: |
-        echo Build with ${ARGS}
-        stack build ${ARGS} ${FLAGS} --only-dependencies
+        stack build ${ARGS} ${FLAGS_1} --only-dependencies
     - name: Build
       run: |
-        stack build ${ARGS} ${FLAGS}
+        stack build ${ARGS} ${FLAGS_1}
+        stack build ${ARGS} ${FLAGS_2}


### PR DESCRIPTION
GitHub Actions allow **60** concurrent jobs for GitHub Team account. 

I am going to use this to reduce the workload of Travis.