### PR TITLE
Remove the LevelAtom type

### DIFF
--- a/src/full/Agda/Auto/Convert.hs
+++ b/src/full/Agda/Auto/Convert.hs
@@ -429,11 +429,7 @@ fmExps :: I.MetaId -> I.Args -> Bool
 fmExps m as = any (fmExp m . Cm.unArg) as
 
 fmLevel :: I.MetaId -> I.PlusLevel -> Bool
-fmLevel m (I.Plus _ l) = case l of
-  I.MetaLevel m' _   -> m == m'
-  I.NeutralLevel _ v -> fmExp m v
-  I.BlockedLevel _ v -> fmExp m v
-  I.UnreducedLevel v -> fmExp m v
+fmLevel m (I.Plus _ l) = fmExp m l
 
 -- ---------------------------------------------
 

--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -94,13 +94,6 @@ instance GetDefs Level where
 instance GetDefs PlusLevel where
   getDefs (Plus _ l)    = getDefs l
 
-instance GetDefs LevelAtom where
-  getDefs a = case a of
-    MetaLevel x vs   -> getDefs x >> getDefs vs
-    BlockedLevel _ v -> getDefs v
-    NeutralLevel _ v -> getDefs v
-    UnreducedLevel v -> getDefs v
-
 -- collection instances
 
 instance GetDefs a => GetDefs (Maybe a) where

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -120,10 +120,6 @@ instance TermLike PlusLevel where
   traverseTermM f (Plus n l) = Plus n <$> traverseTermM f l
   foldTerm f (Plus _ l)      = foldTerm f l
 
-instance TermLike LevelAtom where
-  traverseTermM f l = UnreducedLevel <$> traverseTermM f (levelAtomTerm l)
-  foldTerm f = foldTerm f . levelAtomTerm
-
 instance TermLike Type where
   traverseTermM f (El s t) = El s <$> traverseTermM f t
   foldTerm f (El s t) = foldTerm f t

--- a/src/full/Agda/Syntax/Internal/MetaVars.hs
+++ b/src/full/Agda/Syntax/Internal/MetaVars.hs
@@ -48,13 +48,12 @@ allMetas' :: (TermLike a, Monoid m) => (MetaId -> m) -> a -> m
 allMetas' singl = foldTerm metas
   where
   metas (MetaV m _) = singl m
-  metas (Level l)   = levelMetas l
   metas (Sort s)    = sortMetas s
   metas _           = mempty
 
-  sortMetas (Type l)      = levelMetas l
-  sortMetas (Prop l)      = levelMetas l
-  sortMetas (SSet l)      = levelMetas l
+  sortMetas Type{}        = mempty
+  sortMetas Prop{}        = mempty
+  sortMetas SSet{}        = mempty
   sortMetas Inf{}         = mempty
   sortMetas SizeUniv{}    = mempty
   sortMetas (PiSort _ b)  = sortMetas $ unAbs b  -- the domain is a type so is covered by the fold
@@ -63,13 +62,6 @@ allMetas' singl = foldTerm metas
   sortMetas (MetaS x _)   = singl x
   sortMetas DefS{}        = mempty
   sortMetas DummyS{}      = mempty
-
-  levelMetas (Max _ as) = foldMap plusLevelMetas as
-
-  plusLevelMetas (Plus _ l)    = levelAtomMetas l
-
-  levelAtomMetas (MetaLevel m _) = singl m
-  levelAtomMetas _               = mempty
 
 -- | Returns 'allMetas' in a list.
 --   @allMetasList = allMetas (:[])@.

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -163,13 +163,6 @@ instance NamesIn Level where
 instance NamesIn PlusLevel where
   namesIn' sg (Plus _ l) = namesIn' sg l
 
-instance NamesIn LevelAtom where
-  namesIn' sg = \case
-    MetaLevel _ args -> namesIn' sg args
-    BlockedLevel _ v -> namesIn' sg v
-    NeutralLevel _ v -> namesIn' sg v
-    UnreducedLevel v -> namesIn' sg v
-
 -- For QName literals!
 instance NamesIn Literal where
   namesIn' sg = \case

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -975,12 +975,6 @@ instance ExtractCalls Level where
 instance ExtractCalls PlusLevel where
   extract (Plus n l) = extract l
 
