### PR TITLE
The standard library forbids ghc-9 base library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,7 +422,7 @@ quicklatex-test :
 .PHONY : std-library-test ##
 std-lib-test :
 	@$(call decorate, "Standard library test", \
-		(cd std-lib && cabal run GenerateEverything && \
+		(cd std-lib && cabal run GenerateEverything --allow-newer=base && \
 						time $(AGDA_BIN) $(AGDA_OPTS) --ignore-interfaces --no-default-libraries -v profile:$(PROFVERB) \
 														 -i. -isrc README.agda \
 														 +RTS -s))


### PR DESCRIPTION
The `GenerateEverything` program has an explicit upper bound on the base library that excludes base from ghc-9.0.1. Until that is fixed adding an `--allow-newer=base` to the `Makefile` lets the tests go through.

Related: #4955 and #5200.