### PR TITLE
Add default flags to .agda-lib files + add caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,22 @@ Reflection
 
   The builtin is only available when `--allow-exec` is passed. (Note that `--allow-exec` is incompatible with ``--safe``.) To make an executable available to Agda, add the absolute path on a new line in `~/.agda/executables`.
 
+Library management
+------------------
+
+- `.agda-lib` files can now contain an extra field `flags:` with
+  default flags for the library. Flags can be any flags that are
+  accepted as part of an `{-# OPTIONS ... #-}` pragma. For example,
+  file `my-library.agda-lib` with
+
+  ```
+  flags: --without-K
+  ```
+
+  will apply the `--without-K` flag to all Agda files in the current
+  directory and (recursive) subdirectories that do not themselves
+  contain an `.agda-lib` file.
+
 
 Emacs mode
 ----------

--- a/doc/user-manual/tools/package-system.rst
+++ b/doc/user-manual/tools/package-system.rst
@@ -66,6 +66,7 @@ A library consists of
 - a name
 - a set of dependencies
 - a set of include paths
+- a set of default flags
 
 Libraries are defined in ``.agda-lib`` files with the following syntax:
 
@@ -78,15 +79,19 @@ Libraries are defined in ``.agda-lib`` files with the following syntax:
   include: PATH1
     PATH2
     PATH3
+  flags: OPTION1 OPTION2
+    OPTION3
 
 Dependencies are library names, not paths to ``.agda-lib`` files, and include
 paths are relative to the location of the library-file.
 
-Each of the three fields is optional.
+Default flags can be any valid pragma options (see :ref:`Command-line
+and pragma options<command-line-pragmas>`).
+
+Each of the four fields is optional.
 Naturally, unnamed libraries cannot be depended upon.
 But dropping the ``name`` is possible if the library file only serves to list
 include paths and/or dependencies of the current project.
-
 
 Installing libraries
 --------------------

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -39,6 +39,7 @@ import Agda.Interaction.Options ( optLocalInterfaces )
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Benchmark (billTo)
 import qualified Agda.TypeChecking.Monad.Benchmark as Bench
+import Agda.TypeChecking.Monad.Options (libToTCM)
 import Agda.TypeChecking.Warnings (runPM)
 
 import Agda.Version ( version )
@@ -76,12 +77,12 @@ mkInterfaceFile fp = do
 -- | Converts an Agda file name to the corresponding interface file
 --   name. Note that we do not guarantee that the file exists.
 
-toIFile :: (HasOptions m, MonadIO m) => SourceFile -> m AbsolutePath
+toIFile :: SourceFile -> TCM AbsolutePath
 toIFile (SourceFile src) = do
   let fp = filePath src
   mroot <- ifM (optLocalInterfaces <$> commandLineOptions)
                {- then -} (pure Nothing)
-               {- else -} (liftIO $ findProjectRoot $ takeDirectory fp)
+               {- else -} (libToTCM $ findProjectRoot (takeDirectory fp))
   pure $ replaceModuleExtension ".agdai" $ case mroot of
     Nothing   -> src
     Just root ->
@@ -173,9 +174,8 @@ findFile'' dirs m modFile =
 -- Raises 'Nothing' if the the interface file cannot be found.
 
 findInterfaceFile'
-  :: (HasOptions m, MonadIO m)
-  => SourceFile                 -- ^ Path to the source file
-  -> m (Maybe InterfaceFile)    -- ^ Maybe path to the interface file
+  :: SourceFile                 -- ^ Path to the source file
+  -> TCM (Maybe InterfaceFile)  -- ^ Maybe path to the interface file
 findInterfaceFile' fp = liftIO . mkInterfaceFile =<< toIFile fp
 
 -- | Finds the interface file corresponding to a given top-level

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -392,7 +392,7 @@ getInterface' x isMain msi =
              (unless (includeStateChanges isMain) . (stPragmaOptions `setTCLens`)) $ do
      -- We remember but reset the pragma options locally
      -- For the main interface, we also remember the pragmas from the file
-     let mpragmas = fst . siModule <$> msi
+     let mpragmas = C.modPragmas . siModule <$> msi
      -- Issue #3644 (Abel 2020-05-08): Set approximate range for errors in options
      currentOptions <- setCurrentRange mpragmas $ do
        when (includeStateChanges isMain) $ do
