### PR TITLE
[doc] Precedence of arrow

### DIFF
--- a/doc/user-manual/language/mixfix-operators.lagda.rst
+++ b/doc/user-manual/language/mixfix-operators.lagda.rst
@@ -47,6 +47,11 @@ Each operator is associated to a precedence, which is a floating point number
 (can be negative and fractional!).
 The default precedence for an operator is 20.
 
+.. note::
+   Please note that ``->`` is directly handled in the parser. As a result, the
+   precedence of ``->`` is lower than any precedence you may declare with
+   ``infixl`` and ``infixr``.
+
 If we give ``_and_`` more precedence than ``_⇒_``, then we will get the first result::
 
   infix 30 _and_


### PR DESCRIPTION
Added a note about the precedence of arrow from the discussion between Martin Escardo and Guillaume Allais in the agda list:
https://lists.chalmers.se/pipermail/agda/2020/011497.html