### PR TITLE
Reuse existing meta variables in postponed projection applications

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -439,7 +439,7 @@ instance Reify Constraint where
               t0 <- reify t0
               t1 <- reify t1
               return $ PostponedCheckArgs m' (map (namedThing . unArg) args) t0 t1
-            CheckProjAppToKnownPrincipalArg cmp e _ _ _ t _ _ _ -> TypedAssign m' e <$> reify t
+            CheckProjAppToKnownPrincipalArg cmp e _ _ _ t _ _ _ _ -> TypedAssign m' e <$> reify t
             DoQuoteTerm cmp v t -> do
               tm <- A.App defaultAppInfo_ (A.QuoteTerm exprNoRange) . defaultNamedArg <$> reify v
               OfType tm <$> reify t

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -300,8 +300,8 @@ checkTypeCheckingProblem :: TypeCheckingProblem -> TCM Term
 checkTypeCheckingProblem p = case p of
   CheckExpr cmp e t              -> checkExpr' cmp e t
   CheckArgs eh r args t0 t1 k    -> checkArguments eh r args t0 t1 k
-  CheckProjAppToKnownPrincipalArg cmp e o ds args t k v0 pt at ->
-    checkProjAppToKnownPrincipalArg cmp e o ds args t k v0 pt at
+  CheckProjAppToKnownPrincipalArg cmp e o ds args t k v0 pt patm ->
+    checkProjAppToKnownPrincipalArg cmp e o ds args t k v0 pt patm
   CheckLambda cmp args body target -> checkPostponedLambda cmp args body target
   DoQuoteTerm cmp et t           -> doQuoteTerm cmp et t
 

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -300,8 +300,8 @@ checkTypeCheckingProblem :: TypeCheckingProblem -> TCM Term
 checkTypeCheckingProblem p = case p of
   CheckExpr cmp e t              -> checkExpr' cmp e t
   CheckArgs eh r args t0 t1 k    -> checkArguments eh r args t0 t1 k
-  CheckProjAppToKnownPrincipalArg cmp e o ds args t k v0 pt ->
-    checkProjAppToKnownPrincipalArg cmp e o ds args t k v0 pt
+  CheckProjAppToKnownPrincipalArg cmp e o ds args t k v0 pt at ->
+    checkProjAppToKnownPrincipalArg cmp e o ds args t k v0 pt at
   CheckLambda cmp args body target -> checkPostponedLambda cmp args body target
   DoQuoteTerm cmp et t           -> doQuoteTerm cmp et t
 

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -439,7 +439,7 @@ postponeTypeCheckingProblem_ p = do
   where
     unblock (CheckExpr _ _ t)         = unblockedTester t
     unblock (CheckArgs _ _ _ t _ _)   = unblockedTester t  -- The type of the head of the application.
-    unblock (CheckProjAppToKnownPrincipalArg _ _ _ _ _ _ _ _ t) = unblockedTester t -- The type of the principal argument
+    unblock (CheckProjAppToKnownPrincipalArg _ _ _ _ _ _ _ _ t _) = unblockedTester t -- The type of the principal argument
     unblock (CheckLambda _ _ _ t)     = unblockedTester t
     unblock (DoQuoteTerm _ _ _)       = __IMPOSSIBLE__     -- also quoteTerm problems
 
@@ -484,7 +484,7 @@ postponeTypeCheckingProblem p unblock = do
 problemType :: TypeCheckingProblem -> Type
 problemType (CheckExpr _ _ t         ) = t
 problemType (CheckArgs _ _ _ _ t _ )   = t  -- The target type of the application.
-problemType (CheckProjAppToKnownPrincipalArg _ _ _ _ _ t _ _ _) = t -- The target type of the application
+problemType (CheckProjAppToKnownPrincipalArg _ _ _ _ _ t _ _ _ _) = t -- The target type of the application
 problemType (CheckLambda _ _ _ t     ) = t
 problemType (DoQuoteTerm _ _ t)        = t
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1264,10 +1264,17 @@ data MetaInstantiation
 data CheckedTarget = CheckedTarget (Maybe ProblemId)
                    | NotCheckedTarget
 
