### PR TITLE
Fix #5357 by using a better fix for #5161

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -691,13 +691,7 @@ loadDecodedModule file mi = do
   -- If any of the imports are newer we need to retype check
   badHashMessages <- fmap lefts $ forM (iImportedModules i) $ \(impName, impHash) -> runExceptT $ do
     reportSLn "import.iface" 30 $ concat ["Checking that module hash of import ", prettyShow impName, " matches ", prettyShow impHash ]
-    latestImpHash <- either throwError return =<< do
-                      lift $ lift $ (Right <$> moduleHash impName) `catchError` \ _ ->
-                                    -- Issue5161: Don't hard-fail here because we don't have the
-                                    -- location of the import at this point. Discarding the
-                                    -- interface here will force the error later when we do.
-                                    return $ Left $ concat ["imported module ", prettyShow impName,
-                                                            " has warnings preventing it from being imported"]
+    latestImpHash <- lift $ lift $ setCurrentRange impName $ moduleHash impName
     reportSLn "import.iface" 30 $ concat ["Done checking module hash of import ", prettyShow impName]
     when (impHash /= latestImpHash) $
       throwError $ concat

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -72,7 +72,7 @@ import Agda.Utils.IORef
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20210422 * 10 + 0
+currentInterfaceVersion = 20210510 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances.hs
@@ -3,16 +3,30 @@
 -- Only instances exported
 module Agda.TypeChecking.Serialise.Instances () where
 
+import Agda.Syntax.Position
+import Agda.Syntax.Abstract.Name
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Serialise.Base
+import Agda.TypeChecking.Serialise.Instances.Common (SerialisedRange(..))
 import Agda.TypeChecking.Serialise.Instances.Highlighting ()
 import Agda.TypeChecking.Serialise.Instances.Errors ()
+import Agda.Utils.Hash
+
+type RangedImportedModules = [(SerialisedRange, ModuleName, Hash)]
+
+fromImportedModules :: [(ModuleName, Hash)] -> RangedImportedModules
+fromImportedModules ms = [(SerialisedRange $ getRange x, x, hash) | (x, hash) <- ms]
+
+toImportedModules :: RangedImportedModules -> [(ModuleName, Hash)]
+toImportedModules ms = [(setRange (underlyingRange r) x, hash) | (r, x, hash) <- ms]
 
 instance EmbPrj Interface where
   icod_ (Interface a b c d e f g h i j k l m n o p q r s t) =
-    icodeN' Interface a b c d e f g h i j k l m n o p q r s t
+      icodeN' interface a b c (fromImportedModules d) e f g h i j k l m n o p q r s t
+    where interface a b c = Interface a b c . toImportedModules
 
   value = vcase valu where
     valu [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t] =
-      valuN Interface a b c d e f g h i j k l m n o p q r s t
+        valuN interface a b c d e f g h i j k l m n o p q r s t
+      where interface a b c = Interface a b c . toImportedModules
     valu _ = malformed

--- a/test/interaction/Imports/Issue5357-B.agda
+++ b/test/interaction/Imports/Issue5357-B.agda
@@ -1,0 +1,2 @@
+module Imports.Issue5357-B where
+import Imports.Issue5357-D

--- a/test/interaction/Imports/Issue5357-BadD.agda
+++ b/test/interaction/Imports/Issue5357-BadD.agda
@@ -1,0 +1,3 @@
+module Imports.Issue5357-D where
+A : Set₁
+A = Set₁

--- a/test/interaction/Imports/Issue5357-C.agda
+++ b/test/interaction/Imports/Issue5357-C.agda
@@ -1,0 +1,2 @@
+module Imports.Issue5357-C where
+import Imports.Issue5357-D

--- a/test/interaction/Imports/Issue5357-D.agda
+++ b/test/interaction/Imports/Issue5357-D.agda
@@ -1,0 +1,3 @@
+module Imports.Issue5357-D where
+A : Set₁
+A = Set

--- a/test/interaction/Issue2487-2.out
+++ b/test/interaction/Issue2487-2.out
@@ -2,14 +2,9 @@ Checking Issue2487.A (Issue2487/A.agda).
 Checking Issue2487-2 (Issue2487-2.agda).
 Changes in the following options in Issue2487/A.agda, re-typechecking: [--no-sized-types, --safe]
 Checking Issue2487.A (Issue2487/A.agda).
-Checking Issue2487-2 (Issue2487-2.agda).
-Issue2487-2.agda:4,1-19
+Issue2487-2.agda:4,8-19
 Importing module Issue2487.A not using the --safe flag from a
 module which does.
-when scope checking the declaration
-import Issue2487.A
-Issue2487-2.agda:4,1-19
+Issue2487-2.agda:4,8-19
 Importing module Issue2487.A not using the --no-sized-types flag
 from a module which does.
-when scope checking the declaration
-import Issue2487.A

--- a/test/interaction/Issue5357.agda
+++ b/test/interaction/Issue5357.agda
@@ -1,0 +1,2 @@
+import Imports.Issue5357-B
+import Imports.Issue5357-C

--- a/test/interaction/Issue5357.out
+++ b/test/interaction/Issue5357.out
@@ -1,0 +1,12 @@
+== Good run
+== Should check Top -> B -> D -> C
+Checking Issue5357 (Issue5357.agda).
+Checking Imports.Issue5357-B (Imports/Issue5357-B.agda).
+Checking Imports.Issue5357-D (Imports/Issue5357-D.agda).
+Checking Imports.Issue5357-C (Imports/Issue5357-C.agda).
+== Failing run
+== Should check D -> error
+Checking Imports.Issue5357-D (Imports/Issue5357-D.agda).
+Imports/Issue5357-D.agda:3,5-9
+Set₂ != Set₁
+when checking that the expression Set₁ has type Set₁

--- a/test/interaction/Issue5357.sh
+++ b/test/interaction/Issue5357.sh
@@ -1,0 +1,18 @@
+AGDA_BIN=$1
+
+# Everything works
+echo "== Good run"
+echo "== Should check Top -> B -> D -> C"
+$AGDA_BIN Issue5357.agda -v1 --ignore-interfaces
+
+# Make D fail
+cp Imports/Issue5357-D.agda Imports/Issue5357-GoodD.agda
+cp Imports/Issue5357-BadD.agda Imports/Issue5357-D.agda
+
+# Should not recheck D multiple times
+echo "== Failing run"
+echo "== Should check D -> error"
+$AGDA_BIN Issue5357.agda -v1
+
+# Restore D
+mv Imports/Issue5357-GoodD.agda Imports/Issue5357-D.agda


### PR DESCRIPTION
Store source location for imports in the interface so we can provide it if the interface cannot be loaded.