### PR TITLE
[ fix #6076 ] Remove right-to-left characters from Agda input method.

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -299,7 +299,7 @@ order for the change to take effect."
   (".-"        . ("∸"))
   (":"         . ,(agda-input-to-string-list "∶⦂ː꞉˸፥፦：﹕︓"))
   (","         . ,(agda-input-to-string-list "ʻ،⸲⸴⹁⹉、︐︑﹐﹑，､"))
-  (";"         . ,(agda-input-to-string-list "؛⨾⨟⁏፤꛶；︔﹔⍮⸵;"))
+  (";"         . ,(agda-input-to-string-list "⨾⨟⁏፤꛶；︔﹔⍮⸵;"))
   ("::"        . ("∷"))
   ("::-"       . ("∺"))
   ("-:"        . ("∹"))


### PR DESCRIPTION
After this commit, only the following Unicode bidirectional classes occur:
- CS: Common Separator
- EN: European Number
- ET: European Terminator
- ES: European Separator
- L: Left To Right
- NSM: Nonspacing Mark
- ON: Other Neutral