### PR TITLE
Fix #4254 roll back marking eta-constructor matches as lazy

### DIFF
--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -209,7 +209,7 @@ isTrivialPattern :: (HasConstInfo m) => Pattern' a -> m Bool
 isTrivialPattern p = case p of
   VarP{}      -> return True
   DotP{}      -> return True
-  ConP c i ps -> andM $ return (conPLazy i)
+  ConP c i ps -> andM $ ((conPLazy i ||) <$> isEtaCon (conName c))
                       : (map (isTrivialPattern . namedArg) ps)
   DefP{}      -> return False
   LitP{}      -> return False

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1314,14 +1314,11 @@ checkLHS mf = updateModality checkLHS_ where
           -- Also remember if we are a record pattern.
           isRec <- isRecord d
 
-          -- Mark eta-record matches as lazy
-          lazy <- isEtaRecord d
-
           let cpi = ConPatternInfo { conPInfo   = PatternInfo PatOCon []
                                    , conPRecord = isJust isRec
                                    , conPFallThrough = False
                                    , conPType   = Just $ Arg info a'
-                                   , conPLazy   = lazy }
+                                   , conPLazy   = False } -- Don't mark eta-record matches as lazy (#4254)
 
           -- compute final context and substitution
           let crho    = ConP c cpi $ applySubst rho0 $ (telePatterns gamma boundary)

--- a/test/Succeed/Issue4254.agda
+++ b/test/Succeed/Issue4254.agda
@@ -1,0 +1,52 @@
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+data D (A : Set) : Set → Set₁ where
+  c₁ : {B : Set} → D A B
+  c₂ : D A A
+
+record P {A B : Set} (p : D A B) : Set₁ where
+  constructor c
+  field
+    d : D A B
+
+Q : {A B₁ B₂ C : Set} {x : D A (B₁ → C)} {y : D A B₂} →
+    P x → P y → B₁ ≡ B₂ → Nat
+Q (c c₁) _      refl = 0
+Q _      (c c₁) refl = 1
+Q _      _      _    = 2
+
+module _ {A B C : Set} where
+
+  checkQ₀ : {x : D A (B → C)} {y : D A B} (px : P x) (py : P y) →
+              Q {x = x} {y = y} (c c₁) py refl ≡ 0
+  checkQ₀ _ _ = refl
+
+  checkQ₁ : {x : D (A → B) (A → B)} {y : D (A → B) A} (px : P x) (py : P y) →
+              Q {x = x} {y = y} (c c₂) (c c₁) refl ≡ 1
+  checkQ₁ _ _ = refl
+
+  checkQ₂ : {x : D (A → B) (A → B)} {y : D (A → B) (A → B)} (px : P x) (py : P y) (eq : A ≡ (A → B)) →
+              Q {x = x} {y = y} (c c₂) (c c₂) eq ≡ 2
+  checkQ₂ _ _ _ = refl
+
+R : {A B₁ B₂ C : Set} {x : D A (B₁ → C)} {y : D A B₂} →
+    P x → P y → B₁ ≡ B₂ → Nat
+R (c c₂) _      refl = 0
+R _      (c c₂) refl = 1
+R _      _      _    = 2
+
+module _ {A B C : Set} where
+
+  checkR₀ : ∀ {B C} {x : D (B → C) (B → C)} {y : D (B → C) B} (px : P x) (py : P y) →
+             R {x = x} {y = y} (c c₂) py refl ≡ 0
+  checkR₀ _ _ = refl
+
+  checkR₁ : ∀ {A B} {x : D A (A → B)} {y : D A A} (px : P x) (py : P y) →
+             R {x = x} {y = y} (c c₁) (c c₂) refl ≡ 1
+  checkR₁ _ _ = refl
+
+  checkR₂ : ∀ {A B C} {x : D A (B → C)} {y : D A B} (px : P x) (py : P y) →
+             R {x = x} {y = y} (c c₁) (c c₁) refl ≡ 2
+  checkR₂ _ _ = refl


### PR DESCRIPTION
Fixes #4254.

I don't completely understand how the coverage checker and clause compiler use the laziness
information so better to undo this change (717e7112b).