### PR TITLE
Use 'Map a (NonEmpty a)' for Ren

### DIFF
--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -15,8 +15,6 @@ import Prelude hiding (null)
 import Data.Bifunctor
 import qualified Data.Foldable as Fold
 import Data.Function (on)
-import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe
@@ -128,7 +126,7 @@ type RecordAssign  = Either Assign ModuleName
 type RecordAssigns = [RecordAssign]
 
 -- | Renaming (generic).
-type Ren a = Map a (NonEmpty a)
+type Ren a = Map a (List1 a)
 
 data ScopeCopyInfo = ScopeCopyInfo
   { renModules :: Ren ModuleName
@@ -147,7 +145,7 @@ instance Pretty ScopeCopyInfo where
     where
       prRen s r = sep [ text s, nest 2 $ vcat (map pr xs) ]
         where
-          xs = Map.toList r >>= (\(k, vs) -> map (k,) (NonEmpty.toList vs))
+          xs = [ (k, v) | (k, vs) <- Map.toList r, v <- List1.toList vs ]
       pr (x, y) = pretty x <+> "->" <+> pretty y
 
 data Declaration

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -15,7 +15,10 @@ import Prelude hiding (null)
 import Data.Bifunctor
 import qualified Data.Foldable as Fold
 import Data.Function (on)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map (Map)
+import qualified Data.Map as Map
 import Data.Maybe
 import Data.Sequence (Seq, (<|), (><))
 import qualified Data.Sequence as Seq
@@ -125,7 +128,7 @@ type RecordAssign  = Either Assign ModuleName
 type RecordAssigns = [RecordAssign]
 
 -- | Renaming (generic).
-type Ren a = [(a, a)]
+type Ren a = Map a (NonEmpty a)
 
 data ScopeCopyInfo = ScopeCopyInfo
   { renModules :: Ren ModuleName
@@ -134,15 +137,17 @@ data ScopeCopyInfo = ScopeCopyInfo
 
 initCopyInfo :: ScopeCopyInfo
 initCopyInfo = ScopeCopyInfo
-  { renModules = []
-  , renNames   = []
+  { renModules = mempty
+  , renNames   = mempty
   }
 
 instance Pretty ScopeCopyInfo where
   pretty i = vcat [ prRen "renModules =" (renModules i)
                   , prRen "renNames   =" (renNames i) ]
     where
-      prRen s r = sep [ text s, nest 2 $ vcat (map pr r) ]
+      prRen s r = sep [ text s, nest 2 $ vcat (map pr xs) ]
+        where
+          xs = Map.toList r >>= (\(k, vs) -> map (k,) (NonEmpty.toList vs))
       pr (x, y) = pretty x <+> "->" <+> pretty y
 
 data Declaration

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -9,7 +9,7 @@ import Prelude hiding (mapM, any, all, null)
 
 import Control.Arrow ((***))
 import Control.Monad hiding (mapM, forM)
-import Control.Monad.Writer hiding (mapM, forM)
+import Control.Monad.Writer hiding (mapM, forM, (<>))
 import Control.Monad.State hiding (mapM, forM)
 
 import Data.Either ( partitionEithers )
@@ -22,7 +22,6 @@ import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Foldable (all)
-import qualified Data.Semigroup as S
 import Data.Traversable hiding (for)
 
 import Agda.Interaction.Options
@@ -541,7 +540,7 @@ copyScope oldc new0 s = (inScopeBecause (Applied oldc) *** memoToScopeInfo) <$> 
             _ -> lensAnameName f d
 
         -- Adding to memo structure.
-        addName x y     = modify $ \ i -> i { memoNames   = Map.insertWith (S.<>) x (pure y) (memoNames i) }
+        addName x y     = modify $ \ i -> i { memoNames   = Map.insertWith (<>) x (pure y) (memoNames i) }
         addMod  x y rec = modify $ \ i -> i { memoModules = Map.insert x (y, rec) (memoModules i) }
 
         -- Querying the memo structure.

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -22,6 +22,7 @@ import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Foldable (all)
+import qualified Data.Semigroup as S
 import Data.Traversable hiding (for)
 
 import Agda.Interaction.Options
@@ -55,7 +56,7 @@ import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import Agda.Utils.Pretty hiding ((<>))
+import Agda.Utils.Pretty
 
 import Agda.Utils.Impossible
 
@@ -540,7 +541,7 @@ copyScope oldc new0 s = (inScopeBecause (Applied oldc) *** memoToScopeInfo) <$> 
             _ -> lensAnameName f d
 
         -- Adding to memo structure.
-        addName x y     = modify $ \ i -> i { memoNames   = Map.insertWith (<>) x (pure y) (memoNames i) }
+        addName x y     = modify $ \ i -> i { memoNames   = Map.insertWith (S.<>) x (pure y) (memoNames i) }
         addMod  x y rec = modify $ \ i -> i { memoModules = Map.insert x (y, rec) (memoModules i) }
 
         -- Querying the memo structure.

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -492,7 +492,7 @@ type WSM = StateT ScopeMemo ScopeM
 
 data ScopeMemo = ScopeMemo
   { memoNames   :: A.Ren A.QName
-  , memoModules :: [(ModuleName, (ModuleName, Bool))]
+  , memoModules :: Map ModuleName (ModuleName, Bool)
     -- ^ Bool: did we copy recursively? We need to track this because we don't
     --   copy recursively when creating new modules for reexported functions
     --   (issue1985), but we might need to copy recursively later.
@@ -501,13 +501,13 @@ data ScopeMemo = ScopeMemo
 memoToScopeInfo :: ScopeMemo -> ScopeCopyInfo
 memoToScopeInfo (ScopeMemo names mods) =
   ScopeCopyInfo { renNames   = names
-                , renModules = [ (x, y) | (x, (y, _)) <- mods ] }
+                , renModules = Map.map (pure . fst) mods }
 
 -- | Create a new scope with the given name from an old scope. Renames
 --   public names in the old scope to match the new name and returns the
 --   renamings.
 copyScope :: C.QName -> A.ModuleName -> Scope -> ScopeM (Scope, ScopeCopyInfo)
-copyScope oldc new0 s = (inScopeBecause (Applied oldc) *** memoToScopeInfo) <$> runStateT (copy new0 s) (ScopeMemo [] [])
+copyScope oldc new0 s = (inScopeBecause (Applied oldc) *** memoToScopeInfo) <$> runStateT (copy new0 s) (ScopeMemo mempty mempty)
   where
     copy :: A.ModuleName -> Scope -> WSM Scope
     copy new s = do
@@ -540,12 +540,12 @@ copyScope oldc new0 s = (inScopeBecause (Applied oldc) *** memoToScopeInfo) <$> 
             _ -> lensAnameName f d
 
         -- Adding to memo structure.
-        addName x y     = modify $ \ i -> i { memoNames   = (x, y)        : memoNames   i }
-        addMod  x y rec = modify $ \ i -> i { memoModules = (x, (y, rec)) : filter ((/= x) . fst) (memoModules i) }
+        addName x y     = modify $ \ i -> i { memoNames   = Map.insertWith (<>) x (pure y) (memoNames i) }
+        addMod  x y rec = modify $ \ i -> i { memoModules = Map.insert x (y, rec) (memoModules i) }
 
         -- Querying the memo structure.
-        findName x = gets (lookup x . memoNames) -- NB:: Defined but not used
-        findMod  x = gets (lookup x . memoModules)
+        findName x = gets (Map.lookup x . memoNames) -- NB:: Defined but not used
+        findMod  x = gets (Map.lookup x . memoModules)
 
         refresh :: A.Name -> WSM A.Name
         refresh x = do

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -55,7 +55,7 @@ import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import Agda.Utils.Pretty
+import Agda.Utils.Pretty hiding ((<>))
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -21,6 +21,7 @@ import qualified Data.Set as Set
 import qualified Data.Map as Map
 import qualified Data.HashMap.Strict as HMap
 import Data.Maybe
+import qualified Data.Semigroup as S
 
 import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Abstract (Ren, ScopeCopyInfo(..))
@@ -311,10 +312,10 @@ applySection new ptel old ts ScopeCopyInfo{ renModules = rm, renNames = rd } = d
     closeConstructors rd = do
         ds <- nubOn id . catMaybes <$> traverse constructorData (Map.keys rd)
         cs <- nubOn id . concat    <$> traverse dataConstructors (Map.keys rd)
-        new <- Map.unionsWith (<>) <$> traverse rename (ds ++ cs)
+        new <- Map.unionsWith (S.<>) <$> traverse rename (ds ++ cs)
         reportSDoc "tc.mod.apply.complete" 30 $
           "also copying: " <+> pretty new
-        return $ Map.unionWith (<>) new rd
+        return $ Map.unionWith (S.<>) new rd
       where
         rename :: QName -> TCM (Ren QName)
         rename x

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -13,7 +13,9 @@ import Control.Monad.Writer
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Identity
 
+import Data.Foldable (for_)
 import qualified Data.List as List
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Map as Map
@@ -307,28 +309,27 @@ applySection new ptel old ts ScopeCopyInfo{ renModules = rm, renNames = rd } = d
     -- and if a constructor is copied its datatype needs to be.
     closeConstructors :: Ren QName -> TCM (Ren QName)
     closeConstructors rd = do
-        ds <- nubOn id . catMaybes <$> mapM (constructorData  . fst) rd
-        cs <- nubOn id . concat    <$> mapM (dataConstructors . fst) rd
-        new <- concat <$> mapM rename (ds ++ cs)
+        ds <- nubOn id . catMaybes <$> traverse constructorData (Map.keys rd)
+        cs <- nubOn id . concat    <$> traverse dataConstructors (Map.keys rd)
+        new <- Map.unionsWith (<>) <$> traverse rename (ds ++ cs)
         reportSDoc "tc.mod.apply.complete" 30 $
           "also copying: " <+> pretty new
-        return $ new ++ rd
+        return $ Map.unionWith (<>) new rd
       where
         rename :: QName -> TCM (Ren QName)
-        rename x =
-          case lookup x rd of
-            Nothing -> do y <- freshName_ (show $ qnameName x)
-                          return [(x, qnameFromList $ singleton y)]
-            Just{}  -> return []
+        rename x
+          | x `Map.member` rd = pure mempty
+          | otherwise =
+              Map.singleton x . pure . qnameFromList . singleton <$> freshName_ (show $ qnameName x)
 
         constructorData :: QName -> TCM (Maybe QName)
-        constructorData x = do
+        constructorData x =
           (theDef <$> getConstInfo x) <&> \case
             Constructor{ conData = d } -> Just d
             _                          -> Nothing
 
         dataConstructors :: QName -> TCM [QName]
-        dataConstructors x = do
+        dataConstructors x =
           (theDef <$> getConstInfo x) <&> \case
             Datatype{ dataCons = cs } -> cs
             Record{ recConHead = h }  -> [conName h]
@@ -338,7 +339,7 @@ applySection' :: ModuleName -> Telescope -> ModuleName -> Args -> ScopeCopyInfo 
 applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = do
   do
     noCopyList <- catMaybes <$> mapM getName' constrainedPrims
-    forM_ (map fst rd) $ \ q -> do
+    for_ (Map.keys rd) $ \ q ->
       when (q `elem` noCopyList) $ typeError (TriedToCopyConstrainedPrim q)
 
   reportSDoc "tc.mod.apply" 10 $ vcat
@@ -348,9 +349,9 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
     , "old  =" <+> pretty old
     , "ts   =" <+> pretty ts
     ]
-  mapM_ (copyDef ts) rd
-  mapM_ (copySec ts) rm
-  computePolarity (map snd rd)
+  _ <- Map.traverseWithKey (traverse . copyDef ts) rd
+  _ <- Map.traverseWithKey (traverse . copySec ts) rm
+  computePolarity (Map.elems rd >>= NonEmpty.toList)
   where
     -- Andreas, 2013-10-29
     -- Here, if the name x is not imported, it persists as
@@ -360,15 +361,15 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
     -- I guess it would make sense to mark non-imported names
     -- as such (out-of-scope) and let splitting fail if it would
     -- produce out-of-scope constructors.
-    copyName x = fromMaybe x $ lookup x rd
+    copyName x = maybe x NonEmpty.head (Map.lookup x rd)
 
     argsToUse x = do
       let m = commonParentModule old x
       reportSDoc "tc.mod.apply" 80 $ "Common prefix: " <+> pretty m
       size <$> lookupSection m
 
-    copyDef :: Args -> (QName, QName) -> TCM ()
-    copyDef ts (x, y) = do
+    copyDef :: Args -> QName -> QName -> TCM ()
+    copyDef ts x y = do
       def <- getConstInfo x
       np  <- argsToUse (qnameModule x)
       -- Issue #3083: We need to use the hiding from the telescope of the
@@ -522,9 +523,9 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
       tel = Ξ.(Θ.Δ)[ts]
 
     calls
-      1. copySec ts (Top.A.M, C.M)
-      2. copySec ts (Top.B.N, C.N)
-      3. copySec ts (Top.B.N.O, C.N.O)
+      1. copySec ts Top.A.M C.M
+      2. copySec ts Top.B.N C.N
+      3. copySec ts Top.B.N.O C.N.O
     with
       old = Top.B
 
@@ -537,8 +538,8 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
       new section C.M
         tel =  Θ₂.Γ.Φ[ts']
     -}
-    copySec :: Args -> (ModuleName, ModuleName) -> TCM ()
-    copySec ts (x, y) = do
+    copySec :: Args -> ModuleName -> ModuleName -> TCM ()
+    copySec ts x y = do
       totalArgs <- argsToUse x
       tel       <- lookupSection x
       let sectionTel =  apply tel $ take totalArgs ts

--- a/test/Fail/Issue2446.err
+++ b/test/Fail/Issue2446.err
@@ -1,3 +1,3 @@
 Issue2446.agda:7,1-13
-Cannot create a module containing a copy of C.primTransp
+Cannot create a module containing a copy of C.primPOr
 when checking the module application module M = C


### PR DESCRIPTION
This speeds up a few lookups and an insertion (`addMod  x y rec = modify $ \ i -> i { memoModules = (x, (y, rec)) : filter ((/= x) . fst) (memoModules i) }`) asymptotically. Closes #4467.