### PR TITLE
Crusade against `Prelude.last` and `Prelude.init`

### DIFF
--- a/src/full/Agda/Auto/CaseSplit.hs
+++ b/src/full/Agda/Auto/CaseSplit.hs
@@ -22,6 +22,7 @@ import Agda.Auto.Typecheck
 
 import Agda.Utils.Impossible
 import Agda.Utils.Monad (or2M)
+import Agda.Utils.List (last1)
 
 abspatvarname :: String
 abspatvarname = "\0absurdPattern"
@@ -645,7 +646,7 @@ getblks tt = do
    _ -> return []
  where
   f blks = case blks of
-             (_:_) -> case rawValue (last blks) of
+             (b : bs) -> case rawValue (last1 b bs) of
               HNApp (Var v) _ -> Just v
               _ -> Nothing
              _ -> Nothing

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -998,7 +998,7 @@ callGHC = do
   agdaMod <- curAgdaMod
   let outputName = case mnameToList agdaMod of
         [] -> __IMPOSSIBLE__
-        ms -> last ms
+        m:ms -> last1 m ms
   (mdir, fp) <- curOutFileAndDir
   let ghcopts = optGhcFlags opts
 

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -31,8 +31,9 @@ import Agda.Compiler.MAlonzo.Misc
 import Agda.Compiler.MAlonzo.Pretty () --instance only
 
 import qualified Agda.Utils.Haskell.Syntax as HS
-import Agda.Utils.Pretty (prettyShow)
+import Agda.Utils.List
 import Agda.Utils.Null
+import Agda.Utils.Pretty (prettyShow)
 
 import Agda.Utils.Impossible
 
@@ -243,9 +244,9 @@ hsTypeApproximation poly fv t = do
           Pi a b -> hsFun <$> go n (unEl $ unDom a) <*> go (n + k) (unEl $ unAbs b)
             where k = case b of Abs{} -> 1; NoAbs{} -> 0
           Def q els
-            | q `is` list, Apply t <- last (Proj ProjSystem __IMPOSSIBLE__ : els)
+            | q `is` list, Apply t <- last1 (Proj ProjSystem __IMPOSSIBLE__) els
                         -> HS.TyApp (tyCon "[]") <$> go n (unArg t)
-            | q `is` mayb, Apply t <- last (Proj ProjSystem __IMPOSSIBLE__ : els)
+            | q `is` mayb, Apply t <- last1 (Proj ProjSystem __IMPOSSIBLE__) els
                         -> HS.TyApp (tyCon "Maybe") <$> go n (unArg t)
             | q `is` bool -> return $ tyCon "Bool"
             | q `is` int  -> return $ tyCon "Integer"

--- a/src/full/Agda/Compiler/Treeless/Uncase.hs
+++ b/src/full/Agda/Compiler/Treeless/Uncase.hs
@@ -5,6 +5,8 @@ import Agda.TypeChecking.Substitute
 import Agda.Compiler.Treeless.Subst
 import Agda.Compiler.Treeless.Compare
 
+import Agda.Utils.List
+
 import Agda.Utils.Impossible
 
 caseToSeq :: Monad m => TTerm -> m TTerm
@@ -41,7 +43,7 @@ uncase t = case t of
         fallback = TCase x t d bs
         (fv, mu)
           | isUnreachable d =
-            case last bs of
+            case lastWithDefault __IMPOSSIBLE__ bs of
               TACon _ a b -> (a, tryStrengthen a b)
               TALit l b   -> (0, Just b)
               TAGuard _ b -> (0, Just b)

--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -41,6 +41,7 @@ import Agda.TypeChecking.Monad
 import           Agda.Utils.FileName
 import           Agda.Utils.Function
 import           Agda.Utils.Functor
+import           Agda.Utils.List                     ( initLast1 )
 import           Agda.Utils.List1                    ( List1 )
 import qualified Agda.Utils.List1          as List1
 import           Agda.Utils.Maybe
@@ -533,17 +534,18 @@ hiliteField xs x bindingR = hiliteCName xs x noRange bindingR $ nameAsp Field
 -- which defines this module.
 hiliteModule :: (Bool, A.ModuleName) -> Hiliter
 hiliteModule (isTopLevelModule, A.MName []) = mempty
