### PR TITLE
Support `mtl-2.3-rc3`: fix imports to make up for removed re-exports

### DIFF
--- a/cabal.project.local.mtl23
+++ b/cabal.project.local.mtl23
@@ -1,0 +1,74 @@
+-- Andreas, 2022-02-23, configuration to build with mtl-2.3-rc3
+-- Invocation:
+-- $ ln -s cabal.project.local.mtl23 cabal.project.local
+-- $ cabal build --builddir dist-mtl23 -f +enable-cluster-counting
+
+flags: +enable-cluster-counting
+constraints: text-icu == 0.8.*
+
+-- =====================================================================
+-- Released versions needed to test mtl-2.3-rc3
+-- =====================================================================
+
+-- transformers
+------------------------------------------------------------------------
+
+constraints: transformers == 0.6.*
+allow-newer: *:transformers
+
+-- equivalence
+------------------------------------------------------------------------
+
+constraints: equivalence  == 0.4
+allow-newer: *:equivalence
+
+-- =====================================================================
+-- Unreleased versions needed to test mtl-2.3-rc3
+-- =====================================================================
+
+-- mtl
+------------------------------------------------------------------------
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell/mtl.git
+  tag: v2.3-rc3
+
+constraints: mtl == 2.3.*
+allow-newer: *:mtl
+
+-- happy
+------------------------------------------------------------------------
+
+source-repository-package
+  type: git
+  location: git@github.com:simonmar/happy.git
+  subdir: .
+  subdir: packages/backend-glr
+  subdir: packages/backend-lalr
+  subdir: packages/codegen-common
+  subdir: packages/frontend
+  subdir: packages/grammar
+  subdir: packages/tabular
+
+constraints: happy == 1.21.*
+allow-newer: *:happy
+
+-- exceptions
+------------------------------------------------------------------------
+
+source-repository-package
+  type: git
+  location: git@github.com:ekmett/exceptions
+  tag: 28b9b49a51deb7c1343e003dafb4c69ef79f2e8b
+
+-- random
+------------------------------------------------------------------------
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell/random.git
+  tag: 5ecc8935994159c6d39088233a0887714aacaf5e
+
+constraints: random == 1.3.*
+allow-newer: *:random

--- a/src/full/Agda/Auto/Auto.hs
+++ b/src/full/Agda/Auto/Auto.hs
@@ -7,7 +7,9 @@ module Agda.Auto.Auto
 
 import Prelude hiding ((!!), null)
 
+import Control.Monad          ( filterM, forM, guard, join, when )
 import Control.Monad.Except
+import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.State
 
 import qualified Data.List as List

--- a/src/full/Agda/Auto/CaseSplit.hs
+++ b/src/full/Agda/Auto/CaseSplit.hs
@@ -3,6 +3,12 @@ module Agda.Auto.CaseSplit where
 
 import Prelude hiding ((!!))
 
+import Control.Monad.State as St hiding (lift)
+import Control.Monad.Reader as Rd hiding (lift)
+import qualified Control.Monad.State as St
+import Control.Monad.IO.Class ( MonadIO(..) )
+
+import Data.Function
 import Data.IORef
 import Data.Tuple (swap)
 import Data.List (elemIndex)
@@ -10,10 +16,6 @@ import Data.List (elemIndex)
 import Data.Monoid ((<>), Sum(..))
 import qualified Data.Set    as Set
 import qualified Data.IntMap as IntMap
-import Control.Monad.State as St hiding (lift)
-import Control.Monad.Reader as Rd hiding (lift)
-import qualified Control.Monad.State as St
-import Data.Function
 
 import Agda.Syntax.Common (Hiding(..))
 import Agda.Auto.NarrowingSearch

--- a/src/full/Agda/Auto/Convert.hs
+++ b/src/full/Agda/Auto/Convert.hs
@@ -3,7 +3,9 @@ module Agda.Auto.Convert where
 
 import Prelude hiding ((!!))
 
+import Control.Monad          ( when )
 import Control.Monad.Except
+import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.State
 
 import Data.Bifunctor (first)

--- a/src/full/Agda/Auto/NarrowingSearch.hs
+++ b/src/full/Agda/Auto/NarrowingSearch.hs
@@ -1,9 +1,12 @@
 
 module Agda.Auto.NarrowingSearch where
 
+import Control.Monad       ( foldM, when )
+import Control.Monad.State ( MonadState(..), modify, StateT, evalStateT, runStateT )
+import Control.Monad.Trans ( lift )
+
 import Data.IORef hiding (writeIORef, modifyIORef)
 import qualified Data.IORef as NoUndo (writeIORef, modifyIORef)
-import Control.Monad.State
 
 import Agda.Utils.Impossible
 import Agda.Utils.Empty

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -22,7 +22,8 @@ module Agda.Compiler.Backend
   ) where
 
 import Control.DeepSeq
