### PR TITLE
Fix #5823: checking for loops when constructing singleton inhabitant

### DIFF
--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -106,3 +106,11 @@ instance GetDefs a => GetDefs (Abs a)   where
 
 instance (GetDefs a, GetDefs b) => GetDefs (a,b) where
   getDefs (a,b) = getDefs a >> getDefs b
+
+instance GetDefs Telescope where
+  getDefs = getDefs . telToList
+
+-- no defs here
+
+instance {-# OVERLAPPING #-} GetDefs String where
+  getDefs _ = return ()

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -152,7 +152,7 @@ instance NamesIn Defn where
       -> namesAndMetasIn' sg (cl, cc, el)
     Datatype _ _ cl cs s _ _ _ trX trD
       -> namesAndMetasIn' sg (cl, cs, s, trX, trD)
-    Record _ cl c _ fs recTel _ _ _ _ _ comp
+    Record _ cl c _ fs recTel _ _ _ _ _ _ comp
       -> namesAndMetasIn' sg (cl, c, fs, recTel, comp)
     Constructor _ _ c d _ _ kit fs _ _
       -> namesAndMetasIn' sg (c, d, kit, fs)

--- a/src/full/Agda/Termination/RecCheck.hs
+++ b/src/full/Agda/Termination/RecCheck.hs
@@ -89,6 +89,9 @@ markNonRecursive q = modifySignature $ updateDefinition q $ updateTheDef $ \case
    { funTerminates = Just True
    , funClauses    = map (\ cl -> cl { clauseRecursive = Just False }) $ funClauses def
    }
+  def@Record{} -> def
+   { recTerminates = Just True
+   }
   def -> def
 
 -- | Mark all clauses of a function as recursive or non-recursive.
@@ -113,11 +116,17 @@ recDef include name = do
 
   -- Get names in body
   (perClause, ns2) <- case theDef def of
+
     Function{ funClauses = cls } -> do
       perClause <- do
         forM (zip [0..] cls) $ \ (i, cl) ->
           (i,) <$> anyDefs include cl
       return (IntMap.fromList perClause, mconcat $ map snd perClause)
+
+    Record{ recTel } -> do
+      ns <- anyDefs include recTel
+      return (IntMap.singleton 0 ns, ns)
+
     _ -> return (mempty, mempty)
 
   reportS "rec.graph" 20

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -830,6 +830,7 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
            , recEtaEquality' = Inferred YesEta
            , recPatternMatching = CopatternMatching
            , recInduction    = Nothing
+           , recTerminates   = Just True    -- not recursive
            , recAbstr        = ConcreteDef
            , recComp         = emptyCompKit
            }

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2222,6 +2222,10 @@ data Defn = Axiom -- ^ Postulate
               -- ^ 'Inductive' or 'CoInductive'?  Matters only for recursive records.
               --   'Nothing' means that the user did not specify it, which is an error
               --   for recursive records.
+            , recTerminates     :: Maybe Bool
+              -- ^ 'Just True' means that unfolding of the recursive record terminates,
+              --   'Just False' means that we have no evidence for termination,
+              --   and 'Nothing' means we have not run the termination checker yet.
             , recAbstr          :: IsAbstract
             , recComp           :: CompKit
             }
@@ -4730,8 +4734,8 @@ instance KillRange Defn where
       AbstractDefn{} -> __IMPOSSIBLE__ -- only returned by 'getConstInfo'!
       Function cls comp ct tt covering inv mut isAbs delayed proj flags term extlam with ->
         killRange14 Function cls comp ct tt covering inv mut isAbs delayed proj flags term extlam with
-      Datatype a b c d e f g h i j   -> killRange8 Datatype a b c d e f g h i j
-      Record a b c d e f g h i j k l -> killRange12 Record a b c d e f g h i j k l
+      Datatype a b c d e f g h i j   -> killRange10 Datatype a b c d e f g h i j
+      Record a b c d e f g h i j k l m -> killRange13 Record a b c d e f g h i j k l m
       Constructor a b c d e f g h i j-> killRange10 Constructor a b c d e f g h i j
       Primitive a b c d e            -> killRange5 Primitive a b c d e
       PrimitiveSort a b              -> killRange2 PrimitiveSort a b

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -109,9 +109,10 @@ addConstant' q info x t def = do
   addConstant q $ defaultDefn info x t lang def
 
 -- | Set termination info of a defined function symbol.
