### PR TITLE
LaTeX output: preserve spaces in comments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -722,6 +722,13 @@ Compiler backends
   for that particular instance, see
   [#5153](https://github.com/agda/agda/issues/5153)).
 
+LaTeX backend
+-------------
+
+- The spacing in comments is now preserved when generating
+  LaTex files from literate Agda.  See [#5320](https://github.com/agda/agda/pull/5320)
+  for more details.
+
 JS backend
 ----------
 

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -569,6 +569,7 @@ escape (T.uncons -> Just (c, s)) = T.pack (replace c) <+> escape s
     '~'  -> "\\textasciitilde{}"
     '^'  -> "\\textasciicircum{}"
     '\\' -> "\\textbackslash{}"
+    ' '  -> "\\ "
     _    -> [ char ]
 #if __GLASGOW_HASKELL__ < 810
 escape _                         = __IMPOSSIBLE__

--- a/test/LaTeXAndHTML/succeed/Issue1062.quick.tex
+++ b/test/LaTeXAndHTML/succeed/Issue1062.quick.tex
@@ -104,7 +104,7 @@
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- Sized streams via head/tail.}\<%
+\>[0]\AgdaComment{--\ Sized\ streams\ via\ head/tail.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
@@ -185,11 +185,11 @@
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- Streams and lists.}\<%
+\>[0]\AgdaComment{--\ Streams\ and\ lists.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- Prepending a list to a stream.}\<%
+\>[0]\AgdaComment{--\ Prepending\ a\ list\ to\ a\ stream.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
@@ -230,7 +230,7 @@
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- Unfold which produces several outputs at one step}\<%
+\>[0]\AgdaComment{--\ Unfold\ which\ produces\ several\ outputs\ at\ one\ step}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
@@ -285,7 +285,7 @@
 \AgdaKeyword{using}\AgdaSpace{}%
 \AgdaSymbol{(}\AgdaField{head}\AgdaSymbol{;}\AgdaSpace{}%
 \AgdaField{tail}\AgdaSymbol{)}\AgdaSpace{}%
-\AgdaComment{-- problem: imports not colored}\<%
+\AgdaComment{--\ problem:\ imports\ not\ colored}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/succeed/Issue1062.tex
+++ b/test/LaTeXAndHTML/succeed/Issue1062.tex
@@ -104,7 +104,7 @@
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- Sized streams via head/tail.}\<%
+\>[0]\AgdaComment{--\ Sized\ streams\ via\ head/tail.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
@@ -185,11 +185,11 @@
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- Streams and lists.}\<%
+\>[0]\AgdaComment{--\ Streams\ and\ lists.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- Prepending a list to a stream.}\<%
+\>[0]\AgdaComment{--\ Prepending\ a\ list\ to\ a\ stream.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
@@ -230,7 +230,7 @@
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- Unfold which produces several outputs at one step}\<%
+\>[0]\AgdaComment{--\ Unfold\ which\ produces\ several\ outputs\ at\ one\ step}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
@@ -285,7 +285,7 @@
 \AgdaKeyword{using}\AgdaSpace{}%
 \AgdaSymbol{(}\AgdaField{head}\AgdaSymbol{;}\AgdaSpace{}%
 \AgdaField{tail}\AgdaSymbol{)}\AgdaSpace{}%
-\AgdaComment{-- problem: imports not colored}\<%
+\AgdaComment{--\ problem:\ imports\ not\ colored}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/succeed/Issue2019.quick.tex
+++ b/test/LaTeXAndHTML/succeed/Issue2019.quick.tex
@@ -4,9 +4,9 @@
 \begin{document}
 
 \begin{code}%
-\>[0]\AgdaComment{-- We use non-standard spaces between the name of the term and the}\<%
+\>[0]\AgdaComment{--\ We\ use\ non-standard\ spaces\ between\ the\ name\ of\ the\ term\ and\ the}\<%
 \\
-\>[0]\AgdaComment{-- colon.}\<%
+\>[0]\AgdaComment{--\ colon.}\<%
 \\
 \>[0]\AgdaKeyword{postulate}\<%
 \\
@@ -14,19 +14,19 @@
 \>[2]\AgdaPostulate{s00A0}\AgdaSpace{}%
 \AgdaSymbol{:}\AgdaSpace{}%
 \AgdaPrimitive{Set}%
