### PR TITLE
Add new TC primitives `onlyReduceDefs` and `dontReduceDefs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,26 @@ Reflection
 
   The builtin is only available when `--allow-exec` is passed. (Note that `--allow-exec` is incompatible with ``--safe``.) To make an executable available to Agda, add the absolute path on a new line in `~/.agda/executables`.
 
+- Two new operations in the `TC` monad, `onlyReduceDefs` and
+  `dontReduceDefs`:
+  ```agda
+  onlyReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A
+  dontReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A
+  ```
+  These functions allow picking a specific set of functions that
+  should (resp. should not) be reduced while executing the given `TC`
+  computation.
+
+  For example, the following macro unifies the current hole with the
+  term `3 - 3`:
+  ```agda
+  macro₁ : Term -> TC ⊤
+  macro₁ goal = do
+    u   ← quoteTC ((1 + 2) - 3)
+    u'  ← onlyReduceDefs (quote _+_ ∷ []) (normalise u)
+    unify u' goal
+  ```
+
 Library management
 ------------------
 

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -448,8 +448,13 @@ following primitive operations::
     -- is higher than the second argument. Note that Level 0 and 1 are printed
     -- to the info buffer instead. For instance, giving -v a.b.c:10 enables
     -- printing from debugPrint "a.b.c.d" 10 msg.
-
     debugPrint : String → Nat → List ErrorPart → TC ⊤
+
+    -- Only allow reduction of specific definitions while executing the TC computation
+    onlyReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A
+
+    -- Don't allow reduction of specific definitions while executing the TC computation
+    dontReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A
 
     -- Fail if the given computation gives rise to new, unsolved
     -- "blocking" constraints.
@@ -484,6 +489,8 @@ following primitive operations::
   {-# BUILTIN AGDATCMISMACRO                    isMacro                    #-}
   {-# BUILTIN AGDATCMWITHNORMALISATION          withNormalisation          #-}
   {-# BUILTIN AGDATCMDEBUGPRINT                 debugPrint                 #-}
+  {-# BUILTIN AGDATCMONLYREDUCEDEFS             onlyReduceDefs             #-}
+  {-# BUILTIN AGDATCMDONTREDUCEDEFS             dontReduceDefs             #-}
   {-# BUILTIN AGDATCMNOCONSTRAINTS              noConstraints              #-}
   {-# BUILTIN AGDATCMRUNSPECULATIVE             runSpeculative             #-}
 

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -277,6 +277,12 @@ postulate
   -- on (with the -v flag to Agda).
   debugPrint : String → Nat → List ErrorPart → TC ⊤
 
+  -- Only allow reduction of specific definitions while executing the TC computation
+  onlyReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A
+
+  -- Don't allow reduction of specific definitions while executing the TC computation
+  dontReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A
+
   -- Fail if the given computation gives rise to new, unsolved
   -- "blocking" constraints.
   noConstraints : ∀ {a} {A : Set a} → TC A → TC A
@@ -313,5 +319,7 @@ postulate
 {-# BUILTIN AGDATCMISMACRO                    isMacro                    #-}
 {-# BUILTIN AGDATCMWITHNORMALISATION          withNormalisation          #-}
 {-# BUILTIN AGDATCMDEBUGPRINT                 debugPrint                 #-}
+{-# BUILTIN AGDATCMONLYREDUCEDEFS             onlyReduceDefs             #-}
+{-# BUILTIN AGDATCMDONTREDUCEDEFS             dontReduceDefs             #-}
 {-# BUILTIN AGDATCMNOCONSTRAINTS              noConstraints              #-}
 {-# BUILTIN AGDATCMRUNSPECULATIVE             runSpeculative             #-}

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -65,6 +65,7 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinAgdaTCMQuoteTerm, builtinAgdaTCMUnquoteTerm, builtinAgdaTCMQuoteOmegaTerm,
   builtinAgdaTCMBlockOnMeta, builtinAgdaTCMCommit, builtinAgdaTCMIsMacro,
   builtinAgdaTCMWithNormalisation, builtinAgdaTCMDebugPrint,
+  builtinAgdaTCMOnlyReduceDefs, builtinAgdaTCMDontReduceDefs,
   builtinAgdaTCMNoConstraints,
   builtinAgdaTCMRunSpeculative,
   builtinAgdaTCMExec
@@ -255,6 +256,8 @@ builtinAgdaTCMQuoteOmegaTerm             = "AGDATCMQUOTEOMEGATERM"
 builtinAgdaTCMIsMacro                    = "AGDATCMISMACRO"
 builtinAgdaTCMWithNormalisation          = "AGDATCMWITHNORMALISATION"
 builtinAgdaTCMDebugPrint                 = "AGDATCMDEBUGPRINT"
+builtinAgdaTCMOnlyReduceDefs             = "AGDATCMONLYREDUCEDEFS"
+builtinAgdaTCMDontReduceDefs             = "AGDATCMDONTREDUCEDEFS"
 builtinAgdaTCMNoConstraints              = "AGDATCMNOCONSTRAINTS"
 builtinAgdaTCMRunSpeculative             = "AGDATCMRUNSPECULATIVE"
 builtinAgdaTCMExec                       = "AGDATCMEXEC"

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2294,6 +2294,16 @@ shouldReduceDef f = asksTC envReduceDefs <&> \case
   OnlyReduceDefs defs -> f `Set.member` defs
   DontReduceDefs defs -> not $ f `Set.member` defs
 
+instance Semigroup ReduceDefs where
+  OnlyReduceDefs qs1 <> OnlyReduceDefs qs2 = OnlyReduceDefs $ Set.intersection qs1 qs2
+  OnlyReduceDefs qs1 <> DontReduceDefs qs2 = OnlyReduceDefs $ Set.difference   qs1 qs2
+  DontReduceDefs qs1 <> OnlyReduceDefs qs2 = OnlyReduceDefs $ Set.difference   qs2 qs1
+  DontReduceDefs qs1 <> DontReduceDefs qs2 = DontReduceDefs $ Set.union        qs1 qs2
+
+instance Monoid ReduceDefs where
+  mempty  = reduceAllDefs
+  mappend = (<>)
+
 -- | Primitives
 
 data PrimitiveImpl = PrimImpl Type PrimFun
@@ -2944,6 +2954,9 @@ eSimplification f e = f (envSimplification e) <&> \ x -> e { envSimplification =
 
 eAllowedReductions :: Lens' AllowedReductions TCEnv
 eAllowedReductions f e = f (envAllowedReductions e) <&> \ x -> e { envAllowedReductions = x }
+
+eReduceDefs :: Lens' ReduceDefs TCEnv
+eReduceDefs f e = f (envReduceDefs e) <&> \ x -> e { envReduceDefs = x }
 
 eInjectivityDepth :: Lens' Int TCEnv
 eInjectivityDepth f e = f (envInjectivityDepth e) <&> \ x -> e { envInjectivityDepth = x }

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2289,6 +2289,12 @@ data ReduceDefs
 reduceAllDefs :: ReduceDefs
 reduceAllDefs = DontReduceDefs empty
 
+locallyReduceDefs :: MonadTCEnv m => ReduceDefs -> m a -> m a
+locallyReduceDefs = locallyTC eReduceDefs . const
+
+locallyReduceAllDefs :: MonadTCEnv m => m a -> m a
+locallyReduceAllDefs = locallyReduceDefs reduceAllDefs
+
 shouldReduceDef :: (MonadTCEnv m) => QName -> m Bool
 shouldReduceDef f = asksTC envReduceDefs <&> \case
   OnlyReduceDefs defs -> f `Set.member` defs

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -221,6 +221,7 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primAgdaTCMQuoteTerm, primAgdaTCMUnquoteTerm, primAgdaTCMQuoteOmegaTerm,
     primAgdaTCMBlockOnMeta, primAgdaTCMCommit, primAgdaTCMIsMacro,
     primAgdaTCMWithNormalisation, primAgdaTCMDebugPrint,
+    primAgdaTCMOnlyReduceDefs, primAgdaTCMDontReduceDefs,
     primAgdaTCMNoConstraints,
     primAgdaTCMRunSpeculative,
     primAgdaTCMExec
@@ -409,6 +410,8 @@ primAgdaTCMCommit                     = getBuiltin builtinAgdaTCMCommit
 primAgdaTCMIsMacro                    = getBuiltin builtinAgdaTCMIsMacro
 primAgdaTCMWithNormalisation          = getBuiltin builtinAgdaTCMWithNormalisation
 primAgdaTCMDebugPrint                 = getBuiltin builtinAgdaTCMDebugPrint
+primAgdaTCMOnlyReduceDefs             = getBuiltin builtinAgdaTCMOnlyReduceDefs
+primAgdaTCMDontReduceDefs             = getBuiltin builtinAgdaTCMDontReduceDefs
 primAgdaTCMNoConstraints              = getBuiltin builtinAgdaTCMNoConstraints
 primAgdaTCMRunSpeculative             = getBuiltin builtinAgdaTCMRunSpeculative
 primAgdaTCMExec                       = getBuiltin builtinAgdaTCMExec

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -694,8 +694,8 @@ class ( Functor m
 
 {-# SPECIALIZE getConstInfo :: QName -> TCM Definition #-}
 
-defaultGetRewriteRulesFor :: (Monad m) => m TCState -> QName -> m RewriteRules
-defaultGetRewriteRulesFor getTCState q = do
+defaultGetRewriteRulesFor :: (ReadTCState m, MonadTCEnv m) => QName -> m RewriteRules
+defaultGetRewriteRulesFor q = ifNotM (shouldReduceDef q) (return []) $ do
   st <- getTCState
   let sig = st^.stSignature
       imp = st^.stImports
@@ -708,7 +708,7 @@ getOriginalProjection :: HasConstInfo m => QName -> m QName
 getOriginalProjection q = projOrig . fromMaybe __IMPOSSIBLE__ <$> isProjection q
 
 instance HasConstInfo (TCMT IO) where
-  getRewriteRulesFor = defaultGetRewriteRulesFor getTC
+  getRewriteRulesFor = defaultGetRewriteRulesFor
   getConstInfo' q = do
     st  <- getTC
     env <- askTC

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -526,6 +526,7 @@ unfoldDefinitionStep unfoldDelayed v0 f es =
   rewr <- instantiateRewriteRules =<< getRewriteRulesFor f
   allowed <- asksTC envAllowedReductions
   prp <- runBlocked $ isPropM $ defType info
+  defOk <- shouldReduceDef f
   let def = theDef info
       v   = v0 `applyE` es
       -- Non-terminating functions
@@ -537,6 +538,7 @@ unfoldDefinitionStep unfoldDelayed v0 f es =
         || (defTerminationUnconfirmed info && SmallSet.notMember UnconfirmedReductions allowed)
         || (defDelayed info == Delayed && not unfoldDelayed)
         || prp == Right True || isIrrelevant (defArgInfo info)
+        || not defOk
       copatterns = defCopatternLHS info
   case def of
     Constructor{conSrcCon = c} -> do

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -121,9 +121,11 @@ compactDef bEnv def rewr = do
         _      -> False
   let irr = isPrp || isIrrelevant (defArgInfo def)
 
+  dontReduce <- not <$> shouldReduceDef (defName def)
+
   cdefn <-
     case theDef def of
-      _ | irr -> pure CAxiom
+      _ | irr || dontReduce -> pure CAxiom
       _ | Just (defName def) == bPrimForce bEnv   -> pure CForce
       _ | Just (defName def) == bPrimErase bEnv ->
           case telView' (defType def) of

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -87,7 +87,7 @@ instance MonadDebug ReduceM where
     bracket_ (openVerboseBracket k n s) (const $ closeVerboseBracket k n)
 
 instance HasConstInfo ReduceM where
-  getRewriteRulesFor = defaultGetRewriteRulesFor getTCState
+  getRewriteRulesFor = defaultGetRewriteRulesFor
   getConstInfo' q = do
     ReduceEnv env st <- askR
     defaultGetConstInfo st env q

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -370,6 +370,9 @@ coreBuiltins =
   , builtinAgdaTCMIsMacro                    |-> builtinPostulate (tqname --> tTCM_ primBool)
   , builtinAgdaTCMWithNormalisation          |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tbool --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMDebugPrint                 |-> builtinPostulate (tstring --> tnat --> tlist terrorpart --> tTCM_ primUnit)
+  , builtinAgdaTCMOnlyReduceDefs             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tlist tqname --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+  , builtinAgdaTCMDontReduceDefs             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tlist tqname --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+
   , builtinAgdaTCMNoConstraints              |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMRunSpeculative             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
                                                                    tTCM 1 (primSigma <#> varM 1 <#> primLevelZero <@> varM 0 <@> (Lam defaultArgInfo . Abs "_" <$> primBool)) --> tTCM 1 (varM 0))

--- a/test/Succeed/ReduceDefs.agda
+++ b/test/Succeed/ReduceDefs.agda
@@ -1,0 +1,32 @@
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
+open import Agda.Builtin.Equality
+
+macro
+  macro₁ : Term -> TC ⊤
+  macro₁ goal = do
+    u   ← quoteTC ((1 + 2) - 3)
+    u'  ← onlyReduceDefs (quote _+_ ∷ []) (normalise u)
+    qu' ← quoteTC u'
+    unify qu' goal
+
+test₁ : macro₁ ≡ def (quote _-_)
+                   (arg (arg-info visible relevant) (lit (nat 3)) ∷
+                    arg (arg-info visible relevant) (lit (nat 3)) ∷ [])
+test₁ = refl
+
+
+macro
+  macro₂ : Term -> TC ⊤
+  macro₂ goal = do
+    u   ← quoteTC ((1 - 2) + 3)
+    u'  ← dontReduceDefs (quote _+_ ∷ []) (normalise u)
+    qu' ← quoteTC u'
+    unify qu' goal
+
+test₂ : macro₂ ≡ def (quote _+_)
+                   (arg (arg-info visible relevant) (lit (nat 0)) ∷
+                    arg (arg-info visible relevant) (lit (nat 3)) ∷ [])
+test₂ = refl


### PR DESCRIPTION
This PR adds two new reflection primitives that allow controlling what definitions should be unfolded. See the changelog and test case for more details.