### PR TITLE
Embrace git switch/restore

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -58,8 +58,8 @@ For instance, fixing issue 1234 would work as follows.
 Suppose you are using `upstream` as your upstream Agda repository.
 This could be either `origin` (if you have push rights) or your own fork of Agda.
 
-    git checkout master
-    git checkout -b issue1234 # create a new branch based on master
+    git switch master
+    git switch -c issue1234 # create a new branch based on master
     ... work on issue 1234 ...
     git commit -p             # record some patches
 
@@ -92,7 +92,7 @@ the following recipe:
   ```sh
     git clone <agda repository> agda-bug
     cd agda-bug
-    git checkout <suitable branch>
+    git switch <suitable branch>
     cabal sandbox init
     git bisect start <bad commit> <good commit>
     cp <some path>/Module-that-should-be-accepted.agda .
@@ -160,7 +160,7 @@ Standard library submodule
   `/std-lib` subdirectory will appear as a git repository in a detached-HEAD
   state.
 
-  To avoid this, you may run, inside the submodule directory `git checkout <branch name>`
+  To avoid this, you may run, inside the submodule directory `git switch <branch name>`
 
   and then, from the root directory `git submodule update --remote [--merge|--rebase]`.
 

--- a/notes/agda-future-branch-releases.txt
+++ b/notes/agda-future-branch-releases.txt
@@ -4,7 +4,7 @@ Some notes when releasing from the future branch (INCOMPLETE).
 
     git clone git@github.com:agda/agda agda-release
     cd agda-release
-    git checkout future
+    git switch future
 
 * The version of the release is current version in the future branch, so if
   this is 2.5.0 the versions used in these notes are:
@@ -29,7 +29,7 @@ Some notes when releasing from the future branch (INCOMPLETE).
 
   ** Merge future into master
 
-       git checkout master
+       git switch master
        git merge future
 
   ** Update the version numbers to $NEXT_MASTER_VERSION in $FILES.
@@ -46,7 +46,7 @@ Some notes when releasing from the future branch (INCOMPLETE).
 
   ** Merge the master back into the future branch.
 
-       git checkout future
+       git switch future
        git merge master
 
 * Update the version numbers to $NEXT_FUTURE_VERSION in $FILES.

--- a/notes/agda-releases-candidates.txt
+++ b/notes/agda-releases-candidates.txt
@@ -44,11 +44,11 @@ followed:
     VERSION=<current-released-version-eg-2.4.0.2>
     git clone git@github.com:agda/agda.git agda-release
     cd agda-release
-    git checkout master
+    git switch master
 
 * Create the branch used for the release
 
-    git checkout -b release-$MAJORVERSION
+    git switch -c release-$MAJORVERSION
 
 * The version of the RC is $VERSION + current date
 

--- a/notes/agda-releases.txt
+++ b/notes/agda-releases.txt
@@ -61,7 +61,7 @@ When releasing the following procedure can be followed:
     VERSION=<current-released-version-eg-2.4.0.2>
     git clone git@github.com:agda/agda.git agda-release
     cd agda-release
-    git checkout master
+    git switch master
 
 * Update the Agda version
 


### PR DESCRIPTION
Git 2.23 introduced git switch/restore three years ago. While they remain "experimental", there is no sign that they would be changed. Perhaps it is time to embrace the better version of git checkout.

PS: I did not change `release.sh` in this PR. See #6323.