### PR TITLE
[ fix #5545 ] lexer: commit to match at eof

### DIFF
--- a/fix-whitespace.yaml
+++ b/fix-whitespace.yaml
@@ -55,9 +55,10 @@ included-files:
 excluded-files:
 # Andreas (24 Sep 2014).
 # The following files are exempt from the whitespace check,
-# as they test behavior of Agda with regard to tab characters.
+# as they test behavior of Agda with regard to e.g. tab characters.
   - "test/Succeed/Whitespace.agda"
   - "test/Succeed/Issue1337.agda"
+  - "test/Succeed/Issue5545.agda"
   - "test/Fail/Tabs.agda"
   - "test/Fail/TabsInPragmas.agda"
   - "src/full/Agda/Syntax/Parser/Lexer.hs"

--- a/src/full/Agda/Syntax/Parser/Literate.hs
+++ b/src/full/Agda/Syntax/Parser/Literate.hs
@@ -26,6 +26,9 @@ import Control.Monad ((<=<))
 import Data.Char (isSpace)
 import Data.List (isPrefixOf)
 import Text.Regex.TDFA
+  ( Regex, getAllTextSubmatches, match, matchM
+  , makeRegexOpts, blankCompOpt, blankExecOpt, newSyntax, caseSensitive
+  )
 
 import Agda.Syntax.Common
 import Agda.Syntax.Position

--- a/test/Succeed/Issue5545.agda
+++ b/test/Succeed/Issue5545.agda
@@ -1,0 +1,13 @@
+-- Andreas, 2021-09-06, issue #5545,
+-- regression introduced by #5522 (fix for #5291).
+--
+-- Note: this test requires that there is no newline at the end of file.
+-- So, it violates the whitespace requirement of fix-whitespace,
+-- and needs to be an exception in the configuration of fix-whitespace.
+
+{-# OPTIONS --allow-unsolved-metas #-}
+
+-- No newline at end of file triggered "Unterminated {!" error.
+
+_ : Set
+_ = {! !}


### PR DESCRIPTION
[ fix #5545 ] lexer: commit to match at eof

Fixes regression introduced by #5522.