### PR TITLE
re #5448: check that clause target type is usable at modality

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -491,7 +491,7 @@ instance Reify Constraint where
       t <- jMetaType . mvJudgement <$> lookupLocalMeta m
       OfType <$> reify (MetaV m []) <*> reify t
     reify (CheckType t) = JustType <$> reify t
-    reify (UsableAtModality _ mod t) = UsableAtMod mod <$> reify t
+    reify (UsableAtModality _ _ mod t) = UsableAtMod mod <$> reify t
 
 instance (Pretty a, Pretty b) => PrettyTCM (OutputForm a b) where
   prettyTCM (OutputForm r pids unblock c) =
@@ -664,7 +664,7 @@ getConstraintsMentioning norm m = getConstrs instantiateBlockingFull (mentionsMe
         CheckMetaInst{}            -> Nothing
         CheckType t                -> isMeta (unEl t)
         CheckLockedVars t _ _ _    -> isMeta t
-        UsableAtModality ms _ t    -> caseMaybe ms (isMeta t) $ \ s -> isMetaS s `mplus` isMeta t
+        UsableAtModality _ ms _ t  -> caseMaybe ms (isMeta t) $ \ s -> isMetaS s `mplus` isMeta t
 
     isMeta (MetaV m' es_m)
       | m == m' = Just es_m

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1244,7 +1244,6 @@ nonStrictToIrr :: Relevance -> Relevance
 nonStrictToIrr NonStrict = Irrelevant
 nonStrictToIrr rel       = rel
 
-
 ---------------------------------------------------------------------------
 -- * Annotations
 ---------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -156,6 +156,28 @@ instance Pretty Modality where
     , pretty (getCohesion mod)
     ]
 
+-- | Show the attributes necessary to recover a modality, in long-form
+-- (e.g. using at-syntax rather than dots). For the default modality,
+-- the result is at-ω (rather than the empty document). Suitable for
+-- showing modalities outside of binders.
+attributesForModality :: Modality -> Doc
+attributesForModality mod
+  | mod == defaultModality = text "@ω"
+  | otherwise = fsep $ catMaybes [relevance, quantity, cohesion]
+  where
+    relevance = case getRelevance mod of
+      Relevant   -> Nothing
+      Irrelevant -> Just "@irrelevant"
+      NonStrict  -> Just "@shape-irrelevant"
+    quantity = case getQuantity mod of
+      Quantity0{} -> Just "@0"
+      Quantity1{} -> Just "@1"
+      Quantityω{} -> Nothing
+    cohesion = case getCohesion mod of
+      Flat{}       -> Just "@♭"
+      Continuous{} -> Nothing
+      Squash{}     -> Just "@⊤"
+
 instance Pretty (OpApp Expr) where
   pretty (Ordinary e) = pretty e
   pretty (SyntaxBindingLambda r bs e) = pretty (Lam r bs e)

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -294,7 +294,7 @@ solveConstraint_ (HasPTSRule a b)       = hasPTSRule a b
 solveConstraint_ (CheckDataSort q s)    = checkDataSort q s
 solveConstraint_ (CheckMetaInst m)      = checkMetaInst m
 solveConstraint_ (CheckType t)          = checkType t
-solveConstraint_ (UsableAtModality ms mod t) = usableAtModality' ms mod t
+solveConstraint_ (UsableAtModality cc ms mod t) = usableAtModality' ms cc mod t
 
 checkTypeCheckingProblem :: TypeCheckingProblem -> TCM Term
 checkTypeCheckingProblem = \case

--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -901,7 +901,7 @@ createMissingTrXConClause q_trX f n x old_sc c (UE gamma gamma' xTel u v rho tau
   applyModalityToContext mod $ do
     unlessM (asksTC hasQuantity0) $ do
     reportSDoc "tc.cover.trxcon" 20 $ text "testing usable at mod: " <+> pretty mod
-    addContext cTel $ usableAtModality mod rhs
+    addContext cTel $ usableAtModality IndexedClause mod rhs
 
   return cl
 

--- a/src/full/Agda/TypeChecking/Errors.hs-boot
+++ b/src/full/Agda/TypeChecking/Errors.hs-boot
@@ -1,6 +1,7 @@
 module Agda.TypeChecking.Errors where
 
 import Agda.Syntax.Abstract.Name
+import Agda.Syntax.Common
 
 import Agda.TypeChecking.Monad.Base
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug (MonadDebug)

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -510,7 +510,7 @@ usableAtModality' ms why mod t =
 
         justification
           | (cubical || compatible) = "used for computing transports."
-          | otherwise               = "used in substitutions."
+          | otherwise               = "used to compute substitutions in Cubical Agda."
         mod = if Null.null mod' then "@ω" else mod'
 
       case why of

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -94,6 +94,7 @@ import Agda.Utils.Lens
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.WithDefault
+import qualified Agda.Utils.Null as Null
 
 -- | data 'Relevance'
 --   see "Agda.Syntax.Common".
@@ -481,18 +482,44 @@ instance UsableModality a => UsableModality (Arg a) where
 instance UsableModality a => UsableModality (Dom a) where
   usableMod mod Dom{unDom = u} = usableMod mod u
 
-usableAtModality' :: MonadConstraint TCM => Maybe Sort -> Modality -> Term -> TCM ()
-usableAtModality' ms mod t = catchConstraint (UsableAtModality ms mod t) $ do
-  whenM (maybe (pure True) isFibrant ms) $ do
-    res <- runExceptT $ usableMod mod t
-    case res of
-      Right b -> do
-        unless b $
-          typeError . GenericDocError =<< (prettyTCM t <+> "is not usable at the required modality" <+> prettyTCM mod)
-      Left blocker -> patternViolation blocker
+usableAtModality'
+  :: MonadConstraint TCM
+  -- Note: This weird-looking constraint is to trick GHC into accepting
+  -- that an instance of MonadConstraint TCM will exist, even if we
+  -- can't import the module in which it is defined.
+  => Maybe Sort -> WhyCheckModality -> Modality -> Term -> TCM ()
+usableAtModality' ms why mod t =
+  catchConstraint (UsableAtModality why ms mod t) $ do
+    whenM (maybe (pure True) isFibrant ms) $ do
+      res <- runExceptT $ usableMod mod t
+      case res of
+        Right b -> unless b $
+          typeError . GenericDocError =<< formatWhy
+        Left blocker -> patternViolation blocker
+  where
+    formatWhy = do
+      cubes <- isJust . optCubical <$> pragmaOptions
+      let
+        justification = if cubes then "in Cubical Agda," else "when --without-K is enabled,"
+      case why of
+        IndexedClause ->
+          vcat
+            [ fsep ( pwords "This clause has target type"
+                  ++ [prettyTCM t]
+                  ++ pwords "which is not usable at the required modality"
+                  ++ [prettyTCM mod])
+            , ""
+            , fsep ( "Note:":pwords justification
+                  ++ pwords "the target type must be usable at the modality"
+                  ++ pwords "in which the function was defined, since it is"
+                  ++ pwords (if cubes then "used for computing transports." else "used in substitutions.")
+                   )
+            , ""
+            ]
+        _ -> prettyTCM t <+> "is not usable at the required modality" <+> prettyTCM mod
 
 
-usableAtModality :: MonadConstraint TCM => Modality -> Term -> TCM ()
+usableAtModality :: MonadConstraint TCM => WhyCheckModality -> Modality -> Term -> TCM ()
 usableAtModality = usableAtModality' Nothing
 
 

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -508,26 +508,27 @@ usableAtModality' ms why mod t =
           | compatible = "to maintain compatibility with Cubical Agda,"
           | otherwise  = "when --without-K is enabled,"
 
-        justification
-          | (cubical || compatible) = "used for computing transports"
-          | otherwise               = "used to compute substitutions in Cubical Agda"
+        explanation
+          | cubical || compatible =
+            [ ""
+            , fsep ( "Note:":pwords context
+                  ++ pwords "the target type must be usable at the modality"
+                  ++ pwords "in which the function was defined, since it is"
+                  ++ pwords "used for computing transports"
+                  )
+            , ""
+            ]
+          | otherwise = []
 
       case why of
         IndexedClause ->
-          vcat
-            [ fsep ( pwords "This clause has target type"
+          vcat $
+            ( fsep ( pwords "This clause has target type"
                   ++ [prettyTCM t]
                   ++ pwords "which is not usable at the required modality"
                   ++ [pure (attributesForModality mod) <> "."]
                    )
-            , ""
-            , fsep ( "Note:":pwords context
-                  ++ pwords "the target type must be usable at the modality"
-                  ++ pwords "in which the function was defined, since it is"
-                  ++ pwords justification
-                   )
-            , ""
-            ]
+            : explanation)
         _ -> prettyTCM t <+> "is not usable at the required modality"
          <+> pure (attributesForModality mod)
 

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -501,6 +501,7 @@ usableAtModality' ms why mod t =
     formatWhy = do
       compatible <- collapseDefault . optCubicalCompatible <$> pragmaOptions
       cubical <- isJust . optCubical <$> pragmaOptions
+      mod' <- prettyTCM mod
       let
         context
           | cubical    = "in Cubical Agda,"
@@ -510,6 +511,7 @@ usableAtModality' ms why mod t =
         justification
           | (cubical || compatible) = "used for computing transports."
           | otherwise               = "used in substitutions."
+        mod = if Null.null mod' then "@ω" else mod'
 
       case why of
         IndexedClause ->
@@ -517,7 +519,7 @@ usableAtModality' ms why mod t =
             [ fsep ( pwords "This clause has target type"
                   ++ [prettyTCM t]
                   ++ pwords "which is not usable at the required modality"
-                  ++ [prettyTCM mod])
+                  ++ [pure mod])
             , ""
             , fsep ( "Note:":pwords context
                   ++ pwords "the target type must be usable at the modality"
@@ -526,7 +528,7 @@ usableAtModality' ms why mod t =
                    )
             , ""
             ]
-        _ -> prettyTCM t <+> "is not usable at the required modality" <+> prettyTCM mod
+        _ -> prettyTCM t <+> "is not usable at the required modality" <+> pure mod'
 
 
 usableAtModality :: MonadConstraint TCM => WhyCheckModality -> Modality -> Term -> TCM ()

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -83,6 +83,7 @@ import Agda.Interaction.Options
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
+import Agda.Syntax.Concrete.Pretty
 
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
@@ -501,7 +502,6 @@ usableAtModality' ms why mod t =
     formatWhy = do
       compatible <- collapseDefault . optCubicalCompatible <$> pragmaOptions
       cubical <- isJust . optCubical <$> pragmaOptions
-      mod' <- prettyTCM mod
       let
         context
           | cubical    = "in Cubical Agda,"
@@ -509,9 +509,8 @@ usableAtModality' ms why mod t =
           | otherwise  = "when --without-K is enabled,"
 
         justification
-          | (cubical || compatible) = "used for computing transports."
-          | otherwise               = "used to compute substitutions in Cubical Agda."
-        mod = if Null.null mod' then "@ω" else mod'
+          | (cubical || compatible) = "used for computing transports"
+          | otherwise               = "used to compute substitutions in Cubical Agda"
 
       case why of
         IndexedClause ->
@@ -519,7 +518,8 @@ usableAtModality' ms why mod t =
             [ fsep ( pwords "This clause has target type"
                   ++ [prettyTCM t]
                   ++ pwords "which is not usable at the required modality"
-                  ++ [pure mod])
+                  ++ [pure (attributesForModality mod) <> "."]
+                   )
             , ""
             , fsep ( "Note:":pwords context
                   ++ pwords "the target type must be usable at the modality"
@@ -528,7 +528,8 @@ usableAtModality' ms why mod t =
                    )
             , ""
             ]
-        _ -> prettyTCM t <+> "is not usable at the required modality" <+> pure mod'
+        _ -> prettyTCM t <+> "is not usable at the required modality"
+         <+> pure (attributesForModality mod)
 
 
 usableAtModality :: MonadConstraint TCM => WhyCheckModality -> Modality -> Term -> TCM ()

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -123,7 +123,7 @@ instance MentionsMeta Constraint where
     CheckMetaInst m     -> True   -- TODO
     CheckType t         -> mm t
     CheckLockedVars a b c d -> mm ((a, b), (c, d))
-    UsableAtModality ms mod t -> mm (ms, t)
+    UsableAtModality _ ms mod t -> mm (ms, t)
     where
       mm :: forall t. MentionsMeta t => t -> Bool
       mm = mentionsMetas xs

--- a/src/full/Agda/TypeChecking/Pretty/Constraint.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Constraint.hs
@@ -157,7 +157,7 @@ instance PrettyTCM Constraint where
           prettyTCM t <+> "is a well-formed type"
         CheckLockedVars t ty lk lk_ty -> do
           "Lock" <+> prettyTCM lk <+> "|-" <+> prettyTCMCtx TopCtx t <+> ":" <+> prettyTCM ty
-        UsableAtModality ms mod t -> "Is usable at" <+> text (verbalize mod) <+> "modality:" <+> prettyTCM t
+        UsableAtModality _ ms mod t -> "Is usable at" <+> text (verbalize mod) <+> "modality:" <+> prettyTCM t
           -- TODO: print @ms : Maybe Sort@ as well?
 
       where

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -301,7 +301,7 @@ instance Instantiate Constraint where
   instantiate' (CheckDataSort q s)  = CheckDataSort q <$> instantiate' s
   instantiate' c@CheckMetaInst{}    = return c
   instantiate' (CheckType t)        = CheckType <$> instantiate' t
-  instantiate' (UsableAtModality ms mod t) = flip UsableAtModality mod <$> instantiate' ms <*> instantiate' t
+  instantiate' (UsableAtModality cc ms mod t) = flip (UsableAtModality cc) mod <$> instantiate' ms <*> instantiate' t
 
 instance Instantiate CompareAs where
   instantiate' (AsTermsOf a) = AsTermsOf <$> instantiate' a
@@ -938,7 +938,7 @@ instance Reduce Constraint where
   reduce' (CheckDataSort q s)   = CheckDataSort q <$> reduce' s
   reduce' c@CheckMetaInst{}     = return c
   reduce' (CheckType t)         = CheckType <$> reduce' t
-  reduce' (UsableAtModality ms mod t) = flip UsableAtModality mod <$> reduce' ms <*> reduce' t
+  reduce' (UsableAtModality cc ms mod t) = flip (UsableAtModality cc) mod <$> reduce' ms <*> reduce' t
 
 instance Reduce CompareAs where
   reduce' (AsTermsOf a) = AsTermsOf <$> reduce' a
@@ -1105,7 +1105,7 @@ instance Simplify Constraint where
   simplify' (CheckDataSort q s)   = CheckDataSort q <$> simplify' s
   simplify' c@CheckMetaInst{}     = return c
   simplify' (CheckType t)         = CheckType <$> simplify' t
-  simplify' (UsableAtModality ms mod t) = flip UsableAtModality mod <$> simplify' ms <*> simplify' t
+  simplify' (UsableAtModality cc ms mod t) = flip (UsableAtModality cc) mod <$> simplify' ms <*> simplify' t
 
 instance Simplify CompareAs where
   simplify' (AsTermsOf a) = AsTermsOf <$> simplify' a
@@ -1287,7 +1287,7 @@ instance Normalise Constraint where
   normalise' (CheckDataSort q s)   = CheckDataSort q <$> normalise' s
   normalise' c@CheckMetaInst{}     = return c
   normalise' (CheckType t)         = CheckType <$> normalise' t
-  normalise' (UsableAtModality ms mod t) = flip UsableAtModality mod <$> normalise' ms <*> normalise' t
+  normalise' (UsableAtModality cc ms mod t) = flip (UsableAtModality cc) mod <$> normalise' ms <*> normalise' t
 
 instance Normalise CompareAs where
   normalise' (AsTermsOf a) = AsTermsOf <$> normalise' a
@@ -1522,7 +1522,7 @@ instance InstantiateFull Constraint where
     CheckDataSort q s   -> CheckDataSort q <$> instantiateFull' s
     c@CheckMetaInst{}   -> return c
     CheckType t         -> CheckType <$> instantiateFull' t
-    UsableAtModality ms mod t -> flip UsableAtModality mod <$> instantiateFull' ms <*> instantiateFull' t
+    UsableAtModality cc ms mod t -> flip (UsableAtModality cc) mod <$> instantiateFull' ms <*> instantiateFull' t
 
 instance InstantiateFull CompareAs where
   instantiateFull' (AsTermsOf a) = AsTermsOf <$> instantiateFull' a

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1734,7 +1734,7 @@ fitsIn uc forceds t s = do
   withoutK <- withoutKOption
   when withoutK $ do
     q <- viewTC eQuantity
-    usableAtModality' (Just s) (setQuantity q defaultModality) (unEl t)
+    usableAtModality' (Just s) ConstructorType (setQuantity q defaultModality) (unEl t)
 
   fitsIn' withoutK forceds t s
   where

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -73,6 +73,7 @@ import Agda.Utils.Size
 import qualified Agda.Utils.SmallSet as SmallSet
 
 import Agda.Utils.Impossible
+import Agda.Utils.WithDefault
 
 ---------------------------------------------------------------------------
 -- * Definitions by pattern matching
@@ -680,7 +681,7 @@ checkClause
 
 checkClause t withSub c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats rhs0 wh catchall) = do
   cxtNames <- reverse . map (fst . unDom) <$> getContext
