### PR TITLE
Document LuaLaTeX fallback fonts

### DIFF
--- a/doc/user-manual/tools/generating-latex.rst
+++ b/doc/user-manual/tools/generating-latex.rst
@@ -92,7 +92,7 @@ Known pitfalls and issues
         \usepackage{luaotfload}
         \directlua{luaotfload.add_fallback
           ("mycustomfallback",
-            { "SymbolamonospacifiedforSourceCodePro:style=Regular"
+            { "SymbolamonospacifiedforSourceCodePro:style=Regular;"
             , "NotoSansMono:style=Regular;"
             , "NotoSansMath:style=Regular;"
             }

--- a/doc/user-manual/tools/generating-latex.rst
+++ b/doc/user-manual/tools/generating-latex.rst
@@ -86,9 +86,9 @@ Known pitfalls and issues
     In recent versions of LuaLaTeX, you can avoid using
     ``\newunicodechar`` at all by instead setting up
     a chain of fallback fonts, e.g.
-    
+
     .. code-block:: latex
-    
+
         \usepackage{luaotfload}
         \directlua{luaotfload.add_fallback
           ("mycustomfallback",

--- a/doc/user-manual/tools/generating-latex.rst
+++ b/doc/user-manual/tools/generating-latex.rst
@@ -83,6 +83,22 @@ Known pitfalls and issues
       \usepackage{newunicodechar}
       \newunicodechar{λ}{\ensuremath{\mathnormal\lambda}}
 
+    In recent versions of LuaLaTeX, you can avoid using
+    ``\newunicodechar`` at all by instead setting up
+    a chain of fallback fonts, e.g.
+    
+    .. code-block:: latex
+    
+        \usepackage{luaotfload}
+        \directlua{luaotfload.add_fallback
+          ("mycustomfallback",
+            { "SymbolamonospacifiedforSourceCodePro:style=Regular"
+            , "NotoSansMono:style=Regular;"
+            , "NotoSansMath:style=Regular;"
+            }
+          )}
+        \defaultfontfeatures{RawFeature={fallback=mycustomfallback}}
+
 * If ``<`` and ``>`` are typeset like ``¡`` and ``¿``, then the
   problem might be that you are using pdfLaTeX and have not selected a
   suitable font encoding.


### PR DESCRIPTION
This trick recently saved me many lines of `\newunicodechar` when rendering Agda code to LaTeX.

Other users of the LaTeX backed may be interested.