### PR TITLE
re #6298: consider also arguments when checking modality at LHS

### DIFF
--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -773,7 +773,8 @@ createMissingTrXConClause q_trX f n x old_sc c (UE gamma gamma' xTel u v rho tau
             (phi:p) <- sequence phi_p
             args <- sequence args
             let cargs = defaultArg $ unnamed $ ConP chead noConPatternInfo args
-            param_args <- fmap (map (setHiding Hidden . fmap (unnamed . dotP))) $
+            -- Amy (2022-11-06): Set the parameters to quantity-0.
+            param_args <- fmap (map (setQuantity (Quantity0 Q0Inferred) . setHiding Hidden . fmap (unnamed . dotP))) $
               pure params `applyN` take gamma1_size (fmap unArg <$> g1_args)
             pure $ DefP defaultPatternInfo q_trX $ param_args ++ p ++ [phi,cargs]
       pat = (fmap . fmap) patternToTerm <$> pat'

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -353,7 +353,7 @@ instance UsableRelevance a => UsableRelevance (Elim' a) where
   usableRel rel (Proj _ p) = do
     prel <- relOfConst p
     return $ prel `moreRelevant` rel
-  usableRel rel (IApply x y v) = allM [x,y,v] $ usableRel rel
+  usableRel rel (IApply x y v) = usableRel rel v
 
 instance UsableRelevance a => UsableRelevance (Arg a) where
   usableRel rel (Arg info u) =
@@ -474,7 +474,7 @@ instance UsableModality a => UsableModality (Elim' a) where
   usableMod mod (Proj _ p) = do
     pmod <- modalityOfConst p
     return $ pmod `moreUsableModality` mod
-  usableMod mod (IApply x y v) = allM [x,y,v] $ usableMod mod
+  usableMod mod (IApply x y v) = usableMod mod v
 
 instance UsableModality a => UsableModality (Arg a) where
   usableMod mod (Arg info u) =

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -508,12 +508,12 @@ usableAtModality' ms why mod t =
           | compatible = "to maintain compatibility with Cubical Agda,"
           | otherwise  = "when --without-K is enabled,"
 
-        explanation
+        explanation what
           | cubical || compatible =
             [ ""
             , fsep ( "Note:":pwords context
-                  ++ pwords "the target type must be usable at the modality"
-                  ++ pwords "in which the function was defined, since it is"
+                  ++ pwords what ++ pwords "must be usable at the modality"
+                  ++ pwords "in which the function was defined, since it will be"
                   ++ pwords "used for computing transports"
                   )
             , ""
@@ -528,7 +528,24 @@ usableAtModality' ms why mod t =
                   ++ pwords "which is not usable at the required modality"
                   ++ [pure (attributesForModality mod) <> "."]
                    )
-            : explanation)
+            : explanation "the target type")
+
+        -- Arguments sometimes need to be transported too:
+        IndexedClauseArg forced the_arg ->
+          vcat $
+            ( fsep (pwords "The argument" ++ [prettyTCM the_arg] ++ pwords "has type")
+            : nest 2 (prettyTCM t)
+            : fsep ( pwords "which is not usable at the required modality"
+                  ++ [pure (attributesForModality mod) <> "."] )
+            : explanation "this argument's type")
+
+        -- Note: if a generated clause is modality-incorrect, that's a
+        -- bug in the LHS modality check
+        GeneratedClause ->
+          __IMPOSSIBLE_VERBOSE__ . show =<<
+                   prettyTCM t
+              <+> "is not usable at the required modality"
+              <+> pure (attributesForModality mod)
         _ -> prettyTCM t <+> "is not usable at the required modality"
          <+> pure (attributesForModality mod)
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1100,6 +1100,13 @@ data WhyCheckModality
   | IndexedClause
   -- ^ Because --without-K is enabled, so the result type of clauses
   -- must be usable at the context's modality.
+  | IndexedClauseArg Name Name
+  -- ^ Because --without-K is enabled, so any argument (second name)
+  -- which mentions a dotted argument (first name) must have a type
+  -- which is usable at the context's modality.
+  | GeneratedClause
+  -- ^ Because we double-check the --cubical-compatible clauses. This is
+  -- an internal error!
   deriving (Show, Generic)
 
 data Constraint

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
@@ -330,12 +330,12 @@ buildEquiv (UnificationStep st step@(Solution k ty fx tm side) output) next = ru
                   -- csingl :: NamesT tcm Term -> NamesT tcm [Arg Term]
                   csingl i = mapM (fmap defaultArg) $ csingl' i
                   -- csingl' :: NamesT tcm Term -> [NamesT tcm Term]
-                  csingl' i = [ k_arg <@@> (u,v,appSide <$> i)
+                  csingl' i = [ k_arg <@> (appSide <$> i)
                               , lam "j" $ \ j ->
                                   let r i j = case side of
                                             Left{} -> unview (IMax (argN j) (argN i))
                                             Right{} -> unview (IMin (argN j) (argN . unview $ INeg $ argN i))
-                                  in k_arg <@@> (u,v,r <$> i <*> j)
+                                  in k_arg <@> (r <$> i <*> j)
                               ]
           let replaceAt n x xs = xs0 ++ x:xs1
                 where (xs0,_:xs1) = splitAt n xs

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
@@ -330,12 +330,12 @@ buildEquiv (UnificationStep st step@(Solution k ty fx tm side) output) next = ru
                   -- csingl :: NamesT tcm Term -> NamesT tcm [Arg Term]
                   csingl i = mapM (fmap defaultArg) $ csingl' i
                   -- csingl' :: NamesT tcm Term -> [NamesT tcm Term]
