### PR TITLE
re #6047: Just enough injectivity with --cubical

### DIFF
--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -152,7 +152,7 @@ instance NamesIn Defn where
     PrimitiveSort _ s  -> namesAndMetasIn' sg s
     AbstractDefn{}     -> __IMPOSSIBLE__
     -- Andreas 2017-07-27, Q: which names can be in @cc@ which are not already in @cl@?
-    Function cl cc _ _ _ _ _ _ _ _ _ _ el _
+    Function cl cc _ _ _ _ _ _ _ _ _ _ el _ _
       -> namesAndMetasIn' sg (cl, cc, el)
     Datatype _ _ cl cs s _ _ _ trX trD
       -> namesAndMetasIn' sg (cl, cs, s, trX, trD)
@@ -319,7 +319,7 @@ instance NamesIn ExtLamInfo where
 instance NamesIn a => NamesIn (FunctionInverse' a) where
   namesAndMetasIn' sg = \case
     NotInjective -> mempty
-    Inverse _ m  -> namesAndMetasIn' sg m
+    Inverse m  -> namesAndMetasIn' sg m
 
 instance NamesIn TTerm where
   namesAndMetasIn' sg = \case

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -824,6 +824,7 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
                , funExtLam       = Nothing
                , funWith         = Nothing
                , funCovering     = []
+               , funIsKanOp      = Nothing
                }
   addConstant' (conName genRecCon) defaultArgInfo (conName genRecCon) __DUMMY_TYPE__ $ -- Filled in later
     Constructor { conPars   = 0

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -52,6 +52,7 @@ import qualified Data.Set as Set
 import Data.Maybe
 import Data.Traversable hiding (for)
 import Data.Semigroup ((<>))
+import Data.Foldable (fold)
 
 import qualified Agda.Syntax.Abstract.Name as A
 import Agda.Syntax.Common
@@ -62,6 +63,9 @@ import Agda.TypeChecking.Datatypes
 import Agda.TypeChecking.Irrelevance (isIrrelevantOrPropM)
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute
+import Agda.TypeChecking.Telescope.Path
+import Agda.TypeChecking.Primitive.Base
+import Agda.TypeChecking.Primitive.Cubical
 import Agda.TypeChecking.Reduce
 import {-# SOURCE #-} Agda.TypeChecking.MetaVars
 import {-# SOURCE #-} Agda.TypeChecking.Conversion
@@ -138,6 +142,7 @@ isUnstableDef qn = do
     [ builtinHComp
     , builtinComp
     , builtinTrans
+    , builtinGlue
     , builtin_glue
     , builtin_glueU ]
   case theDef defn of
@@ -225,6 +230,15 @@ checkInjectivity' f cs = fromMaybe NotInjective <.> runMaybeT $ do
       -- hasDefP clauses are skipped, these matter only for --cubical, in which case the function will behave as NotInjective.
       computeHead c@Clause{ clauseBody = Just body , clauseType = Just tbody } = addContext (clauseTel c) $ do
         maybeIrr <- fromRight (const True) <.> runBlocked $ isIrrelevantOrPropM tbody
+        -- We treat ordinary clauses with IApply copatterns as
+        -- *immediately* failing the injectivity check. Consider e.g.
+        --   foo x = T
+        --   foo (y i) = Glue U λ { (i = i0) → T , _ ; (i = i1) → T , _ }
+        -- seeing foo α = Glue ... and inverting it to α = y β loses solutions. E.g. if we
+        -- later had some other α = x, now we're screwed, x ≠ y β. But if we had postponed
+        -- originally we'd just compare T = Glue ... which has a chance of going through.
+        let ivars = iApplyVars (namedClausePats c)
+        guard (null ivars)
         h <- if maybeIrr then return UnknownHead else
           varToArg c =<< do
             lift $ fromMaybe UnknownHead <$> do

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -230,8 +230,8 @@ checkInjectivity' f cs = fromMaybe NotInjective <.> runMaybeT $ do
       -- hasDefP clauses are skipped, these matter only for --cubical, in which case the function will behave as NotInjective.
       computeHead c@Clause{ clauseBody = Just body , clauseType = Just tbody } = addContext (clauseTel c) $ do
         maybeIrr <- fromRight (const True) <.> runBlocked $ isIrrelevantOrPropM tbody
-        -- We treat ordinary clauses with IApply copatterns as
-        -- *immediately* failing the injectivity check. Consider e.g.
+        -- We treat ordinary clauses with IApply copatterns as *immediately*
+        -- failing the injectivity check. Consider e.g.
         --   foo x = T
         --   foo (y i) = Glue U λ { (i = i0) → T , _ ; (i = i1) → T , _ }
         -- seeing foo α = Glue ... and inverting it to α = y β loses solutions. E.g. if we

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1621,7 +1621,7 @@ instance InstantiateFull System where
 
 instance InstantiateFull FunctionInverse where
   instantiateFull' NotInjective = return NotInjective
-  instantiateFull' (Inverse w inv) = Inverse w <$> instantiateFull' inv
+  instantiateFull' (Inverse inv) = Inverse <$> instantiateFull' inv
 
 instance InstantiateFull a => InstantiateFull (Case a) where
   instantiateFull' (Branches cop cs eta ls m b lz) =

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -791,6 +791,7 @@ defineTranspIx d = do
                   , _funProjection = Nothing
                   , _funMutual     = Just []
                   , _funTerminates = Just True
+                  , _funIsKanOp    = Just d
                   }
         inTopContext $ do
          reportSDoc "tc.transpx.type" 15 $ vcat
@@ -901,6 +902,7 @@ defineTranspFun d mtrX cons pathCons = do
                   , _funProjection = Nothing
                   , _funMutual     = Just []
                   , _funTerminates = Just True
+                  , _funIsKanOp    = Just d
                   }
         inTopContext $ addConstant trD $
           (defaultDefn defaultArgInfo trD theType (Cubical CErased) $ FunctionDefn fun)
@@ -1363,7 +1365,7 @@ defineTranspForFields pathCons applyProj name params fsT fns rect = do
   lang <- getLanguage
   noMutualBlock $ addConstant theName $
     (defaultDefn defaultArgInfo theName theType lang
-       (FunctionDefn $ emptyFunctionData { _funTerminates = Just True }))
+       (FunctionDefn $ emptyFunctionData { _funTerminates = Just True, _funIsKanOp = Just name }))
       { defNoCompilation = True }
   -- ⊢ Γ = gamma = (δ : Δ^I) (φ : I) (u0 : R (δ i0))
   -- Γ ⊢     rtype = R (δ i1)
