### PR TITLE
Flat globals

### DIFF
--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -755,6 +755,7 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
                , funExtLam       = Nothing
                , funWith         = Nothing
                , funCovering     = []
+               , funDeclaredModality = Nothing
                }
   addConstant (conName genRecCon) $ defaultDefn defaultArgInfo (conName genRecCon) __DUMMY_TYPE__ $ -- Filled in later
     Constructor { conPars   = 0

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -255,7 +255,8 @@ applyModalityToContextFunBody thing cont = do
     ifM (optIrrelevantProjections <$> pragmaOptions)
       {-then-} (applyModalityToContext m cont)                -- enable global irr. defs always
       {-else-} (applyRelevanceToContextFunBody (getRelevance m)
-               $ applyCohesionToContext (getCohesion m)
+      -- Andrea: pfenning-davis modalities are already applied to the context by this point.
+      --         $ applyCohesionToContext (getCohesion m)
                $ applyQuantityToContext (getQuantity m) cont) -- enable local irr. defs only when option
   where
     m = getModality thing

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2143,6 +2143,7 @@ emptyFunction = Function
   , funExtLam      = Nothing
   , funWith        = Nothing
   , funCovering    = []
+  , funDeclaredModality = Nothing
   }
 
 funFlag :: FunctionFlag -> Lens' Bool Defn

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1943,6 +1943,11 @@ data Defn = Axiom -- ^ Postulate
             , funWith           :: Maybe QName
               -- ^ Is this a generated with-function? If yes, then what's the
               --   name of the parent function.
+            , funDeclaredModality :: Maybe Modality
+              -- ^ Pfenning-Davis modalities do not apply to global
+              -- constants (they are always topModality), but they do apply to the body (and type) of
+              -- functions, so we keep track here of how the function was declared.
+              -- Initialized by checkAxiom.
             }
           | Datatype
             { dataPars           :: Nat            -- ^ Number of parameters.
@@ -4283,8 +4288,8 @@ instance KillRange Defn where
       DataOrRecSig n -> DataOrRecSig n
       GeneralizableVar -> GeneralizableVar
       AbstractDefn{} -> __IMPOSSIBLE__ -- only returned by 'getConstInfo'!
-      Function cls comp ct tt covering inv mut isAbs delayed proj flags term extlam with ->
-        killRange14 Function cls comp ct tt covering inv mut isAbs delayed proj flags term extlam with
+      Function cls comp ct tt covering inv mut isAbs delayed proj flags term extlam with mod ->
+        killRange14 Function cls comp ct tt covering inv mut isAbs delayed proj flags term extlam with mod
       Datatype a b c d e f g h       -> killRange7 Datatype a b c d e f g h
       Record a b c d e f g h i j k l -> killRange12 Record a b c d e f g h i j k l
       Constructor a b c d e f g h i j-> killRange10 Constructor a b c d e f g h i j

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -84,7 +84,9 @@ addConstant q d = do
                     Nothing -> fallback
                     Just (doms, dom) -> telFromList $ fmap hideOrKeepInstance doms ++ [dom]
               _ -> tel
-  let d' = abstract tel' $ d { defName = q }
+  -- Andrea: for Pfenning-Davis modalities global constants are always available.
+  --         We do check at application site that any implicit module parameters are still usable.
+  let d' = mapArgInfo (setCohesion topCohesion) $ abstract tel' $ d { defName = q }
   reportSDoc "tc.signature" 60 $ "lambda-lifted definition =" <?> pretty d'
   modifySignature $ updateDefinitions $ HMap.insertWith (+++) q d'
   i <- currentOrFreshMutualBlock
@@ -992,6 +994,7 @@ inFreshModuleIfFreeParams k = do
 
 -- | Instantiate a closed definition with the correct part of the current
 --   context.
+--   Andrea: The Pfenning-Davis modality of an instantated def is meaningless.
 {-# SPECIALIZE instantiateDef :: Definition -> TCM Definition #-}
 instantiateDef
   :: ( Functor m, HasConstInfo m, HasOptions m

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -81,7 +81,10 @@ checkFunDef delayed i name cs = do
         modifySignature $ updateDefinition name $ updateDefBlocked $ const $
           NotBlocked MissingClauses ()
         -- Get the type and relevance of the function
-        def <- instantiateDef =<< getConstInfo name
+        def' <- getConstInfo name
+        let c = getCohesion $ fromMaybe __IMPOSSIBLE__ $ funDeclaredModality $ theDef def'
+        applyCohesionToContext c $ do
+        def <- instantiateDef def'
         let t    = defType def
         let info = getArgInfo def
         case isAlias cs t of

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -71,7 +71,7 @@ import Agda.Utils.IORef
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20200501 * 10 + 0
+currentInterfaceVersion = 20200525 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -350,9 +350,9 @@ instance EmbPrj EtaEquality where
 
 instance EmbPrj Defn where
   icod_ Axiom                                           = icodeN 0 Axiom
-  icod_ (Function    a b s t (_:_) c d e f g h i j k)   = __IMPOSSIBLE__
-  icod_ (Function    a b s t []    c d e f g h i j k)   =
-    icodeN 1 (\ a b s -> Function a b s t []) a b s c d e f g h i j k
+  icod_ (Function    a b s t (_:_) c d e f g h i j k l)   = __IMPOSSIBLE__
+  icod_ (Function    a b s t []    c d e f g h i j k l)   =
+    icodeN 1 (\ a b s -> Function a b s t []) a b s c d e f g h i j k l
   icod_ (Datatype    a b c d e f g h)                   = icodeN 2 Datatype a b c d e f g h
   icod_ (Record      a b c d e f g h i j k l)           = icodeN 3 Record a b c d e f g h i j k l
   icod_ (Constructor a b c d e f g h i j)               = icodeN 4 Constructor a b c d e f g h i j
@@ -364,7 +364,7 @@ instance EmbPrj Defn where
 
   value = vcase valu where
     valu [0]                                        = valuN Axiom
-    valu [1, a, b, s, c, d, e, f, g, h, i, j, k]    = valuN (\ a b s -> Function a b s Nothing []) a b s c d e f g h i j k
+    valu [1, a, b, s, c, d, e, f, g, h, i, j, k, l]    = valuN (\ a b s -> Function a b s Nothing []) a b s c d e f g h i j k l
     valu [2, a, b, c, d, e, f, g, h]                = valuN Datatype a b c d e f g h
     valu [3, a, b, c, d, e, f, g, h, i, j, k, l]    = valuN Record  a b c d e f g h i j k l
     valu [4, a, b, c, d, e, f, g, h, i, j]          = valuN Constructor a b c d e f g h i j


### PR DESCRIPTION
Once a definition is lambda lifted and put into the signature it should be available as flat (this is the K rule of modal logics).

In particular this was affecting the `usableMod` check used during pattern matching.