### PR TITLE
More precise blocking of LHS checking

### DIFF
--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -476,7 +476,8 @@ compareAtom cmp t m n =
           MetaV y yArgs <- ignoreBlocking nb -> -- envCompareBlocked check above.
         if | x == y, cmpBlocked -> do
               a <- metaType x
-              compareElims [] [] a (MetaV x []) xArgs yArgs
+              addOrUnblocker (unblockOnMeta x) $
+                compareElims [] [] a (MetaV x []) xArgs yArgs
            | x == y ->
             case intersectVars xArgs yArgs of
               -- all relevant arguments are variables

--- a/src/full/Agda/TypeChecking/Conversion/Pure.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Pure.hs
@@ -106,8 +106,8 @@ instance (PureTCM m, MonadBlock m) => MonadConstraint (PureConversionT m) where
 
 instance (PureTCM m, MonadBlock m) => MonadMetaSolver (PureConversionT m) where
   newMeta' _ _ _ _ _ _ = patternViolation alwaysUnblock  -- TODO: does this happen?
-  assignV _ _ _ _ _ = patternViolation alwaysUnblock  -- TODO: does this happen?
-  assignTerm' _ _ _ = patternViolation alwaysUnblock  -- TODO: does this happen?
+  assignV _ m _ _ _ = patternViolation alwaysUnblock
+  assignTerm' m _ _ = patternViolation alwaysUnblock
   etaExpandMeta _ _ = return ()
   updateMetaVar _ _ = patternViolation alwaysUnblock  -- TODO: does this happen?
   speculateMetas fallback m = m >>= \case

