### PR TITLE
main/interaction: Improve state management for repl/backends/etc.

### DIFF
--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -178,15 +178,17 @@ parseBackendOptions backends argv opts0 =
       opts <- checkOpts opts
       return (forgetAll forgetOpts backends, opts)
 
-backendInteraction :: [Backend] -> TCM (Maybe Interface) -> TCM ()
-backendInteraction backends check = do
+backendInteraction :: [Backend] -> TCM () -> TCM (Maybe Interface) -> TCM ()
+backendInteraction backends setup check = do
   opts   <- commandLineOptions
   let backendNames = [ backendName b | Backend b <- backends ]
       err flag = genericError $ "Cannot mix --" ++ flag ++ " and backends (" ++ List.intercalate ", " backendNames ++ ")"
   when (optInteractive     opts) $ err "interactive"
   when (optGHCiInteraction opts) $ err "interaction"
   when (optJSONInteraction opts) $ err "interaction-json"
-  mi     <- check
+
+  setup
+  mi <- check
 
   -- reset warnings
   stTCWarnings `setTCLens` []

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -178,8 +178,8 @@ parseBackendOptions backends argv opts0 =
       opts <- checkOpts opts
       return (forgetAll forgetOpts backends, opts)
 
-backendInteraction :: [Backend] -> TCM () -> TCM (Maybe Interface) -> TCM ()
-backendInteraction backends setup check = do
+backendInteraction :: AbsolutePath -> [Backend] -> TCM () -> (AbsolutePath -> TCM (Maybe Interface)) -> TCM ()
+backendInteraction mainFile backends setup check = do
   opts   <- commandLineOptions
   let backendNames = [ backendName b | Backend b <- backends ]
       err flag = genericError $ "Cannot mix --" ++ flag ++ " and backends (" ++ List.intercalate ", " backendNames ++ ")"
@@ -188,7 +188,7 @@ backendInteraction backends setup check = do
   when (optJSONInteraction opts) $ err "interaction-json"
 
   setup
-  mi <- check
+  mi <- check mainFile
 
   -- reset warnings
   stTCWarnings `setTCLens` []

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -180,13 +180,6 @@ parseBackendOptions backends argv opts0 =
 
 backendInteraction :: AbsolutePath -> [Backend] -> TCM () -> (AbsolutePath -> TCM (Maybe Interface)) -> TCM ()
 backendInteraction mainFile backends setup check = do
-  opts   <- commandLineOptions
-  let backendNames = [ backendName b | Backend b <- backends ]
-      err flag = genericError $ "Cannot mix --" ++ flag ++ " and backends (" ++ List.intercalate ", " backendNames ++ ")"
-  when (optInteractive     opts) $ err "interactive"
-  when (optGHCiInteraction opts) $ err "interaction"
-  when (optJSONInteraction opts) $ err "interaction-json"
-
   setup
   mi <- check mainFile
 

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -178,9 +178,8 @@ parseBackendOptions backends argv opts0 =
       opts <- checkOpts opts
       return (forgetAll forgetOpts backends, opts)
 
-backendInteraction :: [Backend] -> (TCM (Maybe Interface) -> TCM ()) -> TCM (Maybe Interface) -> TCM ()
-backendInteraction [] fallback check = fallback check
-backendInteraction backends _ check = do
+backendInteraction :: [Backend] -> TCM (Maybe Interface) -> TCM ()
+backendInteraction backends check = do
   opts   <- commandLineOptions
   let backendNames = [ backendName b | Backend b <- backends ]
       err flag = genericError $ "Cannot mix --" ++ flag ++ " and backends (" ++ List.intercalate ", " backendNames ++ ")"

--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -80,14 +80,11 @@ curIF = do
   name <- curMName
   maybe __IMPOSSIBLE__ miInterface <$> getVisitedModule (toTopLevelModuleName name)
 
-curSig :: ReadTCState m => m Signature
-curSig = iSignature <$> curIF
-
 curMName :: ReadTCState m => m ModuleName
 curMName = fromMaybe __IMPOSSIBLE__ <$> useTC stCurrentModule
 
