### PR TITLE
Fix #5557: doc --print-agda-dir and how to get Agda.css and agda.sty

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -53,6 +53,15 @@ General options
 
      Show version number.
 
+.. option:: --print-agda-dir
+
+     .. versionadded:: 2.6.2
+
+     Outputs the root (:envvar:`AGDA_DIR`)
+     of the directory structure holding Agda's data files
+     such as core libraries, style files for the backends etc.
+
+
 Compilation
 ~~~~~~~~~~~
 

--- a/doc/user-manual/tools/generating-html.rst
+++ b/doc/user-manual/tools/generating-html.rst
@@ -15,6 +15,14 @@ You can change the way in which the code is highlighted by providing
 your own CSS file instead of the :download:`default, included one
 <../../../src/data/html/Agda.css>` (use the ``--css`` option).
 
+.. note::
+
+  The :file:`Agda.css` shipped with Agda is located at
+  :file:`{${AGDA_DIR}}/html/Agda.css`.  Since version 2.6.2, the
+  :envvar:`AGDA_DIR` is printed by option :option:`--print-agda-dir`.
+  Thus, you can get hold of the CSS file via
+  :samp:`cat $(agda --print-agda-dir)/html/Agda.css`.
+
 You can also highlight all the occurrences of the symbol your mouse is
 hovering in the HTML by adding the ``--highlight-occurrences`` option.
 The default behaviour only highlight the single symbol your mouse is

--- a/doc/user-manual/tools/generating-latex.rst
+++ b/doc/user-manual/tools/generating-latex.rst
@@ -29,6 +29,14 @@ the LaTeX output directory (by default :file:`latex`). Note that the
 appearance of typeset code can be modified by overriding definitions
 from :file:`agda.sty`.
 
+.. note::
+
+  The :file:`agda.sty` shipped with Agda is located at
+  :file:`{${AGDA_DIR}}/latex/agda.sty`.  Since version 2.6.2, the
+  :envvar:`AGDA_DIR` is printed by option :option:`--print-agda-dir`.
+  Thus, you can get hold of the CSS file via
+  :samp:`cat $(agda --print-agda-dir)/latex/agda.sty`.
+
 .. _unicode-latex:
 
 Known pitfalls and issues


### PR DESCRIPTION
Fix #5557: doc `--print-agda-dir` and how to get `Agda.css` and `agda.sty`

@wenkokke : Does this help? 