-import Control.Monad.State
+import Control.Monad              ( (<=<) )
+import Control.Monad.Trans        ( lift )
 import Control.Monad.Trans.Maybe
 
 import qualified Data.List as List

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -3,9 +3,12 @@ module Agda.Compiler.MAlonzo.Compiler where
 
 import Control.Arrow (second)
 import Control.DeepSeq
-import Control.Monad.Except (throwError)
-import Control.Monad.Reader
-import Control.Monad.Writer hiding ((<>))
+import Control.Monad
+import Control.Monad.Except   ( throwError )
+import Control.Monad.IO.Class ( MonadIO(..) )
+import Control.Monad.Reader   ( MonadReader(..), asks, ReaderT, runReaderT, withReaderT)
+import Control.Monad.Trans    ( lift )
+import Control.Monad.Writer   ( MonadWriter(..), WriterT, runWriterT )
 
 import qualified Data.HashSet as HashSet
 import qualified Data.List as List

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -6,8 +6,10 @@ module Agda.Compiler.ToTreeless
 
 import Prelude hiding ((!!))
 
-import Control.Arrow (first)
-import Control.Monad.Reader
+import Control.Arrow        ( first )
+import Control.Monad        ( filterM, foldM, forM, zipWithM )
+import Control.Monad.Reader ( MonadReader(..), asks, ReaderT, runReaderT )
+import Control.Monad.Trans  ( lift )
 
 import Data.Maybe
 import Data.Map (Map)

--- a/src/full/Agda/Compiler/Treeless/Simplify.hs
+++ b/src/full/Agda/Compiler/Treeless/Simplify.hs
@@ -1,7 +1,8 @@
 module Agda.Compiler.Treeless.Simplify (simplifyTTerm) where
 
-import Control.Arrow (second, (***))
-import Control.Monad.Reader
+import Control.Arrow        ( (***), second )
+import Control.Monad        ( (>=>), guard )
+import Control.Monad.Reader ( MonadReader(..), asks, Reader, runReader )
 import qualified Data.List as List
 
 import Agda.Syntax.Treeless

--- a/src/full/Agda/Interaction/AgdaTop.hs
+++ b/src/full/Agda/Interaction/AgdaTop.hs
@@ -2,7 +2,11 @@ module Agda.Interaction.AgdaTop
     ( repl
     ) where
 
-import Control.Monad.State
+import Control.Monad                ( unless )
+import Control.Monad.IO.Class       ( MonadIO(..) )
+import Control.Monad.State          ( evalStateT, runStateT )
+import Control.Monad.Trans          ( lift )
+
 import Data.Char
 import Data.Maybe
 import System.IO

--- a/src/full/Agda/Interaction/Base.hs
+++ b/src/full/Agda/Interaction/Base.hs
@@ -5,6 +5,8 @@ module Agda.Interaction.Base where
 
 import           Control.Concurrent.STM.TChan
 import           Control.Concurrent.STM.TVar
+
+import           Control.Monad                ( mplus, liftM2, liftM4 )
 import           Control.Monad.Except
 import           Control.Monad.Identity
 import           Control.Monad.State

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -6,7 +6,8 @@ module Agda.Interaction.BasicOps where
 
 import Prelude hiding (null)
 
-import Control.Arrow (first)
+import Control.Arrow          ( first )
+import Control.Monad          ( (>=>), forM, guard )
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State

--- a/src/full/Agda/Interaction/CommandLine.hs
+++ b/src/full/Agda/Interaction/CommandLine.hs
@@ -3,7 +3,9 @@ module Agda.Interaction.CommandLine
   ( runInteractionLoop
   ) where
 
+import Control.Monad
 import Control.Monad.Except
+import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.State
 import Control.Monad.Reader
 

--- a/src/full/Agda/Interaction/EmacsTop.hs
+++ b/src/full/Agda/Interaction/EmacsTop.hs
@@ -7,7 +7,11 @@ module Agda.Interaction.EmacsTop
     , prettyTypeOfMeta
     ) where
 
-import Control.Monad.State hiding (state)
+import Control.Monad
+import Control.Monad.IO.Class ( MonadIO(..) )
+import Control.Monad.State    ( evalStateT )
+import Control.Monad.Trans    ( lift )
+
 import qualified Data.List as List
 
 import Agda.Syntax.Common

--- a/src/full/Agda/Interaction/Highlighting/Dot/Backend.hs
+++ b/src/full/Agda/Interaction/Highlighting/Dot/Backend.hs
@@ -6,12 +6,13 @@ module Agda.Interaction.Highlighting.Dot.Backend
 import Agda.Interaction.Highlighting.Dot.Base (renderDotToFile)
 
 import Control.Monad.Except
