### PR TITLE
add 'Z NOTATION SCHEMA COMPOSITION' to \;

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -299,7 +299,7 @@ order for the change to take effect."
   (".-"        . ("∸"))
   (":"         . ,(agda-input-to-string-list "∶⦂ː꞉˸፥፦：﹕︓"))
   (","         . ,(agda-input-to-string-list "ʻ،⸲⸴⹁⹉、︐︑﹐﹑，､"))
-  (";"         . ,(agda-input-to-string-list "؛⁏፤꛶；︔﹔⍮⸵;"))
+  (";"         . ,(agda-input-to-string-list "⨟؛⁏፤꛶；︔﹔⍮⸵;"))
   ("::"        . ("∷"))
   ("::-"       . ("∺"))
   ("-:"        . ("∹"))

--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -299,7 +299,7 @@ order for the change to take effect."
   (".-"        . ("∸"))
   (":"         . ,(agda-input-to-string-list "∶⦂ː꞉˸፥፦：﹕︓"))
   (","         . ,(agda-input-to-string-list "ʻ،⸲⸴⹁⹉、︐︑﹐﹑，､"))
-  (";"         . ,(agda-input-to-string-list "⨟؛⁏፤꛶；︔﹔⍮⸵;"))
+  (";"         . ,(agda-input-to-string-list "؛⨾⨟⁏፤꛶；︔﹔⍮⸵;"))
   ("::"        . ("∷"))
   ("::-"       . ("∺"))
   ("-:"        . ("∹"))


### PR DESCRIPTION
The `Z NOTATION TYPE COLON` is already available in `\:` as well as `\z:`, so I think it makes sense for the z semicolon to be in `\;` as well as `\z;`.