### PR TITLE
Note that type sigs are forbidden in mutrec data

### DIFF
--- a/doc/user-manual/language/mutual-recursion.lagda.rst
+++ b/doc/user-manual/language/mutual-recursion.lagda.rst
@@ -27,7 +27,7 @@ For data types and records the following syntax is used to separate the declarat
   data Vec (A : Set) : Nat → Set  -- Note the absence of ‘where’.
 
   -- Definition.
-  data Vec A where
+  data Vec A where  -- Note the absence of a type signature.
     []   : Vec A zero
     _::_ : {n : Nat} → A → Vec A n → Vec A (suc n)
 


### PR DESCRIPTION
I was tripped up by the just how forbidden type signatures on mutually recursive data are. I think the note in the PR would have helped me (though I'm not sure it would help others / is worth its weigth in text). Feel free to accept/deny as you see fit (as in, I won't be offended either way) :-)

See also #4430