### PR TITLE
Allow running of erased macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@ Language
   type information better. Similarly, `extendContext` takes an extra argument
   of type `String`.
 
+* `macro` definitions can now be used even when they are declared as erased.
+  For example, this is now accepted:
+  ```agda
+  macro
+    @0 trivial : Term → TC ⊤
+    trivial = unify (con (quote refl) [])
+
+  test : 42 ≡ 42
+  test = trivial
+  ```
 
 
 Syntax

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -118,7 +118,7 @@ toAbstractWithoutImplicit ::
   , HasConstInfo m
   ) => r -> m (AbsOfRef r)
 toAbstractWithoutImplicit x = do
-  xs <- getContextNames
+  xs <- killRange <$> getContextNames
   let ctx = zip xs $ repeat R.Unknown
   runReaderT (toAbstract x) ctx
 

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -336,7 +336,8 @@ unquoteTop xs e = do
   lzero <- primLevelZero
   let vArg = defaultArg
       hArg = setHiding Hidden . vArg
-  m    <- checkExpr e $ El (mkType 0) $ apply tcm [hArg lzero, vArg unit]
+  m    <- applyQuantityToContext zeroQuantity $
+            checkExpr e $ El (mkType 0) $ apply tcm [hArg lzero, vArg unit]
   res  <- runUnquoteM $ tell xs >> evalTCM m
   case res of
     Left err      -> typeError $ UnquoteFailed err

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1338,7 +1338,8 @@ doQuoteTerm cmp et t = do
 -- | Unquote a TCM computation in a given hole.
 unquoteM :: A.Expr -> Term -> Type -> TCM ()
 unquoteM tacA hole holeType = do
-  tac <- checkExpr tacA =<< (el primAgdaTerm --> el (primAgdaTCM <#> primLevelZero <@> primUnit))
+  tac <- applyQuantityToContext zeroQuantity $
+    checkExpr tacA =<< (el primAgdaTerm --> el (primAgdaTCM <#> primLevelZero <@> primUnit))
   inFreshModuleIfFreeParams $ unquoteTactic tac hole holeType
 
 -- | Run a tactic `tac : Term → TC ⊤` in a hole (second argument) of the type

--- a/test/Fail/ErasedMacro1.agda
+++ b/test/Fail/ErasedMacro1.agda
@@ -1,0 +1,15 @@
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Unit
+
+@0 A : Set₁
+A = Set
+
+macro
+
+  @0 m : Term → TC ⊤
+  m B =
+    bindTC (quoteTC A) λ A →
+    unify A B
+
+B : Set₁
+B = m

--- a/test/Fail/ErasedMacro1.err
+++ b/test/Fail/ErasedMacro1.err
@@ -1,0 +1,3 @@
+ErasedMacro1.agda:15,5-6
+Identifier A is declared erased, so it cannot be used here
+when inferring the type of A

--- a/test/Fail/ErasedMacro2.agda
+++ b/test/Fail/ErasedMacro2.agda
@@ -1,0 +1,12 @@
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Unit
+
+macro
+
+  @0 m : @0 Set → Term → TC ⊤
+  m A B =
+    bindTC (quoteTC A) λ A →
+    unify A B
+
+F : @0 Set → Set
+F A = m A

--- a/test/Fail/ErasedMacro2.err
+++ b/test/Fail/ErasedMacro2.err
@@ -1,0 +1,3 @@
+ErasedMacro2.agda:12,7-10
+Variable A is declared erased, so it cannot be used here
+when inferring the type of A

--- a/test/Fail/ErasedMacro3.agda
+++ b/test/Fail/ErasedMacro3.agda
@@ -1,0 +1,12 @@
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Unit
+
+macro
+
+  @0 m : Set → Term → TC ⊤
+  m A B =
+    bindTC (quoteTC A) λ A →
+    unify A B
+
+F : @0 Set → Set
+F A = m A

--- a/test/Fail/ErasedMacro3.err
+++ b/test/Fail/ErasedMacro3.err
@@ -1,0 +1,3 @@
+ErasedMacro3.agda:12,7-10
+Variable A is declared erased, so it cannot be used here
+when inferring the type of A

--- a/test/Fail/ErasedMacro4.agda
+++ b/test/Fail/ErasedMacro4.agda
@@ -1,0 +1,19 @@
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Unit
+
+@0 m : Name → TC ⊤
+m F = defineFun F
+  (clause
+     (( "A"
+      , arg (arg-info visible (modality relevant quantity-0))
+          (agda-sort (lit 0))) ∷
+      [])
+     (arg (arg-info visible (modality relevant quantity-0)) (var 0) ∷
+      [])
+     (var 0 []) ∷
+   [])
+
+F : @0 Set → Set
+unquoteDef F = m F

--- a/test/Fail/ErasedMacro4.err
+++ b/test/Fail/ErasedMacro4.err
@@ -1,0 +1,3 @@
+ErasedMacro4.agda:19,1-19
+Variable A is declared erased, so it cannot be used here
+when checking that the expression A has type Set

--- a/test/Succeed/ErasedMacro.agda
+++ b/test/Succeed/ErasedMacro.agda
@@ -3,6 +3,7 @@ open import Agda.Builtin.List
 open import Agda.Builtin.Nat
 open import Agda.Builtin.Equality
 open import Agda.Builtin.Reflection
+open import Agda.Builtin.Sigma
 
 macro
   @0 trivial : Term → TC ⊤
@@ -10,3 +11,18 @@ macro
 
 test : 42 ≡ 42
 test = trivial
+
+@0 m : Name → TC ⊤
+m F = defineFun F
+  (clause
+     (( "A"
+      , arg (arg-info visible (modality relevant quantity-0))
+          (agda-sort (lit 0))) ∷
+      [])
+     (arg (arg-info visible (modality relevant quantity-0)) (var 0) ∷
+      [])
+     (var 0 []) ∷
+   [])
+
+F : Set → Set
+unquoteDef F = m F

--- a/test/Succeed/ErasedMacro.agda
+++ b/test/Succeed/ErasedMacro.agda
@@ -1,0 +1,12 @@
+open import Agda.Builtin.Unit
+open import Agda.Builtin.List
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Reflection
+
+macro
+  @0 trivial : Term → TC ⊤
+  trivial = unify (con (quote refl) [])
+
+test : 42 ≡ 42
+test = trivial


### PR DESCRIPTION
As discussed in https://github.com/agda/agda/issues/5734, macros are always executed during compile time so it should be allowed to mark them as erased.