### PR TITLE
Use ICU version 65.1-1 in Github workflows

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -115,7 +115,7 @@ jobs:
   #     matrix:
   #       ghc-ver: ["8.10.1"]
   #       cabal-ver: ["3.2"]
-  #       icu-ver: [58.2-3]
+  #       icu-ver: [65.1-1]
 
   #   env:
   #     FLAGS: "-f enable-cluster-counting"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       matrix:
         ghc-ver: [8.10.1]
-        icu-ver: [58.2-3]
+        icu-ver: [65.1-1]
 
     env:
       ICU_FILE: "mingw-w64-x86_64-icu-${{ matrix.icu-ver }}-any.pkg.tar.xz"

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -124,7 +124,7 @@ jobs:
     strategy:
       matrix:
         ghc-ver: [8.10.1]
-        icu-ver: [58.2-3]
+        icu-ver: [65.1-1]
 
     env:
       ICU_FILE: "mingw-w64-x86_64-icu-${{ matrix.icu-ver }}-any.pkg.tar.xz"


### PR DESCRIPTION
The Windows build has been failing on master recently (example: b1fd5a9) and hopefully this will fix it. 65.1-1 seems to be the only ICU .pkg.tar.xz file currently available at http://repo.msys2.org/mingw/x86_64/ (although maybe a .pkg.tar.zst would work just as well)