-\>[15]\AgdaComment{-- NO-BREAK SPACE        ("\textbackslash{} " with Agda input method)}\<%
+\>[15]\AgdaComment{--\ NO-BREAK\ SPACE\ \ \ \ \ \ \ \ ("\textbackslash{}\ "\ with\ Agda\ input\ method)}\<%
 \\
 %
 \>[2]\AgdaPostulate{s2004}\AgdaSpace{}%
 \AgdaSymbol{:}\AgdaSpace{}%
 \AgdaPrimitive{Set}%
-\>[15]\AgdaComment{-- THREE-PER-EM SPACE    ("\textbackslash{};" with Agda input method)}\<%
+\>[15]\AgdaComment{--\ THREE-PER-EM\ SPACE\ \ \ \ ("\textbackslash{};"\ with\ Agda\ input\ method)}\<%
 \\
 %
 \>[2]\AgdaPostulate{s202F}\AgdaSpace{}%
 \AgdaSymbol{:}\AgdaSpace{}%
 \AgdaPrimitive{Set}%
-\>[15]\AgdaComment{-- NARROW NO-BREAK SPACE ("\textbackslash{}," with Agda input method)}\<%
+\>[15]\AgdaComment{--\ NARROW\ NO-BREAK\ SPACE\ ("\textbackslash{},"\ with\ Agda\ input\ method)}\<%
 \end{code}
 
 % Various whitespace characters: "    ".
@@ -37,7 +37,7 @@
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- Various whitespace characters: "    ".}\<%
+\>[0]\AgdaComment{--\ Various\ whitespace\ characters:\ "\    ".}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
@@ -47,7 +47,7 @@
 \\
 \>[0]\AgdaFunction{various-whitespace-characters}\AgdaSpace{}%
 \AgdaSymbol{=}\AgdaSpace{}%
-\AgdaString{"    "}\<%
+\AgdaString{"\    "}\<%
 \end{code}
 
 \end{document}

--- a/test/LaTeXAndHTML/succeed/Issue2019.tex
+++ b/test/LaTeXAndHTML/succeed/Issue2019.tex
@@ -4,9 +4,9 @@
 \begin{document}
 
 \begin{code}%
-\>[0]\AgdaComment{-- We use non-standard spaces between the name of the term and the}\<%
+\>[0]\AgdaComment{--\ We\ use\ non-standard\ spaces\ between\ the\ name\ of\ the\ term\ and\ the}\<%
 \\
-\>[0]\AgdaComment{-- colon.}\<%
+\>[0]\AgdaComment{--\ colon.}\<%
 \\
 \>[0]\AgdaKeyword{postulate}\<%
 \\
@@ -14,19 +14,19 @@
 \>[2]\AgdaPostulate{s00A0}\AgdaSpace{}%
 \AgdaSymbol{:}\AgdaSpace{}%
 \AgdaPrimitive{Set}%
-\>[15]\AgdaComment{-- NO-BREAK SPACE        ("\textbackslash{} " with Agda input method)}\<%
+\>[15]\AgdaComment{--\ NO-BREAK\ SPACE\ \ \ \ \ \ \ \ ("\textbackslash{}\ "\ with\ Agda\ input\ method)}\<%
 \\
 %
 \>[2]\AgdaPostulate{s2004}\AgdaSpace{}%
 \AgdaSymbol{:}\AgdaSpace{}%
 \AgdaPrimitive{Set}%
-\>[15]\AgdaComment{-- THREE-PER-EM SPACE    ("\textbackslash{};" with Agda input method)}\<%
+\>[15]\AgdaComment{--\ THREE-PER-EM\ SPACE\ \ \ \ ("\textbackslash{};"\ with\ Agda\ input\ method)}\<%
 \\
 %
 \>[2]\AgdaPostulate{s202F}\AgdaSpace{}%
 \AgdaSymbol{:}\AgdaSpace{}%
 \AgdaPrimitive{Set}%
