### PR TITLE
Fixed #6244: --no-load-primitives is not --safe

### DIFF
--- a/doc/user-manual/language/safe-agda.lagda.rst
+++ b/doc/user-manual/language/safe-agda.lagda.rst
@@ -57,6 +57,9 @@ Here is a list of the features ``--safe`` is incompatible with:
 
 * :option:`--allow-exec`; allows system calls during type checking.
 
+* :option:`--no-load-primitives`; allows the user to bind the sort
+  and level primitives manually.
+
 The option ``--safe`` is coinfective (see
 :ref:`consistency-checking-options`); if a module is declared safe,
 then all its imported modules must also be declared safe.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -586,6 +586,8 @@ Other features
      that all of the `BUILTIN` things defined in those modules are
      loaded. Agda will not work otherwise.
 
+     Incompatible with :option:`--safe`.
+
 .. option:: --save-metas, --no-save-metas
 
      .. versionadded:: 2.6.3
@@ -993,6 +995,7 @@ again, the source file is re-typechecked instead:
 * :option:`--allow-exec`
 * :option:`--save-metas`
 * :option:`--erase-record-parameters`
+* :option:`--no-load-primitives`
 
 
 .. _Vim: https://www.vim.org/

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -404,6 +404,7 @@ unsafePragmaOptions clo opts =
                                                  , not (collapseDefault $ optWithoutK opts) ] ++
   [ "--cumulativity"                             | optCumulativity opts              ] ++
   [ "--allow-exec"                               | optAllowExec opts                 ] ++
+  [ "--no-load-primitives"                       | not $ optLoadPrimitives opts      ] ++
   []
 
 -- | If any these options have changed, then the file will be
@@ -455,6 +456,7 @@ restartOptions =
   , (B . optAllowExec, "--allow-exec")
   , (B . collapseDefault . optSaveMetas, "--save-metas")
   , (B . optEraseRecordParameters, "--erase-record-parameters")
+  , (B . not . optLoadPrimitives, "--no-load-primitives")
   ]
 
 -- to make all restart options have the same type

--- a/test/Fail/Issue6244.agda
+++ b/test/Fail/Issue6244.agda
@@ -1,0 +1,7 @@
+-- Andreas, 2022-10-28, issue #6244
+-- Option --no-load-primitives was decided tonot be --safe.
+
+{-# OPTIONS --no-load-primitives --safe #-}
+
+-- Expected error:
+-- Cannot set OPTIONS pragma --no-load-primitives with safe flag.

--- a/test/Fail/Issue6244.err
+++ b/test/Fail/Issue6244.err
@@ -1,0 +1,2 @@
+Issue6244.agda:4,1-44
+Cannot set OPTIONS pragma --no-load-primitives with safe flag.


### PR DESCRIPTION
Fixed #6244: `--no-load-primitives` is not considered `--safe`.

In most cases, the level `postulate`s would already conflict with `--safe`.  But if only the sort primitives are bound, we do not need `postulate`, so we could coexist with `--safe`.  This is ruled out by this PR.