### PR TITLE
GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Issue report
+about: Create a report to help us improve Agda
+title: ''
+labels: ''
+assignees: ''
+---
+
+
+---
+
+Please make sure it is actually a problem with Agda or its documentation.
+For user questions, the [mailing list](https://lists.chalmers.se/mailman/listinfo/agda)
+or the [chat](https://agda.zulipchat.com)
+are better fora.
+
+Please take some time to search through the exising issues whether the
+problem has already been reported.  If it is already an open issue,
+you might confine yourself with just adding your problem instance as a
+comment there.
+
+For opening a new issue, please make sure you can check the following boxes:
+
+* [ ] My report includes the version of Agda
+      (and Emacs, GHC, and OS versions where relevant).
+
+* [ ] The issue can be reproduced with the _latest version_ of Agda
+      (either [released](https://wiki.portal.chalmers.se/agda/Main/Download) or
+      `master` branch).
+      Note: We do not fix issues in older versions of Agda.
+
+* [ ] I have supplied all information so the bug can be easily reproduced
+      (in particular, the reproducer is a complete Agda file).
+
+Note: The best reproducers are those only using the `Agda.Builtin` and
+`Agda.Primitive` modules shipped with Agda.


### PR DESCRIPTION
This is a proposal for a bug report template for use with the issue tracker.  The purpose is to prevent

- user questions on the bug tracker
- bugs reported for older versions of Agda
- incomplete reproducers