### PR TITLE
Add new `workOnTypes` reflection primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,21 @@ Reflection
     pickWhatever _ = typeError (strErr "Already solved!" ∷ [])
   ```
 
+* A new reflection primitive `workOnTypes : TC A → TC A` was added to
+  `Agda.Builtin.Reflection`. This runs the given computation at the type level,
+  which enables the use of erased things. In particular, this is needed when
+  working with (dependent) function types with erased arguments. For example,
+  one can get the type of the tuple constructor `_,_` (which now takes its type
+  parameters as erased arguments, see above) and unify it with the current goal
+  as follows:
+  ```agda
+  macro
+    testM : Term → TC ⊤
+    testM hole = bindTC (getType (quote _,_)) (λ t → workOnTypes (unify hole t))
+
+  typeOfComma = testM
+  ```
+
 * [**Breaking**] The reflection primitives `getContext` and `inContext` use a nominal context
   `List (Σ String λ _ → Arg Type)` instead of  `List (Arg Type)` for printing
   type information better. Similarly, `extendContext` takes an extra argument

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -511,6 +511,9 @@ following primitive operations::
     -- "blocking" constraints.
     noConstraints : ∀ {a} {A : Set a} → TC A → TC A
 
+    -- Run the given computation at the type level, allowing use of erased things.
+    workOnTypes : ∀ {a} {A : Set a} → TC A → TC A
+
     -- Run the given TC action and return the first component. Resets to
     -- the old TC state if the second component is 'false', or keep the
     -- new TC state if it is 'true'.
@@ -549,6 +552,7 @@ following primitive operations::
   {-# BUILTIN AGDATCMONLYREDUCEDEFS             onlyReduceDefs             #-}
   {-# BUILTIN AGDATCMDONTREDUCEDEFS             dontReduceDefs             #-}
   {-# BUILTIN AGDATCMNOCONSTRAINTS              noConstraints              #-}
+  {-# BUILTIN AGDATCMWORKONTYPES                workOnTypes                #-}
   {-# BUILTIN AGDATCMRUNSPECULATIVE             runSpeculative             #-}
   {-# BUILTIN AGDATCMGETINSTANCES               getInstances               #-}
 

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -319,6 +319,9 @@ postulate
   -- "blocking" constraints.
   noConstraints : ∀ {a} {A : Set a} → TC A → TC A
 
+  -- Run the given computation at the type level, allowing use of erased things.
+  workOnTypes : ∀ {a} {A : Set a} → TC A → TC A
+
   -- Run the given TC action and return the first component. Resets to
   -- the old TC state if the second component is 'false', or keep the
   -- new TC state if it is 'true'.
@@ -364,6 +367,7 @@ postulate
 {-# BUILTIN AGDATCMDONTREDUCEDEFS             dontReduceDefs             #-}
 {-# BUILTIN AGDATCMWITHRECONSPARAMS           withReconstructed          #-}
 {-# BUILTIN AGDATCMNOCONSTRAINTS              noConstraints              #-}
+{-# BUILTIN AGDATCMWORKONTYPES                workOnTypes                #-}
 {-# BUILTIN AGDATCMRUNSPECULATIVE             runSpeculative             #-}
 {-# BUILTIN AGDATCMGETINSTANCES               getInstances               #-}
 

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -284,6 +284,7 @@ ghcPreCompile flags = do
       , builtinAgdaTCMOnlyReduceDefs
       , builtinAgdaTCMDontReduceDefs
       , builtinAgdaTCMNoConstraints
+      , builtinAgdaTCMWorkOnTypes
       , builtinAgdaTCMRunSpeculative
       , builtinAgdaTCMExec
       , builtinAgdaTCMGetInstances

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -73,6 +73,7 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinAgdaTCMWithNormalisation, builtinAgdaTCMWithReconsParams,
   builtinAgdaTCMOnlyReduceDefs, builtinAgdaTCMDontReduceDefs,
   builtinAgdaTCMNoConstraints,
+  builtinAgdaTCMWorkOnTypes,
   builtinAgdaTCMRunSpeculative,
   builtinAgdaTCMExec,
   builtinAgdaTCMGetInstances,
@@ -283,6 +284,7 @@ builtinAgdaTCMDebugPrint                 = "AGDATCMDEBUGPRINT"
 builtinAgdaTCMOnlyReduceDefs             = "AGDATCMONLYREDUCEDEFS"
 builtinAgdaTCMDontReduceDefs             = "AGDATCMDONTREDUCEDEFS"
 builtinAgdaTCMNoConstraints              = "AGDATCMNOCONSTRAINTS"
+builtinAgdaTCMWorkOnTypes                = "AGDATCMWORKONTYPES"
 builtinAgdaTCMRunSpeculative             = "AGDATCMRUNSPECULATIVE"
 builtinAgdaTCMExec                       = "AGDATCMEXEC"
 builtinAgdaTCMGetInstances               = "AGDATCMGETINSTANCES"

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -246,6 +246,7 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primAgdaTCMWithNormalisation, primAgdaTCMWithReconsParams,
     primAgdaTCMOnlyReduceDefs, primAgdaTCMDontReduceDefs,
     primAgdaTCMNoConstraints,
+    primAgdaTCMWorkOnTypes,
     primAgdaTCMRunSpeculative,
     primAgdaTCMExec,
     primAgdaTCMGetInstances,
@@ -452,6 +453,7 @@ primAgdaTCMDebugPrint                 = getBuiltin builtinAgdaTCMDebugPrint
 primAgdaTCMOnlyReduceDefs             = getBuiltin builtinAgdaTCMOnlyReduceDefs
 primAgdaTCMDontReduceDefs             = getBuiltin builtinAgdaTCMDontReduceDefs
 primAgdaTCMNoConstraints              = getBuiltin builtinAgdaTCMNoConstraints
+primAgdaTCMWorkOnTypes                = getBuiltin builtinAgdaTCMWorkOnTypes
 primAgdaTCMRunSpeculative             = getBuiltin builtinAgdaTCMRunSpeculative
 primAgdaTCMExec                       = getBuiltin builtinAgdaTCMExec
 primAgdaTCMGetInstances               = getBuiltin builtinAgdaTCMGetInstances

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -393,6 +393,7 @@ coreBuiltins =
   , builtinAgdaTCMDontReduceDefs             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tlist tqname --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
 
   , builtinAgdaTCMNoConstraints              |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+  , builtinAgdaTCMWorkOnTypes                |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMRunSpeculative             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
                                                                    tTCM 1 (primSigma <#> varM 1 <#> primLevelZero <@> varM 0 <@> (Lam defaultArgInfo . Abs "_" <$> primBool)) --> tTCM 1 (varM 0))
   , builtinAgdaTCMExec                       |-> builtinPostulate (tstring --> tlist tstring --> tstring -->

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -605,6 +605,7 @@ evalTCM v = do
              , (f `isDef` getBuiltin' builtinAgdaTCMRunSpeculative, tcRunSpeculative (unElim u))
              , (f `isDef` getBuiltin' builtinAgdaTCMExec, tcFun3 tcExec l a u)
              , (f `isDef` getBuiltin' builtinAgdaTCMPragmaCompile, tcFun3 tcPragmaCompile l a u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMWorkOnTypes, tcWorkOnTypes (unElim u))
              ]
              failEval
     I.Def f [_, _, u, v] ->
@@ -726,6 +727,9 @@ evalTCM v = do
 
     tcNoConstraints :: Term -> UnquoteM Term
     tcNoConstraints m = liftU1 noConstraints (evalTCM m)
+
+    tcWorkOnTypes :: Term -> UnquoteM Term
+    tcWorkOnTypes m = liftU1 workOnTypes (evalTCM m)
 
     tcInferType :: R.Term -> TCM Term
     tcInferType v = do

--- a/test/Fail/TranspErasedPi-lhs.agda
+++ b/test/Fail/TranspErasedPi-lhs.agda
@@ -1,0 +1,26 @@
+-- This test case verifies that we cannot transport along an erased pi
+-- type where the codomain depends on the argument in a non-erased
+-- way.
+
+{-# OPTIONS --erased-cubical #-}
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive.Cubical
+  renaming (primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primTransp to transp)
+open import Agda.Builtin.Cubical.Sub
+  renaming (primSubOut to outS)
+open import Agda.Builtin.Cubical.Path
+
+refl : ∀ {ℓ} {A : Type ℓ} {x : A} → x ≡ x
+refl {x = x} i = x
+
+module
+  _ {ℓ ℓ′} {A0 : Type ℓ} {B0 : A0 → Type ℓ′}
+    (φ : I)
+    {A : I → Sub (Type ℓ) φ (λ ._ → A0)}
+    {B : ∀ i → (x : outS (A i)) → Sub (Type ℓ′) φ (λ { (φ = i1) → B0 x })}
+    (f : (@0 x : outS (A i0)) → outS (B i0 x))
+  where
+
+  lhs : (@0 x : outS (A i1)) → outS (B i1 x)
+  lhs = transp (λ i → (@0 x : outS (A i)) → outS (B i x)) φ f

--- a/test/Fail/TranspErasedPi-lhs.err
+++ b/test/Fail/TranspErasedPi-lhs.err
@@ -1,0 +1,3 @@
+TranspErasedPi-lhs.agda:26,55-56
+Variable x is declared erased, so it cannot be used here
+when checking that the expression x has type outS (A i)

--- a/test/Fail/TranspErasedPi-rhs.agda
+++ b/test/Fail/TranspErasedPi-rhs.agda
@@ -1,0 +1,28 @@
+-- This test case contains the reduct of the would-be transport in
+-- TranspErasedPi-lhs.agda (which should not be well-typed).
+
+{-# OPTIONS --erased-cubical #-}
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive.Cubical
+  renaming (primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primTransp to transp)
+open import Agda.Builtin.Cubical.Sub
+  renaming (primSubOut to outS)
+open import Agda.Builtin.Cubical.Path
+
+refl : ∀ {ℓ} {A : Type ℓ} {x : A} → x ≡ x
+refl {x = x} i = x
+
+module
+  _ {ℓ ℓ′} {A0 : Type ℓ} {B0 : A0 → Type ℓ′}
+    (φ : I)
+    {A : I → Sub (Type ℓ) φ (λ ._ → A0)}
+    {B : ∀ i → (x : outS (A i)) → Sub (Type ℓ′) φ (λ { (φ = i1) → B0 x })}
+    (f : (@0 x : outS (A i0)) → outS (B i0 x))
+  where
+
+  rhs : (@0 x : outS (A i1)) → outS (B i1 x)
+  rhs = λ x → transp (λ i → outS (B i (transp (λ j → outS (A (i ∨ ~ j))) (φ ∨ i) x))) φ
+    --                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    --                                transpFill (λ i → outS (A i)) φ x but inlined
+              (f (transp (λ i → outS (A (~ i))) φ x))

--- a/test/Fail/TranspErasedPi-rhs.err
+++ b/test/Fail/TranspErasedPi-rhs.err
@@ -1,0 +1,3 @@
+TranspErasedPi-rhs.agda:25,82-83
+Variable x is declared erased, so it cannot be used here
+when checking that the expression x has type outS (A (i ∨ ~ i0))

--- a/test/Succeed/Issue6124.agda
+++ b/test/Succeed/Issue6124.agda
@@ -1,0 +1,26 @@
+open import Agda.Primitive
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+--open import Agda.Builtin.Reflection.External
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Sigma
+
+id : (@0 A : Set) → A → A
+id _ x = x
+
+macro
+  @0 Unit : Term → TC ⊤
+  Unit goal =
+    bindTC (inferType (def (quote id) [])) λ t →
+    bindTC (workOnTypes (reduce t)) λ _ →
+    unify goal (def (quote ⊤) [])
+
+_ : Set
+_ = Unit
+
+macro
+  testM : Term → TC ⊤
+  testM hole = bindTC (getType (quote _,_)) (λ t → workOnTypes (unify hole t))
+
+test : Setω
+test = testM

--- a/test/Succeed/TranspErasedPi.agda
+++ b/test/Succeed/TranspErasedPi.agda
@@ -1,0 +1,29 @@
+-- This test verifies that transp has the correct computational
+-- behaviour on erased pi types (test case constructed by Amélia Liao)
+
+{-# OPTIONS --erased-cubical #-}
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive.Cubical
+  renaming (primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primTransp to transp)
+open import Agda.Builtin.Cubical.Sub
+  renaming (primSubOut to outS)
+open import Agda.Builtin.Cubical.Path
+
+refl : ∀ {ℓ} {A : Type ℓ} {x : A} → x ≡ x
+refl {x = x} i = x
+
+module
+  _ {ℓ ℓ′} {A0 : Type ℓ} {B0 : @0 A0 → Type ℓ′}
+    (φ : I)
+    {A : I → Sub (Type ℓ) φ (λ ._ → A0)}
+    {B : ∀ i → (@0 x : outS (A i)) → Sub (Type ℓ′) φ (λ { (φ = i1) → B0 x })}
+    (f : (@0 x : outS (A i0)) → outS (B i0 x))
+  where
+
+  _ : transp (λ i → (@0 x : outS (A i)) → outS (B i x)) φ f
+    ≡ λ x → transp (λ i → outS (B i (transp (λ j → outS (A (i ∨ ~ j))) (φ ∨ i) x))) φ
+    --                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    --                                transpFill (λ i → outS (A i)) φ x but inlined
+              (f (transp (λ i → outS (A (~ i))) φ x))
+  _ = refl


### PR DESCRIPTION
This fixes #6124 (kind of) by adding a new primitive `workOnTypes` that can be used to go into "erased mode", i.e. manipulate terms that contain erased things.