### PR TITLE
Fix #6337: keep old option name, but deprecate it

### DIFF
--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -206,7 +206,7 @@ parseBackendOptions backends argv opts0 =
       (backends, opts) <- getOptSimple (stripRTS argv)
                                        (agdaFlags ++ backendFlags) (embedFlag lSnd . inputFlag)
                                        (bs, opts0)
-      opts <- checkOpts opts
+      () <- checkOpts opts
       return (forgetAll forgetOpts backends, opts)
 
 backendInteraction :: AbsolutePath -> [Backend] -> TCM () -> (AbsolutePath -> TCM CheckResult) -> TCM ()

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -477,6 +477,7 @@ warningHighlighting' b w = case tcWarning w of
   AsPatternShadowsConstructorOrPatternSynonym{}
                              -> deadcodeHighlighting w
   RecordFieldWarning w       -> recordFieldWarningHighlighting w
+  OptionWarning w            -> mempty
   ParseWarning w             -> case w of
     Pa.UnsupportedAttribute{}     -> deadcodeHighlighting w
     Pa.MultipleAttributes{}       -> deadcodeHighlighting w

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -39,7 +39,7 @@ import qualified Agda.TypeChecking.Monad as TCM
 import qualified Agda.TypeChecking.Pretty as TCP
 import Agda.TypeChecking.Rules.Term (checkExpr, isType_)
 import Agda.TypeChecking.Errors
-import Agda.TypeChecking.Warnings (runPM)
+import Agda.TypeChecking.Warnings (runPM, warning)
 
 import Agda.Syntax.Fixity
 import Agda.Syntax.Position
@@ -926,9 +926,10 @@ cmd_load' file argv unsolvedOK mode cmd = do
     -- choice of whether or not to display implicit arguments.
     opts0 <- gets optionsOnReload
     backends <- useTC stBackends
-    z <- runOptM $ parseBackendOptions backends argv opts0
+    let (z, warns) = runOptM $ parseBackendOptions backends argv opts0
+    mapM_ (lift . warning . OptionWarning) warns
     case z of
-      Left err   -> lift $ typeError $ GenericError err
+      Left err -> lift $ typeError $ GenericError err
       Right (_, opts) -> do
         opts <- lift $ addTrustedExecutables opts
         let update o = o { optAllowUnsolved = unsolvedOK && optAllowUnsolved o}

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -5,6 +5,7 @@ module Agda.Interaction.Options.Base
     ( CommandLineOptions(..)
     , PragmaOptions(..)
     , OptionsPragma
+    , OptionWarning(..), optionWarningName
     , Flag, OptM, runOptM, OptDescr(..), ArgDescr(..)
     , Verbosity, VerboseKey, VerboseLevel
     , WarningMode(..)
@@ -34,9 +35,12 @@ module Agda.Interaction.Options.Base
     , getOptSimple
     ) where
 
+import Prelude hiding ( null )
+
 import Control.DeepSeq
 import Control.Monad ( when, void )
-import Control.Monad.Except ( Except, MonadError(throwError), runExcept )
+import Control.Monad.Except ( ExceptT, MonadError(throwError), runExceptT )
+import Control.Monad.Writer ( Writer, runWriter, MonadWriter(..) )
 
 import qualified System.IO.Unsafe as UNSAFE (unsafePerformIO)
 import Data.Maybe
@@ -74,12 +78,15 @@ import Agda.Utils.List          ( groupOn, initLast1 )
 import Agda.Utils.List1         ( String1, toList )
 import qualified Agda.Utils.List1        as List1
 import qualified Agda.Utils.Maybe.Strict as Strict
-import Agda.Utils.Null (empty)
+import Agda.Utils.Monad         ( tell1 )
+import Agda.Utils.Null
 import Agda.Utils.Pretty
 import Agda.Utils.ProfileOptions
 import Agda.Utils.Trie          ( Trie )
 import qualified Agda.Utils.Trie as Trie
 import Agda.Utils.WithDefault
+
+import Agda.Utils.Impossible
 
 import Agda.Version
 
