### PR TITLE
[ fix #4735 ] store original concrete name in abstract names

### DIFF
--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -267,6 +267,7 @@ freshAbstractName fx x = do
   return $ A.Name
     { nameId          = i
     , nameConcrete    = x
+    , nameCanonical   = x
     , nameBindingSite = getRange x
     , nameFixity      = fx
     , nameIsRecordName = False

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -772,7 +772,7 @@ freshName r s = do
 freshNoName :: MonadFresh NameId m => Range -> m Name
 freshNoName r =
     do  i <- fresh
-        return $ Name i (C.NoName noRange i) r noFixity' False
+        return $ makeName i (C.NoName noRange i) r noFixity' False
 
 freshNoName_ :: MonadFresh NameId m => m Name
 freshNoName_ = freshNoName noRange
@@ -780,7 +780,7 @@ freshNoName_ = freshNoName noRange
 freshRecordName :: MonadFresh NameId m => m Name
 freshRecordName = do
   i <- fresh
-  return $ Name i (C.setNotInScope $ C.simpleName "r") noRange noFixity' True
+  return $ makeName i (C.setNotInScope $ C.simpleName "r") noRange noFixity' True
 
 -- | Create a fresh name from @a@.
 class FreshName a where

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -166,8 +166,7 @@ lookupPrimitiveFunction x =
 
 lookupPrimitiveFunctionQ :: QName -> TCM (String, PrimitiveImpl)
 lookupPrimitiveFunctionQ q = do
-  let s = case qnameName q of
-            Name _ x _ _ _ -> prettyShow x
+  let s = prettyShow (nameCanonical $ qnameName q)
   PrimImpl t pf <- lookupPrimitiveFunction s
   return (s, PrimImpl t $ pf { primFunName = q })
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -71,7 +71,7 @@ import Agda.Utils.IORef
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20200603 * 10 + 0
+currentInterfaceVersion = 20200618 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -378,10 +378,10 @@ instance EmbPrj A.ModuleName where
   value n           = A.MName `fmap` value n
 
 instance EmbPrj A.Name where
-  icod_ (A.Name a b c d e) = icodeMemo nameD nameC a $
-    icodeN' (\ a b -> A.Name a b . underlyingRange) a b (SerialisedRange c) d e
+  icod_ (A.Name a b c d e f) = icodeMemo nameD nameC a $
+    icodeN' (\ a b c -> A.Name a b c . underlyingRange) a b c (SerialisedRange d) e f
 
-  value = valueN (\a b c -> A.Name a b (underlyingRange c))
+  value = valueN (\a b c d -> A.Name a b c (underlyingRange d))
 
 instance EmbPrj a => EmbPrj (C.FieldAssignment' a) where
   icod_ (C.FieldAssignment a b) = icodeN' C.FieldAssignment a b

--- a/test/Internal/Syntax/Abstract/Name.hs
+++ b/test/Internal/Syntax/Abstract/Name.hs
@@ -16,7 +16,7 @@ import Test.QuickCheck
 
 instance Arbitrary Name where
   arbitrary =
-    Name <$> arbitrary <*> arbitrary <*> arbitrary
+    Name <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
          <*> return noFixity'
          <*> return False
 

--- a/test/Internal/TypeChecking/Generators.hs
+++ b/test/Internal/TypeChecking/Generators.hs
@@ -153,6 +153,7 @@ makeConfiguration ds cs ps vs = TermConf
                      , qnameName   = Name
                         { nameId          = NameId n 1
                         , nameConcrete    = C.simpleName s
+                        , nameCanonical   = C.simpleName s
                         , nameBindingSite = noRange
                         , nameFixity      = noFixity'
                         , nameIsRecordName = False

--- a/test/Succeed/Issue4735.agda
+++ b/test/Succeed/Issue4735.agda
@@ -1,0 +1,13 @@
+
+module _ where
+
+open import Agda.Builtin.Nat renaming (Nat to Nombre)
+open import Agda.Builtin.Equality
+open import Agda.Builtin.String
+open import Agda.Builtin.Reflection
+
+check₁ : primShowQName (quote Nombre) ≡ "Agda.Builtin.Nat.Nat"
+check₁ = refl
+
+check₂ : primShowQName (quote Agda.Builtin.Nat.Nat) ≡ "Agda.Builtin.Nat.Nat"
+check₂ = refl

--- a/test/Succeed/QuoteTerm.agda
+++ b/test/Succeed/QuoteTerm.agda
@@ -35,7 +35,7 @@ test₄ = refl
 -- Test that primShowQName prints something reasonable
 -- for quoted names.
 
-issue4734 : primShowQName (quote ℕ) ≡ "Agda.Builtin.Nat.ℕ"
+issue4734 : primShowQName (quote ℕ) ≡ "Agda.Builtin.Nat.Nat"
 issue4734 = refl
 
 -- Not sure this response is very reasonable, since


### PR DESCRIPTION
Needed to make sure `primShowQName` gives a canonical result.