### PR TITLE
Re #6035: make `WhyInScope` explanation part of `AmbiguousName` error

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1317,10 +1317,12 @@ getModuleContents norm mm = do
   return (Map.keys modules, EmptyTel, types)
 
 
-whyInScope :: String -> TCM (Maybe LocalVar, [AbstractName], [AbstractModule])
+whyInScope :: String -> TCM (C.QName, Maybe LocalVar, [AbstractName], [AbstractModule])
 whyInScope s = do
   x     <- parseName noRange s
   scope <- getScope
-  return ( lookup x $ map (first C.QName) $ scope ^. scopeLocals
+  return ( x
+         , lookup x $ map (first C.QName) $ scope ^. scopeLocals
          , scopeLookup x scope
-         , scopeLookup x scope )
+         , scopeLookup x scope
+         )

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1317,12 +1317,13 @@ getModuleContents norm mm = do
   return (Map.keys modules, EmptyTel, types)
 
 
-whyInScope :: String -> TCM (C.QName, Maybe LocalVar, [AbstractName], [AbstractModule])
-whyInScope s = do
+whyInScope :: FilePath -> String -> TCM WhyInScopeData
+whyInScope cwd s = do
   x     <- parseName noRange s
   scope <- getScope
-  return ( x
-         , lookup x $ map (first C.QName) $ scope ^. scopeLocals
-         , scopeLookup x scope
-         , scopeLookup x scope
-         )
+  return $ WhyInScopeData
+    x
+    cwd
+    (lookup x $ map (first C.QName) $ scope ^. scopeLocals)
+    (scopeLookup x scope)
+    (scopeLookup x scope)

--- a/src/full/Agda/Interaction/EmacsTop.hs
+++ b/src/full/Agda/Interaction/EmacsTop.hs
@@ -181,8 +181,8 @@ lispifyDisplayInfo info = case info of
       let doc = "Definitions about" <+>
                 text (List.intercalate ", " $ words names) $$ nest 2 (align 10 hitDocs)
       format (render doc) "*Search About*"
-    Info_WhyInScope s cwd v xs ms -> do
-      doc <- explainWhyInScope s cwd v xs ms
+    Info_WhyInScope y cwd v xs ms -> do
+      doc <- explainWhyInScope y cwd v xs ms
       format (render doc) "*Scope Info*"
     Info_Context ii ctx -> do
       doc <- localTCState (prettyResponseContext ii False ctx)
@@ -318,15 +318,21 @@ showInfoError (Info_HighlightingParseError ii) =
 showInfoError (Info_HighlightingScopeCheckError ii) =
   return $ "Highlighting failed to scope check expression in " ++ show ii
 
