### PR TITLE
Fixed #5434.

### DIFF
--- a/doc/user-manual/language/runtime-irrelevance.lagda.rst
+++ b/doc/user-manual/language/runtime-irrelevance.lagda.rst
@@ -167,12 +167,12 @@ The type checker enters compile-time mode when
   - Compile-time mode is not entered for the domains of non-erased Π
     types.
   - If the K rule is off then compile-time mode is not entered for
-    non-erased constructors or record fields.
+    non-erased constructors (of fibrant type) or record fields.
 
-Note that the type checker does not enter compile-time mode based on the type a term is checked against. In particular
+Note that the type checker does not enter compile-time mode based on
+the type a term is checked against (except that a distinction is
+sometimes made between fibrant and non-fibrant types). In particular,
 checking a term against ``Set`` does not trigger compile-time mode.
-
-
 
 Subtyping of runtime-irrelevant function spaces
 ===============================================

--- a/test/Fail/Issue4638-2.err
+++ b/test/Fail/Issue4638-2.err
@@ -1,4 +1,4 @@
 Issue4638-2.agda:4,3-5
-A is not usable at the required modality
+A → E A is not usable at the required modality
 when checking that the type A → E A of the constructor c₁ fits in
 the sort Set of the datatype.

--- a/test/Fail/Issue4748c.err
+++ b/test/Fail/Issue4748c.err
@@ -1,3 +1,3 @@
 Issue4748c.agda:14,8-9
-B x is not usable at the required modality
+(@0 x : A) (y : B x) → R is not usable at the required modality
 when checking the definition of R

--- a/test/Fail/Issue4784b.err
+++ b/test/Fail/Issue4784b.err
@@ -1,4 +1,4 @@
 Issue4784b.agda:15,3-6
-B x is not usable at the required modality
+(@0 x : A) → B x → D is not usable at the required modality
 when checking that the type (@0 x : A) → B x → D of the constructor
 con fits in the sort Set of the datatype.

--- a/test/Fail/Issue5410-3.err
+++ b/test/Fail/Issue5410-3.err
@@ -1,4 +1,4 @@
 Issue5410-3.agda:7,3-4
-A is not usable at the required modality
+{@0 A : Set} → A → D is not usable at the required modality
 when checking that the type {@0 A : Set} → A → D of the constructor
 c fits in the sort Set₁ of the datatype.

--- a/test/Fail/Issue5410-4.err
+++ b/test/Fail/Issue5410-4.err
@@ -1,3 +1,3 @@
 Issue5410-4.agda:6,8-9
-{@0 A : Set} → A is not usable at the required modality
+(f : {@0 A : Set} → A) → D is not usable at the required modality
 when checking the definition of D

--- a/test/Fail/Issue5434-1.agda
+++ b/test/Fail/Issue5434-1.agda
@@ -1,0 +1,4 @@
+{-# OPTIONS --without-K #-}
+
+data D : Set → Set₁ where
+  c : (@0 A : Set) → D A

--- a/test/Fail/Issue5434-1.err
+++ b/test/Fail/Issue5434-1.err
@@ -1,0 +1,4 @@
+Issue5434-1.agda:4,3-4
+(@0 A : Set) → D A is not usable at the required modality
+when checking that the type (@0 A : Set) → D A of the constructor c
+fits in the sort Set₁ of the datatype.

--- a/test/Fail/Issue5434-2.agda
+++ b/test/Fail/Issue5434-2.agda
@@ -1,0 +1,6 @@
+{-# OPTIONS --cubical #-}
+
+open import Agda.Builtin.Cubical.Path
+
+data D : Set where
+  c : (@0 x y : D) → x ≡ y

--- a/test/Fail/Issue5434-2.err
+++ b/test/Fail/Issue5434-2.err
@@ -1,0 +1,4 @@
+Issue5434-2.agda:6,3-4
+(@0 x y : D) → x ≡ y is not usable at the required modality
+when checking that the type (@0 x y : D) → x ≡ y of the constructor
+c fits in the sort Set of the datatype.

--- a/test/Fail/Issue5434-3.agda
+++ b/test/Fail/Issue5434-3.agda
@@ -1,0 +1,9 @@
+{-# OPTIONS --without-K #-}
+
+mutual
+
+  data D : Set → Set₁ where
+    c : (@0 A : Set) → _ → D _
+
+  _ : (@0 A : Set) → A → D A
+  _ = c

--- a/test/Fail/Issue5434-3.err
+++ b/test/Fail/Issue5434-3.err
@@ -1,0 +1,4 @@
+Issue5434-3.agda:6,5-6
+(@0 A : Set) → A → D A is not usable at the required modality
+when checking that the type (@0 A : Set) → A → D A of the
+constructor c fits in the sort Set₁ of the datatype.

--- a/test/Fail/Issue5434-4.agda
+++ b/test/Fail/Issue5434-4.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --without-K #-}
+
+mutual
+
+  record R : Set₁ where
+    constructor c
+    field
+      @0 A : Set
+      x    : _
+
+  _ : (@0 A : Set) → A → R
+  _ = c

--- a/test/Fail/Issue5434-4.err
+++ b/test/Fail/Issue5434-4.err
@@ -1,0 +1,3 @@
+Issue5434-4.agda:5,10-11
+(@0 A : Set) (x : A) → R is not usable at the required modality
+when checking the definition of R

--- a/test/Succeed/Issue5434.agda
+++ b/test/Succeed/Issue5434.agda
@@ -1,0 +1,9 @@
+{-# OPTIONS --two-level --without-K #-}
+
+open import Agda.Primitive
+
+data D₁ : SSet → SSet (lsuc lzero) where
+  c : (@0 A : SSet) → A → D₁ A
+
+data D₂ : Set → SSet (lsuc lzero) where
+  c : (@0 A : Set) → A → D₂ A


### PR DESCRIPTION
The procedure `fitsIn` now calls `usableAtModality` once, instead of possibly several times inside a loop. I think this makes the code easier to follow. However, it makes some error messages less precise. Perhaps `usableMod` could be changed so that it throws precise error messages instead of returning a boolean, but I don't want to do that right now.