-curDefs :: TCM Definitions
-curDefs = fmap (HMap.filter (not . defNoCompilation)) $ (^. sigDefinitions) <$> curSig
+curDefs :: ReadTCState m => m Definitions
+curDefs = HMap.filter (not . defNoCompilation) . (^. sigDefinitions) . iSignature <$> curIF
 
 sortDefs :: Definitions -> [(QName, Definition)]
 sortDefs defs =

--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -78,20 +78,13 @@ setInterface i = do
 curIF :: ReadTCState m => m Interface
 curIF = do
   name <- curMName
-  mm <- getVisitedModule (toTopLevelModuleName name)
-  case mm of
-    Nothing -> __IMPOSSIBLE__
-    Just mi -> return $ miInterface mi
+  maybe __IMPOSSIBLE__ miInterface <$> getVisitedModule (toTopLevelModuleName name)
 
 curSig :: ReadTCState m => m Signature
 curSig = iSignature <$> curIF
 
 curMName :: ReadTCState m => m ModuleName
-curMName = do
-  mName <- useTC stCurrentModule
-  case mName of
-    Nothing -> __IMPOSSIBLE__
-    Just name -> return name
+curMName = fromMaybe __IMPOSSIBLE__ <$> useTC stCurrentModule
 
 curDefs :: TCM Definitions
 curDefs = fmap (HMap.filter (not . defNoCompilation)) $ (^. sigDefinitions) <$> curSig

--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -75,7 +75,7 @@ setInterface i = do
   stImportedModules `setTCLens` Set.fromList (map fst $ iImportedModules i)
   stCurrentModule   `setTCLens` Just (iModuleName i)
 
-curIF :: TCM Interface
+curIF :: ReadTCState m => m Interface
 curIF = do
   mName <- useTC stCurrentModule
   case mName of
@@ -110,7 +110,7 @@ sigMName sig = case Map.keys (sig ^. sigSections) of
   m : _ -> m
 
 
-compileDir :: TCM FilePath
+compileDir :: HasOptions m => m FilePath
 compileDir = do
   mdir <- optCompileDir <$> commandLineOptions
   maybe __IMPOSSIBLE__ return mdir
@@ -162,7 +162,7 @@ inCompilerEnv mainI cont = do
   stTCWarnings `setTCLens` newWarnings
   return a
 
-topLevelModuleName :: ModuleName -> TCM ModuleName
+topLevelModuleName :: ReadTCState m => ModuleName -> m ModuleName
 topLevelModuleName m = do
   -- get the names of the visited modules
   visited <- List.map (iModuleName . miInterface) . Map.elems <$>

--- a/src/full/Agda/Interaction/CommandLine.hs
+++ b/src/full/Agda/Interaction/CommandLine.hs
@@ -78,14 +78,16 @@ interaction prompt cmds eval = loop
                     liftIO $ putStrLn s
                     loop
 
-runInteractionLoop :: TCM (Maybe Interface) -> TCM ()
-runInteractionLoop = runIM . interactionLoop
+runInteractionLoop :: TCM () -> TCM (Maybe Interface) -> TCM ()
+runInteractionLoop doSetup doCheck = runIM $ interactionLoop doSetup doCheck
 
 -- | The interaction loop.
-interactionLoop :: TCM (Maybe Interface) -> IM ()
-interactionLoop doTypeCheck =
-    do  liftTCM reload
-        interaction "Main> " commands evalTerm
+interactionLoop :: TCM () -> TCM (Maybe Interface) -> IM ()
+interactionLoop doSetup doTypeCheck = do
+    liftTCM doSetup
+    liftIO $ putStr splashScreen
+    liftTCM reload
+    interaction "Main> " commands evalTerm
     where
         reload = do
             mi <- doTypeCheck

--- a/src/full/Agda/Interaction/CommandLine.hs
+++ b/src/full/Agda/Interaction/CommandLine.hs
@@ -1,5 +1,7 @@
 
-module Agda.Interaction.CommandLine where
+module Agda.Interaction.CommandLine
+  ( runInteractionLoop
+  ) where
 
 import Control.Monad.Except
 import Control.Monad.Reader
