### PR TITLE
[ build ] tweaking build options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ GHC_RTS_OPTS := -M4G
 endif
 #
 endif
-GHC_OPTS = "-j +RTS -A128M $(GHC_RTS_OPTS) -RTS"
+GHC_OPTS = "+RTS -A128M $(GHC_RTS_OPTS) -RTS"
 
 # The following options are used in several invocations of cabal
 # install/configure below. They are always the last options given to

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ GHC_RTS_OPTS := -M4G
 endif
 #
 endif
-GHC_OPTS = "+RTS $(GHC_RTS_OPTS) -RTS"
+GHC_OPTS = "-j +RTS -A128M $(GHC_RTS_OPTS) -RTS"
 
 # The following options are used in several invocations of cabal
 # install/configure below. They are always the last options given to


### PR DESCRIPTION
Playing with the options mentioned in [this blog post](https://rybczak.net/2016/03/26/how-to-reduce-compilation-times-of-haskell-projects/) and I've settled on the following options.

The baseline spends 500s on GC whereas the tweaked version with `-A128M` only spends 350s.
Combined with `-j`-enabled parallelism, build time is reduced from ~20 min to ~15 min.

I've tried the `-n2m` option too but it didn't make any difference.
Using even higher values for `-A` leads to 'exhausted heap' exceptions.

Baseline:
```
1,553,149,846,512 bytes allocated in the heap
 153,752,214,208 bytes copied during GC
   3,323,925,680 bytes maximum residency (76 sample(s))
      19,958,608 bytes maximum slop
            3169 MB total memory in use (1 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     18319 colls,     0 par   191.752s  191.474s     0.0105s    0.2807s
  Gen  1        76 colls,     0 par   311.658s  311.328s     4.0964s    11.3058s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time  710.517s  (737.671s elapsed)
  GC      time  503.410s  (502.801s elapsed)
  EXIT    time    0.001s  (  0.008s elapsed)
  Total   time  1213.928s  (1240.480s elapsed)

  Alloc rate    2,185,944,369 bytes per MUT second

  Productivity  58.5% of total user, 59.5% of total elapsed
```


With `-A128M`:
```
1,552,616,489,384 bytes allocated in the heap
  87,164,243,920 bytes copied during GC
   3,246,547,424 bytes maximum residency (40 sample(s))
      19,906,080 bytes maximum slop
            3096 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      1278 colls,   320 par   141.056s  100.505s     0.0786s    0.3577s
  Gen  1        40 colls,    14 par   205.948s  187.003s     4.6751s    11.3559s

  Parallel GC work balance: 95.13% (serial 0%, perfect 100%)

  TASKS: 27 (1 bound, 26 peak workers (26 total), using -N8)

  SPARKS: 2 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 2 fizzled)

  INIT    time    0.002s  (  0.002s elapsed)
  MUT     time  892.780s  (620.130s elapsed)
  GC      time  347.004s  (287.508s elapsed)
  EXIT    time    0.003s  (  0.002s elapsed)
  Total   time  1239.790s  (907.642s elapsed)

  Alloc rate    1,739,080,489 bytes per MUT second

  Productivity  72.0% of total user, 68.3% of total elapsed
```