### PR TITLE
Fix #5823: when checking isSingletonRecord, remember encountered record types

### DIFF
--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -106,3 +106,11 @@ instance GetDefs a => GetDefs (Abs a)   where
 
 instance (GetDefs a, GetDefs b) => GetDefs (a,b) where
   getDefs (a,b) = getDefs a >> getDefs b
+
+instance GetDefs Telescope where
+  getDefs = getDefs . telToList
+
+-- no defs here
+
+instance {-# OVERLAPPING #-} GetDefs String where
+  getDefs _ = return ()

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -152,7 +152,7 @@ instance NamesIn Defn where
       -> namesAndMetasIn' sg (cl, cc, el)
     Datatype _ _ cl cs s _ _ _ trX trD
       -> namesAndMetasIn' sg (cl, cs, s, trX, trD)
-    Record _ cl c _ fs recTel _ _ _ _ _ comp
+    Record _ cl c _ fs recTel _ _ _ _ _ _ comp
       -> namesAndMetasIn' sg (cl, c, fs, recTel, comp)
     Constructor _ _ c d _ _ kit fs _ _
       -> namesAndMetasIn' sg (c, d, kit, fs)

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -65,7 +65,14 @@ type MutualNames = [QName]
 
 -- | The target of the function we are checking.
 
-type Target = QName
+data Target
+  = TargetDef QName
+      -- ^ The target of recursion is a @record@, @data@, or unreducible @Def@.
+  | TargetRecord
+      -- ^ We are termination-checking a record.
+  | TargetOther
+      -- ^ None of the above two or unknown.
+  deriving (Eq, Show)
 
 -- | The current guardedness level.
 
@@ -100,7 +107,7 @@ data TerEnv = TerEnv
   , terHaveInlinedWith :: Bool
     -- ^ Does the actual clause result from with-inlining?
     --   (If yes, it may be ill-typed.)
-  , terTarget  :: Maybe Target
+  , terTarget  :: Target
     -- ^ Target type of the function we are currently termination checking.
     --   Only the constructors of 'Target' are considered guarding.
   , terDelayed :: Delayed
@@ -153,7 +160,7 @@ defaultTerEnv = TerEnv
   , terMutual                   = __IMPOSSIBLE__ -- needs to be set!
   , terCurrent                  = __IMPOSSIBLE__ -- needs to be set!
   , terHaveInlinedWith          = False
-  , terTarget                   = Nothing
+  , terTarget                   = TargetOther
   , terDelayed                  = NotDelayed
   , terMaskArgs                 = repeat False   -- use all arguments (mask none)
   , terMaskResult               = False          -- use result (do not mask)
@@ -282,10 +289,10 @@ terGetMutual = terAsks terMutual
 terGetUserNames :: TerM [QName]
 terGetUserNames = terAsks terUserNames
 
-terGetTarget :: TerM (Maybe Target)
+terGetTarget :: TerM Target
 terGetTarget = terAsks terTarget
 
-terSetTarget :: Maybe Target -> TerM a -> TerM a
+terSetTarget :: Target -> TerM a -> TerM a
 terSetTarget t = terLocal $ \ e -> e { terTarget = t }
 
 terGetHaveInlinedWith :: TerM Bool

--- a/src/full/Agda/Termination/RecCheck.hs
+++ b/src/full/Agda/Termination/RecCheck.hs
@@ -89,10 +89,8 @@ markNonRecursive q = modifySignature $ updateDefinition q $ updateTheDef $ \case
    { funTerminates = Just True
    , funClauses    = map (\ cl -> cl { clauseRecursive = Just False }) $ funClauses def
    }
-  def@Record{ recMutual = mut } -> def
+  def@Record{} -> def
    { recTerminates = Just True
-   , recMutual     = if maybe True null mut then Just [] else __IMPOSSIBLE__
-       -- Andreas, 2022-03-12: Crash if some other agent (positivity checker) came to another result.
    }
   def -> def
 

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -207,22 +207,14 @@ termMutual names0 = ifNotM (optTerminationCheck <$> pragmaOptions) (return mempt
              " with cutoff=" ++ show cutoff ++ "..."
            terLocal setNames cont
 
-     -- New check currently only makes a difference for copatterns.
+     -- New check currently only makes a difference for copatterns and record types.
      -- Since it is slow, only invoke it if
-     -- any of the definitions uses copatterns.
-     res <- ifM (pure True) -- TODO (orM $ map usesCopatterns allNames)
+     -- any of the definitions uses copatterns or is a record type.
+     ifM (anyM allNames $ \ q -> usesCopatterns q `or2M` (isJust <$> isRecord q))
          -- Then: New check, one after another.
          (runTerm $ forM' allNames $ termFunction)
          -- Else: Old check, all at once.
          (runTerm $ termMutual')
-
-     -- Record result of termination check in signature.
-     -- If there are some termination errors, we collect them in
-     -- the state and mark the definition as non-terminating so
-     -- that it does not get unfolded
-     let terminates = null res
-     forM_ allNames $ \ q -> setTerminates q terminates
-     return res
 
 -- | @termMutual'@ checks all names of the current mutual block,
 --   henceforth called @allNames@, for termination.
@@ -268,10 +260,15 @@ termMutual' = do
   -- the names the user has declared.  This is for error reporting.
   names <- terGetUserNames
   case r of
-    Left calls -> return $ singleton $ terminationError names $ callInfos calls
+
+    Left calls -> do
+      mapM_ (`setTerminates` False) allNames
+      return $ singleton $ terminationError names $ callInfos calls
+
     Right{} -> do
       liftTCM $ reportSLn "term.warn.yes" 2 $
         prettyShow (names) ++ " does termination check"
+      mapM_ (`setTerminates` True) allNames
       return mempty
 
 -- | Smart constructor for 'TerminationError'.
@@ -346,7 +343,7 @@ reportCalls no calls = do
 -- If it passes the termination check it is marked as "terminates" in the signature.
 
 termFunction :: QName -> TerM Result
-termFunction name = do
+termFunction name = inConcreteOrAbstractMode name $ \ def -> do
 
   -- Function @name@ is henceforth referred to by its @index@
   -- in the list of @allNames@ of the mutual block.
@@ -357,7 +354,13 @@ termFunction name = do
   -- Retrieve the target type of the function to check.
   -- #4256: Don't use typeOfConst (which instantiates type with module params), since termination
   -- checking is running in the empty context, but with the current module unchanged.
-  target <- liftTCM $ do typeEndsInDef . defType =<< getConstInfo name
+  target <- case theDef def of
+    -- We are termination-checking a record (calls to record will not be guarding):
+    Record{} -> return TargetRecord
+    -- We are termination-checking a definition:
+    _ -> typeEndsInDef (defType def) <&> \case
+           Just d  -> TargetDef d
+           Nothing -> TargetOther
   reportTarget target
   terSetTarget target $ do
 
@@ -386,21 +389,36 @@ termFunction name = do
      cutoff <- terGetCutOff
      let ?cutoff = cutoff
      r <- billToTerGraph $ Term.terminatesFilter (== index) calls1
-     case r of
+
+     -- Andrea: 22/04/2020.
+     -- With cubical we will always have a clause where the dot
+     -- patterns are instead replaced with a variable, so they
+     -- cannot be relied on for termination.
+     -- See issue #4606 for a counterexample involving HITs.
+     --
+     -- Without the presence of HITs I conjecture that dot patterns
+     -- could be turned into actual splits, because no-confusion
+     -- would make the other cases impossible, so I do not disable
+     -- this for --without-K entirely.
+     --
+     -- Andreas, 2022-03-21: The check for --cubical was missing here.
+     ifM (isJust . optCubical <$> pragmaOptions) (return r) {- else -} $ case r of
        Right () -> return $ Right ()
-       Left{}    -> do
+       Left{}   -> do
          -- Try again, but include the dot patterns this time.
          calls2 <- terSetUseDotPatterns True $ collect
          reportCalls "" calls2
-         billToTerGraph $ mapLeft callInfos $ Term.terminatesFilter (== index) calls2
+         billToTerGraph $ Term.terminatesFilter (== index) calls2
 
     names <- terGetUserNames
-    case r of
+    case mapLeft callInfos r of
 
       Left calls -> do
-        let err = terminationError [name | name `elem` names] calls
+        -- Mark as non-terminating.
+        setTerminates name False
+
         -- Functions must be terminating, records types need not...
-        getConstInfo name <&> theDef >>= \case
+        case theDef def of
 
           -- Records need not terminate, so we just put the error on the debug log.
           Record{} -> do
@@ -410,20 +428,22 @@ termFunction name = do
             mempty
 
           -- Functions must terminate, so we report the error.
-          Function{} -> return $ singleton err
-
-          _ -> __IMPOSSIBLE__
+          _ -> do
+            let err = TerminationError [name | name `elem` names] calls
+            return $ singleton err
 
       Right () -> do
         reportSLn "term.warn.yes" 2 $
           prettyShow name ++ " does termination check"
-        liftTCM $ setTerminates name True
+        setTerminates name True
         return mempty
    where
-     reportTarget r = liftTCM $
-       reportSLn "term.target" 20 $ "  target type " ++
-         caseMaybe r "not recognized" (\ q ->
-           "ends in " ++ prettyShow q)
+     reportTarget :: MonadDebug m => Target -> m ()
+     reportTarget tgt = reportSLn "term.target" 20 $ ("  " ++) $
+       case tgt of
+         TargetRecord -> "termination checking a record type"
+         TargetDef q  -> unwords [ "target type ends in", prettyShow q ]
+         TargetOther  -> "target type not recognized"
 
 -- | To process the target type.
 typeEndsInDef :: MonadTCM tcm => Type -> tcm (Maybe QName)
@@ -445,6 +465,13 @@ typeEndsInDef t = liftTCM $ do
 --   consider dot patterns or not.
 termDef :: QName -> TerM Calls
 termDef name = terSetCurrent name $ inConcreteOrAbstractMode name $ \ def -> do
+
+ -- Skip calls to record types unless we are checking a record type in the first place.
+ let isRecord_ = case theDef def of { Record{} -> True; _ -> False }
+ let notTargetRecord = terGetTarget <&> \case
+       TargetRecord -> False
+       _ -> True
+ ifM (pure isRecord_ `and2M` notTargetRecord) mempty {-else-} $ do
 
   -- Retrieve definition
   let t = defType def
@@ -557,24 +584,12 @@ setMasks t cont = do
 
 -- | Is the current target type among the given ones?
 
-targetElem :: [Target] -> TerM Bool
-targetElem ds = maybe False (`elem` ds) <$> terGetTarget
+targetElem :: [QName] -> TerM Bool
+targetElem ds = terGetTarget <&> \case
+  TargetDef d  -> d `elem` ds
+  TargetRecord -> False
+  TargetOther  -> False
 
-{-
--- | The target type of the considered recursive definition.
-data Target
-  = Set        -- ^ Constructing a Set (only meaningful with 'guardingTypeConstructors').
-  | Data QName -- ^ Constructing a coinductive or mixed type (could be data or record).
-  deriving (Eq, Show)
-
--- | Check wether a 'Target" corresponds to the current one.
-matchingTarget :: DBPConf -> Target -> TCM Bool
-matchingTarget conf t = maybe (return True) (match t) (currentTarget conf)
-  where
-    match Set      Set       = return True
-    match (Data d) (Data d') = mutuallyRecursive d d'
-    match _ _                = return False
--}
 
 -- | Convert a term (from a dot pattern) to a DeBruijn pattern.
 --
@@ -800,8 +815,11 @@ function g es0 = do
        -- call leads outside the mutual block and can be ignored
        Nothing   -> return calls
 
-       -- call is to one of the mutally recursive functions
+       -- call is to one of the mutally recursive functions/record
        Just gInd -> do
+         cutoff <- terGetCutOff
+         let ?cutoff = cutoff
+
          delayed <- terGetDelayed
          -- Andreas, 2017-02-14, issue #2458:
          -- If we have inlined with-functions, we could be illtyped,
@@ -837,15 +855,30 @@ function g es0 = do
          -- spent on call matrix generation
          (nrows, ncols, matrix) <- billTo [Benchmark.Termination, Benchmark.Compare] $
            compareArgs es
-         -- only a delayed definition can be guarded
-         let ifDelayed o | Order.decreasing o && delayed == NotDelayed = Order.le
-                         | otherwise                                  = o
+
+         -- Andreas, 2022-03-21, #5823:
+         -- If we are "calling" a record type we are guarded unless the origin
+         -- of the termination analysis is itself a record.
+         -- This is because we usually do not "unfold" record types into their
+         -- field telescope.  We only do so when trying to construct the
+         -- unique inhabitant of record type (singleton analysis).
+         -- In the latter case, a call to a record type is not guarding.
+         guarded' <- isRecord g >>= \case
+           Just{} -> terGetTarget >>= \case
+             TargetRecord
+               -> return guarded
+             _ -> return (guarded .*. Order.lt)
+                    -- guarding when we call a record and not termination checking a record
+           Nothing
+             -- only a delayed definition can be guarded
+             | Order.decreasing guarded && delayed == NotDelayed
+               -> return Order.le
+             | otherwise
+               -> return guarded
          liftTCM $ reportSLn "term.guardedness" 20 $
            "composing with guardedness " ++ prettyShow guarded ++
-           " counting as " ++ prettyShow (ifDelayed guarded)
-         cutoff <- terGetCutOff
-         let ?cutoff = cutoff
-         let matrix' = composeGuardedness (ifDelayed guarded) matrix
+           " counting as " ++ prettyShow guarded'
+         let matrix' = composeGuardedness guarded' matrix
 
          -- Andreas, 2013-04-26 FORBIDDINGLY expensive!
          -- This PrettyTCM QName cost 50% of the termination time for std-lib!!
@@ -948,12 +981,11 @@ getNonRecursiveClauses q =
 
 instance ExtractCalls Term where
   extract t = do
-    liftTCM $ reportSDoc "term.check.term" 50 $ do
+    reportSDoc "term.check.term" 50 $ do
       "looking for calls in" <+> prettyTCM t
 
     -- Instantiate top-level MetaVar.
-    t <- liftTCM $ instantiate t
-    case t of
+    instantiate t >>= \case
 
       -- Constructed value.
       Con ConHead{conName = c, conDataRecord = dataOrRec} _ es -> do
@@ -964,13 +996,19 @@ instance ExtractCalls Term where
         -- If we encounter a coinductive record constructor
         -- in a type mutual with the current target
         -- then we count it as guarding.
-        let inductive   = return Inductive
-            coinductive = return CoInductive
+        let inductive   = return Inductive    -- not guarding, but preserving
+            coinductive = return CoInductive  -- guarding
+        -- ♯ is guarding
         ind <- ifM ((Just c ==) <$> terGetSharp) coinductive $ {-else-} do
+          -- data constructors are not guarding
           if dataOrRec == IsData then inductive else do
-          caseMaybeM (liftTCM $ isRecordConstructor c) inductive $ \ (q, def) -> do
+          -- abstract constructors are not guarding
+          caseMaybeM (isRecordConstructor c) inductive $ \ (q, def) -> do
             reportSLn "term.check.term" 50 $ "constructor " ++ prettyShow c ++ " has record type " ++ prettyShow q
+            -- inductive record constructors are not guarding
             if recInduction def /= Just CoInductive then inductive else do
+            -- coinductive constructors unrelated to the mutually
+            -- constructed inhabitants of coinductive types are not guarding
             ifM (targetElem . fromMaybe __IMPOSSIBLE__ $ recMutual def)
                {-then-} coinductive
                {-else-} inductive
@@ -985,17 +1023,16 @@ instance ExtractCalls Term where
       -- Neutral term. Destroys guardedness.
       Var i es -> terUnguarded $ extract es
 
-      -- Dependent function space. Destroys guardedness.
+      -- Dependent function space.
       Pi a (Abs x b) ->
-        terUnguarded $
         CallGraph.union <$>
         extract a <*> do
           a <- maskSizeLt a  -- OR: just do not add a to the context!
           addContext (x, a) $ terRaise $ extract b
 
-      -- Non-dependent function space. Destroys guardedness.
+      -- Non-dependent function space.
       Pi a (NoAbs _ b) ->
-        terUnguarded $ CallGraph.union <$> extract a <*> extract b
+        CallGraph.union <$> extract a <*> extract b
 
       -- Literal.
       Lit l -> return empty
@@ -1074,7 +1111,7 @@ compareArgs es = do
   let guardedness =
         if useGuardedness
         then decr True $ projsCaller - projsCallee
-        else Order.Unknown
+        else Order.le
   liftTCM $ reportSDoc "term.guardedness" 30 $ sep
     [ "compareArgs:"
     , nest 2 $ text $ "projsCaller = " ++ prettyShow projsCaller

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -830,6 +830,7 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
            , recEtaEquality' = Inferred YesEta
            , recPatternMatching = CopatternMatching
            , recInduction    = Nothing
+           , recTerminates   = Just True    -- not recursive
            , recAbstr        = ConcreteDef
            , recComp         = emptyCompKit
            }

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2222,6 +2222,10 @@ data Defn = Axiom -- ^ Postulate
               -- ^ 'Inductive' or 'CoInductive'?  Matters only for recursive records.
               --   'Nothing' means that the user did not specify it, which is an error
               --   for recursive records.
+            , recTerminates     :: Maybe Bool
+              -- ^ 'Just True' means that unfolding of the recursive record terminates,
+              --   'Just False' means that we have no evidence for termination,
+              --   and 'Nothing' means we have not run the termination checker yet.
             , recAbstr          :: IsAbstract
             , recComp           :: CompKit
             }
@@ -4730,8 +4734,8 @@ instance KillRange Defn where
       AbstractDefn{} -> __IMPOSSIBLE__ -- only returned by 'getConstInfo'!
       Function cls comp ct tt covering inv mut isAbs delayed proj flags term extlam with ->
         killRange14 Function cls comp ct tt covering inv mut isAbs delayed proj flags term extlam with
-      Datatype a b c d e f g h i j   -> killRange8 Datatype a b c d e f g h i j
-      Record a b c d e f g h i j k l -> killRange12 Record a b c d e f g h i j k l
+      Datatype a b c d e f g h i j   -> killRange10 Datatype a b c d e f g h i j
+      Record a b c d e f g h i j k l m -> killRange13 Record a b c d e f g h i j k l m
       Constructor a b c d e f g h i j-> killRange10 Constructor a b c d e f g h i j
       Primitive a b c d e            -> killRange5 Primitive a b c d e
       PrimitiveSort a b              -> killRange2 PrimitiveSort a b

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -109,7 +109,7 @@ addConstant' q info x t def = do
   addConstant q $ defaultDefn info x t lang def
 
 -- | Set termination info of a defined function symbol.
-setTerminates :: QName -> Bool -> TCM ()
+setTerminates :: MonadTCState m => QName -> Bool -> m ()
 setTerminates q b = modifySignature $ updateDefinition q $ updateTheDef $ \case
     def@Function{} -> def { funTerminates = Just b }
     def@Record{}   -> def { recTerminates = Just b }

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -112,6 +112,7 @@ addConstant' q info x t def = do
 setTerminates :: QName -> Bool -> TCM ()
 setTerminates q b = modifySignature $ updateDefinition q $ updateTheDef $ \case
     def@Function{} -> def { funTerminates = Just b }
+    def@Record{}   -> def { recTerminates = Just b }
     def -> def
 
 -- | Set CompiledClauses of a defined function symbol.

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -82,7 +82,7 @@ prettyWarning = \case
                concatMap termErrFunctions because)
         $$ fwords "Problematic calls:"
         $$ nest 2 (fmap (P.vcat . List.nub) $
-              mapM prettyTCM $ List.sortBy (compare `on` callInfoRange) $
+              mapM prettyTCM $ List.sortOn callInfoRange $
               concatMap termErrCalls because)
 
     UnreachableClauses f pss -> fsep $

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -790,8 +790,9 @@ isSingletonRecord' regardIrrelevance r ps rs = do
       -- We might not know yet whether a record type is recursive because the positivity checker hasn't run yet.
       -- In this case, we pessimistically consider the record type to be recursive (@True@).
       let recursive = maybe True (not . null) $ recMutual def
+      let nonTerminating = maybe True not $ recTerminates def
       fmap (mkCon (recConHead def) ConOSystem) <$> do
-        check (applyWhen recursive (Set.insert r) rs) $ recTel def `apply` ps
+        check (applyWhen (recursive && nonTerminating) (Set.insert r) rs) $ recTel def `apply` ps
   where
   -- Check that all entries of the constructor telescope are singletons.
   check :: Set QName -> Telescope -> m (Maybe [Arg Term])

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -82,6 +82,7 @@ bindBuiltinSharp x =
                   , recEtaEquality'   = Inferred $ NoEta CopatternMatching
                   , recPatternMatching= CopatternMatching
                   , recMutual         = Just []
+                  , recTerminates     = Just True  -- not recursive
                   , recAbstr          = ConcreteDef
                   , recComp           = emptyCompKit
                   }

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -235,6 +235,8 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
                   -- in case the record turns out to be recursive.
               -- Determined by positivity checker:
               , recMutual         = Nothing
+              -- Determined by the termination checker:
+              , recTerminates     = Nothing
               , recComp           = emptyCompKit -- filled in later
               }
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -80,7 +80,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20220217 * 10 + 0
+currentInterfaceVersion = 20220312 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -371,7 +371,7 @@ instance EmbPrj Defn where
   icod_ (Function    a b s t []    c d e f g h i j k)   =
     icodeN 1 (\ a b s -> Function a b s t []) a b s c d e f g h i j k
   icod_ (Datatype    a b c d e f g h i j)               = icodeN 2 Datatype a b c d e f g h i j
-  icod_ (Record      a b c d e f g h i j k l)           = icodeN 3 Record a b c d e f g h i j k l
+  icod_ (Record      a b c d e f g h i j k l m)         = icodeN 3 Record a b c d e f g h i j k l m
   icod_ (Constructor a b c d e f g h i j)               = icodeN 4 Constructor a b c d e f g h i j
   icod_ (Primitive   a b c d e)                         = icodeN 5 Primitive a b c d e
   icod_ (PrimitiveSort a b)                             = icodeN 6 PrimitiveSort a b
@@ -383,7 +383,7 @@ instance EmbPrj Defn where
     valu [0, a]                                     = valuN Axiom a
     valu [1, a, b, s, c, d, e, f, g, h, i, j, k]    = valuN (\ a b s -> Function a b s Nothing []) a b s c d e f g h i j k
     valu [2, a, b, c, d, e, f, g, h, i, j]          = valuN Datatype a b c d e f g h i j
-    valu [3, a, b, c, d, e, f, g, h, i, j, k, l]    = valuN Record  a b c d e f g h i j k l
+    valu [3, a, b, c, d, e, f, g, h, i, j, k, l, m] = valuN Record   a b c d e f g h i j k l m
     valu [4, a, b, c, d, e, f, g, h, i, j]          = valuN Constructor a b c d e f g h i j
     valu [5, a, b, c, d, e]                         = valuN Primitive   a b c d e
     valu [6, a, b]                                  = valuN PrimitiveSort a b

--- a/test/Fail/Issue5819.err
+++ b/test/Fail/Issue5819.err
@@ -3,6 +3,7 @@ Termination checking failed for the following functions:
   dl-iso, Fresh→Fresh′, Fresh→AllFresh
 Problematic calls:
   f dl-iso (dcons a₁ l x)
+  f⁻¹ dl-iso (dl″ l′ (proj₂ p))
   Fresh→Fresh′ eq p | l″ | sym eq
   f dl-iso (dcons a l x)
   Fresh→AllFresh eq p | l″ | sym eq

--- a/test/Fail/Issue5823.agda
+++ b/test/Fail/Issue5823.agda
@@ -1,0 +1,31 @@
+-- Andreas, 2022-03-10, issue #5823, reported by oisdk
+-- One could make the check for singleton record loop.
+-- This has never worked (not a regression).
+
+open import Agda.Primitive
+open import Agda.Builtin.Equality
+
+isProp : ∀{a} (A : Set a) → Set a
+isProp A = ∀ (x y : A) → x ≡ y
+
+cong : ∀{a b} {A : Set a} {B : Set b} (f : A → B) {x y : A} (eq : x ≡ y) → f x ≡ f y
+cong f refl = refl
+
+postulate
+  funExt : ∀{a b}{A : Set a} {B : (x : A) → Set b} {f g : (x : A) → B x} → (∀ (x : A) → f x ≡ g x) → f ≡ g
+
+record Acc {a} {A : Set a} {r} (R : A → A → Set r) (x : A) : Set (a ⊔ r) where
+  inductive; eta-equality
+  constructor acc
+  field step : ∀ y → R y x → Acc R y
+open Acc public
+-- Naively testing Acc R x for being a singleton will infinitely unfold its definition.
+-- We need to keep track of which record types we already unfolded!
+
+isPropAcc : ∀ {a r} {A : Set a} {R : A → A → Set r} {x : A} → isProp (Acc R x)
+isPropAcc (acc x) (acc y) = cong acc (funExt λ n → funExt λ p → isPropAcc (x n p) (y n p))
+
+-- Agda used to loop when trying determine whether Acc is a singleton type.
+-- Now it gives a termination error, as expected.
+
+-- -}

