### PR TITLE
Invariant: ProblemEq does not have top-level AsP

### DIFF
--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -326,6 +326,7 @@ noDataDefParams = DataDefParams Set.empty []
 --      emptiness of the type will be checked after splitting is complete.
 data ProblemEq = ProblemEq
   { problemInPat :: Pattern
+      -- ^ Invariant: not an 'AsP'.
   , problemInst  :: I.Term
   , problemType  :: I.Dom I.Type
   } deriving (Data, Show)


### PR DESCRIPTION
While looking at #4631, I thought I could apply `updateProblemEqs` to the original `ProblemEqs` to flatten out @-patterns eagerly (and making calls to `asView` redundant).  

However, this breaks `Builtin/Cubical/Id.agda`:
https://github.com/agda/agda/blob/07a949041cad19372ac13a6a9c2f0672640c180c/src/data/lib/prim/Agda/Builtin/Cubical/Id.agda#L30
```
x != ouc y of type A
when checking that the expression λ _ → x has type x ≡ ouc y
```

The reason could be that cubical does something in `updateProblemEqs` which is not safe to do at just any point:
https://github.com/agda/agda/blob/07a949041cad19372ac13a6a9c2f0672640c180c/src/full/Agda/TypeChecking/Rules/LHS.hs#L268-L270
Is that right, @Saizan ?

Intuitively, I would have expected that something like `updateProblemEqs` is safe to call at any point; it is a kind of normalization function.
