### PR TITLE
Fix #5956: reify empty system to absurd lambda

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,39 @@ jobs:
         - ubuntu-20.04
         stack-ver:
         - latest
-  cubical-interaction-latex-html:
+  cubical:
+    needs: build
+    runs-on: ${{ needs.build.outputs.os }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - uses: haskell/actions/setup@v1
+      with:
+        enable-stack: true
+        ghc-version: ${{ needs.build.outputs.ghc-ver }}
+        stack-version: ${{ needs.build.outputs.stack-ver }}
+    - uses: actions/download-artifact@v2
+      with:
+        name: agda-${{ runner.os }}-${{ github.sha }}
+    - name: Unpack artifacts
+      run: |
+        tar --use-compress-program zstd -xvf dist.tzst
+        tar --use-compress-program zstd -xvf stack-work.tzst
+    - id: cache
+      name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+          }}-${{ hashFiles('stack.yaml.lock') }}
+        path: ~/.stack
+    - name: Install and configure the icu library
+      run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
+    - name: Cubical library test
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
+    - name: Successful tests using the cubical library
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-succeed
+  interaction-latex-html:
     needs: build
     runs-on: ${{ needs.build.outputs.os }}
     steps:
@@ -129,8 +161,6 @@ jobs:
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" testing-emacs-mode
     - name: Suite of interaction tests
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
-    - name: Cubical library test
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
   stdlib-test:
     needs: build
     runs-on: ${{ needs.build.outputs.os }}

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -864,6 +864,7 @@ test-suite agda-tests
   main-is:          Main.hs
   other-modules:      Bugs.Tests
                     , Compiler.Tests
+                    , CubicalSucceed.Tests
                     , Fail.Tests
                     , Interactive.Tests
                     , Internal.Compiler.MAlonzo.Encode

--- a/Makefile
+++ b/Makefile
@@ -537,6 +537,12 @@ continue-std-lib-test :
 	@(cd std-lib && \
           time $(AGDA_BIN) $(PROFILEOPTS) --no-default-libraries -i. -isrc README.agda +RTS -s)
 
