### PR TITLE
Minor nit refactor: Derive `envModuleNestingLevel` from `envImportPath`

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -399,7 +399,7 @@ getInterface'
      -- ^ Optional information about the source code.
   -> TCM (Interface, MaybeWarnings)
 getInterface' x isMain msi =
-  withIncreasedModuleNestingLevel $
+  addImportCycleCheck x $
     -- Preserve the pragma options unless we are checking the main
     -- interface.
     bracket_ (useTC stPragmaOptions)
@@ -417,7 +417,7 @@ getInterface' x isMain msi =
        setCommandLineOptions . stPersistentOptions . stPersistentState =<< getTC
        return currentOptions
 
-     alreadyVisited x isMain currentOptions $ addImportCycleCheck x $ do
+     alreadyVisited x isMain currentOptions $ do
       file <- findFile x  -- requires source to exist
 
       reportSLn "import.iface" 10 $ "  Check for cycle"
@@ -675,7 +675,6 @@ typeCheck x file isMain msi = do
 
     NotMainInterface -> do
       ms          <- getImportPath
-      nesting     <- asksTC envModuleNestingLevel
       range       <- asksTC envRange
       call        <- asksTC envCall
       mf          <- useTC stModuleToSource
@@ -698,12 +697,12 @@ typeCheck x file isMain msi = do
            -- should be restored after the module has been type-checked
            freshTCM $
              withImportPath ms $
