### PR TITLE
Fix #5702: DefP can't cover VarP

### DIFF
--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -455,7 +455,7 @@ matchPat p q = case p of
     IApplyP _ _ _ x -> blockedOnConstructor (splitPatVarIndex x) c ci
 
   DefP o c ps -> unDotP q >>= \case
-    VarP _ x -> __IMPOSSIBLE__ -- blockedOnConstructor (splitPatVarIndex x) c
+    VarP _ x -> no
     ConP c' i qs -> no
     DotP o t  -> no
     LitP{}    -> no

--- a/test/interaction/PartialHigherSplit.agda
+++ b/test/interaction/PartialHigherSplit.agda
@@ -1,0 +1,36 @@
+{-# OPTIONS --cubical --safe #-}
+module PartialHigherSplit where
+
+open import Agda.Primitive
+open import Agda.Builtin.Nat
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Cubical.Path
+
+data ℤ : Set where
+  pos : (n : Nat) → ℤ
+  neg : (n : Nat) → ℤ
+  posneg : pos 0 ≡ neg 0
+
+-- copied and adapted from Cubical.Data.Int.MoreInts.QuoInt.Base
+
+sucℤ : ℤ → ℤ
+sucℤ (pos n)       = pos (suc n)
+sucℤ (neg zero)    = pos 1
+sucℤ (neg (suc n)) = neg n
+sucℤ (posneg _)    = pos 1
+
+predℤ : ℤ → ℤ
+predℤ (neg n)       = neg (suc n)
+predℤ (pos zero)    = neg 1
+predℤ (pos (suc n)) = pos n
+predℤ (posneg _)    = neg 1
+
+_+ℤ_ : ℤ → ℤ → ℤ
+m +ℤ (pos (suc n)) = sucℤ   (m +ℤ pos n)
+m +ℤ (neg (suc n)) = predℤ  (m +ℤ neg n)
+m +ℤ _             = m
+
+0+ : ∀ a → pos zero +ℤ a ≡ a
+0+ (pos (suc n)) = {!   !}
+0+ (neg (suc n)) = {!   !}
+0+ a = {! a !}

--- a/test/interaction/PartialHigherSplit.in
+++ b/test/interaction/PartialHigherSplit.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 2 cmd_make_case "a"

--- a/test/interaction/PartialHigherSplit.out
+++ b/test/interaction/PartialHigherSplit.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : (pos zero +ℤ pos (suc n)) ≡ pos (suc n) ?1 : (pos zero +ℤ neg (suc n)) ≡ neg (suc n) ?2 : (pos zero +ℤ a) ≡ a " nil)
+((last . 1) . (agda2-goals-action '(0 1 2)))
+((last . 2) . (agda2-make-case-action '("0+ (pos n) = ?" "0+ (neg n) = ?" "0+ (posneg i) = ?")))
+((last . 1) . (agda2-goals-action '(0 1 2)))


### PR DESCRIPTION
I _think_ this is correct: DefP matches on hcomp/transpIx, and while it's technically possible for a substitution of interval variables to cause an `hcomp {φ} u u0` to cover some other pattern, IApplyConfluence means that even if this happens the RHS-es are definitionally equal. Is this right?

(Issue references can't be in titles..? Fixes #5702)