### PR TITLE
[ reflection ] Add new primitive `getInstances`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,22 @@ Language
   `(j : J) → A : Set l`, that is, the type of functions from a type in `ISet`
   to a fibrant type is fibrant.
 
+* A new reflection primitive `getInstances : Meta → TC (List Term)`
+  was added to `Agda.Builtin.Reflection`. This operation returns the
+  list of all possibly valid instance candidates for a given
+  metavariable. For example, the following macro instantiates the goal
+  with the first instance candidate, even if there are several:
+  ```agda
+  macro
+    pickWhatever : Term → TC ⊤
+    pickWhatever hole@(meta m _) = do
+      (cand ∷ _) ← getInstances m
+        where [] -> typeError (strErr "No candidates!" ∷ [])
+      unify hole cand
+    pickWhatever _ = typeError (strErr "Already solved!" ∷ [])
+  ```
+
+
 Syntax
 ------
 

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -492,6 +492,10 @@ following primitive operations::
     -- the old TC state if the second component is 'false', or keep the
     -- new TC state if it is 'true'.
     runSpeculative : ∀ {a} {A : Set a} → TC (Σ A λ _ → Bool) → TC A
+    
+    -- Get a list of all possible instance candidates for the given meta
+    -- variable (it does not have to be an instance meta).
+    getInstances : Meta → TC (List Term)
 
   {-# BUILTIN AGDATCMUNIFY                      unify                      #-}
   {-# BUILTIN AGDATCMTYPEERROR                  typeError                  #-}
@@ -521,6 +525,7 @@ following primitive operations::
   {-# BUILTIN AGDATCMDONTREDUCEDEFS             dontReduceDefs             #-}
   {-# BUILTIN AGDATCMNOCONSTRAINTS              noConstraints              #-}
   {-# BUILTIN AGDATCMRUNSPECULATIVE             runSpeculative             #-}
+  {-# BUILTIN AGDATCMGETINSTANCES               getInstances               #-}
 
 Metaprogramming
 ---------------

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -492,7 +492,7 @@ following primitive operations::
     -- the old TC state if the second component is 'false', or keep the
     -- new TC state if it is 'true'.
     runSpeculative : ∀ {a} {A : Set a} → TC (Σ A λ _ → Bool) → TC A
-    
+
     -- Get a list of all possible instance candidates for the given meta
     -- variable (it does not have to be an instance meta).
     getInstances : Meta → TC (List Term)

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -316,6 +316,10 @@ postulate
   -- new TC state if it is 'true'.
   runSpeculative : ∀ {a} {A : Set a} → TC (Σ A λ _ → Bool) → TC A
 
+  -- Get a list of all possible instance candidates for the given meta
+  -- variable (it does not have to be an instance meta).
+  getInstances : Meta → TC (List Term)
+
 {-# BUILTIN AGDATCM                           TC                         #-}
 {-# BUILTIN AGDATCMRETURN                     returnTC                   #-}
 {-# BUILTIN AGDATCMBIND                       bindTC                     #-}
@@ -348,6 +352,7 @@ postulate
 {-# BUILTIN AGDATCMWITHRECONSPARAMS           withReconstructed          #-}
 {-# BUILTIN AGDATCMNOCONSTRAINTS              noConstraints              #-}
 {-# BUILTIN AGDATCMRUNSPECULATIVE             runSpeculative             #-}
+{-# BUILTIN AGDATCMGETINSTANCES               getInstances               #-}
 
 -- All the TC primitives are compiled to functions that return
 -- undefined, rather than just undefined, in an attempt to make sure
@@ -384,3 +389,4 @@ postulate
 {-# COMPILE JS dontReduceDefs    = _ => _ => _ => _ => undefined #-}
 {-# COMPILE JS noConstraints     = _ => _ => _ =>      undefined #-}
 {-# COMPILE JS runSpeculative    = _ => _ => _ =>      undefined #-}
+{-# COMPILE JS getInstances      = _ =>                undefined #-}

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -275,6 +275,7 @@ ghcPreCompile flags = do
       , builtinAgdaTCMNoConstraints
       , builtinAgdaTCMRunSpeculative
       , builtinAgdaTCMExec
+      , builtinAgdaTCMGetInstances
       ]
     return $
       flip HashSet.member $

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -73,7 +73,8 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinAgdaTCMOnlyReduceDefs, builtinAgdaTCMDontReduceDefs,
   builtinAgdaTCMNoConstraints,
   builtinAgdaTCMRunSpeculative,
-  builtinAgdaTCMExec
+  builtinAgdaTCMExec,
+  builtinAgdaTCMGetInstances
   :: String
 
 builtinNat                               = "NATURAL"
@@ -277,6 +278,7 @@ builtinAgdaTCMDontReduceDefs             = "AGDATCMDONTREDUCEDEFS"
 builtinAgdaTCMNoConstraints              = "AGDATCMNOCONSTRAINTS"
 builtinAgdaTCMRunSpeculative             = "AGDATCMRUNSPECULATIVE"
 builtinAgdaTCMExec                       = "AGDATCMEXEC"
+builtinAgdaTCMGetInstances               = "AGDATCMGETINSTANCES"
 
 -- | Builtins that come without a definition in Agda syntax.
 --   These are giving names to Agda internal concepts which

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -220,7 +220,8 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primAgdaTCMOnlyReduceDefs, primAgdaTCMDontReduceDefs,
     primAgdaTCMNoConstraints,
     primAgdaTCMRunSpeculative,
-    primAgdaTCMExec
+    primAgdaTCMExec,
+    primAgdaTCMGetInstances
     :: (HasBuiltins m, MonadError TCErr m, MonadTCEnv m, ReadTCState m) => m Term
 
 primInteger                           = getBuiltin builtinInteger
@@ -421,6 +422,7 @@ primAgdaTCMDontReduceDefs             = getBuiltin builtinAgdaTCMDontReduceDefs
 primAgdaTCMNoConstraints              = getBuiltin builtinAgdaTCMNoConstraints
 primAgdaTCMRunSpeculative             = getBuiltin builtinAgdaTCMRunSpeculative
 primAgdaTCMExec                       = getBuiltin builtinAgdaTCMExec
+primAgdaTCMGetInstances               = getBuiltin builtinAgdaTCMGetInstances
 
 -- | The coinductive primitives.
 

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -394,6 +394,7 @@ coreBuiltins =
                                                                    tTCM_ (primSigma <#> primLevelZero <#> primLevelZero <@> primNat <@>
                                                                           (Lam defaultArgInfo . Abs "_" <$> (primSigma <#> primLevelZero <#> primLevelZero <@> primString <@>
                                                                            (Lam defaultArgInfo . Abs "_" <$> primString)))))
+  , builtinAgdaTCMGetInstances               |-> builtinPostulate (tmeta --> tTCM_ (list primAgdaTerm))
   ]
   where
         (|->) = BuiltinInfo

--- a/test/Succeed/GetInstanceCandidates.agda
+++ b/test/Succeed/GetInstanceCandidates.agda
@@ -1,0 +1,37 @@
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
+open import Agda.Builtin.Unit
+
+macro
+  pickWhatever : Term → TC ⊤
+  pickWhatever hole@(meta m _) = do
+    (cand ∷ _) ← getInstances m
+      where [] -> typeError (strErr "No candidates!" ∷ [])
+    unify hole cand
+  pickWhatever _ = typeError (strErr "Already solved!" ∷ [])
+
+-- Testing basic functionality
+data YesNo : Set where instance yes no : YesNo
+
+test₁ : YesNo
+test₁ = pickWhatever
+
+test₁-ok : test₁ ≡ yes
+test₁-ok = refl
+
+-- Testing if candidates are correctly filtered
+data IsYesNo : YesNo → Set where instance
+  isYes : IsYesNo yes
+  isNo : IsYesNo no
+
+test₂ : IsYesNo no
+test₂ = pickWhatever
+
+-- Testing local candidates
+test₃ : {{YesNo}} → YesNo
+test₃ = pickWhatever
+
+test₃-ok : ∀ {x} → test₃ {{x}} ≡ x
+test₃-ok = refl


### PR DESCRIPTION
This adds a new primitive for getting all instance candidates, as discussed in https://agda.zulipchat.com/#narrow/stream/259645-developers/topic/Hint.20databases.20for.20tactics/near/260776141

Here are a few examples of how it works: https://github.com/jespercockx/agda/blob/8c30b009df05b79cd7d2afab4198d76b91936886/test/Succeed/GetInstanceCandidates.agda#L7-L37