+.PHONY : cubical-succeed ##
+cubical-succeed :
+	@$(call decorate, "Successful tests using the cubical library", \
+	  find test/CubicalSucceed -type f -name '*.agdai' -delete ; \
+	  AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/CubicalSucceed)
+
 .PHONY : std-lib-succeed ##
 std-lib-succeed :
 	@$(call decorate, "Successful tests using the standard library", \

--- a/src/full/Agda/Compiler/Treeless/Identity.hs
+++ b/src/full/Agda/Compiler/Treeless/Identity.hs
@@ -6,13 +6,13 @@ import Prelude hiding ((!!))  -- don't use partial functions
 
 import Control.Applicative ( Alternative((<|>), empty) )
 import Data.Semigroup
-import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List as List
 
 import Agda.Syntax.Treeless
 import Agda.TypeChecking.Monad
 
 import Agda.Utils.List
+import Agda.Utils.List1 (pattern (:|))
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -69,7 +69,7 @@ import Agda.Utils.Functor ( (<&>) )
 import Agda.Utils.IO ( catchIO )
 import qualified Agda.Utils.IO.UTF8 as UTF8
 import Agda.Utils.List
-import Agda.Utils.List1 ( List1 )
+import Agda.Utils.List1 ( List1, pattern (:|) )
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
@@ -146,7 +146,7 @@ getPrimitiveLibDir = do
 --   by default.
 --
 defaultLibraryFiles :: List1 FilePath
-defaultLibraryFiles = List1.fromList ["libraries-" ++ version, "libraries"]
+defaultLibraryFiles = ("libraries-" ++ version) :| "libraries" : []
 
 -- | The @defaultsFile@ contains a list of library names relevant for each Agda project.
 --
@@ -162,7 +162,7 @@ defaultsFile = "defaults"
 --   by default.
 --
 defaultExecutableFiles :: List1 FilePath
-defaultExecutableFiles = List1.fromList ["executables-" ++ version, "executables"]
+defaultExecutableFiles = ("executables-" ++ version) :| "executables" : []
 
 ------------------------------------------------------------------------
 -- * Get the libraries for the current project

--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -181,7 +181,7 @@ nameStringParts n = [ s | Id s <- List1.toList $ nameParts n ]
 stringNameParts :: String -> NameParts
 stringNameParts ""  = singleton $ Id "_"  -- NoName
 stringNameParts "_" = singleton $ Id "_"  -- NoName
-stringNameParts s = List1.fromList $ loop s
+stringNameParts s = List1.fromList __IMPOSSIBLE__ $ loop s
   where
   loop ""                              = []
   loop ('_':s)                         = Hole : loop s

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -4,7 +4,6 @@ module Agda.Syntax.Internal.Names where
 
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HMap
-import Data.List.NonEmpty (NonEmpty(..))
 import Data.Map (Map)
 import Data.Set (Set)
 
@@ -18,6 +17,7 @@ import Agda.Syntax.Treeless
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.CompiledClause
 
+import Agda.Utils.List1 (List1)
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Singleton
 import Agda.Utils.Impossible
@@ -73,7 +73,7 @@ class NamesIn a where
 instance NamesIn a => NamesIn (Maybe a)
 instance NamesIn a => NamesIn (Strict.Maybe a)
 instance NamesIn a => NamesIn [a]
-instance NamesIn a => NamesIn (NonEmpty a)
+instance NamesIn a => NamesIn (List1 a)
 instance NamesIn a => NamesIn (Set a)
 instance NamesIn a => NamesIn (Map k a)
 

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -851,7 +851,7 @@ LamBindings
   : LamBinds '->' {%
       case absurdBinding $1 of
         Just{}  -> parseError "Absurd lambda cannot have a body."
-        Nothing -> return $ List1.fromList $ lamBindings $1
+        Nothing -> return $ List1.fromList __IMPOSSIBLE__ $ lamBindings $1
       }
 
 AbsurdLamBindings :: { Either ([LamBinding], Hiding) (List1 Expr) }

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -867,7 +867,7 @@ instance ToConcrete A.Expr where
                 reportSLn "extendedlambda" 50 $ "abstractToConcrete extended lambda patterns ps = " ++ prettyShow ps
                 return $ LamClause ps rhs ca
               decl2clause _ = __IMPOSSIBLE__
-          C.ExtendedLam (getRange i) erased . List1.fromList <$>
+          C.ExtendedLam (getRange i) erased . List1.fromList __IMPOSSIBLE__ <$>
             mapM decl2clause decls
             -- TODO List1: can we demonstrate non-emptiness?
 

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -43,8 +43,6 @@ import Data.Map (Map)
 import qualified Data.Foldable as Fold
 import Data.Void
 import Data.List (sortBy)
-import Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.List.NonEmpty as NonEmpty
 import Data.Semigroup (Semigroup, (<>))
 import Data.String
 
@@ -186,7 +184,7 @@ isBuiltinFun = asks $ is . builtins
   where is m q b = Just q == Map.lookup b m
 
 -- | Resolve a concrete name. If illegally ambiguous fail with the ambiguous names.
-resolveName :: KindsOfNames -> Maybe (Set A.Name) -> C.QName -> AbsToCon (Either (NonEmpty A.QName) ResolvedName)
+resolveName :: KindsOfNames -> Maybe (Set A.Name) -> C.QName -> AbsToCon (Either (List1 A.QName) ResolvedName)
 resolveName kinds candidates q = runExceptT $ tryResolveName kinds candidates q
 
 -- | Treat illegally ambiguous names as UnknownNames.
@@ -722,9 +720,9 @@ instance ToConcrete ResolvedName where
   toConcrete = \case
     VarName x _          -> C.QName <$> toConcrete x
     DefinedName _ x s    -> addSuffixConcrete s $ toConcrete x
-    FieldName xs         -> toConcrete (NonEmpty.head xs)
-    ConstructorName _ xs -> toConcrete (NonEmpty.head xs)
-    PatternSynResName xs -> toConcrete (NonEmpty.head xs)
+    FieldName xs         -> toConcrete (List1.head xs)
+    ConstructorName _ xs -> toConcrete (List1.head xs)
+    PatternSynResName xs -> toConcrete (List1.head xs)
     UnknownName          -> __IMPOSSIBLE__
 
 addSuffixConcrete :: HasOptions m => A.Suffix -> m C.QName -> m C.QName

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -29,8 +29,6 @@ import Data.Set (Set)
 import Data.Map (Map)
 import Data.Functor (void)
 import qualified Data.List as List
-import Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Set as Set
 import qualified Data.Map as Map
 import Data.Maybe
@@ -608,8 +606,8 @@ instance ToAbstract ResolveQName where
     q -> return q
 
 data APatName = VarPatName A.Name
-              | ConPatName (NonEmpty AbstractName)
-              | PatternSynPatName (NonEmpty AbstractName)
+              | ConPatName (List1 AbstractName)
+              | PatternSynPatName (List1 AbstractName)
 
 instance ToAbstract PatName where
   type AbsOfCon PatName = APatName
@@ -667,9 +665,9 @@ instance ToQName a => ToAbstract (OldName a) where
       DefinedName _ d NoSuffix -> return $ anameName d
       DefinedName _ d Suffix{} -> notInScopeError (toQName x)
       -- We can get the cases below for DISPLAY pragmas
-      ConstructorName _ ds -> return $ anameName (NonEmpty.head ds)   -- We'll throw out this one, so it doesn't matter which one we pick
-      FieldName ds         -> return $ anameName (NonEmpty.head ds)
-      PatternSynResName ds -> return $ anameName (NonEmpty.head ds)
+      ConstructorName _ ds -> return $ anameName (List1.head ds)   -- We'll throw out this one, so it doesn't matter which one we pick
+      FieldName ds         -> return $ anameName (List1.head ds)
+      PatternSynResName ds -> return $ anameName (List1.head ds)
       VarName x _          -> genericError $ "Not a defined name: " ++ prettyShow x
       UnknownName          -> notInScopeError (toQName x)
 

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -833,7 +833,7 @@ scopeCheckExtendedLam r erased cs = do
       setScope si  -- This turns into an A.ScopedExpr si $ A.ExtendedLam...
       return $
         A.ExtendedLam (ExprRange r) di erased qname' $
-        List1.fromList cs
+        List1.fromList __IMPOSSIBLE__ cs
     _ -> __IMPOSSIBLE__
 
 -- | Raise an error if argument is a C.Dot with Hiding info.

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -820,7 +820,7 @@ reifyTerm expandAnonDefs0 v0 = do
             Quantityω o -> NotErased o
             Quantity1 o -> __IMPOSSIBLE__
       elims (A.ExtendedLam exprNoRange dInfo erased x $
-             List1.fromList cls)
+             List1.fromList __IMPOSSIBLE__ cls)
         =<< reify rest
 
 -- | @nameFirstIfHidden (x:a) ({e} es) = {x = e} es@

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -795,7 +795,7 @@ reifyTerm expandAnonDefs0 v0 = do
       :: MonadReify m
       => QName -> ArgInfo -> Int -> Maybe System -> [I.Clause]
       -> I.Elims -> m Expr
