### PR TITLE
Fix #5258 #5887 CI test.yml: remove `stack.yaml.lock` from cache-key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   BUILD_DIR: dist
   GHC_VER: 9.4.3
   PARALLEL_TESTS: 2
-  STACK_OPTS: --system-ghc
+  STACK: stack --system-ghc
   STACK_VER: 2.9.1
   TASTY_ANSI_TRICKS: 'false'
 jobs:
@@ -46,8 +46,7 @@ jobs:
         key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml')
           }}
         path: ~/.stack
-    - if: ${{ !steps.cache.outputs.cache-hit }}
-      name: Install dependencies for Agda and its test suites
+    - name: Install dependencies for Agda and its test suites
       run: make install-deps
     - name: Build Agda
       run: make BUILD_DIR="${BUILD_DIR}" install-bin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ env:
   APT_GET_OPTS: -yqq --no-install-suggests --no-install-recommends
   BUILD_DIR: dist
   PARALLEL_TESTS: 2
+  STACK_VER: 2.9.1
   TASTY_ANSI_TRICKS: 'false'
 jobs:
   build:
@@ -21,7 +22,6 @@ jobs:
     outputs:
       ghc-ver: ${{ matrix.ghc-ver }}
       os: ${{ matrix.os }}
-      stack-ver: ${{ matrix.stack-ver }}
     runs-on: ${{ matrix.os }}
     steps:
     - uses: styfle/cancel-workflow-action@0.11.0
@@ -34,7 +34,7 @@ jobs:
       with:
         enable-stack: true
         ghc-version: ${{ matrix.ghc-ver }}
-        stack-version: ${{ matrix.stack-ver }}
+        stack-version: ${{ env.STACK_VER }}
     - name: Update and configure stack
       run: |
         stack update --silent
@@ -47,7 +47,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - if: ${{ !steps.cache.outputs.cache-hit }}
@@ -86,8 +86,6 @@ jobs:
         - 9.4.3
         os:
         - ubuntu-22.04
-        stack-ver:
-        - 2.9.1
   cubical:
     needs: build
     runs-on: ${{ needs.build.outputs.os }}
@@ -99,7 +97,7 @@ jobs:
       with:
         enable-stack: true
         ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ needs.build.outputs.stack-ver }}
+        stack-version: ${{ env.STACK_VER }}
     - uses: actions/download-artifact@v3
       with:
         name: agda-${{ runner.os }}-${{ github.sha }}
@@ -111,7 +109,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -131,7 +129,7 @@ jobs:
       with:
         enable-stack: true
         ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ needs.build.outputs.stack-ver }}
+        stack-version: ${{ env.STACK_VER }}
     - uses: actions/download-artifact@v3
       with:
         name: agda-${{ runner.os }}-${{ github.sha }}
@@ -143,7 +141,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -170,7 +168,7 @@ jobs:
       with:
         enable-stack: true
         ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ needs.build.outputs.stack-ver }}
+        stack-version: ${{ env.STACK_VER }}
     - uses: actions/download-artifact@v3
       with:
         name: agda-${{ runner.os }}-${{ github.sha }}
@@ -182,7 +180,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -210,7 +208,7 @@ jobs:
       with:
         enable-stack: true
         ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ needs.build.outputs.stack-ver }}
+        stack-version: ${{ env.STACK_VER }}
     - uses: actions/download-artifact@v3
       with:
         name: agda-${{ runner.os }}-${{ github.sha }}
@@ -222,7 +220,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Suite of tests for bugs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,7 @@ jobs:
         ghc-version: ${{ env.GHC_VER }}
         stack-version: ${{ env.STACK_VER }}
     - name: Copy stack-${{ env.GHC_VER}}.yaml to stack.yaml
-      run: |
-        cp stack-${{ env.GHC_VER }}.yaml stack.yaml
-
-        # We skip the generation of stack.yaml.lock
-        # make STACK_INSTALL_OPTS='--dry-run' install-deps
+      run: cp stack-${{ env.GHC_VER }}.yaml stack.yaml
     - id: cache
       name: Cache dependencies
       uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,10 @@
 ######################################################
 env:
   AGDA_TESTS_OPTIONS: -j${PARALLEL_TESTS} --hide-successes
-  APT_GET_OPTS: -yqq --no-install-suggests --no-install-recommends
   BUILD_DIR: dist
+  GHC_VER: 9.4.3
   PARALLEL_TESTS: 2
