### PR TITLE
Allow tactic modality on record fields (#4124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,19 @@ Language
   example₂ : (depth : Nat) {@(tactic search depth) x : A} → B
   ```
 
+  Record fields can also be annotated with a tactic, allowing them to be
+  omitted in constructor applications, record constructions and co-pattern
+  matches:
+
+  ```agda
+  record Example : Set where
+    constructor mkExample
+    field x : A
+          @(tactic solveP x) {y} : P x
+  ```
+
+  where `solveP : (x : A) → Term → TC ⊤` is a tactic that tries to prove `P x`.
+
 * The legacy reflection framework using `quoteGoal` and `quoteContext` has been
   removed.
 

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -619,6 +619,25 @@ For instance,
   test-g : g 4 ≡ 8
   test-g = refl
 
+Record fields can also be annotated with a tactic, allowing them to be
+omitted in constructor applications, record constructions and co-pattern
+matches::
+
+  record Bools : Set where
+    constructor mkBools
+    field fst : Bool
+          @(tactic defaultTo fst) {snd} : Bool
+  open Bools
+
+  tt₀ tt₁ tt₂ tt₃ : Bools
+  tt₀ = mkBools true {true}
+  tt₁ = mkBools true
+  tt₂ = record{ fst = true }
+  tt₃ .fst = true
+
+  test-tt : tt₁ ∷ tt₂ ∷ tt₃ ∷ [] ≡ tt₀ ∷ tt₀ ∷ tt₀ ∷ []
+  test-tt = refl
+
 Unquoting Declarations
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/full/Agda/Auto/Convert.hs
+++ b/src/full/Agda/Auto/Convert.hs
@@ -137,7 +137,7 @@ tomy imi icns typs = do
        let Datatype [con] [] = cdcont cc
        lift $ liftIO $ modifyIORef con (\cdef -> cdef {cdtype = contyp'})
 
-       projfcns <- mapM (\name -> getConst False name TMAll) (map Cm.unArg fields)
+       projfcns <- mapM (\name -> getConst False name TMAll) (map I.unDom fields)
 
        return (Datatype [con] projfcns, []{-map snd fields-})
       MB.Constructor {MB.conData = dt} -> do

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -29,7 +29,7 @@ import Agda.Syntax.Abstract.Name
     mnameToList, qnameName, qnameModule, nameId )
 import Agda.Syntax.Internal
   ( Name, Type
-  , arity, nameFixity )
+  , arity, nameFixity, unDom )
 import Agda.Syntax.Literal ( Literal(..) )
 import Agda.Syntax.Fixity
 import qualified Agda.Syntax.Treeless as T
@@ -330,7 +330,7 @@ definition' kit q d t ls = do
             ( (last ls , Lambda 1
                  (Apply (Lookup (Local (LocalId 0)) (last ls))
                    [ Local (LocalId (np - i)) | i <- [0 .. np-1] ]))
-            : (zip [ jsMember (qnameName (unArg fld)) | fld <- flds ]
+            : (zip [ jsMember (qnameName (unDom fld)) | fld <- flds ]
                  [ Local (LocalId (np - i)) | i <- [1 .. np] ])))))
         _ ->
           ret (curriedLambda (np + 1)

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1087,8 +1087,8 @@ introTactic pmLambda ii = do
     introRec d = do
       hfs <- getRecordFieldNames d
       fs <- ifM showImplicitArguments
-            (return $ map unArg hfs)
-            (return [ unArg a | a <- hfs, visible a ])
+            (return $ map unDom hfs)
+            (return [ unDom a | a <- hfs, visible a ])
       let e = C.Rec noRange $ for fs $ \ f ->
             Left $ C.FieldAssignment f $ C.QuestionMark noRange Nothing
       return [ prettyShow e ]
@@ -1210,7 +1210,7 @@ getRecordContents norm ce = do
   (q, vs, defn) <- fromMaybeM notRecordType $ isRecordType t
   case defn of
     Record{ recFields = fs, recTel = rtel } -> do
-      let xs   = map (nameConcrete . qnameName . unArg) fs
+      let xs   = map (nameConcrete . qnameName . unDom) fs
           tel  = apply rtel vs
           doms = flattenTel tel
       -- Andreas, 2019-04-10, issue #3687: use flattenTel

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -449,7 +449,7 @@ makeAbsurdClause f ell (SClause tel sps _ _ t) = do
     -- Contract implicit record patterns before printing.
     -- c <- translateRecordPatterns $ Clause noRange tel perm ps NoBody t False
     -- Jesper, 2015-09-19 Don't contract, since we do on-demand splitting
-    let c = Clause noRange noRange tel ps Nothing t False Nothing ell
+    let c = Clause noRange noRange tel ps Nothing (argFromDom <$> t) False Nothing ell
     -- Normalise the dot patterns
     ps <- addContext tel $ normalise $ namedClausePats c
     reportSDoc "interaction.case" 60 $ "normalized patterns: " <+> prettyTCMPatternList ps

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -189,6 +189,8 @@ data Declaration
   | ScopedDecl ScopeInfo [Declaration]  -- ^ scope annotation
   deriving (Data, Show)
 
+type DefInfo = DefInfo' Expr
+
 type ImportDirective = ImportDirective' QName ModuleName
 type Renaming        = Renaming'        QName ModuleName
 type ImportedName    = ImportedName'    QName ModuleName

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -27,6 +27,7 @@ module Agda.Syntax.Concrete
   , FieldAssignment, FieldAssignment'(..), nameFieldA, exprFieldA
   , ModuleAssignment(..)
   , BoundName(..), mkBoundName_, mkBoundName
+  , TacticAttribute
   , Telescope -- (..)
   , countTelVars
   , lamBindingsToTelescope
@@ -231,9 +232,11 @@ data LamBinding' a
 data BoundName = BName
   { boundName   :: Name
   , bnameFixity :: Fixity'
-  , bnameTactic :: Maybe Expr   -- From @tactic attribute
+  , bnameTactic :: TacticAttribute -- From @tactic attribute
   }
   deriving (Data, Eq)
+
+type TacticAttribute = Maybe Expr
 
 mkBoundName_ :: Name -> BoundName
 mkBoundName_ x = mkBoundName x noFixity'
@@ -380,8 +383,8 @@ type TypeSignatureOrInstanceBlock = Declaration
 -}
 
 data Declaration
-  = TypeSig ArgInfo Name Expr
-  | FieldSig IsInstance Name (Arg Expr)
+  = TypeSig ArgInfo TacticAttribute Name Expr
+  | FieldSig IsInstance TacticAttribute Name (Arg Expr)
   -- ^ Axioms and functions can be irrelevant. (Hiding should be NotHidden)
   | Generalize Range [TypeSignature] -- ^ Variables to be generalized, can be hidden and/or irrelevant.
   | Field Range [FieldSignature]
@@ -738,8 +741,8 @@ instance HasRange ModuleAssignment where
   getRange (ModuleAssignment a b c) = fuseRange a b `fuseRange` c
 
 instance HasRange Declaration where
-  getRange (TypeSig _ x t)         = fuseRange x t
-  getRange (FieldSig _ x t)        = fuseRange x t
+  getRange (TypeSig _ _ x t)       = fuseRange x t
+  getRange (FieldSig _ _ x t)      = fuseRange x t
   getRange (Field r _)             = r
   getRange (FunClause lhs rhs wh _) = fuseRange lhs rhs `fuseRange` wh
   getRange (DataSig r _ _ _ _)     = r
@@ -875,8 +878,8 @@ instance KillRange BoundName where
   killRange (BName n f t) = killRange3 BName n f t
 
 instance KillRange Declaration where
-  killRange (TypeSig i n e)         = killRange2 (TypeSig i) n e
-  killRange (FieldSig i n e)        = killRange3 FieldSig i n e
+  killRange (TypeSig i t n e)       = killRange3 (TypeSig i) t n e
+  killRange (FieldSig i t n e)      = killRange4 FieldSig i t n e
   killRange (Generalize r ds )      = killRange1 (Generalize noRange) ds
   killRange (Field r fs)            = killRange1 (Field noRange) fs
   killRange (FunClause l r w ca)    = killRange4 FunClause l r w ca
@@ -1087,8 +1090,8 @@ instance NFData Pattern where
 -- | Ranges are not forced.
 
 instance NFData Declaration where
-  rnf (TypeSig a b c)         = rnf a `seq` rnf b `seq` rnf c
-  rnf (FieldSig a b c)        = rnf a `seq` rnf b `seq` rnf c
+  rnf (TypeSig a b c d)       = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
+  rnf (FieldSig a b c d)      = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
   rnf (Generalize _ a)        = rnf a
   rnf (Field _ fs)            = rnf fs
   rnf (FunClause a b c d)     = rnf a `seq` rnf b `seq` rnf c `seq` rnf d

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -118,7 +118,7 @@ data NiceDeclaration
       --
       --   'ArgInfo' argument: Axioms and functions can be declared irrelevant.
       --   ('Hiding' should be 'NotHidden'.)
-  | NiceField Range Access IsAbstract IsInstance Name (Arg Expr)
+  | NiceField Range Access IsAbstract IsInstance TacticAttribute Name (Arg Expr)
   | PrimitiveFunction Range Access IsAbstract Name Expr
   | NiceMutual Range TerminationCheck CoverageCheck PositivityCheck [NiceDeclaration]
   | NiceModule Range Access IsAbstract QName Telescope [Declaration]
@@ -143,7 +143,7 @@ data NiceDeclaration
   | NiceRecDef Range Origin IsAbstract PositivityCheck UniverseCheck Name (Maybe (Ranged Induction)) (Maybe HasEta)
            (Maybe (Name, IsInstance)) [LamBinding] [Declaration]
   | NicePatternSyn Range Access Name [Arg Name] Pattern
-  | NiceGeneralize Range Access ArgInfo Name Expr
+  | NiceGeneralize Range Access ArgInfo TacticAttribute Name Expr
   | NiceUnquoteDecl Range Access IsAbstract IsInstance TerminationCheck CoverageCheck [Name] Expr
   | NiceUnquoteDef Range Access IsAbstract TerminationCheck CoverageCheck [Name] Expr
   deriving (Data, Show)
@@ -315,7 +315,7 @@ instance HasRange DeclarationWarning where
 
 instance HasRange NiceDeclaration where
   getRange (Axiom r _ _ _ _ _ _)           = r
-  getRange (NiceField r _ _ _ _ _)         = r
+  getRange (NiceField r _ _ _ _ _ _)       = r
   getRange (NiceMutual r _ _ _ _)          = r
   getRange (NiceModule r _ _ _ _ _ )       = r
   getRange (NiceModuleMacro r _ _ _ _ _)   = r
@@ -330,7 +330,7 @@ instance HasRange NiceDeclaration where
   getRange (NiceRecSig r _ _ _ _ _ _ _)    = r
   getRange (NiceDataSig r _ _ _ _ _ _ _)   = r
   getRange (NicePatternSyn r _ _ _ _)      = r
-  getRange (NiceGeneralize r _ _ _ _)      = r
+  getRange (NiceGeneralize r _ _ _ _ _)    = r
   getRange (NiceFunClause r _ _ _ _ _ _)   = r
   getRange (NiceUnquoteDecl r _ _ _ _ _ _ _) = r
   getRange (NiceUnquoteDef r _ _ _ _ _ _)    = r
@@ -338,7 +338,7 @@ instance HasRange NiceDeclaration where
 instance Pretty NiceDeclaration where
   pretty = \case
     Axiom _ _ _ _ _ x _            -> text "postulate" <+> pretty x <+> colon <+> text "_"
-    NiceField _ _ _ _ x _          -> text "field" <+> pretty x
+    NiceField _ _ _ _ _ x _        -> text "field" <+> pretty x
     PrimitiveFunction _ _ _ x _    -> text "primitive" <+> pretty x
     NiceMutual{}                   -> text "mutual"
     NiceModule _ _ _ x _ _         -> text "module" <+> pretty x <+> text "where"
@@ -354,7 +354,7 @@ instance Pretty NiceDeclaration where
     NiceDataDef _ _ _ _ _ x _ _    -> text "data" <+> pretty x <+> text "where"
     NiceRecDef _ _ _ _ _ x _ _ _ _ _   -> text "record" <+> pretty x <+> text "where"
     NicePatternSyn _ _ x _ _       -> text "pattern" <+> pretty x
-    NiceGeneralize _ _ _ x _       -> text "variable" <+> pretty x
+    NiceGeneralize _ _ _ _ x _     -> text "variable" <+> pretty x
     NiceUnquoteDecl _ _ _ _ _ _ xs _ -> text "<unquote declarations>"
     NiceUnquoteDef _ _ _ _ _ xs _    -> text "<unquote definitions>"
 
@@ -923,7 +923,7 @@ niceDeclarations fixs ds = do
 
       case d of
 
-        TypeSig info x t -> do
+        TypeSig info _tac x t -> do
           termCheck <- use terminationCheckPragma
           covCheck  <- use coverageCheckPragma
           let r = getRange d
@@ -937,8 +937,8 @@ niceDeclarations fixs ds = do
         Generalize r [] -> justWarning $ EmptyGeneralize r
         Generalize r sigs -> do
           gs <- forM sigs $ \case
-            sig@(TypeSig info x t) -> do
-              return $ NiceGeneralize (getRange sig) PublicAccess info x t
+            sig@(TypeSig info tac x t) -> do
+              return $ NiceGeneralize (getRange sig) PublicAccess info tac x t
             _ -> __IMPOSSIBLE__
           return (gs, ds)
 
@@ -1289,10 +1289,10 @@ niceDeclarations fixs ds = do
 
     niceAxiom :: KindOfBlock -> TypeSignatureOrInstanceBlock -> Nice [NiceDeclaration]
     niceAxiom b d = case d of
-      TypeSig rel x t -> do
+      TypeSig rel _tac x t -> do
         return [ Axiom (getRange d) PublicAccess ConcreteDef NotInstanceDef rel x t ]
-      FieldSig i x argt | b == FieldBlock -> do
-        return [ NiceField (getRange d) PublicAccess ConcreteDef i x argt ]
+      FieldSig i tac x argt | b == FieldBlock -> do
+        return [ NiceField (getRange d) PublicAccess ConcreteDef i tac x argt ]
       InstanceB r decls -> do
         instanceBlock r =<< niceAxioms InstanceBlock decls
       Pragma p@(RewritePragma r _) -> do
@@ -1727,7 +1727,7 @@ instance MakeAbstract NiceDeclaration where
       FunSig r p a i m rel tc cc x e -> return $ FunSig            r p AbstractDef i m rel tc cc x e
       NiceRecSig r p a pc uc x ls t  -> return $ NiceRecSig        r p AbstractDef pc uc x ls t
       NiceDataSig r p a pc uc x ls t -> return $ NiceDataSig       r p AbstractDef pc uc x ls t
-      NiceField r p _ i x e          -> return $ NiceField         r p AbstractDef i x e
+      NiceField r p _ i tac x e      -> return $ NiceField         r p AbstractDef i tac x e
       PrimitiveFunction r p _ x e    -> return $ PrimitiveFunction r p AbstractDef x e
       -- Andreas, 2016-07-17 it does have effect on unquoted defs.
       -- Need to set updater state to dirty!
@@ -1782,20 +1782,20 @@ instance MakePrivate Access where
 
 instance MakePrivate NiceDeclaration where
   mkPrivate o = \case
-      Axiom r p a i rel x e                    -> (\ p -> Axiom r p a i rel x e)                    <$> mkPrivate o p
-      NiceField r p a i x e                    -> (\ p -> NiceField r p a i x e)                    <$> mkPrivate o p
-      PrimitiveFunction r p a x e              -> (\ p -> PrimitiveFunction r p a x e)              <$> mkPrivate o p
-      NiceMutual r tc cc pc ds                 -> (\ ds-> NiceMutual r tc cc pc ds)                 <$> mkPrivate o ds
-      NiceModule r p a x tel ds                -> (\ p -> NiceModule r p a x tel ds)                <$> mkPrivate o p
-      NiceModuleMacro r p x ma op is           -> (\ p -> NiceModuleMacro r p x ma op is)           <$> mkPrivate o p
-      FunSig r p a i m rel tc cc x e           -> (\ p -> FunSig r p a i m rel tc cc x e)              <$> mkPrivate o p
-      NiceRecSig r p a pc uc x ls t            -> (\ p -> NiceRecSig r p a pc uc x ls t)            <$> mkPrivate o p
-      NiceDataSig r p a pc uc x ls t           -> (\ p -> NiceDataSig r p a pc uc x ls t)           <$> mkPrivate o p
+      Axiom r p a i rel x e                    -> (\ p -> Axiom r p a i rel x e)                <$> mkPrivate o p
+      NiceField r p a i tac x e                -> (\ p -> NiceField r p a i tac x e)            <$> mkPrivate o p
+      PrimitiveFunction r p a x e              -> (\ p -> PrimitiveFunction r p a x e)          <$> mkPrivate o p
+      NiceMutual r tc cc pc ds                 -> (\ ds-> NiceMutual r tc cc pc ds)             <$> mkPrivate o ds
+      NiceModule r p a x tel ds                -> (\ p -> NiceModule r p a x tel ds)            <$> mkPrivate o p
+      NiceModuleMacro r p x ma op is           -> (\ p -> NiceModuleMacro r p x ma op is)       <$> mkPrivate o p
+      FunSig r p a i m rel tc cc x e           -> (\ p -> FunSig r p a i m rel tc cc x e)       <$> mkPrivate o p
+      NiceRecSig r p a pc uc x ls t            -> (\ p -> NiceRecSig r p a pc uc x ls t)        <$> mkPrivate o p
+      NiceDataSig r p a pc uc x ls t           -> (\ p -> NiceDataSig r p a pc uc x ls t)       <$> mkPrivate o p
       NiceFunClause r p a tc cc catchall d     -> (\ p -> NiceFunClause r p a tc cc catchall d) <$> mkPrivate o p
-      NiceUnquoteDecl r p a i tc cc x e        -> (\ p -> NiceUnquoteDecl r p a i tc cc x e)            <$> mkPrivate o p
-      NiceUnquoteDef r p a tc cc x e           -> (\ p -> NiceUnquoteDef r p a tc cc x e)               <$> mkPrivate o p
-      NicePatternSyn r p x xs p'               -> (\ p -> NicePatternSyn r p x xs p')               <$> mkPrivate o p
-      NiceGeneralize r p i x t                 -> (\ p -> NiceGeneralize r p i x t)                 <$> mkPrivate o p
+      NiceUnquoteDecl r p a i tc cc x e        -> (\ p -> NiceUnquoteDecl r p a i tc cc x e)    <$> mkPrivate o p
+      NiceUnquoteDef r p a tc cc x e           -> (\ p -> NiceUnquoteDef r p a tc cc x e)       <$> mkPrivate o p
+      NicePatternSyn r p x xs p'               -> (\ p -> NicePatternSyn r p x xs p')           <$> mkPrivate o p
+      NiceGeneralize r p i tac x t             -> (\ p -> NiceGeneralize r p i tac x t)         <$> mkPrivate o p
       d@NicePragma{}                           -> return d
       d@(NiceOpen _ _ directives)              -> do
         whenJust (publicOpen directives) $ lift . niceWarning . OpenPublicPrivate
@@ -1829,9 +1829,9 @@ instance MakePrivate WhereClause where
 -- 'Declaration's.
 notSoNiceDeclarations :: NiceDeclaration -> [Declaration]
 notSoNiceDeclarations = \case
-    Axiom _ _ _ i rel x e          -> inst i [TypeSig rel x e]
-    NiceField _ _ _ i x argt       -> [FieldSig i x argt]
-    PrimitiveFunction r _ _ x e    -> [Primitive r [TypeSig defaultArgInfo x e]]
+    Axiom _ _ _ i rel x e          -> inst i [TypeSig rel Nothing x e]
+    NiceField _ _ _ i tac x argt   -> [FieldSig i tac x argt]
+    PrimitiveFunction r _ _ x e    -> [Primitive r [TypeSig defaultArgInfo Nothing x e]]
     NiceMutual r _ _ _ ds          -> [Mutual r $ concatMap notSoNiceDeclarations ds]
     NiceModule r _ _ x tel ds      -> [Module r x tel ds]
     NiceModuleMacro r _ x ma o dir -> [ModuleMacro r x ma o dir]
@@ -1841,12 +1841,12 @@ notSoNiceDeclarations = \case
     NiceRecSig r _ _ _ _ x bs e    -> [RecordSig r x bs e]
     NiceDataSig r _ _ _ _ x bs e   -> [DataSig r Inductive x bs e]
     NiceFunClause _ _ _ _ _ _ d    -> [d]
-    FunSig _ _ _ i _ rel _ _ x e   -> inst i [TypeSig rel x e]
+    FunSig _ _ _ i _ rel _ _ x e   -> inst i [TypeSig rel Nothing x e]
     FunDef _ ds _ _ _ _ _ _        -> ds
     NiceDataDef r _ _ _ _ x bs cs  -> [DataDef r Inductive x bs $ concatMap notSoNiceDeclarations cs]
     NiceRecDef r _ _ _ _ x i e c bs ds -> [RecordDef r x i e c bs ds]
     NicePatternSyn r _ n as p      -> [PatternSyn r n as p]
-    NiceGeneralize r _ i n e       -> [Generalize r [TypeSig i n e]]
+    NiceGeneralize r _ i tac n e   -> [Generalize r [TypeSig i tac n e]]
     NiceUnquoteDecl r _ _ i _ _ x e -> inst i [UnquoteDecl r x e]
     NiceUnquoteDef r _ _ _ _ x e    -> [UnquoteDef r x e]
   where
@@ -1857,7 +1857,7 @@ notSoNiceDeclarations = \case
 niceHasAbstract :: NiceDeclaration -> Maybe IsAbstract
 niceHasAbstract = \case
     Axiom{}                       -> Nothing
-    NiceField _ _ a _ _ _         -> Just a
+    NiceField _ _ a _ _ _ _       -> Just a
     PrimitiveFunction _ _ a _ _   -> Just a
     NiceMutual{}                  -> Nothing
     NiceModule _ _ a _ _ _        -> Just a

--- a/src/full/Agda/Syntax/Concrete/Fixity.hs
+++ b/src/full/Agda/Syntax/Concrete/Fixity.hs
@@ -204,8 +204,8 @@ declaresName x = declaresNames [x]
 --   i.e., do not go into modules.
 declaredNames :: Declaration -> DeclaredNames
 declaredNames d = case d of
-  TypeSig _ x _        -> declaresName x
-  FieldSig _ x _       -> declaresName x
+  TypeSig _ _ x _      -> declaresName x
+  FieldSig _ _ x _     -> declaresName x
   Field _ fs           -> foldMap declaredNames fs
   FunClause (LHS p [] [] _) _ _ _
     | IdentP (QName x) <- removeSingletonRawAppP p

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -204,8 +204,8 @@ instance ExprLike ModuleApplication where
 
 instance ExprLike Declaration where
   mapExpr f = \case
-     TypeSig ai x e            -> TypeSig ai x                         $ mapE e
-     FieldSig i n e            -> FieldSig i n                         $ mapE e
+     TypeSig ai t x e          -> TypeSig ai (mapE t) x (mapE e)
+     FieldSig i t n e          -> FieldSig i (mapE t) n (mapE e)
      Field r fs                -> Field r                              $ map (mapExpr f) fs
      FunClause lhs rhs wh ca   -> FunClause (mapE lhs) (mapE rhs) (mapE wh) (mapE ca)
      DataSig r ind x bs e      -> DataSig r ind x (mapE bs)            $ mapE e

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -169,8 +169,11 @@ prettyCohesion a d =
   if render d == "_" then d else pretty (getCohesion a) <+> d
 
 prettyTactic :: BoundName -> Doc -> Doc
-prettyTactic BName{ bnameTactic = Nothing } d = d
-prettyTactic BName{ bnameTactic = Just t }  d = "@" <> (parens ("tactic" <+> pretty t) <+> d)
+prettyTactic = prettyTactic' . bnameTactic
+
+prettyTactic' :: TacticAttribute -> Doc -> Doc
+prettyTactic' Nothing  d = d
+prettyTactic' (Just t) d = "@" <> (parens ("tactic" <+> pretty t) <+> d)
 
 instance (Pretty a, Pretty b) => Pretty (a, b) where
     pretty (a, b) = parens $ (pretty a <> comma) <+> pretty b
@@ -446,15 +449,15 @@ instance Pretty Declaration where
     prettyList = vcat . map pretty
     pretty d =
         case d of
-            TypeSig i x e ->
-                sep [ prettyRelevance i $ prettyCohesion i $ prettyQuantity i $ pretty x <+> ":"
+            TypeSig i tac x e ->
+                sep [ prettyTactic' tac $ prettyRelevance i $ prettyCohesion i $ prettyQuantity i $ pretty x <+> ":"
                     , nest 2 $ pretty e
                     ]
 
-            FieldSig inst x (Arg i e) ->
+            FieldSig inst tac x (Arg i e) ->
                 mkInst inst $ mkOverlap i $
                 prettyRelevance i $ prettyHiding i id $ prettyCohesion i $ prettyQuantity i $
-                pretty $ TypeSig (setRelevance Relevant i) x e
+                pretty $ TypeSig (setRelevance Relevant i) tac x e
 
                 where
 

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1426,6 +1426,12 @@ instance Pretty Term where
       pApp d els = mparens (not (null els) && p > 9) $
                    sep [d, nest 2 $ fsep (map (prettyPrec 10) els)]
 
+instance (Pretty t, Pretty e) => Pretty (Dom' t e) where
+  pretty dom = pTac <+> pDom dom (pretty $ unDom dom)
+    where
+      pTac | Just t <- domTactic dom = "@" <> parens ("tactic" <+> pretty t)
+           | otherwise               = empty
+
 pDom :: LensHiding a => a -> Doc -> Doc
 pDom i =
   case getHiding i of

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -460,7 +460,7 @@ reifyTerm expandAnonDefs0 v0 = do
           r  <- getConstructorData x
           xs <- fromMaybe __IMPOSSIBLE__ <$> getRecordFieldNames_ r
           vs <- map unArg <$> reify (fromMaybe __IMPOSSIBLE__ $ allApplyElims vs)
-          return $ A.Rec noExprInfo $ map (Left . uncurry FieldAssignment . mapFst unArg) $ filter keep $ zip xs vs
+          return $ A.Rec noExprInfo $ map (Left . uncurry FieldAssignment . mapFst unDom) $ filter keep $ zip xs vs
         False -> reifyDisplayForm x vs $ do
           def <- getConstInfo x
           let Constructor{conPars = np} = theDef def
@@ -1212,7 +1212,7 @@ tryRecPFromConP p = do
             unless (length fs == length ps) __IMPOSSIBLE__
             return $ A.RecP patNoRange $ zipWith mkFA fs ps
         where
-          mkFA ax nap = FieldAssignment (unArg ax) (namedArg nap)
+          mkFA ax nap = FieldAssignment (unDom ax) (namedArg nap)
     _ -> __IMPOSSIBLE__
 
 instance Reify (QNamed I.Clause) A.Clause where

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1057,7 +1057,7 @@ compareProj d d'
           def <- theDef <$> getConstInfo r
           case def of
             Record{ recFields = fs } -> do
-              fs <- return $ map unArg fs
+              fs <- return $ map unDom fs
               case (List.find (d==) fs, List.find (d'==) fs) of
                 (Just i, Just i')
                   -- earlier field is smaller

--- a/src/full/Agda/TypeChecking/Datatypes.hs
+++ b/src/full/Agda/TypeChecking/Datatypes.hs
@@ -156,7 +156,7 @@ getFullyAppliedConType c t = do
 
 data ConstructorInfo
   = DataCon Nat                  -- ^ Arity.
-  | RecordCon HasEta [Arg QName] -- ^ List of field names.
+  | RecordCon HasEta [Dom QName] -- ^ List of field names.
 
 -- | Return the number of non-parameter arguments to a data constructor,
 --   or the field names of a record constructor.

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -693,16 +693,16 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
   current <- currentModule
   let freshQName s = qualify current <$> freshName_ (s :: String)
       mkFieldName  = freshQName . (generalizedFieldName ++) <=< getMetaNameSuggestion
-  genRecFields <- mapM (defaultArg <.> mkFieldName) sortedMetas
+  genRecFields <- mapM (defaultDom <.> mkFieldName) sortedMetas
   genRecName   <- freshQName "GeneralizeTel"
   genRecCon    <- freshQName "mkGeneralizeTel" <&> \ con -> ConHead
                   { conName      = con
                   , conInductive = Inductive
-                  , conFields    = genRecFields }
+                  , conFields    = map argFromDom genRecFields }
   forM_ (zip sortedMetas genRecFields) $ \ (meta, fld) -> do
     fieldTy <- getMetaType meta
-    let field = unArg fld
-    addConstant field $ defaultDefn (argInfo fld) field fieldTy $
+    let field = unDom fld
+    addConstant field $ defaultDefn (getArgInfo fld) field fieldTy $
       let proj = Projection { projProper   = Just genRecName
                             , projOrig     = field
                             , projFromType = defaultArg genRecName
@@ -756,7 +756,7 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
   args <- getContextArgs
   let genRecTy = El genRecSort $ Def genRecName $ map Apply args
   noConstraints $ equalType genRecTy genRecMeta
-  return (genRecName, genRecCon, map unArg genRecFields)
+  return (genRecName, genRecCon, map unDom genRecFields)
 
 -- | Once we have the generalized telescope we can fill in the missing details of the record type.
 fillInGenRecordDetails :: QName -> ConHead -> [QName] -> Type -> Telescope -> TCM ()

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1336,7 +1336,7 @@ inverseSubst args = map (mapFst unArg) <$> loop (zip args terms)
               , length fs == length es
               , hasQuantity0 info || all usableQuantity fs     -- Andreas, 2019-11-12/17, issue #4168b
               , irrProj || all isRelevant fs -> do
-                let aux (Arg _ v) (Arg info' f) = (Arg ai v,) $ t `applyE` [Proj ProjSystem f] where
+                let aux (Arg _ v) Dom{domInfo = info', unDom = f} = (Arg ai v,) $ t `applyE` [Proj ProjSystem f] where
                      ai = ArgInfo
                        { argInfoHiding   = min (getHiding info) (getHiding info')
                        , argInfoModality = Modality

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1035,7 +1035,7 @@ data Constraint
     --   on which the constraint may be blocked on and the third one is the list
     --   of candidates (or Nothing if we haven’t determined the list of
     --   candidates yet)
-  | CheckFunDef Delayed Info.DefInfo QName [A.Clause]
+  | CheckFunDef Delayed A.DefInfo QName [A.Clause]
   | UnquoteTactic (Maybe MetaId) Term Term Type   -- ^ First argument is computation and the others are hole and goal type
   deriving (Data, Show)
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1956,7 +1956,7 @@ data Defn = Axiom -- ^ Postulate
               -- ^ Constructor name and fields.
             , recNamedCon       :: Bool
               -- ^ Does this record have a @constructor@?
-            , recFields         :: [Arg QName]
+            , recFields         :: [Dom QName]
               -- ^ The record field names.
             , recTel            :: Telescope
               -- ^ The record field telescope. (Includes record parameters.)

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -231,7 +231,7 @@ matchPattern p u = case (p, u) of
       (theDef <$> getConstInfo c) >>= \case
         Constructor{ conData = d } -> do
           (theDef <$> getConstInfo d) >>= \case
-            r@Record{ recFields = fs } | YesEta <- recEtaEquality r -> return $ Just fs
+            r@Record{ recFields = fs } | YesEta <- recEtaEquality r -> return $ Just $ map argFromDom fs
             _ -> return Nothing
         _ -> __IMPOSSIBLE__
   (DefP o q ps, v) -> do

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -205,7 +205,7 @@ getSigmaKit = do
           return . Just $ SigmaKit
             { sigmaName = sigma
             , sigmaCon  = con
-            , sigmaFst  = unArg fst
-            , sigmaSnd  = unArg snd
+            , sigmaFst  = unDom fst
+            , sigmaSnd  = unDom snd
             }
         _ -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -172,7 +172,7 @@ quotingKit = do
       quoteList :: (a -> ReduceM Term) -> [a] -> ReduceM Term
       quoteList q xs = list (map q xs)
 
-      quoteDom :: (Type -> ReduceM Term) -> Dom Type -> ReduceM Term
+      quoteDom :: (a -> ReduceM Term) -> Dom a -> ReduceM Term
       quoteDom q Dom{domInfo = info, unDom = t} = arg !@ quoteArgInfo info @@ q t
 
       quoteAbs :: Subst t a => (a -> ReduceM Term) -> Abs a -> ReduceM Term
@@ -252,7 +252,7 @@ quotingKit = do
           Record{recConHead = c, recFields = fs} ->
             agdaDefinitionRecordDef
               !@! quoteName (conName c)
-              @@ quoteList (quoteArg (pure . quoteName)) fs
+              @@ quoteList (quoteDom (pure . quoteName)) fs
           Axiom{}       -> pure agdaDefinitionPostulate
           DataOrRecSig{} -> pure agdaDefinitionPostulate
           GeneralizableVar{} -> pure agdaDefinitionPostulate  -- TODO: reflect generalizable vars

--- a/src/full/Agda/TypeChecking/Records.hs-boot
+++ b/src/full/Agda/TypeChecking/Records.hs-boot
@@ -8,7 +8,7 @@ import Agda.TypeChecking.Monad
 
 isRecord :: HasConstInfo m => QName -> m (Maybe Defn)
 isEtaRecord :: HasConstInfo m => QName -> m Bool
-getRecordFieldNames_ :: (HasConstInfo m, ReadTCState m) => QName -> m (Maybe [Arg C.Name])
+getRecordFieldNames_ :: (HasConstInfo m, ReadTCState m) => QName -> m (Maybe [Dom C.Name])
 etaContractRecord :: HasConstInfo m => QName -> ConHead -> ConInfo -> Args -> m Term
 isGeneratedRecordConstructor :: (MonadTCEnv m, HasConstInfo m) => QName -> m Bool
 isRecordConstructor :: HasConstInfo m => QName -> m (Maybe (QName, Defn))

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -454,7 +454,7 @@ forceEtaExpansion a v (e:es) = case e of
 
     -- Eta-expand v at record type r, and get field corresponding to f
     (_ , c , ci , fields) <- etaExpandRecord_ r pars (theDef rdef) v
-    let fs        = recFields $ theDef rdef
+    let fs        = map argFromDom $ recFields $ theDef rdef
         i         = fromMaybe __IMPOSSIBLE__ $ elemIndex f $ map unArg fs
         fContent  = unArg $ fromMaybe __IMPOSSIBLE__ $ fields !!! i
         fUpdate w = Con c ci $ map Apply $ updateAt i (w <$) fields

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -286,7 +286,7 @@ instance Match Type NLPat Term where
             def <- addContext k $ theDef <$> getConstInfo d
             (tel, c, ci, vs) <- addContext k $ etaExpandRecord_ d pars def v
             ~(Just (_ , ct)) <- addContext k $ getFullyAppliedConType c t
-            let flds = recFields def
+            let flds = map argFromDom $ recFields def
                 mkField fld = PDef f (ps ++ [Proj ProjSystem fld])
                 -- Issue #3335: when matching against the record constructor,
                 -- don't add projections but take record field directly.
@@ -327,7 +327,7 @@ instance Match Type NLPat Term where
           def <- addContext k $ theDef <$> getConstInfo d
           (tel, c, ci, vs) <- addContext k $ etaExpandRecord_ d pars def v
           ~(Just (_ , ct)) <- addContext k $ getFullyAppliedConType c t
-          let flds = recFields def
+          let flds = map argFromDom $ recFields def
               ps'  = map (fmap $ \fld -> PBoundVar i (ps ++ [Proj ProjSystem fld])) flds
           match r gamma k (ct, Con c ci []) (map Apply ps') (map Apply vs)
         _ -> no ""

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -973,7 +973,7 @@ inferOrCheckProjApp e o ds args mt = do
       caseMaybeM (isRecordType ta) (refuseProjNotRecordType ds) $ \ (_q, _pars, defn) -> do
       case defn of
         Record { recFields = fs } -> do
-          case forMaybe fs $ \ (Arg _ f) -> List.find (f ==) (toList ds) of
+          case forMaybe fs $ \ f -> List.find (unDom f ==) (toList ds) of
             [] -> refuseProjNoMatching ds
             [d] -> do
               storeDisambiguatedName d

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -162,7 +162,7 @@ bindBuiltinFlat x =
     modifySignature $ updateDefinition sharp $ updateTheDef $ \ def ->
       def { conSrcCon = sharpCon }
     modifySignature $ updateDefinition inf $ updateTheDef $ \ def ->
-      def { recConHead = sharpCon, recFields = [defaultArg flat] }
+      def { recConHead = sharpCon, recFields = [defaultDom flat] }
     return flatE
 
 -- The coinductive primitives.

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -56,7 +56,7 @@ import Agda.Utils.Impossible
 
 -- | Type check a datatype definition. Assumes that the type has already been
 --   checked.
-checkDataDef :: Info.DefInfo -> QName -> UniverseCheck -> A.DataDefParams -> [A.Constructor] -> TCM ()
+checkDataDef :: A.DefInfo -> QName -> UniverseCheck -> A.DataDefParams -> [A.Constructor] -> TCM ()
 checkDataDef i name uc (A.DataDefParams gpars ps) cs =
     traceCall (CheckDataDef (getRange name) name ps cs) $ do
 

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -322,12 +322,12 @@ revisitRecordPatternTranslation qs = do
 
 type FinalChecks = Maybe (TCM ())
 
-checkUnquoteDecl :: Info.MutualInfo -> [Info.DefInfo] -> [QName] -> A.Expr -> TCM FinalChecks
+checkUnquoteDecl :: Info.MutualInfo -> [A.DefInfo] -> [QName] -> A.Expr -> TCM FinalChecks
 checkUnquoteDecl mi is xs e = do
   reportSDoc "tc.unquote.decl" 20 $ "Checking unquoteDecl" <+> sep (map prettyTCM xs)
   Nothing <$ unquoteTop xs e
 
-checkUnquoteDef :: [Info.DefInfo] -> [QName] -> A.Expr -> TCM ()
+checkUnquoteDef :: [A.DefInfo] -> [QName] -> A.Expr -> TCM ()
 checkUnquoteDef _ xs e = do
   reportSDoc "tc.unquote.decl" 20 $ "Checking unquoteDef" <+> sep (map prettyTCM xs)
   () <$ unquoteTop xs e
@@ -516,7 +516,7 @@ checkProjectionLikeness_ names = Bench.billTo [Bench.ProjectionLikeness] $ do
                "mutual definitions are not considered for projection-likeness"
 
 -- | Freeze metas created by given computation if in abstract mode.
-whenAbstractFreezeMetasAfter :: Info.DefInfo -> TCM a -> TCM a
+whenAbstractFreezeMetasAfter :: A.DefInfo -> TCM a -> TCM a
 whenAbstractFreezeMetasAfter Info.DefInfo{ defAccess, defAbstract} m = do
   let pubAbs = defAccess == PublicAccess && defAbstract == AbstractDef
   if not pubAbs then m else do
@@ -528,7 +528,7 @@ whenAbstractFreezeMetasAfter Info.DefInfo{ defAccess, defAbstract} m = do
       ]
     return a
 
-checkGeneralize :: Set QName -> Info.DefInfo -> ArgInfo -> QName -> A.Expr -> TCM ()
+checkGeneralize :: Set QName -> A.DefInfo -> ArgInfo -> QName -> A.Expr -> TCM ()
 checkGeneralize s i info x e = do
 
     reportSDoc "tc.decl.gen" 20 $ sep
@@ -552,14 +552,14 @@ checkGeneralize s i info x e = do
 
 
 -- | Type check an axiom.
-checkAxiom :: A.Axiom -> Info.DefInfo -> ArgInfo ->
+checkAxiom :: A.Axiom -> A.DefInfo -> ArgInfo ->
               Maybe [Occurrence] -> QName -> A.Expr -> TCM ()
 checkAxiom = checkAxiom' Nothing
 
 -- | Data and record type signatures need to remember the generalized
 --   parameters for when checking the corresponding definition, so for these we
 --   pass in the parameter telescope separately.
-checkAxiom' :: Maybe A.GeneralizeTelescope -> A.Axiom -> Info.DefInfo -> ArgInfo ->
+checkAxiom' :: Maybe A.GeneralizeTelescope -> A.Axiom -> A.DefInfo -> ArgInfo ->
                Maybe [Occurrence] -> QName -> A.Expr -> TCM ()
 checkAxiom' gentel funSig i info0 mp x e = whenAbstractFreezeMetasAfter i $ defaultOpenLevelsToZero $ do
   -- Andreas, 2016-07-19 issues #418 #2102:
@@ -653,7 +653,7 @@ checkAxiom' gentel funSig i info0 mp x e = whenAbstractFreezeMetasAfter i $ defa
     solveSizeConstraints $ if checkingWhere then DontDefaultToInfty else DefaultToInfty
 
 -- | Type check a primitive function declaration.
-checkPrimitive :: Info.DefInfo -> QName -> A.Expr -> TCM ()
+checkPrimitive :: A.DefInfo -> QName -> A.Expr -> TCM ()
 checkPrimitive i x e =
     traceCall (CheckPrimitive (getRange i) x e) $ do
     (name, PrimImpl t' pf) <- lookupPrimitiveFunctionQ x

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -76,7 +76,7 @@ import Agda.Utils.Impossible
 -- * Definitions by pattern matching
 ---------------------------------------------------------------------------
 
-checkFunDef :: Delayed -> Info.DefInfo -> QName -> [A.Clause] -> TCM ()
+checkFunDef :: Delayed -> A.DefInfo -> QName -> [A.Clause] -> TCM ()
 checkFunDef delayed i name cs = do
         -- Get the type and relevance of the function
         def <- instantiateDef =<< getConstInfo name
@@ -128,7 +128,7 @@ isAlias cs t =
     trivialClause _ = Nothing
 
 -- | Check a trivial definition of the form @f = e@
-checkAlias :: Type -> ArgInfo -> Delayed -> Info.DefInfo -> QName -> A.Expr -> Maybe C.Expr -> TCM ()
+checkAlias :: Type -> ArgInfo -> Delayed -> A.DefInfo -> QName -> A.Expr -> Maybe C.Expr -> TCM ()
 checkAlias t ai delayed i name e mc =
   let clause = A.Clause { clauseLHS          = A.SpineLHS (LHSInfo (getRange i) NoEllipsis) name []
                         , clauseStrippedPats = []
@@ -191,12 +191,12 @@ checkAlias t ai delayed i name e mc =
 
 -- | Type check a definition by pattern matching.
 checkFunDef' :: Type             -- ^ the type we expect the function to have
-             -> ArgInfo        -- ^ is it irrelevant (for instance)
+             -> ArgInfo          -- ^ is it irrelevant (for instance)
              -> Delayed          -- ^ are the clauses delayed (not unfolded willy-nilly)
              -> Maybe ExtLamInfo -- ^ does the definition come from an extended lambda
                                  --   (if so, we need to know some stuff about lambda-lifted args)
              -> Maybe QName      -- ^ is it a with function (if so, what's the name of the parent function)
-             -> Info.DefInfo     -- ^ range info
+             -> A.DefInfo        -- ^ range info
              -> QName            -- ^ the name of the function
              -> [A.Clause]       -- ^ the clauses to check
              -> TCM ()
@@ -205,12 +205,12 @@ checkFunDef' t ai delayed extlam with i name cs =
 
 -- | Type check a definition by pattern matching.
 checkFunDefS :: Type             -- ^ the type we expect the function to have
-             -> ArgInfo        -- ^ is it irrelevant (for instance)
+             -> ArgInfo          -- ^ is it irrelevant (for instance)
              -> Delayed          -- ^ are the clauses delayed (not unfolded willy-nilly)
              -> Maybe ExtLamInfo -- ^ does the definition come from an extended lambda
                                  --   (if so, we need to know some stuff about lambda-lifted args)
              -> Maybe QName      -- ^ is it a with function (if so, what's the name of the parent function)
-             -> Info.DefInfo     -- ^ range info
+             -> A.DefInfo        -- ^ range info
              -> QName            -- ^ the name of the function
              -> Maybe Substitution -- ^ substitution (from with abstraction) that needs to be applied to module parameters
              -> [A.Clause]       -- ^ the clauses to check

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -148,12 +148,15 @@ checkRecDef i name uc ind eta con (A.DataDefParams gpars ps) contel fields =
 
       etaenabled <- etaEnabled
 
-      let getName :: A.Declaration -> [Arg QName]
-          getName (A.Field _ x arg)    = [x <$ arg]
+      let getName :: A.Declaration -> [Dom QName]
+          getName (A.Field _ x arg)    = [x <$ domFromArg arg]
           getName (A.ScopedDecl _ [f]) = getName f
           getName _                    = []
 
-          fs = concatMap getName fields
+          setTactic dom f = f { domTactic = domTactic dom }
+
+          fs = zipWith setTactic (telToList ftel) $ concatMap getName fields
+
           -- indCo is what the user wrote: inductive/coinductive/Nothing.
           -- We drop the Range.
           indCo = rangedThing <$> ind
@@ -164,7 +167,7 @@ checkRecDef i name uc ind eta con (A.DataDefParams gpars ps) contel fields =
           -- We should turn it off until it is proven to be safe.
           haveEta      = maybe (Inferred NoEta) Specified eta
           -- haveEta      = maybe (Inferred $ conInduction == Inductive && etaenabled) Specified eta
-          con = ConHead conName conInduction fs
+          con = ConHead conName conInduction $ map argFromDom fs
 
           -- A record is irrelevant if all of its fields are.
           -- In this case, the associated module parameter will be irrelevant.
@@ -289,7 +292,7 @@ checkRecDef i name uc ind eta con (A.DataDefParams gpars ps) contel fields =
           [ "record section:"
           , nest 2 $ sep
             [ prettyTCM m <+> (inTopContext . prettyTCM =<< getContextTelescope)
-            , fsep $ punctuate comma $ map (return . P.pretty . getName) fields
+            , fsep $ punctuate comma $ map (return . P.pretty . map argFromDom . getName) fields
             ]
           ]
         reportSDoc "tc.rec.def" 15 $ nest 2 $ vcat
@@ -317,13 +320,13 @@ checkRecDef i name uc ind eta con (A.DataDefParams gpars ps) contel fields =
 
       -- we define composition here so that the projections are already in the signature.
       escapeContext npars $ do
-        addCompositionForRecord name con tel fs ftel rect
+        addCompositionForRecord name con tel (map argFromDom fs) ftel rect
 
       -- Jesper, 2019-06-07: Check confluence of projection clauses
       whenM (optConfluenceCheck <$> pragmaOptions) $ forM_ fs $ \f -> do
-        cls <- defClauses <$> getConstInfo (unArg f)
+        cls <- defClauses <$> getConstInfo (unDom f)
         forM (zip cls [0..]) $ \(cl,i) ->
-          checkConfluenceOfClause (unArg f) i cl
+          checkConfluenceOfClause (unDom f) i cl
 
       return ()
 

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -63,7 +63,7 @@ import Agda.Utils.Impossible
 --     [@fields@]  List of field signatures.
 --
 checkRecDef
-  :: Info.DefInfo              -- ^ Position and other info.
+  :: A.DefInfo                 -- ^ Position and other info.
   -> QName                     -- ^ Record type identifier.
   -> UniverseCheck             -- ^ Check universes?
   -> Maybe (Ranged Induction)  -- ^ Optional: (co)inductive declaration.

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -844,7 +844,7 @@ checkRecordExpression cmp mfs e t = do
       reportSDoc "tc.term.rec" 20 $ text $ "  r   = " ++ prettyShow r
 
       reportSDoc "tc.term.rec" 30 $ "  xs  = " <> do
-        text =<< prettyShow . map unArg <$> getRecordFieldNames r
+        text =<< prettyShow . map unDom <$> getRecordFieldNames r
       reportSDoc "tc.term.rec" 30 $ "  ftel= " <> do
         prettyTCM =<< getRecordFieldTypes r
       reportSDoc "tc.term.rec" 30 $ "  con = " <> do
@@ -852,7 +852,7 @@ checkRecordExpression cmp mfs e t = do
 
       def <- getRecordDef r
       let -- Field names (C.Name) with ArgInfo from record type definition.
-          cxs  = recordFieldNames def
+          cxs  = map argFromDom $ recordFieldNames def
           -- Just field names.
           xs   = map unArg cxs
           -- Record constructor.
@@ -866,7 +866,7 @@ checkRecordExpression cmp mfs e t = do
       -- Andreas, 2018-09-06, issue #3122.
       -- Associate the concrete record field names used in the record expression
       -- to their counterpart in the record type definition.
-      disambiguateRecordFields (map _nameFieldA $ lefts mfs) (map unArg $ recFields def)
+      disambiguateRecordFields (map _nameFieldA $ lefts mfs) (map unDom $ recFields def)
 
       -- Compute the list of given fields, decorated with the ArgInfo from the record def.
       -- Andreas, 2019-03-18, issue #3122, also pick up non-visible fields from the modules.
@@ -950,14 +950,14 @@ checkRecordUpdate cmp ei recexpr fs e t = do
       v <- checkExpr' cmp recexpr t
       name <- freshNoName (getRange recexpr)
       addLetBinding defaultArgInfo name v t $ do
-        projs <- recFields <$> getRecordDef r
+        projs <- map argFromDom . recFields <$> getRecordDef r
 
         -- Andreas, 2018-09-06, issue #3122.
         -- Associate the concrete record field names used in the record expression
         -- to their counterpart in the record type definition.
         disambiguateRecordFields (map _nameFieldA fs) (map unArg projs)
 
-        axs <- getRecordFieldNames r
+        axs <- map argFromDom <$> getRecordFieldNames r
         let xs = map unArg axs
         es <- orderFields r (\ _ -> Nothing) axs $ map (\ (FieldAssignment x e) -> (x, Just e)) fs
         let es' = zipWith (replaceFields name ei) projs es

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -85,9 +85,10 @@ teleArgNames :: Telescope -> [Arg ArgName]
 teleArgNames = map (argFromDom . fmap fst) . telToList
 
 teleArgs :: (DeBruijn a) => Tele (Dom t) -> [Arg a]
-teleArgs tel =
-  [ Arg info (deBruijnVar i)
-  | (i, Dom {domInfo = info, unDom = (n,_)}) <- zip (downFrom $ size l) l ]
+teleArgs = map argFromDom . teleDoms
+
+teleDoms :: (DeBruijn a) => Tele (Dom t) -> [Dom a]
+teleDoms tel = zipWith (\ i dom -> deBruijnVar i <$ dom) (downFrom $ size l) l
   where l = telToList tel
 
 -- UNUSED
@@ -98,10 +99,7 @@ teleArgs tel =
 --   where l = telToList tel
 
 teleNamedArgs :: (DeBruijn a) => Telescope -> [NamedArg a]
-teleNamedArgs tel =
-  [ fmap (deBruijnVar i <$) $ namedArgFromDom dom
-  | (i, dom) <- zip (downFrom $ size l) l ]
-  where l = telToList tel
+teleNamedArgs = map namedArgFromDom . teleDoms
 
 -- | A variant of `teleNamedArgs` which takes the argument names (and the argument info)
 --   from the first telescope and the variable names from the second telescope.

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -492,7 +492,8 @@ stripWithClausePatterns cxtNames parent f t delta qs npars perm ps = do
             stripConP d us b c ConOCon qs' ps'
 
           A.RecP _ fs -> caseMaybeM (liftTCM $ isRecord d) mismatch $ \ def -> do
-            ps' <- liftTCM $ insertMissingFields d (const $ A.WildP empty) fs (recordFieldNames def)
+            ps' <- liftTCM $ insertMissingFields d (const $ A.WildP empty) fs
+                                                 (map argFromDom $ recordFieldNames def)
             stripConP d us b c ConORec qs' ps'
 
           p@(A.PatternSynP pi' c' ps') -> do

--- a/test/Succeed/Issue4124.agda
+++ b/test/Succeed/Issue4124.agda
@@ -1,0 +1,91 @@
+
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Bool
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Equality
+
+variable
+  A B : Set
+
+data Eqn (A : Set) : Set where
+  eqn : (x y : A) → x ≡ y → Eqn A
+
+infix 3 _==_
+pattern _==_ x y = eqn x y refl
+
+infixl 0 such-that
+syntax such-that a (λ x → P) p = a is x such-that p proves P
+such-that : (x : A) (P : A → Set) → P x → A
+such-that x _ _ = x
+
+infix -1 check_
+check_ : A → ⊤
+check _ = _
+
+infixl -2 _and_
+_and_ : ⊤ → A → ⊤
+_ and _ = _
+
+-- Record fields can be marked with @tactic
+
+data ShouldRun : Set where
+  run norun : ShouldRun
+
+defaultTo : {A : Set} (x : A) → ShouldRun → Term → TC ⊤
+defaultTo _ norun _    = typeError (strErr "Should not run!" ∷ [])
+defaultTo x run   hole = bindTC (quoteTC x) (unify hole)
+
+record Class (r : ShouldRun) : Set where
+  constructor con
+  field
+    x : Bool
+    @(tactic defaultTo x r) {y} : Bool
+open Class
+
+-- # Cases where the tactic should run
+
+test₁ test₂ test₃ : Class run
+test₁    = con true             -- Constructor application
+test₂    = record { x = true }  -- Record construction
+test₃ .x = true                 -- Missing copattern clause
+
+_ = check test₁ == con true {true}
+      and test₂ == con true {true}
+      and test₃ == con true {true}
+
+-- More elaborate missing copatterns
+test₃′ : List Bool → Class run
+test₃′ []      .x = false
+test₃′ []      .y = true
+test₃′ (b ∷ _) .x = b
+
+_ =
+  check test₃′ []             == con false {true}
+    and λ b → test₃′ (b ∷ []) == con b {b}
+
+-- # Cases where the tactic should not run
+
+-- ## Giving the field explicitly
+
+test₄ test₅ : Class norun
+test₄ = con true {_}              is c such-that refl proves c .y ≡ false
+test₅ = record{ x = true; y = _ } is c such-that refl proves c .y ≡ false
+
+_ = check test₄ == con true {false}
+      and test₅ == con true {false}
+
+-- ## Eta-expansion
+
+-- Eta-expansion of record metas should *not* trigger the tactic, since that
+-- would make eta-expansion potentially lose solutions. For instance,
+-- `con true {false} == _1`. Here solving `_1 := con true {false}` is valid, but
+-- eta-expanding to `con _2 {_3}` and running `defaultTo _2 _3` leads to an error.
+
+test₆ : Class norun
+test₆ =
+  _ is c such-that refl proves c .x ≡ true
+    is c such-that refl proves c .y ≡ false
+
+check₆ : test₆ ≡ con true {false}
+check₆ = refl


### PR DESCRIPTION
In addition to running the tactic on constructor application and record constructions with the field omitted, it also lets you omit copattern clauses on the field.

Fixes #4124 
