### PR TITLE
Agda.Utils.Size: new natSize :: a -> Peano

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-04-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - if: ${{ !steps.cache.outputs.cache-hit }}
@@ -111,7 +111,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-04-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -143,7 +143,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-04-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -182,7 +182,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-04-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Install and configure the icu library
@@ -222,7 +222,7 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
+        key: ${{ runner.os }}-stack-04-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml')
           }}-${{ hashFiles('stack.yaml.lock') }}
         path: ~/.stack
     - name: Suite of tests for bugs

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -242,6 +242,7 @@ library
                 , mtl >= 2.2.1 && < 2.4
                 , murmur-hash >= 0.1 && < 0.2
                 , parallel >= 3.2.2.0 && < 3.3
+                , peano >= 0.1.0.1 && < 0.2
                 , pretty >= 1.1.3.3 && < 1.2
                 , process >= 1.4.2.0 && < 1.7
                 , regex-tdfa >= 1.3.1.0 && < 1.4

--- a/src/full/Agda/Auto/Auto.hs
+++ b/src/full/Agda/Auto/Auto.hs
@@ -58,6 +58,7 @@ import Agda.Utils.List
 import Agda.Utils.Maybe
 import Agda.Utils.Null
 import Agda.Utils.Pretty ( prettyShow )
+import Agda.Utils.Size
 import Agda.Utils.Tuple
 
 
@@ -347,7 +348,7 @@ auto ii rng argstr = liftTCM $ locallyTC eMakeCase (const True) $ do
                            -- When Agsy produces an ill-typed solution, return nothing.
                            -- TODO: try other solution.
                            -- `catchError` const retry -- (return (Nothing, Nothing))
-                      let msg = if length exprs == 1 then
+                      let msg = if natSize exprs == 1 then
                                  Nothing
                                 else
                                  Just $ "Also gave solution(s) for hole(s)" ++

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -468,9 +468,11 @@ instance KillRange AmbiguousQName where
 
 instance Sized QName where
   size = size . qnameToList
+  natSize = natSize . qnameToList
 
 instance Sized ModuleName where
   size = size . mnameToList
+  natSize = natSize . mnameToList
 
 ------------------------------------------------------------------------
 -- * NFData instances

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1101,8 +1101,12 @@ instance Sized (Tele a) where
   size  EmptyTel         = 0
   size (ExtendTel _ tel) = 1 + size tel
 
+  natSize EmptyTel          = Zero
+  natSize (ExtendTel _ tel) = Succ $ natSize tel
+
 instance Sized a => Sized (Abs a) where
-  size = size . unAbs
+  size    = size    . unAbs
+  natSize = natSize . unAbs
 
 -- | The size of a term is roughly the number of nodes in its
 --   syntax tree.  This number need not be precise for logical

--- a/src/full/Agda/Syntax/Internal/SanityCheck.hs
+++ b/src/full/Agda/Syntax/Internal/SanityCheck.hs
@@ -36,7 +36,7 @@ sanityCheckSubst gamma rho delta = go gamma rho delta
       case rho of
 
         IdS      -> do
-          unless (natSize gamma == natSize delta) $ err $
+          unless (size gamma == size delta) $ err $
             "idS:" <+> hang (pretty gamma <+> "/=") 2 (pretty delta)
 
         EmptyS _ -> do

--- a/src/full/Agda/Syntax/Internal/SanityCheck.hs
+++ b/src/full/Agda/Syntax/Internal/SanityCheck.hs
@@ -34,24 +34,34 @@ sanityCheckSubst gamma rho delta = go gamma rho delta
   where
     go gamma rho delta =
       case rho of
