### PR TITLE
[ interaction ] Constraints overlapping metas not highlighted

### DIFF
--- a/src/full/Agda/Interaction/Highlighting/Range.hs
+++ b/src/full/Agda/Interaction/Highlighting/Range.hs
@@ -20,6 +20,8 @@ import Prelude hiding (null)
 
 import qualified Agda.Syntax.Position as P
 
+import Agda.Utils.List
+import Agda.Utils.Maybe
 import Agda.Utils.Null
 
 -- | Character ranges. The first character in the file has position 1.
@@ -60,11 +62,16 @@ rangesInvariant (Ranges rs) =
 -- The ranges are assumed to be well-formed.
 
 overlapping :: Range -> Range -> Bool
-overlapping r1 r2 = not $
-  to r1 <= from r2 || to r2 <= from r1
+overlapping r1 r2 = (not $ r1 `isLeftOf` r2) && (not $ r2 `isLeftOf` r1)
+
+isLeftOf :: Range -> Range -> Bool
+isLeftOf r1 r2 = to r1 <= from r2
 
 overlappings :: Ranges -> Ranges -> Bool
-overlappings (Ranges r1s) (Ranges r2s) = or [ overlapping r1 r2 | r1 <- r1s, r2 <- r2s ]
+-- specification: overlappings (Ranges r1s) (Ranges r2s) = or [ overlapping r1 r2 | r1 <- r1s, r2 <- r2s ]
+overlappings (Ranges r1s) (Ranges r2s) =
+  isNothing $ mergeStrictlyOrderedBy isLeftOf r1s r2s
+
 
 ------------------------------------------------------------------------
 -- Conversion

--- a/src/full/Agda/Interaction/Highlighting/Range.hs
+++ b/src/full/Agda/Interaction/Highlighting/Range.hs
@@ -7,6 +7,7 @@ module Agda.Interaction.Highlighting.Range
   , Ranges(..)
   , rangesInvariant
   , overlapping
+  , overlappings
   , empty
   , rangeToPositions
   , rangesToPositions
@@ -61,6 +62,9 @@ rangesInvariant (Ranges rs) =
 overlapping :: Range -> Range -> Bool
 overlapping r1 r2 = not $
   to r1 <= from r2 || to r2 <= from r1
+
+overlappings :: Ranges -> Ranges -> Bool
+overlappings (Ranges r1s) (Ranges r2s) = or [ overlapping r1 r2 | r1 <- r1s, r2 <- r2s ]
 
 ------------------------------------------------------------------------
 -- Conversion

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -247,8 +247,7 @@ handleCommand wrap onFail cmd = handleNastyErrors $ wrap $ do
     -- the status information is also updated.
     handleErr method e = do
         unsolvedNotOK <- lift $ not . optAllowUnsolved <$> pragmaOptions
-        meta    <- lift $ computeUnsolvedMetaWarnings
-        constr  <- lift $ computeUnsolvedConstraints
+        unsolved <- lift $ computeUnsolvedInfo
         err     <- lift $ errorHighlighting e
         modFile <- lift $ useTC stModuleToSource
         method  <- case method of
@@ -256,7 +255,7 @@ handleCommand wrap onFail cmd = handleNastyErrors $ wrap $ do
           Just m  -> return m
         let info = compress $ mconcat $
                      -- Errors take precedence over unsolved things.
-                     err : if unsolvedNotOK then [meta, constr] else []
+                     err : if unsolvedNotOK then [unsolved] else []
 
         -- TODO: make a better predicate for this
         noError <- lift $ null <$> prettyError e

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -642,3 +642,13 @@ editDistance xs ys = editD 0 0
   xsA, ysA :: Array Int a
   xsA = listArray (0,n-1) xs
   ysA = listArray (0,m-1) ys
+
+
+mergeStrictlyOrderedBy :: (a -> a -> Bool) -> [a] -> [a] -> Maybe [a]
+mergeStrictlyOrderedBy (<) = loop where
+  loop [] ys = Just ys
+  loop xs [] = Just xs
+  loop (x:xs) (y:ys)
+    | x < y = (x:) <$> loop xs (y:ys)
+    | y < x = (y:) <$> loop (x:xs) ys
+    | otherwise = Nothing

--- a/test/Internal/Interaction/Highlighting/Range.hs
+++ b/test/Internal/Interaction/Highlighting/Range.hs
@@ -40,6 +40,11 @@ prop_rangesInvariant2 = rangesInvariant . rToR
 prop_rangesInvariant3 :: Ranges -> Ranges -> Bool
 prop_rangesInvariant3 r1 r2 = rangesInvariant $ r1 `minus` r2
 
+prop_overlappings :: Ranges -> Ranges -> Bool
+prop_overlappings rs1 rs2 = overlappings rs1 rs2 == overlappings_spec rs1 rs2
+  where
+    overlappings_spec (Ranges r1s) (Ranges r2s) = or [ overlapping r1 r2 | r1 <- r1s, r2 <- r2s ]
+
 ------------------------------------------------------------------------
 -- Conversion
 


### PR DESCRIPTION
If an unsolved constraint range overlaps an unsolved or interaction
meta range it does not generate highlighting in the interaction mode.

