### PR TITLE
[ new ] quoteωTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,11 @@ Pragmas and options
   backend to include a JavaScript file that highlights all occurrences of
   the mouse-hovered symbol (see
   [#4535](https://github.com/agda/agda/pull/4535)).
+
+Reflection
+----------
+
+- New operation in `TC` monad, similar to `quoteTC` but operating on types in `Setω`
+  ```agda
+  quoteωTC : ∀ {A : Setω} → A → TC Term
+  ```

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -12,6 +12,7 @@
   open import Agda.Builtin.String
   open import Agda.Builtin.Word
   open import Agda.Builtin.Equality
+  open import Agda.Primitive
 
   data ⊥ : Set where
 

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -412,6 +412,9 @@ following primitive operations::
     -- Unquote a Term, returning the corresponding value.
     unquoteTC : ∀ {a} {A : Set a} → Term → TC A
 
+    -- Quote a value in Setω, returning the corresponding Term
+    quoteωTC : ∀ {A : Setω} → A → TC Term
+
     -- Create a fresh name.
     freshName : String → TC Name
 
@@ -473,6 +476,7 @@ following primitive operations::
   {-# BUILTIN AGDATCMINCONTEXT                  inContext                  #-}
   {-# BUILTIN AGDATCMQUOTETERM                  quoteTC                    #-}
   {-# BUILTIN AGDATCMUNQUOTETERM                unquoteTC                  #-}
+  {-# BUILTIN AGDATCMQUOTEOMEGATERM             quoteωTC                   #-}
   {-# BUILTIN AGDATCMFRESHNAME                  freshName                  #-}
   {-# BUILTIN AGDATCMDECLAREDEF                 declareDef                 #-}
   {-# BUILTIN AGDATCMDECLAREPOSTULATE           declarePostulate           #-}

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -13,6 +13,7 @@ open import Agda.Builtin.Char
 open import Agda.Builtin.Float
 open import Agda.Builtin.Int
 open import Agda.Builtin.Sigma
+open import Agda.Primitive
 
 -- Names --
 
@@ -254,6 +255,7 @@ postulate
   catchTC          : ∀ {a} {A : Set a} → TC A → TC A → TC A
   quoteTC          : ∀ {a} {A : Set a} → A → TC Term
   unquoteTC        : ∀ {a} {A : Set a} → Term → TC A
+  quoteωTC         : ∀ {A : Setω} → A → TC Term
   getContext       : TC (List (Arg Type))
   extendContext    : ∀ {a} {A : Set a} → Arg Type → TC A → TC A
   inContext        : ∀ {a} {A : Set a} → List (Arg Type) → TC A → TC A
@@ -296,6 +298,7 @@ postulate
 {-# BUILTIN AGDATCMCATCHERROR                 catchTC                    #-}
 {-# BUILTIN AGDATCMQUOTETERM                  quoteTC                    #-}
 {-# BUILTIN AGDATCMUNQUOTETERM                unquoteTC                  #-}
+{-# BUILTIN AGDATCMQUOTEOMEGATERM             quoteωTC                   #-}
 {-# BUILTIN AGDATCMGETCONTEXT                 getContext                 #-}
 {-# BUILTIN AGDATCMEXTENDCONTEXT              extendContext              #-}
 {-# BUILTIN AGDATCMINCONTEXT                  inContext                  #-}

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -59,7 +59,7 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinAgdaTCMGetContext, builtinAgdaTCMExtendContext, builtinAgdaTCMInContext,
   builtinAgdaTCMFreshName, builtinAgdaTCMDeclareDef, builtinAgdaTCMDeclarePostulate, builtinAgdaTCMDefineFun,
   builtinAgdaTCMGetType, builtinAgdaTCMGetDefinition,
-  builtinAgdaTCMQuoteTerm, builtinAgdaTCMUnquoteTerm,
+  builtinAgdaTCMQuoteTerm, builtinAgdaTCMUnquoteTerm, builtinAgdaTCMQuoteOmegaTerm,
   builtinAgdaTCMBlockOnMeta, builtinAgdaTCMCommit, builtinAgdaTCMIsMacro,
   builtinAgdaTCMWithNormalisation, builtinAgdaTCMDebugPrint,
   builtinAgdaTCMNoConstraints,
@@ -242,6 +242,7 @@ builtinAgdaTCMBlockOnMeta                = "AGDATCMBLOCKONMETA"
 builtinAgdaTCMCommit                     = "AGDATCMCOMMIT"
 builtinAgdaTCMQuoteTerm                  = "AGDATCMQUOTETERM"
 builtinAgdaTCMUnquoteTerm                = "AGDATCMUNQUOTETERM"
+builtinAgdaTCMQuoteOmegaTerm             = "AGDATCMQUOTEOMEGATERM"
 builtinAgdaTCMIsMacro                    = "AGDATCMISMACRO"
 builtinAgdaTCMWithNormalisation          = "AGDATCMWITHNORMALISATION"
 builtinAgdaTCMDebugPrint                 = "AGDATCMDEBUGPRINT"

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -213,7 +213,7 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primAgdaTCMCatchError, primAgdaTCMGetContext, primAgdaTCMExtendContext, primAgdaTCMInContext,
     primAgdaTCMFreshName, primAgdaTCMDeclareDef, primAgdaTCMDeclarePostulate, primAgdaTCMDefineFun,
     primAgdaTCMGetType, primAgdaTCMGetDefinition,
-    primAgdaTCMQuoteTerm, primAgdaTCMUnquoteTerm,
+    primAgdaTCMQuoteTerm, primAgdaTCMUnquoteTerm, primAgdaTCMQuoteOmegaTerm,
     primAgdaTCMBlockOnMeta, primAgdaTCMCommit, primAgdaTCMIsMacro,
     primAgdaTCMWithNormalisation, primAgdaTCMDebugPrint,
     primAgdaTCMNoConstraints,
@@ -391,6 +391,7 @@ primAgdaTCMDefineFun                  = getBuiltin builtinAgdaTCMDefineFun
 primAgdaTCMGetType                    = getBuiltin builtinAgdaTCMGetType
 primAgdaTCMGetDefinition              = getBuiltin builtinAgdaTCMGetDefinition
 primAgdaTCMQuoteTerm                  = getBuiltin builtinAgdaTCMQuoteTerm
+primAgdaTCMQuoteOmegaTerm             = getBuiltin builtinAgdaTCMQuoteOmegaTerm
 primAgdaTCMUnquoteTerm                = getBuiltin builtinAgdaTCMUnquoteTerm
 primAgdaTCMBlockOnMeta                = getBuiltin builtinAgdaTCMBlockOnMeta
 primAgdaTCMCommit                     = getBuiltin builtinAgdaTCMCommit

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -358,7 +358,7 @@ coreBuiltins =
   , builtinAgdaTCMGetDefinition              |-> builtinPostulate (tqname --> tTCM_ primAgdaDefinition)
   , builtinAgdaTCMQuoteTerm                  |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ elV 1 (varM 0) --> tTCM_ primAgdaTerm)
   , builtinAgdaTCMUnquoteTerm                |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tterm --> tTCM 1 (varM 0))
-  , builtinAgdaTCMQuoteOmegaTerm             |-> builtinPostulate (hPi "A" tsetOmega $ (El Inf <$> (varM 0)) --> tTCM_ primAgdaTerm)
+  , builtinAgdaTCMQuoteOmegaTerm             |-> builtinPostulate (hPi "A" tsetOmega $ (El Inf <$> varM 0) --> tTCM_ primAgdaTerm)
   , builtinAgdaTCMBlockOnMeta                |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tmeta --> tTCM 1 (varM 0))
   , builtinAgdaTCMCommit                     |-> builtinPostulate (tTCM_ primUnit)
   , builtinAgdaTCMIsMacro                    |-> builtinPostulate (tqname --> tTCM_ primBool)

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -358,6 +358,7 @@ coreBuiltins =
   , builtinAgdaTCMGetDefinition              |-> builtinPostulate (tqname --> tTCM_ primAgdaDefinition)
   , builtinAgdaTCMQuoteTerm                  |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ elV 1 (varM 0) --> tTCM_ primAgdaTerm)
   , builtinAgdaTCMUnquoteTerm                |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tterm --> tTCM 1 (varM 0))
+  , builtinAgdaTCMQuoteOmegaTerm             |-> builtinPostulate (hPi "A" tsetOmega $ (El Inf <$> (varM 0)) --> tTCM_ primAgdaTerm)
   , builtinAgdaTCMBlockOnMeta                |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tmeta --> tTCM 1 (varM 0))
   , builtinAgdaTCMCommit                     |-> builtinPostulate (tTCM_ primUnit)
   , builtinAgdaTCMIsMacro                    |-> builtinPostulate (tqname --> tTCM_ primBool)
@@ -384,6 +385,7 @@ coreBuiltins =
         elV x a = El (varSort x) <$> a
 
         tsetL l    = return $ sort (varSort l)
+        tsetOmega  = return $ sort Inf
         tlevel     = el primLevel
         tlist x    = el $ list (fmap unEl x)
         tmaybe x   = el $ tMaybe (fmap unEl x)

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -493,7 +493,9 @@ evalTCM v = do
              , (f `isDef` primAgdaTCMCheckType,  tcFun2 tcCheckType  u v)
              , (f `isDef` primAgdaTCMDeclareDef, uqFun2 tcDeclareDef u v)
              , (f `isDef` primAgdaTCMDeclarePostulate, uqFun2 tcDeclarePostulate u v)
-             , (f `isDef` primAgdaTCMDefineFun,  uqFun2 tcDefineFun  u v) ]
+             , (f `isDef` primAgdaTCMDefineFun,  uqFun2 tcDefineFun  u v)
+             , (f `isDef` primAgdaTCMQuoteOmegaTerm, tcQuoteTerm (unElim v))
+             ]
              failEval
     I.Def f [l, a, u] ->
       choice [ (f `isDef` primAgdaTCMReturn,      return (unElim u))

--- a/test/interaction/Issue3831.out
+++ b/test/interaction/Issue3831.out
@@ -18,6 +18,6 @@
 (agda2-info-action "*Error*" "1,10-17 1 when checking that the expression unquote (test3 n) has type _134" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")
-(agda2-info-action "*Error*" "We reached a program point we did not want to reach. Location of the error: src/full/Agda/TypeChecking/Unquote.hs:650 " nil)
+(agda2-info-action "*Error*" "We reached a program point we did not want to reach. Location of the error: src/full/Agda/TypeChecking/Unquote.hs:652 " nil)
 (agda2-highlight-add-annotations 'nil)
 (agda2-status-action "")


### PR DESCRIPTION
Fixes #4576. This enables macros that were previously impossible. This new operation is relied on by an upcoming change to https://github.com/agda/agda-stdlib/pull/1158.