### PR TITLE
Use the word 'underscore' in the documentation for Implicit Arguments

### DIFF
--- a/doc/user-manual/language/implicit-arguments.lagda.rst
+++ b/doc/user-manual/language/implicit-arguments.lagda.rst
@@ -17,7 +17,7 @@ Implicit Arguments
 ******************
 
 It is possible to omit terms that the type checker can figure out for
-itself, replacing them by ``_``.
+itself, replacing them by an underscore (``_``).
 If the type checker cannot infer the value of an ``_`` it will report
 an error.
 For instance, for the polymorphic identity function


### PR DESCRIPTION
This should improve searchability™️