### PR TITLE
[ re #4177 ] Travis overhaul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,9 @@ git:
 
 stages:
   - name: compilation
+    if: NOT (branch =~ /^release-.*/) AND NOT (tag IS present) AND NOT (commit_message =~ complete\s+tests)
   - name: main
+    if: NOT (branch =~ /^release-.*/) AND NOT (tag IS present) AND NOT (commit_message =~ complete\s+tests)
   - name: complete
     if: (branch =~ /^release-.*/) OR (tag IS present) OR (commit_message =~ complete\s+tests)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ jobs:
 
     - &main-job
       stage: main
-      name: "Successful, failing, and compiler tests"
+      name: "Successful and failing tests"
       env:
         GHC_VER=8.8.1
       addons:
@@ -194,10 +194,8 @@ jobs:
       script:
         - stack ${ARGS} exec -- ${MAKE_CMD} succeed
         - stack ${ARGS} exec -- ${MAKE_CMD} fail
-        - stack ${ARGS} exec -- ${MAKE_CMD} compiler-test
       before_cache:
         - mv $HOME/stack.sqlite3.ori ${HOME}/.stack/stack.sqlite3
-
     - <<: *main-job
       name: "Test suites using standard library"
       git:
@@ -206,6 +204,12 @@ jobs:
         - stack ${ARGS} exec -- ${MAKE_CMD} library-test
         - stack ${ARGS} exec -- ${MAKE_CMD} lib-succeed
         - stack ${ARGS} exec -- ${MAKE_CMD} lib-interaction
+    - <<: *main-job
+      name: "Compiler tests and benchmark"
+      git:
+        submodules: true
+      script:
+        - stack ${ARGS} exec -- ${MAKE_CMD} compiler-test
         - stack ${ARGS} exec -- ${MAKE_CMD} stdlib-compiler-test
         - stack ${ARGS} exec -- ${MAKE_CMD} benchmark-without-logs
     - <<: *main-job
@@ -260,15 +264,5 @@ jobs:
       env: GHC_VER=8.4.4 CABAL_VER=2.2
     - <<: *complete-job
       env: GHC_VER=8.2.2 CABAL_VER=2.0
-
-    # Andreas, 2019-11-13, issue #4177, temporarily disable 8.0
-    # - <<: *complete-job
-    #   env: GHC_VER=8.0.2 CABAL_VER=1.24
-    #   addons:
-    #     apt:
-    #       packages:
-    #         - cabal-install-1.24
-    #         - ghc-8.0.2
-    #         - texlive-binaries
-    #       sources:
-    #         - hvr-ghc
+    - <<: *complete-job
+      env: GHC_VER=8.0.2 CABAL_VER=1.24

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,17 +35,12 @@ git:
 ##############################################################################
 # Stages:
 #
-# - Main: Agda is compiled via Cabal and tested, including the test
-#   suite, the benchmark suite, and the compilation with a specific set of
-#   dependencies, the testing of other programs like `hTags`, etc.)
-#
-# - Documentation: User manual and Haddock are compiled.
 
 stages:
+  - name: compilation
   - name: main
-    if: NOT (commit_message =~ main\s+skip|skip\s+main)
-  - name: documentation
-    if: NOT (commit_message =~ doc\s+skip|skip\s+doc)
+  - name: complete
+    if: (branch =~ /^release-.*/) OR (tag IS present) OR (commit_message =~ complete\s+tests)
 
 jobs:
   allow_failures:
@@ -56,81 +51,42 @@ jobs:
   fast_finish: true
 
   include:
-    ##############################################################################
-    # Main stage
-    #
-    # The builds involving the testsuite (60-80min) are run then.
-    - &complete-job
-      stage: main
-      env: GHC_VER=8.8.1 CABAL_VER=2.4
-      addons:
-        apt:
-          packages:
-            - cabal-install-2.4
-            - ghc-8.8.1
-            - texlive-binaries
-          sources:
-            - hvr-ghc
+    - stage: compilation
+      env:
+        GHC_VER=8.8.1
+      cache:
+        directories:
+          - $HOME/.stack
+          - $TRAVIS_BUILD_DIR/.stack-work
+          - $HOME/.local/bin
       before_install:
-        - export PATH=/opt/ghc/$GHC_VER/bin:/opt/cabal/$CABAL_VER/bin:$PATH
-        - export PATH=$HOME/.local/bin:$PATH
-        - export BUILD_DIR=$HOME/dist
-        - export PARALLEL_TESTS=2
-        - export PATH=$HOME/.cabal/bin:$PATH
-        - export PATH=$HOME/texlive/bin/x86_64-linux:$PATH
-          # - export AGDA_HOME=`pwd` this is $TRAVIS_BUILD_DIR
+        # Install ghc
+        - sudo -E apt-add-repository -y "ppa:hvr/ghc"
+        - travis_apt_get_update
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install ghc-${GHC_VER}
+
+        - export PATH=/opt/ghc/$GHC_VER/bin:$PATH
+        - mkdir -p ~/.local/bin && export PATH=$HOME/.local/bin:$PATH
+
+        # Install stack
+        - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+        - export ARGS="--stack-yaml stack-${GHC_VER}.yaml --no-terminal --system-ghc"
+        - export FLAGS="--flag Agda:enable-cluster-counting"
+
+        - echo "*** GHC version ***"     && ghc     --version &&
+          echo "*** Stack version ***"   && stack   --version &&
+          echo "*** Haddock version ***" && haddock --version &&
+          echo "*** Emacs version ***"   && emacs   --version | sed 2q
       install:
-        - .travis/cabal_install
-      ##############################################################################
+        - stack build Agda ${ARGS} ${FLAGS} --test --no-run-tests --only-dependencies
       script:
-        - .travis/cabal_script
+        - stack build Agda ${ARGS} ${FLAGS} --test --no-run-tests
+        # shelltestrunner is used by `make test-size-solver`
+        # we need to cache it first.
+        - stack install shelltestrunner ${ARGS}
 
-    - <<: *complete-job
-      env: GHC_VER=8.6.5 CABAL_VER=2.4
-      addons:
-        apt:
-          packages:
-            - cabal-install-2.4
-            - ghc-8.6.5
-            - texlive-binaries
-          sources:
-            - hvr-ghc
-
-    - <<: *complete-job
-      env: GHC_VER=8.4.4 CABAL_VER=2.2
-      addons:
-        apt:
-          packages:
-            - cabal-install-2.2
-            - ghc-8.4.4
-            - texlive-binaries
-          sources:
-            - hvr-ghc
-
-    - <<: *complete-job
-      env: GHC_VER=8.2.2 CABAL_VER=2.0
-      addons:
-        apt:
-          packages:
-            - cabal-install-2.0
-            - ghc-8.2.2
-            - texlive-binaries
-          sources:
-            - hvr-ghc
-
-    # Andreas, 2019-11-13, issue #4177, temporarily disable 8.0
-    # - <<: *complete-job
-    #   env: GHC_VER=8.0.2 CABAL_VER=1.24
-    #   addons:
-    #     apt:
-    #       packages:
-    #         - cabal-install-1.24
-    #         - ghc-8.0.2
-    #         - texlive-binaries
-    #       sources:
-    #         - hvr-ghc
-
-    - stage: main
+    # Windows environment
+    - stage: compilation
       os: windows
       cache:
         directories:
@@ -138,26 +94,21 @@ jobs:
           - $APPDATA/stack
       language: c
       env:
-        - GHC_VER=8.8.1 ICU_VER=58.2-3
+        GHC_VER=8.8.1
+        ICU_VER=58.2-3
       before_install:
-        - export AGDA_STACK_BUILD_FLAGS="--flag Agda:enable-cluster-counting"
-        - export ARGS="--stack-yaml stack-${GHC_VER}.yaml --no-terminal --system-ghc"
-
         - travis_retry choco install haskell-stack --no-progress
+        - export ARGS="--stack-yaml stack-${GHC_VER}.yaml --no-terminal --system-ghc"
+        - export FLAGS="--flag Agda:enable-cluster-counting"
       install:
         - travis_retry wget -q http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-icu-${ICU_VER}-any.pkg.tar.xz
         - yes | stack --compiler ghc-${GHC_VER} exec -- pacman -U mingw-w64-x86_64-icu-${ICU_VER}-any.pkg.tar.xz
-
         - stack build --compiler ghc-${GHC_VER} text-icu
-        - stack build ${ARGS} --only-dependencies ${AGDA_STACK_BUILD_FLAGS}
+        - stack build ${ARGS} ${FLAGS} --only-dependencies
       script:
-        - travis_wait 35 stack build ${ARGS} ${AGDA_STACK_BUILD_FLAGS} --ghc-options=-O0
+        - stack build ${ARGS} ${FLAGS} --fast
 
-    ##############################################################################
-    # Documentation stage
-    #
-    # Converting the user manual to html and pdf is fast (< 2min).
-    - stage: documentation
+    - stage: compilation
       name: User Manual
       language: python
       python: "3.4"
@@ -178,7 +129,7 @@ jobs:
     # Test documentation: haddock, user-manual.
     # Since `stack haddock` compiles Agda but `cabal haddock` does
     # not, this test is faster using `BUILD=CABAL` [Issue #2188].
-    - stage: documentation
+    - stage: compilation
       name: Haddock
       env: GHC_VER=8.8.1 CABAL_VER=2.4
       addons:
@@ -200,3 +151,124 @@ jobs:
       # Testing Haddock [Issue 1773]
       script:
         - make BUILD_DIR=$BUILD_DIR haddock
+
+    - &main-job
+      stage: main
+      name: "Successful, failing, and compiler tests"
+      env:
+        GHC_VER=8.8.1
+      addons:
+        apt:
+          packages:
+            - ghc-8.8.1
+            - cabal-install-3.0
+            - texlive-binaries
+          sources:
+            - hvr-ghc
+      cache:
+        directories:
+          - $HOME/.stack
+          - ${TRAVIS_BUILD_DIR}/.stack-work
+          - $HOME/.local/bin
+      before_install:
+        # Test suites shouldn't touch global stack packages, so we try to avoid changing its database.
+        - cp ${HOME}/.stack/stack.sqlite3 $HOME/stack.sqlite3.ori
+
+        # Setup ghc & cabal path
+        - export PATH=/opt/ghc/$GHC_VER/bin:$PATH
+        - export PATH=/opt/ghc/$GHC_VER/bin:/opt/cabal/$CABAL_VER/bin:$PATH
+        - export PATH=$HOME/.cabal/bin:$PATH
+        # Install stack
+        - mkdir -p ~/.local/bin && export PATH=$HOME/.local/bin:$PATH
+        - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+        - export PATH=$HOME/.local/bin:$PATH
+        - export PATH=$HOME/texlive/bin/x86_64-linux:$PATH
+
+        - export PARALLEL_TESTS=2
+        - export FLAGS="--flag Agda:enable-cluster-counting"
+        - export ARGS="--stack-yaml stack-${GHC_VER}.yaml --no-terminal --system-ghc"
+        - export AGDA_TESTS_OPTIONS="-j${PARALLEL_TESTS} --hide-successes"
+        - export BUILD_DIR=$(pwd)/$(stack ${ARGS} path --dist-dir)
+        - export MAKE_CMD="make AGDA_TESTS_OPTIONS=${ARGA_TESTS_OPTIONS} TASTY_ANSI_TRICKS=false BUILD_DIR=$BUILD_DIR"
+      ##############################################################################
+      script:
+        - stack ${ARGS} exec -- ${MAKE_CMD} succeed
+        - stack ${ARGS} exec -- ${MAKE_CMD} fail
+        - stack ${ARGS} exec -- ${MAKE_CMD} compiler-test
+      before_cache:
+        - mv $HOME/stack.sqlite3.ori ${HOME}/.stack/stack.sqlite3
+
+    - <<: *main-job
+      name: "Test suites using standard library"
+      git:
+        submodules: true
+      script:
+        - stack ${ARGS} exec -- ${MAKE_CMD} library-test
+        - stack ${ARGS} exec -- ${MAKE_CMD} lib-succeed
+        - stack ${ARGS} exec -- ${MAKE_CMD} lib-interaction
+        - stack ${ARGS} exec -- ${MAKE_CMD} stdlib-compiler-test
+        - stack ${ARGS} exec -- ${MAKE_CMD} benchmark-without-logs
+    - <<: *main-job
+      name: "Other test suites"
+      script:
+        - stack ${ARGS} exec -- ${MAKE_CMD} interaction
+        - stack ${ARGS} exec -- ${MAKE_CMD} interactive
+        - stack ${ARGS} exec -- ${MAKE_CMD} DONT_RUN_LATEX="Y" latex-html-test
+        - stack ${ARGS} exec -- ${MAKE_CMD} examples
+        - stack ${ARGS} exec -- ${MAKE_CMD} api-test
+        - stack ${ARGS} exec -- ${MAKE_CMD} user-manual-test
+        - stack ${ARGS} exec -- ${MAKE_CMD} internal-tests
+        - stack ${ARGS} exec -- ${MAKE_CMD} testing-emacs-mode
+
+        - travis_retry cabal v1-update
+        - make TAGS
+
+        # Build & install size-solver
+        - stack build ${ARGS} ${FLAGS} size-solver
+        - mkdir -p src/size-solver/dist/build/size-solver
+        - cp $(stack path ${ARGS} --local-install-root)/bin/size-solver src/size-solver/dist/build/size-solver/size-solver
+        # Test size-solver
+        - make -C src/size-solver/ test
+
+        # Build agda-bisect
+        - make install-agda-bisect
+
+    - &complete-job
+      stage: complete
+      env: GHC_VER=8.8.1 CABAL_VER=2.4
+      before_install:
+        - sudo -E apt-add-repository -y "ppa:hvr/ghc"
+        - travis_apt_get_update
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install ghc-${GHC_VER} cabal-install-${CABAL_VER}
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install texlive-binaries
+
+        - export PATH=/opt/ghc/$GHC_VER/bin:/opt/cabal/$CABAL_VER/bin:$PATH
+        - export PATH=$HOME/.local/bin:$PATH
+        - export BUILD_DIR=$HOME/dist
+        - export PARALLEL_TESTS=2
+        - export PATH=$HOME/.cabal/bin:$PATH
+        - export PATH=$HOME/texlive/bin/x86_64-linux:$PATH
+          # - export AGDA_HOME=`pwd` this is $TRAVIS_BUILD_DIR
+      install:
+        - .travis/cabal_install
+      ##############################################################################
+      script:
+        - .travis/cabal_script
+    - <<: *complete-job
+      env: GHC_VER=8.6.5 CABAL_VER=2.4
+    - <<: *complete-job
+      env: GHC_VER=8.4.4 CABAL_VER=2.2
+    - <<: *complete-job
+      env: GHC_VER=8.2.2 CABAL_VER=2.0
+
+    # Andreas, 2019-11-13, issue #4177, temporarily disable 8.0
+    # - <<: *complete-job
+    #   env: GHC_VER=8.0.2 CABAL_VER=1.24
+    #   addons:
+    #     apt:
+    #       packages:
+    #         - cabal-install-1.24
+    #         - ghc-8.0.2
+    #         - texlive-binaries
+    #       sources:
+    #         - hvr-ghc

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ CABAL_INSTALL           = $(CABAL_INSTALL_HELPER) \
 # The following options are used in several invocations of cabal
 # install/configure below. They are always the last options given to
 # the command.
-CABAL_INSTALL_OPTS = -fenable-cluster-counting $(CABAL_OPTS)
+CABAL_INSTALL_OPTS = -fenable-cluster-counting --ghc-options="+RTS -M4G -RTS" $(CABAL_OPTS)
 
 CABAL_INSTALL_BIN_OPTS = --disable-library-profiling \
                          $(CABAL_INSTALL_OPTS)
@@ -399,7 +399,7 @@ testing-emacs-mode:
 
 ## Clean ##################################################################
 
-clean_helper = if [ -d $(1) ]; then $(CABAL_CMD) clean --builddir=$(1); fi;
+clean_helper = if [ -d $(1) ]; then $(CABAL_CMD) $(CABAL_CLEAN_CMD) --builddir=$(1); fi;
 
 
 .PHONY : clean
@@ -458,7 +458,7 @@ install-agda-bisect :
 	@echo "======================================================================"
 	@echo "============== Installing the agda-bisect program ===================="
 	@echo "======================================================================"
-	cd src/agda-bisect && $(CABAL_CMD) install
+	cd src/agda-bisect && $(CABAL_CMD) $(CABAL_INSTALL_CMD)
 
 ###########################################################################
 # HPC

--- a/stack-8.8.1.yaml
+++ b/stack-8.8.1.yaml
@@ -49,6 +49,48 @@ extra-deps:
 - old-locale-1.0.0.7
 - old-time-1.1.0.3
 - polyparse-1.13
+# The following packages are used for testing
+- polyparse-1.13
+- QuickCheck-2.13.2
+- filemanip-0.3.6.3
+- process-extras-0.7.4
+- tasty-1.2.3
+- tasty-hunit-0.10.0.2
+- tasty-quickcheck-0.10.1
+- tasty-silver-3.1.13
+- temporary-1.3
+- unix-compat-0.5.2
+- ListLike-4.6.2
+- ansi-terminal-0.10.1
+- call-stack-0.2.0
+- clock-0.8
+- data-default-0.7.1.1
+- generic-deriving-1.13
+- optparse-applicative-0.15.1.0
+- semigroups-0.19.1
+- splitmix-0.0.3
+- unbounded-delays-0.1.1.0
+- wcwidth-0.0.2
+- ansi-wl-pprint-0.6.9
+- colour-2.3.5
+- data-default-class-0.1.2.0
+- data-default-instances-containers-0.0.1
+- data-default-instances-dlist-0.0.1
+- data-default-instances-old-locale-0.0.1
+- fmlist-0.9.3
+# The following packages are used to install shelltestrunner only
+- Diff-0.4.0
+- HUnit-1.6.0.0
+- cmdargs-0.10.20
+- pretty-show-1.9.5
+- safe-0.3.17
+- test-framework-0.8.2.0
+- test-framework-hunit-0.3.0.2
+- extensible-exceptions-0.1.1.4
+- haskell-lexer-1.0.2
+- hostname-1.0
+- regex-posix-0.96.0.0
+- xml-1.3.14
 
 flags:
   transformers-compat:
@@ -57,3 +99,4 @@ flags:
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
+- 'src/size-solver'

--- a/stack-8.8.1.yaml
+++ b/stack-8.8.1.yaml
@@ -50,7 +50,6 @@ extra-deps:
 - old-time-1.1.0.3
 - polyparse-1.13
 # The following packages are used for testing
-- polyparse-1.13
 - QuickCheck-2.13.2
 - filemanip-0.3.6.3
 - process-extras-0.7.4


### PR DESCRIPTION
Since GH Actions only allows 2GB for cache in total, Travis is only used to compile Agda with the latest GHC and to run the test suites in parallel (via caching). The compilation test with various GHC versions and flags has been moved to GH Actions.