-  checkClauseLHS t withSub c $ \ lhsResult@(LHSResult npars delta ps absurdPat trhs patSubst asb psplit) -> do
+  checkClauseLHS t withSub c $ \ lhsResult@(LHSResult npars delta ps absurdPat trhs patSubst asb psplit ixsplit) -> do
         -- Note that we might now be in irrelevant context,
         -- in case checkLeftHandSide walked over an irrelevant projection pattern.
 
@@ -800,7 +801,7 @@ checkRHS
   -> A.RHS                   -- ^ Rhs to check.
   -> TCM (Maybe Term, WithFunctionProblem)
                                               -- Note: the as-bindings are already bound (in checkClause)
-checkRHS i x aps t lhsResult@(LHSResult _ delta ps absurdPat trhs _ _asb _) rhs0 =
+checkRHS i x aps t lhsResult@(LHSResult _ delta ps absurdPat trhs _ _asb _ _) rhs0 =
   handleRHS rhs0 where
 
   handleRHS :: A.RHS -> TCM (Maybe Term, WithFunctionProblem)
@@ -1016,7 +1017,7 @@ checkWithRHS
   -> [A.Clause]                        -- ^ With-clauses to check.
   -> TCM (Maybe Term, WithFunctionProblem)
                                 -- Note: as-bindings already bound (in checkClause)
