### PR TITLE
Fix #6066: `pattern` with eta record: document; warn

### DIFF
--- a/doc/user-manual/language/record-types.lagda.rst
+++ b/doc/user-manual/language/record-types.lagda.rst
@@ -459,6 +459,16 @@ is on.  If you want the converse, you can add the record directive
   pred : HereditaryList → List HereditaryList
   pred record{ sublists = ts } = ts
 
+If ``pattern`` is given for record types that have η, Agda will alert
+the user of a redundant ``pattern`` directive.  However, there is an
+exception:  While checking a mutual block, Agda might first turn off η
+for a record that has not explicitly been labelled with
+``eta-equality``, and only at the end of the mutual block infer that η
+is safe for this record and switch it on.  To allow pattern matching
+on such record constructor in the mutual block, you may supply the
+``pattern`` directive.  However, it is rather recommended to turn on
+``eta-equality`` manually in such cases.
+
 .. _instance-fields:
 
 Instance fields

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -170,7 +170,7 @@ checkStrictlyPositive mi qset = do
             -- otherwise, if the record is recursive, mark it as well
             Just o | o <= GuardPos -> do
               reportSDoc "tc.pos.record" 5 $ how "recursive" GuardPos
-              recursiveRecord q
+              updateEtaForRecord q
               checkInduction q
             -- If the record is not recursive, switch on eta
             -- unless it is coinductive or a no-eta-equality record.
@@ -178,7 +178,7 @@ checkStrictlyPositive mi qset = do
               reportSDoc "tc.pos.record" 10 $
                 "record type " <+> prettyTCM q <+>
                 "is not recursive"
-              nonRecursiveRecord q
+              updateEtaForRecord q
             _ -> return ()
 
     checkInduction :: QName -> TCM ()

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -143,6 +143,7 @@ prettyWarning = \case
 
     UselessPatternDeclarationForRecord s -> fwords $ unwords
       [ "`pattern' attribute ignored for", s, "record" ]
+      -- the @s@ is a qualifier like "eta" or "coinductive"
 
     UselessPublic -> fwords $ "Keyword `public' is ignored here"
 

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1453,7 +1453,7 @@ checkLHS mf = updateModality checkLHS_ where
 
 -- | Ensures that we are not performing pattern matching on coinductive constructors.
 
-checkMatchingAllowed :: (MonadTCError m)
+checkMatchingAllowed :: (HasConstInfo m, MonadTCError m, MonadTCState m)
   => QName         -- ^ The name of the data or record type the constructor belongs to.
   -> DataOrRecord  -- ^ Information about data or (co)inductive (no-)eta-equality record.
   -> m ()
@@ -1462,7 +1462,7 @@ checkMatchingAllowed d = \case
     | Just CoInductive <- ind -> typeError $
         GenericError "Pattern matching on coinductive types is not allowed"
     | not $ patternMatchingAllowed eta -> typeError $ SplitOnNonEtaRecord d
-    | otherwise -> return ()
+    | otherwise -> registerRecordMatching d
   IsData -> return ()
 
 -- | When working with a monad @m@ implementing @MonadTCM@ and @MonadError TCErr@,

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -371,7 +371,7 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
   -- If the user declared the record constructor as @pattern@,
   -- then switch on pattern matching for no-eta-equality.
   -- Default is no pattern matching, but definition by copatterns instead.
-  patCopat = maybe CopatternMatching (const PatternMatching) pat
+  patCopat = maybe CopatternMatching (`PatternMatching` False) pat
   eta      = (patCopat <$) <$> eta0
 
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -83,7 +83,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20220930 * 10 + 0
+currentInterfaceVersion = 20220930 * 10 + 1
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -503,7 +503,15 @@ instance EmbPrj a => EmbPrj (HasEta' a) where
     valu [a] = valuN NoEta a
     valu _   = malformed
 
-instance EmbPrj PatternOrCopattern
+instance EmbPrj PatternOrCopattern where
+  icod_ = \case
+    PatternMatching a b -> icodeN' PatternMatching a b
+    CopatternMatching   -> icodeN' CopatternMatching
+
+  value = vcase $ \case
+    [a, b] -> valuN PatternMatching a b
+    []     -> valuN CopatternMatching
+    _      -> malformed
 
 instance EmbPrj Induction where
   icod_ Inductive   = icodeN' Inductive

--- a/test/Succeed/Issue6066.agda
+++ b/test/Succeed/Issue6066.agda
@@ -1,0 +1,17 @@
+-- Andreas, 2022-09-30, issue #6066
+-- Warn also about redundant "pattern" attribute
+-- if eta for a record was inferred, rather than declared.
+
+record D : Set1 where
+  pattern
+  field
+    foo : Set
+
+match : D → Set
+match record{ foo = A } = A
+
+comatch : Set → D
+comatch A .D.foo = A
+
+-- Expected warning:
+-- `pattern' attribute ignored for eta record

--- a/test/Succeed/Issue6066.warn
+++ b/test/Succeed/Issue6066.warn
@@ -1,0 +1,7 @@
+Issue6066.agda:6,3-10
+'pattern' attribute ignored for eta record
+
+———— All done; warnings encountered ————————————————————————
+
+Issue6066.agda:6,3-10
+'pattern' attribute ignored for eta record


### PR DESCRIPTION
Fix #6066: `pattern` with eta record: document; warn.

The warning "useless pattern directive" is now extended to records with inferred eta (was only for declared eta).

However, to make it correct, we have to remember whether the record constructor was subject to matching before we inferred eta for the record.
(Note: the positivity checker runs at the end of the mutual block.)

I wonder whether we should rather advice the user to change `pattern` to `eta-equality` in this case.  This would also save us the bookkeeping of record constructor matches.