### PR TITLE
[ fix #5727 ] Normalise level expressions before checking convertibility

### DIFF
--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1307,8 +1307,8 @@ leqLevel a b = catchConstraint (LevelCmp CmpLeq a b) $ do
           sep [ prettyTCM a <+> "=<"
               , prettyTCM b ]
 
-      (a, b) <- reduce (a, b)
-      SynEq.checkSyntacticEquality a b
+      (a, b) <- normalise (a, b)
+      SynEq.checkSyntacticEquality' a b
         (\_ _ ->
           reportSDoc "tc.conv.level" 60
             "checkSyntacticEquality returns True") $ \a b -> do
@@ -1457,17 +1457,18 @@ equalLevel a b = do
                ]
         ]
 
-  (a, b) <- reduce (a, b)
-  SynEq.checkSyntacticEquality a b
+  (a, b) <- normalise (a, b)
+
+  -- Jesper, 2014-02-02 remove terms that certainly do not contribute
+  -- to the maximum
+  let (a', b') = removeSubsumed a b
+
+  SynEq.checkSyntacticEquality' a' b'
     (\_ _ ->
       reportSDoc "tc.conv.level" 60
         "checkSyntacticEquality returns True") $ \a b -> do
 
   reportSDoc "tc.conv.level" 60 "checkSyntacticEquality returns False"
-
-  -- Jesper, 2014-02-02 remove terms that certainly do not contribute
-  -- to the maximum
-  let (a', b') = removeSubsumed a b
 
   let notok    = unlessM typeInType notOk
       notOk    = typeError $ UnequalLevel CmpEq a' b'

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1563,8 +1563,8 @@ equalLevel a b = do
               List1.zipWithM_ ((===) `on` levelTm . unSingleLevel . fmap ignoreBlocking) as bs
 
         -- more cases?
-        _ | noMetas (Level a , Level b) -> notok
-          | otherwise                   -> postpone
+        _ | noMetas (a , b) -> notok
+          | otherwise       -> postpone
 
       where
         a === b = unlessM typeInType $ do

--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -82,6 +82,8 @@ checkSyntacticEquality u v s f =
       Strict.Just n  ->
         env { envSyntacticEqualityFuel = Strict.Just (pred n) }
 
+-- | Syntactic equality check for terms without checking remaining fuel.
+
 {-# SPECIALIZE checkSyntacticEquality' ::
       Term -> Term ->
       (Term -> Term -> ReduceM a) ->
@@ -97,9 +99,7 @@ checkSyntacticEquality'
   => a
   -> a
   -> (a -> a -> m b)  -- ^ Continuation used upon success.
-  -> (a -> a -> m b)  -- ^ Continuation used upon failure, or if
-                      --   syntactic equality checking has been turned
-                      --   off.
+  -> (a -> a -> m b)  -- ^ Continuation used upon failure.
   -> m b
 checkSyntacticEquality' u v s f = do
   ((u, v), equal) <- liftReduce $ synEq u v `runStateT` True

--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -10,6 +10,7 @@
 module Agda.TypeChecking.SyntacticEquality
   ( SynEq
   , checkSyntacticEquality
+  , checkSyntacticEquality'
   , syntacticEqualityFuelRemains
   )
   where
@@ -70,18 +71,39 @@ checkSyntacticEquality
                       --   syntactic equality checking has been turned
                       --   off.
   -> m b
-checkSyntacticEquality v v' s f =
+checkSyntacticEquality u v s f =
   ifM syntacticEqualityFuelRemains
-  {-then-} (do ((v, v'), equal) <-
-                 liftReduce $ synEq v v' `runStateT` True
-               if equal then s v v' else localTC decreaseFuel (f v v'))
-  {-else-} (uncurry f =<< instantiate (v,v'))
+  {-then-} (checkSyntacticEquality' u v s (\u v -> localTC decreaseFuel (f u v)))
+  {-else-} (uncurry f =<< instantiate (u, v))
   where
   decreaseFuel env =
     case envSyntacticEqualityFuel env of
       Strict.Nothing -> env
       Strict.Just n  ->
         env { envSyntacticEqualityFuel = Strict.Just (pred n) }
+
+{-# SPECIALIZE checkSyntacticEquality' ::
+      Term -> Term ->
+      (Term -> Term -> ReduceM a) ->
+      (Term -> Term -> ReduceM a) ->
+      ReduceM a #-}
+{-# SPECIALIZE checkSyntacticEquality' ::
+      Type -> Type ->
+      (Type -> Type -> ReduceM a) ->
+      (Type -> Type -> ReduceM a) ->
+      ReduceM a #-}
+checkSyntacticEquality'
+  :: (Instantiate a, SynEq a, MonadReduce m)
+  => a
+  -> a
+  -> (a -> a -> m b)  -- ^ Continuation used upon success.
+  -> (a -> a -> m b)  -- ^ Continuation used upon failure, or if
+                      --   syntactic equality checking has been turned
+                      --   off.
+  -> m b
+checkSyntacticEquality' u v s f = do
+  ((u, v), equal) <- liftReduce $ synEq u v `runStateT` True
+  if equal then s u v else f u v
 
 -- | Does the syntactic equality check have any remaining fuel?
 

--- a/test/Succeed/Issue5727.agda
+++ b/test/Succeed/Issue5727.agda
@@ -1,0 +1,18 @@
+open import Agda.Primitive
+
+data Wrap (A : Set) : Set where
+  wrap : A → Wrap A
+
+foldWrap : {A B : Set} → (A → B) → Wrap A → B
+foldWrap f (wrap x) = f x
+
+id₀ : Level → Level
+id₀ ℓ = ℓ
+
+id₁ : Level → Level
+id₁ = id₀
+
+id₂ : {wℓ : Wrap Level}
+    → Set (foldWrap id₀ wℓ ⊔ foldWrap id₁ wℓ)
+    → Set (foldWrap id₀ wℓ)
+id₂ A = A


### PR DESCRIPTION
1. Add `checkSyntacticEquality'` that always checks without considering fuel
2. Use normalisation for the universe check
3. Remove subsumed terms right after normalisation

Some small test cases are being cooked, but I have been using this patch for a while in a research project.