### PR TITLE
Streamline installation from source

### DIFF
--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -254,15 +254,18 @@ After getting the development version from the Git `repository
   .. code-block:: bash
 
     cabal update
-    make install
+    make install CABAL_OPTS='-j1'
     agda-mode setup
+
+  You can omit ``CABAL_OPTS='-j1'`` in order to speed up installation of Agda's
+  dependencies, but ``cabal`` will output less build progress to stdout.
 
   Note that on a Mac, because ICU is installed in a non-standard location,
   you need to specify this location on the command line:
 
   .. code-block:: bash
 
-    make install CABAL_OPTS='--extra-lib-dirs=/usr/local/opt/icu4c/lib --extra-include-dirs=/usr/local/opt/icu4c/include'
+    make install CABAL_OPTS='-j1 --extra-lib-dirs=/usr/local/opt/icu4c/lib --extra-include-dirs=/usr/local/opt/icu4c/include'
 
   You can also add the ``CABAL_OPTS`` variable to ``mk/config.mk`` (see
   ``HACKING.md``) instead of passing it via the command line.

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -267,6 +267,15 @@ After getting the development version from the Git `repository
   You can also add the ``CABAL_OPTS`` variable to ``mk/config.mk`` (see
   ``HACKING.md``) instead of passing it via the command line.
 
+  To install via ``stack`` instead of ``cabal``, copy one of the
+  ``stack-x.x.x.yaml`` files of your choice to a ``stack.yaml`` file before
+  running ``make``. For example:
+
+  .. code-block:: bash
+
+    cp stack-8.10.1.yaml stack.yaml
+    make install
+
 .. _installation-flags:
 
 Installation Flags

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -255,7 +255,6 @@ After getting the development version from the Git `repository
 
     cabal update
     make install CABAL_OPTS='-j1'
-    agda-mode setup
 
   You can omit ``CABAL_OPTS='-j1'`` in order to speed up installation of Agda's
   dependencies, but ``cabal`` will output less build progress to stdout.

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -254,17 +254,14 @@ After getting the development version from the Git `repository
   .. code-block:: bash
 
     cabal update
-    make install CABAL_OPTS='-j1'
-
-  You can omit ``CABAL_OPTS='-j1'`` in order to speed up installation of Agda's
-  dependencies, but ``cabal`` will output less build progress to stdout.
+    make install
 
   Note that on a Mac, because ICU is installed in a non-standard location,
   you need to specify this location on the command line:
 
   .. code-block:: bash
 
-    make install CABAL_OPTS='-j1 --extra-lib-dirs=/usr/local/opt/icu4c/lib --extra-include-dirs=/usr/local/opt/icu4c/include'
+    make install CABAL_OPTS='--extra-lib-dirs=/usr/local/opt/icu4c/lib --extra-include-dirs=/usr/local/opt/icu4c/include'
 
   You can also add the ``CABAL_OPTS`` variable to ``mk/config.mk`` (see
   ``HACKING.md``) instead of passing it via the command line.

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -244,30 +244,28 @@ To configure the way of editing agda files, follow the section
 Installation of the Development Version
 =======================================
 
-After getting the development version following the instructions in
-the `Agda wiki <https://wiki.portal.chalmers.se/agda/pmwiki.php>`_:
+After getting the development version from the Git `repository
+<https://github.com/agda/agda>`_
 
 * Install the :ref:`prerequisites <prerequisites>`
 
-* In the top-level directory of the Agda source tree
+* In the top-level directory of the Agda source tree, run:
 
-  * Follow the :ref:`instructions <installation-from-hackage>` for
-    installing Agda from Hackage (except run ``cabal install``
-    instead of ``cabal install Agda``) or
+  .. code-block:: bash
 
-  * You can try to install Agda (including a compiled Emacs mode) by
-    running the following command:
+    cabal update
+    make install
+    agda-mode setup
 
-    .. code-block:: bash
+  Note that on a Mac, because ICU is installed in a non-standard location,
+  you need to specify this location on the command line:
 
-      make install
+  .. code-block:: bash
 
-    Note that on a Mac, because ICU is installed in a non-standard location,
-    you need to specify this location on the command line:
+    make install CABAL_OPTS='--extra-lib-dirs=/usr/local/opt/icu4c/lib --extra-include-dirs=/usr/local/opt/icu4c/include'
 
-    .. code-block:: bash
-
-      make install-bin CABAL_OPTS='--extra-lib-dirs=/usr/local/opt/icu4c/lib --extra-include-dirs=/usr/local/opt/icu4c/include'
+  You can also add the ``CABAL_OPTS`` variable to ``mk/config.mk`` (see
+  ``HACKING.md``) instead of passing it via the command line.
 
 .. _installation-flags:
 


### PR DESCRIPTION
I figure we should just tell people to run `make install` instead of `cabal install`.

Should I also mention `CABAL_OPTS=-j1`? Without it, cabal install doesn't show any progress on stdout, which might confuse people.