### PR TITLE
Fix #5809: retain parameters for irrelevant projections.

### DIFF
--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -346,8 +346,8 @@ inferDef f es = do
 -- | Infer possibly projection-like function application
 inferDef' :: (MonadCheckInternal m) => QName -> Arg Term -> Elims -> m Type
 inferDef' f a es = do
-  isProj <- isProjection f
-  case isProj of
+  -- Andreas, 2022-03-07, issue #5809: don't drop parameters of irrelevant projections.
+  isRelevantProjection f >>= \case
     Just Projection{ projIndex = n } | n > 0 -> do
       let self = unArg a
       b <- infer self

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -197,8 +197,10 @@ compareAs cmp a u v = do
         (Def f es, Def f' es') | f == f' ->
           ifNotM (optFirstOrder <$> pragmaOptions) fallback $ {- else -} unlessSubtyping $ do
           def <- getConstInfo f
-          -- We do not shortcut projection-likes
-          if isJust $ isProjection_ (theDef def) then fallback else do
+          -- We do not shortcut projection-likes,
+          -- Andreas, 2022-03-07, issue #5809:
+          -- but irrelevant projections since they are applied to their parameters.
+          if isJust $ isRelevantProjection_ def then fallback else do
           pol <- getPolarity' cmp f
           compareElims pol [] (defType def) (Def f []) es es' `orelse` fallback
         _               -> fallback
@@ -397,8 +399,8 @@ computeElimHeadType f es es' = do
   def <- getConstInfo f
   -- To compute the type @a@ of a projection-like @f@,
   -- we have to infer the type of its first argument.
