### PR TITLE
Fix #5944: allow rewriting to match on SSet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v2
       with:
-        key: ${{ runner.os }}-stack-00-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-01-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -113,7 +113,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v2
       with:
-        key: ${{ runner.os }}-stack-00-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -166,7 +166,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v2
       with:
-        key: ${{ runner.os }}-stack-00-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -206,7 +206,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v2
       with:
-        key: ${{ runner.os }}-stack-00-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Suite of tests for bugs

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -291,6 +291,7 @@ instance NamesIn NLPSort where
   namesAndMetasIn' sg = \case
     PType a       -> namesAndMetasIn' sg a
     PProp a       -> namesAndMetasIn' sg a
+    PSSet a       -> namesAndMetasIn' sg a
     PInf _ _      -> mempty
     PSizeUniv     -> mempty
     PLockUniv     -> mempty

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1817,6 +1817,7 @@ data NLPType = NLPType
 data NLPSort
   = PType NLPat
   | PProp NLPat
+  | PSSet NLPat
   | PInf IsFibrant Integer
   | PSizeUniv
   | PLockUniv
@@ -4704,6 +4705,7 @@ instance KillRange NLPType where
 instance KillRange NLPSort where
   killRange (PType l) = killRange1 PType l
   killRange (PProp l) = killRange1 PProp l
+  killRange (PSSet l) = killRange1 PSSet l
   killRange s@(PInf f n) = s
   killRange PSizeUniv = PSizeUniv
   killRange PLockUniv = PLockUniv

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -427,6 +427,7 @@ instance PrettyTCM NLPSort where
   prettyTCM = \case
     PType l   -> parens $ "Set" <+> prettyTCM l
     PProp l   -> parens $ "Prop" <+> prettyTCM l
+    PSSet l   -> parens $ "SSet" <+> prettyTCM l
     PInf f n  -> prettyTCM (Inf f n :: Sort)
     PSizeUniv -> prettyTCM (SizeUniv :: Sort)
     PLockUniv -> prettyTCM (LockUniv :: Sort)

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1510,6 +1510,7 @@ instance InstantiateFull NLPType where
 instance InstantiateFull NLPSort where
   instantiateFull' (PType x) = PType <$> instantiateFull' x
   instantiateFull' (PProp x) = PProp <$> instantiateFull' x
+  instantiateFull' (PSSet x) = PSSet <$> instantiateFull' x
   instantiateFull' (PInf f n) = return $ PInf f n
   instantiateFull' PSizeUniv = return PSizeUniv
   instantiateFull' PLockUniv = return PLockUniv

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -224,6 +224,7 @@ instance Match () NLPSort Sort where
     case (p , s) of
       (PType lp  , Type l  ) -> match r gamma k () lp l
       (PProp lp  , Prop l  ) -> match r gamma k () lp l
+      (PSSet lp  , SSet l  ) -> match r gamma k () lp l
       (PInf fp np , Inf f n)
         | fp == f, np == n   -> yes
       (PSizeUniv , SizeUniv) -> yes

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -92,8 +92,8 @@ instance PatternFrom () Sort NLPSort where
     case s of
       Type l   -> PType <$> patternFrom r k () l
       Prop l   -> PProp <$> patternFrom r k () l
+      SSet l   -> PSSet <$> patternFrom r k () l
       Inf f n  -> return $ PInf f n
-      SSet l   -> __IMPOSSIBLE__
       SizeUniv -> return PSizeUniv
       LockUniv -> return PLockUniv
       IntervalUniv -> return PIntervalUniv
@@ -232,6 +232,7 @@ instance NLPatToTerm NLPType Type where
 instance NLPatToTerm NLPSort Sort where
   nlPatToTerm (PType l) = Type <$> nlPatToTerm l
   nlPatToTerm (PProp l) = Prop <$> nlPatToTerm l
+  nlPatToTerm (PSSet l) = SSet <$> nlPatToTerm l
   nlPatToTerm (PInf f n) = return $ Inf f n
   nlPatToTerm PSizeUniv = return SizeUniv
   nlPatToTerm PLockUniv = return LockUniv
