### PR TITLE
[ fix #4380 ] Use close (not vclose) for parsing instance record constructor

### DIFF
--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1244,8 +1244,8 @@ RecordSig : 'record' Expr3NoCurly TypedUntypedBindings ':' Expr
 
 -- Declaration of record constructor name.
 RecordConstructorName :: { (Name, IsInstance) }
-RecordConstructorName :                  'constructor' Id        { ($2, NotInstanceDef) }
-                      | 'instance' vopen 'constructor' Id vclose { ($4, InstanceDef) }
+RecordConstructorName :                  'constructor' Id       { ($2, NotInstanceDef) }
+                      | 'instance' vopen 'constructor' Id close { ($4, InstanceDef) }
 
 -- Fixity declarations.
 Infix :: { Declaration }

--- a/test/Succeed/Issue4380.agda
+++ b/test/Succeed/Issue4380.agda
@@ -1,0 +1,3 @@
+record Unit : Set where
+  instance
+    constructor tt


### PR DESCRIPTION
Fixes #4380 by deleting a 'v'. 