### PR TITLE
Fix for #5462

### DIFF
--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -877,7 +877,8 @@ computeNeighbourhood delta1 n delta2 d pars ixs hix tel ps cps c = do
 
   -- Lookup the type of the constructor at the given parameters
   (gamma0, cixs, boundary) <- do
-    (TelV gamma0 (El _ d), boundary) <- liftTCM $ telViewPathBoundaryP (ctype `piApply` pars)
+    (TelV gamma0 (El _ d), boundary) <- liftTCM $ addContext delta1 $
+      telViewPathBoundaryP (ctype `piApply` pars)
     let Def _ es = d
         Just cixs = allApplyElims es
     return (gamma0, cixs, boundary)
@@ -907,7 +908,7 @@ computeNeighbourhood delta1 n delta2 d pars ixs hix tel ps cps c = do
   -- Andrea 2019-07-17 propagate the Cohesion to the equation telescope
   -- TODO: should we propagate the modality in general?
   -- See also LHS checking.
-  dtype <- do
+  dtype <- addContext delta1 $ do
          let updCoh = composeCohesion (getCohesion info)
          TelV dtel dt <- telView dtype
          return $ abstract (mapCohesion updCoh <$> dtel) dt
@@ -1289,7 +1290,7 @@ split' checkEmpty ind allowPartialCover inserttrailing
                 ]
               throwError (GenericSplitError "precomputed set of constructors does not cover all cases")
 
-      liftTCM $ checkSortOfSplitVar dr (unDom t) delta2 target
+      liftTCM $ inContextOfT $ checkSortOfSplitVar dr (unDom t) delta2 target
       return $ Right $ Covering (lookupPatternVar sc x) ns
 
   where

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -196,13 +196,12 @@ checkInjectivity' f cs = fromMaybe NotInjective <.> runMaybeT $ do
   -- We don't need to consider absurd clauses
   let computeHead c | hasDefP (namedClausePats c) = return []
       -- hasDefP clauses are skipped, these matter only for --cubical, in which case the function will behave as NotInjective.
-      computeHead c@Clause{ clauseBody = Just body , clauseType = Just tbody } = do
+      computeHead c@Clause{ clauseBody = Just body , clauseType = Just tbody } = addContext (clauseTel c) $ do
         maybeIrr <- fromRight (const True) <.> runBlocked $ isIrrelevantOrPropM tbody
         h <- if maybeIrr then return UnknownHead else
           varToArg c =<< do
             lift $ fromMaybe UnknownHead <$> do
-              addContext (clauseTel c) $
-                headSymbol body
+              headSymbol body
         return [Map.singleton h [c]]
       computeHead _ = return []
 

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -352,7 +352,17 @@ checkRewriteRule q = do
     checkAxFunOrCon :: QName -> Definition -> TCM ()
     checkAxFunOrCon f def = case theDef def of
       Axiom{}        -> return ()
