### PR TITLE
[ refactor RE #4784 ] DRY when checking domain of a function type.

### DIFF
--- a/test/Fail/Issue3945.agda
+++ b/test/Fail/Issue3945.agda
@@ -1,8 +1,8 @@
 module _ where
 
-data Flat (A : Set) : Set where
+data Flat (@♭ A : Set) : Set where
   flat : @♭ A → Flat A
 
 -- the lambda cohesion annotation must match the domain.
-into : {A : Set} → A → Flat A
+into : {@♭ A : Set} → A → Flat A
 into = λ (@♭ a) → flat a


### PR DESCRIPTION
The logic to typecheck `A.Pi` and `A.Fun` was duplicated between `isType_` and `checkExpr'`.

Moreover the logic to typecheck the domain of functions was duplicated between `A.Fun` and `A.Pi` cases, and it was no longer the same logic.

This PR addresses both forms of duplication.