### PR TITLE
Template for early GHC 9.8 adoption

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -181,8 +181,8 @@ flag optimise-heavily
 
 custom-setup
   setup-depends:
-    , base      >= 4.12.0.0 && < 4.18
-    , Cabal     >= 2.4.0.1  && < 3.9
+    , base      >= 4.12.0.0 && < 4.19
+    , Cabal     >= 2.4.0.1  && < 3.11
     , directory >= 1.3.3.0  && < 1.4
     , filepath  >= 1.4.2.1  && < 1.5
     , process   >= 1.6.3.0  && < 1.7
@@ -366,7 +366,7 @@ library
     , aeson                >= 1.1.2.0   && < 2.2
     , array                >= 0.5.2.0   && < 0.6
     , async                >= 2.2       && < 2.3
-    , base                 >= 4.12.0.0  && < 4.18
+    , base                 >= 4.12.0.0  && < 4.19
     , binary               >= 0.8.6.0   && < 0.9
     , blaze-html           >= 0.8       && < 0.10
     , boxes                >= 0.1.3     && < 0.2

--- a/cabal.project.local.ghc96
+++ b/cabal.project.local.ghc96
@@ -1,0 +1,96 @@
+tests:       True
+flags:       +enable-cluster-counting
+
+-- Crude adjustment for GHC 9.6
+
+-- allow-newer for GHC-shipped packages
+allow-newer: *:Cabal
+allow-newer: *:Cabal-syntax
+allow-newer: *:array
+allow-newer: *:base
+allow-newer: *:binary
+allow-newer: *:bytestring
+allow-newer: *:containers
+allow-newer: *:deepseq
+allow-newer: *:directory
+allow-newer: *:exceptions
+allow-newer: *:filepath
+allow-newer: *:ghc
+allow-newer: *:ghc-bignum
+allow-newer: *:ghc-boot
+allow-newer: *:ghc-boot-th
+allow-newer: *:ghc-compact
+allow-newer: *:ghc-heap
+allow-newer: *:ghc-prim
+allow-newer: *:ghci
+allow-newer: *:haskeline
+allow-newer: *:hpc
+allow-newer: *:integer-gmp
+allow-newer: *:libiserv
+allow-newer: *:mtl
+allow-newer: *:parsec
+allow-newer: *:pretty
+allow-newer: *:process
+allow-newer: *:rts
+allow-newer: *:stm
+allow-newer: *:system-cxx-std-lib
+allow-newer: *:template-haskell
+allow-newer: *:terminfo
+allow-newer: *:text
+allow-newer: *:time
+allow-newer: *:transformers
+allow-newer: *:unix
+allow-newer: *:xhtml
+
+-- Fix installed versions to avoid picking up wrong versions
+-- due to allow-newer.
+-- Not all of these fixtures are necessary, I suppose.
+constraints:  Cabal              installed
+constraints:  Cabal-syntax       installed
+constraints:  array              installed
+constraints:  base               installed
+constraints:  binary             installed
+constraints:  bytestring         installed
+constraints:  containers         installed
+constraints:  deepseq            installed
+constraints:  directory          installed
+constraints:  exceptions         installed
+constraints:  filepath           installed
+constraints:  ghc                installed
+constraints:  ghc-bignum         installed
+constraints:  ghc-boot           installed
+constraints:  ghc-boot-th        installed
+constraints:  ghc-compact        installed
+constraints:  ghc-heap           installed
+constraints:  ghc-prim           installed
+constraints:  ghci               installed
+constraints:  haskeline          installed
+constraints:  hpc                installed
+constraints:  integer-gmp        installed
+constraints:  libiserv           installed
+constraints:  mtl                installed
+constraints:  parsec             installed
+constraints:  pretty             installed
+constraints:  process            installed
+constraints:  rts                installed
+constraints:  stm                installed
+constraints:  system-cxx-std-lib installed
+constraints:  template-haskell   installed
+constraints:  terminfo           installed
+constraints:  text               installed
+constraints:  time               installed
+constraints:  transformers       installed
+constraints:  unix               installed
+constraints:  xhtml              installed
+
+constraints:  text-icu           == 0.8.0.2
+
+-- unix-compat-0.7 from fork that works with unix-2.8
+
+constraints: unix-compat == 0.7
+allow-newer: *:unix-compat
+
+source-repository-package
+  type: git
+  location: https://github.com/mitchellwrosen/fork--unix-compat.git
+  tag: f28060acd449643d267954647c1bb7c748c35fa9

