### PR TITLE
Fix #6138 Refine the error message about failure of overloaded resolution

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -66,6 +66,7 @@ import Agda.TypeChecking.Reduce (instantiate)
 import Agda.Utils.FileName
 import Agda.Utils.Float  ( toStringWithoutDotZero )
 import Agda.Utils.Function
+import Agda.Utils.Functor( for )
 import Agda.Utils.List   ( initLast )
 import Agda.Utils.List1 (List1, pattern (:|))
 import qualified Agda.Utils.List1 as List1
@@ -773,8 +774,10 @@ instance PrettyTCM TypeError where
           , text "because"
           , pure reason
           ]
-        , nest 2 (text "Signatures in the scope:")
-        , vcat $ fmap (typeOfConst >=> prettyTCM >=> (\typeDoc -> text "-" <+> nest 2 (nameRaw <+> text ":" <+> pure typeDoc))) ds
+        , nest 2 $ text "candidates in scope:"
+        , vcat $ for ds $ \ d -> do
+            t <- typeOfConst d
+            text "-" <+> nest 2 (nameRaw <+> text ":" <+> prettyTCM t)
         ]
 
     ClashingFileNamesFor x files ->

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4368,6 +4368,7 @@ data TypeError
             --   If it is non-empty, the first entry could be printed as error hint.
         | AmbiguousParseForLHS LHSOrPatSyn C.Pattern [C.Pattern]
             -- ^ Pattern and its possible interpretations.
