### PR TITLE
Fix --only-scope-checking + (vim,interact…) exclusivity check

### DIFF
--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -321,26 +321,22 @@ type Flag opts = opts -> OptM opts
 -- | Checks that the given options are consistent.
 
 checkOpts :: Flag CommandLineOptions
-checkOpts opts
-  | or [ p opts && matches ps > 1 | (p, ps) <- exclusive ] =
-      throwError exclusiveMessage
-  | otherwise = return opts
-  where
-  matches = length . filter ($ opts)
-  atMostOne = map fst exclusive
-
-  exclusive =
-    [ ( optOnlyScopeChecking
-      , optGenerateVimFile :
-        atMostOne
-      )
-    ]
-
-  exclusiveMessage = unlines $
-    [ "The options --interactive, --interaction, --interaction-json and"
-    , "--only-scope-checking cannot be combined with each other."
-    , "Furthermore --only-scope-checking cannot be combined with --vim."
-    ]
+checkOpts opts = do
+  -- NOTE: This is a temporary hold-out until --vim can be converted into a backend or plugin,
+  -- whose options compatibility currently is checked in `Agda.Compiler.Backend`.
+  --
+  -- Additionally, note that some options checking is performed in `Agda.Main`
+  -- in which the top-level frontend and backend interactors are selected.
+  --
+  -- Those checks are not represented here, because:
+  --   - They are used solely for selecting the initial executon mode; they
+  --     don't need to be checked on a per-module etc basis.
+  --   - I hope/expect that the presence of those specific flags will be eventually
+  --     abstracted out (like the Backends' internal flags), so that they are invisible
+  --     to the rest of the type-checking system.
+  when (optGenerateVimFile opts && optOnlyScopeChecking opts) $
+    throwError $ "The --only-scope-checking flag cannot be combined with --vim."
+  return opts
 
 -- | Check for unsafe pragmas. Gives a list of used unsafe flags.
 

--- a/test/Fail/OnlyScopeCheckingEmacs.err
+++ b/test/Fail/OnlyScopeCheckingEmacs.err
@@ -1,0 +1,4 @@
+ret > ExitFailure 71
+out > Error: The --only-scope-checking flag cannot be combined with --interaction
+out > Run 'agda --help' for help on command line options.
+out >

--- a/test/Fail/OnlyScopeCheckingEmacs.flags
+++ b/test/Fail/OnlyScopeCheckingEmacs.flags
@@ -1,0 +1,1 @@
+--only-scope-checking --interaction

--- a/test/Fail/OnlyScopeCheckingJSON.err
+++ b/test/Fail/OnlyScopeCheckingJSON.err
@@ -1,0 +1,4 @@
+ret > ExitFailure 71
+out > Error: The --only-scope-checking flag cannot be combined with --interaction-json
+out > Run 'agda --help' for help on command line options.
+out >

--- a/test/Fail/OnlyScopeCheckingJSON.flags
+++ b/test/Fail/OnlyScopeCheckingJSON.flags
@@ -1,0 +1,1 @@
+--only-scope-checking --interaction-json

--- a/test/Fail/OnlyScopeCheckingRepl.err
+++ b/test/Fail/OnlyScopeCheckingRepl.err
@@ -1,0 +1,4 @@
+ret > ExitFailure 71
+out > Error: The --only-scope-checking flag cannot be combined with --interactive
+out > Run 'agda --help' for help on command line options.
+out >

--- a/test/Fail/OnlyScopeCheckingRepl.flags
+++ b/test/Fail/OnlyScopeCheckingRepl.flags
@@ -1,0 +1,1 @@
+--only-scope-checking --interactive

--- a/test/Fail/OnlyScopeCheckingVim.err
+++ b/test/Fail/OnlyScopeCheckingVim.err
@@ -1,0 +1,4 @@
+ret > ExitFailure 71
+out > Error: The --only-scope-checking flag cannot be combined with --vim.
+out > Run 'agda --help' for help on command line options.
+out >

--- a/test/Fail/OnlyScopeCheckingVim.flags
+++ b/test/Fail/OnlyScopeCheckingVim.flags
@@ -1,0 +1,1 @@
+--only-scope-checking --vim


### PR DESCRIPTION
This additionally adds `Fail` tests to check that behaviour.
Fixes agda/agda#5101