### PR TITLE
Fix #6380: no unusable instance warnings when activating anonymous instances

### DIFF
--- a/test/Fail/Issue2372.err
+++ b/test/Fail/Issue2372.err
@@ -3,9 +3,5 @@ Terms marked as eligible for instance search should end with a
 name, so 'instance' is ignored here.
 when checking the definition of i
 Issue2372.agda:21,5-6
-Terms marked as eligible for instance search should end with a
-name, so 'instance' is ignored here.
-when checking that the expression r has type Set
-Issue2372.agda:21,5-6
 No instance of type R was found in scope.
 when checking that the expression r has type Set

--- a/test/Succeed/Issue6380.agda
+++ b/test/Succeed/Issue6380.agda
@@ -1,0 +1,21 @@
+-- Andreas, 2022-12-04, issue #6380, reported by Felix Cherubini.
+
+postulate
+  B C : Set
+  b   : B
+  c   : C
+
+record R : Set where
+  instance
+    irrelevantInstance = b
+
+  something : C → C
+  something c = c
+
+postulate r : R
+open R {{...}}
+
+instance _ = r
+
+_ =  something c
+-- This used to trigger an InstanceWithExplicitArg warning.


### PR DESCRIPTION
Fix #6380: no unusable instance warnings when activating anonymous instances.