@@ -354,11 +361,16 @@ defaultPragmaOptions = PragmaOptions
   , optKeepCoveringClauses       = False
   }
 
-type OptM = Except String
+-- | The options parse monad 'OptM' collects warnings that are not discarded
+--   when a fatal error occurrs
+newtype OptM a = OptM { unOptM :: ExceptT OptionError (Writer OptionWarnings) a }
+  deriving (Functor, Applicative, Monad, MonadError OptionError, MonadWriter OptionWarnings)
 
-runOptM :: Monad m => OptM opts -> m (Either String opts)
-runOptM = pure . runExcept
-type OptError = String
+type OptionError = String
+type OptionWarnings = [OptionWarning]
+
+runOptM :: OptM opts -> (Either OptionError opts, OptionWarnings)
+runOptM = runWriter . runExceptT . unOptM
 
 {- | @f :: Flag opts@  is an action on the option record that results from
      parsing an option.  @f opts@ produces either an error message or an
@@ -366,9 +378,28 @@ type OptError = String
 -}
 type Flag opts = opts -> OptM opts
 
+-- | Warnings when parsing options.
+
+data OptionWarning
+  = OptionRenamed { oldOptionName :: String, newOptionName :: String }
+  deriving (Show, Generic)
+
+instance NFData OptionWarning
+
+instance Pretty OptionWarning where
+  pretty = \case
+    OptionRenamed old new -> hsep
+      [ "Option", name old, "is deprecated, please use", name new, "instead" ]
+    where
+    name = text . ("--" ++)
+
+optionWarningName :: OptionWarning -> WarningName
+optionWarningName = \case
+  OptionRenamed{} -> OptionRenamed_
+
 -- | Checks that the given options are consistent.
 
-checkOpts :: MonadError OptError m => CommandLineOptions -> m ()
+checkOpts :: MonadError OptionError m => CommandLineOptions -> m ()
 checkOpts opts = do
   -- NOTE: This is a temporary hold-out until --vim can be converted into a backend or plugin,
   -- whose options compatibility currently is checked in `Agda.Compiler.Backend`.
@@ -1120,8 +1151,7 @@ pragmaOptions =
                     "enable cubical features (some only in erased settings), implies --cubical-compatible"
     , Option []     ["guarded"] (NoArg guardedFlag)
                     "enable @lock/@tick attributes"
-    , Option []     ["lossy-unification"] (NoArg firstOrderFlag)
-                    "enable heuristically unifying `f es = f es'` by unifying `es = es'`, even when it could lose solutions."
+    , lossyUnificationOption
     , Option []     ["postfix-projections"] (NoArg postfixProjectionsFlag)
                     "make postfix projection notation the default"
     , Option []     ["keep-pattern-variables"] (NoArg keepPatternVariablesFlag)
@@ -1190,10 +1220,16 @@ pragmaOptions =
                     "do not discard covering clauses (required for some external backends)"
     ]
 
+lossyUnificationOption :: OptDescr (Flag PragmaOptions)
+lossyUnificationOption =
+      Option []     ["lossy-unification"] (NoArg firstOrderFlag)
+                    "enable heuristically unifying `f es = f es'` by unifying `es = es'`, even when it could lose solutions"
+
 -- | Pragma options of previous versions of Agda.
 --   Should not be listed in the usage info, put parsed by GetOpt for good error messaging.
 deadPragmaOptions :: [OptDescr (Flag PragmaOptions)]
-deadPragmaOptions = map (uncurry removedOption) $
+deadPragmaOptions = concat
+  [ map (uncurry removedOption)
     [ ("guardedness-preserving-type-constructors"
       , "")
     , ("no-coverage-check"
@@ -1206,6 +1242,12 @@ deadPragmaOptions = map (uncurry removedOption) $
       , inVersion "2.6.3") -- see issue #5427
     , ("no-flat-split", inVersion "2.6.3")  -- See issue #6263.
     ]
+  , map (uncurry renamedNoArgOption)
+    [ ( "experimental-lossy-unification"
+      , lossyUnificationOption
+      )
+    ]
+  ]
   where
     inVersion = ("in version " ++)
 
