### PR TITLE
Removed all data instances

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -776,7 +776,6 @@ library
                     -- slightly shorter, see PR #3920.
                     --, DataKinds
                     , DefaultSignatures
-                    , DeriveDataTypeable
                     , DeriveFoldable
                     , DeriveFunctor
                     , DeriveGeneric

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -46,7 +46,6 @@ import Control.Monad.Writer
 import Control.Monad.IO.Class ( MonadIO(..) )
 
 import Data.Char
-import Data.Data ( Data )
 import Data.Either
 import Data.Function
 import Data.Map ( Map )

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -10,7 +10,6 @@ import Control.Monad.Writer
 import Control.Monad.IO.Class ( MonadIO(..) )
 
 import Data.Char ( isDigit )
-import Data.Data ( Data )
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -49,7 +48,7 @@ data ExecutablesFile = ExecutablesFile
   , efExists :: Bool
        -- ^ The executables file might not exist,
        --   but we may print its assumed location in error messages.
-  } deriving (Show, Data, Generic)
+  } deriving (Show, Generic)
 
 -- | The special name @\".\"@ is used to indicated that the current directory
 --   should count as a project root.
@@ -117,15 +116,15 @@ data LibPositionInfo = LibPositionInfo
   , lineNumPos :: LineNumber     -- ^ Line number in @libraries@ file.
   , filePos    :: FilePath       -- ^ Library file
   }
-  deriving (Show, Data, Generic)
+  deriving (Show, Generic)
 
 data LibWarning = LibWarning (Maybe LibPositionInfo) LibWarning'
-  deriving (Show, Data, Generic)
+  deriving (Show, Generic)
 
 -- | Library Warnings.
 data LibWarning'
   = UnknownField String
-  deriving (Show, Data, Generic)
+  deriving (Show, Generic)
 
 data LibError = LibError (Maybe LibPositionInfo) LibError'
 

--- a/src/full/Agda/Interaction/Library/Parse.hs
+++ b/src/full/Agda/Interaction/Library/Parse.hs
@@ -33,7 +33,6 @@ import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Writer
 import Data.Char
-import Data.Data
 import qualified Data.List as List
 import System.FilePath
 

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -23,7 +23,6 @@ import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Set (Set)
 import Data.Void
-import Data.Data (Data)
 
 import GHC.Generics (Generic)
 
@@ -56,7 +55,7 @@ import Agda.Utils.Impossible
 -- e.g. in @{_ : A} -> ..@ vs. @{r : A} -> ..@.
 
 newtype BindName = BindName { unBind :: Name }
-  deriving (Show, Data, HasRange, KillRange, SetRange, NFData)
+  deriving (Show, HasRange, KillRange, SetRange, NFData)
 
 mkBindName :: Name -> BindName
 mkBindName x = BindName x
@@ -115,7 +114,7 @@ data Expr
   | QuoteTerm ExprInfo                 -- ^ Quote a term.
   | Unquote ExprInfo                   -- ^ The splicing construct: unquote ...
   | DontCare Expr                      -- ^ For printing @DontCare@ from @Syntax.Internal@.
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 -- | Pattern synonym for regular 'Def'.
 pattern Def :: QName -> Expr
@@ -139,7 +138,7 @@ type Ren a = Map a (List1 a)
 data ScopeCopyInfo = ScopeCopyInfo
   { renModules :: Ren ModuleName
   , renNames   :: Ren QName }
-  deriving (Eq, Show, Data, Generic)
+  deriving (Eq, Show, Generic)
 
 initCopyInfo :: ScopeCopyInfo
 initCopyInfo = ScopeCopyInfo
@@ -191,7 +190,7 @@ data Declaration
   | UnquoteDef  [DefInfo] [QName] Expr
   | UnquoteData [DefInfo] QName UniverseCheck [DefInfo] [QName] Expr
   | ScopedDecl ScopeInfo [Declaration]  -- ^ scope annotation
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 type DefInfo = DefInfo' Expr
 
@@ -204,7 +203,7 @@ data ModuleApplication
       -- ^ @tel. M args@:  applies @M@ to @args@ and abstracts @tel@.
     | RecordModuleInstance ModuleName
       -- ^ @M {{...}}@
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 data Pragma
   = OptionsPragma [String]
@@ -224,7 +223,7 @@ data Pragma
   | InjectivePragma QName
   | InlinePragma Bool QName -- INLINE or NOINLINE
   | DisplayPragma QName [NamedArg Pattern] Expr
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 -- | Bindings that are valid in a @let@.
 data LetBinding
@@ -240,7 +239,7 @@ data LetBinding
   | LetDeclaredVariable BindName
     -- ^ Only used for highlighting. Refers to the first occurrence of
     -- @x@ in @let x : A; x = e@.
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 -- | Only 'Axiom's.
 type TypeSignature  = Declaration
@@ -253,7 +252,7 @@ type TacticAttr = Maybe Expr
 data Binder' a = Binder
   { binderPattern :: Maybe Pattern
   , binderName    :: a
-  } deriving (Data, Show, Eq, Functor, Foldable, Traversable, Generic)
+  } deriving (Show, Eq, Functor, Foldable, Traversable, Generic)
 
 type Binder = Binder' BindName
 
@@ -272,7 +271,7 @@ data LamBinding
     -- ^ . @x@ or @{x}@ or @.x@ or @{x = y}@ or @x\@p@ or @(p)@
   | DomainFull TypedBinding
     -- ^ . @(xs:e)@ or @{xs:e}@ or @(let Ds)@
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 mkDomainFree :: NamedArg Binder -> LamBinding
 mkDomainFree = DomainFree Nothing
@@ -296,7 +295,7 @@ data TypedBinding
     -- ^ As in telescope @(x y z : A)@ or type @(x y z : A) -> B@.
   | TLet Range (List1 LetBinding)
     -- ^ E.g. @(let x = e)@ or @(let open M)@.
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 mkTBind :: Range -> List1 (NamedArg Binder) -> Type -> TypedBinding
 mkTBind r = TBind r Nothing
@@ -317,7 +316,7 @@ data GeneralizeTelescope = GeneralizeTel
     -- ^ Maps generalize variables to the corresponding bound variable (to be
     --   introduced by the generalisation).
   , generalizeTel     :: Telescope }
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 data DataDefParams = DataDefParams
   { dataDefGeneralizedParams :: Set Name
@@ -325,7 +324,7 @@ data DataDefParams = DataDefParams
     --   sig, so we keep these in a set on the side.
   , dataDefParams :: [LamBinding]
   }
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 noDataDefParams :: DataDefParams
 noDataDefParams = DataDefParams Set.empty []
@@ -347,7 +346,7 @@ data ProblemEq = ProblemEq
   { problemInPat :: Pattern
   , problemInst  :: I.Term
   , problemType  :: I.Dom I.Type
-  } deriving (Data, Show, Generic)
+  } deriving (Show, Generic)
 
 -- These are not relevant for caching purposes
 instance Eq ProblemEq where _ == _ = True
@@ -363,7 +362,7 @@ data Clause' lhs = Clause
   , clauseRHS        :: RHS
   , clauseWhereDecls :: WhereDeclarations
   , clauseCatchall   :: Bool
-  } deriving (Data, Show, Functor, Foldable, Traversable, Eq, Generic)
+  } deriving (Show, Functor, Foldable, Traversable, Eq, Generic)
 
 data WhereDeclarations = WhereDecls
   { whereModule :: Maybe ModuleName
@@ -373,7 +372,7 @@ data WhereDeclarations = WhereDecls
       -- ^ is it an ordinary unnamed @where@?
   , whereDecls :: Maybe Declaration
       -- ^ The declaration is a 'Section'.
-  } deriving (Data, Show, Eq, Generic)
+  } deriving (Show, Eq, Generic)
 
 instance Null WhereDeclarations where
   empty = WhereDecls empty False empty
@@ -411,7 +410,7 @@ data RHS
       -- ^ The where clauses are attached to the @RewriteRHS@ by
       ---  the scope checker (instead of to the clause).
     }
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 -- | Ignore 'rhsConcrete' when comparing 'RHS's.
 instance Eq RHS where
@@ -429,7 +428,7 @@ data SpineLHS = SpineLHS
   , spLhsDefName  :: QName               -- ^ Name of function we are defining.
   , spLhsPats     :: [NamedArg Pattern]  -- ^ Elimination by pattern, projections, with-patterns.
   }
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 -- | Ignore 'Range' when comparing 'LHS's.
 instance Eq LHS where
@@ -441,7 +440,7 @@ data LHS = LHS
   { lhsInfo     :: LHSInfo               -- ^ Range.
   , lhsCore     :: LHSCore               -- ^ Copatterns.
   }
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 -- | The lhs in projection-application and with-pattern view.
 --   Parameterised over the type @e@ of dot patterns.
