### PR TITLE
Highlight: use ScopeInfo instead of custom NameKinds

### DIFF
--- a/src/full/Agda/Interaction/Highlighting/Precise.hs
+++ b/src/full/Agda/Interaction/Highlighting/Precise.hs
@@ -264,6 +264,22 @@ instance Semigroup NameKind where
   -- -- TODO necessary?
   -- Field    <> Function = Field
   -- Function <> Field    = Field
+  -- BREAKS Issue1062
+  -- -- @Inductive@ is the default, override by @CoInductive@.
+  -- -- Constructor i   <> Constructor i'  = Constructor $ max i i'
+
+  -- -- SEEM unnecessary
+  -- k@Constructor{} <> Function        = k
+  -- Function        <> k@Constructor{} = k
+  -- -- Primitive > Function, Postulate
+  -- Primitive       <> Function        = Primitive
+  -- Function        <> Primitive       = Primitive
+  -- Primitive       <> Postulate       = Primitive
+  -- Postulate       <> Primitive       = Primitive
+  -- -- Postulate > Function
+  -- Postulate       <> Function        = Postulate
+  -- Function        <> Postulate       = Postulate
+
   -- TODO: more overwrites?
   k1 <> k2 | k1 == k2  = k1
            | otherwise = k1 -- TODO: __IMPOSSIBLE__

--- a/test/LaTeXAndHTML/succeed/Issue2756.html
+++ b/test/LaTeXAndHTML/succeed/Issue2756.html
@@ -8,5 +8,5 @@
 <a id="62" class="Keyword">module</a> <a id="M′"></a><a id="69" href="Issue2756.html#69" class="Module">M′</a> <a id="72" class="Symbol">=</a> <a id="74" href="Issue2756.html#32" class="Module">M</a>
 
 <a id="B"></a><a id="77" href="Issue2756.html#77" class="Function">B</a> <a id="79" class="Symbol">:</a> <a id="81" class="PrimitiveType">Set</a>
-<a id="85" href="Issue2756.html#77" class="Function">B</a> <a id="87" class="Symbol">=</a> <a id="89" href="Issue2756.html#53" class="Function">M′.A</a>
+<a id="85" href="Issue2756.html#77" class="Function">B</a> <a id="87" class="Symbol">=</a> <a id="89" href="Issue2756.html#53" class="Postulate">M′.A</a>
 </pre></body></html>


### PR DESCRIPTION
Continuation of #4574.  The highlighter here uses the `KindOfName` information generated by the scope checker, using function
```
  scopeInverseLookupName''
```
Unfortunately, the infrastructure behind this function is slow, making highlighting costly.  Thus, this work cannot be merged now.

Advantages:

  * More precise highlighting.
    E.g. in `test/LaTeXAndHTML/succeed/Issue2756` a postulate imported
    from a local module is currently highlighted as "Function".  This
    patch corrects this to "Postulate".

  * Less specific infrastructure to the highlighter, reusing `ScopeInfo`.

Loose ends:

* Refactor `NameKind` to extend `KindOfName` rather than copying most alternatives.

* Maybe simplify `highlightExpr` in `InteractionTop` by providing a more generic entry to `generateAndPrintSyntaxInfo`.

* It seems that cubical isn't maintaining the scope correctly. With hard failure in `FromAbstract.getNameKind`, I can trigger
```
    Highlighting: unbound A.QName: CubicalPrims.RecordComp._.a
```

Statistics:
  - MacBook Pro Intel Core i7 3.1 GHz, 16 GB mem, SSD drive
  - GHC 8.4.4
  - Cabal 2.4

* Fresh quick compilation of Agda (-O0), -j1
```
  real	4m13.977s
  user	3m35.174s
  sys	0m17.951s
```
* Fresh compilation of Agda (with agressive optimizations) -j1
```
  real	24m13.051s
  user	22m14.452s
  sys	0m38.016s
```
* Highlighting the standard library:

  There is an explosion of costs in:
```
    Scoping.InverseScopeLookup    47,188ms
```
  Seems like this is a carelessly engineered tool.
  (The inverse map seems to be recomputed from scratch upon any
  change in the scope.)
```
    Total                        436,390ms
    Miscellaneous                  9,395ms
    Typing                        26,147ms (182,236ms)
    Typing.CheckRHS               72,639ms
    Typing.TypeSig                28,366ms
    Typing.CheckLHS               15,297ms  (27,603ms)
    Typing.CheckLHS.UnifyIndices  12,305ms
    Typing.Generalize             10,650ms
    Typing.OccursCheck             9,981ms
    Typing.With                    6,267ms
    Typing.InstanceSearch            579ms
    Serialization                 48,791ms  (83,975ms)
    Serialization.BinaryEncode    24,913ms
    Serialization.BuildInterface   4,735ms
    Serialization.Compress         2,971ms
    Serialization.Sort             2,562ms
    Scoping                        8,982ms  (56,170ms)
    Scoping.InverseScopeLookup    47,188ms
    Deserialization               36,477ms  (42,344ms)
    Deserialization.Compaction     5,867ms
    Parsing                        2,391ms  (28,192ms)
    Parsing.OperatorsExpr         20,559ms
    Parsing.OperatorsPattern       5,241ms
    Positivity                     8,964ms
    DeadCode                       5,637ms
    Coverage                       5,233ms
    Highlighting                   4,581ms
    Import                         4,567ms
    Termination                    1,464ms   (3,658ms)
    Termination.Compare            1,003ms
    Termination.RecCheck             951ms
    Termination.Graph                239ms
    Injectivity                    1,277ms
    ProjectionLikeness               155ms

     513,184,313,240 bytes allocated in the heap
      75,786,005,176 bytes copied during GC
         766,990,784 bytes maximum residency (214 sample(s))
           2,598,464 bytes maximum slop
                1526 MB total memory in use (0 MB lost due to fragmentation)

                                         Tot time (elapsed)  Avg pause  Max pause
      Gen  0     487378 colls,     0 par   108.381s  111.200s     0.0002s    0.0614s
      Gen  1       214 colls,     0 par   12.519s  13.374s     0.0625s    0.3805s

      TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

      INIT    time    0.000s  (  0.002s elapsed)
      MUT     time  304.165s  (319.915s elapsed)
      GC      time  120.900s  (124.574s elapsed)
      EXIT    time    0.000s  (  0.012s elapsed)
      Total   time  425.065s  (444.503s elapsed)

      Alloc rate    1,687,189,761 bytes per MUT second

      Productivity  71.6% of total user, 72.0% of total elapsed

    real	7m24.666s
    user	7m5.068s
    sys	0m11.588s
```