### PR TITLE
Fix #5773: doc: link to ICU installation instructions

### DIFF
--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -63,9 +63,18 @@ as root to get the correct files installed.
 Optionally one can also install the `ICU
 <http://site.icu-project.org>`_ library, which is used to implement
 the :option:`--count-clusters` flag. Under Debian or Ubuntu it may suffice
-to install *libicu-dev*. Once the ICU library is installed one can
+to install ``libicu-dev``. Once the ICU library is installed one can
 hopefully enable the :option:`--count-clusters` flag by giving the
-:option:`enable-cluster-counting` flag to *cabal install*.
+:option:`enable-cluster-counting` flag to *cabal install*:
+
+.. code-block:: bash
+
+  cabal install -f enable-cluster-counting
+
+More information on installing the ICU prerequisite (like for other OSs)
+is available at
+https://github.com/haskell/text-icu/blob/master/README.markdown#prerequisites
+(retrieved 2022-02-09).
 
 
 
@@ -206,6 +215,8 @@ is an additional step using `a separate repository <https://github.com/agda/agda
 
 Prebuilt Packages and System-Specific Instructions
 ==================================================
+
+See also https://repology.org/project/agda/versions.
 
 Arch Linux
 ----------
@@ -418,7 +429,14 @@ After getting the development version from the Git `repository
     make install
 
   Note that on a Mac, because ICU is installed in a non-standard location,
-  you need to specify this location on the command line:
+  you may need to set
+
+  .. code-block:: bash
+
+    export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig"
+
+  (cf. ``brew link icu4c``)
+  or specify this location on the command line:
 
   .. code-block:: bash
 

--- a/doc/user-manual/tools/generating-latex.rst
+++ b/doc/user-manual/tools/generating-latex.rst
@@ -145,11 +145,11 @@ backend:
   :file:`.tex` file are placed to :samp:`{directory}`. Default:
   ``latex``.
 
-``--only-scope-checking``
+:option:`--only-scope-checking`
   Generates highlighting without typechecking the file. See
   :ref:`quickLaTeX`.
 
-``--count-clusters``
+:option:`--count-clusters`
   Count extended grapheme clusters when generating LaTeX code. This
   option can be given in :ref:`OPTIONS<options-pragma>` pragmas.
   See :ref:`grapheme-clusters`.
@@ -282,7 +282,7 @@ The alignment feature regards the string ``+̲``, containing ``+`` and a
 combining character, as having length two. However, it seems more
 reasonable to treat it as having length one, as it occupies a single
 column, if displayed "properly" using a monospace font. The flag
-``--count-clusters`` is an attempt at fixing this. When this flag is
+:option:`--count-clusters` is an attempt at fixing this. When this flag is
 enabled the backend counts `"extended grapheme clusters"
 <http://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries>`_
 rather than code points.
@@ -305,7 +305,7 @@ character by the alignment algorithm:
 
 Note also that the layout machinery does not count extended grapheme
 clusters, but code points. The following code is syntactically
-correct, but if ``--count-clusters`` is used, then the LaTeX backend
+correct, but if :option:`--count-clusters` is used, then the LaTeX backend
 does not align the two field keywords:
 
 ::
@@ -313,7 +313,7 @@ does not align the two field keywords:
   record +̲ : Set₁ where  field A : Set
                           field B : Set
 
-The ``--count-clusters`` flag is not enabled in all builds of Agda,
+The :option:`--count-clusters` flag is not enabled in all builds of Agda,
 because the implementation depends on the ICU_ library, the
 installation of which could cause extra trouble for some users. The
 presence of this flag is controlled by the Cabal flag


### PR DESCRIPTION
Fix #5773: doc: link to ICU installation instructions