### PR TITLE
Allow elision of inS/outS by coercive subtyping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,9 @@ Language
   symId reflId = reflId
   ```
 
+* Agda will automatically insert `inS`/`outS` when a value of type `Sub
+  A φ p` is used where one of type `A` is expected, and vice-versa.
+
 Syntax
 ------
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -432,7 +432,15 @@ one has ``outS a = u 1=1``.
 With all of this cubical infrastructure we can now describe the
 ``hcomp`` operations.
 
+In situations where a cubical subtype is used instead of a fibrant type,
+or vice-versa, Agda will insert `inS` and `outS` implicitly. As a silly
+example,
 
+::
+
+  module _ {φ} {A : Set} {P : Partial φ A} (s : A [ φ ↦ P ]) where
+    _ : A
+    _ = s
 
 Homogeneous composition
 -----------------------

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -438,9 +438,8 @@ example,
 
 ::
 
-  module _ {φ} {A : Set} {P : Partial φ A} (s : A [ φ ↦ P ]) where
-    _ : A
-    _ = s
+  example : ∀ {φ} {A : Set} {P : Partial φ A} (s : A [ φ ↦ P ]) → A
+  example s = s
 
 Homogeneous composition
 -----------------------

--- a/test/Fail/CubicalSubtype1.agda
+++ b/test/Fail/CubicalSubtype1.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --cubical --safe #-}
+module CubicalSubtype1 where
+
+open import Agda.Primitive renaming (_⊔_ to ℓ-max)
+open import Agda.Primitive.Cubical renaming (primIMin to _∧_; primIMax to _∨_; primINeg to ~_; isOneEmpty to empty)
+open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to outS)
+open import Agda.Builtin.Cubical.Path
+
+module _ {φ} {A B : Set} {P : Partial φ A} (s : A [ φ ↦ P ]) where
+  _ : B
+  _ = s
+  -- A !≤ B
+  -- projected the partial element but does not let us cheat the type
+  -- checker (ok, it doesn't let us cheat the type checker *that* much)

--- a/test/Fail/CubicalSubtype1.err
+++ b/test/Fail/CubicalSubtype1.err
@@ -1,0 +1,3 @@
+CubicalSubtype1.agda:11,7-8
+A !=< B
+when checking that the expression s has type B

--- a/test/Fail/CubicalSubtype2.agda
+++ b/test/Fail/CubicalSubtype2.agda
@@ -1,0 +1,13 @@
+{-# OPTIONS --cubical --safe #-}
+module CubicalSubtype2 where
+
+open import Agda.Primitive renaming (_⊔_ to ℓ-max)
+open import Agda.Primitive.Cubical renaming (primIMin to _∧_; primIMax to _∨_; primINeg to ~_; isOneEmpty to empty)
+open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to outS)
+
+module _ {φ} {A : Set} {P : Partial φ A} (s : A) where
+  _ : A [ φ ↦ P ]
+  _ = s
+  -- s != P
+  -- included into partial element but φ ⊢ s ≠ P. so boundaries are
+  -- preserved.

--- a/test/Fail/CubicalSubtype2.err
+++ b/test/Fail/CubicalSubtype2.err
@@ -1,0 +1,3 @@
+CubicalSubtype2.agda:10,7-8
+s != P _ of type A
+when checking that the expression s has type A [ φ ↦ P ]

--- a/test/Succeed/CubicalSubtyping.agda
+++ b/test/Succeed/CubicalSubtyping.agda
@@ -1,0 +1,30 @@
+{-# OPTIONS --cubical --safe #-}
+module CubicalSubtyping where
+
+open import Agda.Primitive renaming (_⊔_ to ℓ-max)
+open import Agda.Primitive.Cubical renaming (primIMin to _∧_; primIMax to _∨_; primINeg to ~_; isOneEmpty to empty)
+open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to outS)
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.Cubical.Glue renaming (primGlue to Glue; prim^glue to glue; prim^unglue to unglue)
+open Helpers
+
+module _ {φ} {A : Set} {P : Partial φ A} (s : A [ φ ↦ P ]) where
+  -- Can project implicitly:
+  _ : A
+  _ = s
+
+  -- Can project explicitly:
+  _ : A
+  _ = outS s
+
+  -- Can refer as extension type:
+  _ : A [ φ ↦ P ]
+  _ = s
+
+_ : {ℓ : Level} {A : Set ℓ} {w x y z : A}
+  → w ≡ x → x ≡ y → y ≡ z → I → A
+_ = λ p q r i →
+  hfill (λ { j (i = i0) → p (~ j) ; j (i = i1) → r j }) (q i) i
+--                                                      ^^^^^
+-- Can include automatically with non-trivial comparison between actual
+-- term and given partial element


### PR DESCRIPTION
If coercive subtyping is being applied across different sorts, we can insert `inS` and `outS` without harming type inference. More precisely, if we have `x : Sub A φ p` and we want to coerce it into some fibrant type `T`, then we can just as well coerce `(outS x) : A` into `T`.

This alleviates the need for #3715:

```agda
_ : {ℓ : Level} {A : Set ℓ} {w x y z : A}
  → w ≡ x → x ≡ y → y ≡ z → I → A
_ = λ p q r i →
  hfill (λ { j (i = i0) → p (~ j) ; j (i = i1) → r j }) 
    (q i) i
--  ^ look, ma! no inS!
```

It should also be feasible to use extension types to encode the magic type-checking rules of the cubical primitives, but this is a rather large change which I do not want to pursue (yet?).