### PR TITLE
[ doc ] Authors and contributors gathered at team.rst

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -4,7 +4,8 @@ cabal-version:   >= 1.10
 build-type:      Custom
 license:         OtherLicense
 license-file:    LICENSE
-author:          Agda 2 was originally written by Ulf Norell, partially based on code from Agda 1 by Catarina Coquand and Makoto Takeyama, and from Agdalight by Ulf Norell and Andreas Abel. Agda 2 is currently actively developed mainly by Andreas Abel, Guillaume Allais, Jesper Cockx, Nils Anders Danielsson, Philipp Hausmann, Fredrik Nordvall Forsberg, Ulf Norell, Víctor López Juan, Andrés Sicard-Ramírez, and Andrea Vezzosi. Further, Agda 2 has received contributions by, amongst others, Stevan Andjelkovic, Marcin Benke, Jean-Philippe Bernardy, Guillaume Brunerie, James Chapman, Liang-Ting Chen, Dominique Devriese, Péter Diviánszky, Olle Fredriksson, Adam Gundry, Daniel Gustafsson, Kuen-Bang Hou (favonia), Patrik Jansson, Alan Jeffrey, Wolfram Kahl, Wen Kokke, Fredrik Lindblad, Francesco Mazzoli, Stefan Monnier, Darin Morrison, Guilhem Moulin, Nicolas Pouillard, Nobuo Yamashita, Christian Sattler, and Makoto Takeyama and many more.
+copyright:       (c) 2005-2020 The Agda Team.
+author:          Ulf Norell and The Agda Team, see https://agda.readthedocs.io/en/latest/team.html
 maintainer:      Ulf Norell <ulfn@chalmers.se>
 homepage:        http://wiki.portal.chalmers.se/agda/
 bug-reports:     https://github.com/agda/agda/issues

--- a/doc/user-manual/conf.py
+++ b/doc/user-manual/conf.py
@@ -20,25 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Agda'
-copyright = u'''2005–2020 remains with the authors.
-Agda 2 was originally written by Ulf Norell,
-partially based on code from Agda 1 by Catarina Coquand and Makoto Takeyama,
-and from Agdalight by Ulf Norell and Andreas Abel.
-
-Agda 2 is currently actively developed mainly by Andreas Abel,
-Guillaume Allais, Jesper Cockx, Nils Anders Danielsson, Philipp
-Hausmann, Fredrik Nordvall Forsberg, Ulf Norell, Víctor López Juan,
-Andrés Sicard-Ramírez, and Andrea Vezzosi.
-
-Further, Agda 2 has received contributions by, amongst others, Stevan
-Andjelkovic, Marcin Benke, Jean-Philippe Bernardy, Guillaume Brunerie,
-James Chapman, Dominique Devriese, Péter Diviánszky, Olle Fredriksson,
-Adam Gundry, Daniel Gustafsson, Kuen-Bang Hou (favonia), Patrik
-Jansson, Alan Jeffrey, Wolfram Kahl, Wen Kokke, John Leo, Fredrik Lindblad,
-Francesco Mazzoli, Stefan Monnier, Darin Morrison, Guilhem Moulin,
-Nicolas Pouillard, Benjamin Price, Nobuo Yamashita, Christian Sattler,
-Makoto Takeyama and Tesla Ice Zhang.  The full list of contributors is
-available at https://github.com/agda/agda/graphs/contributors'''
+copyright = u'''2005–2020 remains with the authors.'''
 author = u'The Agda Team'
 
 # The short X.Y version

--- a/doc/user-manual/team.rst
+++ b/doc/user-manual/team.rst
@@ -3,42 +3,75 @@
 The Agda Team and License
 *************************
 
-Authors:
+Agda 2 was originally written by Ulf Norell,
+partially based on code from Agda 1 by Catarina Coquand and Makoto Takeyama,
+and from Agdalight by Ulf Norell and Andreas Abel.
 
-* Ulf Norell
+Agda 2 is currently actively developed mainly by (in alphabetical order):
+
 * Andreas Abel
-* Nils Anders Danielsson
-* Makoto Takeyama
-* Catarina Coquand
-
-Contributors (alphabetically sorted):
-
-* Stevan Andjelkovic
-* Marcin Benke
-* Jean-Philippe Bernardy
-* James Chapman
+* Guillaume Allais
+* Liang-Ting Chen
 * Jesper Cockx
