### PR TITLE
[ fixed #5205 ] Updated user manual tests.

### DIFF
--- a/doc/user-manual/tools/acmart-pdflatex.lagda.tex
+++ b/doc/user-manual/tools/acmart-pdflatex.lagda.tex
@@ -25,6 +25,8 @@
 \DisableLigatures[-]{encoding=T1}
 
 \begin{document}
+\acmConference{Some conference}
+\maketile
 
 Some code:
 \begin{code}

--- a/doc/user-manual/tools/acmart-xelatex.lagda.tex
+++ b/doc/user-manual/tools/acmart-xelatex.lagda.tex
@@ -20,6 +20,8 @@
 \renewcommand{\AgdaBoundFontStyle}[1]{\textit{\AgdaSerifFont{}#1}}
 
 \begin{document}
+\acmConference{Some conference}
+\maketile
 
 Some code:
 \begin{code}

--- a/test/LaTeXAndHTML/user-manual/acmart-pdflatex.quick.tex
+++ b/test/LaTeXAndHTML/user-manual/acmart-pdflatex.quick.tex
@@ -25,6 +25,8 @@
 \DisableLigatures[-]{encoding=T1}
 
 \begin{document}
+\acmConference{Some conference}
+\maketile
 
 Some code:
 \begin{code}%

--- a/test/LaTeXAndHTML/user-manual/acmart-pdflatex.tex
+++ b/test/LaTeXAndHTML/user-manual/acmart-pdflatex.tex
@@ -25,6 +25,8 @@
 \DisableLigatures[-]{encoding=T1}
 
 \begin{document}
+\acmConference{Some conference}
+\maketile
 
 Some code:
 \begin{code}%

--- a/test/LaTeXAndHTML/user-manual/acmart-xelatex.quick.tex
+++ b/test/LaTeXAndHTML/user-manual/acmart-xelatex.quick.tex
@@ -20,6 +20,8 @@
 \renewcommand{\AgdaBoundFontStyle}[1]{\textit{\AgdaSerifFont{}#1}}
 
 \begin{document}
+\acmConference{Some conference}
+\maketile
 
 Some code:
 \begin{code}%

--- a/test/LaTeXAndHTML/user-manual/acmart-xelatex.tex
+++ b/test/LaTeXAndHTML/user-manual/acmart-xelatex.tex
@@ -20,6 +20,8 @@
 \renewcommand{\AgdaBoundFontStyle}[1]{\textit{\AgdaSerifFont{}#1}}
 
 \begin{document}
+\acmConference{Some conference}
+\maketile
 
 Some code:
 \begin{code}%


### PR DESCRIPTION
The changes were required by the following version of `acmart.cls`:

[2020/11/15 v1.75 Typesetting articles for the Association for
Computing Machinery]