### PR TITLE
Don't quote single-clause absurd pattern to absurd lambda

### DIFF
--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -682,7 +682,7 @@ reifyTerm expandAnonDefs0 v0 = do
 
         extLam <- case def of
           Function{ funExtLam = Just{}, funProjection = Just{} } -> __IMPOSSIBLE__
-          Function{ funExtLam = Just (ExtLamInfo m sys) } ->
+          Function{ funExtLam = Just (ExtLamInfo m b sys) } ->
             Just . (,Strict.toLazy sys) . size <$> lookupSection m
           _ -> return Nothing
         case extLam of

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1815,6 +1815,8 @@ data ExtLamInfo = ExtLamInfo
     --   module during type checking though, since if the lambda appears in a
     --   refined context the module picked by the scope checker has very much
     --   the wrong parameters.
+  , extLamAbsurd :: Bool
+    -- ^ Was this definition created from an absurd lambda @λ ()@?
   , extLamSys :: !(Strict.Maybe System)
   } deriving (Data, Show)
 
@@ -4439,7 +4441,7 @@ instance KillRange System where
   killRange (System tel sys) = System (killRange tel) (killRange sys)
 
 instance KillRange ExtLamInfo where
-  killRange (ExtLamInfo m sys) = killRange2 ExtLamInfo m sys
+  killRange (ExtLamInfo m b sys) = killRange3 ExtLamInfo m b sys
 
 instance KillRange FunctionFlag where
   killRange = id

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -892,8 +892,8 @@ getDefModule :: HasConstInfo m => QName -> m (Either SigError ModuleName)
 getDefModule f = mapRight modName <$> getConstInfo' f
   where
     modName def = case theDef def of
-      Function{ funExtLam = Just (ExtLamInfo m _) } -> m
-      _                                             -> qnameModule f
+      Function{ funExtLam = Just (ExtLamInfo m _ _) } -> m
+      _                                               -> qnameModule f
 
 -- | Compute the number of free variables of a defined name. This is the sum of
 --   number of parameters shared with the current module and the number of

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -231,14 +231,14 @@ quotingKit = do
             let
               conOrProjPars = defParameters defn
               ts = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
-              qx Function{ funExtLam = Just (ExtLamInfo m _), funClauses = cs } = do
+              qx Function{ funExtLam = Just (ExtLamInfo m False _), funClauses = cs } = do
                     -- An extended lambda should not have any extra parameters!
                     unless (null conOrProjPars) __IMPOSSIBLE__
                     n <- size <$> lookupSection m
                     let (pars, args) = splitAt n ts
                     extlam !@ list (map (quoteClause . (`apply` pars)) cs)
                            @@ list (map (quoteArg quoteTerm) args)
-              qx df@Function{ funCompiled = Just Fail, funClauses = [cl] } = do
+              qx df@Function{ funExtLam = Just (ExtLamInfo _ True _) , funCompiled = Just Fail, funClauses = [cl] } = do
                     -- See also corresponding code in InternalToAbstract
                     let n = length (namedClausePats cl) - 1
                         pars = take n ts

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -742,6 +742,7 @@ checkAbsurdLambda cmp i h e t = localTC (set eQuantity topQuantity) $ do
               , funSplitTree      = Just $ SplittingDone 0
               , funMutual         = Just []
               , funTerminates     = Just True
+              , funExtLam         = Just $ ExtLamInfo top True empty
               }
           -- Andreas 2012-01-30: since aux is lifted to toplevel
           -- it needs to be applied to the current telescope (issue 557)
@@ -788,7 +789,7 @@ checkExtendedLambda cmp i di qname cs e t = localTC (set eQuantity topQuantity) 
        addConstant qname =<< do
          useTerPragma $
            (defaultDefn info qname t emptyFunction) { defMutual = j }
-       checkFunDef' t info NotDelayed (Just $ ExtLamInfo lamMod empty) Nothing di qname $
+       checkFunDef' t info NotDelayed (Just $ ExtLamInfo lamMod False empty) Nothing di qname $
          List1.toList cs
        whenNothingM (asksTC envMutualBlock) $
          -- Andrea 10-03-2018: Should other checks be performed here too? e.g. termination/positivity/..

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -293,7 +293,7 @@ instance EmbPrj System where
   value = valueN System
 
 instance EmbPrj ExtLamInfo where
-  icod_ (ExtLamInfo a b) = icodeN' ExtLamInfo a b
+  icod_ (ExtLamInfo a b c) = icodeN' ExtLamInfo a b c
 
   value = valueN ExtLamInfo
 

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -479,7 +479,7 @@ instance Apply CompiledClauses where
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
 
 instance Apply ExtLamInfo where
-  apply (ExtLamInfo m sys) args = ExtLamInfo m (apply sys args)
+  apply (ExtLamInfo m b sys) args = ExtLamInfo m b (apply sys args)
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
 
 instance Apply System where

--- a/test/Succeed/QuoteAbsurdClause.agda
+++ b/test/Succeed/QuoteAbsurdClause.agda
@@ -1,0 +1,41 @@
+
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.List
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
+
+data ⊥ : Set where
+
+[_] : {A : Set} → A → List A
+[ x ] = x ∷ []
+
+vArg : {A : Set} → A → Arg A
+vArg x = arg (arg-info visible relevant) x
+
+macro
+  getFunDef : Name → Term → TC ⊤
+  getFunDef f hole = do
+    function cls ← getDefinition f
+      where _ → error
+    niceCls ← quoteTC cls
+    unify hole niceCls
+
+    where postulate error : _
+
+noooo : (A : Set) → ⊥ → A
+noooo A ()
+
+-- Quoting the term `noooo Nat x` used to produce an absurd lambda
+-- applied to `x`, which should not happen. It should instead simply
+-- keep the term `noooo Nat x` as-is.
+fooooo : ⊥ → Nat
+fooooo x = noooo Nat x
+
+test : getFunDef fooooo ≡
+         [
+           clause [ "x" , vArg (def (quote ⊥) []) ] [ vArg (var 0) ]
+                  (def (quote noooo) (vArg (def (quote Nat) []) ∷ vArg (var 0 []) ∷ []))
+         ]
+test = refl


### PR DESCRIPTION
Currently, applications of simple definitions with a single absurd clause are quoted to an application of an absurd lambda. This patch fixes that by remembering which definitions were created from absurd lambdas, and leave alone the others.