### PR TITLE
Fix for #5469

### DIFF
--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -126,11 +126,8 @@ isDef f tm = loop <$> liftTCM tm
 
 reduceQuotedTerm :: Term -> UnquoteM Term
 reduceQuotedTerm t = do
-  b <- ifBlocked t {-then-} (\ m _ -> pure $ Left  m)
-                   {-else-} (\ _ t -> pure $ Right t)
-  case b of
-    Left m  -> do s <- gets snd; throwError $ BlockedOnMeta s m
-    Right t -> return t
+  ifBlocked t {-then-} (\ m _ -> do s <- gets snd; throwError $ BlockedOnMeta s m)
+              {-else-} (\ _ t -> return t)
 
 class Unquote a where
   unquote :: I.Term -> UnquoteM a

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -125,7 +125,7 @@ isDef f tm = loop <$> liftTCM tm
     loop _         = False
 
 reduceQuotedTerm :: Term -> UnquoteM Term
-reduceQuotedTerm t = do
+reduceQuotedTerm t = locallyReduceAllDefs $ do
   ifBlocked t {-then-} (\ m _ -> do s <- gets snd; throwError $ BlockedOnMeta s m)
               {-else-} (\ _ t -> return t)
 

--- a/test/Succeed/Issue5469.agda
+++ b/test/Succeed/Issue5469.agda
@@ -1,0 +1,15 @@
+open import Agda.Builtin.List
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Reflection
+
+pattern vArg x = arg (arg-info visible (modality relevant quantity-ω)) x
+
+make2 : Term → TC ⊤
+make2 hole = bindTC (normalise (def (quote _+_) (vArg (lit (nat 1)) ∷ vArg (lit (nat 1)) ∷ []))) (unify hole)
+
+macro
+  tester : Term → TC ⊤
+  tester hole = onlyReduceDefs (quote _+_ ∷ []) (make2 hole)
+
+_ = tester


### PR DESCRIPTION
`dontReduceDefs` and `onlyReduceDefs` should only have an effect when working with unquoted terms, but not during the unquoting of the terms itself.