+  STACK_OPTS: --system-ghc
   STACK_VER: 2.9.1
   TASTY_ANSI_TRICKS: 'false'
 jobs:
@@ -19,10 +20,7 @@ jobs:
       && !contains(github.event.head_commit.message, '[ci skip]')
       && !contains(github.event.head_commit.message, '[github skip]')
       && !contains(github.event.head_commit.message, '[skip github]')
-    outputs:
-      ghc-ver: ${{ matrix.ghc-ver }}
-      os: ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     steps:
     - uses: styfle/cancel-workflow-action@0.11.0
       with:
@@ -33,26 +31,24 @@ jobs:
     - uses: haskell/actions/setup@v2
       with:
         enable-stack: true
-        ghc-version: ${{ matrix.ghc-ver }}
+        ghc-version: ${{ env.GHC_VER }}
         stack-version: ${{ env.STACK_VER }}
-    - name: Update and configure stack
+    - name: Copy stack-${{ env.GHC_VER}}.yaml to stack.yaml
       run: |
-        stack update --silent
-        echo "system-ghc: true" >> ~/.stack/config.yaml
-    - name: Copy stack-${{ matrix.ghc-ver}}.yaml to stack.yaml
-      run: |
-        cp stack-${{ matrix.ghc-ver }}.yaml stack.yaml
-        make STACK_INSTALL_OPTS='--dry-run' install-deps
+        cp stack-${{ env.GHC_VER }}.yaml stack.yaml
+
+        # We skip the generation of stack.yaml.lock
+        # make STACK_INSTALL_OPTS='--dry-run' install-deps
     - id: cache
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml')
-          }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml')
+          }}
         path: ~/.stack
     - if: ${{ !steps.cache.outputs.cache-hit }}
       name: Install dependencies for Agda and its test suites
-      run: make STACK_OPTS=--silent install-deps
+      run: make install-deps
     - name: Build Agda
       run: make BUILD_DIR="${BUILD_DIR}" install-bin
     - name: Run tests for the size solver
@@ -80,15 +76,9 @@ jobs:
           dist.tzst
           stack-work.tzst
         retention-days: 1
-    strategy:
-      matrix:
-        ghc-ver:
-        - 9.4.3
-        os:
-        - ubuntu-22.04
   cubical:
     needs: build
-    runs-on: ${{ needs.build.outputs.os }}
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -96,7 +86,7 @@ jobs:
     - uses: haskell/actions/setup@v2
       with:
         enable-stack: true
-        ghc-version: ${{ needs.build.outputs.ghc-ver }}
+        ghc-version: ${{ env.GHC_VER }}
         stack-version: ${{ env.STACK_VER }}
     - uses: actions/download-artifact@v3
       with:
@@ -109,18 +99,16 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml')
-          }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml')
+          }}
         path: ~/.stack
-    - name: Install and configure the icu library
-      run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
     - name: Cubical library test
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
     - name: Successful tests using the cubical library
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-succeed
   interaction-latex-html:
     needs: build
-    runs-on: ${{ needs.build.outputs.os }}
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -128,7 +116,7 @@ jobs:
     - uses: haskell/actions/setup@v2
       with:
         enable-stack: true
-        ghc-version: ${{ needs.build.outputs.ghc-ver }}
+        ghc-version: ${{ env.GHC_VER }}
         stack-version: ${{ env.STACK_VER }}
     - uses: actions/download-artifact@v3
       with:
@@ -141,11 +129,9 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml')
-          }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml')
+          }}
         path: ~/.stack
-    - name: Install and configure the icu library
-      run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
     - name: Install Tex Live and Emacs
       run: |
         sudo apt-get update
@@ -159,7 +145,7 @@ jobs:
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
   stdlib-test:
     needs: build
-    runs-on: ${{ needs.build.outputs.os }}
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -167,7 +153,7 @@ jobs:
     - uses: haskell/actions/setup@v2
       with:
         enable-stack: true
-        ghc-version: ${{ needs.build.outputs.ghc-ver }}
+        ghc-version: ${{ env.GHC_VER }}
         stack-version: ${{ env.STACK_VER }}
     - uses: actions/download-artifact@v3
       with:
@@ -180,11 +166,9 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml')
-          }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml')
+          }}
         path: ~/.stack
-    - name: Install and configure the icu library
-      run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
     - name: Standard library test
       run: |
         # ASR (2021-01-17). `cabal update` is required due to #5138.
