### PR TITLE
[ fix #5120, #5259 ] A hotfix for building text-icu with icu4c 68+

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -56,15 +56,15 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Patch text-icu
+      run: |
+        make text-icu
+
     - uses: haskell/actions/setup@v1
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc-ver }}
         cabal-version: ${{ matrix.cabal-ver }}
-
-    - name: Patch text-icu
-      run: |
-        make text-icu
 
     - name: Configure the build plan
       run: |

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -62,6 +62,10 @@ jobs:
         ghc-version: ${{ matrix.ghc-ver }}
         cabal-version: ${{ matrix.cabal-ver }}
 
+    - name: Patch text-icu
+      run: |
+        make text-icu
+
     - name: Configure the build plan
       run: |
         cabal update

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -103,16 +103,11 @@ jobs:
         key: ${{ runner.os }}-cabal-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver }}-${{ hashFiles('**/plan.json') }}
 
     - name: Install dependencies
-      # Andreas, 2021-03-04, issue #5259.
-      # Disable -fenable-cluster-counting build on macOS because of text-icu issues.
-      if: ${{ runner.os != 'macOS' && !steps.cache.outputs.cache-hit }}
+      if: ${{ !steps.cache.outputs.cache-hit }}
       run: |
         cabal build --only-dependencies
 
     - name: Build Agda
-      # Andreas, 2021-03-04, issue #5259.
-      # Disable -fenable-cluster-counting build on macOS because of text-icu issues.
-      if: ${{ runner.os != 'macOS' }}
       run: |
         cabal build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,6 @@
 name: Deploy
 
 on:
-  workflow_dispatch:
   workflow_run:
     workflows: ["Build, Test, and Benchmark"]
     branches: [master]
@@ -87,6 +86,10 @@ jobs:
       with:
         ghc-version: ${{ matrix.ghc-ver }}
         cabal-version: ${{ matrix.cabal-ver }}
+
+    - name: Patch text-icu
+      run: |
+        make text-icu
 
     - name: Add the path to icu4c to the cabal configuration (macOS)
       if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,13 @@
 name: Deploy
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Build, Test, and Benchmark"]
     branches: [master]
     types:
       - completed
+
 defaults:
   run:
     shell: bash
@@ -27,18 +29,13 @@ jobs:
         cabal-ver: [3.2]
 
     env:
-      ARGS: "--disable-executable-profiling --disable-library-profiling"
+      ARGS: "--disable-executable-profiling --disable-library-profiling --enable-split-sections"
       # Liang-Ting Chen (2021-01-01):
       # Cabal cannot compile statically with text-icu (required by the flag `enable-cluster-counting`),
       # see https://github.com/4e6/text-icu-static-example
-      LINUX_ARGS: "--enable-split-sections --enable-executable-static"
-      # Liang-Ting Chen (2021-01-01):
-      # The option `split-sections` is ignored on macOS, see https://gitlab.haskell.org/ghc/ghc/-/issues/11445 for details.
-      # Andreas, 2021-03-04, issue #5259.
-      # Disable -fenable-cluster-counting build on macOS because of text-icu issues.
-      # MACOS_ARGS: "--flags=enable-cluster-counting"
-      MACOS_ARGS: ""
-      WIN64_ARGS: "--enable-split-sections --flags=enable-cluster-counting"
+      LINUX_ARGS: "--enable-executable-static"
+      MACOS_ARGS: "--flags=enable-cluster-counting"
+      WIN64_ARGS: "--flags=enable-cluster-counting"
     outputs:
       sha: ${{ steps.vars.outputs.sha }}
     runs-on: ${{ matrix.os }}
@@ -143,6 +140,9 @@ jobs:
 
     - name: Move artefacts to ${{ steps.vars.outputs.nightly }}
       # TODO: Move this part to Makefile
+      env:
+        ICU_VER: '68'
+        ICU_DIR: '/usr/local/opt/icu4c/lib'
       run: |
         mkdir -p ${{ steps.vars.outputs.nightly }}/bin
         cp -a src/data ${{ steps.vars.outputs.nightly }}
