### PR TITLE
Allow several BUILTIN REWRITE relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,28 @@ Library management
 Pragmas and options
 -------------------
 
+* It is now possible to declare several `BUILTIN REWRITE` relations.
+  Example:
+  ```agda
+  {-# OPTIONS --rewriting #-}
+
+  open import Agda.Builtin.Equality
+  open import Agda.Builtin.Equality.Rewrite  -- 1st rewrite relation
+
+  postulate
+    R : (A : Set) → A → A → Set
+    A : Set
+    a b c : A
+    foo : R A a b  -- using 2nd rewrite relation
+    bar : b ≡ c    -- using 1st rewrite relation
+
+  {-# BUILTIN REWRITE R #-}  -- 2nd rewrite relation
+  {-# REWRITE foo bar #-}
+
+  test : a ≡ c
+  test = refl
+  ```
+
 * New verbosity `-v debug.time:100` adds time stamps to debugging output.
 
 * Profiling options are now turned on with a new `--profile` flag instead of

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -26,6 +26,8 @@ import Agda.TypeChecking.Pretty
 
 import Agda.Utils.Either
 import Agda.Utils.Lens
+import Agda.Utils.List   (hasElem)
+import Agda.Utils.Maybe
 import Agda.Utils.Pretty (prettyShow)
 import qualified Agda.Utils.Haskell.Syntax as HS
 
@@ -156,12 +158,14 @@ xForPrim :: Map String a -> BuiltinThings PrimFun -> [Definition] -> [a]
 xForPrim table builtinThings defs = catMaybes
     [ Map.lookup s table
     | (s, def) <- Map.toList builtinThings
-    , getName def `Set.member` qs
+    , maybe False elemDefs $ getName def
     ]
   where
-  qs = Set.fromList $ map defName defs
-  getName (Builtin t)            = getPrimName t
-  getName (Prim (PrimFun q _ _)) = q
+  elemDefs = hasElem $ map defName defs
+  getName = \case
+    Builtin t                 -> Just $ getPrimName t
+    Prim (PrimFun q _ _)      -> Just q
+    BuiltinRewriteRelations _ -> Nothing
 
 
 -- | Definition bodies for primitive functions

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -263,6 +263,7 @@ instance NamesIn a => NamesIn (Builtin a) where
   namesAndMetasIn' sg = \case
     Builtin t -> namesAndMetasIn' sg t
     Prim x    -> namesAndMetasIn' sg x
+    BuiltinRewriteRelations xs -> namesAndMetasIn' sg xs
 
 -- | Note that the 'primFunImplementation' is skipped.
 instance NamesIn PrimFun where

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1660,6 +1660,7 @@ instantiateFullExceptForDefinitions =
 instance InstantiateFull a => InstantiateFull (Builtin a) where
     instantiateFull' (Builtin t) = Builtin <$> instantiateFull' t
     instantiateFull' (Prim x)   = Prim <$> instantiateFull' x
+    instantiateFull' b@(BuiltinRewriteRelations xs) = pure b
 
 instance InstantiateFull Candidate where
   instantiateFull' (Candidate q u t ov) =

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -22,13 +22,16 @@ import Agda.TypeChecking.Monad hiding (enterClosure, constructorForm)
 import Agda.TypeChecking.Substitute
 
 import Agda.Utils.Lens
+import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Pretty () --instance only
 
 
 instance HasBuiltins ReduceM where
-  getBuiltinThing b = liftM2 mplus (Map.lookup b <$> useR stLocalBuiltins)
-                                   (Map.lookup b <$> useR stImportedBuiltins)
+  getBuiltinThing b =
+    liftM2 (unionMaybeWith unionBuiltin)
+      (Map.lookup b <$> useR stLocalBuiltins)
+      (Map.lookup b <$> useR stImportedBuiltins)
 
 constructorForm :: HasBuiltins m => Term -> m Term
 constructorForm v = do

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -844,7 +844,8 @@ bindBuiltinInfo (BuiltinInfo s d) e = do
           t <- tcmt
           (,t) <$> checkExpr e t
         f v t
-        bindBuiltinName s v
+        if | s == builtinRewrite -> bindBuiltinRewriteRelation =<< getQNameFromTerm v
+           | otherwise           -> bindBuiltinName s v
 
 setConstTranspAxiom :: QName -> TCM ()
 setConstTranspAxiom q =

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -80,7 +80,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20220606 * 10 + 0
+currentInterfaceVersion = 20220624 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -551,10 +551,12 @@ instance EmbPrj a => EmbPrj (I.Pattern' a) where
 instance EmbPrj a => EmbPrj (Builtin a) where
   icod_ (Prim    a) = icodeN' Prim a
   icod_ (Builtin a) = icodeN 1 Builtin a
+  icod_ (BuiltinRewriteRelations a) = icodeN 2 BuiltinRewriteRelations a
 
   value = vcase valu where
     valu [a]    = valuN Prim    a
     valu [1, a] = valuN Builtin a
+    valu [2, a] = valuN BuiltinRewriteRelations a
     valu _      = malformed
 
 instance EmbPrj a => EmbPrj (Substitution' a) where

--- a/test/Succeed/MultipleRewriteRelations.agda
+++ b/test/Succeed/MultipleRewriteRelations.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2022-06-24, allow several rewrite relations.
+
+{-# OPTIONS --rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+postulate
+  R : (A : Set) → A → A → Set
+  A : Set
+  a b c : A
+  foo : R A a b  -- using new rewrite relation
+  bar : b ≡ c    -- using old rewrite relation
+
+{-# BUILTIN REWRITE R #-}
+{-# REWRITE foo bar #-}
+
+test : a ≡ c
+test = refl


### PR DESCRIPTION
For @mikeshulman: Allow several BUILTIN REWRITE relations. E.g.
```agda
{-# OPTIONS --rewriting #-}

open import Agda.Builtin.Equality
open import Agda.Builtin.Equality.Rewrite

postulate
  R : (A : Set) → A → A → Set
  A : Set
  a b c : A
  foo : R A a b  -- using new rewrite relation
  bar : b ≡ c    -- using old rewrite relation

{-# BUILTIN REWRITE R #-}
{-# REWRITE foo bar #-}

test : a ≡ c
test = refl
```

This adds `BuiltinRewriteRelations` as a new `Builtin` form.

Also:
- remove unused `primRewrite`