### PR TITLE
[ cabal ] allow text-2.0; remove duplicate build constraints

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -24,7 +24,7 @@ description:
   theory, a foundational system for constructive mathematics developed
   by the Swedish logician Per Martin-L&#xf6;f. It has many
   similarities with other proof assistants based on dependent types,
-  such as Coq, Epigram and NuPRL.
+  such as Coq, Idris, Lean and NuPRL.
   .
   This package includes both a command-line program (agda) and an
   Emacs mode. If you want to use the Emacs mode you can set it up by
@@ -252,7 +252,7 @@ library
                 , stm >= 2.4.4 && < 2.6
                 , strict >= 0.3.2 && < 0.5
                 , template-haskell >= 2.11.0.0 && < 2.19
-                , text >= 1.2.3.0 && < 1.3
+                , text >= 1.2.3.0 && < 2.1
                 , time >= 1.6.0.1 && < 1.13
                 , transformers >= 0.5 && < 0.7
                 , unordered-containers >= 0.2.5.0 && < 0.3
@@ -800,8 +800,8 @@ executable agda
                   -- GHC 8.2.1 RC1).
 
                   -- Nothing is used from the following package,
-                  -- except for the prelude.
-                , base >= 4.9.0.0 && < 6
+                  -- except for the Prelude.
+                , base
   default-language: Haskell2010
   -- If someone installs Agda with the setuid bit set, then the
   -- presence of +RTS may be a security problem (see GHC bug #3910).
@@ -834,7 +834,7 @@ executable agda-mode
 -- This test suite should only be run using the Makefile.
 -- The Makefile sets up the required environment,
 -- executing the tests using cabal directly is almost
--- guarantued to fail. See also Issue 1490.
+-- guaranteed to fail. See also Issue 1490.
 test-suite agda-tests
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test/
@@ -908,19 +908,18 @@ test-suite agda-tests
   build-tool-depends: Agda:agda
 
   build-depends:  Agda
-                , array >= 0.5.1.1 && < 0.6
-                , base >= 4.9.0.0 && < 4.17
-                , bytestring >= 0.10.8.1 && < 0.12
-                -- containers-0.5.11.0 is the first to contain IntSet.intersection
-                , containers >= 0.5.11.0 && < 0.7
-                , directory >= 1.2.6.2 && < 1.4
-                , filepath >= 1.4.1.0 && < 1.5
+                , array
+                , base
+                , bytestring
+                , containers
+                , directory
+                , filepath
                 , filemanip >= 0.3.6.3 && < 0.4
-                , mtl >= 2.2.1 && < 2.3
-                , process >= 1.4.2.0 && < 1.7
+                , mtl
+                , process
                 , process-extras >= 0.3.0 && < 0.3.4 || >= 0.4.1.3 && < 0.5 || >= 0.7.1 && < 0.8
                 , QuickCheck >= 2.14.1 && < 2.15
-                , regex-tdfa >= 1.3.1.0 && < 1.4
+                , regex-tdfa
                 , strict >= 0.3.2 && < 0.5
                 , tasty >= 1.1.0.4 && < 1.5
                 , tasty-hunit >= 0.9.2 && < 0.11
@@ -930,30 +929,13 @@ test-suite agda-tests
                 -- tasty-silver < 3.3 does not work interactively under Windows
                 , tasty-silver >= 3.1.13 && < 3.4
                 , temporary >= 1.2.0.3 && < 1.4
-                , text >= 1.2.3.0 && < 1.3
+                , text
                 , unix-compat >= 0.4.3.1 && < 0.6
-                , uri-encode >= 1.5.0.4 && < 1.6
+                , uri-encode
 
   -- Andreas (2021-10-11): tasty-silver < 3.3 does not work interactively under Windows
   if os(windows)
     build-depends: tasty-silver >= 3.3
-
-  -- ASR (2018-10-16).
-  -- text-1.2.3.0 required for supporting GHC 8.4.1, 8.4.2 and
-  -- 8.4.3. See Issue #3277.
-  -- The other GHC versions can be restricted to >= 1.2.3.1.
-  if impl(ghc < 8.4.1) || impl(ghc > 8.4.3)
-    build-depends: text >= 1.2.3.1
-
-  -- Agda cannot be built with GHC 8.6.1 due to a compiler bug, see
-  -- Agda Issue #3344.
-  if impl(ghc == 8.6.1)
-    buildable: False
-
-  -- Agda cannot be built with Windows and GHC 8.6.3 due to a compiler
-  -- bug, see Agda Issue #3657.
-  if os(windows) && impl(ghc == 8.6.3)
-    buildable: False
 
   default-language:  Haskell2010
 


### PR DESCRIPTION
[ cabal ] allow text-2.0; remove duplicate build constraints.

If a component depends on `Agda`, the build constraints and package
versions constraints are inherited and need not be stated again.