### PR TITLE
[ closed #4321 ] Removed the `cabal.project` file.

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -24,12 +24,6 @@ jobs:
         ghc-ver: [8.8.1]
     steps:
     - uses: actions/checkout@v2
-    - name: Checkout submodules
-      shell: bash
-      run: |
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-        git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
     - uses: actions/setup-haskell@v1
       with:
         ghc-version: ${{ matrix.ghc-ver }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -176,9 +176,6 @@ jobs:
     - &complete-job
       stage: complete
       env: GHC_VER=8.8.1 CABAL_VER=3.0
-      git:
-        # Required by cabal-install >= 3.0.0.0.
-        submodules: true
       before_install:
         - sudo -E apt-add-repository -y "ppa:hvr/ghc" &&
           travis_apt_get_update &&

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,0 @@
-packages: . src/fix-agda-whitespace std-lib/


### PR DESCRIPTION
In addition to `agda` and `agda-mode`, we have different programs
(i.e. `agda-bisect`, `closed-issues-for-milestone`,
`fix-agda-whitespace`, `hTags` and `size-solver`) which are
independent of each other. To use a global `cabal.project` file in
this case is too complicate and it is unnecessary.