### PR TITLE
Fix #5657: isProjection might fail on an A.Proj, so, not IMPOSSIBLE

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -118,10 +118,12 @@ checkApplication cmp hd args e t =
     ]
   case unScope hd of
     -- Subcase: unambiguous projection
-    A.Proj o p | Just x <- getUnambiguous p -> checkUnambiguousProjectionApplication cmp e t x o hd args
+    A.Proj o p | Just x <- getUnambiguous p -> do
+      checkUnambiguousProjectionApplication cmp e t x o hd args
 
     -- Subcase: ambiguous projection
-    A.Proj o p -> checkProjApp cmp e o (unAmbQ p) args t
+    A.Proj o p -> do
+      checkProjApp cmp e o (unAmbQ p) args t
 
     -- Subcase: unambiguous constructor
     A.Con ambC | Just c <- getUnambiguous ambC -> do

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -961,16 +961,20 @@ disambiguateConstructor cs0 t = do
 ---------------------------------------------------------------------------
 
 checkUnambiguousProjectionApplication :: Comparison -> A.Expr -> Type -> QName -> ProjOrigin -> A.Expr -> [NamedArg A.Expr] -> TCM Term
-checkUnambiguousProjectionApplication cmp e t x o hd args =
+checkUnambiguousProjectionApplication cmp e t x o hd args = do
+  let fallback = checkHeadApplication cmp e t hd args
   -- Andreas, 2021-02-19, issue #3289
   -- If a postfix projection was moved to the head by appView,
   -- we have to patch the first argument with the correct hiding info.
   case (o, args) of
     (ProjPostfix, arg : rest) -> do
-      pr <- fromMaybe __IMPOSSIBLE__ <$> isProjection x
-      let ai = projArgInfo pr
-      checkHeadApplication cmp e t hd (setArgInfo ai arg : rest)
-    _ -> checkHeadApplication cmp e t hd args
+      -- Andreas, 2021-11-19, issue #5657:
+      -- If @x@ has been brought into scope by e.g. @open R r@, it is no longer
+      -- a projection even though the scope checker labels it so.
+      -- Thus, @isProjection@ may fail.
+      caseMaybeM (isProjection x) fallback $ \ pr -> do
+        checkHeadApplication cmp e t hd (setArgInfo (projArgInfo pr) arg : rest)
+    _ -> fallback
 
 -- | Inferring the type of an overloaded projection application.
 --   See 'inferOrCheckProjApp'.

--- a/test/Fail/Issue5657.agda
+++ b/test/Fail/Issue5657.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2021-11-19, issue #5657 reported by J Barrett
+-- Regression in 2.6.2: internal error instead of error message
+
+record R : Set₁ where
+  field A : Set
+
+postulate r : R
+open R r
+
+fail : Set
+fail = r .A
+
+-- WAS:
+-- An internal error has occurred. Please report this as a bug.
+-- Location of the error: __IMPOSSIBLE__, called at src/full/Agda/TypeChecking/Rules/Application.hs:968
+
+-- Expected:
+-- Set should be a function type, but it isn't
+-- when checking that r is a valid argument to a function of type Set

--- a/test/Fail/Issue5657.err
+++ b/test/Fail/Issue5657.err
@@ -1,0 +1,3 @@
+Issue5657.agda:11,11-12
+Set should be a function type, but it isn't
+when checking that r is a valid argument to a function of type Set


### PR DESCRIPTION
Fix #5657: `isProjection` might fail on an `A.Proj`, so, not `__IMPOSSIBLE__`.