-  ( MonadIO
-  , ExceptT
+  ( ExceptT
   , runExceptT
   , MonadError(throwError)
   )
-
+import Control.Monad.IO.Class
+  ( MonadIO(..)
+  )
 import Control.DeepSeq
 
 import Data.HashSet (HashSet)

--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -13,7 +13,8 @@ module Agda.Interaction.Highlighting.FromAbstract
 import Prelude hiding (null)
 
 import Control.Applicative
-import Control.Monad.Reader
+import Control.Monad         ( (<=<) )
+import Control.Monad.Reader  ( MonadReader(..), asks, Reader, runReader )
 
 import qualified Data.Map      as Map
 import           Data.Maybe

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -29,10 +29,13 @@ import Data.Semigroup (Semigroup(..))
 import Control.Monad (forM_, mapM_, unless, when)
 import Control.Monad.Trans.Reader as R ( ReaderT(runReaderT))
 import Control.Monad.RWS.Strict
-  ( MonadIO(..), RWST(runRWST)
+  ( RWST(runRWST)
   , MonadReader(..), asks
   , MonadState(..), gets, modify
   , lift, tell
+  )
+import Control.Monad.IO.Class
+  ( MonadIO(..)
   )
 
 import System.Directory

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -24,7 +24,9 @@ module Agda.Interaction.Imports
 
 import Prelude hiding (null)
 
+import Control.Monad               ( forM, forM_, void )
 import Control.Monad.Except
+import Control.Monad.IO.Class      ( MonadIO(..) )
 import Control.Monad.State
 import Control.Monad.Trans.Maybe
 import qualified Control.Exception as E

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -13,13 +13,16 @@ import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Concurrent.STM.TChan
 import Control.Concurrent.STM.TVar
-import qualified Control.Exception as E
-import Control.Monad.Except
-import Control.Monad.Fail (MonadFail)
-import Control.Monad.Identity
-import Control.Monad.Reader
-import Control.Monad.State hiding (state)
+
+import qualified Control.Exception  as E
+
+import Control.Monad
+import Control.Monad.Except         ( MonadError(..), ExceptT(..), runExceptT )
+import Control.Monad.IO.Class       ( MonadIO(..) )
+import Control.Monad.Fail           ( MonadFail )
+import Control.Monad.State          ( MonadState(..), gets, modify, runStateT )
 import Control.Monad.STM
+import Control.Monad.Trans          ( lift )
 
 import qualified Data.Char as Char
 import Data.Function

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -1,7 +1,9 @@
 module Agda.Interaction.JSONTop
     ( jsonREPL
     ) where
-import Control.Monad.State
+
+import Control.Monad          ( (<=<), forM )
+import Control.Monad.IO.Class ( MonadIO(..) )
 
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as BS

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -38,10 +38,12 @@ module Agda.Interaction.Library
   , findLib'
   ) where
 
-import Control.Arrow ( first , second )
+import Control.Arrow          ( first , second )
+import Control.Monad          ( filterM, forM )
 import Control.Monad.Except
 import Control.Monad.State
 import Control.Monad.Writer
+import Control.Monad.IO.Class ( MonadIO(..) )
 
 import Data.Char
 import Data.Data ( Data )

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -7,6 +7,7 @@ import Control.DeepSeq
 import Control.Monad.Except
 import Control.Monad.State
 import Control.Monad.Writer
+import Control.Monad.IO.Class ( MonadIO(..) )
 
 import Data.Char ( isDigit )
 import Data.Data ( Data )

--- a/src/full/Agda/Interaction/Options/Lenses.hs
+++ b/src/full/Agda/Interaction/Options/Lenses.hs
@@ -6,7 +6,7 @@
 
 module Agda.Interaction.Options.Lenses where
 
-import Control.Monad.State
+import Control.Monad.IO.Class   ( MonadIO(..) )
 
 import Data.Set (Set)
 import qualified Data.Set as Set

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -5,7 +5,9 @@ module Agda.Main where
 
 import Prelude hiding (null)
 
-import Control.Monad.Except
+import Control.Monad          ( void )
+import Control.Monad.Except   ( MonadError(..), ExceptT(..), runExceptT )
+import Control.Monad.IO.Class ( MonadIO(..) )
 
 import qualified Data.List as List
 import Data.Maybe

--- a/src/full/Agda/Syntax/Abstract/Pattern.hs
+++ b/src/full/Agda/Syntax/Abstract/Pattern.hs
@@ -7,9 +7,10 @@ module Agda.Syntax.Abstract.Pattern where
 
 import Prelude hiding (null)
 
-import Control.Arrow ((***), second)
-import Control.Monad.Identity
-import Control.Applicative (liftA2)
+import Control.Arrow           ( (***), second )
+import Control.Monad           ( (>=>) )
+import Control.Monad.Identity  ( Identity(..), runIdentity )
+import Control.Applicative     ( liftA2 )
 
 
 import Data.Maybe

--- a/src/full/Agda/Syntax/Abstract/PatternSynonyms.hs
+++ b/src/full/Agda/Syntax/Abstract/PatternSynonyms.hs
@@ -8,8 +8,9 @@ module Agda.Syntax.Abstract.PatternSynonyms
   , mergePatternSynDefs
   ) where
 