-explainWhyInScope :: FilePath
-                  -> String
-                  -> (Maybe LocalVar)
-                  -> [AbstractName]
-                  -> [AbstractModule]
-                  -> TCM Doc
-explainWhyInScope s _ Nothing [] [] = TCP.text (s ++ " is not in scope.")
-explainWhyInScope s _ v xs ms = TCP.vcat
-  [ TCP.text (s ++ " is in scope as")
+explainWhyInScope ::
+     C.QName
+       -- ^ The name @x@ this explanation is about.
+  -> FilePath
+       -- ^ The directory in which the current module resides.
+  -> Maybe LocalVar
+       -- ^ The local variable that @x@ could denote, if any.
+  -> [AbstractName]
+       -- ^ The defined names that @x@ could denote.
+  -> [AbstractModule]
+       -- ^ The modules that @x@ could denote.
+  -> TCM Doc
+explainWhyInScope y _ Nothing [] [] = TCP.text (prettyShow  y ++ " is not in scope.")
+explainWhyInScope y _ v xs ms = TCP.vcat
+  [ TCP.text (prettyShow y ++ " is in scope as")
   , TCP.nest 2 $ TCP.vcat [variable v xs, modules ms]
   ]
   where

--- a/src/full/Agda/Interaction/EmacsTop.hs
+++ b/src/full/Agda/Interaction/EmacsTop.hs
@@ -21,7 +21,7 @@ import Agda.Syntax.Abstract.Pretty (prettyATop)
 import Agda.Syntax.Abstract as A
 import Agda.Syntax.Concrete as C
 
-import Agda.TypeChecking.Errors (prettyError, getAllWarningsOfTCErr)
+import Agda.TypeChecking.Errors ( explainWhyInScope, getAllWarningsOfTCErr, prettyError )
 import qualified Agda.TypeChecking.Pretty as TCP
 import Agda.TypeChecking.Pretty (prettyTCM)
 import Agda.TypeChecking.Pretty.Warning (prettyTCWarnings, prettyTCWarnings')
@@ -181,8 +181,8 @@ lispifyDisplayInfo info = case info of
       let doc = "Definitions about" <+>
                 text (List.intercalate ", " $ words names) $$ nest 2 (align 10 hitDocs)
       format (render doc) "*Search About*"
-    Info_WhyInScope y cwd v xs ms -> do
-      doc <- explainWhyInScope y cwd v xs ms
+    Info_WhyInScope why -> do
+      doc <- explainWhyInScope why
       format (render doc) "*Scope Info*"
     Info_Context ii ctx -> do
       doc <- localTCState (prettyResponseContext ii False ctx)
@@ -317,93 +317,6 @@ showInfoError (Info_HighlightingParseError ii) =
   return $ "Highlighting failed to parse expression in " ++ show ii
 showInfoError (Info_HighlightingScopeCheckError ii) =
   return $ "Highlighting failed to scope check expression in " ++ show ii
-
-explainWhyInScope ::
-     C.QName
-       -- ^ The name @x@ this explanation is about.
-  -> FilePath
-       -- ^ The directory in which the current module resides.
-  -> Maybe LocalVar
-       -- ^ The local variable that @x@ could denote, if any.
-  -> [AbstractName]
-       -- ^ The defined names that @x@ could denote.
-  -> [AbstractModule]
-       -- ^ The modules that @x@ could denote.
-  -> TCM Doc
-explainWhyInScope y _ Nothing [] [] = TCP.text (prettyShow  y ++ " is not in scope.")
-explainWhyInScope y _ v xs ms = TCP.vcat
-  [ TCP.text (prettyShow y ++ " is in scope as")
-  , TCP.nest 2 $ TCP.vcat [variable v xs, modules ms]
-  ]
-  where
-    -- variable :: Maybe _ -> [_] -> TCM Doc
-    variable Nothing vs = names vs
-    variable (Just x) vs
-      | null vs   = asVar
-      | otherwise = TCP.vcat
-         [ TCP.sep [ asVar, TCP.nest 2 $ shadowing x]
-         , TCP.nest 2 $ names vs
-         ]
-      where
-        asVar :: TCM Doc
-        asVar = do
-          "* a variable bound at" TCP.<+> TCP.prettyTCM (nameBindingSite $ localVar x)
-        shadowing :: LocalVar -> TCM Doc
-        shadowing (LocalVar _ _ [])    = "shadowing"
-        shadowing _ = "in conflict with"
-    names   = TCP.vcat . map pName
-    modules = TCP.vcat . map pMod
-
-    pKind = \case
-      ConName                  -> "constructor"
-      CoConName                -> "coinductive constructor"
-      FldName                  -> "record field"
-      PatternSynName           -> "pattern synonym"
-      GeneralizeName           -> "generalizable variable"
-      DisallowedGeneralizeName -> "generalizable variable from let open"
-      MacroName                -> "macro name"
-      QuotableName             -> "quotable name"
-      -- previously DefName:
-      DataName                 -> "data type"
-      RecName                  -> "record type"
-      AxiomName                -> "postulate"
-      PrimName                 -> "primitive function"
-      FunName                  -> "defined name"
-      OtherDefName             -> "defined name"
-
-    pName :: AbstractName -> TCM Doc
-    pName a = TCP.sep
-      [ "* a"
-        TCP.<+> pKind (anameKind a)
-        TCP.<+> TCP.text (prettyShow $ anameName a)
-      , TCP.nest 2 $ "brought into scope by"
-      ] TCP.$$
-      TCP.nest 2 (pWhy (nameBindingSite $ qnameName $ anameName a) (anameLineage a))
-    pMod :: AbstractModule -> TCM Doc
-    pMod  a = TCP.sep
-      [ "* a module" TCP.<+> TCP.text (prettyShow $ amodName a)
-      , TCP.nest 2 $ "brought into scope by"
-      ] TCP.$$
-      TCP.nest 2 (pWhy (nameBindingSite $ qnameName $ mnameToQName $ amodName a) (amodLineage a))
-
-    pWhy :: Range -> WhyInScope -> TCM Doc
-    pWhy r Defined = "- its definition at" TCP.<+> TCP.prettyTCM r
-    pWhy r (Opened (C.QName x) w) | isNoName x = pWhy r w
-    pWhy r (Opened m w) =
-      "- the opening of"
-      TCP.<+> TCP.prettyTCM m
-      TCP.<+> "at"
-      TCP.<+> TCP.prettyTCM (getRange m)
-      TCP.$$
-      pWhy r w
-    pWhy r (Applied m w) =
-      "- the application of"
-      TCP.<+> TCP.prettyTCM m
-      TCP.<+> "at"
-      TCP.<+> TCP.prettyTCM (getRange m)
-      TCP.$$
-      pWhy r w
-
 
 -- | Pretty-prints the context of the given meta-variable.
 

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -1104,8 +1104,8 @@ whyInScope :: String -> CommandM ()
 whyInScope s = do
   Just (CurrentFile file _ _) <- gets theCurrentFile
   let cwd = takeDirectory (filePath file)
-  (y, v, xs, ms) <- liftLocalState $ B.whyInScope s
-  display_info $ Info_WhyInScope y cwd v xs ms
+  why <- liftLocalState $ B.whyInScope cwd s
+  display_info $ Info_WhyInScope why
 
 -- | Sets the command line options and updates the status information.
 

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -1104,8 +1104,8 @@ whyInScope :: String -> CommandM ()
 whyInScope s = do
   Just (CurrentFile file _ _) <- gets theCurrentFile
   let cwd = takeDirectory (filePath file)
-  (v, xs, ms) <- liftLocalState (B.whyInScope s)
-  display_info $ Info_WhyInScope s cwd v xs ms
+  (y, v, xs, ms) <- liftLocalState $ B.whyInScope s
+  display_info $ Info_WhyInScope y cwd v xs ms
 
 -- | Sets the command line options and updates the status information.
 

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -31,6 +31,8 @@ import Agda.Syntax.Internal
          ( telToList, Dom'(..), Dom, MetaId(..), ProblemId(..), Blocker(..), alwaysUnblock )
 import Agda.Syntax.Position
          ( Range, rangeIntervals, Interval'(..), Position'(..), noRange )
+import Agda.Syntax.Scope.Base
+         ( WhyInScopeData(..) )
 
 import Agda.TypeChecking.Errors
          ( getAllWarningsOfTCErr )
@@ -328,11 +330,11 @@ instance EncodeTCM DisplayInfo where
     [ "results"           #= forM results encodeNamedPretty
     , "search"            @= toJSON search
     ]
-  encodeTCM (Info_WhyInScope y path v xs ms) = kind "WhyInScope"
+  encodeTCM (Info_WhyInScope why@(WhyInScopeData y path _ _ _)) = kind "WhyInScope"
     [ "thing"             @= prettyShow y
     , "filepath"          @= toJSON path
     -- use Emacs message first
-    , "message"           #= explainWhyInScope y path v xs ms
+    , "message"           #= explainWhyInScope why
     ]
   encodeTCM (Info_NormalForm commandState computeMode time expr) = kind "NormalForm"
     [ "commandState"      @= commandState

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -2,8 +2,10 @@ module Agda.Interaction.JSONTop
     ( jsonREPL
     ) where
 
-import Control.Monad          ( (<=<), forM )
-import Control.Monad.IO.Class ( MonadIO(..) )
+import Control.Monad
+         ( (<=<), forM )
+import Control.Monad.IO.Class
+         ( MonadIO(..) )
 
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as BS
@@ -12,30 +14,45 @@ import qualified Data.Set as Set
 
 import Agda.Interaction.AgdaTop
 import Agda.Interaction.Base
-  (CommandState(..), CurrentFile(..), ComputeMode(..), Rewrite(..), OutputForm(..), OutputConstraint(..))
+         ( CommandState(..), CurrentFile(..), ComputeMode(..), Rewrite(..), OutputForm(..), OutputConstraint(..) )
 import qualified Agda.Interaction.BasicOps as B
 import Agda.Interaction.EmacsTop
 import Agda.Interaction.JSON
 import Agda.Interaction.Response as R
 import Agda.Interaction.Highlighting.JSON
-import Agda.Syntax.Abstract.Pretty (prettyATop)
+
+import Agda.Syntax.Abstract.Pretty
+         ( prettyATop )
 import Agda.Syntax.Common
 import qualified Agda.Syntax.Concrete as C
-import Agda.Syntax.Concrete.Name (NameInScope(..), Name)
-import Agda.Syntax.Internal (telToList, Dom'(..), Dom, MetaId(..), ProblemId(..), Blocker(..), alwaysUnblock)
-import Agda.Syntax.Position (Range, rangeIntervals, Interval'(..), Position'(..), noRange)
-import Agda.VersionCommit
+import Agda.Syntax.Concrete.Name
+         ( NameInScope(..), Name )
+import Agda.Syntax.Internal
+         ( telToList, Dom'(..), Dom, MetaId(..), ProblemId(..), Blocker(..), alwaysUnblock )
+import Agda.Syntax.Position
+         ( Range, rangeIntervals, Interval'(..), Position'(..), noRange )
 
-import Agda.TypeChecking.Errors (getAllWarningsOfTCErr)
-import Agda.TypeChecking.Monad (Comparison(..), inTopContext, TCM, TCErr, TCWarning, NamedMeta(..), withInteractionId)
-import Agda.TypeChecking.Monad.MetaVars (getInteractionRange, getMetaRange, withMetaId)
-import Agda.TypeChecking.Pretty (PrettyTCM(..), prettyTCM)
+import Agda.TypeChecking.Errors
+         ( getAllWarningsOfTCErr )
+import Agda.TypeChecking.Monad
+         ( Comparison(..), inTopContext, TCM, TCErr, TCWarning, NamedMeta(..), withInteractionId )
+import Agda.TypeChecking.Monad.MetaVars
+         ( getInteractionRange, getMetaRange, withMetaId )
+import Agda.TypeChecking.Pretty
+         ( PrettyTCM(..), prettyTCM )
 -- borrowed from EmacsTop, for temporarily serialising stuff
-import Agda.TypeChecking.Pretty.Warning (filterTCWarnings)
-import Agda.TypeChecking.Warnings (WarningsAndNonFatalErrors(..))
-import Agda.Utils.Pretty (Pretty(..))
+import Agda.TypeChecking.Pretty.Warning
+         ( filterTCWarnings )
+import Agda.TypeChecking.Warnings
+         ( WarningsAndNonFatalErrors(..) )
+
 import qualified Agda.Utils.Pretty as P
-import Agda.Utils.Time (CPUTime(..))
+import Agda.Utils.Pretty
+         ( Pretty(..), prettyShow )
+import Agda.Utils.Time
+         ( CPUTime(..) )
+
+import Agda.VersionCommit
 
 --------------------------------------------------------------------------------
 
@@ -311,11 +328,11 @@ instance EncodeTCM DisplayInfo where
     [ "results"           #= forM results encodeNamedPretty
     , "search"            @= toJSON search
     ]
-  encodeTCM (Info_WhyInScope thing path v xs ms) = kind "WhyInScope"
-    [ "thing"             @= thing
+  encodeTCM (Info_WhyInScope y path v xs ms) = kind "WhyInScope"
+    [ "thing"             @= prettyShow y
     , "filepath"          @= toJSON path
     -- use Emacs message first
-    , "message"           #= explainWhyInScope thing path v xs ms
+    , "message"           #= explainWhyInScope y path v xs ms
     ]
   encodeTCM (Info_NormalForm commandState computeMode time expr) = kind "NormalForm"
     [ "commandState"      @= commandState

--- a/src/full/Agda/Interaction/Response.hs
+++ b/src/full/Agda/Interaction/Response.hs
@@ -30,10 +30,10 @@ import Agda.Interaction.Base
   )
 import Agda.Interaction.Highlighting.Precise
 import qualified Agda.Syntax.Abstract as A
-import Agda.Syntax.Common   (InteractionId(..), Arg)
-import Agda.Syntax.Concrete (Expr, Name)
-import Agda.Syntax.Concrete.Name (NameInScope)
-import Agda.Syntax.Scope.Base (AbstractModule, AbstractName, LocalVar)
+import Agda.Syntax.Common         (InteractionId(..), Arg)
+import Agda.Syntax.Concrete       (Expr)
+import Agda.Syntax.Concrete.Name  (Name, QName, NameInScope)
+import Agda.Syntax.Scope.Base     (AbstractModule, AbstractName, LocalVar)
 import qualified Agda.Syntax.Internal as I
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Base
   (TCM, TCErr, TCWarning, HighlightingMethod, ModuleToSource, NamedMeta, TCWarning, IPBoundary')
@@ -108,7 +108,17 @@ data DisplayInfo
         --   TODO: split these into separate constructors
     | Info_ModuleContents [Name] I.Telescope [(Name, I.Type)]
     | Info_SearchAbout [(Name, I.Type)] String
-    | Info_WhyInScope String FilePath (Maybe LocalVar) [AbstractName] [AbstractModule]
+    | Info_WhyInScope
+        QName
+          -- ^ The name @x@ this explanation is about.
+        FilePath
+          -- ^ The directory in which the current module resides.
+        (Maybe LocalVar)
+          -- ^ The local variable that @x@ could denote, if any.
+        [AbstractName]
+          -- ^ The defined names that @x@ could denote.
+        [AbstractModule]
+          -- ^ The modules that @x@ could denote.
     | Info_NormalForm CommandState ComputeMode (Maybe CPUTime) A.Expr
     | Info_InferredType CommandState (Maybe CPUTime) A.Expr
     | Info_Context InteractionId [ResponseContextEntry]

--- a/src/full/Agda/Interaction/Response.hs
+++ b/src/full/Agda/Interaction/Response.hs
@@ -33,7 +33,7 @@ import qualified Agda.Syntax.Abstract as A
 import Agda.Syntax.Common         (InteractionId(..), Arg)
 import Agda.Syntax.Concrete       (Expr)
 import Agda.Syntax.Concrete.Name  (Name, QName, NameInScope)
-import Agda.Syntax.Scope.Base     (AbstractModule, AbstractName, LocalVar)
+import Agda.Syntax.Scope.Base     (AbstractModule, AbstractName, LocalVar, WhyInScopeData)
 import qualified Agda.Syntax.Internal as I
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Base
   (TCM, TCErr, TCWarning, HighlightingMethod, ModuleToSource, NamedMeta, TCWarning, IPBoundary')
@@ -108,17 +108,7 @@ data DisplayInfo
         --   TODO: split these into separate constructors
     | Info_ModuleContents [Name] I.Telescope [(Name, I.Type)]
     | Info_SearchAbout [(Name, I.Type)] String
-    | Info_WhyInScope
-        QName
-          -- ^ The name @x@ this explanation is about.
-        FilePath
-          -- ^ The directory in which the current module resides.
-        (Maybe LocalVar)
-          -- ^ The local variable that @x@ could denote, if any.
-        [AbstractName]
-          -- ^ The defined names that @x@ could denote.
-        [AbstractModule]
-          -- ^ The modules that @x@ could denote.
+    | Info_WhyInScope WhyInScopeData
     | Info_NormalForm CommandState ComputeMode (Maybe CPUTime) A.Expr
     | Info_InferredType CommandState (Maybe CPUTime) A.Expr
     | Info_Context InteractionId [ResponseContextEntry]

--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -179,7 +179,7 @@ nameStringParts n = [ s | Id s <- List1.toList $ nameParts n ]
 stringNameParts :: String -> NameParts
 stringNameParts ""  = singleton $ Id "_"  -- NoName
 stringNameParts "_" = singleton $ Id "_"  -- NoName
-stringNameParts s = List1.fromList __IMPOSSIBLE__ $ loop s
+stringNameParts s = List1.fromListSafe __IMPOSSIBLE__ $ loop s
   where
   loop ""                              = []
   loop ('_':s)                         = Hole : loop s

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -854,7 +854,7 @@ LamBindings
   : LamBinds '->' {%
       case absurdBinding $1 of
         Just{}  -> parseError "Absurd lambda cannot have a body."
-        Nothing -> return $ List1.fromList __IMPOSSIBLE__ $ lamBindings $1
+        Nothing -> return $ List1.fromListSafe __IMPOSSIBLE__ $ lamBindings $1
       }
 
 AbsurdLamBindings :: { Either ([LamBinding], Hiding) (List1 Expr) }

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -555,6 +555,24 @@ ambiguousNamesInReason = \case
   AmbiguousLocalVar (LocalVar y _ _) xs -> List2.cons (A.qualify_ y) $ fmap anameName xs
   AmbiguousDeclName xs -> fmap anameName xs
 
+data WhyInScopeData
+  = WhyInScopeData
+      C.QName
+        -- ^ The name @x@ this explanation is about.
+      FilePath
+        -- ^ The directory in which the current module resides.
+      (Maybe LocalVar)
+        -- ^ The local variable that @x@ could denote, if any.
+      [AbstractName]
+        -- ^ The defined names that @x@ could denote.
+      [AbstractModule]
+        -- ^ The modules that @x@ could denote.
+
+whyInScopeDataFromAmbiguousNameReason :: C.QName -> AmbiguousNameReason -> WhyInScopeData
+whyInScopeDataFromAmbiguousNameReason q = \case
+  AmbiguousLocalVar x ys -> WhyInScopeData q empty (Just x) (toList ys) empty
+  AmbiguousDeclName ys   -> WhyInScopeData q empty Nothing  (toList ys) empty
+
 -- * Operations on name and module maps.
 
 mergeNames :: Eq a => ThingsInScope a -> ThingsInScope a -> ThingsInScope a

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -882,7 +882,7 @@ instance ToConcrete A.Expr where
                 reportSLn "extendedlambda" 50 $ "abstractToConcrete extended lambda patterns ps = " ++ prettyShow ps
                 return $ LamClause ps rhs ca
               decl2clause _ = __IMPOSSIBLE__
-          C.ExtendedLam (getRange i) erased . List1.fromList __IMPOSSIBLE__ <$>
+          C.ExtendedLam (getRange i) erased . List1.fromListSafe __IMPOSSIBLE__ <$>
             mapM decl2clause decls
             -- TODO List1: can we demonstrate non-emptiness?
 

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -190,7 +190,7 @@ isBuiltinFun = asks $ is . builtins
   where is m q b = Just q == Map.lookup b m
 
 -- | Resolve a concrete name. If illegally ambiguous fail with the ambiguous names.
-resolveName :: KindsOfNames -> Maybe (Set A.Name) -> C.QName -> AbsToCon (Either (List1 A.QName) ResolvedName)
+resolveName :: KindsOfNames -> Maybe (Set A.Name) -> C.QName -> AbsToCon (Either AmbiguousNameReason ResolvedName)
 resolveName kinds candidates q = runExceptT $ tryResolveName kinds candidates q
 
 -- | Treat illegally ambiguous names as UnknownNames.

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -838,7 +838,7 @@ scopeCheckExtendedLam r erased cs = do
       setScope si  -- This turns into an A.ScopedExpr si $ A.ExtendedLam...
       return $
         A.ExtendedLam (ExprRange r) di erased qname' $
-        List1.fromList __IMPOSSIBLE__ cs
+        List1.fromListSafe __IMPOSSIBLE__ cs
     _ -> __IMPOSSIBLE__
 
 -- | Raise an error if argument is a C.Dot with Hiding info.

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -185,7 +185,7 @@ recordConstructorType decls =
       let failure = typeError $ NotValidBeforeField d
           r       = getRange d
           mkLet d = Just . A.TLet r <$> toAbstract (LetDef d)
-      traceCall (SetRange r) $ case d of
+      setCurrentRange r $ case d of
 
         C.NiceField r pr ab inst tac x a -> do
           fx  <- getConcreteFixity x
@@ -1283,7 +1283,7 @@ instance ToAbstract (TopLevel [C.Declaration]) where
 
         -- If there are declarations after the top-level module
         -- we have to report a parse error here.
-        (_, C.Module{} : d : _) -> traceCall (SetRange $ getRange d) $
+        (_, C.Module{} : d : _) -> setCurrentRange d $
           genericError $ "No declarations allowed after top-level module."
 
         -- Otherwise, proceed.
@@ -1314,7 +1314,7 @@ instance ToAbstract (TopLevel [C.Declaration]) where
                          void $ toAbstract (Declarations outsideDecls)
                          void $ toAbstract (Declarations ds0)
                          -- Fail with a crude error otherwise
-                         traceCall (SetRange $ getRange ds0) $ genericError
+                         setCurrentRange ds0 $ genericError
                            "Illegal declaration(s) before top-level module"
 
                     -- Otherwise, reconstruct the top-level module name
@@ -1932,7 +1932,7 @@ instance ToAbstract NiceDeclaration where
       dir <- notPublicWithoutOpen open dir
 
       -- Andreas, 2018-11-03, issue #3364, parse expression in as-clause as Name.
-      let illformedAs s = traceCall (SetRange $ getRange as) $ do
+      let illformedAs s = setCurrentRange as $ do
             -- If @as@ is followed by something that is not a simple name,
             -- throw a warning and discard the as-clause.
             Nothing <$ warning (IllformedAsClause s)

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -816,7 +816,7 @@ instance PrettyTCM TypeError where
       [ fsep $ pwords "Ambiguous name" ++ [pretty x <> "."] ++
                pwords "It could refer to any one of"
       , nest 2 $ vcat $ fmap nameWithBinding $ ambiguousNamesInReason reason
-      , fwords "(hint: Use C-c C-w (in Emacs) if you want to know why)"
+      , explainWhyInScope $ whyInScopeDataFromAmbiguousNameReason x reason
       ]
 
     AmbiguousModule x ys -> vcat

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -811,10 +811,10 @@ instance PrettyTCM TypeError where
 
     NoSuchModule x -> fsep $ pwords "No module" ++ [pretty x] ++ pwords "in scope"
 
-    AmbiguousName x ys -> vcat
+    AmbiguousName x reason -> vcat
       [ fsep $ pwords "Ambiguous name" ++ [pretty x <> "."] ++
                pwords "It could refer to any one of"
-      , nest 2 $ vcat $ fmap nameWithBinding ys
+      , nest 2 $ vcat $ fmap nameWithBinding $ ambiguousNamesInReason reason
       , fwords "(hint: Use C-c C-w (in Emacs) if you want to know why)"
       ]
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4274,7 +4274,7 @@ data TypeError
         | AbstractConstructorNotInScope A.QName
         | NotInScope [C.QName]
         | NoSuchModule C.QName
-        | AmbiguousName C.QName (List1 A.QName)
+        | AmbiguousName C.QName AmbiguousNameReason
         | AmbiguousModule C.QName (List1 A.ModuleName)
         | ClashingDefinition C.QName A.QName (Maybe NiceDeclaration)
         | ClashingModule A.ModuleName A.ModuleName

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -433,7 +433,7 @@ checkPath b@(A.TBind _r _tac (xp :| []) typ) body ty = do
         rhs' = subst 0 iOne  v
     let t = Lam info $ Abs (namedArgName x) v
     let btyp i = El s (unArg typ `apply` [argN i])
-    locallyTC eRange (const noRange) $ blockTerm ty $ traceCall (SetRange $ getRange body) $ do
+    locallyTC eRange (const noRange) $ blockTerm ty $ setCurrentRange body $ do
       equalTerm (btyp iZero) lhs' (unArg lhs)
       equalTerm (btyp iOne) rhs' (unArg rhs)
       return t
@@ -1462,7 +1462,7 @@ checkKnownArguments
   -> TCM (Args, Type)   -- ^ Remaining inferred arguments, remaining type.
 checkKnownArguments []           vs t = return (vs, t)
 checkKnownArguments (arg : args) vs t = do
-  (vs', t') <- traceCall (SetRange $ getRange arg) $ checkKnownArgument arg vs t
+  (vs', t') <- setCurrentRange arg $ checkKnownArgument arg vs t
   checkKnownArguments args vs' t'
 
 -- | Check an argument whose value we already know.

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -491,7 +491,7 @@ instance Unquote R.Term where
           , (c `isCon` primAgdaTermMeta,    R.Meta    <$> unquoteN x <*> unquoteN y)
           , (c `isCon` primAgdaTermLam,     R.Lam     <$> unquoteN x <*> unquoteN y)
           , (c `isCon` primAgdaTermPi,      mkPi      <$> unquoteN x <*> unquoteN y)
-          , (c `isCon` primAgdaTermExtLam,  R.ExtLam  <$> (List1.fromList __IMPOSSIBLE__ <$> unquoteN x) <*> unquoteN y)
+          , (c `isCon` primAgdaTermExtLam,  R.ExtLam  <$> (List1.fromListSafe __IMPOSSIBLE__ <$> unquoteN x) <*> unquoteN y)
           ]
           __IMPOSSIBLE__
         where

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -22,6 +22,7 @@
 module Agda.Utils.List1
   ( module Agda.Utils.List1
   , module List1
+  , module IsList
   ) where
 
 import Prelude hiding (filter)
@@ -35,14 +36,16 @@ import qualified Data.List as List
 import qualified Data.Maybe as Maybe
 import qualified Data.Semigroup as Semigroup
 
-import qualified Data.List.NonEmpty (NonEmpty)
-import Data.List.NonEmpty as List1 hiding (NonEmpty, fromList)
+import Data.List.NonEmpty as List1 hiding (fromList, toList)
+import qualified Data.List.NonEmpty as List1 (toList)
+
+import GHC.Exts as IsList ( IsList(..) )
 
 import Agda.Utils.Functor ((<.>))
 import Agda.Utils.Null (Null(..))
 import qualified Agda.Utils.List as List
 
-type List1 = Data.List.NonEmpty.NonEmpty
+type List1 = NonEmpty
 
 -- | Safe version of 'Data.List.NonEmpty.fromList'.
 

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -46,12 +46,12 @@ type List1 = Data.List.NonEmpty.NonEmpty
 
 -- | Safe version of 'Data.List.NonEmpty.fromList'.
 
-fromList
+fromListSafe
   :: List1 a  -- ^ Default value if convertee is empty.
   -> [a]      -- ^ List to convert, supposedly non-empty.
   -> List1 a  -- ^ Converted list.
-fromList err   [] = err
-fromList _ (x:xs) = x :| xs
+fromListSafe err   [] = err
+fromListSafe _ (x:xs) = x :| xs
 
 -- | Return the last element and the rest.
 

--- a/src/full/Agda/Utils/List2.hs
+++ b/src/full/Agda/Utils/List2.hs
@@ -29,6 +29,39 @@ import Agda.Utils.Impossible
 data List2 a = List2 a a [a]
   deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
 
+-- | 'fromList' is unsafe.
+instance IsList (List2 a) where
+  type Item (List2 a) = a
+
+  -- Unsafe! O(1).
+  fromList :: [a] -> List2 a
+  fromList (a : b : cs) = List2 a b cs
+  fromList _            = __IMPOSSIBLE__
+
+  toList :: List2 a -> [a]
+  toList (List2 a b cs) = a : b : cs
+
+-- * Construction
+
+-- | O(1).
+cons :: a -> List1 a -> List2 a
+cons x (y :| ys) = List2 x y ys
+
+-- | O(length first list).
+append :: List1 a -> List1 a -> List2 a
+append (x :| xs) ys = cons x $ List1.prependList xs ys
+
+-- | O(length first list).
+appendList :: List2 a -> [a] -> List2 a
+appendList (List2 x y ys) zs = List2 x y $ mappend ys zs
+
+-- | Unsafe!
+fromList1 :: List1 a -> List2 a
+fromList1 (a :| b : cs) = List2 a b cs
+fromList1 _             = __IMPOSSIBLE__
+
+-- * Destruction
+
 -- | Safe. O(1).
 head :: List2 a -> a
 head (List2 a _ _) = a
@@ -51,25 +84,11 @@ fromList1Maybe = \case
   (a :| b : cs) -> Just (List2 a b cs)
   _ -> Nothing
 
-instance IsList (List2 a) where
-  type Item (List2 a) = a
-
-  -- Unsafe! O(1).
-  fromList :: [a] -> List2 a
-  fromList (a : b : cs) = List2 a b cs
-  fromList _            = __IMPOSSIBLE__
-
-  toList :: List2 a -> [a]
-  toList (List2 a b cs) = a : b : cs
-
 -- | Safe. O(1).
 toList1 :: List2 a -> List1 a
 toList1 (List2 a b cs) = a :| b : cs
 
--- | Unsafe!
-fromList1 :: List1 a -> List2 a
-fromList1 (a :| b : cs) = List2 a b cs
-fromList1 _             = __IMPOSSIBLE__
+-- * Partition
 
 break :: (a -> Bool) -> List2 a -> ([a],[a])
 break p = List.break p . toList

--- a/test/Fail/AmbiguousSet1.err
+++ b/test/Fail/AmbiguousSet1.err
@@ -1,7 +1,14 @@
 AmbiguousSet1.agda:5,8-12
 Ambiguous name Set₁. It could refer to any one of
-  Set bound at AmbiguousSet1.agda:3,45-48
   Set₁ bound at
     AmbiguousSet1.agda:3,58-62
-(hint: Use C-c C-w (in Emacs) if you want to know why)
+  Set bound at
+    AmbiguousSet1.agda:3,45-48
+Set₁ is in scope as
+  * a primitive function Agda.Primitive.Prop brought into scope by
+    - the opening of Agda.Primitive at AmbiguousSet1.agda:3,13-27
+    - its definition at AmbiguousSet1.agda:3,58-62
+  * a primitive function Agda.Primitive.Set brought into scope by
+    - the opening of Agda.Primitive at AmbiguousSet1.agda:3,13-27
+    - its definition at AmbiguousSet1.agda:3,45-48
 when scope checking Set₁

--- a/test/Fail/AmbiguousSet1b.err
+++ b/test/Fail/AmbiguousSet1b.err
@@ -1,7 +1,13 @@
 AmbiguousSet1b.agda:11,7-11
 Ambiguous name Set₁. It could refer to any one of
+  Set₁ bound at
+    AmbiguousSet1b.agda:6,3-7
   Set bound at
     agda-default-include-path/Agda/Primitive.agda:13,18-21
-  Set₁ bound at AmbiguousSet1b.agda:6,3-7
-(hint: Use C-c C-w (in Emacs) if you want to know why)
+Set₁ is in scope as
+  * a postulate AmbiguousSet1b.Set₁ brought into scope by
+    - its definition at AmbiguousSet1b.agda:6,3-7
+  * a primitive function Agda.Primitive.Set brought into scope by
+    - the opening of Agda.Primitive at AmbiguousSet1b.agda:8,13-27
+    - its definition at agda-default-include-path/Agda/Primitive.agda:13,18-21
 when scope checking Set₁

--- a/test/Fail/Issue1194m.err
+++ b/test/Fail/Issue1194m.err
@@ -4,5 +4,11 @@ Ambiguous name _∷_. It could refer to any one of
     Issue1194m.agda:10,5-8
   B._∷_ bound at
     Issue1194m.agda:17,5-8
-(hint: Use C-c C-w (in Emacs) if you want to know why)
+_∷_ is in scope as
+  * a postulate Issue1194m.A._∷_ brought into scope by
+    - the opening of A at Issue1194m.agda:19,6-7
+    - its definition at Issue1194m.agda:10,5-8
+  * a postulate Issue1194m.B._∷_ brought into scope by
+    - the opening of B at Issue1194m.agda:20,6-7
+    - its definition at Issue1194m.agda:17,5-8
 when scope checking Set ∷ Set

--- a/test/Fail/Issue1266.err
+++ b/test/Fail/Issue1266.err
@@ -1,7 +1,13 @@
 Issue1266.agda:12,34-35
 Ambiguous name A. It could refer to any one of
-  A bound at Issue1266.agda:12,9-10
+  A bound at
+    Issue1266.agda:12,9-10
   Issue1266.A bound at
     Issue1266.agda:7,5-6
-(hint: Use C-c C-w (in Emacs) if you want to know why)
+A is in scope as
+  * a variable bound at Issue1266.agda:12,9-10
+    in conflict with
+    * a record field Issue1266._.A brought into scope by
+      - the application of R at Issue1266.agda:12,27-28
+      - its definition at Issue1266.agda:7,5-6
 when scope checking A

--- a/test/Fail/Issue1266a.err
+++ b/test/Fail/Issue1266a.err
@@ -1,6 +1,13 @@
 Issue1266a.agda:13,34-35
 Ambiguous name A. It could refer to any one of
-  A bound at Issue1266a.agda:13,9-10
-  M.A bound at Issue1266a.agda:11,3-4
-(hint: Use C-c C-w (in Emacs) if you want to know why)
+  A bound at
+    Issue1266a.agda:13,9-10
+  M.A bound at
+    Issue1266a.agda:11,3-4
+A is in scope as
+  * a variable bound at Issue1266a.agda:13,9-10
+    in conflict with
+    * a defined name Issue1266a.M.A brought into scope by
+      - the opening of M at Issue1266a.agda:13,29-30
+      - its definition at Issue1266a.agda:11,3-4
 when scope checking A

--- a/test/Fail/Issue1266b.err
+++ b/test/Fail/Issue1266b.err
@@ -1,6 +1,13 @@
 Issue1266b.agda:14,7-8
 Ambiguous name A. It could refer to any one of
-  A bound at Issue1266b.agda:9,11-12
-  D.A bound at Issue1266b.agda:7,5-6
-(hint: Use C-c C-w (in Emacs) if you want to know why)
+  A bound at
+    Issue1266b.agda:9,11-12
+  D.A bound at
+    Issue1266b.agda:7,5-6
+A is in scope as
+  * a variable bound at Issue1266b.agda:9,11-12
+    in conflict with
+    * a constructor Issue1266b.Data.D.A brought into scope by
+      - the opening of Data at Issue1266b.agda:11,8-12
+      - its definition at Issue1266b.agda:7,5-6
 when scope checking A

--- a/test/Fail/Issue4154.err
+++ b/test/Fail/Issue4154.err
@@ -12,5 +12,11 @@ Ambiguous name B. It could refer to any one of
     Issue4154.agda:10,7-8
   M.A bound at
     Issue4154.agda:15,23-24
-(hint: Use C-c C-w (in Emacs) if you want to know why)
+B is in scope as
+  * a postulate Issue4154.M.B brought into scope by
+    - the opening of M at Issue4154.agda:15,6-7
+    - its definition at Issue4154.agda:10,7-8
+  * a postulate Issue4154.M.A brought into scope by
+    - the opening of M at Issue4154.agda:15,6-7
+    - its definition at Issue4154.agda:15,23-24
 when scope checking B

--- a/test/Internal/Helpers.hs
+++ b/test/Internal/Helpers.hs
@@ -217,7 +217,7 @@ listOfElements xs = listOf $ elements xs
 
 -- | Generates an officially non-empty list, while 'listOf1' does it inofficially.
 list1Of :: Gen a -> Gen (List1 a)
-list1Of = List1.fromList undefined <.> listOf1
+list1Of = List1.fromListSafe undefined <.> listOf1
 
 -- | If the given list is non-empty, then an element from the list is
 -- generated, and otherwise an arbitrary element is generated.

--- a/test/interaction/Issue2371.out
+++ b/test/interaction/Issue2371.out
@@ -6,6 +6,6 @@
 ((last . 1) . (agda2-goals-action '()))
 (agda2-status-action "Checked")
 (agda2-info-action "*Normal Form*" "0" nil)
-(agda2-info-action "*Error*" "1,1-4 Ambiguous name Nat. It could refer to any one of Nat bound at Issue2371.agda:4,19-22 Agda.Builtin.Nat.Nat bound at agda-default-include-path/Agda/Builtin/Nat.agda:8,6-9 (hint: Use C-c C-w (in Emacs) if you want to know why) when scope checking Nat" nil)
+(agda2-info-action "*Error*" "1,1-4 Ambiguous name Nat. It could refer to any one of Nat bound at Issue2371.agda:4,19-22 Agda.Builtin.Nat.Nat bound at agda-default-include-path/Agda/Builtin/Nat.agda:8,6-9 Nat is in scope as * a variable bound at Issue2371.agda:4,19-22 in conflict with * a data type Agda.Builtin.Nat.Nat brought into scope by - the opening of Agda.Builtin.Nat at - its definition at agda-default-include-path/Agda/Builtin/Nat.agda:8,6-9 when scope checking Nat" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")


### PR DESCRIPTION
Re #6035: make `WhyInScope` explanation part of `AmbiguousName` error.

Only the last commit implements this feature.  The other commits are refactorings.