### PR TITLE
[ #5635 ] The JS backend now rejects Erased Cubical Agda code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -475,7 +475,6 @@ tracker](https://github.com/agda/agda/issues)):
   - [#5760](https://github.com/agda/agda/issues/5760): Some code related to Cubical Agda runs also when the K rule is on
   - [#5763](https://github.com/agda/agda/issues/5763): Internal parser error using syntax rules
   - [#5765](https://github.com/agda/agda/issues/5765): Erasure check failure when pattern matching on refl in erased definition
-  - [#5769](https://github.com/agda/agda/issues/5769): Parameter arguments of projections of instance-opened record type are not erased
   - [#5775](https://github.com/agda/agda/issues/5775): JSON interaction produces fully qualified terms
   - [#5794](https://github.com/agda/agda/issues/5794): Agsy/Auto crashes with `Prelude.!!: index too large`
   - [#5823](https://github.com/agda/agda/issues/5823): Singleton check loops on recursive eta record

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Highlights
 
 * Added support for [Erased Cubical
   Agda](https://agda.readthedocs.io/en/latest/language/cubical.html#cubical-agda-with-erased-glue),
-  a variant of Cubical Agda that is supported by the GHC and
-  JavaScript backends, under the flag `--erased-cubical`.
+  a variant of Cubical Agda that is supported by the GHC backend,
+  under the flag `--erased-cubical`.
 
 * Added a new flag `--cubical-compatible` to turn on generation of
   Cubical Agda-specific support code (previously this behaviour was
@@ -55,8 +55,8 @@ Erasure
   manual](https://agda.readthedocs.io/en/latest/language/cubical.html#cubical-agda-with-erased-glue-and-erased-higher-constructors)
   for more details.
 
-  The GHC and JS backends can compile code that uses
-  `--erased-cubical` if the top-level module uses this flag.
+  The GHC backend can compile code that uses `--erased-cubical` if the
+  top-level module uses this flag.
 
   This feature is experimental.
 
@@ -406,7 +406,7 @@ Compiler backends
   `--cubical`.
 
   Note that support for compiling code that uses `--erased-cubical`
-  has been added to both backends (see above).
+  has been added to the GHC backend (see above).
 
 * If the GHC backend is invoked when `--interaction` or
   `--interaction-json` is active (for instance when the Emacs mode is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,10 @@ Erasure
 
 * The parameter arguments of constructors and record fields are now
   marked as erased
-  ([#4786](https://github.com/agda/agda/issues/4786)).
+  ([#4786](https://github.com/agda/agda/issues/4786)), with one
+  exception: for indexed data types this only happens if the
+  `--with-K` flag is active
+  ([#6297](https://github.com/agda/agda/issues/6297)).
 
   For instance, the type of the constructor `c` below is now `{@0 A :
   Set} → D A`, and the type of the record field `R.f` is `{@0 A : Set}

--- a/doc/user-manual/language/runtime-irrelevance.lagda.rst
+++ b/doc/user-manual/language/runtime-irrelevance.lagda.rst
@@ -47,7 +47,9 @@ arguments.
 .. note::
   In the type signature of a constructor or record field the
   parameters are always marked as erased, even if the parameters are
-  not marked as erased in the data or record type's telescope.
+  not marked as erased in the data or record type's telescope, with
+  one exception: for indexed data types this only happens if the
+  :option:`--with-K` flag is active.
 
 Erasure annotations can also appear in function arguments (both first-order and higher-order). For instance, here is
 an implementation of ``foldl`` on vectors::

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -156,7 +156,7 @@ jsPreCompile opts = do
           "Compilation of code that uses " ++ s ++ " is not supported."
   case cubical of
     Nothing      -> return ()
-    Just CErased -> return ()
+    Just CErased -> notSupported "--erased-cubical"
     Just CFull   -> notSupported "--cubical"
 
   return opts

--- a/test/Compiler/simple/Erased-cubical.options
+++ b/test/Compiler/simple/Erased-cubical.options
@@ -1,0 +1,9 @@
+TestOptions
+  { forCompilers =
+      [ (MAlonzo Lazy,       CompilerOptions {extraAgdaArgs = []})
+      , (MAlonzo StrictData, CompilerOptions {extraAgdaArgs = []})
+      , (MAlonzo Strict,     CompilerOptions {extraAgdaArgs = []})
+      ]
+  , runtimeOptions = []
+  , executeProg = True
+  }

--- a/test/Fail/Issue6297.agda
+++ b/test/Fail/Issue6297.agda
@@ -1,0 +1,7 @@
+{-# OPTIONS --without-K #-}
+
+data _≡_ {A : Set} (x : A) : A → Set where
+  refl : x ≡ x
+
+refl′ : (A : Set) (@0 x : A) → x ≡ x
+refl′ A x = refl {A = A} {x = x}

--- a/test/Fail/Issue6297.err
+++ b/test/Fail/Issue6297.err
@@ -1,0 +1,3 @@
+Issue6297.agda:7,31-32
+Variable x is declared erased, so it cannot be used here
+when checking that the expression x has type A

--- a/test/Succeed/Erasure-succeed-Issue3855.agda
+++ b/test/Succeed/Erasure-succeed-Issue3855.agda
@@ -64,8 +64,14 @@ module ErasedEquality where
 
 module ParametersAreErased where
 
-  test : (@0 A : Set) → A ≡ A
-  test A = refl {x = A}
+  -- This module uses --with-K, so the parameters of this indexed data
+  -- type are erased in the type of the constructor c.
+
+  data D (A : Set) : Bool → Set where
+    c : D A true
+
+  test : (@0 A : Set) → D A true
+  test A = c {A = A}
 
 module Records where
 

--- a/test/interaction/Issue4022.out
+++ b/test/interaction/Issue4022.out
@@ -5,7 +5,7 @@
 (agda2-info-action "*All Done*" "" nil)
 ((last . 1) . (agda2-goals-action '()))
 (agda2-status-action "Checked")
-(agda2-info-action "*Search About*" "Definitions about _≡_ primCharToNatInjective : (a b : Char) → primCharToNat a ≡ primCharToNat b → a ≡ b primFloatToWord64Injective : (a b : Float) → primFloatToWord64 a ≡ primFloatToWord64 b → a ≡ b primStringFromListInjective : (a b : List Char) → primStringFromList a ≡ primStringFromList b → a ≡ b primStringToListInjective : (a b : String) → primStringToList a ≡ primStringToList b → a ≡ b refl : {@0 a : Agda.Primitive.Level} {@0 A : Set a} {@0 x : A} → x ≡ x" nil)
+(agda2-info-action "*Search About*" "Definitions about _≡_ primCharToNatInjective : (a b : Char) → primCharToNat a ≡ primCharToNat b → a ≡ b primFloatToWord64Injective : (a b : Float) → primFloatToWord64 a ≡ primFloatToWord64 b → a ≡ b primStringFromListInjective : (a b : List Char) → primStringFromList a ≡ primStringFromList b → a ≡ b primStringToListInjective : (a b : String) → primStringToList a ≡ primStringToList b → a ≡ b refl : {a : Agda.Primitive.Level} {A : Set a} {x : A} → x ≡ x" nil)
 (agda2-status-action "Checked")
 (agda2-info-action "*Search About*" "Definitions about _≡_, \"prim\" primCharToNatInjective : (a b : Char) → primCharToNat a ≡ primCharToNat b → a ≡ b primFloatToWord64Injective : (a b : Float) → primFloatToWord64 a ≡ primFloatToWord64 b → a ≡ b primStringFromListInjective : (a b : List Char) → primStringFromList a ≡ primStringFromList b → a ≡ b primStringToListInjective : (a b : String) → primStringToList a ≡ primStringToList b → a ≡ b" nil)
 (agda2-status-action "Checked")


### PR DESCRIPTION
This fixes #5635, except that I have not updated the changelog, which has been [removed](https://github.com/agda/agda/commit/a5e93b99f134f40a2cfb5136889dedd9e7964dd3).