### PR TITLE
Fix #4967

### DIFF
--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -127,8 +127,12 @@ compilerPass tag v name code = SinglePass (CompilerPass tag v name code)
 compilerPipeline :: Int -> QName -> Pipeline
 compilerPipeline v q =
   Sequential
-    [ compilerPass "simpl"   (35 + v) "simplification"      $ const simplifyTTerm
-    , compilerPass "builtin" (30 + v) "builtin translation" $ const translateBuiltins
+    -- Issue #4967: No simplification step before builtin translation! Simplification relies
+    --              on either all or no builtins being translated. Since we might have inlined
+    --              functions that have had the builtin translation applied, we need to apply it
+    --              first.
+    -- [ compilerPass "simpl"   (35 + v) "simplification"      $ const simplifyTTerm
+    [ compilerPass "builtin" (30 + v) "builtin translation" $ const translateBuiltins
     , FixedPoint 5 $ Sequential
       [ compilerPass "simpl"  (30 + v) "simplification"     $ const simplifyTTerm
       , compilerPass "erase"  (30 + v) "erasure"            $ eraseTerms q

--- a/test/Compiler/simple/CaseOnCase.out
+++ b/test/Compiler/simple/CaseOnCase.out
@@ -30,15 +30,16 @@ out >       _ | c >= 1 → "not less"
 out >       _ → "less"
 out > CaseOnCase.fancyCase =
 out >   λ a b →
+out >     let c = a - 1 in
 out >     case a of
 out >       0 → 0
 out >       1 → 1
 out >       2 → 2
-out >       _ → let c = a - 3 in
+out >       _ → let d = a - 3 in
 out >           case b of
 out >             CaseOnCase.Cmp.equal → 4
-out >             CaseOnCase.Cmp.greater → c
-out >             CaseOnCase.Cmp.less → a - 1
+out >             CaseOnCase.Cmp.greater → d
+out >             CaseOnCase.Cmp.less → c
 out > CaseOnCase.main =
 out >   Common.IO.then
 out >     () () _ _ (Common.IO.putStrLn (CaseOnCase.cmp 31 -6))

--- a/test/Succeed/Issue4967.agda
+++ b/test/Succeed/Issue4967.agda
@@ -1,0 +1,16 @@
+
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Nat renaming (_<_ to natLessThan)
+open import Agda.Builtin.Int
+
+_<_ : Int -> Int -> Bool
+_<_ = \ where
+  (pos m) (pos n) -> natLessThan m n
+  (negsuc m) (negsuc n) -> natLessThan n m
+  (negsuc _) (pos _) -> true
+  (pos _) (negsuc _) -> false
+{-# INLINE _<_ #-}
+
+check : Int -> Bool
+check n = pos 0 < n

--- a/test/Succeed/Issue4967.flags
+++ b/test/Succeed/Issue4967.flags
@@ -1,0 +1,1 @@
+-c --no-main -v treeless.opt.final:20

--- a/test/Succeed/Issue4967.warn
+++ b/test/Succeed/Issue4967.warn
@@ -1,0 +1,15 @@
+Issue4967._<_ =
+  λ a b →
+    case a of
+      _ | a >= 0 →
+        case b of
+          _ | b >= 0 → a < b
+          _ → Agda.Builtin.Bool.Bool.false
+      _ → case b of
+            _ | b >= 0 → Agda.Builtin.Bool.Bool.true
+            _ → a < b
+Issue4967.check =
+  λ a →
+    case a of
+      _ | a >= 0 → 0 < a
+      _ → Agda.Builtin.Bool.Bool.false


### PR DESCRIPTION
Fixes #4967.

The problem was that the instance gets inlined and the simplifier can't handle partially builtin-translated code. In this case the pattern matching in the instance implementation had been translated to Haskell integers instead of `pos` and `negsuc` constructors, but the `pos 0` argument in `check` had not. Solution: do builtin-translation as the first step in the pipeline.

This PR also adds a few missing simplifications for Int matching.
