### PR TITLE
Fix #6168 by using `getBuiltin` in `levelType`. Proper error over crash.

### DIFF
--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -228,7 +228,7 @@ checkInternal' action v cmp t = verboseBracket "tc.check.internal" 20 "" $ do
       return $ Sort s
     Level l    -> do
       l <- checkLevel action l
-      lt <- levelType
+      lt <- levelType'
       compareType cmp lt t
       return $ Level l
     DontCare v -> DontCare <$> checkInternal' action v cmp t
@@ -469,7 +469,7 @@ checkLevel action (Max n ls) = Max n <$> mapM checkPlusLevel ls
     checkPlusLevel (Plus k l)      = Plus k <$> checkLevelAtom l
 
     checkLevelAtom l = do
-      lvl <- levelType
+      lvl <- levelType'
       checkInternal' action l CmpLeq lvl
 
 -- | Universe subsumption and type equality (subtyping for sizes, resp.).

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1569,7 +1569,7 @@ equalLevel a b = do
           | MetaV x as' <- ignoreBlocking a
           , MetaV y bs' <- ignoreBlocking b
           , k == l -> do
-              lvl <- levelType
+              lvl <- levelType'
               equalAtom (AsTermsOf lvl) (MetaV x as') (MetaV y bs')
         (SinglePlus (Plus k a) :| [] , _)
           | MetaV x as' <- ignoreBlocking a
@@ -1602,14 +1602,14 @@ equalLevel a b = do
 
       where
         a === b = unlessM typeInType $ do
-          lvl <- levelType
+          lvl <- levelType'
           equalAtom (AsTermsOf lvl) a b
 
         -- perform assignment (MetaV x as) := b
         meta x as b = do
           reportSLn "tc.meta.level" 30 $ "Assigning meta level"
           reportSDoc "tc.meta.level" 50 $ "meta" <+> sep [prettyList $ map pretty as, pretty b]
-          lvl <- levelType
+          lvl <- levelType'
           assignE DirEq x as (levelTm b) (AsTermsOf lvl) (===) -- fallback: check equality as atoms
 
         isNeutral (SinglePlus (Plus _ NotBlocked{})) = True

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -31,9 +31,16 @@ data LevelKit = LevelKit
   , zeroName :: QName
   }
 
