### PR TITLE
Fix #6355: explicit imports from mtl; test mtl-2.3 in CI cabal.yml

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure ${FLAGS} -O0
+        cabal configure ${FLAGS} -O0 ${{ matrix.cabal-flags }}
     - id: cache
       name: Cache dependencies
       uses: actions/cache@v3
@@ -105,6 +105,10 @@ jobs:
         - cabal-ver: '3.8'
           ghc-ver: 8.2.2
           os: ubuntu-20.04
+        - cabal-flags: -c 'mtl >= 2.3.1'
+          cabal-ver: '3.8'
+          ghc-ver: 9.4.3
+          os: ubuntu-22.04
         - cabal-ver: '3.8'
           ghc-ver: 9.4.3
           os: macos-12

--- a/cabal.project.tc
+++ b/cabal.project.tc
@@ -10,3 +10,4 @@ packages: .
 
 package Agda
   ghc-options: -fno-code -fwrite-interface
+  constraint:  mtl >= 2.3.1

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -11,11 +11,10 @@ module Agda.TypeChecking.Rules.Application
 import Prelude hiding ( null )
 
 import Control.Applicative        ( (<|>) )
-import Control.Monad              ( forM, forM_, guard, liftM2 )
-import Control.Monad.Except
+import Control.Monad              ( filterM, forM, forM_, guard, liftM2 )
+import Control.Monad.Except       ( ExceptT, runExceptT, MonadError, catchError, throwError )
 import Control.Monad.Trans
 import Control.Monad.Trans.Maybe
-import Control.Monad.Reader
 
 import Data.Bifunctor
 import Data.Maybe

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -58,6 +58,13 @@ jobs:
           - os: ubuntu-20.04
             ghc-ver: 8.2.2
             cabal-ver: '3.8'
+          ## Latest GHC
+          # Linux
+          - os: ubuntu-22.04
+            ghc-ver: 9.4.3
+            cabal-ver: '3.8'
+            ## Andreas, 2022-11-23: Test mtl-2.3.1 here which has breaking changes.
+            cabal-flags: "-c 'mtl >= 2.3.1'"
           # macOS
           - os: macos-12
             ghc-ver: 9.4.3
@@ -141,7 +148,7 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure ${FLAGS} -O0
+        cabal configure ${FLAGS} -O0 ${{ matrix.cabal-flags }}
 
     - uses: actions/cache@v3
       name: Cache dependencies


### PR DESCRIPTION
Fix #6355: 
- explicit imports from `mtl`
- test `mtl-2.3` in CI `cabal.yml`

This can go on `release-2.6.3` and will help testing with `mtl-2.3.1` there.