### PR TITLE
Refine #5672 (fix for #5600)

### DIFF
--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -974,7 +974,7 @@ tryReduceNonRecursiveClause g es continue fallback = do
 
   -- Finally, try to reduce with the non-recursive clauses (and no rewrite rules).
   r <- liftTCM $ modifyAllowedReductions (SmallSet.delete UnconfirmedReductions) $
-    runReduceM $ appDefE' v0 cls [] (map notReduced es)
+    runReduceM $ appDefE' g v0 cls [] (map notReduced es)
   case r of
     NoReduction{}    -> fallback
     YesReduction _ v -> do

--- a/src/full/Agda/TypeChecking/CompiledClause/Match.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Match.hs
@@ -198,7 +198,7 @@ match' [] = {- new line here since __IMPOSSIBLE__ does not like the ' in match' 
   caseMaybeM (asksTC envAppDef) __IMPOSSIBLE__ $ \ f -> do
     pds <- getPartialDefs
     if f `elem` pds
-    then return (NoReduction $ NotBlocked MissingClauses [])
+    then return (NoReduction $ NotBlocked (MissingClauses f) [])
     else do
       ifM (optRewriting <$> pragmaOptions)
       {-then-} (return (NoReduction $ NotBlocked ReallyNotBlocked [])) -- See #5396

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -448,8 +448,8 @@ computeElimHeadType f es es' = do
 abortIfMissingClauses :: (Blocked Term, Blocked Term) -> Blocker
 abortIfMissingClauses (NotBlocked nb t, NotBlocked nb' t') =
   case nb <> nb' of
-    MissingClauses -> alwaysUnblock
-    _              -> neverUnblock
+    MissingClauses _ -> alwaysUnblock
+    _                -> neverUnblock
 abortIfMissingClauses _ = __IMPOSSIBLE__
 
 
@@ -470,7 +470,7 @@ compareAtom cmp t m n =
         -- re #5600: We might add more clauses to the function later,
         --           so we shouldn't commit to an UnequalTerms error yet,
         --           even if there are no metas blocking computation.
-        blockIfMissingClauses (NotBlocked MissingClauses t) = Blocked alwaysUnblock t
+        blockIfMissingClauses (NotBlocked MissingClauses{} t) = Blocked alwaysUnblock t
         blockIfMissingClauses b@NotBlocked{} = b
     -- Andreas: what happens if I cut out the eta expansion here?
     -- Answer: Triggers issue 245, does not resolve 348

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -834,7 +834,7 @@ instance AnyRigid Term where
         -- If the definition is incomplete, arguments might disappear
         -- by reductions that come with more clauses, thus, these
         -- arguments are not rigid.
-        NotBlocked MissingClauses _ -> return False
+        NotBlocked (MissingClauses _) _ -> return False
         -- _        -> mempty -- breaks: ImproveInertRHS, Issue442, PruneRecord, PruningNonMillerPattern
         _        -> anyRigid f es
       Con _ _ ts -> anyRigid f ts

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3037,7 +3037,7 @@ data TCEnv =
                 -- these will become unsolved metas.
           , envAppDef :: Maybe QName
                 -- ^ We are reducing an application of this function.
-                -- (For debugging of incomplete matches only.)
+                -- (For tracking of incomplete matches.)
           , envSimplification :: Simplification
                 -- ^ Did we encounter a simplification (proper match)
                 --   during the current reduction process?

--- a/src/full/Agda/TypeChecking/Monad/Mutual.hs
+++ b/src/full/Agda/TypeChecking/Monad/Mutual.hs
@@ -66,14 +66,11 @@ setMutualBlock i x = do
 currentOrFreshMutualBlock :: TCM MutualId
 currentOrFreshMutualBlock = maybe fresh return =<< asksTC envMutualBlock
 
