### PR TITLE
Refact: Explicit operations and initial values on modalities

### DIFF
--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -371,9 +371,6 @@ data Modality = Modality
       --   Currently only the comonad is implemented.
   } deriving (Data, Eq, Ord, Show, Generic)
 
-defaultModality :: Modality
-defaultModality = Modality defaultRelevance defaultQuantity defaultCohesion
-
 -- | Pointwise composition.
 instance Semigroup Modality where
   (<>) = composeModality
@@ -447,6 +444,12 @@ unitModality = Modality unitRelevance unitQuantity unitCohesion
 -- | Absorptive element under addition.
 topModality :: Modality
 topModality = Modality topRelevance topQuantity topCohesion
+
+-- | The default Modality
+--   Beware that this is neither the additive unit nor the unit under
+--   composition, because the default quantity is ω.
+defaultModality :: Modality
+defaultModality = Modality defaultRelevance defaultQuantity defaultCohesion
 
 -- | Equality ignoring origin.
 
@@ -712,9 +715,6 @@ data Quantity
   deriving (Data, Show, Generic, Eq, Ord)
     -- @Ord@ instance in case @Quantity@ is used in keys for maps etc.
 
-defaultQuantity :: Quantity
-defaultQuantity = topQuantity
-
 -- | Equality ignoring origin.
 
 sameQuantity :: Quantity -> Quantity -> Bool
@@ -768,10 +768,17 @@ addQuantity = curry $ \case
   -- 1 + 1 = ω
   (Quantity1 _, Quantity1 _) -> topQuantity
 
+-- | Identity element under addition
 zeroQuantity :: Quantity
 zeroQuantity = Quantity0 mempty
 
--- | Identity element
+-- | Absorptive element!
+--   This differs from Relevance and Cohesion whose default
+--   is the multiplicative unit.
+defaultQuantity :: Quantity
+defaultQuantity = topQuantity
+
+-- | Identity element under composition
 unitQuantity :: Quantity
 unitQuantity = Quantity1 mempty
 
@@ -922,9 +929,6 @@ data Relevance
 allRelevances :: [Relevance]
 allRelevances = [minBound..maxBound]
 
-defaultRelevance :: Relevance
-defaultRelevance = Relevant
-
 instance HasRange Relevance where
   getRange _ = noRange
 
@@ -1070,6 +1074,10 @@ unitRelevance = Relevant
 topRelevance :: Relevance
 topRelevance = Relevant
 
+-- | Default Relevance is the identity element under composition
+defaultRelevance :: Relevance
+defaultRelevance = unitRelevance
+
 -- | Irrelevant function arguments may appear non-strictly in the codomain type.
 irrToNonStrict :: Relevance -> Relevance
 irrToNonStrict Irrelevant = NonStrict
@@ -1188,9 +1196,6 @@ data Cohesion
 
 allCohesions :: [Cohesion]
 allCohesions = [minBound..maxBound]
-
-defaultCohesion :: Cohesion
-defaultCohesion = Continuous
 
 instance HasRange Cohesion where
   getRange _ = noRange
@@ -1329,6 +1334,10 @@ unitCohesion = Continuous
 -- | Absorptive element under addition.
 topCohesion :: Cohesion
 topCohesion = Flat
+
+-- | Default Cohesion is the identity element under composition
+defaultCohesion :: Cohesion
+defaultCohesion = unitCohesion
 
 ---------------------------------------------------------------------------
 -- * Origin of arguments (user-written, inserted or reflected)

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -980,10 +980,7 @@ instance PartialOrd Relevance where
 
 -- | @usableRelevance rel == False@ iff we cannot use a variable of @rel@.
 usableRelevance :: LensRelevance a => a -> Bool
-usableRelevance a = case getRelevance a of
-  Irrelevant -> False
-  NonStrict  -> False
-  Relevant   -> True
+usableRelevance = isRelevant
 
 -- | 'Relevance' composition.
 --   'Irrelevant' is dominant, 'Relevant' is neutral.

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -405,7 +405,10 @@ usableModality a = usableRelevance m && usableQuantity m
 
 -- | Multiplicative monoid (standard monoid).
 composeModality :: Modality -> Modality -> Modality
