### PR TITLE
Re #6187: Agda.Utils.List.findOverlap: complexity and QuickCheck property

### DIFF
--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -439,12 +439,19 @@ data StrSufSt a
 
 -- ** Finding overlap
 
--- | Find out whether the first string @xs@
---   has a suffix that is a prefix of the second string @ys@.
+-- | Find the longest suffix of the first string @xs@
+--   that is a prefix of the second string @ys@.
 --   So, basically, find the overlap where the strings can be glued together.
 --   Returns the index where the overlap starts and the length of the overlap.
 --   The length of the overlap plus the index is the length of the first string.
 --   Note that in the worst case, the empty overlap @(length xs,0)@ is returned.
+--
+--   Worst-case time complexity is quadratic: @O(min(n,m)²)@
+--   where @n = length xs@ and @m = length ys@.
+--
+--   There might be asymptotically better implementations following
+--   Knuth-Morris-Pratt (KMP), but for rather short lists this is good enough.
+--
 findOverlap :: forall a. Eq a => [a] -> [a] -> (Int, Int)
 findOverlap xs ys =
   headWithDefault __IMPOSSIBLE__ $ mapMaybe maybePrefix $ zip [0..] (List.tails xs)

--- a/test/Internal/Utils/List.hs
+++ b/test/Internal/Utils/List.hs
@@ -177,6 +177,16 @@ prop_commonSuffix xs ys zs =
   where
     zs' = commonSuffix (xs ++ zs) (ys ++ zs)
 
+-- | If @xs@, @ys@ and @zs@ are pairwise disjoint, then the overlap between
+--   @xs ++ ys@ and @ys ++ zs@ is certainly @ys@.
+prop_findOverlap :: [Int] -> [Int] -> [Int] -> Bool
+prop_findOverlap xs ys zs = findOverlap (xs1 ++ ys2) (ys2 ++ zs3) == (length xs, length ys)
+  where
+  -- Make sure the lists are disjoint.
+  xs1 = (,1) <$> xs
+  ys2 = (,2) <$> ys
+  zs3 = (,3) <$> zs
+
 prop_editDistance :: Property
 prop_editDistance =
   forAllShrink (choose (0, 10)) shrink $ \ n ->


### PR DESCRIPTION
See https://github.com/agda/agda/pull/6187.  
Secure `findOverlap` against accidential breakage.