### PR TITLE
Support GHC 9.2.2

### DIFF
--- a/.github/workflows/cabal-test.yml
+++ b/.github/workflows/cabal-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         ghc-ver:
-        - 9.2.1
+        - 9.2.2
         cabal-ver:
         - latest
         os:

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -14,13 +14,25 @@ jobs:
       FLAGS: -f enable-cluster-counting
     strategy:
       matrix:
+        include:
+        - ghc-ver: 9.2.2
+          cabal-ver: latest
+          os: macos-latest
+        - ghc-ver: 9.2.1
+          cabal-ver: latest
+          os: windows-latest
         ghc-ver:
-        - 9.2.1
+        - 9.2.2
+        - 9.0.2
+        - 8.10.7
+        - 8.8.4
+        - 8.6.5
+        - 8.4.4
+        - 8.2.2
+        - 8.0.2
         cabal-ver:
         - latest
         os:
-        - windows-latest
-        - macos-latest
         - ubuntu-20.04
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -42,10 +54,6 @@ jobs:
         echo "GHC_VER=${GHC_VER}"       >> ${GITHUB_ENV}
         echo "CABAL_VER=${CABAL_VER}"   >> ${GITHUB_ENV}
       name: Environment settings based on the Haskell setup
-    - run: |
-        cabal update
-        cabal configure ${FLAGS} -O0
-      name: Configure the build plan
     - if: ${{ runner.os == 'Windows' }}
       shell: pwsh
       run: |
@@ -59,6 +67,10 @@ jobs:
       run: |
         echo "PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
       name: Set up pkg-config for the ICU library (macOS)
+    - run: |
+        cabal update
+        cabal configure ${FLAGS} -O0
+      name: Configure the build plan
     - with:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         ghc-ver:
-        - 9.2.1
+        - 9.2.2
         cabal-ver:
         - latest
         os:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -30,7 +30,13 @@ jobs:
       matrix:
         include:
         - stack-ver: latest
-          ghc-ver: 9.2.1
+          ghc-ver: 9.2.2
+          os: ubuntu-20.04
+        - stack-ver: latest
+          ghc-ver: 9.0.2
+          os: ubuntu-20.04
+        - stack-ver: latest
+          ghc-ver: 9.2.2
           os: macos-latest
         - stack-ver: latest
           ghc-ver: 9.0.1
@@ -38,8 +44,6 @@ jobs:
         stack-ver:
         - latest
         ghc-ver:
-        - 9.2.1
-        - 9.0.2
         - 8.10.7
         - 8.8.4
         - 8.6.5
@@ -96,6 +100,11 @@ jobs:
       uses: actions/cache@v2
       name: Cache dependencies
       id: cache
+    - if: ${{ runner.os == 'macOS' }}
+      shell: bash
+      run: |
+        echo "PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
+      name: Set up pkg-config for the ICU library (macOS)
     - if: ${{ runner.os == 'Linux' }}
       run: |
         sudo apt-get update -qq

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,9 +154,9 @@ jobs:
         stack-ver:
         - latest
         ghc-ver:
-        - 9.0.2
+        - 9.2.2
         os:
-        - ubuntu-18.04
+        - ubuntu-20.04
     runs-on: ${{ matrix.os }}
     steps:
     - with:

--- a/.github/workflows/user_manual.yml
+++ b/.github/workflows/user_manual.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version:
         - 3.7
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - with:
         submodules: recursive

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         ghc-ver:
-        - 9.2.1
+        - 9.2.2
         cabal-ver:
         - latest
         fix-whitespace-ver:
         - 0.0.7
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       name: Checkout agda sources

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -43,6 +43,7 @@ tested-with:        GHC == 8.0.2
                     GHC == 9.0.1
                     GHC == 9.0.2
                     GHC == 9.2.1
+                    GHC == 9.2.2
 
 extra-source-files: CHANGELOG.md
                     README.md
@@ -92,6 +93,7 @@ extra-source-files: CHANGELOG.md
                     stack-9.0.1.yaml
                     stack-9.0.2.yaml
                     stack-9.2.1.yaml
