### PR TITLE
[ .cabal ] Added new `-Wredundant-bang-patterns` warning (since GHC 9.2)

### DIFF
--- a/.ghci-9.2.2
+++ b/.ghci-9.2.2
@@ -3,3 +3,4 @@
 -- in this directory.
 
 :script .ghci-9.0.2
+:set -Wredundant-bang-patterns

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -769,7 +769,8 @@ library
 
   -- NOTE: If adding or removing flags, also change `.ghci-9.2.2`
   if impl(ghc >= 9.2.2)
-    ghc-options: -Werror=unicode-bidirectional-format-characters
+    ghc-options: -Werror=redundant-bang-patterns
+                 -Werror=unicode-bidirectional-format-characters
 
   ghc-prof-options: -fprof-auto
 
@@ -1111,4 +1112,5 @@ test-suite agda-tests
 
   -- NOTE: If adding or removing flags, also change `.ghci-9.2.2`
   if impl(ghc >= 9.2.2)
-    ghc-options: -Werror=unicode-bidirectional-format-characters
+    ghc-options: -Werror=redundant-bang-patterns
+                 -Werror=unicode-bidirectional-format-characters

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -867,7 +867,7 @@ reduceTm rEnv bEnv !constInfo normalisation ReductionFlags{..} =
     --  - Look up in the environment if variable
     --  - Perform a beta step if lambda and application elimination in the spine
     --  - Perform a record beta step if record constructor and projection elimination in the spine
-    runAM' s@(Eval cl@(Closure Unevaled t env spine) !ctrl) = {-# SCC "runAM.Eval" #-}
+    runAM' s@(Eval cl@(Closure Unevaled t env spine) ctrl) = {-# SCC "runAM.Eval" #-}
       case t of
 
         -- Case: definition. Enter 'Match' state if defined function or shift to evaluating an


### PR DESCRIPTION
See https://downloads.haskell.org/~ghc/9.2.2/docs/html/users_guide/using-warnings.html#ghc-flag--Wredundant-bang-patterns.

CI testing...