### PR TITLE
[ fix #4530 ] Do not normalize goal type of instance search

### DIFF
--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -274,7 +274,6 @@ findInstance' m cands = ifM (isFrozen m) (do
             prettyTCM (List.map candidateTerm cs)
           return (Just (cs, Nothing))
 
--- | Precondition: type is spine reduced and ends in a Def or a Var.
 insidePi :: Type -> (Type -> TCM a) -> TCM a
 insidePi t ret = reduce (unEl t) >>= \case
     Pi a b     -> addContext (absName b, a) $ insidePi (absBody b) ret

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -228,7 +228,7 @@ findInstance' m cands = ifM (isFrozen m) (do
        nest 2 $ vcat
         [ sep [ (if overlap then "overlap" else empty) <+> pretty v <+> ":"
               , nest 2 $ pretty t ] | Candidate v t overlap <- cands ]
-      t <- normalise =<< getMetaTypeInContext m
+      t <- getMetaTypeInContext m
       reportSLn "tc.instance" 70 $ "findInstance 2: t: " ++ prettyShow t
       insidePi t $ \ t -> do
       reportSDoc "tc.instance" 15 $ "findInstance 3: t =" <+> prettyTCM t
@@ -276,8 +276,7 @@ findInstance' m cands = ifM (isFrozen m) (do
 
 -- | Precondition: type is spine reduced and ends in a Def or a Var.
 insidePi :: Type -> (Type -> TCM a) -> TCM a
-insidePi t ret =
-  case unEl t of
+insidePi t ret = reduce (unEl t) >>= \case
     Pi a b     -> addContext (absName b, a) $ insidePi (absBody b) ret
     Def{}      -> ret t
     Var{}      -> ret t

--- a/test/Fail/Issue2288.err
+++ b/test/Fail/Issue2288.err
@@ -1,3 +1,3 @@
 Issue2288.agda:22,1-10
-No instance of type Eq Nat was found in scope.
+No instance of type Eq ∣ NatSetoid ∣ was found in scope.
 when checking the definition of NatSetoid

--- a/test/Fail/Issue4530.agda
+++ b/test/Fail/Issue4530.agda
@@ -1,0 +1,12 @@
+
+open import Agda.Builtin.Bool public
+open import Agda.Builtin.Nat public
+
+data IsTrue : Bool → Set where
+  instance truth : IsTrue true
+
+postulate
+  foo : {{IsTrue (3 < 2)}} → Nat
+
+test : Nat
+test = foo

--- a/test/Fail/Issue4530.err
+++ b/test/Fail/Issue4530.err
@@ -1,0 +1,3 @@
+Issue4530.agda:12,8-11
+No instance of type IsTrue (3 < 2) was found in scope.
+when checking that the expression foo has type Nat


### PR DESCRIPTION
This removes the call to `normalise` on the type of instance search and replaces it by the minimal set of `reduce`s necessary to perform instance search.

@ajrouvoet Could you test your project with this patch and report if it has a (positive or negative) impact on the performance of instance search?