@@ -469,7 +468,7 @@ data LHSCore' e
              , lhsPats         :: [NamedArg (Pattern' e)]
                  -- ^ Further applied to patterns.
              }
-  deriving (Data, Show, Functor, Foldable, Traversable, Eq, Generic)
+  deriving (Show, Functor, Foldable, Traversable, Eq, Generic)
 
 type LHSCore = LHSCore' Expr
 
@@ -500,7 +499,7 @@ data Pattern' e
   | EqualP PatInfo [(e, e)]
   | WithP PatInfo (Pattern' e)  -- ^ @| p@, for with-patterns.
   | AnnP PatInfo e (Pattern' e) -- ^ Pattern with type annotation
-  deriving (Data, Show, Functor, Foldable, Traversable, Eq, Generic)
+  deriving (Show, Functor, Foldable, Traversable, Eq, Generic)
 
 type NAPs e   = [NamedArg (Pattern' e)]
 type NAPs1 e  = List1 (NamedArg (Pattern' e))

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -11,7 +11,6 @@ import Prelude hiding (length)
 
 import Control.DeepSeq
 
-import Data.Data (Data)
 import Data.Foldable (length)
 import Data.Function
 import Data.Hashable (Hashable(..))
@@ -46,7 +45,7 @@ data Name = Name
   , nameIsRecordName :: Bool
       -- ^ Is this the name of the invisible record variable `self`?
       --   Should not be printed or displayed in the context, see issue #3584.
-  } deriving Data
+  }
 
 -- | Useful for debugging scoping problems
 uglyShowName :: Name -> String
@@ -61,7 +60,6 @@ uglyShowName x = show (nameId x, nameConcrete x)
 data QName = QName { qnameModule :: ModuleName
                    , qnameName   :: Name
                    }
-    deriving Data
 
 -- | Something preceeded by a qualified name.
 data QNamed a = QNamed
@@ -75,14 +73,14 @@ data QNamed a = QNamed
 -- The 'SetRange' instance for module names sets all individual ranges
 -- to the given one.
 newtype ModuleName = MName { mnameToList :: [Name] }
-  deriving (Eq, Ord, Data)
+  deriving (Eq, Ord)
 
 -- | Ambiguous qualified names. Used for overloaded constructors.
 --
 -- Invariant: All the names in the list must have the same concrete,
 -- unqualified name.  (This implies that they all have the same 'Range').
 newtype AmbiguousQName = AmbQ { unAmbQ :: List1 QName }
-  deriving (Eq, Ord, Data, NFData)
+  deriving (Eq, Ord, NFData)
 
 -- | A singleton "ambiguous" name.
 unambiguous :: QName -> AmbiguousQName
@@ -105,7 +103,7 @@ getUnambiguous _                = Nothing
 data Suffix
   = NoSuffix
   | Suffix !Integer
-  deriving (Data, Show, Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 instance NFData Suffix where
   rnf NoSuffix   = ()

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -20,7 +20,6 @@ import qualified Data.Foldable as Fold
 import Data.Function
 import Data.Hashable (Hashable(..))
 import qualified Data.Strict.Maybe as Strict
-import Data.Data (Data)
 import Data.Word
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
@@ -50,7 +49,7 @@ type Arity  = Nat
 
 -- | Used to specify whether something should be delayed.
 data Delayed = Delayed | NotDelayed
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 instance KillRange Delayed where
   killRange = id
@@ -62,7 +61,7 @@ instance NFData Delayed
 ---------------------------------------------------------------------------
 
 data FileType = AgdaFileType | MdFileType | RstFileType | TexFileType | OrgFileType
-  deriving (Data, Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance Pretty FileType where
   pretty = \case
@@ -109,7 +108,7 @@ data RecordDirectives' a = RecordDirectives
   , recHasEta      :: Maybe HasEta0
   , recPattern     :: Maybe Range
   , recConstructor :: Maybe a
-  } deriving (Functor, Data, Show, Eq)
+  } deriving (Functor, Show, Eq)
 
 emptyRecordDirectives :: RecordDirectives' a
 emptyRecordDirectives = RecordDirectives empty empty empty empty
@@ -131,7 +130,7 @@ instance NFData a => NFData (RecordDirectives' a) where
 data HasEta' a
   = YesEta
   | NoEta a
-  deriving (Data, Show, Eq, Ord, Functor, Foldable, Traversable)
+  deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
 
 instance HasRange a => HasRange (HasEta' a) where
   getRange = foldMap getRange
@@ -158,7 +157,7 @@ data PatternOrCopattern
       -- ^ Can match on the record constructor.
   | CopatternMatching
       -- ^ Can copattern match using the projections. (Default.)
-  deriving (Data, Show, Eq, Ord, Enum, Bounded)
+  deriving (Show, Eq, Ord, Enum, Bounded)
 
 instance NFData PatternOrCopattern where
   rnf PatternMatching   = ()
@@ -201,7 +200,7 @@ instance CopatternMatchingAllowed HasEta where
 
 -- | @Inductive < Coinductive@
 data Induction = Inductive | CoInductive  -- Keep in this order!
-  deriving (Data, Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 instance Pretty Induction where
   pretty Inductive   = "inductive"
@@ -225,10 +224,10 @@ instance PatternMatchingAllowed Induction where
 ---------------------------------------------------------------------------
 
 data Overlappable = YesOverlap | NoOverlap
-  deriving (Data, Show, Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 data Hiding  = Hidden | Instance Overlappable | NotHidden
-  deriving (Data, Show, Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 instance Pretty Hiding where
   pretty = \case
@@ -280,7 +279,7 @@ data WithHiding a = WithHiding
   { whHiding :: !Hiding
   , whThing  :: a
   }
-  deriving (Data, Eq, Ord, Show, Functor, Foldable, Traversable)
+  deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
 
 instance Decoration WithHiding where
   traverseF f (WithHiding h a) = WithHiding h <$> f a
@@ -416,7 +415,7 @@ data Modality = Modality
       -- ^ Cohesion/what was in Agda-flat.
       --   see "Brouwer's fixed-point theorem in real-cohesive homotopy type theory" (arXiv:1509.07584)
       --   Currently only the comonad is implemented.
-  } deriving (Data, Eq, Ord, Show, Generic)
+  } deriving (Eq, Ord, Show, Generic)
 
 -- | Dominance ordering.
 instance PartialOrd Modality where
@@ -621,21 +620,21 @@ data Q0Origin
   = Q0Inferred       -- ^ User wrote nothing.
   | Q0       Range   -- ^ User wrote "@0".
   | Q0Erased Range   -- ^ User wrote "@erased".
-  deriving (Data, Show, Generic, Eq, Ord)
+  deriving (Show, Generic, Eq, Ord)
 
 -- | Origin of 'Quantity1'.
 data Q1Origin
   = Q1Inferred       -- ^ User wrote nothing.
   | Q1       Range   -- ^ User wrote "@1".
   | Q1Linear Range   -- ^ User wrote "@linear".
-  deriving (Data, Show, Generic, Eq, Ord)
+  deriving (Show, Generic, Eq, Ord)
 
 -- | Origin of 'Quantityω'.
 data QωOrigin
   = QωInferred       -- ^ User wrote nothing.
   | Qω       Range   -- ^ User wrote "@ω".
   | QωPlenty Range   -- ^ User wrote "@plenty".
-  deriving (Data, Show, Generic, Eq, Ord)
+  deriving (Show, Generic, Eq, Ord)
 
 -- *** Instances for 'Q0Origin'.
 
@@ -776,7 +775,7 @@ data Quantity
   | Quantity1 Q1Origin -- ^ Linear use @{1}@ (could be updated destructively).
     -- Mostly TODO (needs postponable constraints between quantities to compute uses).
   | Quantityω QωOrigin -- ^ Unrestricted use @ℕ@.
-  deriving (Data, Show, Generic, Eq, Ord)
+  deriving (Show, Generic, Eq, Ord)
     -- @Ord@ instance in case @Quantity@ is used in keys for maps etc.
 
 -- | Equality ignoring origin.
@@ -995,7 +994,7 @@ instance NFData Quantity where
 data Erased
   = Erased Q0Origin
   | NotErased QωOrigin
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 -- | The default value of type 'Erased': not erased.
 
@@ -1065,7 +1064,7 @@ data Relevance
                 --   Therefore, it is irrelevant at run-time.
                 --   It is treated relevantly during equality checking.
   | Irrelevant  -- ^ The argument is irrelevant at compile- and runtime.
-    deriving (Data, Show, Eq, Enum, Bounded, Generic)
+    deriving (Show, Eq, Enum, Bounded, Generic)
 
 allRelevances :: [Relevance]
 allRelevances = [minBound..maxBound]
@@ -1254,7 +1253,7 @@ data Annotation = Annotation
   { annLock :: Lock
     -- ^ Fitch-style dependent right adjoints.
     --   See Modal Dependent Type Theory and Dependent Right Adjoints, arXiv:1804.05236.
-  } deriving (Data, Eq, Ord, Show, Generic)
+  } deriving (Eq, Ord, Show, Generic)
 
 instance HasRange Annotation where
   getRange _ = noRange
@@ -1300,7 +1299,7 @@ instance LensAnnotation (Arg t) where
 data Lock = IsNotLock
           | IsLock -- ^ In the future there might be different kinds of them.
                    --   For now we assume lock weakening.
-  deriving (Data, Show, Generic, Eq, Enum, Bounded, Ord)
+  deriving (Show, Generic, Eq, Enum, Bounded, Ord)
 
 defaultLock :: Lock
 defaultLock = IsNotLock
@@ -1344,7 +1343,7 @@ data Cohesion
   | Continuous  -- ^ identity modality.
   -- | Sharp    -- ^ same points, codiscrete topology, idempotent monad, diamond-like.
   | Squash      -- ^ single point space, artificially added for Flat left-composition.
-    deriving (Data, Show, Eq, Enum, Bounded, Generic)
+    deriving (Show, Eq, Enum, Bounded, Generic)
 
 allCohesions :: [Cohesion]
 allCohesions = [minBound..maxBound]
@@ -1514,7 +1513,7 @@ data Origin
   | Reflected    -- ^ Produced by the reflection machinery.
   | CaseSplit    -- ^ Produced by an interactive case split.
   | Substitution -- ^ Named application produced to represent a substitution. E.g. "?0 (x = n)" instead of "?0 n"
-  deriving (Data, Show, Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 instance HasRange Origin where
   getRange _ = noRange
@@ -1534,7 +1533,7 @@ data WithOrigin a = WithOrigin
   { woOrigin :: !Origin
   , woThing  :: a
   }
-  deriving (Data, Eq, Ord, Show, Functor, Foldable, Traversable)
+  deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
 
 instance Decoration WithOrigin where
   traverseF f (WithOrigin h a) = WithOrigin h <$> f a
@@ -1587,7 +1586,7 @@ instance LensOrigin (WithOrigin a) where
 -----------------------------------------------------------------------------
 
 data FreeVariables = UnknownFVs | KnownFVs IntSet
-  deriving (Data, Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 instance Semigroup FreeVariables where
   UnknownFVs   <> _            = UnknownFVs
@@ -1659,7 +1658,7 @@ data ArgInfo = ArgInfo
   , argInfoAnnotation    :: Annotation
     -- ^ Sometimes we want a different kind of binder/pi-type, without it
     --   supporting any of the @Modality@ interface.
-  } deriving (Data, Eq, Ord, Show)
+  } deriving (Eq, Ord, Show)
 
 instance HasRange ArgInfo where
   getRange (ArgInfo h m o _fv a) = getRange (h, m, o, a)
@@ -1791,7 +1790,7 @@ isInsertedHidden a = getHiding a == Hidden && getOrigin a == Inserted
 data Arg e  = Arg
   { argInfo :: ArgInfo
   , unArg :: e
-  } deriving (Data, Eq, Ord, Show, Functor, Foldable, Traversable)
+  } deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
 
 instance Decoration Arg where
   traverseF f (Arg ai a) = Arg ai <$> f a
@@ -1961,7 +1960,7 @@ data Named name a =
     Named { nameOf     :: Maybe name
           , namedThing :: a
           }
-    deriving (Eq, Ord, Show, Data, Functor, Foldable, Traversable)
+    deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
 
 -- | Standard naming.
 type Named_ = Named NamedName
@@ -2130,7 +2129,7 @@ data Ranged a = Ranged
   { rangeOf     :: Range
   , rangedThing :: a
   }
-  deriving (Data, Show, Functor, Foldable, Traversable)
+  deriving (Show, Functor, Foldable, Traversable)
 
 -- | Thing with no range info.
 unranged :: a -> Ranged a
@@ -2188,7 +2187,7 @@ data ConOrigin
   | ConOCon     -- ^ User wrote a constructor (pattern).
   | ConORec     -- ^ User wrote a record (pattern).
   | ConOSplit   -- ^ Generated by interactive case splitting.
-  deriving (Data, Show, Eq, Ord, Enum, Bounded, Generic)
+  deriving (Show, Eq, Ord, Enum, Bounded, Generic)
 
 instance NFData ConOrigin
 
@@ -2205,7 +2204,7 @@ data ProjOrigin
   = ProjPrefix    -- ^ User wrote a prefix projection.
   | ProjPostfix   -- ^ User wrote a postfix projection.
   | ProjSystem    -- ^ Projection was generated by the system.
-  deriving (Data, Show, Eq, Ord, Enum, Bounded, Generic)
+  deriving (Show, Eq, Ord, Enum, Bounded, Generic)
 
 instance NFData ProjOrigin
 
@@ -2219,7 +2218,7 @@ instance KillRange ProjOrigin where
 -- | Functions can be defined in both infix and prefix style. See
 --   'Agda.Syntax.Concrete.LHS'.
 data IsInfix = InfixDef | PrefixDef
-    deriving (Data, Show, Eq, Ord)
+    deriving (Show, Eq, Ord)
 
 -- ** private blocks, public imports
 
@@ -2229,7 +2228,7 @@ data Access
       -- ^ Store the 'Origin' of the private block that lead to this qualifier.
       --   This is needed for more faithful printing of declarations.
   | PublicAccess
-    deriving (Data, Show, Eq, Ord)
+    deriving (Show, Eq, Ord)
 
 instance Pretty Access where
   pretty = text . \case
@@ -2249,7 +2248,7 @@ instance KillRange Access where
 
 -- | Abstract or concrete.
 data IsAbstract = AbstractDef | ConcreteDef
-    deriving (Data, Show, Eq, Ord, Generic)
+    deriving (Show, Eq, Ord, Generic)
 
 -- | Semigroup computes if any of several is an 'AbstractDef'.
 instance Semigroup IsAbstract where
@@ -2291,7 +2290,7 @@ instance AnyIsAbstract a => AnyIsAbstract (Maybe a) where
 data IsInstance
   = InstanceDef Range  -- ^ Range of the @instance@ keyword.
   | NotInstanceDef
-    deriving (Data, Show, Eq, Ord)
+    deriving (Show, Eq, Ord)
 
 instance KillRange IsInstance where
   killRange = \case
@@ -2311,7 +2310,7 @@ instance NFData IsInstance where
 
 -- | Is this a macro definition?
 data IsMacro = MacroDef | NotMacroDef
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 instance KillRange IsMacro where killRange = id
 instance HasRange  IsMacro where getRange _ = noRange
@@ -2323,7 +2322,7 @@ instance NFData IsMacro
 ---------------------------------------------------------------------------
 
 newtype ModuleNameHash = ModuleNameHash { moduleNameHash :: Word64 }
-  deriving (Eq, Ord, Data, Hashable)
+  deriving (Eq, Ord, Hashable)
 
 noModuleNameHash :: ModuleNameHash
 noModuleNameHash = ModuleNameHash 0
@@ -2337,7 +2336,7 @@ instance Show ModuleNameHash where
 -- | The unique identifier of a name. Second argument is the top-level module
 --   identifier.
 data NameId = NameId {-# UNPACK #-} !Word64 {-# UNPACK #-} !ModuleNameHash
-    deriving (Eq, Ord, Data, Generic, Show)
+    deriving (Eq, Ord, Generic, Show)
 
 instance KillRange NameId where
   killRange = id
@@ -2371,7 +2370,7 @@ data MetaId = MetaId
   { metaId     :: {-# UNPACK #-} !Word64
   , metaModule :: {-# UNPACK #-} !ModuleNameHash
   }
-  deriving (Eq, Ord, Data, Generic)
+  deriving (Eq, Ord, Generic)
 
 instance Pretty MetaId where
   pretty (MetaId n m) =
@@ -2410,7 +2409,7 @@ newtype Constr a = Constr a
 -- | A "problem" consists of a set of constraints and the same constraint can be part of multiple
 --   problems.
 newtype ProblemId = ProblemId Nat
-  deriving (Data, Eq, Ord, Enum, Real, Integral, Num, NFData)
+  deriving (Eq, Ord, Enum, Real, Integral, Num, NFData)
 
 -- This particular Show instance is ok because of the Num instance.
 instance Show   ProblemId where show   (ProblemId n) = show n
@@ -2431,7 +2430,7 @@ data PositionInName
     -- @foo_bar@.
   | End
     -- ^ The following underscore is at the end of the name: @foo_@.
-  deriving (Show, Eq, Ord, Data)
+  deriving (Show, Eq, Ord)
 
 -- | Placeholders are used to represent the underscores in a section.
 
@@ -2440,7 +2439,7 @@ data MaybePlaceholder e
   | NoPlaceholder !(Strict.Maybe PositionInName) e
     -- ^ The second argument is used only (but not always) for name
     -- parts other than underscores.
-  deriving (Data, Eq, Ord, Functor, Foldable, Traversable, Show)
+  deriving (Eq, Ord, Functor, Foldable, Traversable, Show)
 
 -- | An abbreviation: @noPlaceholder = 'NoPlaceholder'
 -- 'Strict.Nothing'@.
@@ -2472,7 +2471,6 @@ newtype InteractionId = InteractionId { interactionId :: Nat }
              , Integral
              , Real
              , Enum
-             , Data
              , NFData
              )
 
@@ -2494,7 +2492,7 @@ data FixityLevel
     -- ^ No fixity declared.
   | Related !PrecedenceLevel
     -- ^ Fixity level declared as the number.
-  deriving (Eq, Ord, Show, Data)
+  deriving (Eq, Ord, Show)
 
 instance Null FixityLevel where
   null Unrelated = True
@@ -2508,7 +2506,7 @@ instance NFData FixityLevel where
 -- | Associativity.
 
 data Associativity = NonAssoc | LeftAssoc | RightAssoc
-   deriving (Eq, Ord, Show, Data)
+   deriving (Eq, Ord, Show)
 
 -- | Fixity of operators.
 
@@ -2518,7 +2516,7 @@ data Fixity = Fixity
   , fixityLevel :: !FixityLevel
   , fixityAssoc :: !Associativity
   }
-  deriving (Data, Show)
+  deriving Show
 
 noFixity :: Fixity
 noFixity = Fixity noRange Unrelated NonAssoc
@@ -2558,7 +2556,7 @@ data Fixity' = Fixity'
       -- ^ Range of the name in the fixity declaration
       --   (used for correct highlighting, see issue #2140).
     }
-  deriving (Data, Show)
+  deriving Show
 
 noFixity' :: Fixity'
 noFixity' = Fixity' noFixity noNotation noRange
@@ -2615,7 +2613,7 @@ data ImportDirective' n m = ImportDirective
   , impRenaming    :: RenamingDirective' n m
   , publicOpen     :: Maybe Range -- ^ Only for @open@. Exports the opened names from the current module.
   }
-  deriving (Data, Eq)
+  deriving Eq
 
 type HidingDirective'   n m = [ImportedName' n m]
 type RenamingDirective' n m = [Renaming' n m]
@@ -2653,7 +2651,7 @@ isDefaultImportDir dir = null dir && null (publicOpen dir)
 data Using' n m
   = UseEverything              -- ^ No @using@ clause given.
   | Using [ImportedName' n m]  -- ^ @using@ the specified names.
-  deriving (Data, Eq)
+  deriving Eq
 
 instance Semigroup (Using' n m) where
   UseEverything <> u             = u
@@ -2678,7 +2676,7 @@ mapUsing f = \case
 data ImportedName' n m
   = ImportedModule  m  -- ^ Imported module name of type @m@.
   | ImportedName    n  -- ^ Imported name of type @n@.
-  deriving (Data, Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 fromImportedName :: ImportedName' a a -> a
 fromImportedName = \case
@@ -2714,7 +2712,7 @@ data Renaming' n m = Renaming
   , renToRange :: Range
     -- ^ The range of the \"to\" keyword.  Retained for highlighting purposes.
   }
-  deriving (Data, Eq)
+  deriving Eq
 
 -- ** HasRange instances
 
@@ -2785,7 +2783,7 @@ data TerminationCheck m
     -- ^ Treat as terminating (unsafe).  Same effect as 'NoTerminationCheck'.
   | TerminationMeasure Range m
     -- ^ Skip termination checking but use measure instead.
-    deriving (Data, Show, Eq, Functor)
+    deriving (Show, Eq, Functor)
 
 instance KillRange m => KillRange (TerminationCheck m) where
   killRange (TerminationMeasure _ m) = TerminationMeasure noRange (killRange m)
@@ -2804,7 +2802,7 @@ instance NFData a => NFData (TerminationCheck a) where
 
 -- | Positivity check? (Default = True).
 data PositivityCheck = YesPositivityCheck | NoPositivityCheck
-  deriving (Eq, Ord, Show, Bounded, Enum, Data, Generic)
+  deriving (Eq, Ord, Show, Bounded, Enum, Generic)
 
 instance KillRange PositivityCheck where
   killRange = id
@@ -2827,7 +2825,7 @@ instance NFData PositivityCheck
 
 -- | Universe check? (Default is yes).
 data UniverseCheck = YesUniverseCheck | NoUniverseCheck
-  deriving (Eq, Ord, Show, Bounded, Enum, Data, Generic)
+  deriving (Eq, Ord, Show, Bounded, Enum, Generic)
 
 instance KillRange UniverseCheck where
   killRange = id
@@ -2840,7 +2838,7 @@ instance NFData UniverseCheck
 
 -- | Coverage check? (Default is yes).
 data CoverageCheck = YesCoverageCheck | NoCoverageCheck
-  deriving (Eq, Ord, Show, Bounded, Enum, Data, Generic)
+  deriving (Eq, Ord, Show, Bounded, Enum, Generic)
 
 instance KillRange CoverageCheck where
   killRange = id
@@ -2871,7 +2869,7 @@ instance NFData CoverageCheck
 data RewriteEqn' qn nm p e
   = Rewrite (List1 (qn, e))             -- ^ @rewrite e@
   | Invert qn (List1 (Named nm (p, e))) -- ^ @with p <- e in eq@
-  deriving (Data, Eq, Show, Functor, Foldable, Traversable)
+  deriving (Eq, Show, Functor, Foldable, Traversable)
 
 instance (NFData qn, NFData nm, NFData p, NFData e) => NFData (RewriteEqn' qn nm p e) where
   rnf = \case
@@ -2912,7 +2910,7 @@ data ExpandedEllipsis
   , ellipsisWithArgs :: Int
   }
   | NoEllipsis
-  deriving (Data, Show, Eq)
+  deriving (Show, Eq)
 
 instance Null ExpandedEllipsis where
   null  = (== NoEllipsis)
@@ -2958,7 +2956,7 @@ data BoundVariablePosition = BoundVariablePosition
     -- for @x@ is @0@, the number for @_@ is @1@, and the number for
     -- @y@ is @2@.
   }
-  deriving (Data, Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 -- | Notation parts.
 
@@ -2981,7 +2979,7 @@ data NotationPart
     -- range of the variable in the left-hand side.
   | WildPart (Ranged BoundVariablePosition)
     -- ^ A wildcard (an underscore in binding position).
-  deriving (Data, Show)
+  deriving Show
 
 instance Eq NotationPart where
   VarPart _ i  == VarPart _ j  = i == j

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -70,7 +70,6 @@ import Prelude hiding (null)
 
 import Control.DeepSeq
 
-import Data.Data        ( Data )
 import qualified Data.DList as DL
 import Data.Functor.Identity
 import Data.Set         ( Set  )
@@ -104,14 +103,14 @@ data OpApp e
     -- ^ An abstraction inside a special syntax declaration
     --   (see Issue 358 why we introduce this).
   | Ordinary e
-  deriving (Data, Functor, Foldable, Traversable, Eq)
+  deriving (Functor, Foldable, Traversable, Eq)
 
 fromOrdinary :: e -> OpApp e -> e
 fromOrdinary d (Ordinary e) = e
 fromOrdinary d _            = d
 
 data FieldAssignment' a = FieldAssignment { _nameFieldA :: Name, _exprFieldA :: a }
-  deriving (Data, Functor, Foldable, Traversable, Show, Eq)
+  deriving (Functor, Foldable, Traversable, Show, Eq)
 
 type FieldAssignment = FieldAssignment' Expr
 
@@ -120,7 +119,7 @@ data ModuleAssignment  = ModuleAssignment
                            , _exprModA      :: [Expr]
                            , _importDirModA :: ImportDirective
                            }
-  deriving (Data, Eq)
+  deriving Eq
 
 type RecordAssignment  = Either FieldAssignment ModuleAssignment
 type RecordAssignments = [RecordAssignment]
@@ -180,7 +179,7 @@ data Expr
   | Equal Range Expr Expr                      -- ^ ex: @a = b@, used internally in the parser
   | Ellipsis Range                             -- ^ @...@, used internally to parse patterns.
   | Generalized Expr
-  deriving (Data, Eq)
+  deriving Eq
 
 type OpAppArgs = OpAppArgs' Expr
 type OpAppArgs' e = [NamedArg (MaybePlaceholder (OpApp e))]
@@ -211,19 +210,19 @@ data Pattern
                                            --   Second arg is @Nothing@ before expansion, and
                                            --   @Just p@ after expanding ellipsis to @p@.
   | WithP Range Pattern                    -- ^ @| p@, for with-patterns.
-  deriving (Data, Eq)
+  deriving Eq
 
 data DoStmt
   = DoBind Range Pattern Expr [LamClause]   -- ^ @p ← e where cs@
   | DoThen Expr
   | DoLet Range (List1 Declaration)
-  deriving (Data, Eq)
+  deriving Eq
 
 -- | A Binder @x\@p@, the pattern is optional
 data Binder' a = Binder
   { binderPattern :: Maybe Pattern
   , binderName    :: a
-  } deriving (Data, Eq, Functor, Foldable, Traversable)
+  } deriving (Eq, Functor, Foldable, Traversable)
 
 type Binder = Binder' BoundName
 
@@ -241,7 +240,7 @@ data LamBinding' a
     -- ^ . @x@ or @{x}@ or @.x@ or @.{x}@ or @{.x}@ or @x\@p@ or @(p)@
   | DomainFull a
     -- ^ . @(xs : e)@ or @{xs : e}@
-  deriving (Data, Functor, Foldable, Traversable, Eq)
+  deriving (Functor, Foldable, Traversable, Eq)
 
 -- | Drop type annotations and lets from bindings.
 dropTypeAndModality :: LamBinding -> [LamBinding]
@@ -255,7 +254,7 @@ data BoundName = BName
   , bnameFixity :: Fixity'
   , bnameTactic :: TacticAttribute -- From @tactic attribute
   }
-  deriving (Data, Eq)
+  deriving Eq
 
 type TacticAttribute = Maybe Expr
 
@@ -274,7 +273,7 @@ data TypedBinding' e
     -- ^ Binding @(x1\@p1 ... xn\@pn : A)@.
   | TLet  Range (List1 Declaration)
     -- ^ Let binding @(let Ds)@ or @(open M args)@.
-  deriving (Data, Functor, Foldable, Traversable, Eq)
+  deriving (Functor, Foldable, Traversable, Eq)
 
 -- | A telescope is a sequence of typed bindings. Bound variables are in scope
 --   in later types.
@@ -328,7 +327,7 @@ data LHS = LHS  -- ^ Original pattern (including with-patterns), rewrite equatio
   , lhsWithExpr        :: [WithExpr]
     -- ^ @with e1 in eq | {e2} | ...@ (many)
   }
-  deriving (Data, Eq)
+  deriving Eq
 
 type RewriteEqn = RewriteEqn' () Name Pattern Expr
 type WithExpr   = Named Name (Arg Expr)
@@ -352,13 +351,13 @@ data LHSCore
              { lhsEllipsisRange :: Range
              , lhsEllipsisPat   :: LHSCore           -- ^ Pattern that was expanded from an ellipsis @...@.
              }
-  deriving (Data, Eq)
+  deriving Eq
 
 type RHS = RHS' Expr
 data RHS' e
   = AbsurdRHS -- ^ No right hand side because of absurd match.
   | RHS e
-  deriving (Data, Functor, Foldable, Traversable, Eq)
+  deriving (Functor, Foldable, Traversable, Eq)
 
 -- | @where@ block following a clause.
 type WhereClause = WhereClause' [Declaration]
@@ -376,14 +375,14 @@ data WhereClause' decls
       --   The 'Access' flag applies to the 'Name' (not the module contents!)
       --   and is propagated from the parent function.
       --   List of declarations can be empty.
-  deriving (Data, Eq, Functor, Foldable, Traversable)
+  deriving (Eq, Functor, Foldable, Traversable)
 
 data LamClause = LamClause
   { lamLHS      :: [Pattern]   -- ^ Possibly empty sequence.
   , lamRHS      :: RHS
   , lamCatchAll :: Bool
   }
-  deriving (Data, Eq)
+  deriving Eq
 
 -- | An expression followed by a where clause.
 --   Currently only used to give better a better error message in interaction.
@@ -407,7 +406,7 @@ data AsName' a = AsName
   , asRange :: Range
     -- ^ The range of the \"as\" keyword.  Retained for highlighting purposes.
   }
-  deriving (Data, Show, Functor, Foldable, Traversable, Eq)
+  deriving (Show, Functor, Foldable, Traversable, Eq)
 
 -- | From the parser, we get an expression for the @as@-'Name', which
 --   we have to parse into a 'Name'.
@@ -435,7 +434,7 @@ data RecordDirective
        -- ^ Range of @[no-]eta-equality@ keyword.
    | PatternOrCopattern Range
        -- ^ If declaration @pattern@ is present, give its range.
-   deriving (Data,Eq,Show)
+   deriving (Eq, Show)
 
 type RecordDirectives = RecordDirectives' (Name, IsInstance)
 
@@ -486,7 +485,7 @@ data Declaration
   | UnquoteData Range Name [Name] Expr
       -- ^ @unquoteDecl data d constructor xs = e@
   | Pragma      Pragma
-  deriving (Data, Eq)
+  deriving Eq
 
 -- | Extract a record directive
 isRecordDirective :: Declaration -> Maybe RecordDirective
@@ -499,10 +498,10 @@ data ModuleApplication
     -- ^ @tel. M args@
   | RecordModuleInstance Range QName
     -- ^ @M {{...}}@
-  deriving (Data, Eq)
+  deriving Eq
 
 data OpenShortHand = DoOpen | DontOpen
-  deriving (Data, Eq, Show, Generic)
+  deriving (Eq, Show, Generic)
 
 -- Pragmas ----------------------------------------------------------------
 
@@ -544,7 +543,7 @@ data Pragma
   | PolarityPragma            Range Name [Occurrence]
   | NoUniverseCheckPragma     Range
     -- ^ Applies to the following data/record type.
-  deriving (Data, Eq)
+  deriving Eq
 
 ---------------------------------------------------------------------------
 

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -60,7 +60,6 @@ import Control.Monad.State   ( MonadState(..), gets, StateT, runStateT )
 import Control.Monad.Trans   ( lift )
 
 import Data.Bifunctor
-import Data.Data (Data)
 import Data.Either (isLeft, isRight)
 import Data.Function (on)
 import qualified Data.Map as Map

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -2,8 +2,6 @@ module Agda.Syntax.Concrete.Definitions.Errors where
 
 import Control.DeepSeq
 
-import Data.Data
-
 import GHC.Generics (Generic)
 
 import Agda.Syntax.Position
@@ -47,7 +45,7 @@ data DeclarationException'
       --   Range is of mutual block.
   | UnquoteDefRequiresSignature (List1 Name)
   | BadMacroDef NiceDeclaration
-    deriving (Data, Show)
+    deriving Show
 
 ------------------------------------------------------------------------
 -- Warnings
@@ -119,7 +117,7 @@ data DeclarationWarning'
       -- ^ @instance@ block with nothing that can (newly) become an instance.
   | UselessPrivate Range
       -- ^ @private@ block with nothing that can (newly) be made private.
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 declarationWarningName :: DeclarationWarning -> WarningName
 declarationWarningName = declarationWarningName' . dwWarning

--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -2,7 +2,6 @@ module Agda.Syntax.Concrete.Definitions.Types where
 
 import Control.DeepSeq
 
-import Data.Data
 import Data.Map (Map)
 import Data.Semigroup ( Semigroup(..) )
 
@@ -81,7 +80,7 @@ data NiceDeclaration
   | NiceUnquoteDecl Range Access IsAbstract IsInstance TerminationCheck CoverageCheck [Name] Expr
   | NiceUnquoteDef Range Access IsAbstract TerminationCheck CoverageCheck [Name] Expr
   | NiceUnquoteData Range Access IsAbstract PositivityCheck UniverseCheck Name [Name] Expr
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 instance NFData NiceDeclaration
 
@@ -101,7 +100,7 @@ type NiceTypeSignature  = NiceDeclaration
 -- | One clause in a function definition. There is no guarantee that the 'LHS'
 --   actually declares the 'Name'. We will have to check that later.
 data Clause = Clause Name Catchall LHS RHS WhereClause [Clause]
-    deriving (Data, Show, Generic)
+    deriving (Show, Generic)
 
 instance NFData Clause
 
@@ -192,7 +191,7 @@ data KindOfBlock
   | FieldBlock      -- ^ @field@.  Ensured by parser.
   | DataBlock       -- ^ @data ... where@.  Here we got a bad error message for Agda-2.5 (Issue 1698).
   | ConstructorBlock  -- ^ @constructor@, in @interleaved mutual@.
-  deriving (Data, Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 
 instance HasRange NiceDeclaration where
@@ -289,7 +288,7 @@ data DataRecOrFun
     -- ^ Name of a record type
   | FunName TerminationCheck CoverageCheck
     -- ^ Name of a function.
-  deriving (Data, Show)
+  deriving Show
 
 -- Ignore pragmas when checking equality
 instance Eq DataRecOrFun where

--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -11,7 +11,6 @@ import Data.ByteString.Char8 (ByteString)
 import Data.Function
 import qualified Data.Foldable as Fold
 import qualified Data.List as List
-import Data.Data (Data)
 
 import GHC.Generics (Generic)
 
@@ -51,7 +50,6 @@ data Name
     { nameRange     :: Range
     , nameId        :: NameId
     }
-  deriving Data
 
 type NameParts = List1 NamePart
 
@@ -74,7 +72,7 @@ instance Underscore Name where
 data NamePart
   = Hole       -- ^ @_@ part.
   | Id RawName  -- ^ Identifier part.
-  deriving (Data, Generic)
+  deriving Generic
 
 -- | Define equality on @Name@ to ignore range so same names in different
 --   locations are equal.
@@ -117,7 +115,7 @@ instance Ord NamePart where
 data QName
   = Qual  Name QName -- ^ @A.rest@.
   | QName Name       -- ^ @x@.
-  deriving (Data, Eq, Ord)
+  deriving (Eq, Ord)
 
 instance Underscore QName where
   underscore = QName underscore
@@ -132,7 +130,7 @@ data TopLevelModuleName = TopLevelModuleName
   { moduleNameRange :: Range
   , moduleNameParts :: List1 String
   }
-  deriving (Show, Data, Generic)
+  deriving (Show, Generic)
 
 instance Eq    TopLevelModuleName where (==)    = (==)    `on` moduleNameParts
 instance Ord   TopLevelModuleName where compare = compare `on` moduleNameParts
@@ -225,7 +223,7 @@ isNonfix  x = not (isHole (List1.head xs)) && not (isHole (List1.last xs)) where
 ------------------------------------------------------------------------
 
 data NameInScope = InScope | NotInScope
-  deriving (Eq, Show, Data)
+  deriving (Eq, Show)
 
 class LensInScope a where
   lensInScope :: Lens' NameInScope a

--- a/src/full/Agda/Syntax/Fixity.hs
+++ b/src/full/Agda/Syntax/Fixity.hs
@@ -5,8 +5,6 @@ module Agda.Syntax.Fixity where
 
 import Control.DeepSeq
 
-import Data.Data (Data)
-
 import GHC.Generics (Generic)
 
 import Agda.Syntax.Position
@@ -21,7 +19,7 @@ import Agda.Utils.Impossible
 
 -- | Decorating something with @Fixity'@.
 data ThingWithFixity x = ThingWithFixity x Fixity'
-  deriving (Functor, Foldable, Traversable, Data, Show)
+  deriving (Functor, Foldable, Traversable, Show)
 
 instance LensFixity' (ThingWithFixity a) where
   lensFixity' f (ThingWithFixity a fix') = ThingWithFixity a <$> f fix'
@@ -32,7 +30,7 @@ instance LensFixity (ThingWithFixity a) where
 -- | Do we prefer parens around arguments like @λ x → x@ or not?
 --   See 'lamBrackets'.
 data ParenPreference = PreferParen | PreferParenless
-  deriving (Eq, Ord, Show, Data, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance NFData ParenPreference
 
@@ -49,7 +47,7 @@ data Precedence = TopCtx | FunctionSpaceDomainCtx
                 | LeftOperandCtx Fixity | RightOperandCtx Fixity ParenPreference
                 | FunctionCtx | ArgumentCtx ParenPreference | InsideOperandCtx
                 | WithFunCtx | WithArgCtx | DotPatternCtx
-    deriving (Show, Data, Eq, Generic)
+    deriving (Show, Eq, Generic)
 
 instance NFData Precedence
 

--- a/src/full/Agda/Syntax/Info.hs
+++ b/src/full/Agda/Syntax/Info.hs
@@ -11,7 +11,6 @@ import Prelude hiding (null)
 
 import Control.DeepSeq
 
-import Data.Data (Data)
 import Data.Semigroup (Semigroup)
 
 import GHC.Generics (Generic)
@@ -36,7 +35,7 @@ data MetaInfo = MetaInfo
   , metaNumber         :: Maybe MetaId
   , metaNameSuggestion :: String
   }
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 emptyMetaInfo :: MetaInfo
 emptyMetaInfo = MetaInfo
@@ -59,7 +58,7 @@ instance NFData MetaInfo
  --------------------------------------------------------------------------}
 
 newtype ExprInfo = ExprRange Range
