### PR TITLE
Escape metacharacters "{" and "}" in postprocess script

### DIFF
--- a/src/data/postprocess-latex.pl
+++ b/src/data/postprocess-latex.pl
@@ -10,7 +10,7 @@ my $commands   = qr"(InductiveConstructor|CoinductiveConstructor\
 
 while (<>) {
 
-  s|(\\Agda$commands){(.*?)}
+  s|(\\Agda$commands)\{(.*?)\}
 
    | my $cmd = $1;
      my $arg = $3;


### PR DESCRIPTION
Perl warns that "[the] unescaped left brace in regex is passed through in regex"; Be explicit about that the left and right brace are to be interpreted as literal characters here (enclosing the argument to an \Agda command in the LaTeX code being processed) by quoting them.