### PR TITLE
CI build fix: Disable cluster-counting on Windows build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -102,33 +102,25 @@ jobs:
       matrix:
         # We can not use 8.10.2 because #4965.
         ghc-ver: [8.10.1]
-        icu-ver: [65.1-1]
 
-    env:
-      ICU_FILE: "mingw-w64-x86_64-icu-${{ matrix.icu-ver }}-any.pkg.tar.xz"
+    # NOTE: The flag Agda:enable-cluster-counting is not included below, due to issues installing
+    #       the ICU library with Stack's version of msys, as of about 2020-10-27. See:
+    #   - https://github.com/agda/agda/issues/5012
+    #   - https://github.com/commercialhaskell/stack/issues/5300
 
     steps:
     - uses: actions/checkout@v2.3.2
       with:
         submodules: recursive
 
-    - name: Download ICU ${{ matrix.icu-ver }}
-      run: |
-        stack --compiler ghc-${{ matrix.ghc-ver }} exec -- wget -q http://repo.msys2.org/mingw/x86_64/${env:ICU_FILE}
-
-    - name: Install text-icu ${{ matrix.icu-ver }}
-      run: |
-        stack --compiler ghc-${{ matrix.ghc-ver }} exec -- pacman -U --noconfirm ${env:ICU_FILE}
-        stack build --compiler ghc-${{ matrix.ghc-ver }} text-icu
-
     # See comment in .github/workflows/stack.yml
     - name: Build dependencies
       run: |
-        stack build --stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal --fast --flag Agda:enable-cluster-counting --only-dependencies
+        stack build --stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal --fast --only-dependencies
 
     - name: Build agda
       run: |
-        stack build --stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal --fast --flag Agda:enable-cluster-counting
+        stack build --stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal --fast
 
     - name: Pack artifacts
       shell: bash

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -125,24 +125,16 @@ jobs:
       matrix:
         # We can not use 8.10.2 because #4965.
         ghc-ver: [8.10.1]
-        icu-ver: [65.1-1]
 
-    env:
-      ICU_FILE: "mingw-w64-x86_64-icu-${{ matrix.icu-ver }}-any.pkg.tar.xz"
+    # NOTE: The flag Agda:enable-cluster-counting is not included below, due to issues installing
+    #       the ICU library with Stack's version of msys, as of about 2020-10-27. See:
+    #   - https://github.com/agda/agda/issues/5012
+    #   - https://github.com/commercialhaskell/stack/issues/5300
 
     steps:
     - uses: actions/checkout@v2.3.2
       with:
         submodules: recursive
-
-    - name: Download ICU ${{ matrix.icu-ver }}
-      run: |
-        stack --compiler ghc-${{ matrix.ghc-ver }} exec -- wget -q http://repo.msys2.org/mingw/x86_64/${env:ICU_FILE}
-
-    - name: Install text-icu ${{ matrix.icu-ver }}
-      run: |
-        stack --compiler ghc-${{ matrix.ghc-ver }} exec -- pacman -U --noconfirm ${env:ICU_FILE}
-        stack build --compiler ghc-${{ matrix.ghc-ver }} text-icu
 
     # I [Ed Nutting] don't understand how to make Powershell treat a string from ${env:ARGS}
     #  as a list of arguments to pass to an executable. Anything I try causes Powershell
@@ -150,7 +142,7 @@ jobs:
     #  it's a path to a package. So for now, I've written out the arguments explicitly.
     - name: Install dependencies for Agda.
       run: |
-        stack build --stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal --fast --flag Agda:enable-cluster-counting --flag Agda:cpphs --flag Agda:debug --only-dependencies
+        stack build --stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal --fast --flag Agda:cpphs --flag Agda:debug --only-dependencies
 
     - name: Build Agda with the default flags in Agda.cabal.
       run: |
@@ -158,4 +150,4 @@ jobs:
 
     - name: Build Agda with the non-default flags in Agda.cabal.
       run: |
-        stack build --stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal --fast --flag Agda:enable-cluster-counting --flag Agda:cpphs --flag Agda:debug
+        stack build --stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal --fast --flag Agda:cpphs --flag Agda:debug

--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,18 @@ GHC_OPTS = "+RTS $(GHC_RTS_OPTS) -RTS"
 # The following options are used in several invocations of cabal
 # install/configure below. They are always the last options given to
 # the command.
-CABAL_INSTALL_OPTS = -fenable-cluster-counting --ghc-options=$(GHC_OPTS) $(CABAL_OPTS)
-STACK_INSTALL_OPTS = --flag Agda:enable-cluster-counting --ghc-options $(GHC_OPTS) $(STACK_OPTS)
+CABAL_INSTALL_OPTS =
+STACK_INSTALL_OPTS =
+
+# Only enable cluster-counting by default for non-Windows, due to agda/agda#5012
+# The msys* and mingw* strings derived from: https://stackoverflow.com/a/18434831/141513
+ifeq ($(filter msys% mingw%,$(shell echo "$${OSTYPE:-unknown}")),)
+  CABAL_INSTALL_OPTS += -fenable-cluster-counting
+  STACK_INSTALL_OPTS += --flag Agda:enable-cluster-counting
+endif
+
+CABAL_INSTALL_OPTS += --ghc-options=$(GHC_OPTS) $(CABAL_OPTS)
+STACK_INSTALL_OPTS += --ghc-options $(GHC_OPTS) $(STACK_OPTS)
 
 # Options for building Agda's dependencies.
 CABAL_INSTALL_DEP_OPTS = --only-dependencies \


### PR DESCRIPTION
Works around the problem described here: https://github.com/agda/agda/issues/5012

Unfortunately, there does not appear to be a trivial way to get the `text-icu` package to install properly in Windows right now. So to avoid having all builds marked as failed, and avoid skipping windows entirely, this disables the `--flag Agda:enable-cluster-counting` on Windows on CI.