### PR TITLE
#5002 Fix problem with =null exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,10 +59,11 @@ dist/
 doc/user-manual.pdf
 exec-test*
 hlint-report.html
+jAgda.*.js
 module-dependency-graph.dot
 module-dependency-graph.pdf
 pkg-build*
 stack.yaml
-stack.yaml.lock
+stack*.yaml.lock
 trash.txt
 \#*\#

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -365,7 +365,9 @@ definition' kit q d t ls = do
                   $ T.mkTApp (raise etaN body) (T.TVar <$> [etaN-1, etaN-2 .. 0])
 
         reportSDoc "compile.js" 30 $ " compiled JS fun:" <+> (text . show) funBody'
-        return $ Just $ Export ls funBody'
+        return $
+          if funBody' == Null then Nothing
+          else Just $ Export ls funBody'
 
     Primitive{primName = p} | p `Set.member` primitives ->
       plainJS $ "agdaRTS." ++ p

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -48,6 +48,11 @@ initLast :: List1 a -> ([a], a)
 initLast = List1.init &&& List1.last
   -- traverses twice, but does not create intermediate pairs
 
+-- | Build a list with one element.
+
+singleton :: a -> List1 a
+singleton = (:| [])
+
 -- | Append a list to a non-empty list.
 
 append :: List1 a -> [a] -> List1 a

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -193,7 +193,7 @@ agdaRunProgGoldenTest :: FilePath     -- ^ directory where to run the tests.
     -> TestOptions
     -> Maybe TestTree
 agdaRunProgGoldenTest dir comp extraArgs inp opts =
-      agdaRunProgGoldenTest1 dir comp extraArgs inp opts (\compDir out err -> do
+      agdaRunProgGoldenTest1 dir comp extraArgs inp opts $ \compDir out err -> do
         if executeProg opts then do
           -- read input file, if it exists
           inp' <- maybe T.empty decodeUtf8 <$> readFileMaybe inpFile
@@ -209,7 +209,6 @@ agdaRunProgGoldenTest dir comp extraArgs inp opts =
               return $ ExecutedProg $ ProgramResult ret (out <> out') (err <> err')
         else
           return $ CompileSucceeded (ProgramResult ExitSuccess out err)
-        )
   where inpFile = dropAgdaExtension inp <.> ".inp"
 
 agdaRunProgGoldenTest1 :: FilePath     -- ^ directory where to run the tests.

--- a/test/Compiler/with-stdlib/AllStdLib.agda
+++ b/test/Compiler/with-stdlib/AllStdLib.agda
@@ -6,8 +6,8 @@ import README
 
 open import Data.Unit.Polymorphic using (⊤)
 open import Data.String
-open import IO hiding (_>>_)
-import IO.Primitive as Prim
+open import IO using (putStrLn; run)
+open import IO.Primitive using (IO; _>>=_)
 
 import DivMod
 import HelloWorld
@@ -18,15 +18,16 @@ import Vec
 import dimensions
 
 infixr 1 _>>_
-_>>_ : ∀ {A B : Set} → Prim.IO A → Prim.IO B → Prim.IO B
-m >> m₁ = m Prim.>>= λ _ → m₁
+_>>_ : ∀ {A B : Set} → IO A → IO B → IO B
+m >> m₁ = m >>= λ _ → m₁
 
-main : Prim.IO ⊤
-main = run (putStrLn "Hello World!") >>
-       DivMod.main >>
-       HelloWorld.main >>
-       HelloWorldPrim.main >>
-       ShowNat.main >>
-       TrustMe.main >>
-       Vec.main >>
-       dimensions.main
+main : IO ⊤
+main = do
+  run (putStrLn "Hello World!")
+  DivMod.main
+  HelloWorld.main
+  HelloWorldPrim.main
+  ShowNat.main
+  TrustMe.main
+  Vec.main
+  dimensions.main


### PR DESCRIPTION
#5002 and #4962 Fix problem with =null exports:

* Skip exports of the form

  exports["A"]["B"]["f"] = null;

since these are anyway redundant and have caused havoc when A.B.f was already defined otherwise.

* Only emit call to main if main is present

* Refactorings for safety and Haskell code readability
