### PR TITLE
[ fix #5489 fix #5490 ] Emacs: C-c C-x C-a (abort)

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -606,10 +606,10 @@ May be more efficient than restarting Agda."
                       "Cmd_abort"))
 
 (defun agda2-abort-done ()
-  "Removes annotations, resets certain variables.
+  "Resets certain variables.
 Intended to be used by the backend if an abort command was
 successful."
-  (agda2-remove-annotations)
+  (agda2-info-action "*Aborted*" "Aborted." t)
   (setq agda2-highlight-in-progress nil
         agda2-last-responses        nil))
 


### PR DESCRIPTION
[ fix #5489 fix #5490 ] Emacs: `C-c C-x C-a` (abort)

Change the behavior of 'abort' in the emacs mode:

  - Do not remove highlighting.
    (Can still be useful after abort, e.g. jump to definition).

  - Tell the user that the command was aborted.