@@ -156,22 +156,20 @@ jobs:
           find dist-newstyle/build \( -name 'agda' -o -name 'agda-mode' \) -type f -exec cp {} ${{ steps.vars.outputs.nightly }}/bin \;
           strip ${{ steps.vars.outputs.nightly }}/bin/*
           cp -a .github/*.sh ${{ steps.vars.outputs.nightly }}
-          # Andreas, 2021-03-04, issue #5259.
-          # Disable -fenable-cluster-counting build on macOS because of text-icu issues.
-          # if [[ "$OSTYPE" == "darwin"* ]]; then
-          # # Change the path to the dynamic library icu4c to the run-time search path:
-          # #
-          # # 1. the same directory of executable, i.e. @executable_path
-          # # 2. @executable_path/../lib
-          # # 3. the default location of system-wide icu4c installed by homebrew, ie. /usr/local/opt/icu4c/lib
-          # #
-          #   mkdir ${{ steps.vars.outputs.nightly }}/lib
-          #   cp /usr/local/opt/icu4c/lib/libicuuc.67.dylib /usr/local/opt/icu4c/lib/libicui18n.67.dylib /usr/local/opt/icu4c/lib/libicudata.67.dylib ${{ steps.vars.outputs.nightly }}/lib
-          #   install_name_tool -change /usr/local/opt/icu4c/lib/libicuuc.67.dylib @rpath/libicuuc.67.dylib ${{ steps.vars.outputs.nightly }}/bin/agda
-          #   install_name_tool -change /usr/local/opt/icu4c/lib/libicui18n.67.dylib @rpath/libicui18n.67.dylib ${{ steps.vars.outputs.nightly }}/bin/agda
-          #   install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath /usr/local/opt/icu4c/lib ${{ steps.vars.outputs.nightly }}/bin/agda
-          #   otool -L ${{ steps.vars.outputs.nightly }}/bin/agda
-          # fi
+          if [[ "$OSTYPE" == "darwin"* ]]; then
+          # Change the path to the dynamic library icu4c to the run-time search path:
+          #
+          # 1. the same directory of executable, i.e. @executable_path
+          # 2. @executable_path/../lib
+          # 3. the default location of system-wide icu4c installed by homebrew, ie. /usr/local/opt/icu4c/lib
+          #
+          mkdir ${{ steps.vars.outputs.nightly }}/lib
+          cp ${ICU_DIR}/libicuuc.${ICU_VER}.dylib ${ICU_DIR}/libicui18n.${ICU_VER}.dylib ${ICU_DIR}/libicudata.${ICU_VER}.dylib ${{ steps.vars.outputs.nightly }}/lib
+          install_name_tool -change ${ICU_DIR}/libicuuc.${ICU_VER}.dylib @rpath/libicuuc.${ICU_VER}.dylib ${{ steps.vars.outputs.nightly }}/bin/agda
+          install_name_tool -change ${ICU_DIR}/libicui18n.${ICU_VER}.dylib @rpath/libicui18n.${ICU_VER}.dylib ${{ steps.vars.outputs.nightly }}/bin/agda
+          install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath ${ICU_DIR} ${{ steps.vars.outputs.nightly }}/bin/agda
+          otool -L ${{ steps.vars.outputs.nightly }}/bin/agda
+          fi
         fi
         file ${{ steps.vars.outputs.nightly }}/bin/agda
     - name: Compress the Agda executable

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -33,6 +33,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Patch text-icu
+      run: |
+        make text-icu
+
     - uses: haskell/actions/setup@v1
       id: setup-haskell
       with:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -74,15 +74,15 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Patch text-icu
+      run: |
+        make text-icu
+
     - uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc-ver }}
         stack-version: ${{ matrix.stack-ver }}
         enable-stack: true
-
-    - name: Patch text-icu
-      run: |
-        make text-icu
 
     - name: Update and configure stack package index
       run: |

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -125,12 +125,11 @@ jobs:
       run: printf "extra-lib-dirs:\n - /usr/local/opt/icu4c/lib\nextra-include-dirs:\n - /usr/local/opt/icu4c/include\n" > ~/.stack/config.yaml
 
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
-      if: ${{ runner.os != 'macOS' && !steps.cache-on-unix.outputs.cache-hit && !steps.cache-on-win64.outputs.cache-hit }}
+      if: ${{ !steps.cache-on-unix.outputs.cache-hit && !steps.cache-on-win64.outputs.cache-hit }}
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies --silent
 
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests` (i.e. the test suite).
       run: stack build ${ARGS} ${EXTRA_ARGS} --test --no-run-tests
 
     - name: Build Agda with the non-default flags Agda.cabal.
-      if: ${{ runner.os != 'macOS' }}
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -80,6 +80,10 @@ jobs:
         stack-version: ${{ matrix.stack-ver }}
         enable-stack: true
 
+    - name: Patch text-icu
+      run: |
+        make text-icu
+
     - name: Update and configure stack package index
       run: |
         stack update --silent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -339,4 +339,5 @@ jobs:
     - name: "Run tests for the size solver"
       run: |
         export PATH=${HOME}/.local/bin:${PATH}
+        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" text-icu
         make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" test-size-solver

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,10 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Patch text-icu
+      run: |
+        make text-icu
+
     - uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc-ver }}
@@ -127,7 +131,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "cubical"]
 	path = cubical
 	url = https://github.com/agda/cubical
+[submodule "text-icu"]
+	path = text-icu
+	url = https://github.com/haskell/text-icu.git

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -186,7 +186,7 @@ library
 
   if flag(enable-cluster-counting)
     cpp-options:    -DCOUNT_CLUSTERS
-    build-depends:  text-icu == 0.7.*
+    build-depends:  text-icu >= 0.7.1.0
 
   if os(windows)
     build-depends:  Win32 >= 2.3.1.1 && < 2.7

--- a/Makefile
+++ b/Makefile
@@ -527,7 +527,7 @@ testing-emacs-mode:
 .PHONY : install-size-solver ## Install the size solver.
 install-size-solver :
 	@$(call decorate, "Installing the size-solver program", \
-		$(MAKE) -C src/size-solver STACK_INSTALL_OPTS='$(STACK_INSTALL_OPTS)' CABAL_INSTALL_OPTS='$(CABAL_INSTALL_OPTS)' install-bin)
+		$(MAKE) -C src/size-solver STACK_INSTALL_OPTS='$(SLOW_STACK_INSTALL_OPTS) $(STACK_INSTALL_OPTS)' CABAL_INSTALL_OPTS='$(SLOW_CABAL_INSTALL_OPTS) $(CABAL_INSTALL_OPTS)' install-bin)
 
 .PHONY : test-size-solver ##
 test-size-solver : install-size-solver

--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,13 @@ install: install-bin compile-emacs-mode setup-emacs-mode
 ensure-hash-is-correct:
 	touch src/full/Agda/VersionCommit.hs
 
+.PHONY : text-icu ## Fetch and patch text-icu for icu4c 68+
+text-icu:
+	git submodule update --init text-icu
+	if ! patch --dry-run -Rfsp0 < patches/text-icu-C99-true.patch; then patch -p0 < patches/text-icu-C99-true.patch ; fi
+
 .PHONY: install-deps ## Install Agda dependencies.
-install-deps:
+install-deps: text-icu
 ifdef HAS_STACK
 	@echo "===================== Installing dependencies using Stack ================"
 	time $(STACK_INSTALL) $(STACK_INSTALL_DEP_OPTS)
@@ -159,8 +164,8 @@ else
 	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS)
 endif
 
-## Developer install goal without -foptimize-aggressively nor dependencies
-## Alternative to 'install-bin'
+# Developer install goal without -foptimize-aggressively nor dependencies
+# Alternative to 'install-bin'
 .PHONY: v1-install
 v1-install:  ensure-hash-is-correct
 ifdef HAS_STACK
@@ -309,6 +314,8 @@ tags : have-bin-hs-tags
 TAGS : have-bin-hs-tags
 	@$(call decorate, "TAGS", \
 		$(MAKE) -C $(FULL_SRC_DIR) TAGS)
+
+
 
 ##############################################################################
 ## Standard library
@@ -542,7 +549,7 @@ remove-default-stack-file :
 	rm -f stack.yaml
 	cd $(FIXW_PATH) && rm -f stack.yaml
 
-## Installing binaries for developer services
+# Installing binaries for developer services
 
 .PHONY : have-bin-%
 have-bin-% :

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/RikvanToor/text-icu.git
+    tag: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20 

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,1 @@
-packages: . text-icu
+packages: . std-lib text-icu

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,1 @@
-packages: .
-
-source-repository-package
-    type: git
-    location: https://github.com/RikvanToor/text-icu.git
-    tag: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20 
+packages: . text-icu

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,2 @@
-packages: . std-lib text-icu
+packages: .
+optional-packages: std-lib text-icu

--- a/patches/text-icu-C99-true.patch
+++ b/patches/text-icu-C99-true.patch
@@ -1,0 +1,33 @@
+diff -ruN text-icu/cbits/text_icu.c text-icu-patched/cbits/text_icu.c
+--- text-icu/cbits/text_icu.c	2021-04-21 14:53:01.000000000 +0800
++++ text-icu-patched/cbits/text_icu.c	2021-04-21 14:53:23.000000000 +0800
+@@ -305,7 +305,7 @@
+ 
+ int32_t __hs_u_strCompareIter(UCharIterator *iter1, UCharIterator *iter2)
+ {
+-    return u_strCompareIter(iter1, iter2, TRUE);
++    return u_strCompareIter(iter1, iter2, true);
+ }
+ 
+ UBlockCode __hs_ublock_getCode(UChar32 c)
+diff -ruN text-icu/include/hs_text_icu.h text-icu-patched/include/hs_text_icu.h
+--- text-icu/include/hs_text_icu.h	2021-04-21 14:53:01.000000000 +0800
++++ text-icu-patched/include/hs_text_icu.h	2021-04-21 14:53:42.000000000 +0800
+@@ -15,6 +15,7 @@
+ #include "unicode/ustring.h"
+ 
+ #include <stdint.h>
++#include <stdbool.h>
+ 
+ /* ubrk.h */
+ 
+diff -ruN text-icu/text-icu.cabal text-icu-patched/text-icu.cabal
+--- text-icu/text-icu.cabal	2021-04-21 14:53:01.000000000 +0800
++++ text-icu-patched/text-icu.cabal	2021-04-21 14:54:15.000000000 +0800
+@@ -1,5 +1,5 @@
+ name:           text-icu
+-version:        0.55.1.0
++version:        0.7.1.0
+ synopsis:       Bindings to the ICU library
+ homepage:       https://github.com/bos/text-icu
+ bug-reports:    https://github.com/bos/text-icu/issues

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -21,8 +21,7 @@ extra-deps:
   - text-1.2.3.1
   - uuid-types-1.0.3
   - wcwidth-0.0.2