--- a/src/full/Agda/Auto/CaseSplit.hs
+++ b/src/full/Agda/Auto/CaseSplit.hs
@@ -8,7 +8,7 @@ import Control.Monad.Reader as Rd hiding (lift)
 import qualified Control.Monad.State as St
 import Control.Monad.IO.Class ( MonadIO(..) )
 
-import Data.Function
+import Data.Function (on)
 import Data.IORef
 import Data.Tuple (swap)
 import Data.List (elemIndex)

--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -11,7 +11,7 @@ import qualified Data.Set as Set
 import qualified Data.HashMap.Strict as HMap
 import qualified Data.HashSet as HSet
 import Data.Char
-import Data.Function
+import Data.Function (on)
 #if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup
 #endif

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -20,7 +20,7 @@ import Prelude hiding (log)
 import Data.Bifunctor (second)
 import Data.Char
 import Data.Maybe
-import Data.Function
+import Data.Function (on)
 import Data.Foldable (toList)
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup (Semigroup(..))

--- a/src/full/Agda/Interaction/Highlighting/Precise.hs
+++ b/src/full/Agda/Interaction/Highlighting/Precise.hs
@@ -33,7 +33,7 @@ import Control.Arrow (second)
 import Control.DeepSeq
 import Control.Monad
 
-import Data.Function
+import Data.Function (on)
 import qualified Data.List as List
 import Data.Maybe
 import Data.Semigroup

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -25,7 +25,7 @@ import Control.Monad.STM
 import Control.Monad.Trans          ( lift )
 
 import qualified Data.Char as Char
-import Data.Function
+import Data.Function (on)
 import qualified Data.List as List
 import qualified Data.Map as Map
 import Data.Maybe

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -51,7 +51,7 @@ import Control.Monad.IO.Class ( MonadIO(..) )
 
 import Data.Char
 import Data.Either
-import Data.Function
+import Data.Function (on)
 import Data.Map ( Map )
 import qualified Data.Map as Map
 import Data.Maybe ( catMaybes, fromMaybe )

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -7,7 +7,7 @@ import Prelude hiding ((!!), null)
 import Control.Monad
 
 import Data.Either
-import Data.Function
+import Data.Function (on)
 import qualified Data.List as List
 import Data.Maybe
 import Data.Monoid

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -12,7 +12,7 @@ import Prelude hiding (length)
 import Control.DeepSeq
 
 import Data.Foldable (length)
-import Data.Function
+import Data.Function (on)
 import Data.Hashable (Hashable(..))
 import qualified Data.List as List
 import Data.Maybe

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -17,7 +17,7 @@ import Data.Bifunctor
 import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as ByteString
 import qualified Data.Foldable as Fold
-import Data.Function
+import Data.Function (on)
 import Data.Hashable (Hashable(..))
 import qualified Data.Strict.Maybe as Strict
 import Data.Word

--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -8,7 +8,7 @@ import Prelude hiding ((!!))
 import Control.DeepSeq
 
 import Data.ByteString.Char8 (ByteString)
-import Data.Function
+import Data.Function (on)
 import qualified Data.Foldable as Fold
 
 import GHC.Generics (Generic)

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -23,7 +23,8 @@ import Control.Monad.Except (throwError)
 
 import Data.Either (partitionEithers)
 import qualified Data.Foldable as Fold
-import Data.Function
+import Data.Function (on)
+import qualified Data.Function
 import qualified Data.List as List
 import Data.Maybe
 import Data.Map (Map)

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -14,7 +14,7 @@ import Prelude hiding (null)
 import Control.Monad.Identity
 import Control.DeepSeq
 
-import Data.Function
+import Data.Function (on)
 import qualified Data.List as List
 import Data.Maybe
 import Data.Semigroup ( Semigroup, (<>), Sum(..) )

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -71,7 +71,7 @@ import Control.Monad
 import Control.Monad.Writer (runWriter, tell)
 
 import qualified Data.Foldable as Fold
-import Data.Function
+import Data.Function (on)
 import Data.Int
 import Data.List (sort)
 import Data.Map (Map)

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -12,7 +12,7 @@ import Control.Monad
 
 import Data.Either (partitionEithers)
 import Data.Foldable ( length, toList )
-import Data.Function
+import Data.Function (on)
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map

