### PR TITLE
[ workflow, close #2570 ] Upload haddock to gh-pages

### DIFF
--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -71,6 +71,7 @@ jobs:
 
     - name: Deploy haddock
       uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/master'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: html

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -16,26 +16,25 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
+        ghc-ver: ["8.10.2"]
+        cabal-ver: ["3.2"]
+
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
       && !contains(github.event.head_commit.message, '[ci skip]')
       && !contains(github.event.head_commit.message, '[github skip]')
       && !contains(github.event.head_commit.message, '[skip github]')
 
-    strategy:
-      matrix:
-        os: ["ubuntu-18.04"]
-        ghc-ver: ["8.10.2"]
-        cabal-ver: ["3.2"]
-
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: recursive
 
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1
+      id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc-ver }}
         cabal-version: ${{ matrix.cabal-ver }}
@@ -47,16 +46,32 @@ jobs:
 
     - uses: actions/cache@v2
       name: Cache dependencies
+      id: cache
       with:
-        path: "~/.cabal"
-        key: ${{ runner.os }}-new-cabal-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver }}-${{ hashFiles('**/plan.json') }}
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+        # The file `plan.json` contains the build information.
+        key: ${{ runner.os }}-cabal-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver }}-${{ hashFiles('**/plan.json') }}
 
     - name: Install dependencies
+      if: ${{ !steps.cache.outputs.cache-hit }}
       run: |
-        cabal install alex happy --overwrite-policy=always
         cabal build --dependencies-only --force-reinstalls
 
     # Testing Haddock [Issue 1773]
     - name: Build Haddock
       run: |
-        cabal haddock
+        cabal haddock --haddock-html-location='https://hackage.haskell.org/package/$pkg-$version/docs' --haddock-hyperlink-source --haddock-quickjump
+
+    - name: Prepare to upload built htmls
+      run: |
+        mkdir html
+        find dist-newstyle -path '*/doc/html/Agda' -type d -exec cp -R {} html\doc \;
+        ls -R html
+
+    - name: Deploy haddock
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: html
+

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Prepare to upload built htmls
       run: |
         mkdir html
-        find dist-newstyle -path '*/doc/html/Agda' -type d -exec cp -R {} html\doc \;
+        find dist-newstyle -path '*/doc/html/Agda' -type d -exec cp -R {} html/docs \;
         ls -R html
 
     - name: Deploy haddock


### PR DESCRIPTION
As discussed in #2570, I modified the workflow `haddock.yml` to upload the Haddock documentation to the project site using GitHub Pages. 

The uploaded site will look like https://l-tchen.github.io/agda/ but in a different URL, i.e. https://agda.github.io/agda/. 

What I am not sure of is the URL and how do make it usable. Any suggestions? 