### PR TITLE
Issue 5147

### DIFF
--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -157,9 +157,12 @@ computeGeneralization genRecMeta nameMap allmetas = postponeInstanceConstraints 
   -- Pair metas with their metaInfo
   mvs <- mapM ((\ x -> (x,) <$> lookupMeta x) . MetaId) $ IntSet.toList allmetas
 
-  constrainedMetas <- Set.unions <.> mapM (constraintMetas . clValue . theConstraint) =<<
-                        ((++) <$> useTC stAwakeConstraints
-                              <*> useTC stSleepingConstraints)
+  cs <- (++) <$> useTC stAwakeConstraints
+             <*> useTC stSleepingConstraints
+
+  reportSDoc "tc.generalize" 50 $ "current constraints:" <?> vcat (map prettyTCM cs)
+
+  constrainedMetas <- Set.unions <$> mapM (constraintMetas . clValue . theConstraint) cs
 
   reportSDoc "tc.generalize" 30 $ nest 2 $
     "constrainedMetas     = " <+> prettyList_ (map prettyTCM $ Set.toList constrainedMetas)

--- a/test/Succeed/Issue5147.agda
+++ b/test/Succeed/Issue5147.agda
@@ -1,0 +1,21 @@
+open import Agda.Primitive
+open import Agda.Builtin.List
+open import Agda.Builtin.Equality
+
+private
+  variable
+    a p : Level
+    A : Set a
+    P Q : A → Set p
+
+data Any {a p} {A : Set a} (P : A → Set p) : List A → Set (a ⊔ p) where
+  here  : ∀ {x xs} (px  : P x)      → Any P (x ∷ xs)
+  there : ∀ {x xs} (pxs : Any P xs) → Any P (x ∷ xs)
+
+map : (∀ {x} → P x → Q x) → (∀ {xs} → Any P xs → Any Q xs)
+map g (here px)   = here (g px)
+map g (there pxs) = there (map g pxs)
+
+postulate
+  map-id : ∀ (f : ∀ {x} → P x → P x) → (∀ {x} (p : P x) → f p ≡ p) →
+          ∀ {xs} → (p : Any P xs) → map f p ≡ p


### PR DESCRIPTION
Fixes #5147.

Don't block generalization for metas in types of constraints.

Since a constraint u = v : A doesn't contribute to solving metas in A, it makes sense to allow generalization over these metas.

