### PR TITLE
New flag --no-qualified-instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,12 @@
 Release notes for Agda version 2.6.2
 ====================================
+
+
+Pragmas and options
+-------------------
+
+* New options `--qualified-instances` (default) and
+  `--no-qualified-instances`. When `--no-qualified-instances` is
+  enabled, Agda will only consider candidates for instance search that
+  are in scope under an unqualified name (see
+  [#4522](https://github.com/agda/agda/pull/4522)).

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -170,6 +170,7 @@ data PragmaOptions = PragmaOptions
       --   (False) or keep them as variables (True).
   , optInstanceSearchDepth       :: Int
   , optOverlappingInstances      :: Bool
+  , optQualifiedInstances        :: Bool  -- ^ Should instance search consider instances with qualified names?
   , optInversionMaxDepth         :: Int
   , optSafe                      :: Bool
   , optDoubleCheck               :: Bool
@@ -281,6 +282,7 @@ defaultPragmaOptions = PragmaOptions
   , optKeepPatternVariables      = False
   , optInstanceSearchDepth       = 500
   , optOverlappingInstances      = False
+  , optQualifiedInstances        = True
   , optInversionMaxDepth         = 50
   , optSafe                      = False
   , optDoubleCheck               = False
@@ -430,6 +432,8 @@ restartOptions =
   , (B . optRewriting, "--rewriting")
   , (B . optCubical, "--cubical")
   , (B . optOverlappingInstances, "--overlapping-instances")
+  , (B . optQualifiedInstances, "--qualified-instances")
+  , (B . not . optQualifiedInstances, "--no-qualified-instances")
   , (B . optSafe, "--safe")
   , (B . optDoubleCheck, "--double-check")
   , (B . not . optSyntacticEquality, "--no-syntactic-equality")
@@ -738,6 +742,12 @@ overlappingInstancesFlag o = return $ o { optOverlappingInstances = True }
 noOverlappingInstancesFlag :: Flag PragmaOptions
 noOverlappingInstancesFlag o = return $ o { optOverlappingInstances = False }
 
+qualifiedInstancesFlag :: Flag PragmaOptions
+qualifiedInstancesFlag o = return $ o { optQualifiedInstances = True }
+
+noQualifiedInstancesFlag :: Flag PragmaOptions
+noQualifiedInstancesFlag o = return $ o { optQualifiedInstances = False }
+
 inversionMaxDepthFlag :: String -> Flag PragmaOptions
 inversionMaxDepthFlag s o = do
   d <- integerArgument "--inversion-max-depth" s
@@ -1008,6 +1018,10 @@ pragmaOptions =
                     "consider recursive instance arguments during pruning of instance candidates"
     , Option []     ["no-overlapping-instances"] (NoArg noOverlappingInstancesFlag)
                     "don't consider recursive instance arguments during pruning of instance candidates (default)"
+    , Option []     ["qualified-instances"] (NoArg qualifiedInstancesFlag)
+                    "use instances with qualified names (default)"
+    , Option []     ["no-qualified-instances"] (NoArg noQualifiedInstancesFlag)
+                    "don't use instances with qualified names (default)"
     , Option []     ["inversion-max-depth"] (ReqArg inversionMaxDepthFlag "N")
                     "set maximum depth for pattern match inversion to N (default: 50)"
     , Option []     ["safe"] (NoArg safeFlag)

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -1097,7 +1097,7 @@ isNameInScope q scope =
   Set.member q (scope ^. scopeInScope)
 
 -- | Find the concrete names that map (uniquely) to a given abstract name.
---   Sort by length, shortest first.
+--   Sort by number of modules in the qualified name, unqualified names first.
 
 inverseScopeLookup :: Either A.ModuleName A.QName -> ScopeInfo -> [C.QName]
 inverseScopeLookup = inverseScopeLookup' AmbiguousConProjs

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -15,13 +15,14 @@ import qualified Data.List as List
 import Data.Function (on)
 import Data.Monoid hiding ((<>))
 
-import Agda.Interaction.Options (optOverlappingInstances)
+import Agda.Interaction.Options (optOverlappingInstances, optQualifiedInstances)
 
 import Agda.Syntax.Common
+import Agda.Syntax.Concrete.Name (isQualified)
 import Agda.Syntax.Position
 import Agda.Syntax.Internal as I
 import Agda.Syntax.Internal.MetaVars
-import Agda.Syntax.Scope.Base (isNameInScope)
+import Agda.Syntax.Scope.Base (isNameInScope, inverseScopeLookup', AllowAmbiguousNames(..))
 
 import Agda.TypeChecking.Errors () --instance only
 import Agda.TypeChecking.Implicit (implicitArgs)
@@ -146,6 +147,10 @@ initialInstanceCandidates t = do
 
     candidate :: Relevance -> QName -> TCM (Maybe Candidate)
     candidate rel q = ifNotM (isNameInScope q <$> getScope) (return Nothing) $ do
+      -- Jesper, 2020-03-16: When using --no-qualified-instances,
+      -- filter out instances that are only in scope under a qualified
+      -- name.
+      filterQualified $ do
       -- Andreas, 2012-07-07:
       -- we try to get the info for q
       -- while opening a module, q may be in scope but not in the signature
@@ -173,6 +178,13 @@ initialInstanceCandidates t = do
         -- unbound constant throws an internal error
         handle (TypeError _ (Closure {clValue = InternalError _})) = return Nothing
         handle err                                                 = throwError err
+
+        filterQualified :: TCM (Maybe Candidate) -> TCM (Maybe Candidate)
+        filterQualified m = ifM (optQualifiedInstances <$> pragmaOptions) m $ do
+          qc <- inverseScopeLookup' AmbiguousAnything (Right q) <$> getScope
+          let isQual = maybe False isQualified $ listToMaybe qc
+          if isQual then return Nothing else m
+
 
 -- | @findInstance m (v,a)s@ tries to instantiate on of the types @a@s
 --   of the candidate terms @v@s to the type @t@ of the metavariable @m@.

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -200,12 +200,12 @@ instance EmbPrj Doc where
 
 instance EmbPrj PragmaOptions where
   icod_ = \case
-    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ->
-      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv
+    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww ->
+      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww
 
   value = vcase $ \case
-    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv] ->
-      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv
+    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww] ->
+      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww
     _ -> malformed
 
 instance EmbPrj WarningMode where

--- a/test/Fail/NoQualifiedInstances.agda
+++ b/test/Fail/NoQualifiedInstances.agda
@@ -1,0 +1,10 @@
+{-# OPTIONS --no-qualified-instances #-}
+
+postulate
+  A : Set
+  f : {{A}} → A
+
+module M where postulate instance a : A
+
+test : A
+test = f

--- a/test/Fail/NoQualifiedInstances.err
+++ b/test/Fail/NoQualifiedInstances.err
@@ -1,0 +1,3 @@
+NoQualifiedInstances.agda:10,8-9
+No instance of type A was found in scope.
+when checking that the expression f has type A

--- a/test/Succeed/NoQualifiedInstances-AnonymousInstance.agda
+++ b/test/Succeed/NoQualifiedInstances-AnonymousInstance.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --no-qualified-instances #-}
+
+module NoQualifiedInstances-AnonymousInstance where
+
+postulate
+  A : Set
+  f : {{A}} → A
+
+postulate instance _ : A
+
+test : A
+test = f

--- a/test/Succeed/NoQualifiedInstances-Import.agda
+++ b/test/Succeed/NoQualifiedInstances-Import.agda
@@ -1,0 +1,11 @@
+{-# OPTIONS --no-qualified-instances #-}
+
+module NoQualifiedInstances-Import where
+
+open import NoQualifiedInstances.Import.A as A
+
+postulate
+  f : {{A.I}} → A.I
+
+test : A.I
+test = f

--- a/test/Succeed/NoQualifiedInstances-InAnonymousModule.agda
+++ b/test/Succeed/NoQualifiedInstances-InAnonymousModule.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --no-qualified-instances #-}
+
+module NoQualifiedInstances-InAnonymousModule where
+
+postulate
+  A : Set
+  f : {{A}} → A
+
+module _ where postulate instance a : A
+
+test : A
+test = f

--- a/test/Succeed/NoQualifiedInstances-ParameterizedImport.agda
+++ b/test/Succeed/NoQualifiedInstances-ParameterizedImport.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --no-qualified-instances #-}
+
+module NoQualifiedInstances-ParameterizedImport where
+
+postulate
+  T : Set
+
+open import NoQualifiedInstances.ParameterizedImport.A T as A
+
+postulate
+  f : {{A.I}} → A.I
+
+test : A.I
+test = f

--- a/test/Succeed/NoQualifiedInstances/Import/A.agda
+++ b/test/Succeed/NoQualifiedInstances/Import/A.agda
@@ -1,0 +1,6 @@
+module NoQualifiedInstances.Import.A where
+
+record I : Set where
+
+instance
+  postulate i : I

--- a/test/Succeed/NoQualifiedInstances/ParameterizedImport/A.agda
+++ b/test/Succeed/NoQualifiedInstances/ParameterizedImport/A.agda
@@ -1,0 +1,5 @@
+module NoQualifiedInstances.ParameterizedImport.A (T : Set) where
+
+record I : Set where
+
+postulate instance i : I


### PR DESCRIPTION
This flag adds a new flag `--no-qualified-instances` (and its opposite `--qualified-instances`) that makes Agda disregard instances that are only in scope under a qualified name. The reason for adding this option is because @ajrouvoet is having major performance problems with instance search (see https://github.com/agda/agda/issues/4517) and currently it is very hard to control which instances are considered by Agda. Enabling this flag also fixes the undesired behaviour in #4166 (although having a proper fix for that issue would still be good).