### PR TITLE
User-manual: small improvements to section on `postulate`

### DIFF
--- a/doc/user-manual/language/postulates.lagda.rst
+++ b/doc/user-manual/language/postulates.lagda.rst
@@ -2,9 +2,6 @@
   ::
   module language.postulates where
 
-  open import Agda.Builtin.Bool     using (Bool; true; false)
-  open import Agda.Builtin.Equality using (_≡_; refl)
-
 .. _postulates:
 
 **********
@@ -69,18 +66,3 @@ Postulates are declarations and can appear in positions where arbitrary declarat
     my-theorem A = I-prove-this-later
       where
         postulate I-prove-this-later : _
-
-Postulates are _not_ permitted in ``let``, which limits the trick with local postulates a bit, since ``where`` is not allowed in expressions.  However, there is a workaround, using ``let open`` for a dedicated module::
-
-  module PostulateInLet where
-
-    -- A generic module containing a postulate of desired type.
-    module POSTULATE {a} {A : Set a} where
-      postulate
-        □ : A
-
-    everything-is-true : (b : Bool) → b ≡ true
-    everything-is-true = λ where
-      true  → refl
-      false → let open POSTULATE in □
-              -- `where` is not allowed here

--- a/doc/user-manual/unicode-symbols-sphinx.tex.txt
+++ b/doc/user-manual/unicode-symbols-sphinx.tex.txt
@@ -259,6 +259,7 @@
 \DeclareUnicodeCharacter{2467}{\ensuremath{\text{\ding{179}}}} % Symbol ⑧
 \DeclareUnicodeCharacter{2468}{\ensuremath{\text{\ding{180}}}} % Symbol ⑨
 
+\DeclareUnicodeCharacter{25A1}{\ensuremath{\Box}}           % Symbol □
 \DeclareUnicodeCharacter{25C5}{\ensuremath{\triangleleft}}  % Symbol ◅
 
 \DeclareUnicodeCharacter{2660}{\ensuremath{\spadesuit}} % Symbol ♠


### PR DESCRIPTION
One cannot postulate something in an expression, except via using `let open M in ...` where `M` contains the postulate. 
Maybe a nice trick for the working Agda programmer...
```agda
    module POSTULATE {a} {A : Set a} where
      postulate
        □ : A

    everything-is-true : (b : Bool) → b ≡ true
    everything-is-true = λ where
      true  → refl
      false → let open POSTULATE in □
              -- `where` is not allowed here
```