--- a/src/full/Agda/TypeChecking/Conversion/Pure.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Pure.hs
@@ -11,6 +11,7 @@ import Data.String
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
+import Agda.Syntax.Internal.MetaVars (unblockOnAnyMetaIn)
 
 import {-# SOURCE #-} Agda.TypeChecking.Conversion
 import Agda.TypeChecking.Monad
@@ -106,8 +107,8 @@ instance (PureTCM m, MonadBlock m) => MonadConstraint (PureConversionT m) where
 
 instance (PureTCM m, MonadBlock m) => MonadMetaSolver (PureConversionT m) where
   newMeta' _ _ _ _ _ _ = patternViolation alwaysUnblock  -- TODO: does this happen?
-  assignV _ m _ _ _ = patternViolation alwaysUnblock
-  assignTerm' m _ _ = patternViolation alwaysUnblock
+  assignV _ m us v _ = patternViolation $ unblockOnAnyMetaIn (MetaV m (map Apply us), v)
+  assignTerm' m _ v = patternViolation $ unblockOnAnyMetaIn (MetaV m [], v)
   etaExpandMeta _ _ = return ()
   updateMetaVar _ _ = patternViolation alwaysUnblock  -- TODO: does this happen?
   speculateMetas fallback m = m >>= \case

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -1160,17 +1160,17 @@ computeNeighbourhood delta1 n delta2 d pars ixs hix tel ps cps c = do
          conIxs
          givenIxs
 
-  let stuck errs = do
+  let stuck b errs = do
         debugCantSplit
-        throwError $ UnificationStuck (conName con) (delta1 `abstract` gamma) conIxs givenIxs errs
+        throwError $ UnificationStuck b (conName con) (delta1 `abstract` gamma) conIxs givenIxs errs
 
 
   case r of
     NoUnify {} -> debugNoUnify $> Nothing
 
-    UnifyBlocked block -> stuck [] -- TODO: postpone and retry later
+    UnifyBlocked block -> stuck (Just block) []
 
-    UnifyStuck errs -> stuck errs
+    UnifyStuck errs -> stuck Nothing errs
 
     Unifies (delta1',rho0,_) -> do
       debugSubst "rho0" rho0

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -387,7 +387,7 @@ instance PrettyTCM TypeError where
     IllformedProjectionPattern p -> fsep $
       pwords "Ill-formed projection pattern " ++ [prettyA p]
 
-    CannotEliminateWithPattern p a -> do
+    CannotEliminateWithPattern b p a -> do
       let isProj = isJust (isProjP p)
       fsep $
         pwords "Cannot eliminate type" ++ prettyTCM a : if
@@ -1260,7 +1260,7 @@ instance PrettyTCM SplitError where
     NotADatatype t -> enterClosure t $ \ t -> fsep $
       pwords "Cannot split on argument of non-datatype" ++ [prettyTCM t]
 
-    BlockedType t -> enterClosure t $ \ t -> fsep $
+    BlockedType b t -> enterClosure t $ \ t -> fsep $
       pwords "Cannot split on argument of unresolved type" ++ [prettyTCM t]
 
     IrrelevantDatatype t -> enterClosure t $ \ t -> fsep $
@@ -1282,7 +1282,7 @@ instance PrettyTCM SplitError where
       pwords "because it has no constructor"
  -}
 
-    UnificationStuck c tel cIxs gIxs errs
+    UnificationStuck b c tel cIxs gIxs errs
       | length cIxs /= length gIxs -> __IMPOSSIBLE__
       | otherwise                  -> vcat . concat $
         [ [ fsep . concat $

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3379,7 +3379,7 @@ data TerminationError = TerminationError
 -- | Error when splitting a pattern variable into possible constructor patterns.
 data SplitError
   = NotADatatype        (Closure Type)  -- ^ Neither data type nor record.
-  | BlockedType         (Closure Type)  -- ^ Type could not be sufficiently reduced.
+  | BlockedType Blocker (Closure Type)  -- ^ Type could not be sufficiently reduced.
   | IrrelevantDatatype  (Closure Type)  -- ^ Data type, but in irrelevant position.
   | ErasedDatatype Bool (Closure Type)  -- ^ Data type, but in erased position.
                                         --   If the boolean is 'True',
@@ -3390,7 +3390,8 @@ data SplitError
   -- UNUSED, but keep!
   -- -- | NoRecordConstructor Type  -- ^ record type, but no constructor
   | UnificationStuck
-    { cantSplitConName  :: QName        -- ^ Constructor.
+    { cantSplitBlocker  :: Maybe Blocker -- ^ Blocking metavariable (if any)
+    , cantSplitConName  :: QName        -- ^ Constructor.
     , cantSplitTel      :: Telescope    -- ^ Context for indices.
     , cantSplitConIdx   :: Args         -- ^ Inferred indices (from type of constructor).
     , cantSplitGivenIdx :: Args         -- ^ Expected indices (from checking pattern).
@@ -3478,7 +3479,7 @@ data TypeError
         | UninstantiatedDotPattern A.Expr
         | ForcedConstructorNotInstantiated A.Pattern
         | IllformedProjectionPattern A.Pattern
-        | CannotEliminateWithPattern (NamedArg A.Pattern) Type
+        | CannotEliminateWithPattern (Maybe Blocker) (NamedArg A.Pattern) Type
         | WrongNumberOfConstructorArguments QName Nat Nat
         | ShouldBeEmpty Type [DeBruijnPattern]
         | ShouldBeASort Type

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -953,8 +953,9 @@ checkLHS mf = updateModality checkLHS_ where
         ]
 
       -- @p@ should be a projection pattern projection from @target@
-      (orig, ambProjName) <- ifJust (A.isProjP p) return $
-        addContext tel $ softTypeError $ CannotEliminateWithPattern p (unArg target)
+      (orig, ambProjName) <- ifJust (A.isProjP p) return $ addContext tel $ do
+        block <- isBlocked target
+        softTypeError $ CannotEliminateWithPattern block p (unArg target)
 
       (projName, comatchingAllowed, recName, projType) <- suspendErrors $ do
         -- Andreas, 2018-10-18, issue #3289: postfix projections do not have hiding
@@ -1338,18 +1339,18 @@ checkLHS mf = updateModality checkLHS_ where
              TelV tel dt <- telView da'
              return $ abstract (mapCohesion updCoh <$> tel) a
 
-      let stuck errs = softTypeError $ SplitError $
-            UnificationStuck (conName c) (delta1 `abstract` gamma) cixs ixs' errs
+      let stuck b errs = softTypeError $ SplitError $
+            UnificationStuck b (conName c) (delta1 `abstract` gamma) cixs ixs' errs
 
       liftTCM (withKIfStrict $ unifyIndices delta1Gamma flex da' cixs ixs') >>= \case
 
         -- Mismatch.  Report and abort.
         NoUnify neg -> hardTypeError $ ImpossibleConstructor (conName c) neg
 
-        UnifyBlocked block -> stuck [] -- TODO: postpone and retry later
+        UnifyBlocked block -> stuck (Just block) []
 
         -- Unclear situation.  Try next split.
-        UnifyStuck errs -> stuck errs
+        UnifyStuck errs -> stuck Nothing errs
 
         -- Success.
         Unifies (delta1',rho0,es) -> do
@@ -1545,13 +1546,20 @@ isDataOrRecordType a0 = ifBlocked a0 blocked $ \case
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 
-  -- Type is blocked on something: fail softly
-  _ -> \ _a -> blockedType
+  -- neutral type: fail softly
+  StuckOn{}     -> \ _a -> softTypeError =<< notData
+  AbsurdMatch{} -> \ _a -> softTypeError =<< notData
+
+  -- missing clauses: fail hard
+  -- TODO: postpone checking of the whole clause until later?
+  MissingClauses{} -> \ _a -> hardTypeError =<< notData
+
+  -- underapplied type: should not happen
+  Underapplied{} -> __IMPOSSIBLE__
 
   where
   notData      = liftTCM $ SplitError . NotADatatype <$> buildClosure a0
-  blockedType  = softTypeError =<< do liftTCM $ SplitError . BlockedType <$> buildClosure a0
-  blocked _ _a = blockedType
+  blocked b _a = softTypeError =<< do liftTCM $ SplitError . BlockedType b <$> buildClosure a0
 
 -- | Get the constructor of the given record type together with its type.
 --   Throws an error if the type is not a record type.

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -852,33 +852,16 @@ catchIlltypedPatternBlockedOnMeta m handle = do
     -- Get the blocker responsible for the type error.
     -- If we do not find a blocker or the error should not be handled,
     -- we reraise the error.
-    blocker <- maybe reraise return =<< do
-      case err of
-        TypeError _ s cl -> localTCState $ do
-          putTC s
-          enterClosure cl $ \case
-            SortOfSplitVarError m _ -> return m
-
-            SplitError (UnificationStuck c tel us vs _) -> do
-              -- Andreas, 2018-11-23, re issue #3403
-              -- The following computation of meta-variables and picking
-              -- of the first one, seems a bit brittle.
-              -- I do not understand why there is a single @reduce@ here
-              -- (seems to archieve a bit along @normalize@, but how much??).
-              problem <- reduce =<< instantiateFull (flattenTel tel, us, vs)
-              -- over-approximating the set of metas actually blocking unification
-              return $ Just $ unblockOnAnyMetaIn problem
-
-            SplitError (BlockedType aClosure) ->
-              enterClosure aClosure $ \ a -> isBlocked a
-
-            -- Andrea: TODO look for blocking meta in tClosure and its Sort.
-            -- SplitError (CannotCreateMissingClause _ _ _ tClosure) ->
-
-            CannotEliminateWithPattern p a -> isBlocked a
-
-            _ -> return Nothing
-        _ -> return Nothing
+    blocker <- maybe reraise return $ case err of
+      TypeError _ s cl -> case clValue cl of
+        SortOfSplitVarError b _                       -> b
+        SplitError (UnificationStuck b c tel us vs _) -> b
+        SplitError (BlockedType b aClosure)           -> Just b
+        CannotEliminateWithPattern b p a              -> b
+        -- Andrea: TODO look for blocking meta in tClosure and its Sort.
+        -- SplitError (CannotCreateMissingClause _ _ _ tClosure) ->
+        _                                             -> Nothing
+      _ -> Nothing
 
     reportSDoc "tc.postpone" 20 $ vcat $
       [ "checking definition blocked on: " <+> prettyTCM blocker ]

--- a/test/Fail/Issue199.err
+++ b/test/Fail/Issue199.err
@@ -8,7 +8,7 @@ Failed to solve the following constraints:
         {D} ≟ {_T_13}
         d ≟ _15
       when checking that the pattern p _ has type P _15
-    (blocked on any(_A_12, _T_13, _15))
+    (blocked on _T_13)
   D A =< _T_13 _A_12 (blocked on _T_13)
 Unsolved metas at the following locations:
   Issue199.agda:10,25-26

--- a/test/Fail/Issue2344.err
+++ b/test/Fail/Issue2344.err
@@ -10,7 +10,7 @@ Failed to solve the following constraints:
         suc n ≟ _m_23 (A = A) (X = X)
       when checking that the pattern zero n has type
       Fin (_m_23 (A = A) (X = X))
-    (blocked on any(_18, _m_23))
+    (blocked on _m_23)
 Unsolved metas at the following locations:
   Issue2344.agda:25,31-32
   Issue2344.agda:25,46-47

--- a/test/Fail/Issue3672b.err
+++ b/test/Fail/Issue3672b.err
@@ -1,3 +1,4 @@
 Unsolved metas at the following locations:
   Issue3672b.agda:33,14-16
+  Issue3672b.agda:33,42-43
   Issue3672b.agda:33,57-58

--- a/test/Fail/Issue3882.err
+++ b/test/Fail/Issue3882.err
@@ -1,48 +1,58 @@
 Failed to solve the following constraints:
-  _B_103 (ψ = ψ) (n = _x_128) (b = b) x
-    = _B_103 (ψ = ψ) (n = n₀) (b = b) x
-    : Set
-  _B_103 (ψ = ψ) (n = _x_128)
-  (b = (×id (λ x₁ → p x₁ .fst) (s , p s .snd))) x
-    = _B_103 (ψ = ψ) (n = n₀)
-      (b = (×id (λ x₁ → p x₁ .fst) (s , p s .snd))) x
-    : Set
-  _B_103 (ψ = ψ) (n = n₀) (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w s₁)))
-  x = _B_103 (ψ = ψ) (n = _x_128)
-      (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w s₁))) x
-    : Set
-  _B_103 (ψ = ψ) (n = _x_128)
-  (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w' s₁))) x
-    = _B_103 (ψ = ψ) (n = n₀)
-      (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w' s₁))) x
-    : Set
-  _B_103 (ψ = ψ) (n = _x_128)
+  _B_103 (ψ = ψ) (n = _y_129)
   (b = (×id (λ x₁ → p x₁ .fst) (s₁ , wrap (v s₁)))) x
     = _B_103 (ψ = ψ) (n = n₀)
       (b = (×id (λ x₁ → p x₁ .fst) (s₁ , wrap (v s₁)))) x
     : Set
-  _B_103 (ψ = ψ) (n = _y_129) (b = b) x
-    = _B_103 (ψ = ψ) (n = n₀) (b = b) x
-    : Set
+    (blocked on any(_B_103, _y_129))
   _B_103 (ψ = ψ) (n = _y_129)
-  (b = (×id (λ x₁ → p x₁ .fst) (s , p s .snd))) x
+  (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w' s₁))) x
     = _B_103 (ψ = ψ) (n = n₀)
-      (b = (×id (λ x₁ → p x₁ .fst) (s , p s .snd))) x
+      (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w' s₁))) x
     : Set
+    (blocked on any(_B_103, _y_129))
   _B_103 (ψ = ψ) (n = n₀) (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w s₁)))
   x = _B_103 (ψ = ψ) (n = _y_129)
       (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w s₁))) x
     : Set
+    (blocked on any(_B_103, _y_129))
   _B_103 (ψ = ψ) (n = _y_129)
-  (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w' s₁))) x
+  (b = (×id (λ x₁ → p x₁ .fst) (s , p s .snd))) x
     = _B_103 (ψ = ψ) (n = n₀)
-      (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w' s₁))) x
+      (b = (×id (λ x₁ → p x₁ .fst) (s , p s .snd))) x
     : Set
-  _B_103 (ψ = ψ) (n = _y_129)
+    (blocked on any(_B_103, _y_129))
+  _B_103 (ψ = ψ) (n = _y_129) (b = b) x
+    = _B_103 (ψ = ψ) (n = n₀) (b = b) x
+    : Set
+    (blocked on any(_B_103, _y_129))
+  _B_103 (ψ = ψ) (n = _x_128)
   (b = (×id (λ x₁ → p x₁ .fst) (s₁ , wrap (v s₁)))) x
     = _B_103 (ψ = ψ) (n = n₀)
       (b = (×id (λ x₁ → p x₁ .fst) (s₁ , wrap (v s₁)))) x
     : Set
+    (blocked on any(_B_103, _x_128))
+  _B_103 (ψ = ψ) (n = _x_128)
+  (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w' s₁))) x
+    = _B_103 (ψ = ψ) (n = n₀)
+      (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w' s₁))) x
+    : Set
+    (blocked on any(_B_103, _x_128))
+  _B_103 (ψ = ψ) (n = n₀) (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w s₁)))
+  x = _B_103 (ψ = ψ) (n = _x_128)
+      (b = (×id (λ x₁ → p x₁ .fst) (s₁ , w s₁))) x
+    : Set
+    (blocked on any(_B_103, _x_128))
+  _B_103 (ψ = ψ) (n = _x_128)
+  (b = (×id (λ x₁ → p x₁ .fst) (s , p s .snd))) x
+    = _B_103 (ψ = ψ) (n = n₀)
+      (b = (×id (λ x₁ → p x₁ .fst) (s , p s .snd))) x
+    : Set
+    (blocked on any(_B_103, _x_128))
+  _B_103 (ψ = ψ) (n = _x_128) (b = b) x
+    = _B_103 (ψ = ψ) (n = n₀) (b = b) x
+    : Set
+    (blocked on any(_B_103, _x_128))
 Unsolved metas at the following locations:
   Issue3882.agda:72,72-75
   Issue3882.agda:78,19-33

--- a/test/Fail/PruningNonMillerPatternFail.err
+++ b/test/Fail/PruningNonMillerPatternFail.err
@@ -1,5 +1,6 @@
 Failed to solve the following constraints:
   _13 (_19 x (λ k₁ → k₁ y)) y = _13 x x : Nat
+    (blocked on any(_13, _19))
   _19 x (λ k₁ → k₁ x) = x : Nat (blocked on _19)
   _13 x x = suc (_19 x (λ k₁ → k₁ y)) : Nat (blocked on _13)
 Unsolved metas at the following locations:

--- a/test/Fail/RecordPattern5.err
+++ b/test/Fail/RecordPattern5.err
@@ -1,3 +1,3 @@
 RecordPattern5.agda:15,6-19
-Cannot split on argument of unresolved type T b
+Cannot split on argument of non-datatype T b
 when checking that the pattern record { f = a } has type T b


### PR DESCRIPTION
This PR improves the LHS checker so it makes better use of the new blocking machinery to indicate which metavariable(s) are blocking the elaboration, if any. This should lead to less futile attempts to recheck pattern lambdas, and improved information about metavariables in the error messages.