### PR TITLE
re #6017: add a Call for IApplyConfluence

### DIFF
--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -1254,7 +1254,7 @@ createMissingHCompClause f n x old_sc (SClause tel ps _sigma' _cps (Just t)) cs 
               case x of
                 Left bad_t -> cannotCreate "Cannot transport with type family:" bad_t
                 Right args -> return args
-          comp <- mkComp "hcompClause"
+          comp <- mkCompLazy "hcompClause"
           let
             hcomp la bA phi u u0 = pure tHComp <#> la <#> bA
                                                <#> phi

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3137,6 +3137,16 @@ data Call
   | CheckWithFunctionType Type
   | CheckSectionApplication Range ModuleName A.ModuleApplication
   | CheckNamedWhere ModuleName
+  -- | Checking a clause for confluence with endpoint reductions. Always
+  -- @φ ⊢ f vs = rhs@ for now, but we store the simplifications of
+    -- @f vs[φ]@ and @rhs[φ]@.
+  | CheckIApplyConfluence
+      Range  -- ^ Clause range
+      QName  -- ^ Function name
+      Term   -- ^ (As-is) Function applied to the patterns in this clause
+      Term   -- ^ (Simplified) Function applied to the patterns in this clause
+      Term   -- ^ (Simplified) clause RHS
+      Type   -- ^ (Simplified) clause type
   | ScopeCheckExpr C.Expr
   | ScopeCheckDeclaration NiceDeclaration
   | ScopeCheckLHS C.QName C.Pattern
@@ -3181,43 +3191,45 @@ instance Pretty Call where
     pretty CheckConfluence{}         = "CheckConfluence"
     pretty NoHighlighting{}          = "NoHighlighting"
     pretty ModuleContents{}          = "ModuleContents"
+    pretty CheckIApplyConfluence{}   = "ModuleContents"
 
 instance HasRange Call where
-    getRange (CheckClause _ c)               = getRange c
-    getRange (CheckLHS lhs)                  = getRange lhs
-    getRange (CheckPattern p _ _)            = getRange p
-    getRange (CheckPatternLinearityType x)   = getRange x
-    getRange (CheckPatternLinearityValue x)  = getRange x
-    getRange (InferExpr e)                   = getRange e
-    getRange (CheckExprCall _ e _)           = getRange e
-    getRange (CheckLetBinding b)             = getRange b
-    getRange (CheckProjection r _ _)         = r
-    getRange (IsTypeCall cmp e s)            = getRange e
-    getRange (IsType_ e)                     = getRange e
-    getRange (InferVar x)                    = getRange x
-    getRange (InferDef f)                    = getRange f
-    getRange (CheckArguments r _ _ _)        = r
-    getRange (CheckMetaSolution r _ _ _)     = r
-    getRange (CheckTargetType r _ _)         = r
-    getRange (CheckDataDef i _ _ _)          = getRange i
-    getRange (CheckRecDef i _ _ _)           = getRange i
-    getRange (CheckConstructor _ _ _ c)      = getRange c
-    getRange (CheckConstructorFitsIn c _ _)  = getRange c
-    getRange (CheckFunDefCall i _ _ _)       = getRange i
-    getRange (CheckPragma r _)               = r
-    getRange (CheckPrimitive i _ _)          = getRange i
-    getRange CheckWithFunctionType{}         = noRange
-    getRange (CheckNamedWhere m)             = getRange m
-    getRange (ScopeCheckExpr e)              = getRange e
-    getRange (ScopeCheckDeclaration d)       = getRange d
-    getRange (ScopeCheckLHS _ p)             = getRange p
-    getRange (CheckDotPattern e _)           = getRange e
-    getRange (SetRange r)                    = r
-    getRange (CheckSectionApplication r _ _) = r
-    getRange (CheckIsEmpty r _)              = r
-    getRange (CheckConfluence rule1 rule2)   = max (getRange rule1) (getRange rule2)
-    getRange NoHighlighting                  = noRange
-    getRange ModuleContents                  = noRange
+    getRange (CheckClause _ c)                   = getRange c
+    getRange (CheckLHS lhs)                      = getRange lhs
+    getRange (CheckPattern p _ _)                = getRange p
+    getRange (CheckPatternLinearityType x)       = getRange x
+    getRange (CheckPatternLinearityValue x)      = getRange x
+    getRange (InferExpr e)                       = getRange e
+    getRange (CheckExprCall _ e _)               = getRange e
+    getRange (CheckLetBinding b)                 = getRange b
+    getRange (CheckProjection r _ _)             = r
+    getRange (IsTypeCall cmp e s)                = getRange e
+    getRange (IsType_ e)                         = getRange e
+    getRange (InferVar x)                        = getRange x
+    getRange (InferDef f)                        = getRange f
+    getRange (CheckArguments r _ _ _)            = r
+    getRange (CheckMetaSolution r _ _ _)         = r
+    getRange (CheckTargetType r _ _)             = r
+    getRange (CheckDataDef i _ _ _)              = getRange i
+    getRange (CheckRecDef i _ _ _)               = getRange i
+    getRange (CheckConstructor _ _ _ c)          = getRange c
+    getRange (CheckConstructorFitsIn c _ _)      = getRange c
+    getRange (CheckFunDefCall i _ _ _)           = getRange i
+    getRange (CheckPragma r _)                   = r
+    getRange (CheckPrimitive i _ _)              = getRange i
+    getRange CheckWithFunctionType{}             = noRange
+    getRange (CheckNamedWhere m)                 = getRange m
+    getRange (ScopeCheckExpr e)                  = getRange e
+    getRange (ScopeCheckDeclaration d)           = getRange d
+    getRange (ScopeCheckLHS _ p)                 = getRange p
+    getRange (CheckDotPattern e _)               = getRange e
+    getRange (SetRange r)                        = r
+    getRange (CheckSectionApplication r _ _)     = r
+    getRange (CheckIsEmpty r _)                  = r
+    getRange (CheckConfluence rule1 rule2)       = max (getRange rule1) (getRange rule2)
+    getRange NoHighlighting                      = noRange
+    getRange ModuleContents                      = noRange
+    getRange (CheckIApplyConfluence e _ _ _ _ _) = getRange e
 
 ---------------------------------------------------------------------------
 -- ** Instance table

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -61,6 +61,7 @@ interestingCall = \case
     CheckDataDef{}            -> True
     CheckRecDef{}             -> True
     CheckConstructor{}        -> True
+    CheckIApplyConfluence{}   -> True
     CheckConstructorFitsIn{}  -> True
     CheckFunDefCall{}         -> True
     CheckPragma{}             -> True
@@ -190,6 +191,7 @@ instance MonadTrace TCM where
       CheckPrimitive{}          -> True
       CheckIsEmpty{}            -> True
       CheckConfluence{}         -> False
+      CheckIApplyConfluence{}   -> False
       CheckWithFunctionType{}   -> True
       CheckSectionApplication{} -> True
       CheckNamedWhere{}         -> False

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -15,6 +15,7 @@ import Agda.Syntax.Translation.AbstractToConcrete
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Context
+import Agda.TypeChecking.Monad.Closure
 import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Pretty
 
@@ -195,6 +196,17 @@ instance PrettyTCM Call where
       info = A.ModuleInfo noRange noRange Nothing Nothing Nothing
 
     ModuleContents -> fsep $ pwords "when retrieving the contents of a module"
+
+    CheckIApplyConfluence _ qn fn l r t -> do
+      vcat
+        [ fsep (pwords "when checking that a clause of" ++ [prettyTCM qn] ++ pwords "has the correct boundary.")
+        , ""
+        , "Specifically, the terms"
+        , nest 2 (prettyTCM l)
+        , "and"
+        , nest 2 (prettyTCM r)
+        , fsep (pwords "must be equal, since" ++ [prettyTCM fn] ++ pwords "could reduce to either.")
+        ]
 
     where
     hPretty :: MonadPretty m => Arg (Named_ Expr) -> m Doc

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1015,9 +1015,9 @@ instance Simplify Term where
       Def f vs   -> iapp vs $ do
         let keepGoing simp v = return (simp, notBlocked v)
         (simpl, v) <- unfoldDefinition' False keepGoing (Def f []) f vs
-        traceSDoc "tc.simplify'" 90 (
-          text ("simplify': unfolding definition returns " ++ show simpl)
-            <+> pretty (ignoreBlocking v)) $ do
+        when (simpl == YesSimplification) $
+          reportSDoc "tc.simplify'" 90 $
+            pretty f <+> text ("simplify': unfolding definition returns " ++ show simpl) <+> pretty (ignoreBlocking v)
         case simpl of
           YesSimplification -> simplifyBlocked' v -- Dangerous, but if @simpl@ then @v /= Def f vs@
           NoSimplification  -> Def f <$> simplify' vs

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -600,7 +600,7 @@ checkSystemCoverage f [n] t cs = do
              initWithDefault __IMPOSSIBLE__ $ List.tails pcs) $ \ ((phi1,cl1):pcs') -> do
         forM_ pcs' $ \ (phi2,cl2) -> do
           phi12 <- reduce (imin `apply` [argN phi1, argN phi2])
-          forallFaceMaps phi12 (\ _ _ -> __IMPOSSIBLE__) $ \ sigma -> do
+          forallFaceMaps phi12 (\ _ _ -> __IMPOSSIBLE__) $ \_ sigma -> do
             let args = sigma `applySubst` teleArgs gamma
                 t' = sigma `applySubst` t
                 fromReduced (YesReduction _ x) = x

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1110,7 +1110,7 @@ checkLHS mf = updateModality checkLHS_ where
          phi <- reduce phi
          reportSDoc "tc.lhs.split.partial" 10 $ text "phi (reduced) =" <+> prettyTCM phi
          refined <- forallFaceMaps phi (\ bs m t -> typeError $ GenericError $ "face blocked on meta")
-                            (\ sigma -> (,sigma) <$> getContextTelescope)
+                            (\_ sigma -> (,sigma) <$> getContextTelescope)
          case refined of
            [(gamma,sigma)] -> return (gamma,sigma)
            []              -> typeError $ GenericError $ "The face constraint is unsatisfiable."

--- a/test/Fail/IApplyConfluence.err
+++ b/test/Fail/IApplyConfluence.err
@@ -1,3 +1,3 @@
-IApplyConfluence.agda:15,1-9
+IApplyConfluence.agda:18,1-20
 true != false of type Bool
 when checking the definition of decideEq

--- a/test/Fail/Issue3572.err
+++ b/test/Fail/Issue3572.err
@@ -4,6 +4,6 @@ Termination checking failed for the following functions:
 Problematic calls:
   id (sq i1)
     (at Issue3572.agda:20,12-14)
-Issue3572.agda:17,1-3
+Issue3572.agda:18,1-10
 id (sq i0) != left of type Interval
 when checking the definition of id

--- a/test/Fail/Issue5838.err
+++ b/test/Fail/Issue5838.err
@@ -1,3 +1,13 @@
-Issue5838.agda:210,1-4
+Issue5838.agda:211,1-6
 false != true of type Bool
-when checking the definition of bad
+when checking that a clause of bad has the correct boundary.
+
+Specifically, the terms
+  false
+and
+  transp
+  (λ i →
+     DoubleCover
+     (transp (twisted-square i) (primIMin i1 (primIMax i (~ i))) base))
+  i0 false
+must be equal, since bad i1 could reduce to either.

--- a/test/Fail/Issue5838b.err
+++ b/test/Fail/Issue5838b.err
@@ -1,3 +1,13 @@
-Issue5838b.agda:218,1-5
+Issue5838b.agda:219,1-7
 false != true of type Bool
-when checking the definition of bad'
+when checking that a clause of bad' has the correct boundary.
+
+Specifically, the terms
+  false
+and
+  transp
+  (λ i →
+     DoubleCover
+     (transp (twisted-square' i) (primIMin i1 (primIMax i (~ i))) base))
+  i0 false
+must be equal, since bad' i1 could reduce to either.

--- a/test/Fail/Issue6017.agda
+++ b/test/Fail/Issue6017.agda
@@ -1,0 +1,24 @@
+{-# OPTIONS --cubical --no-double-check  #-}
+
+module Issue6017 where
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Builtin.Cubical.Path
+open import Agda.Primitive.Cubical
+  renaming (primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primComp to comp ; primHComp to hcomp)
+
+_∙_ : ∀ {ℓ} {A : Type ℓ} {x y z : A} → x ≡ y → y ≡ z → x ≡ z
+(p ∙ q) i = hcomp (λ { j (i = i0) → p i0 ; j (i = i1) → q j }) (p i)
+
+refl : ∀ {ℓ} {A : Type ℓ} (x : A) → x ≡ x
+refl x i = x
+
+data T : Type where
+  base : T
+  p    : base ≡ base
+  surf : p ∙ p ≡ p
+
+f : (x : T) → x ≡ x
+f base       = refl T.base
+f (p i)      = refl (p i)
+f (surf i j) = refl (surf i j)

--- a/test/Fail/Issue6017.err
+++ b/test/Fail/Issue6017.err
@@ -1,0 +1,11 @@
+Issue6017.agda:24,1-13
+(~ j ∨ j) ∨ ~ i ∨ i != ~ j ∨ j of type I
+when checking that a clause of f has the correct boundary.
+
+Specifically, the terms
+  comp
+  (λ i .o → f ((λ { i₁ (j = i0) → p i0 ; i₁ (j = i1) → p i₁ }) i _))
+  (refl (p j))
+and
+  refl (surf i0 j)
+must be equal, since f (surf i0 j) could reduce to either.

--- a/test/Fail/Issue6108.err
+++ b/test/Fail/Issue6108.err
@@ -4,6 +4,6 @@ Termination checking failed for the following functions:
 Problematic calls:
   r i
     (at Issue6108.agda:23,26-27)
-Issue6108.agda:26,1-6
+Issue6108.agda:27,1-8
 x != r i0 .R.force of type D
 when checking the definition of loops

--- a/test/Fail/PathWithBoundary.err
+++ b/test/Fail/PathWithBoundary.err
@@ -1,3 +1,3 @@
-PathWithBoundary.agda:17,1-20,16
-suc (w + m) != m of type Nat
+PathWithBoundary.agda:20,1-12
+suc (q + m) != m of type Nat
 when checking the definition of PathWithBoundary.with-18

--- a/test/interaction/Issue4679.out
+++ b/test/interaction/Issue4679.out
@@ -4,6 +4,6 @@
 (agda2-status-action "")
 (agda2-info-action "*All Goals, Errors*" "?0 : Foo → Set ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: ?0 (baz tt) =< ⊥ (blocked on _B_35) Unit =< ?0 (bar tt) (blocked on _B_35) " nil)
 ((last . 1) . (agda2-goals-action '(0)))
-(agda2-info-action "*Error*" "1,1-43 ((λ { (bar _) → Unit ; (baz _) → ⊥ ; _ → ⊥ ; (primHComp {.Agda.Primitive.lzero} {.Foo} {φ = φ} u a) → primHComp (λ i .o → transp (λ i₁ → Set) i (.extendedlambda0 p₁ (u i _))) (transp (λ i → Set) i0 (.extendedlambda0 p₁ a)) }) x) != ⊥ of type Set when checking the definition of .extendedlambda0" nil)
+(agda2-info-action "*Error*" "1,36-37 ((λ { (bar _) → Unit ; (baz _) → ⊥ ; _ → ⊥ ; (primHComp {.Agda.Primitive.lzero} {.Foo} {φ = φ} u a) → primComp (λ i .o → .extendedlambda0 p₁ (u i _)) (.extendedlambda0 p₁ a) }) x) != ⊥ of type Set when checking the definition of .extendedlambda0" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")


### PR DESCRIPTION
Fix half of #6017. Before:
```
(~ i ∨ i) ∨ ~ i₁ ∨ i₁ != ~ i ∨ i of type I
when checking the definition of f
```

After:
```
(~ j ∨ j) ∨ ~ i ∨ i != ~ j ∨ j of type I
when checking that a clause of f has the correct boundary.

Specifically, the terms
  comp
  (λ i .o → f ((λ { i₁ (j = i0) → p i0 ; i₁ (j = i1) → p i₁ }) i _))
  (refl (p j))
and
  refl (surf i0 j)
must be equal, since f (surf i0 j) could reduce to either.
```

Other than the most obvious change, note that the variable names are now the ones the user specified, instead of having `i₁` for `i` and `i` for `j`. Previously, `IApplyConfluence` used the `clauseTel` from the covering clauses, which has its `ArgName`s drawn from the types of the constructors; in the case of `T.surf`, the names are both `i`, since `T.surf : PathP (λ i → PathP (λ i → ...`. I made the coverage checker draw the `ArgName`s (only!) from the user patterns. (That's `renTeleFromNap`, which I think is funny, but could be changed to `renTeleFromNAPs` to be consistent).

Two tiny changes got caught up in this PR: Using the clause range for IApplyConfluence (previously it used the range associated with the function), and not treating `comp ... → hcomp ...` reductions as simplifications.