### PR TITLE
Fix #6165 by not insisting on `builtinSet` in the scope checker

### DIFF
--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -73,6 +73,18 @@ lamView (Lam i b e) = cons b $ lamView e
 lamView (ScopedExpr _ e) = lamView e
 lamView e = LamView [] e
 
+-- | Collect @A.Pi@s.
+data PiView = PiView [(ExprInfo, Telescope1)] Type
+
+piView :: Expr -> PiView
+piView = \case
+   Pi i tel b -> cons $ piView b
+     where cons (PiView tels t) = PiView ((i,tel) : tels) t
+   e -> PiView [] e
+
+unPiView :: PiView -> Expr
+unPiView (PiView tels t) = foldr (uncurry Pi) t tels
+
 -- | Gather top-level 'AsP'atterns and 'AnnP'atterns to expose underlying pattern.
 asView :: A.Pattern -> ([Name], [A.Expr], A.Pattern)
 asView (A.AsP _ x p)  = (\(asb, ann, p) -> (unBind x : asb, ann, p)) $ asView p

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -172,7 +172,11 @@ recordConstructorType decls =
     buildType :: [C.NiceDeclaration] -> ScopeM A.Expr
       -- TODO: Telescope instead of Expr in abstract RecDef
     buildType ds = do
-      dummy <- A.Def . fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinSet
+      -- The constructor target type is computed in the type checker.
+      -- For now, we put a dummy expression there.
+      -- Andreas, 2022-10-06, issue #6165:
+      -- The dummy was builtinSet, but this might not be defined yet.
+      let dummy = A.Lit empty $ LitString "TYPE"
       tel   <- catMaybes <$> mapM makeBinding ds
       return $ A.mkPi (ExprRange (getRange ds)) tel dummy
 

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -11,6 +11,7 @@ import qualified Data.Set as Set
 import Agda.Interaction.Options
 
 import qualified Agda.Syntax.Abstract as A
+import qualified Agda.Syntax.Abstract.Views as A
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
@@ -64,7 +65,7 @@ import Agda.Utils.Impossible
 --
 --     [@ps@]      Record parameters.
 --
---     [@contel@]  Approximate type of constructor (@fields@ -> Set).
+--     [@contel@]  Approximate type of constructor (@fields@ -> dummy).
 --                 Does not include record parameters.
 --
 --     [@fields@]  List of field signatures.
@@ -75,11 +76,19 @@ checkRecDef
   -> UniverseCheck             -- ^ Check universes?
   -> A.RecordDirectives        -- ^ (Co)Inductive, (No)Eta, (Co)Pattern, Constructor?
   -> A.DataDefParams           -- ^ Record parameters.
-  -> A.Expr                    -- ^ Approximate type of constructor (@fields@ -> Set).
+  -> A.Expr                    -- ^ Approximate type of constructor (@fields@ -> dummy).
                                --   Does not include record parameters.
   -> [A.Field]                 -- ^ Field signatures.
   -> TCM ()
-checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars ps) contel fields =
+checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars ps) contel0 fields = do
+
+  -- Andreas, 2022-10-06, issue #6165:
+  -- The target type of the constructor is a meaningless dummy expression which does not type-check.
+  -- We replace it by Set/Type (builtinSet) which is still incorrect but type-checks.
+  -- It will be fixed after type-checking.
+  aType <- A.Def . fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinSet
+  let contel = A.unPiView . (\ (A.PiView tels _) -> A.PiView tels aType) . A.piView $ contel0
+
   traceCall (CheckRecDef (getRange name) name ps fields) $ do
     reportSDoc "tc.rec" 10 $ vcat
       [ "checking record def" <+> prettyTCM name

--- a/test/Succeed/Issue6165.agda
+++ b/test/Succeed/Issue6165.agda
@@ -1,0 +1,15 @@
+-- Andreas, 2022-10-06, issue #6128
+-- Make sure you can use BUILTIN TYPE already in the same file.
+
+{-# OPTIONS --no-load-primitives #-}
+
+{-# BUILTIN TYPE Type #-}
+{-# BUILTIN PROP Prop #-}
+{-# BUILTIN SETOMEGA Typeω #-}
+{-# BUILTIN STRICTSET SSet #-}
+{-# BUILTIN STRICTSETOMEGA SSetω #-}
+
+record ⊤ : Type where
+
+-- WAS: internal error because scope checker tried to use BUILTIN TYPE.
+-- Should pass.


### PR DESCRIPTION
Fix #6165 by not insisting on `builtinSet` in the scope checker.

Even in the presence of `{-# BUILTIN TYPE Type #-}`, this builtin might not be defined in the scope checker, as this pragma is fully processed only in the type checker.  Thus, don't insist on `builtinSet` in the scope checker, rather produce different dummy expression for the target of the record constructor.