### PR TITLE
Fix "fix-whitespace" fresh build issue under `make test` + `stack.yaml`

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.2
+      with:
+        submodules: recursive
 
     - uses: actions/setup-haskell@v1.1.2
       with:
@@ -76,7 +78,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.2
-
+      with:
+        submodules: recursive
 
     - name: Install ghc and cabal-install
       run: |

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -29,6 +29,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.2
+      with:
+        submodules: recursive
+
     - uses: actions/setup-haskell@v1.1.2
       with:
         ghc-version: '8.10.1'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,6 +33,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2.3.1
+    # NOTE: Because `src/fix-whitespace` currently has lint warnings, (See
+    # https://github.com/agda/fix-whitespace/pull/8), we do not checking out
+    # submodules recursively here like we normally do. Perhaps the submodule
+    # should be moved to a separate non-linted directory like lib/.
 
     - name: Set up hlint
       uses: rwe/actions-hlint-setup@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.2
+      with:
+        submodules: recursive
+
     - uses: actions/setup-haskell@v1.1.2
       with:
         ghc-version: ${{ matrix.ghc-ver }}
@@ -60,6 +63,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.2
+      with:
+        submodules: recursive
 
     - name: Install stack
       run: |
@@ -103,6 +108,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.2
+      with:
+        submodules: recursive
 
     - name: Download ICU ${{ matrix.icu-ver }}
       run: |

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -37,6 +37,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.2
+      with:
+        submodules: recursive
+
     - uses: actions/setup-haskell@v1.1.2
       with:
         ghc-version: ${{ matrix.ghc-ver }}
@@ -82,6 +85,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.2
+      with:
+        submodules: recursive
 
     - name: Install stack
       run: |
@@ -122,6 +127,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.2
+      with:
+        submodules: recursive
 
     - name: Download ICU ${{ matrix.icu-ver }}
       run: |

--- a/.github/workflows/user_manual.yml
+++ b/.github/workflows/user_manual.yml
@@ -24,6 +24,9 @@ jobs:
         python-version: [3.7]
     steps:
     - uses: actions/checkout@v2.3.2
+      with:
+        submodules: recursive
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.2
+        with:
+          submodules: recursive
 
       - uses: actions/setup-haskell@v1.1.2
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ branches:
     - /^future-.*/
 
 ##############################################################################
-# The submodules are only needed by the tests using the standard library
-# and the cubical library, so they are fetched manually in the
-# `install` section.
+# The submodules are needed by tests using the standard library and the cubical
+# library, but also needed for stack to find fix-whitespace. Even if it doesn't
+# need it, stack expects it to be there.
 #
 git:
-  submodules: false
+  submodules: true
 
 ##############################################################################
 # Stages:
@@ -143,8 +143,6 @@ jobs:
 
     - <<: *main-job
       name: "Test suites using the standard library and the cubical library"
-      git:
-        submodules: true
       script:
         - stack ${ARGS} exec -- ${MAKE_CMD} std-lib-test
         - stack ${ARGS} exec -- ${MAKE_CMD} cubical-test
@@ -154,8 +152,6 @@ jobs:
         - stack ${ARGS} exec -- ${MAKE_CMD} std-lib-interaction
     - <<: *main-job
       name: "Compiler tests, benchmark summary, and other test suites"
-      git:
-        submodules: true
       script:
         - stack ${ARGS} exec -- ${MAKE_CMD} compiler-test
 

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -18,6 +18,10 @@ extra-deps:
 - text-1.2.3.1
 - text-icu-0.7.0.1
 - wcwidth-0.0.2
+# Built as needed (e.g. via the makefile), but not by default:
+- 'src/fix-whitespace'
+- extra-1.7.1
+- filepattern-0.1.2
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -96,6 +96,17 @@ extra-deps:
 - wcwidth-0.0.2
 - xml-1.3.14
 - zlib-0.6.2.1
