### PR TITLE
[ #3677 ] WIP

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -924,14 +924,25 @@ instance PrettyTCM TypeError where
         unambiguousP (C.OpAppP r op _ xs) = foldl C.AppP (C.IdentP op) xs
         unambiguousP e                    = e
 
-    OperatorInformation sects err ->
+    OperatorInformation sects names err ->
       prettyTCM err
         $+$
-      fsep (pwords "Operators used in the grammar:")
-        $$
-      nest 2
-        (if null sects then "None" else
-         vcat (map text $
+      usedOperators
+        $+$
+      usedNames
+      where
+      usedNames
+        | null names = empty
+        | otherwise  = vcat
+            [ fsep $ pwords "Further definitions used in the grammar:"
+            , nest 2 $ sep $ map prettyTCM names
+            ]
+      usedOperators
+        | null sects = "(no operators used in the grammar)"
+        | otherwise  = vcat
+            [ fsep $ pwords "Operators used in the grammar:"
+            , nest 2 $ vcat $
+               map text $
                lines $
                Boxes.render $
                (\(col1, col2, col3) ->
@@ -940,8 +951,8 @@ instance PrettyTCM TypeError where
                unzip3 $
                map prettySect $
                sortBy (compare `on` show . notaName . sectNotation) $
-               filter (not . closedWithoutHoles) sects))
-      where
+               filter (not . closedWithoutHoles) sects
+             ]
       trimLeft  = dropWhile isNormalHole
       trimRight = dropWhileEnd isNormalHole
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3456,7 +3456,8 @@ data TypeError
             --   If it is non-empty, the first entry could be printed as error hint.
         | AmbiguousParseForLHS LHSOrPatSyn C.Pattern [C.Pattern]
             -- ^ Pattern and its possible interpretations.
-        | OperatorInformation [NotationSection] TypeError
+        | OperatorInformation [NotationSection] [C.QName] TypeError
+            -- ^ Operators and other names used during failed operator parse.
 {- UNUSED
         | NoParseForPatternSynonym C.Pattern
         | AmbiguousParseForPatternSynonym C.Pattern [C.Pattern]


### PR DESCRIPTION
We want to report the names that are identical to name parts of
operators.  The current approach does not work;

- we want to report the abstract names (with bindingSite)
- we have to figure out a way how to get them from the flattenedScope

TODO!