### PR TITLE
`closed-issues-for-milestone`: Efficient retrieval of milestone (needs unreleased `github-0.28`)

### DIFF
--- a/src/release-tools/closed-issues-for-milestone/Main.hs
+++ b/src/release-tools/closed-issues-for-milestone/Main.hs
@@ -37,7 +37,10 @@ import GitHub.Data.Issues
 
 import GitHub.Data.Name ( Name( N ), untagName )
 import GitHub.Data.Milestone ( Milestone( milestoneNumber, milestoneTitle ) )
-import GitHub.Data.Options ( stateClosed )
+import GitHub.Data.Options
+  ( optionsMilestone
+  , stateClosed
+  )
 import GitHub.Data.Request ( FetchCount(FetchAll) )
 
 import GitHub.Endpoints.Issues.Milestones ( milestonesR )
@@ -130,10 +133,11 @@ run mileStoneTitle = do
   -- Debug.
   debugPrint $ "Getting issues for milestone number " ++ show  mileStoneId
 
+  let issueFilter = optionsMilestone mileStoneId <> stateClosed
   -- Get list of issues. GitHub's REST API v3 considers every pull
   -- request an issue. For this reason we get a list of both issues
   -- and pull requests when using the function 'issuesForRepo''.
-  issueVector <- crashOr $ github auth (issuesForRepoR (N owner) (N repo) stateClosed FetchAll)
+  issueVector <- crashOr $ github auth (issuesForRepoR (N owner) (N repo) issueFilter FetchAll)
     -- Symbols not exported.
     -- IssueRepoMod $ \ o ->
     --   o { issueRepoOptionsMilestone = FilterBy mileStoneId

--- a/src/release-tools/closed-issues-for-milestone/closed-issues-for-milestone.cabal
+++ b/src/release-tools/closed-issues-for-milestone/closed-issues-for-milestone.cabal
@@ -23,7 +23,7 @@ executable closed-issues-for-milestone
 
   build-depends:  base       >= 4.13.0.0  && < 4.17
                 , bytestring >= 0.10.9.0  && < 0.12
-                , github     >= 0.26      && < 0.28
+                , github     >= 0.28      && < 0.29
                 , text       >= 1.2.3     && < 1.3
                 , vector     >= 0.12.0.3  && < 0.13
 


### PR DESCRIPTION
`closed-issues-for-milestone`: Efficient retrieval of milestone (needs unreleased `github-0.28`)

The latest `github-0.27` Haskell API misses parametrization of the "repo issues" request by a milestone id.
Thus, the only way to get the closed issues for a milestone with `github-0.27` is to download _all_ closed issues.

By extending the github-0.27 API with
```
    optionsMilestone :: Id Milestone -> IssueRepoMod
```
we can communicate to github that we only want the issues for a certain milestone.
Instead of waiting for minutes, we now get the closed issues for e.g. 2.6.3 instantaneously.

Blocked on:
- https://github.com/phadej/github/pull/470