@@ -1521,7 +1523,7 @@ defineHCompForFields applyProj name params fsT fns rect = do
   lang <- getLanguage
   noMutualBlock $ addConstant theName $
     (defaultDefn defaultArgInfo theName theType lang
-       (FunctionDefn $ emptyFunctionData { _funTerminates = Just True }))
+       (FunctionDefn $ emptyFunctionData { _funTerminates = Just True, _funIsKanOp = Just name }))
       { defNoCompilation = True }
   --   ⊢ Γ = gamma = (δ : Δ) (φ : I) (_ : (i : I) -> Partial φ (R δ)) (_ : R δ)
   -- Γ ⊢     rtype = R δ

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20221017 * 10 + 0
+currentInterfaceVersion = 20221022 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -369,7 +369,7 @@ instance EmbPrj EtaEquality where
 
 instance EmbPrj Defn where
   icod_ (Axiom       a)                                 = icodeN 0 Axiom a
-  icod_ (Function    a b s t u c d e f g h i j k)       = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k
+  icod_ (Function    a b s t u c d e f g h i j k l)     = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k l
   icod_ (Datatype    a b c d e f g h i j)               = icodeN 2 Datatype a b c d e f g h i j
   icod_ (Record      a b c d e f g h i j k l m)         = icodeN 3 Record a b c d e f g h i j k l m
   icod_ (Constructor a b c d e f g h i j)               = icodeN 4 Constructor a b c d e f g h i j
@@ -380,15 +380,15 @@ instance EmbPrj Defn where
   icod_ DataOrRecSig{}                                  = __IMPOSSIBLE__
 
   value = vcase valu where
