### PR TITLE
Restrict type of equivProof; Remove primIdJ; Rename ouc→outS everywhere.

### DIFF
--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -896,7 +896,7 @@ files. However, for regular users and beginners the ``agda/cubical``
 library should be sufficient and this section can safely be ignored.
 
 **Warning**: Many of the built-ins whose definitions can be written in
-Agda are nonetheless used internally the implementation of cubical Agda,
+Agda are nonetheless used internally in the implementation of cubical Agda,
 and using different implementations can easily lead to unsoundness. Even
 though they are definable in user code, this is not a supported
 use-case.

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -20,6 +20,12 @@
           ; equiv-proof
           ; _≃_
           ; primGlue )
+  open import Agda.Builtin.Cubical.Id public
+    using ( Id
+          ; conid
+          ; primIdElim
+          ; reflId
+          )
 
   open import Agda.Builtin.Sigma public
   open import Agda.Builtin.Bool public
@@ -731,7 +737,7 @@ exports all of the primitives for this type, including the notation
 ``_≡_`` and a ``J`` eliminator that computes definitionally on
 ``refl``.
 
-The cubical identity type and the path type are equivalent, so all of
+The cubical identity types and path types are equivalent, so all of
 the results for one can be transported to the other one (using
 univalence). Using this we have implemented an `interface to HoTT/UF <https://github.com/agda/cubical/blob/5de11df25b79ee49d5c084fbbe6dfc66e4147a2e/Cubical/Experiments/HoTT-UF.agda>`_
 which provides the user with the key primitives of Homotopy Type
