### PR TITLE
Make lexing of floating-point literals more restrictive

### DIFF
--- a/src/full/Agda/Syntax/Parser/Lexer.x
+++ b/src/full/Agda/Syntax/Parser/Lexer.x
@@ -54,13 +54,14 @@ $nonalpha    = $idchar # $alpha
 $white_notab = $white # \t
 $white_nonl  = $white_notab # \n
 
-@number       = $digit+ | "0x" $hexdigit+
 @prettynumber = $digit+ ([_] $digit+)*
               | "0x" $hexdigit+ ([_] $hexdigit+)*
               | "0b" $binarydigit+ ([_] $binarydigit+)*
 @integer      = [\-]? @prettynumber
-@exponent     = [eE] [\-\+]? @number
-@float        = @integer \. @number @exponent? | @number @exponent
+@decimal      = $digit+
+@exponent     = [eE] [\-\+]? @decimal
+@float        = [\-]? @decimal \. @decimal @exponent?
+              | [\-]? @decimal @exponent
 
 -- A name can't start with \x (to allow \x -> x).
 -- Bug in alex: [ _ op ]+ doesn't seem to work!

--- a/test/Fail/Issue4132.agda
+++ b/test/Fail/Issue4132.agda
@@ -1,0 +1,4 @@
+open import Agda.Builtin.Float
+
+_ : Float
+_ = 1.0xA

--- a/test/Fail/Issue4132.err
+++ b/test/Fail/Issue4132.err
@@ -1,0 +1,4 @@
+Issue4132.agda:4,5-5
+Issue4132.agda:4,5: in the name 1, the part 1 is not valid because it is a literal
+<EOF><ERROR>
+...


### PR DESCRIPTION
Fixes #4132.

The lexing of floating-point literals now matches [the docs](https://agda.readthedocs.io/en/v2.6.1.1/language/lexical-structure.html#lexical-structure-float-literals).

This has the unfortunate side-effect that the invalid literal `1.0xA` is parsed as a qualified name, so the resulting error message is that `1` is not a valid module name. However, it is a bit better than before (which was a crash with no source location). Should I open an issue to improve the error message?