@@ -865,7 +865,7 @@ createInterface file mname isMain msi =
       reportSLn "import.iface.create" 10 $
         "  visited: " ++ List.intercalate ", " (map prettyShow visited)
 
-    (source, fileType, (pragmas, top)) <- do
+    (source, fileType, C.Mod pragmas top) <- do
       si <- case msi of
         Nothing -> sourceInfo file
         Just si -> return si

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -45,7 +45,6 @@ import Data.Char
 import Data.Data ( Data )
 import Data.Either
 import Data.Function
-import Data.Functor
 import Data.Map ( Map )
 import qualified Data.Map as Map
 import Data.Maybe ( catMaybes, fromMaybe )
@@ -62,6 +61,7 @@ import Agda.Interaction.Options.Warnings
 
 import Agda.Utils.Environment
 import Agda.Utils.FileName
+import Agda.Utils.Functor ( (<&>) )
 import Agda.Utils.IO ( catchIO )
 import Agda.Utils.List
 import Agda.Utils.List1 ( List1 )

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -30,19 +30,22 @@ module Agda.Interaction.Library
   , LibWarning(..)
   , LibPositionInfo(..)
   , libraryWarningName
+  , ProjectConfig(..)
   -- * Exported for testing
   , VersionView(..), versionView, unVersionView
   , findLib'
   ) where
 
+import Control.Arrow ( first , second )
 import Control.Monad.Except
+import Control.Monad.State
 import Control.Monad.Writer
 
 import Data.Char
 import Data.Data ( Data )
 import Data.Either
-import Data.Bifunctor ( first )
 import Data.Function
+import Data.Functor
 import Data.Map ( Map )
 import qualified Data.Map as Map
 import Data.Maybe ( catMaybes, fromMaybe )
@@ -58,6 +61,7 @@ import Agda.Interaction.Library.Parse
 import Agda.Interaction.Options.Warnings
 
 import Agda.Utils.Environment
+import Agda.Utils.FileName
 import Agda.Utils.IO ( catchIO )
 import Agda.Utils.List
 import Agda.Utils.List1 ( List1 )
@@ -87,7 +91,7 @@ data VersionView = VersionView
 --
 mkLibM :: [AgdaLibFile] -> LibErrorIO a -> LibM a
 mkLibM libs m = do
-  (x, ews) <- liftIO $ runWriterT m
+  (x, ews) <- lift $ lift $ runWriterT m
   let (errs, warns) = partitionEithers ews
   tell warns
   unless (null errs) $ do
