### PR TITLE
Remove `MaybeWarnings` and replace with `[TCWarning]`

### DIFF
--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -32,6 +32,7 @@ import qualified Data.Map as Map
 import System.Console.GetOpt
 
 import Agda.Syntax.Treeless
+import Agda.TypeChecking.Errors (getAllWarnings)
 -- Agda.TypeChecking.Monad.Base imports us, relying on the .hs-boot file to
 -- resolve the circular dependency. Fine. However, ghci loads the module after
 -- compilation, so it brings in all of the symbols. That causes .Base to see
@@ -44,7 +45,6 @@ import Agda.TypeChecking.Pretty as P
 
 import Agda.Interaction.Options
 import Agda.Interaction.FindFile
-import Agda.Interaction.Imports (getAllWarnings)
 import Agda.TypeChecking.Warnings
 
 import Agda.Utils.FileName

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -24,7 +24,6 @@ import qualified Data.Text as T
 
 import Agda.Interaction.Base
 import Agda.Interaction.Options
-import {-# SOURCE #-} Agda.Interaction.Imports (getAllWarnings)
 import Agda.Interaction.Response (Goals, ResponseContextEntry(..))
 
 import qualified Agda.Syntax.Concrete as C -- ToDo: Remove with instance of ToConcrete
@@ -48,7 +47,7 @@ import Agda.Syntax.Parser
 import Agda.TheTypeChecker
 import Agda.TypeChecking.Constraints
 import Agda.TypeChecking.Conversion
-import Agda.TypeChecking.Errors ( stringTCErr )
+import Agda.TypeChecking.Errors ( getAllWarnings, stringTCErr )
 import Agda.TypeChecking.Monad as M hiding (MetaInfo)
 import Agda.TypeChecking.MetaVars
 import Agda.TypeChecking.MetaVars.Mention

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -24,7 +24,7 @@ import qualified Data.Text as T
 
 import Agda.Interaction.Base
 import Agda.Interaction.Options
-import {-# SOURCE #-} Agda.Interaction.Imports (MaybeWarnings'(..), getMaybeWarnings)
+import {-# SOURCE #-} Agda.Interaction.Imports (getAllWarnings)
 import Agda.Interaction.Response (Goals, ResponseContextEntry(..))
 
 import qualified Agda.Syntax.Concrete as C -- ToDo: Remove with instance of ToConcrete
@@ -719,10 +719,10 @@ showGoals (ims, hms) = do
 
 getWarningsAndNonFatalErrors :: TCM WarningsAndNonFatalErrors
 getWarningsAndNonFatalErrors = do
-  mws <- getMaybeWarnings AllWarnings
-  let notMetaWarnings = filter (not . isMetaTCWarning) <$> mws
+  mws <- getAllWarnings AllWarnings
+  let notMetaWarnings = filter (not . isMetaTCWarning) mws
   return $ case notMetaWarnings of
-    SomeWarnings ws@(_:_) -> classifyWarnings ws
+    ws@(_:_) -> classifyWarnings ws
     _ -> emptyWarningsAndNonFatalErrors
 
 -- | Collecting the context of the given meta-variable.

--- a/src/full/Agda/Interaction/EmacsTop.hs
+++ b/src/full/Agda/Interaction/EmacsTop.hs
@@ -17,7 +17,7 @@ import Agda.Syntax.Abstract.Pretty (prettyATop)
 import Agda.Syntax.Abstract as A
 import Agda.Syntax.Concrete as C
 
-import Agda.TypeChecking.Errors (prettyError)
+import Agda.TypeChecking.Errors (prettyError, getAllWarningsOfTCErr)
 import qualified Agda.TypeChecking.Pretty as TCP
 import Agda.TypeChecking.Pretty (prettyTCM)
 import Agda.TypeChecking.Pretty.Warning (prettyTCWarnings, prettyTCWarnings')
@@ -31,7 +31,6 @@ import Agda.Interaction.EmacsCommand hiding (putResponse)
 import Agda.Interaction.Highlighting.Emacs
 import Agda.Interaction.Highlighting.Precise (TokenBased(..))
 import Agda.Interaction.InteractionTop (localStateCommandM)
-import Agda.Interaction.Imports (getAllWarningsOfTCErr)
 import Agda.Utils.Function (applyWhen)
 import Agda.Utils.Null (empty)
 import Agda.Utils.Maybe

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -9,7 +9,6 @@ module Agda.Interaction.Imports
   , MaybeWarnings
   , MaybeWarnings'(NoWarnings, SomeWarnings)
   , SourceInfo(..)
-  , applyFlagsToMaybeWarnings
   , isNewerThan
   , getAllWarnings
   , getAllWarningsOfTCErr
@@ -242,13 +241,8 @@ scopeCheckImport x = do
     return (iModuleName i `withRangesOfQ` mnameToConcrete x, s)
 
 data MaybeWarnings' a = NoWarnings | SomeWarnings a
-  deriving (Show, Functor, Foldable, Traversable)
+  deriving (Show, Functor)
 type MaybeWarnings = MaybeWarnings' [TCWarning]
-
-applyFlagsToMaybeWarnings :: MaybeWarnings -> TCM MaybeWarnings
-applyFlagsToMaybeWarnings mw = do
-  w' <- traverse applyFlagsToTCWarnings mw
-  return $ if null w' then NoWarnings else w'
 
 instance Null a => Null (MaybeWarnings' a) where
   empty = NoWarnings

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -12,7 +12,6 @@ module Agda.Interaction.Imports
   , isNewerThan
   , getAllWarnings
   , getAllWarningsOfTCErr
-  , getMaybeWarnings
   , scopeCheckImport
   , sourceInfo
   , typeCheckMain
@@ -1133,9 +1132,6 @@ getAllWarnings' isMain ww = do
   fmap (filter (showWarn . tcWarning))
     $ applyFlagsToTCWarnings' isMain $ reverse
     $ unsolved ++ collectedTCWarnings
-
-getMaybeWarnings :: WhichWarnings -> TCM MaybeWarnings
-getMaybeWarnings = getMaybeWarnings' NotMainInterface
 
 getMaybeWarnings' :: MainInterface -> WhichWarnings -> TCM MaybeWarnings
 getMaybeWarnings' isMain ww = do

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -81,7 +81,6 @@ import Agda.Interaction.Response
 
 import Agda.Utils.FileName
 import Agda.Utils.Lens
-import Agda.Utils.List
 import Agda.Utils.Maybe
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Monad
@@ -1089,18 +1088,9 @@ createInterface file mname isMain msi =
 
     return $ first constructIScope (i, mallWarnings)
 
-getUniqueMetasRanges :: [MetaId] -> TCM [Range]
-getUniqueMetasRanges = fmap (nubOn id) . mapM getMetaRange
-
-getUnsolvedMetas :: TCM [Range]
-getUnsolvedMetas = do
-  openMetas            <- getOpenMetas
-  interactionMetas     <- getInteractionMetas
-  getUniqueMetasRanges (openMetas List.\\ interactionMetas)
-
 getAllUnsolved :: TCM [TCWarning]
 getAllUnsolved = do
-  unsolvedInteractions <- getUniqueMetasRanges =<< getInteractionMetas
+  unsolvedInteractions <- getUnsolvedInteractionMetas
   unsolvedConstraints  <- getAllConstraints
   unsolvedMetas        <- getUnsolvedMetas
 

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -3,7 +3,25 @@
 {-| This module deals with finding imported modules and loading their
     interface files.
 -}
-module Agda.Interaction.Imports where
+module Agda.Interaction.Imports
+  ( MainInterface(MainInterface, NotMainInterface)
+  , Mode(ScopeCheck, TypeCheck)
+  , MaybeWarnings
+  , MaybeWarnings'(NoWarnings, SomeWarnings)
+  , SourceInfo(..)
+  , applyFlagsToMaybeWarnings
+  , isNewerThan
+  , getAllWarnings
+  , getAllWarningsOfTCErr
+  , getMaybeWarnings
+  , scopeCheckImport
+  , sourceInfo
+  , typeCheckMain
+
+  -- Currently only used by test/api/Issue1168.hs:
+  , readInterface'
+  , readInterface
+  ) where
 
 import Prelude hiding (null)
 

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -395,14 +395,10 @@ getInterface_
   -> TCM Interface
 getInterface_ x msi = do
   (i, wt) <- getInterface' x NotMainInterface msi
-  case wt of
-    SomeWarnings w  -> tcWarningsToError (filter (notIM . tcWarning) w)
-    NoWarnings      -> return i
-   -- filter out unsolved interaction points for imported module so
-   -- that we get the right error message (see test case Fail/Issue1296)
-   where notIM UnsolvedInteractionMetas{} = False
-         notIM _                          = True
-
+  tcWarningsToError $ case wt of
+      NoWarnings -> []
+      SomeWarnings ws -> ws
+  return i
 
 -- | A more precise variant of 'getInterface'. If warnings are
 -- encountered then they are returned instead of being turned into

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -9,7 +9,6 @@ import Prelude hiding (null)
 
 import Control.Arrow
 import Control.Monad.Except
-import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Trans.Maybe
 import qualified Control.Exception as E
@@ -22,7 +21,6 @@ import Data.Maybe
 import Data.Map (Map)
 import qualified Data.HashMap.Strict as HMap
 import Data.Text (Text)
-import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 
 import System.Directory (doesFileExist, getModificationTime, removeFile)

--- a/src/full/Agda/Interaction/Imports.hs-boot
+++ b/src/full/Agda/Interaction/Imports.hs-boot
@@ -5,10 +5,6 @@ import Data.Map                     ( Map )
 
 import Agda.Syntax.Abstract.Name    ( ModuleName )
 import Agda.Syntax.Scope.Base       ( Scope )
-import Agda.TypeChecking.Monad.Base ( TCM, TCWarning )
-
-data MaybeWarnings' a = NoWarnings | SomeWarnings a
-type MaybeWarnings = MaybeWarnings' [TCWarning]
-instance Functor MaybeWarnings'
+import Agda.TypeChecking.Monad.Base ( TCM )
 
 scopeCheckImport :: ModuleName -> TCM (ModuleName, Map ModuleName Scope)

--- a/src/full/Agda/Interaction/Imports.hs-boot
+++ b/src/full/Agda/Interaction/Imports.hs-boot
@@ -11,10 +11,5 @@ data MaybeWarnings' a = NoWarnings | SomeWarnings a
 type MaybeWarnings = MaybeWarnings' [TCWarning]
 instance Functor MaybeWarnings'
 
-data Mode
-data MainInterface = MainInterface Mode | NotMainInterface
-
-instance Eq MainInterface
-
 scopeCheckImport :: ModuleName -> TCM (ModuleName, Map ModuleName Scope)
 getAllWarnings :: WhichWarnings -> TCM [TCWarning]

--- a/src/full/Agda/Interaction/Imports.hs-boot
+++ b/src/full/Agda/Interaction/Imports.hs-boot
@@ -17,4 +17,4 @@ data MainInterface = MainInterface Mode | NotMainInterface
 instance Eq MainInterface
 
 scopeCheckImport :: ModuleName -> TCM (ModuleName, Map ModuleName Scope)
-getMaybeWarnings :: WhichWarnings -> TCM MaybeWarnings
+getAllWarnings :: WhichWarnings -> TCM [TCWarning]

--- a/src/full/Agda/Interaction/Imports.hs-boot
+++ b/src/full/Agda/Interaction/Imports.hs-boot
@@ -1,19 +1,14 @@
 
 module Agda.Interaction.Imports where
 
--- Control.Monad.Fail import is redundant since GHC 8.8.1
-import Control.Monad.Fail (MonadFail)
-
 import Data.Map                     ( Map )
 
 import Agda.Syntax.Abstract.Name    ( ModuleName )
 import Agda.Syntax.Scope.Base       ( Scope )
-import Agda.TypeChecking.Monad.Base ( TCM, TCWarning, ReadTCState )
-import Agda.TypeChecking.Warnings   ( WhichWarnings, MonadWarning )
+import Agda.TypeChecking.Monad.Base ( TCM, TCWarning )
 
 data MaybeWarnings' a = NoWarnings | SomeWarnings a
 type MaybeWarnings = MaybeWarnings' [TCWarning]
 instance Functor MaybeWarnings'
 
 scopeCheckImport :: ModuleName -> TCM (ModuleName, Map ModuleName Scope)
-getAllWarnings :: (MonadFail m, ReadTCState m, MonadWarning m) => WhichWarnings -> m [TCWarning]

--- a/src/full/Agda/Interaction/Imports.hs-boot
+++ b/src/full/Agda/Interaction/Imports.hs-boot
@@ -1,15 +1,19 @@
 
 module Agda.Interaction.Imports where
 
+-- Control.Monad.Fail import is redundant since GHC 8.8.1
+import Control.Monad.Fail (MonadFail)
+
+import Data.Map                     ( Map )
+
 import Agda.Syntax.Abstract.Name    ( ModuleName )
 import Agda.Syntax.Scope.Base       ( Scope )
-import Agda.TypeChecking.Monad.Base ( TCM, TCWarning )
-import Agda.TypeChecking.Warnings   ( WhichWarnings )
-import Data.Map                     ( Map )
+import Agda.TypeChecking.Monad.Base ( TCM, TCWarning, ReadTCState )
+import Agda.TypeChecking.Warnings   ( WhichWarnings, MonadWarning )
 
 data MaybeWarnings' a = NoWarnings | SomeWarnings a
 type MaybeWarnings = MaybeWarnings' [TCWarning]
 instance Functor MaybeWarnings'
 
 scopeCheckImport :: ModuleName -> TCM (ModuleName, Map ModuleName Scope)
-getAllWarnings :: WhichWarnings -> TCM [TCWarning]
+getAllWarnings :: (MonadFail m, ReadTCState m, MonadWarning m) => WhichWarnings -> m [TCWarning]

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -503,9 +503,7 @@ interpret (Cmd_load m argv) =
 
 interpret (Cmd_compile backend file argv) =
   cmd_load' file argv allowUnsolved mode $ \ (i, mw) -> do
-    mw' <- lift $ applyFlagsToTCWarnings $ case mw of
-      Imp.NoWarnings -> []
-      Imp.SomeWarnings ws -> ws
+    mw' <- lift $ applyFlagsToTCWarnings mw
     case mw' of
       [] -> do
         lift $ case backend of
@@ -878,7 +876,7 @@ cmd_load'
                --   Providing 'TypeCheck RegularInteraction' here
                --   will reset 'InteractionMode' accordingly.
                --   Otherwise, only if different file from last time.
-  -> ((Interface, Imp.MaybeWarnings) -> CommandM a)
+  -> ((Interface, [TCWarning]) -> CommandM a)
                -- ^ Continuation after successful loading.
   -> CommandM a
 cmd_load' file argv unsolvedOK mode cmd = do

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -227,7 +227,7 @@ runAgdaWithOptions generateHTML interactor progName opts = do
             LaTeX.generateLaTeX i
 
           -- Print accumulated warnings
-          unlessNullM (tcWarnings . classifyWarnings <$> Imp.getAllWarnings AllWarnings) $ \ ws -> do
+          unlessNullM (tcWarnings . classifyWarnings <$> getAllWarnings AllWarnings) $ \ ws -> do
             let banner = text $ "\n" ++ delimiter "All done; warnings encountered"
             reportSDoc "warning" 1 $
               vcat $ punctuate "\n" $ banner : (prettyTCM <$> ws)
@@ -270,7 +270,7 @@ optionError err = do
 runTCMPrettyErrors :: TCM () -> IO ()
 runTCMPrettyErrors tcm = do
     r <- runTCMTop $ tcm `catchError` \err -> do
-      s2s <- prettyTCWarnings' =<< Imp.getAllWarningsOfTCErr err
+      s2s <- prettyTCWarnings' =<< getAllWarningsOfTCErr err
       s1  <- prettyError err
       let ss = filter (not . null) $ s2s ++ [s1]
       unless (null s1) (liftIO $ putStr $ unlines ss)

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -213,7 +213,7 @@ runAgdaWithOptions generateHTML interactor progName opts = do
             (Imp.ScopeCheck, _)  -> return Nothing
             (_, NoWarnings)      -> return $ Just i
             (_, SomeWarnings ws) ->
-              ifNotNullM (applyFlagsToTCWarnings ws) {-then-} tcWarningsToError {-else-} $ return Nothing
+              ifNotNullM (applyFlagsToTCWarnings ws) {-then-} (typeError . NonFatalErrors) {-else-} $ return Nothing
 
           reportSDoc "main" 50 $ pretty i
 

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -22,7 +22,6 @@ import Agda.Interaction.Options
 import Agda.Interaction.Options.Help (Help (..))
 import Agda.Interaction.EmacsTop (mimicGHCi)
 import Agda.Interaction.JSONTop (jsonREPL)
-import Agda.Interaction.Imports (MaybeWarnings'(..))
 import Agda.Interaction.FindFile ( SourceFile(SourceFile) )
 import qualified Agda.Interaction.Imports as Imp
 import qualified Agda.Interaction.Highlighting.Dot as Dot
@@ -211,8 +210,8 @@ runAgdaWithOptions generateHTML interactor progName opts = do
           -- Imp.TypeCheck and there are no warnings.
           result <- case (mode, mw) of
             (Imp.ScopeCheck, _)  -> return Nothing
-            (_, NoWarnings)      -> return $ Just i
-            (_, SomeWarnings ws) ->
+            (_, [])              -> return $ Just i
+            (_, ws@(_:_))        ->
               ifNotNullM (applyFlagsToTCWarnings ws) {-then-} (typeError . NonFatalErrors) {-else-} $ return Nothing
 
           reportSDoc "main" 50 $ pretty i

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -8,7 +8,7 @@ module Agda.TypeChecking.Errors
   , prettyTCWarnings'
   , prettyTCWarnings
   , tcWarningsToError
-  , applyFlagsToTCWarnings'
+  , applyFlagsToTCWarningsPreserving
   , applyFlagsToTCWarnings
   , dropTopLevelModule
   , topLevelModuleDropper

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -10,6 +10,10 @@ module Agda.TypeChecking.Errors
   , tcWarningsToError
   , applyFlagsToTCWarningsPreserving
   , applyFlagsToTCWarnings
+  , getAllUnsolvedWarnings
+  , getAllWarningsPreserving
+  , getAllWarnings
+  , getAllWarningsOfTCErr
   , dropTopLevelModule
   , topLevelModuleDropper
   , stringTCErr

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -419,7 +419,7 @@ tcWarningsToError ws = typeError $ case ws of
 -- | Depending which flags are set, one may happily ignore some
 -- warnings.
 
-applyFlagsToTCWarningsPreserving :: Set WarningName -> [TCWarning] -> TCM [TCWarning]
+applyFlagsToTCWarningsPreserving :: HasOptions m => Set WarningName -> [TCWarning] -> m [TCWarning]
 applyFlagsToTCWarningsPreserving additionalKeptWarnings ws = do
   -- For some reason some SafeFlagPragma seem to be created multiple times.
   -- This is a way to collect all of them and remove duplicates.
@@ -444,5 +444,5 @@ applyFlagsToTCWarningsPreserving additionalKeptWarnings ws = do
 
   return $ sfp ++ filter (cleanUp . tcWarning) ws
 
-applyFlagsToTCWarnings :: [TCWarning] -> TCM [TCWarning]
+applyFlagsToTCWarnings :: HasOptions m => [TCWarning] -> m [TCWarning]
 applyFlagsToTCWarnings = applyFlagsToTCWarningsPreserving Set.empty


### PR DESCRIPTION
Annoyance/cleanup refactor. This is part of a series of other PRs related to import handling.

The `MaybeWarnings` type was awkward to work with and complicated reasoning about refactors. It introduced cases that were impossible, but not obviously so and which were not handled consistently. It was the same as a list of warnings, _except_ for the existence of an extra possible value (`SomeWarnings []`) which:
  * was never constructed for fresh `MaybeWarnings` values. (Everything that created them would check for an empty list and try to awkwardly replace it with `NoWarnings`).
  * might exist transiently post-construction in one place, which would filter the warnings, and then immediately treat it as a list anyway.
  * forced every destructuring to consider, "hmm, what do I do with `SomeWarnings []`?" and then inevitably treat it the same as `NoWarnings`. There was no consistency nor rules enforced about it: just room for error.
  * forced duplicate utility functions for things that worked on `[TCWarning]` vs. `MaybeWarnings`.

etc. etc.

Also, it lived in `Agda.Interaction.Imports` which caused a significant import cycle bottleneck. Some of the related utility functions have been moved to more appropriate places.