### PR TITLE
[ fix #5308 ] don't eta contract in instantiateFull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -620,6 +620,8 @@ Reflection
   `unknown` but to a proper `Term`. (See
   [#3553](https://github.com/agda/agda/issues/3553).)
 
+- Terms quoted by the reflection machinery are no longer eta-contracted.
+
 Library management
 ------------------
 

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -20,7 +20,7 @@ import Agda.Syntax.Treeless (TTerm, EvaluationStrategy, ArgUsage(..))
 
 import Agda.TypeChecking.CompiledClause as CC
 import qualified Agda.TypeChecking.CompiledClause.Compile as CC
-import Agda.TypeChecking.EtaContract (binAppView, BinAppView(..))
+import Agda.TypeChecking.EtaContract (binAppView, BinAppView(..), etaContract)
 import Agda.TypeChecking.Monad as TCM
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records (getRecordConstructor)
@@ -233,7 +233,7 @@ casetree cc = do
     CC.Done xs v -> withContextSize (length xs) $ do
       -- Issue 2469: Body context size (`length xs`) may be smaller than current context size
       -- if some arguments are not used in the body.
-      v <- lift (putAllowedReductions (SmallSet.fromList [ProjectionReductions, CopatternReductions]) $ normalise v)
+      v <- lift (putAllowedReductions (SmallSet.fromList [ProjectionReductions, CopatternReductions]) $ etaContract =<< normalise v)
       cxt <- asks ccCxt
       v' <- substTerm v
       reportS "treeless.convert.casetree" 40 $

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -47,6 +47,7 @@ import qualified Agda.Termination.Termination  as Term
 import Agda.Termination.RecCheck
 
 import Agda.TypeChecking.Datatypes
+import Agda.TypeChecking.EtaContract
 import Agda.TypeChecking.Functions
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
@@ -777,7 +778,8 @@ function g es0 = do
              -- Maybe we thought an eta redex could come from a meta instantiation.
              -- However, eta-contraction is already performed by instantiateFull.
              -- See test/Succeed/Issue2732-termination.agda.
-             traverse reduceCon <=< instantiateFull
+             -- 2021-04-20, Ulf: Since #5308 we are no longer eta contracting in instantiateFull.
+             etaContract <=< traverse reduceCon <=< instantiateFull
 
            -- 2017-05-16, issue #2403: Argument normalization is too expensive,
            -- even if we only expand non-recursive functions.

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -21,6 +21,7 @@ import Agda.Syntax.Internal.MetaVars
 import Agda.Syntax.Translation.InternalToAbstract (reify)
 
 import Agda.TypeChecking.Monad
+import Agda.TypeChecking.EtaContract
 import Agda.TypeChecking.MetaVars
 import Agda.TypeChecking.MetaVars.Occurs (killArgs,PruneResult(..),rigidVarsNotContainedIn)
 import Agda.TypeChecking.Names
@@ -986,8 +987,8 @@ compareIrrelevant t (DontCare v) w = compareIrrelevant t v w
 compareIrrelevant t v (DontCare w) = compareIrrelevant t v w
 -}
 compareIrrelevant t v0 w0 = do
-  let v = stripDontCare v0
-      w = stripDontCare w0
+  v <- etaContract $ stripDontCare v0
+  w <- etaContract $ stripDontCare w0
   reportSDoc "tc.conv.irr" 20 $ vcat
     [ "compareIrrelevant"
     , nest 2 $ "v =" <+> prettyTCM v

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -23,6 +23,7 @@ binAppView :: Term -> BinAppView
 binAppView t = case t of
   Var i xs   -> appE (Var i) xs
   Def c xs   -> appE (Def c) xs
+  MetaV m xs -> appE (MetaV m) xs
   -- Andreas, 2013-09-17: do not eta-contract when body is (record) constructor
   -- like in \ x -> s , x!  (See interaction/DoNotEtaContractFunIntoRecord)
   -- (Cf. also issue 889 (fixed differently).)
@@ -38,7 +39,6 @@ binAppView t = case t of
   Lam _ _    -> noApp
   Pi _ _     -> noApp
   Sort _     -> noApp
-  MetaV _ _  -> noApp
   DontCare _ -> noApp
   Dummy{}    -> __IMPOSSIBLE__
   where
@@ -69,6 +69,10 @@ etaOnce = \case
   Con c ci es -> etaCon c ci es etaContractRecord
 
   v -> return v
+
+-- For the boot file.
+etaContractTCM :: Term -> TCM Term
+etaContractTCM = etaContract
 
 -- | If record constructor, call eta-contraction function.
 etaCon :: (MonadTCEnv m, HasConstInfo m, HasOptions m)

--- a/src/full/Agda/TypeChecking/EtaContract.hs-boot
+++ b/src/full/Agda/TypeChecking/EtaContract.hs-boot
@@ -1,0 +1,7 @@
+
+module Agda.TypeChecking.EtaContract where
+
+import Agda.Syntax.Internal (Term)
+import Agda.TypeChecking.Monad.Base (TCM)
+
+etaContractTCM :: Term -> TCM Term

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -71,6 +71,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Internal
 
 import Agda.TypeChecking.Monad
+import Agda.TypeChecking.EtaContract
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
@@ -94,7 +95,7 @@ computeForcingAnnotations c t =
     -- Andreas, 2015-03-28  Issue 1469: Normalization too costly.
     -- Instantiation also fixes Issue 1454.
     -- Note that normalization of s0 below does not help.
-    t <- instantiateFull t
+    t <- etaContract =<< instantiateFull t
     -- Ulf, 2018-01-28 (#2919): We do need to reduce the target type enough to
     -- get to the actual data type.
     -- Also #2947: The type might reduce to a pi type.

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -648,6 +648,9 @@ assignWrapper dir x es v doAssign = do
 assign :: CompareDirection -> MetaId -> Args -> Term -> CompareAs -> TCM ()
 assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
 
+  -- Eta-contract arguments first. We rely on this in inverseSubst below.
+  args <- (mapM . traverse) etaContract args
+
   mvar <- lookupMeta x  -- information associated with meta x
   let t = jMetaType $ mvJudgement mvar
 

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -22,6 +22,7 @@ import Agda.Syntax.Literal
 import Agda.Syntax.Builtin
 import Agda.Syntax.Internal as I
 import Agda.TypeChecking.Monad.Base
+import {-# SOURCE #-} Agda.TypeChecking.EtaContract
 -- import Agda.TypeChecking.Functions  -- LEADS TO IMPORT CYCLE
 import Agda.TypeChecking.Substitute
 
@@ -81,6 +82,7 @@ setBuiltinThings b = stLocalBuiltins `setTCLens` b
 
 bindBuiltinName :: String -> Term -> TCM ()
 bindBuiltinName b x = do
+  x <- etaContractTCM x
   builtin <- getBuiltinThing b
   case builtin of
     Just (Builtin y) -> typeError $ DuplicateBuiltinBinding b y x

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1306,7 +1306,7 @@ instance InstantiateFull t => InstantiateFull (Type' t) where
       El <$> instantiateFull' s <*> instantiateFull' t
 
 instance InstantiateFull Term where
-    instantiateFull' = instantiate' >=> recurse >=> etaOnce
+    instantiateFull' = instantiate' >=> recurse -- >=> etaOnce
       -- Andreas, 2010-11-12 DONT ETA!? eta-reduction breaks subject reduction
       -- but removing etaOnce now breaks everything
       where

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1329,7 +1329,7 @@ checkExpr' cmp e t =
 
 doQuoteTerm :: Comparison -> Term -> Type -> TCM Term
 doQuoteTerm cmp et t = do
-  et'       <- etaContract =<< instantiateFull et
+  et'       <- instantiateFull et
   case allMetasList et' of
     []  -> do
       q  <- quoteTerm et'

--- a/test/Fail/Issue183.err
+++ b/test/Fail/Issue183.err
@@ -1,3 +1,3 @@
 Issue183.agda:15,13-14
-E _x_10 _x_10 !=< L (E f f)
-when checking that the expression e has type L (E f f)
+E _x_10 _x_10 !=< L (E f (λ x → f x))
+when checking that the expression e has type L (E f (λ x → f x))

--- a/test/Fail/Issue3810b.err
+++ b/test/Fail/Issue3810b.err
@@ -1,9 +1,11 @@
 Issue3810b.agda:25,13-18
-Global confluence check failed: f ((x : A) → A) (g ((x : A) → A))
-can be rewritten to either b or f ((x : A) → A) (λ x → a).
+Global confluence check failed:
+f ((x : A) → A) (λ x → g ((x₁ : A) → A) x) can be rewritten to
+either b or f ((x : A) → A) (λ x → a).
 Possible fix: add a rewrite rule with left-hand side
-f ((x : A) → A) (g ((x : A) → A)) to resolve the ambiguity.
+f ((x : A) → A) (λ x → g ((x₁ : A) → A) x) to resolve the
+ambiguity.
 when checking confluence of the rewrite rule rewf₂ with rewg
-Issue3810b.agda:31,9-13
+Issue3810b.agda:28,7-11
 a != b of type A
-when checking that the expression refl has type a ≡ b
+when checking that the expression refl has type test ≡ b

--- a/test/Fail/Issue3810c.err
+++ b/test/Fail/Issue3810c.err
@@ -1,8 +1,8 @@
 Issue3810c.agda:34,13-18
-Global confluence check failed: f (Box A) (g (Box A)) can be
-rewritten to either b or f (Box A) (box a).
+Global confluence check failed: f (Box A) (box (unbox (g (Box A))))
+can be rewritten to either b or f (Box A) (box a).
 Possible fix: add a rewrite rule with left-hand side
-f (Box A) (g (Box A)) to resolve the ambiguity.
+f (Box A) (box (unbox (g (Box A)))) to resolve the ambiguity.
 when checking confluence of the rewrite rule rewf₂ with rewg
 Issue3810c.agda:40,9-13
 a != b of type A

--- a/test/Fail/Issue765.err
+++ b/test/Fail/Issue765.err
@@ -5,6 +5,9 @@ problems (inferred index ≟ expected index):
   to m ≟ to n
 Possible reason why unification failed:
   Cannot eliminate reflexive equation ⊥-elim = ⊥-elim of type
-  Position (constC (C ⋆ X) ⊎C C) (inj₁ m) → μ (constC (C ⋆ X) ⊎C C)
+  Position
+  (constC ((Shape C ◃ Position C) ⋆ X) ⊎C Shape C ◃ Position C)
+  (inj₁ m) →
+  μ (constC ((Shape C ◃ Position C) ⋆ X) ⊎C Shape C ◃ Position C)
   because K has been disabled.
 when checking that the pattern refl has type to m ≡ to n

--- a/test/Succeed/Issue1269.agda
+++ b/test/Succeed/Issue1269.agda
@@ -12,25 +12,40 @@ data Even  : ℕ → Set where
   isEven0  : Even 0
   isEven+2 : ∀ {n} → Even n → Even (suc (suc n))
 
-pattern expected =
+pattern hid = argInfo hidden relevant
+pattern vis = argInfo visible relevant
+
+pattern expected-eta =
   def (quote ∃)
-      ( arg (argInfo hidden relevant) (def (quote Common.Level.lzero) []) ∷
-        arg (argInfo hidden relevant) (def (quote Common.Level.lzero) []) ∷
-        arg (argInfo hidden relevant) (def (quote ℕ) []) ∷
-        arg (argInfo visible relevant) (def (quote Even) []) ∷
+      ( arg hid (def (quote Common.Level.lzero) []) ∷
+        arg hid (def (quote Common.Level.lzero) []) ∷
+        arg hid (def (quote ℕ) []) ∷
+        arg vis (def (quote Even) []) ∷
         [] )
 
-isExpected : Term → Bool
-isExpected expected = true
-isExpected _        = false
+pattern expected-noeta =
+  def (quote ∃)
+      ( arg hid (def (quote Common.Level.lzero) []) ∷
+        arg hid (def (quote Common.Level.lzero) []) ∷
+        arg hid (def (quote ℕ) []) ∷
+        arg vis (lam visible (abs "n" (def (quote Even) (arg vis (var 0 []) ∷ [])))) ∷
+        [] )
+
+isEta : Term → Bool
+isEta expected-eta = true
+isEta _            = false
+
+isNoEta : Term → Bool
+isNoEta expected-noeta = true
+isNoEta _              = false
 
 `_ : Bool → Term
 ` true  = con (quote true) []
 ` false = con (quote false) []
 
 macro
-  checkExpectedType : QName → Tactic
-  checkExpectedType i hole =
+  checkExpectedType : (Term → Bool) → QName → Tactic
+  checkExpectedType isExpected i hole =
     bindTC (getType i) λ t →
     give (` isExpected t) hole
 
@@ -41,10 +56,10 @@ input1 : ∃ (λ n → Even n)
 input1 = 0 , isEven0
 
 quote0 : Bool
-quote0 = checkExpectedType input0
+quote0 = checkExpectedType isEta input0
 
 quote1 : Bool
-quote1 = checkExpectedType input1
+quote1 = checkExpectedType isNoEta input1
 
 ok0 : quote0 ≡ true
 ok0 = refl
@@ -61,8 +76,8 @@ quotedTerm0 = quoteTerm (∃ Even)
 quotedTerm1 : Term
 quotedTerm1 = quoteTerm (∃ (λ n → Even n))
 
-b : quotedTerm0 ≡ expected
+b : quotedTerm0 ≡ expected-eta
 b = refl
 
-c : quotedTerm1 ≡ expected
+c : quotedTerm1 ≡ expected-noeta
 c = refl

--- a/test/interaction/Issue5250/Issue5250.agda-lib
+++ b/test/interaction/Issue5250/Issue5250.agda-lib
@@ -1,2 +1,2 @@
-flags:
+flags: -Wall
 include: .

--- a/test/interaction/Issue5308.agda
+++ b/test/interaction/Issue5308.agda
@@ -1,0 +1,11 @@
+module _ where
+
+record Foo : Set₂ where
+  field foo : Set₁
+record Bar (f : Foo) : Set₂ where
+  field bar : Set₁
+resize : ∀ f g → Bar f → Bar g
+resize f g b = record { bar = Bar.bar b }
+
+resize' : ∀ f g → Bar f → Bar g
+resize' f g b = {!resize f g b!}

--- a/test/interaction/Issue5308.in
+++ b/test/interaction/Issue5308.in
@@ -1,0 +1,5 @@
+top_command    (cmd_load currentFile [])
+
+-- Should compute to "resize f g b"
+goal_command 0 (cmd_compute DefaultCompute) "resize f g b"
+

--- a/test/interaction/Issue5308.out
+++ b/test/interaction/Issue5308.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : Bar g " nil)
+((last . 1) . (agda2-goals-action '(0)))
+(agda2-status-action "")
+(agda2-info-action "*Normal Form*" "resize f g b" nil)


### PR DESCRIPTION
Adds explicit eta-contraction to the following places
- when binding builtins
- of the meta args when assigning metas, to make Miller checks happy
- in the termination checker, to respect eta-equality in structural ordering
- in treeless compiler
- when comparing irrelevant terms (to hunt for meta solutions)
- in forcing analysis

*WIP*

Currently makes the cubical library run out of memory checking `Cubical.Codata.M.AsLimit.M.Properties`. It seems to get past type checking, but I'm not sure where it gets stuck after that. The problematic definition is `in-out-id` (but I suspect the real problem is `in-inverse-out`). Both before and after this PR, normalising `in-inverse-out` does not return in ~10min.

@Saizan do you have time to take a look?