### PR TITLE
Update installation instructions on Ubuntu using apt

### DIFF
--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -246,6 +246,12 @@ The standard library is available in Debian and Ubuntu from Lucid onwards. To in
 
   apt-get install agda-stdlib
 
+You may need to install the main agda package on Ubuntu as well
+
+.. code-block:: bash
+
+  apt-get install agda
+
 More information:
 
 * `Agda (Debian) <https://tracker.debian.org/pkg/agda>`_


### PR DESCRIPTION
Only apt installing agda-mode and agda-stdlib on my machine didn't work, I had to install agda as well.
Adding this to the documentation.

It may well be that this is needed on versions other than Ubuntu 20.
It also might be the case that I didn't need to install agda as well, some other thing was needed but not documented.