-    reifyExtLam x i npars msys cls es = do
+    reifyExtLam x ai npars msys cls es = do
       reportSLn "reify.def" 10 $ "reifying extended lambda " ++ prettyShow x
       reportSLn "reify.def" 50 $ render $ nest 2 $ vcat
         [ "npars =" <+> pretty npars
@@ -815,13 +815,14 @@ reifyTerm expandAnonDefs0 v0 = do
       let cx     = nameConcrete $ qnameName x
           dInfo  = mkDefInfo cx noFixity' PublicAccess ConcreteDef
                      (getRange x)
-          erased = case getQuantity i of
+          erased = case getQuantity ai of
             Quantity0 o -> Erased o
             Quantityω o -> NotErased o
             Quantity1 o -> __IMPOSSIBLE__
-      elims (A.ExtendedLam exprNoRange dInfo erased x $
-             List1.fromList __IMPOSSIBLE__ cls)
-        =<< reify rest
+          lam = case cls of
+            []       -> A.AbsurdLam exprNoRange NotHidden
+            (cl:cls) -> A.ExtendedLam exprNoRange dInfo erased x (cl :| cls)
+      elims lam =<< reify rest
 
 -- | @nameFirstIfHidden (x:a) ({e} es) = {x = e} es@
 nameFirstIfHidden :: Dom (ArgName, t) -> [Elim' a] -> [Elim' (Named_ a)]

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -27,7 +27,6 @@ import qualified Data.CaseInsensitive as CaseInsens
 import Data.Foldable (foldl)
 import Data.Function
 import Data.List (sortBy, dropWhileEnd, intercalate)
-import qualified Data.List.NonEmpty as NonEmpty
 import Data.Maybe
 import qualified Data.Set as Set
 import qualified Text.PrettyPrint.Boxes as Boxes
@@ -937,7 +936,7 @@ instance PrettyTCM TypeError where
       , fsep $ pwords "(hint: overloaded pattern synonyms must be equal up to variable and constructor names)"
       ]
       where
