### PR TITLE
[ #5026 ] Option --js-verify run generated JS modules through node.

### DIFF
--- a/src/full/Agda/Compiler/JS/Syntax.hs
+++ b/src/full/Agda/Compiler/JS/Syntax.hs
@@ -68,10 +68,10 @@ data Export = Export { expName :: JSQName, defn :: Exp }
 type JSQName = List1 MemberId
 
 data Module = Module
-  { modName :: GlobalId
-  , imports :: [GlobalId]
-  , exports :: [Export]
-  , postscript :: Maybe Exp
+  { modName  :: GlobalId
+  , imports  :: [GlobalId]
+  , exports  :: [Export]
+  , callMain :: Maybe Exp
   }
   deriving Show
 


### PR DESCRIPTION
[ #5026 ] Option --js-verify run generated JS modules through node.

Skips main modules, since we do not actually want to execute the compiled program.  We only want to do some basic syntax checking and exclude blunders like #5002.

The JS compiler test uses --js-verify.