### PR TITLE
Made --cubical-compatible less coinfective

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -910,7 +910,10 @@ used in all modules that depend on this module. The following options
 are infective:
 
 * ``--prop``
-* ``--rewriting``
+* :option:`--rewriting`
+* ``--guarded``
+* ``--two-level``
+* :option:`--cumulativity`
 
 Furthermore :option:`--cubical` and :option:`--erased-cubical` are
 *jointly infective*: if one of them is used in one module, then one or

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -952,29 +952,40 @@ again, the source file is re-typechecked instead:
 * :option:`--no-termination-check`
 * :option:`--type-in-type`
 * :option:`--omega-in-omega`
+* :option:`--cumulativity`
 * :option:`--no-sized-types`
 * :option:`--no-guardedness`
 * :option:`--injective-type-constructors`
 * ``--prop``
+* ``--two-level``
 * :option:`--no-universe-polymorphism`
 * :option:`--irrelevant-projections`
 * :option:`--experimental-irrelevance`
 * :option:`--without-K`
+* :option:`--cubical-compatible`
 * :option:`--exact-split`
 * :option:`--no-eta-equality`
 * :option:`--rewriting`
 * :option:`--cubical`
+* :option:`--erased-cubical`
+* ``--guarded``
 * :option:`--overlapping-instances`
+* ``--qualified-instances``
 * :option:`--safe`
 * :option:`--double-check`
-* :option:`--no-syntactic-equality`
+* :option:`--syntactic-equality`
 * :option:`--no-auto-inline`
 * :option:`--no-fast-reduce`
+* :option:`--call-by-name`
 * :option:`--instance-search-depth`
 * :option:`--inversion-max-depth`
 * :option:`--warning`
+* :option:`--local-confluence-check`
+* :option:`--confluence-check`
+* :option:`--no-import-sorts`
 * :option:`--allow-exec`
 * :option:`--save-metas`
+* :option:`--erase-record-parameters`
 
 
 .. _Vim: https://www.vim.org/

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -909,9 +909,12 @@ An *infective* option is an option that if used in one module, must be
 used in all modules that depend on this module. The following options
 are infective:
 
-* :option:`--cubical`
 * ``--prop``
 * ``--rewriting``
+
+Furthermore :option:`--cubical` and :option:`--erased-cubical` are
+*jointly infective*: if one of them is used in one module, then one or
+the other must be used in all modules that depend on this module.
 
 A *coinfective* option is an option that if used in one module, must
 be used in all modules that this module depends on. The following

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -919,10 +919,20 @@ options are coinfective:
 
 * :option:`--safe`
 * :option:`--without-K`
-* :option:`--cubical-compatible`
 * :option:`--no-universe-polymorphism`
 * :option:`--no-sized-types`
 * :option:`--no-guardedness`
+
+Furthermore the option :option:`--cubical-compatible` is mostly
+coinfective. If a module uses :option:`--cubical-compatible` then all
+modules that this module imports (directly) must also use
+:option:`--cubical-compatible`, with the following exception: if a
+module uses both :option:`--cubical-compatible` and
+:option:`--with-K`, then it is not required to use
+:option:`--cubical-compatible` in (directly) imported modules that use
+:option:`--with-K`. (Note that one cannot use
+:option:`--cubical-compatible` and :option:`--with-K` at the same time
+if :option:`--safe` is used.)
 
 Agda records the options used when generating an interface file. If
 any of the following options differ when trying to load the interface

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -543,8 +543,7 @@ infectiveCoinfectiveOptions :: [InfectiveCoinfectiveOption]
 infectiveCoinfectiveOptions =
   [ coinfectiveOption optSafe "--safe"
   , coinfectiveOption (collapseDefault . optWithoutK) "--without-K"
-  , coinfectiveOption (collapseDefault . optCubicalCompatible)
-                      "--cubical-compatible"
+  , cubicalCompatible
   , coinfectiveOption (not . optUniversePolymorphism)
                       "--no-universe-polymorphism"
   , coinfectiveOption (not . optCumulativity) "--no-cumulativity"
@@ -556,6 +555,26 @@ infectiveCoinfectiveOptions =
   , infectiveOption (collapseDefault . optSizedTypes) "--sized-types"
   , infectiveOption (collapseDefault . optGuardedness) "--guardedness"
   ]
