### PR TITLE
Add hie.yaml for Haskell LSP + and vscode recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "haskell.haskell",
+  ],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": [
+  ],
+}
+// vim:ft=json5:

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,17 @@
+cradle:
+  stack:
+    - path: './src/full'
+      component: 'Agda:lib'
+    - path: './src/main'
+      component: 'Agda:exe:agda'
+    - path: './src/agda-mode'
+      component: 'Agda:exe:agda-mode'
+    - path: './src/size-solver'
+      component: 'size-solver:exe:size-solver'
+    - path: './test'
+      component: 'Agda:test:agda-tests'
+
+    # Default catch-all. This prevents errors from Paths_Agda which is generated into
+    # .stack-work/dist/…/Cabal-…/build/autogen/Paths_Agda.hs
+    - path: '.stack-work/dist'
+      component: 'Agda:lib'


### PR DESCRIPTION
The `hie.yaml` facilitates using the Haskell Language Server with the Agda codebase. (In particular, using VSCode. Finally something that seems to work well and have minimal fuss!)

More information here:
  * [haskell/haskell-language-server](https://github.com/haskell/haskell-language-server)
  * [mpickering/hie-bios](https://github.com/mpickering/hie-bios)
  * https://mpickering.github.io/ide/posts/2020-07-10-ghc-libdir.html

Although `hie.yaml` supports _either_ Stack or Cabal, it does not yet support _both_ configurations well. (mpickering/hie-bios#199).

Therefore this somewhat arbitrarily chooses to prefer Stack on the basis that:
  * There seem to be more open bugs for Cabal support than Stack in the `hie-bios` repo.
  * Stack makes it easier to switch out GHC versions for testing, especially when diagnosing build issues.
  * I use Stack, so functionality was easier to test. (This is the true reason, but I'll never admit to it).

Alternative approaches I considered and rejected:
  * Prefer Cabal instead. (Mainly just risk aversion for my own time: I'm more familiar with stack than Cabal and didn't really want to rebuild everything from scratch to find out it didn't work).
  * Make two template files and have users copy them. (This means they would not receive updates, and adds an extra step for the user).

P.S. I've tagged random people for review again since I'm not sure who owns this but I imagine people might have opinions. Don't feel bothered or left out you were/weren't tagged.

P.P.S. I took the liberty of creating a `devx` label for developer experience (linting, local builds, IDE setup, etc.) since nothing really seemed to fit that. Please yell at me if I shouldn't have done that.