### PR TITLE
[ fixed #5103 ] --allow-unsolved-metas in compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -576,6 +576,12 @@ for additional details.
   }
   ```
 
+Compiler backends
+-----------------
+
+- With option `--allow-unsolved-metas`, code with holes can be compiled.
+  If a hole is reached at runtime, the compiled program crashes.
+  See issue [#5103](https://github.com/agda/agda/issues/5103)
 
 JS backend
 ----------

--- a/src/data/MAlonzo/src/MAlonzo/RTE.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE.hs
@@ -37,6 +37,9 @@ mazIncompleteMatch s = error ("Agda: incomplete pattern matching: " ++ s)
 mazUnreachableError :: a
 mazUnreachableError = error ("Agda: unreachable code reached.")
 
+mazHole :: String -> a
+mazHole s = error ("Agda: reached hole: " ++ s)
+
 addInt :: Integer -> Integer -> Integer
 addInt = (+)
 

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -532,6 +532,7 @@ compileTerm kit t = go t
       T.TSort -> unit
       T.TErased -> unit
       T.TError T.TUnreachable -> return Undefined
+      T.TError T.TMeta{}      -> return Undefined
       T.TCoerce t -> go t
 
     getDef (T.TDef f) = Just (Left f)

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -195,8 +195,6 @@ data GHCDefinition = GHCDefinition
 
 ghcPreCompile :: GHCFlags -> TCM GHCCompileEnv
 ghcPreCompile flags = do
-  allowUnsolved <- optAllowUnsolved <$> pragmaOptions
-  when allowUnsolved $ genericError $ "Unsolved meta variables are not allowed when compiling."
   outDir <- compileDir
   let ghcOpts = GHCOptions
                 { optGhcCallGhc    = flagGhcCallGhc flags
@@ -764,6 +762,7 @@ noApplication = \case
   T.TErased   -> return $ hsVarUQ $ HS.Ident mazErasedName
   T.TError e  -> return $ case e of
     T.TUnreachable -> rtmUnreachableError
+    T.TMeta s      -> rtmHole s
 
 hsCoerce :: HS.Exp -> HS.Exp
 hsCoerce t = HS.App mazCoerce t

--- a/src/full/Agda/Compiler/MAlonzo/Misc.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Misc.hs
@@ -247,6 +247,12 @@ mazUnreachableError = HS.Var $ HS.Qual mazRTE $ HS.Ident "mazUnreachableError"
 rtmUnreachableError :: HS.Exp
 rtmUnreachableError = mazUnreachableError
 
+mazHole :: HS.Exp
+mazHole = HS.Var $ HS.Qual mazRTE $ HS.Ident "mazHole"
+
+rtmHole :: String -> HS.Exp
+rtmHole s = mazHole `HS.App` HS.Lit (HS.String $ T.pack s)
+
 mazAnyType :: HS.Type
 mazAnyType = HS.TyCon (hsName mazAnyTypeName)
 

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -427,7 +427,7 @@ substTerm term = normaliseStatic term >>= \ term ->
         C.mkTApp (C.TCon c') <$> substArgs args
     I.Pi _ _ -> return C.TUnit
     I.Sort _  -> return C.TSort
-    I.MetaV _ _ -> __IMPOSSIBLE__   -- we don't compiled if unsolved metas
+    I.MetaV x _ -> return $ C.TError $ C.TMeta $ prettyShow x
     I.DontCare _ -> return C.TErased
     I.Dummy{} -> __IMPOSSIBLE__
 

--- a/src/full/Agda/Syntax/Treeless.hs
+++ b/src/full/Agda/Syntax/Treeless.hs
@@ -213,6 +213,10 @@ data TError
   -- Runtime behaviour of unreachable code is undefined, but preferably
   -- the program will exit with an error message. The compiler is free
   -- to assume that this code is unreachable and to remove it.
+  | TMeta String
+  -- ^ Code which could not be obtained because of a hole in the program.
+  -- This should throw a runtime error.
+  -- The string gives some information about the meta variable that got compiled.
   deriving (Data, Show, Eq, Ord)
 
 

--- a/test/Compiler/simple/VecReverse.agda
+++ b/test/Compiler/simple/VecReverse.agda
@@ -1,3 +1,7 @@
+-- Andreas, 2020-12-16, also test #5103
+-- Allow compilation with unsolved metas
+
+{-# OPTIONS --allow-unsolved-metas #-}
 
 module _ where
 
@@ -22,7 +26,7 @@ foldl B f z (x ∷ xs) = foldl (λ n → B (suc n)) f (f z x) xs
 foldl B f z [] = z
 
 reverse : ∀ {A n} → Vec A n → Vec A n
-reverse = foldl (Vec _) (λ xs x → x ∷ xs) []
+reverse = foldl (Vec {!!}) (λ xs x → x ∷ xs) []  -- inessential unsolved meta here
 
 downFrom : ∀ n → Vec Nat n
 downFrom zero    = []


### PR DESCRIPTION
[ fixed #5103 ] `--allow-unsolved-metas` in compilation

Unsolved metas are compiled to runtime errors.

Being able to compile and run a partial program might be beneficial in the development cycle.  At least I do not see a reason why to categorically refuse it if the user explicitly does `--allow-unsolved-metas`.