### PR TITLE
Added the module Agda.Syntax.Scope.Flat

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -419,6 +419,7 @@ library
                     Agda.Syntax.Position
                     Agda.Syntax.Reflected
                     Agda.Syntax.Scope.Base
+                    Agda.Syntax.Scope.Flat
                     Agda.Syntax.Scope.Monad
                     Agda.Syntax.Translation.AbstractToConcrete
                     Agda.Syntax.Translation.ConcreteToAbstract

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -19,7 +19,6 @@ module Agda.Syntax.Concrete.Operators
     ) where
 
 import Control.Applicative ( Alternative((<|>)))
-import Control.Arrow (second)
 import Control.Monad.Except (throwError)
 
 import Data.Either (partitionEithers)
@@ -42,6 +41,7 @@ import qualified Agda.Syntax.Abstract.Name as A
 import Agda.Syntax.Position
 import Agda.Syntax.Notation
 import Agda.Syntax.Scope.Base
+import Agda.Syntax.Scope.Flat
 import Agda.Syntax.Scope.Monad
 
 import Agda.TypeChecking.Monad.Base (typeError, TypeError(..), LHSOrPatSyn(..))
@@ -80,45 +80,6 @@ billToParser k = Bench.billTo
 ---------------------------------------------------------------------------
 -- * Building the parser
 ---------------------------------------------------------------------------
-
-type FlatScope = Map QName [AbstractName]
-
--- | Compute all defined names in scope and their fixities/notations.
--- Note that overloaded names (constructors) can have several
--- fixities/notations. Then we 'mergeNotations'. (See issue 1194.)
-getDefinedNames :: KindsOfNames -> FlatScope -> [[NewNotation]]
-getDefinedNames kinds names =
-  [ mergeNotations $ map (namesToNotation x . A.qnameName . anameName) ds
-  | (x, ds) <- Map.toList names
-  , any ((`elemKindsOfNames` kinds) . anameKind) ds
-  , not (null ds)
-  ]
-  -- Andreas, 2013-03-21 see Issue 822
-  -- Names can have different kinds, i.e., 'defined' and 'constructor'.
-  -- We need to consider all names that have *any* matching kind,
-  -- not only those whose first appearing kind is matching.
-
--- | Compute all names (first component) and operators/notations
--- (second component) in scope.
-localNames :: FlatScope -> ScopeM ([QName], [NewNotation])
-localNames flat = do
-  let defs = getDefinedNames allKindsOfNames flat
-  locals <- nubOn fst . notShadowedLocals <$> getLocalVars
-  -- Note: Debug printout aligned with the one in buildParsers.
-  reportS "scope.operators" 50
-    [ "flat  = " ++ prettyShow flat
-    , "defs  = " ++ prettyShow defs
-    , "locals= " ++ prettyShow locals
-    ]
-  let localNots  = map localOp locals
-      notLocal   = not . hasElem (map notaName localNots) . notaName
-      otherNots  = concatMap (filter notLocal) defs
-  return $ second (map useDefaultFixity) $ split $ localNots ++ otherNots
-  where
-    localOp (x, y) = namesToNotation (QName x) y
-    split          = partitionEithers . concatMap opOrNot
-    opOrNot n      = Left (notaName n) :
-                     [Right n | not (null (notation n))]
 
 -- | A data structure used internally by 'buildParsers'.
 data InternalParsers e = InternalParsers

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -1094,7 +1094,9 @@ concreteNamesInScope scope =
 
     build :: (forall a. InScope a => Scope -> ThingsInScope a) -> Scope -> Set C.QName
     build getNames s = Set.unions $
