### PR TITLE
Don't require ieee754 for code that doesn't use floats

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -127,6 +127,7 @@ data-files:         Agda.css
                     lib/prim/Agda/Primitive.agda
                     lib/prim/Agda/Primitive/Cubical.agda
                     MAlonzo/src/MAlonzo/*.hs
+                    MAlonzo/src/MAlonzo/RTE/*.hs
                     postprocess-latex.pl
 
 source-repository head

--- a/src/data/MAlonzo/src/MAlonzo/RTE.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE.hs
@@ -1,15 +1,11 @@
 {-# LANGUAGE CPP       #-}
 {-# LANGUAGE PolyKinds #-}
 
-module MAlonzo.RTE
-  ( module MAlonzo.RTE
-  , module MAlonzo.RTE.Float
-  ) where
+module MAlonzo.RTE where
 
 import Unsafe.Coerce
 import qualified GHC.Exts as GHC (Any)
 import qualified Data.Word
-import MAlonzo.RTE.Float
 
 type AgdaAny = GHC.Any
 

--- a/src/data/MAlonzo/src/MAlonzo/RTE.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE.hs
@@ -1,19 +1,15 @@
 {-# LANGUAGE CPP       #-}
 {-# LANGUAGE PolyKinds #-}
 
-module MAlonzo.RTE where
+module MAlonzo.RTE
+  ( module MAlonzo.RTE
+  , module MAlonzo.RTE.Float
+  ) where
 
 import Unsafe.Coerce
 import qualified GHC.Exts as GHC (Any)
 import qualified Data.Word
-import Numeric.IEEE ( IEEE(identicalIEEE, nan) )
-#if __GLASGOW_HASKELL__ >= 804
-import GHC.Float (castDoubleToWord64)
-#else
-import System.IO.Unsafe (unsafePerformIO)
-import qualified Foreign          as F
-import qualified Foreign.Storable as F
-#endif
+import MAlonzo.RTE.Float
 
 type AgdaAny = GHC.Any
 
@@ -69,64 +65,6 @@ quotInt = quot
 
 remInt :: Integer -> Integer -> Integer
 remInt = rem
-
-eqFloat :: Double -> Double -> Bool
-eqFloat x y = identicalIEEE x y || (isNaN x && isNaN y)
-
-eqNumFloat :: Double -> Double -> Bool
-eqNumFloat = (==)
-
-ltNumFloat :: Double -> Double -> Bool
-ltNumFloat = (<)
-
-negativeZero :: Double
-negativeZero = -0.0
-
-positiveInfinity :: Double
-positiveInfinity = 1.0 / 0.0
-
-negativeInfinity :: Double
-negativeInfinity = -positiveInfinity
-
-positiveNaN :: Double
-positiveNaN = 0.0 / 0.0
-
-negativeNaN :: Double
-negativeNaN = -positiveNaN
-
--- Adapted from the same function on Agda.Syntax.Literal.
-compareFloat :: Double -> Double -> Ordering
-compareFloat x y
-  | identicalIEEE x y          = EQ
-  | isNegInf x                 = LT
-  | isNegInf y                 = GT
-  | isNaN x && isNaN y         = EQ
-  | isNaN x                    = LT
-  | isNaN y                    = GT
-  | otherwise                  = compare (x, isNegZero y) (y, isNegZero x)
-  where
-    isNegInf  z = z < 0 && isInfinite z
-    isNegZero z = identicalIEEE z negativeZero
-
-ltFloat :: Double -> Double -> Bool
-ltFloat x y = case compareFloat x y of
-                LT -> True
-                _  -> False
-
-#if __GLASGOW_HASKELL__ < 804
-castDoubleToWord64 :: Double -> Word64
-castDoubleToWord64 float = unsafePerformIO $ F.alloca $ \buf -> do
-  F.poke (F.castPtr buf) float
-  F.peek buf
-#endif
-
-normaliseNaN :: Double -> Double
-normaliseNaN x
-  | isNaN x   = nan
-  | otherwise = x
-
-doubleToWord64 :: Double -> Word64
-doubleToWord64 = castDoubleToWord64 . normaliseNaN
 
 -- Words --
 

--- a/src/data/MAlonzo/src/MAlonzo/RTE/Float.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE/Float.hs
@@ -4,6 +4,8 @@
 module MAlonzo.RTE.Float where
 
 import Numeric.IEEE ( IEEE(identicalIEEE, nan) )
+import Data.Word (Word64)
+
 #if __GLASGOW_HASKELL__ >= 804
 import GHC.Float (castDoubleToWord64)
 #else

--- a/src/data/MAlonzo/src/MAlonzo/RTE/Float.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE/Float.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE CPP       #-}
+{-# LANGUAGE PolyKinds #-}
+
+module MAlonzo.RTE.Float where
+
+import Numeric.IEEE ( IEEE(identicalIEEE, nan) )
+#if __GLASGOW_HASKELL__ >= 804
+import GHC.Float (castDoubleToWord64)
+#else
+import System.IO.Unsafe (unsafePerformIO)
+import qualified Foreign          as F
+import qualified Foreign.Storable as F
+#endif
+
+eqFloat :: Double -> Double -> Bool
+eqFloat x y = identicalIEEE x y || (isNaN x && isNaN y)
+
+eqNumFloat :: Double -> Double -> Bool
+eqNumFloat = (==)
+
+ltNumFloat :: Double -> Double -> Bool
+ltNumFloat = (<)
+
+negativeZero :: Double
+negativeZero = -0.0
+
+positiveInfinity :: Double
+positiveInfinity = 1.0 / 0.0
+
+negativeInfinity :: Double
+negativeInfinity = -positiveInfinity
+
+positiveNaN :: Double
+positiveNaN = 0.0 / 0.0
+
+negativeNaN :: Double
+negativeNaN = -positiveNaN
+
+-- Adapted from the same function on Agda.Syntax.Literal.
+compareFloat :: Double -> Double -> Ordering
+compareFloat x y
+  | identicalIEEE x y          = EQ
+  | isNegInf x                 = LT
+  | isNegInf y                 = GT
+  | isNaN x && isNaN y         = EQ
+  | isNaN x                    = LT
+  | isNaN y                    = GT
+  | otherwise                  = compare (x, isNegZero y) (y, isNegZero x)
+  where
+    isNegInf  z = z < 0 && isInfinite z
+    isNegZero z = identicalIEEE z negativeZero
+
+ltFloat :: Double -> Double -> Bool
+ltFloat x y = case compareFloat x y of
+                LT -> True
+                _  -> False
+
+#if __GLASGOW_HASKELL__ < 804
+castDoubleToWord64 :: Double -> Word64
+castDoubleToWord64 float = unsafePerformIO $ F.alloca $ \buf -> do
+  F.poke (F.castPtr buf) float
+  F.peek buf
+#endif
+
+normaliseNaN :: Double -> Double
+normaliseNaN x
+  | isNaN x   = nan
+  | otherwise = x
+
+doubleToWord64 :: Double -> Word64
+doubleToWord64 = castDoubleToWord64 . normaliseNaN
+

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -3,7 +3,7 @@ module Agda.Compiler.MAlonzo.Compiler where
 
 import Control.Arrow ((***), first, second)
 import Control.Monad.Reader
-import Control.Monad.Writer
+import Control.Monad.Writer hiding ((<>))
 
 import qualified Data.List as List
 import Data.Map (Map)
@@ -13,7 +13,7 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Monoid (Monoid, mempty, mappend)
-import Data.Semigroup (Semigroup, (<>))
+import Data.Semigroup ((<>))
 
 import Numeric.IEEE
 
@@ -47,7 +47,8 @@ import Agda.Syntax.Literal
 
 import Agda.TypeChecking.Primitive (getBuiltinName)
 import Agda.TypeChecking.Reduce
-import Agda.TypeChecking.Pretty
+import Agda.TypeChecking.Pretty hiding ((<>))
+import qualified Agda.TypeChecking.Pretty as P
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Warnings

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -1,7 +1,9 @@
 
 module Agda.Compiler.MAlonzo.Compiler where
 
+import Control.Arrow ((***), first, second)
 import Control.Monad.Reader
+import Control.Monad.Writer
 
 import qualified Data.List as List
 import Data.Map (Map)
@@ -10,6 +12,8 @@ import Data.Maybe
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.Monoid (Monoid, mempty, mappend)
+import Data.Semigroup (Semigroup, (<>))
 
 import Numeric.IEEE
 
@@ -68,7 +72,7 @@ import Agda.Utils.Impossible
 ghcBackend :: Backend
 ghcBackend = Backend ghcBackend'
 
-ghcBackend' :: Backend' GHCOptions GHCOptions GHCModuleEnv IsMain [HS.Decl]
+ghcBackend' :: Backend' GHCOptions GHCOptions GHCModuleEnv IsMain (UsesFloat, [HS.Decl])
 ghcBackend' = Backend'
   { backendName           = "GHC"
   , backendVersion        = Nothing
@@ -157,20 +161,21 @@ ghcPostModule
   -> GHCModuleEnv
   -> IsMain        -- ^ Are we looking at the main module?
   -> ModuleName
-  -> [[HS.Decl]]   -- ^ Compiled module content.
+  -> [(UsesFloat, [HS.Decl])]   -- ^ Compiled module content.
   -> TCM IsMain    -- ^ Could we confirm the existence of a main function?
-ghcPostModule _ _ isMain _ defs = do
+ghcPostModule _ _ isMain _ defs0 = do
+  let (impFloat, defs) = (mconcat *** concat) $ unzip defs0
   m      <- curHsMod
-  imps   <- imports
+  imps   <- (mazRTEFloatImport impFloat ++) <$> imports
   -- Get content of FOREIGN pragmas.
   (headerPragmas, hsImps, code) <- foreignHaskell
   writeModule $ HS.Module m
     (map HS.OtherPragma headerPragmas)
     imps
-    (map fakeDecl (hsImps ++ code) ++ concat defs)
+    (map fakeDecl (hsImps ++ code) ++ defs)
   hasMainFunction isMain <$> curIF
 
-ghcCompileDef :: GHCOptions -> GHCModuleEnv -> IsMain -> Definition -> TCM [HS.Decl]
+ghcCompileDef :: GHCOptions -> GHCModuleEnv -> IsMain -> Definition -> TCM (UsesFloat, [HS.Decl])
 ghcCompileDef _ env isMain def = definition env isMain def
 
 -- | We do not erase types that have a 'HsData' pragma.
@@ -203,9 +208,9 @@ imports = (hsImps ++) <$> imps where
                       | x <- [mazCoerceName, mazErasedName, mazAnyTypeName] ++
                              map treelessPrimName rtePrims ])
 
-  rtePrims = [T.PAdd, T.PSub, T.PMul, T.PQuot, T.PRem, T.PGeq, T.PLt, T.PEqI, T.PEqF,
+  rtePrims = [T.PAdd, T.PSub, T.PMul, T.PQuot, T.PRem, T.PGeq, T.PLt, T.PEqI,
               T.PAdd64, T.PSub64, T.PMul64, T.PQuot64, T.PRem64, T.PLt64, T.PEq64,
-              T.PITo64, T.P64ToI]
+              T.PITo64, T.P64ToI] -- Excludes T.PEqF, which is defined in MAlonzo.RTE.Float
 
   imps :: TCM [HS.ImportDecl]
   imps = List.map decl . uniq <$>
@@ -220,11 +225,27 @@ imports = (hsImps ++) <$> imps where
   uniq :: [HS.ModuleName] -> [HS.ModuleName]
   uniq = List.map head . List.group . List.sort
 
+-- Should we import MAlonzo.RTE.Float
+data UsesFloat = YesFloat | NoFloat
+  deriving (Eq, Show)
+
+instance Semigroup UsesFloat where
+  NoFloat  <> i        = i
+  i        <> NoFloat  = i
+  YesFloat <> YesFloat = YesFloat
+
+instance Monoid UsesFloat where
+  mempty  = NoFloat
+  mappend = (<>)
+
+mazRTEFloatImport :: UsesFloat -> [HS.ImportDecl]
+mazRTEFloatImport i = [ HS.ImportDecl mazRTEFloat True Nothing | i == YesFloat ]
+
 --------------------------------------------------
 -- Main compiling clauses
 --------------------------------------------------
 
-definition :: GHCModuleEnv -> IsMain -> Definition -> TCM [HS.Decl]
+definition :: GHCModuleEnv -> IsMain -> Definition -> TCM (UsesFloat, [HS.Decl])
 -- ignore irrelevant definitions
 {- Andreas, 2012-10-02: Invariant no longer holds
 definition kit (Defn NonStrict _ _  _ _ _ _ _ _) = __IMPOSSIBLE__
@@ -232,7 +253,7 @@ definition kit (Defn NonStrict _ _  _ _ _ _ _ _) = __IMPOSSIBLE__
 definition _env _isMain Defn{defArgInfo = info, defName = q} | not $ usableModality info = do
   reportSDoc "compile.ghc.definition" 10 $
     ("Not compiling" <+> prettyTCM q) <> "."
-  return []
+  return mempty
 definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
   reportSDoc "compile.ghc.definition" 10 $ vcat
     [ ("Compiling" <+> prettyTCM q) <> ":"
@@ -244,8 +265,10 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
   mmaybe <- getBuiltinName builtinMaybe
   minf   <- getBuiltinName builtinInf
   mflat  <- getBuiltinName builtinFlat
-  checkTypeOfMain isMain q def $ do
-    infodecl q <$> case d of
+  let retDecls ds = return (mempty, ds)
+  main <- checkTypeOfMain isMain q def
+  second ((main ++) . infodecl q) <$>
+    case d of
 
       _ | Just (HsDefn r hs) <- pragma -> setCurrentRange r $
           if Just q == mflat
@@ -261,7 +284,7 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
             inline <- (^. funInline) . theDef <$> getConstInfo q
             when inline $ warning $ UselessInline q
 
-            return $ fbWithType hsty (fakeExp hs)
+            retDecls $ fbWithType hsty (fakeExp hs)
 
       -- Compiling Bool
       Datatype{} | Just q == mbool -> do
@@ -270,9 +293,9 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
         Just true  <- getBuiltinName builtinTrue
         Just false <- getBuiltinName builtinFalse
         cs <- mapM compiledcondecl [false, true]
-        return $ [ compiledTypeSynonym q "Bool" 0
-                 , HS.FunBind [HS.Match d [] (HS.UnGuardedRhs HS.unit_con) emptyBinds] ] ++
-                 cs
+        retDecls $ [ compiledTypeSynonym q "Bool" 0
+                   , HS.FunBind [HS.Match d [] (HS.UnGuardedRhs HS.unit_con) emptyBinds] ] ++
+                   cs
 
       -- Compiling List
       Datatype{ dataPars = np } | Just q == mlist -> do
@@ -285,9 +308,9 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
         Just cons <- getBuiltinName builtinCons
         let vars f n = map (f . ihname "a") [0 .. n - 1]
         cs <- mapM compiledcondecl [nil, cons]
-        return $ [ HS.TypeDecl t (vars HS.UnkindedVar (np - 1)) (HS.FakeType "[]")
-                 , HS.FunBind [HS.Match d (vars HS.PVar np) (HS.UnGuardedRhs HS.unit_con) emptyBinds] ] ++
-                 cs
+        retDecls $ [ HS.TypeDecl t (vars HS.UnkindedVar (np - 1)) (HS.FakeType "[]")
+                   , HS.FunBind [HS.Match d (vars HS.PVar np) (HS.UnGuardedRhs HS.unit_con) emptyBinds] ] ++
+                   cs
 
       -- Compiling Maybe
       Datatype{ dataPars = np } | Just q == mmaybe -> do
@@ -300,9 +323,9 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
         Just just    <- getBuiltinName builtinJust
         let vars f n = map (f . ihname "a") [0 .. n - 1]
         cs <- mapM compiledcondecl [nothing, just]
-        return $ [ HS.TypeDecl t (vars HS.UnkindedVar (np - 1)) (HS.FakeType "Maybe")
-                 , HS.FunBind [HS.Match d (vars HS.PVar np) (HS.UnGuardedRhs HS.unit_con) emptyBinds] ] ++
-                 cs
+        retDecls $ [ HS.TypeDecl t (vars HS.UnkindedVar (np - 1)) (HS.FakeType "Maybe")
+                   , HS.FunBind [HS.Match d (vars HS.PVar np) (HS.UnGuardedRhs HS.unit_con) emptyBinds] ] ++
+                   cs
 
       -- Compiling Inf
       _ | Just q == minf -> do
@@ -311,22 +334,22 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
         sharpC     <- compiledcondecl sharp
         let d   = unqhname "d" q
             err = "No term-level implementation of the INFINITY builtin."
-        return $ [ compiledTypeSynonym q "MAlonzo.RTE.Infinity" 2
-                 , HS.FunBind [HS.Match d [HS.PVar (ihname "a" 0)]
-                     (HS.UnGuardedRhs (HS.FakeExp ("error " ++ show err)))
-                     emptyBinds]
-                 , sharpC
-                 ]
+        retDecls $ [ compiledTypeSynonym q "MAlonzo.RTE.Infinity" 2
+                   , HS.FunBind [HS.Match d [HS.PVar (ihname "a" 0)]
+                       (HS.UnGuardedRhs (HS.FakeExp ("error " ++ show err)))
+                       emptyBinds]
+                   , sharpC
+                   ]
 
       DataOrRecSig{} -> __IMPOSSIBLE__
 
       Axiom{} -> do
         ar <- typeArity ty
-        return $ [ compiledTypeSynonym q ty ar | Just (HsType r ty) <- [pragma] ] ++
-                 fb axiomErr
-      Primitive{ primName = s } -> fb <$> primBody s
+        retDecls $ [ compiledTypeSynonym q ty ar | Just (HsType r ty) <- [pragma] ] ++
+                   fb axiomErr
+      Primitive{ primName = s } -> (mempty,) . fb <$> primBody s
 
-      PrimitiveSort{ primName = s } -> return []
+      PrimitiveSort{ primName = s } -> retDecls []
 
       Function{} -> function pragma $ functionViaTreeless q
 
@@ -343,14 +366,14 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
               , cds
               , ccscov
               ]
-        return result
+        retDecls result
       Datatype{ dataPars = np, dataIxs = ni, dataClause = cl,
                 dataCons = cs } -> do
         computeErasedConstructorArgs q
         cds <- mapM (flip condecl Inductive) cs
-        return $ tvaldecl q Inductive (np + ni) cds cl
-      Constructor{} -> return []
-      GeneralizableVar{} -> return []
+        retDecls $ tvaldecl q Inductive (np + ni) cds cl
+      Constructor{} -> retDecls []
+      GeneralizableVar{} -> retDecls []
       Record{ recPars = np, recClause = cl, recConHead = con,
               recInduction = ind } ->
         let -- Non-recursive record types are treated as being
@@ -362,18 +385,19 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
             computeErasedConstructorArgs q
             ccscov <- constructorCoverageCode q np cs ty hsCons
             cds <- mapM compiledcondecl cs
-            return $
+            retDecls $
               tvaldecl q inductionKind np [] (Just __IMPOSSIBLE__) ++
               [compiledTypeSynonym q ty np] ++ cds ++ ccscov
           _ -> do
             computeErasedConstructorArgs q
             cd <- condecl (conName con) inductionKind
-            return $ tvaldecl q inductionKind (I.arity ty) [cd] cl
+            retDecls $ tvaldecl q inductionKind (I.arity ty) [cd] cl
       AbstractDefn{} -> __IMPOSSIBLE__
   where
-  function :: Maybe HaskellPragma -> TCM [HS.Decl] -> TCM [HS.Decl]
+  function :: Maybe HaskellPragma -> TCM (UsesFloat, [HS.Decl]) -> TCM (UsesFloat, [HS.Decl])
   function mhe fun = do
-    ccls  <- mkwhere <$> fun
+    (imp, defs) <- fun
+    let ccls = mkwhere defs
     mflat <- getBuiltinName builtinFlat
     case mhe of
       Just (HsExport r name) -> setCurrentRange r $
@@ -387,11 +411,11 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
 
               def :: HS.Decl
               def = HS.FunBind [HS.Match (HS.Ident name) [] (HS.UnGuardedRhs (hsCoerce $ hsVarUQ $ dname q)) emptyBinds]
-          return ([tsig,def] ++ ccls)
-      _ -> return ccls
+          return (imp, [tsig,def] ++ ccls)
+      _ -> return (imp, ccls)
 
-  functionViaTreeless :: QName -> TCM [HS.Decl]
-  functionViaTreeless q = caseMaybeM (toTreeless LazyEvaluation q) (pure []) $ \ treeless -> do
+  functionViaTreeless :: QName -> TCM (UsesFloat, [HS.Decl])
+  functionViaTreeless q = caseMaybeM (toTreeless LazyEvaluation q) (pure mempty) $ \ treeless -> do
 
     used <- getCompiledArgUse q
     let dostrip = any not used
@@ -405,8 +429,8 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
         argTypes  = drop pars argTypes0
         argTypesS = [ t | (t, True) <- zip argTypes (used ++ repeat True) ]
 
-    e <- if dostrip then closedTerm (stripUnusedArguments used treeless)
-                    else closedTerm treeless
+    (e, useFloat) <- if dostrip then closedTerm (stripUnusedArguments used treeless)
+                                else closedTerm treeless
     let (ps, b) = lamView e
         lamView e =
           case e of
@@ -420,13 +444,14 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
           in [tydecl f ts' t, funbind f ps b]
 
     -- The definition of the non-stripped function
-    (ps0, _) <- lamView <$> closedTerm (foldr ($) T.TErased $ replicate (length used) T.TLam)
+    (ps0, _) <- lamView <$> closedTerm_ (foldr ($) T.TErased $ replicate (length used) T.TLam)
     let b0 = foldl HS.App (hsVarUQ $ duname q) [ hsVarUQ x | (~(HS.PVar x), True) <- zip ps0 used ]
 
-    return $ if dostrip
-      then tyfunbind (dname q) argTypes resType ps0 b0 ++
-           tyfunbind (duname q) argTypesS resType ps b
-      else tyfunbind (dname q) argTypes resType ps b
+    return (useFloat,
+            if dostrip
+              then tyfunbind (dname q) argTypes resType ps0 b0 ++
+                   tyfunbind (duname q) argTypesS resType ps b
+              else tyfunbind (dname q) argTypes resType ps b)
 
   mkwhere :: [HS.Decl] -> [HS.Decl]
   mkwhere (HS.FunBind [m0, HS.Match dn ps rhs emptyBinds] : fbs@(_:_)) =
@@ -443,7 +468,7 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
 
   fb :: HS.Exp -> [HS.Decl]
   fb e  = [HS.FunBind [HS.Match (unqhname "d" q) []
-                                (HS.UnGuardedRhs $ e) emptyBinds]]
+                                (HS.UnGuardedRhs e) emptyBinds]]
 
   axiomErr :: HS.Exp
   axiomErr = rtmError $ T.pack $ "postulate evaluated: " ++ prettyShow q
@@ -483,7 +508,10 @@ initCCEnv = CCEnv
 lookupIndex :: Int -> CCContext -> HS.Name
 lookupIndex i xs = fromMaybe __IMPOSSIBLE__ $ xs !!! i
 
-type CC = ReaderT CCEnv TCM
+type CC = ReaderT CCEnv (WriterT UsesFloat TCM)
+
+liftCC :: TCM a -> CC a
+liftCC = lift . lift
 
 freshNames :: Int -> ([HS.Name] -> CC a) -> CC a
 freshNames n _ | n < 0 = __IMPOSSIBLE__
@@ -520,16 +548,19 @@ checkCover q ty n cs hsCons = do
                                 (HS.UnGuardedRhs rhs) emptyBinds]
          ]
 
-closedTerm :: T.TTerm -> TCM HS.Exp
+closedTerm_ :: T.TTerm -> TCM HS.Exp
+closedTerm_ t = fst <$> closedTerm t
+
+closedTerm :: T.TTerm -> TCM (HS.Exp, UsesFloat)
 closedTerm v = do
   v <- addCoercions v
-  term v `runReaderT` initCCEnv
+  runWriterT (term v `runReaderT` initCCEnv)
 
 -- Translate case on bool to if
 mkIf :: T.TTerm -> CC T.TTerm
 mkIf t@(TCase e _ d [TACon c1 0 b1, TACon c2 0 b2]) | T.isUnreachable d = do
-  mTrue  <- lift $ getBuiltinName builtinTrue
-  mFalse <- lift $ getBuiltinName builtinFalse
+  mTrue  <- liftCC $ getBuiltinName builtinTrue
+  mFalse <- liftCC $ getBuiltinName builtinFalse
   let isTrue  c = Just c == mTrue
       isFalse c = Just c == mFalse
   if | isTrue c1, isFalse c2 -> return $ T.tIfThenElse (TCoerce $ TVar e) b1 b2
@@ -550,32 +581,32 @@ term tm0 = mkIf tm0 >>= \ tm0 -> do
     (T.TPrim T.PIf, [c, x, y]) -> coe <$> do HS.If <$> term c <*> term x <*> term y
 
     (T.TDef f, ts) -> do
-      used <- lift $ getCompiledArgUse f
+      used <- liftCC $ getCompiledArgUse f
       -- #2248: no unused argument pruning for COMPILE'd functions
-      isCompiled <- lift $ isJust <$> getHaskellPragma f
+      isCompiled <- liftCC $ isJust <$> getHaskellPragma f
       let given   = length ts
           needed  = length used
           missing = drop given used
           notUsed = not
       if not isCompiled && any not used
         then if any notUsed missing then term (etaExpand (needed - given) tm0) else do
-          f <- lift $ HS.Var <$> xhqn "du" f  -- use stripped function
+          f <- liftCC $ HS.Var <$> xhqn "du" f  -- use stripped function
           -- Andreas, 2019-11-07, issue #4169.
           -- Insert coercion unconditionally as erasure of arguments
           -- that are matched upon might remove the unfolding of codomain types.
           -- (Hard to explain, see test/Compiler/simple/Issue4169.)
           hsCoerce f `apps` [ t | (t, True) <- zip ts $ used ++ repeat True ]
         else do
-          f <- lift $ HS.Var <$> xhqn "d" f  -- use original (non-stripped) function
+          f <- liftCC $ HS.Var <$> xhqn "d" f  -- use original (non-stripped) function
           coe f `apps` ts
 
     (T.TCon c, ts) -> do
-      erased  <- lift $ getErasedConArgs c
+      erased  <- liftCC $ getErasedConArgs c
       let missing = drop (length ts) erased
           notErased = not
       if all notErased missing
         then do
-                f <- lift $ HS.Con <$> conhqn c
+                f <- liftCC $ HS.Con <$> conhqn c
                 hsCoerce f `apps` [ t | (t, False) <- zip ts erased ]
         else do
                 let n = length missing
@@ -611,7 +642,7 @@ noApplication = \case
     let defAlt = HS.Alt HS.PWildCard (HS.UnGuardedRhs def') emptyBinds
     return $ HS.Case (hsCoerce sc') (alts' ++ [defAlt])
 
-  T.TLit l    -> return $ literal l
+  T.TLit l    -> literal l
   T.TPrim p   -> return $ compilePrim p
   T.TUnit     -> return $ HS.unit_con
   T.TSort     -> return $ HS.unit_con
@@ -630,13 +661,13 @@ alt sc a = do
   case a of
     T.TACon {T.aCon = c} -> do
       intros (T.aArity a) $ \ xs -> do
-        erased <- lift $ getErasedConArgs c
-        nil  <- lift $ getBuiltinName builtinNil
-        cons <- lift $ getBuiltinName builtinCons
+        erased <- liftCC $ getErasedConArgs c
+        nil  <- liftCC $ getBuiltinName builtinNil
+        cons <- liftCC $ getBuiltinName builtinCons
         hConNm <-
           if | Just c == nil  -> return $ HS.UnQual $ HS.Ident "[]"
              | Just c == cons -> return $ HS.UnQual $ HS.Symbol ":"
-             | otherwise      -> lift $ conhqn c
+             | otherwise      -> liftCC $ conhqn c
         mkAlt (HS.PApp hConNm $ [HS.PVar x | (x, False) <- zip xs erased])
     T.TAGuard g b -> do
       g <- term g
@@ -645,7 +676,10 @@ alt sc a = do
                       (HS.GuardedRhss [HS.GuardedRhs [HS.Qualifier g] b])
                       emptyBinds
     T.TALit { T.aLit = LitQName q } -> mkAlt (litqnamepat q)
-    T.TALit { T.aLit = l@LitFloat{}, T.aBody = b } -> mkGuarded (treelessPrimName T.PEqF) (literal l) b
+    T.TALit { T.aLit = l@LitFloat{}, T.aBody = b } -> do
+      tell YesFloat
+      l <- literal l
+      mkGuarded (treelessPrimName T.PEqF) l b
     T.TALit { T.aLit = LitString s , T.aBody = b } -> mkGuarded "(==)" (litString s) b
     T.TALit {} -> mkAlt (HS.PLit $ hslit $ T.aLit a)
   where
@@ -666,30 +700,30 @@ alt sc a = do
         body' <- term $ T.aBody a
         return $ HS.Alt pat (HS.UnGuardedRhs body') emptyBinds
 
-literal :: Literal -> HS.Exp
+literal :: Literal -> CC HS.Exp
 literal l = case l of
-  LitNat    _   -> typed "Integer"
-  LitWord64 _   -> typed "MAlonzo.RTE.Word64"
+  LitNat    _   -> return $ typed "Integer"
+  LitWord64 _   -> return $ typed "MAlonzo.RTE.Word64"
   LitFloat  x   -> floatExp x "Double"
-  LitQName  x   -> litqname x
-  LitString s   -> litString s
-  _             -> l'
+  LitQName  x   -> return $ litqname x
+  LitString s   -> return $ litString s
+  _             -> return $ l'
   where
     l'    = HS.Lit $ hslit l
     typed = HS.ExpTypeSig l' . HS.TyCon . rtmQual
 
     -- ASR (2016-09-14): See Issue #2169.
     -- Ulf, 2016-09-28: and #2218.
-    floatExp :: Double -> String -> HS.Exp
+    floatExp :: Double -> String -> CC HS.Exp
     floatExp x s
       | isNegativeZero x = rte "negativeZero"
       | isNegativeInf  x = rte "negativeInfinity"
       | isInfinite x     = rte "positiveInfinity"
       | isNegativeNaN x  = rte "negativeNaN"
       | isNaN x          = rte "positiveNaN"
-      | otherwise        = typed s
-
-    rte = HS.Var . HS.Qual mazRTE . HS.Ident
+      | otherwise        = return $ typed s
+      where
+        rte s = do tell YesFloat; return $ HS.Var $ HS.Qual mazRTEFloat $ HS.Ident s
 
     isNegativeInf x = isInfinite x && x < 0.0
     isNegativeNaN x = isNaN x && not (identicalIEEE x (0.0 / 0.0))

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs-boot
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs-boot
@@ -1,8 +1,0 @@
-module Agda.Compiler.MAlonzo.Compiler where
-
-import qualified Agda.Utils.Haskell.Syntax as HS
-
-import Agda.Syntax.Treeless (TTerm)
-import Agda.TypeChecking.Monad (TCM)
-
-closedTerm :: TTerm -> TCM HS.Exp

--- a/src/full/Agda/Compiler/MAlonzo/Misc.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Misc.hs
@@ -181,6 +181,9 @@ mazAnyType = HS.TyCon (hsName mazAnyTypeName)
 mazRTE :: HS.ModuleName
 mazRTE = HS.ModuleName "MAlonzo.RTE"
 
+mazRTEFloat :: HS.ModuleName
+mazRTEFloat = HS.ModuleName "MAlonzo.RTE.Float"
+
 rtmQual :: String -> HS.QName
 rtmQual = HS.UnQual . HS.Ident
 

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -3,13 +3,13 @@ module Agda.Compiler.MAlonzo.Primitives where
 
 import qualified Data.List as List
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import qualified Data.HashMap.Strict as HMap
 import Data.Maybe
 import qualified Data.Text as T
 
 import Agda.Compiler.Common
 import Agda.Compiler.ToTreeless
-import {-# SOURCE #-} Agda.Compiler.MAlonzo.Compiler (closedTerm)
 import Agda.Compiler.MAlonzo.Misc
 import Agda.Compiler.MAlonzo.Pretty
 import Agda.Syntax.Common
@@ -59,15 +59,15 @@ hasMainFunction IsMain i
     names = HMap.toList $ iSignature i ^. sigDefinitions
 
 -- | Check that the main function has type IO a, for some a.
-checkTypeOfMain :: IsMain -> QName -> Definition -> TCM [HS.Decl] -> TCM [HS.Decl]
-checkTypeOfMain NotMain q def ret = ret
-checkTypeOfMain  IsMain q def ret
-  | not (isMainFunction q $ theDef def) = ret
+checkTypeOfMain :: IsMain -> QName -> Definition -> TCM [HS.Decl]
+checkTypeOfMain NotMain q def = return []
+checkTypeOfMain  IsMain q def
+  | not (isMainFunction q $ theDef def) = return []
   | otherwise = do
     Def io _ <- primIO
     ty <- reduce $ defType def
     case unEl ty of
-      Def d _ | d == io -> (mainAlias :) <$> ret
+      Def d _ | d == io -> return [mainAlias]
       _                 -> do
         err <- fsep $
           pwords "The type of main should be" ++
@@ -98,7 +98,7 @@ treelessPrimName p =
     PEq64  -> "eq64"
     PITo64 -> "word64FromNat"
     P64ToI -> "word64ToNat"
-    PEqF  -> "eqFloat"
+    PEqF  -> "MAlonzo.RTE.Float.eqFloat"
     -- MAlonzo uses literal patterns, so we don't need equality for the other primitive types
     PEqC  -> __IMPOSSIBLE__
     PEqS  -> __IMPOSSIBLE__
@@ -124,6 +124,15 @@ importsForPrim =
   , "primIsSpace"       |-> ["Data.Char"]
   , "primToLower"       |-> ["Data.Char"]
   , "primToUpper"       |-> ["Data.Char"]
+  , "primFloatEquality"          |-> ["MAlonzo.RTE.Float"]
+  , "primFloatLess"              |-> ["MAlonzo.RTE.Float"]
+  , "primFloatNumericalEquality" |-> ["MAlonzo.RTE.Float"]
+  , "primFloatNumericalLess"     |-> ["MAlonzo.RTE.Float"]
+  , "primFloatSqrt"              |-> ["MAlonzo.RTE.Float"]
+  , "primRound"                  |-> ["MAlonzo.RTE.Float"]
+  , "primFloor"                  |-> ["MAlonzo.RTE.Float"]
+  , "primCeiling"                |-> ["MAlonzo.RTE.Float"]
+  , "primFloatToWord64"          |-> ["MAlonzo.RTE.Float"]
   ]
   where (|->) = (,)
 
@@ -131,7 +140,7 @@ importsForPrim =
 
 xForPrim :: [(String, TCM [a])] -> TCM [a]
 xForPrim table = do
-  qs <- HMap.keys <$> curDefs
+  qs <- Set.fromList . HMap.keys <$> curDefs
   bs <- Map.toList <$> getsTC stBuiltinThings
   let getName (Builtin (Def q _))    = q
       getName (Builtin (Con q _ _))  = conName q
@@ -139,7 +148,7 @@ xForPrim table = do
       getName (Builtin _)            = __IMPOSSIBLE__
       getName (Prim (PrimFun q _ _)) = q
   concat <$> sequence [ fromMaybe (return []) $ List.lookup s table
-                        | (s, def) <- bs, getName def `elem` qs ]
+                        | (s, def) <- bs, getName def `Set.member` qs ]
 
 
 -- | Definition bodies for primitive functions
@@ -192,14 +201,14 @@ primBody s = maybe unimplemented (fromRight (hsVarUQ . HS.Ident) <$>) $
   -- ASR (2016-09-14). We use bitwise equality for comparing Double
   -- because Haskell's Eq, which equates 0.0 and -0.0, allows to prove
   -- a contradiction (see Issue #2169).
-  , "primFloatEquality"          |-> return "MAlonzo.RTE.eqFloat"
-  , "primFloatLess"              |-> return "MAlonzo.RTE.ltFloat"
-  , "primFloatNumericalEquality" |-> return "MAlonzo.RTE.eqNumFloat"
-  , "primFloatNumericalLess"     |-> return "MAlonzo.RTE.ltNumFloat"
+  , "primFloatEquality"          |-> return "MAlonzo.RTE.Float.eqFloat"
+  , "primFloatLess"              |-> return "MAlonzo.RTE.Float.ltFloat"
+  , "primFloatNumericalEquality" |-> return "MAlonzo.RTE.Float.eqNumFloat"
+  , "primFloatNumericalLess"     |-> return "MAlonzo.RTE.Float.ltNumFloat"
   , "primFloatSqrt"         |-> return "(sqrt :: Double -> Double)"
-  , "primRound"             |-> return "(round . MAlonzo.RTE.normaliseNaN :: Double -> Integer)"
-  , "primFloor"             |-> return "(floor . MAlonzo.RTE.normaliseNaN :: Double -> Integer)"
-  , "primCeiling"           |-> return "(ceiling . MAlonzo.RTE.normaliseNaN :: Double -> Integer)"
+  , "primRound"             |-> return "(round . MAlonzo.RTE.Float.normaliseNaN :: Double -> Integer)"
+  , "primFloor"             |-> return "(floor . MAlonzo.RTE.Float.normaliseNaN :: Double -> Integer)"
+  , "primCeiling"           |-> return "(ceiling . MAlonzo.RTE.Float.normaliseNaN :: Double -> Integer)"
   , "primExp"               |-> return "(exp :: Double -> Double)"
   , "primLog"               |-> return "(log :: Double -> Double)"
   , "primSin"               |-> return "(sin :: Double -> Double)"
@@ -210,7 +219,7 @@ primBody s = maybe unimplemented (fromRight (hsVarUQ . HS.Ident) <$>) $
   , "primATan"              |-> return "(atan :: Double -> Double)"
   , "primATan2"             |-> return "(atan2 :: Double -> Double -> Double)"
   , "primShowFloat"         |-> return "(Data.Text.pack . show :: Double -> Data.Text.Text)"
-  , "primFloatToWord64"     |-> return "MAlonzo.RTE.doubleToWord64"
+  , "primFloatToWord64"     |-> return "MAlonzo.RTE.Float.doubleToWord64"
   , "primFloatToWord64Injective" |-> return "erased"
 
   -- Character functions
@@ -257,11 +266,7 @@ primBody s = maybe unimplemented (fromRight (hsVarUQ . HS.Ident) <$>) $
   , "primForceLemma" |-> return "erased"
 
   -- Erase
-  , ("primEraseEquality", Right <$> do
-       refl <- primRefl
-       let erase = hLam "a" $ hLam "A" $ hLam "x" $ hLam "y" $ nLam "eq" refl
-       closedTerm =<< closedTermToTreeless LazyEvaluation erase
-    )
+  , "primEraseEquality" |-> return "erased"
   ]
   where
   x |-> s = (x, Left <$> s)

--- a/test/Succeed/Issue3619.agda
+++ b/test/Succeed/Issue3619.agda
@@ -1,0 +1,16 @@
+-- Not using any Floats so shouldn't need ieee754 installed.
+-- .flags file contains
+--    -c --ghc-flag="-hide-package ieee754"
+
+module _ where
+
+open import Agda.Builtin.IO
+open import Agda.Builtin.Unit
+
+postulate
+  return : {A : Set} → A → IO A
+
+{-# COMPILE GHC return = \ _ -> return #-}
+
+main : IO ⊤
+main = return _


### PR DESCRIPTION
Separates the float parts into `MAlonzo.RTE.Float` and only imports this if needed.

Fixes #3619.