### PR TITLE
Fix the reflection primitive `getType` ignoring module parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,9 @@ Reflection
   invoked from instead of returning the type a name would have outside
   of all modules.
 
+Syntax
+------
+
 * It is now OK to put lambda-bound variables anywhere in the
   right-hand side of a syntax declaration. However, there must always
   be at least one "identifier" between any two regular "holes". For
@@ -521,4 +524,3 @@ tracker](https://github.com/agda/agda/issues)):
   - [#6273](https://github.com/agda/agda/issues/6273): Missing highlighting when interleaved mutual is used
   - [#6276](https://github.com/agda/agda/issues/6276): LaTeX/HTML generation doesn't properly render parameters of pre-declared records
   - [#6281](https://github.com/agda/agda/issues/6281): Special treatment of attribute followed by underscore in pretty-printer
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,10 @@ Reflection
   instead of returning information that would be expected in the top
   context.
 
+* [**Breaking**] The reflection primitive `inContext` cannot step
+  outside of the context that the `TC` computation is invoked from
+  anymore. The telescope is now relative to that context instead.
+
 Syntax
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,9 +234,10 @@ Reflection
 * [**Breaking**] A new constructor `pattErr : Pattern → ErrorPart` of `ErrorPart` for reflection
   is added.
 
-* The reflection primitive `getType` respects the module context it is
-  invoked from instead of returning the type a name would have outside
-  of all modules.
+* [**Breaking**] The reflection primitives `getType` and
+  `getDefinition` respect the module context they are invoked from
+  instead of returning information that would be expected in the top
+  context.
 
 Syntax
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,8 +234,9 @@ Reflection
 * [**Breaking**] A new constructor `pattErr : Pattern → ErrorPart` of `ErrorPart` for reflection
   is added.
 
-Syntax declarations
--------------------
+* The reflection primitive `getType` respects the module context it is
+  invoked from instead of returning the type a name would have outside
+  of all modules.
 
 * It is now OK to put lambda-bound variables anywhere in the
   right-hand side of a syntax declaration. However, there must always

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -423,9 +423,10 @@ following primitive operations::
     -- Extend the current context with a variable of the given type and its name.
     extendContext : ∀ {a} {A : Set a} → String → Arg Type → TC A → TC A
 
-    -- Set the current context. Takes a context telescope entries in
-    -- reverse order, as given by `getContext`. Each type should be valid
-    -- in the context formed by the remaining elements in the list.
+    -- Set the current context relative to the context the TC computation
+    -- is invoked from.  Takes a context telescope entries in reverse
+    -- order, as given by `getContext`. Each type should be valid in the
+    -- context formed by the remaining elements in the list.
     inContext : ∀ {a} {A : Set a} → Telescope → TC A → TC A
 
     -- Quote a value, returning the corresponding Term.

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -464,10 +464,12 @@ following primitive operations::
     -- 'declareDef' or with an explicit type signature in the program.
     defineFun : Name → List Clause → TC ⊤
 
-    -- Get the type of a defined name. Replaces 'primNameType'.
+    -- Get the type of a defined name relative to the current
+    -- module. Replaces 'primNameType'.
     getType : Name → TC Type
 
-    -- Get the definition of a defined name. Replaces 'primNameDefinition'.
+    -- Get the definition of a defined name relative to the current
+    -- module. Replaces 'primNameDefinition'.
     getDefinition : Name → TC Definition
 
     -- Check if a name refers to a macro

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -845,7 +845,7 @@ evalTCM v = do
     tcGetType :: QName -> TCM Term
     tcGetType x = do
       r  <- isReconstructed
-      ci <- constInfo x
+      ci <- constInfo x >>= instantiateDef
       let t = defType ci
       if r then do
         t <- locallyReduceAllDefs $ reconstructParametersInType t

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -869,11 +869,11 @@ evalTCM v = do
       if r then
         tcGetDefinitionRecons x
       else
-        quoteDefn =<< constInfo x
+        quoteDefn =<< instantiateDef =<< constInfo x
 
     tcGetDefinitionRecons :: QName -> TCM Term
     tcGetDefinitionRecons x = do
-      ci@(Defn {theDef=d}) <- constInfo x
+      ci@(Defn {theDef=d}) <- constInfo x >>= instantiateDef
       case d of
         f@(Function {funClauses=cs}) -> do
           cs' <- mapM reconsClause cs

--- a/test/Succeed/ReflectionGetType.agda
+++ b/test/Succeed/ReflectionGetType.agda
@@ -21,8 +21,8 @@ module Temp {A : Set} where
 
   -- inContext [] goes to the original context of the macro call, so
   -- it should not have any effect here.
-  id-type₁′ : Term
-  id-type₁′ = byTC (inContext [] (getType (quote id)))
+  id-type₁' : Term
+  id-type₁' = byTC (inContext [] (getType (quote id)))
 
   id-def₁ : Definition
   id-def₁ = byTC (getDefinition (quote id))

--- a/test/Succeed/ReflectionGetType.agda
+++ b/test/Succeed/ReflectionGetType.agda
@@ -1,0 +1,32 @@
+open import Agda.Builtin.Reflection
+open import Common.Equality
+open import Common.Reflection
+open import Common.Unit
+open import Common.List
+
+module ReflectionGetType where
+
+macro
+  byTC : ∀ {a} {A : Set a} → TC A → Term → TC Unit
+  byTC comp goal = comp >>= quoteTC >>= unify goal
+
+module Temp {A : Set} where
+
+  id : A → A
+  id a = a
+
+  id-type₁ : Term
+  id-type₁ = byTC (getType (quote id))
+
+open Temp
+
+wrap : Term → Term
+wrap t =
+  pi (arg (arg-info hidden (modality relevant quantity-ω)) (agda-sort (lit 0)))
+     (abs "A" t)
+
+id-type₂ : Term
+id-type₂ = byTC (getType (quote id))
+
+pf : ∀ {A} → wrap (id-type₁ {A}) ≡ id-type₂
+pf = refl

--- a/test/Succeed/ReflectionGetType.agda
+++ b/test/Succeed/ReflectionGetType.agda
@@ -18,6 +18,11 @@ module Temp {A : Set} where
   id-type₁ : Term
   id-type₁ = byTC (getType (quote id))
 
+  -- inContext [] goes to the original context of the macro call, so
+  -- it should not have any effect here.
+  id-type₁′ : Term
+  id-type₁′ = byTC (inContext [] (getType (quote id)))
+
 open Temp
 
 wrap : Term → Term
@@ -30,3 +35,6 @@ id-type₂ = byTC (getType (quote id))
 
 pf : ∀ {A} → wrap (id-type₁ {A}) ≡ id-type₂
 pf = refl
+
+pf′ : ∀ {A} → wrap (id-type₁′ {A}) ≡ id-type₂
+pf′ = refl

--- a/test/Succeed/ReflectionGetType.agda
+++ b/test/Succeed/ReflectionGetType.agda
@@ -1,8 +1,9 @@
 open import Agda.Builtin.Reflection
+open import Agda.Builtin.Sigma
 open import Common.Equality
+open import Common.List
 open import Common.Reflection
 open import Common.Unit
-open import Common.List
 
 module ReflectionGetType where
 
@@ -23,6 +24,13 @@ module Temp {A : Set} where
   id-type₁′ : Term
   id-type₁′ = byTC (inContext [] (getType (quote id)))
 
+  id-def₁ : Definition
+  id-def₁ = byTC (getDefinition (quote id))
+
+  -- same as above
+  id-def₁' : Definition
+  id-def₁' = byTC (inContext [] (getDefinition (quote id)))
+
 open Temp
 
 wrap : Term → Term
@@ -33,8 +41,18 @@ wrap t =
 id-type₂ : Term
 id-type₂ = byTC (getType (quote id))
 
-pf : ∀ {A} → wrap (id-type₁ {A}) ≡ id-type₂
-pf = refl
+id-def₂ : Definition
+id-def₂ = byTC (getDefinition (quote id))
 
-pf′ : ∀ {A} → wrap (id-type₁′ {A}) ≡ id-type₂
-pf′ = refl
+pf-type : ∀ {A} → wrap (id-type₁ {A}) ≡ id-type₂
+pf-type = refl
+
+pf-type' : ∀ {A} → id-type₁' {A} ≡ id-type₁ {A}
+pf-type' = refl
+
+pf-def : ∀ {A} →
+  id-def₁ {A} ≡ function (clause (("a" , vArg (var 0 [])) ∷ []) (vArg (var 0) ∷ []) (var 0 []) ∷ [])
+pf-def = refl
+
+pf-def' : ∀ {A} → id-def₁' {A} ≡ id-def₁ {A}
+pf-def' = refl


### PR DESCRIPTION
`getType` currently ignores the context it is invoked from, returning the type a name would have outside of any module. This means that the type it returns might not actually be the type that a name has where it is currently invoked. This PR should give `getType` the expected behaviour in this scenario.

Alternatives to this would be to either make this behaviour controllable or to provide a primitive that returns the common module context with a name and to expect the user to manually adjust the type. I this those are both useful additions, but the behaviour implemented by this PR seems like a sensible default. 