### PR TITLE
Provenance of where modules in Internal syntax.

### DIFF
--- a/src/full/Agda/Auto/Auto.hs
+++ b/src/full/Agda/Auto/Auto.hs
@@ -382,12 +382,12 @@ auto ii rng argstr = liftTCM $ locallyTC eMakeCase (const True) $ do
             case cls' of
              Left{} -> stopWithMsg "No solution found"
              Right cls' -> do
-              cls'' <- forM cls' $ \ (I.Clause _ _ tel ps body t catchall exact recursive reachable ell) -> do
+              cls'' <- forM cls' $ \ (I.Clause _ _ tel ps body t catchall exact recursive reachable ell wm) -> do
                 withCurrentModule (AN.qnameModule def) $ do
                  -- Normalise the dot patterns
                  ps <- addContext tel $ normalise ps
                  body <- etaContract body
-                 fmap modifyAbstractClause $ inTopContext $ reify $ AN.QNamed def $ I.Clause noRange noRange tel ps body t catchall exact recursive reachable ell
+                 fmap modifyAbstractClause $ inTopContext $ reify $ AN.QNamed def $ I.Clause noRange noRange tel ps body t catchall exact recursive reachable ell wm
               moduleTel <- lookupSection (AN.qnameModule def)
               pcs <- withInteractionId ii $ inTopContext $ addContext moduleTel $ mapM prettyA cls''
               ticks <- liftIO $ readIORef ticks

--- a/src/full/Agda/Auto/Convert.hs
+++ b/src/full/Agda/Auto/Convert.hs
@@ -668,18 +668,19 @@ frommyClause (ids, pats, mrhs) = do
           Nothing -> return $ Nothing
           Just e -> Just <$> convert e
  let cperm =  Perm nv perm
- return $ I.Clause
+ return I.Clause
    { I.clauseLHSRange  = SP.noRange
    , I.clauseFullRange = SP.noRange
    , I.clauseTel       = tel
    , I.namedClausePats = IP.numberPatVars __IMPOSSIBLE__ cperm $ applySubst (renamingR $ compactP cperm) ps
-   , I.clauseBody  = body
-   , I.clauseType  = Nothing -- TODO: compute clause type
-   , I.clauseCatchall = False
+   , I.clauseBody      = body
+   , I.clauseType      = Nothing -- TODO: compute clause type
+   , I.clauseCatchall    = False
    , I.clauseExact       = Nothing -- TODO
    , I.clauseRecursive   = Nothing -- TODO: Don't know here whether recursive or not !?
    , I.clauseUnreachable = Nothing -- TODO: Don't know here whether reachable or not !?
-   , I.clauseEllipsis = Cm.NoEllipsis
+   , I.clauseEllipsis    = Cm.NoEllipsis
+   , I.clauseWhereModule = Nothing
    }
 
 contains_constructor :: [CSPat O] -> Bool

--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -333,7 +333,7 @@ instance Hilite A.ProblemEq where
   hilite (A.ProblemEq p _t _dom) = hilite p
 
 instance Hilite A.WhereDeclarations where
-  hilite (A.WhereDecls m ds) = hilite m <> hilite ds
+  hilite (A.WhereDecls m _ ds) = hilite m <> hilite ds
 
 instance Hilite A.GeneralizeTelescope where
   hilite (A.GeneralizeTel _gen tel) = hilite tel

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -368,12 +368,14 @@ data WhereDeclarations = WhereDecls
   { whereModule :: Maybe ModuleName
       -- #2897: we need to restrict named where modules in refined contexts,
       --        so remember whether it was named here
-  , whereDecls  :: Maybe Declaration
+  , whereAnywhere :: Bool
+      -- ^ is it an ordinary unnamed @where@?
+  , whereDecls :: Maybe Declaration
       -- ^ The declaration is a 'Section'.
   } deriving (Data, Show, Eq, Generic)
 
 instance Null WhereDeclarations where
