### PR TITLE
Fix #5856: error out on pattern in path lambda

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -945,8 +945,8 @@ metaHelperType norm ii rng s = case words s of
     -- renameVars = onNames (stringToArgName <.> renameVar . argNameToString)
     renameVars = onNames renameVar
 
-    -- onNames :: Applicative m => (ArgName -> m ArgName) -> Type -> m Type
-    onNames :: Applicative m => (String -> m String) -> Type -> m Type
+    -- onNames :: Applicative m => (ArgName -> m ArgName) -> I.Type -> m I.Type
+    onNames :: Applicative m => (String -> m String) -> I.Type -> m I.Type
     onNames f (El s v) = El s <$> onNamesTm f v
 
     -- onNamesTel :: Applicative f => (ArgName -> f ArgName) -> I.Telescope -> f I.Telescope
@@ -1016,7 +1016,7 @@ contextOfMeta ii norm = withInteractionId ii $ do
         ty <- reifyUnblocked =<< normalForm norm t
         return $ ResponseContextEntry n x (Arg ai ty) Nothing s
 
-    mkLet :: (Name, Open (Term, Dom Type)) -> TCM (Maybe ResponseContextEntry)
+    mkLet :: (Name, Open (Term, Dom I.Type)) -> TCM (Maybe ResponseContextEntry)
     mkLet (name, lb) = do
       (tm, !dom) <- getOpen lb
       if shouldHide (domInfo dom) name then return Nothing else Just <$> do
@@ -1229,7 +1229,7 @@ moduleContents
      -- ^ The range of the next argument.
   -> String
      -- ^ The module name.
-  -> TCM ([C.Name], I.Telescope, [(C.Name, Type)])
+  -> TCM ([C.Name], I.Telescope, [(C.Name, I.Type)])
      -- ^ Module names,
      --   context extension needed to print types,
      --   names paired up with corresponding types.
@@ -1252,7 +1252,7 @@ moduleContents norm rng s = traceCall ModuleContents $ do
 getRecordContents
   :: Rewrite  -- ^ Amount of normalization in types.
   -> C.Expr   -- ^ Expression presumably of record type.
-  -> TCM ([C.Name], I.Telescope, [(C.Name, Type)])
+  -> TCM ([C.Name], I.Telescope, [(C.Name, I.Type)])
               -- ^ Module names,
               --   context extension,
               --   names paired up with corresponding types.
@@ -1286,7 +1286,7 @@ getModuleContents
        -- ^ Amount of normalization in types.
   -> Maybe C.QName
        -- ^ Module name, @Nothing@ if top-level module.
-  -> TCM ([C.Name], I.Telescope, [(C.Name, Type)])
+  -> TCM ([C.Name], I.Telescope, [(C.Name, I.Type)])
        -- ^ Module names,
        --   context extension,
        --   names paired up with corresponding types.

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -479,7 +479,9 @@ data Declaration
   | ModuleMacro Range  Name ModuleApplication !OpenShortHand ImportDirective
   | Module      Range QName Telescope [Declaration]
   | UnquoteDecl Range [Name] Expr
+      -- ^ @unquoteDecl xs = e@
   | UnquoteDef  Range [Name] Expr
+      -- ^ @unquoteDef xs = e@
   | Pragma      Pragma
   deriving (Data, Eq)
 

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1347,8 +1347,8 @@ instance Reify (QNamed System) where
         result = A.Clause (spineToLhs lhs) [] rhs A.noWhereDecls False
       return result
 
-instance Reify Type where
-    type ReifiesTo Type = Expr
+instance Reify I.Type where
+    type ReifiesTo I.Type = A.Type
 
     reifyWhen = reifyWhenE
     reify (I.El _ t) = reify t

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1261,7 +1261,7 @@ instance PrettyUnequal Term where
     (d1, d2, d) <- prettyInEqual t1 t2
     fsep $ return d1 : ncmp : return d2 : return d : []
 
-instance PrettyUnequal Type where
+instance PrettyUnequal I.Type where
   prettyUnequal t1 ncmp t2 = prettyUnequal (unEl t1) ncmp (unEl t2)
 
 instance PrettyTCM SplitError where
