### PR TITLE
[ fix #5465 ] keep Parser.y in ASCII

### DIFF
--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -28,6 +28,10 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout agda sources
 
+    - name: Check encoding of Parser.y
+      run: |
+        make check-encoding
+
     - name: Create directory for binary
       run: |
         mkdir -p $HOME/.local/bin

--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,7 @@ fast-forward-cubical :
 
 .PHONY : test ## Run all test suites.
 test : check-whitespace \
+       check-encoding \
        common \
        succeed \
        fail \
@@ -377,6 +378,16 @@ test-using-std-lib : std-lib-test \
 
 .PHONY : quicktest ## Run successful and failing tests.
 quicktest : common succeed fail
+
+.PHONY : check-encoding ## Make sure that Parser.y is ASCII. [Issue #5465]
+check-encoding :
+	@$(call decorate, "Check that Parser.y is ASCII", \
+          iconv -f ASCII src/full/Agda/Syntax/Parser/Parser.y > /dev/null)
+# Hint: if the encoding check fails, use
+#
+#     pcregrep --color='auto' -n "[\x80-\xFF]" src/full/Agda/Syntax/Parser/Parser.y
+#
+# to find non-ASCII characters.
 
 .PHONY : bugs ##
 bugs :

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1002,11 +1002,19 @@ data Erased
 defaultErased :: Erased
 defaultErased = NotErased QωInferred
 
--- 'Erased' can be converted into 'Quantity'.
+-- | 'Erased' can be embedded into 'Quantity'.
 
 asQuantity :: Erased -> Quantity
 asQuantity (Erased    o) = Quantity0 o
 asQuantity (NotErased o) = Quantityω o
+
+-- | 'Quantity' can be projected onto 'Erased'.
+
+erasedFromQuantity :: Quantity -> Maybe Erased
+erasedFromQuantity = \case
+  Quantity1{} -> Nothing
+  Quantity0 o -> Just $ Erased    o
+  Quantityω o -> Just $ NotErased o
 
 -- | Equality ignoring origin.
 


### PR DESCRIPTION
[ fix #5465 ] keep unicode out of `Parser.y`

This is a workaround for https://github.com/simonmar/happy/issues/157.

By sticking to ASCII, we avoid locale issues.

- remove unicode from Parser.y
- new make goal

      make check-encoding

  that checks that Parser.y is ASCII (no proper unicode characters).