-  empty = WhereDecls empty empty
+  empty = WhereDecls empty False empty
 
 noWhereDecls :: WhereDeclarations
 noWhereDecls = empty
@@ -702,7 +704,7 @@ instance HasRange RHS where
     getRange (RewriteRHS xes _ rhs wh) = getRange (xes, rhs, wh)
 
 instance HasRange WhereDeclarations where
-  getRange (WhereDecls _ ds) = getRange ds
+  getRange (WhereDecls _ _ ds) = getRange ds
 
 instance HasRange LetBinding where
     getRange (LetBind i _ _ _ _     ) = getRange i
@@ -845,7 +847,7 @@ instance KillRange RHS where
   killRange (RewriteRHS xes spats rhs wh) = killRange4 RewriteRHS xes spats rhs wh
 
 instance KillRange WhereDeclarations where
-  killRange (WhereDecls a b) = killRange2 WhereDecls a b
+  killRange (WhereDecls a b c) = killRange3 WhereDecls a b c
 
 instance KillRange LetBinding where
   killRange (LetBind   i info a b c) = killRange5 LetBind i info a b c

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -367,7 +367,7 @@ instance (ExprLike qn, ExprLike nm, ExprLike p, ExprLike e) => ExprLike (Rewrite
     Invert qn pes -> Invert <$> recurseExpr f qn <*> recurseExpr f pes
 
 instance ExprLike WhereDeclarations where
-  recurseExpr f (WhereDecls a b) = WhereDecls a <$> recurseExpr f b
+  recurseExpr f (WhereDecls a b c) = WhereDecls a b <$> recurseExpr f c
 
 instance ExprLike ModuleApplication where
   recurseExpr :: forall m. RecurseExprFn m ModuleApplication
@@ -519,7 +519,7 @@ instance DeclaredNames Clause where
   declaredNames (Clause _ _ rhs decls _) = declaredNames rhs <> declaredNames decls
 
 instance DeclaredNames WhereDeclarations where
-  declaredNames (WhereDecls _ ds) = declaredNames ds
+  declaredNames (WhereDecls _ _ ds) = declaredNames ds
 
 instance DeclaredNames RHS where
   declaredNames = \case

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -160,7 +160,7 @@ instance NamesIn Defn where
       -> namesAndMetasIn' sg (cl, cc)
 
 instance NamesIn Clause where
-  namesAndMetasIn' sg (Clause _ _ tel ps b t _ _ _ _ _) =
+  namesAndMetasIn' sg (Clause _ _ tel ps b t _ _ _ _ _ _) =
     namesAndMetasIn' sg (tel, ps, b, t)
 
 instance NamesIn CompiledClauses where

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1035,15 +1035,15 @@ instance ToConcrete A.LetBinding where
 instance ToConcrete A.WhereDeclarations where
   type ConOfAbs A.WhereDeclarations = WhereClause
 
-  bindToConcrete (A.WhereDecls _ Nothing) ret = ret C.NoWhere
-  bindToConcrete (A.WhereDecls (Just am) (Just (A.Section _ _ _ ds))) ret = do
+  bindToConcrete (A.WhereDecls _ _ Nothing) ret = ret C.NoWhere
+  bindToConcrete (A.WhereDecls (Just am) False (Just (A.Section _ _ _ ds))) ret = do
     ds' <- declsToConcrete ds
     cm  <- unqualify <$> lookupModule am
     -- Andreas, 2016-07-08 I put PublicAccess in the following SomeWhere
     -- Should not really matter for printing...
     let wh' = (if isNoName cm then AnyWhere noRange else SomeWhere noRange cm PublicAccess) $ ds'
     local (openModule' am defaultImportDir id) $ ret wh'
-  bindToConcrete (A.WhereDecls _ (Just d)) ret =
+  bindToConcrete (A.WhereDecls _ _ (Just d)) ret =
     ret . AnyWhere noRange =<< toConcrete d
 
 mergeSigAndDef :: [C.Declaration] -> [C.Declaration]

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2524,7 +2524,7 @@ whereToAbstract1 r whname whds inner = do
    void $ -- We can ignore the returned default A.ImportDirective.
     openModule TopOpenModule (Just am) (C.QName m) $
       defaultImportDir { publicOpen = Just noRange }
-  return (x, A.WhereDecls (am <$ whname) $ singleton d)
+  return (x, A.WhereDecls (Just am) (isNothing whname) $ singleton d)
 
 data TerminationOrPositivity = Termination | Positivity
   deriving (Show)

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -173,17 +173,18 @@ coverageCheck f t cs = do
         -- ifNotM (isEmptyTel tel) (return True) $ do
       -- Jesper, 2018-11-28, Issue #3407: if the clause is absurd,
       -- add the appropriate absurd clause to the definition.
-      let cl = Clause { clauseLHSRange    = noRange
-                      , clauseFullRange   = noRange
-                      , clauseTel         = tel
-                      , namedClausePats   = applySubst sub ps
-                      , clauseBody        = Nothing
-                      , clauseType        = Nothing
+      let cl = Clause { clauseLHSRange  = noRange
+                      , clauseFullRange = noRange
+                      , clauseTel       = tel
+                      , namedClausePats = applySubst sub ps
+                      , clauseBody      = Nothing
+                      , clauseType      = Nothing
                       , clauseCatchall    = True       -- absurd clauses are safe as catch-all
                       , clauseExact       = Just False
                       , clauseRecursive   = Just False
                       , clauseUnreachable = Just False
                       , clauseEllipsis    = NoEllipsis
+                      , clauseWhereModule = Nothing
                       }
       reportSDoc "tc.cover.missing" 20 $ inTopContext $ do
         sep [ "adding missing absurd clause"
@@ -390,11 +391,12 @@ cover f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
                     , namedClausePats = (s `applySubst` ps) ++ extra
                     , clauseBody      = (`applyE` patternsToElims extra) . (s `applyPatSubst`) <$> clauseBody cl
                     , clauseType      = ty
-                    , clauseCatchall  = clauseCatchall cl
-                    , clauseExact     = clauseExact cl
-                    , clauseRecursive = clauseRecursive cl
+                    , clauseCatchall    = clauseCatchall cl
+                    , clauseExact       = clauseExact cl
+                    , clauseRecursive   = clauseRecursive cl
                     , clauseUnreachable = clauseUnreachable cl
-                    , clauseEllipsis  = clauseEllipsis cl
+                    , clauseEllipsis    = clauseEllipsis cl
+                    , clauseWhereModule = clauseWhereModule cl
                     }
       where
         (vs,qs) = unzip mps
@@ -600,11 +602,12 @@ inferMissingClause f (SClause tel ps _ cps (Just t)) = setCurrentRange f $ do
                   , namedClausePats = fromSplitPatterns ps
                   , clauseBody      = Just rhs
                   , clauseType      = Just (argFromDom t)
-                  , clauseCatchall  = False
+                  , clauseCatchall    = False
                   , clauseExact       = Just True
                   , clauseRecursive   = Nothing     -- could be recursive
                   , clauseUnreachable = Just False  -- missing, thus, not unreachable
-                  , clauseEllipsis  = NoEllipsis
+                  , clauseEllipsis    = NoEllipsis
+                  , clauseWhereModule = Nothing
                   }
   addClauses f [cl]  -- Important: add at the end.
   return cl

--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -359,18 +359,19 @@ createMissingTrXTrXClause q_trX f n x old_sc = do
     (,,) <$> ps <*> rhsTy <*> rhs
   let (ps,ty,rhs) = unAbsN $ unAbs $ unAbsN $ unAbs $ unAbsN $ unAbs $ unAbsN $ ps_ty_rhs
   reportSDoc "tc.cover.trx.trx" 20 $ "trX-trX clause for" <+> prettyTCM f
-  let c = Clause { clauseTel = cTel
-                  , namedClausePats = ps
-                  , clauseBody = Just rhs
-                  , clauseType = Just $ Arg (getArgInfo ty) (unDom ty)
-                  , clauseLHSRange = noRange
-                  , clauseFullRange = noRange
-                  , clauseCatchall = False
-                  , clauseRecursive = Just True
-                  , clauseUnreachable = Just False
-                  , clauseEllipsis = NoEllipsis
-                  , clauseExact = Nothing
-                  }
+  let c = Clause { clauseLHSRange  = noRange
+                 , clauseFullRange = noRange
+                 , clauseTel       = cTel
+                 , namedClausePats = ps
+                 , clauseBody      = Just rhs
+                 , clauseType      = Just $ Arg (getArgInfo ty) (unDom ty)
+                 , clauseCatchall    = False
+                 , clauseExact       = Nothing
+                 , clauseRecursive   = Just True
+                 , clauseUnreachable = Just False
+                 , clauseEllipsis    = NoEllipsis
+                 , clauseWhereModule = Nothing
+                 }
   debugClause "tc.cover.trx.trx" c
   return $ c
 createMissingTrXHCompClause :: QName
@@ -627,20 +628,21 @@ createMissingTrXHCompClause q_trX f n x old_sc = do
     (,,) <$> ps <*> rhsTy <*> pure rhs
   let (ps,ty,rhs) = unAbsN $ unAbs $ unAbs $ unAbs $ unAbsN $ unAbs $ unAbsN $ ps_ty_rhs
   reportSDoc "tc.cover.trx.hcomp" 20 $ "trX-hcomp clause for" <+> prettyTCM f
-  let c = Clause { clauseTel = cTel
-                  , namedClausePats = ps
-                  , clauseBody = Just rhs
-                  , clauseType = Just $ Arg (getArgInfo ty) (unDom ty)
-                  , clauseLHSRange = noRange
-                  , clauseFullRange = noRange
-                  , clauseCatchall = False
-                  , clauseRecursive = Just True
-                  , clauseUnreachable = Just False
-                  , clauseEllipsis = NoEllipsis
-                  , clauseExact = Nothing
-                  }
+  let c = Clause { clauseLHSRange  = noRange
+                 , clauseFullRange = noRange
+                 , clauseTel       = cTel
+                 , namedClausePats = ps
+                 , clauseBody      = Just rhs
+                 , clauseType      = Just $ Arg (getArgInfo ty) (unDom ty)
+                 , clauseCatchall    = False
+                 , clauseExact       = Nothing
+                 , clauseRecursive   = Just True
+                 , clauseUnreachable = Just False
+                 , clauseEllipsis    = NoEllipsis
+                 , clauseWhereModule = Nothing
+                 }
   debugClause "tc.cover.trx.hcomp" c
-  return $ c
+  return c
 createMissingTrXConClause :: QName -- trX
                             -> QName -- f defined
                             -> Arg Nat
@@ -861,17 +863,18 @@ createMissingTrXConClause q_trX f n x old_sc c (UE gamma gamma' xTel u v rho tau
   qs <- mapM (fmap (fromMaybe __IMPOSSIBLE__) . getName') [builtinINeg, builtinIMax, builtinIMin]
   rhs <- addContext cTel $
            locallyReduceDefs (OnlyReduceDefs (Set.fromList $ q_trX : qs)) $ normalise rhs
-  let cl = Clause { clauseTel = cTel
-                  , namedClausePats = ps
-                  , clauseBody = Just rhs
-                  , clauseType = Just $ Arg (getArgInfo ty) (unDom ty)
-                  , clauseLHSRange = noRange
+  let cl = Clause { clauseLHSRange  = noRange
                   , clauseFullRange = noRange
-                  , clauseCatchall = False
-                  , clauseRecursive = Just True
+                  , clauseTel       = cTel
+                  , namedClausePats = ps
+                  , clauseBody      = Just rhs
+                  , clauseType      = Just $ Arg (getArgInfo ty) (unDom ty)
+                  , clauseCatchall    = False
+                  , clauseExact       = Nothing
+                  , clauseRecursive   = Just True
                   , clauseUnreachable = Just False
-                  , clauseEllipsis = NoEllipsis
-                  , clauseExact = Nothing
+                  , clauseEllipsis    = NoEllipsis
+                  , clauseWhereModule = Nothing
                   }
 
 
@@ -1111,11 +1114,12 @@ createMissingConIdClause f _n x old_sc (TheInfo info) = setCurrentRange f $ do
                     , namedClausePats = ps
                     , clauseBody      = Just $ rhs
                     , clauseType      = Just $ Arg (domInfo ty) (unDom ty)
-                    , clauseCatchall  = False
+                    , clauseCatchall    = False
                     , clauseUnreachable = Just False  -- missing, thus, not unreachable
-                    , clauseRecursive = Just False
-                    , clauseEllipsis = NoEllipsis
-                    , clauseExact = Nothing
+                    , clauseRecursive   = Just False
+                    , clauseEllipsis    = NoEllipsis
+                    , clauseExact       = Nothing
+                    , clauseWhereModule = Nothing
                     }
   addClauses f [cl]
   return $ Just ((SplitCon conId,SplittingDone (size working_tel)),cl)
@@ -1356,11 +1360,12 @@ createMissingHCompClause f n x old_sc (SClause tel ps _sigma' _cps (Just t)) cs 
                     , namedClausePats = fromSplitPatterns ps
                     , clauseBody      = Just $ rhs
                     , clauseType      = Just $ defaultArg t
-                    , clauseCatchall  = False
+                    , clauseCatchall    = False
                     , clauseExact       = Just True
                     , clauseRecursive   = Nothing     -- TODO: can it be recursive?
                     , clauseUnreachable = Just False  -- missing, thus, not unreachable
-                    , clauseEllipsis  = NoEllipsis
+                    , clauseEllipsis    = NoEllipsis
+                    , clauseWhereModule = Nothing
                     }
   addClauses f [cl]  -- Important: add at the end.
   let result = CoverResult

--- a/src/full/Agda/TypeChecking/Functions.hs
+++ b/src/full/Agda/TypeChecking/Functions.hs
@@ -38,9 +38,9 @@ import Agda.Utils.Size
 etaExpandClause :: MonadTCM tcm => Clause -> tcm Clause
 etaExpandClause clause = liftTCM $ do
   case clause of
-    Clause _  _  ctel ps _           Nothing  _ _ _ _ _ -> return clause
-    Clause _  _  ctel ps Nothing     (Just t) _ _ _ _ _ -> return clause
-    Clause rl rf ctel ps (Just body) (Just t) catchall exact recursive unreachable ell -> do
+    Clause _  _  ctel ps _           Nothing  _ _ _ _ _ _ -> return clause
+    Clause _  _  ctel ps Nothing     (Just t) _ _ _ _ _ _ -> return clause
+    Clause rl rf ctel ps (Just body) (Just t) catchall exact recursive unreachable ell wm -> do
 
       -- Get the telescope to expand the clause with.
       TelV tel0 t' <- addContext ctel $ telView $ unArg t
@@ -62,7 +62,7 @@ etaExpandClause clause = liftTCM $ do
         , "  xs      = " <+> text (prettyShow xs)
         , "  new tel = " <+> prettyTCM ctel'
         ]
-      return $ Clause rl rf ctel' ps' (Just body') (Just (t $> t')) catchall exact recursive unreachable ell
+      return $ Clause rl rf ctel' ps' (Just body') (Just (t $> t')) catchall exact recursive unreachable ell wm
   where
     -- Get all initial lambdas of the body.
     peekLambdas :: Term -> [Arg ArgName]

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -552,19 +552,20 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
                   reportSDoc "tc.mod.apply" 80 $ ("new def for" <+> pretty x) <?> pretty newDef
                   return newDef
 
-            cl = Clause { clauseLHSRange  = getRange $ defClauses d
-                        , clauseFullRange = getRange $ defClauses d
-                        , clauseTel       = EmptyTel
-                        , namedClausePats = []
-                        , clauseBody      = Just $ dropArgs pars $ case oldDef of
+            cl = Clause { clauseLHSRange    = getRange $ defClauses d
+                        , clauseFullRange   = getRange $ defClauses d
+                        , clauseTel         = EmptyTel
+                        , namedClausePats   = []
+                        , clauseBody        = Just $ dropArgs pars $ case oldDef of
                             Function{funProjection = Just p} -> projDropParsApply p ProjSystem rel ts'
                             _ -> Def x $ map Apply ts'
-                        , clauseType      = Just $ defaultArg t
-                        , clauseCatchall  = False
+                        , clauseType        = Just $ defaultArg t
+                        , clauseCatchall    = False
                         , clauseExact       = Just True
                         , clauseRecursive   = Just False -- definitely not recursive
                         , clauseUnreachable = Just False -- definitely not unreachable
-                        , clauseEllipsis  = NoEllipsis
+                        , clauseEllipsis    = NoEllipsis
+                        , clauseWhereModule = Nothing
                         }
               where
                 -- The number of remaining parameters. We need to drop the

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1587,7 +1587,7 @@ instance InstantiateFull CompiledClauses where
   instantiateFull' (Case n bs) = Case n <$> instantiateFull' bs
 
 instance InstantiateFull Clause where
-    instantiateFull' (Clause rl rf tel ps b t catchall exact recursive unreachable ell) =
+    instantiateFull' (Clause rl rf tel ps b t catchall exact recursive unreachable ell wm) =
        Clause rl rf <$> instantiateFull' tel
        <*> instantiateFull' ps
        <*> instantiateFull' b
@@ -1597,6 +1597,7 @@ instance InstantiateFull Clause where
        <*> return recursive
        <*> return unreachable
        <*> return ell
+       <*> return wm
 
 instance InstantiateFull Instantiation where
   instantiateFull' (Instantiation a b) =

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -135,11 +135,12 @@ bindBuiltinFlat x =
               ConP sharpCon cpi [ argN $ Named Nothing $ debruijnNamedVar "x" 0 ] ]
           , clauseBody      = Just $ var 0
           , clauseType      = Just $ defaultArg $ El (varSort 2) $ var 1
-          , clauseCatchall  = False
+          , clauseCatchall    = False
           , clauseExact       = Just True
           , clauseRecursive   = Just False
           , clauseUnreachable = Just False
-          , clauseEllipsis  = NoEllipsis
+          , clauseEllipsis    = NoEllipsis
+          , clauseWhereModule = Nothing
           }
         cc = Case (defaultArg 0) $ conCase sharp False $ WithArity 1 $ Done [defaultArg "x"] $ var 0
         projection = Projection

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -608,6 +608,7 @@ defineCompData d con params names fsT t boundary = do
               -- Or: Just False;  is it known to be non-recursive?
           , clauseUnreachable = Just False
           , clauseEllipsis    = NoEllipsis
