### PR TITLE
More precise blocking in conversion checker

### DIFF
--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -106,6 +106,16 @@ intersectVars = zipWithM areVars where
     areVars (Apply (Arg _ (Var n []))) (Apply (Arg _ (Var m []))) = Just $ n /= m -- prune different vars
     areVars _ _                                   = Nothing
 
+-- | Run the given computation but turn any errors into blocked computations with the given blocker
+blockOnError :: MonadError TCErr m => Blocker -> m a -> m a
+blockOnError blocker f
+  | blocker == neverUnblock = f
+  | otherwise               = f `catchError` \case
+    TypeError{}         -> throwError $ PatternErr blocker
+    PatternErr blocker' -> throwError $ PatternErr $ unblockOnEither blocker blocker'
+    err@Exception{}     -> throwError err
+    err@IOException{}   -> throwError err
+
 equalTerm :: MonadConversion m => Type -> Term -> Term -> m ()
 equalTerm = compareTerm CmpEq
 
@@ -243,20 +253,20 @@ compareAs' cmp tt m n = case tt of
 compareTerm' :: forall m. MonadConversion m => Comparison -> Type -> Term -> Term -> m ()
 compareTerm' cmp a m n =
   verboseBracket "tc.conv.term" 20 "compareTerm" $ do
-  a' <- reduce a
-  (catchConstraint (ValueCmp cmp (AsTermsOf a') m n) :: m () -> m ()) $ do
+  (ba, a') <- reduceWithBlocker a
+  (catchConstraint (ValueCmp cmp (AsTermsOf a') m n) :: m () -> m ()) $ blockOnError ba $ do
     reportSDoc "tc.conv.term" 30 $ fsep
       [ "compareTerm", prettyTCM m, prettyTCM cmp, prettyTCM n, ":", prettyTCM a' ]
     propIrr  <- isPropEnabled
     isSize   <- isJust <$> isSizeType a'
-    s        <- reduce $ getSort a'
+    (bs, s)  <- reduceWithBlocker $ getSort a'
     mlvl     <- getBuiltin' builtinLevel
     reportSDoc "tc.conv.level" 60 $ nest 2 $ sep
       [ "a'   =" <+> pretty a'
       , "mlvl =" <+> pretty mlvl
       , text $ "(Just (unEl a') == mlvl) = " ++ show (Just (unEl a') == mlvl)
       ]
-    case s of
+    blockOnError bs $ case s of
       Prop{} | propIrr -> compareIrrelevant a' m n
       _    | isSize   -> compareSizes cmp m n
       _               -> case unEl a' of
@@ -417,10 +427,13 @@ compareAtom cmp t m n =
                              ]
     -- Andreas: what happens if I cut out the eta expansion here?
     -- Answer: Triggers issue 245, does not resolve 348
-    (mb',nb') <- ifM (asksTC envCompareBlocked) ((notBlocked -*- notBlocked) <$> reduce (m,n)) $ do
+    (mb',nb') <- do
       mb' <- etaExpandBlocked =<< reduceB m
       nb' <- etaExpandBlocked =<< reduceB n
       return (mb', nb')
+    let getBlocker (Blocked b _) = b
+        getBlocker NotBlocked{}  = neverUnblock
+        blocker = unblockOnEither (getBlocker mb') (getBlocker nb')
     reportSLn "tc.conv.atom.size" 50 $ "term size after reduce: " ++ show (termSize $ ignoreBlocking mb', termSize $ ignoreBlocking nb')
 
     -- constructorForm changes literal to constructors
@@ -438,22 +451,9 @@ compareAtom cmp t m n =
     let m = ignoreBlocking mb
         n = ignoreBlocking nb
 
-        postpone u = addConstraint u $ ValueCmp cmp t m n
+        checkDefinitionalEquality = unlessM (pureCompareAs CmpEq t m n) notEqual
 
-        -- Jesper, 2019-05-14, Issue #3776: If the type is blocked,
-        -- the comparison could be solved by eta-expansion so we
-        -- cannot fail hard
-        postponeIfBlockedAs :: CompareAs -> (Blocked CompareAs -> m ()) -> m ()
-        postponeIfBlockedAs AsTypes       f = f $ NotBlocked ReallyNotBlocked AsTypes
-        postponeIfBlockedAs AsSizes       f = f $ NotBlocked ReallyNotBlocked AsSizes
-        postponeIfBlockedAs (AsTermsOf t) f = ifBlocked t
-          (\ b t -> f (Blocked b $ AsTermsOf t) `catchError` \case
-              TypeError{} -> postpone b
-              err         -> throwError err)
-          (\nb t -> f $ NotBlocked nb $ AsTermsOf t)
-
-        checkDefinitionalEquality = unlessM (pureCompareAs CmpEq t m n) $
-                                      postpone (unblockOnAnyMetaIn (m, n))
+        notEqual = typeError $ UnequalTerms cmp m n t
 
         dir = fromCmp cmp
         rid = flipCmp dir     -- The reverse direction.  Bad name, I know.
@@ -476,9 +476,9 @@ compareAtom cmp t m n =
           MetaV y yArgs <- ignoreBlocking nb -> -- envCompareBlocked check above.
         if | x == y, cmpBlocked -> do
               a <- metaType x
-              addOrUnblocker (unblockOnMeta x) $
+              blockOnError (unblockOnMeta x) $
                 compareElims [] [] a (MetaV x []) xArgs yArgs
-           | x == y ->
+           | x == y -> blockOnError (unblockOnMeta x) $
             case intersectVars xArgs yArgs of
               -- all relevant arguments are variables
               Just kills -> do
@@ -487,8 +487,8 @@ compareAtom cmp t m n =
                 case killResult of
                   NothingToPrune   -> return ()
                   PrunedEverything -> return ()
-                  PrunedNothing    -> postpone (unblockOnAnyMetaIn (m, n))
-                  PrunedSomething  -> postpone (unblockOnAnyMetaIn (m, n))
+                  PrunedNothing    -> checkDefinitionalEquality
+                  PrunedSomething  -> checkDefinitionalEquality
               -- not all relevant arguments are variables
               Nothing -> checkDefinitionalEquality -- Check definitional equality on meta-variables
                               -- (same as for blocked terms)
@@ -512,10 +512,10 @@ compareAtom cmp t m n =
       -- one side a meta
       _ | MetaV x es <- ignoreBlocking mb -> assign dir x es n
       _ | MetaV x es <- ignoreBlocking nb -> assign rid x es m
-      (Blocked{}, Blocked{})  -> checkDefinitionalEquality
-      (Blocked b _, _) -> useInjectivity (fromCmp cmp) b t m n   -- The blocked term goes first
-      (_, Blocked b _) -> useInjectivity (flipCmp $ fromCmp cmp) b t n m
-      _ -> postponeIfBlockedAs t $ \bt -> do
+      (Blocked{}, Blocked{}) | not cmpBlocked  -> checkDefinitionalEquality
+      (Blocked b _, _) | not cmpBlocked -> useInjectivity (fromCmp cmp) b t m n   -- The blocked term  goes first
+      (_, Blocked b _) | not cmpBlocked -> useInjectivity (flipCmp $ fromCmp cmp) b t n m
+      _ -> blockOnError blocker $ do
         -- -- Andreas, 2013-10-20 put projection-like function
         -- -- into the spine, to make compareElims work.
         -- -- 'False' means: leave (Def f []) unchanged even for
@@ -574,7 +574,7 @@ compareAtom cmp t m n =
                   -- Constructors are covariant in their arguments
                   -- (see test/succeed/CovariantConstructors).
                   compareElims (repeat $ polFromCmp cmp) forcedArgs a' (Con x ci []) xArgs yArgs
-          _ -> typeError $ UnequalTerms cmp m n $ ignoreBlocking bt
+          _ -> notEqual
     where
         -- returns True in case we handled the comparison already.
         compareEtaPrims :: MonadConversion m => QName -> Elims -> Elims -> m Bool

--- a/src/full/Agda/TypeChecking/Conversion/Pure.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Pure.hs
@@ -16,9 +16,11 @@ import Agda.Syntax.Internal.MetaVars (unblockOnAnyMetaIn)
 import {-# SOURCE #-} Agda.TypeChecking.Conversion
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
+import Agda.TypeChecking.Reduce (isBlocked)
 import Agda.TypeChecking.Warnings
 
 import Agda.Utils.Either
+import Agda.Utils.Maybe
 import Agda.Utils.Null
 
 import Agda.Utils.Impossible
@@ -37,23 +39,23 @@ pureEqualTerm
   :: (PureTCM m, MonadBlock m)
   => Type -> Term -> Term -> m Bool
 pureEqualTerm a u v =
-  isRight <$> runPureConversion (equalTerm a u v)
+  isJust <$> runPureConversion (equalTerm a u v)
 
 pureEqualType
   :: (PureTCM m, MonadBlock m)
   => Type -> Type -> m Bool
 pureEqualType a b =
-  isRight <$> runPureConversion (equalType a b)
+  isJust <$> runPureConversion (equalType a b)
 
 pureCompareAs
   :: (PureTCM m, MonadBlock m)
   => Comparison -> CompareAs -> Term -> Term -> m Bool
 pureCompareAs cmp a u v =
-  isRight <$> runPureConversion (compareAs cmp a u v)
+  isJust <$> runPureConversion (compareAs cmp a u v)
 
 runPureConversion
   :: (MonadBlock m, PureTCM m, Show a)
-  => PureConversionT m a -> m (Either TCErr a)
+  => PureConversionT m a -> m (Maybe a)
 runPureConversion (PureConversionT m) = locallyTC eCompareBlocked (const True) $ do
   i <- useR stFreshInt
   pid <- useR stFreshProblemId
@@ -61,7 +63,14 @@ runPureConversion (PureConversionT m) = locallyTC eCompareBlocked (const True) $
   let frsh = FreshThings i pid nid
   result <- fst <$> runStateT (runExceptT m) frsh
   reportSLn "tc.conv.pure" 40 $ "runPureConversion result: " ++ show result
-  return result
+  case result of
+    Left (PatternErr block)
+     | block == neverUnblock -> return Nothing
+     | otherwise             -> patternViolation block
+    Left TypeError{}   -> return Nothing
+    Left Exception{}   -> __IMPOSSIBLE__
+    Left IOException{} -> __IMPOSSIBLE__
+    Right x            -> return $ Just x
 
 instance MonadTrans PureConversionT where
   lift = PureConversionT . lift . lift
@@ -86,14 +95,12 @@ instance Monad m => Null (PureConversionT m Doc) where
   empty = return empty
   null = __IMPOSSIBLE__
 
--- | Pattern violations are NOT caught but instead thrown into the
---   outside world. This gives us access to more precise blocking
---   information when a pure conversion check is blocked.
-instance MonadBlock m => MonadBlock (PureConversionT m) where
-  patternViolation = PureConversionT . lift . lift . patternViolation
-  catchPatternErr handle m = PureConversionT $ ExceptT $ StateT $ \s -> do
-    let run f = runStateT (runExceptT $ unPureConversionT f) s
-    catchPatternErr (run . handle) $ run m
+instance Monad m => MonadBlock (PureConversionT m) where
+  patternViolation = throwError . PatternErr
+  catchPatternErr handle m = m `catchError` \case
+    PatternErr b -> handle b
+    err          -> throwError err
+
 
 instance (PureTCM m, MonadBlock m) => MonadConstraint (PureConversionT m) where
   addConstraint u _ = patternViolation u
@@ -107,8 +114,14 @@ instance (PureTCM m, MonadBlock m) => MonadConstraint (PureConversionT m) where
 
 instance (PureTCM m, MonadBlock m) => MonadMetaSolver (PureConversionT m) where
   newMeta' _ _ _ _ _ _ = patternViolation alwaysUnblock  -- TODO: does this happen?
-  assignV _ m us v _ = patternViolation $ unblockOnAnyMetaIn (MetaV m (map Apply us), v)
-  assignTerm' m _ v = patternViolation $ unblockOnAnyMetaIn (MetaV m [], v)
+  assignV _ m _ v _ = do
+    bv <- isBlocked v
+    let blocker = caseMaybe bv id unblockOnEither $ unblockOnMeta m
+    patternViolation blocker
+  assignTerm' m _ v = do
+    bv <- isBlocked v
+    let blocker = caseMaybe bv id unblockOnEither $ unblockOnMeta m
+    patternViolation blocker
   etaExpandMeta _ _ = return ()
   updateMetaVar _ _ = patternViolation alwaysUnblock  -- TODO: does this happen?
   speculateMetas fallback m = m >>= \case

--- a/src/full/Agda/TypeChecking/Monad/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Monad/Constraints.hs
@@ -171,10 +171,14 @@ instance MonadConstraint m => MonadConstraint (ReaderT e m) where
   wakeConstraints = lift . wakeConstraints
 
 addAndUnblocker :: MonadBlock m => Blocker -> m a -> m a
-addAndUnblocker u = catchPatternErr $ \ u' -> patternViolation (u <> u')
+addAndUnblocker u
+  | u == alwaysUnblock = id
+  | otherwise          = catchPatternErr $ \ u' -> patternViolation (u <> u')
 
 addOrUnblocker :: MonadBlock m => Blocker -> m a -> m a
-addOrUnblocker u = catchPatternErr $ \ u' -> patternViolation (unblockOnEither u u')
+addOrUnblocker u
+  | u == neverUnblock = id
+  | otherwise         = catchPatternErr $ \ u' -> patternViolation (unblockOnEither u u')
 
 -- | Add new a constraint
 addConstraint' :: Blocker -> Constraint -> TCM ()

--- a/src/full/Agda/TypeChecking/Monad/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Monad/Constraints.hs
@@ -170,10 +170,10 @@ instance MonadConstraint m => MonadConstraint (ReaderT e m) where
   modifySleepingConstraints = lift . modifySleepingConstraints
   wakeConstraints = lift . wakeConstraints
 
-addAndUnblocker :: MonadConstraint m => Blocker -> m a -> m a
+addAndUnblocker :: MonadBlock m => Blocker -> m a -> m a
 addAndUnblocker u = catchPatternErr $ \ u' -> patternViolation (u <> u')
 
-addOrUnblocker :: MonadConstraint m => Blocker -> m a -> m a
+addOrUnblocker :: MonadBlock m => Blocker -> m a -> m a
 addOrUnblocker u = catchPatternErr $ \ u' -> patternViolation (unblockOnEither u u')
 
 -- | Add new a constraint

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -69,7 +69,7 @@ reduceWithBlocker a = ifBlocked a
 -- Reduce a term and call the continuation. If the continuation is
 -- blocked, the whole call is blocked either on what blocked the reduction
 -- or on what blocked the continuation (using `blockedOnEither`).
-withReduced 
+withReduced
   :: (Reduce a, IsMeta a, MonadReduce m, MonadBlock m)
   => a -> (a -> m b) -> m b
 withReduced a cont = ifBlocked a (\b a' -> addOrUnblocker b $ cont a') (\_ a' -> cont a')

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -59,6 +59,21 @@ reduce = liftReduce . reduce'
 reduceB :: (Reduce a, MonadReduce m) => a -> m (Blocked a)
 reduceB = liftReduce . reduceB'
 
+-- Reduce a term and also produce a blocker signifying when
+-- this reduction should be retried.
+reduceWithBlocker :: (Reduce a, IsMeta a, MonadReduce m) => a -> m (Blocker, a)
+reduceWithBlocker a = ifBlocked a
+  (\b a' -> return (b, a'))
+  (\_ a' -> return (neverUnblock, a'))
+
+-- Reduce a term and call the continuation. If the continuation is
+-- blocked, the whole call is blocked either on what blocked the reduction
+-- or on what blocked the continuation (using `blockedOnEither`).
+withReduced 
+  :: (Reduce a, IsMeta a, MonadReduce m, MonadBlock m)
+  => a -> (a -> m b) -> m b
+withReduced a cont = ifBlocked a (\b a' -> addOrUnblocker b $ cont a') (\_ a' -> cont a')
+
 normalise :: (Normalise a, MonadReduce m) => a -> m a
 normalise = liftReduce . normalise'
 

--- a/test/Fail/Issue3672b.err
+++ b/test/Fail/Issue3672b.err
@@ -1,4 +1,3 @@
 Unsolved metas at the following locations:
   Issue3672b.agda:33,14-16
-  Issue3672b.agda:33,42-43
   Issue3672b.agda:33,57-58

--- a/test/Succeed/Issue1719/Pushouts.agda
+++ b/test/Succeed/Issue1719/Pushouts.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --confluence-check #-}
+{-# OPTIONS --without-K --rewriting #-}
 
 module Issue1719.Pushouts where
 


### PR DESCRIPTION
This makes the conversion checker be more precise in the blocking tags it produces when a conversion check is blocked on a metavariable. It has (almost) no effect on the test suite but it should lead to (1) fewer futile attempts at retrying blocked problems and (2) more hard type errors in cases where constraints are really unsolvable.

There are still several other places where blocking is imprecise, so hopefully we will eventually see some real results once all of them are made precise.