@@ -153,48 +157,64 @@ defaultExecutableFiles = List1.fromList ["executables-" ++ version, "executables
 
 findProjectConfig
   :: FilePath                          -- ^ Candidate (init: the directory Agda was called in)
-  -> IO (Maybe (FilePath, [FilePath])) -- ^ Actual root and @.agda-lib@ files for this project
-findProjectConfig root = do
-  libs <- map (root </>) . filter ((== ".agda-lib") . takeExtension) <$> getDirectoryContents root
-  case libs of
-    []    -> do
-      -- Note that "going up" one directory is OS dependent
-      -- if the directory is a symlink.
-      --
-      -- Quoting from https://hackage.haskell.org/package/directory-1.3.6.1/docs/System-Directory.html#v:canonicalizePath :
-      --
-      --   Note that on Windows parent directories .. are always fully
-      --   expanded before the symbolic links, as consistent with the
-      --   rest of the Windows API (such as GetFullPathName). In
-      --   contrast, on POSIX systems parent directories .. are
-      --   expanded alongside symbolic links from left to right. To
-      --   put this more concretely: if L is a symbolic link for R/P,
-      --   then on Windows L\.. refers to ., whereas on other
-      --   operating systems L/.. refers to R.
+  -> LibM ProjectConfig                -- ^ Actual root and @.agda-lib@ files for this project
+findProjectConfig root = mkLibM [] $ findProjectConfig' root
+
+findProjectConfig'
+  :: FilePath                          -- ^ Candidate (init: the directory Agda was called in)
+  -> LibErrorIO ProjectConfig          -- ^ Actual root and @.agda-lib@ files for this project
+findProjectConfig' root = do
+  getCachedProjectConfig root >>= \case
+    Just conf -> return conf
+    Nothing   -> do
+      libFiles <- liftIO $ filter ((== ".agda-lib") . takeExtension) <$> getDirectoryContents root
+      case libFiles of
+        []     -> liftIO (upPath root) >>= \case
+          Just up -> do
+            conf <- findProjectConfig' up
+            storeCachedProjectConfig root conf
+            return conf
+          Nothing -> return DefaultProjectConfig
+        files -> do
+          let conf = ProjectConfig root files
+          storeCachedProjectConfig root conf
+          return conf
+
+  where
+    -- Note that "going up" one directory is OS dependent
+    -- if the directory is a symlink.
+    --
+    -- Quoting from https://hackage.haskell.org/package/directory-1.3.6.1/docs/System-Directory.html#v:canonicalizePath :
+    --
+    --   Note that on Windows parent directories .. are always fully
+    --   expanded before the symbolic links, as consistent with the
+    --   rest of the Windows API (such as GetFullPathName). In
+    --   contrast, on POSIX systems parent directories .. are
+    --   expanded alongside symbolic links from left to right. To
+    --   put this more concretely: if L is a symbolic link for R/P,
+    --   then on Windows L\.. refers to ., whereas on other
+    --   operating systems L/.. refers to R.
+    upPath :: FilePath -> IO (Maybe FilePath)
+    upPath root = do
       up <- canonicalizePath $ root </> ".."
-      if up == root then return Nothing else findProjectConfig up
-    files -> return (Just (root, files))
+      if up == root then return Nothing else return $ Just up
+
 
 -- | Get project root
 
-findProjectRoot :: FilePath -> IO (Maybe FilePath)
-findProjectRoot root = fmap fst <$> findProjectConfig root
-
--- | Get pathes of @.agda-lib@ files in given project root.
-
-findAgdaLibFiles
-  :: FilePath       -- ^ Project root.
-  -> IO [FilePath]  -- ^ Pathes of @.agda-lib@ files for this project (if any).
-findAgdaLibFiles root = maybe [] snd <$> findProjectConfig root
+findProjectRoot :: FilePath -> LibM (Maybe FilePath)
+findProjectRoot root = findProjectConfig root <&> \case
+  ProjectConfig p _    -> Just p
+  DefaultProjectConfig -> Nothing
 
 -- | Get the contents of @.agda-lib@ files in the given project root.
 getAgdaLibFiles :: FilePath -> LibM [AgdaLibFile]
 getAgdaLibFiles root = mkLibM [] $ getAgdaLibFiles' root
 
 getAgdaLibFiles' :: FilePath -> LibErrorIO [AgdaLibFile]
-getAgdaLibFiles' root = do
-  libs <- lift $ findAgdaLibFiles root
-  parseLibFiles Nothing (map (0,) libs)
+getAgdaLibFiles' path = findProjectConfig' path >>= \case
+  DefaultProjectConfig    -> return []
+  ProjectConfig root libs -> parseLibFiles Nothing $ map ((0,) . (root </>)) libs
 
 -- | Get dependencies and include paths for given project root:
 --
@@ -222,10 +242,10 @@ getDefaultLibraries root optDefaultLibs = mkLibM [] $ do
 --
 readDefaultsFile :: LibErrorIO [LibName]
 readDefaultsFile = do
-    agdaDir <- lift $ getAgdaAppDir
+    agdaDir <- liftIO getAgdaAppDir
     let file = agdaDir </> defaultsFile
-    ifNotM (lift $ doesFileExist file) (return []) $ {-else-} do
-      ls <- lift $ map snd . stripCommentLines <$> readFile file
+    ifNotM (liftIO $ doesFileExist file) (return []) $ {-else-} do
+      ls <- liftIO $ map snd . stripCommentLines <$> readFile file
       return $ concatMap splitCommas ls
   `catchIO` \ e -> do
     raiseErrors' [ OtherError $ unlines ["Failed to read defaults file.", show e] ]
@@ -260,10 +280,10 @@ getInstalledLibraries
   :: Maybe FilePath     -- ^ Override the default @libraries@ file?
   -> LibM [AgdaLibFile] -- ^ Content of library files.  (Might have empty @LibName@s.)
 getInstalledLibraries overrideLibFile = mkLibM [] $ do
-    file <- lift $ getLibrariesFile overrideLibFile
+    file <- liftIO $ getLibrariesFile overrideLibFile
     if not (lfExists file) then return [] else do
-      ls    <- lift $ stripCommentLines <$> readFile (lfPath file)
-      files <- lift $ sequence [ (i, ) <$> expandEnvironmentVariables s | (i, s) <- ls ]
+      ls    <- liftIO $ stripCommentLines <$> readFile (lfPath file)
+      files <- liftIO $ sequence [ (i, ) <$> expandEnvironmentVariables s | (i, s) <- ls ]
       parseLibFiles (Just file) $ nubOn snd files
   `catchIO` \ e -> do
     raiseErrors' [ OtherError $ unlines ["Failed to read installed libraries.", show e] ]
@@ -276,10 +296,22 @@ parseLibFiles
   -> [(LineNumber, FilePath)]  -- ^ Library files paired with their line number in @libraries@.
   -> LibErrorIO [AgdaLibFile]  -- ^ Content of library files.  (Might have empty @LibName@s.)
 parseLibFiles mlibFile files = do
-  rs' <- lift $ mapM (parseLibFile . snd) files
-  let ann (ln, fp) (e, ws) = (first (Just pos,) e, map (LibWarning (Just pos)) ws)
-        where pos = LibPositionInfo (lfPath <$> mlibFile) ln fp
-  let (xs, warns) = unzip $ zipWith ann files (map runP rs')
+
+  anns <- forM files $ \(ln, file) -> do
+    getCachedAgdaLibFile file >>= \case
+      Just lib -> return (Right lib, [])
+      Nothing  -> do
+        (e, ws) <- liftIO $ runP <$> parseLibFile file
+        let pos = LibPositionInfo (lfPath <$> mlibFile) ln file
+            ws' = map (LibWarning (Just pos)) ws
+        case e of
+          Left err -> do
+            return (Left (Just pos, err), ws')
+          Right lib -> do
+            storeCachedAgdaLibFile file lib
+            return (Right lib, ws')
+
+  let (xs, warns) = unzip anns
       (errs, als) = partitionEithers xs
 
   unless (null warns) $ warnings $ concat warns
@@ -317,10 +349,10 @@ getExecutablesFile = do
 getTrustedExecutables
   :: LibM (Map ExeName FilePath)  -- ^ Content of @executables@ files.
 getTrustedExecutables = mkLibM [] $ do
-    file <- lift $ getExecutablesFile
+    file <- liftIO getExecutablesFile
     if not (efExists file) then return Map.empty else do
-      es    <- lift $ stripCommentLines <$> readFile (efPath file)
-      files <- lift $ sequence [ (i, ) <$> expandEnvironmentVariables s | (i, s) <- es ]
+      es    <- liftIO $ stripCommentLines <$> readFile (efPath file)
+      files <- liftIO $ sequence [ (i, ) <$> expandEnvironmentVariables s | (i, s) <- es ]
       tmp   <- parseExecutablesFile file $ nubOn snd files
       return tmp
   `catchIO` \ e -> do
@@ -337,14 +369,14 @@ parseExecutablesFile ef files =
   fmap (Map.fromList . catMaybes) . forM files $ \(ln, fp) -> do
 
     -- Check if the executable exists.
-    fpExists <- lift $ doesFileExist fp
+    fpExists <- liftIO $ doesFileExist fp
     if not fpExists
       then do warnings' [ExeNotFound ef fp]
               return Nothing
       else do
 
       -- Check if the executable is executable.
-      fpPerms <- lift $ getPermissions fp
+      fpPerms <- liftIO $ getPermissions fp
       if not (executable fpPerms)
         then do warnings' [ExeNotExecutable ef fp]
                 return Nothing
@@ -354,7 +386,7 @@ parseExecutablesFile ef files =
         let strExeName  = takeFileName fp
         let strExeName' = fromMaybe strExeName $ stripExtension exeExtension strExeName
         let txtExeName  = T.pack strExeName'
-        exePath <- lift $ makeAbsolute fp
+        exePath <- liftIO $ makeAbsolute fp
         return $ Just (txtExeName, exePath)
 
 ------------------------------------------------------------------------
@@ -368,7 +400,7 @@ libraryIncludePaths
   -> [LibName]       -- ^ (Non-empty) library names to be resolved to (lists of) pathes.
   -> LibM [FilePath] -- ^ Resolved pathes (no duplicates).  Contains "." if @[LibName]@ does.
 libraryIncludePaths overrideLibFile libs xs0 = mkLibM libs $ WriterT $ do
-    file <- getLibrariesFile overrideLibFile
+    file <- liftIO $ getLibrariesFile overrideLibFile
     return $ runWriter $ (dot ++) . incs <$> find file [] xs
   where
     (dots, xs) = List.partition (== libNameForCurrentDir) $ map trim xs0

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -180,7 +180,7 @@ getCachedProjectConfig
   => FilePath -> m (Maybe ProjectConfig)
 getCachedProjectConfig path = do
   path <- liftIO $ canonicalizePath path
-  cache <- fst <$> get
+  cache <- gets fst
   return $ Map.lookup path cache
 
 storeCachedProjectConfig
@@ -195,7 +195,7 @@ getCachedAgdaLibFile
   => FilePath -> m (Maybe AgdaLibFile)
 getCachedAgdaLibFile path = do
   path <- liftIO $ canonicalizePath path
-  Map.lookup path . snd <$> get
+  gets $ Map.lookup path . snd
 
 storeCachedAgdaLibFile
   :: (MonadState LibState m, MonadIO m)

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -54,6 +54,7 @@ data AgdaLibFile = AgdaLibFile
   , _libFile     :: FilePath    -- ^ Path to this @.agda-lib@ file (not content of the file).
   , _libIncludes :: [FilePath]  -- ^ Roots where to look for the modules of the library.
   , _libDepends  :: [LibName]   -- ^ Dependencies.
+  , _libPragmas  :: [String]    -- ^ Default pragma options for all files in the library.
   }
   deriving (Show)
 
@@ -63,6 +64,7 @@ emptyLibFile = AgdaLibFile
   , _libFile     = ""
   , _libIncludes = []
   , _libDepends  = []
+  , _libPragmas  = []
   }
 
 -- | Lenses for AgdaLibFile
@@ -78,6 +80,9 @@ libIncludes f a = f (_libIncludes a) <&> \ x -> a { _libIncludes = x }
 
 libDepends :: Lens' [LibName] AgdaLibFile
 libDepends f a = f (_libDepends a) <&> \ x -> a { _libDepends = x }
+
+libPragmas :: Lens' [String] AgdaLibFile
+libPragmas f a = f (_libPragmas a) <&> \ x -> a { _libPragmas = x }
 
 
 ------------------------------------------------------------------------

--- a/src/full/Agda/Interaction/Library/Parse.hs
+++ b/src/full/Agda/Interaction/Library/Parse.hs
@@ -83,6 +83,7 @@ agdaLibFields =
   [ optionalField "name"    parseName                      libName
   , optionalField "include" (pure . concatMap parsePaths)  libIncludes
   , optionalField "depend"  (pure . concatMap splitCommas) libDepends
+  , optionalField "flags"   (pure . concatMap parseFlags)  libPragmas
   ]
   where
     parseName :: [String] -> P LibName
@@ -97,6 +98,9 @@ agdaLibFields =
       go acc ('\\' : '\\' :cs) = go (acc . ('\\':)) cs
       go acc (       ' '  :cs) = fixup acc ++ go id cs
       go acc (c           :cs) = go (acc . (c:)) cs
+
+    parseFlags :: String -> [String]
+    parseFlags = words
 
 -- | Parse @.agda-lib@ file.
 --

--- a/src/full/Agda/Interaction/Library/Parse.hs
+++ b/src/full/Agda/Interaction/Library/Parse.hs
@@ -250,8 +250,8 @@ splitCommas s = words $ map (\c -> if c == ',' then ' ' else c) s
 -- | ...and trailing, but not leading, whitespace.
 stripComments :: String -> String
 stripComments "" = ""
-stripComments ('-':'-':_) = ""
-stripComments (c : s)     = cons c (stripComments s)
+stripComments ('-':'-':c:_) | isSpace c = ""
+stripComments (c : s) = cons c (stripComments s)
   where
     cons c "" | isSpace c = ""
     cons c s = c : s

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -49,7 +49,7 @@ module Agda.Syntax.Concrete
   , RHS, RHS'(..), WhereClause, WhereClause'(..), ExprWhere(..)
   , DoStmt(..)
   , Pragma(..)
-  , Module
+  , Module(..)
   , ThingWithFixity(..)
   , HoleContent, HoleContent'(..)
   , topLevelModuleName
@@ -498,7 +498,10 @@ data Pragma
 
 -- | Modules: Top-level pragmas plus other top-level declarations.
 
-type Module = ([Pragma], [Declaration])
+data Module = Mod
+  { modPragmas :: [Pragma]
+  , modDecls   :: [Declaration]
+  }
 
 -- | Computes the top-level module name.
 --
@@ -508,8 +511,8 @@ type Module = ([Pragma], [Declaration])
 -- See 'spanAllowedBeforeModule'.
 
 topLevelModuleName :: Module -> TopLevelModuleName
-topLevelModuleName (_, []) = __IMPOSSIBLE__
-topLevelModuleName (_, ds) = case spanAllowedBeforeModule ds of
+topLevelModuleName (Mod _ []) = __IMPOSSIBLE__
+topLevelModuleName (Mod _ ds) = case spanAllowedBeforeModule ds of
   (_, Module _ n _ _ : _) -> toTopLevelModuleName n
   _ -> __IMPOSSIBLE__
 

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -53,6 +53,7 @@ deriving instance Show LamClause
 deriving instance Show WhereClause
 deriving instance Show ModuleApplication
 deriving instance Show DoStmt
+deriving instance Show Module
 
 -- Lays out a list of documents [d₁, d₂, …] in the following way:
 -- @

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -342,7 +342,7 @@ Token
     Top level
  --------------------------------------------------------------------------}
 
-File :: { ([Pragma], [Declaration]) }
+File :: { Module }
 File : vopen TopLevel maybe_vclose { takeOptionsPragmas $2 }
 
 maybe_vclose :: { () }
@@ -1779,10 +1779,10 @@ happyError = parseError "Parse error"
  --------------------------------------------------------------------------}
 
 -- | Grab leading OPTIONS pragmas.
