### PR TITLE
Only compile Agda.Primitive if it was visited

### DIFF
--- a/test/Compiler/simple/Issue2914.agda
+++ b/test/Compiler/simple/Issue2914.agda
@@ -1,7 +1,43 @@
+{-# OPTIONS --no-load-primitives #-}
 
-open import Agda.Builtin.IO
-open import Agda.Builtin.Nat
-open import Agda.Builtin.Unit
+-- Andreas, 2022-10-06, PR #6161:
+-- Also test --no-load-primitives.
+
+{-# BUILTIN TYPE Type #-}
+{-# BUILTIN PROP Prop #-}
+{-# BUILTIN SETOMEGA Typeω #-}
+{-# BUILTIN STRICTSET SSet #-}
+{-# BUILTIN STRICTSETOMEGA SSetω #-}
+
+postulate
+  Level : Type
+  lzero : Level
+  lsuc  : Level → Level
+  _⊔_   : Level → Level → Level
+
+{-# BUILTIN LEVEL Level #-}
+{-# BUILTIN LEVELZERO lzero #-}
+{-# BUILTIN LEVELSUC lsuc #-}
+{-# BUILTIN LEVELMAX _⊔_ #-}
+
+-- We cannot import the builtin modules since they use Agda.Primitive.
+
+postulate IO : ∀ {a} → Type a → Type a
+
+{-# BUILTIN IO IO #-}
+{-# FOREIGN GHC type AgdaIO a b = IO b #-}
+{-# COMPILE GHC IO = type AgdaIO #-}
+
+data Nat : Type where
+  zero : Nat
+  suc  : (n : Nat) → Nat
+
+{-# BUILTIN NATURAL Nat #-}
+
+record ⊤ : Type where
+
+{-# BUILTIN UNIT ⊤ #-}
+{-# COMPILE GHC ⊤ = data () (()) #-}
 
 private
   n : Nat


### PR DESCRIPTION
Should fix compilation (including `--html`) with `--no-load-primitives`: If that option's given, we don't try to independently compile the primitive modules;  cc @totbwf. Now I've _really_ got to work on my talk for tomorrow.