### PR TITLE
Fix #5952: rebalance test.yml workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
         - ubuntu-20.04
         stack-ver:
         - latest
-  cubical-benchmark-misc:
+  cubical-latex-html:
     needs: build
     runs-on: ${{ needs.build.outputs.os }}
     steps:
@@ -123,22 +123,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install texlive-binaries ${APT_GET_OPTS}
         sudo apt-get install emacs-nox ${APT_GET_OPTS}
-    - name: Benchmark
-      run: |
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-summary
-    - name: Internal test suite
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" internal-tests
-    - name: Suite of interaction tests
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" DONT_RUN_LATEX=Y interaction
     - name: Suite of tests for the LaTeX and HTML backends
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" DONT_RUN_LATEX=Y latex-html-test
-    - name: Suite of examples
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" examples
-    - name: Successful tests using Agda as a Haskell library
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" api-test
-    - name: User manual (test)
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-test
     - name: Testing the Emacs mode
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" testing-emacs-mode
     - name: Cubical library test
@@ -217,10 +203,24 @@ jobs:
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" succeed
     - name: Suite of failing tests
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" fail
-    - name: Compiler tests
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" compiler-test
+    - name: User manual (test)
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-test
+    - name: Suite of examples
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" examples
     - name: Suite of interactive tests
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interactive
+    - name: Successful tests using Agda as a Haskell library
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" api-test
+    - name: Internal test suite
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" internal-tests
+    - name: Suite of interaction tests
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
+    - name: Benchmark
+      run: |
+        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs
+        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-summary
+    - name: Compiler tests
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" compiler-test
 name: Build, Test, and Benchmark
 'on':
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,7 @@ jobs:
     - name: Internal test suite
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" internal-tests
     - name: Suite of interaction tests
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" DONT_RUN_LATEX=Y interaction
     - name: Benchmark
       run: |
         make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,7 @@ jobs:
     - name: Internal test suite
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" internal-tests
     - name: Suite of interaction tests
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" DONT_RUN_LATEX=Y interaction
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
     - name: Benchmark
       run: |
         make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
         - ubuntu-20.04
         stack-ver:
         - latest
-  cubical-latex-html:
+  cubical-interaction-latex-html:
     needs: build
     runs-on: ${{ needs.build.outputs.os }}
     steps:
@@ -127,6 +127,8 @@ jobs:
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" DONT_RUN_LATEX=Y latex-html-test
     - name: Testing the Emacs mode
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" testing-emacs-mode
+    - name: Suite of interaction tests
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
     - name: Cubical library test
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
   stdlib-test:
@@ -213,8 +215,6 @@ jobs:
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" api-test
     - name: Internal test suite
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" internal-tests
-    - name: Suite of interaction tests
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
     - name: Benchmark
       run: |
         make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -58,6 +58,10 @@ env:
   TASTY_ANSI_TRICKS: "false"
 
 jobs:
+
+  # Step 1: Building Agda
+  ###########################################################################
+
   build:
     strategy:
       matrix:
@@ -152,6 +156,10 @@ jobs:
           dist.tzst
           stack-work.tzst
 
+
+  # Step 2a: Basic testsuites: succeed, fail, etc.
+  ###########################################################################
+
   test:
     needs: build
     runs-on: ${{ needs.build.outputs.os }}
@@ -185,21 +193,58 @@ jobs:
 
     - name: "Suite of tests for bugs"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" bugs
+      #    14s (2022-06-17)
 
     - name: "Suite of successful tests: mini-library Common"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" common
+      #     8s (2022-06-17)
 
     - name: "Suite of successful tests"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" succeed
+      # 4m 14s (2022-06-17)
 
     - name: "Suite of failing tests"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" fail
+      # 2m  0s (2022-06-17)
 
-    - name: "Compiler tests"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" compiler-test
+    - name: "User manual (test)"
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-test
+      #    13s (2022-06-17)
+
+    - name: "Suite of examples"
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" examples
+      #    41s (2022-06-17)
 
     - name: "Suite of interactive tests"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interactive
