### PR TITLE
Fix #4869 - Instantiate metas in AbsurdPatternRequiresNoRHS warning.

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -748,7 +748,9 @@ checkRHS i x aps t lhsResult@(LHSResult _ delta ps absurdPat trhs _ _asb _) rhs0
     -- one we complain, ignore it and return the same @(Nothing, NoWithFunction)@
     -- as the case dealing with @A.AbsurdRHS@.
     mv <- if absurdPat
-          then Nothing <$ setCurrentRange e (warning $ AbsurdPatternRequiresNoRHS ps)
+          then do
+            ps <- instantiateFull ps
+            Nothing <$ setCurrentRange e (warning $ AbsurdPatternRequiresNoRHS ps)
           else Just <$> checkExpr e (unArg trhs)
     return (mv, NoWithFunction)
 

--- a/test/Succeed/Issue4869.agda
+++ b/test/Succeed/Issue4869.agda
@@ -1,0 +1,12 @@
+module Issue4869 where
+
+open import Agda.Builtin.Nat
+
+infix 4 _≤_
+
+data _≤_ : Nat → Nat → Set where
+  z≤n : ∀ {n} → zero ≤ n
+  s≤s : ∀ {m n} (m≤n : m ≤ n) → suc m ≤ suc n
+
+foo : 2 ≤ 1 → Nat
+foo (s≤s ()) = 123

--- a/test/Succeed/Issue4869.warn
+++ b/test/Succeed/Issue4869.warn
@@ -1,0 +1,13 @@
+Issue4869.agda:12,16-19
+The right-hand side must be omitted if there is an absurd pattern,
+() or {}, in the left-hand side.
+when checking that the clause foo (s≤s ()) = 123 has type
+2 ≤ 1 → Nat
+
+———— All done; warnings encountered ————————————————————————
+
+Issue4869.agda:12,16-19
+The right-hand side must be omitted if there is an absurd pattern,
+() or {}, in the left-hand side.
+when checking that the clause foo (s≤s ()) = 123 has type
+2 ≤ 1 → Nat


### PR DESCRIPTION
This fixes #4869 - i.e., the serialization of `AbsurdPatternRequiresNoRHS` warnings - by instantiating any metas that may be contained in the argument information carried in the warning.

I don't fully understand meta instantiation, but `instantiateFull` seems to be the weapon of choice when getting rid of metas in clauses. As the argument information carried in the warning also shows up in clauses, I figured that `instantiateFull` would also do the trick for the warning.