### PR TITLE
[ #5336 ] data...where is extensible

### DIFF
--- a/doc/user-manual/language/mutual-recursion.lagda.rst
+++ b/doc/user-manual/language/mutual-recursion.lagda.rst
@@ -48,7 +48,7 @@ The clauses for different functions can be interleaved e.g. for pedagogical purp
 
 You can mix arbitrary declarations, such as modules and postulates, with mutually recursive
 definitions. For data types and records the following syntax is used to separate the
-declaration from the introduction of constructors in one or many ``constructor`` blocks::
+declaration from the introduction of constructors in one or many ``data ... where`` blocks::
 
   interleaved mutual
 
@@ -58,7 +58,7 @@ declaration from the introduction of constructors in one or many ``constructor``
     El : U → Set
 
     -- We have a code for the type of natural numbers in our universe
-    constructor `Nat : U
+    data U where `Nat : U
     El `Nat = Nat
 
     -- Btw we know how to pair values in a record
@@ -67,7 +67,8 @@ declaration from the introduction of constructors in one or many ``constructor``
       field fst : A; snd : B
 
     -- And we have a code for pairs in our universe
-    constructor _`×_ : (A B : U) → U
+    data _ where
+      _`×_ : (A B : U) → U
     El (A `× B) = El A × El B
 
   -- we can now build types of nested pairs of natural numbers
@@ -78,17 +79,8 @@ declaration from the introduction of constructors in one or many ``constructor``
   val-example : El ty-example
   val-example = 0 , ((1 , 2) , 3)
 
-Constructor blocks can also be introduced by ``data ... where``, in this case, e.g.:
-
-.. code-block:: agda
-
-    data U where `Nat : U
-
-The ``data ... where`` syntax can be preferable over ``constructor``
-when there are many data types defined mutually and one wants to make
-clear to which data type new constructors are added.  On the other
-hand, one can add constructors to *different* data types in a
-``constructor`` block.
+You can mix constructors for different data types in a ``data _ where`` block
+(underscore instead of name).
 
 The ``interleaved mutual`` blocks get desugared into the
 :ref:`mutual-recursion-forward-declaration` blocks described below by:

--- a/doc/user-manual/language/mutual-recursion.lagda.rst
+++ b/doc/user-manual/language/mutual-recursion.lagda.rst
@@ -63,8 +63,7 @@ declaration from the introduction of constructors in one or many ``constructor``
 
     -- Btw we know how to pair values in a record
     record _×_ A B where
-      constructor _,_
-      inductive
+      inductive; constructor _,_
       field fst : A; snd : B
 
     -- And we have a code for pairs in our universe
@@ -79,8 +78,20 @@ declaration from the introduction of constructors in one or many ``constructor``
   val-example : El ty-example
   val-example = 0 , ((1 , 2) , 3)
 
+Constructor blocks can also be introduced by ``data ... where``, in this case, e.g.:
 
-These mutual blocks get desugared into the forward declaration blocks described below by:
+.. code-block:: agda
+
+    data U where `Nat : U
+
+The ``data ... where`` syntax can be preferable over ``constructor``
+when there are many data types defined mutually and one wants to make
+clear to which data type new constructors are added.  On the other
+hand, one can add constructors to *different* data types in a
+``constructor`` block.
+
+The ``interleaved mutual`` blocks get desugared into the
+:ref:`mutual-recursion-forward-declaration` blocks described below by:
 
 - leaving the signatures where they are,
 - grouping the clauses for a function together with the first of them, and
@@ -103,8 +114,7 @@ automatically inferred by Agda:
   g = b[f, g].
 
 You can mix arbitrary declarations, such as modules and postulates, with mutually recursive definitions.
-For data types and records the following syntax is used to separate the declaration from the definition:
-::
+For data types and records the following syntax is used to separate the declaration from the definition::
 
   -- Declaration.
   data Vec (A : Set) : Nat → Set  -- Note the absence of ‘where’.
@@ -144,6 +154,11 @@ Such a separation of declaration and definition is for instance needed when defi
 
     Interpretation nat      = Nat
     Interpretation (pi a b) = (x : Interpretation a) → Interpretation (b x)
+
+.. note::
+  In contrast to :ref:`mutual-recursion-interleaved-mutual`,
+  in forward-declaration style we can only have one ``data ... where``
+  block per data type.
 
 When making separated declarations/definitions private or abstract you should attach the ``private`` keyword to the declaration and the ``abstract`` keyword to the definition. For instance, a private, abstract function can be defined as
 

