### PR TITLE
Fix #5581: Allow tabs in literate parts of a .lagda file

### DIFF
--- a/fix-whitespace.yaml
+++ b/fix-whitespace.yaml
@@ -63,3 +63,5 @@ excluded-files:
   - "test/Fail/TabsInPragmas.agda"
   - "src/full/Agda/Syntax/Parser/Lexer.hs"
   - "test/LaTeXAndHTML/succeed/AccidentalSpacesAfterBeginCode.lagda"
+  - "test/LaTeXAndHTML/succeed/MdDontHighlightCode.html"
+  - "test/LaTeXAndHTML/succeed/MdDontHighlightCode.lagda.md"

--- a/src/full/Agda/Syntax/Parser.hs
+++ b/src/full/Agda/Syntax/Parser.hs
@@ -141,7 +141,7 @@ parseLiterateWithComments p layers = do
   let (terms, overlaps) = interleaveRanges (map Left code) (map Right literate)
 
   forM_ (map fst overlaps) $ \c ->
-    warning$ OverlappingTokensWarning { warnRange = getRange c }
+    warning $ OverlappingTokensWarning { warnRange = getRange c }
 
   return $ forMaybe terms $ \case
     Left t                           -> Just t

--- a/src/full/Agda/Syntax/Parser/Literate.hs
+++ b/src/full/Agda/Syntax/Parser/Literate.hs
@@ -131,10 +131,7 @@ illiterate xs = concat
 -- | Replaces non-space characters in a string with spaces.
 
 bleach :: String -> String
-bleach s = map go s
-  where
-  go c | isSpace c = c
-  go _             = ' '
+bleach = map $ \ c -> if isSpace c && c /= '\t' then c else ' '
 
 -- | Check if a character is a blank character.
 

--- a/src/full/Agda/Syntax/Parser/Literate.hs
+++ b/src/full/Agda/Syntax/Parser/Literate.hs
@@ -21,7 +21,6 @@ module Agda.Syntax.Parser.Literate
   )
   where
 
-import Prelude hiding (getLine)
 import Control.Monad ((<=<))
 import Data.Char (isSpace)
 import Data.List (isPrefixOf)
@@ -34,6 +33,8 @@ import Agda.Syntax.Common
 import Agda.Syntax.Position
 
 import Agda.Utils.List
+import qualified Agda.Utils.List1 as List1
+
 import Agda.Utils.Impossible
 
 -- | Role of a character in the file.
@@ -149,8 +150,12 @@ literateExtsShortList = [".lagda"]
 -- | Returns a tuple consisting of the first line of the input, and the rest
 --   of the input.
 
-getLine :: String -> (String, String)
-getLine = breakAfter (== '\n')
+caseLine :: a -> (String -> String -> a) -> String -> a
+caseLine a k = \case
+  []   -> a
+  x:xs -> k (List1.toList line) rest
+    where
+    (line, rest) = breakAfter1 (== '\n') x xs
 
 -- | Canonical decomposition of an empty literate file.
 
@@ -172,22 +177,18 @@ literateTeX :: Position -> String -> [Layer]
 literateTeX pos s = mkLayers pos (tex s)
   where
   tex :: String -> [(LayerRole, String)]
-  tex [] = []
-  tex s  =
-    let (line, rest) = getLine s in
+  tex = caseLine [] $ \ line rest ->
     case r_begin `matchM` line of
       Just (getAllTextSubmatches -> [_, pre, _, markup, whitespace]) ->
         (Comment, pre) : (Markup, markup) :
         (Code, whitespace) : code rest
       Just _  -> __IMPOSSIBLE__
-      Nothing -> (Comment, line):tex rest
+      Nothing -> (Comment, line) : tex rest
 
   r_begin = rex "(([^\\%]|\\\\.)*)(\\\\begin\\{code\\}[^\n]*)(\n)?"
 
   code :: String -> [(LayerRole, String)]
-  code [] = []
-  code s  =
-    let (line, rest) = getLine s in
+  code = caseLine [] $ \ line rest ->
     case r_end `matchM` line of
       Just (getAllTextSubmatches -> [_, code, markup, post]) ->
         (Code, code) : (Markup, markup) : (Comment, post) : tex rest
@@ -199,12 +200,10 @@ literateTeX pos s = mkLayers pos (tex s)
 -- | Preprocessor for Markdown.
 
 literateMd :: Position -> String -> [Layer]
-literateMd pos s = mkLayers pos$ md s
+literateMd pos s = mkLayers pos $ md s
   where
   md :: String -> [(LayerRole, String)]
-  md [] = []
-  md s  =
-    let (line, rest) = getLine s in
+  md = caseLine [] $ \ line rest ->
     case md_begin `matchM` line of
       Just (getAllTextSubmatches -> [_, pre, markup, _]) ->
         (Comment, pre) : (Markup, markup) : code rest