-import Control.Applicative ( Alternative(empty) )
-import Control.Monad.Writer hiding (forM)
+import Control.Applicative  ( Alternative(empty) )
+import Control.Monad        ( foldM, guard, zipWithM, zipWithM_ )
+import Control.Monad.Writer ( MonadWriter(..), WriterT, execWriterT )
 
 import Data.Map (Map)
 import qualified Data.Map as Map

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -54,8 +54,10 @@ module Agda.Syntax.Concrete.Definitions
 
 import Prelude hiding (null)
 
-import Control.Monad.Except
-import Control.Monad.State
+import Control.Monad         ( forM, guard, unless, void, when )
+import Control.Monad.Except  ( )
+import Control.Monad.State   ( MonadState(..), gets, StateT, runStateT )
+import Control.Monad.Trans   ( lift )
 
 import Data.Bifunctor
 import Data.Data (Data)

--- a/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
@@ -1,7 +1,8 @@
 module Agda.Syntax.Concrete.Definitions.Monad where
 
-import Control.Monad.Except
-import Control.Monad.State
+import Control.Monad        ( unless )
+import Control.Monad.Except ( MonadError(..), ExceptT, runExceptT )
+import Control.Monad.State  ( MonadState(..), modify, State, runState )
 
 import Data.Bifunctor (second)
 import Data.Map (Map)

--- a/src/full/Agda/Syntax/Concrete/Pattern.hs
+++ b/src/full/Agda/Syntax/Concrete/Pattern.hs
@@ -5,8 +5,10 @@ module Agda.Syntax.Concrete.Pattern where
 
 import Control.Applicative ( liftA2 )
 import Control.Arrow ( first )
+import Control.Monad ( (>=>) )
 import Control.Monad.Identity
-import Control.Monad.Writer
+
+import Data.Monoid ( Any(..), Endo(..), Sum(..) )
 
 import Agda.Syntax.Common
 import Agda.Syntax.Concrete

--- a/src/full/Agda/Syntax/Internal/Pattern.hs
+++ b/src/full/Agda/Syntax/Internal/Pattern.hs
@@ -1,8 +1,9 @@
 
 module Agda.Syntax.Internal.Pattern where
 
-import Control.Arrow (second)
-import Control.Monad.State
+import Control.Arrow       ( second )
+import Control.Monad       ( (>=>), forM )
+import Control.Monad.State ( MonadState(..), State, evalState )
 
 import Data.Maybe
 import Data.Monoid

--- a/src/full/Agda/Syntax/Parser.hs
+++ b/src/full/Agda/Syntax/Parser.hs
@@ -24,8 +24,10 @@ module Agda.Syntax.Parser
     ) where
 
 import Control.Exception
+import Control.Monad          ( forM_ )
 import Control.Monad.Except
 import Control.Monad.State
+import Control.Monad.IO.Class ( MonadIO(..) )
 
 import Data.Bifunctor
 import qualified Data.List as List

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -10,7 +10,6 @@ import Prelude hiding (null)
 import Control.Arrow ((***))
 import Control.Monad
 import Control.Monad.Except
-import Control.Monad.Writer hiding ((<>))
 import Control.Monad.State
 
 import Data.Either ( partitionEithers )

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -26,10 +26,11 @@ module Agda.Syntax.Translation.AbstractToConcrete
 
 import Prelude hiding (null)
 
-import Control.Arrow ((&&&), first)
-import Control.Monad.Except
-import Control.Monad.Reader
-import Control.Monad.State
+import Control.Arrow        ( (&&&), first )
+import Control.Monad        ( (<=<), forM, forM_, guard, liftM2 )
+import Control.Monad.Except ( runExceptT )
+import Control.Monad.Reader ( MonadReader(..), asks, runReaderT )
+import Control.Monad.State  ( StateT(..), runStateT )
 
 import qualified Control.Monad.Fail as Fail
 

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -19,9 +19,9 @@ module Agda.Syntax.Translation.ConcreteToAbstract
 
 import Prelude hiding ( null )
 
-import Control.Applicative hiding ( empty )
-import Control.Monad.Except
-import Control.Monad.Reader
+import Control.Monad        ( (<=<), foldM, forM, forM_, zipWithM, zipWithM_ )
+import Control.Applicative  ( liftA2, liftA3 )
+import Control.Monad.Except ( MonadError(..) )
 
 import Data.Bifunctor
 import Data.Foldable (traverse_)

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -23,9 +23,9 @@ module Agda.Syntax.Translation.InternalToAbstract
 
 import Prelude hiding (null)
 
-import Control.Applicative (liftA2)
-import Control.Arrow ((&&&))
-import Control.Monad.State
+import Control.Applicative ( liftA2 )
+import Control.Arrow       ( (&&&) )
+import Control.Monad       ( filterM, forM )
 
 import qualified Data.List as List
 import qualified Data.Map as Map

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -2,9 +2,10 @@
 
 module Agda.Syntax.Translation.ReflectedToAbstract where
 
