### PR TITLE
Add de Bruijn index to reflected absurd patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,10 +310,13 @@ Reflection
   clause, the types in the clause telescope are currently ignored (but
   this is subject to change in the future).
 
-  Two constructors of the `Pattern` datatype were also changed:
-  pattern variables now refer to a de Bruijn index (relative to the
-  clause telescope) rather than a string, and dot patterns now include
-  the actual dotted term.
+  Three constructors of the `Pattern` datatype were also changed:
+
+  * pattern variables now refer to a de Bruijn index (relative to the
+    clause telescope) rather than a string,
+  * absurd patterns take a de Bruijn index and are expected to be bound by the
+    clause telescope,
+  * dot patterns now include the actual dotted term.
 
   ```agda
   data Pattern where
@@ -322,7 +325,7 @@ Reflection
     var    : (x : Nat)     → Pattern   -- previously:   var : (x : String) → Pattern
     lit    : (l : Literal) → Pattern
     proj   : (f : Name)    → Pattern
-    absurd : Pattern
+    absurd : (x : Nat)     → Pattern
   ```
 
   It is likely that this change to the reflected syntax requires you
@@ -338,11 +341,11 @@ Reflection
     telescope for the types of the pattern variables. To get back the
     old behaviour of Agda, it is sufficient to set all the types of
     the pattern variables to `unknown`. So you can construct the
