### PR TITLE
[ cabal ] relax bounds on bytestring, time, and tasty-*

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -201,7 +201,7 @@ library
                 , binary >= 0.8.3.0 && < 0.9
                 , blaze-html >= 0.8 && < 0.10
                 , boxes >= 0.1.3 && < 0.2
-                , bytestring >= 0.10.8.1 && < 0.11
+                , bytestring >= 0.10.8.1 && < 0.12
                 , case-insensitive >= 1.2.0.4 && < 1.3
                 , containers >= 0.5.7.1 && < 0.7
                 , data-hash >= 0.2.0.0 && < 0.3
@@ -239,7 +239,7 @@ library
                 , stm >= 2.4.4 && < 2.6
                 , strict >= 0.3.2 && < 0.5
                 , template-haskell >= 2.11.0.0 && < 2.18
-                , time >= 1.6.0.1 && < 1.10
+                , time >= 1.6.0.1 && < 1.12
                 , unordered-containers >= 0.2.5.0 && < 0.3
                 , uri-encode >= 1.5.0.4 && < 1.6
                 , zlib == 0.6.*
@@ -865,7 +865,7 @@ test-suite agda-tests
   build-depends:  Agda
                 , array >= 0.5.1.1 && < 0.6
                 , base >= 4.9.0.0 && < 4.16
-                , bytestring >= 0.10.8.1 && < 0.11
+                , bytestring >= 0.10.8.1 && < 0.12
                 -- containers-0.5.11.0 is the first to contain IntSet.intersection
                 , containers >= 0.5.11.0 && < 0.7
                 , directory >= 1.2.6.2 && < 1.4
@@ -879,12 +879,12 @@ test-suite agda-tests
                 , process-extras >= 0.3.0 && < 0.3.4 || >= 0.4.1.3 && < 0.5 || >= 0.7.1 && < 0.8
                 , QuickCheck >= 2.14.1 && < 2.15
                 , regex-tdfa >= 1.3.1.0 && < 1.4
-                , tasty >= 1.1.0.4 && < 1.3
-                --, tasty >= 1.2.2 && < 1.3
+                , tasty >= 1.1.0.4 && < 1.5
                 , tasty-hunit >= 0.9.2 && < 0.11
                 , tasty-quickcheck >= 0.9.2 && < 0.11
                 -- tasty-silver 3.1.13 has option --ansi-tricks=false
-                , tasty-silver >= 3.1.13 && < 3.2
+                -- NB: tasty-silver 3.2 requires tasty >= 1.4
+                , tasty-silver >= 3.1.13 && < 3.3
                 , temporary >= 1.2.0.3 && < 1.4
                 , unix-compat >= 0.4.3.1 && < 0.6
                 , uri-encode >= 1.5.0.4 && < 1.6


### PR DESCRIPTION
[ cabal ] relax bounds on bytestring, time, and tasty-*

Addresses complaints by `cabal outdated`.

What stack concerns, liberal upper bounds are preferable.
Testing on GHA/travis...