### PR TITLE
Add a --call-by-name flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Pragmas and options
   are in scope under an unqualified name (see
   [#4522](https://github.com/agda/agda/pull/4522)).
 
+* New option `--call-by-name` turns off call-by-need evaluation at type
+  checking time.
+
 * New option `--highlight-occurrences` (off by default) enables the HTML
   backend to include a JavaScript file that highlights all occurrences of
   the mouse-hovered symbol (see

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -379,6 +379,10 @@ Other features
 
      Disable reduction using the Agda Abstract Machine.
 
+.. option:: --call-by-name
+
+     Disable call-by-need evaluation in the Agda Abstract Machine.
+
 .. option:: --no-forcing
 
      Disable the forcing optimisation. Since Agda 2.6.1 is a pragma

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -189,6 +189,8 @@ data PragmaOptions = PragmaOptions
   , optPrintPatternSynonyms      :: Bool
   , optFastReduce                :: Bool
     -- ^ Use the Agda abstract machine (fastReduce)?
+  , optCallByName                :: Bool
+    -- ^ Use call-by-name instead of call-by-need
   , optConfluenceCheck           :: Bool
     -- ^ Check confluence of rewrite rules?
   , optFlatSplit                 :: Bool
@@ -299,6 +301,7 @@ defaultPragmaOptions = PragmaOptions
   , optAutoInline                = True
   , optPrintPatternSynonyms      = True
   , optFastReduce                = True
+  , optCallByName                = False
   , optConfluenceCheck           = False
   , optFlatSplit                 = True
   }
@@ -445,6 +448,7 @@ restartOptions =
   , (B . not . optCompareSorts, "--no-sort-comparison")
   , (B . not . optAutoInline, "--no-auto-inline")
   , (B . not . optFastReduce, "--no-fast-reduce")
+  , (B . optCallByName, "--call-by-name")
   , (I . optInstanceSearchDepth, "--instance-search-depth")
   , (I . optInversionMaxDepth, "--inversion-max-depth")
   , (W . optWarningMode, "--warning")
@@ -606,6 +610,9 @@ noPrintPatSynFlag o = return $ o { optPrintPatternSynonyms = False }
 
 noFastReduceFlag :: Flag PragmaOptions
 noFastReduceFlag o = return $ o { optFastReduce = False }
+
+callByNameFlag :: Flag PragmaOptions
+callByNameFlag o = return $ o { optCallByName = True }
 
 latexDirFlag :: FilePath -> Flag CommandLineOptions
 latexDirFlag d o = return $ o { optLaTeXDir = d }
@@ -1067,6 +1074,8 @@ pragmaOptions =
                     "expand pattern synonyms when printing terms"
     , Option []     ["no-fast-reduce"] (NoArg noFastReduceFlag)
                     "disable reduction using the Agda Abstract Machine"
+    , Option []     ["call-by-name"] (NoArg callByNameFlag)
+                    "use call-by-name evaluation instead of call-by-need"
     ]
 
 -- | Pragma options of previous versions of Agda.

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -787,7 +787,7 @@ reduceTm rEnv bEnv !constInfo normalisation ReductionFlags{..} =
     getMeta m      = maybe __IMPOSSIBLE__ mvInstantiation (IntMap.lookup (metaId m) metaStore)
     partialDefs    = runReduce getPartialDefs
     rewriteRules f = cdefRewriteRules (constInfo f)
-    callByNeed     = envCallByNeed (redEnv rEnv)
+    callByNeed     = envCallByNeed (redEnv rEnv) && not (optCallByName $ redSt rEnv ^. stPragmaOptions)
     iview          = runReduce intervalView'
 
     runReduce :: ReduceM a -> a

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -70,7 +70,7 @@ import Agda.Utils.Except
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20200322 * 10 + 0
+currentInterfaceVersion = 20200325 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -200,12 +200,12 @@ instance EmbPrj Doc where
 
 instance EmbPrj PragmaOptions where
   icod_ = \case
-    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww ->
-      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww
+    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx ->
+      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx
 
   value = vcase $ \case
-    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww] ->
-      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww
+    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx] ->
+      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx
     _ -> malformed
 
 instance EmbPrj WarningMode where


### PR DESCRIPTION
Since we only have local call-by-need, losing sharing between calls to `reduce`, call-by-need evaluation can blow up the size of terms in certain situations. This PR adds the flag `--call-by-name` to turn switch the abstract machine to call-by-name instead of call-by-need.

Triggered by #4060