### PR TITLE
[ workflows ] try to fix stack/Win (ICU again)

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -112,7 +112,8 @@ jobs:
       name: Install the icu library (Ubuntu)
     - if: ${{ runner.os == 'Windows' }}
       run: |
-        stack exec ${ARGS} -- pacman --noconfirm -Sy msys2-keyring
+        stack exec ${ARGS} -- pacman --noconfirm -Syuu
+        # stack exec ${ARGS} -- pacman --noconfirm -Sy msys2-keyring
         stack exec ${ARGS} -- pacman --noconfirm -S ${ICU}
         stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
       name: Install the icu library (Windows)

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -96,7 +96,7 @@ jobs:
     - with:
         path: ${{ steps.haskell-setup.outputs.stack-root }}
         key: |
-          ${{ runner.os }}-stack-00-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml.lock', env.GHC_VER)) }}
+          ${{ runner.os }}-stack-20220503-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml.lock', env.GHC_VER)) }}
       uses: actions/cache@v2
       name: Cache dependencies
       id: cache

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -187,7 +187,8 @@ jobs:
     - name: Install the icu library (Windows)
       if: ${{ runner.os == 'Windows' }}
       run: |
-        stack exec ${ARGS} -- pacman --noconfirm -Sy msys2-keyring
+        stack exec ${ARGS} -- pacman --noconfirm -Syuu
+        # stack exec ${ARGS} -- pacman --noconfirm -Sy msys2-keyring
         stack exec ${ARGS} -- pacman --noconfirm -S ${ICU}
         stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
 

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -163,7 +163,7 @@ jobs:
         # A unique cache is used for each stack.yaml.
         # Note that matrix.stack-ver might be simply 'latest', so we use STACK_VER.
         key: |
-          ${{ runner.os }}-stack-00-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml.lock', env.GHC_VER)) }}
+          ${{ runner.os }}-stack-20220503-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml.lock', env.GHC_VER)) }}
 
     - name: Set up pkg-config for the ICU library (macOS)
       if: ${{ runner.os == 'macOS' }}
@@ -184,6 +184,8 @@ jobs:
     # NB: the ${ARGS} is necessary, otherwise stack installs another GHC...
     # Andreas, 2022-02-04, issue #5768:
     # To work around keyring problems, we update msys2-keyring before installing ICU.
+    # Andreas, 2022-05-15, pr #5909: the keyring problem was solved upstream by
+    # updating Stack-MSYS to 2022-05-03.
     - name: Install the icu library (Windows)
       if: ${{ runner.os == 'Windows' }}
       run: |


### PR DESCRIPTION
Windows Stack CI broken by upstream change:
- https://github.com/agda/agda/runs/6435596174?check_suite_focus=true
```
addDLL: icudt or dependencies not loaded. (Win32 error 126)
ghc.exe: addLibrarySearchPath: 
C:\Users\runneradmin\AppData\Local\Programs\stack\x86_64-windows\msys2-20210604\mingw64\lib (Win32 error 3): 
The system cannot find the path specified.
```

Clearing the stack fixed it.  Context:
- https://github.com/commercialhaskell/stack/issues/5567#issuecomment-1126974336