@@ -199,7 +183,7 @@ jobs:
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" std-lib-interaction
   test:
     needs: build
-    runs-on: ${{ needs.build.outputs.os }}
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -207,7 +191,7 @@ jobs:
     - uses: haskell/actions/setup@v2
       with:
         enable-stack: true
-        ghc-version: ${{ needs.build.outputs.ghc-ver }}
+        ghc-version: ${{ env.GHC_VER }}
         stack-version: ${{ env.STACK_VER }}
     - uses: actions/download-artifact@v3
       with:
@@ -220,8 +204,8 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml')
-          }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml')
+          }}
         path: ~/.stack
     - name: Suite of tests for bugs
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" bugs

--- a/Makefile
+++ b/Makefile
@@ -756,6 +756,7 @@ debug : ## Print debug information.
 	@echo "PARALLEL_TESTS        = $(PARALLEL_TESTS)"
 	@echo "STACK                 = $(STACK)"
 	@echo "STACK_INSTALL_OPTS    = $(STACK_INSTALL_OPTS)"
+	@echo "STACK_OPTS            = $(STACK_OPTS)"
 	@echo
 	@echo "Run \`make -pq\` to get a detailed report."
 	@echo

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   # Part 1: Versions (need update)
-  ########################################################################
+  ###########################################################################
 
   # Andreas, 2022-11-24, set the stack version here so that it is easily
   # shared between the jobs.
@@ -56,7 +56,7 @@ env:
   GHC_VER: "9.4.3"
 
   # Part 2: Variables that should not have to be changed
-  ########################################################################
+  ###########################################################################
 
   # # Other variables (local to this workflow)
   # APT_GET_OPTS: "-yqq --no-install-suggests --no-install-recommends"
@@ -100,19 +100,9 @@ jobs:
         stack-version: ${{ env.STACK_VER }}
         enable-stack: true
 
-    ## This step is obsolete because we use --system-ghc in STACK_OPTS
-    # - name: "Update and configure stack"
-    #   run: |
-    #     stack update --silent
-    #     echo "system-ghc: true" >> ~/.stack/config.yaml
-
-    # The Makefile tests whether stack.yaml is present.
+    # The Makefile tests whether stack.yaml is present to decide on stack vs. cabal build.
     - name: "Copy stack-${{ env.GHC_VER}}.yaml to stack.yaml"
-      run: |
-        cp stack-${{ env.GHC_VER }}.yaml stack.yaml
-
-        # We skip the generation of stack.yaml.lock
-        # make STACK_INSTALL_OPTS='--dry-run' install-deps
+      run:  cp stack-${{ env.GHC_VER }}.yaml stack.yaml
 
     - &cache
       uses: actions/cache@v3
@@ -128,8 +118,11 @@ jobs:
     #   run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
 
     - name: "Install dependencies for Agda and its test suites"
+      ## Always do this step, even if we got a cache hit.  Should be fast in case we got a hit.
       # if: ${{ !steps.cache.outputs.cache-hit }}
       run: make install-deps
+      ## This used to be: make STACK_OPTS=--silent install-deps
+      ## but printing stuff might not hurt here.
 
     - name: "Build Agda"
       run: make BUILD_DIR="${BUILD_DIR}" install-bin
@@ -140,7 +133,7 @@ jobs:
         make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
 
     - name: "Pack artifacts"
-      # This step should go to Makefile.
+      # This step should go into the Makefile.
       run: |
         strip ${BUILD_DIR}/build/agda-tests/agda-tests \
           ${BUILD_DIR}/build/agda/agda \
@@ -172,7 +165,6 @@ jobs:
     runs-on: *runs_on
 
     steps:
-
     - *checkout
     - *haskell_setup
 
@@ -244,7 +236,6 @@ jobs:
     runs-on: *runs_on
 
     steps:
-
     - *checkout
     - *haskell_setup
     - *download_artifact
@@ -276,7 +267,6 @@ jobs:
     runs-on: *runs_on
 
     steps:
-
     - *checkout
     - *haskell_setup
     - *download_artifact
@@ -308,7 +298,6 @@ jobs:
     runs-on: *runs_on
 
     steps:
-
     - *checkout
     - *haskell_setup
     - *download_artifact

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -44,15 +44,30 @@ on:
   workflow_dispatch:
 
 env:
+  # Part 1: Versions (need update)
+  ########################################################################
+
   # Andreas, 2022-11-24, set the stack version here so that it is easily
   # shared between the jobs.
   STACK_VER: "2.9.1"
