### PR TITLE
Revert optimization of `findOverlap`

### DIFF
--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -443,11 +443,14 @@ data StrSufSt a
 --   Returns the index where the overlap starts and the length of the overlap.
 --   The length of the overlap plus the index is the length of the first string.
 --   Note that in the worst case, the empty overlap @(length xs,0)@ is returned.
-findOverlap :: Eq a => [a] -> [a] -> (Int, Int)
-findOverlap xs ys = go 0 (reverse xs) ys
+findOverlap :: forall a. Eq a => [a] -> [a] -> (Int, Int)
+findOverlap xs ys =
+  headWithDefault __IMPOSSIBLE__ $ mapMaybe maybePrefix $ zip [0..] (List.tails xs)
   where
-  go !i (x : xs) (y : ys) | x == y = go (i + 1) xs ys
-  go  i xs       _                 = (length xs, i)
+  maybePrefix :: (Int, [a]) -> Maybe (Int, Int)
+  maybePrefix (k, xs')
+    | xs' `List.isPrefixOf` ys = Just (k, length xs')
+    | otherwise                = Nothing
 
 ---------------------------------------------------------------------------
 -- * Groups and chunks

--- a/test/Succeed/Issue6185.agda
+++ b/test/Succeed/Issue6185.agda
@@ -1,0 +1,11 @@
+{-# OPTIONS --cubical --allow-unsolved-metas #-}
+
+open import Agda.Builtin.Cubical.Path
+
+postulate A : Set
+
+record R : Set where
+  p : A → A ≡ A
+  p a i = {!!}
+
+  field a : A


### PR DESCRIPTION
Reverts the commit 42820f191fb131d7168eb682e56dd89b50bd8553 from #6092. The optimized version had a different behavior, it used the reversed suffix instead of the normal suffix.

Fixes #6185.
