### PR TITLE
Refactoring: structured errors in library file parsing and handling

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -941,7 +941,8 @@ test-suite agda-tests
                 , process-extras >= 0.3.0 && < 0.3.4 || >= 0.4.1.3 && < 0.5 || >= 0.7.1 && < 0.8
                 , QuickCheck >= 2.14.1 && < 2.15
                 , regex-tdfa
-                , strict >= 0.3.2 && < 0.5
+                , split
+                , strict
                 , tasty >= 1.1.0.4 && < 1.5
                 , tasty-hunit >= 0.9.2 && < 0.11
                 , tasty-quickcheck >= 0.9.2 && < 0.11
@@ -952,7 +953,7 @@ test-suite agda-tests
                 , temporary >= 1.2.0.3 && < 1.4
                 , text
                 , unix-compat >= 0.4.3.1 && < 0.7
-                , unordered-containers >= 0.2.5.0 && < 0.3
+                , unordered-containers
                 , uri-encode
 
   -- Andreas (2021-10-11): tasty-silver < 3.3 does not work interactively under Windows

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -906,6 +906,7 @@ test-suite agda-tests
                     , Internal.Utils.IntSet
                     , Internal.Utils.List
                     , Internal.Utils.List1
+                    , Internal.Utils.List2
                     , Internal.Utils.ListT
                     , Internal.Utils.Maybe.Strict
                     , Internal.Utils.Monoid

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -446,7 +446,7 @@ libraryIncludePaths overrideLibFile libs xs0 = mkLibM libs $ WriterT $ do
       :: LibrariesFile  -- Only for error reporting.
       -> [LibName]      -- Already resolved libraries.
       -> [LibName]      -- Work list: libraries left to be resolved.
-      -> Writer [Either LibError LibWarning] [AgdaLibFile]
+      -> Writer LibErrWarns [AgdaLibFile]
     find _ _ [] = pure []
     find file visited (x : xs)
       | x `elem` visited = find file visited xs

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -348,7 +348,7 @@ parseLibFiles mlibFile files = do
 
   List1.unlessNull (concat warns) warnings
   List1.unlessNull errs $ \ errs1 ->
-    raiseErrors $ fmap (\ (mc, s) -> LibError mc $ LibParseError s) errs1
+    raiseErrors $ fmap (\ (mc, err) -> LibError mc $ LibParseError err) errs1
 
   return $ nubOn _libFile als
 

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -171,23 +171,27 @@ type LibState =
   , Map FilePath AgdaLibFile
   )
 
+-- | Collection of 'LibError's and 'LibWarning's.
+--
+type LibErrWarns = [Either LibError LibWarning]
+
 -- | Collects 'LibError's and 'LibWarning's.
 --
-type LibErrorIO = WriterT [Either LibError LibWarning] (StateT LibState IO)
+type LibErrorIO = WriterT LibErrWarns (StateT LibState IO)
 
 -- | Throws 'Doc' exceptions, still collects 'LibWarning's.
 type LibM = ExceptT Doc (WriterT [LibWarning] (StateT LibState IO))
 
-warnings :: MonadWriter [Either LibError LibWarning] m => List1 LibWarning -> m ()
+warnings :: MonadWriter LibErrWarns m => List1 LibWarning -> m ()
 warnings = tell . map Right . toList
 
-warnings' :: MonadWriter [Either LibError LibWarning] m => List1 LibWarning' -> m ()
+warnings' :: MonadWriter LibErrWarns m => List1 LibWarning' -> m ()
 warnings' = tell . map (Right . LibWarning Nothing) . toList
 
-raiseErrors' :: MonadWriter [Either LibError LibWarning] m => List1 LibError' -> m ()
+raiseErrors' :: MonadWriter LibErrWarns m => List1 LibError' -> m ()
 raiseErrors' = tell . map (Left . (LibError Nothing)) . toList
 