-    valu [0, a]                                     = valuN Axiom a
-    valu [1, a, b, s, u, c, d, e, f, g, h, i, j, k] = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k
-    valu [2, a, b, c, d, e, f, g, h, i, j]          = valuN Datatype a b c d e f g h i j
-    valu [3, a, b, c, d, e, f, g, h, i, j, k, l, m] = valuN Record   a b c d e f g h i j k l m
-    valu [4, a, b, c, d, e, f, g, h, i, j]          = valuN Constructor a b c d e f g h i j
-    valu [5, a, b, c, d, e]                         = valuN Primitive   a b c d e
-    valu [6, a, b]                                  = valuN PrimitiveSort a b
-    valu [7]                                        = valuN GeneralizableVar
-    valu _                                          = malformed
+    valu [0, a]                                        = valuN Axiom a
+    valu [1, a, b, s, u, c, d, e, f, g, h, i, j, k, l] = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k l
+    valu [2, a, b, c, d, e, f, g, h, i, j]             = valuN Datatype a b c d e f g h i j
+    valu [3, a, b, c, d, e, f, g, h, i, j, k, l, m]    = valuN Record   a b c d e f g h i j k l m
+    valu [4, a, b, c, d, e, f, g, h, i, j]             = valuN Constructor a b c d e f g h i j
+    valu [5, a, b, c, d, e]                            = valuN Primitive   a b c d e
+    valu [6, a, b]                                     = valuN PrimitiveSort a b
+    valu [7]                                           = valuN GeneralizableVar
+    valu _                                             = malformed
 
 instance EmbPrj LazySplit where
   icod_ StrictSplit = icodeN' StrictSplit
@@ -451,22 +451,13 @@ instance EmbPrj CompiledClauses where
     valu [2, a, b] = valuN Case a b
     valu _         = malformed
 
-instance EmbPrj WhenInjective where
-  icod_ AlwaysInjective = icodeN 0 AlwaysInjective
-  icod_ UnlessCubical   = icodeN 1 UnlessCubical
-
-  value = vcase valu where
-    valu [0] = valuN AlwaysInjective
-    valu [1] = valuN UnlessCubical
-    valu _   = malformed
-
 instance EmbPrj a => EmbPrj (FunctionInverse' a) where
   icod_ NotInjective = icodeN' NotInjective
-  icod_ (Inverse w a)  = icodeN' Inverse w a
+  icod_ (Inverse a)  = icodeN' Inverse a
 
   value = vcase valu where
     valu []  = valuN NotInjective
-    valu [w,a] = valuN Inverse w a
+    valu [a] = valuN Inverse a
     valu _   = malformed
 
 instance EmbPrj TermHead where

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -520,7 +520,7 @@ instance Apply a => Apply (Case a) where
 
 instance Apply FunctionInverse where
   apply NotInjective  args = NotInjective
-  apply (Inverse w inv) args = Inverse w $ apply inv args
+  apply (Inverse inv) args = Inverse $ apply inv args
 
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
 
@@ -757,7 +757,7 @@ namedTelVars m (ExtendTel !dom tel) =
 
 instance Abstract FunctionInverse where
   abstract tel NotInjective  = NotInjective
-  abstract tel (Inverse w inv) = Inverse w $ abstract tel inv
+  abstract tel (Inverse inv) = Inverse $ abstract tel inv
 
 instance {-# OVERLAPPABLE #-} Abstract t => Abstract [t] where
   abstract tel = map (abstract tel)

--- a/test/Succeed/Issue6047.agda
+++ b/test/Succeed/Issue6047.agda
@@ -1,0 +1,28 @@
+{-# OPTIONS --cubical #-}
+
+module Issue6047 where
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.Nat
+open import Agda.Primitive
+
+data Fin : Nat → Set where
+  zero : {n : Nat} → Fin (suc n)
+  suc  : {n : Nat} (i : Fin n) → Fin (suc n)
+
+data ⊥ : Set where
+
+toℕ : ∀ {n} → Fin n → Nat
+toℕ zero    = 0
+toℕ (suc i) = suc (toℕ i)
+
+postulate
+  inj-toℕ : {n : Nat} {k l : Fin n} → (toℕ k ≡ toℕ l) → k ≡ l
+  isSetℕ : (x y : Nat) (p q : x ≡ y) → p ≡ q
+
+ap : ∀ {A : Set} {B : A → Set} (f : ∀ x → B x) → ∀ {x y : A} (p : x ≡ y)
+   → PathP (λ i → B (p i)) (f x) (f y)
+ap f p i = f (p i)
+
+inj-cong : {n : Nat} {k l : Fin n} → (p : toℕ k ≡ toℕ l) → ap toℕ (inj-toℕ p) ≡ p
+inj-cong p = isSetℕ _ _ _ _


### PR DESCRIPTION
I think there once was an injective function called Goldilocks?

Fixes #6047, and _doesn't_ break #5576 and #5579. Rather than banning any function which matches on a "freely Kan type" (that is: higher inductive types, and, assuming --cubical, indexed inductive types) from being injective, it suffices _not_ to consider `f (hcomp φ u u0)` and `f (transpX ...)` to be "constructor-headed", and skip inverting these applications.