### PR TITLE
Collection of Makefile housekeeping

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -221,6 +221,17 @@ Testing and documentation
   This path is `.gitignored` and will be loaded if it exists. Put custom
   overrides there.
 
+* Test parallelization can be controlled via the `PARALLEL_TESTS` Makefile
+  variable. If unset, it will default to the number of CPUs available.
+  This variable can be customized per-run as usual:
+  ```sh
+    make PARALLEL_TESTS=4 test
+  ```
+  To keep it a persisted default, add it to your `mk/config.mk`:
+  ```make
+    PARALLEL_TESTS = 4
+  ```
+
 * You can run a single interaction test by going into the
   `test/interaction` directory and typing `make <test name>.cmp`.
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -217,6 +217,10 @@ Testing and documentation
 * Run the test-suite, using `make test`.
   Maybe you want to build Agda first, using `make` or `make install-bin`.
 
+* To persist local Makefile options, create a file called `mk/config.mk`.
+  This path is `.gitignored` and will be loaded if it exists. Put custom
+  overrides there.
+
 * You can run a single interaction test by going into the
   `test/interaction` directory and typing `make <test name>.cmp`.
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 # Top-level Makefile for Agda 2
 # Authors: Ulf Norell, Nils Anders Danielsson, Francesco Mazzoli, Liang-Ting Chen
 
-SHELL=bash
-
 # Profiling verbosity for std-lib-test
 PROFVERB=7
 

--- a/Makefile
+++ b/Makefile
@@ -20,18 +20,12 @@ include ./mk/pretty.mk
 
 # Run in interactive and parallel mode by default
 
-# You can use the $(PARALLEL_TESTS_FILE) file for setting the number of
-# parallel tests, e.g.
-#   PARALLEL_TESTS = 123
-
-PARALLEL_TESTS_FILE = mk/parallel-tests.mk
-
-ifeq ($(wildcard $(PARALLEL_TESTS_FILE)),)
-# Setting the default value.
-PARALLEL_TESTS = $(shell getconf _NPROCESSORS_ONLN)
-else
-# Getting the value from the $(PARALLEL_TESTS_FILE) file.
-include $(PARALLEL_TESTS_FILE)
+# You can use the PARALLEL_TESTS variable to control the number of parallel
+# tests. The default is one per processor. Invoke make like this:
+#   make PARALLEL_TESTS=123 test
+# Or set it in ./mk/config.mk, which is .gitignored
+ifeq ($(PARALLEL_TESTS),)
+PARALLEL_TESTS := $(shell getconf _NPROCESSORS_ONLN)
 endif
 
 AGDA_TESTS_OPTIONS ?=-i -j$(PARALLEL_TESTS)

--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,7 @@ quicklatex-test :
 .PHONY : std-library-test ##
 std-lib-test :
 	@$(call decorate, "Standard library test", \
-		(cd std-lib && runhaskell GenerateEverything.hs && \
+		(cd std-lib && runghc GenerateEverything.hs && \
 						time $(AGDA_BIN) $(AGDA_OPTS) --ignore-interfaces --no-default-libraries -v profile:$(PROFVERB) \
 														 -i. -isrc README.agda \
 														 +RTS -s))

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TOP=.
 # mk/path.mk uses TOP, so include after the definition of TOP.
 include ./mk/paths.mk
 include ./mk/cabal.mk
-STACK_CMD=stack
+STACK=stack
 
 # mk/prtty.mk pretty prints information, depending on whether it is run on Travis on not
 include ./mk/pretty.mk
@@ -30,8 +30,8 @@ endif
 
 AGDA_TESTS_OPTIONS ?=-i -j$(PARALLEL_TESTS)
 
-CABAL_INSTALL_HELPER = $(CABAL_CMD) $(CABAL_INSTALL_CMD) --disable-documentation
-STACK_INSTALL_HELPER = $(STACK_CMD) install Agda --no-haddock --system-ghc
+CABAL_INSTALL_HELPER = $(CABAL) $(CABAL_INSTALL_CMD) --disable-documentation
+STACK_INSTALL_HELPER = $(STACK) install Agda --no-haddock --system-ghc
 
 # 2016-07-15. We use a different build directory in the quick
 # installation for avoiding recompilation (see Issue #2083 and
@@ -155,7 +155,7 @@ endif
 .PHONY: type-check
 type-check:
 	@echo "================= Type checking using Cabal with -fno-code ==============="
-	time $(CABAL_CMD) $(CABAL_BUILD_CMD) --builddir=$(BUILD_DIR)-no-code \
+	time $(CABAL) $(CABAL_BUILD_CMD) --builddir=$(BUILD_DIR)-no-code \
 	  --ghc-options=-fno-code \
 	  --ghc-options=-fwrite-interface \
 	  2>&1 \
@@ -199,7 +199,7 @@ setup-emacs-mode : install-bin
 	$(AGDA_MODE) setup
 
 ## Clean ####################################################################
-clean_helper = if [ -d $(1) ]; then $(CABAL_CMD) $(CABAL_CLEAN_CMD) --builddir=$(1); fi;
+clean_helper = if [ -d $(1) ]; then $(CABAL) $(CABAL_CLEAN_CMD) --builddir=$(1); fi;
 
 clean : ## Clean all local builds
 	$(call clean_helper,$(BUILD_DIR))
@@ -211,8 +211,8 @@ clean : ## Clean all local builds
 
 .PHONY : haddock ##
 haddock :
-	$(CABAL_CMD) $(CABAL_CONFIGURE_CMD) $(CABAL_CONFIGURE_OPTS)
-	$(CABAL_CMD) $(CABAL_HADDOCK_CMD) --builddir=$(BUILD_DIR)
+	$(CABAL) $(CABAL_CONFIGURE_CMD) $(CABAL_CONFIGURE_OPTS)
+	$(CABAL) $(CABAL_HADDOCK_CMD) --builddir=$(BUILD_DIR)
 
 ##############################################################################
 ## The user manual
@@ -483,21 +483,21 @@ ifneq ("$(wildcard stack.yaml)","") # if `stack.yaml` exists
 	mkdir -p $(FIXW_PATH)/dist/build/fix-whitespace/
 	cp $(shell stack path --local-install-root)/bin/fix-whitespace $(FIXW_BIN)
 else
-	cd $(FIXW_PATH) && $(CABAL_CMD) $(CABAL_INSTALL_CMD)
+	cd $(FIXW_PATH) && $(CABAL) $(CABAL_INSTALL_CMD)
 endif
 
 ## agda-bisect standalone program ############################################
 .PHONY : install-agda-bisect ## Install agda-bisect.
 install-agda-bisect :
 	@$(call decorate, "Installing the agda-bisect program", \
-		cd src/agda-bisect && $(CABAL_CMD) $(CABAL_INSTALL_CMD))
+		cd src/agda-bisect && $(CABAL) $(CABAL_INSTALL_CMD))
 
 ## HPC #######################################################################
 .PHONY: hpc-build ##
 hpc-build: ensure-hash-is-correct
