### PR TITLE
issue #6415: don't compare reducts of glued values

### DIFF
--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -396,22 +396,35 @@ compareTerm' cmp a m n =
               let mkUnglue m = apply unglue $ map (setHiding Hidden) args ++ [argN m]
               reportSDoc "conv.glue" 20 $ prettyTCM (aty,mkUnglue m,mkUnglue n)
 
-              -- When φ is an interval expression which can be
-              -- decomposed into substitutions σ, then we also compare
-              -- the terms m[σ] = n[σ] at the type (Glue a φ _)[σ]. This
-              -- is because, under decomposing φ, the Glue type might
-              -- reduce.
-              phi' <- decomposeInterval' (unArg phi)
-              -- However if φ is *not* decomposable (e.g. because it is
-              -- a function application φ i, see Issue #5955), then we
-              -- do not recur, otherwise we'd just end up right back
-              -- here.
-              unless (IntMap.null (foldMap fst phi')) $
-                compareTermOnFace cmp (unArg phi) a' m n
+              -- Amy, 2023-01-04: Here and in hcompu below we used to
+              -- also compare whatever the glued terms would evaluate to
+              -- on φ. This is very loopy (consider φ = f i or φ = i0:
+              -- both generate empty substitutions so get us back to
+              -- exactly the same conversion problem)!
+              --
+              -- But is there a reason to do this comparison? The
+              -- answer, it turns out, is no!
+              --
+              -- Suppose you had
+              --    Γ ⊢ x = glue [φ → t] xb : Glue T S
+              --    Γ ⊢ y = glue [φ → s] yb : Glue T S
+              --    Γ ⊢ xb = yb : T
+              -- Is there a need to check whether Γ φ ⊢ t = s : S? No!
+              -- That's because the typing rule for glue is something like
+              --   glue φ : (s : PartialP φ S) (t : T [ φ → s ]) → Glue T S
+              -- where the bracket notation stands for an "implicit
+              -- Sub"-type, i.e. Γ, φ ⊢ t = s (definitionally)
+              --
+              -- So if we have a glued element, and we have xb = yb, we
+              -- can be sure that
+              --   Γ , φ ⊢ t = xb = yb = s
+              --
+              -- But what about the general case, where we're not
+              -- looking at a literal glue? Well, eta for Glue
+              -- means x = glue [φ → x] (unglue x), so the logic above
+              -- still applies. On φ, for the reducts to agree, it's
+              -- enough for the bases to agree.
 
-              -- And in the general case, we compare the glued things by
-              -- "eta": m and n are the same if they unglue to the same
-              -- thing.
               compareTerm cmp aty (mkUnglue m) (mkUnglue n)
          Def q es | Just q == mHComp, Just (sl:s:args@[phi,u,u0]) <- allApplyElims es
                   , Sort (Type lvl) <- unArg s
@@ -422,7 +435,6 @@ compareTerm' cmp a m n =
               let bA = subIn `apply` [sl,s,phi,u0]
               let mkUnglue m = apply unglueU $ [argH l] ++ map (setHiding Hidden) [phi,u]  ++ [argH bA,argN m]
               reportSDoc "conv.hcompU" 20 $ prettyTCM (ty,mkUnglue m,mkUnglue n)
-              compareTermOnFace cmp (unArg phi) ty m n
               compareTerm cmp ty (mkUnglue m) (mkUnglue n)
          Def q es | Just q == mSub, Just args@(l:a:_) <- allApplyElims es -> do
               ty <- el' (pure $ unArg l) (pure $ unArg a)

--- a/test/Fail/Issue6415.agda
+++ b/test/Fail/Issue6415.agda
@@ -1,0 +1,20 @@
+{-# OPTIONS --cubical --lossy-unification #-}
+module Issue6415 where
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Cubical.Glue
+open import Agda.Builtin.Cubical.Path
+
+data S¹ : Type where
+  base : S¹
+  loop : base ≡ base
+
+G : Type
+G = primGlue S¹ {i0} isOneEmpty ?
+
+g : G
+g = prim^glue isOneEmpty base
+
+hmm : primTransp (λ _ → G) i0 g ≡ g
+hmm = Helpers.refl

--- a/test/Fail/Issue6415.agda
+++ b/test/Fail/Issue6415.agda
@@ -11,10 +11,10 @@ data S¹ : Type where
   loop : base ≡ base
 
 G : Type
-G = primGlue S¹ {i0} isOneEmpty ?
+G = primGlue S¹ {i0} isOneEmpty isOneEmpty
 
 g : G
-g = prim^glue isOneEmpty base
+g = prim^glue (isOneEmpty {A = λ .p → isOneEmpty p}) base
 
 hmm : primTransp (λ _ → G) i0 g ≡ g
 hmm = Helpers.refl

--- a/test/Fail/Issue6415.err
+++ b/test/Fail/Issue6415.err
@@ -1,0 +1,24 @@
+Issue6415.agda:20,7-19
+primHComp (λ i → isOneEmpty)
+(primHComp
+ (λ i →
+    primPOr
+    (primIMax i0
+     (Agda.Builtin.Cubical.HCompU.primFaceForall (λ i₁ → i0)))
+    (primINeg
+     (primIMax i0
+      (Agda.Builtin.Cubical.HCompU.primFaceForall (λ i₁ → i0))))
+    (λ .o →
+       primTransp (λ i₁ → S¹) i
+       (primPOr i0
+        (Agda.Builtin.Cubical.HCompU.primFaceForall (λ i₁ → i0))
+        (λ .o₁ → prim^unglue g)
+        (λ .o₁ →
+           equivFun (isOneEmpty _)
+           (primTransp (λ j → isOneEmpty _) (primIMax i0 (primINeg i)) g))
+        _))
+    (λ .o → primTransp (λ i₁ → S¹) i0 (prim^unglue g)))
+ (primTransp (λ i → S¹) i0 (prim^unglue g)))
+!= base of type S¹
+when checking that the expression Helpers.refl has type
+primTransp (λ _ → G) i0 g ≡ g


### PR DESCRIPTION
I'm still getting rid of the redundant conversion, but the _actual_ issue was that the first-order shortcut was removing an `unglue` that was added by eta-conversion for Glue, and removing that `unglue` means that the unglued things wouldn't compute. So the conversion checker was stuck looking at `transport refl g = g → unglue (transport refl g) = g → transport refl g = g` when the first-order shortcut kicked in, vs `transport refl g = g → [big normal form] = g` without it.

---

When the conversion checker is faced with `x = y : Glue {φ} T S`, it also compares the reducts the reducts of `x` and `y` under `φ`: we turn `φ` into a set of substitutions `σs` and compare, for each, `x[σ] = y[σ] : (Glue {φ} T S)[σ]`. This is very loopy: if `φ` is something we either can't turn into a substitution (#5955), or produces an identity substitution (#6415), we're right back where we started. Woops!

But is there an actual reason to do this comparison? Well, let's think: suppose you had

```
  Γ ⊢ x = glue [φ → t] xb : Glue {φ} T S
  Γ ⊢ y = glue [φ → s] yb : Glue {φ} T S
  Γ ⊢ xb = yb : T
  --- want:
  Γ ⊢ x = y : Glue {φ} T S
```

After checking `xb = yb`, there a need to check whether `Γ, φ ⊢ t = s : S`? Well, no! That's because the typing rule for glue is something like (modulo a big abuse of notation)

```
  glue φ : (s : PartialP φ S) (t : T [ φ → s ]) → Glue T S
```

where the bracket notation in `T` stands for an "implicit Sub"-type, i.e. it must be the case that `Γ, φ ⊢ t = s` *definitionally*. So if we have a glued element, and we have `xb = yb` *everywhere*, we can be sure that

```
  Γ , φ ⊢ t = xb -- by the typing rule for glue
            = yb -- we've already checked this
            = s  -- by the typing rule for glue
```

But what about the general case, where we're not looking at a literal glue? Well, eta for Glue means `x = glue [φ → x] (unglue x)`, so the logic above still applies. On `φ`, for the reducts to agree, it's enough for the bases to agree.

Fixes #6415. Should also be a performance win, but I did not benchmark.