### PR TITLE
Follow hlint suggestion: use fewer imports.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -67,7 +67,6 @@
 - ignore: {name: "Use const"} # 67 hints
 - ignore: {name: "Use elem"} # 2 hints
 - ignore: {name: "Use empty"} # 1 hint
-- ignore: {name: "Use fewer imports"} # 6 hints
 - ignore: {name: "Use fmap"} # 5 hints
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use fromMaybe"} # 1 hint

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -25,7 +25,6 @@ import Data.Foldable (toList)
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup (Semigroup(..))
 #endif
-import qualified Data.Text as T
 
 import Control.Exception.Base (IOException, try)
 import Control.Monad (forM_, mapM_, unless, when)

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -96,7 +96,6 @@ import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.WithDefault
 import qualified Agda.Utils.Null as Null
-import Agda.Utils.WithDefault (collapseDefault)
 
 -- | data 'Relevance'
 --   see "Agda.Syntax.Common".

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -45,7 +45,6 @@ import Agda.TypeChecking.Telescope
 import Agda.Utils.Either
 import Agda.Utils.Function
 import Agda.Utils.Functor
-import Agda.Utils.Maybe
 
 import Agda.Utils.Impossible
 import Agda.Utils.Maybe

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -170,7 +170,6 @@ import Agda.TypeChecking.Rules.LHS.Unify.Types
 import Agda.TypeChecking.Rules.LHS.Unify.LeftInverse
 
 import Agda.Utils.Empty
-import Agda.Utils.Either
 import Agda.Utils.Benchmark
 import Agda.Utils.Either
 import Agda.Utils.Function

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
@@ -48,7 +48,6 @@ import Agda.TypeChecking.Rules.LHS.Problem
 import Agda.TypeChecking.Rules.LHS.Unify.Types
 
 import Agda.Utils.Empty
-import Agda.Utils.Either
 import Agda.Utils.Benchmark
 import Agda.Utils.Either
 import Agda.Utils.Function

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/Types.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/Types.hs
@@ -48,7 +48,6 @@ import Agda.TypeChecking.Records
 import Agda.TypeChecking.Rules.LHS.Problem
 
 import Agda.Utils.Empty
-import Agda.Utils.Either
 import Agda.Utils.Benchmark
 import Agda.Utils.Either
 import Agda.Utils.Function


### PR DESCRIPTION
As part of #6437, I checked if any of the "use fewer imports" hints were within `CPP #if` conditionals. They weren't. Here I remove the ignore for that and remove the duplicate imports (losing one explicit import in the process - hope that is OK).