### PR TITLE
re #6073: treat Sub A i1 x as singleton

### DIFF
--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs-boot
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs-boot
@@ -1,0 +1,6 @@
+module Agda.TypeChecking.Primitive.Cubical.Base where
+
+import Agda.TypeChecking.Monad.Pure
+import Agda.Syntax.Internal
+
+isCubicalSubtype :: PureTCM m => Type -> m (Maybe (Term, Term, Term, Term))

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -8,6 +8,7 @@ import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Trans.Maybe
 import Control.Monad.Writer
+import Control.Applicative
 
 import Data.Bifunctor
 import qualified Data.List as List
@@ -20,6 +21,7 @@ import Agda.Syntax.Common
 import qualified Agda.Syntax.Concrete.Name as C
 import Agda.Syntax.Concrete (FieldAssignment'(..))
 import Agda.Syntax.Abstract.Name
+import Agda.Syntax.Internal.MetaVars (unblockOnAnyMetaIn)
 import Agda.Syntax.Internal as I
 import Agda.Syntax.Position
 import Agda.Syntax.Scope.Base (isNameInScope)
@@ -32,6 +34,7 @@ import Agda.TypeChecking.Reduce.Monad () --instance only
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Warnings
+import {-# SOURCE #-} Agda.TypeChecking.Primitive.Cubical.Base (isCubicalSubtype)
 
 import {-# SOURCE #-} Agda.TypeChecking.ProjectionLike (eligibleForProjectionLike)
 
@@ -835,7 +838,7 @@ isSingletonTypeModuloRelevance :: (PureTCM m, MonadBlock m) => Type -> m Bool
 isSingletonTypeModuloRelevance t = isJust <$> isSingletonType' True t mempty
 
 isSingletonType'
-  :: (PureTCM m, MonadBlock m)
+  :: forall m. (PureTCM m, MonadBlock m)
   => Bool            -- ^ Should disregard irrelevant fields?
   -> Type            -- ^ Type to check.
   -> Set QName       -- ^ Non-terminating record typess we already encountered.
@@ -846,11 +849,36 @@ isSingletonType' regardIrrelevance t rs = do
     TelV tel t <- telView t
     t <- abortIfBlocked t
     addContext tel $ do
-      res <- isRecordType t
-      case res of
-        Just (r, ps, def) | YesEta <- recEtaEquality def -> do
-          fmap (abstract tel) <$> isSingletonRecord' regardIrrelevance r ps rs
-        _ -> return Nothing
+      let
+        -- Easy case: η for records.
+        record :: m (Maybe Term)
+        record = runMaybeT $ do
+          (r, ps, def) <- MaybeT $ isRecordType t
+          guard (YesEta == recEtaEquality def)
+          abstract tel <$> MaybeT (isSingletonRecord' regardIrrelevance r ps rs)
+
+        -- Slightly harder case: η for Sub {level} tA phi elt.
+        -- tA : Type level, phi : I, elt : Partial phi tA.
+        subtype :: m (Maybe Term)
+        subtype = runMaybeT $ do
+          (level, tA, phi, elt) <- MaybeT $ isCubicalSubtype t
+          subin <- MaybeT $ getBuiltinName' builtinSubIn
+          itIsOne <- MaybeT $ getBuiltinName' builtinIsOne
+          phiV <- intervalView phi
+          case phiV of
+            -- If phi = i1, then inS (elt 1=1) is the only inhabitant.
+            IOne -> do
+              let
+                argH = Arg $ setHiding Hidden defaultArgInfo
+                it = elt `apply` [defaultArg (Def itIsOne [])]
+              pure (Def subin [] `apply` [argH level, argH tA, argH phi, defaultArg it])
+            -- Otherwise we're blocked
+            OTerm phi' -> patternViolation (unblockOnAnyMetaIn phi')
+            -- This fails the MaybeT: we're not looking at a
+            -- definitional singleton.
+            _ -> fail ""
+
+      (<|>) <$> record <*> subtype
 
 -- | Checks whether the given term (of the given type) is beta-eta-equivalent
 --   to a variable. Returns just the de Bruijn-index of the variable if it is,

--- a/test/Succeed/Issue6073.agda
+++ b/test/Succeed/Issue6073.agda
@@ -1,0 +1,33 @@
+{-# OPTIONS --cubical #-}
+open import Agda.Primitive
+open import Agda.Builtin.Cubical.Sub
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Nat
+
+module Issue6073 where
+
+“unit” : _
+“unit” = Sub Nat i1 λ ._ → 42
+
+“tt” : “unit”
+“tt” = inS 42
+
+data _≡ₛ_ {A : SSet} (a : A) : A → SSet where
+  reflₛ : a ≡ₛ a
+
+-- demonstrating definitional eta:
+_ : ∀ {x y : “unit”} → x ≡ₛ y
+_ = reflₛ
+
+refl : ∀ {l} {A : Set l} {x : A} → PathP (λ i → A) x x
+refl {x = x} i = x
+
+-- Amy (2022-10-07): This is the same bug as #593. The solution of X
+-- should be F (inS 42), since that's the only value that “unit” can
+-- have.
+
+bla7 : (F : “unit” → Set) ->
+  let X : Set
+      X = _
+  in (z : “unit”) -> PathP (λ i → Set) X (F z)
+bla7 F z = refl


### PR DESCRIPTION
Implementation's a tad ugly since I didn't want to make the dependency cycle _too_ awful, so I ended up redefining `argH` in a `let` locally. Magic words: closes #6073.