@@ -745,7 +751,7 @@ which computes properly.
 
   open import Cubical.Core.Id public
      using ( _≡_            -- The identity type.
-           ; refl            -- Unfortunately, pattern matching on refl is not available.
+           ; refl           -- Its constructor.
            ; J              -- Until it is, you have to use the induction principle J.
 
            ; transport      -- As in the HoTT Book.
@@ -789,21 +795,51 @@ follows:
 
   open import Cubical.Core.HoTT-UF
 
-However, even though this interface exists it is still recommended
-that one uses the cubical identity types unless one really need ``J``
-to compute on ``refl``. The reason for this is that the syntax for
-path types does not work for the identity types, making many proofs
-more involved as the only way to reason about them is using ``J``.
-Furthermore, the path types satisfy many useful definitional
-equalities that the identity types don't.
+However, even though this interface exists, we recommend that users of
+cubical mode use the path types rather than the cubical identity types.
+Primarily, this is because many operations for path types are
+implemented directly, rather than by induction (e.g. ``ap``, ``funExt``,
+``happly``, ``sym``, etc), and thus enjoy better computational
+behaviour. In addition to using ``J`` directly, it is possible to match
+on the reflexivity constructor, as if ``Id`` were an inductive type:
+
+::
+
+  symId : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → Id y x
+  symId reflId = reflId
+
+Cubical identity types are *not* inductively defined, and we may observe
+this using the primitives ``conid`` and ``primIdElim``. These primitives
+expose underlying representation: terms of the cubical identity type can
+be thought of pairs consisting of a path `p` and a cofibration `φ`, such
+that, under the cofibration `φ`, the path `p` is the reflexivty path.
+These primitives are very low-level, and their use is not recommended.
+
+::
+
+  apId : ∀ {ℓ ℓ′} {A : Set ℓ} {B : Set ℓ′} (f : A → B)
+       → {x y : A} → Id x y → Id (f x) (f y)
+  apId f {x = x} = primIdElim (λ y _ → Id (f x) (f y))
+    λ φ y w → conid φ λ i → f (outS w i)
+
+Even though it is possible to define the reflexivity path using
+``conid``, the name ``reflId`` is special, in that it is treated as a
+"matchable" constructor, whereas ``conid`` is not. Depending on your
+syntax highlighting scheme, this can be observed using agda-mode: they
+are different colours. However, for computation, they are treated as the
+same:
+
+::
+  _ : ∀ {ℓ} {A : Set ℓ} {x : A} → reflId ≡ conid i1 (λ _ → x)
+  _ = refl
 
 .. _erased-cubical:
 
-Cubical Agda with erased glue
+Cubical Agda with erased Glue
 -----------------------------
 
 The option :option:`--erased-cubical` enables a variant of Cubical
-Agda in which glue (and the other builtins defined in
+Agda in which Glue (and the other builtins defined in
 ``Agda.Builtin.Cubical.Glue``) must only be used in
 :ref:`erased<runtime-irrelevance>` settings.
 
@@ -858,6 +894,12 @@ primitives available that are not really exported by ``agda/cubical``,
 so the goal of this section is to list the contents of these
 files. However, for regular users and beginners the ``agda/cubical``
 library should be sufficient and this section can safely be ignored.
+
+**Warning**: Many of the built-ins whose definitions can be written in
+Agda are nonetheless used internally the implementation of cubical Agda,
+and using different implementations can easily lead to unsoundness. Even
+though they are definable in user code, this is not a supported
+use-case.
 
 The key file with primitives is ``Agda.Primitive.Cubical``. It exports
 the following ``BUILTIN``, primitives and postulates:
@@ -957,7 +999,7 @@ The Glue types are exported by ``Agda.Builtin.Cubical.Glue``:
   equivFun e = fst e
 
   equivProof : ∀ {la lt} (T : Set la) (A : Set lt) → (w : T ≃ A) → (a : A)
-             → ∀ ψ → (Partial ψ (fiber (w .fst) a)) → fiber (w .fst) a
+             → ∀ ψ (f : Partial ψ (fiber (w .fst) a)) → fiber (w .fst) a [ ψ ↦ f ]
   equivProof A B w a ψ fb = contr' {A = fiber (w .fst) a} (w .snd .equiv-proof a) ψ fb
     where
       contr' : ∀ {ℓ} {A : Set ℓ} → isContr A → (φ : I) → (u : Partial φ A) → A
@@ -1003,6 +1045,7 @@ The ``Agda.Builtin.Cubical.Id`` exports the cubical identity types:
 
   {-# BUILTIN ID           Id       #-}
   {-# BUILTIN CONID        conid    #-}
+  {-# BUILTIN REFLID       reflId   #-}
 
   primitive
     primDepIMin : _

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -14,9 +14,7 @@
              ; itIsOne to 1=1 )
   open import Agda.Builtin.Cubical.Path
   open import Agda.Builtin.Cubical.Sub
-    renaming ( primSubOut to outS
-             ; inc        to inS
-             )
+    renaming ( primSubOut to outS )
   open import Agda.Builtin.Cubical.Glue public
     using ( isEquiv
           ; equiv-proof
@@ -1010,11 +1008,6 @@ The ``Agda.Builtin.Cubical.Id`` exports the cubical identity types:
     primDepIMin : _
     primIdFace : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → I
     primIdPath : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → x ≡ y
-
-  primitive
-    primIdJ : ∀ {ℓ ℓ'} {A : Set ℓ} {x : A} (P : ∀ y → Id x y → Set ℓ') →
-                P x (conid i1 (λ i → x)) → ∀ {y} (p : Id x y) → P y p
-
 
   primitive
     primIdElim : ∀ {a c} {A : Set a} {x : A}

--- a/src/data/JS/agda-rts.js
+++ b/src/data/JS/agda-rts.js
@@ -353,7 +353,6 @@ exports.primDepIMin =
 exports.primConId = _ => _ => _ => _ => i => p => { return { "i" : i, "p" : p } };
 exports.primIdFace = _ => _ => _ => _ => x => x["i"];
 exports.primIdPath = _ => _ => _ => _ => x => x["p"];
-exports.primIdJ = _ => _ => _ => _ => _ => x => _ => _ => x;
 exports.primIdElim =
     _ => _ => _ => _ => _ => f => x => y => f(y["i"])(x)(y["p"]);
 

--- a/src/data/lib/prim/Agda/Builtin/Cubical/Glue.agda
+++ b/src/data/lib/prim/Agda/Builtin/Cubical/Glue.agda
@@ -8,7 +8,7 @@ open import Agda.Primitive.Cubical renaming (primINeg to ~_; primIMax to _∨_; 
                                              primHComp to hcomp; primTransp to transp; primComp to comp;
                                              itIsOne to 1=1)
 open import Agda.Builtin.Cubical.Path
-open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to ouc)
+open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_])
 import Agda.Builtin.Cubical.HCompU as HCompU
 
 module Helpers = HCompU.Helpers
@@ -40,8 +40,9 @@ equivFun e = fst e
 -- case. This makes the computational behavior better, in particular
 -- for transp in Glue.
 equivProof : ∀ {la lt} (T : Set la) (A : Set lt) → (w : T ≃ A) → (a : A)
-           → ∀ ψ → (Partial ψ (fiber (w .fst) a)) → fiber (w .fst) a
-equivProof A B w a ψ fb = contr' {A = fiber (w .fst) a} (w .snd .equiv-proof a) ψ fb
+           → ∀ ψ (f : Partial ψ (fiber (w .fst) a)) → fiber (w .fst) a [ ψ ↦ f ]
+equivProof A B w a ψ fb =
+  inS (contr' {A = fiber (w .fst) a} (w .snd .equiv-proof a) ψ fb)
   where
     contr' : ∀ {ℓ} {A : Set ℓ} → isContr A → (φ : I) → (u : Partial φ A) → A
     contr' {A = A} (c , p) φ u = hcomp (λ i → λ { (φ = i1) → p (u 1=1) i
@@ -96,11 +97,11 @@ module _ {ℓ : I → Level} (P : (i : I) → Set (ℓ i)) where
           sys x i (j = i1) = u (~ i) x
         ω0 = comp ~E (sys x0) ((β0 (~ j)))
         ω1 = comp ~E (sys x1) ((β1 (~ j)))
-        θ0 = fill ~E (sys x0) (inc (β0 (~ j)))
-        θ1 = fill ~E (sys x1) (inc (β1 (~ j)))
+        θ0 = fill ~E (sys x0) (inS (β0 (~ j)))
+        θ1 = fill ~E (sys x1) (inS (β1 (~ j)))
       sys = λ {j (k = i0) → ω0 j ; j (k = i1) → ω1 j}
       ω = hcomp sys (g y)
-      θ = hfill sys (inc (g y))
+      θ = hfill sys (inS (g y))
       δ = λ (j : I) → comp E
             (λ i → λ { (j = i0) → v i y ; (k = i0) → θ0 j (~ i)
                      ; (j = i1) → u i ω ; (k = i1) → θ1 j (~ i) })

--- a/src/data/lib/prim/Agda/Builtin/Cubical/HCompU.agda
+++ b/src/data/lib/prim/Agda/Builtin/Cubical/HCompU.agda
@@ -8,7 +8,7 @@ open import Agda.Primitive.Cubical renaming (primINeg to ~_; primIMax to _∨_; 
                                              primHComp to hcomp; primTransp to transp; primComp to comp;
                                              itIsOne to 1=1)
 open import Agda.Builtin.Cubical.Path
-open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to outS; inc to inS)
+open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to outS)
 
 module Helpers where
     -- Homogeneous filling

--- a/src/data/lib/prim/Agda/Builtin/Cubical/Id.agda
+++ b/src/data/lib/prim/Agda/Builtin/Cubical/Id.agda
@@ -4,7 +4,7 @@ module Agda.Builtin.Cubical.Id where
 
   open import Agda.Primitive.Cubical
   open import Agda.Builtin.Cubical.Path
-  open import Agda.Builtin.Cubical.Sub renaming (primSubOut to ouc; Sub to _[_↦_])
+  open import Agda.Builtin.Cubical.Sub renaming (primSubOut to outS; Sub to _[_↦_])
 
   {-# BUILTIN ID           Id       #-}
   {-# BUILTIN REFLID       reflId   #-}
@@ -16,7 +16,7 @@ module Agda.Builtin.Cubical.Id where
 
   open ConId public renaming (primConId to conid)
 
-  -- Id x y is treated as a pair of I and x ≡ y, using "i" for the
+  -- Id x y is treated as a pair of I and x ≡ y, using "i" for the
   -- first component and "p" for the second.
   {-# COMPILE JS conid =
       _ => _ => _ => _ => i => p => { return { "i" : i, "p" : p } }
@@ -28,14 +28,22 @@ module Agda.Builtin.Cubical.Id where
     primIdPath : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → x ≡ y
 
   primitive
-    primIdJ : ∀ {ℓ ℓ'} {A : Set ℓ} {x : A} (P : ∀ y → Id x y → Set ℓ') →
-                P x (conid i1 (λ i → x)) → ∀ {y} (p : Id x y) → P y p
-
-
-  primitive
     primIdElim : ∀ {a c} {A : Set a} {x : A}
                    (C : (y : A) → Id x y → Set c) →
                    ((φ : I) (y : A [ φ ↦ (λ _ → x) ])
-                    (w : (x ≡ ouc y) [ φ ↦ (λ { (φ = i1) → \ _ → x}) ]) →
-                    C (ouc y) (conid φ (ouc w))) →
+                    (w : (x ≡ outS y) [ φ ↦ (λ { (φ = i1) → \ _ → x}) ]) →
+                    C (outS y) (conid φ (outS w))) →
                    {y : A} (p : Id x y) → C y p
+
+  -- IdJ can be defined in terms of pattern matching on the reflId
+  -- constructor. This equality is definitional; For non-reflId
+  -- identifications, it computes in terms of primIdElim and primComp.
+  IdJ : ∀ {ℓ ℓ'} {A : Set ℓ} {x : A} (P : ∀ y → Id x y → Set ℓ') →
+      P x (conid i1 (λ i → x)) → ∀ {y} (p : Id x y) → P y p
+  IdJ {x = x} P prefl reflId = prefl
+
+  -- Test computational behaviour of IdJ:
+  _ : ∀ {ℓ ℓ'} {A : Set ℓ} {x : A} (P : ∀ y → Id x y → Set ℓ')
+    → (a : P x (conid i1 (λ i → x)))
+    → IdJ P a (conid i1 (λ i → x)) ≡ a
+  _ = λ P a i → a

--- a/src/data/lib/prim/Agda/Builtin/Cubical/Sub.agda
+++ b/src/data/lib/prim/Agda/Builtin/Cubical/Sub.agda
@@ -7,12 +7,12 @@ module Agda.Builtin.Cubical.Sub where
   {-# BUILTIN SUB Sub #-}
 
   postulate
-    inc : ∀ {ℓ} {A : Set ℓ} {φ} (x : A) → Sub A φ (λ _ → x)
+    inS : ∀ {ℓ} {A : Set ℓ} {φ} (x : A) → Sub A φ (λ _ → x)
 
-  {-# BUILTIN SUBIN inc #-}
+  {-# BUILTIN SUBIN inS #-}
 
-  -- Sub A φ u is treated as A.
-  {-# COMPILE JS inc = _ => _ => _ => x => x #-}
+  -- Sub A φ u is treated as A.
+  {-# COMPILE JS inS = _ => _ => _ => x => x #-}
 
   primitive
     primSubOut : ∀ {ℓ} {A : Set ℓ} {φ : I} {u : Partial φ A} → Sub _ φ u → A

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -853,7 +853,6 @@ primitives = Set.fromList
   , "primDepIMin"
   , "primIdFace"
   , "primIdPath"
-  , "primIdJ"
   , builtinIdElim
   , builtinConId
   -- , builtinGlue                   -- missing

--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -317,7 +317,6 @@ primBody s = maybe unimplemented (fromRight (hsVarUQ . HS.Ident) <$>) $
   , "primDepIMin"     |-> return "\\i f -> if i then f () else False"
   , "primIdFace"      |-> return "\\_ _ _ _ -> fst"
   , "primIdPath"      |-> return "\\_ _ _ _ -> snd"
-  , "primIdJ"         |-> return "\\_ _ _ _ _ x _ _ -> x"
   , builtinIdElim     |-> return
                             "\\_ _ _ _ _ f x y -> f (fst y) x (snd y)"
   ]

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -958,7 +958,6 @@ primitiveFunctions = localTCStateSavingWarnings <$> Map.fromListWith __IMPOSSIBL
   , "primComp"            |-> primComp
   , builtinTrans          |-> primTrans'
   , builtinHComp          |-> primHComp'
-  , "primIdJ"             |-> primIdJ
   , "primPartial"         |-> primPartial'
   , "primPartialP"        |-> primPartialP'
   , builtinGlue           |-> primGlue'

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -362,7 +362,7 @@ primIdPath' = do
         mConId <- getName' builtinConId
         cview <- conidView'
         case cview (unArg x) $ unArg (ignoreBlocking st) of
-          Just (phi, w) -> redReturn (unArg w)
+          Just (_, w) -> redReturn (unArg w)
           _ -> return $ NoReduction $ map notReduced [l,bA,x,y] ++ [reduced st]
       _ -> __IMPOSSIBLE__
 

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -194,13 +194,15 @@ coreBuiltins =
                                                                              (cl primEquiv <#> la <#> lb <@> bA <@> bB)) $ \ e -> do
                                                                nPi' "b" (el' lb bB) $ \ b -> do
                                                                 let f = cl primEquivFun <#> la <#> lb <#> bA <#> bB <@> e
-                                                                    fiber = el' (cl primLevelMax <@> la <@> lb)
+                                                                    lub = cl primLevelMax <@> la <@> lb
+                                                                    fiber = el' lub
                                                                                 (cl primSigma <#> la <#> lb
                                                                                   <@> bA
                                                                                   <@> lam "a" (\ a ->
                                                                                          cl primPath <#> lb <#> bB <@> (f <@> a) <@> b))
                                                                 nPi' "φ" (cl tinterval) $ \ phi ->
-                                                                  pPi' "o" phi (\ o -> fiber) --> fiber
+                                                                  nPi' "f" (pPi' "o" phi (\ o -> fiber)) $ \ pfib ->
+                                                                    el' lub (cl primSub <#> lub <#> fmap unEl fiber <@> phi <@> pfib)
                                                              ))
                                                               (const $ const $ return ()))
   , (builtinTranspProof                       |-> BuiltinUnknown (Just $ requireCubical CErased "" >> runNamesT [] (

--- a/test/Common/Path.agda
+++ b/test/Common/Path.agda
@@ -7,6 +7,6 @@ open import Agda.Primitive.Cubical renaming (primINeg to ~_; primIMax to _∨_; 
                                              primHComp to hcomp; primTransp to transp; primComp to comp;
                                              itIsOne to 1=1)
                                    public
-open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to outS; inc to inS) public
+open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to outS) public
 
 open Helpers public

--- a/test/Compiler/simple/Erased-cubical.agda
+++ b/test/Compiler/simple/Erased-cubical.agda
@@ -55,7 +55,7 @@ n₁ : Nat
 n₁ = p₄ i0
 
 s : Sub Nat i1 (λ _ → 13)
-s = inc 13
+s = inS 13
 
 n₂ : Nat
 n₂ = primSubOut s
@@ -76,7 +76,7 @@ p₅ : 12 ≡ 12
 p₅ = primIdPath i₃
 
 n₃ : Nat
-n₃ = primIdJ (λ _ _ → Nat) 14 i₃
+n₃ = IdJ (λ _ _ → Nat) 14 i₃
 
 n₄ : Nat
 n₄ = primIdElim (λ _ _ → Nat) (λ _ _ _ → 14) i₃

--- a/test/Fail/Issue3577.agda
+++ b/test/Fail/Issue3577.agda
@@ -5,7 +5,7 @@ module Issue3577 where
 open import Agda.Primitive.Cubical renaming (primTransp to transp; primHComp to hcomp)
 open import Agda.Builtin.Cubical.Path
 open import Agda.Builtin.Sigma
-open import Agda.Builtin.Cubical.Sub renaming (primSubOut to ouc; Sub to _[_↦_])
+open import Agda.Builtin.Cubical.Sub renaming (primSubOut to outS; Sub to _[_↦_])
 
 refl : ∀ {l} {A : Set l} {x : A} → x ≡ x
 refl {x = x} = \ _ → x
@@ -19,8 +19,8 @@ data Susp' (A : ptType) : Set where
 -- Non-computation of transp on non-HIT's hcomp
 testTr : {A' : ptType} (ψ : I) (A : I → ptType [ ψ ↦ (\ _ → A') ])
          {φ : I}
-         (u : ∀ i → Partial φ (Susp' (ouc (A i0))))
-         (u0 : Susp' (ouc (A i0)) [ φ ↦ u i0 ])
-         → transp (\ i -> Susp' (ouc (A i))) ψ (hcomp u (ouc u0))
-         ≡ hcomp (λ j .o → transp (λ i → Susp' (ouc (A i))) ψ (u j o)) (transp (λ i → Susp' (ouc (A i))) ψ (ouc u0))
+         (u : ∀ i → Partial φ (Susp' (outS (A i0))))
+         (u0 : Susp' (outS (A i0)) [ φ ↦ u i0 ])
+         → transp (\ i -> Susp' (outS (A i))) ψ (hcomp u (outS u0))
+         ≡ hcomp (λ j .o → transp (λ i → Susp' (outS (A i))) ψ (u j o)) (transp (λ i → Susp' (outS (A i))) ψ (ouc u0))
 testTr ψ A u u0 = refl

--- a/test/Fail/Issue3577.agda
+++ b/test/Fail/Issue3577.agda
@@ -22,5 +22,5 @@ testTr : {A' : ptType} (ψ : I) (A : I → ptType [ ψ ↦ (\ _ → A') ])
          (u : ∀ i → Partial φ (Susp' (outS (A i0))))
          (u0 : Susp' (outS (A i0)) [ φ ↦ u i0 ])
          → transp (\ i -> Susp' (outS (A i))) ψ (hcomp u (outS u0))
-         ≡ hcomp (λ j .o → transp (λ i → Susp' (outS (A i))) ψ (u j o)) (transp (λ i → Susp' (outS (A i))) ψ (ouc u0))
+         ≡ hcomp (λ j .o → transp (λ i → Susp' (outS (A i))) ψ (u j o)) (transp (λ i → Susp' (outS (A i))) ψ (outS u0))
 testTr ψ A u u0 = refl

--- a/test/Fail/Issue3577.err
+++ b/test/Fail/Issue3577.err
@@ -1,9 +1,9 @@
 Issue3577.agda:26,19-23
-Issue3577.transpSusp' (λ i → ouc (A i)) ψ (hcomp u (ouc u0)) !=
-hcomp (λ j .o → transp (λ i → Susp' (ouc (A i))) ψ (u j _))
-(Issue3577.transpSusp' (λ i → ouc (A i)) ψ (ouc u0))
-of type Susp' (ouc (A i1))
+Issue3577.transpSusp' (λ i → outS (A i)) ψ (hcomp u (outS u0)) !=
+hcomp (λ j .o → transp (λ i → Susp' (outS (A i))) ψ (u j _))
+(Issue3577.transpSusp' (λ i → outS (A i)) ψ (outS u0))
+of type Susp' (outS (A i1))
 when checking that the expression refl has type
-transp (λ i → Susp' (ouc (A i))) ψ (hcomp u (ouc u0)) ≡
-hcomp (λ j .o → transp (λ i → Susp' (ouc (A i))) ψ (u j _))
-(transp (λ i → Susp' (ouc (A i))) ψ (ouc u0))
+transp (λ i → Susp' (outS (A i))) ψ (hcomp u (outS u0)) ≡
+hcomp (λ j .o → transp (λ i → Susp' (outS (A i))) ψ (u j _))
+(transp (λ i → Susp' (outS (A i))) ψ (outS u0))

--- a/test/Fail/Issue5838.agda
+++ b/test/Fail/Issue5838.agda
@@ -25,8 +25,7 @@ open import Agda.Primitive.Cubical public
 open import Agda.Builtin.Cubical.Path
 open import Agda.Builtin.Cubical.Glue; open Helpers public
 open import Agda.Builtin.Cubical.Sub public
-  renaming ( inc to inS
-           ; primSubOut to outS
+  renaming ( primSubOut to outS
            )
 
 ---------------------------------------------------------------------------

--- a/test/Fail/Issue5838.err
+++ b/test/Fail/Issue5838.err
@@ -1,3 +1,3 @@
-Issue5838.agda:211,1-4
+Issue5838.agda:210,1-4
 false != true of type Bool
 when checking the definition of bad

--- a/test/Fail/Issue5838b.agda
+++ b/test/Fail/Issue5838b.agda
@@ -20,8 +20,7 @@ open import Agda.Primitive.Cubical public
 open import Agda.Builtin.Cubical.Path
 open import Agda.Builtin.Cubical.Glue; open Helpers public
 open import Agda.Builtin.Cubical.Sub public
-  renaming ( inc to inS
-           ; primSubOut to outS
+  renaming ( primSubOut to outS
            )
 
 ---------------------------------------------------------------------------

--- a/test/Fail/Issue5838b.err
+++ b/test/Fail/Issue5838b.err
@@ -1,3 +1,3 @@
-Issue5838b.agda:219,1-5
+Issue5838b.agda:218,1-5
 false != true of type Bool
 when checking the definition of bad'

--- a/test/Succeed/CubicalPrims.agda
+++ b/test/Succeed/CubicalPrims.agda
@@ -4,9 +4,9 @@ module CubicalPrims where
 open import Agda.Primitive renaming (_⊔_ to ℓ-max)
 open import Agda.Primitive.Cubical renaming (primIMin to _∧_; primIMax to _∨_; primINeg to ~_; isOneEmpty to empty)
 open import Agda.Builtin.Bool
-open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to ouc)
+open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to outS)
 open import Agda.Builtin.Cubical.Path
-open import Agda.Builtin.Cubical.Id renaming (primIdJ to J)
+open import Agda.Builtin.Cubical.Id renaming (IdJ to J)
 open import Agda.Builtin.Cubical.Glue renaming (primGlue to Glue; prim^glue to glue; prim^unglue to unglue)
 open import Agda.Builtin.Sigma
 open import Agda.Builtin.List
@@ -28,9 +28,9 @@ module DerivedComp where
 
   module _ (la : I → Level) (A : ∀ i → Set (la i)) (φ : I) (u : ∀ i → Partial φ (A i)) (u0 : A i0 [ φ ↦ u i0 ]) where
     comp : A i1
-    comp = primHComp (\ i → \ { (φ = i1) → forward la A i (u i itIsOne) }) (forward la A i0 (ouc u0))
+    comp = primHComp (\ i → \ { (φ = i1) → forward la A i (u i itIsOne) }) (forward la A i0 (outS u0))
 
-    comp-test : comp ≡ primComp A u (ouc u0)
+    comp-test : comp ≡ primComp A u (outS u0)
     comp-test = refl
 
 test-sym : ∀ {ℓ} {A : Set ℓ} → {x y : A} → (p : x ≡ y) → sym (sym p) ≡ p
@@ -38,9 +38,9 @@ test-sym p = refl
 
 transpFill : ∀ {ℓ} {A' : Set ℓ} (φ : I)
                (A : (i : I) → Set ℓ [ φ ↦ (\ _ → A') ]) →
-               (u0 : ouc (A i0)) →
-               PathP (λ i → ouc (A i)) u0 (primTransp (λ i → ouc (A i)) φ u0)
-transpFill φ A u0 i = primTransp (\ j → ouc (A (i ∧ j))) (~ i ∨ φ) u0
+               (u0 : outS (A i0)) →
+               PathP (λ i → outS (A i)) u0 (primTransp (λ i → outS (A i)) φ u0)
+transpFill φ A u0 i = primTransp (\ j → outS (A (i ∧ j))) (~ i ∨ φ) u0
 
 
 test-bool : (p : true ≡ false) → Bool
@@ -107,7 +107,7 @@ module _ {ℓ ℓ'} {A : I → Set ℓ} {B : ∀ i → A i → Set ℓ'}
   compPi : (φ : I) → (u : ∀ i → Partial φ (C i)) → (a : C i0 [ φ ↦ u i0 ]) → C i1
   compPi φ u a' x1 = primComp
       (λ i → B i (v i)) (λ i o → u i o (v i)) (a (v i0)) where
-    a = ouc a'
+    a = outS a'
     v : (i : I) → A i
     v i = primTransp (λ j → A (i ∨ (~ j))) i x1
     f : ∀ i → (a : A i) → Partial φ (B i a)
@@ -115,7 +115,7 @@ module _ {ℓ ℓ'} {A : I → Set ℓ} {B : ∀ i → A i → Set ℓ'}
 
 
   compPi' : (φ : I) → (u : ∀ i → Partial φ (C i)) → (a : C i0 [ φ ↦ u i0 ]) → C i1
-  compPi' φ u a = primComp (\ i → C i) (\ i → u i) (ouc a)
+  compPi' φ u a = primComp (\ i → C i) (\ i → u i) (outS a)
 
   test-compPi : (φ : I) → (u : ∀ i → Partial φ (C i)) → (a : C i0 [ φ ↦ u i0 ]) →
                   compPi φ u a ≡ compPi' φ u a
@@ -128,10 +128,10 @@ module HCompPathP {ℓ} {A : I → Set ℓ} (u : A i0) (v : A i1) (φ : I)
   hcompPathP j = primHComp (\ { i (φ = i1) → p i itIsOne j
                               ; i (j = i0) → u
                               ; i (j = i1) → v })
-                           (ouc p0 j)
+                           (outS p0 j)
 
 
-  test-hcompPathP : hcompPathP ≡ primHComp p (ouc p0)
+  test-hcompPathP : hcompPathP ≡ primHComp p (outS p0)
   test-hcompPathP = refl
 
 module TranspPathP {ℓ} {A : I → I → Set ℓ} (u : ∀ i → A i i0)(v : ∀ i → A i i1)
@@ -163,28 +163,28 @@ module RecordComp where
     (let ℓ = _ ; Z : Set ℓ ; Z = R(A)(B)(C))
     (φ : I) → (u : ∀ i → Partial φ Z) → Z [ φ ↦ u i0 ] → Z
   fst (hcompR {A = A} {B} φ w w0)
-    = primComp (\ _ → A) (λ i →  (λ{ (φ = i1) → fst (w i itIsOne) }) ) (fst (ouc w0))
+    = primComp (\ _ → A) (λ i →  (λ{ (φ = i1) → fst (w i itIsOne) }) ) (fst (outS w0))
   snd (hcompR {A = A} {B} φ w w0)
-    = primComp (λ i → B (a i)) (λ i → (λ { (φ = i1) → snd (w i itIsOne) })) (snd (ouc w0))
+    = primComp (λ i → B (a i)) (λ i → (λ { (φ = i1) → snd (w i itIsOne) })) (snd (outS w0))
     where
-      a = fill (λ z → A) (λ i → (λ { (φ = i1) → fst (w i itIsOne) }) ) (inc (fst (ouc w0)))
+      a = fill (λ z → A) (λ i → (λ { (φ = i1) → fst (w i itIsOne) }) ) (inS (fst (outS w0)))
   trd (hcompR {A = A} {B} {C} φ w w0)
-    = primComp (λ i → C (a i) (b i)) ((λ i → (λ { (φ = i1) → trd (w i itIsOne)}))) (trd (ouc w0))
+    = primComp (λ i → C (a i) (b i)) ((λ i → (λ { (φ = i1) → trd (w i itIsOne)}))) (trd (outS w0))
     where
-      a = fill (λ z → A) (λ i → (λ { (φ = i1) → fst (w i itIsOne) }) ) (inc (fst (ouc w0)))
-      b = fill (λ i → B (a i)) (λ i → (λ { (φ = i1) → snd (w i itIsOne) }) ) (inc (snd (ouc w0)))
+      a = fill (λ z → A) (λ i → (λ { (φ = i1) → fst (w i itIsOne) }) ) (inS (fst (outS w0)))
+      b = fill (λ i → B (a i)) (λ i → (λ { (φ = i1) → snd (w i itIsOne) }) ) (inS (snd (outS w0)))
 
   module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'}
                   {C : (x : A) → B x → Set ℓ}
                   (let ℓ = _ ; Z : Set ℓ ; Z = R(A)(B)(C))
                   (φ : I) (u : ∀ i → Partial φ (Z)) (a : Z [ φ ↦ u i0 ]) where
-     test-compR-fst : hcompR {A = A} {B} {C} φ u a .fst ≡ primHComp u (ouc a) .fst
+     test-compR-fst : hcompR {A = A} {B} {C} φ u a .fst ≡ primHComp u (outS a) .fst
      test-compR-fst = refl
 
-     test-compR-snd : hcompR {A = A} {B} {C} φ u a .snd ≡ primHComp u (ouc a) .snd
+     test-compR-snd : hcompR {A = A} {B} {C} φ u a .snd ≡ primHComp u (outS a) .snd
      test-compR-snd = refl
 
-     test-compR-trd : hcompR {A = A} {B} {C} φ u a .trd ≡ primHComp u (ouc a) .trd
+     test-compR-trd : hcompR {A = A} {B} {C} φ u a .trd ≡ primHComp u (outS a) .trd
      test-compR-trd = refl
 
 
@@ -199,11 +199,11 @@ module RecordComp where
       primTransp (\ i → A i) φ (fst w0)
     snd (transpR w0) = primTransp (\ i → B i (a i)) φ (snd w0)
        where
-         a = transpFill {A' = A i0} φ (λ i → inc (A i)) (fst w0)
+         a = transpFill {A' = A i0} φ (λ i → inS (A i)) (fst w0)
     trd (transpR w0) = primTransp (\ i → C i (a i) (b i)) φ (trd w0)
        where
-         a = transpFill {A' = A i0} φ (λ i → inc (A i)) (fst w0)
-         b = transpFill {A' = B i0 (a i0)} φ (λ i → inc (B i (a i))) (snd w0)
+         a = transpFill {A' = A i0} φ (λ i → inS (A i)) (fst w0)
+         b = transpFill {A' = B i0 (a i0)} φ (λ i → inS (B i (a i))) (snd w0)
 
   module _ {ℓ ℓ'} {A : I → Set ℓ} {B : ∀ i → A i → Set ℓ'}
                   {C : ∀ i → (x : A i) → B i x → Set ℓ}
@@ -224,7 +224,7 @@ module _ {ℓ} {A : Set ℓ} {φ : I} {T : Partial φ (Set ℓ)}
              {e : PartialP φ (λ o → T o ≃ A)}
              where
   test-Glue-β : (t : PartialP φ T) (a : A [ φ ↦ (\ o → e o .fst (t o)) ]) →
-    unglue {A = A} {φ = φ} {T = T} {e} (glue t (ouc a)) ≡ ouc a
+    unglue {A = A} {φ = φ} {T = T} {e} (glue t (outS a)) ≡ outS a
   test-Glue-β _ _ = refl
 
   test-Glue-η : (b : Glue A T e) →
@@ -240,11 +240,11 @@ module _ {ℓ} {A : Set ℓ} (let φ = i1) {T : Partial φ (Set ℓ)}
 
   test-unglue-2 : (t : PartialP φ T) (a : A [ φ ↦ (\ o → e o .fst (t o)) ]) →
     unglue {A = A} {φ = φ} {T = T} {e}
-    (glue {A = A}{φ = φ}{T = T}{e} t (ouc a)) ≡ e itIsOne .fst (t itIsOne) -- = a
+    (glue {A = A}{φ = φ}{T = T}{e} t (outS a)) ≡ e itIsOne .fst (t itIsOne) -- = a
   test-unglue-2 _ _ = refl
 
   test-glue-0 : (t : PartialP φ T) (a : A [ φ ↦ (\ o → e o .fst (t o)) ]) →
-    (glue {A = A} {T = T} {e} t (ouc a)) ≡ t itIsOne
+    (glue {A = A} {T = T} {e} t (outS a)) ≡ t itIsOne
   test-glue-0 _ _ = refl
 
 eqToPath : ∀ {ℓ} {A B : Set ℓ} → A ≃ B → A ≡ B
@@ -397,9 +397,9 @@ module HCompI→ {ℓ} {A : I → Set ℓ} (φ : I)
    where
 
   hcompI→ : C
-  hcompI→ j = primHComp (λ i u → p i u j) (ouc p0 j)
+  hcompI→ j = primHComp (λ i u → p i u j) (outS p0 j)
 
-  test-hcompI→ : hcompI→ ≡ primHComp p (ouc p0)
+  test-hcompI→ : hcompI→ ≡ primHComp p (outS p0)
   test-hcompI→ = refl
 
 module TranspI→ {ℓ} {A : I → I → Set ℓ}

--- a/test/Succeed/Issue2846.agda
+++ b/test/Succeed/Issue2846.agda
@@ -14,9 +14,9 @@ _ : ∀ {ℓ} {A : Set ℓ} {x : A} → reflId' {x = x} ≡ reflId
 _ = reflPath
 
 Id-comp-Id : ∀ {ℓ ℓ'} {A : Set ℓ} {x : A} (P : ∀ y → Id x y → Set ℓ')
-           → (b : P x reflId) → Id (primIdJ P b reflId) b
+           → (b : P x reflId) → Id (IdJ P b reflId) b
 Id-comp-Id P b = reflId
 
 Id-comp-Path : ∀ {ℓ ℓ'} {A : Set ℓ} {x : A} (P : ∀ y → Id x y → Set ℓ')
-             → (b : P x reflId) → (primIdJ P b reflId) ≡ b
+             → (b : P x reflId) → (IdJ P b reflId) ≡ b
 Id-comp-Path P b = λ i → b

--- a/test/Succeed/Issue3399.agda
+++ b/test/Succeed/Issue3399.agda
@@ -3,15 +3,15 @@ module _ where
 open import Agda.Primitive.Cubical renaming (primINeg to ~_; primIMax to _∨_; primIMin to _∧_)
 open import Agda.Builtin.Cubical.Path
 open import Agda.Builtin.Cubical.Sub
-open import Agda.Builtin.Cubical.Sub using () renaming (Sub to _[_↦_]; primSubOut to ouc)
+open import Agda.Builtin.Cubical.Sub using () renaming (Sub to _[_↦_])
 open import Agda.Primitive renaming (_⊔_ to ℓ-max)
 open import Agda.Builtin.Sigma
 
 transpFill : ∀ {ℓ} {A' : Set ℓ} (φ : I)
                (A : (i : I) → Set ℓ [ φ ↦ (\ _ → A') ]) →
-               (u0 : ouc (A i0)) →
-               PathP (λ i → ouc (A i)) u0 (primTransp (λ i → ouc (A i)) φ u0)
-transpFill φ A u0 i = primTransp (\ j → ouc (A (i ∧ j))) (~ i ∨ φ) u0
+               (u0 : outS (A i0)) →
+               PathP (λ i → outS (A i)) u0 (primTransp (λ i → outS (A i)) φ u0)
+transpFill φ A u0 i = primTransp (\ j → outS (A (i ∧ j))) (~ i ∨ φ) u0
 
 forward : (la : Level) (A : ∀ i → Set la) (r : I) → A r → A i1
 forward la A r x = primTransp (\ i → A (i ∨ r)) r x
@@ -19,8 +19,8 @@ forward la A r x = primTransp (\ i → A (i ∨ r)) r x
 -- gcomp^i A [ phi -> u ] u0 = hcomp^i A(1/i) [ phi -> forward A i u, ~ phi -> forward A 0 u ] (forward A 0 u0)
 
 gcomp : ∀ {l} (A : I → Set l) (φ : I) (u : ∀ i → Partial φ (A i)) (u0 : A i0 [ φ ↦ u i0 ]) -> A i1
-gcomp A φ u u0 = primHComp {A = A i1} (\ i → \ { (φ = i1) →  forward _ A i (u i itIsOne); (φ = i0) →  forward _ A i0 (ouc u0) })
-                                         (forward _ A i0 (ouc u0))
+gcomp A φ u u0 = primHComp {A = A i1} (\ i → \ { (φ = i1) →  forward _ A i (u i itIsOne); (φ = i0) →  forward _ A i0 (outS u0) })
+                                         (forward _ A i0 (outS u0))
 
 -- private
 --   internalFiber : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) (y : B) → Set (ℓ-max ℓ ℓ')
@@ -93,8 +93,8 @@ module TestTransp {ℓ ℓ'} (A : Set ℓ) {φ : I} (Te : Partial φ (Σ (Set �
   a0 = unglue {φ = φ} u0
   a1 = gcomp (\ _ → A)
          φ
-         (\ { i (φ = i1) → equivFun (Te itIsOne .snd) (transpFill {A' = Te itIsOne .fst} ψ (\ i → inc (Te itIsOne .fst)) u0 i) })
-         (inc a0)
+         (\ { i (φ = i1) → equivFun (Te itIsOne .snd) (transpFill {A' = Te itIsOne .fst} ψ (\ i → inS (Te itIsOne .fst)) u0 i) })
+         (inS a0)
 
   pair : PartialP φ λ o → Helpers.fiber (Te o .snd .fst) a1
   pair o = equivProof (Te o .fst) A (Te o .snd) a1 φ \ { (φ = i1) → _ , Helpers.refl }

--- a/test/Succeed/Issue3399.agda
+++ b/test/Succeed/Issue3399.agda
@@ -3,7 +3,7 @@ module _ where
 open import Agda.Primitive.Cubical renaming (primINeg to ~_; primIMax to _∨_; primIMin to _∧_)
 open import Agda.Builtin.Cubical.Path
 open import Agda.Builtin.Cubical.Sub
-open import Agda.Builtin.Cubical.Sub using () renaming (Sub to _[_↦_])
+open import Agda.Builtin.Cubical.Sub using () renaming (Sub to _[_↦_]; primSubOut to outS)
 open import Agda.Primitive renaming (_⊔_ to ℓ-max)
 open import Agda.Builtin.Sigma
 
@@ -97,7 +97,7 @@ module TestTransp {ℓ ℓ'} (A : Set ℓ) {φ : I} (Te : Partial φ (Σ (Set �
          (inS a0)
 
   pair : PartialP φ λ o → Helpers.fiber (Te o .snd .fst) a1
-  pair o = equivProof (Te o .fst) A (Te o .snd) a1 φ \ { (φ = i1) → _ , Helpers.refl }
+  pair o = outS (equivProof (Te o .fst) A (Te o .snd) a1 φ \ { (φ = i1) → _ , Helpers.refl })
 
   result : Glue A Te
   result = glue {φ = φ} (λ o → pair o .fst) (primHComp (\ { j (φ = i1) → pair itIsOne .snd j}) a1)

--- a/test/Succeed/Issue3577.agda
+++ b/test/Succeed/Issue3577.agda
@@ -5,7 +5,7 @@ module Issue3577 where
 open import Agda.Primitive.Cubical renaming (primTransp to transp; primHComp to hcomp)
 open import Agda.Builtin.Cubical.Path
 open import Agda.Builtin.Sigma
-open import Agda.Builtin.Cubical.Sub renaming (primSubOut to ouc; Sub to _[_↦_])
+open import Agda.Builtin.Cubical.Sub renaming (primSubOut to outS; Sub to _[_↦_])
 refl : ∀ {l} {A : Set l} {x : A} → x ≡ x
 refl {x = x} = \ _ → x
 
@@ -20,8 +20,8 @@ data Susp' (A : ptType) : Set where
 -- computation of transp on HIT's hcomp
 testTr : {A' : ptType} (ψ : I) (A : I → ptType [ ψ ↦ (\ _ → A') ])
          {φ : I}
-         (u : ∀ i → Partial φ (Susp' (ouc (A i0))))
-         (u0 : Susp' (ouc (A i0)) [ φ ↦ u i0 ])
-         → transp (\ i -> Susp' (ouc (A i))) ψ (hcomp u (ouc u0))
-         ≡ hcomp (λ j .o → transp (λ i → Susp' (ouc (A i))) ψ (u j o)) (transp (λ i → Susp' (ouc (A i))) ψ (ouc u0))
+         (u : ∀ i → Partial φ (Susp' (outS (A i0))))
+         (u0 : Susp' (outS (A i0)) [ φ ↦ u i0 ])
+         → transp (\ i -> Susp' (outS (A i))) ψ (hcomp u (outS u0))
+         ≡ hcomp (λ j .o → transp (λ i → Susp' (outS (A i))) ψ (u j o)) (transp (λ i → Susp' (outS (A i))) ψ (outS u0))
 testTr ψ A u u0 = refl


### PR DESCRIPTION
Closes #5661, by ensuring that the fibre returned from `equivTransp` must be an extension of the given partial fibre. This immediately implies that equivalences must actually be equivalences, using the characterisation of contractible types as those for which all fibres are extensible. The price is we pay is a inS/outS critical pair around equivTransp; I would very much like to believe that this is negligible, but I'm not sure: I'm throwing this PR up to run the benchmarks.

I'm not sure whether there are other builtins that computation for `--cubical` relies on, but part of the changes I want to make to the documentation is to add a big banner saying that re-defining these builtins is not supported. But this definitely reduces the surface area of foot that's available for users to shoot off.

Closes #3714, by.. well, renaming inc and ouc everywhere.

---

I'm not sure whether this is a good idea or not, but I've removed `primIdJ`. Its implementation was essentially deferring to `primIdElim` (though using the Haskell function `conidView` for that, rather than building an application of `primIdElim`) and `primComp`, so we can safely move its implementation out of the trusted codebase. `primIdJ` can be implemented with the exact same computational behaviour in user-land as

```agda
idJ′ : ∀ {ℓ ℓ'} {A : Set ℓ} {x : A} (P : ∀ y → Id x y → Set ℓ') →
     P x (conid i1 (λ i → x)) → ∀ {y} (p : Id x y) → P y p
idJ′ {x = x} P prefl =
  primIdElim P
    (λ φ y w →
      comp (λ i → P (outS w i) (conid (φ ∨ ~ i) λ j → outS w (i ∧ j)))
        (λ { i (φ = i1) → prefl }) prefl)
```

But in the course of doing this, I noticed commit https://github.com/agda/agda/commit/3560209c3e853fd9201238baab59f19b972158de, so that primIdJ can be implemented as..

```agda
  IdJ : ∀ {ℓ ℓ'} {A : Set ℓ} {x : A} (P : ∀ y → Id x y → Set ℓ') →
      P x (conid i1 (λ i → x)) → ∀ {y} (p : Id x y) → P y p
  IdJ {x = x} P prefl reflId = prefl
```

This change isn't documented anywhere, and I only noticed because `reflId` was constructor-coloured when I was fixing inc/ouc in `Agda.Builtin.Cubical.Id`, so I also want to add it to the changelog and the documentation for cubical mode.