### PR TITLE
New global confluence checker for rewrite rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Pragmas and options
 * New option `--auto-inline` turns on automatic compile-time inlining of simple
   functions. This was previously enabled by default.
 
+* New option `--local-confluence-check` to restore the old behaviour
+  of the `--confluence-check` flag (see below for the new behaviour).
+
 Language
 --------
 
@@ -120,6 +123,26 @@ Language
   Used this opportunity to introduce a `primStringUncons` primitive in
   `Agda.Builtin.String` (and to correspondingly add the `Agda.Builtin.Maybe`
   it needs).
+
+* The option `--confluence-check` for rewrite rules has been given a
+  new implementation that checks global confluence instead of local
+  confluence. Concretely, it does so by enforcing two properties:
+
+  1. For any two left-hand sides of the rewrite rules that overlap
+     (either at the root position or at a subterm), the most general
+     unifier of the two left-hand sides is again a left-hand side of a
+     rewrite rule. For example, if there are two rules @suc m + n =
+     suc (m + n)@ and @m + suc n = suc (m + n)@, then there should
+     also be a rule @suc m + suc n = suc (suc (m + n))@.
+
+  2. Each rewrite rule should satisfy the *triangle property*: For any
+     rewrite rule @u = w@ and any single-step parallel unfolding @u =>
+     v@, we should have another single-step parallel unfolding @v =>
+     w@.
+
+  The previous behaviour of the confluence checker that only ensures
+  local confluence can be restored by using the
+  `--local-confluence-check` flag.
 
 
 Reflection

--- a/doc/user-manual/language/rewriting.lagda.rst
+++ b/doc/user-manual/language/rewriting.lagda.rst
@@ -163,8 +163,26 @@ applied to terms that would otherwise be neutral.
 Confluence checking
 -------------------
 
-Agda can optionally check (local) confluence of rewrite rules by
-enabling the ``--confluence-check`` flag.
+Agda can optionally check confluence of rewrite rules by enabling the
+``--confluence-check`` flag. Concretely, it does so by enforcing two
+properties:
+
+  1. For any two left-hand sides of the rewrite rules that overlap
+     (either at the root position or at a subterm), the most general
+     unifier of the two left-hand sides is again a left-hand side of a
+     rewrite rule. For example, if there are two rules ``suc m + n =
+     suc (m + n)`` and ``m + suc n = suc (m + n)``, then there should
+     also be a rule ``suc m + suc n = suc (suc (m + n))``.
+
+  2. Each rewrite rule should satisfy the *triangle property*: For any
+     rewrite rule ``u = w`` and any single-step parallel unfolding ``u
+     => v``, we should have another single-step parallel unfolding ``v
+     => w``.
+
+There is also a flag ``--local-confluence-check`` that is less
+restrictive but only checks local confluence of rewrite rules. In case
+the rewrite rules are terminating (currently not checked), these two
+properties are equivalent.
 
 Advanced usage
 --------------

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -215,12 +215,12 @@ Copatterns and projections
 Experimental features
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. option:: --confluence-check
+.. option:: --confluence-check, --local-confluence-check
 
      .. versionadded:: 2.6.1
 
-     Enable optional confluence checking of REWRITE rules (see
-     :ref:`confluence-check`).
+     Enable optional (global or local) confluence checking of REWRITE
+     rules (see :ref:`confluence-check`).
 
 .. option:: --cubical
 

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -453,6 +453,8 @@ warningHighlighting' b w = case tcWarning w of
   LibraryWarning{}           -> mempty
   RewriteNonConfluent{}      -> confluenceErrorHighlighting w
   RewriteMaybeNonConfluent{} -> confluenceErrorHighlighting w
+  RewriteAmbiguousRules{}    -> confluenceErrorHighlighting w
+  RewriteMissingRule{}       -> confluenceErrorHighlighting w
   PragmaCompileErased{}      -> deadcodeHighlighting w
   NotInScopeW{}              -> deadcodeHighlighting w
   AsPatternShadowsConstructorOrPatternSynonym{}

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -162,9 +162,9 @@ mergeInterface i = do
     reportSLn "import.iface.merge" 20 $
       "  Rebinding primitives " ++ show prim
     mapM_ rebind prim
-    whenM (optConfluenceCheck <$> pragmaOptions) $ do
+    whenJustM (optConfluenceCheck <$> pragmaOptions) $ \confChk -> do
       reportSLn "import.iface.confluence" 20 $ "  Checking confluence of imported rewrite rules"
-      checkConfluenceOfRules $ concat $ HMap.elems $ sig ^. sigRewriteRules
+      checkConfluenceOfRules confChk $ concat $ HMap.elems $ sig ^. sigRewriteRules
     where
         rebind (x, q) = do
             PrimImpl _ pf <- lookupPrimitiveFunction x

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -121,6 +121,8 @@ errorWarnings = Set.fromList
   , CoInfectiveImport_
   , RewriteNonConfluent_
   , RewriteMaybeNonConfluent_
+  , RewriteAmbiguousRules_
+  , RewriteMissingRule_
   ]
 
 allWarnings :: Set WarningName
@@ -198,6 +200,8 @@ data WarningName
   | PragmaCompileErased_
   | RewriteMaybeNonConfluent_
   | RewriteNonConfluent_
+  | RewriteAmbiguousRules_
+  | RewriteMissingRule_
   | SafeFlagEta_
   | SafeFlagInjective_
   | SafeFlagNoCoverageCheck_
@@ -342,8 +346,10 @@ warningNameDescription = \case
   NotStrictlyPositive_             -> "Failed strict positivity checks."
   OldBuiltin_                      -> "Deprecated `BUILTIN' pragmas."
   PragmaCompileErased_             -> "`COMPILE' pragma targeting an erased symbol."
-  RewriteMaybeNonConfluent_      -> "Failed confluence checks while computing overlap."
-  RewriteNonConfluent_           -> "Failed confluence checks while joining critical pairs."
+  RewriteMaybeNonConfluent_        -> "Failed local confluence check while computing overlap."
+  RewriteNonConfluent_             -> "Failed local confluence check while joining critical pairs."
+  RewriteAmbiguousRules_           -> "Failed global confluence check because of overlapping rules."
+  RewriteMissingRule_              -> "Failed global confluence check because of missing rule."
   SafeFlagEta_                     -> "`ETA' pragmas with the safe flag."
   SafeFlagInjective_               -> "`INJECTIVE' pragmas with the safe flag."
   SafeFlagNoCoverageCheck_         -> "`NON_COVERING` pragmas with the safe flag."

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3135,6 +3135,13 @@ data Warning
   | RewriteMaybeNonConfluent Term Term [Doc]
     -- ^ Confluence checker got stuck on computing overlap between two
     --   rewrite rules
+  | RewriteAmbiguousRules Term Term Term
+    -- ^ The global confluence checker found a term @u@ that reduces
+    --   to both @v1@ and @v2@ and there is no rule to resolve the
+    --   ambiguity.
+  | RewriteMissingRule Term Term Term
+    -- ^ The global confluence checker found a term @u@ that reduces
+    --   to @v@, but @v@ does not reduce to @rho(u)@.
   | PragmaCompileErased BackendName QName
     -- ^ COMPILE directive for an erased symbol
   | NotInScopeW [C.QName]
