### PR TITLE
Re #5901: setup agda-mode: don't --no-site-file with --user

### DIFF
--- a/src/agda-mode/Main.hs
+++ b/src/agda-mode/Main.hs
@@ -174,8 +174,10 @@ askEmacs query = do
           -- The flag --user is necessary with --batch so that user-init-file is defined.
           -- The empty user is the default user.
           -- (Option --batch includes --no-init-file, this is reverted by supplying --user.)
-      , "--quick"
-          -- Option --quick includes --no-site-file.
+      -- Andreas, 2022-05-25, issue #5901 reloaded:
+      -- Loading the init file without loading the site fails for some users:
+      -- , "--quick"
+      --     -- Option --quick includes --no-site-file.
       , "--eval"
       , apply [ "with-temp-file", escape file, apply [ "insert", query ] ]
           -- Short cutting the temp file via just [ "princ", query ]


### PR DESCRIPTION
Re #5901: setup agda-mode: don't include `--no-site-file` when loading the user init file.

@nad reports errors with --no-site-file for agda-mode setup: https://github.com/agda/agda/issues/5901#issuecomment-1136055379