### PR TITLE
[ fix #4253 ] don't forget transitive dependencies when sorting metas

### DIFF
--- a/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -62,6 +62,7 @@ module Agda.Utils.Graph.AdjacencyMap.Unidirectional
     -- * Transitive closure
   , gaussJordanFloydWarshallMcNaughtonYamada
   , gaussJordanFloydWarshallMcNaughtonYamadaReference
+  , transitiveClosure
   , complete, completeIter
   )
   where
@@ -862,3 +863,10 @@ gaussJordanFloydWarshallMcNaughtonYamada g =
       starTimes = otimes (ostar (lookup' k k))
 
       lookup' s t = fromMaybe ozero (lookup s t g)
+
+-- | The transitive closure. Using 'gaussJordanFloydWarshallMcNaughtonYamada'.
+--   NOTE: DO NOT USE () AS EDGE LABEL SINCE THIS MEANS EVERY EDGE IS CONSIDERED A ZERO EDGE AND NO
+--         NEW EDGES WILL BE ADDED! Use 'Maybe ()' instead.
+transitiveClosure :: (Ord n, Eq e, StarSemiRing e) => Graph n e -> Graph n e
+transitiveClosure = fst . gaussJordanFloydWarshallMcNaughtonYamada
+

--- a/test/Succeed/Issue4253.agda
+++ b/test/Succeed/Issue4253.agda
@@ -1,0 +1,16 @@
+
+open import Agda.Primitive
+
+variable
+  a : Level
+  A : Set a
+  x : A
+
+postulate
+  P : ∀ {a b} {A : Set a} {B : Set b} → (A → B) → Set
+  p : P x
+
+postulate
+  H : ∀ a (A : Set a) (x : A) → Set
+  Id : ∀ {a} (A : Set a) → A → A → Set a
+  h : (i : H _ _ x) (j : H a _ _) → Id (H _ A _) i j


### PR DESCRIPTION
Fixes #4253 