### PR TITLE
Fix #4680 by adding primFloatToRatio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,18 @@ Language
   local confluence can be restored by using the
   `--local-confluence-check` flag.
 
+Builtins
+--------
+
+- New primitive primFloatToRatio, which converts floating-point numbers to ratios,
+  represented as a pair of a numerator and a denominator.
+  
+  ```agda
+  primFloatToRatio : Float → Σ Int λ _ → Nat
+  ```
+  
+  The primitive maps NaN to (0 , 0), Infinity to (1 , 0), and -Infinity to (-1, 0).
+ 
 
 Reflection
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,13 +156,13 @@ Builtins
 
 - New primitive primFloatToRatio, which converts floating-point numbers to ratios,
   represented as a pair of a numerator and a denominator.
-  
+
   ```agda
   primFloatToRatio : Float → Σ Int λ _ → Nat
   ```
-  
+
   The primitive maps NaN to (0 , 0), Infinity to (1 , 0), and -Infinity to (-1, 0).
- 
+
 
 Reflection
 ----------

--- a/src/data/MAlonzo/src/MAlonzo/RTE/Float.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE/Float.hs
@@ -72,3 +72,9 @@ normaliseNaN x
 doubleToWord64 :: Double -> Word64
 doubleToWord64 = castDoubleToWord64 . normaliseNaN
 
+doubleToRatio :: Double -> (Integer, Integer)
+doubleToRatio x
+  | isNaN     x = ( 0, 0)
+  | isPosInf  x = ( 1, 0)
+  | isNegInf  x = (-1, 0)
+  | otherwise   = let y = toRational x in (numerator y, denominator y)

--- a/src/data/lib/prim/Agda/Builtin/Float.agda
+++ b/src/data/lib/prim/Agda/Builtin/Float.agda
@@ -41,19 +41,39 @@ primitive
   primATan2         : Float → Float → Float
   primShowFloat     : Float → String
 