-checkWithRHS x aux t (LHSResult npars delta ps _absurdPat trhs _ _asb _) vtys0 cs =
+checkWithRHS x aux t (LHSResult npars delta ps _absurdPat trhs _ _asb _ _) vtys0 cs =
   verboseBracket "tc.with.top" 25 "checkWithRHS" $ do
     Bench.billTo [Bench.Typing, Bench.With] $ do
         withArgs <- withArguments vtys0

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -640,10 +640,12 @@ data LHSResult = LHSResult
     -- (Issue 2303).
   , lhsPartialSplit :: IntSet
     -- ^ have we done a partial split?
+  , lhsIndexedSplit :: Bool
+    -- ^ have we split on an indexed type?
   }
 
 instance InstantiateFull LHSResult where
-  instantiateFull' (LHSResult n tel ps abs t sub as psplit) = LHSResult n
+  instantiateFull' (LHSResult n tel ps abs t sub as psplit ixsplit) = LHSResult n
     <$> instantiateFull' tel
     <*> instantiateFull' ps
     <*> instantiateFull' abs
@@ -651,6 +653,7 @@ instance InstantiateFull LHSResult where
     <*> instantiateFull' sub
     <*> instantiateFull' as
     <*> pure psplit
+    <*> pure ixsplit
 
 -- | Check a LHS. Main function.
 --
