### PR TITLE
[ agda input ] more parentheses

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -549,8 +549,8 @@ order for the change to take effect."
 
   ;; Parentheses.
 
-  ("(" . ,(agda-input-to-string-list "([{⁅⁽₍〈⎴⟅⟦⟨⟪⦃〈《「『【〔〖〚︵︷︹︻︽︿﹁﹃﹙﹛﹝（［｛｢"))
-  (")" . ,(agda-input-to-string-list ")]}⁆⁾₎〉⎵⟆⟧⟩⟫⦄〉》」』】〕〗〛︶︸︺︼︾﹀﹂﹄﹚﹜﹞）］｝｣"))
+  ("(" . ,(agda-input-to-string-list "([{⁅⁽₍〈⎴⟅⟦⟨⟪⦃〈《「『【〔〖〚︵︷︹︻︽︿﹁﹃﹙﹛﹝（［｛｢❪❬❰❲❴⟮⦅⦗⧼⸨❮⦇⦉"))
+  (")" . ,(agda-input-to-string-list ")]}⁆⁾₎〉⎵⟆⟧⟩⟫⦄〉》」』】〕〗〛︶︸︺︼︾﹀﹂﹄﹚﹜﹞）］｝｣❫❭❱❳❵⟯⦆⦘⧽⸩❯⦈⦊"))
 
   ("[[" . ("⟦"))
   ("]]" . ("⟧"))
@@ -566,6 +566,9 @@ order for the change to take effect."
 
   ("lbag" . ("⟅"))
   ("rbag" . ("⟆"))
+
+  ("<|" . ("⦉"))  ;; Angle bar brackets
+  ("|>" . ("⦊"))
 
   ("(|" . ("⦇"))  ;; Idiom brackets
   ("|)" . ("⦈"))


### PR DESCRIPTION
Add parentheses to agda input mode, to cover section "Bold, double, angular" of https://unicode-table.com/en/sets/brackets/

The file `agda-input.el` should maybe contain instructions how to add more symbols.
I appended the new parentheses at the end of the lists for `\(` and `\)`, for backwards compatibility.  However, there weren't any instructions what the best practice is.