### PR TITLE
Fix #5269: agda-bisect: WIP: Support v2-cabal via v2-build and cabal-plan

### DIFF
--- a/src/agda-bisect/Bisect.hs
+++ b/src/agda-bisect/Bisect.hs
@@ -563,7 +563,7 @@ main = do
 
 checkOptions :: Options -> IO ()
 checkOptions Options{ .. } = do
-  mapM checkCompiler compiler
+  mapM_ checkCompiler compiler
   checkCabal v1cabal cabal
   unless v1cabal $ checkCabalPlan cabalPlan
 
@@ -606,10 +606,10 @@ checkCabalPlan cabalPlan = do
         ]
       return "(unkonwn)"
     version : _ -> do
-      unless (version >= makeVersion [0,2]) $
+      unless (version >= cabalPlanMinVersion) $
         die $ unwords
-          [ "Need cabal-plan >= 0.2, but got version"
-          , showVersion version
+          [ "Need cabal-plan >=", showVersion cabalPlanMinVersion
+          , "but got version", showVersion version
           ]
       return $ showVersion version
   putStrLn $ unwords [ "Using", cabalPlan, "version", versionString ]
@@ -889,6 +889,11 @@ compiledAgdaFromCabalPlan :: FilePath -> IO FilePath
 compiledAgdaFromCabalPlan cabalPlan =
   readProcessChar8 cabalPlan ["--ascii", "list-bin", "agda"]
     -- TODO: should this be --unicode (UTF8 encoding)?
+
+-- | Option @--ascii@ requires @cabal-plan >= 0.7.1.0@.
+
+cabalPlanMinVersion :: Version
+cabalPlanMinVersion = makeVersion [0,7,1,0]
 
 -- | Prepare Agda source code for compilation.
 

--- a/src/agda-bisect/Bisect.hs
+++ b/src/agda-bisect/Bisect.hs
@@ -707,6 +707,8 @@ bisect opts =
          then return Skip
          else installAndRunAgda opts
 
+    putStrLn $ "Verdict: " ++ show r
+
     ok <- callProcessWithResult "git" ["bisect", map toLower (show r)]
 
     case logFile opts of
@@ -817,19 +819,28 @@ runAgda agda opts = do
         " (" ++ (if expectedResult then "good" else "bad") ++ ")"
       unless (null out) $ putStr $ "Stdout:\n" ++ indent out
       unless (null err) $ putStr $ "Stderr:\n" ++ indent err
-      putStrLn $ "Verdict: " ++ show result
-
       return result
+
   where
   indent = unlines . map ("  " ++) . lines
 
   readProcessCabal cmd args input
-    | v1cabal opts = readProcess cmd args input
-    | otherwise    = readProcess (cabal opts) (cabalArgs cmd args) input
+    | v1cabal opts = readProcess' cmd args input
+    | otherwise    = readProcess' (cabal opts) (cabalArgs cmd args) input
 
   readProcessWithExitCodeCabal cmd args input
-    | v1cabal opts = readProcessWithExitCode cmd args input
-    | otherwise    = readProcessWithExitCode (cabal opts) (cabalArgs cmd args) input
+    | v1cabal opts = readProcessWithExitCode' cmd args input
+    | otherwise    = readProcessWithExitCode' (cabal opts) (cabalArgs cmd args) input
+
+  readProcess' cmd args input = do
+    putStr "Running: "
+    putStrLn $ showCommandForUser cmd args
+    readProcess cmd args input
+
+  readProcessWithExitCode' cmd args input = do
+    putStr "Running: "
+    putStrLn $ showCommandForUser cmd args
+    readProcessWithExitCode cmd args input
 
   cabalArgs cmd args
     | cmd == agda = concat

--- a/src/agda-bisect/agda-bisect.cabal
+++ b/src/agda-bisect/agda-bisect.cabal
@@ -3,6 +3,7 @@ synopsis: Git bisect wrapper script for the Agda code base
 version: 0.1
 cabal-version: >= 1.10
 author: Nils Anders Danielsson
+maintainer: Andreas Abel
 build-type: Simple
 tested-with:
   GHC == 8.0.2
@@ -11,7 +12,7 @@ tested-with:
   GHC == 8.6.5
   GHC == 8.8.4
   GHC == 8.10.7
-  GHC == 9.0.1
+  GHC == 9.0.2
   GHC == 9.2.1
 
 executable agda-bisect
@@ -21,7 +22,9 @@ executable agda-bisect
     , ansi-wl-pprint       >= 0.6.7.3 && < 0.7
     , directory            >= 1.2.6.2 && < 1.4
     , filepath             >= 1.4.1.0 && < 1.5
-    , optparse-applicative >= 0.13    && < 0.17
+    , extra                >= 0.3
+        -- `trim` exists so since extra-0.3
+    , optparse-applicative >= 0.13    && < 0.18
     , process              >= 1.4.2.0 && < 1.7
     , time                 >= 1.6.0.1 && < 1.13
     , unix                 >= 2.7.2.0 && < 2.8

--- a/src/agda-bisect/agda-bisect.cabal
+++ b/src/agda-bisect/agda-bisect.cabal
@@ -13,12 +13,13 @@ tested-with:
   GHC == 8.8.4
   GHC == 8.10.7
   GHC == 9.0.2
-  GHC == 9.2.1
+  GHC == 9.2.5
+  GHC == 9.4.4
 
 executable agda-bisect
   main-is:          Bisect.hs
   build-depends:
-      base                 >= 4.9.0.0 && < 4.17
+      base                 >= 4.9.0.0 && < 5
     , ansi-wl-pprint       >= 0.6.7.3 && < 0.7
     , directory            >= 1.2.6.2 && < 1.4
     , filepath             >= 1.4.1.0 && < 1.5


### PR DESCRIPTION
Fix #5269: use v2-cabal in agda-bisect.

Problems:
- call agda so that it finds its data dir