### PR TITLE
Simplifications re internal `SourceInfo` type

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -870,9 +870,7 @@ createInterface file mname isMain msi =
       reportSLn "import.iface.create" 10 $
         "  visited: " ++ List.intercalate ", " (map prettyShow visited)
 
-    si <- case msi of
-      Nothing -> sourceInfo file
-      Just si -> return si
+    si <- maybe (sourceInfo file) pure msi
     let source   = siSource si
         fileType = siFileType si
         top      = C.modDecls $ siModule si

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -881,7 +881,6 @@ cmd_load'
   -> CommandM a
 cmd_load' file argv unsolvedOK mode cmd = do
     fp <- liftIO $ absolute file
-    let f = SourceFile fp
     ex <- liftIO $ doesFileExist $ filePath fp
     unless ex $ typeError $ GenericError $
       "The file " ++ file ++ " was not found."
@@ -903,7 +902,7 @@ cmd_load' file argv unsolvedOK mode cmd = do
     t <- liftIO $ getModificationTime file
 
     -- Parse the file.
-    si <- lift $ Imp.sourceInfo f
+    si <- lift $ Imp.sourceInfo (SourceFile fp)
 
     -- All options are reset when a file is reloaded, including the
     -- choice of whether or not to display implicit arguments.
@@ -931,8 +930,7 @@ cmd_load' file argv unsolvedOK mode cmd = do
     -- Remove any prior syntax highlighting.
     putResponse (Resp_ClearHighlighting NotOnlyTokenBased)
 
-
-    ok <- lift $ Imp.typeCheckMain f mode si
+    ok <- lift $ Imp.typeCheckMain mode si
 
     -- The module type checked. If the file was not changed while the
     -- type checker was running then the interaction points and the

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -204,8 +204,7 @@ runAgdaWithOptions generateHTML interactor progName opts = do
                      then Imp.ScopeCheck
                      else Imp.TypeCheck RegularInteraction
 
-          let file = SourceFile inputFile
-          (i, mw) <- Imp.typeCheckMain file mode =<< Imp.sourceInfo file
+          (i, mw) <- Imp.typeCheckMain mode =<< Imp.sourceInfo (SourceFile inputFile)
 
           -- An interface is only generated if the mode is
           -- Imp.TypeCheck and there are no warnings.

--- a/test/api/PrettyInterface.hs
+++ b/test/api/PrettyInterface.hs
@@ -40,7 +40,7 @@ mainTCM :: TCM ()
 mainTCM = do
   setCommandLineOptions defaultOptions
   f <- liftIO $ SourceFile <$> absolute "PrettyInterface.agda"
-  (i, _mw) <- typeCheckMain f (TypeCheck RegularInteraction) =<< sourceInfo f
+  (i, _mw) <- typeCheckMain (TypeCheck RegularInteraction) =<< sourceInfo f
   compilerMain i
 
 compilerMain :: Interface -> TCM ()


### PR DESCRIPTION
Some minor simplifications around the `SourceInfo` type internally in the `Agda.Interaction.Imports` module.

The main thrust of these is just to clarify some of the invariants re the relation between parsed data and the values used for constructing or type-checking the interface.