### PR TITLE
User manual: Clarify that current directory is not included when using -l

### DIFF
--- a/doc/user-manual/tools/package-system.rst
+++ b/doc/user-manual/tools/package-system.rst
@@ -155,7 +155,8 @@ There are three ways a library gets used:
 
 - You supply the ``--library=LIB`` (or ``-l LIB``) option to Agda. This is
   equivalent to adding a ``-iPATH`` for each of the include paths of ``LIB``
-  and its (transitive) dependencies.
+  and its (transitive) dependencies. In this case the current directory is *not* 
+  implicitly added to the include paths.
 
 - No explicit ``--library`` flag is given, and the current project root
   (of the Agda file that is being loaded) or one of its parent directories


### PR DESCRIPTION
User manual: Clarify that current directory is not included when using -l