-        IdS      -> unless (size gamma == size delta) $ err $ "idS:" <+> hang (pretty gamma <+> "/=") 2 (pretty delta)
-        EmptyS _ -> unless (size delta == 0) $ err $ "emptyS:" <+> pretty delta <+> "is not empty"
+
+        IdS      -> do
+          unless (natSize gamma == natSize delta) $ err $
+            "idS:" <+> hang (pretty gamma <+> "/=") 2 (pretty delta)
+
+        EmptyS _ -> do
+          unless (null delta) $ err $
+            "emptyS:" <+> pretty delta <+> "is not empty"
+
         v :# rho -> do
-          unless (size delta > 0) $ err $ "consS: empty target"
+          when (null delta) $ err $ "consS: empty target"
           sanityCheckVars gamma v
           sanityCheckSubst gamma rho (dropLast delta)
+
         Strengthen _ n rho -> do
-          unless (size delta >= n) $ err $ "strS: empty target"
+          unless (natSize delta >= toEnum n) $ err $ "strS: empty target"
           sanityCheckSubst gamma rho (dropLastN n delta)
+
         Wk n rho -> do
-          unless (size gamma >= n) $ err $ "wkS:" <+> sep [ "|" <> pretty gamma <> "|"
-                                                               , text $ "< " ++ show n ]
+          unless (natSize gamma >= toEnum n) $ err $
+            "wkS:" <+> sep [ "|" <> pretty gamma <> "|" , text $ "< " ++ show n ]
           sanityCheckSubst (dropLastN n gamma) rho delta
+
         Lift n rho -> do
-          unless (size gamma >= n) $ err $ "liftS: source" <+> sep [ "|" <> pretty gamma <> "|"
-                                                                        , text $ "< " ++ show n ]
-          unless (size delta >= n) $ err $ "liftS: target" <+> sep [ "|" <> pretty delta <> "|"
-                                                                        , text $ "< " ++ show n ]
+          unless (natSize gamma >= toEnum n) $ err $
+            "liftS: source" <+> sep [ "|" <> pretty gamma <> "|" , text $ "< " ++ show n ]
+          unless (natSize delta >= toEnum n) $ err $
+            "liftS: target" <+> sep [ "|" <> pretty delta <> "|" , text $ "< " ++ show n ]
           sanityCheckSubst (dropLastN n gamma) rho (dropLastN n delta)
 
     dropLast = telFromList . initWithDefault __IMPOSSIBLE__ . telToList

--- a/src/full/Agda/Syntax/TopLevelModuleName.hs
+++ b/src/full/Agda/Syntax/TopLevelModuleName.hs
@@ -55,6 +55,7 @@ instance Ord RawTopLevelModuleName where
 
 instance Sized RawTopLevelModuleName where
   size = size . rawModuleNameParts
+  natSize = natSize . rawModuleNameParts
 
 instance Pretty RawTopLevelModuleName where
   pretty = text . rawTopLevelModuleNameToString
@@ -157,6 +158,7 @@ instance Hashable TopLevelModuleName where
 
 instance Sized TopLevelModuleName where
   size = size . rawTopLevelModuleName