+        | AmbiguousProjectionError (List1 QName) Doc
         | OperatorInformation [NotationSection] TypeError
 {- UNUSED
         | NoParseForPatternSynonym C.Pattern

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -33,6 +33,7 @@ import Agda.Syntax.Concrete.Pretty () -- only Pretty instances
 import Agda.Syntax.Common
 import Agda.Syntax.Internal as I
 import Agda.Syntax.Position
+import Agda.Syntax.Translation.InternalToAbstract (reify)
 
 import Agda.TypeChecking.Conversion
 import Agda.TypeChecking.Constraints
@@ -1342,7 +1343,7 @@ inferOrCheckProjApp e o ds args mt = do
       ifBlocked core (\ m _ -> postpone m) $ {-else-} \ _ core -> do
       ifNotPiType core (\ _ -> refuseProjNotApplied ds) $ {-else-} \ dom _b -> do
       ifBlocked (unDom dom) (\ m _ -> postpone m) $ {-else-} \ _ ta -> do
-      caseMaybeM (isRecordType ta) (refuseProjNotRecordType ds) $ \ (_q, _pars, defn) -> do
+      caseMaybeM (isRecordType ta) (refuseProjNotRecordType ds Nothing ta) $ \ (_q, _pars, defn) -> do
       case defn of
         Record { recFields = fs } -> do
           case forMaybe fs $ \ f -> Fold.find (unDom f ==) ds of
@@ -1403,7 +1404,7 @@ inferOrCheckProjAppToKnownPrincipalArg e o ds args mt k v0 ta mpatm = do
     Nothing -> uncurry PrincipalArgTypeMetas <$> implicitArgs (-1) (not . visible) ta
   let v = v0 `apply` vargs
   ifBlocked ta (\ m _ -> postpone m patm) {-else-} $ \ _ ta -> do
-  caseMaybeM (isRecordType ta) (refuseProjNotRecordType ds) $ \ (q, _pars0, _) -> do
+  caseMaybeM (isRecordType ta) (refuseProjNotRecordType ds (Just v0) ta) $ \ (q, _pars0, _) -> do
 
       -- try to project it with all of the possible projections
       let try d = do
@@ -1466,8 +1467,7 @@ inferOrCheckProjAppToKnownPrincipalArg e o ds args mt k v0 ta mpatm = do
       case cands of
         [] -> refuseProjNoMatching ds
         [[]] -> refuseProjNoMatching ds
-        (_:_:_) -> refuseProj ds $ "several matching candidates found: "
-             ++ prettyShow (map (fst . snd) $ concat cands)
+        (_:_:_) -> refuseProj ds $ fwords "several matching candidates can be applied."
         -- case: just one matching projection d
         -- the term u = d v
         -- the type tb is the type of this application
@@ -1497,16 +1497,31 @@ inferOrCheckProjAppToKnownPrincipalArg e o ds args mt k v0 ta mpatm = do
 
               return (v, tc, NotCheckedTarget)
 
-refuseProj :: List1 QName -> String -> TCM a
-refuseProj ds reason = typeError $ GenericError $
-        "Cannot resolve overloaded projection "
-        ++ prettyShow (A.nameConcrete $ A.qnameName $ List1.head ds)
-        ++ " because " ++ reason
+refuseProj :: List1 QName -> TCM Doc -> TCM a
+refuseProj ds reason = do
+  let nameRaw = pretty (A.nameConcrete $ A.qnameName $ List1.head ds)
+  let name = quotes $ nameRaw
+  doc <- vcat
+    [ fsep
+      [ text "Cannot resolve overloaded projection"
+      , name
+      , text "because"
+      , reason
+    ]
+    , "Signatures in the scope: "
+    , vcat $ fmap (typeOfConst >=> reify >=> prettyA >=> (\doc -> text "-" <+> nest 2 (nameRaw <+> text ":" <+> pure doc))) ds
+    ]
+  typeError $ GenericDocError $ doc
 
-refuseProjNotApplied, refuseProjNoMatching, refuseProjNotRecordType :: List1 QName -> TCM a
-refuseProjNotApplied    ds = refuseProj ds "it is not applied to a visible argument"
-refuseProjNoMatching    ds = refuseProj ds "no matching candidate found"
-refuseProjNotRecordType ds = refuseProj ds "principal argument is not of record type"
+refuseProjNotApplied, refuseProjNoMatching :: List1 QName -> TCM a
+refuseProjNotApplied    ds = refuseProj ds $ fwords "it is not applied to a visible argument"
+refuseProjNoMatching    ds = refuseProj ds $ fwords "no matching candidate found"
+refuseProjNotRecordType :: List1 QName -> Maybe Term -> Type -> TCM a
+refuseProjNotRecordType ds pValue pType = do
+    let dType = quotes $ reify pType >>= prettyA
+    let dValue = caseMaybe pValue (return empty) (\term -> quotes (reify term >>= prettyA))
+    refuseProj ds $ fsep $
+      ["principal argument", dValue, "has type", dType, " while it should be of record type"]
 
 -----------------------------------------------------------------------------
 -- * Sorts

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -11,7 +11,7 @@ module Agda.TypeChecking.Rules.Application
 import Prelude hiding ( null )
 
 import Control.Applicative        ( (<|>) )
-import Control.Monad              ( filterM, forM, forM_, guard, liftM2 )
+import Control.Monad              ( filterM, forM, forM_, guard, liftM2, (>=>) )
 import Control.Monad.Except       ( ExceptT, runExceptT, MonadError, catchError, throwError )
 import Control.Monad.Trans
 import Control.Monad.Trans.Maybe
@@ -1499,17 +1499,16 @@ inferOrCheckProjAppToKnownPrincipalArg e o ds args mt k v0 ta mpatm = do
 
 refuseProj :: List1 QName -> TCM Doc -> TCM a
 refuseProj ds reason = do
-  let nameRaw = pretty (A.nameConcrete $ A.qnameName $ List1.head ds)
-  let name = quotes $ nameRaw
+  let nameRaw = pretty $ A.nameConcrete $ A.qnameName $ List1.head ds
   doc <- vcat
     [ fsep
       [ text "Cannot resolve overloaded projection"
-      , name
+      , nameRaw
       , text "because"
       , reason
-    ]
-    , "Signatures in the scope: "
-    , vcat $ fmap (typeOfConst >=> reify >=> prettyA >=> (\doc -> text "-" <+> nest 2 (nameRaw <+> text ":" <+> pure doc))) ds
+      ]
+    , nest 2 (text "Signatures in the scope:")
+    , vcat $ fmap (typeOfConst >=> reify >=> prettyA >=> (\typeDoc -> text "-" <+> nest 2 (nameRaw <+> text ":" <+> pure typeDoc))) ds
     ]
   typeError $ GenericDocError $ doc
 
