### PR TITLE
Re #5659: no need to exclude transformers-0.6.0.0/1/2 on GHC 8.6

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -260,12 +260,6 @@ library
                 , vector-hashtables == 0.1.*
                 , zlib == 0.6.*
 
-  -- Andreas, 2022-02-02, issue #5659:
-  -- Build failure with transformers-0.6.0.{0,1,2} and GHC 8.6.
-  -- Transformers-0.6.0.3 might restored GHC 8.6 buildability.
-  if impl(ghc == 8.6.*)
-    build-depends: transformers < 0.6 || >= 0.6.0.3
-
   -- Andreas, 2021-03-10:
   -- All packages we depend upon should be mentioned in an unconditional
   -- build-depends field, but additional restrictions on their

--- a/cabal.project.tc
+++ b/cabal.project.tc
@@ -10,4 +10,5 @@ packages: .
 
 package Agda
   ghc-options: -fno-code -fwrite-interface
-  constraint:  mtl >= 2.3.1
+
+constraints:  mtl >= 2.3.1

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4551,7 +4551,7 @@ instance Monad ReduceM where
   return = pure
   (>>=) = bindReduce
   (>>) = (*>)
-#if __GLASGOW_HASKELL__ < 808
+#if __GLASGOW_HASKELL__ < 806
   fail = Fail.fail
 #endif
 
@@ -4864,7 +4864,7 @@ instance MonadTrans TCMT where
     lift m = TCM $ \_ _ -> m
 
 -- We want a special monad implementation of fail.
-#if __GLASGOW_HASKELL__ < 808
+#if __GLASGOW_HASKELL__ < 806
 instance MonadIO m => Monad (TCMT m) where
 #else
 -- Andreas, 2022-02-02, issue #5659:
@@ -4875,7 +4875,7 @@ instance Monad m => Monad (TCMT m) where
     return = pure
     (>>=)  = bindTCMT
     (>>)   = (*>)
-#if __GLASGOW_HASKELL__ < 808
+#if __GLASGOW_HASKELL__ < 806
     fail   = Fail.fail
 #endif
 
@@ -4893,7 +4893,7 @@ instance MonadIO m => MonadIO (TCMT m) where
         E.throwIO $ IOException s r err
 
 instance ( MonadFix m
-#if __GLASGOW_HASKELL__ < 808
+#if __GLASGOW_HASKELL__ < 806
          , MonadIO m
 #endif
          ) => MonadFix (TCMT m) where

--- a/src/full/Agda/TypeChecking/Monad/Base.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs-boot
@@ -32,7 +32,7 @@ instance Applicative m => Applicative (TCMT m)
 instance Functor m => Functor (TCMT m)
 instance MonadIO m => MonadIO (TCMT m)
 
-#if __GLASGOW_HASKELL__ < 808
+#if __GLASGOW_HASKELL__ < 806
 instance MonadIO m => Monad (TCMT m) where
 #else
 -- Andreas, 2022-02-02, issue #5659:


### PR DESCRIPTION
Re #5659: no need to exclude `transformers-0.6.0.0/1/2` on GHC 8.6.
This was suggested by @phadej and it works thanks to `MonadFailDesugaring` being on by default in GHC 8.6.

For a MWE, see:
- https://hub.darcs.net/ross/transformers/issue/85#comment-20221123T213034

This can go on 2.6.3.