### PR TITLE
Experiment: η-conversion for Id

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -447,6 +447,7 @@ library
                     Agda.TypeChecking.CompiledClause.Match
                     Agda.TypeChecking.Constraints
                     Agda.TypeChecking.Conversion
+                    Agda.TypeChecking.Conversion.Eta
                     Agda.TypeChecking.Conversion.Pure
                     Agda.TypeChecking.Coverage
                     Agda.TypeChecking.Coverage.Match

--- a/src/data/lib/prim/Agda/Builtin/Cubical/Id.agda
+++ b/src/data/lib/prim/Agda/Builtin/Cubical/Id.agda
@@ -26,6 +26,7 @@ module Agda.Builtin.Cubical.Id where
     primDepIMin : _
     primIdFace : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → I
     primIdPath : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → x ≡ y
+    primExpandId : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → Id x y
 
   primitive
     primIdElim : ∀ {a c} {A : Set a} {x : A}

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -23,7 +23,7 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinGlue, builtin_glue, builtin_unglue,
   builtin_glueU, builtin_unglueU,
   builtinFaceForall,
-  builtinId, builtinReflId, builtinConId, builtinIdElim,
+  builtinId, builtinReflId, builtinConId, builtinIdElim, builtinRelaxId,
   builtinSizeUniv, builtinSize, builtinSizeLt,
   builtinSizeSuc, builtinSizeInf, builtinSizeMax,
   builtinInf, builtinSharp, builtinFlat,
@@ -112,6 +112,7 @@ builtinId                                = "ID"
 builtinReflId                            = "REFLID"
 builtinConId                             = "primConId"
 builtinIdElim                            = "primIdElim"
+builtinRelaxId                           = "primExpandId"
 builtinPath                              = "PATH"
 builtinPathP                             = "PATHP"
 builtinIntervalUniv                      = "CUBEINTERVALUNIV"

