### PR TITLE
GHC Backend: Improved state management and other cleanups

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -269,7 +269,7 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
   minf   <- getBuiltinName builtinInf
   mflat  <- getBuiltinName builtinFlat
   let retDecls ds = return (mempty, ds)
-  main <- checkTypeOfMain isMain q def
+  main <- checkTypeOfMain isMain def
   second ((main ++) . infodecl q) <$>
     case d of
 

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -362,8 +362,9 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
   mmaybe <- getBuiltinName builtinMaybe
   minf   <- getBuiltinName builtinInf
   mflat  <- getBuiltinName builtinFlat
+  typeCheckedMainDef <- checkTypeOfMain isMain def
+  let mainDecl = maybeToList $ checkedMainDecl <$> typeCheckedMainDef
   let retDecls ds = return (mempty, ds)
-  mainDecl <- maybeToList <$> checkTypeOfMain isMain def
   second ((mainDecl ++) . infodecl q) <$>
     case d of
 

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -226,20 +226,23 @@ imports = (hsImps ++) <$> imps where
   uniq = List.map head . List.group . List.sort
 
 -- Should we import MAlonzo.RTE.Float
-data UsesFloat = YesFloat | NoFloat
-  deriving (Eq, Show)
+newtype UsesFloat = UsesFloat Bool deriving (Eq, Show)
+
+pattern YesFloat :: UsesFloat
+pattern YesFloat = UsesFloat True
+
+pattern NoFloat :: UsesFloat
+pattern NoFloat = UsesFloat False
 
 instance Semigroup UsesFloat where
-  NoFloat  <> i        = i
-  i        <> NoFloat  = i
-  YesFloat <> YesFloat = YesFloat
+  UsesFloat a <> UsesFloat b = UsesFloat (a || b)
 
 instance Monoid UsesFloat where
   mempty  = NoFloat
   mappend = (<>)
 
 mazRTEFloatImport :: UsesFloat -> [HS.ImportDecl]
-mazRTEFloatImport i = [ HS.ImportDecl mazRTEFloat True Nothing | i == YesFloat ]
+mazRTEFloatImport (UsesFloat b) = [ HS.ImportDecl mazRTEFloat True Nothing | b ]
 
 --------------------------------------------------
 -- Main compiling clauses

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -535,7 +535,7 @@ checkConstructorType q hs = do
                                 (HS.UnGuardedRhs $ fakeExp hs) emptyBinds]
          ]
 
-checkCover :: QName -> HaskellType -> Nat -> [QName] -> [HaskellCode] -> TCM [HS.Decl]
+checkCover :: HasConstInfo m => QName -> HaskellType -> Nat -> [QName] -> [HaskellCode] -> m [HS.Decl]
 checkCover q ty n cs hsCons = do
   let tvs = [ "a" ++ show i | i <- [1..n] ]
       makeClause c hsc = do

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -174,15 +174,17 @@ ghcPostModule _ _ isMain _ defs0 = do
   let imps = mazRTEFloatImport usedFloat ++ imports builtinThings usedModules defs
 
   m <- curHsMod
+  i <- curIF
 
   -- Get content of FOREIGN pragmas.
-  (headerPragmas, hsImps, code) <- foreignHaskell
+  let (headerPragmas, hsImps, code) = foreignHaskell i
+
   writeModule $ HS.Module m
     (map HS.OtherPragma headerPragmas)
     imps
     (map fakeDecl (hsImps ++ code) ++ decls)
 
-  hasMainFunction isMain <$> curIF
+  return $ hasMainFunction isMain i
 
 ghcCompileDef :: GHCOptions -> GHCModuleEnv -> IsMain -> Definition -> TCM (UsesFloat, [HS.Decl])
 ghcCompileDef _ env isMain def = definition env isMain def

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -47,7 +47,6 @@ import Agda.Syntax.Literal
 import Agda.TypeChecking.Primitive (getBuiltinName)
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Pretty hiding ((<>))
-import qualified Agda.TypeChecking.Pretty as P
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Warnings

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -269,8 +269,8 @@ definition env isMain def@Defn{defName = q, defType = ty, theDef = d} = do
   minf   <- getBuiltinName builtinInf
   mflat  <- getBuiltinName builtinFlat
   let retDecls ds = return (mempty, ds)
