### PR TITLE
Bump workflows to latest virtual environments and Haskell versions

### DIFF
--- a/.github/workflows/cabal-test.yml
+++ b/.github/workflows/cabal-test.yml
@@ -68,12 +68,12 @@ jobs:
       fail-fast: false
       matrix:
         cabal-ver:
-        - latest
+        - '3.8'
         ghc-ver:
-        - '9.2'
+        - '9.4'
         os:
-        - ubuntu-latest
-        - macos-latest
+        - ubuntu-22.04
+        - macos-12
     timeout-minutes: 150
 name: cabal-test
 'on':

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         cabal-ver:
-        - latest
+        - '3.8'
         ghc-ver:
         - 9.4.2
         - 9.2.4
@@ -98,17 +98,21 @@ jobs:
         - 8.8.4
         - 8.6.5
         - 8.4.4
-        - 8.2.2
-        - 8.0.2
         include:
-        - cabal-ver: 3.6.2.0
+        - cabal-ver: '3.8'
+          ghc-ver: 8.0.2
+          os: ubuntu-20.04
+        - cabal-ver: '3.8'
+          ghc-ver: 8.2.2
+          os: ubuntu-20.04
+        - cabal-ver: '3.8'
           ghc-ver: 9.4.2
-          os: macos-latest
-        - cabal-ver: latest
+          os: macos-12
+        - cabal-ver: '3.8'
           ghc-ver: 9.4.2
-          os: windows-latest
+          os: windows-2022
         os:
-        - ubuntu-20.04
+        - ubuntu-22.04
     timeout-minutes: 60
 name: Build (cabal)
 'on':

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,13 +150,13 @@ jobs:
       fail-fast: false
       matrix:
         cabal-ver:
-        - 3.6
+        - '3.8'
         ghc-ver:
-        - '9.2'
+        - '9.4'
         os:
-        - windows-2022
+        - windows-latest
         - macos-latest
-        - ubuntu-18.04
+        - ubuntu-latest
   deploy:
     if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'workflow_run'
       }}

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -62,11 +62,11 @@ jobs:
     strategy:
       matrix:
         cabal-ver:
-        - latest
+        - '3.8'
         ghc-ver:
-        - '9.2'
+        - '9.4'
         os:
-        - ubuntu-latest
+        - ubuntu-22.04
 name: Haddock
 'on':
   pull_request:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,13 +12,13 @@ jobs:
       && !contains(github.event.head_commit.message, '[ci skip]')
       && !contains(github.event.head_commit.message, '[github skip]')
       && !contains(github.event.head_commit.message, '[skip github]')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.1
+    - uses: actions/checkout@v3
     - name: Set up hlint
       uses: rwe/actions-hlint-setup@v1
       with:
-        version: 3.1.6
+        version: '3.5'
     - name: Run hlint
       uses: rwe/actions-hlint-run@v2
       with:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -73,11 +73,6 @@ jobs:
       run: |
         echo "PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
       shell: bash
-    - if: ${{ runner.os == 'Linux' }}
-      name: Install the icu library (Ubuntu)
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install libicu-dev -qq
     - if: ${{ runner.os == 'Windows' }}
       name: Install the icu library (Windows)
       run: |
@@ -101,26 +96,26 @@ jobs:
       fail-fast: false
       matrix:
         ghc-ver:
+        - 9.2.4
+        - 9.0.2
         - 8.10.7
         - 8.8.4
         - 8.6.5
         - 8.4.4
-        - 8.2.2
-        - 8.0.2
         include:
-        - ghc-ver: 9.2.4
+        - ghc-ver: 8.2.2
           os: ubuntu-20.04
-          stack-ver: latest
-        - ghc-ver: 9.0.2
+          stack-ver: 2.9.1
+        - ghc-ver: 8.0.2
           os: ubuntu-20.04
-          stack-ver: latest
+          stack-ver: 2.9.1
         - ghc-ver: 9.2.4
-          os: macos-latest
-          stack-ver: latest
+          os: macos-12
+          stack-ver: 2.9.1
         os:
-        - ubuntu-18.04
+        - ubuntu-22.04
         stack-ver:
-        - latest
+        - 2.9.1
     timeout-minutes: 60
 name: Build (stack)
 'on':

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,11 +47,9 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-01-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-02-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
-    - name: Install and configure the icu library
-      run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
     - if: ${{ !steps.cache.outputs.cache-hit }}
       name: Install dependencies for Agda and its test suites
       run: make STACK_OPTS=--silent install-deps
