### PR TITLE
[ actions ] Pack artifact with installation script

### DIFF
--- a/.github/dist_install_system.bat
+++ b/.github/dist_install_system.bat
@@ -1,0 +1,24 @@
+@echo off
+echo "Installing Agda for all users..."
+
+echo "Writing system paths ..."
+
+setx /M Agda_datadir "%cd%\data"
+setx /M PATH "%cd%\bin;%PATH%"
+
+.\bin\agda.exe --version
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo "Initialize Emacs mode ..."
+
+.\bin\agda-mode.exe setup
+if %errorlevel% neq 0 exit /b %errorlevel%
+.\bin\agda-mode.exe compile
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo "Checking Agda.Primitive.agda..."
+
+.\bin\agda.exe data\lib\prim\Agda\Primitive.agda
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo "Agda is supposed to be installed now."

--- a/.github/dist_install_user.bat
+++ b/.github/dist_install_user.bat
@@ -1,0 +1,24 @@
+@echo off
+echo "Installing Agda for the current user..."
+
+echo "Writing user paths ..."
+
+setx Agda_datadir "%cd%\data"
+setx PATH "%cd%\bin;%PATH%"
+
+.\bin\agda.exe --version
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo "Initialize Emacs mode ..."
+
+.\bin\agda-mode.exe setup
+if %errorlevel% neq 0 exit /b %errorlevel%
+.\bin\agda-mode.exe compile
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo "Checking Agda.Primitive.agda..."
+
+.\bin\agda.exe data\lib\prim\Agda\Primitive.agda
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo "Agda is supposed to be installed now."

--- a/.github/dist_install_user.sh
+++ b/.github/dist_install_user.sh
@@ -4,13 +4,22 @@ set -e
 
 echo "Installing Agda for the current user..."
 
+echo "Writing to ~/.bashrc about the paths ..."
+
 echo "export Agda_datadir="$PWD"/data">>~/.bashrc
 echo "export PATH="$PWD"/bin:$PATH">>~/.bashrc
 
-./bin/agda-mode setup
-./bin/agda-mode compile
+echo "The executable files should be executable ..."
+
+chmod a+x ./bin/agda
+chmod a+x ./bin/agda-mode
 
 ./bin/agda --version
+
+echo "Initialize Emacs mode ..."
+
+./bin/agda-mode setup
+./bin/agda-mode compile
 
 for prim in ./data/lib/prim/Agda/**/*.agda
 do
@@ -18,7 +27,7 @@ do
     Agda_datadir=data ./bin/agda $prim
 done
 
-echo "Agda is supposed to be installed."
+echo "Agda is supposed to be installed now."
 echo ""
 echo "You may use the following command to start using Agda right now:"
 echo ""

--- a/.github/dist_install_user.sh
+++ b/.github/dist_install_user.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+echo "Installing Agda for the current user..."
+
+echo "export Agda_datadir="$PWD"/data">>~/.bashrc
+echo "export PATH="$PWD"/bin:$PATH">>~/.bashrc
+
+./bin/agda-mode setup
+./bin/agda-mode compile
+
+./bin/agda --version
+
+for prim in ./data/lib/prim/Agda/**/*.agda
+do
+    echo "Checking "$prim
+    Agda_datadir=data ./bin/agda $prim
+done
+
+echo "Agda is supposed to be installed."
+echo ""
+echo "You may use the following command to start using Agda right now:"
+echo ""
+echo "    source ~/.bashrc"
+echo ""

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -35,6 +35,18 @@ jobs:
     - name: Build Agda with -fenable-cluster-counting
       run: |
         stack build ${ARGS} ${FLAGS_2}
+    - name: Pack artifacts
+      run: |
+        mkdir -p upload
+        mkdir -p upload/bin
+        cp -av .stack-work/dist/x86_64-linux/**/build/agda/agda upload/bin
+        cp -av .stack-work/dist/x86_64-linux/**/build/agda-mode/agda-mode upload/bin
+        cp -avr src/data upload
+        cp -av .github/dist_install_user.sh upload
+    - uses: actions/upload-artifact@master
+      with:
+        name: agda-linux-${{ matrix.ghc-ver }}
+        path: upload
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -78,3 +78,18 @@ jobs:
       shell: bash
       run: |
         stack build ${ARGS} ${FLAGS}
+    - name: Pack artifacts
+      shell: bash
+      run: |
+        mkdir -p upload
+        mkdir -p upload/bin
+        cp -av .stack-work/dist/**/build/agda/agda.exe upload/bin
+        cp -av .stack-work/dist/**/build/agda-mode/agda-mode.exe upload/bin
+        cp -av .stack-work/dist/**/build/size-solver/size-solver.exe upload/bin
+        cp -avr src/data upload
+        cp -av .github/dist_install_user.bat upload
+        cp -av .github/dist_install_system.bat upload
+    - uses: actions/upload-artifact@master
+      with:
+        name: agda-linux-${{ matrix.ghc-ver }}
+        path: upload


### PR DESCRIPTION
To get a try: download one of the zips from this page: https://github.com/agda/agda/commit/5dbec274542bcf6762d3ccaddf192a987e25f784/checks?check_suite_id=332616110

You should see the list of zips at the top-right corner that looks like the following:
![Screenshot from 2019-11-28 00-08-20](https://user-images.githubusercontent.com/16398479/69778677-36694000-1173-11ea-9a87-9b19076b44b6.png)

The zip file is self-contained -- all you need to do is to download, unzip it and run the `dist_install_user.sh` script.