-  main <- checkTypeOfMain isMain def
-  second ((main ++) . infodecl q) <$>
+  mainDecl <- maybeToList <$> checkTypeOfMain isMain def
+  second ((mainDecl ++) . infodecl q) <$>
     case d of
 
       _ | Just (HsDefn r hs) <- pragma -> setCurrentRange r $

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -60,7 +60,7 @@ data WhyNot = NoPragmaFor QName
             | BadMeta Term
             | BadDontCare Term
 
-type ToHs = ExceptT WhyNot TCM
+type ToHs = ExceptT WhyNot HsCompileM
 
 notAHaskellType :: Term -> WhyNot -> TCM a
 notAHaskellType top offender = typeError . GenericDocError =<< do
@@ -95,14 +95,14 @@ notAHaskellType top offender = typeError . GenericDocError =<< do
            , text ("for a suitable Haskell " ++ hsThing ++ ".")
            ]
 
-runToHs :: Term -> ToHs a -> TCM a
-runToHs top m = either (notAHaskellType top) return =<< runExceptT m
+runToHs :: Term -> ToHs a -> HsCompileM a
+runToHs top m = either (liftTCM . notAHaskellType top) return =<< runExceptT m
 
 liftE1' :: (forall b. (a -> m b) -> m b) -> (a -> ExceptT e m b) -> ExceptT e m b
 liftE1' f k = ExceptT (f (runExceptT . k))
 
 -- Only used in hsTypeApproximation below, and in that case we catch the error.
-getHsType' :: QName -> TCM HS.Type
+getHsType' :: QName -> HsCompileM HS.Type
 getHsType' q = runToHs (Def q []) (getHsType q)
 
 getHsType :: QName -> ToHs HS.Type
@@ -111,7 +111,7 @@ getHsType x = do
   list <- liftTCM $ getBuiltinName builtinList
   mayb <- liftTCM $ getBuiltinName builtinMaybe
   inf  <- liftTCM $ getBuiltinName builtinInf
-  let namedType = liftTCM $ do
+  let namedType = do
         -- For these builtin types, the type name (xhqn ...) refers to the
         -- generated, but unused, datatype and not the primitive type.
         nat  <- getBuiltinName builtinNat
@@ -119,10 +119,10 @@ getHsType x = do
         bool <- getBuiltinName builtinBool
         if  | Just x `elem` [nat, int] -> return $ hsCon "Integer"
             | Just x == bool           -> return $ hsCon "Bool"
-            | otherwise                -> hsCon . prettyShow <$> xhqn "T" x
+            | otherwise                -> lift $ hsCon . prettyShow <$> xhqn "T" x
   mapExceptT (setCurrentRange d) $ case d of
-    _ | Just x == list -> liftTCM $ hsCon . prettyShow <$> xhqn "T" x -- we ignore Haskell pragmas for List
-    _ | Just x == mayb -> liftTCM $ hsCon . prettyShow <$> xhqn "T" x -- we ignore Haskell pragmas for Maybe
+    _ | Just x == list -> lift $ hsCon . prettyShow <$> xhqn "T" x -- we ignore Haskell pragmas for List
+    _ | Just x == mayb -> lift $ hsCon . prettyShow <$> xhqn "T" x -- we ignore Haskell pragmas for Maybe
     _ | Just x == inf  -> return $ hsQCon "MAlonzo.RTE" "Infinity"
     Just HsDefn{}      -> throwError $ WrongPragmaFor (getRange d) x
     Just HsType{}      -> namedType
@@ -139,7 +139,7 @@ getHsVar i = HS.Ident . encodeName <$> nameOfBV i
       | c `elem` okChars = [c]
       | otherwise        = "Z" ++ show (fromEnum c)
 
-haskellType' :: Type -> TCM HS.Type
+haskellType' :: Type -> HsCompileM HS.Type
 haskellType' t = runToHs (unEl t) (fromType t)
   where
     fromArgs = mapM (fromTerm . unArg)
@@ -173,7 +173,7 @@ haskellType' t = runToHs (unEl t) (fromType t)
         DontCare{} -> throwError (BadDontCare v)
         Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 
