### PR TITLE
Fix for #4383

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -126,15 +126,11 @@ checkpointSubstitution' chkpt = viewTC (eCheckpoints . key chkpt)
 -- | Get substitution @Γ ⊢ ρ : Γm@ where @Γ@ is the current context
 --   and @Γm@ is the module parameter telescope of module @m@.
 --
---   In case the we don't have a checkpoint for @m@ we return the identity
---   substitution.
---   This is ok for instance if we are outside module @m@ (in which case we
---   have to supply all module parameters to any symbol defined within @m@ we
---   want to refer).
-getModuleParameterSub :: (MonadTCEnv m, ReadTCState m) => ModuleName -> m Substitution
+--   Returns @Nothing@ in case the we don't have a checkpoint for @m@.
+getModuleParameterSub :: (MonadTCEnv m, ReadTCState m) => ModuleName -> m (Maybe Substitution)
 getModuleParameterSub m = do
   mcp <- (^. stModuleCheckpoints . key m) <$> getTCState
-  maybe (return IdS) checkpointSubstitution mcp
+  traverse checkpointSubstitution mcp
 
 
 -- * Adding to the context

--- a/src/full/Agda/TypeChecking/Monad/Env.hs
+++ b/src/full/Agda/TypeChecking/Monad/Env.hs
@@ -23,7 +23,7 @@ currentModule :: MonadTCEnv m => m ModuleName
 currentModule = asksTC envCurrentModule
 
 -- | Set the name of the current module.
-withCurrentModule :: ModuleName -> TCM a -> TCM a
+withCurrentModule :: (MonadTCEnv m) => ModuleName -> m a -> m a
 withCurrentModule m =
     localTC $ \ e -> e { envCurrentModule = m }
 

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -927,20 +927,27 @@ moduleParamsToApply :: (Functor m, Applicative m, HasOptions m,
                         MonadTCEnv m, ReadTCState m, MonadDebug m)
                     => ModuleName -> m Args
 moduleParamsToApply m = do
-  -- Get the correct number of free variables (correctly raised) of @m@.
 
   traceSDoc "tc.sig.param" 90 ("computing module parameters of " <+> pretty m) $ do
-  n   <- getModuleFreeVars m
-  traceSDoc "tc.sig.param" 60 (nest 2 $ "n    = " <+> text (show n)) $ do
-  tel <- take n . telToList <$> lookupSection m
-  traceSDoc "tc.sig.param" 60 (nest 2 $ "tel  = " <+> pretty tel) $ do
-  sub <- getModuleParameterSub m
+
+  -- Jesper, 2020-01-22: If the module parameter substitution for the
+  -- module cannot be found, that likely means we are within a call to
+  -- @inTopContext@. In that case we should provide no arguments for
+  -- the module parameters (see #4383).
+  caseMaybeM (getModuleParameterSub m) (return []) $ \sub -> do
+
   traceSDoc "tc.sig.param" 60 (do
     cxt <- getContext
     nest 2 $ vcat
       [ "cxt  = " <+> prettyTCM (PrettyContext cxt)
       , "sub  = " <+> pretty sub
       ]) $ do
+
+  -- Get the correct number of free variables (correctly raised) of @m@.
+  n   <- getModuleFreeVars m
+  traceSDoc "tc.sig.param" 60 (nest 2 $ "n    = " <+> text (show n)) $ do
+  tel <- take n . telToList <$> lookupSection m
+  traceSDoc "tc.sig.param" 60 (nest 2 $ "tel  = " <+> pretty tel) $ do
   unless (size tel == n) __IMPOSSIBLE__
   let args = applySubst sub $ zipWith (\ i a -> var i <$ argFromDom a) (downFrom n) tel
   traceSDoc "tc.sig.param" 60 (nest 2 $ "args = " <+> prettyList_ (map pretty args)) $ do
@@ -970,8 +977,8 @@ moduleParamsToApply m = do
 --   sure generated definitions work properly.
 inFreshModuleIfFreeParams :: TCM a -> TCM a
 inFreshModuleIfFreeParams k = do
-  sub <- getModuleParameterSub =<< currentModule
-  if sub == IdS then k else do
+  msub <- getModuleParameterSub =<< currentModule
+  if msub == Nothing || msub == Just IdS then k else do
     m  <- currentModule
     m' <- qualifyM m . mnameFromList . (:[]) <$>
             freshName_ ("_" :: String)

--- a/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
@@ -266,7 +266,7 @@ castConstraintToCurrentContext' cl = do
   let gamma2 = gamma - size gamma1
 
   -- Γ ⊢ σ : Δ₁
-  sigma <- liftTCM $ getModuleParameterSub modN
+  sigma <- liftTCM $ fromMaybe idS <$> getModuleParameterSub modN
 
   -- Debug printing.
   reportSDoc "tc.constr.cast" 40 $ "casting constraint" $$ do

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -653,7 +653,7 @@ evalTCM v = do
     tcInContext :: Term -> Term -> UnquoteM Term
     tcInContext c m = do
       c <- unquote c
-      liftU1 inTopContext $ go c (evalTCM m)
+      liftU1 unsafeInTopContext $ go c (evalTCM m)
       where
         go :: [Arg R.Type] -> UnquoteM Term -> UnquoteM Term
         go []       m = m

--- a/test/Succeed/Issue4383.agda
+++ b/test/Succeed/Issue4383.agda
@@ -1,0 +1,23 @@
+{-# OPTIONS --rewriting        #-}
+{-# OPTIONS --confluence-check #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module _ (A : Set) where
+  postulate
+    D : Set
+    f : D → D → D
+    r : (x y z : D) → f x (f y z) ≡ f x z
+
+  {-# REWRITE r #-}
+  -- WAS:
+  -- Confluence check failed: f x (f y (f y₁ z)) reduces to both
+  -- f x (f y₁ z) and f x (f y z) which are not equal because
+  -- y != y₁ of type D
+  -- when checking confluence of the rewrite rule r with itself
+
+  module _ (x y y₁ z : D) where
+    -- SUCCEEDS:
+    _ : f x (f y₁ z) ≡ f x (f y z)
+    _ = refl


### PR DESCRIPTION
This patch fixes #4383 by changing the implementation of `moduleParamsToApply` to return the empty list when referring to a definition of a module that is not in the module checkpoint map (i.e. when we are inside a call to `inTopContext`). Previously, it would return the module parameters but default to using `IdS` as the module parameter substitution, which produced ill-typed terms and caused #4383.

However, this change also has an effect on the behaviour of the reflection primitive `inContext`: previously, calling `inContext []` would bring you back to the context of the module in which the macro is called, but now it *actually* brings you to to top-level context. I think the new behaviour is the correct one, but the test case for #1827 contains a comment that advocates the old behaviour. @UlfNorell what do you think we should do here?