### PR TITLE
Automatic sorting of rewrite rules for confluence checker

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1639,6 +1639,7 @@ data RewriteRule = RewriteRule
   , rewPats    :: PElims     -- ^ @Γ ⊢ f ps : t@.
   , rewRHS     :: Term       -- ^ @Γ ⊢ rhs : t@.
   , rewType    :: Type       -- ^ @Γ ⊢ t@.
+  , rewFromClause :: Bool    -- ^ Was this rewrite rule created from a clause in the definition of the function?
   }
     deriving (Data, Show)
 
@@ -4380,8 +4381,8 @@ instance KillRange NLPSort where
   killRange PLockUniv = PLockUniv
 
 instance KillRange RewriteRule where
-  killRange (RewriteRule q gamma f es rhs t) =
-    killRange6 RewriteRule q gamma f es rhs t
+  killRange (RewriteRule q gamma f es rhs t c) =
+    killRange6 RewriteRule q gamma f es rhs t c
 
 instance KillRange CompiledRepresentation where
   killRange = id

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -425,7 +425,7 @@ instance PrettyTCM (Type' NLPat) where
   prettyTCM = prettyTCM . unEl
 
 instance PrettyTCM RewriteRule where
-  prettyTCM (RewriteRule q gamma f ps rhs b) = fsep
+  prettyTCM (RewriteRule q gamma f ps rhs b c) = fsep
     [ prettyTCM q
     , prettyTCM gamma <+> " |- "
     , addContext gamma $ sep

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -288,8 +288,7 @@ prettyWarning = \case
         ]
       , fsep $ concat
         [ pwords "Possible fix: add a rule to rewrite"
-        , [ prettyTCM v , "to" , prettyTCM rhou <> "," ]
-        , pwords "or change the order of the rules so more specialized rules come later."
+        , [ prettyTCM v , "to" , prettyTCM rhou ]
         ]
       ]
 

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1404,13 +1404,14 @@ instance InstantiateFull NLPSort where
   instantiateFull' PLockUniv = return PLockUniv
 
 instance InstantiateFull RewriteRule where
-  instantiateFull' (RewriteRule q gamma f ps rhs t) =
+  instantiateFull' (RewriteRule q gamma f ps rhs t c) =
     RewriteRule q
       <$> instantiateFull' gamma
       <*> pure f
       <*> instantiateFull' ps
       <*> instantiateFull' rhs
       <*> instantiateFull' t
+      <*> pure c
 
 instance InstantiateFull DisplayForm where
   instantiateFull' (Display n ps v) = uncurry (Display n) <$> instantiateFull' (ps, v)

--- a/src/full/Agda/TypeChecking/Rewriting/Clause.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Clause.hs
@@ -45,6 +45,7 @@ clauseToRewriteRule f q cl = clauseBody cl <&> \rhs -> RewriteRule
   , rewPats    = toNLPat $ namedClausePats cl
   , rewRHS     = rhs
   , rewType    = unArg $ fromMaybe __IMPOSSIBLE__  $ clauseType cl
+  , rewFromClause = True
   }
 
 class ToNLPat a b where

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -400,7 +400,7 @@ checkConfluenceOfRules' confChk isClause rews = inTopContext $ inAbstractMode $ 
           ]
         return eq
 
-makeHead :: Definition -> Type -> TCM (Type , Elims -> Term)
+makeHead :: PureTCM m => Definition -> Type -> m (Type , Elims -> Term)
 makeHead def a = case theDef def of
   Constructor{ conSrcCon = ch } -> do
     ca <- snd . fromMaybe __IMPOSSIBLE__ <$> getFullyAppliedConType ch a

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -324,15 +324,12 @@ instance Match Type NLPat Term where
                   | conName c == f = ps
                   | otherwise      = map (Apply . fmap mkField) flds
             match r gamma k (ct, Con c ci) ps' (map Apply vs)
-          MetaV m es -> do
-            matchingBlocked $ blocked_ m
           v -> maybeBlock v
       PLam i p' -> case unEl t of
         Pi a b -> do
           let body = raise 1 v `apply` [Arg i (var 0)]
               k'   = ExtendTel a (Abs (absName b) k)
           match r gamma k' (absBody b) (absBody p') body