-haskellType :: QName -> TCM HS.Type
+haskellType :: QName -> HsCompileM HS.Type
 haskellType q = do
   def <- getConstInfo q
   let (np, erased) =
@@ -219,7 +219,7 @@ checkConstructorCount d cs hsCons
 data PolyApprox = PolyApprox | NoPolyApprox
   deriving (Eq)
 
-hsTypeApproximation :: PolyApprox -> Int -> Type -> TCM HS.Type
+hsTypeApproximation :: PolyApprox -> Int -> Type -> HsCompileM HS.Type
 hsTypeApproximation poly fv t = do
   list <- getBuiltinName builtinList
   mayb <- getBuiltinName builtinMaybe
@@ -264,10 +264,10 @@ hsTypeApproximation poly fv t = do
 -- actually keep track of type applications in recursive functions, and
 -- generate parameterised datatypes. Otherwise we'll just coerce all type
 -- variables to `Any` at the first `unsafeCoerce`.
-hsTelApproximation :: Type -> TCM ([HS.Type], HS.Type)
+hsTelApproximation :: Type -> HsCompileM ([HS.Type], HS.Type)
 hsTelApproximation = hsTelApproximation' NoPolyApprox
 
-hsTelApproximation' :: PolyApprox -> Type -> TCM ([HS.Type], HS.Type)
+hsTelApproximation' :: PolyApprox -> Type -> HsCompileM ([HS.Type], HS.Type)
 hsTelApproximation' poly t = do
   TelV tel res <- telView t
   let args = map (snd . unDom) (telToList tel)

--- a/src/full/Agda/Compiler/MAlonzo/Misc.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Misc.hs
@@ -22,7 +22,7 @@ import Agda.Utils.Impossible
 -- Setting up Interface before compile
 --------------------------------------------------
 
-curHsMod :: TCM HS.ModuleName
+curHsMod :: ReadTCState m => m HS.ModuleName
 curHsMod = mazMod <$> curMName
 
 --------------------------------------------------

--- a/src/full/Agda/Compiler/MAlonzo/Misc.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Misc.hs
@@ -1,8 +1,6 @@
 
 module Agda.Compiler.MAlonzo.Misc where
 
-import Control.Monad.Except ( MonadError, throwError )
-
 import Data.Char
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -146,9 +144,6 @@ mazMod' s = HS.ModuleName $ mazstr ++ "." ++ s
 
 mazMod :: ModuleName -> HS.ModuleName
 mazMod = mazMod' . prettyShow
-
-mazerror :: MonadError String m => String -> m a
-mazerror msg = throwError $ mazstr ++ ": " ++ msg
 
 mazCoerceName :: String
 mazCoerceName = "coe"

--- a/src/full/Agda/Compiler/MAlonzo/Misc.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Misc.hs
@@ -22,6 +22,15 @@ import Agda.Utils.Impossible
 -- Setting up Interface before compile
 --------------------------------------------------
 
+data HsModuleEnv = HsModuleEnv
+  { mazModuleName :: ModuleName
+    -- ^ The name of the Agda module
+  , mazIsMainModule :: Bool
+  -- ^ Whether this is the compilation root and therefore should have the `main` function.
+  --   This corresponds to the @IsMain@ flag provided to the backend,
+  --   not necessarily whether the GHC module has a `main` function defined.
+  }
+
 curHsMod :: ReadTCState m => m HS.ModuleName
 curHsMod = mazMod <$> curMName
 

--- a/src/full/Agda/Compiler/MAlonzo/Misc.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Misc.hs
@@ -51,7 +51,7 @@ unqhname s q = ihname s (idnum $ nameId $ qnameName $ q)
    where idnum (NameId x _) = fromIntegral x
 
 -- the toplevel module containing the given one
-tlmodOf :: ModuleName -> TCM HS.ModuleName
+tlmodOf :: ReadTCState m => ModuleName -> m HS.ModuleName
 tlmodOf = fmap mazMod . topLevelModuleName
 
 

--- a/src/full/Agda/Compiler/MAlonzo/Misc.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Misc.hs
@@ -1,6 +1,8 @@
 
 module Agda.Compiler.MAlonzo.Misc where
 