+data PrincipalArgTypeMetas = PrincipalArgTypeMetas
+  { patmMetas     :: Args -- ^ metas created for hidden and instance arguments
+                          --   in the principal argument's type
+  , patmRemainder :: Type -- ^ principal argument's type, stripped of hidden and
+                          --   instance arguments
+  }
+
 data TypeCheckingProblem
   = CheckExpr Comparison A.Expr Type
   | CheckArgs ExpandHidden Range [NamedArg A.Expr] Type Type (ArgsCheckState CheckedTarget -> TCM Term)
-  | CheckProjAppToKnownPrincipalArg Comparison A.Expr ProjOrigin (List1 QName) A.Args Type Int Term Type (Args, Type)
+  | CheckProjAppToKnownPrincipalArg Comparison A.Expr ProjOrigin (List1 QName) A.Args Type Int Term Type PrincipalArgTypeMetas
   | CheckLambda Comparison (Arg (List1 (WithHiding Name), Maybe Type)) A.Expr Type
     -- ^ @(λ (xs : t₀) → e) : t@
     --   This is not an instance of 'CheckExpr' as the domain type

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1267,7 +1267,7 @@ data CheckedTarget = CheckedTarget (Maybe ProblemId)
 data TypeCheckingProblem
   = CheckExpr Comparison A.Expr Type
   | CheckArgs ExpandHidden Range [NamedArg A.Expr] Type Type (ArgsCheckState CheckedTarget -> TCM Term)
-  | CheckProjAppToKnownPrincipalArg Comparison A.Expr ProjOrigin (List1 QName) A.Args Type Int Term Type
+  | CheckProjAppToKnownPrincipalArg Comparison A.Expr ProjOrigin (List1 QName) A.Args Type Int Term Type (Args, Type)
   | CheckLambda Comparison (Arg (List1 (WithHiding Name), Maybe Type)) A.Expr Type
     -- ^ @(λ (xs : t₀) → e) : t@
     --   This is not an instance of 'CheckExpr' as the domain type

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -302,7 +302,7 @@ instance PrettyTCM TypeCheckingProblem where
     sep [ parens $ "_ :" <+> prettyTCM t0
         , nest 2 $ prettyList $ map prettyA es
         , nest 2 $ ":?" <+> prettyTCM t1 ]