@@ -3216,6 +3223,8 @@ warningName = \case
   CoInfectiveImport{}          -> CoInfectiveImport_
   RewriteNonConfluent{}        -> RewriteNonConfluent_
   RewriteMaybeNonConfluent{}   -> RewriteMaybeNonConfluent_
+  RewriteAmbiguousRules{}      -> RewriteAmbiguousRules_
+  RewriteMissingRule{}         -> RewriteMissingRule_
   PragmaCompileErased{}        -> PragmaCompileErased_
   -- record field warnings
   RecordFieldWarning w -> case w of

--- a/src/full/Agda/TypeChecking/Monad/Env.hs
+++ b/src/full/Agda/TypeChecking/Monad/Env.hs
@@ -119,9 +119,10 @@ allowAllReductions = putAllowedReductions allReductions
 allowNonTerminatingReductions :: MonadTCEnv m => m a -> m a
 allowNonTerminatingReductions = putAllowedReductions reallyAllReductions
 
--- | Allow all reductions when reducing types
+-- | Allow all reductions when reducing types. Otherwise only allow
+--   inlined functions to be unfolded.
 onlyReduceTypes :: MonadTCEnv m => m a -> m a
-onlyReduceTypes = putAllowedReductions $ SmallSet.singleton TypeLevelReductions
+onlyReduceTypes = putAllowedReductions $ SmallSet.fromList [TypeLevelReductions, InlineReductions]
 
 -- | Update allowed reductions when working on types
 typeLevelReductions :: MonadTCEnv m => m a -> m a

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -266,7 +266,7 @@ prettyWarning = \case
       [pretty o] ++ pwords "flag from a module which does."
 
     RewriteNonConfluent lhs rhs1 rhs2 err -> fsep
-      [ "Confluence check failed:"
+      [ "Local confluence check failed:"
       , prettyTCM lhs , "reduces to both"
       , prettyTCM rhs1 , "and" , prettyTCM rhs2
       , "which are not equal because"
@@ -281,6 +281,31 @@ prettyWarning = \case
           ]
         ]
       , map (nest 2 . return) cs
+      ]
+
+    RewriteAmbiguousRules lhs rhs1 rhs2 -> vcat
+      [ ( fsep $ concat
+          [ pwords "Global confluence check failed:" , [prettyTCM lhs]
+          , pwords "can be rewritten to either" , [prettyTCM rhs1]
+          , pwords "or" , [prettyTCM rhs2 <> "."]
+          ])
+      , fsep $ concat
+        [ pwords "Possible fix: add a rewrite rule with left-hand side"
+        , [prettyTCM lhs] , pwords "to resolve the ambiguity."
+        ]
+      ]
+
+    RewriteMissingRule u v rhou -> vcat
+      [ fsep $ concat
+        [ pwords "Global confluence check failed:" , [prettyTCM u]
+        , pwords "unfolds to" , [prettyTCM v] , pwords "which should further unfold to"
+        , [prettyTCM rhou] , pwords "but it does not."
+        ]
+      , fsep $ concat
+        [ pwords "Possible fix: add a rule to rewrite"
+        , [ prettyTCM v , "to" , prettyTCM rhou <> "," ]
+        , pwords "or change the order of the rules so more specialized rules come later."
+        ]
       ]
 
     PragmaCompileErased bn qn -> fsep $ concat

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -286,6 +286,9 @@ checkRewriteRule q = do
   where
     checkNoLhsReduction :: QName -> Elims -> TCM ()
     checkNoLhsReduction f es = do