-takeOptionsPragmas :: [Declaration] -> ([Pragma], [Declaration])
-takeOptionsPragmas = spanJust $ \ d -> case d of
+takeOptionsPragmas :: [Declaration] -> Module
+takeOptionsPragmas = uncurry Mod . spanJust (\ d -> case d of
   Pragma p@OptionsPragma{} -> Just p
-  _                        -> Nothing
+  _                        -> Nothing)
 
 -- | Insert a top-level module if there is none.
 --   Also fix-up for the case the declarations in the top-level module

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -297,6 +297,11 @@ data PersistentTCState = PersistentTCSt
     --   Should be @Nothing@ when checking imports.
   , stPersistBackends   :: [Backend]
     -- ^ Current backends with their options
+  , stPersistProjectConfigs :: !(Map FilePath ProjectConfig)
+    -- ^ Map from directories to paths of closest enclosing .agda-lib
+    --   files (or @Nothing@ if there are none).
+  , stPersistAgdaLibFiles   :: !(Map FilePath AgdaLibFile)
+    -- ^ Contents of .agda-lib files that have already been parsed.
   }
 
 data LoadedFileCache = LoadedFileCache
@@ -341,6 +346,8 @@ initPersistentState = PersistentTCSt
   , stAccumStatistics           = Map.empty
   , stPersistLoadedFileCache    = empty
   , stPersistBackends           = []
