### PR TITLE
Optimised TopLevelModuleName, removed SourceToModule and one instance of canonicalizeAbsolutePath

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -421,6 +421,7 @@ library
                     Agda.Syntax.Scope.Base
                     Agda.Syntax.Scope.Flat
                     Agda.Syntax.Scope.Monad
+                    Agda.Syntax.TopLevelModuleName
                     Agda.Syntax.Translation.AbstractToConcrete
                     Agda.Syntax.Translation.ConcreteToAbstract
                     Agda.Syntax.Translation.InternalToAbstract

--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -13,9 +13,9 @@ import GHC.Generics (Generic)
 
 import System.IO.Unsafe
 
-import Agda.Syntax.Concrete.Name (TopLevelModuleName)
 import Agda.Syntax.Concrete.Pretty () --instance only
 import Agda.Syntax.Abstract.Name
+import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
 import Agda.Utils.Benchmark (MonadBench(..))
 import qualified Agda.Utils.Benchmark as B
 import Agda.Utils.Null

--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -86,8 +86,12 @@ setInterface i = do
   opts <- getsTC (stPersistentOptions . stPersistentState)
   setCommandLineOptions opts
   mapM_ setOptionsFromPragma (iDefaultPragmaOptions i ++ iFilePragmaOptions i)
-  stImportedModules `setTCLens` Set.fromList (map fst $ iImportedModules i)
-  stCurrentModule   `setTCLens` Just (iModuleName i)
+  -- One could perhaps make the following command lazy. Note, however,
+  -- that it doesn't suffice to replace setTCLens' with setTCLens,
+  -- because the stPreImportedModules field is strict.
+  stImportedModules `setTCLens'`
+    Set.fromList (map fst $ iImportedModules i)
+  stCurrentModule   `setTCLens'` Just (iModuleName i)
 
 curIF :: ReadTCState m => m Interface
 curIF = do

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -269,7 +269,8 @@ prefix :: [Char]
 prefix = "jAgda"
 
 jsMod :: TopLevelModuleName -> GlobalId
-jsMod m = GlobalId (prefix : List1.toList (moduleNameParts m))
+jsMod m =
+  GlobalId (prefix : map T.unpack (List1.toList (moduleNameParts m)))
 
 jsFileName :: GlobalId -> String
 jsFileName (GlobalId ms) = intercalate "." ms ++ ".js"

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -30,12 +30,13 @@ import Agda.Interaction.Options
 import Agda.Syntax.Common
 import Agda.Syntax.Concrete.Name ( isNoName )
 import Agda.Syntax.Abstract.Name
-  ( ModuleName, QName,
+  ( QName,
     mnameToList, qnameName, qnameModule, nameId )
 import Agda.Syntax.Internal
   ( Name, Type
   , nameFixity, unDom, telToList )
 import Agda.Syntax.Literal       ( Literal(..) )
+import Agda.Syntax.TopLevelModuleName (TopLevelModuleName(..))
 import Agda.Syntax.Treeless      ( ArgUsage(..), filterUsed )
 import qualified Agda.Syntax.Treeless as T
 
@@ -58,8 +59,9 @@ import qualified Agda.Utils.Pretty as P
 import Agda.Utils.IO.Directory
 import Agda.Utils.IO.UTF8 ( writeFile )
 import Agda.Utils.Singleton ( singleton )
+import Agda.Utils.Size (size)
 
-import Agda.Compiler.Common
+import Agda.Compiler.Common as CC
 import Agda.Compiler.ToTreeless
 import Agda.Compiler.Treeless.EliminateDefaults
 import Agda.Compiler.Treeless.EliminateLiteralPatterns
@@ -161,7 +163,8 @@ jsPreCompile opts = do
 
 -- | After all modules have been compiled, copy RTE modules and verify compiled modules.
 
-jsPostCompile :: JSOptions -> IsMain -> Map.Map ModuleName Module -> TCM ()
+jsPostCompile ::
+  JSOptions -> IsMain -> Map.Map TopLevelModuleName Module -> TCM ()
 jsPostCompile opts _ ms = do
 
   -- Copy RTE modules.
@@ -201,7 +204,9 @@ data JSModuleEnv = JSModuleEnv
     -- ^ Should this module be compiled?
   }
 
-jsPreModule :: JSOptions -> IsMain -> ModuleName -> Maybe FilePath -> TCM (Recompile JSModuleEnv Module)
+jsPreModule ::
+  JSOptions -> IsMain -> TopLevelModuleName -> Maybe FilePath ->
+  TCM (Recompile JSModuleEnv Module)
 jsPreModule _opts _ m mifile = do
   cubical <- optCubical <$> pragmaOptions
   let compile = case cubical of
@@ -233,10 +238,12 @@ jsPreModule _opts _ m mifile = do
         , jsCompile        = compile
         }
 
-jsPostModule :: JSOptions -> JSModuleEnv -> IsMain -> ModuleName -> [Maybe Export] -> TCM Module
+jsPostModule ::
+  JSOptions -> JSModuleEnv -> IsMain -> TopLevelModuleName ->
+  [Maybe Export] -> TCM Module
 jsPostModule opts _ isMain _ defs = do
-  m             <- jsMod <$> curMName
-  is            <- map (jsMod . fst) . iImportedModules <$> curIF
+  m  <- jsMod <$> curMName
+  is <- map (jsMod . fst) . iImportedModules <$> curIF
   let mod = Module m is (reorder es) callMain
   writeModule (optJSMinify opts) mod
   return mod
@@ -261,8 +268,8 @@ jsCompileDef opts kit _isMain def = definition (opts, kit) (defName def, def)
 prefix :: [Char]
 prefix = "jAgda"
 
-jsMod :: ModuleName -> GlobalId
-jsMod m = GlobalId (prefix : map prettyShow (mnameToList m))
+jsMod :: TopLevelModuleName -> GlobalId
+jsMod m = GlobalId (prefix : List1.toList (moduleNameParts m))
 
 jsFileName :: GlobalId -> String
 jsFileName (GlobalId ms) = intercalate "." ms ++ ".js"
@@ -277,17 +284,17 @@ jsMember n
 
 global' :: QName -> TCM (Exp, JSQName)
 global' q = do
-  i <- iModuleName <$> curIF
-  modNm <- topLevelModuleName (qnameModule q)
+  i   <- iTopLevelModuleName <$> curIF
+  top <- CC.topLevelModuleName (qnameModule q)
   let
     -- Global module prefix
     qms = mnameToList $ qnameModule q
     -- File-local module prefix
-    localms = drop (length $ mnameToList modNm) qms
+    localms = drop (size top) qms
     nm = fmap jsMember $ List1.snoc localms $ qnameName q
-  if modNm == i
+  if top == i
     then return (Self, nm)
-    else return (Global (jsMod modNm), nm)
+    else return (Global (jsMod top), nm)
 
 global :: QName -> TCM (Exp, JSQName)
 global q = do

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -1284,7 +1284,7 @@ callGHC = do
   opts    <- askGhcOpts
   hsmod   <- prettyPrint <$> curHsMod
   agdaMod <- curAgdaMod
-  let outputName = List1.last $ moduleNameParts agdaMod
+  let outputName = Text.unpack $ List1.last $ moduleNameParts agdaMod
   (mdir, fp) <- curOutFileAndDir
   let ghcopts = optGhcFlags opts
 

--- a/src/full/Agda/Interaction/AgdaTop.hs
+++ b/src/full/Agda/Interaction/AgdaTop.hs
@@ -78,7 +78,6 @@ repl callback prompt setup = do
       case dropWhile isSpace r of
         ""          -> readCommand
         ('-':'-':_) -> readCommand
-        _           -> case listToMaybe $ reads r of
-          Just (x, "")  -> return $ Command x
-          Just (_, rem) -> return $ Error $ "not consumed: " ++ rem
-          _             -> return $ Error $ "cannot read: " ++ r
+        _           -> case parseIOTCM r of
+          Right cmd -> return $ Command cmd
+          Left err  -> return $ Error err

--- a/src/full/Agda/Interaction/Base.hs
+++ b/src/full/Agda/Interaction/Base.hs
@@ -24,6 +24,7 @@ import           Agda.Syntax.Common           (InteractionId (..), Modality)
 import           Agda.Syntax.Internal         (ProblemId, Blocker)
 import           Agda.Syntax.Position
 import           Agda.Syntax.Scope.Base       (ScopeInfo)
+import           Agda.Syntax.TopLevelModuleName
 
 import           Agda.Interaction.Options     (CommandLineOptions,
                                                defaultOptions)
