### PR TITLE
Add minimal hlint.yaml + GitHub workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,46 @@
+name: Lint
+
+on:
+  push:
+    paths:
+      - '.github/workflows/lint.yaml'
+      - '.hlint.yaml'
+      - 'Agda.cabal'
+      - 'src/**'
+      - 'test/**'
+
+  pull_request:
+    # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - '.github/workflows/lint.yaml'
+      - '.hlint.yaml'
+      - 'Agda.cabal'
+      - 'src/**'
+      - 'test/**'
+
+jobs:
+  hlint:
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[github skip]')
+      && !contains(github.event.head_commit.message, '[skip github]')
+
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2.3.1
+
+    - name: Set up hlint
+      uses: rwe/actions-hlint-setup@v1
+      with:
+        version: '3.1.6'
+
+    - name: Run hlint
+      uses: rwe/actions-hlint-run@v2
+      with:
+        path: '["src/", "test/"]'
+        fail-on: warning

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,60 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -29,7 +29,6 @@
 - ignore: {name: "Redundant variable capture"}
 - ignore: {name: "Replace case with fromMaybe"}
 - ignore: {name: "Replace case with maybe"}
-- ignore: {name: "Unused LANGUAGE pragma"}
 - ignore: {name: "Use &&"}
 - ignore: {name: "Use ++"}
 - ignore: {name: "Use :"}

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -41,7 +41,6 @@
 - ignore: {name: "Use concatMap"}
 - ignore: {name: "Use const"}
 - ignore: {name: "Use empty"}
-- ignore: {name: "Use fewer imports"}
 - ignore: {name: "Use fmap"}
 - ignore: {name: "Use fromMaybe"}
 - ignore: {name: "Use id"}

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -6,6 +6,67 @@
 # placed as .hlint.yaml in the root of your project
 
 
+# Warnings currently triggered by your code
+- ignore: {name: "Avoid lambda using `infix`"}
+- ignore: {name: "Avoid lambda"}
+- ignore: {name: "Eta reduce"}
+- ignore: {name: "Evaluate"}
+- ignore: {name: "Fuse foldr/map"}
+- ignore: {name: "Fuse mapM/map"}
+- ignore: {name: "Hoist not"}
+- ignore: {name: "Move brackets to avoid $"}
+- ignore: {name: "Reduce duplication"}
+- ignore: {name: "Redundant $"}
+- ignore: {name: "Redundant <$>"}
+- ignore: {name: "Redundant bracket"}
+- ignore: {name: "Redundant case"}
+- ignore: {name: "Redundant guard"}
+- ignore: {name: "Redundant if"}
+- ignore: {name: "Redundant lambda"}
+- ignore: {name: "Redundant multi-way if"}
+- ignore: {name: "Redundant return"}
+- ignore: {name: "Redundant section"}
+- ignore: {name: "Redundant variable capture"}
+- ignore: {name: "Replace case with fromMaybe"}
+- ignore: {name: "Replace case with maybe"}
+- ignore: {name: "Unused LANGUAGE pragma"}
+- ignore: {name: "Use &&"}
+- ignore: {name: "Use ++"}
+- ignore: {name: "Use :"}
+- ignore: {name: "Use <$"}
+- ignore: {name: "Use <$>"}
+- ignore: {name: "Use <=<"}
+- ignore: {name: "Use >"}
+- ignore: {name: "Use Just"}
+- ignore: {name: "Use camelCase"}
+- ignore: {name: "Use concatMap"}
+- ignore: {name: "Use const"}
+- ignore: {name: "Use empty"}
+- ignore: {name: "Use fewer imports"}
+- ignore: {name: "Use fmap"}
+- ignore: {name: "Use fromMaybe"}
+- ignore: {name: "Use id"}
+- ignore: {name: "Use infix"}
+- ignore: {name: "Use intercalate"}
+- ignore: {name: "Use lambda-case"}
+- ignore: {name: "Use list comprehension"}
+- ignore: {name: "Use list literal pattern"}
+- ignore: {name: "Use list literal"}
+- ignore: {name: "Use mapMaybe"}
+- ignore: {name: "Use maximum"}
+- ignore: {name: "Use maybe"}
+- ignore: {name: "Use mconcat"}
+- ignore: {name: "Use newtype instead of data"}
+- ignore: {name: "Use notElem"}
+- ignore: {name: "Use null"}
+- ignore: {name: "Use record patterns"}
+- ignore: {name: "Use second"}
+- ignore: {name: "Use section"}
+- ignore: {name: "Use sequenceA"}
+- ignore: {name: "Use unless"}
+- ignore: {name: "Use ||"}
+
+
 # Specify additional command line arguments
 #
 # - arguments: [--color, --cpp-simple, -XQuasiQuotes]

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -9,7 +9,36 @@
 # Specify additional command line arguments
 #
 # - arguments: [--color, --cpp-simple, -XQuasiQuotes]
