### PR TITLE
Workflows use latest

### DIFF
--- a/.github/workflows/cabal-test.yml
+++ b/.github/workflows/cabal-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         ghc-ver:
-        - latest
+        - 9.0.1
         cabal-ver:
         - latest
         os:
@@ -32,14 +32,22 @@ jobs:
       uses: haskell/actions/setup@v1
       id: setup-haskell
     - run: |
+        export GHC_VER=$(ghc --numeric-version)
+        export CABAL_VER=$(cabal --numeric-version)
+        echo "GHC_VER   = ${GHC_VER}"
+        echo "CABAL_VER = ${CABAL_VER}"
+        echo "GHC_VER=${GHC_VER}"       >> ${GITHUB_ENV}
+        echo "CABAL_VER=${CABAL_VER}"   >> ${GITHUB_ENV}
+      name: Environment settings based on the Haskell setup
+    - run: |
         cabal update
         cabal configure -O1 --enable-tests
       name: Configure the build plan
     - with:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: ${{ runner.os }}-cabal-01-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver
-          }}-${{ hashFiles('**/plan.json') }}
+        key: ${{ runner.os }}-cabal-test-${{ env.GHC_VER }}-${{ env.CABAL_VER }}-${{
+          hashFiles('**/plan.json') }}
       uses: actions/cache@v2
       name: Cache dependencies
       id: cache

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -18,7 +18,7 @@ jobs:
         ghc-ver:
         - 9.0.1
         cabal-ver:
-        - 3.4
+        - latest
         os:
         - windows-latest
         - macos-latest
@@ -35,6 +35,14 @@ jobs:
         ghc-version: ${{ matrix.ghc-ver }}
       uses: haskell/actions/setup@v1
       id: setup-haskell
+    - run: |
+        export GHC_VER=$(ghc --numeric-version)
+        export CABAL_VER=$(cabal --numeric-version)
+        echo "GHC_VER   = ${GHC_VER}"
+        echo "CABAL_VER = ${CABAL_VER}"
+        echo "GHC_VER=${GHC_VER}"       >> ${GITHUB_ENV}
+        echo "CABAL_VER=${CABAL_VER}"   >> ${GITHUB_ENV}
+      name: Environment settings based on the Haskell setup
     - run: |
         cabal update
         cabal configure ${FLAGS} -O0
@@ -60,8 +68,8 @@ jobs:
     - with:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: ${{ runner.os }}-cabal-01-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver
-          }}-${{ hashFiles('**/plan.json') }}
+        key: ${{ runner.os }}-cabal-01-${{ env.GHC_VER }}-${{ env.CABAL_VER }}-${{
+          hashFiles('**/plan.json') }}
       uses: actions/cache@v2
       name: Cache dependencies
       id: cache

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -17,7 +17,7 @@ jobs:
         ghc-ver:
         - 9.0.1
         cabal-ver:
-        - '3.4'
+        - latest
         os:
         - ubuntu-18.04
     runs-on: ${{ matrix.os }}
@@ -29,14 +29,22 @@ jobs:
       uses: haskell/actions/setup@v1
       id: setup-haskell
     - run: |
+        export GHC_VER=$(ghc --numeric-version)
+        export CABAL_VER=$(cabal --numeric-version)
+        echo "GHC_VER    = ${GHC_VER}"
+        echo "CABLAL_VER = ${CABAL_VER}"
+        echo "GHC_VER=${GHC_VER}"         >> ${GITHUB_ENV}
+        echo "CABAL_VER=${CABAL_VER}"     >> ${GITHUB_ENV}
+      name: Environment settings based on the Haskell setup
+    - run: |
         cabal update
         cabal configure -fenable-cluster-counting --enable-tests --disable-library-profiling
       name: Resolve dependencies
     - with:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: ${{ runner.os }}-cabal-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver }}-${{
-          hashFiles('**/plan.json') }}
+        key: ${{ runner.os }}-cabal-${{ env.GHC_VER }}-${{ env.CABAL_VER }}-${{ hashFiles('**/plan.json')
+          }}
       uses: actions/cache@v2
       name: Cache dependencies
       id: cache

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -20,7 +20,6 @@ jobs:
   stack:
     env:
       ICU: mingw-w64-x86_64-icu
-      ARGS: --stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal
       NON_DEFAULT_FLAGS: --flag Agda:enable-cluster-counting --flag Agda:cpphs --flag
         Agda:debug
       EXTRA_ARGS: --fast
