### PR TITLE
Update to standard-library-v1.5

### DIFF
--- a/test/Compiler/with-stdlib/DivMod.agda
+++ b/test/Compiler/with-stdlib/DivMod.agda
@@ -4,8 +4,9 @@ open import IO
 open import Data.Nat
 open import Data.Nat.DivMod
 open import Codata.Musical.Notation
-open import Data.String
-open import Data.Fin
+open import Data.String.Base
+open import Data.Fin.Base using (toℕ)
+open import Level using (0ℓ)
 
 g : ℕ
 g = 7 div 5
@@ -17,4 +18,4 @@ showNat : ℕ → String
 showNat zero = "Z"
 showNat (suc x) = "S (" ++ showNat x ++ ")"
 
-main = run (♯ (putStrLn (showNat g)) >> ♯ (putStrLn (showNat k)))
+main = run {0ℓ} (putStrLn (showNat g) >> putStrLn (showNat k))

--- a/test/Compiler/with-stdlib/HelloWorld.agda
+++ b/test/Compiler/with-stdlib/HelloWorld.agda
@@ -3,5 +3,6 @@ module HelloWorld where
 open import IO
 open import Data.String
 open import Data.Unit
+open import Level using (0ℓ)
 
-main = run (putStrLn "Hello World!")
+main = run {0ℓ} (putStrLn "Hello World!")

--- a/test/Compiler/with-stdlib/ShowNat.agda
+++ b/test/Compiler/with-stdlib/ShowNat.agda
@@ -3,5 +3,6 @@ module ShowNat where
 open import IO
 open import Data.Unit
 open import Data.Nat.Show
+open import Level using (0ℓ)
 
-main = run (putStrLn (Data.Nat.Show.show 10))
+main = run {0ℓ} (putStrLn (Data.Nat.Show.show 10))

--- a/test/Compiler/with-stdlib/TrustMe.agda
+++ b/test/Compiler/with-stdlib/TrustMe.agda
@@ -7,10 +7,11 @@ open import IO
 import IO.Primitive as Prim
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary
+open import Level using (0ℓ)
 
 -- Check that trustMe works.
 
-testTrustMe : IO ⊤
+testTrustMe : IO {0ℓ} ⊤
 testTrustMe with "apa" ≟ "apa"
 ... | yes refl = putStrLn "Yes!"
 ... | no  _    = putStrLn "No."

--- a/test/Compiler/with-stdlib/Vec.agda
+++ b/test/Compiler/with-stdlib/Vec.agda
@@ -5,6 +5,7 @@ open import IO
 open import Data.Vec
 open import Data.Nat
 open import Data.Nat.Show
+open import Level using (0ℓ)
 
 Matrix : Set -> ℕ -> ℕ -> Set
 Matrix a n m = Vec (Vec a m) n
@@ -34,4 +35,4 @@ compute = sum (map sum g)
         g : Matrix ℕ 3 3
         g = madd (transposeM (transposeM m)) (transposeM (madd m idMatrix))
 
-main = run (putStrLn (show compute))
+main = run {0ℓ} (putStrLn (show compute))

--- a/test/Compiler/with-stdlib/dimensions.agda
+++ b/test/Compiler/with-stdlib/dimensions.agda
@@ -248,18 +248,16 @@ throw  ℕ.zero   dt p = p V.∷ V.[]
 throw (ℕ.suc n) dt p = p V.∷ throw n dt (newton dt p)
 
 -- the display function generating the output
-open import Data.List       as L using (List)
 open import Data.String     renaming (_++_ to _+s+_)
-open import Data.Product
 open import IO
 import IO.Primitive
-open import Codata.Musical.Notation
 open import Codata.Musical.Colist
 open import Data.Nat.Show as Nat
+open import Level using (0ℓ)
 
-printPoint : point → IO ⊤
+printPoint : point → IO {0ℓ} ⊤
 printPoint p = putStrLn ((Nat.show (val (x p))) +s+ ";" +s+ Nat.show (val (y p)))
 
 main : IO.Primitive.IO ⊤
-main = run (♯ (mapM printPoint (Codata.Musical.Colist.fromList trace)) >> (♯ (return _)))
+main = run (Colist.mapM printPoint (Codata.Musical.Colist.fromList trace) >> return _)
   where trace = V.toList $ throw 15 ⟨ 1 ∶ s ⟩ base


### PR DESCRIPTION
This PR updates the stdlib module's experimental branch to include changes about to be released in version 1.5 of the standard library.

Unfortunately #5147 is causing the standard library to no longer type-check.