### PR TITLE
Allow shadowing of pattern vars contained in ellipsis ... (#4704)

### DIFF
--- a/src/full/Agda/Syntax/Abstract/Pattern.hs
+++ b/src/full/Agda/Syntax/Abstract/Pattern.hs
@@ -372,6 +372,13 @@ lhsCoreWith :: LHSCore' e -> [Pattern' e] -> LHSCore' e
 lhsCoreWith (LHSWith core wps []) wps' = LHSWith core (wps ++ wps') []
 lhsCoreWith core                  wps' = LHSWith core wps' []
 
+-- Andreas, 2020-06-04, issue #4704:
+-- The type-checker does not deal correctly with consecutive LHSWith,
+-- thus we fuse them.  (I did not get to the bottom of this problem.)
+-- | Smart 'LHSWith' constructor, fuses consecutive 'LHSWith'.
+lhsWith :: IsProjP e => LHSCore' e -> [Pattern' e] -> [NamedArg (Pattern' e)] -> LHSCore' e
+lhsWith core wps ps = core `lhsCoreWith` wps `lhsCoreAddSpine` ps
+
 lhsCoreAddChunk :: IsProjP e => LHSCore' e -> LHSPatternView e -> LHSCore' e
 lhsCoreAddChunk core = \case
   LHSAppP ps               -> lhsCoreApp core ps

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -410,7 +410,7 @@ instance Pretty LHSCore where
   pretty (LHSProj d ps lhscore ps') = sep $
     pretty d : map (parens . pretty) ps ++
     parens (pretty lhscore) : map (parens . pretty) ps'
-  pretty (LHSWith h wps ps) = if null ps then doc else
+  pretty (LHSWith h _ell wps ps) = if null ps then doc else
       sep $ parens doc : map (parens . pretty) ps
     where
     doc = sep $ pretty h : map (("|" <+>) . pretty) wps
@@ -698,7 +698,7 @@ instance Pretty Pattern where
             QuoteP _        -> "quote"
             RecP _ fs       -> sep [ "record", bracesAndSemicolons (map pretty fs) ]
             EqualP _ es     -> sep $ [ parens (sep [pretty e1, "=", pretty e2]) | (e1,e2) <- es ]
-            EllipsisP _     -> "..."
+            EllipsisP _ _   -> "..."
             WithP _ p       -> "|" <+> pretty p
 
 prettyOpApp :: forall a .

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2626,6 +2626,8 @@ data TCEnv =
           , envMakeCase            :: Bool                 -- ^ are we inside a make-case (if so, ignore forcing analysis in unifier)
           , envSolvingConstraints  :: Bool
                 -- ^ Are we currently in the process of solving active constraints?
+          , envScopeCheckingEllipsis :: Bool
+                -- ^ Are we scope checking an ellipsis?
           , envCheckingWhere       :: Bool
                 -- ^ Have we stepped into the where-declarations of a clause?
                 --   Everything under a @where@ will be checked with this flag on.
@@ -2752,6 +2754,7 @@ initEnv = TCEnv { envContext             = []
                 , envCoverageCheck       = YesCoverageCheck
                 , envMakeCase            = False
                 , envSolvingConstraints  = False
+                , envScopeCheckingEllipsis = False
                 , envCheckingWhere       = False
                 , envActiveProblems      = Set.empty
                 , envWorkingOnTypes      = False
@@ -2859,6 +2862,9 @@ eMakeCase f e = f (envMakeCase e) <&> \ x -> e { envMakeCase = x }
 
 eSolvingConstraints :: Lens' Bool TCEnv
 eSolvingConstraints f e = f (envSolvingConstraints e) <&> \ x -> e { envSolvingConstraints = x }
+
+eScopeCheckingEllipsis :: Lens' Bool TCEnv
+eScopeCheckingEllipsis f e = f (envScopeCheckingEllipsis e) <&> \ x -> e { envScopeCheckingEllipsis = x }
 
 eCheckingWhere :: Lens' Bool TCEnv
 eCheckingWhere f e = f (envCheckingWhere e) <&> \ x -> e { envCheckingWhere = x }

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -749,7 +749,8 @@ checkLeftHandSide call f ps a withSub' strippedPats =
                  , "qs      = " <+> addContext delta (prettyList $ map pretty qs)
                  ]
                ]
-        reportSDoc "tc.lhs.top" 30 $
+        reportSDoc "tc.lhs.top" 20 $ nest 2 $ "vars     = " <+> pretty vars
+        reportSDoc "tc.lhs.top" 50 $
           nest 2 $ vcat
                  [ "vars   = " <+> text (show vars)
                  ]

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -203,6 +203,9 @@ buildWithFunction cxtNames f aux t delta qs npars withSub perm n1 n cs = mapM bu
       reportSDoc "tc.with" 20 $ vcat
         [ "buildWithClause returns" <+> prettyA result
         ]
+      reportSDoc "tc.with.clause" 70 $ vcat
+        [ "buildWithClause returns" <+> (text . show) result
+        ]
       return result
 
     buildRHS _ rhs@A.RHS{}                 = return rhs

--- a/test/Fail/Issue3937.err
+++ b/test/Fail/Issue3937.err
@@ -1,5 +1,6 @@
 Issue3937.agda:3,9-12
 Could not parse the left-hand side ...
+Problematic expression: ...
 Operators used in the grammar:
   None
 when scope checking let ... = ? in ?

--- a/test/Fail/Issue4518.agda
+++ b/test/Fail/Issue4518.agda
@@ -1,4 +1,5 @@
--- Andreas, 2020-03-18, issue 4518, reported by strangeglyph
+-- Andreas, 2020-03-18, issue #4518, reported by strangeglyph
+-- Andreas, 2020-06-03, issue #4704, now preserves ellipsis in error
 
 -- Better error message when parsing of LHS fails
 
@@ -13,6 +14,6 @@ test with foo
 ... | suc n = Set
 
 -- ERROR:
--- Could not parse the left-hand side test | suc n
+-- Could not parse the left-hand side ... | suc n
 -- NEW INFORMATION:
 -- Problematic expression: (suc n)

--- a/test/Fail/Issue4518.err
+++ b/test/Fail/Issue4518.err
@@ -1,7 +1,7 @@
-Issue4518.agda:13,1-12
-Could not parse the left-hand side test | suc n
+Issue4518.agda:14,1-12
+Could not parse the left-hand side ... | suc n
 Problematic expression: (suc n)
 Operators used in the grammar:
   None
-when scope checking the left-hand side test | suc n in the
+when scope checking the left-hand side ... | suc n in the
 definition of test

--- a/test/Fail/Issue4586LetEllipsis.err
+++ b/test/Fail/Issue4586LetEllipsis.err
@@ -1,5 +1,6 @@
 Issue4586LetEllipsis.agda:5,12-19
 Could not parse the left-hand side ... | _
+Problematic expression: ...
 Operators used in the grammar:
   None
 when scope checking let ... | _ = Set in Set

--- a/test/Fail/Issue4723.agda
+++ b/test/Fail/Issue4723.agda
@@ -1,0 +1,10 @@
+-- Andreas, 2020-06-03, issue #4723
+-- Regression introduced in 2.5.4 due to work on #2822
+
+f : Set₁ → Set₁
+f with Set
+... | _ = λ _ → Set
+... x = x
+
+-- ERROR WAS: Unreachable clause f x = x
+-- EXPECTED: This should not parse.

--- a/test/Fail/Issue4723.err
+++ b/test/Fail/Issue4723.err
@@ -1,0 +1,6 @@
+Issue4723.agda:7,1-6
+Could not parse the left-hand side ... x
+Problematic expression: x
+Operators used in the grammar:
+  None
+when scope checking the left-hand side ... x in the definition of f

--- a/test/Succeed/CopatternsWith.agda
+++ b/test/Succeed/CopatternsWith.agda
@@ -1,4 +1,5 @@
 -- Andreas, 2015-05-02 Integrate copatterns with with.
+-- Andreas, 2020-06-03 issue #4704: shadowing of pattern variables under ellipsis
 
 {-# OPTIONS --guardedness #-}
 
@@ -24,11 +25,15 @@ force (map f s) with force s
 
 zipWith : ∀{A B C} → (A → B → C) → Stream A → Stream B → Stream C
 force (zipWith f s t) with force s | force t
-... | a , as | b , bs = f a b , zipWith f as bs
+... | a , s | b , t = f a b , zipWith f s t
+  -- Andreas, 2020-06-03 issue #4704
+  -- Allow shadowing of pattern variables (s, t) under an ellipsis.
 
-interleave : ∀{A} (s t : Stream A) → Stream A
-force (interleave s t) with force s
-... | a , as = a , interleave t as
+_interleave_ : ∀{A} (s t : Stream A) → Stream A
+force (s interleave t) with force s
+... | a , s = a , t interleave s
+  -- Andreas, 2020-06-03 issue #4704
+  -- Should also work with operator lhs (see pr #4709).
 
 mutual
   evens : ∀{A} (s : Stream A) → Stream A

--- a/test/interaction/Issue2589.agda
+++ b/test/interaction/Issue2589.agda
@@ -16,3 +16,14 @@ baz : Nat → Nat
 baz m with m
 ... | n with n
 ... | p = {!p!}
+
+-- data IsSuc : Nat → Set where
+--   isSuc : ∀ n → IsSuc (suc n)
+
+-- postulate
+--   lie : ∀ n → IsSuc n
+
+-- blub : Nat → Nat → Nat
+-- blub x y with lie x | bar y
+-- ... | isSuc n | q with lie q | lie x
+-- ... | r | isSuc _ = {!r!}


### PR DESCRIPTION
Working on fixing #4704. (And the OP of #1820.)

To this end, I modified `EllipsisP` to hold a pattern the ellipsis will be expanded into.  This pattern is filled in in the nicifier.  The scope checker then will allow shadowing of pattern variables that are inside `EllipsisP`.  Concretely when having
```agda
test : Nat -> Nat
test n with suc n
... | n = ?
```
the patterns (`n`) after the ellipsis are checked first, then the content of the ellipsis is checked (`test n`) where the shadowed pattern variables (`n`) are allocated as fresh abstract names to not clash with the higher-prio pattern variables (`n`).

Currently, the pattern parsing does not work anymore when I have a operator lhs, e.g.
```agda
_test : Nat -> Nat
(suc n) test with suc n
... | _ = _
```
Somehow stuff inside the `EllipsisP` (here: `(suc n) test`) is not parsed correctly and thus not recognized as possible lhs.  It is parsed as `(suc n test)` rather than `test_ (suc n)`.  I have no clue why this is, @nad, could you take a look?  The relevant code is in the file `Operator.hs`.