+import Control.Monad.Except ( MonadError, throwError )
+
 import Data.Char
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -145,8 +147,8 @@ mazMod' s = HS.ModuleName $ mazstr ++ "." ++ s
 mazMod :: ModuleName -> HS.ModuleName
 mazMod = mazMod' . prettyShow
 
-mazerror :: String -> a
-mazerror msg = error $ mazstr ++ ": " ++ msg
+mazerror :: MonadError String m => String -> m a
+mazerror msg = throwError $ mazstr ++ ": " ++ msg
 
 mazCoerceName :: String
 mazCoerceName = "coe"

--- a/src/full/Agda/Compiler/MAlonzo/Pragmas.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Pragmas.hs
@@ -95,7 +95,7 @@ parsePragma (CompilerPragma r s) =
                                                     paren (sepBy (skipSpaces *> hsIdent) barP) <* skipSpaces
     defnP   = HsDefn   r <$ wordsP ["="]         <* whitespace <*  notTypeOrData <*> hsCode
 
-parseHaskellPragma :: CompilerPragma -> TCM HaskellPragma
+parseHaskellPragma :: (MonadTCError m, MonadTrace m) => CompilerPragma -> m HaskellPragma
 parseHaskellPragma p = setCurrentRange p $
   case parsePragma p of
     Left err -> genericError err
@@ -107,7 +107,7 @@ getHaskellPragma q = do
   def <- getConstInfo q
   setCurrentRange pragma $ pragma <$ sanityCheckPragma def pragma
 
-sanityCheckPragma :: Definition -> Maybe HaskellPragma -> TCM ()
+sanityCheckPragma :: (HasBuiltins m, MonadTCError m, MonadReduce m) => Definition -> Maybe HaskellPragma -> m ()
 sanityCheckPragma _ Nothing = return ()
 sanityCheckPragma def (Just HsDefn{}) =
   case theDef def of

--- a/src/full/Agda/Compiler/MAlonzo/Pragmas.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Pragmas.hs
@@ -178,9 +178,9 @@ getHaskellConstructor c = do
 
 -- | Get content of @FOREIGN GHC@ pragmas, sorted by 'KindOfForeignCode':
 --   file header pragmas, import statements, rest.
-foreignHaskell :: TCM ([String], [String], [String])
+foreignHaskell :: Interface -> ([String], [String], [String])
 foreignHaskell = partitionByKindOfForeignCode classifyForeign
-    . map getCode . fromMaybe [] . Map.lookup ghcBackendName . iForeignCode <$> curIF
+    . map getCode . fromMaybe [] . Map.lookup ghcBackendName . iForeignCode
   where getCode (ForeignCode _ code) = code
 
 -- | Classify @FOREIGN@ Haskell code.

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -59,15 +59,15 @@ hasMainFunction IsMain i
     defs = HMap.elems $ iSignature i ^. sigDefinitions
 
 -- | Check that the main function has type IO a, for some a.
-checkTypeOfMain :: IsMain -> Definition -> TCM [HS.Decl]
-checkTypeOfMain NotMain def = return []
+checkTypeOfMain :: IsMain -> Definition -> TCM (Maybe HS.Decl)
+checkTypeOfMain NotMain def = return Nothing
 checkTypeOfMain  IsMain def
-  | not (isMainFunction def) = return []
+  | not (isMainFunction def) = return Nothing
   | otherwise = do
     Def io _ <- primIO
     ty <- reduce $ defType def
     case unEl ty of
-      Def d _ | d == io -> return [mainAlias]
+      Def d _ | d == io -> return $ Just mainAlias
       _                 -> do
         err <- fsep $
           pwords "The type of main should be" ++

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -58,16 +58,6 @@ asMainFunctionDef d = case (theDef d) of
           | otherwise   = no
   no                    = Nothing
 
