### PR TITLE
Remove `Null Modality` instance, inline its single use

### DIFF
--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -366,9 +366,6 @@ data Modality = Modality
 defaultModality :: Modality
 defaultModality = Modality defaultRelevance defaultQuantity defaultCohesion
 
-instance Null Modality where
-  empty = defaultModality
-
 -- | Pointwise composition.
 instance Semigroup Modality where
   Modality r q c <> Modality r' q' c' = Modality (r <> r') (q <> q') (c <> c')

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2551,7 +2551,7 @@ mergeEqualPs = go (empty, [])
   where
     go acc (p@(Arg i (Named mn (A.EqualP r es))) : ps) = setCurrentRange p $ do
       -- Face constraint patterns must be defaultNamedArg; check this:
-      unless (null $ getModality i) __IMPOSSIBLE__
+      unless (getModality i == defaultModality) __IMPOSSIBLE__
       when (hidden     i) $ warn i $ "Face constraint patterns cannot be hidden arguments"
       when (isInstance i) $ warn i $ "Face constraint patterns cannot be instance arguments"
       whenJust mn $ \ x -> setCurrentRange x $ warn x $ P.hcat


### PR DESCRIPTION
This fixes #4845 in the smallest way possible.

The `Null Modality` instance was dangerous: its `empty` (and therefore `null` method) did not correspond to the `Monoid Modality` `mempty`. Thankfully it turned out to be used hardly anywhere. This PR should introduce no functional changes.

There still exist some ambiguities with the use of `mempty` vs. `defaultModality`, but those could be addressed separately.