### PR TITLE
Fix #6137: add `-Wincomplete-record-updates`

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -677,7 +677,9 @@ library
                  -Wduplicate-exports
                  -Wempty-enumerations
                  -Widentities
-                 -Wincomplete-patterns
+                 -- #6137: GHC 8.0 has no COMPLETE pragma, so we have to turn off the completeness checker
+                 -- -Wincomplete-patterns
+                 -- -Wincomplete-record-updates
                  -Winline-rule-shadowing
                  -Wmissing-fields
                  -Wmissing-methods
@@ -686,7 +688,8 @@ library
                  -Wnoncanonical-monad-instances
                  -Wnoncanonical-monoid-instances
                  -Woverflowed-literals
-                 -Woverlapping-patterns
+                 -- #6137: GHC 8.0 has no COMPLETE pragma, so we have to turn off the completeness checker
+                 -- -Woverlapping-patterns
                  -Wsemigroup
                  -Wtabs
                  -Wtyped-holes
@@ -709,7 +712,6 @@ library
                  -Werror=duplicate-exports
                  -Werror=empty-enumerations
                  -Werror=identities
-                 -Werror=incomplete-patterns
                  -Werror=inline-rule-shadowing
                  -Werror=missing-fields
                  -Werror=missing-methods
@@ -755,6 +757,9 @@ library
 
   if impl(ghc >= 9.0)
     ghc-options: -Werror=invalid-haddock
+                 -- #6137: coverage checker works only sufficiently well from GHC 9.0
+                 -Werror=incomplete-patterns
+                 -Werror=incomplete-record-updates
 
   -- ASR (2022-04-27). This warning was added in GHC 9.0.2, removed
   -- from 9.2.1 and added back in 9.2.2.
@@ -1010,7 +1015,9 @@ test-suite agda-tests
                  -Wduplicate-exports
                  -Wempty-enumerations
                  -Widentities
-                 -Wincomplete-patterns
+                 -- #6137: GHC 8.0 has no COMPLETE pragma, so we have to turn off the completeness checker
+                 -- -Wincomplete-patterns
+                 -- -Wincomplete-record-updates
                  -Winline-rule-shadowing
                  -Wmissing-fields
                  -Wmissing-methods
@@ -1019,7 +1026,8 @@ test-suite agda-tests
                  -Wnoncanonical-monad-instances
                  -Wnoncanonical-monoid-instances
                  -Woverflowed-literals
-                 -Woverlapping-patterns
+                 -- #6137: GHC 8.0 has no COMPLETE pragma, so we have to turn off the completeness checker
+                 -- -Woverlapping-patterns
                  -Wsemigroup
                  -Wtabs
                  -Wtyped-holes
@@ -1042,7 +1050,6 @@ test-suite agda-tests
                  -Werror=duplicate-exports
                  -Werror=empty-enumerations
                  -Werror=identities
-                 -Werror=incomplete-patterns
                  -Werror=inline-rule-shadowing
                  -Werror=missing-fields
                  -Werror=missing-methods
@@ -1095,6 +1102,9 @@ test-suite agda-tests
   if impl(ghc >= 9.0)
     ghc-options: -Werror=compat-unqualified-imports
                  -Werror=invalid-haddock
+                 -- #6137: coverage checker works only sufficiently well from GHC 9.0
+                 -Werror=incomplete-patterns
+                 -Werror=incomplete-record-updates
 
   -- ASR (2022-04-27). This warning was added in GHC 9.0.2, removed
   -- from 9.2.1 and added back in 9.2.2.

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -710,7 +710,7 @@ definition def@Defn{defName = q, defType = ty, theDef = d} = do
                    fb axiomErr
       Primitive{ primName = s } -> (mempty,) . fb <$> (liftTCM . primBody) s
 
-      PrimitiveSort{ primName = s } -> retDecls []
+      PrimitiveSort{} -> retDecls []
 
       Function{} -> function pragma $ functionViaTreeless q
 

--- a/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
@@ -113,9 +113,9 @@ loneSigs f e = f (_loneSigs e) <&> \ s -> e { _loneSigs = s }
 addLoneSig :: Range -> Name -> DataRecOrFun -> Nice Name
 addLoneSig r x k = do
   -- Andreas, 2020-05-19, issue #4157, make '_' unique.
-  x' <- if not $ isNoName x then return x else do
-    i <- nextNameId
-    return x{ nameId = i }
+  x' <- case x of
+    Name{}     -> pure x
+    NoName r _ -> NoName r <$> nextNameId
   loneSigs %== \ s -> do
     let (mr, s') = Map.insertLookupWithKey (\ _k new _old -> new) x (LoneSig r x' k) s
     case mr of

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE PatternSynonyms            #-}
 
 module Agda.Syntax.Internal
@@ -729,7 +730,10 @@ pattern EqualityType
 pattern EqualityType{ eqtSort, eqtName, eqtParams, eqtType, eqtLhs, eqtRhs } =
   EqualityViewType (EqualityTypeData eqtSort eqtName eqtParams eqtType eqtLhs eqtRhs)
 