@@ -1328,7 +1328,7 @@ instance PrettyTCM SplitError where
       pwords "Case to handle:") $$ nest 2 (vcat $ [display cl])
                                 $$ ((pure msg <+> enterClosure t displayAbs) <> ".")
         where
-        displayAbs :: Abs Type -> m Doc
+        displayAbs :: Abs I.Type -> m Doc
         displayAbs (Abs x t) = addContext x $ prettyTCM t
         displayAbs (NoAbs x t) = prettyTCM t
         display (tel, ps) = prettyTCM $ NamedClause f True $

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -416,8 +416,12 @@ checkTacticAttribute PiNotLam e = do
   checkExpr e expectedType
 
 checkPath :: A.TypedBinding -> A.Expr -> Type -> TCM Term
-checkPath b@(A.TBind _ _ (x':|[]) typ) body ty = do
-    let x    = updateNamedArg (A.unBind . A.binderName) x'
+checkPath b@(A.TBind _r _tac (xp :| []) typ) body ty = do
+ reportSDoc "tc.term.lambda" 30 $ hsep [ "checking path lambda", prettyA xp ]
+ case (A.extractPattern $ namedArg xp) of
+  Just{}  -> setCurrentRange xp $ genericError $ "Patterns are not allowed in Path-lambdas"
+  Nothing -> do
+    let x    = updateNamedArg (A.unBind . A.binderName) xp
         info = getArgInfo x
     PathType s path level typ lhs rhs <- pathView ty
     interval <- primIntervalType
@@ -434,6 +438,7 @@ checkPath b@(A.TBind _ _ (x':|[]) typ) body ty = do
       equalTerm (btyp iOne) rhs' (unArg rhs)
       return t
 checkPath b body ty = __IMPOSSIBLE__
+
 ---------------------------------------------------------------------------
 -- * Lambda abstractions
 ---------------------------------------------------------------------------

--- a/test/Fail/Issue5856.agda
+++ b/test/Fail/Issue5856.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2022-03-28, issue #5856, reported by Szumi Xie.
+-- Patterns in path-lambdas were simply ignored, but should be illegal.
+
+{-# OPTIONS --cubical #-}
+
+-- {-# OPTIONS -v tc.term.lambda:30 #-}
+
+open import Agda.Builtin.Cubical.Path
+
+postulate
+  A E : Set
+  a : A
+
+data C : Set where
+  c : E → C
+
+p : a ≡ a
+p = λ (c e) → a
+
+-- WAS: accepted.
+
+-- Expected error:
+-- Patterns are not allowed in Path-lambdas
+-- when checking that the expression λ .patternInTele0 @ (c e) → a has type a ≡ a

--- a/test/Fail/Issue5856.err
+++ b/test/Fail/Issue5856.err
@@ -1,0 +1,4 @@
+Issue5856.agda:18,8-11
+Patterns are not allowed in Path-lambdas
+when checking that the expression λ .patternInTele0 @ (c e) → a has
+type a ≡ a

--- a/test/Fail/Issue5856b.agda
+++ b/test/Fail/Issue5856b.agda
@@ -1,0 +1,22 @@
+-- Andreas, 2022-03-28, issue #5856, reported by Szumi Xie.
+-- Patterns in path-lambdas were simply ignored, but should be illegal.
+
+{-# OPTIONS --cubical #-}
+
+open import Agda.Builtin.Cubical.Path
+
+postulate
+  A E : Set
+  a : A
+
+data C : Set where
+  c : E → C
+
+p : a ≡ a
+p = λ (c e) → e
+
+-- WAS: panic about unbound identifier e.
+
+-- Expected error:
+-- Patterns are not allowed in Path-lambdas
+-- when checking that the expression λ .patternInTele0 @ (c e) → e has type a ≡ a

--- a/test/Fail/Issue5856b.err
+++ b/test/Fail/Issue5856b.err
@@ -1,0 +1,4 @@
+Issue5856b.agda:16,8-11
+Patterns are not allowed in Path-lambdas
+when checking that the expression λ .patternInTele0 @ (c e) → e has
+type a ≡ a


### PR DESCRIPTION
Fix #5856: error out on pattern in path lambda.

Previously, the pattern was just dropped, leading to faults and crashes (unbound name).

Further in this PR:
- introduce `A.Type` as synonym for `A.Expr`
- some cosmetics on the implementation of `checkLambda`