### PR TITLE
Fix GHC 8.10 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ jobs:
           travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
         # Set up arguments and flags for stack compilation
         - ARGS=(--stack-yaml "stack-${GHC_VER}.yaml" --no-terminal --system-ghc)
-        - FLAGS=(--flag Agda:enable-cluster-counting)
+        - FLAGS=(--flag Agda:enable-cluster-counting --ghc-options '+RTS -M4G -RTS')
         - echo "*** GHC version ***"     && ghc     --version &&
           echo "*** Stack version ***"   && stack   --version &&
           echo "*** Haddock version ***" && haddock --version &&
@@ -120,7 +120,7 @@ jobs:
         - export PATH=$HOME/.local/bin:$PATH
         - export PATH=$HOME/texlive/bin/x86_64-linux:$PATH
 
-        - FLAGS=(--flag Agda:enable-cluster-counting)
+        - FLAGS=(--flag Agda:enable-cluster-counting --ghc-options '+RTS -M4G -RTS')
         - ARGS=(--silent --stack-yaml "stack-${GHC_VER}.yaml" --no-terminal --system-ghc)
         - PARALLEL_TESTS=2
         - AGDA_TESTS_OPTIONS=("-j${PARALLEL_TESTS}" --hide-successes)

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,20 +69,19 @@ jobs:
         - mkdir -p ~/.local/bin && export PATH=$HOME/.local/bin:$PATH &&
           travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
         # Set up arguments and flags for stack compilation
-        - export ARGS="--stack-yaml stack-${GHC_VER}.yaml --no-terminal --system-ghc" &&
-          export FLAGS="--flag Agda:enable-cluster-counting"
-
+        - ARGS=(--stack-yaml "stack-${GHC_VER}.yaml" --no-terminal --system-ghc)
+        - FLAGS=(--flag Agda:enable-cluster-counting)
         - echo "*** GHC version ***"     && ghc     --version &&
           echo "*** Stack version ***"   && stack   --version &&
           echo "*** Haddock version ***" && haddock --version &&
           echo "*** Emacs version ***"   && emacs   --version | sed 2q
       install:
-        - stack build Agda ${ARGS} ${FLAGS} --test --no-run-tests --only-dependencies
+        - stack build Agda "${ARGS[@]}" "${FLAGS[@]}" --test --no-run-tests --only-dependencies
       script:
-        - stack build Agda ${ARGS} ${FLAGS} --test --no-run-tests
+        - stack build Agda "${ARGS[@]}" "${FLAGS[@]}" --test --no-run-tests
         # shelltestrunner is used by `make test-size-solver`
         # we need to cache it first.
-        - stack install shelltestrunner ${ARGS}
+        - stack install shelltestrunner "${ARGS[@]}"
       before_cache:
         - find ${TRAVIS_BUILD_DIR}/.stack-work -type f -name '*.agdai' -delete
 
@@ -121,23 +120,23 @@ jobs:
         - export PATH=$HOME/.local/bin:$PATH
         - export PATH=$HOME/texlive/bin/x86_64-linux:$PATH
 
-        - export PARALLEL_TESTS=2
-        - export FLAGS="--flag Agda:enable-cluster-counting"
-        - export ARGS="--silent --stack-yaml stack-${GHC_VER}.yaml --no-terminal --system-ghc"
-        - export AGDA_TESTS_OPTIONS="-j${PARALLEL_TESTS} --hide-successes"
-        - export BUILD_DIR=$(pwd)/$(stack ${ARGS} path --dist-dir)
-        - export MAKE_CMD="make AGDA_TESTS_OPTIONS=${ARGA_TESTS_OPTIONS} TASTY_ANSI_TRICKS=false BUILD_DIR=$BUILD_DIR"
-        - echo "*** Agda version ***" && stack ${ARGS} exec -- agda --version
+        - FLAGS=(--flag Agda:enable-cluster-counting)
+        - ARGS=(--silent --stack-yaml "stack-${GHC_VER}.yaml" --no-terminal --system-ghc)
+        - PARALLEL_TESTS=2
+        - AGDA_TESTS_OPTIONS=("-j${PARALLEL_TESTS}" --hide-successes)
+        - BUILD_DIR=$(pwd)/$(stack "${ARGS[@]}" path --dist-dir)
+        - MAKE_CMD=(make "AGDA_TESTS_OPTIONS=${ARGA_TESTS_OPTIONS[*]}" TASTY_ANSI_TRICKS=false "BUILD_DIR=${BUILD_DIR}")
+        - echo "*** Agda version ***" && stack "${ARGS[@]}" exec -- agda --version
       script:
