### PR TITLE
Fix #5655 (cifm): use `github` package with flag `openssl`

### DIFF
--- a/src/release-tools/closed-issues-for-milestone/Main.hs
+++ b/src/release-tools/closed-issues-for-milestone/Main.hs
@@ -15,11 +15,9 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Data.Vector as V
 
 import System.Environment ( getArgs, getEnv, getProgName )
-import System.Exit ( exitFailure )
-import System.IO ( hPutStrLn, stderr )
+import System.Exit        ( die )
 
 import GitHub.Auth ( Auth( OAuth ) )
--- import GitHub.Data.Id ( Id(..) )
 
 import GitHub.Data.Definitions
   ( IssueLabel ( labelName )
@@ -47,7 +45,7 @@ import GitHub.Endpoints.Issues ( issuesForRepoR )
 import GitHub.Request ( github )
 
 envGHToken :: String
-envGHToken = "GITHUBTOKEN"
+envGHToken = "GITHUB_TOKEN"
 
 owner, repo :: Text
 owner = "agda"
@@ -57,7 +55,11 @@ theRepo :: String
 theRepo = Text.unpack owner ++ "/" ++ Text.unpack repo
 
 main :: IO ()
-main = getArgs >>= \case { [arg] -> run (Text.pack arg) ; _ -> usage }
+main = getArgs >>= \case
+  "-h"     : _ -> usage
+  "--help" : _ -> usage
+  [arg]        -> run (Text.pack arg)
+  _            -> usage
 
 usage :: IO ()
 usage = do
@@ -66,7 +68,9 @@ usage = do
     [ "Usage: " ++ progName ++ " <milestone>"
     , ""
     , "Retrieves closed issues for the given milestone from github repository"
-    , theRepo ++ " and prints them as csv to stdout."
+    , theRepo ++ " and prints them as markdown to stdout."
+    , ""
+    , "Expects an access token in environment variable GITHUB_TOKEN."
     ]
 
 issueLabelsNames :: Issue -> [Text]
@@ -160,7 +164,3 @@ run mileStoneTitle = do
 -- | Crash on exception.
 crashOr :: Show e => IO (Either e a) -> IO a
 crashOr m = either (die . show) return =<< m
-
--- | Crash with error message
-die :: String -> IO a
-die e = do hPutStrLn stderr e; exitFailure

--- a/src/release-tools/closed-issues-for-milestone/cabal.project
+++ b/src/release-tools/closed-issues-for-milestone/cabal.project
@@ -1,0 +1,10 @@
+packages: .
+
+-- Andreas, 2021-11-19, configuration for GHC-9.2
+-- see https://github.com/phadej/github/issues/468
+
+constraints: github +openssl
+
+-- Obsoleted by https://github.com/haskell-hvr/deepseq-generics/pull/12
+-- allow-newer: deepseq-generics-0.2.0.0:base
+-- allow-newer: deepseq-generics-0.2.0.0:ghc-prim

--- a/src/release-tools/closed-issues-for-milestone/closed-issues-for-milestone.cabal
+++ b/src/release-tools/closed-issues-for-milestone/closed-issues-for-milestone.cabal
@@ -15,12 +15,13 @@ tested-with:
   GHC == 8.8.4
   GHC == 8.10.7
   GHC == 9.0.1
+  GHC == 9.2.1
 
 executable closed-issues-for-milestone
   main-is:          Main.hs
   default-language: Haskell2010
 
-  build-depends:  base       >= 4.13.0.0  && < 4.16
+  build-depends:  base       >= 4.13.0.0  && < 4.17
                 , bytestring >= 0.10.9.0  && < 0.12
                 , github     >= 0.26      && < 0.28
                 , text       >= 1.2.3     && < 1.3
@@ -30,3 +31,4 @@ executable closed-issues-for-milestone
     -Wall
     -Wcompat
     -Werror
+    -threaded


### PR DESCRIPTION
Fix #5655 (cifm): use `github` package with flag `openssl`

Some further changes:
- compile with `-threaded`
- option `--help` / `-h`
- env var `GITHUB_TOKEN` (with underscore) rather than `GITHUBTOKEN`