-	$(CABAL_CMD) $(CABAL_CLEAN_CMD) $(CABAL_OPTS)
-	$(CABAL_CMD) $(CABAL_CONFIGURE_CMD) --enable-library-coverage $(CABAL_INSTALL_OPTS)
-	$(CABAL_CMD) $(CABAL_BUILD_CMD) $(CABAL_OPTS)
+	$(CABAL) $(CABAL_CLEAN_CMD) $(CABAL_OPTS)
+	$(CABAL) $(CABAL_CONFIGURE_CMD) --enable-library-coverage $(CABAL_INSTALL_OPTS)
+	$(CABAL) $(CABAL_BUILD_CMD) $(CABAL_OPTS)
 
 agda.tix: ./examples/agda.tix ./test/common/agda.tix ./test/Succeed/agda.tix ./test/compiler/agda.tix ./test/api/agda.tix ./test/interaction/agda.tix ./test/fail/agda.tix ./test/lib-succeed/agda.tix ./std-lib/agda.tix ##
 	hpc sum --output=$@ $^
@@ -559,7 +559,7 @@ debug : ## Print debug information.
 	@echo "BUILD_DIR             = $(BUILD_DIR)"
 	@echo "CABAL_BUILD_CMD       = $(CABAL_BUILD_CMD)"
 	@echo "CABAL_CLEAN_CMD       = $(CABAL_CLEAN_CMD)"
-	@echo "CABAL_CMD             = $(CABAL_CMD)"
+	@echo "CABAL                 = $(CABAL)"
 	@echo "CABAL_CONFIGURE_CMD   = $(CABAL_CONFIGURE_CMD)"
 	@echo "CABAL_CONFIGURE_OPTS  = $(CABAL_CONFIGURE_OPTS)"
 	@echo "CABAL_HADDOCK_CMD     = $(CABAL_HADDOCK_CMD)"
@@ -568,7 +568,7 @@ debug : ## Print debug information.
 	@echo "CABAL_OPTS            = $(CABAL_OPTS)"
 	@echo "GHC_VERSION           = $(GHC_VERSION)"
 	@echo "PARALLEL_TESTS        = $(PARALLEL_TESTS)"
-	@echo "STACK_CMD             = $(STACK_CMD)"
+	@echo "STACK                 = $(STACK)"
 	@echo "STACK_INSTALL_OPTS    = $(STACK_INSTALL_OPTS)"
 	@echo
 	@echo "Run \`make -pq\` to get a detailed report."

--- a/Makefile
+++ b/Makefile
@@ -257,12 +257,12 @@ std-lib :
 
 .PHONY : up-to-date-std-lib ##
 up-to-date-std-lib : std-lib
-	@(cd std-lib && make setup)
+	@($(MAKE) -C std-lib setup)
 
 .PHONY : fast-forward-std-lib ##
 fast-forward-std-lib :
 	git submodule update --init --remote std-lib
-	@(cd std-lib && make setup)
+	@($(MAKE) -C std-lib setup)
 
 ##############################################################################
 ## Cubical library
@@ -521,7 +521,7 @@ agda-loc : ## Agda files (tests) in this project
 	@wc $(agdalocfiles)
 
 loc : ## Source code of Agda
-	make -C src/full loc
+	$(MAKE) -C src/full loc
 
 ## Module dependency graph ###################################################
 

--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,8 @@ type-check:
 	  --ghc-options=-fno-code \
 	  --ghc-options=-fwrite-interface \
 	  2>&1 \
-	  | sed -e '/.*dist.*build.*: No such file or directory/d' \
-	        -e '/.*Warning: the following files would be used as linker inputs, but linking is not being done:.*/d'
+	  | $(SED) -e '/.*dist.*build.*: No such file or directory/d' \
+	           -e '/.*Warning: the following files would be used as linker inputs, but linking is not being done:.*/d'
 
 
 .PHONY : install-prof-bin ## Install Agda with profiling enabled via cabal.
@@ -541,7 +541,7 @@ hlint : $(BUILD_DIR)/build/autogen/cabal_macros.h ##
 
 help: ## Display this information.
 	@echo "Available targets:"
-	@sed -n \
+	@$(SED) -n \
 		-e 's/^\.PHONY[[:blank:]]*:[[:blank:]]*\([[:graph:]]*[[:blank:]]*##\)/\1/p' \
 		-e 's/\([[:alnum:]_-]\{1,\}\)[[:blank:]]*:[[:blank:]]*[^#]*##[[:blank:]]*\([^\#]*\)$$/\1 ## \2/p' \
 		-e 's/^\(#\{2,\}\)$$//p' \

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ ensure-hash-is-correct:
 
 .PHONY: install-bin ## Install Agda and test suites via cabal (or stack if stack.yaml exists).
 install-bin: ensure-hash-is-correct