+  , stPersistProjectConfigs     = Map.empty
+  , stPersistAgdaLibFiles       = Map.empty
   }
 
 -- | Empty state of type checker.
@@ -524,6 +531,16 @@ stBackends :: Lens' [Backend] TCState
 stBackends f s =
   f (stPersistBackends (stPersistentState s)) <&>
   \x -> s {stPersistentState = (stPersistentState s) {stPersistBackends = x}}
+
+stProjectConfigs :: Lens' (Map FilePath ProjectConfig) TCState
+stProjectConfigs f s =
+  f (stPersistProjectConfigs (stPersistentState s)) <&>
+  \ x -> s {stPersistentState = (stPersistentState s) {stPersistProjectConfigs = x}}
+
+stAgdaLibFiles :: Lens' (Map FilePath AgdaLibFile) TCState
+stAgdaLibFiles f s =
+  f (stPersistAgdaLibFiles (stPersistentState s)) <&>
+  \ x -> s {stPersistentState = (stPersistentState s) {stPersistAgdaLibFiles = x}}
 
 stFreshNameId :: Lens' NameId TCState
 stFreshNameId f s =

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -1,10 +1,13 @@
 
 module Agda.TypeChecking.Monad.Options where
 
+import Control.Arrow ( (&&&) )
 import Control.Monad.Except
 import Control.Monad.Reader