-\>[15]\AgdaComment{-- NARROW NO-BREAK SPACE ("\textbackslash{}," with Agda input method)}\<%
+\>[15]\AgdaComment{--\ NARROW\ NO-BREAK\ SPACE\ ("\textbackslash{},"\ with\ Agda\ input\ method)}\<%
 \end{code}
 
 % Various whitespace characters: "    ".
@@ -37,7 +37,7 @@
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- Various whitespace characters: "    ".}\<%
+\>[0]\AgdaComment{--\ Various\ whitespace\ characters:\ "\    ".}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
@@ -47,7 +47,7 @@
 \\
 \>[0]\AgdaFunction{various-whitespace-characters}\AgdaSpace{}%
 \AgdaSymbol{=}\AgdaSpace{}%
-\AgdaString{"    "}\<%
+\AgdaString{"\    "}\<%
 \end{code}
 
 \end{document}

--- a/test/LaTeXAndHTML/succeed/Issue2401.quick.tex
+++ b/test/LaTeXAndHTML/succeed/Issue2401.quick.tex
@@ -41,7 +41,7 @@ av
 %
 \>[6]\AgdaInductiveConstructor{aa}%
 \>[12]\AgdaSymbol{:}\AgdaSpace{}%
-\AgdaComment{\{- \textbackslash{}end\{code\} -\}}\AgdaSpace{}%
+\AgdaComment{\{-\ \textbackslash{}end\{code\}\ -\}}\AgdaSpace{}%
 \AgdaDatatype{Bool}\<%
 \\
 \>[0]\<%

--- a/test/LaTeXAndHTML/succeed/Issue2401.tex
+++ b/test/LaTeXAndHTML/succeed/Issue2401.tex
@@ -41,7 +41,7 @@ av
 %
 \>[6]\AgdaInductiveConstructor{aa}%
 \>[12]\AgdaSymbol{:}\AgdaSpace{}%
-\AgdaComment{\{- \textbackslash{}end\{code\} -\}}\AgdaSpace{}%
+\AgdaComment{\{-\ \textbackslash{}end\{code\}\ -\}}\AgdaSpace{}%
 \AgdaDatatype{Bool}\<%
 \\
 \>[0]\<%

--- a/test/LaTeXAndHTML/succeed/LaTeX-succeed.quick.tex
+++ b/test/LaTeXAndHTML/succeed/LaTeX-succeed.quick.tex
@@ -101,7 +101,7 @@
 \\
 \>[0]\AgdaInductiveConstructor{suc}\AgdaSpace{}%
 \AgdaBound{m}\AgdaSpace{}%
-\AgdaComment{\{- ugh -\}}%
+\AgdaComment{\{-\ ugh\ -\}}%
 \>[17]\AgdaOperator{\AgdaFunction{+}}\AgdaSpace{}%
 \AgdaBound{n}\AgdaSpace{}%
 \AgdaSymbol{=}\AgdaSpace{}%

--- a/test/LaTeXAndHTML/succeed/LaTeX-succeed.tex
+++ b/test/LaTeXAndHTML/succeed/LaTeX-succeed.tex
@@ -101,7 +101,7 @@
 \\
 \>[0]\AgdaInductiveConstructor{suc}\AgdaSpace{}%
 \AgdaBound{m}\AgdaSpace{}%
-\AgdaComment{\{- ugh -\}}%
+\AgdaComment{\{-\ ugh\ -\}}%
 \>[17]\AgdaOperator{\AgdaFunction{+}}\AgdaSpace{}%
 \AgdaBound{n}\AgdaSpace{}%
 \AgdaSymbol{=}\AgdaSpace{}%

