### PR TITLE
Fix #6022 crudely: do not subject primitives to dead-code removal

### DIFF
--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -48,10 +48,20 @@ eliminateDeadCode bs disp sig ms = Bench.billTo [Bench.DeadCode] $ do
                  (sig ^. sigDefinitions)
   -- #2921: Eliminating definitions with attached COMPILE pragmas results in
   -- the pragmas not being checked. Simple solution: don't eliminate these.
-  let hasCompilePragma =
-        Set.fromList . HMap.keys .
-        HMap.filter (not . MapS.null . defCompiledRep) $ defs
-      rootNames = Set.union public hasCompilePragma
+  -- #6022 (Andreas, 2022-09-30): Eliminating cubical primitives can lead to crashes.
+   -- Simple solution: retain all primitives (shouldn't be many).
+  let hasCompilePragma = not . MapS.null . defCompiledRep
+      isPrimitive = \case
+        Primitive{}     -> True
+        PrimitiveSort{} -> True
+        _ -> False
+      extraRootsFilter (name, def)
+        | hasCompilePragma def || isPrimitive (theDef def) = Just name
+        | otherwise = Nothing
+      extraRoots =
+        Set.fromList $ mapMaybe extraRootsFilter $ HMap.toList defs
+
+      rootNames = Set.union public extraRoots
       rootMetas =
         if not save then Set.empty else metasIn
           ( bs

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -83,7 +83,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20220909 * 10 + 0
+currentInterfaceVersion = 20220930 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/test/Fail/Issue6022.agda
+++ b/test/Fail/Issue6022.agda
@@ -1,0 +1,25 @@
+-- Andreas, 2022-09-30, issue #6022, test by Amelia
+
+-- Dead-code elimination removed private primitives
+-- used in cubical stuff, leading to a crash.
+
+{-# OPTIONS --cubical #-}
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Primitive.Cubical renaming (primTransp to transp)
+
+open import Issue6022.Cubical
+
+module _ {ℓ} {A : Set ℓ} {x y : A} (p : x ≡ y) where
+
+  q : Id x y
+  q = transp (λ i → Id x (p i)) i0 refl
+
+  q' : Id x y
+  q' = transp (λ i → Id x (p i)) i0 refl
+
+  test : q ≡ q'
+  test i = {!!}
+
+-- WAS: crash due to unbound name
+-- Expected error: Failed to solve constraints.

--- a/test/Fail/Issue6022.err
+++ b/test/Fail/Issue6022.err
@@ -1,0 +1,13 @@
+Failed to solve the following constraints:
+  Issue6022.Cubical.primConId i0
+  (transp (λ i → x₁ ≡ p₁ i) i0 (Issue6022.Cubical.primIdPath refl))
+    = ?0 (p = p₁) (i = i1)
+    : Id x₁ y₁
+    (blocked on _21)
+  Issue6022.Cubical.primConId i0
+  (transp (λ i → x₁ ≡ p₁ i) i0 (Issue6022.Cubical.primIdPath refl))
+    = ?0 (p = p₁) (i = i0)
+    : Id x₁ y₁
+    (blocked on _21)
+Unsolved interaction metas at the following locations:
+  Issue6022.agda:22,12-16

--- a/test/Fail/Issue6022/Cubical.agda
+++ b/test/Fail/Issue6022/Cubical.agda
@@ -1,0 +1,20 @@
+{-# OPTIONS --cubical #-}
+
+module Issue6022.Cubical where
+
+open import Agda.Primitive.Cubical renaming
+  (primINeg to ~_; primIMax to _∨_; primIMin to _∧_;
+  primHComp to hcomp; primTransp to transp; primComp to comp;
+  itIsOne to 1=1)
+open import Agda.Builtin.Cubical.Path
+
+{-# BUILTIN ID      Id   #-}
+{-# BUILTIN REFLID  refl #-}
+
+private primitive
+  primDepIMin : _
+  primIdFace  : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → I
+  primIdPath  : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → x ≡ y
+  primConId   : ∀ {ℓ} {A : Set ℓ} {x y : A} → I → x ≡ y → Id x y
+
+-- These private primitives used to be nuked by dead-code elimination.


### PR DESCRIPTION
Fix #6022 crudely: do not subject primitives to dead-code removal.

Some cubical primitives are used internally even if declared privately, so removing them from the interface leads to crashes in client modules.