@@ -75,11 +74,15 @@ jobs:
         echo "STACK_ROOT (orig) = ${{ env.STACK_ROOT                          }}"
         echo "STACK_ROOT=${{ steps.haskell-setup.outputs.stack-root }}" >> ${GITHUB_ENV}
         echo "STACK_VER=$(stack --numeric-version)"                     >> ${GITHUB_ENV}
-      name: Information about the Haskell setup
+        export GHC_VER=$(ghc --numeric-version)
+        echo "GHC_VER=${GHC_VER}"                                       >> ${GITHUB_ENV}
+        echo "ARGS=--stack-yaml=stack-${GHC_VER}.yaml --no-terminal"    >> ${GITHUB_ENV}
+      name: Environment settings based on the Haskell setup
     - run: |
         echo "STACK_ROOT (fix)  = ${STACK_ROOT}"
         echo "STACK_VER         = ${STACK_VER}"
-      name: More information about the Haskell setup
+        echo "GHC_VER           = ${GHC_VER}"
+      name: Environment (review)
     - run: |
         stack update --silent
         echo "system-ghc: true" >> ${STACK_ROOT}/config.yaml
@@ -88,7 +91,7 @@ jobs:
     - with:
         path: ${{ steps.haskell-setup.outputs.stack-root }}
         key: |
-          ${{ runner.os }}-stack-01-${{ env.STACK_VER }}-${{ hashFiles(format('stack-{0}.yaml.lock', matrix.ghc-ver)) }}
+          ${{ runner.os }}-stack-01-${{ env.STACK_VER }}-${{ hashFiles(format('stack-{0}.yaml.lock', env.GHC_VER)) }}
       uses: actions/cache@v2
       name: Cache dependencies
       id: cache
@@ -103,7 +106,7 @@ jobs:
         # stack exec ${ARGS} -- pacman -U --noconfirm ${ICU_FILE}
         stack exec ${ARGS} -- pacman -S --noconfirm ${ICU}
       name: Install the icu library (Windows)
-    - if: ${{ runner.os == 'Linux' && matrix.ghc-ver == '8.4.4' }}
+    - if: ${{ runner.os == 'Linux' && env.GHC_VER == '8.4.4' }}
       run: |
         sudo apt-get install libnuma-dev -qq
       name: Install the numa library (Ubuntu, GHC 8.4.4)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,6 +227,7 @@ name: Build, Test, and Benchmark
     paths-ignore:
     - .github/*
     - .github/workflows/cabal.yml
+    - .github/workflows/cabal-test.yml
     - .github/workflows/haddock.yml
     - .github/workflows/lint.yml
     - .github/workflows/deploy.yml
@@ -259,6 +260,7 @@ name: Build, Test, and Benchmark
     paths-ignore:
     - .github/*
     - .github/workflows/cabal.yml
+    - .github/workflows/cabal-test.yml
     - .github/workflows/haddock.yml
     - .github/workflows/lint.yml
     - .github/workflows/deploy.yml

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -17,9 +17,9 @@ jobs:
         ghc-ver:
         - 9.0.1
         cabal-ver:
-        - 3.4.0.0
+        - latest
         fix-whitespace-ver:
-        - 0.0.5
+        - 0.0.7
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2

--- a/src/github/workflows/cabal-test.yml
+++ b/src/github/workflows/cabal-test.yml
@@ -49,8 +49,8 @@ jobs:
           ## There is e.g. https://github.com/phile314/tasty-silver/issues/16
           ## that may be responsible that diffs are not shown,
           ## and that prevents me from running the test-suite interactively.
-        ghc-ver: ['latest']
-        cabal-ver: ['latest']
+        ghc-ver: [9.0.1]
+        cabal-ver: [latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/src/github/workflows/cabal-test.yml
+++ b/src/github/workflows/cabal-test.yml
@@ -63,6 +63,16 @@ jobs:
         ghc-version: ${{ matrix.ghc-ver }}
         cabal-version: ${{ matrix.cabal-ver }}
 
+    - name: Environment settings based on the Haskell setup
+      run: |
+        export GHC_VER=$(ghc --numeric-version)
+        export CABAL_VER=$(cabal --numeric-version)
+        echo "GHC_VER   = ${GHC_VER}"
+        echo "CABAL_VER = ${CABAL_VER}"
+        echo "GHC_VER=${GHC_VER}"       >> ${GITHUB_ENV}
+        echo "CABAL_VER=${CABAL_VER}"   >> ${GITHUB_ENV}
+      # From now on, use env.{GHC|CABAL}_VER rather than matrix.{ghc|cabal}-ver!
+
     - name: Configure the build plan
       run: |
         cabal update
@@ -75,7 +85,7 @@ jobs:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
         # The file `plan.json` contains the build information.
-        key: ${{ runner.os }}-cabal-01-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver }}-${{ hashFiles('**/plan.json') }}
+        key: ${{ runner.os }}-cabal-test-${{ env.GHC_VER }}-${{ env.CABAL_VER }}-${{ hashFiles('**/plan.json') }}
 
     - name: Install dependencies
       if: ${{ !steps.cache.outputs.cache-hit }}

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -44,10 +44,11 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-18.04]
         ghc-ver: [9.0.1]
