### PR TITLE
Only recur for comparing in Glue if φ breaks down

### DIFF
--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -378,7 +378,7 @@ compareTerm' cmp a m n =
               -- reduce.
               phi' <- decomposeInterval' (unArg phi)
               -- However if φ is *not* decomposable (e.g. because it is
-              -- a function application φ i, see Issue #5959), then we
+              -- a function application φ i, see Issue #5955), then we
               -- do not recur, otherwise we'd just end up right back
               -- here.
               unless (IntMap.null (foldMap fst phi')) $

--- a/test/Succeed/Issue5955.agda
+++ b/test/Succeed/Issue5955.agda
@@ -1,0 +1,24 @@
+{-# OPTIONS --cubical --safe #-}
+
+open import Agda.Primitive            renaming (Set to Type)
+open import Agda.Primitive.Cubical    renaming (primComp to comp)
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Cubical.Sub  renaming (primSubOut to outS ; inc to inS)
+open import Agda.Builtin.Cubical.Glue using    (primGlue; _≃_)
+
+Glue : ∀ {ℓ ℓ'} (A : Type ℓ) {φ : I}
+       → (Te : Partial φ (Σ (Type ℓ') (_≃ A)))
+       → Type ℓ'
+Glue A Te = primGlue A (λ x → Te x .fst) (λ x → Te x .snd)
+
+compGlue :
+  {ℓ ℓ' : Level}
+  (Y    : I → Type ℓ')
+  (φ    : I → I)
+  (Te   : (i : I) → Partial (φ i) (Σ (Type ℓ) (_≃ Y i)))
+  (ψ    : I)
+  (x    : (i : I) → Partial ψ (Glue (Y i) (Te i)))
+  → Sub (Glue (Y i0) (Te i0)) ψ (x i0)
+  → Sub (Glue (Y i1) (Te i1)) ψ (x i1)
+
+compGlue Y φ Te ψ x x₀ = inS (comp (λ i → Glue (Y i) (Te i)) x (outS x₀))


### PR DESCRIPTION
Fixes #5955. I added some comments to the code explaining the change. The problem was that, when comparing terms at type `Glue φ T`, the conversion checker would try to decompose φ into faces, and recursively compare each face under the resulting substitutions (this is `compareTermOnFace`/`forallFaceMaps`).

But some expressions are indecomposable, e.g. `φ i`, and in that case, `compareTermOnFace` would try comparing `m, n` at type `(Glue φ T)[idS]`.. i.e., exactly the situation we started in. Not good for termination!