@@ -689,7 +692,7 @@ checkLeftHandSide call f ps a withSub' strippedPats =
       eqs0 = zipWith3 ProblemEq (map namedArg cps) (map var $ downFrom $ size tel) (flattenTel tel)
 
   let finalChecks :: LHSState a -> TCM a
-      finalChecks (LHSState delta qs0 (Problem eqs rps _) b psplit) = do
+      finalChecks (LHSState delta qs0 (Problem eqs rps _) b psplit ixsplit) = do
 
         reportSDoc "tc.lhs.top" 20 $ vcat
           [ "lhs: final checks with remaining equations"
@@ -701,6 +704,12 @@ checkLeftHandSide call f ps a withSub' strippedPats =
 
         addContext delta $ do
           mapM_ noShadowingOfConstructors eqs
+
+          -- If we're working --without-K, then we have to check the
+          withoutK <- collapseDefault . optWithoutK <$> pragmaOptions
+          mod <- asksTC getModality
+          when (withoutK && ixsplit) $
+            usableAtModality IndexedClause mod (unEl (unArg b))
 
         arity_a <- arityPiPath a
         -- Compute substitution from the out patterns @qs0@
@@ -769,7 +778,7 @@ checkLeftHandSide call f ps a withSub' strippedPats =
 
         let hasAbsurd = not . null $ absurds
 
-        let lhsResult = LHSResult (length cxt) delta qs hasAbsurd b patSub asb (IntSet.fromList $ catMaybes psplit)
+        let lhsResult = LHSResult (length cxt) delta qs hasAbsurd b patSub asb (IntSet.fromList $ catMaybes psplit) ixsplit
 
         -- Debug output
         reportSDoc "tc.lhs.top" 10 $
@@ -862,7 +871,7 @@ checkLHS
 checkLHS mf = updateModality checkLHS_ where
     -- If the target type is irrelevant or in Prop,
     -- we need to check the lhs in irr. cxt. (see Issue 939).
- updateModality cont st@(LHSState tel ip problem target psplit) = do
+ updateModality cont st@(LHSState tel ip problem target psplit _) = do
       let m = getModality target
       applyModalityToContext m $ do
         cont $ over (lhsTel . listTel)
@@ -870,7 +879,7 @@ checkLHS mf = updateModality checkLHS_ where
         -- Andreas, 2018-10-23, issue #3309
         -- the modalities in the clause telescope also need updating.
 
- checkLHS_ st@(LHSState tel ip problem target psplit) = do
+ checkLHS_ st@(LHSState tel ip problem target psplit ixsplit) = do
   reportSDoc "tc.lhs" 40 $ "tel is" <+> prettyTCM tel
   reportSDoc "tc.lhs" 40 $ "ip is" <+> pretty ip
   reportSDoc "tc.lhs" 40 $ "target is" <+> addContext tel (prettyTCM target)
@@ -985,7 +994,7 @@ checkLHS mf = updateModality checkLHS_ where
           ip'      = ip ++ [projP]
           -- drop the projection pattern (already splitted)
           problem' = over problemRestPats tail problem
-      liftTCM $ updateLHSState (LHSState tel ip' problem' target' psplit)
+      liftTCM $ updateLHSState (LHSState tel ip' problem' target' psplit ixsplit)
 
 
     -- Split a Partial.
@@ -1145,7 +1154,7 @@ checkLHS mf = updateModality checkLHS_ where
       -- Compute the new state
       let problem' = set problemEqs eqs' problem
       reportSDoc "tc.lhs.split.partial" 60 $ text (show problem')
-      liftTCM $ updateLHSState (LHSState delta' ip' problem' target' (psplit ++ [Just o_n]))
+      liftTCM $ updateLHSState (LHSState delta' ip' problem' target' (psplit ++ [Just o_n]) ixsplit)
 
 
     splitLit :: Telescope      -- The types of arguments before the one we split on
@@ -1184,7 +1193,7 @@ checkLHS mf = updateModality checkLHS_ where
 
       -- Compute the new state
       let problem' = set problemEqs eqs' problem
-      liftTCM $ updateLHSState (LHSState delta' ip' problem' target' psplit)
+      liftTCM $ updateLHSState (LHSState delta' ip' problem' target' psplit ixsplit)
 
 
     splitCon :: Telescope      -- The types of arguments before the one we split on
@@ -1448,7 +1457,7 @@ checkLHS mf = updateModality checkLHS_ where
 
           -- if rest type reduces,
           -- extend the split problem by previously not considered patterns
-          st' <- liftTCM $ updateLHSState $ LHSState delta' ip' problem' target'' psplit
+          st' <- liftTCM $ updateLHSState $ LHSState delta' ip' problem' target'' psplit (ixsplit || not (null ixs))
 
           reportSDoc "tc.lhs.top" 12 $ sep
             [ "new problem from rest"

--- a/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
@@ -236,7 +236,7 @@ data LHSState a = LHSState
     --   be type-checked in irrelevant mode.
   , _lhsPartialSplit :: ![Maybe Int]
     -- ^ have we splitted with a PartialFocus?
-  , _lhsIndexedSplit :: Bool
+  , _lhsIndexedSplit :: !Bool
     -- ^ Have we split on any indexed inductive types?
   }
 

--- a/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
@@ -236,6 +236,8 @@ data LHSState a = LHSState
     --   be type-checked in irrelevant mode.
   , _lhsPartialSplit :: ![Maybe Int]
     -- ^ have we splitted with a PartialFocus?
+  , _lhsIndexedSplit :: Bool
+    -- ^ Have we split on any indexed inductive types?
   }
 
 lhsTel :: Lens' Telescope (LHSState a)
@@ -409,7 +411,7 @@ instance InstantiateFull AsBinding where
   instantiateFull' (AsB x v a m) = AsB x <$> instantiateFull' v <*> instantiateFull' a <*> pure m
 
 instance PrettyTCM (LHSState a) where
-  prettyTCM (LHSState tel outPat (Problem eqs rps _) target _) = vcat
+  prettyTCM (LHSState tel outPat (Problem eqs rps _) target _ _) = vcat
     [ "tel             = " <+> prettyTCM tel
     , "outPat          = " <+> addContext tel (prettyTCMPatternList outPat)
     , "problemEqs      = " <+> addContext tel (prettyList_ $ map prettyTCM eqs)

--- a/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
@@ -104,14 +104,14 @@ initLHSState delta eqs ps a ret = do
   let problem = Problem eqs ps ret
       qs0     = teleNamedArgs delta
 
-  updateProblemRest $ LHSState delta qs0 problem (defaultArg a) []
+  updateProblemRest $ LHSState delta qs0 problem (defaultArg a) [] False
 
 -- | Try to move patterns from the problem rest into the problem.
 --   Possible if type of problem rest has been updated to a function type.
 updateProblemRest
   :: forall m a. (PureTCM m, MonadError TCErr m, MonadTrace m, MonadFresh NameId m)
   => LHSState a -> m (LHSState a)
-updateProblemRest st@(LHSState tel0 qs0 p@(Problem oldEqs ps ret) a psplit) = addContext tel0 $ do
+updateProblemRest st@(LHSState tel0 qs0 p@(Problem oldEqs ps ret) a psplit ixsplit) = addContext tel0 $ do
   ps <- insertImplicitPatternsT ExpandLast ps $ unArg a
   reportSDoc "tc.lhs.imp" 20 $
     "insertImplicitPatternsT returned" <+> fsep (map prettyA ps)
@@ -162,4 +162,5 @@ updateProblemRest st@(LHSState tel0 qs0 p@(Problem oldEqs ps ret) a psplit) = ad
                    }
     , _lhsTarget  = a $> b
     , _lhsPartialSplit = psplit
+    , _lhsIndexedSplit = ixsplit
     }

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1639,7 +1639,7 @@ checkLetBinding b@(A.LetPatBind i p e) ret =
         ]
       ]
     fvs <- getContextSize
