### PR TITLE
Add a primitive to format `Reflection.ErrorParts` and a built-in constructor `Pattern -> ErrorPart`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Language
     pickWhatever _ = typeError (strErr "Already solved!" ∷ [])
   ```
 
-* The reflection primitives `getContext` and `inContext` use nominal context
+* The reflection primitives `getContext` and `inContext` use a nominal context
   `List (Σ String λ _ → Arg Type)` instead of  `List (Arg Type)` for printing
   type information better. Similarly, `extendContext` takes an extra argument
   of type `String`.
@@ -80,6 +80,11 @@ Language
   test = trivial
   ```
 
+* A new reflection primitive `formatErrorParts : List ErrorPart → TC String` 
+  is added. It takes a list of `ErrorPart` and return its formatted string.
+
+* A new constructor `pattErr : Pattern → ErrorPart` of `ErrorPart` for reflection
+  is added.
 
 Syntax
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ Language
   test = trivial
   ```
 
-* A new reflection primitive `formatErrorParts : List ErrorPart → TC String` 
+* A new reflection primitive `formatErrorParts : List ErrorPart → TC String`
   is added. It takes a list of `ErrorPart` and return its formatted string.
 
 * A new constructor `pattErr : Pattern → ErrorPart` of `ErrorPart` for reflection

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -351,6 +351,7 @@ implement pretty printing for reflected terms.
   data ErrorPart : Set where
     strErr  : String → ErrorPart
     termErr : Term → ErrorPart
+    pattErr : Pattern → ErrorPart
     nameErr : Name → ErrorPart
 
   {-# BUILTIN AGDAERRORPART       ErrorPart #-}
@@ -473,6 +474,9 @@ following primitive operations::
     -- to the info buffer instead. For instance, giving -v a.b.c:10 enables
     -- printing from debugPrint "a.b.c.d" 10 msg.
     debugPrint : String → Nat → List ErrorPart → TC ⊤
+
+    -- Return the formatted string of the argument using the internal pretty printer.
+    formatErrorParts : List ErrorPart → TC String
 
     -- Only allow reduction of specific definitions while executing the TC computation
     onlyReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -298,6 +298,7 @@ postulate
   -- getDefinition, normalise, reduce, inferType, checkType and getContext
   withReconstructed : ∀ {a} {A : Set a} → TC A → TC A
 
+  formatErrorParts : List ErrorPart → TC String
   -- Prints the third argument if the corresponding verbosity level is turned
   -- on (with the -v flag to Agda).
   debugPrint : String → Nat → List ErrorPart → TC ⊤
@@ -347,6 +348,7 @@ postulate
 {-# BUILTIN AGDATCMCOMMIT                     commitTC                   #-}
 {-# BUILTIN AGDATCMISMACRO                    isMacro                    #-}
 {-# BUILTIN AGDATCMWITHNORMALISATION          withNormalisation          #-}
+{-# BUILTIN AGDATCMFORMATERRORPARTS           formatErrorParts           #-}
 {-# BUILTIN AGDATCMDEBUGPRINT                 debugPrint                 #-}
 {-# BUILTIN AGDATCMONLYREDUCEDEFS             onlyReduceDefs             #-}
 {-# BUILTIN AGDATCMDONTREDUCEDEFS             dontReduceDefs             #-}

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -254,11 +254,13 @@ data Definition : Set where
 data ErrorPart : Set where
   strErr  : String → ErrorPart
   termErr : Term → ErrorPart
+  pattErr : Pattern → ErrorPart
   nameErr : Name → ErrorPart
 
 {-# BUILTIN AGDAERRORPART       ErrorPart #-}
 {-# BUILTIN AGDAERRORPARTSTRING strErr    #-}
 {-# BUILTIN AGDAERRORPARTTERM   termErr   #-}
+{-# BUILTIN AGDAERRORPARTPATT   pattErr   #-}
 {-# BUILTIN AGDAERRORPARTNAME   nameErr   #-}
 
 -- TC monad --

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -271,6 +271,7 @@ ghcPreCompile flags = do
       , builtinAgdaTCMIsMacro
       , builtinAgdaTCMWithNormalisation
       , builtinAgdaTCMWithReconsParams
+      , builtinAgdaTCMFormatErrorParts
       , builtinAgdaTCMDebugPrint
       , builtinAgdaTCMOnlyReduceDefs
       , builtinAgdaTCMDontReduceDefs

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -69,7 +69,8 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinAgdaTCMGetType, builtinAgdaTCMGetDefinition,
   builtinAgdaTCMQuoteTerm, builtinAgdaTCMUnquoteTerm, builtinAgdaTCMQuoteOmegaTerm,
   builtinAgdaTCMBlockOnMeta, builtinAgdaTCMCommit, builtinAgdaTCMIsMacro,
-  builtinAgdaTCMWithNormalisation, builtinAgdaTCMWithReconsParams, builtinAgdaTCMDebugPrint,
+  builtinAgdaTCMFormatErrorParts, builtinAgdaTCMDebugPrint,
+  builtinAgdaTCMWithNormalisation, builtinAgdaTCMWithReconsParams,
   builtinAgdaTCMOnlyReduceDefs, builtinAgdaTCMDontReduceDefs,
   builtinAgdaTCMNoConstraints,
   builtinAgdaTCMRunSpeculative,
@@ -272,6 +273,7 @@ builtinAgdaTCMQuoteOmegaTerm             = "AGDATCMQUOTEOMEGATERM"
 builtinAgdaTCMIsMacro                    = "AGDATCMISMACRO"
 builtinAgdaTCMWithNormalisation          = "AGDATCMWITHNORMALISATION"
 builtinAgdaTCMWithReconsParams           = "AGDATCMWITHRECONSPARAMS"
+builtinAgdaTCMFormatErrorParts           = "AGDATCMFORMATERRORPARTS"
 builtinAgdaTCMDebugPrint                 = "AGDATCMDEBUGPRINT"
 builtinAgdaTCMOnlyReduceDefs             = "AGDATCMONLYREDUCEDEFS"
 builtinAgdaTCMDontReduceDefs             = "AGDATCMDONTREDUCEDEFS"

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -49,7 +49,7 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinAgdaTermVar, builtinAgdaTermLam, builtinAgdaTermExtLam,
   builtinAgdaTermDef, builtinAgdaTermCon, builtinAgdaTermPi,
   builtinAgdaTermSort, builtinAgdaTermLit, builtinAgdaTermUnsupported, builtinAgdaTermMeta,
-  builtinAgdaErrorPart, builtinAgdaErrorPartString, builtinAgdaErrorPartTerm, builtinAgdaErrorPartName,
+  builtinAgdaErrorPart, builtinAgdaErrorPartString, builtinAgdaErrorPartTerm, builtinAgdaErrorPartPatt, builtinAgdaErrorPartName,
   builtinAgdaLiteral, builtinAgdaLitNat, builtinAgdaLitWord64, builtinAgdaLitFloat,
   builtinAgdaLitChar, builtinAgdaLitString, builtinAgdaLitQName, builtinAgdaLitMeta,
   builtinAgdaClause, builtinAgdaClauseClause, builtinAgdaClauseAbsurd, builtinAgdaPattern,
@@ -219,6 +219,7 @@ builtinAgdaTermMeta                      = "AGDATERMMETA"
 builtinAgdaErrorPart                     = "AGDAERRORPART"
 builtinAgdaErrorPartString               = "AGDAERRORPARTSTRING"
 builtinAgdaErrorPartTerm                 = "AGDAERRORPARTTERM"
+builtinAgdaErrorPartPatt                 = "AGDAERRORPARTPATT"
 builtinAgdaErrorPartName                 = "AGDAERRORPARTNAME"
 builtinAgdaLiteral                       = "AGDALITERAL"
 builtinAgdaLitNat                        = "AGDALITNAT"

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -216,7 +216,8 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primAgdaTCMGetType, primAgdaTCMGetDefinition,
     primAgdaTCMQuoteTerm, primAgdaTCMUnquoteTerm, primAgdaTCMQuoteOmegaTerm,
     primAgdaTCMBlockOnMeta, primAgdaTCMCommit, primAgdaTCMIsMacro,
-    primAgdaTCMWithNormalisation, primAgdaTCMDebugPrint, primAgdaTCMWithReconsParams,
+    primAgdaTCMFormatErrorParts, primAgdaTCMDebugPrint,
+    primAgdaTCMWithNormalisation, primAgdaTCMWithReconsParams,
     primAgdaTCMOnlyReduceDefs, primAgdaTCMDontReduceDefs,
     primAgdaTCMNoConstraints,
     primAgdaTCMRunSpeculative,
@@ -416,6 +417,7 @@ primAgdaTCMCommit                     = getBuiltin builtinAgdaTCMCommit
 primAgdaTCMIsMacro                    = getBuiltin builtinAgdaTCMIsMacro
 primAgdaTCMWithNormalisation          = getBuiltin builtinAgdaTCMWithNormalisation
 primAgdaTCMWithReconsParams           = getBuiltin builtinAgdaTCMWithReconsParams
+primAgdaTCMFormatErrorParts           = getBuiltin builtinAgdaTCMFormatErrorParts
 primAgdaTCMDebugPrint                 = getBuiltin builtinAgdaTCMDebugPrint
 primAgdaTCMOnlyReduceDefs             = getBuiltin builtinAgdaTCMOnlyReduceDefs
 primAgdaTCMDontReduceDefs             = getBuiltin builtinAgdaTCMDontReduceDefs

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -191,7 +191,7 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primQName, primArgInfo, primArgArgInfo, primArg, primArgArg, primAbs, primAbsAbs, primAgdaTerm, primAgdaTermVar,
     primAgdaTermLam, primAgdaTermExtLam, primAgdaTermDef, primAgdaTermCon, primAgdaTermPi,
     primAgdaTermSort, primAgdaTermLit, primAgdaTermUnsupported, primAgdaTermMeta,
-    primAgdaErrorPart, primAgdaErrorPartString, primAgdaErrorPartTerm, primAgdaErrorPartName,
+    primAgdaErrorPart, primAgdaErrorPartString, primAgdaErrorPartTerm, primAgdaErrorPartPatt, primAgdaErrorPartName,
     primHiding, primHidden, primInstance, primVisible,
     primRelevance, primRelevant, primIrrelevant,
     primQuantity, primQuantity0, primQuantityω,
@@ -363,6 +363,7 @@ primAgdaTermMeta                      = getBuiltin builtinAgdaTermMeta
 primAgdaErrorPart                     = getBuiltin builtinAgdaErrorPart
 primAgdaErrorPartString               = getBuiltin builtinAgdaErrorPartString
 primAgdaErrorPartTerm                 = getBuiltin builtinAgdaErrorPartTerm
+primAgdaErrorPartPatt                 = getBuiltin builtinAgdaErrorPartPatt
 primAgdaErrorPartName                 = getBuiltin builtinAgdaErrorPartName
 primAgdaLiteral                       = getBuiltin builtinAgdaLiteral
 primAgdaLitNat                        = getBuiltin builtinAgdaLitNat

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -272,6 +272,9 @@ instance PrettyTCM A.Expr where
 instance PrettyTCM A.TypedBinding where
   prettyTCM = prettyA
 
+instance PrettyTCM A.Pattern where
+  prettyTCM = prettyA
+
 instance PrettyTCM Relevance where
   prettyTCM = pretty
 

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -231,9 +231,10 @@ coreBuiltins =
                                                    , builtinAgdaTermPi, builtinAgdaTermSort
                                                    , builtinAgdaTermLit, builtinAgdaTermMeta
                                                    , builtinAgdaTermUnsupported])
-  , builtinAgdaErrorPart                     |-> BuiltinData tset [ builtinAgdaErrorPartString, builtinAgdaErrorPartTerm, builtinAgdaErrorPartName ]
+  , builtinAgdaErrorPart                     |-> BuiltinData tset [ builtinAgdaErrorPartString, builtinAgdaErrorPartTerm, builtinAgdaErrorPartPatt, builtinAgdaErrorPartName ]
   , builtinAgdaErrorPartString               |-> BuiltinDataCons (tstring --> terrorpart)
   , builtinAgdaErrorPartTerm                 |-> BuiltinDataCons (tterm --> terrorpart)
+  , builtinAgdaErrorPartPatt                 |-> BuiltinDataCons (tpat --> terrorpart)
   , builtinAgdaErrorPartName                 |-> BuiltinDataCons (tqname --> terrorpart)
   -- Andreas, 2017-01-12, issue #2386: special handling of builtinEquality
   -- , (builtinEquality                         |-> BuiltinData (hPi "a" (el primLevel) $

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -383,6 +383,7 @@ coreBuiltins =
   , builtinAgdaTCMIsMacro                    |-> builtinPostulate (tqname --> tTCM_ primBool)
   , builtinAgdaTCMWithNormalisation          |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tbool --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMWithReconsParams           |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+  , builtinAgdaTCMFormatErrorParts           |-> builtinPostulate (tlist terrorpart --> tTCM_ primString)
   , builtinAgdaTCMDebugPrint                 |-> builtinPostulate (tstring --> tnat --> tlist terrorpart --> tTCM_ primUnit)
   , builtinAgdaTCMOnlyReduceDefs             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tlist tqname --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMDontReduceDefs             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tlist tqname --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -557,6 +557,7 @@ evalTCM v = do
              , (f `isDef` primAgdaTCMReduce,                     tcFun1 tcReduce                     u)
              , (f `isDef` primAgdaTCMGetType,                    tcFun1 tcGetType                    u)
              , (f `isDef` primAgdaTCMGetDefinition,              tcFun1 tcGetDefinition              u)
+             , (f `isDef` primAgdaTCMFormatErrorParts,           tcFun1 tcFormatErrorParts           u)
              , (f `isDef` primAgdaTCMIsMacro,                    tcFun1 tcIsMacro                    u)
              , (f `isDef` primAgdaTCMFreshName,                  tcFun1 tcFreshName                  u)
              , (f `isDef` primAgdaTCMGetInstances,               uqFun1 tcGetInstances               u)
@@ -572,15 +573,15 @@ evalTCM v = do
              ]
              failEval
     I.Def f [l, a, u] ->
-      choice [ (f `isDef` primAgdaTCMReturn,      return (unElim u))
-             , (f `isDef` primAgdaTCMTypeError,   tcFun1 tcTypeError   u)
-             , (f `isDef` primAgdaTCMQuoteTerm,   tcQuoteTerm (unElim u))
-             , (f `isDef` primAgdaTCMUnquoteTerm, tcFun1 (tcUnquoteTerm (mkT (unElim l) (unElim a))) u)
-             , (f `isDef` primAgdaTCMBlockOnMeta, uqFun1 tcBlockOnMeta u)
-             , (f `isDef` primAgdaTCMDebugPrint,  tcFun3 tcDebugPrint l a u)
-             , (f `isDef` primAgdaTCMNoConstraints, tcNoConstraints (unElim u))
-             , (f `isDef` primAgdaTCMWithReconsParams, tcWithReconsParams (unElim u))
-             , (f `isDef` primAgdaTCMRunSpeculative, tcRunSpeculative (unElim u))
+      choice [ (f `isDef` primAgdaTCMReturn,             return (unElim u))
+             , (f `isDef` primAgdaTCMTypeError,          tcFun1 tcTypeError   u)
+             , (f `isDef` primAgdaTCMQuoteTerm,          tcQuoteTerm (unElim u))
+             , (f `isDef` primAgdaTCMUnquoteTerm,        tcFun1 (tcUnquoteTerm (mkT (unElim l) (unElim a))) u)
+             , (f `isDef` primAgdaTCMBlockOnMeta,        uqFun1 tcBlockOnMeta u)
+             , (f `isDef` primAgdaTCMDebugPrint,         tcFun3 tcDebugPrint l a u)
+             , (f `isDef` primAgdaTCMNoConstraints,      tcNoConstraints (unElim u))
+             , (f `isDef` primAgdaTCMWithReconsParams,   tcWithReconsParams (unElim u))
+             , (f `isDef` primAgdaTCMRunSpeculative,     tcRunSpeculative (unElim u))
              , (f `isDef` primAgdaTCMExec, tcFun3 tcExec l a u)
              ]
              failEval
@@ -689,6 +690,10 @@ evalTCM v = do
       s <- getTC
       modify (second $ const s)
       liftTCM primUnitUnit
+
+    tcFormatErrorParts :: [ErrorPart] -> TCM Term
+    tcFormatErrorParts msg = quoteString . prettyShow <$> prettyErrorParts msg
+
 
     tcTypeError :: [ErrorPart] -> TCM a
     tcTypeError err = typeError . GenericDocError =<< prettyErrorParts err

--- a/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
+++ b/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
@@ -203,11 +203,13 @@ data Definition : Set where
 data ErrorPart : Set where
   strErr  : String → ErrorPart
   termErr : Term → ErrorPart
+  pattErr : Pattern → ErrorPart
   nameErr : Name → ErrorPart
 
 {-# BUILTIN AGDAERRORPART       ErrorPart #-}
 {-# BUILTIN AGDAERRORPARTSTRING strErr    #-}
 {-# BUILTIN AGDAERRORPARTTERM   termErr   #-}
+{-# BUILTIN AGDAERRORPARTPATT   pattErr   #-}
 {-# BUILTIN AGDAERRORPARTNAME   nameErr   #-}
 
 -- TC monad --


### PR DESCRIPTION
Since `var : (x : Nat) (args : List (Arg Term)) → Term` depends on the context and it is sometimes desirable to print `ErrorParts` later in a different context, I suggest that we add a primitive `formatErrorParts : List ErrorPart → TC String` to get the formatted string earlier. 

It will also be useful to make `Pattern` an `ErrorPart` so that patterns can be printed using the internal pretty-printer because of mixfix operators.