-raiseErrors :: MonadWriter [Either LibError LibWarning] m => List1 LibError -> m ()
+raiseErrors :: MonadWriter LibErrWarns m => List1 LibError -> m ()
 raiseErrors = tell . map Left . toList
 
 getCachedProjectConfig

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -24,6 +24,7 @@ import Agda.Interaction.Options.Warnings
 
 import Agda.Utils.FileName
 import Agda.Utils.Lens
+import Agda.Utils.List1 (List1, toList)
 import Agda.Utils.Pretty
 
 -- | A symbolic library name.
@@ -157,21 +158,17 @@ type LibErrorIO = WriterT [Either LibError LibWarning] (StateT LibState IO)
 -- | Throws 'Doc' exceptions, still collects 'LibWarning's.
 type LibM = ExceptT Doc (WriterT [LibWarning] (StateT LibState IO))
 
-warnings :: MonadWriter [Either LibError LibWarning] m => [LibWarning] -> m ()
-warnings = tell . map Right
+warnings :: MonadWriter [Either LibError LibWarning] m => List1 LibWarning -> m ()
+warnings = tell . map Right . toList
 
-warnings' :: MonadWriter [Either LibError LibWarning] m => [LibWarning'] -> m ()
-warnings' = tell . map (Right . LibWarning Nothing)
+warnings' :: MonadWriter [Either LibError LibWarning] m => List1 LibWarning' -> m ()
+warnings' = tell . map (Right . LibWarning Nothing) . toList
 
--- UNUSED Liang-Ting Chen 2019-07-16
---warning :: MonadWriter [Either LibError LibWarning] m => LibWarning -> m ()
---warning = warnings . pure
+raiseErrors' :: MonadWriter [Either LibError LibWarning] m => List1 LibError' -> m ()
+raiseErrors' = tell . map (Left . (LibError Nothing)) . toList
 
-raiseErrors' :: MonadWriter [Either LibError LibWarning] m => [LibError'] -> m ()
-raiseErrors' = tell . map (Left . (LibError Nothing))
-
-raiseErrors :: MonadWriter [Either LibError LibWarning] m => [LibError] -> m ()
-raiseErrors = tell . map Left
+raiseErrors :: MonadWriter [Either LibError LibWarning] m => List1 LibError -> m ()
+raiseErrors = tell . map Left . toList
 
 getCachedProjectConfig
   :: (MonadState LibState m, MonadIO m)

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -73,7 +73,7 @@ import Control.Monad.Writer (runWriter, tell)
 import qualified Data.Foldable as Fold
 import Data.Function
 import Data.Int