+      #     0s (2022-06-17)
+
+    - name: "Successful tests using Agda as a Haskell library"
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" api-test
+      #    21s (2022-06-17)
+
+    - name: "Internal test suite"
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" internal-tests
+      #    11s (2022-06-17)
+
+    - name: "Suite of interaction tests"
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
+      # 2m 39s (2022-06-17)
+      # This test has erratic outages (#5619), so we place it late in the queue.
+
+    - name: "Benchmark"
+      run: |
+        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs
+        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-summary
+      # 6m  3s (2022-06-17)
+
+    - name: "Compiler tests"
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" compiler-test
+      # 9m 34s (2022-06-17)
+
+
+  # Step 2b: tests involving the standard library
+  ###########################################################################
 
   stdlib-test:
     needs: build
@@ -252,7 +297,11 @@ jobs:
     - name: "Interaction tests using the standard library"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" std-lib-interaction
 
-  cubical-benchmark-misc:
+
+  # Step 2c: testing the cubical library and the LaTeX/HTML backend
+  ###########################################################################
+
+  cubical-latex-html:
     needs: build
 
     runs-on: ${{ needs.build.outputs.os }}
@@ -293,28 +342,8 @@ jobs:
         sudo apt-get install texlive-binaries ${APT_GET_OPTS}
         sudo apt-get install emacs-nox ${APT_GET_OPTS}
 
-    - name: "Benchmark"
-      run: |
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-summary
-
-    - name: "Internal test suite"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" internal-tests
-
-    - name: "Suite of interaction tests"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" DONT_RUN_LATEX=Y interaction
-
     - name: "Suite of tests for the LaTeX and HTML backends"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" DONT_RUN_LATEX=Y latex-html-test
-
-    - name: "Suite of examples"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" examples
-
-    - name: "Successful tests using Agda as a Haskell library"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" api-test
-
-    - name: "User manual (test)"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-test
 
     - name: "Testing the Emacs mode"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" testing-emacs-mode

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -228,10 +228,7 @@ jobs:
       #    11s (2022-06-17)
 
     - name: "Suite of interaction tests"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" DONT_RUN_LATEX=Y interaction
-        # Andreas, 2022-06-17: dropping DONT_RUN_LATEX=Y fails test/interaction/QuickLaTeX-Caching.
-        # DONT_RUN_LATEX is checked in test/LaTeXAndHTML/Tests.hs (and only there, says grep).
-        # It is unclear to me how the information is propagated...
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
       # 2m 39s (2022-06-17)
       # This test has erratic outages (#5619), so we place it late in the queue.
 

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -228,7 +228,10 @@ jobs:
       #    11s (2022-06-17)
 
     - name: "Suite of interaction tests"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" DONT_RUN_LATEX=Y interaction
+        # Andreas, 2022-06-17: dropping DONT_RUN_LATEX=Y fails test/interaction/QuickLaTeX-Caching.
+        # DONT_RUN_LATEX is checked in test/LaTeXAndHTML/Tests.hs (and only there, says grep).
+        # It is unclear to me how the information is propagated...
       # 2m 39s (2022-06-17)
       # This test has erratic outages (#5619), so we place it late in the queue.
 

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -227,11 +227,6 @@ jobs:
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" internal-tests
       #    11s (2022-06-17)
 
-    - name: "Suite of interaction tests"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
-      # 2m 39s (2022-06-17)
-      # This test has erratic outages (#5619), so we place it late in the queue.
-
     - name: "Benchmark"
       run: |
         make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs
@@ -301,7 +296,7 @@ jobs:
   # Step 2c: testing the cubical library and the LaTeX/HTML backend
   ###########################################################################
 
-  cubical-latex-html:
+  cubical-interaction-latex-html:
     needs: build
 
     runs-on: ${{ needs.build.outputs.os }}
@@ -347,6 +342,11 @@ jobs:
 
     - name: "Testing the Emacs mode"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" testing-emacs-mode
+
+    - name: "Suite of interaction tests"
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
+      # 2m 39s (2022-06-17)
+      # This test has erratic outages (#5619), so we place it late in the queue.
 
     # (Liang-Ting Chen, 2022-01-02): For testing breaking changes where
     # libraries need to be updated, cubical library test is moved to the end of


### PR DESCRIPTION
Moving stuff from (3) cubical-benchmark-misc to (1) test.

- (3) only retains the cubical and the LaTeX/HTML tests.

- In (1), test are ordered as in Makefile, with some adjustments
  to place quicker tests earlier.