-  if projectionArgs (theDef def) <= 0 then return $ defType def else do
-    -- Find an first argument to @f@.
+  if projectionArgs def <= 0 then return $ defType def else do
+    -- Find a first argument to @f@.
     let arg = case (es, es') of
               (Apply arg : _, _) -> arg
               (_, Apply arg : _) -> arg

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -601,7 +601,8 @@ applyDroppingParameters t vs = do
         Constructor {conPars = n} -> return $ Con c ci (map Apply $ drop n vs)
         _ -> __IMPOSSIBLE__
     Def f [] -> do
-      mp <- isProjection f
+      -- Andreas, 2022-03-07, issue #5809: don't drop parameters of irrelevant projections.
+      mp <- isRelevantProjection f
       case mp of
         Just Projection{projIndex = n} -> do
           case drop n vs of

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -266,8 +266,8 @@ lookupSection m = maybe EmptyTel (^. secTelescope) <$> getSection m
 addDisplayForms :: QName -> TCM ()
 addDisplayForms x = do
   reportSDoc "tc.display.section" 20 $ "Computing display forms for" <+> pretty x
-  def <- theDef <$> getConstInfo x
-  let v = case def of
+  def <- getConstInfo x
+  let v = case theDef def of
              Constructor{conSrcCon = h} -> Con h{ conName = x } ConOSystem []
              _                          -> Def x []
 
@@ -1225,7 +1225,7 @@ droppedPars d = case theDef d of
     Axiom{}                  -> 0
     DataOrRecSig{}           -> 0
     GeneralizableVar{}       -> 0
-    def@Function{}           -> projectionArgs def
+    def@Function{}           -> projectionArgs d
     Datatype  {dataPars = _} -> 0  -- not dropped
     Record     {recPars = _} -> 0  -- not dropped
     Constructor{conPars = n} -> n
@@ -1244,6 +1244,15 @@ isProjection_ def =
     Function { funProjection = result } -> result
     _                                   -> Nothing
 
+-- | Is it the name of a non-irrelevant record projection?
+{-# SPECIALIZE isProjection :: QName -> TCM (Maybe Projection) #-}
+isRelevantProjection :: HasConstInfo m => QName -> m (Maybe Projection)
+isRelevantProjection qn = isRelevantProjection_ <$> getConstInfo qn
+
+isRelevantProjection_ :: Definition -> Maybe Projection
+isRelevantProjection_ def =
+  if isIrrelevant def then Nothing else isProjection_ $ theDef def
+
 -- | Is it a function marked STATIC?
 isStaticFun :: Defn -> Bool
 isStaticFun = (^. funStatic)
@@ -1260,20 +1269,21 @@ isProperProjection d = caseMaybe (isProjection_ d) False $ \ isP ->
   (projIndex isP > 0) && isJust (projProper isP)
 
 -- | Number of dropped initial arguments of a projection(-like) function.
-projectionArgs :: Defn -> Int
-projectionArgs = maybe 0 (max 0 . pred . projIndex) . isProjection_
+projectionArgs :: Definition -> Int
+projectionArgs = maybe 0 (max 0 . pred . projIndex) . isRelevantProjection_
 
 -- | Check whether a definition uses copatterns.
 usesCopatterns :: (HasConstInfo m) => QName -> m Bool
 usesCopatterns q = defCopatternLHS <$> getConstInfo q
 
 -- | Apply a function @f@ to its first argument, producing the proper
---   postfix projection if @f@ is a projection.
+--   postfix projection if @f@ is a projection which is not irrelevant.
 applyDef :: (HasConstInfo m)
          => ProjOrigin -> QName -> Arg Term -> m Term
 applyDef o f a = do
   let fallback = return $ Def f [Apply a]
-  caseMaybeM (isProjection f) fallback $ \ isP -> do
+  -- Andreas, 2022-03-07, issue #5809: don't drop parameters of irrelevant projections.
+  caseMaybeM (isRelevantProjection f) fallback $ \ isP -> do
     if projIndex isP <= 0 then fallback else do
       -- Get the original projection, if existing.
       if isNothing (projProper isP) then fallback else do

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -263,10 +263,7 @@ checkStrictlyPositive mi qset = do
 
 getDefArity :: Definition -> TCM Int
 getDefArity def = do
-  let dropped = case theDef def of
-        defn@Function{} -> projectionArgs defn
-        _ -> 0
-  subtract dropped <$> arity' (defType def)
+  subtract (projectionArgs def) <$> arity' (defType def)
   where
   -- A variant of "\t -> arity <$> instantiateFull t".
   arity' :: Type -> TCM Int

--- a/src/full/Agda/TypeChecking/ReconstructParameters.hs
+++ b/src/full/Agda/TypeChecking/ReconstructParameters.hs
@@ -177,17 +177,14 @@ reconstructParameters' act a v = do
     mapHide t l = l
 
 dropParameters :: TermLike a => a -> TCM a
-dropParameters = traverseTermM dropPars
-  where
-    dropPars v =
-      case v of
+dropParameters = traverseTermM $
+    \case
         Con c ci vs -> do
           Constructor{ conData = d } <- theDef <$> getConstInfo (conName c)
           Just n <- defParameters <$> getConstInfo d
           return $ Con c ci $ drop n vs
-        Def f vs -> do
-          isProj <- isProjection f
-          case isProj of
+        v@(Def f vs) -> do
+          isRelevantProjection f >>= \case
             Nothing -> return v
             Just pr -> return $ applyE (projDropPars pr ProjSystem) vs
-        _        -> return v
+        v -> return v

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -263,7 +263,8 @@ inferApplication exh hd args e = postponeInstanceConstraints $ do
 
 inferHeadDef :: ProjOrigin -> QName -> TCM (Elims -> Term, Type)
 inferHeadDef o x = do
-  proj <- isProjection x
+  -- Andreas, 2022-03-07, issue #5809: don't drop parameters of irrelevant projections.
+  proj <- isRelevantProjection x
   rel  <- getRelevance . defArgInfo <$> getConstInfo x
   let app =
         case proj of

--- a/test/Fail/Issue543.agda
+++ b/test/Fail/Issue543.agda
@@ -4,8 +4,6 @@
 
 module Issue543 where
 
-import Common.Level
-import Common.Irrelevance
 open import Common.Equality
 
 data   ⊥ : Set where

--- a/test/Fail/Issue543.err
+++ b/test/Fail/Issue543.err
@@ -1,6 +1,6 @@
-Issue543.agda:34,10-72
-unsquash (squash _) != true of type Bool
+Issue543.agda:32,10-72
+unsquash _ != true of type Bool
 when checking that the inferred type of an application
-  unsquash (squash _) ≡ unsquash _y_28
+  unsquash _ ≡ unsquash _
 matches the expected type
   true ≡ false

--- a/test/Fail/Issue543a.agda
+++ b/test/Fail/Issue543a.agda
@@ -4,8 +4,6 @@
 
 module Issue543a where
 
-import Common.Level
-import Common.Irrelevance
 open import Common.Equality
 
 data   ⊥ : Set where

--- a/test/Fail/Issue543a.err
+++ b/test/Fail/Issue543a.err
@@ -1,4 +1,3 @@
-Issue543a.agda:36,50-54
-true != (unsquash (squash _)) of type Bool
-when checking that the expression refl has type
-true ≡ unsquash (squash _)
+Issue543a.agda:34,50-54
+true != (unsquash _) of type Bool
+when checking that the expression refl has type true ≡ unsquash _

--- a/test/Succeed/Issue5809.agda
+++ b/test/Succeed/Issue5809.agda
@@ -1,0 +1,32 @@
+-- Andreas, 2022-03-07, issue #5809 reported by jamestmartin
+-- Regression in Agda 2.6.1.
+-- Not reducing irrelevant projections lead to non-inferable elim-terms
+-- and consequently to internal errors.
+--
+-- The fix is to treat irrelevant projections as just functions,
+-- retaining their parameters, so that they remain inferable
+-- even if not in normal form.
+
+{-# OPTIONS --irrelevant-projections #-}
+{-# OPTIONS --allow-unsolved-metas #-}
+
+-- {-# OPTIONS --no-double-check #-}
+-- {-# OPTIONS -v impossible:100 #-}
+-- {-# OPTIONS -v tc:40 #-}
+
+open import Agda.Builtin.Equality
+
+record Squash {ℓ} (A : Set ℓ) : Set ℓ where
+  constructor squash
+  field
+    .unsquash : A
+open Squash
+
+.test : ∀ {ℓ} {A : Set ℓ} (x : A) (y : Squash A) → {!!}
+test x y = {!!}
+  where
+    help : unsquash (squash x) ≡ unsquash y
+    help = refl
+
+-- WAS: internal error.
+-- Should succeed with unsolved metas.


### PR DESCRIPTION
Fix #5809: retain parameters for irrelevant projections.

Since irrelevant projections are not reduced since Agda 2.6.1, they can lead to non-inferable terms if they drop their parameters.
A simple solution (implemented here) is to retain parameters for all irrelevant projection, treating them as ordinary functions on the rhs.