-  deriving (Data, Show, Eq, Null, NFData)
+  deriving (Show, Eq, Null, NFData)
 
 exprNoRange :: ExprInfo
 exprNoRange = ExprRange noRange
@@ -80,7 +79,7 @@ data AppInfo = AppInfo
   , appOrigin :: Origin
   , appParens :: ParenPreference -- ^ Do we prefer a lambda argument with or without parens?
   }
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 -- | Default is system inserted and prefer parens.
 defaultAppInfo :: Range -> AppInfo
@@ -117,7 +116,7 @@ data ModuleInfo = ModuleInfo
   , minfoDirective :: Maybe ImportDirective
     -- ^ Retained for @abstractToConcrete@ of 'ModuleMacro'.
   }
-  deriving (Data, Eq, Show, Generic)
+  deriving (Eq, Show, Generic)
 
 instance HasRange ModuleInfo where
   getRange = minfoRange
@@ -135,7 +134,7 @@ instance NFData ModuleInfo
 ---------------------------------------------------------------------------
 
 newtype LetInfo = LetRange Range
-  deriving (Data, Show, Eq, Null, NFData)
+  deriving (Show, Eq, Null, NFData)
 
 instance HasRange LetInfo where
   getRange (LetRange r)   = r
@@ -156,7 +155,7 @@ data DefInfo' t = DefInfo
   , defInfo     :: DeclInfo
   , defTactic   :: Maybe t
   }
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 mkDefInfo :: Name -> Fixity' -> Access -> IsAbstract -> Range -> DefInfo' t
 mkDefInfo x f a ab r = mkDefInfoInstance x f a ab NotInstanceDef NotMacroDef r
