### PR TITLE
Fix #5728: proper error on misplaced ellipsis rather than internal error

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -482,7 +482,10 @@ insertInspects ps = \case
   A.LHSWith core wps [] ->
     let ps' = map (fmap $ fmap patOfName) ps in
     A.LHSWith core (insertIn ps' wps) []
-  _ -> __IMPOSSIBLE__
+  -- Andreas, AIM XXXV, 2022-05-09, issue #5728:
+  -- Cases other than LHSWith actually do not make sense, but let them
+  -- through to get a proper error later.
+  lhs -> lhs
 
   where
 

--- a/test/Fail/Issue5728.agda
+++ b/test/Fail/Issue5728.agda
@@ -1,0 +1,11 @@
+-- Andreas, AIM XXXV, 2022-05-09, issue #5728
+-- Give a proper error rather than crashing.
+
+test : Set
+test with Set
+...
+
+-- This used to be an internal error.
+-- Expected error now:
+-- The right-hand side can only be omitted if there is an absurd
+-- pattern, () or {}, in the left-hand side.

--- a/test/Fail/Issue5728.err
+++ b/test/Fail/Issue5728.err
@@ -1,0 +1,5 @@
+Issue5728.agda:6,1-4
+The right-hand side can only be omitted if there is an absurd
+pattern, () or {}, in the left-hand side.
+when checking that the clause Issue5728.with-4 has type
+(w : Set₁) → w


### PR DESCRIPTION
Fix #5728: proper error on misplaced ellipsis rather than internal error.

This does not bring back the more precise error of Agda-2.6.1, but it gives a comprehensible error (rather than crashing).