### PR TITLE
[ fix #5600 ] alwaysUnblock when comparing MissingClauses neutrals

### DIFF
--- a/benchmark/cwf/Setoid.agda
+++ b/benchmark/cwf/Setoid.agda
@@ -19,6 +19,9 @@ Pred A = A -> Set
 Resp : {A : Set} -> Rel A -> {B : Set} -> Rel B -> Pred (A -> B)
 Resp _R_ _S_ f = forall x y -> x R y -> f x S f y
 
+_∋_ : (A : Set) → A → A
+A ∋ x = x
+
 mutual
 
   infixr 10 _,_
@@ -58,11 +61,11 @@ mutual
               {pf₂ : (x y : El A₂) -> x =El= y -> f₂ x =El= f₂ y} ->
               A₂ =S= A₁ ->
               ((x : El A₁)(y : El A₂) -> x =El= y -> f₁ x =El= f₂ y) ->
-              ƛ f₁ pf₁ =El= ƛ f₂ pf₂
+              (El (Π A₁ F₁) ∋ ƛ f₁ pf₁) =El= (El (Π A₂ F₂) ∋ ƛ f₂ pf₂)
     eqInΣ   : {A₁ A₂ : Setoid}{F₁ : Fam A₁}{F₂ : Fam A₂}
               {x₁ : El A₁}{y₁ : El (F₁ ! x₁)}
               {x₂ : El A₂}{y₂ : El (F₂ ! x₂)} ->
-              F₁ =Fam= F₂ -> x₁ =El= x₂ -> y₁ =El= y₂ -> (x₁ , y₁) =El= (x₂ , y₂)
+              F₁ =Fam= F₂ -> x₁ =El= x₂ -> y₁ =El= y₂ -> (El (Σ A₁ F₁) ∋ (x₁ , y₁ )) =El= (El (Σ A₂ F₂) ∋ (x₂ , y₂))
 
   data _=Fam=_ {A B : Setoid}(F : Fam A)(G : Fam B) : Set where
     eqFam : B =S= A -> (forall x y -> x =El= y -> F ! x =S= G ! y) -> F =Fam= G

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -412,6 +412,15 @@ computeElimHeadType f es es' = do
     targ <- abortIfBlocked targ
     fromMaybeM __IMPOSSIBLE__ $ getDefType f targ
 
+
+abortIfMissingClauses :: (Blocked Term, Blocked Term) -> Blocker
+abortIfMissingClauses (NotBlocked nb t, NotBlocked nb' t') =
+  case nb <> nb' of
+    MissingClauses -> alwaysUnblock
+    _              -> neverUnblock
+abortIfMissingClauses _ = __IMPOSSIBLE__
+
+
 -- | Syntax directed equality on atomic values
 --
 compareAtom :: forall m. MonadConversion m => Comparison -> CompareAs -> Term -> Term -> m ()
@@ -425,12 +434,18 @@ compareAtom cmp t m n =
                              , prettyTCM n
                              , prettyTCM t
                              ]
+    let blockIfMissingClauses b@Blocked{} = b
+        -- re #5600: We might add more clauses to the function later,
+        --           so we shouldn't commit to an UnequalTerms error yet,
+        --           even if there are no metas blocking computation.
+        blockIfMissingClauses (NotBlocked MissingClauses t) = Blocked alwaysUnblock t
+        blockIfMissingClauses b@NotBlocked{} = b
     -- Andreas: what happens if I cut out the eta expansion here?
     -- Answer: Triggers issue 245, does not resolve 348
     (mb',nb') <- do
       mb' <- etaExpandBlocked =<< reduceB m
       nb' <- etaExpandBlocked =<< reduceB n
-      return (mb', nb')
+      return (blockIfMissingClauses mb', blockIfMissingClauses nb')
     let getBlocker (Blocked b _) = b
         getBlocker NotBlocked{}  = neverUnblock
         blocker = unblockOnEither (getBlocker mb') (getBlocker nb')
@@ -515,7 +530,10 @@ compareAtom cmp t m n =
       (Blocked{}, Blocked{}) | not cmpBlocked  -> checkDefinitionalEquality
       (Blocked b _, _) | not cmpBlocked -> useInjectivity (fromCmp cmp) b t m n   -- The blocked term  goes first
       (_, Blocked b _) | not cmpBlocked -> useInjectivity (flipCmp $ fromCmp cmp) b t n m
-      _ -> blockOnError blocker $ do
+      bs -> do
+        let blocker' | cmpBlocked = blocker
+                     | otherwise = unblockOnEither blocker $ abortIfMissingClauses bs
+        blockOnError blocker' $ do
         -- -- Andreas, 2013-10-20 put projection-like function
         -- -- into the spine, to make compareElims work.
         -- -- 'False' means: leave (Def f []) unchanged even for

--- a/test/Fail/IncompletePatternMatching.err
+++ b/test/Fail/IncompletePatternMatching.err
@@ -3,6 +3,7 @@ Incomplete pattern matching for _==_. Missing cases:
   zero == suc x
   suc x == zero
 when checking the definition of _==_
-IncompletePatternMatching.agda:18,7-9
-True !=< zero == suc zero
-when checking that the expression tt has type zero == suc zero
+Failed to solve the following constraints:
+  True =< zero == suc zero
+Unsolved metas at the following locations:
+  IncompletePatternMatching.agda:18,7-9

--- a/test/Fail/Issue3012.err
+++ b/test/Fail/Issue3012.err
@@ -2,6 +2,7 @@ Issue3012.agda:12,1-15
 Incomplete pattern matching for partial. Missing cases:
   snd (partial x)
 when checking the definition of partial
-Issue3012.agda:17,13-17
-partial x .snd != x of type A
-when checking that the expression refl has type partial x .snd ≡ x
+Failed to solve the following constraints:
+  partial x .snd = x : A
+Unsolved metas at the following locations:
+  Issue3012.agda:17,13-17


### PR DESCRIPTION
Fix #5600: `alwaysUnblock` when comparing `MissingClauses` neutrals.

As usual when improving equality we make inference worse, so some test cases needed some extra annotations.