+          , clauseWhereModule = Nothing
           }
         cs = [clause]
       addClauses theName cs
@@ -1274,7 +1275,8 @@ defineConClause trD' isHIT mtrX npars nixs xTel' telI sigma dT' cnames = do
             -- it is indirectly recursive through transp, does it count?
             , clauseUnreachable = Just False
             , clauseEllipsis    = NoEllipsis
-            , clauseExact = Nothing
+            , clauseExact       = Nothing
+            , clauseWhereModule = Nothing
             }
       reportSDoc "tc.data.transp.con" 20 $
         "gamma:" <+> prettyTCM gamma

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -194,11 +194,12 @@ checkAlias t ai delayed i name e mc =
                           , namedClausePats = []
                           , clauseBody      = Just $ bodyMod v
                           , clauseType      = Just $ Arg ai t
-                          , clauseCatchall  = False
-                          , clauseExact     = Just True
-                          , clauseRecursive = Nothing   -- we don't know yet
+                          , clauseCatchall    = False
+                          , clauseExact       = Just True
+                          , clauseRecursive   = Nothing   -- we don't know yet
                           , clauseUnreachable = Just False
-                          , clauseEllipsis = NoEllipsis
+                          , clauseEllipsis    = NoEllipsis
+                          , clauseWhereModule = Nothing
                           } ]
                       , funCompiled = Just $ Done [] $ bodyMod v
                       , funSplitTree = Just $ SplittingDone 0
