### PR TITLE
doc: Rename natEquals to _≡ᵇ_

### DIFF
--- a/doc/user-manual/language/instance-arguments.lagda.rst
+++ b/doc/user-manual/language/instance-arguments.lagda.rst
@@ -5,7 +5,7 @@
 
   open import language.built-ins
     using (Bool; true; false; List; _∷_; []; Nat; _-_; zero; suc; _+_)
-    renaming (_==_ to natEquals)
+    renaming (_==_ to _≡ᵇ_)
 
   open import Agda.Primitive
 
@@ -270,7 +270,7 @@ recursively during instance resolution. For instance,
       _==_ {{eqList}} _        _        = false
 
       eqNat : Eq Nat
-      _==_ {{eqNat}} = natEquals
+      _==_ {{eqNat}} = _≡ᵇ_  -- imported from Data.Nat.Base
 
     ex : Bool
     ex = (1 ∷ 2 ∷ 3 ∷ []) == (1 ∷ 2 ∷ []) -- false

--- a/doc/user-manual/unicode-symbols-sphinx.tex.txt
+++ b/doc/user-manual/unicode-symbols-sphinx.tex.txt
@@ -90,6 +90,7 @@
 \DeclareUnicodeCharacter{1100}{\ensuremath{\mathrm{PDF\;TODO}}}  % Symbol ᄀ
 \DeclareUnicodeCharacter{11F9}{\ensuremath{\mathrm{PDF\;TODO}}}  % Symbol ᇹ
 
+\DeclareUnicodeCharacter{1D47}{\ensuremath{^b}}  % Symbol ᵇ
 \DeclareUnicodeCharacter{1D48}{\ensuremath{^d}}  % Symbol ᵈ
 \DeclareUnicodeCharacter{1D50}{\ensuremath{^m}}  % Symbol ᵐ
 \DeclareUnicodeCharacter{1D56}{\ensuremath{^p}}  % Symbol ᵖ


### PR DESCRIPTION
It's its name in `Data.Nat.Base`.