### PR TITLE
Fix #6434: new option `--no-infer-absurd-clauses`

### DIFF
--- a/doc/release-notes/2.6.4.md
+++ b/doc/release-notes/2.6.4.md
@@ -166,10 +166,12 @@ Pragmas and options
   See [--trace-imports](https://agda.readthedocs.io/en/v2.6.4/tools/command-line-options.html#cmdoption-trace-imports)
   in the documentation for more.
 
-* New option `--performance:absurd-clauses` to simplify coverage checking and case splitting:
+* New option `--no-infer-absurd-clauses` to simplify coverage checking and case splitting:
   Agda will then no longer attempt to automatically eliminate absurd clauses which can be a costly operation.
   This means that these absurd clauses have to be written out in the Agda text.
   Try this option if you experience type checking performance degradation with omitted absurd clauses.
+
+  Opposite: `--infer-absurd-clauses`.
 
 * Benign warnings are now printed together with their warning name, to give a hint how they can be disabled
   (see [#6229](https://github.com/agda/agda/issues/6229)).

--- a/doc/release-notes/2.6.4.md
+++ b/doc/release-notes/2.6.4.md
@@ -166,6 +166,11 @@ Pragmas and options
   See [--trace-imports](https://agda.readthedocs.io/en/v2.6.4/tools/command-line-options.html#cmdoption-trace-imports)
   in the documentation for more.
 
+* New option `--performance:absurd-clauses` to simplify coverage checking and case splitting:
+  Agda will then no longer attempt to automatically eliminate absurd clauses which can be a costly operation.
+  This means that these absurd clauses have to be written out in the Agda text.
+  Try this option if you experience type checking performance degradation with omitted absurd clauses.
+
 * Benign warnings are now printed together with their warning name, to give a hint how they can be disabled
   (see [#6229](https://github.com/agda/agda/issues/6229)).
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -532,6 +532,15 @@ Pattern matching and equality
      Prevent interactive case splitting from replacing variables with
      dot patterns (see :ref:`dot-patterns`).
 
+.. option:: --performance:absurd-clauses
+
+     .. versionadded:: 2.6.4
+
+     Prevent interactive case splitting and coverage checking from automatically filtering out absurd clauses.
+     This means that these absurd clauses have to be written out in the Agda text.
+     Try this option if you experience type checking performance degradation with omitted absurd clauses.
+
+
 Search depth and instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1175,6 +1175,7 @@ again, the source file is re-typechecked instead:
 * :option:`--experimental-irrelevance`
 * :option:`--flat-split`
 * :option:`--guarded`
+* :option:`--infer-absurd-clauses`
 * :option:`--injective-type-constructors`
 * :option:`--instance-search-depth`
 * :option:`--inversion-max-depth`

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -532,14 +532,15 @@ Pattern matching and equality
      Prevent interactive case splitting from replacing variables with
      dot patterns (see :ref:`dot-patterns`).
 
-.. option:: --performance:absurd-clauses
+.. option:: --infer-absurd-clauses, --no-infer-absurd-clauses
 
      .. versionadded:: 2.6.4
 
-     Prevent interactive case splitting and coverage checking from automatically filtering out absurd clauses.
+     ``--no-infer-absurd-clauses`` prevents interactive case splitting and coverage checking from automatically filtering out absurd clauses.
      This means that these absurd clauses have to be written out in the Agda text.
      Try this option if you experience type checking performance degradation with omitted absurd clauses.
 
+     Default: ``--infer-absurd-clauses``.
 
 Search depth and instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -415,7 +415,7 @@ makeCase hole rng s = withInteractionId hole $ locallyTC eMakeCase (const True) 
       then Just <$> makeAbsurdClause f ell' sc
       -- trivially empty clause due to the refined patterns
       else
-        ifM (liftTCM $ isEmptyTel (scTel sc))
+        ifM (liftTCM $ (not . optKeepAbsurdClauses <$> pragmaOptions) `and2M` isEmptyTel (scTel sc))
           {- then -} (pure Nothing)
           {- else -} (Just <$> makeAbstractClause f rhs ell' sc)
     reportSLn "interaction.case" 70 $ "makeCase: survived filtering out impossible clauses"

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -415,7 +415,7 @@ makeCase hole rng s = withInteractionId hole $ locallyTC eMakeCase (const True) 
       then Just <$> makeAbsurdClause f ell' sc
       -- trivially empty clause due to the refined patterns
       else
-        ifM (liftTCM $ (not . optKeepAbsurdClauses <$> pragmaOptions) `and2M` isEmptyTel (scTel sc))
+        ifM (liftTCM $ (optInferAbsurdClauses <$> pragmaOptions) `and2M` isEmptyTel (scTel sc))
           {- then -} (pure Nothing)
           {- else -} (Just <$> makeAbstractClause f rhs ell' sc)
     reportSLn "interaction.case" 70 $ "makeCase: survived filtering out impossible clauses"

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -200,11 +200,9 @@ data PragmaOptions = PragmaOptions
   , optKeepPatternVariables      :: Bool
       -- ^ Should case splitting replace variables with dot patterns
       --   (False) or keep them as variables (True).
-  , optKeepAbsurdClauses         :: Bool
-      -- ^ Should case splitting and coverage checking keep clauses
-      --   that Agda can discharge as absurd at some cost?
-      --   Default: 'False', but 'True' might make coverage checking
-      --   considerably faster in some cases.
+  , optInferAbsurdClauses        :: Bool
+      -- ^ Should case splitting and coverage checking try to discharge absurd clauses?
+      --   Default: 'True', but 'False' might make coverage checking considerably faster in some cases.
   , optInstanceSearchDepth       :: Int
   , optOverlappingInstances      :: Bool
   , optQualifiedInstances        :: Bool  -- ^ Should instance search consider instances with qualified names?
@@ -350,7 +348,7 @@ defaultPragmaOptions = PragmaOptions
   , optFirstOrder                = False
   , optPostfixProjections        = False
   , optKeepPatternVariables      = False
-  , optKeepAbsurdClauses         = False
+  , optInferAbsurdClauses        = True
   , optInstanceSearchDepth       = 500
   , optOverlappingInstances      = False
   , optQualifiedInstances        = True
@@ -897,8 +895,8 @@ postfixProjectionsFlag o = return $ o { optPostfixProjections = True }
 keepPatternVariablesFlag :: Flag PragmaOptions
 keepPatternVariablesFlag o = return $ o { optKeepPatternVariables = True }
 
-keepAbsurdClausesFlag :: Flag PragmaOptions
-keepAbsurdClausesFlag o = return $ o { optKeepAbsurdClauses = True }
+inferAbsurdClausesFlag :: Bool -> Flag PragmaOptions
+inferAbsurdClausesFlag b o = return $ o { optInferAbsurdClauses = b }
 
 instanceDepthFlag :: String -> Flag PragmaOptions
 instanceDepthFlag s o = do
@@ -1209,7 +1207,9 @@ pragmaOptions =
                     "make postfix projection notation the default"
     , Option []     ["keep-pattern-variables"] (NoArg keepPatternVariablesFlag)
                     "don't replace variables with dot patterns during case splitting"
-    , Option []     ["performance:absurd-clauses"] (NoArg keepAbsurdClausesFlag)
+    , Option []     ["infer-absurd-clauses"] (NoArg (inferAbsurdClausesFlag True))
+                    "eliminate absurd clauses in case splitting and coverage checking (default)"
+    , Option []     ["no-infer-absurd-clauses"] (NoArg (inferAbsurdClausesFlag False))
                     "do not automatically eliminate absurd clauses in case splitting and coverage checking (can speed up type-checking)"
     , Option []     ["instance-search-depth"] (ReqArg instanceDepthFlag "N")
                     "set instance search depth to N (default: 500)"

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -200,6 +200,11 @@ data PragmaOptions = PragmaOptions
   , optKeepPatternVariables      :: Bool
       -- ^ Should case splitting replace variables with dot patterns
       --   (False) or keep them as variables (True).
+  , optKeepAbsurdClauses         :: Bool
+      -- ^ Should case splitting and coverage checking keep clauses
+      --   that Agda can discharge as absurd at some cost?
+      --   Default: 'False', but 'True' might make coverage checking
+      --   considerably faster in some cases.
   , optInstanceSearchDepth       :: Int
   , optOverlappingInstances      :: Bool
   , optQualifiedInstances        :: Bool  -- ^ Should instance search consider instances with qualified names?
@@ -345,6 +350,7 @@ defaultPragmaOptions = PragmaOptions
   , optFirstOrder                = False
   , optPostfixProjections        = False
   , optKeepPatternVariables      = False
+  , optKeepAbsurdClauses         = False
   , optInstanceSearchDepth       = 500
   , optOverlappingInstances      = False
   , optQualifiedInstances        = True
@@ -891,6 +897,9 @@ postfixProjectionsFlag o = return $ o { optPostfixProjections = True }
 keepPatternVariablesFlag :: Flag PragmaOptions
 keepPatternVariablesFlag o = return $ o { optKeepPatternVariables = True }
 
+keepAbsurdClausesFlag :: Flag PragmaOptions
+keepAbsurdClausesFlag o = return $ o { optKeepAbsurdClauses = True }
+
 instanceDepthFlag :: String -> Flag PragmaOptions
 instanceDepthFlag s o = do
   d <- integerArgument "--instance-search-depth" s
@@ -1200,6 +1209,8 @@ pragmaOptions =
                     "make postfix projection notation the default"
     , Option []     ["keep-pattern-variables"] (NoArg keepPatternVariablesFlag)
                     "don't replace variables with dot patterns during case splitting"
+    , Option []     ["performance:absurd-clauses"] (NoArg keepAbsurdClausesFlag)
+                    "do not automatically eliminate absurd clauses in case splitting and coverage checking (can speed up type-checking)"
     , Option []     ["instance-search-depth"] (ReqArg instanceDepthFlag "N")
                     "set instance search depth to N (default: 500)"
     , Option []     ["overlapping-instances"] (NoArg overlappingInstancesFlag)

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -168,7 +168,8 @@ coverageCheck f t cs = do
 
 
   -- filter out the missing clauses that are absurd.
-  pss <- flip filterM pss $ \(tel,ps) ->
+  pss <- ifM (optKeepAbsurdClauses <$> pragmaOptions) (pure pss) {-else-} $
+   flip filterM pss $ \(tel,ps) ->
     -- Andreas, 2019-04-13, issue #3692: when adding missing absurd
     -- clauses, also put the absurd pattern in.
     caseEitherM (checkEmptyTel noRange tel) (\ _ -> return True) $ \ l -> do

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -168,7 +168,7 @@ coverageCheck f t cs = do
 
 
   -- filter out the missing clauses that are absurd.
-  pss <- ifM (optKeepAbsurdClauses <$> pragmaOptions) (pure pss) {-else-} $
+  pss <- ifNotM (optInferAbsurdClauses <$> pragmaOptions) (pure pss) {-else-} $
    flip filterM pss $ \(tel,ps) ->
     -- Andreas, 2019-04-13, issue #3692: when adding missing absurd
     -- clauses, also put the absurd pattern in.

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20230103 * 10 + 1
+currentInterfaceVersion = 20230113 * 10 + 1
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -293,12 +293,12 @@ instance EmbPrj InfectiveCoinfective where
 
 instance EmbPrj PragmaOptions where
   icod_ = \case
-    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj ->
-      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj
+    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk ->
+      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk
 
   value = vcase $ \case
-    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx, yy, zz, aaa, bbb, ccc, ddd, eee, fff, ggg, hhh, iii, jjj] ->
-      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj
+    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx, yy, zz, aaa, bbb, ccc, ddd, eee, fff, ggg, hhh, iii, jjj, kkk] ->
+      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk
     _ -> malformed
 
 instance EmbPrj ProfileOptions where

--- a/test/Fail/Issue6434.agda
+++ b/test/Fail/Issue6434.agda
@@ -1,7 +1,7 @@
 -- Andreas, 2023-01-13, issue #6434
--- This test/Succeed/Issue1086.agda made to fail by --performance:absurd-clauses
+-- This test/Succeed/Issue1086.agda made to fail by --no-infer-absurd-clauses
 
-{-# OPTIONS --performance:absurd-clauses #-}
+{-# OPTIONS --no-infer-absurd-clauses #-}
 
 open import Agda.Builtin.Bool
 open import Agda.Builtin.Equality

--- a/test/Fail/Issue6434.agda
+++ b/test/Fail/Issue6434.agda
@@ -1,0 +1,20 @@
+-- Andreas, 2023-01-13, issue #6434
+-- This test/Succeed/Issue1086.agda made to fail by --performance:absurd-clauses
+
+{-# OPTIONS --performance:absurd-clauses #-}
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+
+and : (a b : Bool) → Bool
+and true  b = b
+and false b = false
+
+test : ∀ a b → and a b ≡ true → a ≡ true
+test true true refl = refl
+
+-- Expected error:
+--
+-- Incomplete pattern matching for test. Missing cases:
+--   test false b x
+--   test true false x

--- a/test/Fail/Issue6434.err
+++ b/test/Fail/Issue6434.err
@@ -1,0 +1,5 @@
+Issue6434.agda:14,1-20
+Incomplete pattern matching for test. Missing cases:
+  test false b x
+  test true false x
+when checking the definition of test

--- a/test/interaction/Issue6434.agda
+++ b/test/interaction/Issue6434.agda
@@ -1,0 +1,14 @@
+-- Andreas, 2023-01-13, issue #6434
+-- With the following option, case splitting should not eliminate absurd clauses automatically.
+
+{-# OPTIONS --performance:absurd-clauses #-}
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+
+idTrue : ∀ b → b ≡ true → Bool
+idTrue b eq = {!!}
+
+-- C-c C-c b RET gives us:
+-- idTrue false eq = {!!}
+-- idTrue true eq = {!!}

--- a/test/interaction/Issue6434.agda
+++ b/test/interaction/Issue6434.agda
@@ -1,7 +1,7 @@
 -- Andreas, 2023-01-13, issue #6434
 -- With the following option, case splitting should not eliminate absurd clauses automatically.
 
-{-# OPTIONS --performance:absurd-clauses #-}
+{-# OPTIONS --no-infer-absurd-clauses #-}
 
 open import Agda.Builtin.Bool
 open import Agda.Builtin.Equality

--- a/test/interaction/Issue6434.in
+++ b/test/interaction/Issue6434.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 0 cmd_make_case "b"

--- a/test/interaction/Issue6434.out
+++ b/test/interaction/Issue6434.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : Bool " nil)
+((last . 1) . (agda2-goals-action '(0)))
+((last . 2) . (agda2-make-case-action '("idTrue false eq = ?" "idTrue true eq = ?")))
+((last . 1) . (agda2-goals-action '(0)))


### PR DESCRIPTION
Fix #6434: new option `--no-infer-absurd-clauses`.

This option switches off automatic filtering of absurd clauses in coverage checking (#1086) and case splitting (#3526). Such might make sense to speed up coverage checking.