### PR TITLE
Don't expand last or add implicit lambda when checking reflected metas

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2959,7 +2959,13 @@ aModeToDef _ = Nothing
 data ExpandHidden
   = ExpandLast      -- ^ Add implicit arguments in the end until type is no longer hidden 'Pi'.
   | DontExpandLast  -- ^ Do not append implicit arguments.
+  | ReallyDontExpandLast -- ^ Makes 'doExpandLast' have no effect. Used to avoid implicit insertion of arguments to metavariables.
   deriving (Eq, Data)
+
+isDontExpandLast :: ExpandHidden -> Bool
+isDontExpandLast ExpandLast           = False
+isDontExpandLast DontExpandLast       = True
+isDontExpandLast ReallyDontExpandLast = True
 
 -- | A candidate solution for an instance meta is a term with its type.
 --   It may be the case that the candidate is not fully applied yet or

--- a/src/full/Agda/TypeChecking/Monad/Env.hs
+++ b/src/full/Agda/TypeChecking/Monad/Env.hs
@@ -71,10 +71,16 @@ withoutOptionsChecking = localTC $ \ e -> e { envCheckOptionConsistency = False 
 
 -- | Restore setting for 'ExpandLast' to default.
 doExpandLast :: TCM a -> TCM a
-doExpandLast = localTC $ \ e -> e { envExpandLast = ExpandLast }
+doExpandLast = localTC $ \ e -> e { envExpandLast = setExpand (envExpandLast e) }
+  where
+    setExpand ReallyDontExpandLast = ReallyDontExpandLast
+    setExpand _                    = ExpandLast
 
 dontExpandLast :: TCM a -> TCM a
 dontExpandLast = localTC $ \ e -> e { envExpandLast = DontExpandLast }
+
+reallyDontExpandLast :: TCM a -> TCM a
+reallyDontExpandLast = localTC $ \ e -> e { envExpandLast = ReallyDontExpandLast }
 
 -- | If the reduced did a proper match (constructor or literal pattern),
 --   then record this as simplification step.

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1197,9 +1197,12 @@ checkExpr' cmp e t =
         , not (hiddenLambdaOrHole h e)
         = do
       let proceed = doInsert (setOrigin Inserted info) $ absName b
+      expandHidden <- asksTC envExpandLast
       -- If we skip the lambda insertion for an introduction,
       -- we will hit a dead end, so proceed no matter what.
-      if definitelyIntroduction then proceed else do
+      if definitelyIntroduction then proceed else
+        -- #3019 and #4170: don't insert implicit lambdas in arguments to existing metas
+        if expandHidden == ReallyDontExpandLast then fallback else do
         -- Andreas, 2017-01-19, issue #2412:
         -- We do not want to insert a hidden lambda if A is
         -- possibly empty type of sizes, as this will produce an error.

--- a/test/Succeed/Issue3019.agda
+++ b/test/Succeed/Issue3019.agda
@@ -1,0 +1,18 @@
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Unit
+
+macro
+  five : Term → TC ⊤
+  five hole = unify hole (lit (nat 5))
+
+-- Here you get hole = _X (λ {n} → y {_n})
+-- and fail to solve _n.
+yellow : ({n : Nat} → Set) → Nat
+yellow y = five
+
+-- Here you get hole = _X ⦃ n ⦄ (λ ⦃ n' ⦄ → y ⦃ _n ⦄)
+-- and fail to solve _n due to the multiple candidates n and n'.
+more-yellow : ⦃ n : Nat ⦄ → (⦃ n : Nat ⦄ → Set) → Nat
+more-yellow y = five

--- a/test/Succeed/Issue4170.agda
+++ b/test/Succeed/Issue4170.agda
@@ -1,0 +1,16 @@
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.List
+open import Agda.Builtin.Unit
+
+data World : Set where
+  ww : World
+
+test : Term → TC ⊤
+test hole
+  = unify (con (quote ww) []) hole
+
+HVet : Set₁
+HVet = {@(tactic test) w : World} → Set
+
+a : {HQ : HVet} → HQ → ⊤
+a = _


### PR DESCRIPTION
Fixes #4170.

Solves the main problem in #3019, but keeping that open for the feature request.