### PR TITLE
Re #6001: Hard error when hcomp is tried on possibly non-fibrant type

### DIFF
--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -1204,7 +1204,7 @@ instance Subst CType where
   applySubst rho (LType t) = LType $ applySubst rho t
 
 hcomp
-  :: (HasBuiltins m, MonadError TCErr m, MonadReduce m)
+  :: (HasBuiltins m, MonadError TCErr m, MonadReduce m, MonadPretty m)
   => NamesT m Type
   -> [(NamesT m Term, NamesT m Term)]
   -> NamesT m Term
@@ -1216,7 +1216,9 @@ hcomp ty sys u0 = do
   ty <- ty
   (l, ty) <- toLType ty >>= \case
     Just (LEl l ty) -> return (l, ty)
-    Nothing -> return (__DUMMY_LEVEL__, unEl ty) -- TODO: support Setω properly
+    Nothing -> lift $ do -- TODO: support Setω properly
+      typeError . GenericDocError =<< sep
+        [ text "Cubical Agda: cannot generate hcomp clauses at type", prettyTCM ty ]
   l <- open $ Level l
   ty <- open $ ty
   face <- (foldr max (pure iz) $ map fst $ sys)

--- a/test/Fail/Issue5730-without-k.err
+++ b/test/Fail/Issue5730-without-k.err
@@ -1,12 +1,4 @@
-Issue5730-without-k.agda:13,1-4
-Cannot generate inferred clause for seq. Case to handle:
-  seq
-    (ι _ _
-       (Agda.Primitive.Cubical.primHComp {.Agda.Primitive.lzero}
-          {.(_ _ ≡ _)}
-          {φ = φ}
-          u
-          a))
-    x
-Cannot compose with type family: RecO (λ i → f (e i)) D (ι j).
+Issue5730-without-k.agda:16,1-43
+Cubical Agda: cannot generate hcomp clauses at type
+RecO (λ i → @10 (@11 i)) @8 (ι @6)
 when checking the definition of seq

--- a/test/Fail/Issue6001.agda
+++ b/test/Fail/Issue6001.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2022-09-30, issue #6001
+-- Testcase by @tomdjong, Jakob Bruenker, Amelia
+
+-- Cubical extra-clauses cannot be generated unless
+-- target is known to be fibrant.
+
+{-# OPTIONS --without-K #-}
+
+data Foo {A : Set} : A → Set where
+  con : (x : A) → Foo x
+
+bug : ∀ {A : Set} {a : A} {p : Foo a} → ?
+bug {p = con _} = {!!}
+
+-- WAS: internal error
+-- Now:
+-- Cubical Agda: cannot generate hcomp clauses at type
+-- ?0
+-- when checking the definition of bug

--- a/test/Fail/Issue6001.err
+++ b/test/Fail/Issue6001.err
@@ -1,0 +1,4 @@
+Issue6001.agda:13,1-23
+Cubical Agda: cannot generate hcomp clauses at type
+?0
+when checking the definition of bug


### PR DESCRIPTION
Re #6001: Hard error when hcomp is tried on possibly non-fibrant type.

Used to crash on 2.6.3 instead.  Error isn't nice since `hcomp` called from `Agda.TypeChecking.Coverage.Cubical` isn't in the right context.  @jespercockx, your error for 
- #5730 
 
got worse, I suppose.