### PR TITLE
Fix #5891: Postponable check that data isn't IUniv, SizeUniv,…

### DIFF
--- a/src/full/Agda/Interaction/Base.hs
+++ b/src/full/Agda/Interaction/Base.hs
@@ -443,6 +443,7 @@ data OutputConstraint a b
       | PTSInstance b b
       | PostponedCheckFunDef QName a TCErr
       | CheckLock b b
+      | DataSort QName b
       | UsableAtMod Modality b
   deriving (Functor)
 

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -231,6 +231,10 @@ encodeOC f encPrettyTCM = \case
   , "type"           #= encPrettyTCM a
   , "error"          #= encodeTCM err
   ]
+ DataSort q s -> kind "DataSort"
+  [ "name"           @= encodePretty q
+  , "sort"           #= f s
+  ]
  CheckLock t lk -> kind "CheckLock"
   [ "head"           #= f t
   , "lock"           #= f lk

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -26,6 +26,7 @@ import Agda.TypeChecking.Warnings
 
 import Agda.TypeChecking.Irrelevance
 import {-# SOURCE #-} Agda.TypeChecking.Rules.Application
+import {-# SOURCE #-} Agda.TypeChecking.Rules.Data ( checkDataSort )
 import {-# SOURCE #-} Agda.TypeChecking.Rules.Def
 import {-# SOURCE #-} Agda.TypeChecking.Rules.Term
 import {-# SOURCE #-} Agda.TypeChecking.Conversion
@@ -297,6 +298,7 @@ solveConstraint_ (CheckFunDef d i q cs _err) = withoutCache $
 solveConstraint_ (CheckLockedVars a b c d)   = checkLockedVars a b c d
 solveConstraint_ (HasBiggerSort a)      = hasBiggerSort a
 solveConstraint_ (HasPTSRule a b)       = hasPTSRule a b
+solveConstraint_ (CheckDataSort q s)    = checkDataSort q s
 solveConstraint_ (CheckMetaInst m)      = checkMetaInst m
 solveConstraint_ (CheckType t)          = checkType t
 solveConstraint_ (UsableAtModality mod t) = usableAtModality mod t

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -118,6 +118,7 @@ instance MentionsMeta Constraint where
     HasBiggerSort a     -> mm a
     HasPTSRule a b      -> mm (a, b)
     UnquoteTactic tac hole goal -> False
+    CheckDataSort q s   -> mm s
     CheckMetaInst m     -> True   -- TODO
     CheckType t         -> mm t
     CheckLockedVars a b c d -> mm ((a, b), (c, d))

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1110,6 +1110,10 @@ data Constraint
 --    -- ^ A delayed instantiation.  Replaces @ValueCmp@ in 'postponeTypeCheckingProblem'.
   | HasBiggerSort Sort
   | HasPTSRule (Dom Type) (Abs Sort)
+  | CheckDataSort QName Sort
+    -- ^ Check that the sort 'Sort' of data type 'QName' admits data/record types.
+    -- E.g., sorts @IUniv@, @SizeUniv@ etc. do not admit such constructions.
+    -- See 'Agda.TypeChecking.Rules.Data.checkDataSort'.
   | CheckMetaInst MetaId
   | CheckType Type
   | UnBlock MetaId
@@ -1160,6 +1164,7 @@ instance Free Constraint where
       HasPTSRule a s        -> freeVars' (a , s)
       CheckLockedVars a b c d -> freeVars' ((a,b),(c,d))
       UnquoteTactic t h g   -> freeVars' (t, (h, g))
+      CheckDataSort _ s     -> freeVars' s
       CheckMetaInst m       -> mempty
       CheckType t           -> freeVars' t
       UsableAtModality mod t -> freeVars' t
@@ -1180,6 +1185,7 @@ instance TermLike Constraint where
       CheckFunDef{}          -> mempty
       HasBiggerSort s        -> foldTerm f s
       HasPTSRule a s         -> foldTerm f (a, Sort <$> s)
+      CheckDataSort _ s      -> foldTerm f s
       CheckMetaInst m        -> mempty
       CheckType t            -> foldTerm f t
       UsableAtModality m t   -> foldTerm f t

--- a/src/full/Agda/TypeChecking/Monad/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Monad/Constraints.hs
@@ -201,6 +201,7 @@ addConstraintTo bucket unblock c = do
       FindInstance{}   -> False
       HasBiggerSort{}  -> False
       HasPTSRule{}     -> False
+      CheckDataSort{}  -> False
       ValueCmp{}       -> True
       ValueCmpOnFace{} -> True
       ElimCmp{}        -> True

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -405,6 +405,7 @@ constraintMetas = \case
       CheckSizeLtSat{}         -> return mempty
       HasBiggerSort{}          -> return mempty
       HasPTSRule{}             -> return mempty
+      CheckDataSort{}          -> return mempty
       CheckMetaInst x          -> return mempty
       CheckType t              -> return $ allMetas Set.singleton t
       CheckLockedVars a b c d  -> return $ allMetas Set.singleton (a, b, c, d)

--- a/src/full/Agda/TypeChecking/Pretty/Constraint.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Constraint.hs
@@ -146,6 +146,8 @@ instance PrettyTCM Constraint where
         UnquoteTactic v _ _ -> do
           e <- reify v
           prettyTCM (A.App A.defaultAppInfo_ (A.Unquote A.exprNoRange) (defaultNamedArg e))
+        CheckDataSort q s -> do
+          hsep [ "Sort", prettyTCM s, "of", prettyTCM q, "admits data/record definitions." ]
         CheckMetaInst x -> do
           m <- lookupLocalMeta x
           case mvJudgement m of

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -132,12 +132,15 @@ path t = primPath <@> t
 el :: Functor m => m Term -> m Type
 el t = El (mkType 0) <$> t
 
+-- | The universe @Set0@ as a type.
 tset :: Applicative m => m Type
 tset = pure $ sort (mkType 0)
 
+-- | @SizeUniv@ as a sort.
 sSizeUniv :: Sort
 sSizeUniv = SizeUniv
 
+-- | @SizeUniv@ as a type.
 tSizeUniv :: Applicative m => m Type
 tSizeUniv = pure $ sort sSizeUniv
 

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -136,18 +136,9 @@ tset :: Applicative m => m Type
 tset = pure $ sort (mkType 0)
 
 sSizeUniv :: Sort
--- sSizeUniv = mkType 0
--- Andreas, 2016-04-14 switching off SizeUniv, unfixing issue #1428
 sSizeUniv = SizeUniv
 
 tSizeUniv :: Applicative m => m Type
--- tSizeUniv = tset
--- Andreas, 2016-04-14 switching off SizeUniv, unfixing issue #1428
--- tSizeUniv = return $ El sSizeUniv $ Sort sSizeUniv
--- Andreas, 2015-03-16 Since equality checking for types
--- includes equality checking for sorts, we cannot put
--- SizeUniv in Setω.  (SizeUniv : Setω) == (_0 : suc _0)
--- will first instantiate _0 := Setω, which is wrong.
 tSizeUniv = pure $ sort sSizeUniv
 
 -- | Abbreviation: @argN = 'Arg' 'defaultArgInfo'@.

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -273,6 +273,7 @@ instance Instantiate Constraint where
   instantiate' (CheckLockedVars a b c d) =
     CheckLockedVars <$> instantiate' a <*> instantiate' b <*> instantiate' c <*> instantiate' d
   instantiate' (UnquoteTactic t h g) = UnquoteTactic <$> instantiate' t <*> instantiate' h <*> instantiate' g
+  instantiate' (CheckDataSort q s)  = CheckDataSort q <$> instantiate' s
   instantiate' c@CheckMetaInst{}    = return c
   instantiate' (CheckType t)        = CheckType <$> instantiate' t
   instantiate' (UsableAtModality mod t) = UsableAtModality mod <$> instantiate' t
@@ -883,6 +884,7 @@ instance Reduce Constraint where
   reduce' (UnquoteTactic t h g) = UnquoteTactic <$> reduce' t <*> reduce' h <*> reduce' g
   reduce' (CheckLockedVars a b c d) =
     CheckLockedVars <$> reduce' a <*> reduce' b <*> reduce' c <*> reduce' d
+  reduce' (CheckDataSort q s)   = CheckDataSort q <$> reduce' s
   reduce' c@CheckMetaInst{}     = return c
   reduce' (CheckType t)         = CheckType <$> reduce' t
   reduce' (UsableAtModality mod t) = UsableAtModality mod <$> reduce' t
@@ -1049,6 +1051,7 @@ instance Simplify Constraint where
   simplify' (UnquoteTactic t h g) = UnquoteTactic <$> simplify' t <*> simplify' h <*> simplify' g
   simplify' (CheckLockedVars a b c d) =
     CheckLockedVars <$> simplify' a <*> simplify' b <*> simplify' c <*> simplify' d
+  simplify' (CheckDataSort q s)   = CheckDataSort q <$> simplify' s
   simplify' c@CheckMetaInst{}     = return c
   simplify' (CheckType t)         = CheckType <$> simplify' t
   simplify' (UsableAtModality mod t) = UsableAtModality mod <$> simplify' t
@@ -1230,6 +1233,7 @@ instance Normalise Constraint where
   normalise' (UnquoteTactic t h g) = UnquoteTactic <$> normalise' t <*> normalise' h <*> normalise' g
   normalise' (CheckLockedVars a b c d) =
     CheckLockedVars <$> normalise' a <*> normalise' b <*> normalise' c <*> normalise' d
+  normalise' (CheckDataSort q s)   = CheckDataSort q <$> normalise' s
   normalise' c@CheckMetaInst{}     = return c
   normalise' (CheckType t)         = CheckType <$> normalise' t
   normalise' (UsableAtModality mod t) = UsableAtModality mod <$> normalise' t
@@ -1464,6 +1468,7 @@ instance InstantiateFull Constraint where
     UnquoteTactic t g h -> UnquoteTactic <$> instantiateFull' t <*> instantiateFull' g <*> instantiateFull' h
     CheckLockedVars a b c d ->
       CheckLockedVars <$> instantiateFull' a <*> instantiateFull' b <*> instantiateFull' c <*> instantiateFull' d
+    CheckDataSort q s   -> CheckDataSort q <$> instantiateFull' s
     c@CheckMetaInst{}   -> return c
     CheckType t         -> CheckType <$> instantiateFull' t
     UsableAtModality mod t -> UsableAtModality mod <$> instantiateFull' t

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -304,9 +304,7 @@ coreBuiltins =
   , (builtinHidden                           |-> BuiltinDataCons thiding)
   , (builtinInstance                         |-> BuiltinDataCons thiding)
   , (builtinVisible                          |-> BuiltinDataCons thiding)
-  , (builtinSizeUniv                         |-> builtinPostulate tSizeUniv) -- SizeUniv : SizeUniv
--- See comment on tSizeUniv: the following does not work currently.
---  , (builtinSizeUniv                          |-> builtinPostulate tSetOmega) -- SizeUniv : Setω
+  , (builtinSizeUniv                         |-> builtinPostulate tsetOmega) -- SizeUniv : Setω
   , (builtinSize                             |-> builtinPostulate tSizeUniv)
   , (builtinSizeLt                           |-> builtinPostulate (tsize ..--> tSizeUniv))
   , (builtinSizeSuc                          |-> builtinPostulate (tsize --> tsize))

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -218,6 +218,8 @@ checkDataSort name s = setCurrentRange name $ do
                    , prettyTCM name
                    , "does not admit data or record declarations"
                    ]
+      dunno :: TCM ()
+      dunno = postpone (unblockOnAnyMetaIn s) s
     case s of
       -- Sorts that admit data definitions.
       Type _       -> yes
@@ -230,9 +232,9 @@ checkDataSort name s = setCurrentRange name $ do
       LockUniv     -> no
       IntervalUniv -> no
       -- Unsolved sorts.
-      PiSort _ _ _ -> postpone (unblockOnAnyMetaIn s) s
-      FunSort _ _  -> postpone (unblockOnAnyMetaIn s) s
-      UnivSort _   -> postpone (unblockOnAnyMetaIn s) s
+      PiSort _ _ _ -> dunno
+      FunSort _ _  -> dunno
+      UnivSort _   -> dunno
       MetaS _ _    -> __IMPOSSIBLE__
       DummyS _     -> __IMPOSSIBLE__
   where

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -126,24 +126,6 @@ checkDataDef i name uc (A.DataDefParams gpars ps) cs =
                   else throwError err
               reduce s
 
-            -- cubical: the interval universe does not contain datatypes
-            when (s == IntervalUniv) $
-              typeError . GenericDocError =<<
-              fsep [ "The sort of" <+> prettyTCM name
-                   , "cannot be the interval universe"
-                   , prettyTCM s
-                   ]
-
-            -- when `--without-K`, all the indices should fit in the
-            -- sort of the datatype (see #3420).
-            let s' = case s of
-                  Prop l -> Type l
-                  _      -> s
-            -- Andreas, 2019-07-16, issue #3916:
-            -- NoUniverseCheck should also disable the index sort check!
-            unless (uc == NoUniverseCheck) $
-              whenM withoutKOption $ checkIndexSorts s' ixTel
-
             reportSDoc "tc.data.sort" 20 $ vcat
               [ "checking datatype" <+> prettyTCM name
               , nest 2 $ vcat
@@ -180,11 +162,25 @@ checkDataDef i name uc (A.DataDefParams gpars ps) cs =
               isPathCons <- checkConstructor name uc tel' nofIxs s c
               return $ if isPathCons == PathCons then Just (A.axiomName c) else Nothing
 
+
+            -- cubical: the interval universe does not contain datatypes
+            -- similar: SizeUniv, ...
+            checkDataSort name s
+
+            -- when `--without-K`, all the indices should fit in the
+            -- sort of the datatype (see #3420).
+            -- Andreas, 2019-07-16, issue #3916:
+            -- NoUniverseCheck should also disable the index sort check!
+            unless (uc == NoUniverseCheck) $
+              whenM withoutKOption $ do
+                let s' = case s of
+                      Prop l -> Type l
+                      _      -> s
+                checkIndexSorts s' ixTel
+
             -- Return the data definition
             return dataDef{ dataPathCons = catMaybes pathCons
                           }
-
-
 
         let cons   = map A.axiomName cs  -- get constructor names
 
@@ -205,6 +201,44 @@ checkDataDef i name uc (A.DataDefParams gpars ps) cs =
                    , dataTransp   = transpFun
                    }
 
+-- | Make sure that the target universe admits data type definitions.
+--   E.g. @IUniv@, @SizeUniv@ etc. do not accept new constructions.
+checkDataSort :: QName -> Sort -> TCM ()
+checkDataSort name s = do
+  s <- reduce s
+  let
+   yes   = return ()
+   no    = typeError . GenericDocError =<<
+              fsep [ "The universe"
+                   , prettyTCM s
+                   , "of"
+                   , prettyTCM name
+                   , "does not admit data or record declarations"
+                   ]
+   dunno = typeError . GenericDocError =<<
+              fsep [ "The universe"
+                   , prettyTCM s
+                   , "of"
+                   , prettyTCM name
+                   , "is unresolved, thus does not permit data or record declarations"
+                   ]
+  case s of
+    -- Sorts that admit data definitions.
+    Type _   -> yes
+    Prop _   -> yes
+    Inf _ _  -> yes
+    SSet _   -> yes
+    DefS _ _ -> yes
+    -- Sorts that do not admit data definitions.
+    SizeUniv     -> no
+    LockUniv     -> no
+    IntervalUniv -> no
+    -- Unsolved sorts.
+    PiSort _ _ _ -> dunno
+    FunSort _ _  -> dunno
+    UnivSort _   -> dunno
+    MetaS _ _    -> dunno
+    DummyS _     -> __IMPOSSIBLE__
 
 -- | Ensure that the type is a sort.
 --   If it is not directly a sort, compare it to a 'newSortMetaBelowInf'.

--- a/src/full/Agda/TypeChecking/Rules/Data.hs-boot
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs-boot
@@ -1,0 +1,6 @@
+module Agda.TypeChecking.Rules.Data where
+
+import Agda.Syntax.Internal         ( QName, Sort )
+import Agda.TypeChecking.Monad.Base ( TCM )
+
+checkDataSort :: QName -> Sort -> TCM ()

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -994,6 +994,7 @@ instance Subst Constraint where
     HasPTSRule a s           -> HasPTSRule (rf a) (rf s)
     CheckLockedVars a b c d  -> CheckLockedVars (rf a) (rf b) (rf c) (rf d)
     UnquoteTactic t h g      -> UnquoteTactic (rf t) (rf h) (rf g)
+    CheckDataSort q s        -> CheckDataSort q (rf s)
     CheckMetaInst m          -> CheckMetaInst m
     CheckType t              -> CheckType (rf t)
     UsableAtModality mod m   -> UsableAtModality mod (rf m)

--- a/test/Fail/IUnivData.err
+++ b/test/Fail/IUnivData.err
@@ -1,3 +1,4 @@
 IUnivData.agda:3,6-13
-The sort of BadData cannot be the interval universe IUniv
+The universe IUniv of BadData
+does not admit data or record declarations
 when checking the definition of BadData

--- a/test/Fail/IUnivRecord.err
+++ b/test/Fail/IUnivRecord.err
@@ -1,3 +1,4 @@
 IUnivRecord.agda:3,8-11
-The sort of Bad cannot be the interval universe IUniv
+The universe IUniv of Bad
+does not admit data or record declarations
 when checking the definition of Bad

--- a/test/Fail/Issue2285-record.err
+++ b/test/Fail/Issue2285-record.err
@@ -1,4 +1,4 @@
-Failed to solve the following constraints:
-  Agda.Primitive.Setω =< _4 (blocked on _4)
-Unsolved metas at the following locations:
-  Issue2285-record.agda:4,8-11
+Issue2285-record.agda:4,8-11
+The universe _4 of Big
+is unresolved, thus does not permit data or record declarations
+when checking the definition of Big

--- a/test/Fail/Issue2285-record.err
+++ b/test/Fail/Issue2285-record.err
@@ -1,4 +1,5 @@
-Issue2285-record.agda:4,8-11
-The universe _4 of Big
-is unresolved, thus does not permit data or record declarations
-when checking the definition of Big
+Failed to solve the following constraints:
+  Sort _4 of Big admits data/record definitions. (blocked on _4)
+  Agda.Primitive.Setω =< _4 (blocked on _4)
+Unsolved metas at the following locations:
+  Issue2285-record.agda:4,8-11

--- a/test/Fail/Issue2285.err
+++ b/test/Fail/Issue2285.err
@@ -1,4 +1,5 @@
-Issue2285.agda:13,8-11
-The universe _5 of Big
-is unresolved, thus does not permit data or record declarations
-when checking the definition of Big
+Failed to solve the following constraints:
+  Sort _5 of Big admits data/record definitions. (blocked on _5)
+  Agda.Primitive.Setω =< _5 (blocked on _5)
+Unsolved metas at the following locations:
+  Issue2285.agda:13,8-11

--- a/test/Fail/Issue2285.err
+++ b/test/Fail/Issue2285.err
@@ -1,4 +1,4 @@
-Failed to solve the following constraints:
-  Agda.Primitive.Setω =< _5 (blocked on _5)
-Unsolved metas at the following locations:
-  Issue2285.agda:13,8-11
+Issue2285.agda:13,8-11
+The universe _5 of Big
+is unresolved, thus does not permit data or record declarations
+when checking the definition of Big

--- a/test/Fail/Issue5891.agda
+++ b/test/Fail/Issue5891.agda
@@ -1,0 +1,71 @@
+-- AIM XXXV, 2022-05-06, issue #5891:
+-- SizeUniv : SizeUniv was causing non-termination and inhabitation of Size< 0.
+
+{-# OPTIONS --sized-types #-}
+
+open import Agda.Primitive
+open import Agda.Builtin.Size
+
+data ⊥ : Set where
+
+False : SizeUniv
+False = (X : SizeUniv) → X
+
+-- Should fail.
+
+-- Expected error:
+-- Setω != SizeUniv
+-- when checking that the expression (X : SizeUniv) → X has type SizeUniv
+
+
+℘ : SizeUniv → SizeUniv
+℘ S = S → SizeUniv
+
+U : SizeUniv
+U = ∀ (X : SizeUniv) → (℘ (℘ X) → X) → ℘ (℘ X)
+
+τ : ℘ (℘ U) → U
+τ t = λ X f p → t (λ x → p (f (x X f)))
+
+σ : U → ℘ (℘ U)
+σ s = s U τ
+
+Δ : ℘ U
+Δ y = (∀ p → σ y p → p (τ (σ y))) → False
+
+Ω : U
+Ω = τ (λ p → (∀ x → σ x p → p x))
+
+R : ∀ p → (∀ x → σ x p → p x) → p Ω
+R _ 𝟙 = 𝟙 Ω (λ x → 𝟙 (τ (σ x)))
+
+M : ∀ x → σ x Δ → Δ x
+M _ 𝟚 𝟛 = 𝟛 Δ 𝟚 (λ p → 𝟛 (λ y → p (τ (σ y))))
+
+L : (∀ p → (∀ x → σ x p → p x) → p Ω) → False
+L 𝟘 = 𝟘 Δ M (λ p → 𝟘 (λ y → p (τ (σ y))))
+
+false : False
+false = L R
+
+not-true : ∀ i → Size< i
+not-true i = false (Size< i)
+
+data Empty (i : Size) : Set where
+  emp : ∀{j : Size< i} → Empty j → Empty i
+
+empty : ∀ i → Empty i
+empty i = empty (false (Size< i))
+
+{-
+
+-- -}
+
+
+-- data Eq {ℓ} (A : Set ℓ) (x : A) : A → Set ℓ where
+--   refl : Eq A x x
+
+-- -}
+-- -}
+-- -}
+-- -}

--- a/test/Fail/Issue5891.agda
+++ b/test/Fail/Issue5891.agda
@@ -8,6 +8,9 @@ open import Agda.Builtin.Size
 
 data ⊥ : Set where
 
+-- Original exploit:
+-- data False : SizeUniv where
+
 False : SizeUniv
 False = (X : SizeUniv) → X
 

--- a/test/Fail/Issue5891.err
+++ b/test/Fail/Issue5891.err
@@ -1,0 +1,4 @@
+Issue5891.agda:12,9-27
+Setω != SizeUniv
+when checking that the expression (X : SizeUniv) → X has type
+SizeUniv

--- a/test/Fail/Issue5891.err
+++ b/test/Fail/Issue5891.err
@@ -1,4 +1,4 @@
-Issue5891.agda:15,9-27
+Issue5891.agda:16,9-27
 Setω != SizeUniv
 when checking that the expression (X : SizeUniv) → X has type
 SizeUniv

--- a/test/Fail/Issue5891.err
+++ b/test/Fail/Issue5891.err
@@ -1,4 +1,4 @@
-Issue5891.agda:12,9-27
+Issue5891.agda:15,9-27
 Setω != SizeUniv
 when checking that the expression (X : SizeUniv) → X has type
 SizeUniv

--- a/test/Fail/Issue5891DataInIUniv.agda
+++ b/test/Fail/Issue5891DataInIUniv.agda
@@ -1,0 +1,20 @@
+-- Andreas, Ulf, 2022-05-06, AIM XXXV
+-- Make sure you cannot trick Agda into admitting data types in IUniv.
+-- The previous check let this exploit through.
+-- Note: I : IUniv : SSet₁
+
+open import Agda.Primitive.Cubical
+
+mutual
+  Univ = _
+  data False : Univ where
+
+  I' : Univ
+  I' = I
+
+-- Should fail.
+
+-- Error:
+-- The universe _6 of False
+-- is unresolved, thus does not permit data or record declarations
+-- when checking the definition of False

--- a/test/Fail/Issue5891DataInIUniv.err
+++ b/test/Fail/Issue5891DataInIUniv.err
@@ -1,4 +1,4 @@
 Issue5891DataInIUniv.agda:10,8-13
-The universe _6 of False
-is unresolved, thus does not permit data or record declarations
+The universe IUniv of False
+does not admit data or record declarations
 when checking the definition of False

--- a/test/Fail/Issue5891DataInIUniv.err
+++ b/test/Fail/Issue5891DataInIUniv.err
@@ -1,0 +1,4 @@
+Issue5891DataInIUniv.agda:10,8-13
+The universe _6 of False
+is unresolved, thus does not permit data or record declarations
+when checking the definition of False

--- a/test/Fail/LargeIndicesWithoutK.err
+++ b/test/Fail/LargeIndicesWithoutK.err
@@ -1,3 +1,4 @@
-LargeIndicesWithoutK.agda:4,6-15
+LargeIndicesWithoutK.agda:5,3-6
 Set a is not less or equal than Set
-when checking the definition of Singleton
+when checking that the type (x : A) → Singleton x of the
+constructor [_] fits in the sort Set of the datatype.

--- a/test/Succeed/Issue2290.agda
+++ b/test/Succeed/Issue2290.agda
@@ -6,7 +6,7 @@ postulate
   F : Set → Set
 
 mutual
-  data D : A → _ where
+  data D : A → Set _ where
   FDa = F (D a)
 
 -- ERROR WAS:
@@ -15,5 +15,5 @@ mutual
 -- Should pass.
 
 mutual
-  data E : (x : A) → _ where
+  data E : (x : A) → Set _ where
   FEa = F (E a)

--- a/test/Succeed/Issue2290.agda
+++ b/test/Succeed/Issue2290.agda
@@ -6,7 +6,7 @@ postulate
   F : Set → Set
 
 mutual
-  data D : A → Set _ where
+  data D : A → _ where
   FDa = F (D a)
 
 -- ERROR WAS:
@@ -15,5 +15,5 @@ mutual
 -- Should pass.
 
 mutual
-  data E : (x : A) → Set _ where
+  data E : (x : A) → _ where
   FEa = F (E a)

--- a/test/Succeed/Issue5891DataOfPiSort.agda
+++ b/test/Succeed/Issue5891DataOfPiSort.agda
@@ -1,0 +1,27 @@
+-- AIM XXXV, 2022-05-06, issue #5891.
+-- When checking that the sort of a data type admits data definitions
+-- (checkDataSort), we need to handle the case of PiSort.
+
+mutual
+  Univ1 = _
+  Univ2 = _
+  Univ3 = _
+
+  postulate
+    A1 : Univ1
+    A2 : Univ2
+
+  A : Univ3
+  A = A1 → A2
+
+  -- This demonstrates that the sort of a data types can be a PiSort
+  -- (temporarily, until further information becomes available later):
+  data Empty : Univ3 where
+
+  _ : Univ1
+  _ = Set
+
+  _ : Univ2
+  _ = Set
+
+-- Should succeed.


### PR DESCRIPTION
More robust check that data cannot live in `IUniv`, `SizeUniv`,…

There was a check for `IUniv` but this could be worked around with sort metas.
There was no check for `SizeUniv` nor `LockUniv`.

See also:
- #5891