-        cabal-ver: [3.4]
+        cabal-ver: [latest]
     env:
       FLAGS: "-f enable-cluster-counting"
       ICU_URL: 'https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-Win64-MSVC2019.zip'
+
     steps:
     - uses: actions/checkout@v2
       with:

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -59,6 +59,16 @@ jobs:
         ghc-version: ${{ matrix.ghc-ver }}
         cabal-version: ${{ matrix.cabal-ver }}
 
+    - name: Environment settings based on the Haskell setup
+      run: |
+        export GHC_VER=$(ghc --numeric-version)
+        export CABAL_VER=$(cabal --numeric-version)
+        echo "GHC_VER   = ${GHC_VER}"
+        echo "CABAL_VER = ${CABAL_VER}"
+        echo "GHC_VER=${GHC_VER}"       >> ${GITHUB_ENV}
+        echo "CABAL_VER=${CABAL_VER}"   >> ${GITHUB_ENV}
+      # From now on, use env.{GHC|CABAL}_VER rather than matrix.{ghc|cabal}-ver!
+
     - name: Configure the build plan
       run: |
         cabal update
@@ -91,7 +101,7 @@ jobs:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
         # The file `plan.json` contains the build information.
-        key: ${{ runner.os }}-cabal-01-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver }}-${{ hashFiles('**/plan.json') }}
+        key: ${{ runner.os }}-cabal-01-${{ env.GHC_VER }}-${{ env.CABAL_VER }}-${{ hashFiles('**/plan.json') }}
 
     - name: Install dependencies
       if: ${{ !steps.cache.outputs.cache-hit }}

--- a/src/github/workflows/haddock.yml
+++ b/src/github/workflows/haddock.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
-        ghc-ver: ["9.0.1"]
-        cabal-ver: ["3.4"]
+        ghc-ver: ['9.0.1']
+        cabal-ver: [latest]
 
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')

--- a/src/github/workflows/haddock.yml
+++ b/src/github/workflows/haddock.yml
@@ -40,6 +40,16 @@ jobs:
         ghc-version: ${{ matrix.ghc-ver }}
         cabal-version: ${{ matrix.cabal-ver }}
 
+    - name: Environment settings based on the Haskell setup
+      run: |
+        export GHC_VER=$(ghc --numeric-version)
+        export CABAL_VER=$(cabal --numeric-version)
+        echo "GHC_VER    = ${GHC_VER}"
+        echo "CABLAL_VER = ${CABAL_VER}"
+        echo "GHC_VER=${GHC_VER}"         >> ${GITHUB_ENV}
+        echo "CABAL_VER=${CABAL_VER}"     >> ${GITHUB_ENV}
+      # From now on, use env.{GHC|CABAL}_VER rather than matrix.{ghc|cabal}-ver!
+
     - name: Resolve dependencies
       run: |
         cabal update
@@ -52,7 +62,7 @@ jobs:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
         # The file `plan.json` contains the build information.
-        key: ${{ runner.os }}-cabal-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver }}-${{ hashFiles('**/plan.json') }}
+        key: ${{ runner.os }}-cabal-${{ env.GHC_VER }}-${{ env.CABAL_VER }}-${{ hashFiles('**/plan.json') }}
 
     - name: Install dependencies
       if: ${{ !steps.cache.outputs.cache-hit }}

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -53,7 +53,8 @@ jobs:
             stack-ver: latest
 
     env:
-      ARGS: "--stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal"
+      ## ARGS is set later, depending on the actually picked GHC version
+      # ARGS: "--stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal"
       EXTRA_ARGS: "--fast"
       NON_DEFAULT_FLAGS: "--flag Agda:enable-cluster-counting --flag Agda:cpphs --flag Agda:debug"
 
@@ -64,6 +65,7 @@ jobs:
       # ICU_FILE: "mingw-w64-x86_64-icu-68.2-3-any.pkg.tar.zst"
       ICU: "mingw-w64-x86_64-icu"
 
+    # Need bash on Windows for piping and evaluation.
     defaults:
       run:
         shell: bash
@@ -80,7 +82,7 @@ jobs:
         stack-version: ${{ matrix.stack-ver }}
         enable-stack: true
 
-    - name: Information about the Haskell setup
+    - name: Environment settings based on the Haskell setup
       run: |
         echo "runner.os         = ${{ runner.os                               }}"
         echo "OSTYPE            = ${{ env.OSTYPE                              }}"
@@ -95,12 +97,17 @@ jobs:
         echo "STACK_ROOT (orig) = ${{ env.STACK_ROOT                          }}"
         echo "STACK_ROOT=${{ steps.haskell-setup.outputs.stack-root }}" >> ${GITHUB_ENV}
         echo "STACK_VER=$(stack --numeric-version)"                     >> ${GITHUB_ENV}
+        export GHC_VER=$(ghc --numeric-version)
+        echo "GHC_VER=${GHC_VER}"                                       >> ${GITHUB_ENV}
+        echo "ARGS=--stack-yaml=stack-${GHC_VER}.yaml --no-terminal"    >> ${GITHUB_ENV}
+    # From now on, use env.GHC_VER rather than matrix.ghc-ver
 
-    # In a second step we can inspect the GITHUB_ENV set in the previous step:
-    - name: More information about the Haskell setup
+    # In a second step we can inspect and use the GITHUB_ENV set in the previous step:
+    - name: Environment (review)
       run: |
         echo "STACK_ROOT (fix)  = ${STACK_ROOT}"
         echo "STACK_VER         = ${STACK_VER}"
+        echo "GHC_VER           = ${GHC_VER}"
 
     - name: Update and configure stack package index
       ## Using ${{ steps.haskell-setup.outputs.stack-root }} fails because of \-mangling
@@ -118,7 +125,7 @@ jobs:
         # A unique cache is used for each stack.yaml.
         # Note that matrix.stack-ver might be simply 'latest', so we use STACK_VER.
         key: |
-          ${{ runner.os }}-stack-01-${{ env.STACK_VER }}-${{ hashFiles(format('stack-{0}.yaml.lock', matrix.ghc-ver)) }}
+          ${{ runner.os }}-stack-01-${{ env.STACK_VER }}-${{ hashFiles(format('stack-{0}.yaml.lock', env.GHC_VER)) }}
 
     - name: Install the icu library (Ubuntu)
       if: ${{ runner.os == 'Linux' }}
@@ -134,7 +141,7 @@ jobs:
         stack exec ${ARGS} -- pacman -S --noconfirm ${ICU}
 
     - name: Install the numa library (Ubuntu, GHC 8.4.4)
-      if: ${{ runner.os == 'Linux' && matrix.ghc-ver == '8.4.4' }}
+      if: ${{ runner.os == 'Linux' && env.GHC_VER == '8.4.4' }}
       run: |
         sudo apt-get install libnuma-dev -qq
 

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore: &ignore_path_list
     - '.github/*'
     - '.github/workflows/cabal.yml'
+    - '.github/workflows/cabal-test.yml'
     - '.github/workflows/haddock.yml'
     - '.github/workflows/lint.yml'
     - '.github/workflows/deploy.yml'

--- a/src/github/workflows/whitespace.yml
+++ b/src/github/workflows/whitespace.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         ghc-ver: [9.0.1]
-        cabal-ver: [3.4.0.0]
+        cabal-ver: [latest]
         # stack-ver: [2.5.1]
-        fix-whitespace-ver: [0.0.5]
+        fix-whitespace-ver: [0.0.7]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- Use always latest versions of `cabal` and `stack` in workflows.
- Also `windows-latest` and `macOS-latest` work (so far).  
- Atm, we cannot have `ubuntu-latest`, because of ICU dependencies (hardwired lib versions in workflows).
- For `ghc` we can not robustly use `latest` as new releases of major GHC versions typically require lots of adaptation.