### PR TITLE
Minor deserialisation optimisations

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -244,6 +244,7 @@ library
                 , regex-tdfa >= 1.3.1.0 && < 1.4
                 , split >= 0.2.0.0 && < 0.2.4
                 , stm >= 2.4.4 && < 2.6
+                , STMonadTrans >= 0.4.3 && < 0.5
                 , strict >= 0.3.2 && < 0.5
                 , template-haskell >= 2.11.0.0 && < 2.19
                 , text >= 1.2.3.0 && < 2.1

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -186,6 +186,8 @@ instance B.Binary a => B.Binary (ListLike a) where
     n <- lift (B.get :: B.Get Int)
     arr <- newArray_ (0, fromIntegral n - 1) :: STT s B.Get (STArray s Int32 a)
 
+    -- We'd like to use 'for_ [0..n-1]' here, but unfortunately GHC doesn't unfold
+    -- the list construction and so performs worse than the hand-written version.
     let
       getMany i = if i == n then return () else do
         x <- lift B.get

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -181,7 +181,7 @@ encode a = do
 newtype ListLike a = ListLike { unListLike :: Array Int32 a }
 
 instance B.Binary a => B.Binary (ListLike a) where
-  put = __IMPOSSIBLE__ -- Will never deserialise this
+  put = __IMPOSSIBLE__ -- Will never serialise this
   get = fmap ListLike $ runSTArray $ do
     n <- lift (B.get :: B.Get Int)
     arr <- newArray_ (0, fromIntegral n - 1) :: STT s B.Get (STArray s Int32 a)

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -38,6 +38,7 @@ import Control.Monad.Reader
 import Control.Monad.State.Strict
 
 import Data.Array.IArray
+import Data.Array.IO
 import Data.Word
 import Data.ByteString.Lazy    ( ByteString )
 import Data.ByteString.Builder ( byteString, toLazyByteString )
@@ -197,7 +198,7 @@ decode s = do
      else do
 
       st <- St (ar nL) (ar ltL) (ar stL) (ar bL) (ar iL) (ar dL)
-              <$> liftIO H.empty
+              <$> liftIO (newArray (0, List.genericLength nL - 1) mempty)
               <*> return mf <*> return incs
       (r, st) <- runStateT (runExceptT (value r)) st
       return (Just $ modFile st, r)


### PR DESCRIPTION
Related to #5977, I've been fiddling with a couple of other minor optimisations to the deserialiser:

 - Use an `Array Int32 (HashMap TypeRepr U)` for caching deserialised nodes, rather than `HashTable (Int32, TypeRepr) U`

   The intuition here is that _most_ nodes will only deserialise to a single type type, and so its quicker to do an array lookup + lookup in a singleton HashMap (the latter of which is cheap) compare with a lookup in a hashtable (which requires several array accesses).

 - Deserialise "straight" to an array:

   The current `decode` implementation reads/writes a list of a type (strings, numbers, nodes) using `Binary.get`, gets the length of that array, and then converts it to an array.

   Replacing the call to `genericLength :: [a] -> Int32` with `fromIntegral . genericLength` significantly brings a reasonable boost (0.6s quicker in my test project). However, we can avoid computing the length entirely by defining our own `Binary` instance which can reuse the length, gaining another 0.3s.

   It's possible writing our own `Binary` instance specialises better too - I've tried to dig into the core, but it's a very noisy diff to wade through.

As in #5977, benchmarks were taken on a non-profiling build built with GHC 8.10.7, then tested by loading [this project](https://github.com/plt-amy/1lab). I've not tested this on other projects, compilers or machines, so not sure how consistent these improvements will be (somewhat scared to test it on the whole stdlib, given how long it takes to TC, but not sure if there's other good projects to benchmark?).

Definitely not an expert on any of this, and not sure how sensible this patch is, so happy to make any changes!

<details><summary>Baseline (#5977)</summary>

```
Total                      9,508ms
Miscellaneous                  4ms
Deserialization            7,103ms (9,412ms)
Deserialization.Compaction 2,308ms
Import                        69ms
Parsing                       21ms
  10,808,268,736 bytes allocated in the heap
   3,967,777,072 bytes copied during GC
     285,751,936 bytes maximum residency (44 sample(s))
       4,242,320 bytes maximum slop
             515 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      8977 colls,     0 par    3.248s   3.270s     0.0004s    0.0173s
  Gen  1        44 colls,     0 par    0.547s   0.548s     0.0124s    0.0474s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    5.729s  (  5.693s elapsed)
  GC      time    3.796s  (  3.818s elapsed)
  EXIT    time    0.001s  (  0.009s elapsed)
  Total   time    9.527s  (  9.521s elapsed)

  Alloc rate    1,886,509,235 bytes per MUT second

  Productivity  60.1% of total user, 59.8% of total elapsed
```

</details>

<details><summary>Use an array for memoising deserialised values (783ae634f1f754b94a74568c105293a1297bbe3c)</summary>

```
Total                      8,464ms
Miscellaneous                  3ms
Deserialization            5,805ms (8,385ms)
Deserialization.Compaction 2,579ms
Import                        61ms
Parsing                       14ms
   8,407,722,464 bytes allocated in the heap
   3,794,800,792 bytes copied during GC
     278,672,144 bytes maximum residency (36 sample(s))
         233,256 bytes maximum slop
             528 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      7127 colls,     0 par    3.440s   3.462s     0.0005s    0.0177s
  Gen  1        36 colls,     0 par    0.434s   0.434s     0.0121s    0.0477s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    4.615s  (  4.589s elapsed)
  GC      time    3.874s  (  3.896s elapsed)
  EXIT    time    0.001s  (  0.005s elapsed)
  Total   time    8.491s  (  8.490s elapsed)

  Alloc rate    1,821,966,522 bytes per MUT second

  Productivity  54.3% of total user, 54.0% of total elapsed
```

</details>

<details><summary>Deserialise directly to an array (73dcce0e76b262daff2a0d1f293b0ed25abd1da5)</summary>

```
Total                      7,524ms          
Miscellaneous                  6ms          
Deserialization            4,987ms (7,415ms)
Deserialization.Compaction 2,428ms          
Import                        62ms          
Parsing                       29ms          
ModuleName                    10ms          
   7,573,159,984 bytes allocated in the heap
   3,359,548,336 bytes copied during GC
     275,288,952 bytes maximum residency (33 sample(s))
         314,592 bytes maximum slop
             486 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      6510 colls,     0 par    2.909s   2.925s     0.0004s    0.0180s
  Gen  1        33 colls,     0 par    0.355s   0.356s     0.0108s    0.0481s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    4.275s  (  4.243s elapsed)
  GC      time    3.265s  (  3.281s elapsed)
  EXIT    time    0.001s  (  0.006s elapsed)
  Total   time    7.542s  (  7.531s elapsed)

  Alloc rate    1,771,375,687 bytes per MUT second

  Productivity  56.7% of total user, 56.3% of total elapsed
```

</details>