@@ -191,7 +190,7 @@ data DeclInfo = DeclInfo
   { declName  :: Name
   , declRange :: Range
   }
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 instance HasRange DeclInfo where
   getRange = declRange
@@ -214,7 +213,7 @@ data MutualInfo = MutualInfo
   , mutualPositivityCheck  :: PositivityCheck
   , mutualRange            :: Range
   }
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 -- | Default value for 'MutualInfo'.
 instance Null MutualInfo where
@@ -235,7 +234,7 @@ instance NFData MutualInfo
 data LHSInfo = LHSInfo
   { lhsRange    :: Range
   , lhsEllipsis :: ExpandedEllipsis
-  } deriving (Data, Show, Eq, Generic)
+  } deriving (Show, Eq, Generic)
 
 instance HasRange LHSInfo where
   getRange (LHSInfo r _) = r
@@ -256,7 +255,7 @@ instance NFData LHSInfo
 -- | For a general pattern we remember the source code position.
 newtype PatInfo
   = PatRange Range
-  deriving (Data, Eq, Null, Semigroup, Monoid, Show, SetRange, HasRange,
+  deriving (Eq, Null, Semigroup, Monoid, Show, SetRange, HasRange,
             KillRange, NFData)
 
 -- | Empty range for patterns.
@@ -271,7 +270,7 @@ data ConPatInfo = ConPatInfo
   , conPatInfo     :: PatInfo
   , conPatLazy     :: ConPatLazy
   }
