### PR TITLE
[ re #6211 ] Pull off the band-aid

### DIFF
--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -64,10 +64,8 @@ addConstraintTCM unblock c = do
         , "unblocker: " , prettyTCM unblock
         ]
       -- Jesper, 2022-10-22: We should never block on a meta that is
-      -- already solved. However, currently this is not always
-      -- strictly adhered to. TODO: pull off the band-aid and
-      -- uncomment the following line.
-      -- whenM (anyM (Set.toList $ allBlockingMetas unblock) isInstantiatedMeta) __IMPOSSIBLE__
+      -- already solved.
+      whenM (anyM (Set.toList $ allBlockingMetas unblock) isInstantiatedMeta) __IMPOSSIBLE__
       -- Need to reduce to reveal possibly blocking metas
       c <- reduce =<< instantiateFull c
       caseMaybeM (simpl c) {-no-} (addConstraint' unblock c) $ {-yes-} \ cs -> do


### PR DESCRIPTION
This adds a check that we never postpone a constraint on a metavariable that is already solved. This might cause some internal errors at first, but hopefully we have enough time before 2.6.4 to fix them.