### PR TITLE
[ fix #5033 ] Require primLockUniv when checking @lock/@tick

### DIFF
--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1366,7 +1366,7 @@ instance Reify Sort where
           I.Def sizeU [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSizeUniv
           return $ A.Def sizeU
         I.LockUniv  -> do
-          I.Def lockU [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLockUniv
+          lockU <- fromMaybe __IMPOSSIBLE__ <$> getName' builtinLockUniv
           return $ A.Def lockU
         I.PiSort a s1 s2 -> do
           pis <- freshName_ ("piSort" :: String) -- TODO: hack

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -326,7 +326,11 @@ checkDomain lamOrPi xs e = do
          applyCohesionToContext c $
          modEnv lamOrPi $ isType_ e
     -- Andrea TODO: also make sure that LockUniv implies IsLock
-    when (any (\ x -> getLock x == IsLock) xs) $
+    when (any (\ x -> getLock x == IsLock) xs) $ do
+         -- Solves issue #5033
+        unlessM (isJust <$> getName' builtinLockUniv) $ do
+          genericDocError $ "Missing binding for primLockUniv primitive."
+
         equalSort (getSort t) LockUniv
 
     return t

--- a/test/Fail/Issue5033.agda
+++ b/test/Fail/Issue5033.agda
@@ -1,0 +1,3 @@
+
+postulate
+  test : (@tick _ : _) → Set

--- a/test/Fail/Issue5033.err
+++ b/test/Fail/Issue5033.err
@@ -1,0 +1,3 @@
+Issue5033.agda:3,10-29
+Missing binding for primLockUniv primitive.
+when checking that the expression ∀ _ → Set is a type


### PR DESCRIPTION
We then get a proper error rather than __IMPOSSIBLE__.