@@ -1518,10 +1517,10 @@ refuseProjNotApplied    ds = refuseProj ds $ fwords "it is not applied to a visi
 refuseProjNoMatching    ds = refuseProj ds $ fwords "no matching candidate found"
 refuseProjNotRecordType :: List1 QName -> Maybe Term -> Type -> TCM a
 refuseProjNotRecordType ds pValue pType = do
-    let dType = quotes $ reify pType >>= prettyA
-    let dValue = caseMaybe pValue (return empty) (\term -> quotes (reify term >>= prettyA))
+    let dType = (reify >=> prettyA) pType
+    let dValue = caseMaybe pValue (return empty) (reify >=> prettyA)
     refuseProj ds $ fsep $
-      ["principal argument", dValue, "has type", dType, " while it should be of record type"]
+      ["principal argument", dValue, "has type", dType, "while it should be of record type"]
 
 -----------------------------------------------------------------------------
 -- * Sorts

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1496,10 +1496,9 @@ inferOrCheckProjAppToKnownPrincipalArg e o ds args mt k v0 ta mpatm = do
 
               return (v, tc, NotCheckedTarget)
 
+-- | Throw 'AmbiguousProjectionError' with additional explanation.
 refuseProj :: List1 QName -> TCM Doc -> TCM a
-refuseProj ds reason = do
-  doc <- reason
-  typeError $ AmbiguousProjectionError ds doc
+refuseProj ds reason = typeError . AmbiguousProjectionError ds =<< reason
 
 refuseProjNotApplied, refuseProjNoMatching :: List1 QName -> TCM a
 refuseProjNotApplied    ds = refuseProj ds $ fwords "it is not applied to a visible argument"

--- a/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
+++ b/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
@@ -1,4 +1,7 @@
 Issue1944-UnappliedOverloadedProjectionNotRecord.agda:15,8-9
-Cannot resolve overloaded projection f because principal argument
-is not of record type
-when checking that the expression f has type A → A
+Cannot resolve overloaded projection 'f' because
+principal argument has type 'A₁'  while it should be of record type
+Signatures in the scope: 
+- f : {@0 B : Set} → R B → B
+- f : {@0 B : Set} → S B → B
+when checking that the expression f has type A₁ → A₁

--- a/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
+++ b/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
@@ -1,7 +1,7 @@
 Issue1944-UnappliedOverloadedProjectionNotRecord.agda:15,8-9
 Cannot resolve overloaded projection f because
 principal argument has type A₁ while it should be of record type
-  Signatures in the scope:
+  candidates in scope:
 - f : {@0 B : Set} → R B → B
 - f : {@0 B : Set} → S B → B
 when checking that the expression f has type A₁ → A₁

--- a/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
+++ b/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
@@ -1,7 +1,7 @@
 Issue1944-UnappliedOverloadedProjectionNotRecord.agda:15,8-9
-Cannot resolve overloaded projection 'f' because
-principal argument has type 'A₁'  while it should be of record type
-Signatures in the scope: 
+Cannot resolve overloaded projection f because
+principal argument has type A₁ while it should be of record type
+  Signatures in the scope:
 - f : {@0 B : Set} → R B → B
 - f : {@0 B : Set} → S B → B
 when checking that the expression f has type A₁ → A₁

--- a/test/Fail/Issue1944-instance.err
+++ b/test/Fail/Issue1944-instance.err
@@ -1,8 +1,7 @@
 Issue1944-instance.agda:23,14-20
-Cannot resolve overloaded projection 'test' because
-principal argument 'x' has type 'A'
- while it should be of record type
-Signatures in the scope: 
+Cannot resolve overloaded projection test because
+principal argument x has type A while it should be of record type
+  Signatures in the scope:
 - test : ({A = A₁ : Set} ⦃ r : Testable A₁ ⦄ → A₁ → Bool)
 - test : ({@0 A = A₁ : Set} → Testable A₁ → A₁ → Bool)
 when checking that the expression test x has type Bool