+  # Andreas, 2022-03-26, 2022-11-28:
+  # GHC_VER should be given as x.y.z (as opposed to x.y only)
+  # because it is used verbatim when referring to stack-x.y.z.yaml.
+  GHC_VER: "9.4.3"
 
+  # Part 2: Variables that should not have to be changed
+  ########################################################################
+
+  # # Other variables (local to this workflow)
+  # APT_GET_OPTS: "-yqq --no-install-suggests --no-install-recommends"
+
+  # Variables of/for the Makefile
   PARALLEL_TESTS: 2
   BUILD_DIR: "dist" # relative path, please!
-
-  APT_GET_OPTS: "-yqq --no-install-suggests --no-install-recommends"
   AGDA_TESTS_OPTIONS: "-j${PARALLEL_TESTS} --hide-successes"
+  STACK_OPTS: "--system-ghc"
+
+  # tasty configuration (see issue #3905)
   TASTY_ANSI_TRICKS: "false"
 
 jobs:
@@ -61,60 +76,52 @@ jobs:
   ###########################################################################
 
   build:
-    strategy:
-      matrix:
-        # Andreas, 2022-03-26:
-        # ghc-ver should be given as x.y.z (as opposed to x.y only)
-        # because it is used verbatim when referring to stack-x.y.z.yaml.
-        ghc-ver: ['9.4.3']
-        os: [ubuntu-22.04]
-          # Andreas, 2022-10-18
-          # - on ubuntu-22.04 with stack-2.7.5 I experienced a build failure:
-          #   libicuuc.so.66: cannot open shared object file: No such file or directory
-
     if: |
       !contains(github.event.head_commit.message, '[skip ci]')
       && !contains(github.event.head_commit.message, '[ci skip]')
       && !contains(github.event.head_commit.message, '[github skip]')
       && !contains(github.event.head_commit.message, '[skip github]')
 
-    outputs:
-      ghc-ver: ${{ matrix.ghc-ver }}
-      os: ${{ matrix.os }}
-
-    runs-on: ${{ matrix.os }}
+    runs-on: &runs_on ubuntu-22.04
     steps:
     - uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v3
+    - &checkout
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
-    - uses: haskell/actions/setup@v2
+    - &haskell_setup
+      uses: haskell/actions/setup@v2
       with:
-        ghc-version: ${{ matrix.ghc-ver }}
+        ghc-version: ${{ env.GHC_VER }}
         stack-version: ${{ env.STACK_VER }}
         enable-stack: true
 
-    - name: "Update and configure stack"
-      run: |
-        stack update --silent
-        echo "system-ghc: true" >> ~/.stack/config.yaml
+    ## This step is obsolete because we use --system-ghc in STACK_OPTS
+    # - name: "Update and configure stack"
+    #   run: |
+    #     stack update --silent
+    #     echo "system-ghc: true" >> ~/.stack/config.yaml
 
-    - name: "Copy stack-${{ matrix.ghc-ver}}.yaml to stack.yaml"
+    # The Makefile tests whether stack.yaml is present.
+    - name: "Copy stack-${{ env.GHC_VER}}.yaml to stack.yaml"
       run: |
-        cp stack-${{ matrix.ghc-ver }}.yaml stack.yaml
-        make STACK_INSTALL_OPTS='--dry-run' install-deps
+        cp stack-${{ env.GHC_VER }}.yaml stack.yaml
 
-    - uses: actions/cache@v3
+        # We skip the generation of stack.yaml.lock
+        # make STACK_INSTALL_OPTS='--dry-run' install-deps
+
+    - &cache
+      uses: actions/cache@v3
       name: Cache dependencies
       id: cache
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: &cache_key ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml') }}
 
     # ICU is already installed on ubuntu >= 20.04
     # - name: "Install and configure the icu library"
@@ -122,7 +129,7 @@ jobs:
 
     - name: "Install dependencies for Agda and its test suites"
       if: ${{ !steps.cache.outputs.cache-hit }}
-      run: make STACK_OPTS=--silent install-deps
+      run: make install-deps
 
     - name: "Build Agda"
       run: make BUILD_DIR="${BUILD_DIR}" install-bin
@@ -162,35 +169,25 @@ jobs:
 
   test:
     needs: build
-    runs-on: ${{ needs.build.outputs.os }}
+    runs-on: *runs_on
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
 
-    - uses: haskell/actions/setup@v2
-      with:
-        ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ env.STACK_VER }}
-        enable-stack: true
+    - *checkout
+    - *haskell_setup
 
