### PR TITLE
Implement binary integer literals with prefix `0b`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,8 @@ Language
   local confluence can be restored by using the
   `--local-confluence-check` flag.
 
+* Binary integer literals with prefix `0b` (for instance, `0b11001001`) are now
+  supported.
 
 Reflection
 ----------

--- a/doc/user-manual/language/lexical-structure.lagda.rst
+++ b/doc/user-manual/language/lexical-structure.lagda.rst
@@ -96,13 +96,15 @@ strings. See :ref:`built-ins` for the corresponding types, and
 .. _lexical-structure-int-literals:
 
 Integers
-  Integer values in decimal or hexadecimal (prefixed by ``0x``) notation.
-  Non-negative numbers map by default to :ref:`built-in natural numbers
-  <built-in-nat>`, but can be overloaded. Negative numbers have no default
-  interpretation and can only be used through :ref:`overloading
+  Integer values in decimal, hexadecimal (prefixed by ``0x``), or binary
+  (prefixed by ``0b``) notation. The character `_` can be used to separate
+  groups of digits. Non-negative numbers map by default to :ref:`built-in
+  natural numbers <built-in-nat>`, but can be overloaded. Negative numbers have
+  no default interpretation and can only be used through :ref:`overloading
   <literal-overloading>`.
 
-  Examples: ``123``, ``0xF0F080``, ``-42``, ``-0xF``
+  Examples: ``123``, ``0xF0F080``, ``-42``, ``-0xF``, ``0b11001001``,
+  ``1_000_000_000``, ``0b01001000_01001001``.
 
 .. _lexical-structure-float-literals:
 

--- a/src/full/Agda/Syntax/Parser/LexActions.hs
+++ b/src/full/Agda/Syntax/Parser/LexActions.hs
@@ -20,6 +20,7 @@ module Agda.Syntax.Parser.LexActions
 
 import Data.Bifunctor
 import Data.Char
+import Data.List
 import Data.Maybe
 
 import Agda.Syntax.Common (pattern Ranged)
@@ -191,9 +192,24 @@ symbol s = withInterval_ (TokSymbol s)
 -- | Parse a number.
 
 number :: String -> Integer
-number str = read $ case str of
-  '0' : 'x' : num -> str
-  _               -> concat $ wordsBy ('_' ==) str
+number str = case str of
+    '0' : 'x' : num -> parseNumber 16 num
+    '0' : 'b' : num -> parseNumber 2  num
+    num             -> parseNumber 10 num
+    where
+        parseNumber :: Integer -> String -> Integer
+        parseNumber radix = foldl' (addDigit radix)  0
+
+        addDigit :: Integer -> Integer -> Char -> Integer
+        addDigit radix n '_' = n
+        addDigit radix n c   = n * radix + fromIntegral (parseDigit c)
+
+        parseDigit :: Char -> Int
+        parseDigit c
+            | '0' <= c && c <= '9' = ord c - ord '0'
+            | 'a' <= c && c <= 'f' = ord c - ord 'a' + 10
+            | 'A' <= c && c <= 'F' = ord c - ord 'A' + 10
+            | otherwise            = __IMPOSSIBLE__
 
 integer :: String -> Integer
 integer = \case

--- a/src/full/Agda/Syntax/Parser/LexActions.hs
+++ b/src/full/Agda/Syntax/Parser/LexActions.hs
@@ -198,21 +198,14 @@ number str = case str of
     num             -> parseNumber 10 num
     where
         parseNumber :: Integer -> String -> Integer
-        parseNumber radix = foldl' (addDigit radix)  0
-
-        addDigit :: Integer -> Integer -> Char -> Integer
-        addDigit radix n '_' = n
-        addDigit radix n c   = n * radix + fromIntegral (parseDigit c)
+        parseNumber radix = foldl' (addDigit radix) 0
 
         -- We rely on Agda.Syntax.Parser.Lexer to enforce that the digits are
         -- in the correct range (so e.g. the digit 'E' cannot appear in a
         -- binary number).
-        parseDigit :: Char -> Int
-        parseDigit c
-            | '0' <= c && c <= '9' = ord c - ord '0'
-            | 'a' <= c && c <= 'f' = ord c - ord 'a' + 10
-            | 'A' <= c && c <= 'F' = ord c - ord 'A' + 10
-            | otherwise            = __IMPOSSIBLE__
+        addDigit :: Integer -> Integer -> Char -> Integer
+        addDigit radix n '_' = n
+        addDigit radix n c   = n * radix + fromIntegral (digitToInt c)
 
 integer :: String -> Integer
 integer = \case

--- a/src/full/Agda/Syntax/Parser/LexActions.hs
+++ b/src/full/Agda/Syntax/Parser/LexActions.hs
@@ -204,6 +204,9 @@ number str = case str of
         addDigit radix n '_' = n
         addDigit radix n c   = n * radix + fromIntegral (parseDigit c)
 
+        -- We rely on Agda.Syntax.Parser.Lexer to enforce that the digits are
+        -- in the correct range (so e.g. the digit 'E' cannot appear in a
+        -- binary number).
         parseDigit :: Char -> Int
         parseDigit c
             | '0' <= c && c <= '9' = ord c - ord '0'

--- a/src/full/Agda/Syntax/Parser/Lexer.x
+++ b/src/full/Agda/Syntax/Parser/Lexer.x
@@ -44,8 +44,8 @@ import Agda.Syntax.Literal
 -- by Agda.Syntax.Parser.LexActions.foolAlex in a preprocessing pass.
 
 $digit       = 0-9
-$binarydigit = 0-1
 $hexdigit    = [ $digit a-f A-F ]
+$binarydigit = 0-1
 $alpha       = [ A-Z a-z _ ]
 $op          = [ \- \! \# \$ \% \& \* \+ \/ \< \= \> \^ \| \~ \? \` \[ \] \, \: ]
 $idstart     = [ $digit $alpha $op ]

--- a/src/full/Agda/Syntax/Parser/Lexer.x
+++ b/src/full/Agda/Syntax/Parser/Lexer.x
@@ -44,6 +44,7 @@ import Agda.Syntax.Literal
 -- by Agda.Syntax.Parser.LexActions.foolAlex in a preprocessing pass.
 
 $digit       = 0-9
+$binarydigit = 0-1
 $hexdigit    = [ $digit a-f A-F ]
 $alpha       = [ A-Z a-z _ ]
 $op          = [ \- \! \# \$ \% \& \* \+ \/ \< \= \> \^ \| \~ \? \` \[ \] \, \: ]
@@ -54,7 +55,9 @@ $white_notab = $white # \t
 $white_nonl  = $white_notab # \n
 
 @number       = $digit+ | "0x" $hexdigit+
-@prettynumber = $digit+ ([_] $digit+)* | "0x" $hexdigit+
+@prettynumber = $digit+ ([_] $digit+)*
+              | "0x" $hexdigit+ ([_] $hexdigit+)*
+              | "0b" $binarydigit+ ([_] $binarydigit+)*
 @integer      = [\-]? @prettynumber
 @exponent     = [eE] [\-\+]? @number
 @float        = @integer \. @number @exponent? | @number @exponent

--- a/test/Succeed/IntegerLiteral.agda
+++ b/test/Succeed/IntegerLiteral.agda
@@ -3,3 +3,9 @@ open import Agda.Builtin.Equality
 
 _ : 10_000 * 100_000 ≡ 1_000_000_000
 _ = refl
+
+_ : 0xDEADBEEF ≡ 3735928559
+_ = refl
+
+_ : 0b01001000_01001001 ≡ 18505
+_ = refl


### PR DESCRIPTION
For example `0b01001001`. I was trying to formalize some low-level computing stuff and found it's often much clearer to write constants in binary rather than hexadecimal. Several other languages have binary literals too (e.g. Java, Python, and Haskell with the BinaryLiterals extension).