+import Control.Monad.State
 import Control.Monad.Writer
 
+import Data.Functor
 import Data.Maybe
 
 import System.Directory
@@ -78,7 +81,14 @@ setCommandLineOptions' root opts = do
 
 libToTCM :: LibM a -> TCM a
 libToTCM m = do
-  (z, warns) <- liftIO $ runWriterT $ runExceptT m
+  cachedConfs <- useTC stProjectConfigs
+  cachedLibs  <- useTC stAgdaLibFiles
+
+  ((z, warns), (cachedConfs', cachedLibs')) <- liftIO $
+    (`runStateT` (cachedConfs, cachedLibs)) $ runWriterT $ runExceptT m
+
+  modifyTCLens stProjectConfigs $ const cachedConfs'
+  modifyTCLens stAgdaLibFiles   $ const cachedLibs'
 
   unless (null warns) $ warnings $ map LibraryWarning warns
   case z of
@@ -202,8 +212,12 @@ setIncludeDirs incs root = do
   when (oldIncs /= incs) $ do
     ho <- getInteractionOutputCallback
     tcWarnings <- useTC stTCWarnings -- restore already generated warnings
+    projectConfs <- useTC stProjectConfigs  -- restore cached project configs & .agda-lib
+    agdaLibFiles <- useTC stAgdaLibFiles    -- files, since they use absolute paths
     resetAllState
     setTCLens stTCWarnings tcWarnings
