### PR TITLE
Some changes related to the DOT backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,3 +134,13 @@ LaTeX backend
 * Italics correction (inserted by `\textit` e.g. in `\AgdaBound`) now works,
   thanks to moving the `\textcolor` wrapping to the outside in `agda.sty`
   (see [#5471](https://github.com/agda/agda/issues/5471)).
+
+DOT backend
+-----------
+
+* The new option `--dependency-graph-include=LIBRARY` can be used to
+  restrict the dependency graph to modules from one or more libraries
+  (see [#5634](https://github.com/agda/agda/issues/5634)).
+
+  Note that the module given on the command line might not be
+  included.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,3 +144,7 @@ DOT backend
 
   Note that the module given on the command line might not be
   included.
+
+* The generated graphs no longer contain "redundant" edges: if a
+  module is imported both directly and indirectly, then the edge
+  corresponding to the direct import is omitted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,18 @@ Syntax
   syntax Σ₂ A (λ x₁ x₂ → P) = [ x₁ x₂ ⦂ A ] × P
   ```
 
+Library management
+------------------
+
+* Library files below the "project root" are now ignored
+  (see [#5644](https://github.com/agda/agda/issues/5644)).
+
+  For instance, if you have a module called `A.B.C` in the directory
+  `Root/A/B`, then `.agda-lib` files in `Root/A` or `Root/A/B` do not
+  affect what options are used to type-check `A.B.C`: `.agda-lib`
+  files for `A.B.C` have to reside in `Root`, or further up the
+  directory hierarchy.
+
 Compiler backends
 -----------------
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -99,6 +99,20 @@ Generating highlighted source code
 
      Generate a Dot_ file ``FILE`` with a module dependency graph.
 
+.. option:: --dependency-graph-include={LIBRARY}
+
+     Include modules from the given library in the dependency graph.
+     This option can be used multiple times to include modules from
+     several libraries. If this option is not used at all, then all
+     modules are included. (Note that the module given on the command
+     line might not be included.)
+
+     A module ``M`` is considered to be in the library ``L`` if ``L``
+     is the ``name`` of a ``.agda-lib`` file ``A``
+     :ref:`associated<The_agda-lib_files_associated_to_a_give_Agda_file>`
+     to ``M`` (even if ``M``'s file can not be found via the
+     ``include`` paths in ``A``).
+
 .. option:: --html
 
      Generate HTML files with highlighted source code (see

--- a/doc/user-manual/tools/package-system.rst
+++ b/doc/user-manual/tools/package-system.rst
@@ -93,6 +93,31 @@ Naturally, unnamed libraries cannot be depended upon.
 But dropping the ``name`` is possible if the library file only serves to list
 include paths and/or dependencies of the current project.
 
+.. _The_agda-lib_files_associated_to_a_give_Agda_file:
+
+The ``.agda-lib`` files associated to a given Agda file
+-------------------------------------------------------
+
+When a given file is type-checked Agda uses the options from the
+``flags`` field of zero or more library files. These files are found
+in the following way:
+
+- First the file's root directory is found. If the top-level module in
+  the file is called ``A.B.C``, then it has to be in the directory
+  ``root/A/B`` or ``root\A\B``. The root directory is the directory
+  ``root``.
+
+- If ``root`` contains any ``.agda-lib`` files, then these files are
+  used.
+
+- Otherwise a search is made upwards in the directory hierarchy, and
+  the search stops once one or more ``.agda-lib`` files are found in a
+  directory. If no ``.agda-lib`` files are found, then none are used.
+
+Note that if the search finds two or more ``.agda-lib`` files, then
+the flags from all of these files are used, and flags from different
+files are ordered in an unspecified way.
+
 Installing libraries
 --------------------
 

--- a/src/full/Agda/Interaction/Highlighting/Dot/Backend.hs
+++ b/src/full/Agda/Interaction/Highlighting/Dot/Backend.hs
@@ -224,8 +224,14 @@ postCompileDot cenv _main modulesByName =
   moduleGraph :: Graph (WithUniqueInt L.Text) ()
   moduleGraph =
     Graph.renameNodesMonotonic (fmap (L.pack . prettyShow)) $
+    Graph.transitiveReduction $
     Graph.filterNodesKeepingEdges
       (\n -> Graph.otherValue n `Set.member` modulesToInclude) $
+    -- The following use of transitive reduction should not affect the
+    -- semantics. It tends to make the graph smaller, so it might
+    -- improve the overall performance of the code, but I did not
+    -- verify this.
+    Graph.transitiveReduction $
     Graph.addUniqueInts $
     Graph.fromEdges $
     concat $

--- a/src/full/Agda/Interaction/Highlighting/Dot/Backend.hs
+++ b/src/full/Agda/Interaction/Highlighting/Dot/Backend.hs
@@ -3,11 +3,7 @@ module Agda.Interaction.Highlighting.Dot.Backend
   ( dotBackend
   ) where
 
-import Agda.Interaction.Highlighting.Dot.Base
-  ( dottify
-  , renderDotToFile
-  , Env(Env, deConnections, deLabel)
-  )
+import Agda.Interaction.Highlighting.Dot.Base (renderDotToFile)
 
 import Control.Monad.Except
   ( MonadIO
@@ -18,8 +14,10 @@ import Control.Monad.Except
 
 import Control.DeepSeq
 
-import Data.Map ( Map )
-import Data.Set ( Set )
+import Data.HashSet (HashSet)
+import Data.Map (Map)
+import Data.Set (Set)
+import qualified Data.HashSet as HashSet
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.Maybe
@@ -30,27 +28,38 @@ import GHC.Generics (Generic)
 import Agda.Compiler.Backend (Backend(..), Backend'(..), Definition, Recompile(..))
 import Agda.Compiler.Common (curIF, IsMain)
 
+import Agda.Interaction.FindFile (findFile, srcFilePath)
+import Agda.Interaction.Library
 import Agda.Interaction.Options
   ( ArgDescr(ReqArg)
   , Flag
   , OptDescr(..)
   )
 
-import Agda.Syntax.Abstract ( ModuleName )
+import Agda.Syntax.Abstract (ModuleName, toTopLevelModuleName)
 
 import Agda.TypeChecking.Monad
   ( Interface(iImportedModules, iModuleName)
   , MonadTCError
   , ReadTCState
+  , MonadTCM(..)
   , genericError
+  , reportSDoc
+  , getAgdaLibFiles
   )
+import Agda.TypeChecking.Pretty
 
+import Agda.Utils.Graph.AdjacencyMap.Unidirectional
+  (Graph, WithUniqueInt)
+import qualified Agda.Utils.Graph.AdjacencyMap.Unidirectional as Graph
 import Agda.Utils.Pretty ( prettyShow )
 
 -- ------------------------------------------------------------------------
 
 data DotFlags = DotFlags
   { dotFlagDestination :: Maybe FilePath
+  , dotFlagLibraries   :: Maybe (HashSet String)
+    -- ^ Only include modules from the given libraries.
   } deriving (Eq, Generic)
 
 instance NFData DotFlags
@@ -58,27 +67,43 @@ instance NFData DotFlags
 defaultDotFlags :: DotFlags
 defaultDotFlags = DotFlags
   { dotFlagDestination = Nothing
+  , dotFlagLibraries   = Nothing
   }
 
 dotFlagsDescriptions :: [OptDescr (Flag DotFlags)]
 dotFlagsDescriptions =
   [ Option [] ["dependency-graph"] (ReqArg dependencyGraphFlag "FILE")
               "generate a Dot file with a module dependency graph"
+  , Option [] ["dependency-graph-include"]
+      (ReqArg includeFlag "LIBRARY")
+      "include modules from the given library (default: all modules)"
   ]
 
 dependencyGraphFlag :: FilePath -> Flag DotFlags
 dependencyGraphFlag f o = return $ o { dotFlagDestination = Just f }
 
+includeFlag :: String -> Flag DotFlags
+includeFlag l o = return $
+  o { dotFlagLibraries =
+        case dotFlagLibraries o of
+          Nothing -> Just (HashSet.singleton l)
+          Just s  -> Just (HashSet.insert l s)
+    }
+
 data DotCompileEnv = DotCompileEnv
-  { _dotCompileEnvDestination :: FilePath
+  { dotCompileEnvDestination :: FilePath
+  , dotCompileEnvLibraries   :: Maybe (HashSet String)
+    -- ^ Only include modules from the given libraries.
   }
 
 -- Currently unused
 data DotModuleEnv = DotModuleEnv
 
 data DotModule = DotModule
-  { _dotModuleName :: ModuleName
+  { dotModuleName          :: ModuleName
   , dotModuleImportedNames :: Set ModuleName
+  , dotModuleInclude       :: Bool
+    -- ^ Include the module in the graph?
   }
 
 -- | Currently unused
@@ -111,8 +136,13 @@ preCompileDot
   :: MonadError String m
   => DotFlags
   -> m DotCompileEnv
-preCompileDot (DotFlags (Just dest)) = return $ DotCompileEnv dest
-preCompileDot (DotFlags Nothing)     = throwError "The Dot backend was invoked without being enabled!"
+preCompileDot d = case dotFlagDestination d of
+  Just dest -> return $ DotCompileEnv
+    { dotCompileEnvDestination = dest
+    , dotCompileEnvLibraries   = dotFlagLibraries d
+    }
+  Nothing ->
+    throwError "The Dot backend was invoked without being enabled!"
 
 preModuleDot
   :: Applicative m
@@ -133,17 +163,50 @@ compileDefDot
 compileDefDot _cenv _menv _main _def = pure DotDef
 
 postModuleDot
-  :: (MonadIO m, ReadTCState m)
+  :: (MonadTCM m, ReadTCState m)
   => DotCompileEnv
   -> DotModuleEnv
   -> IsMain
   -> ModuleName
   -> [DotDef]
   -> m DotModule
-postModuleDot _cenv DotModuleEnv _main moduleName _defs = do
+postModuleDot cenv DotModuleEnv _main moduleName _defs = do
   i <- curIF
   let importedModuleNames = Set.fromList $ fst <$> (iImportedModules i)
-  return $ DotModule moduleName importedModuleNames
+  include <- case dotCompileEnvLibraries cenv of
+    Nothing -> return True
+    Just ls -> liftTCM $ do
+      let m = toTopLevelModuleName moduleName
+      f    <- findFile m
+      libs <- getAgdaLibFiles (srcFilePath f) m
+
+      let incLibs = filter (\l -> _libName l `HashSet.member` ls) libs
+          inLib   = not (null incLibs)
+
+      reportSDoc "dot.include" 10 $ do
+        let name = pretty moduleName
+            list = nest 2 . vcat . map (text . _libName)
+        if inLib then
+          fsep
+            ([ "Including"
+             , name
+             ] ++
+             pwords "because it is in the following libraries:") $$
+          list incLibs
+        else
+          fsep
+            (pwords "Not including" ++
+             [name <> ","] ++
+             pwords "which is in the following libraries:") $$
+          list libs
+
+      return inLib
+
+  return $ DotModule
+    { dotModuleName          = moduleName
+    , dotModuleImportedNames = importedModuleNames
+    , dotModuleInclude       = include
+    }
 
 postCompileDot
   :: (MonadIO m, ReadTCState m)
@@ -151,10 +214,27 @@ postCompileDot
   -> IsMain
   -> Map ModuleName DotModule
   -> m ()
-postCompileDot (DotCompileEnv fp) _main modulesByName = do
-  let env = Env
-        { deConnections = (maybe [] (Set.toList . dotModuleImportedNames) . (flip Map.lookup modulesByName))
-        , deLabel       = L.pack . prettyShow
-        }
-  dot <- dottify env . iModuleName <$> curIF
-  renderDotToFile dot fp
+postCompileDot cenv _main modulesByName =
+  renderDotToFile moduleGraph (dotCompileEnvDestination cenv)
+  where
+  modulesToInclude :: Set ModuleName
+  modulesToInclude =
+    Map.keysSet $ Map.filter dotModuleInclude modulesByName
+
+  moduleGraph :: Graph (WithUniqueInt L.Text) ()
+  moduleGraph =
+    Graph.renameNodesMonotonic (fmap (L.pack . prettyShow)) $
+    Graph.filterNodesKeepingEdges
+      (\n -> Graph.otherValue n `Set.member` modulesToInclude) $
+    Graph.addUniqueInts $
+    Graph.fromEdges $
+    concat $
+    map (\(name, m) ->
+          [ Graph.Edge
+              { source = name
+              , target = target
+              , label  = ()
+              }
+          | target <- Set.toList $ dotModuleImportedNames m
+          ]) $
+    Map.toList modulesByName

--- a/src/full/Agda/Interaction/Highlighting/Dot/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/Dot/Base.hs
@@ -2,127 +2,45 @@
 -- | Generate an import dependency graph for a given module.
 
 module Agda.Interaction.Highlighting.Dot.Base
-  ( dottify
-  , renderDotToFile
+  ( renderDotToFile
   , renderDot
-  , DotGraph (..)
-  , Env(..)
+  , DotGraph
   ) where
 
-import Control.Monad.Reader
-import Control.Monad.State
+import Control.Monad.IO.Class
 
-import qualified Data.Map as M
-import Data.Map(Map)
-
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import Data.Set (Set)
 
 import qualified Data.Text.Lazy as L
 import qualified Data.Text.Lazy.Encoding as E
 import qualified Data.ByteString.Lazy as BS
 
--- | Internal module identifiers for construction of dependency graph.
-type NodeId = L.Text
+import Agda.Utils.Graph.AdjacencyMap.Unidirectional
+  (Graph, WithUniqueInt)
+import qualified Agda.Utils.Graph.AdjacencyMap.Unidirectional as Graph
 
 -- | Graph structure
-data DotGraph = DotGraph
-  { dgNodeLabels :: Map NodeId L.Text
-  , dgEdges      :: Set (NodeId, NodeId)
-  }
-
--- * Graph construction monad
-
--- Read-only environment when constructing the graph.
-data Env n where
-  Env :: Ord n =>
-    { deConnections :: n -> [n]
-    -- ^ Names connected to an entity
-    , deLabel       :: n -> L.Text
-    -- ^ Rendering that entity's name to a label
-    } -> Env n
-
-data DotState n = DotState
-  { dsNodeIds      :: Map n NodeId
-    -- ^ Records already processed entities
-    --   and maps them to an internal identifier.
-  , dsNodeIdSupply :: [NodeId]
-    -- ^ Supply of internal identifiers.
-  , dsGraph        :: DotGraph
-  }
-
-initialDotState :: DotState n
-initialDotState = DotState
-  { dsNodeIds      = M.empty
-  , dsNodeIdSupply = map (L.pack . ('m':) . show) [0..]
-  , dsGraph        = DotGraph mempty mempty
-  }
-
-type DotM n a = ReaderT (Env n) (State (DotState n)) a
-
-runDotM :: Env n -> DotM n x -> DotGraph
-runDotM env@Env{} = dsGraph . flip execState initialDotState . flip runReaderT env
-
-getLabel :: n -> DotM n L.Text
-getLabel = liftM2 deLabel ask . pure
-
-getConnections :: n -> DotM n [n]
-getConnections = liftM2 deConnections ask . pure
-
--- | Translate an entity name into an internal 'NodeId'.
---   Returns @True@ if the 'ModuleName' is new, i.e., has not been
---   encountered before and is thus added to the map of processed modules.
-addEntity :: Ord n => n -> DotM n (NodeId, Bool)
-addEntity name = do
-    s@(DotState nodeIds nodeIdSupply graph) <- get
-    case M.lookup name nodeIds of
-        Just nodeId  -> return (nodeId, False)
-        Nothing -> do
-            let newNodeId:remainingNodeIdSupply = nodeIdSupply
-            label <- getLabel name
-            put s
-              { dsNodeIds      = M.insert name newNodeId nodeIds
-              , dsNodeIdSupply = remainingNodeIdSupply
-              , dsGraph        = graph
-                { dgNodeLabels = M.insert newNodeId label . dgNodeLabels $ graph
-                }
-              }
-            return (newNodeId, True)
-
--- | Add an arc from importer to imported.
-addConnection :: NodeId -> NodeId -> DotM n ()
-addConnection m1 m2 = modify $ \s -> s
-  { dsGraph = (dsGraph s)
-    { dgEdges = S.insert (m1, m2) . dgEdges . dsGraph $ s
-    }
-  }
-
-dottify :: Ord n => Env n -> n -> DotGraph
-dottify env root = runDotM env (dottify' root)
-
-dottify' :: Ord n => n -> DotM n NodeId
-dottify' entity = do
-  (nodeId, continue) <- addEntity entity
-  -- If we have not visited this interface yet,
-  -- process its imports recursively and
-  -- add them as connections to the graph.
-  when continue $ do
-    connectedEntities <- getConnections entity
-    connectedNodeIds <- mapM dottify' connectedEntities
-    mapM_ (addConnection nodeId) connectedNodeIds
-  return nodeId
+type DotGraph = Graph (WithUniqueInt L.Text) ()
 
 -- * Graph rendering
 
 renderDot :: DotGraph -> L.Text
 renderDot g = L.unlines $ concat
   [ [ "digraph dependencies {" ]
-  , [ L.concat ["   ", nodeId, "[label=\"", label, "\"];"]
-    | (nodeId, label) <- M.toList (dgNodeLabels g) ]
-  , [ L.concat ["   ", r1, " -> ", r2, ";"]
-    | (r1 , r2) <- S.toList (dgEdges g) ]
+  , [ L.concat ["   ", show' nodeId, "[label=\"", label, "\"];"]
+    | Graph.WithUniqueInt nodeId label <- S.toList $ Graph.nodes g
+    ]
+  , [ L.concat ["   ", show' r1, " -> ", show' r2, ";"]
+    | Graph.Edge
+        { source = Graph.WithUniqueInt r1 _
+        , target = Graph.WithUniqueInt r2 _
+        } <- Graph.edges g
+    ]
   , ["}"]
   ]
+  where
+  show' = L.pack . ("m" ++) . show
 
 renderDotToFile :: MonadIO m => DotGraph -> FilePath -> m ()
 renderDotToFile dot fp = liftIO $ BS.writeFile fp $ E.encodeUtf8 $ renderDot dot

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -126,7 +126,7 @@ parseSource sourceFile@(SourceFile f) = Bench.billTo [Bench.Parsing] $ do
   (parsedMod, fileType) <- runPM $
                            parseFile moduleParser f $ TL.unpack source
   parsedModName         <- moduleName f parsedMod
-  libs <- getAgdaLibFiles $ takeDirectory $ filePath f
+  libs                  <- getAgdaLibFiles f parsedModName
   return Source
     { srcText        = source
     , srcFileType    = fileType
@@ -671,7 +671,9 @@ loadDecodedModule file mi = do
   -- want the pragmas to apply to interactive commands in the UI.
   -- Jesper, 2021-04-18: Check for changed options in library files!
   -- (see #5250)
-  libOptions <- lift $ getLibraryOptions $ takeDirectory fp
+  libOptions <- lift $ getLibraryOptions
+    (srcFilePath file)
+    (toTopLevelModuleName $ iModuleName i)
   lift $ mapM_ setOptionsFromPragma (libOptions ++ iFilePragmaOptions i)
 
   -- Check that options that matter haven't changed compared to

--- a/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -492,16 +492,28 @@ composeWith times plus (Graph g) (Graph g') = Graph (Map.map comp g)
 
 -- | The graph's strongly connected components, in reverse topological
 -- order.
+--
+-- The time complexity is likely /O(n + e log n)/ (but this depends on
+-- the, at the time of writing undocumented, time complexity of
+-- 'Graph.stronglyConnComp').
 
 sccs' :: Ord n => Graph n e -> [Graph.SCC n]
 sccs' g =
   Graph.stronglyConnComp
-    [ (n, n, map target (edgesFrom g [n]))
-    | n <- Set.toList (nodes g)
+    [ (n, n, Map.keys es)
+    | (n, es) <- Map.toAscList (graph g)
     ]
+    -- Graph.stronglyConnComp sorts this list, and the sorting
+    -- algorithm that is used is adaptive, so it may make sense to
+    -- generate a sorted list. (These comments apply to one specific
+    -- version of the code in Graph, compiled in a specific way.)
 
 -- | The graph's strongly connected components, in reverse topological
 -- order.
+--
+-- The time complexity is likely /O(n + e log n)/ (but this depends on
+-- the, at the time of writing undocumented, time complexity of
+-- 'Graph.stronglyConnComp').
 
 sccs :: Ord n => Graph n e -> [[n]]
 sccs = map Graph.flattenSCC . sccs'

--- a/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -64,6 +64,7 @@ module Agda.Utils.Graph.AdjacencyMap.Unidirectional
   , gaussJordanFloydWarshallMcNaughtonYamada
   , gaussJordanFloydWarshallMcNaughtonYamadaReference
   , transitiveClosure
+  , transitiveReduction
   , complete, completeIter
   )
   where
@@ -993,3 +994,21 @@ gaussJordanFloydWarshallMcNaughtonYamada g =
 --         NEW EDGES WILL BE ADDED! Use 'Maybe ()' instead.
 transitiveClosure :: (Ord n, Eq e, StarSemiRing e) => Graph n e -> Graph n e
 transitiveClosure = fst . gaussJordanFloydWarshallMcNaughtonYamada
+
+-- | The transitive reduction of the graph: a graph with the same
+-- reachability relation as the graph, but with as few edges as
+-- possible.
+--
+-- Precondition: The graph must be acyclic. The number of nodes in the
+-- graph must not be larger than @'maxBound' :: 'Int'@.
+--
+-- Worst-case time complexity: /O(e n log n)/ (this has not been
+-- verified carefully).
+--
+-- The algorithm is based on one found on Wikipedia.
+
+transitiveReduction :: Ord n => Graph n e -> Graph n ()
+transitiveReduction g =
+  fmap (const ()) $
+  filterEdges ((== 1) . fst . label) $
+  longestPaths g

--- a/test/Fail/Tests.hs
+++ b/test/Fail/Tests.hs
@@ -38,6 +38,7 @@ tests = do
   where
   customizedTests =
     [ testGroup "customised" $
+        issue5644 :
         issue5508 :
         issue5101 :
         issue4671 :
@@ -91,6 +92,31 @@ caseInsensitiveFileSystem4671 = do
     goldenFileSens    = dir </> "Issue4671.err.case-sensitive"
     goldenFileInsens  = dir </> "Issue4671.err.case-insensitive"
     goldenFileInsens' = dir </> "Issue4671.err.cAsE-inSensitive" -- case variant, to test file system
+
+issue5644 :: TestTree
+issue5644 =
+  goldenTest1
+    name
+    (readTextFileMaybe goldenFile)
+    doRun
+    textDiff
+    ShowText
+    (writeTextFile goldenFile)
+  where
+    name       = "Issue5644"
+    dir        = testDir </> "customised"
+    goldenFile = dir </> name <.> "err"
+    doRun = do
+      let agdaArgs file =
+            [ "-v0"
+            , "--no-default-libraries"
+            , "-i" ++ dir
+            , "-i" ++ dir </> name
+            , dir </> file
+            ]
+      runAgdaWithOptions
+        name (agdaArgs (name <.> "agda")) Nothing Nothing
+        <&> printTestResult . expectFail
 
 issue4671 :: TestTree
 issue4671 =

--- a/test/Fail/customised/Issue5644.agda
+++ b/test/Fail/customised/Issue5644.agda
@@ -1,0 +1,1 @@
+import A.B

--- a/test/Fail/customised/Issue5644.err
+++ b/test/Fail/customised/Issue5644.err
@@ -1,0 +1,4 @@
+customised/Issue5644/A/B.agda:3,1-24
+Cannot use NON_TERMINATING pragma with safe flag.
+when scope checking the declaration
+  import A.B

--- a/test/Fail/customised/Issue5644/A/B.agda
+++ b/test/Fail/customised/Issue5644/A/B.agda
@@ -1,0 +1,6 @@
+module A.B where
+
+{-# NON_TERMINATING #-}
+
+easy : (A : Set) → A
+easy = easy

--- a/test/Fail/customised/Issue5644/A/ignored.agda-lib
+++ b/test/Fail/customised/Issue5644/A/ignored.agda-lib
@@ -1,0 +1,2 @@
+name: ignored
+include: .

--- a/test/Fail/customised/Issue5644/issue5644.agda-lib
+++ b/test/Fail/customised/Issue5644/issue5644.agda-lib
@@ -1,0 +1,3 @@
+name: issue5644
+flags: --safe
+include: .

--- a/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -326,6 +326,11 @@ prop_invariant_gaussEtAl :: G -> Bool
 prop_invariant_gaussEtAl =
   invariant . fst . gaussJordanFloydWarshallMcNaughtonYamada
 
+prop_invariant_transitiveReduction :: Property
+prop_invariant_transitiveReduction =
+  forAll (acyclicGraph :: Gen G) $ \g ->
+    invariant (transitiveReduction g)
+
 ------------------------------------------------------------------------
 -- * Graph properties
 ------------------------------------------------------------------------
@@ -643,6 +648,24 @@ prop_gaussEtAl g =
                     else ">= 4") ++
     " strongly connected component(s)"
     where noSCCs = length (sccs g)
+
+prop_transitiveReduction1 :: Property
+prop_transitiveReduction1 =
+  forAll (acyclicGraph :: Gen G) $ \g ->
+  fmap (const ())
+    (transitiveClosure (fmap Just (transitiveReduction g)))
+    ==
+  fmap (const ()) (transitiveClosure (fmap Just g))
+
+prop_transitiveReduction2 :: Property
+prop_transitiveReduction2 =
+  forAll positive $ \n ->
+  let g = decreasingGraph n in
+  Set.fromList (edges (transitiveReduction g)) ==
+  Set.fromList
+    [ Edge { source = 1 + i, target = i, label = () }
+    | i <- [1 .. n - 1]
+    ]
 
 -- | A property for
 -- 'Agda.TypeChecking.Positivity.Occurrence.productOfEdgesInBoundedWalk'.

--- a/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -294,6 +294,20 @@ prop_invariant_filterNodesKeepingEdges p =
   forAll (acyclicGraph :: Gen G) $ \g ->
   invariant (filterNodesKeepingEdges p g)
 
+prop_invariant_renameNodes :: G -> Bool
+prop_invariant_renameNodes = invariant . renameNodes ren
+  where
+  ren (N (Positive n)) = - n
+
+prop_invariant_renameNodesMonotonic :: G -> Bool
+prop_invariant_renameNodesMonotonic =
+  invariant . renameNodesMonotonic ren
+  where
+  ren (N (Positive n)) = n
+
+prop_invariant_addUniqueInts :: G -> Bool
+prop_invariant_addUniqueInts = invariant . addUniqueInts
+
 prop_invariant_unzip :: G -> Bool
 prop_invariant_unzip g = invariant g1 && invariant g2
   where
@@ -433,6 +447,24 @@ prop_filterNodesKeepingEdges p =
     then Set.filter p (Map.keysSet (reachableFrom g n)) ==
          Map.keysSet (reachableFrom g' n)
     else not (n `Set.member` nodes g')
+
+prop_renameNodes :: G -> Bool
+prop_renameNodes g =
+  renameNodes inv (renameNodes ren g) == g
+  where
+  ren (N (Positive n)) = - n
+  inv n                = N (Positive (- n))
+
+prop_renameNodesMonotonic :: G -> Bool
+prop_renameNodesMonotonic g =
+  renameNodesMonotonic inv (renameNodesMonotonic ren g) == g
+  where
+  ren (N (Positive n)) = n
+  inv n                = N (Positive n)
+
+prop_addUniqueInts :: G -> Bool
+prop_addUniqueInts g =
+  renameNodes otherValue (addUniqueInts g) == g
 
 prop_sccs' :: G -> Bool
 prop_sccs' g =

--- a/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -222,6 +222,10 @@ prop_invariant_transpose = invariant . transpose
 prop_invariant_clean :: G -> Bool
 prop_invariant_clean = invariant . clean
 
+prop_invariant_filterNodes :: (N -> Bool) -> G -> Bool
+prop_invariant_filterNodes p g =
+  invariant (filterNodes p g)
+
 prop_invariant_removeNodes :: G -> Property
 prop_invariant_removeNodes g =
   forAll (listOf (frequency [(5, nodeIn g), (1, arbitrary)])) $ \ns ->
@@ -344,6 +348,10 @@ prop_clean g =
   all (not . null . Graph.label) (edges (clean g))
     &&
   discrete g == (null . edges . clean) g
+
+prop_filterNodes :: (N -> Bool) -> G -> Bool
+prop_filterNodes p g =
+  Set.filter p (nodes g) == nodes (filterNodes p g)
 
 prop_removeEdge :: G -> Property
 prop_removeEdge g =

--- a/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -21,6 +21,7 @@ import Agda.Utils.SemiRing
 import Agda.Utils.Singleton (Singleton)
 import qualified Agda.Utils.Singleton as Singleton
 import Agda.Utils.Impossible
+import Agda.Utils.Pretty
 
 import Control.Monad
 
@@ -156,6 +157,9 @@ n = N . Positive
 
 instance Show N where
   show (N (Positive n)) = "n " ++ show n
+
+instance Pretty N where
+  pretty = text . show
 
 instance CoArbitrary N where
   coarbitrary (N (Positive n)) = coarbitrary n

--- a/test/Succeed/Issue481.dot.orig
+++ b/test/Succeed/Issue481.dot.orig
@@ -1,11 +1,5 @@
 digraph dependencies {
-   m0[label="Issue481"];
-   m1[label="Common.Issue481ParametrizedModule"];
-   m2[label="Agda.Primitive"];
-   m3[label="Issue481Record"];
-   m0 -> m1;
-   m0 -> m2;
-   m0 -> m3;
-   m1 -> m2;
+   m2[label="Issue481Record"];
+   m3[label="Issue481"];
    m3 -> m2;
 }

--- a/test/Succeed/Issue481.flags
+++ b/test/Succeed/Issue481.flags
@@ -1,1 +1,1 @@
---dependency-graph=Issue481.dot
+--dependency-graph=Issue481.dot --dependency-graph-include=test-succeed

--- a/test/Succeed/Tests.hs
+++ b/test/Succeed/Tests.hs
@@ -85,12 +85,15 @@ mkSucceedTest extraOpts dir agdaFile =
   doRun = do
 
     let agdaArgs = [ "-v0", "-i" ++ dir, "-itest/", agdaFile
-                   , "--no-libraries"
                    , "-vimpossible:10" -- BEWARE: no spaces allowed here
                    , "-vwarning:1"
                    , "--double-check"
-                   ]
-                     ++ extraOpts
+                   ] ++
+                   [ if testName == "Issue481"
+                     then "--no-default-libraries"
+                     else "--no-libraries"
+                   ] ++
+                   extraOpts
 
     (res, ret) <- runAgdaWithOptions testName agdaArgs (Just flagFile) (Just varFile)
 


### PR DESCRIPTION
* A new option, `--dependency-graph-include`.
* The generated graphs no longer contain redundant edges.