@@ -85,6 +86,8 @@ type CommandM = StateT CommandState TCM
 data CurrentFile = CurrentFile
   { currentFilePath  :: AbsolutePath
       -- ^ The file currently loaded into interaction.
+  , currentFileModule :: TopLevelModuleName
+      -- ^ The top-level module name of the currently loaded file.
   , currentFileArgs  :: [String]
       -- ^ The arguments to Agda used for loading the file.
   , currentFileStamp :: ClockTime

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1165,8 +1165,8 @@ introTactic pmLambda ii = do
 atTopLevel :: TCM a -> TCM a
 atTopLevel m = inConcreteMode $ do
   let err = typeError $ GenericError "The file has not been loaded yet."
-  caseMaybeM (useTC stCurrentModule) err $ \ current -> do
-    caseMaybeM (getVisitedModule $ toTopLevelModuleName current) __IMPOSSIBLE__ $ \ mi -> do
+  caseMaybeM (useTC stCurrentModule) err $ \(current, topCurrent) -> do
+    caseMaybeM (getVisitedModule topCurrent) __IMPOSSIBLE__ $ \ mi -> do
       let scope = iInsideScope $ miInterface mi
       tel <- lookupSection current
       -- Get the names of the local variables from @scope@

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -254,8 +254,8 @@ moduleName
 moduleName file parsedModule = billTo [Bench.ModuleName] $ do
   let defaultName = rootNameModule file
       raw         = rawTopLevelModuleNameForModule parsedModule
-  topLevelModuleName =<< case rawModuleNameParts raw of
-    "_" :| [] -> do
+  topLevelModuleName =<< if isNoName raw
+    then do
       m <- runPM (parse moduleNameParser defaultName)
              `catchError` \_ ->
            typeError $ GenericError $
@@ -271,7 +271,7 @@ moduleName file parsedModule = billTo [Bench.ModuleName] $ do
             { rawModuleNameRange = getRange m
             , rawModuleNameParts = singleton (T.pack defaultName)
             }
-    _ -> return raw
+    else return raw
 
 parseFileExtsShortList :: [String]
 parseFileExtsShortList = ".agda" : literateExtsShortList

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -25,6 +25,7 @@ import Control.Monad.Except
 import Control.Monad.Trans
 import Data.Maybe (catMaybes)
 import qualified Data.Map as Map
+import qualified Data.Text as T
 import System.FilePath
 
 import Agda.Interaction.Library ( findProjectRoot )
@@ -268,7 +269,7 @@ moduleName file parsedModule = billTo [Bench.ModuleName] $ do
         QName {} ->
           return $ RawTopLevelModuleName
             { rawModuleNameRange = getRange m
-            , rawModuleNameParts = singleton defaultName
+            , rawModuleNameParts = singleton (T.pack defaultName)
             }
     _ -> return raw
 

--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -54,26 +54,25 @@ import           Agda.Utils.Size
 
 -- Entry point:
 -- | Create highlighting info for some piece of syntax.
-runHighlighter ::
-  Hilite a =>
-  SourceToModule -> AbsolutePath -> NameKinds -> a ->
-  HighlightingInfoBuilder
-runHighlighter modMap fileName kinds x =
+runHighlighter
+  :: Hilite a
+  => TopLevelModuleName
+     -- ^ The current top-level module's name.
+  -> NameKinds -> a -> HighlightingInfoBuilder
+runHighlighter top kinds x =
   runReader (hilite x) $
   HiliteEnv
-    { hleNameKinds = kinds
-    , hleModMap    = modMap
-    , hleFileName  = fileName
+    { hleNameKinds         = kinds
+    , hleCurrentModuleName = top
     }
 
 -- | Environment of the highlighter.
 data HiliteEnv = HiliteEnv
   { hleNameKinds :: NameKinds
       -- ^ Function mapping qualified names to their kind.
-  , hleModMap    :: SourceToModule
-      -- ^ Maps source file paths to module names.
-  , hleFileName  :: AbsolutePath
-      -- ^ The file name of the current module. Used for consistency checking.
+  , hleCurrentModuleName :: TopLevelModuleName
+      -- ^ The current top-level module's name. Used for consistency
+      -- checking.
   }
 
 -- | A function mapping names to the kind of name they stand for.
@@ -455,17 +454,14 @@ instance Hilite A.AmbiguousQName where
   hilite = hiliteAmbiguousQName Nothing
 
 instance Hilite A.ModuleName where
-  hilite m@(A.MName xs) = do
-    modMap <- asks hleModMap
-    hiliteModule (isTopLevelModule modMap, m)
+  hilite m@(A.MName xs) = hiliteModule (isTopLevelModule, m)
     where
-    isTopLevelModule modMap =
-      case mapMaybe
-          ((Strict.toLazy . P.srcFile) <=< (P.rStart . A.nameBindingSite)) xs of
-        f : _ ->
-          (rawTopLevelModuleName <$> Map.lookup f modMap) ==
-          Just (rawTopLevelModuleNameForModuleName m)
-        [] -> False
+    isTopLevelModule =
+      case mapMaybe (P.rangeModule . A.nameBindingSite) xs of
+        []      -> False
+        top : _ ->
+          rawTopLevelModuleName top ==
+          rawTopLevelModuleNameForModuleName m
 
   -- Andreas, 2020-09-29, issue #4952.
 -- The target of a @renaming@ clause needs to be highlighted in a special way.
@@ -568,30 +564,28 @@ hiliteCName
      --   The argument is 'True' iff the name is an operator.
   -> Hiliter
 hiliteCName xs x fr mR asp = do
-  HiliteEnv _ modMap fileName <- ask
+  env <- ask
   -- We don't care if we get any funny ranges.
-  if all (== Strict.Just fileName) fileNames then pure $
-    frFile modMap <>
-    H.singleton (rToR rs)
-                (aspects { definitionSite = mFilePos modMap })
-   else
-    mempty
+  if all (== Just (hleCurrentModuleName env)) moduleNames
+  then pure $
+    frFile <>
+    H.singleton (rToR rs) (aspects { definitionSite = mFilePos })
+  else mempty
   where
-  aspects       = asp $ C.isOperator x
-  fileNames     = mapMaybe (fmap P.srcFile . P.rStart . getRange) (x : xs)
-  frFile modMap = H.singleton (rToR fr) (aspects { definitionSite = notHere <$> mFilePos modMap })
-  rs            = getRange (x : xs)
+  aspects     = asp $ C.isOperator x
+  moduleNames = mapMaybe (P.rangeModule' . getRange) (x : xs)
+  frFile      = H.singleton (rToR fr) $
+                aspects { definitionSite = notHere <$> mFilePos }
+  rs          = getRange (x : xs)
 
   -- The fixity declaration should not get a symbolic anchor.
   notHere d = d { defSiteHere = False }
 
-  mFilePos
-    :: SourceToModule  -- Maps source file paths to module names.
-    -> Maybe DefinitionSite
-  mFilePos modMap = do
+  mFilePos :: Maybe DefinitionSite
+  mFilePos = do
     r <- mR
     P.Pn { P.srcFile = Strict.Just f, P.posPos = p } <- P.rStart r
-    mod <- Map.lookup f modMap
+    mod <- P.rangeFileName f
     -- Andreas, 2017-06-16, Issue #2604: Symbolic anchors.
     -- We drop the file name part from the qualifiers, since
     -- this is contained in the html file name already.
@@ -645,13 +639,13 @@ hiliteAName
      -- ^ The argument is 'True' iff the name is an operator.
   -> Hiliter
 hiliteAName x include asp = do
-  fileName <- asks hleFileName
+  currentModule <- asks hleCurrentModuleName
   hiliteCName (concreteQualifier x)
               (concreteBase x)
-              (rangeOfFixityDeclaration fileName)
+              (rangeOfFixityDeclaration currentModule)
               (if include then Just $ bindingSite x else Nothing)
               asp
-    <> (notationFile fileName)
+    <> notationFile currentModule
   where
   -- TODO: Currently we highlight fixity and syntax declarations by
   -- producing highlighting something like once per occurrence of the
@@ -659,14 +653,14 @@ hiliteAName x include asp = do
   -- avoid doing this for other files). Perhaps it would be better to
   -- only produce this highlighting once.
 
-  rangeOfFixityDeclaration fileName =
-    if P.rangeFile r == Strict.Just fileName
+  rangeOfFixityDeclaration currentModule =
+    if P.rangeModule r == Just currentModule
     then r else noRange
     where
     r = theNameRange $ A.nameFixity $ A.qnameName x
 
-  notationFile fileName = pure $
-    if P.rangeFile (getRange notation) == Strict.Just fileName
+  notationFile currentModule = pure $
+    if P.rangeModule (getRange notation) == Just currentModule
     then mconcat $ map genPartFile notation
     else mempty
     where

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -64,7 +64,9 @@ import qualified Agda.Syntax.Literal as L
 import qualified Agda.Syntax.Parser as Pa
 import qualified Agda.Syntax.Parser.Tokens as T
 import qualified Agda.Syntax.Position as P
-import Agda.Syntax.Position (Range, HasRange, getRange, noRange)
+import Agda.Syntax.Position
+  (RangeFile, Range, HasRange, getRange, noRange)
+import Agda.Syntax.TopLevelModuleName
 
 import Agda.Syntax.Scope.Base     ( WithKind(..) )
 import Agda.Syntax.Abstract.Views ( KName, declaredNames )
@@ -127,19 +129,18 @@ generateAndPrintSyntaxInfo
   -> TCM ()
 generateAndPrintSyntaxInfo decl _ _ | null $ getRange decl = return ()
 generateAndPrintSyntaxInfo decl hlLevel updateState = do
-  file <- getCurrentPath
+  top <- fromMaybe __IMPOSSIBLE__ <$> currentTopLevelModule
 
   reportSLn "import.iface.create" 15 $ concat
     [ "Generating syntax info for "
-    , filePath file
+    , prettyShow top
     , case hlLevel of
         Full   {} -> " (final)."
         Partial{} -> " (first approximation)."
     ]
 
   ignoreAbstractMode $ do
-    modMap <- sourceToModule
-    kinds  <- nameKinds hlLevel decl
+    kinds <- nameKinds hlLevel decl
 
     -- After the code has been type checked more information may be
     -- available for overloaded constructors, and
@@ -147,11 +148,11 @@ generateAndPrintSyntaxInfo decl hlLevel updateState = do
     -- Note, however, that highlighting for overloaded constructors is
     -- included also in @nameInfo@.
     constructorInfo <- case hlLevel of
-      Full{} -> generateConstructorInfo modMap file kinds decl
+      Full{} -> generateConstructorInfo top kinds decl
       _      -> return mempty
 
     -- Main source of scope-checker generated highlighting:
-    let nameInfo = runHighlighter modMap file kinds decl
+    let nameInfo = runHighlighter top kinds decl
 
     reportSDoc "highlighting.warning" 60 $ TCM.hcat
       [ "current path = "
@@ -184,14 +185,23 @@ generateAndPrintSyntaxInfo decl hlLevel updateState = do
 
 generateTokenInfo :: AbsolutePath -> TCM HighlightingInfo
 generateTokenInfo file =
-  generateTokenInfoFromSource file . Text.unpack =<<
-    runPM (Pa.readFilePM file)
+  generateTokenInfoFromSource rf . Text.unpack =<<
+    runPM (Pa.readFilePM rf)
+  where
+  -- Note the use of Nothing here. The file might not even parse, but
+  -- it should still be possible to obtain token-based highlighting
+  -- information. The top-level module names seem to be *mostly*
+  -- unused, but one cannot use __IMPOSSIBLE__ instead of Nothing,
+  -- because the top-level module names are used by interleaveRanges,
+  -- which is used by parseLiterateWithComments, which is used by
+  -- generateTokenInfoFromSource.
+  rf = P.mkRangeFile file Nothing
 
 -- | Generate and return the syntax highlighting information for the
 -- tokens in the given file.
 
 generateTokenInfoFromSource
-  :: AbsolutePath
+  :: RangeFile
      -- ^ The module to highlight.
   -> String
      -- ^ The file contents. Note that the file is /not/ read from
@@ -323,12 +333,12 @@ instance Collection KName NameKindBuilder
 -- the type checker.
 
 generateConstructorInfo
-  :: SourceToModule  -- ^ Maps source file paths to module names.
-  -> AbsolutePath    -- ^ The module to highlight.
+  :: TopLevelModuleName
+     -- ^ The module to highlight.
   -> NameKinds
   -> A.Declaration
   -> TCM HighlightingInfoBuilder
-generateConstructorInfo modMap file kinds decl = do
+generateConstructorInfo top kinds decl = do
 
   -- Get boundaries of current declaration.
   -- @noRange@ should be impossible, but in case of @noRange@
@@ -345,7 +355,7 @@ generateConstructorInfo modMap file kinds decl = do
         constrs = IntMap.elems m2
 
     -- Return suitable syntax highlighting information.
-    return $ foldMap (runHighlighter modMap file kinds) constrs
+    return $ foldMap (runHighlighter top kinds) constrs
 
 printSyntaxInfo :: Range -> TCM ()
 printSyntaxInfo r = do

--- a/src/full/Agda/Interaction/Highlighting/HTML/Backend.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML/Backend.hs
@@ -25,7 +25,7 @@ import Agda.Interaction.Options
 import Agda.Compiler.Backend (Backend(..), Backend'(..), Recompile(..))
 import Agda.Compiler.Common (IsMain(..), curIF)
 
-import Agda.Syntax.Abstract (ModuleName, toTopLevelModuleName)
+import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
 
 import Agda.TypeChecking.Monad
   ( MonadDebug
@@ -52,7 +52,7 @@ data HtmlCompileEnv = HtmlCompileEnv
 
 data HtmlModuleEnv = HtmlModuleEnv
   { htmlModEnvCompileEnv :: HtmlCompileEnv
-  , htmlModEnvName       :: ModuleName
+  , htmlModEnvName       :: TopLevelModuleName
   }
 
 data HtmlModule = HtmlModule
@@ -164,7 +164,7 @@ preModuleHtml
   :: Applicative m
   => HtmlCompileEnv
   -> IsMain
-  -> ModuleName
+  -> TopLevelModuleName
   -> Maybe FilePath
   -> m (Recompile HtmlModuleEnv HtmlModule)
 preModuleHtml cenv _isMain modName _ifacePath = pure $ Recompile (HtmlModuleEnv cenv modName)
@@ -183,12 +183,12 @@ postModuleHtml
   => HtmlCompileEnv
   -> HtmlModuleEnv
   -> IsMain
-  -> ModuleName
+  -> TopLevelModuleName
   -> [HtmlDef]
   -> m HtmlModule
 postModuleHtml _env menv _isMain _modName _defs = do
   let generatePage = defaultPageGen . htmlCompileEnvOpts . htmlModEnvCompileEnv $ menv
-  htmlSrc <- srcFileOfInterface (toTopLevelModuleName . htmlModEnvName $ menv) <$> curIF
+  htmlSrc <- srcFileOfInterface (htmlModEnvName menv) <$> curIF
   runLogHtmlWithMonadDebug $ generatePage htmlSrc
   return HtmlModule
 
@@ -196,6 +196,6 @@ postCompileHtml
   :: Applicative m
   => HtmlCompileEnv
   -> IsMain
-  -> Map ModuleName HtmlModule
+  -> Map TopLevelModuleName HtmlModule
   -> m ()
 postCompileHtml _cenv _isMain _modulesByName = pure ()

--- a/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
@@ -54,8 +54,8 @@ import Paths_Agda
 
 import Agda.Interaction.Highlighting.Precise hiding (toList)
 
-import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Common
+import Agda.Syntax.TopLevelModuleName
 
 import qualified Agda.TypeChecking.Monad as TCM
   ( Interface(..)
@@ -137,7 +137,7 @@ data HtmlOptions = HtmlOptions
 -- | Internal type bundling the information related to a module source file
 
 data HtmlInputSourceFile = HtmlInputSourceFile
-  { _srcFileModuleName :: C.TopLevelModuleName
+  { _srcFileModuleName :: TopLevelModuleName
   , _srcFileType :: FileType
   -- ^ Source file type
   , _srcFileText :: Text
@@ -148,7 +148,8 @@ data HtmlInputSourceFile = HtmlInputSourceFile
 
 -- | Bundle up the highlighting info for a source file
 
-srcFileOfInterface :: C.TopLevelModuleName -> TCM.Interface -> HtmlInputSourceFile
+srcFileOfInterface ::
+  TopLevelModuleName -> TCM.Interface -> HtmlInputSourceFile
 srcFileOfInterface m i = HtmlInputSourceFile m (TCM.iFileType i) (TCM.iSource i) (TCM.iHighlighting i)
 
 -- | Logging during HTML generation
@@ -213,7 +214,7 @@ prepareCommonDestinationAssets options = liftIO $ do
 
 -- | Converts module names to the corresponding HTML file names.
 
-modToFile :: C.TopLevelModuleName -> String -> FilePath
+modToFile :: TopLevelModuleName -> String -> FilePath
 modToFile m ext = Network.URI.Encode.encode $ render (pretty m) <.> ext
 
 -- | Generates a highlighted, hyperlinked version of the given module.
@@ -236,7 +237,7 @@ h !! as = h ! mconcat as
 page :: FilePath              -- ^ URL to the CSS file.
      -> Bool                  -- ^ Highlight occurrences
      -> Bool                  -- ^ Whether to reserve literate
-     -> C.TopLevelModuleName  -- ^ Module to be highlighted.
+     -> TopLevelModuleName    -- ^ Module to be highlighted.
      -> Html
      -> Text
 page css

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Backend.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Backend.hs
@@ -35,8 +35,7 @@ import Agda.Interaction.Options
   , OptDescr(..)
   )
 
-import Agda.Syntax.Abstract.Name (ModuleName, toTopLevelModuleName)
-import Agda.Syntax.Concrete.Name (TopLevelModuleName, projectRoot)
+import Agda.Syntax.TopLevelModuleName (TopLevelModuleName, projectRoot)
 
 import Agda.TypeChecking.Monad
   ( HasOptions(commandLineOptions)
@@ -147,11 +146,11 @@ preModuleLaTeX
   :: (HasOptions m, ReadTCState m)
   => LaTeXCompileEnv
   -> IsMain
-  -> ModuleName
+  -> TopLevelModuleName
   -> Maybe FilePath
   -> m (Recompile LaTeXModuleEnv LaTeXModule)
 preModuleLaTeX (LaTeXCompileEnv flags) isMain moduleName _ifacePath = case isMain of
-  IsMain  -> Recompile . LaTeXModuleEnv <$> resolveLaTeXOptions flags (toTopLevelModuleName moduleName)
+  IsMain  -> Recompile . LaTeXModuleEnv <$> resolveLaTeXOptions flags moduleName
   NotMain -> return $ Skip LaTeXModule
 
 compileDefLaTeX
@@ -168,7 +167,7 @@ postModuleLaTeX
   => LaTeXCompileEnv
   -> LaTeXModuleEnv
   -> IsMain
-  -> ModuleName
+  -> TopLevelModuleName
   -> [LaTeXDef]
   -> m LaTeXModule
 postModuleLaTeX _cenv (LaTeXModuleEnv latexOpts) _main _moduleName _defs = do
@@ -186,6 +185,6 @@ postCompileLaTeX
   :: Applicative m
   => LaTeXCompileEnv
   -> IsMain
-  -> Map ModuleName LaTeXModule
+  -> Map TopLevelModuleName LaTeXModule
   -> m ()
 postCompileLaTeX _cenv _main _modulesByName = pure ()

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -63,7 +63,7 @@ import Paths_Agda
 import Agda.Syntax.Common
 import Agda.Syntax.Parser.Literate (literateTeX, LayerRole, atomizeLayers)
 import qualified Agda.Syntax.Parser.Literate as L
-import Agda.Syntax.Position (startPos)
+import Agda.Syntax.Position (RangeFile, startPos)
 import Agda.Syntax.TopLevelModuleName
   (TopLevelModuleName, moduleNameParts)
 
@@ -71,7 +71,6 @@ import Agda.Interaction.Highlighting.Precise hiding (toList)
 
 import Agda.TypeChecking.Monad (Interface(..)) --, reportSLn)
 
-import Agda.Utils.FileName (AbsolutePath)
 import Agda.Utils.Function (applyWhen)
 import Agda.Utils.Functor  ((<&>))
 import Agda.Utils.List     (last1, updateHead, updateLast)
@@ -697,7 +696,7 @@ defaultStyFile = "agda.sty"
 
 data LaTeXOptions = LaTeXOptions
   { latexOptOutDir         :: FilePath
-  , latexOptSourceFileName :: Maybe AbsolutePath
+  , latexOptSourceFileName :: Maybe RangeFile
     -- ^ The parser uses a @Position@ which includes a source filename for
     -- error reporting and such. We don't actually get the source filename
     -- with an @Interface@, and it isn't necessary to look it up.
@@ -784,7 +783,7 @@ groupByFst =
 toLaTeX
   :: MonadLogLaTeX m
   => Env
-  -> Maybe AbsolutePath
+  -> Maybe RangeFile
   -> L.Text
   -> HighlightingInfo
   -> m L.Text

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -60,12 +60,12 @@ import qualified Data.List    as List
 
 import Paths_Agda
 
-import Agda.Syntax.Abstract (toTopLevelModuleName)
 import Agda.Syntax.Common
-import Agda.Syntax.Concrete (TopLevelModuleName, moduleNameParts)
 import Agda.Syntax.Parser.Literate (literateTeX, LayerRole, atomizeLayers)
 import qualified Agda.Syntax.Parser.Literate as L
 import Agda.Syntax.Position (startPos)
+import Agda.Syntax.TopLevelModuleName
+  (TopLevelModuleName, moduleNameParts)
 
 import Agda.Interaction.Highlighting.Precise hiding (toList)
 

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -757,7 +757,8 @@ generateLaTeXIO :: (MonadLogLaTeX m, MonadIO m) => LaTeXOptions -> Interface -> 
 generateLaTeXIO opts i = do
   let textWidthEstimator = getTextWidthEstimator (latexOptCountClusters opts)
   let baseDir = latexOptOutDir opts
-  let outPath = baseDir </> (latexOutRelativeFilePath $ toTopLevelModuleName $ iModuleName i)
+  let outPath = baseDir </>
+                latexOutRelativeFilePath (iTopLevelModuleName i)
   latex <- E.encodeUtf8 <$> toLaTeX
               (emptyEnv textWidthEstimator)
               (latexOptSourceFileName opts)

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -25,6 +25,7 @@ import Data.Foldable (toList)
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup (Semigroup(..))
 #endif
+import qualified Data.Text as T
 
 import Control.Exception.Base (IOException, try)
 import Control.Monad (forM_, mapM_, unless, when)
@@ -768,7 +769,10 @@ generateLaTeXIO opts i = do
     BS.writeFile outPath latex
 
 latexOutRelativeFilePath :: TopLevelModuleName -> FilePath
-latexOutRelativeFilePath m = List.intercalate [pathSeparator] (List1.toList $ moduleNameParts m) <.> "tex"
+latexOutRelativeFilePath m =
+  List.intercalate [pathSeparator]
+    (map T.unpack $ List1.toList $ moduleNameParts m) <.>
+  "tex"
 
 groupByFst :: forall a b. Eq a => [(a,b)] -> [(a,[b])]
 groupByFst =

--- a/src/full/Agda/Interaction/Highlighting/Precise.hs
+++ b/src/full/Agda/Interaction/Highlighting/Precise.hs
@@ -51,7 +51,7 @@ import GHC.Generics (Generic)
 
 import qualified Agda.Syntax.Position as P
 import qualified Agda.Syntax.Common   as Common
-import qualified Agda.Syntax.Concrete as C
+import Agda.Syntax.TopLevelModuleName
 import Agda.Syntax.Scope.Base                   ( KindOfName(..) )
 
 import Agda.Interaction.Highlighting.Range
@@ -162,7 +162,7 @@ data Aspects = Aspects
   deriving (Show, Generic)
 
 data DefinitionSite = DefinitionSite
-  { defSiteModule :: C.TopLevelModuleName
+  { defSiteModule :: TopLevelModuleName
       -- ^ The defining module.
   , defSitePos    :: Int
       -- ^ The file position in that module. File positions are

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -1227,6 +1227,7 @@ buildInterface src topLevel = do
           , iFileType        = fileType
           , iImportedModules = mhs
           , iModuleName      = mname
+          , iTopLevelModuleName = srcModuleName src
           , iScope           = empty -- publicModules scope
           , iInsideScope     = topLevelScope topLevel
           , iSignature       = sig

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -427,7 +427,7 @@ typeCheckMain mode src = do
 
   mi <- getInterface (srcModuleName src) (MainInterface mode) (Just src)
 
-  stCurrentModule `setTCLens` Just (iModuleName (miInterface mi))
+  stCurrentModule `setTCLens'` Just (iModuleName (miInterface mi))
 
   return $ CheckResult' mi src
   where

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -42,6 +42,7 @@ import Data.Maybe
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.HashMap.Strict as HMap
+import qualified Data.HashSet as HSet
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -59,7 +60,8 @@ import Agda.Syntax.Common
 import Agda.Syntax.Parser
 import Agda.Syntax.Position
 import Agda.Syntax.Scope.Base
-import Agda.Syntax.Translation.ConcreteToAbstract
+import Agda.Syntax.TopLevelModuleName
+import Agda.Syntax.Translation.ConcreteToAbstract as CToA
 
 import Agda.TypeChecking.Errors
 import Agda.TypeChecking.Warnings hiding (warnings)
@@ -119,7 +121,7 @@ data Source = Source
   , srcFileType    :: FileType              -- ^ Source file type
   , srcOrigin      :: SourceFile            -- ^ Source location at the time of its parsing
   , srcModule      :: C.Module              -- ^ The parsed module.
-  , srcModuleName  :: C.TopLevelModuleName  -- ^ The top-level module name.
+  , srcModuleName  :: TopLevelModuleName    -- ^ The top-level module name.
   , srcProjectLibs :: [AgdaLibFile]         -- ^ The .agda-lib file(s) of the project this file belongs to.
   }
 
@@ -262,16 +264,18 @@ addImportedThings isig metas ibuiltin patsyns display userwarn
 -- | Scope checks the given module. A proper version of the module
 -- name (with correct definition sites) is returned.
 
-scopeCheckImport :: ModuleName -> TCM (ModuleName, Map ModuleName Scope)
-scopeCheckImport x = do
+scopeCheckImport ::
+  TopLevelModuleName -> ModuleName ->
+  TCM (ModuleName, Map ModuleName Scope)
+scopeCheckImport top x = do
     reportSLn "import.scope" 5 $ "Scope checking " ++ prettyShow x
     verboseS "import.scope" 10 $ do
       visited <- prettyShow <$> getPrettyVisitedModules
       reportSLn "import.scope" 10 $ "  visited: " ++ visited
     -- Since scopeCheckImport is called from the scope checker,
     -- we need to reimburse her account.
-    i <- Bench.billTo [] $ getNonMainInterface (toTopLevelModuleName x) Nothing
-    addImport x
+    i <- Bench.billTo [] $ getNonMainInterface top Nothing
+    addImport top
 
     -- If that interface was supposed to raise a warning on import, do so.
     whenJust (iImportWarning i) $ warning . UserWarning
@@ -285,7 +289,7 @@ scopeCheckImport x = do
 -- used to find the interface and the computed interface is stored for
 -- potential later use.
 
-alreadyVisited :: C.TopLevelModuleName ->
+alreadyVisited :: TopLevelModuleName ->
                   MainInterface ->
                   PragmaOptions ->
                   TCM ModuleInfo ->
@@ -343,7 +347,7 @@ alreadyVisited x isMain currentOptions getModule =
       _                             -> storeDecodedModule mi
 
     reportS "warning.import" 10
-      [ "module: " ++ show (C.moduleNameParts x)
+      [ "module: " ++ show (moduleNameParts x)
       , "WarningOnImport: " ++ show (iImportWarning (miInterface mi))
       ]
 
@@ -427,7 +431,10 @@ typeCheckMain mode src = do
 
   mi <- getInterface (srcModuleName src) (MainInterface mode) (Just src)
 
-  stCurrentModule `setTCLens'` Just (iModuleName (miInterface mi))
+  stCurrentModule `setTCLens'`
+    Just ( iModuleName (miInterface mi)
+         , iTopLevelModuleName (miInterface mi)
+         )
 
   return $ CheckResult' mi src
   where
@@ -446,7 +453,7 @@ typeCheckMain mode src = do
 --   Do not use this for the main file, use 'typeCheckMain' instead.
 
 getNonMainInterface
-  :: C.TopLevelModuleName
+  :: TopLevelModuleName
   -> Maybe Source
      -- ^ Optional: the source code and some information about the source code.
   -> TCM Interface
@@ -463,7 +470,7 @@ getNonMainInterface x msrc = do
 -- errors.
 
 getInterface
-  :: C.TopLevelModuleName
+  :: TopLevelModuleName
   -> MainInterface
   -> Maybe Source
      -- ^ Optional: the source code and some information about the source code.
@@ -557,7 +564,7 @@ getOptionsCompatibilityWarnings isMain isPrim currentOptions i = runMaybeT $ exc
 -- | Try to get the interface from interface file or cache.
 
 getStoredInterface
-  :: C.TopLevelModuleName
+  :: TopLevelModuleName
      -- ^ Module name of file we process.
   -> SourceFile
      -- ^ File we process.
@@ -652,7 +659,7 @@ getStoredInterface x file msrc = do
           readInterface ifile
 
         -- Ensure that the given module name matches the one in the file.
-        let topLevelName = toTopLevelModuleName $ iModuleName i
+        let topLevelName = iTopLevelModuleName i
         unless (topLevelName == x) $
           -- Andreas, 2014-03-27 This check is now done in the scope checker.
           -- checkModuleName topLevelName file
@@ -693,7 +700,7 @@ loadDecodedModule file mi = do
   -- (see #5250)
   libOptions <- lift $ getLibraryOptions
     (srcFilePath file)
-    (toTopLevelModuleName $ iModuleName i)
+    (iTopLevelModuleName i)
   lift $ mapM_ setOptionsFromPragma (libOptions ++ iFilePragmaOptions i)
 
   -- Check that options that matter haven't changed compared to
@@ -741,7 +748,7 @@ loadDecodedModule file mi = do
 --   in order to forget some state changes after successful type checking.
 
 createInterfaceIsolated
-  :: C.TopLevelModuleName
+  :: TopLevelModuleName
      -- ^ Module name of file we process.
   -> SourceFile
      -- ^ File we process.
@@ -822,7 +829,7 @@ createInterfaceIsolated x file msrc = do
 
 chaseMsg
   :: String               -- ^ The prefix, like @Checking@, @Finished@, @Loading @.
-  -> C.TopLevelModuleName -- ^ The module name.
+  -> TopLevelModuleName   -- ^ The module name.
   -> Maybe String         -- ^ Optionally: the file name.
   -> TCM ()
 chaseMsg kind x file = do
@@ -919,7 +926,7 @@ writeInterface file i = let fp = filePath file in do
 -- information.
 
 createInterface
-  :: C.TopLevelModuleName  -- ^ The expected module name.
+  :: TopLevelModuleName    -- ^ The expected module name.
   -> SourceFile            -- ^ The file to type check.
   -> MainInterface         -- ^ Are we dealing with the main module?
   -> Maybe Source      -- ^ Optional information about the source code.
@@ -1182,7 +1189,7 @@ buildInterface
   -> TCM Interface
 buildInterface src topLevel = do
     reportSLn "import.iface" 5 "Building interface..."
-    let mname = topLevelModuleName topLevel
+    let mname = CToA.topLevelModuleName topLevel
         source   = srcText src
         fileType = srcFileType src
         defPragmas = srcDefaultPragmas src
@@ -1198,8 +1205,9 @@ buildInterface src topLevel = do
     -- faster and interface file sizes a bit smaller, at least for the
     -- standard library).
     builtin     <- useTC stLocalBuiltins
-    ms          <- getImports
-    mhs         <- mapM (\ m -> (m,) <$> moduleHash m) $ Set.toList ms
+    mhs         <- mapM (\top -> (top,) <$> moduleHash top) .
+                   HSet.toList =<<
+                   useR stImportedModules
     foreignCode <- useTC stForeignCode
     -- Ulf, 2016-04-12:
     -- Non-closed display forms are not applicable outside the module anyway,
@@ -1268,5 +1276,5 @@ getInterfaceFileHashes fp = do
   maybe 0 (uncurry (+)) hs `seq` close
   return hs
 
-moduleHash :: ModuleName -> TCM Hash
-moduleHash m = iFullHash <$> getNonMainInterface (toTopLevelModuleName m) Nothing
+moduleHash :: TopLevelModuleName -> TCM Hash
+moduleHash m = iFullHash <$> getNonMainInterface m Nothing

--- a/src/full/Agda/Interaction/Imports.hs-boot
+++ b/src/full/Agda/Interaction/Imports.hs-boot
@@ -5,6 +5,9 @@ import Data.Map                     ( Map )
 
 import Agda.Syntax.Abstract.Name    ( ModuleName )
 import Agda.Syntax.Scope.Base       ( Scope )
+import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
 import Agda.TypeChecking.Monad.Base ( TCM )
 
-scopeCheckImport :: ModuleName -> TCM (ModuleName, Map ModuleName Scope)
+scopeCheckImport ::
+  TopLevelModuleName -> ModuleName ->
+  TCM (ModuleName, Map ModuleName Scope)

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -53,6 +53,7 @@ import Agda.Syntax.Info (mkDefInfo)
 import Agda.Syntax.Translation.ConcreteToAbstract
 import Agda.Syntax.Translation.AbstractToConcrete hiding (withScope)
 import Agda.Syntax.Scope.Base
+import Agda.Syntax.TopLevelModuleName
 
 import Agda.Interaction.Base
 import Agda.Interaction.ExitCode

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -89,7 +89,7 @@ instance ToJSON CommandState where
 
 instance EncodeTCM CurrentFile where
 instance ToJSON CurrentFile where
-  toJSON (CurrentFile path _ time) = toJSON (path, time)  -- backwards compat.
+  toJSON (CurrentFile path _ _ time) = toJSON (path, time)  -- backwards compat.
 
 instance EncodeTCM ResponseContextEntry where
   encodeTCM entry = obj

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -223,16 +223,6 @@ mnameToConcrete (MName (x:xs)) = foldr C.Qual (C.QName $ List1.last cs) $ List1.
   where
     cs = fmap nameConcrete (x :| xs)
 
--- | Computes the 'TopLevelModuleName' corresponding to the given
--- module name, which is assumed to represent a top-level module name.
---
--- Precondition: The module name must be well-formed.
-
-toTopLevelModuleName :: ModuleName -> C.TopLevelModuleName
-toTopLevelModuleName (MName []) = __IMPOSSIBLE__
-toTopLevelModuleName (MName ms) = List1.ifNull ms __IMPOSSIBLE__ {-else-} $ \ ms1 ->
-  C.TopLevelModuleName (getRange ms1) $ fmap (C.nameToRawName . nameConcrete) ms1
-
 qualifyM :: ModuleName -> ModuleName -> ModuleName
 qualifyM m1 m2 = mnameFromList $ mnameToList m1 ++ mnameToList m2
 

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -28,6 +28,7 @@ import GHC.Generics (Generic)
 
 import Agda.Syntax.Position
 
+import Agda.Utils.BiMap (HasTag(..))
 import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List1  ( List1, pattern (:|), (<|) )
@@ -2323,6 +2324,10 @@ instance NFData IsMacro
 
 newtype ModuleNameHash = ModuleNameHash { moduleNameHash :: Word64 }
   deriving (Eq, Ord, Hashable)
+
+instance HasTag ModuleNameHash where
+  type Tag ModuleNameHash = ModuleNameHash
+  tag = Just . id
 
 noModuleNameHash :: ModuleNameHash
 noModuleNameHash = ModuleNameHash 0

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -61,7 +61,6 @@ module Agda.Syntax.Concrete
   , Module(..)
   , ThingWithFixity(..)
   , HoleContent, HoleContent'(..)
-  , topLevelModuleName
   , spanAllowedBeforeModule
   )
   where
@@ -553,19 +552,6 @@ data Module = Mod
   { modPragmas :: [Pragma]
   , modDecls   :: [Declaration]
   }
-
--- | Computes the top-level module name.
---
--- Precondition: The 'Module' has to be well-formed.
--- This means that there are only allowed declarations before the
--- first module declaration, typically import declarations.
--- See 'spanAllowedBeforeModule'.
-
-topLevelModuleName :: Module -> TopLevelModuleName
-topLevelModuleName (Mod _ []) = __IMPOSSIBLE__
-topLevelModuleName (Mod _ ds) = case spanAllowedBeforeModule ds of
-  (_, Module _ n _ _ : _) -> toTopLevelModuleName n
-  _ -> __IMPOSSIBLE__
 
 -- | Splits off allowed (= import) declarations before the first
 --   non-allowed declaration.

--- a/src/full/Agda/Syntax/Literal.hs
+++ b/src/full/Agda/Syntax/Literal.hs
@@ -11,6 +11,8 @@ import qualified Data.Text as T
 import Agda.Syntax.Position
 import Agda.Syntax.Common
 import Agda.Syntax.Abstract.Name
+import {-# SOURCE #-} Agda.Syntax.TopLevelModuleName
+  (TopLevelModuleName)
 import Agda.Utils.FileName
 import Agda.Utils.Float ( doubleDenotEq, doubleDenotOrd )
 import Agda.Utils.Pretty
@@ -23,7 +25,7 @@ data Literal
   | LitString !Text
   | LitChar   !Char
   | LitQName  !QName
-  | LitMeta   AbsolutePath MetaId
+  | LitMeta   !TopLevelModuleName !MetaId
   deriving Show
 
 instance Pretty Literal where
@@ -91,7 +93,7 @@ instance KillRange Literal where
   killRange (LitString x) = LitString x
   killRange (LitChar   x) = LitChar   x
   killRange (LitQName  x) = killRange1 LitQName x
-  killRange (LitMeta f x) = LitMeta f x
+  killRange (LitMeta m x) = LitMeta (killRange m) x
 
 -- | Ranges are not forced.
 
@@ -102,4 +104,4 @@ instance NFData Literal where
   rnf (LitString _  ) = ()
   rnf (LitChar _    ) = ()
   rnf (LitQName a   ) = rnf a
-  rnf (LitMeta _ x  ) = rnf x
+  rnf (LitMeta m _  ) = rnf m

--- a/src/full/Agda/Syntax/Parser/Monad.hs
+++ b/src/full/Agda/Syntax/Parser/Monad.hs
@@ -150,12 +150,12 @@ data ParseError
 
   -- | Parse errors that concern a whole file.
   | InvalidExtensionError
-    { errPath      :: !AbsolutePath
+    { errPath      :: !RangeFile
                       -- ^ The file which the error concerns.
     , errValidExts :: [String]
     }
   | ReadFileError
-    { errPath      :: !AbsolutePath
+    { errPath      :: !RangeFile
     , errIOError   :: IOError
     }
   deriving Show
@@ -299,8 +299,8 @@ initStatePos pos flags inp st =
 -- | Constructs the initial state of the parser. The string argument
 --   is the input string, the file path is only there because it's part
 --   of a position.
-initState :: Maybe AbsolutePath -> ParseFlags -> String -> [LexState]
-          -> ParseState
+initState ::
+  Maybe RangeFile -> ParseFlags -> String -> [LexState] -> ParseState
 initState file = initStatePos (startPos file)
 
 -- | The default flags.

--- a/src/full/Agda/Syntax/Position.hs-boot
+++ b/src/full/Agda/Syntax/Position.hs-boot
@@ -1,0 +1,3 @@
+module Agda.Syntax.Position where
+
+class KillRange a

--- a/src/full/Agda/Syntax/TopLevelModuleName.hs
+++ b/src/full/Agda/Syntax/TopLevelModuleName.hs
@@ -1,0 +1,230 @@
+------------------------------------------------------------------------
+-- Top-level module names
+------------------------------------------------------------------------
+
+module Agda.Syntax.TopLevelModuleName where
+
+import Control.DeepSeq
+
+import Data.Function
+import Data.Hashable
+import qualified Data.List as List
+
+import GHC.Generics (Generic)
+
+import System.FilePath
+
+import qualified Agda.Syntax.Abstract.Name as A
+import Agda.Syntax.Common
+import qualified Agda.Syntax.Concrete as C
+import Agda.Syntax.Position
+
+import Agda.Utils.BiMap (HasTag(..))
+import Agda.Utils.FileName
+import Agda.Utils.Hash
+import Agda.Utils.Impossible
+import Agda.Utils.Lens
+import Agda.Utils.List1 (List1)
+import qualified Agda.Utils.List1 as List1
+import Agda.Utils.Pretty
+import Agda.Utils.Singleton
+import Agda.Utils.Size
+
+------------------------------------------------------------------------
+-- Raw top-level module names
+
+-- | A top-level module name has one or more name parts.
+
+type TopLevelModuleNameParts = List1 String
+
+-- | Raw top-level module names (with linear-time comparisons).
+
+data RawTopLevelModuleName = RawTopLevelModuleName
+  { rawModuleNameRange :: Range
+  , rawModuleNameParts :: TopLevelModuleNameParts
+  }
+  deriving (Show, Generic)
+
+instance Eq RawTopLevelModuleName where
+  (==) = (==) `on` rawModuleNameParts
+
+instance Ord RawTopLevelModuleName where
+  compare = compare `on` rawModuleNameParts
+
+instance Sized RawTopLevelModuleName where
+  size = size . rawModuleNameParts
+
+instance Pretty RawTopLevelModuleName where
+  pretty = text . rawTopLevelModuleNameToString
+
+instance HasRange RawTopLevelModuleName where
+  getRange = rawModuleNameRange
+
+instance SetRange RawTopLevelModuleName where
+  setRange r (RawTopLevelModuleName _ x) = RawTopLevelModuleName r x
+
+instance KillRange RawTopLevelModuleName where
+  killRange (RawTopLevelModuleName _ x) =
+    RawTopLevelModuleName noRange x
+
+instance C.IsNoName RawTopLevelModuleName where
+  isNoName m = rawModuleNameParts m == singleton "_"
+
+-- | The 'Range' is not forced.
+
+instance NFData RawTopLevelModuleName where
+  rnf (RawTopLevelModuleName _ x) = rnf x
+
+-- | Turns a raw top-level module name into a string.
+
+rawTopLevelModuleNameToString :: RawTopLevelModuleName -> String
+rawTopLevelModuleNameToString =
+  List.intercalate "." . List1.toList . rawModuleNameParts
+
+-- | Hashes a raw top-level module name.
+
+hashRawTopLevelModuleName :: RawTopLevelModuleName -> ModuleNameHash
+hashRawTopLevelModuleName =
+  ModuleNameHash . hashString . rawTopLevelModuleNameToString
+
+-- | Turns a qualified name into a 'RawTopLevelModuleName'. The
+-- qualified name is assumed to represent a top-level module name.
+
+rawTopLevelModuleNameForQName :: C.QName -> RawTopLevelModuleName
+rawTopLevelModuleNameForQName q = RawTopLevelModuleName
+  { rawModuleNameRange = getRange q
+  , rawModuleNameParts = fmap C.nameToRawName $ C.qnameParts q
+  }
+
+-- | Computes the 'RawTopLevelModuleName' corresponding to the given
+-- module name, which is assumed to represent a top-level module name.
+--
+-- Precondition: The module name must be well-formed.
+
+rawTopLevelModuleNameForModuleName ::
+  A.ModuleName -> RawTopLevelModuleName
+rawTopLevelModuleNameForModuleName (A.MName []) = __IMPOSSIBLE__
+rawTopLevelModuleNameForModuleName (A.MName ms) =
+  List1.ifNull ms __IMPOSSIBLE__ $ \ms ->
+  RawTopLevelModuleName
+    { rawModuleNameRange = getRange ms
+    , rawModuleNameParts = fmap (C.nameToRawName . A.nameConcrete) ms
+    }
+
+-- | Computes the top-level module name.
+--
+-- Precondition: The 'C.Module' has to be well-formed.
+-- This means that there are only allowed declarations before the
+-- first module declaration, typically import declarations.
+-- See 'spanAllowedBeforeModule'.
+
+rawTopLevelModuleNameForModule :: C.Module -> RawTopLevelModuleName
+rawTopLevelModuleNameForModule (C.Mod _ []) = __IMPOSSIBLE__
+rawTopLevelModuleNameForModule (C.Mod _ ds) =
+  case C.spanAllowedBeforeModule ds of
+    (_, C.Module _ n _ _ : _) -> rawTopLevelModuleNameForQName n
+    _                         -> __IMPOSSIBLE__
+
+------------------------------------------------------------------------
+-- Top-level module names
+
+-- | Top-level module names (with constant-time comparisons).
+
+data TopLevelModuleName = TopLevelModuleName
+  { moduleNameRange :: Range
+  , moduleNameId    :: {-# UNPACK #-} !ModuleNameHash
+  , moduleNameParts :: TopLevelModuleNameParts
+  }
+  deriving (Show, Generic)
+
+instance HasTag TopLevelModuleName where
+  type Tag TopLevelModuleName = ModuleNameHash
+  tag = Just . moduleNameId
+
+instance Eq TopLevelModuleName where
+  (==) = (==) `on` moduleNameId
+
+instance Ord TopLevelModuleName where
+  compare = compare `on` moduleNameId
+
+instance Hashable TopLevelModuleName where
+  hashWithSalt salt = hashWithSalt salt . moduleNameId
+
+instance Sized TopLevelModuleName where
+  size = size . rawTopLevelModuleName
+
+instance Pretty TopLevelModuleName where
+  pretty = pretty . rawTopLevelModuleName
+
+instance HasRange TopLevelModuleName where
+  getRange = moduleNameRange
+
+instance SetRange TopLevelModuleName where
+  setRange r (TopLevelModuleName _ h x) = TopLevelModuleName r h x
+
+instance KillRange TopLevelModuleName where
+  killRange (TopLevelModuleName _ h x) = TopLevelModuleName noRange h x
+
+-- | The 'Range' is not forced.
+
+instance NFData TopLevelModuleName where
+  rnf (TopLevelModuleName _ x y) = rnf (x, y)
+
+-- | A lens focusing on the 'moduleNameParts'.
+
+lensTopLevelModuleNameParts ::
+  Lens' TopLevelModuleNameParts TopLevelModuleName
+lensTopLevelModuleNameParts f m =
+  f (moduleNameParts m) <&> \ xs -> m{ moduleNameParts = xs }
+
+-- | Converts a top-level module name to a raw top-level module name.
+
+rawTopLevelModuleName :: TopLevelModuleName -> RawTopLevelModuleName
+rawTopLevelModuleName m = RawTopLevelModuleName
+  { rawModuleNameRange = moduleNameRange m
+  , rawModuleNameParts = moduleNameParts m
+  }
+
+-- | Converts a raw top-level module name and a hash to a top-level
+-- module name.
+--
+-- This function does not ensure that there are no hash collisions,
+-- that is taken care of by
+-- 'Agda.TypeChecking.Monad.State.topLevelModuleName'.
+
+unsafeTopLevelModuleName ::
+  RawTopLevelModuleName -> ModuleNameHash -> TopLevelModuleName
+unsafeTopLevelModuleName m h = TopLevelModuleName
+  { moduleNameRange = rawModuleNameRange m
+  , moduleNameParts = rawModuleNameParts m
+  , moduleNameId    = h
+  }
+
+-- | A corresponding 'C.QName'. The range of each 'Name' part is the
+-- whole range of the 'TopLevelModuleName'.
+
+topLevelModuleNameToQName :: TopLevelModuleName -> C.QName
+topLevelModuleNameToQName m =
+  List1.foldr C.Qual C.QName $
+  fmap (C.Name (getRange m) C.NotInScope . C.stringNameParts) $
+  moduleNameParts m
+
+-- | Turns a top-level module name into a file name with the given
+-- suffix.
+
+moduleNameToFileName :: TopLevelModuleName -> String -> FilePath
+moduleNameToFileName TopLevelModuleName{ moduleNameParts = ms } ext =
+  joinPath (List1.init ms) </> List1.last ms <.> ext
+
+-- | Finds the current project's \"root\" directory, given a project
+-- file and the corresponding top-level module name.
+--
+-- Example: If the module \"A.B.C\" is located in the file
+-- \"/foo/A/B/C.agda\", then the root is \"/foo/\".
+--
+-- Precondition: The module name must be well-formed.
+
+projectRoot :: AbsolutePath -> TopLevelModuleName -> AbsolutePath
+projectRoot file TopLevelModuleName{ moduleNameParts = m } =
+  mkAbsolute $
+    iterate takeDirectory (filePath file) !! length m

--- a/src/full/Agda/Syntax/TopLevelModuleName.hs-boot
+++ b/src/full/Agda/Syntax/TopLevelModuleName.hs-boot
@@ -1,0 +1,13 @@
+module Agda.Syntax.TopLevelModuleName where
+
+import Control.DeepSeq
+
+import Agda.Syntax.Position
+
+data TopLevelModuleName
+
+instance Eq        TopLevelModuleName
+instance Ord       TopLevelModuleName
+instance Show      TopLevelModuleName
+instance NFData    TopLevelModuleName
+instance KillRange TopLevelModuleName

--- a/src/full/Agda/Syntax/TopLevelModuleName.hs-boot
+++ b/src/full/Agda/Syntax/TopLevelModuleName.hs-boot
@@ -2,7 +2,7 @@ module Agda.Syntax.TopLevelModuleName where
 
 import Control.DeepSeq
 
-import Agda.Syntax.Position
+import {-# SOURCE #-} Agda.Syntax.Position (KillRange)
 
 data TopLevelModuleName
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -883,25 +883,6 @@ instance FreshName () where
 
 type ModuleToSource = Map TopLevelModuleName AbsolutePath
 
--- | Maps source file names to the corresponding top-level module
--- names.
-
-type SourceToModule = Map AbsolutePath TopLevelModuleName
-
--- | Creates a 'SourceToModule' map based on 'stModuleToSource'.
---
---   O(n log n).
---
---   For a single reverse lookup in 'stModuleToSource',
---   rather use 'lookupModuleFromSourse'.
-
-sourceToModule :: TCM SourceToModule
-sourceToModule =
-  Map.fromListWith __IMPOSSIBLE__
-     .  List.map (\(m, f) -> (f, m))
-     .  Map.toList
-    <$> useTC stModuleToSource
-
 ---------------------------------------------------------------------------
 -- ** Associating concrete names to an abstract name
 ---------------------------------------------------------------------------

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -978,6 +978,8 @@ data Interface = Interface
     -- ^ Imported modules and their hashes.
   , iModuleName      :: ModuleName
     -- ^ Module name of this interface.
+  , iTopLevelModuleName :: C.TopLevelModuleName
+    -- ^ The module's top-level module name.
   , iScope           :: Map ModuleName Scope
     -- ^ Scope defined by this module.
     --
@@ -1016,10 +1018,10 @@ data Interface = Interface
 
 instance Pretty Interface where
   pretty (Interface
-            sourceH source fileT importedM moduleN scope insideS signature
-            metas display userwarn importwarn builtin foreignCode
-            highlighting libPragmaO filePragmaO oUsed patternS warnings
-            partialdefs) =
+            sourceH source fileT importedM moduleN topModN scope insideS
+            signature metas display userwarn importwarn builtin
+            foreignCode highlighting libPragmaO filePragmaO oUsed
+            patternS warnings partialdefs) =
 
     hang "Interface" 2 $ vcat
       [ "source hash:"         <+> (pretty . show) sourceH
@@ -1027,6 +1029,7 @@ instance Pretty Interface where
       , "file type:"           <+> (pretty . show) fileT
       , "imported modules:"    <+> (pretty . show) importedM
       , "module name:"         <+> pretty moduleN
+      , "top-level module name:" <+> pretty topModN
       , "scope:"               <+> (pretty . show) scope
       , "inside scope:"        <+> (pretty . show) insideS
       , "signature:"           <+> (pretty . show) signature

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -900,15 +900,6 @@ sourceToModule =
      .  Map.toList
     <$> useTC stModuleToSource
 
--- | Lookup an 'AbsolutePath' in 'sourceToModule'.
---
---   O(n).
-
-lookupModuleFromSource :: ReadTCState m => AbsolutePath -> m (Maybe TopLevelModuleName)
-lookupModuleFromSource f =
-  fmap fst . List.find ((f ==) . snd) . Map.toList <$> useR stModuleToSource
-
-
 ---------------------------------------------------------------------------
 -- ** Associating concrete names to an abstract name
 ---------------------------------------------------------------------------

--- a/src/full/Agda/TypeChecking/Monad/Base.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs-boot
@@ -7,7 +7,7 @@ import Data.IORef (IORef)
 import Data.Map (Map)
 
 import Agda.Syntax.Common (Nat)
-import Agda.Syntax.Concrete.Name (TopLevelModuleName)
+import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
 import Agda.Utils.FileName (AbsolutePath)
 
 data Warning

--- a/src/full/Agda/TypeChecking/Monad/Env.hs
+++ b/src/full/Agda/TypeChecking/Monad/Env.hs
@@ -8,6 +8,7 @@ import Data.Maybe (fromMaybe)
 
 import Agda.Syntax.Common
 import Agda.Syntax.Abstract.Name
+import Agda.Syntax.TopLevelModuleName
 
 import Agda.TypeChecking.Monad.Base
 

--- a/src/full/Agda/TypeChecking/Monad/Imports.hs
+++ b/src/full/Agda/TypeChecking/Monad/Imports.hs
@@ -11,7 +11,6 @@ module Agda.TypeChecking.Monad.Imports
   , getPrettyVisitedModules
   , getVisitedModule
   , getVisitedModules
-  , isImported
   , setDecodedModules
   , setVisitedModules
   , storeDecodedModule
@@ -45,9 +44,6 @@ addImportCycleCheck m =
 
 getImports :: TCM (Set ModuleName)
 getImports = useTC stImportedModules
-
-isImported :: ModuleName -> TCM Bool
-isImported m = Set.member m <$> getImports
 
 getImportPath :: TCM [C.TopLevelModuleName]
 getImportPath = asksTC envImportPath

--- a/src/full/Agda/TypeChecking/Monad/Imports.hs
+++ b/src/full/Agda/TypeChecking/Monad/Imports.hs
@@ -51,7 +51,7 @@ getImportPath = asksTC envImportPath
 visitModule :: ModuleInfo -> TCM ()
 visitModule mi =
   modifyTCLens stVisitedModules $
-    Map.insert (toTopLevelModuleName $ iModuleName $ miInterface mi) mi
+    Map.insert (iTopLevelModuleName $ miInterface mi) mi
 
 setVisitedModules :: VisitedModules -> TCM ()
 setVisitedModules ms = setTCLens stVisitedModules ms
@@ -88,7 +88,7 @@ storeDecodedModule :: ModuleInfo -> TCM ()
 storeDecodedModule mi = modifyTC $ \s ->
   s { stPersistentState =
         (stPersistentState s) { stDecodedModules =
-          Map.insert (toTopLevelModuleName $ iModuleName $ miInterface mi) mi $
+          Map.insert (iTopLevelModuleName $ miInterface mi) mi $
             stDecodedModules (stPersistentState s)
         }
   }

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -19,9 +19,9 @@ import System.Directory
 import System.FilePath
 
 import Agda.Syntax.Common
-import Agda.Syntax.Concrete (TopLevelModuleName)
 import qualified Agda.Syntax.Concrete as C
 import qualified Agda.Syntax.Abstract as A
+import Agda.Syntax.TopLevelModuleName
 import Agda.TypeChecking.Monad.Debug (reportSDoc)
 import Agda.TypeChecking.Warnings
 import Agda.TypeChecking.Monad.Base
@@ -119,7 +119,7 @@ getAgdaLibFiles f m = do
   if | useLibs   -> libToTCM $ mkLibM [] $ getAgdaLibFiles' root
      | otherwise -> return []
   where
-  root = filePath (C.projectRoot f m)
+  root = filePath (projectRoot f m)
 
 -- | Returns the library options for a given file.
 
@@ -290,16 +290,16 @@ setIncludeDirs incs root = do
     -- A graph with one node per module in old, and an edge from m to
     -- n if the module corresponding to m imports the module
     -- corresponding to n.
-    dependencyGraph :: G.Graph A.ModuleName ()
+    dependencyGraph :: G.Graph TopLevelModuleName ()
     dependencyGraph =
       G.fromNodes
-        [ iModuleName $ miInterface m
+        [ iTopLevelModuleName $ miInterface m
         | m <- Map.elems old
         ]
         `G.union`
       G.fromEdges
         [ G.Edge
-            { source = iModuleName $ miInterface m
+            { source = iTopLevelModuleName $ miInterface m
             , target = d
             , label = ()
             }
@@ -316,17 +316,16 @@ setIncludeDirs incs root = do
                 -- Agda does not allow cycles in the dependency graph.
                 __IMPOSSIBLE__
               Graph.AcyclicSCC m ->
-                case Map.lookup (A.toTopLevelModuleName m) old of
+                case Map.lookup m old of
                   Just m  -> m
                   Nothing -> __IMPOSSIBLE__) $
       G.sccs' dependencyGraph
 
     process ::
-      Map A.ModuleName ModuleInfo -> ModuleToSource -> [ModuleInfo] ->
-      TCM (DecodedModules, ModuleToSource)
+      Map TopLevelModuleName ModuleInfo -> ModuleToSource ->
+      [ModuleInfo] -> TCM (DecodedModules, ModuleToSource)
     process !keep !modFile [] = return
       ( Map.fromList $
-        map (mapFst A.toTopLevelModuleName) $
         Map.toList keep
       , modFile
       )
@@ -335,13 +334,12 @@ setIncludeDirs incs root = do
           depsKept = all (`Map.member` keep) deps
       (keep, modFile) <-
         if not depsKept then return (keep, modFile) else do
-        let n = iModuleName $ miInterface m
-            t = A.toTopLevelModuleName n
+        let t = iTopLevelModuleName $ miInterface m
         oldF            <- findFile' t
         (newF, modFile) <- liftIO $ findFile'' incs t modFile
         return $ case (oldF, newF) of
           (Right f1, Right f2) | f1 == f2 ->
-            (Map.insert n m keep, modFile)
+            (Map.insert t m keep, modFile)
           _ -> (keep, modFile)
       process keep modFile ms
 

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -62,8 +62,7 @@ setPragmaOptions opts = do
 --
 -- Relative include directories are made absolute with respect to the
 -- current working directory. If the include directories have changed
--- (thus, they are 'Left' now, and were previously @'Right' something@),
--- then the state is reset (completely, see setIncludeDirs) .
+-- then the state is reset (partly, see 'setIncludeDirs').
 --
 -- An empty list of relative include directories (@'Left' []@) is
 -- interpreted as @["."]@.

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -366,6 +366,23 @@ setTopLevelModule top = do
            , metaModule = hash
            }
 
+-- | The name of the current top-level module, if any.
+{-# SPECIALIZE
+    currentTopLevelModule :: TCM (Maybe TopLevelModuleName) #-}
+{-# SPECIALIZE
+    currentTopLevelModule :: ReduceM (Maybe TopLevelModuleName) #-}
+currentTopLevelModule ::
+  (MonadTCEnv m, ReadTCState m) => m (Maybe TopLevelModuleName)
+currentTopLevelModule = do
+  m <- useR stCurrentModule
+  case m of
+    Just (_, top) -> return (Just top)
+    Nothing       -> do
+      p <- asksTC envImportPath
+      return $ case p of
+        top : _ -> Just top
+        []      -> Nothing
+
 -- | Use a different top-level module for a computation. Used when generating
 --   names for imported modules.
 withTopLevelModule :: TopLevelModuleName -> TCM a -> TCM a

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -5,7 +5,7 @@ module Agda.TypeChecking.Monad.State where
 
 import qualified Control.Exception as E
 
-import Control.Monad       (void)
+import Control.Monad       (void, when)
 import Control.Monad.Trans (MonadIO, liftIO)
 
 import Data.Maybe
@@ -28,6 +28,8 @@ import Agda.Syntax.Abstract (PatternSynDefn, PatternSynDefns)
 import Agda.Syntax.Abstract.PatternSynonyms
 import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Internal
+import Agda.Syntax.Position
+import Agda.Syntax.TopLevelModuleName
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Warnings
@@ -36,6 +38,7 @@ import Agda.TypeChecking.Monad.Debug (reportSDoc, reportSLn, verboseS)
 import Agda.TypeChecking.Positivity.Occurrence
 import Agda.TypeChecking.CompiledClause
 
+import qualified Agda.Utils.BiMap as BiMap
 import Agda.Utils.Hash
 import Agda.Utils.Lens
 import qualified Agda.Utils.List1 as List1
@@ -326,33 +329,46 @@ updateDefBlocked f def@Defn{ defBlocked = b } = def { defBlocked = f b }
 -- * Top level module
 ---------------------------------------------------------------------------
 
+-- | Tries to convert a raw top-level module name to a top-level
+-- module name.
+
+topLevelModuleName :: RawTopLevelModuleName -> TCM TopLevelModuleName
+topLevelModuleName raw = do
+  hash <- BiMap.lookup raw <$> useR stTopLevelModuleNames
+  case hash of
+    Just hash -> return (unsafeTopLevelModuleName raw hash)
+    Nothing   -> do
+      let hash = hashRawTopLevelModuleName raw
+      when (hash == noModuleNameHash) $ typeError $ GenericError $
+        "The module name " ++ prettyShow raw ++ " has a reserved " ++
+        "hash (you may want to consider renaming the module with " ++
+        "this name)"
+      raw' <- BiMap.invLookup hash <$> useR stTopLevelModuleNames
+      case raw' of
+        Just raw' -> typeError $ GenericError $
+          "Module name hash collision for " ++ prettyShow raw ++
+          " and " ++ prettyShow raw' ++ " (you may want to consider " ++
+          "renaming one of these modules)"
+        Nothing -> do
+          stTopLevelModuleNames `modifyTCLens'`
+            BiMap.insert (killRange raw) hash
+          return (unsafeTopLevelModuleName raw hash)
+
 -- | Set the top-level module. This affects the global module id of freshly
 --   generated names.
 
-setTopLevelModule :: C.QName -> TCM ()
-setTopLevelModule x = do
-  m <- Map.lookup hash <$> useR stModuleNameHashes
-  case m of
-    Nothing -> stModuleNameHashes `modifyTCLens` Map.insert hash x
-    Just m
-      | m == x    -> return ()
-      | otherwise ->
-        typeError $ GenericError $
-          "Module name hash collision for " ++ name ++ " and " ++
-          prettyShow m ++ " (you may want to consider renaming one " ++
-          "of these modules)"
+setTopLevelModule :: TopLevelModuleName -> TCM ()
+setTopLevelModule top = do
+  let hash = moduleNameId top
   stFreshNameId `setTCLens'` NameId 0 hash
   stFreshMetaId `setTCLens'`
     MetaId { metaId     = 0
            , metaModule = hash
            }
-  where
-  name = prettyShow x
-  hash = ModuleNameHash (hashString name)
 
 -- | Use a different top-level module for a computation. Used when generating
 --   names for imported modules.
-withTopLevelModule :: C.QName -> TCM a -> TCM a
+withTopLevelModule :: TopLevelModuleName -> TCM a -> TCM a
 withTopLevelModule x m = do
   nextN <- useTC stFreshNameId
   nextM <- useTC stFreshMetaId

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -341,8 +341,8 @@ setTopLevelModule x = do
           "Module name hash collision for " ++ name ++ " and " ++
           prettyShow m ++ " (you may want to consider renaming one " ++
           "of these modules)"
-  stFreshNameId `setTCLens` NameId 0 hash
-  stFreshMetaId `setTCLens`
+  stFreshNameId `setTCLens'` NameId 0 hash
+  stFreshMetaId `setTCLens'`
     MetaId { metaId     = 0
            , metaModule = hash
            }

--- a/src/full/Agda/TypeChecking/Monad/Statistics.hs
+++ b/src/full/Agda/TypeChecking/Monad/Statistics.hs
@@ -14,7 +14,7 @@ import Control.Monad.Trans.Maybe
 import qualified Data.Map as Map
 import qualified Text.PrettyPrint.Boxes as Boxes
 
-import Agda.Syntax.Concrete.Name as C
+import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Debug
@@ -79,7 +79,7 @@ tickMax s n = modifyCounter s (max n)
 -- | Print the given statistics.
 printStatistics
   :: (MonadDebug m, MonadTCEnv m, HasOptions m)
-  => Maybe C.TopLevelModuleName -> Statistics -> m ()
+  => Maybe TopLevelModuleName -> Statistics -> m ()
 printStatistics mmname stats = do
   unlessNull (Map.toList stats) $ \ stats -> do
     let -- First column (left aligned) is accounts.

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -135,7 +135,7 @@ instance MonadTrace TCM where
     verboseS "check.ranges" 90 $
       Strict.whenJust (rangeFile callRange) $ \f -> do
         currentFile <- asksTC envCurrentPath
-        when (currentFile /= Just f) $ do
+        when (currentFile /= Just (rangeFilePath f)) $ do
           reportSLn "check.ranges" 90 $
             prettyShow call ++
             " is setting the current range to " ++ show callRange ++

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -39,12 +39,14 @@ import qualified Agda.Syntax.Concrete.Pretty as CP
 import qualified Agda.Syntax.Info as A
 import Agda.Syntax.Scope.Base  (AbstractName(..))
 import Agda.Syntax.Scope.Monad (withContextPrecedence)
+import Agda.Syntax.TopLevelModuleName
 
 import Agda.TypeChecking.Coverage.SplitTree
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Positivity.Occurrence
 import Agda.TypeChecking.Substitute
 
+import qualified Agda.Utils.BiMap as BiMap
 import Agda.Utils.Graph.AdjacencyMap.Unidirectional (Graph)
 import qualified Agda.Utils.Graph.AdjacencyMap.Unidirectional as Graph
 import Agda.Utils.List1 ( List1, pattern (:|) )
@@ -163,7 +165,7 @@ instance {-# OVERLAPPING #-} PrettyTCM String where prettyTCM = text
 instance PrettyTCM Bool        where prettyTCM = pretty
 instance PrettyTCM C.Name      where prettyTCM = pretty
 instance PrettyTCM C.QName     where prettyTCM = pretty
-instance PrettyTCM C.TopLevelModuleName
+instance PrettyTCM TopLevelModuleName
                                where prettyTCM = pretty
 instance PrettyTCM Comparison  where prettyTCM = pretty
 instance PrettyTCM Literal     where prettyTCM = pretty
@@ -242,20 +244,20 @@ instance PrettyTCM MetaId where
 instance PrettyTCM NamedMeta where
   prettyTCM (NamedMeta s m) = do
     current <- currentModuleNameHash
-    modName <- Map.lookup (metaModule m) <$> useR stModuleNameHashes
-    case modName of
-      Nothing      -> __IMPOSSIBLE__
-      Just modName -> prefix <> inBetween <> text (show (metaId m))
-        where
-        prefix =
-          if metaModule m == current
-          then empty
-          else pretty modName <> text "."
-
-        inBetween = case s of
+    prefix  <-
+      if metaModule m == current
+      then return empty
+      else do
+        modName <- BiMap.invLookup (metaModule m) <$>
+                   useR stTopLevelModuleNames
+        return $ case modName of
+          Nothing      -> __IMPOSSIBLE__
+          Just modName -> pretty modName <> text "."
+    let inBetween = case s of
           ""  -> text "_"
           "_" -> text "_"
           s   -> text $ "_" ++ s ++ "_"
+    prefix <> inBetween <> text (show (metaId m))
 
 instance PrettyTCM a => PrettyTCM (Blocked a) where
   prettyTCM (Blocked x a) = ("[" <+> prettyTCM a <+> "]") <> text (P.prettyShow x)

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -169,8 +169,8 @@ instance ToTerm Text    where toTerm = return $ Lit . LitString
 instance ToTerm QName   where toTerm = return $ Lit . LitQName
 instance ToTerm MetaId  where
   toTerm = do
-    file <- getCurrentPath
-    return $ Lit . LitMeta file
+    top <- fromMaybe __IMPOSSIBLE__ <$> currentTopLevelModule
+    return $ Lit . LitMeta top
 
 instance ToTerm Integer where
   toTerm = do

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -13,6 +13,7 @@ import Agda.Syntax.Internal as I
 import Agda.Syntax.Internal.Pattern ( hasDefP, dbPatPerm )
 import Agda.Syntax.Literal
 import Agda.Syntax.Position
+import Agda.Syntax.TopLevelModuleName
 
 import Agda.TypeChecking.CompiledClause
 import Agda.TypeChecking.DropArgs
@@ -58,7 +59,7 @@ data QuotingKit = QuotingKit
 
 quotingKit :: TCM QuotingKit
 quotingKit = do
-  currentFile     <- fromMaybe __IMPOSSIBLE__ <$> asksTC envCurrentPath
+  currentModule   <- fromMaybe __IMPOSSIBLE__ <$> currentTopLevelModule
   hidden          <- primHidden
   instanceH       <- primInstance
   visible         <- primVisible
@@ -298,7 +299,8 @@ quotingKit = do
           Level l    -> quoteTerm (unlevelWithKit lkit l)
           Lit l      -> lit !@ quoteLit l
           Sort s     -> sort !@ quoteSort s
-          MetaV x es -> meta !@! quoteMeta currentFile x @@ quoteArgs vs
+          MetaV x es -> meta !@! quoteMeta currentModule x
+                              @@ quoteArgs vs
             where vs = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
           DontCare u -> quoteTerm u
           Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
@@ -357,8 +359,8 @@ quoteNat n
 quoteConName :: ConHead -> Term
 quoteConName = quoteName . conName
 
-quoteMeta :: AbsolutePath -> MetaId -> Term
-quoteMeta file = Lit . LitMeta file
+quoteMeta :: TopLevelModuleName -> MetaId -> Term
+quoteMeta m = Lit . LitMeta m
 
 quoteTerm :: Term -> TCM Term
 quoteTerm v = do

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1677,10 +1677,10 @@ instance InstantiateFull Interface where
 
 instantiateFullExceptForDefinitions' :: Interface -> ReduceM Interface
 instantiateFullExceptForDefinitions'
-  (Interface h s ft ms mod scope inside sig metas display userwarn
+  (Interface h s ft ms mod tlmod scope inside sig metas display userwarn
      importwarn b foreignCode highlighting libPragmas filePragmas
      usedOpts patsyns warnings partialdefs) =
-  Interface h s ft ms mod scope inside
+  Interface h s ft ms mod tlmod scope inside
     <$> ((\s r -> Sig { _sigSections     = s
                       , _sigDefinitions  = sig ^. sigDefinitions
                       , _sigRewriteRules = r

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20221011 * 10 + 1
+currentInterfaceVersion = 20221012 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -83,7 +83,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20221004 * 10 + 0
+currentInterfaceVersion = 20221010 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -83,7 +83,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20220930 * 10 + 0
+currentInterfaceVersion = 20221004 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -83,7 +83,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20221010 * 10 + 0
+currentInterfaceVersion = 20221011 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -109,7 +109,6 @@ data Dict = Dict
   , collectStats :: Bool
     -- ^ If @True@ collect in @stats@ the quantities of
     --   calls to @icode@ for each @Typeable a@.
-  , absPathD     :: !(HashTable AbsolutePath Int32) -- ^ Not written to interface file.
   }
 
 -- | Creates an empty dictionary.
@@ -138,7 +137,6 @@ emptyDict collectStats = Dict
   <*> newIORef farEmpty
   <*> H.empty
   <*> pure collectStats
-  <*> H.empty
 
 -- | Universal type, wraps everything.
 data U = forall a . Typeable a => U !a

--- a/src/full/Agda/TypeChecking/Serialise/Instances.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances.hs
@@ -21,12 +21,12 @@ toImportedModules :: RangedImportedModules -> [(ModuleName, Hash)]
 toImportedModules ms = [(setRange (underlyingRange r) x, hash) | (r, x, hash) <- ms]
 
 instance EmbPrj Interface where
-  icod_ (Interface a b c d e f g h i j k l m n o p q r s t u) =
-      icodeN' interface a b c (fromImportedModules d) e f g h i j k l m n o p q r s t u
+  icod_ (Interface a b c d e f g h i j k l m n o p q r s t u v) =
+      icodeN' interface a b c (fromImportedModules d) e f g h i j k l m n o p q r s t u v
     where interface a b c = Interface a b c . toImportedModules
 
   value = vcase valu where
-    valu [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u] =
-        valuN interface a b c d e f g h i j k l m n o p q r s t u
+    valu [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v] =
+        valuN interface a b c d e f g h i j k l m n o p q r s t u v
       where interface a b c = Interface a b c . toImportedModules
     valu _ = malformed

--- a/src/full/Agda/TypeChecking/Serialise/Instances.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances.hs
@@ -4,7 +4,7 @@
 module Agda.TypeChecking.Serialise.Instances () where
 
 import Agda.Syntax.Position
-import Agda.Syntax.Abstract.Name
+import Agda.Syntax.TopLevelModuleName
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Serialise.Base
 import Agda.TypeChecking.Serialise.Instances.Common (SerialisedRange(..))
@@ -12,12 +12,15 @@ import Agda.TypeChecking.Serialise.Instances.Highlighting ()
 import Agda.TypeChecking.Serialise.Instances.Errors ()
 import Agda.Utils.Hash
 
-type RangedImportedModules = [(SerialisedRange, ModuleName, Hash)]
+type RangedImportedModules =
+  [(SerialisedRange, TopLevelModuleName, Hash)]
 
-fromImportedModules :: [(ModuleName, Hash)] -> RangedImportedModules
+fromImportedModules ::
+  [(TopLevelModuleName, Hash)] -> RangedImportedModules
 fromImportedModules ms = [(SerialisedRange $ getRange x, x, hash) | (x, hash) <- ms]
 
-toImportedModules :: RangedImportedModules -> [(ModuleName, Hash)]
+toImportedModules ::
+  RangedImportedModules -> [(TopLevelModuleName, Hash)]
 toImportedModules ms = [(setRange (underlyingRange r) x, hash) | (r, x, hash) <- ms]
 
 instance EmbPrj Interface where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -38,6 +38,7 @@ import qualified Agda.Syntax.Concrete as C
 import qualified Agda.Syntax.Abstract as A
 import Agda.Syntax.Position as P
 import Agda.Syntax.Literal
+import Agda.Syntax.TopLevelModuleName
 import Agda.Interaction.FindFile
 
 import Agda.TypeChecking.Serialise.Base
@@ -240,7 +241,7 @@ instance Typeable b => EmbPrj (WithDefault b) where
     _ -> malformed
 
 instance EmbPrj TopLevelModuleName where
-  icod_ (TopLevelModuleName a b) = icodeN' TopLevelModuleName a b
+  icod_ (TopLevelModuleName a b c) = icodeN' TopLevelModuleName a b c
 
   value = valueN TopLevelModuleName
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -315,6 +315,11 @@ instance EmbPrj a => EmbPrj (P.Interval' a) where
 
   value = valueN P.Interval
 
+instance EmbPrj RangeFile where
+  icod_ (RangeFile a b) = icode (a, b)
+
+  value r = uncurry RangeFile <$> value r
+
 -- | Ranges are always deserialised as 'noRange'.
 
 instance EmbPrj Range where

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -418,10 +418,9 @@ instance Unquote MetaId where
   unquote t = do
     t <- reduceQuotedTerm t
     case t of
-      Lit (LitMeta f x) -> liftTCM $ do
-        live <- (f ==) <$> getCurrentPath
-        unless live $ do
-            m <- fromMaybe __IMPOSSIBLE__ <$> lookupModuleFromSource f
+      Lit (LitMeta m x) -> liftTCM $ do
+        live <- (Just m ==) <$> currentTopLevelModule
+        unless live $
             typeError . GenericDocError =<<
               sep [ "Can't unquote stale metavariable"
                   , pretty m <> "._" <> pretty (metaId x) ]
@@ -462,7 +461,11 @@ instance Unquote Literal where
           , (c `isCon` primAgdaLitChar,   LitChar   <$> unquoteN x)
           , (c `isCon` primAgdaLitString, LitString <$> unquoteNString x)
           , (c `isCon` primAgdaLitQName,  LitQName  <$> unquoteN x)
-          , (c `isCon` primAgdaLitMeta,   LitMeta   <$> getCurrentPath <*> unquoteN x) ]
+          , (c `isCon` primAgdaLitMeta,
+             LitMeta
+               <$> (fromMaybe __IMPOSSIBLE__ <$> currentTopLevelModule)
+               <*> unquoteN x)
+          ]
           __IMPOSSIBLE__
       Con c _ _ -> __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "literal" t

--- a/src/full/Agda/Utils/BiMap.hs
+++ b/src/full/Agda/Utils/BiMap.hs
@@ -58,8 +58,8 @@ tagInjectiveFor vs = and
 -- Every value of this type must satisfy 'biMapInvariant'.
 
 data BiMap k v = BiMap
-  { biMapThere :: Map k v
-  , biMapBack  :: Map (Tag v) k
+  { biMapThere :: !(Map k v)
+  , biMapBack  :: !(Map (Tag v) k)
   }
   deriving Generic
 

--- a/src/full/Agda/Utils/FileName.hs
+++ b/src/full/Agda/Utils/FileName.hs
@@ -91,7 +91,7 @@ canonicalizeAbsolutePath (AbsolutePath f) =
   AbsolutePath . Text.pack <$> canonicalizePath (Text.unpack f)
 
 -- | Tries to establish if the two file paths point to the same file
--- (or directory).
+-- (or directory). False negatives may be returned.
 
 sameFile :: AbsolutePath -> AbsolutePath -> IO Bool
 sameFile = liftA2 equalFilePath `on` (canonicalizePath . filePath)

--- a/test/Internal/Syntax/Concrete/Name.hs
+++ b/test/Internal/Syntax/Concrete/Name.hs
@@ -1,7 +1,10 @@
 
 module Internal.Syntax.Concrete.Name () where
 
+import qualified Data.List as List
+
 import Agda.Syntax.Concrete.Name
+import Agda.Syntax.TopLevelModuleName
 import Agda.Utils.Function ( applyWhen )
 import Agda.Utils.List1    ( (<|) )
 import qualified Agda.Utils.List1 as List1
@@ -16,11 +19,24 @@ import Test.QuickCheck
 -- * QuickCheck instances
 ------------------------------------------------------------------------
 
+instance Arbitrary RawTopLevelModuleName where
+  arbitrary = do
+    r     <- arbitrary
+    parts <- list1Of (listOf1 $ elements "AB")
+    return $ RawTopLevelModuleName
+      { rawModuleNameRange = r
+      , rawModuleNameParts = parts
+      }
+
 instance Arbitrary TopLevelModuleName where
-  arbitrary = TopLevelModuleName <$> arbitrary <*> list1Of (listOf1 $ elements "AB")
+  arbitrary = do
+    raw <- arbitrary
+    return $
+      unsafeTopLevelModuleName raw
+        (hashRawTopLevelModuleName raw)
 
 instance CoArbitrary TopLevelModuleName where
-  coarbitrary (TopLevelModuleName _ m) = coarbitrary m
+  coarbitrary = coarbitrary . moduleNameId
 
 instance Arbitrary Name where
   arbitrary = oneof

--- a/test/Internal/Syntax/Concrete/Name.hs
+++ b/test/Internal/Syntax/Concrete/Name.hs
@@ -4,13 +4,11 @@ module Internal.Syntax.Concrete.Name () where
 import qualified Data.List as List
 
 import Agda.Syntax.Concrete.Name
-import Agda.Syntax.TopLevelModuleName
 import Agda.Utils.Function ( applyWhen )
 import Agda.Utils.List1    ( (<|) )
 import qualified Agda.Utils.List1 as List1
 
 import Internal.Helpers
-import Internal.Syntax.Common ()
 import Internal.Syntax.Position ()
 
 import Test.QuickCheck
@@ -18,25 +16,6 @@ import Test.QuickCheck
 ------------------------------------------------------------------------
 -- * QuickCheck instances
 ------------------------------------------------------------------------
-
-instance Arbitrary RawTopLevelModuleName where
-  arbitrary = do
-    r     <- arbitrary
-    parts <- list1Of (listOf1 $ elements "AB")
-    return $ RawTopLevelModuleName
-      { rawModuleNameRange = r
-      , rawModuleNameParts = parts
-      }
-
-instance Arbitrary TopLevelModuleName where
-  arbitrary = do
-    raw <- arbitrary
-    return $
-      unsafeTopLevelModuleName raw
-        (hashRawTopLevelModuleName raw)
-
-instance CoArbitrary TopLevelModuleName where
-  coarbitrary = coarbitrary . moduleNameId
 
 instance Arbitrary Name where
   arbitrary = oneof

--- a/test/Internal/Syntax/Position.hs
+++ b/test/Internal/Syntax/Position.hs
@@ -3,9 +3,11 @@
 module Internal.Syntax.Position ( tests ) where
 
 import Agda.Syntax.Position
+import Agda.Syntax.TopLevelModuleName
 import Agda.Utils.FileName
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.List ( distinct )
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Null ( null )
 
 import Control.Monad
@@ -16,11 +18,13 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 
 import Internal.Helpers
-import Internal.Utils.FileName ()
+import Internal.Syntax.Common ()
+import Internal.Utils.FileName (rootPath)
 import Internal.Utils.Maybe.Strict ()
 
 import Prelude hiding ( null )
 
+import System.FilePath
 
 ------------------------------------------------------------------------
 -- Test suite
@@ -49,7 +53,7 @@ prop_iLength i = iLength i >= 0
 prop_startPos' :: Bool
 prop_startPos' = positionInvariant (startPos' ())
 
-prop_startPos :: Maybe AbsolutePath -> Bool
+prop_startPos :: Maybe RangeFile -> Bool
 prop_startPos = positionInvariant . startPos
 
 prop_noRange :: Bool
@@ -178,6 +182,33 @@ prop_rangeInSameFileAs r =
       (Range f _, Range f' _) -> f == f'
       (Range _ _, NoRange)    -> False
 
+instance Arbitrary RawTopLevelModuleName where
+  arbitrary = do
+    r     <- arbitrary
+    parts <- list1Of (listOf1 $ elements "AB")
+    return $ RawTopLevelModuleName
+      { rawModuleNameRange = r
+      , rawModuleNameParts = parts
+      }
+
+instance Arbitrary TopLevelModuleName where
+  arbitrary = do
+    raw <- arbitrary
+    return $
+      unsafeTopLevelModuleName raw
+        (hashRawTopLevelModuleName raw)
+
+instance CoArbitrary TopLevelModuleName where
+  coarbitrary = coarbitrary . moduleNameId
+
+instance Arbitrary RangeFile where
+  arbitrary = do
+    top   <- arbitrary
+    extra <- take 2 . map (take 2) <$> listOf (listOf1 (elements "a1"))
+    let f = mkAbsolute $ joinPath $
+            rootPath : extra ++ List1.toList (moduleNameParts top)
+    return $ mkRangeFile f (Just top)
+
 instance (Arbitrary a, Ord a) => Arbitrary (Interval' a) where
   arbitrary = do
     (p1, p2 :: Position' a) <- liftM2 (,) arbitrary arbitrary
@@ -194,6 +225,7 @@ instance (Ord a, Arbitrary a) => Arbitrary (Range' a) where
       | otherwise            = i1 : fuse (i2 : is)
     fuse is = is
 
+instance CoArbitrary RangeFile
 instance CoArbitrary a => CoArbitrary (Position' a)
 instance CoArbitrary a => CoArbitrary (Interval' a)
 instance CoArbitrary a => CoArbitrary (Range' a)

--- a/test/Internal/Syntax/Position.hs
+++ b/test/Internal/Syntax/Position.hs
@@ -16,6 +16,7 @@ import Data.Int
 import Data.List (sort)
 import Data.Set (Set)
 import qualified Data.Set as Set
+import qualified Data.Text as T
 
 import Internal.Helpers
 import Internal.Syntax.Common ()
@@ -185,7 +186,7 @@ prop_rangeInSameFileAs r =
 instance Arbitrary RawTopLevelModuleName where
   arbitrary = do
     r     <- arbitrary
-    parts <- list1Of (listOf1 $ elements "AB")
+    parts <- list1Of (T.pack <$> listOf1 (elements "AB"))
     return $ RawTopLevelModuleName
       { rawModuleNameRange = r
       , rawModuleNameParts = parts
@@ -206,7 +207,8 @@ instance Arbitrary RangeFile where
     top   <- arbitrary
     extra <- take 2 . map (take 2) <$> listOf (listOf1 (elements "a1"))
     let f = mkAbsolute $ joinPath $
-            rootPath : extra ++ List1.toList (moduleNameParts top)
+            rootPath : extra ++
+            map T.unpack (List1.toList (moduleNameParts top))
     return $ mkRangeFile f (Just top)
 
 instance (Arbitrary a, Ord a) => Arbitrary (Interval' a) where

--- a/test/Internal/Utils/FileName.hs
+++ b/test/Internal/Utils/FileName.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP             #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Internal.Utils.FileName ( tests ) where
+module Internal.Utils.FileName (rootPath, tests) where
 
 import qualified Data.Text as Text
 import System.FilePath

--- a/test/Internal/Utils/List.hs
+++ b/test/Internal/Utils/List.hs
@@ -10,9 +10,12 @@ module Internal.Utils.List ( tests ) where
 
 import Agda.Utils.List
 
+import Data.Bifunctor (first)
 import Data.Either (partitionEithers)
 import Data.Function
-import Data.List ( (\\), elemIndex, intercalate, isPrefixOf, isSuffixOf, nub, nubBy, sort, sortBy )
+import Data.List
+  ((\\), elemIndex, intercalate, isPrefixOf, isSuffixOf,
+   minimumBy, nub, nubBy, sort, sortBy)
 
 import Internal.Helpers
 
@@ -139,6 +142,17 @@ prop_zipWithKeepRest_init_zipWith f as bs =
 
 prop_nubOn :: (Integer -> Integer) -> [Integer] -> Bool
 prop_nubOn f xs = nubOn f xs == nubBy ((==) `on` f) xs
+
+prop_nubFavouriteOn ::
+  Fun Integer Integer -> Fun Integer Bool -> [Integer] -> Property
+prop_nubFavouriteOn (Fun _ f) (Fun _ p) xs =
+  nubFavouriteOn f p xs ===
+  map fst (sortBy (compare `on` snd) (find p xs ++ find (not . p) xs))
+  where
+  find p xs =
+    case filter (p . fst) $ zip xs [0..] of
+      [] -> []
+      xs -> [minimumBy (compare `on` first f) xs]
 
 prop_nubAndDuplicatesOn :: (Integer -> Integer) -> [Integer] -> Bool
 prop_nubAndDuplicatesOn f xs = nubAndDuplicatesOn f xs == (ys, xs \\ ys)

--- a/test/Succeed/ImportWarnings.warn
+++ b/test/Succeed/ImportWarnings.warn
@@ -27,22 +27,22 @@ Empty REWRITE pragma
 when scope checking the declaration
   {-# REWRITE #-}
 
-Issue708quote.agda:9,1-29
+Unreachable.agda:21,1-23,19
+Unreachable clauses
+when checking the definition of unreachable
+
+Issue2243.agda:9,1-12
 Unreachable clause
-when checking the definition of example
+when checking the definition of f
 
 RewritingEmptyPragma.agda:3,1-16
 Empty REWRITE pragma
 when scope checking the declaration
   {-# REWRITE #-}
 
-Issue2243.agda:9,1-12
+Issue708quote.agda:9,1-29
 Unreachable clause
-when checking the definition of f
-
-Unreachable.agda:21,1-23,19
-Unreachable clauses
-when checking the definition of unreachable
+when checking the definition of example
 
 ImportWarnings.agda:6,1-16
 Empty REWRITE pragma


### PR DESCRIPTION
Some of these changes are related to #6146. One of the changes fixes #6145.

Now `Range`s contain `TopLevelModuleName`s, which in turn now contain `ModuleNameHash`es to enable fast comparisons. I also replaced `String` with `Text` in `TopLevelModuleName`. I removed `SourceToModule` and `lookupModuleFromSource`, and the serialiser no longer uses `canonicalizeAbsolutePath`.

Quick testing for the standard library (with GHC 9.4.2 and `-foptimise-heavily`) suggests a speed-up of 10-20%, but as [noted before](https://github.com/agda/agda/pull/6099#issuecomment-1252039574) one should perhaps take such numbers with a grain of salt. Before:
```
 981,074,791,736 bytes allocated in the heap
  95,509,216,416 bytes copied during GC
   1,707,164,008 bytes maximum residency (166 sample(s))
       4,930,384 bytes maximum slop
            2684 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     231748 colls,     0 par   76.336s  76.454s     0.0003s    0.0293s
  Gen  1       166 colls,     0 par   13.247s  13.247s     0.0798s    0.8304s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time  300.721s  (299.141s elapsed)
  GC      time   89.584s  ( 89.701s elapsed)
  EXIT    time    0.001s  (  0.008s elapsed)
  Total   time  390.307s  (388.850s elapsed)

  Alloc rate    3,262,407,786 bytes per MUT second

  Productivity  77.0% of total user, 76.9% of total elapsed


real	6m28,928s
user	6m18,086s
sys	0m12,299s
```
After (another run was faster, `real	5m19,033s`):
```
 820,385,471,096 bytes allocated in the heap
  92,492,394,712 bytes copied during GC
   1,695,477,656 bytes maximum residency (159 sample(s))
       4,837,064 bytes maximum slop
            2670 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     195161 colls,     0 par   72.794s  72.907s     0.0004s    0.0263s
  Gen  1       159 colls,     0 par   12.663s  12.664s     0.0796s    0.8577s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time  253.297s  (251.793s elapsed)
  GC      time   85.457s  ( 85.571s elapsed)
  EXIT    time    0.001s  (  0.006s elapsed)
  Total   time  338.756s  (337.370s elapsed)

  Alloc rate    3,238,833,943 bytes per MUT second

  Productivity  74.8% of total user, 74.6% of total elapsed


real	5m37,449s
user	5m35,123s
sys	0m3,711s
```
Note that the `sys` time is significantly lower.