### PR TITLE
Resolve most causes of UndecidableInstances via type families (33 modules → 5)

### DIFF
--- a/src/full/Agda/Auto/Auto.hs
+++ b/src/full/Agda/Auto/Auto.hs
@@ -191,7 +191,8 @@ auto ii rng argstr = liftTCM $ locallyTC eMakeCase (const True) $ do
                  nsol' <- readIORef nsol
                  if nsol' /= 0 && depreached then loop (d + costIncrease) else return depreached
 
-        let getsols sol = do
+        let getsols :: [I.Term] -> TCM [(MetaId, A.Expr)]
+            getsols sol = do
              exprs <- forM (zip (Map.keys tccons) sol) $ \ (mi, e) -> do
                mv   <- lookupMeta mi
                e    <- etaContract e

--- a/src/full/Agda/Auto/NarrowingSearch.hs
+++ b/src/full/Agda/Auto/NarrowingSearch.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Agda.Auto.NarrowingSearch where
@@ -12,13 +13,18 @@ import Agda.Utils.Empty
 newtype Prio = Prio { getPrio :: Int }
  deriving (Eq, Ord, Num)
 
-class Trav a blk | a -> blk where
-  trav :: Monad m => (forall b . Trav b blk => MM b blk -> m ()) -> a -> m ()
+class Trav a where
+  type Block a
+  trav :: Monad m => (forall b. TravWith b (Block a) => MM b (Block b) -> m ()) -> a -> m ()
 
-instance Trav a blk => Trav (MM a blk) blk where
+-- | Trav instance 'a' with block type 'blk'
+type TravWith a blk = (Trav a, Block a ~ blk)
+
+instance TravWith a blk => Trav (MM a blk) where
+  type Block (MM a blk) = blk
   trav f me = f me
 
-data Term blk = forall a . Trav a blk => Term a
+data Term blk = forall a. TravWith a blk => Term a
 
 -- | Result of type-checking.
 data Prop blk
@@ -556,7 +562,10 @@ calc cont node = do
        storeprio node (NoPrio False) []
     PDoubleBlocked m1 m2 cont -> do
      flag <- lift $ newIORef False
-     let newobs = ((QPDoubleBlocked flag cont, node) :)
+
+     let newobs :: forall b. [(QPB b blk, Maybe (CTree blk))]
+                          -> [(QPB b blk, Maybe (CTree blk))]
+         newobs = ((QPDoubleBlocked flag cont, node) :)
      umodifyIORef (mobs m1) newobs
      umodifyIORef (mobs m2) newobs
      storeprio node (NoPrio False) []

--- a/src/full/Agda/Auto/SearchControl.hs
+++ b/src/full/Agda/Auto/SearchControl.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeFamilies         #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Agda.Auto.SearchControl where
@@ -412,17 +412,21 @@ prioTypecheck True = 0
 
 -- ---------------------------------
 
-instance Trav a blk => Trav [a] blk where
+instance Trav a => Trav [a] where
+  type Block [a] = Block a
   trav _ []     = return ()
   trav f (x:xs) = trav f x >> trav f xs
 
-instance Trav (MId, CExp o) (RefInfo o) where
+instance Trav (MId, CExp o) where
+  type Block (MId, CExp o) = RefInfo o
   trav f (_, ce) = trav f ce
 
-instance Trav (TrBr a o) (RefInfo o) where
+instance Trav (TrBr a o) where
+  type Block (TrBr a o) = RefInfo o
   trav f (TrBr es _) = trav f es
 
-instance Trav (Exp o) (RefInfo o) where
+instance Trav (Exp o) where
+  type Block (Exp o) = RefInfo o
   trav f e = case e of
     App _ _ _ args          -> trav f args
     Lam _ (Abs _ b)        -> trav f b
@@ -430,7 +434,8 @@ instance Trav (Exp o) (RefInfo o) where
     Sort _                 -> return ()
     AbsurdLambda{}         -> return ()
 
-instance Trav (ArgList o) (RefInfo o) where
+instance Trav (ArgList o) where
+  type Block (ArgList o) = RefInfo o
   trav _ ALNil               = return ()
   trav f (ALCons _ arg args) = trav f arg >> trav f args
   trav f (ALProj eas _ _ as) = trav f eas >> trav f as

--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies         #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Agda-specific benchmarking structure.
@@ -126,7 +127,8 @@ isInternalAccount _                  = True
 benchmarks :: IORef Benchmark
 benchmarks = unsafePerformIO $ newIORef empty
 
-instance MonadBench Phase IO where
+instance MonadBench IO where
+  type BenchPhase IO = Phase
   getBenchmark = readIORef benchmarks
   putBenchmark = writeIORef benchmarks
   finally = E.finally

--- a/src/full/Agda/Compiler/Treeless/Builtin.hs
+++ b/src/full/Agda/Compiler/Treeless/Builtin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 -- | Translates the Agda builtin nat datatype to arbitrary-precision integers.
 --
 -- Philipp, 20150921:
@@ -134,7 +135,7 @@ transform BuiltinKit{..} = tr
                 b -> [posAlt  b]
               where
                 -- subst scrutinee for the pos argument
