### PR TITLE
Fix release sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -8,10 +8,10 @@ ChoicesQuestion() {
     shift; shift; shift
     while true; do
         {   echo -n "$question ["
-            [ "$default" = "$first" ] && echo -n "$first" | tr '[a-z]' '[A-Z]' || echo -n "$first"
+            [ "$default" = "$first" ] && echo -n "$first" | tr 'a-z' 'A-Z' || echo -n "$first"
             for c in "$@"; do
                 echo -n '/'
-                [ "$default" = "$c" ] && echo -n "$c" | tr '[a-z]' '[A-Z]' || echo -n "$c"
+                [ "$default" = "$c" ] && echo -n "$c" | tr 'a-z' 'A-Z' || echo -n "$c"
             done
             echo -n '] '
             read ans;

--- a/release.sh
+++ b/release.sh
@@ -77,7 +77,7 @@ git clone "$url" "$srcdir"
 cd "$srcdir"
 
 version=$( sed -rn '/^version:\s*([0-9]+\.[0-9]+)\.([0-9]+)(\.[0-9]+)?\s*$/ {s//\1 \2/p; q}' Agda.cabal \
-         | { read -r maj min; echo "$maj.$(( 1 + $min))"; } )
+         | { read -r maj min; echo "$maj.$(( 1 + min))"; } )
 version=$( Question "Release version number?" "$version" )
 echo "$version" | grep -Eqx "[0-9]+(\.[0-9]+){2,3}" || { echo "Bad version number: $version" >&2; exit 1; }
 echo "$version" | grep -Eqx "[0-9]+(\.[0-9]+){2}" && maint=${version##*.} || maint=0
@@ -173,11 +173,11 @@ cabal upload "dist/Agda-$version.tar.gz"
 
 [ $maint = 0 ] && maintv="$version" || maintv="${version%.*}"
 git checkout -b "maint-$maintv"
-updateVersion "${maintv}.$(( $maint + 1 ))"
+updateVersion "${maintv}.$(( maint + 1 ))"
 
 sed -ri 's/^#\s*(override CABAL_OPTS\+=--program-suffix=-\$\(VERSION\))$/\1/' Makefile
 git add Makefile
-git commit -vm "Release ${maintv}.$(( $maint + 1))."
+git commit -vm "Release ${maintv}.$(( maint + 1))."
 
 git checkout master
 git merge "maint-$version"

--- a/release.sh
+++ b/release.sh
@@ -131,7 +131,7 @@ cabal sdist
 cabal check
 cabal install
 
-AGDA_BIN="`pwd`/.cabal-sandbox/bin/agda"
+AGDA_BIN="$(pwd)/.cabal-sandbox/bin/agda"
 export AGDA_BIN
 
 make install-fix-agda-whitespace
@@ -149,7 +149,7 @@ cabal install --only-dependencies -j
 cabal configure
 cabal install
 
-AGDA_BIN="`pwd`/.cabal-sandbox/bin/agda"
+AGDA_BIN="$(pwd)/.cabal-sandbox/bin/agda"
 export AGDA_BIN
 
 stdlib=std-lib

--- a/release.sh
+++ b/release.sh
@@ -14,7 +14,7 @@ ChoicesQuestion() {
                 [ "$default" = "$c" ] && echo -n "$c" | tr 'a-z' 'A-Z' || echo -n "$c"
             done
             echo -n '] '
-            read ans;
+            read -r ans;
         } </dev/tty >/dev/tty
         if ! [ "$ans" ]; then
             echo "$default"
@@ -34,7 +34,7 @@ YesNoQuestion() {
 Question() {
     local question="$1" default="$2" ans
     echo -n "$question [$default] " >/dev/tty
-    read ans </dev/tty
+    read -r ans </dev/tty
     [ "$ans" ] || ans="$default"
     echo "$ans"
 }
@@ -77,7 +77,7 @@ git clone "$url" "$srcdir"
 cd "$srcdir"
 
 version=$( sed -rn '/^version:\s*([0-9]+\.[0-9]+)\.([0-9]+)(\.[0-9]+)?\s*$/ {s//\1 \2/p; q}' Agda.cabal \
-         | { read maj min; echo "$maj.$(( 1 + $min))"; } )
+         | { read -r maj min; echo "$maj.$(( 1 + $min))"; } )
 version=$( Question "Release version number?" "$version" )
 echo "$version" | grep -Eqx "[0-9]+(\.[0-9]+){2,3}" || { echo "Bad version number: $version" >&2; exit 1; }
 echo "$version" | grep -Eqx "[0-9]+(\.[0-9]+){2}" && maint=${version##*.} || maint=0

--- a/release.sh
+++ b/release.sh
@@ -164,7 +164,7 @@ cd "$srcdir"
 git diff-index --cached --quiet HEAD || git commit -vm "Preparing new release ($version)."
 git tag "$version"
 git push --tags HEAD
-git checkout Agda.cabal
+git restore Agda.cabal
 
 cabal upload "dist/Agda-$version.tar.gz"
 
@@ -172,14 +172,14 @@ cabal upload "dist/Agda-$version.tar.gz"
 # XXX Announce the release of the new version on the Agda mailing list.
 
 [ $maint = 0 ] && maintv="$version" || maintv="${version%.*}"
-git checkout -b "maint-$maintv"
+git switch -c "maint-$maintv"
 updateVersion "${maintv}.$(( maint + 1 ))"
 
 sed -ri 's/^#\s*(override CABAL_OPTS\+=--program-suffix=-\$\(VERSION\))$/\1/' Makefile
 git add Makefile
 git commit -vm "Release ${maintv}.$(( maint + 1))."
 
-git checkout master
+git switch master
 git merge "maint-$version"
 
 if [ $maint = 0 ]; then
@@ -194,5 +194,5 @@ if [ $maint = 0 ]; then
 fi
 
 git push
-git checkout "maint-$version"
+git switch "maint-$version"
 git push -u origin "maint-$version"


### PR DESCRIPTION
This PR polishes the `release.sh` script a bit. Each issue is fixed by a single commit. It's probably easier to go through the git history instead of checking the accumulative changes.

PS: I did not suggest `[:lower:]` and `[:upper:]` because that would be overkill for `yn`.