--- a/src/full/Agda/Syntax/Parser/LexActions.hs
+++ b/src/full/Agda/Syntax/Parser/LexActions.hs
@@ -188,24 +188,28 @@ keyword k =
         _ | k `elem` layoutKeywords ->
             withLayout k cont
 
-        -- @constructor@ is not a layout keyword in @record ... where@ blocks,
-        -- only in @interleaved mutual@ blocks.
-        KwConstructor -> do
-            cxt <- getContext
-            if inMutualAndNotInWhereBlock cxt
-              then withLayout k cont
-              else cont
+        -- Andreas, 2021-05-06, issue #5356:
+        -- @constructor@ is not a layout keyword after all, replaced by @data _ where@.
+        -- -- @constructor@ is not a layout keyword in @record ... where@ blocks,
+        -- -- only in @interleaved mutual@ blocks.
+        -- KwConstructor -> do
+        --     cxt <- getContext
+        --     if inMutualAndNotInWhereBlock cxt
+        --       then withLayout k cont
+        --       else cont
 
         _ -> cont
     where
     cont = withInterval_ (TokKeyword k)
 
-    -- Most recent block decides ...
-    inMutualAndNotInWhereBlock = \case
-      Layout KwMutual _ _ : _ -> True
-      Layout KwWhere  _ _ : _ -> False
-      _ : bs                  -> inMutualAndNotInWhereBlock bs
-      []                      -> True  -- For better errors on stray @constructor@ decls.
+    -- Andreas, 2021-05-06, issue #5356:
+    -- @constructor@ is not a layout keyword after all, replaced by @data _ where@.
+    -- -- Most recent block decides ...
+    -- inMutualAndNotInWhereBlock = \case
+    --   Layout KwMutual _ _ : _ -> True
+    --   Layout KwWhere  _ _ : _ -> False
+    --   _ : bs                  -> inMutualAndNotInWhereBlock bs
+    --   []                      -> True  -- For better errors on stray @constructor@ decls.
 
 
 -- | Parse a 'Symbol' token.

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1228,8 +1228,8 @@ RecordSig : 'record' Expr3NoCurly TypedUntypedBindings ':' Expr
   {% exprToName $2 >>= \ n -> return $ RecordSig (getRange ($1,$2,$3,$4,$5)) n $3 $5 }
 
 Constructor :: { Declaration }
-Constructor : 'constructor' Declarations0
-  { LoneConstructor (getRange ($1,$2)) $2 }
+Constructor : 'data' '_' 'where' Declarations0
+  { LoneConstructor (getRange ($1,$4)) $4 }
 
 -- Declaration of record constructor name.
 RecordConstructorName :: { (Name, IsInstance) }

--- a/test/Fail/Issue1465-data.err
+++ b/test/Fail/Issue1465-data.err
@@ -1,5 +1,5 @@
-Issue1465-data.agda:1,6-6
-Issue1465-data.agda:1,6: Parse error
-_<ERROR>
- : Set where
+Issue1465-data.agda:1,8-8
+Issue1465-data.agda:1,8: Parse error
+:<ERROR>
+ Set where
 ...

--- a/test/Fail/Issue2858-codata.agda
+++ b/test/Fail/Issue2858-codata.agda
@@ -3,12 +3,12 @@ interleaved mutual
   data CoNat : Set
   record ∞CoNat : Set
 
-  constructor
+  data _ where
     zero : CoNat
 
   record ∞CoNat where
     coinductive
     field force : CoNat
 
-  constructor
+  data _ where
     suc : ∞CoNat → ?

--- a/test/Fail/Issue2858-conflict.agda
+++ b/test/Fail/Issue2858-conflict.agda
@@ -3,5 +3,5 @@ interleaved mutual
   data Foo : Set → Set
   data Foo_Bar : Set
 
-  constructor
+  data _ where
     foobar : Foo Bar

--- a/test/Succeed/Issue2858-EvenOdd.agda
+++ b/test/Succeed/Issue2858-EvenOdd.agda
@@ -8,11 +8,11 @@ interleaved mutual
   data Odd  : Nat → Set
 
   -- base cases: 0 is Even, 1 is Odd
-  constructor
+  data _ where
     even-zero : Even zero
     odd-one   : Odd (suc zero)
 
   -- step case: suc switches the even/odd-ness
-  constructor
+  data _ where
     even-suc : ∀ {n} → Odd n → Even (suc n)
     odd-suc  : ∀ {n} → Even n → Odd (suc n)

