### PR TITLE
[ travis ] Clean `.agdai` after compiling Agda & Display Agda's version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,8 @@ jobs:
         export AGDA_TESTS_OPTIONS="-j${PARALLEL_TESTS} --hide-successes"
         export BUILD_DIR=$(pwd)/$(stack ${ARGS} path --dist-dir)
         export MAKE_CMD="make AGDA_TESTS_OPTIONS=${ARGA_TESTS_OPTIONS} TASTY_ANSI_TRICKS=false BUILD_DIR=$BUILD_DIR"
+
+        echo "*** Agda version ***" && stack ${ARGS} exec -- agda --version
       script:
         - stack ${ARGS} exec -- ${MAKE_CMD} bugs
         - stack ${ARGS} exec -- ${MAKE_CMD} succeed

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,8 @@ jobs:
         # shelltestrunner is used by `make test-size-solver`
         # we need to cache it first.
         stack install shelltestrunner ${ARGS}
+      before_cache:
+        - find ${TRAVIS_BUILD_DIR}/.stack-work -type f -name '*.agdai' -delete
 
     - &main-job
       stage: main


### PR DESCRIPTION
Due to caching, the compiled Agda version is based on the last commit where Agda's codebase is changed. It is nice to know which version is actually used when running test suites.