-                  csingl' i = [ k_arg <@> (appSide <$> i)
+                  csingl' i = [ k_arg <@@> (u, v, appSide <$> i)
                               , lam "j" $ \ j ->
                                   let r i j = case side of
                                             Left{} -> unview (IMax (argN j) (argN i))
                                             Right{} -> unview (IMin (argN j) (argN . unview $ INeg $ argN i))
-                                  in k_arg <@> (r <$> i <*> j)
+                                  in k_arg <@@> (u, v, r <$> i <*> j)
                               ]
           let replaceAt n x xs = xs0 ++ x:xs1
                 where (xs0,_:xs1) = splitAt n xs

--- a/test/Fail/Issue5448-1.err
+++ b/test/Fail/Issue5448-1.err
@@ -1,10 +1,9 @@
-Issue5448-1.agda:8,1-15
+Issue5448-1.agda:8,9-13
 This clause has target type P x which is not usable at the required
 modality @ω.
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,
-since it is used for computing transports
+since it will be used for computing transports
 
-when checking the clause left hand side
-subst P refl p
+when checking that the pattern refl has type x ≡ y

--- a/test/Fail/Issue5448-2.err
+++ b/test/Fail/Issue5448-2.err
@@ -1,10 +1,9 @@
-Issue5448-2.agda:8,1-15
+Issue5448-2.agda:8,9-13
 This clause has target type P x which is not usable at the required
 modality @ω.
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,
-since it is used for computing transports
+since it will be used for computing transports
 
-when checking the clause left hand side
-subst P refl p
+when checking that the pattern refl has type x ≡ y

--- a/test/Fail/Issue5448-3.err
+++ b/test/Fail/Issue5448-3.err
@@ -1,10 +1,9 @@
-Issue5448-3.agda:8,1-15
+Issue5448-3.agda:8,9-13
 This clause has target type P x which is not usable at the required
 modality @ω.
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,
-since it is used for computing transports
+since it will be used for computing transports
 
-when checking the clause left hand side
-subst P refl p
+when checking that the pattern refl has type x ≡ y

--- a/test/Fail/Issue5448-4-noK.err
+++ b/test/Fail/Issue5448-4-noK.err
@@ -1,5 +1,4 @@
-Issue5448-4-noK.agda:8,1-15
+Issue5448-4-noK.agda:8,9-13
 This clause has target type P x which is not usable at the required
 modality @ω.
-when checking the clause left hand side
-subst P refl p
+when checking that the pattern refl has type x ≡ y

--- a/test/Fail/Issue5448-4.err
+++ b/test/Fail/Issue5448-4.err
@@ -1,10 +1,9 @@
-Issue5448-4.agda:8,1-15
+Issue5448-4.agda:8,9-13
 This clause has target type P x which is not usable at the required
 modality @ω.
 
 Note: to maintain compatibility with Cubical Agda, the target type
 must be usable at the modality in which the function was defined,
