### PR TITLE
Fix Agda input giving two characters at the same time for few of the inputs

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -316,7 +316,7 @@ order for the change to take effect."
   ("increment" . ("∆"))
   ("inf"       . ("∞"))
   ("&"         . ("⅋"))
-  ("z;"        . ("⨟⨾"))
+  ("z;"        . ,(agda-input-to-string-list "⨟⨾"))
   ("z:"        . ("⦂"))
 
   ;; Circled operators.

--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -298,7 +298,7 @@ order for the change to take effect."
   ("x"         . ("×"))
   ("o"         . ("∘"))
   ("comp"      . ("∘"))
-  ("."         . ("∙．"))
+  ("."         . ,(agda-input-to-string-list "∙．"))
   ("*"         . ("⋆"))
   (".+"        . ("∔"))
   (".-"        . ("∸"))

--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -756,8 +756,8 @@ order for the change to take effect."
   ("(|" . ("⦇"))  ;; Idiom brackets
   ("|)" . ("⦈"))
 
-  ("((" . ("⦅｟"))  ;; Banana brackets
-  ("))" . ("⦆｠"))
+  ("((" . ,(agda-input-to-string-list "⦅｟"))  ;; Banana brackets
+  ("))" . ,(agda-input-to-string-list "⦆｠"))
 
   ;; Primes.
 


### PR DESCRIPTION
Few of the Agda inputs were associated with two characters without `agda-input-to-string-list`, typing them in Emacs would result in two characters appearing at the same time.

They were introduced by
- #6077
- #6078
