### PR TITLE
[ re #2151 ] Update reflected syntax to include clause telescope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,57 @@ Reflection
   `nameErr` parts. They also do a better job of respecting line breaks in
   `strErr` parts.
 
+- The representation of reflected patterns and clauses has
+  changed. Each clause now includes a telescope with the names and
+  types of the pattern variables.
+
+  ```agda
+  data Clause where
+    clause        : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) (t : Term) → Clause
+    absurd-clause : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) → Clause
+  ```
+
+  These telescopes provide additional information on the types of
+  pattern variables that was previously hard to reconstruct (see
+  [#2151](https://github.com/agda/agda/issues/2151)). When unquoting a
+  clause, the types in the clause telescope are currently ignored (but
+  this is subject to change in the future).
+
+  Two constructors of the `Pattern` datatype were also changed:
+  pattern variables now refer to a de Bruijn index (relative to the
+  clause telescope) rather than a string, and dot patterns now include
+  the actual dotted term.
+
+  ```agda
+  data Pattern where
+    con    : (c : Name) (ps : List (Arg Pattern)) → Pattern
+    dot    : (t : Term)    → Pattern   -- previously:   dot : Pattern
+    var    : (x : Nat)     → Pattern   -- previously:   var : (x : String) → Pattern
+    lit    : (l : Literal) → Pattern
+    proj   : (f : Name)    → Pattern
+    absurd : Pattern
+  ```
+
+  It is likely that this change to the reflected syntax requires you
+  to update reflection code written for previous versions of
+  Agda. Here are some tips for updating your code:
+
+  * When quoting a clause, you can recover the name of a pattern
+    variable by looking up the given index in the clause
+    telescope. The contents of dot patterns can safely be ignored
+    (unless you have a use for them).
+
+  * When creating a new clause for unquoting, you need to create a
+    telescope for the types of the pattern variables. To get back the
+    old behaviour of Agda, it is sufficient to set all the types of
+    the pattern variables to `unknown`. So you can construct the
+    telescope by listing the names of all pattern variables together
+    with their `ArgInfo`. Meanwhile, the pattern variables should be
+    numbered in order to update them to the new representation. As for
+    the telescope types, the contents of a `dot` pattern can safely be
+    set to `unknown`.
+
+
 Emacs mode
 ----------
 

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -142,29 +142,13 @@ data Literal : Set where
 {-# BUILTIN AGDALITQNAME  name    #-}
 {-# BUILTIN AGDALITMETA   meta    #-}
 
--- Patterns --
 
-data Pattern : Set where
-  con    : (c : Name) (ps : List (Arg Pattern)) → Pattern
-  dot    : Pattern
-  var    : (s : String)  → Pattern
-  lit    : (l : Literal) → Pattern
-  proj   : (f : Name)    → Pattern
-  absurd : Pattern
+-- Terms and patterns --
 
-{-# BUILTIN AGDAPATTERN   Pattern #-}
-{-# BUILTIN AGDAPATCON    con     #-}
-{-# BUILTIN AGDAPATDOT    dot     #-}
-{-# BUILTIN AGDAPATVAR    var     #-}
-{-# BUILTIN AGDAPATLIT    lit     #-}
-{-# BUILTIN AGDAPATPROJ   proj    #-}
-{-# BUILTIN AGDAPATABSURD absurd  #-}
-
--- Terms --
-
-data Sort   : Set
-data Clause : Set
-data Term   : Set
+data Term    : Set
+data Sort    : Set
+data Pattern : Set
+data Clause  : Set
 Type = Term
 
 data Term where
@@ -184,13 +168,22 @@ data Sort where
   lit     : (n : Nat) → Sort
   unknown : Sort
 
-data Clause where
-  clause        : (ps : List (Arg Pattern)) (t : Term) → Clause
-  absurd-clause : (ps : List (Arg Pattern)) → Clause
+data Pattern where
+  con    : (c : Name) (ps : List (Arg Pattern)) → Pattern
+  dot    : (t : Term)    → Pattern
+  var    : (x : Nat)     → Pattern
+  lit    : (l : Literal) → Pattern
+  proj   : (f : Name)    → Pattern
+  absurd : Pattern
 
-{-# BUILTIN AGDASORT    Sort   #-}
-{-# BUILTIN AGDATERM    Term   #-}
-{-# BUILTIN AGDACLAUSE  Clause #-}
+data Clause where
+  clause        : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) (t : Term) → Clause
+  absurd-clause : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) → Clause
+
+{-# BUILTIN AGDATERM      Term    #-}
+{-# BUILTIN AGDASORT      Sort    #-}
+{-# BUILTIN AGDAPATTERN   Pattern #-}
+{-# BUILTIN AGDACLAUSE    Clause  #-}
 
 {-# BUILTIN AGDATERMVAR         var       #-}
 {-# BUILTIN AGDATERMCON         con       #-}
@@ -206,6 +199,13 @@ data Clause where
 {-# BUILTIN AGDASORTSET         set     #-}
 {-# BUILTIN AGDASORTLIT         lit     #-}
 {-# BUILTIN AGDASORTUNSUPPORTED unknown #-}
+
+{-# BUILTIN AGDAPATCON    con     #-}
+{-# BUILTIN AGDAPATDOT    dot     #-}
+{-# BUILTIN AGDAPATVAR    var     #-}
+{-# BUILTIN AGDAPATLIT    lit     #-}
+{-# BUILTIN AGDAPATPROJ   proj    #-}
+{-# BUILTIN AGDAPATABSURD absurd  #-}
 
 {-# BUILTIN AGDACLAUSECLAUSE clause        #-}
 {-# BUILTIN AGDACLAUSEABSURD absurd-clause #-}

--- a/src/full/Agda/Syntax/Reflected.hs
+++ b/src/full/Agda/Syntax/Reflected.hs
@@ -2,6 +2,8 @@
 
 module Agda.Syntax.Reflected where
 
+import Data.Text (Text)
+
 import Agda.Syntax.Common
 import Agda.Syntax.Literal
 import Agda.Syntax.Abstract.Name
@@ -43,14 +45,23 @@ data Sort = SetS Term
   deriving (Show)
 
 data Pattern = ConP QName [Arg Pattern]
-             | DotP
-             | VarP String
+             | DotP Term
+             | VarP Int
              | LitP Literal
              | AbsurdP
              | ProjP QName
   deriving (Show)
 
-data Clause = Clause [Arg Pattern] Term | AbsurdClause [Arg Pattern]
+data Clause
+  = Clause
+    { clauseTel  :: [(Text, Arg Type)]
+    , clausePats :: [Arg Pattern]
+    , clauseRHS  :: Term
+    }
+  | AbsurdClause
+    { clauseTel  :: [(Text, Arg Type)]
+    , clausePats :: [Arg Pattern]
+    }
   deriving (Show)
 
 data Definition = FunDef Type [Clause]

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -8,6 +8,8 @@ import Control.Monad.Except
 import Control.Monad.Reader
 
 import Data.Maybe
+import Data.Text (Text)
+import qualified Data.Text as Text
 
 import Agda.Syntax.Literal
 import Agda.Syntax.Position
@@ -22,6 +24,7 @@ import Agda.TypeChecking.Monad as M hiding (MetaInfo)
 import Agda.Syntax.Scope.Monad (getCurrentModule)
 
 import Agda.Utils.Impossible
+import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.List
 import Agda.Utils.List1 (List1, pattern (:|))
@@ -53,6 +56,11 @@ withName s f = do
   local (name:) $ f name'
   where
     notTaken xs x = isNoName x || nameConcrete x `notElem` xs
+
+withNames :: MonadReflectedToAbstract m => [String] -> ([Name] -> m a) -> m a
+withNames ss f = case ss of
+  []     -> f []
+  (s:ss) -> withNames ss $ \ns -> withName s $ \n -> f (n:ns)
 
 -- | Returns the name of the variable with the given de Bruijn index.
 askName :: MonadReflectedToAbstract m => Int -> m (Maybe Name)
@@ -93,7 +101,7 @@ instance ToAbstract r a => ToAbstract (Named name r) (Named name a) where
 instance ToAbstract r a => ToAbstract (Arg r) (NamedArg a) where
   toAbstract (Arg i x) = Arg i <$> toAbstract (unnamed x)
 
-instance ToAbstract [Arg Term] [NamedArg Expr] where
+instance ToAbstract r a => ToAbstract [Arg r] [NamedArg a] where
   toAbstract = traverse toAbstract
 
 instance ToAbstract r Expr => ToAbstract (Dom r, Name) (A.TypedBinding) where
@@ -122,13 +130,8 @@ instance ToAbstract Literal Expr where
 instance ToAbstract Term Expr where
   toAbstract t = case t of
     R.Var i es -> do
-      mname <- askName i
-      case mname of
-        Nothing -> do
-          cxt   <- getContextTelescope
-          names <- asks $ drop (size cxt) . reverse
-          withShowAllArguments' False $ typeError $ DeBruijnIndexOutOfScope i cxt names
-        Just name -> toAbstract (A.Var name, es)
+      name <- mkVarName i
+      toAbstract (A.Var name, es)
     R.Con c es -> toAbstract (A.Con (unambiguous $ killRange c), es)
     R.Def f es -> do
       af <- mkDef (killRange f)
@@ -164,6 +167,12 @@ mkDef f =
 mkApp :: Expr -> Expr -> Expr
 mkApp e1 e2 = App (setOrigin Reflected defaultAppInfo_) e1 $ defaultNamedArg e2
 
+mkVarName :: MonadReflectedToAbstract m => Int -> m Name
+mkVarName i = ifJustM (askName i) return $ do
+  cxt   <- getContextTelescope
+  names <- asks $ drop (size cxt) . reverse
+  withShowAllArguments' False $ typeError $ DeBruijnIndexOutOfScope i cxt names
+
 instance ToAbstract Sort Expr where
   toAbstract s = do
     setName <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinSet
@@ -172,37 +181,26 @@ instance ToAbstract Sort Expr where
       LitS x -> return $ A.Def' setName $ A.Suffix x
       UnknownS -> return $ mkApp (A.Def setName) $ Underscore emptyMetaInfo
 
-instance ToAbstract R.Pattern (Names, A.Pattern) where
+instance ToAbstract R.Pattern A.Pattern where
   toAbstract pat = case pat of
     R.ConP c args -> do
-      (names, args) <- toAbstractPats args
-      return (names, A.ConP (ConPatInfo ConOCon patNoRange ConPatEager) (unambiguous $ killRange c) args)
-    R.DotP    -> return ([], A.WildP patNoRange)
-    R.VarP s | isNoName s -> withName "z" $ \ name -> return ([name], A.VarP $ mkBindName name)
-        -- Ulf, 2016-08-09: Also bind noNames (#2129). This to make the
-        -- behaviour consistent with lambda and pi.
-        -- return ([], A.WildP patNoRange)
-    R.VarP s  -> withName s $ \ name -> return ([name], A.VarP $ mkBindName name)
-    R.LitP l  -> return ([], A.LitP patNoRange l)
-    R.AbsurdP -> return ([], A.AbsurdP patNoRange)
-    R.ProjP d -> return ([], A.ProjP patNoRange ProjSystem $ unambiguous $ killRange d)
-
-toAbstractPats :: MonadReflectedToAbstract m => [Arg R.Pattern] -> m (Names, [NamedArg A.Pattern])
-toAbstractPats pats = case pats of
-    []   -> return ([], [])
-    p:ps -> do
-      (names,  p)  <- (distributeF . fmap distributeF) <$> toAbstract p
-      (namess, ps) <- local (names++) $ toAbstractPats ps
-      return (namess++names, p:ps)
+      args <- toAbstract args
+      return $ A.ConP (ConPatInfo ConOCon patNoRange ConPatEager) (unambiguous $ killRange c) args
+    R.DotP t -> A.DotP patNoRange <$> toAbstract t
+    R.VarP i -> A.VarP . mkBindName <$> mkVarName i
+    R.LitP l  -> return $ A.LitP patNoRange l
+    R.AbsurdP -> return $ A.AbsurdP patNoRange
+    R.ProjP d -> return $ A.ProjP patNoRange ProjSystem $ unambiguous $ killRange d
 
 instance ToAbstract (QNamed R.Clause) A.Clause where
-  toAbstract (QNamed name (R.Clause pats rhs)) = do
-    (names, pats) <- toAbstractPats pats
-    rhs           <- local (names++) $ toAbstract rhs
+  -- TODO: remember the types in the telescope
+  toAbstract (QNamed name (R.Clause tel pats rhs)) = withNames (map (Text.unpack . fst) tel) $ \_ -> do
+    pats <- toAbstract pats
+    rhs  <- toAbstract rhs
     let lhs = spineToLhs $ SpineLHS empty name pats
     return $ A.Clause lhs [] (RHS rhs Nothing) noWhereDecls False
-  toAbstract (QNamed name (R.AbsurdClause pats)) = do
-    (_, pats) <- toAbstractPats pats
+  toAbstract (QNamed name (R.AbsurdClause tel pats)) = withNames (map (Text.unpack . fst) tel) $ \_ -> do
+    pats <- toAbstract pats
     let lhs = spineToLhs $ SpineLHS empty name pats
     return $ A.Clause lhs [] AbsurdRHS noWhereDecls False
 

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -90,9 +90,9 @@ coreBuiltins =
                                                                    builtinAgdaLitQName, builtinAgdaLitMeta])
   , (builtinAgdaPattern                      |-> BuiltinData tset [builtinAgdaPatVar, builtinAgdaPatCon, builtinAgdaPatDot,
                                                                    builtinAgdaPatLit, builtinAgdaPatProj, builtinAgdaPatAbsurd])
-  , (builtinAgdaPatVar                       |-> BuiltinDataCons (tstring --> tpat))
+  , (builtinAgdaPatVar                       |-> BuiltinDataCons (tnat --> tpat))
   , (builtinAgdaPatCon                       |-> BuiltinDataCons (tqname --> tlist (targ tpat) --> tpat))
-  , (builtinAgdaPatDot                       |-> BuiltinDataCons tpat)
+  , (builtinAgdaPatDot                       |-> BuiltinDataCons (tterm --> tpat))
   , (builtinAgdaPatLit                       |-> BuiltinDataCons (tliteral --> tpat))
   , (builtinAgdaPatProj                      |-> BuiltinDataCons (tqname --> tpat))
   , (builtinAgdaPatAbsurd                    |-> BuiltinDataCons tpat)
@@ -319,8 +319,8 @@ coreBuiltins =
   , (builtinProp                             |-> BuiltinSort "primProp")
   , (builtinSetOmega                         |-> BuiltinSort "primSetOmega")
   , (builtinAgdaClause                       |-> BuiltinData tset [builtinAgdaClauseClause, builtinAgdaClauseAbsurd])
-  , (builtinAgdaClauseClause                 |-> BuiltinDataCons (tlist (targ tpat) --> tterm --> tclause))
-  , (builtinAgdaClauseAbsurd                 |-> BuiltinDataCons (tlist (targ tpat) --> tclause))
+  , (builtinAgdaClauseClause                 |-> BuiltinDataCons (ttelescope --> tlist (targ tpat) --> tterm --> tclause))
+  , (builtinAgdaClauseAbsurd                 |-> BuiltinDataCons (ttelescope --> tlist (targ tpat) --> tclause))
   , (builtinAgdaDefinition                   |-> BuiltinData tset [builtinAgdaDefinitionFunDef
                                                                   ,builtinAgdaDefinitionDataDef
                                                                   ,builtinAgdaDefinitionDataConstructor
@@ -392,6 +392,11 @@ coreBuiltins =
         tlevel     = el primLevel
         tlist x    = el $ list (fmap unEl x)
         tmaybe x   = el $ tMaybe (fmap unEl x)
+        tpair lx ly x y = el $ primSigma
+                            <#> lx
+                            <#> ly
+                            <@> fmap unEl x
+                            <@> (Lam defaultArgInfo . NoAbs "_" <$> fmap unEl y)
         targ x     = el (arg (fmap unEl x))
         tabs x     = el (primAbs <@> fmap unEl x)
         targs      = el (list (arg primAgdaTerm))
@@ -420,6 +425,7 @@ coreBuiltins =
         tliteral   = el primAgdaLiteral
         tpat       = el primAgdaPattern
         tclause    = el primAgdaClause
+        ttelescope = tlist (tpair primLevelZero primLevelZero tstring (targ ttype))
         tTCM l a   = elV l (primAgdaTCM <#> varM l <@> a)
         tTCM_ a    = el (primAgdaTCM <#> primLevelZero <@> a)
         tinterval  = El (Inf 0) <$> primInterval

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -296,6 +296,17 @@ instance Unquote a => Unquote [a] where
       Con c _ _ -> __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "list" t
 
+instance (Unquote a, Unquote b) => Unquote (a, b) where
+  unquote t = do
+    t <- reduceQuotedTerm t
+    SigmaKit{..} <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
+    case t of
+      Con c _ es | Just [x,y] <- allApplyElims es ->
+        choice
+          [(pure (c == sigmaCon), (,) <$> unquoteN x <*> unquoteN y)]
+          __IMPOSSIBLE__
+      _ -> throwError $ NonCanonical "pair" t
+
 instance Unquote Hiding where
   unquote t = do
     t <- reduceQuotedTerm t
@@ -438,11 +449,11 @@ instance Unquote R.Pattern where
       Con c _ [] ->
         choice
           [ (c `isCon` primAgdaPatAbsurd, return R.AbsurdP)
-          , (c `isCon` primAgdaPatDot,    return R.DotP)
           ] __IMPOSSIBLE__
       Con c _ es | Just [x] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaPatVar,  R.VarP . T.unpack <$> unquoteNString x)
+          [ (c `isCon` primAgdaPatVar,  R.VarP . fromInteger <$> unquoteN x)
+          , (c `isCon` primAgdaPatDot,  R.DotP  <$> unquoteN x)
           , (c `isCon` primAgdaPatProj, R.ProjP <$> unquoteN x)
           , (c `isCon` primAgdaPatLit,  R.LitP  <$> unquoteN x) ]
           __IMPOSSIBLE__
@@ -457,13 +468,13 @@ instance Unquote R.Clause where
   unquote t = do
     t <- reduceQuotedTerm t
     case t of
-      Con c _ es | Just [x] <- allApplyElims es ->
-        choice
-          [ (c `isCon` primAgdaClauseAbsurd, R.AbsurdClause <$> unquoteN x) ]
-          __IMPOSSIBLE__
       Con c _ es | Just [x, y] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaClauseClause, R.Clause <$> unquoteN x <*> unquoteN y) ]
+          [ (c `isCon` primAgdaClauseAbsurd, R.AbsurdClause <$> unquoteN x <*> unquoteN y) ]
+          __IMPOSSIBLE__
+      Con c _ es | Just [x, y, z] <- allApplyElims es ->
+        choice
+          [ (c `isCon` primAgdaClauseClause, R.Clause <$> unquoteN x <*> unquoteN y <*> unquoteN z) ]
           __IMPOSSIBLE__
       Con c _ _ -> __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "clause" t

--- a/test/Fail/Issue1228.agda
+++ b/test/Fail/Issue1228.agda
@@ -2,6 +2,7 @@
 open import Common.Prelude hiding (tt)
 open import Common.Reflection
 open import Common.Equality
+open import Agda.Builtin.Sigma
 
 tt : ⊤
 tt = record{}
@@ -28,9 +29,11 @@ noConf = funDef
   ([ "A" ∈ `Nat ]→ [ "B" ∈ `Nat ]→
    [ "C" ∈ def (quote _≡_) (vArg (var 1 []) ∷ vArg (var 0 []) ∷ []) ]→
    def (quote NoConf) (vArg (var 2 []) ∷ vArg (var 1 []) ∷ []))
-  ( clause (vArg (con (quote zero) []) ∷ vArg dot ∷ vArg (con (quote refl) []) ∷ [])
+  ( clause []
+           (vArg (con (quote zero) []) ∷ vArg (dot unknown) ∷ vArg (con (quote refl) []) ∷ [])
            (con (quote tt) [])
-  ∷ clause (vArg (con (quote suc) (vArg (var "m") ∷ [])) ∷ vArg dot ∷ vArg (con (quote refl) []) ∷ [])
+  ∷ clause (("m" , vArg unknown) ∷ [])
+           (vArg (con (quote suc) (vArg (var 0) ∷ [])) ∷ vArg (dot unknown) ∷ vArg (con (quote refl) []) ∷ [])
            (con (quote refl) [])
   ∷ [])
 

--- a/test/Fail/Issue1228.err
+++ b/test/Fail/Issue1228.err
@@ -1,2 +1,2 @@
-Issue1228.agda:37,1-45
+Issue1228.agda:40,1-45
 Use def instead of con for non-constructor tt

--- a/test/Fail/Issue1228b.agda
+++ b/test/Fail/Issue1228b.agda
@@ -2,6 +2,7 @@
 open import Common.Prelude hiding (tt)
 open import Common.Reflection
 open import Common.Equality
+open import Agda.Builtin.Sigma
 
 tt : ⊤
 tt = record{}
@@ -28,9 +29,11 @@ noConf = funDef
   ([ "A" ∈ `Nat ]→ [ "B" ∈ `Nat ]→
    [ "C" ∈ def (quote _≡_) (vArg (var 1 []) ∷ vArg (var 0 []) ∷ []) ]→
    def (quote NoConf) (vArg (var 2 []) ∷ vArg (var 1 []) ∷ []))
-  ( clause (vArg (con (quote zero) []) ∷ vArg dot ∷ vArg (con (quote refl) []) ∷ [])
+  ( clause []
+           (vArg (con (quote zero) []) ∷ vArg (dot unknown) ∷ vArg (con (quote refl) []) ∷ [])
            (def (quote tt) [])
-  ∷ clause (vArg (con (quote suc) (vArg (var "m") ∷ [])) ∷ vArg dot ∷ vArg (con (quote refl) []) ∷ [])
+  ∷ clause (("m" , vArg unknown) ∷ [])
+           (vArg (con (quote suc) (vArg (var 0) ∷ [])) ∷ vArg (dot unknown) ∷ vArg (con (quote refl) []) ∷ [])
            (def (quote refl) [])
   ∷ [])
 

--- a/test/Fail/Issue1228b.err
+++ b/test/Fail/Issue1228b.err
@@ -1,2 +1,2 @@
-Issue1228b.agda:37,1-45
+Issue1228b.agda:40,1-45
 Use con instead of def for constructor refl

--- a/test/Fail/Issue1303.agda
+++ b/test/Fail/Issue1303.agda
@@ -2,6 +2,7 @@
 
 open import Common.Reflection
 open import Common.Prelude
+open import Agda.Builtin.Sigma
 
 data Box : Set → Set₁ where
   box : (A : Set) → Box A
@@ -13,7 +14,8 @@ unquoteDecl test = define (vArg test) (funDef
     (vArg (def (quote Box) (vArg (var 0 []) ∷ [])))
     (abs "x" (sort (lit 0))))))
  (clause
-   (vArg dot ∷
-    vArg (con (quote box) (vArg (var "dot") ∷ [])) ∷ [])
+   (("dot" , vArg unknown) ∷ [])
+   (vArg (dot unknown) ∷
+    vArg (con (quote box) (vArg (var 0) ∷ [])) ∷ [])
    (var 1 [])
  ∷ []))

--- a/test/Fail/Issue1303.err
+++ b/test/Fail/Issue1303.err
@@ -1,2 +1,2 @@
-Issue1303.agda:9,1-19,8
+Issue1303.agda:10,1-21,8
 de Bruijn index 1 is not in scope in the context (dot₁ : _)

--- a/test/Fail/Issue4012.agda
+++ b/test/Fail/Issue4012.agda
@@ -13,13 +13,13 @@ abstract
   f : D
   unquoteDef f = do
     qc ← quoteTC c  -- Previously, there was a complaint here about c.
-    defineFun f (clause [] qc ∷ [])
+    defineFun f (clause [] [] qc ∷ [])
 
   unquoteDecl g = do
     ty ← quoteTC D
     _  ← declareDef (arg (arg-info visible relevant) g) ty
     qc ← quoteTC c
-    defineFun g (clause [] qc ∷ [])
+    defineFun g (clause [] [] qc ∷ [])
 
 test : f ≡ g
 test = refl

--- a/test/Fail/TerminationCheckUnquote.agda
+++ b/test/Fail/TerminationCheckUnquote.agda
@@ -20,7 +20,7 @@ makeLoop : TC Term
 makeLoop =
   freshName "cheat" >>= λ cheat →
   declareDef (vArg cheat) `⊥ >>= λ _ →
-  defineFun cheat (clause [] (def cheat []) ∷ []) >>= λ _ →
+  defineFun cheat (clause [] [] (def cheat []) ∷ []) >>= λ _ →
   returnTC (def cheat [])
 
 macro

--- a/test/Fail/TerminationCheckUnquoteDecl.agda
+++ b/test/Fail/TerminationCheckUnquoteDecl.agda
@@ -19,8 +19,8 @@ makeLoop : QName → TC ⊤
 makeLoop loop =
   freshName "aux" >>= λ aux →
   declareDef (vArg aux) `⊥ >>= λ _ →
-  defineFun aux (clause [] (def aux []) ∷ []) >>= λ _ →
+  defineFun aux (clause [] [] (def aux []) ∷ []) >>= λ _ →
   declareDef (vArg loop) `⊥ >>= λ _ →
-  defineFun loop (clause [] (def aux []) ∷ [])
+  defineFun loop (clause [] [] (def aux []) ∷ [])
 
 unquoteDecl loop = makeLoop loop

--- a/test/Fail/TerminationCheckUnquoteDeclUnnamed.agda
+++ b/test/Fail/TerminationCheckUnquoteDeclUnnamed.agda
@@ -25,7 +25,7 @@ makeLoop : TC ⊤
 makeLoop =
   freshName "aux" >>= λ aux →
   declareDef (iArg aux) `Box >>= λ _ →
-  defineFun aux (clause [] (con (quote box) (vArg (def (quote unbox) (vArg (def aux []) ∷ [])) ∷ [])) ∷ [])
+  defineFun aux (clause [] [] (con (quote box) (vArg (def (quote unbox) (vArg (def aux []) ∷ [])) ∷ [])) ∷ [])
 
 unquoteDecl = makeLoop
 

--- a/test/Fail/TerminationCheckUnquoteDef.agda
+++ b/test/Fail/TerminationCheckUnquoteDef.agda
@@ -19,8 +19,8 @@ makeLoop : QName → TC ⊤
 makeLoop loop =
   freshName "aux" >>= λ aux →
   declareDef (vArg aux) `⊥ >>= λ _ →
-  defineFun aux (clause [] (def aux []) ∷ []) >>= λ _ →
-  defineFun loop (clause [] (def aux []) ∷ [])
+  defineFun aux (clause [] [] (def aux []) ∷ []) >>= λ _ →
+  defineFun loop (clause [] [] (def aux []) ∷ [])
 
 loop : ⊥
 unquoteDef loop = makeLoop loop

--- a/test/Fail/UnquoteDeclHelperNotDefined.agda
+++ b/test/Fail/UnquoteDeclHelperNotDefined.agda
@@ -10,4 +10,4 @@ unquoteDecl f =
   declareDef (vArg f) `Nat >>= λ _ →
   freshName "aux" >>= λ aux →
   declareDef (vArg aux) `Nat >>= λ _ →
-  defineFun f (clause [] (def aux []) ∷ [])
+  defineFun f (clause [] [] (def aux []) ∷ [])

--- a/test/Fail/UnquoteDeclHelperNotDefined.err
+++ b/test/Fail/UnquoteDeclHelperNotDefined.err
@@ -1,2 +1,2 @@
-UnquoteDeclHelperNotDefined.agda:9,1-13,44
+UnquoteDeclHelperNotDefined.agda:9,1-13,47
 Missing definition for UnquoteDeclHelperNotDefined.aux

--- a/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
+++ b/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
@@ -9,6 +9,7 @@ open import Agda.Builtin.List
 open import Agda.Builtin.String
 open import Agda.Builtin.Char
 open import Agda.Builtin.Float
+open import Agda.Builtin.Sigma
 
 -- Names --
 
@@ -90,21 +91,6 @@ data Literal : Set where
 
 -- Patterns --
 
-data Pattern : Set where
-  con    : (c : Name) (ps : List (Arg Pattern)) → Pattern
-  dot    : Pattern
-  var    : (s : String)  → Pattern
-  lit    : (l : Literal) → Pattern
-  proj   : (f : Name)    → Pattern
-  absurd : Pattern
-
-{-# BUILTIN AGDAPATTERN   Pattern #-}
-{-# BUILTIN AGDAPATCON    con     #-}
-{-# BUILTIN AGDAPATDOT    dot     #-}
-{-# BUILTIN AGDAPATVAR    var     #-}
-{-# BUILTIN AGDAPATLIT    lit     #-}
-{-# BUILTIN AGDAPATPROJ   proj    #-}
-{-# BUILTIN AGDAPATABSURD absurd  #-}
 
 -- Terms --
 
@@ -130,13 +116,22 @@ data Sort where
   lit     : (n : Nat) → Sort
   unknown : Sort
 
-data Clause where
-  clause        : (ps : List (Arg Pattern)) (t : Term) → Clause
-  absurd-clause : (ps : List (Arg Pattern)) → Clause
+data Pattern : Set where
+  con    : (c : Name) (ps : List (Arg Pattern)) → Pattern
+  dot    : (t : Term)    → Pattern
+  var    : (x : Nat)     → Pattern
+  lit    : (l : Literal) → Pattern
+  proj   : (f : Name)    → Pattern
+  absurd : Pattern
 
-{-# BUILTIN AGDASORT    Sort   #-}
-{-# BUILTIN AGDATERM    Term   #-}
-{-# BUILTIN AGDACLAUSE  Clause #-}
+data Clause where
+  clause        : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) (t : Term) → Clause
+  absurd-clause : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) → Clause
+
+{-# BUILTIN AGDATERM    Term    #-}
+{-# BUILTIN AGDASORT    Sort    #-}
+{-# BUILTIN AGDAPATTERN Pattern #-}
+{-# BUILTIN AGDACLAUSE  Clause  #-}
 
 {-# BUILTIN AGDATERMVAR         var       #-}
 {-# BUILTIN AGDATERMCON         con       #-}
@@ -152,6 +147,13 @@ data Clause where
 {-# BUILTIN AGDASORTSET         set     #-}
 {-# BUILTIN AGDASORTLIT         lit     #-}
 {-# BUILTIN AGDASORTUNSUPPORTED unknown #-}
+
+{-# BUILTIN AGDAPATCON    con     #-}
+{-# BUILTIN AGDAPATDOT    dot     #-}
+{-# BUILTIN AGDAPATVAR    var     #-}
+{-# BUILTIN AGDAPATLIT    lit     #-}
+{-# BUILTIN AGDAPATPROJ   proj    #-}
+{-# BUILTIN AGDAPATABSURD absurd  #-}
 
 {-# BUILTIN AGDACLAUSECLAUSE clause        #-}
 {-# BUILTIN AGDACLAUSEABSURD absurd-clause #-}

--- a/test/Succeed/Issue1218.agda
+++ b/test/Succeed/Issue1218.agda
@@ -7,4 +7,4 @@ open import Common.Reflection
 unquoteDecl loop =
   define (vArg loop)
          (funDef (def (quote Nat) [])
-                 (clause [] (def loop []) ∷ []))
+                 (clause [] [] (def loop []) ∷ []))

--- a/test/Succeed/Issue1227.agda
+++ b/test/Succeed/Issue1227.agda
@@ -2,6 +2,7 @@
 open import Common.Prelude hiding (pred)
 open import Common.Reflection
 open import Common.Equality
+open import Agda.Builtin.Sigma
 
 un-function : Definition → FunDef
 un-function (funDef cs) = funDef unknown cs
@@ -16,7 +17,8 @@ pred ._ (is-suc n) = n
 pred-def : FunDef
 pred-def =
   funDef (quoteTerm ((n : Nat) → Is-suc n → Nat))
-         (clause (vArg dot ∷ vArg (con (quote is-suc) (vArg (var "n") ∷ [])) ∷ [])
+         (clause (("n" , vArg unknown) ∷ [])
+                 (vArg (dot unknown) ∷ vArg (con (quote is-suc) (vArg (var 0) ∷ [])) ∷ [])
                  (var 0 []) ∷ [])
 
 data Is-zero : Nat → Set where
@@ -28,7 +30,8 @@ f ._ is-zero = zero
 f-def : FunDef
 f-def =
   funDef (quoteTerm ((n : Nat) → Is-zero n → Nat))
-         (clause (vArg dot ∷ vArg (con (quote is-zero) []) ∷ [])
+         (clause []
+                 (vArg (dot unknown) ∷ vArg (con (quote is-zero) []) ∷ [])
                  (con (quote zero) []) ∷ [])
 
 unquoteDecl pred' = define (vArg pred') pred-def

--- a/test/Succeed/Issue1344.agda
+++ b/test/Succeed/Issue1344.agda
@@ -1,6 +1,7 @@
 {-# OPTIONS -v tc.unquote:30 #-}
 open import Common.Prelude
 open import Common.Reflection
+open import Agda.Builtin.Sigma
 
 data Box : Bool → Set where
   box : (b : Bool) → Box b
@@ -10,18 +11,23 @@ works b (box .b) = unquote (give (var 0 []))
 
 works₂ : (b : Bool) → Box b → Bool
 unquoteDef works₂ = defineFun works₂ (clause
-  ( arg (argInfo visible relevant) (var "b")
+  ( ("b" , arg (argInfo visible relevant) unknown) ∷ [])
+  ( arg (argInfo visible relevant) (var 0)
   ∷ arg (argInfo visible relevant) (con (quote box)
-        (arg (argInfo visible relevant) dot ∷ []))
+        (arg (argInfo visible relevant) (dot unknown) ∷ []))
   ∷ [])
   (var 0 []) ∷ [])
 
 works₃ : (b : Bool) → Box b → (x y : Bool) → Bool
 unquoteDef works₃ = defineFun works₃ (clause
-  ( arg (argInfo visible relevant) (var "b")
+  ( ("y" , arg (argInfo visible relevant) unknown)
+  ∷ ("x" , arg (argInfo visible relevant) unknown)
+  ∷ ("b" , arg (argInfo visible relevant) unknown)
+  ∷ [])
+  ( arg (argInfo visible relevant) (var 2)
   ∷ arg (argInfo visible relevant) (con (quote box)
-        (arg (argInfo visible relevant) dot ∷ []))
-  ∷ arg (argInfo visible relevant) (var "x")
-  ∷ arg (argInfo visible relevant) (var "y")
+        (arg (argInfo visible relevant) (dot unknown) ∷ []))
+  ∷ arg (argInfo visible relevant) (var 1)
+  ∷ arg (argInfo visible relevant) (var 0)
   ∷ [])
   (var 2 []) ∷ [])

--- a/test/Succeed/Issue1345.agda
+++ b/test/Succeed/Issue1345.agda
@@ -3,6 +3,7 @@
 open import Common.Prelude
 open import Common.Reflection
 open import Common.Equality
+open import Agda.Builtin.Sigma
 
 module Issue1345 (A : Set) where
 
@@ -12,7 +13,7 @@ module Issue1345 (A : Set) where
 abstract
   unquoteDecl idNat = define (vArg idNat)
     (funDef (pi (vArg (def (quote Nat) [])) (abs "" (def (quote Nat) [])))
-            (clause (vArg (var "") ∷ []) (var 0 []) ∷ []))
+            (clause (("", vArg unknown) ∷ []) (vArg (var 0) ∷ []) (var 0 []) ∷ []))
   -- This raised the UselessAbstract error in error.
   -- Should work.
 

--- a/test/Succeed/Issue1827.agda
+++ b/test/Succeed/Issue1827.agda
@@ -19,10 +19,10 @@ freshFun t cs hole =
 
 macro
   ack : Tactic
-  ack = freshFun set! (clause [] set₀ ∷ [])
+  ack = freshFun set! (clause [] [] set₀ ∷ [])
 
   theA : Tactic
-  theA = freshFun set₀ (clause [] (var 0 []) ∷ [])
+  theA = freshFun set₀ (clause [] [] (var 0 []) ∷ [])
 
 module Foo (A : Set) where
   foo : Set

--- a/test/Succeed/Issue1890b.agda
+++ b/test/Succeed/Issue1890b.agda
@@ -3,6 +3,7 @@ module _ where
 open import Common.Prelude hiding (_>>=_)
 open import Common.Reflection
 open import Common.Equality
+open import Agda.Builtin.Sigma
 
 module _ (A : Set) where
   record R : Set where
@@ -28,15 +29,18 @@ module _ (A : Set) where
   helper-term : Term
   helper-term = var 0 []
 
+  helper-telescope : List (Σ String λ _ → Arg Type)
+  helper-telescope = ("x" , vArg unknown) ∷ []
+
   helper-patterns : List (Arg Pattern)
-  helper-patterns = vArg (var "x") ∷
+  helper-patterns = vArg (var 0) ∷
                     []
 
   defineHelper : Type → TC ⊤
   defineHelper t =
     freshName "n" >>= λ n →
     declareDef (vArg n) t >>= λ _ →
-    defineFun n (clause helper-patterns helper-term ∷ [])
+    defineFun n (clause helper-telescope helper-patterns helper-term ∷ [])
 
   noFail : TC ⊤ → TC Bool
   noFail m = catchTC (bindTC m λ _ → returnTC true) (returnTC false)

--- a/test/Succeed/Issue2129.agda
+++ b/test/Succeed/Issue2129.agda
@@ -5,6 +5,7 @@ open import Agda.Builtin.List
 open import Agda.Builtin.Nat
 open import Agda.Builtin.Unit
 open import Agda.Builtin.Equality
+open import Agda.Builtin.Sigma
 
 data Wrap (A : Set) : Set where
   [_] : A → Wrap A
@@ -33,7 +34,10 @@ id-ok = refl
 -- Underscores should behave the same for clauses as for lambda and pi
 
 idClause : Clause
-idClause = clause (hArg (var "_") ∷ vArg (var "_") ∷ []) (var 0 [])
+idClause = clause
+             (("_" , vArg unknown) ∷ ("_" , hArg unknown) ∷ [])
+             (hArg (var 1) ∷ vArg (var 0) ∷ [])
+             (var 0 [])
 
 infixr 4 _>>=_
 _>>=_ = bindTC

--- a/test/Succeed/Issue2151-ClauseTelescope.agda
+++ b/test/Succeed/Issue2151-ClauseTelescope.agda
@@ -1,0 +1,58 @@
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
+
+data Fin : Nat → Set where
+  zero : {n : Nat} → Fin (suc n)
+  suc  : {n : Nat} → Fin n → Fin (suc n)
+
+test : (x : Nat) (y : Fin x) {z : Nat} → x ≡ suc z → Set
+test .(suc z) y {z} refl = Nat
+
+-- Telescope: (z : Nat) (y : Fin (suc z))
+--  agda rep: ("z" , Nat) ("y" , Fin (suc @0))
+-- Patterns:  test .(suc @1) @0 @1 refl = ?
+
+macro
+  testDef : Term → TC _
+  testDef goal = do
+    d  ← getDefinition (quote test)
+    `d ← quoteTC d
+    unify `d goal
+
+foo : Definition
+foo = testDef
+
+fooTest : foo ≡ function
+                  (clause
+                   (("z" , arg (arg-info hidden relevant) (def (quote Nat) [])) ∷
+                    ("y" ,
+                     arg (arg-info visible relevant)
+                     (def (quote Fin)
+                      (arg (arg-info visible relevant)
+                       (con (quote Nat.suc)
+                        (arg (arg-info visible relevant) (var 0 []) ∷ []))
+                       ∷ [])))
+                    ∷ [])
+                   (arg (arg-info visible relevant)
+                    (dot
+                     (con (quote Nat.suc)
+                      (arg (arg-info visible relevant) (var 1 []) ∷ [])))
+                    ∷
+                    arg (arg-info visible relevant) (var 0) ∷
+                    arg (arg-info hidden relevant) (var 1) ∷
+                    arg (arg-info visible relevant) (con (quote refl) []) ∷ [])
+                   (def (quote Nat) [])
+                   ∷ [])
+fooTest = refl
+
+defBar : (name : Name) → TC _
+defBar x = do
+  function cls ← returnTC foo
+    where _ → typeError []
+  defineFun x cls
+
+bar : (x : Nat) (y : Fin x) {z : Nat} → x ≡ suc z → Set
+unquoteDef bar = defBar bar

--- a/test/Succeed/Issue2226.agda
+++ b/test/Succeed/Issue2226.agda
@@ -7,6 +7,7 @@ open import Agda.Builtin.Reflection
 open import Agda.Builtin.List
 open import Agda.Builtin.Unit
 open import Agda.Builtin.Equality
+open import Agda.Builtin.Sigma
 
 infixl 6 _>>=_
 _>>=_ = bindTC
@@ -46,12 +47,15 @@ pattern hArg x = rArg hidden  x
 pattern iArg x = rArg instance′ x
 pattern `? = hArg unknown
 
-pattern fun₀ b = function (clause [] b ∷ [])
-pattern fun₁ p b = function (clause (p ∷ []) b ∷ [])
-pattern fun₂ p q b = function (clause (p ∷ q ∷ []) b ∷ [])
+pattern fun₀ b = function (clause [] [] b ∷ [])
+pattern fun₁ tel p b = function (clause tel (p ∷ []) b ∷ [])
+pattern fun₂ tel p q b = function (clause tel (p ∷ q ∷ []) b ∷ [])
 
 -- foo {{r}} = Foo.foo {_} r
-foo-def : getDef foo ≡ fun₁ (iArg (var "r")) (def (quote Foo.foo) (`? ∷ vArg (var 0 []) ∷ []))
+foo-def : getDef foo ≡ fun₁
+            (("r" , iArg (def (quote Foo) (vArg (var 0 []) ∷ []))) ∷ [])
+            (iArg (var 0))
+            (def (quote Foo.foo) (`? ∷ vArg (var 0 []) ∷ []))
 foo-def = refl
 
 -- Andreas, 2018-03-12: Behavior before fix of #2963:
@@ -59,7 +63,10 @@ foo-def = refl
 -- foo₁-def : getDef foo₁ ≡ fun₁ (iArg (var "r")) (def (quote Foo.foo₁) (`? ∷ vArg (var 0 []) ∷ []))
 -- NOW:
 -- foo₁ {A} {{r}} = Foo.foo₁ {A} r
-foo₁-def : getDef foo₁ ≡ fun₂ (hArg (var "A")) (iArg (var "r")) (def (quote Foo.foo₁) (hArg (var 1 []) ∷ vArg (var 0 []) ∷ []))
+foo₁-def : getDef foo₁ ≡ fun₂
+             (("A" , hArg (agda-sort (lit 0))) ∷ ("r" , iArg (def (quote Foo) (vArg (var 0 []) ∷ []))) ∷ [])
+             (hArg (var 1)) (iArg (var 0))
+             (def (quote Foo.foo₁) (hArg (var 1 []) ∷ vArg (var 0 []) ∷ []))
 foo₁-def = refl
 
 -- bar = foo {_} FooA

--- a/test/Succeed/Issue2618.agda
+++ b/test/Succeed/Issue2618.agda
@@ -4,6 +4,7 @@ open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
 open import Agda.Builtin.Bool
 open import Agda.Builtin.Equality
 open import Agda.Builtin.Nat
+open import Agda.Builtin.Sigma
 
 data Unit : Set where
   unit : Unit
@@ -37,16 +38,18 @@ mkArgs = map λ i → vArg (var i [])
 
 unit,X=>_∙_ : Nat → List Nat → Term
 unit,X=> n ∙ args =
-  pat-lam [ clause (vArg (con (quote unit) []) ∷ vArg (var "X") ∷ [])
+  pat-lam [ clause [ "X" , vArg (agda-sort (lit 0)) ]
+                   (vArg (con (quote unit) []) ∷ vArg (var 0) ∷ [])
                    (var n []) ]
           (mkArgs args)
 
 abs,X=>∙_ : List Nat → Term
-abs,X=>∙ is = pat-lam [ absurd-clause (vArg absurd ∷ vArg (var "X") ∷ []) ]
+abs,X=>∙ is = pat-lam [ absurd-clause ( ("()" , vArg (def (quote Empty) [])) ∷  ("X" , vArg (agda-sort (lit 0))) ∷ [])
+                                      (vArg absurd ∷ vArg (var 0) ∷ []) ]
                       (mkArgs is)
 
 abs=>∙_ : List Nat → Term
-abs=>∙ is = pat-lam [ absurd-clause (vArg absurd ∷ []) ]
+abs=>∙ is = pat-lam [ absurd-clause [ "()" , vArg (def (quote Empty) []) ] (vArg absurd ∷ []) ]
                     (mkArgs is)
 
 _ : qU (λ { unit X → X }) ≡ unit,X=> 0 ∙ []

--- a/test/Succeed/Issue3075.agda
+++ b/test/Succeed/Issue3075.agda
@@ -26,7 +26,7 @@ f₂ n = id-inline n
 macro
   rhs : Name → Term → TC ⊤
   rhs f hole = do
-    function (clause _ rhs ∷ _) ← getDefinition f
+    function (clause _ _ rhs ∷ _) ← getDefinition f
       where _ → typeError (strErr "fail" ∷ [])
     `rhs ← quoteTC rhs
     unify hole `rhs

--- a/test/Succeed/Issue3075b.agda
+++ b/test/Succeed/Issue3075b.agda
@@ -25,7 +25,7 @@ f₂ n = id n
 macro
   rhs : Name → Term → TC ⊤
   rhs f hole = do
-    function (clause _ rhs ∷ _) ← getDefinition f
+    function (clause _ _ rhs ∷ _) ← getDefinition f
       where _ → typeError (strErr "fail" ∷ [])
     `rhs ← quoteTC rhs
     unify hole `rhs

--- a/test/Succeed/Issue4010.agda
+++ b/test/Succeed/Issue4010.agda
@@ -12,10 +12,10 @@ abstract
   f : D
   unquoteDef f = do
     qc ← quoteTC c  -- Previously, there was a complaint here about c.
-    defineFun f (clause [] qc ∷ [])
+    defineFun f (clause [] [] qc ∷ [])
 
   unquoteDecl g = do
     ty ← quoteTC D
     _  ← declareDef (arg (arg-info visible relevant) g) ty
     qc ← quoteTC c
-    defineFun g (clause [] qc ∷ [])
+    defineFun g (clause [] [] qc ∷ [])

--- a/test/Succeed/Issue4016.agda
+++ b/test/Succeed/Issue4016.agda
@@ -23,6 +23,6 @@ module M where
       ty ← quoteTC D
       _  ← declareDef (arg (arg-info visible relevant) g) ty
       qc ← quoteTC c
-      defineFun g (clause [] qc ∷ [])
+      defineFun g (clause [] [] qc ∷ [])
 
 -- Should print lots of debug stuff and succeed.

--- a/test/Succeed/QuoteExtLam.agda
+++ b/test/Succeed/QuoteExtLam.agda
@@ -2,6 +2,7 @@
 open import Common.Prelude
 open import Common.Reflection
 open import Common.Equality
+open import Agda.Builtin.Sigma
 
 magic₁ : ⊥ → Nat
 magic₁ = λ ()
@@ -36,13 +37,13 @@ pattern `Wrap a = def (quote Wrap) (vArg a ∷ [])
 pattern `⊥ = def (quote ⊥) []
 
 pattern expected₄ = funDef
-  (absurdClause (vArg (con (quote wrap) (vArg absurd ∷ [])) ∷ [])
-    ∷ [])
+  (absurdClause (("()" , vArg `⊥) ∷ []) (vArg (con (quote wrap) (vArg absurd ∷ [])) ∷ [])
+  ∷ [])
 
 check₄ : OK
 check₄ = checkDefinition (λ { expected₄ → true; _ → false }) magic₄
 
-expected = extLam (absurdClause (arg (argInfo visible relevant) absurd ∷ []) ∷ []) []
+expected = extLam (absurdClause (("()" , vArg `⊥) ∷ []) (arg (argInfo visible relevant) absurd ∷ []) ∷ []) []
 
 macro
 
@@ -59,7 +60,7 @@ check₂ : quoteTermNormalised magic₂ ≡ expected
 check₂ = refl
 
 pattern expectedDef =
-  funDef (absurdClause (vArg absurd ∷ []) ∷ [])
+  funDef (absurdClause (("()" , vArg `⊥) ∷ []) (vArg absurd ∷ []) ∷ [])
 
 check₃ : OK
 check₃ = checkDefinition (λ { expectedDef → true; _ → false }) magic₃

--- a/test/Succeed/ReflectTC.agda
+++ b/test/Succeed/ReflectTC.agda
@@ -4,6 +4,7 @@ module _ where
 open import Common.Reflection
 open import Common.Prelude hiding (_>>=_)
 open import Common.Equality
+open import Agda.Builtin.Sigma
 
 -- Some helpers --
 
@@ -40,7 +41,10 @@ newMeta! : TC Term
 newMeta! = newMeta unknown
 
 absurdLam : Term
-absurdLam = extLam (absurdClause (arg (argInfo visible relevant) absurd ∷ []) ∷ []) []
+absurdLam = extLam (absurdClause
+                      (("()" , arg (argInfo visible relevant) unknown) ∷ [])
+                      (arg (argInfo visible relevant) absurd ∷ [])
+                   ∷ []) []
 
 -- Simple assumption tactic --
 

--- a/test/Succeed/ReflectionCopatterns.agda
+++ b/test/Succeed/ReflectionCopatterns.agda
@@ -2,6 +2,7 @@
 open import Common.Prelude hiding (_>>=_)
 open import Common.Reflection
 open import Common.Equality
+open import Agda.Builtin.Sigma
 
 record Functor (F : Set → Set) : Set₁ where
   field
@@ -9,7 +10,8 @@ record Functor (F : Set → Set) : Set₁ where
 
 IdF : Functor (λ A → A)
 unquoteDef IdF =
-  defineFun IdF (clause (vArg (projP (quote Functor.fmap)) ∷ vArg (var "f") ∷ vArg (var "x") ∷ [])
+  defineFun IdF (clause (("x" , vArg unknown) ∷ ("f" , vArg unknown) ∷ [])
+                        (vArg (projP (quote Functor.fmap)) ∷ vArg (var 1) ∷ vArg (var 0) ∷ [])
                         (var 1 (vArg (var 0 []) ∷ [])) ∷ [])
 
 check : ∀ {A B} (f : A → B) (x : A) → Functor.fmap IdF f x ≡ f x
@@ -20,7 +22,8 @@ open Functor {{...}}
 instance
   InstF : Functor (λ A → A)
   unquoteDef InstF =
-    defineFun InstF (clause (iArg (projP (quote fmap)) ∷ vArg (var "f") ∷ vArg (var "x") ∷ [])
+    defineFun InstF (clause (("x" , vArg unknown) ∷ ("f" , vArg unknown) ∷ [])
+                            (iArg (projP (quote fmap)) ∷ vArg (var 1) ∷ vArg (var 0) ∷ [])
                             (var 1 (vArg (var 0 []) ∷ [])) ∷ [])
 
 check₁ : ∀ {A B} (f : A → B) (x : A) → fmap f x ≡ f x

--- a/test/Succeed/UnquoteDecl.agda
+++ b/test/Succeed/UnquoteDecl.agda
@@ -4,13 +4,14 @@ module UnquoteDecl where
 open import Common.Prelude
 open import Common.Reflection
 open import Common.Equality
+open import Agda.Builtin.Sigma
 
 infixr 3 _`⇒_
 pattern _`⇒_ a b = pi (vArg a) (abs "_" b)
 pattern `Nat = def (quote Nat) []
 
 unquoteDecl x =
-  define (vArg x) (funDef `Nat (clause [] (quoteTerm 15) ∷ []))
+  define (vArg x) (funDef `Nat (clause [] [] (quoteTerm 15) ∷ []))
 
 y = x + 4
 
@@ -23,8 +24,9 @@ pattern `suc n = con (quote suc) (vArg n ∷ [])
 unquoteDecl plus =
   define (vArg plus) (
   funDef (`Nat `⇒ `Nat `⇒ `Nat)
-         ( clause (vArg (con (quote zero) []) ∷ vArg (var "y") ∷ []) (var 0 [])
-         ∷ clause (vArg (con (quote suc) (vArg (var "x") ∷ [])) ∷ vArg (var "y") ∷ [])
+         ( clause (("y" , vArg unknown) ∷ []) (vArg (con (quote zero) []) ∷ vArg (var 0) ∷ []) (var 0 [])
+         ∷ clause (("y" , vArg unknown) ∷ ("x" , vArg unknown) ∷ [])
+                  (vArg (con (quote suc) (vArg (var 1) ∷ [])) ∷ vArg (var 0) ∷ [])
                   (`suc (def plus (vArg (var 1 []) ∷ vArg (var 0 []) ∷ [])))
          ∷ []))
 
@@ -34,6 +36,6 @@ prf = refl
 magicDef : FunDef
 magicDef =
   funDef (def (quote ⊥) [] `⇒ `Nat)
-         (absurdClause (vArg absurd ∷ []) ∷ [])
+         (absurdClause (("()" , vArg unknown) ∷ []) (vArg absurd ∷ []) ∷ [])
 
 unquoteDecl magic = define (vArg magic) magicDef

--- a/test/Succeed/UnquoteDef.agda
+++ b/test/Succeed/UnquoteDef.agda
@@ -3,6 +3,7 @@ module UnquoteDef where
 
 open import Common.Reflection
 open import Common.Prelude
+open import Agda.Builtin.Sigma
 
 module Target where
   mutual
@@ -28,14 +29,14 @@ pattern `Bool = def (quote Bool) []
 -- Simple non-mutual case
 `id : QName → FunDef
 `id f = funDef `idType
-        ( clause (vArg `zero            ∷ []) `zero
-        ∷ clause (vArg (`suc (var "n")) ∷ []) (`suc (def f (vArg (var 0 []) ∷ [])))
+        ( clause []                       (vArg `zero          ∷ []) `zero
+        ∷ clause (("n" , vArg `Nat) ∷ []) (vArg (`suc (var 0)) ∷ []) (`suc (def f (vArg (var 0 []) ∷ [])))
         ∷ [])
 
 `idDef : QName → List Clause
 `idDef f =
-   clause (vArg `zero            ∷ []) `zero
- ∷ clause (vArg (`suc (var "n")) ∷ []) (`suc (def f (vArg (var 0 []) ∷ [])))
+   clause []                       (vArg `zero          ∷ []) `zero
+ ∷ clause (("n" , vArg `Nat) ∷ []) (vArg (`suc (var 0)) ∷ []) (`suc (def f (vArg (var 0 []) ∷ [])))
  ∷ []
 
 -- Andreas, 2016-07-17
@@ -50,8 +51,8 @@ abstract
 -- Now for the mutal ones
 `evenOdd : Term → QName → List Clause
 `evenOdd base step =
-    clause (vArg `zero            ∷ []) base
-  ∷ clause (vArg (`suc (var "n")) ∷ []) (def step (vArg (var 0 []) ∷ []))
+    clause []                       (vArg `zero          ∷ []) base
+  ∷ clause (("n" , vArg `Nat) ∷ []) (vArg (`suc (var 0)) ∷ []) (def step (vArg (var 0 []) ∷ []))
   ∷ []
 
 _>>_ : TC ⊤ → TC ⊤ → TC ⊤

--- a/test/Succeed/UnquoteExtLam.agda
+++ b/test/Succeed/UnquoteExtLam.agda
@@ -2,6 +2,7 @@
 open import Common.Reflection
 open import Common.Prelude
 open import Common.Equality
+open import Agda.Builtin.Sigma
 
 pattern `Nat = def (quote Nat) []
 pattern _`→_ a b = pi (vArg a) (abs "_" b)
@@ -14,16 +15,16 @@ pattern `suc n = con (quote suc) (vArg n ∷ [])
 prDef : FunDef
 prDef =
   funDef (`Nat `→ `Nat)
-       ( clause [] (extLam ( clause (vArg `zero ∷ []) `zero
-                           ∷ clause (vArg (`suc (var "x")) ∷ []) (var 0 [])
-                           ∷ []) [])
+       ( clause [] [] (extLam ( clause [] (vArg `zero ∷ []) `zero
+                              ∷ clause (("x" , vArg `Nat) ∷ []) (vArg (`suc (var 0)) ∷ []) (var 0 [])
+                              ∷ []) [])
        ∷ [] )
 
 magicDef : FunDef
 magicDef =
   funDef (pi (hArg `Set) (abs "A" (`⊥ `→ var 1 [])))
-       ( clause [] (extLam ( absurdClause (vArg absurd ∷ [])
-                           ∷ []) [])
+       ( clause [] [] (extLam ( absurdClause (("()" , vArg `⊥) ∷ []) (vArg absurd ∷ [])
+                              ∷ []) [])
        ∷ [] )
 
 unquoteDecl magic = define (vArg magic) magicDef
@@ -34,7 +35,7 @@ checkMagic = magic
 unquoteDecl pr = define (vArg pr) prDef
 
 magic′ : {A : Set} → ⊥ → A
-magic′ = unquote (give (extLam (absurdClause (vArg absurd ∷ []) ∷ []) []))
+magic′ = unquote (give (extLam (absurdClause (("()" , vArg `⊥) ∷ []) (vArg absurd ∷ []) ∷ []) []))
 
 module Pred (A : Set) where
   unquoteDecl pr′ = define (vArg pr′) prDef

--- a/test/Succeed/UnquoteInstance.agda
+++ b/test/Succeed/UnquoteInstance.agda
@@ -35,12 +35,12 @@ private
 
 unquoteDecl EqNat = define (iArg EqNat)
   (funDef (def (quote Eq) (vArg (def (quote Nat) []) ∷ []))
-          (clause [] (con (quote eqDict) (vArg (def (quote eqNat) []) ∷ [])) ∷ []))
+          (clause [] [] (con (quote eqDict) (vArg (def (quote eqNat) []) ∷ [])) ∷ []))
 
 instance
   EqBool : Eq Bool
   unquoteDef EqBool =
-    defineFun EqBool (clause [] (con (quote eqDict) (vArg (def (quote eqBool) []) ∷ [])) ∷ [])
+    defineFun EqBool (clause [] [] (con (quote eqDict) (vArg (def (quote eqBool) []) ∷ [])) ∷ [])
 
 id : {A : Set} → A → A
 id x = x

--- a/test/interaction/Issue3831.out
+++ b/test/interaction/Issue3831.out
@@ -18,6 +18,6 @@
 (agda2-info-action "*Error*" "1,10-17 1 when checking that the expression unquote (test3 n) has type _134" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")
-(agda2-info-action "*Error*" "We reached a program point we did not want to reach. Location of the error: src/full/Agda/TypeChecking/Unquote.hs:665 " nil)
+(agda2-info-action "*Error*" "We reached a program point we did not want to reach. Location of the error: src/full/Agda/TypeChecking/Unquote.hs:676 " nil)
 (agda2-highlight-add-annotations 'nil)
 (agda2-status-action "")


### PR DESCRIPTION
This PR changes the internal syntax of Agda so clauses include the telescope of the pattern variables. It implements half of the required changes: the types in this telescope are given to you by Agda when quoting a definition, but they are not yet checked when unquoting a definition.

This also changes the syntax for pattern variables to refer to a de-Bruijn index instead of a name, and changes the representation of dot patterns to include the dotted term.

Note that this is a backwards-incompatible change and it will likely break most currently existing reflection code. However, I think the change is worth it nevertheless. If the Agda community agrees to this PR, then I can write a conversion guide for in the changelog.