### PR TITLE
Fix #5283: reject 'tactic' expressions in scope checker

### DIFF
--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -261,7 +261,6 @@ instance Hilite A.Expr where
       A.Quote _r                    -> mempty
       A.QuoteTerm _r                -> mempty
       A.Unquote _r                  -> mempty
-      A.Tactic _r e es              -> hl e <> hl es
       A.DontCare e                  -> hl e
     where
     hl a = hilite a

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -110,8 +110,6 @@ data Expr
   | Quote ExprInfo                     -- ^ Quote an identifier 'QName'.
   | QuoteTerm ExprInfo                 -- ^ Quote a term.
   | Unquote ExprInfo                   -- ^ The splicing construct: unquote ...
-  | Tactic ExprInfo Expr [NamedArg Expr]
-                                       -- ^ @tactic e x1 .. xn@
   | DontCare Expr                      -- ^ For printing @DontCare@ from @Syntax.Internal@.
   deriving (Data, Show, Generic)
 
@@ -557,7 +555,6 @@ instance Eq Expr where
   Quote a1                   == Quote a2                   = a1 == a2
   QuoteTerm a1               == QuoteTerm a2               = a1 == a2
   Unquote a1                 == Unquote a2                 = a1 == a2
-  Tactic a1 b1 c1            == Tactic a2 b2 c2            = (a1, b1, c1) == (a2, b2, c2)
   DontCare a1                == DontCare a2                = a1 == a2
 
   _                          == _                          = False
@@ -640,7 +637,6 @@ instance HasRange Expr where
     getRange (Quote i)               = getRange i
     getRange (QuoteTerm i)           = getRange i
     getRange (Unquote i)             = getRange i
-    getRange (Tactic i _ _)          = getRange i
     getRange (DontCare{})            = noRange
     getRange (PatternSyn x)          = getRange x
     getRange (Macro x)               = getRange x
@@ -771,7 +767,6 @@ instance KillRange Expr where
   killRange (Quote i)                = killRange1 Quote i
   killRange (QuoteTerm i)            = killRange1 QuoteTerm i
   killRange (Unquote i)              = killRange1 Unquote i
-  killRange (Tactic i e xs)          = killRange3 Tactic i e xs
   killRange (DontCare e)             = killRange1 DontCare e
   killRange (PatternSyn x)           = killRange1 PatternSyn x
   killRange (Macro x)                = killRange1 Macro x
@@ -1052,7 +1047,6 @@ instance SubstExpr Expr where
     Quote{}         -> __IMPOSSIBLE__
     QuoteTerm{}     -> __IMPOSSIBLE__
     Unquote{}       -> __IMPOSSIBLE__
-    Tactic{}        -> __IMPOSSIBLE__
     DontCare{}      -> __IMPOSSIBLE__
     Macro{}         -> __IMPOSSIBLE__
 

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -166,7 +166,6 @@ instance ExprLike Expr where
       Unquote{}                  -> pure e0
       DontCare e                 -> DontCare <$> recurse e
       PatternSyn{}               -> pure e0
-      Tactic ei e xs             -> Tactic ei <$> recurse e <*> recurse xs
       Macro{}                    -> pure e0
 
   foldExpr :: forall m. FoldExprFn m Expr
@@ -198,7 +197,6 @@ instance ExprLike Expr where
       Quote{}                -> m
       QuoteTerm{}            -> m
       Unquote{}              -> m
-      Tactic _ e xs          -> m `mappend` fold e `mappend` fold xs
       DontCare e             -> m `mappend` fold e
    where
      m = f e
@@ -235,7 +233,6 @@ instance ExprLike Expr where
       Quote{}                    -> f e
       QuoteTerm{}                -> f e
       Unquote{}                  -> f e
-      Tactic ei e xs             -> f =<< Tactic ei <$> trav e <*> trav xs
       DontCare e                 -> f =<< DontCare <$> trav e
       PatternSyn{}               -> f e
       Macro{}                    -> f e
@@ -585,7 +582,6 @@ instance DeclaredNames RHS where
 --     Quote{}               -> mempty
 --     QuoteTerm{}           -> mempty
 --     Unquote{}             -> mempty
---     Tactic _ e xs         -> declaredNames e <> declaredNames xs
 --     DontCare{}            -> mempty
 --     PatternSyn{}          -> mempty
 --     Macro{}               -> mempty

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -880,12 +880,6 @@ instance ToConcrete A.Expr where
     toConcrete (A.Quote i) = return $ C.Quote (getRange i)
     toConcrete (A.QuoteTerm i) = return $ C.QuoteTerm (getRange i)
     toConcrete (A.Unquote i) = return $ C.Unquote (getRange i)
-    toConcrete (A.Tactic i e xs) = do
-      e' <- toConcrete e
-      xs' <- toConcrete xs
-      let r      = getRange i
-          rawtac = foldl (C.App r) e' xs'
-      return $ C.Tactic (getRange i) rawtac
 
     -- Andreas, 2012-04-02: TODO!  print DontCare as irrAxiom
     -- Andreas, 2010-10-05 print irrelevant things as ordinary things

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1035,11 +1035,7 @@ instance ToAbstract C.Expr where
       C.QuoteTerm r -> return $ A.QuoteTerm (ExprRange r)
       C.Unquote r -> return $ A.Unquote (ExprRange r)
 
-      C.Tactic r e -> do
-        let AppView e' args = appView e
-        e'   <- toAbstract e'
-        args <- toAbstract args
-        return $ A.Tactic (ExprRange r) e' args
+      C.Tactic r e -> genericError "Syntax error: 'tactic' can only appear in attributes"
 
   -- DontCare
       C.DontCare e -> A.DontCare <$> toAbstract e

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1051,7 +1051,6 @@ instance BlankVars A.Expr where
     A.Quote {}               -> __IMPOSSIBLE__
     A.QuoteTerm {}           -> __IMPOSSIBLE__
     A.Unquote {}             -> __IMPOSSIBLE__
-    A.Tactic {}              -> __IMPOSSIBLE__
     A.DontCare v             -> A.DontCare $ blank bound v
     A.PatternSyn {}          -> e
     A.Macro {}               -> e

--- a/test/Fail/Issue5283.agda
+++ b/test/Fail/Issue5283.agda
@@ -1,0 +1,14 @@
+-- Andreas, 2021-08-19, issue #5283, reported by guilhermehas
+
+-- 'tactic' should only appear in attributes and 'C.Tactic' is converted to
+-- 'TacticAttribute' there.
+-- Other occurrences of 'C.Tactic' should be a scope error.
+-- At the time of writing, the scope checker passes it as A.Tactic to the type
+-- checker, and that loops on it.
+
+open import Agda.Builtin.Reflection
+
+A : Set
+A = tactic ?
+
+-- Should be syntax error.

--- a/test/Fail/Issue5283.err
+++ b/test/Fail/Issue5283.err
@@ -1,0 +1,3 @@
+Issue5283.agda:12,5-13
+Syntax error: 'tactic' can only appear in attributes
+when scope checking tactic ?


### PR DESCRIPTION
Fix #5283: reject 'tactic' expressions in scope checker