### PR TITLE
[ #4958 ] deprecation warnings for things in import directives

### DIFF
--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -2461,6 +2461,12 @@ instance (HasRange a, HasRange b) => HasRange (ImportedName' a b) where
   getRange (ImportedName   x) = getRange x
   getRange (ImportedModule x) = getRange x
 
+-- ** SetRange instances
+
+instance (SetRange a, SetRange b) => SetRange (ImportedName' a b) where
+  setRange r (ImportedName   x) = ImportedName   $ setRange r x
+  setRange r (ImportedModule x) = ImportedModule $ setRange r x
+
 -- ** KillRange instances
 
 instance (KillRange a, KillRange b) => KillRange (ImportDirective' a b) where

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs-boot
@@ -1,0 +1,11 @@
+module Agda.TypeChecking.Monad.Trace where
+
+import Data.Kind (Type)
+
+import Agda.Syntax.Position (HasRange)
+import Agda.TypeChecking.Monad.Base (TCM)
+
+class MonadTrace (m :: Type -> Type)
+instance MonadTrace TCM
+
+setCurrentRange :: (MonadTrace m, HasRange x) => x -> m a -> m a

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -35,6 +35,7 @@ import {-# SOURCE #-} Agda.TypeChecking.Pretty (MonadPretty, prettyTCM)
 import {-# SOURCE #-} Agda.TypeChecking.Pretty.Call
 import {-# SOURCE #-} Agda.TypeChecking.Pretty.Warning ( prettyWarning )
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Pure
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Trace ( MonadTrace, setCurrentRange )
 
 import Agda.Syntax.Abstract.Name ( QName )
 import Agda.Syntax.Common
@@ -147,8 +148,8 @@ warning = withCallerCallStack . flip warning'
 
 -- | Raise every 'WARNING_ON_USAGE' connected to a name.
 {-# SPECIALIZE raiseWarningsOnUsage :: QName -> TCM () #-}
-raiseWarningsOnUsage :: (MonadWarning m, ReadTCState m) => QName -> m ()
-raiseWarningsOnUsage d = do
+raiseWarningsOnUsage :: (MonadWarning m, MonadTrace m, ReadTCState m) => QName -> m ()
+raiseWarningsOnUsage d = setCurrentRange d $ do
   -- In case we find a defined name, we start by checking whether there's
   -- a warning attached to it
   reportSLn "scope.warning.usage" 50 $ "Checking usage of " ++ P.prettyShow d

--- a/test/Succeed/Issue4958.agda
+++ b/test/Succeed/Issue4958.agda
@@ -1,0 +1,10 @@
+-- Andreas, 2020-10-11, issue #4958
+-- Deprecation warning already at import statement.
+
+open import Agda.Builtin.Float public
+  renaming
+    ( primFloatNumericalLess to foo )  -- Expect warning here
+  using
+    ( primFloatNumericalEquality )     -- Expect warning here
+
+bar = foo -- Warning here

--- a/test/Succeed/Issue4958.warn
+++ b/test/Succeed/Issue4958.warn
@@ -1,0 +1,41 @@
+Issue4958.agda:6,7-29
+Warning: primFloatNumericalLess was deprecated in Agda v2.6.2.
+Please use primFloatLess instead.
+when scope checking the declaration
+  open import Agda.Builtin.Float public
+                                 using (primFloatNumericalEquality)
+                                 renaming (primFloatNumericalLess to foo)
+Issue4958.agda:8,7-33
+Warning: primFloatNumericalEquality was deprecated in Agda v2.6.2.
+Please use primFloatEquality instead.
+when scope checking the declaration
+  open import Agda.Builtin.Float public
+                                 using (primFloatNumericalEquality)
+                                 renaming (primFloatNumericalLess to foo)
+Issue4958.agda:10,7-10
+Warning: primFloatNumericalLess was deprecated in Agda v2.6.2.
+Please use primFloatLess instead.
+when scope checking foo
+
+———— All done; warnings encountered ————————————————————————
+
+Issue4958.agda:6,7-29
+Warning: primFloatNumericalLess was deprecated in Agda v2.6.2.
+Please use primFloatLess instead.
+when scope checking the declaration
+  open import Agda.Builtin.Float public
+                                 using (primFloatNumericalEquality)
+                                 renaming (primFloatNumericalLess to foo)
+
+Issue4958.agda:8,7-33
+Warning: primFloatNumericalEquality was deprecated in Agda v2.6.2.
+Please use primFloatEquality instead.
+when scope checking the declaration
+  open import Agda.Builtin.Float public
+                                 using (primFloatNumericalEquality)
+                                 renaming (primFloatNumericalLess to foo)
+
+Issue4958.agda:10,7-10
+Warning: primFloatNumericalLess was deprecated in Agda v2.6.2.
+Please use primFloatLess instead.
+when scope checking foo


### PR DESCRIPTION
User warnings for names mentioned in `using` or `renaming` should be emitted there.  Emitting them at use-site can be confusing, esp. if an identifier has been renamed.

This patch adds code to emit these warnings, but does not take away warnings at use site.

However, this adds deprecation warnings in the std-lib when deprecated identifiers are imported for reexport. See discussion at #4958.