### PR TITLE
Fix #5610 for real now

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -48,7 +48,9 @@ typeOfFlat = hPi "a" (el primLevel) $
 -- definition.
 
 bindBuiltinInf :: ResolvedName -> TCM ()
-bindBuiltinInf x = bindPostulatedName builtinInf x $ \inf _ -> return $ Def inf []
+bindBuiltinInf x = bindPostulatedName builtinInf x $ \inf _ -> do
+  _ <- checkExpr (A.Def inf) =<< typeOfInf
+  return $ Def inf []
 
 -- | Binds the SHARP builtin, and changes the definitions of INFINITY
 -- and SHARP.
@@ -63,7 +65,7 @@ bindBuiltinSharp x =
   bindPostulatedName builtinSharp x $ \sharp sharpDefn -> do
     sharpType <- typeOfSharp
     TelV fieldTel _ <- telView sharpType
-    let sharpE = Def sharp []
+    _ <- checkExpr (A.Def sharp) sharpType
     Def inf _ <- primInf
     infDefn   <- getConstInfo inf
     addConstant (defName infDefn) $
@@ -98,7 +100,7 @@ bindBuiltinSharp x =
                     , conErased = Nothing
                     }
                 }
-    return sharpE
+    return $ Def sharp []
 
 -- | Binds the FLAT builtin, and changes its definition.
 
@@ -110,7 +112,7 @@ bindBuiltinSharp x =
 bindBuiltinFlat :: ResolvedName -> TCM ()
 bindBuiltinFlat x =
   bindPostulatedName builtinFlat x $ \ flat flatDefn -> do
-    let flatE   = Def flat []
+    _ <- checkExpr (A.Def flat) =<< typeOfFlat
     Def sharp _ <- primSharp
     kit         <- requireLevels
     Def inf _   <- primInf
@@ -164,7 +166,7 @@ bindBuiltinFlat x =
       def { conSrcCon = sharpCon }
     modifySignature $ updateDefinition inf $ updateTheDef $ \ def ->
       def { recConHead = sharpCon, recFields = [defaultDom flat] }
-    return flatE
+    return $ Def flat []
 
 -- The coinductive primitives.
 -- moved to TypeChecking.Monad.Builtin

