### PR TITLE
Issue 4857

### DIFF
--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1021,7 +1021,7 @@ hasElims v =
     Con{}      -> Nothing
     Lit{}      -> Nothing
     -- Andreas, 2016-04-13, Issue 1932: We convert λ x → x .f  into f
-    Lam _ (Abs _ v)  -> case v of
+    Lam h (Abs _ v) | visible h -> case v of
       Var 0 [Proj _o f] -> Just (Def f, [])
       _ -> Nothing
     Lam{}      -> Nothing

--- a/src/full/Agda/TypeChecking/DisplayForm.hs
+++ b/src/full/Agda/TypeChecking/DisplayForm.hs
@@ -2,14 +2,16 @@
 
 -- | Tools for 'DisplayTerm' and 'DisplayForm'.
 
-module Agda.TypeChecking.DisplayForm where
+module Agda.TypeChecking.DisplayForm (displayForm) where
 
 import Control.Monad
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Maybe
 
 import Data.Monoid (All(..))
+import Data.Map (Map)
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
@@ -70,7 +72,7 @@ displayForm q es = do
         [ "displayForm for" <+> pretty q
         , nest 2 $ "cxt =" <+> pretty cxt
         , nest 2 $ "cps =" <+> vcat (map pretty (Map.toList cps))
-        , nest 2 $ "dfs =" <+> vcat (map pshow odfs) ]
+        , nest 2 $ "dfs =" <+> vcat (map pretty odfs) ]
     -- Use only the display forms that can be opened in the current context.
     dfs   <- catMaybes <$> mapM tryGetOpen odfs
     scope <- getScope
@@ -80,12 +82,12 @@ displayForm q es = do
       return [ m | Just (d, m) <- ms, wellScoped scope d ]
     -- Not safe when printing non-terminating terms.
     -- (nfdfs, us) <- normalise (dfs, es)
