### PR TITLE
More efficient encoding of maps in interface files

### DIFF
--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -83,7 +83,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20220628 * 10 + 0
+currentInterfaceVersion = 20220708 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 


### PR DESCRIPTION
Apologies for the PR spam, was continuing to fiddle with deserialisation and thought this might be useful!

Currently maps (and map-like structures like `RangeMap`) are encoded as            a list of integers, each integer pointing to a k,v pair. While this encoding does maximise sharing (in the stored file, not in the deserialised maps), the additional indirection does come with a performance cost when reading and writing the file.

This patch encodes maps with a flat list of integers (so `k1:v1:k2:v2:...`). This reduces file size by about 20%, speeds up serialisation by ~10% and deserialisation by ~2%.

It's worth noting that most of these improvements come from `RangeMap` (which uses `start1:end1:v1:...` instead of its previous `(start1, (end1, v1):...`). I'd be happy to just cherry-pick that out if you'd prefer not to change the encoding of Map/HashMap.

### Performance
Comparison when serialising/deserialising several projects, measured with `--profile=internal`.

| Project         | Serialisation before  | Serialisation after   | Deserialisation before | Deserialisation after |
|-----------------|-----------------------|-----------------------|------------------------|-----------------------|
| agda-stdlib     | 162,354ms (182,401ms) | 148,514ms (165,233ms) | 19,523ms (30,966ms)    | 18,843ms (30,129ms)   |
| agda-categories | 199,015ms (209,933ms) | 179,155ms (188,871ms) | 10,156ms (16,276ms)    | 9,729ms (15,661ms)    |