--- a/test/Fail/Issue5823.err
+++ b/test/Fail/Issue5823.err
@@ -1,0 +1,6 @@
+Issue5823.agda:25,1-26,91
+Termination checking failed for the following functions:
+  isPropAcc
+Problematic calls:
+  isPropAcc (x n p) (y n p)
+    (at Issue5823.agda:26,65-74)

--- a/test/Fail/SizedBTree.err
+++ b/test/Fail/SizedBTree.err
@@ -14,5 +14,7 @@ Termination checking failed for the following functions:
 Problematic calls:
   deep2 {i} {A} (node {i'} (node {i''} l r) x)
   | deep2 {↑ i''} {A} (deep2 {↑ i''} {A} (node {_} {_} {i''} l r))
+  deep2 {↑ i''} {A} (deep2 {↑ i''} {A} (node {_} {_} {i''} l r))
+    (at SizedBTree.agda:67,34-39)
   deep2 {↑ i'} {A} (node {_} {_} {i'} l2 r2)
     (at SizedBTree.agda:69,22-27)

--- a/test/Succeed/Issue5823.agda
+++ b/test/Succeed/Issue5823.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2022-03-11, issue #5823
+-- Make sure we do not weaken the singleton detection too much by checking for loops.
+
+record ⊤ : Set where
+
+record Wrap (A : Set) : Set where
+  field unwrap : A
+
+record _×_ (A B : Set) : Set where
+  field
+    fst : A
+    snd : B
+
+-- A singleton record type with nestings of Wrap.
+
+Singleton = (Wrap ⊤ × Wrap (Wrap ⊤)) × Wrap (Wrap (Wrap ⊤ × ⊤) × Wrap ⊤)
+
+-- Agda should solve this meta:
+
+unique : Singleton
+unique = _
+
+-- This is fine, even though we pass through 'Wrap' several times.
+-- Passing already visited non-recursive records is fine!


### PR DESCRIPTION
Fix #5823: when checking `isSingletonRecord`, remember encountered record types.
Otherwise we might get into infinite unfolding...