+# Built as needed (e.g. via the makefile), but not by default:
+- 'src/fix-whitespace'
+- yaml-0.11.3.0
+- conduit-1.3.2
+- mono-traversable-1.0.15.1
+- vector-algorithms-0.8.0.3
+- resourcet-1.2.3
+- unliftio-core-0.2.0.1
+- libyaml-0.1.2
+- extra-1.7.2
+- filepattern-0.1.2
 
 flags:
   transformers-compat:

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -96,6 +96,17 @@ extra-deps:
 - wcwidth-0.0.2
 - xml-1.3.14
 - zlib-0.6.2.2
+# Built as needed (e.g. via the makefile), but not by default:
+- 'src/fix-whitespace'
+- yaml-0.11.3.0
+- conduit-1.3.2
+- mono-traversable-1.0.15.1
+- vector-algorithms-0.8.0.3
+- resourcet-1.2.3
+- unliftio-core-0.2.0.1
+- libyaml-0.1.2
+- extra-1.7.2
+- filepattern-0.1.2
 
 flags:
   transformers-compat:

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -14,3 +14,8 @@ extra-deps:
 - text-1.2.3.1
 - text-icu-0.7.0.1
 - wcwidth-0.0.2
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+- 'src/size-solver'

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -14,6 +14,10 @@ extra-deps:
 - text-1.2.3.1
 - text-icu-0.7.0.1
 - wcwidth-0.0.2
+# Built as needed (e.g. via the makefile), but not by default:
+- 'src/fix-whitespace'
+- extra-1.7.1
+- filepattern-0.1.2
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -10,3 +10,8 @@ extra-deps:
 - splitmix-0.0.3
 - tasty-silver-3.1.13
 - text-icu-0.7.0.1
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+- 'src/size-solver'

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -10,6 +10,10 @@ extra-deps:
 - splitmix-0.0.3
 - tasty-silver-3.1.13
 - text-icu-0.7.0.1
+# Built as needed (e.g. via the makefile), but not by default:
+- 'src/fix-whitespace'
+- extra-1.7.1
+- filepattern-0.1.2
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -11,3 +11,8 @@ extra-deps:
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 - text-icu-0.7.0.1
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+- 'src/size-solver'

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -11,6 +11,10 @@ extra-deps:
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 - text-icu-0.7.0.1
+# Built as needed (e.g. via the makefile), but not by default:
+- 'src/fix-whitespace'
+- extra-1.7.2
+- filepattern-0.1.2
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -9,6 +9,10 @@ extra-deps:
 - equivalence-0.3.5
 - geniplate-mirror-0.7.6
 - text-icu-0.7.0.1
+# Built as needed (e.g. via the makefile), but not by default:
+- 'src/fix-whitespace'
+- extra-1.7.2
+- filepattern-0.1.2
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -9,6 +9,10 @@ extra-deps:
 - equivalence-0.3.5
 - geniplate-mirror-0.7.6
 - text-icu-0.7.0.1
+# Built as needed (e.g. via the makefile), but not by default:
+- 'src/fix-whitespace'
+- extra-1.7.2
+- filepattern-0.1.2
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
From @wenkokke (https://github.com/agda/agda/issues/4850#issuecomment-676583540):
```
$ make test
git submodule update --init src/fix-whitespace
stack build fix-whitespace

Error: While constructing the build plan, the following exceptions were encountered:

Unknown package: fix-whitespace

Some different approaches to resolving this:


Plan construction failed.
make: *** [src/fix-whitespace/dist/build/fix-whitespace/fix-whitespace] Error 1
```

This would occur when building via `stack build fix-whitespace…` because stack did not know about that package.

It's added to the `extra-deps` instead of `packages` so that it does not need to be built by default. (It's only used by `make fix-whitespace` which will correctly attempt to build/install it if necessary).

While doing this I also created https://github.com/agda/fix-whitespace/pull/8 which contains some fixes that I don't _believe_ are blocking for this, but are nice cleanups to have.