### PR TITLE
[ fix ] Use correct type for projection clauses

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -667,18 +667,16 @@ checkRecordProjections m r hasNamedCon con tel ftel fs = do
                                     , conPFallThrough = False
                                     , conPType   = Just $ argFromDom $ fmap snd rt
                                     , conPLazy   = True }
-            conp   = defaultArg $ ConP con cpi $
-                     [ Arg ai' $ unnamed $ varP ("x" :: String)
-                     | Dom{domInfo = ai'} <- telToList ftel
-                     ]
+            conp   = defaultNamedArg $ ConP con cpi $ teleNamedArgs ftel
             body   = Just $ bodyMod $ var (size ftel2)
             cltel  = ptel `abstract` ftel
+            cltype = Just $ Arg ai $ raise (1 + size ftel2) t
             clause = Clause { clauseLHSRange  = getRange info
                             , clauseFullRange = getRange info
                             , clauseTel       = killRange cltel
-                            , namedClausePats = [Named Nothing <$> numberPatVars __IMPOSSIBLE__ (idP $ size ftel) conp]
+                            , namedClausePats = [conp]
                             , clauseBody      = body
-                            , clauseType      = Just $ Arg ai t'
+                            , clauseType      = cltype
                             , clauseCatchall  = False
                             , clauseExact       = Just True
                             , clauseRecursive   = Just False


### PR DESCRIPTION
The type of projection clauses is not currently used by Agda itself, but it is used by some of the backends. In particular, this one caused problems when updating Agda2Dedukti to Agda 2.6.2.