--- a/src/full/Agda/Syntax/TopLevelModuleName.hs
+++ b/src/full/Agda/Syntax/TopLevelModuleName.hs
@@ -6,7 +6,7 @@ module Agda.Syntax.TopLevelModuleName where
 
 import Control.DeepSeq
 
-import Data.Function
+import Data.Function (on)
 import Data.Hashable
 import qualified Data.List as List
 import Data.Text (Text)

--- a/src/full/Agda/Termination/SparseMatrix.hs
+++ b/src/full/Agda/Termination/SparseMatrix.hs
@@ -48,7 +48,7 @@ module Agda.Termination.SparseMatrix
   ) where
 
 import Data.Array
-import Data.Function
+import Data.Function (on)
 import qualified Data.List as List
 import Data.Maybe
 

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -5,7 +5,7 @@ module Agda.TypeChecking.Abstract where
 import Control.Monad
 import Control.Monad.Except
 
-import Data.Function
+import Data.Function (on)
 import qualified Data.HashMap.Strict as HMap
 
 import Agda.Syntax.Common

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -8,7 +8,7 @@ import Control.Monad.Except
 -- Control.Monad.Fail import is redundant since GHC 8.8.1
 import Control.Monad.Fail (MonadFail)
 
-import Data.Function
+import Data.Function (on)
 import Data.Semigroup ((<>))
 import Data.IntMap (IntMap)
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -29,7 +29,7 @@ import Control.Monad.Except
 
 import qualified Data.CaseInsensitive as CaseInsens
 import Data.Foldable (foldl)
-import Data.Function
+import Data.Function (on)
 import Data.List (sortBy, dropWhileEnd, intercalate)
 import Data.Maybe
 import qualified Data.Set as Set

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -9,7 +9,7 @@ import Control.Monad        ( foldM, forM, forM_, liftM2, void )
 import Control.Monad.Except ( MonadError(..), ExceptT, runExceptT )
 import Control.Monad.Trans  ( lift )
 
-import Data.Function
+import Data.Function (on)
 import qualified Data.IntSet as IntSet
 import qualified Data.List as List
 import qualified Data.Map.Strict as MapS

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -32,7 +32,7 @@ import Control.Parallel             ( pseq )
 
 import Data.Array (Ix)
 import Data.DList (DList)
-import Data.Function
+import Data.Function (on)
 import Data.Int
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -12,7 +12,7 @@ import Control.Monad.Reader ( MonadReader(..), asks, Reader, runReader )
 
 import Data.Either
 import qualified Data.Foldable as Fold
-import Data.Function
+import Data.Function (on)
 import Data.Graph (SCC(..))
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap

--- a/src/full/Agda/TypeChecking/Pretty/Constraint.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Constraint.hs
@@ -7,7 +7,7 @@ import qualified Data.Set as Set
 import Data.Foldable (Foldable)
 import qualified Data.Foldable as Foldable
 import qualified Data.List as List
-import Data.Function
+import Data.Function (on)
 
 import Agda.Syntax.Common
 import Agda.Syntax.Position

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -9,7 +9,7 @@ import Control.Monad ( guard )
 import Control.Monad.Fail ( MonadFail )
 
 import Data.Char ( toLower )
-import Data.Function
+import Data.Function (on)
 import Data.Maybe
 
 import qualified Data.Set as Set

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -8,7 +8,7 @@ import Control.Monad        ( forM, forM_ )
 import Control.Monad.Except ( MonadError(..) )
 
 import Data.Bifunctor
-import Data.Function
+import Data.Function (on)
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
 import qualified Data.List as List

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -50,7 +50,7 @@ import qualified Data.Binary as B
 import qualified Data.Binary.Get as B
 import qualified Data.Binary.Put as B
 import qualified Data.List as List
-import Data.Function
+import Data.Function (on)
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup((<>))
 #endif

--- a/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
@@ -57,7 +57,7 @@ import Control.Monad.Trans.Maybe
 import Data.Either
 import Data.Foldable (forM_)
 import qualified Data.Foldable as Fold
-import Data.Function
+import Data.Function (on)
 import qualified Data.IntSet as IntSet
 import qualified Data.List as List
 import Data.Monoid

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -22,7 +22,7 @@ import Control.Monad (guard)
 import Control.Monad.Except (throwError)
 
 import Data.Coerce
