### PR TITLE
Allow modalities on primitives

### DIFF
--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -160,7 +160,7 @@ data Declaration
   | Generalize (Set QName) DefInfo ArgInfo QName Expr
     -- ^ First argument is set of generalizable variables used in the type.
   | Field      DefInfo QName (Arg Expr)              -- ^ record field
-  | Primitive  DefInfo QName Expr                    -- ^ primitive function
+  | Primitive  DefInfo QName (Arg Expr)              -- ^ primitive function
   | Mutual     MutualInfo [Declaration]              -- ^ a bunch of mutually recursive definitions
   | Section    Range ModuleName GeneralizeTelescope [Declaration]
   | Apply      ModuleInfo ModuleName ModuleApplication ScopeCopyInfo ImportDirective

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -116,7 +116,7 @@ data NiceDeclaration
       --   'ArgInfo' argument: Axioms and functions can be declared irrelevant.
       --   ('Hiding' should be 'NotHidden'.)
   | NiceField Range Access IsAbstract IsInstance TacticAttribute Name (Arg Expr)
-  | PrimitiveFunction Range Access IsAbstract Name Expr
+  | PrimitiveFunction Range Access IsAbstract Name (Arg Expr)
   | NiceMutual Range TerminationCheck CoverageCheck PositivityCheck [NiceDeclaration]
   | NiceModule Range Access IsAbstract QName Telescope [Declaration]
   | NiceModuleMacro Range Access Name ModuleApplication OpenShortHand ImportDirective
@@ -1350,7 +1350,7 @@ niceDeclarations fixs ds = do
       _ -> throwError $ WrongContentBlock b $ getRange d
 
     toPrim :: NiceDeclaration -> NiceDeclaration
-    toPrim (Axiom r p a i rel x t) = PrimitiveFunction r p a x t
+    toPrim (Axiom r p a i rel x t) = PrimitiveFunction r p a x (Arg rel t)
     toPrim _                       = __IMPOSSIBLE__
 
     -- Create a function definition.
@@ -1884,7 +1884,7 @@ notSoNiceDeclarations :: NiceDeclaration -> [Declaration]
 notSoNiceDeclarations = \case
     Axiom _ _ _ i rel x e          -> inst i [TypeSig rel Nothing x e]
     NiceField _ _ _ i tac x argt   -> [FieldSig i tac x argt]
-    PrimitiveFunction r _ _ x e    -> [Primitive r [TypeSig defaultArgInfo Nothing x e]]
+    PrimitiveFunction r _ _ x e    -> [Primitive r [TypeSig (argInfo e) Nothing x (unArg e)]]
     NiceMutual r _ _ _ ds          -> [Mutual r $ concatMap notSoNiceDeclarations ds]
     NiceModule r _ _ x tel ds      -> [Module r x tel ds]
     NiceModuleMacro r _ x ma o dir -> [ModuleMacro r x ma o dir]

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1281,7 +1281,10 @@ Postulate : 'postulate' Declarations0 { Postulate (fuseRange $1 $2) $2 }
 
 -- Primitives. Can only contain type signatures.
 Primitive :: { Declaration }
-Primitive : 'primitive' TypeSignatures0  { Primitive (fuseRange $1 $2) $2 }
+Primitive : 'primitive' ArgTypeSignaturesOrEmpty  {
+  let { setArg (Arg info (TypeSig _ tac x t)) = TypeSig info tac x t
+      ; setArg _ = __IMPOSSIBLE__ } in
+  Primitive (fuseRange $1 $2) (map setArg $2) }
 
 -- Unquoting declarations.
 UnquoteDecl :: { Declaration }

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1061,8 +1061,8 @@ instance ToConcrete A.Declaration [C.Declaration] where
     x' <- unsafeQNameToName <$> toConcrete x
     withAbstractPrivate i $
       withInfixDecl i x'  $ do
