### PR TITLE
[ #4437 ] checkInjectivity: computeHead: UnknownHead instead of hard fail

### DIFF
--- a/test/Fail/Issue821.err
+++ b/test/Fail/Issue821.err
@@ -1,3 +1,3 @@
 Issue821.agda:26,9-10
-x != (f _ x) of type (D A)
-when checking that the expression p has type P (f _ x)
+x != (f A x) of type (D A)
+when checking that the expression p has type P (f A x)

--- a/test/Fail/ReifyProjectionLike.err
+++ b/test/Fail/ReifyProjectionLike.err
@@ -1,4 +1,4 @@
 ReifyProjectionLike.agda:20,8-14
 just is not a constructor of the datatype Sing
 when checking that the pattern just x has type
-Sing A (fromJust _ m)
+Sing A (fromJust A m)


### PR DESCRIPTION
Re: #4437 

Letting computeHead return UnknownHead instead of aborting the injectivity check has the effect that data projections are now classified as injective.

Injectivity prevents projection-likeness.  Currently, injectivity takes precedence over projection-likeness.  As a consequences, this patch makes

    benchmark/proj/Data.agda

fail which uses Sigma-types implemented as data types, relying that the projections fst and snd would be classified as projection-like.

This PR isn't ready yet, we need to clarify the precedence of projection-like and injectivity.  See @UlfNorell 's comment: https://github.com/agda/agda/issues/4437#issuecomment-584260140