### PR TITLE
[ fix #5480 ] Makefile: use sed instead of gawk (for macOS sake)

### DIFF
--- a/mk/ghc.mk
+++ b/mk/ghc.mk
@@ -26,7 +26,9 @@ ifneq ($(GHC),)
 
   # major.minor.subminor, e.g. 8.10.2
   ifdef HAS_STACK
-    GHC_VER := $(shell stack query | awk 'match ($$0, /actual: ghc-([0-9]+\.[0-9]+\.[0-9]+)/, ver) { print (ver[1]); }')
+    GHC_VER := $(shell stack query | sed -n 's/.*actual: ghc-\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')
+    # The following variant needs GNU awk (not POSIX compatible) [issue #5480]:
+    # GHC_VER := $(shell stack query | awk 'match ($$0, /actual: ghc-([0-9]+\.[0-9]+\.[0-9]+)/, ver) { print (ver[1]); }')
   else
     GHC_VER := $(shell $(GHC) --numeric-version | cut -d. -f1-3)
   endif


### PR DESCRIPTION
[ fix #5480 ] Makefile: use sed instead of gawk (for macOS sake)

Staying POSIX compliant, we cannot use `awk`'s 3-ary `match` (GNU only).