@@ -1219,6 +1261,21 @@ removedOption ::
 removedOption name remark = Option [] [name] (NoArg $ const $ throwError msg) msg
   where
   msg = unwords ["Option", "--" ++ name, "has been removed", remark]
+
+-- | Generate a deprecated option that resolves to another option.
+renamedNoArgOption ::
+     String
+       -- ^ The deprecated long option name.
+  -> OptDescr (Flag a)
+       -- ^ The new option.
+  -> OptDescr (Flag a)
+       -- ^ The old option which additionally emits a 'RenamedOption' warning.
+renamedNoArgOption old = \case
+  Option _ [new] (NoArg flag) description ->
+    Option [] [old] (NoArg flag') $ concat [description, " (DEPRECATED, use --", new, ")"]
+    where
+    flag' o = tell1 (OptionRenamed old new) >> flag o
+  _ -> __IMPOSSIBLE__
 
 -- | Used for printing usage info.
 --   Does not include the dead options.

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -167,9 +167,10 @@ usualWarnings = allWarnings Set.\\ Set.fromList
 -- to existing warnings in the codebase.
 
 data WarningName
-  =
+  -- Option Warnings
+  = OptionRenamed_
   -- Parser Warnings
-    OverlappingTokensWarning_
+  | OverlappingTokensWarning_
   | UnsupportedAttribute_
   | MultipleAttributes_
   -- Library Warnings
@@ -324,6 +325,8 @@ usageWarning = intercalate "\n"
 
 warningNameDescription :: WarningName -> String
 warningNameDescription = \case
+  -- Option Warnings
+  OptionRenamed_                   -> "Renamed options."
   -- Parser Warnings
   OverlappingTokensWarning_        -> "Multi-line comments spanning one or more literate text blocks."
   UnsupportedAttribute_            -> "Unsupported attributes."

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -57,8 +57,10 @@ runAgda' :: [Backend] -> IO ()
 runAgda' backends = runTCMPrettyErrors $ do
   progName <- liftIO getProgName
   argv     <- liftIO getArgs
+  let (z, warns) = runOptM $ parseBackendOptions backends argv defaultOptions
+  mapM_ (warning . OptionWarning) warns
   conf     <- liftIO $ runExceptT $ do
-    (bs, opts) <- ExceptT $ runOptM $ parseBackendOptions backends argv defaultOptions
+    (bs, opts) <- ExceptT $ pure z
     -- The absolute path of the input file, if provided
     inputFile <- liftIO $ mapM absolute $ optInputFile opts
     mode      <- getMainMode bs inputFile opts

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3927,6 +3927,7 @@ data Warning
   | SafeFlagNoCoverageCheck
   | SafeFlagInjective
   | SafeFlagEta                            -- ^ ETA pragma is unsafe.
+  | OptionWarning            OptionWarning
   | ParseWarning             ParseWarning
   | LibraryWarning           LibWarning
   | DeprecationWarning String String String
@@ -3989,6 +3990,7 @@ warningName :: Warning -> WarningName
 warningName = \case
   -- special cases
   NicifierIssue dw             -> declarationWarningName dw
+  OptionWarning ow             -> optionWarningName ow
   ParseWarning pw              -> parseWarningName pw
   LibraryWarning lw            -> libraryWarningName lw
   AsPatternShadowsConstructorOrPatternSynonym{} -> AsPatternShadowsConstructorOrPatternSynonym_

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -174,7 +174,9 @@ addTrustedExecutables o = do
 setOptionsFromPragma :: OptionsPragma -> TCM ()
 setOptionsFromPragma ps = do
     opts <- commandLineOptions
-    runOptM (parsePragmaOptions ps opts) >>= \case
+    let (z, warns) = runOptM (parsePragmaOptions ps opts)
+    mapM_ (warning . OptionWarning) warns
+    case z of
       Left err    -> typeError $ GenericError err
       Right opts' -> setPragmaOptions opts'
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -230,6 +230,8 @@ prettyWarning = \case
     SafeFlagNoCoverageCheck -> fsep $
       pwords "Cannot use NON_COVERING pragma with safe flag."
 
+    OptionWarning ow -> pretty ow
+
     ParseWarning pw -> pretty pw
 
     DeprecationWarning old new version -> fsep $

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20221031 * 10 + 0
+currentInterfaceVersion = 20221119 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -86,6 +86,7 @@ instance EmbPrj Warning where
     ParseWarning a                        -> icodeN 38 ParseWarning a
     NoGuardednessFlag a                   -> icodeN 39 NoGuardednessFlag a
     UnsupportedIndexedMatch f             -> icodeN 40 UnsupportedIndexedMatch f
+    OptionWarning a                       -> icodeN 41 OptionWarning a
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -129,6 +130,15 @@ instance EmbPrj Warning where
     [38, a]              -> valuN ParseWarning a
     [39, a]              -> valuN NoGuardednessFlag a
     [40, a]              -> valuN UnsupportedIndexedMatch a
+    [41, a]              -> valuN OptionWarning a
+    _ -> malformed
+
+instance EmbPrj OptionWarning where
+  icod_ = \case
+    OptionRenamed a b -> icodeN' OptionRenamed a b
+
+  value = vcase $ \case
+    [a, b] -> valuN OptionRenamed a b
     _ -> malformed
 
 instance EmbPrj ParseWarning where
@@ -416,6 +426,7 @@ instance EmbPrj WarningName where
     InfectiveImport_                             -> 92
     DuplicateFieldsWarning_                      -> 93
     TooManyFieldsWarning_                        -> 94
+    OptionRenamed_                               -> 95
 
   value = \case
     0  -> return OverlappingTokensWarning_
@@ -513,6 +524,7 @@ instance EmbPrj WarningName where
     92 -> return InfectiveImport_
     93 -> return DuplicateFieldsWarning_
     94 -> return TooManyFieldsWarning_
+    95 -> return OptionRenamed_
     _ -> malformed
 
 

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -12,7 +12,7 @@ import Control.Monad          ( MonadPlus(..), guard, unless, when )
 import Control.Monad.Except   ( MonadError(catchError, throwError) )
 import Control.Monad.Identity ( runIdentity )
 import Control.Monad.State    ( MonadState(get, put) )
-import Control.Monad.Writer   ( Writer, WriterT, mapWriterT )
+import Control.Monad.Writer   ( MonadWriter(tell), Writer, WriterT, mapWriterT )
 
 import Data.Bifunctor         ( first, second )
 import Data.Bool              ( bool )
@@ -24,6 +24,7 @@ import Data.Monoid
 import Agda.Utils.Applicative
 import Agda.Utils.Either
 import Agda.Utils.Null (empty, ifNotNullM)
+import Agda.Utils.Singleton
 
 import Agda.Utils.Impossible
 
@@ -238,3 +239,7 @@ localState = bracket_ get put
 
 embedWriter :: (Monoid w, Monad m) => Writer w a -> WriterT w m a
 embedWriter = mapWriterT (pure . runIdentity)
+
+-- | Output a single value.
+tell1 :: (Monoid ws, Singleton w ws, MonadWriter ws m) => w -> m ()
+tell1 = tell . singleton

--- a/test/Internal/Helpers.hs
+++ b/test/Internal/Helpers.hs
@@ -34,12 +34,6 @@ import Agda.Utils.Impossible
 ------------------------------------------------------------------------
 -- QuickCheck helpers
 
-#if !MIN_VERSION_QuickCheck(2,12,5)
-isSuccess :: Result -> Bool
-isSuccess Success{} = True
-isSuccess _         = False
-#endif
-
 quickCheck' :: Testable prop => prop -> IO Bool
 quickCheck' p = fmap isSuccess $ quickCheckResult p
 

--- a/test/Internal/Interaction/Options.hs
+++ b/test/Internal/Interaction/Options.hs
@@ -16,29 +16,31 @@ import System.FilePath ((</>), takeExtension)
 
 import Utils (getAgdaFilesInDir, SearchMode(Rec))
 
-import Internal.Helpers
+import Internal.Helpers hiding (reason)
 
-prop_defaultOptions :: Property
-prop_defaultOptions = ioProperty $
-  either (const False) (const True) <$> runOptM (checkOpts defaultOptions)
+prop_defaultOptions :: Bool
+prop_defaultOptions =
+  case runOptM (checkOpts defaultOptions) of
+    (Right _, []) -> True
+    _ -> False
 
 -- | The default pragma options should be considered safe.
 
 prop_defaultPragmaOptionsSafe :: Property
-prop_defaultPragmaOptionsSafe = ioProperty helper
+prop_defaultPragmaOptionsSafe = ioProperty $
+  case runOptM $ safeFlag defaultPragmaOptions of
+    (Right opts, []) ->
+      case unsafePragmaOptions opts of
+        []         -> yes
+        unsafe     -> no $ "Following pragmas are default but not safe: " ++ intercalate ", " unsafe
+    (Right _ , ws) -> no $ "Unexpected warning(s): " ++ show ws
+    (Left errs, _) -> no $ "Unexpected error: " ++ errs
   where
-    helper :: IO Bool
-    helper = do
-      defaultSafe <- runOptM $ safeFlag defaultPragmaOptions
-      case defaultSafe of
-        Left errs -> do
-          putStrLn $ "Unexpected error: " ++ errs
-          return False
-        Right opts -> let unsafe = unsafePragmaOptions opts in
-          if null unsafe then return True else do
-            putStrLn $ "Following pragmas are default but not safe: "
-                                          ++ intercalate ", " unsafe
-            return False
+  yes :: IO Bool
+  yes = return True
+  no :: String -> IO Bool
+  no msg = False <$ putStrLn msg
+
 
 prop_allBuiltinsSafePostulatesOrNot :: Property
 prop_allBuiltinsSafePostulatesOrNot = ioProperty helper

--- a/test/Internal/Interaction/Options.hs
+++ b/test/Internal/Interaction/Options.hs
@@ -34,7 +34,7 @@ prop_defaultPragmaOptionsSafe = ioProperty helper
         Left errs -> do
           putStrLn $ "Unexpected error: " ++ errs
           return False
-        Right opts -> let unsafe = unsafePragmaOptions defaultOptions opts in
+        Right opts -> let unsafe = unsafePragmaOptions opts in
           if null unsafe then return True else do
             putStrLn $ "Following pragmas are default but not safe: "
                                           ++ intercalate ", " unsafe

--- a/test/Succeed/LossyUnification.agda
+++ b/test/Succeed/LossyUnification.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --experimental-lossy-unification #-} -- sic!
+  -- Keep the deprecated option name for the sake of #6337
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+-- Lossy unification solves these metas.
+test : 3 + 4 ≡ _ + _
+test = refl
+
+-- Expected warning:
+-- Option --experimental-lossy-unification is deprecated, please use --lossy-unification instead

--- a/test/Succeed/LossyUnification.warn
+++ b/test/Succeed/LossyUnification.warn
@@ -1,0 +1,12 @@
+LossyUnification.agda:1,1-49
+Option --experimental-lossy-unification is deprecated, please use --lossy-unification instead
+LossyUnification.agda:1,1-49
+Option --experimental-lossy-unification is deprecated, please use --lossy-unification instead
+
+———— All done; warnings encountered ————————————————————————
+
+LossyUnification.agda:1,1-49
+Option --experimental-lossy-unification is deprecated, please use --lossy-unification instead
+
+LossyUnification.agda:1,1-49
+Option --experimental-lossy-unification is deprecated, please use --lossy-unification instead


### PR DESCRIPTION
Fix #6337: 
- Infrastructure for renamed options, such as `--experimental-lossy-unification` to `--lossy-unification`.
- Parsing options can now generate warnings.
- Test case for lossy unification.