### PR TITLE
[ interaction ] Add flag to show identity substitutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Pragmas and options
 * New option `--allow-exec` enables the use of system calls during type checking
   using the `AGDATCMEXECTC` builtin.
 
+* New option `--show-identity-substitutions` shows all arguments of metavariables
+  when pretty-printing a term, even if they amount to just applying
+  all the variables in the context.
+
 Language
 --------
 

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -208,6 +208,9 @@ data PragmaOptions = PragmaOptions
      -- ^ Should every top-level module start with an implicit statement
      --   @open import Agda.Primitive using (Set; Prop)@?
   , optAllowExec                 :: Bool
+  , optShowIdentitySubstitutions :: Bool
+    -- ^ Show identity substitutions when pretty-printing terms
+    --   (i.e. always show all arguments of a metavariable)
   }
   deriving (Show, Eq)
 
@@ -327,6 +330,7 @@ defaultPragmaOptions = PragmaOptions
   , optFlatSplit                 = True
   , optImportSorts               = True
   , optAllowExec                 = False
+  , optShowIdentitySubstitutions = False
   }
 
 -- | The default termination depth.
@@ -605,6 +609,9 @@ showImplicitFlag o = return $ o { optShowImplicit = True }
 
 showIrrelevantFlag :: Flag PragmaOptions
 showIrrelevantFlag o = return $ o { optShowIrrelevant = True }
+
+showIdentitySubstitutionsFlag :: Flag PragmaOptions
+showIdentitySubstitutionsFlag o = return $ o { optShowIdentitySubstitutions = True }
 
 asciiOnlyFlag :: Flag PragmaOptions
 asciiOnlyFlag o = do
@@ -993,6 +1000,8 @@ pragmaOptions =
                     "show implicit arguments when printing"
     , Option []     ["show-irrelevant"] (NoArg showIrrelevantFlag)
                     "show irrelevant arguments when printing"
+    , Option []     ["show-identity-substitutions"] (NoArg showIrrelevantFlag)
+                    "show all arguments of metavariables when printing terms"
     , Option []     ["no-unicode"] (NoArg asciiOnlyFlag)
                     "don't use unicode characters when printing terms"
     , Option ['v']  ["verbose"] (ReqArg verboseFlag "N")

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -560,6 +560,8 @@ reifyTerm expandAnonDefs0 v0 = do
                                     <*> getContextTelescope
                                     <*> viewTC (eCheckpoints . key local_chkpt)
             (,,) <$> viewTC (eCheckpoints . key chkpt) <*> pure tel <*> pure msub2
+
+          opt_show_ids <- showIdentitySubstitutions
           let
               addNames []    es = map (fmap unnamed) es
               addNames _     [] = []
@@ -590,7 +592,8 @@ reifyTerm expandAnonDefs0 v0 = do
                      doDrop _         [] = []
                  in doDrop dropArg $ named_es'
 
-              simpl_named_es' | Just sub_mtel2local <- msub1 = dropIdentitySubs IdS           sub_mtel2local
+              simpl_named_es' | opt_show_ids                 = named_es'
+                              | Just sub_mtel2local <- msub1 = dropIdentitySubs IdS           sub_mtel2local
                               | Just sub_local2mtel <- msub2 = dropIdentitySubs sub_local2mtel IdS
                               | otherwise                    = named_es'
 

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -241,6 +241,9 @@ showImplicitArguments = optShowImplicit <$> pragmaOptions
 showIrrelevantArguments :: HasOptions m => m Bool
 showIrrelevantArguments = optShowIrrelevant <$> pragmaOptions
 
+showIdentitySubstitutions :: HasOptions m => m Bool
+showIdentitySubstitutions = optShowIdentitySubstitutions <$> pragmaOptions
+
 -- | Switch on printing of implicit and irrelevant arguments.
 --   E.g. for reification in with-function generation.
 --

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -253,12 +253,12 @@ instance EmbPrj Doc where
 
 instance EmbPrj PragmaOptions where
   icod_ = \case
-    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ->
-      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb
+    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ->
+      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc
 
   value = vcase $ \case
-    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx, yy, zz, aaa, bbb] ->
-      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb
+    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx, yy, zz, aaa, bbb, ccc] ->
+      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc
     _ -> malformed
 
 instance EmbPrj UnicodeOrAscii


### PR DESCRIPTION
See https://agda.zulipchat.com/#narrow/stream/238741-general/topic/Printing.20terms.20in.20full/near/215859192

> @vlopezj : When debugging some changes to the Conversion code, I have noticed that Terms have more free variables (Agda.TypeChecking.Free.freeVars) than those displayed by prettyTCM. I believe they are lurking in the arguments in some metavariables. Is there a way of forcing prettyTCM to show all these arguments? I have tried setting envPrintMetasBare to False in the environment, and passing the --show-implicit and --show-irrelevant arguments to Agda, both unsuccessfully.

> @jespercockx : It's probably the logic for not printing identity substitutions at https://github.com/agda/agda/blob/05d0e8752f3ffc80b78981e79264ef415017b064/src/full/Agda/Syntax/Translation/InternalToAbstract.hs#L550-L597 There's currently no way to turn that off with a flag, it might make sense to add one

I am not sure how useful this flag is outside of my use cases, but I'll put the pull request here in case someone wants to merge it.