### PR TITLE
Add --no-load-primitives to disable loading Agda.Primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,13 @@ Language
 * A new constructor `pattErr : Pattern → ErrorPart` of `ErrorPart` for reflection
   is added.
 
+* The new option `--no-load-primitives` complements `--no-import-sorts`
+  by foregoing loading of the primitive modules altogether. This option
+  leaves Agda in a very fragile state, as the built-in sorts are used
+  extensively throughout the implementation. It is intended to be used
+  with Literate Agda projects which want to bind `BUILTIN TYPE` (and
+  other primitives) in their own literate files.
+
 Syntax
 ------
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -542,6 +542,19 @@ Other features
      Disable the implicit statement `open import Agda.Primitive using
      (Set; Prop)` at the start of each top-level Agda module.
 
+.. option:: --no-load-primitives
+
+     .. versionadded:: 2.6.3
+
+     Do not load the primitive modules (`Agda.Primitive`,
+     `Agda.Primitive.Cubical`) when type-checking this program. This is
+     useful if you want to declare Agda's very magical primitives in a
+     Literate Agda file of your choice.
+
+     If you are using this option, it is your responsibility to ensure
+     that all of the `BUILTIN` things defined in those modules are
+     loaded. Agda will not work otherwise.
+
 .. option:: --save-metas, --no-save-metas
 
      .. versionadded:: 2.6.3

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -395,29 +395,33 @@ typeCheckMain
 typeCheckMain mode src = do
   -- liftIO $ putStrLn $ "This is typeCheckMain " ++ prettyShow f
   -- liftIO . putStrLn . show =<< getVerbosity
-  reportSLn "import.main" 10 "Importing the primitive modules."
-  libdirPrim <- liftIO getPrimitiveLibDir
-  reportSLn "import.main" 20 $ "Library primitive dir = " ++ show libdirPrim
-  -- Turn off import-chasing messages.
-  -- We have to modify the persistent verbosity setting, since
-  -- getInterface resets the current verbosity settings to the persistent ones.
-  bracket_ (getsTC Lens.getPersistentVerbosity) Lens.putPersistentVerbosity $ do
-    Lens.modifyPersistentVerbosity (Trie.delete [])  -- set root verbosity to 0
-
-    -- We don't want to generate highlighting information for Agda.Primitive.
-    withHighlightingLevel None $
-      forM_ (Set.map (libdirPrim </>) Lens.primitiveModules) $ \f -> do
-        primSource <- parseSource (SourceFile $ mkAbsolute f)
-        checkModuleName' (srcModuleName primSource) (srcOrigin primSource)
-        void $ getNonMainInterface (srcModuleName primSource) (Just primSource)
-
-  reportSLn "import.main" 10 $ "Done importing the primitive modules."
-
-  -- Now do the type checking via getInterface.
-  checkModuleName' (srcModuleName src) (srcOrigin src)
 
   -- For the main interface, we also remember the pragmas from the file
   setOptionsFromSourcePragmas src
+  loadPrims <- optLoadPrimitives <$> pragmaOptions
+
+  when loadPrims $ do
+    reportSLn "import.main" 10 "Importing the primitive modules."
+    libdirPrim <- liftIO getPrimitiveLibDir
+    reportSLn "import.main" 20 $ "Library primitive dir = " ++ show libdirPrim
+    -- Turn off import-chasing messages.
+    -- We have to modify the persistent verbosity setting, since
+    -- getInterface resets the current verbosity settings to the persistent ones.
+
+    bracket_ (getsTC Lens.getPersistentVerbosity) Lens.putPersistentVerbosity $ do
+      Lens.modifyPersistentVerbosity (Trie.delete [])  -- set root verbosity to 0
+
+      -- We don't want to generate highlighting information for Agda.Primitive.
+      withHighlightingLevel None $
+        forM_ (Set.map (libdirPrim </>) Lens.primitiveModules) $ \f -> do
+          primSource <- parseSource (SourceFile $ mkAbsolute f)
+          checkModuleName' (srcModuleName primSource) (srcOrigin primSource)
+          void $ getNonMainInterface (srcModuleName primSource) (Just primSource)
+
+    reportSLn "import.main" 10 $ "Done importing the primitive modules."
+
+  -- Now do the type checking via getInterface.
+  checkModuleName' (srcModuleName src) (srcOrigin src)
 
   mi <- getInterface (srcModuleName src) (MainInterface mode) (Just src)
 

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -207,6 +207,9 @@ data PragmaOptions = PragmaOptions
   , optImportSorts               :: Bool
      -- ^ Should every top-level module start with an implicit statement
      --   @open import Agda.Primitive using (Set; Prop)@?