-import Data.List (foldl', sort)
+import Data.List (sort)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
@@ -676,8 +676,8 @@ movePos (Pn f p l c) _    = Pn f (p + 1) l (c + 1)
 -- | Advance the position by a string.
 --
 --   > movePosByString = foldl' movePos
-movePosByString :: Position' a -> String -> Position' a
-movePosByString = foldl' movePos
+movePosByString :: Foldable t => Position' a -> t Char -> Position' a
+movePosByString = Fold.foldl' movePos
 
 -- | Backup the position by one character.
 --

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -292,9 +292,6 @@ closeVerboseBracketException k n = displayDebugMessage k n "} (exception)\n"
 --   reportSLn
 --   reportSDoc
 
-parseVerboseKey :: VerboseKey -> [String]
-parseVerboseKey = wordsBy (`elem` (".:" :: String))
-
 -- | Check whether a certain verbosity level is activated.
 --
 --   Precondition: The level must be non-negative.

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -477,21 +477,6 @@ groupBy' p xxs@(x : xs) = grp x $ zipWith (\x y -> (p x y, y)) xxs xs
                    []            -> []
                    ((_, z) : zs) -> grp z zs
 
--- | Split a list into sublists. Generalisation of the prelude function
---   @words@.
---   O(n).
---
---   > words xs == wordsBy isSpace xs
-wordsBy :: (a -> Bool) -> [a] -> [[a]]
-wordsBy p xs = yesP xs
-    where
-        yesP xs = noP (dropWhile p xs)
-
-        noP []  = []
-        noP xs  = ys : yesP zs
-            where
-                (ys,zs) = break p xs
-
 -- | Chop up a list in chunks of a given length.
 -- O(n).
 chop :: Int -> [a] -> [[a]]

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -46,6 +46,7 @@ import Agda.Utils.Null (Null(..))
 import qualified Agda.Utils.List as List
 
 type List1 = NonEmpty
+type String1 = List1 Char
 
 -- | Safe version of 'Data.List.NonEmpty.fromList'.
 
@@ -101,6 +102,20 @@ groupBy' p xxs@(x : xs) = grp x $ List.zipWith (\ x y -> (p x y, y)) xxs xs
     = (x :| List.map snd xs) : case rest of
       []                 -> []
       ((_false, z) : zs) -> grp z zs
+
+-- | Split a list into sublists. Generalisation of the prelude function
+--   @words@.
+--   Same as 'Data.List.Split.wordsBy' and 'Data.List.Extra.wordsBy',
+--   but with the non-emptyness guarantee on the chunks.
+--   O(n).
+--
+--   > words xs == wordsBy isSpace xs
+wordsBy :: (a -> Bool) -> [a] -> [List1 a]
+wordsBy p = loop
+  where
+  loop as = case List.dropWhile p as of
+    []   -> []
+    x:xs -> (x :| ys) : loop zs where (ys, zs) = List.break p xs
 
 -- | Breaks a list just /after/ an element satisfying the predicate is
 --   found.

--- a/src/full/Agda/Utils/List2.hs
+++ b/src/full/Agda/Utils/List2.hs
@@ -60,6 +60,18 @@ fromList1 :: List1 a -> List2 a
 fromList1 (a :| b : cs) = List2 a b cs
 fromList1 _             = __IMPOSSIBLE__
 
+-- | Any 'List1' is either a singleton or a 'List2'.
+fromList1Either :: List1 a -> Either a (List2 a)
+fromList1Either (a :| as) = case as of
+  []   -> Left a
+  b:bs -> Right (List2 a b bs)
+
+-- | Inverse of 'fromList1Either'
+toList1Either :: Either a (List2 a) -> List1 a
+toList1Either = \case
+  Left  a              -> a :| []
+  Right (List2 a b bs) -> a :| b : bs
+
 -- * Destruction
 
 -- | Safe. O(1).

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -7,13 +7,15 @@ module Agda.Utils.Monad
     )
     where
 
-import Control.Applicative  ( liftA2 )
-import Control.Monad        ( MonadPlus(..), guard, unless, when )
-import Control.Monad.Except ( MonadError(catchError, throwError) )
-import Control.Monad.State  ( MonadState(get, put) )
+import Control.Applicative    ( liftA2 )
+import Control.Monad          ( MonadPlus(..), guard, unless, when )
+import Control.Monad.Except   ( MonadError(catchError, throwError) )
+import Control.Monad.Identity ( runIdentity )
+import Control.Monad.State    ( MonadState(get, put) )
+import Control.Monad.Writer   ( Writer, WriterT, mapWriterT )
 
-import Data.Bifunctor       ( first, second )
-import Data.Bool            ( bool )
+import Data.Bifunctor         ( first, second )
+import Data.Bool              ( bool )
 import Data.Traversable as Trav hiding (for, sequence)
 import Data.Foldable as Fold
 import Data.Maybe
@@ -231,3 +233,8 @@ bracket_ acquire release compute = do
 -- | Restore state after computation.
 localState :: MonadState s m => m a -> m a
 localState = bracket_ get put
+
+-- Writer monad -----------------------------------------------------------
+
+embedWriter :: (Monoid w, Monad m) => Writer w a -> WriterT w m a
+embedWriter = mapWriterT (pure . runIdentity)

--- a/src/full/Agda/Utils/Null.hs
+++ b/src/full/Agda/Utils/Null.hs
@@ -8,8 +8,10 @@ module Agda.Utils.Null where
 import Prelude hiding (null)
 
 import Control.Monad