--- | Check for "main" function, but only in the main module.
-hasMainFunction
-  :: IsMain    -- ^ Are we looking at the main module?
-  -> Interface -- ^ The module.
-  -> IsMain    -- ^ Did we find a "main" function?
-hasMainFunction NotMain _ = NotMain
-hasMainFunction IsMain i
-  | (not . null . mainFunctionDefs) i = IsMain
-  | otherwise = NotMain
-
 mainFunctionDefs :: Interface -> [MainFunctionDef]
 mainFunctionDefs i = catMaybes $ asMainFunctionDef <$> defs
   where

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -1,8 +1,6 @@
 
 module Agda.Compiler.MAlonzo.Primitives where
 
-import Control.Monad.Except ( liftEither )
-
 import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -313,13 +311,6 @@ noCheckCover :: QName -> TCM Bool
 noCheckCover q = (||) <$> isBuiltin q builtinNat <*> isBuiltin q builtinInteger
 
 ----------------------
-
-
-pconName :: String -> TCM String
-pconName s = toS =<< getBuiltin s where
-  toS (Con q _ _) = prettyPrint <$> conhqn (conName q)
-  toS (Lam _ t) = toS (unAbs t)
-  toS _ = liftEither =<< ((either genericError return) <$> mazerror $ "pconName" ++ s)
 
 bltQual' :: String -> String -> TCM String
 bltQual' b s = prettyPrint <$> bltQual b s

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -155,7 +155,7 @@ xForPrim table = do
 
 
 -- | Definition bodies for primitive functions
-primBody :: String -> TCM HS.Exp
+primBody :: MonadTCError m => String -> m HS.Exp
 primBody s = maybe unimplemented (fromRight (hsVarUQ . HS.Ident) <$>) $
              List.lookup s $
   [
@@ -307,7 +307,7 @@ primBody s = maybe unimplemented (fromRight (hsVarUQ . HS.Ident) <$>) $
   hLam x t = Lam (setHiding Hidden defaultArgInfo) (Abs x t)
   nLam x t = Lam (setHiding NotHidden defaultArgInfo) (Abs x t)
 
-noCheckCover :: QName -> TCM Bool
+noCheckCover :: (HasBuiltins m, MonadReduce m) => QName -> m Bool
 noCheckCover q = (||) <$> isBuiltin q builtinNat <*> isBuiltin q builtinInteger
 
 ----------------------

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -110,14 +110,8 @@ treelessPrimName p =
     PIf     -> __IMPOSSIBLE__
 
 -- | Haskell modules to be imported for BUILT-INs
-importsForPrim :: ReadTCState m => m [HS.ModuleName]
-importsForPrim = do
-  builtinThings <- getsTC stBuiltinThings
-  defs <- HMap.elems <$> curDefs
-  return $ importsForPrim' builtinThings defs
-
-importsForPrim' :: BuiltinThings PrimFun -> [Definition] -> [HS.ModuleName]
-importsForPrim' builtinThings defs = xForPrim table builtinThings defs ++ [HS.ModuleName "Data.Text"]
+importsForPrim :: BuiltinThings PrimFun -> [Definition] -> [HS.ModuleName]
+importsForPrim builtinThings defs = xForPrim table builtinThings defs ++ [HS.ModuleName "Data.Text"]
   where
   table = Map.fromList $ second (HS.ModuleName <$>) <$>
     [ "CHAR"                       |-> ["Data.Char"]

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -1,6 +1,8 @@
 
 module Agda.Compiler.MAlonzo.Primitives where
 
+import Control.Monad.Except ( liftEither )
+
 import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -317,7 +319,7 @@ pconName :: String -> TCM String
 pconName s = toS =<< getBuiltin s where
   toS (Con q _ _) = prettyPrint <$> conhqn (conName q)
   toS (Lam _ t) = toS (unAbs t)
-  toS _ = mazerror $ "pconName" ++ s
+  toS _ = liftEither =<< ((either genericError return) <$> mazerror $ "pconName" ++ s)
 
 bltQual' :: String -> String -> TCM String
 bltQual' b s = prettyPrint <$> bltQual b s

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -64,7 +64,7 @@ mainFunctionDefs i = catMaybes $ asMainFunctionDef <$> defs
     defs = HMap.elems $ iSignature i ^. sigDefinitions
 
 -- | Check that the main function has type IO a, for some a.
-checkTypeOfMain :: IsMain -> Definition -> TCM (Maybe CheckedMainFunctionDef)
+checkTypeOfMain :: IsMain -> Definition -> HsCompileM (Maybe CheckedMainFunctionDef)
 checkTypeOfMain NotMain def = return Nothing
 checkTypeOfMain  IsMain def = runMaybeT $ do
   mainDef <- MaybeT . pure . asMainFunctionDef $ def
@@ -320,5 +320,5 @@ noCheckCover q = (||) <$> isBuiltin q builtinNat <*> isBuiltin q builtinInteger
 
 ----------------------
 
-bltQual' :: String -> String -> TCM String
+bltQual' :: String -> String -> HsCompileM String
 bltQual' b s = prettyPrint <$> bltQual b s

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -64,10 +64,11 @@ mainFunctionDefs i = catMaybes $ asMainFunctionDef <$> defs
     defs = HMap.elems $ iSignature i ^. sigDefinitions
 
 -- | Check that the main function has type IO a, for some a.
-checkTypeOfMain :: IsMain -> Definition -> HsCompileM (Maybe CheckedMainFunctionDef)
-checkTypeOfMain NotMain def = return Nothing
-checkTypeOfMain  IsMain def = runMaybeT $ do
-  mainDef <- MaybeT . pure . asMainFunctionDef $ def
+checkTypeOfMain :: Definition -> HsCompileM (Maybe CheckedMainFunctionDef)
+checkTypeOfMain def = runMaybeT $ do
+  -- Only indicate main functions in the main module.
+  isMainModule <- curIsMainModule
+  mainDef <- MaybeT $ pure $ if isMainModule then asMainFunctionDef def else Nothing
   liftTCM $ checkTypeOfMain' mainDef
 
 checkTypeOfMain' :: MainFunctionDef -> TCM CheckedMainFunctionDef

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -128,8 +128,6 @@ data CommandLineOptions = Options
   , optOnlyScopeChecking     :: Bool
     -- ^ Should the top-level module only be scope-checked, and not
     --   type-checked?
-  , optWithCompiler          :: Maybe FilePath
-    -- ^ Use the compiler at PATH instead of ghc / js / etc.
   }
   deriving Show
 
@@ -268,7 +266,6 @@ defaultOptions = Options
   , optLocalInterfaces       = False
   , optPragmaOptions         = defaultPragmaOptions
   , optOnlyScopeChecking     = False
-  , optWithCompiler          = Nothing
   }
 
 defaultPragmaOptions :: PragmaOptions