-    checkLeftHandSide (CheckPattern p EmptyTel t) Nothing [p0] t0 Nothing [] $ \ (LHSResult _ delta0 ps _ _t _ asb _) -> bindAsPatterns asb $ do
+    checkLeftHandSide (CheckPattern p EmptyTel t) Nothing [p0] t0 Nothing [] $ \ (LHSResult _ delta0 ps _ _t _ asb _ _) -> bindAsPatterns asb $ do
           -- After dropping the free variable patterns there should be a single pattern left.
       let p = case drop fvs ps of [p] -> namedArg p; _ -> __IMPOSSIBLE__
           -- Also strip the context variables from the telescope

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1034,7 +1034,7 @@ instance Subst Constraint where
     CheckDataSort q s        -> CheckDataSort q (rf s)
     CheckMetaInst m          -> CheckMetaInst m
     CheckType t              -> CheckType (rf t)
-    UsableAtModality ms mod m -> UsableAtModality (rf ms) mod (rf m)
+    UsableAtModality cc ms mod m -> UsableAtModality cc (rf ms) mod (rf m)
     where
       rf :: forall a. TermSubst a => a -> a
       rf x = applySubst rho x

--- a/test/Fail/Issue4638-2.err
+++ b/test/Fail/Issue4638-2.err
@@ -1,4 +1,4 @@
 Issue4638-2.agda:4,3-5