-instance ExtractCalls LevelAtom where
-  extract (MetaLevel x es)   = extract es
-  extract (BlockedLevel x t) = extract t
-  extract (NeutralLevel _ t) = extract t
-  extract (UnreducedLevel t) = extract t
-
 -- | Rewrite type @tel -> Size< u@ to @tel -> Size@.
 maskSizeLt :: MonadTCM tcm => Dom Type -> tcm (Dom Type)
 maskSizeLt !dom = liftTCM $ do

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -189,13 +189,6 @@ instance AbsTerm Level where
 instance AbsTerm PlusLevel where
   absTerm u (Plus n l) = Plus n $ absTerm u l
 
-instance AbsTerm LevelAtom where
-  absTerm u l = case l of
-    MetaLevel m vs   -> UnreducedLevel $ absTerm u (MetaV m vs)
-    NeutralLevel r v -> NeutralLevel r $ absTerm u v
-    BlockedLevel _ v -> UnreducedLevel $ absTerm u v -- abstracting might remove the blockage
-    UnreducedLevel v -> UnreducedLevel $ absTerm u v
-
 instance AbsTerm a => AbsTerm (Elim' a) where
   absTerm = fmap . absTerm
 
@@ -257,9 +250,6 @@ instance EqualSy Level where
 
 instance EqualSy PlusLevel where
   equalSy (Plus n v) (Plus n' v') = n == n' && equalSy v v'
-
-instance EqualSy LevelAtom where
-  equalSy = equalSy `on` unLevelAtom
 
 instance EqualSy Sort where
   equalSy = curry $ \case

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -441,11 +441,7 @@ checkLevel action (Max n ls) = Max n <$> mapM checkPlusLevel ls
 
     checkLevelAtom l = do
       lvl <- levelType
-      UnreducedLevel <$> case l of
-        MetaLevel x es   -> checkInternal' action (MetaV x es) CmpLeq lvl
-        BlockedLevel _ v -> checkInternal' action v CmpLeq lvl
-        NeutralLevel _ v -> checkInternal' action v CmpLeq lvl
-        UnreducedLevel v -> checkInternal' action v CmpLeq lvl
+      checkInternal' action l CmpLeq lvl
 
 -- | Universe subsumption and type equality (subtyping for sizes, resp.).
 cmptype :: (MonadCheckInternal m) => Comparison -> Type -> Type -> m ()

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -117,9 +117,5 @@ etaLam i x b = do
     -- is in fact @Level@, e.g. @\(A : Set) → F lzero@ should not be
     -- eta-contracted to @F@.
     -- isVar0 True Level{}               = True
-    isVar0 tyty (Level (Max 0 [Plus 0 l])) = case l of
-      NeutralLevel _ v -> isVar0 tyty v
-      UnreducedLevel v -> isVar0 tyty v
-      BlockedLevel{}   -> False
-      MetaLevel{}      -> False
+    isVar0 tyty (Level (Max 0 [Plus 0 l])) = isVar0 tyty l
     isVar0 _ _ = False

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -558,15 +558,8 @@ instance Free Sort where
 instance Free Level where
   freeVars' (Max _ as) = freeVars' as
 
-instance Free PlusLevel where
+instance Free t => Free (PlusLevel' t) where
   freeVars' (Plus _ l)    = freeVars' l
-
-instance Free LevelAtom where
-  freeVars' l = case l of
-    MetaLevel m vs   -> underFlexRig (Flexible $ singleton m) $ freeVars' vs
-    NeutralLevel _ v -> freeVars' v
-    BlockedLevel _ v -> freeVars' v
-    UnreducedLevel v -> freeVars' v
 
 instance Free t => Free [t]            where
 instance Free t => Free (Maybe t)      where

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -93,14 +93,6 @@ instance PrecomputeFreeVars Level where
 instance PrecomputeFreeVars PlusLevel where
   precomputeFreeVars (Plus n l) = Plus n <$> precomputeFreeVars l
 
-instance PrecomputeFreeVars LevelAtom where
-  precomputeFreeVars l =
-    case l of
-      MetaLevel x es   -> MetaLevel x <$> precomputeFreeVars es
-      BlockedLevel x t -> BlockedLevel x <$> precomputeFreeVars t
-      NeutralLevel b t -> NeutralLevel b <$> precomputeFreeVars t
-      UnreducedLevel t -> UnreducedLevel <$> precomputeFreeVars t
-
 instance PrecomputeFreeVars Type where
   precomputeFreeVars (El s t) = uncurry El <$> precomputeFreeVars (s, t)
 

--- a/src/full/Agda/TypeChecking/Free/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Free/Reduce.hs
@@ -135,14 +135,6 @@ instance ForceNotFree Level where
 instance ForceNotFree PlusLevel where
   forceNotFree' (Plus k a) = Plus k <$> forceNotFree' a
 
-instance ForceNotFree LevelAtom where
-  forceNotFree' l = case l of
-    MetaLevel x es   -> local (insertMetaSet x) $
-                        MetaLevel x    <$> forceNotFree' es
-    BlockedLevel x t -> BlockedLevel x <$> forceNotFree' t
-    NeutralLevel b t -> NeutralLevel b <$> forceNotFree' t
-    UnreducedLevel t -> UnreducedLevel <$> forceNotFreeR t  -- Already reduce in the cases above
-
 instance ForceNotFree Sort where
   -- Reduce for sorts already goes under all sort constructors, so we can get
   -- away without forceNotFreeR here.

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -338,15 +338,6 @@ instance UsableRelevance Level where
 instance UsableRelevance PlusLevel where
   usableRel rel (Plus _ l) = usableRel rel l
 
-instance UsableRelevance LevelAtom where
-  usableRel rel l = case l of
-    MetaLevel m vs -> do
-      mrel <- getMetaRelevance <$> lookupMeta m
-      return (mrel `moreRelevant` rel) `and2M` usableRel rel vs
-    NeutralLevel _ v -> usableRel rel v
-    BlockedLevel _ v -> usableRel rel v
-    UnreducedLevel v -> usableRel rel v
-
 instance UsableRelevance a => UsableRelevance [a] where
   usableRel rel = andM . map (usableRel rel)
 
@@ -443,15 +434,6 @@ instance UsableModality Level where
 -- instance UsableModality PlusLevel where
 --   usableMod mod ClosedLevel{} = return True
 --   usableMod mod (Plus _ l)    = usableMod mod l
-
--- instance UsableModality LevelAtom where
---   usableMod mod l = case l of
---     MetaLevel m vs -> do
---       mmod <- getMetaModality <$> lookupMeta m
---       return (mmod `moreUsableModality` mod) `and2M` usableMod mod vs
---     NeutralLevel _ v -> usableMod mod v
---     BlockedLevel _ v -> usableMod mod v
---     UnreducedLevel v -> usableMod mod v
 
 instance UsableModality a => UsableModality [a] where
   usableMod mod = andM . map (usableMod mod)

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -4,6 +4,7 @@ module Agda.TypeChecking.Level where
 import Data.Maybe
 import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty(..))
+import Data.Traversable (Traversable)
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
@@ -107,7 +108,7 @@ unConstV :: Term -> (Term -> Term) -> Integer -> Term
 unConstV zer suc n = foldr ($) zer (List.genericReplicate n suc)
 
 unPlusV :: (Term -> Term) -> PlusLevel -> Term
-unPlusV suc (Plus n a) = foldr ($) (unLevelAtom a) (List.genericReplicate n suc)
+unPlusV suc (Plus n a) = foldr ($) a (List.genericReplicate n suc)
 
 maybePrimCon :: TCM Term -> TCM (Maybe ConHead)
 maybePrimCon prim = tryMaybe $ do
@@ -143,20 +144,8 @@ levelView' a = do
             | z == lzero -> return $ ClosedLevel 0
           Def m [Apply arg1, Apply arg2]
             | m == lmax  -> levelLub <$> view (unArg arg1) <*> view (unArg arg2)
-          _              -> return $ mkAtom ba
+          l              -> return $ atomicLevel l
   view a
-  where
-    mkAtom ba = atomicLevel $ case ba of
-        Blocked _ (MetaV m as) -> MetaLevel m as
-        NotBlocked _ MetaV{}   -> __IMPOSSIBLE__
-        NotBlocked r _         ->
-          case r of
-            StuckOn{}            -> NeutralLevel r $ ignoreBlocking ba
-            Underapplied{}       -> NeutralLevel r $ ignoreBlocking ba
-            AbsurdMatch{}        -> NeutralLevel r $ ignoreBlocking ba
-            MissingClauses{}     -> UnreducedLevel $ ignoreBlocking ba
-            ReallyNotBlocked{}   -> NeutralLevel r $ ignoreBlocking ba
-        Blocked m _            -> BlockedLevel m $ ignoreBlocking ba
 
 -- | Given a level @l@, find the maximum constant @n@ such that @l = n + l'@
 levelPlusView :: Level -> (Integer, Level)
@@ -218,10 +207,14 @@ levelMaxDiff (Max m as) (Max n bs) = Max <$> diffC m n <*> diffP as bs
 
 -- | A @SingleLevel@ is a @Level@ that cannot be further decomposed as
 --   a maximum @a ⊔ b@.
-data SingleLevel = SingleClosed Integer | SinglePlus PlusLevel
-  deriving (Eq, Show)
+data SingleLevel' t = SingleClosed Integer | SinglePlus (PlusLevel' t)
+  deriving (Show, Functor, Foldable, Traversable)
 
