### PR TITLE
[ fix #5302 ] make 'cabal test' work for part of the test-suite

### DIFF
--- a/.github/workflows/cabal-test.yml
+++ b/.github/workflows/cabal-test.yml
@@ -1,0 +1,91 @@
+name: cabal-test
+
+on:
+  push:
+    branches:
+    - master
+    - ci-*
+    - release*
+    paths:
+    - '.github/workflows/cabal-test.yml'
+    - 'Agda.cabal'
+    - 'Setup.hs'
+    - 'src/agda-mode/**'
+    - 'src/full/**'
+    - 'src/main/**'
+    - 'test/**.hs'
+  pull_request:
+    paths:
+    - '.github/workflows/cabal-test.yml'
+    - 'Agda.cabal'
+    - 'Setup.hs'
+    - 'src/agda-mode/**'
+    - 'src/full/**'
+    - 'src/main/**'
+    - 'test/**.hs'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  auto-cancel:
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[github skip]')
+      && !contains(github.event.head_commit.message, '[skip github]')
+    runs-on: Ubuntu-latest # Required, but it can be anything here.
+
+    steps:
+    - uses: styfle/cancel-workflow-action@0.6.0
+      with:
+        access_token: ${{ github.token }}
+
+  cabal:
+    needs: auto-cancel
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ghc-ver: ['latest']
+        cabal-ver: ['latest']
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: haskell/actions/setup@v1
+      id: setup-haskell
+      with:
+        ghc-version: ${{ matrix.ghc-ver }}
+        cabal-version: ${{ matrix.cabal-ver }}
+
+    - name: Configure the build plan
+      run: |
+        cabal update
+        cabal configure ${FLAGS} -O1
+
+    - uses: actions/cache@v2
+      name: Cache dependencies
+      id: cache
+      with:
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+        # The file `plan.json` contains the build information.
+        key: ${{ runner.os }}-cabal-01-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver }}-${{ hashFiles('**/plan.json') }}
+
+    - name: Install dependencies
+      if: ${{ !steps.cache.outputs.cache-hit }}
+      run: |
+        cabal build --only-dependencies --enable-tests
+
+    - name: Build Agda
+      run: |
+        cabal build
+
+    - name: Build and test Agda
+      run: |
+        cabal test

--- a/.github/workflows/cabal-test.yml
+++ b/.github/workflows/cabal-test.yml
@@ -10,7 +10,6 @@ on:
     - '.github/workflows/cabal-test.yml'
     - 'Agda.cabal'
     - 'Setup.hs'
-    - 'src/agda-mode/**'
     - 'src/full/**'
     - 'src/main/**'
     - 'test/**.hs'
@@ -19,7 +18,6 @@ on:
     - '.github/workflows/cabal-test.yml'
     - 'Agda.cabal'
     - 'Setup.hs'
-    - 'src/agda-mode/**'
     - 'src/full/**'
     - 'src/main/**'
     - 'test/**.hs'
@@ -90,6 +88,12 @@ jobs:
       run: |
         cabal build --only-dependencies --enable-tests
 
+    # Andreas, 2021-09-02:
+    # Installing Agda, instead of just building it, is to work around
+    # https://github.com/haskell/cabal/issues/7577
+    # which hides the build executable from the tests when there is
+    # a Custom cabal setup (atm works only for Simple setup).
+    # Once haskell/cabal#7577 is fixed, we can dispose of this workaround.
     - name: Install Agda
       run: |
         mkdir -p ${HOME}/bin

--- a/.github/workflows/cabal-test.yml
+++ b/.github/workflows/cabal-test.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure ${FLAGS} -O1
+        cabal configure -O1 --enable-tests
 
     - uses: actions/cache@v2
       name: Cache dependencies
@@ -82,10 +82,13 @@ jobs:
       run: |
         cabal build --only-dependencies --enable-tests
 
-    - name: Build Agda
+    - name: Install Agda
       run: |
-        cabal build
+        mkdir -p ${HOME}/bin
+        cabal install --installdir=${HOME}/bin
+# bin instead of .cabal/bin as this might be more portable (Windows)
 
     - name: Build and test Agda
       run: |