@@ -75,6 +77,9 @@ interaction prompt cmds eval = loop
                 do  s <- liftTCM $ prettyError e
                     liftIO $ putStrLn s
                     loop
+
+runInteractionLoop :: TCM (Maybe Interface) -> TCM ()
+runInteractionLoop = runIM . interactionLoop
 
 -- | The interaction loop.
 interactionLoop :: TCM (Maybe Interface) -> IM ()

--- a/src/full/Agda/Interaction/CommandLine.hs
+++ b/src/full/Agda/Interaction/CommandLine.hs
@@ -130,7 +130,7 @@ continueAfter m = withCurrentFile $ do
 -- | Set 'envCurrentPath' to 'optInputFile'.
 withCurrentFile :: TCM a -> TCM a
 withCurrentFile cont = do
-  mpath <- getInputFile'
+  mpath <- getInputFile
   localTC (\ e -> e { envCurrentPath = mpath }) cont
 
 loadFile :: TCM () -> [String] -> TCM ()

--- a/src/full/Agda/Interaction/CommandLine.hs
+++ b/src/full/Agda/Interaction/CommandLine.hs
@@ -237,15 +237,10 @@ parseExpr s = do
 evalTerm :: String -> TCM (ExitCode a)
 evalTerm s =
     do  e <- parseExpr s
-        v <- evalInCurrent e
+        v <- evalInCurrent DefaultCompute e
         e <- prettyTCM v
         liftIO $ print e
         return Continue
-    where
-        evalInCurrent e = do
-          (v,t) <- inferExpr e
-          normalise v
-
 
 typeOf :: [String] -> TCM ()
 typeOf s =

