### PR TITLE
Fix #5588: determine point of generalization in the scope checker, purge `C.Generalized`

### DIFF
--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -119,9 +119,11 @@ pattern Def x = Def' x NoSuffix
 
 -- | Smart constructor for Generalized
 generalized :: Set QName -> Expr -> Expr
-generalized s e
-    | null s    = e
-    | otherwise = Generalized s e
+generalized s
+  | null s    = id
+  | otherwise = \case
+      Generalized s' e -> Generalized (s `Set.union` s') e
+      e                -> Generalized s e
 
 -- | Record field assignment @f = e@.
 type Assign  = FieldAssignment' Expr

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -178,7 +178,6 @@ data Expr
   | DontCare Expr                              -- ^ to print irrelevant things
   | Equal Range Expr Expr                      -- ^ ex: @a = b@, used internally in the parser
   | Ellipsis Range                             -- ^ @...@, used internally to parse patterns.
-  | Generalized Expr
   deriving (Data, Eq)
 
 type OpAppArgs = OpAppArgs' Expr
@@ -668,7 +667,6 @@ returnExpr (Pi _ e)        = returnExpr e
 returnExpr (Fun _ _  e)    = returnExpr e
 returnExpr (Let _ _ e)     = returnExpr =<< e
 returnExpr (Paren _ e)     = returnExpr e
-returnExpr (Generalized e) = returnExpr e
 returnExpr e               = pure e
 
 -- | Turn an expression into a pattern. Fails if the expression is not a
@@ -831,7 +829,6 @@ instance HasRange Expr where
       DontCare{}         -> noRange
       Equal r _ _        -> r
       Ellipsis r         -> r
-      Generalized e      -> getRange e
 
 -- instance HasRange Telescope where
 --     getRange (TeleBind bs) = getRange bs
@@ -1086,7 +1083,6 @@ instance KillRange Expr where
   killRange (DontCare e)          = killRange1 DontCare e
   killRange (Equal _ x y)         = Equal noRange x y
   killRange (Ellipsis _)          = Ellipsis noRange
-  killRange (Generalized e)       = killRange1 Generalized e
 
 instance KillRange LamBinding where
   killRange (DomainFree b) = killRange1 DomainFree b
@@ -1203,7 +1199,6 @@ instance NFData Expr where
   rnf (DontCare a)        = rnf a
   rnf (Equal _ a b)       = rnf a `seq` rnf b
   rnf (Ellipsis _)        = ()
-  rnf (Generalized e)     = rnf e
 
 -- | Ranges are not forced.
 

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -201,10 +201,10 @@ replaceSigs ps = if Map.null ps then id else \case
         let x = if isNoName x' then noName (nameRange x') else x' in
         Just (x, Axiom r acc abst inst argi x' e)
       NiceRecSig r acc abst _ _ x pars t ->
-        let e = Generalized $ makePi (lamBindingsToTelescope r pars) t in
+        let e = makePi (lamBindingsToTelescope r pars) t in
         Just (x, Axiom r acc abst NotInstanceDef defaultArgInfo x e)
       NiceDataSig r acc abst _ _ x pars t ->
-        let e = Generalized $ makePi (lamBindingsToTelescope r pars) t in
+        let e = makePi (lamBindingsToTelescope r pars) t in
         Just (x, Axiom r acc abst NotInstanceDef defaultArgInfo x e)
       _ -> Nothing
 

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -139,7 +139,6 @@ instance ExprLike Expr where
      DontCare e         -> f $ DontCare               $ mapE e
      Equal{}            -> f $ e0
      Ellipsis{}         -> f $ e0
-     Generalized e      -> f $ Generalized            $ mapE e
    where
      mapE :: ExprLike e => e -> e
      mapE = mapExpr f

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -226,7 +226,6 @@ instance Pretty Expr where
             DontCare e -> "." <> parens (pretty e)
             Equal _ a b -> pretty a <+> "=" <+> pretty b
             Ellipsis _  -> "..."
-            Generalized e -> pretty e
         where
           absurd NotHidden  = "()"
           absurd Instance{} = "{{}}"

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -839,7 +839,7 @@ instance ToConcrete A.Expr where
         piTel (A.Pi _ tel e) = first List1.toList $ piTel1 tel e
         piTel e              = ([], e)
 
-    toConcrete (A.Generalized _ e) = C.Generalized <$> toConcrete e
+    toConcrete (A.Generalized _ e) = toConcrete e
 
     toConcrete (A.Fun i a b) =
         bracket piBrackets
@@ -1127,7 +1127,7 @@ instance ToConcrete A.Declaration where
     withAbstractPrivate i $
       withInfixDecl i x'  $ do
       t' <- toConcreteTop t
-      return [C.Generalize (getRange i) [C.TypeSig j tac x' $ C.Generalized t']]
+      return [C.Generalize (getRange i) [C.TypeSig j tac x' t']]
 
   toConcrete (A.Field i x t) = do
     x' <- unsafeQNameToName <$> toConcrete x

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1040,9 +1040,6 @@ instance ToAbstract C.Expr where
   -- DontCare
       C.DontCare e -> A.DontCare <$> toAbstract e
 
-  -- forall-generalize
-      C.Generalized e -> toAbstractGeneralized e
-
 -- | Scope check and prefix with set of generalizable variables.
 toAbstractGeneralized :: C.Expr -> ScopeM A.Expr
 toAbstractGeneralized e = do


### PR DESCRIPTION
Fix #5588: determine point of generalization in the scope checker:

- type signatures (`Axiom`)
- data/record signatures (`Nice{Data|Rec}Sig`)

Remove constructor `Generalized` from `Concrete` syntax.