-  deriving (Data, Eq, Show, Generic)
+  deriving (Eq, Show, Generic)
 
 instance HasRange ConPatInfo where
   getRange = getRange . conPatInfo
@@ -288,6 +287,6 @@ instance NFData ConPatInfo
 data ConPatLazy
   = ConPatLazy   -- ^ Dotted constructor.
   | ConPatEager  -- ^ Ordinary constructor.
-  deriving (Data, Eq, Ord, Show, Bounded, Enum, Generic)
+  deriving (Eq, Ord, Show, Bounded, Enum, Generic)
 
 instance NFData ConPatLazy

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -21,7 +21,6 @@ import qualified Data.Set as Set
 import Data.Set (Set)
 
 import Data.Traversable
-import Data.Data (Data)
 
 import GHC.Generics (Generic)
 
@@ -76,7 +75,7 @@ data Dom' t e = Dom
   , domName   :: Maybe NamedName  -- ^ e.g. @x@ in @{x = y : A} -> B@.
   , domTactic :: Maybe t        -- ^ "@tactic e".
   , unDom     :: e
-  } deriving (Data, Show, Functor, Foldable, Traversable)
+  } deriving (Show, Functor, Foldable, Traversable)
 
 type Dom = Dom' Term
 
@@ -151,7 +150,7 @@ type NamedArgs  = [NamedArg Term]
 data DataOrRecord
   = IsData
   | IsRecord PatternOrCopattern
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 -- | Store the names of the record fields in the constructor.
 --   This allows reduction of projection redexes outside of TCM.
@@ -163,7 +162,7 @@ data ConHead = ConHead
   , conFields     :: [Arg QName]   -- ^ The name of the record fields.
       --   'Arg' is stored since the info in the constructor args
       --   might not be accurate because of subtyping (issue #2170).
-  } deriving (Data, Show, Generic)
+  } deriving (Show, Generic)
 
 instance Eq ConHead where
   (==) = (==) `on` conName
@@ -225,7 +224,7 @@ data Term = Var {-# UNPACK #-} !Int Elims -- ^ @x es@ neutral
             --   where they can affect type checking, so syntactic checks are free to ignore the
             --   eliminators, which are only there to ease debugging when a dummy term incorrectly
             --   leaks into a relevant position.
-  deriving (Data, Show)
+  deriving Show
 
 type ConInfo = ConOrigin
 
@@ -242,7 +241,7 @@ data Abs a = Abs   { absName :: ArgName, unAbs :: a }
                -- ^ The body has (at least) one free variable.
                --   Danger: 'unAbs' doesn't shift variables properly
            | NoAbs { absName :: ArgName, unAbs :: a }
-  deriving (Data, Functor, Foldable, Traversable, Generic)
+  deriving (Functor, Foldable, Traversable, Generic)
 
 instance Decoration Abs where
   traverseF f (Abs   x a) = Abs   x <$> f a
@@ -251,7 +250,7 @@ instance Decoration Abs where
 -- | Types are terms with a sort annotation.
 --
 data Type'' t a = El { _getSort :: Sort' t, unEl :: a }
-  deriving (Data, Show, Functor, Foldable, Traversable)
+  deriving (Show, Functor, Foldable, Traversable)
 
 type Type' a = Type'' Term a
 
@@ -284,12 +283,12 @@ instance LensSort a => LensSort (Arg a) where
 --   and so on.
 data Tele a = EmptyTel
             | ExtendTel a (Abs (Tele a))  -- ^ 'Abs' is never 'NoAbs'.
-  deriving (Data, Show, Functor, Foldable, Traversable, Generic)
+  deriving (Show, Functor, Foldable, Traversable, Generic)
 
 type Telescope = Tele (Dom Type)
 
 data IsFibrant = IsFibrant | IsStrict
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 -- | Sorts.
 --
@@ -311,19 +310,19 @@ data Sort' t
     --   Replaces the abuse of @Prop@ for a dummy sort.
     --   The @String@ typically describes the location where we create this dummy,
     --   but can contain other information as well.
-  deriving (Data, Show)
+  deriving Show
 
 type Sort = Sort' Term
 
 -- | A level is a maximum expression of a closed level and 0..n
 --   'PlusLevel' expressions each of which is an atom plus a number.
 data Level' t = Max !Integer [PlusLevel' t]
-  deriving (Show, Data, Functor, Foldable, Traversable)
+  deriving (Show, Functor, Foldable, Traversable)
 
 type Level = Level' Term
 
 data PlusLevel' t = Plus !Integer t
-  deriving (Show, Data, Functor, Foldable, Traversable)
+  deriving (Show, Functor, Foldable, Traversable)
 
 type PlusLevel = PlusLevel' Term
 type LevelAtom = Term
@@ -334,7 +333,7 @@ type LevelAtom = Term
 
 -- | Newtypes for terms that produce a dummy, rather than crash, when
 --   applied to incompatible eliminations.
-newtype BraveTerm = BraveTerm { unBrave :: Term } deriving (Data, Show)
+newtype BraveTerm = BraveTerm { unBrave :: Term } deriving Show
 
 ---------------------------------------------------------------------------
 -- * Blocked Terms
@@ -406,7 +405,7 @@ data Clause = Clause
     , clauseWhereModule :: Maybe ModuleName
       -- ^ Keeps track of the module name associate with the clause's where clause.
     }
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 clausePats :: Clause -> [Arg DeBruijnPattern]
 clausePats = map (fmap namedThing) . namedClausePats
@@ -426,7 +425,7 @@ nameToPatVarName = nameToArgName
 data PatternInfo = PatternInfo
   { patOrigin :: PatOrigin
   , patAsNames :: [Name]
-  } deriving (Data, Show, Eq, Generic)
+  } deriving (Show, Eq, Generic)
 
 defaultPatternInfo :: PatternInfo
 defaultPatternInfo = PatternInfo PatOSystem []
@@ -442,7 +441,7 @@ data PatOrigin
   | PatORec            -- ^ User wrote a record pattern
   | PatOLit            -- ^ User wrote a literal pattern
   | PatOAbsurd         -- ^ User wrote an absurd pattern
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 -- | Patterns are variables, constructors, or wildcards.
 --   @QName@ is used in @ConP@ rather than @Name@ since
@@ -466,7 +465,7 @@ data Pattern' x
     -- ^ Path elimination pattern, like @VarP@ but keeps track of endpoints.
   | DefP PatternInfo QName [NamedArg (Pattern' x)]
     -- ^ Used for HITs, the QName should be the one from primHComp.
-  deriving (Data, Show, Functor, Foldable, Traversable, Generic)
+  deriving (Show, Functor, Foldable, Traversable, Generic)
 
 type Pattern = Pattern' PatVarName
     -- ^ The @PatVarName@ is a name suggestion.
@@ -484,7 +483,7 @@ litP = LitP defaultPatternInfo
 data DBPatVar = DBPatVar
   { dbPatVarName  :: PatVarName
   , dbPatVarIndex :: !Int
-  } deriving (Data, Show, Eq, Generic)
+  } deriving (Show, Eq, Generic)
 
 type DeBruijnPattern = Pattern' DBPatVar
 
@@ -531,7 +530,7 @@ data ConPatternInfo = ConPatternInfo
     --   variables they bind are unused. The GHC backend compiles lazy matches
     --   to lazy patterns in Haskell (TODO: not yet).
   }
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 noConPatternInfo :: ConPatternInfo
 noConPatternInfo = ConPatternInfo defaultPatternInfo False False Nothing False

--- a/src/full/Agda/Syntax/Internal/Blockers.hs
+++ b/src/full/Agda/Syntax/Internal/Blockers.hs
@@ -3,7 +3,6 @@ module Agda.Syntax.Internal.Blockers where
 
 import Control.DeepSeq
 
-import Data.Data (Data)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Semigroup
@@ -40,7 +39,7 @@ data NotBlocked' t
   | ReallyNotBlocked
     -- ^ Reduction was not blocked, we reached a whnf
     --   which can be anything but a stuck @'Def'@.
-  deriving (Show, Data, Generic)
+  deriving (Show, Generic)
 
 -- | 'ReallyNotBlocked' is the unit.
 --   'MissingClauses' is dominant.
@@ -68,7 +67,7 @@ data Blocker = UnblockOnAll (Set Blocker)
              | UnblockOnAny (Set Blocker)
              | UnblockOnMeta MetaId     -- ^ Unblock if meta is instantiated
              | UnblockOnProblem ProblemId
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 instance NFData Blocker
 
@@ -151,7 +150,7 @@ instance Pretty Blocker where
 data Blocked' t a
   = Blocked    { theBlocker      :: Blocker,       ignoreBlocking :: a }
   | NotBlocked { blockingStatus  :: NotBlocked' t, ignoreBlocking :: a }
-  deriving (Data, Show, Functor, Foldable, Traversable, Generic)
+  deriving (Show, Functor, Foldable, Traversable, Generic)
 
 instance Decoration (Blocked' t) where
   traverseF f (Blocked b x)     = Blocked b <$> f x

--- a/src/full/Agda/Syntax/Internal/Elim.hs
+++ b/src/full/Agda/Syntax/Internal/Elim.hs
@@ -2,7 +2,6 @@
 module Agda.Syntax.Internal.Elim where
 
 import Control.DeepSeq
-import Data.Data (Data)
 
 import Agda.Syntax.Common
 import Agda.Syntax.Concrete.Pretty () -- Pretty Arg instance
@@ -20,7 +19,7 @@ data Elim' a
   = Apply (Arg a)         -- ^ Application.
   | Proj ProjOrigin QName -- ^ Projection.  'QName' is name of a record projection.
   | IApply a a a -- ^ IApply x y r, x and y are the endpoints
-  deriving (Data, Show, Functor, Foldable, Traversable)
+  deriving (Show, Functor, Foldable, Traversable)
 
 -- | This instance cheats on 'Proj', use with care.
 --   'Proj's are always assumed to be 'UserWritten', since they have no 'ArgInfo'.

--- a/src/full/Agda/Syntax/Literal.hs
+++ b/src/full/Agda/Syntax/Literal.hs
@@ -5,7 +5,6 @@ import Control.DeepSeq
 import Data.Char
 import Data.Word
 
-import Data.Data (Data)
 import Data.Text (Text)
 import qualified Data.Text as T
 
@@ -25,7 +24,7 @@ data Literal
   | LitChar   !Char
   | LitQName  !QName
   | LitMeta   AbsolutePath MetaId
-  deriving (Data, Show)
+  deriving Show
 
 instance Pretty Literal where
     pretty (LitNat n)     = pretty n

--- a/src/full/Agda/Syntax/Parser/Monad.hs
+++ b/src/full/Agda/Syntax/Parser/Monad.hs
@@ -37,7 +37,6 @@ import Control.Monad.Except
 import Control.Monad.State
 
 import Data.Int
-import Data.Data  ( Data )
 import Data.Maybe ( listToMaybe )
 
 import Agda.Interaction.Options.Warnings
@@ -172,7 +171,7 @@ data ParseWarning
     -- ^ Unsupported attribute.
   | MultipleAttributes Range !(Maybe String)
     -- ^ Multiple attributes.
-  deriving (Data, Show)
+  deriving Show
 
 instance NFData ParseWarning where
   rnf (OverlappingTokensWarning _) = ()

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -73,7 +73,6 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Data (Data)
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Semigroup (Semigroup(..))
@@ -115,7 +114,7 @@ data Position' a = Pn
   , posCol  :: !Int32
     -- ^ Column number, counting from 1.
   }
-  deriving (Show, Data, Functor, Foldable, Traversable, Generic)
+  deriving (Show, Functor, Foldable, Traversable, Generic)
 
 positionInvariant :: Position' a -> Bool
 positionInvariant p =
@@ -145,7 +144,7 @@ instance NFData PositionWithoutFile where
 --
 -- Note the invariant which intervals have to satisfy: 'intervalInvariant'.
 data Interval' a = Interval { iStart, iEnd :: !(Position' a) }