-  prettyTCM (CheckProjAppToKnownPrincipalArg cmp e _ _ _ t _ _ _) = prettyTCM (CheckExpr cmp e t)
+  prettyTCM (CheckProjAppToKnownPrincipalArg cmp e _ _ _ t _ _ _ _) = prettyTCM (CheckExpr cmp e t)
   prettyTCM (CheckLambda cmp (Arg ai (xs, mt)) e t) =
     sep [ pure CP.lambda <+>
           (CP.prettyRelevance ai .

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1077,14 +1077,14 @@ inferOrCheckProjAppToKnownPrincipalArg e o ds args mt k v0 ta mpatm = do
         v <- postponeTypeCheckingProblem (CheckProjAppToKnownPrincipalArg cmp e o ds args tc k v0 ta patm) b
         return (v, tc, NotCheckedTarget)
   -- ta should be a record type (after introducing the hidden args in v0)
-  PrincipalArgTypeMetas vargs ta <- case mpatm of
+  patm@(PrincipalArgTypeMetas vargs ta) <- case mpatm of
     -- keep using the previously created metas, when picking up a postponed
     -- problem - see #4924
     Just patm -> return patm
     -- create fresh metas
     Nothing -> uncurry PrincipalArgTypeMetas <$> implicitArgs (-1) (not . visible) ta
   let v = v0 `apply` vargs
-  ifBlocked ta (\ m _ -> postpone m (PrincipalArgTypeMetas vargs ta)) {-else-} $ \ _ ta -> do
+  ifBlocked ta (\ m _ -> postpone m patm) {-else-} $ \ _ ta -> do
   caseMaybeM (isRecordType ta) (refuseProjNotRecordType ds) $ \ (q, _pars0, _) -> do
 
       -- try to project it with all of the possible projections

--- a/src/full/Agda/TypeChecking/Rules/Application.hs-boot
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs-boot
@@ -19,4 +19,4 @@ checkApplication :: Comparison -> A.Expr -> A.Args -> A.Expr -> Type -> TCM Term
 
 inferApplication :: ExpandHidden -> A.Expr -> A.Args -> A.Expr -> TCM (Term, Type)
 
-checkProjAppToKnownPrincipalArg  :: Comparison -> A.Expr -> ProjOrigin -> NonEmpty QName -> A.Args -> Type -> Int -> Term -> Type -> TCM Term
+checkProjAppToKnownPrincipalArg  :: Comparison -> A.Expr -> ProjOrigin -> NonEmpty QName -> A.Args -> Type -> Int -> Term -> Type -> (Args, Type) -> TCM Term

--- a/src/full/Agda/TypeChecking/Rules/Application.hs-boot
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs-boot
@@ -19,4 +19,4 @@ checkApplication :: Comparison -> A.Expr -> A.Args -> A.Expr -> Type -> TCM Term
 
 inferApplication :: ExpandHidden -> A.Expr -> A.Args -> A.Expr -> TCM (Term, Type)
 
-checkProjAppToKnownPrincipalArg  :: Comparison -> A.Expr -> ProjOrigin -> NonEmpty QName -> A.Args -> Type -> Int -> Term -> Type -> (Args, Type) -> TCM Term
+checkProjAppToKnownPrincipalArg  :: Comparison -> A.Expr -> ProjOrigin -> NonEmpty QName -> A.Args -> Type -> Int -> Term -> Type -> PrincipalArgTypeMetas -> TCM Term

--- a/test/Fail/Issue4924.agda
+++ b/test/Fail/Issue4924.agda
@@ -1,0 +1,15 @@
+module Issue4924 where
+
+record R (T : Set) : Set where
+  field
+    f : T → T
+
+module _ {A B : Set} (ra : R A) (rb : R B) (pri : {T : Set} → {{r : R T}} → T) where
+  open R ra
+  open R rb
+
+  instance
+    _ = ra
+
+  _ : A
+  _ = f pri

--- a/test/Fail/Issue4924.err
+++ b/test/Fail/Issue4924.err
@@ -1,0 +1,4 @@
+Issue4924.agda:15,7-12
+Cannot resolve overloaded projection f because principal argument
+is not of record type
+when checking that the expression f pri has type A


### PR DESCRIPTION
A proposal for addressing #4924. 

Suppose that `f` is an ambiguous projection. #4924 shows that applying it to a principal argument `pri : {T : Set} → {{r : R T}} → T` makes the type checker loop forever.

When type checking `f pri`, two new meta variables are created for the implicit / instance arguments of `pri`: `T` and `r`. The type of `pri` only becomes known, once these meta variables have been solved. Hence, the type check gets postponed until then.

However, when the postponed type check is picked up again, it does not use the now solved meta variables for `T` and `r`. Instead, it again creates new meta variables. Hence, the type check gets postponed again. And so on.

The idea underlying this proposal is to stash the created meta variables into `CheckProjAppToKnownPrincipalArg` when postponing the type check problem, and to extract them again when picking up the postponed problem, instead of using new meta variables:

  * `CheckProjAppToKnownPrincipalArg` is extended by one more argument so that it can hold the `(vargs, ta)` obtained right at the beginning of `inferOrCheckProjAppToKnownPrincipalArg` from `implicitArgs`. We thus capture the result from `implicitArgs` for later reuse.

  *  `inferOrCheckProjAppToKnownPrincipalArg` gets an additional parameter, `mat`, which is `Just (vargs, ta)` when the postponed type check gets picked up and, otherwise, `Nothing`. `Nothing` triggers creation of new meta variables via `implicitArgs`. `Just _` triggers reuse of the given / previously captured `implicitArgs` result.

The other changes to the code mechanically follow from that.

While the proposal fixes the issue and doesn't break any tests, I cannot say with confidence that there isn't any adverse impact on other parts of the type checker. I simply don't know it well enough. On the other hand, the code touched by the changes is specific to postponed ambiguous projections. I wouldn't expect this to cause trouble anywhere else.

More details can be found in #4924. 