--- a/test/Succeed/Issue2858-Fresh.agda
+++ b/test/Succeed/Issue2858-Fresh.agda
@@ -6,11 +6,11 @@ module Issue2858-Fresh {A : Set} (_#_ : A → A → Set) where
     data IsFresh (a : A) : Fresh → Set
 
     -- nil is a fresh list
-    constructor
+    data _ where
       []  : Fresh
       #[] : IsFresh a []
 
     -- cons is fresh as long as the new value is fresh
-    constructor
+    data _ where
       cons  : (x : A) (xs : Fresh) → IsFresh x xs → Fresh
       #cons : ∀ {x xs p} → a # x → IsFresh a xs → IsFresh a (cons x xs p)

--- a/test/Succeed/Issue2858-IR-record.agda
+++ b/test/Succeed/Issue2858-IR-record.agda
@@ -6,7 +6,7 @@ interleaved mutual
   data Rec : Set
   ⟦_⟧ : Rec → Set
 
-  constructor `Nat : Rec
+  data Rec where `Nat : Rec
   ⟦ `Nat   ⟧ = Nat
 
   _ : Rec
@@ -15,7 +15,7 @@ interleaved mutual
   _ : Rec → Rec
   _ = λ r → `Σ r (λ _ → `Nat)
 
-  constructor `Σ : (r : Rec) → (⟦ r ⟧ → Rec) → Rec
+  data Rec where `Σ : (r : Rec) → (⟦ r ⟧ → Rec) → Rec
   ⟦ `Σ A B ⟧ = Σ ⟦ A ⟧ λ a → ⟦ B a ⟧
 
 _+1-Nats : Nat → Rec

--- a/test/Succeed/Issue2858-invalid.agda
+++ b/test/Succeed/Issue2858-invalid.agda
@@ -1,5 +1,5 @@
 -- This is not valid with magic mutual blocks that guess how far down the
 -- file the mutual block extends
-constructor
+data _ where
   zero : Nat
   suc : Nat → Nat

--- a/test/Succeed/Issue2858-nbe.agda
+++ b/test/Succeed/Issue2858-nbe.agda
@@ -42,19 +42,19 @@ interleaved mutual
   th^Chk : Ren Γ Δ → Chk σ Γ → Chk σ Δ
 
   -- variable rule
-  constructor
+  data _ where
     var : Var σ Γ → Syn σ Γ
   th^Syn ρ (var v) = var (lookup ρ v)
 
   -- change of direction rules
-  constructor
+  data _ where
     emb : Syn σ Γ → Chk σ Γ
     cut : Chk σ Γ → Syn σ Γ
   th^Chk ρ (emb t) = emb (th^Syn ρ t)
   th^Syn ρ (cut c) = cut (th^Chk ρ c)
 
   -- function introduction and elimination
-  constructor
+  data _ where
     app : Syn (σ ↝ τ) Γ → Chk σ Γ → Syn τ Γ
     lam : Chk τ (σ ∷ Γ) → Chk (σ ↝ τ) Γ
   th^Syn ρ (app f t) = app (th^Syn ρ f) (th^Chk ρ t)

--- a/test/Succeed/Issue5334.agda
+++ b/test/Succeed/Issue5334.agda
@@ -16,9 +16,9 @@ interleaved mutual
 
   data Nat : Set
   data Fin : Nat → Set
-  constructor
+  data _ where
     zero : Nat
-  constructor
+  data _ where
     zero : Fin {!!}  -- should work
 
 -- Error was:

--- a/test/Succeed/Issue5336.agda
+++ b/test/Succeed/Issue5336.agda
@@ -1,0 +1,197 @@
+-- Andreas, 2021-04-28, issue #5336
+-- data...where is already extensible.
+
+module _ where
+
+module C where
+  postulate
+    Name QName : Set
+
+variable
+  x  y  : C.Name
+  xs ys : C.QName
+
+interleaved mutual
+
+  -- Scope of a declaration.
+
+  data Scope : Set
+  variable
+    sc sc' : Scope
+
+  -- Declarations in a scope.
+
+  data Decls (sc : Scope) : Set
+  variable
+    ds₀ ds ds' : Decls sc
+
+  -- A definition in a scope.
+  -- So far, we can only define modules, which hold declarations.
+
+  data Val : (sc : Scope) → Set
+
+  -- We use letter v ("value") for definitions.
+
+  variable
+    v v' : Val sc
+
+  -- A well-scoped name pointing to its definition.
+
+  data Name : (sc : Scope) → Val sc → Set
+
+  variable
+    n n' : Name sc v
+
+  -- A well-scoped declaration is one of
+  --
+  --   * A module definition.
+  --   * Importing the declarations of another module via `open`.
+
+  data Decl (sc : Scope) : Set where
+    modl : (x : C.Name) (ds : Decls sc) → Decl sc
+    opn  : (n : Name sc v)              → Decl sc
+
+  variable
+    d d' : Decl sc
+
+  -- A scope is a snoc list of lists of declarations.
+
+  data Scope where
+    ε   : Scope
+
+  data Scope where
+    _▷_ : (sc : Scope) (ds : Decls sc) → Scope
+
+  -- Lists of declarations are also given in snoc-form.
+
+  data Decls where
+    ε   : Decls sc
+
+  data Decls where
+    _▷_ : (ds : Decls sc) (d : Decl (sc ▷ ds)) → Decls sc
+
+  data Val where
+    -- The content of a module.
+    content : (ds : Decls sc) → Val sc
+    -- Qualifying a value that is taken from inside module x.
+    inside  : (x : C.Name) (v : Val ((sc ▷ ds) ▷ ds')) → Val (sc ▷ (ds ▷ modl x ds'))
+    imp     : (n : Name (sc ▷ ds₀) (content ds')) (v : Val ((sc ▷ ds₀) ▷ ds'))
+            → Val (sc ▷ (ds₀ ▷ opn n))
+
+  -- Weakning from one scope to an extended scope.
+
+  data _⊆_ : (sc sc' : Scope) → Set
+
+  variable
+    τ : sc ⊆ sc'
+
+  -- Weakning by a list of declarations or a single declaration.
+
+  wk1  : sc ⊆ (sc ▷ ds)
+  wk01 : (sc ▷ ds) ⊆ (sc ▷ (ds ▷ d))
+
+  -- Weakening a definition.
+
+  data WkVal : (τ : sc ⊆ sc') → Val sc → Val sc' → Set
+
+  variable
+    wv wv' wv₀ : WkVal τ v v'
+
+  data WkDecl  (τ : sc ⊆ sc') : Decl  sc → Decl  sc' → Set
+  variable
+    wd wd' : WkDecl τ d d'
+
+  data WkDecls : (τ : sc ⊆ sc') → Decls sc → Decls sc' → Set
+  variable
+    wds₀ wds wds' : WkDecls τ ds ds'
+
+  -- Names resolving in a list of declarations.
+
+  data DsName (sc : Scope) : (ds : Decls sc) → Val (sc ▷ ds) → Set -- where
+  variable
+    nds nds' : DsName sc ds v
+
+  -- Names resolving in a declaration.
+
+  data DName  (sc : Scope) (ds₀ : Decls sc) : (d : Decl (sc ▷ ds₀)) → Val (sc ▷ (ds₀ ▷ d)) → Set where
+
+    modl   : (wds : WkDecls wk01 ds ds')
+           → DName sc ds₀ (modl x ds) (content ds')
+
+    inside : (n : DsName (sc ▷ ds₀) ds' v)
+           → DName sc ds₀ (modl x ds') (inside x v)
+
+    imp    : (n : Name (sc ▷ ds₀) (content ds'))
+             (nds : DsName (sc ▷ ds₀) ds' v)
+           → DName sc ds₀ (opn n) (imp n v)
+
+  variable
+    nd nd' : DName sc ds d  v
+
+  -- This finally allows us to define names resolving in a scope.
+
+  data DsName where
+    here  : (nd  : DName  sc ds d v)                     → DsName sc (ds ▷ d) v
+    there : (w : WkVal wk01 v v') (nds : DsName sc ds v) → DsName sc (ds ▷ d) v'
+
+  data Name where
+    site   :                      (nds : DsName sc ds v) → Name (sc ▷ ds) v
+    parent : (w : WkVal wk1 v v') (n   : Name   sc    v) → Name (sc ▷ ds) v'
+
+  ------------------------------------------------------------------------
+  -- Relating entities defined in a scope to their weakenings.
+
+  -- Weakenings are order-preserving embeddings.
+
+  data _⊆_ where
+    ε    : ε ⊆ ε
+    _▷_  : (τ : sc ⊆ sc') (wds : WkDecls τ ds ds') → (sc ▷ ds) ⊆ (sc' ▷ ds')
+    _▷ʳ_ : (τ : sc ⊆ sc') (ds  : Decls sc')        → sc        ⊆ (sc' ▷ ds)
+
+  data WkDecls where
+    ε     : WkDecls τ ε ε
+    _▷_   : (ws : WkDecls τ ds ds') (wd : WkDecl (τ ▷ ws) d d') → WkDecls τ (ds ▷ d) (ds' ▷ d')
+    _▷ʳ_  : (ws : WkDecls τ ds ds') (d  : Decl (_ ▷ ds'))       → WkDecls τ  ds      (ds' ▷ d)
+
+  refl-⊆         : sc ⊆ sc
+  wkDecls-refl-⊆ : WkDecls τ ds ds
+  wkDecl-refl-⊆  : WkDecl  τ d  d
+
+  wkDecls-refl-⊆ {ds = ε}      = ε
+  wkDecls-refl-⊆ {ds = ds ▷ d} = wkDecls-refl-⊆ ▷ wkDecl-refl-⊆
+
+  refl-⊆ {sc = ε}       = ε
+  refl-⊆ {sc = sc ▷ ds} = refl-⊆ ▷ wkDecls-refl-⊆
+
+  -- We can now define the singleton weaknings.
+
+  -- By another list of declarations.
+  wk1 {ds = ds} = refl-⊆ ▷ʳ ds
+
+  -- By a single declaration.
+  wk01 {d = d} = refl-⊆ ▷ (wkDecls-refl-⊆ ▷ʳ d)
+
+  -- Weakning names
+
+  data WkName : (τ : sc ⊆ sc') (wv : WkVal τ v v') → Name sc v → Name sc' v' → Set
+
+  postulate
+    wkVal-refl-⊆  : WkVal  τ    v v
+    wkName-refl-⊆ : WkName τ wv n n
+
+  data WkDecl where
+    modl : (w  : WkDecls τ    ds ds') → WkDecl τ (modl x ds) (modl x ds')
+    opn  : (wn : WkName  τ wv n  n' ) → WkDecl τ (opn n)   (opn n')
+
+  wkDecl-refl-⊆ {d = modl x ds} = modl wkDecls-refl-⊆
+  wkDecl-refl-⊆ {d = opn n    } = opn {wv = wkVal-refl-⊆} wkName-refl-⊆
+
+  -- We can prove that the identity weaking leaves definitions unchanged.
+
+  data WkVal where
+    content : (wds : WkDecls τ ds ds') → WkVal τ (content ds) (content ds')
+    inside  : (wv : WkVal ((τ ▷ wds) ▷ wds') v  v' )
+            → WkVal (τ ▷ (wds ▷ modl wds')) (inside x v) (inside x v')
+
+  data WkName where
+    site   : WkName τ wv (site nds) (site nds')

--- a/test/Succeed/Issue5336.flags
+++ b/test/Succeed/Issue5336.flags
@@ -1,0 +1,1 @@
+--no-double-check

--- a/test/Succeed/Issue5339.agda
+++ b/test/Succeed/Issue5339.agda
@@ -8,24 +8,24 @@ module Works where
   interleaved mutual
     data Nat : Set
     data Fin : Nat → Set
-    constructor
+    data _ where
       zero : Nat
-    constructor
+    data _ where
       suc  : Nat → Nat
       zero : ∀ {n} → Fin (suc n)
-    constructor
+    data _ where
       suc : ∀ {n} (i : Fin n) → Fin (suc n)
 
 interleaved mutual
   data Nat : Set
   data Fin : Nat → Set
-  constructor
+  data _ where
     zero : Nat
     suc  : Nat → Nat
     zero : ∀ {n} → Fin (suc n)
     suc  : ∀ {n} (i : Fin n) → Fin (suc n)
 
--- `constructor` block should be accepted despite duplicate constructor names.
+-- `data _ where` block should be accepted despite duplicate constructor names.
 
 wkFin : ∀{n} → Fin n → Fin (suc n)
 wkFin zero    = zero


### PR DESCRIPTION
[ #5336 ] `data...where` is extensible

Alternative PR (see also #5350) for fixing #5336.
We can have several `data...where` blocks of constructors for one `DataSig`.

I notice that `data...where` is extensible only in `interleaved mutual`.  
- [ ] Document how `data...where` works in `interleaved mutual`.
- [ ] Also document that `data...where` is not extensible in ordinary _forward declaration_ new-style mutual blocks.