### PR TITLE
Fix #6066: documentation for redundant `pattern` directive in records

### DIFF
--- a/doc/user-manual/language/record-types.lagda.rst
+++ b/doc/user-manual/language/record-types.lagda.rst
@@ -459,6 +459,12 @@ is on.  If you want the converse, you can add the record directive
   pred : HereditaryList → List HereditaryList
   pred record{ sublists = ts } = ts
 
+If both ``eta-equality`` and ``pattern`` are given for a record types,
+Agda will alert the user of a redundant ``pattern`` directive.
+However, if η is inferred but not declared explicitly, Agda will just
+ignore a redundant ``pattern`` directive; this is because the default
+can be changed globally by option :option:`--no-eta-equality`.
+
 .. _instance-fields:
 
 Instance fields

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -143,6 +143,7 @@ prettyWarning = \case
 
     UselessPatternDeclarationForRecord s -> fwords $ unwords
       [ "`pattern' attribute ignored for", s, "record" ]
+      -- the @s@ is a qualifier like "eta" or "coinductive"
 
     UselessPublic -> fwords $ "Keyword `public' is ignored here"
 


### PR DESCRIPTION
Fix #6066: documentation for redundant `pattern` directive in records.
Superseds:
- #6154

Salvages from #6154 the unification of the identical functions `recursiveRecord` and `nonRecursiveRecord`.