+-- The COMPLETE pragma is new in GHC 8.2
+#if __GLASGOW_HASKELL__ >= 802
 {-# COMPLETE EqualityType, OtherType, IdiomType #-}
+#endif
 
 isEqualityType :: EqualityView -> Bool
 isEqualityType EqualityType{} = True

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -705,16 +705,31 @@ instance Null (Substitution' a) where
 -- | View type as equality type.
 
 data EqualityView
-  = EqualityType
-    { eqtSort  :: Sort     -- ^ Sort of this type.
-    , eqtName  :: QName    -- ^ Builtin EQUALITY.
-    , eqtParams :: [Arg Term] -- ^ Hidden.  Empty or @Level@.
-    , eqtType  :: Arg Term -- ^ Hidden
-    , eqtLhs   :: Arg Term -- ^ NotHidden
-    , eqtRhs   :: Arg Term -- ^ NotHidden
-    }
+  = EqualityViewType EqualityTypeData
   | OtherType Type -- ^ reduced
   | IdiomType Type -- ^ reduced
+
+data EqualityTypeData = EqualityTypeData
+    { _eqtSort   :: Sort        -- ^ Sort of this type.
+    , _eqtName   :: QName       -- ^ Builtin EQUALITY.
+    , _eqtParams :: Args        -- ^ Hidden.  Empty or @Level@.
+    , _eqtType   :: Arg Term    -- ^ Hidden.
+    , _eqtLhs    :: Arg Term    -- ^ NotHidden.
+    , _eqtRhs    :: Arg Term    -- ^ NotHidden.
+    }
+
+pattern EqualityType
+  :: Sort
+  -> QName
+  -> Args
+  -> Arg Term
+  -> Arg Term
+  -> Arg Term
+  -> EqualityView
+pattern EqualityType{ eqtSort, eqtName, eqtParams, eqtType, eqtLhs, eqtRhs } =
+  EqualityViewType (EqualityTypeData eqtSort eqtName eqtParams eqtType eqtLhs eqtRhs)
+
+{-# COMPLETE EqualityType, OtherType, IdiomType #-}
 
 isEqualityType :: EqualityView -> Bool
 isEqualityType EqualityType{} = True

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -81,9 +81,10 @@ piAbstract (Arg info (v, IdiomType a)) b = do
   pure $ mkPi (setHiding (getHiding info) $ defaultDom ("w", a))
        $ mkPi (setHiding NotHidden        $ defaultDom ("eq", eq))
        $ b
-piAbstract (Arg info (prf, eqt@(EqualityType _ _ _ (Arg _ a) v _))) b = do
+piAbstract (Arg info (prf, EqualityViewType eqt@(EqualityTypeData _ _ _ (Arg _ a) v _))) b = do
   s <- sortOf a
-  let prfTy = equalityUnview eqt
+  let prfTy :: Type
+      prfTy = equalityUnview eqt
       vTy   = El s a
   b <- abstractType prfTy prf b
   b <- addContext ("w" :: String, defaultDom prfTy) $
@@ -92,8 +93,10 @@ piAbstract (Arg info (prf, eqt@(EqualityType _ _ _ (Arg _ a) v _))) b = do
   where
     funType str a = mkPi $ setArgInfo info $ defaultDom (str, a)
     -- Abstract the lhs (@a@) of the equality only.
+    eqt1 :: EqualityTypeData
     eqt1  = raise 1 eqt
-    eqTy' = equalityUnview $ eqt1 { eqtLhs = eqtLhs eqt1 $> var 0 }
+    eqTy' :: Type
+    eqTy' = equalityUnview $ eqt1{ _eqtLhs = _eqtLhs eqt1 $> var 0 }
 
 
 -- | @isPrefixOf u v = Just es@ if @v == u `applyE` es@.

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -46,6 +46,7 @@ import Agda.Utils.Benchmark
 import qualified Agda.Utils.BiMap as BiMap
 import Agda.Utils.Functor
 import Agda.Utils.Impossible
+import Agda.Utils.Lens
 import Agda.Utils.List (downFrom, hasElem)
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
@@ -885,7 +886,6 @@ fillInGenRecordDetails name con fields recTy fieldTel = do
   reportSDoc "tc.generalize" 40 $ text "Final genRecCon type:" <+> inTopContext (prettyTCM conType)
   setType (conName con) conType
   -- Record telescope: Includes both parameters and fields.
-  modifyGlobalDefinition name $ \ r ->
-    r { theDef = (theDef r) { recTel = fullTel } }
+  modifyGlobalDefinition name $ set (lensTheDef . lensRecord . lensRecTel) fullTel
   where
     setType q ty = modifyGlobalDefinition q $ \ d -> d { defType = ty }

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2200,9 +2200,12 @@ data Defn
   | PrimitiveSortDefn PrimitiveSortData
     deriving (Show, Generic)
 
+-- The COMPLETE pragma is new in GHC 8.2
+#if __GLASGOW_HASKELL__ >= 802
 {-# COMPLETE
   Axiom, DataOrRecSig, GeneralizableVar, AbstractDefn,
   Function, Datatype, Record, Constructor, Primitive, PrimitiveSort #-}
+#endif
 
 data AxiomData = AxiomData
   { _axiomConstTransp :: Bool

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2679,23 +2679,26 @@ recEtaEquality :: Defn -> HasEta
 recEtaEquality = theEtaEquality . recEtaEquality'
 
 -- | A template for creating 'Function' definitions, with sensible defaults.
-emptyFunction :: Defn
-emptyFunction = Function
-  { funClauses     = []
-  , funCompiled    = Nothing
-  , funSplitTree   = Nothing
-  , funTreeless    = Nothing
-  , funInv         = NotInjective
-  , funMutual      = Nothing
-  , funAbstr       = ConcreteDef
-  , funDelayed     = NotDelayed
-  , funProjection  = Nothing
-  , funFlags       = Set.empty
-  , funTerminates  = Nothing
-  , funExtLam      = Nothing
-  , funWith        = Nothing
-  , funCovering    = []
+emptyFunctionData :: FunctionData
+emptyFunctionData = FunctionData
+  { _funClauses     = []
+  , _funCompiled    = Nothing
+  , _funSplitTree   = Nothing
+  , _funTreeless    = Nothing
+  , _funInv         = NotInjective
+  , _funMutual      = Nothing
+  , _funAbstr       = ConcreteDef
+  , _funDelayed     = NotDelayed
+  , _funProjection  = Nothing
+  , _funFlags       = Set.empty
+  , _funTerminates  = Nothing
+  , _funExtLam      = Nothing
+  , _funWith        = Nothing
+  , _funCovering    = []
   }
+
+emptyFunction :: Defn
+emptyFunction = FunctionDefn emptyFunctionData
 
 funFlag :: FunctionFlag -> Lens' Bool Defn
 funFlag flag f def@Function{ funFlags = flags } =

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1994,8 +1994,8 @@ data NumGeneralizableArgs
     --   'SomeGeneralizableArgs', also when the number is zero.
   deriving Show
 
-theDefLens :: Lens' Defn Definition
-theDefLens f d = f (theDef d) <&> \ df -> d { theDef = df }
+lensTheDef :: Lens' Defn Definition
+lensTheDef f d = f (theDef d) <&> \ df -> d { theDef = df }
 
 -- | Create a definition with sensible defaults.
 defaultDefn ::

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2571,6 +2571,31 @@ pattern PrimitiveSort
     primSortSort
   )
 
+-- TODO: lenses for all Defn variants
+
+lensFunction :: Lens' FunctionData Defn
+lensFunction f = \case
+  FunctionDefn d -> FunctionDefn <$> f d
+  _ -> __IMPOSSIBLE__
+
+lensConstructor :: Lens' ConstructorData Defn
+lensConstructor f = \case
+  ConstructorDefn d -> ConstructorDefn <$> f d
+  _ -> __IMPOSSIBLE__
+
+lensRecord :: Lens' RecordData Defn
+lensRecord f = \case
+  RecordDefn d -> RecordDefn <$> f d
+  _ -> __IMPOSSIBLE__
+
+-- Lenses for Record
+
+lensRecTel :: Lens' Telescope RecordData
+lensRecTel f r =
+  f (_recTel r) <&> \ tel -> r { _recTel = tel }
+
+-- Pretty printing definitions
+
 instance Pretty Definition where
   pretty Defn{..} =
     "Defn {" <?> vcat

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2591,11 +2591,38 @@ instance Pretty Definition where
       , "theDef            =" <?> pretty theDef ] <+> "}"
 
 instance Pretty Defn where
-  pretty Axiom{} = "Axiom"
-  pretty (DataOrRecSig n)   = "DataOrRecSig" <+> pretty n
-  pretty GeneralizableVar{} = "GeneralizableVar"
-  pretty (AbstractDefn def) = "AbstractDefn" <?> parens (pretty def)
-  pretty Function{..} =
+  pretty = \case
+    AxiomDefn _         -> "Axiom"
+    DataOrRecSigDefn d  -> pretty d
+    GeneralizableVar    -> "GeneralizableVar"
+    AbstractDefn def    -> "AbstractDefn" <?> parens (pretty def)
+    FunctionDefn d      -> pretty d
+    DatatypeDefn d      -> pretty d
+    RecordDefn d        -> pretty d
+    ConstructorDefn d   -> pretty d
+    PrimitiveDefn d     -> pretty d
+    PrimitiveSortDefn d -> pretty d
+
+instance Pretty DataOrRecSigData where
+  pretty (DataOrRecSigData n) = "DataOrRecSig" <+> pretty n
+
+instance Pretty FunctionData where
+  pretty (FunctionData
+      funClauses
+      funCompiled
+      funSplitTree
+      funTreeless
+      _funCovering
+      funInv
+      funMutual
+      funAbstr
+      funDelayed
+      funProjection
+      funFlags
+      funTerminates
+      _funExtLam
+      funWith
+    ) =
     "Function {" <?> vcat
       [ "funClauses      =" <?> vcat (map pretty funClauses)
       , "funCompiled     =" <?> pretty funCompiled
@@ -2608,8 +2635,22 @@ instance Pretty Defn where
       , "funProjection   =" <?> pretty funProjection
       , "funFlags        =" <?> pshow funFlags
       , "funTerminates   =" <?> pshow funTerminates
-      , "funWith         =" <?> pretty funWith ] <?> "}"
-  pretty Datatype{..} =
+      , "funWith         =" <?> pretty funWith
+      ] <?> "}"
+
+instance Pretty DatatypeData where
+  pretty (DatatypeData
+      dataPars
+      dataIxs
+      dataClause
+      dataCons
+      dataSort
+      dataMutual
+      _dataAbstr
+      _dataPathCons
+      _dataTranspIx
+      _dataTransp
+    ) =
     "Datatype {" <?> vcat
       [ "dataPars       =" <?> pshow dataPars
       , "dataIxs        =" <?> pshow dataIxs
@@ -2617,8 +2658,25 @@ instance Pretty Defn where
       , "dataCons       =" <?> pshow dataCons
       , "dataSort       =" <?> pretty dataSort
       , "dataMutual     =" <?> pshow dataMutual
-      , "dataAbstr      =" <?> pshow dataAbstr ] <?> "}"
-  pretty Record{..} =
+      , "dataAbstr      =" <?> pshow dataAbstr
+      ] <?> "}"
+
+instance Pretty RecordData where
+  pretty (RecordData
+      recPars
+      recClause
+      recConHead
+      recNamedCon
+      recFields
+      recTel
+      recMutual
+      recEtaEquality'
+      _recPatternMatching
+      recInduction
+      _recTerminates
+      recAbstr
+      _recComp
+    ) =
     "Record {" <?> vcat
       [ "recPars         =" <?> pshow recPars
       , "recClause       =" <?> pretty recClause
@@ -2629,8 +2687,22 @@ instance Pretty Defn where
       , "recMutual       =" <?> pshow recMutual
       , "recEtaEquality' =" <?> pshow recEtaEquality'
       , "recInduction    =" <?> pshow recInduction
-      , "recAbstr        =" <?> pshow recAbstr ] <?> "}"
-  pretty Constructor{..} =
+      , "recAbstr        =" <?> pshow recAbstr
+      ] <?> "}"
+
+instance Pretty ConstructorData where
+  pretty (ConstructorData
+      conPars
+      conArity
+      conSrcCon
+      conData
+      conAbstr
+      conInd
+      _conComp
+      _conProj
+      _conForced
+      conErased
+    ) =
     "Constructor {" <?> vcat
       [ "conPars   =" <?> pshow conPars
       , "conArity  =" <?> pshow conArity
@@ -2638,14 +2710,26 @@ instance Pretty Defn where
       , "conData   =" <?> pretty conData
       , "conAbstr  =" <?> pshow conAbstr
       , "conInd    =" <?> pshow conInd
-      , "conErased =" <?> pshow conErased ] <?> "}"
-  pretty Primitive{..} =
+      , "conErased =" <?> pshow conErased
+      ] <?> "}"
+
+instance Pretty PrimitiveData where
+  pretty (PrimitiveData
+      primAbstr
+      primName
+      primClauses
+      _primInv
+      primCompiled
+      ) =
     "Primitive {" <?> vcat
       [ "primAbstr    =" <?> pshow primAbstr
       , "primName     =" <?> pshow primName
       , "primClauses  =" <?> pshow primClauses
-      , "primCompiled =" <?> pshow primCompiled ] <?> "}"
-  pretty PrimitiveSort{..} =
+      , "primCompiled =" <?> pshow primCompiled
+      ] <?> "}"
+
+instance Pretty PrimitiveSortData where
+  pretty (PrimitiveSortData primSortName primSortSort) =
     "PrimitiveSort {" <?> vcat
       [ "primSortName =" <?> pshow primSortName
       , "primSortSort =" <?> pshow primSortSort

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -718,11 +718,18 @@ equalityView t0@(El s t) = do
 --
 --   Postcondition: type is reduced.
 
-equalityUnview :: EqualityView -> Type
-equalityUnview (OtherType t) = t
-equalityUnview (IdiomType t) = t
-equalityUnview (EqualityType s equality l t lhs rhs) =
-  El s $ Def equality $ map Apply (l ++ [t, lhs, rhs])
+class EqualityUnview a where
+  equalityUnview :: a -> Type
+
+instance EqualityUnview EqualityView where
+  equalityUnview = \case
+    OtherType t -> t
+    IdiomType t -> t
+    EqualityViewType eqt -> equalityUnview eqt
+
+instance EqualityUnview EqualityTypeData where
+  equalityUnview (EqualityTypeData s equality l t lhs rhs) =
+    El s $ Def equality $ map Apply (l ++ [t, lhs, rhs])
 
 -- | Primitives with typechecking constrants.
 constrainedPrims :: [String]

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -181,7 +181,7 @@ getUniqueCompilerPragma backend q = do
                        vcat [ "-" <+> pretty (getRange p) | p <- ps ]
 
 setFunctionFlag :: FunctionFlag -> Bool -> QName -> TCM ()
-setFunctionFlag flag val q = modifyGlobalDefinition q $ set (theDefLens . funFlag flag) val
+setFunctionFlag flag val q = modifyGlobalDefinition q $ set (lensTheDef . funFlag flag) val
 
 markStatic :: QName -> TCM ()
 markStatic = setFunctionFlag FunStatic True

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -539,15 +539,15 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
                         set funMacro  (oldDef ^. funMacro) $
                         set funStatic (oldDef ^. funStatic) $
                         set funInline True $
-                        emptyFunction
-                        { funClauses        = [cl]
-                        , funCompiled       = Just cc
-                        , funSplitTree      = mst
-                        , funMutual         = mutual
-                        , funProjection     = proj
-                        , funTerminates     = Just True
-                        , funExtLam         = extlam
-                        , funWith           = with
+                        FunctionDefn emptyFunctionData
+                        { _funClauses        = [cl]
+                        , _funCompiled       = Just cc
+                        , _funSplitTree      = mst
+                        , _funMutual         = mutual
+                        , _funProjection     = proj
+                        , _funTerminates     = Just True
+                        , _funExtLam         = extlam
+                        , _funWith           = with
                         }
                   reportSDoc "tc.mod.apply" 80 $ ("new def for" <+> pretty x) <?> pretty newDef
                   return newDef

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -647,7 +647,7 @@ unfoldDefinitionStep unfoldDelayed v0 f es =
         then reducePrimitive x v0 f es pf dontUnfold
                              cls (defCompiled info) rewr
         else noReduction $ notBlocked v
-    PrimitiveSort{ primSort = s } -> yesReduction NoSimplification $ Sort s `applyE` es
+    PrimitiveSort{ primSortSort = s } -> yesReduction NoSimplification $ Sort s `applyE` es
 
     _  -> do
       if or

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -959,11 +959,11 @@ bindBuiltinNoDef b q = inTopContext $ do
       where
         -- Andreas, 2015-02-14
         -- Special treatment of SizeUniv, should maybe be a primitive.
-        def | b == builtinSizeUniv = emptyFunction
-                { funClauses = [ (empty :: Clause) { clauseBody = Just $ Sort sSizeUniv } ]
-                , funCompiled = Just (CC.Done [] $ Sort sSizeUniv)
-                , funMutual    = Just []
-                , funTerminates = Just True
+        def | b == builtinSizeUniv = FunctionDefn $ emptyFunctionData
+                { _funClauses    = [ (empty :: Clause) { clauseBody = Just $ Sort sSizeUniv } ]
+                , _funCompiled   = Just (CC.Done [] $ Sort sSizeUniv)
+                , _funMutual     = Just []
+                , _funTerminates = Just True
                 }
             | otherwise = defaultAxiom
 

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -154,12 +154,12 @@ bindBuiltinFlat x =
       flatDefn { defPolarity       = []
                , defArgOccurrences = [StrictPos]  -- changing that to [Mixed] destroys monotonicity of 'Rec' in test/succeed/GuardednessPreservingTypeConstructors
                , defCopatternLHS = hasProjectionPatterns cc
-               , theDef = emptyFunction
-                   { funClauses      = [clause]
-                   , funCompiled     = Just $ cc
-                   , funProjection   = Just projection
-                   , funMutual       = Just []
-                   , funTerminates   = Just True
+               , theDef = FunctionDefn emptyFunctionData
+                   { _funClauses      = [clause]
+                   , _funCompiled     = Just $ cc
+                   , _funProjection   = Just projection
+                   , _funMutual       = Just []
+                   , _funTerminates   = Just True
                    }
                 }
 

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -22,6 +22,8 @@ import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Rules.Builtin
 import Agda.TypeChecking.Rules.Term
 
+import Agda.Utils.Lens
+
 -- | The type of @∞@.
 
 typeOfInf :: TCM Type
@@ -164,10 +166,10 @@ bindBuiltinFlat x =
                 }
 
     -- register flat as record field for constructor sharp
-    modifySignature $ updateDefinition sharp $ updateTheDef $ \ def ->
-      def { conSrcCon = sharpCon }
-    modifySignature $ updateDefinition inf $ updateTheDef $ \ def ->
-      def { recConHead = sharpCon, recFields = [defaultDom flat] }
+    modifySignature $ updateDefinition sharp $ updateTheDef $ over lensConstructor $ \ def ->
+      def { _conSrcCon = sharpCon }
+    modifySignature $ updateDefinition inf $ updateTheDef $ over lensRecord $ \ def ->
+      def { _recConHead = sharpCon, _recFields = [defaultDom flat] }
     return $ Def flat []
 
 -- The coinductive primitives.

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1365,7 +1365,7 @@ defineTranspForFields pathCons applyProj name params fsT fns rect = do
   lang <- getLanguage
   noMutualBlock $ addConstant theName $
     (defaultDefn defaultArgInfo theName theType lang
-       (emptyFunction { funTerminates = Just True }))
+       (FunctionDefn $ emptyFunctionData { _funTerminates = Just True }))
       { defNoCompilation = True }
   -- ⊢ Γ = gamma = (δ : Δ^I) (φ : I) (u0 : R (δ i0))
   -- Γ ⊢     rtype = R (δ i1)
@@ -1523,7 +1523,7 @@ defineHCompForFields applyProj name params fsT fns rect = do
   lang <- getLanguage
   noMutualBlock $ addConstant theName $
     (defaultDefn defaultArgInfo theName theType lang
-       (emptyFunction { funTerminates = Just True }))
+       (FunctionDefn $ emptyFunctionData { _funTerminates = Just True }))
       { defNoCompilation = True }
   --   ⊢ Γ = gamma = (δ : Δ) (φ : I) (_ : (i : I) -> Partial φ (R δ)) (_ : R δ)
   -- Γ ⊢     rtype = R δ

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -671,23 +671,23 @@ defineProjections dataName con params names fsT t = do
     noMutualBlock $ do
       let cs = [ clause ]
       (mst, _, cc) <- compileClauses Nothing cs
-      let fun = emptyFunction
-                { funClauses    = cs
-                , funCompiled   = Just cc
-                , funSplitTree  = mst
-                , funProjection = Just $ Projection
+      let fun = emptyFunctionData
+                { _funClauses    = cs
+                , _funCompiled   = Just cc
+                , _funSplitTree  = mst
+                , _funProjection = Just $ Projection
                     { projProper   = Nothing
                     , projOrig     = projName
                     , projFromType = Arg (getArgInfo ty) dataName
                     , projIndex    = np + 1
                     , projLams     = ProjLams $ map (argFromDom . fmap fst) $ telToList projTel
                     }
-                , funMutual     = Just []
-                , funTerminates = Just True
+                , _funMutual     = Just []
+                , _funTerminates = Just True
                 }
       lang <- getLanguage
       inTopContext $ addConstant projName $
-        (defaultDefn defaultArgInfo projName (unDom projType) lang fun)
+        (defaultDefn defaultArgInfo projName (unDom projType) lang $ FunctionDefn fun)
           { defNoCompilation  = True
           , defArgOccurrences = [StrictPos]
           }
@@ -786,13 +786,13 @@ defineTranspIx d = do
         let cs = [ clause ]
 --        we do not compile clauses as that leads to throwing missing clauses errors.
 --        (mst, _, cc) <- compileClauses Nothing cs
-        let fun = emptyFunction
-                  { funClauses    = cs
-               --   , funCompiled   = Just cc
-               --   , funSplitTree  = mst
-                  , funProjection = Nothing
-                  , funMutual     = Just []
-                  , funTerminates = Just True
+        let fun = emptyFunctionData
+                  { _funClauses    = cs
+               --   , _funCompiled   = Just cc
+               --   , _funSplitTree  = mst
+                  , _funProjection = Nothing
+                  , _funMutual     = Just []
+                  , _funTerminates = Just True
                   }
         inTopContext $ do
          reportSDoc "tc.transpx.type" 15 $ vcat
@@ -801,7 +801,7 @@ defineTranspIx d = do
            ]
 
          addConstant trIx $
-          (defaultDefn defaultArgInfo trIx theType (Cubical CErased) fun)
+          (defaultDefn defaultArgInfo trIx theType (Cubical CErased) $ FunctionDefn fun)
             { defNoCompilation  = True
             }
 
@@ -896,16 +896,16 @@ defineTranspFun d mtrX cons pathCons = do
         ecs <- tryTranspError $ (clause:) <$> defineConClause trD (not $ null pathCons) mtrX npars nixs ixs telI sigma dTs cons
         caseEitherM (pure ecs) (\ cl -> debugNoTransp cl >> return Nothing) $ \ cs -> do
         (mst, _, cc) <- compileClauses Nothing cs
-        let fun = emptyFunction
-                  { funClauses    = cs
-                  , funCompiled   = Just cc
-                  , funSplitTree  = mst
-                  , funProjection = Nothing
-                  , funMutual     = Just []
-                  , funTerminates = Just True
+        let fun = emptyFunctionData
+                  { _funClauses    = cs
+                  , _funCompiled   = Just cc
+                  , _funSplitTree  = mst
+                  , _funProjection = Nothing
+                  , _funMutual     = Just []
+                  , _funTerminates = Just True
                   }
         inTopContext $ addConstant trD $
-          (defaultDefn defaultArgInfo trD theType (Cubical CErased) fun)
+          (defaultDefn defaultArgInfo trD theType (Cubical CErased) $ FunctionDefn fun)
             { defNoCompilation  = True
             }
         reportSDoc "tc.data.transp" 20 $ sep

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -141,21 +141,21 @@ checkDataDef i name uc (A.DataDefParams gpars ps) cs =
             let npars = size tel
 
             -- Change the datatype from an axiom to a datatype with no constructors.
-            let dataDef = Datatype
-                  { dataPars       = npars
-                  , dataIxs        = nofIxs
-                  , dataClause     = Nothing
-                  , dataCons       = []     -- Constructors are added later
-                  , dataSort       = s
-                  , dataAbstr      = Info.defAbstract i
-                  , dataMutual     = Nothing
-                  , dataPathCons   = []     -- Path constructors are added later
-                  , dataTranspIx   = Nothing -- Generated later if nofIxs > 0.
-                  , dataTransp     = Nothing -- Added later
+            let dataDef = DatatypeData
+                  { _dataPars       = npars
+                  , _dataIxs        = nofIxs
+                  , _dataClause     = Nothing
+                  , _dataCons       = []     -- Constructors are added later
+                  , _dataSort       = s
+                  , _dataAbstr      = Info.defAbstract i
+                  , _dataMutual     = Nothing
+                  , _dataPathCons   = []     -- Path constructors are added later
+                  , _dataTranspIx   = Nothing -- Generated later if nofIxs > 0.
+                  , _dataTransp     = Nothing -- Added later
                   }
 
             escapeContext impossible npars $ do
-              addConstant' name defaultArgInfo name t dataDef
+              addConstant' name defaultArgInfo name t $ DatatypeDefn dataDef
                 -- polarity and argOcc.s determined by the positivity checker
 
             -- Check the types of the constructors
@@ -180,7 +180,7 @@ checkDataDef i name uc (A.DataDefParams gpars ps) cs =
                 checkIndexSorts s' ixTel
 
             -- Return the data definition
-            return dataDef{ dataPathCons = catMaybes pathCons
+            return dataDef{ _dataPathCons = catMaybes pathCons
                           }
 
         let cons   = map A.axiomName cs  -- get constructor names
@@ -190,16 +190,16 @@ checkDataDef i name uc (A.DataDefParams gpars ps) cs =
             (do mtranspix <- inTopContext $ defineTranspIx name
                 transpFun <- inTopContext $
                                defineTranspFun name mtranspix cons
-                                 (dataPathCons dataDef)
+                                 (_dataPathCons dataDef)
                 return (mtranspix, transpFun))
             (return (Nothing, Nothing))
 
         -- Add the datatype to the signature with its constructors.
         -- It was previously added without them.
-        addConstant' name defaultArgInfo name t $
-            dataDef{ dataCons = cons
-                   , dataTranspIx = mtranspix
-                   , dataTransp   = transpFun
+        addConstant' name defaultArgInfo name t $ DatatypeDefn
+            dataDef{ _dataCons = cons
+                   , _dataTranspIx = mtranspix
+                   , _dataTransp   = transpFun
                    }
 
 -- | Make sure that the target universe admits data type definitions.

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -647,12 +647,13 @@ checkAxiom' gentel kind i info0 mp x e = whenAbstractFreezeMetasAfter i $ defaul
   lang <- getLanguage
   let defn = defaultDefn info x t lang $
         case kind of   -- #4833: set abstract already here so it can be inherited by with functions
-          FunName   -> emptyFunction{ funAbstr = Info.defAbstract i }
-          MacroName -> set funMacro True emptyFunction{ funAbstr = Info.defAbstract i }
+          FunName   -> fun
+          MacroName -> set funMacro True fun
           DataName  -> DataOrRecSig npars
           RecName   -> DataOrRecSig npars
           AxiomName -> defaultAxiom     -- Old comment: NB: used also for data and record type sigs
           _         -> __IMPOSSIBLE__
+        where fun = FunctionDefn $ emptyFunctionData{ _funAbstr = Info.defAbstract i }
 
   addConstant x =<< do
     useTerPragma $ defn

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -184,28 +184,27 @@ checkAlias t ai delayed i name e mc =
         _          -> id
 
   -- Add the definition
-  addConstant' name ai name t
-                   $ set funMacro (Info.defMacro i == MacroDef) $
-                     emptyFunction
-                      { funClauses = [ Clause  -- trivial clause @name = v@
-                          { clauseLHSRange  = getRange i
-                          , clauseFullRange = getRange i
-                          , clauseTel       = EmptyTel
-                          , namedClausePats = []
-                          , clauseBody      = Just $ bodyMod v
-                          , clauseType      = Just $ Arg ai t
-                          , clauseCatchall    = False
-                          , clauseExact       = Just True
-                          , clauseRecursive   = Nothing   -- we don't know yet
-                          , clauseUnreachable = Just False
-                          , clauseEllipsis    = NoEllipsis
-                          , clauseWhereModule = Nothing
-                          } ]
-                      , funCompiled = Just $ Done [] $ bodyMod v
-                      , funSplitTree = Just $ SplittingDone 0
-                      , funDelayed  = delayed
-                      , funAbstr    = Info.defAbstract i
-                      }
+  addConstant' name ai name t $ set funMacro (Info.defMacro i == MacroDef) $
+      FunctionDefn emptyFunctionData
+          { _funClauses   = [ Clause  -- trivial clause @name = v@
+              { clauseLHSRange    = getRange i
+              , clauseFullRange   = getRange i
+              , clauseTel         = EmptyTel
+              , namedClausePats   = []
+              , clauseBody        = Just $ bodyMod v
+              , clauseType        = Just $ Arg ai t
+              , clauseCatchall    = False
+              , clauseExact       = Just True
+              , clauseRecursive   = Nothing   -- we don't know yet
+              , clauseUnreachable = Just False
+              , clauseEllipsis    = NoEllipsis
+              , clauseWhereModule = Nothing
+              } ]
+          , _funCompiled  = Just $ Done [] $ bodyMod v
+          , _funSplitTree = Just $ SplittingDone 0
+          , _funDelayed   = delayed
+          , _funAbstr     = Info.defAbstract i
+          }
 
   -- Andreas, 2017-01-01, issue #2372:
   -- Add the definition to the instance table, if needed, to update its type.
@@ -420,16 +419,16 @@ checkFunDefS t ai delayed extlam with i name withSub cs = do
           -- funTerminates field directly.
           defn <- autoInline $
              set funMacro (ismacro || Info.defMacro i == MacroDef) $
-             emptyFunction
-             { funClauses        = cs
-             , funCompiled       = Just cc
-             , funSplitTree      = mst
-             , funDelayed        = delayed
-             , funInv            = inv
-             , funAbstr          = Info.defAbstract i
-             , funExtLam         = (\ e -> e { extLamSys = sys }) <$> extlam
-             , funWith           = with
-             , funCovering       = covering
+             FunctionDefn emptyFunctionData
+             { _funClauses        = cs
+             , _funCompiled       = Just cc
+             , _funSplitTree      = mst
+             , _funDelayed        = delayed
+             , _funInv            = inv
+             , _funAbstr          = Info.defAbstract i
+             , _funExtLam         = (\ e -> e { extLamSys = sys }) <$> extlam
+             , _funWith           = with
+             , _funCovering       = covering
              }
           lang <- getLanguage
           useTerPragma $

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -740,14 +740,14 @@ checkRecordProjections m r hasNamedCon con tel ftel fs = do
         escapeContext impossible (size tel) $ do
           lang <- getLanguage
           addConstant projname $
-            (defaultDefn ai projname (killRange finalt) lang
-              emptyFunction
-                { funClauses        = [clause]
-                , funCompiled       = Just cc
-                , funSplitTree      = mst
-                , funProjection     = Just projection
-                , funMutual         = Just []  -- Projections are not mutually recursive with anything
-                , funTerminates     = Just True
+            (defaultDefn ai projname (killRange finalt) lang $ FunctionDefn
+              emptyFunctionData
+                { _funClauses        = [clause]
+                , _funCompiled       = Just cc
+                , _funSplitTree      = mst
+                , _funProjection     = Just projection
+                , _funMutual         = Just []  -- Projections are not mutually recursive with anything
+                , _funTerminates     = Just True
                 })
               { defArgOccurrences = [StrictPos]
               , defCopatternLHS   = hasProjectionPatterns cc

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -746,8 +746,8 @@ checkAbsurdLambda cmp i h e t = localTC (set eQuantity topQuantity) $ do
             (\ d -> (defaultDefn (setModality mod info') aux t' lang d)
                     { defPolarity       = [Nonvariant]
                     , defArgOccurrences = [Unused] })
-            $ emptyFunction
-              { funClauses        =
+            $ FunctionDefn emptyFunctionData
+              { _funClauses        =
                   [ Clause
                     { clauseLHSRange  = getRange e
                     , clauseFullRange = getRange e
@@ -763,11 +763,11 @@ checkAbsurdLambda cmp i h e t = localTC (set eQuantity topQuantity) $ do
                     , clauseWhereModule = Nothing
                     }
                   ]
-              , funCompiled       = Just $ Fail [Arg info' "()"]
-              , funSplitTree      = Just $ SplittingDone 0
-              , funMutual         = Just []
-              , funTerminates     = Just True
-              , funExtLam         = Just $ ExtLamInfo top True empty
+              , _funCompiled       = Just $ Fail [Arg info' "()"]
+              , _funSplitTree      = Just $ SplittingDone 0
+              , _funMutual         = Just []
+              , _funTerminates     = Just True
+              , _funExtLam         = Just $ ExtLamInfo top True empty
               }
           -- Andreas 2012-01-30: since aux is lifted to toplevel
           -- it needs to be applied to the current telescope (issue 557)

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -676,16 +676,19 @@ instance Abstract Defn where
             , funProjection = Just p } ->
       -- Andreas, 2015-05-11 if projection was applied to Var 0
       -- then abstract over last element of tel (the others are params).
-      if projIndex p > 0 then d' else
-        d' { funClauses  = map (abstractClause tel1) cs
-           , funCompiled = abstract tel1 cc
-           , funCovering = abstract tel1 cov
-           , funInv      = abstract tel1 inv
-           , funExtLam   = modifySystem (\ _ -> __IMPOSSIBLE__) <$> extLam
-           }
+      if projIndex p > 0 then
+        d { funProjection = Just $ abstract tel p
+          , funClauses    = map (abstractClause EmptyTel) cs
+          }
+      else
+        d { funProjection = Just $ abstract tel p
+          , funClauses    = map (abstractClause tel1) cs
+          , funCompiled   = abstract tel1 cc
+          , funCovering   = abstract tel1 cov
+          , funInv        = abstract tel1 inv
+          , funExtLam     = modifySystem (\ _ -> __IMPOSSIBLE__) <$> extLam
+          }
         where
-          d' = d { funProjection = Just $ abstract tel p
-                 , funClauses    = map (abstractClause EmptyTel) cs }
           tel1 = telFromList $ drop (size tel - 1) $ telToList tel
           -- #5128: clause telescopes should be abstracted over the full telescope, regardless of
           --        projection shenanigans.

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1109,11 +1109,14 @@ instance Subst Candidate where
 
 instance Subst EqualityView where
   type SubstArg EqualityView = Term
-  applySubst rho (OtherType t) = OtherType
-    (applySubst rho t)
-  applySubst rho (IdiomType t) = IdiomType
-    (applySubst rho t)
-  applySubst rho (EqualityType s eq l t a b) = EqualityType
+  applySubst rho = \case
+    OtherType t          -> OtherType $ applySubst rho t
+    IdiomType t          -> IdiomType $ applySubst rho t
+    EqualityViewType eqt -> EqualityViewType $ applySubst rho eqt
+
+instance Subst EqualityTypeData where
+  type SubstArg EqualityTypeData = Term
+  applySubst rho (EqualityTypeData s eq l t a b) = EqualityTypeData
     (applySubst rho s)
     eq
     (map (applySubst rho) l)


### PR DESCRIPTION
Aiming to fix #6137.

Refactoring steps:
1. Break `Defn` into a tagged union or records.  Needs the `COMPLETE` pragma which requires GHC >= 8.2.
2. Refine `emptyFunction` to `emptyFunctionData`.
3. ... (see commits)