@@ -892,11 +889,6 @@ confluenceCheckFlag f o = return $ o { optConfluenceCheck = Just f }
 noConfluenceCheckFlag :: Flag PragmaOptions
 noConfluenceCheckFlag o = return $ o { optConfluenceCheck = Nothing }
 
-withCompilerFlag :: FilePath -> Flag CommandLineOptions
-withCompilerFlag fp o = case optWithCompiler o of
- Nothing -> pure o { optWithCompiler = Just fp }
- Just{}  -> throwError "only one compiler path allowed"
-
 noImportSorts :: Flag PragmaOptions
 noImportSorts o = return $ o { optImportSorts = False }
 
@@ -964,8 +956,6 @@ standardOptions =
                     "don't use default libraries"
     , Option []     ["only-scope-checking"] (NoArg onlyScopeCheckingFlag)
                     "only scope-check the top-level module, do not type-check it"
-    , Option []     ["with-compiler"] (ReqArg withCompilerFlag "PATH")
-                    "use the compiler available at PATH"
     ] ++ map (fmap lensPragmaOptions) pragmaOptions
 
 -- | Defined locally here since module ''Agda.Interaction.Options.Lenses''


### PR DESCRIPTION
This set of modifications is mainly to reduce reliance on the global TCM state. Especially `stVisitedModules`, which previously was being abused by the backend for its own purposes. Also, as much as possible, reducing reliance on the redundant `curMName` and `curDefs` which magically referring to transient state set up between backend callback invocations.

Note that this highlights some deficiencies + weirdnesses in the current `Backend`  interface, to be addressed another time.

This does not remove *all* statefullness from the compiler. For example, erasure and pragmas and whatever else still happens. But this sets things up to improve that a bit and better call out what things are going on.