-since it is used for computing transports
+since it will be used for computing transports
 
-when checking the clause left hand side
-subst P refl p
+when checking that the pattern refl has type x ≡ y

--- a/test/Fail/Issue5468.err
+++ b/test/Fail/Issue5468.err
@@ -1,9 +1,9 @@
-Issue5468.agda:33,1-16
-This clause has target type primTransp (λ i → x i) φ (unbox [ x₁ ])
-which is not usable at the required modality @ω.
+Issue5468.agda:33,7-12
+This clause has target type A which is not usable at the required
+modality @ω.
 
 Note: in Cubical Agda, the target type must be usable at the
 modality in which the function was defined, since it will be used
 for computing transports
 
-when checking the definition of unbox
+when checking that the pattern [ x ] has type Box A

--- a/test/Fail/Issue5468.err
+++ b/test/Fail/Issue5468.err
@@ -1,9 +1,9 @@
 Issue5468.agda:33,1-16
 This clause has target type primTransp (λ i → x i) φ (unbox [ x₁ ])
-which is not usable at the required modality @irrelevant.
+which is not usable at the required modality @ω.
 
 Note: in Cubical Agda, the target type must be usable at the
-modality in which the function was defined, since it is used for
-computing transports
+modality in which the function was defined, since it will be used
+for computing transports
 
 when checking the definition of unbox

--- a/test/Fail/Issue6298.agda
+++ b/test/Fail/Issue6298.agda
@@ -1,0 +1,10 @@
+{-# OPTIONS --cubical-compatible #-}
+module Issue6298 where
+
+open import Agda.Builtin.Equality
+
+-- Fails because the A argument is used to compute the transport of P
+-- along the path representing eq. The x argument is forced to be y, so
+-- the fact that *it* is erased does not matter.
+J : ∀ (@0 A : Set) (@0 x : A) (P : (y : A) → x ≡ y → Set) → (prefl : P x refl) → (y : A) (eq : x ≡ y) → P y eq
+J A xyz P prefl x refl = prefl

--- a/test/Fail/Issue6298.err
+++ b/test/Fail/Issue6298.err
@@ -1,0 +1,10 @@
+Issue6298.agda:7,19-23
+The argument P has type
+  (y : A) → x ≡ y → Set
+which is not usable at the required modality @ω.
+
+Note: to maintain compatibility with Cubical Agda, this argument's
+type must be usable at the modality in which the function was
+defined, since it will be used for computing transports
+
+when checking that the pattern refl has type xyz ≡ x

--- a/test/Fail/Issue6298.err
+++ b/test/Fail/Issue6298.err
@@ -1,4 +1,4 @@
-Issue6298.agda:7,19-23
+Issue6298.agda:10,19-23
 The argument P has type
   (y : A) → x ≡ y → Set
 which is not usable at the required modality @ω.

--- a/test/Succeed/Issue6298.agda
+++ b/test/Succeed/Issue6298.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --cubical-compatible #-}
+module Issue6298 where
+
+open import Agda.Builtin.Equality
+
+-- The argument x looks like it might throw a spanner in the works, but
+-- the trX-con clause generated here will be modality-correct
+-- regardless. This is because the left inverse generated (really, the
+-- unification log) will eliminate x in favour of y, instead of the
+-- other way around.
+J : ∀ (A : Set) (@0 x : A) (P : (y : A) → x ≡ y → Set) → (prefl : P x refl) → (y : A) (eq : x ≡ y) → P y eq
+J A xyz P prefl x refl = prefl


### PR DESCRIPTION
Fixes #6298 by considering also any arguments that might be transported. I'm throwing this PR up now, but if CI fails, I'll only be able to get to it on Monday (flying out for the AIM tomorrow). But note that I've run the `fail`, `succeed` and `interaction` suites locally and they all passed (modulo some interaction tests which use Agda as a library, which always fail at the GHC stage on my machine :pensive:)

Additionally, I've made it so that modality errors in the `--cubical-compatible` generated clauses are `__IMPOSSIBLE__`. Other than the code from #6298 itself, the failing test case in #5468 was also only caught by the generation of internal clauses. This is now fixed, by checking both the original type (before the substitution from index unification is applied) and the substituted type.