-  deriving (Show, Data, Eq, Ord, Functor, Foldable, Traversable, Generic)
+  deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
 
 type Interval            = Interval' SrcFile
 type IntervalWithoutFile = Interval' ()
@@ -196,7 +195,7 @@ data Range' a
   = NoRange
   | Range !a (Seq IntervalWithoutFile)
   deriving
-    (Show, Data, Eq, Ord, Functor, Foldable, Traversable, Generic)
+    (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
 
 type Range = Range' SrcFile
 

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -21,8 +21,6 @@ import qualified Data.Set as Set
 import Data.Maybe
 import Data.Semigroup ( Semigroup(..) )
 
-import Data.Data (Data)
-
 import GHC.Generics (Generic)
 
 import Agda.Benchmarking
@@ -62,19 +60,19 @@ data Scope = Scope
       , scopeImports        :: Map C.QName A.ModuleName
       , scopeDatatypeModule :: Maybe DataOrRecordModule
       }
-  deriving (Data, Eq, Show, Generic)
+  deriving (Eq, Show, Generic)
 
 data DataOrRecordModule
   = IsDataModule
   | IsRecordModule
-  deriving (Data, Show, Eq, Enum, Bounded, Generic)
+  deriving (Show, Eq, Enum, Bounded, Generic)
 
 -- | See 'Agda.Syntax.Common.Access'.
 data NameSpaceId
   = PrivateNS        -- ^ Things not exported by this module.
   | PublicNS         -- ^ Things defined and exported by this module.
   | ImportedNS       -- ^ Things from open public, exported by this module.
-  deriving (Data, Eq, Bounded, Enum, Show, Generic)
+  deriving (Eq, Bounded, Enum, Show, Generic)
 
 allNameSpaces :: [NameSpaceId]
 allNameSpaces = [minBound..maxBound]
@@ -121,7 +119,7 @@ data ScopeInfo = ScopeInfo
       , _scopeFixities      :: C.Fixities    -- ^ Maps concrete names C.Name to fixities
       , _scopePolarities    :: C.Polarities  -- ^ Maps concrete names C.Name to polarities
       }
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 -- | For the sake of highlighting, the '_scopeInverseName' map also stores
 --   the 'KindOfName' of an @A.QName@.
@@ -129,7 +127,7 @@ data NameMapEntry = NameMapEntry
   { qnameKind     :: KindOfName     -- ^ The 'anameKind'.
   , qnameConcrete :: List1 C.QName  -- ^ Possible renderings of the abstract name.
   }
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 -- | Invariant: the 'KindOfName' components should be equal
 --   whenever we have to concrete renderings of an abstract name.
@@ -154,7 +152,7 @@ data BindingSource
   | PatternBound -- ^ @f ... =@
   | LetBound     -- ^ @let ... in@
   | WithBound    -- ^ @| ... in q@
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 instance Pretty BindingSource where
   pretty = \case
@@ -175,7 +173,7 @@ data LocalVar = LocalVar
      -- ^ If this list is not empty, the local variable is
      --   shadowed by one or more imports.
   }
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 instance Eq LocalVar where
   (==) = (==) `on` localVar
@@ -310,7 +308,7 @@ data NameSpace = NameSpace
         -- ^ All abstract names targeted by a concrete name in scope.
         --   Computed by 'recomputeInScopeSets'.
       }
-  deriving (Data, Eq, Show, Generic)
+  deriving (Eq, Show, Generic)
 
 type ThingsInScope a = Map C.Name [a]
 type NamesInScope    = ThingsInScope AbstractName
@@ -344,7 +342,7 @@ inNameSpace = case inScopeTag :: InScopeTag a of
 
 -- | Non-dependent tag for name or module.
 data NameOrModule = NameNotModule | ModuleNotName
-  deriving (Data, Eq, Ord, Show, Enum, Bounded, Generic)
+  deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 ------------------------------------------------------------------------
 -- * Decorated names
@@ -375,7 +373,7 @@ data KindOfName
   | PrimName                 -- ^ Name of a @primitive@.
   | OtherDefName             -- ^ A @DefName@, but either other kind or don't know which kind.
   -- End @DefName@.  Keep these together in sequence, for sake of @isDefName@!
-  deriving (Eq, Ord, Show, Data, Enum, Bounded, Generic)
+  deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 isDefName :: KindOfName -> Bool
 isDefName = (>= DataName)
@@ -437,7 +435,7 @@ exceptKindsOfNames = ExceptKindsOfNames . Set.fromList
 data WithKind a = WithKind
   { theKind     :: KindOfName
   , kindedThing :: a
-  } deriving (Data, Show, Eq, Ord, Functor, Foldable, Traversable)
+  } deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
 
 -- | Where does a name come from?
 --
@@ -450,7 +448,7 @@ data WhyInScope
     -- ^ Imported from another module.
   | Applied C.QName WhyInScope
     -- ^ Imported by a module application.
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 -- | A decoration of 'Agda.Syntax.Abstract.Name.QName'.
 data AbstractName = AbsName
@@ -464,11 +462,11 @@ data AbstractName = AbsName
     -- ^ Additional information needed during scope checking. Currently used
     --   for generalized data/record params.
   }
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 data NameMetadata = NoMetadata
                   | GeneralizedVarsMetadata (Map A.QName A.Name)
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 -- | A decoration of abstract syntax module names.
 data AbstractModule = AbsModule
@@ -477,7 +475,7 @@ data AbstractModule = AbsModule
   , amodLineage :: WhyInScope
     -- ^ Explanation where this name came from.
   }
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 instance Eq AbstractName where
   (==) = (==) `on` anameName
@@ -524,7 +522,7 @@ data ResolvedName
 
   | -- | Unbound name.
     UnknownName
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 instance Pretty ResolvedName where
   pretty = \case

--- a/src/full/Agda/Syntax/Treeless.hs
+++ b/src/full/Agda/Syntax/Treeless.hs
@@ -14,7 +14,6 @@ module Agda.Syntax.Treeless
 import Control.Arrow (first, second)
 import Control.DeepSeq
 
-import Data.Data (Data)
 import Data.Word
 
 import GHC.Generics (Generic)
@@ -29,13 +28,13 @@ data Compiled = Compiled
   , cArgUsage :: Maybe [ArgUsage]
       -- ^ 'Nothing' if treeless usage analysis has not run yet.
   }
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 -- | Usage status of function arguments in treeless code.
 data ArgUsage
   = ArgUsed
   | ArgUnused
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 -- | The treeless compiler can behave differently depending on the target
 --   language evaluation strategy. For instance, more aggressive erasure for
@@ -72,7 +71,7 @@ data TTerm = TVar Int
            | TCoerce TTerm  -- ^ Used by the GHC backend
            | TError TError
            -- ^ A runtime error, something bad has happened.
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 -- | Compiler-related primitives. This are NOT the same thing as primitives
 -- in Agda's surface or internal syntax!
@@ -100,7 +99,7 @@ data TPrim
   | PIf
   | PSeq
   | PITo64 | P64ToI
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 isPrimEq :: TPrim -> Bool
 isPrimEq p = p `elem` [PEqI, PEqF, PEqS, PEqC, PEqQ, PEq64]
@@ -204,12 +203,12 @@ data CaseType
   | CTString
   | CTFloat
   | CTQName
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 data CaseInfo = CaseInfo
   { caseLazy :: Bool
   , caseType :: CaseType }
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 data TAlt
   = TACon    { aCon  :: QName, aArity :: Int, aBody :: TTerm }
@@ -219,7 +218,7 @@ data TAlt
   | TAGuard  { aGuard :: TTerm, aBody :: TTerm }
   -- ^ Binds no variables
   | TALit    { aLit :: Literal,   aBody:: TTerm }
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 data TError
   = TUnreachable
@@ -231,7 +230,7 @@ data TError
   -- ^ Code which could not be obtained because of a hole in the program.
   -- This should throw a runtime error.
   -- The string gives some information about the meta variable that got compiled.
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 
 class Unreachable a where

--- a/src/full/Agda/TypeChecking/CompiledClause.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause.hs
@@ -14,11 +14,6 @@ import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Semigroup hiding (Arg(..))
 
-
-
-
-import Data.Data (Data)
-
 import GHC.Generics (Generic)
 
 import Agda.Syntax.Common
@@ -33,7 +28,7 @@ import Agda.Utils.Pretty
 import Agda.Utils.Impossible
 
 data WithArity c = WithArity { arity :: Int, content :: c }
-  deriving (Data, Functor, Foldable, Traversable, Show, Generic)
+  deriving (Functor, Foldable, Traversable, Show, Generic)
 
 -- | Branches in a case tree.
 
@@ -57,7 +52,7 @@ data Case c = Branches
     -- ^ Lazy pattern match. Requires single (non-copattern) branch with no lit
     --   branches and no catch-all.
   }
-  deriving (Data, Functor, Foldable, Traversable, Show, Generic)
+  deriving (Functor, Foldable, Traversable, Show, Generic)
 
 -- | Case tree with bodies.
 
@@ -75,7 +70,7 @@ data CompiledClauses' a
   | Fail [Arg ArgName]
     -- ^ Absurd case. Add the free variables here as well so we can build correct
     --   number of lambdas for strict backends. (#4280)
-  deriving (Data, Functor, Traversable, Foldable, Show, Generic)
+  deriving (Functor, Traversable, Foldable, Show, Generic)
 
 type CompiledClauses = CompiledClauses' Term
 

--- a/src/full/Agda/TypeChecking/Coverage/SplitTree.hs
+++ b/src/full/Agda/TypeChecking/Coverage/SplitTree.hs
@@ -15,7 +15,6 @@ module Agda.TypeChecking.Coverage.SplitTree where
 import Control.DeepSeq
 
 import Data.Tree
-import Data.Data (Data)
 
 import GHC.Generics (Generic)
 
@@ -46,10 +45,10 @@ data SplitTree' a
     , splitLazy  :: LazySplit
     , splitTrees :: SplitTrees' a -- ^ Sub split trees.
     }
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 data LazySplit = LazySplit | StrictSplit
-  deriving (Data, Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 -- | Split tree branching.  A finite map from constructor names to splittrees
 --   A list representation seems appropriate, since we are expecting not
@@ -64,7 +63,7 @@ data SplitTag
   = SplitCon QName
   | SplitLit Literal
   | SplitCatchall
-  deriving (Show, Eq, Ord, Data, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 instance Pretty SplitTag where
   pretty (SplitCon c) = pretty c

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -44,7 +44,6 @@ import qualified Data.Set as Set -- hiding (singleton, null, empty)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HMap
 import Data.Semigroup ( Semigroup, (<>)) --, Any(..) )
-import Data.Data (Data)
 import Data.String
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -815,7 +814,7 @@ instance HasFresh ProblemId where
   freshLens = stFreshProblemId
 
 newtype CheckpointId = CheckpointId Int
-  deriving (Data, Eq, Ord, Enum, Real, Integral, Num, NFData)
+  deriving (Eq, Ord, Enum, Real, Integral, Num, NFData)
 
 instance Show CheckpointId where
   show (CheckpointId n) = show n
@@ -1204,7 +1203,7 @@ instance TermLike Constraint where
 instance AllMetas Constraint
 
 data Comparison = CmpEq | CmpLeq
-  deriving (Eq, Data, Show, Generic)
+  deriving (Eq, Show, Generic)
 
 instance Pretty Comparison where
   pretty CmpEq  = "="
@@ -1246,7 +1245,7 @@ data CompareAs
                    --   But currently, we do not rely on this invariant.
   | AsSizes        -- ^ Replaces @AsTermsOf Size@.
   | AsTypes
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 instance Free CompareAs where
   freeVars' (AsTermsOf a) = freeVars' a
@@ -1319,7 +1318,7 @@ data DoGeneralize
                       --   we're currently checking the type of a generalizable variable
                       --   (this should get the default modality).
   | NoGeneralize      -- ^ Don't generalize.
-  deriving (Eq, Ord, Show, Data, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | The value of a generalizable variable. This is created to be a
 --   generalizable meta before checking the type to be generalized.
@@ -1327,7 +1326,7 @@ data GeneralizedValue = GeneralizedValue
   { genvalCheckpoint :: CheckpointId
   , genvalTerm       :: Term
   , genvalType       :: Type
-  } deriving (Show, Data, Generic)
+  } deriving (Show, Generic)
 
 ---------------------------------------------------------------------------
 -- ** Meta variables
@@ -1645,7 +1644,7 @@ type InteractionPoints = BiMap InteractionId InteractionPoint
 --   the size of the telescope in its creation environment
 --   (as stored in MetaInfo).
 data Overapplied = Overapplied | NotOverapplied
-  deriving (Eq, Show, Data, Generic)
+  deriving (Eq, Show, Generic)
 
 -- | Datatype representing a single boundary condition:
 --   x_0 = u_0, ... ,x_n = u_n ⊢ t = ?n es
@@ -1655,7 +1654,7 @@ data IPBoundary' t = IPBoundary
   , ipbMetaApp   :: t          -- ^ @?n es@
   , ipbOverapplied :: Overapplied -- ^ Is @?n@ overapplied in @?n es@ ?
   }
