### PR TITLE
[ fix #4166 ] don't use instances that are not in scope

### DIFF
--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -1016,9 +1016,11 @@ everythingInScopeQualified scope =
       | Set.member name seen = chase seen ss
       | otherwise = s : chase (Set.insert name seen) (imports ++ submods ++ ss)
       where
+        -- #4166: only include things that are actually in scope here
+        inscope x _ = isInScope x == InScope
         name    = scopeName s
         imports = map lookP $ Map.elems $ scopeImports s
-        submods = map (lookP . amodName) $ concat $ Map.elems $ allNamesInScope s
+        submods = map (lookP . amodName) $ concat $ Map.elems $ Map.filterWithKey inscope $ allNamesInScope s
 
 -- | Compute a flattened scope. Only include unqualified names or names
 -- qualified by modules in the first argument.

--- a/test/Succeed/Issue4166.agda
+++ b/test/Succeed/Issue4166.agda
@@ -1,0 +1,10 @@
+
+open import Agda.Builtin.Bool
+
+open import Issue4166.Import {b = true} as A′
+
+it : ⦃ Bool ⦄ → Bool
+it ⦃ b ⦄ = b
+
+b : Bool
+b = it

--- a/test/Succeed/Issue4166/Import.agda
+++ b/test/Succeed/Issue4166/Import.agda
@@ -1,0 +1,9 @@
+
+open import Agda.Builtin.Bool
+
+module Issue4166.Import {b : Bool} where
+
+instance
+
+  i : Bool
+  i = b


### PR DESCRIPTION
When we create a fresh `NotInScope` module its contents should not be considered in scope for instance search.

Fixes #4166