### PR TITLE
`[ci skip]` and `[skip ci]` instructions for Github Workflows

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -18,6 +18,9 @@ on:
 
 jobs:
   Ubuntu:
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
 
     runs-on: ubuntu-18.04
 
@@ -61,6 +64,9 @@ jobs:
         cabal build
 
   macOS:
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
 
     runs-on: macos-latest
 
@@ -88,6 +94,10 @@ jobs:
         cabal build
 
   # Windows:
+  #   if: |
+  #     !contains(github.event.head_commit.message, '[skip ci]')
+  #     && !contains(github.event.head_commit.message, '[ci skip]')
+  #
   #   runs-on: windows-latest
   #   strategy:
   #     matrix:

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -21,6 +21,8 @@ jobs:
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
       && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[github skip]')
+      && !contains(github.event.head_commit.message, '[skip github]')
 
     runs-on: ubuntu-18.04
 
@@ -67,6 +69,8 @@ jobs:
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
       && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[github skip]')
+      && !contains(github.event.head_commit.message, '[skip github]')
 
     runs-on: macos-latest
 
@@ -97,6 +101,8 @@ jobs:
   #   if: |
   #     !contains(github.event.head_commit.message, '[skip ci]')
   #     && !contains(github.event.head_commit.message, '[ci skip]')
+  #     && !contains(github.event.head_commit.message, '[github skip]')
+  #     && !contains(github.event.head_commit.message, '[skip github]')
   #
   #   runs-on: windows-latest
   #   strategy:

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   build:
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
 
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -17,6 +17,8 @@ jobs:
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
       && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[github skip]')
+      && !contains(github.event.head_commit.message, '[skip github]')
 
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -23,6 +23,8 @@ jobs:
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
       && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[github skip]')
+      && !contains(github.event.head_commit.message, '[skip github]')
 
     runs-on: ubuntu-18.04
 
@@ -65,6 +67,8 @@ jobs:
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
       && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[github skip]')
+      && !contains(github.event.head_commit.message, '[skip github]')
 
     runs-on: macos-latest
 
@@ -104,6 +108,8 @@ jobs:
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
       && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[github skip]')
+      && !contains(github.event.head_commit.message, '[skip github]')
 
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -20,6 +20,10 @@ on:
 
 jobs:
   Ubuntu:
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
+
     runs-on: ubuntu-18.04
 
     strategy:
@@ -58,6 +62,10 @@ jobs:
         stack build ${ARGS} ${NON_DEFAULT_FLAGS}
 
   macOS:
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
+
     runs-on: macos-latest
 
     strategy:
@@ -93,6 +101,10 @@ jobs:
         stack build ${ARGS} ${NON_DEFAULT_FLAGS}
 
   Windows:
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
+
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/user_manual.yml
+++ b/.github/workflows/user_manual.yml
@@ -15,6 +15,8 @@ jobs:
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
       && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[github skip]')
+      && !contains(github.event.head_commit.message, '[skip github]')
 
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/user_manual.yml
+++ b/.github/workflows/user_manual.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   build:
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
 
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -6,6 +6,8 @@ jobs:
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
       && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[github skip]')
+      && !contains(github.event.head_commit.message, '[skip github]')
 
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -3,6 +3,10 @@ on: [push, pull_request]
 
 jobs:
   check:
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
+
     runs-on: ubuntu-18.04
 
     strategy:

--- a/HACKING.md
+++ b/HACKING.md
@@ -334,21 +334,21 @@ the Travis dashboard page, if successful.
 
 ### Skipping workflows / Work-In-Progress (WIP) commits
 
-It is also possible to skip Travis and/or Github workflows using a special
+It is also possible to skip Travis jobs and/or GitHub workflows using a special
 phrase in the (head) commit message. The phrase may appear anywhere in the
 commit message. The acceptable phrases are listed below.
 
-The Travis and Github workflows will check for the phrase in the head commit
+The Travis jobs and GitHub workflows will check for the phrase in the head commit
 (only) of a push (i.e. if you push 3 commits at once, only the most recent
 commit's message is checked for the phrase).
 
 | Phrase | Effect |
 |---|---|
-| `[ci skip]` | Skips both Travis and Github workflows |
+| `[ci skip]` | Skips both Travis jobs and GitHub workflows |
 | `[skip ci]` | As-per `[ci skip]` |
-| `[travis skip]` | Skip only Travis workflows (i.e. Github workflows will still run) |
+| `[travis skip]` | Skip only Travis jobs (i.e. GitHub workflows will still run) |
 | `[skip travis]` | As-per `[travis skip]` |
-| `[github skip]` | Skip only Github workflows (i.e. Travis workflows will still run) |
+| `[github skip]` | Skip only GitHub workflows (i.e. Travis jobs will still run) |
 | `[skip github]` | As-per `[github skip]` |
 
 Some Agda Hacking Lore

--- a/HACKING.md
+++ b/HACKING.md
@@ -332,6 +332,25 @@ you some time. One caveat:
 You should see the status in your GitHub Actions page and
 the Travis dashboard page, if successful.
 
+### Skipping workflows / Work-In-Progress (WIP) commits
+
+It is also possible to skip Travis and/or Github workflows using a special
+phrase in the (head) commit message. The phrase may appear anywhere in the
+commit message. The acceptable phrases are listed below.
+
+The Travis and Github workflows will check for the phrase in the head commit
+(only) of a push (i.e. if you push 3 commits at once, only the most recent
+commit's message is checked for the phrase).
+
+| Phrase | Effect |
+|---|---|
+| `[ci skip]` | Skips both Travis and Github workflows |
+| `[skip ci]` | As-per `[ci skip]` |
+| `[travis skip]` | Skip only Travis workflows (i.e. Github workflows will still run) |
+| `[skip travis]` | As-per `[travis skip]` |
+| `[github skip]` | Skip only Github workflows (i.e. Travis workflows will still run) |
+| `[skip github]` | As-per `[github skip]` |
+
 Some Agda Hacking Lore
 ======================
 


### PR DESCRIPTION
Resolves #4729 as per agreed solution. The presence of `[ci skip]` or `[skip ci]` in the head commit of a push will cause Github Workflows to be skipped. This matches the behaviour of Travis.

Note: If someone wants to skip Travis but not Github Workflows, they should include `[skip travis]` in the head commit message, [as per the documentation on this page](https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build).