-  deriving (Show, Data, Functor, Foldable, Traversable, Generic)
+  deriving (Show, Functor, Foldable, Traversable, Generic)
 
 type IPBoundary = IPBoundary' Term
 
@@ -1709,7 +1708,7 @@ type RewriteRuleMap = HashMap QName RewriteRules
 type DisplayForms = HashMap QName [LocalDisplayForm]
 
 newtype Section = Section { _secTelescope :: Telescope }
-  deriving (Data, Show, NFData)
+  deriving (Show, NFData)
 
 instance Pretty Section where
   pretty = pretty . _secTelescope
@@ -1739,7 +1738,7 @@ data DisplayForm = Display
   , dfRHS :: DisplayTerm
     -- ^ Right hand side.
   }
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 type LocalDisplayForm = Open DisplayForm
 
@@ -1761,7 +1760,7 @@ data DisplayTerm
     -- ^ @.v@.
   | DTerm Term
     -- ^ @v@.
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 instance Free DisplayForm where
   freeVars' (Display n ps t) = underBinder (freeVars' ps) `mappend` underBinder' n (freeVars' t)
@@ -1815,7 +1814,7 @@ data NLPat
     -- ^ Matches @x es@ where x is a lambda-bound variable
   | PTerm Term
     -- ^ Matches the term modulo β (ideally βη).
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 type PElims = [Elim' NLPat]
 
 instance TermLike NLPat where
@@ -1842,7 +1841,7 @@ instance AllMetas NLPat
 data NLPType = NLPType
   { nlpTypeSort :: NLPSort
   , nlpTypeUnEl :: NLPat
-  } deriving (Data, Show, Generic)
+  } deriving (Show, Generic)
 
 instance TermLike NLPType where
   traverseTermM f (NLPType s t) = NLPType <$> traverseTermM f s <*> traverseTermM f t
@@ -1859,7 +1858,7 @@ data NLPSort
   | PSizeUniv
   | PLockUniv
   | PIntervalUniv
-  deriving (Data, Show, Generic)
+  deriving (Show, Generic)
 
 instance TermLike NLPSort where
   traverseTermM f = \case
@@ -1895,7 +1894,7 @@ data RewriteRule = RewriteRule
   , rewType    :: Type       -- ^ @Γ ⊢ t@.
   , rewFromClause :: Bool    -- ^ Was this rewrite rule created from a clause in the definition of the function?
   }
-    deriving (Data, Show, Generic)
+    deriving (Show, Generic)
 
 data Definition = Defn
   { defArgInfo        :: ArgInfo -- ^ Hiding should not be used.
@@ -1993,7 +1992,7 @@ data NumGeneralizableArgs
   | SomeGeneralizableArgs !Int
     -- ^ When lambda-lifting new args are generalizable if
     --   'SomeGeneralizableArgs', also when the number is zero.
-  deriving (Data, Show)
+  deriving Show
 
 theDefLens :: Lens' Defn Definition
 theDefLens f d = f (theDef d) <&> \ df -> d { theDef = df }
@@ -2029,7 +2028,7 @@ data Polarity
   | Contravariant  -- ^ antitone
   | Invariant      -- ^ no information (mixed variance)
   | Nonvariant     -- ^ constant
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 instance Pretty Polarity where
   pretty = text . \case
@@ -2042,11 +2041,11 @@ instance Pretty Polarity where
 data IsForced
   = Forced
   | NotForced
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 -- | The backends are responsible for parsing their own pragmas.
 data CompilerPragma = CompilerPragma Range String
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 instance HasRange CompilerPragma where
   getRange (CompilerPragma r _) = r
@@ -2075,7 +2074,7 @@ data System = System
     -- ^ the telescope Δ, binding vars for the clauses, Γ ⊢ Δ
   , systemClauses :: [(Face,Term)]
     -- ^ a system [φ₁ u₁, ... , φₙ uₙ] where Γ, Δ ⊢ φᵢ and Γ, Δ, φᵢ ⊢ uᵢ
-  } deriving (Data, Show, Generic)
+  } deriving (Show, Generic)
 
 -- | Additional information for extended lambdas.
 data ExtLamInfo = ExtLamInfo
@@ -2088,7 +2087,7 @@ data ExtLamInfo = ExtLamInfo
   , extLamAbsurd :: Bool
     -- ^ Was this definition created from an absurd lambda @λ ()@?
   , extLamSys :: !(Strict.Maybe System)
-  } deriving (Data, Show, Generic)
+  } deriving (Show, Generic)
 
 modifySystem :: (System -> System) -> ExtLamInfo -> ExtLamInfo
 modifySystem f e = let !e' = e { extLamSys = f <$> extLamSys e } in e'
@@ -2120,11 +2119,11 @@ data Projection = Projection
     --   (Invariant: the number of abstractions equals 'projIndex'.)
     --   In case of a projection-like function, just the function symbol
     --   is returned as 'Def':  @t = \ pars -> f@.
-  } deriving (Data, Show, Generic)
+  } deriving (Show, Generic)
 
 -- | Abstractions to build projection function (dropping parameters).
 newtype ProjLams = ProjLams { getProjLams :: [Arg ArgName] }
-  deriving (Data, Show, Null, Generic)
+  deriving (Show, Null, Generic)
 
 -- | Building the projection function (which drops the parameters).
 projDropPars :: Projection -> ProjOrigin -> Term
@@ -2149,7 +2148,7 @@ projArgInfo (Projection _ _ _ _ lams) =
 data EtaEquality
   = Specified { theEtaEquality :: !HasEta }  -- ^ User specifed 'eta-equality' or 'no-eta-equality'.
   | Inferred  { theEtaEquality :: !HasEta }  -- ^ Positivity checker inferred whether eta is safe.
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 instance PatternMatchingAllowed EtaEquality where
   patternMatchingAllowed = patternMatchingAllowed . theEtaEquality
@@ -2166,13 +2165,13 @@ data FunctionFlag
   = FunStatic  -- ^ Should calls to this function be normalised at compile-time?
   | FunInline  -- ^ Should calls to this function be inlined by the compiler?
   | FunMacro   -- ^ Is this function a macro?
-  deriving (Data, Eq, Ord, Enum, Show, Generic)
+  deriving (Eq, Ord, Enum, Show, Generic)
 
 data CompKit = CompKit
   { nameOfHComp :: Maybe QName
   , nameOfTransp :: Maybe QName
   }
-  deriving (Data, Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 emptyCompKit :: CompKit
 emptyCompKit = CompKit Nothing Nothing
@@ -2327,7 +2326,7 @@ data Defn = Axiom -- ^ Postulate
             { primName :: String
             , primSort :: Sort
             }
-    deriving (Data, Show, Generic)
+    deriving (Show, Generic)
 
 instance Pretty Definition where
   pretty Defn{..} =
@@ -2508,7 +2507,7 @@ newtype Fields = Fields [(C.Name, Type)]
 --   (unfolding of definitions) does not count as simplifying?
 
 data Simplification = YesSimplification | NoSimplification
-  deriving (Data, Eq, Show, Generic)
+  deriving (Eq, Show, Generic)
 
 instance Null Simplification where
   empty = NoSimplification
@@ -2576,7 +2575,7 @@ data AllowedReduction
                              --   by confluence checker)
   | UnconfirmedReductions    -- ^ Functions whose termination has not (yet) been confirmed.
   | NonTerminatingReductions -- ^ Functions that have failed termination checking.
-  deriving (Show, Eq, Ord, Enum, Bounded, Ix, Data, Generic)
+  deriving (Show, Eq, Ord, Enum, Bounded, Ix, Generic)
 
 type AllowedReductions = SmallSet AllowedReduction
 
@@ -2590,7 +2589,7 @@ reallyAllReductions = SmallSet.total
 data ReduceDefs
   = OnlyReduceDefs (Set QName)
   | DontReduceDefs (Set QName)
-  deriving (Data, Generic)
+  deriving Generic
 
 reduceAllDefs :: ReduceDefs
 reduceAllDefs = DontReduceDefs empty
@@ -2712,19 +2711,20 @@ defForced d = case theDef d of
 type FunctionInverse = FunctionInverse' Clause
 type InversionMap c = Map TermHead [c]
 
-data WhenInjective = AlwaysInjective | UnlessCubical deriving (Data,Show,Generic)
+data WhenInjective = AlwaysInjective | UnlessCubical
+  deriving (Show, Generic)
 
 data FunctionInverse' c
   = NotInjective
   | Inverse WhenInjective (InversionMap c)
-  deriving (Data, Show, Functor, Generic)
+  deriving (Show, Functor, Generic)
 
 data TermHead = SortHead
               | PiHead
               | ConsHead QName
               | VarHead Nat
               | UnknownHead
