### PR TITLE
[ #6055, stack ] Bumped resolver for GHC 9.4.4.

### DIFF
--- a/stack-9.4.4.yaml
+++ b/stack-9.4.4.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2023-01-02
+resolver: nightly-2023-01-05
 compiler: ghc-9.4.4
 compiler-check: match-exact
 


### PR DESCRIPTION
(nightly-2023-01-02 -> nightly-2023-01-05)