### PR TITLE
Use liberal termination checking with both --without-K and --safe on

### DIFF
--- a/doc/user-manual/language/termination-checking.lagda.rst
+++ b/doc/user-manual/language/termination-checking.lagda.rst
@@ -2,6 +2,7 @@
   ::
   module language.termination-checking where
 
+      open import Agda.Builtin.Unit
       open import Agda.Builtin.Bool
       open import Agda.Builtin.Nat
 
@@ -78,6 +79,42 @@ below).
 
 In ``ack`` either the first argument decreases or it stays the same and the second one decreases.
 This is the same as a lexicographic ordering.
+
+.. _termination-checking-large-elimination:
+
+Large elimination and --without-K
+---------------------------------
+
+When type constructors are defined via recursive functions eliminating
+inductive terms rather than data type declarations or record type
+declarations, this is called large elimination. For example, here we
+define a trivial large elimination from unit to the naturals:
+
+::
+
+      F : ⊤ → Set
+      F tt = Nat
+
+We might then want to recurse over terms of this type to recursively
+convert them into just naturals for example:
+
+::
+
+      Nat-of-F : ∀ u → F u → Nat
+      Nat-of-F tt zero = zero
+      Nat-of-F tt (suc n) = suc (Nat-of-F tt n)
+
+If ``--without-K`` has been enabled, ``Nat-of-F`` will fail the
+termination analysis because structurally decreasing recursion that is
+dependent on pattern matching may cause type substitutions that are no
+longer structurally decreasing in the presence of cubical-compatible
+postulates (see `Issue #1023`_ for more information).
+
+However, if both ``--without-K`` and ``--safe`` have been enabled, no
+cubical-compatible postulates are accepted and so termination analysis
+reverts to the standard procedure used when axiom K is available.
+
+.. _`Issue #1023`: https://github.com/agda/agda/issues/1023
 
 .. _termination-checking-with:
 

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -502,7 +502,8 @@ termDef name = terSetCurrent name $ inConcreteOrAbstractMode name $ \ def -> do
   -- which are not of data or record type.
 
   withoutKEnabled <- liftTCM withoutKOption
-  applyWhen withoutKEnabled (setMasks t) $ do
+  safeEnabled <- liftTCM safeOption
+  applyWhen (withoutKEnabled && not safeEnabled) (setMasks t) $ do
 
     -- If the result should be disregarded, set all calls to unguarded.
     applyWhenM terGetMaskResult terUnguarded $ do

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4436,6 +4436,9 @@ guardednessOption = collapseDefault . optGuardedness <$> pragmaOptions
 withoutKOption :: HasOptions m => m Bool
 withoutKOption = collapseDefault . optWithoutK <$> pragmaOptions
 
+safeOption :: HasOptions m => m Bool
+safeOption = optSafe <$> pragmaOptions
+
 cubicalCompatibleOption :: HasOptions m => m Bool
 cubicalCompatibleOption = collapseDefault . optCubicalCompatible <$> pragmaOptions
 


### PR DESCRIPTION
I've noticed that since #1023, termination checking in the presence of `--without-K` has been so conservative that it effectively prohibits a lot of interesting large elimination type definitions that you might make when constructing universes. As far as I can see, this restriction is in place entirely because there exist 'cubical-compatible' postulates that are unaccounted for by the termination checker. I have re-liberalised the termination checker when both `--without-K` and `--safe` are turned on.

I am presently working on a development that would greatly benefit from expressive large elimination and should be entirely compatible with cubical (does not use K) and is completely safe.

I'm aware that some of my phrasing may be a bit clunky in the documentation and would appreciate suggestions to try to make it clearer. I'm also aware that @Saizan's trivial large elimination example that I cribbed for the documentation isn't terribly convincing. I've developed a perhaps more compelling but less minimal example demonstrating a large elimination interpretation of mutually recursive inductive tree codes that I have included below.

