### PR TITLE
Add the link to Agda Zulip; obsolete gitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Agda 2
 [![Travis Status](https://travis-ci.org/agda/agda.svg?branch=master)](https://travis-ci.org/agda/agda)
 [![Stack Build Status via GH Actions](https://github.com/agda/agda/workflows/stack%20build/badge.svg)](https://github.com/agda/agda/actions?query=workflow%3A%22stack+build%22)
 [![nightly build](https://github.com/agda/agda/workflows/nightly%20build/badge.svg?branch=master&event=schedule)](https://github.com/agda/agda/actions?query=workflow%3A%22nightly+build%22+event%3Aschedule)
-[![Documentation Status](https://readthedocs.org/projects/agda/badge/?version=latest)](http://agda.readthedocs.io/en/latest/?badge=latest) [![Join the chat at https://gitter.im/agda/agda](https://badges.gitter.im/agda/agda.svg)](https://gitter.im/agda/agda?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Documentation Status](https://readthedocs.org/projects/agda/badge/?version=latest)](http://agda.readthedocs.io/en/latest/?badge=latest)
+[![Agda Zulip](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://agda.zulipchat.com)
 
 ![The official Agda logo](doc/user-manual/agda.svg)
 


### PR DESCRIPTION
It appears that Agda Zulip is now the official chat platform after AIM XXXIII. Is that right, @jespercockx? 