@@ -332,15 +333,16 @@ checkFunDefS t ai delayed extlam with i name withSub cs = do
                  let c = Clause
                        { clauseFullRange = noRange
                        , clauseLHSRange  = noRange
-                       , clauseTel = tel
+                       , clauseTel       = tel
                        , namedClausePats = teleNamedArgs tel
-                       , clauseBody = Nothing
-                       , clauseType = Just (defaultArg t)
-                       , clauseCatchall = False
-                       , clauseExact     = Just True
-                       , clauseRecursive = Just False
+                       , clauseBody      = Nothing
+                       , clauseType      = Just (defaultArg t)
+                       , clauseCatchall    = False
+                       , clauseExact       = Just True
+                       , clauseRecursive   = Just False
                        , clauseUnreachable = Just False
-                       , clauseEllipsis = NoEllipsis
+                       , clauseEllipsis    = NoEllipsis
+                       , clauseWhereModule = Nothing
                        }
                  return (cs ++ [c], pure sys)
 
@@ -783,7 +785,8 @@ checkClause t withSub c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats rhs0 wh 
                  , clauseExact       = exact
                  , clauseRecursive   = Nothing -- we don't know yet
                  , clauseUnreachable = Nothing -- we don't know yet
-                 , clauseEllipsis  = lhsEllipsis i
+                 , clauseEllipsis    = lhsEllipsis i
+                 , clauseWhereModule = A.whereModule wh
                  }
 
 
