### PR TITLE
Add compiler-check to `stack-*.yaml`

### DIFF
--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -1,4 +1,6 @@
 resolver: lts-9.21
+compiler: ghc-8.0.2
+compiler-check: match-exact
 
 extra-deps:
 - QuickCheck-2.13.2

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -1,4 +1,6 @@
 resolver: ghc-8.10.1
+compiler: ghc-8.10.1
+compiler-check: match-exact
 
 extra-deps:
 - Diff-0.4.0

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -1,4 +1,6 @@
 resolver: lts-11.22
+compiler: ghc-8.2.2
+compiler-check: match-exact
 
 extra-deps:
 - QuickCheck-2.13.2

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -1,4 +1,6 @@
 resolver: lts-12.26
+compiler: ghc-8.4.4
+compiler-check: match-exact
 
 extra-deps:
 - QuickCheck-2.13.2

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,4 +1,6 @@
 resolver: lts-14.27
+compiler: ghc-8.6.5
+compiler-check: match-exact
 
 extra-deps:
 - STMonadTrans-0.4.3

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -1,4 +1,6 @@
 resolver: lts-15.3
+compiler: ghc-8.8.2
+compiler-check: match-exact
 
 extra-deps:
 - STMonadTrans-0.4.4

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -1,4 +1,6 @@
 resolver: lts-16.5
+compiler: ghc-8.8.3
+compiler-check: match-exact
 
 extra-deps:
 - STMonadTrans-0.4.4


### PR DESCRIPTION
Minor, minor change.

This avoids needing to wonder whether the totally opaque stackage resolver number _really_ corresponds to the GHC version indicated by the filename.