-import Control.Arrow ( (***) )
-import Control.Monad.Except
-import Control.Monad.Reader
+import Control.Arrow        ( (***) )
+import Control.Monad        ( foldM )
+import Control.Monad.Except ( MonadError )
+import Control.Monad.Reader ( MonadReader(..), asks, reader, runReaderT )
 
 import Data.Maybe
 import Data.Set (Set)

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -13,6 +13,8 @@ import Control.Applicative hiding (empty)
 
 import qualified Control.Monad.Fail as Fail
 
+import Control.Monad          ( forM )
+import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.Except
 import Control.Monad.Reader
 

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -18,8 +18,8 @@ module Agda.Termination.TermCheck
 
 import Prelude hiding ( null )
 
-import Control.Applicative (liftA2)
-import Control.Monad.Reader
+import Control.Applicative  ( liftA2 )
+import Control.Monad        ( (<=<), filterM, forM, forM_, zipWithM )
 
 import Data.Foldable (toList)
 import qualified Data.List as List

--- a/src/full/Agda/TypeChecking/Datatypes.hs
+++ b/src/full/Agda/TypeChecking/Datatypes.hs
@@ -1,7 +1,8 @@
 
 module Agda.TypeChecking.Datatypes where
 
-import Control.Monad.Except
+import Control.Monad        ( filterM )
+import Control.Monad.Except ( MonadError(..), ExceptT(..), runExceptT )
 
 import Data.Maybe (fromMaybe)
 

--- a/src/full/Agda/TypeChecking/Empty.hs
+++ b/src/full/Agda/TypeChecking/Empty.hs
@@ -6,7 +6,8 @@ module Agda.TypeChecking.Empty
   , checkEmptyTel
   ) where
 
-import Control.Monad.Except
+import Control.Monad        ( void )
+import Control.Monad.Except ( MonadError(..) )
 
 import Data.Semigroup
 import qualified Data.Set as Set

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -60,8 +60,8 @@
 module Agda.TypeChecking.Free.Lazy where
 
 import Control.Applicative hiding (empty)
-import Control.Monad.Reader
-
+import Control.Monad        ( guard )
+import Control.Monad.Reader ( MonadReader(..), asks, ReaderT, Reader, runReader )
 
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -8,8 +8,10 @@ module Agda.TypeChecking.InstanceArguments
   , getInstanceCandidates
   ) where
 
-import Control.Monad.Except
-import Control.Monad.Reader
+import Control.Monad        ( forM )
+import Control.Monad.Except ( MonadError(..) )
+import Control.Monad.Trans  ( lift )
+
 import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
 import qualified Data.Map.Strict as MapS

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -7,7 +7,7 @@ module Agda.TypeChecking.Lock
   )
 where
 
-import Control.Monad.Reader
+import Control.Monad            ( filterM, forM, forM_ )
 
 import qualified Data.IntMap as IMap
 import qualified Data.IntSet as ISet

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -5,8 +5,9 @@ module Agda.TypeChecking.MetaVars where
 
 import Prelude hiding (null)
 
-import Control.Monad.Except
-import Control.Monad.Reader
+import Control.Monad        ( foldM, forM, forM_, liftM2, void )
+import Control.Monad.Except ( MonadError(..), ExceptT, runExceptT )
+import Control.Monad.Trans  ( lift )
 
 import Data.Function
 import qualified Data.IntSet as IntSet

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -15,14 +15,16 @@ import qualified Control.Exception as E
 
 import qualified Control.Monad.Fail as Fail
 
+import Control.Monad                ( void )
 import Control.Monad.Except
-import Control.Monad.State
-import Control.Monad.Reader
-import Control.Monad.Writer hiding ((<>))
+import Control.Monad.IO.Class       ( MonadIO(..) )
+import Control.Monad.State          ( MonadState(..), modify, StateT(..), runStateT )
+import Control.Monad.Reader         ( MonadReader(..), ReaderT(..), runReaderT )
+import Control.Monad.Writer         ( WriterT )
 import Control.Monad.Trans          ( MonadTrans(..), lift )
 import Control.Monad.Trans.Control  ( MonadTransControl(..), liftThrough )
-import Control.Monad.Trans.Identity
-import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.Identity ( IdentityT(..), runIdentityT )
+import Control.Monad.Trans.Maybe    ( MaybeT(..) )
 
 import Control.Parallel             ( pseq )
 

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -6,7 +6,9 @@ module Agda.TypeChecking.Monad.Builtin
 
 import qualified Control.Monad.Fail as Fail
 
+import Control.Monad                ( liftM2, void )
 import Control.Monad.Except
+import Control.Monad.IO.Class       ( MonadIO(..) )
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Trans.Identity (IdentityT)

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
@@ -1,9 +1,11 @@
 
 module Agda.TypeChecking.Monad.Builtin where
 
-import Control.Monad.Reader
-import Control.Monad.State
+import Control.Monad.IO.Class       ( MonadIO )
+import Control.Monad.Reader         ( ReaderT )
+import Control.Monad.State          ( StateT )
 import Control.Monad.Trans.Identity ( IdentityT )
