### PR TITLE
New verbosity -v debug.time:100 adds time stamps to debugging output

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -254,6 +254,8 @@ library
                 , template-haskell >= 2.11.0.0 && < 2.19
                 , text >= 1.2.3.0 && < 2.1
                 , time >= 1.6.0.1 && < 1.13
+                , time-compat >= 1.9.2 && < 1.10
+                    -- time-compat adds needed functionality missing in time < 1.9
                 , transformers >= 0.5 && < 0.7
                 , unordered-containers >= 0.2.5.0 && < 0.3
                 , uri-encode >= 1.5.0.4 && < 1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ Library management
 Pragmas and options
 -------------------
 
+* New verbosity `-v debug.time:100` adds time stamps to debugging output.
+
 * Profiling options are now turned on with a new `--profile` flag instead of
   abusing the debug verbosity option. (See [#5781](https://github.com/agda/agda/issues/5731).)
 

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -24,6 +24,10 @@ extra-deps:
 - wcwidth-0.0.2
 - text-icu-0.7.1.0
 
+# instead of time-1.9, we add time-compat
+- time-compat-1.9.2.2
+- base-orphans-0.8.1
+
 # Local packages, usually specified by relative directory name
 packages:
 - '.'

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -19,6 +19,10 @@ extra-deps:
 - wcwidth-0.0.2
 - text-icu-0.7.1.0
 
+# instead of time-1.9, we add time-compat
+- time-compat-1.9.2.2
+- base-orphans-0.8.1
+
 # Local packages, usually specified by relative directory name
 packages:
 - '.'

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -13,6 +13,10 @@ extra-deps:
 - uuid-types-1.0.3
 - text-icu-0.7.1.0
 
+# instead of time-1.9, we add time-compat
+- time-compat-1.9.2.2
+- base-orphans-0.8.1
+
 # Local packages, usually specified by relative directory name
 packages:
 - '.'


### PR DESCRIPTION
New verbosity `-v debug.time:100`, adds time stamps to debugging output.

Also cosmetic changes to Generalize.hs
- document arguments of one function
- guard some debugging-only code under `reportSDoc`

TODO:
- [x] use `time-compat` package to relax `time >= 1.9` constraint (which gives headache with stack)