### PR TITLE
Cleanups to `Agda.Interaction.Imports`

### DIFF
--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -22,7 +22,6 @@ import System.Process     ( callCommand )
 import Paths_Agda
 
 import Agda.Interaction.Options
-import Agda.Interaction.Imports ( isNewerThan )
 
 import Agda.Syntax.Common
 import Agda.Syntax.Concrete.Name ( isNoName )
@@ -40,6 +39,7 @@ import Agda.TypeChecking.Reduce ( instantiateFull )
 import Agda.TypeChecking.Substitute as TC ( TelV(..), raise, subst )
 import Agda.TypeChecking.Pretty
 
+import Agda.Utils.FileName ( isNewerThan )
 import Agda.Utils.Function ( iterate' )
 import Agda.Utils.List ( headWithDefault )
 import Agda.Utils.List1 ( List1, pattern (:|) )

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -52,6 +52,7 @@ import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Warnings
 
+import Agda.Utils.FileName (isNewerThan)
 import Agda.Utils.Function
 import Agda.Utils.Functor
 import Agda.Utils.Float

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -1027,12 +1027,11 @@ createInterface file mname isMain msi =
     -- permanently freeze them now by turning them into postulates.
     -- This will enable serialization.
     -- savedMetaStore <- useTC stMetaStore
-    allowUnsolved <- optAllowUnsolved <$> pragmaOptions
     unless (includeStateChanges isMain) $
       -- Andreas, 2018-11-15, re issue #3393:
       -- We do not get here when checking the main module
       -- (then includeStateChanges is True).
-      when allowUnsolved $ do
+      whenM (optAllowUnsolved <$> pragmaOptions) $ do
         reportSLn "import.iface.create" 7 "Turning unsolved metas (if any) into postulates."
         withCurrentModule (scope ^. scopeCurrent) openMetasToPostulates
         -- Clear constraints as they might refer to what

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -446,7 +446,9 @@ getInterface' x isMain msi =
           guard (uptodate && maySkip)
           (False,) <$> (MaybeT $ getStoredInterface x file)
 
-        let recheck = typeCheck x file isMain msi
+        let recheck = case isMain of
+              MainInterface _ -> (True,) <$> createInterface x file isMain msi
+              NotMainInterface -> (False,) <$> createInterfaceIsolated x file msi
 
         maybe recheck pure stored
 
@@ -638,21 +640,6 @@ getStoredInterface x file = do
 --   But if it is not the main module we check,
 --   we do it in a fresh state, suitably initialize,
 --   in order to forget some state changes after successful type checking.
-
-typeCheck
-  :: C.TopLevelModuleName
-     -- ^ Module name of file we process.
-  -> SourceFile
-     -- ^ File we process.
-  -> MainInterface
-  -> Maybe SourceInfo
-     -- ^ Optional information about the source code.
-  -> TCM (Bool, (Interface, [TCWarning]))
-     -- ^ @Bool@ is: are the state changes from this interface already incorporated to the current state?
-typeCheck x file isMain msi = do
-  case isMain of
-    MainInterface _ -> (True,) <$> createInterface x file isMain msi
-    NotMainInterface -> (False,) <$> createInterfaceIsolated x file msi
 
 createInterfaceIsolated
   :: C.TopLevelModuleName

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -239,7 +239,7 @@ scopeCheckImport x = do
         "  visited: " ++ List.intercalate ", " (map prettyShow visited)
     -- Since scopeCheckImport is called from the scope checker,
     -- we need to reimburse her account.
-    i <- Bench.billTo [] $ getInterface x
+    i <- Bench.billTo [] $ getInterface_ (toTopLevelModuleName x) Nothing
     addImport x
 
     -- If that interface was supposed to raise a warning on import, do so.
@@ -399,11 +399,6 @@ typeCheckMain mode si = do
 --   An error is raised if a warning is encountered.
 --
 --   Do not use this for the main file, use 'typeCheckMain' instead.
-
-getInterface :: ModuleName -> TCM Interface
-getInterface m = getInterface_ (toTopLevelModuleName m) Nothing
-
--- | See 'getInterface'.
 
 getInterface_
   :: C.TopLevelModuleName
@@ -1203,4 +1198,4 @@ getInterfaceFileHashes fp = do
   return hs
 
 moduleHash :: ModuleName -> TCM Hash
-moduleHash m = iFullHash <$> getInterface m
+moduleHash m = iFullHash <$> getInterface_ (toTopLevelModuleName m) Nothing

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -581,7 +581,7 @@ getStoredInterface
   -> Maybe SourceInfo
      -- ^ Optional information about the source code.
   -> TCM (Bool, (Interface, MaybeWarnings))
-     -- ^ @Bool@ is: do we have to merge the interface?
+     -- ^ @Bool@ is: are the state changes from this interface already incorporated to the current state?
 getStoredInterface x file isMain msi = do
   let fp = filePath $ srcFilePath file
   -- If something goes wrong (interface outdated etc.)
@@ -675,7 +675,7 @@ typeCheck
   -> Maybe SourceInfo
      -- ^ Optional information about the source code.
   -> TCM (Bool, (Interface, MaybeWarnings))
-     -- ^ @Bool@ is: do we have to merge the interface?
+     -- ^ @Bool@ is: are the state changes from this interface already incorporated to the current state?
 typeCheck x file isMain msi = do
   let fp = filePath $ srcFilePath file
   unless (includeStateChanges isMain) cleanCachedLog

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -94,6 +94,16 @@ import qualified Agda.Utils.Trie as Trie
 
 import Agda.Utils.Impossible
 
+-- | Whether to ignore interfaces (@.agdai@) other than built-in modules
+
+ignoreInterfaces :: HasOptions m => m Bool
+ignoreInterfaces = optIgnoreInterfaces <$> commandLineOptions
+
+-- | Whether to ignore all interface files (@.agdai@)
+
+ignoreAllInterfaces :: HasOptions m => m Bool
+ignoreAllInterfaces = optIgnoreAllInterfaces <$> commandLineOptions
+
 -- | Some information about the source code.
 
 data SourceInfo = SourceInfo

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -233,9 +233,8 @@ scopeCheckImport :: ModuleName -> TCM (ModuleName, Map ModuleName Scope)
 scopeCheckImport x = do
     reportSLn "import.scope" 5 $ "Scope checking " ++ prettyShow x
     verboseS "import.scope" 10 $ do
-      visited <- Map.keys <$> getVisitedModules
-      reportSLn "import.scope" 10 $
-        "  visited: " ++ List.intercalate ", " (map prettyShow visited)
+      visited <- prettyShow <$> getPrettyVisitedModules
+      reportSLn "import.scope" 10 $ "  visited: " ++ visited
     -- Since scopeCheckImport is called from the scope checker,
     -- we need to reimburse her account.
     i <- Bench.billTo [] $ getNonMainInterface (toTopLevelModuleName x) Nothing
@@ -890,9 +889,8 @@ createInterface mname file isMain msi = do
     reportSLn "import.iface.create" 5 $
       "Creating interface for " ++ prettyShow mname ++ "."
     verboseS "import.iface.create" 10 $ do
-      visited <- Map.keys <$> getVisitedModules
-      reportSLn "import.iface.create" 10 $
-        "  visited: " ++ List.intercalate ", " (map prettyShow visited)
+      visited <- prettyShow <$> getPrettyVisitedModules
+      reportSLn "import.iface.create" 10 $ "  visited: " ++ visited
 
     si <- maybe (sourceInfo file) pure msi
 

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -837,7 +837,7 @@ writeInterface file i = let fp = filePath file in do
     -- Andreas, 2020-05-13, #1804, #4647: removed private declarations
     -- only when we actually write the interface.
     i <- return $
-      i { iInsideScope  = removePrivates $ iInsideScope i
+      i { iInsideScope  = withoutPrivates $ iInsideScope i
         }
     reportSLn "import.iface.write" 50 $
       "Writing interface file with hash " ++ show (iFullHash i) ++ "."
@@ -856,11 +856,6 @@ writeInterface file i = let fp = filePath file in do
     liftIO $
       whenM (doesFileExist fp) $ removeFile fp
     throwError e
-
-removePrivates :: ScopeInfo -> ScopeInfo
-removePrivates scope = over scopeModules (fmap $ restrictLocalPrivate m) scope
-  where
-  m = scope ^. scopeCurrent
 
 concreteOptionsToOptionPragmas :: [C.Pragma] -> TCM [OptionsPragma]
 concreteOptionsToOptionPragmas p = do

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -674,7 +674,6 @@ typeCheck
      -- ^ @Bool@ is: are the state changes from this interface already incorporated to the current state?
 typeCheck x file isMain msi = do
   let fp = filePath $ srcFilePath file
-  unless (includeStateChanges isMain) cleanCachedLog
   let checkMsg = case isMain of
                    MainInterface ScopeCheck -> "Reading "
                    _                        -> "Checking"
@@ -695,6 +694,8 @@ typeCheck x file isMain msi = do
       return (True, r)
 
     NotMainInterface -> do
+      cleanCachedLog
+
       ms          <- getImportPath
       nesting     <- asksTC envModuleNestingLevel
       range       <- asksTC envRange

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -379,10 +379,7 @@ typeCheckMain f mode si = do
     -- Andreas, 2016-07-11, issue 2092
     -- The error range should be set to the file with the wrong module name
     -- not the importing one (which would be the default).
-    (if null r then id else traceCall (SetRange r)) $
-      checkModuleName m f Nothing
-    where
-    r = getRange m
+    setCurrentRange m $ checkModuleName m f Nothing
 
 -- | Tries to return the interface associated to the given (imported) module.
 --   The time stamp of the relevant interface file is also returned.

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -597,8 +597,7 @@ getStoredInterface x file isMain msi = do
 
       -- Check that options that matter haven't changed compared to
       -- current options (issue #2487)
-      optionsChanged <-ifM ((not <$> asksTC envCheckOptionConsistency) `or2M`
-                            Lens.isBuiltinModule fp)
+      optionsChanged <-ifM (Lens.isBuiltinModule fp)
                        {-then-} (return False) {-else-} $ do
         currentOptions <- useTC stPragmaOptions
         let disagreements =

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -436,11 +436,10 @@ getInterface x isMain msi =
   addImportCycleCheck x $ do
      -- We remember but reset the pragma options locally
      -- Issue #3644 (Abel 2020-05-08): Set approximate range for errors in options
-     currentOptions <- setCurrentRange (C.modPragmas . siModule <$> msi) $ do
-       currentOptions <- useTC stPragmaOptions
+     currentOptions <- useTC stPragmaOptions
+     setCurrentRange (C.modPragmas . siModule <$> msi) $
        -- Now reset the options
        setCommandLineOptions . stPersistentOptions . stPersistentState =<< getTC
-       return currentOptions
 
      alreadyVisited x isMain currentOptions $ do
       file <- maybe (findFile x) (pure . siOrigin) msi -- may require source to exist

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -439,16 +439,16 @@ getInterface' x isMain msi =
       reportSLn "import.iface" 5 $ if visited then "  We've been here. Don't merge."
                                    else "  New module. Let's check it out."
 
-      -- Check that imported module options are consistent with
-      -- current options (issue #2487)
-      -- compute updated warnings if needed
-      wt' <- fromMaybe wt <$> getOptionsCompatibilityWarnings isMain currentOptions i
-
       unless (visited || stateChangesIncluded) $ do
         mergeInterface i
         Bench.billTo [Bench.Highlighting] $
           ifTopLevelAndHighlightingLevelIs NonInteractive $
             highlightFromInterface i file
+
+      -- Check that imported module options are consistent with
+      -- current options (issue #2487)
+      -- compute updated warnings if needed
+      wt' <- fromMaybe wt <$> getOptionsCompatibilityWarnings isMain currentOptions i
 
       -- Interfaces are not stored if we are only scope-checking, or
       -- if any warnings were encountered.

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -10,7 +10,6 @@ module Agda.Interaction.Imports
   , MaybeWarnings'(NoWarnings, SomeWarnings)
   , SourceInfo(..)
   , applyFlagsToMaybeWarnings
-  , isNewerThan
   , getAllWarnings
   , getAllWarningsOfTCErr
   , getMaybeWarnings
@@ -41,7 +40,7 @@ import qualified Data.HashMap.Strict as HMap
 import Data.Text (Text)
 import qualified Data.Text.Lazy as TL
 
-import System.Directory (doesFileExist, getModificationTime, removeFile)
+import System.Directory (doesFileExist, removeFile)
 import System.FilePath ((</>), takeDirectory)
 
 import Agda.Benchmarking
@@ -1262,16 +1261,3 @@ getInterfaceFileHashes' fp = do
 
 moduleHash :: ModuleName -> TCM Hash
 moduleHash m = iFullHash <$> getInterface m
-
--- | True if the first file is newer than the second file. If a file doesn't
--- exist it is considered to be infinitely old.
-isNewerThan :: FilePath -> FilePath -> IO Bool
-isNewerThan new old = do
-    newExist <- doesFileExist new
-    oldExist <- doesFileExist old
-    if not (newExist && oldExist)
-        then return newExist
-        else do
-            newT <- getModificationTime new
-            oldT <- getModificationTime old
-            return $ newT >= oldT

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -888,6 +888,7 @@ createInterface
 createInterface file mname isMain msi =
   Bench.billTo [Bench.TopModule mname] $
   localTC (\e -> e { envCurrentPath = Just (srcFilePath file) }) $ do
+    let onlyScope = isMain == MainInterface ScopeCheck
 
     reportSLn "import.iface.create" 5 $
       "Creating interface for " ++ prettyShow mname ++ "."
@@ -935,7 +936,6 @@ createInterface file mname isMain msi =
       -- Generate and print approximate syntax highlighting info.
       ifTopLevelAndHighlightingLevelIs NonInteractive $
         printHighlightingInfo KeepHighlighting fileTokenInfo
-      let onlyScope = isMain == MainInterface ScopeCheck
       ifTopLevelAndHighlightingLevelIsOr NonInteractive onlyScope $
         mapM_ (\ d -> generateAndPrintSyntaxInfo d Partial onlyScope) ds
     reportSLn "import.iface.create" 7 "Finished highlighting from scope."
@@ -959,11 +959,11 @@ createInterface file mname isMain msi =
         cleanCachedLog
     writeToCurrentLog $ Pragmas opts
 
-    case isMain of
-      MainInterface ScopeCheck -> do
+    if onlyScope
+      then do
         reportSLn "import.iface.create" 7 "Skipping type checking."
         cacheCurrentLog
-      _ -> do
+      else do
         reportSLn "import.iface.create" 7 "Starting type checking."
         Bench.billTo [Bench.Typing] $ mapM_ checkDeclCached ds `finally_` cacheCurrentLog
         reportSLn "import.iface.create" 7 "Finished type checking."

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -1082,8 +1082,9 @@ createInterface file mname isMain msi =
         -- The file was successfully type-checked (and no warnings were
         -- encountered), so the interface should be written out.
         ifile <- toIFile file
-        writeInterface ifile i
-    reportSLn "import.iface.create" 7 "Finished (or skipped) writing to interface file."
+        serializedIface <- writeInterface ifile i
+        reportSLn "import.iface.create" 7 "Finished writing to interface file."
+        return serializedIface
 
     -- -- Restore the open metas, as we might continue in interaction mode.
     -- Actually, we do not serialize the metas if checking the MainInterface

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -385,6 +385,10 @@ typeCheckMain mode si = do
 
   -- Now do the type checking via getInterface.
   checkModuleName' (siModuleName si) (siOrigin si)
+
+  -- For the main interface, we also remember the pragmas from the file
+  setOptionsFromSourceInfoPragmas si
+
   (i, ws) <- getInterface (siModuleName si) (MainInterface mode) (Just si)
 
   stCurrentModule `setTCLens` Just (iModuleName i)
@@ -431,11 +435,8 @@ getInterface
 getInterface x isMain msi =
   addImportCycleCheck x $ do
      -- We remember but reset the pragma options locally
-     -- For the main interface, we also remember the pragmas from the file
      -- Issue #3644 (Abel 2020-05-08): Set approximate range for errors in options
      currentOptions <- setCurrentRange (C.modPragmas . siModule <$> msi) $ do
-       when (includeStateChanges isMain) $
-         setOptionsFromSourceInfoPragmas (fromMaybe __IMPOSSIBLE__ msi)
        currentOptions <- useTC stPragmaOptions
        -- Now reset the options
        setCommandLineOptions . stPersistentOptions . stPersistentState =<< getTC

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -667,7 +667,7 @@ typeCheck x file isMain msi = do
 
   case isMain of
     MainInterface _ -> do
-      r <- withMsgs $ createInterface file x isMain msi
+      r <- withMsgs $ createInterface x file isMain msi
       return (True, r)
 
     NotMainInterface -> do
@@ -713,7 +713,7 @@ typeCheck x file isMain msi = do
                setVisitedModules vs
                addImportedThings isig ibuiltin ipatsyns display userwarn partialdefs []
 
-               r  <- withMsgs $ createInterface file x isMain msi
+               r  <- withMsgs $ createInterface x file isMain msi
                mf' <- useTC stModuleToSource
                ds' <- getDecodedModules
                return (r, mf', ds')
@@ -843,12 +843,12 @@ writeInterface file i = let fp = filePath file in do
 -- information.
 
 createInterface
-  :: SourceFile            -- ^ The file to type check.
-  -> C.TopLevelModuleName  -- ^ The expected module name.
+  :: C.TopLevelModuleName  -- ^ The expected module name.
+  -> SourceFile            -- ^ The file to type check.
   -> MainInterface         -- ^ Are we dealing with the main module?
   -> Maybe SourceInfo      -- ^ Optional information about the source code.
   -> TCM (Interface, [TCWarning])
-createInterface file mname isMain msi =
+createInterface mname file isMain msi =
   Bench.billTo [Bench.TopModule mname] $
   localTC (\e -> e { envCurrentPath = Just (srcFilePath file) }) $ do
     let onlyScope = isMain == MainInterface ScopeCheck

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -519,10 +519,10 @@ isCached
   -> MaybeT TCM Interface
 
 isCached x file = do
-  ifile <- MaybeT $ findInterfaceFile' file
-
   -- Check that we have cached the module.
   mi <- MaybeT $ getDecodedModule x
+
+  ifile <- MaybeT $ findInterfaceFile' file
 
   -- Check that the interface file exists and return its hash.
   h  <- MaybeT $ liftIO $ fmap snd <$> getInterfaceFileHashes' ifile

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -430,13 +430,6 @@ getInterface' x isMain msi =
 
         either recheck pure stored
 
-      -- Ensure that the given module name matches the one in the file.
-      let topLevelName = toTopLevelModuleName $ iModuleName i
-      unless (topLevelName == x) $
-        -- Andreas, 2014-03-27 This check is now done in the scope checker.
-        -- checkModuleName topLevelName file
-        typeError $ OverlappingProjects (srcFilePath file) topLevelName x
-
       visited <- isVisited x
       reportSLn "import.iface" 5 $ if visited then "  We've been here. Don't merge."
                                    else "  New module. Let's check it out."
@@ -598,6 +591,13 @@ getStoredInterface x file msi = do
 
         i <- maybeToExceptT "bad interface, re-type checking" $ MaybeT $
           readInterface ifile
+
+        -- Ensure that the given module name matches the one in the file.
+        let topLevelName = toTopLevelModuleName $ iModuleName i
+        unless (topLevelName == x) $
+          -- Andreas, 2014-03-27 This check is now done in the scope checker.
+          -- checkModuleName topLevelName file
+          lift $ typeError $ OverlappingProjects (srcFilePath file) topLevelName x
 
         r <- validateLoadedInterface file i []
 

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -341,7 +341,7 @@ alreadyVisited x isMain currentOptions getIface =
 --   or the file passed on the command line.
 --
 --   First, the primitive modules are imported.
---   Then, @getInterface'@ is called to do the main work.
+--   Then, @getInterface@ is called to do the main work.
 --
 --   If the 'Mode' is 'ScopeCheck', then type-checking is not
 --   performed, only scope-checking. (This may include type-checking
@@ -378,9 +378,9 @@ typeCheckMain mode si = do
 
   reportSLn "import.main" 10 $ "Done importing the primitive modules."
 
-  -- Now do the type checking via getInterface'.
+  -- Now do the type checking via getInterface.
   checkModuleName' (siModuleName si) (siOrigin si)
-  (i, ws) <- getInterface' (siModuleName si) (MainInterface mode) (Just si)
+  (i, ws) <- getInterface (siModuleName si) (MainInterface mode) (Just si)
 
   stCurrentModule `setTCLens` Just (iModuleName i)
 
@@ -406,21 +406,21 @@ getInterface_
      -- ^ Optional information about the source code.
   -> TCM Interface
 getInterface_ x msi = do
-  (i, wt) <- getInterface' x NotMainInterface msi
+  (i, wt) <- getInterface x NotMainInterface msi
   tcWarningsToError wt
   return i
 
--- | A more precise variant of 'getInterface'. If warnings are
+-- | A more precise variant of 'getInterface_'. If warnings are
 -- encountered then they are returned instead of being turned into
 -- errors.
 
-getInterface'
+getInterface
   :: C.TopLevelModuleName
   -> MainInterface
   -> Maybe SourceInfo
      -- ^ Optional information about the source code.
   -> TCM (Interface, [TCWarning])
-getInterface' x isMain msi =
+getInterface x isMain msi =
   withIncreasedModuleNestingLevel $
     -- Preserve the pragma options unless we are checking the main
     -- interface.

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -346,7 +346,11 @@ typeCheckMain mode si = do
 
   -- Now do the type checking via getInterface'.
   checkModuleName' (siModuleName si) (siOrigin si)
-  getInterface' (siModuleName si) (MainInterface mode) (Just si)
+  (i, ws) <- getInterface' (siModuleName si) (MainInterface mode) (Just si)
+
+  stCurrentModule `setTCLens` Just (iModuleName i)
+
+  return (i, ws)
   where
   checkModuleName' m f =
     -- Andreas, 2016-07-11, issue 2092
@@ -445,8 +449,6 @@ getInterface' x isMain msi =
         Bench.billTo [Bench.Highlighting] $
           ifTopLevelAndHighlightingLevelIs NonInteractive $
             highlightFromInterface i file
-
-      stCurrentModule `setTCLens` Just (iModuleName i)
 
       -- Interfaces are not stored if we are only scope-checking, or
       -- if any warnings were encountered.

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -641,8 +641,7 @@ getStoredInterface x file isMain msi = do
           return True
 
       if optionsChanged then fallback else do
-
-        hs <- map iFullHash <$> mapM (getInterface . fst) (iImportedModules i)
+        hs <- mapM (moduleHash . fst) (iImportedModules i)
 
         -- If any of the imports are newer we need to retype check
         if hs /= map snd (iImportedModules i)

--- a/src/full/Agda/Interaction/Options/Lenses.hs
+++ b/src/full/Agda/Interaction/Options/Lenses.hs
@@ -194,6 +194,11 @@ builtinModules :: Set FilePath
 builtinModules = builtinModulesWithSafePostulates `Set.union`
                  builtinModulesWithUnsafePostulates
 
+isPrimitiveModule :: FilePath -> TCM Bool
+isPrimitiveModule file = do
+  libdirPrim <- (</> "prim") <$> liftIO defaultLibDir
+  return (file `Set.member` Set.map (libdirPrim </>) primitiveModules)
+
 isBuiltinModule :: FilePath -> TCM Bool
 isBuiltinModule file = do
   libdirPrim <- (</> "prim") <$> liftIO defaultLibDir

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -952,6 +952,12 @@ restrictLocalPrivate m =
     rName as = filterMaybe (not . null) $ filter (not . (`isInModule`        m) . anameName) as
     rMod  as = filterMaybe (not . null) $ filter (not . (`isLtChildModuleOf` m) . amodName)  as
 
+-- | Filter privates out of a `ScopeInfo`
+withoutPrivates :: ScopeInfo -> ScopeInfo
+withoutPrivates scope = over scopeModules (fmap $ restrictLocalPrivate m) scope
+  where
+  m = scope ^. scopeCurrent
+
 -- | Disallow using generalized variables from the scope
 disallowGeneralizedVars :: Scope -> Scope
 disallowGeneralizedVars = mapScope_ ((fmap . map) disallow) id id

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2781,9 +2781,6 @@ data TCEnv =
                 -- ^ Should new metas generalized over.
           , envGeneralizedVars :: Map QName GeneralizedValue
                 -- ^ Values for used generalizable variables.
-          , envCheckOptionConsistency :: Bool
-                -- ^ Do we check that options in imported files are
-                --   consistent with each other?
           , envActiveBackendName :: Maybe BackendName
                 -- ^ Is some backend active at the moment, and if yes, which?
                 --   NB: we only store the 'BackendName' here, otherwise
@@ -2847,7 +2844,6 @@ initEnv = TCEnv { envContext             = []
                 , envCheckpoints            = Map.singleton 0 IdS
                 , envGeneralizeMetas        = NoGeneralize
                 , envGeneralizedVars        = Map.empty
-                , envCheckOptionConsistency = True
                 , envActiveBackendName      = Nothing
                 }
 

--- a/src/full/Agda/TypeChecking/Monad/Env.hs
+++ b/src/full/Agda/TypeChecking/Monad/Env.hs
@@ -66,9 +66,6 @@ withIncreasedModuleNestingLevel =
 withHighlightingLevel :: HighlightingLevel -> TCM a -> TCM a
 withHighlightingLevel h = localTC $ \ e -> e { envHighlightingLevel = h }
 
-withoutOptionsChecking :: TCM a -> TCM a
-withoutOptionsChecking = localTC $ \ e -> e { envCheckOptionConsistency = False }
-
 -- | Restore setting for 'ExpandLast' to default.
 doExpandLast :: TCM a -> TCM a
 doExpandLast = localTC $ \ e -> e { envExpandLast = setExpand (envExpandLast e) }

--- a/src/full/Agda/TypeChecking/Monad/Imports.hs
+++ b/src/full/Agda/TypeChecking/Monad/Imports.hs
@@ -12,7 +12,6 @@ module Agda.TypeChecking.Monad.Imports
   , getVisitedModules
   , isImported
   , isVisited
-  , mapVisitedModule
   , setDecodedModules
   , setVisitedModules
   , storeDecodedModule
@@ -69,11 +68,6 @@ getVisitedModule :: ReadTCState m
                  => C.TopLevelModuleName
                  -> m (Maybe ModuleInfo)
 getVisitedModule x = Map.lookup x <$> useTC stVisitedModules
-
-mapVisitedModule :: C.TopLevelModuleName
-                 -> (ModuleInfo -> ModuleInfo)
-                 -> TCM ()
-mapVisitedModule x f = modifyTCLens stVisitedModules (Map.adjust f x)
 
 getDecodedModules :: TCM DecodedModules
 getDecodedModules = stDecodedModules . stPersistentState <$> getTC

--- a/src/full/Agda/TypeChecking/Monad/Imports.hs
+++ b/src/full/Agda/TypeChecking/Monad/Imports.hs
@@ -1,5 +1,24 @@
 
-module Agda.TypeChecking.Monad.Imports where
+module Agda.TypeChecking.Monad.Imports
+  ( addImport
+  , addImportCycleCheck
+  , checkForImportCycle
+  , dropDecodedModule
+  , getDecodedModule
+  , getDecodedModules
+  , getImportPath
+  , getImports
+  , getVisitedModule
+  , getVisitedModules
+  , isImported
+  , isVisited
+  , mapVisitedModule
+  , setDecodedModules
+  , setVisitedModules
+  , storeDecodedModule
+  , visitModule
+  , withImportPath
+  ) where
 
 import Control.Monad.State
 

--- a/src/full/Agda/TypeChecking/Monad/Imports.hs
+++ b/src/full/Agda/TypeChecking/Monad/Imports.hs
@@ -8,6 +8,7 @@ module Agda.TypeChecking.Monad.Imports
   , getDecodedModules
   , getImportPath
   , getImports
+  , getPrettyVisitedModules
   , getVisitedModule
   , getVisitedModules
   , isImported
@@ -29,7 +30,9 @@ import qualified Data.Set as Set
 import Agda.Syntax.Abstract.Name
 import qualified Agda.Syntax.Concrete.Name as C
 import Agda.TypeChecking.Monad.Base
+
 import Agda.Utils.List ( caseListM )
+import Agda.Utils.Pretty
 
 
 import Agda.Utils.Impossible
@@ -60,6 +63,11 @@ setVisitedModules ms = setTCLens stVisitedModules ms
 
 getVisitedModules :: ReadTCState m => m VisitedModules
 getVisitedModules = useTC stVisitedModules
+
+getPrettyVisitedModules :: ReadTCState m => m Doc
+getPrettyVisitedModules = do
+  visited <- Map.keys <$> getVisitedModules
+  return $ hcat $ punctuate ", " $ pretty <$> visited
 
 isVisited :: C.TopLevelModuleName -> TCM Bool
 isVisited x = Map.member x <$> useTC stVisitedModules

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -262,12 +262,6 @@ withShowAllArguments' yes = withPragmaOptions $ \ opts ->
 withPragmaOptions :: ReadTCState m => (PragmaOptions -> PragmaOptions) -> m a -> m a
 withPragmaOptions = locallyTCState stPragmaOptions
 
-ignoreInterfaces :: HasOptions m => m Bool
-ignoreInterfaces = optIgnoreInterfaces <$> commandLineOptions
-
-ignoreAllInterfaces :: HasOptions m => m Bool
-ignoreAllInterfaces = optIgnoreAllInterfaces <$> commandLineOptions
-
 positivityCheckEnabled :: HasOptions m => m Bool
 positivityCheckEnabled = not . optDisablePositivity <$> pragmaOptions
 

--- a/src/full/Agda/Utils/FileName.hs
+++ b/src/full/Agda/Utils/FileName.hs
@@ -10,6 +10,7 @@ module Agda.Utils.FileName
   , canonicalizeAbsolutePath
   , sameFile
   , doesFileExistCaseSensitive
+  , isNewerThan
   ) where
 
 import System.Directory
@@ -110,3 +111,16 @@ doesFileExistCaseSensitive f = do
 #else
 doesFileExistCaseSensitive = doesFileExist
 #endif
+
+-- | True if the first file is newer than the second file. If a file doesn't
+-- exist it is considered to be infinitely old.
+isNewerThan :: FilePath -> FilePath -> IO Bool
+isNewerThan new old = do
+    newExist <- doesFileExist new
+    oldExist <- doesFileExist old
+    if not (newExist && oldExist)
+        then return newExist
+        else do
+            newT <- getModificationTime new
+            oldT <- getModificationTime old
+            return $ newT >= oldT

--- a/test/Fail/Issue641-all-interfaces.err
+++ b/test/Fail/Issue641-all-interfaces.err
@@ -22,7 +22,7 @@ Considering writing to interface file.
 Actually calling writeInterface.
 Writing interface file agda-default-include-path/Agda/Primitive.agdai.
 Wrote interface file.
-Finished (or skipped) writing to interface file.
+Finished writing to interface file.
 Finished Agda.Primitive.
   using stored version of agda-default-include-path/Agda/Primitive.agdai
   imports: []
@@ -56,7 +56,7 @@ Considering writing to interface file.
 Actually calling writeInterface.
 Writing interface file agda-default-include-path/Agda/Primitive/Cubical.agdai.
 Wrote interface file.
-Finished (or skipped) writing to interface file.
+Finished writing to interface file.
 Finished Agda.Primitive.Cubical.
   using stored version of agda-default-include-path/Agda/Primitive/Cubical.agdai
   imports: [(Agda.Primitive, 14631793092877554489)]

--- a/test/Fail/Issue641-all-interfaces.err
+++ b/test/Fail/Issue641-all-interfaces.err
@@ -24,7 +24,6 @@ Writing interface file agda-default-include-path/Agda/Primitive.agdai.
 Wrote interface file.
 Finished writing to interface file.
 Finished Agda.Primitive.
-  using stored version of agda-default-include-path/Agda/Primitive.agdai
   imports: []
   New module. Let's check it out.
 Merging interface
@@ -58,7 +57,6 @@ Writing interface file agda-default-include-path/Agda/Primitive/Cubical.agdai.
 Wrote interface file.
 Finished writing to interface file.
 Finished Agda.Primitive.Cubical.
-  using stored version of agda-default-include-path/Agda/Primitive/Cubical.agdai
   imports: [(Agda.Primitive, 14631793092877554489)]
   Already visited Agda.Primitive
   New module. Let's check it out.

--- a/test/Fail/Issue641-all-interfaces.err
+++ b/test/Fail/Issue641-all-interfaces.err
@@ -1,7 +1,7 @@
 Importing the primitive modules.
   Getting interface for Agda.Primitive
   Check for cycle
-  Agda.Primitive is not up-to-date.
+  Agda.Primitive is not up-to-date because the interface has not been decoded and we're ignoring all interface files.
 Checking Agda.Primitive (agda-default-include-path/Agda/Primitive.agda).
 Creating interface for Agda.Primitive.
   visited: 
@@ -30,7 +30,7 @@ Merging interface
   Now we've looked at Agda.Primitive
   Getting interface for Agda.Primitive.Cubical
   Check for cycle
-  Agda.Primitive.Cubical is not up-to-date.
+  Agda.Primitive.Cubical is not up-to-date because the interface has not been decoded and we're ignoring all interface files.
 Checking Agda.Primitive.Cubical (agda-default-include-path/Agda/Primitive/Cubical.agda).
 Creating interface for Agda.Primitive.Cubical.
   visited: Agda.Primitive
@@ -65,7 +65,7 @@ Merging interface
 Done importing the primitive modules.
   Getting interface for Issue641-all-interfaces
   Check for cycle
-  Issue641-all-interfaces is not up-to-date.
+  Issue641-all-interfaces is not up-to-date because the interface has not been decoded and we're ignoring all interface files.
 Checking Issue641-all-interfaces (Issue641-all-interfaces.agda).
 Creating interface for Issue641-all-interfaces.
   visited: Agda.Primitive, Agda.Primitive.Cubical

--- a/test/Fail/Issue641.err
+++ b/test/Fail/Issue641.err
@@ -21,7 +21,7 @@ Merging interface
 Done importing the primitive modules.
   Getting interface for Issue641
   Check for cycle
-  Issue641 is not up-to-date.
+  Issue641 is not up-to-date because the interface has not been decoded and we're ignoring non-builtin interface files.
 Checking Issue641 (Issue641.agda).
 Creating interface for Issue641.
   visited: Agda.Primitive, Agda.Primitive.Cubical

--- a/test/api/Issue1168.hs
+++ b/test/api/Issue1168.hs
@@ -12,7 +12,7 @@ import System.Exit            ( exitSuccess )
 -- Agda library imports
 
 import Agda.Interaction.FindFile       ( SourceFile(..), findInterfaceFile' )
-import Agda.Interaction.Imports        ( readInterface' )
+import Agda.Interaction.Imports        ( readInterface )
 import Agda.Interaction.Options        ( defaultOptions )
 import Agda.TypeChecking.Monad.Base    ( Interface, runTCMTop, TCErr )
 import Agda.TypeChecking.Monad.Options ( setCommandLineOptions )
@@ -28,7 +28,7 @@ main = do
     do setCommandLineOptions defaultOptions
        src   <- liftIO $ SourceFile <$> absolute "Issue1168.agda"
        ifile <- findInterfaceFile' src
-       readInterface' $ fromMaybe __IMPOSSIBLE__ ifile
+       readInterface $ fromMaybe __IMPOSSIBLE__ ifile
 
   case r of
     Right (Just _) -> exitSuccess


### PR DESCRIPTION
This is a non-comprehensive set of cleanups and small refactors to `Agda.Interaction.Imports`. With the exception of some improved log messages, it is intended to be entirely behaviour- and capability-preserving. The main purpose of this branch was my attempt to understand and clarify the actual import logic going on.

Although many of the commits are independent, they're mostly fairly trivial and didn't seem worth the noise of doing separate PRs for all of them. They should be reasonably easy to review independently, though some of the commits are in place to lead up to a particular change, and might not appear clearly motivated otherwise. Let me know if anything appears unclear.

One exception is that this PR includes:
  * [PR #5080: Nit refactor: Remove redundant `envCheckOptionConsistency`](https://github.com/agda/agda/pull/5080)
which can be reviewed in focus.

This branch is used as the basis of:
  * [PR #5083: Support for scope-only backends](https://github.com/agda/agda/pull/5083)
  * and from there, [PR #5082: LaTeX, GraphViz, and HTML as isolated compiler backends](https://github.com/agda/agda/pull/5082)

which may help motivate some of the changes. (For example, once scope-only interface checks are tracked, some of the conditions in `getInterface` and `alreadyVisited` become simpler than seen here).