+  natSize = natSize . rawTopLevelModuleName
 
 instance Pretty TopLevelModuleName where
   pretty = pretty . rawTopLevelModuleName

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -306,11 +306,9 @@ checkClauseTelescopeBindings :: MonadReflectedToAbstract m => [(Text, Arg R.Type
 checkClauseTelescopeBindings tel pats =
   case reverse [ x | ((x, _), i) <- zip (reverse tel) [0..], not $ Set.member i bs ] of
     [] -> return ()
-    xs -> genericDocError $ ("Missing bindings for telescope variable" <> s) <?>
+    xs -> genericDocError $ (singPlural xs id (<> "s") "Missing bindings for telescope variable") <?>
                               (fsep (punctuate ", " $ map (text . Text.unpack) xs) <> ".") $$
                              "All variables in the clause telescope must be bound in the left-hand side."
-      where s | length xs == 1 = empty
-              | otherwise      = "s"
   where
     bs = boundVars pats
 

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -27,6 +27,7 @@ import Agda.Utils.Functor
 import Agda.Utils.Maybe
 import Agda.Utils.List
 import qualified Agda.Utils.Pretty as P
+import Agda.Utils.Size
 import Agda.Utils.Update
 
 import Agda.Utils.Impossible
@@ -119,7 +120,7 @@ unBruijn c = Cl (applySubst sub $ (map . fmap) (fmap dbPatVarName . namedThing) 
 
 compileWithSplitTree :: SplitTree -> Cls -> CompiledClauses
 compileWithSplitTree t cs = case t of
-  SplitAt i lz ts -> Case i $ compiles lz ts $ splitOn (length ts == 1) (unArg i) cs
+  SplitAt i lz ts -> Case i $ compiles lz ts $ splitOn (natSize ts == 1) (unArg i) cs
         -- if there is just one case, we force expansion of catch-alls
         -- this is needed to generate a sound tree on which we can
         -- collapse record pattern splits

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1968,7 +1968,7 @@ equalSort s1 s2 = do
 --       f (INeg x)   = map (id -*- not) <$> (f . view . unArg) x
 --       f (OTerm (Var i [])) = return [(i,True)]
 --       f (OTerm _) = return [] -- what about metas? we should suspend? maybe no metas is a precondition?
---       isConsistent xs = all (\ xs -> length xs == 1) . map nub . Map.elems $ xs  -- optimize by not doing generate + filter
+--       isConsistent xs = all (\ xs -> natSize xs == 1) . map nub . Map.elems $ xs  -- optimize by not doing generate + filter
 --       as = map (map (id -*- head) . Map.toAscList) . filter isConsistent . map (Map.fromListWith (++) . map (id -*- (:[]))) $ (f (view t))
 --   xs <- mapM (mapM (\ (i,b) -> (,) i <$> intervalUnview (if b then IOne else IZero))) as
 --   return xs

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -700,7 +700,7 @@ splitStrategy bs tel = return $ updateLast setBlockingVarOverlap xs
 -- the data type must be inductive.
 isDatatype :: (MonadTCM tcm, MonadError SplitError tcm) =>
               Induction -> Dom Type ->
-              tcm (DataOrRecord, QName, [Arg Term], [Arg Term], [QName], Bool)
+              tcm (DataOrRecord, QName, Args, Args, [QName], Bool)
 isDatatype ind at = do
   let t       = unDom at
       throw f = throwError . f =<< do liftTCM $ buildClosure t
@@ -1253,7 +1253,7 @@ split' checkEmpty ind allowPartialCover inserttrailing
           NoCheckEmpty -> pure cons'
         mns  <- forM cons $ \ con -> fmap (SplitCon con,) <$>
           computeNeighbourhood delta1 n delta2 d pars ixs x tel ps cps con
-        hcompsc <- if isFib && (isHIT || (size ixs > 0)) && not (null mns) && inserttrailing == DoInsertTrailing
+        hcompsc <- if isFib && (isHIT || not (null ixs)) && not (null mns) && inserttrailing == DoInsertTrailing
                    then computeHCompSplit delta1 n delta2 d pars ixs x tel ps cps
                    else return Nothing
         let ns = catMaybes mns

--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -86,7 +86,7 @@ createMissingIndexedClauses f n x old_sc scs cs = do
          reportSDoc "tc.cover.indexed" 20 $ text "size (xs,infos):" <+> pretty (size xs,size infos)
          reportSDoc "tc.cover.indexed" 20 $ text "xs :" <+> pretty (map fst xs)
 
-         unless (natSize xs == 1 + natSize infos) $
+         unless (size xs == 1 + size infos) $
             reportSDoc "tc.cover.indexed" 20 $ text "missing some infos"
             -- Andrea: what to do when we only managed to build a unification proof for some of the constructors?
          Constructor{conData} <- theDef <$> getConstInfo (fst (head infos))

--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -86,7 +86,7 @@ createMissingIndexedClauses f n x old_sc scs cs = do
          reportSDoc "tc.cover.indexed" 20 $ text "size (xs,infos):" <+> pretty (size xs,size infos)
          reportSDoc "tc.cover.indexed" 20 $ text "xs :" <+> pretty (map fst xs)
 
-         unless (size xs == size infos + 1) $
+         unless (natSize xs == 1 + natSize infos) $
             reportSDoc "tc.cover.indexed" 20 $ text "missing some infos"
             -- Andrea: what to do when we only managed to build a unification proof for some of the constructors?
          Constructor{conData} <- theDef <$> getConstInfo (fst (head infos))

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -481,8 +481,8 @@ underConstructor (ConHead _c _d i fs) es =
     -- Coinductive (record) constructors admit infinite cycles:
     CoInductive -> underFlexRig WeaklyRigid
     -- Inductive constructors do not admit infinite cycles:
-    Inductive   | size es == size fs -> underFlexRig StronglyRigid
-                | otherwise          -> underFlexRig WeaklyRigid
+    Inductive   | natSize es == natSize fs -> underFlexRig StronglyRigid
+                | otherwise                -> underFlexRig WeaklyRigid
     -- Jesper, 2020-10-22: Issue #4995: treat occurrences in non-fully
     -- applied constructors as weakly rigid.
     -- Ulf, 2019-10-18: Now the termination checker treats inductive recursive records

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -53,7 +53,7 @@ import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Utils.Size
 import Agda.Utils.Permutation
-import Agda.Utils.Pretty (prettyShow)
+import Agda.Utils.Pretty (prettyShow, singPlural)
 import Agda.Utils.Tuple
 
 -- | Generalize a telescope over a set of generalizable variables.
@@ -376,8 +376,7 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
     prune cxt tel (x : xs) | not (isGeneralized x) = do
       -- If x is a blocked term we shouldn't instantiate it.
       whenM (not <$> isBlockedTerm x) $ do
-        x <- if size tel > 0 then prePrune x
-                             else return x
+        x <- if null tel then return x else prePrune x
         pruneMeta (telFromList $ reverse cxt) x
       prune cxt tel xs
     prune cxt (ExtendTel a tel) (x : xs) = prune (fmap (x,) a : cxt) (unAbs tel) xs
@@ -658,11 +657,11 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
                      "clear, but simply mentioning the variables in the right order should also work."
           order = sep [ fwords "Dependency analysis suggested this (likely incorrect) order:",
                         nest 2 $ fwords (unwords names) ]
-          guess = "After constraint solving it looks like " ++ commas late ++ " actually depend" ++ s ++
-                  " on " ++ commas early
-            where
-              s | length late == 1 = "s"
-                | otherwise        = ""
+          guess = unwords
+            [ "After constraint solving it looks like", commas late
+            , singPlural late (++ "s") id "actually depend"
+            , "on", commas early
+            ]
       genericDocError =<< vcat
         [ fwords $ "Variable generalization failed."
         , nest 2 $ sep ["- Probable cause", nest 4 $ fwords cause]

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -455,13 +455,13 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
           -- Set display form for the old name if it's not a constructor.
 {- BREAKS fail/Issue478
           -- Andreas, 2012-10-20 and if we are not an anonymous module
-          -- unless (isAnonymousModuleName new || isCon || size ptel > 0) $ do
+          -- unless (isAnonymousModuleName new || isCon || not (null ptel)) $ do
 -}
           -- BREAKS fail/Issue1643a
           -- -- Andreas, 2015-09-09 Issue 1643:
           -- -- Do not add a display form for a bare module alias.
-          -- when (not isCon && size ptel == 0 && not (null ts)) $ do
-          when (size ptel == 0) $ do
+          -- when (not isCon && null ptel && not (null ts)) $ do
+          when (null ptel) $ do
             addDisplayForms y
           where
             ts' = take np ts
@@ -714,7 +714,7 @@ singleConstructorType q = do
       di <- theDef <$> getConstInfo d
       return $ case di of
         Record {}                  -> True
-        Datatype { dataCons = cs } -> length cs == 1
+        Datatype { dataCons = cs } -> natSize cs == 1
         _                          -> __IMPOSSIBLE__
     _ -> __IMPOSSIBLE__
 

--- a/src/full/Agda/TypeChecking/Positivity/Occurrence.hs
+++ b/src/full/Agda/TypeChecking/Positivity/Occurrence.hs
@@ -171,7 +171,8 @@ instance Null Occurrence where
 -- Agda.TypeChecking.Positivity.
 
 instance Sized OccursWhere where
-  size (OccursWhere _ cs os) = 1 + size cs + size os
+  size    (OccursWhere _ cs os) = 1 + size cs + size os
+  natSize (OccursWhere _ cs os) = 1 + natSize cs + natSize os
 
 -- | The map contains bindings of the form @bound |-> ess@, satisfying
 -- the following property: for every non-empty list @w@,

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -53,9 +53,10 @@ import Agda.Utils.List1 ( List1, pattern (:|) )
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Null
-import Agda.Utils.Permutation (Permutation)
-import Agda.Utils.Pretty (Pretty, prettyShow)
+import Agda.Utils.Permutation ( Permutation )
+import Agda.Utils.Pretty      ( Pretty, prettyShow )
 import qualified Agda.Utils.Pretty as P
+import Agda.Utils.Size        ( natSize )
 
 import Agda.Utils.Impossible
 
@@ -326,7 +327,7 @@ instance PrettyTCM TypeCheckingProblem where
   prettyTCM (CheckLambda cmp (Arg ai (xs, mt)) e t) =
     sep [ pure CP.lambda <+>
           (CP.prettyRelevance ai .
-           CP.prettyHiding ai (if isNothing mt && length xs == 1 then id
+           CP.prettyHiding ai (if isNothing mt && natSize xs == 1 then id
                                else P.parens) <$> do
             fsep $
               map prettyTCM (List1.toList xs) ++

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -46,7 +46,7 @@ import Agda.Utils.Lens
 import Agda.Utils.List ( editDistance )
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Null
-import Agda.Utils.Pretty ( Pretty, prettyShow )
+import Agda.Utils.Pretty ( Pretty, prettyShow, singPlural )
 import qualified Agda.Utils.Pretty as P
 
 instance PrettyTCM TCWarning where
@@ -196,11 +196,11 @@ prettyWarning = \case
     SafeFlagPostulate e -> fsep $
       pwords "Cannot postulate" ++ [pretty e] ++ pwords "with safe flag"
 
-    SafeFlagPragma xs ->
-      let plural | length xs == 1 = ""
-                 | otherwise      = "s"
-      in fsep $ [fwords ("Cannot set OPTIONS pragma" ++ plural)]
-                ++ map text xs ++ [fwords "with safe flag."]
+    SafeFlagPragma xs -> fsep $ concat
+      [ [ fwords $ singPlural xs id (++ "s") "Cannot set OPTIONS pragma" ]
+      , map text xs
+      , [ fwords "with safe flag." ]
+      ]
 
     SafeFlagNonTerminating -> fsep $
       pwords "Cannot use NON_TERMINATING pragma with safe flag."

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -134,8 +134,8 @@ compactDef bEnv def rewr = do
       _ | Just (defName def) == bPrimForce bEnv   -> pure CForce
       _ | Just (defName def) == bPrimErase bEnv ->
           case telView' (defType def) of
-            TelV tel _ | size tel == 5 -> pure CErase
-                       | otherwise     -> pure COther
+            TelV tel _ | natSize tel == 5 -> pure CErase
+                       | otherwise        -> pure COther
                           -- Non-standard equality. Fall back to slow reduce.
       _ | defBlocked def /= notBlocked_ -> pure COther -- Blocked definition
       Constructor{conSrcCon = c, conArity = n} -> pure CCon{cconSrcCon = c, cconArity = n}

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -148,7 +148,7 @@ instance PatternFrom Type Term NLPat where
        -- in order to build a Miller pattern
        | Just vs <- allApplyElims es -> do
            TelV tel rest <- telViewPath =<< typeOfBV i
-           unless (size tel >= size vs) $ blockOnMetasIn rest >> addContext tel (errNotPi rest)
+           unless (natSize tel >= natSize vs) $ blockOnMetasIn rest >> addContext tel (errNotPi rest)
            let ts = applySubst (parallelS $ reverse $ map unArg vs) $ map unDom $ flattenTel tel
            mbvs <- forM (zip ts vs) $ \(t , v) -> do
              blockOnMetasIn (v,t)

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1457,7 +1457,7 @@ inferOrCheckProjAppToKnownPrincipalArg e o ds args mt k v0 ta mpatm = do
               ]
             -- See issue 1960 for when the following assertion fails for
             -- the correct disambiguation.
-            -- guard (size tel == size pars)
+            -- guard (natSize tel == natSize pars)
 
             guard =<< do isNothing <$> do lift $ checkModality' d def
             return (orig, (d, (pars, (dom, u, tb))))

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -724,7 +724,7 @@ bindBuiltinEquality x = do
   unless (isJust $ isSort $ unEl eqCore) __IMPOSSIBLE__
 
   -- The types of the last two arguments must be the third-last argument
-  unless (size eqTel >= 3) no
+  unless (natSize eqTel >= 3) no
   let (a, b) = fromMaybe __IMPOSSIBLE__ $ last2 $ telToList eqTel
   [a,b] <- reduce $ map (unEl . snd . unDom) [a,b]
   unless (deBruijnView a == Just 0) no
@@ -896,7 +896,7 @@ bindBuiltin b x = do
       PatternSynResName xs -> failure
       UnknownName          -> failure
     -- For ambiguous names, we check all of their definitions:
-    unlessM (allM xs $ ((0 ==) . size) <.> lookupSection . qnameModule . anameName) $
+    unlessM (allM xs $ null <.> lookupSection . qnameModule . anameName) $
       failure
   -- Since the name was define in a parameter-free context, we can switch to the empty context.
   -- (And we should!)

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -476,9 +476,9 @@ checkLambda' cmp b xps typ body target = do
     [ "info           =" <+> (text . show) info
     ]
   TelV tel btyp <- telViewUpTo numbinds target
-  if size tel < numbinds || numbinds /= 1
-    then (if possiblePath then trySeeingIfPath else dontUseTargetType)
-    else useTargetType tel btyp
+  if numbinds == 1 && not (null tel) then useTargetType tel btyp
+  else if possiblePath then trySeeingIfPath
+  else dontUseTargetType
 
   where
 

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -47,7 +47,8 @@ instance Show Permutation where
           showList sep f (e:es) = f e ++ sep ++ showList sep f es
 
 instance Sized Permutation where
-  size (Perm _ xs) = size xs
+  size    (Perm _ xs) = size xs
+  natSize (Perm _ xs) = natSize xs
 
 instance Null Permutation where
   empty = Perm 0 []

--- a/src/full/Agda/Utils/Pretty.hs
+++ b/src/full/Agda/Utils/Pretty.hs
@@ -184,7 +184,7 @@ pshow :: Show a => a -> Doc
 pshow = text . show
 
 singPlural :: Sized a => a -> c -> c -> c
-singPlural xs singular plural = if size xs == 1 then singular else plural
+singPlural xs singular plural = if natSize xs == 1 then singular else plural
 
 -- | Used for with-like 'telescopes'
 

--- a/src/full/Agda/Utils/Size.hs
+++ b/src/full/Agda/Utils/Size.hs
@@ -6,10 +6,12 @@ module Agda.Utils.Size
   ( Sized(..)
   , SizedThing(..)
   , sizeThing
+  , module X
   ) where
 
 import Prelude hiding (null, length)
 
+import Data.Peano as X     ( Peano(Zero,Succ) )
 import Data.Foldable       (Foldable, length)
 import Data.HashMap.Strict (HashMap)
 import Data.HashSet        (HashSet)
@@ -26,10 +28,26 @@ import Agda.Utils.Null
 -- | The size of a collection (i.e., its length).
 
 class Sized a where
+  -- | Strict size computation.
+  --
+  -- Anti-patterns: @size xs == n@ where @n@ is @0@, @1@ or another number
+  -- that is likely smaller than @size xs@.
+  -- Similar for @size xs >= 1@ etc.
+  -- Use 'natSize' instead.
+  --
+  -- See https://wiki.haskell.org/Haskell_programming_tips#Don.27t_ask_for_the_length_of_a_list_when_you_don.27t_need_it .
   size :: a -> Int
 
   default size :: (Foldable t, t b ~ a) => a -> Int
   size = length
+
+  -- | Lazily compute a (possibly infinite) size.
+  --
+  -- Use when comparing a size against a fixed number.
+  natSize :: a -> Peano
+
+  default natSize :: (Foldable t, t b ~ a) => a -> Peano
+  natSize = foldr (const Succ) Zero
 
 instance Sized [a]
 instance Sized (Set a)
@@ -39,7 +57,9 @@ instance Sized (IntMap a)
 instance Sized (List1 a)
 instance Sized (Map k a)
 instance Sized (Seq a)
-instance Sized IntSet where size = IntSet.size
+instance Sized IntSet where
+  size = IntSet.size
+  natSize = toEnum . size
 
 -- | Thing decorated with its size.
 --   The thing should fit into main memory, thus, the size is an @Int@.
@@ -56,6 +76,7 @@ sizeThing a = SizedThing (size a) a
 -- | Return the cached size.
 instance Sized (SizedThing a) where
   size = theSize
+  natSize = toEnum . theSize
 
 instance Null a => Null (SizedThing a) where
   empty = SizedThing 0 empty

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-03-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-04-${{ matrix.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     # ICU is already installed on ubuntu >= 20.04
     # - name: "Install and configure the icu library"
@@ -187,7 +187,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-04-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Suite of tests for bugs"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" bugs
@@ -269,7 +269,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-04-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
@@ -324,7 +324,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-04-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}
@@ -379,7 +379,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-03-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-04-${{ needs.build.outputs.stack-ver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('stack.yaml.lock') }}
 
     - name: "Install and configure the icu library"
       run: sudo apt-get install libicu-dev ${APT_GET_OPTS}

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -22,6 +22,7 @@ extra-deps:
 - optparse-applicative-0.15.1.0
 - parallel-3.2.2.0
 - parsec-3.1.15.1
+- peano-0.1.0.1
 - primitive-0.7.2.0
 - profunctors-5.2.2
 - random-1.2.0

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -21,6 +21,7 @@ extra-deps:
 - data-fix-0.3.2
 - generic-deriving-1.14.2
 - indexed-traversable-0.1.2
+- peano-0.1.0.1
 - primitive-0.7.4.0
 - random-1.2.0
 - regex-base-0.94.0.0

--- a/stack-9.4.2.yaml
+++ b/stack-9.4.2.yaml
@@ -81,6 +81,7 @@ extra-deps:
 - optparse-applicative-0.17.0.0
 - parallel-3.2.2.0
 - parsec-3.1.15.0
+- peano-0.1.0.1
 - polyparse-1.13
 - pretty-1.1.3.6
 - primitive-0.7.4.0


### PR DESCRIPTION
`Agda.Utils.Size`: new `natSize :: a -> Peano`.

With Peano natural numbers, we can compute lengths of lists lazily. E.g. `natSize xs == 1` is constant-time, while `size xs == 1` can be linear-time.

**SQUASH** this PR.