### PR TITLE
[ nightly ] Revamp the nightly workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,19 +6,21 @@ on:
     branches: [master]
     types:
       - completed
+  workflow_dispatch:
 
 defaults:
   run:
     shell: bash
 jobs:
   auto-cancel:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: Ubuntu-latest
     steps:
     - uses: styfle/cancel-workflow-action@0.6.0
       with:
         access_token: ${{ github.token }}
   build:
+    if: ${{ always() }}
     needs: auto-cancel
     strategy:
       fail-fast: false
@@ -198,7 +200,7 @@ jobs:
         if-no-files-found: error
         retention-days: 3
   deploy: # release a nightly build if triggered on master }}
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'workflow_run' }}
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-18.04]
-        ghc-ver: [8.10.4]
-        cabal-ver: [3.2]
+        ghc-ver: [9.0.1]
+        cabal-ver: [3.4]
 
     env:
       ARGS: "--disable-executable-profiling --disable-library-profiling --enable-split-sections"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,7 +144,7 @@ jobs:
     - name: Move artefacts to ${{ steps.vars.outputs.nightly }}
       # TODO: Move this part to Makefile
       env:
-        ICU_VER: '68'
+        ICU_VER: '69'
         ICU_DIR: '/usr/local/opt/icu4c/lib'
       run: |
         mkdir -p ${{ steps.vars.outputs.nightly }}/bin


### PR DESCRIPTION
* Fix the recent failure on macOS due to the update of `icu4c` on GitHub-hosted runners.
* Use `ghc-9.0.1` to compile Agda binaries.
* Be able to run the workflow manually without deploying binaries.

Tested on my [fork](https://github.com/L-TChen/agda/actions/runs/822611422) already.