### PR TITLE
Fix `compCCHM` (`primComp`) parameter visibility in primitive library

### DIFF
--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -903,7 +903,7 @@ the following ``BUILTIN``, primitives and postulates:
             → PartialP (primIMax i j) A
 
     -- Computes in terms of primHComp and primTransp
-    primComp : ∀ {a} (A : (i : I) → Set (a i)) (φ : I) → (∀ i → Partial φ (A i)) → (a : A i0) → A i1
+    primComp : ∀ {a} (A : (i : I) → Set (a i)) {φ : I} → (∀ i → Partial φ (A i)) → (a : A i0) → A i1
 
   syntax primPOr p q u t = [ p ↦ u , q ↦ t ]
 


### PR DESCRIPTION
Spotted by a friend. See https://github.com/agda/agda/blob/3185db9f8a4ad507dd73cbc4068cd56805e3cbf9/src/data/lib/prim/Agda/Primitive/Cubical.agda#L66