### PR TITLE
Profiling of conversion checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,10 @@ Pragmas and options
 * Profiling options are now turned on with a new `--profile` flag instead of
   abusing the debug verbosity option. (See [#5781](https://github.com/agda/agda/issues/5731).)
 
+* The new profiling option `--profile=conversion` collects statistics
+  on how often various steps of the conversion algorithm are used
+  (reduction, eta-expansion, syntactic equality, etc).
+
 * The option `--without-K` has been renamed `--cubical-compatible` (See
   [#5843](https://github.com/agda/agda/issues/5843).)
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -267,6 +267,10 @@ Printing and debugging
          - Count number of created metavariables
        * - ``interactive``
          - Measure time of interactive commands
+       * - ``conversion``
+         - Count number of times various steps of the conversion algorithm are
+           used (reduction, eta-expansion, syntactic equality, etc)
+
 
     Only one of ``internal``, ``modules``, and ``definitions`` can be turned on
     at a time. You can also give ``--profile=all`` to turn on all profiling

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -333,7 +333,7 @@ compareTerm' cmp a m n =
                      -- if we are dealing with a singleton record,
                      -- we can succeed immediately
                      let profUnitEta = whenProfile Profile.Conversion $ tick "compare at eta-record: both neutral at unit"
-                     ifM (isSingletonRecordModuloRelevance r ps) (profUnitEta >> return ()) $ do
+                     ifM (isSingletonRecordModuloRelevance r ps) (profUnitEta) $ do
                        -- do not eta-expand if comparing two neutrals
                        compareAtom cmp (AsTermsOf a') (ignoreBlocking m) (ignoreBlocking n)
                  | otherwise -> do

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -78,6 +78,7 @@ import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Permutation
 import Agda.Utils.Pretty ( prettyShow )
+import qualified Agda.Utils.ProfileOptions as Profile
 
 import Agda.Utils.Impossible
 
@@ -312,6 +313,7 @@ useInjectivity dir blocker ty blk neu = locallyTC eInjectivityDepth succ $ do
       reportSDoc "tc.inj.use" 30 $ fsep $
         pwords "useInjectivity on" ++
         [ prettyTCM blk, prettyTCM cmp, prettyTCM neu, prettyTCM ty]
+      whenProfile Profile.Conversion $ tick "compare by reduction: injectivity"
       let canReduceToSelf = Map.member (ConsHead f) hdMap || Map.member UnknownHead hdMap
       case neu of
         -- f us == f vs  <=>  us == vs
@@ -329,6 +331,7 @@ useInjectivity dir blocker ty blk neu = locallyTC eInjectivityDepth succ $ do
           fs  <- getForcedArgs f
           pol <- getPolarity' cmp f
           reportSDoc "tc.inj.invert.success" 20 $ hsep ["Successful spine comparison of", prettyTCM f]
+          whenProfile Profile.Conversion $ tick "compare by reduction: injectivity successful"
           app (compareElims pol fs fTy (Def f [])) blkArgs neuArgs
 
         -- f us == c vs

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20221012 * 10 + 0
+currentInterfaceVersion = 20221017 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -35,6 +35,7 @@ import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Utils.Pretty (Pretty, prettyShow)
+import qualified Agda.Utils.ProfileOptions as Profile
 import Agda.Utils.Singleton
 import Agda.Utils.Size
 import Agda.Utils.Tuple
@@ -315,6 +316,7 @@ compareSizes cmp u v = verboseBracket "tc.conv.size" 10 "compareSizes" $ do
       nest 2 $ sep [ pretty u <+> prettyTCM cmp
                    , pretty v
                    ]
+  whenProfile Profile.Conversion $ tick "compare sizes"
   us <- sizeMaxView u
   vs <- sizeMaxView v
   compareMaxViews cmp us vs

--- a/src/full/Agda/Utils/ProfileOptions.hs
+++ b/src/full/Agda/Utils/ProfileOptions.hs
@@ -35,6 +35,7 @@ data ProfileOption = Internal     -- ^ Measure time taken by various parts of th
                    | Constraints  -- ^ Collect statistics about constraint solving
                    | Metas        -- ^ Count number of created metavariables
                    | Interactive  -- ^ Measure time of interactive commands
+                   | Conversion   -- ^ Collect statistics about conversion checking
   deriving (Show, Eq, Ord, Enum, Bounded, Generic)
 
 instance NFData ProfileOption
@@ -104,4 +105,3 @@ profileOptionsToList (ProfileOpts opts) = Set.toList opts
 -- | Use only for serialization.
 profileOptionsFromList :: [ProfileOption] -> ProfileOptions
 profileOptionsFromList opts = ProfileOpts $ Set.fromList opts
-

--- a/test/Fail/Issue5781a.err
+++ b/test/Fail/Issue5781a.err
@@ -1,4 +1,4 @@
 Issue5781a.agda:1,1-35
 Not a valid profiling option: 'notclose'. Valid options are
-constraints, definitions, interactive, internal, metas, modules,
-serialize, sharing, or all.
+constraints, conversion, definitions, interactive, internal, metas,
+modules, serialize, sharing, or all.


### PR DESCRIPTION
This adds some counters for the various different phases of conversion checking. At the time of writing, running Agda with `--profile=conversion` gives the following statistics on the standard library:
```
comparing at eta record type            5,297
comparing at pi type                   22,805
comparing equal terms                 454,818
comparing irrelevant terms                960
comparing levels                       77,437
comparing sizes                         1,642
comparing sorts                       133,801
comparing terms                       967,728
comparing terms by reduction          297,738
eta-expanding at unit type                417
eta-expanding equation at record type   4,486
injectivity successful                  1,457
meta shortcut                         203,147
meta shortcut successful              200,427
trying injectivity                      3,157
trying to solve meta                  325,815
```
and the following counts for the Cubical library:
```
comparing at eta record type             36,857
comparing at face type                   27,303
comparing at interval type                3,215
comparing at path type                   19,354
comparing at pi type                    166,584
comparing equal terms                 1,197,759
comparing irrelevant terms                2,645
comparing levels                        132,665
comparing sorts                         149,990
comparing terms                       2,577,746
comparing terms by reduction            681,727
eta-expanding at unit type                  575
eta-expanding equation at record type    30,786
first-order shortcut                     84,816
injectivity successful                      706
meta shortcut                           405,738
meta shortcut successful                370,504
trying injectivity                        6,772
trying to solve meta                    585,458
```
In particular, this might help with answering questions such as "how often are we *actually* relying on eta-equality during conversion checking? (Answer: about 0.5% of the total number of conversion checks, about 1% of the non-trivial ones).

This is the first time I'm doing anything with the profiling machinery and I must say it was really easy to use. But if anything could be done in a more idiomatic way I'd be glad to hear. Also, should I add anything about this to the documentation?