-A → E A is not usable at the required modality
+A → E A is not usable at the required modality @ω
 when checking that the type A → E A of the constructor c₁ fits in
 the sort Set of the datatype.

--- a/test/Fail/Issue4748c.err
+++ b/test/Fail/Issue4748c.err
@@ -1,3 +1,3 @@
 Issue4748c.agda:14,8-9
-(@0 x : A) (y : B x) → R is not usable at the required modality
+(@0 x : A) (y : B x) → R is not usable at the required modality @ω
 when checking the definition of R

--- a/test/Fail/Issue4784b.err
+++ b/test/Fail/Issue4784b.err
@@ -1,4 +1,4 @@
 Issue4784b.agda:15,3-6
-(@0 x : A) → B x → D is not usable at the required modality
+(@0 x : A) → B x → D is not usable at the required modality @ω
 when checking that the type (@0 x : A) → B x → D of the constructor
 con fits in the sort Set of the datatype.

--- a/test/Fail/Issue5410-3.err
+++ b/test/Fail/Issue5410-3.err
@@ -1,4 +1,4 @@
 Issue5410-3.agda:7,3-4
-{@0 A : Set} → A → D is not usable at the required modality
+{@0 A : Set} → A → D is not usable at the required modality @ω
 when checking that the type {@0 A : Set} → A → D of the constructor
 c fits in the sort Set₁ of the datatype.

--- a/test/Fail/Issue5410-4.err
+++ b/test/Fail/Issue5410-4.err
@@ -1,3 +1,4 @@
 Issue5410-4.agda:6,8-9
-(f : {@0 A : Set} → A) → D is not usable at the required modality
+(f : {@0 A : Set} → A) →
+D is not usable at the required modality @ω
 when checking the definition of D

--- a/test/Fail/Issue5434-1.err
+++ b/test/Fail/Issue5434-1.err
@@ -1,4 +1,4 @@
 Issue5434-1.agda:4,3-4
-(@0 A : Set) → D A is not usable at the required modality
+(@0 A : Set) → D A is not usable at the required modality @ω
 when checking that the type (@0 A : Set) → D A of the constructor c
 fits in the sort Set₁ of the datatype.

--- a/test/Fail/Issue5434-2.err
+++ b/test/Fail/Issue5434-2.err
@@ -1,4 +1,4 @@
 Issue5434-2.agda:6,3-4
-(@0 x y : D) → x ≡ y is not usable at the required modality
+(@0 x y : D) → x ≡ y is not usable at the required modality @ω
 when checking that the type (@0 x y : D) → x ≡ y of the constructor
 c fits in the sort Set of the datatype.

--- a/test/Fail/Issue5434-3.err
+++ b/test/Fail/Issue5434-3.err
@@ -1,4 +1,4 @@
 Issue5434-3.agda:6,5-6
-(@0 A : Set) → A → D A is not usable at the required modality
+(@0 A : Set) → A → D A is not usable at the required modality @ω
 when checking that the type (@0 A : Set) → A → D A of the
 constructor c fits in the sort Set₁ of the datatype.

--- a/test/Fail/Issue5434-4.err
+++ b/test/Fail/Issue5434-4.err
@@ -1,3 +1,3 @@
 Issue5434-4.agda:5,10-11
-(@0 A : Set) (x : A) → R is not usable at the required modality
+(@0 A : Set) (x : A) → R is not usable at the required modality @ω
 when checking the definition of R

--- a/test/Fail/Issue5448-1.err
+++ b/test/Fail/Issue5448-1.err
@@ -1,6 +1,6 @@
 Issue5448-1.agda:8,1-15
 This clause has target type P x which is not usable at the required
-modality
+modality @ω
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,

--- a/test/Fail/Issue5448-1.err
+++ b/test/Fail/Issue5448-1.err
@@ -1,10 +1,10 @@
 Issue5448-1.agda:8,1-15
 This clause has target type P x which is not usable at the required
-modality @ω
+modality @ω.
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,
-since it is used for computing transports.
+since it is used for computing transports
 
 when checking the clause left hand side
 subst P refl p

--- a/test/Fail/Issue5448-1.err
+++ b/test/Fail/Issue5448-1.err
@@ -1,6 +1,10 @@
-Issue5448-1.agda:8,1-19
-Agda.Primitive.Cubical.primTransp (λ i → P (x i)) φ
-(subst P refl
- (Agda.Primitive.Cubical.primTransp (λ i → P x₁) φ
-  x₂)) is not usable at the required modality .
-when checking the definition of subst
+Issue5448-1.agda:8,1-15
+This clause has target type P x which is not usable at the required
+modality
+
+Note: when --without-K is enabled, the target type must be usable
+at the modality in which the function was defined, since it is used
+in substitutions.
+
+when checking the clause left hand side
+subst P refl p