-setTerminates :: QName -> Bool -> TCM ()
+setTerminates :: MonadTCState m => QName -> Bool -> m ()
 setTerminates q b = modifySignature $ updateDefinition q $ updateTheDef $ \case
     def@Function{} -> def { funTerminates = Just b }
+    def@Record{}   -> def { recTerminates = Just b }
     def -> def
 
 -- | Set CompiledClauses of a defined function symbol.

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -82,7 +82,7 @@ prettyWarning = \case
                concatMap termErrFunctions because)
         $$ fwords "Problematic calls:"
         $$ nest 2 (fmap (P.vcat . List.nub) $
-              mapM prettyTCM $ List.sortBy (compare `on` callInfoRange) $
+              mapM prettyTCM $ List.sortOn callInfoRange $
               concatMap termErrCalls because)
 
     UnreachableClauses f pss -> fsep $

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -82,6 +82,7 @@ bindBuiltinSharp x =
                   , recEtaEquality'   = Inferred $ NoEta CopatternMatching
                   , recPatternMatching= CopatternMatching
                   , recMutual         = Just []
+                  , recTerminates     = Just True  -- not recursive
                   , recAbstr          = ConcreteDef
                   , recComp           = emptyCompKit
                   }

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -235,6 +235,8 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
                   -- in case the record turns out to be recursive.
               -- Determined by positivity checker:
               , recMutual         = Nothing
+              -- Determined by the termination checker:
+              , recTerminates     = Nothing
               , recComp           = emptyCompKit -- filled in later
               }
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -80,7 +80,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20220217 * 10 + 0
+currentInterfaceVersion = 20220312 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -371,7 +371,7 @@ instance EmbPrj Defn where
   icod_ (Function    a b s t []    c d e f g h i j k)   =
     icodeN 1 (\ a b s -> Function a b s t []) a b s c d e f g h i j k
   icod_ (Datatype    a b c d e f g h i j)               = icodeN 2 Datatype a b c d e f g h i j
-  icod_ (Record      a b c d e f g h i j k l)           = icodeN 3 Record a b c d e f g h i j k l
+  icod_ (Record      a b c d e f g h i j k l m)         = icodeN 3 Record a b c d e f g h i j k l m
   icod_ (Constructor a b c d e f g h i j)               = icodeN 4 Constructor a b c d e f g h i j
   icod_ (Primitive   a b c d e)                         = icodeN 5 Primitive a b c d e
   icod_ (PrimitiveSort a b)                             = icodeN 6 PrimitiveSort a b
@@ -383,7 +383,7 @@ instance EmbPrj Defn where
     valu [0, a]                                     = valuN Axiom a
     valu [1, a, b, s, c, d, e, f, g, h, i, j, k]    = valuN (\ a b s -> Function a b s Nothing []) a b s c d e f g h i j k
     valu [2, a, b, c, d, e, f, g, h, i, j]          = valuN Datatype a b c d e f g h i j
-    valu [3, a, b, c, d, e, f, g, h, i, j, k, l]    = valuN Record  a b c d e f g h i j k l
+    valu [3, a, b, c, d, e, f, g, h, i, j, k, l, m] = valuN Record   a b c d e f g h i j k l m
     valu [4, a, b, c, d, e, f, g, h, i, j]          = valuN Constructor a b c d e f g h i j
     valu [5, a, b, c, d, e]                         = valuN Primitive   a b c d e
     valu [6, a, b]                                  = valuN PrimitiveSort a b

--- a/test/Fail/Issue5819.err
+++ b/test/Fail/Issue5819.err
@@ -3,6 +3,7 @@ Termination checking failed for the following functions:
   dl-iso, Fresh→Fresh′, Fresh→AllFresh
 Problematic calls:
   f dl-iso (dcons a₁ l x)
+  f⁻¹ dl-iso (dl″ l′ (proj₂ p))
   Fresh→Fresh′ eq p | l″ | sym eq
   f dl-iso (dcons a l x)
   Fresh→AllFresh eq p | l″ | sym eq