-        (x, _) = NonEmpty.head defs
+        (x, _) = List1.head defs
         prDef (x, (xs, p)) = prettyA (A.PatternSynDef x (map (fmap BindName) xs) p) <?> ("at" <+> pretty r)
           where r = nameBindingSite $ qnameName x
 

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -3,7 +3,6 @@ module Agda.TypeChecking.Level where
 
 import Data.Maybe
 import qualified Data.List as List
-import Data.List.NonEmpty (NonEmpty(..))
 import Data.Traversable (Traversable)
 
 import Agda.Syntax.Common
@@ -14,6 +13,7 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Reduce
 
+import Agda.Utils.List1 ( List1, pattern (:|) )
 import Agda.Utils.Maybe ( caseMaybeM, allJustM )
 import Agda.Utils.Monad ( tryMaybe )
 import Agda.Utils.Singleton
@@ -223,7 +223,7 @@ unSingleLevels ls = levelMax n as
     n = maximum $ 0 : [m | SingleClosed m <- ls]
     as = [a | SinglePlus a <- ls]
 
-levelMaxView :: Level' t -> NonEmpty (SingleLevel' t)
+levelMaxView :: Level' t -> List1 (SingleLevel' t)
 levelMaxView (Max n [])     = singleton $ SingleClosed n
 levelMaxView (Max 0 (a:as)) = SinglePlus a :| map SinglePlus as
 levelMaxView (Max n as)     = SingleClosed n :| map SinglePlus as

--- a/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
@@ -8,8 +8,6 @@ module Agda.TypeChecking.Monad.SizedTypes where
 import Control.Monad.Except
 
 import qualified Data.Foldable as Fold
-import Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Traversable as Trav
 
 import Agda.Syntax.Common
@@ -22,6 +20,8 @@ import Agda.TypeChecking.Positivity.Occurrence
 import Agda.TypeChecking.Substitute
 
 import Agda.Utils.List
+import Agda.Utils.List1 (List1, pattern (:|))
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Pretty
@@ -164,7 +164,7 @@ sizeSuc_ suc v = Def suc [Apply $ defaultArg v]
 
 -- | Transform list of terms into a term build from binary maximum.
 sizeMax :: (HasBuiltins m, MonadError TCErr m, MonadTCEnv m, ReadTCState m)
-        => NonEmpty Term -> m Term
+        => List1 Term -> m Term
 sizeMax vs = case vs of
   v :| [] -> return v
   vs  -> do
@@ -295,7 +295,7 @@ unDeepSizeView = \case
 -- * View on sizes where maximum is pulled to the top
 ------------------------------------------------------------------------
 
-type SizeMaxView = NonEmpty DeepSizeView
+type SizeMaxView = List1 DeepSizeView
 type SizeMaxView' = [DeepSizeView]
 
 maxViewMax :: SizeMaxView -> SizeMaxView -> SizeMaxView
@@ -310,7 +310,7 @@ maxViewCons :: DeepSizeView -> SizeMaxView -> SizeMaxView
 maxViewCons _ (DSizeInf :| _) = singleton DSizeInf
 maxViewCons DSizeInf _        = singleton DSizeInf
 maxViewCons v ws = case sizeViewComparableWithMax v ws of
-  NotComparable  -> NonEmpty.cons v ws
+  NotComparable  -> List1.cons v ws
   YesAbove _ ws' -> v :| ws'
   YesBelow{}     -> ws
 

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -12,7 +12,6 @@ import Data.Maybe
 
 import qualified Data.Map as Map
 
-import qualified Data.List.NonEmpty as NonEmpty
 import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.HashMap.Strict as HMap
