### PR TITLE
use prettyShow instead of show for JSON solveAll

### DIFF
--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -423,7 +423,7 @@ instance EncodeTCM Response where
     where
       encodeSolution (i, expr) = object
         [ "interactionPoint"  .= i
-        , "expression"        .= show expr
+        , "expression"        .= P.prettyShow expr
         ]
 
 -- | Convert Response to an JSON value for interactive editor frontends.


### PR DESCRIPTION
Probably fixes #5751. But I'm new to this codebase and am not sure how to go about testing it except manually --- would love some tips!

Indeed, this seems to fix the output:

```
JSON> IOTCM "/home/sandy/prj/agda-playground/ConceptualMathematics/Chapter1.agda" None Direct (Cmd_solveOne Simplified 0 noRange "")
{"kind":"SolveAll","solutions":[{"expression":"g kIso (f kIso (gIso .g x))","interactionPoint":0}]}
```