### PR TITLE
re #6060: remove partial matching on trFillTel

### DIFF
--- a/test/Fail/Issue6060.agda
+++ b/test/Fail/Issue6060.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --cubical --prop -WnoNoEquivWhenSplitting #-}
+
+open import Agda.Builtin.Equality
+
+data S : Set where s : S
+data P : Prop where p : P
+
+-- OK
+f : (x : S) → P → s ≡ x → S
+f .s y refl = s
+
+-- Panic
+g : (x : S) → s ≡ x → P → S
+g .s refl y = s

--- a/test/Fail/Issue6060.err
+++ b/test/Fail/Issue6060.err
@@ -1,0 +1,5 @@
+Issue6060.agda:14,1-16
+Could not generate a transport clause for g
+because a term of type P
+lives in the sort Prop and thus can not be transported
+when checking the definition of g


### PR DESCRIPTION
PR just to make sure everything will be green, it's a simple fix: replaces `Right d_f <- trFillTel ...` patterns by a function which wraps failures to transport in an actual type error. 