### PR TITLE
import Data.List selective or qualified

### DIFF
--- a/.ghci-9.0
+++ b/.ghci-9.0
@@ -3,4 +3,5 @@
 -- in this directory.
 
 :script .ghci-8.10
+:set -Wcompat-unqualified-imports
 :set -Winvalid-haddock

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -1093,4 +1093,5 @@ test-suite agda-tests
 
   -- NOTE: If adding or removing flags, also change `.ghci-9.0`
   if impl(ghc >= 9.0)
-    ghc-options: -Werror=invalid-haddock
+    ghc-options: -Werror=compat-unqualified-imports
+                 -Werror=invalid-haddock

--- a/src/agda-bisect/Bisect.hs
+++ b/src/agda-bisect/Bisect.hs
@@ -1,7 +1,7 @@
 import Control.Exception
 import Control.Monad
 import Data.Char
-import Data.List
+import Data.List (intercalate, isInfixOf, isPrefixOf)
 import Data.Maybe
 import Data.Monoid
 import Data.Time.Clock

--- a/src/agda-mode/Main.hs
+++ b/src/agda-mode/Main.hs
@@ -7,7 +7,7 @@ module Main (main) where
 import Control.Exception
 import Control.Monad
 import Data.Char
-import Data.List
+import Data.List (intercalate, isInfixOf)
 import Data.Maybe
 import Data.Version
 import Numeric

--- a/src/full/Agda/Syntax/Abstract/PatternSynonyms.hs
+++ b/src/full/Agda/Syntax/Abstract/PatternSynonyms.hs
@@ -14,7 +14,6 @@ import Control.Monad.Writer hiding (forM)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Traversable (forM)
-import Data.List
 import Data.Void
 
 import Agda.Syntax.Common

--- a/src/full/Agda/Syntax/Parser/LexActions.hs
+++ b/src/full/Agda/Syntax/Parser/LexActions.hs
@@ -23,7 +23,7 @@ import Control.Monad.State (modify)
 
 import Data.Bifunctor
 import Data.Char