+import Control.Monad.Trans          ( MonadTrans, lift )
 
 import qualified Control.Monad.Fail as Fail
 

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -4,6 +4,7 @@ module Agda.TypeChecking.Monad.Context where
 import Data.Text (Text)
 import qualified Data.Text as T
 
+import Control.Monad                ( (<=<), forM, when )
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -6,6 +6,8 @@ module Agda.TypeChecking.Monad.Debug
 
 import qualified Control.Exception as E
 import qualified Control.DeepSeq as DeepSeq (force)
+
+import Control.Monad.IO.Class       ( MonadIO(..) )
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
@@ -340,4 +342,3 @@ hasProfileOption opt = containsProfileOption opt <$> getProfileOptions
 -- | Run some code when the given profiling option is active.
 whenProfile :: MonadDebug m => ProfileOption -> m () -> m ()
 whenProfile opt = whenM (hasProfileOption opt)
-

--- a/src/full/Agda/TypeChecking/Monad/Imports.hs
+++ b/src/full/Agda/TypeChecking/Monad/Imports.hs
@@ -19,9 +19,8 @@ module Agda.TypeChecking.Monad.Imports
   , withImportPath
   ) where
 
-import Control.Arrow ( (***) )
-import Control.Monad.State
-
+import Control.Arrow   ( (***) )
+import Control.Monad   ( when )
 
 import Data.Set (Set)
 import qualified Data.Map as Map

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -4,6 +4,7 @@ module Agda.TypeChecking.Monad.MetaVars where
 
 import Prelude hiding (null)
 
+import Control.Monad                ( (<=<), guard )
 import Control.Monad.Except
 import Control.Monad.State
 import Control.Monad.Trans.Identity ( IdentityT )

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -1,7 +1,9 @@
 
 module Agda.TypeChecking.Monad.Options where
 
-import Control.Arrow ( (&&&) )
+import Control.Arrow          ( (&&&) )
+import Control.Monad          ( unless, when )
+import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -6,13 +6,14 @@ import Prelude hiding (null)
 
 import qualified Control.Monad.Fail as Fail
 
-import Control.Arrow (first, second)
-import Control.Monad.Except
-import Control.Monad.State
-import Control.Monad.Reader
-import Control.Monad.Writer hiding ((<>))
-import Control.Monad.Trans.Maybe
-import Control.Monad.Trans.Identity
+import Control.Arrow                 ( first, second )
+import Control.Monad.Except          ( ExceptT )
+import Control.Monad.State           ( StateT  )
+import Control.Monad.Reader          ( ReaderT )
+import Control.Monad.Writer          ( WriterT )
+import Control.Monad.Trans.Maybe     ( MaybeT  )
+import Control.Monad.Trans.Identity  ( IdentityT )
+import Control.Monad.Trans           ( MonadTrans, lift )
 
 import Data.Foldable (for_)
 import qualified Data.List as List

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -5,7 +5,7 @@ module Agda.TypeChecking.Monad.State where
 
 import qualified Control.Exception as E
 
-import Control.Monad.State (void)
+import Control.Monad       (void)
 import Control.Monad.Trans (MonadIO, liftIO)
 
 import Data.Maybe

--- a/src/full/Agda/TypeChecking/Names.hs
+++ b/src/full/Agda/TypeChecking/Names.hs
@@ -22,11 +22,14 @@ module Agda.TypeChecking.Names where
 -- Control.Monad.Fail import is redundant since GHC 8.8.1
 import Control.Monad.Fail (MonadFail)
 
-import Control.Monad.Except
-import Control.Monad.Reader
-import Control.Monad.State
+import Control.Monad          ( liftM2, unless )
+import Control.Monad.Except   ( MonadError )
+import Control.Monad.IO.Class ( MonadIO(..) )
+import Control.Monad.Reader   ( MonadReader(..), ReaderT, runReaderT )
+import Control.Monad.State    ( MonadState )
+import Control.Monad.Trans    ( MonadTrans, lift )
 
-import Data.List (isSuffixOf)
+import Data.List              ( isSuffixOf )
 
 import Agda.Syntax.Common hiding (Nat)
 import Agda.Syntax.Internal
@@ -231,4 +234,3 @@ lamTel t = map (Lam defaultArgInfo) . sequenceA <$> t
 
 appTel :: Monad m => NamesT m [Term] -> NamesT m Term -> NamesT m [Term]
 appTel = liftM2 (\ fs x -> map (`apply` [Arg defaultArgInfo x]) fs)
-

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -11,10 +11,10 @@ module Agda.TypeChecking.Polarity
   , polFromOcc
   ) where
 
-import Control.Monad.State
+import Control.Monad  ( forM_, zipWithM )
 
 import Data.Maybe
-import Data.Semigroup (Semigroup(..))
+import Data.Semigroup ( Semigroup(..) )
 
 import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Common

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -7,7 +7,8 @@ import Prelude hiding ( null )
 
 import Control.Applicative hiding (empty)
 import Control.DeepSeq