-        - stack ${ARGS} exec -- ${MAKE_CMD} bugs
-        - stack ${ARGS} exec -- ${MAKE_CMD} common
-        - stack ${ARGS} exec -- ${MAKE_CMD} succeed
-        - stack ${ARGS} exec -- ${MAKE_CMD} fail
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" bugs
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" common
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" succeed
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" fail
       before_cache:
         - find ${TRAVIS_BUILD_DIR}/.stack-work -type f -name '*.agdai' -delete
         - find ${TRAVIS_BUILD_DIR}/.stack-work -type f -name '*.elc' -delete
         - find ${TRAVIS_BUILD_DIR}/.stack-work -type f -name '*.agda.vim' -delete
-        - rm $(stack ${ARGS} path --local-install-root)/bin/size-solver
+        - rm $(stack "${ARGS[@]}" path --local-install-root)/bin/size-solver
         - if [[ -a $HOME/stack-work.sqlite3.ori ]]; then mv $HOME/stack-work.sqlite3.ori ${TRAVIS_BUILD_DIR}/.stack-work/stack.sqlite3; fi
         - if [[ -a $HOME/stack.sqlite3.ori ]]; then mv $HOME/stack.sqlite3.ori ${HOME}/.stack/stack.sqlite3; fi
 
@@ -146,38 +145,39 @@ jobs:
       git:
         submodules: true
       script:
-        - stack ${ARGS} exec -- ${MAKE_CMD} std-lib-test
-        - stack ${ARGS} exec -- ${MAKE_CMD} cubical-test
-        - stack ${ARGS} exec -- ${MAKE_CMD} benchmark-without-logs
-        - stack ${ARGS} exec -- ${MAKE_CMD} std-lib-compiler-test
-        - stack ${ARGS} exec -- ${MAKE_CMD} std-lib-succeed
-        - stack ${ARGS} exec -- ${MAKE_CMD} std-lib-interaction
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" std-lib-test
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" cubical-test
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" benchmark-without-logs
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" std-lib-compiler-test
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" std-lib-succeed
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" std-lib-interaction
     - <<: *main-job
       name: "Compiler tests, benchmark summary, and other test suites"
       git:
         submodules: true
       script:
-        - stack ${ARGS} exec -- ${MAKE_CMD} compiler-test
-
-        - stack ${ARGS} exec -- ${MAKE_CMD} interaction
-        - stack ${ARGS} exec -- ${MAKE_CMD} interactive
-        - stack ${ARGS} exec -- ${MAKE_CMD} DONT_RUN_LATEX="Y" latex-html-test
-        - stack ${ARGS} exec -- ${MAKE_CMD} examples
-        - stack ${ARGS} exec -- ${MAKE_CMD} api-test
-        - stack ${ARGS} exec -- ${MAKE_CMD} user-manual-test
-        - stack ${ARGS} exec -- ${MAKE_CMD} internal-tests
-        - stack ${ARGS} exec -- ${MAKE_CMD} testing-emacs-mode
-        - stack ${ARGS} exec -- ${MAKE_CMD} benchmark-summary
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" compiler-test
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" interaction
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" interactive
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" DONT_RUN_LATEX="Y" latex-html-test
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" examples
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" api-test
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" user-manual-test
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" internal-tests
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" testing-emacs-mode
+        - stack "${ARGS[@]}" exec -- "${MAKE_CMD[@]}" benchmark-summary
         - travis_retry cabal v1-update
-        - ${MAKE_CMD} TAGS
+        # This is surrounded by single quotes to avoid confusing the YAML parsing,
+        # due to the string _beginning_ with a quote that we wish to be literal.
+        - '"${MAKE_CMD[@]}" TAGS'
         # Build & install size-solver
-        - stack build ${ARGS} ${FLAGS} size-solver
+        - stack build "${ARGS[@]}" "${FLAGS[@]}" size-solver
         - mkdir -p src/size-solver/dist/build/size-solver &&
-          cp $(stack path ${ARGS} --local-install-root)/bin/size-solver src/size-solver/dist/build/size-solver/size-solver
+          cp $(stack path "${ARGS[@]}" --local-install-root)/bin/size-solver src/size-solver/dist/build/size-solver/size-solver
         # Test size-solver
-        - ${MAKE_CMD} -C src/size-solver/ test
+        - '"${MAKE_CMD[@]}" -C src/size-solver/ test'
         # Build agda-bisect
-        - ${MAKE_CMD} install-agda-bisect
+        - '"${MAKE_CMD[@]}" install-agda-bisect'
 
     - &complete-job
       stage: complete


### PR DESCRIPTION
This attempts to fix GHC-8.10.2 on Travis by passing the `+RTS -M4G -RTS` options to Stack build when invoked directly. Will it work? Let's see.

In order to do this, I had to fix up a number of unsafely quoted argument/command lists.