### PR TITLE
Force interface regeneration using --ignore-all-interfaces.

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -108,6 +108,7 @@ generateInterfaces pd lbi = do
 
     putStrLn $ "... " ++ fullpath
     ok <- rawSystem' ddir agda [ "--no-libraries", "--local-interfaces"
+                               , "--ignore-all-interfaces"
                                , "-Werror"
                                , fullpath, "-v0"
                                ]


### PR DESCRIPTION
Currently when building Agda, the interface generation step for builtin modules does not force the actual regeneration of the interfaces.  That is, if ` src/data/lib/prim/Agda` already contains `.agdai` interface for a module (from a previous build), its regeneration would be skipped.  This makes the following scenario very difficult to debug:
1. Assume a broken build of Agda that generates incorrect interfaces.
2. If some module `B` uses the (broken) interface of module `A`, the compilation would stop at `B`. E.g. `Cubical/Glue.agda` uses `Sigma.agda`, if `Sigma.agdai` were to be broken, the compilation would fail at `Glue.agda`.
3. Assume I fixed the problem and now I rebuild the project.
4. When we come to generating interfaces, the broken `Sigma.agdai` interface would be picked-up and the compilation would fail at `Glue.agda`.

The fix forces actual regeneration of the interfaces by adding a hidden `--ignore-all-interfaces` to the agda call.

I can verify that the problem is fixed by running
```sh
echo "BOOM" > src/data/lib/prim/Agda/Builtin/Sigma.agdai
```
before recompiling, and observing that compilation terminates successfully.