### PR TITLE
Re #4725 #5953: termination: consider dotted variable and record patterns

### DIFF
--- a/test/Succeed/Issue4725.agda
+++ b/test/Succeed/Issue4725.agda
@@ -1,0 +1,45 @@
+-- Andreas, 2022-06-14, issue #4725 reported by nad
+
+-- The termination checker needs to recognize
+-- dotted variable and record patterns as patterns
+-- for this example to pass.
+-- These should be harmless even with --cubical
+-- (dotted constructor patterns are not, see #4606).
+-- Keep fingers crossed.
+
+{-# OPTIONS --cubical #-}
+
+open import Agda.Builtin.Sigma
+
+mutual
+
+  data D : Set where
+    d : S → D
+
+  S : Set
+  S = Σ D λ x → R x
+
+  fst′ : S → D
+  fst′ s = fst s
+
+  data R : D → Set where
+    r : ∀ x → R (fst′ x) → R (d x)
+
+module _
+  (P : D → Set)
+  (Q : ∀ x → P x → R x → Set)
+  (p : ∀ s (p : P (fst s)) → Q (fst s) p (snd s) → P (d s))
+  (q : ∀ s rs (ps : P (fst s)) (qs : Q (fst s) ps (snd s)) →
+       Q (fst s) ps rs → Q (d s) (p s ps qs) (r s rs))
+  where
+
+  mutual
+
+    f : (x : D) → P x
+    f (d (x , r₁)) = p (x , r₁) (f x) (g x r₁)
+
+    g : (x : D) (x⊑y : R x) → Q x (f x) x⊑y
+    g (d (x , r₁)) (r .(x , r₁) r₂) =
+      q (x , r₁) r₂ (f x) (g x r₁) (g (fst′ (x , r₁)) r₂)
+
+-- Should termination check.

--- a/test/Succeed/Issue4725.warn
+++ b/test/Succeed/Issue4725.warn
@@ -1,0 +1,25 @@
+Issue4725.agda:42,5-43,58
+Could not generate equivalence when splitting on indexed family,
+the function will not compute on transports by a path.
+  Reason: UnsupportedYet Injectivity
+                           position:    0
+                           type:        D
+                           datatype:    D
+                           parameters: 
+                           indices:    
+                           constructor: d
+when checking the definition of g
+
+———— All done; warnings encountered ————————————————————————
+
+Issue4725.agda:42,5-43,58
+Could not generate equivalence when splitting on indexed family,
+the function will not compute on transports by a path.
+  Reason: UnsupportedYet Injectivity
+                           position:    0
+                           type:        D
+                           datatype:    D
+                           parameters: 
+                           indices:    
+                           constructor: d
+when checking the definition of g

--- a/test/Succeed/Issue5953.agda
+++ b/test/Succeed/Issue5953.agda
@@ -1,0 +1,43 @@
+-- Andreas, 2022-06-14, issue #5953 reported by Szumi Xi
+-- Cubical Agda switches dot-pattern termination off (#4606).
+-- However, this breaks also some benign cases.
+--
+-- In this example with inductive-inductive types,
+-- dotted variables should still be recognized
+-- as variable patterns for termination certification.
+
+{-# OPTIONS --cubical #-}  -- worked with --without-K but not --cubical
+
+-- Debugging:
+-- {-# OPTIONS -v term.check.clause:25 #-}
+-- {-# OPTIONS -v term:20 #-}
+
+data Con : Set
+data Ty : Con → Set
+
+data Con where
+  nil : Con
+  ext : (Γ : Con) → Ty Γ → Con
+
+data Ty where
+  univ : (Γ : Con) → Ty Γ
+  pi : (Γ : Con) (A : Ty Γ) → Ty (ext Γ A) → Ty Γ
+
+module _
+  (A : Set)
+  (B : A → Set)
+  (n : A)
+  (e : (a : A) → B a → A)
+  (u : (a : A) → B a)
+  (p : (a : A) (b : B a) → B (e a b) → B a)
+  where
+  recCon : Con → A
+  recTy : (Γ : Con) → Ty Γ → B (recCon Γ)
+
+  recCon nil = n
+  recCon (ext Γ A) = e (recCon Γ) (recTy Γ A)
+
+  recTy Γ (univ Γ) = u (recCon Γ)
+  recTy Γ (pi Γ A B) = p (recCon Γ) (recTy Γ A) (recTy (ext Γ A) B)
+
+-- Should pass the termination checker.


### PR DESCRIPTION
Fix #4725, fix #5953.

With #4606, `--cubical` no longer considered dotted patterns as patterns for termination certification.  

This patch considers dotted variables and dotted record patterns as benign and considers then as pattern
always in the termination checker, even in the first phase (no dot-patterns) which is the only phase with `--cubical`.  (The other modes have the dot-pattern termination phase as well.)

This fix was suggested by @jespercockx https://github.com/agda/agda/issues/4725#issuecomment-780565074.