-
+- arguments: [
+  -XBangPatterns,
+  -XConstraintKinds,
+  -XDefaultSignatures,
+  -XDeriveDataTypeable,
+  -XDeriveFoldable,
+  -XDeriveFunctor,
+  -XDeriveTraversable,
+  -XExistentialQuantification,
+  -XFlexibleContexts,
+  -XFlexibleInstances,
+  -XFunctionalDependencies,
+  -XInstanceSigs,
+  -XLambdaCase,
+  -XMultiParamTypeClasses,
+  -XMultiWayIf,
+  -XNamedFieldPuns,
+  -XOverloadedStrings,
+  -XPatternSynonyms,
+  -XRankNTypes,
+  -XRecordWildCards,
+  -XScopedTypeVariables,
+  -XStandaloneDeriving,
+  -XTupleSections,
+  -XTypeSynonymInstances,
+  # hlint (3.1.6, anyway), seems to assume -XTypeApplications,
+  # which causes a parsing error in some cases.
+  # (At the time of this note, a parse error in Agda.TypeChecking.Generalize)
+  -XNoTypeApplications,
+]
 
 # Control which extensions/flags/modules/functions can be used
 #

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -59,7 +59,6 @@
 - ignore: {name: "Use second"}
 - ignore: {name: "Use section"}
 - ignore: {name: "Use sequenceA"}
-- ignore: {name: "Use unless"}
 - ignore: {name: "Use ||"}
 
 

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -38,7 +38,6 @@
 - ignore: {name: "Use >"}
 - ignore: {name: "Use Just"}
 - ignore: {name: "Use camelCase"}
-- ignore: {name: "Use concatMap"}
 - ignore: {name: "Use const"}
 - ignore: {name: "Use empty"}
 - ignore: {name: "Use fmap"}

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -40,7 +40,6 @@
 - ignore: {name: "Use camelCase"}
 - ignore: {name: "Use const"}
 - ignore: {name: "Use empty"}
-- ignore: {name: "Use fmap"}
 - ignore: {name: "Use fromMaybe"}
 - ignore: {name: "Use id"}
 - ignore: {name: "Use infix"}

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE TypeOperators #-}
+
 
 -- | Interface for compiler backend writers.
 module Agda.Compiler.Backend

--- a/src/full/Agda/Compiler/JS/Pretty.hs
+++ b/src/full/Agda/Compiler/JS/Pretty.hs
@@ -8,7 +8,6 @@ import Data.Set ( Set, toList, singleton, insert, member )
 import qualified Data.Set as Set
 import Data.Map ( Map, toAscList, empty, null )
 import qualified Data.Text as T
-import Data.Map ( Map, toAscList )
 
 import Agda.Syntax.Common ( Nat )
 import Agda.Utils.Hash

