### PR TITLE
[ #6413 ] Tried to compile matches on erased arguments properly

### DIFF
--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -559,7 +559,7 @@ compileTerm kit t = go t
       T.TCon q -> do
         d <- getConstInfo q
         qname q
-      T.TCase sc ct def alts | T.CTData _ dt <- T.caseType ct -> do
+      T.TCase sc ct def alts | T.CTData dt <- T.caseType ct -> do
         dt <- getConstInfo dt
         alts' <- traverse (compileAlt kit) alts
         let cs  = defConstructors $ theDef dt

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -271,7 +271,7 @@ casetree cc = do
               where
               go (c:cs) = canonicalName c >>= getConstInfo <&> theDef >>= \case
                 Constructor{conData} ->
-                  return $ C.CTData (getQuantity i) conData
+                  return $ C.CTData conData
                 _ -> go cs
               go [] = __IMPOSSIBLE__
             ([], LitChar   _ : _) -> return C.CTChar
@@ -283,7 +283,12 @@ casetree cc = do
         updateCatchAll catchAll $ do
           x <- asks (lookupLevel n . ccCxt)
           def <- fromCatchAll
-          let caseInfo = C.CaseInfo { caseType = caseTy, caseLazy = lazy }
+          let caseInfo = C.CaseInfo
+                { caseType   = caseTy
+                , caseLazy   = lazy
+                , caseErased = fromMaybe __IMPOSSIBLE__ $
+                               erasedFromQuantity (getQuantity i)
+                }
           C.TCase x caseInfo def <$> do
             br1 <- conAlts n conBrs'
             br2 <- litAlts n litBrs

--- a/src/full/Agda/Compiler/Treeless/EliminateDefaults.hs
+++ b/src/full/Agda/Compiler/Treeless/EliminateDefaults.hs
@@ -17,7 +17,7 @@ eliminateCaseDefaults = tr
   where
     tr :: TTerm -> TCM TTerm
     tr = \case
-      TCase sc ct@CaseInfo{caseType = CTData _ qn} def alts
+      TCase sc ct@CaseInfo{caseType = CTData qn} def alts
         | not (isUnreachable def) -> do
         dtCons <- defConstructors . theDef <$> getConstInfo qn
         let missingCons = dtCons List.\\ map aCon alts

--- a/src/full/Agda/Compiler/Treeless/EliminateLiteralPatterns.hs
+++ b/src/full/Agda/Compiler/Treeless/EliminateLiteralPatterns.hs
@@ -37,7 +37,7 @@ transform kit = tr
               (tr body)
               cont
           litAlt _ _ = __IMPOSSIBLE__
-      TCase sc t@CaseInfo{caseType = CTData _ dt} def alts ->
+      TCase sc t@CaseInfo{caseType = CTData dt} def alts ->
         TCase sc t (tr def) (map trAlt alts)
         where
           trAlt = \case
@@ -62,7 +62,7 @@ transform kit = tr
       TLet e b                -> TLet (tr e) (tr b)
 
     -- TODO:: Defined but not used
-    isCaseOn (CTData _ dt) xs = dt `elem` mapMaybe ($ kit) xs
+    isCaseOn (CTData dt) xs = dt `elem` mapMaybe ($ kit) xs
     isCaseOn _ _ = False
 
     eqFromLit :: Literal -> TPrim

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -991,11 +991,14 @@ instance NFData Quantity where
 -- ** Erased.
 
 -- | A special case of 'Quantity': erased or not.
+--
+-- Note that the 'Ord' instance does *not* ignore the origin
+-- arguments.
 
 data Erased
   = Erased Q0Origin
   | NotErased QωOrigin
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Ord, Generic)
 
 -- | The default value of type 'Erased': not erased.
 

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -346,7 +346,7 @@ instance NamesIn TAlt where
 
 instance NamesIn CaseType where
   namesAndMetasIn' sg = \case
-    CTData _ x -> namesAndMetasIn' sg x
+    CTData x   -> namesAndMetasIn' sg x
     CTNat      -> mempty
     CTInt      -> mempty
     CTChar     -> mempty
@@ -355,7 +355,7 @@ instance NamesIn CaseType where
     CTQName    -> mempty
 
 instance NamesIn CaseInfo where
