### PR TITLE
Fix #4835 - Fix test for stack builds.

### DIFF
--- a/test/interaction/Issue4835.sh
+++ b/test/interaction/Issue4835.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 AGDA=$1
+RUN=$2
 
 $AGDA --interaction --ignore-interfaces <<EOF
 IOTCM "Issue4835/ModA.agda" None Indirect (Cmd_load "Issue4835/ModA.agda" [])
@@ -8,4 +9,4 @@ IOTCM "Issue4835/ModB.agda" None Indirect (Cmd_load "Issue4835/ModB.agda" [])
 EOF
 
 echo
-runhaskell Issue4835/Count.hs
+$RUN Issue4835/Count.hs

--- a/test/interaction/Makefile
+++ b/test/interaction/Makefile
@@ -59,7 +59,7 @@ run_test=\
            2>&1 | $(filter) ; \
     elif test -f $*.hs; \
     then $(RUNGHC) --ghc-arg=-v0 --ghc-arg=-w ./$*.hs $(AGDA_BIN) 2>&1 | $(filter) ; \
-    else /usr/bin/env bash ./$*.sh $(AGDA_BIN) > $(TMPDIR)/$*.tmp_out ; \
+    else /usr/bin/env bash ./$*.sh $(AGDA_BIN) "$(RUNGHC)" > $(TMPDIR)/$*.tmp_out ; \
          cat $(TMPDIR)/$*.tmp_out | $(filter) ; \
     fi
 


### PR DESCRIPTION
I just discovered `stack` builds and I realized that my test for #4835 doesn't work with them.

The test has a Haskell part that imports parts of the Agda code, which is run with `runhaskell`. This works fine with `cabal` builds, because the build products of `cabal` builds are visible system-wide, so the system `runhaskell` sees them.

For `stack` builds, this isn't true - they are isolated from the rest of the system. The solution then is to run the test with `stack runhaskell` instead of the sytem `runhaskell`.

The Agda build process already figures out how to properly invoke `runhaskell` for the build at hand. I just had to pass this info to the `.sh` test script as a second parameter. (The first parameter is the Agda executable to be used.) The other `.sh` test scripts simply ignore this new additional parameter.