-import Data.Function
+import Data.Function (on)
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map.Strict as MapS

--- a/src/full/Agda/Utils/AssocList.hs
+++ b/src/full/Agda/Utils/AssocList.hs
@@ -8,7 +8,7 @@ module Agda.Utils.AssocList
 
 import Prelude hiding (lookup)
 
-import Data.Function
+import Data.Function (on)
 import Data.List (lookup)
 import qualified Data.List as List
 import qualified Data.Map  as Map

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -15,7 +15,7 @@ import Control.Monad.State
 import Control.Monad.IO.Class ( MonadIO(..) )
 
 
-import Data.Function
+import Data.Function (on)
 import qualified Data.List as List
 import Data.Monoid
 import Data.Maybe

--- a/src/full/Agda/Utils/BiMap.hs
+++ b/src/full/Agda/Utils/BiMap.hs
@@ -12,7 +12,7 @@ import Prelude hiding (null, lookup)
 import Control.Monad.Identity
 import Control.Monad.State
 
-import Data.Function
+import Data.Function (on)
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map

--- a/src/full/Agda/Utils/FileName.hs
+++ b/src/full/Agda/Utils/FileName.hs
@@ -23,7 +23,7 @@ import Control.Exception   ( bracket )
 import System.Win32        ( findFirstFile, findClose, getFindDataFileName )
 #endif
 
-import Data.Function
+import Data.Function (on)
 import Data.Hashable       ( Hashable )
 import Data.Text           ( Text )
 import qualified Data.Text as Text

--- a/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -79,7 +79,7 @@ import Prelude hiding ( lookup, null, unzip )
 import qualified Data.Array.IArray as Array
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
-import Data.Function
+import Data.Function (on)
 import qualified Data.Graph as Graph
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -7,7 +7,7 @@ import Control.Monad (filterM)
 import Data.Array (Array, array, listArray)
 import qualified Data.Array as Array
 import Data.Bifunctor
-import Data.Function
+import Data.Function (on)
 import Data.Hashable
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as List1

--- a/src/full/Agda/Utils/Pointer.hs
+++ b/src/full/Agda/Utils/Pointer.hs
@@ -7,7 +7,7 @@ module Agda.Utils.Pointer
 import Control.DeepSeq
 import Control.Concurrent.MVar
 
-import Data.Function
+import Data.Function (on)
 import Data.Hashable
 import Data.IORef
 

--- a/src/full/Agda/Utils/Trie.hs
+++ b/src/full/Agda/Utils/Trie.hs
@@ -14,7 +14,7 @@ import Prelude hiding (null, lookup, filter)
 
 import Control.DeepSeq
 
-import Data.Function
+import Data.Function (on)
 import qualified Data.Maybe as Lazy
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map

