### PR TITLE
Just a batch of refactors

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -468,6 +468,7 @@ library
                     Agda.TypeChecking.Monad.Mutual
                     Agda.TypeChecking.Monad.Open
                     Agda.TypeChecking.Monad.Options
+                    Agda.TypeChecking.Monad.Pure
                     Agda.TypeChecking.Monad.Signature
                     Agda.TypeChecking.Monad.SizedTypes
                     Agda.TypeChecking.Monad.State

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -144,14 +144,9 @@ reifyWhenE False t = return underscore
 -- Reification ------------------------------------------------------------
 
 type MonadReify m =
-  ( MonadReduce m
-  , MonadAddContext m
+  ( PureTCM m
   , MonadInteractionPoints m
   , MonadFresh NameId m
-  , HasConstInfo m
-  , HasOptions m
-  , HasBuiltins m
-  , MonadDebug m
   )
 
 class Reify i where

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -192,6 +192,7 @@ newtype TerM a = TerM { terM :: ReaderT TerEnv TCM a }
            , ReadTCState
            , MonadReduce
            , MonadAddContext
+           , PureTCM
            )
 
 -- This could be derived automatically, but the derived type family becomes `BenchPhase (ReaderT TerEnv TCM)` which

--- a/src/full/Agda/TypeChecking/CheckInternal.hs-boot
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs-boot
@@ -12,19 +12,14 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Warnings
 
 type MonadCheckInternal m =
