### PR TITLE
Handle surrogate code points

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -563,6 +563,7 @@ library
                     Agda.Utils.Benchmark
                     Agda.Utils.BiMap
                     Agda.Utils.CallStack
+                    Agda.Utils.Char
                     Agda.Utils.Cluster
                     Agda.Utils.Empty
                     Agda.Utils.Environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,6 +406,20 @@ Builtins
 
   All of these operations are implemented on the JavaScript backend.
 
+- `primNatToChar` maps surrogate code points to the replacement character
+  `'U+FFFD` and surrogate code points are disallowed in character literals
+
+  [Surrogate code points](https://www.unicode.org/glossary/#surrogate_code_point)
+  are characters in the range `U+D800` to `U+DFFF` and are reserved for use by
+  UTF-16.
+
+  The reason for this change is that strings are represented (at type-checking
+  time and in the GHC backend) by Data.Text byte strings, which cannot
+  represent surrogate code points and replaces them by `U+FFFD`. By doing the
+  same for characters we can have `primStringFromList` be injective (witnessed
+  by `Agda.Builtin.String.Properties.primStringFromListInjective`).
+
+
 Reflection
 ----------
 

--- a/doc/user-manual/language/built-ins.lagda.rst
+++ b/doc/user-manual/language/built-ins.lagda.rst
@@ -530,7 +530,9 @@ are available on characters (given suitable bindings for
 These functions are implemented by the corresponding Haskell functions from
 `Data.Char <data-char_>`_ (``ord`` and ``chr`` for ``primCharToNat`` and
 ``primNatToChar``). To make ``primNatToChar`` total ``chr`` is applied to the
-natural number modulo ``0x110000``.
+natural number modulo ``0x110000``. Furthermore, to match the behaviour of
+strings, `surrogate code points <surrogate_>`_ are mapped to the replacement
+character ``U+FFFD``.
 
 Converting to a natural number is the obvious embedding, and its proof::
 
@@ -540,6 +542,7 @@ Converting to a natural number is the obvious embedding, and its proof::
 can be found in the ``Properties`` module.
 
 .. _data-char: https://hackage.haskell.org/package/base-4.8.1.0/docs/Data-Char.html
+.. _surrogate: https://www.unicode.org/glossary/#surrogate_code_point
 
 .. _built-in-string:
 
@@ -581,6 +584,10 @@ Converting to and from a list is injective, and their proofs::
     primStringFromListInjective : ∀ a b → primStringFromList a ≡ primStringFromList b → a ≡ b
 
 can found in the ``Properties`` module.
+
+Strings cannot represent `unicode surrogate code points <surrogate_>`_
+(characters in the range ``U+D800`` to ``U+DFFF``). These are replaced by the
+unicode replacement character ``U+FFFD`` if they appear in string literals.
 
 .. _built-in-equality:
 

--- a/src/data/MAlonzo/src/MAlonzo/RTE.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE.hs
@@ -4,6 +4,7 @@ module MAlonzo.RTE where
 
 import Unsafe.Coerce
 import qualified GHC.Exts as GHC (Any)
+import Data.Char
 import qualified Data.Word
 
 type AgdaAny = GHC.Any
@@ -63,6 +64,13 @@ quotInt = quot
 
 remInt :: Integer -> Integer -> Integer
 remInt = rem
+
+-- #4999: Data.Text maps surrogate code points (\xD800 - \xDFFF) to the replacement character
+-- \xFFFD, so to keep strings isomorphic to list of characters we do the same for characters.
+natToChar :: Integer -> Char
+natToChar n | generalCategory c == Surrogate = '\xFFFD'
+            | otherwise                      = c
+  where c = toEnum $ fromIntegral $ mod n 0x110000
 
 -- Words --
 

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -257,7 +257,7 @@ primBody s = maybe unimplemented (fromRight (hsVarUQ . HS.Ident) <$>) $
   , "primToUpper"        |-> return "Data.Char.toUpper"
   , "primToLower"        |-> return "Data.Char.toLower"
   , "primCharToNat" |-> return "(fromIntegral . fromEnum :: Char -> Integer)"
-  , "primNatToChar" |-> return "(toEnum . fromIntegral :: Integer -> Char)"
+  , "primNatToChar" |-> return "MAlonzo.RTE.natToChar"
   , "primShowChar"  |-> return "(Data.Text.pack . show :: Char -> Data.Text.Text)"
   , "primCharToNatInjective" |-> return "erased"
 

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -38,6 +38,7 @@ import Agda.TypeChecking.Primitive.Base
 import Agda.TypeChecking.Primitive.Cubical
 import Agda.TypeChecking.Warnings
 
+import Agda.Utils.Char
 import Agda.Utils.Float
 import Agda.Utils.List
 import Agda.Utils.Monad
@@ -913,7 +914,7 @@ primitiveFunctions = localTCStateSavingWarnings <$> Map.fromList
   , "primToLower"            |-> mkPrimFun1 toLower
   , "primCharToNat"          |-> mkPrimFun1 (fromIntegral . fromEnum :: Char -> Nat)
   , "primCharToNatInjective" |-> primCharToNatInjective
-  , "primNatToChar"          |-> mkPrimFun1 (toEnum . fromIntegral . (`mod` 0x110000)  :: Nat -> Char)
+  , "primNatToChar"          |-> mkPrimFun1 (integerToChar . unNat)
   , "primShowChar"           |-> mkPrimFun1 (T.pack . prettyShow . LitChar)
 
   -- String functions

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -67,6 +67,7 @@ import Agda.TypeChecking.Substitute
 import Agda.Interaction.Options
 
 import Agda.Utils.CallStack ( withCurrentCallStack )
+import Agda.Utils.Char
 import Agda.Utils.Float
 import Agda.Utils.Lens
 import Agda.Utils.List
@@ -227,7 +228,7 @@ compactDef bEnv def rewr = do
           "primToUpper"                -> mkPrim 1 $ charFun toUpper
           "primToLower"                -> mkPrim 1 $ charFun toLower
           "primCharToNat"              -> mkPrim 1 $ \ [LitChar a] -> nat (fromIntegral (fromEnum a))
-          "primNatToChar"              -> mkPrim 1 $ \ [LitNat a] -> char (toEnum $ fromIntegral $ a `mod` 0x110000)
+          "primNatToChar"              -> mkPrim 1 $ \ [LitNat a] -> char (integerToChar a)
           "primShowChar"               -> mkPrim 1 $ \ [a] -> string (prettyShow a)
 
           -- Strings

--- a/src/full/Agda/Utils/Char.hs
+++ b/src/full/Agda/Utils/Char.hs
@@ -1,0 +1,36 @@
+
+-- |
+-- Agda strings uses Data.Text [1], which can only represent unicode scalar values [2], excluding
+-- the surrogate code points [3] (@U+D800..U+DFFF@). To allow @primStringFromList@ to be injective
+-- we make sure character values also exclude surrogate code points, mapping them to the replacement
+-- character @U+FFFD@.
+--
+-- See #4999 for more information.
+--
+-- [1] https://hackage.haskell.org/package/text-1.2.4.0/docs/Data-Text.html#g:2
+-- [2] https://www.unicode.org/glossary/#unicode_scalar_value
+-- [3] https://www.unicode.org/glossary/#surrogate_code_point
+
+module Agda.Utils.Char where
+
+import Data.Char
+
+-- | The unicode replacement character � .
+replacementChar :: Char
+replacementChar = '\xFFFD'
+
+-- | Is a character a surrogate code point.
+isSurrogateCodePoint :: Char -> Bool
+isSurrogateCodePoint c = generalCategory c == Surrogate
+
+-- | Map surrogate code points to the unicode replacement character.
+replaceSurrogateCodePoint :: Char -> Char
+replaceSurrogateCodePoint c
+  | isSurrogateCodePoint c = replacementChar
+  | otherwise              = c
+
+-- | Total function to convert an integer to a character. Maps surrogate code points
+--   to the replacement character @U+FFFD@.
+integerToChar :: Integer -> Char
+integerToChar = replaceSurrogateCodePoint . toEnum . fromIntegral . (`mod` 0x110000)
+

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -84,6 +84,10 @@ disabledTests =
   , disable "Compiler/JS_Optimized/simple/ModuleReexport"
   , disable "Compiler/JS_MinifiedOptimized/simple/ModuleReexport"
     -----------------------------------------------------------------------------
+    -- The following test cases use primitives that are not implemented in the
+    -- JS backend.
+  , disable "Compiler/JS_.*/simple/Issue4999"   -- primNatToChar
+    -----------------------------------------------------------------------------
     -- The following test cases are GHC backend specific and thus disabled on JS.
   , disable "Compiler/JS_.*/simple/Issue2821"
   , disable "Compiler/JS_.*/simple/Issue2879-.*"

--- a/test/Compiler/simple/Issue4999.agda
+++ b/test/Compiler/simple/Issue4999.agda
@@ -1,0 +1,61 @@
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Char renaming (primCharEquality to _==ᶜ_)
+open import Agda.Builtin.List
+open import Agda.Builtin.Equality
+open import Agda.Builtin.String renaming (primStringAppend to _++_)
+open import Agda.Builtin.IO
+open import Agda.Builtin.Unit
+
+variable
+  A B C : Set
+
+map : (A → B) → List A → List B
+map f []       = []
+map f (x ∷ xs) = f x ∷ map f xs
+
+<?> = '\xFFFD'
+
+fromCount : Nat → Nat → List Nat
+fromCount 0 _ = []
+fromCount (suc n) a = a ∷ fromCount n (suc a)
+
+fromTo : Nat → Nat → List Nat
+fromTo a b = fromCount (suc b - a) a
+
+isReplaced : Nat → Bool
+isReplaced n = primNatToChar n ==ᶜ <?>
+
+and : List Bool → Bool
+and []           = true
+and (false ∷ _)  = false
+and (true  ∷ xs) = and xs
+
+all : (A → Bool) → List A → Bool
+all p xs = and (map p xs)
+
+not : Bool → Bool
+not false = true
+not true  = false
+
+_∘_ : (B → C) → (A → B) → A → C
+f ∘ g = λ x → f (g x)
+
+postulate
+  putStrLn : String → IO ⊤
+  _>>_ : IO A → IO B → IO B
+
+{-# FOREIGN GHC import qualified Data.Text.IO as Text #-}
+{-# COMPILE GHC putStrLn = Text.putStrLn #-}
+{-# COMPILE GHC _>>_ = \ _ _ -> (>>) #-}
+
+assert : String → Bool → IO ⊤
+assert s true  = putStrLn (s ++ " PASSED")
+assert s false = putStrLn (s ++ " FAILED")
+
+main : IO ⊤
+main = do
+  assert "before surrogates" (all (not ∘ isReplaced) (fromTo 0xD780 0xD7FF))
+  assert "surrogate range  " (all isReplaced (fromTo 0xD800 0xDFFF))
+  assert "after surrogates " (all (not ∘ isReplaced) (fromTo 0xE000 0xE07F))

--- a/test/Compiler/simple/Issue4999.out
+++ b/test/Compiler/simple/Issue4999.out
@@ -1,0 +1,7 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > before surrogates PASSED
+out > surrogate range   PASSED
+out > after surrogates  PASSED
+out >

--- a/test/Fail/Issue4999.agda
+++ b/test/Fail/Issue4999.agda
@@ -1,0 +1,30 @@
+
+open import Agda.Builtin.Char
+open import Agda.Builtin.List
+open import Agda.Builtin.Equality
+open import Agda.Builtin.String
+open import Agda.Builtin.String.Properties
+
+data ⊥ : Set where
+
+∷⁻¹ : ∀ {A : Set} {x y : A} {xs ys} → x ∷ xs ≡ y ∷ ys → x ≡ y
+∷⁻¹ refl = refl
+
+xD800 = primNatToChar 0xD800
+xD801 = primNatToChar 0xD801
+
+legit : '\xD800' ∷ [] ≡ '\xD801' ∷ []
+legit = primStringFromListInjective _ _ refl
+
+actually : xD800 ≡ xD801
+actually = refl
+
+nope : xD800 ≡ xD801 → ⊥
+nope ()
+
+boom : ⊥
+boom = nope (∷⁻¹ legit)
+
+errorAlsoInLHS : Char → String
+errorAlsoInLHS '\xD8AA' = "bad"
+errorAlsoInLHS _        = "meh"

--- a/test/Fail/Issue4999.err
+++ b/test/Fail/Issue4999.err
@@ -1,0 +1,16 @@
+Issue4999.agda:16,9-17
+Invalid character literal '/55296' (surrogate code points are not supported)
+when scope checking '/55296'
+Issue4999.agda:16,25-33
+Invalid character literal '/55297' (surrogate code points are not supported)
+when scope checking '/55297'
+Issue4999.agda:29,16-24
+Invalid character literal '/55466' (surrogate code points are not supported)
+when scope checking the left-hand side errorAlsoInLHS '/55466' in
+the definition of errorAlsoInLHS
+Issue4999.agda:23,1-8
+xD800 ≡ xD801 should be empty, but the following constructor
+patterns are valid:
+  refl
+when checking the clause left hand side
+nope ()

--- a/test/Succeed/Issue4999.agda
+++ b/test/Succeed/Issue4999.agda
@@ -1,0 +1,21 @@
+
+open import Agda.Builtin.Char
+open import Agda.Builtin.List
+open import Agda.Builtin.Equality
+
+data ⊥ : Set where
+
+infix 4 _≢_
+_≢_ : {A : Set} → A → A → Set
+x ≢ y = x ≡ y → ⊥
+
+<?> = '\xFFFD'
+
+infix 0 _∋_
+_∋_ : (A : Set) → A → A
+A ∋ x = x
+
+_ = primNatToChar 0xD7FF ≢ <?> ∋ λ ()
+_ = primNatToChar 0xD800 ≡ <?> ∋ refl
+_ = primNatToChar 0xDFFF ≡ <?> ∋ refl
+_ = primNatToChar 0xE000 ≢ <?> ∋ λ ()


### PR DESCRIPTION
by mapping them to the replacement character.

Fixes #4999