-      t' <- toConcreteTop t
-      return [C.Primitive (getRange i) [C.TypeSig defaultArgInfo Nothing x' t']]
+      t' <- traverse toConcreteTop t
+      return [C.Primitive (getRange i) [C.TypeSig (argInfo t') Nothing x' (unArg t')]]
         -- Primitives are always relevant.
 
   toConcrete (A.FunDef i _ _ cs) =

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1591,7 +1591,7 @@ instance ToAbstract NiceDeclaration A.Declaration where
 
   -- Primitive function
     PrimitiveFunction r p a x t -> do
-      t' <- toAbstractCtx TopCtx t
+      t' <- traverse (toAbstractCtx TopCtx) t
       f  <- getConcreteFixity x
       y  <- freshAbstractQName f x
       bindName p PrimName x y

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3420,6 +3420,7 @@ data TypeError
         | NoBindingForBuiltin String
         | NoSuchPrimitiveFunction String
         | DuplicatePrimitiveBinding String QName QName
+        | WrongModalityForPrimitive String ArgInfo ArgInfo
         | ShadowedModule C.Name [A.ModuleName]
         | BuiltinInParameterisedModule String
         | IllegalLetInTelescope C.TypedBinding

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -670,8 +670,8 @@ checkAxiom' gentel kind i info0 mp x e = whenAbstractFreezeMetasAfter i $ defaul
     solveSizeConstraints $ if checkingWhere then DontDefaultToInfty else DefaultToInfty
 
 -- | Type check a primitive function declaration.
-checkPrimitive :: A.DefInfo -> QName -> A.Expr -> TCM ()
-checkPrimitive i x e =
+checkPrimitive :: A.DefInfo -> QName -> Arg A.Expr -> TCM ()
+checkPrimitive i x (Arg info e) =
     traceCall (CheckPrimitive (getRange i) x e) $ do
     (name, PrimImpl t' pf) <- lookupPrimitiveFunctionQ x
     -- Certain "primitive" functions are BUILTIN rather than
@@ -693,9 +693,18 @@ checkPrimitive i x e =
     t <- isType_ e
     noConstraints $ equalType t t'
     let s  = prettyShow $ qnameName x
+    -- Checking the modality. Currently all primitives require default
+    -- modalities, and likely very few will have different modalities in the
+    -- future. Thus, rather than, the arguably nicer solution of adding a
+    -- modality to PrimImpl we simply check the few special primitives here.
+    let expectedInfo =
+          case name of
+            -- Currently no special primitives
+            _ -> defaultArgInfo
+    unless (info == expectedInfo) $ typeError $ WrongModalityForPrimitive name info expectedInfo
     bindPrimitive s pf
     addConstant x $
-      defaultDefn defaultArgInfo x t $
+      defaultDefn info x t $
         Primitive { primAbstr    = Info.defAbstract i
                   , primName     = s
                   , primClauses  = []

--- a/test/Fail/WrongPrimitiveModality.agda
+++ b/test/Fail/WrongPrimitiveModality.agda
@@ -1,0 +1,18 @@
+
+module _ where
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+postulate
+  String : Set
+{-# BUILTIN STRING String #-}
+
+primitive
+  @0 ⦃ primShowNat ⦄ : Nat → String
+
+-- Wrong modality for primitive primShowNat
+--   Got:      instance, erased
+--   Expected: visible, unrestricted
+-- when checking that the type of the primitive function primShowNat
+-- is Nat → String

--- a/test/Fail/WrongPrimitiveModality.err
+++ b/test/Fail/WrongPrimitiveModality.err
@@ -1,0 +1,6 @@
+WrongPrimitiveModality.agda:12,8-36
+Wrong modality for primitive primShowNat
+  Got:      instance, erased
+  Expected: visible, unrestricted
+when checking that the type of the primitive function primShowNat
+is Nat → String


### PR DESCRIPTION
Currently all primitives require defaultArgInfo, but instead of
a parse error you get a nice error message if you try to give a
different modality.