-import Control.Monad.Reader
+import Control.Monad        ( forM_, guard, liftM2 )
+import Control.Monad.Reader ( MonadReader(..), asks, Reader, runReader )
 
 import Data.Either
 import qualified Data.Foldable as Fold

--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -9,10 +9,13 @@ module Agda.TypeChecking.RecordPatterns
   , recordPatternToProjections
   ) where
 
-import Control.Arrow (first, second)
-import Control.Monad.Fix
-import Control.Monad.Reader
-import Control.Monad.State
+import Control.Arrow          ( first, second )
+import Control.Monad          ( forM, unless, when, zipWithM )
+import Control.Monad.Fix      ( mfix )
+import Control.Monad.IO.Class ( MonadIO(..) )
+import Control.Monad.Reader   ( MonadReader(..), ReaderT(..), runReaderT )
+import Control.Monad.State    ( MonadState(..), StateT(..), runStateT )
+import Control.Monad.Trans    ( lift )
 
 import qualified Data.List as List
 import Data.Maybe

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -2,7 +2,7 @@
 
 module Agda.TypeChecking.Reduce where
 
-import Control.Monad.Reader
+import Control.Monad ( (>=>), void )
 
 import Data.Maybe
 import Data.Map (Map)

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -10,7 +10,7 @@ module Agda.TypeChecking.Reduce.Monad
 
 import Prelude hiding (null)
 
-import Control.Monad.Reader
+import Control.Monad         ( liftM2 )
 
 import qualified Data.Map as Map
 import Data.Maybe

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -22,9 +22,10 @@ module Agda.TypeChecking.Rewriting.NonLinMatch where
 
 import Prelude hiding (null, sequence)
 
-import Control.Applicative (Alternative)
-import Control.Monad.Except
-import Control.Monad.State
+import Control.Applicative  ( Alternative )
+import Control.Monad        ( void )
+import Control.Monad.Except ( MonadError(..), ExceptT, runExceptT )
+import Control.Monad.State  ( MonadState, StateT, runStateT )
 
 import qualified Control.Monad.Fail as Fail
 

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -6,7 +6,8 @@
 
 module Agda.TypeChecking.Rewriting.NonLinPattern where
 
-import Control.Monad.Reader
+import Control.Monad        ( (>=>), forM )
+import Control.Monad.Reader ( asks )
 
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -10,7 +10,8 @@ module Agda.TypeChecking.Rules.Application
 
 import Prelude hiding ( null )
 
-import Control.Applicative ((<|>))
+import Control.Applicative        ( (<|>) )
+import Control.Monad              ( forM, forM_, guard, liftM2 )
 import Control.Monad.Except
 import Control.Monad.Trans
 import Control.Monad.Trans.Maybe

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -4,8 +4,8 @@ module Agda.TypeChecking.Rules.Def where
 
 import Prelude hiding ( null )
 
-import Control.Monad.Except
-import Control.Monad.State
+import Control.Monad        ( forM, forM_ )
+import Control.Monad.Except ( MonadError(..) )
 
 import Data.Bifunctor
 import Data.Function

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -18,7 +18,7 @@ import Control.Arrow (left, second)
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Reader
-import Control.Monad.Writer hiding ((<>))
+import Control.Monad.Writer       ( MonadWriter(..), runWriterT )
 import Control.Monad.Trans.Maybe
 
 import Data.IntSet (IntSet)

--- a/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
@@ -11,8 +11,9 @@ module Agda.TypeChecking.Rules.LHS.Problem
 
 import Prelude hiding (null)
 
-import Control.Arrow ( (***) )
-import Control.Monad.Writer hiding ((<>))
+import Control.Arrow        ( (***) )
+import Control.Monad        ( zipWithM )
+import Control.Monad.Writer ( MonadWriter(..), Writer, runWriter )
 
 import Data.Functor (($>))
 import Data.IntMap (IntMap)

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -4,6 +4,7 @@ module Agda.TypeChecking.Rules.Term where
 
 import Prelude hiding ( null )
 
+import Control.Monad         ( (<=<), forM )
 import Control.Monad.Except
 import Control.Monad.Reader
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -33,6 +33,7 @@ import Control.DeepSeq
 import qualified Control.Exception as E
 import Control.Monad
 import Control.Monad.Except
+import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -9,6 +9,7 @@ import Control.Exception (evaluate)
 
 import Control.Monad.Catch (catchAll)
 import Control.Monad.Except
+import Control.Monad.IO.Class     ( MonadIO(..) )
 import Control.Monad.Reader
 import Control.Monad.State.Strict (StateT, gets)
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -3,10 +3,11 @@
 
 module Agda.TypeChecking.Serialise.Instances.Common (SerialisedRange(..)) where
 
-import Control.Monad.Except
-import Control.Monad.Reader
-import Control.Monad.State.Strict (gets, modify)
-
+import Control.Monad              ( (<=<) )
+import Control.Monad.IO.Class     ( MonadIO(..) )
+import Control.Monad.Except       ( MonadError(..) )
+import Control.Monad.Reader       ( MonadReader(..), asks )
+import Control.Monad.State.Strict ( gets, modify )
 
 import Data.Array.IArray
 import Data.Word

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -4,8 +4,8 @@ module Agda.TypeChecking.SizedTypes where
 
 import Prelude hiding (null)
 