-composeModality (Modality r q c) (Modality r' q' c') = Modality (r <> r') (q <> q') (c <> c')
+composeModality (Modality r q c) (Modality r' q' c') =
+    Modality (r `composeRelevance` r')
+             (q `composeQuantity` q')
+             (c `composeCohesion` c')
 
 -- | Compose with modality flag from the left.
 --   This function is e.g. used to update the modality information

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -380,7 +380,7 @@ instance Semigroup Modality where
 
 -- | Pointwise unit.
 instance Monoid Modality where
-  mempty = Modality mempty mempty mempty
+  mempty = unitModality
   mappend = (<>)
 
 -- | Dominance ordering.
@@ -436,8 +436,13 @@ inverseApplyModality m = mapModality (m `inverseComposeModality`)
 addModality :: Modality -> Modality -> Modality
 addModality (Modality r q c) (Modality r' q' c') = Modality (addRelevance r r') (addQuantity q q') (addCohesion c c')
 
+-- | Identity under addition
 zeroModality :: Modality
 zeroModality = Modality zeroRelevance zeroQuantity zeroCohesion
+
+-- | Identity under composition
+unitModality :: Modality
+unitModality = Modality unitRelevance unitQuantity unitCohesion
 
 -- | Absorptive element under addition.
 topModality :: Modality
@@ -732,7 +737,7 @@ instance Semigroup Quantity where
 -- | In the absense of finite quantities besides 0, ω is the unit.
 --   Otherwise, 1 is the unit.
 instance Monoid Quantity where
-  mempty  = Quantity1 mempty
+  mempty  = unitQuantity
   mappend = (<>)
 
 -- | Note that the order is @ω ≤ 0,1@, more options is smaller.
@@ -765,6 +770,10 @@ addQuantity = curry $ \case
 
 zeroQuantity :: Quantity
 zeroQuantity = Quantity0 mempty
+
+-- | Identity element
+unitQuantity :: Quantity
+unitQuantity = Quantity1 mempty
 
 -- | Absorptive element is ω.
 topQuantity :: Quantity
@@ -1034,9 +1043,8 @@ inverseApplyRelevance rel = mapRelevance (rel `inverseComposeRelevance`)
 instance Semigroup Relevance where
   (<>) = composeRelevance
 
--- | 'Relevant' is the unit.
 instance Monoid Relevance where
-  mempty  = Relevant
+  mempty  = unitRelevance
   mappend = (<>)
 
 instance POSemigroup Relevance where
@@ -1053,6 +1061,10 @@ addRelevance = min
 -- | 'Relevance' forms a monoid under addition, and even a semiring.
 zeroRelevance :: Relevance
 zeroRelevance = Irrelevant
+
+-- | Identity element under composition
+unitRelevance :: Relevance
+unitRelevance = Relevant
 
 -- | Absorptive element under addition.
 topRelevance :: Relevance
@@ -1292,7 +1304,7 @@ instance Semigroup Cohesion where
 
 -- | 'Continous' is the unit.
 instance Monoid Cohesion where
-  mempty  = Continuous
+  mempty  = unitCohesion
   mappend = (<>)
 
 instance POSemigroup Cohesion where
@@ -1309,6 +1321,10 @@ addCohesion = min
 -- | 'Cohesion' forms a monoid under addition, and even a semiring.
 zeroCohesion :: Cohesion
 zeroCohesion = Squash
+
+-- | Identity under composition
+unitCohesion :: Cohesion
+unitCohesion = Continuous
 
 -- | Absorptive element under addition.
 topCohesion :: Cohesion

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -744,7 +744,7 @@ instance LensHiding TypedBinding where
 
 instance LensRelevance TypedBinding where
   getRelevance (TBind _ (x :|_) _) = getRelevance x   -- Slightly dubious
-  getRelevance TLet{}              = mempty
+  getRelevance TLet{}              = unitRelevance
   mapRelevance f (TBind r xs e) = TBind r (fmap (mapRelevance f) xs) e
   mapRelevance f b@TLet{}       = b
 

--- a/src/full/Agda/Syntax/Internal/Pattern.hs
+++ b/src/full/Agda/Syntax/Internal/Pattern.hs
@@ -334,7 +334,7 @@ instance PatternVarModalities a => PatternVarModalities (Named s a) where
 
 instance PatternVarModalities a => PatternVarModalities (Arg a) where
   type PatVar (Arg a) = PatVar a
-  patternVarModalities arg = map (second (m <>)) (patternVarModalities $ unArg arg)
+  patternVarModalities arg = map (second (composeModality m)) (patternVarModalities $ unArg arg)
     where m = getModality arg
 
 -- UNUSED:

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -951,7 +951,7 @@ fixTargetType tag sc@SClause{ scTel = sctel, scSubst = sigma } target = do
         SplitCon c -> do
           q <- getQuantity <$> getConstInfo c
           case q of
-            Quantity0{} -> return $ mapQuantity (q <>)
+            Quantity0{} -> return $ mapQuantity (composeQuantity q)
             Quantity1{} -> return id
             Quantityω{} -> return id
         SplitLit{} -> return id

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -143,7 +143,7 @@ instance ForcedVariables a => ForcedVariables (Elim' a) where
   forcedVariables Proj{}    = []
 
 instance ForcedVariables a => ForcedVariables (Arg a) where
-  forcedVariables x = [ (m <> m', i) | (m', i) <- forcedVariables (unArg x) ]
+  forcedVariables x = [ (composeModality m m', i) | (m', i) <- forcedVariables (unArg x) ]
     where m = getModality x
 
 -- | Assumes that the term is in normal form.

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -149,7 +149,7 @@ instance ForcedVariables a => ForcedVariables (Arg a) where
 -- | Assumes that the term is in normal form.
 instance ForcedVariables Term where
   forcedVariables = \case
-    Var i [] -> [(mempty, i)]
+    Var i [] -> [(unitModality, i)]
     Con _ _ vs -> forcedVariables vs
     _ -> []
 

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -268,7 +268,7 @@ topVarOcc = VarOcc StronglyRigid topModality
 -- | First argument is the outer occurrence (context) and second is the inner.
 --   This multiplicative operation is to modify an occurrence under a context.
 composeVarOcc :: Semigroup a => VarOcc' a -> VarOcc' a -> VarOcc' a
-composeVarOcc (VarOcc o m) (VarOcc o' m') = VarOcc (composeFlexRig o o') (m <> m')
+composeVarOcc (VarOcc o m) (VarOcc o' m') = VarOcc (composeFlexRig o o') (composeModality m m')
   -- We use the multipicative modality monoid (composition).
 
 oneVarOcc :: VarOcc' a

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -272,7 +272,7 @@ composeVarOcc (VarOcc o m) (VarOcc o' m') = VarOcc (composeFlexRig o o') (compos
   -- We use the multipicative modality monoid (composition).
 
 oneVarOcc :: VarOcc' a
-oneVarOcc = VarOcc Unguarded mempty
+oneVarOcc = VarOcc Unguarded unitModality
 
 ---------------------------------------------------------------------------
 -- * Storing variable occurrences (semimodule).
@@ -418,7 +418,7 @@ initFreeEnv :: Monoid c => b -> SingleVar c -> FreeEnv' a b c
 initFreeEnv e sing = FreeEnv
   { feExtra       = e
   , feFlexRig     = Unguarded
-  , feModality    = mempty            -- multiplicative monoid
+  , feModality    = unitModality      -- multiplicative monoid
   , feSingleton   = maybe mempty sing
   }
 
@@ -529,7 +529,7 @@ instance Free Term where
     Sort s       -> freeVars' s
     Level l      -> freeVars' l
     MetaV m ts   -> underFlexRig (Flexible $ singleton m) $ freeVars' ts
-    DontCare mt  -> underModality (Modality Irrelevant mempty mempty) $ freeVars' mt
+    DontCare mt  -> underModality (Modality Irrelevant unitQuantity unitCohesion) $ freeVars' mt
     Dummy{}      -> mempty
 
 instance Free t => Free (Type' t) where

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -203,9 +203,9 @@ applyQuantityToJudgementOnly = localTC . over eQuantity . composeQuantity
 applyCohesionToContext :: (MonadTCEnv tcm, LensCohesion m) => m -> tcm a -> tcm a
 applyCohesionToContext thing =
   case getCohesion thing of
-    m | m == mempty -> id
-      | otherwise   -> applyCohesionToContextOnly   m
-                       -- Cohesion does not apply to the judgment.
+    m | m == unitCohesion -> id
+      | otherwise         -> applyCohesionToContextOnly   m
+                             -- Cohesion does not apply to the judgment.
 
 applyCohesionToContextOnly :: (MonadTCEnv tcm) => Cohesion -> tcm a -> tcm a
 applyCohesionToContextOnly q = localTC
@@ -227,9 +227,9 @@ splittableCohesion a = do
 applyModalityToContext :: (MonadTCEnv tcm, LensModality m) => m -> tcm a -> tcm a
 applyModalityToContext thing =
   case getModality thing of
-    m | m == mempty -> id
-      | otherwise   -> applyModalityToContextOnly   m
-                     . applyModalityToJudgementOnly m
+    m | m == unitModality -> id
+      | otherwise         -> applyModalityToContextOnly   m
+                           . applyModalityToJudgementOnly m
 
 -- | (Conditionally) wake up irrelevant variables and make them relevant.
 --   For instance,

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -413,8 +413,8 @@ instance UsableModality Term where
     -- Even if Pi contains Type, here we check it as a constructor for terms in the universe.
     Pi a b   -> usableMod domMod (unEl $ unDom a) `and2M` usableModAbs (getArgInfo a) mod (unEl <$> b)
       where
-        domMod = mapQuantity (<> getQuantity a) $
-                 mapCohesion (<> getCohesion a) mod
+        domMod = mapQuantity (composeQuantity $ getQuantity a) $
+                 mapCohesion (composeCohesion $ getCohesion a) mod
     -- Andrea 15/10/2020 not updating these cases yet, but they are quite suspicious,
     -- do we have special typing rules for Sort and Level?
     Sort s   -> usableMod mod s

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -373,7 +373,7 @@ instance Occurs Term where
           nest 2 $ text $ show v
         case v of
           Var i es   -> do
-            allowed <- getAll . ($ mempty) <$> variable i
+            allowed <- getAll . ($ unitModality) <$> variable i
             if allowed then Var i <$> weakly (occurs es) else do
               -- if the offending variable is of singleton type,
               -- eta-expand it away

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2823,7 +2823,7 @@ initEnv = TCEnv { envContext             = []
   -- The initial mode should be 'ConcreteMode', ensuring you
   -- can only look into abstract things in an abstract
   -- definition (which sets 'AbstractMode').
-                , envModality               = mempty
+                , envModality               = unitModality
                 , envSplitOnStrict          = False
                 , envDisplayFormsEnabled    = True
                 , envRange                  = noRange

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1128,7 +1128,7 @@ fitsIn uc forceds t s = do
        whenM (isFibrant s) $ do
         q <- asksTC getQuantity
         usableAtModality
-          (setQuantity (getQuantity dom <> q) defaultModality)
+          (setQuantity (composeQuantity (getQuantity dom) q) defaultModality)
           (unEl $ unDom dom)
       let (forced,forceds') = nextIsForced forceds
       unless (isForced forced && not withoutK) $ do

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1418,7 +1418,7 @@ checkLHS mf = updateModality checkLHS_ where
                   -- either sets to Quantity0 or is the identity.
                   updResMod q =
                     case cq of
-                     Quantity0{} -> cq <> q
+                     Quantity0{} -> composeQuantity cq q
                                  -- zero-out, preserves origin
                      Quantity1{} -> __IMPOSSIBLE__
                      Quantityω{} -> q

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -1175,7 +1175,7 @@ solutionStep retry s
         | IntMap.null vars = tel
         | otherwise        = telFromList $ zipWith upd (downFrom $ size tel) (telToList tel)
         where
-          upd i a | Just md' <- IntMap.lookup i vars = setModality (md <> md') a
+          upd i a | Just md' <- IntMap.lookup i vars = setModality (composeModality md md') a
                   | otherwise                        = a
   s <- return $ s { varTel = updModality (getModality fi) bound (varTel s) }
 
@@ -1324,7 +1324,7 @@ patternBindingForcedVars forced v = do
           | Just vs <- allApplyElims es -> do
             fs <- defForced <$> getConstInfo (conName c)
             let goArg Forced    v = return $ fmap (unnamed . dotP) v
-                goArg NotForced v = fmap unnamed <$> traverse (go $ md <> getModality v) v
+                goArg NotForced v = fmap unnamed <$> traverse (go $ composeModality md $ getModality v) v
             (ps, bound) <- listen $ zipWithM goArg (fs ++ repeat NotForced) vs
             if IntMap.null bound
               then return $ dotP v  -- bound nothing

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -567,7 +567,7 @@ checkRecordProjections m r hasNamedCon con tel ftel fs = do
       --
       -- Alternatively we could create a projection `.. |- π r :c A`
       -- but that would require support for a `t :c A` judgment.
-      if hasLeftAdjoint (getCohesion ai)
+      if hasLeftAdjoint (UnderComposition (getCohesion ai))
         then unless (getCohesion ai == Continuous)
                     -- Andrea TODO: properly update the context/type of the projection when we add Sharp
                     __IMPOSSIBLE__

--- a/test/Internal/Syntax/Common.hs
+++ b/test/Internal/Syntax/Common.hs
@@ -16,6 +16,12 @@ instance CoArbitrary Modality
 instance Arbitrary Modality where
   arbitrary = Modality <$> arbitrary <*> arbitrary <*> arbitrary
 
+instance Arbitrary a => Arbitrary (UnderAddition a) where
+  arbitrary = UnderAddition <$> arbitrary
+
+instance Arbitrary a => Arbitrary (UnderComposition a) where
+  arbitrary = UnderComposition <$> arbitrary
+
 instance CoArbitrary Q0Origin where
   coarbitrary = \case
     Q0Inferred -> variant 0
@@ -100,11 +106,17 @@ instance (Arbitrary a, Arbitrary b) => Arbitrary (Using' a b) where
 
 -- Quantity is a POMonoid
 
-prop_monoid_Quantity :: Property3 Quantity
-prop_monoid_Quantity = isMonoid
+prop_monoid_Quantity_comp :: Property3 (UnderComposition Quantity)
+prop_monoid_Quantity_comp = isMonoid
 
-prop_monotone_comp_Quantity :: Property3 Quantity
-prop_monotone_comp_Quantity = isMonotoneComposition
+prop_monotone_comp_Quantity_comp :: Property3 (UnderComposition Quantity)
+prop_monotone_comp_Quantity_comp = isMonotoneComposition
+
+prop_monoid_Quantity_add :: Property3 (UnderAddition Quantity)
+prop_monoid_Quantity_add = isMonoid
+
+prop_monotone_comp_Quantity_add :: Property3 (UnderAddition Quantity)
+prop_monotone_comp_Quantity_add = isMonotoneComposition
 
 -- -- | Quantities ω=ℕ, 1={1}, 0={0}  do not form a Galois connection.
 --
@@ -118,14 +130,14 @@ prop_monotone_comp_Quantity = isMonotoneComposition
 
 -- Relevance is a LeftClosedPOMonoid
 
-prop_monoid_Relevance :: Property3 Relevance
-prop_monoid_Relevance = isMonoid
+prop_monoid_Relevance_comp :: Property3 (UnderComposition Relevance)
+prop_monoid_Relevance_comp = isMonoid
 
-prop_monotone_comp_Relevance :: Property3 Relevance
-prop_monotone_comp_Relevance = isMonotoneComposition
+prop_monotone_comp_Relevance_comp :: Property3 (UnderComposition Relevance)
+prop_monotone_comp_Relevance_comp = isMonotoneComposition
 
-prop_Galois_Relevance :: Prop3 Relevance
-prop_Galois_Relevance = isGaloisConnection
+prop_Galois_Relevance_comp :: Prop3 (UnderComposition Relevance)
+prop_Galois_Relevance_comp = isGaloisConnection
 
 prop_left_identity_invcomp_Relevance :: Relevance -> Bool
 prop_left_identity_invcomp_Relevance x = Relevant `inverseComposeRelevance` x == x
@@ -133,15 +145,27 @@ prop_left_identity_invcomp_Relevance x = Relevant `inverseComposeRelevance` x ==
 prop_right_absorptive_invcomp_Relevance :: Relevance -> Bool
 prop_right_absorptive_invcomp_Relevance x = x `inverseComposeRelevance` Relevant == Relevant
 
+prop_monoid_Relevance_add :: Property3 (UnderAddition Relevance)
+prop_monoid_Relevance_add = isMonoid
+
+prop_monotone_comp_Relevance_add :: Property3 (UnderAddition Relevance)
+prop_monotone_comp_Relevance_add = isMonotoneComposition
+
 -- Modality is a POMonoid
 
-prop_monoid_Modality :: Property3 Modality
-prop_monoid_Modality = isMonoid
+prop_monoid_Modality_comp :: Property3 (UnderComposition Modality)
+prop_monoid_Modality_comp = isMonoid
 
-prop_monotone_comp_Modality :: Property3 Modality
+prop_monotone_comp_Modality :: Property3 (UnderComposition Modality)
 prop_monotone_comp_Modality = isMonotoneComposition
 
--- -- | The following does not hold, see prop_Galois_Quanity.
+prop_monoid_Modality_add :: Property3 (UnderAddition Modality)
+prop_monoid_Modality_add = isMonoid
+
+prop_monotone_comp_Modality_add :: Property3 (UnderAddition Modality)
+prop_monotone_comp_Modality_add = isMonotoneComposition
+
+-- -- | The following does not hold, see prop_Galois_Quantity.
 -- prop_Galois_Modality :: Prop3 Modality
 -- prop_Galois_Modality = isGaloisConnection
 

--- a/test/Internal/TypeChecking/Free.hs
+++ b/test/Internal/TypeChecking/Free.hs
@@ -305,7 +305,7 @@ prop_isSemimodule_withVarOcc1_counterexample =
   withVarOcc r (m <> m') /=           -- LHS: Flexible [1]
   withVarOcc r m <> withVarOcc r m'   -- RHS: Flexible [1,2]
   where
-    occ o  = VarOcc o mempty
+    occ o  = VarOcc o unitModality
     rig    = occ Unguarded
     flex n = occ $ Flexible $ singleton $ MetaId n
     r      :: VarOcc
@@ -319,7 +319,7 @@ prop_isSemimodule_withVarOcc2_counterexample =
   withVarOcc (r <> s) m /=
   withVarOcc r m <> withVarOcc s m
   where
-    occ o  = VarOcc o mempty
+    occ o  = VarOcc o unitModality
     flex n = occ $ Flexible $ singleton $ MetaId n
     r, s   :: VarOcc
     r      = flex 1


### PR DESCRIPTION
A while ago, I noticed some inconsistencies with the handling of modalities initial values: `empty` vs. `mempty` vs. `default*` were not necessarily the same, though used somewhat interchangeably. Some discussion here: #4845 (_Modality and Quantity inconsistent Null.empty ↔︎ Monoid.mempty_) and here #4847 (_Remove `Null Modality` instance, inline its single use_).

In order to make those choices explicit, this PR removes the bare `Monoid` and `Semigroup` instances, and adds instances with `UnderComposition …`/`UnderAddition …` `newtype` wrappers. (Roughly in the spirit of [`Data.Functor.Product`](https://hackage.haskell.org/package/base-4.14.0.0/docs/Data-Functor-Product.html) which unfortunately requires a `Num` instance). But otherwise preferring to use `unitModality`/`zeroModality`/`defaultModality` etc explicitly.

This doesn't fix any bugs, but it might make some bugs easier to see, and in any case could reduce some head-scratching.

No important developments use this branch; but I've had it sitting around for a while and figured I might as well push it up if it seems useful.