### PR TITLE
Float setCommandLineOptions out of interaction block in interactive mode

### DIFF
--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -112,9 +112,11 @@ runAgdaWithOptions backends generateHTML interaction progName opts
             printStatistics 1 Nothing =<< useTC lensAccumStatistics
   where
     checkFile = Just <$> do
-      when (optInteractive opts) $ liftIO $ putStr splashScreen
-      interaction $ do
+      when (optInteractive opts) $ do
         setCommandLineOptions opts
+        liftIO $ putStr splashScreen
+      interaction $ do
+        unless (optInteractive opts) $ setCommandLineOptions opts
         hasFile <- hasInputFile
         -- Andreas, 2013-10-30 The following 'resetState' kills the
         -- verbosity options.  That does not make sense (see fail/Issue641).

--- a/test/Interactive/Load.agda
+++ b/test/Interactive/Load.agda
@@ -1,0 +1,5 @@
+module Load where
+
+data Bool : Set where
+  tt : Bool
+  ff : Bool

--- a/test/Interactive/Load.in
+++ b/test/Interactive/Load.in
@@ -1,0 +1,2 @@
+:load test/Interactive/Load.agda
+:quit

--- a/test/Interactive/Load.stdout.expected
+++ b/test/Interactive/Load.stdout.expected
@@ -1,0 +1,2 @@
+Checking Load
+test/Interactive/Load.agda

--- a/test/Interactive/Tests.hs
+++ b/test/Interactive/Tests.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DoAndIfThenElse, ScopedTypeVariables   #-}
-
 module Interactive.Tests where
 
 import Data.Foldable

--- a/test/Interactive/Tests.hs
+++ b/test/Interactive/Tests.hs
@@ -1,14 +1,19 @@
-{-# LANGUAGE DoAndIfThenElse   #-}
+{-# LANGUAGE DoAndIfThenElse, ScopedTypeVariables   #-}
 
 module Interactive.Tests where
 
+import Data.Foldable
+import Data.Text (Text)
+import qualified Data.Text as Text
 import qualified Data.Text.IO as TIO
 
 import Test.Tasty
 import Test.Tasty.HUnit
+import System.Directory
 import System.FilePath
 import System.Exit
 
+import Agda.Utils.Monad
 import Utils
 
 testDir :: FilePath
@@ -17,14 +22,28 @@ testDir = "test" </> "Interactive"
 tests :: TestTree
 tests = testGroup "Interactive"
   [ testCase "Naked" $ do
-    runAgda [] "Naked"
+    runAgda [testDir </> "Naked.agda"] "Naked"
   , testCase "Issue1430" $ do
-    runAgda ["--no-libraries"] "Issue1430"
+    runAgda ["--no-libraries", testDir </> "Issue1430.agda"] "Issue1430"
+  , testCase "Load" $ do
+    runAgda ["--no-libraries"] "Load"
   ]
   where
-    agdaArgs = [ "-I", "-i.", "-i..", "--ignore-interfaces" ]
+    agdaArgs = [ "-I", "-i.", "-i..", "-itest/Interactive", "--ignore-interfaces" ]
     runAgda :: [String] -> FilePath -> IO ()
     runAgda extraArgs testName = do
       inp <- TIO.readFile (testDir </> testName <.> "in")
-      ret@(c, _, _) <- readAgdaProcessWithExitCode (agdaArgs ++ extraArgs ++ [testDir </> testName <.> "agda"]) inp
+      ret@(c, stdout, stderr) <- readAgdaProcessWithExitCode (agdaArgs ++ extraArgs) inp
       assertBool ("Agda returned error code: " ++ show ret) (c == ExitSuccess)
+      let stdoutFp = testDir </> testName <.> "stdout" <.> "expected"
+          stderrFp = testDir </> testName <.> "stderr" <.> "expected"
+
+      -- Check that every line in testName.stdout.expected (if exists) is a substring of stdout. Same for stderr.
+      whenM (doesFileExist $ testDir </> testName <.> "stdout" <.> "expected") $ do
+        expected <- TIO.readFile stdoutFp
+        for_ (Text.lines expected) $
+          assertBool ("Invalid stdout: " ++ show stdout) . (`Text.isInfixOf` stdout)
+      whenM (doesFileExist $ testDir </> testName <.> "stderr" <.> "expected") $ do
+        expected <- TIO.readFile stderrFp
+        for_ (Text.lines expected) $
+          assertBool ("Invalid stderr: " ++ show stderr) . (`Text.isInfixOf` stderr)


### PR DESCRIPTION
The `interaction` block is executed for every `:load`. If `setCommandLineOptions` is called inside it, the options including the files to be loaded are reset. This doesn't seem to make any sense because it means `:load` never works.

Floating it out makes `:load` work properly, which can be verified by running
```
agda -I
:l Foo.agda
```

`setCommandLineOptions` still needs to be called inside `interaction` for modes other than interactive.