### PR TITLE
[ hlint ] silence hlint warnings, but only the occurrences

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -39,7 +39,18 @@
 - ignore: {name: "Use Just"}
 - ignore: {name: "Use camelCase"}
 - ignore: {name: "Use const"}
+# Andreas, 2021-02-15
+# Silence specific hlint warnings, e.g.
+# https://github.com/agda/agda/pull/5214/checks?check_run_id=1909201141
+- ignore: {name: "Use curry", within: Agda.TypeChecking.Reduce.reduceWithBlocker }
 - ignore: {name: "Use empty"}
+- ignore:
+    name: "Use fmap"
+    within:
+      - Agda.TypeChecking.Rules.Application.checkPrimTrans
+      - Agda.TypeChecking.Primitive.Cubical.primTrans'
+      - Agda.TypeChecking.Primitive.Cubical.primComp
+      - Agda.Syntax.Concrete.Operators.parsePat
 - ignore: {name: "Use fromMaybe"}
 - ignore: {name: "Use id"}
 - ignore: {name: "Use infix"}

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -183,7 +183,7 @@ resolveName kinds candidates q = runExceptT $ tryResolveName kinds candidates q
 
 -- | Treat illegally ambiguous names as UnknownNames.
 resolveName_ :: C.QName -> [A.Name] -> AbsToCon ResolvedName
-resolveName_ q cands = either (const UnknownName) id <$> resolveName allKindsOfNames (Just $ Set.fromList cands) q
+resolveName_ q cands = fromRight (const UnknownName) <$> resolveName allKindsOfNames (Just $ Set.fromList cands) q
 
 -- The Monad --------------------------------------------------------------
 

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -655,7 +655,7 @@ checkArgumentsE' chk cmp exh r args0@(arg@(Arg info e) : args) t0 mt1 =
                   vis = all visible (telToList tel)
                   isRigid t | PathType{} <- viewPath t = return False -- Path is not rigid!
                   isRigid (El _ (Pi dom _)) = return $ visible dom
-                  isRigid (El _ (Def d _))  = theDef <$> getConstInfo d >>= return . \ case
+                  isRigid (El _ (Def d _))  = getConstInfo d <&> theDef <&> \ case
                     Axiom{}                   -> True
                     DataOrRecSig{}            -> True
                     AbstractDefn{}            -> True

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -136,7 +136,7 @@ composeP p1 (Perm n xs) = Perm n $ permute p1 xs
 --   @composeP p (invertP err p) == p@
 invertP :: Int -> Permutation -> Permutation
 invertP err p@(Perm n xs) = Perm (size xs) $ elems tmpArray
-  where tmpArray = accumArray (flip const) err (0, n-1) $ zip xs [0..]
+  where tmpArray = accumArray (const id) err (0, n-1) $ zip xs [0..]
 
 -- | Turn a possible non-surjective permutation into a surjective permutation.
 compactP :: Permutation -> Permutation


### PR DESCRIPTION
When adding an ignore, I only added it for the specific instances
where the warning was not useful.