### PR TITLE
flake: update and add a devShell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1628427995,
-        "narHash": "sha256-Rut8HcmyPTHMDx1NoGlF2Cmqv6n+fOL5bakcsfW4KFE=",
+        "lastModified": 1650161686,
+        "narHash": "sha256-70ZWAlOQ9nAZ08OU6WY7n4Ij2kOO199dLfNlvO/+pf8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c481b497d5c3754c50e89795c6d903dd0d130baa",
+        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,16 +3,26 @@
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }: (flake-utils.lib.eachDefaultSystem (system: {
-    packages =  let
-      pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
-    in {
+  outputs = { self, nixpkgs, flake-utils }: (flake-utils.lib.eachDefaultSystem (system: let
+    pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
+  in {
+    packages = {
       inherit (pkgs.haskellPackages) Agda;
 
       # TODO agda2-mode
     };
 
     defaultPackage = self.packages.${system}.Agda;
+
+    devShell = pkgs.mkShell {
+      inputsFrom = [ self.defaultPackage.${system} ];
+      packages = with pkgs; [
+        pkg-config
+        zlib
+        icu
+        haskellPackages.fix-whitespace
+      ];
+    };
   })) // {
     overlay = final: prev: {
       haskellPackages = prev.haskellPackages.override {

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1306,7 +1306,8 @@ top-level scope."
 
 (agda2-maybe-normalised
  agda2-elaborate-give
- "Elaborate check the given expression against the hole's type and fill in hole with the elaborated term"
+ "Elaborate check the given expression against the hole's type and fill in the
+ hole with the elaborated term"
  "Cmd_elaborate_give"
  "expression to elaborate and give")
 
@@ -1324,7 +1325,8 @@ top-level scope."
 
 (agda2-maybe-normalised
  agda2-goal-and-context-and-checked
- "Shows the context, the goal and check the given expression's against the hole's type"
+ "Shows the context, the goal and check the given expression's against
+ the hole's type"
  "Cmd_goal_type_context_check"
  "expression to type")
 


### PR DESCRIPTION
Updates the flake lock to a more recent version of nixpkgs with GHC 9.0.2, and adds a `devShell` to provide some dependencies for building and testing.