### PR TITLE
Add license identifiers

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -1,5 +1,6 @@
 ;;; agda-input.el --- The Agda input method
 
+;; SPDX-License-Identifier: MIT License
 ;;; Commentary:
 
 ;; A highly customisable input method which can inherit from other

--- a/src/data/emacs-mode/agda2-abbrevs.el
+++ b/src/data/emacs-mode/agda2-abbrevs.el
@@ -1,4 +1,5 @@
 ;; agda2-abbrevs.el --- Default Agda abbrevs
+;; SPDX-License-Identifier: MIT License
 
 ;;; Commentary:
 

--- a/src/data/emacs-mode/agda2-highlight.el
+++ b/src/data/emacs-mode/agda2-highlight.el
@@ -1,4 +1,5 @@
 ;;; agda2-highlight.el --- Syntax highlighting for Agda (version ≥ 2)
+;; SPDX-License-Identifier: MIT License
 
 ;;; Commentary:
 

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1,4 +1,5 @@
 ;;; agda2-mode.el --- Major mode for Agda
+;; SPDX-License-Identifier: MIT License
 
 ;;; Commentary:
 

--- a/src/data/emacs-mode/agda2-queue.el
+++ b/src/data/emacs-mode/agda2-queue.el
@@ -1,4 +1,5 @@
 ;;; agda2-queue.el --- Simple FIFO character queues.
+;; SPDX-License-Identifier: MIT License
 
 (defun agda2-queue-empty ()
   "Creates a new empty FIFO character queue.

--- a/src/data/emacs-mode/agda2.el
+++ b/src/data/emacs-mode/agda2.el
@@ -1,6 +1,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Agda mode code which should run before the first Agda file is
 ;; loaded
+;; SPDX-License-Identifier: MIT License
 
 (defvar agda2-directory (file-name-directory load-file-name)
   "Path to the directory that contains agda2.el(c).")

--- a/src/data/emacs-mode/annotation.el
+++ b/src/data/emacs-mode/annotation.el
@@ -2,6 +2,7 @@
 
 ;; Note that this library enumerates buffer positions starting from 1,
 ;; just like Emacs.
+;; SPDX-License-Identifier: MIT License
 
 (require 'cl)
 

--- a/src/data/emacs-mode/eri.el
+++ b/src/data/emacs-mode/eri.el
@@ -1,4 +1,5 @@
 ;;; eri.el --- Enhanced relative indentation (eri)
+;; SPDX-License-Identifier: MIT License
 
 ;;; Commentary:
 


### PR DESCRIPTION
The melpa maintainers asked me to add a license identifier to the `.el` files. Please correct me if I chose the wrong one (I'm not sure at all, I think it's MIT, but I have no idea).

https://github.com/melpa/melpa/pull/7080

https://github.com/agda/agda/issues/3360