### PR TITLE
[ re #5500 ] `make install-bin` and similar targets add a version suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ ifeq ($(PARALLEL_TESTS),)
 PARALLEL_TESTS := $(shell getconf _NPROCESSORS_ONLN)
 endif
 
+AGDA_BIN_SUFFIX = -$(VERSION)
 AGDA_TESTS_OPTIONS ?=-i -j$(PARALLEL_TESTS)
 
 CABAL_INSTALL_HELPER = $(CABAL) $(CABAL_INSTALL_CMD) --disable-documentation
@@ -160,12 +161,12 @@ ifdef HAS_STACK
 	time $(STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
 	mkdir -p $(BUILD_DIR)/build/
 	cp -r $(shell $(STACK) path --dist-dir)/build $(BUILD_DIR)
-	$(MAKE) copy-bins-with-suffix-$(VERSION)
+	$(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)
 else
 # `cabal new-install --enable-tests` emits the error message (bug?):
 # cabal: --enable-tests was specified, but tests can't be enabled in a remote package
 	@echo "===================== Installing using Cabal with test suites ============"
-	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=-$(VERSION)
+	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=$(AGDA_BIN_SUFFIX)
 endif
 
 .PHONY: v1-install ## Developer install goal without -foptimize-aggressively nor dependencies.
@@ -176,10 +177,10 @@ ifdef HAS_STACK
 	time $(STACK_INSTALL_HELPER) $(STACK_INSTALL_BIN_OPTS) --test --no-run-tests
 	mkdir -p $(BUILD_DIR)/build/
 	cp -r $(shell $(STACK) path --dist-dir)/build $(BUILD_DIR)
-	$(MAKE) copy-bins-with-suffix-$(VERSION)
+	$(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)
 else
 	@echo "===================== Installing using Cabal with test suites ============"
-	time $(CABAL_INSTALL_HELPER) $(CABAL_INSTALL_BIN_OPTS) --builddir=$(BUILD_DIR) --enable-tests --program-suffix=-$(VERSION)
+	time $(CABAL_INSTALL_HELPER) $(CABAL_INSTALL_BIN_OPTS) --builddir=$(BUILD_DIR) --enable-tests --program-suffix=$(AGDA_BIN_SUFFIX)
 endif
 
 .PHONY: fast-install-bin ## Install Agda compiled with -O0 with tests
@@ -192,12 +193,12 @@ ifdef HAS_STACK
 	time $(FAST_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
 	mkdir -p $(FAST_BUILD_DIR)/build/
 	cp -r $(shell $(STACK) path --work-dir=$(FAST_STACK_BUILD_DIR) --dist-dir)/build $(FAST_BUILD_DIR)
-	STACK_BUILD_DIR=$(FAST_STACK_BUILD_DIR) $(MAKE) copy-bins-with-suffix-$(VERSION)-quicker
+	STACK_BUILD_DIR=$(FAST_STACK_BUILD_DIR) $(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)-quicker
 else
 # `cabal new-install --enable-tests` emits the error message (bug?):
 # cabal: --enable-tests was specified, but tests can't be enabled in a remote package
 	@echo "============= Installing using Cabal with -O0 and test suites ============"
-	time $(FAST_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=-$(VERSION)-fast
+	time $(FAST_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=$(AGDA_BIN_SUFFIX)-fast
 endif
 
 .PHONY: quicker-install-bin ## Install Agda compiled with -O0 without tests
@@ -210,10 +211,10 @@ quicker-install-bin-no-deps:
 ifdef HAS_STACK
 	@echo "===================== Installing using Stack with -O0 ===================="
 	time $(QUICK_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
-	STACK_BUILD_DIR=$(QUICK_STACK_BUILD_DIR) $(MAKE) copy-bins-with-suffix-$(VERSION)-quicker
+	STACK_BUILD_DIR=$(QUICK_STACK_BUILD_DIR) $(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)-quicker
 else
 	@echo "===================== Installing using Cabal with -O0 ===================="
-	time $(QUICK_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=-$(VERSION)-quicker
+	time $(QUICK_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=$(AGDA_BIN_SUFFIX)-quicker
 endif
 
 .PHONY: type-check ## Type check the Agda source only (-fno-code).
@@ -243,20 +244,20 @@ type-check-no-deps :
 # $(BUILD_DIR)/build/, only for installing it into .cabal/bin
 install-prof-bin : install-deps ensure-hash-is-correct
 	$(CABAL_INSTALL) -j1 --enable-library-profiling --enable-profiling \
-          --program-suffix=-$(VERSION)-prof $(CABAL_INSTALL_OPTS)
+          --program-suffix=$(AGDA_BIN_SUFFIX)-prof $(CABAL_INSTALL_OPTS)
 
 .PHONY : install-debug ## Install Agda with debug enabled
 # A separate build directory is used. The suffix "-debug" is used for the binaries.
 
 install-debug : install-deps ensure-hash-is-correct
 	$(CABAL_INSTALL) --disable-library-profiling \
-        -fdebug --program-suffix=-$(VERSION)-debug --builddir=$(DEBUG_BUILD_DIR) \
+        -fdebug --program-suffix=$(AGDA_BIN_SUFFIX)-debug --builddir=$(DEBUG_BUILD_DIR) \
         $(CABAL_INSTALL_BIN_OPTS)
 
 .PHONY : debug-install-quick ## Install Agda -O0 with debug enabled
 debug-install-quick : install-deps
 	$(QUICK_CABAL_INSTALL) --disable-library-profiling \
-        -fdebug --program-suffix=-$(VERSION)-debug-quick --builddir=$(QUICK_DEBUG_BUILD_DIR) \
+        -fdebug --program-suffix=$(AGDA_BIN_SUFFIX)-debug-quick --builddir=$(QUICK_DEBUG_BUILD_DIR) \
         $(CABAL_INSTALL_BIN_OPTS) --ghc-options=-O0
 
 ##############################################################################
@@ -656,6 +657,7 @@ help: ## Display this information.
 
 debug : ## Print debug information.
 	@echo "AGDA_BIN              = $(AGDA_BIN)"
+	@echo "AGDA_BIN_SUFFIX       = $(AGDA_BIN_SUFFIX)"
 	@echo "AGDA_TESTS_BIN        = $(AGDA_TESTS_BIN)"
 	@echo "AGDA_TESTS_OPTIONS    = $(AGDA_TESTS_OPTIONS)"
 	@echo "BUILD_DIR             = $(BUILD_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ ensure-hash-is-correct:
 .PHONY: copy-bins-with-suffix-% ## Copy binaries to local bin directory with suffix
 copy-bins-with-suffix-%:
 ifdef HAS_STACK
+	mkdir -p $(shell $(STACK) path --local-bin)
 	cp $(shell $(STACK) --work-dir=$(STACK_BUILD_DIR) path --dist-dir)/build/agda/agda $(shell $(STACK) path --local-bin)/agda-$*
 	cp $(shell $(STACK) --work-dir=$(STACK_BUILD_DIR) path --dist-dir)/build/agda-mode/agda-mode $(shell $(STACK) path --local-bin)/agda-mode-$*
 endif
@@ -193,7 +194,7 @@ ifdef HAS_STACK
 	time $(FAST_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
 	mkdir -p $(FAST_BUILD_DIR)/build/
 	cp -r $(shell $(STACK) path --work-dir=$(FAST_STACK_BUILD_DIR) --dist-dir)/build $(FAST_BUILD_DIR)
-	STACK_BUILD_DIR=$(FAST_STACK_BUILD_DIR) $(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)-quicker
+	$(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)-quicker STACK_BUILD_DIR=$(FAST_STACK_BUILD_DIR) 
 else
 # `cabal new-install --enable-tests` emits the error message (bug?):
 # cabal: --enable-tests was specified, but tests can't be enabled in a remote package
@@ -211,7 +212,7 @@ quicker-install-bin-no-deps:
 ifdef HAS_STACK
 	@echo "===================== Installing using Stack with -O0 ===================="
 	time $(QUICK_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
-	STACK_BUILD_DIR=$(QUICK_STACK_BUILD_DIR) $(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)-quicker
+	$(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)-quicker STACK_BUILD_DIR=$(QUICK_STACK_BUILD_DIR) 
 else
 	@echo "===================== Installing using Cabal with -O0 ===================="
 	time $(QUICK_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=$(AGDA_BIN_SUFFIX)-quicker

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,10 @@ endif
 QUICK_BUILD_DIR       = $(BUILD_DIR)-quick
 QUICK_STACK_BUILD_DIR = .stack-work-quick
 
-QUICK_CABAL_INSTALL = $(CABAL_INSTALL_HELPER) --builddir=$(QUICK_BUILD_DIR)
-QUICK_STACK_INSTALL = $(STACK_INSTALL_HELPER) --work-dir=$(QUICK_STACK_BUILD_DIR)
+QUICK_CABAL_INSTALL = $(CABAL_INSTALL_HELPER) --builddir=$(QUICK_BUILD_DIR) \
+											--ghc-options=-O0 --program-suffix=-quicker
+QUICK_STACK_INSTALL = $(STACK_INSTALL_HELPER) --work-dir=$(QUICK_STACK_BUILD_DIR) \
+											--fast
 
 # fast install: -O0, but tests
 
@@ -126,12 +128,12 @@ CABAL_CONFIGURE_OPTS = $(SLOW_CABAL_INSTALL_OPTS) \
                        $(CABAL_INSTALL_OPTS)
 
 ##############################################################################
-## Installation
+## Installation (via stack if stack.yaml is present)
 
 .PHONY: default
 default: install-bin
 
-.PHONY: install ## Install Agda, test suites, and Emacs mode via cabal (or stack if stack.yaml exists).
+.PHONY: install ## Install Agda, test suites, and Emacs mode
 install: install-bin compile-emacs-mode setup-emacs-mode
 
 .PHONY: ensure-hash-is-correct
@@ -139,7 +141,7 @@ ensure-hash-is-correct:
 	touch src/full/Agda/VersionCommit.hs
 
 .PHONY: install-deps ## Install Agda dependencies.
-install-deps:
+install-deps: 
 ifdef HAS_STACK
 	@echo "===================== Installing dependencies using Stack ================"
 	time $(STACK_INSTALL) $(STACK_INSTALL_DEP_OPTS)
@@ -148,7 +150,7 @@ else
 	time $(CABAL_INSTALL) $(CABAL_INSTALL_DEP_OPTS)
 endif
 
-.PHONY: install-bin ## Install Agda and test suites via cabal (or stack if stack.yaml exists).
+.PHONY: install-bin ## Install Agda and test suites
 install-bin: install-deps ensure-hash-is-correct
 ifdef HAS_STACK
 	@echo "===================== Installing using Stack with test suites ============"
@@ -162,9 +164,8 @@ else
 	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS)
 endif
 
-# Developer install goal without -foptimize-aggressively nor dependencies
-# Alternative to 'install-bin'
-.PHONY: v1-install
+.PHONY: v1-install ## Developer install goal without -foptimize-aggressively nor dependencies.
+	# Alternative to 'install-bin'
 v1-install:  ensure-hash-is-correct
 ifdef HAS_STACK
 	@echo "===================== Installing using Stack with test suites ============"
@@ -176,10 +177,10 @@ else
 	time $(CABAL_INSTALL_HELPER) $(CABAL_INSTALL_BIN_OPTS) --builddir=$(BUILD_DIR) --enable-tests
 endif
 
-.PHONY: fast-install-bin ## Install Agda -O0 and test suites via cabal (or stack if stack.yaml exists).
+.PHONY: fast-install-bin ## Install Agda compiled with -O0 with tests
 fast-install-bin: install-deps fast-install-bin-no-deps
 
-.PHONY: fast-install-bin-no-deps
+.PHONY: fast-install-bin-no-deps ## 
  fast-install-bin-no-deps:
 ifdef HAS_STACK
 	@echo "============= Installing using Stack with -O0 and test suites ============"
@@ -193,23 +194,22 @@ else
 	time $(FAST_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS)
 endif
 
+.PHONY: quicker-install-bin ## Install Agda compiled with -O0 without tests
 # Disabling optimizations leads to *much* quicker build times.
 # The performance loss is acceptable for running small tests.
-
-.PHONY: quicker-install-bin ## Install Agda (compiled with -O0) via cabal (or stack if stack.yaml exists).
 quicker-install-bin: install-deps quicker-install-bin-no-deps
 
-.PHONY: quicker-install-bin-no-deps
+.PHONY: quicker-install-bin-no-deps ##
 quicker-install-bin-no-deps:
 ifdef HAS_STACK
 	@echo "===================== Installing using Stack with -O0 ===================="
-	time $(QUICK_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS) --fast
+	time $(QUICK_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
 else
 	@echo "===================== Installing using Cabal with -O0 ===================="
-	time $(QUICK_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --ghc-options=-O0 --program-suffix=-quicker
+	time $(QUICK_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) 
 endif
 
-# Type check the Agda source only (-fno-code).
+.PHONY: type-check ## Type check the Agda source only (-fno-code).
 # Takes max 40s; can be quicker than make quicker-install-bin (max 5min).
 #
 # Might "fail" with errors like
@@ -218,11 +218,9 @@ endif
 #   ...
 #
 # Thus, ignore exit code.
-
-.PHONY: type-check
 type-check: install-deps type-check-no-deps
 
-.PHONY: type-check-no-deps
+.PHONY: type-check-no-deps ##
 type-check-no-deps :
 	@echo "================= Type checking using Cabal with -fno-code ==============="
 	-time $(CABAL) $(CABAL_BUILD_CMD) --builddir=$(BUILD_DIR)-no-code \
@@ -233,28 +231,29 @@ type-check-no-deps :
                    -e '/.*Warning: the following files would be used as linker inputs, but linking is not being done:.*/d'
 
 
-.PHONY : install-prof-bin ## Install Agda with profiling enabled via cabal.
+.PHONY : install-prof-bin ## Install Agda with profiling enabled
+# --program-suffix is not for the executable name in
+# $(BUILD_DIR)/build/, only for installing it into .cabal/bin
 install-prof-bin : install-deps ensure-hash-is-correct
 	$(CABAL_INSTALL) -j1 --enable-library-profiling --enable-profiling \
           --program-suffix=_p $(CABAL_INSTALL_OPTS)
 
-# --program-suffix is not for the executable name in
-# $(BUILD_DIR)/build/, only for installing it into .cabal/bin
+.PHONY : install-debug ## Install Agda with debug enabled
+# A separate build directory is used. The suffix "-debug" is used for the binaries.
 
-# Builds Agda with the debug flag enabled. A separate build directory
-# is used. The suffix "-debug" is used for the binaries.
-
-.PHONY : install-debug ## Install Agda with debug enabled via cabal.
 install-debug : install-deps ensure-hash-is-correct
 	$(CABAL_INSTALL) --disable-library-profiling \
         -fdebug --program-suffix=-debug --builddir=$(BUILD_DIR)-debug \
         $(CABAL_INSTALL_BIN_OPTS)
 
-.PHONY : debug-install-quick ## Install Agda (compiled with -O0) with debug enabled via cabal.
+.PHONY : debug-install-quick ## Install Agda -O0 with debug enabled
 debug-install-quick : install-deps
 	$(QUICK_CABAL_INSTALL) --disable-library-profiling \
         -fdebug --program-suffix=-debug-quick --builddir=$(BUILD_DIR)-debug-quick \
         $(CABAL_INSTALL_BIN_OPTS) --ghc-options=-O0
+
+##############################################################################
+## Agda mode for Emacs
 
 .PHONY : compile-emacs-mode ## Compile Agda's Emacs mode using Emacs.
 compile-emacs-mode: install-bin
@@ -268,7 +267,9 @@ setup-emacs-mode : install-bin
 	@echo
 	$(AGDA_MODE) setup
 
-## Clean ####################################################################
+##############################################################################
+## Clean
+
 clean_helper = if [ -d $(1) ]; then $(CABAL) $(CABAL_CLEAN_CMD) --builddir=$(1); fi;
 
 clean : ## Clean all local builds
@@ -277,7 +278,8 @@ clean : ## Clean all local builds
 	$(STACK) clean --full
 	$(STACK) clean --full --work-dir=$(QUICK_STACK_BUILD_DIR)
 
-## Haddock ###################################################################
+##############################################################################
+## Haddock
 
 .PHONY : haddock ##
 haddock :
@@ -312,7 +314,6 @@ tags : have-bin-hs-tags
 TAGS : have-bin-hs-tags
 	@$(call decorate, "TAGS", \
 		$(MAKE) -C $(FULL_SRC_DIR) TAGS)
-
 
 
 ##############################################################################
@@ -533,6 +534,7 @@ testing-emacs-mode:
 
 # NB. It is necessary to install the Agda library (i.e run `make install-bin`)
 # before installing the `size-solver` program.
+
 .PHONY : install-size-solver ## Install the size solver.
 install-size-solver :
 	@$(call decorate, "Installing the size-solver program", \
@@ -550,11 +552,12 @@ test-size-solver : install-size-solver
 
 # The variable `GHC_COMPILER` is to be defined as a command-line argument.
 # For example: `make set-default-stack-file GHC_COMPILER=8.10.2`
-set-default-stack-file : remove-default-stack-file
+
+set-default-stack-file : remove-default-stack-file ##
 	ln -s stack-$(GHC_COMPILER).yaml stack.yaml
 	cd $(FIXW_PATH) && ln -s stack-$(GHC_COMPILER).yaml stack.yaml
 
-remove-default-stack-file :
+remove-default-stack-file : ##
 	rm -f stack.yaml
 	cd $(FIXW_PATH) && rm -f stack.yaml
 
@@ -594,7 +597,7 @@ hpc-build: ensure-hash-is-correct
 agda.tix: ./examples/agda.tix ./test/common/agda.tix ./test/Succeed/agda.tix ./test/compiler/agda.tix ./test/api/agda.tix ./test/interaction/agda.tix ./test/fail/agda.tix ./test/lib-succeed/agda.tix ./std-lib/agda.tix ##
 	hpc sum --output=$@ $^
 
-.PHONY: hpc ## Generate a code coverage report via cabal.
+.PHONY: hpc ## Generate a code coverage report
 hpc: hpc-build test agda.tix
 	hpc report --hpcdir=$(BUILD_DIR)/hpc/mix/Agda-$(VERSION) agda.tix
 	hpc markup --hpcdir=$(BUILD_DIR)/hpc/mix/Agda-$(VERSION) agda --destdir=hpc-report

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 AGDA_TESTS_OPTIONS ?=-i -j$(PARALLEL_TESTS)
 
 CABAL_INSTALL_HELPER = $(CABAL) $(CABAL_INSTALL_CMD) --disable-documentation
-STACK_INSTALL_HELPER = $(STACK) install Agda --no-haddock
+STACK_INSTALL_HELPER = $(STACK) build Agda --no-haddock
 
 # If running on Travis, use --system-ghc.
 # Developers running `make` will usually want to use the GHC version they've
@@ -47,21 +47,17 @@ endif
 
 # quicker install: -O0, no tests
 
-QUICK_BUILD_DIR       = $(BUILD_DIR)-quick
-QUICK_STACK_BUILD_DIR = .stack-work-quick
 
 QUICK_CABAL_INSTALL = $(CABAL_INSTALL_HELPER) --builddir=$(QUICK_BUILD_DIR) \
-											--ghc-options=-O0 --program-suffix=-quicker
+											--ghc-options=-O0
 QUICK_STACK_INSTALL = $(STACK_INSTALL_HELPER) --work-dir=$(QUICK_STACK_BUILD_DIR) \
 											--fast
 
 # fast install: -O0, but tests
 
-FAST_BUILD_DIR       = $(BUILD_DIR)-fast
-FAST_STACK_BUILD_DIR = .stack-work-fast
 
 FAST_CABAL_INSTALL = $(CABAL_INSTALL_HELPER) --builddir=$(FAST_BUILD_DIR) \
-                     --enable-tests --ghc-options=-O0 --program-suffix=-fast
+                     --enable-tests --ghc-options=-O0 
 FAST_STACK_INSTALL = $(STACK_INSTALL_HELPER) --work-dir=$(FAST_STACK_BUILD_DIR) \
                      --test --no-run-tests --fast
 
@@ -140,6 +136,13 @@ install: install-bin compile-emacs-mode setup-emacs-mode
 ensure-hash-is-correct:
 	touch src/full/Agda/VersionCommit.hs
 
+.PHONY: copy-bins-with-suffix-% ## Copy binaries to local bin directory with suffix
+copy-bins-with-suffix-%:
+ifdef HAS_STACK
+	cp $(shell $(STACK) --work-dir=$(STACK_BUILD_DIR) path --dist-dir)/build/agda/agda $(shell $(STACK) path --local-bin)/agda-$*
+	cp $(shell $(STACK) --work-dir=$(STACK_BUILD_DIR) path --dist-dir)/build/agda-mode/agda-mode $(shell $(STACK) path --local-bin)/agda-mode-$*
+endif
+
 .PHONY: install-deps ## Install Agda dependencies.
 install-deps: 
 ifdef HAS_STACK
@@ -157,11 +160,12 @@ ifdef HAS_STACK
 	time $(STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
 	mkdir -p $(BUILD_DIR)/build/
 	cp -r $(shell $(STACK) path --dist-dir)/build $(BUILD_DIR)
+	$(MAKE) copy-bins-with-suffix-$(VERSION)
 else
 # `cabal new-install --enable-tests` emits the error message (bug?):
 # cabal: --enable-tests was specified, but tests can't be enabled in a remote package
 	@echo "===================== Installing using Cabal with test suites ============"
-	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS)
+	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=-$(VERSION)
 endif
 
 .PHONY: v1-install ## Developer install goal without -foptimize-aggressively nor dependencies.
@@ -172,9 +176,10 @@ ifdef HAS_STACK
 	time $(STACK_INSTALL_HELPER) $(STACK_INSTALL_BIN_OPTS) --test --no-run-tests
 	mkdir -p $(BUILD_DIR)/build/
 	cp -r $(shell $(STACK) path --dist-dir)/build $(BUILD_DIR)
+	$(MAKE) copy-bins-with-suffix-$(VERSION)
 else
 	@echo "===================== Installing using Cabal with test suites ============"
-	time $(CABAL_INSTALL_HELPER) $(CABAL_INSTALL_BIN_OPTS) --builddir=$(BUILD_DIR) --enable-tests
+	time $(CABAL_INSTALL_HELPER) $(CABAL_INSTALL_BIN_OPTS) --builddir=$(BUILD_DIR) --enable-tests --program-suffix=-$(VERSION)
 endif
 
 .PHONY: fast-install-bin ## Install Agda compiled with -O0 with tests
@@ -185,13 +190,14 @@ fast-install-bin: install-deps fast-install-bin-no-deps
 ifdef HAS_STACK
 	@echo "============= Installing using Stack with -O0 and test suites ============"
 	time $(FAST_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
-	mkdir -p $(BUILD_DIR)/build/
-	cp -r $(shell $(STACK) path --dist-dir)/build $(BUILD_DIR)
+	mkdir -p $(FAST_BUILD_DIR)/build/
+	cp -r $(shell $(STACK) path --work-dir=$(FAST_STACK_BUILD_DIR) --dist-dir)/build $(FAST_BUILD_DIR)
+	STACK_BUILD_DIR=$(FAST_STACK_BUILD_DIR) $(MAKE) copy-bins-with-suffix-$(VERSION)-quicker
 else
 # `cabal new-install --enable-tests` emits the error message (bug?):
 # cabal: --enable-tests was specified, but tests can't be enabled in a remote package
 	@echo "============= Installing using Cabal with -O0 and test suites ============"
-	time $(FAST_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS)
+	time $(FAST_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=-$(VERSION)-fast
 endif
 
 .PHONY: quicker-install-bin ## Install Agda compiled with -O0 without tests
@@ -204,9 +210,10 @@ quicker-install-bin-no-deps:
 ifdef HAS_STACK
 	@echo "===================== Installing using Stack with -O0 ===================="
 	time $(QUICK_STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS)
+	STACK_BUILD_DIR=$(QUICK_STACK_BUILD_DIR) $(MAKE) copy-bins-with-suffix-$(VERSION)-quicker
 else
 	@echo "===================== Installing using Cabal with -O0 ===================="
-	time $(QUICK_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) 
+	time $(QUICK_CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=-$(VERSION)-quicker
 endif
 
 .PHONY: type-check ## Type check the Agda source only (-fno-code).
@@ -236,20 +243,20 @@ type-check-no-deps :
 # $(BUILD_DIR)/build/, only for installing it into .cabal/bin
 install-prof-bin : install-deps ensure-hash-is-correct
 	$(CABAL_INSTALL) -j1 --enable-library-profiling --enable-profiling \
-          --program-suffix=_p $(CABAL_INSTALL_OPTS)
+          --program-suffix=-$(VERSION)-prof $(CABAL_INSTALL_OPTS)
 
 .PHONY : install-debug ## Install Agda with debug enabled
 # A separate build directory is used. The suffix "-debug" is used for the binaries.
 
 install-debug : install-deps ensure-hash-is-correct
 	$(CABAL_INSTALL) --disable-library-profiling \
-        -fdebug --program-suffix=-debug --builddir=$(BUILD_DIR)-debug \
+        -fdebug --program-suffix=-$(VERSION)-debug --builddir=$(DEBUG_BUILD_DIR) \
         $(CABAL_INSTALL_BIN_OPTS)
 
 .PHONY : debug-install-quick ## Install Agda -O0 with debug enabled
 debug-install-quick : install-deps
 	$(QUICK_CABAL_INSTALL) --disable-library-profiling \
-        -fdebug --program-suffix=-debug-quick --builddir=$(BUILD_DIR)-debug-quick \
+        -fdebug --program-suffix=-$(VERSION)-debug-quick --builddir=$(QUICK_DEBUG_BUILD_DIR) \
         $(CABAL_INSTALL_BIN_OPTS) --ghc-options=-O0
 
 ##############################################################################

--- a/mk/paths.mk
+++ b/mk/paths.mk
@@ -27,7 +27,15 @@ COMPAT_SRC_DIR = $(SRC_DIR)/compat
 # Andreas, 2020-10-26 further refinement:
 # I often switch GHC version, so indexing v1-style build directories
 # by GHC version x.y.z makes sense.
-BUILD_DIR = $(TOP)/dist-$(VERSION)-ghc-$(GHC_VER)
+BUILD_DIR             = $(TOP)/dist-$(VERSION)-ghc-$(GHC_VER)
+QUICK_BUILD_DIR       = $(BUILD_DIR)-quick
+FAST_BUILD_DIR        = $(BUILD_DIR)-fast
+DEBUG_BUILD_DIR       = $(BUILD_DIR)-debug
+QUICK_DEBUG_BUILD_DIR = $(BUILD_DIR)-debug-quick
+
+STACK_BUILD_DIR       = .stack-work
+QUICK_STACK_BUILD_DIR = $(STACK_BUILD_DIR)-quick
+FAST_STACK_BUILD_DIR  = $(STACK_BUILD_DIR)-fast
 
 OUT_DIR        = $(TOP)/out
 FULL_OUT_DIR   = $(OUT_DIR)/full


### PR DESCRIPTION
A version suffix is added to binaries `agda` and `agda-mode` when they are copied into the local bin path (`~/.cabal/bin` for cabal and `~/.local/bin` for stack, by default). Then, one can switch between different versions of Agda in Emacs by pressing `C-c C-x C-s`.

Maybe the added suffix should also be customisable...