### PR TITLE
Fix for issue #5363

### DIFF
--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1371,7 +1371,7 @@ leqLevel a b = catchConstraint (LevelCmp CmpLeq a b) $ do
             -- Jesper, 2019-10-13: abort if this is an interaction
             -- meta or a generalizable meta
             abort <- (isJust <$> isInteractionMeta x) `or2M`
-                     ((== YesGeneralize) <$> isGeneralizableMeta x)
+                     ((== YesGeneralizeVar) <$> isGeneralizableMeta x)
             if | abort -> postpone
                | otherwise -> do
                   x' <- case mvJudgement mv of

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -180,7 +180,7 @@ computeGeneralization genRecMeta nameMap allmetas = postponeInstanceConstraints 
       -- want the nice error from checking the constraint after generalization.
       -- See #3276.
       isGeneralizable (x, mv) = Map.member x nameMap ||
-                                not (isConstrained x) && YesGeneralize == unArg (miGeneralizable (mvInfo mv))
+                                not (isConstrained x) && NoGeneralize /= unArg (miGeneralizable (mvInfo mv))
       isSort = isSortMeta_ . snd
       isOpen = isOpenMeta . mvInstantiation . snd
 
@@ -302,9 +302,6 @@ computeGeneralization genRecMeta nameMap allmetas = postponeInstanceConstraints 
     fmap concat $ forM sortedMetas $ \ m -> do
       mv   <- lookupMeta m
       let info =
-            (if m `elem` alsoGeneralize
-             then setModality defaultModality
-             else id) $
             hideOrKeepInstance $
             getArgInfo $ miGeneralizable $ mvInfo mv
           HasType{ jMetaType = t } = mvJudgement mv
@@ -686,7 +683,7 @@ buildGeneralizeTel con xs = go 0 xs
 -- | Create metas for all used generalizable variables and their dependencies.
 createGenValues :: Set QName -> TCM (Map MetaId QName, Map QName GeneralizedValue)
 createGenValues s = do
-  genvals <- locallyTC eGeneralizeMetas (const YesGeneralize) $
+  genvals <- locallyTC eGeneralizeMetas (const YesGeneralizeVar) $
                forM (sortBy (compare `on` getRange) $ Set.toList s) createGenValue
   let metaMap = Map.fromList [ (m, x) | (x, m, _) <- genvals ]
       nameMap = Map.fromList [ (x, v) | (x, _, v) <- genvals ]
@@ -729,7 +726,7 @@ createGenValue x = setCurrentRange x $ do
 
   -- Update the ArgInfos for the named meta. The argument metas are
   -- created with the correct ArgInfo.
