### PR TITLE
Fix #5989: also track names (and metas) in tactic arguments

### DIFF
--- a/src/full/Agda/Syntax/Internal/MetaVars.hs
+++ b/src/full/Agda/Syntax/Internal/MetaVars.hs
@@ -23,12 +23,17 @@ instance AllMetas Term
 instance AllMetas Type
 instance TermLike a => AllMetas (Elim' a)
 instance TermLike a => AllMetas (Tele a)
-instance TermLike a => AllMetas (Dom a)
+
+instance (AllMetas a, AllMetas b) => AllMetas (Dom' a b) where
+  allMetas f (Dom _ _ _ t e) = allMetas f t <> allMetas f e
 
 -- These types need to be packed up as a Term to get the metas.
 instance AllMetas Sort      where allMetas f   = allMetas f . Sort
 instance AllMetas Level     where allMetas f   = allMetas f . Level
 instance AllMetas PlusLevel where allMetas f l = allMetas f (Max 0 [l])
+
+instance {-# OVERLAPPING #-} AllMetas String where
+  allMetas f _ = mempty
 
 -- Generic instances
 instance (AllMetas a, AllMetas b) => AllMetas (a, b) where

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -79,12 +79,16 @@ instance NamesIn a => NamesIn (Map k a)
 
 -- Decorations
 instance NamesIn a => NamesIn (Arg a)
-instance NamesIn a => NamesIn (Dom a)
 instance NamesIn a => NamesIn (Named n a)
 instance NamesIn a => NamesIn (Abs a)
 instance NamesIn a => NamesIn (WithArity a)
 instance NamesIn a => NamesIn (Open a)
 instance NamesIn a => NamesIn (C.FieldAssignment' a)
+
+instance (NamesIn a, NamesIn b) => NamesIn (Dom' a b) where
+  namesAndMetasIn' sg (Dom _ _ _ t e) =
+    mappend (namesAndMetasIn' sg t) (namesAndMetasIn' sg e)
+
 
 -- Specific collections
 instance NamesIn a => NamesIn (Tele a)

--- a/test/Succeed/Issue5989.agda
+++ b/test/Succeed/Issue5989.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2022-07-12, issue #5989 reported by j-towns
+--
+-- The use of a private macro in a tactic annotation
+-- produced an internal error when the private macro
+-- was removed by dead code elimination.
+--
+-- Reason: names in tactic arguments were not tracked.
+
+{-# OPTIONS -v impossible:10 #-}
+
+module Issue5989 where
+
+open import Agda.Builtin.Nat
+open import Issue5989.Import
+
+two : Nat
+two = use-tactic 2
+
+-- Should succeed without error.

--- a/test/Succeed/Issue5989/Import.agda
+++ b/test/Succeed/Issue5989/Import.agda
@@ -1,0 +1,20 @@
+-- Auxiliary module for issue #5989
+
+-- {-# OPTIONS -v tc.dead:100 #-}
+
+module Issue5989.Import where
+
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+open import Agda.Builtin.List
+
+private
+  trivial-tactic : Term -> TC ⊤
+  trivial-tactic hole = unify hole (con (quote zero) [])
+
+use-tactic : (a : Nat) -> {@(tactic trivial-tactic) x : Nat} -> Nat
+use-tactic a = a
+
+three : Nat
+three = use-tactic 3


### PR DESCRIPTION
Fix #5989: also track names (and metas) in tactic arguments.

Apparently, when the `tactic` feature was introduced (generalizing `Dom` to `Dom'`), the traversals collecting names and metas were not updated.