### PR TITLE
[ #3215 ] Show context of type errors in separate buffer

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -963,7 +963,7 @@ contextOfMeta :: InteractionId -> Rewrite -> TCM [ResponseContextEntry]
 contextOfMeta ii norm = withInteractionId ii $ do
   info <- getMetaInfo <$> (lookupMeta =<< lookupInteractionId ii)
   withMetaInfo info $ getCurrentContext norm
-  
+
 getCurrentContext :: Rewrite -> TCM [ResponseContextEntry]
 getCurrentContext norm = do
   -- List of local variables.

--- a/src/full/Agda/Interaction/EmacsCommand.hs
+++ b/src/full/Agda/Interaction/EmacsCommand.hs
@@ -11,6 +11,7 @@ module Agda.Interaction.EmacsCommand
   , clearRunningInfo
   , clearWarning
   , displayRunningInfo
+  , displayInBuffer
   ) where
 
 import qualified Data.List as List


### PR DESCRIPTION
This is a first (possibly quite naive) attempt at fixing #3215. It adds a new buffer *Error Context* to the Emacs mode that displays the context when there is a type error. Currently the buffer is not focused automatically, so the user has to open it manually to see the context. Any comments or suggestions for how to improve this are welcome.