### PR TITLE
Make case on clause with instance-opened projection

### DIFF
--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -249,9 +249,10 @@ makeCase hole rng s = withInteractionId hole $ locallyTC eMakeCase (const True) 
       , "perm    =" <+> text (show perm)
       , "ps      =" <+> prettyTCMPatternList ps
       , "ell     =" <+> text (show ell)
+      , "type    =" <+> prettyTCM (clauseType clause)
       ]
     ]
-  reportSDoc "interaction.case" 60 $ vcat
+  reportSDoc "interaction.case" 100 $ vcat
     [ "splitting clause:"
     , nest 2 $ vcat
       [ "f       =" <+> (text . show) f

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1684,7 +1684,9 @@ disambiguateProjection h ambD@(AmbQ ds) b = do
         -- If this was not an ambiguous projection, that's an error.
         argd <- maybe (wrongProj d) return $ List.find ((d ==) . unDom) fs
 
-        let ai = setModality (getModality argd) $ projArgInfo proj
+        -- Issue4998: The ArgInfo of the projection's principal argument is not relevant for the
+        -- ArgInfo of the clause rhs.
+        let ai = getArgInfo argd
 
         reportSDoc "tc.lhs.split" 20 $ vcat
           [ text $ "original proj relevance  = " ++ show (getRelevance argd)
@@ -1693,7 +1695,7 @@ disambiguateProjection h ambD@(AmbQ ds) b = do
         -- Andreas, 2016-12-31, issue #2374:
         -- We can also disambiguate by hiding info.
         -- Andreas, 2018-10-18, issue #3289: postfix projections have no hiding info.
-        unless (caseMaybe h True $ sameHiding ai) $ wrongHiding d
+        unless (caseMaybe h True $ sameHiding $ projArgInfo proj) $ wrongHiding d
 
         -- Andreas, 2016-12-31, issue #1976: Check parameters.
         let chk = checkParameters qr r vs

--- a/test/interaction/Issue4998.agda
+++ b/test/interaction/Issue4998.agda
@@ -1,0 +1,10 @@
+
+open import Agda.Builtin.Nat
+
+record R : Set₁ where
+  field f : Nat
+
+open R ⦃ ... ⦄
+
+foo : Nat → R
+foo n .f = {!n!} -- C-c C-c makes clause disappear

--- a/test/interaction/Issue4998.in
+++ b/test/interaction/Issue4998.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 0 cmd_make_case "n"

--- a/test/interaction/Issue4998.out
+++ b/test/interaction/Issue4998.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : Nat " nil)
+((last . 1) . (agda2-goals-action '(0)))
+((last . 2) . (agda2-make-case-action '("foo zero .f = ?" "foo (suc n) .f = ?")))
+((last . 1) . (agda2-goals-action '(0)))


### PR DESCRIPTION
Fixes #4998.

Using the hiding of the principal argument for the clause type makes no sense, and triggered the omission of clauses for instance fields in co-pattern matches.