-  namesAndMetasIn' sg (CaseInfo _ t) = namesAndMetasIn' sg t
+  namesAndMetasIn' sg (CaseInfo _ _ t) = namesAndMetasIn' sg t
 
 instance NamesIn Compiled where
   namesAndMetasIn' sg (Compiled t _) = namesAndMetasIn' sg t

--- a/src/full/Agda/Syntax/Treeless.hs
+++ b/src/full/Agda/Syntax/Treeless.hs
@@ -194,9 +194,8 @@ tIfThenElse :: TTerm -> TTerm -> TTerm -> TTerm
 tIfThenElse c i e = TApp (TPrim PIf) [c, i, e]
 
 data CaseType
-  = CTData Quantity QName
-    -- Case on datatype. The 'Quantity' is zero for matches on erased
-    -- arguments.
+  = CTData QName
+    -- Case on datatype.
   | CTNat
   | CTInt
   | CTChar
@@ -207,6 +206,8 @@ data CaseType
 
 data CaseInfo = CaseInfo
   { caseLazy :: Bool
+  , caseErased :: Erased
+    -- ^ Is this a match on an erased argument?
   , caseType :: CaseType }
   deriving (Show, Eq, Ord, Generic)
 
@@ -217,6 +218,9 @@ data TAlt
   -- (pushes all existing variables aArity steps further away)
   | TAGuard  { aGuard :: TTerm, aBody :: TTerm }
   -- ^ Binds no variables
+  --
+  -- The guard must only use the variable that the case expression
+  -- matches on.
   | TALit    { aLit :: Literal,   aBody:: TTerm }
   deriving (Show, Eq, Ord, Generic)
 

