### PR TITLE
Fix #5718: compatibility with `bytestring-0.11.2`

### DIFF
--- a/src/full/Agda/Utils/Null.hs
+++ b/src/full/Agda/Utils/Null.hs
@@ -11,8 +11,8 @@ import Control.Monad
 import Control.Monad.Reader
 import Control.Monad.State
 
-import Data.ByteString.Char8 (ByteString)
-import qualified Data.ByteString.Char8 as ByteString
+import qualified Data.ByteString.Char8 as ByteStringChar8
+import qualified Data.ByteString.Lazy as ByteStringLazy
 
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
@@ -64,9 +64,13 @@ instance (Null a, Null b, Null c, Null d) => Null (a,b,c,d) where
   empty          = (empty, empty, empty, empty)
   null (a,b,c,d) = null a && null b && null c && null d
 
-instance Null ByteString where
-  empty = ByteString.empty
-  null  = ByteString.null
+instance Null ByteStringChar8.ByteString where
+  empty = ByteStringChar8.empty
+  null  = ByteStringChar8.null
+
+instance Null ByteStringLazy.ByteString where
+  empty = ByteStringLazy.empty
+  null  = ByteStringLazy.null
 
 instance Null Text where
   empty = Text.empty


### PR DESCRIPTION
Fix #5718: compatibility with `bytestring-0.11.2`

This minor version of `bytestring` introduced `Data.ByteString.Builder.writeFile` which clashes with `Data.ByteString.Lazy.writeFile`.

See https://hackage.haskell.org/package/bytestring-0.11.2.0/docs/Data-ByteString-Builder.html#v:writeFile