-                sub :: Subst TTerm a => a -> a
+                sub :: SubstWith TTerm a => a -> a
                 sub = applySubst (TVar e :# IdS)
 
                 posAlt b = TAGuard (tOp PGeq (TVar e) (tInt 0)) $ sub b

--- a/src/full/Agda/Compiler/Treeless/Subst.hs
+++ b/src/full/Agda/Compiler/Treeless/Subst.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
 
 module Agda.Compiler.Treeless.Subst where
 
@@ -18,7 +19,9 @@ instance DeBruijn TTerm where
   deBruijnView (TVar i) = Just i
   deBruijnView _ = Nothing
 
-instance Subst TTerm TTerm where
+instance Subst TTerm where
+  type SubstArg TTerm = TTerm
+
   applySubst IdS t = t
   applySubst rho t = case t of
       TDef{}    -> t
@@ -43,7 +46,8 @@ instance Subst TTerm TTerm where
       tApp (TPrim PSeq) [TErased, b] = b
       tApp f ts = TApp f ts
 
-instance Subst TTerm TAlt where
+instance Subst TAlt where
+  type SubstArg TAlt = TTerm
   applySubst rho (TACon c i b) = TACon c i (applySubst (liftS i rho) b)
   applySubst rho (TALit l b)   = TALit l (applySubst rho b)
   applySubst rho (TAGuard g b) = TAGuard (applySubst rho g) (applySubst rho b)
@@ -132,7 +136,7 @@ instance HasFree TAlt where
     TAGuard g b -> freeVars (g, b)
 
 -- | Strenghtening.
-tryStrengthen :: (HasFree a, Subst t a) => Int -> a -> Maybe a
+tryStrengthen :: (HasFree a, Subst a) => Int -> a -> Maybe a
 tryStrengthen n t =
   case Map.minViewWithKey (freeVars t) of
     Just ((i, _), _) | i < n -> Nothing

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -518,12 +518,13 @@ instance (Pretty a, Pretty b) => Pretty (OutputConstraint a b) where
       val .: ty = bin val ":" (pretty ty)
 
 
-instance (ToConcrete a c, ToConcrete b d) =>
-         ToConcrete (OutputForm a b) (OutputForm c d) where
+instance (ToConcrete a, ToConcrete b) => ToConcrete (OutputForm a b) where
+    type ConOfAbs (OutputForm a b) = OutputForm (ConOfAbs a) (ConOfAbs b)
     toConcrete (OutputForm r pid u c) = OutputForm r pid u <$> toConcrete c
 
-instance (ToConcrete a c, ToConcrete b d) =>
-         ToConcrete (OutputConstraint a b) (OutputConstraint c d) where
+instance (ToConcrete a, ToConcrete b) => ToConcrete (OutputConstraint a b) where
+    type ConOfAbs (OutputConstraint a b) = OutputConstraint (ConOfAbs a) (ConOfAbs b)
+
     toConcrete (OfType e t) = OfType <$> toConcrete e <*> toConcreteCtx TopCtx t
     toConcrete (JustType e) = JustType <$> toConcrete e
     toConcrete (JustSort e) = JustSort <$> toConcrete e
@@ -555,15 +556,17 @@ instance (ToConcrete a c, ToConcrete b d) =>
 instance (Pretty a, Pretty b) => Pretty (OutputConstraint' a b) where
   pretty (OfType' e t) = pretty e <+> ":" <+> pretty t
 
-instance (ToConcrete a c, ToConcrete b d) =>
-            ToConcrete (OutputConstraint' a b) (OutputConstraint' c d) where
+instance (ToConcrete a, ToConcrete b) => ToConcrete (OutputConstraint' a b) where
+  type ConOfAbs (OutputConstraint' a b) = OutputConstraint' (ConOfAbs a) (ConOfAbs b)
   toConcrete (OfType' e t) = OfType' <$> toConcrete e <*> toConcreteCtx TopCtx t
 
 instance Reify a => Reify (IPBoundary' a) where
   type ReifiesTo (IPBoundary' a) = IPBoundary' (ReifiesTo a)
   reify = traverse reify
 
-instance ToConcrete a c => ToConcrete (IPBoundary' a) (IPBoundary' c) where
+instance ToConcrete a => ToConcrete (IPBoundary' a) where
+  type ConOfAbs (IPBoundary' a) = IPBoundary' (ConOfAbs a)
+
   toConcrete = traverse (toConcreteCtx TopCtx)
 
 instance Pretty c => Pretty (IPBoundary' c) where

--- a/src/full/Agda/Syntax/Abstract/Pretty.hs
+++ b/src/full/Agda/Syntax/Abstract/Pretty.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 
 module Agda.Syntax.Abstract.Pretty where
 
@@ -5,21 +6,21 @@ import Agda.Syntax.Fixity
 import Agda.Syntax.Translation.AbstractToConcrete
 import Agda.Utils.Pretty
 
-showA :: (Show c, ToConcrete a c, MonadAbsToCon m) => a -> m String
+showA :: (ToConcrete a, Show (ConOfAbs a), MonadAbsToCon m) => a -> m String
 showA x = show <$> abstractToConcrete_ x
 
-prettyA :: (Pretty c, ToConcrete a c, MonadAbsToCon m) => a -> m Doc
+prettyA :: (ToConcrete a, Pretty (ConOfAbs a), MonadAbsToCon m) => a -> m Doc
 prettyA x = pretty <$> abstractToConcrete_ x
 
-prettyAs :: (Pretty c, ToConcrete a [c], MonadAbsToCon m) => a -> m Doc
+prettyAs :: (ToConcrete a, ConOfAbs a ~ [ce], Pretty ce, MonadAbsToCon m) => a -> m Doc
 prettyAs x = fsep . map pretty <$> abstractToConcrete_ x
 
 -- | Variant of 'showA' which does not insert outermost parentheses.
 
-showATop :: (Show c, ToConcrete a c, MonadAbsToCon m) => a -> m String
+showATop :: (ToConcrete a, Show (ConOfAbs a), MonadAbsToCon m) => a -> m String
 showATop x = show <$> abstractToConcreteCtx TopCtx x
 
 -- | Variant of 'prettyA' which does not insert outermost parentheses.
 
-prettyATop :: (Pretty c, ToConcrete a c, MonadAbsToCon m) => a -> m Doc
+prettyATop :: (ToConcrete a, Pretty (ConOfAbs a),  MonadAbsToCon m) => a -> m Doc
 prettyATop x = pretty <$> abstractToConcreteCtx TopCtx x

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -87,7 +87,8 @@ instance Eq a => Eq (Dom' t a) where
   Dom (ArgInfo h1 m1 _ _) b1 s1 _ x1 == Dom (ArgInfo h2 m2 _ _) b2 s2 _ x2 =
     (h1, m1, b1, s1, x1) == (h2, m2, b2, s2, x2)
 
-instance LensNamed NamedName (Dom' t e) where
+instance LensNamed (Dom' t e) where
+  type NameOf (Dom' t e) = NamedName
   lensNamed f dom = f (domName dom) <&> \ nm -> dom { domName = nm }
 
 instance LensArgInfo (Dom' t e) where

--- a/src/full/Agda/Syntax/Internal/Pattern.hs
+++ b/src/full/Agda/Syntax/Internal/Pattern.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE TypeFamilies           #-}  -- because of type equality ~
-{-# LANGUAGE UndecidableInstances   #-}  -- because of func. deps.
+{-# LANGUAGE TypeFamilies #-}
 
 module Agda.Syntax.Internal.Pattern where
 
@@ -55,27 +54,38 @@ instance {-# OVERLAPPING #-} FunArity [Clause] where
 
 -- | Label the pattern variables from left to right
 --   using one label for each variable pattern and one for each dot pattern.
-class LabelPatVars a b i | b -> i where
-  labelPatVars :: a -> State [i] b
+class LabelPatVars a b where
+  type PatVarLabel b
+  labelPatVars :: a -> State [PatVarLabel b] b
   unlabelPatVars :: b -> a
   -- ^ Intended, but unpractical due to the absence of type-level lambda, is:
   --   @labelPatVars :: f (Pattern' x) -> State [i] (f (Pattern' (i,x)))@
 
   default labelPatVars
-    :: (Traversable f, LabelPatVars a' b' i, f a' ~ a, f b' ~ b)
-    => a -> State [i] b
+    :: (Traversable f
+      , LabelPatVars a' b'
+      , PatVarLabel b ~  PatVarLabel b'
+      , f a' ~ a, f b' ~ b)
+    => a -> State [PatVarLabel b] b
   labelPatVars = traverse labelPatVars
 
   default unlabelPatVars
-    :: (Traversable f, LabelPatVars a' b' i, f a' ~ a, f b' ~ b)
+    :: (Traversable f, LabelPatVars a' b', f a' ~ a, f b' ~ b)
     => b -> a
   unlabelPatVars = fmap unlabelPatVars
 
-instance LabelPatVars a b i => LabelPatVars (Arg a) (Arg b) i         where
-instance LabelPatVars a b i => LabelPatVars (Named x a) (Named x b) i where
-instance LabelPatVars a b i => LabelPatVars [a] [b] i                 where
+instance LabelPatVars a b => LabelPatVars (Arg a) (Arg b) where
+  type PatVarLabel (Arg b) = PatVarLabel b
 
-instance LabelPatVars Pattern DeBruijnPattern Int where
+instance LabelPatVars a b => LabelPatVars (Named x a) (Named x b) where
+  type PatVarLabel (Named x b) = PatVarLabel b
+
+instance LabelPatVars a b => LabelPatVars [a] [b] where
+  type PatVarLabel [b] = PatVarLabel b
+
+instance LabelPatVars Pattern DeBruijnPattern where
+  type PatVarLabel DeBruijnPattern = Int
+
   labelPatVars p = case p of
     VarP o x        -> VarP o . DBPatVar x <$> next
     DotP o t        -> DotP o t <$ next
@@ -106,11 +116,11 @@ instance LabelPatVars Pattern DeBruijnPattern Int where
 --    dBpats    = 3 .(suc 2) (cons 2 1 0 )
 --  @
 --
-numberPatVars :: LabelPatVars a b Int => Int -> Permutation -> a -> b
+numberPatVars :: (LabelPatVars a b, PatVarLabel b ~ Int) => Int -> Permutation -> a -> b
 numberPatVars err perm ps = evalState (labelPatVars ps) $
   permPicks $ flipP $ invertP err perm
 
-unnumberPatVars :: LabelPatVars a b i => b -> a
+unnumberPatVars :: LabelPatVars a b => b -> a
 unnumberPatVars = unlabelPatVars
 
 dbPatPerm :: [NamedArg DeBruijnPattern] -> Maybe Permutation
@@ -310,17 +320,21 @@ instance CountPatternVars (Pattern' x) where
 
 -- Computing modalities of pattern variables ------------------------------
 
-class PatternVarModalities p x | p -> x where
+class PatternVarModalities p where
+  type PatVar p
   -- | Get the list of pattern variables annotated with modalities.
-  patternVarModalities :: p -> [(x, Modality)]
+  patternVarModalities :: p -> [(PatVar p, Modality)]
 
-instance PatternVarModalities a x => PatternVarModalities [a] x where
+instance PatternVarModalities a => PatternVarModalities [a] where
+  type PatVar [a] = PatVar a
   patternVarModalities = foldMap patternVarModalities
 
-instance PatternVarModalities a x => PatternVarModalities (Named s a) x where
+instance PatternVarModalities a => PatternVarModalities (Named s a) where
+  type PatVar (Named s a) = PatVar a
   patternVarModalities = foldMap patternVarModalities
 
-instance PatternVarModalities a x => PatternVarModalities (Arg a) x where
+instance PatternVarModalities a => PatternVarModalities (Arg a) where
+  type PatVar (Arg a) = PatVar a
   patternVarModalities arg = map (second (m <>)) (patternVarModalities $ unArg arg)
     where m = getModality arg
 
@@ -330,7 +344,8 @@ instance PatternVarModalities a x => PatternVarModalities (Arg a) x where
 --   patternVarModalities (IApply x y p) = patternVarModalities [x, y, p]
 --   patternVarModalities Proj{}    = []
 
-instance PatternVarModalities (Pattern' x) x where
+instance PatternVarModalities (Pattern' x) where
+  type PatVar (Pattern' x) = x
   patternVarModalities p =
     case p of
       VarP _ x    -> [(x, defaultModality)]

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -57,7 +57,7 @@ import Agda.Syntax.Concrete.Fixity (DoWarn(..))
 import Agda.Syntax.Notation
 import Agda.Syntax.Scope.Base as A
 import Agda.Syntax.Scope.Monad
-import Agda.Syntax.Translation.AbstractToConcrete (ToConcrete)
+import Agda.Syntax.Translation.AbstractToConcrete (ToConcrete, ConOfAbs)
 import Agda.Syntax.DoNotation
 import Agda.Syntax.IdiomBrackets
 
@@ -294,7 +294,7 @@ checkModuleApplication (C.RecordModuleInstance _ recN) m0 x dir' =
 --   Preserves local variables.
 
 checkModuleMacro
-  :: (Pretty c, ToConcrete a c)
+  :: (ToConcrete a, Pretty (ConOfAbs a))
   => (ModuleInfo
       -> ModuleName
       -> A.ModuleApplication

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE TypeFamilies         #-}  -- for type equality ~
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-| Translation from "Agda.Syntax.Concrete" to "Agda.Syntax.Abstract". Involves scope analysis,
     figuring out infix operator precedences and tidying up definitions.
@@ -170,7 +169,8 @@ noDotorEqPattern err = dot
 
 newtype RecordConstructorType = RecordConstructorType [C.Declaration]
 
-instance ToAbstract RecordConstructorType A.Expr where
+instance ToAbstract RecordConstructorType where
+  type AbsOfCon RecordConstructorType = A.Expr
   toAbstract (RecordConstructorType ds) = recordConstructorType ds
 
 -- | Compute the type of the record constructor (with bogus target type)
@@ -438,28 +438,28 @@ checkOpen r mam x dir = do
     Translation
  --------------------------------------------------------------------------}
 
-concreteToAbstract_ :: ToAbstract c a => c -> ScopeM a
+concreteToAbstract_ :: ToAbstract c => c -> ScopeM (AbsOfCon c)
 concreteToAbstract_ = toAbstract
 
-concreteToAbstract :: ToAbstract c a => ScopeInfo -> c -> ScopeM a
+concreteToAbstract :: ToAbstract c => ScopeInfo -> c -> ScopeM (AbsOfCon c)
 concreteToAbstract scope x = withScope_ scope (toAbstract x)
 
 -- | Things that can be translated to abstract syntax are instances of this
 --   class.
-class ToAbstract concrete abstract | concrete -> abstract where
-    toAbstract :: concrete -> ScopeM abstract
+class ToAbstract c where
+    type AbsOfCon c
+    toAbstract :: c -> ScopeM (AbsOfCon c)
 
 -- | This function should be used instead of 'toAbstract' for things that need
 --   to keep track of precedences to make sure that we don't forget about it.
-toAbstractCtx :: ToAbstract concrete abstract =>
-                 Precedence -> concrete -> ScopeM abstract
+toAbstractCtx :: ToAbstract c => Precedence -> c-> ScopeM (AbsOfCon c)
 toAbstractCtx ctx c = withContextPrecedence ctx $ toAbstract c
 
 --UNUSED Liang-Ting Chen 2019-07-16
 --toAbstractTopCtx :: ToAbstract c a => c -> ScopeM a
 --toAbstractTopCtx = toAbstractCtx TopCtx
 
-toAbstractHiding :: (LensHiding h, ToAbstract c a) => h -> c -> ScopeM a
+toAbstractHiding :: (LensHiding h, ToAbstract c) => h -> c -> ScopeM (AbsOfCon c)
 toAbstractHiding h | visible h = toAbstract -- don't change precedence if visible
 toAbstractHiding _             = toAbstractCtx TopCtx
 
@@ -470,45 +470,50 @@ toAbstractHiding _             = toAbstractCtx TopCtx
 --  old <- useScope scopePrecedence
 --  withContextPrecedence p $ f $ \ x -> setContextPrecedence old >> ret x
 --
---localToAbstractCtx :: ToAbstract concrete abstract =>
---                     Precedence -> concrete -> (abstract -> ScopeM a) -> ScopeM a
+--localToAbstractCtx :: ToAbstract c =>
+--                     Precedence -> c -> (AbsOfCon -> ScopeM (AbsOfCon c)) -> ScopeM (AbsOfCon c)
 --localToAbstractCtx ctx c ret = setContextCPS ctx ret (localToAbstract c)
 
 -- | This operation does not affect the scope, i.e. the original scope
 --   is restored upon completion.
-localToAbstract :: ToAbstract c a => c -> (a -> ScopeM b) -> ScopeM b
+localToAbstract :: ToAbstract c => c -> (AbsOfCon c -> ScopeM b) -> ScopeM b
 localToAbstract x ret = fst <$> localToAbstract' x ret
 
 -- | Like 'localToAbstract' but returns the scope after the completion of the
 --   second argument.
-localToAbstract' :: ToAbstract c a => c -> (a -> ScopeM b) -> ScopeM (b, ScopeInfo)
+localToAbstract' :: ToAbstract c => c -> (AbsOfCon c -> ScopeM b) -> ScopeM (b, ScopeInfo)
 localToAbstract' x ret = do
   scope <- getScope
   withScope scope $ ret =<< toAbstract x
 
-instance ToAbstract () () where
+instance ToAbstract () where
+  type AbsOfCon () = ()
   toAbstract = pure
 
-instance (ToAbstract c1 a1, ToAbstract c2 a2) => ToAbstract (c1,c2) (a1,a2) where
+instance (ToAbstract c1, ToAbstract c2) => ToAbstract (c1, c2) where
+  type AbsOfCon (c1, c2) = (AbsOfCon c1, AbsOfCon c2)
   toAbstract (x,y) = (,) <$> toAbstract x <*> toAbstract y
 
-instance (ToAbstract c1 a1, ToAbstract c2 a2, ToAbstract c3 a3) =>
-         ToAbstract (c1,c2,c3) (a1,a2,a3) where
-    toAbstract (x,y,z) = flatten <$> toAbstract (x,(y,z))
-        where
-            flatten (x,(y,z)) = (x,y,z)
+instance (ToAbstract c1, ToAbstract c2, ToAbstract c3) => ToAbstract (c1, c2, c3) where
+  type AbsOfCon (c1, c2, c3) = (AbsOfCon c1, AbsOfCon c2, AbsOfCon c3)
+  toAbstract (x,y,z) = flatten <$> toAbstract (x,(y,z))
+    where
+      flatten (x,(y,z)) = (x,y,z)
 
-instance {-# OVERLAPPABLE #-} ToAbstract c a => ToAbstract [c] [a] where
+instance ToAbstract c => ToAbstract [c] where
+  type AbsOfCon [c] = [AbsOfCon c]
   toAbstract = mapM toAbstract
 
-instance {-# OVERLAPPABLE #-} ToAbstract c a => ToAbstract (List1 c) (List1 a) where
+instance ToAbstract c => ToAbstract (List1 c) where
+  type AbsOfCon (List1 c) = List1 (AbsOfCon c)
   toAbstract = mapM toAbstract
 
-instance (ToAbstract c1 a1, ToAbstract c2 a2) =>
-         ToAbstract (Either c1 c2) (Either a1 a2) where
-    toAbstract = traverseEither toAbstract toAbstract
+instance (ToAbstract c1, ToAbstract c2) => ToAbstract (Either c1 c2) where
+  type AbsOfCon (Either c1 c2) = Either (AbsOfCon c1) (AbsOfCon c2)
+  toAbstract = traverseEither toAbstract toAbstract
 
-instance ToAbstract c a => ToAbstract (Maybe c) (Maybe a) where
+instance ToAbstract c => ToAbstract (Maybe c) where
+  type AbsOfCon (Maybe c) = Maybe (AbsOfCon c)
   toAbstract = traverse toAbstract
 
 -- Names ------------------------------------------------------------------
@@ -537,23 +542,27 @@ data PatName      = PatName C.QName (Maybe (Set A.Name))
   -- ^ If a set is given, then the first name must correspond to one
   -- of the names in the set.
 
-instance ToAbstract (NewName C.Name) A.Name where
+instance ToAbstract (NewName C.Name) where
+  type AbsOfCon (NewName C.Name) = A.Name
   toAbstract (NewName b x) = do
     y <- freshAbstractName_ x
     bindVariable b x y
     return y
 
-instance ToAbstract (NewName C.BoundName) A.BindName where
+instance ToAbstract (NewName C.BoundName) where
+  type AbsOfCon (NewName C.BoundName) = A.BindName
   toAbstract NewName{ newBinder = b, newName = BName{ boundName = x, bnameFixity = fx }} = do
     y <- freshAbstractName fx x
     bindVariable b x y
     return $ A.BindName y
 
-instance ToAbstract OldQName A.Expr where
+instance ToAbstract OldQName where
+  type AbsOfCon OldQName = A.Expr
   toAbstract q@(OldQName x _) =
     fromMaybeM (notInScopeError x) $ toAbstract (MaybeOldQName q)
 
-instance ToAbstract MaybeOldQName (Maybe A.Expr) where
+instance ToAbstract MaybeOldQName where
+  type AbsOfCon MaybeOldQName = Maybe A.Expr
   toAbstract (MaybeOldQName (OldQName x ns)) = do
     qx <- resolveName' allKindsOfNames ns x
     reportSLn "scope.name" 10 $ "resolved " ++ prettyShow x ++ ": " ++ prettyShow qx
@@ -600,7 +609,8 @@ instance ToAbstract MaybeOldQName (Maybe A.Expr) where
         _       -> return ()
 
 
-instance ToAbstract ResolveQName ResolvedName where
+instance ToAbstract ResolveQName where
+  type AbsOfCon ResolveQName = ResolvedName
   toAbstract (ResolveQName x) = resolveName x >>= \case
     UnknownName -> notInScopeError x
     q -> return q
@@ -609,7 +619,8 @@ data APatName = VarPatName A.Name
               | ConPatName (NonEmpty AbstractName)
               | PatternSynPatName (NonEmpty AbstractName)
 
-instance ToAbstract PatName APatName where
+instance ToAbstract PatName where
+  type AbsOfCon PatName = APatName
   toAbstract (PatName x ns) = do
     reportSLn "scope.pat" 10 $ "checking pattern name: " ++ prettyShow x
     rx <- resolveName' (someKindsOfNames [ConName, CoConName, PatternSynName]) ns x
@@ -656,7 +667,8 @@ instance ToQName C.Name  where toQName = C.QName
 instance ToQName C.QName where toQName = id
 
 -- Should be a defined name.
-instance ToQName a => ToAbstract (OldName a) A.QName where
+instance ToQName a => ToAbstract (OldName a) where
+  type AbsOfCon (OldName a) = A.QName
   toAbstract (OldName x) = do
     rx <- resolveName (toQName x)
     case rx of
@@ -697,7 +709,8 @@ checkForModuleClash x = do
       typeError $ ShadowedModule x $
                 map ((`withRangeOf` x) . amodName) ms
 
-instance ToAbstract NewModuleName A.ModuleName where
+instance ToAbstract NewModuleName where
+  type AbsOfCon NewModuleName = A.ModuleName
   toAbstract (NewModuleName x) = do
     checkForModuleClash x
     m <- getCurrentModule
@@ -705,7 +718,8 @@ instance ToAbstract NewModuleName A.ModuleName where
     createModule Nothing y
     return y
 
-instance ToAbstract NewModuleQName A.ModuleName where
+instance ToAbstract NewModuleQName where
+  type AbsOfCon NewModuleQName = A.ModuleName
   toAbstract (NewModuleQName m) = toAbs noModuleName m
     where
       toAbs m (C.QName x)  = do
@@ -716,7 +730,9 @@ instance ToAbstract NewModuleQName A.ModuleName where
         m' <- freshQModule m x
         toAbs m' q
 
-instance ToAbstract OldModuleName A.ModuleName where
+instance ToAbstract OldModuleName where
+  type AbsOfCon OldModuleName = A.ModuleName
+
   toAbstract (OldModuleName q) = setCurrentRange q $ do
     amodName <$> resolveModule q
 
@@ -815,7 +831,9 @@ scopeCheckExtendedLam r cs = do
 
 -- | Scope check an expression.
 
-instance ToAbstract C.Expr A.Expr where
+instance ToAbstract C.Expr where
+  type AbsOfCon C.Expr = A.Expr
+
   toAbstract e =
     traceCall (ScopeCheckExpr e) $ annotateExpr $ case e of
 
@@ -983,7 +1001,8 @@ instance ToAbstract C.Expr A.Expr where
         (s, e) <- collectGeneralizables $ toAbstract e
         pure $ A.generalized s e
 
-instance ToAbstract C.ModuleAssignment (A.ModuleName, Maybe A.LetBinding) where
+instance ToAbstract C.ModuleAssignment where
+  type AbsOfCon C.ModuleAssignment = (A.ModuleName, Maybe A.LetBinding)
   toAbstract (C.ModuleAssignment m es i)
     | null es && isDefaultImportDir i = (, Nothing) <$> toAbstract (OldModuleName m)
     | otherwise = do
@@ -995,10 +1014,14 @@ instance ToAbstract C.ModuleAssignment (A.ModuleName, Maybe A.LetBinding) where
           LetApply _ m' _ _ _ -> return (m', Just r)
           _ -> __IMPOSSIBLE__
 
-instance ToAbstract c a => ToAbstract (FieldAssignment' c) (FieldAssignment' a) where
+instance ToAbstract c => ToAbstract (FieldAssignment' c) where
+  type AbsOfCon (FieldAssignment' c) = FieldAssignment' (AbsOfCon c)
+
   toAbstract = traverse toAbstract
 
-instance ToAbstract (C.Binder' (NewName C.BoundName)) A.Binder where
+instance ToAbstract (C.Binder' (NewName C.BoundName)) where
+  type AbsOfCon (C.Binder' (NewName C.BoundName)) = A.Binder
+
   toAbstract (C.Binder p n) = do
     let name = C.boundName $ newName n
     -- If we do have a pattern then the variable needs to be inserted
@@ -1017,7 +1040,9 @@ instance ToAbstract (C.Binder' (NewName C.BoundName)) A.Binder where
     p <- toAbstract p
     pure $ A.Binder p n
 
-instance ToAbstract C.LamBinding (Maybe A.LamBinding) where
+instance ToAbstract C.LamBinding where
+  type AbsOfCon C.LamBinding = Maybe A.LamBinding
+
   toAbstract (C.DomainFree x)  = do
     tac <- traverse toAbstract $ bnameTactic $ C.binderName $ namedArg x
     Just . A.DomainFree tac <$> toAbstract (updateNamedArg (fmap $ NewName LambdaBound) x)
@@ -1028,7 +1053,9 @@ makeDomainFull (C.DomainFull b) = b
 makeDomainFull (C.DomainFree x) = C.TBind r (singleton x) $ C.Underscore r Nothing
   where r = getRange x
 
-instance ToAbstract C.TypedBinding (Maybe A.TypedBinding) where
+instance ToAbstract C.TypedBinding where
+  type AbsOfCon C.TypedBinding = Maybe A.TypedBinding
+
   toAbstract (C.TBind r xs t) = do
     t' <- toAbstractCtx TopCtx t
     tac <- traverse toAbstract $
@@ -1209,7 +1236,9 @@ topLevelModuleName = (^. scopeCurrent) . topLevelScope
 --     (import|open)*         -- a bunch of possibly opened imports
 --     module ThisModule ...  -- the top-level module of this file
 --   @
-instance ToAbstract (TopLevel [C.Declaration]) TopLevelInfo where
+instance ToAbstract (TopLevel [C.Declaration]) where
+    type AbsOfCon (TopLevel [C.Declaration]) = TopLevelInfo
+
     toAbstract (TopLevel file expectedMName ds) =
       -- A file is a bunch of preliminary decls (imports etc.)
       -- plus a single module decl.
@@ -1245,8 +1274,8 @@ instance ToAbstract (TopLevel [C.Declaration]) TopLevelInfo where
                          -- the initial segment on the off chance we generate a better error
                          -- message.
                          void importPrimitives
-                         void $ toAbstract outsideDecls
-                         void $ toAbstract ds0
+                         void $ toAbstract (Declarations outsideDecls)
+                         void $ toAbstract (Declarations ds0)
                          -- Fail with a crude error otherwise
                          traceCall (SetRange $ getRange ds0) $ genericError
                            "Illegal declaration(s) before top-level module"
@@ -1274,9 +1303,9 @@ instance ToAbstract (TopLevel [C.Declaration]) TopLevelInfo where
           am <- toAbstract (NewModuleQName m)
           primitiveImport <- importPrimitives
           -- Scope check the declarations outside
-          outsideDecls <- toAbstract outsideDecls
+          outsideDecls <- toAbstract (Declarations outsideDecls)
           (insideScope, insideDecl) <- scopeCheckModule r m am tel $
-             toAbstract insideDecls
+             toAbstract (Declarations insideDecls)
           -- Andreas, 2020-05-13, issue #1804, #4647
           -- Do not eagerly remove private definitions, only when serializing
           -- let scope = over scopeModules (fmap $ restrictLocalPrivate am) insideScope
@@ -1303,7 +1332,7 @@ instance ToAbstract (TopLevel [C.Declaration]) TopLevelInfo where
               importAgdaPrimitive = [C.Import noRange agdaPrimitiveName Nothing C.DoOpen directives]
           if noImportSorts
             then return []
-            else toAbstract importAgdaPrimitive
+            else toAbstract (Declarations importAgdaPrimitive)
 
 -- | runs Syntax.Concrete.Definitions.niceDeclarations on main module
 niceDecls :: DoWarn -> [C.Declaration] -> ([NiceDeclaration] -> ScopeM a) -> ScopeM a
@@ -1340,8 +1369,13 @@ niceDecls warn ds ret = setCurrentRange ds $ computeFixitiesAndPolarities warn d
 
   where notOnlyInSafeMode = (PragmaCompiled_ /=) . declarationWarningName
 
-instance {-# OVERLAPPING #-} ToAbstract [C.Declaration] [A.Declaration] where
-  toAbstract ds = do
+-- | Wrapper to avoid instance conflict with generic list instance.
+newtype Declarations = Declarations [C.Declaration]
+
+instance ToAbstract Declarations where
+  type AbsOfCon Declarations = [A.Declaration]
+
+  toAbstract (Declarations ds) = do
     -- When --safe is active the termination checker (Issue 586),
     -- positivity checker (Issue 1614) and the coverage checker
     -- may not be switched off, and polarities may not be assigned.
@@ -1412,11 +1446,14 @@ instance {-# OVERLAPPING #-} ToAbstract [C.Declaration] [A.Declaration] where
 newtype LetDefs = LetDefs (List1 C.Declaration)
 newtype LetDef = LetDef NiceDeclaration
 
-instance ToAbstract LetDefs [A.LetBinding] where
+instance ToAbstract LetDefs where
+  type AbsOfCon LetDefs = [A.LetBinding]
+
   toAbstract (LetDefs ds) =
     List1.concat <$> niceDecls DoWarn (List1.toList ds) (toAbstract . map LetDef)
 
-instance ToAbstract LetDef (List1 A.LetBinding) where
+instance ToAbstract LetDef where
+  type AbsOfCon LetDef = List1 A.LetBinding
   toAbstract (LetDef d) =
     case d of
       NiceMutual _ _ _ _ d@[C.FunSig _ _ _ instanc macro info _ _ x t, C.FunDef _ _ abstract _ _ _ _ [cl]] ->
@@ -1572,7 +1609,8 @@ instance ToAbstract LetDef (List1 A.LetBinding) where
           no  = genericError "Not a valid let pattern"
 
 
-instance ToAbstract NiceDeclaration A.Declaration where
+instance ToAbstract NiceDeclaration where
+  type AbsOfCon NiceDeclaration = A.Declaration
 
   toAbstract d = annotateDecls $
     traceS "scope.decl.trace" 50
@@ -1784,7 +1822,7 @@ instance ToAbstract NiceDeclaration A.Declaration where
         createModule (Just IsRecordModule) m
         -- We scope check the fields a second time, as actual fields.
         afields <- withCurrentModule m $ do
-          afields <- toAbstract fields
+          afields <- toAbstract (Declarations fields)
           printScope "rec" 15 "checked fields"
           return afields
         -- Andreas, 2017-07-13 issue #2642 disallow duplicate fields
@@ -1816,7 +1854,7 @@ instance ToAbstract NiceDeclaration A.Declaration where
         ]
 
       adecl <- traceCall (ScopeCheckDeclaration $ NiceModule r p a x tel []) $ do
-        scopeCheckNiceModule r p name tel $ toAbstract ds
+        scopeCheckNiceModule r p name tel $ toAbstract (Declarations ds)
 
       reportSDoc "scope.decl" 70 $ vcat $
         [ text $ "scope checked NiceModule " ++ prettyShow x
@@ -2064,11 +2102,14 @@ bindGeneralizablesIfInserted _ _           = __IMPOSSIBLE__
 newtype GenTel = GenTel C.Telescope
 data GenTelAndType = GenTelAndType C.Telescope C.Expr
 
-instance ToAbstract GenTel A.GeneralizeTelescope where
+instance ToAbstract GenTel where
+  type AbsOfCon GenTel = A.GeneralizeTelescope
   toAbstract (GenTel tel) =
     uncurry A.GeneralizeTel <$> collectAndBindGeneralizables (catMaybes <$> toAbstract tel)
 
-instance ToAbstract GenTelAndType (A.GeneralizeTelescope, A.Expr) where
+instance ToAbstract GenTelAndType where
+  type AbsOfCon GenTelAndType = (A.GeneralizeTelescope, A.Expr)
+
   toAbstract (GenTelAndType tel t) = do
     (binds, (tel, t)) <- collectAndBindGeneralizables $
                           (,) <$> toAbstract tel <*> toAbstract t
@@ -2151,7 +2192,9 @@ bindRecordConstructorName x kind a p = do
            AbstractDef -> PrivateAccess Inserted
            _           -> p
 
-instance ToAbstract DataConstrDecl A.Declaration where
+instance ToAbstract DataConstrDecl where
+  type AbsOfCon DataConstrDecl = A.Declaration
+
   toAbstract (DataConstrDecl m a p d) = do
     case d of
       C.Axiom r p1 a1 i info x t -> do -- rel==Relevant
@@ -2172,7 +2215,9 @@ errorNotConstrDecl d = typeError . GenericDocError $
         "Illegal declaration in data type definition " P.$$
         P.nest 2 (P.vcat $ map pretty (notSoNiceDeclarations d))
 
-instance ToAbstract C.Pragma [A.Pragma] where
+instance ToAbstract C.Pragma where
+  type AbsOfCon C.Pragma = [A.Pragma]
+
   toAbstract (C.ImpossiblePragma _) = impossibleTest
   toAbstract (C.OptionsPragma _ opts) = return [ A.OptionsPragma opts ]
   toAbstract (C.RewritePragma _ _ []) = [] <$ warning EmptyRewritePragma
@@ -2347,7 +2392,9 @@ instance ToAbstract C.Pragma [A.Pragma] where
   -- Polarity pragmas are handled by the niceifier.
   toAbstract C.PolarityPragma{} = __IMPOSSIBLE__
 
-instance ToAbstract C.Clause A.Clause where
+instance ToAbstract C.Clause where
+  type AbsOfCon C.Clause = A.Clause
+
   toAbstract (C.Clause top catchall lhs@(C.LHS p eqs with ell) rhs wh wcs) = withLocalVars $ do
     -- Jesper, 2018-12-10, #3095: pattern variables bound outside the
     -- module are locally treated as module parameters
@@ -2419,7 +2466,7 @@ whereToAbstract1 r whname whds inner = do
            -- unnamed where's are private
   old <- getCurrentModule
   am  <- toAbstract (NewModuleName m)
-  (scope, d) <- scopeCheckModule r (C.QName m) am [] $ toAbstract $ List1.toList whds
+  (scope, d) <- scopeCheckModule r (C.QName m) am [] $ toAbstract $ Declarations $ List1.toList whds
   setScope scope
   x <- inner
   setCurrentModule old
@@ -2467,7 +2514,8 @@ withFunctionName s = do
   NameId i _ <- fresh
   qualifyName_ =<< freshName_ (s ++ show i)
 
-instance ToAbstract (RewriteEqn' () A.Pattern A.Expr) A.RewriteEqn where
+instance ToAbstract (RewriteEqn' () A.Pattern A.Expr) where
+  type AbsOfCon (RewriteEqn' () A.Pattern A.Expr) = A.RewriteEqn
   toAbstract = \case
     Rewrite es -> fmap Rewrite $ forM es $ \ (_, e) -> do
       qn <- withFunctionName "-rewrite"
@@ -2476,7 +2524,9 @@ instance ToAbstract (RewriteEqn' () A.Pattern A.Expr) A.RewriteEqn where
       qn <- withFunctionName "-invert"
       pure $ Invert qn pes
 
-instance ToAbstract C.RewriteEqn (RewriteEqn' () A.Pattern A.Expr) where
+instance ToAbstract C.RewriteEqn where
+  type AbsOfCon C.RewriteEqn = RewriteEqn' () A.Pattern A.Expr
+
   toAbstract = \case
     Rewrite es   -> Rewrite <$> mapM toAbstract es
     Invert _ pes -> Invert () <$> do
@@ -2495,7 +2545,9 @@ instance ToAbstract C.RewriteEqn (RewriteEqn' () A.Pattern A.Expr) where
         toAbstract p
       pure $ List1.zip ps es
 
-instance ToAbstract AbstractRHS A.RHS where
+instance ToAbstract AbstractRHS where
+  type AbsOfCon AbstractRHS = A.RHS
+
   toAbstract AbsurdRHS'            = return A.AbsurdRHS
   toAbstract (RHS' e c)            = return $ A.RHS e $ Just c
   toAbstract (RewriteRHS' eqs rhs wh) = do
@@ -2506,7 +2558,8 @@ instance ToAbstract AbstractRHS A.RHS where
     aux <- withFunctionName "with-"
     A.WithRHS aux es <$> do toAbstract =<< sequence cs
 
-instance ToAbstract RightHandSide AbstractRHS where
+instance ToAbstract RightHandSide where
+  type AbsOfCon RightHandSide = AbstractRHS
   toAbstract (RightHandSide eqs@(_:_) es cs rhs wh)               = do
     (rhs, ds) <- whereToAbstract (getRange wh) wh $
                    toAbstract (RightHandSide [] es cs rhs NoWhere)
@@ -2525,13 +2578,17 @@ instance ToAbstract RightHandSide AbstractRHS where
   toAbstract (RightHandSide [] []     [] C.RHS{}      AnyWhere{}) = __IMPOSSIBLE__
   toAbstract (RightHandSide [] []     [] C.RHS{}     SomeWhere{}) = __IMPOSSIBLE__
 
-instance ToAbstract C.RHS AbstractRHS where
+instance ToAbstract C.RHS where
+    type AbsOfCon C.RHS = AbstractRHS
+
     toAbstract C.AbsurdRHS = return $ AbsurdRHS'
     toAbstract (C.RHS e)   = RHS' <$> toAbstract e <*> pure e
 
 data LeftHandSide = LeftHandSide C.QName C.Pattern ExpandedEllipsis
 
-instance ToAbstract LeftHandSide A.LHS where
+instance ToAbstract LeftHandSide where
+    type AbsOfCon LeftHandSide = A.LHS
+
     toAbstract (LeftHandSide top lhs ell) =
       traceCall (ScopeCheckLHS top lhs) $ do
         reportSLn "scope.lhs" 5 $ "original lhs: " ++ prettyShow lhs
@@ -2578,7 +2635,9 @@ mergeEqualPs = go (empty, [])
     warn r d = warning $ GenericUseless (getRange r) d
 
 -- does not check pattern linearity
-instance ToAbstract C.LHSCore (A.LHSCore' C.Expr) where
+instance ToAbstract C.LHSCore where
+    type AbsOfCon C.LHSCore = (A.LHSCore' C.Expr)
+
     toAbstract (C.LHSHead x ps) = do
         x <- withLocalVars $ do
           setLocalVars []
@@ -2601,14 +2660,17 @@ instance ToAbstract C.LHSCore (A.LHSCore' C.Expr) where
         (toAbstract wps)
         (toAbstract ps)
 
-instance ToAbstract c a => ToAbstract (WithHiding c) (WithHiding a) where
+instance ToAbstract c => ToAbstract (WithHiding c) where
+  type AbsOfCon (WithHiding c) = WithHiding (AbsOfCon c)
   toAbstract (WithHiding h a) = WithHiding h <$> toAbstractHiding h a
 
-instance ToAbstract c a => ToAbstract (Arg c) (Arg a) where
+instance ToAbstract c => ToAbstract (Arg c) where
+    type AbsOfCon (Arg c) = Arg (AbsOfCon c)
     toAbstract (Arg info e) =
         Arg info <$> toAbstractHiding info e
 
-instance ToAbstract c a => ToAbstract (Named name c) (Named name a) where
+instance ToAbstract c => ToAbstract (Named name c) where
+    type AbsOfCon (Named name c) = Named name (AbsOfCon c)
     toAbstract (Named n e) = Named n <$> toAbstract e
 
 {- DOES NOT WORK ANYMORE with pattern synonyms
@@ -2616,7 +2678,8 @@ instance ToAbstract c a => ToAbstract (A.LHSCore' c) (A.LHSCore' a) where
     toAbstract = mapM toAbstract
 -}
 
-instance ToAbstract (A.LHSCore' C.Expr) (A.LHSCore' A.Expr) where
+instance ToAbstract (A.LHSCore' C.Expr) where
+    type AbsOfCon (A.LHSCore' C.Expr) = A.LHSCore' A.Expr
     toAbstract (A.LHSHead f ps)         = A.LHSHead f <$> mapM toAbstract ps
     toAbstract (A.LHSProj d lhscore ps) = A.LHSProj d <$> mapM toAbstract lhscore <*> mapM toAbstract ps
     toAbstract (A.LHSWith core wps ps)  = liftA3 A.LHSWith (toAbstract core) (toAbstract wps) (toAbstract ps)
@@ -2625,7 +2688,8 @@ instance ToAbstract (A.LHSCore' C.Expr) (A.LHSCore' A.Expr) where
 -- then the dot patterns. This is because dot patterns can refer to variables
 -- bound anywhere in the pattern.
 
-instance ToAbstract (A.Pattern' C.Expr) (A.Pattern' A.Expr) where
+instance ToAbstract (A.Pattern' C.Expr) where
+  type AbsOfCon (A.Pattern' C.Expr) = A.Pattern' A.Expr
   toAbstract = traverse $ insideDotPattern . toAbstractCtx DotPatternCtx  -- Issue #3033
 
 resolvePatternIdentifier ::
@@ -2679,7 +2743,8 @@ applyAPattern p0 p ps1 = do
   where
     failure = typeError $ InvalidPattern p0
 
-instance ToAbstract C.Pattern (A.Pattern' C.Expr) where
+instance ToAbstract C.Pattern where
+    type AbsOfCon C.Pattern = A.Pattern' C.Expr
 
     toAbstract (C.IdentP x) =
       resolvePatternIdentifier (getRange x) x Nothing
@@ -2880,7 +2945,8 @@ toAbstractOpApp op ns es = do
 
 -- | Content of interaction hole.
 
-instance ToAbstract C.HoleContent A.HoleContent where
+instance ToAbstract C.HoleContent where
+  type AbsOfCon C.HoleContent = A.HoleContent
   toAbstract = \case
     HoleContentExpr e     -> HoleContentExpr <$> toAbstract e
     HoleContentRewrite es -> HoleContentRewrite <$> toAbstract es

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -858,7 +858,7 @@ instance (Ord k, Monoid v) => Monoid (MonoidMap k v) where
   mappend = (<>)
 
 -- | Removes argument names.  Preserves names present in the source.
-removeNameUnlessUserWritten :: (LensNamed n a, LensOrigin n) => a -> a
+removeNameUnlessUserWritten :: (LensNamed a, LensOrigin (NameOf a)) => a -> a
 removeNameUnlessUserWritten a
   | (getOrigin <$> getNameOf a) == Just UserWritten = a
   | otherwise = setNameOf Nothing a

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 {-# OPTIONS_GHC -fwarn-missing-signatures #-}
 
 module Agda.Syntax.Translation.ReflectedToAbstract where
@@ -67,17 +65,18 @@ withNames ss f = case ss of
 askName :: MonadReflectedToAbstract m => Int -> m (Maybe Name)
 askName i = reader (!!! i)
 
-class ToAbstract r a | r -> a where
-  toAbstract :: MonadReflectedToAbstract m => r -> m a
+class ToAbstract r where
+  type AbsOfRef r
+  toAbstract :: MonadReflectedToAbstract m => r -> m (AbsOfRef r)
 
   default toAbstract
-    :: (Traversable t, ToAbstract s b, t s ~ r, t b ~ a)
-    => MonadReflectedToAbstract m => r -> m a
+    :: (Traversable t, ToAbstract s, t s ~ r, t (AbsOfRef s) ~ (AbsOfRef r))
+    => MonadReflectedToAbstract m => r -> m (AbsOfRef r)
   toAbstract = traverse toAbstract
 
 -- | Translate reflected syntax to abstract, using the names from the current typechecking context.
 toAbstract_ ::
-  (ToAbstract r a
+  (ToAbstract r
   , MonadFresh NameId m
   , MonadError TCErr m
   , MonadTCEnv m
@@ -85,12 +84,12 @@ toAbstract_ ::
   , HasOptions m
   , HasBuiltins m
   , HasConstInfo m
-  ) => r -> m a
+  ) => r -> m (AbsOfRef r)
 toAbstract_ = withShowAllArguments . toAbstractWithoutImplicit
 
 -- | Drop implicit arguments unless --show-implicit is on.
 toAbstractWithoutImplicit ::
-  (ToAbstract r a
+  (ToAbstract r
   , MonadFresh NameId m
   , MonadError TCErr m
   , MonadTCEnv m
@@ -98,22 +97,28 @@ toAbstractWithoutImplicit ::
   , HasOptions m
   , HasBuiltins m
   , HasConstInfo m
-  ) => r -> m a
+  ) => r -> m (AbsOfRef r)
 toAbstractWithoutImplicit x = runReaderT (toAbstract x) =<< getContextNames
 
-instance ToAbstract r a => ToAbstract (Named name r) (Named name a) where
+instance ToAbstract r => ToAbstract (Named name r) where
+  type AbsOfRef (Named name r) = Named name (AbsOfRef r)
 
-instance ToAbstract r a => ToAbstract (Arg r) (NamedArg a) where
+instance ToAbstract r => ToAbstract (Arg r) where
+  type AbsOfRef (Arg r) = NamedArg (AbsOfRef r)
   toAbstract (Arg i x) = Arg i <$> toAbstract (unnamed x)
 
-instance ToAbstract r a => ToAbstract [Arg r] [NamedArg a] where
+instance ToAbstract r => ToAbstract [Arg r] where
+  type AbsOfRef [Arg r] = [NamedArg (AbsOfRef r)]
 
-instance ToAbstract r Expr => ToAbstract (Dom r, Name) (A.TypedBinding) where
+-- instance ToAbstract r Expr => ToAbstract (Dom r, Name) (A.TypedBinding) where
+instance (ToAbstract r, AbsOfRef r ~ Expr) => ToAbstract (Dom r, Name) where
+  type AbsOfRef (Dom r, Name) = A.TypedBinding
   toAbstract (Dom{domInfo = i,unDom = x, domTactic = tac}, name) = do
     dom <- toAbstract x
     return $ mkTBind noRange (singleton $ unnamedArg i $ mkBinder_ name) dom
 
-instance ToAbstract (Expr, Elim) Expr where
+instance ToAbstract (Expr, Elim) where
+  type AbsOfRef (Expr, Elim) = Expr
   toAbstract (f, Apply arg) = do
     arg     <- toAbstract arg
     showImp <- showImplicitArguments
@@ -121,17 +126,21 @@ instance ToAbstract (Expr, Elim) Expr where
              then App (setOrigin Reflected defaultAppInfo_) f arg
              else f
 
-instance ToAbstract (Expr, Elims) Expr where
+instance ToAbstract (Expr, Elims) where
+  type AbsOfRef (Expr, Elims) = Expr
   toAbstract (f, elims) = foldM (curry toAbstract) f elims
 
-instance ToAbstract r a => ToAbstract (R.Abs r) (a, Name) where
+instance ToAbstract r => ToAbstract (R.Abs r) where
+  type AbsOfRef (R.Abs r) = (AbsOfRef r, Name)
   toAbstract (Abs s x) = withName s' $ \name -> (,) <$> toAbstract x <*> return name
     where s' = if (isNoName s) then "z" else s -- TODO: only do this when var is free
 
-instance ToAbstract Literal Expr where
+instance ToAbstract Literal where
+  type AbsOfRef Literal = Expr
   toAbstract l = return $ A.Lit empty l
 
-instance ToAbstract Term Expr where
+instance ToAbstract Term where
+  type AbsOfRef Term = Expr
   toAbstract t = case t of
     R.Var i es -> do
       name <- mkVarName i
@@ -177,7 +186,8 @@ mkVarName i = ifJustM (askName i) return $ do
   names <- asks $ drop (size cxt) . reverse
   withShowAllArguments' False $ typeError $ DeBruijnIndexOutOfScope i cxt names
 
-instance ToAbstract Sort Expr where
+instance ToAbstract Sort where
+  type AbsOfRef Sort = Expr
   toAbstract s = do
     setName <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinSet
     case s of
@@ -185,7 +195,8 @@ instance ToAbstract Sort Expr where
       LitS x -> return $ A.Def' setName $ A.Suffix x
       UnknownS -> return $ mkApp (A.Def setName) $ Underscore emptyMetaInfo
 
-instance ToAbstract R.Pattern A.Pattern where
+instance ToAbstract R.Pattern where
+  type AbsOfRef R.Pattern = A.Pattern
   toAbstract pat = case pat of
     R.ConP c args -> do
       args <- toAbstract args
@@ -196,7 +207,9 @@ instance ToAbstract R.Pattern A.Pattern where
     R.AbsurdP -> return $ A.AbsurdP patNoRange
     R.ProjP d -> return $ A.ProjP patNoRange ProjSystem $ unambiguous $ killRange d
 
-instance ToAbstract (QNamed R.Clause) A.Clause where
+instance ToAbstract (QNamed R.Clause) where
+  type AbsOfRef (QNamed R.Clause) = A.Clause
+
   -- TODO: remember the types in the telescope
   toAbstract (QNamed name (R.Clause tel pats rhs)) = withNames (map (Text.unpack . fst) tel) $ \_ -> do
     pats <- toAbstract pats
@@ -208,8 +221,10 @@ instance ToAbstract (QNamed R.Clause) A.Clause where
     let lhs = spineToLhs $ SpineLHS empty name pats
     return $ A.Clause lhs [] AbsurdRHS noWhereDecls False
 
-instance ToAbstract [QNamed R.Clause] [A.Clause] where
+instance ToAbstract [QNamed R.Clause] where
+  type AbsOfRef [QNamed R.Clause] = [A.Clause]
   toAbstract = traverse toAbstract
 
-instance ToAbstract (List1 (QNamed R.Clause)) (List1 A.Clause) where
+instance ToAbstract (List1 (QNamed R.Clause)) where
+  type AbsOfRef (List1 (QNamed R.Clause)) = List1 A.Clause
   toAbstract = traverse toAbstract

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Functions for abstracting terms over other terms.
 module Agda.TypeChecking.Abstract where
@@ -163,6 +163,7 @@ instance AbsTerm Term where
       DontCare mv -> DontCare $ absT mv
       Dummy s es   -> Dummy s $ absT es
       where
+        absT :: AbsTerm b => b -> b
         absT x = absTerm u x
 
 instance AbsTerm Type where
@@ -181,7 +182,9 @@ instance AbsTerm Sort where
     MetaS x es -> MetaS x $ absS es
     DefS d es  -> DefS d $ absS es
     DummyS{}   -> s
-    where absS x = absTerm u x
+    where
+      absS :: AbsTerm b => b -> b
+      absS x = absTerm u x
 
 instance AbsTerm Level where
   absTerm u (Max n as) = Max n $ absTerm u as
@@ -204,7 +207,7 @@ instance AbsTerm a => AbsTerm [a] where
 instance AbsTerm a => AbsTerm (Maybe a) where
   absTerm = fmap . absTerm
 
-instance (Subst Term a, AbsTerm a) => AbsTerm (Abs a) where
+instance (TermSubst a, AbsTerm a) => AbsTerm (Abs a) where
   absTerm u (NoAbs x v) = NoAbs x $ absTerm u v
   absTerm u (Abs   x v) = Abs x $ swap01 $ absTerm (raise 1 u) v
 
@@ -212,7 +215,7 @@ instance (AbsTerm a, AbsTerm b) => AbsTerm (a, b) where
   absTerm u (x, y) = (absTerm u x, absTerm u y)
 
 -- | This swaps @var 0@ and @var 1@.
-swap01 :: (Subst Term a) => a -> a
+swap01 :: TermSubst a => a -> a
 swap01 = applySubst $ var 1 :# liftS 1 (raiseS 1)
 
 
@@ -282,7 +285,7 @@ instance EqualSy a => EqualSy (Elim' a) where
     _ -> False
 
 -- | Ignores 'absName'.
-instance (Subst t a, EqualSy a) => EqualSy (Abs a) where
+instance (Subst a, EqualSy a) => EqualSy (Abs a) where
   equalSy = curry $ \case
     (NoAbs _x b, NoAbs _x' b') -> equalSy b b' -- no need to raise if both are NoAbs
     (a         , a'          ) -> equalSy (absBody a) (absBody a')

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -396,7 +396,7 @@ ensureNPatterns n ais0 cl@(Cl ps b)
   ps'  = for ais $ \ ai -> Arg ai $ varP "_"
   args = zipWith (\ i ai -> Arg ai $ var i) (downFrom m) ais
 
-substBody :: (Subst t a) => Int -> Int -> t -> a -> a
+substBody :: Subst a => Int -> Int -> SubstArg a -> a -> a
 substBody n m v = applySubst $ liftS n $ v :# raiseS m
 
 instance PrecomputeFreeVars a => PrecomputeFreeVars (CompiledClauses' a) where

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeFamilies #-}
+
 {-| Given
 
     1. the function clauses @cs@
@@ -157,12 +159,14 @@ toSplitPSubst = (fmap . fmap) toSplitVar
 fromSplitPSubst :: SplitPSubstitution -> PatternSubstitution
 fromSplitPSubst = (fmap . fmap) fromSplitVar
 
-applySplitPSubst :: (Subst Term a) => SplitPSubstitution -> a -> a
+applySplitPSubst :: TermSubst a => SplitPSubstitution -> a -> a
 applySplitPSubst = applyPatSubst . fromSplitPSubst
 
 -- TODO: merge this instance and the one for DeBruijnPattern in
 -- Substitute.hs into one for Subst (Pattern' a) (Pattern' a).
-instance Subst SplitPattern SplitPattern where
+instance Subst SplitPattern where
+  type SubstArg SplitPattern = SplitPattern
+
   applySubst IdS p = p
   applySubst rho p = case p of
     VarP i x     ->

--- a/src/full/Agda/TypeChecking/Free.hs
+++ b/src/full/Agda/TypeChecking/Free.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE UndecidableInstances       #-} -- Due to underdetermined var in IsVarSet multi-param typeclass
 
 -- | Computing the free variables of a term.
 --

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE TypeFamilies               #-}
 
 -- | Computing the free variables of a term lazily.

--- a/src/full/Agda/TypeChecking/Free/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Free/Reduce.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeFamilies #-}
+
 -- | Free variable check that reduces the subject to make certain variables not
 --   free. Used when pruning metavariables in Agda.TypeChecking.MetaVars.Occurs.
 module Agda.TypeChecking.Free.Reduce
@@ -50,7 +52,7 @@ type MonadFreeRed m =
   , MonadReduce m
   )
 
-class (PrecomputeFreeVars a, Subst Term a) => ForceNotFree a where
+class (PrecomputeFreeVars a, Subst a) => ForceNotFree a where
   -- Reduce the argument if necessary, to make as many as possible of
   -- the variables in the state not free. Updates the state, marking
   -- the variables that couldn't be make not free as `MaybeFree`. By
@@ -85,7 +87,7 @@ instance (Reduce a, ForceNotFree a) => ForceNotFree (Arg a) where
   -- traverse.
   forceNotFree' = reduceIfFreeVars (traverse forceNotFree')
 
-instance (Reduce a, ForceNotFree a) => ForceNotFree (Dom a) where
+instance (Reduce a, ForceNotFree a, TermSubst a) => ForceNotFree (Dom a) where
   forceNotFree' = traverse forceNotFreeR
 
 instance (Reduce a, ForceNotFree a) => ForceNotFree (Abs a) where

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 
 module Agda.TypeChecking.Generalize
   ( generalizeType

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 {-| Compile-time irrelevance.
@@ -359,7 +358,7 @@ instance UsableRelevance a => UsableRelevance (Arg a) where
 instance UsableRelevance a => UsableRelevance (Dom a) where
   usableRel rel Dom{unDom = u} = usableRel rel u
 
-instance (Subst t a, UsableRelevance a) => UsableRelevance (Abs a) where
+instance (Subst a, UsableRelevance a) => UsableRelevance (Abs a) where
   usableRel rel abs = underAbstraction_ abs $ \u -> usableRel rel u
 
 -- | Check whether something can be used in a position of the given modality.
@@ -456,7 +455,7 @@ instance UsableModality a => UsableModality (Arg a) where
 instance UsableModality a => UsableModality (Dom a) where
   usableMod mod Dom{unDom = u} = usableMod mod u
 
-instance (Subst t a, UsableModality a) => UsableModality (Abs a) where
+instance (Subst a, UsableModality a) => UsableModality (Abs a) where
   usableMod mod abs = underAbstraction_ abs $ \u -> usableMod mod u
 
 

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 
 module Agda.TypeChecking.Level where
 
@@ -235,7 +236,9 @@ singleLevelView l = case levelMaxView l of
   s :| [] -> Just s
   _       -> Nothing
 
-instance Subst Term t => Subst Term (SingleLevel' t) where
+instance Subst t => Subst (SingleLevel' t) where
+  type SubstArg (SingleLevel' t) = SubstArg t
+
   applySubst sub (SingleClosed m) = SingleClosed m
   applySubst sub (SinglePlus a)   = SinglePlus $ applySubst sub a
 

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1218,7 +1218,7 @@ expandProjectedVars
   :: ( Show a, PrettyTCM a, NoProjectedVar a
      -- , Normalise a, TermLike a, Subst Term a
      , ReduceAndEtaContract a
-     , PrettyTCM b, Subst Term b
+     , PrettyTCM b, TermSubst b
      )
   => a  -- ^ Meta variable arguments.
   -> b  -- ^ Right hand side.
@@ -1239,7 +1239,7 @@ expandProjectedVars args v ret = loop (args, v) where
       Left (ProjVarExc i _) -> etaExpandProjectedVar i (args, v) done loop
 
 -- | Eta-expand a de Bruijn index of record type in context and passed term(s).
-etaExpandProjectedVar :: (PrettyTCM a, Subst Term a) => Int -> a -> TCM c -> (a -> TCM c) -> TCM c
+etaExpandProjectedVar :: (PrettyTCM a, TermSubst a) => Int -> a -> TCM c -> (a -> TCM c) -> TCM c
 etaExpandProjectedVar i v fail succeed = do
   reportSDoc "tc.meta.assign.proj" 40 $
     "trying to expand projected variable" <+> prettyTCM (var i)
@@ -1276,11 +1276,11 @@ instance NoProjectedVar a => NoProjectedVar [a] where
 
 
 -- | Normalize just far enough to be able to eta-contract maximally.
-class (TermLike a, Subst Term a, Reduce a) => ReduceAndEtaContract a where
+class (TermLike a, TermSubst a, Reduce a) => ReduceAndEtaContract a where
   reduceAndEtaContract :: a -> TCM a
 
   default reduceAndEtaContract
-    :: (Traversable f, TermLike b, Subst Term b, Reduce b, ReduceAndEtaContract b, f b ~ a)
+    :: (Traversable f, TermLike b, Subst b, Reduce b, ReduceAndEtaContract b, f b ~ a)
     => a -> TCM a
   reduceAndEtaContract = Trav.mapM reduceAndEtaContract
 

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NondecreasingIndentation  #-}
+{-# LANGUAGE TypeFamilies              #-}
 
 {- | The occurs check for unification.  Does pruning on the fly.
 
@@ -576,7 +575,7 @@ instance Occurs a => Occurs (Elim' a) where
   metaOccurs m (Apply a) = metaOccurs m a
   metaOccurs m (IApply x y a) = metaOccurs m (x,(y,a))
 
-instance (Occurs a, Subst t a) => Occurs (Abs a) where
+instance (Occurs a, Subst a) => Occurs (Abs a) where
   occurs b@(Abs s _) = Abs   s <$> do underAbstraction_ b $ underBinder . occurs
   occurs (NoAbs s x) = NoAbs s <$> occurs x
 
@@ -781,7 +780,7 @@ instance AnyRigid Level where
 instance AnyRigid PlusLevel where
   anyRigid f (Plus _ l)    = anyRigid f l
 
-instance (Subst t a, AnyRigid a) => AnyRigid (Abs a) where
+instance (Subst a, AnyRigid a) => AnyRigid (Abs a) where
   anyRigid f b = underAbstraction_ b $ anyRigid f
 
 instance AnyRigid a => AnyRigid (Arg a) where

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4121,7 +4121,8 @@ instance (Monoid w, MonadTCM tcm) => MonadTCM (WriterT w tcm)
 -- | We store benchmark statistics in an IORef.
 --   This enables benchmarking pure computation, see
 --   "Agda.Benchmarking".
-instance MonadBench Phase TCM where
+instance MonadBench TCM where
+  type BenchPhase TCM = Phase
   getBenchmark = liftIO $ getBenchmark
   putBenchmark = liftIO . putBenchmark
   finally = finally_

--- a/src/full/Agda/TypeChecking/Monad/Benchmark.hs
+++ b/src/full/Agda/TypeChecking/Monad/Benchmark.hs
@@ -3,6 +3,7 @@
 module Agda.TypeChecking.Monad.Benchmark
   ( module Agda.Benchmarking
   , B.MonadBench
+  , B.BenchPhase
   , B.getBenchmark
   , updateBenchmarkingStatus
   , B.billTo, B.billPureTo, B.billToCPS

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeFamilies #-}  -- for type equality ~
+{-# LANGUAGE TypeFamilies #-}
 
 module Agda.TypeChecking.Monad.Context where
 
@@ -361,35 +361,35 @@ instance AddContext Telescope where
   contextSize = size
 
 -- | Go under an abstraction.  Do not extend context in case of 'NoAbs'.
-{-# SPECIALIZE underAbstraction :: Subst t a => Dom Type -> Abs a -> (a -> TCM b) -> TCM b #-}
-underAbstraction :: (Subst t a, MonadAddContext m) => Dom Type -> Abs a -> (a -> m b) -> m b
+{-# SPECIALIZE underAbstraction :: Subst a => Dom Type -> Abs a -> (a -> TCM b) -> TCM b #-}
+underAbstraction :: (Subst a, MonadAddContext m) => Dom Type -> Abs a -> (a -> m b) -> m b
 underAbstraction = underAbstraction' id
 
-underAbstraction' :: (Subst t a, MonadAddContext m, AddContext (name, Dom Type)) =>
+underAbstraction' :: (Subst a, MonadAddContext m, AddContext (name, Dom Type)) =>
                      (String -> name) -> Dom Type -> Abs a -> (a -> m b) -> m b
 underAbstraction' _ _ (NoAbs _ v) k = k v
 underAbstraction' wrap t a k = underAbstractionAbs' wrap t a k
 
 -- | Go under an abstraction, treating 'NoAbs' as 'Abs'.
-underAbstractionAbs :: (Subst t a, MonadAddContext m) => Dom Type -> Abs a -> (a -> m b) -> m b
+underAbstractionAbs :: (Subst a, MonadAddContext m) => Dom Type -> Abs a -> (a -> m b) -> m b
 underAbstractionAbs = underAbstractionAbs' id
 
 underAbstractionAbs'
-  :: (Subst t a, MonadAddContext m, AddContext (name, Dom Type))
+  :: (Subst a, MonadAddContext m, AddContext (name, Dom Type))
   => (String -> name) -> Dom Type -> Abs a -> (a -> m b) -> m b
 underAbstractionAbs' wrap t a k = addContext (wrap $ realName $ absName a, t) $ k $ absBody a
   where
     realName s = if isNoName s then "x" else argNameToString s
 
 -- | Go under an abstract without worrying about the type to add to the context.
-{-# SPECIALIZE underAbstraction_ :: Subst t a => Abs a -> (a -> TCM b) -> TCM b #-}
-underAbstraction_ :: (Subst t a, MonadAddContext m) => Abs a -> (a -> m b) -> m b
+{-# SPECIALIZE underAbstraction_ :: Subst a => Abs a -> (a -> TCM b) -> TCM b #-}
+underAbstraction_ :: (Subst a, MonadAddContext m) => Abs a -> (a -> m b) -> m b
 underAbstraction_ = underAbstraction __DUMMY_DOM__
 
 -- | Map a monadic function on the thing under the abstraction, adding
 --   the abstracted variable to the context.
 mapAbstraction
-  :: (Subst t a, Subst t' b, MonadAddContext m)
+  :: (Subst a, Subst b, MonadAddContext m)
   => Dom Type -> (a -> m b) -> Abs a -> m (Abs b)
 mapAbstraction dom f x = (x $>) <$> underAbstraction dom x f
 

--- a/src/full/Agda/TypeChecking/Monad/Open.hs
+++ b/src/full/Agda/TypeChecking/Monad/Open.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 
 module Agda.TypeChecking.Monad.Open
         ( makeOpen
@@ -22,14 +23,14 @@ makeOpen x = do
 
 -- | Extract the value from an open term. The checkpoint at which it was
 --   created must be in scope.
-getOpen :: (Subst Term a, MonadTCEnv m) => Open a -> m a
+getOpen :: (TermSubst a, MonadTCEnv m) => Open a -> m a
 getOpen (OpenThing cp x) = do
   sub <- checkpointSubstitution cp
   return $ applySubst sub x
 
 -- | Extract the value from an open term. Returns `Nothing` if the checkpoint
 --   at which it was created is not in scope.
-tryGetOpen :: (Subst Term a, MonadTCEnv m) => Open a -> m (Maybe a)
+tryGetOpen :: (TermSubst a, MonadTCEnv m) => Open a -> m (Maybe a)
 tryGetOpen (OpenThing cp x) = fmap (`applySubst` x) <$> viewTC (eCheckpoints . key cp)
 
 -- | An 'Open' is closed if it has checkpoint 0.

--- a/src/full/Agda/TypeChecking/Names.hs
+++ b/src/full/Agda/TypeChecking/Names.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE UndecidableInstances       #-}
 
 {-| EDSL to construct terms without touching De Bruijn indices.
 
@@ -82,7 +81,7 @@ cxtSubst ctx = do
      then return $ raiseS (genericLength ctx' - genericLength ctx)
      else fail $ "thing out of context (" ++ show ctx ++ " is not a sub context of " ++ show ctx' ++ ")"
 
-inCxt :: (MonadFail m, Subst t a) => Names -> a -> NamesT m a
+inCxt :: (MonadFail m, Subst a) => Names -> a -> NamesT m a
 inCxt ctx a = do
   sigma <- cxtSubst ctx
   return $ applySubst sigma a
@@ -94,20 +93,20 @@ cl' = pure
 cl :: Monad m => m a -> NamesT m a
 cl = lift
 
-open :: (MonadFail m, Subst t a) => a -> NamesT m (NamesT m a)
+open :: (MonadFail m, Subst a) => a -> NamesT m (NamesT m a)
 open a = do
   ctx <- NamesT ask
   pure $ inCxt ctx a
 
-bind' :: (MonadFail m, Subst t' b, DeBruijn b, Subst t a, Free a) => ArgName -> (NamesT m b -> NamesT m a) -> NamesT m a
+bind' :: (MonadFail m, Subst b, DeBruijn b, Subst a, Free a) => ArgName -> (NamesT m b -> NamesT m a) -> NamesT m a
 bind' n f = do
   cxt <- NamesT ask
   (NamesT . local (n:) . unName $ f (inCxt (n:cxt) (deBruijnVar 0)))
 
 bind :: ( MonadFail m
-        , Subst t' b
+        , Subst b
         , DeBruijn b
-        , Subst t a
+        , Subst a
         , Free a
         ) =>
         ArgName -> (NamesT m b -> NamesT m a) -> NamesT m (Abs a)

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE TypeFamilies         #-}  -- for type equality ~
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Check that a datatype is strictly positive.
 module Agda.TypeChecking.Positivity where

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -776,8 +776,8 @@ instance Pretty Node where
 instance PrettyTCM Node where
   prettyTCM = return . P.pretty
 
-instance PrettyTCM n => PrettyTCM (WithNode n (Edge OccursWhere)) where
-  prettyTCM (WithNode n (Edge o w)) = vcat
+instance PrettyTCMWithNode (Edge OccursWhere) where
+  prettyTCMWithNode (WithNode n (Edge o w)) = vcat
     [ prettyTCM o <+> prettyTCM n
     , nest 2 $ return $ P.pretty w
     ]

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -212,7 +212,7 @@ prettyR
   => r -> m Doc
 prettyR = prettyTCM <=< toAbstractWithoutImplicit
 
-instance (Pretty a, PrettyTCM a, Subst a a) => PrettyTCM (Substitution' a) where
+instance (Pretty a, PrettyTCM a, EndoSubst a) => PrettyTCM (Substitution' a) where
   prettyTCM IdS        = "idS"
   prettyTCM (Wk m IdS) = "wkS" <+> pretty m
   prettyTCM (EmptyS _) = "emptyS"

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -73,10 +73,10 @@ equals = pure P.equals
 pretty :: (Applicative m, P.Pretty a) => a -> m Doc
 pretty x = pure $ P.pretty x
 
-prettyA :: (P.Pretty c, ToConcrete a c, MonadAbsToCon m) => a -> m Doc
+prettyA :: (ToConcrete a, P.Pretty (ConOfAbs a), MonadAbsToCon m) => a -> m Doc
 prettyA x = AP.prettyA x
 
-prettyAs :: (P.Pretty c, ToConcrete a [c], MonadAbsToCon m) => a -> m Doc
+prettyAs :: (ToConcrete a, ConOfAbs a ~ [ce], P.Pretty ce, MonadAbsToCon m) => a -> m Doc
 prettyAs x = AP.prettyAs x
 
 text :: Applicative m => String -> m Doc
@@ -239,13 +239,13 @@ instance PrettyTCM a => PrettyTCM (Blocked a) where
   prettyTCM (Blocked x a) = ("[" <+> prettyTCM a <+> "]") <> text (P.prettyShow x)
   prettyTCM (NotBlocked _ x) = prettyTCM x
 
-instance (Reify i, ToConcrete (ReifiesTo i) c, P.Pretty c) => PrettyTCM (Named_ i) where
+instance (Reify i, ToConcrete (ReifiesTo i), P.Pretty (ConOfAbs (ReifiesTo i))) => PrettyTCM (Named_ i) where
   prettyTCM x = prettyA =<< reify x
 
-instance (Reify i, ToConcrete (ReifiesTo i) c, P.Pretty c) => PrettyTCM (Arg i) where
+instance (Reify i, ToConcrete (ReifiesTo i), P.Pretty (ConOfAbs (ReifiesTo i))) => PrettyTCM (Arg i) where
   prettyTCM x = prettyA =<< reify x
 
-instance (Reify i, ToConcrete (ReifiesTo i) c, P.Pretty c) => PrettyTCM (Dom i) where
+instance (Reify i, ToConcrete (ReifiesTo i), P.Pretty (ConOfAbs (ReifiesTo i))) => PrettyTCM (Dom i) where
   prettyTCM x = prettyA =<< reify x
 
 instance (PrettyTCM k, PrettyTCM v) => PrettyTCM (Map k v) where

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -352,6 +352,7 @@ instance PrettyTCM DBPatVar where
   prettyTCM = prettyTCM . var . dbPatVarIndex
 
 instance PrettyTCM a => PrettyTCM (Pattern' a) where
+  prettyTCM :: forall m. MonadPretty m => Pattern' a -> m Doc
   prettyTCM (IApplyP _ _ _ x)    = prettyTCM x
   prettyTCM (VarP _ x)    = prettyTCM x
   prettyTCM (DotP _ t)    = ".(" <> prettyTCM t <> ")"
@@ -363,15 +364,15 @@ instance PrettyTCM a => PrettyTCM (Pattern' a) where
       where
         -- NONE OF THESE BINDINGS IS USED AT THE MOMENT:
         b = conPRecord i && patOrigin (conPInfo i) /= PatOCon
-        showRec :: MonadPretty m => m Doc -- Defined, but currently not used
+        showRec :: m Doc -- Defined, but currently not used
         showRec = sep
           [ "record"
           , bracesAndSemicolons <$> zipWithM showField (conFields c) ps
           ]
-        showField :: MonadPretty m => Arg QName -> NamedArg (Pattern' a) -> m Doc -- NB:: Defined but not used
+        showField :: Arg QName -> NamedArg (Pattern' a) -> m Doc -- NB:: Defined but not used
         showField (Arg ai x) p =
           sep [ prettyTCM (A.qnameName x) <+> "=" , nest 2 $ prettyTCM $ namedArg p ]
-        showCon :: MonadPretty m => m Doc -- NB:: Defined but not used
+        showCon :: m Doc -- NB:: Defined but not used
         showCon = parens $ prTy $ prettyTCM c <+> fsep (map (prettyTCM . namedArg) ps)
         prTy d = caseMaybe (conPType i) d $ \ t -> d  <+> ":" <+> prettyTCM t
   prettyTCM (LitP _ l)    = text (P.prettyShow l)

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -208,7 +208,7 @@ instance PrettyTCM Polarity     where prettyTCM = text . show
 instance PrettyTCM IsForced     where prettyTCM = text . show
 
 prettyR
-  :: (R.ToAbstract r a, PrettyTCM a, MonadPretty m, MonadError TCErr m)
+  :: (R.ToAbstract r, PrettyTCM (R.AbsOfRef r), MonadPretty m, MonadError TCErr m)
   => r -> m Doc
 prettyR = prettyTCM <=< toAbstractWithoutImplicit
 

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Agda.TypeChecking.Pretty
@@ -238,13 +239,13 @@ instance PrettyTCM a => PrettyTCM (Blocked a) where
   prettyTCM (Blocked x a) = ("[" <+> prettyTCM a <+> "]") <> text (P.prettyShow x)
   prettyTCM (NotBlocked _ x) = prettyTCM x
 
-instance (Reify a e, ToConcrete e c, P.Pretty c) => PrettyTCM (Named_ a) where
+instance (Reify i, ToConcrete (ReifiesTo i) c, P.Pretty c) => PrettyTCM (Named_ i) where
   prettyTCM x = prettyA =<< reify x
 
-instance (Reify a e, ToConcrete e c, P.Pretty c) => PrettyTCM (Arg a) where
+instance (Reify i, ToConcrete (ReifiesTo i) c, P.Pretty c) => PrettyTCM (Arg i) where
   prettyTCM x = prettyA =<< reify x
 
-instance (Reify a e, ToConcrete e c, P.Pretty c) => PrettyTCM (Dom a) where
+instance (Reify i, ToConcrete (ReifiesTo i) c, P.Pretty c) => PrettyTCM (Dom i) where
   prettyTCM x = prettyA =<< reify x
 
 instance (PrettyTCM k, PrettyTCM v) => PrettyTCM (Map k v) where

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -1683,7 +1683,7 @@ transpTel delta phi args = do
   ineg <- liftTCM primINeg
   let
     noTranspError t = lift . throwError =<< liftTCM (buildClosure t)
-    bapp :: (Applicative m, Subst t a) => m (Abs a) -> m t -> m a
+    bapp :: (Applicative m, Subst a) => m (Abs a) -> m (SubstArg a) -> m a
     bapp t u = lazyAbsApp <$> t <*> u
     gTransp (Just l) t phi a = pure tTransp <#> l <@> (Lam defaultArgInfo . fmap unEl <$> t) <@> phi <@> a
     gTransp Nothing  t phi a = do

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -206,7 +206,7 @@ quotingKit = do
       quoteDom :: (a -> ReduceM Term) -> Dom a -> ReduceM Term
       quoteDom q Dom{domInfo = info, unDom = t} = arg !@ quoteArgInfo info @@ q t
 
-      quoteAbs :: Subst t a => (a -> ReduceM Term) -> Abs a -> ReduceM Term
+      quoteAbs :: Subst a => (a -> ReduceM Term) -> Abs a -> ReduceM Term
       quoteAbs q (Abs s t)   = abs !@! quoteString s @@ q t
       quoteAbs q (NoAbs s t) = abs !@! quoteString s @@ q (raise 1 t)
 

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE UndecidableInstances     #-}
 {-# LANGUAGE TypeFamilies             #-}
 
 module Agda.TypeChecking.Reduce where
@@ -341,7 +340,7 @@ instance Reduce Level where
 instance Reduce PlusLevel where
   reduceB' (Plus n l) = fmap (Plus n) <$> reduceB' l
 
-instance (Subst t a, Reduce a) => Reduce (Abs a) where
+instance (Subst a, Reduce a) => Reduce (Abs a) where
   reduce' b@(Abs x _) = Abs x <$> underAbstraction_ b reduce'
   reduce' (NoAbs x v) = NoAbs x <$> reduce' v
 
@@ -899,7 +898,7 @@ instance Simplify Level where
 instance Simplify PlusLevel where
   simplify' (Plus n l) = Plus n <$> simplify' l
 
-instance (Subst t a, Simplify a) => Simplify (Abs a) where
+instance (Subst a, Simplify a) => Simplify (Abs a) where
     simplify' a@(Abs x _) = Abs x <$> underAbstraction_ a simplify'
     simplify' (NoAbs x v) = NoAbs x <$> simplify' v
 
@@ -911,7 +910,7 @@ instance Simplify a => Simplify (Closure a) where
         x <- enterClosure cl simplify'
         return $ cl { clValue = x }
 
-instance (Subst t a, Simplify a) => Simplify (Tele a) where
+instance (Subst a, Simplify a) => Simplify (Tele a) where
   simplify' EmptyTel        = return EmptyTel
   simplify' (ExtendTel a b) = uncurry ExtendTel <$> simplify' (a, b)
 
@@ -1067,7 +1066,7 @@ instance Normalise Level where
 instance Normalise PlusLevel where
   normalise' (Plus n l) = Plus n <$> normalise' l
 
-instance (Subst t a, Normalise a) => Normalise (Abs a) where
+instance (Subst a, Normalise a) => Normalise (Abs a) where
     normalise' a@(Abs x _) = Abs x <$> underAbstraction_ a normalise'
     normalise' (NoAbs x v) = NoAbs x <$> normalise' v
 
@@ -1084,7 +1083,7 @@ instance Normalise a => Normalise (Closure a) where
         x <- enterClosure cl normalise'
         return $ cl { clValue = x }
 
-instance (Subst t a, Normalise a) => Normalise (Tele a) where
+instance (Subst a, Normalise a) => Normalise (Tele a) where
   normalise' EmptyTel        = return EmptyTel
   normalise' (ExtendTel a b) = uncurry ExtendTel <$> normalise' (a, b)
 
@@ -1286,7 +1285,7 @@ instance InstantiateFull a => InstantiateFull (Pattern' a) where
     instantiateFull' p@ProjP{}      = return p
     instantiateFull' (IApplyP o t u x) = IApplyP o <$> instantiateFull' t <*> instantiateFull' u <*> instantiateFull' x
 
-instance (Subst t a, InstantiateFull a) => InstantiateFull (Abs a) where
+instance (Subst a, InstantiateFull a) => InstantiateFull (Abs a) where
     instantiateFull' a@(Abs x _) = Abs x <$> underAbstraction_ a instantiateFull'
     instantiateFull' (NoAbs x a) = NoAbs x <$> instantiateFull' a
 
@@ -1334,7 +1333,7 @@ instance InstantiateFull Signature where
 instance InstantiateFull Section where
   instantiateFull' (Section tel) = Section <$> instantiateFull' tel
 
-instance (Subst t a, InstantiateFull a) => InstantiateFull (Tele a) where
+instance (Subst a, InstantiateFull a) => InstantiateFull (Tele a) where
   instantiateFull' EmptyTel = return EmptyTel
   instantiateFull' (ExtendTel a b) = uncurry ExtendTel <$> instantiateFull' (a, b)
 

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE UndecidableInstances     #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 -- | Checking local or global confluence of rewrite rules.
@@ -565,7 +564,7 @@ instance ParallelReduce a => ParallelReduce (Elim' a) where
   parReduce e@Proj{}   = pure e
   parReduce IApply{}   = __IMPOSSIBLE__ -- not yet supported
 
-instance (Free a, Subst t a, ParallelReduce a) => ParallelReduce (Abs a) where
+instance (Free a, Subst a, ParallelReduce a) => ParallelReduce (Abs a) where
   parReduce = mapAbstraction __DUMMY_DOM__ parReduce
 
 
@@ -631,7 +630,7 @@ ohAddBV x a oh = oh { ohBoundVars = ExtendTel a $ Abs x $ ohBoundVars oh }
 
 -- ^ Given a @p : a@, @allHoles p@ lists all the possible
 --   decompositions @p = p'[(f ps)/x]@.
-class (Subst Term p , Free p) => AllHoles p where
+class (TermSubst p, Free p) => AllHoles p where
   type PType p
   allHoles :: (Alternative m , MonadReduce m, MonadAddContext m, HasBuiltins m, HasConstInfo m)
            => PType p -> p -> m (OneHole p)

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE UndecidableInstances     #-}
 
 {- |  Non-linear matching of the lhs of a rewrite rule against a
       neutral term.

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 module Agda.TypeChecking.Rules.Data where
@@ -643,7 +644,8 @@ toLType ty = do
     Type l -> return $ Just $ LEl l (unEl ty)
     _      -> return $ Nothing
 
-instance Subst Term LType where
+instance Subst LType where
+  type SubstArg LType = Term
   applySubst rho (LEl l t) = LEl (applySubst rho l) (applySubst rho t)
 
 -- | A @Type@ that either has sort @Type l@ or is a closed definition.
@@ -667,7 +669,8 @@ toCType ty = do
         _        -> return $ Nothing
     _      -> return $ Nothing
 
-instance Subst Term CType where
+instance Subst CType where
+  type SubstArg CType = Term
   applySubst rho (ClosedType s t) = ClosedType (applySubst rho s) t
   applySubst rho (LType t) = LType $ applySubst rho t
 

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NondecreasingIndentation #-}
+{-# LANGUAGE TypeFamilies             #-}
 
 module Agda.TypeChecking.Rules.Decl where
 
@@ -225,7 +226,8 @@ checkDecl d = setCurrentRange d $ do
 
     -- | Switch maybe to abstract mode, benchmark, and debug print bracket.
     check :: forall m i a
-          . ( MonadTCEnv m, MonadPretty m, MonadDebug m, MonadBench Phase m
+          . ( MonadTCEnv m, MonadPretty m, MonadDebug m
+            , MonadBench m, Bench.BenchPhase m ~ Phase
             , AnyIsAbstract i )
           => QName -> i -> m a -> m a
     check x i m = Bench.billTo [Bench.Definition x] $ do

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 module Agda.TypeChecking.Rules.Def where

--- a/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 
 module Agda.TypeChecking.Rules.LHS.Problem
        ( FlexibleVars , FlexibleVarKind(..) , FlexibleVar(..) , allFlexVars
@@ -341,16 +342,20 @@ getUserVariableNames tel names = runWriter $
     partitionIsParam = (map fst *** map fst) . partition ((== PVParam) . snd)
 
 
-instance Subst Term (Problem a) where
+instance Subst (Problem a) where
+  type SubstArg (Problem a) = Term
   applySubst rho (Problem eqs rps cont) = Problem (applySubst rho eqs) rps cont
 
-instance Subst Term AsBinding where
+instance Subst AsBinding where
+  type SubstArg AsBinding = Term
   applySubst rho (AsB x v a) = uncurry (AsB x) $ applySubst rho (v, a)
 
-instance Subst Term DotPattern where
+instance Subst DotPattern where
+  type SubstArg DotPattern = Term
   applySubst rho (Dot e v a) = uncurry (Dot e) $ applySubst rho (v, a)
 
-instance Subst Term AbsurdPattern where
+instance Subst AbsurdPattern where
+  type SubstArg AbsurdPattern = Term
   applySubst rho (Absurd r a) = Absurd r $ applySubst rho a
 
 instance PrettyTCM ProblemEq where

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE NondecreasingIndentation   #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE NondecreasingIndentation #-}
 
 -- | Unification algorithm for specializing datatype indices, as described in
 --     \"Unifiers as Equivalences: Proof-Relevant Unification of Dependently
@@ -614,7 +613,7 @@ completeStrategyAt k s = msum $ map (\strat -> strat k s) $
 -- | @isHom n x@ returns x lowered by n if the variables 0..n-1 don't occur in x.
 --
 -- This is naturally sensitive to normalization.
-isHom :: (Free a, Subst Term a) => Int -> a -> Maybe a
+isHom :: (Free a, Subst a) => Int -> a -> Maybe a
 isHom n x = do
   guard $ getAll $ runFree (All . (>= n)) IgnoreNot x
   return $ raise (-n) x

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableInstances #-} -- Due to ICODE vararg typeclass
 
 module Agda.TypeChecking.Serialise.Base where
 

--- a/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 -- | Solving size constraints under hypotheses.
@@ -727,7 +728,8 @@ data HypSizeConstraint = HypSizeConstraint
   , sizeConstraint :: SizeConstraint    -- ^ Living in @Context@.
   }
 
-instance Flexs SizeMeta HypSizeConstraint where
+instance Flexs HypSizeConstraint where
+  type FlexOf HypSizeConstraint = SizeMeta
   flexs (HypSizeConstraint _ _ hs c) = flexs hs `mappend` flexs c
 
 instance PrettyTCM HypSizeConstraint where

--- a/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE NondecreasingIndentation #-}
+{-# LANGUAGE TypeFamilies             #-}
 
 -- | Solving size constraints under hypotheses.
 --
@@ -680,7 +680,8 @@ instance Pretty SizeMeta where pretty = P.pretty . sizeMetaId
 instance PrettyTCM SizeMeta where
   prettyTCM (SizeMeta x es) = prettyTCM (MetaV x $ map (Apply . defaultArg . var) es)
 
-instance Subst Term SizeMeta where
+instance Subst SizeMeta where
+  type SubstArg SizeMeta = Term
   applySubst sigma (SizeMeta x es) = SizeMeta x (map raise es)
     where
       raise i =
@@ -696,7 +697,8 @@ type DBSizeExpr = SizeExpr' NamedRigid SizeMeta
 -- deriving instance Traversable (SizeExpr' Int)
 
 -- | Only for 'raise'.
-instance Subst Term (SizeExpr' NamedRigid SizeMeta) where
+instance Subst (SizeExpr' NamedRigid SizeMeta) where
+  type SubstArg (SizeExpr' NamedRigid SizeMeta) = Term
   applySubst sigma a =
     case a of
       Infty   -> a
@@ -709,7 +711,8 @@ instance Subst Term (SizeExpr' NamedRigid SizeMeta) where
 
 type SizeConstraint = Constraint' NamedRigid SizeMeta
 
-instance Subst Term SizeConstraint where
+instance Subst SizeConstraint where
+  type SubstArg SizeConstraint = Term
   applySubst sigma (Constraint a cmp b) =
     Constraint (applySubst sigma a) cmp (applySubst sigma b)
 

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE UndecidableInstances   #-}
-{-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -68,7 +68,7 @@ import Agda.Utils.Impossible
 --   propagate the same strategy to subtrees.
 {-# SPECIALIZE applyTermE :: (Empty -> Term -> Elims -> Term) -> Term -> Elims -> Term #-}
 {-# SPECIALIZE applyTermE :: (Empty -> Term -> Elims -> Term) -> BraveTerm -> Elims -> BraveTerm #-}
-applyTermE :: forall t. (Coercible Term t, Apply t, Subst t t)
+applyTermE :: forall t. (Coercible Term t, Apply t, EndoSubst t)
            => (Empty -> Term -> Elims -> Term) -> t -> Elims -> t
 applyTermE err' m [] = m
 applyTermE err' m es = coerce $
@@ -120,7 +120,8 @@ conApp fk ch                  ci args []             = Con ch ci args
 conApp fk ch                  ci args (a@Apply{} : es) = conApp @t fk ch ci (args ++ [a]) es
 conApp fk ch                  ci args (a@IApply{} : es) = conApp @t fk ch ci (args ++ [a]) es
 conApp fk ch@(ConHead c _ _ fs) ci args ees@(Proj o f : es) =
-  let failure err = flip trace err $ concat
+  let failure :: forall a. a -> a
+      failure err = flip trace err $ concat
         [ "conApp: constructor ", prettyShow c
         , unlines $ " with fields" : map (("  " ++) . prettyShow) fs
         , unlines $ " and args"    : map (("  " ++) . prettyShow) args
@@ -221,7 +222,7 @@ instance Apply Sort where
 
 -- @applyE@ does not make sense for telecopes, definitions, clauses etc.
 
-instance Subst Term a => Apply (Tele a) where
+instance TermSubst a => Apply (Tele a) where
   apply tel               []       = tel
   apply EmptyTel          _        = __IMPOSSIBLE__
   apply (ExtendTel _ tel) (t : ts) = lazyAbsApp tel (unArg t) `apply` ts
@@ -417,7 +418,7 @@ instance Apply Clause where
         --    Δ′ ⊢ ρ′ : Δ[xⁱ:=v]
         --  so we just need Δ[xⁱ:=v] ⊢ σ : Δ and then ρ = ρ′ ∘ σ.
         --  That's achieved by σ = singletonS i v'.
-        mkSub :: Subst a a => (Term -> a) -> Nat -> [NamedArg DeBruijnPattern] -> [Term] -> Substitution' a
+        mkSub :: EndoSubst a => (Term -> a) -> Nat -> [NamedArg DeBruijnPattern] -> [Term] -> Substitution' a
         mkSub _ _ [] [] = idS
         mkSub tm n (p : ps) (v : vs) =
           case namedArg p of
@@ -775,15 +776,16 @@ renamingR :: DeBruijn a => Permutation -> Substitution' a
 renamingR p@(Perm n _) = permute (reverseP p) (map deBruijnVar [0..]) ++# raiseS n
 
 -- | The permutation should permute the corresponding context. (right-to-left list)
-renameP :: Subst t a => Empty -> Permutation -> a -> a
+renameP :: Subst a => Empty -> Permutation -> a -> a
 renameP err p = applySubst (renaming err p)
 
-instance Subst a a => Subst a (Substitution' a) where
+instance EndoSubst a => Subst (Substitution' a) where
+  type SubstArg (Substitution' a) = a
   applySubst rho sgm = composeS rho sgm
 
 {-# SPECIALIZE applySubstTerm :: Substitution -> Term -> Term #-}
 {-# SPECIALIZE applySubstTerm :: Substitution' BraveTerm -> BraveTerm -> BraveTerm #-}
-applySubstTerm :: forall t. (Coercible t Term, Subst t t, Apply t) => Substitution' t -> t -> t
+applySubstTerm :: forall t. (Coercible t Term, EndoSubst t, Apply t) => Substitution' t -> t -> t
 applySubstTerm IdS t = t
 applySubstTerm rho t    = coerce $ case coerce t of
     Var i es    -> coerce $ lookupS rho i  `applyE` subE es
@@ -798,23 +800,27 @@ applySubstTerm rho t    = coerce $ case coerce t of
     DontCare mv -> dontCare $ sub @t mv
     Dummy s es  -> Dummy s $ subE es
  where
-   sub :: forall a b. (Coercible b a, Subst t a) => b -> b
+   sub :: forall a b. (Coercible b a, SubstWith t a) => b -> b
    sub t = coerce $ applySubst rho (coerce t :: a)
    subE :: Elims -> Elims
    subE  = sub @[Elim' t]
    subPi :: (Dom Type, Abs Type) -> (Dom Type, Abs Type)
    subPi = sub @(Dom' t (Type'' t t), Abs (Type'' t t))
 
-instance Subst Term Term where
+instance Subst Term where
+  type SubstArg Term = Term
   applySubst = applySubstTerm
 
-instance Subst BraveTerm BraveTerm where
+instance Subst BraveTerm where
+  type SubstArg BraveTerm = BraveTerm
   applySubst = applySubstTerm
 
-instance (Coercible a Term, Subst t a, Subst t b) => Subst t (Type'' a b) where
+instance (Coercible a Term, Subst a, Subst b, SubstArg a ~ SubstArg b) => Subst (Type'' a b) where
+  type SubstArg (Type'' a b) = SubstArg a
   applySubst rho (El s t) = applySubst rho s `El` applySubst rho t
 
-instance (Coercible a Term, Subst t a) => Subst t (Sort' a) where
+instance (Coercible a Term, Subst a) => Subst (Sort' a) where
+  type SubstArg (Sort' a) = SubstArg a
   applySubst rho s = case s of
     Type n     -> Type $ sub n
     Prop n     -> Prop $ sub n
@@ -827,24 +833,28 @@ instance (Coercible a Term, Subst t a) => Subst t (Sort' a) where
     MetaS x es -> MetaS x $ sub es
     DefS d es  -> DefS d $ sub es
     DummyS{}   -> s
-    where sub x = applySubst rho x
+    where
+      sub :: forall b. (Subst b, SubstArg a ~ SubstArg b) => b -> b
+      sub x = applySubst rho x
 
-instance Subst t a => Subst t (Level' a) where
+instance Subst a => Subst (Level' a) where
+  type SubstArg (Level' a) = SubstArg a
   applySubst rho (Max n as) = Max n $ applySubst rho as
 
-instance Subst t a => Subst t (PlusLevel' a) where
+instance Subst a => Subst (PlusLevel' a) where
+  type SubstArg (PlusLevel' a) = SubstArg a
   applySubst rho (Plus n l) = Plus n $ applySubst rho l
 
-instance Subst Term Name where
+instance Subst Name where
+  type SubstArg Name = Term
   applySubst rho = id
 
-instance {-# OVERLAPPING #-} Subst Term String where
-  applySubst rho = id
-
-instance Subst Term ConPatternInfo where
+instance Subst ConPatternInfo where
+  type SubstArg ConPatternInfo = Term
   applySubst rho i = i{ conPType = applySubst rho $ conPType i }
 
-instance Subst Term Pattern where
+instance Subst Pattern where
+  type SubstArg Pattern = Term
   applySubst rho p = case p of
     ConP c mt ps -> ConP c (applySubst rho mt) $ applySubst rho ps
     DefP o q ps  -> DefP o q $ applySubst rho ps
@@ -854,7 +864,8 @@ instance Subst Term Pattern where
     ProjP{}      -> p
     IApplyP o t u x -> IApplyP o (applySubst rho t) (applySubst rho u) x
 
-instance Subst Term A.ProblemEq where
+instance Subst A.ProblemEq where
+  type SubstArg A.ProblemEq = Term
   applySubst rho (A.ProblemEq p v a) =
     uncurry (A.ProblemEq p) $ applySubst rho (v,a)
 
@@ -874,7 +885,7 @@ instance DeBruijn NLPat where
     PBoundVar{} -> Nothing -- or... ?
     PTerm{}     -> Nothing -- or... ?
 
-applyNLPatSubst :: (Subst Term a) => Substitution' NLPat -> a -> a
+applyNLPatSubst :: TermSubst a => Substitution' NLPat -> a -> a
 applyNLPatSubst = applySubst . fmap nlPatToTerm
   where
     nlPatToTerm :: NLPat -> Term
@@ -887,10 +898,11 @@ applyNLPatSubst = applySubst . fmap nlPatToTerm
       PSort s        -> __IMPOSSIBLE__
       PBoundVar i es -> __IMPOSSIBLE__
 
-applyNLSubstToDom :: Subst NLPat a => Substitution' NLPat -> Dom a -> Dom a
+applyNLSubstToDom :: SubstWith NLPat a => Substitution' NLPat -> Dom a -> Dom a
 applyNLSubstToDom rho dom = applySubst rho <$> dom{ domTactic = applyNLPatSubst rho $ domTactic dom }
 
-instance Subst NLPat NLPat where
+instance Subst NLPat where
+  type SubstArg NLPat = NLPat
   applySubst rho p = case p of
     PVar i bvs -> lookupS rho i `applyBV` bvs
     PDef f es -> PDef f $ applySubst rho es
@@ -911,17 +923,20 @@ instance Subst NLPat NLPat where
         PSort s        -> __IMPOSSIBLE__
         PBoundVar i es -> __IMPOSSIBLE__
 
-instance Subst NLPat NLPType where
+instance Subst NLPType where
+  type SubstArg NLPType = NLPat
   applySubst rho (NLPType s a) = NLPType (applySubst rho s) (applySubst rho a)
 
-instance Subst NLPat NLPSort where
+instance Subst NLPSort where
+  type SubstArg NLPSort = NLPat
   applySubst rho = \case
     PType l   -> PType $ applySubst rho l
     PProp l   -> PProp $ applySubst rho l
     PInf f n  -> PInf f n
     PSizeUniv -> PSizeUniv
 
-instance Subst NLPat RewriteRule where
+instance Subst RewriteRule where
+  type SubstArg RewriteRule = NLPat
   applySubst rho (RewriteRule q gamma f ps rhs t) =
     RewriteRule q (applyNLPatSubst rho gamma)
                 f (applySubst (liftS n rho) ps)
@@ -929,26 +944,32 @@ instance Subst NLPat RewriteRule where
                   (applyNLPatSubst (liftS n rho) t)
     where n = size gamma
 
-instance Subst t a => Subst t (Blocked a) where
+instance Subst a => Subst (Blocked a) where
+  type SubstArg (Blocked a) = SubstArg a
   applySubst rho b = fmap (applySubst rho) b
 
-instance Subst Term DisplayForm where
+instance Subst DisplayForm where
+  type SubstArg DisplayForm = Term
   applySubst rho (Display n ps v) =
     Display n (applySubst (liftS 1 rho) ps)
               (applySubst (liftS n rho) v)
 
-instance Subst Term DisplayTerm where
+instance Subst DisplayTerm where
+  type SubstArg DisplayTerm = Term
   applySubst rho (DTerm v)        = DTerm $ applySubst rho v
   applySubst rho (DDot v)         = DDot  $ applySubst rho v
   applySubst rho (DCon c ci vs)   = DCon c ci $ applySubst rho vs
   applySubst rho (DDef c es)      = DDef c $ applySubst rho es
   applySubst rho (DWithApp v vs es) = uncurry3 DWithApp $ applySubst rho (v, vs, es)
 
-instance Subst t a => Subst t (Tele a) where
+instance Subst a => Subst (Tele a) where
+  type SubstArg (Tele a) = SubstArg a
   applySubst rho  EmptyTel         = EmptyTel
   applySubst rho (ExtendTel t tel) = uncurry ExtendTel $ applySubst rho (t, tel)
 
-instance Subst Term Constraint where
+instance Subst Constraint where
+  type SubstArg Constraint = Term
+
   applySubst rho c = case c of
     ValueCmp cmp a u v       -> ValueCmp cmp (rf a) (rf u) (rf v)
     ValueCmpOnFace cmp p t u v -> ValueCmpOnFace cmp (rf p) (rf t) (rf u) (rf v)
@@ -965,56 +986,82 @@ instance Subst Term Constraint where
     UnquoteTactic t h g      -> UnquoteTactic (rf t) (rf h) (rf g)
     CheckMetaInst m          -> CheckMetaInst m
     where
+      rf :: forall a. TermSubst a => a -> a
       rf x = applySubst rho x
 
-instance Subst Term CompareAs where
+instance Subst CompareAs where
+  type SubstArg CompareAs = Term
   applySubst rho (AsTermsOf a) = AsTermsOf $ applySubst rho a
   applySubst rho AsSizes       = AsSizes
   applySubst rho AsTypes       = AsTypes
 
-instance Subst t a => Subst t (Elim' a) where
+instance Subst a => Subst (Elim' a) where
+  type SubstArg (Elim' a) = SubstArg a
   applySubst rho e = case e of
     Apply v -> Apply $ applySubst rho v
     IApply x y r -> IApply (applySubst rho x) (applySubst rho y) (applySubst rho r)
     Proj{}  -> e
 
-instance Subst t a => Subst t (Abs a) where
+instance Subst a => Subst (Abs a) where
+  type SubstArg (Abs a) = SubstArg a
   applySubst rho (Abs x a)   = Abs x $ applySubst (liftS 1 rho) a
   applySubst rho (NoAbs x a) = NoAbs x $ applySubst rho a
 
-instance Subst t a => Subst t (Arg a) where
+instance Subst a => Subst (Arg a) where
+  type SubstArg (Arg a) = SubstArg a
   applySubst IdS arg = arg
   applySubst rho arg = setFreeVariables unknownFreeVariables $ fmap (applySubst rho) arg
 
-instance Subst t a => Subst t (Named name a) where
+instance Subst a => Subst (Named name a) where
+  type SubstArg (Named name a) = SubstArg a
   applySubst rho = fmap (applySubst rho)
 
-instance (Subst t a, Subst t b) => Subst t (Dom' a b) where
+instance (Subst a, Subst b, SubstArg a ~ SubstArg b) => Subst (Dom' a b) where
+  type SubstArg (Dom' a b) = SubstArg a
+
   applySubst IdS dom = dom
   applySubst rho dom = setFreeVariables unknownFreeVariables $
     fmap (applySubst rho) dom{ domTactic = applySubst rho (domTactic dom) }
 
-instance Subst t a          => Subst t (Maybe a)      where
-instance Subst t a          => Subst t [a]            where
-instance (Ord k, Subst t a) => Subst t (Map k a)      where
-instance Subst t a          => Subst t (WithHiding a) where
+instance Subst a => Subst (Maybe a) where
+  type SubstArg (Maybe a) = SubstArg a
 
-instance Subst Term () where
+instance Subst a => Subst [a] where
+  type SubstArg [a] = SubstArg a
+
+instance (Ord k, Subst a) => Subst (Map k a) where
+  type SubstArg (Map k a) = SubstArg a
+
+instance Subst a => Subst (WithHiding a) where
+  type SubstArg (WithHiding a) = SubstArg a
+
+instance Subst () where
+  type SubstArg () = Term
   applySubst _ _ = ()
 
-instance (Subst t a, Subst t b) => Subst t (a, b) where
+instance (Subst a, Subst b, SubstArg a ~ SubstArg b) => Subst (a, b) where
+  type SubstArg (a, b) = SubstArg a
   applySubst rho (x,y) = (applySubst rho x, applySubst rho y)
 
-instance (Subst t a, Subst t b, Subst t c) => Subst t (a, b, c) where
+instance (Subst a, Subst b, Subst c, SubstArg a ~ SubstArg b, SubstArg b ~ SubstArg c) => Subst (a, b, c) where
+  type SubstArg (a, b, c) = SubstArg a
   applySubst rho (x,y,z) = (applySubst rho x, applySubst rho y, applySubst rho z)
 
-instance (Subst t a, Subst t b, Subst t c, Subst t d) => Subst t (a, b, c, d) where
+instance
+  ( Subst a, Subst b, Subst c, Subst d
+  , SubstArg a ~ SubstArg b
+  , SubstArg b ~ SubstArg c
+  , SubstArg c ~ SubstArg d
+  ) => Subst (a, b, c, d) where
+  type SubstArg (a, b, c, d) = SubstArg a
   applySubst rho (x,y,z,u) = (applySubst rho x, applySubst rho y, applySubst rho z, applySubst rho u)
 
-instance Subst Term Candidate where
+instance Subst Candidate where
+  type SubstArg Candidate = Term
   applySubst rho (Candidate q u t ov) = Candidate q (applySubst rho u) (applySubst rho t) ov
 
-instance Subst Term EqualityView where
+instance Subst EqualityView where
+  type SubstArg EqualityView = Term
   applySubst rho (OtherType t) = OtherType
     (applySubst rho t)
   applySubst rho (EqualityType s eq l t a b) = EqualityType
@@ -1034,7 +1081,7 @@ instance DeBruijn a => DeBruijn (Pattern' a) where
 fromPatternSubstitution :: PatternSubstitution -> Substitution
 fromPatternSubstitution = fmap patternToTerm
 
-applyPatSubst :: (Subst Term a) => PatternSubstitution -> a -> a
+applyPatSubst :: TermSubst a => PatternSubstitution -> a -> a
 applyPatSubst = applySubst . fromPatternSubstitution
 
 
@@ -1058,7 +1105,8 @@ usePatternInfo i p = case patternOrigin p of
     ProjP{} -> __IMPOSSIBLE__
     (IApplyP _ t u x) -> IApplyP i t u x
 
-instance Subst DeBruijnPattern DeBruijnPattern where
+instance Subst DeBruijnPattern where
+  type SubstArg DeBruijnPattern = DeBruijnPattern
   applySubst IdS p = p
   applySubst rho p = case p of
     VarP i x     ->
@@ -1081,7 +1129,8 @@ instance Subst DeBruijnPattern DeBruijnPattern where
         = VarP o $ x { dbPatVarName = n }
       useName _ x = x
 
-instance Subst Term Range where
+instance Subst Range where
+  type SubstArg Range = Term
   applySubst _ = id
 
 ---------------------------------------------------------------------------
@@ -1121,8 +1170,8 @@ type TelView = TelV Type
 data TelV a  = TelV { theTel :: Tele (Dom a), theCore :: a }
   deriving (Show, Functor)
 
-deriving instance (Subst Term a, Eq  a) => Eq  (TelV a)
-deriving instance (Subst Term a, Ord a) => Ord (TelV a)
+deriving instance (TermSubst a, Eq  a) => Eq  (TelV a)
+deriving instance (TermSubst a, Ord a) => Ord (TelV a)
 
 -- | Takes off all exposed function domains from the given type.
 --   This means that it does not reduce to expose @Pi@-types.
@@ -1274,8 +1323,8 @@ deriving instance Eq t => Eq (Blocked t)
 deriving instance Eq CandidateKind
 deriving instance Eq Candidate
 
-deriving instance (Subst t a, Eq a)  => Eq  (Tele a)
-deriving instance (Subst t a, Ord a) => Ord (Tele a)
+deriving instance (Subst a, Eq a)  => Eq  (Tele a)
+deriving instance (Subst a, Ord a) => Ord (Tele a)
 
 -- Andreas, 2019-11-16, issue #4201: to avoid potential unintended
 -- performance loss, the Eq instance for Constraint is disabled:
@@ -1385,23 +1434,23 @@ instance Ord Term where
 -- | Equality of binders relies on weakening
 --   which is a special case of renaming
 --   which is a special case of substitution.
-instance (Subst t a, Eq a) => Eq (Abs a) where
+instance (Subst a, Eq a) => Eq (Abs a) where
   NoAbs _ a == NoAbs _ b = a == b  -- no need to raise if both are NoAbs
   a         == b         = absBody a == absBody b
 
-instance (Subst t a, Ord a) => Ord (Abs a) where
+instance (Subst a, Ord a) => Ord (Abs a) where
   NoAbs _ a `compare` NoAbs _ b = a `compare` b  -- no need to raise if both are NoAbs
   a         `compare` b         = absBody a `compare` absBody b
 
 deriving instance Ord a => Ord (Dom a)
 
-instance (Subst t a, Eq a)  => Eq  (Elim' a) where
+instance (Subst a, Eq a)  => Eq  (Elim' a) where
   Apply  a == Apply  b = a == b
   Proj _ x == Proj _ y = x == y
   IApply x y r == IApply x' y' r' = x == x' && y == y' && r == r'
   _ == _ = False
 
-instance (Subst t a, Ord a) => Ord (Elim' a) where
+instance (Subst a, Ord a) => Ord (Elim' a) where
   Apply  a `compare` Apply  b = a `compare` b
   Proj _ x `compare` Proj _ y = x `compare` y
   IApply x y r `compare` IApply x' y' r' = compare x x' `mappend` compare y y' `mappend` compare r r'
@@ -1571,4 +1620,3 @@ levelTm l =
   case l of
     Max 0 [Plus 0 l] -> l
     _                -> Level l
-

--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
-
 -- | A syntactic equality check that takes meta instantiations into account,
 --   but does not reduce.  It replaces
 --   @
@@ -147,7 +145,7 @@ instance SynEq a => SynEq (Elim' a) where
                           -> (IApply u v *** IApply u' v') <$> synEq r r'
       _                   -> inequal (e, e')
 
-instance (Subst t a, SynEq a) => SynEq (Abs a) where
+instance (Subst a, SynEq a) => SynEq (Abs a) where
   synEq a a' =
     case (a, a') of
       (NoAbs x b, NoAbs x' b') -> (NoAbs x *** NoAbs x') <$>  synEq b b'

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 
 module Agda.TypeChecking.Telescope where
 
@@ -37,7 +38,7 @@ import qualified Agda.Utils.VarSet as VarSet
 import Agda.Utils.Impossible
 
 -- | Flatten telescope: (Γ : Tel) -> [Type Γ]
-flattenTel :: Subst Term a => Tele (Dom a) -> [Dom a]
+flattenTel :: TermSubst a => Tele (Dom a) -> [Dom a]
 flattenTel EmptyTel          = []
 flattenTel (ExtendTel a tel) = raise (size tel + 1) a : flattenTel (absBody tel)
 

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE UndecidableInstances      #-}
+{-# LANGUAGE TypeFamilies              #-}
 
 -- | Tools for benchmarking and accumulating results.
 --   Nothing Agda-specific in here.
@@ -122,13 +122,14 @@ instance (Ord a, Pretty a) => Pretty (Benchmark a) where
 
 -- | Monad with access to benchmarking data.
 
-class (Ord a, Functor m, MonadIO m) => MonadBench a m | m -> a where
-  getBenchmark :: m (Benchmark a)
+class (Ord (BenchPhase m), Functor m, MonadIO m) => MonadBench m where
+  type BenchPhase m
+  getBenchmark :: m (Benchmark (BenchPhase m))
 
-  putBenchmark :: Benchmark a -> m ()
+  putBenchmark :: Benchmark (BenchPhase m) -> m ()
   putBenchmark b = modifyBenchmark $ const b
 
-  modifyBenchmark :: (Benchmark a -> Benchmark a) -> m ()
+  modifyBenchmark :: (Benchmark (BenchPhase m) -> Benchmark (BenchPhase m)) -> m ()
   modifyBenchmark f = do
     b <- getBenchmark
     putBenchmark $! f b
@@ -136,18 +137,20 @@ class (Ord a, Functor m, MonadIO m) => MonadBench a m | m -> a where
   -- | We need to be able to terminate benchmarking in case of an exception.
   finally :: m b -> m c -> m b
 
-getsBenchmark :: MonadBench a m => (Benchmark a -> c) -> m c
+getsBenchmark :: MonadBench m => (Benchmark (BenchPhase m) -> c) -> m c
 getsBenchmark f = f <$> getBenchmark
 
--- needs UndecidableInstances because of weakness of FunctionalDependencies
-instance MonadBench a m => MonadBench a (ReaderT r m) where
+instance MonadBench m => MonadBench (ReaderT r m) where
+  type BenchPhase (ReaderT r m) = BenchPhase m
   getBenchmark    = lift $ getBenchmark
   putBenchmark    = lift . putBenchmark
   modifyBenchmark = lift . modifyBenchmark
   finally m f = ReaderT $ \ r ->
     finally (m `runReaderT` r) (f `runReaderT` r)
 
-instance MonadBench a m => MonadBench a (StateT r m) where
+instance MonadBench m => MonadBench (StateT r m) where
+  type BenchPhase (StateT r m) = BenchPhase m
+
   getBenchmark    = lift $ getBenchmark
   putBenchmark    = lift . putBenchmark
   modifyBenchmark = lift . modifyBenchmark
@@ -156,16 +159,16 @@ instance MonadBench a m => MonadBench a (StateT r m) where
 
 -- | Turn benchmarking on/off.
 
-setBenchmarking :: MonadBench a m => BenchmarkOn a -> m ()
+setBenchmarking :: MonadBench m => BenchmarkOn (BenchPhase m) -> m ()
 setBenchmarking b = modifyBenchmark $ mapBenchmarkOn $ const b
 
 -- | Bill current account with time up to now.
 --   Switch to new account.
 --   Return old account (if any).
 
-switchBenchmarking :: MonadBench a m
-  => Strict.Maybe (Account a)      -- ^ Maybe new account.
-  -> m (Strict.Maybe (Account a))  -- ^ Maybe old account.
+switchBenchmarking :: MonadBench m
+  => Strict.Maybe (Account (BenchPhase m))      -- ^ Maybe new account.
+  -> m (Strict.Maybe (Account (BenchPhase m)))  -- ^ Maybe old account.
 switchBenchmarking newAccount = do
   now <- liftIO $ getCPUTime
   -- Stop and bill current benchmarking.
@@ -178,7 +181,7 @@ switchBenchmarking newAccount = do
 
 -- | Resets the account and the timing information.
 
-reset :: MonadBench a m => m ()
+reset :: MonadBench m => m ()
 reset = modifyBenchmark $
   mapCurrentAccount (const Strict.Nothing) .
   mapTimings (const Trie.empty)
@@ -186,7 +189,7 @@ reset = modifyBenchmark $
 -- | Bill a computation to a specific account.
 --   Works even if the computation is aborted by an exception.
 
-billTo :: MonadBench a m => Account a -> m c -> m c
+billTo :: MonadBench m => Account (BenchPhase m) -> m c -> m c
 billTo account m = ifNotM (isBenchmarkOn account <$> getsBenchmark benchmarkOn) m $ do
   -- Switch to new account.
   old <- switchBenchmarking $ Strict.Just account
@@ -194,7 +197,7 @@ billTo account m = ifNotM (isBenchmarkOn account <$> getsBenchmark benchmarkOn) 
   (liftIO . E.evaluate =<< m) `finally` switchBenchmarking old
 
 -- | Bill a CPS function to an account. Can't handle exceptions.
-billToCPS :: MonadBench a m => Account a -> ((b -> m c) -> m c) -> (b -> m c) -> m c
+billToCPS :: MonadBench m => Account (BenchPhase m) -> ((b -> m c) -> m c) -> (b -> m c) -> m c
 billToCPS account f k = ifNotM (isBenchmarkOn account <$> getsBenchmark benchmarkOn) (f k) $ do
   -- Switch to new account.
   old <- switchBenchmarking $ Strict.Just account
@@ -203,5 +206,5 @@ billToCPS account f k = ifNotM (isBenchmarkOn account <$> getsBenchmark benchmar
     k x
 
 -- | Bill a pure computation to a specific account.
-billPureTo :: MonadBench a m  => Account a -> c -> m c
+billPureTo :: MonadBench m  => Account (BenchPhase m) -> c -> m c
 billPureTo account = billTo account . return

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -125,9 +125,6 @@ instance (Ord a, Pretty a) => Pretty (Benchmark a) where
 class (Ord a, Functor m, MonadIO m) => MonadBench a m | m -> a where
   getBenchmark :: m (Benchmark a)
 
-  getsBenchmark :: (Benchmark a -> c) -> m c
-  getsBenchmark f = f <$> getBenchmark
-
   putBenchmark :: Benchmark a -> m ()
   putBenchmark b = modifyBenchmark $ const b
 
@@ -138,6 +135,9 @@ class (Ord a, Functor m, MonadIO m) => MonadBench a m | m -> a where
 
   -- | We need to be able to terminate benchmarking in case of an exception.
   finally :: m b -> m c -> m b
+
+getsBenchmark :: MonadBench a m => (Benchmark a -> c) -> m c
+getsBenchmark f = f <$> getBenchmark
 
 -- needs UndecidableInstances because of weakness of FunctionalDependencies
 instance MonadBench a m => MonadBench a (ReaderT r m) where

--- a/src/full/Agda/Utils/ListT.hs
+++ b/src/full/Agda/Utils/ListT.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP  #-}
-{-# LANGUAGE UndecidableInstances  #-}  -- Due to limitations of funct.dep.
+{-# LANGUAGE UndecidableInstances  #-} -- Due MonadReader/MonadState fundep
 
 -- | @ListT@ done right,
 --   see https://www.haskell.org/haskellwiki/ListT_done_right_alternative

--- a/test/Internal/TypeChecking/Generators.hs
+++ b/test/Internal/TypeChecking/Generators.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TemplateHaskell        #-}
-{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies    #-}
 
 module Internal.TypeChecking.Generators where
 
@@ -232,6 +232,7 @@ instance GenC Sort where
     (propF, return (mkProp 0)) :
     zip setFs (map (return . mkType) [0..])
     where
+      freq :: forall a. (Frequencies -> a) -> a
       freq f = f $ tcFrequencies conf
       setFs = freq (setFreqs . sortFreqs)
       propF = freq (propFreq . sortFreqs)
@@ -345,19 +346,23 @@ instance Arbitrary TermConfiguration where
 
 -- Shrinking --------------------------------------------------------------
 
-class ShrinkC a b | a -> b where
-  shrinkC  :: TermConfiguration -> a -> [b]
-  noShrink :: a -> b
+class ShrinkC a where
+  type ShrinksTo a
+  shrinkC  :: TermConfiguration -> a -> [ShrinksTo a]
+  noShrink :: a -> ShrinksTo a
 
-instance ShrinkC a b => ShrinkC (YesType a) b where
+instance ShrinkC a => ShrinkC (YesType a) where
+  type ShrinksTo (YesType a) = ShrinksTo a
   shrinkC conf (YesType x) = shrinkC (isTypeConf conf) x
   noShrink (YesType x) = noShrink x
 
-instance ShrinkC a b => ShrinkC (NoType a) b where
+instance ShrinkC a => ShrinkC (NoType a) where
+  type ShrinksTo (NoType a) = ShrinksTo a
   shrinkC conf (NoType x) = shrinkC (isntTypeConf conf) x
   noShrink (NoType x) = noShrink x
 
-instance ShrinkC a b => ShrinkC [a] [b] where
+instance ShrinkC a => ShrinkC [a] where
+  type ShrinksTo [a] = [ShrinksTo a]
   noShrink        = map noShrink
   shrinkC conf xs = noShrink (removeChunks xs) ++ shrinkOne xs
    where
@@ -385,25 +390,30 @@ instance ShrinkC a b => ShrinkC [a] [b] where
     shrinkOne (x:xs) = [ x' : noShrink xs | x'  <- shrinkC conf x ]
                     ++ [ noShrink x : xs' | xs' <- shrinkOne xs ]
 
-instance (ShrinkC a a', ShrinkC b b') => ShrinkC (a, b) (a', b') where
+instance (ShrinkC a, ShrinkC b) => ShrinkC (a, b) where
+  type ShrinksTo (a, b) = (ShrinksTo a, ShrinksTo b)
   noShrink (x, y) = (noShrink x, noShrink y)
   shrinkC conf (x, y) =
     [ (x', noShrink y) | x' <- shrinkC conf x ] ++
     [ (noShrink x, y') | y' <- shrinkC conf y ]
 
-instance ShrinkC VarName Nat where
+instance ShrinkC VarName where
+  type ShrinksTo VarName = Nat
   shrinkC conf (VarName x) = [ y | y <- tcFreeVariables conf, y < x ]
   noShrink = unVarName
 
-instance ShrinkC DefName QName where
+instance ShrinkC DefName where
+  type ShrinksTo DefName = QName
   shrinkC conf (DefName c) = takeWhile (/= c) $ tcDefinedNames conf
   noShrink = unDefName
 
-instance ShrinkC ConName ConHead where
+instance ShrinkC ConName where
+  type ShrinksTo ConName = ConHead
   shrinkC conf (ConName (ConHead{conName = c})) = map (\ c -> ConHead c IsData Inductive []) $ takeWhile (/= c) $ tcConstructorNames conf
   noShrink = unConName
 
-instance ShrinkC Literal Literal where
+instance ShrinkC Literal where
+  type ShrinksTo Literal = Literal
   shrinkC _ (LitNat 0) = []
   shrinkC conf l         = LitNat 0 : case l of
       LitNat    n -> LitNat    <$> shrink n
@@ -415,42 +425,50 @@ instance ShrinkC Literal Literal where
       LitMeta{}     -> []
   noShrink = id
 
-instance ShrinkC Char Char where
+instance ShrinkC Char where
+  type ShrinksTo Char = Char
   shrinkC _ 'a' = []
   shrinkC _ _   = ['a']
   noShrink = id
 
-instance ShrinkC Hiding Hiding where
+instance ShrinkC Hiding where
+  type ShrinksTo Hiding = Hiding
   shrinkC _ Hidden     = [NotHidden]
   shrinkC _ Instance{} = [NotHidden]
   shrinkC _ NotHidden  = []
   noShrink = id
 
-instance ShrinkC a b => ShrinkC (Abs a) (Abs b) where
+instance ShrinkC a => ShrinkC (Abs a) where
+  type ShrinksTo (Abs a) = Abs (ShrinksTo a)
   shrinkC conf (NoAbs s x) = NoAbs s <$> shrinkC conf x
   shrinkC conf (Abs   s x) = Abs s <$> shrinkC (extendConf conf) x
   noShrink = fmap noShrink
 
-instance ShrinkC a b => ShrinkC (Arg a) (Arg b) where
+instance ShrinkC a => ShrinkC (Arg a) where
+  type ShrinksTo (Arg a) = Arg (ShrinksTo a)
   shrinkC conf (Arg info x) = (\ (h,x) -> Arg (setHiding h info) x) <$> shrinkC conf (argInfoHiding info, x)
   noShrink = fmap noShrink
 
-instance ShrinkC a b => ShrinkC (Dom a) (Dom b) where
+instance ShrinkC a => ShrinkC (Dom a) where
+  type ShrinksTo (Dom a) = Dom (ShrinksTo a)
   shrinkC conf dom@Dom{domInfo = info,unDom = x} = (\ (h,x) -> x <$ dom{domInfo = (setHiding h info)}) <$> shrinkC conf (argInfoHiding info, x)
   noShrink = fmap noShrink
 
-instance ShrinkC a b => ShrinkC (Blocked a) (Blocked b) where
+instance ShrinkC a => ShrinkC (Blocked a) where
+  type ShrinksTo (Blocked a) = Blocked (ShrinksTo a)
   shrinkC conf (Blocked m x)    = Blocked m <$> shrinkC conf x
   shrinkC conf (NotBlocked r x) = NotBlocked r <$> shrinkC conf x
   noShrink = fmap noShrink
 
-instance ShrinkC a b => ShrinkC (Elim' a) (Elim' b) where
+instance ShrinkC a => ShrinkC (Elim' a) where
+  type ShrinksTo (Elim' a) = Elim' (ShrinksTo a)
   shrinkC conf (Apply a) = Apply <$> shrinkC conf a
   shrinkC conf (IApply x y a) = IApply <$> shrinkC conf x <*> shrinkC conf y <*> shrinkC conf a
   shrinkC conf Proj{}    = []
   noShrink = fmap noShrink
 
-instance ShrinkC Sort Sort where
+instance ShrinkC Sort where
+  type ShrinksTo Sort = Sort
   shrinkC conf s = mkProp 0 : case s of
     Type n     -> [] -- No Level instance yet -- Type <$> shrinkC conf n
     SSet l     -> []
@@ -465,17 +483,20 @@ instance ShrinkC Sort Sort where
     DummyS{} -> __IMPOSSIBLE__
   noShrink = id
 
-instance ShrinkC Telescope Telescope where
+instance ShrinkC Telescope where
+  type ShrinksTo Telescope = Telescope
   shrinkC conf EmptyTel          = []
   shrinkC conf (ExtendTel a tel) =
     killAbs tel : (uncurry ExtendTel <$> shrinkC conf (a, tel))
   noShrink = id
 
-instance ShrinkC Type Type where
+instance ShrinkC Type where
+  type ShrinksTo Type = Type
   shrinkC conf (El s t) = uncurry El <$> shrinkC conf (s, YesType t)
   noShrink = id
 
-instance ShrinkC Term Term where
+instance ShrinkC Term where
+  type ShrinksTo Term = Term
   shrinkC conf DontCare{}  = []
   shrinkC conf Dummy{}     = []
   shrinkC conf t           = filter validType $ case t of

--- a/test/Internal/TypeChecking/Substitute.hs
+++ b/test/Internal/TypeChecking/Substitute.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies    #-}
 
 module Internal.TypeChecking.Substitute ( tests ) where
 
@@ -90,7 +91,8 @@ instance DeBruijn Tm where
   deBruijnView v = do VarT x <- pure v; pure x
   deBruijnVar x  = VarT x
 
-instance Subst Tm Tm where
+instance Subst Tm where
+  type SubstArg Tm = Tm
   applySubst rho v = case v of
     VarT x    -> lookupS rho x
     AnnT t v  -> AnnT t $ applySubst rho v


### PR DESCRIPTION
The proliferation of `UndecidableInstances` in the codebase was becoming a little alarming: when experimenting with changes, I'd frequently have to enable that flag in new modules due to constraints from existing types, and it wasn't always clear if it was something I'd done or from an existing class. However it's a dangerous, broad, catch-all flag that can hide serious type instance consistency issues, slow down type-checking, and starts to creep across the codebase.

The most frequent cause in the Agda codebase was from a few multi-parameter type-classes. Even with the correctly-declared functional dependencies, GHC is surprisingly basic with how it determines termination of those instance declarations.

Associated type families are slightly more verbose, but when they can be used are significantly safer than `UndecidableInstances`. In many cases they're also clearer to work with. (For example, you can now use `ConOfAbs a` to refer to the concrete-syntax type of an abstract-syntax type).

This PR reduces the number of `UndecidableInstances` modules from 33 to 5, mainly by introducing associated type families. I tried hard _not_ to affect existing semantics. For the remaining few uses, I added a comment noting specifically why they were used. Some of them could be fixed, but not as straightforwardly as this change.

Thoughts?

P.S. (Andreas, 2024-10-09): Closes #1300 
- #1300