### PR TITLE
Fix #6108: higher constructors are not guardedness-preserving

### DIFF
--- a/src/full/Agda/Syntax/Internal/Elim.hs
+++ b/src/full/Agda/Syntax/Internal/Elim.hs
@@ -41,6 +41,13 @@ isApplyElim (IApply _ _ r) = Just (defaultArg r)
 isApplyElim' :: Empty -> Elim' a -> Arg a
 isApplyElim' e = fromMaybe (absurd e) . isApplyElim
 
+-- | Only 'Apply' variant.
+isProperApplyElim :: Elim' a -> Bool
+isProperApplyElim = \case
+  Apply _  -> True
+  IApply{} -> False
+  Proj{}   -> False
+
 -- | Drop 'Apply' constructors. (Safe)
 allApplyElims :: [Elim' a] -> Maybe [Arg a]
 allApplyElims = mapM isApplyElim
@@ -79,4 +86,3 @@ instance NFData a => NFData (Elim' a) where
   rnf (Apply x) = rnf x
   rnf Proj{}    = ()
   rnf (IApply x y r) = rnf x `seq` rnf y `seq` rnf r
-

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1013,7 +1013,9 @@ instance ExtractCalls Term where
       Con ConHead{conName = c, conDataRecord = dataOrRec} _ es -> do
         let args = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
         -- A constructor preserves the guardedness of all its arguments.
-        let argsg = zip args $ repeat True
+        -- Andreas, 2022-09-19, issue #6108:
+        -- A higher constructor does not.  So check if there is an @IApply@ amoung @es@.
+        let argsg = zip args $ repeat $ all isProperApplyElim es
 
         -- If we encounter a coinductive record constructor
         -- in a type mutual with the current target

--- a/test/Fail/Issue6108.agda
+++ b/test/Fail/Issue6108.agda
@@ -1,0 +1,27 @@
+-- Andreas, 2022-09-19, issue #6108, reported by dolio.
+-- Test case by nad.
+
+-- Higher constructors should not be guarding.
+
+{-# OPTIONS --safe --cubical --guardedness #-}
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Primitive.Cubical
+
+mutual
+
+  record R : Set where
+    coinductive
+    field
+      force : D
+
+  data D : Set where
+    higher : R.force ≡ R.force
+
+-- This should not be accepted, since `higher i0` reduces to `R.force`.
+r : I → R
+r i .R.force = higher i (r i)
+
+-- This loops...
+loops : ∀ {x : D} → x ≡ r i0 .R.force
+loops _ = r i0 .R.force

--- a/test/Fail/Issue6108.err
+++ b/test/Fail/Issue6108.err
@@ -1,0 +1,9 @@
+Issue6108.agda:22,1-23,30
+Termination checking failed for the following functions:
+  r
+Problematic calls:
+  r i
+    (at Issue6108.agda:23,26-27)
+Issue6108.agda:26,1-6
+x != r i0 .R.force of type D
+when checking the definition of loops


### PR DESCRIPTION
Fix #6108: higher constructors are not guardedness-preserving