### PR TITLE
[ re #4613 ] Add .agda-lib for builtins

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -91,6 +91,7 @@ data-files:         Agda.css
                     JS/agda-rts.js
                     JS/biginteger.js
                     JS/highlight-hover.js
+                    lib/prim/agda-builtins.agda-lib
                     lib/prim/Agda/Builtin/Bool.agda
                     lib/prim/Agda/Builtin/Char.agda
                     lib/prim/Agda/Builtin/Char/Properties.agda

--- a/Setup.hs
+++ b/Setup.hs
@@ -82,7 +82,7 @@ buildHook' pd lbi hooks flags = do
     removeFile fullpathi `catch` handleExists
 
     putStrLn $ "... " ++ fullpath
-    ok <- rawSystem' ddir agda [ "--no-libraries", "--local-interfaces"
+    ok <- rawSystem' ddir agda [ "--no-libraries"
                                , "-Werror"
                                , fullpath, "-v0"
                                ]

--- a/src/data/lib/prim/agda-builtins.agda-lib
+++ b/src/data/lib/prim/agda-builtins.agda-lib
@@ -1,0 +1,2 @@
+name: agda-builtins
+include: .


### PR DESCRIPTION
And also ensure we only rely on *files* named .agda-lib and ignore
directories.

NB: this does not implement the more efficient directory exploration
strategy discussed in #4526