### PR TITLE
util: Type-agnostic Agda.Utils.WithDefault/TypeLits

### DIFF
--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PolyKinds            #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Agda.TypeChecking.Serialise.Instances.Common (SerialisedRange(..)) where
@@ -200,7 +201,7 @@ instance EmbPrj a => EmbPrj (Position' a) where
 
   value = valueN P.Pn
 
-instance Typeable b => EmbPrj (WithDefault b) where
+instance (EmbPrj t, Typeable (b :: t)) => EmbPrj (WithDefault b) where
   icod_ = \case
     Default -> icodeN' Default
     Value b -> icodeN' Value b

--- a/src/full/Agda/Utils/TypeLits.hs
+++ b/src/full/Agda/Utils/TypeLits.hs
@@ -5,7 +5,10 @@
 
 -- | Type level literals, inspired by GHC.TypeLits.
 
-module Agda.Utils.TypeLits where
+module Agda.Utils.TypeLits
+  ( KnownBool
+  , boolVal
+  ) where
 
 -- | Singleton for type level booleans.
 

--- a/src/full/Agda/Utils/TypeLits.hs
+++ b/src/full/Agda/Utils/TypeLits.hs
@@ -1,37 +1,27 @@
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE DataKinds      #-}
-{-# LANGUAGE GADTs          #-}
-
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
 
 -- | Type level literals, inspired by GHC.TypeLits.
 
 module Agda.Utils.TypeLits
   ( KnownBool
   , boolVal
+  , KnownVal
+  , knownVal
   ) where
 
--- | Singleton for type level booleans.
+-- | Singleton for type level values.
+-- | A known value is one we can obtain a singleton for.
 
-data SBool (b :: Bool) where
-  STrue  :: SBool 'True
-  SFalse :: SBool 'False
+class KnownVal (v :: t) where
+  knownVal :: forall proxy. proxy v -> t
 
-eraseSBool :: SBool b -> Bool
-eraseSBool = \case
-  STrue  -> True
-  SFalse -> False
+-- | Type-level booleans.
 
--- | A known boolean is one we can obtain a singleton for.
---   Concrete values are trivially known.
+instance KnownVal 'True  where knownVal _ = True
+instance KnownVal 'False where knownVal _ = False
 
-class KnownBool (b :: Bool) where
-  boolSing :: SBool b
-
-instance KnownBool 'True where
-  boolSing = STrue
-
-instance KnownBool 'False where
-  boolSing = SFalse
+type KnownBool (b :: Bool) = KnownVal b
 
 boolVal :: forall proxy b. KnownBool b => proxy b -> Bool
-boolVal _ = eraseSBool (boolSing :: SBool b)
+boolVal = knownVal

--- a/src/full/Agda/Utils/WithDefault.hs
+++ b/src/full/Agda/Utils/WithDefault.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE DataKinds      #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
 
 -- | Potentially uninitialised Booleans
 
@@ -15,19 +15,19 @@ module Agda.Utils.WithDefault
   , collapseDefault
   ) where
 
-import Agda.Utils.TypeLits (KnownBool, boolVal)
+import Agda.Utils.TypeLits (KnownVal, knownVal)
 
 -- We don't want to have to remember for each flag whether its default value
 -- is True or False. So we bake it into the representation: the flag's type
 -- will mention its default value as a phantom parameter.
 
-data WithDefault (b :: Bool) = Default | Value Bool
+data WithDefault (b :: t) = Default | Value t
   deriving (Eq, Show)
 
 -- The main mode of operation of these flags, apart from setting them explicitly,
 -- is to toggle them one way or the other if they hadn't been already.
 
-setDefault :: Bool -> WithDefault b -> WithDefault b
+setDefault :: t -> WithDefault (b :: t) -> WithDefault b
 setDefault b = \case
   Default -> Value b
   t -> t
@@ -35,7 +35,7 @@ setDefault b = \case
 -- Provided that the default value is a known boolean (in practice we only use
 -- True or False), we can collapse a potentially uninitialised value to a boolean.
 
-collapseDefault :: KnownBool b => WithDefault b -> Bool
+collapseDefault :: KnownVal (b :: t) => WithDefault b -> t
 collapseDefault = \case
-  w@Default -> boolVal w
+  w@Default -> knownVal w
   Value b -> b

--- a/src/full/Agda/Utils/WithDefault.hs
+++ b/src/full/Agda/Utils/WithDefault.hs
@@ -9,9 +9,13 @@
 -- overriden (e.g. --cubical implies --without-K) while in the other case the
 -- user has made a mistake which they need to fix.
 
-module Agda.Utils.WithDefault where
+module Agda.Utils.WithDefault
+  ( WithDefault (Default, Value)
+  , setDefault
+  , collapseDefault
+  ) where
 
-import Agda.Utils.TypeLits
+import Agda.Utils.TypeLits (KnownBool, boolVal)
 
 -- We don't want to have to remember for each flag whether its default value
 -- is True or False. So we bake it into the representation: the flag's type


### PR DESCRIPTION
In some experimental code, I wanted to use the `WithDefault` stuff in `CommandLineOptions` for a non-`Bool` type, but couldn't.

Note that it does not use `Generic` or `DataTypeable`, so the instances still have to be declared manually; but they're pretty easy to do. Perhaps someone could improve this with those.

This maintains the existing interface, but allows other types to be used with them. For example, like:
```hs
instance KnownVal 'AsciiOnly where knownVal _ = AsciiOnly
instance KnownVal 'UnicodeOk where knownVal _ = UnicodeOk

data PragmaOptions = PragmaOptions
  { _optUseUnicode :: WithDefault 'UnicodeOk
  }

defaultPragmaOptions = PragmaOptions { _optUseUnicode = Default }

optUseUnicode :: PragmaOptions -> UnicodeOrAscii
optUseUnicode = collapseDefault . _optUseUnicode
```