--- a/test/Fail/Issue5448-1.err
+++ b/test/Fail/Issue5448-1.err
@@ -2,9 +2,9 @@ Issue5448-1.agda:8,1-15
 This clause has target type P x which is not usable at the required
 modality
 
-Note: when --without-K is enabled, the target type must be usable
-at the modality in which the function was defined, since it is used
-in substitutions.
+Note: to maintain compatibility with Cubical Agda, the target type
+must be usable at the modality in which the function was defined,
+since it is used for computing transports.
 
 when checking the clause left hand side
 subst P refl p

--- a/test/Fail/Issue5448-2.err
+++ b/test/Fail/Issue5448-2.err
@@ -1,10 +1,10 @@
 Issue5448-2.agda:8,1-15
 This clause has target type P x which is not usable at the required
-modality @ω
+modality @ω.
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,
-since it is used for computing transports.
+since it is used for computing transports
 
 when checking the clause left hand side
 subst P refl p

--- a/test/Fail/Issue5448-2.err
+++ b/test/Fail/Issue5448-2.err
@@ -1,6 +1,10 @@
-Issue5448-2.agda:8,1-19
-Agda.Primitive.Cubical.primTransp (λ i → P (x i)) φ
-(subst P refl
- (Agda.Primitive.Cubical.primTransp (λ i → P x₁) φ
-  x₂)) is not usable at the required modality .
-when checking the definition of subst
+Issue5448-2.agda:8,1-15
+This clause has target type P x which is not usable at the required
+modality
+
+Note: when --without-K is enabled, the target type must be usable
+at the modality in which the function was defined, since it is used
+in substitutions.
+
+when checking the clause left hand side
+subst P refl p

--- a/test/Fail/Issue5448-2.err
+++ b/test/Fail/Issue5448-2.err
@@ -2,9 +2,9 @@ Issue5448-2.agda:8,1-15
 This clause has target type P x which is not usable at the required
 modality
 
-Note: when --without-K is enabled, the target type must be usable
-at the modality in which the function was defined, since it is used
-in substitutions.
+Note: to maintain compatibility with Cubical Agda, the target type
+must be usable at the modality in which the function was defined,
+since it is used for computing transports.
 
 when checking the clause left hand side
 subst P refl p

--- a/test/Fail/Issue5448-2.err
+++ b/test/Fail/Issue5448-2.err
@@ -1,6 +1,6 @@
 Issue5448-2.agda:8,1-15
 This clause has target type P x which is not usable at the required
-modality
+modality @ω
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,

--- a/test/Fail/Issue5448-3.err
+++ b/test/Fail/Issue5448-3.err
@@ -2,9 +2,9 @@ Issue5448-3.agda:8,1-15
 This clause has target type P x which is not usable at the required
 modality
 
-Note: when --without-K is enabled, the target type must be usable
-at the modality in which the function was defined, since it is used
-in substitutions.
+Note: to maintain compatibility with Cubical Agda, the target type
+must be usable at the modality in which the function was defined,
+since it is used for computing transports.
 
 when checking the clause left hand side
 subst P refl p

--- a/test/Fail/Issue5448-3.err
+++ b/test/Fail/Issue5448-3.err
@@ -1,6 +1,6 @@
 Issue5448-3.agda:8,1-15
 This clause has target type P x which is not usable at the required
-modality
+modality @ω
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,

--- a/test/Fail/Issue5448-3.err
+++ b/test/Fail/Issue5448-3.err
@@ -1,10 +1,10 @@
 Issue5448-3.agda:8,1-15
 This clause has target type P x which is not usable at the required
-modality @ω
+modality @ω.
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,
-since it is used for computing transports.
+since it is used for computing transports
 
 when checking the clause left hand side
 subst P refl p

--- a/test/Fail/Issue5448-3.err
+++ b/test/Fail/Issue5448-3.err
@@ -1,6 +1,10 @@
-Issue5448-3.agda:8,1-19
-Agda.Primitive.Cubical.primTransp (λ i → P (x i)) φ
-(subst P refl
- (Agda.Primitive.Cubical.primTransp (λ i → P x₁) φ
-  x₂)) is not usable at the required modality .
-when checking the definition of subst
+Issue5448-3.agda:8,1-15
+This clause has target type P x which is not usable at the required
+modality
+
+Note: when --without-K is enabled, the target type must be usable
+at the modality in which the function was defined, since it is used
+in substitutions.
+
+when checking the clause left hand side
+subst P refl p

