### PR TITLE
[ fix #5807 ] Clarify --irrelevant-projections and irrAx.

### DIFF
--- a/doc/user-manual/language/irrelevance.lagda.rst
+++ b/doc/user-manual/language/irrelevance.lagda.rst
@@ -20,6 +20,8 @@ Since version 2.2.8 Agda supports irrelevancy annotations. The general rule is t
   This section is about compile-time irrelevance. See :ref:`runtime-irrelevance` for the section on
   run-time irrelevance.
 
+The more recent :ref:`prop` serves a similar purpose and can be used to simulate irrelevance.
+
 Motivating example
 ==================
 
@@ -213,6 +215,7 @@ An important example is the irrelevance axiom ``irrAx``: ::
     .irrAx : ∀ {ℓ} {A : Set ℓ} -> .A -> A
 
 This axiom is not provable inside Agda, but it is often very useful when working with irrelevance.
+The irrelevance axiom is a form of non-constructive choice.
 
 Irrelevant record fields
 ========================
@@ -236,12 +239,12 @@ Projections for irrelevant fields are only created if option
   record Squash (A : Set) : Set where
     constructor squash
     field
-      .proof : A
+      .unsquash : A
 
   open Squash
 
-  .unsquash : ∀ {A} → Squash A → A
-  unsquash x = proof x
+  .example : ∀ {A} → Squash A → A
+  example x = unsquash x
 
 **Example 3.** We can define the subset of ``x : A`` satisfying ``P x`` with irrelevant membership certificates. ::
 
@@ -253,6 +256,16 @@ Projections for irrelevant fields are only created if option
 
   .certificate : {A : Set}{P : A -> Set} -> (x : Subset A P) -> P (Subset.elem x)
   certificate (a # p) = irrAx p
+
+**Example 4.** Irrelevant projections are justified by the irrelevance axiom. ::
+
+  .unsquash' : ∀ {A} → Squash A → A
+  unsquash' (squash x) = irrAx x
+
+  .irrAx' : ∀ {A} → .A → A
+  irrAx' x = unsquash (squash x)
+
+Like the irrelevance axiom, irrelevant projections cannot be reduced.
 
 Dependent irrelevant function types
 ===================================


### PR DESCRIPTION
Attempt to clarify some of my initial confusion about irrelevance in the documentation:
* Prop serves as an alternative to irrelevance
* The irrelevance axiom is a form of non-constructive choice
* Irrelevant projections are justified by the irrelevance axiom

I did not mention the reason that irrelevant projections cannot be reduced because that doesn't seem like the sort of thing included elsewhere in the manual. (The reason being that it's inconsistent.)

I also think it would also be helpful to mention what options are unsafe when they are introduced, but that's outside the scope of this PR.

All of these things can already be inferred from what is already written, but this states them explicitly. In hindsight they're obvious, but at the time, it took me a while to figure it out. Hopefully this is helpful and I'm not just bad at reading...? (But this PR is very minor, so if you don't think it's a helpful change, just reject it.)