--- a/test/Compiler/simple/Issue6413-1.agda
+++ b/test/Compiler/simple/Issue6413-1.agda
@@ -1,0 +1,29 @@
+-- This test case is based on a bug report submitted by Xia Li-yao.
+
+{-# OPTIONS --erasure #-}
+
+module Issue6413-1 where
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.IO
+open import Agda.Builtin.Unit
+
+postulate
+  print : Bool → IO ⊤
+
+{-# FOREIGN GHC
+      import qualified Data.Char
+  #-}
+{-# COMPILE GHC print = putStrLn . map Data.Char.toLower . show #-}
+{-# COMPILE JS  print =
+      x => cb => { process.stdout.write(x.toString() + "\n"); cb(0); }
+  #-}
+
+data D (A : Set) : Set where
+  c : ⊤ → A → D A
+
+f : @0 D (D ⊤) → Bool
+f (c _ (c _ _)) = true
+
+main : IO ⊤
+main = print (f (c tt (c tt tt)))

--- a/test/Compiler/simple/Issue6413-1.out
+++ b/test/Compiler/simple/Issue6413-1.out
@@ -1,0 +1,5 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > true
+out >

--- a/test/Compiler/simple/Issue6413-2.agda
+++ b/test/Compiler/simple/Issue6413-2.agda
@@ -1,0 +1,36 @@
+{-# OPTIONS --erasure #-}
+
+module Issue6413-2 where
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+open import Agda.Builtin.IO
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Strict
+open import Agda.Builtin.Unit
+
+postulate
+  print : Bool → IO ⊤
+
+{-# FOREIGN GHC
+      import qualified Data.Char
+  #-}
+{-# COMPILE GHC print = putStrLn . map Data.Char.toLower . show #-}
+{-# COMPILE JS  print =
+      x => cb => { process.stdout.write(x.toString() + "\n"); cb(0); }
+  #-}
+
+data ⊥ : Set where
+
+⊥-elim : {A : Set} → @0 ⊥ → A
+⊥-elim ()
+
+f : (n : Nat) → @0 (0 ≡ 0 → ⊥) → Nat
+f zero    not-zero = ⊥-elim (not-zero refl)
+f (suc n) _        = n
+
+x : @0 (0 ≡ 0 → ⊥) → Nat
+x = f zero
+
+main : IO ⊤
+main = print (primForce x λ _ → true)

--- a/test/Compiler/simple/Issue6413-2.out
+++ b/test/Compiler/simple/Issue6413-2.out
@@ -1,0 +1,5 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > true
+out >


### PR DESCRIPTION
This is related to issue #6413. The commit contains the following changes (assuming that there are no bugs in the implementation):

* One of the arguments of the `TCase` constructor now contains information about whether the match was made on an erased argument. (Previously this information was only present for certain kinds of matches.)
* A (necessarily erased) variable is no longer seen as used (by `Agda.Compiler.Treeless.Unused.usedArguments`) only because it is used in a match on an erased variable.
* I documented what I hope is an invariant: guards only use the variable that the enclosing case expression matches on.
* The treeless compiler now removes all matches on erased variables.

Can someone answer the following questions?
* Is the potential invariant mentioned above actually an invariant?
* The code relies on another potential invariant: that the `TCase` alternatives are given in the order in which they should be attempted (or at least that the first alternative should be attempted first). The documentation of `TCase` suggests that this may not be the case:

  https://github.com/agda/agda/blob/39cc3079c6b4ef46f64868c7146fd7bc3aa4ef23/src/full/Agda/Syntax/Treeless.hs#L63-L67

  However, the GHC backend does not reorder alternatives:

  https://github.com/agda/agda/blob/39cc3079c6b4ef46f64868c7146fd7bc3aa4ef23/src/full/Agda/Compiler/MAlonzo/Compiler.hs#L1013-L1018

  Are the `TCase` alternatives given in the order in which they should be attempted? In that case we could document this.
* This change makes Agda fully erase more things. For instance, consider [a certain piece of code](https://github.com/agda/agda/issues/6413#issuecomment-1368103257). Previously Agda's GHC backend (strict or non-strict) generated the following code for `main`:
  ```haskell
  -- Main.main
  d_main_14 ::
    MAlonzo.Code.Agda.Builtin.IO.T_IO_8
      AgdaAny MAlonzo.Code.Agda.Builtin.Unit.T_'8868'_6
  d_main_14 = coe d_print_2 (d_f_12 erased)
  ```
  Now the following code is generated:
  ```haskell
  -- Main.main
  d_main_14 ::
    MAlonzo.Code.Agda.Builtin.IO.T_IO_8
      AgdaAny MAlonzo.Code.Agda.Builtin.Unit.T_'8868'_6
  d_main_14 = coe d_print_2 (coe du_f_12)
  ```
  Note that  `erased` is removed entirely (because `du_f_12` is used instead of `d_f_12`).

  Does the new implementation fully erase too many things? This might be a problem for strict backends. In "A New Extraction for Coq" Letouzey mentions that one can define a function of type (basically) `(n : Nat) → @0 n ≢ 0 → Nat` that matches on the natural number and uses the erased proof to handle the zero case. If this function is partially applied to zero, then one gets a term that after erasure is basically "raise exception". However, I failed to use this idea to construct Agda code that is compiled incorrectly. Consider the following attempt:
  ```agda
  module Main where

  open import Agda.Builtin.Bool
  open import Agda.Builtin.Equality
  open import Agda.Builtin.IO
  open import Agda.Builtin.Nat
  open import Agda.Builtin.Strict
  open import Agda.Builtin.Unit

  postulate
    print : Bool → IO ⊤

  {-# FOREIGN GHC
        import qualified Data.Char
    #-}
  {-# COMPILE GHC print = putStrLn . map Data.Char.toLower . show #-}
  {-# COMPILE JS  print =
        x => cb => { process.stdout.write(x.toString() + "\n"); cb(0); }
    #-}

  data ⊥ : Set where

  ⊥-elim : {A : Set} → @0 ⊥ → A
  ⊥-elim ()

  f : (n : Nat) → @0 (0 ≡ 0 → ⊥) → Nat
  f zero    not-zero = ⊥-elim (not-zero refl)
  f (suc n) _        = n

  x : @0 (0 ≡ 0 → ⊥) → Nat
  x = f zero

  main : IO ⊤
  main = print (primForce x λ _ → true)
  ```
  This code runs successfully if compiled using either the strict GHC backend or the JS backend. I can imagine that this code could lead to a crash if `x` is compiled in a certain way and then run before `main` is run. However, the tested backends do not generate such code. For instance, the strict GHC backend generates the following code for `x`:
  ```haskell
  -- Main.x
  d_x_18 ::
    (MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12 -> T_'8869'_4) ->
    Integer
  d_x_18 !v0 = coe du_f_12 (coe (0 :: Integer))
  ```
  (There is no definition called `du_x_18`.) Can one come up with some other construction that breaks the tested backends? Or does the new treatment of erased arguments break other backends that should be supported?