### PR TITLE
Use the canonical name when printing out of scope names

### DIFF
--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -214,8 +214,8 @@ showQNameId q = show ns ++ "@" ++ show m
 -- | Turn a qualified name into a concrete name. This should only be used as a
 --   fallback when looking up the right concrete name in the scope fails.
 qnameToConcrete :: QName -> C.QName
-qnameToConcrete (QName m x) =
-   foldr (C.Qual . nameConcrete) (C.QName $ nameConcrete x) (mnameToList m)
+qnameToConcrete (QName m x) =       -- Use the canonical name here (#5048)
+   foldr (C.Qual . nameConcrete) (C.QName $ nameCanonical x) (mnameToList m)
 
 mnameToConcrete :: ModuleName -> C.QName
 mnameToConcrete (MName []) = __IMPOSSIBLE__ -- C.QName C.noName_  -- should never happen?

--- a/test/Fail/Issue5048.agda
+++ b/test/Fail/Issue5048.agda
@@ -1,0 +1,12 @@
+
+module _ where
+
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Equality
+
+module M where
+  open import Agda.Builtin.Nat renaming (Nat to Nombre)
+  a = quote Nombre
+
+fail : M.a ≡ quote Name
+fail = refl

--- a/test/Fail/Issue5048.err
+++ b/test/Fail/Issue5048.err
@@ -1,0 +1,3 @@
+Issue5048.agda:12,8-12
+quote Agda.Builtin.Nat.Nat != quote Name of type Name
+when checking that the expression refl has type M.a ≡ quote Name


### PR DESCRIPTION
Fixes #5048