### PR TITLE
[ fix #5563 ] Allow erased variables in type signatures in let

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1620,7 +1620,7 @@ checkLetBinding b@(A.LetBind i info x t e) ret =
     -- #4131: Only DontExpandLast if no user written type signature
     let check | getOrigin info == Inserted = checkDontExpandLast
               | otherwise                  = checkExpr'
-    t <- isType_ t
+    t <- workOnTypes $ isType_ t
     v <- applyModalityToContext info $ check CmpLeq e t
     addLetBinding info (A.unBind x) v t ret
 

--- a/test/Succeed/Issue5563.agda
+++ b/test/Succeed/Issue5563.agda
@@ -1,0 +1,8 @@
+module Issue5563 where
+
+F : (@0 A : Set) → A → A
+F A x =
+  let
+    y : A
+    y = x
+  in y


### PR DESCRIPTION
Ran into the same issue of type annotations in let-bound definitions not allowing for erased variables.
Credit goes to @jespercockx for the fix.