### PR TITLE
Fix #6095: allow ambiguous pattern synonyms in `checkForClashes`.

### DIFF
--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -1010,8 +1010,12 @@ openModule kind mam cm dir = do
             modClashes = filter (\ (_c, as) -> length as >= 2) $ Map.toList $ nsModules exported
 
             -- No ambiguity if concrete identifier is only mapped to
-            -- constructor names or only to projection names.
-            defClash (_, qs) = not $ all (isJust . isConName) ks || all (==FldName) ks
+            -- constructor names or only to projection names or only to pattern synonyms.
+            defClash (_, qs) = not $ or
+              [ all (isJust . isConName) ks
+              , all (== FldName)         ks
+              , all (== PatternSynName)  ks
+              ]
               where ks = map anameKind qs
         -- We report the first clashing exported identifier.
         unlessNull (filter defClash defClashes) $

--- a/test/Succeed/Issue6095.agda
+++ b/test/Succeed/Issue6095.agda
@@ -1,0 +1,18 @@
+-- Andreas, 2022-09-30, issue #6095, raised by carlostome
+
+data D : Set where
+  c  : D
+
+data E : Set where
+  c' : E
+
+pattern p = c
+
+pattern p = c'
+
+f : D → Set
+f p = D
+
+module _ where  -- This caused a "Multiple definitions of p" error
+
+-- Should succeed.


### PR DESCRIPTION
Fix #6095: allow ambiguous pattern synonyms in `checkForClashes`.