### PR TITLE
Fix #5942 (bullet lists in docs) by updating sphinx_rtd_theme

### DIFF
--- a/doc/user-manual/requirements.txt
+++ b/doc/user-manual/requirements.txt
@@ -1,3 +1,2 @@
-Sphinx>=5.0.0
-sphinx_rtd_theme
-
+Sphinx           >= 5.0.0
+sphinx_rtd_theme >= 1.0


### PR DESCRIPTION
~~Try~~ fix #5942 (bullet lists in docs) by updating sphinx_rtd_theme

I added building of PRs to https://readthedocs.org/projects/agda.

Rendering seems to be fixed: https://agda--5943.org.readthedocs.build/en/5943/language/runtime-irrelevance.html