### PR TITLE
[ fix #4006 ] ignore abstract when translating compiled clauses

### DIFF
--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -130,7 +130,7 @@ getEtaAndArity SplitCatchall = return (False, 1)
 translateCompiledClauses
   :: forall m. (HasConstInfo m, MonadChange m)
   => CompiledClauses -> m CompiledClauses
-translateCompiledClauses cc = do
+translateCompiledClauses cc = ignoreAbstractMode $ do
   reportSDoc "tc.cc.record" 20 $ vcat
     [ "translate record patterns in compiled clauses"
     , nest 2 $ return $ pretty cc

--- a/test/Succeed/Issue4006.agda
+++ b/test/Succeed/Issue4006.agda
@@ -1,0 +1,17 @@
+
+data I : Set where
+  i : I
+
+variable
+  x : I
+
+abstract
+
+  data D : I → Set where
+    d : D i
+
+  accepted : {x : I} → D x → Set₁
+  accepted {x = i} d = Set
+
+  rejected : D x → Set₁
+  rejected {x = i} d = Set


### PR DESCRIPTION
so that we don't crash if the function matches on "abstract" (i.e. not-in-scope)
constructors

Fixes #4006 