### PR TITLE
[ fix #5352 ] new option --no-double-check for .flags file in testsuite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ Pragmas and options
   `--rewriting` enabled, then all modules importing it must also have
   `--rewriting` enabled.
 
+* New option `--no-double-check` (default), opposite of the existing `--double-check`.
+
 Command-line interaction
 ------------------------
 

--- a/doc/user-manual/language/sized-types.flags
+++ b/doc/user-manual/language/sized-types.flags
@@ -1,1 +1,2 @@
 -i std-lib/src
+--no-double-check

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -484,8 +484,8 @@ flatSplitFlag o = return $ o { optFlatSplit = True }
 noFlatSplitFlag :: Flag PragmaOptions
 noFlatSplitFlag o = return $ o { optFlatSplit = False }
 
-doubleCheckFlag :: Flag PragmaOptions
-doubleCheckFlag o = return $ o { optDoubleCheck = True }
+doubleCheckFlag :: Bool -> Flag PragmaOptions
+doubleCheckFlag b o = return $ o { optDoubleCheck = b }
 
 noSyntacticEqualityFlag :: Flag PragmaOptions
 noSyntacticEqualityFlag o = return $ o { optSyntacticEquality = False }
@@ -999,8 +999,10 @@ pragmaOptions =
                     "set maximum depth for pattern match inversion to N (default: 50)"
     , Option []     ["safe"] (NoArg safeFlag)
                     "disable postulates, unsafe OPTION pragmas and primEraseEquality, implies --no-sized-types and --no-guardedness "
-    , Option []     ["double-check"] (NoArg doubleCheckFlag)
+    , Option []     ["double-check"] (NoArg (doubleCheckFlag True))
                     "enable double-checking of all terms using the internal typechecker"
+    , Option []     ["no-double-check"] (NoArg (doubleCheckFlag False))
+                    "disable double-checking of terms (default)"
     , Option []     ["no-syntactic-equality"] (NoArg noSyntacticEqualityFlag)
                     "disable the syntactic equality shortcut in the conversion checker"
     , Option ['W']  ["warning"] (ReqArg warningModeFlag "FLAG")

--- a/test/Fail/CheckSizeMetaBounds.flags
+++ b/test/Fail/CheckSizeMetaBounds.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/ConfluenceNestedOverlap.flags
+++ b/test/Fail/ConfluenceNestedOverlap.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/ConfluenceTypeLevelReduction.flags
+++ b/test/Fail/ConfluenceTypeLevelReduction.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/ConstructorHeadedDivergenceIn2-2-10.flags
+++ b/test/Fail/ConstructorHeadedDivergenceIn2-2-10.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/FrozenMVar.flags
+++ b/test/Fail/FrozenMVar.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/HoTTCompatibleWithSizeBasedTerminationMaximeDenes.flags
+++ b/test/Fail/HoTTCompatibleWithSizeBasedTerminationMaximeDenes.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue118Comment9.flags
+++ b/test/Fail/Issue118Comment9.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue1209-2.flags
+++ b/test/Fail/Issue1209-2.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue1258.flags
+++ b/test/Fail/Issue1258.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue1445-2.flags
+++ b/test/Fail/Issue1445-2.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue1445-3.flags
+++ b/test/Fail/Issue1445-3.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue1467.flags
+++ b/test/Fail/Issue1467.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue1523a.flags
+++ b/test/Fail/Issue1523a.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue1615.flags
+++ b/test/Fail/Issue1615.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue1974.flags
+++ b/test/Fail/Issue1974.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue1976-constraints.flags
+++ b/test/Fail/Issue1976-constraints.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue2450.flags
+++ b/test/Fail/Issue2450.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue2710.flags
+++ b/test/Fail/Issue2710.flags
@@ -1,1 +1,2 @@
 +RTS -M50M -A10M -RTS
+--no-double-check

--- a/test/Fail/Issue2941.flags
+++ b/test/Fail/Issue2941.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue2944.flags
+++ b/test/Fail/Issue2944.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue2985-1.flags
+++ b/test/Fail/Issue2985-1.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue2985-2.flags
+++ b/test/Fail/Issue2985-2.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue2993.flags
+++ b/test/Fail/Issue2993.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue300.flags
+++ b/test/Fail/Issue300.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue3067.flags
+++ b/test/Fail/Issue3067.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue3114.flags
+++ b/test/Fail/Issue3114.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue3401.flags
+++ b/test/Fail/Issue3401.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue3431.flags
+++ b/test/Fail/Issue3431.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue3982.flags
+++ b/test/Fail/Issue3982.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue399.flags
+++ b/test/Fail/Issue399.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue4118.flags
+++ b/test/Fail/Issue4118.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue418.flags
+++ b/test/Fail/Issue418.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue431b.flags
+++ b/test/Fail/Issue431b.flags
@@ -1,1 +1,2 @@
 -v warning:1
+--no-double-check

--- a/test/Fail/Issue483c.flags
+++ b/test/Fail/Issue483c.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue485.flags
+++ b/test/Fail/Issue485.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue585-11.flags
+++ b/test/Fail/Issue585-11.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue585t.flags
+++ b/test/Fail/Issue585t.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue659.flags
+++ b/test/Fail/Issue659.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue691.flags
+++ b/test/Fail/Issue691.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue796.flags
+++ b/test/Fail/Issue796.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue796o.flags
+++ b/test/Fail/Issue796o.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue878.flags
+++ b/test/Fail/Issue878.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue920a.flags
+++ b/test/Fail/Issue920a.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Issue921.flags
+++ b/test/Fail/Issue921.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/NoConstraints.flags
+++ b/test/Fail/NoConstraints.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/RewriteExt-confluence.flags
+++ b/test/Fail/RewriteExt-confluence.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/SizeUnsolvedConstraintsInTypeSignature.flags
+++ b/test/Fail/SizeUnsolvedConstraintsInTypeSignature.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/SizedBTree.flags
+++ b/test/Fail/SizedBTree.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/SizedTypesFunctionFromSuccSize.flags
+++ b/test/Fail/SizedTypesFunctionFromSuccSize.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/SizedTypesRigidVarClash.flags
+++ b/test/Fail/SizedTypesRigidVarClash.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/SizedTypesScopeExtrusion.flags
+++ b/test/Fail/SizedTypesScopeExtrusion.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/SizedTypesScopeViolationInMeta.flags
+++ b/test/Fail/SizedTypesScopeViolationInMeta.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/SizedTypesVarSwap.flags
+++ b/test/Fail/SizedTypesVarSwap.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Fail/Tests.hs
+++ b/test/Fail/Tests.hs
@@ -61,9 +61,10 @@ mkFailTest agdaFile =
   updGolden  = writeTextFile goldenFile
 
   doRun = do
-    let agdaArgs = ["-v0", "-vwarning:1", "-i" ++ testDir, "-itest/" , agdaFile
-                   , "--ignore-interfaces", "--no-libraries"]
-                   ++ [ "--double-check" | not (testName `elem` noDoubleCheckTests) ]
+    let agdaArgs = [ "-v0", "-vwarning:1", "-i" ++ testDir, "-itest/", agdaFile
+                   , "--ignore-interfaces", "--no-libraries"
+                   , "--double-check"
+                   ]
     runAgdaWithOptions testName agdaArgs (Just flagFile) Nothing
       <&> expectFail
 
@@ -202,62 +203,3 @@ printTestResult :: TestResult -> T.Text
 printTestResult = \case
   TestResult t            -> t
   TestUnexpectedSuccess p -> "AGDA_UNEXPECTED_SUCCESS\n\n" <> printProgramResult p
-
-noDoubleCheckTests :: [String]
-noDoubleCheckTests =
-  [ "Issue3982"
-  , "SizedTypesScopeViolationInMeta"
-  , "CheckSizeMetaBounds"
-  , "ConfluenceNestedOverlap"
-  , "ConfluenceTypeLevelReduction"
-  , "ConstructorHeadedDivergenceIn2-2-10"
-  , "FrozenMVar"
-  , "HoTTCompatibleWithSizeBasedTerminationMaximeDenes"
-  , "Issue118Comment9"
-  , "Issue1209-2"
-  , "Issue1258"
-  , "Issue1445-2"
-  , "Issue1445-3"
-  , "Issue1467"
-  , "Issue1523a"
-  , "Issue1615"
-  , "Issue1974"
-  , "Issue1976-constraints"
-  , "Issue2450"
-  , "Issue2710"
-  , "Issue2941"
-  , "Issue2944"
-  , "Issue2985-1"
-  , "Issue2985-2"
-  , "Issue2993"
-  , "Issue300"
-  , "Issue3067"
-  , "Issue3114"
-  , "Issue3401"
-  , "Issue3431"
-  , "Issue399"
-  , "Issue4118"
-  , "Issue418"
-  , "Issue431"
-  , "Issue431b"
-  , "Issue483c"
-  , "Issue485"
-  , "Issue585-11"
-  , "Issue585t"
-  , "Issue659"
-  , "Issue691"
-  , "Issue796"
-  , "Issue796o"
-  , "Issue878"
-  , "Issue920a"
-  , "Issue921"
-  , "NoConstraints"
-  , "RewriteExt-confluence"
-  , "SizeUnsolvedConstraintsInTypeSignature"
-  , "SizedBTree"
-  , "SizedTypesFunctionFromSuccSize"
-  , "SizedTypesRigidVarClash"
-  , "SizedTypesScopeExtrusion"
-  , "SizedTypesVarSwap"
-  , "WrongPolarity"
-  ]

--- a/test/Fail/WrongPolarity.flags
+++ b/test/Fail/WrongPolarity.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/CompileTimeInlining.flags
+++ b/test/Succeed/CompileTimeInlining.flags
@@ -1,1 +1,2 @@
 +RTS -M100M -A10M -RTS
+--no-double-check

--- a/test/Succeed/Conat-Sized.flags
+++ b/test/Succeed/Conat-Sized.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/CopatternTrailingImplicit.flags
+++ b/test/Succeed/CopatternTrailingImplicit.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/CubicalPrims.flags
+++ b/test/Succeed/CubicalPrims.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Cumulativity.flags
+++ b/test/Succeed/Cumulativity.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/DataPolarity.flags
+++ b/test/Succeed/DataPolarity.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1038.flags
+++ b/test/Succeed/Issue1038.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1099.flags
+++ b/test/Succeed/Issue1099.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1203.flags
+++ b/test/Succeed/Issue1203.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1209-4.flags
+++ b/test/Succeed/Issue1209-4.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1209-5.flags
+++ b/test/Succeed/Issue1209-5.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1209-6.flags
+++ b/test/Succeed/Issue1209-6.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1292b.flags
+++ b/test/Succeed/Issue1292b.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1409.flags
+++ b/test/Succeed/Issue1409.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1470.flags
+++ b/test/Succeed/Issue1470.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1523a.flags
+++ b/test/Succeed/Issue1523a.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1551.flags
+++ b/test/Succeed/Issue1551.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1796rewrite.flags
+++ b/test/Succeed/Issue1796rewrite.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1817.flags
+++ b/test/Succeed/Issue1817.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue1914.flags
+++ b/test/Succeed/Issue1914.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2046.flags
+++ b/test/Succeed/Issue2046.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2054.flags
+++ b/test/Succeed/Issue2054.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2257.flags
+++ b/test/Succeed/Issue2257.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2257b.flags
+++ b/test/Succeed/Issue2257b.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2429-subtyping.flags
+++ b/test/Succeed/Issue2429-subtyping.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2484-1.flags
+++ b/test/Succeed/Issue2484-1.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2484-10.flags
+++ b/test/Succeed/Issue2484-10.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2484-11.flags
+++ b/test/Succeed/Issue2484-11.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2484-2.flags
+++ b/test/Succeed/Issue2484-2.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2484-3.flags
+++ b/test/Succeed/Issue2484-3.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2484-4.flags
+++ b/test/Succeed/Issue2484-4.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2484-5.flags
+++ b/test/Succeed/Issue2484-5.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2484-6.flags
+++ b/test/Succeed/Issue2484-6.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2484-7.flags
+++ b/test/Succeed/Issue2484-7.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2484-8.flags
+++ b/test/Succeed/Issue2484-8.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2484-9.flags
+++ b/test/Succeed/Issue2484-9.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2554-size-mutual.flags
+++ b/test/Succeed/Issue2554-size-mutual.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2554-size-plus2.flags
+++ b/test/Succeed/Issue2554-size-plus2.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2558.flags
+++ b/test/Succeed/Issue2558.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue2917.flags
+++ b/test/Succeed/Issue2917.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue298.flags
+++ b/test/Succeed/Issue298.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue298b.flags
+++ b/test/Succeed/Issue298b.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue3577.flags
+++ b/test/Succeed/Issue3577.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue3601.flags
+++ b/test/Succeed/Issue3601.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue3639.flags
+++ b/test/Succeed/Issue3639.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue4320.flags
+++ b/test/Succeed/Issue4320.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue4404.flags
+++ b/test/Succeed/Issue4404.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue4907.flags
+++ b/test/Succeed/Issue4907.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Issue709.flags
+++ b/test/Succeed/Issue709.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/OutStream.flags
+++ b/test/Succeed/OutStream.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/RewriteExt.flags
+++ b/test/Succeed/RewriteExt.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Rose.flags
+++ b/test/Succeed/Rose.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/SizedCoinductiveRecords.flags
+++ b/test/Succeed/SizedCoinductiveRecords.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/SizedNatNew.flags
+++ b/test/Succeed/SizedNatNew.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/SizedQuicksort.flags
+++ b/test/Succeed/SizedQuicksort.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/SizedTypesExtendedLambda.flags
+++ b/test/Succeed/SizedTypesExtendedLambda.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/SizedTypesMergeSort.flags
+++ b/test/Succeed/SizedTypesMergeSort.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/SizedTypesMutual.flags
+++ b/test/Succeed/SizedTypesMutual.flags
@@ -1,2 +1,1 @@
--v warning:1
 --no-double-check

--- a/test/Succeed/Tests.hs
+++ b/test/Succeed/Tests.hs
@@ -70,11 +70,12 @@ mkSucceedTest extraOpts dir agdaFile =
 
   doRun = do
 
-    let agdaArgs = [ "-v0", "-i" ++ dir, "-itest/" , agdaFile
+    let agdaArgs = [ "-v0", "-i" ++ dir, "-itest/", agdaFile
                    , "--no-libraries"
                    , "-vimpossible:10" -- BEWARE: no spaces allowed here
                    , "-vwarning:1"
-                   ] ++ [ "--double-check" | not (testName `elem` noDoubleCheckTests) ]
+                   , "--double-check"
+                   ]
                      ++ extraOpts
 
     (res, ret) <- runAgdaWithOptions testName agdaArgs (Just flagFile) (Just varFile)
@@ -119,71 +120,13 @@ printTestResult = \case
   TestUnexpectedFail p      -> "AGDA_UNEXPECTED_FAIL\n\n" <> printProgramResult p
   TestWrongDotOutput t      -> "AGDA_WRONG_DOT_OUTPUT\n\n" <> t
 
--- List of test cases that do not pass the --double-check yet
+-- WAS: List of test cases that do not pass the --double-check yet
 -- NOTE
 --  Why are a lot of the sized types tests not working with --double-check? The reason can be found
 --  in Agda.TypeChecking.MetaVars.blockTermOnProblem, which does not block a term on unsolved size
 --  constraints (introduced by @andreasabel in 3be79cc7fd). This might be safe to do, but it will
 --  not be accepted by a double check.
-noDoubleCheckTests :: [String]
-noDoubleCheckTests =
-  [ "Cumulativity"
-  , "CompileTimeInlining"
-  , "Conat-Sized"
-  , "CopatternTrailingImplicit"
-  , "CubicalPrims"
-  , "DataPolarity"
-  , "Issue1038"
-  , "Issue1099"
-  , "Issue1203"
-  , "Issue1209-4"
-  , "Issue1209-5"
-  , "Issue1209-6"
-  , "Issue1292b"
-  , "Issue1409"
-  , "Issue1470"
-  , "Issue1523a"
-  , "Issue1551"
-  , "Issue1796rewrite"
-  , "Issue1817"
-  , "Issue1914"
-  , "Issue2046"
-  , "Issue2054"
-  , "Issue2257"
-  , "Issue2257b"
-  , "Issue2429-subtyping"
-  , "Issue2484-1"
-  , "Issue2484-2"
-  , "Issue2484-3"
-  , "Issue2484-4"
-  , "Issue2484-5"
-  , "Issue2484-6"
-  , "Issue2484-7"
-  , "Issue2484-8"
-  , "Issue2484-9"
-  , "Issue2484-10"
-  , "Issue2484-11"
-  , "Issue2554-size-mutual"
-  , "Issue2554-size-plus2"
-  , "Issue2558"
-  , "Issue2917"
-  , "Issue298"
-  , "Issue298b"
-  , "Issue3577"
-  , "Issue3601"
-  , "Issue3639"
-  , "Issue4320"
-  , "Issue4404"
-  , "Issue4907"
-  , "Issue709"
-  , "OutStream"
-  , "RewriteExt"
-  , "Rose"
-  , "SizedCoinductiveRecords"
-  , "SizedNatNew"
-  , "SizedQuicksort"
-  , "SizedTypesExtendedLambda"
-  , "SizedTypesMergeSort"
-  , "SizedTypesMutual"
-  , "language-sized-types"
-  ]
+--
+-- Andreas, 2021-04-29, issue #5352
+-- Now, there is an option `--no-double-check` in the respective .flags file.
+-- To get the list, try:  grep no-double-check *.flags


### PR DESCRIPTION
[ fix #5352 ] new option `--no-double-check` for `.flags` file in testsuite

Instead of hardwiring a list of test cases that skip the `--double-check`, add a new option `--no-double-check` to the respective `.flags` files.