### PR TITLE
Fix #5850: warn about hiding in e.g. `variable {x} : A`

### DIFF
--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -483,6 +483,12 @@ warningHighlighting' b w = case tcWarning w of
     EmptyPrivate{}                   -> deadcodeHighlighting w
     EmptyGeneralize{}                -> deadcodeHighlighting w
     EmptyField{}                     -> deadcodeHighlighting w
+    HiddenGeneralize{}               -> mempty
+      -- Andreas, 2022-03-25, issue #5850
+      -- We would like @deadcodeHighlighting w@ for the braces in
+      -- @variable {x} : A@, but these have no range, so we cannot highlight them.
+      -- Highlighting the variable instead might be misleading,
+      -- suggesting that it is not generalized over.
     UselessAbstract{}                -> deadcodeHighlighting w
     UselessInstance{}                -> deadcodeHighlighting w
     UselessPrivate{}                 -> deadcodeHighlighting w

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -186,6 +186,7 @@ data WarningName
   | EmptyPrivate_
   | EmptyRewritePragma_
   | EmptyWhere_
+  | HiddenGeneralize_
   | InvalidCatchallPragma_
   | InvalidConstructor_
   | InvalidConstructorBlock_
@@ -341,6 +342,7 @@ warningNameDescription = \case
   EmptyPrivate_                    -> "Empty `private' blocks."
   EmptyRewritePragma_              -> "Empty `REWRITE' pragmas."
   EmptyWhere_                      -> "Empty `where' blocks."
+  HiddenGeneralize_                -> "Hidden identifieres in variable blocks."
   InvalidCatchallPragma_           -> "`CATCHALL' pragmas before a non-function clause."
   InvalidConstructor_              -> "`constructor' blocks may only contain type signatures for constructors."
   InvalidConstructorBlock_         -> "No `constructor' blocks outside of `interleaved mutual' blocks."

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -307,6 +307,10 @@ niceDeclarations fixs ds = do
         Generalize r sigs -> do
           gs <- forM sigs $ \case
             sig@(TypeSig info tac x t) -> do
+              -- Andreas, 2022-03-25, issue #5850:
+              -- Warn about @variable {x} : A@ which is equivalent to @variable x : A@.
+              when (getHiding info == Hidden) $
+                declarationWarning $ HiddenGeneralize $ getRange x
               return $ NiceGeneralize (getRange sig) PublicAccess info tac x t
             _ -> __IMPOSSIBLE__
           return (gs, ds)

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -70,6 +70,10 @@ data DeclarationWarning'
   | EmptyPostulate Range   -- ^ Empty @postulate@ block.
   | EmptyPrivate Range     -- ^ Empty @private@   block.
   | EmptyPrimitive Range   -- ^ Empty @primitive@ block.