--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeFamilies #-} -- for type equality ~
-{-# LANGUAGE TypeApplications #-}
 
 {-| Names in the concrete syntax are just strings (or lists of strings for
     qualified names).

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -111,7 +111,7 @@ localNames flat = do
     ]
   let localNots  = map localOp locals
       notLocal   = not . hasElem (map notaName localNots) . notaName
-      otherNots  = concat $ map (filter notLocal) defs
+      otherNots  = concatMap (filter notLocal) defs
   return $ second (map useDefaultFixity) $ split $ localNots ++ otherNots
   where
     localOp (x, y) = namesToNotation (QName x) y

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE UndecidableInstances       #-}  -- because of shortcomings of FunctionalDependencies
 

--- a/src/full/Agda/Syntax/Notation.hs
+++ b/src/full/Agda/Syntax/Notation.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable  #-}
+
 
 {-| As a concrete name, a notation is a non-empty list of alternating 'IdPart's and holes.
     In contrast to concrete names, holes can be binders.

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2551,7 +2551,7 @@ mergeEqualPs = go (empty, [])
   where
     go acc (p@(Arg i (Named mn (A.EqualP r es))) : ps) = setCurrentRange p $ do
       -- Face constraint patterns must be defaultNamedArg; check this:
-      when (not $ null $ getModality i) __IMPOSSIBLE__
+      unless (null $ getModality i) __IMPOSSIBLE__
       when (hidden     i) $ warn i $ "Face constraint patterns cannot be hidden arguments"
       when (isInstance i) $ warn i $ "Face constraint patterns cannot be instance arguments"
       whenJust mn $ \ x -> setCurrentRange x $ warn x $ P.hcat

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE PatternGuards #-}
-{-# LANGUAGE PatternSynonyms #-}
+
 {-# LANGUAGE TypeFamilies  #-}
 
 {-|

--- a/src/full/Agda/Utils/Graph/TopSort.hs
+++ b/src/full/Agda/Utils/Graph/TopSort.hs
@@ -1,4 +1,4 @@
-{-# language ViewPatterns #-}
+
 module Agda.Utils.Graph.TopSort
     ( topSort
     ) where

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -12,7 +12,7 @@
 --
 --   @
 
-{-# LANGUAGE PatternSynonyms #-}
+
 
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
   -- because of https://gitlab.haskell.org/ghc/ghc/issues/10339

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -13,7 +13,7 @@
 -- @
 
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 
 module Agda.Utils.SmallSet
   ( SmallSet()

--- a/src/full/Agda/Utils/Tuple.hs
+++ b/src/full/Agda/Utils/Tuple.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 
 module Agda.Utils.Tuple
   ( (-*-)

--- a/src/full/Agda/Utils/TypeLevel.hs
+++ b/src/full/Agda/Utils/TypeLevel.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE KindSignatures       #-}
+
 -- We need undecidable instances for the definition of @Foldr@,
 -- and @Domains@ and @CoDomain@ using @If@ for instance.
 {-# LANGUAGE UndecidableInstances #-}

--- a/src/hTags/Tags.hs
+++ b/src/hTags/Tags.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeSynonymInstances #-}
+
 {-# LANGUAGE UndecidableInstances #-}
 
 module Tags where

--- a/src/size-solver/Parser.hs
+++ b/src/size-solver/Parser.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE TypeSynonymInstances #-}
+
 
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 

--- a/test/Internal/Interaction/Highlighting/Precise.hs
+++ b/test/Internal/Interaction/Highlighting/Precise.hs
@@ -128,7 +128,7 @@ instance CoArbitrary Aspect where
   coarbitrary Markup        = variant 9
 
 instance Arbitrary NameKind where
-  arbitrary = oneof $ [liftM Constructor arbitrary] ++
+  arbitrary = oneof $ [fmap Constructor arbitrary] ++
                       map return [ Bound
                                  , Datatype
                                  , Field

--- a/test/interaction/Issue4333.hs
+++ b/test/interaction/Issue4333.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards #-}
+
 
 import Control.Monad
 

--- a/test/interaction/RunAgda.hs
+++ b/test/interaction/RunAgda.hs
@@ -80,7 +80,7 @@ readUntilPrompt' h = do
   if s == prompt then return [] else do
     line <- if nl then return s
                   else fmap (s ++) (hGetLine h)
-    liftM (line :) $ readUntilPrompt' h
+    fmap (line :) $ readUntilPrompt' h
 
 -- | Echoes lines read from the first handle on the second handle
 -- until a prompt is encountered. The prompt is not echoed.


### PR DESCRIPTION
Proposed for discussion; this is an experiment, but works. I've tagged a few people for review but I'm not sure who specifically would count as owner on this.

Mainly I wanted to better-understand how to use GitHub Actions to automate checks, and to tinker with how one might integrate those types of tools into Agda's codebase.

## ✅  What this *does*:
  - Adds an initial `hlint.yaml` with most checks disabled.
  - Adds a GitHub workflow to download `hlint` and runs it when files in those directories change.
  - I manually auto-fixed (using `hlint --refactor`) a few straightforward ones, listed per commit. `hlint` version 3.1.6 runs cleanly on `src/` and `test/` in this branch.

The output of `hlint` it transformed to show up as GitHub annotations. (See example below).

## ⚪ What this *does not*:
  - It does _not_ add `hlint` to cabal or `stack-*.yaml`.
  - It does not fix many warnings. The focus of this was more proof-of-concept on the automation side.

## 🎉 Example
Here's an example of what it looks like with a PR that introduces lint warnings:
https://github.com/rwe/agda/pull/1/files#file-src-full-agda-typechecking-reduce-hs-L404
<img width="700" alt="Screen Shot 2020-07-22 at 5 26 51 PM" src="https://user-images.githubusercontent.com/447615/88241948-8afc8680-cc40-11ea-81ef-eda8119823f7.png">

## Miscellany

* ⚠️ Currently I have this set to fail on warnings so they don't get missed. If that feels like overkill, the flag `fail-on: warning` can be changed to to `fail-on: error` in the workflow.
* ❓ _Should_ `hlint` or similar tools be added to the "real" dependencies somehow? If so, how without running into compilation dependency issues? (`hlint` runs fine as a binary, which avoided all of that).

~And a question that will be answered once I press submit: Will this workflow even be triggered in this initial PR? Perhaps it needs exist on a branch on `agda/agda` first?~. Seems to be triggered. Sweet.