### PR TITLE
Add support for Setω+n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,15 @@ Language
   This implicit import can be disabled with the
   `--no-import-sorts` flag.
 
+* Agda now has support for sorts `Setωᵢ` (alternative syntax: `Setωi`)
+  for natural numbers `i`, where `Setω₀ = Setω`. These sorts form a
+  second hierarchy `Setωᵢ : Setωᵢ₊₁` similar to the standard hierarchy
+  of `Setᵢ`, but do not support universe polymorphism. It should not
+  be necessary to refer to these sorts during normal usage of Agda,
+  but they might be useful for defining reflection-based macros (see
+  [#2119](https://github.com/agda/agda/issues/2119) and
+  [#4585](https://github.com/agda/agda/issues/4585)).
+
 Reflection
 ----------
 

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -287,7 +287,7 @@ type Telescope = Tele (Dom Type)
 data Sort' t
   = Type (Level' t)  -- ^ @Set ℓ@.
   | Prop (Level' t)  -- ^ @Prop ℓ@.
-  | Inf Integer      -- ^ @Setω+ n@.
+  | Inf Integer      -- ^ @Setωᵢ@.
   | SizeUniv    -- ^ @SizeUniv@, a sort inhabited by type @Size@.
   | PiSort (Dom' t (Type'' t t)) (Abs (Sort' t)) -- ^ Sort of the pi type.
   | FunSort (Sort' t) (Sort' t) -- ^ Sort of a (non-dependent) function type.
@@ -1488,7 +1488,7 @@ instance Pretty Sort where
       Prop (ClosedLevel n) -> text $ "Prop" ++ show n
       Prop l -> mparens (p > 9) $ "Prop" <+> prettyPrec 10 l
       Inf 0 -> "Setω"
-      Inf n -> text $ "Setω+" ++ show n
+      Inf n -> text $ "Setω" ++ show n
       SizeUniv -> "SizeUniv"
       PiSort a b -> mparens (p > 9) $
         "piSort" <+> pDom (domInfo a) (text (absName b) <+> ":" <+> pretty (unDom a))

--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -78,7 +78,7 @@ instance GetDefs Sort where
   getDefs s = case s of
     Type l    -> getDefs l
     Prop l    -> getDefs l
-    Inf       -> return ()
+    Inf _     -> return ()
     SizeUniv  -> return ()
     PiSort a s  -> getDefs a >> getDefs s
     FunSort s1 s2 -> getDefs s1 >> getDefs s2

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -140,7 +140,7 @@ instance TermLike Sort where
   traverseTermM f s = case s of
     Type l     -> Type <$> traverseTermM f l
     Prop l     -> Prop <$> traverseTermM f l
-    Inf        -> pure s
+    Inf _      -> pure s
     SizeUniv   -> pure s
     PiSort a b -> PiSort   <$> traverseTermM f a <*> traverseTermM f b
     FunSort a b -> FunSort   <$> traverseTermM f a <*> traverseTermM f b
@@ -152,7 +152,7 @@ instance TermLike Sort where
   foldTerm f s = case s of
     Type l     -> foldTerm f l
     Prop l     -> foldTerm f l
-    Inf        -> mempty
+    Inf _      -> mempty
     SizeUniv   -> mempty
     PiSort a b -> foldTerm f a <> foldTerm f b
     FunSort a b -> foldTerm f a <> foldTerm f b

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -108,7 +108,7 @@ instance NamesIn Sort where
   namesIn s = case s of
     Type l   -> namesIn l
     Prop l   -> namesIn l
-    Inf      -> Set.empty
+    Inf _    -> Set.empty
     SizeUniv -> Set.empty
     PiSort a b -> namesIn (a, b)
     FunSort a b -> namesIn (a, b)

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -41,7 +41,7 @@ import Agda.Syntax.Concrete.Definitions (DeclarationWarning(..)) -- TODO: move t
 import Agda.Syntax.Scope.Base as A
 
 import Agda.TypeChecking.Monad.Base
-import Agda.TypeChecking.Monad.Builtin ( HasBuiltins , getBuiltinName' , builtinSet , builtinProp )
+import Agda.TypeChecking.Monad.Builtin ( HasBuiltins , getBuiltinName' , builtinSet , builtinProp , builtinSetOmega )
 import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.State
 import Agda.TypeChecking.Monad.Trace
@@ -385,7 +385,8 @@ canHaveSuffixTest :: HasBuiltins m => m (A.QName -> Bool)
 canHaveSuffixTest = do
   builtinSet  <- getBuiltinName' builtinSet
   builtinProp <- getBuiltinName' builtinProp
-  return $ \x -> Just x == builtinSet || Just x == builtinProp
+  builtinSetOmega <- getBuiltinName' builtinSetOmega
+  return $ \x -> Just x `elem` [builtinSet, builtinProp, builtinSetOmega]
 
 -- | Look up a module in the scope.
 resolveModule :: C.QName -> ScopeM AbstractModule

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1327,12 +1327,8 @@ instance Reify Sort Expr where
         I.Prop a -> do
           a <- reify a
           return $ A.App defaultAppInfo_ (A.Def nameOfProp) (defaultNamedArg a)
-        I.Inf 0 -> do
-          I.Def inf [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSetOmega
-          return $ A.Def inf
-        I.Inf n -> do
-          infs <- freshName_ ("Setω+" ++ show n :: String) -- TODO: hack
-          return $ A.Var infs
+        I.Inf 0 -> return $ A.Def' nameOfSetOmega A.NoSuffix
+        I.Inf n -> return $ A.Def' nameOfSetOmega (A.Suffix n)
         I.SizeUniv  -> do
           I.Def sizeU [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSizeUniv
           return $ A.Def sizeU

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1327,7 +1327,12 @@ instance Reify Sort Expr where
         I.Prop a -> do
           a <- reify a
           return $ A.App defaultAppInfo_ (A.Def nameOfProp) (defaultNamedArg a)
-        I.Inf       -> return $ A.Def nameOfSetOmega
+        I.Inf 0 -> do
+          I.Def inf [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSetOmega
+          return $ A.Def inf
+        I.Inf n -> do
+          infs <- freshName_ ("Setω+" ++ show n :: String) -- TODO: hack
+          return $ A.Var infs
         I.SizeUniv  -> do
           I.Def sizeU [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSizeUniv
           return $ A.Def sizeU

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -678,7 +678,7 @@ instance ExtractCalls Sort where
       reportSDoc "term.sort" 50 $
         text ("s = " ++ show s)
     case s of
-      Inf        -> return empty
+      Inf n      -> return empty
       SizeUniv   -> return empty
       Type t     -> terUnguarded $ extract t  -- no guarded levels
       Prop t     -> terUnguarded $ extract t

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -172,7 +172,7 @@ instance AbsTerm Sort where
   absTerm u s = case s of
     Type n     -> Type $ absS n
     Prop n     -> Prop $ absS n
-    Inf        -> Inf
+    Inf n      -> Inf n
     SizeUniv   -> SizeUniv
     PiSort a s -> PiSort (absS a) (absS s)
     FunSort s1 s2 -> FunSort (absS s1) (absS s2)
@@ -264,7 +264,7 @@ instance EqualSy Sort where
   equalSy = curry $ \case
     (Type l    , Type l'     ) -> equalSy l l'
     (Prop l    , Prop l'     ) -> equalSy l l'
-    (Inf       , Inf         ) -> True
+    (Inf m     , Inf n       ) -> m == n
     (SizeUniv  , SizeUniv    ) -> True
     (PiSort a b, PiSort a' b') -> equalSy a a' && equalSy b b'
     (FunSort a b, FunSort a' b') -> equalSy a a' && equalSy b b'

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -400,7 +400,7 @@ checkSort action s =
   case s of
     Type l   -> Type <$> checkLevel action l
     Prop l   -> Prop <$> checkLevel action l
-    Inf      -> return Inf
+    Inf n    -> return $ Inf n
     SizeUniv -> return SizeUniv
     PiSort dom s2 -> do
       let El s1 a = unDom dom

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1239,8 +1239,8 @@ leqSort s1 s2 = (catchConstraint (SortCmp CmpLeq s1 s2) :: m () -> m ()) $ do
 
       -- If the first sort is a small sort that rigidly depends on a
       -- variable and the second sort does not mention this variable,
-      -- the second sort must be at least Inf.
-      (_       , _       ) | isSmallSort s1 , badRigid -> leqSort (Inf 0) s2
+      -- the second sort must be at least @Setω@.
+      (_       , _       ) | isSmallSort s1 == Just True , badRigid -> leqSort (Inf 0) s2
 
       -- PiSort, FunSort, UnivSort and MetaS might reduce once we instantiate
       -- more metas, so we postpone.
@@ -1708,7 +1708,7 @@ equalSort s1 s2 = do
            -- If @b@ is dependent, then @piSort a b@ computes to
            -- @Setω@. Hence, if @s@ is small, then @b@
            -- cannot be dependent.
-        if | isSmallSort s         -> do
+        if | isSmallSort s == Just True -> do
                -- We force @b@ to be non-dependent by unifying it with
                -- a fresh meta that does not depend on @x : a@
                b' <- newSortMeta
@@ -1732,11 +1732,11 @@ equalSort s1 s2 = do
         case s0 of
           -- If @Setω+ n == funSort s1 s2@, then either @s1@ or @s2@ must
           -- be @Setω+ n@.
-          Inf n | isSmallSort s1 && isSmallSort s2 -> do
+          Inf n | isSmallSort s1 == Just True && isSmallSort s2 == Just True -> do
                     typeError $ UnequalSorts s0 (FunSort s1 s2)
-                | isSmallSort s1 -> equalSort (Inf n) s2
-                | isSmallSort s2 -> equalSort (Inf n) s1
-                | otherwise      -> synEq s0 (FunSort s1 s2)
+                | isSmallSort s1 == Just True -> equalSort (Inf n) s2
+                | isSmallSort s2 == Just True -> equalSort (Inf n) s1
+                | otherwise                   -> synEq s0 (FunSort s1 s2)
           -- If @Set l == funSort s1 s2@, then @s2@ must be of the
           -- form @Set l2@. @s1@ can be one of @Set l1@, @Prop l1@, or
           -- @SizeUniv@.

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1216,7 +1216,7 @@ leqSort s1 s2 = (catchConstraint (SortCmp CmpLeq s1 s2) :: m () -> m ()) $ do
       (Prop a  , Type b  ) -> leqLevel a b
       (Type a  , Prop b  ) -> no
 
-      -- @Setω+ n@ is above all small sorts (spelling out all cases
+      -- @Setωᵢ@ is above all small sorts (spelling out all cases
       -- for the exhaustiveness checker)
       (Inf m   , Inf n   ) ->
         if m <= n || typeInTypeEnabled || omegaInOmegaEnabled then yes else no
@@ -1604,7 +1604,7 @@ equalSort s1 s2 = do
             (Inf m      , Inf n      ) ->
               if m == n || typeInTypeEnabled || omegaInOmegaEnabled then yes else no
 
-            -- if --type-in-type is enabled, (Setω+ n) is equal to any Set ℓ (see #3439)
+            -- if --type-in-type is enabled, Setωᵢ is equal to any Set ℓ (see #3439)
             (Type{}     , Inf{}      )
               | typeInTypeEnabled      -> yes
             (Inf{}      , Type{}     )
@@ -1679,7 +1679,7 @@ equalSort s1 s2 = do
                    equalSort (Type l2) s2
                -- Otherwise we postpone
                | otherwise -> synEq (Type l1) (UnivSort s2)
-          -- @Setω+ n@ is a successor sort if n > 0, or if
+          -- @Setωᵢ@ is a successor sort if n > 0, or if
           -- --type-in-type or --omega-in-omega is enabled.
           Inf n | n > 0 -> equalSort (Inf $ n - 1) s2
           Inf 0 -> do
@@ -1730,8 +1730,8 @@ equalSort s1 s2 = do
         propEnabled <- isPropEnabled
         sizedTypesEnabled <- sizedTypesOption
         case s0 of
-          -- If @Setω+ n == funSort s1 s2@, then either @s1@ or @s2@ must
-          -- be @Setω+ n@.
+          -- If @Setωᵢ == funSort s1 s2@, then either @s1@ or @s2@ must
+          -- be @Setωᵢ@.
           Inf n | isSmallSort s1 == Just True && isSmallSort s2 == Just True -> do
                     typeError $ UnequalSorts s0 (FunSort s1 s2)
                 | isSmallSort s1 == Just True -> equalSort (Inf n) s2

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -538,10 +538,10 @@ instance PrettyTCM TypeError where
       (Sort s1      , Sort s2      )
         | CmpEq  <- cmp              -> prettyTCM $ UnequalSorts s1 s2
         | CmpLeq <- cmp              -> prettyTCM $ NotLeqSort s1 s2
-      (Sort MetaS{} , t            ) -> prettyTCM $ ShouldBeASort $ El (Inf 0) t
-      (s            , Sort MetaS{} ) -> prettyTCM $ ShouldBeASort $ El (Inf 0) s
-      (Sort DefS{}  , t            ) -> prettyTCM $ ShouldBeASort $ El (Inf 0) t
-      (s            , Sort DefS{}  ) -> prettyTCM $ ShouldBeASort $ El (Inf 0) s
+      (Sort MetaS{} , t            ) -> prettyTCM $ ShouldBeASort $ El __IMPOSSIBLE__ t
+      (s            , Sort MetaS{} ) -> prettyTCM $ ShouldBeASort $ El __IMPOSSIBLE__ s
+      (Sort DefS{}  , t            ) -> prettyTCM $ ShouldBeASort $ El __IMPOSSIBLE__ t
+      (s            , Sort DefS{}  ) -> prettyTCM $ ShouldBeASort $ El __IMPOSSIBLE__ s
       (_            , _            ) -> do
         (d1, d2, d) <- prettyInEqual s t
         fsep $ concat $

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -538,10 +538,10 @@ instance PrettyTCM TypeError where
       (Sort s1      , Sort s2      )
         | CmpEq  <- cmp              -> prettyTCM $ UnequalSorts s1 s2
         | CmpLeq <- cmp              -> prettyTCM $ NotLeqSort s1 s2
-      (Sort MetaS{} , t            ) -> prettyTCM $ ShouldBeASort $ El Inf t
-      (s            , Sort MetaS{} ) -> prettyTCM $ ShouldBeASort $ El Inf s
-      (Sort DefS{}  , t            ) -> prettyTCM $ ShouldBeASort $ El Inf t
-      (s            , Sort DefS{}  ) -> prettyTCM $ ShouldBeASort $ El Inf s
+      (Sort MetaS{} , t            ) -> prettyTCM $ ShouldBeASort $ El (Inf 0) t
+      (s            , Sort MetaS{} ) -> prettyTCM $ ShouldBeASort $ El (Inf 0) s
+      (Sort DefS{}  , t            ) -> prettyTCM $ ShouldBeASort $ El (Inf 0) t
+      (s            , Sort DefS{}  ) -> prettyTCM $ ShouldBeASort $ El (Inf 0) s
       (_            , _            ) -> do
         (d1, d2, d) <- prettyInEqual s t
         fsep $ concat $

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -547,7 +547,7 @@ instance Free Sort where
     case s of
       Type a     -> freeVars' a
       Prop a     -> freeVars' a
-      Inf        -> mempty
+      Inf _      -> mempty
       SizeUniv   -> mempty
       PiSort a s -> underFlexRig (Flexible mempty) (freeVars' $ unDom a) `mappend`
                     underFlexRig WeaklyRigid (freeVars' (getSort a, s))

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -77,7 +77,7 @@ instance PrecomputeFreeVars Sort where
     case s of
       Type a     -> Type <$> precomputeFreeVars a
       Prop a     -> Prop <$> precomputeFreeVars a
-      Inf        -> pure s
+      Inf _      -> pure s
       SizeUniv   -> pure s
       PiSort a s -> uncurry PiSort <$> precomputeFreeVars (a, s)
       FunSort s1 s2 -> uncurry FunSort <$> precomputeFreeVars (s1, s2)

--- a/src/full/Agda/TypeChecking/Free/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Free/Reduce.hs
@@ -154,6 +154,6 @@ instance ForceNotFree Sort where
     UnivSort s -> UnivSort <$> forceNotFree' s
     MetaS x es -> MetaS x  <$> forceNotFree' es
     DefS d es  -> DefS d   <$> forceNotFree' es
-    Inf        -> return s
+    Inf _      -> return s
     SizeUniv   -> return s
     DummyS{}   -> return s

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -322,7 +322,7 @@ instance UsableRelevance Sort where
   usableRel rel s = case s of
     Type l -> usableRel rel l
     Prop l -> usableRel rel l
-    Inf    -> return True
+    Inf n  -> return True
     SizeUniv -> return True
     PiSort a s -> usableRel rel (a,s)
     FunSort s1 s2 -> usableRel rel (s1,s2)

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -420,7 +420,7 @@ blockTermOnProblem t v pid =
 blockTypeOnProblem
   :: (MonadMetaSolver m, MonadFresh Nat m)
   => Type -> ProblemId -> m Type
-blockTypeOnProblem (El s a) pid = El s <$> blockTermOnProblem (El Inf $ Sort s) a pid
+blockTypeOnProblem (El s a) pid = El s <$> blockTermOnProblem (sort s) a pid
 
 -- | @unblockedTester t@ returns @False@ if @t@ is a meta or a blocked term.
 --
@@ -1123,7 +1123,7 @@ checkSolutionForMeta x m v a = do
       reportSDoc "tc.meta.check" 30 $ nest 2 $
         prettyTCM x <+> ":=" <+> prettyTCM v <+> " is a sort"
       s <- shouldBeSort (El __DUMMY_SORT__ v)
-      traceCall (CheckMetaSolution (getRange m) x (sort (univSort Nothing s)) (Sort s)) $
+      traceCall (CheckMetaSolution (getRange m) x (sort (univSort s)) (Sort s)) $
         checkSort defaultAction s
 
 -- | Given two types @a@ and @b@ with @a <: b@, check that @a == b@.
@@ -1514,7 +1514,7 @@ openMetasToPostulates = do
     -- codomains by Setω.
     dummyTypeToOmega t =
       case telView' t of
-        TelV tel (El _ Dummy{}) -> abstract tel topSort
+        TelV tel (El _ Dummy{}) -> abstract tel (sort $ Inf 0)
         _ -> t
 
 -- | Sort metas in dependency order.

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -50,7 +50,7 @@ instance MentionsMeta Sort where
   mentionsMetas xs s = case s of
     Type l     -> mentionsMetas xs l
     Prop l     -> mentionsMetas xs l
-    Inf        -> False
+    Inf _      -> False
     SizeUniv   -> False
     PiSort a s -> mentionsMetas xs (a, s)
     FunSort s1 s2 -> mentionsMetas xs (s1, s2)

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -552,7 +552,7 @@ instance Occurs Sort where
       FunSort s1 s2 -> FunSort <$> flexibly (occurs s1) <*> flexibly (occurs s2)
       Type a     -> Type <$> occurs a
       Prop a     -> Prop <$> occurs a
-      s@Inf      -> return s
+      s@Inf{}    -> return s
       s@SizeUniv -> return s
       UnivSort s -> UnivSort <$> do flexibly $ occurs s
       MetaS x es -> do
@@ -570,7 +570,7 @@ instance Occurs Sort where
       FunSort s1 s2 -> metaOccurs m (s1,s2)
       Type a     -> metaOccurs m a
       Prop a     -> metaOccurs m a
-      Inf        -> return ()
+      Inf _      -> return ()
       SizeUniv   -> return ()
       UnivSort s -> metaOccurs m s
       MetaS x es -> metaOccurs m $ MetaV x es
@@ -775,7 +775,7 @@ instance AnyRigid Sort where
     case s of
       Type l     -> anyRigid f l
       Prop l     -> anyRigid f l
-      Inf        -> return False
+      Inf _      -> return False
       SizeUniv   -> return False
       PiSort a s -> return False
       FunSort s1 s2 -> return False

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1604,7 +1604,7 @@ data NLPType = NLPType
 data NLPSort
   = PType NLPat
   | PProp NLPat
-  | PInf
+  | PInf Integer
   | PSizeUniv
   deriving (Data, Show)
 
@@ -4250,7 +4250,7 @@ instance KillRange NLPType where
 instance KillRange NLPSort where
   killRange (PType l) = killRange1 PType l
   killRange (PProp l) = killRange1 PProp l
-  killRange PInf      = PInf
+  killRange (PInf n)  = PInf n
   killRange PSizeUniv = PSizeUniv
 
 instance KillRange RewriteRule where

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -473,7 +473,7 @@ instance PrettyTCM NLPSort where
   prettyTCM = \case
     PType l   -> parens $ "Set" <+> prettyTCM l
     PProp l   -> parens $ "Prop" <+> prettyTCM l
-    PInf      -> prettyTCM (Inf :: Sort)
+    PInf n    -> prettyTCM (Inf n :: Sort)
     PSizeUniv -> prettyTCM (SizeUniv :: Sort)
 
 instance PrettyTCM (Elim' NLPat) where

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -622,8 +622,8 @@ mkPrimLevelMax = do
 
 mkPrimSetOmega :: TCM PrimitiveImpl
 mkPrimSetOmega = do
-  let t = sort $ UnivSort Inf
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 0 $ \_ -> redReturn $ Sort Inf
+  let t = sort $ Inf 1
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 0 $ \_ -> redReturn $ Sort $ Inf 0
 
 mkPrimFun1TCM :: (FromTerm a, ToTerm b, TermLike b) =>
                  TCM Type -> (a -> ReduceM b) -> TCM PrimitiveImpl

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -76,7 +76,7 @@ el' :: Monad m => m Term -> m Term -> m Type
 el' l a = El <$> (tmSort <$> l) <*> a
 
 elInf :: Functor m => m Term -> m Type
-elInf t = (El Inf <$> t)
+elInf t = (El (Inf 0) <$> t)
 
 nolam :: Term -> Term
 nolam = Lam defaultArgInfo . NoAbs "_"

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -265,7 +265,7 @@ primPartial' = do
        hPi' "a" (el $ cl primLevel) (\ a ->
         nPi' "φ" (elInf (cl primInterval)) $ \ _ ->
         nPi' "A" (sort . tmSort <$> a) $ \ bA ->
-        return (sort $ Inf))
+        return (sort $ Inf 0))
   isOne <- primIsOne
   return $ PrimImpl t $ primFun __IMPOSSIBLE__ 3 $ \ ts -> do
     case ts of
@@ -283,7 +283,7 @@ primPartialP' = do
        hPi' "a" (el $ cl primLevel) (\ a ->
         nPi' "φ" (elInf (cl primInterval)) $ \ phi ->
         nPi' "A" (pPi' "o" phi $ \ _ -> el' (cl primLevelSuc <@> a) (Sort . tmSort <$> a)) $ \ bA ->
-        return (sort $ Inf))
+        return (sort $ Inf 0))
   let toFinitePi :: Type -> Term
       toFinitePi (El _ (Pi d b)) = Pi (setRelevance Irrelevant $ d { domFinite = True }) b
       toFinitePi _               = __IMPOSSIBLE__
@@ -1712,7 +1712,7 @@ transpTel delta phi args = do
             b' <- open b'
             axi <- open axi
             gTransp (Just l) b' phi axi
-          Inf    ->
+          Inf n  ->
             if 0 `freeIn` (raise 1 b' `lazyAbsApp` var 0) then noTranspError b' else return axi
           _ -> noTranspError b'
     lam_i = Lam defaultArgInfo . Abs "i"
@@ -1726,7 +1726,7 @@ transpTel delta phi args = do
       -- Γ ⊢ b : t[1], Γ,i ⊢ b : t[i]
       (b,bf) <- runNamesT [] $ do
         l <- case s of
-               Inf -> return Nothing
+               Inf n -> return Nothing
                Type l -> Just <$> open (lam_i (Level l))
                _ -> noTranspError (Abs "i" (unDom t))
         t <- open $ Abs "i" (unDom t)

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -148,7 +148,7 @@ quotingKit = do
       quoteSort :: Sort -> ReduceM Term
       quoteSort (Type t) = quoteSortLevelTerm t
       quoteSort Prop{}   = pure unsupportedSort
-      quoteSort Inf      = pure unsupportedSort
+      quoteSort Inf{}    = pure unsupportedSort
       quoteSort SizeUniv = pure unsupportedSort
       quoteSort PiSort{} = pure unsupportedSort
       quoteSort FunSort{} = pure unsupportedSort

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -309,11 +309,10 @@ instance Reduce Sort where
           maybe (return $ FunSort s1' s2') reduce' $ funSort' s1' s2'
         UnivSort s' -> do
           s' <- reduce' s'
-          ui <- univInf
-          caseMaybe (univSort' ui s') (return $ UnivSort s') reduce'
+          caseMaybe (univSort' s') (return $ UnivSort s') reduce'
         Prop s'    -> Prop <$> reduce' s'
         Type s'    -> Type <$> reduce' s'
-        Inf        -> return Inf
+        Inf n      -> return $ Inf n
         SizeUniv   -> return SizeUniv
         MetaS x es -> return s
         DefS d es  -> return s -- postulated sorts do not reduce
@@ -904,12 +903,10 @@ instance Simplify Sort where
       case s of
         PiSort a s -> piSort <$> simplify' a <*> simplify' s
         FunSort s1 s2 -> funSort <$> simplify' s1 <*> simplify' s2
-        UnivSort s -> do
-          ui <- univInf
-          univSort ui <$> simplify' s
+        UnivSort s -> univSort <$> simplify' s
         Type s     -> Type <$> simplify' s
         Prop s     -> Prop <$> simplify' s
-        Inf        -> return s
+        Inf _      -> return s
         SizeUniv   -> return s
         MetaS x es -> MetaS x <$> simplify' es
         DefS d es  -> DefS d <$> simplify' es
@@ -1058,12 +1055,10 @@ instance Normalise Sort where
       case s of
         PiSort a s -> piSort <$> normalise' a <*> normalise' s
         FunSort s1 s2 -> funSort <$> normalise' s1 <*> normalise' s2
-        UnivSort s -> do
-          ui <- univInf
-          univSort ui <$> normalise' s
+        UnivSort s -> univSort <$> normalise' s
         Prop s     -> Prop <$> normalise' s
         Type s     -> Type <$> normalise' s
-        Inf        -> return Inf
+        Inf _      -> return s
         SizeUniv   -> return SizeUniv
         MetaS x es -> return s
         DefS d es  -> return s
@@ -1272,10 +1267,8 @@ instance InstantiateFull Sort where
             Prop n     -> Prop <$> instantiateFull' n
             PiSort a s -> piSort <$> instantiateFull' a <*> instantiateFull' s
             FunSort s1 s2 -> funSort <$> instantiateFull' s1 <*> instantiateFull' s2
-            UnivSort s -> do
-              ui <- univInf
-              univSort ui <$> instantiateFull' s
-            Inf        -> return s
+            UnivSort s -> univSort <$> instantiateFull' s
+            Inf _      -> return s
             SizeUniv   -> return s
             MetaS x es -> MetaS x <$> instantiateFull' es
             DefS d es  -> DefS d <$> instantiateFull' es
@@ -1421,7 +1414,7 @@ instance InstantiateFull NLPType where
 instance InstantiateFull NLPSort where
   instantiateFull' (PType x) = PType <$> instantiateFull' x
   instantiateFull' (PProp x) = PProp <$> instantiateFull' x
-  instantiateFull' PInf      = return PInf
+  instantiateFull' (PInf n)  = return $ PInf n
   instantiateFull' PSizeUniv = return PSizeUniv
 
 instance InstantiateFull RewriteRule where

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -557,7 +557,7 @@ instance AllHoles Sort where
   allHoles _ = \case
     Type l       -> fmap Type <$> allHoles_ l
     Prop l       -> fmap Prop <$> allHoles_ l
-    Inf          -> empty
+    Inf n        -> empty
     SizeUniv     -> empty
     PiSort{}     -> __IMPOSSIBLE__
     FunSort{}    -> __IMPOSSIBLE__
@@ -639,7 +639,7 @@ instance MetasToVars Sort where
   metasToVars = \case
     Type l     -> Type     <$> metasToVars l
     Prop l     -> Prop     <$> metasToVars l
-    Inf        -> pure Inf
+    Inf n      -> pure $ Inf n
     SizeUniv   -> pure SizeUniv
     PiSort s t -> PiSort   <$> metasToVars s <*> metasToVars t
     FunSort s t -> FunSort <$> metasToVars s <*> metasToVars t

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -187,7 +187,8 @@ instance Match () NLPSort Sort where
     case (p , s) of
       (PType lp  , Type l  ) -> match r gamma k () lp l
       (PProp lp  , Prop l  ) -> match r gamma k () lp l
-      (PInf      , Inf     ) -> yes
+      (PInf np   , Inf n   )
+        | np == n            -> yes
       (PSizeUniv , SizeUniv) -> yes
 
       -- blocked cases

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -84,7 +84,7 @@ instance PatternFrom () Sort NLPSort where
     case s of
       Type l   -> PType <$> patternFrom r k () l
       Prop l   -> PProp <$> patternFrom r k () l
-      Inf      -> return PInf
+      Inf n    -> return $ PInf n
       SizeUniv -> return PSizeUniv
       PiSort _ _ -> __IMPOSSIBLE__
       FunSort _ _ -> __IMPOSSIBLE__
@@ -218,7 +218,7 @@ instance NLPatToTerm NLPType Type where
 instance NLPatToTerm NLPSort Sort where
   nlPatToTerm (PType l) = Type <$> nlPatToTerm l
   nlPatToTerm (PProp l) = Prop <$> nlPatToTerm l
-  nlPatToTerm PInf      = return Inf
+  nlPatToTerm (PInf n)  = return $ Inf n
   nlPatToTerm PSizeUniv = return SizeUniv
 
 -- | Gather the set of pattern variables of a non-linear pattern
@@ -238,7 +238,7 @@ instance NLPatVars NLPSort where
   nlPatVarsUnder k = \case
     PType l   -> nlPatVarsUnder k l
     PProp l   -> nlPatVarsUnder k l
-    PInf      -> empty
+    PInf n    -> empty
     PSizeUniv -> empty
 
 instance NLPatVars NLPat where
@@ -293,7 +293,7 @@ instance GetMatchables NLPSort where
   getMatchables = \case
     PType l   -> getMatchables l
     PProp l   -> getMatchables l
-    PInf      -> empty
+    PInf n    -> empty
     PSizeUniv -> empty
 
 instance GetMatchables Term where
@@ -325,5 +325,5 @@ instance Free NLPSort where
   freeVars' = \case
     PType l   -> freeVars' l
     PProp l   -> freeVars' l
-    PInf      -> mempty
+    PInf n    -> mempty
     PSizeUniv -> mempty

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1196,7 +1196,7 @@ checkSetOmega cmp e t q args = do
 
 inferSetOmega :: A.Expr -> QName -> [NamedArg A.Expr] -> TCM (Term, Type)
 inferSetOmega e q args = case args of
-  [] -> return (Sort Inf , sort (UnivSort Inf))
+  [] -> return (Sort (Inf 0) , sort (Inf 1))
   arg : _ -> typeError . GenericDocError =<< fsep
       [ prettyTCM q , "cannot be applied to an argument" ]
 

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -120,11 +120,11 @@ coreBuiltins =
                                                               (El (varSort 1) <$> varM 0 <@> primIZero) -->
                                                               (El (varSort 1) <$> varM 0 <@> primIOne) -->
                                                               return (sort $ varSort 1)))
-  , (builtinInterval                         |-> BuiltinData (requireCubical >> return (sort Inf)) [builtinIZero,builtinIOne])
+  , (builtinInterval                         |-> BuiltinData (requireCubical >> return (sort $ Inf 0)) [builtinIZero,builtinIOne])
   , (builtinSub                              |-> builtinPostulateC (runNamesT [] $ hPi' "a" (el $ cl primLevel) $ \ a ->
                                                                    nPi' "A" (el' (cl primLevelSuc <@> a) (Sort . tmSort <$> a)) $ \ bA ->
                                                                    nPi' "φ" (elInf $ cl primInterval) $ \ phi ->
-                                                                   elInf (cl primPartial <#> a <@> phi <@> bA) --> return (sort Inf)
+                                                                   elInf (cl primPartial <#> a <@> phi <@> bA) --> return (sort $ Inf 0)
                                                                   ))
   , (builtinSubIn                            |-> builtinPostulateC (runNamesT [] $
                                                                    hPi' "a" (el $ cl primLevel) $ \ a ->
@@ -136,7 +136,7 @@ coreBuiltins =
   , (builtinIOne                             |-> BuiltinDataCons (elInf primInterval))
   , (builtinPartial                          |-> BuiltinPrim "primPartial" (const $ return ()))
   , (builtinPartialP                         |-> BuiltinPrim "primPartialP" (const $ return ()))
-  , (builtinIsOne                            |-> builtinPostulateC (tinterval --> return (sort $ Inf)))
+  , (builtinIsOne                            |-> builtinPostulateC (tinterval --> return (sort $ Inf 0)))
   , (builtinItIsOne                          |-> builtinPostulateC (elInf $ primIsOne <@> primIOne))
   , (builtinIsOne1                           |-> builtinPostulateC (runNamesT [] $
                                                                    nPi' "i" (cl tinterval) $ \ i ->
@@ -361,7 +361,7 @@ coreBuiltins =
   , builtinAgdaTCMGetDefinition              |-> builtinPostulate (tqname --> tTCM_ primAgdaDefinition)
   , builtinAgdaTCMQuoteTerm                  |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ elV 1 (varM 0) --> tTCM_ primAgdaTerm)
   , builtinAgdaTCMUnquoteTerm                |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tterm --> tTCM 1 (varM 0))
-  , builtinAgdaTCMQuoteOmegaTerm             |-> builtinPostulate (hPi "A" tsetOmega $ (El Inf <$> varM 0) --> tTCM_ primAgdaTerm)
+  , builtinAgdaTCMQuoteOmegaTerm             |-> builtinPostulate (hPi "A" tsetOmega $ (El (Inf 0) <$> varM 0) --> tTCM_ primAgdaTerm)
   , builtinAgdaTCMBlockOnMeta                |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tmeta --> tTCM 1 (varM 0))
   , builtinAgdaTCMCommit                     |-> builtinPostulate (tTCM_ primUnit)
   , builtinAgdaTCMIsMacro                    |-> builtinPostulate (tqname --> tTCM_ primBool)
@@ -388,7 +388,7 @@ coreBuiltins =
         elV x a = El (varSort x) <$> a
 
         tsetL l    = return $ sort (varSort l)
-        tsetOmega  = return $ sort Inf
+        tsetOmega  = return $ sort $ Inf 0
         tlevel     = el primLevel
         tlist x    = el $ list (fmap unEl x)
         tmaybe x   = el $ tMaybe (fmap unEl x)
@@ -422,7 +422,7 @@ coreBuiltins =
         tclause    = el primAgdaClause
         tTCM l a   = elV l (primAgdaTCM <#> varM l <@> a)
         tTCM_ a    = el (primAgdaTCM <#> primLevelZero <@> a)
-        tinterval  = El Inf <$> primInterval
+        tinterval  = El (Inf 0) <$> primInterval
 
         verifyPlus plus =
             verify ["n","m"] $ \(@@) zero suc (==) (===) choice -> do
@@ -953,7 +953,7 @@ bindBuiltinNoDef b q = inTopContext $ do
               , dataIxs        = 0
               , dataClause     = Nothing
               , dataCons       = []     -- Constructors are added later
-              , dataSort       = Inf
+              , dataSort       = Inf 0
               , dataAbstr      = ConcreteDef
               , dataMutual     = Nothing
               , dataPathCons   = []
@@ -963,10 +963,10 @@ bindBuiltinNoDef b q = inTopContext $ do
       let s = case sortname of
                 "primSet"      -> mkType 0
                 "primProp"     -> mkProp 0
-                "primSetOmega" -> Inf
+                "primSetOmega" -> Inf 0
                 _              -> __IMPOSSIBLE__
           def = PrimitiveSort sortname s
-      addConstant q $ defaultDefn defaultArgInfo q (sort $ univSort Nothing s) def
+      addConstant q $ defaultDefn defaultArgInfo q (sort $ univSort s) def
       bindBuiltinName b $ Def q []
 
     Just{}  -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -652,7 +652,7 @@ instance Subst Term LType where
 data CType = ClosedType QName | LType LType deriving (Eq,Show)
 
 fromCType :: CType -> Type
-fromCType (ClosedType q) = El Inf (Def q [])
+fromCType (ClosedType q) = El (Inf 0) (Def q [])
 fromCType (LType t) = fromLType t
 
 toCType :: MonadReduce m => Type -> m (Maybe CType)
@@ -660,7 +660,7 @@ toCType ty = do
   sort <- reduce $ getSort ty
   case sort of
     Type l -> return $ Just $ LType (LEl l (unEl ty))
-    Inf    -> do
+    Inf 0  -> do
       t <- reduce (unEl ty)
       case t of
         Def q [] -> return $ Just $ ClosedType q

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1770,7 +1770,7 @@ checkSortOfSplitVar dr a mtarget = do
       | IsRecord _ _ <- dr     -> return ()
       | Just target <- mtarget -> unlessM (isPropM target) splitOnPropError
       | otherwise              -> splitOnPropError
-    Inf{} -> return ()
+    Inf{} -> return () -- see #4109
     _      -> softTypeError =<< do
       liftTCM $ GenericDocError <$> sep
         [ "Cannot split on datatype in sort" , prettyTCM (getSort a) ]

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1764,14 +1764,13 @@ checkSortOfSplitVar :: (MonadTCM m, MonadReduce m, MonadError TCErr m, ReadTCSta
                         LensSort a, PrettyTCM a, LensSort ty, PrettyTCM ty)
                     => DataOrRecord -> a -> Maybe ty -> m ()
 checkSortOfSplitVar dr a mtarget = do
-  infOk <- optOmegaInOmega <$> pragmaOptions
   liftTCM (reduce $ getSort a) >>= \case
     Type{} -> return ()
     Prop{}
       | IsRecord _ _ <- dr     -> return ()
       | Just target <- mtarget -> unlessM (isPropM target) splitOnPropError
       | otherwise              -> splitOnPropError
-    Inf{} | infOk -> return ()
+    Inf{} -> return ()
     _      -> softTypeError =<< do
       liftTCM $ GenericDocError <$> sep
         [ "Cannot split on datatype in sort" , prettyTCM (getSort a) ]

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1149,11 +1149,6 @@ checkExpr' cmp e t =
             noFunctionsIntoSize t0 t'
             let s = getSort t'
                 v = unEl t'
-            when (s == Inf) $ reportSDoc "tc.term.sort" 20 $
-              vcat [ text ("reduced to omega:")
-                   , nest 2 $ "t   =" <+> prettyTCM t'
-                   , nest 2 $ "cxt =" <+> (prettyTCM =<< getContextTelescope)
-                   ]
             coerce cmp v (sort s) t
 
         A.Generalized s e -> do
@@ -1161,11 +1156,6 @@ checkExpr' cmp e t =
             noFunctionsIntoSize t' t'
             let s = getSort t'
                 v = unEl t'
-            when (s == Inf) $ reportSDoc "tc.term.sort" 20 $
-              vcat [ text ("reduced to omega:")
-                   , nest 2 $ "t   =" <+> prettyTCM t'
-                   , nest 2 $ "cxt =" <+> (prettyTCM =<< getContextTelescope)
-                   ]
             coerce cmp v (sort s) t
 
         A.Fun _ (Arg info a) b -> do

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -143,6 +143,11 @@ isType_ e = traceCall (IsType_ e) $ do
         NoSuffix -> return $ sort (mkProp 0)
         Suffix i -> return $ sort (mkProp i)
 
+    -- Setωᵢ
+    A.Def' x suffix | x == nameOfSetOmega -> case suffix of
+      NoSuffix -> return $ sort (Inf 0)
+      Suffix i -> return $ sort (Inf i)
+
     -- Set ℓ
     A.App i s arg
       | visible arg,

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -140,7 +140,7 @@ instance EmbPrj I.Sort where
   icod_ (Type  a  ) = icodeN 0 Type a
   icod_ (Prop  a  ) = icodeN 1 Prop a
   icod_ SizeUniv    = icodeN 2 SizeUniv
-  icod_ Inf         = icodeN 3 Inf
+  icod_ (Inf a)     = icodeN 3 Inf a
   icod_ (PiSort a b) = icodeN 4 PiSort a b
   icod_ (FunSort a b) = icodeN 5 FunSort a b
   icod_ (UnivSort a) = icodeN 6 UnivSort a
@@ -154,7 +154,7 @@ instance EmbPrj I.Sort where
     valu [0, a]    = valuN Type  a
     valu [1, a]    = valuN Prop  a
     valu [2]       = valuN SizeUniv
-    valu [3]       = valuN Inf
+    valu [3, a]    = valuN Inf a
     valu [4, a, b] = valuN PiSort a b
     valu [5, a, b] = valuN FunSort a b
     valu [6, a]    = valuN UnivSort a
@@ -251,13 +251,13 @@ instance EmbPrj NLPType where
 instance EmbPrj NLPSort where
   icod_ (PType a)   = icodeN 0 PType a
   icod_ (PProp a)   = icodeN 1 PProp a
-  icod_ PInf        = icodeN 2 PInf
+  icod_ (PInf a)    = icodeN 2 PInf a
   icod_ PSizeUniv   = icodeN 3 PSizeUniv
 
   value = vcase valu where
     valu [0, a] = valuN PType a
     valu [1, a] = valuN PProp a
-    valu [2]    = valuN PInf
+    valu [2, a] = valuN PInf a
     valu [3]    = valuN PSizeUniv
     valu _      = malformed
 

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -65,7 +65,7 @@ inferUnivSort s = do
   case univSort' s of
     Just s' -> return s'
     Nothing -> do
-      -- Jesper, 2020-04-19: With the addition of Setω+i and the PTS
+      -- Jesper, 2020-04-19: With the addition of Setωᵢ and the PTS
       -- rule SizeUniv : Setω, every sort (with no metas) now has a
       -- bigger sort, so we do not need to add a constraint.
       -- addConstraint $ HasBiggerSort s

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -65,7 +65,10 @@ inferUnivSort s = do
   case univSort' s of
     Just s' -> return s'
     Nothing -> do
-      addConstraint $ HasBiggerSort s
+      -- Jesper, 2020-04-19: With the addition of Setω+i and the PTS
+      -- rule SizeUniv : Setω, every sort (with no metas) now has a
+      -- bigger sort, so we do not need to add a constraint.
+      -- addConstraint $ HasBiggerSort s
       return $ UnivSort s
 
 sortFitsIn :: MonadConversion m => Sort -> Sort -> m ()

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -62,8 +62,7 @@ inferUnivSort
   => Sort -> m Sort
 inferUnivSort s = do
   s <- reduce s
-  ui <- univInf
-  case univSort' ui s of
+  case univSort' s of
     Just s' -> return s'
     Nothing -> do
       addConstraint $ HasBiggerSort s
@@ -169,9 +168,7 @@ sortOf t = do
         sa <- sortOf a
         sb <- mapAbstraction adom (sortOf . unEl) b
         return $ piSort (adom $> El sa a) sb
-      Sort s     -> do
-        ui <- univInf
-        return $ univSort ui s
+      Sort s     -> return $ univSort s
       Var i es   -> do
         a <- typeOfBV i
         sortOfE a (Var i) es

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1436,6 +1436,7 @@ univSort' :: Sort -> Maybe Sort
 univSort' (Type l) = Just $ Type $ levelSuc l
 univSort' (Prop l) = Just $ Type $ levelSuc l
 univSort' (Inf n)  = Just $ Inf  $ 1 + n
+univSort' SizeUniv = Just $ Inf 0
 univSort' s        = Nothing
 
 univSort :: Sort -> Sort

--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -141,7 +141,7 @@ instance SynEq Sort where
       (UnivSort a, UnivSort a') -> UnivSort <$$> synEq a a'
       (SizeUniv, SizeUniv  ) -> pure2 s
       (Prop l  , Prop l'   ) -> Prop <$$> synEq l l'
-      (Inf     , Inf       ) -> pure2 s
+      (Inf m   , Inf n     ) | m == n -> pure2 s
       (MetaS x es , MetaS x' es') | x == x' -> MetaS x <$$> synEq es es'
       (DefS  d es , DefS  d' es') | d == d' -> DefS d  <$$> synEq es es'
       (DummyS{}, DummyS{}) -> pure (s, s')

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -487,7 +487,7 @@ pathViewAsPi'whnf = do
     PathType s l p a x y | Just interval <- minterval ->
       let name | Lam _ (Abs n _) <- unArg a = n
                | otherwise = "i"
-          i = El Inf interval
+          i = El (Inf 0) interval
       in
         Left $ ((defaultDom $ i, Abs name $ El (raise 1 s) $ raise 1 (unArg a) `apply` [defaultArg $ var 0]), (unArg x, unArg y))
 

--- a/test/Fail/Issue2285-record.err
+++ b/test/Fail/Issue2285-record.err
@@ -1,5 +1,4 @@
 Failed to solve the following constraints:
   Agda.Primitive.Setω =< _4
-  Has bigger sort: _4
 Unsolved metas at the following locations:
   Issue2285-record.agda:4,8-11

--- a/test/Fail/Issue2285-record.err
+++ b/test/Fail/Issue2285-record.err
@@ -1,2 +1,5 @@
 Failed to solve the following constraints:
-  Has bigger sort: Agda.Primitive.Setω
+  Agda.Primitive.Setω =< _4
+  Has bigger sort: _4
+Unsolved metas at the following locations:
+  Issue2285-record.agda:4,8-11

--- a/test/Fail/Issue2285.err
+++ b/test/Fail/Issue2285.err
@@ -1,3 +1,6 @@
 Failed to solve the following constraints:
-  Has bigger sort: Agda.Primitive.Setω
-  Has bigger sort: univSort Agda.Primitive.Setω
+  Agda.Primitive.Setω =< _4
+  Has bigger sort: univSort _4
+  Has bigger sort: _4
+Unsolved metas at the following locations:
+  Issue2285.agda:13,8-11

--- a/test/Fail/Issue2285.err
+++ b/test/Fail/Issue2285.err
@@ -1,6 +1,4 @@
 Failed to solve the following constraints:
   Agda.Primitive.Setω =< _4
-  Has bigger sort: univSort _4
-  Has bigger sort: _4
 Unsolved metas at the following locations:
   Issue2285.agda:13,8-11

--- a/test/Internal/TypeChecking/Generators.hs
+++ b/test/Internal/TypeChecking/Generators.hs
@@ -452,7 +452,7 @@ instance ShrinkC Sort Sort where
   shrinkC conf s = mkProp 0 : case s of
     Type n     -> [] -- No Level instance yet -- Type <$> shrinkC conf n
     Prop{}     -> []
-    Inf        -> []
+    Inf _      -> []
     SizeUniv   -> []
     PiSort s1 s2 -> __IMPOSSIBLE__
     FunSort s1 s2 -> __IMPOSSIBLE__

--- a/test/Succeed/Issue2119.agda
+++ b/test/Succeed/Issue2119.agda
@@ -1,0 +1,9 @@
+open import Agda.Builtin.Reflection
+
+t = quoteTerm (∀ {α} {A : Set α} -> A -> A)
+
+macro
+  m : Type -> Term -> TC _
+  m = unify
+
+idType = m t

--- a/test/Succeed/Issue4109.agda
+++ b/test/Succeed/Issue4109.agda
@@ -1,0 +1,3 @@
+open import Agda.Primitive
+
+data Foo : Setω where

--- a/test/Succeed/Issue4109.agda
+++ b/test/Succeed/Issue4109.agda
@@ -1,3 +1,7 @@
 open import Agda.Primitive
 
 data Foo : Setω where
+  foo : Foo
+
+bar : Foo → Foo
+bar foo = foo

--- a/test/Succeed/Issue4585.agda
+++ b/test/Succeed/Issue4585.agda
@@ -1,0 +1,17 @@
+open import Agda.Builtin.Unit
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+
+id : ∀ {a} {A : Set a} → A → A
+id x = x
+
+macro
+  my-macro : Term → TC ⊤
+  my-macro goal = bindTC
+    (getType (quote id))
+    λ idType → bindTC
+      (reduce idType)
+      λ _ → returnTC _
+
+fails? : ⊤
+fails? = my-macro

--- a/test/Succeed/UnquoteSetOmega.agda
+++ b/test/Succeed/UnquoteSetOmega.agda
@@ -8,9 +8,9 @@ module UnquoteSetOmega where
 `Level : Term
 `Level = def (quote Level) []
 
--- while building the syntax of ∀ ℓ → Set ℓ (of type Setω) is harmless
+-- building the syntax of ∀ ℓ → Set ℓ (of type Setω) is harmless
 `∀ℓ→Setℓ : Term
 `∀ℓ→Setℓ = pi (vArg `Level) (abs "_" (sort (set (var 0 []))))
 
--- unquoting it is harmfull
+-- unquoting it is now also fine (since we have sort Setω+1)
 ∀ℓ→Setℓ = unquote (give `∀ℓ→Setℓ)

--- a/test/Succeed/UnquoteSetOmega.agda
+++ b/test/Succeed/UnquoteSetOmega.agda
@@ -12,5 +12,5 @@ module UnquoteSetOmega where
 `∀ℓ→Setℓ : Term
 `∀ℓ→Setℓ = pi (vArg `Level) (abs "_" (sort (set (var 0 []))))
 
--- unquoting it is now also fine (since we have sort Setω+1)
+-- unquoting it is now also fine (since we have sort Setω₁)
 ∀ℓ→Setℓ = unquote (give `∀ℓ→Setℓ)

--- a/test/interaction/SetInf.out
+++ b/test/interaction/SetInf.out
@@ -2,5 +2,5 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 (agda2-status-action "")
-(agda2-info-action "*All Goals, Errors*" "Sort _3 [ at SetInf.agda:3,14-15 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: Has bigger sort: _3 " nil)
+(agda2-info-action "*All Goals*" "Sort _3 [ at SetInf.agda:3,14-15 ] " nil)
 ((last . 1) . (agda2-goals-action '()))


### PR DESCRIPTION
This PR adds internal syntax and typing rules for a second universe hierarchy `Setω+n`, which sits on top of Agda's regular universe hierarchy. Unlike `Set i`, this hierarchy is not polymorphic, so it is not possible to quantify over all `Setω+n` at once. This is my proposed answer to #4595 and fixes issues #2119, #4109, and #4585.

Note that there is no concrete syntax yet for `Setω+n` (except in error messages). I tried to add it in the same way as I did for `Setω`, but adding an infinite number of builtins is hard. Instead, it might be necessary to add hardcoded support for it in the parser, unless someone can think of a better solution.