### PR TITLE
Some potential optimisations

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -221,6 +221,7 @@ library
                 , data-hash >= 0.2.0.0 && < 0.3
                 , deepseq >= 1.4.2.0 && < 1.5
                 , directory >= 1.2.6.2 && < 1.4
+                , dlist >= 0.8 && < 1.1
                 , edit-distance >= 0.2.1.2 && < 0.3
                 , equivalence >= 0.3.2 && < 0.5
                 -- exceptions-0.8 instead of 0.10 because of stack

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -19,6 +19,7 @@ import Control.Monad.Except
 import Control.Monad.Reader
 
 import Data.Semigroup ( Semigroup(..) )
+import Data.Set (Set)
 import qualified Data.Set as Set
 
 import Agda.Interaction.Options (optTerminationDepth)
@@ -31,7 +32,7 @@ import Agda.Syntax.Position (noRange)
 
 import Agda.Termination.CutOff
 import Agda.Termination.Order (Order,le,unknown)
-import Agda.Termination.RecCheck (anyDefs)
+import Agda.Termination.RecCheck (MutualNames, anyDefs)
 
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Benchmark
@@ -55,13 +56,6 @@ import Agda.Utils.VarSet (VarSet)
 import qualified Agda.Utils.VarSet as VarSet
 
 import Agda.Utils.Impossible
-
--- | The mutual block we are checking.
---
---   The functions are numbered according to their order of appearance
---   in this list.
-
-type MutualNames = [QName]
 
 -- | The target of the function we are checking.
 
@@ -101,7 +95,7 @@ data TerEnv = TerEnv
     -- ^ The names of the functions in the mutual block we are checking.
     --   This includes the internally generated functions
     --   (with, extendedlambda, coinduction).
-  , terUserNames :: [QName]
+  , terUserNames :: Set QName
     -- ^ The list of name actually appearing in the file (abstract syntax).
     --   Excludes the internally generated functions.
   , terHaveInlinedWith :: Bool
@@ -286,7 +280,7 @@ terGetCutOff = terAsks terCutOff
 terGetMutual :: TerM MutualNames
 terGetMutual = terAsks terMutual
 
-terGetUserNames :: TerM [QName]
+terGetUserNames :: TerM (Set QName)
 terGetUserNames = terAsks terUserNames
 
 terGetTarget :: TerM Target

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1429,7 +1429,7 @@ compareConArgs ts ps = do
     -- @unknown@ here can lead to non-termination.
     LT -> return Order.unknown
 
-    EQ -> foldl (Order..*.) Order.le <$>
+    EQ -> List.foldl' (Order..*.) Order.le <$>
                zipWithM compareTerm' (map unArg ts) (map (notMasked . namedArg) ps)
        -- corresponds to taking the size, not the height
        -- allows examples like (x, y) < (Succ x, y)

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -75,6 +75,7 @@ import Agda.Utils.Permutation
 import Agda.Utils.Pretty (prettyShow)
 import Agda.Utils.Singleton
 import Agda.Utils.Size
+import Agda.Utils.Tuple
 import Agda.Utils.WithDefault
 
 import Agda.Utils.Impossible
@@ -399,9 +400,13 @@ cover f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
                     , clauseWhereModule = clauseWhereModule cl
                     }
       where
