### PR TITLE
[ new ] Add a stub page for the guarded cubical mode to begin with

### DIFF
--- a/doc/user-manual/language/guarded-cubical.lagda.rst
+++ b/doc/user-manual/language/guarded-cubical.lagda.rst
@@ -6,11 +6,17 @@
 
 .. _guarded-cubical:
 
-
 ********************
 Guarded Cubical
 ********************
 
+.. note::
+   This is a stub.
+
+Cubical Agda is extended with Nakano's later modality and guarded recursion based on Ticked Cubical Type Theory :ref:`[2] <cubical-refs>`.
+For its usage, see :ref:`[1] <cubical-refs>` or the `example <https://github.com/agda/agda/blob/master/test/Succeed/LaterPrims.agda>`_.
+
+.. _cubical-refs:
 
 References
 ==========

--- a/doc/user-manual/language/guarded-cubical.lagda.rst
+++ b/doc/user-manual/language/guarded-cubical.lagda.rst
@@ -1,0 +1,22 @@
+..
+  ::
+
+  {-# OPTIONS --cubical #-}
+  module language.guarded-cubical where
+
+.. _guarded-cubical:
+
+
+********************
+Guarded Cubical
+********************
+
+
+References
+==========
+
+[1] Niccolò Veltri and Andrea Vezzosi. `"Formalizing pi-calculus in guarded cubical Agda." <https://doi.org/10.1145/3372885.3373814>`_
+In CPP'20.  ACM, New York, NY, USA, 2020.
+
+[2] Rasmus Ejlers Møgelberg and Niccolò Veltri. `"Bisimulation as path type for guarded recursive types." <https://doi.org/10.1145/3290317>`_ In POPL'19, 2019.
+

--- a/doc/user-manual/language/index.rst
+++ b/doc/user-manual/language/index.rst
@@ -20,6 +20,7 @@ Language Reference
    function-definitions
    function-types
    generalization-of-declared-variables
+   guarded-cubical
    implicit-arguments
    instance-arguments
    irrelevance


### PR DESCRIPTION
@Saizan implemented the Ticked Cubical Type Theory (introduced in https://dl.acm.org/doi/10.1145/3290317) and demonstrated its usage by formalising pi-calculus in https://dl.acm.org/doi/10.1145/3372885.3373814. 

Maybe it is too early to write a detailed section on this, but it is useful to have some references for people who want to try it out. 