### PR TITLE
CI deploy/mac: bump ICU version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,7 @@ jobs:
     - env:
         ICU_DIR: /usr/local/opt/icu4c/lib
         DLL: /c/msys64/mingw64/bin/libicu*.dll
-        ICU_VER: '69'
+        ICU_VER: '70'
       run: |
         mkdir -p ${{ steps.vars.outputs.nightly }}/bin
         cp -a src/data ${{ steps.vars.outputs.nightly }}

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -149,7 +149,9 @@ jobs:
     - name: Move artefacts to ${{ steps.vars.outputs.nightly }}
       # TODO: Move this part to Makefile
       env:
-        ICU_VER: '69'
+        # Andreas, 2022-03-11, the ICU version has been updated upstream
+        # (WAS: '69').
+        ICU_VER: '70'
         ICU_DIR: '/usr/local/opt/icu4c/lib'
         DLL:     "/c/msys64/mingw64/bin/libicu*.dll"
           ## was /c/icu4c/icu*.dll


### PR DESCRIPTION
CI deploy/mac: ~~do not fix ICU version when copying libraries to artefact, hope that '*' works.~~
Didn't so we fix it to `70`.