### PR TITLE
Trivial: A few `MonadTrans` impls and missing `IdentityT` instances

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -721,6 +721,7 @@ class Monad m => MonadFresh i m where
 instance MonadFresh i m => MonadFresh i (ReaderT r m)
 instance MonadFresh i m => MonadFresh i (StateT s m)
 instance MonadFresh i m => MonadFresh i (ListT m)
+instance MonadFresh i m => MonadFresh i (IdentityT m)
 
 instance HasFresh i => MonadFresh i TCM where
   fresh = do

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -853,6 +853,9 @@ class Monad m => MonadStConcreteNames m where
 instance MonadStConcreteNames TCM where
   runStConcreteNames m = stateTCLensM stConcreteNames $ runStateT m
 
+instance MonadStConcreteNames m => MonadStConcreteNames (IdentityT m) where
+  runStConcreteNames m = IdentityT $ runStConcreteNames $ StateT $ runIdentityT . runStateT m
+
 instance MonadStConcreteNames m => MonadStConcreteNames (ReaderT r m) where
   runStConcreteNames m = ReaderT $ runStConcreteNames . StateT . flip (runReaderT . runStateT m)
 

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -9,6 +9,7 @@ import qualified Control.Monad.Fail as Fail
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
+import Control.Monad.Trans.Identity (IdentityT)
 import Control.Monad.Trans.Maybe
 import Control.Monad.Writer
 