-import Data.List
+import Data.Foldable (foldl')
 import Data.Maybe
 
 import Agda.Syntax.Common (pattern Ranged)

--- a/src/full/Agda/TypeChecking/Names.hs
+++ b/src/full/Agda/TypeChecking/Names.hs
@@ -26,7 +26,7 @@ import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
 
-import Data.List
+import Data.List (isSuffixOf)
 
 import Agda.Syntax.Common hiding (Nat)
 import Agda.Syntax.Internal
@@ -79,7 +79,7 @@ cxtSubst :: MonadFail m => Names -> NamesT m (Substitution' a)
 cxtSubst ctx = do
   ctx' <- currentCxt
   if (ctx `isSuffixOf` ctx')
-     then return $ raiseS (genericLength ctx' - genericLength ctx)
+     then return $ raiseS (length ctx' - length ctx)
      else fail $ "thing out of context (" ++ show ctx ++ " is not a sub context of " ++ show ctx' ++ ")"
 
 inCxt :: (MonadFail m, Subst a) => Names -> a -> NamesT m a

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -13,7 +13,7 @@ import Data.Bits (finiteBitSize)
 import qualified Data.Text as T
 import Data.Text.Encoding
 import Data.Monoid
-import Data.List
+import Data.List (isPrefixOf)
 import System.Directory
 import System.IO.Temp
 import System.FilePath

--- a/test/Internal/Compiler/MAlonzo/Encode.hs
+++ b/test/Internal/Compiler/MAlonzo/Encode.hs
@@ -6,7 +6,7 @@ import Agda.Compiler.MAlonzo.Encode
 import Agda.Compiler.MAlonzo.Misc
 
 import Data.Char
-import Data.List
+import Data.List ( intercalate, isPrefixOf )
 
 import Internal.Helpers
 

--- a/test/Internal/Interaction/Highlighting/Range.hs
+++ b/test/Internal/Interaction/Highlighting/Range.hs
@@ -6,7 +6,7 @@ import Agda.Interaction.Highlighting.Range
 import qualified Agda.Syntax.Position as P
 import Agda.Utils.List
 
-import Data.List
+import Data.List ( (\\), sort)
 
 import Internal.Helpers
 import Internal.Syntax.Position ()

--- a/test/Internal/Interaction/Options.hs
+++ b/test/Internal/Interaction/Options.hs
@@ -9,7 +9,7 @@ import Agda.Interaction.Options.Lenses
 import Agda.Utils.Monad
 import Agda.Syntax.Parser
 
-import Data.List
+import Data.List (intercalate)
 import qualified Data.Set as Set
 
 import System.FilePath ((</>), takeExtension)

--- a/test/Internal/Syntax/Position.hs
+++ b/test/Internal/Syntax/Position.hs
@@ -11,7 +11,7 @@ import Agda.Utils.Null ( null )
 import Control.Monad
 
 import Data.Int
-import Data.List hiding ( null )
+import Data.List (sort)
 import Data.Set (Set)
 import qualified Data.Set as Set
 

--- a/test/Internal/Utils/Cluster.hs
+++ b/test/Internal/Utils/Cluster.hs
@@ -5,7 +5,7 @@ module Internal.Utils.Cluster ( tests ) where
 import Agda.Utils.Cluster
 
 import Data.Char
-import Data.List
+import Data.List (delete, intersect, sort)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Foldable as Fold

--- a/test/Internal/Utils/IntSet.hs
+++ b/test/Internal/Utils/IntSet.hs
@@ -12,7 +12,6 @@ module Internal.Utils.IntSet ( tests ) where
 import Agda.Utils.IntSet.Infinite as Inf
 import Test.QuickCheck
 import Data.Semigroup hiding (All)
-import Data.List
 import qualified Data.Set as Set
 import Data.Foldable
 

--- a/test/Internal/Utils/List.hs
+++ b/test/Internal/Utils/List.hs
@@ -12,7 +12,7 @@ import Agda.Utils.List
 
 import Data.Either (partitionEithers)
 import Data.Function
-import Data.List as List
+import Data.List ( (\\), elemIndex, intercalate, isPrefixOf, isSuffixOf, nub, nubBy, sort, sortBy )
 
 import Internal.Helpers
 
@@ -141,7 +141,7 @@ prop_nubOn :: (Integer -> Integer) -> [Integer] -> Bool
 prop_nubOn f xs = nubOn f xs == nubBy ((==) `on` f) xs
 
 prop_nubAndDuplicatesOn :: (Integer -> Integer) -> [Integer] -> Bool
-prop_nubAndDuplicatesOn f xs = nubAndDuplicatesOn f xs == (ys, xs List.\\ ys)
+prop_nubAndDuplicatesOn f xs = nubAndDuplicatesOn f xs == (ys, xs \\ ys)
   where ys = nubBy ((==) `on` f) xs
 
 prop_uniqOn1 :: (Integer -> Integer) -> [Integer] -> Bool

--- a/test/Internal/Utils/PartialOrd.hs
+++ b/test/Internal/Utils/PartialOrd.hs
@@ -7,7 +7,7 @@ module Internal.Utils.PartialOrd
 
 import Agda.Utils.PartialOrd
 
-import Data.List
+import Data.List ( (\\) )
 import Data.Set (Set)
 import qualified Data.Set as Set
 

--- a/test/Internal/Utils/Permutation.hs
+++ b/test/Internal/Utils/Permutation.hs
@@ -12,7 +12,7 @@ import Agda.Utils.List ( downFrom )
 import Agda.Utils.Permutation
 
 import Data.Functor
-import Data.List as List
+import Data.List ( (\\), nub, sort )
 import Data.Maybe
 
 import Internal.Helpers

--- a/test/Internal/Utils/Warshall.hs
+++ b/test/Internal/Utils/Warshall.hs
@@ -5,7 +5,7 @@ module Internal.Utils.Warshall ( tests ) where
 import Agda.Syntax.Common ( Nat )
 import Agda.Utils.Warshall
 
-import Data.List
+import Data.List          ( sort )
 import qualified Data.Map as Map
 import Data.Maybe
 
@@ -134,4 +134,3 @@ return [] -- KEEP!
 
 tests :: TestTree
 tests = testProperties "Internal.Utils.Warshall" $allProperties
-

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -11,7 +11,7 @@ import Data.Array
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import Data.Char
-import Data.List
+import Data.List (intercalate, sortBy)
 import Data.Maybe
 import Data.Map (Map)
 import qualified Data.Map as Map


### PR DESCRIPTION
Import `Data.List` selective or qualified, enforced by new warning `compat-unqualified-imports` of GHC 9.0.

The plan seems to be that in GHC 9.4 you may run into trouble when importing `Data.List` unqualified, see alse
https://gitlab.haskell.org/ghc/ghc/-/issues/20025 .