-        MetaV m es -> matchingBlocked $ blocked_ m
         v -> maybeBlock v
       PPi pa pb -> case v of
         Pi a b -> do

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -388,13 +388,6 @@ checkFunDefS t ai delayed extlam with i name withSub cs = do
 
         covering <- funCovering . theDef <$> getConstInfo name
 
-        -- Jesper, 2019-05-30: if the constructors used in the
-        -- lhs of a clause have rewrite rules, we need to check
-        -- confluence here
-        whenJustM (optConfluenceCheck <$> pragmaOptions) $ \confChk -> inTopContext $
-          forM_ (zip cs [0..]) $ \(c , clauseNo) ->
-            checkConfluenceOfClause confChk name clauseNo c
-
         -- Add the definition
         inTopContext $ addConstant name =<< do
           -- If there was a pragma for this definition, we can set the
@@ -420,6 +413,12 @@ checkFunDefS t ai delayed extlam with i name withSub cs = do
           sep [ "added " <+> prettyTCM name <+> ":"
               , nest 2 $ prettyTCM . defType =<< getConstInfo name
               ]
+
+        -- Jesper, 2019-05-30: if the constructors used in the
+        -- lhs of a clause have rewrite rules, we need to check
+        -- confluence here
+        whenJustM (optConfluenceCheck <$> pragmaOptions) $ \confChk -> inTopContext $
+          checkConfluenceOfClauses confChk name
 
 -- | Set 'funTerminates' according to termination info in 'TCEnv',
 --   which comes from a possible termination pragma.

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -6,6 +6,7 @@ import Prelude hiding (null)
 
 import Control.Monad
 import Data.Maybe
+import qualified Data.Set as Set
 
 import Agda.Interaction.Options
 
@@ -331,11 +332,10 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
       escapeContext __IMPOSSIBLE__ npars $ do
         addCompositionForRecord name con tel (map argFromDom fs) ftel rect
 
-      -- Jesper, 2019-06-07: Check confluence of projection clauses
-      whenJustM (optConfluenceCheck <$> pragmaOptions) $ \confChk -> forM_ fs $ \f -> do
-        cls <- defClauses <$> getConstInfo (unDom f)
-        forM (zip cls [0..]) $ \(cl,i) ->
-          checkConfluenceOfClause confChk (unDom f) i cl
+      -- The confluence checker needs to know what symbols match against
+      -- the constructor.
+      modifySignature $ updateDefinition conName $ \def ->
+        def { defMatchable = Set.fromList $ map unDom fs }
 
       return ()
   where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -273,7 +273,7 @@ instance EmbPrj NLPSort where
     valu _      = malformed
 
 instance EmbPrj RewriteRule where
-  icod_ (RewriteRule a b c d e f) = icodeN' RewriteRule a b c d e f
+  icod_ (RewriteRule a b c d e f g) = icodeN' RewriteRule a b c d e f g
 
   value = valueN RewriteRule
 

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -246,6 +246,7 @@ instance Apply RewriteRule where
        , rewPats    = applySubst sub (rewPats r)
        , rewRHS     = applyNLPatSubst sub (rewRHS r)
        , rewType    = applyNLPatSubst sub (rewType r)
+       , rewFromClause = rewFromClause r
        }
 
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
@@ -630,8 +631,8 @@ instance Abstract Definition where
 --   we do not need to change lhs, rhs, and t since they live in Γ.
 --   See 'Abstract Clause'.
 instance Abstract RewriteRule where