--- a/src/full/Agda/TypeChecking/Conversion/Eta.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Eta.hs
@@ -1,0 +1,178 @@
+module Agda.TypeChecking.Conversion.Eta
+  (EtaKit(..), etaKitForDef)
+  where
+
+import {-# SOURCE #-} Agda.TypeChecking.Conversion
+import Agda.Syntax.Internal.Blockers
+import Agda.Syntax.Internal
+import Control.Monad.Trans.Maybe
+import Control.Monad.Trans
+import Control.Monad
+import Agda.TypeChecking.Records
+import Agda.Utils.Monad
+import Agda.TypeChecking.Monad.Signature (usesCopatterns)
+import Control.Applicative
+import Agda.Syntax.Common
+import Agda.TypeChecking.Monad.Builtin
+import Agda.Utils.Impossible
+import Agda.TypeChecking.Primitive
+import Agda.TypeChecking.Substitute
+import Agda.TypeChecking.Monad.Debug
+import Agda.TypeChecking.Pretty
+import Agda.Utils.Maybe
+import Data.Char (toLower)
+
+data EtaKit m = EtaKit
+  { isNeutral        :: forall t. Args -> Blocked' t Term -> m Bool
+  , isSingleton      :: Args -> m Bool
+  , etaExpand        :: Args -> Term -> m (Telescope, Args)
+  , headTerm         :: Args -> Term
+  , profilingTickTag :: String -> String
+  , verboseTag       :: String
+  }
+
+-- | Auxilliary function for defining 'EtaKit' for Cubical Agda types,
+-- since those all have "constructors" given by a special Def (e.g. primGlue).
+treatDefNeutral :: forall t m. MonadConversion m => QName -> Blocked' t Term -> m Bool
+treatDefNeutral _    (NotBlocked _ Con{})     = pure False
+treatDefNeutral name (NotBlocked _ (Def d _))
+  | name == d = pure False
+  | otherwise = not <$> usesCopatterns d
+treatDefNeutral _ _ = pure True
+
+recordEtaKit :: MonadConversion m => QName -> MaybeT m (EtaKit m)
+recordEtaKit r = do
+  guardM (isEtaRecord r)
+  con <- getRecordConstructor r
+  let
+    kit = EtaKit
+      { isNeutral = \_ -> \case
+          -- Andreas, 2010-10-11: allowing neutrals to be blocked things does not seem
+          -- to change Agda's behavior
+          --    isNeutral Blocked{}          = False
+          NotBlocked _ Con{} -> return False
+          -- Andreas, 2013-09-18 / 2015-06-29: a Def by copatterns is
+          -- not neutral if it is blocked (there can be missing projections
+          -- to trigger a reduction.
+          (NotBlocked r (Def q _)) -> -- Andreas, 2014-12-06 optimize this using r !!
+            not <$> usesCopatterns q -- a def by copattern can reduce if projected
+          _                   -> return True
+      , isSingleton = \ps -> isSingletonRecordModuloRelevance r ps
+      , etaExpand = etaExpandRecord r
+      , headTerm = \_ -> Con con ConOSystem []
+      , profilingTickTag = ("compare at eta record" ++)
+      , verboseTag = "rec"
+      }
+  pure kit
+
+newtypeEtaKit
+  :: MonadConversion m
+  => m (Maybe QName)                  -- ^ The type (e.g. Glue)
+  -> m (Maybe QName)                  -- ^ The constructor (e.g. glue)
+  -> m (Maybe QName)                  -- ^ The projection
+  -> (QName -> Args -> Term -> Term) -- ^ Project the principal argument
+  -> (Args -> Type)                  -- ^ Type of the principal argument
+  -> String                          -- ^ Profiling tick tag
+  -> Int
+  -- ^ Index (zero-based) which the projection projects (so e.g. if @f
+  -- (g x y z) = z@ and the rest don't matter, this argument would be 2)
+  -> MaybeT m (QName -> MaybeT m (EtaKit m))
+newtypeEtaKit tName con projnm proj projT desc idx = do
+  [tName, con, projnm] <- traverse MaybeT [tName, con, projnm]
+  let
+    project :: Args -> Term -> (Telescope, Args)
+    project ps tm = (ExtendTel (defaultDom (projT ps)) (Abs "g" EmptyTel), [unglued]) where
+      unglued = case tm of
+        Def con' as | con' == con, Just as <- allApplyElims as -> as !! idx
+        _ -> argN (proj projnm ps tm)
+  pure $ \nm -> do
+    guard (nm == tName)
+    pure EtaKit
+      { isNeutral   = const (treatDefNeutral con)
+      , isSingleton = \_ -> pure False
+      , etaExpand   = \ps tm -> pure (project ps tm)
+      , headTerm    = const (Def con [])
+      , profilingTickTag = ("compare at " ++) . (desc ++)
+      , verboseTag = map toLower (head (words desc))
+      }
+
+glueEtaKit :: MonadConversion m => MaybeT m (QName -> MaybeT m (EtaKit m))
+glueEtaKit = newtypeEtaKit
+  (getName' builtinGlue)
+  (getName' builtin_glue)
+  (getName' builtin_unglue)
+  (\unglue ps tm -> Def unglue (map (Apply . setHiding Hidden) ps ++ [Apply (argN tm)]))
+  (\(Arg _ la:_:Arg _ base:_) -> El (tmSort la) base)
+  "Glue type"
+  7
+
+hcompUEtaKit :: MonadConversion m => MaybeT m (QName -> MaybeT m (EtaKit m))
+hcompUEtaKit = do
+  inS <- MaybeT $ getTerm' builtinSubIn
+  outS <- MaybeT $ getTerm' builtinSubOut
+  iz <- primIZero
+  newtypeEtaKit
+    (getName' builtinHComp)
+    (getName' builtin_glueU)
+    (getName' builtin_unglueU)
+    (\unglue (sl:s:args@[phi, u, u0]) tm ->
+      let
+        Sort (Type lvl) = unArg s
+        bA = inS `apply` [sl,s,phi,u0]
+      in Def unglue [] `apply` ([argH (Level lvl)] ++ map (setHiding Hidden) [phi,u]  ++ [argH bA, argN tm]))
+    (\(sl:s:args@[phi, u, u0]) -> let Sort (Type lvl) = unArg s in El (tmSort (Level lvl)) (unArg u0))
+    "hcomp {Type}"
+    5 -- glueU {la} {φ} {partial} {base} it
+
+subEtaKit :: MonadConversion m => MaybeT m (QName -> MaybeT m (EtaKit m))
+subEtaKit = do
+  kit <- newtypeEtaKit
+    (getName' builtinSub)
+    (getName' builtinSubIn)
+    (getName' builtinSubOut)
+    (\unglue args tm ->
+      Def unglue (map (Apply . setHiding Hidden) args ++ [Apply (argN tm)]))
+    (\(l:a:_) -> El (tmSort (unArg l)) (unArg a))
+    "Sub type"
+    3 -- inS {la} {A} {φ} it
+  pure $ \nm -> do
+    sub <- MaybeT $ getName' builtinSub
+    kit <- kit nm
+    pure kit { isSingleton = \args -> isJust <$> isSingletonType (El (tmSSort __DUMMY_TERM__) (Def sub (map Apply args))) }
+
+idEtaKit :: MonadConversion m => MaybeT m (QName -> MaybeT m (EtaKit m))
+idEtaKit = do
+  idT  <- getName' builtinId
+  conid <- getName' builtinConId
+  idp <- getTerm' "primIdPath"
+  idf <- getTerm' "primIdFace"
+  [idT, conid] <- traverse (MaybeT . pure) [idT, conid]
+  [idp, idf] <- traverse (MaybeT . pure) [idp, idf]
+  path <- getBuiltin builtinPath
+  it <- primIntervalType
+  cv <- conidView'
+  let
+    pathT l a x y = El (tmSort l) $ path `apply` [argH l, argH a, argN x, argN y]
+  pure $ \tn -> do
+    guard (tn == idT)
+    pure EtaKit
+      { isNeutral = \(l:a:x:_) e -> pure $ case e of
+          NotBlocked ReallyNotBlocked tm@(Def q _) -> isNothing (cv (unArg x) tm)
+          _ -> False
+      , etaExpand = \[Arg _ l, Arg _ a, Arg _ x, Arg _ y] tm ->
+          let
+            ap = flip apply [argH l, argH a, argH x, argH y, argN tm]
+            (phi, w) = case cv x tm of
+              Just (phi, w) -> (argN (unArg phi), argN (unArg w))
+              Nothing -> (argN (ap idf), argN (ap idp))
+          in pure (ExtendTel (defaultDom it) (Abs "" (ExtendTel (defaultDom (pathT l a x y)) (Abs "" EmptyTel))), [phi, w])
+      , isSingleton = const (pure False)
+      , headTerm = Def conid . map (Apply . setHiding Hidden)
+      , profilingTickTag = ("compare at Id type" ++)
+      , verboseTag = "id"
+      }
+
+etaKitForDef :: MonadConversion m => QName -> m (Maybe (EtaKit m))
+etaKitForDef r = do
+  others <- catMaybes <$> traverse runMaybeT [glueEtaKit, hcompUEtaKit, subEtaKit, idEtaKit]
+  runMaybeT $ recordEtaKit r <|> asum (map ($ r) others)

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -969,6 +969,7 @@ primitiveFunctions = localTCStateSavingWarnings <$> Map.fromListWith __IMPOSSIBL
   , "primIdFace"          |-> primIdFace'
   , "primIdPath"          |-> primIdPath'
   , builtinIdElim         |-> primIdElim'
+  , builtinRelaxId        |-> primExpandId'
   , builtinSubOut         |-> primSubOut'
   , builtinConId          |-> primConId'
   , builtin_glueU         |-> prim_glueU'

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Id.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Id.hs
@@ -171,10 +171,15 @@ primExpandId' = do
       conid <- getTerm "primExpandId" builtinConId
       idp <- getTerm "primExpandId" "primIdPath"
       idf <- getTerm "primExpandId" "primIdFace"
-      let
-        phi = idf `apply` [l, bA, x, y, t]
-        w   = idp `apply` [l, bA, x, y, t]
-      redReturn $ conid `apply` [l, bA, x, y, argN phi, argN w]
+      st <- reduceB' t
+      cview <- conidView'
+      case cview (unArg x) (unArg (ignoreBlocking st)) of
+        Just (phi, w) -> redReturn (unArg (ignoreBlocking st))
+        Nothing -> do
+          let
+            phi = idf `apply` [l, bA, x, y, t]
+            w   = idp `apply` [l, bA, x, y, t]
+          redReturn $ conid `apply` [l, bA, x, y, argN phi, argN w]
     _ -> __IMPOSSIBLE__
 
 -- | Extract the underlying path from an inhabitant of the

--- a/test/Succeed/CubicalPrims.agda
+++ b/test/Succeed/CubicalPrims.agda
@@ -2,15 +2,19 @@
 module CubicalPrims where
 
 open import Agda.Primitive renaming (_⊔_ to ℓ-max)
-open import Agda.Primitive.Cubical renaming (primIMin to _∧_; primIMax to _∨_; primINeg to ~_; isOneEmpty to empty)
+open import Agda.Primitive.Cubical renaming (primIMin to _∧_; primIMax to _∨_; primINeg to ~_; isOneEmpty to empty ; itIsOne to 1=1)
 open import Agda.Builtin.Bool
 open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_]; primSubOut to outS)
 open import Agda.Builtin.Cubical.Path
 open import Agda.Builtin.Cubical.Id renaming (IdJ to J)
 open import Agda.Builtin.Cubical.Glue renaming (primGlue to Glue; prim^glue to glue; prim^unglue to unglue)
+open import Agda.Builtin.Cubical.HCompU
+  renaming (prim^glueU to glueU; prim^unglueU to unglueU)
+  hiding (module Helpers)
 open import Agda.Builtin.Sigma
 open import Agda.Builtin.List
 open Helpers
+
 
 module _ {ℓ} {A : Set ℓ} where
   trans : {x y z : A} → x ≡ y → y ≡ z → x ≡ z
@@ -28,7 +32,7 @@ module DerivedComp where
 
   module _ (la : I → Level) (A : ∀ i → Set (la i)) (φ : I) (u : ∀ i → Partial φ (A i)) (u0 : A i0 [ φ ↦ u i0 ]) where
     comp : A i1
-    comp = primHComp (\ i → \ { (φ = i1) → forward la A i (u i itIsOne) }) (forward la A i0 (outS u0))
+    comp = primHComp (\ i → \ { (φ = i1) → forward la A i (u i 1=1) }) (forward la A i0 (outS u0))
 
     comp-test : comp ≡ primComp A u (outS u0)
     comp-test = refl
@@ -97,7 +101,7 @@ J-comp : ∀ {ℓ ℓ'} {A : Set ℓ} {x : A} {P : ∀ y → Id x y → Set ℓ'
 J-comp _ = refl
 
 outPartial : ∀ {ℓ} {A : Set ℓ} → Partial i1 A → A
-outPartial = λ f → f itIsOne
+outPartial = λ f → f 1=1
 
 inPartial : ∀ {ℓ} {A : Set ℓ} → A → Partial i1 A
 inPartial a = λ _ → a
@@ -111,7 +115,7 @@ module _ {ℓ ℓ'} {A : I → Set ℓ} {B : ∀ i → A i → Set ℓ'}
     v : (i : I) → A i
     v i = primTransp (λ j → A (i ∨ (~ j))) i x1
     f : ∀ i → (a : A i) → Partial φ (B i a)
-    f i a = λ { (φ = i1) → u i itIsOne a  }
+    f i a = λ { (φ = i1) → u i 1=1 a  }
 
 
   compPi' : (φ : I) → (u : ∀ i → Partial φ (C i)) → (a : C i0 [ φ ↦ u i0 ]) → C i1
@@ -125,7 +129,7 @@ module HCompPathP {ℓ} {A : I → Set ℓ} (u : A i0) (v : A i1) (φ : I)
          (let C = PathP A u v) (p : ∀ i → Partial φ C) (p0 : C [ φ ↦ p i0 ]) where
 
   hcompPathP : C
-  hcompPathP j = primHComp (\ { i (φ = i1) → p i itIsOne j
+  hcompPathP j = primHComp (\ { i (φ = i1) → p i 1=1 j
                               ; i (j = i0) → u
                               ; i (j = i1) → v })
                            (outS p0 j)
@@ -165,16 +169,16 @@ module RecordComp where
     (let ℓ = _ ; Z : Set ℓ ; Z = R(A)(B)(C))
     (φ : I) → (u : ∀ i → Partial φ Z) → Z [ φ ↦ u i0 ] → Z
   fst (hcompR {A = A} {B} φ w w0)
-    = primComp (\ _ → A) (λ i →  (λ{ (φ = i1) → fst (w i itIsOne) }) ) (fst (outS w0))
+    = primComp (\ _ → A) (λ i →  (λ{ (φ = i1) → fst (w i 1=1) }) ) (fst (outS w0))
   snd (hcompR {A = A} {B} φ w w0)
-    = primComp (λ i → B (a i)) (λ i → (λ { (φ = i1) → snd (w i itIsOne) })) (snd (outS w0))
+    = primComp (λ i → B (a i)) (λ i → (λ { (φ = i1) → snd (w i 1=1) })) (snd (outS w0))
     where
-      a = fill (λ z → A) (λ i → (λ { (φ = i1) → fst (w i itIsOne) }) ) (inS (fst (outS w0)))
+      a = fill (λ z → A) (λ i → (λ { (φ = i1) → fst (w i 1=1) }) ) (inS (fst (outS w0)))
   trd (hcompR {A = A} {B} {C} φ w w0)
-    = primComp (λ i → C (a i) (b i)) ((λ i → (λ { (φ = i1) → trd (w i itIsOne)}))) (trd (outS w0))
+    = primComp (λ i → C (a i) (b i)) ((λ i → (λ { (φ = i1) → trd (w i 1=1)}))) (trd (outS w0))
     where
-      a = fill (λ z → A) (λ i → (λ { (φ = i1) → fst (w i itIsOne) }) ) (inS (fst (outS w0)))
-      b = fill (λ i → B (a i)) (λ i → (λ { (φ = i1) → snd (w i itIsOne) }) ) (inS (snd (outS w0)))
+      a = fill (λ z → A) (λ i → (λ { (φ = i1) → fst (w i 1=1) }) ) (inS (fst (outS w0)))
+      b = fill (λ i → B (a i)) (λ i → (λ { (φ = i1) → snd (w i 1=1) }) ) (inS (snd (outS w0)))
 
   module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'}
                   {C : (x : A) → B x → Set ℓ}
@@ -233,20 +237,31 @@ module _ {ℓ} {A : Set ℓ} {φ : I} {T : Partial φ (Set ℓ)}
     (glue {φ = φ} (λ{ (φ = i1) → b }) (unglue {φ = φ} b)) ≡ b
   test-Glue-η b = refl
 
+module _ {ℓ} {φ : I} {T : I → Partial φ (Set ℓ)} {A : Set ℓ [ φ ↦ T i0 ]} where
+  test-HCompU-β :
+    (t : PartialP φ (T i1))
+    (a : outS A [ φ ↦ (λ { (φ = i1) → primTransp (λ i → T (~ i) 1=1) i0 (t 1=1) }) ] ) →
+    unglueU {φ = φ} {T = T} {A = A} (glueU {φ = φ} {T = T} {A = A} t (outS a)) ≡ outS a
+  test-HCompU-β t a = refl
+
+  test-HCompU-η : (b : primHComp T (outS A)) →
+    glueU {φ = φ} {A = A} (λ { (φ = i1) → b }) (unglueU {φ = φ} {A = A} b) ≡ b
+  test-HCompU-η b = refl
+
 module _ {ℓ} {A : Set ℓ} (let φ = i1) {T : Partial φ (Set ℓ)}
              {e : PartialP φ (λ o → T o ≃ A)}
               where
   test-unglue-0 : (b : Glue A T e) →
-    unglue {A = A} {φ = φ} {T = T} {e} b ≡ e itIsOne .fst b
+    unglue {A = A} {φ = φ} {T = T} {e} b ≡ e 1=1 .fst b
   test-unglue-0 _ = refl
 
   test-unglue-2 : (t : PartialP φ T) (a : A [ φ ↦ (\ o → e o .fst (t o)) ]) →
     unglue {A = A} {φ = φ} {T = T} {e}
-    (glue {A = A}{φ = φ}{T = T}{e} t (outS a)) ≡ e itIsOne .fst (t itIsOne) -- = a
+    (glue {A = A}{φ = φ}{T = T}{e} t (outS a)) ≡ e 1=1 .fst (t 1=1) -- = a
   test-unglue-2 _ _ = refl
 
   test-glue-0 : (t : PartialP φ T) (a : A [ φ ↦ (\ o → e o .fst (t o)) ]) →
-    (glue {A = A} {T = T} {e} t (outS a)) ≡ t itIsOne
+    (glue {A = A} {T = T} {e} t (outS a)) ≡ t 1=1
   test-glue-0 _ _ = refl
 
 eqToPath : ∀ {ℓ} {A B : Set ℓ} → A ≃ B → A ≡ B
@@ -393,6 +408,7 @@ record Wrap (A : IUniv) : SSet where
     unwrap : A
 
 -- composition and transport in I → A
+
 
 module HCompI→ {ℓ} {A : I → Set ℓ} (φ : I)
    (let C = (j : I) → A j) (p : ∀ i → Partial φ C) (p0 : C [ φ ↦ p i0 ])

--- a/test/Succeed/SwanIdEtaTricks.agda
+++ b/test/Succeed/SwanIdEtaTricks.agda
@@ -1,0 +1,82 @@
+{-# OPTIONS --cubical #-}
+
+module SwanIdEtaTricks where
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive.Cubical
+  renaming (primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primComp to comp ; primHComp to hcomp ; primTransp to transp)
+import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.Cubical.Id renaming (IdJ to J ; primIdElim to idElim ; reflId to refl ; Id to infix 4 _≡_)
+open import Agda.Builtin.Cubical.Sub renaming (primSubOut to outS; Sub to _[_↦_])
+
+{-# NO_UNIVERSE_CHECK #-}
+record Smuggle {ℓ} (A : SSet ℓ) : Type ℓ where
+  constructor shh
+  field huh! : A
+
+data IdView {ℓ} {A : Type ℓ} {x : A} : {y : A} → x ≡ y → SSet ℓ where
+  ⟨_,_,_⟩
+    : (φ : I) (z : A [ φ ↦ (λ ._ → x) ]) (p : (PathP (λ _ → A) x (outS z)) [ φ ↦ (λ { (φ = i1) → λ i → x } ) ])
+    → IdView (conid φ (outS p))
+
+_ : ∀ {ℓ} {A : Type ℓ} {x y : A} (p : x ≡ y) → p ≡ primExpandId p
+_ = λ p → refl
+
+-- conveniently evil:
+view : ∀ {ℓ} {A : Type ℓ} {x y : A} (p : x ≡ y) → IdView p
+view p = Smuggle.huh! (idElim (λ y p → Smuggle (IdView p)) (λ φ y w → shh ⟨ φ , y , w ⟩) (primExpandId p))
+--                                                       new primitive powers this stuff: ^^^^^^^^^^^^^^
+-- the code below could be rewritten not to use view/Smuggle at all (by
+-- inlining the primIdElim (primExpandId p) calls), which would make it
+-- compatible with --safe, but noisier. i went with the short & even
+-- more evil version
+
+_∙_ : ∀ {ℓ} {A : Type ℓ} {x y z : A} → x ≡ y → y ≡ z → x ≡ z
+_∙_ {x = x} {y} {z} p q with view p | view q
+... | ⟨ φ , y′ , p ⟩ | ⟨ ψ , z′ , q ⟩ = conid (φ ∧ ψ) λ i → hcomp
+  (λ { j (i = i0) → x
+     ; j (i = i1) → outS q j
+     ; j (φ = i1) → outS q (i ∧ j)
+     ; j (ψ = i1) → outS p i
+     })
+  (outS p i)
+
+idl : {A : Type} {x y : A} (p : x ≡ y) → refl ∙ p ≡ p
+idl p = refl
+
+idr : {A : Type} {x y : A} (p : x ≡ y) → p ∙ refl ≡ p
+idr p = refl
+
+assoc′
+  : {A : Type} {w x y z : A} (p : w ≡ x) (q : x ≡ y) (r : y ≡ z)
+  → (p ∙ (q ∙ r)) ≡ ((p ∙ q) ∙ r)
+assoc′ refl q r = refl
+
+ap : ∀ {ℓ ℓ′} {A : Type ℓ} {B : Type ℓ′} (f : A → B) {x y : A} → x ≡ y → f x ≡ f y
+ap f {x} p with view p
+... | ⟨ φ , y′ , w ⟩ = conid φ λ i → f (outS w i)
+
+sym : ∀ {ℓ} {A : Type ℓ} {x y : A} → x ≡ y → y ≡ x
+sym p with view p
+... | ⟨ φ , y′ , w ⟩ = conid φ λ i → outS w (~ i)
+
+sym-inv : ∀ {ℓ} {A : Type ℓ} {x y : A} (p : x ≡ y) → sym (sym p) ≡ p
+sym-inv p = refl
+
+J-comp : ∀ {ℓ ℓ'} {A : Set ℓ} {x : A} {P : ∀ y → x ≡ y → Set ℓ'} →
+         (d : P x (conid i1 (λ i → x))) → J P d (conid i1 (λ i → x)) ≡ d
+J-comp d = refl
+
+ap-comp
+  : ∀ {ℓ ℓ′ ℓ′′} {A : Type ℓ} {B : Type ℓ′} {C : Type ℓ′′} {x y : A} (p : x ≡ y)
+  → (f : B → C) (g : A → B)
+  → ap f (ap g p) ≡ ap (λ x → f (g x)) p
+ap-comp p f g = refl
+
+ap-comp-path
+  : ∀ {ℓ ℓ′} {A : Type ℓ} {B : Type ℓ′} {x y z : A} (p : x ≡ y) (q : y ≡ z) (f : A → B)
+  → ap f (p ∙ q) ≡ ap f p ∙ ap f q
+ap-comp-path refl q f = refl
+
+pathToId : ∀ {ℓ} {A : Type ℓ} {x y : A} → PathP (λ _ → A) x y → x ≡ y
+pathToId {x = x} p = transp (λ i → x ≡ p i) i0 refl


### PR DESCRIPTION
This PR changes the conversion checker so it'll compare `x, y : Id a b` by their projections `primIdFace` and `primIdPath` rather than falling back to `compareAtom`. I also went and unified the logic used for handling η records and the η rules for Cubical Agda types (that's the new `Eta` module/`EtaKit` stuff, I'll write Haddock tomorrow).

The `primIdElim` primitive (and functions matching on `Id a b`) still only compute on literal `conid` forms (and `reflId`, too, I guess). I'm not sure whether this can be changed so they compute on everything — I originally had it immediately evaluate to projections, too, but it was rather loopy. This was several hours ago, though, before I unified the handling of η in the conversion checker, so it's possible it's better now.

Eta for `Id`, together with a new `primExpandId p` primitive enable the definition of ~~evil~~ optimised combinators on the `Id` type, like the `p ∙ q` operator which is strictly unital in both arguments(!), doing better than both inductive equality _and_ paths. The new `primExpandId` is **super evil**. It's the identity function: it reduces to `conid (primIdFace p) (primIdPath p)`. But note that since its reduct is a constructor, `primIdElim _ _ (primExpandId p)` will always compute, regardless of whether `primIdElim _ _ p` would be stuck or not.