### PR TITLE
Makefile: restore cubical-test: pass AGDA_BIN instead of AGDA_EXEC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -524,7 +524,7 @@ cubical-test :
 	-rm -rf cubical/_build
 	@$(call decorate, "Cubical library test", \
 		time $(MAKE) -C cubical \
-                  AGDA_EXEC=$(AGDA_BIN) RTS_OPTIONS=$(AGDA_OPTS))
+                  AGDA_BIN=$(AGDA_BIN) RTS_OPTIONS=$(AGDA_OPTS))
 
 .PHONY : continue-std-lib-test ##
 continue-std-lib-test :


### PR DESCRIPTION
`Makefile`: restore `cubical-test`: pass `AGDA_BIN` instead of `AGDA_EXEC`.

See https://github.com/agda/cubical/commit/eada2613162c1fb7c99ebc4ffcc81ca68b0b57db#r69587495

Reorganization of the `cubical` `GNUmakefile` broke the communication of the Agda executable, which should be restored here.