-  abstract tel (RewriteRule q gamma f ps rhs t) =
-    RewriteRule q (abstract tel gamma) f ps rhs t
+  abstract tel (RewriteRule q gamma f ps rhs t c) =
+    RewriteRule q (abstract tel gamma) f ps rhs t c
 
 instance {-# OVERLAPPING #-} Abstract [Occ.Occurrence] where
   abstract tel []  = []
@@ -948,11 +949,12 @@ instance Subst NLPSort where
 
 instance Subst RewriteRule where
   type SubstArg RewriteRule = NLPat
-  applySubst rho (RewriteRule q gamma f ps rhs t) =
+  applySubst rho (RewriteRule q gamma f ps rhs t c) =
     RewriteRule q (applyNLPatSubst rho gamma)
                 f (applySubst (liftS n rho) ps)
                   (applyNLPatSubst (liftS n rho) rhs)
                   (applyNLPatSubst (liftS n rho) t)
+                  c
     where n = size gamma
 
 instance Subst a => Subst (Blocked a) where

--- a/test/Fail/ConstructorRewriteConfluenceFail.err
+++ b/test/Fail/ConstructorRewriteConfluenceFail.err
@@ -4,11 +4,11 @@ rewritten to either count-suc (suc x) or count-suc x.
 Possible fix: add a rewrite rule with left-hand side
 count-suc (pred (suc x)) to resolve the ambiguity.
 when checking confluence of the rewrite rule
-ConstructorRewriteConfluenceFail.count-suc-clause1 with pred-suc
+ConstructorRewriteConfluenceFail.count-suc-clause2 with pred-suc
 ConstructorRewriteConfluenceFail.agda:31,1-10
 Global confluence check failed: count-suc (suc (pred x)) can be
 rewritten to either 1 +ℕ count-suc (pred x) or count-suc x.
 Possible fix: add a rewrite rule with left-hand side
 count-suc (suc (pred x)) to resolve the ambiguity.
 when checking confluence of the rewrite rule
-ConstructorRewriteConfluenceFail.count-suc-clause2 with suc-pred
+ConstructorRewriteConfluenceFail.count-suc-clause3 with suc-pred

--- a/test/Fail/Issue3810a.err
+++ b/test/Fail/Issue3810a.err
@@ -1,6 +1,5 @@
 Issue3810a.agda:14,1-21
 Global confluence check failed: f a unfolds to b which should
 further unfold to a but it does not.
-Possible fix: add a rule to rewrite b to a, or change the order of
-the rules so more specialized rules come later.
+Possible fix: add a rule to rewrite b to a
 when checking the pragma REWRITE rew₂

--- a/test/Fail/Issue3816.err
+++ b/test/Fail/Issue3816.err
@@ -1,6 +1,5 @@
 Issue3816.agda:17,1-33
 Global confluence check failed: f (λ z → g z) unfolds to
 f (λ _ → a) which should further unfold to a but it does not.
-Possible fix: add a rule to rewrite f (λ _ → a) to a, or change the
-order of the rules so more specialized rules come later.
+Possible fix: add a rule to rewrite f (λ _ → a) to a
 when checking the pragma REWRITE rewf₁ rewf₂ rewg

--- a/test/Fail/Issue3817.err
+++ b/test/Fail/Issue3817.err
@@ -1,6 +1,5 @@
 Issue3817.agda:16,1-28
 Global confluence check failed: f (lsuc g) unfolds to f (lsuc h)
 which should further unfold to a but it does not.
-Possible fix: add a rule to rewrite f (lsuc h) to a, or change the
-order of the rules so more specialized rules come later.
+Possible fix: add a rule to rewrite f (lsuc h) to a
 when checking the pragma REWRITE f-g f-h g-h

--- a/test/Fail/Issue3848.err
+++ b/test/Fail/Issue3848.err
@@ -8,6 +8,5 @@ with rew₁
 Issue3848.agda:30,1-21
 Global confluence check failed: g (f r) unfolds to g a which should
 further unfold to a but it does not.
-Possible fix: add a rule to rewrite g a to a, or change the order
-of the rules so more specialized rules come later.
+Possible fix: add a rule to rewrite g a to a
 when checking the pragma REWRITE rew₃

--- a/test/Fail/Issue4147.err
+++ b/test/Fail/Issue4147.err
@@ -1,12 +1,10 @@
 Issue4147.agda:21,5-22
-Global confluence check failed: A unfolds to ⊤ which should further
-unfold to ⊥ but it does not.
-Possible fix: add a rule to rewrite ⊤ to ⊥, or change the order of
-the rules so more specialized rules come later.
+Global confluence check failed: A unfolds to ⊥ which should further
+unfold to ⊤ but it does not.
+Possible fix: add a rule to rewrite ⊥ to ⊤
 when checking the pragma REWRITE q
 Issue4147.agda:21,5-22
-Global confluence check failed: A unfolds to ⊤ which should further
-unfold to ⊥ but it does not.
-Possible fix: add a rule to rewrite ⊤ to ⊥, or change the order of
-the rules so more specialized rules come later.
+Global confluence check failed: A unfolds to ⊥ which should further
+unfold to ⊤ but it does not.
+Possible fix: add a rule to rewrite ⊥ to ⊤
 when checking the pragma REWRITE q

--- a/test/Succeed/Issue3795.agda
+++ b/test/Succeed/Issue3795.agda
@@ -10,6 +10,7 @@ postulate
   a b c : Unit → A
   a→b : a ∗ ≡ b ∗
   a→c : ∀ x → a x ≡ c x
+  a→c' : a ∗ ≡ c ∗      -- for global confluence checker
   b→c : b ∗ ≡ c ∗
 
-{-# REWRITE a→b a→c b→c #-}
+{-# REWRITE a→b a→c a→c' b→c #-}

--- a/test/Succeed/RewritingGlobalConfluenceWithClauses.agda
+++ b/test/Succeed/RewritingGlobalConfluenceWithClauses.agda
@@ -1,0 +1,63 @@
+{-# OPTIONS --rewriting --confluence-check #-}
+
+open import Agda.Builtin.List
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+variable
+  A B : Set
+  x y z : A
+  xs ys zs : List A
+  f : A → B
+  m n : Nat
+
+cong : (f : A → B) → x ≡ y → f x ≡ f y
+cong f refl = refl
+
+trans : x ≡ y → y ≡ z → x ≡ z
+trans refl refl = refl
+
++zero : m + zero ≡ m
++zero {zero} = refl
++zero {suc m} = cong suc +zero
+
+suc+zero : suc m + zero ≡ suc m
+suc+zero = +zero
+
++suc : m + (suc n) ≡ suc (m + n)
++suc {zero} = refl
++suc {suc m} = cong suc +suc
+
+zero+suc : zero + (suc n) ≡ suc n
+zero+suc = refl
+
+suc+suc : (suc m) + (suc n) ≡ suc (suc (m + n))
+suc+suc = cong suc +suc
+
+{-# REWRITE +zero +suc suc+zero zero+suc suc+suc #-}
+
+map : (A → B) → List A → List B
+map f [] = []
+map f (x ∷ xs) = (f x) ∷ (map f xs)
+
+_++_ : List A → List A → List A
+[] ++ ys = ys
+(x ∷ xs) ++ ys = x ∷ (xs ++ ys)
+
+++-[] : xs ++ [] ≡ xs
+++-[] {xs = []} = refl
+++-[] {xs = x ∷ xs} = cong (_∷_ x) ++-[]
+
+∷-++-[] : (x ∷ xs) ++ [] ≡ x ∷ xs
+∷-++-[] = ++-[]
+
+map-id : map (λ x → x) xs ≡ xs
+map-id {xs = []} = refl
+map-id {xs = x ∷ xs} = cong (_∷_ x) map-id
+
+map-id-∷ : map (λ x → x) (x ∷ xs) ≡ x ∷ xs
+map-id-∷ = map-id
+
+{-# REWRITE ++-[] ∷-++-[] #-}
+{-# REWRITE map-id map-id-∷ #-}

--- a/test/interaction/Issue4333.out
+++ b/test/interaction/Issue4333.out
@@ -7,8 +7,7 @@ Global confluence check failed: Issue4333.M.a unfolds to
 Issue4333.M.a₁' which should further unfold to Issue4333.M.a₀' but
 it does not.
 Possible fix: add a rule to rewrite Issue4333.M.a₁' to
-Issue4333.M.a₀', or change the order of the rules so more
-specialized rules come later.
+Issue4333.M.a₀'
 when scope checking the declaration
 open import Issue4333.N1
 Issue4333/N.agda:6,1-25
@@ -16,7 +15,6 @@ Global confluence check failed: Issue4333.M.a unfolds to
 Issue4333.M.a₁' which should further unfold to Issue4333.M.a₀' but
 it does not.
 Possible fix: add a rule to rewrite Issue4333.M.a₁' to
-Issue4333.M.a₀', or change the order of the rules so more
-specialized rules come later.
+Issue4333.M.a₀'
 when scope checking the declaration
 open import Issue4333.N1


### PR DESCRIPTION
Previously one had to give the rules in the right order for them to pass the global confluence check. This was sometimes not even possible because some of the rules were actually created from clauses of a definition. This PR fixes this problem by automatically sorting the rules according to the generality of their left-hand sides. It also contains some refactorings and performance improvements to the confluence checker that I did along the way.