### PR TITLE
[ fix #5470 ] skip getConstInfo if freeVarsToApply = 0

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -991,6 +991,12 @@ freeVarsToApply :: (Functor m, HasConstInfo m, HasOptions m,
                 => QName -> m Args
 freeVarsToApply q = do
   vs <- moduleParamsToApply $ qnameModule q
+  -- Andreas, 2021-07-14, issue #5470
+  -- getConstInfo will fail if q is not in scope,
+  -- but in this case there are no free vars to apply, since
+  -- we cannot be in a child module of its defining module.
+  -- So if we short cut the nil-case here, we avoid the internal error of #5470.
+  if null vs then return [] else do
   t <- defType <$> getConstInfo q
   let TelV tel _ = telView'UpTo (size vs) t
   unless (size tel == size vs) __IMPOSSIBLE__

--- a/test/Succeed/Issue5470.agda
+++ b/test/Succeed/Issue5470.agda
@@ -1,0 +1,34 @@
+-- Andreas, 2021-07-14, issue #5470, reported by HarrisonGrodin
+--
+-- Importing a rewrite rule that was declared private
+-- at the point of definition caused an internal error.
+
+{-# OPTIONS --rewriting #-}
+
+-- {-# OPTIONS -v impossible:10 #-}
+-- {-# OPTIONS -v rewriting:100 #-}
+
+module Issue5470 where
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+open import Issue5470.Import
+
+postulate
+  _≤_ : (n m : Nat) → Set
+  ≤-refl : ∀{n} → n ≤ n
+
+infix 4 _IsRelatedTo_
+
+data _IsRelatedTo_ (x : Nat) : (y : Nat) → Set where
+  equals : x IsRelatedTo x
+
+begin : ∀ {x y} → x IsRelatedTo y → x ≤ y
+begin equals = ≤-refl
+
+example : ∀ n → n ≤ bar n
+example n = begin equals
+
+-- WAS: internal error
+-- Unbound name: Issue5470Import.lemma[0,10]@ModuleNameHash 8608063155492000951

--- a/test/Succeed/Issue5470/Import.agda
+++ b/test/Succeed/Issue5470/Import.agda
@@ -1,0 +1,20 @@
+{-# OPTIONS --rewriting #-}
+
+module Issue5470.Import where
+
+open import Agda.Builtin.Nat
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+private
+  postulate
+    foo : Nat → Nat
+
+bar : Nat → Nat
+bar n = foo n
+
+private
+  postulate
+    lemma : ∀ n → foo n ≡ n
+  {-# REWRITE lemma #-}


### PR DESCRIPTION
[ fix #5470 ] skip getConstInfo if freeVarsToApply = 0

This optimization also fixes the internal error triggered in [#5470] when trying to instantiate a rewrite rule that is not in scope (but anyway available via its `QName`).