### PR TITLE
Reset state in :load

### DIFF
--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -65,7 +65,7 @@ runAgda' backends = runTCMPrettyErrors $ do
 
 defaultInteraction :: CommandLineOptions -> TCM (Maybe Interface) -> TCM ()
 defaultInteraction opts
-  | i         = runIM . interactionLoop
+  | i         = runIM . interactionLoop opts
   | ghci      = mimicGHCi . (failIfInt =<<)
   | json      = jsonREPL . (failIfInt =<<)
   | otherwise = (() <$)

--- a/test/Interactive/LoadTwice.in
+++ b/test/Interactive/LoadTwice.in
@@ -1,0 +1,6 @@
+:load test/Interactive/LoadTwice1.agda
+:typeOf t1
+:load test/Interactive/LoadTwice2.agda
+:typeOf t1
+:typeOf f
+:quit

--- a/test/Interactive/LoadTwice.stdout.expected
+++ b/test/Interactive/LoadTwice.stdout.expected
@@ -1,0 +1,4 @@
+nameNameParts = Id "Bool1"
+Not in scope
+when scope checking t1
+nameNameParts = Id "Bool2"

--- a/test/Interactive/LoadTwice1.agda
+++ b/test/Interactive/LoadTwice1.agda
@@ -1,0 +1,5 @@
+module LoadTwice1 where
+
+data Bool1 : Set where
+  t1 : Bool1
+  f  : Bool1

--- a/test/Interactive/LoadTwice2.agda
+++ b/test/Interactive/LoadTwice2.agda
@@ -1,0 +1,5 @@
+module LoadTwice2 where
+
+data Bool2 : Set where
+  t2 : Bool2
+  f  : Bool2


### PR DESCRIPTION
If the state is not reset, then if you `:load` a file, change it, and `:load` it again, the updated file would not be loaded.

Resetting the state makes `:load` behave in a similar way as the `:load` command in ghci, which forgets all previously loaded modules.