-lookupMutualBlock :: MutualId -> TCM MutualBlock
-lookupMutualBlock mi = do
-  mbs <- useTC stMutualBlocks
-  case Map.lookup mi mbs of
-    Just mb -> return mb
-    Nothing -> return empty -- can end up here if we ask for the current mutual block and there is none
+lookupMutualBlock :: ReadTCState tcm => MutualId -> tcm MutualBlock
+lookupMutualBlock mi = Map.findWithDefault empty mi <$> useTC stMutualBlocks
+   -- can be empty if we ask for the current mutual block and there is none
 
--- | Reverse lookup of a mutual block id for a names.
+-- | Reverse lookup of a mutual block id for a name.
 mutualBlockOf :: QName -> TCM MutualId
 mutualBlockOf x = do
   mb <- Map.toList <$> useTC stMutualBlocks

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -272,7 +272,7 @@ matchPattern p u = case (p, u) of
         t@(Def q [l,a,x,y,phi,p]) | Just q == mconid
                 -> Just t
         -- TODO this covers the transpIx functions, but it's a hack.
-        t@(Def q _) | NotBlocked{blockingStatus = MissingClauses} <- r -> Just t
+        t@(Def q _) | NotBlocked{blockingStatus = MissingClauses _} <- r -> Just t
         _       -> Nothing
 
   -- DefP hcomp and ConP matching.

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1,6 +1,29 @@
 {-# LANGUAGE NondecreasingIndentation #-}
 
-module Agda.TypeChecking.Reduce where
+module Agda.TypeChecking.Reduce
+ -- Meta instantiation
+ ( Instantiate, instantiate', instantiate, instantiateWhen
+ -- Recursive meta instantiation
+ , InstantiateFull, instantiateFull', instantiateFull
+ , instantiateFullExceptForDefinitions
+ -- Check for meta (no reduction)
+ , IsMeta, isMeta
+ -- Reduction and blocking
+ , Reduce, reduce', reduceB', reduce, reduceB, reduceWithBlocker, reduceIApply'
+ , reduceDefCopy, reduceDefCopyTCM
+ , reduceHead
+ , slowReduceTerm
+ , unfoldCorecursion, unfoldCorecursionE
+ , unfoldDefinitionE, unfoldDefinitionStep
+ , unfoldInlined
+ , appDef', appDefE'
+ , abortIfBlocked, ifBlocked, isBlocked
+ -- Simplification
+ , Simplify, simplify, simplifyBlocked'
+ -- Normalization
+ , Normalise, normalise', normalise
+ , slowNormaliseArgs
+ ) where
 
 import Control.Monad ( (>=>), void )
 
@@ -92,10 +115,11 @@ withReduced a cont = ifBlocked a (\b a' -> addOrUnblocker b $ cont a') (\_ a' ->
 normalise :: (Normalise a, MonadReduce m) => a -> m a
 normalise = liftReduce . normalise'
 
--- | Normalise the given term but also preserve blocking tags
---   TODO: implement a more efficient version of this.
-normaliseB :: (MonadReduce m, Reduce t, Normalise t) => t -> m (Blocked t)
-normaliseB = normalise >=> reduceB
+-- UNUSED
+-- -- | Normalise the given term but also preserve blocking tags
+-- --   TODO: implement a more efficient version of this.
+-- normaliseB :: (MonadReduce m, Reduce t, Normalise t) => t -> m (Blocked t)
+-- normaliseB = normalise >=> reduceB
 
 simplify :: (Simplify a, MonadReduce m) => a -> m a
 simplify = liftReduce . simplify'

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -1263,7 +1263,7 @@ reduceTm rEnv bEnv !constInfo normalisation ReductionFlags{..} =
             (spine0, Proj o p : spine1) ->
               case lookupCon p bs <|> ((`lookupCon` bs) =<< op) of
                 Nothing
-                  | f `elem` partialDefs -> stuckMatch (NotBlocked MissingClauses ()) stack ctrl
+                  | f `elem` partialDefs -> stuckMatch (NotBlocked (MissingClauses f) ()) stack ctrl
                   | otherwise          -> __IMPOSSIBLE__
                 Just cc -> runAM (Match f cc (spine0 <> spine1) stack ctrl)
               where CFun{ cfunProjection = op } = cdefDef (constInfo p)
@@ -1386,8 +1386,8 @@ reduceTm rEnv bEnv !constInfo normalisation ReductionFlags{..} =
     failedMatch f (CatchAll cc spine : stack :> cl) ctrl = runAM (Match f cc spine (stack :> cl) ctrl)
     failedMatch f ([] :> cl) ctrl
         -- Bad work-around for #3870: don't fail hard during instance search.
-      | speculative          = rewriteAM (Eval (mkValue (NotBlocked MissingClauses ()) cl) ctrl)
-      | f `elem` partialDefs = rewriteAM (Eval (mkValue (NotBlocked MissingClauses ()) cl) ctrl)
+      | speculative          = rewriteAM (Eval (mkValue (NotBlocked (MissingClauses f) ()) cl) ctrl)
+      | f `elem` partialDefs = rewriteAM (Eval (mkValue (NotBlocked (MissingClauses f) ()) cl) ctrl)
       | hasRewriting         = rewriteAM (Eval (mkValue (NotBlocked ReallyNotBlocked ()) cl) ctrl)  -- See #5396
       | otherwise            = runReduce $
           traceSLn "impossible" 10 ("Incomplete pattern matching when applying " ++ prettyShow f)

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -637,8 +637,8 @@ checkAxiom' gentel kind i info0 mp x e = whenAbstractFreezeMetasAfter i $ defaul
 
   -- Set blocking tag to MissingClauses if we still expect clauses
   let blk = case kind of
-        FunName   -> NotBlocked MissingClauses   ()
-        MacroName -> NotBlocked MissingClauses   ()
+        FunName   -> NotBlocked (MissingClauses x) ()
+        MacroName -> NotBlocked (MissingClauses x) ()
         _         -> NotBlocked ReallyNotBlocked ()
 
   -- Not safe. See Issue 330

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -82,7 +82,7 @@ checkFunDef :: Delayed -> A.DefInfo -> QName -> [A.Clause] -> TCM ()
 checkFunDef delayed i name cs = do
         -- Reset blocking tag (in case a previous attempt was blocked)
         modifySignature $ updateDefinition name $ updateDefBlocked $ const $
-          NotBlocked MissingClauses ()
+          NotBlocked (MissingClauses name) ()
         -- Get the type and relevance of the function
         def <- instantiateDef =<< getConstInfo name
         let t    = defType def
@@ -611,7 +611,7 @@ checkSystemCoverage f [n] t cs = do
                   TelV delta _ <- telViewUpTo extra t'
                   fmap (abstract delta) $ addContext delta $ do
                     fmap fromReduced $ runReduceM $
-                      appDef' (Def f []) [cl] [] (map notReduced $ raise (size delta) args ++ teleArgs delta)
+                      appDef' f (Def f []) [cl] [] (map notReduced $ raise (size delta) args ++ teleArgs delta)
             v1 <- body cl1
             v2 <- body cl2
             equalTerm t' v1 v2

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -83,7 +83,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20220708 * 10 + 0
+currentInterfaceVersion = 20220829 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -219,14 +219,14 @@ instance EmbPrj NotBlocked where
   icod_ (StuckOn a)      = icodeN 0 StuckOn a
   icod_ Underapplied     = icodeN 1 Underapplied
   icod_ AbsurdMatch      = icodeN 2 AbsurdMatch
-  icod_ MissingClauses   = icodeN 3 MissingClauses
+  icod_ (MissingClauses a) = icodeN 3 MissingClauses a
 
   value = vcase valu where
     valu []     = valuN ReallyNotBlocked
     valu [0, a] = valuN StuckOn a
     valu [1]    = valuN Underapplied
     valu [2]    = valuN AbsurdMatch
-    valu [3]    = valuN MissingClauses
+    valu [3, a] = valuN MissingClauses a
     valu _      = malformed
 
 instance EmbPrj Blocked_ where

--- a/test/Fail/IncompletePatternMatching.err
+++ b/test/Fail/IncompletePatternMatching.err
@@ -3,7 +3,6 @@ Incomplete pattern matching for _==_. Missing cases:
   zero == suc x
   suc x == zero
 when checking the definition of _==_
-Failed to solve the following constraints:
-  True =< zero == suc zero
-Unsolved metas at the following locations:
-  IncompletePatternMatching.agda:18,7-9
+IncompletePatternMatching.agda:18,7-9
+True !=< zero == suc zero
+when checking that the expression tt has type zero == suc zero

--- a/test/Fail/Issue3012.err
+++ b/test/Fail/Issue3012.err
@@ -2,7 +2,6 @@ Issue3012.agda:12,1-15
 Incomplete pattern matching for partial. Missing cases:
   snd (partial x)
 when checking the definition of partial
-Failed to solve the following constraints:
-  partial x .snd = x : A
-Unsolved metas at the following locations:
-  Issue3012.agda:17,13-17
+Issue3012.agda:17,13-17
+partial x .snd != x of type A
+when checking that the expression refl has type partial x .snd ≡ x

--- a/test/Internal/Syntax/Internal.hs
+++ b/test/Internal/Syntax/Internal.hs
@@ -7,17 +7,19 @@ import Agda.TypeChecking.Substitute ()
 
 import Internal.Helpers
 import Internal.Syntax.Common ()
+import Internal.Syntax.Abstract.Name ()
 
 ------------------------------------------------------------------------
 -- Instances
 
 instance Arbitrary NotBlocked where
-  arbitrary = elements [ Underapplied
-                       , AbsurdMatch
-                       , MissingClauses
-                       , ReallyNotBlocked
-                       -- , StuckOn Elim  -- TODO
-                       ]
+  arbitrary = oneof
+    [ pure Underapplied
+    , pure AbsurdMatch
+    , MissingClauses <$> arbitrary
+    , pure ReallyNotBlocked
+    -- , StuckOn Elim  -- TODO
+    ]
 
 instance Arbitrary (Blocked ()) where
   arbitrary = do

--- a/test/Succeed/Issue5600.agda
+++ b/test/Succeed/Issue5600.agda
@@ -1,0 +1,29 @@
+-- Issue #5600, reported 2021-10-14 by Samuel Mimram.
+-- Dependency on cubical library removed by Nisse.
+-- Issue fixed 2021-11-24 by Andrea in #5672.
+-- Test added 2022-08-29 by Andreas.
+
+{-# OPTIONS --cubical #-}
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.Nat
+
+refl : {A : Set₁} (x : A) → x ≡ x
+refl x = λ _ → x
+
+mutual
+
+  data A : Set₁ where
+    s : A → A
+    e : {k : Nat} {n : A} → refl (f (suc zero) n) ≡ refl (s n)
+
+  f : Nat → A → A
+  f zero    n = n
+  f (suc k) n = s (f k n)
+
+-- Should succeed.
+--
+-- Error was:
+-- s n != f 1 n of type A
+-- when checking that the expression refl {x = s n} has type
+-- f 1 n ≡ f 1 n


### PR DESCRIPTION
Refine #5672 (fix for #5600).

Only `alwaysUnblock` when comparing `MissingClauses f` neutrals for a function `f` of the current mutual block.

This was suggested by @Saizan in https://github.com/agda/agda/issues/5600#issuecomment-964052741 but the implementation in #5672 did not include the check of whether the missing clauses are from a function of the current mutual block (and hence have hope to be filled in still...).

Unfortunately, this refinement does not fix #6008.

Still, the code is worth merging imo, as adding the extra information to `MissingClauses` can come in handy in other situations; and, it might fix some other, yet unreported problem...