### PR TITLE
[ close #5715 ] Use `Telescope` instead of `List (Arg Type)` in the reflection API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,8 +84,6 @@ jobs:
         sudo apt-get install texlive-binaries ${APT_GET_OPTS}
         sudo apt-get install emacs-nox ${APT_GET_OPTS}
       name: Install Tex Live and Emacs
-    - run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
-      name: Cubical library test
     - run: |
         make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs
         make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-summary
@@ -104,6 +102,8 @@ jobs:
       name: User manual (test)
     - run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" testing-emacs-mode
       name: Testing the Emacs mode
+    - run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
+      name: Cubical library test
   test:
     runs-on: ${{ needs.build.outputs.os }}
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ Language
     pickWhatever _ = typeError (strErr "Already solved!" ∷ [])
   ```
 
+* The reflection primitives `getContext` and `inContext` use nominal context
+  `List (Σ String λ _ → Arg Type)` instead of  `List (Arg Type)` for printing
+  type information better. Similarly, `extendContext` takes an extra argument
+  of type `String`.
+
+
 
 Syntax
 ------

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -417,15 +417,15 @@ following primitive operations::
     -- it is indexable by deBruijn index. Note that the types in the context are
     -- valid in the rest of the context. To use in the current context they need
     -- to be weakened by 1 + their position in the list.
-    getContext : TC (List (Arg Type))
+    getContext : TC Telescope
 
-    -- Extend the current context with a variable of the given type.
-    extendContext : ∀ {a} {A : Set a} → Arg Type → TC A → TC A
+    -- Extend the current context with a variable of the given type and its name.
+    extendContext : ∀ {a} {A : Set a} → String → Arg Type → TC A → TC A
 
     -- Set the current context. Takes a context telescope entries in
     -- reverse order, as given by `getContext`. Each type should be valid
     -- in the context formed by the remaining elements in the list.
-    inContext : ∀ {a} {A : Set a} → List (Arg Type) → TC A → TC A
+    inContext : ∀ {a} {A : Set a} → Telescope → TC A → TC A
 
     -- Quote a value, returning the corresponding Term.
     quoteTC : ∀ {a} {A : Set a} → A → TC Term

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -164,6 +164,7 @@ data Sort    : Set
 data Pattern : Set
 data Clause  : Set
 Type = Term
+Telescope = List (Σ String λ _ → Arg Type)
 
 data Term where
   var       : (x : Nat) (args : List (Arg Term)) → Term
@@ -194,8 +195,8 @@ data Pattern where
   absurd : (x : Nat)     → Pattern  -- absurd patterns counts as variables
 
 data Clause where
-  clause        : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) (t : Term) → Clause
-  absurd-clause : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) → Clause
+  clause        : (tel : Telescope) (ps : List (Arg Pattern)) (t : Term) → Clause
+  absurd-clause : (tel : Telescope) (ps : List (Arg Pattern)) → Clause
 
 {-# BUILTIN AGDATERM      Term    #-}
 {-# BUILTIN AGDASORT      Sort    #-}
@@ -276,9 +277,9 @@ postulate
   quoteTC          : ∀ {a} {A : Set a} → A → TC Term
   unquoteTC        : ∀ {a} {A : Set a} → Term → TC A
   quoteωTC         : ∀ {A : Setω} → A → TC Term
-  getContext       : TC (List (Arg Type))
-  extendContext    : ∀ {a} {A : Set a} → Arg Type → TC A → TC A
-  inContext        : ∀ {a} {A : Set a} → List (Arg Type) → TC A → TC A
+  getContext       : TC Telescope
+  extendContext    : ∀ {a} {A : Set a} → String → Arg Type → TC A → TC A
+  inContext        : ∀ {a} {A : Set a} → Telescope → TC A → TC A
   freshName        : String → TC Name
   declareDef       : Arg Name → Type → TC ⊤
   declarePostulate : Arg Name → Type → TC ⊤
@@ -371,7 +372,7 @@ postulate
 {-# COMPILE JS unquoteTC         = _ => _ => _ =>      undefined #-}
 {-# COMPILE JS quoteωTC          = _ => _ =>           undefined #-}
 {-# COMPILE JS getContext        =                     undefined #-}
-{-# COMPILE JS extendContext     = _ => _ => _ => _ => undefined #-}
+{-# COMPILE JS extendContext     = _ => _ => _ => _ => _ => undefined #-}
 {-# COMPILE JS inContext         = _ => _ => _ => _ => undefined #-}
 {-# COMPILE JS freshName         = _ =>                undefined #-}
 {-# COMPILE JS declareDef        = _ => _ =>           undefined #-}

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -987,7 +987,7 @@ contextOfMeta ii norm = withInteractionId ii $ do
          <*> forMaybeM letVars mkLet
 
   where
-    mkVar :: Dom (Name, Type) -> TCM (Maybe ResponseContextEntry)
+    mkVar :: ContextEntry -> TCM (Maybe ResponseContextEntry)
     mkVar Dom{ domInfo = ai, unDom = (name, t) } = do
       if shouldHide ai name then return Nothing else Just <$> do
         let n = nameConcrete name

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -420,8 +420,8 @@ addLetBinding info x v t0 ret = addLetBinding' x v (defaultArgDom info t0) ret
 -- * Querying the context
 
 -- | Get the current context.
-{-# SPECIALIZE getContext :: TCM [Dom (Name, Type)] #-}
-getContext :: MonadTCEnv m => m [Dom (Name, Type)]
+{-# SPECIALIZE getContext :: TCM Context #-}
+getContext :: MonadTCEnv m => m Context
 getContext = asksTC envContext
 
 -- | Get the size of the current context.
@@ -452,8 +452,8 @@ getContextNames = map (fst . unDom) <$> getContext
 
 -- | get type of bound variable (i.e. deBruijn index)
 --
-{-# SPECIALIZE lookupBV' :: Nat -> TCM (Maybe (Dom (Name, Type))) #-}
-lookupBV' :: MonadTCEnv m => Nat -> m (Maybe (Dom (Name, Type)))
+{-# SPECIALIZE lookupBV' :: Nat -> TCM (Maybe ContextEntry) #-}
+lookupBV' :: MonadTCEnv m => Nat -> m (Maybe ContextEntry)
 lookupBV' n = do
   ctx <- getContext
   return $ raise (n + 1) <$> ctx !!! n

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -1,6 +1,9 @@
 
 module Agda.TypeChecking.Monad.Context where
 
+import Data.Text (Text)
+import qualified Data.Text as T
+
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
@@ -328,6 +331,10 @@ instance AddContext (List1 (NamedArg Name), Type) where
 instance AddContext (String, Dom Type) where
   addContext (s, dom) ret =
     withFreshName noRange s $ \x -> addCtx (setNotInScope x) dom ret
+  contextSize _ = 1
+
+instance AddContext (Text, Dom Type) where
+  addContext (s, dom) ret = addContext (T.unpack s, dom) ret
   contextSize _ = 1
 
 instance AddContext (KeepNames String, Dom Type) where

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -209,7 +209,7 @@ instance PrettyTCM (Arg A.Expr)       where prettyTCM = prettyA <=< reify
 instance PrettyTCM (NamedArg A.Expr)  where prettyTCM = prettyA <=< reify
 instance PrettyTCM (NamedArg Term)    where prettyTCM = prettyA <=< reify
 instance PrettyTCM (Dom Type)         where prettyTCM = prettyA <=< reify
-instance PrettyTCM (Dom (Name, Type)) where prettyTCM = prettyA <=< reify
+instance PrettyTCM ContextEntry       where prettyTCM = prettyA <=< reify
 
 instance PrettyTCM Permutation where prettyTCM = text . show
 instance PrettyTCM Polarity    where prettyTCM = text . show

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -33,7 +33,7 @@ import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Level
 
-import Agda.TypeChecking.Quote (quoteTermWithKit, quoteTypeWithKit, quotingKit)
+import Agda.TypeChecking.Quote (quoteTermWithKit, quoteTypeWithKit, quoteDomWithKit, quotingKit)
 import Agda.TypeChecking.Primitive.Base
 import Agda.TypeChecking.Primitive.Cubical
 import Agda.TypeChecking.Warnings
@@ -189,6 +189,10 @@ instance ToTerm Bool where
 instance ToTerm Term where
   toTerm  = do kit <- quotingKit; runReduceF (quoteTermWithKit kit)
   toTermR = do quoteTermWithKit <$> quotingKit;
+
+instance ToTerm (Dom Type) where
+  toTerm  = do kit <- quotingKit; runReduceF (quoteDomWithKit kit)
+  toTermR = do quoteDomWithKit <$> quotingKit
 
 instance ToTerm Type where
   toTerm  = do kit <- quotingKit; runReduceF (quoteTypeWithKit kit)

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -221,11 +221,11 @@ quotingKit = do
 
       quoteTelescope :: Telescope -> ReduceM Term
       quoteTelescope tel = quoteList quoteTelEntry $ telToList tel
-        where
-          quoteTelEntry :: Dom (ArgName, Type) -> ReduceM Term
-          quoteTelEntry dom@Dom{ unDom = (x , t) } = do
-            SigmaKit{..} <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
-            Con sigmaCon ConOSystem [] !@! quoteString x @@ quoteDom quoteType (fmap snd dom)
+
+      quoteTelEntry :: Dom (ArgName, Type) -> ReduceM Term
+      quoteTelEntry dom@Dom{ unDom = (x , t) } = do
+        SigmaKit{..} <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
+        Con sigmaCon ConOSystem [] !@! quoteString x @@ quoteDom quoteType (fmap snd dom)
 
       list :: [ReduceM Term] -> ReduceM Term
       list = foldr (\ a as -> cons !@ a @@ as) (pure nil)

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -366,7 +366,7 @@ coreBuiltins =
                                                                    tTCM 1 (varM 0) --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMGetContext                 |-> builtinPostulate (tTCM_ (unEl <$> tlist (targ ttype)))
   , builtinAgdaTCMExtendContext              |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
-                                                                   targ ttype --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+                                                                   tstring --> targ ttype --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMInContext                  |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
                                                                    tlist (targ ttype) --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMFreshName                  |-> builtinPostulate (tstring --> tTCM_ primQName)

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -368,7 +368,7 @@ coreBuiltins =
   , builtinAgdaTCMExtendContext              |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
                                                                    tstring --> targ ttype --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMInContext                  |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
-                                                                   tlist (targ ttype) --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+                                                                   ttelescope --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMFreshName                  |-> builtinPostulate (tstring --> tTCM_ primQName)
   , builtinAgdaTCMDeclareDef                 |-> builtinPostulate (targ tqname --> ttype --> tTCM_ primUnit)
   , builtinAgdaTCMDeclarePostulate           |-> builtinPostulate (targ tqname --> ttype --> tTCM_ primUnit)

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -364,7 +364,7 @@ coreBuiltins =
   , builtinAgdaTCMReduce                     |-> builtinPostulate (tterm --> tTCM_ primAgdaTerm)
   , builtinAgdaTCMCatchError                 |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
                                                                    tTCM 1 (varM 0) --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
-  , builtinAgdaTCMGetContext                 |-> builtinPostulate (tTCM_ (unEl <$> tlist (targ ttype)))
+  , builtinAgdaTCMGetContext                 |-> builtinPostulate (tTCM_ (unEl <$> ttelescope))
   , builtinAgdaTCMExtendContext              |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
                                                                    tstring --> targ ttype --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMInContext                  |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -586,7 +586,6 @@ evalTCM v = do
     I.Def f [_, _, u, v] ->
       choice [ (f `isDef` primAgdaTCMCatchError,    tcCatchError    (unElim u) (unElim v))
              , (f `isDef` primAgdaTCMWithNormalisation, tcWithNormalisation (unElim u) (unElim v))
---             , (f `isDef` primAgdaTCMExtendContext, tcExtendContext (unElim u) (unElim v))
              , (f `isDef` primAgdaTCMInContext,     tcInContext     (unElim u) (unElim v))
              , (f `isDef` primAgdaTCMOnlyReduceDefs, tcOnlyReduceDefs (unElim u) (unElim v))
              , (f `isDef` primAgdaTCMDontReduceDefs, tcDontReduceDefs (unElim u) (unElim v))
@@ -802,9 +801,9 @@ evalTCM v = do
       c <- unquote c
       liftU1 unsafeInTopContext $ go c (evalTCM m)
       where
-        go :: [Arg R.Type] -> UnquoteM Term -> UnquoteM Term
+        go :: [(Text , Arg R.Type)] -> UnquoteM Term -> UnquoteM Term
         go []       m = m
-        go (a : as) m = go as (extendCxt "x" a m)
+        go ((s , a) : as) m = go as (extendCxt (T.unpack s) a m)
 
     constInfo :: QName -> TCM Definition
     constInfo x = either err return =<< getConstInfo' x

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -292,9 +292,6 @@ jobs:
         sudo apt-get install texlive-binaries ${APT_GET_OPTS}
         sudo apt-get install emacs-nox ${APT_GET_OPTS}
 
-    - name: "Cubical library test"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
-
     - name: "Benchmark"
       run: |
         make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs
@@ -320,3 +317,10 @@ jobs:
 
     - name: "Testing the Emacs mode"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" testing-emacs-mode
+
+    # (Liang-Ting Chen, 2022-01-02): For testing breaking changes where
+    # libraries need to be updated, cubical library test is moved to the end of
+    # this job.
+    - name: "Cubical library test"
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
+

--- a/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
+++ b/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
@@ -113,6 +113,7 @@ data Sort   : Set
 data Clause : Set
 data Term   : Set
 Type = Term
+Telescope = List (Σ String λ _ → Arg Type)
 
 data Term where
   var       : (x : Nat) (args : List (Arg Term)) → Term
@@ -143,8 +144,8 @@ data Pattern : Set where
   absurd : (x : Nat)     → Pattern
 
 data Clause where
-  clause        : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) (t : Term) → Clause
-  absurd-clause : (tel : List (Σ String λ _ → Arg Type)) (ps : List (Arg Pattern)) → Clause
+  clause        : (tel : Telescope) (ps : List (Arg Pattern)) (t : Term) → Clause
+  absurd-clause : (tel : Telescope) (ps : List (Arg Pattern)) → Clause
 
 {-# BUILTIN AGDATERM    Term    #-}
 {-# BUILTIN AGDASORT    Sort    #-}
@@ -223,9 +224,9 @@ postulate
   catchTC       : ∀ {a} {A : Set a} → TC A → TC A → TC A
   quoteTC       : ∀ {a} {A : Set a} → A → TC Term
   unquoteTC     : ∀ {a} {A : Set a} → Term → TC A
-  getContext    : TC (List (Arg Type))
-  extendContext : ∀ {a} {A : Set a} → Arg Type → TC A → TC A
-  inContext     : ∀ {a} {A : Set a} → List (Arg Type) → TC A → TC A
+  getContext    : TC Telescope
+  extendContext : ∀ {a} {A : Set a} → String → Arg Type → TC A → TC A
+  inContext     : ∀ {a} {A : Set a} → Telescope → TC A → TC A
   freshName     : String → TC Name
   declareDef    : Arg Name → Type → TC ⊤
   defineFun     : Name → List Clause → TC ⊤

--- a/test/Succeed/Issue1833.agda
+++ b/test/Succeed/Issue1833.agda
@@ -18,13 +18,17 @@ macro
 
 -- The context on the rhs of each of the two functions below is the same, a single String
 
-Γ = vArg (def (quote String) []) ∷ []
+Γ : Telescope
+Γ = ("s" , vArg (def (quote String) [])) ∷ []
 
 context-Γ₀ : String → This: Γ
 context-Γ₀ s = this: evalT getContext
 
 module _ (S : String) where
-  context-Γ₁ : This: Γ
+  Γ' : Telescope
+  Γ' = ("S" , vArg (def (quote String) [])) ∷ []
+
+  context-Γ₁ : This: Γ'
   context-Γ₁ = this: evalT getContext
 
 downMap : {A : Set} → (Nat → A) → Nat → List A

--- a/test/Succeed/Issue5075.agda
+++ b/test/Succeed/Issue5075.agda
@@ -27,7 +27,7 @@ macro
   rtest f a = do
      (function (clause tel _ t ∷ [])) ← withReconstructed (getDefinition f) where
         _ → typeError (strErr "ERROR" ∷ [])
-     t ← inContext (reverse (map snd tel)) (normalise t)
+     t ← inContext (reverse tel) (normalise t)
      quoteTC t >>= unify a
 
 transp : ∀ m n → Vec (Vec Nat n) m → Vec (Vec Nat m) n

--- a/test/Succeed/normalise-bug.agda
+++ b/test/Succeed/normalise-bug.agda
@@ -30,7 +30,7 @@ macro
   ntest f a = do
      (function te@(clause tel _ t ∷ [])) ← withReconstructed $ getDefinition f where
         _ → typeError $ strErr "ERROR" ∷ []
-     t ← withReconstructed $ inContext (reverse $ map snd tel) $ normalise t
+     t ← withReconstructed $ inContext (reverse tel) $ normalise t
      quoteTC t >>= unify a
 
 -- A record with parameters.

--- a/test/Succeed/recons-tele.agda
+++ b/test/Succeed/recons-tele.agda
@@ -53,9 +53,8 @@ macro
     (function (clause tel ps t ∷ [])) ←
       withReconstructed $ getDefinition n
       where _ → quoteTC "ERROR" >>= unify hole
-    let ctx = map snd tel
     t ← withReconstructed
-        $ inContext (reverse ctx)
+        $ inContext (reverse tel)
         $ normalise t
     quoteTC t >>= unify hole
 

--- a/test/Succeed/recons-with-reducedefs.agda
+++ b/test/Succeed/recons-with-reducedefs.agda
@@ -54,8 +54,7 @@ macro
   y hole = do
       (function (clause tel ps t ∷ [])) ← withReconstructed (dontReduceDefs (quote foo ∷ []) (getDefinition (quote bar)))
         where _ → quoteTC "ERROR" >>= unify hole
-      let ctx = map snd tel
-      t ← inContext (reverse ctx)
+      t ← inContext (reverse tel)
           (withReconstructed (dontReduceDefs (quote foo ∷ []) (normalise t)))
       quoteTC t >>= unify hole
 

--- a/test/Succeed/test-recons.agda
+++ b/test/Succeed/test-recons.agda
@@ -60,8 +60,7 @@ macro
     (function (clause tel ps t ∷ [])) ←
       withReconstructed (getDefinition n)
       where _ → quoteTC "ERROR" >>= unify hole
-    let ctx = map snd tel
-    t ← inContext (reverse ctx)
+    t ← inContext (reverse tel)
         (withReconstructed (normalise t))
     let d = function (clause tel ps t ∷ [])
     get-len d >>= unify hole
@@ -72,8 +71,7 @@ macro
     (function (clause tel ps t ∷ [])) ←
       withReconstructed (getDefinition n)
       where _ → quoteTC "ERROR" >>= unify hole
-    let ctx = map snd tel
-    t ← inContext (reverse ctx) (withReconstructed (reduce t))
+    t ← inContext (reverse tel) (withReconstructed (reduce t))
     let d = function (clause tel ps t ∷ [])
     get-len d >>= unify hole
 
@@ -91,8 +89,8 @@ test₄ : (lit (nat 5)) ≡ def-redR test-rvec
 test₄ = refl
 
 
-pictx : Term → List (Arg Type)
-pictx (pi a (abs s x)) = a ∷ pictx x
+pictx : Term → Telescope
+pictx (pi a (abs s x)) = (s , a) ∷ pictx x
 pictx _ = []
 
 macro
@@ -108,9 +106,8 @@ bar : (A : Set) (eq : [] {A = A} ≡ []) (x : Nat) → ⊤
 bar _ _ _ = tt
 
 -- if getContext were to work incorrectly, this function wouldn't typecheck
-test₅ : List (Arg Type)
+test₅ : Telescope
 test₅ = get-ctx bar
-
 
 
 data NotAVec (X : Set) (y : Nat) : Set where

--- a/test/interaction/Issue3831.agda
+++ b/test/interaction/Issue3831.agda
@@ -18,11 +18,11 @@ postulate
 macro
   test1 : Nat → Term → TC _
   test1 n _ =
-    extendContext (vArg (quoteTerm Nat)) do
+    extendContext "x" (vArg (quoteTerm Nat)) do
       var₀ i ← quoteTC n where _ → whatever
       m ← unquoteTC {A = Nat} (var₀ 0)
       var₀ j ← quoteTC m where _ → whatever
-      extendContext (vArg (quoteTerm Nat)) do
+      extendContext "x" (vArg (quoteTerm Nat)) do
         var₀ k ← quoteTC n where _ → whatever
         var₀ l ← quoteTC m where _ → whatever
         typeError (strErr (show i ++ show k ++ show j ++ show l) ∷ [])
@@ -30,9 +30,9 @@ macro
   test2 : Term → TC _
   test2 hole = do
     st ← quoteTC Set
-    t ← extendContext (vArg st) do
+    t ← extendContext "x" (vArg st) do
       v ← unquoteTC {A = Set} (var₀ zero)
-      extendContext (vArg (var₀ zero)) do
+      extendContext "x" (vArg (var₀ zero)) do
         _ ← unquoteTC {A = v} (var₀ zero)
         return tt
     u ← quoteTC t
@@ -40,11 +40,11 @@ macro
 
   test3 : Nat → Term → TC _
   test3 n _ = do
-    m      ← extendContext (vArg (quoteTerm Nat)) (return n)
+    m      ← extendContext "x" (vArg (quoteTerm Nat)) (return n)
     var₀ i ← quoteTC m where _ → whatever
     typeError (strErr (show i) ∷ [])
 
   localvar : Term → TC _
   localvar _ = do
-    m ← extendContext (vArg (quoteTerm Nat)) (unquoteTC {A = Nat} (var₀ 0))
+    m ← extendContext "x" (vArg (quoteTerm Nat)) (unquoteTC {A = Nat} (var₀ 0))
     typeError (strErr (show m) ∷ [])


### PR DESCRIPTION
This PR includes the following changes to implement the proposal #5715

* Add `Telescope = List (Σ String λ _ → Arg Type)` in `Agda.Builtin.Reflection`.
* `getContext` returns a `Telescope` instead of `List (Arg Type)`.
* `inContext` takes a `Telescope` instead of `List (Arg Type)`.
* `extendContext` takes an additional argument of type `String`.

I will document this change in the CHANGELOG and the documentation once this PR is reviewed.

### Question

What's the difference between `runReduceM` and `runReduceF`? 
The current implementation of `tcGetContext` uses `quoteDom` which uses `runReduceM` in the end:

https://github.com/agda/agda/blob/ee722117bf17786432b27f674acb85db7de669fa/src/full/Agda/TypeChecking/Quote.hs#L372-L375

In my PR, I use `toTerm` to quote a pair since it is already there, but I am aware that `toTerm` uses `runReduceF`. Given the comment 
https://github.com/agda/agda/blob/ee722117bf17786432b27f674acb85db7de669fa/src/full/Agda/TypeChecking/Monad/Base.hs#L3944-L3960
I am not sure in this case which version is more appropriate, but both of them seem working anyway.