### PR TITLE
[ #5259 ] github: disable -fenable-cluster-counting for macOS

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -103,11 +103,16 @@ jobs:
         key: ${{ runner.os }}-cabal-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver }}-${{ hashFiles('**/plan.json') }}
 
     - name: Install dependencies
-      if: ${{ !steps.cache.outputs.cache-hit }}
+      # Andreas, 2021-03-04, issue #5259.
+      # Disable -fenable-cluster-counting build on macOS because of text-icu issues.
+      if: ${{ runner.os != 'macOS' && !steps.cache.outputs.cache-hit }}
       run: |
         cabal build --only-dependencies
 
     - name: Build Agda
+      # Andreas, 2021-03-04, issue #5259.
+      # Disable -fenable-cluster-counting build on macOS because of text-icu issues.
+      if: ${{ runner.os != 'macOS' }}
       run: |
         cabal build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,10 @@ jobs:
       LINUX_ARGS: "--enable-executable-static"
       # Liang-Ting Chen (2021-01-01):
       # The option `split-sections` is ignored on macOS, see https://gitlab.haskell.org/ghc/ghc/-/issues/11445 for details.
-      MACOS_ARGS: "--flags=enable-cluster-counting"
+      # Andreas, 2021-03-04, issue #5259.
+      # Disable -fenable-cluster-counting build on macOS because of text-icu issues.
+      # MACOS_ARGS: "--flags=enable-cluster-counting"
+      MACOS_ARGS: ""
       WIN64_ARGS: "--enable-split-sections --flags=enable-cluster-counting"
     outputs:
       sha: ${{ steps.vars.outputs.sha }}
@@ -153,20 +156,22 @@ jobs:
           find dist-newstyle/build \( -name 'agda' -o -name 'agda-mode' \) -type f -exec cp {} ${{ steps.vars.outputs.nightly }}/bin \;
           strip ${{ steps.vars.outputs.nightly }}/bin/*
           cp -a .github/*.sh ${{ steps.vars.outputs.nightly }}
-          if [[ "$OSTYPE" == "darwin"* ]]; then
-          # Change the path to the dynamic library icu4c to the run-time search path:
-          #
-          # 1. the same directory of executable, i.e. @executable_path
-          # 2. @executable_path/../lib
-          # 3. the default location of system-wide icu4c installed by homebrew, ie. /usr/local/opt/icu4c/lib
-          #
-            mkdir ${{ steps.vars.outputs.nightly }}/lib
-            cp /usr/local/opt/icu4c/lib/libicuuc.67.dylib /usr/local/opt/icu4c/lib/libicui18n.67.dylib /usr/local/opt/icu4c/lib/libicudata.67.dylib ${{ steps.vars.outputs.nightly }}/lib
-            install_name_tool -change /usr/local/opt/icu4c/lib/libicuuc.67.dylib @rpath/libicuuc.67.dylib ${{ steps.vars.outputs.nightly }}/bin/agda
-            install_name_tool -change /usr/local/opt/icu4c/lib/libicui18n.67.dylib @rpath/libicui18n.67.dylib ${{ steps.vars.outputs.nightly }}/bin/agda
-            install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath /usr/local/opt/icu4c/lib ${{ steps.vars.outputs.nightly }}/bin/agda
-            otool -L ${{ steps.vars.outputs.nightly }}/bin/agda
-          fi
+          # Andreas, 2021-03-04, issue #5259.
+          # Disable -fenable-cluster-counting build on macOS because of text-icu issues.
+          # if [[ "$OSTYPE" == "darwin"* ]]; then
+          # # Change the path to the dynamic library icu4c to the run-time search path:
+          # #
+          # # 1. the same directory of executable, i.e. @executable_path
+          # # 2. @executable_path/../lib
+          # # 3. the default location of system-wide icu4c installed by homebrew, ie. /usr/local/opt/icu4c/lib
+          # #
+          #   mkdir ${{ steps.vars.outputs.nightly }}/lib
+          #   cp /usr/local/opt/icu4c/lib/libicuuc.67.dylib /usr/local/opt/icu4c/lib/libicui18n.67.dylib /usr/local/opt/icu4c/lib/libicudata.67.dylib ${{ steps.vars.outputs.nightly }}/lib
+          #   install_name_tool -change /usr/local/opt/icu4c/lib/libicuuc.67.dylib @rpath/libicuuc.67.dylib ${{ steps.vars.outputs.nightly }}/bin/agda
+          #   install_name_tool -change /usr/local/opt/icu4c/lib/libicui18n.67.dylib @rpath/libicui18n.67.dylib ${{ steps.vars.outputs.nightly }}/bin/agda
+          #   install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath /usr/local/opt/icu4c/lib ${{ steps.vars.outputs.nightly }}/bin/agda
+          #   otool -L ${{ steps.vars.outputs.nightly }}/bin/agda
+          # fi
         fi
         file ${{ steps.vars.outputs.nightly }}/bin/agda
     - name: Compress the Agda executable

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -114,7 +114,7 @@ jobs:
         sudo apt-get update -qq
         sudo apt-get install libicu-dev -qq
 
-    - name: Install the icu librery (Windows)
+    - name: Install the icu library (Windows)
       if: ${{ runner.os == 'Windows' }}
       run: |
         stack exec ${ARGS} -- wget -q http://repo.msys2.org/mingw/x86_64/${ICU_FILE}
@@ -125,11 +125,12 @@ jobs:
       run: printf "extra-lib-dirs:\n - /usr/local/opt/icu4c/lib\nextra-include-dirs:\n - /usr/local/opt/icu4c/include\n" > ~/.stack/config.yaml
 
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
-      if: ${{ !steps.cache-on-unix.outputs.cache-hit && !steps.cache-on-win64.outputs.cache-hit }}
+      if: ${{ runner.os != 'macOS' && !steps.cache-on-unix.outputs.cache-hit && !steps.cache-on-win64.outputs.cache-hit }}
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies --silent
 
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests` (i.e. the test suite).
       run: stack build ${ARGS} ${EXTRA_ARGS} --test --no-run-tests
 
     - name: Build Agda with the non-default flags Agda.cabal.
+      if: ${{ runner.os != 'macOS' }}
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS}


### PR DESCRIPTION
[ #5259 ] github: disable -fenable-cluster-counting for macOS

This is a hopefully only temporary workaround to keep CI running while text-icu hasn't been adapted to ICU 68.