### PR TITLE
Fixed #394

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,34 @@ Language
   `(j : J) → A : Set l`, that is, the type of functions from a type in `ISet`
   to a fibrant type is fibrant.
 
+Syntax
+------
+
+* It is now OK to put lambda-bound variables anywhere in the
+  right-hand side of a syntax declaration. However, there must always
+  be at least one "identifier" between any two regular "holes". For
+  instance, the following syntax declaration is accepted because `-`
+  is between the holes `B` and `D`.
+
+  ```agda
+  postulate
+    F : (Set → Set) → (Set → Set) → Set
+
+  syntax F (λ A → B) (λ C → D) = B A C - D
+  ```
+
+* Syntax can now use lambdas with multiple arguments
+  ([#394](https://github.com/agda/agda/issues/394)).
+
+  Example:
+
+  ```agda
+  postulate
+    Σ₂ : (A : Set) → (A → A → Set) → Set
+
+  syntax Σ₂ A (λ x₁ x₂ → P) = [ x₁ x₂ ⦂ A ] × P
+  ```
+
 Compiler backends
 -----------------
 

--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -668,10 +668,10 @@ hiliteAName x include asp = do
 
     boundAspect = nameAsp Bound False
 
-    genPartFile (BindHole r i)   = several [rToR r, rToR $ getRange i] boundAspect
-    genPartFile (NormalHole r i) = several [rToR r, rToR $ getRange i] boundAspect
-    genPartFile WildHole{}       = mempty
-    genPartFile (IdPart x)       = H.singleton (rToR $ getRange x) (asp False)
+    genPartFile (VarPart r i)  = several [rToR r, rToR $ getRange i] boundAspect
+    genPartFile (HolePart r i) = several [rToR r, rToR $ getRange i] boundAspect
+    genPartFile WildPart{}     = mempty
+    genPartFile (IdPart x)     = H.singleton (rToR $ getRange x) (asp False)
 
 -- * Short auxiliary functions.
 ---------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -224,9 +224,9 @@ buildParsers kind exprNames = do
           Trie.member (addHole withHole p) partListsInExpr
           where
           p = case n of
-            NormalHole{} : IdPart p : _ -> rangedThing p
-            IdPart p : _                -> rangedThing p
-            _                           -> __IMPOSSIBLE__
+            HolePart{} : IdPart p : _ -> rangedThing p
+            IdPart p : _              -> rangedThing p
+            _                         -> __IMPOSSIBLE__
 
         -- Is the last identifier part present in n present in the
         -- expression, without any succeeding name parts, except for a
@@ -235,9 +235,9 @@ buildParsers kind exprNames = do
           Trie.member (addHole withHole p) reversedPartListsInExpr
           where
           p = case reverse n of
-            NormalHole{} : IdPart p : _ -> rangedThing p
-            IdPart p : _                -> rangedThing p
-            _                           -> __IMPOSSIBLE__
+            HolePart{} : IdPart p : _ -> rangedThing p
+            IdPart p : _              -> rangedThing p
+            _                         -> __IMPOSSIBLE__
 
         -- Are the initial and final identifier parts present with
         -- the right mix of leading and trailing underscores?

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -623,11 +623,11 @@ instance Pretty Fixity where
     Unrelated  -> empty
     Related{}  -> pretty ass <+> pretty level
 
-instance Pretty GenPart where
-    pretty (IdPart x)   = text $ rangedThing x
-    pretty BindHole{}   = underscore
-    pretty NormalHole{} = underscore
-    pretty WildHole{}   = underscore
+instance Pretty NotationPart where
+    pretty (IdPart x) = text $ rangedThing x
+    pretty HolePart{} = underscore
+    pretty VarPart{}  = underscore
+    pretty WildPart{} = underscore
 
     prettyList = hcat . map pretty
 

--- a/src/full/Agda/Syntax/Notation.hs
+++ b/src/full/Agda/Syntax/Notation.hs
@@ -34,18 +34,20 @@ import Agda.Syntax.Position
 
 import Agda.Utils.Lens
 import Agda.Utils.List
+import Agda.Utils.List1 (List1)
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Null
 import Agda.Utils.Pretty
 
 import Agda.Utils.Impossible
 
--- | Data type constructed in the Happy parser; converted to 'GenPart'
---   before it leaves the Happy code.
+-- | Data type constructed in the Happy parser; converted to
+-- 'NotationPart' before it leaves the Happy code.
 data HoleName
-  = LambdaHole { _bindHoleName :: RString
-               , holeName      :: RString }
-    -- ^ @\ x -> y@; 1st argument is the bound name (unused for now).
+  = LambdaHole { _bindHoleNames :: List1 RString
+               , holeName       :: RString
+               }
+    -- ^ @λ x₁ … xₙ → y@: The first argument contains the bound names.
   | ExprHole   { holeName      :: RString }
     -- ^ Simple named hole with hiding.
 
@@ -59,32 +61,25 @@ stringParts :: Notation -> [String]
 stringParts gs = [ rangedThing x | IdPart x <- gs ]
 
 -- | Target argument position of a part (Nothing if it is not a hole).
-holeTarget :: GenPart -> Maybe Int
-holeTarget (BindHole _   n) = Just $ rangedThing n
-holeTarget (WildHole     n) = Just $ rangedThing n
-holeTarget (NormalHole _ n) = Just $ rangedThing $ namedArg n
-holeTarget IdPart{}         = Nothing
+holeTarget :: NotationPart -> Maybe Int
+holeTarget (VarPart _ n)  = Just $ holeNumber $ rangedThing n
+holeTarget (WildPart n)   = Just $ holeNumber $ rangedThing n
+holeTarget (HolePart _ n) = Just $ rangedThing $ namedArg n
+holeTarget IdPart{}       = Nothing
 
--- | Is the part a hole? WildHoles don't count since they don't correspond to
---   anything the user writes.
-isAHole :: GenPart -> Bool
-isAHole BindHole{}   = True
-isAHole NormalHole{} = True
-isAHole WildHole{}   = False
-isAHole IdPart{}     = False
-
--- | Is the part a normal hole?
-isNormalHole :: GenPart -> Bool
-isNormalHole NormalHole{} = True
-isNormalHole BindHole{}   = False
-isNormalHole WildHole{}   = False
-isNormalHole IdPart{}     = False
+-- | Is the part a hole?
+isAHole :: NotationPart -> Bool
+isAHole HolePart{} = True
+isAHole VarPart{}  = False
+isAHole WildPart{} = False
+isAHole IdPart{}   = False
 
 -- | Is the part a binder?
-isBindingHole :: GenPart -> Bool
-isBindingHole BindHole{} = True
-isBindingHole WildHole{} = True
-isBindingHole _          = False
+isBinder :: NotationPart -> Bool
+isBinder HolePart{} = False
+isBinder VarPart{}  = True
+isBinder WildPart{} = True
+isBinder IdPart{}   = False
 
 -- | Classification of notations.
 
@@ -101,7 +96,7 @@ data NotationKind
 notationKind :: Notation -> NotationKind
 notationKind []  = NoNotation
 notationKind (h:syn) =
-  case (isNormalHole h, isNormalHole $ last1 h syn) of
+  case (isAHole h, isAHole $ last1 h syn) of
     (True , True ) -> InfixNotation
     (True , False) -> PostfixNotation
     (False, True ) -> PrefixNotation
@@ -109,16 +104,16 @@ notationKind (h:syn) =
 
 -- | From notation with names to notation with indices.
 --
---   Example:
+--   An example (with some parts of the code omitted):
+--   The lists
+--   @["for", "x", "∈", "xs", "return", "e"]@
+--   and
+--   @['LambdaHole' ("x" :| []) "e", 'ExprHole' "xs"]@
+--   are mapped to the following notation:
 --   @
---      ids   = ["for", "x", "∈", "xs", "return", "e"]
---      holes = [ LambdaHole "x" "e",  ExprHole "xs" ]
---   @
---   creates the notation
---   @
---      [ IdPart "for"    , BindHole 0
---      , IdPart "∈"      , NormalHole 1
---      , IdPart "return" , NormalHole 0
+--      [ 'IdPart' "for"    , 'VarPart' ('BoundVariablePosition' 0 0)
+--      , 'IdPart' "∈"      , 'HolePart' 1
+--      , 'IdPart' "return" , 'HolePart' 0
 --      ]
 --   @
 mkNotation :: [NamedArg HoleName] -> [RString] -> Either String Notation
@@ -136,11 +131,11 @@ mkNotation holes ids = do
   -- Andreas, 2018-10-18, issue #3285:
   -- syntax that is just a single hole is ill-formed and crashes the operator parser
   when   (isSingleHole xs)   $ throwError "syntax cannot be a single hole"
-  return $ insertWildHoles xs
+  return $ insertWildParts xs
     where
       holeNames :: [RString]
       holeNames = map namedArg holes >>= \case
-        LambdaHole x y -> [x, y]
+        LambdaHole _ y -> [y]
         ExprHole y     -> [y]
 
       prettyHoles :: String
@@ -153,55 +148,86 @@ mkNotation holes ids = do
       numberedHoles :: [(Int, NamedArg HoleName)]
       numberedHoles = zip holeNumbers holes
 
-      -- The WildHoles don't correspond to anything in the right-hand side so
+      -- The WildParts don't correspond to anything in the right-hand side so
       -- we add them next to their corresponding body. Slightly subtle: due to
       -- the way the operator parsing works they can't be added first or last.
-      insertWildHoles :: [GenPart] -> [GenPart]
-      insertWildHoles xs = foldr ins xs wilds
+      insertWildParts :: [NotationPart] -> [NotationPart]
+      insertWildParts xs = foldr ins xs wilds
         where
-          wilds = [ i | (_, WildHole i) <- holeMap ]
-          ins w (NormalHole r h : hs)
-            | namedArg h == w = NormalHole r h : WildHole w : hs
+          wilds = [ i | (_, WildPart i) <- holeMap ]
+
+          ins w (HolePart r h : hs)
+            | namedArg h == fmap holeNumber w =
+              HolePart r h : WildPart w : hs
           ins w (h : hs) = h : insBefore w hs
           ins _ [] = __IMPOSSIBLE__
 
-          insBefore w (NormalHole r h : hs)
-            | namedArg h == w = WildHole w : NormalHole r h : hs
+          insBefore w (HolePart r h : hs)
+            | namedArg h == fmap holeNumber w =
+              WildPart w : HolePart r h : hs
           insBefore w (h : hs) = h : insBefore w hs
           insBefore _ [] = __IMPOSSIBLE__
 
-      -- Create a map (association list) from hole names to holes.
-      -- A @LambdaHole@ contributes two entries:
-      -- both names are mapped to the same number,
-      -- but distinguished by BindHole vs. NormalHole.
-      holeMap :: [(RString, GenPart)]
+      -- A map (association list) from hole names to notation parts. A
+      -- @LambdaHole@ contributes one or more entries, one @HolePart@
+      -- and zero or more @VarPart@s or @WildParts@, all mapped to the
+      -- same number.
+      holeMap :: [(RString, NotationPart)]
       holeMap = do
-        (i, h) <- numberedHoles    -- v This range is filled in by mkPart
-        let ri x = Ranged (getRange x) i
-            normalHole y = NormalHole noRange $ fmap (ri y <$) h
+        (i, h) <- numberedHoles
+        let ri x   = Ranged (getRange x) i
+            rp x n = Ranged (getRange x) $
+                     BoundVariablePosition
+                       { holeNumber = i
+                       , varNumber  = n
+                       }
+            hole y = HolePart noRange $ fmap (ri y <$) h
+                              -- This range is filled in by mkPart.
         case namedArg h of
-          ExprHole y       -> [(y, normalHole y)]
-          LambdaHole x y
-            | "_" <- rangedThing x -> [(x, WildHole (ri x)),         (y, normalHole y)]
-            | otherwise            -> [(x, BindHole noRange (ri x)), (y, normalHole y)]
-                                                 -- Filled in by mkPart
+          ExprHole y      -> [(y, hole y)]
+          LambdaHole xs y ->
+            [(y, hole y)] ++
+            map
+              (\(n, x) -> case rangedThing x of
+                "_" -> (x, WildPart (rp x n))
+                _   -> (x, VarPart noRange (rp x n)))
+                                   -- Filled in by mkPart.
+               (zip [0..] $ List1.toList xs)
 
       -- Check whether all hole names are distinct.
       -- The hole names are the keys of the @holeMap@.
       uniqueHoleNames = distinct [ x | (x, _) <- holeMap, rangedThing x /= "_" ]
 
-      isExprLinear   xs = List.sort [ i | x <- xs, isNormalHole x, let Just i = holeTarget x ] == holeNumbers
-      isLambdaLinear xs = List.sort [ rangedThing x | BindHole _ x <- xs ] ==
-                          [ i | (i, h) <- numberedHoles,
-                                LambdaHole x _ <- [namedArg h], rangedThing x /= "_" ]
+      isExprLinear xs =
+        List.sort [ i | x <- xs, isAHole x, let Just i = holeTarget x ]
+          ==
+        holeNumbers
 
-      noAdjacentHoles :: [GenPart] -> Bool
-      noAdjacentHoles []       = __IMPOSSIBLE__
-      noAdjacentHoles [x]      = True
-      noAdjacentHoles (x:y:xs) =
-        not (isAHole x && isAHole y) && noAdjacentHoles (y:xs)
+      isLambdaLinear xs =
+        List.sort [ rangedThing x | VarPart _ x <- xs ]
+          ==
+        [ BoundVariablePosition { holeNumber = i, varNumber = v }
+        | (i, h) <- numberedHoles
+        , LambdaHole vs _ <- [namedArg h]
+        , (v, x) <- zip [0..] $ map rangedThing $ List1.toList vs
+        , x /= "_"
+        ]
 
-      isSingleHole :: [GenPart] -> Bool
+      noAdjacentHoles :: [NotationPart] -> Bool
+      noAdjacentHoles =
+        noAdj .
+        filter (\h -> case h of
+                   HolePart{} -> True
+                   IdPart{}   -> True
+                   _          -> False)
+        where
+        noAdj []       = __IMPOSSIBLE__
+        noAdj [x]      = True
+        noAdj (x:y:xs) =
+          not (isAHole x && isAHole y) &&
+          noAdj (y:xs)
+
+      isSingleHole :: [NotationPart] -> Bool
       isSingleHole = \case
         [ IdPart{} ] -> False
         [ _hole ]    -> True
@@ -260,7 +286,7 @@ notationNames (NewNotation q _ _ parts _) =
 
 -- | Create a 'Notation' (without binders) from a concrete 'Name'.
 --   Does the obvious thing:
---   'Hole's become 'NormalHole's, 'Id's become 'IdParts'.
+--   'Hole's become 'HolePart's, 'Id's become 'IdParts'.
 --   If 'Name' has no 'Hole's, it returns 'noNotation'.
 syntaxOf :: Name -> Notation
 syntaxOf y
@@ -272,7 +298,7 @@ syntaxOf y
     -- Result will have no 'BindingHole's.
     mkSyn :: Int -> [NamePart] -> Notation
     mkSyn n []          = []
-    mkSyn n (Hole : xs) = NormalHole noRange (defaultNamedArg $ unranged n) : mkSyn (1 + n) xs
+    mkSyn n (Hole : xs) = HolePart noRange (defaultNamedArg $ unranged n) : mkSyn (1 + n) xs
     mkSyn n (Id x : xs) = IdPart (unranged x) : mkSyn n xs
 
 -- | Merges 'NewNotation's that have the same precedence level and

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2969,9 +2969,9 @@ toAbstractOpApp op ns es = do
     -- Get the notation for the operator.
     nota <- getNotation op ns
     let parts = notation nota
-    -- We can throw away the @BindingHoles@, since binders
+    -- We can throw away the @VarPart@s, since binders
     -- have been preprocessed into @OpApp C.Expr@.
-    let nonBindingParts = filter (not . isBindingHole) parts
+    let nonBindingParts = filter (not . isBinder) parts
     -- We should be left with as many holes as we have been given args @es@.
     -- If not, crash.
     unless (length (filter isAHole nonBindingParts) == length es) __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1005,14 +1005,14 @@ instance PrettyTCM TypeError where
                sortBy (compare `on` prettyShow . notaName . sectNotation) $
                filter (not . closedWithoutHoles) sects))
       where
-      trimLeft  = dropWhile isNormalHole
-      trimRight = dropWhileEnd isNormalHole
+      trimLeft  = dropWhile isAHole
+      trimRight = dropWhileEnd isAHole
 
       closedWithoutHoles sect =
         sectKind sect == NonfixNotation
           &&
-        null [ () | NormalHole {} <- trimLeft $ trimRight $
-                                       notation (sectNotation sect) ]
+        null [ () | HolePart{} <- trimLeft $ trimRight $
+                                    notation (sectNotation sect) ]
 
       prettyName n = Boxes.text $
         P.render (P.pretty n) ++

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -74,7 +74,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20211019 * 10 + 0
+currentInterfaceVersion = 20211026 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -385,16 +385,21 @@ instance EmbPrj Fixity' where
 
   value = valueN (\ f n -> Fixity' f n noRange)
 
-instance EmbPrj GenPart where
-  icod_ (BindHole a b)   = icodeN 0 BindHole a b
-  icod_ (NormalHole a b) = icodeN 1 NormalHole a b
-  icod_ (WildHole a)     = icodeN 2 WildHole a
-  icod_ (IdPart a)       = icodeN' IdPart a
+instance EmbPrj BoundVariablePosition where
+  icod_ (BoundVariablePosition a b) = icodeN' BoundVariablePosition a b
+
+  value = valueN BoundVariablePosition
+
+instance EmbPrj NotationPart where
+  icod_ (VarPart a b)  = icodeN 0 VarPart a b
+  icod_ (HolePart a b) = icodeN 1 HolePart a b
+  icod_ (WildPart a)   = icodeN 2 WildPart a
+  icod_ (IdPart a)     = icodeN' IdPart a
 
   value = vcase valu where
-    valu [0, a, b] = valuN BindHole a b
-    valu [1, a, b] = valuN NormalHole a b
-    valu [2, a]    = valuN WildHole a
+    valu [0, a, b] = valuN VarPart a b
+    valu [1, a, b] = valuN HolePart a b
+    valu [2, a]    = valuN WildPart a
     valu [a]       = valuN IdPart a
     valu _         = malformed
 

--- a/test/Fail/Issue394-1.agda
+++ b/test/Fail/Issue394-1.agda
@@ -1,0 +1,5 @@
+postulate
+  A : Set
+  F : (A : Set₁) → (A → A → Set) → Set
+
+syntax F A (λ x y → B) = y ⟨ A ∼ B ⟩

--- a/test/Fail/Issue394-1.err
+++ b/test/Fail/Issue394-1.err
@@ -1,0 +1,4 @@
+Issue394-1.agda:5,36-36
+Issue394-1.agda:5,36: Malformed syntax declaration: syntax must use binding holes exactly once
+<EOF><ERROR>
+...

--- a/test/Fail/Issue394-2.agda
+++ b/test/Fail/Issue394-2.agda
@@ -1,0 +1,5 @@
+postulate
+  A : Set
+  F : (A : Set₁) → (A → A → Set) → Set
+
+syntax F A (λ x y → B) = y , y ⟨ A ∼ B ⟩ x

--- a/test/Fail/Issue394-2.err
+++ b/test/Fail/Issue394-2.err
@@ -1,0 +1,4 @@
+Issue394-2.agda:5,42-42
+Issue394-2.agda:5,42: Malformed syntax declaration: syntax must use binding holes exactly once
+<EOF><ERROR>
+...

--- a/test/Fail/Issue394-3.agda
+++ b/test/Fail/Issue394-3.agda
@@ -1,0 +1,5 @@
+postulate
+  A : Set
+  F : (A : Set₁) → (A → A → Set) → Set
+
+syntax F A (λ x y → B) = y ⟨ A ∼ ⟩ x

--- a/test/Fail/Issue394-3.err
+++ b/test/Fail/Issue394-3.err
@@ -1,0 +1,4 @@
+Issue394-3.agda:5,36-36
+Issue394-3.agda:5,36: Malformed syntax declaration: syntax must use holes exactly once
+<EOF><ERROR>
+...

--- a/test/Fail/Issue394-4.agda
+++ b/test/Fail/Issue394-4.agda
@@ -1,0 +1,5 @@
+postulate
+  A : Set
+  F : (A : Set₁) → (A → A → Set) → Set
+
+syntax F A (λ x y → B) = A x B y

--- a/test/Fail/Issue394-4.err
+++ b/test/Fail/Issue394-4.err
@@ -1,0 +1,4 @@
+Issue394-4.agda:5,32-32
+Issue394-4.agda:5,32: Malformed syntax declaration: syntax must not contain adjacent holes (A B)
+<EOF><ERROR>
+...

--- a/test/Succeed/Issue394.agda
+++ b/test/Succeed/Issue394.agda
@@ -1,0 +1,31 @@
+open import Agda.Builtin.Equality
+
+postulate
+  A         : Set
+  F G H I J : (A : Set₁) → (A → A → Set) → Set
+  K         : ⦃ Set → Set → Set ⦄ → { Set → Set → Set } → Set
+
+syntax F A (λ x y → B)               = y ⟨ A ∼ B ⟩₁ x
+syntax G A (λ _ y → B)               = y ⟨ A ∼ B ⟩₂
+syntax H A (λ x _ → B)               =   ⟨ B ∼ A ⟩₃ x
+syntax I A (λ _ _ → B)               =   ⟨ B ∼ A ⟩₄
+syntax J A (λ x y → B)               = x y ∶ A ↝ B
+syntax K ⦃ λ A B → C ⦄ { λ D E → F } = A B C - D E F
+
+_ : (P ⟨ (Set → Set) ∼ P (Q A) ⟩₁ Q) ≡ F (Set → Set) (λ F G → G (F A))
+_ = refl
+
+_ : (P ⟨ (Set → Set) ∼ P A ⟩₂) ≡ G (Set → Set) (λ _ G → G A)
+_ = refl
+
+_ : (⟨ Q A ∼ (Set → Set) ⟩₃ Q) ≡ H (Set → Set) (λ F _ → F A)
+_ = refl
+
+_ : (⟨ A ∼ (Set → Set) ⟩₄) ≡ I (Set → Set) (λ _ _ → A)
+_ = refl
+
+_ : (P Q ∶ (Set → Set) ↝ P (Q A)) ≡ J (Set → Set) (λ F G → F (G A))
+_ = refl
+
+_ : (x x x - x x x) ≡ K ⦃ λ _ x → x ⦄ { λ _ y → y }
+_ = refl


### PR DESCRIPTION
From the changelog:

* It is now OK to put lambda-bound variables anywhere in the right-hand side of a syntax declaration. However, there must always be at least one "identifier" between any two regular "holes". For instance, the following syntax declaration is accepted because `-` is between the holes `B` and `D`.

  ```agda
  postulate
    F : (Set → Set) → (Set → Set) → Set

  syntax F (λ A → B) (λ C → D) = B A C - D
  ```

* Syntax can now use lambdas with multiple arguments ([#394](https://github.com/agda/agda/issues/394)).

  Example:

  ```agda
  postulate
    Σ₂ : (A : Set) → (A → A → Set) → Set

  syntax Σ₂ A (λ x₁ x₂ → P) = [ x₁ x₂ ⦂ A ] × P
  ```

Are there any objections to these changes?