### PR TITLE
Spend some effort printing typeError and debugPrint messages in TC

### DIFF
--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -251,6 +251,25 @@ instance PrettyTCM ErrorPart where
   prettyTCM (TermPart t) = prettyTCM t
   prettyTCM (NamePart x) = prettyTCM x
 
+-- | We do a little bit of work here to make it possible to generate nice
+--   layout for multi-line error messages. Specifically we split the parts
+--   into lines (indicated by \n in a string part) and vcat all the lines.
+prettyErrorParts :: [ErrorPart] -> TCM Doc
+prettyErrorParts = vcat . map (hcat . map prettyTCM) . splitLines
+  where
+    splitLines [] = []
+    splitLines (StrPart s : ss) =
+      case break (=='\n') s of
+        (s0, '\n' : s1) -> [StrPart s0] : splitLines (StrPart s1 : ss)
+        (s0, "")        -> consLine (StrPart s0) (splitLines ss)
+        _               -> __IMPOSSIBLE__
+    splitLines (p@TermPart{} : ss) = consLine p (splitLines ss)
+    splitLines (p@NamePart{} : ss) = consLine p (splitLines ss)
+
+    consLine l []        = [[l]]
+    consLine l (l' : ls) = (l : l') : ls
+
+
 instance Unquote ErrorPart where
   unquote t = do
     t <- reduceQuotedTerm t
@@ -589,11 +608,11 @@ evalTCM v = do
       liftTCM primUnitUnit
 
     tcTypeError :: [ErrorPart] -> TCM a
-    tcTypeError err = typeError . GenericDocError =<< fsep (map prettyTCM err)
+    tcTypeError err = typeError . GenericDocError =<< prettyErrorParts err
 
     tcDebugPrint :: Text -> Integer -> [ErrorPart] -> TCM Term
     tcDebugPrint s n msg = do
-      reportSDoc (T.unpack s) (fromIntegral n) $ fsep (map prettyTCM msg)
+      reportSDoc (T.unpack s) (fromIntegral n) $ prettyErrorParts msg
       primUnitUnit
 
     tcNoConstraints :: Term -> UnquoteM Term

--- a/test/Fail/TacticFail.agda
+++ b/test/Fail/TacticFail.agda
@@ -8,8 +8,8 @@ open import Common.Reflection
 failTactic : Term → TC ⊤
 failTactic hole =
   inferType hole >>= λ goal →
-  typeError (strErr "Surprisingly the" ∷ nameErr (quote failTactic) ∷
-             strErr "failed to prove" ∷ termErr goal ∷ [])
+  typeError (strErr "Surprisingly the " ∷ nameErr (quote failTactic) ∷
+             strErr " failed to prove " ∷ termErr goal ∷ [])
 
 macro
   proveIt = failTactic

--- a/test/interaction/Issue3831.out
+++ b/test/interaction/Issue3831.out
@@ -18,6 +18,6 @@
 (agda2-info-action "*Error*" "1,10-17 1 when checking that the expression unquote (test3 n) has type _134" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")
-(agda2-info-action "*Error*" "We reached a program point we did not want to reach. Location of the error: src/full/Agda/TypeChecking/Unquote.hs:646 " nil)
+(agda2-info-action "*Error*" "We reached a program point we did not want to reach. Location of the error: src/full/Agda/TypeChecking/Unquote.hs:665 " nil)
 (agda2-highlight-add-annotations 'nil)
 (agda2-status-action "")


### PR DESCRIPTION
Previously all parts were `fsep`d together. Now we split the error up into lines and `hcat` the parts of a line and `vcat` the result. A side effect of this is that there is no longer a space inserted before and after terms and names, so some error messages might need to insert extra spaces
to not look weird. On the other hand you can now construct error messages that you couldn't before.