+        export PATH=${HOME}/bin:${PATH}
         cabal test

--- a/.github/workflows/cabal-test.yml
+++ b/.github/workflows/cabal-test.yml
@@ -49,7 +49,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          # - windows-latest
+          ## Andreas, 2021-08-28, giving up on running the test-suite under Windows.
+          ## There is e.g. https://github.com/phile314/tasty-silver/issues/16
+          ## that may be responsible that diffs are not shown,
+          ## and that prevents me from running the test-suite interactively.
         ghc-ver: ['latest']
         cabal-ver: ['latest']
 

--- a/.github/workflows/cabal-test.yml
+++ b/.github/workflows/cabal-test.yml
@@ -49,9 +49,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         ghc-ver: ['latest']
         cabal-ver: ['latest']
+
     steps:
     - uses: actions/checkout@v2
       with:

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -915,6 +915,11 @@ test-suite agda-tests
                     , UserManual.Tests
                     , Utils
 
+  -- Andreas, 2021-08-26, see https://github.com/haskell/cabal/issues/7577
+  -- Since 'agda-tests' wants to call 'agda', we have to add it here,
+  -- should we want to run 'cabal test'.
+  build-tool-depends: Agda:agda
+
   build-depends:  Agda
                 , array >= 0.5.1.1 && < 0.6
                 , base >= 4.9.0.0 && < 4.16

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -106,6 +106,12 @@ disabledTests =
   ]
   where disable = RFInclude
 
+stdlibTestFilter :: [RegexFilter]
+stdlibTestFilter =
+  [ disable "Compiler/.*/with-stdlib"
+  ]
+  where disable = RFInclude
+
 tests :: IO TestTree
 tests = do
   nodeBin <- findExecutable "node"

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -106,6 +106,8 @@ disabledTests =
   ]
   where disable = RFInclude
 
+-- | Filtering out compiler tests using the Agda standard library.
+
 stdlibTestFilter :: [RegexFilter]
 stdlibTestFilter =
   [ disable "Compiler/.*/with-stdlib"

--- a/test/LaTeXAndHTML/Tests.hs
+++ b/test/LaTeXAndHTML/Tests.hs
@@ -52,6 +52,19 @@ userManualTestDir = testDirPrefix "user-manual"
 disabledTests :: [RegexFilter]
 disabledTests = []
 
+-- | Filtering out tests using Text.ICU.
+
+icuTests :: [RegexFilter]
+icuTests = [ disable "LaTeXAndHTML/.*/Grapheme.*" ]
+  where disable = RFInclude
+
+-- | Filtering out tests using latex.
+
+latexTests :: [RegexFilter]
+latexTests = [ disable "LaTeXAndHTML/.*LaTeX/.*" ]
+  where disable = RFInclude
+
+
 -- | Test group with subgroups
 --
 -- @

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -31,7 +31,13 @@ main = do
         , "@ The preferred way of running the tests is via the Makefile ('make test'). @"
         , "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
         ]
