### PR TITLE
Help/doc: neither --sized-types nor --guardedness is default

### DIFF
--- a/doc/user-manual/language/safe-agda.lagda.rst
+++ b/doc/user-manual/language/safe-agda.lagda.rst
@@ -63,35 +63,3 @@ Here is a list of the features :option:`--safe` is incompatible with:
 The option :option:`--safe` is coinfective (see
 :ref:`consistency-checking-options`); if a module is declared safe,
 then all its imported modules must also be declared safe.
-
-.. NOTE::
-
-   The :option:`--guardedness` and :option:`--sized-types` options are
-   both on by default.  However, unless they have been set explicitly
-   by the user, setting the :option:`--safe` option will turn them both
-   off. That is to say that
-
-   .. code-block:: agda
-
-     {-# OPTIONS --safe #-}
-
-   will correspond to :option:`--safe`, :option:`--no-guardedness`, and
-   :option:`--no-sized-types`.  When both
-
-   .. code-block:: agda
-
-     {-# OPTIONS --safe --guardedness #-}
-
-   and
-
-   .. code-block:: agda
-
-     {-# OPTIONS --guardedness --safe #-}
-
-   will turn on :option:`--safe`, :option:`--guardedness`, and
-   :option:`--no-sized-types`.
-
-
-   Setting both :option:`--sized-types` and :option:`--guardedness`
-   whilst demanding that the module is :option:`--safe` will lead to an
-   error as combining these options currently is inconsistent.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -543,11 +543,11 @@ Other features
      Enable [disable] constructor-based guarded corecursion (see
      :ref:`coinduction`).
 
-     The option ``--guardedness`` is inconsistent with sized types and
-     it is turned off by :option:`--safe` (but can be turned on again,
-     as long as not also :option:`--sized-types` is on).
+     The option ``--guardedness`` is inconsistent with sized types,
+     thus, it cannot be used with both :option:`--safe` and
+     :option:`--sized-types`.
 
-     Default: ``--guardedness``
+     Default: ``--no-guardedness`` (since 2.6.2).
 
 .. option:: --irrelevant-projections, --no-irrelevant-projections
 
@@ -630,9 +630,9 @@ Other features
      .. versionadded:: 2.3.0
 
      Disable postulates, unsafe :ref:`OPTIONS<options-pragma>` pragmas
-     and ``primTrustMe``. Turns off :option:`--sized-types` and
-     :option:`--guardedness` (at most one can be turned back on again)
-     (see :ref:`safe-agda`).
+     and ``primTrustMe``. Prevents to have both :option:`--sized-types` and
+     :option:`--guardedness` on.
+     Further reading: :ref:`safe-agda`.
 
 .. option:: --sized-types, --no-sized-types
 
@@ -641,11 +641,11 @@ Other features
      Enable [disable] sized types (see :ref:`sized-types`).
 
      The option ``--sized-types`` is inconsistent with
-     constructor-based guarded corecursion and it is turned off by
-     :option:`--safe` (but can be turned on again, as long as not also
-     :option:`--guardedness` is on).
+     constructor-based guarded corecursion,
+     thus, it cannot be used with both :option:`--safe`
+     and :option:`--guardedness`.
 
-     Default: ``--sized-types``
+     Default: ``--no-sized-types`` (since 2.6.2).
 
 .. option:: --type-in-type
 

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -1081,7 +1081,7 @@ pragmaOptions =
     , Option []     ["omega-in-omega"] (NoArg omegaInOmegaFlag)
                     "enable typing rule Setω : Setω (this makes Agda inconsistent)"
     , Option []     ["cumulativity"] (NoArg cumulativityFlag)
-                    "enable subtyping of universes (e.g. Set =< Set₁) (implies --subtyping)"
+                    "enable subtyping of universes (e.g. Set =< Set₁)"
     , Option []     ["no-cumulativity"] (NoArg noCumulativityFlag)
                     "disable subtyping of universes (default)"
     , Option []     ["prop"] (NoArg propFlag)
@@ -1091,17 +1091,17 @@ pragmaOptions =
     , Option []     ["two-level"] (NoArg twoLevelFlag)
                     "enable the use of SSet* universes"
     , Option []     ["sized-types"] (NoArg sizedTypes)
-                    "enable sized types (default, inconsistent with --guardedness, implies --subtyping)"
+                    "enable sized types (inconsistent with --guardedness)"
     , Option []     ["no-sized-types"] (NoArg noSizedTypes)
-                    "disable sized types"
+                    "disable sized types (default)"
     , Option []     ["flat-split"] (NoArg flatSplitFlag)
                     "allow split on (@flat x : A) arguments (default)"
     , Option []     ["no-flat-split"] (NoArg noFlatSplitFlag)
                     "disable split on (@flat x : A) arguments"
     , Option []     ["guardedness"] (NoArg guardedness)
-                    "enable constructor-based guarded corecursion (default, inconsistent with --sized-types)"
+                    "enable constructor-based guarded corecursion (inconsistent with --sized-types)"
     , Option []     ["no-guardedness"] (NoArg noGuardedness)
-                    "disable constructor-based guarded corecursion"
+                    "disable constructor-based guarded corecursion (default)"
     , Option []     ["injective-type-constructors"] (NoArg injectiveTypeConstructorFlag)
                     "enable injective type constructors (makes Agda anti-classical and possibly inconsistent)"
     , Option []     ["no-universe-polymorphism"] (NoArg noUniversePolymorphismFlag)


### PR DESCRIPTION
Fix #6250 fix #6251: neither --sized-types nor --guardedness is default.

Also remove mentions of --subtyping.