@@ -219,9 +218,7 @@ literateMd pos s = mkLayers pos$ md s
   md_begin_other = rex "[[:space:]]*```[a-zA-Z0-9-]*[[:space:]]*"
 
   code :: String -> [(LayerRole, String)]
-  code [] = []
-  code s  =
-    let (line, rest) = getLine s in
+  code = caseLine [] $ \ line rest ->
     case md_end `matchM` line of
       Just (getAllTextSubmatches -> [_, markup]) ->
         (Markup, markup) : md rest
@@ -230,9 +227,7 @@ literateMd pos s = mkLayers pos$ md s
 
   -- A non-Agda code block.
   code_other :: String -> [(LayerRole, String)]
-  code_other [] = []
-  code_other s  =
-    let (line, rest) = getLine s in
+  code_other = caseLine [] $ \ line rest ->
     (Comment, line) :
     if md_end `match` line
     then md rest
@@ -243,13 +238,12 @@ literateMd pos s = mkLayers pos$ md s
 -- | Preprocessor for reStructuredText.
 
 literateRsT :: Position -> String -> [Layer]
-literateRsT pos s = mkLayers pos$ rst s
+literateRsT pos s = mkLayers pos $ rst s
   where
   rst :: String -> [(LayerRole, String)]
-  rst [] = []
-  rst s  = maybe_code s
+  rst = caseLine [] maybe_code
 
-  maybe_code s =
+  maybe_code line rest =
     if r_comment `match` line then
       not_code
     else case r_code `match` line of
@@ -262,30 +256,25 @@ literateRsT pos s = mkLayers pos$ rst s
           (Comment, before ++ ":") : (Markup, ":" ++ after) : code rest
       _ -> __IMPOSSIBLE__
     where
-    (line, rest) = getLine s
     not_code     = (Comment, line) : rst rest
 
   -- Finds the next indented block in the input.
   code :: String -> [(LayerRole, String)]
-  code [] = []
-  code s  =
-    let (line, rest) = getLine s in
+  code = caseLine [] $ \ line rest ->
     if all isSpace line then
       (Markup, line) : code rest
     else
       let xs = takeWhile isBlank line in
       if null xs
-      then maybe_code s
+      then maybe_code line rest
       else (Code, line) : indented xs rest
 
   -- Process an indented block.
   indented :: String -> String -> [(LayerRole, String)]
-  indented _ [] = []
-  indented ind s =
-    let (line, rest) = getLine s
-    in  if all isSpace line || (ind `isPrefixOf` line)
+  indented ind = caseLine [] $ \ line rest ->
+    if all isSpace line || (ind `isPrefixOf` line)
           then (Code, line) : indented ind rest
-          else maybe_code s
+          else maybe_code line rest
 
   -- Beginning of a code block.
   r_code = rex "(.*)(::)([[:space:]]*)"
@@ -296,12 +285,10 @@ literateRsT pos s = mkLayers pos$ rst s
 -- | Preprocessor for Org mode documents.
 
 literateOrg :: Position -> String -> [Layer]
-literateOrg pos s = mkLayers pos$ org s
+literateOrg pos s = mkLayers pos $ org s
   where
   org :: String -> [(LayerRole, String)]
-  org [] = []
-  org s  =
-    let (line, rest) = getLine s in
+  org = caseLine [] $ \ line rest ->
     if org_begin `match` line then
       (Markup, line) : code rest
     else
@@ -313,9 +300,7 @@ literateOrg pos s = mkLayers pos$ org s
   org_begin = rex' "\\`(.*)([[:space:]]*\\#\\+begin_src agda2[[:space:]]+)"
 
   code :: String -> [(LayerRole, String)]
-  code [] = []
-  code s  =
-    let (line, rest) = getLine s in
+  code = caseLine [] $ \ line rest ->
     if org_end `match` line then
       (Markup, line) : org rest
     else

--- a/src/full/Agda/Syntax/Parser/Literate.hs
+++ b/src/full/Agda/Syntax/Parser/Literate.hs
@@ -146,22 +146,11 @@ isBlank = (&&) <$> isSpace <*> (/= '\n')
 literateExtsShortList :: [String]
 literateExtsShortList = [".lagda"]
 
--- | Breaks a list just /after/ an element satisfying the predicate is
---   found.
---
---   >>> break1 even [1,3,5,2,4,7,8]
---   ([1,3,5,2],[4,7,8])
-
-break1 :: (a -> Bool) -> [a] -> ([a],[a])
-break1 _ []           =  ([], [])
-break1 p (x:xs) | p x = (x:[],xs)
-break1 p (x:xs)       = let (ys,zs) = break1 p xs in (x:ys,zs)
-
 -- | Returns a tuple consisting of the first line of the input, and the rest
 --   of the input.
 
 getLine :: String -> (String, String)
