### PR TITLE
[ cabal ] Bump outdated dependencies

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -251,8 +251,8 @@ library
                 , strict >= 0.3.2 && < 0.5
                 , template-haskell >= 2.11.0.0 && < 2.18
                 , text >= 1.2.3.0 && < 1.3
-                , time >= 1.6.0.1 && < 1.12
-                , transformers == 0.5.*
+                , time >= 1.6.0.1 && < 1.13
+                , transformers >= 0.5 && < 0.7
                 , unordered-containers >= 0.2.5.0 && < 0.3
                 , uri-encode >= 1.5.0.4 && < 1.6
                 , zlib == 0.6.*
@@ -265,21 +265,6 @@ library
   -- The goal is to be able to make (e.g. when a new GHC comes out)
   -- revisions on hackage, e.g. relaxing upper bounds.  This process
   -- currently does not support revising conditionals.
-
-  -- In hs-tags the mtl library must be compiled with the version of
-  -- transformers shipped with GHC, so we use that version in Agda (see,
-  -- for example, Issue #2983).
-  if impl(ghc > 9.0.1)
-    build-depends: transformers >= 0.5.6.2
-
-  if impl(ghc >= 8.6.4) && impl(ghc <= 9.0.1)
-    build-depends: transformers == 0.5.6.2
-
-  if impl(ghc >= 8.4) && impl(ghc < 8.6.4)
-    build-depends: transformers == 0.5.5.0
-
-  if impl(ghc < 8.4)
-    build-depends: transformers == 0.5.2.0
 
   -- ASR (2018-10-16).
   -- text-1.2.3.0 required for supporting GHC 8.4.1, 8.4.2 and
@@ -940,11 +925,16 @@ test-suite agda-tests
                 , tasty-quickcheck >= 0.9.2 && < 0.11
                 -- tasty-silver 3.1.13 has option --ansi-tricks=false
                 -- NB: tasty-silver 3.2 requires tasty >= 1.4
-                , tasty-silver >= 3.1.13 && < 3.3
+                -- tasty-silver < 3.3 does not work interactively under Windows
+                , tasty-silver >= 3.1.13 && < 3.4
                 , temporary >= 1.2.0.3 && < 1.4
                 , text >= 1.2.3.0 && < 1.3
                 , unix-compat >= 0.4.3.1 && < 0.6
                 , uri-encode >= 1.5.0.4 && < 1.6
+
+  -- Andreas (2021-10-11): tasty-silver < 3.3 does not work interactively under Windows
+  if os(windows)
+    build-depends: tasty-silver >= 3.3
 
   -- ASR (2018-10-16).
   -- text-1.2.3.0 required for supporting GHC 8.4.1, 8.4.2 and

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -61,13 +61,14 @@ extra-deps:
 - QuickCheck-2.14.2
 - filemanip-0.3.6.3
 - process-extras-0.7.4
+- silently-1.2.5.1
 - tasty-1.4.1
 - tasty-hunit-0.10.0.3
 - tasty-quickcheck-0.10.1.2
-- tasty-silver-3.2.1
+- tasty-silver-3.3
 - temporary-1.3
 - unix-compat-0.5.3
-- ListLike-4.7.4
+- ListLike-4.7.6
 - ansi-terminal-0.11
 - call-stack-0.3.0
 - clock-0.8.2


### PR DESCRIPTION
Bump outdated dependencies: 
- time
- transformers
- tasty-silver

Since `hs-tags` is decoupled from Agda, the conditionals around `transformers` should be obsolete.