### PR TITLE
[ travis ] require cabal version >= 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,13 @@ jobs:
     - <<: *complete-job
       env: GHC_VER=8.4.4 CABAL_VER=2.2
     - <<: *complete-job
-      env: GHC_VER=8.2.2 CABAL_VER=2.0
+      env: GHC_VER=8.2.2 CABAL_VER=2.2
     - <<: *complete-job
-      env: GHC_VER=8.0.2 CABAL_VER=1.24
+      env: GHC_VER=8.0.2 CABAL_VER=2.2
+    # Andreas, 2021-01-16: Problems with older cabal versions
+    # E.g. https://travis-ci.org/github/agda/agda/builds/754755486
+    # See #4770
+    # - <<: *complete-job
+    #   env: GHC_VER=8.2.2 CABAL_VER=2.0
+    # - <<: *complete-job
+    #   env: GHC_VER=8.0.2 CABAL_VER=1.24

--- a/.travis/cabal_install
+++ b/.travis/cabal_install
@@ -51,7 +51,12 @@ travis_fold start "build.dependencies"
 
 title "Building dependencies"
 # travis_retry cabal fetch `cabal install --dependencies-only --enable-tests --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g"`
-travis_retry make CABAL_OPTS=-v0 install-deps
+# Only install dependencies separately if GHC version > 8.2
+# See Pull Request #4770
+
+if [[ $GHC_VER != "8.0.2" && $GHC_VER != "8.2.2" ]]; then
+  travis_retry make CABAL_OPTS=-v0 install-deps
+fi
 
 travis_fold end "build.dependencies"
 ##############################################################################

--- a/.travis/cabal_install
+++ b/.travis/cabal_install
@@ -51,7 +51,7 @@ travis_fold start "build.dependencies"
 
 title "Building dependencies"
 # travis_retry cabal fetch `cabal install --dependencies-only --enable-tests --dry-run | sed 1,2d | sed "s|(latest[^)]*)||g"`
-travis_retry make CABAL_OPTS='-v0 --only-dependencies' install-bin
+travis_retry make CABAL_OPTS=-v0 install-deps
 
 travis_fold end "build.dependencies"
 ##############################################################################

--- a/.travis/cabal_install
+++ b/.travis/cabal_install
@@ -70,7 +70,7 @@ title "Building Agda"
 if [[ $GHC_VER == "8.0.2" ]]; then
   make BUILD_DIR=$BUILD_DIR CABAL_OPTS="-v1 --ghc-option=-fno-specialise --ghc-option=-fno-expose-all-unfoldings" install-bin
 else
-  make BUILD_DIR=$BUILD_DIR CABAL_OPTS=-v1 install-bin
+  make BUILD_DIR=$BUILD_DIR CABAL_OPTS="-v1 --force-reinstalls" install-bin
 fi
 
 travis_fold end "build.agda"

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ else
 endif
 
 .PHONY: install-bin ## Install Agda and test suites via cabal (or stack if stack.yaml exists).
-install-bin: install-deps ensure-hash-is-correct
+install-bin: ensure-hash-is-correct
 ifdef HAS_STACK
 	@echo "===================== Installing using Stack with test suites ============"
 	time $(STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)


### PR DESCRIPTION
Require cabal version >= 2.2 on travis. See #4770 and https://github.com/agda/agda/pull/5135#issuecomment-761559724.

- ghc 8.0: cabal 1.24 not supported by hvr's haskell CI
- ghc 8.2: cabal 2.0 problems with --only-dependencies !?
