### PR TITLE
Fix issue #6336: include endpoints in positivity checking

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/Primitives.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Primitives.hs
@@ -162,7 +162,7 @@ xForPrim table builtinThings defs = catMaybes
   elemDefs = hasElem $ map defName defs
   getName = \case
     Builtin t                 -> Just $ getPrimName t
-    Prim (PrimFun q _ _)      -> Just q
+    Prim (PrimFun q _ _ _)    -> Just q
     BuiltinRewriteRelations _ -> Nothing
 
 

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -271,7 +271,7 @@ instance NamesIn a => NamesIn (Builtin a) where
 -- | Note that the 'primFunImplementation' is skipped.
 instance NamesIn PrimFun where
   namesAndMetasIn' sg = \case
-    PrimFun x _ _ -> namesAndMetasIn' sg x
+    PrimFun x _ _ _ -> namesAndMetasIn' sg x
 
 instance NamesIn Section where
   namesAndMetasIn' sg = \case

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3126,12 +3126,14 @@ data PrimitiveImpl = PrimImpl Type PrimFun
 data PrimFun = PrimFun
   { primFunName           :: QName
   , primFunArity          :: Arity
+  , primFunArgOccurrences :: [Occurrence]
+    -- ^ See 'defArgOccurrences'.
   , primFunImplementation :: [Arg Term] -> Int -> ReduceM (Reduced MaybeReducedArgs Term)
   }
   deriving Generic
 
 primFun :: QName -> Arity -> ([Arg Term] -> ReduceM (Reduced MaybeReducedArgs Term)) -> PrimFun
-primFun q ar imp = PrimFun q ar (\ args _ -> imp args)
+primFun q ar imp = PrimFun q ar [] (\args _ -> imp args)
 
 defClauses :: Definition -> [Clause]
 defClauses Defn{theDef = Function{funClauses = cs}}        = cs

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -536,16 +536,21 @@ computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do
             -- Andreas, 2020-02-15, issue #4447:
             -- Allow UnconfimedReductions here to make sure we get the constructor type
             -- in same way as it was obtained when the data types was checked.
-            TelV tel t <- putAllowedReductions allReductions $
-              telViewPath . defType =<< getConstInfo c
+            (TelV tel t, bnd) <- putAllowedReductions allReductions $
+              telViewUpToPathBoundary' (-1) . defType =<< getConstInfo c
             let (tel0,tel1) = splitTelescopeAt np tel
             -- Do not collect occurrences in the data parameters.
             -- Normalization needed e.g. for test/succeed/Bush.agda.
             -- (Actually, for Bush.agda, reducing the parameters should be sufficient.)
             tel1' <- addContext tel0 $ normalise $ tel1
-            let vars = map (Just . AnArg) . downFrom
+            let vars    = map (Just . AnArg) . downFrom
+                varsTel = vars (size tel)
             -- Occurrences in the types of the constructor arguments.