-unSingleLevel :: SingleLevel -> Level
+type SingleLevel = SingleLevel' Term
+
+deriving instance Eq SingleLevel
+
+unSingleLevel :: SingleLevel' t -> Level' t
 unSingleLevel (SingleClosed m) = Max m []
 unSingleLevel (SinglePlus a)   = Max 0 [a]
 
@@ -232,20 +225,20 @@ unSingleLevels ls = levelMax n as
     n = maximum $ 0 : [m | SingleClosed m <- ls]
     as = [a | SinglePlus a <- ls]
 
-levelMaxView :: Level -> NonEmpty SingleLevel
+levelMaxView :: Level' t -> NonEmpty (SingleLevel' t)
 levelMaxView (Max n [])     = singleton $ SingleClosed n
 levelMaxView (Max 0 (a:as)) = SinglePlus a :| map SinglePlus as
 levelMaxView (Max n as)     = SingleClosed n :| map SinglePlus as
 
-singleLevelView :: Level -> Maybe SingleLevel
+singleLevelView :: Level' t -> Maybe (SingleLevel' t)
 singleLevelView l = case levelMaxView l of
   s :| [] -> Just s
   _       -> Nothing
 
-instance Subst Term SingleLevel where
+instance Subst Term t => Subst Term (SingleLevel' t) where
   applySubst sub (SingleClosed m) = SingleClosed m
   applySubst sub (SinglePlus a)   = SinglePlus $ applySubst sub a
 
-instance Free SingleLevel where
+instance Free t => Free (SingleLevel' t) where
   freeVars' (SingleClosed m) = mempty
   freeVars' (SinglePlus a)   = freeVars' a

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -191,8 +191,7 @@ newLevelMeta = do
   (x, v) <- newValueMeta RunMetaOccursCheck CmpEq =<< levelType
   return $ case v of
     Level l    -> l
-    MetaV x vs -> Max 0 [Plus 0 (MetaLevel x vs)]
-    _          -> Max 0 [Plus 0 (UnreducedLevel v)]
+    _          -> atomicLevel v
 
 -- | @newInstanceMeta s t cands@ creates a new instance metavariable
 --   of type the output type of @t@ with name suggestion @s@.

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -37,13 +37,6 @@ instance MentionsMeta Level where
 instance MentionsMeta PlusLevel where
   mentionsMetas xs (Plus _ a) = mentionsMetas xs a
 
-instance MentionsMeta LevelAtom where
-  mentionsMetas xs l = case l of
-    MetaLevel m vs   -> HashSet.member m xs || mentionsMetas xs vs
-    BlockedLevel b _ -> mentionsMetas xs b  -- if it's blocked on a different meta it doesn't matter if it mentions the meta somewhere else
-    UnreducedLevel l -> mentionsMetas xs l
-    NeutralLevel _ l -> mentionsMetas xs l
-
 instance MentionsMeta Blocker where
   mentionsMetas xs (UnblockOnAll bs)  = mentionsMetas xs $ Set.toList bs
   mentionsMetas xs (UnblockOnAny bs)  = mentionsMetas xs $ Set.toList bs

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -524,25 +524,6 @@ instance Occurs PlusLevel where
 
   metaOccurs m (Plus n l) = metaOccurs m l
 
-instance Occurs LevelAtom where
-  occurs l = do
-    unfold l >>= \case
-      MetaLevel m' args -> do
-        MetaV m' args <- occurs (MetaV m' args)
-        return $ MetaLevel m' args
-      NeutralLevel r v  -> NeutralLevel r  <$> occurs v
-      BlockedLevel m' v -> BlockedLevel m' <$> do flexibly $ occurs v
-      UnreducedLevel v  -> UnreducedLevel  <$> occurs v
-
-  metaOccurs m l = do
-    l <- instantiate l
-    case l of
-      MetaLevel m' args -> metaOccurs m $ MetaV m' args
-      NeutralLevel _ v  -> metaOccurs m v
-      BlockedLevel _ v  -> metaOccurs m v
-      UnreducedLevel v  -> metaOccurs m v
-
-
 instance Occurs Type where
   occurs (El s v) = uncurry El <$> occurs (s,v)
 
@@ -799,15 +780,6 @@ instance AnyRigid Level where
 
 instance AnyRigid PlusLevel where
   anyRigid f (Plus _ l)    = anyRigid f l
-
-instance AnyRigid LevelAtom where
-  anyRigid f l =
-    case l of
-      MetaLevel{} -> return False
-      NeutralLevel MissingClauses _ -> return False
-      NeutralLevel _              l -> anyRigid f l
-      BlockedLevel _              l -> anyRigid f l
-      UnreducedLevel              l -> anyRigid f l
 
 instance (Subst t a, AnyRigid a) => AnyRigid (Abs a) where
   anyRigid f b = underAbstraction_ b $ anyRigid f

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -216,10 +216,6 @@ instance IsInstantiatedMeta PlusLevel where
   isInstantiatedMeta (Plus n l) | n == 0 = isInstantiatedMeta l
   isInstantiatedMeta _ = __IMPOSSIBLE__
 
-instance IsInstantiatedMeta LevelAtom where
-  isInstantiatedMeta (MetaLevel x es) = isInstantiatedMeta x
-  isInstantiatedMeta _ = __IMPOSSIBLE__
-
 instance IsInstantiatedMeta a => IsInstantiatedMeta [a] where
   isInstantiatedMeta = andM . map isInstantiatedMeta
 
@@ -618,12 +614,6 @@ instance UnFreezeMeta Level where
 
 instance UnFreezeMeta PlusLevel where
   unfreezeMeta (Plus _ a)    = unfreezeMeta a
-
-instance UnFreezeMeta LevelAtom where
-  unfreezeMeta (MetaLevel x _)    = unfreezeMeta x
-  unfreezeMeta (BlockedLevel _ t) = unfreezeMeta t
-  unfreezeMeta (NeutralLevel _ t) = unfreezeMeta t
-  unfreezeMeta (UnreducedLevel t) = unfreezeMeta t
 
 instance UnFreezeMeta a => UnFreezeMeta [a] where
   unfreezeMeta = mapM_ unfreezeMeta

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -373,9 +373,3 @@ instance HasPolarity Level where
 instance HasPolarity PlusLevel where
   polarities i (Plus _ l) = polarities i l
 
-instance HasPolarity LevelAtom where
-  polarities i l = case l of
-    MetaLevel _ vs   -> map (const Invariant) <$> polarities i vs
-    BlockedLevel _ v -> polarities i v
-    NeutralLevel _ v -> polarities i v
-    UnreducedLevel v -> polarities i v

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -460,14 +460,6 @@ instance ComputeOccurrences Level where
 instance ComputeOccurrences PlusLevel where
   occurrences (Plus _ l) = occurrences l
 
-instance ComputeOccurrences LevelAtom where
-  occurrences = occurrences . unLevelAtom
-      -- MetaLevel x es -> occurrences $ MetaV x es
-      -- Andreas, 2016-07-25, issue 2108
-      -- NOT: OccursAs MetaArg <$> occurrences es
-      -- since we need to unSpine!
-      -- (Otherwise, we run into __IMPOSSIBLE__ at Proj elims)
-
 instance ComputeOccurrences Type where
   occurrences (El _ v) = occurrences v
 

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -635,7 +635,7 @@ mkPrimSetOmega f = do
 
 -- mkPrimStrictSet :: TCM PrimitiveImpl
 -- mkPrimStrictSet = do
---   t <- nPi "ℓ" (el primLevel) (pure $ sort $ SSet $ Max 0 [Plus 1 $ NeutralLevel mempty $ var 0])
+--   t <- nPi "ℓ" (el primLevel) (pure $ sort $ SSet $ Max 0 [Plus 1 $ var 0])
 --   return $ PrimImpl t $ primFun __IMPOSSIBLE__ 1 $ \ ~[a] -> do
 --     l <- levelView' $ unArg a
 --     redReturn $ Sort $ SSet l

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -77,7 +77,7 @@ el' :: Monad m => m Term -> m Term -> m Type
 el' l a = El <$> (tmSort <$> l) <*> a
 
 el's :: Monad m => m Term -> m Term -> m Type
-el's l a = El <$> (SSet . unreducedLevel <$> l) <*> a
+el's l a = El <$> (SSet . atomicLevel <$> l) <*> a
 
 elInf :: Functor m => m Term -> m Type
 elInf t = (El (Inf IsFibrant 0) <$> t)

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -305,7 +305,7 @@ primSubOut' = do
           hPi' "A" (el' (cl primLevelSuc <@> a) (Sort . tmSort <$> a)) $ \ bA ->
           hPi' "φ" primIntervalType $ \ phi ->
           hPi' "u" (el's a $ cl primPartial <#> a <@> phi <@> bA) $ \ u ->