+  | HiddenGeneralize Range
+      -- ^ A 'Hidden' identifier in a @variable@ declaration.
+      --   Hiding has no effect there as generalized variables are always hidden
+      --   (or instance variables).
   | InvalidCatchallPragma Range
       -- ^ A {-\# CATCHALL \#-} pragma
       --   that does not precede a function clause.
@@ -133,6 +137,7 @@ declarationWarningName' = \case
   EmptyPrivate{}                    -> EmptyPrivate_
   EmptyPostulate{}                  -> EmptyPostulate_
   EmptyPrimitive{}                  -> EmptyPrimitive_
+  HiddenGeneralize{}                -> HiddenGeneralize_
   InvalidCatchallPragma{}           -> InvalidCatchallPragma_
   InvalidConstructor{}              -> InvalidConstructor_
   InvalidConstructorBlock{}         -> InvalidConstructorBlock_
@@ -174,6 +179,7 @@ unsafeDeclarationWarning' = \case
   EmptyPrivate{}                    -> False
   EmptyPostulate{}                  -> False
   EmptyPrimitive{}                  -> False
+  HiddenGeneralize{}                -> False
   InvalidCatchallPragma{}           -> False
   InvalidConstructor{}              -> False
   InvalidConstructorBlock{}         -> False
@@ -243,6 +249,7 @@ instance HasRange DeclarationWarning' where
   getRange (EmptyGeneralize r)                  = r
   getRange (EmptyPrimitive r)                   = r
   getRange (EmptyField r)                       = r
+  getRange (HiddenGeneralize r)                 = r
   getRange (InvalidTerminationCheckPragma r)    = r
   getRange (InvalidCoverageCheckPragma r)       = r
   getRange (InvalidNoPositivityCheckPragma r)   = r
@@ -340,6 +347,7 @@ instance Pretty DeclarationWarning' where
   pretty (EmptyGeneralize _) = fsep $ pwords "Empty variable block."
   pretty (EmptyPrimitive _)  = fsep $ pwords "Empty primitive block."
   pretty (EmptyField _)      = fsep $ pwords "Empty field block."
+  pretty (HiddenGeneralize _) = fsep $ pwords "Declaring a variable as hidden has no effect in a variable block. Generalization never introduces visible arguments."
   pretty InvalidRecordDirective{} = fsep $
     pwords "Record directives can only be used inside record definitions and before field declarations."
   pretty (InvalidTerminationCheckPragma _) = fsep $

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -80,7 +80,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20220312 * 10 + 0
+currentInterfaceVersion = 20220325 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -194,6 +194,7 @@ instance EmbPrj DeclarationWarning' where
     InvalidConstructor a              -> icodeN 30 InvalidConstructor a
     InvalidConstructorBlock a         -> icodeN 31 InvalidConstructorBlock a
     MissingDeclarations a             -> icodeN 32 MissingDeclarations a
+    HiddenGeneralize r                -> icodeN 33 HiddenGeneralize r
 
   value = vcase $ \case
     [0, a]   -> valuN UnknownNamesInFixityDecl a
@@ -229,6 +230,7 @@ instance EmbPrj DeclarationWarning' where
     [30,r]   -> valuN InvalidConstructor r
     [31,r]   -> valuN InvalidConstructorBlock r
     [32,r]   -> valuN MissingDeclarations r
+    [33,r]   -> valuN HiddenGeneralize r
     _ -> malformed
 
 instance EmbPrj LibWarning where

--- a/test/Succeed/Generalize.warn
+++ b/test/Succeed/Generalize.warn
@@ -1,0 +1,107 @@
+Generalize.agda:64,14-15
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:64,16-17
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:64,18-19
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:69,14-15
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:69,16-17
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:69,18-19
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:73,14-15
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:73,16-17
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:73,18-19
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:82,14-15
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:82,16-17
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:82,18-19
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:129,14-15
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:129,16-17
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+Generalize.agda:129,18-19
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+———— All done; warnings encountered ————————————————————————
+
+Generalize.agda:64,14-15
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:64,16-17
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:64,18-19
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:69,14-15
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:69,16-17
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:69,18-19
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:73,14-15
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:73,16-17
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:73,18-19
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:82,14-15
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:82,16-17
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:82,18-19
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:129,14-15
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:129,16-17
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+Generalize.agda:129,18-19
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.

--- a/test/Succeed/Issue3108.warn
+++ b/test/Succeed/Issue3108.warn
@@ -1,0 +1,9 @@
+Issue3108.agda:3,11-12
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+———— All done; warnings encountered ————————————————————————
+
+Issue3108.agda:3,11-12
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.

--- a/test/Succeed/Issue3115.warn
+++ b/test/Succeed/Issue3115.warn
@@ -1,0 +1,9 @@
+Issue3115.agda:2,11-12
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+———— All done; warnings encountered ————————————————————————
+
+Issue3115.agda:2,11-12
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.

--- a/test/Succeed/Issue3306.warn
+++ b/test/Succeed/Issue3306.warn
@@ -1,0 +1,9 @@
+Issue3306.agda:6,4-6
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.
+
+———— All done; warnings encountered ————————————————————————
+
+Issue3306.agda:6,4-6
+Declaring a variable as hidden has no effect in a variable block.
+Generalization never introduces visible arguments.


### PR DESCRIPTION
Fix #5850: warn about hiding in e.g. `variable {x} : A`.

This hiding has no effect.