### PR TITLE
Fix for issue #5894

### DIFF
--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1371,9 +1371,8 @@ instance Pretty Sort where
       LockUniv -> "LockUniv"
       IntervalUniv -> "IntervalUniv"
       PiSort a s1 s2 -> mparens (p > 9) $
-        "piSort" <+> pDom (domInfo a) (text (absName s2) <+> ":" <+> pretty (unDom a))
-                      <+> parens (sep [ text ("λ " ++ absName s2 ++ " ->")
-                                      , nest 2 $ pretty (unAbs s2) ])
+        "piSort" <+> pDom (domInfo a) (text (absName s2) <+> ":" <+> pretty (unDom a) <+> ":" <+> pretty s1)
+                      <+> parens (pretty (unAbs s2))
       FunSort a b -> mparens (p > 9) $
         "funSort" <+> prettyPrec 10 a <+> prettyPrec 10 b
       UnivSort s -> mparens (p > 9) $ "univSort" <+> prettyPrec 10 s

--- a/src/full/Agda/TypeChecking/Empty.hs
+++ b/src/full/Agda/TypeChecking/Empty.hs
@@ -36,7 +36,7 @@ data ErrorNonEmpty
   | DontKnow Blocker   -- ^ Emptyness check blocked
 
 instance Semigroup ErrorNonEmpty where
-  DontKnow u1     <> DontKnow u2  = DontKnow $ u1 <> u2  -- Both must unblock for this to proceed
+  DontKnow u1     <> DontKnow u2  = DontKnow $ unblockOnBoth u1 u2  -- Both must unblock for this to proceed
   e@DontKnow{}    <> _            = e
   _               <> e@DontKnow{} = e
   FailBecause err <> _            = FailBecause err

--- a/src/full/Agda/TypeChecking/Free.hs
+++ b/src/full/Agda/TypeChecking/Free.hs
@@ -178,17 +178,17 @@ instance IsVarSet MetaSet SingleVarOcc where
 -- ** Flexible /rigid occurrence info for a single variable.
 
 -- | Get the full occurrence information of a free variable.
-flexRigOccurrenceIn :: Free a => Nat -> a -> Maybe (FlexRig' ())
+flexRigOccurrenceIn :: Free a => Nat -> a -> Maybe FlexRig
 flexRigOccurrenceIn = flexRigOccurrenceIn' IgnoreNot
 
-flexRigOccurrenceIn' :: Free a => IgnoreSorts -> Nat -> a -> Maybe (FlexRig' ())
+flexRigOccurrenceIn' :: Free a => IgnoreSorts -> Nat -> a -> Maybe FlexRig
 flexRigOccurrenceIn' ig x t = theSingleFlexRig $ runFree sg ig t
   where
   sg y = if x == y then oneSingleFlexRig else mempty
 
 -- | "Collection" just keeping track of the occurrence of a single variable.
 --   'Nothing' means variable does not occur freely.
-newtype SingleFlexRig = SingleFlexRig { theSingleFlexRig :: Maybe (FlexRig' ()) }
+newtype SingleFlexRig = SingleFlexRig { theSingleFlexRig :: Maybe FlexRig }
 
 oneSingleFlexRig :: SingleFlexRig
 oneSingleFlexRig = SingleFlexRig $ Just $ oneFlexRig
@@ -204,8 +204,8 @@ instance Monoid SingleFlexRig where
   mempty = SingleFlexRig Nothing
   mappend = (<>)
 
-instance IsVarSet () SingleFlexRig where
-  withVarOcc o = SingleFlexRig . fmap (composeFlexRig $ () <$ varFlexRig o) . theSingleFlexRig
+instance IsVarSet MetaSet SingleFlexRig where
+  withVarOcc o = SingleFlexRig . fmap (composeFlexRig $ varFlexRig o) . theSingleFlexRig
 
 -- ** Plain free occurrence.
 

--- a/src/full/Agda/TypeChecking/Free.hs
+++ b/src/full/Agda/TypeChecking/Free.hs
@@ -57,7 +57,7 @@ module Agda.TypeChecking.Free
     , flexRigOccurrenceIn
     , closed
     , MetaSet
-    , insertMetaSet, foldrMetaSet
+    , insertMetaSet, foldrMetaSet, metaSetToBlocker
     ) where
 
 import Prelude hiding (null)

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -68,7 +68,8 @@ import qualified Data.IntMap as IntMap
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
 import Data.Semigroup ( Semigroup, (<>) )
-
+import qualified Data.Set as Set
+import Data.Set (Set)
 
 
 import Agda.Syntax.Common
@@ -98,6 +99,9 @@ insertMetaSet m (MetaSet ms) = MetaSet $ HashSet.insert m ms
 
 foldrMetaSet :: (MetaId -> a -> a) -> a -> MetaSet -> a
 foldrMetaSet f e ms = HashSet.foldr f e $ theMetaSet ms
+
+metaSetToBlocker :: MetaSet -> Blocker
+metaSetToBlocker ms = unblockOnAny $ foldrMetaSet (Set.insert . unblockOnMeta) Set.empty ms
 
 ---------------------------------------------------------------------------
 -- * Flexible and rigid occurrences (semigroup)

--- a/src/full/Agda/TypeChecking/Monad/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Monad/Constraints.hs
@@ -173,7 +173,7 @@ instance MonadConstraint m => MonadConstraint (ReaderT e m) where
 addAndUnblocker :: MonadBlock m => Blocker -> m a -> m a
 addAndUnblocker u
   | u == alwaysUnblock = id
-  | otherwise          = catchPatternErr $ \ u' -> patternViolation (u <> u')
+  | otherwise          = catchPatternErr $ \ u' -> patternViolation (unblockOnBoth u u')
 
 addOrUnblocker :: MonadBlock m => Blocker -> m a -> m a
 addOrUnblocker u

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -794,6 +794,17 @@ isFrozen x = do
   mvar <- lookupLocalMeta x
   return $ mvFrozen mvar == Frozen
 
