### PR TITLE
Add package indexing metadata to annotation.el

### DIFF
--- a/src/data/emacs-mode/annotation.el
+++ b/src/data/emacs-mode/annotation.el
@@ -2,9 +2,14 @@
 
 ;; Version: 1.0
 
+;; SPDX-License-Identifier: MIT License
+;; URL: https://github.com/agda/agda
+;; Version: 1.0
+
+;;; Commentary:
+
 ;; Note that this library enumerates buffer positions starting from 1,
 ;; just like Emacs.
-;; SPDX-License-Identifier: MIT License
 
 (require 'cl)
 


### PR DESCRIPTION
This gives indexing tools some additional metadata (source URL, and a 'long' description).

See: #4915 and melpa/melpa#7080