-hiliteModule (isTopLevelModule, A.MName ns) =
+hiliteModule (isTopLevelModule, A.MName (n:ns)) =
   hiliteCName
-    (map A.nameConcrete (init ns))
-    (A.nameConcrete (last ns))
+    (map A.nameConcrete ms)
+    (A.nameConcrete m)
     noRange
     mR
     (nameAsp Module)
   where
+  (ms, m) = initLast1 n ns
   mR = Just $
        applyWhen isTopLevelModule P.beginningOfFile $
-       A.nameBindingSite (last ns)
+       A.nameBindingSite m
 
 -- This was Highlighting.Generate.nameToFile:
 -- | Converts names to suitable 'File's.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -70,6 +70,7 @@ import Agda.Syntax.Scope.Base     ( WithKind(..) )
 import Agda.Syntax.Abstract.Views ( KName, declaredNames )
 
 import Agda.Utils.FileName
+import Agda.Utils.List            ( caseList, initWithDefault, last1 )
 import Agda.Utils.Maybe
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Null
@@ -330,10 +331,10 @@ generateConstructorInfo modMap file kinds decl = do
   -- Get boundaries of current declaration.
   -- @noRange@ should be impossible, but in case of @noRange@
   -- it makes sense to return mempty.
-  ifNull (P.rangeIntervals $ getRange decl)
-         (return mempty) $ \is -> do
-    let start = fromIntegral $ P.posPos $ P.iStart $ head is
-        end   = fromIntegral $ P.posPos $ P.iEnd   $ last is
+  caseList (P.rangeIntervals $ getRange decl)
+           (return mempty) $ \ i is -> do
+    let start = fromIntegral $ P.posPos $ P.iStart i
+        end   = fromIntegral $ P.posPos $ P.iEnd $ last1 i is
 
     -- Get all disambiguated names that fall within the range of decl.
     m0 <- useTC stDisambiguatedNames
@@ -551,7 +552,7 @@ shadowingTelHighlighting :: [Range] -> HighlightingInfoBuilder
 shadowingTelHighlighting =
   -- we do not want to highlight the one variable in scope so we take
   -- the @init@ segment of the ranges in question
-  foldMap (\r -> H.singleton (rToR $ P.continuous r) m) . init
+  foldMap (\r -> H.singleton (rToR $ P.continuous r) m) . initWithDefault __IMPOSSIBLE__
   where
   m = parserBased { otherAspects =
                       Set.singleton H.ShadowingInTelescope }

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -55,6 +55,7 @@ import Agda.Interaction.Highlighting.Precise hiding (toList)
 import Agda.TypeChecking.Monad (Interface(..))
 
 import Agda.Utils.FileName (AbsolutePath)
+import Agda.Utils.List     (last1)
 import qualified Agda.Utils.List1 as List1
 
 import Agda.Utils.Impossible
@@ -261,10 +262,10 @@ resetColumn = modify $ \s ->
     }
   where
   -- Remove shadowed columns from old.
-  mergeCols []  old = old
-  mergeCols new old = new ++ filter ((< leastNew) . columnColumn) old
+  mergeCols []         old = old
+  mergeCols new@(n:ns) old = new ++ filter ((< leastNew) . columnColumn) old
     where
-    leastNew = columnColumn (last new)
+    leastNew = columnColumn (last1 n ns)
 
 moveColumn :: Int -> LaTeX ()
 moveColumn i = modify $ \s -> s { column = i + column s }

--- a/src/full/Agda/Interaction/Highlighting/Precise.hs
+++ b/src/full/Agda/Interaction/Highlighting/Precise.hs
@@ -57,6 +57,7 @@ import Agda.Syntax.Scope.Base                   ( KindOfName(..) )
 import Agda.Interaction.Highlighting.Range
 
 import Agda.Utils.List
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Null
 import Agda.Utils.RangeMap (RangeMap, IsBasicRangeMap(..))
