### PR TITLE
Allow configuring ghc memory limit in config.mk

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -232,6 +232,13 @@ Testing and documentation
     PARALLEL_TESTS = 4
   ```
 
+* RTS options to ghc can be provided through the `GHC_RTS_OPTS` variable,
+  either on the command line
+  ```sh
+    make GHC_RTS_OPTS=-M8G install-bin
+  ```
+  or in `mk/config.mk`.
+
 * You can run a single interaction test by going into the
   `test/interaction` directory and typing `make <test name>.cmp`.
 

--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,21 @@ CABAL_INSTALL           = $(CABAL_INSTALL_HELPER) \
 STACK_INSTALL           = $(STACK_INSTALL_HELPER) \
                           $(SLOW_STACK_INSTALL_OPTS)
 
+# Depending on your machine and ghc version you might want to tweak the amount of memory
+# given to ghc to compile Agda. To do this set GHC_RTS_OPTS in mk/config.mk (gitignored).
+ifeq ($(GHC_RTS_OPTS),)
 ifeq ("$(shell $(GHC) --info | grep 'target word size' | cut -d\" -f4)","4")
-GHC_OPTS           = "+RTS -M1.7G -RTS"
+GHC_RTS_OPTS := -M1.7G
 else
-GHC_OPTS           = "+RTS -M4G -RTS"
+ifeq ($(GHC_VERSION),8.10)
+GHC_RTS_OPTS := -M6G
+else
+GHC_RTS_OPTS := -M4G
 endif
+endif
+endif
+GHC_OPTS = "+RTS $(GHC_RTS_OPTS) -RTS"
+
 # The following options are used in several invocations of cabal
 # install/configure below. They are always the last options given to
 # the command.


### PR DESCRIPTION
Also increase the default limit for ghc-8.10 on 64-bit machines. Compiling from scratch on 8.10.2 struggles a lot to stay within 4Gb.