--- a/test/LaTeXAndHTML/user-manual/acmart-pdflatex.quick.tex
+++ b/test/LaTeXAndHTML/user-manual/acmart-pdflatex.quick.tex
@@ -44,9 +44,9 @@ Some code:
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[0]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
-\>[0]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[0]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/acmart-pdflatex.tex
+++ b/test/LaTeXAndHTML/user-manual/acmart-pdflatex.tex
@@ -44,9 +44,9 @@ Some code:
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[0]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
-\>[0]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[0]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/acmart-xelatex.quick.tex
+++ b/test/LaTeXAndHTML/user-manual/acmart-xelatex.quick.tex
@@ -39,9 +39,9 @@ Some code:
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[0]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
-\>[0]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[0]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/acmart-xelatex.tex
+++ b/test/LaTeXAndHTML/user-manual/acmart-xelatex.tex
@@ -39,9 +39,9 @@ Some code:
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[0]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
-\>[0]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[0]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/article-luaxelatex-different-fonts.quick.tex
+++ b/test/LaTeXAndHTML/user-manual/article-luaxelatex-different-fonts.quick.tex
@@ -39,9 +39,9 @@ Some code:
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[0]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
-\>[0]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[0]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/article-luaxelatex-different-fonts.tex
+++ b/test/LaTeXAndHTML/user-manual/article-luaxelatex-different-fonts.tex
@@ -39,9 +39,9 @@ Some code:
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[0]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
-\>[0]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[0]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/article-luaxelatex.quick.tex
+++ b/test/LaTeXAndHTML/user-manual/article-luaxelatex.quick.tex
@@ -42,9 +42,9 @@ Some code:
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[0]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
-\>[0]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[0]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/article-luaxelatex.tex
+++ b/test/LaTeXAndHTML/user-manual/article-luaxelatex.tex
@@ -42,9 +42,9 @@ Some code:
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[0]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
-\>[0]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[0]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/article-pdflatex.quick.tex
+++ b/test/LaTeXAndHTML/user-manual/article-pdflatex.quick.tex
@@ -39,9 +39,9 @@ Some code:
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[0]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
-\>[0]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[0]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/article-pdflatex.tex
+++ b/test/LaTeXAndHTML/user-manual/article-pdflatex.tex
@@ -39,9 +39,9 @@ Some code:
 \\
 %
 \\[\AgdaEmptyExtraSkip]%
-\>[0]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[0]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
-\>[0]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[0]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/beamer-luaxelatex.quick.tex
+++ b/test/LaTeXAndHTML/user-manual/beamer-luaxelatex.quick.tex
@@ -48,10 +48,10 @@
 %
 \\[\AgdaEmptyExtraSkip]%
 %
-\>[2]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[2]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
 %
-\>[2]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[2]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/beamer-luaxelatex.tex
+++ b/test/LaTeXAndHTML/user-manual/beamer-luaxelatex.tex
@@ -48,10 +48,10 @@
 %
 \\[\AgdaEmptyExtraSkip]%
 %
-\>[2]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[2]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
 %
-\>[2]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[2]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/beamer-pdflatex.quick.tex
+++ b/test/LaTeXAndHTML/user-manual/beamer-pdflatex.quick.tex
@@ -46,10 +46,10 @@
 %
 \\[\AgdaEmptyExtraSkip]%
 %
-\>[2]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[2]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
 %
-\>[2]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[2]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%

--- a/test/LaTeXAndHTML/user-manual/beamer-pdflatex.tex
+++ b/test/LaTeXAndHTML/user-manual/beamer-pdflatex.tex
@@ -46,10 +46,10 @@
 %
 \\[\AgdaEmptyExtraSkip]%
 %
-\>[2]\AgdaComment{-- A comment with some TeX ligatures:}\<%
+\>[2]\AgdaComment{--\ A\ comment\ with\ some\ TeX\ ligatures:}\<%
 \\
 %
-\>[2]\AgdaComment{-- --, ---, ?`, !`, `, ``, ', '', <<, >>.}\<%
+\>[2]\AgdaComment{--\ --,\ ---,\ ?`,\ !`,\ `,\ ``,\ ',\ '',\ <<,\ >>.}\<%
 \\
 %
 \\[\AgdaEmptyExtraSkip]%


### PR DESCRIPTION
Consider the following lagda file:
```latex
\documentclass{article}
\usepackage{agda}
\begin{document}
\begin{code}
-- Say we have a + b
--               ^
--               |_____ this is plus
\end{code}
\end{document}
```

Currently, if I run `agda --latex x.lagda` and then `pdflatex`, the spaces inside the comments disappear in the pdf output:
![image](https://user-images.githubusercontent.com/892232/114749887-5212bd80-9d4b-11eb-8209-ebba5b85ef50.png)


With the patch the pdf looks like this:
![image](https://user-images.githubusercontent.com/892232/114749941-5dfe7f80-9d4b-11eb-9986-1bdfca1bfcfe.png)