+withFrozenMetas
+  :: (MonadMetaSolver m, MonadTCState m)
+  => m a -> m a
+withFrozenMetas act = do
+  openMetas <- useR stOpenMetaStore
+  frozenMetas <- freezeMetas openMetas
+  result <- act
+  forM_ (Set.toList frozenMetas) $ \m ->
+    updateMetaVar m $ \ mv -> mv { mvFrozen = Instantiable }
+  return result
+
 -- | Unfreeze a meta and its type if this is a meta again.
 --   Does not unfreeze deep occurrences of meta-variables or remote
 --   meta-variables.

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -762,7 +762,7 @@ solveAwakeConstraints' = solveSomeAwakeConstraints (const True)
 
 -- | Freeze the given meta-variables (but only if they are open) and
 -- return those that were not already frozen.
-freezeMetas :: LocalMetaStore -> TCM (Set MetaId)
+freezeMetas :: MonadTCState m => LocalMetaStore -> m (Set MetaId)
 freezeMetas ms =
   execWriterT $
   modifyTCLensM stOpenMetaStore $

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -449,8 +449,8 @@ instance Reduce PlusLevel where
   reduceB' (Plus n l) = fmap (Plus n) <$> reduceB' l
 
 instance (Subst a, Reduce a) => Reduce (Abs a) where
-  reduce' b@(Abs x _) = Abs x <$> underAbstraction_ b reduce'
-  reduce' (NoAbs x v) = NoAbs x <$> reduce' v
+  reduceB' b@(Abs x _) = fmap (Abs x) <$> underAbstraction_ b reduceB'
+  reduceB' (NoAbs x v) = fmap (NoAbs x) <$> reduceB' v
 
 -- Lists are never blocked
 instance Reduce t => Reduce [t] where

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -218,8 +218,6 @@ checkDataSort name s = setCurrentRange name $ do
                    , prettyTCM name
                    , "does not admit data or record declarations"
                    ]
-      dunno :: TCM ()
-      dunno = postpone (unblockOnAnyMetaIn s) s
     case s of
       -- Sorts that admit data definitions.
       Type _       -> yes
@@ -231,10 +229,10 @@ checkDataSort name s = setCurrentRange name $ do
       SizeUniv     -> no
       LockUniv     -> no
       IntervalUniv -> no
-      -- Unsolved sorts.
-      PiSort _ _ _ -> dunno
-      FunSort _ _  -> dunno
-      UnivSort _   -> dunno
+      -- Blocked sorts.
+      PiSort _ _ _ -> __IMPOSSIBLE__
+      FunSort _ _  -> __IMPOSSIBLE__
+      UnivSort _   -> __IMPOSSIBLE__
       MetaS _ _    -> __IMPOSSIBLE__
       DummyS _     -> __IMPOSSIBLE__
   where

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -725,7 +725,7 @@ checkClause t withSub c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats rhs0 wh 
               [ "double checking rhs"
               , nest 2 (prettyTCM v <+> " : " <+> prettyTCM (unArg trhs))
               ]
-            nonConstraining $ checkInternal v CmpLeq $ unArg trhs
+            noConstraints $ withFrozenMetas $ checkInternal v CmpLeq $ unArg trhs
           Nothing -> return ()
 
         reportSDoc "tc.lhs.top" 10 $ vcat

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -64,8 +64,8 @@ inferUnivSort
 inferUnivSort s = do
   s <- reduce s
   case univSort' s of
-    Just s' -> return s'
-    Nothing -> do
+    Right s' -> return s'
+    Left _ -> do
       -- Jesper, 2020-04-19: With the addition of Setωᵢ and the PTS
       -- rule SizeUniv : Setω, every sort (with no metas) now has a
       -- bigger sort, so we do not need to add a constraint.

--- a/test/Fail/Issue399.err
+++ b/test/Fail/Issue399.err
@@ -12,7 +12,7 @@ Failed to solve the following constraints:
      funSort (_7 (m = m) (mzero = mzero))
      (funSort (_10 (m = m) (mzero = mzero)) Set))
     =< Set₁
-    (blocked on any(_7, _10))
+    (blocked on all(_7, _10))
   piSort Set₁ (λ a → funSort (_2 (m = m)) Set) =< Set₁
     (blocked on _2)
 Unsolved metas at the following locations:


### PR DESCRIPTION
At first I thought this would be an easy thing to fix, but once I started to compute proper blocking information about sorts (rather than just relying on `allMetasIn`) this started to have rippling effects on code dealing with sorts in other places. I decided to stop my work once I managed to deal with the fishy code @andreasabel mentioned in https://github.com/agda/agda/pull/5892/files#r867752534, but there is still similar code hidden in the conversion checker (and possibly other places) where I just added a TODO.