### PR TITLE
wrap org-mode exported html as html

### DIFF
--- a/src/full/Agda/Interaction/Highlighting/HTML.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML.hs
@@ -75,7 +75,7 @@ rstDelimiter = ".. raw:: html\n"
 -- | The directive inserted before rendered code blocks in org
 
 orgDelimiterStart :: String
-orgDelimiterStart = "#+BEGIN_EXPORT html\n<pre class=\"agda\">\n"
+orgDelimiterStart = "#+BEGIN_EXPORT html\n<pre class=\"Agda\">\n"
 
 -- | The directive inserted after rendered code blocks in org
 

--- a/src/full/Agda/Interaction/Highlighting/HTML.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML.hs
@@ -72,6 +72,16 @@ occurrenceHighlightJsFile = "highlight-hover.js"
 rstDelimiter :: String
 rstDelimiter = ".. raw:: html\n"
 
+-- | The directive inserted before rendered code blocks in org
+
+orgDelimiterStart :: String
+orgDelimiterStart = "#+BEGIN_EXPORT html\n<pre class=\"agda\">\n"
+
+-- | The directive inserted after rendered code blocks in org
+
+orgDelimiterEnd :: String
+orgDelimiterEnd = "</pre>\n#+END_EXPORT\n"
+
 -- | Determine how to highlight the file
 
 highlightOnlyCode :: HtmlHighlight -> FileType -> Bool
@@ -318,8 +328,16 @@ code onlyCode fileType = mconcat . if onlyCode
       go _      = __IMPOSSIBLE__
 
   mkOrg :: [TokenInfo] -> Html
-  mkOrg = mconcat . map go
+  mkOrg tokens = mconcat $ if containsCode then formatCode else formatNonCode
     where
+      containsCode = any ((/= Just Background) . aspect . trd) tokens
+
+      startDelimiter = preEscapedToHtml orgDelimiterStart
+      endDelimiter = preEscapedToHtml orgDelimiterEnd
+
+      formatCode = startDelimiter : foldr (\x -> (go x :)) [endDelimiter] tokens
+      formatNonCode = map go tokens
+
       go token@(_, s, mi) = if aspect mi == Just Background
         then preEscapedToHtml s
         else mkHtml token

--- a/test/LaTeXAndHTML/Tests.hs
+++ b/test/LaTeXAndHTML/Tests.hs
@@ -113,6 +113,8 @@ mkLaTeXOrHTMLTest k copy agdaBin inp =
                   then "md"
                   else if "RsTHighlight" `List.isPrefixOf` inFileName
                   then "rst"
+                  else if "OrgHighlight" `List.isPrefixOf` inFileName
+                  then "org"
                   else "html"
 
   flags :: FilePath -> [String]

--- a/test/LaTeXAndHTML/succeed/OrgHighlightCode.flags
+++ b/test/LaTeXAndHTML/succeed/OrgHighlightCode.flags
@@ -1,0 +1,1 @@
+--html-highlight=code

--- a/test/LaTeXAndHTML/succeed/OrgHighlightCode.lagda.org
+++ b/test/LaTeXAndHTML/succeed/OrgHighlightCode.lagda.org
@@ -1,0 +1,18 @@
+* Org mode
+
+- A list item!
+- Another1
+
+#+begin_src agda2
+module OrgHighlightCode where
+
+data Bool : Set where
+#+end_src
+
+Some prose.
+Some more code.
+
+#+begin_src agda2
+  true  : Bool
+  false : Bool
+#+end_src