-          el's a (cl primSub <#> a <@> bA <@> phi <@> u) --> el' (Sort . tmSort <$> a) bA
+          el's a (cl primSub <#> a <@> bA <@> phi <@> u) --> el' a bA
   return $ PrimImpl t $ primFun __IMPOSSIBLE__ 5 $ \ ts -> do
     case ts of
       [a,bA,phi,u,x] -> do

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -817,17 +817,9 @@ instance AllHoles [PlusLevel] where
 
 instance AllHoles PlusLevel where
   type PType PlusLevel = ()
-  allHoles _ (Plus n l) = fmap (Plus n) <$> allHoles_ l
-
-instance AllHoles LevelAtom where
-  type PType LevelAtom = ()
-  allHoles _ l = do
+  allHoles _ (Plus n l) = do
     la <- levelType
-    case l of
-      MetaLevel{}      -> __IMPOSSIBLE__
-      BlockedLevel{}   -> __IMPOSSIBLE__
-      NeutralLevel b u -> fmap (NeutralLevel b) <$> allHoles la u
-      UnreducedLevel u -> fmap UnreducedLevel <$> allHoles la u
+    fmap (Plus n) <$> allHoles la l
 
 
 -- | Convert metavariables to normal variables. Warning: doesn't
@@ -890,13 +882,6 @@ instance MetasToVars Level where
 
 instance MetasToVars PlusLevel where
   metasToVars (Plus n x) = Plus n <$> metasToVars x
