### PR TITLE
[ #5117 ] Avoid redundant solution attempts for instance constraints

### DIFF
--- a/benchmark/misc/InstanceArgs.agda
+++ b/benchmark/misc/InstanceArgs.agda
@@ -1,0 +1,79 @@
+module InstanceArgs where
+
+data UnitMonoid : Set where
+  u : UnitMonoid
+  p : UnitMonoid → UnitMonoid → UnitMonoid
+
+record Plus (A : Set) : Set where
+  infixl 6 _+_
+  field
+    _+_ : A → A → A
+
+open Plus {{...}}
+
+instance
+  plus-unitMonoid : Plus UnitMonoid
+  plus-unitMonoid = record { _+_ = p }
+
+bigValue : UnitMonoid
+bigValue =
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u +
+  u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u + u

--- a/benchmark/tests.mk
+++ b/benchmark/tests.mk
@@ -31,7 +31,8 @@ functor			 = $(call misc,Functor)
 latemeta		 = $(call misc,LateMetaVariableInstantiation)
 polyfunctor  = $(call misc,UniversePolymorphicFunctor)
 patternmatch = $(call misc,Coverage)
-miscTests		 = functor latemeta polyfunctor patternmatch
+instanceargs = $(call misc,InstanceArgs)
+miscTests		 = functor latemeta polyfunctor patternmatch instanceargs
 
 #proj
 proj = proj/$1.agda -iproj --ignore-interfaces

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -255,7 +255,6 @@ findInstance' m cands = ifM (isFrozen m) (do
       reportSLn "tc.instance" 70 $ "findInstance 3: t: " ++ prettyShow t
 
       mcands <-
-        nowConsideringInstance $
         -- Temporarily remove other instance constraints to avoid
         -- redundant solution attempts
         holdConstraints (const isInstanceProblemConstraint) $
@@ -511,6 +510,7 @@ checkCandidates m t cands =
         where
           runCandidateCheck check =
             flip catchError handle $
+            nowConsideringInstance $
             ifNoConstraints check
               (\ r -> case r of
                   Yes           -> r <$ debugSuccess


### PR DESCRIPTION
A suggestion for solving #5117. See that issue for more context.

Fixes the issue by temporarily removing all instance constraints from the typechecker state while an instance argument search is in progress. Since none of those instance constraints could be resolved anyway, due to the restriction on recursive instance search, this avoids wasted work without impacting correctness. It brings the typechecking time for [my example file](https://github.com/cruhland/agda-axiomatic/blob/3a05ebd0de707a2ccffaa04e9ec8c40d6358e8c9/src/net/cruhland/models/Integers/Multiplication.agda) way down, from over 3 minutes to about 20 seconds!

I don't have a good understanding of the overall design of the constraint solver, so I'm sure there's a better approach. But I figured this is a good starting point for discussion. Happy to make changes, add tests, etc., but I might need some guidance on how to do so :smiley: 