### PR TITLE
Fix #6388: do not cancel test.yml on master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,8 @@ jobs:
       && !contains(github.event.head_commit.message, '[skip github]')
     runs-on: ubuntu-22.04
     steps:
-    - uses: styfle/cancel-workflow-action@0.11.0
+    - if: github.ref != 'refs/heads/master'
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - uses: actions/checkout@v3

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -85,6 +85,8 @@ jobs:
     runs-on: &runs_on ubuntu-22.04
     steps:
     - uses: styfle/cancel-workflow-action@0.11.0
+      # Andreas, 2022-12-05, issue #6388: do not cancel on `master`!
+      if: github.ref != 'refs/heads/master'
       with:
         access_token: ${{ github.token }}
 


### PR DESCRIPTION
Fix #6388: do not cancel workflow `test.yml` on `master`.