--- a/src/full/Agda/Interaction/Monad.hs
+++ b/src/full/Agda/Interaction/Monad.hs
@@ -1,12 +1,47 @@
-module Agda.Interaction.Monad (IM, runIM, readline) where
+{-# OPTIONS_GHC -fwarn-orphans #-}
+{-# LANGUAGE CPP               #-}
 
-import Control.Monad.Trans
-import System.Console.Haskeline
+module Agda.Interaction.Monad
+  ( IM
+  , runIM
+  , readline
+  ) where
 
 import Agda.TypeChecking.Monad
+  ( HasOptions
+  , MonadTCEnv
+  , MonadTCM
+  , MonadTCState
+  , ReadTCState
+  , TCErr
+  , TCM, TCMT(..)
+  , mapTCMT
+  )
+import Control.Exception (throwIO)
+import Control.Monad.Except (MonadError (..))
+import Control.Monad.Trans (MonadIO, lift, liftIO)
+import qualified System.Console.Haskeline as Haskeline
+
+-- MonadException is replaced by MonadCatch in haskeline 0.8
+#if MIN_VERSION_haskeline(0,8,0)
+import qualified Control.Monad.Catch as Haskeline (catch)
+#endif
+
+-- | Interaction monad.
+newtype IM a = IM {unIM :: TCMT (Haskeline.InputT IO) a}
+  deriving
+  ( Functor, Applicative, Monad, MonadIO
+  , HasOptions, MonadTCEnv, ReadTCState, MonadTCState, MonadTCM )
+
+runIM :: IM a -> TCM a
+runIM = mapTCMT (Haskeline.runInputT Haskeline.defaultSettings) . unIM
+
+instance MonadError TCErr IM where
+  throwError                = liftIO . throwIO
+  catchError (IM (TCM m)) h = IM . TCM $ \s e ->
+    m s e `Haskeline.catch` \err -> unTCM (unIM (h err)) s e
 
 -- | Line reader. The line reader history is not stored between
 -- sessions.
-
 readline :: String -> IM (Maybe String)
-readline s = lift (getInputLine s)
+readline s = IM $ lift (Haskeline.getInputLine s)

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -360,8 +360,6 @@ type Flag opts = opts -> OptM opts
 checkOpts :: Flag CommandLineOptions
 checkOpts opts
   | htmlRelated = throwError htmlRelatedMessage
-  | matches [optGHCiInteraction, optJSONInteraction, isJust . optInputFile] > 1 =
-      throwError "Choose at most one: input file, --interactive, or --interaction-json.\n"
   | or [ p opts && matches ps > 1 | (p, ps) <- exclusive ] =
       throwError exclusiveMessage
   | otherwise = return opts

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -65,7 +65,7 @@ runAgda' backends = runTCMPrettyErrors $ do
 
 defaultInteraction :: CommandLineOptions -> TCM (Maybe Interface) -> TCM ()
 defaultInteraction opts
-  | i         = runIM . interactionLoop
+  | i         = runInteractionLoop
   | ghci      = mimicGHCi . (failIfInt =<<)
   | json      = jsonREPL . (failIfInt =<<)
   | otherwise = (() <$)

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -5,6 +5,7 @@ module Agda.Main where
 
 import Control.Monad.Except
 
+import qualified Data.List as List
 import Data.Maybe
 
 import System.Environment
@@ -35,8 +36,7 @@ import Agda.Compiler.Builtin
 
 import Agda.VersionCommit
 
-import Agda.Utils.FileName (absolute, AbsolutePath)
-import Agda.Utils.Maybe (caseMaybe)
+import Agda.Utils.FileName (absolute, filePath, AbsolutePath)
 import Agda.Utils.Monad
 import Agda.Utils.String
 import qualified Agda.Utils.Benchmark as UtilsBench
@@ -52,20 +52,38 @@ runAgda' :: [Backend] -> IO ()
 runAgda' backends = runTCMPrettyErrors $ do
   progName <- liftIO getProgName
   argv     <- liftIO getArgs
-  opts     <- liftIO $ runOptM $ parseBackendOptions backends argv defaultOptions
-  case opts of
-    Left  err        -> liftIO $ optionError err
-    Right (bs, opts) -> do
-      setTCLens stBackends bs
-      let enabled (Backend b) = isEnabled b (options b)
-      interactor <- case filter enabled bs of
-            []  -> return $ defaultInteraction opts
-            bs' -> do
-              -- NOTE: The existence of optInputFile is checked in @runAgdaWithOptions@
-              -- before this block is executed.
-              file <- liftIO $ caseMaybe (optInputFile opts) __IMPOSSIBLE__ absolute
-              return $ backendInteraction file bs'
-      () <$ runAgdaWithOptions backends generateHTML interactor progName opts
+  conf     <- liftIO $ runOptM $ do
+    (bs, opts) <- parseBackendOptions backends argv defaultOptions
+    -- The absolute path of the input file, if provided
+    inputFile <- maybe (pure Nothing) (fmap Just . liftIO . absolute) (optInputFile opts)
+    mode      <- getMainMode bs inputFile opts
+    return (bs, opts, mode)
+
+  case conf of
+    Left err -> liftIO $ optionError err
+    Right (bs, opts, mode) -> case mode of
+      MainModeShowHelp hp  -> liftIO $ printUsage bs hp
+      MainModePrintVersion -> liftIO $ printVersion bs
+      MainModeRun interactor -> do
+        setTCLens stBackends bs
+        () <$ runAgdaWithOptions generateHTML interactor progName opts
+
+-- | Main execution mode
+data MainMode
+  = MainModeRun (Interactor ())
+  | MainModeShowHelp Help
+  | MainModePrintVersion
+
+-- | Determine the main execution mode to run, based on the configured backends and command line options.
+-- | This is pure.
+getMainMode :: MonadError String m => [Backend] -> Maybe AbsolutePath -> CommandLineOptions -> m MainMode
+getMainMode configuredBackends maybeInputFile opts
+  | Just hp <- optShowHelp opts = return $ MainModeShowHelp hp
+  | optShowVersion opts         = return $ MainModePrintVersion
+  | otherwise                   = do
+      mi <- getInteractor configuredBackends maybeInputFile opts
+      -- If there was no selection whatsoever (e.g. just invoked "agda"), we just show help and exit.
+      return $ maybe (MainModeShowHelp GeneralHelp) MainModeRun mi
 
 type Interactor a
     -- Setup/initialization action.
@@ -76,45 +94,69 @@ type Interactor a
     -- Main transformed action.
     -> TCM a
 
-defaultInteraction :: CommandLineOptions -> Interactor ()
-defaultInteraction opts setup check
-  | i         = do
-      maybeFile <- liftIO $ case (optInputFile opts) of
-                Nothing -> return Nothing
-                Just rel -> Just <$> absolute rel
-      runInteractionLoop maybeFile setup check
-  -- Emacs and JSON interaction call typeCheck directly.
-  | ghci      = mimicGHCi setup
-  | json      = jsonREPL setup
-  -- The default type-checking mode.
-  | otherwise = do
-      -- NOTE: The existence of optInputFile is checked in @runAgdaWithOptions@
-      -- before this block is executed.
-      file <- liftIO $ caseMaybe (optInputFile opts) __IMPOSSIBLE__ absolute
-      setup
-      void $ check file
+data FrontendType
+  = FrontEndEmacs
+  | FrontEndJson
+  | FrontEndRepl
+
+-- Emacs mode. Note that it ignores the "check" action because it calls typeCheck directly.
+emacsModeInteractor :: Interactor ()
+emacsModeInteractor setup _check = mimicGHCi setup
+
+-- JSON mode. Note that it ignores the "check" action because it calls typeCheck directly.
+jsonModeInteractor :: Interactor ()
+jsonModeInteractor setup _check = jsonREPL setup
+
+-- The deprecated repl mode.
+replInteractor :: Maybe AbsolutePath -> Interactor ()
+replInteractor = runInteractionLoop
+
+-- The interactor to use when there are no frontends or backends specified.
+defaultInteractor :: AbsolutePath -> Interactor ()
+defaultInteractor file setup check = setup >> (void $ check file)
+
+getInteractor :: MonadError String m => [Backend] -> Maybe AbsolutePath -> CommandLineOptions -> m (Maybe (Interactor ()))
+getInteractor configuredBackends maybeInputFile opts = case (maybeInputFile, enabledFrontends, enabledBackends) of
+  (Just inputFile, [],             _:_) -> return $ Just $ backendInteraction inputFile enabledBackends
+  (Just inputFile, [],              []) -> return $ Just $ defaultInteractor inputFile
+  (Nothing,        [],              []) -> return Nothing -- No backends, frontends, or input files specified.
+  (Nothing,        [],             _:_) -> throwError $ concat ["No input file specified for ", enabledBackendNames]
+  (_,              _:_,            _:_) -> throwError $ concat ["Cannot mix ", enabledFrontendNames, " with ", enabledBackendNames]
+  (_,              _:_:_,           []) -> throwError $ concat ["Must not specify multiple ", enabledFrontendNames]
+  (_,              [FrontEndRepl],  []) -> return $ Just $ replInteractor maybeInputFile
+  (Nothing,        [FrontEndEmacs], []) -> return $ Just $ emacsModeInteractor
+  (Nothing,        [FrontEndJson],  []) -> return $ Just $ jsonModeInteractor
+  (Just inputFile, [FrontEndEmacs], []) -> throwError $ concat ["Must not specify an input file (", filePath inputFile, ") with --interaction"]
+  (Just inputFile, [FrontEndJson],  []) -> throwError $ concat ["Must not specify an input file (", filePath inputFile, ") with --interaction-json"]
   where
-    i    = optInteractive     opts
-    ghci = optGHCiInteraction opts
-    json = optJSONInteraction opts
+    -- NOTE: The notion of a backend being "enabled" *just* refers to this top-level interaction mode selection. The
+    -- interaction/interactive front-ends may still invoke available backends even if they are not "enabled".
+    isBackendEnabled (Backend b) = isEnabled b (options b)
+    enabledBackends = filter isBackendEnabled configuredBackends
+    enabledFrontends = [ name | (name, enabled) <-
+      [ (FrontEndRepl, optInteractive opts)
+      , (FrontEndEmacs, optGHCiInteraction opts)
+      , (FrontEndJson, optJSONInteraction opts)
+      ], enabled ]
+    -- Constructs messages like "(no backend)", "backend ghc", "backends (ghc, ocaml)"
+    pluralize w [] = concat ["(no ", w, ")"]
+    pluralize w [x] = concat [w, " ", x]
+    pluralize w xs = concat [w, "s (", List.intercalate ", " xs, ")"]
+    enabledBackendNames = pluralize "backend" [ backendName b | Backend b <- enabledBackends ]
+    enabledFrontendNames = pluralize "frontend" (frontendFlagName <$> enabledFrontends)
+    frontendFlagName = ("--" ++) . \case
+      FrontEndEmacs -> "interaction"
+      FrontEndJson -> "interaction-json"
+      FrontEndRepl -> "interactive"
 
 -- | Run Agda with parsed command line options and with a custom HTML generator
 runAgdaWithOptions
-  :: [Backend]          -- ^ Backends only for printing usage and version information
-  -> TCM ()             -- ^ HTML generating action
+  :: TCM ()             -- ^ HTML generating action
   -> Interactor a       -- ^ Backend interaction
   -> String             -- ^ program name
   -> CommandLineOptions -- ^ parsed command line options
   -> TCM (Maybe a)
-runAgdaWithOptions backends generateHTML interactor progName opts
-      | Just hp <- optShowHelp opts = Nothing <$ liftIO (printUsage backends hp)
-      | optShowVersion opts         = Nothing <$ liftIO (printVersion backends)
-      | isNothing (optInputFile opts)
-          && not (optInteractive opts)
-          && not (optGHCiInteraction opts)
-          && not (optJSONInteraction opts)
-                            = Nothing <$ liftIO (printUsage backends GeneralHelp)
-      | otherwise           = Just <$> do
+runAgdaWithOptions generateHTML interactor progName opts = Just <$> do
           -- Main function.
           -- Bill everything to root of Benchmark trie.
           UtilsBench.setBenchmarking UtilsBench.BenchmarkOn

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -94,7 +94,7 @@ runAgdaWithOptions backends generateHTML interaction progName opts
           && not (optGHCiInteraction opts)
           && not (optJSONInteraction opts)
                             = Nothing <$ liftIO (printUsage backends GeneralHelp)
-      | otherwise           = do
+      | otherwise           = Just <$> do
           -- Main function.
           -- Bill everything to root of Benchmark trie.
           UtilsBench.setBenchmarking UtilsBench.BenchmarkOn
@@ -111,7 +111,7 @@ runAgdaWithOptions backends generateHTML interaction progName opts
             -- Print accumulated statistics.
             printStatistics 1 Nothing =<< useTC lensAccumStatistics
   where
-    checkFile = Just <$> do
+    checkFile = do
       opts <- addTrustedExecutables opts
       when (optInteractive opts) $ do
         setCommandLineOptions opts

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -58,10 +58,11 @@ runAgda' backends = runTCMPrettyErrors $ do
     Right (bs, opts) -> do
       setTCLens stBackends bs
       let enabled (Backend b) = isEnabled b (options b)
-          bs' = filter enabled bs
-      () <$ runAgdaWithOptions backends generateHTML (interaction bs') progName opts
-      where
-        interaction bs = backendInteraction bs $ defaultInteraction opts
+          interactor = case filter enabled bs of
+            []  -> defaultInteraction opts
+            bs' -> backendInteraction bs'
+      () <$ runAgdaWithOptions backends generateHTML interactor progName opts
+
 
 defaultInteraction :: CommandLineOptions -> TCM (Maybe Interface) -> TCM ()
 defaultInteraction opts

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -43,12 +43,6 @@ import qualified Data.Text.Lazy as TL
 
 import Data.IORef
 
-import qualified System.Console.Haskeline as Haskeline
--- MonadException is replaced by MonadCatch in haskeline 0.8
-#if MIN_VERSION_haskeline(0,8,0)
-import qualified Control.Monad.Catch as Haskeline (catch)
-#endif
-
 import Agda.Benchmarking (Benchmark, Phase)
 
 import Agda.Syntax.Concrete (TopLevelModuleName)
@@ -4207,18 +4201,6 @@ instance {-# OVERLAPPABLE #-} (MonadIO m, Semigroup a, Monoid a) => Monoid (TCMT
 instance {-# OVERLAPPABLE #-} (MonadIO m, Null a) => Null (TCMT m a) where
   empty = return empty
   null  = __IMPOSSIBLE__
-
--- | Interaction monad.
-
-type IM = TCMT (Haskeline.InputT IO)
-
-runIM :: IM a -> TCM a
-runIM = mapTCMT (Haskeline.runInputT Haskeline.defaultSettings)
-
-instance MonadError TCErr IM where
-  throwError     = liftIO . E.throwIO
-  catchError (TCM m) h = TCM $ \s env ->
-    m s env `Haskeline.catch` \e -> unTCM (h e) s env
 
 -- | Preserve the state of the failing computation.
 catchError_ :: TCM a -> (TCErr -> TCM a) -> TCM a

--- a/src/full/Agda/TypeChecking/Monad/Imports.hs
+++ b/src/full/Agda/TypeChecking/Monad/Imports.hs
@@ -40,14 +40,15 @@ visitModule mi =
 setVisitedModules :: VisitedModules -> TCM ()
 setVisitedModules ms = setTCLens stVisitedModules ms
 
-getVisitedModules :: TCM VisitedModules
+getVisitedModules :: ReadTCState m => m VisitedModules
 getVisitedModules = useTC stVisitedModules
 
 isVisited :: C.TopLevelModuleName -> TCM Bool
 isVisited x = Map.member x <$> useTC stVisitedModules
 
-getVisitedModule :: C.TopLevelModuleName
-                 -> TCM (Maybe ModuleInfo)
+getVisitedModule :: ReadTCState m
+                 => C.TopLevelModuleName
+                 -> m (Maybe ModuleInfo)
 getVisitedModule x = Map.lookup x <$> useTC stVisitedModules
 
 mapVisitedModule :: C.TopLevelModuleName

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -228,18 +228,10 @@ setInputFile file =
         setCommandLineOptions $
           opts { optInputFile = Just file }
 
--- | Should only be run if 'hasInputFile'.
-getInputFile :: TCM AbsolutePath
-getInputFile = fromMaybeM __IMPOSSIBLE__ $
-  getInputFile'
-
 -- | Return the 'optInputFile' as 'AbsolutePath', if any.
-getInputFile' :: TCM (Maybe AbsolutePath)
-getInputFile' = mapM (liftIO . absolute) =<< do
+getInputFile :: TCM (Maybe AbsolutePath)
+getInputFile = mapM (liftIO . absolute) =<< do
   optInputFile <$> commandLineOptions
-
-hasInputFile :: HasOptions m => m Bool
-hasInputFile = isJust . optInputFile <$> commandLineOptions
 
 isPropEnabled :: HasOptions m => m Bool
 isPropEnabled = optProp <$> pragmaOptions

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -222,17 +222,6 @@ setIncludeDirs incs root = do
 
   Lens.putAbsoluteIncludePaths incs
 
-setInputFile :: FilePath -> TCM ()
-setInputFile file =
-    do  opts <- commandLineOptions
-        setCommandLineOptions $
-          opts { optInputFile = Just file }
-
--- | Return the 'optInputFile' as 'AbsolutePath', if any.
-getInputFile :: TCM (Maybe AbsolutePath)
-getInputFile = mapM (liftIO . absolute) =<< do
-  optInputFile <$> commandLineOptions
-
 isPropEnabled :: HasOptions m => m Bool
 isPropEnabled = optProp <$> pragmaOptions
 

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -815,7 +815,7 @@ setCompiledArgUse q use =
       fun{ funTreeless = for (funTreeless fun) $ \ c -> c { cArgUsage = use } }
     _ -> __IMPOSSIBLE__
 
-getCompiled :: QName -> TCM (Maybe Compiled)
+getCompiled :: HasConstInfo m => QName -> m (Maybe Compiled)
 getCompiled q = do
   (theDef <$> getConstInfo q) <&> \case
     Function{ funTreeless = t } -> t
@@ -823,7 +823,7 @@ getCompiled q = do
 
 -- | Returns a list of length 'conArity'.
 --   If no erasure analysis has been performed yet, this will be a list of 'False's.
-getErasedConArgs :: QName -> TCM [Bool]
+getErasedConArgs :: HasConstInfo m => QName -> m [Bool]
 getErasedConArgs q = do
   def <- getConstInfo q
   case theDef def of
@@ -838,10 +838,10 @@ setErasedConArgs q args = modifyGlobalDefinition q $ updateTheDef $ \case
       | otherwise               -> __IMPOSSIBLE__
     def -> def   -- no-op for non-constructors
 
-getTreeless :: QName -> TCM (Maybe TTerm)
+getTreeless :: HasConstInfo m => QName -> m (Maybe TTerm)
 getTreeless q = fmap cTreeless <$> getCompiled q
 
-getCompiledArgUse :: QName -> TCM [Bool]
+getCompiledArgUse :: HasConstInfo m => QName -> m [Bool]
 getCompiledArgUse q = maybe [] cArgUsage <$> getCompiled q
 
 -- | add data constructors to a datatype

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -5,6 +5,7 @@ import Prelude hiding (null)
 
 import Control.Monad.Except
 import Control.Monad.Reader
+import Control.Monad.State
 import Control.Monad.Writer
 
 import qualified Data.Set as Set
@@ -108,6 +109,9 @@ class (MonadTCEnv m, ReadTCState m) => MonadTrace m where
 
 instance MonadTrace m => MonadTrace (ReaderT r m) where
   traceClosureCall c f = ReaderT $ \r -> traceClosureCall c $ runReaderT f r
+
+instance MonadTrace m => MonadTrace (StateT s m) where
+  traceClosureCall c f = StateT (traceClosureCall c . runStateT f)
 
 instance (MonadTrace m, Monoid w) => MonadTrace (WriterT w m) where
   traceClosureCall c f = WriterT $ traceClosureCall c $ runWriterT f

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -181,7 +181,7 @@ lookupPrimitiveFunctionQ q = do
   PrimImpl t pf <- lookupPrimitiveFunction s
   return (s, PrimImpl t $ pf { primFunName = q })
 
-getBuiltinName :: String -> TCM (Maybe QName)
+getBuiltinName :: (HasBuiltins m, MonadReduce m) => String -> m (Maybe QName)
 getBuiltinName b = do
   caseMaybeM (getBuiltin' b) (return Nothing) (Just <.> getName)
   where
@@ -193,7 +193,7 @@ getBuiltinName b = do
       Lam _ b   -> getName $ unAbs b
       _ -> __IMPOSSIBLE__
 
-isBuiltin :: QName -> String -> TCM Bool
+isBuiltin :: (HasBuiltins m, MonadReduce m) => QName -> String -> m Bool
 isBuiltin q b = (Just q ==) <$> getBuiltinName b
 
 ------------------------------------------------------------------------

--- a/test/Fail/Interaction-and-input-file.err
+++ b/test/Fail/Interaction-and-input-file.err
@@ -1,5 +1,4 @@
 ret > ExitFailure 71
-out > Error: Choose at most one: input file, --interactive, or --interaction-json.
-out >
+out > Error: Must not specify an input file (Interaction-and-input-file.agda) with --interaction
 out > Run 'agda --help' for help on command line options.
 out >


### PR DESCRIPTION
This has a few cleanups while from trying to understand what was going on. The (deprecated, but still there) repl uses the command line vars for keeping its current file state. This lifts that up into a state transformer. and cleans up some of the special casing for `optInteractive` and forced-unwrapping of `optInputFile`.

Note that this shares some base commits with #5019 (a few trivial instances and generalizations). This was pretty early in one of my branches and so…hopefully it makes sense! It is not an ideal structure, but hopefully it makes sense and gets things a little closer. I think these "interactor" options might be better represented in with a type along the lines similar to the `Backend` interface, but that's not done here.

From one of the commit messages:

This consolidates a lot of the initial "main cli entry" options checking and structures it in a more-or-less type-safe way.

This also ensures that the "initial invoked file" options is validated for compatibility early, so that there are fewer forced unwrappings.

(Before, this was impossible because that argument was used as state).
This makes it so that *initial* high-level execution-mode options like "show help", "show version", or high-level mode selection are all validated in (roughly) one place. It's not an ideal structure yet: those flags shouldn't even be _visible_ to most of the other code, to avoid the chance of some internal behaviour relying on them. One step at a time.