### PR TITLE
Make ghci flags consistent

### DIFF
--- a/.ghci-8.0
+++ b/.ghci-8.0
@@ -20,7 +20,6 @@
 :set -Wdodgy-imports
 :set -Wduplicate-exports
 :set -Wempty-enumerations
-:set -Whi-shadowing
 :set -Widentities
 :set -Wincomplete-patterns
 :set -Winline-rule-shadowing

--- a/.ghci-8.0
+++ b/.ghci-8.0
@@ -45,8 +45,8 @@
 
 :set -XBangPatterns
 :set -XConstraintKinds
-:set -XDataKinds
 :set -XDefaultSignatures
+:set -XDeriveDataTypeable
 :set -XDeriveFoldable
 :set -XDeriveFunctor
 :set -XDeriveTraversable
@@ -54,11 +54,13 @@
 :set -XFlexibleContexts
 :set -XFlexibleInstances
 :set -XFunctionalDependencies
+:set -XInstanceSigs
 :set -XLambdaCase
 :set -XMultiParamTypeClasses
 :set -XMultiWayIf
 :set -XNamedFieldPuns
 :set -XOverloadedStrings
+:set -XPatternSynonyms
 :set -XRankNTypes
 :set -XRecordWildCards
 :set -XScopedTypeVariables

--- a/.ghci-8.6
+++ b/.ghci-8.6
@@ -2,7 +2,6 @@
 -- It should be loaded automatically by the `.ghci` file in this directory.
 --
 :script .ghci-8.2
-:set -Wimplicit-kind-vars
 :set -Winaccessible-code
 :set -Wstar-binder
 :set -Wstar-is-type

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -681,7 +681,7 @@ library
                  -Werror=warnings-deprecations
                  -Werror=wrong-do-bind
 
-  -- NOTE: If adding flags, also add to `.ghci-8.2`
+  -- NOTE: If adding or removing flags, also change `.ghci-8.2`
   if impl(ghc >= 8.2)
     ghc-options: -Wcpp-undef
                  -- ASR TODO (2017-07-23): `make haddock` fails when
@@ -690,7 +690,7 @@ library
                  -Werror=simplifiable-class-constraints
                  -Werror=unbanged-strict-patterns
 
-  -- NOTE: If adding flags, also add to `.ghci-8.6`
+  -- NOTE: If adding or removing flags, also change `.ghci-8.6`
   if impl(ghc >= 8.6)
     ghc-options: -Werror=inaccessible-code
                  -Werror=star-binder
@@ -700,6 +700,9 @@ library
 
   default-language: Haskell2010
 
+  -- NOTE: If adding or removing default extensions, also change:
+  --         .ghci-8.0
+  --         .hlint.yaml
   default-extensions: BangPatterns
                     , ConstraintKinds
                     --L-T Chen (2019-07-15):
@@ -886,6 +889,9 @@ test-suite agda-tests
 
   default-language:  Haskell2010
 
+  -- NOTE: If adding or removing default extensions, also change:
+  --         .ghci-8.0
+  --         .hlint.yaml
   default-extensions:  BangPatterns
                      , ConstraintKinds
                      , DataKinds
@@ -912,7 +918,7 @@ test-suite agda-tests
                      , TupleSections
                      , TypeSynonymInstances
 
-  -- NOTE: If adding flags, also add to `.ghci-8.0`
+  -- NOTE: If adding or removing flags, also change `.ghci-8.0`
   if impl(ghc <= 8.0.2)
     ghc-options: -fexpose-all-unfoldings
                  -fspecialise-aggressively
@@ -985,13 +991,13 @@ test-suite agda-tests
 
   -- ASR (2017-04-11). TODO: Using -Werror=missing-home-modules generates an
   -- error.
-  -- NOTE: If adding flags, also add to `.ghci-8.2`
+  -- NOTE: If adding or removing flags, also change `.ghci-8.2`
   if impl(ghc >= 8.2)
     ghc-options: -Werror=cpp-undef
                  -Werror=simplifiable-class-constraints
                  -Werror=unbanged-strict-patterns
 
-  -- NOTE: If adding flags, also add to `.ghci-8.6`
+  -- NOTE: If adding or removing flags, also change `.ghci-8.6`
   if impl(ghc >= 8.6)
     ghc-options: -Werror=inaccessible-code
                  -Werror=star-binder

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -703,6 +703,7 @@ library
   -- NOTE: If adding or removing default extensions, also change:
   --         .ghci-8.0
   --         .hlint.yaml
+  -- This should also use the same extensions as the `test-suite` target below.
   default-extensions: BangPatterns
                     , ConstraintKinds
                     --L-T Chen (2019-07-15):
@@ -892,9 +893,13 @@ test-suite agda-tests
   -- NOTE: If adding or removing default extensions, also change:
   --         .ghci-8.0
   --         .hlint.yaml
+  -- This should also use the same extensions as the `library` target above.
   default-extensions:  BangPatterns
                      , ConstraintKinds
-                     , DataKinds
+                     --L-T Chen (2019-07-15):
+                     -- Enabling DataKinds only locally makes the compile time
+                     -- slightly shorter, see PR #3920.
+                     --, DataKinds
                      , DefaultSignatures
                      , DeriveDataTypeable
                      , DeriveFoldable


### PR DESCRIPTION
I believe this is a very low-impact/low-risk fixup change.

Some flags were removed from `Agda.cabal` in #4242 but missed in the `.ghci-*` scripts. This removes them there too, which avoids a deprecation warning, and updates the comments. This also makes the `test-suite` flags the same as `executable`: `DataKinds` had been removed from one but not the other.