### PR TITLE
[ fix #4572 ] added piSort UnivSort funSort and Setω+n to the user-manual

### DIFF
--- a/doc/user-manual/language/index.rst
+++ b/doc/user-manual/language/index.rst
@@ -41,6 +41,7 @@ Language Reference
    runtime-irrelevance
    safe-agda
    sized-types
+   sort-system
    syntactic-sugar
    syntax-declarations
    telescopes

--- a/doc/user-manual/language/lexical-structure.lagda.rst
+++ b/doc/user-manual/language/lexical-structure.lagda.rst
@@ -43,7 +43,7 @@ keywords
   ``open`` :ref:`overlap <instance-fields>` ``pattern`` ``postulate``
   ``primitive`` ``private`` ``public`` :ref:`quote <reflection>`
   ``quoteContext`` ``quoteGoal`` :ref:`quoteTerm <macros>` ``record``
-  ``renaming`` ``rewrite`` ``Set`` ``Setω`` ``syntax`` ``tactic``
+  ``renaming`` ``rewrite`` ``Set`` ``syntax`` ``tactic``
   :ref:`unquote <macros>` :ref:`unquoteDecl <unquoting-declarations>`
   :ref:`unquoteDef <unquoting-declarations>` ``using``
   :ref:`variable <generalization-of-declared-variables>`
@@ -52,11 +52,6 @@ keywords
   The ``Set`` keyword can appear with a natural number suffix, optionally
   subscripted (see :ref:`universe-levels`). For instance ``Set42`` and
   ``Set₄₂`` are both keywords.
-
-  The ``Setω`` keyword can appear with a number suffix like ``Set``, and
-  also subscripted. See :ref:`set-omega-plus-n`) for details. For instance
-  ``Setω19`` and ``Setω₁₉`` are examples of keywords.
-
 
 .. _names:
 

--- a/doc/user-manual/language/lexical-structure.lagda.rst
+++ b/doc/user-manual/language/lexical-structure.lagda.rst
@@ -43,15 +43,19 @@ keywords
   ``open`` :ref:`overlap <instance-fields>` ``pattern`` ``postulate``
   ``primitive`` ``private`` ``public`` :ref:`quote <reflection>`
   ``quoteContext`` ``quoteGoal`` :ref:`quoteTerm <macros>` ``record``
-  ``renaming`` ``rewrite`` ``Set`` ``syntax`` ``tactic``
+  ``renaming`` ``rewrite`` ``Set`` ``Setω`` ``syntax`` ``tactic``
   :ref:`unquote <macros>` :ref:`unquoteDecl <unquoting-declarations>`
   :ref:`unquoteDef <unquoting-declarations>` ``using``
   :ref:`variable <generalization-of-declared-variables>`
   ``where`` ``with``
 
-  The ``Set`` keyword can appear with a number suffix, optionally subscripted
-  (see :ref:`universe-levels`). For instance ``Set42`` and ``Set₄₂`` are both
-  keywords.
+  The ``Set`` keyword can appear with a natural number suffix, optionally
+  subscripted (see :ref:`universe-levels`). For instance ``Set42`` and
+  ``Set₄₂`` are both keywords.
+
+  The ``Setω`` keyword can appear with a number suffix like ``Set``, and
+  also subscripted. See :ref:`set-omega-plus-n`) for details. For instance
+  ``Setω19`` and ``Setω₁₉`` are examples of keywords.
 
 
 .. _names:

--- a/doc/user-manual/language/sort-system.lagda.rst
+++ b/doc/user-manual/language/sort-system.lagda.rst
@@ -165,19 +165,27 @@ ensures the argument is not ``Setω``.
 Sorts ``Setωᵢ``
 ---------------
 
+Agda implements sorts of the form ``Setωᵢ``, being ``i`` any natural number,
+i.e. ``0``, ``1``, ``2``, ``3``, ...
+
 .. note::
