### PR TITLE
[ workflows ] test.yml: fix #6386: add Agda.cabal to the cache key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,8 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml')
-          }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{
+          hashFiles('stack.yaml', 'Agda.cabal') }}
         path: ~/.stack
     - name: Install dependencies for Agda and its test suites
       run: make install-deps
@@ -94,8 +94,8 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml')
-          }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{
+          hashFiles('stack.yaml', 'Agda.cabal') }}
         path: ~/.stack
     - name: Cubical library test
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
@@ -124,8 +124,8 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml')
-          }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{
+          hashFiles('stack.yaml', 'Agda.cabal') }}
         path: ~/.stack
     - name: Install Tex Live and Emacs
       run: |
@@ -161,8 +161,8 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml')
-          }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{
+          hashFiles('stack.yaml', 'Agda.cabal') }}
         path: ~/.stack
     - name: Standard library test
       run: |
@@ -199,8 +199,8 @@ jobs:
       name: Cache dependencies
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml')
-          }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{
+          hashFiles('stack.yaml', 'Agda.cabal') }}
         path: ~/.stack
     - name: Suite of tests for bugs
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" bugs

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
       with:
         path: "~/.stack"
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml') }}
+        key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles('stack.yaml', 'Agda.cabal') }}
 
     # ICU is already installed on ubuntu >= 20.04
     # - name: "Install and configure the icu library"


### PR DESCRIPTION
Attempt fix #6386: add Agda.cabal to the cache key of test.yml