### PR TITLE
[ make ] Distinguish v1-cabal dist directories by GHC version

### DIFF
--- a/mk/ghc.mk
+++ b/mk/ghc.mk
@@ -23,5 +23,8 @@ endif
 # We ask if GHC is available for removing a warning on Travis when
 # testing the documentation.
 ifneq ($(GHC),)
+# major.minor, e.g. 8.10
 GHC_VERSION := $(shell $(GHC) --numeric-version | cut -d. -f1-2)
+# major.minor.subminor, e.g. 8.10.2
+GHC_VER := $(shell $(GHC) --numeric-version | cut -d. -f1-3)
 endif

--- a/mk/paths.mk
+++ b/mk/paths.mk
@@ -23,7 +23,11 @@ COMPAT_SRC_DIR = $(SRC_DIR)/compat
 #
 # Thus it may be worthwhile to keep the present infrastructure with
 # different build directories for different versions of Agda.
-BUILD_DIR = $(TOP)/dist-$(VERSION)
+#
+# Andreas, 2020-10-26 further refinement:
+# I often switch GHC version, so indexing v1-style build directories
+# by GHC version x.y.z makes sense.
+BUILD_DIR = $(TOP)/dist-$(VERSION)-ghc-$(GHC_VER)
 
 OUT_DIR        = $(TOP)/out
 FULL_OUT_DIR   = $(OUT_DIR)/full


### PR DESCRIPTION
Since I often switch GHC version to test compilation, it is convenient to not overwrite the .o/.hi files generated by another version of GHC.

The format of the dist directories is now

    dist-${VERSION}-ghc-${GHC_VER}

where `VERSION` is the Agda version and `GHC_VER` the x.y.z GHC version.