### PR TITLE
Remove -j1 from cabal v1-configure flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,8 @@ STACK_INSTALL_BIN_OPTS = --no-library-profiling \
                          $(STACK_INSTALL_OPTS)
 
 CABAL_CONFIGURE_OPTS = $(SLOW_CABAL_INSTALL_OPTS) \
-                       $(CABAL_INSTALL_BIN_OPTS)
+                       --disable-library-profiling \
+                       $(CABAL_INSTALL_OPTS)
 
 ##############################################################################
 ## Installation


### PR DESCRIPTION
The -j1 was inadvertently added in #4981, and broke `make haddock`. Fixes #5452.

