### PR TITLE
[ lib ] strenghtening and decidable equality for well-scoped reflection

### DIFF
--- a/notes/reflection/ReflectionWellScoped.agda
+++ b/notes/reflection/ReflectionWellScoped.agda
@@ -265,6 +265,9 @@ unscopeSort (inf m) = R.inf m
 unscopeSort unknown = R.unknown
 
 unscopeTelescope : Telescope n m → R.Telescope
+unscopeTele : {T : Nat → Set} {R : Set} →
+              (∀ {m} → T m → R) → Tele T n m → List R
+
 unscopePattern : Pattern n m → R.Pattern
 unscopePatterns : Patterns n m → List (Arg R.Pattern)
 unscopePatterns = map (mapArg unscopePattern)
@@ -272,8 +275,10 @@ unscopePatterns = map (mapArg unscopePattern)
 unscopeClause (clause tel ps t) = R.clause (unscopeTelescope tel) (unscopePatterns ps) (unscopeTerm t)
 unscopeClause (absurd-clause tel ps) = R.absurd-clause (unscopeTelescope tel) (unscopePatterns ps)
 
-unscopeTelescope emptyTel = []
-unscopeTelescope (extTel (s , t) tel) = (s , mapArg unscopeTerm t) ∷ unscopeTelescope tel
+unscopeTelescope = unscopeTele λ { (s , arg i t) → (s , arg i (unscopeTerm t)) }
+
+unscopeTele f emptyTel = []
+unscopeTele f (extTel t tel) = f t ∷ unscopeTele f tel
 
 unscopePattern (con c ps) = R.con c (unscopePatterns ps)
 unscopePattern (dot t) = R.dot (unscopeTerm t)

--- a/notes/reflection/ReflectionWellScoped.agda
+++ b/notes/reflection/ReflectionWellScoped.agda
@@ -1012,6 +1012,13 @@ getInstances x = recoverScope' (λ{n = n} → traverseList (scopeCheckTerm {n = 
 {-# COMPILE JS runSpeculative    = _ => _ => _ =>      undefined #-}
 {-# COMPILE JS getInstances      = _ =>                undefined #-}
 
+mkMacro : (∀ {n} → Term n → TC n ⊤) → R.Term → R.TC ⊤
+mkMacro f hole = R.bindTC R.getContext λ ctx →
+  let n = length ctx in
+  TC.unTC {n = n} (let _>>=_ = bindTC in do
+    just t ← returnTC (scopeCheckTerm hole)
+      where nothing → mkTC (R.typeError (R.strErr "The IMPOSSIBLE has happened" ∷ []))
+    f t)
 
 -- -}
 -- -}


### PR DESCRIPTION
Given [Andreas' call](
https://agda.zulipchat.com/#narrow/stream/351337-aim-xxxi/topic/Well-scoped.20reflection.20API/near/309603140) to experiment with the new interface and the fact even the most basic
of tactics requires a bit of infrastructure, I thought I'd share the work I've already done
(I'm porting [this `assumption` tactic](https://github.com/gallais/potpourri/blob/main/agda/poc/Assumption.agda) for which intrinsic scopes would have helped realise
my initial misunderstanding a lot faster).