### PR TITLE
Fixed example given in the Precedence section of documentation

### DIFF
--- a/doc/user-manual/language/mixfix-operators.lagda.rst
+++ b/doc/user-manual/language/mixfix-operators.lagda.rst
@@ -71,10 +71,10 @@ operators:
 Precedence
 ==========
 
-Consider the expression ``true and false ⇒ false``.
+Consider the expression ``false and true ⇒ false``.
 Depending on which of ``_and_`` and ``_⇒_`` has more precedence,
 it can either be read as ``(false and true) ⇒ false = true``,
-or as ``false and (true ⇒ false) = true``.
+or as ``false and (true ⇒ false) = false``.
 
 Each operator is associated to a precedence, which is a floating point number
 (can be negative and fractional!).

--- a/doc/user-manual/language/mixfix-operators.lagda.rst
+++ b/doc/user-manual/language/mixfix-operators.lagda.rst
@@ -73,8 +73,8 @@ Precedence
 
 Consider the expression ``false and true ⇒ false``.
 Depending on which of ``_and_`` and ``_⇒_`` has more precedence,
-it can either be read as ``(false and true) ⇒ false = true``,
-or as ``false and (true ⇒ false) = false``.
+it can either be read as ``(false and true) ⇒ false`` (which is ``true``),
+or as ``false and (true ⇒ false)`` (which is ``false``).
 
 Each operator is associated to a precedence, which is a floating point number
 (can be negative and fractional!).


### PR DESCRIPTION
Fixed errors in the example provided at [Language Reference → Mixfix Operators → Precedence](https://agda.readthedocs.io/en/v2.6.2.2/language/mixfix-operators.html#precedence). The edits are minimal -- in that if I made the corrections consistent with the consideration of `true and false ⇒ false` more edits would be required -- while providing distinct outputs between the 2 different interpretations, which both seems desirable to distinguish the 2 function precedence cases and is true for the proceeding code blocks.