### PR TITLE
Fix 5198

### DIFF
--- a/test/Succeed/Imports/Issue5198.agda
+++ b/test/Succeed/Imports/Issue5198.agda
@@ -1,0 +1,7 @@
+
+module Imports.Issue5198 (Y : Set₁) where
+
+record R : Set₂ where
+  constructor mkR
+  field
+    A : Set₁

--- a/test/Succeed/Issue5198.agda
+++ b/test/Succeed/Issue5198.agda
@@ -1,0 +1,16 @@
+
+module _ (_ : Set) where
+
+open import Imports.Issue5198 Set
+
+data D : Set where
+  r : D
+
+F : D → Set₂
+F r = R
+
+f : {d : D} → F d → F d
+f x = x
+
+_ : R
+_ = f record {A = Set}


### PR DESCRIPTION
Fix #5198 

We know the module params of the current module so don't generate metas for them when inferring the type of record expressions.