-getLine = break1 (== '\n')
+getLine = breakAfter (== '\n')
 
 -- | Canonical decomposition of an empty literate file.
 

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -9,6 +9,8 @@ import qualified Data.Array as Array
 import Data.Bifunctor
 import Data.Function
 import qualified Data.List as List
+import qualified Data.List.NonEmpty as List1
+import Data.List.NonEmpty (pattern (:|))
 import Data.Maybe
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -17,6 +19,8 @@ import qualified Agda.Utils.Bag as Bag
 import Agda.Utils.Function (applyWhen)
 import Agda.Utils.Functor  ((<.>))
 import Agda.Utils.Tuple
+
+import {-# SOURCE #-} Agda.Utils.List1 (List1)
 
 import Agda.Utils.Impossible
 
@@ -458,15 +462,16 @@ chop n xs = ys : chop n zs
 --   O(n).
 --
 --    > intercalate [x] (chopWhen (== x) xs) == xs
-chopWhen :: (a -> Bool) -> [a] -> [[a]]
-chopWhen p [] = []
-chopWhen p xs = loop xs
+chopWhen :: forall a. (a -> Bool) -> [a] -> [[a]]
+chopWhen p []     = []
+chopWhen p (x:xs) = loop (x :| xs)
   where
   -- Local function to avoid unnecessary pattern matching.
-  loop xs = case break p xs of
-    (w, [])     -> [w]
-    (w, [_])    -> [w, []]
-    (w, _ : ys) -> w : loop ys  -- here we already know that ys /= []
+  loop :: List1 a -> [[a]]
+  loop xs = case List1.break p xs of
+    (w, []        ) -> [w]
+    (w, _ : []    ) -> [w, []]
+    (w, _ : y : ys) -> w : loop (y :| ys)
 
 ---------------------------------------------------------------------------
 -- * List as sets

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -88,6 +88,15 @@ groupBy' p xxs@(x : xs) = grp x $ List.zipWith (\ x y -> (p x y, y)) xxs xs
       []                 -> []
       ((_false, z) : zs) -> grp z zs
 
+-- | Breaks a list just /after/ an element satisfying the predicate is
+--   found.
+--
+--   >>> breakAfter even [1,3,5,2,4,7,8]
+--   ([1,3,5,2],[4,7,8])
+
+breakAfter :: (a -> Bool) -> List1 a -> (List1 a, [a])
+breakAfter p (x :| xs) = List.breakAfter1 p x xs
+
 -- | Concatenate one or more non-empty lists.
 
 concat :: [List1 a] -> [a]

--- a/src/full/Agda/Utils/List1.hs-boot
+++ b/src/full/Agda/Utils/List1.hs-boot
@@ -1,0 +1,5 @@
+module Agda.Utils.List1 where
+
+import qualified Data.List.NonEmpty (NonEmpty)
+
+type List1 = Data.List.NonEmpty.NonEmpty

--- a/test/LaTeXAndHTML/succeed/MdDontHighlightCode.html
+++ b/test/LaTeXAndHTML/succeed/MdDontHighlightCode.html
@@ -8,8 +8,8 @@
 </a><a id="102" class="Background">
 ### Marisa
 
-&gt; Sure, but you&#39;re still just a tanuki, right?
-&gt; The kind that drums on their bellies on the night of the full moon, right?
+&gt; Sure, but you&#39;re still just a tanuki,	right?
+&gt; The kind that drums on their bellies on the night of the full moon,	right?
 
 </a><a id="240" class="Markup">```agda
 </a><a id="248" class="Keyword">module</a> <a id="TenDesires"></a><a id="255" href="MdDontHighlightCode.html#255" class="Module">TenDesires</a> <a id="266" class="Keyword">where</a>

--- a/test/LaTeXAndHTML/succeed/MdDontHighlightCode.lagda.md
+++ b/test/LaTeXAndHTML/succeed/MdDontHighlightCode.lagda.md
@@ -7,8 +7,8 @@ open import Agda.Builtin.String
 
 ### Marisa
 
-> Sure, but you're still just a tanuki, right?
-> The kind that drums on their bellies on the night of the full moon, right?
+> Sure, but you're still just a tanuki,	right?
+> The kind that drums on their bellies on the night of the full moon,	right?
 
 ```agda
 module TenDesires where


### PR DESCRIPTION
Fix #5581: Allow tabs in literate parts of a .lagda file

Also: Some refactorings in `Literate.hs` and `Agda.Utils.List1?`.