### PR TITLE
[ re #5765 ] Use same modality as parent for generated `with` functions

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -1205,7 +1205,8 @@ checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs n
 
   -- Check the with function
   let info = Info.mkDefInfo (nameConcrete $ qnameName aux) noFixity' PublicAccess abstr (getRange cs)
-  checkFunDefS withFunType defaultArgInfo NotDelayed Nothing (Just f) info aux (Just withSub) cs
+  ai <- defArgInfo <$> getConstInfo f
+  checkFunDefS withFunType ai NotDelayed Nothing (Just f) info aux (Just withSub) cs
   return $ Just $ call_in_parent
 
 -- | Type check a where clause.

--- a/test/Succeed/Issue5765.agda
+++ b/test/Succeed/Issue5765.agda
@@ -6,3 +6,10 @@ postulate @0 A : Set
 
 @0 f : (X : Set) → A ≡ X → Set
 f X refl = {!!}
+
+sym : ∀ {ℓ} {X : Set ℓ} {x y : X} → x ≡ y → y ≡ x
+sym refl = refl
+
+@0 g : (X : Set) → A ≡ X → Set
+g X eq with (sym eq)
+... | refl = {!!}


### PR DESCRIPTION
Fixes #5765 (or what's left of it)