### PR TITLE
Add 4 reflection primitives of the form `ask*` and `with*`

### DIFF
--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -486,6 +486,21 @@ following primitive operations::
     -- to normalise (or not) their results. The default behaviour is no
     -- normalisation.
     withNormalisation : ∀ {a} {A : Set a} → Bool → TC A → TC A
+    askNormalisation  : TC Bool
+
+    -- If 'true', makes the following primitives to reconstruct hidden arguments:
+    -- getDefinition, normalise, reduce, inferType, checkType and getContext
+    withReconstructed : ∀ {a} {A : Set a} → Bool → TC A → TC A
+    askReconstructed  : TC Bool
+
+    -- Whether implicit arguments at the end should be turned into metavariables
+    withExpandLast : ∀ {a} {A : Set a} → Bool → TC A → TC A
+    askExpandLast  : TC Bool
+
+    -- White/blacklist specific definitions for reduction while executing the TC computation
+    -- 'true' for whitelist, 'false' for blacklist
+    withReduceDefs : ∀ {a} {A : Set a} → (Σ Bool λ _ → List Name) → TC A → TC A
+    askReduceDefs  : TC (Σ Bool λ _ → List Name)
 
     -- Prints the third argument to the debug buffer in Emacs
     -- if the verbosity level (set by the -v flag to Agda)
@@ -496,16 +511,6 @@ following primitive operations::
 
     -- Return the formatted string of the argument using the internal pretty printer.
     formatErrorParts : List ErrorPart → TC String
-
-    -- Only allow reduction of specific definitions while executing the TC computation
-    onlyReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A
-
-    -- Don't allow reduction of specific definitions while executing the TC computation
-    dontReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A
-
-    -- Makes the following primitives to reconstruct hidden parameters:
-    -- getDefinition, normalise, reduce, inferType, checkType and getContext
-    withReconstructed : ∀ {a} {A : Set a} → TC A → TC A
 
     -- Fail if the given computation gives rise to new, unsolved
     -- "blocking" constraints.