@@ -40,9 +41,10 @@ class ( Functor m
   default getBuiltinThing :: (MonadTrans t, HasBuiltins n, t n ~ m) => String -> m (Maybe (Builtin PrimFun))
   getBuiltinThing = lift . getBuiltinThing
 
-instance HasBuiltins m => HasBuiltins (MaybeT m)
 instance HasBuiltins m => HasBuiltins (ExceptT e m)
+instance HasBuiltins m => HasBuiltins (IdentityT m)
 instance HasBuiltins m => HasBuiltins (ListT m)
+instance HasBuiltins m => HasBuiltins (MaybeT m)
 instance HasBuiltins m => HasBuiltins (ReaderT e m)
 instance HasBuiltins m => HasBuiltins (StateT s m)
 instance (HasBuiltins m, Monoid w) => HasBuiltins (WriterT w m)

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -57,6 +57,10 @@ instance (HasBuiltins m, Monoid w) => HasBuiltins (WriterT w m) where
 
 deriving instance HasBuiltins m => HasBuiltins (BlockT m)
 
+instance MonadIO m => HasBuiltins (TCMT m) where
+  getBuiltinThing b = liftM2 mplus (Map.lookup b <$> useTC stLocalBuiltins)
+                      (Map.lookup b <$> useTC stImportedBuiltins)
+
 -- If Agda is changed so that the type of a literal can belong to an
 -- inductive family (with at least one index), then the implementation
 -- of split' in Agda.TypeChecking.Coverage should be changed.
@@ -77,10 +81,6 @@ litType = \case
   LitMeta _ _ -> el <$> primAgdaMeta
   where
     el t = El (mkType 0) t
-
-instance MonadIO m => HasBuiltins (TCMT m) where
-  getBuiltinThing b = liftM2 mplus (Map.lookup b <$> useTC stLocalBuiltins)
-                      (Map.lookup b <$> useTC stImportedBuiltins)
 
 setBuiltinThings :: BuiltinThings PrimFun -> TCM ()
 setBuiltinThings b = stLocalBuiltins `setTCLens` b

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -37,23 +37,15 @@ class ( Functor m
       ) => HasBuiltins m where
   getBuiltinThing :: String -> m (Maybe (Builtin PrimFun))
 
-instance HasBuiltins m => HasBuiltins (MaybeT m) where
-  getBuiltinThing b = lift $ getBuiltinThing b
+  default getBuiltinThing :: (MonadTrans t, HasBuiltins n, t n ~ m) => String -> m (Maybe (Builtin PrimFun))
+  getBuiltinThing = lift . getBuiltinThing
 
-instance HasBuiltins m => HasBuiltins (ExceptT e m) where
-  getBuiltinThing b = lift $ getBuiltinThing b
-
-instance HasBuiltins m => HasBuiltins (ListT m) where
-  getBuiltinThing b = lift $ getBuiltinThing b
-
-instance HasBuiltins m => HasBuiltins (ReaderT e m) where
-  getBuiltinThing b = lift $ getBuiltinThing b
-
-instance HasBuiltins m => HasBuiltins (StateT s m) where
-  getBuiltinThing b = lift $ getBuiltinThing b
-
-instance (HasBuiltins m, Monoid w) => HasBuiltins (WriterT w m) where
-  getBuiltinThing b = lift $ getBuiltinThing b
+instance HasBuiltins m => HasBuiltins (MaybeT m)
+instance HasBuiltins m => HasBuiltins (ExceptT e m)
+instance HasBuiltins m => HasBuiltins (ListT m)
+instance HasBuiltins m => HasBuiltins (ReaderT e m)
+instance HasBuiltins m => HasBuiltins (StateT s m)
+instance (HasBuiltins m, Monoid w) => HasBuiltins (WriterT w m)
 
 deriving instance HasBuiltins m => HasBuiltins (BlockT m)
 

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
@@ -13,6 +13,8 @@ class ( Functor m
       , Fail.MonadFail m
       ) => HasBuiltins m where
   getBuiltinThing :: String -> m (Maybe (Builtin PrimFun))
+  default getBuiltinThing :: (MonadTrans t, HasBuiltins n, t n ~ m) => String -> m (Maybe (Builtin PrimFun))
+  getBuiltinThing = lift . getBuiltinThing
 
 instance HasBuiltins m => HasBuiltins (ReaderT e m)
 instance HasBuiltins m => HasBuiltins (StateT s m)

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
@@ -3,6 +3,7 @@ module Agda.TypeChecking.Monad.Builtin where
 
 import Control.Monad.Reader
 import Control.Monad.State
+import Control.Monad.Trans.Identity ( IdentityT )
 
 import qualified Control.Monad.Fail as Fail
 
@@ -16,6 +17,7 @@ class ( Functor m
   default getBuiltinThing :: (MonadTrans t, HasBuiltins n, t n ~ m) => String -> m (Maybe (Builtin PrimFun))
   getBuiltinThing = lift . getBuiltinThing
 
+instance HasBuiltins m => HasBuiltins (IdentityT m)
 instance HasBuiltins m => HasBuiltins (ReaderT e m)
 instance HasBuiltins m => HasBuiltins (StateT s m)
 

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -5,6 +5,7 @@ import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Trans.Control  ( MonadTransControl(..), liftThrough )
+import Control.Monad.Trans.Identity ( IdentityT )
 import Control.Monad.Trans.Maybe
 import Control.Monad.Writer
 -- Control.Monad.Fail import is redundant since GHC 8.8.1
@@ -197,8 +198,9 @@ defaultAddCtx x a ret = do
 withFreshName_ :: (MonadAddContext m) => ArgName -> (Name -> m a) -> m a
 withFreshName_ = withFreshName noRange
 
-instance MonadAddContext m => MonadAddContext (MaybeT m)
 instance MonadAddContext m => MonadAddContext (ExceptT e m)
+instance MonadAddContext m => MonadAddContext (IdentityT m)
+instance MonadAddContext m => MonadAddContext (MaybeT m)
 instance MonadAddContext m => MonadAddContext (ReaderT r m)
 instance MonadAddContext m => MonadAddContext (StateT r m)
 instance (Monoid w, MonadAddContext m) => MonadAddContext (WriterT w m)

--- a/src/full/Agda/TypeChecking/Monad/Context.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs-boot
@@ -5,6 +5,7 @@ module Agda.TypeChecking.Monad.Context where
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Trans.Control  ( MonadTransControl(..), liftThrough )
+import Control.Monad.Trans.Identity ( IdentityT )
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
@@ -42,6 +43,7 @@ class MonadTCEnv m => MonadAddContext m where
       withFreshName r x $ run . cont
     restoreT $ return st
 
+instance MonadAddContext m => MonadAddContext (IdentityT m) where
 instance MonadAddContext m => MonadAddContext (ReaderT r m) where
 instance MonadAddContext m => MonadAddContext (StateT r m) where
 

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -6,6 +6,7 @@ import Prelude hiding (null)
 
 import Control.Monad.Except
 import Control.Monad.State
+import Control.Monad.Trans.Identity ( IdentityT )
 import Control.Monad.Reader
 import Control.Monad.Writer
 -- Control.Monad.Fail import is redundant since GHC 8.8.1
@@ -333,6 +334,7 @@ class (MonadTCEnv m, ReadTCState m) => MonadInteractionPoints m where
     => (InteractionPoints -> InteractionPoints) -> m ()
   modifyInteractionPoints = lift . modifyInteractionPoints
 
+instance MonadInteractionPoints m => MonadInteractionPoints (IdentityT m)
 instance MonadInteractionPoints m => MonadInteractionPoints (ReaderT r m)
 instance MonadInteractionPoints m => MonadInteractionPoints (StateT s m)
 

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -322,15 +322,19 @@ setMetaOccursCheck mi b = updateMetaVar mi $ \ mvar ->
 
 class (MonadTCEnv m, ReadTCState m) => MonadInteractionPoints m where
   freshInteractionId :: m InteractionId
+  default freshInteractionId
+    :: (MonadTrans t, MonadInteractionPoints n, t n ~ m)
+    => m InteractionId
+  freshInteractionId = lift freshInteractionId
+
   modifyInteractionPoints :: (InteractionPoints -> InteractionPoints) -> m ()
-
-instance MonadInteractionPoints m => MonadInteractionPoints (ReaderT r m) where
-  freshInteractionId = lift freshInteractionId
+  default modifyInteractionPoints
+    :: (MonadTrans t, MonadInteractionPoints n, t n ~ m)
+    => (InteractionPoints -> InteractionPoints) -> m ()
   modifyInteractionPoints = lift . modifyInteractionPoints
 
-instance MonadInteractionPoints m => MonadInteractionPoints (StateT r m) where
-  freshInteractionId = lift freshInteractionId
-  modifyInteractionPoints = lift . modifyInteractionPoints
+instance MonadInteractionPoints m => MonadInteractionPoints (ReaderT r m)
+instance MonadInteractionPoints m => MonadInteractionPoints (StateT s m)
 
 instance MonadInteractionPoints TCM where
   freshInteractionId = fresh

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs-boot
@@ -3,6 +3,7 @@ module Agda.TypeChecking.Monad.MetaVars where
 
 import Control.Monad.Reader
 import Control.Monad.State
+import Control.Monad.Trans.Identity ( IdentityT )
 
 import Agda.Syntax.Common (InteractionId)
 import Agda.TypeChecking.Monad.Base
@@ -21,6 +22,7 @@ class (MonadTCEnv m, ReadTCState m) => MonadInteractionPoints m where
     => (InteractionPoints -> InteractionPoints) -> m ()
   modifyInteractionPoints = lift . modifyInteractionPoints
 
+instance MonadInteractionPoints m => MonadInteractionPoints (IdentityT m)
 instance MonadInteractionPoints m => MonadInteractionPoints (ReaderT r m)
 instance MonadInteractionPoints m => MonadInteractionPoints (StateT s m)
 

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs-boot
@@ -11,7 +11,17 @@ class (MonadTCEnv m, ReadTCState m) => MonadInteractionPoints m where
   freshInteractionId :: m InteractionId
   modifyInteractionPoints :: (InteractionPoints -> InteractionPoints) -> m ()
 
+  default freshInteractionId
+    :: (MonadTrans t, MonadInteractionPoints n, t n ~ m)
+    => m InteractionId
+  freshInteractionId = lift freshInteractionId
+
+  default modifyInteractionPoints
+    :: (MonadTrans t, MonadInteractionPoints n, t n ~ m)
+    => (InteractionPoints -> InteractionPoints) -> m ()
+  modifyInteractionPoints = lift . modifyInteractionPoints
+
 instance MonadInteractionPoints m => MonadInteractionPoints (ReaderT r m)
-instance MonadInteractionPoints m => MonadInteractionPoints (StateT r m)
+instance MonadInteractionPoints m => MonadInteractionPoints (StateT s m)
 
 instance MonadInteractionPoints TCM

--- a/src/full/Agda/TypeChecking/Monad/Pure.hs
+++ b/src/full/Agda/TypeChecking/Monad/Pure.hs
@@ -9,6 +9,7 @@ import Control.Monad.Except ( ExceptT )
 import Control.Monad.Trans.Maybe ( MaybeT )
 import Control.Monad.Reader ( ReaderT )
 import Control.Monad.State ( StateT )
+import Control.Monad.Trans.Identity ( IdentityT )
 import Control.Monad.Writer ( WriterT )
 
 import Agda.TypeChecking.Monad.Base
@@ -32,6 +33,7 @@ class
 instance PureTCM TCM where
 instance PureTCM m => PureTCM (BlockT m)
 instance PureTCM m => PureTCM (ExceptT e m)
+instance PureTCM m => PureTCM (IdentityT m)
 instance PureTCM m => PureTCM (ListT m)
 instance PureTCM m => PureTCM (MaybeT m)
 instance PureTCM m => PureTCM (ReaderT r m)

--- a/src/full/Agda/TypeChecking/Monad/Pure.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Pure.hs-boot
@@ -3,6 +3,7 @@ module Agda.TypeChecking.Monad.Pure where
 
 import Control.Monad.Reader ( ReaderT )
 import Control.Monad.State ( StateT )
+import Control.Monad.Trans.Identity ( IdentityT )
 import Control.Monad.Writer ( WriterT )
 
 import Agda.TypeChecking.Monad.Base
@@ -22,7 +23,7 @@ class
   ) => PureTCM m where
 
 instance PureTCM TCM where
+instance PureTCM m => PureTCM (IdentityT m)
 instance PureTCM m => PureTCM (ReaderT r m)
 instance (PureTCM m, Monoid w) => PureTCM (WriterT w m)
 instance PureTCM m => PureTCM (StateT s m)
-

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -6,6 +6,7 @@ import Prelude hiding (null)
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
+import Control.Monad.Trans.Identity
 import Control.Monad.Writer
 
 import qualified Data.Set as Set
@@ -106,6 +107,9 @@ class (MonadTCEnv m, ReadTCState m) => MonadTrace m where
     :: (MonadTrans t, MonadTrace n, t n ~ m)
     => RemoveTokenBasedHighlighting -> HighlightingInfo -> m ()
   printHighlightingInfo r i = lift $ printHighlightingInfo r i
+
+instance MonadTrace m => MonadTrace (IdentityT m) where
+  traceClosureCall c f = IdentityT $ traceClosureCall c $ runIdentityT f
 
 instance MonadTrace m => MonadTrace (ReaderT r m) where
   traceClosureCall c f = ReaderT $ \r -> traceClosureCall c $ runReaderT f r


### PR DESCRIPTION
The default `MonadTrans` implementations simplify a few of the listed instances. The missing `IdentityT` instances are not particularly important, but are useful to have around when experimenting.