```agda
{-# OPTIONS --safe --exact-split --without-K #-}

open import Agda.Builtin.Nat

open import Data.Empty
open import Data.Unit
open import Data.Sum
open import Data.Product

open import Data.List

open import Relation.Binary.PropositionalEquality

{- We don't have K so if we want to compare equalities (of, say,
   naturals), we need to witness them inductively
-}
data Nat≡ : Nat → Nat → Set where
  zero : Nat≡ zero zero
  suc : ∀ {m n} → Nat≡ m n → Nat≡ (suc m) (suc n)

{- We'll define a universe of mutually recursive un-parameterized inductive types and their term constructors -}

TypeId = Nat
TypeId≡ = Nat≡

Tele = List TypeId -- A telescope is just a list of types

record Cons : Set where
  constructor cons
  field
    id   : TypeId  -- my type
    tele : Tele    -- my arguments

Code = List Cons

-- To make a term of a particular type T in an algebra (code), we supply
-- the complete algebra, the rest of the algebra, and the type T.
⟦_⊇_⊢_⟧ : ∀ (Γ Δ : Code) (T : TypeId) → Set

-- The interpretation of a telescope in the algebra Γ
⟦Tele⟧ : ∀ (Γ : Code) (tel : Tele) → Set

-- The interpretation of a term constructor which must be defined as a
-- 'Set' (either record or data) to stop the infinite regress in the
-- large elimination
record Term (Γ : Code) (c : Cons) (n : TypeId) : Set where
  constructor term
  inductive
  field
    eq   : TypeId≡ (c .Cons.id) n
    tele : ⟦Tele⟧ Γ (c .Cons.tele)

⟦ Γ ⊇ [] ⊢ n ⟧ = ⊥  -- if we have no more constructors left, we can't be inhabited
⟦ Γ ⊇ c ∷ Δ ⊢ n ⟧ = Term Γ c n ⊎ ⟦ Γ ⊇ Δ ⊢ n ⟧  -- either this constructor is used or we keep looking

⟦_⊢_⟧ : Code → Nat → Set
⟦ Γ ⊢ n ⟧ = ⟦ Γ ⊇ Γ ⊢ n ⟧

⟦Tele⟧ Γ [] = ⊤
⟦Tele⟧ Γ (x ∷ tel) = ⟦ Γ ⊢ x ⟧ × ⟦Tele⟧ Γ tel


-- Now we want to define a propositional predicate that asserts that a
-- given term doesn't use any k-ary constructors for k>1
NoForks : ∀ {Γ Δ n} → ⟦ Γ ⊇ Δ ⊢ n ⟧ → Set

-- This implementation should be fine but fails due to the recursive call + #1023
{-
NoForks {Δ = x ∷ a} (inj₂ y) = NoForks y
NoForks {Δ = cons id [] ∷ a} (inj₁ (term eq tele)) = ⊤
NoForks {Δ = cons id (x ∷ []) ∷ a} (inj₁ (term eq (fst , tt))) = NoForks fst
NoForks {Δ = cons id (x ∷ x₁ ∷ tele₁) ∷ a} (inj₁ (term eq tele)) = ⊥
-}

-- We can use the same trick we used in the interpretation elimination
-- to convince the termination checker that there isn't an infinite
-- loop
record NoForksRec {Γ Δ n} (t : ⟦ Γ ⊇ Δ ⊢ n ⟧) : Set where
  constructor noforks
  inductive
  pattern
  field
    continue : NoForks t

NoForks {Δ = x ∷ a} (inj₂ y) = NoForks y
NoForks {Δ = cons id [] ∷ a} (inj₁ (term eq tele)) = ⊤
NoForks {Δ = cons id (x ∷ []) ∷ a} (inj₁ (term eq (fst , tt))) = NoForksRec fst
NoForks {Δ = cons id (x ∷ x₁ ∷ tele₁) ∷ a} (inj₁ (term eq tele)) = ⊥

-- ... but we're still stuck because we can't prove anything about the predicate!
NoForks-prop : ∀ {Γ Δ n} {t : ⟦ Γ ⊇ Δ ⊢ n ⟧} (x y : NoForks t) → x ≡ y
NoForks-prop {Δ = x₁ ∷ Δ} {t = inj₂ y₁} x y = NoForks-prop {Δ = Δ} x y
NoForks-prop {Δ = cons id [] ∷ Δ} {t = inj₁ (term eq tele)} x y = refl
NoForks-prop {Δ = cons id (x₁ ∷ []) ∷ Δ} {t = inj₁ (term eq (fst , tt))} (noforks x) (noforks y) = cong noforks (NoForks-prop {t = fst} x y)
```