### PR TITLE
[github-actions] Add Windows run for cabal-install tests

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -17,7 +17,7 @@ on:
     - 'Setup.hs'
 
 jobs:
-  linux:
+  Ubuntu:
 
     runs-on: ubuntu-16.04
 
@@ -60,7 +60,7 @@ jobs:
       run: |
         cabal build
 
-  mac:
+  macOS:
 
     runs-on: macos-latest
 
@@ -86,3 +86,48 @@ jobs:
     - name: Build Agda
       run: |
         cabal build
+
+  Windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        ghc-ver: ["8.10.1"]
+        cabal-ver: ["3.2"]
+        icu-ver: [58.2-3]
+
+    env:
+      FLAGS: "-f enable-cluster-counting"
+      ICU_FILE: "mingw-w64-x86_64-icu-${{ matrix.icu-ver }}-any.pkg.tar.xz"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-haskell@v1.1
+      with:
+        ghc-version: ${{ matrix.ghc-ver }}
+        cabal-version: ${{ matrix.cabal-ver }}
+
+    - name: Update cabal
+      run: |
+        cabal update
+
+    - name: Download ICU ${{ matrix.icu-ver }}
+      run: |
+        C:\msys64\usr\bin\wget.exe -q http://repo.msys2.org/mingw/x86_64/${env:ICU_FILE}
+
+    - name: Install ICU ${{ matrix.icu-ver }}
+      run: |
+        C:\msys64\usr\bin\pacman.exe -U --noconfirm ${env:ICU_FILE}
+
+    - name: Create cabal.config
+      run: |
+        echo "extra-lib-dirs: C:\msys64\mingw64\lib" >> cabal.config
+        echo "extra-include-dirs: C:\msys64\mingw64\include" >> cabal.config
+
+    - name: Build dependencies
+      run: |
+        cabal build ${FLAGS} --only-dependencies
+
+    - name: Build Agda
+      run: |
+        cabal build ${FLAGS}


### PR DESCRIPTION
Resolves #4513 by adding a CI run for Windows that uses cabal-install. 

This also includes enable-cluster-counting with text-icu support.