### PR TITLE
Added the copatterns with coinduction section to the user manual

### DIFF
--- a/doc/user-manual/language/coinduction.lagda.rst
+++ b/doc/user-manual/language/coinduction.lagda.rst
@@ -107,8 +107,8 @@ Finally, we can prove that ``merge`` is a left inverse for ``split``:
     hd-≡ (merge-split-id _)  = refl
     tl-≈ (merge-split-id xs) = merge-split-id (tl xs)
 
-On top of creating fuctions that work on existing ``Stream``\s we can also use 
-:ref:`copatterns <copatterns>` to instantiate a ``Stream``\. Like the ``repeat``
+On top of creating functions that work on existing ``Stream``\s we can also use 
+:ref:`copatterns <copatterns>` to instantiate a ``Stream``\, like the ``repeat``
 function which will repeat the given element ``a`` infinite amount of times.
 
 ::

--- a/doc/user-manual/language/coinduction.lagda.rst
+++ b/doc/user-manual/language/coinduction.lagda.rst
@@ -107,6 +107,15 @@ Finally, we can prove that ``merge`` is a left inverse for ``split``:
     hd-≡ (merge-split-id _)  = refl
     tl-≈ (merge-split-id xs) = merge-split-id (tl xs)
 
+On top of creating fuctions that work on existing ``Stream``\s we can also use 
+:ref:`copatterns <copatterns>` to instantiate a ``Stream``\. Like the ``repeat``
+function which will repeat the given element ``a`` infinite amount of times.
+
+::
+
+    repeat : {A : Set} (a : A) -> Stream A
+    hd (repeat a) = a
+    tl (repeat a) = repeat a
 
 
 Old Coinduction

--- a/doc/user-manual/language/copatterns.lagda.rst
+++ b/doc/user-manual/language/copatterns.lagda.rst
@@ -1,8 +1,5 @@
 ..
   ::
-
-  {-# OPTIONS --guardedness #-}
-
   module language.copatterns where
 
   data _≡_ {A : Set} : A → A →  Set where
@@ -24,7 +21,9 @@
 Copatterns
 **********
 
-Consider the following record:
+If you are looking for information on how to use copatterns with 
+coinductive records please go to the section on :ref:`coinduction <coinduction>`. 
+Now consider the following record:
 
 ::
 
@@ -122,33 +121,7 @@ The resulting behaviour is the same in both cases:
     test₂ : backward-2 enum-Nat 5 ≡ 3
     test₂ = refl
 
-Copatterns with coinduction
-----------------------------------
 
-Recall the coinductive record of Stream in the section on coinduction:
-
-::
-
-    record Stream (A : Set) : Set where
-      coinductive
-      field
-        hd : A
-        tl : Stream A
-
-Now we can create streams using copatterns, a typical example would be 
-the common function repeat. 
-
-::
-
-    open Stream
-
-    repeat : {A : Set} (a : A) -> Stream A
-    hd (repeat a) = a
-    tl (repeat a) = repeat a
-
-And this way allows us to construct an infinite stream repeating the given value 'a'
-never reducing in of itself. Whilst using normal record syntax would have lead 
-to the termination checker throwing an error.
 
 Copatterns in function definitions
 ----------------------------------

--- a/doc/user-manual/language/copatterns.lagda.rst
+++ b/doc/user-manual/language/copatterns.lagda.rst
@@ -21,9 +21,9 @@
 Copatterns
 **********
 
-If you are looking for information on how to use copatterns with 
-coinductive records please go to the section on :ref:`coinduction <coinduction>`. 
-Now consider the following record:
+.. note:: If you are looking for information on how to use copatterns with 
+   coinductive records please go to the section on :ref:`coinduction <coinduction>`. 
+   Now consider the following record:
 
 ::
 

--- a/doc/user-manual/language/copatterns.lagda.rst
+++ b/doc/user-manual/language/copatterns.lagda.rst
@@ -1,5 +1,8 @@
 ..
   ::
+
+  {-# OPTIONS --guardedness #-}
+
   module language.copatterns where
 
   data _≡_ {A : Set} : A → A →  Set where
@@ -119,7 +122,33 @@ The resulting behaviour is the same in both cases:
     test₂ : backward-2 enum-Nat 5 ≡ 3
     test₂ = refl
 
+Copatterns with coinduction
+----------------------------------
 
+Recall the coinductive record of Stream in the section on coinduction:
+
+::
+
+    record Stream (A : Set) : Set where
+      coinductive
+      field
+        hd : A
+        tl : Stream A
+
+Now we can create streams using copatterns, a typical example would be 
+the common function repeat. 
+
+::
+
+    open Stream
+
+    repeat : {A : Set} (a : A) -> Stream A
+    hd (repeat a) = a
+    tl (repeat a) = repeat a
+
+And this way allows us to construct an infinite stream repeating the given value 'a'
+never reducing in of itself. Whilst using normal record syntax would have lead 
+to the termination checker throwing an error.
 
 Copatterns in function definitions
 ----------------------------------


### PR DESCRIPTION
While I was experimenting with coinduction and copatterns for agda2hs, I came across [this gist](https://gist.github.com/puffnfresh/8960574) of  @puffnfresh which explained nicely how to use copatterns in combination with coinduction.

I felt I was missing this in the user manual of Agda, after reading the section on copatterns I myself still couldn't apply it on coinductive records. That's also the reason I came across this gist.

So I added the explanation of @puffnfresh and made it consistent with the other parts of the user manual. I didn't add the section of 'nats' because I wasn't sure how to explain that properly so that might still be of interest to include.