@@ -39,6 +38,7 @@ import Agda.TypeChecking.CompiledClause
 
 import Agda.Utils.Hash
 import Agda.Utils.Lens
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Monad (bracket_)
 import Agda.Utils.Pretty
 import Agda.Utils.Tuple
@@ -418,7 +418,7 @@ lookupPatternSyn (AmbQ xs) = do
   defs <- traverse lookupSinglePatternSyn xs
   case mergePatternSynDefs defs of
     Just def   -> return def
-    Nothing    -> typeError $ CannotResolveAmbiguousPatternSynonym (NonEmpty.zip xs defs)
+    Nothing    -> typeError $ CannotResolveAmbiguousPatternSynonym $ List1.zip xs defs
 
 lookupSinglePatternSyn :: QName -> TCM PatternSynDefn
 lookupSinglePatternSyn x = do

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -15,7 +15,6 @@ import Control.Monad
 import Control.Monad.Except
 
 import Data.List (find, sortBy)
-import Data.List.NonEmpty (NonEmpty(..))
 import Data.Function (on)
 
 import qualified Agda.Syntax.Abstract as A
@@ -47,6 +46,7 @@ import {-# SOURCE #-} Agda.TypeChecking.Rewriting
 
 import Agda.Utils.Functor
 import Agda.Utils.List
+import Agda.Utils.List1 (pattern (:|))
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null

--- a/src/full/Agda/TypeChecking/Rules/Display.hs
+++ b/src/full/Agda/TypeChecking/Rules/Display.hs
@@ -1,7 +1,6 @@
 
 module Agda.TypeChecking.Rules.Display (checkDisplayPragma) where
 
-import qualified Data.List.NonEmpty as NonEmpty
 import Control.Monad.State
 import Data.Maybe
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -20,8 +20,6 @@ import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.IntSet as IntSet
 import Data.IntSet (IntSet)
-import Data.List.NonEmpty (NonEmpty(..), nonEmpty)
-import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Set as Set
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
@@ -49,6 +47,8 @@ import qualified Agda.Utils.BiMap as BiMap
 import qualified Agda.Utils.Empty as Empty
 import Agda.Utils.FileName
 import qualified Agda.Utils.HashTable as H
+import Agda.Utils.List1 (List1)
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.List2 (List2(List2))
 import qualified Agda.Utils.List2 as List2
 import Agda.Utils.Maybe
@@ -253,9 +253,9 @@ instance {-# OVERLAPPABLE #-} EmbPrj a => EmbPrj [a] where
 --                            valu [x, xs] = valu2 (:) x xs
 --                            valu _       = malformed
 
-instance EmbPrj a => EmbPrj (NonEmpty a) where
-  icod_ = icod_ . NonEmpty.toList
-  value = maybe malformed return . nonEmpty <=< value
+instance EmbPrj a => EmbPrj (List1 a) where
+  icod_ = icod_ . List1.toList
+  value = maybe malformed return . List1.nonEmpty <=< value
 
 instance EmbPrj a => EmbPrj (List2 a) where
   icod_ = icod_ . List2.toList

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -9,7 +9,6 @@ import Control.Monad.Writer ( MonadWriter(..), WriterT(..), runWriterT )
 
 import qualified Data.Foldable as Fold
 import qualified Data.List as List
-import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.Set (Set)
@@ -31,6 +30,7 @@ import {-# SOURCE #-} Agda.TypeChecking.Constraints
 
 import Agda.Utils.Functor
 import Agda.Utils.List as List
+import Agda.Utils.List1 (pattern (:|))
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -485,7 +485,7 @@ instance Unquote R.Term where
           , (c `isCon` primAgdaTermMeta,    R.Meta    <$> unquoteN x <*> unquoteN y)
           , (c `isCon` primAgdaTermLam,     R.Lam     <$> unquoteN x <*> unquoteN y)
           , (c `isCon` primAgdaTermPi,      mkPi      <$> unquoteN x <*> unquoteN y)
-          , (c `isCon` primAgdaTermExtLam,  R.ExtLam  <$> (List1.fromList <$> unquoteN x) <*> unquoteN y)
+          , (c `isCon` primAgdaTermExtLam,  R.ExtLam  <$> (List1.fromList __IMPOSSIBLE__ <$> unquoteN x) <*> unquoteN y)
           ]
           __IMPOSSIBLE__
         where

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -36,13 +36,22 @@ import qualified Data.Maybe as Maybe
 import qualified Data.Semigroup as Semigroup
 
 import qualified Data.List.NonEmpty (NonEmpty)
-import Data.List.NonEmpty as List1 hiding (NonEmpty)
+import Data.List.NonEmpty as List1 hiding (NonEmpty, fromList)
 
 import Agda.Utils.Functor ((<.>))
 import Agda.Utils.Null (Null(..))
 import qualified Agda.Utils.List as List
 
 type List1 = Data.List.NonEmpty.NonEmpty
+
+-- | Safe version of 'Data.List.NonEmpty.fromList'.
+
+fromList
+  :: List1 a  -- ^ Default value if convertee is empty.
+  -> [a]      -- ^ List to convert, supposedly non-empty.
+  -> List1 a  -- ^ Converted list.
+fromList err   [] = err
+fromList _ (x:xs) = x :| xs
 
 -- | Return the last element and the rest.
 

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -288,10 +288,10 @@ jobs:
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" std-lib-interaction
 
 
-  # Step 2c: testing the cubical library and the LaTeX/HTML backend
+  # Step 2c: testing the interaction and the LaTeX/HTML backend
   ###########################################################################
 
-  cubical-interaction-latex-html:
+  interaction-latex-html:
     needs: build
 
     runs-on: ${{ needs.build.outputs.os }}
@@ -343,8 +343,46 @@ jobs:
       # 2m 39s (2022-06-17)
       # This test has erratic outages (#5619), so we place it late in the queue.
 
-    # (Liang-Ting Chen, 2022-01-02): For testing breaking changes where
-    # libraries need to be updated, cubical library test is moved to the end of
-    # this job.
+  # Step 2d: testing the cubical library
+  ###########################################################################
+
+  cubical:
+    needs: build
+
+    runs-on: ${{ needs.build.outputs.os }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: haskell/actions/setup@v1
+      with:
+        ghc-version: ${{ needs.build.outputs.ghc-ver }}
+        stack-version: ${{ needs.build.outputs.stack-ver }}
+        enable-stack: true
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: agda-${{ runner.os }}-${{ github.sha }}
+
+    - name: "Unpack artifacts"
+      run: |
+        tar --use-compress-program zstd -xvf dist.tzst
+        tar --use-compress-program zstd -xvf stack-work.tzst
+
+    - uses: actions/cache@v2
+      name: Cache dependencies
+      id: cache
+      with:
+        path: "~/.stack"
+        # A unique cache is used for each stack.yaml.
+        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+
+    - name: "Install and configure the icu library"
+      run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
+
     - name: "Cubical library test"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
+
+    - name: "Successful tests using the cubical library"
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-succeed

--- a/test/CubicalSucceed/Issue5956.agda
+++ b/test/CubicalSucceed/Issue5956.agda
@@ -1,0 +1,18 @@
+-- Andreas, 2022-07-21, issue #5956, reported by kangrongji
+-- Testcase by dolio
+
+{-# OPTIONS --cubical --allow-unsolved-metas #-}
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Univalence
+
+p : I → Type₁
+p i = Glue Type (λ { (i = i0) → (Type , idEquiv _) })
+
+P : Type ≡ Glue Type _
+P i = p i
+
+-- Used to crash when trying to reify an empty system to a
+-- pattern lambda.  Now reified as absurd lambda.
+-- Expected result: unsolved metas.

--- a/test/CubicalSucceed/Tests.hs
+++ b/test/CubicalSucceed/Tests.hs
@@ -1,0 +1,88 @@
+
+module CubicalSucceed.Tests where
+
+import qualified Data.Text as T
+import Data.List (isInfixOf)
+import Data.Monoid ((<>))
+
+import System.Exit
+import System.FilePath
+
+import Test.Tasty                 ( testGroup, TestTree )
+import Test.Tasty.Silver          ( printProcResult )
+import Test.Tasty.Silver.Advanced ( GDiff(..), GShow(..), goldenTestIO1 )
+import Test.Tasty.Silver.Filter   ( RegexFilter(RFInclude) )
+
+import Utils
+
+testDir :: FilePath
+testDir = "test" </> "CubicalSucceed"
+
+disabledTests :: [RegexFilter]
+disabledTests =
+  []
+
+-- | Filter out files that contain one of these words.
+notTests :: [String]
+notTests =
+  []
+
+tests :: IO TestTree
+tests = do
+  let isTest file = not $ any (`isInfixOf` file) notTests
+  inpFiles <- filter isTest <$> getAgdaFilesInDir Rec testDir
+
+  let tests' :: [TestTree]
+      tests' = map mkCubicalSucceedTest inpFiles
+
+  return $ testGroup "CubicalSucceed" tests'
+
+rtsOptions :: [String]
+rtsOptions = [ "+RTS", "-H1G", "-M1.5G", "-RTS" ]
+
+data TestResult
+  = TestSuccess
+  | TestUnexpectedFail ProgramResult
+
+mkCubicalSucceedTest :: FilePath  -- ^ Agda file to test.
+                 -> TestTree
+mkCubicalSucceedTest agdaFile =
+  goldenTestIO1
+    testName
+    readGolden
+    (printAgdaResult <$> doRun)
+    (textDiffWithTouch agdaFile)
+    (return . ShowText)
+    Nothing
+  where
+    testName :: String
+    testName = asTestName testDir agdaFile
+
+    -- We don't really have a golden file. Just use a dummy update
+    -- function. TODO extend tasty-silver to handle this use case
+    -- properly
+    readGolden :: IO (Maybe T.Text)
+    readGolden = return $ Just $ printAgdaResult TestSuccess
+
+    doRun :: IO TestResult
+    doRun = do
+      -- ASR (04 January 2016). We don't use the @--ignore-interfaces@
+      -- option for avoiding type-check the cubical library in every
+      -- test-case. The interface files are deleted in the Makefile.
+      let agdaArgs :: AgdaArgs
+          agdaArgs = [ "-v0"
+                     , "-i" ++ testDir
+                     , "-i" ++ "cubical"
+                     , "--no-libraries"
+                     , "--cubical"
+                     , agdaFile
+                     ] ++ rtsOptions
+      (res, ret) <- runAgdaWithOptions testName agdaArgs Nothing Nothing
+      pure $ case ret of
+        AgdaSuccess{} -> TestSuccess -- TODO: fail if unexpected warnings?
+        AgdaFailure{} -> TestUnexpectedFail res
+
+printAgdaResult :: TestResult -> T.Text
+printAgdaResult = \case
+  TestSuccess          -> "AGDA_SUCCESS"
+  TestUnexpectedFail p -> "AGDA_UNEXPECTED_FAIL\n\n" <> printProgramResult p

--- a/test/Internal/Helpers.hs
+++ b/test/Internal/Helpers.hs
@@ -217,7 +217,7 @@ listOfElements xs = listOf $ elements xs
 
 -- | Generates an officially non-empty list, while 'listOf1' does it inofficially.
 list1Of :: Gen a -> Gen (List1 a)
-list1Of = List1.fromList <.> listOf1
+list1Of = List1.fromList undefined <.> listOf1
 
 -- | If the given list is non-empty, then an element from the list is
 -- generated, and otherwise an arbitrary element is generated.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,6 +7,7 @@ import qualified Interactive.Tests as INTERACTIVE
 import qualified Internal.Tests as INTERNAL
 import qualified LaTeXAndHTML.Tests as LATEXHTML
 import qualified LibSucceed.Tests as LIBSUCCEED
+import qualified CubicalSucceed.Tests as CUBICALSUCCEED
 import qualified UserManual.Tests as USERMANUAL
 import qualified Bugs.Tests as BUGS
 
@@ -55,6 +56,7 @@ tests = do
       {- 6 -} pu INTERNAL.tests    :
       {- 7 -} sg COMPILER.tests    :
       {- 8 -} sg LIBSUCCEED.tests  :
+      {- 9 -} sg CUBICALSUCCEED.tests  :
       []
   where
   sg = id


### PR DESCRIPTION
Fix #5956: reify empty system to absurd lambda.

Before, Agda crashed when trying to reify it to a pattern lambda, which does not allow 0 clauses.