### PR TITLE
Fix #6011: explicit error on garbage BUILTIN REWRITE

### DIFF
--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -2,8 +2,10 @@
 
 module Agda.TypeChecking.Primitive.Base where
 
--- Control.Monad.Fail import is redundant since GHC 8.8.1
-import Control.Monad.Fail (MonadFail)
+import Control.Monad             ( mzero )
+import Control.Monad.Fail        ( MonadFail )
+  -- Control.Monad.Fail import is redundant since GHC 8.8.1
+import Control.Monad.Trans.Maybe ( MaybeT(..), runMaybeT )
 
 import qualified Data.Map as Map
 
@@ -176,18 +178,18 @@ lookupPrimitiveFunctionQ q = do
   return (s, PrimImpl t $ pf { primFunName = q })
 
 getBuiltinName :: (HasBuiltins m, MonadReduce m) => String -> m (Maybe QName)
-getBuiltinName b = traverse getQNameFromTerm =<< getBuiltin' b
+getBuiltinName b = runMaybeT $ getQNameFromTerm =<< MaybeT (getBuiltin' b)
 
 -- | Convert a name in 'Term' form back to 'QName'.
 --
-getQNameFromTerm :: MonadReduce m => Term -> m QName
+getQNameFromTerm :: MonadReduce m => Term -> MaybeT m QName
 getQNameFromTerm v = do
     v <- reduce v
     case unSpine v of
       Def x _   -> return x
       Con x _ _ -> return $ conName x
       Lam _ b   -> getQNameFromTerm $ unAbs b
-      _ -> __IMPOSSIBLE__
+      _ -> mzero
 
 isBuiltin :: (HasBuiltins m, MonadReduce m) => QName -> String -> m Bool
 isBuiltin q b = (Just q ==) <$> getBuiltinName b

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -13,6 +13,7 @@ import Prelude hiding (null)
 
 import Control.Monad
 import Control.Monad.Except
+import Control.Monad.Trans.Maybe
 
 import Data.List (find, sortBy)
 import Data.Function (on)
@@ -844,7 +845,9 @@ bindBuiltinInfo (BuiltinInfo s d) e = do
           t <- tcmt
           (,t) <$> checkExpr e t
         f v t
-        if | s == builtinRewrite -> bindBuiltinRewriteRelation =<< getQNameFromTerm v
+        if | s == builtinRewrite -> runMaybeT (getQNameFromTerm v) >>= \case
+              Nothing -> genericError "Invalid rewrite relation"
+              Just q  -> bindBuiltinRewriteRelation q
            | otherwise           -> bindBuiltinName s v
 
 setConstTranspAxiom :: QName -> TCM ()

--- a/test/Fail/Issue6011.agda
+++ b/test/Fail/Issue6011.agda
@@ -1,0 +1,14 @@
+-- Andreas, 2022-08-13, issue #6011 reported by szumixie
+--
+-- Agda 2.6.3 dev version was crashing on a rewrite relation
+-- that produced no name.  (Regression over 2.6.2.2.)
+
+{-# OPTIONS --rewriting #-}
+
+P : Set → Set → Set
+P A B = A
+
+{-# BUILTIN REWRITE P #-}
+
+-- Should give proper error:
+-- Invalid rewrite relation

--- a/test/Fail/Issue6011.err
+++ b/test/Fail/Issue6011.err
@@ -1,0 +1,3 @@
+Issue6011.agda:11,1-26
+Invalid rewrite relation
+when checking the pragma BUILTIN REWRITE P


### PR DESCRIPTION
Fix #6011: explicit error rather than crash on garbage BUILTIN REWRITE (such as `\ A B -> A`).