-* Dominique Devriese
-* Péter Diviánszky
-* Fredrik Nordvall Forsberg
-* Olle Fredriksson
-* Daniel Gustafsson
-* Philipp Hausmann
-* Patrik Jansson
-* Alan Jeffrey
-* Wolfram Kahl
-* John Leo
-* Fredrik Lindblad
-* Francesco Mazzoli
-* Stefan Monnier
-* Darin Morrison
-* Guilhem Moulin
-* Nicolas Pouillard
-* Benjamin Price
+* Nils Anders Danielsson
+* Víctor López Juan
+* Ulf Norell
 * Andrés Sicard-Ramírez
 * Andrea Vezzosi
 * Tesla Ice Zhang
-* and many more
+
+Agda 2 has received major contributions by the following developers, amongst others.
+Some contributors have pioneered a feature which shall be mentioned here.
+But many have worked on these features for improvements and maintenance.
+
+* Andreas Abel: *termination checker, sized types, irrelevance, copatterns*
+* Guillaume Allais: *warnings, pattern guards, standard library 1.0*
+* Stevan Andjelkovic: *LaTeX backend*
+* Miëtek Bak: *Agda logo*
+* Marcin Benke: *original "Alonzo" compiler to Haskell*
+* Jean-Philippe Bernardy: ``syntax`` *declarations*
+* Guillaume Brunerie
+* James Chapman
+* Liang-Ting Chen: *github workflows*
+* Jesper Cockx: *rewriting, unification* ``--without-K``
+* Catarina Coquand: *Agda 1*
+* Matthew Daggitt: *standard library 1.0*
+* Nils Anders Danielsson: *efficient positivity checker, HTML backend, highlighting, standard library*
+* Dominique Devriese: ``instance`` *arguments*
+* Péter Diviánszky: *web frontent,* ``variable`` *declarations*
+* Robert Estelle
+* Olle Fredriksson: *Epic compiler backend*
+* Paolo Giarrusso
+* Adam Gundry: *pattern synonyms*
+* Daniel Gustafsson: *Epic compiler backend*
+* Philipp Hausmann: *treeless compiler, UHC compiler backend, testsuite runner, Travis CI*
+* Kuen-Bang Hou "favonia"
+* Patrik Jansson
+* Alan Jeffrey: *JavaScript compiler backend*
+* Wolfram Kahl
+* Wen Kokke
+* John Leo
+* Fredrik Lindblad: *Agsy proof search "Auto"*
+* Víctor López Juan: "tog" prototype, markdown frontend, documentation*
+* Ting-Gan Lua
+* Francesco Mazzoli: "tog" prototype*
+* Stefan Monnier
+* Guilhem Moulin: *highlighting*
+* Fredrik Nordvall Forsberg: *pattern lambdas, warnings*
+* Ulf Norell: *Agda 2*
+* Nicolas Pouillard: *module record expressions*
+* Benjamin Price
+* Jonathan Prieto: *Agda package manager*
+* Nobuo Yamashita
+* Christian Sattler
+* Andrés Sicard-Ramírez: *Agda releases, Travis CI*
+* Makoto Takeyama: *Agda 1, Emacs mode, "MAlonzo" compiler to Haskell, serialization*
+* Andrea Vezzosi: *Cubical Agda, Agda-flat, Agda-parametric*
+* Noam Zeilberger: *pattern lambdas*
+* Tesla Ice Zhang
+
+The full list of contributors (more than 140)
+is available at https://github.com/agda/agda/graphs/contributors .
 
 The Agda license is `here
 <https://github.com/agda/agda/blob/master/LICENSE>`_.


### PR DESCRIPTION
Removed author lists from Agda.cabal and copyright field of documentation.  The list is maintained now at team.rst in the documentation.  There are three categories:

  1. Main developers: consistently and currently active major developers.

  2. Major contributors: more that a few patches, or some pioneering deed.
     "A few" is not exactly quantifiable, but I added new developers to the list from around 20 patches.  Number of patches isn't a strict measure for size of a contribution.

  3. All contributors: can be obtained from the git repo.

TODOs:

  * Ad 3. Make list explicit?

  * Ad 2. Added the contributed features from my memory.  There might be omissions or misattributions.

