### PR TITLE
Fix #5659: port `instance Monad (TCMT m)` to `transformers-0.6`

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -240,11 +240,9 @@ library
                 , haskeline >= 0.7.2.3 && < 0.9
                 -- monad-control-1.0.1.0 is the first to contain liftThrough
                 , monad-control >= 1.0.1.0 && < 1.1
-                -- mtl-2.1 contains a severe bug.
-                --
                 -- mtl >= 2.2 && < 2.2.1 doesn't export Control.Monad.Except.
                 -- Need mtl 2.2.2  for export of Control.Monad.IdentityT (ghc 8.2.2+)
-                , mtl >= 2.2.1 && < 2.3
+                , mtl >= 2.2.1 && < 2.4
                 , murmur-hash >= 0.1 && < 0.2
                 , parallel >= 3.2.2.0 && < 3.3
                 , pretty >= 1.1.3.3 && < 1.2
@@ -260,6 +258,12 @@ library
                 , unordered-containers >= 0.2.5.0 && < 0.3
                 , uri-encode >= 1.5.0.4 && < 1.6
                 , zlib == 0.6.*
+
+  -- Andreas, 2022-02-02, issue #5659:
+  -- Build failure with transformers-0.6.0.{0,1,2} and GHC 8.6.
+  -- Transformers-0.6.0.3 might restored GHC 8.6 buildability.
+  if impl(ghc == 8.6.*)
+    build-depends: transformers < 0.6 || >= 0.6.0.3
 
   -- Andreas, 2021-03-10:
   -- All packages we depend upon should be mentioned in an unconditional

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4233,31 +4233,31 @@ pureTCM f = TCM $ \ r e -> do
 -- [1] When compiled with -auto-all and run with -p: roughly 750%
 -- faster for one example.
 
-returnTCMT :: MonadIO m => a -> TCMT m a
-returnTCMT = \x -> TCM $ \_ _ -> return x
+returnTCMT :: Applicative m => a -> TCMT m a
+returnTCMT = \x -> TCM $ \_ _ -> pure x
 {-# INLINE returnTCMT #-}
 
-bindTCMT :: MonadIO m => TCMT m a -> (a -> TCMT m b) -> TCMT m b
+bindTCMT :: Monad m => TCMT m a -> (a -> TCMT m b) -> TCMT m b
 bindTCMT = \(TCM m) k -> TCM $ \r e -> m r e >>= \x -> unTCM (k x) r e
 {-# INLINE bindTCMT #-}
 
-thenTCMT :: MonadIO m => TCMT m a -> TCMT m b -> TCMT m b
-thenTCMT = \(TCM m1) (TCM m2) -> TCM $ \r e -> m1 r e >> m2 r e
+thenTCMT :: Applicative m => TCMT m a -> TCMT m b -> TCMT m b
+thenTCMT = \(TCM m1) (TCM m2) -> TCM $ \r e -> m1 r e *> m2 r e
 {-# INLINE thenTCMT #-}
 
-instance MonadIO m => Functor (TCMT m) where
+instance Functor m => Functor (TCMT m) where
   fmap = fmapTCMT
 
-fmapTCMT :: MonadIO m => (a -> b) -> TCMT m a -> TCMT m b
+fmapTCMT :: Functor m => (a -> b) -> TCMT m a -> TCMT m b
 fmapTCMT = \f (TCM m) -> TCM $ \r e -> fmap f (m r e)
 {-# INLINE fmapTCMT #-}
 
-instance MonadIO m => Applicative (TCMT m) where
+instance Applicative m => Applicative (TCMT m) where
   pure  = returnTCMT
   (<*>) = apTCMT
 
-apTCMT :: MonadIO m => TCMT m (a -> b) -> TCMT m a -> TCMT m b
-apTCMT = \(TCM mf) (TCM m) -> TCM $ \r e -> ap (mf r e) (m r e)
+apTCMT :: Applicative m => TCMT m (a -> b) -> TCMT m a -> TCMT m b
+apTCMT = \(TCM mf) (TCM m) -> TCM $ \r e -> mf r e <*> m r e
 {-# INLINE apTCMT #-}
 
 instance MonadTrans TCMT where

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4264,7 +4264,14 @@ instance MonadTrans TCMT where
     lift m = TCM $ \_ _ -> m
 
 -- We want a special monad implementation of fail.
+#if __GLASGOW_HASKELL__ < 808
 instance MonadIO m => Monad (TCMT m) where
+#else
+-- Andreas, 2022-02-02, issue #5659:
+-- @transformers-0.6@ requires exactly a @Monad@ superclass constraint here
+-- if we want @instance MonadTrans TCMT@.
+instance Monad m => Monad (TCMT m) where
+#endif
     return = pure
     (>>=)  = bindTCMT
     (>>)   = (*>)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs-boot
@@ -26,8 +26,8 @@ data TCEnv
 data TCState
 newtype TCMT m a = TCM { unTCM :: IORef TCState -> TCEnv -> m a }
 
-instance MonadIO m => Applicative (TCMT m)
-instance MonadIO m => Functor (TCMT m)
+instance Applicative m => Applicative (TCMT m)
+instance Functor m => Functor (TCMT m)
 instance MonadIO m => Monad (TCMT m)
 instance MonadIO m => MonadIO (TCMT m)
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs-boot
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Agda.TypeChecking.Monad.Base where
 
 import Control.Monad.IO.Class (MonadIO)
@@ -28,8 +30,16 @@ newtype TCMT m a = TCM { unTCM :: IORef TCState -> TCEnv -> m a }
 
 instance Applicative m => Applicative (TCMT m)
 instance Functor m => Functor (TCMT m)
-instance MonadIO m => Monad (TCMT m)
 instance MonadIO m => MonadIO (TCMT m)
+
+#if __GLASGOW_HASKELL__ < 808
+instance MonadIO m => Monad (TCMT m) where
+#else
+-- Andreas, 2022-02-02, issue #5659:
+-- @transformers-0.6@ requires exactly a @Monad@ superclass constraint here
+-- if we want @instance MonadTrans TCMT@.
+instance Monad m => Monad (TCMT m) where
+#endif
 
 type TCM = TCMT IO
 


### PR DESCRIPTION
Fix #5659: port `instance Monad (TCMT m)` to `transformers-0.6`.
This allows `mtl-2.3` (which was so far shielding us from `transformers-0.6`).

This PR allows building with `transformers-0.6.0.*` except for with GHC 8.6, which needs `transformers-0.6.0.3` or higher.