### PR TITLE
Agda emacs command wrapper

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -469,6 +469,30 @@ Emacs mode
                   (insert "\n")))))))
   ```
 
+* You can run agda inside nix-shell by setting a custom wrapper function
+  ```elisp
+      (defun nix-file (where &optional name)
+        "Locate the nix file `NAME' closest to `WHERE'.
+
+      Returns a string containing the path to the `nix-file'.
+
+      If `NAME' is not provided it tries to find `shell.nix', if that
+      fails too then `default.nix', otherwise nil is returned."
+        (flet ((locate (file) (let ((location (locate-dominating-file where file)))
+                                (when location (concat location file)))))
+          (if name (locate name)
+            (or (locate "shell.nix") (locate "default.nix")))))
+
+      (defun nix-shell-agda2 (args)
+        (let ((nix-file (or (nix-file ".")
+                          (error "Nix file not found."))))
+          (cons "nix-shell"
+            (list (expand-file-name nix-file) "--run"
+              (mapconcat #'identity args " ")))))
+
+      (setq agda2-command-wrapper-function #'nix-shell-agda2)
+  ```
+
 Faster compilation of Agda
 ==========================
 


### PR DESCRIPTION
Hi,
 
I didn't see an issue for this, although i think this would be useful.

It enables you to wrap/transform the agda command, so you can run inside a nix-shell for example by setting a variable:
```elisp
      (setq agda2-command-wrapper-function #'nix-shell-agda2)
```

where `nix-shell-agda2` is
```elisp
      (defun nix-shell-agda2 (args)
        (let ((nix-file (or (nix-file ".")
                          (error "Nix file not found."))))
          (cons "nix-shell"
            (list (expand-file-name nix-file) "--run"
              (mapconcat #'identity args " ")))))

      (defun nix-file (where &optional name)
        "Locate the nix file `NAME' closest to `WHERE'.

      Returns a string containing the path to the `nix-file'.

      If `NAME' is not provided it tries to find `shell.nix', if that
      fails too then `default.nix', otherwise nil is returned."
        (flet ((locate (file) (let ((location (locate-dominating-file where file)))
                                (when location (concat location file)))))
          (if name (locate name)
            (or (locate "shell.nix") (locate "default.nix")))))
```

This is something analog to the `haskell-wrapper-function` or `flycheck-wrapper-function` .

The default behaviour is not modified, which is to call just `agda2-program-name` with desired arguments, for this you can leave the default wrapper function to identity:
```elisp
      (defvar agda2-command-wrapper-function #'identity)
```

Functions added
```elisp
agda2-wrap-command
agda2-call-process
agda2-start-process
```

Calls to `call-process` were replaced by `agda2-call-process`, and `start-process` by `agda2-call-process`

Variables added
```elisp
agda2-command-wrapper-function
```

I will add documentation or more information needed if required.

Thanks