### PR TITLE
Separate --interaction-json error messages into error & warnings

### DIFF
--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -31,7 +31,7 @@ import Agda.TypeChecking.Monad (Comparison(..), inTopContext, TCM, NamedMeta(..)
 import Agda.TypeChecking.Monad.MetaVars (getInteractionRange, getMetaRange)
 import Agda.TypeChecking.Pretty (PrettyTCM(..), prettyTCM)
 -- borrowed from EmacsTop, for temporarily serialising stuff
-import Agda.TypeChecking.Pretty.Warning (prettyTCWarnings)
+import Agda.TypeChecking.Pretty.Warning (prettyTCWarnings')
 import Agda.TypeChecking.Warnings (WarningsAndNonFatalErrors(..))
 import Agda.Utils.Pretty (Pretty(..))
 import Agda.Utils.Time (CPUTime(..))
@@ -253,8 +253,8 @@ instance EncodeTCM Blocker where
 
 instance EncodeTCM DisplayInfo where
   encodeTCM (Info_CompilationOk wes) = kind "CompilationOk"
-    [ "warnings"          #= prettyTCWarnings (tcWarnings wes)
-    , "errors"            #= prettyTCWarnings (nonFatalErrors wes)
+    [ "warnings"          #= prettyTCWarnings' (tcWarnings wes)
+    , "errors"            #= prettyTCWarnings' (nonFatalErrors wes)
     ]
   encodeTCM (Info_Constraints constraints) = kind "Constraints"
     [ "constraints"       #= forM constraints encodeTCM
@@ -262,26 +262,18 @@ instance EncodeTCM DisplayInfo where
   encodeTCM (Info_AllGoalsWarnings (vis, invis) wes) = kind "AllGoalsWarnings"
     [ "visibleGoals"      #= forM vis (encodeOC encodeTCM encodePrettyTCM)
     , "invisibleGoals"    #= forM invis (encodeOC encodeTCM encodePrettyTCM)
-    , "warnings"          #= prettyTCWarnings (tcWarnings wes)
-    , "errors"            #= prettyTCWarnings (nonFatalErrors wes)
+    , "warnings"          #= prettyTCWarnings' (tcWarnings wes)
+    , "errors"            #= prettyTCWarnings' (nonFatalErrors wes)
     ]
   encodeTCM (Info_Time time) = kind "Time"
     [ "time"              @= time
     ]
   encodeTCM (Info_Error (Info_GenericError err)) = kind "Error"
-    [ "warnings"          #= (prettyTCWarnings =<< getAllWarningsOfTCErr err)
+    [ "warnings"          #= (prettyTCWarnings' =<< getAllWarningsOfTCErr err)
     , "error"             #= prettyError err
     ]
-  encodeTCM (Info_Error (Info_CompilationError warnings)) = kind "Error"
-    [ "warnings"          #= prettyTCWarnings warnings
-    , "error"             @= ("" :: String)
-    ]
-  encodeTCM (Info_Error err@(Info_HighlightingParseError _)) = kind "Error"
-    [ "warnings"          @= ("" :: String)
-    , "error"             #= showInfoError err
-    ]
-  encodeTCM (Info_Error err@(Info_HighlightingScopeCheckError _)) = kind "Error"
-    [ "warnings"          @= ("" :: String)
+  encodeTCM (Info_Error err) = kind "Error"
+    [ "warnings"          @= ([] :: [String])
     , "error"             #= showInfoError err
     ]
   encodeTCM Info_Intro_NotFound = kind "IntroNotFound" []

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -27,13 +27,14 @@ import Agda.Syntax.Position (Range, rangeIntervals, Interval'(..), Position'(..)
 import Agda.VersionCommit
 
 import Agda.TypeChecking.Errors (prettyError)
-import Agda.TypeChecking.Monad (Comparison(..), inTopContext, TCM, NamedMeta(..))
+import Agda.TypeChecking.Monad (Comparison(..), inTopContext, TCM, TCErr, TCWarning, NamedMeta(..))
 import Agda.TypeChecking.Monad.MetaVars (getInteractionRange, getMetaRange)
 import Agda.TypeChecking.Pretty (PrettyTCM(..), prettyTCM)
 -- borrowed from EmacsTop, for temporarily serialising stuff
-import Agda.TypeChecking.Pretty.Warning (prettyTCWarnings')
+import Agda.TypeChecking.Pretty.Warning (filterTCWarnings)
 import Agda.TypeChecking.Warnings (WarningsAndNonFatalErrors(..))
 import Agda.Utils.Pretty (Pretty(..))
+import qualified Agda.Utils.Pretty as P
 import Agda.Utils.Time (CPUTime(..))
 
 --------------------------------------------------------------------------------
@@ -220,7 +221,7 @@ encodeOC f encPrettyTCM = \case
  PostponedCheckFunDef name a err -> kind "PostponedCheckFunDef"
   [ "name"           @= encodePretty name
   , "type"           #= encPrettyTCM a
-  , "error"          #= encodePrettyTCM err
+  , "error"          #= encodeTCM err
   ]
  CheckLock t lk -> kind "CheckLock"
   [ "head"           #= f t
@@ -253,8 +254,8 @@ instance EncodeTCM Blocker where
 
 instance EncodeTCM DisplayInfo where
   encodeTCM (Info_CompilationOk wes) = kind "CompilationOk"
-    [ "warnings"          #= prettyTCWarnings' (tcWarnings wes)
-    , "errors"            #= prettyTCWarnings' (nonFatalErrors wes)
+    [ "warnings"          #= encodeTCM (filterTCWarnings (tcWarnings wes))
+    , "errors"            #= encodeTCM (filterTCWarnings (nonFatalErrors wes))
     ]
   encodeTCM (Info_Constraints constraints) = kind "Constraints"
     [ "constraints"       #= forM constraints encodeTCM
@@ -262,20 +263,13 @@ instance EncodeTCM DisplayInfo where
   encodeTCM (Info_AllGoalsWarnings (vis, invis) wes) = kind "AllGoalsWarnings"
     [ "visibleGoals"      #= forM vis (encodeOC encodeTCM encodePrettyTCM)
     , "invisibleGoals"    #= forM invis (encodeOC encodeTCM encodePrettyTCM)
-    , "warnings"          #= prettyTCWarnings' (tcWarnings wes)
-    , "errors"            #= prettyTCWarnings' (nonFatalErrors wes)
+    , "warnings"          #= encodeTCM (filterTCWarnings (tcWarnings wes))
+    , "errors"            #= encodeTCM (filterTCWarnings (nonFatalErrors wes))
     ]
   encodeTCM (Info_Time time) = kind "Time"
     [ "time"              @= time
     ]
-  encodeTCM (Info_Error (Info_GenericError err)) = kind "Error"
-    [ "warnings"          #= (prettyTCWarnings' =<< getAllWarningsOfTCErr err)
-    , "error"             #= prettyError err
-    ]
-  encodeTCM (Info_Error err) = kind "Error"
-    [ "warnings"          @= ([] :: [String])
-    , "error"             #= showInfoError err
-    ]
+  encodeTCM (Info_Error err) = encodeTCM err
   encodeTCM Info_Intro_NotFound = kind "IntroNotFound" []
   encodeTCM (Info_Intro_ConstructorUnknown introductions) = kind "IntroConstructorUnknown"
     [ "constructors"      @= map toJSON introductions
@@ -364,6 +358,29 @@ encodeGoalSpecific ii = go
     ]
   go (Goal_InferredType expr) = kind "InferredType"
     [ "expr"        #= prettyATop expr
+    ]
+
+instance EncodeTCM Info_Error where
+  encodeTCM (Info_GenericError err) = kind "Error"
+    [ "warnings"          #= (getAllWarningsOfTCErr err
+                            >>= encodeTCM . filterTCWarnings)
+    , "error"             #= encodeTCM err
+    ]
+  encodeTCM err = kind "Error"
+    [ "warnings"          @= ([] :: [String])
+    , "error"             #= obj
+      [ "message"           #= showInfoError err
+      ]
+    ]
+
+instance EncodeTCM TCErr where
+  encodeTCM err = obj
+    [ "message"     #= encodePrettyTCM err
+    ]
+
+instance EncodeTCM TCWarning where
+  encodeTCM w = obj
+    [ "message"     #= (P.render <$> prettyTCM w)
     ]
 
 instance EncodeTCM Response where


### PR DESCRIPTION
## Summary

Currently, the `--interaction-json` mode produces JSON error messages consisting of a single `message` field. This pull request would separate the message into separate `error` and `warnings` fields, which is more consistent with how `--interaction-json` handles other interaction messages. We use an empty string to indicate that there is no error (or no warning).

## Example

File `Test.agda`:

```
module Test where
import M -- nonexistent module
postulate
```

Old JSON output when loading file:

```
{"kind":"DisplayInfo","info":{"kind":"Error","message":"———— Error —————————————————————————————————————————————————\n/data/code/agda-test/Test.agda:2,1-9\nFailed to find source of module M in any of the following\nlocations:\n  /data/code/agda-test/M.agda\n  /data/code/agda-test/M.lagda\n  /nix/store/7ijyk09sf8xbn9spz9pf846c5nsmfy2g-Agda-2.6.1.1-data/share/ghc-8.8.4/x86_64-linux-ghc-8.8.4/Agda-2.6.1.1/lib/prim/M.agda\n  /nix/store/7ijyk09sf8xbn9spz9pf846c5nsmfy2g-Agda-2.6.1.1-data/share/ghc-8.8.4/x86_64-linux-ghc-8.8.4/Agda-2.6.1.1/lib/prim/M.lagda\nwhen scope checking the declaration\n  import M\n\n———— Warning(s) ————————————————————————————————————————————\n/data/code/agda-test/Test.agda:3,1-10\nEmpty postulate block."}}
```

New JSON output when loading file:

```
{"kind":"DisplayInfo","info":{"kind":"Error","error":"/data/code/agda-test/Test.agda:2,1-9\nFailed to find source of module M in any of the following\nlocations:\n  /data/code/agda-test/M.agda\n  /data/code/agda-test/M.lagda\n  /home/matt/.cabal/share/x86_64-linux-ghc-8.8.4/Agda-2.6.2/lib/prim/M.agda\n  /home/matt/.cabal/share/x86_64-linux-ghc-8.8.4/Agda-2.6.2/lib/prim/M.lagda\nwhen scope checking the declaration\n  import M","warnings":"/data/code/agda-test/Test.agda:3,1-10\nEmpty postulate block.\n"}}
```

## Discussion

Note that it is possible that there is an error but no warning, or warnings but no error. I made the decision to use the same object structure in each case, but to use an empty string when either field is missing. One possible alternative would be to distinguish the different cases using the `kind` field, say into "Error", "Warnings", and "ErrorWarnings", or something similar.

I want to point out that we could keep the `message` field around to avoid a breaking change, still adding the two new fields. I haven't done that here because it would be somewhat inconsistent with the other message kinds.

I'd like @banacorn to check this before it gets pulled. Also paging @ice1000 @rwe.