### PR TITLE
#5763: Don't include operators with binders when parsing patterns

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -181,7 +181,9 @@ buildParsers
 buildParsers kind exprNames = do
     flat         <- flattenScope (qualifierModules exprNames) <$>
                       getScope
-    (names, ops) <- localNames flat
+    (names, ops0) <- localNames flat
+    let ops | kind == IsPattern = filter (not . isLambdaNotation) ops0
+            | otherwise         = ops0
 
     let -- All names.
         namesInExpr :: Set QName

--- a/src/full/Agda/Syntax/Notation.hs
+++ b/src/full/Agda/Syntax/Notation.hs
@@ -363,6 +363,15 @@ mergeNotations =
   merge []         = __IMPOSSIBLE__
   merge ns@(n : _) = n { notaNames = Set.unions $ map notaNames ns }
 
+-- | Check if a notation contains any lambdas (in which case it cannot be used in a pattern).
+isLambdaNotation :: NewNotation -> Bool
+isLambdaNotation n = any isBinder (notation n)
+  where
+    isBinder VarPart{}  = True
+    isBinder WildPart{} = True
+    isBinder IdPart{}   = False
+    isBinder HolePart{} = False
+
 -- | Lens for 'Fixity' in 'NewNotation'.
 
 _notaFixity :: Lens' Fixity NewNotation

--- a/test/Fail/Issue5763.agda
+++ b/test/Fail/Issue5763.agda
@@ -1,0 +1,8 @@
+
+data Fun (A B : Set) : Set where
+  fun : (A → B) → Fun A B
+
+syntax fun (λ x → y) = fn x , y
+
+foo : ∀ {A} → Fun A A → A
+foo (fn x , y) = y

--- a/test/Fail/Issue5763.err
+++ b/test/Fail/Issue5763.err
@@ -1,0 +1,6 @@
+Issue5763.agda:8,1-15
+Could not parse the left-hand side foo (fn x , y)
+Operators used in the grammar:
+  None
+when scope checking the left-hand side foo (fn x , y) in the
+definition of foo


### PR DESCRIPTION
Fixes #5763