-      TM.defaultMain1 (makefileDependentTests ++ disabledTests) =<< tests
+      agdaBin <- getAgdaBin
+      doesCommandExist agdaBin >>= \case
+        True ->
+          TM.defaultMain1 cabalDisabledTests =<< tests
+        False -> do
+          putStrLn $ unwords ["Could not find executable", agdaBin ]
+          exitFailure
       -- putStrLn $ unlines
       --       [ "The AGDA_BIN environment variable is not set. Do not execute"
       --       , "these tests directly using \"cabal test\" or \"cabal install --run-tests\", instead"
@@ -50,12 +56,12 @@ tests = do
     sequence $
       -- N.B.: This list is written using (:) so that lines can be swapped easily:
       -- (The number denotes the order of the Makefile as of 2021-08-25.)
+      {- 5 -} sg LATEXHTML.tests   :
       {- 1 -} sg SUCCEED.tests     :
       {- 2 -} sg FAIL.tests        :
       {- 3 -} sg BUGS.tests        :
       {- 4 -} pu INTERACTIVE.tests :
       {- 9 -} sg USERMANUAL.tests  :
-      {- 5 -} sg LATEXHTML.tests   :
       {- 6 -} pu INTERNAL.tests    :
       {- 7 -} sg COMPILER.tests    :
       {- 8 -} sg LIBSUCCEED.tests  :
@@ -66,6 +72,16 @@ tests = do
   -- If one @tests@ returns a list of test trees, use these wrappers:
   -- sg m = (:[]) <$> m
   -- pu x = pure [x]
+
+-- | Filtering out tests for @cabal test@.
+
+cabalDisabledTests :: [RegexFilter]
+cabalDisabledTests = concat
+  [ disabledTests
+  , makefileDependentTests
+  , LATEXHTML.latexTests
+  , LATEXHTML.icuTests
+  ]
 
 makefileDependentTests :: [RegexFilter]
 makefileDependentTests = SUCCEED.makefileDependentTests

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -26,7 +26,7 @@ main = do
       putStrLn $ unlines
         [ "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
         , "@ The AGDA_BIN environment variable is not set.                             @"
-        , "@ It looks like you are running 'cabal test' or 'cabal install --runtests'. @"
+        , "@ Maybe you are running 'cabal test' or 'cabal v1-install --runtests'?      @"
         , "@ This will only run parts of the Agda test-suite.                          @"
         , "@ The preferred way of running the tests is via the Makefile ('make test'). @"
         , "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
@@ -38,16 +38,6 @@ main = do
         False -> do
           putStrLn $ unwords ["Could not find executable", agdaBin ]
           exitFailure
-      -- putStrLn $ unlines
-      --       [ "The AGDA_BIN environment variable is not set. Do not execute"
-      --       , "these tests directly using \"cabal test\" or \"cabal install --run-tests\", instead"
-      --       , "use the Makefile."
-      --       , "Are you maybe using the Makefile together with an old cabal-install version?"
-      --       , "Versions of cabal-install before 1.20.0.0 have a bug and will trigger this error."
-      --       , "The Makefile requires cabal-install 1.20.0.0 or later to work properly."
-      --       , "See also Issue #1489 and #1490."
-      --       ]
-      -- exitWith (ExitFailure 1)
 
 -- | All tests covered by the tasty testsuite.
 tests :: IO TestTree
@@ -56,12 +46,12 @@ tests = do
     sequence $
       -- N.B.: This list is written using (:) so that lines can be swapped easily:
       -- (The number denotes the order of the Makefile as of 2021-08-25.)
-      {- 5 -} sg LATEXHTML.tests   :
       {- 1 -} sg SUCCEED.tests     :
       {- 2 -} sg FAIL.tests        :
       {- 3 -} sg BUGS.tests        :
       {- 4 -} pu INTERACTIVE.tests :
       {- 9 -} sg USERMANUAL.tests  :
+      {- 5 -} sg LATEXHTML.tests   :
       {- 6 -} pu INTERNAL.tests    :
       {- 7 -} sg COMPILER.tests    :
       {- 8 -} sg LIBSUCCEED.tests  :

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -74,6 +74,8 @@ cabalDisabledTests = concat
   , COMPILER.stdlibTestFilter
   ]
 
+-- | Some tests get extra setup through the @Makefile@.
+
 makefileDependentTests :: [RegexFilter]
 makefileDependentTests = SUCCEED.makefileDependentTests
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -81,6 +81,7 @@ cabalDisabledTests = concat
   , makefileDependentTests
   , LATEXHTML.latexTests
   , LATEXHTML.icuTests
+  , COMPILER.stdlibTestFilter
   ]
 
 makefileDependentTests :: [RegexFilter]

--- a/test/Succeed/Tests.hs
+++ b/test/Succeed/Tests.hs
@@ -13,6 +13,7 @@ import Test.Tasty
 import Test.Tasty.Silver
 import Test.Tasty.Silver.Advanced
   (readFileMaybe, goldenTestIO1, GDiff (..), GShow (..))
+import Test.Tasty.Silver.Filter ( RegexFilter( RFInclude ) )
 
 import System.Directory
 import System.Exit
@@ -34,9 +35,17 @@ tests = do
 
   return $ testGroup "Succeed" tests'
   where
