### PR TITLE
Fix two tiny bugs in Cubical Glue/HCompU

### DIFF
--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
@@ -196,7 +196,7 @@ doGlueKanOp (TranspOp psi u0) (IsFam (la, lb, bA, phi, bT, e)) tpos = do
       --        (unglue_u0 i0)
       a1 = gcomp la bA (imax psi forallphi)
         (lam "i" $ \ i -> combineSys (la <@> i) (bA <@> i)
-          [ (phi,       ilam "o" $ \_ -> unglue_u0 i)
+          [ (psi,       ilam "o" $ \_ -> unglue_u0 i)
           , (forallphi, ilam "o" $ \o -> w i o <@> (tf i o))
           ])
         (unglue_u0 (pure iz))

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
@@ -159,7 +159,7 @@ doHCompUKanOp (TranspOp psi u0) (IsFam (la, phi, bT, bA)) tpos = do
       -- a1 with gcomp
       a1 = gcomp la bA (imax psi forallphi)
         (lam "i" $ \ i -> combineSys (la <@> i) (bA <@> i)
-          [ (phi,       ilam "o" $ \_ -> unglue_u0 i)
+          [ (psi,       ilam "o" $ \_ -> unglue_u0 i)
           , (forallphi, ilam "o" (\o -> transp (la <@> i) (\j -> bT <@> i <@> ineg j <..> o) (tf i o)))
           ])
           (unglue_u0 (pure iz))


### PR DESCRIPTION
This fixes two tiny (one character) bugs in Cubical Glue/HCompU.

I am not sure how to properly observe the bug in a test. I discovered the bug by noticing ill-typed terms in the output of C-c C-n, like this:
```
primPOr (λ i₃ → ~ i ∨ i ∨ ~ i₃ ∨ i₃) (~ i ∨ i) ...
```
The first arg there is supposed to be in `I`, not `I -> I`.

Looking at the code near the bugs, we can see that `phi` has the wrong type, because it is passed to `tForall` (of type `(I -> I) -> I`) to produce `forallphi`.

Moreover, [Simon Huber's note](https://simhu.github.io/misc/hcomp.pdf) says that this is supposed to be `psi`, not `phi`.

Here is a silly example which shows the ill-typed primPOr above. Normalize `example` to see it.

```agda
{-# OPTIONS --cubical #-}

module Cubical.Experiments.PhiPsi where

open import Agda.Primitive renaming ( Set to Type ; _⊔_ to ℓ-max )
open import Agda.Primitive.Cubical renaming ( primIMin to _∧_ ; primIMax to _∨_ ; primINeg to ~_ )
open import Agda.Builtin.Cubical.Glue using ( _≃_ ; isEquiv ; primGlue )
open import Agda.Builtin.Sigma using ( Σ ; _,_ ; fst ; snd )

_≡_ : ∀ {ℓ} {A : Type ℓ} → A → A → Type ℓ
_≡_ {A = A} x y = PathP (λ _ → A) x y

fiber : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (f : A → B) (y : B) → Type (ℓ-max ℓ ℓ')
fiber {A = A} f y = Σ A (λ x → f x ≡ y)

strictContrFibers : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} {f : A → B} (g : B → A) (b : B)
  → Σ (fiber f (f (g b))) λ t → ((t' : fiber f b) → PathP (λ _ → fiber f (f (g b))) t (g (f (t' .fst)) , λ i → f (g (t' .snd i))))
strictContrFibers {f = f} g b .fst = (g b , λ _ → f (g b))
strictContrFibers {f = f} g b .snd (a , p) i = (g (p (~ i)) , λ j → f (g (p (~ i ∨ j))))

idIsEquiv : ∀ {ℓ} {A : Type ℓ} → isEquiv (λ (x : A) → x)
isEquiv.equiv-proof idIsEquiv = strictContrFibers (λ x → x)

System : ∀ {ℓ} (X : Type ℓ) (i j : I) → Partial (~ i ∨ i ∨ ~ j ∨ j) (Type ℓ)
System X i j _ = X

system : ∀ {ℓ} (X : Type ℓ) (i j : I) → PartialP (~ i ∨ i ∨ ~ j ∨ j) (λ o → System X i j o ≃ X)
system X i j _ = _ , idIsEquiv

Dummy : ∀ {ℓ} (X : Type ℓ) → (i j : I) → Type ℓ
Dummy X i j = primGlue X {~ i ∨ i ∨ ~ j ∨ j} (System X i j) (system X i j)

example : ∀ {ℓ} (X : Type ℓ) (x : X) → primTransp (λ j → X) i0 x ≡ x
example X x i = primTransp (λ j → Dummy X i j) i x
```