--- a/test/Fail/Issue5448-4-noK.agda
+++ b/test/Fail/Issue5448-4-noK.agda
@@ -1,0 +1,8 @@
+{-# OPTIONS --without-K #-}
+
+open import Agda.Builtin.Equality
+
+subst :
+  {@0 A : Set} {@0 x y : A}
+  (@0 P : A → Set) → x ≡ y → P x → P y
+subst P refl p = p

--- a/test/Fail/Issue5448-4-noK.err
+++ b/test/Fail/Issue5448-4-noK.err
@@ -1,10 +1,5 @@
 Issue5448-4-noK.agda:8,1-15
 This clause has target type P x which is not usable at the required
 modality @ω.
-
-Note: when --without-K is enabled, the target type must be usable
-at the modality in which the function was defined, since it is used
-to compute substitutions in Cubical Agda
-
 when checking the clause left hand side
 subst P refl p

--- a/test/Fail/Issue5448-4-noK.err
+++ b/test/Fail/Issue5448-4-noK.err
@@ -4,7 +4,7 @@ modality @ω
 
 Note: when --without-K is enabled, the target type must be usable
 at the modality in which the function was defined, since it is used
-in substitutions.
+to compute substitutions in Cubical Agda.
 
 when checking the clause left hand side
 subst P refl p

--- a/test/Fail/Issue5448-4-noK.err
+++ b/test/Fail/Issue5448-4-noK.err
@@ -1,0 +1,10 @@
+Issue5448-4-noK.agda:8,1-15
+This clause has target type P x which is not usable at the required
+modality @ω
+
+Note: when --without-K is enabled, the target type must be usable
+at the modality in which the function was defined, since it is used
+in substitutions.
+
+when checking the clause left hand side
+subst P refl p

--- a/test/Fail/Issue5448-4-noK.err
+++ b/test/Fail/Issue5448-4-noK.err
@@ -1,10 +1,10 @@
 Issue5448-4-noK.agda:8,1-15
 This clause has target type P x which is not usable at the required
-modality @ω
+modality @ω.
 
 Note: when --without-K is enabled, the target type must be usable
 at the modality in which the function was defined, since it is used
-to compute substitutions in Cubical Agda.
+to compute substitutions in Cubical Agda
 
 when checking the clause left hand side
 subst P refl p

--- a/test/Fail/Issue5448-4.err
+++ b/test/Fail/Issue5448-4.err
@@ -1,10 +1,10 @@
 Issue5448-4.agda:8,1-15
 This clause has target type P x which is not usable at the required
-modality @ω
+modality @ω.
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,
-since it is used for computing transports.
+since it is used for computing transports
 
 when checking the clause left hand side
 subst P refl p

--- a/test/Fail/Issue5448-4.err
+++ b/test/Fail/Issue5448-4.err
@@ -1,6 +1,10 @@
-Issue5448-4.agda:8,1-19
-Agda.Primitive.Cubical.primTransp (λ i → P (x i)) φ
-(subst P refl
- (Agda.Primitive.Cubical.primTransp (λ i → P x₁) φ
-  x₂)) is not usable at the required modality .
-when checking the definition of subst
+Issue5448-4.agda:8,1-15
+This clause has target type P x which is not usable at the required
+modality
+
+Note: when --without-K is enabled, the target type must be usable
+at the modality in which the function was defined, since it is used
+in substitutions.
+
+when checking the clause left hand side
+subst P refl p

--- a/test/Fail/Issue5448-4.err
+++ b/test/Fail/Issue5448-4.err
@@ -2,9 +2,9 @@ Issue5448-4.agda:8,1-15
 This clause has target type P x which is not usable at the required
 modality
 
-Note: when --without-K is enabled, the target type must be usable
-at the modality in which the function was defined, since it is used
-in substitutions.
+Note: to maintain compatibility with Cubical Agda, the target type
+must be usable at the modality in which the function was defined,
+since it is used for computing transports.
 
 when checking the clause left hand side
 subst P refl p

--- a/test/Fail/Issue5448-4.err
+++ b/test/Fail/Issue5448-4.err
@@ -1,6 +1,6 @@
 Issue5448-4.agda:8,1-15
 This clause has target type P x which is not usable at the required
-modality
+modality @ω
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,

--- a/test/Fail/Issue5468.err
+++ b/test/Fail/Issue5468.err
@@ -1,9 +1,9 @@
 Issue5468.agda:33,1-16
 This clause has target type primTransp (λ i → x i) φ (unbox [ x₁ ])
-which is not usable at the required modality .
+which is not usable at the required modality @irrelevant.
 
 Note: in Cubical Agda, the target type must be usable at the
 modality in which the function was defined, since it is used for
-computing transports.
+computing transports
 
 when checking the definition of unbox

--- a/test/Fail/Issue5468.err
+++ b/test/Fail/Issue5468.err
@@ -1,4 +1,9 @@
 Issue5468.agda:33,1-16
-primTransp (λ i → x i) φ
-(unbox [ x₁ ]) is not usable at the required modality .
+This clause has target type primTransp (λ i → x i) φ (unbox [ x₁ ])
+which is not usable at the required modality .
+
+Note: in Cubical Agda, the target type must be usable at the
+modality in which the function was defined, since it is used for
+computing transports.
+
 when checking the definition of unbox

--- a/test/Fail/Issue5920a.err
+++ b/test/Fail/Issue5920a.err
@@ -1,3 +1,3 @@
 Issue5920a.agda:8,8-9
-(f : P c) → R is not usable at the required modality
+(f : P c) → R is not usable at the required modality @ω
 when checking the definition of R

--- a/test/Fail/Issue5920b.err
+++ b/test/Fail/Issue5920b.err
@@ -1,4 +1,4 @@
 Issue5920b.agda:7,3-4
-P c is not usable at the required modality
+P c is not usable at the required modality @ω
 when checking that the type P c of the constructor d fits in the
 sort Set of the datatype.


### PR DESCRIPTION
Implements the check for #5448, which at current `master` only happens with the  `--cubical-compatible` flag, eagerly (during LHS checking).

Because of how `transpX` clauses are generated (they use the RHS type, though with the unification substitutions represented as paths, in a relevant argument), checking that the RHS type is usable at the required modality will reject exactly the same definitions that `--cubical-compatible` would. With the benefit that the user doesn't have to see internal Cubical Agda code.

Consider:

```agda
subst : {A : Set} (@0 P : A → Set) {α β : A} (p : α ≡ β) → P α → P β
subst P refl a = {! a  !}
```

The error you get with `--without-K` is as follows. When `--cubical` is used, the note mentions "used for computing transports" and "in Cubical Agda" more specifically, and `--cubical-compatible` has yet a third wording. 

```
This clause has target type P α which is not usable at modality @ω

Note: when --without-K is enabled, the target type must be usable
at the modality in which the function was defined, since it is used
in substitutions.

when checking the clause left hand side
subst P refl a
```