+      -- Skip this check when global confluence check is enabled, as
+      -- redundant rewrite rules may be required to prove confluence.
+      unlessM ((== Just GlobalConfluenceCheck) . optConfluenceCheck <$> pragmaOptions) $ do
       let v = Def f es
       v' <- reduce v
       let fail = do

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -151,8 +151,8 @@ addRewriteRules qs = do
 
   -- Run confluence check for the new rules
   -- (should be done after adding all rules, see #3795)
-  whenM (optConfluenceCheck <$> pragmaOptions) $
-    checkConfluenceOfRules rews
+  whenJustM (optConfluenceCheck <$> pragmaOptions) $ \confChk ->
+    checkConfluenceOfRules confChk rews
 
 
 -- | Check the validity of @q : Γ → rel us lhs rhs@ as rewrite rule

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -141,7 +141,12 @@ instance Match (Type, Elims -> Term) [Elim' NLPat] Elims where
   match r gamma k (t, hd) [] [] = return ()
   match r gamma k (t, hd) [] _  = matchingBlocked $ NotBlocked ReallyNotBlocked ()
   match r gamma k (t, hd) _  [] = matchingBlocked $ NotBlocked ReallyNotBlocked ()
-  match r gamma k (t, hd) (p:ps) (v:vs) = case (p,v) of
+  match r gamma k (t, hd) (p:ps) (v:vs) =
+   traceSDoc "rewriting.match" 50 (sep
+     [ "matching elimination " <+> addContext (gamma `abstract` k) (prettyTCM p)
+     , "  with               " <+> addContext k (prettyTCM v)
+     , "  eliminating head   " <+> addContext k (prettyTCM $ hd []) <+> ":" <+> addContext k (prettyTCM t)]) $ do
+   case (p,v) of
     (Apply p, Apply v) -> do
       ~(Pi a b) <- addContext k $ unEl <$> reduce t
       match r gamma k a p v

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -377,7 +377,7 @@ reallyFree xs v = do
 
 makeSubstitution :: Telescope -> Sub -> Substitution
 makeSubstitution gamma sub =
-  prependS __IMPOSSIBLE__ (map val [0 .. size gamma-1]) IdS
+  parallelS $ map (fromMaybe __DUMMY_TERM__ . val) [0 .. size gamma-1]
     where
       val i = case IntMap.lookup i sub of
                 Just (Irrelevant, v) -> Just $ dontCare v

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -388,9 +388,9 @@ checkFunDefS t ai delayed extlam with i name withSub cs = do
         -- Jesper, 2019-05-30: if the constructors used in the
         -- lhs of a clause have rewrite rules, we need to check
         -- confluence here
-        whenM (optConfluenceCheck <$> pragmaOptions) $ inTopContext $
+        whenJustM (optConfluenceCheck <$> pragmaOptions) $ \confChk -> inTopContext $
           forM_ (zip cs [0..]) $ \(c , clauseNo) ->
-            checkConfluenceOfClause name clauseNo c
+            checkConfluenceOfClause confChk name clauseNo c
 
         -- Add the definition
         inTopContext $ addConstant name =<< do

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -335,10 +335,10 @@ checkRecDef i name uc ind eta0 pat con (A.DataDefParams gpars ps) contel fields 
         addCompositionForRecord name con tel (map argFromDom fs) ftel rect
 
       -- Jesper, 2019-06-07: Check confluence of projection clauses
-      whenM (optConfluenceCheck <$> pragmaOptions) $ forM_ fs $ \f -> do
+      whenJustM (optConfluenceCheck <$> pragmaOptions) $ \confChk -> forM_ fs $ \f -> do
         cls <- defClauses <$> getConstInfo (unDom f)
         forM (zip cls [0..]) $ \(cl,i) ->
-          checkConfluenceOfClause (unDom f) i cl
+          checkConfluenceOfClause confChk (unDom f) i cl
 
       return ()
   where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -86,6 +86,8 @@ instance EmbPrj Warning where
     DuplicateUsing a                      -> icodeN 33 DuplicateUsing a
     UselessHiding a                       -> icodeN 34 UselessHiding a
     GenericUseless a b                    -> icodeN 35 GenericUseless a b
+    RewriteAmbiguousRules a b c           -> icodeN 36 RewriteAmbiguousRules a b c
+    RewriteMissingRule a b c              -> icodeN 37 RewriteMissingRule a b c
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -124,6 +126,8 @@ instance EmbPrj Warning where
     [33, a]              -> valuN DuplicateUsing a
     [34, a]              -> valuN UselessHiding a
     [35, a, b]           -> valuN GenericUseless a b
+    [36, a, b, c]        -> valuN RewriteAmbiguousRules a b c
+    [37, a, b, c]        -> valuN RewriteMissingRule a b c
     _ -> malformed
 
 instance EmbPrj RecordFieldWarning where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -243,6 +243,15 @@ instance EmbPrj PragmaOptions where
       valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa
     _ -> malformed
 
+instance EmbPrj ConfluenceCheck where
+  icod_ LocalConfluenceCheck  = icodeN' LocalConfluenceCheck
+  icod_ GlobalConfluenceCheck = icodeN 0 GlobalConfluenceCheck
+
+  value = vcase valu where
+    valu []  = valuN LocalConfluenceCheck
+    valu [0] = valuN GlobalConfluenceCheck
+    valu _   = malformed
+
 instance EmbPrj WarningMode where
   icod_ = \case
     WarningMode a b -> icodeN' WarningMode a b

--- a/src/full/Agda/Utils/Applicative.hs
+++ b/src/full/Agda/Utils/Applicative.hs
@@ -1,10 +1,13 @@
 module Agda.Utils.Applicative
        ( (?*>)
        , (?$>)
+       , foldA
+       , foldMapA
        )
        where
 
 import Control.Applicative
+import Data.Monoid ( Alt(..) )
 
 -- | Guard: return the action @f@ only if the boolean is @True@
 (?*>) :: Alternative f => Bool -> f a -> f a
@@ -13,3 +16,12 @@ b ?*> f = if b then f else empty
 -- | Guard: return the value @a@ only if the boolean is @True@
 (?$>) :: Alternative f => Bool -> a -> f a
 b ?$> a = b ?*> pure a
+
+-- | Branch over a 'Foldable' collection of values.
+foldA :: (Alternative f, Foldable t) => t a -> f a
+foldA = foldMapA pure
+
+-- | Branch over a 'Foldable' collection of values using the supplied
+--   action.
+foldMapA :: (Alternative f, Foldable t) => (a -> f b) -> t a -> f b
+foldMapA f = getAlt . foldMap (Alt . f)

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -14,7 +14,9 @@ import Control.Monad.State
 import Data.Traversable as Trav hiding (for, sequence)
 import Data.Foldable as Fold
 import Data.Maybe
+import Data.Monoid
 
+import Agda.Utils.Applicative
 import Agda.Utils.Either
 import Agda.Utils.Null (ifNotNullM)
 
@@ -171,12 +173,17 @@ partitionM f xs =
 
 -- | Translates 'Maybe' to 'MonadPlus'.
 fromMaybeMP :: MonadPlus m => Maybe a -> m a
-fromMaybeMP = maybe mzero return
+fromMaybeMP = foldA
 
 -- | Generalises the 'catMaybes' function from lists to an arbitrary
 -- 'MonadPlus'.
 catMaybesMP :: MonadPlus m => m (Maybe a) -> m a
-catMaybesMP = (>>= fromMaybeMP)
+catMaybesMP = scatterMP
+
+-- | Branch over elements of a monadic 'Foldable' data structure.
+scatterMP :: (MonadPlus m, Foldable t) => m (t a) -> m a
+scatterMP = (>>= foldA)
+
 
 -- Error monad ------------------------------------------------------------
 

--- a/test/Fail/ConfluenceNestedOverlap.err
+++ b/test/Fail/ConfluenceNestedOverlap.err
@@ -1,6 +1,8 @@
 ConfluenceNestedOverlap.agda:17,13-17
-Confluence check failed: f (g a) reduces to both c and f a
-which are not equal because c != b of type A
+Global confluence check failed: f (g a) can be rewritten to either
+c or f a.
+Possible fix: add a rewrite rule with left-hand side f (g a) to
+resolve the ambiguity.
 when checking confluence of the rewrite rule rew₂ with rew₃
 ConfluenceNestedOverlap.agda:26,9-13
 b != c of type A

--- a/test/Fail/ConstructorRewriteConfluenceFail.err
+++ b/test/Fail/ConstructorRewriteConfluenceFail.err
@@ -1,12 +1,14 @@
 ConstructorRewriteConfluenceFail.agda:31,1-10
-Confluence check failed: count-suc (pred (suc x)) reduces to both
-count-suc (suc x) and count-suc x which are not equal because
-suc (count-suc x) != count-suc x of type ℕ
+Global confluence check failed: count-suc (pred (suc x)) can be
+rewritten to either count-suc (suc x) or count-suc x.
+Possible fix: add a rewrite rule with left-hand side
+count-suc (pred (suc x)) to resolve the ambiguity.
 when checking confluence of the rewrite rule
 ConstructorRewriteConfluenceFail.count-suc-clause1 with pred-suc
 ConstructorRewriteConfluenceFail.agda:31,1-10
-Confluence check failed: count-suc (suc (pred x)) reduces to both
-1 +ℕ count-suc (pred x) and count-suc x which are not equal because
-suc (count-suc x) != count-suc x of type ℕ
+Global confluence check failed: count-suc (suc (pred x)) can be
+rewritten to either 1 +ℕ count-suc (pred x) or count-suc x.
+Possible fix: add a rewrite rule with left-hand side
+count-suc (suc (pred x)) to resolve the ambiguity.
 when checking confluence of the rewrite rule
 ConstructorRewriteConfluenceFail.count-suc-clause2 with suc-pred

--- a/test/Fail/Issue1445-2.err
+++ b/test/Fail/Issue1445-2.err
@@ -1,5 +1,7 @@
 Issue1445-2.agda:26,15-16
-Confluence check failed: block unit false reduces to both true and
-false which are not equal because true != false of type Bool
+Global confluence check failed: block unit false can be rewritten
+to either true or false.
+Possible fix: add a rewrite rule with left-hand side
+block unit false to resolve the ambiguity.
 when checking confluence of the rewrite rule r with
 Issue1445-2.block-clause1

--- a/test/Fail/Issue1445-3.err
+++ b/test/Fail/Issue1445-3.err
@@ -1,5 +1,7 @@
 Issue1445-3.agda:19,13-16
-Confluence check failed: Bar unit reduces to both Unit and Foo y
-which are not equal because Unit != Foo y of type Set
+Global confluence check failed: Bar unit y can be rewritten to
+either Unit or Foo y.
+Possible fix: add a rewrite rule with left-hand side Bar unit y to
+resolve the ambiguity.
 when checking confluence of the rewrite rule bar with
 Issue1445-3.Bar-clause1

--- a/test/Fail/Issue2573-confluence.err
+++ b/test/Fail/Issue2573-confluence.err
@@ -1,5 +1,7 @@
 Issue2573-confluence.agda:21,15-18
-Confluence check failed: op true A reduces to both Bool and A
-which are not equal because Bool != A of type Set
+Global confluence check failed: op true A can be rewritten to
+either Bool or A.
+Possible fix: add a rewrite rule with left-hand side op true A to
+resolve the ambiguity.
 when checking confluence of the rewrite rule law with
 Issue2573-confluence.op-clause2

--- a/test/Fail/Issue3538-2-record.err
+++ b/test/Fail/Issue3538-2-record.err
@@ -1,6 +1,7 @@
 Issue3538-2-record.agda:19,13-16
-Confluence check failed: unD (c ((_ : Nat) → Nat)) reduces to both
-(_ : Nat) → Nat and Nat → Bool which are not equal because
-Nat != Bool
+Global confluence check failed: unD (c ((_ : Nat) → Nat)) can be
+rewritten to either (_ : Nat) → Nat or Nat → Bool.
+Possible fix: add a rewrite rule with left-hand side
+unD (c ((_ : Nat) → Nat)) to resolve the ambiguity.
 when checking confluence of the rewrite rule
 Issue3538-2-record.R.unD-clause1 with rew

--- a/test/Fail/Issue3538-2.err
+++ b/test/Fail/Issue3538-2.err
@@ -1,6 +1,7 @@
 Issue3538-2.agda:19,13-16
-Confluence check failed: unD (c ((_ : Nat) → Nat)) reduces to both
-(_ : Nat) → Nat and unD (c (Nat → Bool))
-which are not equal because Nat != Bool
+Global confluence check failed: unD (c ((_ : Nat) → Nat)) can be
+rewritten to either (_ : Nat) → Nat or unD (c (Nat → Bool)).
+Possible fix: add a rewrite rule with left-hand side
+unD (c ((_ : Nat) → Nat)) to resolve the ambiguity.
 when checking confluence of the rewrite rule
 Issue3538-2.unD-clause1 with rew

--- a/test/Fail/Issue3810a.err
+++ b/test/Fail/Issue3810a.err
@@ -1,4 +1,6 @@
-Issue3810a.agda:14,13-17
-Confluence check failed: f a reduces to both a and b
-which are not equal because a != b of type A
-when checking confluence of the rewrite rule rew₂ with rew₁
+Issue3810a.agda:14,1-21
+Global confluence check failed: f a unfolds to b which should
+further unfold to a but it does not.
+Possible fix: add a rule to rewrite b to a, or change the order of
+the rules so more specialized rules come later.
+when checking the pragma REWRITE rew₂

--- a/test/Fail/Issue3810b.err
+++ b/test/Fail/Issue3810b.err
@@ -1,7 +1,8 @@
 Issue3810b.agda:25,13-18
-Confluence check failed: f ((x : A) → A) (g ((x : A) → A))
-reduces to both b and f ((x : A) → A) (λ x → a)
-which are not equal because b != a of type A
+Global confluence check failed: f ((x : A) → A) (g ((x : A) → A))
+can be rewritten to either b or f ((x : A) → A) (λ x → a).
+Possible fix: add a rewrite rule with left-hand side
+f ((x : A) → A) (g ((x : A) → A)) to resolve the ambiguity.
 when checking confluence of the rewrite rule rewf₂ with rewg
 Issue3810b.agda:31,9-13
 a != b of type A

--- a/test/Fail/Issue3810c.err
+++ b/test/Fail/Issue3810c.err
@@ -1,6 +1,8 @@
 Issue3810c.agda:34,13-18
-Confluence check failed: f (Box A) (g (Box A)) reduces to both b
-and f (Box A) (box a) which are not equal because b != a of type A
+Global confluence check failed: f (Box A) (g (Box A)) can be
+rewritten to either b or f (Box A) (box a).
+Possible fix: add a rewrite rule with left-hand side
+f (Box A) (g (Box A)) to resolve the ambiguity.
 when checking confluence of the rewrite rule rewf₂ with rewg
 Issue3810c.agda:40,9-13
 a != b of type A

--- a/test/Fail/Issue3816.err
+++ b/test/Fail/Issue3816.err
@@ -1,4 +1,6 @@
-Issue3816.agda:17,25-29
-Confluence check failed: f g reduces to both a and f (λ _ → a)
-which are not equal because a != b of type A
-when checking confluence of the rewrite rule rewf₁ with rewg
+Issue3816.agda:17,1-33
+Global confluence check failed: f (λ z → g z) unfolds to
+f (λ _ → a) which should further unfold to a but it does not.
+Possible fix: add a rule to rewrite f (λ _ → a) to a, or change the
+order of the rules so more specialized rules come later.
+when checking the pragma REWRITE rewf₁ rewf₂ rewg

--- a/test/Fail/Issue3817.err
+++ b/test/Fail/Issue3817.err
@@ -1,4 +1,6 @@
-Issue3817.agda:16,21-24
-Confluence check failed: f (lsuc g) reduces to both a and
-f (lsuc h) which are not equal because a != b of type A
-when checking confluence of the rewrite rule f-g with g-h
+Issue3817.agda:16,1-28
+Global confluence check failed: f (lsuc g) unfolds to f (lsuc h)
+which should further unfold to a but it does not.
+Possible fix: add a rule to rewrite f (lsuc h) to a, or change the
+order of the rules so more specialized rules come later.
+when checking the pragma REWRITE f-g f-h g-h

--- a/test/Fail/Issue3848.err
+++ b/test/Fail/Issue3848.err
@@ -1,9 +1,12 @@
-Issue3848.agda:19,13-17
-Confluence check failed: f (c f₁) reduces to both f₁ and f r
-which are not equal because f₁ != f r of type A
-when checking confluence of the rewrite rule Issue3848.R.f-clause1
-with rew₁
-Issue3848.agda:30,13-17
-Confluence check failed: g (f r) reduces to both a and g a
-which are not equal because a != g a of type A
-when checking confluence of the rewrite rule rew₂ with rew₃
+Issue3848.agda:19,1-21
+Global confluence check failed: f (c f₁) unfolds to f r which
+should further unfold to f₁ but it does not.
+Possible fix: add a rule to rewrite f r to f₁, or change the order
+of the rules so more specialized rules come later.
+when checking the pragma REWRITE rew₁
+Issue3848.agda:30,1-21
+Global confluence check failed: g (f r) unfolds to g a which should
+further unfold to a but it does not.
+Possible fix: add a rule to rewrite g a to a, or change the order
+of the rules so more specialized rules come later.
+when checking the pragma REWRITE rew₃

--- a/test/Fail/Issue4147.err
+++ b/test/Fail/Issue4147.err
@@ -1,5 +1,12 @@
-Issue4147.agda:21,17-18
-Confluence check failed: A reduces to both ⊤ and ⊥
-which are not equal because ⊤ != ⊥ of type Set
-when checking confluence of the rewrite rule q with
-Issue4147.Test.A-clause1
+Issue4147.agda:21,5-22
+Global confluence check failed: A unfolds to ⊤ which should further
+unfold to ⊥ but it does not.
+Possible fix: add a rule to rewrite ⊤ to ⊥, or change the order of
+the rules so more specialized rules come later.
+when checking the pragma REWRITE q
+Issue4147.agda:21,5-22
+Global confluence check failed: A unfolds to ⊤ which should further
+unfold to ⊥ but it does not.
+Possible fix: add a rule to rewrite ⊤ to ⊥, or change the order of
+the rules so more specialized rules come later.
+when checking the pragma REWRITE q

--- a/test/Fail/RewriteExt-confluence.err
+++ b/test/Fail/RewriteExt-confluence.err
@@ -1,5 +1,7 @@
 RewriteExt-confluence.agda:32,17-21
-Confluence check failed: id unit x (f x) reduces to both g x and
-f x which are not equal because g x != f x of type B x
+Global confluence check failed: id unit x (f x) can be rewritten to
+either g x or f x.
+Possible fix: add a rewrite rule with left-hand side
+id unit x (f x) to resolve the ambiguity.
 when checking confluence of the rewrite rule f≡g′ with
 RewriteExt-confluence.id-clause1

--- a/test/Fail/RewritingNonConfluent1.err
+++ b/test/Fail/RewritingNonConfluent1.err
@@ -1,18 +1,59 @@
+RewritingNonConfluent1.agda:22,13-19
+Global confluence check failed: max (suc m) (suc m) can be
+rewritten to either suc (max m m) or suc m.
+Possible fix: add a rewrite rule with left-hand side
+max (suc m) (suc m) to resolve the ambiguity.
+when checking confluence of the rewrite rule max-ss with max-diag
 RewritingNonConfluent1.agda:23,13-22
-Confluence check failed: max (max k l) (max k l) reduces to both
-max k (max l (max k l)) and max k l which are not equal because
-max l (max k l) != l of type Nat
+Global confluence check failed: max (max k l) (max k l) can be
+rewritten to either max k (max l (max k l)) or max k l.
+Possible fix: add a rewrite rule with left-hand side
+max (max k l) (max k l) to resolve the ambiguity.
 when checking confluence of the rewrite rule max-assoc with
 max-diag
 RewritingNonConfluent1.agda:23,13-22
-Confluence check failed: max (max (suc m) (suc n)) m₁
-reduces to both max (suc m) (max (suc n) m₁) and
-max (suc (max m n)) m₁ which are not equal because
-m != max m n of type Nat
+Global confluence check failed: max (max k l) 0 can be rewritten to
+either max k (max l 0) or max k l.
+Possible fix: add a rewrite rule with left-hand side
+max (max k l) 0 to resolve the ambiguity.
+when checking confluence of the rewrite rule max-assoc with max-0r
+RewritingNonConfluent1.agda:23,13-22
+Global confluence check failed: max (max (max k l) l₁) m can be
+rewritten to either max (max k l) (max l₁ m) or
+max (max k (max l l₁)) m.
+Possible fix: add a rewrite rule with left-hand side
+max (max (max k l) l₁) m to resolve the ambiguity.
+when checking confluence of the rewrite rule max-assoc with itself
+RewritingNonConfluent1.agda:23,13-22
+Global confluence check failed: max (max (suc m) (suc n)) m₁ can be
+rewritten to either max (suc m) (max (suc n) m₁) or
+max (suc (max m n)) m₁.
+Possible fix: add a rewrite rule with left-hand side
+max (max (suc m) (suc n)) m₁ to resolve the ambiguity.
 when checking confluence of the rewrite rule max-assoc with max-ss
 RewritingNonConfluent1.agda:23,13-22
-Confluence check failed: max (max k k) m reduces to both
-max k (max k m) and max k m which are not equal because
-max k m != m of type Nat
+Global confluence check failed: max (max k k) m can be rewritten to
+either max k (max k m) or max k m.
+Possible fix: add a rewrite rule with left-hand side
+max (max k k) m to resolve the ambiguity.
 when checking confluence of the rewrite rule max-assoc with
 max-diag
+RewritingNonConfluent1.agda:23,13-22
+Global confluence check failed: max (max k 0) m can be rewritten to
+either max k (max 0 m) or max k m.
+Possible fix: add a rewrite rule with left-hand side
+max (max k 0) m to resolve the ambiguity.
+when checking confluence of the rewrite rule max-assoc with max-0r
+RewritingNonConfluent1.agda:23,13-22
+Global confluence check failed: max (max 0 l) m can be rewritten to
+either max 0 (max l m) or max l m.
+Possible fix: add a rewrite rule with left-hand side
+max (max 0 l) m to resolve the ambiguity.
+when checking confluence of the rewrite rule max-assoc with max-0l
+RewritingNonConfluent1.agda:23,13-22
+Global confluence check failed: max (max (max k l) l₁) m can be
+rewritten to either max (max k l) (max l₁ m) or
+max (max k (max l l₁)) m.
+Possible fix: add a rewrite rule with left-hand side
+max (max (max k l) l₁) m to resolve the ambiguity.
+when checking confluence of the rewrite rule max-assoc with itself

--- a/test/Fail/RewritingNonConfluent2.err
+++ b/test/Fail/RewritingNonConfluent2.err
@@ -1,6 +1,42 @@
+RewritingNonConfluent2.agda:20,13-23
+Global confluence check failed: suc m + 0 can be rewritten to
+either suc (m + 0) or suc m.
+Possible fix: add a rewrite rule with left-hand side suc m + 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-l with
+plus-0r
+RewritingNonConfluent2.agda:21,13-23
+Global confluence check failed: suc m + suc n can be rewritten to
+either suc (suc m + n) or suc (m + suc n).
+Possible fix: add a rewrite rule with left-hand side suc m + suc n
+to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-r with
+plus-suc-l
+RewritingNonConfluent2.agda:21,13-23
+Global confluence check failed: 0 + suc n can be rewritten to
+either suc (0 + n) or suc n.
+Possible fix: add a rewrite rule with left-hand side 0 + suc n to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-r with
+plus-0l
+RewritingNonConfluent2.agda:36,13-23
+Global confluence check failed: suc m * 0 can be rewritten to
+either 0 + (m * 0) or 0.
+Possible fix: add a rewrite rule with left-hand side suc m * 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule mult-suc-l with
+mult-0r
 RewritingNonConfluent2.agda:37,13-23
-Confluence check failed: suc m * suc n reduces to both
-(suc m * n) + suc m and suc n + (m * suc n)
-which are not equal because n + (m * n) != n of type Nat
+Global confluence check failed: suc m * suc n can be rewritten to
+either (suc m * n) + suc m or suc n + (m * suc n).
+Possible fix: add a rewrite rule with left-hand side suc m * suc n
+to resolve the ambiguity.
 when checking confluence of the rewrite rule mult-suc-r with
 mult-suc-l
+RewritingNonConfluent2.agda:37,13-23
+Global confluence check failed: 0 * suc n can be rewritten to
+either (0 * n) + 0 or 0.
+Possible fix: add a rewrite rule with left-hand side 0 * suc n to
+resolve the ambiguity.
+when checking confluence of the rewrite rule mult-suc-r with
+mult-0l

--- a/test/Fail/RewritingNonConfluent3.err
+++ b/test/Fail/RewritingNonConfluent3.err
@@ -1,12 +1,145 @@
+RewritingNonConfluent3.agda:20,13-23
+Global confluence check failed: suc m + 0 can be rewritten to
+either suc (m + 0) or suc m.
+Possible fix: add a rewrite rule with left-hand side suc m + 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-l with
+plus-0r
+RewritingNonConfluent3.agda:21,13-23
+Global confluence check failed: suc m + suc n can be rewritten to
+either suc (suc m + n) or suc (m + suc n).
+Possible fix: add a rewrite rule with left-hand side suc m + suc n
+to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-r with
+plus-suc-l
+RewritingNonConfluent3.agda:21,13-23
+Global confluence check failed: 0 + suc n can be rewritten to
+either suc (0 + n) or suc n.
+Possible fix: add a rewrite rule with left-hand side 0 + suc n to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-r with
+plus-0l
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: (k + l) + suc n can be rewritten to
+either k + (l + suc n) or suc ((k + l) + n).
+Possible fix: add a rewrite rule with left-hand side
+(k + l) + suc n to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-r
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: (k + l) + 0 can be rewritten to
+either k + (l + 0) or k + l.
+Possible fix: add a rewrite rule with left-hand side (k + l) + 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-0r
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: ((k + l) + l₁) + m can be rewritten
+to either (k + l) + (l₁ + m) or (k + (l + l₁)) + m.
+Possible fix: add a rewrite rule with left-hand side
+((k + l) + l₁) + m to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with itself
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: (k + suc n) + m can be rewritten to
+either k + (suc n + m) or suc (k + n) + m.
+Possible fix: add a rewrite rule with left-hand side
+(k + suc n) + m to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-r
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: (suc m + l) + m₁ can be rewritten
+to either suc m + (l + m₁) or suc (m + l) + m₁.
+Possible fix: add a rewrite rule with left-hand side
+(suc m + l) + m₁ to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-l
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: (k + 0) + m can be rewritten to
+either k + (0 + m) or k + m.
+Possible fix: add a rewrite rule with left-hand side (k + 0) + m to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-0r
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: (0 + l) + m can be rewritten to
+either 0 + (l + m) or l + m.
+Possible fix: add a rewrite rule with left-hand side (0 + l) + m to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-0l
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: ((k + l) + l₁) + m can be rewritten
+to either (k + l) + (l₁ + m) or (k + (l + l₁)) + m.
+Possible fix: add a rewrite rule with left-hand side
+((k + l) + l₁) + m to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with itself
+RewritingNonConfluent3.agda:36,13-23
+Global confluence check failed: suc m * 0 can be rewritten to
+either 0 + (m * 0) or 0.
+Possible fix: add a rewrite rule with left-hand side suc m * 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule mult-suc-l with
+mult-0r
+RewritingNonConfluent3.agda:37,13-23
+Global confluence check failed: suc m * suc n can be rewritten to
+either (suc m * n) + suc m or suc n + (m * suc n).
+Possible fix: add a rewrite rule with left-hand side suc m * suc n
+to resolve the ambiguity.
+when checking confluence of the rewrite rule mult-suc-r with
+mult-suc-l
+RewritingNonConfluent3.agda:37,13-23
+Global confluence check failed: 0 * suc n can be rewritten to
+either (0 * n) + 0 or 0.
+Possible fix: add a rewrite rule with left-hand side 0 * suc n to
+resolve the ambiguity.
+when checking confluence of the rewrite rule mult-suc-r with
+mult-0l
 RewritingNonConfluent3.agda:38,13-30
-Confluence check failed: suc m * (l + m₁) reduces to both
-(suc m * l) + (suc m * m₁) and (l + m₁) + (m * (l + m₁))
-which are not equal because m * l != m₁ of type Nat
+Global confluence check failed: suc m * (l + m₁) can be rewritten
+to either (suc m * l) + (suc m * m₁) or (l + m₁) + (m * (l + m₁)).
+Possible fix: add a rewrite rule with left-hand side
+suc m * (l + m₁) to resolve the ambiguity.
 when checking confluence of the rewrite rule plus-mult-distr-l with
 mult-suc-l
 RewritingNonConfluent3.agda:38,13-30
-Confluence check failed: k * (suc m + m₁) reduces to both
-(k * suc m) + (k * m₁) and k * suc (m + m₁)
-which are not equal because k != k * m of type Nat
+Global confluence check failed: 0 * (l + m) can be rewritten to
+either (0 * l) + (0 * m) or 0.
+Possible fix: add a rewrite rule with left-hand side 0 * (l + m) to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-mult-distr-l with
+mult-0l
+RewritingNonConfluent3.agda:38,13-30
+Global confluence check failed: k * ((k₁ + l) + m) can be rewritten
+to either (k * (k₁ + l)) + (k * m) or k * (k₁ + (l + m)).
+Possible fix: add a rewrite rule with left-hand side
+k * ((k₁ + l) + m) to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-mult-distr-l with
+plus-assoc
+RewritingNonConfluent3.agda:38,13-30
+Global confluence check failed: k * (l + suc n) can be rewritten to
+either (k * l) + (k * suc n) or k * suc (l + n).
+Possible fix: add a rewrite rule with left-hand side
+k * (l + suc n) to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-mult-distr-l with
+plus-suc-r
+RewritingNonConfluent3.agda:38,13-30
+Global confluence check failed: k * (suc m + m₁) can be rewritten
+to either (k * suc m) + (k * m₁) or k * suc (m + m₁).
+Possible fix: add a rewrite rule with left-hand side
+k * (suc m + m₁) to resolve the ambiguity.
 when checking confluence of the rewrite rule plus-mult-distr-l with
 plus-suc-l
+RewritingNonConfluent3.agda:38,13-30
+Global confluence check failed: k * (l + 0) can be rewritten to
+either (k * l) + (k * 0) or k * l.
+Possible fix: add a rewrite rule with left-hand side k * (l + 0) to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-mult-distr-l with
+plus-0r
+RewritingNonConfluent3.agda:38,13-30
+Global confluence check failed: k * (0 + m) can be rewritten to
+either (k * 0) + (k * m) or k * m.
+Possible fix: add a rewrite rule with left-hand side k * (0 + m) to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-mult-distr-l with
+plus-0l

--- a/test/Fail/RewritingNonConfluent4.err
+++ b/test/Fail/RewritingNonConfluent4.err
@@ -1,19 +1,150 @@
+RewritingNonConfluent4.agda:20,13-23
+Global confluence check failed: suc m + 0 can be rewritten to
+either suc (m + 0) or suc m.
+Possible fix: add a rewrite rule with left-hand side suc m + 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-l with
+plus-0r
+RewritingNonConfluent4.agda:21,13-23
+Global confluence check failed: suc m + suc n can be rewritten to
+either suc (suc m + n) or suc (m + suc n).
+Possible fix: add a rewrite rule with left-hand side suc m + suc n
+to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-r with
+plus-suc-l
+RewritingNonConfluent4.agda:21,13-23
+Global confluence check failed: 0 + suc n can be rewritten to
+either suc (0 + n) or suc n.
+Possible fix: add a rewrite rule with left-hand side 0 + suc n to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-r with
+plus-0l
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: (k + l) + suc n can be rewritten to
+either k + (l + suc n) or suc ((k + l) + n).
+Possible fix: add a rewrite rule with left-hand side
+(k + l) + suc n to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-r
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: (k + l) + 0 can be rewritten to
+either k + (l + 0) or k + l.
+Possible fix: add a rewrite rule with left-hand side (k + l) + 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-0r
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: ((k + l) + l₁) + m can be rewritten
+to either (k + l) + (l₁ + m) or (k + (l + l₁)) + m.
+Possible fix: add a rewrite rule with left-hand side
+((k + l) + l₁) + m to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with itself
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: (k + suc n) + m can be rewritten to
+either k + (suc n + m) or suc (k + n) + m.
+Possible fix: add a rewrite rule with left-hand side
+(k + suc n) + m to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-r
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: (suc m + l) + m₁ can be rewritten
+to either suc m + (l + m₁) or suc (m + l) + m₁.
+Possible fix: add a rewrite rule with left-hand side
+(suc m + l) + m₁ to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-l
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: (k + 0) + m can be rewritten to
+either k + (0 + m) or k + m.
+Possible fix: add a rewrite rule with left-hand side (k + 0) + m to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-0r
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: (0 + l) + m can be rewritten to
+either 0 + (l + m) or l + m.
+Possible fix: add a rewrite rule with left-hand side (0 + l) + m to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-0l
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: ((k + l) + l₁) + m can be rewritten
+to either (k + l) + (l₁ + m) or (k + (l + l₁)) + m.
+Possible fix: add a rewrite rule with left-hand side
+((k + l) + l₁) + m to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with itself
+RewritingNonConfluent4.agda:36,13-23
+Global confluence check failed: suc m * 0 can be rewritten to
+either 0 + (m * 0) or 0.
+Possible fix: add a rewrite rule with left-hand side suc m * 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule mult-suc-l with
+mult-0r
+RewritingNonConfluent4.agda:37,13-23
+Global confluence check failed: suc m * suc n can be rewritten to
+either (suc m * n) + suc m or suc n + (m * suc n).
+Possible fix: add a rewrite rule with left-hand side suc m * suc n
+to resolve the ambiguity.
+when checking confluence of the rewrite rule mult-suc-r with
+mult-suc-l
+RewritingNonConfluent4.agda:37,13-23
+Global confluence check failed: 0 * suc n can be rewritten to
+either (0 * n) + 0 or 0.
+Possible fix: add a rewrite rule with left-hand side 0 * suc n to
+resolve the ambiguity.
+when checking confluence of the rewrite rule mult-suc-r with
+mult-0l
 RewritingNonConfluent4.agda:38,13-23
-Confluence check failed: (k * l) * suc n reduces to both
-k * (l * suc n) and ((k * l) * n) + (k * l)
-which are not equal because
-k * (l * suc n) != ((k * l) * n) + (k * l) of type Nat
+Global confluence check failed: (k * l) * suc n can be rewritten to
+either k * (l * suc n) or ((k * l) * n) + (k * l).
+Possible fix: add a rewrite rule with left-hand side
+(k * l) * suc n to resolve the ambiguity.
 when checking confluence of the rewrite rule mult-assoc with
 mult-suc-r
 RewritingNonConfluent4.agda:38,13-23
-Confluence check failed: (k * suc n) * m reduces to both
-k * (suc n * m) and ((k * n) + k) * m which are not equal because
-k != (k * n) + k of type Nat
+Global confluence check failed: (k * l) * 0 can be rewritten to
+either k * (l * 0) or 0.
+Possible fix: add a rewrite rule with left-hand side (k * l) * 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule mult-assoc with
+mult-0r
+RewritingNonConfluent4.agda:38,13-23
+Global confluence check failed: ((k * l) * l₁) * m can be rewritten
+to either (k * l) * (l₁ * m) or (k * (l * l₁)) * m.
+Possible fix: add a rewrite rule with left-hand side
+((k * l) * l₁) * m to resolve the ambiguity.
+when checking confluence of the rewrite rule mult-assoc with itself
+RewritingNonConfluent4.agda:38,13-23
+Global confluence check failed: (k * suc n) * m can be rewritten to
+either k * (suc n * m) or ((k * n) + k) * m.
+Possible fix: add a rewrite rule with left-hand side
+(k * suc n) * m to resolve the ambiguity.
 when checking confluence of the rewrite rule mult-assoc with
 mult-suc-r
 RewritingNonConfluent4.agda:38,13-23
-Confluence check failed: (suc m * l) * m₁ reduces to both
-suc m * (l * m₁) and (l + (m * l)) * m₁ which are not equal because
-(l * m) + (m₁ * (l * m)) != (l + (m₁ * l)) * m of type Nat
+Global confluence check failed: (suc m * l) * m₁ can be rewritten
+to either suc m * (l * m₁) or (l + (m * l)) * m₁.
+Possible fix: add a rewrite rule with left-hand side
+(suc m * l) * m₁ to resolve the ambiguity.
 when checking confluence of the rewrite rule mult-assoc with
 mult-suc-l
+RewritingNonConfluent4.agda:38,13-23
+Global confluence check failed: (k * 0) * m can be rewritten to
+either k * (0 * m) or 0 * m.
+Possible fix: add a rewrite rule with left-hand side (k * 0) * m to
+resolve the ambiguity.
+when checking confluence of the rewrite rule mult-assoc with
+mult-0r
+RewritingNonConfluent4.agda:38,13-23
+Global confluence check failed: (0 * l) * m can be rewritten to
+either 0 * (l * m) or 0 * m.
+Possible fix: add a rewrite rule with left-hand side (0 * l) * m to
+resolve the ambiguity.
+when checking confluence of the rewrite rule mult-assoc with
+mult-0l
+RewritingNonConfluent4.agda:38,13-23
+Global confluence check failed: ((k * l) * l₁) * m can be rewritten
+to either (k * l) * (l₁ * m) or (k * (l * l₁)) * m.
+Possible fix: add a rewrite rule with left-hand side
+((k * l) * l₁) * m to resolve the ambiguity.
+when checking confluence of the rewrite rule mult-assoc with itself

--- a/test/Succeed/ConstructorRewriteConfluence.agda
+++ b/test/Succeed/ConstructorRewriteConfluence.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --prop --rewriting --confluence-check #-}
+{-# OPTIONS --prop --rewriting --local-confluence-check #-}
 
 open import Agda.Primitive
 open import Agda.Builtin.Equality

--- a/test/Succeed/Issue1550.agda
+++ b/test/Succeed/Issue1550.agda
@@ -1,6 +1,6 @@
 -- Andreas, 2015-08-27 Allow rewrite rules for symbols defined in other file
 
-{-# OPTIONS --rewriting --confluence-check #-}
+{-# OPTIONS --rewriting --local-confluence-check #-}
 
 open import Common.Nat
 open import Common.Equality

--- a/test/Succeed/Issue1553.agda
+++ b/test/Succeed/Issue1553.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --rewriting --confluence-check #-}
+{-# OPTIONS --rewriting --local-confluence-check #-}
 
 --{-# OPTIONS -v rewriting:100 #-}
 

--- a/test/Succeed/Issue1652-2.agda
+++ b/test/Succeed/Issue1652-2.agda
@@ -1,6 +1,6 @@
 {- Example by Andreas (2015-09-18) -}
 
-{-# OPTIONS --rewriting --confluence-check #-}
+{-# OPTIONS --rewriting --local-confluence-check #-}
 
 open import Common.Prelude
 open import Common.Equality

--- a/test/Succeed/Issue1997.agda
+++ b/test/Succeed/Issue1997.agda
@@ -1,6 +1,6 @@
 -- Andreas, 2016-06-01, issue 1997 reported by Andres
 
-{-# OPTIONS --rewriting --confluence-check #-}
+{-# OPTIONS --rewriting --local-confluence-check #-}
 
 infix  4 _≡_
 infixl 6 _+_

--- a/test/Succeed/Issue2328.agda
+++ b/test/Succeed/Issue2328.agda
@@ -1,6 +1,6 @@
 {- Examples by Twan van Laarhoven -}
 
-{-# OPTIONS --rewriting --confluence-check #-}
+{-# OPTIONS --rewriting --local-confluence-check #-}
 module _ where
 
 open import Agda.Builtin.Equality

--- a/test/Succeed/Issue4383.agda
+++ b/test/Succeed/Issue4383.agda
@@ -1,5 +1,5 @@
-{-# OPTIONS --rewriting        #-}
-{-# OPTIONS --confluence-check #-}
+{-# OPTIONS --rewriting              #-}
+{-# OPTIONS --local-confluence-check #-}
 
 open import Agda.Builtin.Equality
 open import Agda.Builtin.Equality.Rewrite

--- a/test/Succeed/NewEquations.agda
+++ b/test/Succeed/NewEquations.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --rewriting --confluence-check #-}
+{-# OPTIONS --rewriting --local-confluence-check #-}
 
 module NewEquations where
 

--- a/test/Succeed/RewritingBlocked.agda
+++ b/test/Succeed/RewritingBlocked.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --rewriting --confluence-check #-}
+{-# OPTIONS --rewriting --local-confluence-check #-}
 
 -- {-# OPTIONS -v rewriting:100 -v tc.conv.atom:30 -v tc.inj.use:30 #-}
 

--- a/test/Succeed/RewritingGlobalConfluence.agda
+++ b/test/Succeed/RewritingGlobalConfluence.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --rewriting --local-confluence-check #-}
+{-# OPTIONS --rewriting --confluence-check #-}
 
 open import Agda.Builtin.Nat using (Nat; zero; suc)
 open import Agda.Builtin.Equality
@@ -13,42 +13,45 @@ postulate
   max-0r : max m 0 ≡ m
   max-diag : max m m ≡ m
   max-ss : max (suc m) (suc n) ≡ suc (max m n)
+  max-diag-s : max (suc m) (suc m) ≡ suc m -- for global confluence
   max-assoc : max (max k l) m ≡ max k (max l m)
 
-{-# REWRITE max-0l #-}
-{-# REWRITE max-0r #-}
-{-# REWRITE max-diag #-}
-{-# REWRITE max-ss #-}
+{-# REWRITE max-0l max-0r #-}
+{-# REWRITE max-ss max-diag max-diag-s #-}
 --{-# REWRITE max-assoc #-} -- not confluent!
 
 postulate
   _+_ : Nat → Nat → Nat
   plus-0l : 0 + n ≡ n
   plus-0r : m + 0 ≡ m
+  plus-00 : 0 + 0 ≡ 0  -- for global confluence
   plus-suc-l : (suc m) + n ≡ suc (m + n)
+  plus-suc-0 : (suc m) + 0 ≡ suc m -- for global confluence
   plus-suc-r : m + (suc n) ≡ suc (m + n)
-  plus-assoc : (k + l) + m ≡ k + (l + m)
+  plus-0-suc : 0 + (suc n) ≡ suc n
+  plus-suc-suc : (suc m) + (suc n) ≡ suc (suc (m + n))
+  plus-assoc : (k + l) + m ≡ k + (l + m) -- not accepted by global confluence check
 
-{-# REWRITE plus-0l #-}
-{-# REWRITE plus-0r #-}
-{-# REWRITE plus-suc-l #-}
-{-# REWRITE plus-suc-r #-}
-{-# REWRITE plus-assoc #-}
+{-# REWRITE plus-00 plus-0l plus-0r
+            plus-suc-l plus-suc-0
+            plus-suc-r plus-0-suc
+            plus-suc-suc #-}
 
 postulate
   _*_ : Nat → Nat → Nat
   mult-0l : 0 * n ≡ 0
   mult-0r : m * 0 ≡ 0
+  mult-00 : 0 * 0 ≡ 0
   mult-suc-l : (suc m) * n ≡ n + (m * n)
+  mult-suc-l-0 : (suc m) * 0 ≡ 0
   mult-suc-r : m * (suc n) ≡ (m * n) + m
   plus-mult-distr-l : k * (l + m) ≡ (k * l) + (k * m)
   plus-mult-distr-r : (k + l) * m ≡ (k * m) + (l * m)
   mult-assoc : (k * l) * m ≡ k * (l * m)
 
-{-# REWRITE mult-0l #-}
-{-# REWRITE mult-0r #-}
-{-# REWRITE mult-suc-l #-}
-{-# REWRITE mult-suc-r #-} -- requires rule plus-assoc!
+{-# REWRITE mult-0l mult-0r mult-00
+            mult-suc-l mult-suc-l-0 #-}
+--{-# REWRITE mult-suc-r #-} -- requires rule plus-assoc!
 --{-# REWRITE plus-mult-distr-l #-}
 --{-# REWRITE plus-mult-distr-r #-}
 --{-# REWRITE mult-assoc #-}

--- a/test/Succeed/RewritingNat.agda
+++ b/test/Succeed/RewritingNat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --rewriting --confluence-check #-}
+{-# OPTIONS --rewriting --local-confluence-check #-}
 
 module RewritingNat where
 

--- a/test/interaction/Issue4038.agda
+++ b/test/interaction/Issue4038.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --confluence-check #-}
+{-# OPTIONS --without-K --rewriting --local-confluence-check #-}
 
 open import Agda.Primitive using (Level; _⊔_; Setω; lzero; lsuc)
 

--- a/test/interaction/Issue4333.out
+++ b/test/interaction/Issue4333.out
@@ -3,8 +3,20 @@ Checking Issue4333.N0 (Issue4333/N0.agda).
 Checking Issue4333.N1 (Issue4333/N1.agda).
 Checking Issue4333.N (Issue4333/N.agda).
 Issue4333/N.agda:6,1-25
-Confluence check failed: Issue4333.M.a reduces to both
-Issue4333.M.a₁' and Issue4333.M.a₀' which are not equal because
-Issue4333.M.a₁' != Issue4333.M.a₀' of type Issue4333.M.A
-when checking confluence of the rewrite rule Issue4333.M.p₁ with
-Issue4333.M.p₀
+Global confluence check failed: Issue4333.M.a unfolds to
+Issue4333.M.a₁' which should further unfold to Issue4333.M.a₀' but
+it does not.
+Possible fix: add a rule to rewrite Issue4333.M.a₁' to
+Issue4333.M.a₀', or change the order of the rules so more
+specialized rules come later.
+when scope checking the declaration
+open import Issue4333.N1
+Issue4333/N.agda:6,1-25
+Global confluence check failed: Issue4333.M.a unfolds to
+Issue4333.M.a₁' which should further unfold to Issue4333.M.a₀' but
+it does not.
+Possible fix: add a rule to rewrite Issue4333.M.a₁' to
+Issue4333.M.a₀', or change the order of the rules so more
+specialized rules come later.
+when scope checking the declaration
+open import Issue4333.N1


### PR DESCRIPTION
This PR implements a chek for *global* confluence of `REWRITE` rules in Agda. This should ensure that rewrite rules preserve subject reduction of Agda, even in the presence of potentially non-terminating rewrite rules. This is important because termination checking algorithms often rely on well-typedness, so they cannot be used when subject reduction is in danger. The previous behaviour of the `--confluence-check` flag has been kept under the new `--local-confluence-check` flag. 

Please see the changelog and the documentation for more information about how the new check works.