+  , optLoadPrimitives            :: Bool
+    -- ^ Should we load the primitive modules at all? This is a stronger
+    -- form of 'optImportSorts'.
   , optAllowExec                 :: Bool
   , optSaveMetas                 :: WithDefault 'False
     -- ^ Save meta-variables.
@@ -330,6 +333,7 @@ defaultPragmaOptions = PragmaOptions
   , optAllowExec                 = False
   , optSaveMetas                 = Default
   , optShowIdentitySubstitutions = False
+  , optLoadPrimitives            = True
   }
 
 type OptM = Except String
@@ -555,6 +559,12 @@ ignoreAllInterfacesFlag o = return $ o { optIgnoreAllInterfaces = True }
 
 localInterfacesFlag :: Flag CommandLineOptions
 localInterfacesFlag o = return $ o { optLocalInterfaces = True }
+
+noLoadPrimitivesFlag :: Flag PragmaOptions
+noLoadPrimitivesFlag o = return $ o
+  { optLoadPrimitives = False
+  , optImportSorts = False
+  }
 
 allowUnsolvedFlag :: Flag PragmaOptions
 allowUnsolvedFlag o = do
@@ -1079,6 +1089,8 @@ pragmaOptions =
                     "use call-by-name evaluation instead of call-by-need"
     , Option []     ["no-import-sorts"] (NoArg noImportSorts)
                     "disable the implicit import of Agda.Primitive using (Set; Prop) at the start of each top-level module"
+    , Option []     ["no-load-primitives"] (NoArg noLoadPrimitivesFlag)
+                    "disable loading of primitive modules at all (implies --no-import-sorts)"
     , Option []     ["allow-exec"] (NoArg allowExec)
                     "allow system calls to trusted executables with primExec"
     , Option []     ["save-metas"] (NoArg $ saveMetas True)

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1360,7 +1360,7 @@ instance Reify Sort where
     reifyWhen = reifyWhenE
     reify s = do
       s <- instantiateFull s
-      SortKit{..} <- sortKit
+      SortKit{..} <- infallibleSortKit
       case s of
         I.Type (I.ClosedLevel 0) -> return $ A.Def' nameOfSet A.NoSuffix
         I.Type (I.ClosedLevel n) -> return $ A.Def' nameOfSet (A.Suffix n)

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -24,6 +24,7 @@ import Agda.Syntax.Position
 import Agda.Syntax.Literal
 import Agda.Syntax.Builtin
 import Agda.Syntax.Internal as I
+import Agda.Interaction.Options.Base (PragmaOptions(..))
 import Agda.TypeChecking.Monad.Base
 -- import Agda.TypeChecking.Functions  -- LEADS TO IMPORT CYCLE
 import Agda.TypeChecking.Substitute
@@ -484,13 +485,23 @@ data SortKit = SortKit
   , nameOfSetOmega :: IsFibrant -> QName
   }
 
-sortKit :: HasBuiltins m => m SortKit
+-- | Compute a 'SortKit' in an environment that supports failures. When
+-- 'optLoadPrimitives' is set to 'False', 'sortKit' is a fallible
+-- operation, so for the uses of 'sortKit' in fallible contexts (e.g.
+-- 'TCM'), we report a type error rather than exploding.
+sortKit :: (HasBuiltins m, MonadTCError m, HasOptions m) => m SortKit
 sortKit = do
-  Def set      _ <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSet
-  Def prop     _ <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinProp
-  Def setomega _ <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSetOmega
-  Def sset     _ <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinStrictSet
-  Def ssetomega _ <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSSetOmega
+  loadPrim <- optLoadPrimitives <$> pragmaOptions
+  let
+    -- When '--no-load-primitives', recover by throwing a TC error.
+    recover s
+      | not loadPrim = typeError (GenericDocError ("Agda will not function without a binding for BUILTIN " <> s))
+      | otherwise = __IMPOSSIBLE__
+  Def set      _  <- maybe (recover "TYPE") pure           =<< getBuiltin' builtinSet
+  Def prop     _  <- maybe (recover "PROP") pure           =<< getBuiltin' builtinProp
+  Def setomega _  <- maybe (recover "SETOMEGA") pure       =<< getBuiltin' builtinSetOmega
+  Def sset     _  <- maybe (recover "STRICTSET") pure      =<< getBuiltin' builtinStrictSet
+  Def ssetomega _ <- maybe (recover "STRICTSETOMEGA") pure =<< getBuiltin' builtinSSetOmega
   return $ SortKit
     { nameOfSet      = set
     , nameOfProp     = prop
@@ -500,6 +511,25 @@ sortKit = do
         IsStrict  -> ssetomega
     }
 
