### PR TITLE
Avoid normalisation where possible

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -252,7 +252,6 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
           else do
             -- Make sure we have imports for all names mentioned in the type.
             hsty <- haskellType q
-            ty   <- normalise ty
             sequence_ [ xqual x (HS.Ident "_") | x <- Set.toList (namesIn ty) ]
 
           -- Check that the function isn't INLINE (since that will make this

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -63,7 +63,7 @@ checkTypeOfMain  IsMain q def ret
   | not (isMainFunction q $ theDef def) = ret
   | otherwise = do
     Def io _ <- primIO
-    ty <- normalise $ defType def
+    ty <- reduce $ defType def
     case unEl ty of
       Def d _ | d == io -> (mainAlias :) <$> ret
       _                 -> do

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -449,9 +449,7 @@ makeAbsurdClause f ell (SClause tel sps _ _ t) = do
     -- c <- translateRecordPatterns $ Clause noRange tel perm ps NoBody t False
     -- Jesper, 2015-09-19 Don't contract, since we do on-demand splitting
     let c = Clause noRange noRange tel ps Nothing (argFromDom <$> t) False Nothing Nothing ell
-    -- Normalise the dot patterns
-    ps <- addContext tel $ normalise $ namedClausePats c
-    reportSDoc "interaction.case" 60 $ "normalized patterns: " <+> prettyTCMPatternList ps
+    let ps = namedClausePats c
     inTopContext $ reify $ QNamed f $ c { namedClausePats = ps }
 
 

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -449,7 +449,7 @@ isCoinductiveProjection mustBeRecursive q = liftTCM $ do
                   , addContext tel $ prettyTCM core
                   ]
                 when (null mut) __IMPOSSIBLE__
