### PR TITLE
Proposed fix for #4725

### DIFF
--- a/test/Succeed/Issue4725.agda
+++ b/test/Succeed/Issue4725.agda
@@ -1,0 +1,34 @@
+{-# OPTIONS --cubical #-}
+
+open import Agda.Builtin.Sigma
+
+mutual
+
+  data D : Set where
+    d : S → D
+
+  S : Set
+  S = Σ D λ x → R x
+
+  fst′ : S → D
+  fst′ s = fst s
+
+  data R : D → Set where
+    r : ∀ x → R (fst′ x) → R (d x)
+
+module _
+  (P : D → Set)
+  (Q : ∀ x → P x → R x → Set)
+  (p : ∀ s (p : P (fst s)) → Q (fst s) p (snd s) → P (d s))
+  (q : ∀ s rs (ps : P (fst s)) (qs : Q (fst s) ps (snd s)) →
+       Q (fst s) ps rs → Q (d s) (p s ps qs) (r s rs))
+  where
+
+  mutual
+
+    f : (x : D) → P x
+    f (d (x , r₁)) = p (x , r₁) (f x) (g x r₁)
+
+    g : (x : D) (x⊑y : R x) → Q x (f x) x⊑y
+    g (d (x , r₁)) (r .(x , r₁) r₂) =
+      q (x , r₁) r₂ (f x) (g x r₁) (g _ r₂)

--- a/test/Succeed/Issue4725b.agda
+++ b/test/Succeed/Issue4725b.agda
@@ -1,0 +1,17 @@
+{-# OPTIONS --cubical #-}
+
+mutual
+  data Ord : Set
+  data _≤_ : Ord -> Ord -> Set
+
+  data Ord where
+    succ  : Ord -> Ord
+    limit : (x y : Ord) -> (x<y : succ x ≤ y) → Ord
+
+  data _≤_ where
+    ≤-limiting  : ∀ x y x<y z -> (limit x y x<y) ≤ z
+
+≤-ind : (P : {x y : Ord} → x ≤ y → Set) →
+        (∀ x y x<y z → P x<y → P (≤-limiting x y x<y z)) →
+        (x y : Ord) → (x≤y : x ≤ y) → P x≤y
+≤-ind P l .(limit x y x<y) .z (≤-limiting x y x<y z) = l x y x<y z (≤-ind P l (succ x) y x<y)


### PR DESCRIPTION
This is my proposed fix for #4725 which allows the termination checker to look inside *some* dot patterns even with `--cubical`, namely dotted variables and dotted record constructors. It would be good if someone familiar with cubical such as @Saizan take a look if this is a good solution.