+  where
+  cubicalCompatible =
+    (coinfectiveOption
+       (collapseDefault . optCubicalCompatible)
+       "--cubical-compatible")
+      { icOptionOK = \current imported ->
+        -- One must use --cubical-compatible in the imported module if
+        -- it is used in the current module, except if the current
+        -- module also uses --with-K and not --safe, and the imported
+        -- module uses --with-K.
+        if collapseDefault (optCubicalCompatible current)
+        then collapseDefault (optCubicalCompatible imported)
+               ||
+             not (collapseDefault (optWithoutK imported))
+               &&
+             not (collapseDefault (optWithoutK current))
+               &&
+             not (optSafe current)
+        else True
+      }
 
 inputFlag :: FilePath -> Flag CommandLineOptions
 inputFlag f o =

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3896,9 +3896,9 @@ data Warning
     -- ^ Some imported names are not actually exported by the source module.
     --   The second argument is the names that could be exported.
     --   The third  argument is the module names that could be exported.
-  | InfectiveImport String ModuleName
+  | InfectiveImport Doc
     -- ^ Importing a file using an infective option into one which doesn't
-  | CoInfectiveImport String ModuleName
+  | CoInfectiveImport Doc
     -- ^ Importing a file not using a coinfective option from one which does
   | RewriteNonConfluent Term Term Term Doc
     -- ^ Confluence checker found critical pair and equality checking

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -255,13 +255,9 @@ prettyWarning = \case
 
     LibraryWarning lw -> pretty lw
 
-    InfectiveImport o m -> fsep $
-      pwords "Importing module" ++ [pretty m] ++ pwords "using the" ++
-      [pretty o] ++ pwords "flag from a module which does not."
+    InfectiveImport msg -> return msg
 
-    CoInfectiveImport o m -> fsep $
-      pwords "Importing module" ++ [pretty m] ++ pwords "not using the" ++
-      [pretty o] ++ pwords "flag from a module which does."
+    CoInfectiveImport msg -> return msg
 
     RewriteNonConfluent lhs rhs1 rhs2 err -> fsep
       [ "Local confluence check failed:"

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20221022 * 10 + 0
+currentInterfaceVersion = 20221024 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -63,8 +63,8 @@ instance EmbPrj Warning where
     IllformedAsClause a                   -> icodeN 15 IllformedAsClause a
     WithoutKFlagPrimEraseEquality         -> icodeN 16 WithoutKFlagPrimEraseEquality
     InstanceWithExplicitArg a             -> icodeN 17 InstanceWithExplicitArg a
-    InfectiveImport a b                   -> icodeN 18 InfectiveImport a b
-    CoInfectiveImport a b                 -> icodeN 19 CoInfectiveImport a b
+    InfectiveImport a                     -> icodeN 18 InfectiveImport a
+    CoInfectiveImport a                   -> icodeN 19 CoInfectiveImport a
     InstanceNoOutputTypeName a            -> icodeN 20 InstanceNoOutputTypeName a
     InstanceArgWithExplicitArg a          -> icodeN 21 InstanceArgWithExplicitArg a
     WrongInstanceDeclaration              -> icodeN 22 WrongInstanceDeclaration
@@ -106,8 +106,8 @@ instance EmbPrj Warning where
     [15, a]              -> valuN IllformedAsClause a
     [16]                 -> valuN WithoutKFlagPrimEraseEquality
     [17, a]              -> valuN InstanceWithExplicitArg a
-    [18, a, b]           -> valuN InfectiveImport a b
-    [19, a, b]           -> valuN CoInfectiveImport a b
+    [18, a]              -> valuN InfectiveImport a
+    [19, a]              -> valuN CoInfectiveImport a
     [20, a]              -> valuN InstanceNoOutputTypeName a
     [21, a]              -> valuN InstanceArgWithExplicitArg a
     [22]                 -> valuN WrongInstanceDeclaration
@@ -269,6 +269,15 @@ instance EmbPrj Doc where
   icod_ d = icodeN' (undefined :: String -> Doc) (render d)
 
   value = valueN text
+
+instance EmbPrj InfectiveCoinfective where
+  icod_ Infective   = icodeN' Infective
+  icod_ Coinfective = icodeN 0 Coinfective
+
+  value = vcase valu where
+    valu []  = valuN Infective
+    valu [0] = valuN Coinfective
+    valu _   = malformed
 
 instance EmbPrj PragmaOptions where
   icod_ = \case

--- a/test/Succeed/Issue6220.agda
+++ b/test/Succeed/Issue6220.agda
@@ -1,0 +1,3 @@
+{-# OPTIONS --with-K --cubical-compatible #-}
+
+import Issue6220.M

--- a/test/Succeed/Issue6220/M.agda
+++ b/test/Succeed/Issue6220/M.agda
@@ -1,0 +1,3 @@
+{-# OPTIONS --with-K #-}
+
+module Issue6220.M where


### PR DESCRIPTION
The option `--cubical-compatible` was made less coinfective, see issue #6220.

The pull request also includes some changes to other pieces of documentation in the section "Consistency checking of options used".