### PR TITLE
[ fixed #4267 ] record expressions need the record type in scope

### DIFF
--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -17,6 +17,7 @@ import Agda.Syntax.Concrete (FieldAssignment'(..))
 import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Internal as I
 import Agda.Syntax.Position
+import Agda.Syntax.Scope.Base (isNameInScope)
 
 import Agda.TypeChecking.Irrelevance
 import Agda.TypeChecking.Monad
@@ -135,7 +136,8 @@ findPossibleRecords :: [C.Name] -> TCM [QName]
 findPossibleRecords fields = do
   defs  <- HMap.elems <$> useTC (stSignature . sigDefinitions)
   idefs <- HMap.elems <$> useTC (stImports   . sigDefinitions)
-  return $ cands defs ++ cands idefs
+  scope <- getScope
+  return $ filter (`isNameInScope` scope) $ cands defs ++ cands idefs
   where
     cands defs = [ defName d | d <- defs, possible d ]
     possible def =

--- a/test/Succeed/Issue4267.agda
+++ b/test/Succeed/Issue4267.agda
@@ -1,0 +1,15 @@
+-- Andreas, 2019-12-08, issue #4267, reported and test case by csattler
+
+-- Problem: definitions from files (A1) imported by a module
+-- (Issue4267) may leak into the handling of an independent module
+-- (B).
+
+-- The root issue here is that having a signature stImports that
+-- simply accumulates the signatures of all visited modules is
+-- unhygienic.
+
+module Issue4267 where
+
+open import Issue4267.A0
+open import Issue4267.A1 -- importing A1 here (in main) affects how B is type-checked
+open import Issue4267.B

--- a/test/Succeed/Issue4267/A0.agda
+++ b/test/Succeed/Issue4267/A0.agda
@@ -1,0 +1,5 @@
+module Issue4267.A0 where
+
+record RA0 : Set₁ where
+  field
+    A : Set

--- a/test/Succeed/Issue4267/A1.agda
+++ b/test/Succeed/Issue4267/A1.agda
@@ -1,0 +1,5 @@
+module Issue4267.A1 where
+
+record RA1 : Set₁ where
+  field
+    A : Set

--- a/test/Succeed/Issue4267/B.agda
+++ b/test/Succeed/Issue4267/B.agda
@@ -1,0 +1,10 @@
+module Issue4267.B where
+
+open import Issue4267.A0
+
+postulate
+  X : Set
+
+-- Crucial for bug: omitting signature of ra,
+-- letting Agda infer its type.
+ra = record {A = X}


### PR DESCRIPTION
It might be a sensible restriction that the type of

  record { fields = exprs }

can only be inferred if it could be written as well, i.e., if the record
type is in scope.

This fixes #4267; but the root cause of #4267 is the unhygienic import
handling of Agda, see #4272.