### PR TITLE
[ user manual ] Add warning not to install emacs-mode from melpa

### DIFF
--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -163,7 +163,7 @@ GHC version, respectively.
 
 Running the ``agda-mode`` program
 ---------------------------------
-**Warning**: Intalling ``agda-mode`` via ``melpa`` is discouraged.  
+**Warning**: Intalling ``agda-mode`` via ``melpa`` is discouraged.
 It is stronly advised to install ``agda-mode`` for ``emacs`` as described below:
 
 After installing the ``agda-mode`` program using ``cabal`` or

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -163,6 +163,8 @@ GHC version, respectively.
 
 Running the ``agda-mode`` program
 ---------------------------------
+**Warning**: Intalling ``agda-mode`` via ``melpa`` is discouraged.  
+It is stronly advised to install ``agda-mode`` for ``emacs`` as described below:
 
 After installing the ``agda-mode`` program using ``cabal`` or
 ``stack`` run the following command:


### PR DESCRIPTION
I added a warning about using agda-mode package from emacs melpa, as discussed [here](https://github.com/agda/agda/issues/5578) 