### PR TITLE
[ re #5579 #5576 ] Less injecitivity with --cubical

### DIFF
--- a/src/full/Agda/TypeChecking/Datatypes.hs
+++ b/src/full/Agda/TypeChecking/Datatypes.hs
@@ -68,6 +68,15 @@ consOfHIT c = do
     Record{} -> return False
     _  -> __IMPOSSIBLE__
 
+isPathCons :: HasConstInfo m => QName -> m Bool
+isPathCons c = do
+  d <- getConstructorData c
+  def <- theDef <$> getConstInfo d
+  case def of
+    Datatype {dataPathCons = xs} -> return $ c `elem` xs
+    Record{} -> return False
+    _  -> __IMPOSSIBLE__
+
 -- | @getConType c t@ computes the constructor parameters from type @t@
 --   and returns them plus the instantiated type of constructor @c@.
 --   This works also if @t@ is a function type ending in a data/record type;

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -58,6 +58,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
 
+import Agda.TypeChecking.Datatypes
 import Agda.TypeChecking.Irrelevance (isIrrelevantOrPropM)
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute
@@ -67,6 +68,8 @@ import {-# SOURCE #-} Agda.TypeChecking.Conversion
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Polarity
 import Agda.TypeChecking.Warnings
+
+import Agda.Interaction.Options
 
 import Agda.Utils.Either
 import Agda.Utils.Functor
@@ -104,14 +107,16 @@ headSymbol v = do -- ignoreAbstractMode $ do
             fs <- mutualNames <$> lookupMutualBlock mb
             if Set.member f fs then no else yes
         Function{}    -> no
-        Primitive{primName} | primName == builtinHComp -> yes -- TODO 3733: only if it's a HIT or indexed fam.
-                            | otherwise -> no
+        Primitive{}   -> no
         PrimitiveSort{} -> no
         GeneralizableVar{} -> __IMPOSSIBLE__
         Constructor{} -> __IMPOSSIBLE__
         AbstractDefn{}-> __IMPOSSIBLE__
     -- Andreas, 2019-07-10, issue #3900: canonicalName needs ignoreAbstractMode
-    Con c _ _ -> ignoreAbstractMode $ Just . ConsHead <$> canonicalName (conName c)
+    Con c _ _ -> ignoreAbstractMode $ do
+                 q <- canonicalName (conName c)
+                 ifM (isPathCons q) (return Nothing) $
+                     {- else -}     return $ Just $ ConsHead q
     Sort _  -> return (Just SortHead)
     Pi _ _  -> return (Just PiHead)
     Var i [] -> return (Just $ VarHead i) -- Only naked variables. Otherwise substituting a neutral term is not guaranteed to stay neutral.
@@ -190,7 +195,7 @@ checkInjectivity' f cs = fromMaybe NotInjective <.> runMaybeT $ do
 
   -- We don't need to consider absurd clauses
   let computeHead c | hasDefP (namedClausePats c) = return []
-      -- re #3733 TODO: properly handle transpX/hcomp clauses above.
+      -- hasDefP clauses are skipped, these matter only for --cubical, in which case the function will behave as NotInjective.
       computeHead c@Clause{ clauseBody = Just body , clauseType = Just tbody } = do
         maybeIrr <- fromRight (const True) <.> runBlocked $ isIrrelevantOrPropM tbody
         h <- if maybeIrr then return UnknownHead else
@@ -214,8 +219,9 @@ checkInjectivity' f cs = fromMaybe NotInjective <.> runMaybeT $ do
       case uc of
         [c] -> prettyTCM $ map namedArg $ namedClausePats c
         _   -> "(multiple clauses)"
-
-  return $ Inverse hdMap
+  let cond | any (hasDefP . namedClausePats) cs = UnlessCubical
+           | otherwise                          = AlwaysInjective
+  return $ Inverse cond hdMap
 
 -- | If a clause is over-applied we can't trust the head (Issue 2944). For
 --   instance, the clause might be `f ps = u , v` and the actual call `f vs
@@ -275,9 +281,11 @@ functionInverse
 functionInverse = \case
   Def f es -> do
     inv <- defInverse <$> getConstInfo f
+    cubical <- optCubical <$> pragmaOptions
     case inv of
       NotInjective -> return NoInv
-      Inverse m    -> maybe NoInv (Inv f es) <$> (traverse (checkOverapplication es) =<< instantiateVarHeads f es m)
+      Inverse UnlessCubical m | isJust cubical -> return NoInv
+      Inverse w m -> maybe NoInv (Inv f es) <$> (traverse (checkOverapplication es) =<< instantiateVarHeads f es m)
         -- NB: Invertible functions are never classified as
         --     projection-like, so this is fine, we are not
         --     missing parameters.  (Andreas, 2013-11-01)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2238,7 +2238,7 @@ instance Pretty Projection where
 
 instance Pretty c => Pretty (FunctionInverse' c) where
   pretty NotInjective = "NotInjective"
-  pretty (Inverse inv) = "Inverse" <?>
+  pretty (Inverse w inv) = "Inverse" <+> text (show w) <?>
     vcat [ pretty h <+> "->" <?> pretty cs
          | (h, cs) <- Map.toList inv ]
 
@@ -2529,9 +2529,11 @@ defForced d = case theDef d of
 type FunctionInverse = FunctionInverse' Clause
 type InversionMap c = Map TermHead [c]
 
+data WhenInjective = AlwaysInjective | UnlessCubical deriving (Data,Show,Generic)
+
 data FunctionInverse' c
   = NotInjective
-  | Inverse (InversionMap c)
+  | Inverse WhenInjective (InversionMap c)
   deriving (Data, Show, Functor, Generic)
 
 data TermHead = SortHead
@@ -4594,7 +4596,7 @@ instance KillRange MutualId where
 
 instance KillRange c => KillRange (FunctionInverse' c) where
   killRange NotInjective = NotInjective
-  killRange (Inverse m)  = Inverse $ killRangeMap m
+  killRange (Inverse w m)  = Inverse w $ killRangeMap m
 
 instance KillRange TermHead where
   killRange SortHead     = SortHead
@@ -4717,6 +4719,7 @@ instance NFData Simplification
 instance NFData AllowedReduction
 instance NFData ReduceDefs
 instance NFData PrimFun
+instance NFData WhenInjective
 instance NFData c => NFData (FunctionInverse' c)
 instance NFData TermHead
 instance NFData Call

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1492,7 +1492,7 @@ instance InstantiateFull System where
 
 instance InstantiateFull FunctionInverse where
   instantiateFull' NotInjective = return NotInjective
-  instantiateFull' (Inverse inv) = Inverse <$> instantiateFull' inv
+  instantiateFull' (Inverse w inv) = Inverse w <$> instantiateFull' inv
 
 instance InstantiateFull a => InstantiateFull (Case a) where
   instantiateFull' (Branches cop cs eta ls m b lz) =

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -451,13 +451,22 @@ instance EmbPrj CompiledClauses where
     valu [2, a, b] = valuN Case a b
     valu _         = malformed
 
+instance EmbPrj WhenInjective where
+  icod_ AlwaysInjective = icodeN 0 AlwaysInjective
+  icod_ UnlessCubical   = icodeN 1 UnlessCubical
+
+  value = vcase valu where
+    valu [0] = valuN AlwaysInjective
+    valu [1] = valuN UnlessCubical
+    valu _   = malformed
+
 instance EmbPrj a => EmbPrj (FunctionInverse' a) where
   icod_ NotInjective = icodeN' NotInjective
-  icod_ (Inverse a)  = icodeN' Inverse a
+  icod_ (Inverse w a)  = icodeN' Inverse w a
 
   value = vcase valu where
     valu []  = valuN NotInjective
-    valu [a] = valuN Inverse a
+    valu [w,a] = valuN Inverse w a
     valu _   = malformed
 
 instance EmbPrj TermHead where

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -508,7 +508,7 @@ instance Apply a => Apply (Case a) where
 
 instance Apply FunctionInverse where
   apply NotInjective  args = NotInjective
-  apply (Inverse inv) args = Inverse $ apply inv args
+  apply (Inverse w inv) args = Inverse w $ apply inv args
 
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
 
@@ -741,7 +741,7 @@ namedTelVars m (ExtendTel !dom tel) =
 
 instance Abstract FunctionInverse where
   abstract tel NotInjective  = NotInjective
-  abstract tel (Inverse inv) = Inverse $ abstract tel inv
+  abstract tel (Inverse w inv) = Inverse w $ abstract tel inv
 
 instance {-# OVERLAPPABLE #-} Abstract t => Abstract [t] where
   abstract tel = map (abstract tel)

--- a/test/Fail/InjectivityHITs.agda
+++ b/test/Fail/InjectivityHITs.agda
@@ -1,0 +1,50 @@
+{-# OPTIONS --cubical #-}
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Primitive
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Bool
+
+variable
+  a p         : Level
+  A           : Set a
+  P           : A → Set p
+  x y : A
+
+refl : x ≡ x
+refl {x = x} = λ _ → x
+
+
+data 𝕊¹ : Set where
+  base : 𝕊¹
+  loop : base ≡ base
+
+
+g : Bool → I → 𝕊¹
+g true i = base
+g false i = loop i
+
+_ : g false i0 ≡ base
+_ = refl
+
+_ : g true i0 ≡ base
+_ = refl
+
+-- non-unique solutions, should not solve either of the metas.
+_ : g _ _ ≡ base
+_ = refl
+
+
+h : Bool → base ≡ base
+h true = \ _ → base
+h false = loop
+
+_ : h false i0 ≡ base
+_ = refl
+
+_ : h true i0 ≡ base
+_ = refl
+
+-- non-unique solutions, should not solve either of the metas.
+_ : h _ _ ≡ base
+_ = refl

--- a/test/Fail/InjectivityHITs.err
+++ b/test/Fail/InjectivityHITs.err
@@ -1,0 +1,10 @@
+Failed to solve the following constraints:
+  h _75 _76 = base : 𝕊¹ (blocked on all(_75, _76))
+  g _49 _50 = base : 𝕊¹ (blocked on _49)
+Unsolved metas at the following locations:
+  InjectivityHITs.agda:34,7-8
+  InjectivityHITs.agda:34,9-10
+  InjectivityHITs.agda:35,5-9
+  InjectivityHITs.agda:49,7-8
+  InjectivityHITs.agda:49,9-10
+  InjectivityHITs.agda:50,5-9

--- a/test/Succeed/InjectivityHITs.agda
+++ b/test/Succeed/InjectivityHITs.agda
@@ -1,0 +1,33 @@
+{-# OPTIONS --cubical #-}
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Primitive
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Bool
+
+variable
+  a p         : Level
+  A           : Set a
+  P           : A → Set p
+  x y : A
+
+refl : x ≡ x
+refl {x = x} = λ _ → x
+
+
+
+data Interval : Set where
+  left right : Interval
+  line : left ≡ right
+
+h2 : Bool → Interval
+h2 true = left
+h2 false = right
+
+-- `left` and `right` are distinct canonical forms,
+-- so `h2 ? = left` imples `? = true`.
+--
+-- Added this test to make sure we do not always give up on
+-- injectivity when targeting a HIT.
+_ : h2 _ ≡ left
+_ = refl

--- a/test/Succeed/Issue5576.agda
+++ b/test/Succeed/Issue5576.agda
@@ -1,0 +1,75 @@
+{-# OPTIONS --cubical #-}
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Primitive
+open import Agda.Primitive.Cubical
+
+variable
+  a p         : Level
+  A           : Set a
+  P           : A → Set p
+  eq₁ u v x y : A
+
+refl : x ≡ x
+refl {x = x} = λ _ → x
+
+subst : (P : A → Set p) → x ≡ y → P x → P y
+subst P x≡y p = primTransp (λ i → P (x≡y i)) i0 p
+
+hcong :
+  (f : (x : A) → P x) (x≡y : x ≡ y) →
+  PathP (λ i → P (x≡y i)) (f x) (f y)
+hcong f x≡y = λ i → f (x≡y i)
+
+dcong :
+  (f : (x : A) → P x) (x≡y : x ≡ y) →
+  subst P x≡y (f x) ≡ f y
+dcong {P = P} f x≡y = λ i →
+  primTransp (λ j → P (x≡y (primIMax i j))) i (f (x≡y i))
+
+-- This lemma is due to Anders Mörtberg.
+
+lemma₁ :
+  {P : I → Set p} {p : P i0} {q : P i1} →
+  PathP P p q ≡ (primTransp P i0 p ≡ q)
+lemma₁ {P = P} {p = p} {q = q} = λ i →
+  PathP
+    (λ j → P (primIMax i j))
+    (primTransp (λ j → P (primIMin i j)) (primINeg i) p)
+    q
+
+data 𝕊¹ : Set where
+  base : 𝕊¹
+  loop : base ≡ base
+
+postulate
+
+  Q : 𝕊¹ → Set
+  b : Q base
+  ℓ : subst Q loop b ≡ b
+
+lemma₂ :
+  {eq : x ≡ y} →
+  subst Q eq u ≡ v →
+  PathP (λ i → Q (eq i)) u v
+lemma₂ = subst (λ A → A → PathP _ _ _) lemma₁ (λ x → x)
+
+lemma₃ : (x : 𝕊¹) → Q x
+lemma₃ base     = b
+lemma₃ (loop i) = lemma₂ ℓ i
+
+postulate
+
+  lemma₄ :
+    (eq₂ : subst Q eq₁ (lemma₃ x) ≡ lemma₃ y) →
+    hcong lemma₃ eq₁ ≡ lemma₂ eq₂ →
+    dcong lemma₃ eq₁ ≡ eq₂
+
+
+works : dcong lemma₃ loop ≡ ℓ
+works = lemma₄ ℓ refl
+
+
+-- "injectivity" of lemma₃ was the problem
+should-work-too : dcong lemma₃ loop ≡ ℓ
+should-work-too = lemma₄ _ refl

--- a/test/Succeed/Issue5579.agda
+++ b/test/Succeed/Issue5579.agda
@@ -1,0 +1,40 @@
+{-# OPTIONS --cubical --allow-unsolved-metas #-}
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Bool
+
+postulate
+  Index : Set
+  i     : Index
+
+data D : Index →  Set where
+  c : D i
+
+cong : {A B : Set} (x y : A) (f : A → B) → x ≡ y → f x ≡ f y
+cong _ _ f x≡y = λ i → f (x≡y i)
+
+refl : {A : Set} {x : A} → x ≡ x
+refl {x = x} = λ _ → x
+
+subst :
+  {A : Set} {x y : A}
+  (P : A → Set) → x ≡ y → P x → P y
+subst P eq p = primTransp (λ i → P (eq i)) i0 p
+
+postulate
+  subst-refl :
+    {A : Set} {x : A} (P : A → Set) {p : P x} →
+    subst P refl p ≡ p
+
+f : {i : Index} (xs : D i) → D i
+f c = c
+
+
+works : f (subst D refl c) ≡ c
+works = cong (subst D refl c) c f (subst-refl D)
+
+-- There is no type error here, just a meta to solve.
+-- The original problem was assuming injectivity of f.
+should-work-too : f (subst D refl c) ≡ c
+should-work-too = cong _ _ f (subst-refl D)


### PR DESCRIPTION
Made the Injectivity machinery more conservative in the presence of
cubical primitives. Some functions on non-indexed HITs might be caught
in the crossfire, but I opted for simplicity atm:

- if --cubical and there are clauses matching on hcomp/transpX, then
  the function is `NotInjective`.

- also, path constructors do not count as `ConsHead`.

The above should not impact `useInjectivity` when only --without-K is
enabled.