-  - git: https://github.com/RikvanToor/text-icu.git
-    commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
+  - 'text-icu'
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -19,9 +19,10 @@ extra-deps:
   - tasty-silver-3.1.13
   - tasty-quickcheck-0.10.1.1
   - text-1.2.3.1
-  - text-icu-0.7.0.1
   - uuid-types-1.0.3
   - wcwidth-0.0.2
+  - git: https://github.com/RikvanToor/text-icu.git
+    commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.10.4.yaml
+++ b/stack-8.10.4.yaml
@@ -5,8 +5,7 @@ compiler-check: match-exact
 extra-deps:
 - tasty-1.4.0.3
 - tasty-silver-3.2.1
-- git: https://github.com/RikvanToor/text-icu.git
-  commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
+- 'text-icu'
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.10.4.yaml
+++ b/stack-8.10.4.yaml
@@ -5,6 +5,8 @@ compiler-check: match-exact
 extra-deps:
 - tasty-1.4.0.3
 - tasty-silver-3.2.1
+- git: https://github.com/RikvanToor/text-icu.git
+  commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -15,9 +15,10 @@ extra-deps:
   - tasty-1.1.0.4
   - tasty-silver-3.1.13
   - text-1.2.3.1
-  - text-icu-0.7.0.1
   - uuid-types-1.0.3
   - wcwidth-0.0.2