-  setMetaArgInfo m $ hideExplicit (defArgInfo def)
+  setMetaGeneralizableArgInfo m $ hideExplicit (defArgInfo def)
 
   reportSDoc "tc.generalize" 50 $ vcat
     [ "created metas for generalized variable" <+> prettyTCM x

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -326,7 +326,12 @@ newArgsMetaCtx' frozen condition (El s tm) tel perm ctx = do
           ctx' = (map . mapModality) (mod `inverseComposeModality`) ctx
       (m, u) <- applyModalityToContext info $
                  newValueMetaCtx frozen RunMetaOccursCheck CmpLeq a tel' perm ctx'
-      setMetaArgInfo m (getArgInfo dom)
+      -- Jesper, 2021-05-05: When creating a metavariable from a
+      -- generalizable variable, we must set the modality at which it
+      -- will be generalized.  Don't do this for other metavariables,
+      -- as they should keep the defaul modality (see #5363).
+      whenM ((== YesGeneralizeVar) <$> viewTC eGeneralizeMetas) $
+        setMetaGeneralizableArgInfo m $ hideOrKeepInstance info
       setMetaNameSuggestion m (absName codom)
       args <- newArgsMetaCtx' frozen condition (codom `absApp` u) tel perm ctx
       return $ Arg info u : args

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -245,11 +245,11 @@ metaCheck m = do
           reportSDoc "tc.meta.occurs" 20 $ "Meta occurs check found bad relevance"
           reportSDoc "tc.meta.occurs" 20 $ "aborting because" <+> reason
           patternViolation $ unblockOnMeta m
-    when (mvFrozen mv == Frozen)                 $ fail "meta is frozen"
-    when (not (isOpenMeta $ mvInstantiation mv)) $ fail "meta is already solved"
-    when (not allowAssign)                       $ fail "assigning metas is not allowed here"
-    when (isFlexible cxt)                        $ fail "occurrence is flexible"
-    when (isUnguarded cxt)                       $ fail "occurrence is unguarded"
+    when (mvFrozen mv == Frozen)             $ fail "meta is frozen"
+    unless (isOpenMeta $ mvInstantiation mv) $ fail "meta is already solved"
+    unless allowAssign                       $ fail "assigning metas is not allowed here"
+    when (isFlexible cxt)                    $ fail "occurrence is flexible"
+    when (isUnguarded cxt)                   $ fail "occurrence is unguarded"
 
     reportSDoc "tc.meta.occurs" 20 $ "Promoting meta" <+> prettyTCM m <+> "to modality" <+> prettyTCM mmod'
     let info' = setModality mmod' $ mvInfo mv

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1246,7 +1246,12 @@ instance Pretty a => Pretty (Judgement a) where
 -- ** Generalizable variables
 -----------------------------------------------------------------------------
 
-data DoGeneralize = YesGeneralize | NoGeneralize
+data DoGeneralize
+  = YesGeneralizeVar  -- ^ Generalize because it is a generalizable variable.
+  | YesGeneralizeMeta -- ^ Generalize because it is a metavariable and
+                      --   we're currently checking the type of a generalizable variable
+                      --   (this should get the default modality).
+  | NoGeneralize      -- ^ Don't generalize.
   deriving (Eq, Ord, Show, Data, Generic)
 
 -- | The value of a generalizable variable. This is created to be a

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -290,15 +290,15 @@ createMetaInfo' b = do
   r        <- getCurrentRange
   cl       <- buildClosure r
   gen      <- viewTC eGeneralizeMetas
-  let onlyUserQ q | noUserQuantity q = setQuantity topQuantity q
-                  | otherwise        = q
   modality <- viewTC eModality
   return MetaInfo
     { miClosRange       = cl
     , miModality        = modality
     , miMetaOccursCheck = b
     , miNameSuggestion  = ""
-    , miGeneralizable   = hide $ setModality (onlyUserQ modality) $ defaultArg gen
+    , miGeneralizable   = defaultArg gen
+                          -- The ArgInfo is set to the right value in
+                          -- the newArgsMetaCtx' function.
     }
 
 setValueMetaName :: MonadMetaSolver m => Term -> MetaNameSuggestion -> m ()
@@ -320,8 +320,9 @@ setMetaNameSuggestion mi s = unless (null s || isUnderscore s) $ do
   updateMetaVar mi $ \ mvar ->
     mvar { mvInfo = (mvInfo mvar) { miNameSuggestion = s }}
 
-setMetaArgInfo :: MonadMetaSolver m => MetaId -> ArgInfo -> m ()
-setMetaArgInfo m i = updateMetaVar m $ \ mv ->
+-- | Change the ArgInfo that will be used when generalizing over this meta.
+setMetaGeneralizableArgInfo :: MonadMetaSolver m => MetaId -> ArgInfo -> m ()
+setMetaGeneralizableArgInfo m i = updateMetaVar m $ \ mv ->
   mv { mvInfo = (mvInfo mv)
         { miGeneralizable = setArgInfo i (miGeneralizable (mvInfo mv)) } }
 

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -539,7 +539,7 @@ checkGeneralize s i info x e = do
 
     -- Check the signature and collect the created metas.
     (telNames, tGen) <-
-      generalizeType s $ locallyTC eGeneralizeMetas (const YesGeneralize) $
+      generalizeType s $ locallyTC eGeneralizeMetas (const YesGeneralizeMeta) $
         workOnTypes $ isType_ e
     let n = length telNames
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -327,11 +327,13 @@ instance EmbPrj NumGeneralizableArgs where
     valu _   = malformed
 
 instance EmbPrj DoGeneralize where
-  icod_ YesGeneralize = return 0
-  icod_ NoGeneralize  = return 1
+  icod_ YesGeneralizeVar  = return 0
+  icod_ YesGeneralizeMeta = return 1
+  icod_ NoGeneralize      = return 2
 
-  value 0 = return YesGeneralize
-  value 1 = return NoGeneralize
+  value 0 = return YesGeneralizeVar
+  value 1 = return YesGeneralizeMeta
+  value 2 = return NoGeneralize
   value _ = malformed
 
 instance EmbPrj Occurrence where

--- a/test/Fail/Issue5363b.agda
+++ b/test/Fail/Issue5363b.agda
@@ -1,0 +1,8 @@
+open import Agda.Primitive
+
+variable
+  @0 ℓ : Level
+  A : Set ℓ
+
+levelOf : A → Level
+levelOf {a} _ = a

--- a/test/Fail/Issue5363b.err
+++ b/test/Fail/Issue5363b.err
@@ -1,0 +1,3 @@
+Issue5363b.agda:8,17-18
+Variable a is declared erased, so it cannot be used here
+when checking that the expression a has type Level

--- a/test/Succeed/Issue5363.agda
+++ b/test/Succeed/Issue5363.agda
@@ -1,0 +1,7 @@
+open import Agda.Primitive
+
+variable
+  A : Set _
+
+levelOf : A → Level
+levelOf {a} _ = a


### PR DESCRIPTION
Fixes #5363 by distinguishing between metavariables created from generalizable variables, and metavariables that will be generalized over because they occur in the type of a generalizable meta declaration.