--- a/test/Fail/BuiltinFlatBadType.agda
+++ b/test/Fail/BuiltinFlatBadType.agda
@@ -1,0 +1,10 @@
+data ⊥ : Set where
+
+postulate
+  ∞  : ∀ {a} (A : Set a) → Set a
+  ♯_ : ∀ {a} {A : Set a} → A → ∞ A
+  ♭  : ∀ {a} {A : Set a} → ∞ A → A → ⊥
+
+{-# BUILTIN INFINITY ∞  #-}
+{-# BUILTIN SHARP    ♯_ #-}
+{-# BUILTIN FLAT     ♭  #-}

--- a/test/Fail/BuiltinFlatBadType.agda
+++ b/test/Fail/BuiltinFlatBadType.agda
@@ -8,23 +8,3 @@ postulate
 {-# BUILTIN INFINITY ∞  #-}
 {-# BUILTIN SHARP    ♯_ #-}
 {-# BUILTIN FLAT     ♭  #-}
-
--- Issue #5610: with these bad types for sharp and flat, we can prove
--- false. The reason is that ∞ is assumed to be strictly-positive in
--- the positivity checker (even guarding positive). So making ∞ A
--- isomorphic to A → ⊥ will be contradictory to this assumption.
-
-data D : Set where
-  wrap : ∞ D → D
-
-lam : (D → ⊥) → D
-lam f = wrap (♯ f)
-
-app : D → D → ⊥
-app (wrap g) d = ♭ g d
-
-delta : D
-delta = lam (λ x → app x x)
-
-omega : ⊥
-omega = app delta delta

--- a/test/Fail/BuiltinFlatBadType.agda
+++ b/test/Fail/BuiltinFlatBadType.agda
@@ -8,3 +8,23 @@ postulate
 {-# BUILTIN INFINITY ∞  #-}
 {-# BUILTIN SHARP    ♯_ #-}
 {-# BUILTIN FLAT     ♭  #-}
+
+-- Issue #5610: with these bad types for sharp and flat, we can prove
+-- false. The reason is that ∞ is assumed to be strictly-positive in
+-- the positivity checker (even guarding positive). So making ∞ A
+-- isomorphic to A → ⊥ will be contradictory to this assumption.
+
+data D : Set where
+  wrap : ∞ D → D
+
+lam : (D → ⊥) → D
+lam f = wrap (♯ f)
+
+app : D → D → ⊥
+app (wrap g) d = ♭ g d
+
+delta : D
+delta = lam (λ x → app x x)
+
+omega : ⊥
+omega = app delta delta

--- a/test/Fail/BuiltinFlatBadType.err
+++ b/test/Fail/BuiltinFlatBadType.err
@@ -1,0 +1,3 @@
+BuiltinFlatBadType.agda:10,22-23
+A → ⊥ !=< A
+when checking that the expression ♭ has type ∞ A → A

--- a/test/Fail/BuiltinInfinityBadType.agda
+++ b/test/Fail/BuiltinInfinityBadType.agda
@@ -1,0 +1,7 @@
+
+open import Agda.Primitive
+
+postulate
+  ∞  : ∀ {a} (A : Set a) → Set (lsuc a)
+
+{-# BUILTIN INFINITY ∞  #-}

--- a/test/Fail/BuiltinInfinityBadType.err
+++ b/test/Fail/BuiltinInfinityBadType.err
@@ -1,0 +1,3 @@
+BuiltinInfinityBadType.agda:7,22-23
+Set (lsuc a) != Set a
+when checking that the expression ∞ has type Set a → Set a

--- a/test/Fail/BuiltinSharpBadType.agda
+++ b/test/Fail/BuiltinSharpBadType.agda
@@ -4,6 +4,28 @@ data ⊥ : Set where
 postulate
   ∞  : ∀ {a} → Set a → Set a
   ♯_ : ∀ {a} {A : Set a} → (A → ⊥) → ∞ A
+  ♭  : ∀ {a} {A : Set a} → ∞ A → A → ⊥
 
 {-# BUILTIN INFINITY ∞  #-}
 {-# BUILTIN SHARP    ♯_ #-}
+{-# BUILTIN FLAT     ♭  #-}
+
+-- Issue #5610: with these bad types for sharp and flat, we can prove
+-- false. The reason is that ∞ is assumed to be strictly-positive in
+-- the positivity checker (even guarding positive). So making ∞ A
+-- isomorphic to A → ⊥ will be contradictory to this assumption.
+
+data D : Set where
+  wrap : ∞ D → D
+
+lam : (D → ⊥) → D
+lam f = wrap (♯ f)
+
+app : D → D → ⊥
+app (wrap g) d = ♭ g d
+
+delta : D
+delta = lam (λ x → app x x)
+
+omega : ⊥
+omega = app delta delta

--- a/test/Fail/BuiltinSharpBadType.agda
+++ b/test/Fail/BuiltinSharpBadType.agda
@@ -1,0 +1,9 @@
+
+data ⊥ : Set where
+
+postulate
+  ∞  : ∀ {a} → Set a → Set a
+  ♯_ : ∀ {a} {A : Set a} → (A → ⊥) → ∞ A
+
+{-# BUILTIN INFINITY ∞  #-}
+{-# BUILTIN SHARP    ♯_ #-}

--- a/test/Fail/BuiltinSharpBadType.err
+++ b/test/Fail/BuiltinSharpBadType.err
@@ -1,3 +1,3 @@
-BuiltinSharpBadType.agda:9,22-24
-A !=< _A_11 → ⊥
+BuiltinSharpBadType.agda:10,22-24
+A !=< _A_17 → ⊥
 when checking that the expression ♯_ has type A → ∞ A

--- a/test/Fail/BuiltinSharpBadType.err
+++ b/test/Fail/BuiltinSharpBadType.err
@@ -1,0 +1,3 @@
+BuiltinSharpBadType.agda:9,22-24
+A !=< _A_11 → ⊥
+when checking that the expression ♯_ has type A → ∞ A


### PR DESCRIPTION
Re-insert necessary checks on types of built-in coinduction primitives