### PR TITLE
Clean up cubical primitives

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -512,6 +512,10 @@ library
                     Agda.TypeChecking.Primitive
                     Agda.TypeChecking.Primitive.Base
                     Agda.TypeChecking.Primitive.Cubical
+                    Agda.TypeChecking.Primitive.Cubical.Id
+                    Agda.TypeChecking.Primitive.Cubical.Glue
+                    Agda.TypeChecking.Primitive.Cubical.Base
+                    Agda.TypeChecking.Primitive.Cubical.HCompU
                     Agda.TypeChecking.ProjectionLike
                     Agda.TypeChecking.Quote
                     Agda.TypeChecking.ReconstructParameters

--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -4,7 +4,7 @@ module Agda.Compiler.Common where
 
 import Prelude hiding ((!!))
 
-import Data.List as List (sortBy, isPrefixOf)
+import Data.List (sortBy, isPrefixOf)
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -100,7 +100,7 @@ sortDefs defs =
   -- The list is sorted to ensure that the order of the generated
   -- definitions does not depend on things like the number of bits
   -- in an Int (see Issue 1900).
-  List.sortBy (compare `on` fst) $
+  sortBy (compare `on` fst) $
   HMap.toList defs
 
 compileDir :: HasOptions m => m FilePath

--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -4,7 +4,7 @@ module Agda.Compiler.Common where
 
 import Prelude hiding ((!!))
 
-import Data.List as List hiding ((!!))
+import Data.List as List (sortBy, isPrefixOf)
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -169,11 +169,11 @@ inCompilerEnv checkResult cont = do
 topLevelModuleName :: ReadTCState m => ModuleName -> m ModuleName
 topLevelModuleName m = do
   -- get the names of the visited modules
-  visited <- List.map (iModuleName . miInterface) . Map.elems <$>
+  visited <- map (iModuleName . miInterface) . Map.elems <$>
     getVisitedModules
   -- find the module with the longest matching prefix to m
   let ms = sortBy (compare `on` (length . mnameToList)) $
