### PR TITLE
Expose precise blocking machinery to reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,24 @@ Reflection
 * Two primitives `onlyReduceDefs` and `dontReduceDefs` are removed but re-implemented
   using the new family of primitives `with*` and `ask*` for backward compatibility.
 
+* Blocking the type-checking monad can now be done with more precision
+  by using the `Blocker` type, and the `blockTC` primitive:
+
+  ```agda
+  data Blocker : Set where
+    blockerAny  : List Blocker → Blocker
+    blockerAll  : List Blocker → Blocker
+    blockerMeta : Meta → Blocker
+  ```
+
+  When blocking on a value of this type, the TCM computation will only
+  be retried when any (resp. all) of the mentioned metavariables have
+  been solved. This can avoid getting into loops where a macro blocks on
+  a meta, gets unblocked, traverses some term again, and then blocks on
+  a meta that was already present.
+
+  The `blockOnMeta` builtin has been deprecated, and an implementation
+  in terms of `blockTC` is given for backwards compatibility.
 
 Erasure
 -------

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -359,6 +359,26 @@ implement pretty printing for reflected terms.
   {-# BUILTIN AGDAERRORPARTTERM   termErr   #-}
   {-# BUILTIN AGDAERRORPARTNAME   nameErr   #-}
 
+Blockers
+~~~~~~~~
+
+A blocker represents a set of metavariables that impedes the progress of
+a reflective computation. Using a blocker containing all the metas in
+(for example) a term traversed by a macro is a lot more efficient than
+blocking on individual metas as they are encountered.
+
+::
+
+  data Blocker : Set where
+    blockerAny  : List Blocker → Blocker
+    blockerAll  : List Blocker → Blocker
+    blockerMeta : Meta → Blocker
+
+  {-# BUILTIN AGDABLOCKER     Blocker #-}
+  {-# BUILTIN AGDABLOCKERANY  blockerAny #-}
+  {-# BUILTIN AGDABLOCKERALL  blockerAll #-}
+  {-# BUILTIN AGDABLOCKERMETA blockerMeta #-}
+
 .. _reflection-tc-monad:
 
 Type checking computations
@@ -387,10 +407,10 @@ following primitive operations::
     -- Throw a type error. Can be caught by catchTC.
     typeError : ∀ {a} {A : Set a} → List ErrorPart → TC A
 
-    -- Block a type checking computation on a metavariable. This will abort
+    -- Block a type checking computation on a blocker. This will abort
     -- the computation and restart it (from the beginning) when the
-    -- metavariable is solved.
-    blockOnMeta : ∀ {a} {A : Set a} → Meta → TC A
+    -- blocker has been solved.
+    blockTC : ∀ {a} {A : Set a} → Blocker → TC A
 
     -- Prevent current solutions of metavariables from being rolled back in
     -- case 'blockOnMeta' is called.
@@ -527,7 +547,7 @@ following primitive operations::
 
   {-# BUILTIN AGDATCMUNIFY                      unify                      #-}
   {-# BUILTIN AGDATCMTYPEERROR                  typeError                  #-}
-  {-# BUILTIN AGDATCMBLOCKONMETA                blockOnMeta                #-}
+  {-# BUILTIN AGDATCMBLOCK                      blockTC                    #-}
   {-# BUILTIN AGDATCMCATCHERROR                 catchTC                    #-}
   {-# BUILTIN AGDATCMINFERTYPE                  inferType                  #-}
   {-# BUILTIN AGDATCMCHECKTYPE                  checkType                  #-}

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -468,4 +468,3 @@ blockOnMeta m = blockTC (blockerMeta m)
 
 {-# WARNING_ON_USAGE onlyReduceDefs "DEPRECATED: Use `withReduceDefs` instead of `onlyReduceDefs`" #-}
 {-# WARNING_ON_USAGE dontReduceDefs "DEPRECATED: Use `withReduceDefs` instead of `dontReduceDefs`" #-}
-{-# WARNING_ON_USAGE blockOnMeta    "DEPRECATED: Use `blockTC` instead of `blockOnMeta`" #-}

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -128,6 +128,16 @@ data Arg {a} (A : Set a) : Set a where
 {-# BUILTIN ARG        Arg      #-}
 {-# BUILTIN ARGARG     arg      #-}
 
+data Blocker : Set where
+  blockerAny  : List Blocker → Blocker
+  blockerAll  : List Blocker → Blocker
+  blockerMeta : Meta → Blocker
+
+{-# BUILTIN AGDABLOCKER     Blocker #-}
+{-# BUILTIN AGDABLOCKERANY  blockerAny #-}
+{-# BUILTIN AGDABLOCKERALL  blockerAll #-}
+{-# BUILTIN AGDABLOCKERMETA blockerMeta #-}
+
 -- Name abstraction --
 
 data Abs {a} (A : Set a) : Set a where
@@ -290,7 +300,7 @@ postulate
   defineFun        : Name → List Clause → TC ⊤
   getType          : Name → TC Type
   getDefinition    : Name → TC Definition
-  blockOnMeta      : ∀ {a} {A : Set a} → Meta → TC A
+  blockTC          : ∀ {a} {A : Set a} → Blocker → TC A
   commitTC         : TC ⊤
   isMacro          : Name → TC Bool
   pragmaForeign    : String → String → TC ⊤
@@ -357,7 +367,7 @@ postulate
 {-# BUILTIN AGDATCMDEFINEFUN                  defineFun                  #-}
 {-# BUILTIN AGDATCMGETTYPE                    getType                    #-}
 {-# BUILTIN AGDATCMGETDEFINITION              getDefinition              #-}
-{-# BUILTIN AGDATCMBLOCKONMETA                blockOnMeta                #-}
+{-# BUILTIN AGDATCMBLOCK                      blockTC                    #-}
 {-# BUILTIN AGDATCMCOMMIT                     commitTC                   #-}
 {-# BUILTIN AGDATCMISMACRO                    isMacro                    #-}
 {-# BUILTIN AGDATCMPRAGMAFOREIGN              pragmaForeign              #-}
@@ -403,7 +413,7 @@ postulate
 {-# COMPILE JS defineFun         = _ => _ =>           undefined #-}
 {-# COMPILE JS getType           = _ =>                undefined #-}
 {-# COMPILE JS getDefinition     = _ =>                undefined #-}
-{-# COMPILE JS blockOnMeta       = _ => _ => _ =>      undefined #-}
+{-# COMPILE JS blockTC           = _ => _ =>           undefined #-}
 {-# COMPILE JS commitTC          =                     undefined #-}
 {-# COMPILE JS isMacro           = _ =>                undefined #-}
 {-# COMPILE JS pragmaForeign     = _ => _ =>           undefined #-}
@@ -453,5 +463,9 @@ onlyReduceDefs dontReduceDefs : ∀ {a} {A : Set a} → List Name → TC A → T
 onlyReduceDefs defs x = bindTC askReduceDefs (λ exDefs → withReduceDefs (combineReduceDefs (true  , defs) exDefs) x)
 dontReduceDefs defs x = bindTC askReduceDefs (λ exDefs → withReduceDefs (combineReduceDefs (false , defs) exDefs) x)
 
+blockOnMeta   : ∀ {a} {A : Set a} → Meta → TC A
+blockOnMeta m = blockTC (blockerMeta m)
+
 {-# WARNING_ON_USAGE onlyReduceDefs "DEPRECATED: Use `withReduceDefs` instead of `onlyReduceDefs`" #-}
 {-# WARNING_ON_USAGE dontReduceDefs "DEPRECATED: Use `withReduceDefs` instead of `dontReduceDefs`" #-}
+{-# WARNING_ON_USAGE blockOnMeta    "DEPRECATED: Use `blockTC` instead of `blockOnMeta`" #-}

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -274,7 +274,7 @@ ghcPreCompile flags = do
       , builtinAgdaTCMDefineFun
       , builtinAgdaTCMGetType
       , builtinAgdaTCMGetDefinition
-      , builtinAgdaTCMBlockOnMeta
+      , builtinAgdaTCMBlock
       , builtinAgdaTCMCommit
       , builtinAgdaTCMIsMacro
       , builtinAgdaTCMWithNormalisation
@@ -293,6 +293,10 @@ ghcPreCompile flags = do
       , builtinAgdaTCMGetInstances
       , builtinAgdaTCMPragmaForeign
       , builtinAgdaTCMPragmaCompile
+      , builtinAgdaBlocker
+      , builtinAgdaBlockerAll
+      , builtinAgdaBlockerAny
+      , builtinAgdaBlockerMeta
       ]
     return $
       flip HashSet.member $

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -218,7 +218,7 @@ data BuiltinId
   | BuiltinAgdaTCMDefineFun
   | BuiltinAgdaTCMGetType
   | BuiltinAgdaTCMGetDefinition
-  | BuiltinAgdaTCMBlockOnMeta
+  | BuiltinAgdaTCMBlock
   | BuiltinAgdaTCMCommit
   | BuiltinAgdaTCMQuoteTerm
   | BuiltinAgdaTCMUnquoteTerm
@@ -240,6 +240,10 @@ data BuiltinId
   | BuiltinAgdaTCMGetInstances
   | BuiltinAgdaTCMPragmaForeign
   | BuiltinAgdaTCMPragmaCompile
+  | BuiltinAgdaBlocker
+  | BuiltinAgdaBlockerAny
+  | BuiltinAgdaBlockerAll
+  | BuiltinAgdaBlockerMeta
   deriving (Show, Eq, Ord, Bounded, Enum, Generic)
 
 instance NFData BuiltinId
@@ -433,7 +437,7 @@ instance IsBuiltin BuiltinId where
     BuiltinAgdaTCMDefineFun                  -> "AGDATCMDEFINEFUN"
     BuiltinAgdaTCMGetType                    -> "AGDATCMGETTYPE"
     BuiltinAgdaTCMGetDefinition              -> "AGDATCMGETDEFINITION"
-    BuiltinAgdaTCMBlockOnMeta                -> "AGDATCMBLOCKONMETA"
+    BuiltinAgdaTCMBlock                      -> "AGDATCMBLOCK"
     BuiltinAgdaTCMCommit                     -> "AGDATCMCOMMIT"
     BuiltinAgdaTCMQuoteTerm                  -> "AGDATCMQUOTETERM"
     BuiltinAgdaTCMUnquoteTerm                -> "AGDATCMUNQUOTETERM"
@@ -455,7 +459,10 @@ instance IsBuiltin BuiltinId where
     BuiltinAgdaTCMGetInstances               -> "AGDATCMGETINSTANCES"
     BuiltinAgdaTCMPragmaForeign              -> "AGDATCMPRAGMAFOREIGN"
     BuiltinAgdaTCMPragmaCompile              -> "AGDATCMPRAGMACOMPILE"
-
+    BuiltinAgdaBlocker                       -> "AGDABLOCKER"
+    BuiltinAgdaBlockerAny                    -> "AGDABLOCKERANY"
+    BuiltinAgdaBlockerAll                    -> "AGDABLOCKERALL"
+    BuiltinAgdaBlockerMeta                   -> "AGDABLOCKERMETA"
 
 -- | Builtins that come without a definition in Agda syntax.
 --   These are giving names to Agda internal concepts which
@@ -563,7 +570,8 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinAgdaTCMFreshName, builtinAgdaTCMDeclareDef, builtinAgdaTCMDeclarePostulate, builtinAgdaTCMDeclareData, builtinAgdaTCMDefineData, builtinAgdaTCMDefineFun,
   builtinAgdaTCMGetType, builtinAgdaTCMGetDefinition,
   builtinAgdaTCMQuoteTerm, builtinAgdaTCMUnquoteTerm, builtinAgdaTCMQuoteOmegaTerm,
-  builtinAgdaTCMBlockOnMeta, builtinAgdaTCMCommit, builtinAgdaTCMIsMacro,
+  builtinAgdaTCMCommit, builtinAgdaTCMIsMacro, builtinAgdaTCMBlock,
+  builtinAgdaBlocker, builtinAgdaBlockerAll, builtinAgdaBlockerAny, builtinAgdaBlockerMeta,
   builtinAgdaTCMFormatErrorParts, builtinAgdaTCMDebugPrint,
   builtinAgdaTCMWithNormalisation, builtinAgdaTCMWithReconstructed,
   builtinAgdaTCMWithExpandLast, builtinAgdaTCMWithReduceDefs,
@@ -752,7 +760,7 @@ builtinAgdaTCMDefineData                 = BuiltinAgdaTCMDefineData
 builtinAgdaTCMDefineFun                  = BuiltinAgdaTCMDefineFun
 builtinAgdaTCMGetType                    = BuiltinAgdaTCMGetType
 builtinAgdaTCMGetDefinition              = BuiltinAgdaTCMGetDefinition
-builtinAgdaTCMBlockOnMeta                = BuiltinAgdaTCMBlockOnMeta
+builtinAgdaTCMBlock                      = BuiltinAgdaTCMBlock
 builtinAgdaTCMCommit                     = BuiltinAgdaTCMCommit
 builtinAgdaTCMQuoteTerm                  = BuiltinAgdaTCMQuoteTerm
 builtinAgdaTCMUnquoteTerm                = BuiltinAgdaTCMUnquoteTerm
@@ -774,6 +782,10 @@ builtinAgdaTCMExec                       = BuiltinAgdaTCMExec
 builtinAgdaTCMGetInstances               = BuiltinAgdaTCMGetInstances
 builtinAgdaTCMPragmaForeign              = BuiltinAgdaTCMPragmaForeign
 builtinAgdaTCMPragmaCompile              = BuiltinAgdaTCMPragmaCompile
+builtinAgdaBlocker                       = BuiltinAgdaBlocker
+builtinAgdaBlockerAny                    = BuiltinAgdaBlockerAny
+builtinAgdaBlockerAll                    = BuiltinAgdaBlockerAll
+builtinAgdaBlockerMeta                   = BuiltinAgdaBlockerMeta
 
 -- | Lookup a builtin by the string used in the @BUILTIN@ pragma.
 builtinById :: String -> Maybe BuiltinId

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -262,6 +262,7 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primAgdaPatLit, primAgdaPatProj,
     primAgdaPatAbsurd,
     primAgdaMeta,
+    primAgdaBlocker, primAgdaBlockerAny, primAgdaBlockerAll, primAgdaBlockerMeta,
     primAgdaTCM, primAgdaTCMReturn, primAgdaTCMBind, primAgdaTCMUnify,
     primAgdaTCMTypeError, primAgdaTCMInferType, primAgdaTCMCheckType,
     primAgdaTCMNormalise, primAgdaTCMReduce,
@@ -269,7 +270,7 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primAgdaTCMFreshName, primAgdaTCMDeclareDef, primAgdaTCMDeclarePostulate, primAgdaTCMDeclareData, primAgdaTCMDefineData, primAgdaTCMDefineFun,
     primAgdaTCMGetType, primAgdaTCMGetDefinition,
     primAgdaTCMQuoteTerm, primAgdaTCMUnquoteTerm, primAgdaTCMQuoteOmegaTerm,
-    primAgdaTCMBlockOnMeta, primAgdaTCMCommit, primAgdaTCMIsMacro,
+    primAgdaTCMCommit, primAgdaTCMIsMacro, primAgdaTCMBlock,
     primAgdaTCMFormatErrorParts, primAgdaTCMDebugPrint,
     primAgdaTCMWithNormalisation, primAgdaTCMWithReconstructed,
     primAgdaTCMWithExpandLast, primAgdaTCMWithReduceDefs,
@@ -400,6 +401,10 @@ primPrecRelated                       = getBuiltin builtinPrecRelated
 primPrecUnrelated                     = getBuiltin builtinPrecUnrelated
 primFixity                            = getBuiltin builtinFixity
 primFixityFixity                      = getBuiltin builtinFixityFixity
+primAgdaBlocker                       = getBuiltin builtinAgdaBlocker
+primAgdaBlockerAny                    = getBuiltin builtinAgdaBlockerAny
+primAgdaBlockerAll                    = getBuiltin builtinAgdaBlockerAll
+primAgdaBlockerMeta                   = getBuiltin builtinAgdaBlockerMeta
 primArgInfo                           = getBuiltin builtinArgInfo
 primArgArgInfo                        = getBuiltin builtinArgArgInfo
 primAgdaSortSet                       = getBuiltin builtinAgdaSortSet
@@ -474,7 +479,7 @@ primAgdaTCMGetDefinition              = getBuiltin builtinAgdaTCMGetDefinition
 primAgdaTCMQuoteTerm                  = getBuiltin builtinAgdaTCMQuoteTerm
 primAgdaTCMQuoteOmegaTerm             = getBuiltin builtinAgdaTCMQuoteOmegaTerm
 primAgdaTCMUnquoteTerm                = getBuiltin builtinAgdaTCMUnquoteTerm
-primAgdaTCMBlockOnMeta                = getBuiltin builtinAgdaTCMBlockOnMeta
+primAgdaTCMBlock                      = getBuiltin builtinAgdaTCMBlock
 primAgdaTCMCommit                     = getBuiltin builtinAgdaTCMCommit
 primAgdaTCMIsMacro                    = getBuiltin builtinAgdaTCMIsMacro
 primAgdaTCMWithNormalisation          = getBuiltin builtinAgdaTCMWithNormalisation

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -242,6 +242,20 @@ instance ToTerm Associativity where
         LeftAssoc  -> lassoc
         RightAssoc -> rassoc
 
+instance ToTerm Blocker where
+  toTerm = do
+    all <- primAgdaBlockerAll
+    any <- primAgdaBlockerAny
+    meta <- primAgdaBlockerMeta
+    lists <- buildList
+    metaTm <- toTerm
+    let go (UnblockOnAny xs)    = any `apply` [defaultArg (lists (go <$> Set.toList xs))]
+        go (UnblockOnAll xs)    = all `apply` [defaultArg (lists (go <$> Set.toList xs))]
+        go (UnblockOnMeta m)    = meta `apply` [defaultArg (metaTm m)]
+        go (UnblockOnDef _)     = __IMPOSSIBLE__
+        go (UnblockOnProblem _) = __IMPOSSIBLE__
+    pure go
+
 instance ToTerm FixityLevel where
   toTerm = do
     (iToTm :: PrecedenceLevel -> Term) <- toTerm

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -241,6 +241,10 @@ coreBuiltins =
   , builtinAgdaErrorPartTerm                 |-> BuiltinDataCons (tterm --> terrorpart)
   , builtinAgdaErrorPartPatt                 |-> BuiltinDataCons (tpat --> terrorpart)
   , builtinAgdaErrorPartName                 |-> BuiltinDataCons (tqname --> terrorpart)
+  , builtinAgdaBlocker                       |-> BuiltinData tset [ builtinAgdaBlockerAll, builtinAgdaBlockerAny, builtinAgdaBlockerMeta ]
+  , builtinAgdaBlockerAny                    |-> BuiltinDataCons (tlist tblocker --> tblocker)
+  , builtinAgdaBlockerAll                    |-> BuiltinDataCons (tlist tblocker --> tblocker)
+  , builtinAgdaBlockerMeta                   |-> BuiltinDataCons (tmeta --> tblocker)
   -- Andreas, 2017-01-12, issue #2386: special handling of builtinEquality
   -- , (builtinEquality                         |-> BuiltinData (hPi "a" (el primLevel) $
   --                                                             hPi "A" (return $ sort $ varSort 0) $
@@ -386,7 +390,7 @@ coreBuiltins =
   , builtinAgdaTCMQuoteTerm                  |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ elV 1 (varM 0) --> tTCM_ primAgdaTerm)
   , builtinAgdaTCMUnquoteTerm                |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tterm --> tTCM 1 (varM 0))
   , builtinAgdaTCMQuoteOmegaTerm             |-> builtinPostulate (hPi "A" tsetOmega $ (elInf $ varM 0) --> tTCM_ primAgdaTerm)
-  , builtinAgdaTCMBlockOnMeta                |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tmeta --> tTCM 1 (varM 0))
+  , builtinAgdaTCMBlock                      |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tblocker --> tTCM 1 (varM 0))
   , builtinAgdaTCMCommit                     |-> builtinPostulate (tTCM_ primUnit)
   , builtinAgdaTCMIsMacro                    |-> builtinPostulate (tqname --> tTCM_ primBool)
   , builtinAgdaTCMWithNormalisation          |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tbool --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
@@ -448,6 +452,7 @@ coreBuiltins =
         tstring    = el primString
         tqname     = el primQName
         tmeta      = el primAgdaMeta
+        tblocker   = el primAgdaBlocker
         tsize      = El sSizeUniv <$> primSize
         tbool      = el primBool
         thiding    = el primHiding

--- a/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
+++ b/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
@@ -234,7 +234,6 @@ postulate
   defineFun     : Name → List Clause → TC ⊤
   getType       : Name → TC Type
   getDefinition : Name → TC Definition
-  blockOnMeta   : ∀ {a} {A : Set a} → Meta → TC A
   commitTC      : TC ⊤
 
 {-# BUILTIN AGDATCM              TC            #-}
@@ -256,7 +255,6 @@ postulate
 {-# BUILTIN AGDATCMDEFINEFUN     defineFun     #-}
 {-# BUILTIN AGDATCMGETTYPE       getType       #-}
 {-# BUILTIN AGDATCMGETDEFINITION getDefinition #-}
-{-# BUILTIN AGDATCMBLOCKONMETA   blockOnMeta   #-}
 {-# BUILTIN AGDATCMCOMMIT        commitTC      #-}
 
 -- The code below used to be rejected, but it was accepted if the code


### PR DESCRIPTION
Closes https://github.com/agda/agda/issues/4594 (ping @nad) by exposing the `Blocker` type and constructors corresponding to `UnblockOnMeta`, `UnblockOnAny` and `UnblockOnAll` to reflection. The `Set` arguments to any/all are represented by lists on the Agda side.

To be honest I have no idea how to test this. To make sure it's working locally I changed a call to `(blockOnMeta x)` with 
```agda
(blockTC (blockerAny (blockerMeta x ∷ [])))
```
and observed that the debug output (`tc.unquote.block:10`) contains an `UnblockOnAny`. I'll add a changelog entry in the morning.