@@ -87,9 +85,9 @@ jobs:
         ghc-ver:
         - 9.2.4
         os:
-        - ubuntu-20.04
+        - ubuntu-22.04
         stack-ver:
-        - latest
+        - 2.9.1
   cubical:
     needs: build
     runs-on: ${{ needs.build.outputs.os }}
@@ -113,7 +111,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-02-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -145,7 +143,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-02-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -184,7 +182,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-02-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -224,7 +222,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-02-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Suite of tests for bugs

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -12,7 +12,7 @@ jobs:
       && !contains(github.event.head_commit.message, '[ci skip]')
       && !contains(github.event.head_commit.message, '[github skip]')
       && !contains(github.event.head_commit.message, '[skip github]')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout agda sources
       uses: actions/checkout@v3
@@ -44,11 +44,11 @@ jobs:
     strategy:
       matrix:
         cabal-ver:
-        - latest
+        - '3.8'
         fix-whitespace-ver:
         - 0.0.10
         ghc-ver:
-        - '9.2'
+        - '9.4'
 name: Whitespace
 'on':
   pull_request: null

--- a/src/github/workflows/cabal-test.yml
+++ b/src/github/workflows/cabal-test.yml
@@ -44,15 +44,15 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
+          - ubuntu-22.04
+          - macos-12
           # - windows-latest
           ## Andreas, 2021-08-28, giving up on running the test-suite under Windows.
           ## There is e.g. https://github.com/phile314/tasty-silver/issues/16
           ## that may be responsible that diffs are not shown,
           ## and that prevents me from running the test-suite interactively.
-        ghc-ver: ['9.2']
-        cabal-ver: [latest]
+        ghc-ver: ['9.4']
+        cabal-ver: ['3.8']
 
     steps:
     - uses: actions/checkout@v3
@@ -60,10 +60,6 @@ jobs:
         submodules: recursive
 
     - uses: haskell/actions/setup@v2
-        # Andreas, 2022-10-07.
-        # @v2 pulls in cabal 3.8.1.0 which has atm a problem with the pkgconfig-depends
-        # of text-icu-0.8.0 on macos-latest.  However, as we do not supply the flag
-        # -fenable-cluster-counting here, we do not depend on text-icu and are fine.
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc-ver }}

--- a/src/github/workflows/cabal-test.yml
+++ b/src/github/workflows/cabal-test.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: Ubuntu-latest # Required, but it can be anything here.
 
     steps:
-    - uses: styfle/cancel-workflow-action@0.10.1
+    - uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: Ubuntu-latest # Required, but it can be anything here.
 
     steps:
-    - uses: styfle/cancel-workflow-action@0.10.1
+    - uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -44,22 +44,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        ghc-ver: [9.4.2, 9.2.4, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
-        cabal-ver: [latest]
+        os: [ubuntu-22.04]
+        ghc-ver: [9.4.2, 9.2.4, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4]
+        cabal-ver: ['3.8']
         include:
-          - os: macos-latest
+          # Andreas, 2022-10-18
+          # Installation of 8.0.2 and 8.2.2 for ubuntu-22.04 (jammy) fails
+          # because there is no hvr-ppa for jammy.
+          # (The other versions are supported via ghcup.)
+          - os: ubuntu-20.04
+            ghc-ver: 8.0.2
+            cabal-ver: '3.8'
+          - os: ubuntu-20.04
+            ghc-ver: 8.2.2
+            cabal-ver: '3.8'
+          # macOS
+          - os: macos-12
             ghc-ver: 9.4.2
-            cabal-ver: 3.6.2.0
-              # Andreas, 2022-10-07.
-              # Stick to cabal 3.6 on macOS, since
-              # text-icu-0.8.0.2 does not work with cabal 3.8.1.0 there
-              # because some mysterious pkg-config problem. See:
-              # - https://github.com/haskell/cabal/pull/8496
-              # - https://github.com/actions/runner-images/issues/6364
-          - os: windows-latest
+            cabal-ver: '3.8'
+          # Windows
+          - os: windows-2022
             ghc-ver: 9.4.2
-            cabal-ver: latest
+            cabal-ver: '3.8'
     env:
       FLAGS: "-f enable-cluster-counting"
       # ICU_URL: 'https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-Win64-MSVC2019.zip'

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -25,18 +25,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Andreas, 2022-04-30, issue #5874
-        # statically linked executables with GHC 9.2.2 broke on ubuntu-20.04
-        # on 2022-04-08
-        # Reverting to ubuntu-18.04 fixes this for the moment.
-        os: [windows-2022, macos-latest, ubuntu-18.04]
-        ghc-ver: ['9.2']
-        cabal-ver: [3.6]
-          # Andreas, 2022-10-07.
-          # Switching to cabal 3.8.1.0 will likely cause problems on macOS
-          # as long as the issue with pkg-config exists, see:
-          # - https://github.com/haskell/cabal/pull/8496
-          # - https://github.com/actions/runner-images/issues/6364
+        # Andreas, 2022-10-18
+        # We stick to '-latest' virtual environments here in the sense of
+        # "most canonical", since this is the deploy action.
+        # As of today, this is [windows-2022, macOS-11, ubuntu-20.04].
+        os: [windows-latest, macos-latest, ubuntu-latest]
+        ghc-ver: ['9.4']
+        cabal-ver: ['3.8']
 
     env:
       ARGS: "--disable-executable-profiling --disable-library-profiling"
@@ -103,15 +98,6 @@ jobs:
       with:
         ghc-version: ${{ matrix.ghc-ver }}
         cabal-version: ${{ matrix.cabal-ver }}
-
-    # DOES NOT HELP
-    # # Workaround suggested in https://gitlab.haskell.org/ghc/ghc/-/issues/21454#note_425291
-    # # Force reinstall of GHC 9.2.2 from ubuntu binaries
-    # - name: Force reinstall of GHC 9.2.2 (Linux)
-    #   if: ${{ runner.os == 'Linux' }}
-    #   run: |
-    #     ghcup config set url-source '{"OwnSource": "https://raw.githubusercontent.com/haskell/ghcup-metadata/ubuntu20.04/ghcup-0.0.7.yaml"}'
-    #     ghcup install ghc --force --set 9.2.2
 
     - name: Set up pkg-config for the ICU library (macOS)
       if: ${{ runner.os == 'macOS' }}

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: Ubuntu-latest
     steps:
-    - uses: styfle/cancel-workflow-action@0.10.1
+    - uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
   build:

--- a/src/github/workflows/haddock.yml
+++ b/src/github/workflows/haddock.yml
@@ -1,7 +1,7 @@
 name: Haddock
 # Test documentation: haddock, user-manual.
-# Since `stack haddock` compiles Agda but `cabal haddock` does
-# not, this test is faster using `BUILD=CABAL` [Issue #2188].
+# Since `stack haddock` compiles Agda but `cabal haddock` does not,
+# we use cabal if we just want to build the haddockumentation [Issue #2188].
 on:
   push:
     branches:
@@ -19,9 +19,14 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        ghc-ver: ['9.2']
-        cabal-ver: [latest]
+        # Andreas, 2022-10-18
+        # Don't use 'latest' when you want the latest version,
+        # since this often does not point at the latest version;
+        # not for the virtual environments, and also haskell/action/setup
+        # is usually not up-to-date.
+        os: [ubuntu-22.04]
+        ghc-ver: ['9.4']
+        cabal-ver: ['3.8']
 
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')

--- a/src/github/workflows/lint.yaml
+++ b/src/github/workflows/lint.yaml
@@ -29,18 +29,16 @@ jobs:
       && !contains(github.event.head_commit.message, '[github skip]')
       && !contains(github.event.head_commit.message, '[skip github]')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.1
-    # NOTE: Because `src/fix-whitespace` currently has lint warnings, (See
-    # https://github.com/agda/fix-whitespace/pull/8), we do not checking out
-    # submodules recursively here like we normally do. Perhaps the submodule
-    # should be moved to a separate non-linted directory like lib/.
+    - uses: actions/checkout@v3
+    # We don't currently have any submodules that need hlinting,
+    # so we don't checkout submodules recursively here.
 
     - name: Set up hlint
       uses: rwe/actions-hlint-setup@v1
       with:
-        version: '3.1.6'
+        version: '3.5'
 
     - name: Run hlint
       uses: rwe/actions-hlint-run@v2

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: Ubuntu-latest # Required, but it can be anything here.
 
     steps:
-    - uses: styfle/cancel-workflow-action@0.10.1
+    - uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
   stack:

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -42,42 +42,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
-        stack-ver: [latest]
-        # Andreas, 2022-03-26:
-        # Note: ghc-ver needs to be spelled out with minor version, i.e., x.y.z
-        # rather than x.y (which haskell-setup would resolve to a suitable .z)
-        # because ghc-ver is to pick the stack-$(ghc-ver).yaml file.
-        # If switching to a new GHC minor version needs manual action, i.e.,
-        # adding the respective stack-x.y.z.yaml file.
-        ghc-ver: [8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
-          # Andreas, 2022-03-10: the LTS for GHC 8.10 has text-icu-0.7.1.0
-          # (sarting with LTS 17.14).  Our stack-8.y.z.yaml files
-          # declare extra-dep text-icu-0.7.1.0 (rather than using 0.7.0.1 from LTS).
-          # text-icu-0.7 works on ubuntu-18 but not on ubuntu-20, as the latter
-          # has a too new ICU library (requires text-icu-0.8).
-          # We could update the vm to ubuntu-20.04, but then we would have
-          # to put text-icu-0.8.0.1 as extra-dep into the stack.yaml files.
-          # This might draw more extra-deps after it, so let's not do it
-          # while we can still run ubuntu-18.
-          # (This also means that we test both text-icu-0.7 and -0.8).
+        os: [ubuntu-22.04]
+        stack-ver: ['2.9.1']
+        ghc-ver: [9.2.4, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4]
+          # Andreas, 2022-03-26:
+          # Note: ghc-ver needs to be spelled out with minor version, i.e., x.y.z
+          # rather than x.y (which haskell-setup would resolve to a suitable .z)
+          # because ghc-ver is to pick the stack-$(ghc-ver).yaml file.
+          # If switching to a new GHC minor version needs manual action, i.e.,
+          # adding the respective stack-x.y.z.yaml file.
         include:
+          # Andreas, 2022-10-18
+          # system-ghc installation of 8.0 and 8.2 fails on ubuntu-22.04
+          # (maybe stack could install it).
           - os: ubuntu-20.04
-            ghc-ver: 9.2.4
-            stack-ver: latest
+            ghc-ver: 8.2.2
+            stack-ver: '2.9.1'
           - os: ubuntu-20.04
-            ghc-ver: 9.0.2
-            stack-ver: latest
-          - os: macos-latest
+            ghc-ver: 8.0.2
+            stack-ver: '2.9.1'
+          - os: macos-12
             ghc-ver: 9.2.4
-            stack-ver: latest
+            stack-ver: '2.9.1'
           # Andreas, 2022-10-06, issue #6128
           # The action stalls. Last message is "installing agda-mode in ...".
-          # Happens also on windows-2019.  I have no clue what causes this.
-          # Temporarily disable the windows build, maybe stack 2.9.1 will fix this.
-          # - os: windows-latest
+          # Happens on windows-2019 and windows-2022, with stack 2.7.5 and 2.9.1.
+          # I have no clue what causes this.
+          # Temporarily disable the windows build.
+          # - os: windows-2022
           #   ghc-ver: 9.2.4
-          #   stack-ver: latest
+          #   stack-ver: '2.9.1'
     # # Try "allowed-failure" for Windows with GHC 9.2
     # continue-on-error: ${{ startsWith(matrix.os, 'windows') && startsWith(matrix.ghc-ver,'9.2') }}
     env:
@@ -159,11 +153,12 @@ jobs:
       run: |
         echo "PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
 
-    - name: Install the icu library (Ubuntu)
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install libicu-dev -qq
+    # # On ubuntu >= 20.04, ICU is already installed.
+    # - name: Install the icu library (Ubuntu)
+    #   if: ${{ matrix.os == 'ubuntu-18.04' }}
+    #   run: |
+    #     sudo apt-get update -qq
+    #     sudo apt-get install libicu-dev -qq
 
     # Note that msys2 libraries have to be installed via
     #   stack exec ${ARGS} -- pacman ...

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -63,8 +63,11 @@ jobs:
         # ghc-ver should be given as x.y.z (as opposed to x.y only)
         # because it is used verbatim when referring to stack-x.y.z.yaml.
         ghc-ver: ['9.2.4']
-        stack-ver: [latest]
-        os: [ubuntu-20.04]
+        stack-ver: ['2.9.1']
+        os: [ubuntu-22.04]
+          # Andreas, 2022-10-18
+          # - on ubuntu-22.04 with stack-2.7.5 I experienced a build failure:
+          #   libicuuc.so.66: cannot open shared object file: No such file or directory
 
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
@@ -109,10 +112,11 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-01-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-02-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
-    - name: "Install and configure the icu library"
-      run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
+    # ICU is already installed on ubuntu >= 20.04
+    # - name: "Install and configure the icu library"
+    #   run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
 
     - name: "Install dependencies for Agda and its test suites"
       if: ${{ !steps.cache.outputs.cache-hit }}
@@ -183,7 +187,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-02-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Suite of tests for bugs"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" bugs
@@ -265,7 +269,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-02-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
@@ -320,7 +324,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-02-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
@@ -375,7 +379,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-01-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-02-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: styfle/cancel-workflow-action@0.10.1
+    - uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 

--- a/src/github/workflows/user_manual.yml
+++ b/src/github/workflows/user_manual.yml
@@ -30,7 +30,7 @@ jobs:
         submodules: recursive
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/src/github/workflows/whitespace.yml
+++ b/src/github/workflows/whitespace.yml
@@ -15,12 +15,12 @@ jobs:
       && !contains(github.event.head_commit.message, '[github skip]')
       && !contains(github.event.head_commit.message, '[skip github]')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        ghc-ver: ['9.2']
-        cabal-ver: [latest]
+        ghc-ver: ['9.4']
+        cabal-ver: ['3.8']
         # stack-ver: [2.5.1]
         fix-whitespace-ver: [0.0.10]
 

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -41,7 +41,7 @@ extra-deps:
 - vector-0.12.3.1
 - vector-hashtables-0.1.1.1
 - wcwidth-0.0.2
-- text-icu-0.7.1.0
+- text-icu-0.8.0.2
 
 # instead of time-1.9, we add time-compat
 - time-compat-1.9.2.2

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -3,6 +3,7 @@ compiler: ghc-8.10.7
 compiler-check: match-exact
 
 extra-deps:
+- text-icu-0.8.0.2
 - vector-hashtables-0.1.1.1
 
 # Local packages, usually specified by relative directory name

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -38,7 +38,7 @@ extra-deps:
 - vector-0.12.3.1
 - vector-hashtables-0.1.1.1
 - wcwidth-0.0.2
-- text-icu-0.7.1.0
+- text-icu-0.8.0.2
 
 # instead of time-1.9, we add time-compat
 - time-compat-1.9.5

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -22,7 +22,7 @@ extra-deps:
 - uuid-types-1.0.3
 - strict-0.4.0.1
 - tagged-0.8.6.1
-- text-icu-0.7.1.0
+- text-icu-0.8.0.2
 - th-abstraction-0.4.5.0
 - these-1.1.1.1
 - unordered-containers-0.2.19.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -17,7 +17,7 @@ extra-deps:
 - strict-0.4.0.1
 - these-1.1.1.1
 - uuid-types-1.0.3
-- text-icu-0.7.1.0
+- text-icu-0.8.0.2
 - vector-hashtables-0.1.1.1
 
 # Local packages, usually specified by relative directory name

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -8,7 +8,7 @@ extra-deps:
 - random-1.2.0
 - splitmix-0.1.0.3
 - strict-0.4.0.1
-- text-icu-0.7.1.0
+- text-icu-0.8.0.2
 - vector-hashtables-0.1.1.1
 
 # Local packages, usually specified by relative directory name

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,8 +1,9 @@
-resolver: lts-19.24
+resolver: lts-19.29
 compiler: ghc-9.0.2
 compiler-check: match-exact
 
 extra-deps:
+- text-icu-0.8.0.2
 - vector-hashtables-0.1.1.1
 
 # Local packages, usually specified by relative directory name

--- a/stack-9.2.4.yaml
+++ b/stack-9.2.4.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-09-19
+resolver: nightly-2022-10-18
 compiler: ghc-9.2.4
 compiler-check: match-exact
 

--- a/test/api/Makefile
+++ b/test/api/Makefile
@@ -17,3 +17,8 @@ all : Issue1168.api PrettyInterface.api ScopeFromInterface.api
 
 clean :
 	rm -f *.agdai *.hi *.o
+
+debug :
+	@echo "GHC     = ${GHC}"
+	@echo "AGDA    = ${AGDA}"
+	@echo "VERSION = ${VERSION}"


### PR DESCRIPTION
Haskell versions:
- GHC 9.4
- Cabal 3.8
- Stack 2.9

Virtual environments:
- Ubuntu-22.04
- macOS-12
- Windows-2022

Observations:
- Ubuntu >= 20.04 does not need ICU installation.
- Ubuntu-22.04 cannot install GHC 8.0 and 8.2 with haskell/actions/setup
  because hvr-ppa does not exist for this version.
- `text-icu-0.8.0.2` needed to drop Ubuntu 18.04 (update `stack-*.yaml` files)