--- a/src/github/workflows/cabal-test.yml
+++ b/src/github/workflows/cabal-test.yml
@@ -1,0 +1,125 @@
+name: cabal-test
+
+on:
+  push:
+    branches:
+    - master
+    - ci-*
+    - release*
+    paths: &trigger_path_list
+    - '.github/workflows/cabal-test.yml'
+    - 'Agda.cabal'
+    - 'Setup.hs'
+    - 'src/full/**'
+    - 'src/main/**'
+    - 'test/**.hs'
+  pull_request:
+    paths: *trigger_path_list
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  auto-cancel:
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]')
+      && !contains(github.event.head_commit.message, '[ci skip]')
+      && !contains(github.event.head_commit.message, '[github skip]')
+      && !contains(github.event.head_commit.message, '[skip github]')
+    runs-on: Ubuntu-latest # Required, but it can be anything here.
+
+    steps:
+    - uses: styfle/cancel-workflow-action@0.11.0
+      with:
+        access_token: ${{ github.token }}
+
+  cabal:
+    needs: auto-cancel
+
+    timeout-minutes: 150
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # os:
+        #   - ubuntu-22.04
+        #   - macos-12
+        #   # - windows-latest
+        #   ## Andreas, 2021-08-28, giving up on running the test-suite under Windows.
+        #   ## There is e.g. https://github.com/phile314/tasty-silver/issues/16
+        #   ## that may be responsible that diffs are not shown,
+        #   ## and that prevents me from running the test-suite interactively.
+        # ghc-ver: ['9.4']
+        # cabal-ver: ['3.8']
+        ## Andreas, 2023-01-17: test GHC 9.6.1 alpha1
+        include:
+          - os: ubuntu-22.04
+            ghc-ver: '9.6.0.20230210'
+            cabal-ver: '3.8'
+            ghcup-release-channel: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml
+
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - uses: haskell/actions/setup@v2
+      id: setup-haskell
+      with:
+        ghc-version: ${{ matrix.ghc-ver }}
+        cabal-version: ${{ matrix.cabal-ver }}
+        ghcup-release-channel: ${{ matrix.ghcup-release-channel }}
+
+    - name: Environment settings based on the Haskell setup
+      run: |
+        export GHC_VER=$(ghc --numeric-version)
+        export CABAL_VER=$(cabal --numeric-version)
+        echo "GHC_VER   = ${GHC_VER}"
+        echo "CABAL_VER = ${CABAL_VER}"
+        echo "GHC_VER=${GHC_VER}"       >> ${GITHUB_ENV}
+        echo "CABAL_VER=${CABAL_VER}"   >> ${GITHUB_ENV}
+      # From now on, use env.{GHC|CABAL}_VER rather than matrix.{ghc|cabal}-ver!
+
+    - name: Configure the build plan
+      run: |
+        cabal update
+        cabal configure -O1 --enable-tests
+
+    - name: Build plan for GHC 9.6.1 alpha
+      if:  ${{ matrix.ghc-ver > '9.6' }}
+      run: |
+        cp cabal.project.local.ghc96 cabal.project.local
+
+    - uses: actions/cache@v3
+      name: Cache dependencies
+      id: cache
+      with:
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+        # The file `plan.json` contains the build information.
+        key: ${{ runner.os }}-cabal-test-${{ env.GHC_VER }}-${{ env.CABAL_VER }}-${{ hashFiles('**/plan.json') }}
+
+    - name: Install dependencies
+      if: ${{ !steps.cache.outputs.cache-hit }}
+      run: |
+        cabal build --only-dependencies --enable-tests
+
+    # Andreas, 2021-09-02:
+    # Installing Agda, instead of just building it, is to work around
+    # https://github.com/haskell/cabal/issues/7577
+    # which hides the build executable from the tests when there is
+    # a Custom cabal setup (atm works only for Simple setup).
+    # Once haskell/cabal#7577 is fixed, we can dispose of this workaround.
+    - name: Install Agda
+      run: |
+        mkdir -p ${HOME}/bin
+        cabal install --installdir=${HOME}/bin
+# bin instead of .cabal/bin as this might be more portable (Windows)
+
+    - name: Build and test Agda
+      run: |
+        export PATH=${HOME}/bin:${PATH}
+        cabal test

--- a/test/Internal/Termination/SparseMatrix.hs
+++ b/test/Internal/Termination/SparseMatrix.hs
@@ -12,7 +12,7 @@ import Agda.Utils.Functor
 import Agda.Utils.Tuple
 
 import Data.Array
-import Data.Function
+import Data.Function (on)
 import qualified Data.List as List
 
 import Internal.Helpers
@@ -304,4 +304,3 @@ return [] -- KEEP!
 
 tests :: TestTree
 tests = testProperties "Internal.Termination.SparseMatrix" $allProperties
-

--- a/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -26,7 +26,7 @@ import Agda.Utils.Pretty
 import Control.Monad
 
 import qualified Data.Foldable as Fold
-import Data.Function
+import Data.Function (on)
 import qualified Data.Graph as Graph
 import qualified Data.List as List
 import Data.Maybe

--- a/test/Internal/Utils/List.hs
+++ b/test/Internal/Utils/List.hs
@@ -12,7 +12,7 @@ import Agda.Utils.List
 
 import Data.Bifunctor (first)
 import Data.Either (partitionEithers)
-import Data.Function
+import Data.Function (on)
 import Data.List
   ((\\), elemIndex, intercalate, isPrefixOf, isSuffixOf,
    minimumBy, nub, nubBy, sort, sortBy)


### PR DESCRIPTION
GHC 9.6.1 alpha has been released.  

- For base-4.18 (GHC 9.6): import Data.Function qualified
  `base-4.18` shipped with GHC 9.6 defines `Data.Function.applyWhen` which conflicts with `Agda.Utils.Function.applyWhen`.
  This commit ensures build with GHC 9.6.0.20230111 by importing `Data.Function` (from which we typically only use `on`) qualified.
- Add 9.6 job to `cabal-test` workflow.