-    - uses: actions/download-artifact@v3
+    - &download_artifact
+      uses: actions/download-artifact@v3
       with:
         name: agda-${{ runner.os }}-${{ github.sha }}
 
-    - name: "Unpack artifacts"
+    - &unpack_artifact
+      name: "Unpack artifacts"
       run: |
         tar --use-compress-program zstd -xvf dist.tzst
         tar --use-compress-program zstd -xvf stack-work.tzst
 
-    - uses: actions/cache@v3
-      name: Cache dependencies
-      id: cache
-      with:
-        path: "~/.stack"
-        # A unique cache is used for each stack.yaml.
-        key: *cache_key
+    - *cache
 
     - name: "Suite of tests for bugs"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" bugs
@@ -244,38 +241,15 @@ jobs:
 
   stdlib-test:
     needs: build
-    runs-on: ${{ needs.build.outputs.os }}
+    runs-on: *runs_on
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
 
-    - uses: haskell/actions/setup@v2
-      with:
-        ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ env.STACK_VER }}
-        enable-stack: true
-
-    - uses: actions/download-artifact@v3
-      with:
-        name: agda-${{ runner.os }}-${{ github.sha }}
-
-    - name: "Unpack artifacts"
-      run: |
-        tar --use-compress-program zstd -xvf dist.tzst
-        tar --use-compress-program zstd -xvf stack-work.tzst
-
-    - uses: actions/cache@v3
-      name: Cache dependencies
-      id: cache
-      with:
-        path: "~/.stack"
-        # A unique cache is used for each stack.yaml.
-        key: *cache_key
-
-    - name: "Install and configure the icu library"
-      run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
+    - *checkout
+    - *haskell_setup
+    - *download_artifact
+    - *unpack_artifact
+    - *cache
 
     - name: "Standard library test"
       run: |
@@ -299,38 +273,15 @@ jobs:
 
   interaction-latex-html:
     needs: build
-    runs-on: ${{ needs.build.outputs.os }}
+    runs-on: *runs_on
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
 
-    - uses: haskell/actions/setup@v2
-      with:
-        ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ env.STACK_VER }}
-        enable-stack: true
-
-    - uses: actions/download-artifact@v3
-      with:
-        name: agda-${{ runner.os }}-${{ github.sha }}
-
-    - name: "Unpack artifacts"
-      run: |
-        tar --use-compress-program zstd -xvf dist.tzst
-        tar --use-compress-program zstd -xvf stack-work.tzst
-
-    - uses: actions/cache@v3
-      name: Cache dependencies
-      id: cache
-      with:
-        path: "~/.stack"
-        # A unique cache is used for each stack.yaml.
-        key: *cache_key
-
-    - name: "Install and configure the icu library"
-      run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
+    - *checkout
+    - *haskell_setup
+    - *download_artifact
+    - *unpack_artifact
+    - *cache
 
     - name: "Install Tex Live and Emacs"
       run: |
@@ -354,38 +305,15 @@ jobs:
 
   cubical:
     needs: build
-    runs-on: ${{ needs.build.outputs.os }}
+    runs-on: *runs_on
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
 
-    - uses: haskell/actions/setup@v2
-      with:
-        ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ env.STACK_VER }}
-        enable-stack: true
-
-    - uses: actions/download-artifact@v3
-      with:
-        name: agda-${{ runner.os }}-${{ github.sha }}
-
-    - name: "Unpack artifacts"
-      run: |
-        tar --use-compress-program zstd -xvf dist.tzst
-        tar --use-compress-program zstd -xvf stack-work.tzst
-
-    - uses: actions/cache@v3
-      name: Cache dependencies
-      id: cache
-      with:
-        path: "~/.stack"
-        # A unique cache is used for each stack.yaml.
-        key: *cache_key
-
-    - name: "Install and configure the icu library"
-      run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
+    - *checkout
+    - *haskell_setup
+    - *download_artifact
+    - *unpack_artifact
+    - *cache
 
     - name: "Cubical library test"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -65,7 +65,7 @@ env:
   PARALLEL_TESTS: 2
   BUILD_DIR: "dist" # relative path, please!
   AGDA_TESTS_OPTIONS: "-j${PARALLEL_TESTS} --hide-successes"
-  STACK_OPTS: "--system-ghc"
+  STACK: "stack --system-ghc"
 
   # tasty configuration (see issue #3905)
   TASTY_ANSI_TRICKS: "false"