+    setTCLens stProjectConfigs projectConfs
+    setTCLens stAgdaLibFiles agdaLibFiles
     setInteractionOutputCallback ho
 
   Lens.putAbsoluteIncludePaths incs

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -7,7 +7,6 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Writer
 
-import Data.Functor
 import Data.Maybe
 
 import System.Directory
@@ -22,6 +21,7 @@ import Agda.Interaction.Options
 import qualified Agda.Interaction.Options.Lenses as Lens
 import Agda.Interaction.Library
 import Agda.Utils.FileName
+import Agda.Utils.Functor
 import Agda.Utils.Maybe
 import Agda.Utils.Pretty
 import Agda.Utils.WithDefault

--- a/src/full/Agda/Utils/IO.hs
+++ b/src/full/Agda/Utils/IO.hs
@@ -3,6 +3,7 @@
 module Agda.Utils.IO where
 
 import Control.Exception
+import Control.Monad.State
 import Control.Monad.Writer
 
 -- | Catch 'IOException's.
@@ -19,3 +20,8 @@ instance CatchIO IO where
 --
 instance CatchIO m => CatchIO (WriterT w m) where
   catchIO m h = WriterT $ runWriterT m `catchIO` \ e -> runWriterT (h e)
+
+-- | Upon exception, the state is reset.
+--
+instance CatchIO m => CatchIO (StateT s m) where
+  catchIO m h = StateT $ \s -> runStateT m s `catchIO` \ e -> runStateT (h e) s

--- a/test/Succeed/default-flags/DefaultFlags.agda
+++ b/test/Succeed/default-flags/DefaultFlags.agda
@@ -1,0 +1,2 @@
+
+test = Prop

--- a/test/Succeed/default-flags/DefaultFlags.flags
+++ b/test/Succeed/default-flags/DefaultFlags.flags
@@ -1,0 +1,3 @@
+-itest/Succeed/default-flags
+--library-file=test/Succeed/default-flags/libraries
+--library=lib

--- a/test/Succeed/default-flags/lib.agda-lib
+++ b/test/Succeed/default-flags/lib.agda-lib
@@ -1,0 +1,2 @@
+name: lib
+flags: --prop

--- a/test/Succeed/default-flags/libraries
+++ b/test/Succeed/default-flags/libraries
@@ -1,0 +1,1 @@
+test/Succeed/default-flags/lib.agda-lib


### PR DESCRIPTION
This PR consists of two main changes:

1. It fixes #3118, i.e. it adds a `flags:` field to the format of `.agda-lib` files
2. It adds caching of the project configs (i.e. locations of nearest `.agda-lib` files) and the parsed `.agda-lib` files themselves, which should improve (but not completely fix) #4526 .

The reason I've made this into a single PR is that the change in 1. introduced some duplicate warnings which were easiest to fix by adding the caching from 2.