### PR TITLE
Move `\langle` and `\rangle` to be the first choices for `\<` and `\>`

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -235,9 +235,6 @@ order for the change to take effect."
   ("squb="  . ("⊑"))  ("squp="  . ("⊒"))
   ("squb=n" . ("⋢"))  ("squp=n" . ("⋣"))
 
-  ("<"    . ,(agda-input-to-string-list "<≪⋘≺⊂⋐⊏⊰⊲⋖＜"))
-  (">"    . ,(agda-input-to-string-list ">≫⋙≻⊃⋑⊐⊱⊳⋗＞"))
-
   ;; Set membership etc.
 
   ("member" . ,(agda-input-to-string-list "∈∉∊∋∌∍⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿"))
@@ -737,8 +734,8 @@ order for the change to take effect."
 
   ("[[" . ("⟦"))
   ("]]" . ("⟧"))
-  ("<"  . ("⟨"))
-  (">"  . ("⟩"))
+  ("<"  . ,(agda-input-to-string-list "⟨<≪⋘≺⊂⋐⊏⊰⊲⋖＜"))
+  (">"  . ,(agda-input-to-string-list "⟩>≫⋙≻⊃⋑⊐⊱⊳⋗＞"))
   ("<<" . ("⟪"))
   (">>" . ("⟫"))
   ("{{" . ("⦃"))


### PR DESCRIPTION
Fixes #6172.