@@ -545,9 +550,14 @@ following primitive operations::
   {-# BUILTIN AGDATCMCOMMIT                     commitTC                   #-}
   {-# BUILTIN AGDATCMISMACRO                    isMacro                    #-}
   {-# BUILTIN AGDATCMWITHNORMALISATION          withNormalisation          #-}
+  {-# BUILTIN AGDATCMWITHRECONSTRUCTED          withReconstructed          #-}
+  {-# BUILTIN AGDATCMWITHEXPANDLAST             withExpandLast             #-}
+  {-# BUILTIN AGDATCMWITHREDUCEDEFS             withReduceDefs             #-}
+  {-# BUILTIN AGDATCMASKNORMALISATION           askNormalisation           #-}
+  {-# BUILTIN AGDATCMASKRECONSTRUCTED           askReconstructed           #-}
+  {-# BUILTIN AGDATCMASKEXPANDLAST              askExpandLast              #-}
+  {-# BUILTIN AGDATCMASKREDUCEDEFS              askReduceDefs              #-}
   {-# BUILTIN AGDATCMDEBUGPRINT                 debugPrint                 #-}
-  {-# BUILTIN AGDATCMONLYREDUCEDEFS             onlyReduceDefs             #-}
-  {-# BUILTIN AGDATCMDONTREDUCEDEFS             dontReduceDefs             #-}
   {-# BUILTIN AGDATCMNOCONSTRAINTS              noConstraints              #-}
   {-# BUILTIN AGDATCMRUNSPECULATIVE             runSpeculative             #-}
   {-# BUILTIN AGDATCMGETINSTANCES               getInstances               #-}

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -296,22 +296,22 @@ postulate
   pragmaForeign    : String → String → TC ⊤
   pragmaCompile    : String → Name → String → TC ⊤
 
-  -- If the argument is 'true' makes the following primitives also normalise
+  -- If 'true', makes the following primitives also normalise
   -- their results: inferType, checkType, quoteTC, getType, and getContext
   withNormalisation : ∀ {a} {A : Set a} → Bool → TC A → TC A
   askNormalisation  : TC Bool
 
-  -- Makes the following primitives to reconstruct hidden arguments
+  -- If 'true', makes the following primitives to reconstruct hidden arguments:
   -- getDefinition, normalise, reduce, inferType, checkType and getContext
   withReconstructed : ∀ {a} {A : Set a} → Bool → TC A → TC A
   askReconstructed  : TC Bool
 
-  -- Whether implicit arguments at the end should be turned into metas
+  -- Whether implicit arguments at the end should be turned into metavariables
   withExpandLast : ∀ {a} {A : Set a} → Bool → TC A → TC A
   askExpandLast  : TC Bool
 
   -- White/blacklist specific definitions for reduction while executing the TC computation
-  -- true for whitelist, false for blacklist
+  -- 'true' for whitelist, 'false' for blacklist
   withReduceDefs : ∀ {a} {A : Set a} → (Σ Bool λ _ → List Name) → TC A → TC A
   askReduceDefs  : TC (Σ Bool λ _ → List Name)
 

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -299,21 +299,26 @@ postulate
   -- If the argument is 'true' makes the following primitives also normalise
   -- their results: inferType, checkType, quoteTC, getType, and getContext
   withNormalisation : ∀ {a} {A : Set a} → Bool → TC A → TC A
+  askNormalisation  : TC Bool
 
   -- Makes the following primitives to reconstruct hidden arguments
   -- getDefinition, normalise, reduce, inferType, checkType and getContext
-  withReconstructed : ∀ {a} {A : Set a} → TC A → TC A
+  withReconstructed : ∀ {a} {A : Set a} → Bool → TC A → TC A
+  askReconstructed  : TC Bool
+
+  -- Whether implicit arguments at the end should be turned into metas
+  withExpandLast : ∀ {a} {A : Set a} → Bool → TC A → TC A
+  askExpandLast  : TC Bool
+
+  -- White/blacklist specific definitions for reduction while executing the TC computation
+  -- true for whitelist, false for blacklist
+  withReduceDefs : ∀ {a} {A : Set a} → (Σ Bool λ _ → List Name) → TC A → TC A
+  askReduceDefs  : TC (Σ Bool λ _ → List Name)
 
   formatErrorParts : List ErrorPart → TC String
   -- Prints the third argument if the corresponding verbosity level is turned
   -- on (with the -v flag to Agda).
   debugPrint : String → Nat → List ErrorPart → TC ⊤
-
-  -- Only allow reduction of specific definitions while executing the TC computation
-  onlyReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A
-
-  -- Don't allow reduction of specific definitions while executing the TC computation
-  dontReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A
 
   -- Fail if the given computation gives rise to new, unsolved
   -- "blocking" constraints.
@@ -358,11 +363,15 @@ postulate
 {-# BUILTIN AGDATCMPRAGMAFOREIGN              pragmaForeign              #-}
 {-# BUILTIN AGDATCMPRAGMACOMPILE              pragmaCompile              #-}
 {-# BUILTIN AGDATCMWITHNORMALISATION          withNormalisation          #-}
+{-# BUILTIN AGDATCMWITHRECONSTRUCTED          withReconstructed          #-}
+{-# BUILTIN AGDATCMWITHEXPANDLAST             withExpandLast             #-}
+{-# BUILTIN AGDATCMWITHREDUCEDEFS             withReduceDefs             #-}
+{-# BUILTIN AGDATCMASKNORMALISATION           askNormalisation           #-}
+{-# BUILTIN AGDATCMASKRECONSTRUCTED           askReconstructed           #-}
+{-# BUILTIN AGDATCMASKEXPANDLAST              askExpandLast              #-}
+{-# BUILTIN AGDATCMASKREDUCEDEFS              askReduceDefs              #-}
 {-# BUILTIN AGDATCMFORMATERRORPARTS           formatErrorParts           #-}
 {-# BUILTIN AGDATCMDEBUGPRINT                 debugPrint                 #-}
-{-# BUILTIN AGDATCMONLYREDUCEDEFS             onlyReduceDefs             #-}
-{-# BUILTIN AGDATCMDONTREDUCEDEFS             dontReduceDefs             #-}
-{-# BUILTIN AGDATCMWITHRECONSPARAMS           withReconstructed          #-}
 {-# BUILTIN AGDATCMNOCONSTRAINTS              noConstraints              #-}
 {-# BUILTIN AGDATCMRUNSPECULATIVE             runSpeculative             #-}
 {-# BUILTIN AGDATCMGETINSTANCES               getInstances               #-}
@@ -400,10 +409,14 @@ postulate
 {-# COMPILE JS pragmaForeign     = _ => _ =>           undefined #-}
 {-# COMPILE JS pragmaCompile     = _ => _ => _ =>      undefined #-}
 {-# COMPILE JS withNormalisation = _ => _ => _ => _ => undefined #-}
-{-# COMPILE JS withReconstructed = _ => _ => _ =>      undefined #-}
+{-# COMPILE JS withReconstructed = _ => _ => _ => _ => undefined #-}
+{-# COMPILE JS withExpandLast    = _ => _ => _ => _ => undefined #-}
+{-# COMPILE JS withReduceDefs    = _ => _ => _ => _ => undefined #-}
+{-# COMPILE JS askNormalisation  =                     undefined #-}
+{-# COMPILE JS askReconstructed  =                     undefined #-}
+{-# COMPILE JS askExpandLast     =                     undefined #-}
+{-# COMPILE JS askReduceDefs     =                     undefined #-}
 {-# COMPILE JS debugPrint        = _ => _ => _ =>      undefined #-}
-{-# COMPILE JS onlyReduceDefs    = _ => _ => _ => _ => undefined #-}
-{-# COMPILE JS dontReduceDefs    = _ => _ => _ => _ => undefined #-}
 {-# COMPILE JS noConstraints     = _ => _ => _ =>      undefined #-}
 {-# COMPILE JS runSpeculative    = _ => _ => _ =>      undefined #-}
 {-# COMPILE JS getInstances      = _ =>                undefined #-}

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -449,9 +449,9 @@ private
   combineReduceDefs (true  , defs₁) (false , defs₂) = (true  , filter (_∉ defs₂) defs₁)
   combineReduceDefs (false , defs₁) (false , defs₂) = (false , defs₁ ++ defs₂)
 
-{-# WARNING_ON_USAGE onlyReduceDefs "DEPRECATED: Use `withReduceDefs` instead of `onlyReduceDefs`" #-}
-{-# WARNING_ON_USAGE dontReduceDefs "DEPRECATED: Use `withReduceDefs` instead of `dontReduceDefs`" #-}
-
 onlyReduceDefs dontReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → TC A
 onlyReduceDefs defs x = bindTC askReduceDefs (λ exDefs → withReduceDefs (combineReduceDefs (true  , defs) exDefs) x)
 dontReduceDefs defs x = bindTC askReduceDefs (λ exDefs → withReduceDefs (combineReduceDefs (false , defs) exDefs) x)
+
+{-# WARNING_ON_USAGE onlyReduceDefs "DEPRECATED: Use `withReduceDefs` instead of `onlyReduceDefs`" #-}
+{-# WARNING_ON_USAGE dontReduceDefs "DEPRECATED: Use `withReduceDefs` instead of `dontReduceDefs`" #-}

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -278,11 +278,15 @@ ghcPreCompile flags = do
       , builtinAgdaTCMCommit
       , builtinAgdaTCMIsMacro
       , builtinAgdaTCMWithNormalisation
-      , builtinAgdaTCMWithReconsParams
+      , builtinAgdaTCMWithReconstructed
+      , builtinAgdaTCMWithExpandLast
+      , builtinAgdaTCMWithReduceDefs
+      , builtinAgdaTCMAskNormalisation
+      , builtinAgdaTCMAskReconstructed
+      , builtinAgdaTCMAskExpandLast
+      , builtinAgdaTCMAskReduceDefs
       , builtinAgdaTCMFormatErrorParts
       , builtinAgdaTCMDebugPrint
-      , builtinAgdaTCMOnlyReduceDefs
-      , builtinAgdaTCMDontReduceDefs
       , builtinAgdaTCMNoConstraints
       , builtinAgdaTCMRunSpeculative
       , builtinAgdaTCMExec

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -70,8 +70,10 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinAgdaTCMQuoteTerm, builtinAgdaTCMUnquoteTerm, builtinAgdaTCMQuoteOmegaTerm,
   builtinAgdaTCMBlockOnMeta, builtinAgdaTCMCommit, builtinAgdaTCMIsMacro,
   builtinAgdaTCMFormatErrorParts, builtinAgdaTCMDebugPrint,
-  builtinAgdaTCMWithNormalisation, builtinAgdaTCMWithReconsParams,
-  builtinAgdaTCMOnlyReduceDefs, builtinAgdaTCMDontReduceDefs,
+  builtinAgdaTCMWithNormalisation, builtinAgdaTCMWithReconstructed,
+  builtinAgdaTCMWithExpandLast, builtinAgdaTCMWithReduceDefs,
+  builtinAgdaTCMAskNormalisation, builtinAgdaTCMAskReconstructed,
+  builtinAgdaTCMAskExpandLast, builtinAgdaTCMAskReduceDefs,
   builtinAgdaTCMNoConstraints,
   builtinAgdaTCMRunSpeculative,
   builtinAgdaTCMExec,
@@ -277,11 +279,15 @@ builtinAgdaTCMUnquoteTerm                = "AGDATCMUNQUOTETERM"
 builtinAgdaTCMQuoteOmegaTerm             = "AGDATCMQUOTEOMEGATERM"
 builtinAgdaTCMIsMacro                    = "AGDATCMISMACRO"
 builtinAgdaTCMWithNormalisation          = "AGDATCMWITHNORMALISATION"
-builtinAgdaTCMWithReconsParams           = "AGDATCMWITHRECONSPARAMS"
+builtinAgdaTCMWithReconstructed          = "AGDATCMWITHRECONSTRUCTED"
+builtinAgdaTCMWithExpandLast             = "AGDATCMWITHEXPANDLAST"
+builtinAgdaTCMWithReduceDefs             = "AGDATCMWITHREDUCEDEFS"
+builtinAgdaTCMAskNormalisation           = "AGDATCMASKNORMALISATION"
+builtinAgdaTCMAskReconstructed           = "AGDATCMASKRECONSTRUCTED"
+builtinAgdaTCMAskExpandLast              = "AGDATCMASKEXPANDLAST"
+builtinAgdaTCMAskReduceDefs              = "AGDATCMASKREDUCEDEFS"
 builtinAgdaTCMFormatErrorParts           = "AGDATCMFORMATERRORPARTS"
 builtinAgdaTCMDebugPrint                 = "AGDATCMDEBUGPRINT"
-builtinAgdaTCMOnlyReduceDefs             = "AGDATCMONLYREDUCEDEFS"
-builtinAgdaTCMDontReduceDefs             = "AGDATCMDONTREDUCEDEFS"
 builtinAgdaTCMNoConstraints              = "AGDATCMNOCONSTRAINTS"
 builtinAgdaTCMRunSpeculative             = "AGDATCMRUNSPECULATIVE"
 builtinAgdaTCMExec                       = "AGDATCMEXEC"

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3872,13 +3872,13 @@ data ExpandHidden
   | ReallyDontExpandLast -- ^ Makes 'doExpandLast' have no effect. Used to avoid implicit insertion of arguments to metavariables.
   deriving (Eq, Generic)
 
-isDontExpandLast :: ExpandHidden -> Bool
-isDontExpandLast ExpandLast           = False
-isDontExpandLast DontExpandLast       = True
-isDontExpandLast ReallyDontExpandLast = True
-
 isExpandLast :: ExpandHidden -> Bool
-isExpandLast = not . isDontExpandLast
+isExpandLast ExpandLast           = True
+isExpandLast DontExpandLast       = False
+isExpandLast ReallyDontExpandLast = False
+
+isDontExpandLast :: ExpandHidden -> Bool
+isDontExpandLast = not . isExpandLast
 
 toExpandLast :: Bool -> ExpandHidden
 toExpandLast True  = ExpandLast

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -41,7 +41,7 @@ import Data.Maybe
 import Data.Map (Map)
 import qualified Data.Map as Map -- hiding (singleton, null, empty)
 import Data.Sequence (Seq)
-import Data.Set (Set)
+import Data.Set (Set, toList, fromList)
 import qualified Data.Set as Set -- hiding (singleton, null, empty)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HMap
@@ -3031,16 +3031,13 @@ shouldReduceDef f = asksTC envReduceDefs <&> \case
   OnlyReduceDefs defs -> f `Set.member` defs
   DontReduceDefs defs -> not $ f `Set.member` defs
 
-instance Semigroup ReduceDefs where
-  OnlyReduceDefs qs1 <> OnlyReduceDefs qs2 = OnlyReduceDefs $ Set.intersection qs1 qs2
-  OnlyReduceDefs qs1 <> DontReduceDefs qs2 = OnlyReduceDefs $ Set.difference   qs1 qs2
-  DontReduceDefs qs1 <> OnlyReduceDefs qs2 = OnlyReduceDefs $ Set.difference   qs2 qs1
-  DontReduceDefs qs1 <> DontReduceDefs qs2 = DontReduceDefs $ Set.union        qs1 qs2
+toReduceDefs :: (Bool, [QName]) -> ReduceDefs
+toReduceDefs (True,  ns) = OnlyReduceDefs (Data.Set.fromList ns)
+toReduceDefs (False, ns) = DontReduceDefs (Data.Set.fromList ns)
 
-instance Monoid ReduceDefs where
-  mempty  = reduceAllDefs
-  mappend = (<>)
-
+fromReduceDefs :: ReduceDefs -> (Bool, [QName])
+fromReduceDefs (OnlyReduceDefs ns) = (True,  toList ns)
+fromReduceDefs (DontReduceDefs ns) = (False, toList ns)
 
 locallyReconstructed :: MonadTCEnv m => m a -> m a
 locallyReconstructed = locallyTC eReconstructed . const $ True
@@ -3735,6 +3732,9 @@ eHighlightingMethod f e = f (envHighlightingMethod e) <&> \ x -> e { envHighligh
 eExpandLast :: Lens' ExpandHidden TCEnv
 eExpandLast f e = f (envExpandLast e) <&> \ x -> e { envExpandLast = x }
 
+eExpandLastBool :: Lens' Bool TCEnv
+eExpandLastBool f e = f (isExpandLast $ envExpandLast e) <&> \ x -> e { envExpandLast = toExpandLast x }
+
 eAppDef :: Lens' (Maybe QName) TCEnv
 eAppDef f e = f (envAppDef e) <&> \ x -> e { envAppDef = x }
 
@@ -3746,6 +3746,9 @@ eAllowedReductions f e = f (envAllowedReductions e) <&> \ x -> e { envAllowedRed
 
 eReduceDefs :: Lens' ReduceDefs TCEnv
 eReduceDefs f e = f (envReduceDefs e) <&> \ x -> e { envReduceDefs = x }
+
+eReduceDefsPair :: Lens' (Bool, [QName]) TCEnv
+eReduceDefsPair f e = f (fromReduceDefs $ envReduceDefs e) <&> \ x -> e { envReduceDefs = toReduceDefs x }
 
 eReconstructed :: Lens' Bool TCEnv
 eReconstructed f e = f (envReconstructed e) <&> \ x -> e { envReconstructed = x }
@@ -3873,6 +3876,13 @@ isDontExpandLast :: ExpandHidden -> Bool
 isDontExpandLast ExpandLast           = False
 isDontExpandLast DontExpandLast       = True
 isDontExpandLast ReallyDontExpandLast = True
+
+isExpandLast :: ExpandHidden -> Bool
+isExpandLast = not . isDontExpandLast
+
+toExpandLast :: Bool -> ExpandHidden
+toExpandLast True  = ExpandLast
+toExpandLast False = DontExpandLast
 
 data CandidateKind
   = LocalCandidate

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -243,8 +243,10 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primAgdaTCMQuoteTerm, primAgdaTCMUnquoteTerm, primAgdaTCMQuoteOmegaTerm,
     primAgdaTCMBlockOnMeta, primAgdaTCMCommit, primAgdaTCMIsMacro,
     primAgdaTCMFormatErrorParts, primAgdaTCMDebugPrint,
-    primAgdaTCMWithNormalisation, primAgdaTCMWithReconsParams,
-    primAgdaTCMOnlyReduceDefs, primAgdaTCMDontReduceDefs,
+    primAgdaTCMWithNormalisation, primAgdaTCMWithReconstructed,
+    primAgdaTCMWithExpandLast, primAgdaTCMWithReduceDefs,
+    primAgdaTCMAskNormalisation, primAgdaTCMAskReconstructed,
+    primAgdaTCMAskExpandLast, primAgdaTCMAskReduceDefs,
     primAgdaTCMNoConstraints,
     primAgdaTCMRunSpeculative,
     primAgdaTCMExec,
@@ -446,11 +448,15 @@ primAgdaTCMBlockOnMeta                = getBuiltin builtinAgdaTCMBlockOnMeta
 primAgdaTCMCommit                     = getBuiltin builtinAgdaTCMCommit
 primAgdaTCMIsMacro                    = getBuiltin builtinAgdaTCMIsMacro
 primAgdaTCMWithNormalisation          = getBuiltin builtinAgdaTCMWithNormalisation
-primAgdaTCMWithReconsParams           = getBuiltin builtinAgdaTCMWithReconsParams
+primAgdaTCMWithReconstructed          = getBuiltin builtinAgdaTCMWithReconstructed
+primAgdaTCMWithExpandLast             = getBuiltin builtinAgdaTCMWithExpandLast
+primAgdaTCMWithReduceDefs             = getBuiltin builtinAgdaTCMWithReduceDefs
+primAgdaTCMAskNormalisation           = getBuiltin builtinAgdaTCMAskNormalisation
+primAgdaTCMAskReconstructed           = getBuiltin builtinAgdaTCMAskReconstructed
+primAgdaTCMAskExpandLast              = getBuiltin builtinAgdaTCMAskExpandLast
+primAgdaTCMAskReduceDefs              = getBuiltin builtinAgdaTCMAskReduceDefs
 primAgdaTCMFormatErrorParts           = getBuiltin builtinAgdaTCMFormatErrorParts
 primAgdaTCMDebugPrint                 = getBuiltin builtinAgdaTCMDebugPrint
-primAgdaTCMOnlyReduceDefs             = getBuiltin builtinAgdaTCMOnlyReduceDefs
-primAgdaTCMDontReduceDefs             = getBuiltin builtinAgdaTCMDontReduceDefs
 primAgdaTCMNoConstraints              = getBuiltin builtinAgdaTCMNoConstraints
 primAgdaTCMRunSpeculative             = getBuiltin builtinAgdaTCMRunSpeculative
 primAgdaTCMExec                       = getBuiltin builtinAgdaTCMExec

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -388,11 +388,15 @@ coreBuiltins =
   , builtinAgdaTCMCommit                     |-> builtinPostulate (tTCM_ primUnit)
   , builtinAgdaTCMIsMacro                    |-> builtinPostulate (tqname --> tTCM_ primBool)
   , builtinAgdaTCMWithNormalisation          |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tbool --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
-  , builtinAgdaTCMWithReconsParams           |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+  , builtinAgdaTCMWithReconstructed          |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tbool --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+  , builtinAgdaTCMWithExpandLast             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tbool --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+  , builtinAgdaTCMWithReduceDefs             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ (tpair primLevelZero primLevelZero tbool (tlist tqname)) --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+  , builtinAgdaTCMAskNormalisation           |-> builtinPostulate (tTCM_ (unEl <$> tbool))
+  , builtinAgdaTCMAskReconstructed           |-> builtinPostulate (tTCM_ (unEl <$> tbool))
+  , builtinAgdaTCMAskExpandLast              |-> builtinPostulate (tTCM_ (unEl <$> tbool))
+  , builtinAgdaTCMAskReduceDefs              |-> builtinPostulate (tTCM_ (unEl <$> (tpair primLevelZero primLevelZero tbool (tlist tqname))))
   , builtinAgdaTCMFormatErrorParts           |-> builtinPostulate (tlist terrorpart --> tTCM_ primString)
   , builtinAgdaTCMDebugPrint                 |-> builtinPostulate (tstring --> tnat --> tlist terrorpart --> tTCM_ primUnit)
-  , builtinAgdaTCMOnlyReduceDefs             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tlist tqname --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
-  , builtinAgdaTCMDontReduceDefs             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tlist tqname --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
 
   , builtinAgdaTCMNoConstraints              |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMRunSpeculative             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $

--- a/test/Succeed/Issue5075.agda
+++ b/test/Succeed/Issue5075.agda
@@ -1,3 +1,4 @@
+open import Agda.Builtin.Bool
 open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
 open import Agda.Builtin.Sigma
 open import Agda.Builtin.List
@@ -25,7 +26,7 @@ postulate
 macro
   rtest : Name → Term → TC ⊤
   rtest f a = do
-     (function (clause tel _ t ∷ [])) ← withReconstructed (getDefinition f) where
+     (function (clause tel _ t ∷ [])) ← withReconstructed true (getDefinition f) where
         _ → typeError (strErr "ERROR" ∷ [])
      t ← inContext (reverse tel) (normalise t)
      quoteTC t >>= unify a

--- a/test/Succeed/Issue5469.agda
+++ b/test/Succeed/Issue5469.agda
@@ -1,3 +1,5 @@
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Sigma
 open import Agda.Builtin.List
 open import Agda.Builtin.Nat
 open import Agda.Builtin.Unit
@@ -10,6 +12,6 @@ make2 hole = bindTC (normalise (def (quote _+_) (vArg (lit (nat 1)) ∷ vArg (li
 
 macro
   tester : Term → TC ⊤
-  tester hole = onlyReduceDefs (quote _+_ ∷ []) (make2 hole)
+  tester hole = withReduceDefs (true , (quote _+_ ∷ [])) (make2 hole)
 
 _ = tester

--- a/test/Succeed/Issue5699c.agda
+++ b/test/Succeed/Issue5699c.agda
@@ -3,6 +3,7 @@
 open import Agda.Builtin.List
 open import Agda.Builtin.Nat
 open import Agda.Builtin.Unit
+open import Agda.Builtin.Bool
 open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
 
 data D (A : Set) : Set where
@@ -13,7 +14,7 @@ f A (c x) = x
 
 macro
   m : Term → TC ⊤
-  m hole = withReconstructed do
+  m hole = withReconstructed true do
     qf ← quoteTC (f Nat (c 0))
     uqf ← unquoteTC {A = Nat} qf
     returnTC _

--- a/test/Succeed/Issue5699d.agda
+++ b/test/Succeed/Issue5699d.agda
@@ -3,6 +3,7 @@
 open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
 open import Agda.Builtin.Unit
 open import Agda.Builtin.Nat
+open import Agda.Builtin.Bool
 
 data D : Nat → Set where
   c : (n : Nat) → D n → D n
@@ -12,7 +13,7 @@ c' = c
 macro
   m : Term → TC ⊤
   m a = do
-     _ ← withReconstructed (getDefinition (quote c'))
+     _ ← withReconstructed true (getDefinition (quote c'))
      returnTC _
 
 test : Term

--- a/test/Succeed/Issue6205.agda
+++ b/test/Succeed/Issue6205.agda
@@ -1,6 +1,7 @@
 
 open import Agda.Primitive
 open import Agda.Builtin.Unit
+open import Agda.Builtin.Bool
 open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
 
 record Test (X : Set) : Set₁ where
@@ -14,7 +15,7 @@ postulate
 macro
   myMacro : Term → TC ⊤
   myMacro hole = do
-    ty ← withReconstructed (getType (quote F))
+    ty ← withReconstructed true (getType (quote F))
     unify hole ty
 
 test = myMacro

--- a/test/Succeed/ReduceDefs.agda
+++ b/test/Succeed/ReduceDefs.agda
@@ -1,3 +1,5 @@
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Sigma
 open import Agda.Builtin.Unit
 open import Agda.Builtin.Nat
 open import Agda.Builtin.List
@@ -10,7 +12,7 @@ macro
   macro₁ : Term -> TC ⊤
   macro₁ goal = do
     u   ← quoteTC ((1 + 2) - 3)
-    u'  ← onlyReduceDefs (quote _+_ ∷ []) (normalise u)
+    u'  ← withReduceDefs (true , (quote _+_ ∷ [])) (normalise u)
     qu' ← quoteTC u'
     unify qu' goal
 
@@ -24,7 +26,7 @@ macro
   macro₂ : Term -> TC ⊤
   macro₂ goal = do
     u   ← quoteTC ((1 - 2) + 3)
-    u'  ← dontReduceDefs (quote _+_ ∷ []) (normalise u)
+    u'  ← withReduceDefs (false , (quote _+_ ∷ [])) (normalise u)
     qu' ← quoteTC u'
     unify qu' goal
 

--- a/test/Succeed/normalise-bug.agda
+++ b/test/Succeed/normalise-bug.agda
@@ -1,3 +1,4 @@
+open import Agda.Builtin.Bool
 open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
 open import Agda.Builtin.Sigma
 open import Agda.Builtin.List
@@ -28,9 +29,9 @@ data Vec (A : Set) : Nat → Set where
 macro
   ntest : Name → Term → TC ⊤
   ntest f a = do
-     (function te@(clause tel _ t ∷ [])) ← withReconstructed $ getDefinition f where
+     (function te@(clause tel _ t ∷ [])) ← withReconstructed true $ getDefinition f where
         _ → typeError $ strErr "ERROR" ∷ []
-     t ← withReconstructed $ inContext (reverse tel) $ normalise t
+     t ← withReconstructed true $ inContext (reverse tel) $ normalise t
      quoteTC t >>= unify a
 
 -- A record with parameters.

--- a/test/Succeed/recons-tele.agda
+++ b/test/Succeed/recons-tele.agda
@@ -1,3 +1,4 @@
+open import Agda.Builtin.Bool
 open import Agda.Builtin.Nat
 open import Agda.Builtin.Unit
 open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
@@ -51,9 +52,9 @@ macro
   z : Name → Term → TC ⊤
   z n hole = do
     (function (clause tel ps t ∷ [])) ←
-      withReconstructed $ getDefinition n
+      withReconstructed true $ getDefinition n
       where _ → quoteTC "ERROR" >>= unify hole
-    t ← withReconstructed
+    t ← withReconstructed true
         $ inContext (reverse tel)
         $ normalise t
     quoteTC t >>= unify hole
@@ -71,9 +72,9 @@ test₁ = refl
 macro
   q : Name → Term → TC ⊤
   q n hole = do
-    t ← withReconstructed $
+    t ← withReconstructed true $
         getType n
-    t ← withReconstructed $
+    t ← withReconstructed true $
         normalise t
     quoteTC t >>= unify hole
 

--- a/test/Succeed/recons-with-reducedefs.agda
+++ b/test/Succeed/recons-with-reducedefs.agda
@@ -1,3 +1,4 @@
+open import Agda.Builtin.Bool
 open import Agda.Builtin.Nat
 open import Agda.Builtin.Unit
 open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
@@ -18,9 +19,9 @@ d = record { fld = 5 }
 macro
   x : Term → TC ⊤
   x hole = do
-      (function (clause tel ps t ∷ [])) ← withReconstructed (getDefinition (quote d))
+      (function (clause tel ps t ∷ [])) ← withReconstructed true (getDefinition (quote d))
         where _ → quoteTC "ERROR" >>= unify hole
-      a ← withReconstructed (dontReduceDefs (quote lzero ∷ []) (normalise t))
+      a ← withReconstructed true (withReduceDefs (false , (quote lzero ∷ [])) (normalise t))
       quoteTC a >>= unify hole
 
 -- If we were to consider suppressed reduction of lzero, we end up with
@@ -52,10 +53,10 @@ bar x = foo (foo (x))
 macro
   y : Term → TC ⊤
   y hole = do
-      (function (clause tel ps t ∷ [])) ← withReconstructed (dontReduceDefs (quote foo ∷ []) (getDefinition (quote bar)))
+      (function (clause tel ps t ∷ [])) ← withReconstructed true (withReduceDefs (false , (quote foo ∷ [])) (getDefinition (quote bar)))
         where _ → quoteTC "ERROR" >>= unify hole
       t ← inContext (reverse tel)
-          (withReconstructed (dontReduceDefs (quote foo ∷ []) (normalise t)))
+          (withReconstructed true (withReduceDefs (false , (quote foo ∷ [])) (normalise t)))
       quoteTC t >>= unify hole
 
 test₂ : y ≡ def (quote foo) (arg _ (def (quote foo) _) ∷ [])

--- a/test/Succeed/test-recons.agda
+++ b/test/Succeed/test-recons.agda
@@ -1,3 +1,4 @@
+open import Agda.Builtin.Bool
 open import Agda.Builtin.Nat
 open import Agda.Builtin.Unit
 open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
@@ -50,7 +51,7 @@ macro
 
   def-recons : Name → Term → TC ⊤
   def-recons n hole = do
-    d ← withReconstructed (getDefinition n)
+    d ← withReconstructed true (getDefinition n)
     l ← get-len d
     unify hole l
 
@@ -58,10 +59,10 @@ macro
   def-normR : Name → Term → TC ⊤
   def-normR n hole = do
     (function (clause tel ps t ∷ [])) ←
-      withReconstructed (getDefinition n)
+      withReconstructed true (getDefinition n)
       where _ → quoteTC "ERROR" >>= unify hole
     t ← inContext (reverse tel)
-        (withReconstructed (normalise t))
+        (withReconstructed true (normalise t))
     let d = function (clause tel ps t ∷ [])
     get-len d >>= unify hole
 
@@ -69,9 +70,9 @@ macro
   def-redR : Name → Term → TC ⊤
   def-redR n hole = do
     (function (clause tel ps t ∷ [])) ←
-      withReconstructed (getDefinition n)
+      withReconstructed true (getDefinition n)
       where _ → quoteTC "ERROR" >>= unify hole
-    t ← inContext (reverse tel) (withReconstructed (reduce t))
+    t ← inContext (reverse tel) (withReconstructed true (reduce t))
     let d = function (clause tel ps t ∷ [])
     get-len d >>= unify hole
 
@@ -98,7 +99,7 @@ macro
   get-ctx n hole = do
     t ← getType n
     let c = pictx t
-    c ← withReconstructed
+    c ← withReconstructed true
         (inContext (reverse c) getContext)
     quoteTC c >>= unify hole
 
@@ -122,7 +123,7 @@ macro
   chk-type hole = do
     T ← quoteTC (NotAVec Nat 5)
     t ← quoteTC (mk {X = Nat} {y = 5})
-    (con _ (_ ∷ arg _ t ∷ [])) ← withReconstructed (checkType t T)
+    (con _ (_ ∷ arg _ t ∷ [])) ← withReconstructed true (checkType t T)
       where _ → quoteTC "ERROR" >>= unify hole
     quoteTC t >>= unify hole
 
@@ -137,9 +138,9 @@ q = refl
 macro
   inf-type₁ : Term → TC ⊤
   inf-type₁ hole = do
-    (function (clause _ _ b ∷ [])) ← withReconstructed (getDefinition (quote q))
+    (function (clause _ _ b ∷ [])) ← withReconstructed true (getDefinition (quote q))
       where _ → quoteTC "ERROR" >>= unify hole
-    (def _ (l ∷ L ∷ e₁ ∷ e₂ ∷ [])) ← withReconstructed  (inferType b)
+    (def _ (l ∷ L ∷ e₁ ∷ e₂ ∷ [])) ← withReconstructed true (inferType b)
       where _ → quoteTC "ERROR" >>= unify hole
     (arg _ (con _ (_ ∷ (arg _ N) ∷ []))) ← returnTC e₁
       where _ → quoteTC "ERROR" >>= unify hole
@@ -161,9 +162,9 @@ eq = refl
 macro
   inf-type₂ : Term → TC ⊤
   inf-type₂ hole = do
-    (function (clause _ _ b ∷ [])) ← withReconstructed (getDefinition (quote eq))
+    (function (clause _ _ b ∷ [])) ← withReconstructed true (getDefinition (quote eq))
       where _ → quoteTC "ERROR" >>= unify hole
-    (def _ (_ ∷ _ ∷ arg _ lhs ∷ _ ∷ [])) ← withReconstructed  (inferType b)
+    (def _ (_ ∷ _ ∷ arg _ lhs ∷ _ ∷ [])) ← withReconstructed true (inferType b)
       where _ → quoteTC "ERROR" >>= unify hole
     quoteTC lhs >>= unify hole
 


### PR DESCRIPTION
The asterisk ranges over Reconstructed, Normalisation, ExpandLast and
ReduceDefs. `withReconstructed` and `withNormalisation` replace their
old counterparts, and `onlyReduceDefs` and `dontReduceDefs` have been
removed.