### PR TITLE
Fix #4526: skip FS traversal for primitive library

### DIFF
--- a/src/data/lib/prim/prim.agda-lib
+++ b/src/data/lib/prim/prim.agda-lib
@@ -1,0 +1,3 @@
+name: prim
+include: .
+depend:

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -201,9 +201,9 @@ findProjectConfig root = do
     []    -> do
       up <- canonicalizePath $ root </> ".."
       if up == root then return (Nothing, []) else findProjectConfig up
-    files@["prim.agda-lib"] -> do
+    files@["prim.agda-lib"] ->
       return (Nothing, files)
-    files -> return ((Just root, files))
+    files -> return (Just root, files)
 
 -- | Get project root
 

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -194,26 +194,26 @@ defaultsFile = "defaults"
 
 findProjectConfig
   :: FilePath                          -- ^ Candidate (init: the directory Agda was called in)
-  -> IO (Maybe (FilePath, [FilePath])) -- ^ Actual root and @.agda-lib@ files for this project
+  -> IO (Maybe FilePath, [FilePath])   -- ^ Actual root and @.agda-lib@ files for this project
 findProjectConfig root = do
   libs <- map (root </>) . filter ((== ".agda-lib") . takeExtension) <$> getDirectoryContents root
   case libs of
     []    -> do
       up <- canonicalizePath $ root </> ".."
-      if up == root then return Nothing else findProjectConfig up
-    files -> return (Just (root, files))
+      if up == root then return (Nothing, []) else findProjectConfig up
+    files -> return ((Just root, files))
 
 -- | Get project root
 
 findProjectRoot :: FilePath -> IO (Maybe FilePath)
-findProjectRoot root = fmap fst <$> findProjectConfig root
+findProjectRoot root = fst <$> findProjectConfig root
 
 -- | Get pathes of @.agda-lib@ files in given project root.
 
 findAgdaLibFiles
   :: FilePath       -- ^ Project root.
   -> IO [FilePath]  -- ^ Pathes of @.agda-lib@ files for this project (if any).
-findAgdaLibFiles root = fromMaybe [] . fmap snd <$> findProjectConfig root
+findAgdaLibFiles root = snd <$> findProjectConfig root
 
 -- | Get dependencies and include paths for given project root:
 --

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -201,6 +201,8 @@ findProjectConfig root = do
     []    -> do
       up <- canonicalizePath $ root </> ".."
       if up == root then return (Nothing, []) else findProjectConfig up
+    files@["prim.agda-lib"] -> do
+      return (Nothing, files)
     files -> return ((Just root, files))
 
 -- | Get project root


### PR DESCRIPTION
_Sketch_ a fix for #4526 by (1) adding an .agda-lib file (2) hard-coding that the `prim` library is processed as if using `--local-interfaces` (to test). Otherwise, that library should be installed without `--local-interfaces` — which could be acceptable.

Not a complete fix, concerns in https://github.com/agda/agda/issues/4526#issuecomment-609013568 and https://github.com/agda/agda/issues/4526#issuecomment-609014308 should be addressed.

TODO:
- [x] decide on the best approach
- [ ] confirm this PR actually implement the chosen approach