-import Control.Monad.Reader
-import Control.Monad.State
+import Control.Monad.Reader ( ReaderT )
+import Control.Monad.State  ( StateT  )
+import Control.Monad.Writer ( WriterT )
+import Control.Monad.Trans  ( lift    )
 
 import qualified Data.ByteString.Char8 as ByteStringChar8
 import qualified Data.ByteString.Lazy as ByteStringLazy
@@ -122,11 +124,19 @@ instance Null Doc where
   empty = mempty
   null  = isEmpty
 
+instance Null a => Null (IO a) where
+  empty = return empty
+  null  = __IMPOSSIBLE__
+
 instance (Null (m a), Monad m) => Null (ReaderT r m a) where
   empty = lift empty
   null  = __IMPOSSIBLE__
 
-instance (Null (m a), Monad m) => Null (StateT r m a) where
+instance (Null (m a), Monad m) => Null (StateT s m a) where
+  empty = lift empty
+  null  = __IMPOSSIBLE__
+
+instance (Null (m a), Monad m, Monoid w) => Null (WriterT w m a) where
   empty = lift empty
   null  = __IMPOSSIBLE__
 

--- a/src/full/Agda/Utils/Null.hs
+++ b/src/full/Agda/Utils/Null.hs
@@ -8,10 +8,12 @@ module Agda.Utils.Null where
 import Prelude hiding (null)
 
 import Control.Monad
-import Control.Monad.Reader ( ReaderT )
-import Control.Monad.State  ( StateT  )
-import Control.Monad.Writer ( WriterT )
-import Control.Monad.Trans  ( lift    )
+import Control.Monad.Except   ( ExceptT )
+import Control.Monad.Identity ( Identity(..) )
+import Control.Monad.Reader   ( ReaderT )
+import Control.Monad.State    ( StateT  )
+import Control.Monad.Writer   ( WriterT )
+import Control.Monad.Trans    ( lift    )
 
 import qualified Data.ByteString.Char8 as ByteStringChar8
 import qualified Data.ByteString.Lazy as ByteStringLazy
@@ -124,8 +126,16 @@ instance Null Doc where
   empty = mempty
   null  = isEmpty
 
+instance Null a => Null (Identity a) where
+  empty = return empty
+  null  = null . runIdentity
+
 instance Null a => Null (IO a) where
   empty = return empty
+  null  = __IMPOSSIBLE__
+
+instance (Null (m a), Monad m) => Null (ExceptT e m a) where
+  empty = lift empty
   null  = __IMPOSSIBLE__
 
 instance (Null (m a), Monad m) => Null (ReaderT r m a) where

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -27,6 +27,7 @@ import Data.Maybe
 import Text.Read
 
 import Agda.Utils.List
+import Agda.Utils.List1 (wordsBy, toList)
 
 type GHCArgs = [String]
 
@@ -340,6 +341,6 @@ findGHCVersion = do
     ExitSuccess   -> return $
       sequence $
       concat $
-      map (map readMaybe . wordsBy (== '.')) $
+      map (map (readMaybe . toList) . wordsBy (== '.')) $
       take 1 $
       lines version

--- a/test/Internal/Tests.hs
+++ b/test/Internal/Tests.hs
@@ -43,6 +43,7 @@ import qualified Internal.Utils.Graph.AdjacencyMap.Unidirectional  as UtilGraphU
 import qualified Internal.Utils.IntSet                             as UtilIntSet   ( tests )
 import qualified Internal.Utils.List                               as UtilList     ( tests )
 import qualified Internal.Utils.List1                              as UtilList1    ( tests )
+import qualified Internal.Utils.List2                              as UtilList2    ( tests )
 import qualified Internal.Utils.ListT                              as UtilListT    ( tests )
 import qualified Internal.Utils.Maybe.Strict                       as UtilMaybeS   ( tests )
 import qualified Internal.Utils.Monoid                             as UtilMonoid   ( tests )
@@ -93,6 +94,7 @@ tests = testGroup "Internal"
   , UtilIntSet.tests
   , UtilList.tests
   , UtilList1.tests