-ifneq ("$(wildcard stack.yaml)","") # if `stack.yaml` exists
+ifdef HAS_STACK
 	@echo "===================== Installing using Stack with test suites ============"
 	time $(STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
 	mkdir -p $(BUILD_DIR)/build/
@@ -113,7 +113,7 @@ endif
 
 .PHONY: fast-install-bin ## Install Agda -O0 and test suites via cabal (or stack if stack.yaml exists).
 fast-install-bin:
-ifneq ("$(wildcard stack.yaml)","") # if `stack.yaml` exists
+ifdef HAS_STACK
 	@echo "============= Installing using Stack with -O0 and test suites ============"
 	time $(FAST_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
 	mkdir -p $(BUILD_DIR)/build/
@@ -128,7 +128,7 @@ endif
 # Andreas, 2020-06-02, AIM XXXII, quick-install-bin seems obsolete since we have quicker-install-bin
 # .PHONY: quick-install-bin ## Install Agda via cabal (or stack if stack.yaml exists).
 # quick-install-bin: ensure-hash-is-correct
-# ifneq ("$(wildcard stack.yaml)","") # if `stack.yaml` exists
+# ifdef HAS_STACK
 # 	@echo "===================== Installing using Stack ============================="
 # 	$(QUICK_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
 # else
@@ -141,7 +141,7 @@ endif
 
 .PHONY: quicker-install-bin ## Install Agda (compiled with -O0) via cabal (or stack if stack.yaml exists).
 quicker-install-bin:
-ifneq ("$(wildcard stack.yaml)","") # if `stack.yaml` exists
+ifdef HAS_STACK
 	@echo "===================== Installing using Stack with -O0 ===================="
 	time $(QUICK_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS) --fast
 else
@@ -478,7 +478,7 @@ install-fix-whitespace : $(FIXW_BIN)
 
 $(FIXW_BIN) :
 	git submodule update --init src/fix-whitespace
-ifneq ("$(wildcard stack.yaml)","") # if `stack.yaml` exists
+ifdef HAS_STACK
 	$(STACK) build fix-whitespace
 	mkdir -p $(FIXW_PATH)/dist/build/fix-whitespace/
 	cp $(shell $(STACK) path --local-install-root)/bin/fix-whitespace $(FIXW_BIN)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TOP=.
 # mk/path.mk uses TOP, so include after the definition of TOP.
 include ./mk/paths.mk
 include ./mk/cabal.mk
-STACK=stack
+include ./mk/stack.mk
 
 # mk/prtty.mk pretty prints information, depending on whether it is run on Travis on not
 include ./mk/pretty.mk

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ ifneq ("$(wildcard stack.yaml)","") # if `stack.yaml` exists
 	@echo "===================== Installing using Stack with test suites ============"
 	time $(STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
 	mkdir -p $(BUILD_DIR)/build/
-	cp -r $(shell stack path --dist-dir)/build $(BUILD_DIR)
+	cp -r $(shell $(STACK) path --dist-dir)/build $(BUILD_DIR)
 else
 # `cabal new-install --enable-tests` emits the error message (bug?):
 # cabal: --enable-tests was specified, but tests can't be enabled in a remote package
@@ -117,7 +117,7 @@ ifneq ("$(wildcard stack.yaml)","") # if `stack.yaml` exists
 	@echo "============= Installing using Stack with -O0 and test suites ============"
 	time $(FAST_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
 	mkdir -p $(BUILD_DIR)/build/
-	cp -r $(shell stack path --dist-dir)/build $(BUILD_DIR)
+	cp -r $(shell $(STACK) path --dist-dir)/build $(BUILD_DIR)
 else
 # `cabal new-install --enable-tests` emits the error message (bug?):
 # cabal: --enable-tests was specified, but tests can't be enabled in a remote package
@@ -204,8 +204,8 @@ clean_helper = if [ -d $(1) ]; then $(CABAL) $(CABAL_CLEAN_CMD) --builddir=$(1);
 clean : ## Clean all local builds
 	$(call clean_helper,$(BUILD_DIR))
 	$(call clean_helper,$(QUICK_BUILD_DIR))
-	stack clean --full
-	stack clean --full --work-dir=$(QUICK_STACK_BUILD_DIR)
+	$(STACK) clean --full
+	$(STACK) clean --full --work-dir=$(QUICK_STACK_BUILD_DIR)
 
 ## Haddock ###################################################################
 
@@ -479,9 +479,9 @@ install-fix-whitespace : $(FIXW_BIN)
 $(FIXW_BIN) :
 	git submodule update --init src/fix-whitespace
 ifneq ("$(wildcard stack.yaml)","") # if `stack.yaml` exists
-	stack build fix-whitespace
+	$(STACK) build fix-whitespace
 	mkdir -p $(FIXW_PATH)/dist/build/fix-whitespace/
-	cp $(shell stack path --local-install-root)/bin/fix-whitespace $(FIXW_BIN)
+	cp $(shell $(STACK) path --local-install-root)/bin/fix-whitespace $(FIXW_BIN)
 else
 	cd $(FIXW_PATH) && $(CABAL) $(CABAL_INSTALL_CMD)
 endif

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,17 @@ endif
 AGDA_TESTS_OPTIONS ?=-i -j$(PARALLEL_TESTS)
 
 CABAL_INSTALL_HELPER = $(CABAL) $(CABAL_INSTALL_CMD) --disable-documentation
-STACK_INSTALL_HELPER = $(STACK) install Agda --no-haddock --system-ghc
+STACK_INSTALL_HELPER = $(STACK) install Agda --no-haddock
+
+# If running on Travis, use --system-ghc.
+# Developers running `make` will usually want to use the GHC version they've
+# specified in their stack.yaml. Otherwise they can put that option in
+# themselves.
+# Note that GitHub workflows currently do not use the Makefile, but instead
+# invoke `stack` directly. (See: .github/workflows/stack.yml)
+ifneq ($(TRAVIS),)
+STACK_INSTALL_HELPER += --system-ghc
+endif
 
 # 2016-07-15. We use a different build directory in the quick
 # installation for avoiding recompilation (see Issue #2083 and

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ CABAL_INSTALL           = $(CABAL_INSTALL_HELPER) \
 STACK_INSTALL           = $(STACK_INSTALL_HELPER) \
                           $(SLOW_STACK_INSTALL_OPTS)
 
-ifeq ("$(shell ghc --info | grep 'target word size' | cut -d\" -f4)","4")
+ifeq ("$(shell $(GHC) --info | grep 'target word size' | cut -d\" -f4)","4")
 GHC_OPTS           = "+RTS -M1.7G -RTS"
 else
 GHC_OPTS           = "+RTS -M4G -RTS"
@@ -371,7 +371,7 @@ quicklatex-test :
 .PHONY : std-library-test ##
 std-lib-test :
 	@$(call decorate, "Standard library test", \
-		(cd std-lib && runghc GenerateEverything.hs && \
+		(cd std-lib && $(RUNGHC) GenerateEverything.hs && \
 						time $(AGDA_BIN) $(AGDA_OPTS) --ignore-interfaces --no-default-libraries -v profile:$(PROFVERB) \
 														 -i. -isrc README.agda \
 														 +RTS -s))

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ endif
 .PHONY: type-check
 type-check:
 	@echo "================= Type checking using Cabal with -fno-code ==============="
-	time cabal $(CABAL_BUILD_CMD) --builddir=$(BUILD_DIR)-no-code \
+	time $(CABAL_CMD) $(CABAL_BUILD_CMD) --builddir=$(BUILD_DIR)-no-code \
 	  --ghc-options=-fno-code \
 	  --ghc-options=-fwrite-interface \
 	  2>&1 \

--- a/benchmark/Create/Makefile
+++ b/benchmark/Create/Makefile
@@ -1,4 +1,8 @@
 # Andreas, 2020-02-15
+#
+TOP=../../
+
+include $(TOP)/mk/paths.mk
 
 .PHONY : default imp-%
 
@@ -7,13 +11,13 @@ default: imp-300
 # Benchmark nested imports with one data decl
 
 imp-% : import-%
-	time agda +RTS -s -RTS -v profile:20 --ignore-interfaces -i $< $</Main.agda
+	time $(AGDA_BIN) +RTS -s -RTS -v profile:20 --ignore-interfaces -i $< $</Main.agda
 
 import-% :
 	runhaskell QuadraticImportOneData.hs $@ $*
 
 imp0-% : import0-%
-	time agda +RTS -s -RTS -v profile:20 --ignore-interfaces -i $< $</Main.agda
+	time $(AGDA_BIN) +RTS -s -RTS -v profile:20 --ignore-interfaces -i $< $</Main.agda
 
 import0-% :
 	runhaskell QuadraticImportOneDataNoUsing.hs $@ $*

--- a/benchmark/Create/Makefile
+++ b/benchmark/Create/Makefile
@@ -3,6 +3,7 @@
 TOP=../../
 
 include $(TOP)/mk/paths.mk
+include $(TOP)/mk/ghc.mk
 
 .PHONY : default imp-%
 
@@ -14,19 +15,19 @@ imp-% : import-%
 	time $(AGDA_BIN) +RTS -s -RTS -v profile:20 --ignore-interfaces -i $< $</Main.agda
 
 import-% :
-	runghc QuadraticImportOneData.hs $@ $*
+	$(RUNGHC) QuadraticImportOneData.hs $@ $*
 
 imp0-% : import0-%
 	time $(AGDA_BIN) +RTS -s -RTS -v profile:20 --ignore-interfaces -i $< $</Main.agda
 
 import0-% :
-	runghc QuadraticImportOneDataNoUsing.hs $@ $*
+	$(RUNGHC) QuadraticImportOneDataNoUsing.hs $@ $*
 
 hs-imp-% : hs-import-%
 	-rm $</*.hi $</*.o $</Main
-	time ghc +RTS -s -RTS -i$< $</Main.hs
+	time $(GHC) +RTS -s -RTS -i$< $</Main.hs
 
 hs-import-% :
-	runghc QuadraticImportOneDataHaskell.hs $@ $*
+	$(RUNGHC) QuadraticImportOneDataHaskell.hs $@ $*
 
 # EOF

--- a/benchmark/Create/Makefile
+++ b/benchmark/Create/Makefile
@@ -14,19 +14,19 @@ imp-% : import-%
 	time $(AGDA_BIN) +RTS -s -RTS -v profile:20 --ignore-interfaces -i $< $</Main.agda
 
 import-% :
-	runhaskell QuadraticImportOneData.hs $@ $*
+	runghc QuadraticImportOneData.hs $@ $*
 
 imp0-% : import0-%
 	time $(AGDA_BIN) +RTS -s -RTS -v profile:20 --ignore-interfaces -i $< $</Main.agda
 
 import0-% :
-	runhaskell QuadraticImportOneDataNoUsing.hs $@ $*
+	runghc QuadraticImportOneDataNoUsing.hs $@ $*
 
 hs-imp-% : hs-import-%
 	-rm $</*.hi $</*.o $</Main
 	time ghc +RTS -s -RTS -i$< $</Main.hs
 
 hs-import-% :
-	runhaskell QuadraticImportOneDataHaskell.hs $@ $*
+	runghc QuadraticImportOneDataHaskell.hs $@ $*
 
 # EOF

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -30,11 +30,11 @@ all : clean $(logDir) $(logFiles)
 
 # If an error is encountered, then the logs are not removed.
 without-creating-logs : all
-	@runghc Benchmark.hs $(TAG)
+	@$(RUNGHC) Benchmark.hs $(TAG)
 	rm -r $(logDir)
 
 summary :
-	@runghc Benchmark.hs
+	@$(RUNGHC) Benchmark.hs
 
 $(logDir) :
 	@mkdir -p $@

--- a/benchmark/ac/Makefile
+++ b/benchmark/ac/Makefile
@@ -2,8 +2,6 @@
 TOP = ../..
 include $(TOP)/mk/paths.mk
 
-agda = $(AGDA_BIN)
-
 ac1 = AC.agda --ignore-interfaces
 ac2 = Example.agda --ignore-interfaces
 ac3 = Example.agda
@@ -14,7 +12,7 @@ foo-% :
 all : test1-$(SUFFIX) test2-$(SUFFIX) test3-$(SUFFIX)
 
 $(LOG_DIR)/%-$(SUFFIX) :
-	$(agda) $($*) +RTS -s$@
+	$(AGDA_BIN) $($*) +RTS -s$@
 	@echo "──────────────────────────────────────────────────────────────────" >> $@
 	@hostinfo >> $@
 

--- a/doc/user-manual/language/Makefile
+++ b/doc/user-manual/language/Makefile
@@ -1,7 +1,7 @@
 # Makefile for documentation
 
 default :
-	make -C ../../.. user-manual-test
-	make -C .. html
+	$(MAKE) -C ../../.. user-manual-test
+	$(MAKE) -C .. html
 
 # EOF

--- a/doc/user-manual/tools/Makefile
+++ b/doc/user-manual/tools/Makefile
@@ -1,7 +1,7 @@
 # Makefile for documentation
 
 default :
-	make -C .. html
-	make -C ../../.. user-manual-test
+	$(MAKE) -C .. html
+	$(MAKE) -C ../../.. user-manual-test
 
 # EOF

--- a/mk/cabal.mk
+++ b/mk/cabal.mk
@@ -1,7 +1,7 @@
 
-CABAL_CMD=cabal
+CABAL=cabal
 
-CABAL_VERSION := $(shell $(CABAL_CMD) --numeric-version | cut -d. -f1-2)
+CABAL_VERSION := $(shell $(CABAL) --numeric-version | cut -d. -f1-2)
 
 # Amazing hack to do =< comparison (due to https://stackoverflow.com/questions/3437160).
 # Relies on there being no cabal 2.10.x or above.

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -1,0 +1,11 @@
+# All makefiles must define TOP, corresponding to the Agda root directory.
+ifeq ($(TOP),)
+  $(error "Makefiles must define the TOP variable to correspond with the Agda source root")
+endif
+
+# Include the user config makefile, if it exists. That file is .gitignored.
+# We could do `-include …` to silently try, but that would not bail on errors.
+USER_CONFIG_MK := $(TOP)/mk/config.mk
+ifneq ($(wildcard $(USER_CONFIG_MK)),)
+include $(USER_CONFIG_MK)
+endif

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -3,6 +3,16 @@ ifeq ($(TOP),)
   $(error "Makefiles must define the TOP variable to correspond with the Agda source root")
 endif
 
+# Standard "as safe as bash can be, which isn't very" flags to eagerly detect
+# problems rather than barging on through and possibly executing unsafe
+# commands in an unexpected state.
+#  -E inherits ERR traps on subcommands and subshells.
+#  -e exits on errors.
+#  -o pipefail propagates errors through piped sequences.
+#  -c indicates the start of the command.
+SHELL := bash
+.SHELLFLAGS := -Eeu -o pipefail -c
+
 # Include the user config makefile, if it exists. That file is .gitignored.
 # We could do `-include …` to silently try, but that would not bail on errors.
 USER_CONFIG_MK := $(TOP)/mk/config.mk

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -10,9 +10,9 @@ ifneq ($(wildcard $(USER_CONFIG_MK)),)
 include $(USER_CONFIG_MK)
 endif
 
-# use gsed on Mac OS instead of sed
+# Use gsed on Mac OS instead of sed
 ifeq ($(shell uname), Darwin)
-sed=gsed
+  SED := gsed
 else
-sed=sed
+  SED := sed
 endif

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -16,8 +16,33 @@ SHELL := bash
 # Include the user config makefile, if it exists. That file is .gitignored.
 # We could do `-include …` to silently try, but that would not bail on errors.
 USER_CONFIG_MK := $(TOP)/mk/config.mk
+
 ifneq ($(wildcard $(USER_CONFIG_MK)),)
 include $(USER_CONFIG_MK)
+else
+  # The Agda makefiles prior to PR #4841 would load `mk/parallel-test.mk`,
+  # which, if existed, would be expected to define the single variable
+  # `PARALLEL_TESTS`. They did not load `mk/config.mk` or expect that to exist.
+  #
+  # It's simpler to maintain a single source of truth for user configuration.
+  # So: if the new `mk/config.mk` file does not exist, but the old
+  # `mk/parallel-tests.mk` does, load it and gently nudge them toward putting
+  # creating a `mk/config.mk`.
+  #
+  # We don't create it automatically because this loading phase may not be
+  # atomic and we don't want to clobber things that aren't build targets.
+  #
+  # The following lines should be removed at some point in the mid future.
+  DEPRECATED_PARALLEL_TESTS_MK := $(TOP)/mk/parallel-tests.mk
+  ifneq ($(wildcard $(DEPRECATED_PARALLEL_TESTS_MK)),)
+    ifndef DID_WARN_DEPRECATED_PARALLEL_TESTS_MK
+      export DID_WARN_DEPRECATED_PARALLEL_TESTS_MK := 1
+      $(warning Loading deprecated $(DEPRECATED_PARALLEL_TESTS_MK))
+      $(warning Please put custom makefile options in $(USER_CONFIG_MK) instead.)
+      $(warning (It can contain the line "include $$(TOP)/mk/parallel-tests.mk", if you want))
+    endif
+    include $(DEPRECATED_PARALLEL_TESTS_MK)
+  endif
 endif
 
 # Use gsed on Mac OS instead of sed

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -9,3 +9,10 @@ USER_CONFIG_MK := $(TOP)/mk/config.mk
 ifneq ($(wildcard $(USER_CONFIG_MK)),)
 include $(USER_CONFIG_MK)
 endif
+
+# use gsed on Mac OS instead of sed
+ifeq ($(shell uname), Darwin)
+sed=gsed
+else
+sed=sed
+endif

--- a/mk/ghc.mk
+++ b/mk/ghc.mk
@@ -1,0 +1,8 @@
+# GHC version removing the patchlevel number (e.g. in GHC 7.10.3, the
+# patchlevel number is 3).
+
+# We ask if GHC is available for removing a warning on Travis when
+# testing the documentation.
+ifneq ($(shell which ghc),)
+GHC_VERSION := $(shell ghc --numeric-version | cut -d. -f1-2)
+endif

--- a/mk/ghc.mk
+++ b/mk/ghc.mk
@@ -1,8 +1,16 @@
+ifeq ($(GHC),)
+GHC := $(shell which ghc)
+endif
+
+ifeq ($(RUNGHC),)
+RUNGHC := $(shell which runghc)
+endif
+
 # GHC version removing the patchlevel number (e.g. in GHC 7.10.3, the
 # patchlevel number is 3).
 
 # We ask if GHC is available for removing a warning on Travis when
 # testing the documentation.
-ifneq ($(shell which ghc),)
-GHC_VERSION := $(shell ghc --numeric-version | cut -d. -f1-2)
+ifneq ($(GHC),)
+GHC_VERSION := $(shell $(GHC) --numeric-version | cut -d. -f1-2)
 endif

--- a/mk/ghc.mk
+++ b/mk/ghc.mk
@@ -1,9 +1,20 @@
+include $(TOP)/mk/cabal.mk
+include $(TOP)/mk/stack.mk
+
 ifeq ($(GHC),)
-GHC := $(shell which ghc)
+  ifdef HAS_STACK
+    GHC := stack ghc --
+  else
+    GHC := $(shell which ghc)
+  endif
 endif
 
 ifeq ($(RUNGHC),)
-RUNGHC := $(shell which runghc)
+  ifdef HAS_STACK
+    RUNGHC := stack runghc --
+  else
+    RUNGHC := $(shell which runghc)
+  endif
 endif
 
 # GHC version removing the patchlevel number (e.g. in GHC 7.10.3, the

--- a/mk/paths.mk
+++ b/mk/paths.mk
@@ -1,5 +1,6 @@
 include $(TOP)/mk/common.mk
 include $(TOP)/mk/versions.mk
+include $(TOP)/mk/ghc.mk
 
 MACRO_DIR = $(TOP)/macros
 

--- a/mk/paths.mk
+++ b/mk/paths.mk
@@ -1,3 +1,4 @@
+include $(TOP)/mk/common.mk
 include $(TOP)/mk/versions.mk
 
 MACRO_DIR = $(TOP)/macros

--- a/mk/stack.mk
+++ b/mk/stack.mk
@@ -1,0 +1,1 @@
+STACK=stack

--- a/mk/stack.mk
+++ b/mk/stack.mk
@@ -1,1 +1,7 @@
 STACK=stack
+
+ifneq ($(wildcard $(TOP)/stack.yaml),)
+  HAS_STACK := 1
+else
+  undefine HAS_STACK
+endif

--- a/mk/versions.mk
+++ b/mk/versions.mk
@@ -1,4 +1,5 @@
 # Agda version.
+# This is incremented via the script src/release-tools/change-version.bash
 VERSION=2.6.2
 
 # GHC version removing the patchlevel number (e.g. in GHC 7.10.3, the

--- a/mk/versions.mk
+++ b/mk/versions.mk
@@ -1,12 +1,3 @@
 # Agda version.
 # This is incremented via the script src/release-tools/change-version.bash
 VERSION=2.6.2
-
-# GHC version removing the patchlevel number (e.g. in GHC 7.10.3, the
-# patchlevel number is 3).
-
-# We ask if GHC is available for removing a warning on Travis when
-# testing the documentation.
-ifneq ($(shell which ghc),)
-GHC_VERSION := $(shell ghc --numeric-version | cut -d. -f1-2)
-endif

--- a/src/hTags/Makefile
+++ b/src/hTags/Makefile
@@ -10,9 +10,9 @@ include ../../mk/cabal.mk
 default : $(bin)
 
 $(setup) : hTags.cabal
-	$(CABAL_CMD) $(CABAL_OLD_INSTALL_CMD) --only-dependencies
-	$(CABAL_CMD) $(CABAL_OLD_CONFIGURE_CMD)
+	$(CABAL) $(CABAL_OLD_INSTALL_CMD) --only-dependencies
+	$(CABAL) $(CABAL_OLD_CONFIGURE_CMD)
 
 $(bin) : $(setup) $(sources)
-	$(CABAL_CMD) $(CABAL_OLD_BUILD_CMD)
+	$(CABAL) $(CABAL_OLD_BUILD_CMD)
 

--- a/src/size-solver/Makefile
+++ b/src/size-solver/Makefile
@@ -12,7 +12,7 @@ ifneq ("$(wildcard ../../stack.yaml)","") # if `stack.yaml` exists
 	mkdir -p dist/build/size-solver
 	cp $(shell stack path --local-install-root)/bin/size-solver dist/build/size-solver/size-solver
 else
-	$(CABAL_CMD) $(CABAL_INSTALL_CMD)
+	$(CABAL) $(CABAL_INSTALL_CMD)
 endif
 
 # Tested with shelltestrunner 1.9.

--- a/src/size-solver/Makefile
+++ b/src/size-solver/Makefile
@@ -1,16 +1,16 @@
 SHELL=bash
 
 TOP=../../
-# include $(TOP)/mk/versions.mk
 
 include $(TOP)/mk/cabal.mk
+include $(TOP)/mk/stack.mk
 
 .PHONY : install-bin
 install-bin :
 ifneq ("$(wildcard ../../stack.yaml)","") # if `stack.yaml` exists
-	stack build size-solver
+	$(STACK) build size-solver
 	mkdir -p dist/build/size-solver
-	cp $(shell stack path --local-install-root)/bin/size-solver dist/build/size-solver/size-solver
+	cp $(shell $(STACK) path --local-install-root)/bin/size-solver dist/build/size-solver/size-solver
 else
 	$(CABAL) $(CABAL_INSTALL_CMD)
 endif
@@ -19,7 +19,7 @@ endif
 .PHONY : test
 test :
 ifneq ("$(wildcard ../../stack.yaml)","") # if `stack.yaml` exists
-	stack install shelltestrunner
+	$(STACK) install shelltestrunner
 endif
 	shelltest --color --precise test/succeed.test
 	shelltest --color --precise test/fail.test

--- a/src/size-solver/Makefile
+++ b/src/size-solver/Makefile
@@ -7,7 +7,7 @@ include $(TOP)/mk/stack.mk
 
 .PHONY : install-bin
 install-bin :
-ifneq ("$(wildcard ../../stack.yaml)","") # if `stack.yaml` exists
+ifdef HAS_STACK
 	$(STACK) build size-solver
 	mkdir -p dist/build/size-solver
 	cp $(shell $(STACK) path --local-install-root)/bin/size-solver dist/build/size-solver/size-solver
@@ -18,7 +18,7 @@ endif
 # Tested with shelltestrunner 1.9.
 .PHONY : test
 test :
-ifneq ("$(wildcard ../../stack.yaml)","") # if `stack.yaml` exists
+ifdef HAS_STACK
 	$(STACK) install shelltestrunner
 endif
 	shelltest --color --precise test/succeed.test

--- a/src/size-solver/Makefile
+++ b/src/size-solver/Makefile
@@ -1,5 +1,3 @@
-SHELL=bash
-
 TOP=../../
 
 include $(TOP)/mk/cabal.mk

--- a/test/LibSucceed/Makefile
+++ b/test/LibSucceed/Makefile
@@ -4,7 +4,6 @@
 # Makefile for successful tests depending on the standard library
 # Author: Andreas Abel, Ulf Norell
 # Created: 2012-02-24 (from test/succeed/Makefile)
-SHELL=bash
 
 TOP=../..
 

--- a/test/api/Makefile
+++ b/test/api/Makefile
@@ -11,8 +11,8 @@ all : Issue1168.api PrettyInterface.api ScopeFromInterface.api
 
 %.api : %.agdai %.hs
 	$(eval tmpdir = $(shell mktemp -d /tmp/api-test.XXXX))
-ifneq ("$(wildcard ../../stack.yaml)","") # if `stack.yaml` exists
-	stack ghc -- -Wall -Werror -o $(tmpdir)/$* $*.hs
+ifneq ("$(wildcard $(TOP)/stack.yaml)","") # if `stack.yaml` exists
+	$(STACK) ghc -- -Wall -Werror -o $(tmpdir)/$* $*.hs
 else
 	$(GHC) -Wall -Werror -package Agda-$(VERSION) -o $(tmpdir)/$* $*.hs
 endif

--- a/test/api/Makefile
+++ b/test/api/Makefile
@@ -14,7 +14,7 @@ all : Issue1168.api PrettyInterface.api ScopeFromInterface.api
 ifneq ("$(wildcard ../../stack.yaml)","") # if `stack.yaml` exists
 	stack ghc -- -Wall -Werror -o $(tmpdir)/$* $*.hs
 else
-	ghc -Wall -Werror -package Agda-$(VERSION) -o $(tmpdir)/$* $*.hs
+	$(GHC) -Wall -Werror -package Agda-$(VERSION) -o $(tmpdir)/$* $*.hs
 endif
 	$(tmpdir)/$*
 	rm -r $(tmpdir)

--- a/test/api/Makefile
+++ b/test/api/Makefile
@@ -11,11 +11,7 @@ all : Issue1168.api PrettyInterface.api ScopeFromInterface.api
 
 %.api : %.agdai %.hs
 	$(eval tmpdir = $(shell mktemp -d /tmp/api-test.XXXX))
-ifdef HAS_STACK
-	$(STACK) ghc -- -Wall -Werror -o $(tmpdir)/$* $*.hs
-else
 	$(GHC) -Wall -Werror -package Agda-$(VERSION) -o $(tmpdir)/$* $*.hs
-endif
 	$(tmpdir)/$*
 	rm -r $(tmpdir)
 

--- a/test/api/Makefile
+++ b/test/api/Makefile
@@ -11,7 +11,7 @@ all : Issue1168.api PrettyInterface.api ScopeFromInterface.api
 
 %.api : %.agdai %.hs
 	$(eval tmpdir = $(shell mktemp -d /tmp/api-test.XXXX))
-ifneq ("$(wildcard $(TOP)/stack.yaml)","") # if `stack.yaml` exists
+ifdef HAS_STACK
 	$(STACK) ghc -- -Wall -Werror -o $(tmpdir)/$* $*.hs
 else
 	$(GHC) -Wall -Werror -package Agda-$(VERSION) -o $(tmpdir)/$* $*.hs

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -5,9 +5,6 @@ include $(TOP)/mk/paths.mk
 # Extra options when running agda --interaction
 AGDA_OPT=--no-default-libraries
 
-# Enable read -n and 2>&1 |.
-SHELL=/usr/bin/env bash
-
 # Get the current directory (OS dependent).
 uname:=$(shell uname)
 ifeq (NT-5,$(findstring NT-5,$(uname)))
@@ -44,7 +41,10 @@ filter=$(SED) -e 's"$(pwdPlusDelimiter)""g' \
               -e 's/Agda2> //g' \
      | $(clean)
 
-run_test=if test -f $*.in; \
+# Turn off "eager failure" flags (e, E, pipefail) while running the test.
+run_test=\
+    set +eE +o pipefail; \
+    if test -f $*.in; \
     then cat $*.in \
          | $(SED) "s/ioTCM/IOTCM/g" \
          | $(SED) "s/cmd_give/(cmd_give WithoutForce)/g" \

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -122,8 +122,6 @@ $(OutFiles) : %.out : $$($$@.*agda) $$($$@.in $$@.hs $$@.sh)
 	@echo "=== End of output ==="
 	@rm -rf $(TMPDIR)
 
-#			diff -b $*.out $*.tmp;
-
 # Comparing output
 ########################################################################
 
@@ -137,7 +135,7 @@ $(Tests) : %.cmp : %.out
 	@rm -f "$(@:.cmp=.agdai)"
 	@echo $*
 	@$(run_test) > $*.tmp
-	@if diff -b $*.out $*.tmp; \
+	@if diff -q -b $*.out $*.tmp; \
 		then rm -f $*.tmp; true; \
 		else \
 			for file in ls `$*.*agda`; do touch $file; done ; \

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -144,7 +144,7 @@ $(Tests) : %.cmp : %.out
 			echo "=== New output ==="; \
 			cat $*.tmp; \
 			echo "=== Diff ==="; \
-			wdiff $*.out $*.tmp | colordiff; \
+			(  git diff --no-index --no-ext-diff -w $*.out $*.tmp || true  ) ; \
 			echo -n "Accept new error [y/n/Q] (default: no)? "; \
 			read -n 1; \
 			echo ""; \

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -138,7 +138,7 @@ $(Tests) : %.cmp : %.out
 	@if diff -q -b $*.out $*.tmp; \
 		then rm -f $*.tmp; true; \
 		else \
-			for file in ls `$*.*agda`; do touch $file; done ; \
+			touch -c $*.*agda; \
 			echo "=== Old output ==="; \
 			cat $*.out; \
 			echo "=== New output ==="; \

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -11,7 +11,7 @@ SHELL=/usr/bin/env bash
 # Get the current directory (OS dependent).
 uname:=$(shell uname)
 ifeq (NT-5,$(findstring NT-5,$(uname)))
-pwd=$(shell (cmd /c 'echo %CD%') | sed -e 's/\\/\\\\\\\\/g')
+pwd=$(shell (cmd /c 'echo %CD%') | $(SED) -e 's/\\/\\\\\\\\/g')
 pwdPlusDelimiter=$(pwd)\\\\
 else
 pwd=$(shell pwd)

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -18,13 +18,6 @@ pwd=$(shell pwd)
 pwdPlusDelimiter=$(pwd)/
 endif
 
-# use gsed on Mac OS instead of sed
-ifeq (Darwin,$(findstring Darwin,$(uname)))
-sed=gsed
-else
-sed=sed
-endif
-
 clean=/usr/bin/env bash $(shell pwd)/clean.sh $(sed)
 
 # Construct the list of tests to carry out.

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -18,7 +18,7 @@ pwd=$(shell pwd)
 pwdPlusDelimiter=$(pwd)/
 endif
 
-clean=/usr/bin/env bash $(shell pwd)/clean.sh $(sed)
+clean=/usr/bin/env bash $(shell pwd)/clean.sh $(SED)
 
 # Construct the list of tests to carry out.
 # Andreas, 2017-04-24 ls -t: sort by newest first
@@ -33,7 +33,7 @@ export BUILDDIR=_build/
 
 # Filter out absolute pathes, make all whitespace equal, remove
 # "Linking..." messages since GHC 7.0 doesn't have them.
-filter=$(sed) -e 's"$(pwdPlusDelimiter)""g' \
+filter=$(SED) -e 's"$(pwdPlusDelimiter)""g' \
               -e 's"$(pwd)""g' \
               -e 's" \"$(TMPDIR).*\"""' \
               -e 's"[^ (\"]*lib.prim"agda-default-include-path"g' \
@@ -46,15 +46,15 @@ filter=$(sed) -e 's"$(pwdPlusDelimiter)""g' \
 
 run_test=if test -f $*.in; \
     then cat $*.in \
-         | $(sed) "s/ioTCM/IOTCM/g" \
-         | $(sed) "s/cmd_give/(cmd_give WithoutForce)/g" \
-         | $(sed) "s/cmd_/Cmd_/g" \
-         | $(sed) "s/showImplicitArgs/ShowImplicitArgs/g" \
-         | $(sed) "s/toggleImplicitArgs/ToggleImplicitArgs/g" \
-         | $(sed) "s/top_command/IOTCM currentFile None Indirect/g" \
-         | $(sed) "s/goal_command \\([0-9]\+\\) (\\([^)]\+\\)) \\(\"[^\"]*\"\\)/IOTCM currentFile None Indirect (\\2 \\1 noRange \\3)/g" \
-         | $(sed) "s/goal_command \\([0-9]\+\\) \\([^ ]\+\\) \\(\"[^\"]*\"\\)/IOTCM currentFile None Indirect (\\2 \\1 noRange \\3)/g" \
-         | $(sed) "s/currentFile/\"$(wildcard $*.agda $*.lagda)\"/g" \
+         | $(SED) "s/ioTCM/IOTCM/g" \
+         | $(SED) "s/cmd_give/(cmd_give WithoutForce)/g" \
+         | $(SED) "s/cmd_/Cmd_/g" \
+         | $(SED) "s/showImplicitArgs/ShowImplicitArgs/g" \
+         | $(SED) "s/toggleImplicitArgs/ToggleImplicitArgs/g" \
+         | $(SED) "s/top_command/IOTCM currentFile None Indirect/g" \
+         | $(SED) "s/goal_command \\([0-9]\+\\) (\\([^)]\+\\)) \\(\"[^\"]*\"\\)/IOTCM currentFile None Indirect (\\2 \\1 noRange \\3)/g" \
+         | $(SED) "s/goal_command \\([0-9]\+\\) \\([^ ]\+\\) \\(\"[^\"]*\"\\)/IOTCM currentFile None Indirect (\\2 \\1 noRange \\3)/g" \
+         | $(SED) "s/currentFile/\"$(wildcard $*.agda $*.lagda)\"/g" \
          | $(AGDA_BIN) -v0 -i . -i .. --interaction --ignore-interfaces $(AGDA_OPT) $(RTS_$*) \
            2>&1 | $(filter) ; \
     elif test -f $*.hs; \

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -58,7 +58,7 @@ run_test=if test -f $*.in; \
          | $(AGDA_BIN) -v0 -i . -i .. --interaction --ignore-interfaces $(AGDA_OPT) $(RTS_$*) \
            2>&1 | $(filter) ; \
     elif test -f $*.hs; \
-    then /usr/bin/env runghc --ghc-arg=-v0 --ghc-arg=-w ./$*.hs $(AGDA_BIN) 2>&1 | $(filter) ; \
+    then $(RUNGHC) --ghc-arg=-v0 --ghc-arg=-w ./$*.hs $(AGDA_BIN) 2>&1 | $(filter) ; \
     else /usr/bin/env bash ./$*.sh $(AGDA_BIN) > $(TMPDIR)/$*.tmp_out ; \
          cat $(TMPDIR)/$*.tmp_out | $(filter) ; \
     fi

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -58,7 +58,7 @@ run_test=if test -f $*.in; \
          | $(AGDA_BIN) -v0 -i . -i .. --interaction --ignore-interfaces $(AGDA_OPT) $(RTS_$*) \
            2>&1 | $(filter) ; \
     elif test -f $*.hs; \
-    then /usr/bin/env runhaskell --ghc-arg=-v0 --ghc-arg=-w ./$*.hs $(AGDA_BIN) 2>&1 | $(filter) ; \
+    then /usr/bin/env runghc --ghc-arg=-v0 --ghc-arg=-w ./$*.hs $(AGDA_BIN) 2>&1 | $(filter) ; \
     else /usr/bin/env bash ./$*.sh $(AGDA_BIN) > $(TMPDIR)/$*.tmp_out ; \
          cat $(TMPDIR)/$*.tmp_out | $(filter) ; \
     fi

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -113,7 +113,7 @@ RTS_Issue1785      = --library-file=issue1785.libs
 
 .SECONDEXPANSION:
 $(OutFiles) : %.out : $$($$@.*agda) $$($$@.in $$@.hs $$@.sh)
-	@-mkdir $(TMPDIR)
+	@-mkdir -p $(TMPDIR)
 	@$(setup_$*)
 	@rm -f "$(@:.out=.agdai)"
 	@echo "=== Output for $* ==="
@@ -130,7 +130,7 @@ $(OutFiles) : %.out : $$($$@.*agda) $$($$@.in $$@.hs $$@.sh)
 # thus, we sort it up for the next run by touching the .agda file.
 
 $(Tests) : %.cmp : %.out
-	@-mkdir $(TMPDIR)
+	@-mkdir -p $(TMPDIR)
 	@$(setup_$*)
 	@rm -f "$(@:.cmp=.agdai)"
 	@echo $*

--- a/test/lib-interaction/Makefile
+++ b/test/lib-interaction/Makefile
@@ -4,9 +4,6 @@ TOP = ../..
 
 include $(TOP)/mk/paths.mk
 
-# Enable read -n and 2>&1 |.
-SHELL=/usr/bin/env bash
-
 uname:=$(shell uname)
 ifeq (NT-5,$(findstring NT-5,$(uname)))
 pwd=$(shell (cmd /c 'echo %CD%') | $(SED) -e 's/\\/\\\\\\\\/g')
@@ -35,7 +32,10 @@ filter=$(SED) -e 's"$(pwdPlusDelimiter)""g' \
               -e 's/\(\\n\| \)\+/ /g' \
      | $(clean)
 
-run_test=if test -f $*.in; \
+# Turn off "eager failure" flags (e, E, pipefail) while running the test.
+run_test=\
+    set +eE +o pipefail; \
+    if test -f $*.in; \
     then cat $*.in \
          | $(SED) "s/ioTCM/IOTCM/g" \
          | $(SED) "s/cmd_/Cmd_/g" \

--- a/test/lib-interaction/Makefile
+++ b/test/lib-interaction/Makefile
@@ -16,7 +16,7 @@ pwd=$(shell pwd)
 pwdPlusDelimiter=$(pwd)/
 endif
 
-clean=/usr/bin/env bash $(shell pwd)/clean.sh $(sed)
+clean=/usr/bin/env bash $(shell pwd)/clean.sh $(SED)
 
 # Andreas, 2017-04-24 ls -t: sort by newest first
 AgdaFiles=$(shell ls -t *agda)
@@ -28,7 +28,7 @@ default : $(Tests)
 export TMPDIR=highlighting-tmp
 
 # Filter out absolute pathes
-filter=$(sed) -e 's"$(pwdPlusDelimiter)""g' \
+filter=$(SED) -e 's"$(pwdPlusDelimiter)""g' \
               -e 's"$(pwd)""g' \
               -e 's" \"$(TMPDIR).*\"""' \
               -e 's"[^ (\"]*lib.prim"agda-default-include-path"g' \
@@ -37,14 +37,14 @@ filter=$(sed) -e 's"$(pwdPlusDelimiter)""g' \
 
 run_test=if test -f $*.in; \
     then cat $*.in \
-         | $(sed) "s/ioTCM/IOTCM/g" \
-         | $(sed) "s/cmd_/Cmd_/g" \
-         | $(sed) "s/showImplicitArgs/ShowImplicitArgs/g" \
-         | $(sed) "s/toggleImplicitArgs/ToggleImplicitArgs/g" \
-         | $(sed) "s/top_command/IOTCM currentFile None Indirect/g" \
-         | $(sed) "s/goal_command \\([0-9]\+\\) (\\([^)]\+\\)) \\(\"[^\"]*\"\\)/IOTCM currentFile None Indirect (\\2 \\1 noRange \\3)/g" \
-         | $(sed) "s/goal_command \\([0-9]\+\\) \\([^ ]\+\\) \\(\"[^\"]*\"\\)/IOTCM currentFile None Indirect (\\2 \\1 noRange \\3)/g" \
-         | $(sed) "s/currentFile/\"$(wildcard $*.agda $*.lagda)\"/g" \
+         | $(SED) "s/ioTCM/IOTCM/g" \
+         | $(SED) "s/cmd_/Cmd_/g" \
+         | $(SED) "s/showImplicitArgs/ShowImplicitArgs/g" \
+         | $(SED) "s/toggleImplicitArgs/ToggleImplicitArgs/g" \
+         | $(SED) "s/top_command/IOTCM currentFile None Indirect/g" \
+         | $(SED) "s/goal_command \\([0-9]\+\\) (\\([^)]\+\\)) \\(\"[^\"]*\"\\)/IOTCM currentFile None Indirect (\\2 \\1 noRange \\3)/g" \
+         | $(SED) "s/goal_command \\([0-9]\+\\) \\([^ ]\+\\) \\(\"[^\"]*\"\\)/IOTCM currentFile None Indirect (\\2 \\1 noRange \\3)/g" \
+         | $(SED) "s/currentFile/\"$(wildcard $*.agda $*.lagda)\"/g" \
          | $(AGDA_BIN) -v 0 -i . -i .. --interaction --no-default-libraries $(RTS_$*) \
            2>&1 | $(filter) ; \
     else /usr/bin/env bash ./$*.sh $(AGDA_BIN) > $(TMPDIR)/$*.tmp_out ; \

--- a/test/lib-interaction/Makefile
+++ b/test/lib-interaction/Makefile
@@ -79,7 +79,7 @@ $(Tests) : %.cmp : %.out
 	@rm -f "$(@:.cmp=.agdai)"
 	@echo $*
 	@$(run_test) > $*.tmp
-	@if diff -b $*.out $*.tmp; \
+	@if diff -q -b $*.out $*.tmp; \
 		then rm -f $*.tmp; true; \
 		else \
 			echo "=== Old output ==="; \

--- a/test/lib-interaction/Makefile
+++ b/test/lib-interaction/Makefile
@@ -9,7 +9,7 @@ SHELL=/usr/bin/env bash
 
 uname:=$(shell uname)
 ifeq (NT-5,$(findstring NT-5,$(uname)))
-pwd=$(shell (cmd /c 'echo %CD%') | sed -e 's/\\/\\\\\\\\/g')
+pwd=$(shell (cmd /c 'echo %CD%') | $(SED) -e 's/\\/\\\\\\\\/g')
 pwdPlusDelimiter=$(pwd)\\\\
 else
 pwd=$(shell pwd)

--- a/test/lib-interaction/Makefile
+++ b/test/lib-interaction/Makefile
@@ -87,7 +87,7 @@ $(Tests) : %.cmp : %.out
 			echo "=== New output ==="; \
 			cat $*.tmp; \
 			echo "=== Diff ==="; \
-			diff -b $*.out $*.tmp; \
+			( git diff --no-index --no-ext-diff -w $*.out $*.tmp || true ) ; \
 			/bin/echo -n "Accept new error [y/N/q]? "; \
 			read -n 1; \
 			echo ""; \

--- a/test/lib-interaction/Makefile
+++ b/test/lib-interaction/Makefile
@@ -16,13 +16,6 @@ pwd=$(shell pwd)
 pwdPlusDelimiter=$(pwd)/
 endif
 
-# use gsed on Mac OS instead of sed
-ifeq (Darwin,$(findstring Darwin,$(uname)))
-sed=gsed
-else
-sed=sed
-endif
-
 clean=/usr/bin/env bash $(shell pwd)/clean.sh $(sed)
 
 # Andreas, 2017-04-24 ls -t: sort by newest first

--- a/test/lib-interaction/Makefile
+++ b/test/lib-interaction/Makefile
@@ -63,7 +63,7 @@ run_test=if test -f $*.in; \
 
 # No recorded output
 $(OutFiles) : %.out : $(wildcard %.agda %.lagda) $(wildcard %.in %.in_ghci)
-	@-mkdir $(TMPDIR)
+	@-mkdir -p $(TMPDIR)
 	@$(setup_$*)
 	@rm -f "$(@:.out=.agdai)"
 	@echo "=== Output for $* ==="
@@ -74,7 +74,7 @@ $(OutFiles) : %.out : $(wildcard %.agda %.lagda) $(wildcard %.in %.in_ghci)
 
 # Comparing output
 $(Tests) : %.cmp : %.out
-	@-mkdir $(TMPDIR)
+	@-mkdir -p $(TMPDIR)
 	@$(setup_$*)
 	@rm -f "$(@:.cmp=.agdai)"
 	@echo $*


### PR DESCRIPTION
This includes a bunch of teensy improvements, nothing huge. `make && make test` had lots of strange failures for me when run out of the box with a normal stack configuration.

Some highlights:
  * Set safe-ish bash flags (`set -Eeu -o pipefail`) for make recipes. This should prevent (or at least reduce) make barging head when things go wrong.
  * Consistently invoke `ghc` or `runghc` via `stack ghc`/`stack runghc`, if using stack. This solved a lot of head-scratching issues for me.
  * Along the same lines, don't force `--system-ghc` for stack. The user can specify that, but they probably don't want it. I've left it enabled for Travis just in case.
  * No longer depend on systems having `wdiff` or `colordiff` installed. (macOS doesn't by default). Instead it uses `git diff`, which will use diff coloring if the user has that set up, and they probably do. Also it's guaranteed to be installed.

This cleans up a few trivial consistency issues and one or two makefile bugs caught by the stricter bash flags.