### PR TITLE
Re #5822: only silence stack when running ghc through it

### DIFF
--- a/mk/ghc.mk
+++ b/mk/ghc.mk
@@ -3,7 +3,7 @@ include $(TOP)/mk/stack.mk
 
 ifeq ($(GHC),)
   ifdef HAS_STACK
-    GHC := $(STACK) ghc --
+    GHC := $(STACK_SILENT) ghc --
   else
     GHC := $(shell which ghc)
   endif
@@ -11,7 +11,7 @@ endif
 
 ifeq ($(RUNGHC),)
   ifdef HAS_STACK
-    RUNGHC := $(STACK) runghc --
+    RUNGHC := $(STACK_SILENT) runghc --
   else
     RUNGHC := $(shell which runghc)
   endif

--- a/mk/stack.mk
+++ b/mk/stack.mk
@@ -1,7 +1,9 @@
+STACK=stack
+
 # Andreas, 2022-03-10: suppress chatty announcements like
 # "Stack has not been tested with GHC versions above 9.0, and using 9.2.2, this may fail".
 # These might get in the way of interaction testing.
-STACK=stack --silent
+STACK_SILENT=$(STACK) --silent
 
 ifneq ($(wildcard $(TOP)/stack.yaml),)
   HAS_STACK := 1


### PR DESCRIPTION
`stack` puts alerts like
> Stack has not been tested with GHC versions above 9.0, and using 9.2.2, this may fail

onto `stderr` which get in the way with running GHC through `stack ghc` in `test/interaction`.
Thus, when running GHC, we use `stack --silent ghc`.