### PR TITLE
Tweaking the test suite runner (issue #4736)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,7 @@ jobs:
         - echo "*** Agda version ***" && stack ${ARGS} exec -- agda --version
       script:
         - stack ${ARGS} exec -- ${MAKE_CMD} bugs
+        - stack ${ARGS} exec -- ${MAKE_CMD} common
         - stack ${ARGS} exec -- ${MAKE_CMD} succeed
         - stack ${ARGS} exec -- ${MAKE_CMD} fail
       before_cache:
@@ -195,6 +196,7 @@ jobs:
         - .travis/cabal_install
       ##############################################################################
       script:
+        - make BUILD_DIR=$BUILD_DIR common
         - make AGDA_TESTS_OPTIONS="-j${PARALLEL_TESTS} --hide-successes" TASTY_ANSI_TRICKS=false BUILD_DIR=$BUILD_DIR succeed
         - make AGDA_TESTS_OPTIONS="-j${PARALLEL_TESTS} --hide-successes" TASTY_ANSI_TRICKS=false BUILD_DIR=$BUILD_DIR fail
         - make BUILD_DIR=$BUILD_DIR interaction

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,7 @@ fast-forward-cubical :
 
 .PHONY : test ## Run all test suites.
 test : check-whitespace \
+       common \
        succeed \
        fail \
        bugs \
@@ -309,7 +310,7 @@ test-using-std-lib : std-lib-test \
                      std-lib-interaction
 
 .PHONY : quicktest ## Run successful and failing tests.
-quicktest : succeed fail
+quicktest : common succeed fail
 
 .PHONY : bugs ##
 bugs :
@@ -321,10 +322,14 @@ internal-tests :
 	@$(call decorate, "Internal test suite", \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Internal )
 
+.PHONY : common ##
+common :
+	@$(call decorate, "Suite of successful tests: mini-library Common", \
+		$(MAKE) -C test/Common )
+
 .PHONY : succeed ##
 succeed :
 	@$(call decorate, "Suite of successful tests", \
-		$(MAKE) -C test/Common; \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Succeed )
 
 .PHONY : fail ##
@@ -496,7 +501,7 @@ hpc-build: ensure-hash-is-correct
 	$(CABAL_CMD) $(CABAL_CONFIGURE_CMD) --enable-library-coverage $(CABAL_INSTALL_OPTS)
 	$(CABAL_CMD) $(CABAL_BUILD_CMD) $(CABAL_OPTS)
 
-agda.tix: ./examples/agda.tix ./test/Succeed/agda.tix ./test/compiler/agda.tix ./test/api/agda.tix ./test/interaction/agda.tix ./test/fail/agda.tix ./test/lib-succeed/agda.tix ./std-lib/agda.tix ##
+agda.tix: ./examples/agda.tix ./test/common/agda.tix ./test/Succeed/agda.tix ./test/compiler/agda.tix ./test/api/agda.tix ./test/interaction/agda.tix ./test/fail/agda.tix ./test/lib-succeed/agda.tix ./std-lib/agda.tix ##
 	hpc sum --output=$@ $^
 
 .PHONY: hpc ## Generate a code coverage report via cabal.

--- a/test/Fail/Tests.hs
+++ b/test/Fail/Tests.hs
@@ -26,9 +26,10 @@ testDir = "test" </> "Fail"
 tests :: IO TestTree
 tests = do
   inpFiles <- getAgdaFilesInDir NonRec testDir
-  return $ testGroup "Fail" $
-    [ testGroup "customised" [ issue2649, nestedProjectRoots ]]
-    ++ map mkFailTest inpFiles
+  return $ testGroup "Fail" $ concat
+    [ map mkFailTest inpFiles
+    , [ testGroup "customised" [ issue2649, nestedProjectRoots ]]
+    ]
 
 data TestResult
   = TestResult T.Text -- the cleaned stdout

--- a/test/Succeed/Tests.hs
+++ b/test/Succeed/Tests.hs
@@ -43,52 +43,10 @@ data TestResult
 mkSucceedTest
   :: AgdaArgs -- ^ Extra options to Agda.
   -> FilePath -- ^ Test directory.
-  -> FilePath -- ^ Input file.
+  -> FilePath -- ^ Input file (an Agda file).
   -> TestTree
-mkSucceedTest extraOpts dir inp =
+mkSucceedTest extraOpts dir agdaFile =
   goldenTestIO1 testName readGolden (printTestResult <$> doRun) resDiff resShow updGolden
---  goldenVsAction testName goldenFile doRun printAgdaResult
-  where testName = asTestName dir inp
-        flagFile = dropAgdaExtension inp <.> ".flags"
-        warnFile = dropAgdaExtension inp <.> ".warn"
-
-        -- Unless we have a .warn file, we don't really have a golden
-        -- file. Just use a dummy update function.
-        -- TODO extend tasty-silver to handle this use case properly
-        readGolden = do
-          warnExists <- doesFileExist warnFile
-          if warnExists then readTextFileMaybe warnFile
-                        else return $ Just $ printTestResult TestSuccess
-
-        updGolden = Just $ writeTextFile warnFile
-
-        doRun = do
-          let agdaArgs = [ "-v0", "-i" ++ dir, "-itest/" , inp
-                         , "--no-libraries"
-                         , "-vimpossible:10" -- BEWARE: no spaces allowed here
-                         , "-vwarning:1"
-                         ] ++ [ "--double-check" | not (testName `elem` noDoubleCheckTests) ]
-                           ++ extraOpts
-
-          (res, ret) <- runAgdaWithOptions testName agdaArgs (Just flagFile)
-          case ret of
-            AgdaSuccess{} | testName == "Issue481" -> do
-              dotOrig <- TIO.readFile (dir </> "Issue481.dot.orig")
-              dot <- TIO.readFile "Issue481.dot"
-              removeFile "Issue481.dot"
-              if dot == dotOrig
-                then
-                  return $ TestSuccess
-                else
-                  return $ TestWrongDotOutput dot
-            AgdaSuccess warn -> do
-              warnExists <- doesFileExist warnFile
-              return $
-                if warnExists || isJust warn
-                then TestSuccessWithWarnings $ stdOut res -- TODO: distinguish log vs. warn?
-                else TestSuccess
-            AgdaFailure{} -> return $ TestUnexpectedFail res
-
 resDiff :: T.Text -> T.Text -> IO GDiff
 resDiff t1 t2 =
   if T.words t1 == T.words t2
@@ -96,12 +54,54 @@ resDiff t1 t2 =
       return Equal
     else
       return $ DiffText Nothing t1 t2
+  where
+  testName = asTestName dir agdaFile
+  flagFile = dropAgdaExtension agdaFile <.> ".flags"
+  warnFile = dropAgdaExtension agdaFile <.> ".warn"
+
+  -- Unless we have a .warn file, we don't really have a golden
+  -- file. Just use a dummy update function.
+  -- TODO extend tasty-silver to handle this use case properly
+  readGolden = do
+    warnExists <- doesFileExist warnFile
+    if warnExists then readTextFileMaybe warnFile
+                  else return $ Just $ printTestResult TestSuccess
+
+  updGolden = Just $ writeTextFile warnFile
+
+  doRun = do
+    let agdaArgs = [ "-v0", "-i" ++ dir, "-itest/" , agdaFile
+                   , "--no-libraries"
+                   , "-vimpossible:10" -- BEWARE: no spaces allowed here
+                   , "-vwarning:1"
+                   ] ++ [ "--double-check" | not (testName `elem` noDoubleCheckTests) ]
+                     ++ extraOpts
+
+    (res, ret) <- runAgdaWithOptions testName agdaArgs (Just flagFile)
+    case ret of
+      AgdaSuccess{} | testName == "Issue481" -> do
+        dotOrig <- TIO.readFile (dir </> "Issue481.dot.orig")
+        dot <- TIO.readFile "Issue481.dot"
+        removeFile "Issue481.dot"
+        if dot == dotOrig
+          then
+            return $ TestSuccess
+          else
+            return $ TestWrongDotOutput dot
+      AgdaSuccess warn -> do
+        warnExists <- doesFileExist warnFile
+        return $
+          if warnExists || isJust warn
+          then TestSuccessWithWarnings $ stdOut res -- TODO: distinguish log vs. warn?
+          else TestSuccess
+      AgdaFailure{} -> return $ TestUnexpectedFail res
+
 
 resShow :: T.Text -> IO GShow
 resShow = return . ShowText
 
 printTestResult :: TestResult -> T.Text
-printTestResult r = case r of
+printTestResult = \case
   TestSuccess               -> "AGDA_SUCCESS\n\n"
   TestSuccessWithWarnings t -> t
   TestUnexpectedFail p      -> "AGDA_UNEXPECTED_FAIL\n\n" <> printProgramResult p

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -27,6 +27,7 @@ import System.FilePath.GlobPattern
 import System.IO.Temp
 import System.PosixCompat.Time (epochTime)
 import System.PosixCompat.Files (modificationTime)
+import System.Process (proc, CreateProcess(..) )
 import qualified System.Process.Text as PT
 
 import Test.Tasty.Silver
@@ -61,7 +62,8 @@ readAgdaProcessWithExitCode :: AgdaArgs -> Text
 readAgdaProcessWithExitCode args inp = do
   agdaBin <- getAgdaBin
   envArgs <- getEnvAgdaArgs
-  PT.readProcessWithExitCode agdaBin (envArgs ++ args) inp
+  let agdaProc = (proc agdaBin (envArgs ++ args)) { create_group = True }
+  PT.readCreateProcessWithExitCode agdaProc inp
 
 data AgdaResult
   = AgdaSuccess (Maybe Text)          -- ^ A success can come with warnings

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -127,6 +127,10 @@ $(OutFiles) : %.out : $$($$@.*agda) $$($$@.in $$@.hs $$@.sh)
 # Comparing output
 ########################################################################
 
+# Andreas, 2020-06-09, issue #4736
+# If the output has changed, the test case is "interesting",
+# thus, we sort it up for the next run by touching the .agda file.
+
 $(Tests) : %.cmp : %.out
 	@-mkdir $(TMPDIR)
 	@$(setup_$*)
@@ -136,13 +140,14 @@ $(Tests) : %.cmp : %.out
 	@if diff -b $*.out $*.tmp; \
 		then rm -f $*.tmp; true; \
 		else \
+			for file in ls `$*.*agda`; do touch $file; done ; \
 			echo "=== Old output ==="; \
 			cat $*.out; \
 			echo "=== New output ==="; \
 			cat $*.tmp; \
 			echo "=== Diff ==="; \
 			wdiff $*.out $*.tmp | colordiff; \
-			echo -n "Accept new error [y(es)/n(o)/Q(uit)] (default: no)? "; \
+			echo -n "Accept new error [y/n/Q] (default: no)? "; \
 			read -n 1; \
 			echo ""; \
 			if [ "fckShPrg$$REPLY" != "fckShPrgy"  ]; \


### PR DESCRIPTION
A couple of tweaks to make the testsuite running smarter. (See #4736.)

For the moment, agda files are also touched when the test suite is interrupted.  This is undesirable.  Currently discussed at: https://github.com/phile314/tasty-silver/issues/2