+                    stack-9.2.2.yaml
 
 data-dir:           src/data
 data-files:         emacs-mode/*.el

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -38,7 +38,7 @@ You need recent versions of the following programs to compile Agda:
 * GHC:           https://www.haskell.org/ghc/
 
   + Agda has been tested with GHC 8.0.2, 8.2.2, 8.4.4, 8.6.5, 8.8.4,
-    8.10.7, 9.0.1 and 9.2.1.
+    8.10.7, 9.0.2 and 9.2.2.
 
 * cabal-install: https://www.haskell.org/cabal/
 * Alex:          https://www.haskell.org/alex/

--- a/mk/ghc.mk
+++ b/mk/ghc.mk
@@ -3,7 +3,7 @@ include $(TOP)/mk/stack.mk
 
 ifeq ($(GHC),)
   ifdef HAS_STACK
-    GHC := stack ghc --
+    GHC := $(STACK) ghc --
   else
     GHC := $(shell which ghc)
   endif
@@ -11,7 +11,7 @@ endif
 
 ifeq ($(RUNGHC),)
   ifdef HAS_STACK
-    RUNGHC := stack runghc --
+    RUNGHC := $(STACK) runghc --
   else
     RUNGHC := $(shell which runghc)
   endif
@@ -26,9 +26,9 @@ ifneq ($(GHC),)
 
   # major.minor.subminor, e.g. 8.10.2
   ifdef HAS_STACK
-    GHC_VER := $(shell stack query | sed -n 's/.*actual: ghc-\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')
+    GHC_VER := $(shell $(STACK) query | sed -n 's/.*actual: ghc-\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')
     # The following variant needs GNU awk (not POSIX compatible) [issue #5480]:
-    # GHC_VER := $(shell stack query | awk 'match ($$0, /actual: ghc-([0-9]+\.[0-9]+\.[0-9]+)/, ver) { print (ver[1]); }')
+    # GHC_VER := $(shell $(STACK) query | awk 'match ($$0, /actual: ghc-([0-9]+\.[0-9]+\.[0-9]+)/, ver) { print (ver[1]); }')
   else
     GHC_VER := $(shell $(GHC) --numeric-version | cut -d. -f1-3)
   endif

--- a/mk/stack.mk
+++ b/mk/stack.mk
@@ -1,4 +1,7 @@
-STACK=stack
+# Andreas, 2022-03-10: suppress chatty announcements like
+# "Stack has not been tested with GHC versions above 9.0, and using 9.2.2, this may fail".
+# These might get in the way of interaction testing.
+STACK=stack --silent
 
 ifneq ($(wildcard $(TOP)/stack.yaml),)
   HAS_STACK := 1

--- a/src/github/workflows/cabal-test.yml
+++ b/src/github/workflows/cabal-test.yml
@@ -49,7 +49,7 @@ jobs:
           ## There is e.g. https://github.com/phile314/tasty-silver/issues/16
           ## that may be responsible that diffs are not shown,
           ## and that prevents me from running the test-suite interactively.
-        ghc-ver: [9.2.1]
+        ghc-ver: [9.2.2]
         cabal-ver: [latest]
 
     steps:

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -42,9 +42,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-20.04]
-        ghc-ver: [9.2.1]
+        os: [ubuntu-20.04]
+        ghc-ver: [9.2.2, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
         cabal-ver: [latest]
+        include:
+          - os: macos-latest
+            ghc-ver: 9.2.2
+            cabal-ver: latest
+          # Andreas, 2022-03-10, chocolatey does not have GHC 9.2.2 yet
+          - os: windows-latest
+            ghc-ver: 9.2.1
+            cabal-ver: latest
     env:
       FLAGS: "-f enable-cluster-counting"
       # ICU_URL: 'https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-Win64-MSVC2019.zip'
@@ -69,11 +77,6 @@ jobs:
         echo "GHC_VER=${GHC_VER}"       >> ${GITHUB_ENV}
         echo "CABAL_VER=${CABAL_VER}"   >> ${GITHUB_ENV}
       # From now on, use env.{GHC|CABAL}_VER rather than matrix.{ghc|cabal}-ver!
-
-    - name: Configure the build plan
-      run: |
-        cabal update
-        cabal configure ${FLAGS} -O0
 
     # from: https://github.com/haskell/text-icu/blob/c73d7fe6f29e178d3ea40160e904ab39236e3c9d/.github/workflows/cabal-mac-win.yml#L29-L32
     - name: Setup MSYS path (Windows)
@@ -114,6 +117,11 @@ jobs:
     #     mv ${ICU_DIR}/*.h ${ICU_DIR}/include/unicode
 
     #     cabal user-config update --augment="extra-lib-dirs: $(cygpath -w ${ICU_DIR})" --augment="extra-include-dirs: $(cygpath -w ${ICU_DIR}/include)"
+
+    - name: Configure the build plan
+      run: |
+        cabal update
+        cabal configure ${FLAGS} -O0
 
     - uses: actions/cache@v2
       name: Cache dependencies

--- a/src/github/workflows/haddock.yml
+++ b/src/github/workflows/haddock.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ghc-ver: ['9.2.1']
+        ghc-ver: ['9.2.2']
         cabal-ver: [latest]
 
     if: |

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -43,13 +43,32 @@ jobs:
       matrix:
         os: [ubuntu-18.04]
         stack-ver: [latest]
-        ghc-ver: [9.2.1, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        ghc-ver: [8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+          # Andreas, 2022-03-10: the LTS for GHC 8.10 has text-icu-0.7.1.0
+          # (sarting with LTS 17.14).  Our stack-8.y.z.yaml files
+          # declare extra-dep text-icu-0.7.1.0 (rather than using 0.7.0.1 from LTS).
+          # text-icu-0.7 works on ubuntu-18 but not on ubuntu-20, as the latter
+          # has a too new ICU library (requires text-icu-0.8).
+          # We could update the vm to ubuntu-20.04, but then we would have
+          # to put text-icu-0.8.0.1 as extra-dep into the stack.yaml files.
+          # This might draw more extra-deps after it, so let's not do it
+          # while we can still run ubuntu-18.
+          # (This also means that we test both text-icu-0.7 and -0.8).
         include:
+          - os: ubuntu-20.04
+            ghc-ver: 9.2.2
+            stack-ver: latest
+          - os: ubuntu-20.04
+            ghc-ver: 9.0.2
+            stack-ver: latest
           - os: macos-latest
-            ghc-ver: 9.2.1
+            ghc-ver: 9.2.2
             stack-ver: latest
           - os: windows-latest
             ghc-ver: 9.0.1
+              # Andreas, 2022-03-10: chocolatey does not have GHC 9.2.2 yet.
+              # (This makes haskell/actions/setup crash.)
+              # But also, stack/windows is still not ready for GHC 9.2.
               # Andreas, 2022-02-07: stack-9.0.1.yaml has text-icu-0.8.0 just for the Windows CI.
               # If you update the ghc-ver here, make sure that text-icu is new enough to work
               # with the latest mingw-w64-x86_64-icu.
@@ -58,9 +77,9 @@ jobs:
     # pause stack/Win/9.2 workflow until stack is ready for 9.2
     #       - os: windows-latest
     #         # TODO (Andreas, 2021-11-14)
-    #         # Upgrade to 9.2.1 once stack works fine with GHC 9.2 and Cabal 3.6 under Windows
+    #         # Upgrade to 9.2.2 once stack works fine with GHC 9.2 and Cabal 3.6 under Windows
     #         # Also, unix-compat is a bit behind: https://github.com/jacobstanley/unix-compat/pull/47
-    #         ghc-ver: 9.2.1
+    #         ghc-ver: 9.2.2
     #         stack-ver: latest
     # # Try "allowed-failure" for Windows with GHC 9.2
     # continue-on-error: ${{ startsWith(matrix.os, 'windows') && startsWith(matrix.ghc-ver,'9.2') }}
@@ -141,6 +160,12 @@ jobs:
         # Note that matrix.stack-ver might be simply 'latest', so we use STACK_VER.
         key: |
           ${{ runner.os }}-stack-01-${{ env.STACK_VER }}-${{ hashFiles(format('stack-{0}.yaml.lock', env.GHC_VER)) }}
+
+    - name: Set up pkg-config for the ICU library (macOS)
+      if: ${{ runner.os == 'macOS' }}
+      shell: bash
+      run: |
+        echo "PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
 
     - name: Install the icu library (Ubuntu)
       if: ${{ runner.os == 'Linux' }}

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -62,11 +62,11 @@ jobs:
     strategy:
       matrix:
         # TODO (Andreas, 2021-11-13)
-        # Upgrade to 9.2.1 once this does not cause problems with shelltestrunner
+        # Upgrade to 9.2.2 once this does not cause problems with shelltestrunner
         # https://github.com/agda/agda/pull/5648#issuecomment-968100273
-        ghc-ver: [9.0.2]
+        ghc-ver: [9.2.2]
         stack-ver: [latest]
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
 
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
@@ -324,4 +324,3 @@ jobs:
     # this job.
     - name: "Cubical library test"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
-

--- a/src/github/workflows/user_manual.yml
+++ b/src/github/workflows/user_manual.yml
@@ -20,7 +20,7 @@ jobs:
       && !contains(github.event.head_commit.message, '[github skip]')
       && !contains(github.event.head_commit.message, '[skip github]')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7]

--- a/src/github/workflows/whitespace.yml
+++ b/src/github/workflows/whitespace.yml
@@ -15,11 +15,11 @@ jobs:
       && !contains(github.event.head_commit.message, '[github skip]')
       && !contains(github.event.head_commit.message, '[skip github]')
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        ghc-ver: [9.2.1]
+        ghc-ver: [9.2.2]
         cabal-ver: [latest]
         # stack-ver: [2.5.1]
         fix-whitespace-ver: [0.0.7]

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,21 +1,21 @@
-resolver: nightly-2022-01-19
+resolver: nightly-2022-03-10
 compiler: ghc-9.0.2
 compiler-check: match-exact
 
-extra-deps:
-# Andreas, 2021-11-13
-# happy-1.21.0 is deprecated, but currently in nightly
-# (commercialhaskell/stackage#6294)
-- happy-1.20.0
+# extra-deps:
+# # Andreas, 2021-11-13
+# # happy-1.21.0 is deprecated, but currently in nightly
+# # (commercialhaskell/stackage#6294)
+# - happy-1.20.0
 
 flags:
   transformers-compat:
     five-three: true
-  # Andreas, 2021-11-14
-  # Work around problem in nightly-2021-11-12
-  # (commercialhaskell/stackage#6304 and RyanGlScott/mintty#4):
-  mintty:
-    Win32-2-13-1: false
+  # # Andreas, 2021-11-14
+  # # Work around problem in nightly-2021-11-12
+  # # (commercialhaskell/stackage#6304 and RyanGlScott/mintty#4):
+  # mintty:
+  #   Win32-2-13-1: false
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack-9.2.2.yaml
+++ b/stack-9.2.2.yaml
@@ -1,5 +1,5 @@
-resolver: ghc-9.2.1
-compiler: ghc-9.2.1
+resolver: ghc-9.2.2
+compiler: ghc-9.2.2
 compiler-check: match-exact
 
 extra-deps:
@@ -10,7 +10,7 @@ extra-deps:
 - QuickCheck-2.14.2
 - StateVar-1.2.2
 - STMonadTrans-0.4.6
-- aeson-2.0.2.0
+- aeson-2.0.3.0
 - alex-3.2.6
 - ansi-terminal-0.11
 - ansi-wl-pprint-0.6.9
@@ -72,7 +72,7 @@ extra-deps:
 - random-1.2.1
 - regex-base-0.94.0.1
 - regex-posix-0.96.0.1
-- regex-tdfa-1.3.1.1
+- regex-tdfa-1.3.1.2
 - safe-0.3.19
 - scientific-0.3.7.0
 - semialign-1.2.0.1
@@ -90,7 +90,7 @@ extra-deps:
 - test-framework-0.8.2.0
 - test-framework-hunit-0.3.0.2
 - text-icu-0.8.0.1
-- text-short-0.1.4
+- text-short-0.1.5
 - th-abstraction-0.4.3.0
 - th-compat-0.1.3
 - these-1.1.1.1


### PR DESCRIPTION
Bump CI to GHC 9.2.2 and ubuntu-20.04 where possible.

Upstream problems with `text-icu`:
- [x] https://github.com/haskell/text-icu/issues/71
- [x] https://github.com/haskell/text-icu/issues/72

After CI is successful:
- [x] Look for outdated comments in .yml files.
- [x] Squash this PR before merging, but with meaningful commit message compiled from the commits.