@@ -1223,8 +1226,8 @@ checkWhere
   :: A.WhereDeclarations -- ^ Where-declarations to check.
   -> TCM a               -- ^ Continuation.
   -> TCM a
-checkWhere wh@(A.WhereDecls whmod ds) ret = do
-  ensureNoNamedWhereInRefinedContext whmod
+checkWhere wh@(A.WhereDecls whmod whNamed ds) ret = do
+  when (not whNamed) $ ensureNoNamedWhereInRefinedContext whmod
   loop ds
   where
     loop = \case

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -489,36 +489,38 @@ defineTranspOrHCompR cmd name params fsT fns rect = do
                 (g0,_:g1) = splitAt (size gamma - 1 - ix) $ flattenTel gamma
                 (ns0,_:ns1) = splitAt (size gamma - 1 - ix) $ teleNames gamma
 
-              c = Clause { clauseTel       = gamma'
-                         , clauseType      = Just $ argN t
-                         , namedClausePats = pats
-                         , clauseFullRange = noRange
+              c = Clause { clauseFullRange = noRange
                          , clauseLHSRange  = noRange
-                         , clauseCatchall  = False
+                         , clauseTel       = gamma'
+                         , namedClausePats = pats
                          , clauseBody      = Just $ rhs
+                         , clauseType      = Just $ argN t
+                         , clauseCatchall    = False
                          , clauseExact       = Just True
                          , clauseRecursive   = Just False  -- definitely non-recursive!
                          , clauseUnreachable = Just False
-                         , clauseEllipsis  = NoEllipsis
+                         , clauseEllipsis    = NoEllipsis
+                         , clauseWhereModule = Nothing
                          }
            reportSDoc "trans.rec.face" 17 $ text $ show c
            return c
   cs <- forM (zip3 fns clause_types bodies) $ \ (fname, clause_ty, body) -> do
           let
               pats = teleNamedArgs gamma ++ [defaultNamedArg $ ProjP ProjSystem $ unArg fname]
-              c = Clause { clauseTel       = gamma
-                         , clauseType      = Just $ argN (unDom clause_ty)
-                         , namedClausePats = pats
-                         , clauseFullRange = noRange
+              c = Clause { clauseFullRange = noRange
                          , clauseLHSRange  = noRange
-                         , clauseCatchall  = False
+                         , clauseTel       = gamma
+                         , namedClausePats = pats
                          , clauseBody      = Just body
+                         , clauseType      = Just $ argN (unDom clause_ty)
+                         , clauseCatchall    = False
                          , clauseExact       = Just True
                          , clauseRecursive   = Nothing
                              -- Andreas 2020-02-06 TODO
                              -- Or: Just False;  is it known to be non-recursive?
                          , clauseUnreachable = Just False
-                         , clauseEllipsis  = NoEllipsis
+                         , clauseEllipsis    = NoEllipsis
+                         , clauseWhereModule = Nothing
                          }
           reportSDoc "trans.rec" 17 $ text $ show c
           reportSDoc "trans.rec" 16 $ text "type =" <+> text (show (clauseType c))
@@ -695,7 +697,8 @@ checkRecordProjections m r hasNamedCon con tel ftel fs = do
                             , clauseExact       = Just True
                             , clauseRecursive   = Just False
                             , clauseUnreachable = Just False
-                            , clauseEllipsis  = NoEllipsis
+                            , clauseEllipsis    = NoEllipsis
+                            , clauseWhereModule = Nothing
                             }
 
         let projection = Projection

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -759,7 +759,8 @@ checkAbsurdLambda cmp i h e t = localTC (set eQuantity topQuantity) $ do
                     , clauseExact       = Just False
                     , clauseRecursive   = Just False
                     , clauseUnreachable = Just True -- absurd clauses are unreachable
-                    , clauseEllipsis  = NoEllipsis
+                    , clauseEllipsis    = NoEllipsis
+                    , clauseWhereModule = Nothing
                     }
                   ]
               , funCompiled       = Just $ Fail [Arg info' "()"]

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -485,7 +485,7 @@ instance EmbPrj TermHead where
     valu _      = malformed
 
 instance EmbPrj I.Clause where
-  icod_ (Clause a b c d e f g h i j k) = icodeN' Clause a b c d e f g h i j k
+  icod_ (Clause a b c d e f g h i j k l) = icodeN' Clause a b c d e f g h i j k l
 
   value = valueN Clause
 

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -360,7 +360,7 @@ instance Apply Clause where
     -- It is assumed that we only apply a clause to "parameters", i.e.
     -- arguments introduced by lambda lifting. The problem is that these aren't
     -- necessarily the first elements of the clause telescope.
-    apply cls@(Clause rl rf tel ps b t catchall exact recursive unreachable ell) args
+    apply cls@(Clause rl rf tel ps b t catchall exact recursive unreachable ell wm) args
       | length args > length ps = __IMPOSSIBLE__
       | otherwise =
       Clause rl rf
@@ -373,6 +373,7 @@ instance Apply Clause where
              recursive
              unreachable
              ell
+             wm
       where
         -- We have
         --  Γ ⊢ args, for some outer context Γ
@@ -702,7 +703,7 @@ instance Abstract PrimFun where
         where n = size tel
 
 instance Abstract Clause where
-  abstract tel (Clause rl rf tel' ps b t catchall exact recursive unreachable ell) =
+  abstract tel (Clause rl rf tel' ps b t catchall exact recursive unreachable ell wm) =
     Clause rl rf (abstract tel tel')
            (namedTelVars m tel ++ ps)
            b
@@ -712,6 +713,7 @@ instance Abstract Clause where
            recursive
            unreachable
            ell
+           wm
       where m = size tel + size tel'
 
 instance Abstract CompiledClauses where


### PR DESCRIPTION
Keep track of the internally generated where module, even if unnamed.
Useful for backends that wish to recreate the user-written where clauses as they were never λ-lifted, e.g. [agda2hs](https://github.com/agda/agda2hs).