--- a/test/Fail/Issue1944-instance.err
+++ b/test/Fail/Issue1944-instance.err
@@ -1,7 +1,7 @@
 Issue1944-instance.agda:23,14-20
 Cannot resolve overloaded projection test because
 principal argument x has type A while it should be of record type
-  Signatures in the scope:
+  candidates in scope:
 - test : ({A = A₁ : Set} ⦃ r : Testable A₁ ⦄ → A₁ → Bool)
 - test : ({@0 A = A₁ : Set} → Testable A₁ → A₁ → Bool)
 when checking that the expression test x has type Bool

--- a/test/Fail/Issue1944-instance.err
+++ b/test/Fail/Issue1944-instance.err
@@ -1,4 +1,8 @@
 Issue1944-instance.agda:23,14-20
-Cannot resolve overloaded projection test because principal
-argument is not of record type
+Cannot resolve overloaded projection 'test' because
+principal argument 'x' has type 'A'
+ while it should be of record type
+Signatures in the scope: 
+- test : ({A = A₁ : Set} ⦃ r : Testable A₁ ⦄ → A₁ → Bool)
+- test : ({@0 A = A₁ : Set} → Testable A₁ → A₁ → Bool)
 when checking that the expression test x has type Bool

--- a/test/Fail/Issue2797.err
+++ b/test/Fail/Issue2797.err
@@ -1,7 +1,7 @@
 Issue2797.agda:27,9-15
-Cannot resolve overloaded projection 'nat' because
+Cannot resolve overloaded projection nat because
 no matching candidate found
-Signatures in the scope: 
+  Signatures in the scope:
 - nat : Dummy → Set
 - nat : .S → Nat
 when checking that the expression s .nat has type Nat

--- a/test/Fail/Issue2797.err
+++ b/test/Fail/Issue2797.err
@@ -1,7 +1,7 @@
 Issue2797.agda:27,9-15
 Cannot resolve overloaded projection nat because
 no matching candidate found
-  Signatures in the scope:
+  candidates in scope:
 - nat : Dummy → Set
 - nat : .S → Nat
 when checking that the expression s .nat has type Nat

--- a/test/Fail/Issue2797.err
+++ b/test/Fail/Issue2797.err
@@ -1,4 +1,7 @@
 Issue2797.agda:27,9-15
-Cannot resolve overloaded projection nat because no matching
-candidate found
+Cannot resolve overloaded projection 'nat' because
+no matching candidate found
+Signatures in the scope: 
+- nat : Dummy → Set
+- nat : .S → Nat
 when checking that the expression s .nat has type Nat

--- a/test/Fail/Issue4924.err
+++ b/test/Fail/Issue4924.err
@@ -1,8 +1,7 @@
 Issue4924.agda:15,7-12
-Cannot resolve overloaded projection 'f' because
-principal argument 'pri' has type 'A'
- while it should be of record type
-Signatures in the scope: 
+Cannot resolve overloaded projection f because
+principal argument pri has type A while it should be of record type
+  Signatures in the scope:
 - f : A → A
 - f : B → B
 when checking that the expression f pri has type A

--- a/test/Fail/Issue4924.err
+++ b/test/Fail/Issue4924.err
@@ -1,4 +1,8 @@
 Issue4924.agda:15,7-12
-Cannot resolve overloaded projection f because principal argument
-is not of record type
+Cannot resolve overloaded projection 'f' because
+principal argument 'pri' has type 'A'
+ while it should be of record type
+Signatures in the scope: 
+- f : A → A
+- f : B → B
 when checking that the expression f pri has type A

--- a/test/Fail/Issue4924.err
+++ b/test/Fail/Issue4924.err
@@ -1,7 +1,7 @@
 Issue4924.agda:15,7-12
 Cannot resolve overloaded projection f because
 principal argument pri has type A while it should be of record type
-  Signatures in the scope:
+  candidates in scope:
 - f : A → A
 - f : B → B
 when checking that the expression f pri has type A


### PR DESCRIPTION
Basically, all sorts of errors that are printed via `refuseProj` are about ambiguous record fields. Sometimes the error messages indeed became unclear, especially if they did not talk about existence of multiple same-named definitions in the scope. 