-  -- Andreas, 2020-10-19, work around issue #4940:
-  -- Put @ExecAgda@ last.
-  reorder = uncurry (++) . List.partition (("ExecAgda" /=) . dropAgdaExtension)
+  reorder = id
+  -- -- Andreas, 2020-10-19, work around issue #4940:
+  -- -- Put @ExecAgda@ last.
+  -- reorder = uncurry (++) . List.partition (not . ("ExecAgda" `List.isInfixOf`))
+
+-- | Tests that get special preparation from the Makefile.
+makefileDependentTests :: [RegexFilter]
+makefileDependentTests =
+  [ disable "Succeed/ExecAgda"
+  ]
+  where disable = RFInclude
 
 data TestResult
   = TestSuccess

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -315,6 +315,11 @@ cleanOutput' pwd t = foldl (\ t' (rgx, n) -> replace rgx n t') t rgxs
       , (T.pack Agda.Version.package, "«Agda-package»")
       -- Andreas, 2021-08-26.  When run with 'cabal test',
       -- Agda.Version.package didn't match, so let's be generous:
+      -- Andreas, 2021-09-02.  The match failure could be triggered
+      -- when we are running the *installed* version of Agda rather
+      -- than the *built* one, see .github/workflows/cabal-test.yml.
+      -- Maybe the match failures will disappear once we drop
+      -- the workaround for haskell/cabal#7577.
       -- Andreas, 2021-08-28.  To work around haskell/cabal#7209,
       -- "The Grinch stole all the vowels", we also have to
       -- recognize Agd (instead of Agda) as package name.

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -315,7 +315,11 @@ cleanOutput' pwd t = foldl (\ t' (rgx, n) -> replace rgx n t') t rgxs
       , (T.pack Agda.Version.package, "«Agda-package»")
       -- Andreas, 2021-08-26.  When run with 'cabal test',
       -- Agda.Version.package didn't match, so let's be generous:
-      , ("Agda-[.0-9]+(-[[:alnum:]]+){0,1}", "«Agda-package»")
+      -- Andreas, 2021-08-28.  To work around haskell/cabal#7209,
+      -- "The Grinch stole all the vowels", we also have to
+      -- recognize Agd (instead of Agda) as package name.
+      -- See CI run: https://github.com/agda/agda/runs/3449775214?check_suite_focus=true
+      , ("Agda?-[.0-9]+(-[[:alnum:]]+)?", "«Agda-package»")
       , ("[^ (]*lib.prim", "agda-default-include-path")
       , ("\xe2\x80\x9b|\xe2\x80\x99|\xe2\x80\x98|`", "'")
       ]

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -135,9 +135,7 @@ getEnvAgdaArgs :: IO AgdaArgs
 getEnvAgdaArgs = maybe [] words <$> getEnvVar "AGDA_ARGS"
 
 getAgdaBin :: IO FilePath
-getAgdaBin = fromMaybeM err $ getEnvVar "AGDA_BIN"
-  where
-  err = fail "AGDA_BIN environment variable not set, aborting..."
+getAgdaBin = getProg "agda"
 
 -- | Gets the program executable. If an environment variable
 -- YYY_BIN is defined (with yyy converted to upper case),
@@ -315,6 +313,9 @@ cleanOutput' pwd t = foldl (\ t' (rgx, n) -> replace rgx n t') t rgxs
       , ("\\\\", "/")
       , ("\\.hs(:[[:digit:]]+){2}", ".hs:«line»:«col»")
       , (T.pack Agda.Version.package, "«Agda-package»")
+      -- Andreas, 2021-08-26.  When run with 'cabal test',
+      -- Agda.Version.package didn't match, so let's be generous:
+      , ("Agda-[.0-9]+(-[[:alnum:]]+){0,1}", "«Agda-package»")
       , ("[^ (]*lib.prim", "agda-default-include-path")
       , ("\xe2\x80\x9b|\xe2\x80\x99|\xe2\x80\x98|`", "'")
       ]


### PR DESCRIPTION
[ fix #5302 ] make `cabal test` work for part of the test-suite

`cabal test` will run only some of the tests defined by `agda-tests`