### PR TITLE
[ fix #4729 ] limit github on.push to master, issue*, release*

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -2,6 +2,10 @@ name: Build (cabal)
 
 on:
   push:
+    branches:
+    - master
+    - issue*
+    - release*
     paths:
     - '.github/workflows/cabal.yml'
     - 'Agda.cabal'

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -4,6 +4,10 @@ name: Haddock
 # not, this test is faster using `BUILD=CABAL` [Issue #2188].
 on:
   push:
+    branches:
+    - master
+    - issue*
+    - release*
     paths:
     - 'src/full/**.hs'
     - 'Agda.cabal'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,10 @@ name: Lint
 
 on:
   push:
+    branches:
+      - master
+      - issue*
+      - release*
     paths:
       - '.github/workflows/lint.yaml'
       - '.hlint.yaml'

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -2,6 +2,10 @@ name: Build (stack)
 
 on:
   push:
+    branches:
+    - master
+    - issue*
+    - release*
     paths:
     - '.github/workflows/stack.yml'
     - 'Agda.cabal'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,6 @@ name: Build, Test, and Benchmark
 
 on:
   pull_request:
-    branches:
-    - master
-    - issue*
-    - release*
     paths-ignore:
     - '.github/*'
     - '.github/workflows/cabal.yml'

--- a/.github/workflows/user_manual.yml
+++ b/.github/workflows/user_manual.yml
@@ -2,6 +2,10 @@ name: User Manual
 
 on:
   push:
+    branches:
+    - master
+    - issue*
+    - release*
     paths:
     - 'doc/user-manual/**'
     - '.github/workflows/user_manual.yml'

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -1,5 +1,11 @@
 name: Whitespace
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+    - issue*
+    - release*
+  pull_request:
 
 jobs:
   check:


### PR DESCRIPTION
[ fix #4729 ] limit github `on.push` to `master`, `issue*`, `release*`

Do not run workflows on any push, only to master and some dedicated branch types like `issue*` and `release*`.