### PR TITLE
[ fixed #5288 ] treeless de Bruijn problem "withContextSize"

### DIFF
--- a/test/Compiler/simple/Issue5288.agda
+++ b/test/Compiler/simple/Issue5288.agda
@@ -18,6 +18,7 @@ postulate
   printNat : Nat → IO ⊤
 
 {-# COMPILE GHC printNat = print #-}
+{-# COMPILE JS  printNat = function (x) { return function(cb) { process.stdout.write(x + "\n"); cb(0); }; } #-}
 
 test : Nat
 test = f 123 1

--- a/test/Compiler/simple/Issue5288.agda
+++ b/test/Compiler/simple/Issue5288.agda
@@ -1,0 +1,30 @@
+-- Andreas, 2021-04-10, issue #5288
+-- De Bruijn index problem in treeless compiler
+
+-- {-# OPTIONS -v tc.cc:20 #-}
+-- {-# OPTIONS -v treeless:40 #-}
+-- {-# OPTIONS -v treeless.convert.lambdas:40 #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.IO
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Unit
+
+f : Nat → Nat → Nat
+f _ zero = 0
+f m      = λ _ → m   -- this catch-all was wrongly compiled
+
+postulate
+  printNat : Nat → IO ⊤
+
+{-# COMPILE GHC printNat = print #-}
+
+test : Nat
+test = f 123 1
+
+prf : test ≡ 123
+prf = refl
+
+main = printNat test
+
+-- Should print 123

--- a/test/Compiler/simple/Issue5288.out
+++ b/test/Compiler/simple/Issue5288.out
@@ -1,0 +1,5 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > 123
+out >


### PR DESCRIPTION
[ fixed #5288 ] treeless de Bruijn problem `withContextSize`

For the translation of the catch-all clause of the enclosed testcase,
```agda
f : Nat → Nat → Nat
f _ zero = 0
f m      = λ _ → m
```
we enter from a context of length 2 (commonArity) to a context of
length 1 (where `λ _ → m` lives).

The previous code would translate `λ _ → m` in context `0:m` and then
simply drop back to the context `[1:m,0:_]`, resulting in a wrong de
Bruijn index (`λ _ → 1`).  We now keep translate in context `[1:m]`
resulting in `λ _ → 2` which is correct when going back to `[1:m,0:_]`.