-   Recall that the data type ``Nat`` is bound by default to a special
-   representation as Haskell integers (Agda's natural number concept).
-   For more information, see the section :ref:`Built-ins <built-ins>`.
+   In particular, ``i`` can *not* be an arbitrary expression of type ``Nat``;
+   therefore, ``Setωi`` cannot depend on any variables. This is an intentional
+   design decision. Allowing it would require a new universe ``Set2ω``, which
+   would then naturally lead to ``Set2ω+1``, and so on. Restricting ``i`` to
+   just literal natural numbers avoids such an undesired circumstance.
 
-Agda implements sorts of the form ``Setωᵢ``, where ``i`` can be any
-expression of type ``Nat`` (in particular also the decimal representations
-of the natural numbers, i.e. 0, 1, 2, 3, ...).
+The constructors ``funSort``, ``univSort``, and ``piSort`` that we saw in
+the previous sections also work for ``Setωi``, but with this restriction
+in mind. For example, ``piSort s` (λ x -> Setωi)`` will always reduce to
+``funSort s Setωi`` since there is no way for the ``i`` to depend on the
+variable ``x``.
 
-These sorts constitute a second hierarchy ``Setωᵢ : Setωᵢ₊₁``
-where each sort has the type of its successor. This mechanism is similar to
-the one implemented in the standard hierarchy ``Setᵢ : Setᵢ₊₁`` that we
-introduced in the section :ref:`Universe Levels <universe-levels>`.
+The family of sorts ``Setωᵢ`` (aka ``Setω+n``) constitute a second hierarchy
+``Setωᵢ : Setωᵢ₊₁`` where each sort has the type of its successor. This
+mechanism is similar to the one implemented in the standard hierarchy
+``Setᵢ : Setᵢ₊₁`` that we introduced in the section
+:ref:`Universe Levels <universe-levels>`.
 
 But, unlike the standard hierarchy of universes ``Setᵢ``, this second
 hierarchy ``Setωᵢ`` does not support universe polymorphism. This means that
@@ -186,9 +194,9 @@ expression ``∀ {i} (A : Setω i) → A → A`` would not be a well-formed agda
 term.
 
 You can also refer to these sorts with the alternative syntax ``Setωi``.
-That means that you can also write ``Setω1``, ``Setω2``, etc., instead
-of ``Setω₁``, ``Setω₂``. To enter the subscript ``₁`` in the Emacs mode,
-type "``\_1``".
+That means that you can also write ``Setω0``, ``Setω1``, ``Setω2``, etc.,
+instead of ``Setω₀``, ``Setω₁``, ``Setω₂``. To enter the subscript ``₁`` in
+the Emacs mode, type "``\_1``".
 
 The sort formerly known as ``Setω`` becomes now just an abbreviation for
 ``Setω₀``. Now it is allowed, for instance, to declare a datatype in ``Setω``.

--- a/doc/user-manual/language/sort-system.lagda.rst
+++ b/doc/user-manual/language/sort-system.lagda.rst
@@ -1,0 +1,112 @@
+..
+  ::
+  module sort.system where
+
+.. _sort-system:
+
+***********
+Sort System
+***********
+
+.. _intro-sorts:
+
+Agda's sorts system
+-------------------
+
+The implementation of Agda’s sorts system is closely based on the theory
+of pure type systems. Sorts (aka universes) are types whose members
+themselves are again types. The fundamental sort in Agda is named ``Set``
+and it denotes the universe of small types.
+
+But for some applications, other sorts are needed. Martin-Löf’s type theory
+had originally a rule ``Set : Set`` but Girard showed that it is inconsistent.
+This result is known as Girard’s paradox. Agda implements an
+:ref:`infinite hierarchy of universes <universe-levels>` that avoids this
+inconsistency.
+
+Under universe polymorphism, levels can be arbitrary terms, e.g., a
+level that contains free variables. Sometimes, we will have to check
+that some expression has a valid type without knowing what sort it has.
+
+funSort
+-------
+
+Agda’s internal representation of sorts implements a constructor (sort
+metavariable) representing an unknown sort. The constraint solver can
+compute these sort metavariables, just like it does when computing
+regular term metavariables.
+
+But this sort metavariable need other constructors to solve function
+types. The constructor ``funSort`` computes the sort of a function type
+even if the sort of the domain and the sort of the codomain are still
+unknown. Here is how ``funSort`` behaves with all possible sorts:
+
+.. code-block::
+
+  funSort Setω     _        = Setω
+  funSort _        Setω     = Setω
+  funSort (Set a)  (Set b)  = Set (a ⊔ b)
+  funSort (Prop a) (Set b)  = Set (a ⊔ b)
+  funSort (Set a)  (Prop b) = Prop (a ⊔ b)
+  funSort (Prop a) (Prop b) = Prop (a ⊔ b)
+
+Example: the sort of the function type ``∀ {A} → A → A`` with normal form
+``{A : _5} → A → A`` evaluates to ``funSort (univSort _5) (funSort _5 _5)``
+where:
+
+* ``_5`` is a metavariable that represents the sort of ``A``.
+* ``funSort _5 _5`` is the sort of ``A → A``
+
+Note that ``funSort`` can admit just two arguments, so it will be iterated
+when the function type has multiple arguments. E.g. the function type
+``∀ {A} → A → A → A`` evaluates to
+``funSort (univSort _5) (funSort _5 (funSort _5 _5))``
+
+univSort
+--------
+
+`univSort`` returns the successor sort of a given sort.
+
+* ``univSort _5`` is the sort where the sort of ``A`` lives, ie. the
+  successor level of ``_5``.
+
+``univSort`` appled to ``Setω`` is well-defined only if the option
+``--omega-in-omega`` is enabled in the agda file.
+
+.. code-block::
+
+  univSort (Set a)  = Set (lsuc a)
+  univSort (Prop a) = Set (lsuc a)
+  univSort Setω     = Setω                      (only if --omega-in-omega is enabled)
+
+PiSort
+------
+
+Similarly, ``PiSort s1 s2`` is a constructor that computes the sort of
+a Π-type given the sort ``s1`` of its domain and the sort ``s2`` of its
+codomain as arguments.
+
+.. code-block::
+
+  piSort s1 (λ x → s2) = funSort s1 s2          (if x does not occur freely in s2)
+  piSort s1 (λ x → s2) = Setω                   (if x occurs freely in s2)
+
+All these constructors do not represent new sorts but instead, they compute
+to the right sort once their arguments are known.
+
+More examples:
+
+* ``piSort Level (λ l → Set l)`` evaluates to ``Setω``
+* ``piSort (Set l) (λ _ → Set l')`` evaluates to ``Set (l ⊔ l')``
+* ``univSort (Set l)`` evaluates to ``Set (lsuc l)``
+* The function type ``∀ {A} → ∀ {B} → B → A → B`` with normal form
+  ``{A : _9} {B : _7} → B → A → B`` evaluates to
+  ``piSort (univSort _9) (λ A → funSort (univSort _7)
+  (funSort _7 (funSort _9 _7)))``
+
+Note that ``funSort`` and ``PiSort`` are total functions on sort. But
+``UnivSort`` is not always well-defined. Eg. without adding the
+``--omega-in-omega`` option, ``Setω`` does not have a ``UnivSort``
+(successor sort) since there is currently no next sort to ``Setω``.
+Any uses of ``univSort`` will lead to a 'has bigger sort' constraint that
+ensures the argument is not ``Setω``.

--- a/doc/user-manual/language/sort-system.lagda.rst
+++ b/doc/user-manual/language/sort-system.lagda.rst
@@ -1,6 +1,6 @@
 ..
   ::
-  module sort.system where
+  module language.sort-system where
 
 .. _sort-system:
 
@@ -165,8 +165,16 @@ ensures the argument is not ``Setω``.
 Sorts ``Setωᵢ``
 ---------------
 
-Agda implements sorts of the form ``Setωᵢ``, where ``i`` is a natural number
-``i : Nat``. These sorts constitute a second hierarchy ``Setωᵢ : Setωᵢ₊₁``
+.. note::
+   Recall that the data type ``Nat`` is bound by default to a special
+   representation as Haskell integers (Agda's natural number concept).
+   For more information, see the section :ref:`Built-ins <built-ins>`.
+
+Agda implements sorts of the form ``Setωᵢ``, where ``i`` can be any
+expression of type ``Nat`` (in particular also the decimal representations
+of the natural numbers, i.e. 0, 1, 2, 3, ...).
+
+These sorts constitute a second hierarchy ``Setωᵢ : Setωᵢ₊₁``
 where each sort has the type of its successor. This mechanism is similar to
 the one implemented in the standard hierarchy ``Setᵢ : Setᵢ₊₁`` that we
 introduced in the section :ref:`Universe Levels <universe-levels>`.

--- a/doc/user-manual/language/sort-system.lagda.rst
+++ b/doc/user-manual/language/sort-system.lagda.rst
@@ -153,3 +153,33 @@ Note that ``funSort`` and ``piSort`` are total functions on sort. But
 (successor sort) since there is currently no next sort to ``Setω``.
 Any uses of ``univSort`` will lead to a 'has bigger sort' constraint that
 ensures the argument is not ``Setω``.
+
+Sorts ``Setωᵢ``
+---------------
+
+Agda implements sorts of the form ``Setωᵢ``, where ``i`` is a natural number
+``i : Nat``. These sorts constitute a second hierarchy ``Setωᵢ : Setωᵢ₊₁``
+where each sort has the type of its successor. This mechanism is similar to
+the one implemented in the standard hierarchy ``Setᵢ : Setᵢ₊₁`` that we
+introduced in the section :ref:`Universe Levels <universe-levels>`.
+
+But, unlike the standard hierarchy of universes ``Setᵢ``, this second
+hierarchy ``Setωᵢ`` does not support universe polymorphism. This means that
+it is not possible to quantify over *all* Setω+n at once. For example, the
+expression ``∀ {i} (A : Setω i) → A → A`` would not be a well-formed agda
+term.
+
+You can also refer to these sorts with the alternative syntax ``Setωi``.
+That means that you can also write ``Setω1``, ``Setω2``, etc., instead
+of ``Setω₁``, ``Setω₂``. To enter the subscript ``₁`` in the Emacs mode,
+type "``\_1``".
+
+The sort formerly known as ``Setω`` becomes now just an abbreviation for
+``Setω₀``. Now it is allowed, for instance, to declare a datatype in ``Setω``.
+This means that ``Setω`` before the implementation of this hierarchy,
+``Setω`` used to be a term, and there was no bigger sort that it in Agda.
+Now a type can be assigned to it, in this case, ``Setω₁``.
+
+Concerning other applications,  It should not be necessary to refer to these
+sorts during normal usage of Agda, but they might be useful for defining
+:ref:`reflection-based macros <macros>`.

--- a/doc/user-manual/language/sort-system.lagda.rst
+++ b/doc/user-manual/language/sort-system.lagda.rst
@@ -101,28 +101,28 @@ We list below all the possible computations that ``univSort`` can perform:
   univSort (Prop a) = Set (lsuc a)
   univSort Setω     = Setω                      (only if --omega-in-omega is enabled)
 
-PiSort
+piSort
 ------
 
-Similarly, ``PiSort s1 s2`` is a constructor that computes the sort of
+Similarly, ``piSort s1 s2`` is a constructor that computes the sort of
 a Π-type given the sort ``s1`` of its domain and the sort ``s2`` of its
 codomain as arguments.
 
-To understand how ``PiSort`` works in general, we set the following scenario:
+To understand how ``piSort`` works in general, we set the following scenario:
 
 * ``sA`` and ``sB`` are two (possibly different) sorts.
 * ``A : sA``, meaning that ``A`` is a type that has sort ``sA``.
 * ``x : A``, meaning that ``x`` has type ``A``.
-* ``B : sB``, meaning that B is a type (possibly different than ``A``) that
-  has sort sB.
+* ``B : sB``, meaning that ``B`` is a type (possibly different than ``A``) that
+  has sort ``sB``.
 
 Under these conditions, we can build the dependent function type
-``(x : A) → B : PiSort sA (λ x → sB)``. This type signature means that the
+``(x : A) → B : piSort sA (λ x → sB)``. This type signature means that the
 dependent function type ``(x : A) → B`` has a (possibly unknown) but
-well-defined sort ``PiSort sA sB``, specified in terms of the element
+well-defined sort ``piSort sA sB``, specified in terms of the element
 ``x : A`` and the sorts of its domain and codomain.
 
-We list below all the possible computations that ``PiSort`` can perform:
+We list below all the possible computations that ``piSort`` can perform:
 
 .. code-block::
 
@@ -142,7 +142,7 @@ More examples:
   ``piSort (univSort _9) (λ A → funSort (univSort _7)
   (funSort _7 (funSort _9 _7)))``
 
-Note that ``funSort`` and ``PiSort`` are total functions on sort. But
+Note that ``funSort`` and ``piSort`` are total functions on sort. But
 ``UnivSort`` is not always well-defined. Eg. without adding the
 ``--omega-in-omega`` option, ``Setω`` does not have a ``UnivSort``
 (successor sort) since there is currently no next sort to ``Setω``.

--- a/doc/user-manual/language/sort-system.lagda.rst
+++ b/doc/user-manual/language/sort-system.lagda.rst
@@ -36,10 +36,27 @@ metavariable) representing an unknown sort. The constraint solver can
 compute these sort metavariables, just like it does when computing
 regular term metavariables.
 
-But this sort metavariable need other constructors to solve function
+But this sort metavariable needs other constructors to solve function
 types. The constructor ``funSort`` computes the sort of a function type
 even if the sort of the domain and the sort of the codomain are still
-unknown. Here is how ``funSort`` behaves with all possible sorts:
+unknown.
+
+To understand how ``funSort`` works in general, let us assume the following
+scenario:
+
+* ``sA`` and ``sB`` are two (possibly different) sorts.
+* ``A : sA``, meaning that ``A`` is a type that has sort ``sA``.
+* ``B : sB``, meaning that ``B`` is a (possibly different) type that has
+  sort ``sB``.
+
+Under these conditions, we can build the function type
+``A → B : funSort sA sB``. This type signature means that the function type
+``A → B`` has a (possibly unknown) but well-defined sort ``funSort sA sB``,
+specified in terms of the sorts of its domain and codomain.
+
+If ``sA`` and ``sB`` happen to be known, then ``funSort sA sB`` can be computed
+to a sort value. We list below all the possible computations that ``funSort``
+can perform:
 
 .. code-block::
 
@@ -55,7 +72,7 @@ Example: the sort of the function type ``∀ {A} → A → A`` with normal form
 where:
 
 * ``_5`` is a metavariable that represents the sort of ``A``.
-* ``funSort _5 _5`` is the sort of ``A → A``
+* ``funSort _5 _5`` is the sort of ``A → A``.
 
 Note that ``funSort`` can admit just two arguments, so it will be iterated
 when the function type has multiple arguments. E.g. the function type
@@ -65,13 +82,18 @@ when the function type has multiple arguments. E.g. the function type
 univSort
 --------
 
-`univSort`` returns the successor sort of a given sort.
+``univSort`` returns the successor sort of a given sort.
+
+Example: the sort of the function type ``∀ {A} → A`` with normal form
+``{A : _5} → A`` evaluates to ``funSort (univSort _5) _5`` where:
 
 * ``univSort _5`` is the sort where the sort of ``A`` lives, ie. the
   successor level of ``_5``.
 
-``univSort`` appled to ``Setω`` is well-defined only if the option
+Note that ``univSort`` appled to ``Setω`` is well-defined only if the option
 ``--omega-in-omega`` is enabled in the agda file.
+
+We list below all the possible computations that ``univSort`` can perform:
 
 .. code-block::
 
@@ -85,6 +107,22 @@ PiSort
 Similarly, ``PiSort s1 s2`` is a constructor that computes the sort of
 a Π-type given the sort ``s1`` of its domain and the sort ``s2`` of its
 codomain as arguments.
+
+To understand how ``PiSort`` works in general, we set the following scenario:
+
+* ``sA`` and ``sB`` are two (possibly different) sorts.
+* ``A : sA``, meaning that ``A`` is a type that has sort ``sA``.
+* ``x : A``, meaning that ``x`` has type ``A``.
+* ``B : sB``, meaning that B is a type (possibly different than ``A``) that
+  has sort sB.
+
+Under these conditions, we can build the dependent function type
+``(x : A) → B : PiSort sA (λ x → sB)``. This type signature means that the
+dependent function type ``(x : A) → B`` has a (possibly unknown) but
+well-defined sort ``PiSort sA sB``, specified in terms of the element
+``x : A`` and the sorts of its domain and codomain.
+
+We list below all the possible computations that ``PiSort`` can perform:
 
 .. code-block::
 

--- a/doc/user-manual/language/sort-system.lagda.rst
+++ b/doc/user-manual/language/sort-system.lagda.rst
@@ -10,10 +10,10 @@ Sort System
 
 .. _intro-sorts:
 
-Agda's sorts system
+Agda's sort system
 -------------------
 
-The implementation of Agda’s sorts system is closely based on the theory
+The implementation of Agda’s sort system is closely based on the theory
 of pure type systems. Sorts (aka universes) are types whose members
 themselves are again types. The fundamental sort in Agda is named ``Set``
 and it denotes the universe of small types.
@@ -27,6 +27,11 @@ inconsistency.
 Under universe polymorphism, levels can be arbitrary terms, e.g., a
 level that contains free variables. Sometimes, we will have to check
 that some expression has a valid type without knowing what sort it has.
+
+.. note::
+   ``funSort``, ``univSort`` and ``piSort`` are *internal* constructors
+   that may be printed when evaluating a term. The user can not enter them,
+   nor introduce them in agda code.
 
 funSort
 -------
@@ -143,8 +148,8 @@ More examples:
   (funSort _7 (funSort _9 _7)))``
 
 Note that ``funSort`` and ``piSort`` are total functions on sort. But
-``UnivSort`` is not always well-defined. Eg. without adding the
-``--omega-in-omega`` option, ``Setω`` does not have a ``UnivSort``
+``univSort`` is not always well-defined. Eg. without adding the
+``--omega-in-omega`` option, ``Setω`` does not have a ``univSort``
 (successor sort) since there is currently no next sort to ``Setω``.
 Any uses of ``univSort`` will lead to a 'has bigger sort' constraint that
 ensures the argument is not ``Setω``.

--- a/doc/user-manual/language/sort-system.lagda.rst
+++ b/doc/user-manual/language/sort-system.lagda.rst
@@ -33,6 +33,8 @@ that some expression has a valid type without knowing what sort it has.
    that may be printed when evaluating a term. The user can not enter them,
    nor introduce them in agda code.
 
+.. _funSort:
+
 funSort
 -------
 
@@ -84,6 +86,8 @@ when the function type has multiple arguments. E.g. the function type
 ``∀ {A} → A → A → A`` evaluates to
 ``funSort (univSort _5) (funSort _5 (funSort _5 _5))``
 
+.. _univSort:
+
 univSort
 --------
 
@@ -105,6 +109,8 @@ We list below all the possible computations that ``univSort`` can perform:
   univSort (Set a)  = Set (lsuc a)
   univSort (Prop a) = Set (lsuc a)
   univSort Setω     = Setω                      (only if --omega-in-omega is enabled)
+
+.. _piSort:
 
 piSort
 ------
@@ -153,6 +159,8 @@ Note that ``funSort`` and ``piSort`` are total functions on sort. But
 (successor sort) since there is currently no next sort to ``Setω``.
 Any uses of ``univSort`` will lead to a 'has bigger sort' constraint that
 ensures the argument is not ``Setω``.
+
+.. _set-omega-plus-n:
 
 Sorts ``Setωᵢ``
 ---------------

--- a/doc/user-manual/language/universe-levels.lagda.rst
+++ b/doc/user-manual/language/universe-levels.lagda.rst
@@ -282,7 +282,7 @@ Example: the sort of the function type ``∀ {A} → A → A`` with normal form
 where:
 
 * ``_5`` is a metavariable that represents the sort of ``A``.
-* ``funSort _5 _5)`` is the sort of ``A → A``
+* ``funSort _5 _5`` is the sort of ``A → A``
 * ``univSort _5`` is the sort where the sort of ``A`` lives, ie. the
   successor level of ``_5``.
 
@@ -300,8 +300,8 @@ to the right sort once their arguments are known.
 
 More examples:
 
-* ``piSort Level (\l. Set l)`` evaluates to ``Setω``
-* ``piSort (Set l) (\_. Set l')`` evaluates to ``Set (l ⊔ l')``
+* ``piSort Level (λ → Set l)`` evaluates to ``Setω``
+* ``piSort (Set l) (λ → Set l')`` evaluates to ``Set (l ⊔ l')``
 * ``univSort (Set l)`` evaluates to ``Set (lsuc l)``
 * The function type ``∀ {A} → ∀ {B} → B → A → B`` with normal form
   ``{A : _9} {B : _7} → B → A → B`` evaluates to

--- a/doc/user-manual/language/universe-levels.lagda.rst
+++ b/doc/user-manual/language/universe-levels.lagda.rst
@@ -260,6 +260,58 @@ Level) → Set n`` belongs to ``Setω`` which is not of this form. The
 only type constructor that can be applied to expressions of kind
 ``Setω`` is ``→``.
 
+univSort, piSort and funSort
+----------------------------
+
+Under universe polymorphism, levels can be arbitrary terms, e.g., a
+level that contains free variables. Sometimes, we will have to check
+that some expression has a valid type without knowing what sort it has.
+
+Agda’s internal representation of sorts implements a constructor (sort
+metavariable) representing an unknown sort. The constraint solver can
+compute these sort metavariables, just like it does when computing
+regular term metavariables.
+
+But this sort metavariable need other constructors to solve function
+types. The constructor ``funSort`` computes the sort of a function type
+even if the sort of the domain and the sort of the codomain are still
+unknown.
+
+Example: the sort of the function type ``∀ {A} → A → A`` with normal form
+``{A : _5} → A → A`` evaluates to ``funSort (univSort _5) (funSort _5 _5)``
+where:
+
+* ``_5`` is a metavariable that represents the sort of ``A``.
+* ``funSort _5 _5)`` is the sort of ``A → A``
+* ``univSort _5`` is the sort where the sort of ``A`` lives, ie. the
+  successor level of ``_5``.
+
+Note that ``funSort`` can admit just two arguments, so it will be iterated
+when the function type has multiple arguments. E.g. the function type
+``∀ {A} → A → A → A`` evaluates to
+``funSort (univSort _5) (funSort _5 (funSort _5 _5))``
+
+Similarly, ``PiSort s1 s2`` is a constructor that computes the sort of
+a Π-type given the sort ``s1`` of its domain and the sort ``s2`` of its
+codomain as arguments.
+
+These constructors do not represent new sorts but instead, they compute
+to the right sort once their arguments are known.
+
+More examples:
+
+* ``piSort Level (\l. Set l)`` evaluates to ``Setω``
+* ``piSort (Set l) (\_. Set l')`` evaluates to ``Set (l ⊔ l')``
+* ``univSort (Set l)`` evaluates to ``Set (lsuc l)``
+* The function type ``∀ {A} → ∀ {B} → B → A → B`` with normal form
+  ``{A : _9} {B : _7} → B → A → B`` evaluates to
+  ``piSort (univSort _9) (λ A → funSort (univSort _7)
+  (funSort _7 (funSort _9 _7)))``
+
+Note that ``funSort``, ``PiSort`` and ``UnivSort`` are not always
+well-defined. Eg. ``Setω`` does not have a ``UnivSort`` (successor
+sort) since there is currently no next sort to ``Setω``.
+
 Pragmas and options
 -------------------
 

--- a/doc/user-manual/language/universe-levels.lagda.rst
+++ b/doc/user-manual/language/universe-levels.lagda.rst
@@ -260,58 +260,6 @@ Level) → Set n`` belongs to ``Setω`` which is not of this form. The
 only type constructor that can be applied to expressions of kind
 ``Setω`` is ``→``.
 
-univSort, piSort and funSort
-----------------------------
-
-Under universe polymorphism, levels can be arbitrary terms, e.g., a
-level that contains free variables. Sometimes, we will have to check
-that some expression has a valid type without knowing what sort it has.
-
-Agda’s internal representation of sorts implements a constructor (sort
-metavariable) representing an unknown sort. The constraint solver can
-compute these sort metavariables, just like it does when computing
-regular term metavariables.
-
-But this sort metavariable need other constructors to solve function
-types. The constructor ``funSort`` computes the sort of a function type
-even if the sort of the domain and the sort of the codomain are still
-unknown.
-
-Example: the sort of the function type ``∀ {A} → A → A`` with normal form
-``{A : _5} → A → A`` evaluates to ``funSort (univSort _5) (funSort _5 _5)``
-where:
-
-* ``_5`` is a metavariable that represents the sort of ``A``.
-* ``funSort _5 _5`` is the sort of ``A → A``
-* ``univSort _5`` is the sort where the sort of ``A`` lives, ie. the
-  successor level of ``_5``.
-
-Note that ``funSort`` can admit just two arguments, so it will be iterated
-when the function type has multiple arguments. E.g. the function type
-``∀ {A} → A → A → A`` evaluates to
-``funSort (univSort _5) (funSort _5 (funSort _5 _5))``
-
-Similarly, ``PiSort s1 s2`` is a constructor that computes the sort of
-a Π-type given the sort ``s1`` of its domain and the sort ``s2`` of its
-codomain as arguments.
-
-These constructors do not represent new sorts but instead, they compute
-to the right sort once their arguments are known.
-
-More examples:
-
-* ``piSort Level (λ → Set l)`` evaluates to ``Setω``
-* ``piSort (Set l) (λ → Set l')`` evaluates to ``Set (l ⊔ l')``
-* ``univSort (Set l)`` evaluates to ``Set (lsuc l)``
-* The function type ``∀ {A} → ∀ {B} → B → A → B`` with normal form
-  ``{A : _9} {B : _7} → B → A → B`` evaluates to
-  ``piSort (univSort _9) (λ A → funSort (univSort _7)
-  (funSort _7 (funSort _9 _7)))``
-
-Note that ``funSort``, ``PiSort`` and ``UnivSort`` are not always
-well-defined. Eg. ``Setω`` does not have a ``UnivSort`` (successor
-sort) since there is currently no next sort to ``Setω``.
-
 Pragmas and options
 -------------------
 


### PR DESCRIPTION
Finally, I was editing the page of Universe levels. I think its name should also be changed maybe to `Universe hierarchy`, `Sort hierarchy` or something similar? What do you think? Since the arrival of `Setω` the levels are not the only possible universes.