### PR TITLE
Fix #6283: build with mtl-2.3.1

### DIFF
--- a/cabal.project.local.mtl23
+++ b/cabal.project.local.mtl23
@@ -1,4 +1,5 @@
 -- Andreas, 2022-02-23, configuration to build with mtl-2.3-rc3
+-- Andreas, 2022-11-04, configuration to build with mtl-2.3.1
 -- Invocation:
 -- $ ln -s cabal.project.local.mtl23 cabal.project.local
 -- $ cabal build --builddir dist-mtl23 -f +enable-cluster-counting
@@ -6,8 +7,14 @@
 flags: +enable-cluster-counting
 constraints: text-icu == 0.8.*
 
+-- mtl
+------------------------------------------------------------------------
+
+constraints: mtl == 2.3.1
+allow-newer: *:mtl
+
 -- =====================================================================
--- Released versions needed to test mtl-2.3-rc3
+-- Released versions needed to test mtl-2.3.1
 -- =====================================================================
 
 -- transformers
@@ -16,26 +23,9 @@ constraints: text-icu == 0.8.*
 constraints: transformers == 0.6.*
 allow-newer: *:transformers
 
--- equivalence
-------------------------------------------------------------------------
-
-constraints: equivalence  == 0.4
-allow-newer: *:equivalence
-
 -- =====================================================================
--- Unreleased versions needed to test mtl-2.3-rc3
+-- Unreleased versions needed to test mtl-2.3.1
 -- =====================================================================
-
--- mtl
-------------------------------------------------------------------------
-
-source-repository-package
-  type: git
-  location: https://github.com/haskell/mtl.git
-  tag: v2.3-rc3
-
-constraints: mtl == 2.3.*
-allow-newer: *:mtl
 
 -- happy
 ------------------------------------------------------------------------
@@ -53,22 +43,3 @@ source-repository-package
 
 constraints: happy == 1.21.*
 allow-newer: *:happy
-
--- exceptions
-------------------------------------------------------------------------
-
-source-repository-package
-  type: git
-  location: git@github.com:ekmett/exceptions
-  tag: 28b9b49a51deb7c1343e003dafb4c69ef79f2e8b
-
--- random
-------------------------------------------------------------------------
-
-source-repository-package
-  type: git
-  location: https://github.com/haskell/random.git
-  tag: 5ecc8935994159c6d39088233a0887714aacaf5e
-
-constraints: random == 1.3.*
-allow-newer: *:random

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -8,8 +8,9 @@ module Agda.Compiler.MAlonzo.HaskellTypes
   , hsTelApproximation, hsTelApproximation'
   ) where
 
-import Control.Monad (zipWithM)
-import Control.Monad.Except
+import Control.Monad         ( zipWithM )
+import Control.Monad.Except  ( ExceptT(ExceptT), runExceptT, mapExceptT, catchError, throwError )
+import Control.Monad.Trans   ( lift )
 -- Control.Monad.Fail import is redundant since GHC 8.8.1
 import Control.Monad.Fail (MonadFail)
 import Data.Maybe (fromMaybe)

--- a/src/full/Agda/TypeChecking/IApplyConfluence.hs
+++ b/src/full/Agda/TypeChecking/IApplyConfluence.hs
@@ -3,9 +3,10 @@ module Agda.TypeChecking.IApplyConfluence where
 
 import Prelude hiding (null, (!!))  -- do not use partial functions like !!
 
+import Control.Monad
 import Control.Monad.Except
-import Control.Arrow (first,second)
 
+import Data.Bifunctor (first, second)
 import Data.DList (DList)
 import Data.Foldable (toList)
 import Data.IntMap (IntMap)

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -41,6 +41,7 @@ Projection patterns (@ProjP@) are excluded because metas cannot occupy their pla
 module Agda.TypeChecking.Injectivity where
 
 import Control.Applicative
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Fail
 import Control.Monad.State

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -11,7 +11,7 @@ import Control.Monad.State
 import Control.Monad.Trans.Control  ( MonadTransControl(..), liftThrough )
 import Control.Monad.Trans.Identity ( IdentityT )
 import Control.Monad.Trans.Maybe
-import Control.Monad.Writer hiding ((<>))
+import Control.Monad.Writer         ( WriterT )
 -- Control.Monad.Fail import is redundant since GHC 8.8.1
 import Control.Monad.Fail (MonadFail)
 

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -4,12 +4,13 @@ module Agda.TypeChecking.Monad.MetaVars where
 
 import Prelude hiding (null)
 
-import Control.Monad                ( (<=<), guard )
-import Control.Monad.Except
-import Control.Monad.State
+import Control.Monad                ( (<=<), forM_, guard )
+import Control.Monad.Except         ( MonadError )
+import Control.Monad.State          ( StateT, execStateT, get, put )
+import Control.Monad.Trans          ( MonadTrans, lift )
 import Control.Monad.Trans.Identity ( IdentityT )
-import Control.Monad.Reader
-import Control.Monad.Writer
+import Control.Monad.Reader         ( ReaderT(ReaderT), runReaderT )
+import Control.Monad.Writer         ( WriterT, execWriterT, tell )
 -- Control.Monad.Fail import is redundant since GHC 8.8.1
 import Control.Monad.Fail (MonadFail)
 

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
@@ -18,12 +18,13 @@ module Agda.TypeChecking.Primitive.Cubical.Base
   )
   where
 
-import Control.Arrow (second)
-import Control.Monad.Except
+import Control.Monad        ( msum, mzero )
+import Control.Monad.Except ( MonadError )
 
 import qualified Data.IntMap as IntMap
 import Data.IntMap (IntMap)
 import Data.String (IsString (fromString))
+import Data.Bifunctor (second)
 import Data.Either (partitionEithers)
 import Data.Maybe (fromMaybe, maybeToList)
 

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
@@ -6,7 +6,8 @@ module Agda.TypeChecking.Primitive.Cubical.HCompU
   )
   where
 
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Except ( MonadError )
 
 import Agda.Utils.Functor
 import Agda.Utils.Monad

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -17,10 +17,10 @@ module Agda.TypeChecking.Warnings
   ) where
 
 import Control.Monad ( forM, unless )
-import Control.Monad.Except
+import Control.Monad.Except ( MonadError(..) )
 import Control.Monad.Reader ( ReaderT )
 import Control.Monad.State ( StateT )
-import Control.Monad.Trans ( lift )
+import Control.Monad.Trans ( MonadTrans, lift )
 
 import qualified Data.List as List
 import qualified Data.Map  as Map


### PR DESCRIPTION
Some reexports got removed in `mtl` 2.3 over 2.2.