-{-# COMPILE JS primFloatToRatio = function(x) {
-    if (x !== x) {
+{-# COMPILE JS
+  primFloatToRatio = function(float) {
+    if (isNaN(float)) {
       return z_jAgda_Agda_Builtin_Sigma["_,_"](0)(0);
     }
-    else if (x === Infinity) {
+    else if (float > 0 && !isFinite(float)) {
       return z_jAgda_Agda_Builtin_Sigma["_,_"](1)(0);
     }
-    else if (x === -Infinity) {
+    else if (float < 0 && !isFinite(float)) {
       return z_jAgda_Agda_Builtin_Sigma["_,_"](-1)(0);
     }
     else {
-      return z_jAgda_Agda_Builtin_Sigma["_,_"](Math.round(x*10e8))(10e8);
+      // Greatest common factor function
+      var gcf = function(x, y) {
+        var z;
+        x = Math.abs(x);
+        y = Math.abs(y);
+        while (y) {
+          z = x % y;
+          x = y;
+          y = z;
+        }
+        return x;
+      };
+      // Start with a ratio with 9 decimal places precision
+      var numerator = Math.round(float*1e9);
+      var denominator = 1e9;
+      // Normalise
+      var greatestCommonFactor = gcf(numerator, denominator);
+      numerator /= greatestCommonFactor;
+      denominator /= greatestCommonFactor;
+      return z_jAgda_Agda_Builtin_Sigma["_,_"](numerator)(denominator);
     }
-  }
+  };
 #-}
 

--- a/src/data/lib/prim/Agda/Builtin/Float.agda
+++ b/src/data/lib/prim/Agda/Builtin/Float.agda
@@ -7,6 +7,7 @@ open import Agda.Builtin.Bool
 open import Agda.Builtin.Nat
 open import Agda.Builtin.Int
 open import Agda.Builtin.Word
+open import Agda.Builtin.Sigma
 open import Agda.Builtin.String
 
 postulate Float : Set
@@ -14,6 +15,7 @@ postulate Float : Set
 
 primitive
   primFloatToWord64 : Float → Word64
+  primFloatToRatio  : Float → Σ Int (λ _ → Nat)
   primFloatEquality : Float → Float → Bool
   primFloatLess     : Float → Float → Bool
   primFloatNumericalEquality : Float → Float → Bool

--- a/src/data/lib/prim/Agda/Builtin/Float.agda
+++ b/src/data/lib/prim/Agda/Builtin/Float.agda
@@ -40,3 +40,20 @@ primitive
   primATan          : Float → Float
   primATan2         : Float → Float → Float
   primShowFloat     : Float → String
+
+{-# COMPILE JS primFloatToRatio = function(x) {
+    if (x !== x) {
+      return z_jAgda_Agda_Builtin_Sigma["_,_"](0)(0);
+    }
+    else if (x === Infinity) {
+      return z_jAgda_Agda_Builtin_Sigma["_,_"](1)(0);
+    }
+    else if (x === -Infinity) {
+      return z_jAgda_Agda_Builtin_Sigma["_,_"](-1)(0);
+    }
+    else {
+      return z_jAgda_Agda_Builtin_Sigma["_,_"](Math.round(x*10e8))(10e8);
+    }
+  }
+#-}
+

--- a/src/data/lib/prim/Agda/Builtin/Float/Properties.agda
+++ b/src/data/lib/prim/Agda/Builtin/Float/Properties.agda
@@ -9,4 +9,3 @@ open import Agda.Builtin.Equality
 primitive
 
   primFloatToWord64Injective : ∀ a b → primFloatToWord64 a ≡ primFloatToWord64 b → a ≡ b
-  primFloatToRatioInjective : ∀ a b → primFloatToRatio a ≡ primFloatToRatio b → a ≡ b

--- a/src/data/lib/prim/Agda/Builtin/Float/Properties.agda
+++ b/src/data/lib/prim/Agda/Builtin/Float/Properties.agda
@@ -9,3 +9,4 @@ open import Agda.Builtin.Equality
 primitive
 
   primFloatToWord64Injective : ∀ a b → primFloatToWord64 a ≡ primFloatToWord64 b → a ≡ b
+  primFloatToRatioInjective : ∀ a b → primFloatToRatio a ≡ primFloatToRatio b → a ≡ b

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -221,6 +221,7 @@ primBody s = maybe unimplemented (fromRight (hsVarUQ . HS.Ident) <$>) $
   , "primATan2"             |-> return "(atan2 :: Double -> Double -> Double)"
   , "primShowFloat"         |-> return "(Data.Text.pack . show :: Double -> Data.Text.Text)"
   , "primFloatToWord64"     |-> return "MAlonzo.RTE.Float.doubleToWord64"
+  , "primFloatToRatio"      |-> return "MAlonzo.RTE.Float.doubleToRatio"
   , "primFloatToWord64Injective" |-> return "erased"
 
   -- Character functions

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -11,6 +11,7 @@ module Agda.TypeChecking.Primitive
        , module Agda.TypeChecking.Primitive
        ) where
 
+import Data.Bifunctor (second)
 import Data.Char
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -465,6 +466,13 @@ primFloatToWord64Injective = do
   toWord <- primFunName <$> getPrimitive "primFloatToWord64"
   mkPrimInjective float word toWord
 
+primFloatToRatioInjective :: TCM PrimitiveImpl
+primFloatToRatioInjective = do
+  float   <- primType (undefined :: Double)
+  ratio   <- primType (undefined :: (Integer, Nat))
+  toRatio <- primFunName <$> getPrimitive "primFloatToRatio"
+  mkPrimInjective float ratio toRatio
+
 primQNameToWord64sInjective :: TCM PrimitiveImpl
 primQNameToWord64sInjective = do
   name    <- primType (undefined :: QName)
@@ -844,6 +852,8 @@ primitiveFunctions = localTCStateSavingWarnings <$> Map.fromList
   , "primATan"            |-> mkPrimFun1 (atan            :: Fun Double)
   , "primATan2"           |-> mkPrimFun2 (atan2           :: Op Double)
   , "primShowFloat"       |-> mkPrimFun1 (T.pack . show   :: Double -> Text)
+  , "primFloatToRatio"    |-> mkPrimFun1 (second Nat . doubleToRatio :: Double -> (Integer, Nat))
+  , "primFloatToRatioInjective" |-> primFloatToRatioInjective
   , "primFloatToWord64"   |-> mkPrimFun1 doubleToWord64
   , "primFloatToWord64Injective" |-> primFloatToWord64Injective
 

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -466,13 +466,6 @@ primFloatToWord64Injective = do
   toWord <- primFunName <$> getPrimitive "primFloatToWord64"
   mkPrimInjective float word toWord
 
-primFloatToRatioInjective :: TCM PrimitiveImpl
-primFloatToRatioInjective = do
-  float   <- primType (undefined :: Double)
-  ratio   <- primType (undefined :: (Integer, Nat))
-  toRatio <- primFunName <$> getPrimitive "primFloatToRatio"
-  mkPrimInjective float ratio toRatio
-
 primQNameToWord64sInjective :: TCM PrimitiveImpl
 primQNameToWord64sInjective = do
   name    <- primType (undefined :: QName)
@@ -853,7 +846,6 @@ primitiveFunctions = localTCStateSavingWarnings <$> Map.fromList
   , "primATan2"           |-> mkPrimFun2 (atan2           :: Op Double)
   , "primShowFloat"       |-> mkPrimFun1 (T.pack . show   :: Double -> Text)
   , "primFloatToRatio"    |-> mkPrimFun1 (second Nat . doubleToRatio :: Double -> (Integer, Nat))
-  , "primFloatToRatioInjective" |-> primFloatToRatioInjective
   , "primFloatToWord64"   |-> mkPrimFun1 doubleToWord64
   , "primFloatToWord64Injective" |-> primFloatToWord64Injective
 

--- a/test/Compiler/simple/Floats.agda
+++ b/test/Compiler/simple/Floats.agda
@@ -1,7 +1,9 @@
 
 module _ where
 
+open import Agda.Builtin.Sigma
 open import Common.Prelude
+open import Common.Integer
 
 print : Float → IO Unit
 print x = putStrLn (primShowFloat x)
@@ -9,6 +11,10 @@ print x = putStrLn (primShowFloat x)
 printB : Bool → IO Unit
 printB true  = putStrLn "true"
 printB false = putStrLn "false"
+
+printR : Σ Integer (λ _ → Nat) → IO Unit
+printR (n , d) =
+  putStrLn ("(" +S+ primShowInteger n +S+ ", " +S+ primShowNat d +S+ ")")
 
 _/_   = primFloatDiv
 _==_  = primFloatEquality
@@ -40,6 +46,9 @@ isZero : Float → String
 isZero 0.0  = "pos"
 isZero -0.0 = "neg"
 isZero _    = "nonzero"
+
+toRatio : Float → Σ Integer (λ _ → Nat)
+toRatio = primFloatToRatio
 
 main : IO Unit
 main =
@@ -105,4 +114,11 @@ main =
   putStr "cos (acos 0.6)      = " ,, print (cos (acos 0.6)) ,,
   putStr "tan (atan 0.4)      = " ,, print (tan (atan 0.4)) ,,
   putStr "tan (atan2 0.4 1.0) = " ,, print (tan (atan2 0.4 1.0)) ,,
+
+  -- Conversion to ratios.
+  putStr "toRatio NaN  = " ,, printR (toRatio NaN) ,,
+  putStr "toRatio Inf  = " ,, printR (toRatio Inf) ,,
+  putStr "toRatio -Inf = " ,, printR (toRatio -Inf) ,,
+  putStr "toRatio 1.5  = " ,, printR (toRatio 1.5) ,,
+
   return unit

--- a/test/Succeed/FloatToRatio.agda
+++ b/test/Succeed/FloatToRatio.agda
@@ -1,0 +1,23 @@
+module FloatToRatio where
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Float
+open import Agda.Builtin.Int
+open import Agda.Builtin.Sigma
+
+NaN Infinity -Infinity : Float
+NaN = primFloatDiv 0.0 0.0
+Infinity = primFloatDiv 1.0 0.0
+-Infinity = primFloatDiv -1.0 0.0
+
+_ : primFloatToRatio 1.5 ≡ (pos 3 , 2)
+_ = refl
+
+_ : primFloatToRatio NaN ≡ (pos 0 , 0)
+_ = refl
+
+_ : primFloatToRatio Infinity ≡ (pos 1 , 0)
+_ = refl
+
+_ : primFloatToRatio -Infinity ≡ (negsuc 0 , 0)
+_ = refl


### PR DESCRIPTION
New primitive primFloatToRatio, which converts floating-point numbers to ratios, represented as a pair of a numerator and a denominator.
  
```agda
primFloatToRatio : Float → Σ Int λ _ → Nat
```
  
The primitive maps NaN to (0 , 0), Infinity to (1 , 0), and -Infinity to (-1, 0).