+-- | Compute a 'SortKit' in contexts that do not support failure (e.g.
+-- 'Reify'). This should only be used when we are sure that the
+-- primitive sorts have been bound, i.e. because it is "after" type
+-- checking.
+infallibleSortKit :: HasBuiltins m => m SortKit
+infallibleSortKit = do
+  Def set      _  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSet
+  Def prop     _  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinProp
+  Def setomega _  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSetOmega
+  Def sset     _  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinStrictSet
+  Def ssetomega _ <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSSetOmega
+  return $ SortKit
+    { nameOfSet      = set
+    , nameOfProp     = prop
+    , nameOfSSet     = sset
+    , nameOfSetOmega = \case
+        IsFibrant -> setomega
+        IsStrict  -> ssetomega
+    }
 
 ------------------------------------------------------------------------
 -- * Path equality

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -272,12 +272,12 @@ instance EmbPrj Doc where
 
 instance EmbPrj PragmaOptions where
   icod_ = \case
-    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee ->
-      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee
+    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ->
+      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff
 
   value = vcase $ \case
-    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx, yy, zz, aaa, bbb, ccc, ddd, eee] ->
-      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee
+    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx, yy, zz, aaa, bbb, ccc, ddd, eee, fff] ->
+      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff
     _ -> malformed
 
 instance EmbPrj ProfileOptions where

--- a/test/Fail/NoLoadPrims.agda
+++ b/test/Fail/NoLoadPrims.agda
@@ -1,0 +1,7 @@
+{-# OPTIONS --no-load-primitives #-}
+
+module NoLoadPrims where
+
+-- Tests that sortKit doesn't explode the TC when --no-load-primitives is set.
+_ : ?
+_ = ?

--- a/test/Fail/NoLoadPrims.err
+++ b/test/Fail/NoLoadPrims.err
@@ -1,0 +1,3 @@
+NoLoadPrims.agda:6,5-6
+Agda will not function without a binding for BUILTIN TYPE
+when checking that the expression ? is a type

--- a/test/Succeed/NoLoadPrims/Base.agda
+++ b/test/Succeed/NoLoadPrims/Base.agda
@@ -1,0 +1,22 @@
+{-# OPTIONS --no-load-primitives #-}
+module NoLoadPrims.Base where
+
+-- Binding the very magical built-ins works:
+{-# BUILTIN TYPE Type #-}
+{-# BUILTIN PROP Prop #-}
+{-# BUILTIN SETOMEGA Typeω #-}
+{-# BUILTIN STRICTSET SSet #-}
+{-# BUILTIN STRICTSETOMEGA SSetω #-}
+postulate
+  Level : Type
+  lzero : Level
+  lsuc  : Level → Level
+  _⊔_   : Level → Level → Level
+{-# BUILTIN LEVEL Level #-}
+{-# BUILTIN LEVELZERO lzero #-}
+{-# BUILTIN LEVELSUC lsuc #-}
+{-# BUILTIN LEVELMAX _⊔_ #-}
+
+-- Type checking works:
+_ : Typeω
+_ = ∀ l → Type l

--- a/test/Succeed/NoLoadPrims/Suffix.agda
+++ b/test/Succeed/NoLoadPrims/Suffix.agda
@@ -1,0 +1,9 @@
+{-# OPTIONS --no-load-primitives #-}
+module NoLoadPrims.Suffix where
+
+open import NoLoadPrims.Base
+
+-- Suffixed names work in modules that import modules that define the
+-- primitive sorts
+_ : Type₁
+_ = Type


### PR DESCRIPTION
Figured it'd be easier to show up with a working implementation than ask for a feature request :slightly_smiling_face:

In [the 1lab](https://github.com/plt-amy/1lab), I'd really like it if _everything_ were literate Agda. This is still a bit of a pipe dream because I only have so much time, but presently, it's impossible: The definitions of a handful of built-ins (e.g. `Set`, `Level`, `IUniv`, `I` etc) can't be moved out of `Agda.Primitive`, even with `--no-import-sorts`, because Agda will still _load_ those modules even if they aren't brought into scope.

Of course, those primitives are needed during the type checking process, so this makes sense: If Agda doesn't know about `Set`, everything explodes. But I'd still like the possibility of defining them myself!

This PR adds the flag `--no-load-primitives` which goes one step further `--no-import-sorts`: In `typeCheckMain`, if `--no-load-primitives` was given, then we don't even _load_ the primitive modules, let alone import them. I also added a nice error message when building a `SortKit`, but `LevelKit` is used in too many `PureTCM` contexts to easily refactor.