### PR TITLE
[ fix #5770 ] Add option --erase-record-parameters

### DIFF
--- a/src/data/lib/prim/Agda/Builtin/FromNat.agda
+++ b/src/data/lib/prim/Agda/Builtin/FromNat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --safe --no-sized-types --no-guardedness #-}
+{-# OPTIONS --without-K --safe --no-sized-types --no-guardedness --erase-record-parameters #-}
 
 module Agda.Builtin.FromNat where
 

--- a/src/data/lib/prim/Agda/Builtin/FromNeg.agda
+++ b/src/data/lib/prim/Agda/Builtin/FromNeg.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --safe --no-sized-types --no-guardedness #-}
+{-# OPTIONS --without-K --safe --no-sized-types --no-guardedness --erase-record-parameters #-}
 
 module Agda.Builtin.FromNeg where
 

--- a/src/data/lib/prim/Agda/Builtin/FromString.agda
+++ b/src/data/lib/prim/Agda/Builtin/FromString.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --safe --no-sized-types --no-guardedness #-}
+{-# OPTIONS --without-K --safe --no-sized-types --no-guardedness --erase-record-parameters #-}
 
 module Agda.Builtin.FromString where
 

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -160,6 +160,7 @@ data PragmaOptions = PragmaOptions
   , optEta                       :: Bool
   , optForcing                   :: Bool  -- ^ Perform the forcing analysis on data constructors?
   , optProjectionLike            :: Bool  -- ^ Perform the projection-likeness analysis on functions?
+  , optEraseRecordParameters     :: Bool  -- ^ Mark parameters of record modules as erased?
   , optRewriting                 :: Bool  -- ^ Can rewrite rules be added and used?
   , optCubical                   :: Maybe Cubical
   , optGuarded                   :: Bool
@@ -300,6 +301,7 @@ defaultPragmaOptions = PragmaOptions
   , optEta                       = True
   , optForcing                   = True
   , optProjectionLike            = True
+  , optEraseRecordParameters     = False
   , optRewriting                 = False
   , optCubical                   = Nothing
   , optGuarded                   = False
@@ -430,6 +432,7 @@ restartOptions =
   , (B . not . optImportSorts, "--no-import-sorts")
   , (B . optAllowExec, "--allow-exec")
   , (B . collapseDefault . optSaveMetas, "--save-metas")
+  , (B . optEraseRecordParameters, "--erase-record-parameters")
   ]
 
 -- to make all restart options have the same type
@@ -838,6 +841,12 @@ allowExec o = return $ o { optAllowExec = True }
 saveMetas :: Bool -> Flag PragmaOptions
 saveMetas save o = return $ o { optSaveMetas = Value save }
 
+eraseRecordParametersFlag :: Flag PragmaOptions
+eraseRecordParametersFlag o = return $ o { optEraseRecordParameters = True }
+
+noEraseRecordParametersFlag :: Flag PragmaOptions
+noEraseRecordParametersFlag o = return $ o { optEraseRecordParameters = False }
+
 integerArgument :: String -> String -> OptM Int
 integerArgument flag s = maybe usage return $ readMaybe s
   where
@@ -989,6 +998,10 @@ pragmaOptions =
                     "disable the forcing analysis for data constructors (optimisation)"
     , Option []     ["no-projection-like"] (NoArg noProjectionLikeFlag)
                     "disable the analysis whether function signatures liken those of projections (optimisation)"
+    , Option []     ["erase-record-parameters"] (NoArg eraseRecordParametersFlag)
+                    "mark all parameters of record modules as erased"
+    , Option []     ["no-erase-record-parameters"] (NoArg noEraseRecordParametersFlag)
+                    "do mark all parameters of record modules as erased (default)"
     , Option []     ["rewriting"] (NoArg rewritingFlag)
                     "enable declaration and use of REWRITE rules"
     , Option []     ["local-confluence-check"] (NoArg $ confluenceCheckFlag LocalConfluenceCheck)

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -308,11 +308,16 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
 
       let m = qnameToMName name  -- Name of record module.
 
+      eraseRecordParameters <- optEraseRecordParameters <$> pragmaOptions
+      let maybeErase :: forall a. LensQuantity a => a -> a
+          maybeErase | eraseRecordParameters = setQuantity zeroQuantity
+                     | otherwise             = id
+
       -- Andreas, 2016-02-09 setting all parameters hidden in the record
       -- section telescope changes the semantics, see e.g.
       -- test/Succeed/RecordInParModule.
       -- Ulf, 2016-03-02 but it's the right thing to do (#1759)
-      modifyContextInfo hideOrKeepInstance $ addRecordVar $ do
+      modifyContextInfo (hideOrKeepInstance . maybeErase) $ addRecordVar $ do
 
         -- Add the record section.
 
@@ -331,7 +336,7 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
       -- Andreas, 2016-02-09, Issue 1815 (see also issue 1759).
       -- For checking the record declarations, hide the record parameters
       -- and the parameters of the parent modules.
-      modifyContextInfo hideOrKeepInstance $ do
+      modifyContextInfo (hideOrKeepInstance . maybeErase) $ do
         -- The parameters are erased in the types of the projections.
         params <- fmap (applyQuantity zeroQuantity) <$> getContext
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -270,12 +270,12 @@ instance EmbPrj Doc where
 
 instance EmbPrj PragmaOptions where
   icod_ = \case
-    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd ->
-      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd
+    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee ->
+      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee
 
   value = vcase $ \case
-    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx, yy, zz, aaa, bbb, ccc, ddd] ->
-      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd
+    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx, yy, zz, aaa, bbb, ccc, ddd, eee] ->
+      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee
     _ -> malformed
 
 instance EmbPrj ProfileOptions where

--- a/test/Fail/EraseRecordParametersFail1.agda
+++ b/test/Fail/EraseRecordParametersFail1.agda
@@ -1,0 +1,7 @@
+{-# OPTIONS --erase-record-parameters #-}
+
+postulate A : Set
+
+record R (x : A) : Set where
+  y : A
+  y = x

--- a/test/Fail/EraseRecordParametersFail1.err
+++ b/test/Fail/EraseRecordParametersFail1.err
@@ -1,0 +1,3 @@
+EraseRecordParametersFail1.agda:7,7-8
+Variable x is declared erased, so it cannot be used here
+when checking that the expression x has type A

--- a/test/Succeed/EraseRecordParameters.agda
+++ b/test/Succeed/EraseRecordParameters.agda
@@ -1,0 +1,16 @@
+{-# OPTIONS --erase-record-parameters #-}
+
+postulate A : Set
+postulate a : A
+
+record R (x : A) : Set where
+  y : A
+  y = a
+
+f : (@0 x : A) → R x → A
+f x r = R.y {x} r
+
+open R {{...}}
+
+g : {@0 x : A} → {{R x}} → A
+g = y


### PR DESCRIPTION
This provides a simple fix for #5770 by adding a flag --erase-record parameters.

TODO:
- [ ] Add a keyword so the behavior can be toggled on a per-record basis
- [ ] Add entries to the user manual and changelog