-    telescope by listing the names of all pattern variables together
-    with their `ArgInfo`. Meanwhile, the pattern variables should be
-    numbered in order to update them to the new representation. As for
-    the telescope types, the contents of a `dot` pattern can safely be
-    set to `unknown`.
+    telescope by listing the names of all pattern variables and absurd patterns
+    together with their `ArgInfo`. Meanwhile, the pattern variables should be
+    numbered in order to update them to the new representation. As for the
+    telescope types, the contents of a `dot` pattern can safely be set to
+    `unknown`.
 
 - New operation in `TC` monad, `execTC`, which calls an external executable
   ```agda

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,10 @@ endif
 # Thus, ignore exit code.
 
 .PHONY: type-check
-type-check: install-deps
+type-check: install-deps type-check-no-deps
+
+.PHONY: type-check-no-deps
+type-check-no-deps :
 	@echo "================= Type checking using Cabal with -fno-code ==============="
 	-time $(CABAL) $(CABAL_BUILD_CMD) --builddir=$(BUILD_DIR)-no-code \
           --ghc-options=-fno-code \

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -246,7 +246,7 @@ de Bruijn indices to represent variables.
     var    : (x : Nat   )  → Pattern
     lit    : (l : Literal) → Pattern
     proj   : (f : Name)    → Pattern
-    absurd : Pattern
+    absurd : (x : Nat)     → Pattern  -- Absurd patterns have de Bruijn indices
 
   data Clause where
     clause        : (tel : Telescope) (ps : List (Arg Pattern)) (t : Term) → Clause

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -174,7 +174,7 @@ data Pattern where
   var    : (x : Nat)     → Pattern
   lit    : (l : Literal) → Pattern
   proj   : (f : Name)    → Pattern
-  absurd : Pattern
+  absurd : (x : Nat)     → Pattern  -- absurd patterns counts as variables
 
 data Clause where
   clause        : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) (t : Term) → Clause

--- a/src/full/Agda/Syntax/Reflected.hs
+++ b/src/full/Agda/Syntax/Reflected.hs
@@ -48,7 +48,7 @@ data Pattern = ConP QName [Arg Pattern]
              | DotP Term
              | VarP Int
              | LitP Literal
-             | AbsurdP
+             | AbsurdP Int
              | ProjP QName
   deriving (Show)
 

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -215,7 +215,7 @@ mkVarName i = fst <$> mkVar i
 annotatePattern :: MonadReflectedToAbstract m => Int -> R.Type -> A.Pattern -> m A.Pattern
 annotatePattern _ R.Unknown p = return p
 annotatePattern i t p = local (drop $ i + 1) $ do
-  t <- toAbstract t  -- ^^ go into the right context for translating the type
+  t <- toAbstract t  -- go into the right context for translating the type
   return $ A.AnnP patNoRange t p
 
 instance ToAbstract Sort where

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -172,8 +172,8 @@ quotingKit = do
       quotePats ps = list $ map (quoteArg quotePat . fmap namedThing) ps
 
       quotePat :: DeBruijnPattern -> ReduceM Term
-      quotePat p
-       | patternOrigin p == Just PatOAbsurd = pure absurdP
+      quotePat p@(VarP _ x)
+       | patternOrigin p == Just PatOAbsurd = absurdP !@! quoteNat (toInteger $ dbPatVarIndex x)
       quotePat (VarP o x)        = varP !@! quoteNat (toInteger $ dbPatVarIndex x)
       quotePat (DotP _ t)        = dotP !@ quoteTerm t
       quotePat (ConP c _ ps)     = conP !@ quoteQName (conName c) @@ quotePats ps

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -96,7 +96,7 @@ coreBuiltins =
   , (builtinAgdaPatDot                       |-> BuiltinDataCons (tterm --> tpat))
   , (builtinAgdaPatLit                       |-> BuiltinDataCons (tliteral --> tpat))
   , (builtinAgdaPatProj                      |-> BuiltinDataCons (tqname --> tpat))
-  , (builtinAgdaPatAbsurd                    |-> BuiltinDataCons tpat)
+  , (builtinAgdaPatAbsurd                    |-> BuiltinDataCons (tnat --> tpat))
   , (builtinLevel                            |-> builtinPostulate tset)
   , (builtinWord64                           |-> builtinPostulate tset)
   , (builtinInteger                          |-> BuiltinData tset [builtinIntegerPos, builtinIntegerNegSuc])

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -458,16 +458,13 @@ instance Unquote R.Pattern where
   unquote t = do
     t <- reduceQuotedTerm t
     case t of
-      Con c _ [] ->
-        choice
-          [ (c `isCon` primAgdaPatAbsurd, return R.AbsurdP)
-          ] __IMPOSSIBLE__
       Con c _ es | Just [x] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaPatVar,  R.VarP . fromInteger <$> unquoteN x)
-          , (c `isCon` primAgdaPatDot,  R.DotP  <$> unquoteN x)
-          , (c `isCon` primAgdaPatProj, R.ProjP <$> unquoteN x)
-          , (c `isCon` primAgdaPatLit,  R.LitP  <$> unquoteN x) ]
+          [ (c `isCon` primAgdaPatVar,    R.VarP    . fromInteger <$> unquoteN x)
+          , (c `isCon` primAgdaPatAbsurd, R.AbsurdP . fromInteger <$> unquoteN x)
+          , (c `isCon` primAgdaPatDot,    R.DotP  <$> unquoteN x)
+          , (c `isCon` primAgdaPatProj,   R.ProjP <$> unquoteN x)
+          , (c `isCon` primAgdaPatLit,    R.LitP  <$> unquoteN x) ]
           __IMPOSSIBLE__
       Con c _ es | Just [x, y] <- allApplyElims es ->
         choice

--- a/test/Fail/Issue5044.agda
+++ b/test/Fail/Issue5044.agda
@@ -1,0 +1,29 @@
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Equality
+
+pattern vArg x = arg (arg-info visible relevant) x
+pattern hArg x = arg (arg-info hidden  relevant) x
+
+idClause-ok : Clause
+idClause-ok = clause
+             (("A" , hArg (agda-sort (lit 0))) ∷ ("x" , vArg (var 0 [])) ∷ [])
+             (hArg (var 1) ∷ vArg (var 0) ∷ [])
+             (var 0 [])
+
+id-ok : {A : Set} → A → A
+unquoteDef id-ok = defineFun id-ok (idClause-ok ∷ [])
+
+idClause-fail : Clause
+idClause-fail = clause
+             (("A" , hArg (agda-sort (lit 0))) ∷ ("x" , vArg (var 0 [])) ∷ [])
+             ({-hArg (var 1) ∷-} vArg (var 0) ∷ [])
+             (var 0 [])
+
+id-fail : {A : Set} → A → A
+unquoteDef id-fail = defineFun id-fail (idClause-fail ∷ [])
+-- Panic: unbound variable A (id: 191@9559440724209987811)
+-- when checking that the expression A has type _7

--- a/test/Fail/Issue5044.err
+++ b/test/Fail/Issue5044.err
@@ -1,0 +1,3 @@
+Issue5044.agda:27,1-60
+Missing bindings for telescope variable A.
+All variables in the clause telescope must be bound in the left-hand side.

--- a/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
+++ b/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
@@ -122,7 +122,7 @@ data Pattern : Set where
   var    : (x : Nat)     → Pattern
   lit    : (l : Literal) → Pattern
   proj   : (f : Name)    → Pattern
-  absurd : Pattern
+  absurd : (x : Nat)     → Pattern
 
 data Clause where
   clause        : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) (t : Term) → Clause

--- a/test/Succeed/Issue2618.agda
+++ b/test/Succeed/Issue2618.agda
@@ -45,11 +45,11 @@ unit,X=> n ∙ args =
 
 abs,X=>∙_ : List Nat → Term
 abs,X=>∙ is = pat-lam [ absurd-clause ( ("()" , vArg (def (quote Empty) [])) ∷  ("X" , vArg (agda-sort (lit 0))) ∷ [])
-                                      (vArg absurd ∷ vArg (var 0) ∷ []) ]
+                                      (vArg (absurd 1) ∷ vArg (var 0) ∷ []) ]
                       (mkArgs is)
 
 abs=>∙_ : List Nat → Term
-abs=>∙ is = pat-lam [ absurd-clause [ "()" , vArg (def (quote Empty) []) ] (vArg absurd ∷ []) ]
+abs=>∙ is = pat-lam [ absurd-clause [ "()" , vArg (def (quote Empty) []) ] (vArg (absurd 0) ∷ []) ]
                     (mkArgs is)
 
 _ : qU (λ { unit X → X }) ≡ unit,X=> 0 ∙ []

--- a/test/Succeed/QuoteExtLam.agda
+++ b/test/Succeed/QuoteExtLam.agda
@@ -37,13 +37,13 @@ pattern `Wrap a = def (quote Wrap) (vArg a ∷ [])
 pattern `⊥ = def (quote ⊥) []
 
 pattern expected₄ = funDef
-  (absurdClause (("()" , vArg `⊥) ∷ []) (vArg (con (quote wrap) (vArg absurd ∷ [])) ∷ [])
+  (absurdClause (("()" , vArg `⊥) ∷ []) (vArg (con (quote wrap) (vArg (absurd 0) ∷ [])) ∷ [])
   ∷ [])
 
 check₄ : OK
 check₄ = checkDefinition (λ { expected₄ → true; _ → false }) magic₄
 
-expected = extLam (absurdClause (("()" , vArg `⊥) ∷ []) (arg (argInfo visible relevant) absurd ∷ []) ∷ []) []
+expected = extLam (absurdClause (("()" , vArg `⊥) ∷ []) (arg (argInfo visible relevant) (absurd 0) ∷ []) ∷ []) []
 
 macro
 
@@ -60,7 +60,7 @@ check₂ : quoteTermNormalised magic₂ ≡ expected
 check₂ = refl
 
 pattern expectedDef =
-  funDef (absurdClause (("()" , vArg `⊥) ∷ []) (vArg absurd ∷ []) ∷ [])
+  funDef (absurdClause (("()" , vArg `⊥) ∷ []) (vArg (absurd 0) ∷ []) ∷ [])
 
 check₃ : OK
 check₃ = checkDefinition (λ { expectedDef → true; _ → false }) magic₃

--- a/test/Succeed/ReflectTC.agda
+++ b/test/Succeed/ReflectTC.agda
@@ -43,7 +43,7 @@ newMeta! = newMeta unknown
 absurdLam : Term
 absurdLam = extLam (absurdClause
                       (("()" , arg (argInfo visible relevant) unknown) ∷ [])
-                      (arg (argInfo visible relevant) absurd ∷ [])
+                      (arg (argInfo visible relevant) (absurd 0) ∷ [])
                    ∷ []) []
 
 -- Simple assumption tactic --

--- a/test/Succeed/UnquoteDecl.agda
+++ b/test/Succeed/UnquoteDecl.agda
@@ -36,6 +36,6 @@ prf = refl
 magicDef : FunDef
 magicDef =
   funDef (def (quote ⊥) [] `⇒ `Nat)
-         (absurdClause (("()" , vArg unknown) ∷ []) (vArg absurd ∷ []) ∷ [])
+         (absurdClause (("()" , vArg unknown) ∷ []) (vArg (absurd 0) ∷ []) ∷ [])
 
 unquoteDecl magic = define (vArg magic) magicDef

--- a/test/Succeed/UnquoteExtLam.agda
+++ b/test/Succeed/UnquoteExtLam.agda
@@ -23,7 +23,7 @@ prDef =
 magicDef : FunDef
 magicDef =
   funDef (pi (hArg `Set) (abs "A" (`⊥ `→ var 1 [])))
-       ( clause [] [] (extLam ( absurdClause (("()" , vArg `⊥) ∷ []) (vArg absurd ∷ [])
+       ( clause [] [] (extLam ( absurdClause (("()" , vArg `⊥) ∷ []) (vArg (absurd 0) ∷ [])
                               ∷ []) [])
        ∷ [] )
 
@@ -35,7 +35,7 @@ checkMagic = magic
 unquoteDecl pr = define (vArg pr) prDef
 
 magic′ : {A : Set} → ⊥ → A
-magic′ = unquote (give (extLam (absurdClause (("()" , vArg `⊥) ∷ []) (vArg absurd ∷ []) ∷ []) []))
+magic′ = unquote (give (extLam (absurdClause (("()" , vArg `⊥) ∷ []) (vArg (absurd 0) ∷ []) ∷ []) []))
 
 module Pred (A : Set) where
   unquoteDecl pr′ = define (vArg pr′) prDef


### PR DESCRIPTION
This is needed in order to check clause telescopes when unquoting pattern lambdas. Internally absurd patterns a variables (since there's no value to substitute the variable for), so it makes sense that this is the case also in reflected syntax.

Missing: changelog and user manual

Fixes #5044