### PR TITLE
ci: Remove size-solver from nightly release and script

### DIFF
--- a/.github/install_agda_system.sh
+++ b/.github/install_agda_system.sh
@@ -14,7 +14,6 @@ echo "The executable files should be executable ..."
 
 chmod 777 ./bin/agda
 chmod 777 ./bin/agda-mode
-chmod 777 ./bin/size-solver
 
 echo "Copying executables ..."
 

--- a/.github/install_agda_user.sh
+++ b/.github/install_agda_user.sh
@@ -16,7 +16,6 @@ echo "The executable files should be executable ..."
 
 chmod a+x ./bin/agda
 chmod a+x ./bin/agda-mode
-chmod a+x ./bin/size-solver
 
 agda --version
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,6 @@ jobs:
         mkdir -p upload/bin
         cp -av .stack-work/dist/x86_64-linux/**/build/agda/agda upload/bin
         cp -av .stack-work/dist/x86_64-linux/**/build/agda-mode/agda-mode upload/bin
-        cp -av src/size-solver/.stack-work/dist/x86_64-linux/**/build/size-solver/size-solver upload/bin
         cp -avr src/data upload
         cp -av .github/*.sh upload
 
@@ -84,7 +83,6 @@ jobs:
         mkdir -p upload/bin
         cp -av .stack-work/dist/x86_64-osx/**/build/agda/agda upload/bin
         cp -av .stack-work/dist/x86_64-osx/**/build/agda-mode/agda-mode upload/bin
-        cp -av src/size-solver/.stack-work/dist/x86_64-osx/**/build/size-solver/size-solver upload/bin
         cp -av src/data upload
         cp -av .github/*.sh upload
 
@@ -131,7 +129,6 @@ jobs:
         cp -av ~/AppData/Local/Programs/stack/x86_64-windows/msys2-20180531/mingw64/bin/*.dll upload/bin
         cp -av .stack-work/install/**/bin/agda.exe upload/bin
         cp -av .stack-work/install/**/bin/agda-mode.exe upload/bin
-        cp -av .stack-work/install/**/bin/size-solver.exe upload/bin
         cp -avr src/data upload
         cp -av .github/*.bat upload
 


### PR DESCRIPTION
Fixes #4812, re the incorrect fix of #4803 in #4806 whose root cause was the initial implementation of #4244 in #4243.

Apparently `size-solver` was never intended to be in there in the first place, so although the scripts were fixed by adding it to the missing platforms, the right fix was actually to drop it from the scripts.