### PR TITLE
Fix #5427 (revisited): add --(no-)subtyping to the dead options

### DIFF
--- a/test/Fail/GuardednessPreservingTypeConstructors.err
+++ b/test/Fail/GuardednessPreservingTypeConstructors.err
@@ -1,3 +1,2 @@
 GuardednessPreservingTypeConstructors.agda:3,1-59
-Experimental feature --guardedness-preserving-type-constructors has
-been removed.
+Option --guardedness-preserving-type-constructors has been removed

--- a/test/Fail/Issue1918.err
+++ b/test/Fail/Issue1918.err
@@ -1,2 +1,2 @@
 Issue1918.agda:3,1-36
-The --no-coverage-check option has been removed.
+Option --no-coverage-check has been removed in version 2.5.1

--- a/test/Fail/Issue3986.agda
+++ b/test/Fail/Issue3986.agda
@@ -1,0 +1,25 @@
+-- Andreas, 2022-10-28, issue #3986
+-- This issue has been fixed by the removal for subtyping
+-- (in particular, subtyping for irrelevant function types).
+
+{-# OPTIONS --subtyping #-}
+
+postulate
+  A   : Set
+  a b : A
+  f   : .A → A
+  P   : A → Set
+  p   : ∀ x → P x
+
+app : (A → A) → A
+app f = f a
+
+test-failing : P (app f)
+test-failing with b
+... | _ = p (f a)
+
+
+-- A ≤ .A
+-- .A → B ≤ A → B
+
+-- app f a --> f a

--- a/test/Fail/Issue3986.err
+++ b/test/Fail/Issue3986.err
@@ -1,0 +1,2 @@
+Issue3986.agda:5,1-28
+Option --subtyping has been removed in version 2.6.3


### PR DESCRIPTION
Fix #5427 (revisited): add --(no-)subtyping to the dead options, for UX reasons.

_Fight dementia!  Agda shouldn't forget its past entirely._

Also: refactor the treatment of removed options.