### PR TITLE
Remove use of undefine in Makefiles

### DIFF
--- a/mk/stack.mk
+++ b/mk/stack.mk
@@ -3,5 +3,5 @@ STACK=stack
 ifneq ($(wildcard $(TOP)/stack.yaml),)
   HAS_STACK := 1
 else
-  undefine HAS_STACK
+  HAS_STACK :=
 endif


### PR DESCRIPTION
`undefine` was introduced in Make v3.82, but the version that ships with macOS Catalina is v3.81, so Mac users currently have to install another version of make in order to build Agda from source. We can just leave the `HAS_STACK` variable implicitly undefined instead.