### PR TITLE
Correct number of lambdas and unused arg analysis for absurd functions

### DIFF
--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -228,7 +228,7 @@ casetreeTop eval cc = flip runReaderT (initCCEnv eval) $ do
 casetree :: CC.CompiledClauses -> CC C.TTerm
 casetree cc = do
   case cc of
-    CC.Fail -> return C.tUnreachable
+    CC.Fail xs -> withContextSize (length xs) $ return C.tUnreachable
     CC.Done xs v -> withContextSize (length xs) $ do
       -- Issue 2469: Body context size (`length xs`) may be smaller than current context size
       -- if some arguments are not used in the body.
@@ -291,7 +291,7 @@ commonArity cc =
       where cxt' = max (x + 1) cxt
     arities cxt (Case _ Branches{projPatterns = True}) = [cxt]
     arities cxt (Done xs _) = [max cxt (length xs)]
-    arities _   Fail        = []
+    arities cxt (Fail xs)   = [max cxt (length xs)]
 
 
     wArities cxt (WithArity k c) = map (\ x -> x - k + 1) $ arities (cxt - 1 + k) c

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -107,7 +107,7 @@ instance NamesIn Clause where
 instance NamesIn CompiledClauses where
   namesIn' sg (Case _ c) = namesIn' sg c
   namesIn' sg (Done _ v) = namesIn' sg v
-  namesIn' sg Fail       = mempty
+  namesIn' sg Fail{}     = mempty
 
 -- Andreas, 2017-07-27
 -- Why ignoring the litBranches?

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -653,7 +653,7 @@ reifyTerm expandAnonDefs0 v0 = do
 
       -- Check if we have an absurd lambda.
       case def of
-       Function{ funCompiled = Just Fail, funClauses = [cl] }
+       Function{ funCompiled = Just Fail{}, funClauses = [cl] }
                 | isAbsurdLambdaName x -> do
                   -- get hiding info from last pattern, which should be ()
                   let h = getHiding $ last $ namedClausePats cl

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -152,14 +152,14 @@ compileWithSplitTree t cs = case t of
     compiles _ _ Branches{etaBranch = Just{}} = __IMPOSSIBLE__  -- we haven't inserted eta matches yet
 
 compile :: Cls -> CompiledClauses
-compile [] = Fail
+compile [] = Fail []
 compile cs = case nextSplit cs of
   Just (isRecP, n) -> Case n $ compile <$> splitOn isRecP (unArg n) cs
   Nothing -> case clBody c of
     -- It's possible to get more than one clause here due to
     -- catch-all expansion.
     Just t  -> Done (map (fmap name) $ clPats c) t
-    Nothing -> Fail
+    Nothing -> Fail (map (fmap name) $ clPats c)
   where
     -- If there are more than one clauses, take the first one.
     c = headWithDefault __IMPOSSIBLE__ cs

--- a/src/full/Agda/TypeChecking/CompiledClause/Match.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Match.hs
@@ -66,7 +66,7 @@ match' ((c, es, patch) : stack) = do
     case c of
 
       -- impossible case
-      Fail -> no (NotBlocked AbsurdMatch) es
+      Fail{} -> no (NotBlocked AbsurdMatch) es
 
       -- done matching
       Done xs t

--- a/src/full/Agda/TypeChecking/DropArgs.hs
+++ b/src/full/Agda/TypeChecking/DropArgs.hs
@@ -71,7 +71,8 @@ instance DropArgs CompiledClauses where
               | otherwise     -> Case (i <&> \ j -> j - n) $ fmap (dropArgs n) br
     Done xs t | length xs < n -> __IMPOSSIBLE__
               | otherwise     -> Done (drop n xs) t
-    Fail                      -> Fail
+    Fail xs   | length xs < n -> __IMPOSSIBLE__
+              | otherwise     -> Fail (drop n xs)
 
 instance DropArgs SplitTree where
   dropArgs n (SplittingDone m) = SplittingDone (m - n)

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -246,7 +246,7 @@ quotingKit = do
                     let (pars, args) = splitAt n ts
                     extlam !@ list (map (quoteClause Nothing . (`apply` pars)) cs)
                            @@ list (map (quoteArg quoteTerm) args)