@@ -254,6 +255,7 @@ instance NLPatVars NLPSort where
   nlPatVarsUnder k = \case
     PType l   -> nlPatVarsUnder k l
     PProp l   -> nlPatVarsUnder k l
+    PSSet l   -> nlPatVarsUnder k l
     PInf f n  -> empty
     PSizeUniv -> empty
     PLockUniv -> empty
@@ -311,6 +313,7 @@ instance GetMatchables NLPSort where
   getMatchables = \case
     PType l   -> getMatchables l
     PProp l   -> getMatchables l
+    PSSet l   -> getMatchables l
     PInf f n  -> empty
     PSizeUniv -> empty
     PLockUniv -> empty
@@ -345,6 +348,7 @@ instance Free NLPSort where
   freeVars' = \case
     PType l   -> freeVars' l
     PProp l   -> freeVars' l
+    PSSet l   -> freeVars' l
     PInf f n  -> mempty
     PSizeUniv -> mempty
     PLockUniv -> mempty

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -80,7 +80,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20220325 * 10 + 0
+currentInterfaceVersion = 20220606 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -266,6 +266,7 @@ instance EmbPrj NLPSort where
   icod_ PSizeUniv   = icodeN 3 PSizeUniv
   icod_ PLockUniv   = icodeN 4 PLockUniv
   icod_ PIntervalUniv = icodeN 5 PIntervalUniv
+  icod_ (PSSet a)   = icodeN 6 PSSet a
 
   value = vcase valu where
     valu [0, a] = valuN PType a
@@ -274,6 +275,7 @@ instance EmbPrj NLPSort where
     valu [3]    = valuN PSizeUniv
     valu [4]    = valuN PLockUniv
     valu [5]    = valuN PIntervalUniv
+    valu [6, a] = valuN PSSet a
     valu _      = malformed
 
 instance EmbPrj RewriteRule where

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -940,6 +940,7 @@ instance Subst NLPSort where
   applySubst rho = \case
     PType l   -> PType $ applySubst rho l
     PProp l   -> PProp $ applySubst rho l
+    PSSet l   -> PSSet $ applySubst rho l
     PInf f n  -> PInf f n
     PSizeUniv -> PSizeUniv
     PLockUniv -> PLockUniv

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-00-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-01-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
@@ -181,7 +181,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-00-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Suite of tests for bugs"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" bugs
@@ -231,7 +231,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-00-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
@@ -282,7 +282,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-00-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}

--- a/test/Succeed/Issue5944.agda
+++ b/test/Succeed/Issue5944.agda
@@ -1,0 +1,36 @@
+-- Andreas Abel, 2022-06-06, issue #5944 reported by Mike Shulman
+-- Support rewriting with 2ltt (match SSet).
+
+{-# OPTIONS --type-in-type --rewriting --two-level #-}
+
+open import Agda.Primitive public
+
+postulate
+  Tel   : SSet
+  ε     : Tel
+  _≡_   : {A : SSet} (a : A) → A → SSet
+  cong  : (A B : SSet) (f : A → B) {x y : A} (p : x ≡ y) → f x ≡ f y
+  coe←  : (A B : SSet) → (A ≡ B) → B → A
+  el    : Tel → SSet
+  []    : el ε
+  ID    : (Δ : Tel) → Tel
+  ID′   : (Δ : Tel) (Θ : el Δ → Tel) → Tel
+  ID′ε  : (Δ : Tel) → ID′ Δ (λ _ → ε) ≡ ε
+
+{-# BUILTIN REWRITE _≡_ #-}
+{-# REWRITE ID′ε #-}
+
+postulate
+  ID′-CONST   : (Θ : Tel) (Δ : Tel)
+
+              → ID′ Θ (λ _ → Δ) ≡ ID Δ
+
+  ID′-CONST-ε : (Θ : Tel) (δ₂ : el (ID ε))
+
+              → coe← (el (ID′ Θ (λ _ → ε))) (el (ID ε)) (cong Tel (SSet lzero) el (ID′-CONST Θ ε)) δ₂ ≡ []
+
+{-# REWRITE ID′-CONST-ε #-}
+
+-- WAS: internal error when trying to make a pattern from SSet
+
+-- Should succeed now


### PR DESCRIPTION
Fix #5944: allow rewriting to match on `SSet`