### PR TITLE
Fix link in documentation

### DIFF
--- a/doc/user-manual/language/lossy-unification.lagda.rst
+++ b/doc/user-manual/language/lossy-unification.lagda.rst
@@ -77,4 +77,4 @@ the heuristic will repeatedly attempt to unify lists of arguments ``es₀
 References
 ----------
 
-Slow typechecking of single one-line definition, `issue (#1625) <https://arxiv.org/abs/1611.02108>`_.
+Slow typechecking of single one-line definition, `issue (#1625) <https://github.com/agda/agda/issues/1625>`_.


### PR DESCRIPTION
This PR just fixes one link in the user manual, that clearly pointed to the wrong target.