### PR TITLE
Bump interface version number

### DIFF
--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -71,7 +71,7 @@ import Agda.Utils.IORef
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20200714 * 10 + 0
+currentInterfaceVersion = 20200724 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 


### PR DESCRIPTION
The interface version number was bumped in #4781: https://github.com/agda/agda/pull/4781/files#diff-e0de8e8dac3940a70f3258f1e5afa5c4R74 but not in #4759 which merged afterward and also introduced some flags and functionality.

Pointed out in here: https://github.com/agda/agda/pull/4810#pullrequestreview-455196342