--- | Get the 'primLevel' as a 'Type'.  Aborts if the BUILTIN LEVEL is undefined.
+{-# SPECIALIZE levelType :: TCM Type #-}
+-- | Get the 'primLevel' as a 'Type'.  Aborts if any of the level BUILTINs is undefined.
 levelType :: (HasBuiltins m, MonadTCError m) => m Type
-levelType = El (mkType 0) <$> getBuiltin builtinLevel
+levelType = El (mkType 0) . lvlType <$> requireLevels
+  -- Andreas, 2022-10-11, issue #6168
+  -- It seems superfluous to require all level builtins here,
+  -- but since we are in MonadTCError here, this is our chance to make sure
+  -- that all level builtins are defined.
+  -- Otherwise, we might run into an __IMPOSSIBLE__ later,
+  -- e.g. if only BUILTIN LEVEL was defined by reallyUnLevelView requires all builtins.
 
 -- | Get the 'primLevel' as a 'Type'.  Unsafe, crashes if the BUILTIN LEVEL is undefined.
 levelType' :: (HasBuiltins m) => m Type
@@ -45,9 +52,6 @@ isLevelType a = reduce (unEl a) >>= \case
     Def lvl [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevel
     return $ f == lvl
   _ -> return False
-
-levelSucFunction :: TCM (Term -> Term)
-levelSucFunction = apply1 <$> primLevelSuc
 
 {-# SPECIALIZE builtinLevelKit :: TCM LevelKit #-}
 {-# SPECIALIZE builtinLevelKit :: ReduceM LevelKit #-}
@@ -68,9 +72,24 @@ builtinLevelKit = do
       , zeroName = z
       }
 
+{-# SPECIALIZE requireLevels :: TCM LevelKit #-}
 -- | Raises an error if no level kit is available.
-requireLevels :: HasBuiltins m => m LevelKit
-requireLevels = builtinLevelKit
+requireLevels :: (HasBuiltins m, MonadTCError m) => m LevelKit
+requireLevels = do
+    level@(Def l []) <- getBuiltin builtinLevel
+    zero@(Def z [])  <- getBuiltin builtinLevelZero
+    suc@(Def s [])   <- getBuiltin builtinLevelSuc
+    max@(Def m [])   <- getBuiltin builtinLevelMax
+    return $ LevelKit
+      { lvlType  = level
+      , lvlSuc   = \ a -> suc `apply1` a
+      , lvlMax   = \ a b -> max `applys` [a, b]
+      , lvlZero  = zero
+      , typeName = l
+      , sucName  = s
+      , maxName  = m
+      , zeroName = z
+      }
 
 -- | Checks whether level kit is fully available.
 haveLevels :: HasBuiltins m => m Bool
@@ -94,13 +113,7 @@ unLevel v = return v
 {-# SPECIALIZE reallyUnLevelView :: Level -> TCM Term #-}
 {-# SPECIALIZE reallyUnLevelView :: Level -> ReduceM Term #-}
 reallyUnLevelView :: (HasBuiltins m) => Level -> m Term
-reallyUnLevelView nv = do
-  suc <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelSuc
-  zer <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelZero
-  case nv of
-    Max n []       -> return $ unConstV zer (apply1 suc) n
-    Max 0 [a]      -> return $ unPlusV (apply1 suc) a
-    _              -> (`unlevelWithKit` nv) <$> builtinLevelKit
+reallyUnLevelView nv = (`unlevelWithKit` nv) <$> builtinLevelKit
 
 unlevelWithKit :: LevelKit -> Level -> Term
 unlevelWithKit LevelKit{ lvlZero = zer, lvlSuc = suc, lvlMax = max } = \case

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -31,9 +31,13 @@ data LevelKit = LevelKit
   , zeroName :: QName
   }
 
--- | Get the 'primLevel' as a 'Type'.
-levelType :: (HasBuiltins m) => m Type
-levelType = El (mkType 0) . fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevel
+-- | Get the 'primLevel' as a 'Type'.  Aborts if the BUILTIN LEVEL is undefined.
+levelType :: (HasBuiltins m, MonadTCError m) => m Type
+levelType = El (mkType 0) <$> getBuiltin builtinLevel
+
+-- | Get the 'primLevel' as a 'Type'.  Unsafe, crashes if the BUILTIN LEVEL is undefined.
+levelType' :: (HasBuiltins m) => m Type
+levelType' = El (mkType 0) . fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevel
 
 isLevelType :: PureTCM m => Type -> m Bool
 isLevelType a = reduce (unEl a) >>= \case

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -487,23 +487,18 @@ data SortKit = SortKit
   , nameOfSetOmega :: IsFibrant -> QName
   }
 
--- | Compute a 'SortKit' in an environment that supports failures. When
--- 'optLoadPrimitives' is set to 'False', 'sortKit' is a fallible
--- operation, so for the uses of 'sortKit' in fallible contexts (e.g.
--- 'TCM'), we report a type error rather than exploding.
+-- | Compute a 'SortKit' in an environment that supports failures.
+--
+-- When 'optLoadPrimitives' is set to 'False', 'sortKit' is a fallible operation,
+-- so for the uses of 'sortKit' in fallible contexts (e.g. 'TCM'),
+-- we report a type error rather than exploding.
 sortKit :: (HasBuiltins m, MonadTCError m, HasOptions m) => m SortKit
 sortKit = do
-  loadPrim <- optLoadPrimitives <$> pragmaOptions
-  let
-    -- When '--no-load-primitives', recover by throwing a TC error.
-    recover s
-      | not loadPrim = typeError (GenericDocError ("Agda will not function without a binding for BUILTIN " <> s))
-      | otherwise = __IMPOSSIBLE__
-  Def set      _  <- maybe (recover "TYPE") pure           =<< getBuiltin' builtinSet
-  Def prop     _  <- maybe (recover "PROP") pure           =<< getBuiltin' builtinProp
-  Def setomega _  <- maybe (recover "SETOMEGA") pure       =<< getBuiltin' builtinSetOmega
-  Def sset     _  <- maybe (recover "STRICTSET") pure      =<< getBuiltin' builtinStrictSet
-  Def ssetomega _ <- maybe (recover "STRICTSETOMEGA") pure =<< getBuiltin' builtinSSetOmega
+  Def set      _  <- getBuiltin builtinSet
+  Def prop     _  <- getBuiltin builtinProp
+  Def setomega _  <- getBuiltin builtinSetOmega
+  Def sset     _  <- getBuiltin builtinStrictSet
+  Def ssetomega _ <- getBuiltin builtinSSetOmega
   return $ SortKit
     { nameOfSet      = set
     , nameOfProp     = prop

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -120,7 +120,7 @@ getBuiltinRewriteRelations = fmap rels <$> getBuiltinThing builtinRewrite
     Prim{}    -> __IMPOSSIBLE__
     Builtin{} -> __IMPOSSIBLE__
 
-getBuiltin :: (HasBuiltins m, MonadError TCErr m, MonadTCEnv m, ReadTCState m)
+getBuiltin :: (HasBuiltins m, MonadTCError m)
            => String -> m Term
 getBuiltin x =
   fromMaybeM (typeError $ NoBindingForBuiltin x) $ getBuiltin' x

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -872,7 +872,7 @@ instance AllHoles [PlusLevel] where
 instance AllHoles PlusLevel where
   type PType PlusLevel = ()
   allHoles _ (Plus n l) = do
-    la <- levelType
+    la <- levelType'
     fmap (Plus n) <$> allHoles la l
 
 

--- a/test/Fail/Issue6168.agda
+++ b/test/Fail/Issue6168.agda
@@ -1,0 +1,18 @@
+-- Andreas, 2022-10-06, issue #6168
+-- Don't crash if BUILTIN LEVEL is missing, give a proper error.
+
+{-# OPTIONS --no-load-primitives #-}
+
+{-# BUILTIN TYPE Type #-}
+{-# BUILTIN PROP Prop #-}
+{-# BUILTIN SETOMEGA Typeω #-}
+{-# BUILTIN STRICTSET SSet #-}
+{-# BUILTIN STRICTSETOMEGA SSetω #-}
+
+postulate IO : ∀ {a} → Type a → Type a
+
+-- Expected Error:
+
+-- No binding for builtin thing LEVEL, use {-# BUILTIN LEVEL name #-}
+-- to bind it to 'name'
+-- when checking that the expression Type a is a type

--- a/test/Fail/Issue6168.err
+++ b/test/Fail/Issue6168.err
@@ -1,0 +1,4 @@
+Issue6168.agda:12,24-30
+No binding for builtin thing LEVEL, use {-# BUILTIN LEVEL name #-}
+to bind it to 'name'
+when checking that the expression Type a is a type

--- a/test/Fail/Issue6168a.agda
+++ b/test/Fail/Issue6168a.agda
@@ -1,0 +1,23 @@
+-- Andreas, 2022-10-11, issue #6168
+-- Don't crash if BUILTIN LEVELZERO is missing, give a proper error.
+
+{-# OPTIONS --no-load-primitives #-}
+
+{-# BUILTIN TYPE Type #-}
+{-# BUILTIN PROP Prop #-}
+{-# BUILTIN SETOMEGA Typeω #-}
+{-# BUILTIN STRICTSET SSet #-}
+{-# BUILTIN STRICTSETOMEGA SSetω #-}
+
+postulate
+  Level : Type
+
+{-# BUILTIN LEVEL Level #-}
+
+postulate IO : ∀ {a} → Type a → Type a
+
+-- Expected Error:
+
+-- No binding for builtin thing LEVELZERO, use {-# BUILTIN LEVEL name #-}
+-- to bind it to 'name'
+-- when checking that the expression Type a is a type

--- a/test/Fail/Issue6168a.err
+++ b/test/Fail/Issue6168a.err
@@ -1,0 +1,4 @@
+Issue6168a.agda:17,24-30
+No binding for builtin thing LEVELZERO, use {-# BUILTIN LEVELZERO
+name #-} to bind it to 'name'
+when checking that the expression Type a is a type

--- a/test/Fail/NoLoadPrims.err
+++ b/test/Fail/NoLoadPrims.err
@@ -1,3 +1,4 @@
 NoLoadPrims.agda:6,5-6
-Agda will not function without a binding for BUILTIN TYPE
+No binding for builtin thing TYPE, use {-# BUILTIN TYPE name #-} to
+bind it to 'name'
 when checking that the expression ? is a type


### PR DESCRIPTION
Fix #6168 by using `getBuiltin` in `levelType`. Proper error over crash.