-
-instance MetasToVars LevelAtom where
-  metasToVars = \case
-    MetaLevel m es    -> NeutralLevel mempty <$> metasToVars (MetaV m es)
-    BlockedLevel _ u  -> UnreducedLevel      <$> metasToVars u
-    NeutralLevel nb u -> NeutralLevel nb     <$> metasToVars u
-    UnreducedLevel u  -> UnreducedLevel      <$> metasToVars u
 
 instance MetasToVars a => MetasToVars (Tele a) where
   metasToVars EmptyTel = pure EmptyTel

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -130,7 +130,7 @@ coreBuiltins =
                                                                    hPi' "a" (el $ cl primLevel) $ \ a ->
                                                                    hPi' "A" (el' (cl primLevelSuc <@> a) (Sort . tmSort <$> a)) $ \ bA ->
                                                                    hPi' "φ" (elSSet $ cl primInterval) $ \ phi ->
-                                                                   nPi' "x" (el' (Sort . tmSort <$> a) bA) $ \ x ->
+                                                                   nPi' "x" (el' a bA) $ \ x ->
                                                                    el's a $ cl primSub <#> a <@> bA <@> phi <@> lam "o" (\ _ -> x)))
   , (builtinIZero                            |-> BuiltinDataCons tinterval)
   , (builtinIOne                             |-> BuiltinDataCons tinterval)

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -124,7 +124,7 @@ coreBuiltins =
   , (builtinSub                              |-> builtinPostulateC (runNamesT [] $ hPi' "a" (el $ cl primLevel) $ \ a ->
                                                                    nPi' "A" (el' (cl primLevelSuc <@> a) (Sort . tmSort <$> a)) $ \ bA ->
                                                                    nPi' "φ" (cl tinterval) $ \ phi ->
-                                                                   el's a (cl primPartial <#> a <@> phi <@> bA) --> (ssort . unreducedLevel <$> a)
+                                                                   el's a (cl primPartial <#> a <@> phi <@> bA) --> (ssort . atomicLevel <$> a)
                                                                   ))
   , (builtinSubIn                            |-> builtinPostulateC (runNamesT [] $
                                                                    hPi' "a" (el $ cl primLevel) $ \ a ->

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -72,7 +72,7 @@ import Agda.Utils.IORef
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20200724 * 10 + 0
+currentInterfaceVersion = 20200819 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -133,19 +133,6 @@ instance EmbPrj PlusLevel where
 
   value = valueN Plus
 
-instance EmbPrj LevelAtom where
-  icod_ (NeutralLevel r a) = icodeN' (NeutralLevel r) a
-  icod_ (UnreducedLevel a) = icodeN 1 UnreducedLevel a
-  icod_ (MetaLevel a b)    = __IMPOSSIBLE__
-  icod_ BlockedLevel{}     = __IMPOSSIBLE__
-
-  value = vcase valu where
-    valu [a]    = valuN UnreducedLevel a -- we forget that we are a NeutralLevel,
-                                         -- since we do not want do (de)serialize
-                                         -- the reason for neutrality
-    valu [1, a] = valuN UnreducedLevel a
-    valu _      = malformed
-
 instance EmbPrj IsFibrant where
   icod_ IsFibrant = return 0
   icod_ IsStrict  = return 1

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -835,12 +835,6 @@ instance Subst t a => Subst t (Level' a) where
 instance Subst t a => Subst t (PlusLevel' a) where
   applySubst rho (Plus n l) = Plus n $ applySubst rho l
 
-instance Subst t a => Subst t (LevelAtom' a) where
-  applySubst rho (MetaLevel m vs)   = MetaLevel m    $ applySubst rho vs
-  applySubst rho (BlockedLevel m v) = BlockedLevel m $ applySubst rho v
-  applySubst rho (NeutralLevel _ v) = UnreducedLevel $ applySubst rho v
-  applySubst rho (UnreducedLevel v) = UnreducedLevel $ applySubst rho v
-
 instance Subst Term Name where
   applySubst rho = id
 
@@ -1303,12 +1297,6 @@ instance Ord PlusLevel where
   -- Compare on the atom first. Makes most sense for levelMax.
   compare (Plus n a) (Plus m b) = compare (a,n) (b,m)
 
-instance Eq LevelAtom where
-  (==) = (==) `on` unLevelAtom
-
-instance Ord LevelAtom where
-  compare = compare `on` unLevelAtom
-
 -- | Syntactic 'Type' equality, ignores sort annotations.
 instance Eq a => Eq (Type' a) where
   (==) = (==) `on` unEl
@@ -1542,7 +1530,7 @@ piSort a b = case piSort' a b of
 levelMax :: Integer -> [PlusLevel] -> Level
 levelMax n0 as0 = Max n as
   where
-    -- step 1: flatten nested @Level@ expressions in @LevelAtom@s
+    -- step 1: flatten nested @Level@ expressions in @PlusLevel@s
     Max n1 as1 = expandLevel $ Max n0 as0
     -- step 2: remove subsumed @PlusLevel@s
     as2       = removeSubsumed as1
@@ -1561,18 +1549,11 @@ levelMax n0 as0 = Max n as
     expandLevel (Max m as) = lmax m [] $ map expandPlus as
 
     expandPlus :: PlusLevel -> Level
-    expandPlus (Plus m l) = levelPlus m $ expandAtom l
+    expandPlus (Plus m l) = levelPlus m (expandTm l)
 
-    expandAtom :: LevelAtom -> Level
-    expandAtom l = case l of
-      BlockedLevel _ v -> expandTm v
-      NeutralLevel _ v -> expandTm v
-      UnreducedLevel v -> expandTm v
-      MetaLevel{}      -> Max 0 [Plus 0 l]
-      where
-        expandTm (Level l)       = expandLevel l
-        expandTm (Sort (Type l)) = expandLevel l -- TODO: get rid of this horrible hack!
-        expandTm v               = Max 0 [Plus 0 l]
+    expandTm (Level l)       = expandLevel l
+    expandTm (Sort (Type l)) = expandLevel l -- TODO: get rid of this horrible hack!
+    expandTm l               = atomicLevel l
 
     removeSubsumed [] = []
     removeSubsumed (Plus n a : bs)
@@ -1589,11 +1570,6 @@ levelLub (Max m as) (Max n bs) = levelMax (max m n) $ as ++ bs
 levelTm :: Level -> Term
 levelTm l =
   case l of
-    Max 0 [Plus 0 l] -> unLevelAtom l
+    Max 0 [Plus 0 l] -> l
     _                -> Level l
 
-unLevelAtom :: LevelAtom -> Term
-unLevelAtom (MetaLevel x es)   = MetaV x es
-unLevelAtom (NeutralLevel _ v) = v
-unLevelAtom (UnreducedLevel v) = v
-unLevelAtom (BlockedLevel _ v) = v

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1552,7 +1552,6 @@ levelMax n0 as0 = Max n as
     expandPlus (Plus m l) = levelPlus m (expandTm l)
 
     expandTm (Level l)       = expandLevel l
-    expandTm (Sort (Type l)) = expandLevel l -- TODO: get rid of this horrible hack!
     expandTm l               = atomicLevel l
 
     removeSubsumed [] = []

--- a/src/full/Agda/TypeChecking/Substitute/DeBruijn.hs
+++ b/src/full/Agda/TypeChecking/Substitute/DeBruijn.hs
@@ -29,15 +29,6 @@ instance DeBruijn Term where
       Level l -> deBruijnView l
       _ -> Nothing
 
-instance DeBruijn LevelAtom where
-  deBruijnVar = NeutralLevel ReallyNotBlocked . deBruijnVar
-  deBruijnView l =
-    case l of
-      NeutralLevel _ u -> deBruijnView u
-      UnreducedLevel u -> deBruijnView u
-      MetaLevel{}    -> Nothing
-      BlockedLevel{} -> Nothing
-
 instance DeBruijn PlusLevel where
   deBruijnVar = Plus 0 . deBruijnVar
   deBruijnView l =

--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -112,25 +112,6 @@ instance SynEq PlusLevel where
     | n == n'   = Plus n <$$> synEq v v'
     | otherwise = inequal (l, l')
 
-instance SynEq LevelAtom where
-  synEq l l' = do
-    l  <- lift (unBlock =<< instantiate' l)
-    case (l, l') of
-      (MetaLevel m vs  , MetaLevel m' vs'  ) | m == m' -> MetaLevel m    <$$> synEq vs vs'
-      (UnreducedLevel v, UnreducedLevel v' )           -> UnreducedLevel <$$> synEq v v'
-      -- The reason for being blocked should not matter for equality.
-      (NeutralLevel r v, NeutralLevel r' v')           -> NeutralLevel r <$$> synEq v v'
-      (BlockedLevel m v, BlockedLevel m' v')           -> BlockedLevel m <$$> synEq v v'
-      _ -> inequal (l, l')
-    where
-      unBlock l =
-        case l of
-          BlockedLevel b v ->
-            ifM ((alwaysUnblock ==) <$> instantiate b)
-                (pure $ UnreducedLevel v)
-                (pure l)
-          _ -> pure l
-
 instance SynEq Sort where
   synEq s s' = do
     (s, s') <- lift $ instantiate' (s, s')

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -562,7 +562,7 @@ evalTCM v = do
       if norm then normalise v else instantiateFull v
 
     mkT l a = El s a
-      where s = Type $ Max 0 [Plus 0 $ UnreducedLevel l]
+      where s = Type $ atomicLevel l
 
     -- Don't catch Unquote errors!
     tcCatchError :: Term -> Term -> UnquoteM Term


### PR DESCRIPTION
This type was added in an effort to save some computation time by remembering the status of reduced levels. Given that reducing levels is hardly a bottleneck, and that this extra layer adds a lot of code, it seems best to remove this experiment.

Benchmarking the standard library doesn't show any statistically significant difference before and after this patch. If anything it makes things slightly faster.