--- a/test/LaTeXAndHTML/succeed/OrgHighlightCode.org
+++ b/test/LaTeXAndHTML/succeed/OrgHighlightCode.org
@@ -1,0 +1,22 @@
+* Org mode
+
+- A list item!
+- Another1
+
+#+BEGIN_EXPORT html
+<pre class="Agda">
+<a id="58" class="Keyword">module</a> <a id="65" href="OrgHighlightCode.html" class="Module">OrgHighlightCode</a> <a id="82" class="Keyword">where</a>
+
+<a id="89" class="Keyword">data</a> <a id="Bool"></a><a id="94" href="OrgHighlightCode.html#94" class="Datatype">Bool</a> <a id="99" class="Symbol">:</a> <a id="101" class="PrimitiveType">Set</a> <a id="105" class="Keyword">where</a>
+</pre>
+#+END_EXPORT
+
+Some prose.
+Some more code.
+
+#+BEGIN_EXPORT html
+<pre class="Agda">
+  <a id="Bool.true"></a><a id="171" href="OrgHighlightCode.html#171" class="InductiveConstructor">true</a>  <a id="177" class="Symbol">:</a> <a id="179" href="OrgHighlightCode.html#94" class="Datatype">Bool</a>
+  <a id="Bool.false"></a><a id="186" href="OrgHighlightCode.html#186" class="InductiveConstructor">false</a> <a id="192" class="Symbol">:</a> <a id="194" href="OrgHighlightCode.html#94" class="Datatype">Bool</a>
+</pre>
+#+END_EXPORT

--- a/test/LaTeXAndHTML/succeed/OrgHighlightCodeAuto.flags
+++ b/test/LaTeXAndHTML/succeed/OrgHighlightCodeAuto.flags
@@ -1,0 +1,1 @@
+--html-highlight=auto

--- a/test/LaTeXAndHTML/succeed/OrgHighlightCodeAuto.lagda.org
+++ b/test/LaTeXAndHTML/succeed/OrgHighlightCodeAuto.lagda.org
@@ -1,0 +1,18 @@
+* Org mode
+
+- A list item!
+- Another1
+
+#+begin_src agda2
+module OrgHighlightCodeAuto where
+
+data Bool : Set where
+#+end_src
+
+Some prose.
+Some more code.
+
+#+begin_src agda2
+  true  : Bool
+  false : Bool
+#+end_src

--- a/test/LaTeXAndHTML/succeed/OrgHighlightCodeAuto.org
+++ b/test/LaTeXAndHTML/succeed/OrgHighlightCodeAuto.org
@@ -1,0 +1,22 @@
+* Org mode
+
+- A list item!
+- Another1
+
+#+BEGIN_EXPORT html
+<pre class="Agda">
+<a id="58" class="Keyword">module</a> <a id="65" href="OrgHighlightCodeAuto.html" class="Module">OrgHighlightCodeAuto</a> <a id="86" class="Keyword">where</a>
+
+<a id="93" class="Keyword">data</a> <a id="Bool"></a><a id="98" href="OrgHighlightCodeAuto.html#98" class="Datatype">Bool</a> <a id="103" class="Symbol">:</a> <a id="105" class="PrimitiveType">Set</a> <a id="109" class="Keyword">where</a>
+</pre>
+#+END_EXPORT
+
+Some prose.
+Some more code.
+
+#+BEGIN_EXPORT html
+<pre class="Agda">
+  <a id="Bool.true"></a><a id="175" href="OrgHighlightCodeAuto.html#175" class="InductiveConstructor">true</a>  <a id="181" class="Symbol">:</a> <a id="183" href="OrgHighlightCodeAuto.html#98" class="Datatype">Bool</a>
+  <a id="Bool.false"></a><a id="190" href="OrgHighlightCodeAuto.html#190" class="InductiveConstructor">false</a> <a id="196" class="Symbol">:</a> <a id="198" href="OrgHighlightCodeAuto.html#98" class="Datatype">Bool</a>
+</pre>
+#+END_EXPORT


### PR DESCRIPTION
Rst and markdown source blocks are wrapped in the appropriate formatting so that they can be reexported by an appropriate exporter.

Org-mode did not have this feature and just pasted the html where the source block was. This does not work when using org-publish afterwards.

I've tried to add this feature. I am not sure if I have broke any tests in the process.