@@ -323,13 +324,13 @@ instance IsBasicRangeMap Aspects PositionMap where
       IntMap.fromDistinctAscList [ (p, m) | p <- rangesToPositions rs ]
     }
 
-  toList = map join . groupBy' p . IntMap.toAscList . positionMap
+  toList = map join . List1.groupBy' p . IntMap.toAscList . positionMap
     where
     p (pos1, m1) (pos2, m2) = pos2 == pos1 + 1 && m1 == m2
-    join pms = ( Range { from = head ps, to = last ps + 1 }
-               , head ms
+    join pms = ( Range { from = List1.head ps, to = List1.last ps + 1 }
+               , List1.head ms
                )
-      where (ps, ms) = unzip pms
+      where (ps, ms) = List1.unzip pms
 
   toMap = positionMap
 

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -67,7 +67,7 @@ import Agda.Syntax.Concrete.Glyph ( unsafeSetUnicodeOrAscii, UnicodeOrAscii(..) 
 import Agda.Utils.FileName      ( AbsolutePath )
 import Agda.Utils.Functor       ( (<&>) )
 import Agda.Utils.Lens          ( Lens', over )
-import Agda.Utils.List          ( groupOn, wordsBy )
+import Agda.Utils.List          ( groupOn, initLast1, wordsBy )
 import Agda.Utils.Pretty        ( singPlural )
 import Agda.Utils.Trie          ( Trie )
 import qualified Agda.Utils.Trie as Trie
@@ -779,11 +779,13 @@ verboseFlag s o =
     do  (k,n) <- parseVerbose s
         return $ o { optVerbose = Trie.insert k n $ optVerbose o }
   where
+    parseVerbose :: String -> OptM ([VerboseKey], VerboseLevel)
     parseVerbose s = case wordsBy (`elem` (":." :: String)) s of
       []  -> usage
-      ss  -> do
-        n <- maybe usage return $ readMaybe (last ss)
-        return (init ss, n)
+      s0:ss0 -> do
+        let (ss, s) = initLast1 s0 ss0
+        n <- maybe usage return $ readMaybe s
+        return (ss, n)
     usage = throwError "argument to verbose should be on the form x.y.z:N or N"
 
 warningModeFlag :: String -> Flag PragmaOptions

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -35,6 +35,7 @@ import Data.List ( stripPrefix, intercalate )
 import GHC.Generics (Generic)
 
 import Agda.Utils.Lens
+import Agda.Utils.List
 import Agda.Utils.Maybe
 
 import Agda.Utils.Impossible
@@ -279,7 +280,7 @@ string2WarningName :: String -> Maybe WarningName
 string2WarningName = readMaybe . (++ "_")
 
 warningName2String :: WarningName -> String
-warningName2String = init . show
+warningName2String = initWithDefault __IMPOSSIBLE__ . show
 
 -- | @warningUsage@ generated using @warningNameDescription@
 

--- a/src/full/Agda/Interaction/SearchAbout.hs
+++ b/src/full/Agda/Interaction/SearchAbout.hs
@@ -20,6 +20,7 @@ import Agda.Interaction.BasicOps (normalForm, parseName)
 import qualified Agda.Syntax.Concrete as C
 import qualified Agda.Syntax.Internal as I
 
+import Agda.Utils.List   ( initLast1  )
 import Agda.Utils.Pretty ( prettyShow )
 
 findMentions :: Rewrite -> Range -> String -> ScopeM [(C.Name, I.Type)]
@@ -60,11 +61,12 @@ findMentions norm rg nm = do
   return $ concat ress
 
   where
+    isString :: String -> Either String String
+    isString ('"' : c : cs)
+      | (str, '"') <- initLast1 c cs
+      = Left $ filter (/= '"') str
     isString str
-      |  not (null str)
-      && head str == '"'
-      && last str == '"' = Left $ filter (/= '"') str
-      | otherwise        = Right str
+      = Right str
 
     anames (DefinedName _ an _)   = [an]
     anames (FieldName     ans)    = toList ans

--- a/src/full/Agda/Syntax/Concrete/Glyph.hs
+++ b/src/full/Agda/Syntax/Concrete/Glyph.hs
@@ -18,6 +18,7 @@ import qualified System.IO.Unsafe as UNSAFE (unsafePerformIO)
 
 import GHC.Generics (Generic)
 
+import Agda.Utils.List
 import Agda.Utils.Null
 import Agda.Utils.Pretty
 
@@ -88,8 +89,8 @@ specialCharacters :: SpecialCharacters
 specialCharacters = specialCharactersForGlyphs unsafeUnicodeOrAscii
 
 braces' :: Doc -> Doc
-braces' d = ifNull (render d) (braces d) {-else-} $ \ s ->
-  braces (spaceIfDash (head s) <> d <> spaceIfDash (last s))
+braces' d = caseList (render d) (braces d) {-else-} $ \ c cs ->
+  braces (spaceIfDash c <> d <> spaceIfDash (last1 c cs))
   -- Add space to avoid starting a comment (Ulf, 2010-09-13, #269)
   -- Andreas, 2018-07-21, #3161: Also avoid ending a comment
   where

--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -21,6 +21,7 @@ import Agda.Syntax.Position
 
 import Agda.Utils.FileName
 import Agda.Utils.Lens
+import Agda.Utils.List  (last1)
 import Agda.Utils.List1 (List1, pattern (:|), (<|))
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Pretty
@@ -57,7 +58,7 @@ type NameParts = List1 NamePart
 
 isOpenMixfix :: Name -> Bool
 isOpenMixfix = \case
-  Name _ _ (x :| xs@(_:_)) -> x == Hole || last xs == Hole
+  Name _ _ (x :| x' : xs) -> x == Hole || last1 x' xs == Hole
   _ -> False
 
 instance Underscore Name where

--- a/src/full/Agda/Syntax/Internal/SanityCheck.hs
+++ b/src/full/Agda/Syntax/Internal/SanityCheck.hs
@@ -8,7 +8,7 @@ import Agda.Syntax.Internal
 import Agda.TypeChecking.Free
 import Agda.TypeChecking.Monad
 
-import Agda.Utils.List ( dropEnd )
+import Agda.Utils.List ( dropEnd, initWithDefault )
 import Agda.Utils.Pretty
 import Agda.Utils.Size
 import Agda.Utils.Impossible
@@ -54,7 +54,7 @@ sanityCheckSubst gamma rho delta = go gamma rho delta
                                                                         , text $ "< " ++ show n ]
           sanityCheckSubst (dropLastN n gamma) rho (dropLastN n delta)
 
-    dropLast = telFromList . init . telToList
+    dropLast = telFromList . initWithDefault __IMPOSSIBLE__ . telToList
     dropLastN n = telFromList . dropEnd n . telToList
 
     err reason = do

--- a/src/full/Agda/Syntax/Notation.hs
+++ b/src/full/Agda/Syntax/Notation.hs
@@ -100,8 +100,8 @@ data NotationKind
 -- /normal/ holes.
 notationKind :: Notation -> NotationKind
 notationKind []  = NoNotation
-notationKind syn =
-  case (isNormalHole $ head syn, isNormalHole $ last syn) of
+notationKind (h:syn) =
+  case (isNormalHole h, isNormalHole $ last1 h syn) of
     (True , True ) -> InfixNotation
     (True , False) -> PostfixNotation
     (False, True ) -> PrefixNotation

--- a/src/full/Agda/Syntax/Parser/Literate.hs
+++ b/src/full/Agda/Syntax/Parser/Literate.hs
@@ -25,10 +25,12 @@ import Prelude hiding (getLine)
 import Control.Monad ((<=<))
 import Data.Char (isSpace)
 import Data.List (isPrefixOf)
-import Agda.Syntax.Common
-import Agda.Syntax.Position
 import Text.Regex.TDFA
 
+import Agda.Syntax.Common
+import Agda.Syntax.Position
+
+import Agda.Utils.List
 import Agda.Utils.Impossible
 
 -- | Role of a character in the file.
@@ -262,7 +264,7 @@ literateRsT pos s = mkLayers pos$ rst s
       []                         -> not_code
       [[_, before, "::", after]] ->
         -- Code starts
-        if null before || isBlank (last before) then
+        if maybe True isBlank $ lastMaybe before then
           (Markup, line) : code rest
         else
           (Comment, before ++ ":") : (Markup, ":" ++ after) : code rest

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -701,10 +701,10 @@ rEnd r@(Range f _) = (\p -> p { srcFile = f }) <$> rEnd' r
 --
 -- Precondition: The intervals must point to the same file.
 fuseIntervals :: Ord a => Interval' a -> Interval' a -> Interval' a
-fuseIntervals x y = Interval { iStart = head ss, iEnd = last es }
+fuseIntervals x y = Interval { iStart = s, iEnd = e }
     where
-    ss = sort [iStart x, iStart y]
-    es = sort [iEnd   x, iEnd   y]
+    s = headWithDefault __IMPOSSIBLE__ $ sort [iStart x, iStart y]
+    e = lastWithDefault __IMPOSSIBLE__ $ sort [iEnd   x, iEnd   y]
 
 -- | @fuseRanges r r'@ unions the ranges @r@ and @r'@.
 --

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -668,7 +668,7 @@ copyScope oldc new0 s = (inScopeBecause (Applied oldc) *** memoToScopeInfo) <$> 
                --   return $ A.mnameFromList $ newL ++ suffix
                -- Ulf, 2016-02-22: #1726
                -- We still need to copy modules from 'open public'. Same as in renName.
-               y <- refresh (last $ A.mnameToList x)
+               y <- refresh $ lastWithDefault __IMPOSSIBLE__ $ A.mnameToList x
                return $ A.mnameFromList $ newM ++ [y]
             -- Andreas, Jesper, 2015-07-02: Issue 1597
             -- Don't copy a module over itself, it will just be emptied of its contents.

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -658,15 +658,16 @@ reifyTerm expandAnonDefs0 v0 = do
       -- Check if we have an absurd lambda.
       case def of
        Function{ funCompiled = Just Fail{}, funClauses = [cl] }
-                | isAbsurdLambdaName x -> do
+          | isAbsurdLambdaName x -> do
                   -- get hiding info from last pattern, which should be ()
-                  let h = getHiding $ last $ namedClausePats cl
-                      n = length (namedClausePats cl) - 1  -- drop all args before the absurd one
+                  let (ps, p) = fromMaybe __IMPOSSIBLE__ $ initLast $ namedClausePats cl
+                  let h = getHiding p
+                      n = length ps  -- drop all args before the absurd one
                       absLam = A.AbsurdLam exprNoRange h
                   if | n > length es -> do -- We don't have all arguments before the absurd one!
                         let name (I.VarP _ x) = patVarNameToString $ dbPatVarName x
                             name _            = __IMPOSSIBLE__  -- only variables before absurd pattern
-                            vars = map (getArgInfo &&& name . namedArg) $ drop (length es) $ init $ namedClausePats cl
+                            vars = map (getArgInfo &&& name . namedArg) $ drop (length es) ps
                             lam (i, s) = do
                               x <- freshName_ s
                               return $ A.Lam exprNoRange (A.mkDomainFree $ unnamedArg i $ A.mkBinder_ x)

--- a/src/full/Agda/TypeChecking/Empty.hs
+++ b/src/full/Agda/TypeChecking/Empty.hs
@@ -24,7 +24,10 @@ import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 
 import Agda.Utils.Either
+import Agda.Utils.List
 import Agda.Utils.Monad
+
+import Agda.Utils.Impossible
 
 data ErrorNonEmpty
   = Fail               -- ^ Generic failure
@@ -87,7 +90,7 @@ checkEmptyType range t = do
           Left UnificationStuck{} -> return $ Left $ DontKnow $ unblockOnAnyMetaIn tel
           Left _                  -> return $ Left Fail
           Right cov -> do
-            let ps = map (namedArg . last . fromSplitPatterns . scPats) $ splitClauses cov
+            let ps = map (namedArg . lastWithDefault __IMPOSSIBLE__ . fromSplitPatterns . scPats) $ splitClauses cov
             if (null ps) then return (Right ()) else
               Left . FailBecause <$> do typeError_ $ ShouldBeEmpty t ps
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -61,6 +61,7 @@ import Agda.TypeChecking.Reduce (instantiate)
 import Agda.Utils.FileName
 import Agda.Utils.Float  ( toStringWithoutDotZero )
 import Agda.Utils.Function
+import Agda.Utils.List   ( initLast )
 import Agda.Utils.List1 (List1, pattern (:|))
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
@@ -1065,9 +1066,7 @@ instance PrettyTCM TypeError where
           NonfixNotation  -> id
           NoNotation      -> __IMPOSSIBLE__
 
-        (names, name) = case Set.toList $ notaNames nota of
-          [] -> __IMPOSSIBLE__
-          ns -> (init ns, last ns)
+        (names, name) = fromMaybe __IMPOSSIBLE__ $ initLast $ Set.toList $ notaNames nota
 
         strut = Boxes.emptyBox (length names) 0
 

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -5,13 +5,16 @@ module Agda.TypeChecking.EtaContract where
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Generic
+
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Free
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Reduce.Monad () --instance only
 import {-# SOURCE #-} Agda.TypeChecking.Records
 import {-# SOURCE #-} Agda.TypeChecking.Datatypes
+
 import Agda.Utils.Monad
+import Agda.Utils.List (initLast1)
 
 import Agda.Utils.Impossible
 
@@ -44,9 +47,11 @@ binAppView t = case t of
   where
     noApp = NoApp t
     appE f [] = noApp
-    appE f xs
-      | Apply v <- last xs = App (f $ init xs) v
+    appE f (x:xs)
+      | Apply v <- t = App (f ts) v
       | otherwise          = noApp
+      where
+      (ts, t) = initLast1 x xs
 
 -- | Contracts all eta-redexes it sees without reducing.
 {-# SPECIALIZE etaContract :: TermLike a => a -> TCM a #-}

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1938,9 +1938,9 @@ projDropPars (Projection Just{} d _ _ lams) o =
       let core = Lam i $ Abs y $ Var 0 [Proj o d] in
       List.foldr (\ (Arg ai x) -> Lam ai . NoAbs x) core pars
 -- Projection-like functions:
-projDropPars (Projection Nothing _ _ _ lams) o | null lams = __IMPOSSIBLE__
 projDropPars (Projection Nothing d _ _ lams) o =
-  List.foldr (\ (Arg ai x) -> Lam ai . NoAbs x) (Def d []) $ init $ getProjLams lams
+  List.foldr (\ (Arg ai x) -> Lam ai . NoAbs x) (Def d []) $
+    initWithDefault __IMPOSSIBLE__ $ getProjLams lams
 
 -- | The info of the principal (record) argument.
 projArgInfo :: Projection -> ArgInfo

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -273,7 +273,7 @@ hasVerbosity k n | n < 0     = __IMPOSSIBLE__
                  | otherwise = do
     t <- getVerbosity
     let ks = parseVerboseKey k
-        m  = last $ 0 : Trie.lookupPath ks t
+        m  = lastWithDefault 0 $ Trie.lookupPath ks t
     return (n <= m)
 
 -- | Check whether a certain verbosity level is activated (exact match).

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -776,7 +776,9 @@ defaultGetConstInfo st env q = do
             _             -> q
 
           dropLastModule q@QName{ qnameModule = m } =
-            q{ qnameModule = mnameFromList $ ifNull (mnameToList m) __IMPOSSIBLE__ init }
+            q{ qnameModule = mnameFromList $
+                 initWithDefault __IMPOSSIBLE__ $ mnameToList m
+             }
 
 -- HasConstInfo lifts through monad transformers
 -- (see default signatures in HasConstInfo class).

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -725,8 +725,9 @@ etaContractRecord r c ci args = if all (not . usableModality) args then fallBack
           -- if @a@ is the record field name applied to a single argument
           -- then it passes the check
           (_, Just (_, [])) -> Nothing  -- not a projection
-          (_, Just (h, es)) | Proj _o f <- last es, unDom ax == f
-                            -> Just $ Just $ h $ init es
+          (_, Just (h, e0:es0))
+            | (es, Proj _o f) <- initLast1 e0 es0
+            , unDom ax == f -> Just $ Just $ h es
           _                 -> Nothing
   case compare (length args) (length xs) of
     LT -> fallBack       -- Not fully applied

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -579,7 +579,8 @@ checkSystemCoverage f [n] t cs = do
       reportSDoc "tc.sys.cover" 10 $ "equalTerm " <+> prettyTCM (unArg phi) <+> prettyTCM psi
       equalTerm interval (unArg phi) psi
 
-      forM_ (init $ init $ List.tails pcs) $ \ ((phi1,cl1):pcs') -> do
+      forM_ (initWithDefault __IMPOSSIBLE__ $
+             initWithDefault __IMPOSSIBLE__ $ List.tails pcs) $ \ ((phi1,cl1):pcs') -> do
         forM_ pcs' $ \ (phi2,cl2) -> do
           phi12 <- reduce (imin `apply` [argN phi1, argN phi2])
           forallFaceMaps phi12 (\ _ _ -> __IMPOSSIBLE__) $ \ sigma -> do

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -296,7 +296,7 @@ instance Apply ProjLams where
 
 instance Apply Defn where
   apply d [] = d
-  apply d args = case d of
+  apply d args@(arg1:args1) = case d of
     Axiom{} -> d
     DataOrRecSig n -> DataOrRecSig (n - length args)
     GeneralizableVar{} -> d
@@ -329,23 +329,10 @@ instance Apply Defn where
                 , funExtLam         = modifySystem (\ _ -> __IMPOSSIBLE__) <$> extLam
                 }
               where
-                larg  = last args -- the record value
+                larg  = last1 arg1 args1 -- the record value
                 args' = [larg]
                 isVar0 = case unArg larg of Var 0 [] -> True; _ -> False
-{-
-    Function{ funClauses = cs, funCompiled = cc, funInv = inv
-            , funProjection = Just p@Projection{ projIndex = n } }
-        -- case: only applying parameters
-      | size args < n -> d { funProjection = Just $ p `apply` args }
-        -- case: apply also to record value
-      | otherwise     ->
-        d { funClauses        = apply cs args'
-          , funCompiled       = apply cc args'
-          , funInv            = apply inv args'
-          , funProjection     = Just $ p { projIndex = 0 } -- Nothing ?
-          }
-      where args' = [last args]  -- the record value
--}
+
     Datatype{ dataPars = np, dataClause = cl } ->
       d { dataPars = np - size args
         , dataClause     = apply cl args

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -72,6 +72,19 @@ lastMaybe :: [a] -> Maybe a
 lastMaybe [] = Nothing
 lastMaybe xs = Just $ last xs
 
+-- | Last element (safe).  Returns a default list on empty lists.
+--   O(n).
+lastWithDefault :: a -> [a] -> a
+lastWithDefault = last1
+
+-- | Last element of non-empty list (safe).
+--   O(n).
+--   @last1 a as = last (a : as)@
+last1 :: a -> [a] -> a
+last1 a = \case
+  [] -> a
+  b:bs -> last1 b bs
+
 -- | Last two elements (safe).
 --   O(n).
 last2 :: [a] -> Maybe (a, a)
@@ -97,14 +110,36 @@ mcons ma as = maybe as (:as) ma
 --   O(n).
 initLast :: [a] -> Maybe ([a],a)
 initLast []     = Nothing
-initLast (a:as) = Just $ loop a as where
-  loop a []      = ([], a)
-  loop a (b : bs) = mapFst (a:) $ loop b bs
+initLast (a:as) = Just $ initLast1 a as
+
+-- | 'init' and 'last' of non-empty list, safe.
+--   O(n).
+--   @initLast1 a as = (init (a:as), last (a:as)@
+initLast1 :: a -> [a] -> ([a], a)
+initLast1 a = \case
+  []   -> ([], a)
+  b:bs -> first (a:) $ initLast1 b bs
+
+-- | 'init' of non-empty list, safe.
+--   O(n).
+--   @init1 a as = init (a:as)@
+init1 :: a -> [a] -> [a]
+init1 a = \case
+  []   -> []
+  b:bs -> a : init1 b bs
 
 -- | @init@, safe.
 --   O(n).
 initMaybe :: [a] -> Maybe [a]
-initMaybe = fmap fst . initLast
+initMaybe = \case
+  []   -> Nothing
+  a:as -> Just $ init1 a as
+
+-- | @init@, safe.
+--   O(n).
+initWithDefault :: [a] -> [a] -> [a]
+initWithDefault as []     = as
+initWithDefault _  (a:as) = init1 a as
 
 ---------------------------------------------------------------------------
 -- * Lookup and indexing
@@ -365,6 +400,7 @@ groupOn f = List.groupBy ((==) `on` f) . List.sortBy (compare `on` f)
 -- | A variant of 'List.groupBy' which applies the predicate to consecutive
 -- pairs.
 -- O(n).
+-- DEPRECATED in favor of 'Agda.Utils.List1.groupBy''.
 groupBy' :: (a -> a -> Bool) -> [a] -> [[a]]
 groupBy' _ []           = []
 groupBy' p xxs@(x : xs) = grp x $ zipWith (\x y -> (p x y, y)) xxs xs

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -72,6 +72,22 @@ prepend as bs = foldr (<|) bs as
 snoc :: [a] -> a -> List1 a
 snoc as a = prepend as $ a :| []
 
+-- | More precise type for 'Agda.Utils.List.groupBy''.
+--
+-- A variant of 'List.groupBy' which applies the predicate to consecutive
+-- pairs.
+-- O(n).
+groupBy' :: forall a. (a -> a -> Bool) -> [a] -> [List1 a]
+groupBy' _ []           = []
+groupBy' p xxs@(x : xs) = grp x $ List.zipWith (\ x y -> (p x y, y)) xxs xs
+  where
+  grp :: a -> [(Bool,a)] -> [List1 a]
+  grp x ys
+    | let (xs, rest) = List.span fst ys
+    = (x :| List.map snd xs) : case rest of
+      []                 -> []
+      ((_false, z) : zs) -> grp z zs
+
 -- | Concatenate one or more non-empty lists.
 
 concat :: [List1 a] -> [a]

--- a/src/full/Agda/Utils/RangeMap.hs
+++ b/src/full/Agda/Utils/RangeMap.hs
@@ -29,6 +29,7 @@ import Data.Semigroup
 import Data.Strict.Tuple (Pair(..))
 
 import Agda.Interaction.Highlighting.Range
+import Agda.Utils.List
 import Agda.Utils.Null
 
 ------------------------------------------------------------------------
@@ -119,12 +120,12 @@ newtype RangeMap a = RangeMap
 -- The ranges must not be empty, and they must not overlap.
 
 rangeMapInvariant :: RangeMap a -> Bool
-rangeMapInvariant f =
-  all rangeInvariant rs &&
-  all (not . null) rs &&
-  case rs of
-    [] -> True
-    rs -> and (zipWith (<=) (map to $ init rs) (map from $ tail rs))
+rangeMapInvariant f = and
+  [ all rangeInvariant rs
+  , all (not . null) rs
+  , caseList rs True $ \ r rs' ->
+      and $ zipWith (<=) (map to $ init1 r rs') (map from rs')
+  ]
   where
   rs = map fst $ toList f
 

--- a/src/full/Agda/Utils/String.hs
+++ b/src/full/Agda/Utils/String.hs
@@ -66,8 +66,9 @@ delimiter s = concat [ replicate 4 '\x2014'
 
 addFinalNewLine :: String -> String
 addFinalNewLine "" = "\n"
-addFinalNewLine s | last s == '\n' = s
-                  | otherwise      = s ++ "\n"
+addFinalNewLine s@(c:cs)
+  | last1 c cs == '\n' = s
+  | otherwise          = s ++ "\n"
 
 -- | Indents every line the given number of steps.
 


### PR DESCRIPTION
Safe `xxx1` versions for `init`, `last`, `initLast` in `Agda.Utils.List`.