### PR TITLE
Switched to Cabal 1.24

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -1,6 +1,6 @@
 name:            Agda
 version:         2.6.3
-cabal-version:   >= 1.10
+cabal-version:   1.24
 build-type:      Custom
 license:         OtherLicense
 license-file:    LICENSE


### PR DESCRIPTION
This version of Cabal comes with GHC 8.0, and `custom-setup` stanzas are not supported by earlier versions of Cabal.