### PR TITLE
Relax upper bound of `hashtables` to < 1.4

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -231,7 +231,7 @@ library
                 -- in hashtables 1.2.0.0/1.2.0.1. This bug seems to
                 -- have made Agda much slower (infinitely slower?) in
                 -- some cases.
-                , hashtables >= 1.2.0.2 && < 1.3
+                , hashtables >= 1.2.0.2 && < 1.4
                 , haskeline >= 0.7.2.3 && < 0.9
                 -- monad-control-1.0.1.0 is the first to contain liftThrough
                 , monad-control >= 1.0.1.0 && < 1.1


### PR DESCRIPTION
Relax upper bound of `hashtables` to < 1.4

Reason: 
- https://github.com/commercialhaskell/stackage/issues/6322