-        (vs,qs) = unzip mps
-        mps' = zip vs $ map namedArg $ fromSplitPatterns $ map defaultNamedArg qs
-        s = parallelS (for [0..maximum (-1:vs)] $ (\ i -> fromMaybe (deBruijnVar i) (List.lookup i mps')))
+      mps' =
+        Map.fromList $
+        map (mapSnd (namedArg . fromSplitPattern . defaultNamedArg)) mps
+      s = parallelS (for (case Map.lookupMax mps' of
+                            Nothing     -> []
+                            Just (i, _) -> [0..i]) $ \ i ->
+                     fromMaybe (deBruijnVar i) (Map.lookup i mps'))
 
     updateRelevance :: TCM a -> TCM a
     updateRelevance cont =

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -13,7 +13,8 @@ when yes, where).
 
 module Agda.TypeChecking.Coverage.Match
   ( Match(..), match, matchClause
-  , SplitPattern, SplitPatVar(..), fromSplitPatterns, toSplitPatterns
+  , SplitPattern, SplitPatVar(..)
+  , fromSplitPattern, fromSplitPatterns, toSplitPatterns
   , toSplitPSubst, applySplitPSubst
   , isTrivialPattern
   , BlockingVar(..), BlockingVars, BlockedOnResult(..)
@@ -147,8 +148,11 @@ instance DeBruijn SplitPatVar where
 toSplitPatterns :: [NamedArg DeBruijnPattern] -> [NamedArg SplitPattern]
 toSplitPatterns = (fmap . fmap . fmap . fmap) toSplitVar
 
+fromSplitPattern :: NamedArg SplitPattern -> NamedArg DeBruijnPattern
+fromSplitPattern = (fmap . fmap . fmap) fromSplitVar
+
 fromSplitPatterns :: [NamedArg SplitPattern] -> [NamedArg DeBruijnPattern]
-fromSplitPatterns = (fmap . fmap . fmap . fmap) fromSplitVar
+fromSplitPatterns = fmap fromSplitPattern
 
 type SplitPSubstitution = Substitution' SplitPattern
 

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -26,6 +26,8 @@ import Control.Monad.State
 
 import Prelude hiding ( null )
 
+import Data.DList (DList)
+import Data.Foldable (toList)
 import qualified Data.List as List
 import Data.Maybe (mapMaybe, fromMaybe)
 import Data.Semigroup ( Semigroup, (<>))
@@ -44,6 +46,7 @@ import Agda.TypeChecking.Substitute
 import Agda.Utils.Null
 import Agda.Utils.Pretty ( Pretty(..), text, (<+>), cat , prettyList_ )
 import Agda.Utils.Monad
+import Agda.Utils.Singleton
 
 import Agda.Utils.Impossible
 
@@ -111,7 +114,7 @@ match cs ps = foldr choice (return No) $ zipWith matchIt [0..] cs
             => Nat  -- Clause number.
             -> Clause
             -> m (Match (Nat, SplitInstantiation))
-    matchIt i c = fmap (i,) <$> matchClause ps c
+    matchIt i c = fmap (\s -> (i, toList s)) <$> matchClause ps c
 
 -- | For each variable in the patterns of a split clause, we remember the
 --   de Bruijn-index and the literals excluded by previous matches.
@@ -223,7 +226,7 @@ isTrivialPattern = \case
 
 -- | If matching succeeds, we return the instantiation of the clause pattern vector
 --   to obtain the split clause pattern vector.
-type MatchResult = Match SplitInstantiation
+type MatchResult = Match (DList (Nat, SplitPattern))
 
 instance Pretty BlockingVar where
   pretty (BlockingVar i cs ls o l) = cat
@@ -346,7 +349,7 @@ matchPats
   -> m MatchResult
      -- ^ Result.
      --   If 'Yes' the instantiation @rs@ such that @ps[rs] == qs@.
-matchPats [] [] = yes []
+matchPats [] [] = yes mempty
 matchPats (p:ps) (q:qs) =
   matchPat (namedArg p) (namedArg q) `combine` matchPats ps qs
 
@@ -356,8 +359,8 @@ matchPats (p:ps) (q:qs) =
 -- Thus, if the split clause has copatterns left,
 -- the current (shorter) clause is not considered covering.
 matchPats [] qs@(_:_) = case mapMaybe isProjP qs of
-  [] -> yes [] -- no proj. patterns left
-  _  -> no     -- proj. patterns left
+  [] -> yes mempty -- no proj. patterns left
+  _  -> no         -- proj. patterns left
 
 -- Patterns left in candidate clause:
 -- If the current clause has additional copatterns in
@@ -412,9 +415,10 @@ matchPat
      --   to produce the split clause pattern, @p[rs] = q@.
 matchPat p q = case p of
 
-  VarP _ x   -> yes [(fromMaybe __IMPOSSIBLE__ (deBruijnView x),q)]
+  VarP _ x ->
+    yes $ singleton (fromMaybe __IMPOSSIBLE__ (deBruijnView x), q)
 
-  DotP{}   -> yes []
+  DotP{} -> yes mempty
   -- Jesper, 2014-11-04: putting 'Yes [q]' here triggers issue 1333.
   -- Not checking for trivial patterns should be safe here, as dot patterns are
   -- guaranteed to match if the rest of the pattern does, so some extra splitting
@@ -425,16 +429,17 @@ matchPat p q = case p of
                 then no
                 else blockedOnLiteral (splitPatVarIndex x) l
     _ -> isLitP q >>= \case
-      Just l' -> if l == l' then yes [] else no
+      Just l' -> if l == l' then yes mempty else no
       Nothing -> no
 
   ProjP _ d -> case q of
     ProjP _ d' -> do
       d <- getOriginalProjection d
-      if d == d' then yes [] else no
+      if d == d' then yes mempty else no
     _          -> __IMPOSSIBLE__
 
-  IApplyP _ _ _ x -> yes [(fromMaybe __IMPOSSIBLE__ (deBruijnView x),q)]
+  IApplyP _ _ _ x ->
+    yes $ singleton (fromMaybe __IMPOSSIBLE__ (deBruijnView x), q)
 
                            --    Issue #4179: If the inferred pattern is a literal
                            -- v  we need to turn it into a constructor pattern.

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -63,6 +63,8 @@ module Agda.TypeChecking.Forcing
     isForced,
     nextIsForced ) where
 
+import Data.Bifunctor
+import Data.DList (DList)
 import qualified Data.DList as DL
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
@@ -107,7 +109,7 @@ computeForcingAnnotations c t =
           _        -> __IMPOSSIBLE__
         n = size tel
         xs :: [(Modality, Nat)]
-        xs = forcedVariables vs
+        xs = DL.toList $ forcedVariables vs
         xs' :: IntMap [Modality]
         xs' = IntMap.map DL.toList $ IntMap.fromListWith (<>) $
               map (\(m, i) -> (i, DL.singleton m)) xs
@@ -136,9 +138,11 @@ computeForcingAnnotations c t =
 
 -- | Compute the pattern variables of a term or term-like thing.
 class ForcedVariables a where
-  forcedVariables :: a -> [(Modality, Nat)]
+  forcedVariables :: a -> DList (Modality, Nat)
 
-  default forcedVariables :: (ForcedVariables b, Foldable t, a ~ t b) => a -> [(Modality, Nat)]
+  default forcedVariables ::
+    (ForcedVariables b, Foldable t, a ~ t b) =>
+    a -> DList (Modality, Nat)
   forcedVariables = foldMap forcedVariables
 
 instance ForcedVariables a => ForcedVariables [a] where
@@ -146,19 +150,20 @@ instance ForcedVariables a => ForcedVariables [a] where
 -- Note that the 'a' does not include the 'Arg' in 'Apply'.
 instance ForcedVariables a => ForcedVariables (Elim' a) where
   forcedVariables (Apply x) = forcedVariables x
-  forcedVariables IApply{}  = []  -- No forced variables in path applications
-  forcedVariables Proj{}    = []
+  forcedVariables IApply{}  = mempty  -- No forced variables in path applications
+  forcedVariables Proj{}    = mempty
 
 instance ForcedVariables a => ForcedVariables (Arg a) where
-  forcedVariables x = [ (composeModality m m', i) | (m', i) <- forcedVariables (unArg x) ]
+  forcedVariables x =
+    fmap (first (composeModality m)) (forcedVariables (unArg x))
     where m = getModality x
 
 -- | Assumes that the term is in normal form.
 instance ForcedVariables Term where
   forcedVariables = \case
-    Var i [] -> [(unitModality, i)]
+    Var i []   -> DL.singleton (unitModality, i)
     Con _ _ vs -> forcedVariables vs
-    _ -> []
+    _          -> mempty
 
 isForced :: IsForced -> Bool
 isForced Forced    = True

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -46,7 +46,7 @@ import Agda.Utils.Benchmark
 import qualified Agda.Utils.BiMap as BiMap
 import Agda.Utils.Functor
 import Agda.Utils.Impossible
-import Agda.Utils.List   (hasElem)
+import Agda.Utils.List (downFrom, hasElem)
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
@@ -585,10 +585,15 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
     findGenRec :: MetaVariable -> TCM (Maybe Int)
     findGenRec mv = do
       cxt <- instantiateFull =<< getContext
-      let notPruned = permute (takeP (length cxt) $ mvPermutation mv) $
-               reverse $ zipWith const [0..] cxt
-      case [ i | (i, Dom{unDom = (_, El _ (Def q _))}) <- zip [0..] cxt,
-                 q == genRecName, i `elem` notPruned ] of
+      let n         = length cxt
+          notPruned = IntSet.fromList $
+                      permute (takeP n $ mvPermutation mv) $
+                      downFrom n
+      case [ i
+           | (i, Dom{unDom = (_, El _ (Def q _))}) <- zip [0..] cxt
+           , q == genRecName
+           , i `IntSet.member` notPruned
+           ] of
         []    -> return Nothing
         _:_:_ -> __IMPOSSIBLE__
         [i]   -> return (Just i)

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1582,86 +1582,88 @@ data InvertExcept
 inverseSubst :: Args -> ExceptT InvertExcept TCM SubstCand
 inverseSubst args = map (mapFst unArg) <$> loop (zip args terms)
   where
-    loop  = foldM isVarOrIrrelevant []
-    terms = map var (downFrom (size args))
-    failure = do
-      lift $ reportSDoc "tc.meta.assign" 15 $ vcat
-        [ "not all arguments are variables: " <+> prettyTCM args
-        , "  aborting assignment" ]
-      throwError CantInvert
-    neutralArg = throwError NeutralArg
+  loop  = foldM isVarOrIrrelevant []
+  terms = map var (downFrom (size args))
+  failure = do
+    lift $ reportSDoc "tc.meta.assign" 15 $ vcat
+      [ "not all arguments are variables: " <+> prettyTCM args
+      , "  aborting assignment" ]
+    throwError CantInvert
+  neutralArg = throwError NeutralArg
 
-    isVarOrIrrelevant :: Res -> (Arg Term, Term) -> ExceptT InvertExcept TCM Res
-    isVarOrIrrelevant vars (Arg info v, t) = do
-      let irr | isIrrelevant info = True
-              | DontCare{} <- v   = True
-              | otherwise         = False
-      case stripDontCare v of
-        -- i := x
-        Var i [] -> return $ (Arg info i, t) `cons` vars
+  isVarOrIrrelevant :: Res -> (Arg Term, Term) -> ExceptT InvertExcept TCM Res
+  isVarOrIrrelevant vars (Arg info v, t) = do
+    let irr | isIrrelevant info = True
+            | DontCare{} <- v   = True
+            | otherwise         = False
+    case stripDontCare v of
+      -- i := x
+      Var i [] -> return $ (Arg info i, t) `cons` vars
 
-        -- π i := x  try to eta-expand projection π away!
-        Var i es | Just qs <- mapM isProjElim es ->
-          throwError $ ProjVar $ ProjectedVar i qs
+      -- π i := x  try to eta-expand projection π away!
+      Var i es | Just qs <- mapM isProjElim es ->
+        throwError $ ProjVar $ ProjectedVar i qs
 
-        -- (i, j) := x  becomes  [i := fst x, j := snd x]
-        -- Andreas, 2013-09-17 but only if constructor is fully applied
-        Con c ci es -> do
-          let fallback
-               | isIrrelevant info = return vars
-               | otherwise                              = failure
-          irrProj <- optIrrelevantProjections <$> pragmaOptions
-          lift (isRecordConstructor $ conName c) >>= \case
-            Just (_, r@Record{ recFields = fs })
-              | YesEta <- recEtaEquality r  -- Andreas, 2019-11-10, issue #4185: only for eta-records
-              , length fs == length es
-              , hasQuantity0 info || all usableQuantity fs     -- Andreas, 2019-11-12/17, issue #4168b
-              , irrProj || all isRelevant fs -> do
-                let aux (Arg _ v) Dom{domInfo = info', unDom = f} = (Arg ai v,) $ t `applyE` [Proj ProjSystem f] where
-                     ai = ArgInfo
-                       { argInfoHiding   = min (getHiding info) (getHiding info')
-                       , argInfoModality = Modality
-                         { modRelevance  = max (getRelevance info) (getRelevance info')
-                         , modQuantity   = max (getQuantity  info) (getQuantity  info')
-                         , modCohesion   = max (getCohesion  info) (getCohesion  info')
-                         }
-                       , argInfoOrigin   = min (getOrigin info) (getOrigin info')
-                       , argInfoFreeVariables = unknownFreeVariables
-                       , argInfoAnnotation    = argInfoAnnotation info'
-                       }
-                    vs = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
-                res <- loop $ zipWith aux vs fs
-                return $ res `append` vars
-              | otherwise -> fallback
-            _ -> fallback
+      -- (i, j) := x  becomes  [i := fst x, j := snd x]
+      -- Andreas, 2013-09-17 but only if constructor is fully applied
+      Con c ci es -> do
+        let fallback
+             | isIrrelevant info = return vars
+             | otherwise                              = failure
+        irrProj <- optIrrelevantProjections <$> pragmaOptions
+        lift (isRecordConstructor $ conName c) >>= \case
+          Just (_, r@Record{ recFields = fs })
+            | YesEta <- recEtaEquality r  -- Andreas, 2019-11-10, issue #4185: only for eta-records
+            , length fs == length es
+            , hasQuantity0 info || all usableQuantity fs     -- Andreas, 2019-11-12/17, issue #4168b
+            , irrProj || all isRelevant fs -> do
+              let aux (Arg _ v) Dom{domInfo = info', unDom = f} =
+                    (Arg ai v,) $ t `applyE` [Proj ProjSystem f]
+                    where
+                    ai = ArgInfo
+                      { argInfoHiding   = min (getHiding info) (getHiding info')
+                      , argInfoModality = Modality
+                        { modRelevance  = max (getRelevance info) (getRelevance info')
+                        , modQuantity   = max (getQuantity  info) (getQuantity  info')
+                        , modCohesion   = max (getCohesion  info) (getCohesion  info')
+                        }
+                      , argInfoOrigin   = min (getOrigin info) (getOrigin info')
+                      , argInfoFreeVariables = unknownFreeVariables
+                      , argInfoAnnotation    = argInfoAnnotation info'
+                      }
+                  vs = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
+              res <- loop $ zipWith aux vs fs
+              return $ res `append` vars
+            | otherwise -> fallback
+          _ -> fallback
 
-        -- An irrelevant argument which is not an irrefutable pattern is dropped
-        _ | irr -> return vars
+      -- An irrelevant argument which is not an irrefutable pattern is dropped
+      _ | irr -> return vars
 
-        -- Distinguish args that can be eliminated (Con,Lit,Lam,unsure) ==> failure
-        -- from those that can only put somewhere as a whole ==> neutralArg
-        Var{}      -> neutralArg
-        Def{}      -> neutralArg  -- Note that this Def{} is in normal form and might be prunable.
-        Lam{}      -> failure
-        Lit{}      -> failure
-        MetaV{}    -> failure
-        Pi{}       -> neutralArg
-        Sort{}     -> neutralArg
-        Level{}    -> neutralArg
-        DontCare{} -> __IMPOSSIBLE__ -- Ruled out by stripDontCare
-        Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
+      -- Distinguish args that can be eliminated (Con,Lit,Lam,unsure) ==> failure
+      -- from those that can only put somewhere as a whole ==> neutralArg
+      Var{}      -> neutralArg
+      Def{}      -> neutralArg  -- Note that this Def{} is in normal form and might be prunable.
+      Lam{}      -> failure
+      Lit{}      -> failure
+      MetaV{}    -> failure
+      Pi{}       -> neutralArg
+      Sort{}     -> neutralArg
+      Level{}    -> neutralArg
+      DontCare{} -> __IMPOSSIBLE__ -- Ruled out by stripDontCare
+      Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 
-    -- managing an assoc list where duplicate indizes cannot be irrelevant vars
-    append :: Res -> Res -> Res
-    append res vars = foldr cons vars res
+  -- managing an assoc list where duplicate indizes cannot be irrelevant vars
+  append :: Res -> Res -> Res
+  append res vars = foldr cons vars res
 
-    -- adding an irrelevant entry only if not present
-    cons :: (Arg Nat, Term) -> Res -> Res
-    cons a@(Arg ai i, t) vars
-      | isIrrelevant ai = applyUnless (any ((i==) . unArg . fst) vars) (a :) vars
-      | otherwise       = a :  -- adding a relevant entry
-          -- filter out duplicate irrelevants
-          filter (not . (\ a@(Arg info j, t) -> isIrrelevant info && i == j)) vars
+  -- adding an irrelevant entry only if not present
+  cons :: (Arg Nat, Term) -> Res -> Res
+  cons a@(Arg ai i, t) vars
+    | isIrrelevant ai = applyUnless (any ((i==) . unArg . fst) vars) (a :) vars
+    | otherwise       = a :  -- adding a relevant entry
+        -- filter out duplicate irrelevants
+        filter (not . (\ a@(Arg info j, t) -> isIrrelevant info && i == j)) vars
 
 
 -- | Turn open metas into postulates.

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1722,12 +1722,17 @@ dependencySortMetas :: [MetaId] -> TCM (Maybe [MetaId])
 dependencySortMetas metas = do
   metaGraph <- concat <$> do
     forM metas $ \ m -> do
-      deps <- allMetas (\ m' -> if m' `elem` metas then singleton m' else mempty) <$> getType m
+      deps <- allMetas (\m' -> if m' `Set.member` metas'
+                               then singleton m'
+                               else mempty) <$>
+                getType m
       return [ (m, m') | m' <- Set.toList deps ]
 
-  return $ Graph.topSort metas metaGraph
+  return $ Graph.topSort metas' metaGraph
 
   where
+    metas' = Set.fromList metas
+
     -- Sort metas don't have types, but we still want to sort them.
     getType m = do
       j <- lookupMetaJudgement m

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -638,11 +638,11 @@ abstractOverMetas ms x = do
     ns <- forM ms' getMetaNameSuggestion
 
     -- Construct telescope (still containing the metas)
-    let gamma = unflattenTel ns $ map defaultDom as
+    let n     = size ms'
+        gamma = unflattenTel' n ns $ map defaultDom as
 
     -- Replace metas by variables
-    let n           = size ms'
-        metaIndex x = (n-1-) <$> elemIndex x ms'
+    let metaIndex x = (n-1-) <$> elemIndex x ms'
     runReaderT (metasToVars (gamma, x)) metaIndex
 
 -- ^ A @OneHole p@ is a @p@ with a subpattern @f ps@ singled out.

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -889,14 +889,14 @@ solutionStep retry s
 solutionStep _ _ _ = __IMPOSSIBLE__
 
 unify
-  :: (PureTCM m, MonadWriter UnifyLog m, MonadError TCErr m)
+  :: (PureTCM m, MonadWriter UnifyLog' m, MonadError TCErr m)
   => UnifyState -> UnifyStrategy -> m (UnificationResult' UnifyState)
 unify s strategy = if isUnifyStateSolved s
                    then return $ Unifies s
                    else tryUnifyStepsAndContinue (strategy s)
   where
     tryUnifyStepsAndContinue
-      :: (PureTCM m, MonadWriter UnifyLog m, MonadError TCErr m)
+      :: (PureTCM m, MonadWriter UnifyLog' m, MonadError TCErr m)
       => ListT m UnifyStep -> m (UnificationResult' UnifyState)
     tryUnifyStepsAndContinue steps = do
       x <- foldListT tryUnifyStep failure steps
@@ -906,7 +906,7 @@ unify s strategy = if isUnifyStateSolved s
         UnifyBlocked b -> return $ UnifyBlocked b
         UnifyStuck err -> return $ UnifyStuck err
 
-    tryUnifyStep :: (PureTCM m, MonadWriter UnifyLog m, MonadError TCErr m)
+    tryUnifyStep :: (PureTCM m, MonadWriter UnifyLog' m, MonadError TCErr m)
                  => UnifyStep
                  -> m (UnificationResult' UnifyState)
                  -> m (UnificationResult' UnifyState)

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -787,7 +787,27 @@ renaming err p = prependS err gamma $ raiseS $ size p
 
 -- | If @permute π : [a]Γ -> [a]Δ@, then @applySubst (renamingR π) : Term Δ -> Term Γ@
 renamingR :: DeBruijn a => Permutation -> Substitution' a
-renamingR p@(Perm n _) = permute (reverseP p) (map deBruijnVar [0..]) ++# raiseS n
+renamingR p@(Perm n is) = xs ++# raiseS n
+  where
+  xs = map (\i -> deBruijnVar (n - 1 - i)) (reverse is)
+
+  -- The list xs used to be defined in the following way:
+  --
+  --   permute (reverseP p) (map deBruijnVar [0..])
+  --
+  -- We have that
+  --
+  --     permute (reverseP p) (map deBruijnVar [0..])
+  --   = permute (Perm n $ map ((n - 1) -) $ reverse is)
+  --       (map deBruijnVar [0..])
+  --   = map (map deBruijnVar [0..] !!)
+  --       (map ((n - 1) -) $ reverse is)
+  --   = map deBruijnVar (map ((n - 1) -) $ reverse is)
+  --   = map (\i -> deBruijnVar (n - 1 - i)) (reverse is).
+  --
+  -- The latter code is linear in the length of is (if deBruijnVar
+  -- takes constant time), while the time complexity of the former
+  -- code depends on the value of the largest index in is.
 
 -- | The permutation should permute the corresponding context. (right-to-left list)
 renameP :: Subst a => Impossible -> Permutation -> a -> a

--- a/src/full/Agda/Utils/Graph/TopSort.hs
+++ b/src/full/Agda/Utils/Graph/TopSort.hs
@@ -3,6 +3,7 @@ module Agda.Utils.Graph.TopSort
     ( topSort
     ) where
 
+import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Map as Map
 import qualified Agda.Utils.Graph.AdjacencyMap.Unidirectional as G
@@ -21,13 +22,15 @@ mergeBy f (x:xs) (y:ys)
 --   Note: should be stable to preserve order of generalizable variables. Algorithm due to Richard
 --   Eisenberg, and works by walking over the list left-to-right and moving each node the minimum
 --   distance left to guarantee topological ordering.
-topSort :: Ord n => [n] -> [(n, n)] -> Maybe [n]
-topSort nodes edges = go [] nodes
+topSort :: Ord n => Set n -> [(n, n)] -> Maybe [n]
+topSort nodes edges = go [] (Set.toList nodes)
   where
     -- #4253: The input edges do not necessarily include transitive dependencies, so take transitive
     --        closure before sorting.
     w      = Just () -- () is not a good edge label since it counts as a "zero" edge and will be ignored
-    g      = G.transitiveClosure $ G.fromNodes nodes `G.union` G.fromEdges [G.Edge a b w | (a, b) <- edges]
+    g      = G.transitiveClosure $
+               G.fromNodeSet nodes `G.union`
+               G.fromEdges [G.Edge a b w | (a, b) <- edges]
     deps a = Map.keysSet $ G.graph g Map.! a
 
     -- acc: Already sorted nodes in reverse order paired with accumulated set of nodes that must

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -439,14 +439,11 @@ data StrSufSt a
 --   Returns the index where the overlap starts and the length of the overlap.
 --   The length of the overlap plus the index is the length of the first string.
 --   Note that in the worst case, the empty overlap @(length xs,0)@ is returned.
-findOverlap :: forall a. Eq a => [a] -> [a] -> (Int, Int)
-findOverlap xs ys =
-  headWithDefault __IMPOSSIBLE__ $ mapMaybe maybePrefix $ zip [0..] (List.tails xs)
+findOverlap :: Eq a => [a] -> [a] -> (Int, Int)
+findOverlap xs ys = go 0 (reverse xs) ys
   where
-  maybePrefix :: (Int, [a]) -> Maybe (Int, Int)
-  maybePrefix (k, xs')
-    | xs' `List.isPrefixOf` ys = Just (k, length xs')
-    | otherwise                = Nothing
+  go !i (x : xs) (y : ys) | x == y = go (i + 1) xs ys
+  go  i xs       _                 = (length xs, i)
 
 ---------------------------------------------------------------------------
 -- * Groups and chunks

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -152,12 +152,16 @@ initWithDefault _  (a:as) = init1 a as
 -- * Lookup and indexing
 ---------------------------------------------------------------------------
 
--- | Lookup function (partially safe).
+-- | Lookup function (safe).
 --   O(min n index).
 (!!!) :: [a] -> Int -> Maybe a
-[]       !!! _         = Nothing
-(x : _)  !!! 0         = Just x
-(_ : xs) !!! n         = xs !!! (n - 1)
+xs !!! (!i)
+  | i < 0     = Nothing
+  | otherwise = index xs i
+  where
+  index []       !i = Nothing
+  index (x : xs) 0  = Just x
+  index (x : xs) i  = index xs (i - 1)
 
 -- | A variant of 'Prelude.!!' that might provide more informative
 -- error messages if the index is out of bounds.

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -58,8 +58,8 @@ and2M ma mb = ifM ma mb (return False)
 andM :: (Foldable f, Monad m) => f (m Bool) -> m Bool
 andM = Fold.foldl' and2M (return True)
 
-allM :: (Functor f, Foldable f, Monad m) => f a -> (a -> m Bool) -> m Bool
-allM xs f = andM $ fmap f xs
+allM :: (Foldable f, Monad m) => f a -> (a -> m Bool) -> m Bool
+allM xs f = Fold.foldl' (\b -> and2M b . f) (return True) xs
 
 -- | Lazy monadic disjunction.
 or2M :: Monad m => m Bool -> m Bool -> m Bool
@@ -68,8 +68,8 @@ or2M ma = ifM ma (return True)
 orM :: (Foldable f, Monad m) => f (m Bool) -> m Bool
 orM = Fold.foldl' or2M (return False)
 
-anyM :: (Functor f, Foldable f, Monad m) => f a -> (a -> m Bool) -> m Bool
-anyM xs f = orM $ fmap f xs
+anyM :: (Foldable f, Monad m) => f a -> (a -> m Bool) -> m Bool
+anyM xs f = Fold.foldl' (\b -> or2M b . f) (return False) xs
 
 -- | Lazy monadic disjunction with @Either@  truth values.
 --   Returns the last error message if all fail.

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -56,7 +56,7 @@ and2M :: Monad m => m Bool -> m Bool -> m Bool
 and2M ma mb = ifM ma mb (return False)
 
 andM :: (Foldable f, Monad m) => f (m Bool) -> m Bool
-andM = Fold.foldl and2M (return True)
+andM = Fold.foldl' and2M (return True)
 
 allM :: (Functor f, Foldable f, Monad m) => f a -> (a -> m Bool) -> m Bool
 allM xs f = andM $ fmap f xs
@@ -66,7 +66,7 @@ or2M :: Monad m => m Bool -> m Bool -> m Bool
 or2M ma = ifM ma (return True)
 
 orM :: (Foldable f, Monad m) => f (m Bool) -> m Bool
-orM = Fold.foldl or2M (return False)
+orM = Fold.foldl' or2M (return False)
 
 anyM :: (Functor f, Foldable f, Monad m) => f a -> (a -> m Bool) -> m Bool
 anyM xs f = orM $ fmap f xs

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -8,6 +8,7 @@ import Control.Monad (filterM)
 
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
+import qualified Data.IntMap.Strict as IntMapS
 import Data.Functor.Identity
 import qualified Data.List as List
 import Data.Maybe
@@ -97,7 +98,10 @@ instance InversePermute [Maybe a] [Maybe a] where
     where tabulate m = for [0..n-1] $ \ i -> IntMap.lookup i m
 
 instance InversePermute (Int -> a) [Maybe a] where
-  inversePermute (Perm n xs) f = for [0..n-1] $ \ x -> f <$> List.elemIndex x xs
+  inversePermute (Perm n xs) f =
+    for [0..n-1] $ \i -> f <$> IntMap.lookup i m
+    where
+    m = IntMapS.fromListWith (flip const) $ zip xs [0..]
 
 -- | Identity permutation.
 idP :: Int -> Permutation

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -146,12 +146,11 @@ invertP err p@(Perm n xs) = Perm (size xs) $ elems tmpArray
 
 -- | Turn a possible non-surjective permutation into a surjective permutation.
 compactP :: Permutation -> Permutation
-compactP (Perm n xs) = Perm m $ map adjust xs
+compactP p@(Perm _ xs) = Perm (length xs) $ map adjust xs
   where
-    m            = List.genericLength xs
-    missing      = [0..n - 1] List.\\ xs
-    holesBelow k = List.genericLength $ filter (< k) missing
-    adjust k = k - holesBelow k
+  missing      = permPicks $ droppedP p
+  holesBelow k = length $ filter (< k) missing
+  adjust k     = k - holesBelow k
 
 -- | @permute (reverseP p) xs ==
 --    reverse $ permute p $ reverse xs@

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -67,10 +67,7 @@ permute :: Permutation -> [a] -> [a]
 permute p xs = map (fromMaybe __IMPOSSIBLE__) (safePermute p xs)
 
 safePermute :: Permutation -> [a] -> [Maybe a]
-safePermute (Perm _ is) xs = map (xs !!!!) is
-  where
-    xs !!!! n | n < 0     = Nothing
-              | otherwise = xs !!! n
+safePermute (Perm _ is) xs = map (xs !!!) is
 
 -- |  Invert a Permutation on a partial finite int map.
 -- @inversePermute perm f = f'@

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -9,6 +9,7 @@ import Control.Monad (filterM)
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import qualified Data.IntMap.Strict as IntMapS
+import qualified Data.IntSet as IntSet
 import Data.Functor.Identity
 import qualified Data.List as List
 import Data.Maybe
@@ -113,7 +114,10 @@ takeP n (Perm m xs) = Perm n $ filter (< n) xs
 
 -- | Pick the elements that are not picked by the permutation.
 droppedP :: Permutation -> Permutation
-droppedP (Perm n xs) = Perm n $ [0..n-1] List.\\ xs
+droppedP (Perm n xs) =
+  Perm n $ filter (not . (`IntSet.member` xs')) [0..n-1]
+  where
+  xs' = IntSet.fromList xs
 
 -- | @liftP k@ takes a @Perm {m} n@ to a @Perm {m+k} (n+k)@.
 --   Analogous to 'Agda.TypeChecking.Substitution.liftS',

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -10,6 +10,7 @@ import Data.Array.Unboxed
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import qualified Data.IntMap.Strict as IntMapS
+import qualified Data.IntSet as IntSet
 import Data.Functor.Identity
 import qualified Data.List as List
 import Data.Maybe
@@ -156,8 +157,8 @@ invertP err p@(Perm n xs) = Perm (size xs) $ elems tmpArray
 compactP :: Permutation -> Permutation
 compactP p@(Perm _ xs) = Perm (length xs) $ map adjust xs
   where
-  missing      = permPicks $ droppedP p
-  holesBelow k = length $ filter (< k) missing
+  missing      = IntSet.fromList $ permPicks $ droppedP p
+  holesBelow k = IntSet.size $ fst $ IntSet.split k missing
   adjust k     = k - holesBelow k
 
 -- | @permute (reverseP p) xs ==

--- a/src/full/Agda/Utils/Singleton.hs
+++ b/src/full/Agda/Utils/Singleton.hs
@@ -6,6 +6,8 @@ module Agda.Utils.Singleton where
 import Data.Semigroup (Semigroup(..))
 import Data.Monoid (Endo(..))
 
+import Data.DList (DList)
+import qualified Data.DList as DL
 import Data.Hashable (Hashable)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
@@ -36,6 +38,7 @@ class (Semigroup coll, Monoid coll, Singleton el coll) => Collection el coll
 instance Collection a       [a]           where fromList = id
 instance Collection a       ([a] -> [a])  where fromList = (++)
 instance Collection a       (Endo [a])    where fromList = Endo . fromList
+instance Collection a       (DList a)     where fromList = DL.fromList
 instance Collection a       (Seq a)       where fromList = Seq.fromList
 instance Collection Int     IntSet        where fromList = IntSet.fromList
 instance Collection (Int,a) (IntMap a)    where fromList = IntMap.fromList
@@ -61,6 +64,7 @@ instance Singleton a   (Maybe a)   where singleton = Just
 instance Singleton a   [a]         where singleton = (:[])
 instance Singleton a  ([a] -> [a]) where singleton = (:)
 instance Singleton a   (Endo [a])  where singleton = Endo . (:)
+instance Singleton a   (DList a)   where singleton = DL.singleton
 instance Singleton a   (NonEmpty a)
                                    where singleton = (:| [])
 instance Singleton a   (Seq a)     where singleton = Seq.singleton

--- a/test/Fail/Issue921.err
+++ b/test/Fail/Issue921.err
@@ -1,6 +1,6 @@
 Issue921.agda:49,1-117,17
 Termination checking failed for the following functions:
-  _○_, pullback-var, pullback
+  pullback, _○_, pullback-var
 Problematic calls:
   pullback x m
     (at Issue921.agda:96,81-89)

--- a/test/Fail/TerminationWithInsufficientDepth.err
+++ b/test/Fail/TerminationWithInsufficientDepth.err
@@ -1,6 +1,6 @@
 TerminationWithInsufficientDepth.agda:20,3-27,20
 Termination checking failed for the following functions:
-  Depth2.f, Depth2.g
+  Depth2.g, Depth2.f
 Problematic calls:
   g n zero
     (at TerminationWithInsufficientDepth.agda:25,21-22)

--- a/test/Internal/Utils/Permutation.hs
+++ b/test/Internal/Utils/Permutation.hs
@@ -8,7 +8,9 @@
 
 module Internal.Utils.Permutation ( tests ) where
 
-import Agda.Utils.List ( downFrom )
+import Prelude hiding ((!!))
+
+import Agda.Utils.List ( downFrom, (!!), (!!!) )
 import Agda.Utils.Permutation
 
 import Data.Functor
@@ -50,12 +52,25 @@ withStream :: ([a] -> b)  -- ^ Stream function.
            -> b
 withStream k as a = k $ as ++ repeat a
 
+-- | A reference implementation of 'permute'.
+slowPermute :: Permutation -> [a] -> [a]
+slowPermute (Perm _ is) xs = map (xs !!) is
+
+-- | A variant of 'slowPermute' that does not crash for indices that
+-- are out of range.
+safePermute :: Permutation -> [a] -> [Maybe a]
+safePermute (Perm _ is) xs = map (xs !!!) is
+
 -- | Apply a permutation to a list which might be too short.
 --   Silently discard picks that go beyond the list's boundaries.
 permutePartial :: Permutation -> [a] -> [a]
 permutePartial perm xs =
   catMaybes $ permute perm $ map Just xs ++ repeat Nothing
   -- Note: we have to add @Nothing@s to make @permute@ total.
+
+prop_permute_slowPermute :: Permutation -> [A] -> A -> Bool
+prop_permute_slowPermute p = withStream $ \xs ->
+  permute p xs == slowPermute p xs
 
 -- | @perm([0..n-1]) == perm@
 prop_permute_id_r :: Permutation -> Bool


### PR DESCRIPTION
Some of these changes replace an algorithm or a data structure with something that is intended to be asymptotically more efficient (at least for some usage patterns, perhaps ignoring laziness, and ignoring the fact that some types like `Int` have bounded size). There is a risk that such changes can make performance worse in practice for typical code, but the changes do not seem to significantly affect Agda's performance for the standard library (note that I only tested without `-foptimise-heavily`, and I did not test every individual change). Another risk is that the changes make the code harder to read or maintain. For most of the changes I don't think that is the case, but you may want to take a look at the new implementation of `permute` (for which there is a test case that relates it to a simpler implementation).

Some of these commits are related to issue #5983.