### PR TITLE
[ #4521 ] Added the flag optimise-heavily to Agda.cabal.

### DIFF
--- a/.ghci-8.0
+++ b/.ghci-8.0
@@ -7,8 +7,6 @@
 :set -hide-package Agda
 
 :set -fprint-potential-instances
-:set -fexpose-all-unfoldings
-:set -fspecialise-aggressively
 :set -threaded
 :set -w
 -- :set -Werror

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -158,6 +158,11 @@ flag enable-cluster-counting
     Enable the --count-clusters flag. (If enable-cluster-counting is
     False, then the --count-clusters flag triggers an error message.)
 
+flag optimise-heavily
+  default: False
+  description:
+    Enable some expensive optimisations when compiling Agda.
+
 custom-setup
   setup-depends:  base >= 4.9.0.0 && < 4.15
                 , Cabal >= 1.24.0.0 && < 3.3
@@ -625,11 +630,13 @@ library
                     Agda.Utils.CallStack.Base
                     Agda.Utils.CallStack.Pretty
 
-  -- NOTE: If adding flags, also add to `.ghci-8.0`
-  if impl(ghc <= 8.0.2)
+  if flag(optimise-heavily)
     ghc-options: -fexpose-all-unfoldings
                  -fspecialise-aggressively
-                 -fprint-potential-instances
+
+  -- NOTE: If adding flags, also add to `.ghci-8.0`
+  if impl(ghc <= 8.0.2)
+    ghc-options: -fprint-potential-instances
                  -- Initially, we disable all the warnings.
                  -w
                  -Werror
@@ -664,9 +671,7 @@ library
                  -Wwarnings-deprecations
                  -Wwrong-do-bind
   else
-    ghc-options: -fexpose-all-unfoldings
-                 -fspecialise-aggressively
-                 -fprint-potential-instances
+    ghc-options: -fprint-potential-instances
                  -Werror=unrecognised-warning-flags
                  -Werror=deprecated-flags
                  -Werror=deriving-typeable
@@ -943,11 +948,13 @@ test-suite agda-tests
                      , TypeFamilies
                      , TypeSynonymInstances
 
-  -- NOTE: If adding or removing flags, also change `.ghci-8.0`
-  if impl(ghc <= 8.0.2)
+  if flag(optimise-heavily)
     ghc-options: -fexpose-all-unfoldings
                  -fspecialise-aggressively
-                 -threaded
+
+  -- NOTE: If adding or removing flags, also change `.ghci-8.0`
+  if impl(ghc <= 8.0.2)
+    ghc-options: -threaded
                  -- Initially, we disable all the warnings.
                  -w
                  -Werror
@@ -982,9 +989,7 @@ test-suite agda-tests
                  -Wwarnings-deprecations
                  -Wwrong-do-bind
   else
-    ghc-options: -fexpose-all-unfoldings
-                 -fspecialise-aggressively
-                 -threaded
+    ghc-options: -threaded
                  -Werror=unrecognised-warning-flags
                  -Werror=deprecated-flags
                  -Werror=deriving-typeable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Release notes for Agda version 2.6.2
 ====================================
 
+Building Agda
+-------------
+
+* Some expensive optimisations are now off by default
+  (see [#4521](https://github.com/agda/agda/issues/4521)).
+
+  These optimisations can be turned on manually (Cabal:
+  `-foptimise-heavily`, Stack: `--flag Agda:optimise-heavily`). They
+  are turned on (by default) when Agda is installed using `make
+  install`.
+
+  If the optimisations are turned on it might make sense to limit
+  GHC's memory usage (using something like `--ghc-options="+RTS -M6G
+  -RTS"`).
+
 Command-line interaction
 ------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,10 @@ FAST_STACK_INSTALL = $(STACK_INSTALL_HELPER) --work-dir=$(FAST_STACK_BUILD_DIR) 
 
 # ordinary install: optimizations and tests
 
-SLOW_CABAL_INSTALL_OPTS = --builddir=$(BUILD_DIR) --enable-tests
-SLOW_STACK_INSTALL_OPTS = --test --no-run-tests
+SLOW_CABAL_INSTALL_OPTS = --builddir=$(BUILD_DIR) --enable-tests \
+                          -foptimise-heavily
+SLOW_STACK_INSTALL_OPTS = --test --no-run-tests \
+                          --flag Agda:optimise-heavily
 
 CABAL_INSTALL           = $(CABAL_INSTALL_HELPER) \
                           $(SLOW_CABAL_INSTALL_OPTS)

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -336,6 +336,11 @@ When installing Agda the following flags can be used:
      :option:`--count-clusters` flag triggers an error
      message. Default: off.
 
+.. option:: optimise-heavily
+
+     Optimise Agda heavily. (In this case it might make sense to limit
+     GHC's memory usage.) Default: off.
+
 .. _exec-path-from-shell: https://github.com/purcell/exec-path-from-shell
 
 .. _installing-multiple-versions-of-Agda:


### PR DESCRIPTION
With this change in place it should be easier for people to build Agda using (say) `cabal v1-install Agda`.

The flag `optimise-heavily` is activated by `make install`. However, it is not activated for CI. Any opinions on this?