### PR TITLE
Fix broken nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650161686,
-        "narHash": "sha256-70ZWAlOQ9nAZ08OU6WY7n4Ij2kOO199dLfNlvO/+pf8=",
+        "lastModified": 1663551060,
+        "narHash": "sha256-e2SR4cVx9p7aW/XnVsGsWZBplApA9ZJUjc0fejJhnYo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
+        "rev": "8a5b9ee7b7a2b38267c9481f5c629c015108ab0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR updates the hashes in `flake.lock` in order to fix the following issue with the nix flake that the repository provides.

When I run
```bash
nix shell github:agda/agda
```
I get this error:
```
error: Package ‘vector-hashtables-0.1.1.1’ in /nix/store/h96rpxzp4q192r3fnwzclg3rmdg4nlqk-source/pkgs/development/haskell-modules/hackage-packages.nix:287393 is marked as broken, refusing to evaluate.
[...]
```
This seems to be the case since `vector-hashtables` was added in `Agda.cabal` in https://github.com/agda/agda/commit/98c9382a59f707c2c97d75919e389fc2a783ac75. The package `vector-hashtables` was indeed marked as broken in the version of `nixpkgs` that the current `flake.lock` specifies (commit 1ffba9f...), as one can see [here](https://raw.githubusercontent.com/NixOS/nixpkgs/1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887/pkgs/development/haskell-modules/hackage-packages.nix).

With the updated `flake.lock`, the flake works fine as far as I can tell. I tested it by running
```bash
nix shell github:MatthiasHu/agda/687be86f5a030441f884cfecdd015034fd02d196
```
which successfully builds Agda.

@ncfavier Can you comment on this (as the last person who changed `flake.lock`)?