--- a/test/Fail/Issue5823.agda
+++ b/test/Fail/Issue5823.agda
@@ -1,0 +1,31 @@
+-- Andreas, 2022-03-10, issue #5823, reported by oisdk
+-- It was possible to make the check for singleton records loop.
+-- This has never worked (not a regression).
+
+open import Agda.Primitive
+open import Agda.Builtin.Equality
+
+isProp : ∀{a} (A : Set a) → Set a
+isProp A = ∀ (x y : A) → x ≡ y
+
+cong : ∀{a b} {A : Set a} {B : Set b} (f : A → B) {x y : A} (eq : x ≡ y) → f x ≡ f y
+cong f refl = refl
+
+postulate
+  funExt : ∀{a b}{A : Set a} {B : (x : A) → Set b} {f g : (x : A) → B x} → (∀ (x : A) → f x ≡ g x) → f ≡ g
+
+record Acc {a} {A : Set a} {r} (R : A → A → Set r) (x : A) : Set (a ⊔ r) where
+  inductive; eta-equality
+  constructor acc
+  field step : ∀ y → R y x → Acc R y
+open Acc public
+
+-- Naively testing Acc R x for being a singleton will infinitely unfold its definition.
+-- We need to keep track of which record types we already unfolded!
+
+isPropAcc : ∀ {a r} {A : Set a} {R : A → A → Set r} {x : A} → isProp (Acc R x)
+isPropAcc (acc x) (acc y) = cong acc (funExt λ n → funExt λ p → isPropAcc (x n p) (y n p))
+
+-- Agda used to loop when trying determine whether Acc is a singleton type.
+-- Now it gives a termination error, as expected.
+

--- a/test/Fail/Issue5823.err
+++ b/test/Fail/Issue5823.err
@@ -1,0 +1,6 @@
+Issue5823.agda:26,1-27,91
+Termination checking failed for the following functions:
+  isPropAcc
+Problematic calls:
+  isPropAcc (x n p) (y n p)
+    (at Issue5823.agda:27,65-74)

--- a/test/Fail/SizedBTree.err
+++ b/test/Fail/SizedBTree.err
@@ -14,5 +14,7 @@ Termination checking failed for the following functions:
 Problematic calls:
   deep2 {i} {A} (node {i'} (node {i''} l r) x)
   | deep2 {↑ i''} {A} (deep2 {↑ i''} {A} (node {_} {_} {i''} l r))
+  deep2 {↑ i''} {A} (deep2 {↑ i''} {A} (node {_} {_} {i''} l r))
+    (at SizedBTree.agda:67,34-39)
   deep2 {↑ i'} {A} (node {_} {_} {i'} l2 r2)
     (at SizedBTree.agda:69,22-27)

--- a/test/Succeed/Issue5823.agda
+++ b/test/Succeed/Issue5823.agda
@@ -1,0 +1,40 @@
+-- Andreas, 2022-03-11, issue #5823
+-- Make sure we do not weaken the singleton detection too much by checking for loops.
+
+open import Agda.Builtin.Nat
+
+record ⊤ : Set where
+
+record Wrap (A : Set) : Set where
+  field unwrap : A
+
+record _×_ (A B : Set) : Set where
+  field
+    fst : A
+    snd : B
+
+-- A singleton record type with nestings of Wrap.
+
+Singleton = (Wrap ⊤ × Wrap (Wrap ⊤)) × Wrap (Wrap (Wrap ⊤ × ⊤) × Wrap ⊤)
+
+-- Agda should solve this meta:
+
+unique : Singleton
+unique = _
+
+-- This is fine, even though we pass through 'Wrap' several times.
+-- Passing already visited non-recursive records is fine!
+
+mutual
+  record S (n : Nat) : Set where
+    inductive; eta-equality
+    field inn : T n
+
+  T : Nat → Set
+  T zero = ⊤
+  T (suc n) = T n × S n
+
+-- S n is a eta singleton type for each n because it is terminating.
+
+inh5 : S 5
+inh5 = _


### PR DESCRIPTION
Fix #5823: checking for loops when constructing singleton inhabitant.

Squashed version of #5824, with extra comments and tests. Narrative:

For inductive record types with eta-equality, the check for singleton type (constructing the unique inhabitant) was looping for non-terminating records.

As a remedy, the check now keeps a record of already unfolded recursive record types.  This alone is too restrictive, because "terminating" record types should always be unfolded (to their field telescope).
The `Data.Record` module from the standard-library relies on this feature in order to construct the record signature automatically by basically just eta-expansion.

To keep `Data.Record` etc working, this commit also adds a termination checker for record types.  To this end, a record type

    record R pars : Set where
      field
        f1 : A1
        ...
        fn : An

is considered as a list of definitions

    R pars = A1
    ...
    R pars = An

which are subjected to call extraction and termination checking.

Record types that fail the termination check are remembered as such, setting

    recTerminates = Just False

in the `Record` `Definition`, but no termination error is reported.