### PR TITLE
Issue6093: Change primFloatToWord64 to return a Maybe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,18 @@ Pragmas and options
   This option might for instance be used if Agda is controlled from a
   script.
 
+Builtins
+--------
+
+* Change `primFloatToWord64` to return `Maybe Word64`.
+  (See [#6093](https://github.com/agda/agda/issues/6093).)
+
+  The new type is
+  ```agda
+    primFloatToWord64 : Float → Maybe Word64
+  ```
+  and it returns `nothing` for `NaN`.
+
 Performance
 -----------
 

--- a/doc/user-manual/language/built-ins.lagda.rst
+++ b/doc/user-manual/language/built-ins.lagda.rst
@@ -459,9 +459,9 @@ operations do not lose precision.
 Floating point numbers can be converted to their raw representation using the primitive::
 
   primitive
-    primFloatToWord64          : Float → Word64
+    primFloatToWord64          : Float → Maybe Word64
 
-which normalises all ``NaN`` to a canonical ``NaN`` with an injectivity proof::
+which returns ``nothing`` for ``NaN`` and satisfies::
 
     primFloatToWord64Injective : ∀ a b → primFloatToWord64 a ≡ primFloatToWord64 b → a ≡ b
 

--- a/src/data/JS/agda-rts.js
+++ b/src/data/JS/agda-rts.js
@@ -185,7 +185,6 @@ exports.primFloatIsSafeInteger = function(x) {
 
 
 // These WORD64 values were obtained via `castDoubleToWord64` in Haskell:
-const WORD64_NAN      = 18444492273895866368n;
 const WORD64_POS_INF  = 9218868437227405312n;
 const WORD64_NEG_INF  = 18442240474082181120n;
 const WORD64_POS_ZERO = 0n;
@@ -193,7 +192,7 @@ const WORD64_NEG_ZERO = 9223372036854775808n;
 
 exports.primFloatToWord64 = function(x) {
     if (exports.primFloatIsNaN(x)) {
-        return WORD64_NAN;
+        return null;
     }
     else if (x < 0.0 && exports.primFloatIsInfinite(x)) {
         return WORD64_NEG_INF;

--- a/src/data/MAlonzo/src/MAlonzo/RTE/Float.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE/Float.hs
@@ -174,8 +174,10 @@ normaliseNaN x
   | isNaN x   = nan
   | otherwise = x
 
-doubleToWord64 :: Double -> Word64
-doubleToWord64 = castDoubleToWord64 . normaliseNaN
+doubleToWord64 :: Double -> Maybe Word64
+doubleToWord64 x
+  | isNaN x   = Nothing
+  | otherwise = Just (castDoubleToWord64 x)
 
 -- |Denotational equality for floating point numbers, checks bitwise equality.
 --

--- a/src/data/lib/prim/Agda/Builtin/Float.agda
+++ b/src/data/lib/prim/Agda/Builtin/Float.agda
@@ -23,7 +23,7 @@ primitive
   primFloatIsNegativeZero    : Float → Bool
   primFloatIsSafeInteger     : Float → Bool
   -- Conversions
-  primFloatToWord64          : Float → Word64
+  primFloatToWord64          : Float → Maybe Word64
   primNatToFloat             : Nat → Float
   primIntToFloat             : Int → Float
   primFloatRound             : Float → Maybe Int

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -503,9 +503,9 @@ primWord64ToNatInjective =  do
 primFloatToWord64Injective :: TCM PrimitiveImpl
 primFloatToWord64Injective = do
   float  <- primType (undefined :: Double)
-  word   <- primType (undefined :: Word64)
+  mword  <- primType (undefined :: Maybe Word64)
   toWord <- primFunName <$> getPrimitive "primFloatToWord64"
-  mkPrimInjective float word toWord
+  mkPrimInjective float mword toWord
 
 primQNameToWord64sInjective :: TCM PrimitiveImpl
 primQNameToWord64sInjective = do

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -184,7 +184,7 @@ compactDef bEnv def rewr = do
           "primFloatIsDenormalized"    -> mkPrim 1 $ floatPred isDenormalized
           "primFloatIsNegativeZero"    -> mkPrim 1 $ floatPred isNegativeZero
           "primFloatIsSafeInteger"     -> mkPrim 1 $ floatPred isSafeInteger
-          "primFloatToWord64"          -> mkPrim 1 $ \ [LitFloat a] -> word (doubleToWord64 a)
+          -- "primFloatToWord64"          -- returns a maybe
           -- "primFloatToWord64Injective" -- identities are not literals
           "primNatToFloat"             -> mkPrim 1 $ \ [LitNat a] -> float (fromIntegral a)
           -- "primIntToFloat"             -- integers are not literals

--- a/src/full/Agda/Utils/Float.hs
+++ b/src/full/Agda/Utils/Float.hs
@@ -221,8 +221,10 @@ normaliseNaN x
   | isNaN x   = nan
   | otherwise = x
 
-doubleToWord64 :: Double -> Word64
-doubleToWord64 = castDoubleToWord64 . normaliseNaN
+doubleToWord64 :: Double -> Maybe Word64
+doubleToWord64 x
+  | isNaN x   = Nothing
+  | otherwise = Just (castDoubleToWord64 x)
 
 -- |Denotational equality for floating point numbers, checks bitwise equality.
 --

--- a/test/Compiler/simple/Floats.agda
+++ b/test/Compiler/simple/Floats.agda
@@ -120,8 +120,14 @@ T : Bool → Set
 T false = ⊥
 T true  = ⊤
 
+_==MW_ : Maybe Word64 → Maybe Word64 → Bool
+nothing ==MW nothing = true
+nothing ==MW just _  = false
+just _  ==MW nothing = false
+just n  ==MW just m  = toℕ n ==N toℕ m
+
 _==F_ : Float → Float → Bool
-x ==F y = toℕ (toWord x) ==N toℕ (toWord x)
+x ==F y = toWord x ==MW toWord x
 
 _==B_ : Bool → Bool → Bool
 false ==B false = true

--- a/test/Succeed/Builtin.agda
+++ b/test/Succeed/Builtin.agda
@@ -90,7 +90,7 @@ primitive
   primFloatIsInfinite        : Float → Bool
   primFloatIsNaN             : Float → Bool
   primFloatIsNegativeZero    : Float → Bool
-  primFloatToWord64          : Float → Word64
+  primFloatToWord64          : Float → Maybe Word64
   primNatToFloat             : Nat → Float
   primIntToFloat             : Int → Float
   primFloatRound             : Float → Maybe Int

--- a/test/Succeed/Issue4868.agda
+++ b/test/Succeed/Issue4868.agda
@@ -54,6 +54,10 @@ data ⊥ : Set where
 _≢_ : {A : Set} (P Q : A) → Set
 P ≢ Q = P ≡ Q → ⊥
 
+fmap : {A B : Set} → (A → B) → Maybe A → Maybe B
+fmap f nothing  = nothing
+fmap f (just x) = just (f x)
+
 NaN : Float
 NaN = 0.0 ÷ 0.0
 
@@ -194,14 +198,14 @@ _ : show -Infinity ≡ "-Infinity" ; _ = refl
 _ : show  1.0      ≡  "1.0"      ; _ = refl
 _ : show  1.5      ≡  "1.5"      ; _ = refl
 
-_ : toℕ (toWord 1.0)       ≡ 4607182418800017408  ; _ = refl
-_ : toℕ (toWord 1.5)       ≡ 4609434218613702656  ; _ = refl
-_ : toℕ (toWord 0.0)       ≡ 0                    ; _ = refl
-_ : toℕ (toWord -0.0)      ≡ 9223372036854775808  ; _ = refl
-_ : toℕ (toWord NaN)       ≡ 18444492273895866368 ; _ = refl
-_ : toℕ (toWord -NaN)      ≡ 18444492273895866368 ; _ = refl
-_ : toℕ (toWord Infinity)  ≡ 9218868437227405312  ; _ = refl
-_ : toℕ (toWord -Infinity) ≡ 18442240474082181120 ; _ = refl
+_ : fmap toℕ (toWord 1.0)       ≡ just 4607182418800017408  ; _ = refl
+_ : fmap toℕ (toWord 1.5)       ≡ just 4609434218613702656  ; _ = refl
+_ : fmap toℕ (toWord 0.0)       ≡ just 0                    ; _ = refl
+_ : fmap toℕ (toWord -0.0)      ≡ just 9223372036854775808  ; _ = refl
+_ : fmap toℕ (toWord NaN)       ≡ nothing                   ; _ = refl
+_ : fmap toℕ (toWord -NaN)      ≡ nothing                   ; _ = refl
+_ : fmap toℕ (toWord Infinity)  ≡ just 9218868437227405312  ; _ = refl
+_ : fmap toℕ (toWord -Infinity) ≡ just 18442240474082181120 ; _ = refl
 
 _ : round 1.0       ≡ just (pos 1) ; _ = refl
 _ : round 1.5       ≡ just (pos 2) ; _ = refl


### PR DESCRIPTION
With `nothing` for `NaN`. The reason is that there are multiple representations of `NaN` in the IEEE standard, and different platforms choose different ones.

Fixes #6093.

Companion PR for the standard library is here: https://github.com/agda/agda-stdlib/pull/1843