-import Control.Monad.Except
-import Control.Monad.Writer hiding ((<>))
+import Control.Monad.Except ( MonadError(..) )
+import Control.Monad.Writer ( MonadWriter(..), WriterT(..), runWriterT )
 
 import qualified Data.Foldable as Fold
 import qualified Data.List as List

--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -9,10 +9,12 @@
 
 module Agda.TypeChecking.SyntacticEquality (SynEq, checkSyntacticEquality) where
 
-import Control.Arrow ((***))
-import Control.Monad.State
+import Control.Arrow            ( (***) )
+import Control.Monad            ( zipWithM )
+import Control.Monad.State      ( MonadState(..), StateT, runStateT )
+import Control.Monad.Trans      ( lift )
 
-import Agda.Interaction.Options (optSyntacticEquality)
+import Agda.Interaction.Options ( optSyntacticEquality )
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -1,11 +1,14 @@
 
 module Agda.TypeChecking.Unquote where
 
-import Control.Arrow (first, second, (&&&))
-import Control.Monad.Except
-import Control.Monad.Reader
-import Control.Monad.State
-import Control.Monad.Writer hiding ((<>))
+import Control.Arrow          ( first, second, (&&&) )
+import Control.Monad          ( (<=<) )
+import Control.Monad.Except   ( MonadError(..), ExceptT(..), runExceptT )
+import Control.Monad.IO.Class ( MonadIO(..) )
+import Control.Monad.Reader   ( ReaderT(..), runReaderT )
+import Control.Monad.State    ( gets, modify, StateT(..), runStateT )
+import Control.Monad.Writer   ( MonadWriter(..), WriterT(..), runWriterT )
+import Control.Monad.Trans    ( lift )
 
 import Data.Char
 import Data.Map (Map)
@@ -1022,4 +1025,3 @@ raiseExeNotFound exe fp = genericDocError =<< do
 raiseExeNotExecutable :: ExeName -> FilePath -> TCM a
 raiseExeNotExecutable exe fp = genericDocError =<< do
   text $ "File '" ++ fp ++ "' for trusted executable" ++ T.unpack exe ++ " does not have permission to execute"
-

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -12,6 +12,7 @@ import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.Writer
 import Control.Monad.State
+import Control.Monad.IO.Class ( MonadIO(..) )
 
 
 import Data.Function

--- a/src/full/Agda/Utils/IO/Directory.hs
+++ b/src/full/Agda/Utils/IO/Directory.hs
@@ -4,7 +4,10 @@ module Agda.Utils.IO.Directory
 where
 
 import Control.Monad
-import Control.Monad.Writer
+import Control.Monad.Writer ( WriterT, execWriterT, tell )
+import Control.Monad.Trans  ( lift )
+
+import Data.Monoid          ( Endo(Endo, appEndo) )
 
 import System.Directory
 import System.FilePath

--- a/src/full/Agda/Utils/ListT.hs
+++ b/src/full/Agda/Utils/ListT.hs
@@ -15,6 +15,7 @@ import Control.Monad
 import Control.Monad.Fail as Fail
 import Control.Monad.Reader
 import Control.Monad.State
+import Control.Monad.IO.Class ( MonadIO(..) )
 
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup (Semigroup(..))

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -7,9 +7,10 @@ module Agda.Utils.Monad
     )
     where
 
-import Control.Applicative  (liftA2)
-import Control.Monad.Except
-import Control.Monad.State
+import Control.Applicative  ( liftA2 )
+import Control.Monad        ( MonadPlus(..), guard, unless, when )
+import Control.Monad.Except ( MonadError(catchError, throwError) )
+import Control.Monad.State  ( MonadState(get, put) )
 
 import Data.Traversable as Trav hiding (for, sequence)
 import Data.Foldable as Fold

--- a/src/full/Agda/Utils/Update.hs
+++ b/src/full/Agda/Utils/Update.hs
@@ -25,8 +25,9 @@ import Control.Monad.Trans.Control
 -- NB: Control.Monad.Trans.Identity is already exported by Control.Monad.Identity
 -- since version mtl 2.2.2, but this needs at least ghc 8.2.2
 import Control.Monad.Trans.Identity
-import Control.Monad.Writer.Strict
+import Control.Monad.Writer.Strict ( MonadWriter(..), Writer, WriterT, mapWriterT, runWriterT )
 
+import Data.Monoid ( Any(..) )
 
 import Agda.Utils.Tuple
 


### PR DESCRIPTION
mtl-2.3 RC3 removed reexports of `Control.Monad`, `MonadIO(..)` and `MonadTrans(..)` from the `Control.Monad.*` modules.

This PR makes Agda compile with `mtl-2.3-rc3`.
Note that it might generate `unused-import` warnings if build with `mtl-2.*`.