### PR TITLE
Fix #5710: use `cabal user-config` to add extra-*-dirs settings

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -62,8 +62,7 @@ jobs:
         mkdir -p ${ICU_DIR}/include/unicode
         mv ${ICU_DIR}/*.h ${ICU_DIR}/include/unicode
 
-        echo "extra-lib-dirs: $(cygpath -w ${ICU_DIR})">> ${APPDATA}/cabal/config
-        echo "extra-include-dirs: $(cygpath -w ${ICU_DIR}/include)" >> ${APPDATA}/cabal/config
+        cabal user-config update --augment="extra-lib-dirs: $(cygpath -w ${ICU_DIR})" --augment="extra-include-dirs: $(cygpath -w ${ICU_DIR}/include)"
       name: Download the icu4c library from unicode-org (Windows)
     - with:
         path: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,8 +86,7 @@ jobs:
         7z e ${ICU_FILE} -o${ICU_DIR} && rm ${ICU_FILE}
         mkdir -p ${ICU_DIR}/include/unicode && mv ${ICU_DIR}/*.h ${ICU_DIR}/include/unicode
 
-        echo "extra-lib-dirs: $(cygpath -w ${ICU_DIR})">> ${APPDATA}/cabal/config
-        echo "extra-include-dirs: $(cygpath -w ${ICU_DIR}/include)" >> ${APPDATA}/cabal/config
+        cabal user-config update --augment="extra-lib-dirs: $(cygpath -w ${ICU_DIR})" --augment="extra-include-dirs: $(cygpath -w ${ICU_DIR}/include)"
       name: Install the icu4c library (Windows)
     - run: |
         cabal configure ${{ steps.vars.outputs.args }}

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -92,8 +92,7 @@ jobs:
         mkdir -p ${ICU_DIR}/include/unicode
         mv ${ICU_DIR}/*.h ${ICU_DIR}/include/unicode
 
-        echo "extra-lib-dirs: $(cygpath -w ${ICU_DIR})">> ${APPDATA}/cabal/config
-        echo "extra-include-dirs: $(cygpath -w ${ICU_DIR}/include)" >> ${APPDATA}/cabal/config
+        cabal user-config update --augment="extra-lib-dirs: $(cygpath -w ${ICU_DIR})" --augment="extra-include-dirs: $(cygpath -w ${ICU_DIR}/include)"
 
     - uses: actions/cache@v2
       name: Cache dependencies

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -100,8 +100,7 @@ jobs:
         7z e ${ICU_FILE} -o${ICU_DIR} && rm ${ICU_FILE}
         mkdir -p ${ICU_DIR}/include/unicode && mv ${ICU_DIR}/*.h ${ICU_DIR}/include/unicode
 
-        echo "extra-lib-dirs: $(cygpath -w ${ICU_DIR})">> ${APPDATA}/cabal/config
-        echo "extra-include-dirs: $(cygpath -w ${ICU_DIR}/include)" >> ${APPDATA}/cabal/config
+        cabal user-config update --augment="extra-lib-dirs: $(cygpath -w ${ICU_DIR})" --augment="extra-include-dirs: $(cygpath -w ${ICU_DIR}/include)"
 
     - name: Configure the build plan
       run: |


### PR DESCRIPTION
Fix #5710: use `cabal user-config` to add extra-*-dirs settings in github workflows.