-                names <- anyDefs (mut `hasElem`) =<< normalise (map (snd . unDom) tel', core)
+                names <- anyDefs (mut `hasElem`) (map (snd . unDom) tel', core)
                 reportSDoc "term.guardedness" 40 $
                   "found" <+> if null names then "none" else sep (map prettyTCM $ Set.toList names)
                 return $ not $ null names

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -534,7 +534,7 @@ matchingTarget conf t = maybe (return True) (match t) (currentTarget conf)
 
 termToDBP :: Term -> TerM DeBruijnPattern
 termToDBP t = ifNotM terGetUseDotPatterns (return unusedVar) $ {- else -} do
-  termToPattern =<< do liftTCM $ stripAllProjections =<< normalise t
+  termToPattern =<< do liftTCM $ stripAllProjections t
 
 -- | Convert a term (from a dot pattern) to a pattern for the purposes of the termination checker.
 --
@@ -555,7 +555,7 @@ instance TermToPattern a b => TermToPattern (Named c a) (Named c b) where
 --   termToPattern t = unnamed <$> termToPattern t
 
 instance TermToPattern Term DeBruijnPattern where
-  termToPattern t = liftTCM (constructorForm t) >>= \case
+  termToPattern t = liftTCM (reduce t >>= constructorForm) >>= \case
     -- Constructors.
     Con c _ args -> ConP c noConPatternInfo . map (fmap unnamed) <$> termToPattern (fromMaybe __IMPOSSIBLE__ $ allApplyElims args)
     Def s [Apply arg] -> do
@@ -589,7 +589,7 @@ termClause clause = do
     , nest 2 $ "ps  =" <+> do addContext tel $ prettyTCMPatternList ps
     ]
   forM' body $ \ v -> addContext tel $ do
-    -- TODO: combine the following two traversals, avoid full normalisation.
+    -- TODO: combine the following two traversals.
     -- Parse dot patterns as patterns as far as possible.
     ps <- postTraversePatternM parseDotP ps
     -- Blank out coconstructors.

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1261,28 +1261,17 @@ leqSort s1 s2 = (catchConstraint (SortCmp CmpLeq s1 s2) :: m () -> m ()) $ do
     __IMPOSSIBLE__
 
 leqLevel :: MonadConversion m => Level -> Level -> m ()
-leqLevel a b = do
-  reportSDoc "tc.conv.nat" 30 $
-    "compareLevel" <+>
-      sep [ prettyTCM a <+> "=<"
-          , prettyTCM b ]
-  leqView a b
-  where
-    -- Andreas, 2016-09-28
-    -- If we have to postpone a constraint, then its simplified form!
-    leqView :: MonadConversion m => Level -> Level -> m ()
-    leqView a b = catchConstraint (LevelCmp CmpLeq a b) $ do
+leqLevel a b = catchConstraint (LevelCmp CmpLeq a b) $ do
       reportSDoc "tc.conv.level" 30 $
-        "compareLevelView" <+>
-          sep [ pretty a <+> "=<"
-              , pretty b ]
+        "compareLevel" <+>
+          sep [ prettyTCM a <+> "=<"
+              , prettyTCM b ]
 
+      (a, b) <- reduce (a, b)
       ((a, b), equal) <- SynEq.checkSyntacticEquality a b
       reportSDoc "tc.conv.level" 60 $
         "checkSyntacticEquality returns" <+> prettyTCM equal
       unless equal $ do
-
-      (a, b) <- reduce (a, b)
 
       cumulativity <- optCumulativity <$> pragmaOptions
       reportSDoc "tc.conv.level" 40 $
@@ -1314,20 +1303,20 @@ leqLevel a b = do
 
         -- ⊔ as ≤ single
         (as@(_:|_:_), b :| []) ->
-          sequence_ [ leqView (unSingleLevel a') (unSingleLevel b) | a' <- NonEmpty.toList as ]
+          sequence_ [ leqLevel (unSingleLevel a') (unSingleLevel b) | a' <- NonEmpty.toList as ]
 
         -- reduce constants
         (as, bs)
           | let minN = min (fst $ levelPlusView a) (fst $ levelPlusView b)
                 a'   = fromMaybe __IMPOSSIBLE__ $ subLevel minN a
                 b'   = fromMaybe __IMPOSSIBLE__ $ subLevel minN b
-          , minN > 0 -> leqView a' b'
+          , minN > 0 -> leqLevel a' b'
 
         -- remove subsumed
         -- Andreas, 2014-04-07: This is ok if we do not go back to equalLevel
         (as, bs)
           | (subsumed@(_:_) , as') <- List.partition isSubsumed (NonEmpty.toList as)
-          -> leqView (unSingleLevels as') b
+          -> leqLevel (unSingleLevels as') b
           where
             isSubsumed a = any (`subsumes` a) (NonEmpty.toList bs)
 
@@ -1401,12 +1390,9 @@ leqLevel a b = do
         isMetaLevel (SinglePlus (Plus _ UnreducedLevel{})) = __IMPOSSIBLE__
         isMetaLevel _ = False
 
-equalLevel :: MonadConversion m => Level -> Level -> m ()
-equalLevel a b = equalLevel' a b
-
 -- | Precondition: levels are 'normalise'd.
-equalLevel' :: forall m. MonadConversion m => Level -> Level -> m ()
-equalLevel' a b = do
+equalLevel :: forall m. MonadConversion m => Level -> Level -> m ()
+equalLevel a b = do
   reportSDoc "tc.conv.level" 50 $ sep [ "equalLevel", nest 2 $ parens $ pretty a, nest 2 $ parens $ pretty b ]
   -- Andreas, 2013-10-31 remove common terms (that don't contain metas!)
   -- THAT's actually UNSOUND when metas are instantiated, because
@@ -1425,12 +1411,11 @@ equalLevel' a b = do
                ]
         ]
 
+  (a, b) <- reduce (a, b)
   ((a, b), equal) <- SynEq.checkSyntacticEquality a b
   reportSDoc "tc.conv.level" 60 $
     "checkSyntacticEquality returns" <+> prettyTCM equal
   unless equal $ do
-
-  (a, b) <- reduce (a, b)
 
   -- Jesper, 2014-02-02 remove terms that certainly do not contribute
   -- to the maximum
@@ -1480,9 +1465,9 @@ equalLevel' a b = do
 
         -- 0 == a ⊔ b
         (SingleClosed 0 :| [] , bs@(_:|_:_)) ->
-          sequence_ [ equalLevel' (ClosedLevel 0) (unSingleLevel b') | b' <- NonEmpty.toList bs ]
+          sequence_ [ equalLevel (ClosedLevel 0) (unSingleLevel b') | b' <- NonEmpty.toList bs ]
         (as@(_:|_:_) , SingleClosed 0 :| []) ->
-          sequence_ [ equalLevel' (unSingleLevel a') (ClosedLevel 0) | a' <- NonEmpty.toList as ]
+          sequence_ [ equalLevel (unSingleLevel a') (ClosedLevel 0) | a' <- NonEmpty.toList as ]
 
         -- meta == any
         (SinglePlus (Plus k (MetaLevel x as)) :| [] , bs)

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -417,7 +417,7 @@ mkPrimInjective a b qn = do
   return $ PrimImpl ty $ primFun __IMPOSSIBLE__ 3 $ \ ts -> do
     let t  = headWithDefault __IMPOSSIBLE__ ts
     let eq = unArg $ fromMaybe __IMPOSSIBLE__ $ lastMaybe ts
-    eq' <- normalise' eq
+    eq' <- reduce' eq
     case eq' of
       Con{} -> redReturn $ refl t
       _     -> return $ NoReduction $ map notReduced ts

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -510,7 +510,12 @@ primEraseEquality = do
     -- and the conversion checker for eliminations does not
     -- like this.
     -- We can only do untyped equality, e.g., by normalisation.
-    (u', v') <- normalise' (u, v)
+    -- Jesper, 2020-04-04: We reduce rather than normalise for
+    -- efficiency reasons. In general this is weaker but it is
+    -- equivalent at base types. A stronger version of
+    -- primEraseEquality (using type-directed conversion) may be
+    -- implemented using --rewriting.
+    (u', v') <- reduce' (u, v)
     if u' == v' then redReturn $ refl u else
       return $ NoReduction $ map notReduced ts
 

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -217,6 +217,7 @@ checkRewriteRule q = do
           n  = size vs
           (us, [lhs, rhs]) = splitAt (n - 2) vs
       unless (size delta == size us) __IMPOSSIBLE__
+      lhs <- instantiateFull lhs
       rhs <- instantiateFull rhs
       b   <- instantiateFull $ applySubst (parallelS $ reverse us) a
 
@@ -231,7 +232,7 @@ checkRewriteRule q = do
       -- 2017-06-18, Jesper: Unfold inlined definitions on the LHS.
       -- This is necessary to replace copies created by imports by their
       -- original definition.
-      lhs <- modifyAllowedReductions (const $ SmallSet.singleton InlineReductions) $ normalise lhs
+      lhs <- modifyAllowedReductions (const $ SmallSet.singleton InlineReductions) $ reduce lhs
 
       -- Find head symbol f of the lhs, its type and its arguments.
       (f , hd , t , es) <- case lhs of
@@ -249,8 +250,6 @@ checkRewriteRule q = do
       ifNotAlreadyAdded f $ do
 
       addContext gamma1 $ do
-        -- Normalize lhs args: we do not want to match redexes.
-        es <- normalise es
 
         checkNoLhsReduction f es
 

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -139,7 +139,7 @@ checkApplication cmp hd args e t =
     -- Subcase: macro
     A.Macro x -> do
       -- First go: no parameters
-      TelV tel _ <- telView =<< normalise . defType =<< instantiateDef =<< getConstInfo x
+      TelV tel _ <- telView . defType =<< instantiateDef =<< getConstInfo x
 
       tTerm <- primAgdaTerm
       tName <- primQName

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1165,7 +1165,7 @@ constructs nofPars nofExtraVars t q = constrT nofExtraVars t
                       return PathCons
                 Def d es | d == q -> do
                   let vs = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
-                  (pars, ixs) <- normalise $ splitAt nofPars vs
+                  let (pars, ixs) = splitAt nofPars vs
                   -- check that the constructor parameters are the data parameters
                   checkParams n pars
                   return PointCons

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -68,6 +68,7 @@ import Agda.Utils.Permutation
 import Agda.Utils.Pretty ( prettyShow )
 import qualified Agda.Utils.Pretty as P
 import Agda.Utils.Size
+import qualified Agda.Utils.SmallSet as SmallSet
 
 import Agda.Utils.Impossible
 
@@ -1039,11 +1040,13 @@ checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs n
 
   -- Add the type of the auxiliary function to the signature
 
+  -- Jesper, 2020-04-05: Currently variable generalization inserts
+  -- dummy terms, we have to reduce projections to get rid of them.
+  -- (see also #1332).
+  let reds = SmallSet.fromList [ProjectionReductions]
+  delta1 <- modifyAllowedReductions (const reds) $ normalise delta1
+
   -- Generate the type of the with function
-  delta1 <- normalise delta1 -- Issue 1332: checkInternal is picky about argInfo
-                             -- but module application is sloppy.
-                             -- We normalise to get rid of Def's coming
-                             -- from module applications.
   (withFunType, n) <- withFunctionType delta1 vtys delta2 b
   reportSDoc "tc.with.type" 10 $ sep [ "with-function type:", nest 2 $ prettyTCM withFunType ]
   reportSDoc "tc.with.type" 50 $ sep [ "with-function type:", nest 2 $ pretty withFunType ]

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -105,8 +105,7 @@ checkFunDef delayed i name cs = do
 
 checkMacroType :: Type -> TCM ()
 checkMacroType t = do
-  t' <- normalise t
-  TelV tel tr <- telView t'
+  TelV tel tr <- telView t
 
   let telList = telToList tel
       resType = abstract (telFromList (drop (length telList - 1) telList)) tr

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -109,11 +109,11 @@ isCon con tm = do t <- liftTCM tm
                     _ -> return False
 
 isDef :: QName -> TCM Term -> UnquoteM Bool
-isDef f tm = do
-  t <- liftTCM $ etaContract =<< normalise =<< tm
-  case t of
-    Def g _ -> return (f == g)
-    _       -> return False
+isDef f tm = loop <$> liftTCM tm
+  where
+    loop (Def g _) = f == g
+    loop (Lam _ b) = loop $ unAbs b
+    loop _         = False
 
 reduceQuotedTerm :: Term -> UnquoteM Term
 reduceQuotedTerm t = do

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -439,7 +439,7 @@ stripWithClausePatterns cxtNames parent f t delta qs npars perm ps = do
            "parent pattern is constructor " <+> prettyTCM c
          (a, b) <- mustBePi t
          -- The type of the current pattern is a datatype.
-         Def d es <- liftTCM $ normalise (unEl $ unDom a)
+         Def d es <- liftTCM $ reduce (unEl $ unDom a)
          let us = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
          -- Get the original constructor and field names.
          c <- either __IMPOSSIBLE__ (`withRangeOf` c) <$> do liftTCM $ getConForm $ conName c

--- a/test/interaction/Issue3032.out
+++ b/test/interaction/Issue3032.out
@@ -4,5 +4,5 @@
 (agda2-status-action "")
 (agda2-info-action "*All Goals*" "?0 : B " nil)
 ((last . 1) . (agda2-goals-action '(0)))
-((last . 2) . (agda2-make-case-action '("foo _ (c x) = ?")))
+((last . 2) . (agda2-make-case-action '("foo .(foo t x) (c x) = ?")))
 ((last . 1) . (agda2-goals-action '(0)))


### PR DESCRIPTION
In https://github.com/agda/agda/pull/4531#issuecomment-603173162 @nad said:

> It might make sense to inspect every occurrence of `normalise` in the code and see if it can be removed.

I now started going over all calls to `normalise` in the Agda codebase to see which ones could be removed. This is a first batch of cases that seemed harmless to remove, more will follow later (hopefully).