-    unlessDebugPrinting $ reportS "tc.display.top" 100
-      [ "name        : " ++ prettyShow q
-      , "displayForms: " ++ show dfs
-      , "arguments   : " ++ show es
-      , "matches     : " ++ show ms
-      , "result      : " ++ show (listToMaybe ms)
+    unlessDebugPrinting $ reportSDoc "tc.display.top" 100 $ return $ vcat
+      [ "name        :" <+> pretty q
+      , "displayForms:" <+> pretty dfs
+      , "arguments   :" <+> pretty es
+      , "matches     :" <+> pretty ms
+      , "result      :" <+> pretty (listToMaybe ms)
       ]
     -- Return the first display form that matches.
     return $ listToMaybe ms
@@ -107,71 +109,84 @@ displayForm q es = do
 --   i.e., @es / ps = Just us@.
 matchDisplayForm :: MonadDisplayForm m
                  => DisplayForm -> Elims -> MaybeT m (DisplayForm, DisplayTerm)
-matchDisplayForm d@(Display _ ps v) es
+matchDisplayForm d@(Display n ps v) es
   | length ps > length es = mzero
   | otherwise             = do
       let (es0, es1) = splitAt (length ps) es
-      us <- reverse <$> do match ps $ raise 1 es0
+      mm <- match (Window 0 n) ps es0
+      us <- sequence [ do Just u <- return $ Map.lookup i mm; return u | i <- [0..n - 1] ]
       return (d, substWithOrigin (parallelS $ map woThing us) us v `applyE` es1)
+
+type MatchResult = Map Int (WithOrigin Term)
+
+unionMatch :: Monad m => MatchResult -> MatchResult -> MaybeT m MatchResult
+unionMatch m1 m2
+  | Set.null $ Set.intersection (Map.keysSet m1) (Map.keysSet m2) = return $ Map.union m1 m2
+  | otherwise = mzero  -- Non-linear pattern, fail for now.
+
+unionsMatch :: Monad m => [MatchResult] -> MaybeT m MatchResult
+unionsMatch = foldM unionMatch Map.empty
+
+data Window = Window {dbLo, dbHi :: Nat}
+
+inWindow :: Window -> Nat -> Maybe Nat
+inWindow (Window lo hi) n | lo <= n, n < hi = Just (n - lo)
+                          | otherwise       = Nothing
+
+shiftWindow :: Window -> Window
+shiftWindow (Window lo hi) = Window (lo + 1) (hi + 1)
 
 -- | Class @Match@ for matching a term @p@ in the role of a pattern
 --   against a term @v@.
 --
---   The 0th variable in @p@ plays the role
---   of a place holder (pattern variable).  Each occurrence of
---   @var 0@ in @p@ stands for a different pattern variable.
---
---   The result of matching, if successful, is a list of solutions for the
---   pattern variables, in left-to-right order.
---
---   The 0th variable is in scope in the input @v@, but should not
---   actually occur!
---   In the output solution, the @0th@ variable is no longer in scope.
---   (It has been substituted by __IMPOSSIBLE__ which corresponds to
---   a raise by -1).
+--   Free variables inside the window in @p@ are pattern variables and
+--   the result of matching is a map from pattern variables (shifted down to start at 0) to subterms
+--   of @v@.
 class Match a where
-  match :: MonadDisplayForm m => a -> a -> MaybeT m [WithOrigin Term]
+  match :: MonadDisplayForm m => Window -> a -> a -> MaybeT m MatchResult
 
 instance Match a => Match [a] where
-  match xs ys = concat <$> zipWithM match xs ys
+  match n xs ys = unionsMatch =<< zipWithM (match n) xs ys
 
 instance Match a => Match (Arg a) where
-  match p v = map (setOrigin (getOrigin v)) <$> match (unArg p) (unArg v)
+  match n p v = Map.map (setOrigin (getOrigin v)) <$> match n (unArg p) (unArg v)
 
 instance Match a => Match (Elim' a) where
-  match p v =
+  match n p v =
     case (p, v) of
-      (Proj _ f, Proj _ f') | f == f' -> return []
+      (Proj _ f, Proj _ f') | f == f' -> return Map.empty
       _ | Just a  <- isApplyElim p
-        , Just a' <- isApplyElim v    -> match a a'
+        , Just a' <- isApplyElim v    -> match n a a'
       -- we do not care to differentiate between Apply and IApply for
       -- printing.
       _                               -> mzero
 
 instance Match Term where
-  match p v = lift (instantiate v) >>= \ v -> case (p, v) of
-    (Var 0 [], v) -> return [ WithOrigin Inserted $ strengthen __IMPOSSIBLE__ v ]
-    (Var i ps, Var j vs) | i == j  -> match ps vs
-    (Def c ps, Def d vs) | c == d  -> match ps vs
-    (Con c _ ps, Con d _ vs) | c == d -> match ps vs
-    (Lit l, Lit l')      | l == l' -> return []
-    (p, v)               | p == v  -> return []
-    (p, Level l)                   -> match p =<< reallyUnLevelView l
-    (Sort ps, Sort pv)             -> match ps pv
-    (p, Sort (Type v))             -> match p =<< reallyUnLevelView v
+  match w p v = lift (instantiate v) >>= \ v -> case (p, unSpine v) of
+    (Var i [], v)    | Just j <- inWindow w i -> return $ Map.singleton j (WithOrigin Inserted v)
+    (Var i (_:_), v) | Just{} <- inWindow w i -> mzero  -- Higher-order pattern, fail for now.
+    (Var i ps, Var j vs) | i == j  -> match w ps vs
+    (Def c ps, Def d vs) | c == d  -> match w ps vs
+    (Con c _ ps, Con d _ vs) | c == d -> match w ps vs
+    (Lit l, Lit l')      | l == l' -> return Map.empty
+    (Lam h p, Lam h' v)  | h == h' -> match (shiftWindow w) (unAbs p) (unAbs v)
+    (p, v)               | p == v  -> return Map.empty  -- TODO: this is wrong (this is why we lifted the rhs before)
+    (p, Level l)                   -> match w p =<< reallyUnLevelView l
+    (Sort ps, Sort pv)             -> match w ps pv
+    (p, Sort (Type v))             -> match w p =<< reallyUnLevelView v
     _                              -> mzero
 
 instance Match Sort where
-  match p v = case (p, v) of
-    (Type pl, Type vl) -> match pl vl
-    _ | p == v -> return []
+  match w p v = case (p, v) of
+    (Type pl, Type vl) -> match w pl vl
+    _ | p == v -> return Map.empty
     _          -> mzero
 
 instance Match Level where
-  match p v = do
+  match w p v = do
     p <- reallyUnLevelView p
     v <- reallyUnLevelView v
-    match p v
+    match w p v
 
 -- | Substitute terms with origin into display terms,
 --   replacing variables along with their origins.

--- a/src/full/Agda/TypeChecking/DisplayForm.hs
+++ b/src/full/Agda/TypeChecking/DisplayForm.hs
@@ -114,14 +114,14 @@ matchDisplayForm d@(Display n ps v) es
   | otherwise             = do
       let (es0, es1) = splitAt (length ps) es
       mm <- match (Window 0 n) ps es0
-      us <- sequence [ do Just u <- return $ Map.lookup i mm; return u | i <- [0..n - 1] ]
+      let us = map (\ i -> Map.findWithDefault __IMPOSSIBLE__ i mm) [0 .. n - 1]
       return (d, substWithOrigin (parallelS $ map woThing us) us v `applyE` es1)
 
 type MatchResult = Map Int (WithOrigin Term)
 
 unionMatch :: Monad m => MatchResult -> MatchResult -> MaybeT m MatchResult
 unionMatch m1 m2
-  | Set.null $ Set.intersection (Map.keysSet m1) (Map.keysSet m2) = return $ Map.union m1 m2
+  | Set.disjoint (Map.keysSet m1) (Map.keysSet m2) = return $ Map.union m1 m2
   | otherwise = mzero  -- Non-linear pattern, fail for now.
 
 unionsMatch :: Monad m => [MatchResult] -> MaybeT m MatchResult

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2156,9 +2156,9 @@ instance Pretty Defn where
     "Record {" <?> vcat
       [ "recPars         =" <?> pshow recPars
       , "recClause       =" <?> pretty recClause
-      , "recConHead      =" <?> pshow recConHead
-      , "recNamedCon     =" <?> pshow recNamedCon
-      , "recFields       =" <?> pshow recFields
+      , "recConHead      =" <?> pretty recConHead
+      , "recNamedCon     =" <?> pretty recNamedCon
+      , "recFields       =" <?> pretty recFields
       , "recTel          =" <?> pretty recTel
       , "recMutual       =" <?> pshow recMutual
       , "recEtaEquality' =" <?> pshow recEtaEquality'

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1562,29 +1562,22 @@ secTelescope f s =
 emptySignature :: Signature
 emptySignature = Sig Map.empty HMap.empty HMap.empty
 
--- | A @DisplayForm@ is in essence a rewrite rule
---   @
---      q ts --> dt
---   @
---   for a defined symbol (could be a constructor as well) @q@.
---   The right hand side is a 'DisplayTerm' which is used to
---   'reify' to a more readable 'Abstract.Syntax'.
+-- | A @DisplayForm@ is in essence a rewrite rule @q ts --> dt@ for a defined symbol (could be a
+--   constructor as well) @q@. The right hand side is a 'DisplayTerm' which is used to 'reify' to a
+--   more readable 'Abstract.Syntax'.
 --
---   The patterns @ts@ are just terms, but @var 0@ is interpreted
---   as a hole.  Each occurrence of @var 0@ is a new hole (pattern var).
---   For each *occurrence* of @var0@ the rhs @dt@ has a free variable.
---   These are instantiated when matching a display form against a
---   term @q vs@ succeeds.
+--   The patterns @ts@ are just terms, but the first @dfPatternVars@ variables are pattern variables
+--   that matches any term.
 data DisplayForm = Display
-  { dfFreeVars :: Nat
-    -- ^ Number @n@ of free variables in 'dfRHS'.
-  , dfPats     :: Elims
-    -- ^ Left hand side patterns, where @var 0@ stands for a pattern
-    --   variable.  There should be @n@ occurrences of @var0@ in
-    --   'dfPats'.
-    --   The 'ArgInfo' is ignored in these patterns.
-  , dfRHS      :: DisplayTerm
-    -- ^ Right hand side, with @n@ free variables.
+  { dfPatternVars :: Nat
+    -- ^ Number @n@ of pattern variables in 'dfPats'.
+  , dfPats :: Elims
+    -- ^ Left hand side patterns, the @n@ first free variables are pattern variables,
+    --   any variables above @n@ are fixed and only matches that particular variable. This
+    --   happens when you have display forms inside parameterised modules that match on the module
+    --   parameters. The 'ArgInfo' is ignored in these patterns.
+  , dfRHS :: DisplayTerm
+    -- ^ Right hand side.
   }
   deriving (Data, Show, Generic)
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1573,7 +1573,7 @@ data DisplayForm = Display
     -- ^ Number @n@ of pattern variables in 'dfPats'.
   , dfPats :: Elims
     -- ^ Left hand side patterns, the @n@ first free variables are pattern variables,
-    --   any variables above @n@ are fixed and only matches that particular variable. This
+    --   any variables above @n@ are fixed and only match that particular variable. This
     --   happens when you have display forms inside parameterised modules that match on the module
     --   parameters. The 'ArgInfo' is ignored in these patterns.
   , dfRHS :: DisplayTerm

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -321,7 +321,7 @@ applySection new ptel old ts ScopeCopyInfo{ renModules = rm, renNames = rd } = d
         rename x
           | x `Map.member` rd = pure mempty
           | otherwise =
-              Map.singleton x . pure . qnameFromList . singleton <$> freshName_ (show $ qnameName x)
+              Map.singleton x . pure . qnameFromList . singleton <$> freshName_ (prettyShow $ qnameName x)
 
         constructorData :: QName -> TCM (Maybe QName)
         constructorData x = do

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -290,7 +290,7 @@ addDisplayForms x = do
         mkDisplay xs es = Just (Display (n - npars) es $ DTerm $ top `apply` args)
           where
             n    = length xs
-            args = zipWith (\ x i -> var i <$ x) xs [n - 1, n - 2..0]
+            args = zipWith (\ x i -> var i <$ x) xs (downFrom n)
 
     -- Unfold a single defCopy.
     unfoldOnce :: Term -> TCM (Reduced () Term)

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -270,8 +270,8 @@ addDisplayForms x = do
             Just (Def y es) -> do
               let df = Display m es $ DTerm $ Def top $ map Apply args
               reportSDoc "tc.display.section" 20 $ vcat
-                [ "adding display form " <+> pretty y <+> " --> " <+> pretty top
-                , text (show df)
+                [ "adding display form" <+> pretty y <+> "-->" <+> pretty top
+                , nest 2 $ pretty df
                 ]
               addDisplayForm y df
               add args top y es
@@ -282,7 +282,7 @@ addDisplayForms x = do
                   df = Display 0 [] $ DTerm $ Con (h {conName = top }) ConOSystem []
               reportSDoc "tc.display.section" 20 $ vcat
                 [ "adding display form" <+> pretty y <+> "-->" <+> pretty top
-                , text (show df)
+                , nest 2 $ pretty df
                 ]
               addDisplayForm y df
         [] -> noDispForm x "no clauses"

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -638,6 +638,10 @@ unfoldDefinitionStep unfoldDelayed v0 f es =
             reportSDoc "tc.reduce"  95 $ "    result" <+> prettyTCM v
             reportSDoc "tc.reduce" 100 $ "    raw   " <+> text (show v)
 
+-- | Specialized version to put in boot file.
+reduceDefCopyTCM :: QName -> Elims -> TCM (Reduced () Term)
+reduceDefCopyTCM = reduceDefCopy
+
 -- | Reduce a non-primitive definition if it is a copy linking to another def.
 reduceDefCopy :: forall m. PureTCM m => QName -> Elims -> m (Reduced () Term)
 reduceDefCopy f es = do

--- a/src/full/Agda/TypeChecking/Reduce.hs-boot
+++ b/src/full/Agda/TypeChecking/Reduce.hs-boot
@@ -1,0 +1,6 @@
+module Agda.TypeChecking.Reduce where
+
+import Agda.Syntax.Internal (Term, Elims, QName)
+import Agda.TypeChecking.Monad.Base (TCM, Reduced)
+
+reduceDefCopyTCM :: QName -> Elims -> TCM (Reduced () Term)

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -72,7 +72,7 @@ import Agda.Utils.IORef
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20210216 * 10 + 0
+currentInterfaceVersion = 20210315 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -970,7 +970,7 @@ instance Subst a => Subst (Blocked a) where
 instance Subst DisplayForm where
   type SubstArg DisplayForm = Term
   applySubst rho (Display n ps v) =
-    Display n (applySubst (liftS 1 rho) ps)
+    Display n (applySubst (liftS n rho) ps)
               (applySubst (liftS n rho) v)
 
 instance Subst DisplayTerm where

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -17,7 +17,7 @@ module Agda.TypeChecking.Substitute
   , Substitution'(..), Substitution
   ) where
 
-import Control.Arrow (second)
+import Control.Arrow (first, second)
 import Control.Monad (guard)
 import Data.Coerce
 import Data.Function
@@ -1258,6 +1258,14 @@ mkPi !dom b = el $ Pi a (mkAbs x b)
 
 mkLam :: Arg ArgName -> Term -> Term
 mkLam a v = Lam (argInfo a) (Abs (unArg a) v)
+
+lamView :: Term -> ([Arg ArgName], Term)
+lamView (Lam h (Abs   x b)) = first (Arg h x :) $ lamView b
+lamView (Lam h (NoAbs x b)) = first (Arg h x :) $ lamView (raise 1 b)
+lamView t                   = ([], t)
+
+unlamView :: [Arg ArgName] -> Term -> Term
+unlamView xs b = foldr mkLam b xs
 
 telePi' :: (Abs Type -> Abs Type) -> Telescope -> Type -> Type
 telePi' reAbs = telePi where

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -682,7 +682,7 @@ withDisplayForm f aux delta1 delta2 n qs perm@(Perm m _) lhsPerm = do
 
   -- Build the lhs of the display form and finish.
   -- @var 0@ is the pattern variable (hole).
-  let display = Display arity (replicate arity $ Apply $ defaultArg $ var 0) dt
+  let display = Display arity [Apply $ defaultArg $ var i | i <- downFrom arity] dt
 
   -- Debug printing.
   let addFullCtx = addContext delta1

--- a/test/Fail/DebugWith.err
+++ b/test/Fail/DebugWith.err
@@ -33,7 +33,7 @@ checkWithFunction
   withSub= Var 0 [] :# (Var 4 [] :# (Var 1 [] :# (Var 5 [] :# (Var 2 [] :# Wk 6 IdS))))
 with function call DebugWith.with-34 b f (f b) trash1 trash2 trash3
 created with display form
-Display 6 [$ @0, $ @0, $ @0, $ @0, $ @0, $ @0]
+Display 6 [$ @5, $ @4, $ @3, $ @2, $ @1, $ @0]
         test @2 @5 @1 @4 @0 | @3
 added with function DebugWith.with-34 of type
   (b : A) (f : (x : A) → P x) →

--- a/test/interaction/Issue2769.agda
+++ b/test/interaction/Issue2769.agda
@@ -45,3 +45,6 @@ goal = {!!}  -- WAS: goal displayed as  (s : MSet.S) → MSet.S.Rr.A
 -- EXPECTED:
 -- Should display goal 1 as
 -- ?1 : (s : MSet.S) → M.R.A (MSet.S.r s)
+
+-- AFTER FIXING #4857:
+-- ?1 : (s : MSet.S) → MSet.S.Rr.A s

--- a/test/interaction/Issue2769.out
+++ b/test/interaction/Issue2769.out
@@ -2,5 +2,5 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 (agda2-status-action "")
-(agda2-info-action "*All Goals*" "?0 : (s : M.S Set) → M.R.A (M.S.r s) ?1 : (s : MSet.S) → MSet.R.A (MSet.S.r s) " nil)
+(agda2-info-action "*All Goals*" "?0 : (s : M.S Set) → M.R.A (M.S.r s) ?1 : (s : MSet.S) → MSet.S.Rr.A s " nil)
 ((last . 1) . (agda2-goals-action '(0 1)))

--- a/test/interaction/Issue4857.agda
+++ b/test/interaction/Issue4857.agda
@@ -1,0 +1,37 @@
+{-# OPTIONS --show-implicit #-}
+
+module _ where
+
+postulate
+  R : Set
+
+module ModuleB where
+
+  module NotRecordB (r : R) where
+    postulate notfieldB : Set
+
+  open module NotRecBI {{r : R}} = NotRecordB r public
+
+  record RecordB : Set₁ where
+    field
+      fieldB : Set
+
+  open module RecBI {{r : RecordB}} = RecordB r public
+
+open module ModBA = ModuleB
+
+postulate
+  myRecB : RecordB
+  myR    : R
+
+test₀ : fieldB {{myRecB}}
+test₀ = {!!}
+
+test₁ : ModuleB.RecordB.fieldB myRecB
+test₁ = {!!}
+
+test₂ : notfieldB {{myR}}
+test₂ = {!!}
+
+test₃ : ModuleB.NotRecordB.notfieldB myR
+test₃ = {!!}

--- a/test/interaction/Issue4857.in
+++ b/test/interaction/Issue4857.in
@@ -1,0 +1,1 @@
+top_command (cmd_load currentFile [])

--- a/test/interaction/Issue4857.out
+++ b/test/interaction/Issue4857.out
@@ -1,0 +1,6 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "ShowImplicit")
+(agda2-info-action "*All Goals*" "?0 : fieldB ⦃ myRecB ⦄ ?1 : fieldB ⦃ myRecB ⦄ ?2 : notfieldB ⦃ myR ⦄ ?3 : notfieldB ⦃ myR ⦄ " nil)
+((last . 1) . (agda2-goals-action '(0 1 2 3)))


### PR DESCRIPTION
Fixes #4857

- Changes display forms to use distinct indices for pattern variables, instead using var 0 for all of them. Aside from being more sane it opens up for non-linear matching in display forms in the future.
- The code to generate module application display forms is now something that a person can look at without going insane. And it's actually working correctly, which the old code did not.