### PR TITLE
Add agda mode commentary

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -3,7 +3,24 @@
 
 ;;; Commentary:
 
+;; A major mode for editing Agda (the dependently typed programming
+;; language / interactive theorem prover).
 ;;
+;; Major features include:
+;;
+;; - syntax highlighting.
+;;
+;; - on the fly Agda interpretation.
+;;
+;; - goal-driven development
+;;
+;; - interactive case-splitting
+;;
+;; - proof search
+;;
+;; - input support (for utf8 characters)
+;;
+;; see https://agda.readthedocs.io/ for more information
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; Dependency


### PR DESCRIPTION
This is so that the melpa page has more information
than just 'agda-mode'.

This was requested by the melpa maintainers:

- https://github.com/melpa/melpa/pull/7080

Feel free to suggest improvements on the written commentary, I just skimmed the source to see what it does.