-  ( MonadReduce m
-  , MonadAddContext m
+  ( PureTCM m
   , MonadConstraint m
   , MonadMetaSolver m
   , MonadError TCErr m
   , MonadWarning m
-  , MonadDebug m
   , MonadStatistics m
   , MonadFresh ProblemId m
   , MonadFresh Int m
-  , HasBuiltins m
-  , HasConstInfo m
-  , HasOptions m
   , Fail.MonadFail m
   )
 

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -60,19 +60,14 @@ import Agda.Utils.WithDefault
 import Agda.Utils.Impossible
 
 type MonadConversion m =
-  ( MonadReduce m
-  , MonadAddContext m
+  ( PureTCM m
   , MonadConstraint m
   , MonadMetaSolver m
   , MonadError TCErr m
   , MonadWarning m
-  , MonadDebug m
   , MonadStatistics m
   , MonadFresh ProblemId m
   , MonadFresh Int m
-  , HasBuiltins m
-  , HasConstInfo m
-  , HasOptions m
   , MonadFail m
   )
 

--- a/src/full/Agda/TypeChecking/Conversion.hs-boot
+++ b/src/full/Agda/TypeChecking/Conversion.hs-boot
@@ -9,19 +9,14 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Warnings
 
 type MonadConversion m =
-  ( MonadReduce m
-  , MonadAddContext m
+  ( PureTCM m
   , MonadConstraint m
   , MonadMetaSolver m
   , MonadError TCErr m
   , MonadWarning m
-  , MonadDebug m
   , MonadStatistics m
   , MonadFresh ProblemId m
   , MonadFresh Int m
-  , HasBuiltins m
-  , HasConstInfo m
-  , HasOptions m
   , Fail.MonadFail m
   )
 

--- a/src/full/Agda/TypeChecking/Conversion/Pure.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Pure.hs
@@ -38,6 +38,12 @@ pureEqualTerm
 pureEqualTerm a u v =
   isRight <$> runPureConversion (equalTerm a u v)
 
+pureEqualType
+  :: (MonadReduce m, MonadAddContext m, MonadBlock m, HasBuiltins m, HasConstInfo m)
+  => Type -> Type -> m Bool
+pureEqualType a b =
+  isRight <$> runPureConversion (equalType a b)
+
 pureCompareAs
   :: (MonadReduce m, MonadAddContext m, MonadBlock m, HasBuiltins m, HasConstInfo m)
   => Comparison -> CompareAs -> Term -> Term -> m Bool

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -1134,12 +1134,18 @@ computeNeighbourhood delta1 n delta2 d pars ixs hix tel ps cps c = do
          conIxs
          givenIxs
 
+  let stuck errs = do
+        debugCantSplit
+        throwError $ UnificationStuck (conName con) (delta1 `abstract` gamma) conIxs givenIxs errs
+
+
   case r of
     NoUnify {} -> debugNoUnify $> Nothing
 
-    DontKnow errs -> do
-      debugCantSplit
-      throwError $ UnificationStuck (conName con) (delta1 `abstract` gamma) conIxs givenIxs errs
+    UnifyBlocked block -> stuck [] -- TODO: postpone and retry later
+
+    UnifyStuck errs -> stuck errs
+
     Unifies (delta1',rho0,_) -> do
       debugSubst "rho0" rho0
 

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -100,13 +100,13 @@ type SplitInstantiation = [(Nat,SplitPattern)]
 --
 -- If successful, return the index of the covering clause.
 --
-match :: (MonadReduce m , HasConstInfo m , HasBuiltins m)
+match :: PureTCM m
       => [Clause]                           -- ^ Search for clause that covers the patterns.
       -> [NamedArg SplitPattern]            -- ^ Patterns of the current 'SplitClause'.
       -> m (Match (Nat, SplitInstantiation))
 match cs ps = foldr choice (return No) $ zipWith matchIt [0..] cs
   where
-    matchIt :: (MonadReduce m , HasConstInfo m , HasBuiltins m)
+    matchIt :: PureTCM m
             => Nat     -- ^ Clause number.
             -> Clause
             -> m (Match (Nat, SplitInstantiation))
@@ -307,7 +307,7 @@ choice m m' = m >>= \case
 -- | @matchClause qs i c@ checks whether clause @c@
 --   covers a split clause with patterns @qs@.
 matchClause
-  :: (MonadReduce m , HasConstInfo m , HasBuiltins m)
+  :: PureTCM m
   => [NamedArg SplitPattern]
      -- ^ Split clause patterns @qs@.
   -> Clause
@@ -334,7 +334,7 @@ matchClause qs c = matchPats (namedClausePats c) qs
 --   in @mconcat []@ which is @Yes []@.
 
 matchPats
-  :: (MonadReduce m , HasConstInfo m , HasBuiltins m, DeBruijn a)
+  :: (PureTCM m, DeBruijn a)
   => [NamedArg (Pattern' a)]
      -- ^ Clause pattern vector @ps@ (to cover split clause pattern vector).
   -> [NamedArg SplitPattern]
@@ -397,7 +397,7 @@ combine m m' = m >>= \case
 --      a cover if @q@ was split on variable @x@.
 
 matchPat
-  :: (MonadReduce m , HasConstInfo m , HasBuiltins m, DeBruijn a)
+  :: (PureTCM m, DeBruijn a)
   => Pattern' a
      -- ^ Clause pattern @p@ (to cover split clause pattern).
   -> SplitPattern
@@ -467,7 +467,7 @@ unDotP (DotP o v) = reduce v >>= \case
   v     -> return $ dotP v
 unDotP p = return p
 
-isLitP :: (MonadReduce m, HasBuiltins m) => Pattern' a -> m (Maybe Literal)
+isLitP :: PureTCM m => Pattern' a -> m (Maybe Literal)
 isLitP (LitP _ l) = return $ Just l
 isLitP (DotP _ u) = reduce u >>= \case
   Lit l -> return $ Just l

--- a/src/full/Agda/TypeChecking/Datatypes.hs
+++ b/src/full/Agda/TypeChecking/Datatypes.hs
@@ -56,7 +56,7 @@ getConstructorData c = do
 
 -- | Is the datatype of this constructor a Higher Inductive Type?
 --   Precondition: The argument must refer to a constructor of a datatype or record.
-consOfHIT :: QName -> TCM Bool
+consOfHIT :: HasConstInfo m => QName -> m Bool
 consOfHIT c = do
   d <- getConstructorData c
   def <- theDef <$> getConstInfo d

--- a/src/full/Agda/TypeChecking/Datatypes.hs
+++ b/src/full/Agda/TypeChecking/Datatypes.hs
@@ -73,7 +73,7 @@ consOfHIT c = do
 --   @Nothing@ if @t@ is not a data/record type or does not have
 --   a constructor @c@.
 getConType
-  :: (MonadReduce m, MonadAddContext m, HasConstInfo m, MonadDebug m, HasBuiltins m)
+  :: PureTCM m
   => ConHead  -- ^ Constructor.
   -> Type     -- ^ Ending in data/record type.
   -> m (Maybe ((QName, Type, Args), Type))
@@ -118,7 +118,7 @@ getConType c t = do
 --
 --   Precondition: @t@ is reduced.
 getFullyAppliedConType
-  :: (HasConstInfo m, MonadReduce m, MonadDebug m, HasBuiltins m)
+  :: PureTCM m
   => ConHead  -- ^ Constructor.
   -> Type     -- ^ Reduced type of the fully applied constructor.
   -> m (Maybe ((QName, Type, Args), Type))

--- a/src/full/Agda/TypeChecking/EtaExpand.hs
+++ b/src/full/Agda/TypeChecking/EtaExpand.hs
@@ -12,9 +12,7 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 
 -- | Eta-expand a term if its type is a function type or an eta-record type.
-etaExpandOnce
-  :: (MonadReduce m, MonadTCEnv m, HasOptions m, HasConstInfo m, MonadDebug m)
-  => Type -> Term -> m Term
+etaExpandOnce :: PureTCM m => Type -> Term -> m Term
 etaExpandOnce a v = reduce a >>= \case
   El _ (Pi a b) -> return $
     Lam ai $ mkAbs (absName b) $ raise 1 v `apply` [ Arg ai $ var 0 ]
@@ -32,9 +30,7 @@ etaExpandOnce a v = reduce a >>= \case
 deepEtaExpand :: Term -> Type -> TCM Term
 deepEtaExpand v a = checkInternal' etaExpandAction v CmpLeq a
 
-etaExpandAction
-  :: (MonadReduce m, MonadTCEnv m, HasOptions m, HasConstInfo m, MonadDebug m)
-  => Action m
+etaExpandAction :: PureTCM m => Action m
 etaExpandAction = Action
   { preAction       = etaExpandOnce
   , postAction      = \ _ -> return

--- a/src/full/Agda/TypeChecking/Implicit.hs
+++ b/src/full/Agda/TypeChecking/Implicit.hs
@@ -32,8 +32,7 @@ import Agda.Utils.Tuple
 
 -- | Insert implicit binders in a list of binders, but not at the end.
 insertImplicitBindersT
-  :: (HasBuiltins m, MonadReduce m, MonadAddContext m, MonadError TCErr m,
-      MonadFresh NameId m, MonadTrace m, MonadDebug m)
+  :: (PureTCM m, MonadError TCErr m, MonadFresh NameId m, MonadTrace m)
   => [NamedArg Binder]     -- ^ Should be non-empty, otherwise nothing happens.
   -> Type                  -- ^ Function type eliminated by arguments given by binders.
   -> m [NamedArg Binder] -- ^ Padded binders.
@@ -43,8 +42,7 @@ insertImplicitBindersT = \case
 
 -- | Insert implicit binders in a list of binders, but not at the end.
 insertImplicitBindersT1
-  :: (HasBuiltins m, MonadReduce m, MonadAddContext m, MonadError TCErr m,
-      MonadFresh NameId m, MonadTrace m, MonadDebug m)
+  :: (PureTCM m, MonadError TCErr m, MonadFresh NameId m, MonadTrace m)
   => List1 (NamedArg Binder)        -- ^ Non-empty.
   -> Type                           -- ^ Function type eliminated by arguments given by binders.
   -> m (List1 (NamedArg Binder))  -- ^ Padded binders.
@@ -86,7 +84,7 @@ insertImplicitBindersT1 bs@(b :| _) a = setCurrentRange b $ do
 --   and @expand@ holds on the hiding info of its domain.
 
 implicitArgs
-  :: (MonadReduce m, MonadMetaSolver m, MonadDebug m, MonadTCM m)
+  :: (PureTCM m, MonadMetaSolver m, MonadTCM m)
   => Int               -- ^ @n@, the maximum number of implicts to be inserted.
   -> (Hiding -> Bool)  -- ^ @expand@, the predicate to test whether we should keep inserting.
   -> Type              -- ^ The (function) type @t@ we are eliminating.
@@ -99,7 +97,7 @@ implicitArgs n expand t = mapFst (map (fmap namedThing)) <$> do
 --   and @expand@ holds on the hiding and name info of its domain.
 
 implicitNamedArgs
-  :: (MonadReduce m, MonadMetaSolver m, MonadDebug m, MonadTCM m)
+  :: (PureTCM m, MonadMetaSolver m, MonadTCM m)
   => Int                          -- ^ @n@, the maximum number of implicts to be inserted.
   -> (Hiding -> ArgName -> Bool)  -- ^ @expand@, the predicate to test whether we should keep inserting.
   -> Type                         -- ^ The (function) type @t@ we are eliminating.
@@ -130,7 +128,7 @@ implicitNamedArgs n expand t0 = do
 -- | Create a metavariable according to the 'Hiding' info.
 
 newMetaArg
-  :: MonadMetaSolver m
+  :: (PureTCM m, MonadMetaSolver m)
   => ArgInfo    -- ^ Kind/relevance of meta.
   -> ArgName    -- ^ Name suggestion for meta.
   -> Comparison -- ^ Check (@CmpLeq@) or infer (@CmpEq@) the type.

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -127,7 +127,7 @@ headSymbol v = do -- ignoreAbstractMode $ do
 -- | Do a full whnf and treat neutral terms as rigid. Used on the arguments to
 --   an injective functions and to the right-hand side.
 headSymbol'
-  :: (MonadReduce m, MonadError TCErr m, MonadDebug m, HasBuiltins m)
+  :: (PureTCM m, MonadError TCErr m)
   => Term -> m (Maybe TermHead)
 headSymbol' v = do
   v <- traverse constructorForm =<< reduceB v
@@ -257,7 +257,7 @@ checkOverapplication es = updateHeads overapplied
 --   deBruijn variables. Checks that the instantiated heads are still rigid and
 --   distinct.
 instantiateVarHeads
-  :: forall m c. (MonadReduce m, MonadError TCErr m, MonadDebug m, HasBuiltins m)
+  :: forall m c. (PureTCM m, MonadError TCErr m)
   => QName -> Elims -> InversionMap c -> m (Maybe (InversionMap c))
 instantiateVarHeads f es m = runMaybeT $ updateHeads (const . instHead) m
   where
@@ -269,7 +269,7 @@ instantiateVarHeads f es m = runMaybeT $ updateHeads (const . instHead) m
 
 -- | Argument should be in weak head normal form.
 functionInverse
-  :: (MonadReduce m, MonadError TCErr m, HasBuiltins m, HasConstInfo m)
+  :: (PureTCM m, MonadError TCErr m)
   => Term -> m InvView
 functionInverse v = case v of
   Def f es -> do

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -110,7 +110,7 @@ initialInstanceCandidates t = do
                  ]
       return $ vars ++ fields ++ lets
 
-    etaExpand :: (MonadTCM m, MonadReduce m, HasConstInfo m, HasBuiltins m)
+    etaExpand :: (MonadTCM m, PureTCM m)
               => Bool -> Type -> m (Maybe (QName, Args))
     etaExpand etaOnce t =
       isEtaRecordType t >>= \case

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -287,7 +287,9 @@ wakeIrrelevantVars
 --   (irrelevant) definitions.
 --
 class UsableRelevance a where
-  usableRel :: Relevance -> a -> TCM Bool
+  usableRel
+    :: (ReadTCState m, HasConstInfo m, MonadTCEnv m, MonadAddContext m, MonadDebug m)
+    => Relevance -> a -> m Bool
 
 instance UsableRelevance Term where
   usableRel rel u = case u of
@@ -379,7 +381,9 @@ instance (Subst a, UsableRelevance a) => UsableRelevance (Abs a) where
 --   definitions.
 --
 class UsableModality a where
-  usableMod :: Modality -> a -> TCM Bool
+  usableMod
+    :: (ReadTCState m, HasConstInfo m, MonadTCEnv m, MonadAddContext m, MonadDebug m)
+    => Modality -> a -> m Bool
 
 instance UsableModality Term where
   usableMod mod u = case u of

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -472,7 +472,7 @@ instance (Subst a, UsableModality a) => UsableModality (Abs a) where
 -- | Is a type a proposition?  (Needs reduction.)
 
 isPropM
-  :: (LensSort a, PrettyTCM a, MonadReduce m, MonadBlock m, MonadDebug m)
+  :: (LensSort a, PrettyTCM a, PureTCM m, MonadBlock m)
   => a -> m Bool
 isPropM a = do
   traceSDoc "tc.prop" 80 ("Is " <+> prettyTCM a <+> "of sort" <+> prettyTCM (getSort a) <+> "in Prop?") $ do
@@ -481,7 +481,7 @@ isPropM a = do
     _      -> False
 
 isIrrelevantOrPropM
-  :: (LensRelevance a, LensSort a, PrettyTCM a, MonadReduce m, MonadBlock m, MonadDebug m)
+  :: (LensRelevance a, LensSort a, PrettyTCM a, PureTCM m, MonadBlock m)
   => a -> m Bool
 isIrrelevantOrPropM x = return (isIrrelevant x) `or2M` isPropM x
 
@@ -490,7 +490,7 @@ isIrrelevantOrPropM x = return (isIrrelevant x) `or2M` isPropM x
 -- | Is a type fibrant (i.e. Type, Prop)?
 
 isFibrant
-  :: (LensSort a, MonadReduce m, MonadBlock m)
+  :: (LensSort a, PureTCM m, MonadBlock m)
   => a -> m Bool
 isFibrant a = abortIfBlocked (getSort a) <&> \case
   Type{}     -> True

--- a/src/full/Agda/TypeChecking/Irrelevance.hs-boot
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs-boot
@@ -3,11 +3,12 @@ module Agda.TypeChecking.Irrelevance where
 
 import Agda.Syntax.Internal (LensSort)
 
-import Agda.TypeChecking.Monad.Base (MonadTCEnv, HasOptions, MonadReduce, MonadBlock)
+import Agda.TypeChecking.Monad.Base (MonadTCEnv, HasOptions, MonadBlock)
 import Agda.TypeChecking.Monad.Debug (MonadDebug)
 import {-# SOURCE #-} Agda.TypeChecking.Pretty (PrettyTCM)
+import Agda.TypeChecking.Monad.Pure (PureTCM)
 
 workOnTypes :: (MonadTCEnv m, HasOptions m, MonadDebug m) => m a -> m a
 isPropM
-  :: (LensSort a, PrettyTCM a, MonadReduce m, MonadBlock m, MonadDebug m)
+  :: (LensSort a, PrettyTCM a, PureTCM m, MonadBlock m)
   => a -> m Bool

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -35,7 +35,7 @@ data LevelKit = LevelKit
 levelType :: (HasBuiltins m) => m Type
 levelType = El (mkType 0) . fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevel
 
-isLevelType :: (HasBuiltins m, MonadReduce m) => Type -> m Bool
+isLevelType :: PureTCM m => Type -> m Bool
 isLevelType a = reduce (unEl a) >>= \case
   Def f [] -> do
     Def lvl [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevel
@@ -120,16 +120,14 @@ maybePrimDef prim = tryMaybe $ do
     Def f [] <- prim
     return f
 
-levelView :: (HasBuiltins m, MonadReduce m, MonadDebug m)
-          => Term -> m Level
+levelView :: PureTCM m => Term -> m Level
 levelView a = do
   reportSLn "tc.level.view" 50 $ "{ levelView " ++ show a
   v <- levelView' a
   reportSLn "tc.level.view" 50 $ "  view: " ++ show v ++ "}"
   return v
 
-levelView' :: (HasBuiltins m, MonadReduce m, MonadDebug m)
-           => Term -> m Level
+levelView' :: PureTCM m => Term -> m Level
 levelView' a = do
   Def lzero [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelZero
   Def lsuc  [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelSuc

--- a/src/full/Agda/TypeChecking/Level/Solve.hs
+++ b/src/full/Agda/TypeChecking/Level/Solve.hs
@@ -26,13 +26,13 @@ import Agda.Utils.Monad
 -- | Run the given action. At the end take all new metavariables of
 --   type level for which the only constraints are upper bounds on the
 --   level, and instantiate them to the lowest level.
-defaultOpenLevelsToZero :: MonadMetaSolver m => m a -> m a
+defaultOpenLevelsToZero :: (PureTCM m, MonadMetaSolver m) => m a -> m a
 defaultOpenLevelsToZero f = ifNotM (optCumulativity <$> pragmaOptions) f $ do
   (result , newMetas) <- metasCreatedBy f
   defaultLevelsToZero newMetas
   return result
 
-defaultLevelsToZero :: forall m. (MonadMetaSolver m) => IntSet -> m ()
+defaultLevelsToZero :: forall m. (PureTCM m, MonadMetaSolver m) => IntSet -> m ()
 defaultLevelsToZero xs = loop =<< openLevelMetas (map MetaId $ IntSet.elems xs)
   where
     loop :: [MetaId] -> m ()

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -612,7 +612,7 @@ instance (Occurs a, Occurs b, Occurs c) => Occurs (a,b,c) where
 --   we cannot prune, because the offending variables could be removed by
 --   reduction for a suitable instantiation of the meta variable.
 prune
-  :: MonadMetaSolver m
+  :: (PureTCM m, MonadMetaSolver m)
   => MetaId         -- ^ Meta to prune.
   -> Args           -- ^ Arguments to meta variable.
   -> (Nat -> Bool)  -- ^ Test for allowed variable (de Bruijn index).
@@ -639,7 +639,7 @@ prune m' vs xs = do
 --   we cannot prune at all as one of the meta args is matchable.
 --   (See issue 1147.)
 hasBadRigid
-  :: (MonadReduce m, HasConstInfo m, MonadAddContext m)
+  :: PureTCM m
   => (Nat -> Bool)      -- ^ Test for allowed variable (de Bruijn index).
   -> Term               -- ^ Argument of meta variable.
   -> ExceptT () m Bool  -- ^ Exception if argument is matchable.
@@ -704,7 +704,7 @@ isNeutral b f es = do
 --   Reduces the term successively to remove variables in dead subterms.
 --   This fixes issue 1386.
 rigidVarsNotContainedIn
-  :: (MonadReduce m, MonadAddContext m, MonadTCEnv m, MonadDebug m, AnyRigid a)
+  :: (PureTCM m, AnyRigid a)
   => a
   -> (Nat -> Bool)   -- ^ Test for allowed variable (de Bruijn index).
   -> m Bool
@@ -730,7 +730,7 @@ rigidVarsNotContainedIn v is = do
 --   We need to successively reduce the expression to do this.
 
 class AnyRigid a where
-  anyRigid :: (MonadReduce tcm, MonadAddContext tcm)
+  anyRigid :: (PureTCM tcm)
            => (Nat -> tcm Bool) -> a -> tcm Bool
 
 instance AnyRigid Term where

--- a/src/full/Agda/TypeChecking/Monad.hs
+++ b/src/full/Agda/TypeChecking/Monad.hs
@@ -11,6 +11,7 @@ module Agda.TypeChecking.Monad
     , module Agda.TypeChecking.Monad.Mutual
     , module Agda.TypeChecking.Monad.Open
     , module Agda.TypeChecking.Monad.Options
+    , module Agda.TypeChecking.Monad.Pure
     , module Agda.TypeChecking.Monad.Signature
     , module Agda.TypeChecking.Monad.SizedTypes
     , module Agda.TypeChecking.Monad.State
@@ -31,6 +32,7 @@ import Agda.TypeChecking.Monad.MetaVars
 import Agda.TypeChecking.Monad.Mutual
 import Agda.TypeChecking.Monad.Options
 import Agda.TypeChecking.Monad.Open
+import Agda.TypeChecking.Monad.Pure
 import Agda.TypeChecking.Monad.Signature
 import Agda.TypeChecking.Monad.SizedTypes
 import Agda.TypeChecking.Monad.State

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -147,9 +147,11 @@ getTerm use name = flip fromMaybeM (getTerm' name) $
 
 
 -- | Rewrite a literal to constructor form if possible.
-constructorForm :: (HasBuiltins m, MonadError TCErr m, MonadTCEnv m, ReadTCState m)
-                => Term -> m Term
-constructorForm v = constructorForm' primZero primSuc v
+constructorForm :: HasBuiltins m => Term -> m Term
+constructorForm v = do
+  let pZero = fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinZero
+      pSuc  = fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSuc
+  constructorForm' pZero pSuc v
 
 constructorForm' :: Applicative m => m Term -> m Term -> Term -> m Term
 constructorForm' pZero pSuc v =

--- a/src/full/Agda/TypeChecking/Monad/Pure.hs
+++ b/src/full/Agda/TypeChecking/Monad/Pure.hs
@@ -1,0 +1,39 @@
+-- | A typeclass collecting all 'pure' typechecking operations
+-- | (i.e. ones that do not modify the typechecking state, throw or
+-- | catch errors, or do IO other than debug printing).
+
+
+module Agda.TypeChecking.Monad.Pure where
+
+import Control.Monad.Except ( ExceptT )
+import Control.Monad.Trans.Maybe ( MaybeT )
+import Control.Monad.Reader ( ReaderT )
+import Control.Monad.State ( StateT )
+import Control.Monad.Writer ( WriterT )
+
+import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Context
+import Agda.TypeChecking.Monad.Debug
+import Agda.TypeChecking.Monad.Signature
+
+import Agda.Utils.ListT
+
+class
+  ( HasBuiltins m
+  , HasConstInfo m
+  , MonadAddContext m
+  , MonadDebug m
+  , MonadReduce m
+  , MonadTCEnv m
+  , ReadTCState m
+  ) => PureTCM m where
+
+instance PureTCM TCM where
+instance PureTCM m => PureTCM (BlockT m)
+instance PureTCM m => PureTCM (ExceptT e m)
+instance PureTCM m => PureTCM (ListT m)
+instance PureTCM m => PureTCM (MaybeT m)
+instance PureTCM m => PureTCM (ReaderT r m)
+instance (PureTCM m, Monoid w) => PureTCM (WriterT w m)
+instance PureTCM m => PureTCM (StateT s m)

--- a/src/full/Agda/TypeChecking/Monad/Pure.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Pure.hs-boot
@@ -1,0 +1,28 @@
+
+module Agda.TypeChecking.Monad.Pure where
+
+import Control.Monad.Reader ( ReaderT )
+import Control.Monad.State ( StateT )
+import Control.Monad.Writer ( WriterT )
+
+import Agda.TypeChecking.Monad.Base
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Builtin
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Context
+import Agda.TypeChecking.Monad.Debug
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Signature
+
+class
+  ( HasBuiltins m
+  , HasConstInfo m
+  , MonadAddContext m
+  , MonadDebug m
+  , MonadReduce m
+  , MonadTCEnv m
+  , ReadTCState m
+  ) => PureTCM m where
+
+instance PureTCM TCM where
+instance PureTCM m => PureTCM (ReaderT r m)
+instance (PureTCM m, Monoid w) => PureTCM (WriterT w m)
+instance PureTCM m => PureTCM (StateT s m)
+

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -6,7 +6,7 @@ module Agda.TypeChecking.Monad.State where
 import qualified Control.Exception as E
 
 import Control.Monad.State (void)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.Trans (MonadIO, liftIO)
 
 import Data.Maybe
 
@@ -358,7 +358,7 @@ addForeignCode backend code = do
 -- * Interaction output callback
 ---------------------------------------------------------------------------
 
-getInteractionOutputCallback :: TCM InteractionOutputCallback
+getInteractionOutputCallback :: ReadTCState m => m InteractionOutputCallback
 getInteractionOutputCallback
   = getsTC $ stInteractionOutputCallback . stPersistentState
 

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -3,7 +3,9 @@ module Agda.TypeChecking.Monad.Trace where
 
 import Prelude hiding (null)
 
+import Control.Monad.Except
 import Control.Monad.Reader
+import Control.Monad.Writer
 
 import qualified Data.Set as Set
 
@@ -72,123 +74,148 @@ interestingCall = \case
     CheckProjection{}         -> True
     ModuleContents{}          -> True
 
-traceCallM :: (MonadTCM tcm, ReadTCState tcm, MonadDebug tcm) => tcm Call -> tcm a -> tcm a
-traceCallM call m = flip traceCall m =<< call
+class (MonadTCEnv m, ReadTCState m) => MonadTrace m where
 
--- | Reset 'envCall' to previous value in the continuation.
---
--- Caveat: if the last 'traceCall' did not set an 'interestingCall',
--- for example, only set the 'Range' with 'SetRange',
--- we will revert to the last interesting call.
+  -- | Record a function call in the trace.
+  traceCall :: Call -> m a -> m a
+  traceCall call m = do
+    cl <- buildClosure call
+    traceClosureCall cl m
 
-traceCallCPS :: (MonadTCM tcm, ReadTCState tcm, MonadDebug tcm)
-  => Call
-  -> ((a -> tcm b) -> tcm b)
-  -> ((a -> tcm b) -> tcm b)
-traceCallCPS call k ret = do
-  mcall <- asksTC envCall
-  traceCall call $ k $ \ a -> do
-    maybe id traceClosureCall mcall $ ret a
+  traceCallM :: m Call -> m a -> m a
+  traceCallM call m = flip traceCall m =<< call
 
--- | Record a function call in the trace.
+  -- | Reset 'envCall' to previous value in the continuation.
+  --
+  -- Caveat: if the last 'traceCall' did not set an 'interestingCall',
+  -- for example, only set the 'Range' with 'SetRange',
+  -- we will revert to the last interesting call.
+  traceCallCPS :: Call -> ((a -> m b) -> m b) -> ((a -> m b) -> m b)
+  traceCallCPS call k ret = do
+    mcall <- asksTC envCall
+    traceCall call $ k $ \ a -> do
+      maybe id traceClosureCall mcall $ ret a
 
--- RULE left-hand side too complicated to desugar
--- {-# SPECIALIZE traceCall :: Call -> TCM a -> TCM a #-}
-traceCall :: (MonadTCM tcm, ReadTCState tcm, MonadDebug tcm) => Call -> tcm a -> tcm a
-traceCall call m = do
-  cl <- liftTCM $ buildClosure call
-  traceClosureCall cl m
+  traceClosureCall :: Closure Call -> m a -> m a
 
-traceClosureCall :: (MonadTCM tcm, ReadTCState tcm, MonadDebug tcm) => Closure Call -> tcm a -> tcm a
-traceClosureCall cl m = do
+  -- | Lispify and print the given highlighting information.
+  printHighlightingInfo :: RemoveTokenBasedHighlighting -> HighlightingInfo -> m ()
 
-  -- Andreas, 2016-09-13 issue #2177
-  -- Since the fix of #2092 we may report an error outside the current file.
-  -- (For instance, if we import a module which then happens to have the
-  -- wrong name.)
-  -- Thus, we no longer crash, but just report the alien range.
-  -- -- Andreas, 2015-02-09 Make sure we do not set a range
-  -- -- outside the current file
-  verboseS "check.ranges" 90 $
-    Strict.whenJust (rangeFile callRange) $ \f -> do
-      currentFile <- asksTC envCurrentPath
-      when (currentFile /= Just f) $ do
-        reportSLn "check.ranges" 90 $
-          prettyShow call ++
-          " is setting the current range to " ++ show callRange ++
-          " which is outside of the current file " ++ show currentFile
+  default printHighlightingInfo
+    :: (MonadTrans t, MonadTrace n, t n ~ m)
+    => RemoveTokenBasedHighlighting -> HighlightingInfo -> m ()
+  printHighlightingInfo r i = lift $ printHighlightingInfo r i
 
-  -- Compute update to 'Range' and 'Call' components of 'TCEnv'.
-  let withCall = localTC $ foldr (.) id $ concat $
-        [ [ \e -> e { envCall = Just cl } | interestingCall call ]
-        , [ \e -> e { envHighlightingRange = callRange }
-          | callHasRange && highlightCall
-            || isNoHighlighting
+instance MonadTrace m => MonadTrace (ReaderT r m) where
+  traceClosureCall c f = ReaderT $ \r -> traceClosureCall c $ runReaderT f r
+
+instance (MonadTrace m, Monoid w) => MonadTrace (WriterT w m) where
+  traceClosureCall c f = WriterT $ traceClosureCall c $ runWriterT f
+
+instance MonadTrace m => MonadTrace (ExceptT e m) where
+  traceClosureCall c f = ExceptT $ traceClosureCall c $ runExceptT f
+
+instance MonadTrace TCM where
+  traceClosureCall cl m = do
+    -- Andreas, 2016-09-13 issue #2177
+    -- Since the fix of #2092 we may report an error outside the current file.
+    -- (For instance, if we import a module which then happens to have the
+    -- wrong name.)
+    -- Thus, we no longer crash, but just report the alien range.
+    -- -- Andreas, 2015-02-09 Make sure we do not set a range
+    -- -- outside the current file
+    verboseS "check.ranges" 90 $
+      Strict.whenJust (rangeFile callRange) $ \f -> do
+        currentFile <- asksTC envCurrentPath
+        when (currentFile /= Just f) $ do
+          reportSLn "check.ranges" 90 $
+            prettyShow call ++
+            " is setting the current range to " ++ show callRange ++
+            " which is outside of the current file " ++ show currentFile
+
+    -- Compute update to 'Range' and 'Call' components of 'TCEnv'.
+    let withCall = localTC $ foldr (.) id $ concat $
+          [ [ \e -> e { envCall = Just cl } | interestingCall call ]
+          , [ \e -> e { envHighlightingRange = callRange }
+            | callHasRange && highlightCall
+              || isNoHighlighting
+            ]
+          , [ \e -> e { envRange = callRange } | callHasRange ]
           ]
-        , [ \e -> e { envRange = callRange } | callHasRange ]
-        ]
 
-  -- For interactive highlighting, also wrap computation @m@ in 'highlightAsTypeChecked':
-  ifNotM (pure highlightCall `and2M` do (Interactive ==) . envHighlightingLevel <$> askTC)
-    {-then-} (withCall m)
-    {-else-} $ do
-      oldRange <- envHighlightingRange <$> askTC
-      highlightAsTypeChecked oldRange callRange $
-        withCall m
-  where
-  call = clValue cl
-  callRange = getRange call
-  callHasRange = not $ null callRange
+    -- For interactive highlighting, also wrap computation @m@ in 'highlightAsTypeChecked':
+    ifNotM (pure highlightCall `and2M` do (Interactive ==) . envHighlightingLevel <$> askTC)
+      {-then-} (withCall m)
+      {-else-} $ do
+        oldRange <- envHighlightingRange <$> askTC
+        highlightAsTypeChecked oldRange callRange $
+          withCall m
+    where
+    call = clValue cl
+    callRange = getRange call
+    callHasRange = not $ null callRange
 
-  -- | Should the given call trigger interactive highlighting?
-  highlightCall = case call of
-    CheckClause{}             -> True
-    CheckLHS{}                -> True
-    CheckPattern{}            -> True
-    CheckPatternLinearityType{}  -> False
-    CheckPatternLinearityValue{} -> False
-    CheckLetBinding{}         -> True
-    InferExpr{}               -> True
-    CheckExprCall{}           -> True
-    CheckDotPattern{}         -> True
-    IsTypeCall{}              -> True
-    IsType_{}                 -> True
-    InferVar{}                -> True
-    InferDef{}                -> True
-    CheckArguments{}          -> True
-    CheckMetaSolution{}       -> False
-    CheckTargetType{}         -> False
-    CheckDataDef{}            -> True
-    CheckRecDef{}             -> True
-    CheckConstructor{}        -> True
-    CheckConstructorFitsIn{}  -> False
-    CheckFunDefCall _ _ _ h   -> h
-    CheckPragma{}             -> True
-    CheckPrimitive{}          -> True
-    CheckIsEmpty{}            -> True
-    CheckConfluence{}         -> False
-    CheckWithFunctionType{}   -> True
-    CheckSectionApplication{} -> True
-    CheckNamedWhere{}         -> False
-    ScopeCheckExpr{}          -> False
-    ScopeCheckDeclaration{}   -> False
-    ScopeCheckLHS{}           -> False
-    NoHighlighting{}          -> True
-    CheckProjection{}         -> False
-    SetRange{}                -> False
-    ModuleContents{}          -> False
+    -- | Should the given call trigger interactive highlighting?
+    highlightCall = case call of
+      CheckClause{}             -> True
+      CheckLHS{}                -> True
+      CheckPattern{}            -> True
+      CheckPatternLinearityType{}  -> False
+      CheckPatternLinearityValue{} -> False
+      CheckLetBinding{}         -> True
+      InferExpr{}               -> True
+      CheckExprCall{}           -> True
+      CheckDotPattern{}         -> True
+      IsTypeCall{}              -> True
+      IsType_{}                 -> True
+      InferVar{}                -> True
+      InferDef{}                -> True
+      CheckArguments{}          -> True
+      CheckMetaSolution{}       -> False
+      CheckTargetType{}         -> False
+      CheckDataDef{}            -> True
+      CheckRecDef{}             -> True
+      CheckConstructor{}        -> True
+      CheckConstructorFitsIn{}  -> False
+      CheckFunDefCall _ _ _ h   -> h
+      CheckPragma{}             -> True
+      CheckPrimitive{}          -> True
+      CheckIsEmpty{}            -> True
+      CheckConfluence{}         -> False
+      CheckWithFunctionType{}   -> True
+      CheckSectionApplication{} -> True
+      CheckNamedWhere{}         -> False
+      ScopeCheckExpr{}          -> False
+      ScopeCheckDeclaration{}   -> False
+      ScopeCheckLHS{}           -> False
+      NoHighlighting{}          -> True
+      CheckProjection{}         -> False
+      SetRange{}                -> False
+      ModuleContents{}          -> False
 
-  isNoHighlighting = case call of
-    NoHighlighting{} -> True
-    _ -> False
+    isNoHighlighting = case call of
+      NoHighlighting{} -> True
+      _ -> False
+
+  printHighlightingInfo remove info = do
+    modToSrc <- useTC stModuleToSource
+    method   <- viewTC eHighlightingMethod
+    reportS "highlighting" 50
+      [ "Printing highlighting info:"
+      , show info
+      , "  modToSrc = " ++ show modToSrc
+      ]
+    unless (null $ ranges info) $ do
+      appInteractionOutputCallback $
+          Resp_HighlightingInfo info remove method modToSrc
+
 
 getCurrentRange :: MonadTCEnv m => m Range
 getCurrentRange = asksTC envRange
 
 -- | Sets the current range (for error messages etc.) to the range
 --   of the given object, if it has a range (i.e., its range is not 'noRange').
-setCurrentRange :: (MonadTCM tcm, ReadTCState tcm, MonadDebug tcm, HasRange x)
-                => x -> tcm a -> tcm a
+setCurrentRange :: (MonadTrace m, HasRange x) => x -> m a -> m a
 setCurrentRange x = applyUnless (null r) $ traceCall $ SetRange r
   where r = getRange x
 
@@ -205,11 +232,11 @@ setCurrentRange x = applyUnless (null r) $ traceCall $ SetRange r
 --   highlighted as being type-checked.
 
 highlightAsTypeChecked
-  :: (MonadTCM tcm, ReadTCState tcm)
+  :: (MonadTrace m)
   => Range   -- ^ @rPre@
   -> Range   -- ^ @r@
-  -> tcm a
-  -> tcm a
+  -> m a
+  -> m a
 highlightAsTypeChecked rPre r m
   | r /= noRange && delta == rPre' = wrap r'    highlight clear
   | otherwise                      = wrap delta clear     highlight
@@ -227,22 +254,3 @@ highlightAsTypeChecked rPre r m
     return v
     where
     p rs x = printHighlightingInfo KeepHighlighting (singletonC rs x)
-
--- | Lispify and print the given highlighting information.
-
-printHighlightingInfo ::
-  (MonadTCM tcm, ReadTCState tcm) =>
-  RemoveTokenBasedHighlighting ->
-  HighlightingInfo ->
-  tcm ()
-printHighlightingInfo remove info = do
-  modToSrc <- useTC stModuleToSource
-  method   <- viewTC eHighlightingMethod
-  liftTCM $ reportS "highlighting" 50
-    [ "Printing highlighting info:"
-    , show info
-    , "  modToSrc = " ++ show modToSrc
-    ]
-  unless (null $ ranges info) $ do
-    liftTCM $ appInteractionOutputCallback $
-        Resp_HighlightingInfo info remove method modToSrc

--- a/src/full/Agda/TypeChecking/Names.hs
+++ b/src/full/Agda/TypeChecking/Names.hs
@@ -58,6 +58,7 @@ newtype NamesT m a = NamesT { unName :: ReaderT Names m a }
            , MonadError e
            , MonadAddContext
            , HasConstInfo
+           , PureTCM
            )
 
 -- deriving instance MonadState s m => MonadState s (NamesT m)

--- a/src/full/Agda/TypeChecking/Patterns/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Abstract.hs
@@ -4,6 +4,8 @@
 
 module Agda.TypeChecking.Patterns.Abstract where
 
+import Control.Monad.Except
+
 import qualified Data.List as List
 import Data.Void
 
@@ -23,7 +25,9 @@ import Agda.Utils.Impossible
 
 -- | Expand literal integer pattern into suc/zero constructor patterns.
 --
-expandLitPattern :: A.Pattern -> TCM A.Pattern
+expandLitPattern
+  :: (MonadError TCErr m, MonadTCEnv m, ReadTCState m, HasBuiltins m)
+  => A.Pattern -> m A.Pattern
 expandLitPattern p = case asView p of
   (xs, A.LitP info (LitNat n))
     | n < 0     -> negLit -- Andreas, issue #2365, negative literals not yet supported.

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -128,12 +128,7 @@ mergeElim Proj{} _ = __IMPOSSIBLE__
 mergeElims :: [Elim] -> [Arg Term] -> [Elim]
 mergeElims = zipWith mergeElim
 
-type MonadMatch m =
-  ( MonadReduce m
-  , MonadDebug m
-  , HasBuiltins m
-  , HasConstInfo m
-  )
+type MonadMatch m = PureTCM m
 
 -- | @matchCopatterns ps es@ matches spine @es@ against copattern spine @ps@.
 --

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -23,7 +23,7 @@ import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records
 
 import Agda.Utils.Empty
-import Agda.Utils.Functor (for, ($>))
+import Agda.Utils.Functor (for, ($>), (<&>))
 import Agda.Utils.Maybe
 import Agda.Utils.Null
 import Agda.Utils.Singleton
@@ -90,10 +90,11 @@ instance Monoid (Match a) where
 -- upon failure, no further matching is performed.
 
 foldMatch
-  :: forall p v . IsProjP p => (p -> v -> ReduceM (Match Term, v))
-  -> [p] -> [v] -> ReduceM (Match Term, [v])
+  :: forall m p v . (IsProjP p, MonadMatch m)
+  => (p -> v -> m (Match Term, v))
+  -> [p] -> [v] -> m (Match Term, [v])
 foldMatch match = loop where
-  loop :: [p] -> [v] -> ReduceM (Match Term, [v])
+  loop :: [p] -> [v] -> m (Match Term, [v])
   loop ps0 vs0 = do
     case (ps0, vs0) of
       ([], []) -> return (empty, [])
@@ -127,6 +128,13 @@ mergeElim Proj{} _ = __IMPOSSIBLE__
 mergeElims :: [Elim] -> [Arg Term] -> [Elim]
 mergeElims = zipWith mergeElim
 
+type MonadMatch m =
+  ( MonadReduce m
+  , MonadDebug m
+  , HasBuiltins m
+  , HasConstInfo m
+  )
+
 -- | @matchCopatterns ps es@ matches spine @es@ against copattern spine @ps@.
 --
 --   Returns 'Yes' and a substitution for the pattern variables
@@ -140,9 +148,10 @@ mergeElims = zipWith mergeElim
 --   In any case, also returns spine @es@ in reduced form
 --   (with all the weak head reductions performed that were necessary
 --   to come to a decision).
-matchCopatterns :: [NamedArg DeBruijnPattern]
+matchCopatterns :: MonadMatch m
+                => [NamedArg DeBruijnPattern]
                 -> [Elim]
-                -> ReduceM (Match Term, [Elim])
+                -> m (Match Term, [Elim])
 matchCopatterns ps vs = do
   traceSDoc "tc.match" 50
     (vcat [ "matchCopatterns"
@@ -154,12 +163,15 @@ matchCopatterns ps vs = do
   foldMatch (matchCopattern . namedArg) ps vs
 
 -- | Match a single copattern.
-matchCopattern :: DeBruijnPattern
+matchCopattern :: MonadMatch m
+               => DeBruijnPattern
                -> Elim
-               -> ReduceM (Match Term, Elim)
+               -> m (Match Term, Elim)
 matchCopattern pat@ProjP{} elim@(Proj _ q) = do
-  ProjP _ p <- normaliseProjP pat
-  q         <- getOriginalProjection q
+  p <- normaliseProjP pat <&> \case
+         ProjP _ p -> p
+         _         -> __IMPOSSIBLE__
+  q       <- getOriginalProjection q
   return $ if p == q then (Yes YesSimplification empty, elim)
                      else (No,                          elim)
 -- The following two cases are not impossible, see #2964
@@ -168,9 +180,10 @@ matchCopattern _       elim@Proj{}    = return (No , elim)
 matchCopattern p       (Apply v) = mapSnd Apply <$> matchPattern p v
 matchCopattern p       e@(IApply x y r) = mapSnd (mergeElim e) <$> matchPattern p (defaultArg r)
 
-matchPatterns :: [NamedArg DeBruijnPattern]
+matchPatterns :: MonadMatch m
+              => [NamedArg DeBruijnPattern]
               -> [Arg Term]
-              -> ReduceM (Match Term, [Arg Term])
+              -> m (Match Term, [Arg Term])
 matchPatterns ps vs = do
   reportSDoc "tc.match" 20 $
      vcat [ "matchPatterns"
@@ -189,9 +202,10 @@ matchPatterns ps vs = do
   foldMatch (matchPattern . namedArg) ps vs
 
 -- | Match a single pattern.
-matchPattern :: DeBruijnPattern
+matchPattern :: MonadMatch m
+             => DeBruijnPattern
              -> Arg Term
-             -> ReduceM (Match Term, Arg Term)
+             -> m (Match Term, Arg Term)
 matchPattern p u = case (p, u) of
   (ProjP{}, _            ) -> __IMPOSSIBLE__
   (IApplyP _ _ _ x , arg ) -> return (Yes NoSimplification entry, arg)
@@ -200,7 +214,7 @@ matchPattern p u = case (p, u) of
     where entry = singleton (dbPatVarIndex x, arg)
   (DotP _ _ , arg@(Arg _ v)) -> return (Yes NoSimplification empty, arg)
   (LitP _ l , arg@(Arg _ v)) -> do
-    w <- reduceB' v
+    w <- reduceB v
     let arg' = arg $> ignoreBlocking w
     case w of
       NotBlocked _ (Lit l')
@@ -223,7 +237,7 @@ matchPattern p u = case (p, u) of
         mapSnd (Arg info . Con c (fromConPatternInfo cpi) . map Apply) <$> do
           matchPatterns ps $ for fs $ \ (Arg ai f) -> Arg ai $ v `applyE` [Proj ProjSystem f]
     where
-    isEtaRecordCon :: QName -> ReduceM (Maybe [Arg QName])
+    isEtaRecordCon :: HasConstInfo m => QName -> m (Maybe [Arg QName])
     isEtaRecordCon c = do
       (theDef <$> getConstInfo c) >>= \case
         Constructor{ conData = d } -> do
@@ -237,14 +251,16 @@ matchPattern p u = case (p, u) of
     fallback' f ps v
  where
     -- Default: not an eta record constructor.
+  fallback :: MonadMatch m
+           => ConHead -> [NamedArg DeBruijnPattern] -> Arg Term -> m (Match Term, Arg Term)
   fallback c ps v = do
-    isMatchable <- isMatchable'
     let f (Con c' ci' vs) | c == c' = Just (Con c' ci',vs)
         f _                         = Nothing
     fallback' f ps v
 
   -- Regardless of blocking, constructors and a properly applied @hcomp@
   -- can be matched on.
+  isMatchable' :: HasBuiltins m => m (Blocked Term -> Maybe Term)
   isMatchable' = do
     mhcomp <- getName' builtinHComp
     return $ \ r ->
@@ -255,10 +271,15 @@ matchPattern p u = case (p, u) of
         _       -> Nothing
 
   -- DefP hcomp and ConP matching.
+  fallback' :: MonadMatch m
+            => (Term -> Maybe (Elims -> Term , Elims))
+            -> [NamedArg DeBruijnPattern]
+            -> Arg Term
+            -> m (Match Term, Arg Term)
   fallback' mtc ps (Arg info v) = do
         isMatchable <- isMatchable'
 
-        w <- reduceB' v
+        w <- reduceB v
         -- Unfold delayed (corecursive) definitions one step. This is
         -- only necessary if c is a coinductive constructor, but
         -- 1) it does not hurt to do it all the time, and
@@ -277,7 +298,7 @@ matchPattern p u = case (p, u) of
         -- Jesper, 23-06-2016: Note that unfoldCorecursion may destroy
         -- constructor forms, so we only call constructorForm after.
         w <- traverse constructorForm =<< case w of
-               NotBlocked r u -> unfoldCorecursion u  -- Andreas, 2014-06-12 TODO: r == ReallyNotBlocked sufficient?
+               NotBlocked r u -> liftReduce $ unfoldCorecursion u  -- Andreas, 2014-06-12 TODO: r == ReallyNotBlocked sufficient?
                _ -> return w
         let v = ignoreBlocking w
             arg = Arg info v  -- the reduced argument
@@ -304,9 +325,10 @@ yesSimplification r              = r
 -- Matching patterns against patterns -------------------------------------
 
 -- | Match a single pattern.
-matchPatternP :: DeBruijnPattern
-             -> Arg DeBruijnPattern
-             -> ReduceM (Match DeBruijnPattern)
+matchPatternP :: MonadMatch m
+              => DeBruijnPattern
+              -> Arg DeBruijnPattern
+              -> m (Match DeBruijnPattern)
 matchPatternP p (Arg info (DotP _ v)) = do
   (m, arg) <- matchPattern p (Arg info v)
   return $ fmap (DotP defaultPatternInfo) m
@@ -332,8 +354,9 @@ matchPatternP p arg@(Arg info q) = do
                 toLitP _                = __IMPOSSIBLE__
         _      -> termMatch
 
-matchPatternsP :: [NamedArg DeBruijnPattern]
+matchPatternsP :: MonadMatch m
+               => [NamedArg DeBruijnPattern]
                -> [Arg DeBruijnPattern]
-               -> ReduceM (Match DeBruijnPattern)
+               -> m (Match DeBruijnPattern)
 matchPatternsP ps qs = do
   mconcat <$> zipWithM matchPatternP (map namedArg ps) qs

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
@@ -14,5 +14,12 @@ data Match a = Yes Simplification (IntMap (Arg a)) | No | DontKnow (Blocked ())
 
 buildSubstitution :: (DeBruijn a) => Empty -> Int -> IntMap (Arg a) -> Substitution' a
 
-matchPatterns   :: [NamedArg DeBruijnPattern] -> Args  -> ReduceM (Match Term, Args)
-matchCopatterns :: [NamedArg DeBruijnPattern] -> Elims -> ReduceM (Match Term, Elims)
+type MonadMatch m =
+  ( MonadReduce m
+  , MonadDebug m
+  , HasBuiltins m
+  , HasConstInfo m
+  )
+
+matchPatterns   :: MonadMatch m => [NamedArg DeBruijnPattern] -> Args -> m (Match Term, Args)
+matchCopatterns :: MonadMatch m => [NamedArg DeBruijnPattern] -> Elims -> m (Match Term, Elims)

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
@@ -14,12 +14,7 @@ data Match a = Yes Simplification (IntMap (Arg a)) | No | DontKnow (Blocked ())
 
 buildSubstitution :: (DeBruijn a) => Empty -> Int -> IntMap (Arg a) -> Substitution' a
 
-type MonadMatch m =
-  ( MonadReduce m
-  , MonadDebug m
-  , HasBuiltins m
-  , HasConstInfo m
-  )
+type MonadMatch m = PureTCM m
 
 matchPatterns   :: MonadMatch m => [NamedArg DeBruijnPattern] -> Args -> m (Match Term, Args)
 matchCopatterns :: MonadMatch m => [NamedArg DeBruijnPattern] -> Elims -> m (Match Term, Elims)

--- a/src/full/Agda/TypeChecking/Pretty.hs-boot
+++ b/src/full/Agda/TypeChecking/Pretty.hs-boot
@@ -15,6 +15,7 @@ import {-# SOURCE #-} Agda.TypeChecking.Monad.Builtin
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Context (MonadAddContext)
 import Agda.TypeChecking.Monad.Debug (MonadDebug)
 import {-# SOURCE #-} Agda.TypeChecking.Monad.MetaVars (MonadInteractionPoints)
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Pure (PureTCM)
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Signature (HasConstInfo)
 
 import Agda.Utils.Null (Null)
@@ -33,14 +34,9 @@ prettyList_           :: (Applicative m, Semigroup (m Doc), Foldable t) => t (m 
 -- Inlining definitions of MonadReify and MonadAbsToCon to avoid
 -- having to import them
 type MonadPretty m =
-  ( ( MonadReduce m
-    , MonadAddContext m
+  ( ( PureTCM m
     , MonadInteractionPoints m
     , MonadFresh NameId m
-    , HasConstInfo m
-    , HasOptions m
-    , HasBuiltins m
-    , MonadDebug m
     )
   , ( MonadTCEnv m
     , ReadTCState m

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -442,7 +442,7 @@ mkGComp s = do
                 <@> forward la bA (pure iz) u0
 
 
-unglueTranspGlue :: (HasConstInfo m, MonadReduce m, HasBuiltins m) =>
+unglueTranspGlue :: PureTCM m =>
                   Arg Term
                   -> Arg Term
                   -> FamilyOrNot
@@ -575,15 +575,14 @@ unglueTranspGlue _ _ _ = __IMPOSSIBLE__
 
 data TermPosition = Head | Eliminated deriving (Eq,Show)
 
-headStop :: (HasBuiltins m, MonadReduce m) =>
-                  TermPosition -> m Term -> m Bool
+headStop :: PureTCM m => TermPosition -> m Term -> m Bool
 headStop tpos phi
   | Head <- tpos = do
       phi <- intervalView =<< (reduce =<< phi)
       return $ not $ isIOne phi
   | otherwise = return False
 
-compGlue :: (MonadReduce m, HasConstInfo m, HasBuiltins m) =>
+compGlue :: PureTCM m =>
                   TranspOrHComp
                   -> Arg Term
                   -> Maybe (Arg Term)
@@ -757,7 +756,7 @@ compGlue DoTransp psi Nothing u0 (IsFam (la, lb, bA, phi, bT, e)) tpos = do
           Eliminated -> a1'
 compGlue cmd phi u u0 _ _ = __IMPOSSIBLE__
 
-compHCompU :: (MonadReduce m, HasConstInfo m, HasBuiltins m) =>
+compHCompU :: PureTCM m =>
                     TranspOrHComp
                     -> Arg Term
                     -> Maybe (Arg Term)

--- a/src/full/Agda/TypeChecking/ProjectionLike.hs
+++ b/src/full/Agda/TypeChecking/ProjectionLike.hs
@@ -133,7 +133,7 @@ projView v = do
 --   (Also reduces projections, but they should not be there,
 --   since Internal is in lambda- and projection-beta-normal form.)
 --
-reduceProjectionLike :: (MonadReduce m, MonadTCEnv m, HasConstInfo m) => Term -> m Term
+reduceProjectionLike :: PureTCM m => Term -> m Term
 reduceProjectionLike v = do
   -- Andreas, 2013-11-01 make sure we do not reduce a constructor
   -- because that could be folded back into a literal by reduce.
@@ -156,9 +156,7 @@ reduceProjectionLike v = do
 --   No precondition.
 --   Preserves constructorForm, since it really does only something
 --   on (applications of) projection-like functions.
-elimView
-  :: (MonadReduce m, MonadTCEnv m, HasConstInfo m)
-  => Bool -> Term -> m Term
+elimView :: PureTCM m => Bool -> Term -> m Term
 elimView loneProjToLambda v = do
   reportSDoc "tc.conv.elim" 30 $ "elimView of " <+> prettyTCM v
   v <- reduceProjectionLike v

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -632,7 +632,7 @@ curryAt t n = do
 
     where @tel@ is the record telescope instantiated at the parameters @pars@.
 -}
-etaExpandRecord :: (HasConstInfo m, MonadDebug m, ReadTCState m, MonadError TCErr m)
+etaExpandRecord :: (HasConstInfo m, MonadDebug m, ReadTCState m)
                 => QName -> Args -> Term -> m (Telescope, Args)
 etaExpandRecord = etaExpandRecord' False
 
@@ -641,10 +641,10 @@ forceEtaExpandRecord :: (HasConstInfo m, MonadDebug m, ReadTCState m, MonadError
                      => QName -> Args -> Term -> m (Telescope, Args)
 forceEtaExpandRecord = etaExpandRecord' True
 
-etaExpandRecord' :: (HasConstInfo m, MonadDebug m, ReadTCState m, MonadError TCErr m)
+etaExpandRecord' :: (HasConstInfo m, MonadDebug m, ReadTCState m)
                  => Bool -> QName -> Args -> Term -> m (Telescope, Args)
 etaExpandRecord' forceEta r pars u = do
-  def <- getRecordDef r
+  def <- fromMaybe __IMPOSSIBLE__ <$> isRecord r
   (tel, _, _, args) <- etaExpandRecord'_ forceEta r pars def u
   return (tel, args)
 

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -618,8 +618,7 @@ unfoldDefinitionStep unfoldDelayed v0 f es =
             reportSDoc "tc.reduce" 100 $ "    raw   " <+> text (show v)
 
 -- | Reduce a non-primitive definition if it is a copy linking to another def.
-reduceDefCopy :: forall m. (MonadReduce m, HasConstInfo m, HasOptions m,
-                            ReadTCState m, MonadTCEnv m, MonadDebug m)
+reduceDefCopy :: forall m. PureTCM m
               => QName -> Elims -> m (Reduced () Term)
 reduceDefCopy f es = do
   info <- getConstInfo f
@@ -640,8 +639,7 @@ reduceDefCopy f es = do
             NoReduction{}        -> return $ NoReduction ()
 
 -- | Reduce simple (single clause) definitions.
-reduceHead :: (HasBuiltins m, HasConstInfo m, MonadReduce m, MonadDebug m)
-           => Term -> m (Blocked Term)
+reduceHead :: PureTCM m => Term -> m (Blocked Term)
 reduceHead v = do -- ignoreAbstractMode $ do
   -- Andreas, 2013-02-18 ignoreAbstractMode leads to information leakage
   -- see Issue 796
@@ -676,7 +674,7 @@ reduceHead v = do -- ignoreAbstractMode $ do
     _ -> return $ notBlocked v
 
 -- | Unfold a single inlined function.
-unfoldInlined :: (HasConstInfo m, MonadReduce m) => Term -> m Term
+unfoldInlined :: PureTCM m => Term -> m Term
 unfoldInlined v = do
   inTypes <- viewTC eWorkingOnTypes
   case v of

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -91,3 +91,5 @@ instance HasConstInfo ReduceM where
   getConstInfo' q = do
     ReduceEnv env st <- askR
     defaultGetConstInfo st env q
+
+instance PureTCM ReduceM where

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -465,11 +465,7 @@ tryUnification lhs1 lhs2 f = (Just <$> f)
 
 
 type MonadParallelReduce m =
-  ( MonadReduce m
-  , MonadAddContext m
-  , MonadDebug m
-  , HasBuiltins m
-  , HasConstInfo m
+  ( PureTCM m
   , MonadFresh NameId m
   )
 
@@ -631,17 +627,15 @@ ohAddBV x a oh = oh { ohBoundVars = ExtendTel a $ Abs x $ ohBoundVars oh }
 --   decompositions @p = p'[(f ps)/x]@.
 class (TermSubst p, Free p) => AllHoles p where
   type PType p
-  allHoles :: (Alternative m , MonadReduce m, MonadAddContext m, HasBuiltins m, HasConstInfo m)
-           => PType p -> p -> m (OneHole p)
+  allHoles :: (Alternative m, PureTCM m) => PType p -> p -> m (OneHole p)
 
 allHoles_
-  :: ( Alternative m , MonadReduce m, MonadAddContext m, HasBuiltins m, HasConstInfo m, MonadDebug m
-     , AllHoles p , PType p ~ () )
+  :: ( Alternative m , PureTCM m , AllHoles p , PType p ~ () )
   => p -> m (OneHole p)
 allHoles_ = allHoles ()
 
 allHolesList
-  :: ( MonadReduce m, MonadAddContext m, HasBuiltins m, HasConstInfo m , AllHoles p)
+  :: ( PureTCM m , AllHoles p)
   => PType p -> p -> m [OneHole p]
 allHolesList a = sequenceListT . allHoles a
 

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -180,13 +180,11 @@ instance PatternFrom Type Term NLPat where
 -- | Convert from a non-linear pattern to a term.
 
 class NLPatToTerm p a where
-  nlPatToTerm
-    :: (MonadReduce m, HasBuiltins m, HasConstInfo m, MonadDebug m)
-    => p -> m a
+  nlPatToTerm :: PureTCM m => p -> m a
 
   default nlPatToTerm ::
     ( NLPatToTerm p' a', Traversable f, p ~ f p', a ~ f a'
-    , MonadReduce m, HasBuiltins m, HasConstInfo m, MonadDebug m
+    , PureTCM m
     ) => p -> m a
   nlPatToTerm = traverse nlPatToTerm
 

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -104,9 +104,9 @@ import Agda.Utils.Impossible
 -- | A pattern is flexible if it is dotted or implicit, or a record pattern
 --   with only flexible subpatterns.
 class IsFlexiblePattern a where
-  maybeFlexiblePattern :: a -> MaybeT TCM FlexibleVarKind
+  maybeFlexiblePattern :: (HasConstInfo m, MonadDebug m) => a -> MaybeT m FlexibleVarKind
 
-  isFlexiblePattern :: a -> TCM Bool
+  isFlexiblePattern :: (HasConstInfo m, MonadDebug m) => a -> m Bool
   isFlexiblePattern p =
     maybe False notOtherFlex <$> runMaybeT (maybeFlexiblePattern p)
     where

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -821,7 +821,7 @@ splitStrategy = filter shouldSplit
 
 -- | The loop (tail-recursive): split at a variable in the problem until problem is solved
 checkLHS
-  :: forall tcm a. (MonadTCM tcm, MonadReduce tcm, MonadAddContext tcm, MonadWriter Blocked_ tcm, HasConstInfo tcm, MonadError TCErr tcm, MonadDebug tcm, MonadReader Nat tcm, HasBuiltins tcm)
+  :: forall tcm a. (MonadTCM tcm, MonadReduce tcm, MonadAddContext tcm, MonadWriter Blocked_ tcm, HasConstInfo tcm, MonadError TCErr tcm, MonadTrace tcm, MonadDebug tcm, MonadReader Nat tcm, HasBuiltins tcm)
   => Maybe QName      -- ^ The name of the definition we are checking.
   -> LHSState a       -- ^ The current state.
   -> tcm a

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -821,7 +821,7 @@ splitStrategy = filter shouldSplit
 
 -- | The loop (tail-recursive): split at a variable in the problem until problem is solved
 checkLHS
-  :: forall tcm a. (MonadTCM tcm, MonadReduce tcm, MonadAddContext tcm, MonadWriter Blocked_ tcm, HasConstInfo tcm, MonadError TCErr tcm, MonadTrace tcm, MonadDebug tcm, MonadReader Nat tcm, HasBuiltins tcm)
+  :: forall tcm a. (MonadTCM tcm, PureTCM tcm, MonadWriter Blocked_ tcm, MonadError TCErr tcm, MonadTrace tcm, MonadReader Nat tcm)
   => Maybe QName      -- ^ The name of the definition we are checking.
   -> LHSState a       -- ^ The current state.
   -> tcm a
@@ -1433,7 +1433,7 @@ data DataOrRecord
 --   a data/record type by instantiating a variable/metavariable, or fail hard
 --   otherwise.
 isDataOrRecordType
-  :: (MonadTCM m, MonadReduce m, MonadDebug m, ReadTCState m)
+  :: (MonadTCM m, PureTCM m)
   => Type
   -> ExceptT TCErr m (DataOrRecord, QName, Args, Args)
        -- ^ The 'Args' are parameters and indices.
@@ -1869,7 +1869,7 @@ checkParameters dc d pars = liftTCM $ do
       compareArgs [] [] t (Def d []) vs (take (length vs) pars)
     _ -> __IMPOSSIBLE__
 
-checkSortOfSplitVar :: (MonadTCM m, MonadReduce m, MonadError TCErr m, ReadTCState m, MonadDebug m,
+checkSortOfSplitVar :: (MonadTCM m, PureTCM m, MonadError TCErr m,
                         LensSort a, PrettyTCM a, LensSort ty, PrettyTCM ty)
                     => DataOrRecord -> a -> Telescope -> Maybe ty -> m ()
 checkSortOfSplitVar dr a tel mtarget = do

--- a/src/full/Agda/TypeChecking/Rules/LHS/Implicit.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Implicit.hs
@@ -3,6 +3,9 @@ module Agda.TypeChecking.Rules.LHS.Implicit where
 
 import Prelude hiding (null)
 
+import Control.Monad.Except
+import Control.Monad.IO.Class
+
 import Agda.Syntax.Common
 import Agda.Syntax.Position
 import Agda.Syntax.Info
@@ -28,13 +31,18 @@ implicitP info = Arg (setOrigin Inserted info) $ unnamed $ A.WildP $ PatRange $ 
 
 -- | Insert implicit patterns in a list of patterns.
 --   Even if 'DontExpandLast', trailing SIZELT patterns are inserted.
-insertImplicitPatterns :: ExpandHidden -> [NamedArg A.Pattern] ->
-                          Telescope -> TCM [NamedArg A.Pattern]
+insertImplicitPatterns
+  :: (HasBuiltins m, MonadReduce m, MonadAddContext m, MonadError TCErr m,
+      MonadFresh NameId m, MonadTrace m, MonadDebug m)
+  => ExpandHidden -> [NamedArg A.Pattern]
+  -> Telescope -> m [NamedArg A.Pattern]
 insertImplicitPatterns exh ps tel =
   insertImplicitPatternsT exh ps (telePi tel __DUMMY_TYPE__)
 
 -- | Insert trailing SizeLt patterns, if any.
-insertImplicitSizeLtPatterns :: Type -> TCM [NamedArg A.Pattern]
+insertImplicitSizeLtPatterns
+  :: (HasBuiltins m, MonadReduce m, MonadAddContext m)
+  => Type -> m [NamedArg A.Pattern]
 insertImplicitSizeLtPatterns t = do
   -- Testing for SizeLt.  In case of blocked type, we return no.
   -- We assume that on the LHS, we know the type.  (TODO: Sufficient?)
@@ -52,8 +60,11 @@ insertImplicitSizeLtPatterns t = do
 
 -- | Insert implicit patterns in a list of patterns.
 --   Even if 'DontExpandLast', trailing SIZELT patterns are inserted.
-insertImplicitPatternsT :: ExpandHidden -> [NamedArg A.Pattern] -> Type ->
-                           TCM [NamedArg A.Pattern]
+insertImplicitPatternsT
+  :: (HasBuiltins m, MonadReduce m, MonadAddContext m, MonadError TCErr m,
+      MonadFresh NameId m, MonadTrace m, MonadDebug m)
+  => ExpandHidden -> [NamedArg A.Pattern] -> Type
+  -> m [NamedArg A.Pattern]
 insertImplicitPatternsT DontExpandLast [] a = insertImplicitSizeLtPatterns a
 insertImplicitPatternsT exh            ps a = do
   TelV tel b <- telViewUpTo' (-1) (not . visible) a

--- a/src/full/Agda/TypeChecking/Rules/LHS/Implicit.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Implicit.hs
@@ -32,17 +32,14 @@ implicitP info = Arg (setOrigin Inserted info) $ unnamed $ A.WildP $ PatRange $ 
 -- | Insert implicit patterns in a list of patterns.
 --   Even if 'DontExpandLast', trailing SIZELT patterns are inserted.
 insertImplicitPatterns
-  :: (HasBuiltins m, MonadReduce m, MonadAddContext m, MonadError TCErr m,
-      MonadFresh NameId m, MonadTrace m, MonadDebug m)
+  :: (PureTCM m, MonadError TCErr m, MonadFresh NameId m, MonadTrace m)
   => ExpandHidden -> [NamedArg A.Pattern]
   -> Telescope -> m [NamedArg A.Pattern]
 insertImplicitPatterns exh ps tel =
   insertImplicitPatternsT exh ps (telePi tel __DUMMY_TYPE__)
 
 -- | Insert trailing SizeLt patterns, if any.
-insertImplicitSizeLtPatterns
-  :: (HasBuiltins m, MonadReduce m, MonadAddContext m)
-  => Type -> m [NamedArg A.Pattern]
+insertImplicitSizeLtPatterns :: PureTCM m => Type -> m [NamedArg A.Pattern]
 insertImplicitSizeLtPatterns t = do
   -- Testing for SizeLt.  In case of blocked type, we return no.
   -- We assume that on the LHS, we know the type.  (TODO: Sufficient?)
@@ -61,8 +58,7 @@ insertImplicitSizeLtPatterns t = do
 -- | Insert implicit patterns in a list of patterns.
 --   Even if 'DontExpandLast', trailing SIZELT patterns are inserted.
 insertImplicitPatternsT
-  :: (HasBuiltins m, MonadReduce m, MonadAddContext m, MonadError TCErr m,
-      MonadFresh NameId m, MonadTrace m, MonadDebug m)
+  :: (PureTCM m, MonadError TCErr m, MonadFresh NameId m, MonadTrace m)
   => ExpandHidden -> [NamedArg A.Pattern] -> Type
   -> m [NamedArg A.Pattern]
 insertImplicitPatternsT DontExpandLast [] a = insertImplicitSizeLtPatterns a

--- a/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
@@ -27,8 +27,7 @@ import Agda.Syntax.Internal
 import Agda.Syntax.Abstract (ProblemEq(..))
 import qualified Agda.Syntax.Abstract as A
 
-import Agda.TypeChecking.Monad (TCM, IsForced(..), addContext, lookupSection, currentModule)
-import Agda.TypeChecking.Monad.Debug
+import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Records
@@ -289,7 +288,10 @@ instance PrettyTCM LeftoverPatterns where
 -- | Classify remaining patterns after splitting is complete into pattern
 --   variables, as patterns, dot patterns, and absurd patterns.
 --   Precondition: there are no more constructor patterns.
-getLeftoverPatterns :: [ProblemEq] -> TCM LeftoverPatterns
+getLeftoverPatterns
+  :: forall m. (ReadTCState m, MonadReduce m, MonadAddContext m, MonadTCEnv m,
+                MonadDebug m, HasBuiltins m, HasConstInfo m)
+  => [ProblemEq] -> m LeftoverPatterns
 getLeftoverPatterns eqs = do
   reportSDoc "tc.lhs.top" 30 $ "classifying leftover patterns"
   params <- Set.fromList . teleNames <$> (lookupSection =<< currentModule)
@@ -303,7 +305,7 @@ getLeftoverPatterns eqs = do
     absurdPattern info a = LeftoverPatterns empty [] [] [Absurd info a] []
     otherPattern p       = LeftoverPatterns empty [] [] [] [p]
 
-    getLeftoverPattern :: (A.Name -> Bool) -> ProblemEq -> TCM LeftoverPatterns
+    getLeftoverPattern :: (A.Name -> Bool) -> ProblemEq -> m LeftoverPatterns
     getLeftoverPattern isParamName (ProblemEq p v a) = case p of
       (A.VarP A.BindName{unBind = x}) -> isEtaVar v (unDom a) >>= \case
         Just i  | isParamName x -> return $ moduleParameter x i

--- a/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
@@ -289,8 +289,7 @@ instance PrettyTCM LeftoverPatterns where
 --   variables, as patterns, dot patterns, and absurd patterns.
 --   Precondition: there are no more constructor patterns.
 getLeftoverPatterns
-  :: forall m. (ReadTCState m, MonadReduce m, MonadAddContext m, MonadTCEnv m,
-                MonadDebug m, HasBuiltins m, HasConstInfo m)
+  :: forall m. PureTCM m
   => [ProblemEq] -> m LeftoverPatterns
 getLeftoverPatterns eqs = do
   reportSDoc "tc.lhs.top" 30 $ "classifying leftover patterns"

--- a/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
@@ -51,8 +51,7 @@ useNamesFromPattern ps tel = telFromList (zipWith ren ps telList ++ telRemaining
           | otherwise                  -> dom
 
 useNamesFromProblemEqs
-  :: forall m. (ReadTCState m, MonadReduce m, MonadAddContext m, MonadTCEnv m,
-                MonadDebug m, HasBuiltins m, HasConstInfo m)
+  :: forall m. PureTCM m
   => [ProblemEq] -> Telescope -> m Telescope
 useNamesFromProblemEqs eqs tel = addContext tel $ do
   names <- fst . getUserVariableNames tel . patternVariables <$> getLeftoverPatterns eqs
@@ -105,9 +104,7 @@ initLHSState delta eqs ps a ret = do
 -- | Try to move patterns from the problem rest into the problem.
 --   Possible if type of problem rest has been updated to a function type.
 updateProblemRest
-  :: forall m a. (ReadTCState m, MonadReduce m, MonadAddContext m, MonadTCEnv m,
-                  MonadError TCErr m, MonadTrace m, MonadDebug m, HasBuiltins m,
-                  MonadFresh NameId m, HasConstInfo m)
+  :: forall m a. (PureTCM m, MonadError TCErr m, MonadTrace m, MonadFresh NameId m)
   => LHSState a -> m (LHSState a)
 updateProblemRest st@(LHSState tel0 qs0 p@(Problem oldEqs ps ret) a psplit) = do
   ps <- addContext tel0 $ insertImplicitPatternsT ExpandLast ps $ unArg a

--- a/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
@@ -49,7 +49,10 @@ useNamesFromPattern ps tel = telFromList (zipWith ren ps telList ++ telRemaining
         _ | visible dom && isNoName y -> dom{ unDom = (stringToArgName "x", a) }
           | otherwise                  -> dom
 
-useNamesFromProblemEqs :: [ProblemEq] -> Telescope -> TCM Telescope
+useNamesFromProblemEqs
+  :: forall m. (ReadTCState m, MonadReduce m, MonadAddContext m, MonadTCEnv m,
+                MonadDebug m, HasBuiltins m, HasConstInfo m)
+  => [ProblemEq] -> Telescope -> m Telescope
 useNamesFromProblemEqs eqs tel = addContext tel $ do
   names <- fst . getUserVariableNames tel . patternVariables <$> getLeftoverPatterns eqs
   let argNames = map (fmap nameToArgName) names

--- a/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
@@ -2,6 +2,7 @@
 module Agda.TypeChecking.Rules.LHS.ProblemRest where
 
 import Control.Monad
+import Control.Monad.Except
 
 import Data.Maybe
 
@@ -103,7 +104,11 @@ initLHSState delta eqs ps a ret = do
 
 -- | Try to move patterns from the problem rest into the problem.
 --   Possible if type of problem rest has been updated to a function type.
-updateProblemRest :: LHSState a -> TCM (LHSState a)
+updateProblemRest
+  :: forall m a. (ReadTCState m, MonadReduce m, MonadAddContext m, MonadTCEnv m,
+                  MonadError TCErr m, MonadTrace m, MonadDebug m, HasBuiltins m,
+                  MonadFresh NameId m, HasConstInfo m)
+  => LHSState a -> m (LHSState a)
 updateProblemRest st@(LHSState tel0 qs0 p@(Problem oldEqs ps ret) a psplit) = do
   ps <- addContext tel0 $ insertImplicitPatternsT ExpandLast ps $ unArg a
   reportSDoc "tc.lhs.imp" 20 $

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -189,10 +189,7 @@ data UnificationResult' a
   deriving (Show, Functor, Foldable, Traversable)
 
 type MonadUnify m =
-  ( HasBuiltins m
-  , HasConstInfo m
-  , MonadReduce m
-  , MonadAddContext m
+  ( PureTCM m
   , MonadBench m
   , BenchPhase m ~ Bench.Phase
   )
@@ -329,7 +326,7 @@ instance PrettyTCM UnifyState where
       prettyEquality x y = prettyTCM x <+> "=?=" <+> prettyTCM y
 
 initUnifyState
-  :: (MonadReduce m, MonadAddContext m)
+  :: PureTCM m
   => Telescope -> FlexibleVars -> Type -> Args -> Args -> m UnifyState
 initUnifyState tel flex a lhs rhs = do
   (tel, a, lhs, rhs) <- instantiateFull (tel, a, lhs, rhs)
@@ -1280,7 +1277,7 @@ unify s strategy = if isUnifyStateSolved s
 
 -- | Turn a term into a pattern while binding as many of the given forced variables as possible (in
 --   non-forced positions).
-patternBindingForcedVars :: (HasConstInfo m, MonadReduce m) => IntMap Modality -> Term -> m (DeBruijnPattern, IntMap Modality)
+patternBindingForcedVars :: PureTCM m => IntMap Modality -> Term -> m (DeBruijnPattern, IntMap Modality)
 patternBindingForcedVars forced v = do
   let v' = precomputeFreeVars_ v
   runWriterT (evalStateT (go defaultModality v') forced)

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -379,12 +379,12 @@ telViewUpTo' n p t = do
   where
     absV a x (TelV tel t) = TelV (ExtendTel a (Abs x tel)) t
 
-telViewPath :: (MonadReduce m, HasBuiltins m) => Type -> m TelView
+telViewPath :: PureTCM m => Type -> m TelView
 telViewPath = telViewUpToPath (-1)
 
 -- | @telViewUpToPath n t@ takes off $t$
 --   the first @n@ (or arbitrary many if @n < 0@) function domains or Path types.
-telViewUpToPath :: (MonadReduce m, HasBuiltins m) => Int -> Type -> m TelView
+telViewUpToPath :: PureTCM m => Int -> Type -> m TelView
 telViewUpToPath 0 t = return $ TelV EmptyTel t
 telViewUpToPath n t = do
   vt <- pathViewAsPi $ t
@@ -404,7 +404,7 @@ type Boundary' a = [(Term,a)]
 -- by the Path types encountered. The boundary terms live in the
 -- telescope given by the @TelView@.
 -- Each point of the boundary has the type of the codomain of the Path type it got taken from, see @fullBoundary@.
-telViewUpToPathBoundary' :: (MonadReduce m, HasBuiltins m) => Int -> Type -> m (TelView,Boundary)
+telViewUpToPathBoundary' :: PureTCM m => Int -> Type -> m (TelView,Boundary)
 telViewUpToPathBoundary' 0 t = return $ (TelV EmptyTel t,[])
 telViewUpToPathBoundary' n t = do
   vt <- pathViewAsPi' $ t
@@ -438,7 +438,7 @@ fullBoundary tel bs =
 --  Output: ΔΓ ⊢ b
 --          ΔΓ ⊢ i : I
 --          ΔΓ ⊢ [ (i=0) -> t_i; (i=1) -> u_i ] : b
-telViewUpToPathBoundary :: (MonadReduce m, HasBuiltins m) => Int -> Type -> m (TelView,Boundary)
+telViewUpToPathBoundary :: PureTCM m => Int -> Type -> m (TelView,Boundary)
 telViewUpToPathBoundary i a = do
    (telv@(TelV tel b), bs) <- telViewUpToPathBoundary' i a
    return $ (telv, fullBoundary tel bs)
@@ -450,10 +450,10 @@ telViewUpToPathBoundary i a = do
 --          Δ.Γ ⊢ i : I
 --          Δ.Γ ⊢ [ (i=0) -> t_i; (i=1) -> u_i ] : T
 -- Useful to reconstruct IApplyP patterns after teleNamedArgs Γ.
-telViewUpToPathBoundaryP :: (MonadReduce m, HasBuiltins m) => Int -> Type -> m (TelView,Boundary)
+telViewUpToPathBoundaryP :: PureTCM m => Int -> Type -> m (TelView,Boundary)
 telViewUpToPathBoundaryP = telViewUpToPathBoundary'
 
-telViewPathBoundaryP :: (MonadReduce m, HasBuiltins m) => Type -> m (TelView,Boundary)
+telViewPathBoundaryP :: PureTCM m => Type -> m (TelView,Boundary)
 telViewPathBoundaryP = telViewUpToPathBoundaryP (-1)
 
 
@@ -478,13 +478,11 @@ teleElims tel boundary = recurse (teleArgs tel)
         _                                 -> Apply a
 
 pathViewAsPi
-  :: (MonadReduce m, HasBuiltins m)
-  =>Type -> m (Either (Dom Type, Abs Type) Type)
+  :: PureTCM m => Type -> m (Either (Dom Type, Abs Type) Type)
 pathViewAsPi t = either (Left . fst) Right <$> pathViewAsPi' t
 
 pathViewAsPi'
-  :: (MonadReduce m, HasBuiltins m)
-  => Type -> m (Either ((Dom Type, Abs Type), (Term,Term)) Type)
+  :: PureTCM m => Type -> m (Either ((Dom Type, Abs Type), (Term,Term)) Type)
 pathViewAsPi' t = do
   pathViewAsPi'whnf <*> reduce t
 
@@ -530,8 +528,7 @@ telView'Path :: Type -> TCM TelView
 telView'Path = telView'UpToPath (-1)
 
 isPath
-  :: (MonadReduce m, HasBuiltins m)
-  => Type -> m (Maybe (Dom Type, Abs Type))
+  :: PureTCM m => Type -> m (Maybe (Dom Type, Abs Type))
 isPath t = either Just (const Nothing) <$> pathViewAsPi t
 
 telePatterns :: DeBruijn a => Telescope -> Boundary -> [NamedArg (Pattern' a)]

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -379,12 +379,12 @@ telViewUpTo' n p t = do
   where
     absV a x (TelV tel t) = TelV (ExtendTel a (Abs x tel)) t
 
-telViewPath :: Type -> TCM TelView
+telViewPath :: (MonadReduce m, HasBuiltins m) => Type -> m TelView
 telViewPath = telViewUpToPath (-1)
 
 -- | @telViewUpToPath n t@ takes off $t$
 --   the first @n@ (or arbitrary many if @n < 0@) function domains or Path types.
-telViewUpToPath :: Int -> Type -> TCM TelView
+telViewUpToPath :: (MonadReduce m, HasBuiltins m) => Int -> Type -> m TelView
 telViewUpToPath 0 t = return $ TelV EmptyTel t
 telViewUpToPath n t = do
   vt <- pathViewAsPi $ t

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -506,7 +506,7 @@ pathViewAsPi'whnf = do
 
 -- | returns Left (a,b) in case the type is @Pi a b@ or @PathP b _ _@
 --   assumes the type is in whnf.
-piOrPath :: Type -> TCM (Either (Dom Type, Abs Type) Type)
+piOrPath :: HasBuiltins m => Type -> m (Either (Dom Type, Abs Type) Type)
 piOrPath t = do
   t <- pathViewAsPi'whnf <*> pure t
   case t of

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -34,6 +34,7 @@ import Agda.TypeChecking.Monad.Caching
 import {-# SOURCE #-} Agda.TypeChecking.Pretty (MonadPretty, prettyTCM)
 import {-# SOURCE #-} Agda.TypeChecking.Pretty.Call
 import {-# SOURCE #-} Agda.TypeChecking.Pretty.Warning ( prettyWarning )
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Pure
 
 import Agda.Syntax.Abstract.Name ( QName )
 import Agda.Syntax.Common

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -8,7 +8,9 @@ module Agda.Utils.Benchmark where
 import Prelude hiding (null)
 
 import qualified Control.Exception as E (evaluate)
+import Control.Monad.Except
 import Control.Monad.Reader
+import Control.Monad.Writer
 import Control.Monad.State
 
 
@@ -19,6 +21,7 @@ import Data.Maybe
 
 import qualified Text.PrettyPrint.Boxes as Boxes
 
+import Agda.Utils.ListT
 import Agda.Utils.Null
 import Agda.Utils.Monad hiding (finally)
 import qualified Agda.Utils.Maybe.Strict as Strict
@@ -147,6 +150,13 @@ instance MonadBench m => MonadBench (ReaderT r m) where
   finally m f = ReaderT $ \ r ->
     finally (m `runReaderT` r) (f `runReaderT` r)
 
+instance (MonadBench m, Monoid w) => MonadBench (WriterT w m) where
+  type BenchPhase (WriterT w m) = BenchPhase m
+  getBenchmark    = lift $ getBenchmark
+  putBenchmark    = lift . putBenchmark
+  modifyBenchmark = lift . modifyBenchmark
+  finally m f = WriterT $ finally (runWriterT m) (runWriterT f)
+
 instance MonadBench m => MonadBench (StateT r m) where
   type BenchPhase (StateT r m) = BenchPhase m
 
@@ -155,6 +165,22 @@ instance MonadBench m => MonadBench (StateT r m) where
   modifyBenchmark = lift . modifyBenchmark
   finally m f = StateT $ \s ->
     finally (m `runStateT` s) (f `runStateT` s)
+
+instance MonadBench m => MonadBench (ExceptT e m) where
+  type BenchPhase (ExceptT e m) = BenchPhase m
+
+  getBenchmark    = lift $ getBenchmark
+  putBenchmark    = lift . putBenchmark
+  modifyBenchmark = lift . modifyBenchmark
+  finally m f = ExceptT $ finally (runExceptT m) (runExceptT f)
+
+instance MonadBench m => MonadBench (ListT m) where
+  type BenchPhase (ListT m) = BenchPhase m
+
+  getBenchmark    = lift getBenchmark
+  putBenchmark    = lift . putBenchmark
+  modifyBenchmark = lift . modifyBenchmark
+  finally m f = ListT $ finally (runListT m) (runListT f)
 
 -- | Turn benchmarking on/off.
 

--- a/test/Fail/Issue314.err
+++ b/test/Fail/Issue314.err
@@ -3,8 +3,4 @@ I'm not sure if there should be a case for the constructor refl,
 because I get stuck when trying to solve the following unification
 problems (inferred index ≟ expected index):
   x ≟ _y_7 (x = x)
-Possible reason why unification failed:
-  Cannot solve variable x of type A with solution _y_7 (x = x)
-  because the variable occurs in the solution, or in the type of one
-  of the variables in the solution.
 when checking that the pattern refl has type x ≡ _y_7 (x = x)

--- a/test/Fail/SizedTypesScopeExtrusion.err
+++ b/test/Fail/SizedTypesScopeExtrusion.err
@@ -1,4 +1,4 @@
 SizedTypesScopeExtrusion.agda:21,41-42
 Cannot solve size constraints
-∞ =< i : Size (blocked on _size_15, belongs to problems 34, 35)
+∞ =< i : Size (blocked on _size_15, belongs to problems 30, 31)
 when checking that the expression x has type Nat


### PR DESCRIPTION
I promise (or at least I hope) this is leading somewhere. In the meanwhile, Agda developers can enjoy the more general type signatures, shorter constraint lists and reduced number of calls to `liftTCM`.