-  deriving (Data, Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance Pretty TermHead where
   pretty = \ case
@@ -2739,7 +2739,7 @@ instance Pretty TermHead where
 ---------------------------------------------------------------------------
 
 newtype MutualId = MutId Int32
-  deriving (Data, Eq, Ord, Show, Num, Enum, NFData)
+  deriving (Eq, Ord, Show, Num, Enum, NFData)
 
 ---------------------------------------------------------------------------
 -- ** Statistics
@@ -2788,7 +2788,7 @@ data Call
   | NoHighlighting
   | ModuleContents  -- ^ Interaction command: show module contents.
   | SetRange Range  -- ^ used by 'setCurrentRange'
-  deriving (Data, Generic)
+  deriving Generic
 
 instance Pretty Call where
     pretty CheckClause{}             = "CheckClause"
@@ -2923,7 +2923,7 @@ data HighlightingLevel
     -- ^ This includes both non-interactive highlighting and
     -- interactive highlighting of the expression that is currently
     -- being type-checked.
-    deriving (Eq, Ord, Show, Read, Data, Generic)
+    deriving (Eq, Ord, Show, Read, Generic)
 
 -- | How should highlighting be sent to the user interface?
 
@@ -2932,7 +2932,7 @@ data HighlightingMethod
     -- ^ Via stdout.
   | Indirect
     -- ^ Both via files and via stdout.
-    deriving (Eq, Show, Read, Data, Generic)
+    deriving (Eq, Show, Read, Generic)
 
 -- | @ifTopLevelAndHighlightingLevelIs l b m@ runs @m@ when we're
 -- type-checking the top-level module (or before we've started doing
@@ -3189,7 +3189,7 @@ instance LensQuantity  TCEnv where
 
 data UnquoteFlags = UnquoteFlags
   { _unquoteNormalise :: Bool }
-  deriving (Data, Generic)
+  deriving Generic
 
 defaultUnquoteFlags :: UnquoteFlags
 defaultUnquoteFlags = UnquoteFlags
@@ -3375,7 +3375,7 @@ data AbstractMode
   = AbstractMode        -- ^ Abstract things in the current module can be accessed.
   | ConcreteMode        -- ^ No abstract things can be accessed.
   | IgnoreAbstractMode  -- ^ All abstract things can be accessed.
-  deriving (Data, Show, Eq, Generic)
+  deriving (Show, Eq, Generic)
 
 aDefToMode :: IsAbstract -> AbstractMode
 aDefToMode AbstractDef = AbstractMode
@@ -3394,7 +3394,7 @@ data ExpandHidden
   = ExpandLast      -- ^ Add implicit arguments in the end until type is no longer hidden 'Pi'.
   | DontExpandLast  -- ^ Do not append implicit arguments.
   | ReallyDontExpandLast -- ^ Makes 'doExpandLast' have no effect. Used to avoid implicit insertion of arguments to metavariables.
-  deriving (Eq, Data, Generic)
+  deriving (Eq, Generic)
 
 isDontExpandLast :: ExpandHidden -> Bool
 isDontExpandLast ExpandLast           = False
@@ -3404,7 +3404,7 @@ isDontExpandLast ReallyDontExpandLast = True
 data CandidateKind
   = LocalCandidate
   | GlobalCandidate QName
-  deriving (Show, Data, Generic)
+  deriving (Show, Generic)
 
 -- | A candidate solution for an instance meta is a term with its type.
 --   It may be the case that the candidate is not fully applied yet or
@@ -3414,7 +3414,7 @@ data Candidate  = Candidate { candidateKind :: CandidateKind
                             , candidateType :: Type
                             , candidateOverlappable :: Bool
                             }
-  deriving (Show, Data, Generic)
+  deriving (Show, Generic)
 
 instance Free Candidate where
   freeVars' (Candidate _ t u _) = freeVars' (t, u)
@@ -3577,7 +3577,7 @@ data RecordFieldWarning
   | TooManyFieldsWarning QName [C.Name] [(C.Name, Range)]
       -- ^ Record type, fields not supplied by user, non-fields but supplied.
       --   The redundant fields come with a range of associated dead code.
-  deriving (Show, Data, Generic)
+  deriving (Show, Generic)
 
 recordFieldWarningToError :: RecordFieldWarning -> TypeError
 recordFieldWarningToError = \case

--- a/src/full/Agda/TypeChecking/Positivity/Occurrence.hs
+++ b/src/full/Agda/TypeChecking/Positivity/Occurrence.hs
@@ -11,8 +11,6 @@ module Agda.TypeChecking.Positivity.Occurrence
 import Control.DeepSeq
 import Control.Monad
 
-import Data.Data (Data)
-
 import Data.Foldable (toList)
 
 import Data.Map.Strict (Map)
@@ -46,7 +44,7 @@ data OccursWhere
     -- includes the main information, and if the first sequence is
     -- non-empty, then it includes information about the context of
     -- the second sequence.
-  deriving (Show, Eq, Ord, Data, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 instance NFData OccursWhere
 
@@ -63,7 +61,7 @@ data Where
   | Matched          -- ^ matched against in a clause of a defined function
   | IsIndex          -- ^ is an index of an inductive family
   | InDefOf QName    -- ^ in the definition of a constant
-  deriving (Show, Eq, Ord, Data, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 instance NFData Where
 
@@ -78,7 +76,7 @@ data Occurrence
   | StrictPos -- ^ Strictly positive occurrence.
   | GuardPos  -- ^ Guarded strictly positive occurrence (i.e., under ∞).  For checking recursive records.
   | Unused    --  ^ No occurrence.
-  deriving (Data, Show, Eq, Ord, Enum, Bounded)
+  deriving (Show, Eq, Ord, Enum, Bounded)
 
 -- Pretty instances.
 

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -17,7 +17,6 @@ import Control.Monad.Except
 import Control.Monad.Trans ( lift )
 import Control.Exception
 
-import Data.Typeable
 import Data.String
 
 import Data.Bifunctor ( second )

--- a/src/full/Agda/Utils/BoolSet.hs
+++ b/src/full/Agda/Utils/BoolSet.hs
@@ -36,13 +36,11 @@ module Agda.Utils.BoolSet
 
 import Prelude hiding (null)
 
-import Data.Data (Data)
-
 import Agda.Utils.Impossible
 
 -- | Isomorphic to @'Set' 'Bool'@.
 data BoolSet = SetEmpty | SetTrue | SetFalse | SetBoth
-  deriving (Eq, Ord, Show, Enum, Bounded, Data)
+  deriving (Eq, Ord, Show, Enum, Bounded)
 
 -- * Query
 

--- a/src/full/Agda/Utils/Empty.hs
+++ b/src/full/Agda/Utils/Empty.hs
@@ -4,14 +4,10 @@ module Agda.Utils.Empty where
 import Control.DeepSeq
 import Control.Exception (evaluate)
 
-import Data.Data (Data)
-
 import Agda.Utils.Impossible
 
 
 data Empty
-
-deriving instance Data Empty
 
 -- | Values of type 'Empty' are not forced, because 'Empty' is used as
 -- a constructor argument in 'Agda.Syntax.Internal.Substitution''.

--- a/src/full/Agda/Utils/FileName.hs
+++ b/src/full/Agda/Utils/FileName.hs
@@ -22,7 +22,6 @@ import Control.Exception   ( bracket )
 import System.Win32        ( findFirstFile, findClose, getFindDataFileName )
 #endif
 
-import Data.Data           ( Data )
 import Data.Function
 import Data.Hashable       ( Hashable )
 import Data.Text           ( Text )
@@ -39,7 +38,7 @@ import Agda.Utils.Impossible
 -- paths point to the same files or directories.
 
 newtype AbsolutePath = AbsolutePath { textPath :: Text }
-  deriving (Show, Eq, Ord, Data, Hashable, NFData)
+  deriving (Show, Eq, Ord, Hashable, NFData)
 
 -- | Extract the 'AbsolutePath' to be used as 'FilePath'.
 filePath :: AbsolutePath -> FilePath

--- a/src/full/Agda/Utils/List2.hs
+++ b/src/full/Agda/Utils/List2.hs
@@ -15,7 +15,6 @@ module Agda.Utils.List2
 import Control.DeepSeq
 import Control.Monad                   ( (<=<) )
 
-import Data.Data                       ( Data )
 import qualified Data.List as List
 
 import GHC.Exts                        ( IsList(..) )
@@ -28,7 +27,7 @@ import Agda.Utils.Impossible
 
 -- | Lists of length ≥2.
 data List2 a = List2 a a [a]
-  deriving (Eq, Ord, Show, Data, Functor, Foldable, Traversable)
+  deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
 
 -- | Safe. O(1).
 head :: List2 a -> a

--- a/src/full/Agda/Utils/Maybe/Strict.hs
+++ b/src/full/Agda/Utils/Maybe/Strict.hs
@@ -5,7 +5,7 @@
 -- especially since it depends on lens which we consciously ruled out.
 
 {-# LANGUAGE CPP #-}
-
+{-# LANGUAGE DeriveDataTypeable #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -15,8 +15,6 @@ import Data.Functor.Identity
 import qualified Data.List as List
 import Data.Maybe
 
-import Data.Data (Data)
-
 import GHC.Generics (Generic)
 
 import Agda.Utils.Functor
@@ -38,7 +36,7 @@ import Agda.Utils.Impossible
 --   @Perm : {m : Nat}(n : Nat) -> Vec (Fin n) m -> Permutation@
 --   @m@ is the 'size' of the permutation.
 data Permutation = Perm { permRange :: Int, permPicks :: [Int] }
-  deriving (Eq, Data, Generic)
+  deriving (Eq, Generic)
 
 instance Show Permutation where
   show (Perm n xs) = showx [0..n - 1] ++ " -> " ++ showx xs
@@ -266,7 +264,7 @@ data Drop a = Drop
   { dropN    :: Int  -- ^ Non-negative number of things to drop.
   , dropFrom :: a    -- ^ Where to drop from.
   }
-  deriving (Eq, Ord, Show, Data, Functor, Foldable, Traversable)
+  deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
 
 -- | Things that support delayed dropping.
 class DoDrop a where

--- a/src/full/Agda/Utils/Pointer.hs
+++ b/src/full/Agda/Utils/Pointer.hs
@@ -13,20 +13,10 @@ import Data.IORef
 
 import System.IO.Unsafe
 
-import Data.Data (Data (..))
-import Data.Typeable (Typeable)
-
 import Agda.Utils.Impossible
 
 data Ptr a = Ptr { ptrTag :: !Integer
                  , ptrRef :: !(IORef a) }
-  deriving Data
-
--- cheating because you shouldn't be digging this far anyway
-instance Typeable a => Data (IORef a) where
-  gunfold _ _ _ = __IMPOSSIBLE__
-  toConstr      = __IMPOSSIBLE__
-  dataTypeOf    = __IMPOSSIBLE__
 
 {-# NOINLINE freshVar #-}
 freshVar :: MVar Integer

--- a/src/full/Agda/Utils/Pretty.hs
+++ b/src/full/Agda/Utils/Pretty.hs
@@ -10,7 +10,6 @@ module Agda.Utils.Pretty
 
 import Prelude hiding (null)
 
-import Data.Data (Data(..))
 import qualified Data.Foldable as Fold
 import Data.Int (Int32)
 import Data.IntSet (IntSet)
@@ -174,12 +173,6 @@ align max rows =
 -- | Handles strings with newlines properly (preserving indentation)
 multiLineText :: String -> Doc
 multiLineText = vcat . map text . lines
-
--- cheating because you shouldn't be digging this far anyway
-instance Data Doc where
-  gunfold _ _ _ = __IMPOSSIBLE__
-  toConstr      = __IMPOSSIBLE__
-  dataTypeOf    = __IMPOSSIBLE__
 
 infixl 6 <?>
 -- | @a <?> b = hang a 2 b@

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -42,14 +42,13 @@ import Control.DeepSeq
 
 import Data.Array.IArray (Ix, Array)
 import qualified Data.Array.IArray as Array
-import Data.Data (Data)
 
 -- Note: we might want to use unboxed arrays, but they have no Data instance
 
 -- | Let @n@ be the size of type @a@.
 type SmallSetElement a = (Bounded a, Ix a)
 newtype SmallSet a = SmallSet { theSmallSet :: Array a Bool }
-  deriving (Eq, Ord, Show, Data, NFData)
+  deriving (Eq, Ord, Show, NFData)
 
 -- * Query
 

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -25,7 +25,7 @@ module Agda.Utils.SmallSet
   , insert
   , intersection
   , isSubsetOf
-  , mapMemberShip
+  , mapMembership
   , member
   , notMember
   , null
@@ -33,7 +33,7 @@ module Agda.Utils.SmallSet
   , toList, toAscList
   , total
   , union
-  , zipMemberShipWith
+  , zipMembershipWith
   ) where
 
 import Prelude hiding (null)
@@ -102,28 +102,28 @@ delete a = update [(a,False)]
 
 -- | Time O(n).
 complement :: SmallSetElement a => SmallSet a -> SmallSet a
-complement = mapMemberShip not
+complement = mapMembership not
 
 -- | Time O(n).
 difference, (\\) :: SmallSetElement a => SmallSet a -> SmallSet a -> SmallSet a
-difference = zipMemberShipWith $ \ b c -> b && not c
+difference = zipMembershipWith $ \ b c -> b && not c
 (\\)       = difference
 
 -- | Time O(n).
 intersection ::  SmallSetElement a => SmallSet a -> SmallSet a -> SmallSet a
-intersection = zipMemberShipWith (&&)
+intersection = zipMembershipWith (&&)
 
 -- | Time O(n).
 union ::  SmallSetElement a => SmallSet a -> SmallSet a -> SmallSet a
-union = zipMemberShipWith (||)
+union = zipMembershipWith (||)
 
 -- | Time O(n).
-mapMemberShip :: SmallSetElement a => (Bool -> Bool) -> SmallSet a -> SmallSet a
-mapMemberShip f = SmallSet . Array.amap f . theSmallSet
+mapMembership :: SmallSetElement a => (Bool -> Bool) -> SmallSet a -> SmallSet a
+mapMembership f = SmallSet . Array.amap f . theSmallSet
 
 -- | Time O(n).
-zipMemberShipWith :: SmallSetElement a => (Bool -> Bool -> Bool) -> SmallSet a -> SmallSet a -> SmallSet a
-zipMemberShipWith f s t = fromBoolList $ toBoolListZipWith f s t
+zipMembershipWith :: SmallSetElement a => (Bool -> Bool -> Bool) -> SmallSet a -> SmallSet a -> SmallSet a
+zipMembershipWith f s t = fromBoolList $ toBoolListZipWith f s t
 
 -- * Conversion
 

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -44,6 +44,13 @@ import Data.Array.IArray (Ix, Array)
 import qualified Data.Array.IArray as Array
 
 -- Note: we might want to use unboxed arrays, but they have no Data instance
+--
+-- Update: There is currently no need for a Data instance. An attempt
+-- was made to replace Array with Data.Array.Unboxed.UArray. Limited
+-- testing suggested that this does not make much of a difference in
+-- practice (at least not when it comes to type-checking the standard
+-- library up to and including Data.Nat, with Agda compiled without
+-- -foptimise-heavily).
 
 -- | Let @n@ be the size of type @a@.
 type SmallSetElement a = (Bounded a, Ix a)


### PR DESCRIPTION
Does anyone object to the removal of all `Data` instances? We do not use these instances, and I am not aware of any plans to use them for anything. If they are removed the binaries might become a little smaller (depending on how Agda is compiled), and compilation times might go down a little.