+  , UtilList2.tests
   , UtilListT.tests
   , UtilMaybeS.tests
   , UtilMonoid.tests

--- a/test/Internal/Utils/List1.hs
+++ b/test/Internal/Utils/List1.hs
@@ -2,6 +2,9 @@
 
 module Internal.Utils.List1 ( tests ) where
 
+import qualified Data.List       as List
+import qualified Data.List.Split as Split
+
 import Agda.Utils.List1 as List1
 
 import Internal.Helpers
@@ -15,6 +18,17 @@ prop_NonemptyList_roundtrip l = maybe False (l ==) $ nonEmpty $ List1.toList l
 
 prop_foldr_id :: List1 Int -> Bool
 prop_foldr_id xs = List1.foldr (<|) singleton xs == xs
+
+-- A type with few elements.
+type Four = (Bool, Bool)
+
+zero4 :: Four
+zero4 = (False, False)
+
+-- | Our 'wordsBy' conforms to 'Split.wordsBy'.
+prop_wordsBy :: [Four] -> Bool
+prop_wordsBy xs = Split.wordsBy p xs == List.map toList (List1.wordsBy p xs)
+  where p = (== zero4)
 
 ------------------------------------------------------------------------
 -- * All tests

--- a/test/Internal/Utils/List2.hs
+++ b/test/Internal/Utils/List2.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Internal.Utils.List2 ( tests ) where
+
+import Data.Maybe
+
+import Agda.Utils.List  (uncons)
+import Agda.Utils.List1 (List1)
+import Agda.Utils.List2 as List2
+
+import Internal.Helpers
+
+instance Arbitrary a => Arbitrary (List2 a) where
+  arbitrary = List2 <$> arbitrary <*> arbitrary <*> arbitrary
+  shrink (List2 x y ys) = concat $
+    [ -- drop x
+      [ List2 y z zs | (z,zs) <- maybeToList $ uncons ys ]
+    , -- drop y
+      [ List2 x z zs | (z,zs) <- maybeToList $ uncons ys ]
+    , -- drop from ys
+      map (List2 x y) $ shrink ys
+    ]
+
+instance CoArbitrary a => CoArbitrary (List2 a) where
+  coarbitrary (List2 x y zs) = coarbitrary (x, y, zs)
+
+------------------------------------------------------------------------
+-- * Properties
+------------------------------------------------------------------------
+
+prop_iso_List1Either_1 :: Either Int (List2 Int) -> Bool
+prop_iso_List1Either_1 e = fromList1Either (toList1Either e) == e
+
+prop_iso_List1Either_2 :: List1 Int -> Bool
+prop_iso_List1Either_2 xs = toList1Either (fromList1Either xs) == xs
+
+------------------------------------------------------------------------
+-- * All tests
+------------------------------------------------------------------------
+
+-- Template Haskell hack to make the following $allProperties work
+-- under ghc-7.8.
+return [] -- KEEP!
+
+-- | All tests as collected by 'allProperties'.
+--
+-- Using 'allProperties' is convenient and superior to the manual
+-- enumeration of tests, since the name of the property is added
+-- automatically.
+
+tests :: TestTree
+tests = testProperties "Internal.Utils.List2" $allProperties

--- a/test/interaction/Issue1785.out
+++ b/test/interaction/Issue1785.out
@@ -1,3 +1,3 @@
-(agda2-info-action "*Error*" "issue1785.libs:1: Failed to read library file /. Reason: /: openBinaryFile: inappropriate type (is a directory) " nil)
+(agda2-info-action "*Error*" "issue1785.libs:1: Failed to read library file /. Reason: /: openBinaryFile: inappropriate type (is a directory)" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")


### PR DESCRIPTION
This PR does away with `String` errors in the `Interaction.Library` component.  Using structured errors allows us to clean up a seven year old hack in `formatLibPositionInfo`, that would match on error texts to add a position prefix.

Further refactorings in this PR that happened on the side:
- Refine the type of `wordsBy` to `... -> [List1 a]`.  This lead to:
- Unify two copies of `parseVerboseKey`.