@@ -128,7 +128,7 @@ jobs:
     #   run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
 
     - name: "Install dependencies for Agda and its test suites"
-      if: ${{ !steps.cache.outputs.cache-hit }}
+      # if: ${{ !steps.cache.outputs.cache-hit }}
       run: make install-deps
 
     - name: "Build Agda"

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -44,6 +44,10 @@ on:
   workflow_dispatch:
 
 env:
+  # Andreas, 2022-11-24, set the stack version here so that it is easily
+  # shared between the jobs.
+  STACK_VER: "2.9.1"
+
   PARALLEL_TESTS: 2
   BUILD_DIR: "dist" # relative path, please!
 
@@ -63,7 +67,6 @@ jobs:
         # ghc-ver should be given as x.y.z (as opposed to x.y only)
         # because it is used verbatim when referring to stack-x.y.z.yaml.
         ghc-ver: ['9.4.3']
-        stack-ver: ['2.9.1']
         os: [ubuntu-22.04]
           # Andreas, 2022-10-18
           # - on ubuntu-22.04 with stack-2.7.5 I experienced a build failure:
@@ -77,7 +80,6 @@ jobs:
 
     outputs:
       ghc-ver: ${{ matrix.ghc-ver }}
-      stack-ver: ${{ matrix.stack-ver }}
       os: ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
@@ -93,7 +95,7 @@ jobs:
     - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc-ver }}
-        stack-version: ${{ matrix.stack-ver }}
+        stack-version: ${{ env.STACK_VER }}
         enable-stack: true
 
     - name: "Update and configure stack"
@@ -112,7 +114,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-03-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: &cache_key ${{ runner.os }}-stack-03-${{ env.STACK_VER }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     # ICU is already installed on ubuntu >= 20.04
     # - name: "Install and configure the icu library"
@@ -161,6 +163,7 @@ jobs:
   test:
     needs: build
     runs-on: ${{ needs.build.outputs.os }}
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -169,7 +172,7 @@ jobs:
     - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ needs.build.outputs.stack-ver }}
+        stack-version: ${{ env.STACK_VER }}
         enable-stack: true
 
     - uses: actions/download-artifact@v3
@@ -187,7 +190,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: *cache_key
 
     - name: "Suite of tests for bugs"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" bugs
@@ -241,8 +244,8 @@ jobs:
 
   stdlib-test:
     needs: build
-
     runs-on: ${{ needs.build.outputs.os }}
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -251,7 +254,7 @@ jobs:
     - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ needs.build.outputs.stack-ver }}
+        stack-version: ${{ env.STACK_VER }}
         enable-stack: true
 
     - uses: actions/download-artifact@v3
@@ -269,7 +272,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: *cache_key
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
@@ -296,8 +299,8 @@ jobs:
 
   interaction-latex-html:
     needs: build
-
     runs-on: ${{ needs.build.outputs.os }}
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -306,7 +309,7 @@ jobs:
     - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ needs.build.outputs.stack-ver }}
+        stack-version: ${{ env.STACK_VER }}
         enable-stack: true
 
     - uses: actions/download-artifact@v3
@@ -324,7 +327,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: *cache_key
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
@@ -351,8 +354,8 @@ jobs:
 
   cubical:
     needs: build
-
     runs-on: ${{ needs.build.outputs.os }}
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -361,7 +364,7 @@ jobs:
     - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ needs.build.outputs.ghc-ver }}
-        stack-version: ${{ needs.build.outputs.stack-ver }}
+        stack-version: ${{ env.STACK_VER }}
         enable-stack: true
 
     - uses: actions/download-artifact@v3
@@ -379,7 +382,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: *cache_key
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}


### PR DESCRIPTION
Fixes #5258, fixes #5887:
- #5258 
- #5887

To combat the caching problems, use the successful technique from `stack.yml`: 
- #5957 

Also:
- Make use of YAML `&`anchor and `*`ref syntax to remove cut&paste.
- Remove the `matrix` strategy, since we are only testing a single ghc, stack, and OS version.
- Remove obsolete installation of `icu` (present by default since `ubuntu-20.04`).

### OP
CI test.yml: textually share cache key between jobs using yaml syntax.

Keeps the cache key consistent.
I happened to me [again](https://github.com/agda/agda/actions/runs/3536153461) that I only changed it in the first occurrence and forgot about the other occurrences.  (See 9d4e34313208b56618161c5d96839fc0637731f1.)