-              qx df@Function{ funExtLam = Just (ExtLamInfo _ True _), funCompiled = Just Fail, funClauses = [cl] } = do
+              qx df@Function{ funExtLam = Just (ExtLamInfo _ True _), funCompiled = Just Fail{}, funClauses = [cl] } = do
                     -- See also corresponding code in InternalToAbstract
                     let n = length (namedClausePats cl) - 1
                         pars = take n ts

--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -148,7 +148,7 @@ translateCompiledClauses cc = ignoreAbstractMode $ do
 
     loop :: CompiledClauses -> m (CompiledClauses)
     loop cc = case cc of
-      Fail      -> return cc
+      Fail{}    -> return cc
       Done{}    -> return cc
       Case i cs -> loops i cs
 
@@ -211,7 +211,7 @@ recordExpressionsToCopatterns
   -> m CompiledClauses
 recordExpressionsToCopatterns = \case
     Case i bs -> Case i <$> traverse recordExpressionsToCopatterns bs
-    cc@Fail   -> return cc
+    cc@Fail{} -> return cc
     cc@(Done xs (Con c ConORec es)) -> do  -- don't translate if using the record /constructor/
       let vs = map unArg $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
       Constructor{ conArity = ar } <- theDef <$> getConstInfo (conName c)

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1470,7 +1470,7 @@ instance InstantiateFull a => InstantiateFull (Case a) where
       <*> pure lz
 
 instance InstantiateFull CompiledClauses where
-  instantiateFull' Fail        = return Fail
+  instantiateFull' (Fail xs)   = return $ Fail xs
   instantiateFull' (Done m t)  = Done m <$> instantiateFull' t
   instantiateFull' (Case n bs) = Case n <$> instantiateFull' bs
 

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -356,7 +356,7 @@ data FastCompiledClauses
 fastCompiledClauses :: BuiltinEnv -> CompiledClauses -> FastCompiledClauses
 fastCompiledClauses bEnv cc =
   case cc of
-    Fail              -> FFail
+    Fail{}            -> FFail
     Done xs b         -> FDone xs b
     Case (Arg _ n) Branches{ etaBranch = Just (c, cc), catchAllBranch = ca } ->
       FEta n (conFields c) (fastCompiledClauses bEnv $ content cc) (fastCompiledClauses bEnv <$> ca)

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -765,7 +765,7 @@ checkAbsurdLambda cmp i h e t = localTC (set eQuantity topQuantity) $ do
                     , clauseEllipsis  = NoEllipsis
                     }
                   ]
-              , funCompiled       = Just Fail
+              , funCompiled       = Just $ Fail [Arg info' "()"]
               , funSplitTree      = Just $ SplittingDone 0
               , funMutual         = Just []
               , funTerminates     = Just True

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -72,7 +72,7 @@ import Agda.Utils.IORef
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20201119 * 10 + 0
+currentInterfaceVersion = 20210216 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -435,12 +435,12 @@ instance EmbPrj a => EmbPrj (Case a) where
   value = valueN Branches
 
 instance EmbPrj CompiledClauses where
-  icod_ Fail       = icodeN' Fail
+  icod_ (Fail a)   = icodeN' Fail a
   icod_ (Done a b) = icodeN' Done a (P.killRange b)
   icod_ (Case a b) = icodeN 2 Case a b
 
   value = vcase valu where
-    valu []        = valuN Fail
+    valu [a]       = valuN Fail a
     valu [a, b]    = valuN Done a b
     valu [2, a, b] = valuN Case a b
     valu _         = malformed

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -81,7 +81,6 @@ disabledTests =
     -----------------------------------------------------------------------------
     -- The following test cases fail (at least at the time of writing)
     -- for the JS backend.
-  , disable "Compiler/JS_.*/simple/Issue4169-2"
   , disable "Compiler/JS_Optimized/simple/ModuleReexport"
   , disable "Compiler/JS_MinifiedOptimized/simple/ModuleReexport"
     -----------------------------------------------------------------------------


### PR DESCRIPTION
Strict backends need the lambdas to be there even if the body is unreachable.

Fixes #4280