-       List.filter (\ m' -> mnameToList m' `isPrefixOf` mnameToList m) visited
+        filter (\ m' -> mnameToList m' `isPrefixOf` mnameToList m) visited
   case ms of
     (m' : _) -> return m'
     -- if we did not get anything, it may be because m is a section

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -68,7 +68,7 @@ import Control.Monad.Writer (runWriter, tell)
 import qualified Data.Foldable as Fold
 import Data.Function
 import Data.Int
-import Data.List hiding (null)
+import Data.List (foldl', sort)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -286,7 +286,9 @@ compareTerm' cmp a m n =
           b <- levelView n
           equalLevel a b
         a@Pi{}    -> equalFun s a m n
-        Lam _ _   -> reportSDoc "tc.conv.term.sort" 10 (pretty s) >> __IMPOSSIBLE__
+        Lam _ _   -> reportSDoc "tc.conv.term.sort" 10 (fsep
+          [ "compareTerm", prettyTCM m, prettyTCM cmp, prettyTCM n, ":", prettyTCM a'
+          , "at sort", prettyTCM s]) >> __IMPOSSIBLE__
         Def r es  -> do
           isrec <- isEtaRecord r
           if isrec

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -269,6 +269,9 @@ compareTerm' cmp a m n =
     isSize   <- isJust <$> isSizeType a'
     (bs, s)  <- reduceWithBlocker $ getSort a'
     mlvl     <- getBuiltin' builtinLevel
+    reportSDoc "tc.conv.term" 40 $ fsep
+      [ "compareTerm", prettyTCM m, prettyTCM cmp, prettyTCM n, ":", prettyTCM a'
+      , "at sort", prettyTCM s]
     reportSDoc "tc.conv.level" 60 $ nest 2 $ sep
       [ "a'   =" <+> pretty a'
       , "mlvl =" <+> pretty mlvl
@@ -283,7 +286,7 @@ compareTerm' cmp a m n =
           b <- levelView n
           equalLevel a b
         a@Pi{}    -> equalFun s a m n
-        Lam _ _   -> __IMPOSSIBLE__
+        Lam _ _   -> reportSDoc "tc.conv.term.sort" 10 (pretty s) >> __IMPOSSIBLE__
         Def r es  -> do
           isrec <- isEtaRecord r
           if isrec

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -286,9 +286,12 @@ compareTerm' cmp a m n =
           b <- levelView n
           equalLevel a b
         a@Pi{}    -> equalFun s a m n
-        Lam _ _   -> reportSDoc "tc.conv.term.sort" 10 (fsep
-          [ "compareTerm", prettyTCM m, prettyTCM cmp, prettyTCM n, ":", prettyTCM a'
-          , "at sort", prettyTCM s]) >> __IMPOSSIBLE__
+        Lam _ _   -> do
+          reportSDoc "tc.conv.term.sort" 10 $ fsep
+            [ "compareTerm", prettyTCM m, prettyTCM cmp, prettyTCM n, ":", prettyTCM a'
+            , "at sort", prettyTCM s
+            ]
+          __IMPOSSIBLE__
         Def r es  -> do
           isrec <- isEtaRecord r
           if isrec

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -36,6 +36,7 @@ import Agda.TypeChecking.Level
 import Agda.TypeChecking.Quote (quoteTermWithKit, quoteTypeWithKit, quoteDomWithKit, quotingKit)
 import Agda.TypeChecking.Primitive.Base
 import Agda.TypeChecking.Primitive.Cubical
+import Agda.TypeChecking.Primitive.Cubical.Base
 import Agda.TypeChecking.Warnings
 
 import Agda.Utils.Char

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -334,7 +334,7 @@ doPathPKanOp (HCompOp phi u u0) (IsNot l) (IsNot (bA,x,y)) = do
     -- in the Path type.
     lam "j" $ \ j ->
       pure tHComp <#> l <#> (bA <@> j) <#> (phi `imax` (ineg j `imax` j))
-        <@> lam "i'" (\i -> combineSys l (lam "_" (const (bA <@> i)))
+        <@> lam "i'" (\i -> combineSys l (bA <@> i)
           [ (phi,    ilam "o" (\ o -> u <@> i <..> o <@@> (x, y, j)))
           , (j,      ilam "o" (const y))
           , (ineg j, ilam "o" (const x)) ])
@@ -361,7 +361,7 @@ doPathPKanOp (TranspOp phi u0) (IsFam l) (IsFam (bA,x,y)) = do
 
     lam "j" $ \ j ->
       comp l (lam "i" $ \ i -> bA <@> i <@> j) (phi `imax` (ineg j `imax` j))
-        (lam "i'" $ \i -> combineSys l (lam "_" (const (bA <@> i <@> j)))
+        (lam "i'" $ \i -> combineSys l (bA <@> i <@> j)
           [ (phi, ilam "o" (\o -> u0 <@@> (x <@> pure iz, y <@> pure iz, j)))
           -- Note that here we have lines of endpoints which we must
           -- apply to fix the endpoints:

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -280,7 +280,7 @@ doPiKanOp cmd t ab = do
         -- hcomp u u0 x = hcomp (λ i o → u i o x) (u0 x). Short and sweet :)
         (HCompOp _ u _, IsNot (a , b)) -> do
           bT <- (raise 1 b `absApp`) <$> u1
-          u <- open (unArg u)
+          u <- open (raise 1 (unArg u))
           pure tHComp
             <#> (Level <$> toLevel bT)
             <#> pure (unEl bT)

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -1,7 +1,14 @@
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Agda.TypeChecking.Primitive.Cubical where
+module Agda.TypeChecking.Primitive.Cubical
+  ( module Agda.TypeChecking.Primitive.Cubical
+  , module Agda.TypeChecking.Primitive.Cubical.Id
+  , module Agda.TypeChecking.Primitive.Cubical.Base
+  , module Agda.TypeChecking.Primitive.Cubical.Glue
+  , module Agda.TypeChecking.Primitive.Cubical.HCompU
+  )
+  where
 
 import Prelude hiding (null, (!!))
 
@@ -51,165 +58,10 @@ import Agda.Utils.BoolSet (BoolSet)
 import qualified Agda.Utils.Pretty as P
 import qualified Agda.Utils.BoolSet as BoolSet
 
--- | Checks that the correct variant of Cubical Agda is activated.
--- Note that @--erased-cubical@ \"counts as\" @--cubical@ in erased
--- contexts.
-
-requireCubical
-  :: Cubical -- ^ Which variant of Cubical Agda is required?
-  -> String -> TCM ()
-requireCubical wanted s = do
-  cubical         <- optCubical <$> pragmaOptions
-  inErasedContext <- hasQuantity0 <$> getEnv
-  case cubical of
-    Just CFull -> return ()
-    Just CErased | wanted == CErased || inErasedContext -> return ()
-    _ -> typeError $ GenericError $ "Missing option " ++ opt ++ s
-  where
-  opt = case wanted of
-    CFull   -> "--cubical"
-    CErased -> "--cubical or --erased-cubical"
-
-primIntervalType :: (HasBuiltins m, MonadError TCErr m, MonadTCEnv m, ReadTCState m) => m Type
-primIntervalType = El intervalSort <$> primInterval
-
-primINeg' :: TCM PrimitiveImpl
-primINeg' = do
-  requireCubical CErased ""
-  t <- primIntervalType --> primIntervalType
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 1 $ \ ts -> do
-    case ts of
-     [x] -> do
-       unview <- intervalUnview'
-       view <- intervalView'
-       sx <- reduceB' x
-       ix <- intervalView (unArg $ ignoreBlocking sx)
-       let
-         ineg :: Arg Term -> Arg Term
-         ineg = fmap (unview . f . view)
-         f ix = case ix of
-           IZero -> IOne
-           IOne  -> IZero
-           IMin x y -> IMax (ineg x) (ineg y)
-           IMax x y -> IMin (ineg x) (ineg y)
-           INeg x -> OTerm (unArg x)
-           OTerm t -> INeg (Arg defaultArgInfo t)
-       case ix of
-        OTerm t -> return $ NoReduction [reduced sx]
-        _       -> redReturn (unview $ f ix)
-     _ -> __IMPOSSIBLE__
-
-primDepIMin' :: TCM PrimitiveImpl
-primDepIMin' = do
-  requireCubical CErased ""
-  t <- runNamesT [] $
-       nPi' "φ" primIntervalType $ \ φ ->
-       pPi' "o" φ (\ o -> primIntervalType) --> primIntervalType
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 2 $ \ ts -> do
-    case ts of
-      [x,y] -> do
-        sx <- reduceB' x
-        ix <- intervalView (unArg $ ignoreBlocking sx)
-        itisone <- getTerm "primDepIMin" builtinItIsOne
-        case ix of
-          IZero -> redReturn =<< intervalUnview IZero
-          IOne  -> redReturn =<< (pure (unArg y) <@> pure itisone)
-          _     -> do
-            sy <- reduceB' y
-            iy <- intervalView =<< reduce' =<< (pure (unArg $ ignoreBlocking sy) <@> pure itisone)
-            case iy of
-              IZero -> redReturn =<< intervalUnview IZero
-              IOne  -> redReturn (unArg $ ignoreBlocking sx)
-              _     -> return $ NoReduction [reduced sx, reduced sy]
-      _      -> __IMPOSSIBLE__
-
-primIBin :: IntervalView -> IntervalView -> TCM PrimitiveImpl
-primIBin unit absorber = do
-  requireCubical CErased ""
-  t <- primIntervalType --> primIntervalType --> primIntervalType
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 2 $ \ ts -> do
-    case ts of
-     [x,y] -> do
-       sx <- reduceB' x
-       ix <- intervalView (unArg $ ignoreBlocking sx)
-       case ix of
-         ix | ix ==% absorber -> redReturn =<< intervalUnview absorber
-         ix | ix ==% unit     -> return $ YesReduction YesSimplification (unArg y)
-         _     -> do
-           sy <- reduceB' y
-           iy <- intervalView (unArg $ ignoreBlocking sy)
-           case iy of
-            iy | iy ==% absorber -> redReturn =<< intervalUnview absorber
-            iy | iy ==% unit     -> return $ YesReduction YesSimplification (unArg x)
-            _                   -> return $ NoReduction [reduced sx,reduced sy]
-     _ -> __IMPOSSIBLE__
-  where
-    (==%) IZero IZero = True
-    (==%) IOne IOne = True
-    (==%) _ _ = False
-
-
-primIMin' :: TCM PrimitiveImpl
-primIMin' = do
-  requireCubical CErased ""
-  primIBin IOne IZero
-
-primIMax' :: TCM PrimitiveImpl
-primIMax' = do
-  requireCubical CErased ""
-  primIBin IZero IOne
-
-imax :: HasBuiltins m => m Term -> m Term -> m Term
-imax x y = do
-  x' <- x
-  y' <- y
-  intervalUnview (IMax (argN x') (argN y'))
-
-imin :: HasBuiltins m => m Term -> m Term -> m Term
-imin x y = do
-  x' <- x
-  y' <- y
-  intervalUnview (IMin (argN x') (argN y'))
-
-primIdElim' :: TCM PrimitiveImpl
-primIdElim' = do
-  requireCubical CErased ""
-  t <- runNamesT [] $
-       hPi' "a" (el $ cl primLevel) $ \ a ->
-       hPi' "c" (el $ cl primLevel) $ \ c ->
-       hPi' "A" (sort . tmSort <$> a) $ \ bA ->
-       hPi' "x" (el' a bA) $ \ x ->
-       nPi' "C" (nPi' "y" (el' a bA) $ \ y ->
-                 el' a (cl primId <#> a <#> bA <@> x <@> y) --> (sort . tmSort <$> c)) $ \ bC ->
-       nPi' "φ" primIntervalType (\ phi ->
-        nPi' "y" (el's a $ cl primSub <#> a <@> bA <@> phi <@> lam "o" (const x)) $ \ y ->
-        let pathxy = (cl primPath <#> a <@> bA <@> x <@> oucy)
-            oucy = (cl primSubOut <#> a <#> bA <#> phi <#> lam "o" (const x) <@> y)
-            reflx = (lam "o" $ \ _ -> lam "i" $ \ _ -> x) -- TODO Andrea, should block on o
-        in
-        nPi' "w" (el's a $ cl primSub <#> a <@> pathxy <@> phi <@> reflx) $ \ w ->
-        let oucw = (cl primSubOut <#> a <#> pathxy <#> phi <#> reflx <@> w) in
-        el' c $ bC <@> oucy <@> (cl primConId <#> a <#> bA <#> x <#> oucy <@> phi <@> oucw))
-       -->
-       hPi' "y" (el' a bA) (\ y ->
-        nPi' "p" (el' a $ cl primId <#> a <#> bA <@> x <@> y) $ \ p ->
-        el' c $ bC <@> y <@> p)
-  conid <- primConId
-  sin <- primSubIn
-  path <- primPath
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 8 $ \ ts -> do
-    case ts of
-      [a,c,bA,x,bC,f,y,p] -> do
-        sp <- reduceB' p
-        cview <- conidView'
-        case cview (unArg x) $ unArg $ ignoreBlocking sp of
-          Just (phi , w) -> do
-            let y' = sin `apply` [a,bA                            ,phi,argN $ unArg y]
-            let w' = sin `apply` [a,argN $ path `apply` [a,bA,x,y],phi,argN $ unArg w]
-            redReturn $ unArg f `apply` [phi, defaultArg y', defaultArg w']
-          _ -> return $ NoReduction $ map notReduced [a,c,bA,x,bC,f,y] ++ [reduced sp]
-      _ -> __IMPOSSIBLE__
-
+import Agda.TypeChecking.Primitive.Cubical.HCompU
+import Agda.TypeChecking.Primitive.Cubical.Glue
+import Agda.TypeChecking.Primitive.Cubical.Base
+import Agda.TypeChecking.Primitive.Cubical.Id
 
 primPOr :: TCM PrimitiveImpl
 primPOr = do
@@ -301,72 +153,6 @@ primSubOut' = do
               _ -> return $ NoReduction $ map notReduced [a,bA] ++ [reduced sphi, notReduced u, reduced sx]
       _ -> __IMPOSSIBLE__
 
-primConId' :: TCM PrimitiveImpl
-primConId' = do
-  requireCubical CErased ""
-  t <- runNamesT [] $
-       hPi' "a" (el $ cl primLevel) $ \ a ->
-       hPi' "A" (sort . tmSort <$> a) $ \ bA ->
-       hPi' "x" (el' a bA) $ \ x ->
-       hPi' "y" (el' a bA) $ \ y ->
-       primIntervalType -->
-       (el' a $ cl primPath <#> a <#> bA <@> x <@> y)
-       --> (el' a $ cl primId <#> a <#> bA <@> x <@> y)
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 6 $ \ ts -> do
-    case ts of
-      [l,bA,x,y,phi,p] -> do
-        sphi <- reduceB' phi
-        view <- intervalView'
-        case view $ unArg $ ignoreBlocking sphi of
-          IOne -> do
-            reflId <- getTerm builtinConId builtinReflId
-            redReturn $ reflId
-          _ -> return $ NoReduction $ map notReduced [l,bA,x,y] ++ [reduced sphi, notReduced p]
-      _ -> __IMPOSSIBLE__
-
-primIdFace' :: TCM PrimitiveImpl
-primIdFace' = do
-  requireCubical CErased ""
-  t <- runNamesT [] $
-       hPi' "a" (el $ cl primLevel) $ \ a ->
-       hPi' "A" (sort . tmSort <$> a) $ \ bA ->
-       hPi' "x" (el' a bA) $ \ x ->
-       hPi' "y" (el' a bA) $ \ y ->
-       el' a (cl primId <#> a <#> bA <@> x <@> y)
-       --> primIntervalType
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 5 $ \ ts -> do
-    case ts of
-      [l,bA,x,y,t] -> do
-        st <- reduceB' t
-        mConId <- getName' builtinConId
-        cview <- conidView'
-        case cview (unArg x) $ unArg (ignoreBlocking st) of
-          Just (phi,_) -> redReturn (unArg phi)
-          _ -> return $ NoReduction $ map notReduced [l,bA,x,y] ++ [reduced st]
-      _ -> __IMPOSSIBLE__
-
-primIdPath' :: TCM PrimitiveImpl
-primIdPath' = do
-  requireCubical CErased ""
-  t <- runNamesT [] $
-       hPi' "a" (el $ cl primLevel) $ \ a ->
-       hPi' "A" (sort . tmSort <$> a) $ \ bA ->
-       hPi' "x" (el' a bA) $ \ x ->
-       hPi' "y" (el' a bA) $ \ y ->
-       el' a (cl primId <#> a <#> bA <@> x <@> y)
-       --> el' a (cl primPath <#> a <#> bA <@> x <@> y)
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 5 $ \ ts -> do
-    case ts of
-      [l,bA,x,y,t] -> do
-        st <- reduceB' t
-        mConId <- getName' builtinConId
-        cview <- conidView'
-        case cview (unArg x) $ unArg (ignoreBlocking st) of
-          Just (_, w) -> redReturn (unArg w)
-          _ -> return $ NoReduction $ map notReduced [l,bA,x,y] ++ [reduced st]
-      _ -> __IMPOSSIBLE__
-
-
 primTrans' :: TCM PrimitiveImpl
 primTrans' = do
   requireCubical CErased ""
@@ -390,944 +176,359 @@ primHComp' = do
   return $ PrimImpl t $ PrimFun __IMPOSSIBLE__ 5 $ \ ts nelims -> do
     primTransHComp DoHComp ts nelims
 
-data TranspOrHComp = DoTransp | DoHComp deriving (Eq,Show)
-
-cmdToName :: TranspOrHComp -> String
-cmdToName DoTransp = builtinTrans
-cmdToName DoHComp  = builtinHComp
-
-data FamilyOrNot a
-  = IsFam { famThing :: a }
-  | IsNot { famThing :: a }
-  deriving (Eq,Show,Functor,Foldable,Traversable)
-
-familyOrNot :: IsString p => FamilyOrNot a -> p
-familyOrNot (IsFam x) = "IsFam"
-familyOrNot (IsNot x) = "IsNot"
-
-instance Reduce a => Reduce (FamilyOrNot a) where
-  reduceB' x = traverse id <$> traverse reduceB' x
-  reduce' x = traverse reduce' x
-
-
+-- | Construct a helper for CCHM composition, with a string indicating
+-- what function uses it.
 mkComp :: HasBuiltins m => String -> NamesT m (NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term)
 mkComp s = do
   let getTermLocal = getTerm s
-  tComp <- getTermLocal builtinComp
-  return $ \ la bA phi u u0 ->
-    pure tComp <#> la
-               <@> bA
-               <#> phi
-               <@> u
-               <@> u0
-
-
-
-
--- | Define a "ghcomp" version of gcomp. Normal comp looks like:
---
--- comp^i A [ phi -> u ] u0 = hcomp^i A(1/i) [ phi -> forward A i u ] (forward A 0 u0)
---
--- So for "gcomp" we compute:
---
--- gcomp^i A [ phi -> u ] u0 = hcomp^i A(1/i) [ phi -> forward A i u, ~ phi -> forward A 0 u0 ] (forward A 0 u0)
---
--- The point of this is that gcomp does not produce any empty
--- systems (if phi = 0 it will reduce to "forward A 0 u".
-mkGComp :: HasBuiltins m => String -> NamesT m (NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term)
-mkGComp s = do
-  let getTermLocal = getTerm s
-  tPOr <- getTermLocal "primPOr"
-  tIMax <- getTermLocal builtinIMax
-  tIMin <- getTermLocal builtinIMin
-  tINeg <- getTermLocal builtinINeg
+  tIMax  <- getTermLocal builtinIMax
+  tINeg  <- getTermLocal builtinINeg
   tHComp <- getTermLocal builtinHComp
   tTrans <- getTermLocal builtinTrans
-  io      <- getTermLocal builtinIOne
-  iz      <- getTermLocal builtinIZero
-  let ineg j = pure tINeg <@> j
-      imax i j = pure tIMax <@> i <@> j
-  let forward la bA r u = pure tTrans <#> lam "i" (\ i -> la <@> (i `imax` r))
-                                      <@> lam "i" (\ i -> bA <@> (i `imax` r))
-                                      <@> r
-                                      <@> u
-  return $ \ la bA phi u u0 ->
-    pure tHComp <#> (la <@> pure io)
-                <#> (bA <@> pure io)
-                <#> imax phi (ineg phi)
-                <@> lam "i" (\ i ->
-                      pure tPOr <#> (la <@> i)
-                                <@> phi
-                                <@> ineg phi
-                                <@> ilam "o" (\ a -> bA <@> i)
-                                <@> ilam "o" (\ o -> forward la bA i (u <@> i <..> o))
-                                <@> ilam "o" (\ o -> forward la bA (pure iz) u0))
+  iz     <- getTermLocal builtinIZero
+  io     <- getTermLocal builtinIOne
+
+  let
+    forward la bA r u = pure tTrans
+      <#> (lam "i" $ \i -> la <@> (i `imax` r))
+      <@> (lam "i" $ \i -> bA <@> (i `imax` r))
+      <@> r
+      <@> u
+
+  pure $ \la bA phi u u0 ->
+    pure tHComp <#> (la <@> pure io) <#> (bA <@> pure io) <#> phi
+                <@> lam "i" (\i -> ilam "o" $ \o ->
+                        forward la bA i (u <@> i <..> o))
                 <@> forward la bA (pure iz) u0
 
 
-unglueTranspGlue :: PureTCM m =>
-                  Arg Term
-                  -> Arg Term
-                  -> FamilyOrNot
-                       (Arg Term, Arg Term, Arg Term, Arg Term, Arg Term, Arg Term)
-                  -> m Term
--- ...    |- psi, u0
--- ..., i |- la, lb, bA, phi, bT, e
-unglueTranspGlue psi u0 (IsFam (la, lb, bA, phi, bT, e)) = do
+
+-- | Implementation of Kan operations for Pi types. The implementation
+-- of @transp@ and @hcomp@ for Pi types has many commonalities, so most
+-- of it is shared between the two cases.
+doPiKanOp
+  :: KanOperation -- ^ Are we composing or transporting?
+  -> ArgName      -- ^ Name of the binder
+  -> FamilyOrNot (Dom Type, Abs Type)
+  -- ^ The domain and codomain of the Pi type.
+  -> ReduceM (Maybe Term)
+doPiKanOp cmd t ab = do
+  let getTermLocal = getTerm $ kanOpName cmd ++ " for function types"
+
+  tTrans <- getTermLocal builtinTrans
+  tHComp <- getTermLocal builtinHComp
+  tINeg <- getTermLocal builtinINeg
+  tIMax <- getTermLocal builtinIMax
+  iz    <- getTermLocal builtinIZero
+
+  -- We must guarantee that the codomain is a fibrant type, i.e. one
+  -- that supports hcomp and transp. Otherwise, what are we even doing!
+  let
+    toLevel' t = do
+      s <- reduce $ getSort t
+      case s of
+        Type l -> return (Just l)
+        _      -> return Nothing
+    -- But this case is actually impossible:
+    toLevel t = fromMaybe __IMPOSSIBLE__ <$> toLevel' t
+
+  caseMaybeM (toLevel' . absBody . snd . famThing $ ab) (return Nothing) $ \ _ -> do
+  runNamesT [] $ do
+
+    -- When doing transport in Pi types, we need to distinguish a couple
+    -- of different cases depending on the sort of the domain, since
+    -- there are a couple of different possibilities for how we end up
+    -- with a fibrant Pi type:
+    trFibrantDomain <- do
       let
-        localUse = builtinTrans ++ " for " ++ builtinGlue
-        getTermLocal = getTerm localUse
-      tPOr <- getTermLocal "primPOr"
-      tIMax <- getTermLocal builtinIMax
-      tIMin <- getTermLocal builtinIMin
-      tINeg <- getTermLocal builtinINeg
-      tHComp <- getTermLocal builtinHComp
-      tTrans <- getTermLocal builtinTrans
-      tForall  <- getTermLocal builtinFaceForall
-      tEFun  <- getTermLocal builtinEquivFun
-      tEProof <- getTermLocal builtinEquivProof
-      toutS   <- getTermLocal builtinSubOut
-      tglue   <- getTermLocal builtin_glue
-      tunglue <- getTermLocal builtin_unglue
-      io      <- getTermLocal builtinIOne
-      iz      <- getTermLocal builtinIZero
-      tLMax   <- getTermLocal builtinLevelMax
-      tPath   <- getTermLocal builtinPath
-      tTransp <- getTermLocal builtinTranspProof
-      tItIsOne <- getTermLocal builtinItIsOne
-      kit <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
-      runNamesT [] $ do
-        let ineg j = pure tINeg <@> j
-            imax i j = pure tIMax <@> i <@> j
-            imin i j = pure tIMin <@> i <@> j
+        (x, f) = case ab of
+          IsFam (a, _) -> (a, \ a -> runNames [] $ lam "i" (const (pure a)))
+          IsNot (a, _) -> (a, id)
+      s <- reduce $ getSort x
+      case s of
+        -- We're looking at a fibrant Pi with fibrant domain: Transport
+        -- backwards along the domain.
+        Type lx -> do
+          [la, bA] <- mapM (open . f) [Level lx, unEl . unDom $ x]
+          pure $ Just $ \iOrNot phi a0 ->
+            pure tTrans <#> lam "j" (\j -> la <@> iOrNot j)
+              <@> lam "j" (\ j -> bA <@> iOrNot j)
+              <@> phi
+              <@> a0
 
-        gcomp <- mkGComp localUse
+        -- We're looking a fibrant Pi whose domain is a lock: No need to do anything.
+        LockUniv -> return $ Just $ \_ _ a0 -> a0
 
-        let transpFill la bA phi u0 i =
-              pure tTrans <#> lam "j" (\ j -> la <@> imin i j)
-                          <@> lam "j" (\ j -> bA <@> imin i j)
-                          <@> (imax phi (ineg i))
-                          <@> u0
-        [psi,u0] <- mapM (open . unArg) [psi,u0]
+        -- We're looking at an unmarked path type. Make sure that the
+        -- domain is actually the interval before continuing without an
+        -- adjustment, though!
+        IntervalUniv -> do
+          x' <- reduceB $ unDom x
+          mInterval <- getBuiltinName' builtinInterval
+          case unEl $ ignoreBlocking x' of
+            Def q [] | Just q == mInterval -> return $ Just $ \_ _ a0 -> a0
+            _ -> return Nothing
 
-        -- glue1 t a = glue la[i1/i] lb[i1/i] bA[i1/i] phi[i1/i] bT[i1/i] e[i1/i] t a
-        glue1 <- do
-          g <- open $ (tglue `apply`) . map ((setHiding Hidden) . (subst 0 io)) $ [la, lb, bA, phi, bT, e]
-          return $ \ t a -> g <@> t <@> a
+        _ -> return Nothing
 
-        [la, lb, bA, phi, bT, e] <- mapM (\ a -> open . runNames [] $ lam "i" (const (pure $ unArg a))) [la, lb, bA, phi, bT, e]
+    caseMaybe trFibrantDomain (return Nothing) $ \trA -> Just <$> do
+    [phi, u0] <- mapM (open . unArg) [ignoreBlocking (kanOpCofib cmd), kanOpBase cmd]
 
-        -- Andreas, 2022-03-24, fixing #5838
-        -- Following the updated note
-        --
-        --   Simon Huber, A Cubical Type Theory for Higher Inductive Types
-        --   https://simhu.github.io/misc/hcomp.pdf (February 2022)
-        --
-        -- See: https://github.com/agda/agda/issues/5755#issuecomment-1043797776
+    glam (getArgInfo (fst $ famThing ab)) (absName $ snd $ famThing ab) $ \u1 -> do
+      case (cmd, ab) of
 
-        -- unglue_u0 i = unglue la[i/i] lb[i/i] bA[i/i] phi[i/i] bT[i/i] e[i/i] u0
-        let unglue_u0 i =
-              foldl (<#>) (pure tunglue) (map (<@> i) [la, lb, bA, phi, bT, e]) <@> u0
+        -- hcomp u u0 x = hcomp (λ i o → u i o x) (u0 x). Short and sweet :)
+        (HCompOp _ u _, IsNot (a , b)) -> do
+          bT <- (raise 1 b `absApp`) <$> u1
+          u <- open (unArg u)
+          pure tHComp
+            <#> (Level <$> toLevel bT)
+            <#> pure (unEl bT)
+            <#> phi
+            <@> lam "i" (\ i -> ilam "o" $ \ o -> gApply (getHiding a) (u <@> i <..> o) u1)
+            <@> gApply (getHiding a) u0 u1
 
-        view <- intervalView'
+        -- transp (λ i → (a : A i) → B i x) φ f u1 =
+        --  transp (λ i → B i (transp (λ j → A (i ∨ ~ j)) (φ ∨ i) x)) φ
+        --    (f (transp (λ j → A (~ j) φ x)))
+        (TranspOp _ _, IsFam (a , b)) -> do
+          -- trA is a function of three arguments which builds the
+          -- transport fillers in the opposite direction, hence its
+          -- first argument is called "iOrNot" where it's relevant.
+          let
+            -- Γ , u1 : A[i1] , i : I
+            v i = trA (imax i . ineg) (imax phi i) u1
+            bB v = consS v (liftS 1 $ raiseS 1) `applySubst`
+              (absBody b {- Γ , i : I , x : A[i] -})
 
-        let
-          tf i o = transpFill lb (lam "i" $ \ i -> bT <@> i <..> o) psi u0 i
-          t1 o = tf (pure io) o
+            -- Compute B @0 v, in the right scope
+            tLam = Lam defaultArgInfo
 
-          -- compute "forall. phi"
-          forallphi = pure tForall <@> phi
+          -- We know how to substitute v into B, but it's open in a
+          -- variable, so we close over it here:
+          bT <- bind "i" $ \ x -> fmap bB . v $ x
 
-          -- a1 with gcomp
-          a1 = gcomp la bA
-                 (imax psi forallphi)
-                 (lam "i" $ \ i -> pure tPOr <#> (la <@> i)
-                                             <@> psi
-                                             <@> forallphi
-                                             <@> ilam "o" (\ a -> bA <@> i)
-                                             <@> ilam "o" (\ _ -> unglue_u0 i)
-                                             <@> ilam "o" (\ o -> pure tEFun <#> (lb <@> i)
-                                                                               <#> (la <@> i)
-                                                                               <#> (bT <@> i <..> o)
-                                                                               <#> (bA <@> i)
-                                                                               <@> (e <@> i <..> o)
-                                                                               <@> (tf i o)))
-                 (unglue_u0 (pure iz))
+          pure tTrans
+            <#> (tLam <$> traverse (fmap Level . toLevel) bT)
+            <@> (pure . tLam $ unEl <$> bT)
+            <@> phi
+            <@> gApply (getHiding a) u0 (v (pure iz))
 
-          max l l' = pure tLMax <@> l <@> l'
-          sigCon x y = pure (Con (sigmaCon kit) ConOSystem []) <@> x <@> y
-          w i o = pure tEFun <#> (lb <@> i)
-                             <#> (la <@> i)
-                             <#> (bT <@> i <..> o)
-                             <#> (bA <@> i)
-                             <@> (e <@> i <..> o)
-          fiber la lb bA bB f b =
-            (pure (Def (sigmaName kit) []) <#> la
-                                           <#> lb
-                                           <@> bA
-                                           <@> lam "a" (\ a -> pure tPath <#> lb <#> bB <@> (f <@> a) <@> b))
+        (_, _) -> __IMPOSSIBLE_VERBOSE__ "Invalid Kan operation in doPiKanOp"
 
-          -- We don't have to do anything special for "~ forall. phi"
-          -- here (to implement "ghcomp") as it is taken care off by
-          -- tEProof in t1'alpha below
-          pe o = -- o : [ φ 1 ]
-            pure tPOr <#> max (la <@> pure io) (lb <@> pure io)
-                      <@> psi
-                      <@> forallphi
-                      <@> ilam "o" (\ _ ->
-                             fiber (lb <@> pure io) (la <@> pure io)
-                                   (bT <@> (pure io) <..> o) (bA <@> pure io)
-                                   (w (pure io) o) a1)
-                      <@> ilam "o" (\ o -> sigCon u0 (lam "_" $ \ _ -> a1))
-                      <@> ilam "o" (\ o -> sigCon (t1 o) (lam "_" $ \ _ -> a1))
+-- | Compute Kan operations in a type of dependent paths.
+doPathPKanOp
+  :: KanOperation
+  -> FamilyOrNot (Arg Term)
+  -> FamilyOrNot (Arg Term, Arg Term, Arg Term)
+  -> ReduceM (Reduced MaybeReducedArgs Term)
+doPathPKanOp (HCompOp phi u u0) (IsNot l) (IsNot (bA,x,y)) = do
+  let getTermLocal = getTerm "primHComp for path types"
+  tHComp <- getTermLocal builtinHComp
 
-          -- "ghcomp" is implemented in the proof of tEProof
-          -- (see src/data/lib/prim/Agda/Builtin/Cubical/Glue.agda)
-          t1'alpha o = -- o : [ φ 1 ]
-             pure toutS
-              <#> (max (la <@> pure io) (lb <@> pure io))
-              <#> fiber (lb <@> pure io) (la <@> pure io)
-                        (bT <@> (pure io) <..> o) (bA <@> pure io)
-                        (w (pure io) o) a1
-              <#> imax psi forallphi
-              <#> pe o
-              <@> (pure tEProof <#> (lb <@> pure io)
-                                <#> (la <@> pure io)
-                                <@> (bT <@> pure io <..> o)
-                                <@> (bA <@> pure io)
-                                <@> (e <@> pure io <..> o)
-                                <@> a1
-                                <@> (imax psi forallphi)
-                                <@> pe o)
+  redReturn <=< runNamesT [] $ do
+    [l, u, u0, phi, bA, x, y] <- mapM (open . unArg) [l, u, u0, ignoreBlocking phi, bA, x, y]
 
-          -- TODO: optimize?
-          t1' o = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaFst kit)])
-          alpha o = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaSnd kit)])
-          a1' = pure tHComp
-                  <#> (la <@> pure io)
-                  <#> (bA <@> pure io)
-                  <#> (imax (phi <@> pure io) psi)
-                  <@> lam "j" (\ j ->
-                         pure tPOr <#> (la <@> pure io) <@> (phi <@> pure io) <@> psi <@> ilam "o" (\ _ -> bA <@> pure io)
-                                   <@> ilam "o" (\ o -> alpha o <@@> (w (pure io) o <@> t1' o,a1,j))
-                                   <@> ilam "o" (\ _ -> a1))
-                  <@> a1
-        -- glue1 (ilam "o" t1') a1'
-        a1'
-unglueTranspGlue _ _ _ = __IMPOSSIBLE__
+    -- hcomp in path spaces is simply hcomp in the underlying space, but
+    -- fixing the endpoints at (j ∨ ~ j) in the new direction to those
+    -- in the Path type.
+    lam "j" $ \ j ->
+      pure tHComp <#> l <#> (bA <@> j) <#> (phi `imax` (ineg j `imax` j))
+        <@> lam "i'" (\i -> combineSys l (lam "_" (const (bA <@> i)))
+          [ (phi,    ilam "o" (\ o -> u <@> i <..> o <@@> (x, y, j)))
+          , (j,      ilam "o" (const y))
+          , (ineg j, ilam "o" (const x)) ])
+        <@> (u0 <@@> (x, y, j))
 
-data TermPosition = Head | Eliminated deriving (Eq,Show)
+doPathPKanOp (TranspOp phi u0) (IsFam l) (IsFam (bA,x,y)) = do
+  -- Γ    ⊢ l
+  -- Γ, i ⊢ bA, x, y
+  let getTermLocal = getTerm "transport for path types"
+  iz <- getTermLocal builtinIZero
+  io <- getTermLocal builtinIOne
 
-headStop :: PureTCM m => TermPosition -> m Term -> m Bool
-headStop tpos phi
-  | Head <- tpos = do
-      phi <- intervalView =<< (reduce =<< phi)
-      return $ not $ isIOne phi
-  | otherwise = return False
+  -- Transport in path types becomes /CCHM/ composition in the
+  -- underlying line of spaces. The intuition is that not only do we
+  -- have to fix the endpoints (using composition) but also actually
+  -- transport. CCHM composition conveniently does that for us!
 
-compGlue :: PureTCM m =>
-                  TranspOrHComp
-                  -> Arg Term
-                  -> Maybe (Arg Term)
-                  -> Arg Term
-                  -> FamilyOrNot
-                       (Arg Term, Arg Term, Arg Term, Arg Term, Arg Term, Arg Term)
-                  -> TermPosition
-                  -> m (Maybe Term)
-compGlue DoHComp psi (Just u) u0 (IsNot (la, lb, bA, phi, bT, e)) tpos = do
-      let getTermLocal = getTerm $ (builtinHComp ++ " for " ++ builtinGlue)
-      tPOr <- getTermLocal "primPOr"
-      tIMax <- getTermLocal builtinIMax
-      tIMin <- getTermLocal builtinIMin
-      tINeg <- getTermLocal builtinINeg
-      tHComp <- getTermLocal builtinHComp
-      tEFun  <- getTermLocal builtinEquivFun
-      tglue   <- getTermLocal builtin_glue
-      tunglue <- getTermLocal builtin_unglue
-      io      <- getTermLocal builtinIOne
-      tItIsOne <- getTermLocal builtinItIsOne
-      view <- intervalView'
-      runNamesT [] $ do
-        [psi, u, u0] <- mapM (open . unArg) [psi, u, u0]
-        [la, lb, bA, phi, bT, e] <- mapM (open . unArg) [la, lb, bA, phi, bT, e]
-        ifM (headStop tpos phi) (return Nothing) $ Just <$> do
+  redReturn <=< runNamesT [] $ do
+    -- In reality to avoid a round-trip between primComp we use mkComp
+    -- here.
+    comp <- mkComp $ "transport for path types"
+    [l, u0, phi] <- traverse (open . unArg) [l, u0, ignoreBlocking phi]
+    [bA, x, y] <- mapM (\ a -> open . runNames [] $ lam "i" (const (pure $ unArg a))) [bA, x, y]
 
-        let
-          hfill la bA phi u u0 i = pure tHComp <#> la
-                                               <#> bA
-                                               <#> (pure tIMax <@> phi <@> (pure tINeg <@> i))
-                                               <@> lam "j" (\ j -> pure tPOr <#> la <@> phi <@> (pure tINeg <@> i) <@> ilam "o" (\ a -> bA)
-                                                     <@> ilam "o" (\ o -> u <@> (pure tIMin <@> i <@> j) <..> o)
-                                                     <@> ilam "o" (\ _ -> u0))
-                                               <@> u0
-          tf i o = hfill lb (bT <..> o) psi u u0 i
-          unglue g = pure tunglue <#> la <#> lb <#> bA <#> phi <#> bT <#> e <@> g
-          a1 = pure tHComp <#> la <#> bA <#> (pure tIMax <@> psi <@> phi)
-                           <@> lam "i" (\ i -> pure tPOr <#> la <@> psi <@> phi <@> ilam "_" (\ _ -> bA)
-                                 <@> ilam "o" (\ o -> unglue (u <@> i <..> o))
-                                 <@> ilam "o" (\ o -> pure tEFun <#> lb <#> la <#> (bT <..> o) <#> bA <@> (e <..> o) <@> tf i o))
-                           <@> (unglue u0)
-          t1 = tf (pure io)
-        -- pure tglue <#> la <#> lb <#> bA <#> phi <#> bT <#> e <@> (ilam "o" $ \ o -> t1 o) <@> a1
-        case tpos of
-          Head -> t1 (pure tItIsOne)
-          Eliminated -> a1
+    lam "j" $ \ j ->
+      comp l (lam "i" $ \ i -> bA <@> i <@> j) (phi `imax` (ineg j `imax` j))
+        (lam "i'" $ \i -> combineSys l (lam "_" (const (bA <@> i <@> j)))
+          [ (phi, ilam "o" (\o -> u0 <@@> (x <@> pure iz, y <@> pure iz, j)))
+          -- Note that here we have lines of endpoints which we must
+          -- apply to fix the endpoints:
+          , (j,      ilam "_" (const (y <@> i)))
+          , (ineg j, ilam "_" (const (x <@> i)))
+          ])
+        (u0 <@@> (x <@> pure iz, y <@> pure iz, j))
+doPathPKanOp a0 _ _ = __IMPOSSIBLE__
 
--- ...    |- psi, u0
--- ..., i |- la, lb, bA, phi, bT, e
-compGlue DoTransp psi Nothing u0 (IsFam (la, lb, bA, phi, bT, e)) tpos = do
-      let
-        localUse = builtinTrans ++ " for " ++ builtinGlue
-        getTermLocal = getTerm localUse
-      tPOr <- getTermLocal "primPOr"
-      tIMax <- getTermLocal builtinIMax
-      tIMin <- getTermLocal builtinIMin
-      tINeg <- getTermLocal builtinINeg
-      tHComp <- getTermLocal builtinHComp
-      tTrans <- getTermLocal builtinTrans
-      tForall  <- getTermLocal builtinFaceForall
-      tEFun  <- getTermLocal builtinEquivFun
-      tEProof <- getTermLocal builtinEquivProof
-      toutS   <- getTermLocal builtinSubOut
-      tglue   <- getTermLocal builtin_glue
-      tunglue <- getTermLocal builtin_unglue
-      io      <- getTermLocal builtinIOne
-      iz      <- getTermLocal builtinIZero
-      tLMax   <- getTermLocal builtinLevelMax
-      tPath   <- getTermLocal builtinPath
-      tTransp <- getTermLocal builtinTranspProof
-      tItIsOne <- getTermLocal builtinItIsOne
-      kit <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
-      runNamesT [] $ do
-        let ineg j = pure tINeg <@> j
-            imax i j = pure tIMax <@> i <@> j
-            imin i j = pure tIMin <@> i <@> j
-
-        gcomp <- mkGComp localUse
-
-        let transpFill la bA phi u0 i =
-              pure tTrans <#> lam "j" (\ j -> la <@> imin i j)
-                          <@> lam "j" (\ j -> bA <@> imin i j)
-                          <@> (imax phi (ineg i))
-                          <@> u0
-        [psi,u0] <- mapM (open . unArg) [psi,u0]
-
-        -- glue1 t a = glue la[i1/i] lb[i1/i] bA[i1/i] phi[i1/i] bT[i1/i] e[i1/i] t a
-        glue1 <- do
-          g <- open $ (tglue `apply`) . map ((setHiding Hidden) . (subst 0 io)) $ [la, lb, bA, phi, bT, e]
-          return $ \ t a -> g <@> t <@> a
-
-        [la, lb, bA, phi, bT, e] <- mapM (\ a -> open . runNames [] $ lam "i" (const (pure $ unArg a))) [la, lb, bA, phi, bT, e]
-
-        -- Andreas, 2022-03-24, fixing #5838
-        -- Following the updated note
-        --
-        --   Simon Huber, A Cubical Type Theory for Higher Inductive Types
-        --   https://simhu.github.io/misc/hcomp.pdf (February 2022)
-        --
-        -- See: https://github.com/agda/agda/issues/5755#issuecomment-1043797776
-
-        -- unglue_u0 i = unglue la[i/i] lb[i/i] bA[i/i] phi[i/i] bT[i/i] e[i/e] u0
-        let unglue_u0 i =
-              foldl (<#>) (pure tunglue) (map (<@> i) [la, lb, bA, phi, bT, e]) <@> u0
-
-        view <- intervalView'
-
-        ifM (headStop tpos (phi <@> pure io)) (return Nothing) $ Just <$> do
-        let
-          tf i o = transpFill lb (lam "i" $ \ i -> bT <@> i <..> o) psi u0 i
-          t1 o = tf (pure io) o
-
-          -- compute "forall. phi"
-          forallphi = pure tForall <@> phi
-
-          -- a1 with gcomp
-          a1 = gcomp la bA
-                 (imax psi forallphi)
-                 (lam "i" $ \ i -> pure tPOr <#> (la <@> i)
-                                             <@> psi
-                                             <@> forallphi
-                                             <@> ilam "o" (\ _ -> bA <@> i)
-                                             <@> ilam "o" (\ _ -> unglue_u0 i)
-                                             <@> ilam "o" (\ o -> pure tEFun <#> (lb <@> i)
-                                                                               <#> (la <@> i)
-                                                                               <#> (bT <@> i <..> o)
-                                                                               <#> (bA <@> i)
-                                                                               <@> (e <@> i <..> o)
-                                                                               <@> (tf i o)))
-                 (unglue_u0 (pure iz))
-
-          max l l' = pure tLMax <@> l <@> l'
-          sigCon x y = pure (Con (sigmaCon kit) ConOSystem []) <@> x <@> y
-          w i o = pure tEFun <#> (lb <@> i)
-                             <#> (la <@> i)
-                             <#> (bT <@> i <..> o)
-                             <#> (bA <@> i)
-                             <@> (e <@> i <..> o)
-          fiber la lb bA bB f b =
-            (pure (Def (sigmaName kit) []) <#> la
-                                           <#> lb
-                                           <@> bA
-                                           <@> lam "a" (\ a -> pure tPath <#> lb <#> bB <@> (f <@> a) <@> b))
-
-          -- We don't have to do anything special for "~ forall. phi"
-          -- here (to implement "ghcomp") as it is taken care off by
-          -- tEProof in t1'alpha below
-          pe o = -- o : [ φ 1 ]
-            pure tPOr <#> max (la <@> pure io) (lb <@> pure io)
-                      <@> psi
-                      <@> forallphi
-                      <@> ilam "o" (\ _ ->
-                             fiber (lb <@> pure io) (la <@> pure io)
-                                   (bT <@> (pure io) <..> o) (bA <@> pure io)
-                                   (w (pure io) o) a1)
-                      <@> ilam "o" (\ o -> sigCon u0 (lam "_" $ \ _ -> a1))
-                      <@> ilam "o" (\ o -> sigCon (t1 o) (lam "_" $ \ _ -> a1))
-
-          -- "ghcomp" is implemented in the proof of tEProof
-          -- (see src/data/lib/prim/Agda/Builtin/Cubical/Glue.agda)
-          t1'alpha o = -- o : [ φ 1 ]
-             pure toutS
-              <#> (max (la <@> pure io) (lb <@> pure io))
-              <#> fiber (lb <@> pure io) (la <@> pure io)
-                        (bT <@> (pure io) <..> o) (bA <@> pure io)
-                        (w (pure io) o) a1
-              <#> imax psi forallphi
-              <#> pe o
-              <@> (pure tEProof <#> (lb <@> pure io)
-                                <#> (la <@> pure io)
-                                <@> (bT <@> pure io <..> o)
-                                <@> (bA <@> pure io)
-                                <@> (e <@> pure io <..> o)
-                                <@> a1
-                                <@> (imax psi forallphi)
-                                <@> pe o)
-
-          -- TODO: optimize?
-          t1' o = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaFst kit)])
-          alpha o = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaSnd kit)])
-          a1' = pure tHComp
-                  <#> (la <@> pure io)
-                  <#> (bA <@> pure io)
-                  <#> (imax (phi <@> pure io) psi)
-                  <@> lam "j" (\ j ->
-                         pure tPOr <#> (la <@> pure io) <@> (phi <@> pure io) <@> psi <@> ilam "o" (\ _ -> bA <@> pure io)
-                                   <@> ilam "o" (\ o -> alpha o <@@> (w (pure io) o <@> t1' o,a1,j))
-                                   <@> ilam "o" (\ _ -> a1))
-                  <@> a1
-
-        -- glue1 (ilam "o" t1') a1'
-        case tpos of
-          Head -> t1' (pure tItIsOne)
-          Eliminated -> a1'
-compGlue cmd phi u u0 _ _ = __IMPOSSIBLE__
-
-compHCompU :: PureTCM m =>
-                    TranspOrHComp
-                    -> Arg Term
-                    -> Maybe (Arg Term)
-                    -> Arg Term
-                    -> FamilyOrNot (Arg Term, Arg Term, Arg Term, Arg Term)
-                    -> TermPosition
-                    -> m (Maybe Term)
-
-compHCompU DoHComp psi (Just u) u0 (IsNot (la, phi, bT, bA)) tpos = do
-      let getTermLocal = getTerm $ (builtinHComp ++ " for " ++ builtinHComp ++ " of Set")
-      io      <- getTermLocal builtinIOne
-      iz      <- getTermLocal builtinIZero
-      tPOr <- getTermLocal "primPOr"
-      tIMax <- getTermLocal builtinIMax
-      tIMin <- getTermLocal builtinIMin
-      tINeg <- getTermLocal builtinINeg
-      tHComp <- getTermLocal builtinHComp
-      tTransp  <- getTermLocal builtinTrans
-      tglue   <- getTermLocal builtin_glueU
-      tunglue <- getTermLocal builtin_unglueU
-      tLSuc   <- getTermLocal builtinLevelSuc
-      tSubIn <- getTermLocal builtinSubIn
-      tItIsOne <- getTermLocal builtinItIsOne
-      runNamesT [] $ do
-        [psi, u, u0] <- mapM (open . unArg) [psi, u, u0]
-        [la, phi, bT, bA] <- mapM (open . unArg) [la, phi, bT, bA]
-
-        ifM (headStop tpos phi) (return Nothing) $ Just <$> do
-
-        let
-          hfill la bA phi u u0 i = pure tHComp <#> la
-                                               <#> bA
-                                               <#> (pure tIMax <@> phi <@> (pure tINeg <@> i))
-                                               <@> lam "j" (\ j -> pure tPOr <#> la <@> phi <@> (pure tINeg <@> i) <@> ilam "o" (\ _ -> bA)
-                                                     <@> ilam "o" (\ o -> u <@> (pure tIMin <@> i <@> j) <..> o)
-                                                     <@> ilam "o" (\ _ -> u0))
-                                               <@> u0
-          transp la bA a0 = pure tTransp <#> lam "i" (const la) <@> lam "i" bA <@> pure iz <@> a0
-          tf i o = hfill la (bT <@> pure io <..> o) psi u u0 i
-          bAS = pure tSubIn <#> (pure tLSuc <@> la) <#> (Sort . tmSort <$> la) <#> phi <@> bA
-          unglue g = pure tunglue <#> la <#> phi <#> bT <#> bAS <@> g
-          a1 = pure tHComp <#> la <#> bA <#> (pure tIMax <@> psi <@> phi)
-                           <@> lam "i" (\ i -> pure tPOr <#> la <@> psi <@> phi <@> ilam "_" (\ _ -> bA)
-                                 <@> ilam "o" (\ o -> unglue (u <@> i <..> o))
-                                 <@> ilam "o" (\ o -> transp la (\ i -> bT <@> (pure tINeg <@> i) <..> o) (tf i o)))
-                           <@> unglue u0
-          t1 = tf (pure io)
-
-        -- pure tglue <#> la <#> phi <#> bT <#> bAS <@> (ilam "o" $ \ o -> t1 o) <@> a1
-        case tpos of
-          Eliminated -> a1
-          Head       -> t1 (pure tItIsOne)
-
-
-
-compHCompU DoTransp psi Nothing u0 (IsFam (la, phi, bT, bA)) tpos = do
-      let
-        localUse = builtinTrans ++ " for " ++ builtinHComp ++ " of Set"
-        getTermLocal = getTerm localUse
-      tPOr <- getTermLocal "primPOr"
-      tIMax <- getTermLocal builtinIMax
-      tIMin <- getTermLocal builtinIMin
-      tINeg <- getTermLocal builtinINeg
-      tHComp <- getTermLocal builtinHComp
-      tTrans <- getTermLocal builtinTrans
-      tTranspProof <- getTermLocal builtinTranspProof
-      tSubIn <- getTermLocal builtinSubIn
-      tForall  <- getTermLocal builtinFaceForall
-      io      <- getTermLocal builtinIOne
-      iz      <- getTermLocal builtinIZero
-      tLSuc   <- getTermLocal builtinLevelSuc
-      tPath   <- getTermLocal builtinPath
-      tItIsOne   <- getTermLocal builtinItIsOne
-      kit <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
-      runNamesT [] $ do
-        let ineg j = pure tINeg <@> j
-            imax i j = pure tIMax <@> i <@> j
-            imin i j = pure tIMin <@> i <@> j
-            transp la bA a0 = pure tTrans <#> lam "i" (const la) <@> lam "i" bA <@> pure iz <@> a0
-
-        gcomp <- mkGComp localUse
-
-        let transpFill la bA phi u0 i =
-              pure tTrans <#> ilam "j" (\ j -> la <@> imin i j)
-                          <@> ilam "j" (\ j -> bA <@> imin i j)
-                          <@> (imax phi (ineg i))
-                          <@> u0
-        [psi,u0] <- mapM (open . unArg) [psi,u0]
-        glue1 <- do
-          tglue   <- cl $ getTermLocal builtin_glueU
-          [la, phi, bT, bA] <- mapM (open . unArg . subst 0 io) $ [la, phi, bT, bA]
-          let bAS = pure tSubIn <#> (pure tLSuc <@> la) <#> (Sort . tmSort <$> la) <#> phi <@> bA
-          g <- (open =<<) $ pure tglue <#> la <#> phi <#> bT <#> bAS
-          return $ \ t a -> g <@> t <@> a
-
-        [la, phi, bT, bA] <- mapM (\ a -> open . runNames [] $ lam "i" (const (pure $ unArg a))) [la, phi, bT, bA]
-
-        -- Andreas, 2022-03-25, issue #5838.
-        -- Port the fix of @unglueTranspGlue@ and @compGlue DoTransp@
-        -- also to @compHCompU DoTransp@, as suggested by Tom Jack and Anders Mörtberg.
-        -- We define @unglue_u0 i@ that is first used with @i@ and then with @i0@.
-        -- The original code used it only with @i0@.
-        tunglue <- cl $ getTermLocal builtin_unglueU
-        let bAS i =
-              pure tSubIn  <#> (pure tLSuc <@> (la <@> i))
-                           <#> (Sort . tmSort <$> (la <@> i))
-                           <#> (phi <@> i)
-                           <@> (bA <@> i)
-        let unglue_u0 i =
-              pure tunglue <#> (la <@> i)
-                           <#> (phi <@> i)
-                           <#> (bT <@> i)
-                           <#> bAS i
-                           <@> u0
-
-        ifM (headStop tpos (phi <@> pure io)) (return Nothing) $ Just <$> do
-
-        let
-          lb = la
-          tf i o = transpFill lb (lam "i" $ \ i -> bT <@> i <@> pure io <..> o) psi u0 i
-          t1 o = tf (pure io) o
-
-          -- compute "forall. phi"
-          forallphi = pure tForall <@> phi
-
-          -- a1 with gcomp
-          a1 = gcomp la bA
-                 (imax psi forallphi)
-                 (lam "i" $ \ i -> pure tPOr <#> (la <@> i)
-                                             <@> psi
-                                             <@> forallphi
-                                             <@> ilam "o" (\ _ -> bA <@> i)
-                                             <@> ilam "o" (\ _ -> unglue_u0 i)
-                                             <@> ilam "o" (\ o -> transp (la <@> i)
-                                                                           (\ j -> bT <@> i <@> ineg j <..> o)
-                                                                           (tf i o)))
-                 (unglue_u0 (pure iz))
-
-          w i o = lam "x" $
-                  transp (la <@> i)
-                         (\ j -> bT <@> i <@> ineg j <..> o)
-
-          pt o = -- o : [ φ 1 ]
-            pure tPOr <#> (la <@> pure io)
-                      <@> psi
-                      <@> forallphi
-                      <@> ilam "o" (\ _ -> bT <@> pure io <@> pure io <..> o)
-                      <@> ilam "o" (\ o -> u0)
-                      <@> ilam "o" (\ o -> t1 o)
-
-          -- "ghcomp" is implemented in the proof of tTranspProof
-          -- (see src/data/lib/prim/Agda/Builtin/Cubical/HCompU.agda)
-          t1'alpha o = -- o : [ φ 1 ]
-             pure tTranspProof <#> (la <@> pure io)
-                               <@> lam "i" (\ i -> bT <@> pure io <@> ineg i <..> o)
-                               <@> imax psi forallphi
-                               <@> pt o
-                               <@> (pure tSubIn <#> (la <@> pure io) <#> (bA <@> pure io)
-                                                <#> imax psi forallphi
-                                                <@> a1)
-
-          -- TODO: optimize?
-          t1' o = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaFst kit)])
-          alpha o = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaSnd kit)])
-          a1' = pure tHComp
-                  <#> (la <@> pure io)
-                  <#> (bA <@> pure io)
-                  <#> (imax (phi <@> pure io) psi)
-                  <@> lam "j" (\ j ->
-                         pure tPOr <#> (la <@> pure io) <@> (phi <@> pure io) <@> psi <@> ilam "o" (\ _ -> bA <@> pure io)
-                                   <@> ilam "o" (\ o -> alpha o <@@> (w (pure io) o <@> t1' o,a1,j))
-                                   <@> ilam "o" (\ _ -> a1))
-                  <@> a1
-
-        -- glue1 (ilam "o" t1') a1'
-        case tpos of
-          Eliminated -> a1'
-          Head       -> t1' (pure tItIsOne)
-compHCompU _ psi _ u0 _ _ = __IMPOSSIBLE__
-
-
-primTransHComp :: TranspOrHComp -> [Arg Term] -> Int -> ReduceM (Reduced MaybeReducedArgs Term)
+primTransHComp :: Command -> [Arg Term] -> Int -> ReduceM (Reduced MaybeReducedArgs Term)
 primTransHComp cmd ts nelims = do
-  (l,bA,phi,u,u0) <- case (cmd,ts) of
-        (DoTransp, [l,bA,phi,  u0]) -> do
-          -- u <- runNamesT [] $ do
-          --       u0 <- open $ unArg u0
-          --       defaultArg <$> (ilam "o" $ \ _ -> u0)
-          return $ (IsFam l,IsFam bA,phi,Nothing,u0)
-        (DoHComp, [l,bA,phi,u,u0]) -> do
-          -- [l,bA] <- runNamesT [] $ do
-          --   forM [l,bA] $ \ a -> do
-          --     let info = argInfo a
-          --     a <- open $ unArg a
-          --     Arg info <$> (lam "i" $ \ _ -> a)
-          return $ (IsNot l,IsNot bA,phi,Just u,u0)
-        _                          -> __IMPOSSIBLE__
+  (l,bA,phi,u,u0) <- pure $ case (cmd,ts) of
+    (DoTransp, [l, bA, phi, u0]) -> (IsFam l, IsFam bA, phi, Nothing, u0)
+    (DoHComp, [l, bA, phi, u, u0]) -> (IsNot l, IsNot bA, phi, Just u, u0)
+    _ -> __IMPOSSIBLE__
   sphi <- reduceB' phi
   vphi <- intervalView $ unArg $ ignoreBlocking sphi
-  let clP s = getTerm (cmdToName cmd) s
+  let clP s = getTerm "primTransHComp" s
 
   -- WORK
   case vphi of
-     IOne -> redReturn =<< case u of
-                            -- cmd == DoComp
-                            Just u -> runNamesT [] $ do
-                                       u <- open (unArg u)
-                                       u <@> clP builtinIOne <..> clP builtinItIsOne
-                            -- cmd == DoTransp
-                            Nothing -> return $ unArg u0
-     _    -> do
-       let fallback' sc = do
-             u' <- case u of
-                            -- cmd == DoComp
-                     Just u ->
-                              (:[]) <$> case vphi of
-                                          IZero -> fmap (reduced . notBlocked . argN) . runNamesT [] $ do
-                                            [l,c] <- mapM (open . unArg) [famThing l, ignoreBlocking sc]
-                                            lam "i" $ \ i -> clP builtinIsOneEmpty <#> l
-                                                                   <#> ilam "o" (\ _ -> c)
-                                          _     -> return (notReduced u)
-                            -- cmd == DoTransp
-                     Nothing -> return []
-             return $ NoReduction $ [notReduced (famThing l), reduced sc, reduced sphi] ++ u' ++ [notReduced u0]
-       sbA <- reduceB' bA
-       t <- case unArg <$> ignoreBlocking sbA of
-              IsFam (Lam _info t) -> Just . fmap IsFam <$> reduceB' (absBody t)
-              IsFam _             -> return Nothing
-              IsNot t             -> return . Just . fmap IsNot $ (t <$ sbA)
-       case t of
-         Nothing -> fallback' (famThing <$> sbA)
-         Just st  -> do
-               let
-                   fallback = fallback' (fmap famThing $ st *> sbA)
-                   t = ignoreBlocking st
-               mHComp <- getPrimitiveName' builtinHComp
-               mGlue <- getPrimitiveName' builtinGlue
-               mId   <- getBuiltinName' builtinId
-               pathV <- pathView'
-               case famThing t of
-                 MetaV m _ -> fallback' (fmap famThing $ blocked_ m *> sbA)
-                 -- absName t instead of "i"
-                 Pi a b | nelims > 0  -> maybe fallback redReturn =<< compPi cmd "i" ((a,b) <$ t) (ignoreBlocking sphi) u u0
-                        | otherwise -> fallback
+    -- When φ = i1, we know what to do!
+    IOne -> redReturn =<< case cmd of
+      DoHComp -> runNamesT [] $ do
+        -- If we're composing, then we definitely had a partial element
+        -- to extend. But now it's just a total element, so we can
+        -- just.. return it:
+        u <- open $ unArg $ fromMaybe __IMPOSSIBLE__ u
+        u <@> clP builtinIOne <..> clP builtinItIsOne
+      DoTransp ->
+        -- Otherwise we're in the constant part of the line to transport
+        -- over, so we must return the argument unchanged.
+        pure $ unArg u0
 
-                 Sort (Type l) | DoTransp <- cmd -> compSort cmd fallback phi u u0 (l <$ t)
+    _ -> do
+    let
+      fallback' sc = do
+        -- Possibly optimise the partial element to reduce the size of
+        -- hcomps:
+        u' <- case cmd of
+          DoHComp -> (:[]) <$> case vphi of
+            -- If φ=i0 then tabulating equality for Partial φ A
+            -- guarantees that u = is constantly isOneEmpty,
+            -- regardless of how big the original term is, and
+            -- isOneEmpty is *tiny*, so let's use that:
+            IZero -> fmap (reduced . notBlocked . argN) . runNamesT [] $ do
+                [l,c] <- mapM (open . unArg) [famThing l, ignoreBlocking sc]
+                lam "i" $ \ i -> clP builtinIsOneEmpty <#> l <#> ilam "o" (\ _ -> c)
 
-                 Def q [Apply la, Apply lb, Apply bA, Apply phi', Apply bT, Apply e] | Just q == mGlue -> do
-                   maybe fallback redReturn =<< compGlue cmd phi u u0 ((la, lb, bA, phi', bT, e) <$ t) Head
+            -- Otherwise we have some interesting formula (though
+            -- definitely not IOne!) and we have to keep the partial
+            -- element as-is.
+            _ -> pure $ notReduced $ fromMaybe __IMPOSSIBLE__ u
+          DoTransp -> return []
 
-                 Def q [Apply _, Apply s, Apply phi', Apply bT, Apply bA]
-                   | Just q == mHComp, Sort (Type la) <- unArg s  -> do
-                   maybe fallback redReturn =<< compHCompU cmd phi u u0 ((Level la <$ s, phi', bT, bA) <$ t) Head
+        pure . NoReduction $ [notReduced (famThing l), reduced sc, reduced sphi] ++ u' ++ [notReduced u0]
 
-                 -- Path/PathP
-                 d | PathType _ _ _ bA x y <- pathV (El __DUMMY_SORT__ d) -> do
-                   if nelims > 0 then compPathP cmd sphi u u0 l ((bA, x, y) <$ t) else fallback
+    -- Reduce the type whose Kan operations we're composing over:
+    sbA <- reduceB' bA
+    t <- case unArg <$> ignoreBlocking sbA of
+      IsFam (Lam _ t) -> Just . fmap IsFam <$> reduceB' (absBody t)
+      IsFam _         -> pure Nothing
+      IsNot t         -> pure . Just . fmap IsNot $ (t <$ sbA)
 
-                 Def q [Apply _ , Apply bA , Apply x , Apply y] | Just q == mId -> do
-                   maybe fallback return =<< compId cmd sphi u u0 l ((bA, x, y) <$ t)
+    case t of
+      -- If we don't have a grasp of the Kan operations then at least we
+      -- can reuse the work we did for reducing the type later.
+      Nothing -> fallback' (famThing <$> sbA)
+      Just st  -> do
+        -- Similarly, if we're stuck for another reason, we can reuse
+        -- the work for reducing the family.
+        let
+          fallback = fallback' (fmap famThing $ st *> sbA)
+          t = ignoreBlocking st
+          operation = case cmd of
+            DoTransp -> TranspOp { kanOpCofib = sphi, kanOpBase = u0 }
+            DoHComp -> HCompOp
+              { kanOpCofib = sphi, kanOpSides = fromMaybe __IMPOSSIBLE__ u, kanOpBase = u0 }
 
-                 Def q es -> do
-                   info <- getConstInfo q
-                   let   lam_i = Lam defaultArgInfo . Abs "i"
+        mHComp <- getPrimitiveName' builtinHComp
+        mGlue <- getPrimitiveName' builtinGlue
+        mId   <- getBuiltinName' builtinId
+        pathV <- pathView'
 
-                   case theDef info of
-                     r@Record{recComp = kit} | nelims > 0, Just as <- allApplyElims es, DoTransp <- cmd, Just transpR <- nameOfTransp kit
-                                -> if recPars r == 0
-                                   then redReturn $ unArg u0
-                                   else redReturn $ (Def transpR []) `apply`
-                                               (map (fmap lam_i) as ++ [ignoreBlocking sphi,u0])
-                         | nelims > 0, Just as <- allApplyElims es, DoHComp <- cmd, Just hCompR <- nameOfHComp kit
-                                -> redReturn $ (Def hCompR []) `apply`
-                                               (as ++ [ignoreBlocking sphi,fromMaybe __IMPOSSIBLE__ u,u0])
+        -- By cases on the family, determine what Kan operation we defer
+        -- to:
+        case famThing t of
+          -- Metavariables are stuck
+          MetaV m _ -> fallback' (fmap famThing $ blocked_ m *> sbA)
 
-                         | Just as <- allApplyElims es, [] <- recFields r -> compData Nothing False (recPars r) cmd l (as <$ t) sbA sphi u u0
-                     Datatype{dataPars = pars, dataIxs = ixs, dataPathCons = pcons, dataTransp = mtrD}
-                       | and [null pcons && ixs == 0 | DoHComp  <- [cmd]], Just as <- allApplyElims es ->
-                         compData mtrD ((not $ null $ pcons) || ixs > 0) (pars+ixs) cmd l (as <$ t) sbA sphi u u0
-                     Axiom constTransp | constTransp, [] <- es, DoTransp <- cmd -> redReturn $ unArg u0
-                     _          -> fallback
+          -- TODO: absName t instead of "i"
+          Pi a b
+            -- For Π types, we prefer to keep the Kan operations around,
+            -- so only actually reduce if we applied them to a nonzero
+            -- positive of eliminations
+            | nelims > 0 -> maybe fallback redReturn =<< doPiKanOp operation "i" ((a, b) <$ t)
+            | otherwise -> fallback
 
-                 _ -> fallback
+          -- For Type, we have two possibilities:
+          Sort (Type l)
+            -- transp (λ i → Type _) φ is always the identity function.
+            | DoTransp <- cmd -> redReturn $ unArg u0
+            -- hcomp {Type} is actually a normal form! This is the
+            -- "HCompU" optimisation; We do not use Glue for hcomp in
+            -- the universe.
+            | DoHComp <- cmd -> fallback
+
+          -- Glue types have their own implementation of Kan operations
+          -- which are implemented in a different module:
+          Def q [Apply la, Apply lb, Apply bA, Apply phi', Apply bT, Apply e] | Just q == mGlue -> do
+            maybe fallback redReturn =<< doGlueKanOp
+              operation ((la, lb, bA, phi', bT, e) <$ t) Head
+
+          -- Formal homogeneous compositions in the universe: Our family
+          -- is @hcomp {A = Type l}@, so we defer to the implementation
+          -- of Kan operations for HCompU implemented above.
+          Def q [Apply _, Apply s, Apply phi', Apply bT, Apply bA]
+            | Just q == mHComp, Sort (Type la) <- unArg s  -> do
+            maybe fallback redReturn =<< doHCompUKanOp
+              operation ((Level la <$ s, phi', bT, bA) <$ t) Head
+
+          -- PathP types have the same optimisation as for Pi types:
+          -- Only compute the Kan operation if there's >0 eliminations.
+          d | PathType _ _ _ bA x y <- pathV (El __DUMMY_SORT__ d) -> do
+            if nelims > 0 then doPathPKanOp operation l ((bA, x, y) <$ t) else fallback
+
+          -- Identity types:
+          Def q [Apply _ , Apply bA , Apply x , Apply y] | Just q == mId -> do
+            maybe fallback return =<< doIdKanOp operation l ((bA, x, y) <$ t)
+
+          Def q es -> do
+            info <- getConstInfo q
+            let   lam_i = Lam defaultArgInfo . Abs "i"
+
+            -- Record and data types have their own implementations of
+            -- the Kan operations, which get generated as part of their
+            -- definition.
+            case theDef info of
+              r@Record{recComp = kit}
+                | nelims > 0, Just as <- allApplyElims es, DoTransp <- cmd, Just transpR <- nameOfTransp kit ->
+                  -- Optimisation: If the record has no parameters then we can ditch the transport.
+                  if recPars r == 0
+                     then redReturn $ unArg u0
+                     else redReturn $ Def transpR [] `apply` (map (fmap lam_i) as ++ [ignoreBlocking sphi, u0])
+
+                -- Records know how to hcomp themselves:
+                | nelims > 0, Just as <- allApplyElims es, DoHComp <- cmd, Just hCompR <- nameOfHComp kit ->
+                  redReturn $ Def hCompR [] `apply` (as ++ [ignoreBlocking sphi, fromMaybe __IMPOSSIBLE__ u,u0])
+
+                -- If this is a record with no fields, then compData
+                -- will know what to do with it:
+                | Just as <- allApplyElims es, [] <- recFields r -> compData Nothing False (recPars r) cmd l (as <$ t) sbA sphi u u0
+
+              -- For data types, if this data type is indexed and/or a
+              -- higher inductive type, then hcomp is normal; But
+              -- compData knows what to do for the general cases.
+              Datatype{dataPars = pars, dataIxs = ixs, dataPathCons = pcons, dataTransp = mtrD}
+                | and [null pcons && ixs == 0 | DoHComp  <- [cmd]], Just as <- allApplyElims es ->
+                  compData mtrD ((not $ null $ pcons) || ixs > 0) (pars+ixs) cmd l (as <$ t) sbA sphi u u0
+
+              -- Is this an axiom with constrant transport? Then. Well. Transport is constant.
+              Axiom constTransp | constTransp, [] <- es, DoTransp <- cmd -> redReturn $ unArg u0
+
+              _          -> fallback
+
+          _ -> fallback
   where
-    compSort DoTransp fallback phi Nothing u0 (IsFam l) = do
-      -- TODO should check l is constant
-      redReturn $ unArg u0
-    -- compSort DoHComp fallback phi (Just u) u0 (IsNot l) = -- hcomp for Set is a whnf, handled above.
-    compSort _ fallback phi u u0 _ = __IMPOSSIBLE__
-    compPi :: TranspOrHComp -> ArgName -> FamilyOrNot (Dom Type, Abs Type) -- Γ , i : I
-            -> Arg Term -- Γ
-            -> Maybe (Arg Term) -- Γ
-            -> Arg Term -- Γ
-            -> ReduceM (Maybe Term)
-    compPi cmd t ab phi u u0 = do
-     let getTermLocal = getTerm $ cmdToName cmd ++ " for function types"
-
-     tTrans <- getTermLocal builtinTrans
-     tHComp <- getTermLocal builtinHComp
-     tINeg <- getTermLocal builtinINeg
-     tIMax <- getTermLocal builtinIMax
-     iz    <- getTermLocal builtinIZero
-     let
-      toLevel' t = do
-        s <- reduce $ getSort t
-        case s of
-          (Type l) -> return (Just l)
-          _        -> return Nothing
-      toLevel t = fromMaybe __IMPOSSIBLE__ <$> toLevel' t
-     -- make sure the codomain has a level.
-     caseMaybeM (toLevel' . absBody . snd . famThing $ ab) (return Nothing) $ \ _ -> do
-     runNamesT [] $ do
-      labA <- do
-        let (x,f) = case ab of
-              IsFam (a,_) -> (a, \ a -> runNames [] $ lam "i" (const (pure a)))
-              IsNot (a,_) -> (a, id)
-        s <- reduce $ getSort x
-        case s of
-          Type lx -> do
-            [la,bA] <- mapM (open . f) [Level lx, unEl . unDom $ x]
-            pure $ Just $ \ iOrNot phi a0 -> pure tTrans <#> lam "j" (\ j -> la <@> iOrNot j)
-                                                         <@> lam "j" (\ j -> bA <@> iOrNot j)
-                                                         <@> phi
-                                                         <@> a0
-          LockUniv -> return $ Just $ \ _ _ a0 -> a0
-          IntervalUniv -> do
-            x' <- reduceB $ unDom x
-            mInterval <- getBuiltinName' builtinInterval
-            case unEl $ ignoreBlocking x' of
-              Def q [] | Just q == mInterval -> return $ Just $ \ _ _ a0 -> a0
-              _ -> return Nothing
-          _ -> return Nothing
-
-      caseMaybe labA (return Nothing) $ \ trA -> Just <$> do
-      [phi, u0] <- mapM (open . unArg) [phi, u0]
-      u <- traverse open (unArg <$> u)
-
-      glam (getArgInfo (fst $ famThing ab)) (absName $ snd $ famThing ab) $ \ u1 -> do
-        case (cmd, ab, u) of
-          (DoHComp, IsNot (a , b), Just u) -> do
-            bT <- (raise 1 b `absApp`) <$> u1
-            let v = u1
-            pure tHComp <#> (Level <$> toLevel bT)
-                        <#> pure (unEl                      $ bT)
-                        <#> phi
-                        <@> lam "i" (\ i -> ilam "o" $ \ o -> gApply (getHiding a) (u <@> i <..> o) v)
-                        <@> (gApply (getHiding a) u0 v)
-          (DoTransp, IsFam (a , b), Nothing) -> do
-            let v i = do
-                       let
-                         iOrNot j = pure tIMax <@> i <@> (pure tINeg <@> j)
-                       trA iOrNot (pure tIMax <@> phi <@> i)
-                                  u1
-                -- Γ , u1 : A[i1] , i : I
-                bB v = consS v (liftS 1 $ raiseS 1) `applySubst` (absBody b {- Γ , i : I , x : A[i] -})
-                tLam = Lam defaultArgInfo
-            bT <- bind "i" $ \ x -> fmap bB . v $ x
-            -- Γ , u1 : A[i1]
-            (pure tTrans <#> (tLam <$> traverse (fmap Level . toLevel) bT)
-                         <@> (pure . tLam $ unEl                      <$> bT)
-                         <@> phi
-                         <@> gApply (getHiding a) u0 (v (pure iz)))
-          (_,_,_) -> __IMPOSSIBLE__
-    compPathP cmd@DoHComp sphi (Just u) u0 (IsNot l) (IsNot (bA,x,y)) = do
-      let getTermLocal = getTerm $ cmdToName cmd ++ " for path types"
-      tHComp <- getTermLocal builtinHComp
-      tINeg <- getTermLocal builtinINeg
-      tIMax <- getTermLocal builtinIMax
-      tOr   <- getTermLocal "primPOr"
-      let
-        ineg j = pure tINeg <@> j
-        imax i j = pure tIMax <@> i <@> j
-
-      redReturn . runNames [] $ do
-         [l,u,u0] <- mapM (open . unArg) [l,u,u0]
-         phi      <- open . unArg . ignoreBlocking $ sphi
-         [bA, x, y] <- mapM (open . unArg) [bA, x, y]
-         lam "j" $ \ j ->
-           pure tHComp <#> l
-                       <#> (bA <@> j)
-                       <#> (phi `imax` (ineg j `imax` j))
-                       <@> lam "i'" (\ i ->
-                            let or f1 f2 = pure tOr <#> l <@> f1 <@> f2 <#> lam "_" (\ _ -> bA <@> i)
-                            in or phi (ineg j `imax` j)
-                                          <@> ilam "o" (\ o -> u <@> i <..> o <@@> (x, y, j)) -- a0 <@@> (x <@> i, y <@> i, j)
-                                          <@> (or (ineg j) j <@> ilam "_" (const x)
-                                                                  <@> ilam "_" (const y)))
-                       <@> (u0 <@@> (x, y, j))
-    compPathP cmd@DoTransp sphi Nothing u0 (IsFam l) (IsFam (bA,x,y)) = do
-      -- Γ    ⊢ l
-      -- Γ, i ⊢ bA, x, y
-      let getTermLocal = getTerm $ cmdToName cmd ++ " for path types"
-      tINeg <- getTermLocal builtinINeg
-      tIMax <- getTermLocal builtinIMax
-      tOr   <- getTermLocal "primPOr"
-      iz <- getTermLocal builtinIZero
-      io <- getTermLocal builtinIOne
-      let
-        ineg j = pure tINeg <@> j
-        imax i j = pure tIMax <@> i <@> j
-      comp <- do
-        tHComp <- getTermLocal builtinHComp
-        tTrans <- getTermLocal builtinTrans
-        let forward la bA r u = pure tTrans <#> lam "i" (\ i -> la <@> (i `imax` r))
-                                            <@> lam "i" (\ i -> bA <@> (i `imax` r))
-                                            <@> r
-                                            <@> u
-        return $ \ la bA phi u u0 ->
-          pure tHComp <#> (la <@> pure io)
-                      <#> (bA <@> pure io)
-                      <#> phi
-                      <@> lam "i" (\ i -> ilam "o" $ \ o ->
-                              forward la bA i (u <@> i <..> o))
-                      <@> forward la bA (pure iz) u0
-      redReturn . runNames [] $ do
-        [l,u0] <- mapM (open . unArg) [l,u0]
-        phi      <- open . unArg . ignoreBlocking $ sphi
-        [bA, x, y] <- mapM (\ a -> open . runNames [] $ lam "i" (const (pure $ unArg a))) [bA, x, y]
-        lam "j" $ \ j ->
-          comp l (lam "i" $ \ i -> bA <@> i <@> j) (phi `imax` (ineg j `imax` j))
-                      (lam "i'" $ \ i ->
-                            let or f1 f2 = pure tOr <#> l <@> f1 <@> f2 <#> lam "_" (\ _ -> bA <@> i <@> j) in
-                                       or phi (ineg j `imax` j)
-                                          <@> ilam "o" (\ o -> u0 <@@> (x <@> pure iz, y <@> pure iz, j))
-                                          <@> (or (ineg j) j <@> ilam "_" (const (x <@> i))
-                                                                  <@> ilam "_" (const (y <@> i))))
-                      (u0 <@@> (x <@> pure iz, y <@> pure iz, j))
-    compPathP _ sphi u a0 _ _ = __IMPOSSIBLE__
-    compId cmd sphi u a0 l bA_x_y = do
-      let getTermLocal = getTerm $ cmdToName cmd ++ " for " ++ builtinId
-      unview <- intervalUnview'
-      mConId <- getName' builtinConId
-      cview <- conidView'
-      let isConId t = isJust $ cview __DUMMY_TERM__ t
-      sa0 <- reduceB' a0
-      -- wasteful to compute b even when cheaper checks might fail
-      b <- case u of
-             Nothing -> return True
-             Just u  -> allComponents unview (unArg . ignoreBlocking $ sphi) (unArg u) isConId
-      case mConId of
-        Just conid | isConId (unArg . ignoreBlocking $ sa0) , b -> (Just <$>) . (redReturn =<<) $ do
-          tHComp <- getTermLocal builtinHComp
-          tTrans <- getTermLocal builtinTrans
-          tIMin <- getTermLocal "primDepIMin"
-          tFace <- getTermLocal "primIdFace"
-          tPath <- getTermLocal "primIdPath"
-          tPathType <- getTermLocal builtinPath
-          tConId <- getTermLocal builtinConId
-          runNamesT [] $ do
-            let io = pure $ unview IOne
-                iz = pure $ unview IZero
-                conId = pure $ tConId
-            l <- case l of
-                   IsFam l -> open . unArg $ l
-                   IsNot l -> do
-                     open (Lam defaultArgInfo $ NoAbs "_" $ unArg l)
-            [p0] <- mapM (open . unArg) [a0]
-            p <- case u of
-                   Just u -> do
-                     u <- open . unArg $ u
-                     return $ \ i o -> u <@> i <..> o
-                   Nothing -> do
-                     return $ \ i o -> p0
-            phi      <- open . unArg . ignoreBlocking $ sphi
-            [bA, x, y] <-
-              case bA_x_y of
-                IsFam (bA,x,y) -> mapM (\ a -> open . runNames [] $ lam "i" (const (pure $ unArg a))) [bA, x, y]
-                IsNot (bA,x,y) -> forM [bA,x,y] $ \ a -> open (Lam defaultArgInfo $ NoAbs "_" $ unArg a)
-            let
-              eval DoTransp l bA phi _ u0 = pure tTrans <#> l <@> bA <@> phi <@> u0
-              eval DoHComp l bA phi u u0 = pure tHComp <#> (l <@> io) <#> (bA <@> io) <#> phi
-                                                       <@> u <@> u0
-            conId <#> (l <@> io) <#> (bA <@> io) <#> (x <@> io) <#> (y <@> io)
-                  <@> (pure tIMin <@> phi
-                                  <@> ilam "o" (\ o -> pure tFace <#> (l <@> io) <#> (bA <@> io) <#> (x <@> io) <#> (y <@> io)
-                                                                   <@> (p io o)))
-                  <@> (eval cmd l
-                                (lam "i" $ \ i -> pure tPathType <#> (l <@> i) <#> (bA <@> i) <@> (x <@> i) <@> (y <@> i))
-                                phi
-                                (lam "i" $ \ i -> ilam "o" $ \ o -> pure tPath <#> (l <@> i) <#> (bA <@> i)
-                                                                                    <#> (x <@> i) <#> (y <@> i)
-                                                                                    <@> (p i o)
-                                      )
-                                (pure tPath <#> (l <@> iz) <#> (bA <@> iz) <#> (x <@> iz) <#> (y <@> iz)
-                                                  <@> p0)
-                      )
-        _ -> return $ Nothing
-    allComponents unview phi u p = do
-            let
-              boolToI b = if b then unview IOne else unview IZero
-            as <- decomposeInterval phi
-            andM . for as $ \ (bs,ts) -> do
-                 let u' = listS (IntMap.toAscList $ IntMap.map boolToI bs) `applySubst` u
-                 t <- reduce2Lam u'
-                 return $! p $ ignoreBlocking t
-    reduce2Lam t = do
-          t <- reduce' t
-          case lam2Abs Relevant t of
-            t -> underAbstraction_ t $ \ t -> do
-               t <- reduce' t
-               case lam2Abs Irrelevant t of
-                 t -> underAbstraction_ t reduceB'
-         where
-           lam2Abs rel (Lam _ t) = absBody t <$ t
-           lam2Abs rel t         = Abs "y" (raise 1 t `apply` [setRelevance rel $ argN $ var 0])
     allComponentsBack unview phi u p = do
             let
               boolToI b = if b then unview IOne else unview IZero
@@ -1343,7 +544,7 @@ primTransHComp cmd ts nelims = do
                  return $ (p $ ignoreBlocking t, listToMaybe [ (weaken `applySubst` (lamlam <$> t),bs) | null ts ])
             return $ (flags,t_alphas)
     compData mtrD False _ cmd@DoHComp (IsNot l) (IsNot ps) fsc sphi (Just u) a0 = do
-      let getTermLocal = getTerm $ cmdToName cmd ++ " for data types"
+      let getTermLocal = getTerm $ "builtinHComp for data types"
 
       let sc = famThing <$> fsc
       tEmpty <- getTermLocal builtinIsOneEmpty
@@ -1429,7 +630,7 @@ primTransHComp cmd ts nelims = do
       redReturn $ Def trD [] `apply` (map (fmap lam_i) ps ++ map argN [phi,unArg a0])
 
     compData mtrD isHIT _ cmd@DoTransp (IsFam l) (IsFam ps) fsc sphi Nothing a0 = do
-      let getTermLocal = getTerm $ cmdToName cmd ++ " for data types"
+      let getTermLocal = getTerm $ builtinTrans ++ " for data types"
       let sc = famThing <$> fsc
       mhcompName <- getName' builtinHComp
       constrForm <- do
@@ -1480,7 +681,8 @@ primTransHComp cmd ts nelims = do
 
 --    compData _ _ _ _ _ _ _ _ _ _ = __IMPOSSIBLE__
 
-
+-- | CCHM 'primComp' is implemented in terms of 'hcomp' and 'transport'.
+-- The definition of it comes from 'mkComp'.
 primComp :: TCM PrimitiveImpl
 primComp = do
   requireCubical CErased ""
@@ -1498,213 +700,16 @@ primComp = do
         sphi <- reduceB' phi
         vphi <- intervalView $ unArg $ ignoreBlocking sphi
         case vphi of
+          -- Though we short-circuit evaluation for the rule
+          --    comp A i1 (λ _ .1=1 → u) u ==> u
+          -- rather than going through the motions of hcomp and transp.
           IOne -> redReturn (unArg u `apply` [argN io, argN one])
           _    -> do
-            let getTermLocal = getTerm $ builtinComp
-            tIMax <- getTermLocal builtinIMax
-            tINeg <- getTermLocal builtinINeg
-            tHComp <- getTermLocal builtinHComp
-            tTrans <- getTermLocal builtinTrans
-            iz      <- getTermLocal builtinIZero
             redReturn <=< runNamesT [] $ do
-              comp <- do
-                let imax i j = pure tIMax <@> i <@> j
-                    forward la bA r u = pure tTrans <#> (lam "i" $ \ i -> la <@> (i `imax` r))
-                                                    <@> (lam "i" $ \ i -> bA <@> (i `imax` r))
-                                                    <@> r
-                                                    <@> u
-                return $ \ la bA phi u u0 ->
-                  pure tHComp <#> (la <@> pure io) <#> (bA <@> pure io) <#> phi
-                              <@> lam "i" (\ i -> ilam "o" $ \ o ->
-                                      forward la bA i (u <@> i <..> o))
-                              <@> forward la bA (pure iz) u0
-
+              comp <- mkComp builtinComp
               [l,c,phi,u,a0] <- mapM (open . unArg) [l,c,phi,u,a0]
               comp l c phi u a0
 
-      _ -> __IMPOSSIBLE__
-
-
-prim_glueU' :: TCM PrimitiveImpl
-prim_glueU' = do
-  requireCubical CErased ""
-  t <- runNamesT [] $
-       hPi' "la" (el $ cl primLevel) (\ la ->
-       hPi' "φ" primIntervalType $ \ φ ->
-       hPi' "T" (nPi' "i" primIntervalType $ \ _ -> pPi' "o" φ $ \ o -> sort . tmSort <$> la) $ \ t ->
-       hPi' "A" (el's (cl primLevelSuc <@> la) $ cl primSub <#> (cl primLevelSuc <@> la) <@> (Sort . tmSort <$> la) <@> φ <@> (t <@> primIZero)) $ \ a -> do
-       let bA = (cl primSubOut <#> (cl primLevelSuc <@> la) <#> (Sort . tmSort <$> la) <#> φ <#> (t <@> primIZero) <@> a)
-       pPi' "o" φ (\ o -> el' la (t <@> cl primIOne <..> o))
-         --> (el' la bA)
-         --> el' la (cl primHComp <#> (cl primLevelSuc <@> la) <#> (Sort . tmSort <$> la) <#> φ <@> t <@> bA))
-  view <- intervalView'
-  one <- primItIsOne
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 6 $ \ts ->
-    case ts of
-      [la,phi,bT,bA,t,a] -> do
-       sphi <- reduceB' phi
-       case view $ unArg $ ignoreBlocking $ sphi of
-         IOne -> redReturn $ unArg t `apply` [argN one]
-         _    -> return (NoReduction $ map notReduced [la] ++ [reduced sphi] ++ map notReduced [bT,bA,t,a])
-      _ -> __IMPOSSIBLE__
-
-prim_unglueU' :: TCM PrimitiveImpl
-prim_unglueU' = do
-  requireCubical CErased ""
-  t <- runNamesT [] $
-       hPi' "la" (el $ cl primLevel) (\ la ->
-       hPi' "φ" primIntervalType $ \ φ ->
-       hPi' "T" (nPi' "i" primIntervalType $ \ _ -> pPi' "o" φ $ \ o -> sort . tmSort <$> la) $ \ t ->
-       hPi' "A" (el's (cl primLevelSuc <@> la) $ cl primSub <#> (cl primLevelSuc <@> la) <@> (Sort . tmSort <$> la) <@> φ <@> (t <@> primIZero)) $ \ a -> do
-       let bA = (cl primSubOut <#> (cl primLevelSuc <@> la) <#> (Sort . tmSort <$> la) <#> φ <#> (t <@> primIZero) <@> a)
-       el' la (cl primHComp <#> (cl primLevelSuc <@> la) <#> (Sort . tmSort <$> la) <#> φ <@> t <@> bA)
-         --> el' la bA)
-  view <- intervalView'
-  one <- primItIsOne
-  mglueU <- getPrimitiveName' builtin_glueU
-  mtransp <- getPrimitiveName' builtinTrans
-  mHCompU <- getPrimitiveName' builtinHComp
-  let mhcomp = mHCompU
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 5 $ \ts ->
-    case ts of
-      [la,phi,bT,bA,b] -> do
-       sphi <- reduceB' phi
-       case view $ unArg $ ignoreBlocking $ sphi of
-         IOne -> do
-           tTransp <- getTerm builtin_unglueU builtinTrans
-           iNeg    <- getTerm builtin_unglueU builtinINeg
-           iZ      <- getTerm builtin_unglueU builtinIZero
-           redReturn <=< runNamesT [] $ do
-             [la,bT,b] <- mapM (open . unArg) [la,bT,b]
-             pure tTransp <#> lam "i" (\ _ -> la)
-                          <@> lam "i" (\ i -> bT <@> (pure iNeg <@> i) <..> pure one)
-                          <@> pure iZ
-                          <@> b
-         _    -> do
-            sb <- reduceB' b
-            let fallback sbA = return (NoReduction $ map notReduced [la] ++ [reduced sphi] ++ map notReduced [bT,bA] ++ [reduced sb])
-            case unArg $ ignoreBlocking $ sb of
-               Def q [Apply _,Apply _,Apply _,Apply _,Apply _,Apply a]
-                     | Just q == mglueU -> redReturn $ unArg a
-               Def q [Apply l,Apply bA,Apply r,Apply u0]
-                     | Just q == mtransp -> do
-                     sbA <- reduceB bA
-                     case unArg $ ignoreBlocking sbA of
-                       Lam _ t -> do
-                         st <- reduceB' (absBody t)
-                         case ignoreBlocking st of
-                           Def h es | Just [la,_,phi,bT,bA] <- allApplyElims es, Just h == mHCompU -> do
-                             redReturn . fromMaybe __IMPOSSIBLE__ =<< compHCompU DoTransp r Nothing u0 (IsFam (la,phi,bT,bA)) Eliminated
-                           _ -> fallback (st *> sbA)
-                       _  -> fallback sbA
-               Def q [Apply l,Apply bA,Apply r,Apply u,Apply u0]
-                     | Just q == mhcomp -> do
-                     sbA <- reduceB bA
-                     case unArg $ ignoreBlocking sbA of
-                       Def h es | Just [la,_,phi,bT,bA] <- allApplyElims es, Just h == mHCompU -> do
-                         redReturn . fromMaybe __IMPOSSIBLE__ =<< compHCompU DoHComp r (Just u) u0 (IsNot (la,phi,bT,bA)) Eliminated
-                       _ -> fallback sbA
-               _ -> return (NoReduction $ map notReduced [la] ++ [reduced sphi] ++ map notReduced [bT,bA] ++ [reduced sb])
-      _ -> __IMPOSSIBLE__
-
-
-primGlue' :: TCM PrimitiveImpl
-primGlue' = do
-  requireCubical CFull ""
-  -- Glue' : ∀ {l} (A : Set l) → ∀ φ → (T : Partial (Set a) φ) (f : (PartialP φ \ o → (T o) -> A))
-  --            ([f] : PartialP φ \ o → isEquiv (T o) A (f o)) → Set l
-  t <- runNamesT [] $
-       hPi' "la" (el $ cl primLevel) (\ la ->
-       hPi' "lb" (el $ cl primLevel) $ \ lb ->
-       nPi' "A" (sort . tmSort <$> la) $ \ a ->
-       hPi' "φ" primIntervalType $ \ φ ->
-       nPi' "T" (pPi' "o" φ $ \ o -> el' (cl primLevelSuc <@> lb) (Sort . tmSort <$> lb)) $ \ t ->
-       pPi' "o" φ (\ o -> el' (cl primLevelMax <@> la <@> lb) $ cl primEquiv <#> lb <#> la <@> (t <@> o) <@> a)
-       --> (sort . tmSort <$> lb))
-  view <- intervalView'
-  one <- primItIsOne
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 6 $ \ts ->
-    case ts of
-     [la,lb,a,phi,t,e] -> do
-       sphi <- reduceB' phi
-       case view $ unArg $ ignoreBlocking $ sphi of
-         IOne -> redReturn $ unArg t `apply` [argN one]
-         _    -> return (NoReduction $ map notReduced [la,lb,a] ++ [reduced sphi] ++ map notReduced [t,e])
-     _ -> __IMPOSSIBLE__
-
-prim_glue' :: TCM PrimitiveImpl
-prim_glue' = do
-  requireCubical CFull ""
-  t <- runNamesT [] $
-       hPi' "la" (el $ cl primLevel) (\ la ->
-       hPi' "lb" (el $ cl primLevel) $ \ lb ->
-       hPi' "A" (sort . tmSort <$> la) $ \ a ->
-       hPi' "φ" primIntervalType $ \ φ ->
-       hPi' "T" (pPi' "o" φ $ \ o ->  el' (cl primLevelSuc <@> lb) (Sort . tmSort <$> lb)) $ \ t ->
-       hPi' "e" (pPi' "o" φ $ \ o -> el' (cl primLevelMax <@> la <@> lb) $ cl primEquiv <#> lb <#> la <@> (t <@> o) <@> a) $ \ e ->
-       pPi' "o" φ (\ o -> el' lb (t <@> o)) --> (el' la a --> el' lb (cl primGlue <#> la <#> lb <@> a <#> φ <@> t <@> e)))
-  view <- intervalView'
-  one <- primItIsOne
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 8 $ \ts ->
-    case ts of
-      [la,lb,bA,phi,bT,e,t,a] -> do
-       sphi <- reduceB' phi
-       case view $ unArg $ ignoreBlocking $ sphi of
-         IOne -> redReturn $ unArg t `apply` [argN one]
-         _    -> return (NoReduction $ map notReduced [la,lb,bA] ++ [reduced sphi] ++ map notReduced [bT,e,t,a])
-      _ -> __IMPOSSIBLE__
-
-prim_unglue' :: TCM PrimitiveImpl
-prim_unglue' = do
-  requireCubical CFull ""
-  t <- runNamesT [] $
-       hPi' "la" (el $ cl primLevel) (\ la ->
-       hPi' "lb" (el $ cl primLevel) $ \ lb ->
-       hPi' "A" (sort . tmSort <$> la) $ \ a ->
-       hPi' "φ" primIntervalType $ \ φ ->
-       hPi' "T" (pPi' "o" φ $ \ o ->  el' (cl primLevelSuc <@> lb) (Sort . tmSort <$> lb)) $ \ t ->
-       hPi' "e" (pPi' "o" φ $ \ o -> el' (cl primLevelMax <@> la <@> lb) $ cl primEquiv <#> lb <#> la <@> (t <@> o) <@> a) $ \ e ->
-       (el' lb (cl primGlue <#> la <#> lb <@> a <#> φ <@> t <@> e)) --> el' la a)
-  view <- intervalView'
-  one <- primItIsOne
-  mGlue <- getPrimitiveName' builtinGlue
-  mglue <- getPrimitiveName' builtin_glue
-  mtransp <- getPrimitiveName' builtinTrans
-  mhcomp <- getPrimitiveName' builtinHComp
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 7 $ \ts ->
-    case ts of
-      [la,lb,bA,phi,bT,e,b] -> do
-       sphi <- reduceB' phi
-       case view $ unArg $ ignoreBlocking $ sphi of
-         IOne -> do
-           let argOne = setRelevance Irrelevant $ argN one
-           tEFun <- getTerm builtin_unglue builtinEquivFun
-           redReturn $ tEFun `apply` [lb,la,argH $ unArg bT `apply` [argOne],bA, argN $ unArg e `apply` [argOne],b]
-         _    -> do
-            sb <- reduceB' b
-            let fallback sbA = return (NoReduction $ map notReduced [la,lb] ++ map reduced [sbA, sphi] ++ map notReduced [bT,e] ++ [reduced sb])
-            case unArg $ ignoreBlocking $ sb of
-               Def q [Apply _,Apply _,Apply _,Apply _,Apply _,Apply _,Apply _,Apply a]
-                     | Just q == mglue -> redReturn $ unArg a
-               Def q [Apply l,Apply bA,Apply r,Apply u0]
-                     | Just q == mtransp -> do
-                 sbA <- reduceB' bA
-                 case unArg $ ignoreBlocking sbA of
-                   Lam _ t -> do
-                     st <- reduceB' (absBody t)
-                     case ignoreBlocking st of
-                       Def g es | Just [la',lb',bA',phi',bT',e'] <- allApplyElims es, Just g == mGlue -> do
-                           redReturn . fromMaybe __IMPOSSIBLE__ =<< compGlue DoTransp r Nothing u0 (IsFam (la',lb',bA',phi',bT',e')) Eliminated
-                       _ -> fallback (st *> sbA)
-                   _ -> fallback sbA
-               Def q [Apply l,Apply bA,Apply r,Apply u,Apply u0]
-                     | Just q == mhcomp -> do
-                 sbA <- reduceB' bA
-                 case unArg $ ignoreBlocking sbA of
-                   Def g es | Just [la',lb',bA',phi',bT',e'] <- allApplyElims es, Just g == mGlue -> do
-                       redReturn . fromMaybe __IMPOSSIBLE__ =<< compGlue DoHComp r (Just u) u0 (IsNot (la',lb',bA',phi',bT',e')) Eliminated
-                   _ -> fallback sbA
-               _ -> return (NoReduction $ map notReduced [la,lb,bA] ++ [reduced sphi] ++ map notReduced [bT,e] ++ [reduced sb])
       _ -> __IMPOSSIBLE__
 
 
@@ -1713,7 +718,7 @@ primFaceForall' :: TCM PrimitiveImpl
 primFaceForall' = do
   requireCubical CErased ""
   t <- (primIntervalType --> primIntervalType) --> primIntervalType
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 1 $ \ts -> case ts of
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 1 $ \case
     [phi] -> do
       sphi <- reduceB' phi
       case unArg $ ignoreBlocking $ sphi of
@@ -1732,59 +737,39 @@ primFaceForall' = do
       unview <- intervalUnview'
       us' <- decomposeInterval t
       fr <- getTerm builtinFaceForall builtinFaceForall
-      let v = view t
-          us =
-            [ map Left (IntMap.toList bsm) ++ map Right ts
-              | (bsm, ts) <- us',
-                0 `IntMap.notMember` bsm
-            ]
-          fm (i, b) = if b then var (i - 1) else unview (INeg (argN (var $ i - 1)))
-          ffr t = fr `apply` [argN $ Lam defaultArgInfo $ Abs "i" t]
-          r =
-            Just $
-              foldr
-                ( (\x r -> unview (IMax (argN x) (argN r)))
-                    . foldr
-                      (\x r -> unview (IMin (argN (either fm ffr x)) (argN r)))
-                      (unview IOne)
-                )
-                (unview IZero)
-                us
+      let
+        v = view t
+        -- We decomposed the interval expression, without regard for
+        -- inconsistent mappings, and now we keep only those which are
+        -- stuck (the ts) and those which do not mention the 0th variable.
+        us :: [[Either (Int, Bool) Term]]
+        us = [ map Left (IntMap.toList bsm) ++ map Right ts
+             | (bsm, ts) <- us', 0 `IntMap.notMember` bsm
+             ]
+
+        -- Turn a face mapping back into an interval expression:
+        fm (i, b) = if b then var (i - 1) else unview (INeg (argN (var $ i - 1)))
+        -- Apply ∀ to any indecomposable expressions we have encountered
+        ffr t = fr `apply` [argN $ Lam defaultArgInfo $ Abs "i" t]
+
+        -- Unfold one step of the foldr to avoid generation of the last
+        -- ∧ i1. Marginal savings at best but it's cleaner.
+        conjuncts :: [Either (Int, Bool) Term] -> Term
+        conjuncts [] = unview IOne
+        conjuncts [x] = either fm ffr x
+        conjuncts (x:xs) =
+          foldr (\x r -> unview (IMin (argN (either fm ffr x)) (argN r)))
+            (either fm ffr x)
+            xs
+
+        disjuncts = foldr
+          (\conj rest -> unview (IMax (argN (conjuncts conj)) (argN rest)))
+          (unview IZero)
+          us
       --   traceSLn "cube.forall" 20 (unlines [show v, show us', show us, show r]) $
       return $ case us' of
         [(m, [_])] | null m -> Nothing
-        v -> r
-
-decomposeInterval :: HasBuiltins m => Term -> m [(IntMap Bool, [Term])]
-decomposeInterval t = do
-  decomposeInterval' t <&> \ xs ->
-    [ (bm, ts)
-    | (bsm :: IntMap BoolSet, ts) <- xs
-    , bm <- maybeToList $ traverse BoolSet.toSingleton bsm
-        -- discard inconsistent mappings
-    ]
-
-decomposeInterval' :: HasBuiltins m => Term -> m [(IntMap BoolSet, [Term])]
-decomposeInterval' t = do
-     view   <- intervalView'
-     unview <- intervalUnview'
-     let f :: IntervalView -> [[Either (Int,Bool) Term]]
-         -- TODO handle primIMinDep
-         -- TODO? handle forall
-         f IZero = mzero
-         f IOne  = return []
-         f (IMin x y) = do xs <- (f . view . unArg) x; ys <- (f . view . unArg) y; return (xs ++ ys)
-         f (IMax x y) = msum $ map (f . view . unArg) [x,y]
-         f (INeg x)   = map (either (\ (x,y) -> Left (x,not y)) (Right . unview . INeg . argN)) <$> (f . view . unArg) x
-         f (OTerm (Var i [])) = return [Left (i,True)]
-         f (OTerm t)          = return [Right t]
-         v = view t
-     return [ (bsm,ts)
-            | xs <- f v
-            , let (bs,ts) = partitionEithers xs
-            , let bsm     = IntMap.fromListWith BoolSet.union $ map (second BoolSet.singleton) bs
-            ]
-
+        _ -> Just disjuncts
 
 -- | Tries to @primTransp@ a whole telescope of arguments, following the rule for Σ types.
 --   If a type in the telescope does not support transp, @transpTel@ throws it as an exception.
@@ -2042,30 +1027,6 @@ pathTelescope' tel lhs rhs = do
       Type l -> pure l
       s      -> throwError =<< buildClosure t
 
-combineSys :: HasBuiltins m => NamesT m Term -> NamesT m Term -> [(NamesT m Term, NamesT m Term)] -> NamesT m Term
-combineSys l ty xs = snd <$> combineSys' l ty xs
-
-combineSys' :: HasBuiltins m => NamesT m Term -> NamesT m Term -> [(NamesT m Term, NamesT m Term)] -> NamesT m (Term,Term)
-combineSys' l ty xs = do
-    tPOr <- fromMaybe __IMPOSSIBLE__ <$> getTerm' builtinPOr
-    tMax <- fromMaybe __IMPOSSIBLE__ <$> getTerm' builtinIMax
-    iz <- fromMaybe __IMPOSSIBLE__ <$> getTerm' builtinIZero
-    tEmpty <- fromMaybe __IMPOSSIBLE__ <$> getTerm' builtinIsOneEmpty
-
-    let
-      max i j = pure tMax <@> i <@> j
-      pOr l ty phi psi u0 u1 = do
-          pure tPOr <#> l
-                    <@> phi <@> psi
-                    <#> (ilam "o" $ \ _ -> ty) <@> u0 <@> u1
-
-      -- TODO: optimize the foldr away?
-      combine [] = pure tEmpty <#> l <#> (ilam "o" $ \ _ -> ty)
-      combine [(psi,u)] = u
-      combine ((psi,u):xs) = pOr l ty psi (foldr max (pure iz) (map fst xs)) u (combine xs)
-    (,) <$> foldr max (pure iz) (map fst xs) <*> combine xs
-
-
 data TranspError = CannotTransp {errorType :: (Closure (Abs Type)) }
 
 instance Exception TranspError
@@ -2243,11 +1204,12 @@ instance Subst CType where
   applySubst rho (ClosedType s q) = ClosedType (applySubst rho s) q
   applySubst rho (LType t) = LType $ applySubst rho t
 
-hcomp :: (HasBuiltins m, MonadError TCErr m, MonadReduce m) =>
-               NamesT m Type
-               -> [(NamesT m Term, NamesT m Term)]
-               -> NamesT m Term
-               -> NamesT m Term
+hcomp
+  :: (HasBuiltins m, MonadError TCErr m, MonadReduce m)
+  => NamesT m Type
+  -> [(NamesT m Term, NamesT m Term)]
+  -> NamesT m Term
+  -> NamesT m Term
 hcomp ty sys u0 = do
   iz <- primIZero
   tHComp <- primHComp

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 -- | Implementations of the basic primitives of Cubical Agda: The
 -- interval and its operations.
 module Agda.TypeChecking.Primitive.Cubical.Base

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
@@ -365,7 +365,7 @@ hfill
 hfill la bA phi u u0 i = do
   tHComp <- getTerm "hfill" builtinHComp
   pure tHComp <#> la <#> bA <#> (imax phi (ineg i))
-    <@> lam "j" (\ j -> combineSys la (ilam "o" (const bA))
+    <@> lam "j" (\ j -> combineSys la bA
         [ (phi,    ilam "o" (\o -> u <@> (imin i j) <..> o))
         , (ineg i, ilam "o" (\_ -> u0))
         ])

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
@@ -1,0 +1,424 @@
+{-# LANGUAGE LambdaCase #-}
+-- | Implementations of the basic primitives of Cubical Agda: The
+-- interval and its operations.
+module Agda.TypeChecking.Primitive.Cubical.Base
+  ( requireCubical
+  , primIntervalType
+  , primIMin', primIMax', primDepIMin', primINeg'
+  , imax, imin, ineg
+
+  , Command(..), KanOperation(..), kanOpName, TermPosition(..), headStop
+  , FamilyOrNot(..), familyOrNot
+
+    -- * Helper functions for building terms
+  , combineSys, combineSys'
+  , fiber, hfill
+  , decomposeInterval', decomposeInterval
+  , reduce2Lam
+  )
+  where
+
+import Control.Arrow (second)
+import Control.Monad.Except
+
+import qualified Data.IntMap as IntMap
+import Data.IntMap (IntMap)
+import Data.String (IsString (fromString))
+import Data.Either (partitionEithers)
+import Data.Maybe (fromMaybe, maybeToList)
+
+import qualified Agda.Utils.BoolSet as BoolSet
+import Agda.Utils.Impossible (__IMPOSSIBLE__)
+import Agda.Utils.BoolSet (BoolSet)
+import Agda.Utils.Functor
+
+import Agda.TypeChecking.Monad.Signature (HasConstInfo)
+import Agda.TypeChecking.Monad.Debug (__IMPOSSIBLE_VERBOSE__)
+import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Context
+import Agda.TypeChecking.Monad.Pure
+import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Env
+
+import Agda.TypeChecking.Substitute.Class (absBody, raise, apply)
+
+import Agda.TypeChecking.Reduce (Reduce(..), reduceB', reduce', reduce)
+import Agda.TypeChecking.Names (NamesT, runNamesT, ilam, lam)
+
+import Agda.Interaction.Options.Base (optCubical)
+
+import Agda.Syntax.Common
+  (Cubical(..), Arg(..), Relevance(..), setRelevance, defaultArgInfo, hasQuantity0)
+
+import Agda.TypeChecking.Primitive.Base
+  (SigmaKit(..), (-->), nPi', pPi', (<@>), (<#>), (<..>), argN, getSigmaKit)
+
+import Agda.Syntax.Internal
+
+
+-- | Checks that the correct variant of Cubical Agda is activated.
+-- Note that @--erased-cubical@ \"counts as\" @--cubical@ in erased
+-- contexts.
+requireCubical
+  :: Cubical -- ^ Which variant of Cubical Agda is required?
+  -> String  -- ^ Why, exactly, do we need Cubical to be enabled?
+  -> TCM ()
+requireCubical wanted s = do
+  cubical         <- optCubical <$> pragmaOptions
+  inErasedContext <- hasQuantity0 <$> getEnv
+  case cubical of
+    Just CFull -> return ()
+    Just CErased | wanted == CErased || inErasedContext -> return ()
+    _ -> typeError $ GenericError $ "Missing option " ++ opt ++ s
+  where
+  opt = case wanted of
+    CFull   -> "--cubical"
+    CErased -> "--cubical or --erased-cubical"
+
+-- | Our good friend the interval type.
+primIntervalType :: (HasBuiltins m, MonadError TCErr m, MonadTCEnv m, ReadTCState m) => m Type
+primIntervalType = El intervalSort <$> primInterval
+
+-- | Negation on the interval. Negation satisfies De Morgan's laws, and
+-- their implementation is handled here.
+primINeg' :: TCM PrimitiveImpl
+primINeg' = do
+  requireCubical CErased ""
+  t <- primIntervalType --> primIntervalType
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 1 $ \case
+    [x] -> do
+      unview <- intervalUnview'
+      view <- intervalView'
+      sx <- reduceB' x
+      ix <- intervalView (unArg $ ignoreBlocking sx)
+
+      -- Apply De Morgan's laws.
+      let
+        ineg :: Arg Term -> Arg Term
+        ineg = fmap (unview . f . view)
+
+        f ix = case ix of
+          IZero    -> IOne
+          IOne     -> IZero
+          IMin x y -> IMax (ineg x) (ineg y)
+          IMax x y -> IMin (ineg x) (ineg y)
+          INeg x   -> OTerm (unArg x)
+          OTerm t  -> INeg (Arg defaultArgInfo t)
+
+      -- We force the argument in case it happens to be an interval
+      -- expression, but it's quite possible that it's _not_. In those
+      -- cases, negation is stuck.
+      case ix of
+        OTerm t -> return $ NoReduction [reduced sx]
+        _       -> redReturn (unview $ f ix)
+    _ -> __IMPOSSIBLE_VERBOSE__ "implementation of primINeg called with wrong arity"
+
+-- | 'primDepIMin' expresses that cofibrations are closed under @Σ@.
+-- Thus, it serves as a dependent version of 'primIMin' (which, recall,
+-- implements @_∧_@). This is required for the construction of the Kan
+-- operations in @Id@.
+primDepIMin' :: TCM PrimitiveImpl
+primDepIMin' = do
+  requireCubical CErased ""
+  t <- runNamesT [] $
+       nPi' "φ" primIntervalType $ \ φ ->
+       pPi' "o" φ (\ o -> primIntervalType) --> primIntervalType
+  -- Note that the type here is @(φ : I) → (.(IsOne φ) → I) → I@, since
+  -- @Partial φ I@ is not well-sorted.
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 2 $ \case
+    [x,y] -> do
+      sx <- reduceB' x
+      ix <- intervalView (unArg $ ignoreBlocking sx)
+      itisone <- getTerm "primDepIMin" builtinItIsOne
+      case ix of
+        -- Σ 0 iy is 0, and additionally P is def.eq. to isOneEmpty.
+        IZero -> redReturn =<< intervalUnview IZero
+        -- Σ 1 iy is (iy 1=1).
+        IOne  -> redReturn =<< (pure (unArg y) <@> pure itisone)
+        _     -> do
+          -- Hack: We cross our fingers and really hope that eventually
+          -- ix may turn out to be i1. Regardless we evaluate iy 1=1, to
+          -- short-circuit evaluate a couple of cases:
+          sy <- reduceB' y
+          iy <- intervalView =<< reduce' =<< (pure (unArg $ ignoreBlocking sy) <@> pure itisone)
+          case iy of
+            -- Σ _ (λ _ → 0) is always 0
+            IZero -> redReturn =<< intervalUnview IZero
+            -- Σ ix (λ _ → 1) only depends on ix
+            IOne  -> redReturn (unArg $ ignoreBlocking sx)
+            -- Otherwise we're well and truly blocked.
+            _     -> return $ NoReduction [reduced sx, reduced sy]
+    _ -> __IMPOSSIBLE_VERBOSE__ "implementation of primDepIMin called with wrong arity"
+
+-- | Internal helper for constructing binary operations on the interval,
+-- parameterised by their unit and absorbing elements.
+primIBin :: IntervalView -> IntervalView -> TCM PrimitiveImpl
+primIBin unit absorber = do
+  requireCubical CErased ""
+  t <- primIntervalType --> primIntervalType --> primIntervalType
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 2 $ \case
+    [x,y] -> do
+      -- Evaluation here is short-circuiting: If the LHS is either the
+      -- absorbing or unit element, then the RHS does not matter.
+      sx <- reduceB' x
+      ix <- intervalView (unArg $ ignoreBlocking sx)
+      case ix of
+        ix | ix ==% absorber -> redReturn =<< intervalUnview absorber
+        ix | ix ==% unit     -> return $ YesReduction YesSimplification (unArg y)
+        _ -> do
+          -- And in the case where the LHS is stuck, we can make
+          -- progress by comparing the LHS to the absorbing/unit
+          -- elements.
+          sy <- reduceB' y
+          iy <- intervalView (unArg $ ignoreBlocking sy)
+          case iy of
+            iy | iy ==% absorber -> redReturn =<< intervalUnview absorber
+            iy | iy ==% unit     -> return $ YesReduction YesSimplification (unArg x)
+            _                    -> return $ NoReduction [reduced sx,reduced sy]
+    _ -> __IMPOSSIBLE_VERBOSE__ "binary operation on the interval called with incorrect arity"
+  where
+    (==%) IZero IZero = True
+    (==%) IOne IOne = True
+    (==%) _ _ = False
+{-# INLINE primIBin #-}
+
+-- | Implements both the @min@ connection /and/ conjunction on the
+-- cofibration classifier.
+primIMin' :: TCM PrimitiveImpl
+primIMin' = do
+  requireCubical CErased ""
+  primIBin IOne IZero
+
+-- | Implements both the @max@ connection /and/ disjunction on the
+-- cofibration classifier.
+primIMax' :: TCM PrimitiveImpl
+primIMax' = do
+  requireCubical CErased ""
+  primIBin IZero IOne
+
+-- | A helper for evaluating @max@ on the interval in TCM&co.
+imax :: HasBuiltins m => m Term -> m Term -> m Term
+imax x y = do
+  x' <- x
+  y' <- y
+  intervalUnview (IMax (argN x') (argN y'))
+
+-- | A helper for evaluating @min@ on the interval in TCM&co.
+imin :: HasBuiltins m => m Term -> m Term -> m Term
+imin x y = do
+  x' <- x
+  y' <- y
+  intervalUnview (IMin (argN x') (argN y'))
+
+-- | A helper for evaluating @neg@ on the interval in TCM&co.
+ineg :: HasBuiltins m => m Term -> m Term
+ineg x = do
+  x' <- x
+  intervalUnview (INeg (argN x'))
+
+data Command = DoTransp | DoHComp
+  deriving (Eq, Show)
+
+-- | The built-in name associated with a particular Kan operation.
+kanOpName :: KanOperation -> String
+kanOpName TranspOp{} = builtinTrans
+kanOpName HCompOp{}  = builtinHComp
+
+-- | Our Kan operations are @transp@ and @hcomp@. The KanOperation
+-- record stores the data associated with a Kan operation on arbitrary
+-- types: A cofibration and an element of that type.
+data KanOperation
+  -- | A transport problem consists of a cofibration, marking where the
+  -- transport is constant, and a term to move from the fibre over i0 to
+  -- the fibre over i1.
+  = TranspOp
+    { kanOpCofib :: Blocked (Arg Term)
+      -- ^ When this cofibration holds, the transport must
+      -- definitionally be the identity. This is handled generically by
+      -- 'primTransHComp' but specific Kan operations may still need it.
+    , kanOpBase :: Arg Term
+      -- ^ This is the term in @A i0@ which we are transporting.
+    }
+  -- | A composition problem consists of a partial element and a base.
+  -- Semantically, this is justified by the types being Kan fibrations,
+  -- i.e., having the lifting property against trivial cofibrations.
+  -- While the specified cofibration may not be trivial, (φ ∨ ~ r) for r
+  -- ∉ φ is *always* a trivial cofibration.
+  | HCompOp
+    { kanOpCofib :: Blocked (Arg Term)
+      -- ^ Extent of definition of the partial element we are lifting
+      -- against.
+    , kanOpSides :: Arg Term
+      -- ^ The partial element itself
+    , kanOpBase  :: Arg Term
+      -- ^ The base.
+    }
+
+-- | Are we looking at a family of things, or at a single thing?
+data FamilyOrNot a
+  = IsFam { famThing :: a }
+  | IsNot { famThing :: a }
+  deriving (Eq,Show,Functor,Foldable,Traversable)
+
+familyOrNot :: IsString p => FamilyOrNot a -> p
+familyOrNot (IsFam x) = "IsFam"
+familyOrNot (IsNot x) = "IsNot"
+
+instance Reduce a => Reduce (FamilyOrNot a) where
+  reduceB' x = traverse id <$> traverse reduceB' x
+  reduce' x = traverse reduce' x
+
+-- | For the Kan operations in @Glue@ and @hcomp {Type}@, we optimise
+-- evaluation a tiny bit by differentiating the term produced when
+-- evaluating a Kan operation by itself vs evaluating it under @unglue@.
+data TermPosition
+  = Head
+  | Eliminated
+  deriving (Eq,Show)
+
+-- | If we're computing a Kan operation for one of the "unstable" type
+-- formers (@Glue@, @hcomp {Type}@), this tells us whether the type will
+-- reduce further, and whether we should care.
+--
+-- When should we care? When we're in the 'Head' 'TermPosition'. When
+-- will the type reduce further? When @φ@, its formula, is not i1.
+headStop :: PureTCM m => TermPosition -> m Term -> m Bool
+headStop tpos phi
+  | Head <- tpos = do
+    phi <- intervalView =<< (reduce =<< phi)
+    return $ not $ isIOne phi
+  | otherwise = return False
+
+-- | Build a partial element. The type of the resulting partial element
+-- can depend on the computed extent, which we denote by @φ@ here. Note
+-- that @φ@ is the n-ary disjunction of all the @ψ@s.
+combineSys
+  :: HasBuiltins m
+  => NamesT m Term -- The level @l : Level@
+  -> NamesT m Term -- The type @A : Partial φ (Type l)@.
+  -> [(NamesT m Term, NamesT m Term)]
+  -- ^ A list of @(ψ, PartialP ψ λ o → A (... o ...))@ mappings. Note
+  -- that by definitional proof-irrelevance of @IsOne@, the actual
+  -- injection can not matter here.
+  -> NamesT m Term
+combineSys l ty xs = snd <$> combineSys' l ty xs
+
+-- | Build a partial element, and compute its extent. See 'combineSys'
+-- for the details.
+combineSys'
+  :: forall m. HasBuiltins m
+  => NamesT m Term -- The level @l@
+  -> NamesT m Term -- The type @A@
+  -> [(NamesT m Term, NamesT m Term)]
+  -> NamesT m (Term,Term)
+combineSys' l ty xs = do
+  tPOr <- fromMaybe __IMPOSSIBLE__ <$> getTerm' builtinPOr
+  tMax <- fromMaybe __IMPOSSIBLE__ <$> getTerm' builtinIMax
+  iz <- fromMaybe __IMPOSSIBLE__ <$> getTerm' builtinIZero
+  tEmpty <- fromMaybe __IMPOSSIBLE__ <$> getTerm' builtinIsOneEmpty
+
+  let
+    pOr l ty phi psi u0 u1 = pure tPOr
+      <#> l <@> phi <@> psi <#> (ilam "o" $ \ _ -> ty)
+      <@> u0 <@> u1
+
+    -- In one pass, compute the disjunction of all the cofibrations and
+    -- compute the primPOr expression.
+    combine :: [(NamesT m Term, NamesT m Term)] -> NamesT m (Term, Term)
+    combine [] = (iz,) <$> (pure tEmpty <#> l <#> (ilam "o" $ \ _ -> ty))
+    combine [(psi, u)] = (,) <$> psi <*> u
+    combine ((psi, u):xs) = do
+      (phi, c) <- combine xs
+      (,) <$> imax psi (pure phi) <*> pOr l ty psi (pure phi) u (pure c)
+  combine xs
+
+-- | Helper function for constructing the type of fibres of a function
+-- over a given point.
+fiber
+  :: (HasBuiltins m, HasConstInfo m)
+  => NamesT m Term -- @la : Level@
+  -> NamesT m Term -- @lb : Level@
+  -> NamesT m Term -- @A : Type la@
+  -> NamesT m Term -- @B : Type lb@
+  -> NamesT m Term -- @f : A → B@
+  -> NamesT m Term -- @x : B@
+  -> NamesT m Term -- @Σ[ x ∈ A ] (f a ≡ x)@
+fiber la lb bA bB f b = do
+  tPath <- getTerm "fiber" builtinPath
+  kit <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
+  pure (Def (sigmaName kit) [])
+    <#> la <#> lb
+    <@> bA
+    <@> lam "a" (\ a -> pure tPath <#> lb <#> bB <@> (f <@> a) <@> b)
+
+-- | Helper function for constructing the filler of a given composition
+-- problem.
+hfill
+  :: (HasBuiltins m, HasConstInfo m)
+  => NamesT m Term -- @la : Level@
+  -> NamesT m Term -- @A : Type la@
+  -> NamesT m Term -- @φ : I@. Cofibration
+  -> NamesT m Term -- @u : Partial φ A@.
+  -> NamesT m Term -- @u0 : A@. Must agree with @u@ on @φ@
+  -> NamesT m Term -- @i : I@. Position along the cube.
+  -> NamesT m Term
+hfill la bA phi u u0 i = do
+  tHComp <- getTerm "hfill" builtinHComp
+  pure tHComp <#> la <#> bA <#> (imax phi (ineg i))
+    <@> lam "j" (\ j -> combineSys la (ilam "o" (const bA))
+        [ (phi,    ilam "o" (\o -> u <@> (imin i j) <..> o))
+        , (ineg i, ilam "o" (\_ -> u0))
+        ])
+    <@> u0
+
+-- | Decompose an interval expression @i : I@ as in
+-- 'decomposeInterval'', but discard any inconsistent mappings.
+decomposeInterval :: HasBuiltins m => Term -> m [(IntMap Bool, [Term])]
+decomposeInterval t = do
+  decomposeInterval' t <&> \xs ->
+    [ (bm, ts) | (bsm, ts) <- xs, bm <- maybeToList $ traverse BoolSet.toSingleton bsm ]
+
+-- | Decompose an interval expression @φ : I@ into a set of possible
+-- assignments for the variables mentioned in @φ@, together any leftover
+-- neutral terms that could not be put into 'IntervalView' form.
+decomposeInterval' :: HasBuiltins m => Term -> m [(IntMap BoolSet, [Term])]
+decomposeInterval' t = do
+  view   <- intervalView'
+  unview <- intervalUnview'
+  let
+    f :: IntervalView -> [[Either (Int,Bool) Term]]
+    -- TODO handle primIMinDep
+    -- TODO? handle forall
+    f IZero = mzero     -- No assignments are possible
+    f IOne  = return [] -- No assignments are necessary
+    -- Take the cartesian product
+    f (IMin x y) = do
+      xs <- (f . view . unArg) x
+      ys <- (f . view . unArg) y
+      return (xs ++ ys)
+    -- Take the union
+    f (IMax x y) = msum $ map (f . view . unArg) [x,y]
+    -- Invert the possible assignments and negate the neutrals
+    f (INeg x) =
+      map (either (\ (x,y) -> Left (x,not y)) (Right . unview . INeg . argN))
+        <$> (f . view . unArg) x
+    f (OTerm (Var i [])) = return [Left (i,True)]
+    f (OTerm t)          = return [Right t]
+
+  return [ (bsm, ts)
+         | xs <- f (view t)
+         , let (bs,ts) = partitionEithers xs
+         , let bsm     = IntMap.fromListWith BoolSet.union $ map (second BoolSet.singleton) bs
+         ]
+
+reduce2Lam :: Term -> ReduceM (Blocked Term)
+reduce2Lam t = do
+  t <- reduce' t
+  case lam2Abs Relevant t of
+    t -> underAbstraction_ t $ \ t -> do
+      t <- reduce' t
+      case lam2Abs Irrelevant t of
+        t -> underAbstraction_ t reduceB'
+  where
+    lam2Abs rel (Lam _ t) = absBody t <$ t
+    lam2Abs rel t         = Abs "y" (raise 1 t `apply` [setRelevance rel $ argN $ var 0])

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
@@ -1,0 +1,403 @@
+{-# LANGUAGE NondecreasingIndentation #-}
+module Agda.TypeChecking.Primitive.Cubical.Glue
+  ( mkGComp
+  , doGlueKanOp
+
+  , primGlue'
+  , prim_glue'
+  , prim_unglue'
+  )
+  where
+
+import Control.Monad.Except
+
+import Agda.Utils.Functor
+import Agda.Utils.Monad
+import Agda.Utils.Maybe
+
+import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Pure
+import Agda.TypeChecking.Monad.Env
+import Agda.TypeChecking.Substitute (absBody, apply, sort, subst, applyE)
+import Agda.TypeChecking.Reduce (reduceB', reduce')
+import Agda.TypeChecking.Names (NamesT, runNamesT, runNames, cl, lam, open, ilam)
+
+import Agda.Interaction.Options.Base (optCubical)
+
+import Agda.Syntax.Common
+  ( Hiding(..), Cubical(..), Arg(..)
+  , ConOrigin(..), ProjOrigin(..)
+  , Relevance(..)
+  , setRelevance
+  , defaultArgInfo, hasQuantity0, defaultArg, setHiding
+  )
+
+import Agda.TypeChecking.Primitive.Base
+  ( (-->), nPi', pPi', hPi', el, el', el's, (<@>), (<@@>), (<#>), argN, argH, (<..>)
+  , SigmaKit(..), getSigmaKit
+  )
+
+import Agda.Syntax.Internal
+import Agda.Utils.Impossible (__IMPOSSIBLE__)
+import Agda.TypeChecking.Monad.Debug (__IMPOSSIBLE_VERBOSE__)
+
+import Agda.TypeChecking.Primitive.Cubical.Base
+
+-- | Define a "ghcomp" version of gcomp. Normal comp looks like:
+--
+-- comp^i A [ phi -> u ] u0 = hcomp^i A(1/i) [ phi -> forward A i u ] (forward A 0 u0)
+--
+-- So for "gcomp" we compute:
+--
+-- gcomp^i A [ phi -> u ] u0 = hcomp^i A(1/i) [ phi -> forward A i u, ~ phi -> forward A 0 u0 ] (forward A 0 u0)
+--
+-- The point of this is that gcomp does not produce any empty
+-- systems (if phi = 0 it will reduce to "forward A 0 u".
+mkGComp :: HasBuiltins m => String -> NamesT m (NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term -> NamesT m Term)
+mkGComp s = do
+  let getTermLocal = getTerm s
+  tPOr <- getTermLocal "primPOr"
+  tIMax <- getTermLocal builtinIMax
+  tIMin <- getTermLocal builtinIMin
+  tINeg <- getTermLocal builtinINeg
+  tHComp <- getTermLocal builtinHComp
+  tTrans <- getTermLocal builtinTrans
+  io      <- getTermLocal builtinIOne
+  iz      <- getTermLocal builtinIZero
+  let forward la bA r u = pure tTrans <#> lam "i" (\ i -> la <@> (i `imax` r))
+                                      <@> lam "i" (\ i -> bA <@> (i `imax` r))
+                                      <@> r
+                                      <@> u
+  return $ \ la bA phi u u0 ->
+    pure tHComp <#> (la <@> pure io)
+                <#> (bA <@> pure io)
+                <#> imax phi (ineg phi)
+                <@> lam "i" (\ i -> combineSys (la <@> i) (ilam "o" (\a -> bA <@> i))
+                                      [ (phi,      ilam "o" $ \o -> forward la bA i (u <@> i <..> o))
+                                      , (ineg phi, ilam "o" $ \o -> forward la bA (pure iz) u0)
+                                      ])
+                <@> forward la bA (pure iz) u0
+
+-- | Perform the Kan operations for a @Glue φ A (T , e)@ type.
+doGlueKanOp
+  :: PureTCM m
+  => KanOperation -- ^ Are we composing or transporting?
+  -> FamilyOrNot (Arg Term, Arg Term, Arg Term, Arg Term, Arg Term, Arg Term)
+  -- ^ The data of the Glue operation: The levels of @A@ and @T@, @A@
+  -- itself, the extent of @T@, @T@ itself, and the family of
+  -- equivalences.
+  -> TermPosition
+  -- ^ Are we computing a plain hcomp/transp or are we computing under
+  -- @unglue@?
+  -> m (Maybe Term)
+
+doGlueKanOp (HCompOp psi u u0) (IsNot (la, lb, bA, phi, bT, e)) tpos = do
+-- hcomp {psi} u u0 : Glue {la} {lb} bA {φ} (bT, e)
+-- ... |- la, lb : Level
+-- ... |- bA : Type la
+-- ... |- bT : Partial φ (Type lB)
+-- ... |- e : PartialP φ λ o → bT o ≃ bA
+  let getTermLocal = getTerm $ builtinHComp ++ " for " ++ builtinGlue
+  tHComp   <- getTermLocal builtinHComp
+  tEFun    <- getTermLocal builtinEquivFun
+  tglue    <- getTermLocal builtin_glue
+  tunglue  <- getTermLocal builtin_unglue
+  io       <- getTermLocal builtinIOne
+  tItIsOne <- getTermLocal builtinItIsOne
+  view     <- intervalView'
+
+  runNamesT [] $ do
+    [psi, u, u0] <- mapM (open . unArg) [ignoreBlocking psi, u, u0]
+    [la, lb, bA, phi, bT, e] <- mapM (open . unArg) [la, lb, bA, phi, bT, e]
+
+    ifM (headStop tpos phi) (return Nothing) $ Just <$> do
+    let
+      tf i o   = hfill lb (bT <..> o) psi u u0 i
+      unglue g = pure tunglue <#> la <#> lb <#> bA <#> phi <#> bT <#> e <@> g
+
+      a1 = pure tHComp <#> la <#> bA <#> (imax psi phi)
+        <@> lam "i" (\i -> combineSys la (ilam "_" (\ _ -> bA))
+            [ (psi, ilam "o" (\o -> unglue (u <@> i <..> o)))
+            , (phi, ilam "o" (\o -> pure tEFun <#> lb <#> la <#> (bT <..> o) <#> bA <@> (e <..> o) <@> tf i o))
+            ])
+        <@> unglue u0
+
+      t1 = tf (pure io)
+
+    case tpos of
+      Head       -> t1 (pure tItIsOne)
+      Eliminated -> a1
+
+-- ...    |- psi, u0
+-- ..., i |- la, lb, bA, phi, bT, e
+doGlueKanOp (TranspOp psi u0) (IsFam (la, lb, bA, phi, bT, e)) tpos = do
+-- transp (λ i → Glue {la} {lb} bA {φ} (bT , e)) ψ u0
+  let
+    localUse = builtinTrans ++ " for " ++ builtinGlue
+    getTermLocal = getTerm localUse
+  tHComp <- getTermLocal builtinHComp
+  tTrans <- getTermLocal builtinTrans
+  tForall <- getTermLocal builtinFaceForall
+  tEFun   <- getTermLocal builtinEquivFun
+  tEProof <- getTermLocal builtinEquivProof
+  toutS   <- getTermLocal builtinSubOut
+  tglue   <- getTermLocal builtin_glue
+  tunglue <- getTermLocal builtin_unglue
+  io      <- getTermLocal builtinIOne
+  iz      <- getTermLocal builtinIZero
+  tLMax   <- getTermLocal builtinLevelMax
+  tTransp <- getTermLocal builtinTranspProof
+  tItIsOne <- getTermLocal builtinItIsOne
+  kit <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
+  runNamesT [] $ do
+
+    gcomp <- mkGComp localUse
+
+    -- transpFill: transp (λ j → bA (i ∧ j)) (φ ∨ ~ i) u0
+    -- connects u0 and transp bA i0 u0
+    let transpFill la bA phi u0 i =
+          pure tTrans <#> lam "j" (\ j -> la <@> imin i j)
+                      <@> lam "j" (\ j -> bA <@> imin i j)
+                      <@> (imax phi (ineg i))
+                      <@> u0
+    [psi,u0] <- mapM (open . unArg) [ignoreBlocking psi,u0]
+
+    -- glue1 t a = glue la[i1/i] lb[i1/i] bA[i1/i] phi[i1/i] bT[i1/i] e[i1/i] t a
+    glue1 <- do
+      g <- open $ (tglue `apply`) . map ((setHiding Hidden) . (subst 0 io)) $ [la, lb, bA, phi, bT, e]
+      return $ \ t a -> g <@> t <@> a
+
+    [la, lb, bA, phi, bT, e] <- mapM (\ a -> open . runNames [] $ lam "i" (const (pure $ unArg a))) [la, lb, bA, phi, bT, e]
+
+    -- Andreas, 2022-03-24, fixing #5838
+    -- Following the updated note
+    --
+    --   Simon Huber, A Cubical Type Theory for Higher Inductive Types
+    --   https://simhu.github.io/misc/hcomp.pdf (February 2022)
+    --
+    -- See: https://github.com/agda/agda/issues/5755#issuecomment-1043797776
+
+    -- unglue_u0 i = unglue la[i/i] lb[i/i] bA[i/i] phi[i/i] bT[i/i] e[i/e] u0
+    let unglue_u0 i = foldl (<#>) (pure tunglue) (map (<@> i) [la, lb, bA, phi, bT, e]) <@> u0
+
+    view <- intervalView'
+
+    ifM (headStop tpos (phi <@> pure io)) (return Nothing) $ Just <$> do
+    let
+      tf i o = transpFill lb (lam "i" $ \ i -> bT <@> i <..> o) psi u0 i
+      t1 o = tf (pure io) o
+
+      -- compute "forall. phi"
+      forallphi = pure tForall <@> phi
+
+      -- a1 with gcomp
+      -- a1 = gcomp (ψ ∨ (∀ i. φ)) (λ { i (φ = i1) → unglue_u0 i ; i ((∀ i. φ) = i1) → equivFun ... })
+      --        (unglue_u0 i0)
+      a1 = gcomp la bA (imax psi forallphi)
+        (lam "i" $ \ i -> combineSys (la <@> i) (ilam "o" (\_ -> bA <@> i))
+          [ (phi,       ilam "o" $ \_ -> unglue_u0 i)
+          , (forallphi, ilam "o" $ \o -> w i o <@> (tf i o))
+          ])
+        (unglue_u0 (pure iz))
+
+      max l l' = pure tLMax <@> l <@> l'
+      sigCon x y = pure (Con (sigmaCon kit) ConOSystem []) <@> x <@> y
+
+      -- The underlying function of our partial equivalence at the given
+      -- endpoint of the interval, together with proof (o : IsOne φ).
+      w i o = pure tEFun <#> (lb <@> i)
+                         <#> (la <@> i)
+                         <#> (bT <@> i <..> o)
+                         <#> (bA <@> i)
+                         <@> (e <@> i <..> o)
+
+      -- Type of fibres of the partial equivalence over a1.
+      fiberT o = fiber (lb <@> pure io) (la <@> pure io)
+        (bT <@> (pure io) <..> o) (bA <@> pure io)
+        (w (pure io) o)
+        a1
+
+      -- We don't have to do anything special for "~ forall. phi"
+      -- here (to implement "ghcomp") as it is taken care off by
+      -- tEProof in t1'alpha below
+      pe o = -- o : IsOne φ
+        combineSys (max (la <@> pure io) (lb <@> pure io))
+          (ilam "o" (const (fiberT o)))
+          [ (psi       , ilam "o" $ \_ -> sigCon u0     (lam "_" $ \_ -> a1))
+          , (forallphi , ilam "o" $ \o -> sigCon (t1 o) (lam "_" $ \_ -> a1))
+          ]
+      -- pe is a partial fibre of the equivalence with extent (ψ ∨ ∀ i. φ)
+      -- over a1
+
+      -- "ghcomp" is implemented in the proof of tEProof
+      -- (see src/data/lib/prim/Agda/Builtin/Cubical/Glue.agda)
+      t1'alpha o = -- o : IsOne φ
+         -- Because @e i1 1=1@ is an equivalence, we can extend the
+         -- partial fibre @pe@ to an actual fibre of (e i1 1=1) over a1.
+         pure toutS <#> (max (la <@> pure io) (lb <@> pure io)) <#> fiberT o
+          <#> imax psi forallphi
+          <#> pe o
+          <@> (pure tEProof
+                <#> (lb <@> pure io)        <#> (la <@> pure io)
+                <@> (bT <@> pure io <..> o) <@> (bA <@> pure io)
+                <@> (e <@> pure io <..> o)  <@> a1
+                <@> (imax psi forallphi)
+                <@> pe o)
+
+      -- TODO: optimize?
+      t1' o = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaFst kit)])
+      alpha o = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaSnd kit)])
+      a1' = pure tHComp <#> (la <@> pure io) <#> (bA <@> pure io)
+        <#> imax (phi <@> pure io) psi
+        <@> lam "j" (\j -> combineSys (la <@> pure io) (ilam "o" (\_ -> bA <@> pure io))
+          [ (phi <@> pure io, ilam "o" $ \o -> alpha o <@@> (w (pure io) o <@> t1' o, a1, j))
+          , (psi,             ilam "o" $ \o -> a1)
+          ])
+        <@> a1
+
+    -- glue1 (ilam "o" t1') a1'
+    case tpos of
+      Head -> t1' (pure tItIsOne)
+      Eliminated -> a1'
+doGlueKanOp _ _ _ = __IMPOSSIBLE__
+
+-- The implementation of 'primGlue'. Handles reduction where the partial
+-- element is defined.
+primGlue' :: TCM PrimitiveImpl
+primGlue' = do
+  requireCubical CFull ""
+  -- primGlue
+  --   : {la lb : Level} (A : Type la) {φ : I}
+  --   → (T : Partial φ (Type lb)
+  --   → (e : PartialP φ λ o → A ≃ T o)
+  --   → Type lb
+  t <- runNamesT [] $
+       hPi' "la" (el $ cl primLevel) (\ la ->
+       hPi' "lb" (el $ cl primLevel) $ \ lb ->
+       nPi' "A" (sort . tmSort <$> la) $ \ a ->
+       hPi' "φ" primIntervalType $ \ φ ->
+       nPi' "T" (pPi' "o" φ $ \ o -> el' (cl primLevelSuc <@> lb) (Sort . tmSort <$> lb)) $ \ t ->
+       pPi' "o" φ (\ o -> el' (cl primLevelMax <@> la <@> lb) $ cl primEquiv <#> lb <#> la <@> (t <@> o) <@> a)
+       --> (sort . tmSort <$> lb))
+  view <- intervalView'
+  one <- primItIsOne
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 6 $ \ts ->
+    case ts of
+     [la,lb,a,phi,t,e] -> do
+       sphi <- reduceB' phi
+       -- If @φ = i1@ then we reduce to @T 1=1@, since @Glue@ is also a Kan operation.
+       case view $ unArg $ ignoreBlocking $ sphi of
+         IOne -> redReturn $ unArg t `apply` [argN one]
+         -- Otherwise we're a regular ol' type.
+         _    -> return (NoReduction $ map notReduced [la,lb,a] ++ [reduced sphi] ++ map notReduced [t,e])
+     _ -> __IMPOSSIBLE__
+
+-- | The implementation of 'prim_glue', the introduction form for @Glue@
+-- types.
+prim_glue' :: TCM PrimitiveImpl
+prim_glue' = do
+  requireCubical CFull ""
+  t <- runNamesT [] $
+       hPi' "la" (el $ cl primLevel) (\ la ->
+       hPi' "lb" (el $ cl primLevel) $ \ lb ->
+       hPi' "A" (sort . tmSort <$> la) $ \ a ->
+       hPi' "φ" primIntervalType $ \ φ ->
+       hPi' "T" (pPi' "o" φ $ \ o ->  el' (cl primLevelSuc <@> lb) (Sort . tmSort <$> lb)) $ \ t ->
+       hPi' "e" (pPi' "o" φ $ \ o -> el' (cl primLevelMax <@> la <@> lb) $ cl primEquiv <#> lb <#> la <@> (t <@> o) <@> a) $ \ e ->
+       pPi' "o" φ (\ o -> el' lb (t <@> o)) --> (el' la a --> el' lb (cl primGlue <#> la <#> lb <@> a <#> φ <@> t <@> e)))
+
+  -- Takes a partial element of @t : T@ and an element of the base type @A@
+  -- which extends @e t@, and makes it into a Glue.
+  view <- intervalView'
+  one <- primItIsOne
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 8 $ \case
+    [la, lb, bA, phi, bT, e, t, a] -> do
+      sphi <- reduceB' phi
+      -- When @φ = 1@ then @t : T@ is totally defined.
+      case view $ unArg $ ignoreBlocking $ sphi of
+        IOne -> redReturn $ unArg t `apply` [argN one]
+        -- Otherwise we'll just wait to get unglued.
+        _    -> return (NoReduction $ map notReduced [la,lb,bA] ++ [reduced sphi] ++ map notReduced [bT,e,t,a])
+    _ -> __IMPOSSIBLE__
+
+-- | The implementation of 'prim_unglue', the elimination form for
+-- @Glue@ types.
+prim_unglue' :: TCM PrimitiveImpl
+prim_unglue' = do
+  requireCubical CFull ""
+  t <- runNamesT [] $
+       hPi' "la" (el $ cl primLevel) (\ la ->
+       hPi' "lb" (el $ cl primLevel) $ \ lb ->
+       hPi' "A" (sort . tmSort <$> la) $ \ a ->
+       hPi' "φ" primIntervalType $ \ φ ->
+       hPi' "T" (pPi' "o" φ $ \ o ->  el' (cl primLevelSuc <@> lb) (Sort . tmSort <$> lb)) $ \ t ->
+       hPi' "e" (pPi' "o" φ $ \ o -> el' (cl primLevelMax <@> la <@> lb) $ cl primEquiv <#> lb <#> la <@> (t <@> o) <@> a) $ \ e ->
+       (el' lb (cl primGlue <#> la <#> lb <@> a <#> φ <@> t <@> e)) --> el' la a)
+
+  -- Takes an element @b : Glue φ A (T, e)@ to an element of @A@ which,
+  -- under @φ@, agrees with @e b@. Recall that @φ ⊢ e : A → T@ and @φ ⊢
+  -- Glue φ A (T, e) = T@ so this is well-typed.
+  view <- intervalView'
+  one <- primItIsOne
+  mGlue <- getPrimitiveName' builtinGlue
+  mglue <- getPrimitiveName' builtin_glue
+  mtransp <- getPrimitiveName' builtinTrans
+  mhcomp <- getPrimitiveName' builtinHComp
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 7 $ \case
+    [la, lb, bA, phi, bT, e, b] -> do
+      sphi <- reduceB' phi
+      case view $ unArg $ ignoreBlocking $ sphi of
+        -- When @φ = i1@ we have @Glue i1 A (T , e) = T@ so @b : T@,
+        -- and we must produce @unglue b : A [ i1 → e b ]@. But that's
+        -- just @e b@!
+        IOne -> do
+          let argOne = setRelevance Irrelevant $ argN one
+          tEFun <- getTerm builtin_unglue builtinEquivFun
+          redReturn $ tEFun `apply` [lb,la,argH $ unArg bT `apply` [argOne],bA, argN $ unArg e `apply` [argOne],b]
+
+        -- Otherwise we're dealing with a proper glued thing.
+        -- Definitely a sticky situation!
+        _    -> do
+          sb <- reduceB' b
+          let fallback sbA = return (NoReduction $ map notReduced [la,lb] ++ map reduced [sbA, sphi] ++ map notReduced [bT,e] ++ [reduced sb])
+          case unArg $ ignoreBlocking $ sb of
+            -- Case 1: unglue (glue a) = a. This agrees with the @φ =
+            -- i1@ reduction because under @φ@, the argument to
+            -- @glue@ must be in the image of the equivalence.
+            Def q es
+              | Just [_, _, _, _, _, _, _, a] <- allApplyElims es
+              , Just q == mglue -> redReturn $ unArg a
+
+            -- Case 2: unglue (transp (λ i → Glue ...) r u0).
+            -- Defer to the implementation of @doGlueKanOp DoTransp ... Eliminated@: It knows how to unglue itself.
+            Def q [Apply l, Apply bA, Apply r, Apply u0] | Just q == mtransp -> do
+              sbA <- reduceB' bA
+              -- Require that bA be a lambda abstraction...
+              case unArg $ ignoreBlocking sbA of
+                Lam _ t -> do
+                  -- And that its body reduces to a Glue type.
+                  st <- reduceB' (absBody t)
+                  case ignoreBlocking st of
+                    -- In this case, we use the Glue data extracted from
+                    -- the family we're transporting over.
+                    Def g es | Just [la', lb', bA', phi', bT', e'] <- allApplyElims es, Just g == mGlue -> do
+                        redReturn . fromMaybe __IMPOSSIBLE__ =<<
+                          doGlueKanOp (TranspOp (notBlocked r) u0) (IsFam (la',lb',bA',phi',bT',e')) Eliminated
+                    _ -> fallback (st *> sbA)
+                _ -> fallback sbA
+
+            -- Case 3: unglue (hcomp u u0).
+            -- Defer to the implementation of @doGlueKanOp DoHComp ... Eliminated@: It knows how to unglue itself.
+            Def q [Apply l,Apply bA,Apply r,Apply u,Apply u0] | Just q == mhcomp -> do
+              sbA <- reduceB' bA
+              case unArg $ ignoreBlocking sbA of
+                -- Idem: use the Glue data from the type we're doing
+                -- hcomp in.
+                Def g es | Just [la', lb', bA', phi', bT', e'] <- allApplyElims es, Just g == mGlue -> do
+                  redReturn . fromMaybe __IMPOSSIBLE__ =<<
+                    doGlueKanOp (HCompOp (notBlocked r) u u0) (IsNot (la',lb',bA',phi',bT',e')) Eliminated
+                _ -> fallback sbA
+
+            _ -> return (NoReduction $ map notReduced [la,lb,bA] ++ [reduced sphi] ++ map notReduced [bT,e] ++ [reduced sb])
+    _ -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
@@ -73,7 +73,7 @@ mkGComp s = do
     pure tHComp <#> (la <@> pure io)
                 <#> (bA <@> pure io)
                 <#> imax phi (ineg phi)
-                <@> lam "i" (\ i -> combineSys (la <@> i) (ilam "o" (\a -> bA <@> i))
+                <@> lam "i" (\ i -> combineSys (la <@> i) (bA <@> i)
                                       [ (phi,      ilam "o" $ \o -> forward la bA i (u <@> i <..> o))
                                       , (ineg phi, ilam "o" $ \o -> forward la bA (pure iz) u0)
                                       ])
@@ -117,7 +117,7 @@ doGlueKanOp (HCompOp psi u u0) (IsNot (la, lb, bA, phi, bT, e)) tpos = do
       unglue g = pure tunglue <#> la <#> lb <#> bA <#> phi <#> bT <#> e <@> g
 
       a1 = pure tHComp <#> la <#> bA <#> (imax psi phi)
-        <@> lam "i" (\i -> combineSys la (ilam "_" (\ _ -> bA))
+        <@> lam "i" (\i -> combineSys la bA
             [ (psi, ilam "o" (\o -> unglue (u <@> i <..> o)))
             , (phi, ilam "o" (\o -> pure tEFun <#> lb <#> la <#> (bT <..> o) <#> bA <@> (e <..> o) <@> tf i o))
             ])
@@ -195,7 +195,7 @@ doGlueKanOp (TranspOp psi u0) (IsFam (la, lb, bA, phi, bT, e)) tpos = do
       -- a1 = gcomp (ψ ∨ (∀ i. φ)) (λ { i (φ = i1) → unglue_u0 i ; i ((∀ i. φ) = i1) → equivFun ... })
       --        (unglue_u0 i0)
       a1 = gcomp la bA (imax psi forallphi)
-        (lam "i" $ \ i -> combineSys (la <@> i) (ilam "o" (\_ -> bA <@> i))
+        (lam "i" $ \ i -> combineSys (la <@> i) (bA <@> i)
           [ (phi,       ilam "o" $ \_ -> unglue_u0 i)
           , (forallphi, ilam "o" $ \o -> w i o <@> (tf i o))
           ])
@@ -222,8 +222,7 @@ doGlueKanOp (TranspOp psi u0) (IsFam (la, lb, bA, phi, bT, e)) tpos = do
       -- here (to implement "ghcomp") as it is taken care off by
       -- tEProof in t1'alpha below
       pe o = -- o : IsOne φ
-        combineSys (max (la <@> pure io) (lb <@> pure io))
-          (ilam "o" (const (fiberT o)))
+        combineSys (max (la <@> pure io) (lb <@> pure io)) (fiberT o)
           [ (psi       , ilam "o" $ \_ -> sigCon u0     (lam "_" $ \_ -> a1))
           , (forallphi , ilam "o" $ \o -> sigCon (t1 o) (lam "_" $ \_ -> a1))
           ]
@@ -250,7 +249,7 @@ doGlueKanOp (TranspOp psi u0) (IsFam (la, lb, bA, phi, bT, e)) tpos = do
       alpha o = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaSnd kit)])
       a1' = pure tHComp <#> (la <@> pure io) <#> (bA <@> pure io)
         <#> imax (phi <@> pure io) psi
-        <@> lam "j" (\j -> combineSys (la <@> pure io) (ilam "o" (\_ -> bA <@> pure io))
+        <@> lam "j" (\j -> combineSys (la <@> pure io) (bA <@> pure io)
           [ (phi <@> pure io, ilam "o" $ \o -> alpha o <@@> (w (pure io) o <@> t1' o, a1, j))
           , (psi,             ilam "o" $ \o -> a1)
           ])

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
@@ -1,0 +1,300 @@
+{-# LANGUAGE NondecreasingIndentation #-}
+module Agda.TypeChecking.Primitive.Cubical.HCompU
+  ( doHCompUKanOp
+  , prim_glueU'
+  , prim_unglueU'
+  )
+  where
+
+import Control.Monad.Except
+
+import Agda.Utils.Functor
+import Agda.Utils.Monad
+import Agda.Utils.Maybe
+
+import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Pure
+import Agda.TypeChecking.Monad.Env
+import Agda.TypeChecking.Substitute (absBody, apply, sort, subst, applyE)
+import Agda.TypeChecking.Reduce (reduceB', reduceB, reduce')
+import Agda.TypeChecking.Names (NamesT, runNamesT, runNames, cl, lam, open, ilam)
+
+import Agda.Interaction.Options.Base (optCubical)
+
+import Agda.Syntax.Common
+  ( Hiding(..), Cubical(..), Arg(..)
+  , ConOrigin(..), ProjOrigin(..)
+  , Relevance(..)
+  , setRelevance
+  , defaultArgInfo, hasQuantity0, defaultArg, setHiding
+  )
+
+import Agda.TypeChecking.Primitive.Base
+  ( (-->), nPi', pPi', hPi', el, el', el's, (<@>), (<@@>), (<#>), argN, argH, (<..>)
+  , SigmaKit(..), getSigmaKit
+  )
+
+import Agda.Syntax.Internal
+import Agda.Utils.Impossible (__IMPOSSIBLE__)
+import Agda.TypeChecking.Monad.Debug (__IMPOSSIBLE_VERBOSE__)
+
+import Agda.TypeChecking.Primitive.Cubical.Glue
+import Agda.TypeChecking.Primitive.Cubical.Base
+
+-- | Perform the Kan operations for an @hcomp {A = Type} {φ} u u0@ type.
+doHCompUKanOp
+  :: PureTCM m
+  => KanOperation
+  -> FamilyOrNot (Arg Term, Arg Term, Arg Term, Arg Term)
+  -> TermPosition
+  -> m (Maybe Term)
+
+-- TODO (Amy, 2022-08-17): This is literally the same algorithm as
+-- doGlueKanOp, but specialised for using transport as the equivalence.
+-- Can we deduplicate them?
+doHCompUKanOp (HCompOp psi u u0) (IsNot (la, phi, bT, bA)) tpos = do
+  let getTermLocal = getTerm $ (builtinHComp ++ " for " ++ builtinHComp ++ " of Set")
+  io       <- getTermLocal builtinIOne
+  iz       <- getTermLocal builtinIZero
+  tHComp   <- getTermLocal builtinHComp
+  tTransp  <- getTermLocal builtinTrans
+  tglue    <- getTermLocal builtin_glueU
+  tunglue  <- getTermLocal builtin_unglueU
+  tLSuc    <- getTermLocal builtinLevelSuc
+  tSubIn   <- getTermLocal builtinSubIn
+  tItIsOne <- getTermLocal builtinItIsOne
+  runNamesT [] $ do
+    [psi, u, u0] <- mapM (open . unArg) [ignoreBlocking psi, u, u0]
+    [la, phi, bT, bA] <- mapM (open . unArg) [la, phi, bT, bA]
+
+    ifM (headStop tpos phi) (return Nothing) $ Just <$> do
+
+    let
+      transp la bA a0 = pure tTransp <#> lam "i" (const la) <@> lam "i" bA <@> pure iz <@> a0
+      tf i o = hfill la (bT <@> pure io <..> o) psi u u0 i
+
+      bAS = pure tSubIn <#> (pure tLSuc <@> la) <#> (Sort . tmSort <$> la) <#> phi <@> bA
+      unglue g = pure tunglue <#> la <#> phi <#> bT <#> bAS <@> g
+
+      a1 = pure tHComp <#> la <#> bA <#> (imax psi phi)
+        <@> lam "i" (\i -> combineSys la (ilam "_" (\ _ -> bA))
+            [ (psi, ilam "o" (\o -> unglue (u <@> i <..> o)))
+            , (phi, ilam "o" (\ o -> transp la (\i -> bT <@> (ineg i) <..> o) (tf i o)))
+            ])
+        <@> unglue u0
+
+      t1 = tf (pure io)
+
+    -- pure tglue <#> la <#> phi <#> bT <#> bAS <@> (ilam "o" $ \ o -> t1 o) <@> a1
+    case tpos of
+      Eliminated -> a1
+      Head       -> t1 (pure tItIsOne)
+
+
+doHCompUKanOp (TranspOp psi u0) (IsFam (la, phi, bT, bA)) tpos = do
+  let
+    localUse = builtinTrans ++ " for " ++ builtinHComp ++ " of Set"
+    getTermLocal = getTerm localUse
+  tPOr <- getTermLocal "primPOr"
+  tIMax <- getTermLocal builtinIMax
+  tIMin <- getTermLocal builtinIMin
+  tINeg <- getTermLocal builtinINeg
+  tHComp <- getTermLocal builtinHComp
+  tTrans <- getTermLocal builtinTrans
+  tTranspProof <- getTermLocal builtinTranspProof
+  tSubIn <- getTermLocal builtinSubIn
+  tForall  <- getTermLocal builtinFaceForall
+  io      <- getTermLocal builtinIOne
+  iz      <- getTermLocal builtinIZero
+  tLSuc   <- getTermLocal builtinLevelSuc
+  tPath   <- getTermLocal builtinPath
+  tItIsOne   <- getTermLocal builtinItIsOne
+  kit <- fromMaybe __IMPOSSIBLE__ <$> getSigmaKit
+  runNamesT [] $ do
+    -- Helper definitions we'll use:
+    gcomp <- mkGComp localUse
+
+    let
+      transp la bA a0 = pure tTrans <#> lam "i" (const la) <@> lam "i" bA <@> pure iz <@> a0
+      transpFill la bA phi u0 i = pure tTrans
+        <#> ilam "j" (\ j -> la <@> imin i j)
+        <@> ilam "j" (\ j -> bA <@> imin i j)
+        <@> (imax phi (ineg i))
+        <@> u0
+
+    [psi, u0] <- mapM (open . unArg) [ignoreBlocking psi, u0]
+    glue1 <- do
+      tglue             <- cl $ getTermLocal builtin_glueU
+      [la, phi, bT, bA] <- mapM (open . unArg . subst 0 io) $ [la, phi, bT, bA]
+      let bAS = pure tSubIn <#> (pure tLSuc <@> la) <#> (Sort . tmSort <$> la) <#> phi <@> bA
+      g <- (open =<<) $ pure tglue <#> la <#> phi <#> bT <#> bAS
+      return $ \ t a -> g <@> t <@> a
+
+    [la, phi, bT, bA] <- mapM (\a -> open . runNames [] $ lam "i" (const (pure $ unArg a))) [la, phi, bT, bA]
+
+    -- Andreas, 2022-03-25, issue #5838.
+    -- Port the fix of @unglueTranspGlue@ and @doGlueKanOp DoTransp@
+    -- also to @doHCompUKanOp DoTransp@, as suggested by Tom Jack and Anders Mörtberg.
+    -- We define @unglue_u0 i@ that is first used with @i@ and then with @i0@.
+    -- The original code used it only with @i0@.
+    tunglue <- cl $ getTermLocal builtin_unglueU
+    let
+      bAS i = pure tSubIn
+        <#> (pure tLSuc <@> (la <@> i)) <#> (Sort . tmSort <$> (la <@> i)) <#> (phi <@> i)
+        <@> (bA <@> i)
+      unglue_u0 i = pure tunglue
+        <#> (la <@> i) <#> (phi <@> i) <#> (bT <@> i)
+        <#> bAS i <@> u0
+
+    ifM (headStop tpos (phi <@> pure io)) (return Nothing) $ Just <$> do
+
+    let
+      tf i o = transpFill la (lam "i" $ \ i -> bT <@> i <@> pure io <..> o) psi u0 i
+      t1 o   = tf (pure io) o
+
+      -- compute "forall. phi"
+      forallphi = pure tForall <@> phi
+
+      -- a1 with gcomp
+      a1 = gcomp la bA (imax psi forallphi)
+        (lam "i" $ \ i -> combineSys (la <@> i) (ilam "o" (\_ -> bA <@> i))
+          [ (phi,       ilam "o" $ \_ -> unglue_u0 i)
+          , (forallphi, ilam "o" (\o -> transp (la <@> i) (\j -> bT <@> i <@> ineg j <..> o) (tf i o)))
+          ])
+          (unglue_u0 (pure iz))
+
+      w i o = lam "x" $ transp (la <@> i) (\j -> bT <@> i <@> ineg j <..> o)
+
+      pt o = -- o : [ φ 1 ]
+        combineSys (la <@> pure io)
+          (ilam "o" (const (bT <@> pure io <@> pure io <..> o)))
+          [ (psi       , ilam "o" $ \_ -> u0)
+          , (forallphi , ilam "o" $ \o -> t1 o)
+          ]
+
+      -- "ghcomp" is implemented in the proof of tTranspProof
+      -- (see src/data/lib/prim/Agda/Builtin/Cubical/HCompU.agda)
+      t1'alpha o = -- o : [ φ 1 ]
+         pure tTranspProof
+          <#> (la <@> pure io) <@> lam "i" (\i -> bT <@> pure io <@> ineg i <..> o)
+          <@> imax psi forallphi
+          <@> pt o
+          <@> (pure tSubIn <#> (la <@> pure io) <#> (bA <@> pure io) <#> imax psi forallphi
+                <@> a1)
+
+      -- TODO: optimize?
+      t1' o   = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaFst kit)])
+      alpha o = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaSnd kit)])
+      a1' = pure tHComp <#> (la <@> pure io) <#> (bA <@> pure io)
+        <#> imax (phi <@> pure io) psi
+        <@> lam "j" (\j -> combineSys (la <@> pure io) (ilam "o" (\_ -> bA <@> pure io))
+          [ (phi <@> pure io, ilam "o" $ \o -> alpha o <@@> (w (pure io) o <@> t1' o, a1, j))
+          , (psi,             ilam "o" $ \o -> a1)
+          ])
+        <@> a1
+
+    -- glue1 (ilam "o" t1') a1'
+    case tpos of
+      Eliminated -> a1'
+      Head       -> t1' (pure tItIsOne)
+doHCompUKanOp _ _ _ = __IMPOSSIBLE__
+
+-- | The implementation of 'prim_glueU', the introduction form for
+-- @hcomp@ types.
+prim_glueU' :: TCM PrimitiveImpl
+prim_glueU' = do
+-- TODO (Amy, 2022-08-17): Same thing about duplicated code with Glue
+-- applies here.
+  requireCubical CErased ""
+  t <- runNamesT [] $
+       hPi' "la" (el $ cl primLevel) (\ la ->
+       hPi' "φ" primIntervalType $ \ φ ->
+       hPi' "T" (nPi' "i" primIntervalType $ \ _ -> pPi' "o" φ $ \ o -> sort . tmSort <$> la) $ \ t ->
+       hPi' "A" (el's (cl primLevelSuc <@> la) $ cl primSub <#> (cl primLevelSuc <@> la) <@> (Sort . tmSort <$> la) <@> φ <@> (t <@> primIZero)) $ \ a -> do
+       let bA = (cl primSubOut <#> (cl primLevelSuc <@> la) <#> (Sort . tmSort <$> la) <#> φ <#> (t <@> primIZero) <@> a)
+       pPi' "o" φ (\ o -> el' la (t <@> cl primIOne <..> o))
+         --> (el' la bA)
+         --> el' la (cl primHComp <#> (cl primLevelSuc <@> la) <#> (Sort . tmSort <$> la) <#> φ <@> t <@> bA))
+  view <- intervalView'
+  one <- primItIsOne
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 6 $ \ts ->
+    case ts of
+      [la,phi,bT,bA,t,a] -> do
+       sphi <- reduceB' phi
+       case view $ unArg $ ignoreBlocking $ sphi of
+         IOne -> redReturn $ unArg t `apply` [argN one]
+         _    -> return (NoReduction $ map notReduced [la] ++ [reduced sphi] ++ map notReduced [bT,bA,t,a])
+      _ -> __IMPOSSIBLE__
+
+-- | The implementation of 'prim_unglueU', the elimination form for
+-- @hcomp@ types.
+prim_unglueU' :: TCM PrimitiveImpl
+prim_unglueU' = do
+-- TODO (Amy, 2022-08-17): Same thing about duplicated code with Glue
+-- applies here.
+  requireCubical CErased ""
+  t <- runNamesT [] $
+       hPi' "la" (el $ cl primLevel) (\ la ->
+       hPi' "φ" primIntervalType $ \ φ ->
+       hPi' "T" (nPi' "i" primIntervalType $ \ _ -> pPi' "o" φ $ \ o -> sort . tmSort <$> la) $ \ t ->
+       hPi' "A" (el's (cl primLevelSuc <@> la) $ cl primSub <#> (cl primLevelSuc <@> la) <@> (Sort . tmSort <$> la) <@> φ <@> (t <@> primIZero)) $ \ a -> do
+       let bA = (cl primSubOut <#> (cl primLevelSuc <@> la) <#> (Sort . tmSort <$> la) <#> φ <#> (t <@> primIZero) <@> a)
+       el' la (cl primHComp <#> (cl primLevelSuc <@> la) <#> (Sort . tmSort <$> la) <#> φ <@> t <@> bA)
+         --> el' la bA)
+
+  view <- intervalView'
+  one <- primItIsOne
+  mglueU <- getPrimitiveName' builtin_glueU
+  mtransp <- getPrimitiveName' builtinTrans
+  mHCompU <- getPrimitiveName' builtinHComp
+  let mhcomp = mHCompU
+
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 5 $ \case
+    [la,phi,bT,bA,b] -> do
+      sphi <- reduceB' phi
+      case view $ unArg $ ignoreBlocking $ sphi of
+        -- Case where the hcomp has reduced away: Transport backwards
+        -- along the partial element we've glued.
+        IOne -> do
+          tTransp <- getTerm builtin_unglueU builtinTrans
+          iNeg    <- getTerm builtin_unglueU builtinINeg
+          iZ      <- getTerm builtin_unglueU builtinIZero
+          redReturn <=< runNamesT [] $ do
+            [la,bT,b] <- mapM (open . unArg) [la,bT,b]
+            pure tTransp <#> lam "i" (\ _ -> la) <@> lam "i" (\ i -> bT <@> ineg i <..> pure one)
+              <@> pure iZ <@> b
+
+        -- Otherwise, we're dealing with a proper glu- didn't I already
+        -- make this joke? Oh, yeah, in prim_unglue, right.
+        _ -> do
+          sb <- reduceB' b
+          let fallback sbA = return (NoReduction $ map notReduced [la] ++ [reduced sphi] ++ map notReduced [bT,bA] ++ [reduced sb])
+          case unArg $ ignoreBlocking $ sb of
+            -- Project:
+            Def q es | Just [_,_,_,_,_, a] <- allApplyElims es, Just q == mglueU -> redReturn $ unArg a
+
+            -- Transport:
+            Def q [Apply l, Apply bA, Apply r, Apply u0] | Just q == mtransp -> do
+              sbA <- reduceB bA
+              case unArg $ ignoreBlocking sbA of
+                Lam _ t -> do
+                  st <- reduceB' (absBody t)
+                  case ignoreBlocking st of
+                    Def h es | Just [la,_,phi,bT,bA] <- allApplyElims es, Just h == mHCompU -> do
+                      redReturn . fromMaybe __IMPOSSIBLE__ =<<
+                        doHCompUKanOp (TranspOp (notBlocked r) u0) (IsFam (la,phi,bT,bA)) Eliminated
+                    _ -> fallback (st *> sbA)
+                _  -> fallback sbA
+
+            -- Compose:
+            Def q [Apply l,Apply bA,Apply r,Apply u,Apply u0] | Just q == mhcomp -> do
+              sbA <- reduceB bA
+              case unArg $ ignoreBlocking sbA of
+                Def h es | Just [la,_,phi,bT,bA] <- allApplyElims es, Just h == mHCompU -> do
+                  redReturn . fromMaybe __IMPOSSIBLE__ =<<
+                    doHCompUKanOp (HCompOp (notBlocked r) u u0) (IsNot (la,phi,bT,bA)) Eliminated
+                _ -> fallback sbA
+            _ -> return (NoReduction $ map notReduced [la] ++ [reduced sphi] ++ map notReduced [bT,bA] ++ [reduced sb])
+
+    _ -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
@@ -78,7 +78,7 @@ doHCompUKanOp (HCompOp psi u u0) (IsNot (la, phi, bT, bA)) tpos = do
       unglue g = pure tunglue <#> la <#> phi <#> bT <#> bAS <@> g
 
       a1 = pure tHComp <#> la <#> bA <#> (imax psi phi)
-        <@> lam "i" (\i -> combineSys la (ilam "_" (\ _ -> bA))
+        <@> lam "i" (\i -> combineSys la bA
             [ (psi, ilam "o" (\o -> unglue (u <@> i <..> o)))
             , (phi, ilam "o" (\ o -> transp la (\i -> bT <@> (ineg i) <..> o) (tf i o)))
             ])
@@ -158,7 +158,7 @@ doHCompUKanOp (TranspOp psi u0) (IsFam (la, phi, bT, bA)) tpos = do
 
       -- a1 with gcomp
       a1 = gcomp la bA (imax psi forallphi)
-        (lam "i" $ \ i -> combineSys (la <@> i) (ilam "o" (\_ -> bA <@> i))
+        (lam "i" $ \ i -> combineSys (la <@> i) (bA <@> i)
           [ (phi,       ilam "o" $ \_ -> unglue_u0 i)
           , (forallphi, ilam "o" (\o -> transp (la <@> i) (\j -> bT <@> i <@> ineg j <..> o) (tf i o)))
           ])
@@ -167,8 +167,7 @@ doHCompUKanOp (TranspOp psi u0) (IsFam (la, phi, bT, bA)) tpos = do
       w i o = lam "x" $ transp (la <@> i) (\j -> bT <@> i <@> ineg j <..> o)
 
       pt o = -- o : [ φ 1 ]
-        combineSys (la <@> pure io)
-          (ilam "o" (const (bT <@> pure io <@> pure io <..> o)))
+        combineSys (la <@> pure io) (bT <@> pure io <@> pure io <..> o)
           [ (psi       , ilam "o" $ \_ -> u0)
           , (forallphi , ilam "o" $ \o -> t1 o)
           ]
@@ -188,7 +187,7 @@ doHCompUKanOp (TranspOp psi u0) (IsFam (la, phi, bT, bA)) tpos = do
       alpha o = t1'alpha o <&> (`applyE` [Proj ProjSystem (sigmaSnd kit)])
       a1' = pure tHComp <#> (la <@> pure io) <#> (bA <@> pure io)
         <#> imax (phi <@> pure io) psi
-        <@> lam "j" (\j -> combineSys (la <@> pure io) (ilam "o" (\_ -> bA <@> pure io))
+        <@> lam "j" (\j -> combineSys (la <@> pure io) (bA <@> pure io)
           [ (phi <@> pure io, ilam "o" $ \o -> alpha o <@@> (w (pure io) o <@> t1' o, a1, j))
           , (psi,             ilam "o" $ \o -> a1)
           ])

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Id.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Id.hs
@@ -1,0 +1,294 @@
+{-# LANGUAGE LambdaCase #-}
+-- | Implementation of the primitives relating to Cubical identity types.
+module Agda.TypeChecking.Primitive.Cubical.Id
+  ( -- * General elimination form
+    primIdElim'
+  -- * Introduction form
+  , primConId'
+  -- * Projection maps (primarily used internally)
+  , primIdFace'
+  , primIdPath'
+  -- * Kan operations
+  , doIdKanOp
+  )
+  where
+
+import Control.Monad.Except
+
+import Agda.Utils.Impossible (__IMPOSSIBLE__)
+import Agda.Utils.Monad
+
+import qualified Data.IntMap as IntMap
+import Data.Traversable
+import Data.Maybe
+
+import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Monad.Env
+import Agda.TypeChecking.Substitute (apply, sort, listS, applySubst)
+import Agda.TypeChecking.Reduce (reduceB', reduce')
+import Agda.TypeChecking.Names
+  (runNamesT, runNames, cl, lam, ilam, open)
+
+import Agda.Interaction.Options.Base (optCubical)
+
+import Agda.Syntax.Common (Cubical(..), Arg(..), defaultArgInfo, hasQuantity0, defaultArg)
+
+import Agda.TypeChecking.Primitive.Base
+  ((-->), nPi', pPi', hPi', el, el', el's, (<@>), (<#>), (<..>), argN)
+
+import Agda.Syntax.Internal
+import Agda.TypeChecking.Monad.Debug (__IMPOSSIBLE_VERBOSE__)
+
+import Agda.TypeChecking.Primitive.Cubical.Base
+
+-- | Primitive elimination rule for the cubical identity types. Unlike
+-- J, @idElim@ makes explicit the structure of Swan's identity types as
+-- being pairs of a cofibration and a path. Moreover, it records that
+-- the path is definitionally @refl@ under that cofibration.
+primIdElim' :: TCM PrimitiveImpl
+primIdElim' = do
+  -- The implementation here looks terrible but most of it is actually
+  -- the type.
+  requireCubical CErased ""
+  t <- runNamesT [] $
+    hPi' "a" (el $ cl primLevel) $ \ a ->
+    hPi' "c" (el $ cl primLevel) $ \ c ->
+    hPi' "A" (sort . tmSort <$> a) $ \ bA ->
+    hPi' "x" (el' a bA) $ \ x ->
+    nPi' "C" (nPi' "y" (el' a bA) $ \ y ->
+              el' a (cl primId <#> a <#> bA <@> x <@> y) --> (sort . tmSort <$> c)) $ \ bC ->
+    -- To construct (C : (y : A) → Id A x y → Type c), it suffices to:
+
+    -- For all cofibrations φ,
+    nPi' "φ" primIntervalType (\ phi ->
+      -- For all y : A [ φ → (λ _ → x) ]
+      nPi' "y" (el's a $ cl primSub <#> a <@> bA <@> phi <@> lam "o" (const x)) $ \ y ->
+      let pathxy = cl primPath <#> a <@> bA <@> x <@> outSy
+          outSy  = cl primSubOut <#> a <#> bA <#> phi <#> lam "o" (const x) <@> y
+          reflx  = lam "o" $ \ _ -> lam "i" $ \ _ -> x -- TODO Andrea, should block on o
+      -- For all w : (Path A x (outS y)) [ φ (λ _ → refl {x = outS y} ]
+      in nPi' "w" (el's a $ cl primSub <#> a <@> pathxy <@> phi <@> reflx) $ \ w ->
+      let outSw = (cl primSubOut <#> a <#> pathxy <#> phi <#> reflx <@> w)
+      in el' c $ bC <@> outSy <@> (cl primConId <#> a <#> bA <#> x <#> outSy <@> phi <@> outSw))
+      -- Construct an inhabitant of (C (outS y) (conid φ (outS w)))
+    -->
+    hPi' "y" (el' a bA) (\ y ->
+      nPi' "p" (el' a $ cl primId <#> a <#> bA <@> x <@> y) $ \ p ->
+      el' c $ bC <@> y <@> p)
+
+  -- Implementation starts here:
+  conid <- primConId
+  sin <- primSubIn
+  path <- primPath
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 8 $ \case
+    [a,c,bA,x,bC,f,y,p] -> do
+      sp <- reduceB' p
+      cview <- conidView'
+      case cview (unArg x) $ unArg $ ignoreBlocking sp of
+        -- Record that the right endpoint and the path definitionally
+        -- agree with x φ holds. This is guaranteed internally by the
+        -- typing rule for @conId@ but can't be recovered from
+        -- @primIdPath@ and @primIdFace@ (see #2598)
+        Just (phi, w) -> do
+          let y' = sin `apply` [a, bA, phi, argN (unArg y)]
+          let w' = sin `apply` [a, argN (path `apply` [a, bA, x, y]), phi, argN (unArg w)]
+          redReturn $ unArg f `apply` [phi, defaultArg y', defaultArg w']
+        _ -> return $ NoReduction $ map notReduced [a,c,bA,x,bC,f,y] ++ [reduced sp]
+    _ -> __IMPOSSIBLE_VERBOSE__ "implementation of primIdElim called with wrong arity"
+
+-- | Introduction form for the cubical identity types.
+primConId' :: TCM PrimitiveImpl
+primConId' = do
+  requireCubical CErased ""
+  t <- runNamesT [] $
+    hPi' "a" (el $ cl primLevel) $ \ a ->
+    hPi' "A" (sort . tmSort <$> a) $ \ bA ->
+    hPi' "x" (el' a bA) $ \ x ->
+    hPi' "y" (el' a bA) $ \ y ->
+    primIntervalType -- Cofibration
+    --> (el' a $ cl primPath <#> a <#> bA <@> x <@> y)
+    --> (el' a $ cl primId <#> a <#> bA <@> x <@> y)
+
+  -- Implementation note: conId, as the name implies, is a constructor.
+  -- It's not represented as a constructor because users can't match on
+  -- it (but we, internally, can: see createMissingConIdClause).
+
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 6 $ \case
+    [l,bA,x,y,phi,p] -> do
+      sphi <- reduceB' phi
+      view <- intervalView'
+      case view $ unArg $ ignoreBlocking sphi of
+        -- But even though it's a constructor, it does reduce, in some
+        -- cases: If the cofibration is definitely true, then we return
+        -- reflId.  TODO: Handle this in the conversion checker instead?
+        IOne -> do
+          reflId <- getTerm builtinConId builtinReflId
+          redReturn $ reflId
+        _ -> return $ NoReduction $ map notReduced [l,bA,x,y] ++ [reduced sphi, notReduced p]
+    _ -> __IMPOSSIBLE_VERBOSE__ "implementation of primConId called with wrong arity"
+
+-- | Extract the underlying cofibration from an inhabitant of the
+-- cubical identity types.
+--
+-- TODO (Amy, 2022-08-17): Projecting a cofibration from a Kan type
+-- violates the cubical phase distinction.
+primIdFace' :: TCM PrimitiveImpl
+primIdFace' = do
+  requireCubical CErased ""
+  t <- runNamesT [] $
+    hPi' "a" (el $ cl primLevel) $ \ a ->
+    hPi' "A" (sort . tmSort <$> a) $ \ bA ->
+    hPi' "x" (el' a bA) $ \ x ->
+    hPi' "y" (el' a bA) $ \ y ->
+    el' a (cl primId <#> a <#> bA <@> x <@> y)
+    --> primIntervalType
+
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 5 $ \case
+    [l,bA,x,y,t] -> do
+      st <- reduceB' t
+      mConId <- getName' builtinConId
+      cview <- conidView'
+      case cview (unArg x) $ unArg (ignoreBlocking st) of
+        Just (phi, _) -> redReturn (unArg phi)
+        _ -> return $ NoReduction $ map notReduced [l,bA,x,y] ++ [reduced st]
+    _ -> __IMPOSSIBLE__
+
+-- | Extract the underlying path from an inhabitant of the
+-- cubical identity types.
+primIdPath' :: TCM PrimitiveImpl
+primIdPath' = do
+  requireCubical CErased ""
+  t <- runNamesT [] $
+    hPi' "a" (el $ cl primLevel) $ \ a ->
+    hPi' "A" (sort . tmSort <$> a) $ \ bA ->
+    hPi' "x" (el' a bA) $ \ x ->
+    hPi' "y" (el' a bA) $ \ y ->
+    el' a (cl primId <#> a <#> bA <@> x <@> y)
+    --> el' a (cl primPath <#> a <#> bA <@> x <@> y)
+
+  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 5 $ \case
+    [l,bA,x,y,t] -> do
+      st <- reduceB' t
+      mConId <- getName' builtinConId
+      cview <- conidView'
+      case cview (unArg x) $ unArg (ignoreBlocking st) of
+        Just (_, w) -> redReturn (unArg w)
+        _ -> return $ NoReduction $ map notReduced [l,bA,x,y] ++ [reduced st]
+    _ -> __IMPOSSIBLE__
+
+-- | Check that a term matches a given predicate on every consistent
+-- substitution of interval variables which makes the given cofibration
+-- hold.
+onEveryFace
+  :: Term -- ^ The cofibration @φ@
+  -> Term -- ^ The term to test
+  -> (Term -> Bool)
+  -- ^ The predicate to test with.
+  -> ReduceM Bool
+onEveryFace phi u p = do
+  unview <- intervalUnview'
+  let boolToI b = if b then unview IOne else unview IZero
+  as <- decomposeInterval phi
+  bools <- for as $ \ (bs,ts) -> do
+    let u' = listS (IntMap.toAscList $ IntMap.map boolToI bs) `applySubst` u
+    t <- reduce2Lam u'
+    return $! p $ ignoreBlocking t
+  pure (and bools)
+
+doIdKanOp
+  :: KanOperation           -- ^ Are we composing or transporting?
+  -> FamilyOrNot (Arg Term) -- ^ Level argument
+  -> FamilyOrNot (Arg Term, Arg Term, Arg Term)
+    -- ^ Domain, left and right endpoints of the identity type
+  -> ReduceM (Maybe (Reduced t Term))
+doIdKanOp kanOp l bA_x_y = do
+  let getTermLocal = getTerm $ kanOpName kanOp ++ " for " ++ builtinId
+
+  unview <- intervalUnview'
+  mConId <- getName' builtinConId
+  cview <- conidView'
+  let isConId t = isJust $ cview __DUMMY_TERM__ t
+
+  sa0 <- reduceB' (kanOpBase kanOp)
+  -- TODO: wasteful to compute b even when cheaper checks might fail
+  --
+  -- Should we go forward with the Kan operation? This is the case when
+  -- doing transport always, and when every face fo the partial element
+  -- has reduced to @conid@ otherwise. Note that @conidView@ treats
+  -- @reflId@ as though it were @conid i1 refl@.
+  b <- case kanOp of
+    TranspOp{}    -> return True
+    HCompOp _ u _ ->
+      onEveryFace (unArg . ignoreBlocking . kanOpCofib $ kanOp) (unArg u) isConId
+
+  case mConId of
+    Just conid | isConId (unArg . ignoreBlocking $ sa0), b -> (Just <$>) . (redReturn =<<) $ do
+      tHComp    <- getTermLocal builtinHComp
+      tTrans    <- getTermLocal builtinTrans
+      tIMin     <- getTermLocal "primDepIMin"
+      idFace    <- getTermLocal "primIdFace"
+      idPath    <- getTermLocal "primIdPath"
+      tPathType <- getTermLocal builtinPath
+      tConId    <- getTermLocal builtinConId
+
+      runNamesT [] $ do
+        let
+          io = pure $ unview IOne
+          iz = pure $ unview IZero
+          conId = pure tConId
+
+          eval TranspOp{} l bA phi _ u0 =
+            pure tTrans <#> l <@> bA <@> phi <@> u0
+          eval HCompOp{} l bA phi u u0 =
+            pure tHComp <#> (l <@> io) <#> (bA <@> io) <#> phi <@> u <@> u0
+
+        -- Compute a line of levels. So we can invoke 'eval' uniformly.
+        l <- case l of
+          IsFam l -> open . unArg $ l
+          IsNot l -> open (Lam defaultArgInfo $ NoAbs "_" $ unArg l)
+
+        p0 <- open . unArg $ kanOpBase kanOp
+
+        -- p is the partial element we are extending against. This is
+        -- used to compute the resulting cofibration, so we fake a
+        -- partial element when doing transport.
+        p <- case kanOp of
+          HCompOp _ u _ -> do
+            u <- open . unArg $ u
+            pure $ \i o -> u <@> i <..> o
+          TranspOp{} -> do
+            pure $ \i o -> p0
+
+        phi <- open . unArg . ignoreBlocking $ kanOpCofib kanOp
+
+        -- Similarly to the fake line of levels above, fake lines of
+        -- everything even when we're doing composition, for uniformity
+        -- of eval.
+        [bA, x, y] <- case bA_x_y of
+          IsFam (bA, x, y) -> for [bA, x, y] $ \a ->
+            open $ runNames [] $ lam "i" (const (pure $ unArg a))
+          IsNot (bA, x, y) -> for [bA, x, y] $ \a ->
+            open (Lam defaultArgInfo $ NoAbs "_" $ unArg a)
+
+        -- The resulting path is constant when when
+        --    @Σ φ λ o → -- primIdFace p i1 o@
+        -- holds. That's why cofibrations have to be closed under Σ,
+        -- c.f. primDepIMin.
+        cof <- pure tIMin
+          <@> phi
+          <@> ilam "o" (\o ->
+            pure idFace <#> (l <@> io) <#> (bA <@> io) <#> (x <@> io) <#> (y <@> io) <@> (p io o))
+
+        -- Do the Kan operation for our faces in the Path type.
+        path <- eval kanOp l
+          (lam "i" $ \i -> pure tPathType <#> (l <@> i) <#> (bA <@> i) <@> (x <@> i) <@> (y <@> i))
+          phi
+          (lam "i" $ \i -> ilam "o" $ \o ->
+            pure idPath <#> (l <@> i) <#> (bA <@> i) <#> (x <@> i) <#> (y <@> i) <@> (p i o))
+          (pure idPath <#> (l <@> iz) <#> (bA <@> iz) <#> (x <@> iz) <#> (y <@> iz) <@> p0)
+
+        conId <#> (l <@> io) <#> (bA <@> io) <#> (x <@> io) <#> (y <@> io)
+          <@> pure cof
+          <@> pure path
+    _ -> return $ Nothing

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Id.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Id.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 -- | Implementation of the primitives relating to Cubical identity types.
 module Agda.TypeChecking.Primitive.Cubical.Id
   ( -- * General elimination form

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -53,7 +53,7 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Reduce.Monad
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
-import Agda.TypeChecking.Primitive.Cubical
+import Agda.TypeChecking.Primitive.Cubical.Base
 
 import Agda.Utils.Either
 import Agda.Utils.Functor

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -30,7 +30,7 @@ import Agda.TypeChecking.Records
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
-import Agda.TypeChecking.Primitive.Cubical
+import Agda.TypeChecking.Primitive.Cubical.Base
 
 import Agda.Utils.Either
 import Agda.Utils.Functor

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -34,7 +34,7 @@ import Agda.TypeChecking.CompiledClause.Compile
 import Agda.TypeChecking.Rules.Data
   ( getGeneralizedParameters, bindGeneralizedParameters, bindParameters
   , checkDataSort, fitsIn, forceSort
-  , defineCompData, defineTranspOrHCompForFields
+  , defineCompData, defineKanOperationForFields
   )
 import Agda.TypeChecking.Rules.Term ( isType_ )
 import {-# SOURCE #-} Agda.TypeChecking.Rules.Decl (checkDecl)
@@ -428,8 +428,8 @@ defineCompKitR name params fsT fns rect = do
   reportSDoc "tc.rec.cxt" 30 $ prettyTCM fsT
   reportSDoc "tc.rec.cxt" 30 $ pretty rect
   if not $ all isJust required then return $ emptyCompKit else do
-    transp <- whenDefined [builtinTrans]              (defineTranspOrHCompR DoTransp name params fsT fns rect)
-    hcomp  <- whenDefined [builtinTrans,builtinHComp] (defineTranspOrHCompR DoHComp name params fsT fns rect)
+    transp <- whenDefined [builtinTrans]              (defineKanOperationR DoTransp name params fsT fns rect)
+    hcomp  <- whenDefined [builtinTrans,builtinHComp] (defineKanOperationR DoHComp name params fsT fns rect)
     return $ CompKit
       { nameOfTransp = transp
       , nameOfHComp  = hcomp
@@ -440,17 +440,17 @@ defineCompKitR name params fsT fns rect = do
       if all isJust xs then m else return Nothing
 
 
-defineTranspOrHCompR ::
-  TranspOrHComp
+defineKanOperationR
+  :: Command
   -> QName       -- ^ some name, e.g. record name
   -> Telescope   -- ^ param types Δ
   -> Telescope   -- ^ fields' types Δ ⊢ Φ
   -> [Arg QName] -- ^ fields' names
   -> Type        -- ^ record type Δ ⊢ T
   -> TCM (Maybe QName)
-defineTranspOrHCompR cmd name params fsT fns rect = do
+defineKanOperationR cmd name params fsT fns rect = do
   let project = (\ t fn -> t `applyE` [Proj ProjSystem fn])
-  stuff <- fmap fst <$> defineTranspOrHCompForFields cmd Nothing project name params fsT fns rect
+  stuff <- fmap fst <$> defineKanOperationForFields cmd Nothing project name params fsT fns rect
 
   caseMaybe stuff (return Nothing) $ \ (theName, gamma, rtype, clause_types, bodies) -> do
   -- phi = 1 clause

--- a/test/Succeed/CubicalPrims.agda
+++ b/test/Succeed/CubicalPrims.agda
@@ -134,9 +134,11 @@ module HCompPathP {ℓ} {A : I → Set ℓ} (u : A i0) (v : A i1) (φ : I)
   test-hcompPathP : hcompPathP ≡ primHComp p (outS p0)
   test-hcompPathP = refl
 
-module TranspPathP {ℓ} {A : I → I → Set ℓ} (u : ∀ i → A i i0)(v : ∀ i → A i i1)
-                  (let C = λ (i : I) → PathP (A i) (u i) (v i))
-                  (p0 : C i0) where
+module TranspPathP
+  {ℓ : I → Level} {A : (i : I) → I → Set (ℓ i)}
+  (u : ∀ i → A i i0)(v : ∀ i → A i i1)
+  (let C = λ (i : I) → PathP (A i) (u i) (v i))
+  (p0 : C i0) where
  φ = i0
  transpPathP : C i1
  transpPathP j = primComp (λ i → A i j)

--- a/test/interaction/Issue4679.out
+++ b/test/interaction/Issue4679.out
@@ -4,6 +4,6 @@
 (agda2-status-action "")
 (agda2-info-action "*All Goals, Errors*" "?0 : Foo → Set ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: ?0 (baz tt) =< ⊥ (blocked on _B_35) Unit =< ?0 (bar tt) (blocked on _B_35) " nil)
 ((last . 1) . (agda2-goals-action '(0)))
-(agda2-info-action "*Error*" "1,1-43 ((λ { (bar _) → Unit ; (baz _) → ⊥ ; _ → ⊥ ; (primHComp {.Agda.Primitive.lzero} {.Foo} {φ = φ} u a) → primComp (λ i → Set) (λ i .o → .extendedlambda0 p₁ (u i _)) (.extendedlambda0 p₁ a) }) x) != ⊥ of type Set when checking the definition of .extendedlambda0" nil)
+(agda2-info-action "*Error*" "1,1-43 ((λ { (bar _) → Unit ; (baz _) → ⊥ ; _ → ⊥ ; (primHComp {.Agda.Primitive.lzero} {.Foo} {φ = φ} u a) → primHComp (λ i .o → transp (λ i₁ → Set) i (.extendedlambda0 p₁ (u i _))) (transp (λ i → Set) i0 (.extendedlambda0 p₁ a)) }) x) != ⊥ of type Set when checking the definition of .extendedlambda0" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")


### PR DESCRIPTION
Step one in my evil plan to replace abuses of the interval by a proper cofibration classifier is to clean up _all_ the Cubical Agda primitives. Here's ~60% of them.