### PR TITLE
Switch from "Empty" to "HasCallStack"

### DIFF
--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -44,15 +44,15 @@ instance Null (Match a) where
   null (Yes simpl as) = null simpl && null as
   null _              = False
 
-matchedArgs :: Empty -> Int -> IntMap (Arg a) -> [Arg a]
-matchedArgs err n vs = map get [0..n-1]
+matchedArgs :: HasCallStack => Int -> IntMap (Arg a) -> [Arg a]
+matchedArgs n vs = map get [0..n-1]
   where
-    get k = fromMaybe (absurd err) $ IntMap.lookup k vs
+    get k = fromMaybe __IMPOSSIBLE__ $ IntMap.lookup k vs
 
 -- | Builds a proper substitution from an IntMap produced by match(Co)patterns
-buildSubstitution :: (DeBruijn a)
-                  => Empty -> Int -> IntMap (Arg a) -> Substitution' a
-buildSubstitution err n vs = parallelS $ map unArg $ matchedArgs err n vs
+buildSubstitution :: HasCallStack => (DeBruijn a)
+                  => Int -> IntMap (Arg a) -> Substitution' a
+buildSubstitution n vs = parallelS $ map unArg $ matchedArgs n vs
 
 
 instance Semigroup (Match a) where

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
@@ -8,11 +8,11 @@ import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute (DeBruijn)
 
-import Agda.Utils.Empty
+import Agda.Utils.Impossible
 
 data Match a = Yes Simplification (IntMap (Arg a)) | No | DontKnow (Blocked ())
 
-buildSubstitution :: (DeBruijn a) => Empty -> Int -> IntMap (Arg a) -> Substitution' a
+buildSubstitution :: HasCallStack => (DeBruijn a) => Int -> IntMap (Arg a) -> Substitution' a
 
 type MonadMatch m = PureTCM m
 

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -770,7 +770,7 @@ appDefE' v cls rewr es = traceSDoc "tc.reduce" 90 ("appDefE' v = " <+> prettyTCM
                     -- TODO: let matchPatterns also return the reduced forms
                     -- of the original arguments!
                     -- Andreas, 2013-05-19 isn't this done now?
-                    let sigma = buildSubstitution __IMPOSSIBLE__ nvars vs
+                    let sigma = buildSubstitution nvars vs
                     return $ YesReduction simpl $ applySubst sigma w `applyE` es1
                 | otherwise     -> rewrite (NotBlocked AbsurdMatch ()) (applyE v) rewr es
 

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -980,8 +980,8 @@ unifyStep s (Injectivity k a d pars ixs c) = do
         (rhsMatch, _) <- Match.matchPatterns ps $ eqRHS s
         case (lhsMatch, rhsMatch) of
           (Match.Yes _ lhs', Match.Yes _ rhs') -> return
-            (reverse $ Match.matchedArgs __IMPOSSIBLE__ (size eqTel') lhs',
-             reverse $ Match.matchedArgs __IMPOSSIBLE__ (size eqTel') rhs')
+            (reverse $ Match.matchedArgs (size eqTel') lhs',
+             reverse $ Match.matchedArgs (size eqTel') rhs')
           _ -> __IMPOSSIBLE__
 
       return $ Unifies $ s { eqTel = eqTel' , eqLHS = lhs' , eqRHS = rhs' }
@@ -1015,8 +1015,8 @@ unifyStep s (Injectivity k a d pars ixs c) = do
         (rhsMatch, _) <- Match.matchPatterns ps $ eqRHS s
         case (lhsMatch, rhsMatch) of
           (Match.Yes _ lhs', Match.Yes _ rhs') -> return
-            (reverse $ Match.matchedArgs __IMPOSSIBLE__ (size eqTel') lhs',
-             reverse $ Match.matchedArgs __IMPOSSIBLE__ (size eqTel') rhs')
+            (reverse $ Match.matchedArgs (size eqTel') lhs',
+             reverse $ Match.matchedArgs (size eqTel') rhs')
           _ -> __IMPOSSIBLE__
 
       return $ Unifies $ s { eqTel = eqTel' , eqLHS = lhs' , eqRHS = rhs' }

--- a/src/full/Agda/Utils/Impossible.hs
+++ b/src/full/Agda/Utils/Impossible.hs
@@ -3,7 +3,10 @@
 ------------------------------------------------------------------------
 
 
-module Agda.Utils.Impossible where
+module Agda.Utils.Impossible (
+  module Agda.Utils.Impossible,
+  HasCallStack)
+where
 
 import Control.Exception (Exception(..), throw, catchJust)
 import Agda.Utils.CallStack.Base


### PR DESCRIPTION
(From a discussion with @Saizan )

When throwing an exception with `__IMPOSSIBLE__`, the call site (.hs file and line number) is included with the exception in order to aid debugging.

However, if the function calling `__IMPOSSIBLE__` is used in many places, it can be hard to trace back the cause of the `__IMPOSSIBLE__` error.

A pattern that is often used in the Agda codebase is to generate a term of `Empty` type using `__IMPOSSIBLE__` at a call site further up in the call stack, pass it down, and eliminate it at the place where the erroneous circumstance arises. That way, a higher-level calling context can be displayed.

A tidier alternative to passing an `Empty` parameter is to add a `HasCallStack` constraint to the function. This becomes an implicit which contains the call site of the function. When a function with a `HasCallStack` constraint calls another function with a `HasCallStack` constraint, the new call site will be added to the call stack received by the caller before passing it down to the callee.

These call stacks are generated lazily. In my experience the performance impact is negligible, even when adding call stacks to ubiquitous operations such as `typeOfBV`.

This pull request replaces one specific usage of `Empty` with the `HasCallStack` pattern.