### PR TITLE
Re #5549: latex-html-test: sanitize Agda output (Windows compatibility)

### DIFF
--- a/test/LaTeXAndHTML/Tests.hs
+++ b/test/LaTeXAndHTML/Tests.hs
@@ -194,9 +194,12 @@ mkLaTeXOrHTMLTest k copy agdaBin testDir inp =
                    , "--no-libraries"
                    ] ++ extraFlags
     when copy $ copyFile inp newFile
-    res@(ret, _, _) <- PT.readProcessWithExitCode agdaBin agdaArgs T.empty
-    if ret /= ExitSuccess then
-      return $ AgdaFailed (toProgramResult res)
+    (exitcode, out, err) <- PT.readProcessWithExitCode agdaBin agdaArgs T.empty
+    if exitcode /= ExitSuccess then
+      AgdaFailed <$> do
+        ProgramResult exitcode
+          <$> cleanOutput out
+          <*> cleanOutput err
     else do
       output <- decodeUtf8 <$> BS.readFile (outDir </> outFileName)
       let done    = return $ Success output

--- a/test/LaTeXAndHTML/fail/Issue2453.html
+++ b/test/LaTeXAndHTML/fail/Issue2453.html
@@ -1,3 +1,3 @@
 AGDA_COMPILE_FAILED
 
-ret > ExitFailure 42 out > /test/LaTeXAndHTML/fail/Issue2453.lagda:10,14-14 out > /test/LaTeXAndHTML/fail/Issue2453.lagda:10,14: Missing body for lambda out > <EOF><ERROR> out > ... out >
+ret > ExitFailure 42 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14-14 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14: Missing body for lambda out > <EOF><ERROR> out > ... out >

--- a/test/LaTeXAndHTML/fail/Issue2453.quick.tex
+++ b/test/LaTeXAndHTML/fail/Issue2453.quick.tex
@@ -1,3 +1,3 @@
 AGDA_COMPILE_FAILED
 
-ret > ExitFailure 42 out > /test/LaTeXAndHTML/fail/Issue2453.lagda:10,14-14 out > /test/LaTeXAndHTML/fail/Issue2453.lagda:10,14: Missing body for lambda out > <EOF><ERROR> out > ... out >
+ret > ExitFailure 42 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14-14 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14: Missing body for lambda out > <EOF><ERROR> out > ... out >

--- a/test/LaTeXAndHTML/fail/Issue2453.tex
+++ b/test/LaTeXAndHTML/fail/Issue2453.tex
@@ -1,3 +1,3 @@
 AGDA_COMPILE_FAILED
 
-ret > ExitFailure 42 out > /test/LaTeXAndHTML/fail/Issue2453.lagda:10,14-14 out > /test/LaTeXAndHTML/fail/Issue2453.lagda:10,14: Missing body for lambda out > <EOF><ERROR> out > ... out >
+ret > ExitFailure 42 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14-14 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14: Missing body for lambda out > <EOF><ERROR> out > ... out >


### PR DESCRIPTION
Re #5549: `latex-html-test`: sanitize Agda output, just like for the other test suites.  This might help with Windows compatibility.