### PR TITLE
Add -v0 and -w to runhaskell in interaction tests

### DIFF
--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -65,7 +65,7 @@ run_test=if test -f $*.in; \
          | $(AGDA_BIN) -v0 -i . -i .. --interaction --ignore-interfaces $(AGDA_OPT) $(RTS_$*) \
            2>&1 | $(filter) ; \
     elif test -f $*.hs; \
-    then /usr/bin/env runhaskell ./$*.hs $(AGDA_BIN) 2>&1 | $(filter) ; \
+    then /usr/bin/env runhaskell --ghc-arg=-v0 --ghc-arg=-w ./$*.hs $(AGDA_BIN) 2>&1 | $(filter) ; \
     else /usr/bin/env bash ./$*.sh $(AGDA_BIN) > $(TMPDIR)/$*.tmp_out ; \
          cat $(TMPDIR)/$*.tmp_out | $(filter) ; \
     fi


### PR DESCRIPTION
`-v0` because the default is `-v1` which may print some extra messages which causes some tests to fail. For instance if GHC loads the package environment from a local file, it would print

```
Loaded package environment from /home/ziyangliu/.ghc/x86_64-linux-8.8.3/environments/default
```

`-v0` suppresses this message, although unfortunately only for GHC 8.10 and beyond. See https://gitlab.haskell.org/ghc/ghc/issues/16879

`-w` because when I run `make test` from a nix shell it emits the following warnings for some tests:

```
<no location info>: warning: [-Wmissed-extra-shared-lib]
libicuuc.so: cannot open shared object file: No such file or directory
It's OK if you don't want to use symbols from it directly.
(the package DLL is loaded by the system linker
which manages dependencies by itself).

<no location info>: warning: [-Wmissed-extra-shared-lib]
libicui18n.so: cannot open shared object file: No such file or directory
It's OK if you don't want to use symbols from it directly.
(the package DLL is loaded by the system linker
which manages dependencies by itself).

<no location info>: warning: [-Wmissed-extra-shared-lib]
libicudata.so: cannot open shared object file: No such file or directory
It's OK if you don't want to use symbols from it directly.
(the package DLL is loaded by the system linker
which manages dependencies by itself).
```

The reason is not immediately clear to me, but there doesn't seem to be any benefit not to turn off all GHC warnings in these tests.