-             localTC (\e -> e { envModuleNestingLevel = nesting
+             localTC (\e -> e
                               -- Andreas, 2014-08-18:
                               -- Preserve the range of import statement
                               -- for reporting termination errors in
                               -- imported modules:
-                            , envRange              = range
+                            { envRange              = range
                             , envCall               = call
                             }) $ do
                setDecodedModules ds
@@ -748,7 +747,7 @@ chaseMsg
   -> Maybe String         -- ^ Optionally: the file name.
   -> TCM ()
 chaseMsg kind x file = do
-  indentation <- (`replicate` ' ') <$> asksTC envModuleNestingLevel
+  indentation <- (`replicate` ' ') <$> asksTC (pred . length . envImportPath)
   let maybeFile = caseMaybe file "." $ \ f -> " (" ++ f ++ ")."
       vLvl | kind == "Checking" = 1
            | otherwise          = 2
@@ -896,7 +895,7 @@ createInterface file mname isMain msi =
     mapM_ setOptionsFromPragma options
 
     verboseS "import.iface.create" 15 $ do
-      nestingLevel      <- asksTC envModuleNestingLevel
+      nestingLevel      <- asksTC (pred . length . envImportPath)
       highlightingLevel <- asksTC envHighlightingLevel
       reportSLn "import.iface.create" 15 $ unlines
         [ "  nesting      level: " ++ show nestingLevel

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -870,9 +870,7 @@ createInterface file mname isMain msi =
       reportSLn "import.iface.create" 10 $
         "  visited: " ++ List.intercalate ", " (map prettyShow visited)
 
-    si <- case msi of
-      Nothing -> sourceInfo file
-      Just si -> return si
+    si <- maybe (sourceInfo file) pure msi
     let source   = siSource si
         fileType = siFileType si
         top      = C.modDecls $ siModule si

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -1082,11 +1082,12 @@ give_gen force ii rng s0 giveRefine = do
 
 highlightExpr :: A.Expr -> TCM ()
 highlightExpr e =
-  localTC (\st -> st { envModuleNestingLevel = 0
+  localTC (\st -> st { envImportPath         = [dummyModule]
                      , envHighlightingLevel  = NonInteractive
                      , envHighlightingMethod = Direct }) $
     generateAndPrintSyntaxInfo decl Full True
   where
+    dummyModule = C.toTopLevelModuleName (C.QName noName_)
     dummy = mkName_ (NameId 0 0) ("dummy" :: String)
     info  = mkDefInfo (nameConcrete dummy) noFixity' PublicAccess ConcreteDef (getRange e)
     decl  = A.Axiom OtherDefName info defaultArgInfo Nothing (qnameFromList $ singleton dummy) e

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -881,7 +881,6 @@ cmd_load'
   -> CommandM a
 cmd_load' file argv unsolvedOK mode cmd = do
     fp <- liftIO $ absolute file
-    let f = SourceFile fp
     ex <- liftIO $ doesFileExist $ filePath fp
     unless ex $ typeError $ GenericError $
       "The file " ++ file ++ " was not found."
@@ -903,7 +902,7 @@ cmd_load' file argv unsolvedOK mode cmd = do
     t <- liftIO $ getModificationTime file
 
     -- Parse the file.
-    si <- lift $ Imp.sourceInfo f
+    si <- lift $ Imp.sourceInfo (SourceFile fp)
 
     -- All options are reset when a file is reloaded, including the
     -- choice of whether or not to display implicit arguments.
@@ -931,8 +930,7 @@ cmd_load' file argv unsolvedOK mode cmd = do
     -- Remove any prior syntax highlighting.
     putResponse (Resp_ClearHighlighting NotOnlyTokenBased)
 
-
-    ok <- lift $ Imp.typeCheckMain f mode si
+    ok <- lift $ Imp.typeCheckMain mode si
 
     -- The module type checked. If the file was not changed while the
     -- type checker was running then the interaction points and the

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -204,8 +204,7 @@ runAgdaWithOptions generateHTML interactor progName opts = do
                      then Imp.ScopeCheck
                      else Imp.TypeCheck RegularInteraction
 
-          let file = SourceFile inputFile
-          (i, mw) <- Imp.typeCheckMain file mode =<< Imp.sourceInfo file
+          (i, mw) <- Imp.typeCheckMain mode =<< Imp.sourceInfo (SourceFile inputFile)
 
           -- An interface is only generated if the mode is
           -- Imp.TypeCheck and there are no warnings.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2635,19 +2635,24 @@ data HighlightingMethod
 -- level is /at least/ @l@ or @b@ is 'True'.
 
 ifTopLevelAndHighlightingLevelIsOr ::
-  MonadTCM tcm => HighlightingLevel -> Bool -> tcm () -> tcm ()
+  MonadTCEnv tcm => HighlightingLevel -> Bool -> tcm () -> tcm ()
 ifTopLevelAndHighlightingLevelIsOr l b m = do
   e <- askTC
-  when (envModuleNestingLevel e == 0 &&
-        (envHighlightingLevel e >= l || b))
-       m
+  when (envHighlightingLevel e >= l || b) $
+    case (envImportPath e) of
+      -- No current module
+      [] -> pure ()
+      -- Top level ("main") module
+      (_:[]) -> m
+      -- Below the main module
+      (_:_:_) -> pure ()
 
 -- | @ifTopLevelAndHighlightingLevelIs l m@ runs @m@ when we're
 -- type-checking the top-level module and the highlighting level is
 -- /at least/ @l@.
 
 ifTopLevelAndHighlightingLevelIs ::
-  MonadTCM tcm => HighlightingLevel -> tcm () -> tcm ()
+  MonadTCEnv tcm => HighlightingLevel -> tcm () -> tcm ()
 ifTopLevelAndHighlightingLevelIs l =
   ifTopLevelAndHighlightingLevelIsOr l False
 
@@ -2664,7 +2669,16 @@ data TCEnv =
             -- type-checked.  'Nothing' if we do not have a file
             -- (like in interactive mode see @CommandLine@).
           , envAnonymousModules    :: [(ModuleName, Nat)] -- ^ anonymous modules and their number of free variables
-          , envImportPath          :: [C.TopLevelModuleName] -- ^ to detect import cycles
+          , envImportPath          :: [C.TopLevelModuleName]
+            -- ^ The module stack with the entry being the top-level module as
+            --   Agda chases modules. It will be empty if there is no main
+            --   module, will have a single entry for the top level module, or
+            --   more when descending past the main module. This is used to
+            --   detect import cycles and in some cases highlighting behavior.
+            --   The level of a given module is not necessarily the same as the
+            --   length, in the module dependency graph, of the shortest path
+            --   from the top-level module; it depends on in which order Agda
+            --   chooses to chase dependencies.
           , envMutualBlock         :: Maybe MutualId -- ^ the current (if any) mutual block
           , envTerminationCheck    :: TerminationCheck ()  -- ^ are we inside the scope of a termination pragma
           , envCoverageCheck       :: CoverageCheck        -- ^ are we inside the scope of a coverage pragma
@@ -2715,14 +2729,6 @@ data TCEnv =
                 -- ^ Set to 'None' when imported modules are
                 --   type-checked.
           , envHighlightingMethod :: HighlightingMethod
-          , envModuleNestingLevel :: !Int
-                -- ^ This number indicates how far away from the
-                --   top-level module Agda has come when chasing
-                --   modules. The level of a given module is not
-                --   necessarily the same as the length, in the module
-                --   dependency graph, of the shortest path from the
-                --   top-level module; it depends on in which order
-                --   Agda chooses to chase dependencies.
           , envExpandLast :: ExpandHidden
                 -- ^ When type-checking an alias f=e, we do not want
                 -- to insert hidden arguments in the end, because
@@ -2826,7 +2832,6 @@ initEnv = TCEnv { envContext             = []
                 , envCall                   = Nothing
                 , envHighlightingLevel      = None
                 , envHighlightingMethod     = Indirect
-                , envModuleNestingLevel     = -1
                 , envExpandLast             = ExpandLast
                 , envAppDef                 = Nothing
                 , envSimplification         = NoSimplification
@@ -2961,9 +2966,6 @@ eHighlightingLevel f e = f (envHighlightingLevel e) <&> \ x -> e { envHighlighti
 
 eHighlightingMethod :: Lens' HighlightingMethod TCEnv
 eHighlightingMethod f e = f (envHighlightingMethod e) <&> \ x -> e { envHighlightingMethod = x }
-
-eModuleNestingLevel :: Lens' Int TCEnv
-eModuleNestingLevel f e = f (envModuleNestingLevel e) <&> \ x -> e { envModuleNestingLevel = x }
 
 eExpandLast :: Lens' ExpandHidden TCEnv
 eExpandLast f e = f (envExpandLast e) <&> \ x -> e { envExpandLast = x }

--- a/src/full/Agda/TypeChecking/Monad/Env.hs
+++ b/src/full/Agda/TypeChecking/Monad/Env.hs
@@ -55,13 +55,6 @@ withEnv env = localTC $ \ env0 -> env
 getEnv :: TCM TCEnv
 getEnv = askTC
 
--- | Increases the module nesting level by one in the given
--- computation.
-withIncreasedModuleNestingLevel :: TCM a -> TCM a
-withIncreasedModuleNestingLevel =
-  localTC $ \ e -> e { envModuleNestingLevel =
-                       envModuleNestingLevel e + 1 }
-
 -- | Set highlighting level
 withHighlightingLevel :: HighlightingLevel -> TCM a -> TCM a
 withHighlightingLevel h = localTC $ \ e -> e { envHighlightingLevel = h }

--- a/test/api/PrettyInterface.hs
+++ b/test/api/PrettyInterface.hs
@@ -40,7 +40,7 @@ mainTCM :: TCM ()
 mainTCM = do
   setCommandLineOptions defaultOptions
   f <- liftIO $ SourceFile <$> absolute "PrettyInterface.agda"
-  (i, _mw) <- typeCheckMain f (TypeCheck RegularInteraction) =<< sourceInfo f
+  (i, _mw) <- typeCheckMain (TypeCheck RegularInteraction) =<< sourceInfo f
   compilerMain i
 
 compilerMain :: Interface -> TCM ()


### PR DESCRIPTION
Another unimportant but isolated cleanup nit that I came across while trying to determine some of the invariants of various state values. The TCM env variables `envModuleNestingLevel` and (`pred . length .`) `envImportPath` always coincided in value, except for two cases:
  1. *Very* briefly during `getInterface` while setting up options `alreadyVisited` but before starting to load an unvisited module.
  1. `highlightExpr` would set the level but forgot(?) to modify the import path. Since the module name was obviously not used, that now just sets a dummy module name: the expression includes dummy terms already.

Those both seemed like oversights, and that semantically the two variables _should_ be identical and so seemed better to maintain a single source of truth for that value.

An alternative to this small change would be to replace `envModuleNestingLevel` with a function that derives it from `envImportPath`; but that didn't seem necessary to maintain that identifier.