### PR TITLE
[ #5302 ] running tests with `cabal test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,17 +449,17 @@ latex-html-test :
 .PHONY : html-test ##
 html-test :
 	@$(call decorate, "Suite of tests for the HTML backend", \
-	  AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/HTMLOnly)
+	  AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/LaTeXAndHTML/HTML)
 
 .PHONY : latex-test ##
 latex-test :
 	@$(call decorate, "Suite of tests for the LaTeX backend", \
-		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/LaTeXOnly)
+		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/LaTeXAndHTML/LaTeX)
 
 .PHONY : quicklatex-test ##
 quicklatex-test :
 	@$(call decorate, "Suite of tests for the QuickLaTeX backend", \
-	  AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/QuickLaTeXOnly)
+	  AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/LaTeXAndHTML/QuickLaTeX)
 
 .PHONY : std-lib-test ##
 std-lib-test :

--- a/test/LaTeXAndHTML/Tests.hs
+++ b/test/LaTeXAndHTML/Tests.hs
@@ -52,13 +52,13 @@ userManualTestDir = testDirPrefix "user-manual"
 disabledTests :: [RegexFilter]
 disabledTests = []
 
--- | List of test groups with names
+-- | Test group with subgroups
 --
 -- @
---   [ "LaTeXAndHTML" , "HTMLOnly" , "LaTeXOnly" , "QuickLaTeXOnly" ]
+--   "LaTeXAndHTML" / [ "HTML" , "LaTeX" , "QuickLaTeX" ]
 -- @.
 --
-tests :: IO [TestTree]
+tests :: IO TestTree
 tests = do
   agdaBin  <- getAgdaBin
   suiteTests <- concat <$> mapM (taggedListOfAllTests agdaBin) testDirs
@@ -67,11 +67,11 @@ tests = do
         HTML       -> One
         LaTeX      -> Two
         QuickLaTeX -> Three
-  return
-    [ testGroup "LaTeXAndHTML"   $ map snd allTests
-    , testGroup "HTMLOnly"       $ map snd html
-    , testGroup "LaTeXOnly"      $ map snd latex
-    , testGroup "QuickLaTeXOnly" $ map snd quicklatex
+  return $
+    testGroup "LaTeXAndHTML"
+    [ testGroup "HTML"       $ map snd html
+    , testGroup "LaTeX"      $ map snd latex
+    , testGroup "QuickLaTeX" $ map snd quicklatex
     ]
 
 taggedListOfAllTests :: FilePath -> FilePath -> IO [(Kind, TestTree)]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,7 +2,7 @@
 
 module Main where
 
-import qualified Compiler.Tests as COMP
+import qualified Compiler.Tests as COMPILER
 import qualified Succeed.Tests as SUCCEED
 import qualified Fail.Tests as FAIL
 import qualified Interactive.Tests as INTERACTIVE
@@ -38,23 +38,34 @@ main = do
             ]
       exitWith (ExitFailure 1)
 
+-- | All tests covered by the tasty testsuite.
 tests :: IO TestTree
 tests = do
-  latexHtml <- LATEXHTML.tests
-  testGroup "all" . (latexHtml ++) <$>
-    sequence [ COMP.tests
-             , FAIL.tests
-             , return INTERACTIVE.tests
-             , SUCCEED.tests
-             , BUGS.tests
-             , LIBSUCCEED.tests
-             , USERMANUAL.tests
-             , return INTERNAL.tests
-             ]
+  testGroup "all" {- . concat -} <$> do
+    sequence $
+      -- N.B.: This list is written using (:) so that lines can be swapped easily:
+      -- (The number denotes the order of the Makefile as of 2021-08-25.)
+      {- 5 -} sg LATEXHTML.tests   :
+      {- 3 -} sg BUGS.tests        :
+      {- 1 -} sg SUCCEED.tests     :
+      {- 6 -} pu INTERNAL.tests    :
+      {- 9 -} sg USERMANUAL.tests  :
+      {- 4 -} pu INTERACTIVE.tests :
+      {- 2 -} sg FAIL.tests        :
+      {- 7 -} sg COMPILER.tests    :
+      {- 8 -} sg LIBSUCCEED.tests  :
+      []
+  where
+  sg = id
+  pu = pure
+  -- If one @tests@ returns a list of test trees, use these wrappers:
+  -- sg m = (:[]) <$> m
+  -- pu x = pure [x]
+
 
 disabledTests :: [RegexFilter]
 disabledTests = concat
-  [ COMP.disabledTests
+  [ COMPILER.disabledTests
   , LIBSUCCEED.disabledTests
   , LATEXHTML.disabledTests
   ]


### PR DESCRIPTION
[ #5302 ] 

- First step: make LaTeXAndHTML TestTree redundancy free.
  Reorganized into

    LaTeXAndHTML /
    - HTML
    - LaTeX
    - QuickLaTeX
    
  rather than having LaTeXAndHTML being the union of the three subgroup next to them.
  This is removing duplicates from the TestTree, useful when running simply the root (`all` tests).