### PR TITLE
<record-name>.constructor instead of recCon-NOT-PRINTED

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -141,7 +141,10 @@ checkRecDef i name uc ind eta0 pat con (A.DataDefParams gpars ps) contel fields 
         Just c  -> return (True, c)
         Nothing -> do
           m <- killRange <$> currentModule
-          r <- prettyTCM name
+          -- Andreas, 2020-06-01, AIM XXXII
+          -- Using prettyTCM here jinxes the printer, see PR #4699.
+          -- r <- prettyTCM name
+          let r = P.pretty $ qnameName name
           c <- qualify m <$> freshName_ (render r ++ ".constructor")
           return (False, c)
 

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -39,6 +39,7 @@ import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Utils.Permutation
 import Agda.Utils.POMonoid
+import Agda.Utils.Pretty (render)
 import qualified Agda.Utils.Pretty as P
 import Agda.Utils.Size
 
@@ -136,12 +137,13 @@ checkRecDef i name uc ind eta0 pat con (A.DataDefParams gpars ps) contel fields 
         -- NB: contype does not contain the parameter telescope
 
       -- Obtain name of constructor (if present).
-      (hasNamedCon, conName, conInfo) <- case con of
-        Just c  -> return (True, c, i)
+      (hasNamedCon, conName) <- case con of
+        Just c  -> return (True, c)
         Nothing -> do
           m <- killRange <$> currentModule
-          c <- qualify m <$> freshName_ ("recCon-NOT-PRINTED" :: String)
-          return (False, c, i)
+          r <- prettyTCM name
+          c <- qualify m <$> freshName_ (render r ++ ".constructor")
+          return (False, c)
 
       -- Add record type to signature.
       reportSDoc "tc.rec" 15 $ "adding record type to signature"
@@ -226,7 +228,7 @@ checkRecDef i name uc ind eta0 pat con (A.DataDefParams gpars ps) contel fields 
               , conArity  = size fs
               , conSrcCon = con
               , conData   = name
-              , conAbstr  = Info.defAbstract conInfo
+              , conAbstr  = Info.defAbstract i
               , conInd    = conInduction
               , conComp   = emptyCompKit  -- filled in later
               , conProj   = Nothing       -- filled in later

--- a/test/Compiler/simple/Word.out
+++ b/test/Compiler/simple/Word.out
@@ -2,8 +2,8 @@ EXECUTED_PROGRAM
 
 ret > ExitSuccess
 out > Word.NumWord =
-out >   Agda.Builtin.FromNat.recCon-NOT-PRINTED _ (λ a _ → toWord64 a)
-out > Word.NumNat = Agda.Builtin.FromNat.recCon-NOT-PRINTED _ (λ a _ → a)
+out >   Agda.Builtin.FromNat.Number.constructor _ (λ a _ → toWord64 a)
+out > Word.NumNat = Agda.Builtin.FromNat.Number.constructor _ (λ a _ → a)
 out > Word.natOp = λ a b c → toWord64 (a (fromWord64 b) (fromWord64 c))
 out > Word._^_ =
 out >   λ a b →

--- a/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
+++ b/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
@@ -1,4 +1,4 @@
 Issue1944-UnappliedOverloadedProjectionNotRecord.agda:15,8-9
 Cannot resolve overloaded projection f because principal argument
 is not of record type
-when checking that the expression f has type A₁ → A₁
+when checking that the expression f has type A → A

--- a/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
+++ b/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
@@ -1,4 +1,4 @@
 Issue1944-UnappliedOverloadedProjectionNotRecord.agda:15,8-9
 Cannot resolve overloaded projection f because principal argument
 is not of record type
-when checking that the expression f has type A → A
+when checking that the expression f has type A₁ → A₁


### PR DESCRIPTION
For #4697 I changed Agda to name anonymous record constructors as `R.constructor` where `R`is the name of the record type in question.

This change has some non-local effect on the the printer of bound variables.  
@jespercockx, could you take a look? 