### PR TITLE
Allow pattern matching on large natural number literals (#4906)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,10 @@ Language
 * Binary integer literals with prefix `0b` (for instance, `0b11001001`) are now
   supported.
 
+* Agda now allows pattern matching on any natural number literal. Previously,
+  the maximum value Agda could pattern match on was 20, since these patterns
+  were internally translated to `suc` and `zero` patterns.
+
 Reflection
 ----------
 

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2807,7 +2807,9 @@ instance ToAbstract C.Pattern where
     -- Andreas, 2015-05-28 futile attempt to fix issue 819: repeated variable on lhs "_"
     -- toAbstract p@(C.WildP r)    = A.VarP <$> freshName r "_"
     toAbstract (C.ParenP _ p)   = toAbstract p
-    toAbstract (C.LitP r l)     = return $ A.LitP (PatRange r) l
+    toAbstract (C.LitP r l)     = case l of
+      LitNat n | n < 0 -> genericError "Negative literals are not supported in patterns"
+      _                -> return $ A.LitP (PatRange r) l
 
     toAbstract p0@(C.AsP r x p) = do
         -- Andreas, 2018-06-30, issue #3147: as-variables can be non-linear a priori!

--- a/test/Fail/Issue2364.agda
+++ b/test/Fail/Issue2364.agda
@@ -1,0 +1,6 @@
+open import Agda.Builtin.Nat
+
+lit : Nat → Set
+lit 5 with 0
+lit 3 | _ = Nat
+lit _ = Nat

--- a/test/Fail/Issue2364.err
+++ b/test/Fail/Issue2364.err
@@ -1,0 +1,6 @@
+Issue2364.agda:4,1-5,16
+With clause pattern 3 is not an instance of its parent pattern 5
+when checking that the clause
+lit 5 with 0
+lit 3 | _ = Nat
+has type Nat → Set

--- a/test/Fail/Issue2365.err
+++ b/test/Fail/Issue2365.err
@@ -1,3 +1,4 @@
-Issue2365.agda:19,5-8
+Issue2365.agda:19,1-8
 Negative literals are not supported in patterns
-when checking that the pattern -20 has type Int
+when scope checking the left-hand side lit -20 in the definition of
+lit

--- a/test/Fail/Issue2365a.err
+++ b/test/Fail/Issue2365a.err
@@ -1,3 +1,4 @@
-Issue2365a.agda:6,5-8
+Issue2365a.agda:6,1-8
 Negative literals are not supported in patterns
-when checking that the pattern -20 has type Nat
+when scope checking the left-hand side lit -20 in the definition of
+lit

--- a/test/Succeed/NatLiteralPattern.agda
+++ b/test/Succeed/NatLiteralPattern.agda
@@ -1,0 +1,24 @@
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+foo : Nat → Nat
+foo 1_000_000 = 1
+foo (suc (suc n)) = n
+foo _ = 0
+
+_ : foo 1_000_000 ≡ 1
+_ = refl
+
+_ : foo 999_999 ≡ 999_997
+_ = refl
+
+_ : foo 1 ≡ 0
+_ = refl
+
+bar : Nat → Nat
+bar 3 = 0
+bar 2 = 1
+bar _ = 2
+
+_ : ∀ x → bar (suc (suc (suc (suc x)))) ≡ 2
+_ = λ x → refl

--- a/test/Succeed/NatLiteralPatternNoFastReduce.agda
+++ b/test/Succeed/NatLiteralPatternNoFastReduce.agda
@@ -1,0 +1,25 @@
+{-# OPTIONS --no-fast-reduce #-}
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+foo : Nat → Nat
+foo 1_000_000 = 1
+foo (suc (suc n)) = n
+foo _ = 0
+
+_ : foo 1_000_000 ≡ 1
+_ = refl
+
+_ : foo 999_999 ≡ 999_997
+_ = refl
+
+_ : foo 1 ≡ 0
+_ = refl
+
+bar : Nat → Nat
+bar 3 = 0
+bar 2 = 1
+bar _ = 2
+
+_ : ∀ x → bar (suc (suc (suc (suc x)))) ≡ 2
+_ = λ x → refl


### PR DESCRIPTION
Fixes #4906, fixes #2364

Implementation notes:

* During type checking / coverage checking: the case tree splits either on zero/suc or literals, but not both. I was pleasantly surprised that this didn't require many code changes. For example:

```agda
foo : Nat → Nat
foo 1_000_000 = 1
foo (suc (suc n)) = n
foo _ = 0

{-
generated split tree for foo
split at 0
|
+- Agda.Builtin.Nat.Nat.zero -> done, 0 bindings
|
`- Agda.Builtin.Nat.Nat.suc -> split at 0
   |
   +- Agda.Builtin.Nat.Nat.zero -> done, 0 bindings
   |
   `- Agda.Builtin.Nat.Nat.suc -> split at 0
      |
      +- 999998 -> done, 0 bindings
      |
      `- _ -> done, 1 bindings
-}
```

* For reduction: when matching term of the form (suc _) against a literal case tree, we have to count the number of sucs on the term to determine if we can take the catchall case (otherwise, matching on literals would not be equivalent to writing out `suc`s and `zero`s). I'm not totally sure I did this correctly for each of the 3 pattern matching implementations. For example,

```agda
bar 3 = 0
bar 2 = 1
bar _ = 2

-- bar (suc (suc (suc (suc x)))) should reduce to 2
```

* I moved the "no negative literals as patterns" check to ConcreteToAbstract, since this is where negative literals as expressions are handled. But maybe it should go in `Agda.Syntax.Concrete.isPattern` instead?