+  - git: https://github.com/RikvanToor/text-icu.git
+    commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -17,8 +17,7 @@ extra-deps:
   - text-1.2.3.1
   - uuid-types-1.0.3
   - wcwidth-0.0.2
-  - git: https://github.com/RikvanToor/text-icu.git
-    commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
+  - 'text-icu'
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -11,8 +11,7 @@ extra-deps:
   - splitmix-0.1.0.3
   - tasty-silver-3.1.13
   - uuid-types-1.0.3
-  - git: https://github.com/RikvanToor/text-icu.git
-    commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
+  - 'text-icu'
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -10,8 +10,9 @@ extra-deps:
   - regex-tdfa-1.3.1.0
   - splitmix-0.1.0.3
   - tasty-silver-3.1.13
-  - text-icu-0.7.0.1
   - uuid-types-1.0.3
+  - git: https://github.com/RikvanToor/text-icu.git
+    commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -13,8 +13,9 @@ extra-deps:
   - regex-base-0.94.0.0
   - regex-tdfa-1.3.1.0
   - splitmix-0.1.0.3
-  - text-icu-0.7.0.1
   - uuid-types-1.0.3
+  - git: https://github.com/RikvanToor/text-icu.git
+    commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -14,8 +14,7 @@ extra-deps:
   - regex-tdfa-1.3.1.0
   - splitmix-0.1.0.3
   - uuid-types-1.0.3
-  - git: https://github.com/RikvanToor/text-icu.git
-    commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
+  - 'text-icu'
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -6,6 +6,8 @@ extra-deps:
   - QuickCheck-2.14.2
   - random-1.2.0
   - splitmix-0.1.0.3
+  - git: https://github.com/RikvanToor/text-icu.git
+    commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -6,8 +6,7 @@ extra-deps:
   - QuickCheck-2.14.2
   - random-1.2.0
   - splitmix-0.1.0.3
-  - git: https://github.com/RikvanToor/text-icu.git
-    commit: 5451d335a6fd27ab3be99b1d2328bd89a8ce4a20
+  - 'text-icu'
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
This PR includes a patch proposed by @RikvanToor and commented by @marinelli from https://github.com/haskell/text-icu/pull/48. 

In detail, the repo https://github.com/haskell/text-icu/ becomes a submodule and a patch is now included in the directory `patches` (hopefully everything there will be gone one day). A number of changes are integrated into configurations.

* For `cabal`, a new `cabal.project` file is added so that the locally patched `text-icu` is used while invoking `cabal install`. This only works for cabal 2.x, though.
* For `stack`, those `stack-x.y.z.yaml` are changed so that `text-icu` points to the submodule.
* For `make`, a new target `text-icu` which fetch the submodule and apply the patch. The target `install-deps` now depends on it, so `make install-bin` should just work with icu4c 68+.