### PR TITLE
Upload size-solver artifact on macOS and Linux

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,7 @@ jobs:
         mkdir -p upload/bin
         cp -av .stack-work/dist/x86_64-linux/**/build/agda/agda upload/bin
         cp -av .stack-work/dist/x86_64-linux/**/build/agda-mode/agda-mode upload/bin
+        cp -av src/size-solver/.stack-work/dist/x86_64-linux/**/build/size-solver/size-solver upload/bin
         cp -avr src/data upload
         cp -av .github/*.sh upload
 
@@ -83,6 +84,7 @@ jobs:
         mkdir -p upload/bin
         cp -av .stack-work/dist/x86_64-osx/**/build/agda/agda upload/bin
         cp -av .stack-work/dist/x86_64-osx/**/build/agda-mode/agda-mode upload/bin
+        cp -av src/size-solver/.stack-work/dist/x86_64-osx/**/build/size-solver/size-solver upload/bin
         cp -av src/data upload
         cp -av .github/*.sh upload
 


### PR DESCRIPTION
Fixes #4803 (_Installer script for nightly build doesn't work: size-solver binary only exists for Windows_).

Previously only the Windows job was uploading that binary, which meant that the `install_agda_user.sh` script would fail.