### PR TITLE
Remove unnecessary `LANGUAGE` pragmas

### DIFF
--- a/src/data/MAlonzo/src/MAlonzo/RTE.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP       #-}
 {-# LANGUAGE PolyKinds #-}
 
 module MAlonzo.RTE where

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE NoMonoLocalBinds #-}  -- counteract MonoLocalBinds implied by TypeFamilies
-
 {-# OPTIONS_GHC -fno-cse #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -299,6 +297,7 @@ runInteraction (IOTCM current highlighting highlightingMethod cmd) =
         putResponse . Resp_InteractionPoints =<< gets theInteractionPoints
 
   where
+    inEmacs :: forall a. CommandM a -> CommandM a
     inEmacs = liftCommandMT $ withEnv $ initEnv
             { envHighlightingLevel  = highlighting
             , envHighlightingMethod = highlightingMethod

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 -- | Basic data types for library management.
 
 module Agda.Interaction.Library.Base where

--- a/src/full/Agda/Interaction/Options.hs
+++ b/src/full/Agda/Interaction/Options.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP       #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE NoMonoLocalBinds #-}  -- counteract MonoLocalBinds implied by TypeFamilies
 
 module Agda.Interaction.Options
     ( CommandLineOptions(..)
@@ -369,6 +368,7 @@ checkOpts opts
   | otherwise = return opts
   where
   matches = length . filter ($ opts)
+  optionChanged :: Eq a => (CommandLineOptions -> a) -> Bool
   optionChanged opt = ((/=) `on` opt) opts defaultOptions
 
   atMostOne =

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable         #-}
 
 {-| Abstract names carry unique identifiers and stuff.
 -}

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE GADTs                     #-}
-{-# LANGUAGE NoMonoLocalBinds          #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
 
 module Agda.Syntax.Abstract.Views where
 
@@ -107,27 +104,41 @@ deepUnscopeDecl d                                = [deepUnscope d]
 -- * Traversal
 ---------------------------------------------------------------------------
 
+-- Type aliases to abbreviate the quantified foralls which we use to avoid
+-- giving in to NoMonoLocalBinds.
+type RecurseExprFn m a = Applicative m => (Expr -> m Expr -> m Expr) -> a -> m a
+type RecurseExprRecFn m = forall a. ExprLike a => a -> m a
+
+type FoldExprFn m a = Monoid m => (Expr -> m) -> a -> m
+type FoldExprRecFn m = forall a. ExprLike a => a -> m
+
+type TraverseExprFn m a = (Applicative m, Monad m) => (Expr -> m Expr) -> a -> m a
+type TraverseExprRecFn m = forall a. ExprLike a => a -> m a
+
 -- | Apply an expression rewriting to every subexpression, inside-out.
 --   See "Agda.Syntax.Internal.Generic".
 class ExprLike a where
   -- | The first expression is pre-traversal, the second one post-traversal.
-  recurseExpr :: (Applicative m) => (Expr -> m Expr -> m Expr) -> a -> m a
+  recurseExpr :: RecurseExprFn m a
   default recurseExpr :: (Traversable f, ExprLike a', a ~ f a', Applicative m)
                       => (Expr -> m Expr -> m Expr) -> a -> m a
   recurseExpr = traverse . recurseExpr
 
-  foldExpr :: Monoid m => (Expr -> m) -> a -> m
+  foldExpr :: FoldExprFn m a
   foldExpr f = getConst . recurseExpr (\ pre post -> Const (f pre) <* post)
 
-  traverseExpr :: (Applicative m, Monad m) => (Expr -> m Expr) -> a -> m a
+  traverseExpr :: TraverseExprFn m a
   traverseExpr f = recurseExpr (\ pre post -> f =<< post)
 
   mapExpr :: (Expr -> Expr) -> (a -> a)
   mapExpr f = runIdentity . traverseExpr (Identity . f)
 
 instance ExprLike Expr where
+  recurseExpr :: forall m. RecurseExprFn m Expr
   recurseExpr f e0 = f e0 $ do
-    let recurse e = recurseExpr f e
+    let
+      recurse :: RecurseExprRecFn m
+      recurse e = recurseExpr f e
     case e0 of
       Var{}                   -> pure e0
       Def'{}                  -> pure e0
@@ -158,6 +169,7 @@ instance ExprLike Expr where
       Tactic ei e xs          -> Tactic ei <$> recurse e <*> recurse xs
       Macro{}                 -> pure e0
 
+  foldExpr :: forall m. FoldExprFn m Expr
   foldExpr f e =
     case e of
       Var{}                -> m
@@ -189,11 +201,15 @@ instance ExprLike Expr where
       Tactic _ e xs        -> m `mappend` fold e `mappend` fold xs
       DontCare e           -> m `mappend` fold e
    where
-     m    = f e
+     m = f e
+     fold :: FoldExprRecFn m
      fold = foldExpr f
 
+  traverseExpr :: forall m. TraverseExprFn m Expr
   traverseExpr f e = do
-    let trav e = traverseExpr f e
+    let
+      trav :: TraverseExprRecFn m
+      trav e = traverseExpr f e
     case e of
       Var{}                   -> f e
       Def'{}                  -> f e
@@ -288,8 +304,11 @@ instance ExprLike TypedBinding where
       TLet r ds      -> TLet r <$> traverseExpr f ds
 
 instance ExprLike LetBinding where
+  recurseExpr :: forall m. RecurseExprFn m LetBinding
   recurseExpr f e = do
-    let recurse e = recurseExpr f e
+    let
+      recurse :: RecurseExprRecFn m
+      recurse e = recurseExpr f e
     case e of
       LetBind li ai x e e'  -> LetBind li ai x <$> recurse e <*> recurse e'
       LetPatBind li p e     -> LetPatBind li <$> recurse p <*> recurse e
@@ -297,6 +316,7 @@ instance ExprLike LetBinding where
       LetOpen{}             -> pure e
       LetDeclaredVariable _ -> pure e
 
+  foldExpr :: forall m. FoldExprFn m LetBinding
   foldExpr f e =
     case e of
       LetBind _ _ _ e e'    -> fold e `mappend` fold e'
@@ -304,10 +324,15 @@ instance ExprLike LetBinding where
       LetApply{}            -> mempty
       LetOpen{}             -> mempty
       LetDeclaredVariable _ -> mempty
-    where fold e = foldExpr f e
+    where
+      fold :: FoldExprRecFn m
+      fold e = foldExpr f e
 
+  traverseExpr :: forall m. TraverseExprFn m LetBinding
   traverseExpr f e = do
-    let trav e = traverseExpr f e
+    let
+      trav :: TraverseExprRecFn m
+      trav e = traverseExpr f e
     case e of
       LetBind li ai x e e'  -> LetBind li ai x <$> trav e <*> trav e'
       LetPatBind li p e     -> LetPatBind li <$> trav p <*> trav e
@@ -318,17 +343,23 @@ instance ExprLike LetBinding where
 instance ExprLike a => ExprLike (Pattern' a) where
 
 instance ExprLike a => ExprLike (Clause' a) where
+  recurseExpr :: forall m. RecurseExprFn m (Clause' a)
   recurseExpr f (Clause lhs spats rhs ds ca) = Clause <$> rec lhs <*> pure spats <*> rec rhs <*> rec ds <*> pure ca
-    where rec = recurseExpr f
+    where
+      rec :: RecurseExprRecFn m
+      rec = recurseExpr f
 
 instance ExprLike RHS where
+  recurseExpr :: forall m. RecurseExprFn m RHS
   recurseExpr f rhs =
     case rhs of
       RHS e c                 -> RHS <$> rec e <*> pure c
       AbsurdRHS{}             -> pure rhs
       WithRHS x es cs         -> WithRHS x <$> rec es <*> rec cs
       RewriteRHS xes spats rhs ds -> RewriteRHS <$> rec xes <*> pure spats <*> rec rhs <*> rec ds
-    where rec e = recurseExpr f e
+    where
+      rec :: RecurseExprRecFn m
+      rec e = recurseExpr f e
 
 instance (ExprLike qn, ExprLike p, ExprLike e) => ExprLike (RewriteEqn' qn p e) where
   recurseExpr f = \case
@@ -339,13 +370,17 @@ instance ExprLike WhereDeclarations where
   recurseExpr f (WhereDecls a b) = WhereDecls a <$> recurseExpr f b
 
 instance ExprLike ModuleApplication where
+  recurseExpr :: forall m. RecurseExprFn m ModuleApplication
   recurseExpr f a =
     case a of
       SectionApp tel m es -> SectionApp <$> rec tel <*> rec m <*> rec es
       RecordModuleInstance{} -> pure a
-    where rec e = recurseExpr f e
+    where
+      rec :: RecurseExprRecFn m
+      rec e = recurseExpr f e
 
 instance ExprLike Pragma where
+  recurseExpr :: forall m. RecurseExprFn m Pragma
   recurseExpr f p =
     case p of
       BuiltinPragma s x           -> pure p
@@ -358,7 +393,9 @@ instance ExprLike Pragma where
       InlinePragma{}              -> pure p
       EtaPragma{}                 -> pure p
       DisplayPragma f xs e        -> DisplayPragma f <$> rec xs <*> rec e
-    where rec e = recurseExpr f e
+    where
+      rec :: RecurseExprRecFn m
+      rec e = recurseExpr f e
 
 instance ExprLike LHS where
   recurseExpr f (LHS i p) = LHS i <$> recurseExpr f p
@@ -370,6 +407,7 @@ instance ExprLike SpineLHS where
   recurseExpr f (SpineLHS i x ps) = SpineLHS i x <$> recurseExpr f ps
 
 instance ExprLike Declaration where
+  recurseExpr :: forall m. RecurseExprFn m Declaration
   recurseExpr f d =
     case d of
       Axiom a d i mp x e        -> Axiom a d i mp x <$> rec e
@@ -391,7 +429,9 @@ instance ExprLike Declaration where
       UnquoteDecl i is xs e     -> UnquoteDecl i is xs <$> rec e
       UnquoteDef i xs e         -> UnquoteDef i xs <$> rec e
       ScopedDecl s ds           -> ScopedDecl s <$> rec ds
-    where rec e = recurseExpr f e
+    where
+      rec :: RecurseExprRecFn m
+      rec e = recurseExpr f e
 
 
 -- * Getting all declared names

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 
 {-| Some common syntactic entities are defined in this module.

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 
 {-| The concrete syntax is a raw representation of the program text
     without any desugaring at all.  This is what the parser produces.

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoMonoLocalBinds #-}  -- counteract MonoLocalBinds implied by TypeFamilies
 
 -- | Generic traversal and reduce for concrete syntax,
 --   in the style of "Agda.Syntax.Internal.Generic".
@@ -141,7 +140,9 @@ instance ExprLike Expr where
      Equal{}            -> f $ e0
      Ellipsis{}         -> f $ e0
      Generalized e      -> f $ Generalized            $ mapE e
-   where mapE e = mapExpr f e
+   where
+     mapE :: ExprLike e => e -> e
+     mapE = mapExpr f
 
   foldExpr     = __IMPOSSIBLE__
   traverseExpr = __IMPOSSIBLE__
@@ -160,7 +161,9 @@ instance ExprLike a => ExprLike (OpApp a) where
   mapExpr f = \case
      SyntaxBindingLambda r bs e -> SyntaxBindingLambda r (mapE bs) $ mapE e
      Ordinary                 e -> Ordinary                        $ mapE e
-   where mapE e = mapExpr f e
+   where
+     mapE :: ExprLike e => e -> e
+     mapE = mapExpr f
   foldExpr     = __IMPOSSIBLE__
   traverseExpr = __IMPOSSIBLE__
 
@@ -175,7 +178,9 @@ instance ExprLike LamBinding where
 instance ExprLike LHS where
   mapExpr f = \case
      LHS ps res wes ell -> LHS ps (mapE res) (mapE wes) ell
-   where mapE e = mapExpr f e
+   where
+     mapE :: ExprLike a => a -> a
+     mapE = mapExpr f
   foldExpr     = __IMPOSSIBLE__
   traverseExpr = __IMPOSSIBLE__
 
@@ -203,7 +208,9 @@ instance ExprLike ModuleApplication where
   mapExpr f = \case
      SectionApp r bs e -> SectionApp r (mapE bs) $ mapE e
      e@RecordModuleInstance{} -> e
-   where mapE e = mapExpr f e
+   where
+     mapE :: ExprLike e => e -> e
+     mapE = mapExpr f
   foldExpr     = __IMPOSSIBLE__
   traverseExpr = __IMPOSSIBLE__
 
@@ -240,7 +247,9 @@ instance ExprLike Declaration where
      UnquoteDecl r x e         -> UnquoteDecl r x (mapE e)
      UnquoteDef r x e          -> UnquoteDef r x (mapE e)
      e@Pragma{}                -> e
-   where mapE e = mapExpr f e
+   where
+     mapE :: ExprLike e => e -> e
+     mapE = mapExpr f
 
   foldExpr     = __IMPOSSIBLE__
   traverseExpr = __IMPOSSIBLE__

--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 {-| Names in the concrete syntax are just strings (or lists of strings for

--- a/src/full/Agda/Syntax/Fixity.hs
+++ b/src/full/Agda/Syntax/Fixity.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 
 {-| Definitions for fixity, precedence levels, and declared syntax.
 -}

--- a/src/full/Agda/Syntax/Info.hs
+++ b/src/full/Agda/Syntax/Info.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable         #-}
 
 {-| An info object contains additional information about a piece of abstract
     syntax that isn't part of the actual syntax. For instance, it might contain

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE PatternSynonyms            #-}
 
 module Agda.Syntax.Internal

--- a/src/full/Agda/Syntax/Literal.hs
+++ b/src/full/Agda/Syntax/Literal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 
 module Agda.Syntax.Literal where
 

--- a/src/full/Agda/Syntax/Parser/Comments.hs
+++ b/src/full/Agda/Syntax/Parser/Comments.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoMonoLocalBinds #-}  -- counteract MonoLocalBinds implied by TypeFamilies
 
 {-| This module defines the lex action to lex nested comments. As is well-known
     this cannot be done by regular expressions (which, incidently, is probably
@@ -48,6 +47,7 @@ nestedComment inp inp' _ =
          else
           lexToken
     where
+        err :: forall a. String -> LookAhead a
         err _ = liftP $ parseErrorAt (lexPos inp) "Unterminated '{-'"
 
 -- | Lex a hole (@{! ... !}@). Holes can be nested.
@@ -61,6 +61,7 @@ hole inp inp' _ =
           TokSymbol SymQuestionMark $
           posToInterval (lexSrcFile inp) (lexPos inp) p
     where
+        err :: forall a. String -> LookAhead a
         err _ = liftP $ parseErrorAt (lexPos inp) "Unterminated '{!'"
 
 -- | Skip a block of text enclosed by the given open and close strings. Assumes

--- a/src/full/Agda/Syntax/Parser/Monad.hs
+++ b/src/full/Agda/Syntax/Parser/Monad.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable    #-}
 
 module Agda.Syntax.Parser.Monad
     ( -- * The parser monad

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE NoMonomorphismRestriction  #-}
 

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE NoMonomorphismRestriction  #-}
 
 {-| Position information for syntax. Crucial for giving good error messages.
 -}

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE GADTs              #-}
 
 {-| This module defines the notion of a scope and operations on scopes.

--- a/src/full/Agda/Syntax/Treeless.hs
+++ b/src/full/Agda/Syntax/Treeless.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 -- | The treeless syntax is intended to be used as input for the compiler backends.

--- a/src/full/Agda/Termination/RecCheck.hs
+++ b/src/full/Agda/Termination/RecCheck.hs
@@ -11,7 +11,6 @@
    This implementation by Andreas.
 -}
 
-{-# LANGUAGE CPP #-}
 
 module Agda.Termination.RecCheck
     ( recursive

--- a/src/full/Agda/TypeChecking/CompiledClause.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
 -- | Case trees.
 --
 --   After coverage checking, pattern matching is translated

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE NoMonoLocalBinds #-}  -- counteract MonoLocalBinds implied by TypeFamilies
 
 {-| Coverage checking, case splitting, and splitting for refine tactics.
 
@@ -624,6 +623,7 @@ createMissingHCompClause f n x old_sc (SClause tel ps _sigma' cps (Just t)) = se
   io      <- fromMaybe __IMPOSSIBLE__ <$> getTerm' builtinIOne
   iz      <- fromMaybe __IMPOSSIBLE__ <$> getTerm' builtinIZero
   let
+    cannotCreate :: forall m a. (MonadTCEnv m, ReadTCState m, MonadError TCErr m) => Doc -> Closure (Abs Type) -> m a
     cannotCreate doc t = do
       typeError . SplitError $ CannotCreateMissingClause f (tel,fromSplitPatterns ps) doc t
   let old_ps = patternsToElims $ fromSplitPatterns $ scPats old_sc

--- a/src/full/Agda/TypeChecking/Coverage/SplitTree.hs
+++ b/src/full/Agda/TypeChecking/Coverage/SplitTree.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable         #-}
 
 {-| Split tree for transforming pattern clauses into case trees.
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -468,6 +468,7 @@ instance PrettyTCM TypeError where
         pwords "Previous definition of" ++ [help m] ++ pwords "module" ++ [prettyTCM x] ++
         pwords "at" ++ [prettyTCM r]
       where
+        help :: MonadPretty m => ModuleName -> m Doc
         help m = caseMaybeM (isDatatypeModule m) empty $ \case
           IsDataModule   -> "(datatype)"
           IsRecordModule -> "(record)"
@@ -1254,6 +1255,7 @@ instance PrettyUnequal Type where
   prettyUnequal t1 ncmp t2 = prettyUnequal (unEl t1) ncmp (unEl t2)
 
 instance PrettyTCM SplitError where
+  prettyTCM :: forall m. MonadPretty m => SplitError -> m Doc
   prettyTCM err = case err of
     NotADatatype t -> enterClosure t $ \ t -> fsep $
       pwords "Cannot split on argument of non-datatype" ++ [prettyTCM t]
@@ -1300,6 +1302,7 @@ instance PrettyTCM SplitError where
         -- Andreas, 2019-08-08, issue #3943
         -- To not print hidden indices just as {_}, we strip the Arg and print
         -- the hiding information manually.
+        prEq :: Arg Term -> Arg Term -> m Doc
         prEq cIx gIx = addContext tel $ nest 2 $ hsep [ pr cIx , "≟" , pr gIx ]
         pr arg = prettyRelevance arg . prettyHiding arg id <$> prettyTCM (unArg arg)
 
@@ -1318,6 +1321,7 @@ instance PrettyTCM SplitError where
       pwords "Case to handle:") $$ nest 2 (vcat $ [display cl])
                                 $$ ((pure msg <+> enterClosure t displayAbs) <> ".")
         where
+        displayAbs :: Abs Type -> m Doc
         displayAbs (Abs x t) = addContext x $ prettyTCM t
         displayAbs (NoAbs x t) = prettyTCM t
         display (tel, ps) = prettyTCM $ NamedClause f True $

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NoMonoLocalBinds #-}  -- counteract MonoLocalBinds implied by TypeFamilies
-
 {- |
 
 "Injectivity", or more precisely, "constructor headedness", is a
@@ -345,10 +343,12 @@ useInjectivity dir blocker ty blk neu = locallyTC eInjectivityDepth succ $ do
     fallback     = addConstraint blocker $ app (ValueCmp cmp ty) blk neu
     success blk' = app (compareAs cmp ty) blk' neu
 
-    (cmp, app) = case dir of
+    cmpApp :: (Comparison, (a -> a -> b) -> a -> a -> b)
+    cmpApp = case dir of
       DirEq -> (CmpEq, id)
       DirLeq -> (CmpLeq, id)
       DirGeq -> (CmpLeq, flip)
+    (cmp, app) = cmpApp
 
 -- | The second argument should be a blocked application and the third argument
 --   the inverse of the applied function.

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 module Agda.TypeChecking.Lock
   ( isTimeless

--- a/src/full/Agda/TypeChecking/Lock.hs-boot
+++ b/src/full/Agda/TypeChecking/Lock.hs-boot
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 module Agda.TypeChecking.Lock where
 

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoMonoLocalBinds #-}  -- counteract MonoLocalBinds implied by TypeFamilies
 
 module Agda.TypeChecking.MetaVars.Mention where
 
@@ -30,7 +29,8 @@ instance MentionsMeta Term where
     DontCare v   -> False   -- we don't have to look inside don't cares when deciding to wake constraints
     MetaV y args -> HashSet.member y xs || mm args   -- TODO: we really only have to look one level deep at meta args
     where
-      mm v = mentionsMetas xs v
+      mm :: forall t. MentionsMeta t => t -> Bool
+      mm = mentionsMetas xs
 
 instance MentionsMeta Level where
   mentionsMetas xs (Max _ as) = mentionsMetas xs as
@@ -121,7 +121,8 @@ instance MentionsMeta Constraint where
     CheckLockedVars a b c d -> mm ((a, b), (c, d))
     UsableAtModality mod t -> mm t
     where
-      mm v = mentionsMetas xs v
+      mm :: forall t. MentionsMeta t => t -> Bool
+      mm = mentionsMetas xs
 
 instance MentionsMeta CompareAs where
   mentionsMetas xs = \case

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE NondecreasingIndentation  #-}
 
 {- | The occurs check for unification.  Does pruning on the fly.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DeriveDataTypeable         #-}
 
 module Agda.TypeChecking.Monad.Base where
 

--- a/src/full/Agda/TypeChecking/Monad/Context.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs-boot
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}  -- for type equality ~
 
 module Agda.TypeChecking.Monad.Context where
 

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeFamilies #-} -- for type equality ~
 
 module Agda.TypeChecking.Monad.Signature where
 

--- a/src/full/Agda/TypeChecking/Monad/Statistics.hs
+++ b/src/full/Agda/TypeChecking/Monad/Statistics.hs
@@ -1,7 +1,5 @@
 -- | Collect statistics.
 
-{-# LANGUAGE DefaultSignatures #-}
-
 module Agda.TypeChecking.Monad.Statistics
     ( MonadStatistics(..), tick, tickN, tickMax, getStatistics, modifyStatistics, printStatistics
     ) where

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeFamilies #-} -- for type equality ~
-
 -- | Computing the polarity (variance) of function arguments,
 --   for the sake of subtyping.
 

--- a/src/full/Agda/TypeChecking/Positivity/Occurrence.hs
+++ b/src/full/Agda/TypeChecking/Positivity/Occurrence.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
-
 -- | Occurrences.
 
 module Agda.TypeChecking.Positivity.Occurrence

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE MonoLocalBinds             #-}
 
 {-| Primitive functions, such as addition on builtin integers.
 -}

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE NoMonoLocalBinds #-}  -- counteract MonoLocalBinds implied by TypeFamilies
 
 module Agda.TypeChecking.Rules.Builtin
   ( bindBuiltin
@@ -606,6 +605,7 @@ bindPostulatedName builtin x m = do
     Axiom {} -> bindBuiltinName builtin =<< m q def
     _        -> err
   where
+  err :: forall m a. MonadTCError m => m a
   err = typeError $ GenericError $
           "The argument to BUILTIN " ++ builtin ++
           " must be a postulated name"
@@ -841,7 +841,9 @@ bindBuiltin b x = do
   unlessM ((0 ==) <$> getContextSize) $ do
     -- Andreas, 2017-11-01, issue #2824
     -- Only raise an error if the name for the builtin is defined in a parametrized module.
-    let failure = typeError $ BuiltinInParameterisedModule b
+    let
+      failure :: forall m a. MonadTCError m => m a
+      failure = typeError $ BuiltinInParameterisedModule b
     -- Get the non-empty list of AbstractName for x
     xs <- case x of
       VarName{}            -> failure

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE NoMonoLocalBinds #-}  -- counteract MonoLocalBinds implied by TypeFamilies
 
 module Agda.TypeChecking.Rules.Term where
 
@@ -847,7 +846,8 @@ catchIlltypedPatternBlockedOnMeta m handle = do
 
   m `catchError` \ err -> do
 
-    let reraise = throwError err
+    let reraise :: MonadError TCErr m => m a
+        reraise = throwError err
 
     -- Get the blocker responsible for the type error.
     -- If we do not find a blocker or the error should not be handled,

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE NoMonoLocalBinds #-}  -- counteract MonoLocalBinds implied by TypeFamilies
 
 module Agda.TypeChecking.SizedTypes where
 
@@ -240,7 +239,8 @@ trySizeUniv
   => Comparison -> CompareAs -> Term -> Term
   -> QName -> Elims -> QName -> Elims -> m ()
 trySizeUniv cmp t m n x els1 y els2 = do
-  let failure = typeError $ UnequalTerms cmp m n t
+  let failure :: forall m a. MonadTCError m => m a
+      failure = typeError $ UnequalTerms cmp m n t
       forceInfty u = compareSizes CmpEq (unArg u) =<< primSizeInf
   -- Get the SIZE built-ins.
   (size, sizelt) <- flip catchError (const failure) $ do

--- a/src/full/Agda/TypeChecking/SizedTypes/WarshallSolver.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/WarshallSolver.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoMonomorphismRestriction #-}
 
 module Agda.TypeChecking.SizedTypes.WarshallSolver where
 

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NondecreasingIndentation #-}
-{-# LANGUAGE NoMonoLocalBinds #-}  -- counteract MonoLocalBinds implied by TypeFamilies
 
 module Agda.TypeChecking.With where
 
@@ -546,6 +545,7 @@ stripWithClausePatterns cxtNames parent f t delta qs npars perm ps = do
           (e, t') <- piOrPathApplyM t v
           strip (self `applyE` e) t' ps qs
 
+        mismatch :: forall m a. (MonadAddContext m, MonadTCError m) => m a
         mismatch = addContext delta $ typeError $
           WithClausePatternMismatch (namedArg p0) q
         mismatchOrigin o o' = addContext delta . typeError . GenericDocError =<< fsep

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoMonomorphismRestriction #-}
 
 -- | Tools for benchmarking and accumulating results.
 --   Nothing Agda-specific in here.

--- a/src/full/Agda/Utils/Empty.hs
+++ b/src/full/Agda/Utils/Empty.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
 -- | An empty type with some useful instances.
 module Agda.Utils.Empty where
 

--- a/src/full/Agda/Utils/FileName.hs
+++ b/src/full/Agda/Utils/FileName.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DeriveDataTypeable         #-}
 
 {-| Operations on file names. -}
 module Agda.Utils.FileName

--- a/src/full/Agda/Utils/Maybe/Strict.hs
+++ b/src/full/Agda/Utils/Maybe/Strict.hs
@@ -5,7 +5,6 @@
 -- especially since it depends on lens which we consciously ruled out.
 
 {-# LANGUAGE CPP                #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 
 

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable    #-}
 
 module Agda.Utils.Permutation where
 

--- a/src/full/Agda/Utils/Pointer.hs
+++ b/src/full/Agda/Utils/Pointer.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 
 module Agda.Utils.Pointer
   ( Ptr, newPtr, derefPtr, setPtr

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -12,9 +12,6 @@
 --    import Agda.Utils.SmallSet (SmallSet)
 -- @
 
-{-# LANGUAGE DeriveDataTypeable #-}
-
-
 module Agda.Utils.SmallSet
   ( SmallSet()
   , Ix

--- a/src/release-tools/closed-issues-for-milestone/Main.hs
+++ b/src/release-tools/closed-issues-for-milestone/Main.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE NamedFieldPuns            #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings         #-}
 
 module Main ( main ) where

--- a/src/size-solver/Main.hs
+++ b/src/size-solver/Main.hs
@@ -1,7 +1,6 @@
 -- Andreas, 2016-02-01 KEEP in compilation loop to prevent bit-rotting.
 
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Standalone program for testing size constraint solver.

--- a/src/size-solver/Parser.hs
+++ b/src/size-solver/Parser.hs
@@ -5,7 +5,6 @@
 
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
 
 
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE DoAndIfThenElse      #-}
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE PatternGuards        #-}

--- a/test/Internal/Interaction/Library.hs
+++ b/test/Internal/Interaction/Library.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Internal.Interaction.Library ( tests ) where

--- a/test/Internal/Termination/CallMatrix.hs
+++ b/test/Internal/Termination/CallMatrix.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell            #-}
 
 module Internal.Termination.CallMatrix

--- a/test/Internal/TypeChecking/Free.hs
+++ b/test/Internal/TypeChecking/Free.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable        #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE TemplateHaskell           #-}
 {-# LANGUAGE CPP                       #-}

--- a/test/Internal/TypeChecking/Free.hs
+++ b/test/Internal/TypeChecking/Free.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE TemplateHaskell           #-}
 {-# LANGUAGE CPP                       #-}
 

--- a/test/Internal/TypeChecking/Free/Lazy.hs
+++ b/test/Internal/TypeChecking/Free/Lazy.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Internal.TypeChecking.Free.Lazy () where
 

--- a/test/Internal/TypeChecking/Generators.hs
+++ b/test/Internal/TypeChecking/Generators.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies    #-}
 
 module Internal.TypeChecking.Generators where
 

--- a/test/Internal/TypeChecking/Substitute.hs
+++ b/test/Internal/TypeChecking/Substitute.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies    #-}
 
 module Internal.TypeChecking.Substitute ( tests ) where
 

--- a/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoMonomorphismRestriction  #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE CPP                        #-}

--- a/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoMonomorphismRestriction  #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE CPP                        #-}
 

--- a/test/Internal/Utils/PartialOrd.hs
+++ b/test/Internal/Utils/PartialOrd.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell            #-}
 
 module Internal.Utils.PartialOrd

--- a/test/Internal/Utils/Permutation.hs
+++ b/test/Internal/Utils/Permutation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE CPP                #-}
 


### PR DESCRIPTION
Some of these are now under `default-extensions`. Some like `NoMonomorphismRestriction` or `NoMonoLocalBinds` are nice to remove just for overall consistency of the codebase and basically just came down to annotating some types.