-      Function{}     -> return ()
+      def@Function{} -> whenJust (funProjection def) $ \proj ->
+        case projProper proj of
+          Just{} -> typeError . GenericDocError =<< hsep
+            [ prettyTCM q , " is not a legal rewrite rule, since the head symbol"
+            , prettyTCM f , "is a projection."
+            ]
+          Nothing -> typeError . GenericDocError =<< hsep
+            [ prettyTCM q , " is not a legal rewrite rule, since the head symbol"
+            , prettyTCM f , "is a projection-like function."
+            , "You can turn off the projection-like optimization with the flag --no-projection-like"
+            ]
       Constructor{}  -> return ()
       AbstractDefn{} -> return ()
       Primitive{}    -> return () -- TODO: is this fine?

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -356,7 +356,7 @@ checkRewriteRule q = do
         case projProper proj of
           Just{} -> typeError . GenericDocError =<< hsep
             [ prettyTCM q , " is not a legal rewrite rule, since the head symbol"
-            , prettyTCM f , "is a projection."
+            , prettyTCM f , "is a projection"
             ]
           Nothing -> typeError . GenericDocError =<< hsep
             [ prettyTCM q , " is not a legal rewrite rule, since the head symbol"

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -303,7 +303,7 @@ instance GetMatchables NLPat where
   getMatchables p =
     case p of
       PVar _ _       -> empty
-      PDef f _       -> singleton f
+      PDef f es      -> singleton f ++ getMatchables es
       PLam _ x       -> getMatchables x
       PPi a b        -> getMatchables (a,b)
       PSort s        -> getMatchables s

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1335,7 +1335,7 @@ checkLHS mf = updateModality checkLHS_ where
       -- Andrea 2019-07-17 propagate the Cohesion to the equation telescope
       -- TODO: should we propagate the modality in general?
       -- See also Coverage checking.
-      da' <- do
+      da' <- addContext delta1Gamma $ do
              let updCoh = composeCohesion (getCohesion info)
              TelV tel dt <- telView da'
              return $ abstract (mapCohesion updCoh <$> tel) a

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -272,6 +272,7 @@ unifyIndices' tel flex a us vs = do
 
 type UnifyStrategy = forall m. (PureTCM m, MonadPlus m) => UnifyState -> m UnifyStep
 
+
 --UNUSED Liang-Ting Chen 2019-07-16
 --leftToRightStrategy :: UnifyStrategy
 --leftToRightStrategy s =
@@ -348,7 +349,7 @@ basicUnifyStrategy k s = do
 
 dataStrategy :: Int -> UnifyStrategy
 dataStrategy k s = do
-  Equal Dom{unDom = a} u v <- eqConstructorForm =<< eqUnLevel =<< reduce (getEqualityUnraised k s)
+  Equal Dom{unDom = a} u v <- eqConstructorForm =<< eqUnLevel =<< getReducedEqualityUnraised k s
   sortOk <- reduce (getSort a) <&> \case
     Type{} -> True
     Inf{}  -> True
@@ -398,7 +399,7 @@ literalStrategy k s = do
 
 etaExpandVarStrategy :: Int -> UnifyStrategy
 etaExpandVarStrategy k s = do
-  Equal Dom{unDom = a} u v <- eqUnLevel <=< reduce $ getEquality k s
+  Equal Dom{unDom = a} u v <- eqUnLevel =<< getReducedEquality k s
   shouldEtaExpand u v a s `mplus` shouldEtaExpand v u a s
   where
     -- TODO: use IsEtaVar to check if the term is a variable
@@ -411,7 +412,9 @@ etaExpandVarStrategy k s = do
       -- record or if it's unified against a record constructor term. Basically
       -- we need to avoid EtaExpandEquation if EtaExpandVar is possible, or the
       -- forcing translation is unhappy.
-      b         <- reduce $ unDom $ getVarTypeUnraised (varCount s - 1 - i) s
+      let k  = varCount s - 1 - i -- position of var i in telescope
+          b0 = unDom $ getVarTypeUnraised k s
+      b         <- addContext (telFromList $ take k $ telToList $ varTel s) $ reduce b0
       (d, pars) <- catMaybesMP $ isEtaRecordType b
       ps        <- fromMaybeMP $ allProjElims es
       guard =<< orM
@@ -432,7 +435,7 @@ etaExpandVarStrategy k s = do
 etaExpandEquationStrategy :: Int -> UnifyStrategy
 etaExpandEquationStrategy k s = do
   -- Andreas, 2019-02-23, re #3578, is the following reduce redundant?
-  Equal Dom{unDom = a} u v <- reduce $ getEqualityUnraised k s
+  Equal Dom{unDom = a} u v <- getReducedEqualityUnraised k s
   (d, pars) <- catMaybesMP $ addContext tel $ isEtaRecordType a
   guard =<< orM
     [ (Right True ==) <$> runBlocked (isSingletonRecord d pars)
@@ -461,7 +464,7 @@ etaExpandEquationStrategy k s = do
 simplifySizesStrategy :: Int -> UnifyStrategy
 simplifySizesStrategy k s = do
   isSizeName <- isSizeNameTest
-  Equal Dom{unDom = a} u v <- reduce $ getEquality k s
+  Equal Dom{unDom = a} u v <- getReducedEquality k s
   case unEl a of
     Def d _ -> do
       guard $ isSizeName d
@@ -478,7 +481,7 @@ injectiveTypeConStrategy :: Int -> UnifyStrategy
 injectiveTypeConStrategy k s = do
   injTyCon <- optInjectiveTypeConstructors <$> pragmaOptions
   guard injTyCon
-  eq <- eqUnLevel <=< reduce $ getEquality k s
+  eq <- eqUnLevel =<< getReducedEquality k s
   case eq of
     Equal a u@(Def d es) v@(Def d' es') | d == d' -> do
       -- d must be a data, record or axiom
@@ -501,7 +504,7 @@ injectiveTypeConStrategy k s = do
 
 injectivePragmaStrategy :: Int -> UnifyStrategy
 injectivePragmaStrategy k s = do
-  eq <- eqUnLevel <=< reduce $ getEquality k s
+  eq <- eqUnLevel =<< getReducedEquality k s
   case eq of
     Equal a u@(Def d es) v@(Def d' es') | d == d' -> do
       -- d must have an injective pragma
@@ -514,8 +517,9 @@ injectivePragmaStrategy k s = do
 
 skipIrrelevantStrategy :: Int -> UnifyStrategy
 skipIrrelevantStrategy k s = do
-  let Equal a _ _ = getEquality k s                               -- reduce not necessary
-  guard . (== Right True) =<< runBlocked (isIrrelevantOrPropM a)  -- reduction takes place here
+  let Equal a _ _ = getEquality k s                                 -- reduce not necessary
+  addContext (varTel s `abstract` eqTel s) $
+    guard . (== Right True) =<< runBlocked (isIrrelevantOrPropM a)  -- reduction takes place here
   -- TODO: do something in case the above is blocked (i.e. `Left b`)
   return $ SkipIrrelevantEquation k
 
@@ -557,7 +561,7 @@ unifyStep s (Injectivity k a d pars ixs c) = do
   let ctype  = defType cdef `piApply` pars
   addContext (varTel s `abstract` eqTel1) $ reportSDoc "tc.lhs.unify" 40 $
     "Constructor type: " <+> prettyTCM ctype
-  TelV ctel ctarget <- telView ctype
+  TelV ctel ctarget <- addContext (varTel s `abstract` eqTel1) $ telView ctype
   let cixs = case unEl ctarget of
                Def d' es | d == d' ->
                  let args = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
@@ -607,10 +611,10 @@ unifyStep s (Injectivity k a d pars ixs c) = do
 
       tellUnifyProof rho
 
-      eqTel' <- reduce eqTel'
+      eqTel' <- addContext (varTel s) $ reduce eqTel'
 
       -- Compute new lhs and rhs by matching the old ones against rho
-      (lhs', rhs') <- do
+      (lhs', rhs') <- addContext (varTel s) $ do
         let ps = applySubst rho $ teleNamedArgs $ eqTel s
         (lhsMatch, _) <- Match.matchPatterns ps $ eqLHS s
         (rhsMatch, _) <- Match.matchPatterns ps $ eqRHS s
@@ -642,10 +646,10 @@ unifyStep s (Injectivity k a d pars ixs c) = do
 
       tellUnifyProof rho
 
-      eqTel' <- reduce eqTel'
+      eqTel' <- addContext (varTel s) $ reduce eqTel'
 
       -- Compute new lhs and rhs by matching the old ones against rho
-      (lhs', rhs') <- do
+      (lhs', rhs') <- addContext (varTel s) $ do
         let ps = applySubst rho $ teleNamedArgs $ eqTel s
         (lhsMatch, _) <- Match.matchPatterns ps $ eqLHS s
         (rhsMatch, _) <- Match.matchPatterns ps $ eqRHS s

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/Types.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/Types.hs
@@ -76,8 +76,12 @@ data Equality = Equal
   , _eqRight :: Term
   }
 
-instance Reduce Equality where
-  reduce' (Equal a u v) = Equal <$> reduce' a <*> reduce' u <*> reduce' v
+-- Jesper, 2020-01-19: The type type lives in the context of the
+-- variables+equations, while the lhs/rhs only depend on the
+-- variables, so there is no way to give a correct Reduce instance.
+-- WRONG:
+-- instance Reduce Equality where
+--   reduce' (Equal a u v) = Equal <$> reduce' a <*> reduce' u <*> reduce' v
 
 eqConstructorForm :: HasBuiltins m => Equality -> m Equality
 eqConstructorForm (Equal a u v) = Equal a <$> constructorForm u <*> constructorForm v
@@ -199,12 +203,32 @@ getEquality k UState { eqTel = eqs, eqLHS = lhs, eqRHS = rhs } =
           (unArg $ indexWithDefault __IMPOSSIBLE__ lhs k)
           (unArg $ indexWithDefault __IMPOSSIBLE__ rhs k)
 
+getReducedEquality
+  :: (MonadReduce m, MonadAddContext m)
+  => Int -> UnifyState -> m Equality
+getReducedEquality k s = do
+  let Equal a u v = getEquality k s
+  addContext (varTel s) $ Equal
+    <$> addContext (eqTel s) (reduce a)
+    <*> reduce u
+    <*> reduce v
+
 -- | As getEquality, but with the unraised type
 getEqualityUnraised :: Int -> UnifyState -> Equality
 getEqualityUnraised k UState { eqTel = eqs, eqLHS = lhs, eqRHS = rhs } =
     Equal (snd <$> indexWithDefault __IMPOSSIBLE__ (telToList eqs) k)
           (unArg $ indexWithDefault __IMPOSSIBLE__ lhs k)
           (unArg $ indexWithDefault __IMPOSSIBLE__ rhs k)
+
+getReducedEqualityUnraised
+  :: (MonadReduce m, MonadAddContext m)
+  => Int -> UnifyState -> m Equality
+getReducedEqualityUnraised k s = do
+  let Equal a u v = getEqualityUnraised k s
+  addContext (varTel s) $ Equal
+    <$> addContext (telFromList $ take k $ telToList $ eqTel s) (reduce a)
+    <*> reduce u
+    <*> reduce v
 
 --UNUSED Liang-Ting Chen 2019-07-16
 --getEqInfo :: Int -> UnifyState -> ArgInfo

--- a/test/Fail/Issue5462.agda
+++ b/test/Fail/Issue5462.agda
@@ -1,0 +1,85 @@
+{-# OPTIONS --rewriting --confluence-check #-}
+
+open import Agda.Primitive public
+
+infix 4 _≣_
+data _≣_
+  {l : Level}
+  {A : Set l}
+  : -------------------------------
+  {B : Set l}(x : A)(y : B) → Set l
+  where
+  instance refl : {x : A} → x ≣ x
+
+{-# BUILTIN REWRITE _≣_ #-}
+
+postulate
+  𝔸   : Set
+
+data Swap {l : Level}(A : Set l) : Set l where
+  action :
+    (swap : 𝔸 → 𝔸 → A → A)
+    (swap-id : (a : 𝔸)(x : A) → swap a a x ≣ x)
+    → -----------------------------------------
+    Swap A
+
+infix 6 _≀_
+_≀_ :
+  {l : Level}
+  {A : Set l}
+  ⦃ _ : Swap A ⦄
+  (a b : 𝔸)
+  → ------------
+  A → A
+_≀_ ⦃ action swap _ ⦄ = swap
+
+data Swap₁
+  {l m : Level}
+  {A : Set l}
+  ⦃ _ : Swap A ⦄
+  (B : A → Set m)
+  : -------------
+  Set (l ⊔ m)
+  where
+  action₁ :
+    (swap₁ :
+      (a b : 𝔸)
+      {x : A}
+      → -----------------
+      B x → B ((a ≀ b) x))
+    (swap₁-id :
+      (a : 𝔸)
+      {x : A}
+      (y : B x)
+      → --------------
+      swap₁ a a y ≣ y)
+    → --------------------
+    Swap₁ B
+
+infix 6 _≀₁_
+_≀₁_ :
+  {l m : Level}
+  {A : Set l}
+  ⦃ _ : Swap A ⦄
+  {B : A → Set m}
+  ⦃ sw₁ : Swap₁ B ⦄
+  (a b : 𝔸)
+  {x : A}
+  → -----------------
+  B x → B ((a ≀ b) x)
+_≀₁_ ⦃ sw₁ = action₁ swap₁ _ ⦄ = swap₁
+
+≀₁id :
+  {l m : Level}
+  {A : Set l}
+  ⦃ _ : Swap A ⦄
+  {B : A → Set m}
+  ⦃ sw₁ : Swap₁ B ⦄
+  (a : 𝔸)
+  {x : A}
+  (y : B x)
+  → ---------------
+  (a ≀₁ a) y ≣ y
+≀₁id ⦃ sw₁ = action₁ _ swap₁-id ⦄  = swap₁-id
+
+{-# REWRITE ≀₁id #-}

--- a/test/Fail/Issue5462.err
+++ b/test/Fail/Issue5462.err
@@ -1,0 +1,3 @@
+Issue5462.agda:85,1-21
+≀₁id  is not a legal rewrite rule, since the head symbol _≀₁_ is a projection-like function. You can turn off the projection-like optimization with the flag --no-projection-like
+when checking the pragma REWRITE ≀₁id

--- a/test/Succeed/Issue4994.agda
+++ b/test/Succeed/Issue4994.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --rewriting #-}
+{-# OPTIONS --rewriting --no-projection-like #-}
 module _ where
 
 open import Agda.Builtin.Equality


### PR DESCRIPTION
This fixes #5462 by throwing an error when trying to add a rewrite rule with a projection-like head, with a suggestion to turn on `--no-projection-like`. A proper treatment of projection-like functions in rewriting will have to wait until the fix of #1981.