-            mappend (OccursAs (ConArgType c) <$> getOccurrences (vars np) tel1') $ do
+            mappend (mappend
+                       (OccursAs (ConArgType c) <$>
+                        getOccurrences (vars np) tel1')
+                       (OccursAs (ConEndpoint c) <$>
+                        getOccurrences varsTel bnd)) $ do
               -- Occurrences in the indices of the data type the constructor targets.
               -- Andreas, 2020-02-15, issue #4447:
               -- WAS: @t@ is not necessarily a data type, but it could be something
@@ -554,12 +559,12 @@ computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do
               -- In any case, if @t@ is not showing itself as the data type, we need to
               -- do something conservative.  We will just collect *all* occurrences
               -- and flip their sign (variance) using 'LeftOfArrow'.
-              let fallback = OccursAs LeftOfArrow <$> getOccurrences (vars $ size tel) t -- NB::Defined but not used
+              let fallback = OccursAs LeftOfArrow <$> getOccurrences varsTel t -- NB::Defined but not used
               case unEl t of
                 Def q' vs
                   | q == q' -> do
                       let indices = fromMaybe __IMPOSSIBLE__ $ allApplyElims $ drop np vs
-                      OccursAs (IndArgType c) . OnlyVarsUpTo np <$> getOccurrences (vars $ size tel) indices
+                      OccursAs (IndArgType c) . OnlyVarsUpTo np <$> getOccurrences varsTel indices
                   | otherwise -> __IMPOSSIBLE__  -- fallback -- this ought to be impossible now (but wasn't, see #4447)
                 Pi{}       -> __IMPOSSIBLE__  -- eliminated  by telView
                 MetaV{}    -> __IMPOSSIBLE__  -- not a constructor target; should have been solved by now
@@ -755,6 +760,7 @@ computeEdges muts q ob =
     UnderInf       -> addPol GuardPos -- Andreas, 2012-06-09: ∞ is guarding
     ConArgType _   -> keepGoing
     IndArgType _   -> mixed
+    ConEndpoint _  -> keepGoing
     InClause _     -> keepGoing
     Matched        -> mixed -- consider arguments matched against as used
     IsIndex        -> mixed -- And similarly for indices.
@@ -843,6 +849,9 @@ instance PrettyTCM (Seq OccursWhere) where
         MetaArg      -> pwords "in an argument of a metavariable"
         ConArgType c -> pwords "in the type of the constructor" ++ [prettyTCM c]
         IndArgType c -> pwords "in an index of the target type of the constructor" ++ [prettyTCM c]
+        ConEndpoint c
+                     -> pwords "in an endpoint of the target of the" ++
+                        pwords "higher constructor" ++ [prettyTCM c]
         InClause i   -> pwords "in the" ++ nth i ++ pwords "clause"
         Matched      -> pwords "as matched against"
         IsIndex      -> pwords "as an index"

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -559,13 +559,12 @@ computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do
               -- In any case, if @t@ is not showing itself as the data type, we need to
               -- do something conservative.  We will just collect *all* occurrences
               -- and flip their sign (variance) using 'LeftOfArrow'.
-              let fallback = OccursAs LeftOfArrow <$> getOccurrences varsTel t -- NB::Defined but not used
               case unEl t of
                 Def q' vs
                   | q == q' -> do
                       let indices = fromMaybe __IMPOSSIBLE__ $ allApplyElims $ drop np vs
                       OccursAs (IndArgType c) . OnlyVarsUpTo np <$> getOccurrences varsTel indices
-                  | otherwise -> __IMPOSSIBLE__  -- fallback -- this ought to be impossible now (but wasn't, see #4447)
+                  | otherwise -> __IMPOSSIBLE__  -- this ought to be impossible now (but hasn't been before, see #4447)
                 Pi{}       -> __IMPOSSIBLE__  -- eliminated  by telView
                 MetaV{}    -> __IMPOSSIBLE__  -- not a constructor target; should have been solved by now
                 Var{}      -> __IMPOSSIBLE__  -- not a constructor target

--- a/src/full/Agda/TypeChecking/Positivity/Occurrence.hs
+++ b/src/full/Agda/TypeChecking/Positivity/Occurrence.hs
@@ -57,6 +57,8 @@ data Where
   | MetaArg          -- ^ as an argument of a metavariable
   | ConArgType QName -- ^ in the type of a constructor
   | IndArgType QName -- ^ in a datatype index of a constructor
+  | ConEndpoint QName
+                     -- ^ in an endpoint of a higher constructor
   | InClause Nat     -- ^ in the nth clause of a defined function
   | Matched          -- ^ matched against in a clause of a defined function
   | IsIndex          -- ^ is an index of an inductive family
@@ -98,6 +100,8 @@ instance Pretty Where where
     MetaArg      -> "MetaArg"
     ConArgType q -> "ConArgType" <+> pretty q
     IndArgType q -> "IndArgType" <+> pretty q
+    ConEndpoint q
+                 -> "ConEndpoint" <+> pretty q
     InClause i   -> "InClause"   <+> pretty i
     Matched      -> "Matched"
     IsIndex      -> "IsIndex"

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -33,6 +33,7 @@ import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
 
 import Agda.TypeChecking.Names
+import Agda.TypeChecking.Positivity.Occurrence
 import Agda.TypeChecking.Primitive.Base
 import Agda.TypeChecking.Monad
 
@@ -154,7 +155,7 @@ primTrans' = do
           nPi' "A" (nPi' "i" primIntervalType $ \ i -> (sort . tmSort <$> (a <@> i))) $ \ bA ->
           nPi' "φ" primIntervalType $ \ phi ->
           (el' (a <@> cl primIZero) (bA <@> cl primIZero) --> el' (a <@> cl primIOne) (bA <@> cl primIOne))
-  return $ PrimImpl t $ PrimFun __IMPOSSIBLE__ 4 $ \ ts nelims -> do
+  return $ PrimImpl t $ PrimFun __IMPOSSIBLE__ 4 [] $ \ts nelims -> do
     primTransHComp DoTransp ts nelims
 
 primHComp' :: TCM PrimitiveImpl
@@ -166,7 +167,8 @@ primHComp' = do
           hPi' "φ" primIntervalType $ \ phi ->
           nPi' "i" primIntervalType (\ i -> pPi' "o" phi $ \ _ -> el' a bA) -->
           (el' a bA --> el' a bA)
-  return $ PrimImpl t $ PrimFun __IMPOSSIBLE__ 5 $ \ ts nelims -> do
+  let occs = [Mixed, StrictPos, Mixed, StrictPos, StrictPos]
+  return $ PrimImpl t $ PrimFun __IMPOSSIBLE__ 5 occs $ \ts nelims -> do
     primTransHComp DoHComp ts nelims
 
 -- | Construct a helper for CCHM composition, with a string indicating
@@ -735,7 +737,7 @@ primComp = do
           (el' (a <@> cl primIZero) (bA <@> cl primIZero) --> el' (a <@> cl primIOne) (bA <@> cl primIOne))
   one <- primItIsOne
   io  <- primIOne
-  return $ PrimImpl t $ PrimFun __IMPOSSIBLE__ 5 $ \ ts nelims -> do
+  return $ PrimImpl t $ PrimFun __IMPOSSIBLE__ 5 [] $ \ts nelims -> do
     case ts of
       [l,c,phi,u,a0] -> do
         sphi <- reduceB' phi

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -730,14 +730,16 @@ checkPrimitive i x (Arg info e) =
     unless (info == expectedInfo) $
       typeError $ WrongArgInfoForPrimitive name info expectedInfo
     bindPrimitive name pf
-    addConstant' x info x t $
-        Primitive { primAbstr    = Info.defAbstract i
-                  , primName     = name
-                  , primClauses  = []
-                  , primInv      = NotInjective
-                  , primCompiled = Nothing
-                  , primOpaque   = TransparentDef
-                  }
+    lang <- getLanguage
+    addConstant x
+      (defaultDefn info x t lang Primitive
+        { primAbstr    = Info.defAbstract i
+        , primOpaque   = TransparentDef
+        , primName     = name
+        , primClauses  = []
+        , primInv      = NotInjective
+        , primCompiled = Nothing })
+      { defArgOccurrences = primFunArgOccurrences pf }
 
 -- | Check a pragma.
 checkPragma :: Range -> A.Pragma -> TCM ()

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -360,7 +360,10 @@ instance Apply Defn where
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
 
 instance Apply PrimFun where
-  apply (PrimFun x ar def) args = PrimFun x (ar - size args) $ \ vs -> def (args ++ vs)
+  apply (PrimFun x ar occs def) args =
+    PrimFun x (ar - n) (drop n occs) $ \ vs -> def (args ++ vs)
+    where
+    n = size args
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
 
 instance Apply Clause where
@@ -716,7 +719,9 @@ instance Abstract Defn where
     PrimitiveSort{} -> d
 
 instance Abstract PrimFun where
-    abstract tel (PrimFun x ar def) = PrimFun x (ar + n) $ \ts -> def $ drop n ts
+    abstract tel (PrimFun x ar occs def) =
+      PrimFun x (ar + n) (replicate n Mixed ++ occs) $ \ts ->
+        def $ drop n ts
         where n = size tel
 
 instance Abstract Clause where

--- a/test/Fail/Issue6336.agda
+++ b/test/Fail/Issue6336.agda
@@ -1,0 +1,10 @@
+-- This example is due to David Wärn.
+
+{-# OPTIONS --cubical --safe #-}
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.Bool
+
+data A (f : Set → Bool) : Set where
+  g : Bool → A f
+  p : g (f (A f)) ≡ g true

--- a/test/Fail/Issue6336.err
+++ b/test/Fail/Issue6336.err
@@ -1,0 +1,5 @@
+Issue6336.agda:8,1-10,27
+A is not strictly positive, because it occurs
+in an argument of a bound variable
+in an endpoint of the target of the higher constructor p
+in the definition of A.

--- a/test/Internal/TypeChecking/Positivity/Occurrence.hs
+++ b/test/Internal/TypeChecking/Positivity/Occurrence.hs
@@ -34,6 +34,7 @@ instance Arbitrary Where where
     , return MetaArg
     , ConArgType <$> arbitrary
     , IndArgType <$> arbitrary
+    , ConEndpoint <$> arbitrary
     , InClause <$> arbitrary
     , return Matched
     , InDefOf <$> arbitrary
@@ -50,6 +51,8 @@ instance CoArbitrary Where where
   coarbitrary MetaArg        = variant 4
   coarbitrary (ConArgType a) = variant 5 . coarbitrary a
   coarbitrary (IndArgType a) = variant 6 . coarbitrary a
+  coarbitrary (ConEndpoint a)
+                             = variant 11 . coarbitrary a
   coarbitrary (InClause a)   = variant 7 . coarbitrary a
   coarbitrary Matched        = variant 8
   coarbitrary IsIndex        = variant 9

--- a/test/Succeed/Issue6336.agda
+++ b/test/Succeed/Issue6336.agda
@@ -1,0 +1,27 @@
+{-# OPTIONS --cubical --safe --no-double-check #-}
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Primitive.Cubical
+
+-- Andreas Abel reported that this example is due to David Wärn.
+
+id : (A : Set) → A → A
+id _ x = x
+
+data D : Set where
+  point : D
+  loop  : point ≡ id D point
+
+-- The following example was taken from test/Fail/Issue6017.agda.
+
+_∙_ : ∀ {ℓ} {A : Set ℓ} {x y z : A} → x ≡ y → y ≡ z → x ≡ z
+(p ∙ q) i = primHComp
+  (λ where
+     j (i = i0) → p i0
+     j (i = i1) → q j)
+  (p i)
+
+data T : Set where
+  base : T
+  p    : base ≡ base
+  surf : p ∙ p ≡ p


### PR DESCRIPTION
Partly following a suggestion due to Andreas Abel.  Fixes #6336.
- #6336

I encountered some errors when I ran `make cubical-test`. I could fix these by replacing two occurrences of `HopfInvariantPush n (fst f)` with `HopfInvariantPush n (fst g)` in `Cubical.Homotopy.HopfInvariant.Homomorphism` (the first one in `jᵣ-βₗ`), where `f` and `g` are adjacent variables. Do my changes introduce an off-by-one error? Can anyone figure out what went wrong?
