### PR TITLE
[ fix #3695 ] no longer allow eta expansion of frozen metas

### DIFF
--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -491,7 +491,7 @@ etaExpandMetaSafe = etaExpandMeta [SingletonRecords,Levels]
 -- | Eta expand a metavariable, if it is of the specified kind.
 --   Don't do anything if the metavariable is a blocked term.
 etaExpandMetaTCM :: [MetaKind] -> MetaId -> TCM ()
-etaExpandMetaTCM kinds m = whenM (asksTC envAssignMetas `and2M` isEtaExpandable kinds m) $ do
+etaExpandMetaTCM kinds m = whenM ((not <$> isFrozen m) `and2M` asksTC envAssignMetas `and2M` isEtaExpandable kinds m) $ do
   verboseBracket "tc.meta.eta" 20 ("etaExpandMeta " ++ prettyShow m) $ do
     let waitFor x = do
           reportSDoc "tc.meta.eta" 20 $ do

--- a/test/Succeed/Issue3695.agda
+++ b/test/Succeed/Issue3695.agda
@@ -1,0 +1,34 @@
+
+{-# OPTIONS --cubical #-}
+
+open import Agda.Builtin.Cubical.Path using (_≡_)
+open import Agda.Builtin.Sigma using (Σ; fst; _,_)
+
+postulate
+  Is-proposition : Set → Set
+  subst          : ∀ {A : Set} (P : A → Set) {x y} → x ≡ y → P x → P y
+
+Proposition : Set₁
+Proposition = Σ _ Is-proposition
+
+data _/_ (A : Set) (R : A → A → Proposition) : Set where
+  [_]  : A → A / R
+  resp : ∀ {x y} → fst (R x y) → [ x ] ≡ [ y ]
+
+variable
+  A : Set
+  R : A → A → Proposition
+
+postulate
+  F : (P : A / R → Set)
+      (p-[] : ∀ x → P [ x ]) →
+      (∀ {x y} (r : fst (R x y)) → subst P (resp r) (p-[] x) ≡ p-[] y) →
+      Set
+
+F' : (A : Set)
+     (R : A → A → Proposition)
+     (P : A / R → Set)
+     (p-[] : ∀ x → P [ x ]) →
+     (∀ {x y} (r : fst (R x y)) → subst P (resp r) (p-[] x) ≡ p-[] y) →
+     Set
+F' A R = F {A = A} {R = R}


### PR DESCRIPTION
Eta-expansion of frozen metas was introduced by the fix of #658, but disabling it doesn't bring back #658. Generalization uses freezing to prevent metas standing for generalizable variables from being instantiated, and circumventing this caused #3695.