### PR TITLE
Fix #4848 - Missing Agda.Builtin.Reflection.External from data-files in Agda.cabal

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -112,6 +112,7 @@ data-files:         Agda.css
                     lib/prim/Agda/Builtin/Maybe.agda
                     lib/prim/Agda/Builtin/Nat.agda
                     lib/prim/Agda/Builtin/Reflection.agda
+                    lib/prim/Agda/Builtin/Reflection/External.agda
                     lib/prim/Agda/Builtin/Reflection/Properties.agda
                     lib/prim/Agda/Builtin/Sigma.agda
                     lib/prim/Agda/Builtin/Size.agda

--- a/src/data/lib/prim/Agda/Builtin/Reflection/External.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection/External.agda
@@ -6,6 +6,7 @@ open import Agda.Builtin.List
 open import Agda.Builtin.Nat
 open import Agda.Builtin.Sigma
 open import Agda.Builtin.String
+open import Agda.Builtin.Reflection
 
 postulate
   execTC : String → List String → String

--- a/test/Succeed/ExecAgda.agda
+++ b/test/Succeed/ExecAgda.agda
@@ -9,15 +9,11 @@ open import Agda.Builtin.Unit
 open import Agda.Builtin.Sigma
 open import Agda.Builtin.String
 open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
-
-postulate
-  execTC : String → List String → String → TC (Σ Nat (λ _ → Σ String (λ _ → String)))
-
-{-# BUILTIN AGDATCMEXEC execTC #-}
+open import Agda.Builtin.Reflection.External
 
 macro
   test : Term → TC ⊤
-  test hole = execTC "agda" ("-v0" ∷ "-i" ∷ "test/Succeed" ∷ "test/Succeed/exec-tc/empty.agda" ∷ []) ""
+  test hole = execTC "agda" ("-v0" ∷ "-i" ∷ "test/Succeed" ∷ "exec-tc/empty.agda" ∷ []) ""
           >>= λ{(exitCode , (stdOut , stdErr)) → unify hole (lit (string stdOut))}
 
 _ : test ≡ ""

--- a/test/Succeed/ExecAgda.agda
+++ b/test/Succeed/ExecAgda.agda
@@ -13,7 +13,7 @@ open import Agda.Builtin.Reflection.External
 
 macro
   test : Term → TC ⊤
-  test hole = execTC "agda" ("-v0" ∷ "-i" ∷ "test/Succeed" ∷ "exec-tc/empty.agda" ∷ []) ""
+  test hole = execTC "agda" ("-v0" ∷ "-i" ∷ "test/Succeed" ∷ "test/Succeed/exec-tc/empty.agda" ∷ []) ""
           >>= λ{(exitCode , (stdOut , stdErr)) → unify hole (lit (string stdOut))}
 
 _ : test ≡ ""


### PR DESCRIPTION
I think this should fix issue #4848. 

Unfortunately, I can't verify that it works, since I can't run the tests locally.