-        Set.fromList (map C.QName $ Map.keys (getNames s :: ThingsInScope AbstractName)) :
+        Set.fromAscList
+          (map C.QName $
+           Map.keys (getNames s :: ThingsInScope AbstractName)) :
           [ Set.mapMonotonic (\ y -> C.Qual x y) $
               build exportedNamesInScope $ moduleScope m
           | (x, mods) <- Map.toList (getNames s)

--- a/src/full/Agda/Syntax/Scope/Flat.hs
+++ b/src/full/Agda/Syntax/Scope/Flat.hs
@@ -49,7 +49,7 @@ flattenScope ms scope =
                , let -- get the suffixes of c in ms
                      ms' = mapMaybe (List.stripPrefix $ List1.toList $ qnameParts c) ms
                , not $ null ms' ]
-    qual c = Map.mapKeys (q c)
+    qual c = Map.mapKeysMonotonic (q c)
       where
         q (QName x)  = Qual x
         q (Qual m x) = Qual m . q x

--- a/src/full/Agda/Syntax/Scope/Flat.hs
+++ b/src/full/Agda/Syntax/Scope/Flat.hs
@@ -1,0 +1,104 @@
+-- | Flattened scopes.
+module Agda.Syntax.Scope.Flat
+  ( FlatScope
+  , flattenScope
+  , getDefinedNames
+  , localNames
+  ) where
+
+import Data.Bifunctor
+import Data.Either (partitionEithers)
+import qualified Data.List as List
+import Data.Map (Map)
+import qualified Data.Map as Map
+
+import qualified Agda.Syntax.Abstract.Name as A
+import Agda.Syntax.Concrete
+import Agda.Syntax.Notation
+import Agda.Syntax.Scope.Base
+import Agda.Syntax.Scope.Monad
+
+import Agda.TypeChecking.Monad.Debug
+
+import Agda.Utils.Impossible
+import Agda.Utils.Lens
+import Agda.Utils.List
+import qualified Agda.Utils.List1 as List1
+import Agda.Utils.Maybe
+import Agda.Utils.Pretty
+
+-- | Flattened scopes.
+type FlatScope = Map QName [AbstractName]
+
+-- | Compute a flattened scope. Only include unqualified names or names
+-- qualified by modules in the first argument.
+flattenScope :: [[Name]] -> ScopeInfo -> FlatScope
+flattenScope ms scope =
+  Map.unionWith (++)
+    (build ms allNamesInScope root)
+    imported
+  where
+    current = moduleScope $ scope ^. scopeCurrent
+    root    = mergeScopes $ current : map moduleScope (scopeParents current)
+
+    imported = Map.unionsWith (++)
+               [ qual c (build ms' exportedNamesInScope $ moduleScope a)
+               | (c, a) <- Map.toList $ scopeImports root
+               , let -- get the suffixes of c in ms
+                     ms' = mapMaybe (List.stripPrefix $ List1.toList $ qnameParts c) ms
+               , not $ null ms' ]
+    qual c = Map.mapKeys (q c)
+      where
+        q (QName x)  = Qual x
+        q (Qual m x) = Qual m . q x
+
+    build :: [[Name]] -> (forall a. InScope a => Scope -> ThingsInScope a) -> Scope -> Map QName [AbstractName]
+    build ms getNames s = Map.unionsWith (++) $
+        Map.mapKeysMonotonic QName (getNames s) :
+          [ Map.mapKeysMonotonic (\ y -> Qual x y) $
+              build ms' exportedNamesInScope $ moduleScope m
+          | (x, mods) <- Map.toList (getNames s)
+          , let ms' = [ tl | hd:tl <- ms, hd == x ]
+          , not $ null ms'
+          , AbsModule m _ <- mods ]
+
+    moduleScope :: A.ModuleName -> Scope
+    moduleScope m = fromMaybe __IMPOSSIBLE__ $ Map.lookup m $ scope ^. scopeModules
+
+-- | Compute all defined names in scope and their fixities/notations.
+-- Note that overloaded names (constructors) can have several
+-- fixities/notations. Then we 'mergeNotations'. (See issue 1194.)
+getDefinedNames :: KindsOfNames -> FlatScope -> [[NewNotation]]
+getDefinedNames kinds names =
+  [ mergeNotations $ map (namesToNotation x . A.qnameName . anameName) ds
+  | (x, ds) <- Map.toList names
+  , any ((`elemKindsOfNames` kinds) . anameKind) ds
+  , not (null ds)
+  ]
+  -- Andreas, 2013-03-21 see Issue 822
+  -- Names can have different kinds, i.e., 'defined' and 'constructor'.
+  -- We need to consider all names that have *any* matching kind,
+  -- not only those whose first appearing kind is matching.
+
+-- | Compute all names (first component) and operators/notations
+-- (second component) in scope.
+localNames :: FlatScope -> ScopeM ([QName], [NewNotation])
+localNames flat = do
+  let defs = getDefinedNames allKindsOfNames flat
+  locals <- nubOn fst . notShadowedLocals <$> getLocalVars
+  -- Note: Debug printout aligned with the one in
+  -- Agda.Syntax.Concrete.Operators.buildParsers.
+  reportS "scope.operators" 50
+    [ "flat  = " ++ prettyShow flat
+    , "defs  = " ++ prettyShow defs
+    , "locals= " ++ prettyShow locals
+    ]
+  let localNots  = map localOp locals
+      notLocal   = not . hasElem (map notaName localNots) . notaName
+      otherNots  = concatMap (filter notLocal) defs
+  return $ second (map useDefaultFixity) $ split $ localNots ++ otherNots
+  where
+    localOp (x, y) = namesToNotation (QName x) y
+    split          = partitionEithers . concatMap opOrNot
+    opOrNot n      = Left (notaName n) :
+                     [Right n | not (null (notation n))]

--- a/src/full/Agda/Syntax/Scope/Flat.hs
+++ b/src/full/Agda/Syntax/Scope/Flat.hs
@@ -28,12 +28,14 @@ import Agda.Utils.Maybe
 import Agda.Utils.Pretty
 
 -- | Flattened scopes.
-type FlatScope = Map QName [AbstractName]
+newtype FlatScope = Flat (Map QName [AbstractName])
+  deriving Pretty
 
 -- | Compute a flattened scope. Only include unqualified names or names
 -- qualified by modules in the first argument.
 flattenScope :: [[Name]] -> ScopeInfo -> FlatScope
 flattenScope ms scope =
+  Flat $
   Map.unionWith (++)
     (build ms allNamesInScope root)
     imported
@@ -69,7 +71,7 @@ flattenScope ms scope =
 -- Note that overloaded names (constructors) can have several
 -- fixities/notations. Then we 'mergeNotations'. (See issue 1194.)
 getDefinedNames :: KindsOfNames -> FlatScope -> [[NewNotation]]
-getDefinedNames kinds names =
+getDefinedNames kinds (Flat names) =
   [ mergeNotations $ map (namesToNotation x . A.qnameName . anameName) ds
   | (x, ds) <- Map.toList names
   , any ((`elemKindsOfNames` kinds) . anameKind) ds


### PR DESCRIPTION
I moved some code related to `FlatScope` to a separate module and made the implementation of `FlatScope` private. If anyone wants to fix issue #5670 it might now be a little easier to get an overview over how `FlatScope`s are used.