### PR TITLE
[ fixed #5339 ] Allow duplicate constructors in constructor block

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -177,6 +177,7 @@ data KindOfBlock
   | InstanceBlock   -- ^ @instance@.  Actually, here all kinds of sub-declarations are allowed a priori.
   | FieldBlock      -- ^ @field@.  Ensured by parser.
   | DataBlock       -- ^ @data ... where@.  Here we got a bad error message for Agda-2.5 (Issue 1698).
+  | ConstructorBlock  -- ^ @constructor@, in @interleaved mutual@.
   deriving (Data, Eq, Ord, Show)
 
 

--- a/test/Fail/Issue2858-codata.err
+++ b/test/Fail/Issue2858-codata.err
@@ -1,3 +1,3 @@
-Issue2858-codata.agda:14,5-8
+Issue2858-codata.agda:14,5-21
 Could not find a matching data signature for constructor suc
 There was no candidate.

--- a/test/Fail/Issue2858-conflict.err
+++ b/test/Fail/Issue2858-conflict.err
@@ -1,4 +1,4 @@
-Issue2858-conflict.agda:7,5-11
+Issue2858-conflict.agda:7,5-21
 Could not find a matching data signature for constructor foobar
 It could be any of:
 Foo (at Issue2858-conflict.agda:3,8-11)

--- a/test/Succeed/Issue5339.agda
+++ b/test/Succeed/Issue5339.agda
@@ -1,0 +1,32 @@
+-- Andreas, 2021-04-22, issue #5339
+-- Allow constructors of the same name in `constructor` block.
+
+module _ where
+
+module Works where
+
+  interleaved mutual
+    data Nat : Set
+    data Fin : Nat → Set
+    constructor
+      zero : Nat
+    constructor
+      suc  : Nat → Nat
+      zero : ∀ {n} → Fin (suc n)
+    constructor
+      suc : ∀ {n} (i : Fin n) → Fin (suc n)
+
+interleaved mutual
+  data Nat : Set
+  data Fin : Nat → Set
+  constructor
+    zero : Nat
+    suc  : Nat → Nat
+    zero : ∀ {n} → Fin (suc n)
+    suc  : ∀ {n} (i : Fin n) → Fin (suc n)
+
+-- `constructor` block should be accepted despite duplicate constructor names.
+
+wkFin : ∀{n} → Fin n → Fin (suc n)
+wkFin zero    = zero
+wkFin (suc i) = suc (wkFin i)


### PR DESCRIPTION
[ fixed #5339 ] Allow duplicate constructors in constructor block

Using the existing `niceAxioms` instead of the new `mkLoneConstructor` allows duplicate entries.

`mkLoneConstructor` is then obsolete.