### PR TITLE
Avoiding HLint parse errors.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -29,8 +29,6 @@
 - ignore: {name: "Hoist not"} # 18 hints
 - ignore: {name: "Move brackets to avoid $"} # 47 hints
 - ignore: {name: "Move guards forward"} # 2 hints
-- ignore: {name: "Parse error: on input `,'"} # 1 hint
-- ignore: {name: "Parse error: on input `module'"} # 1 hint
 - ignore: {name: "Redundant $"} # 632 hints
 - ignore: {name: "Redundant <$>"} # 46 hints
 - ignore: {name: "Redundant =="} # 1 hint
@@ -103,6 +101,8 @@
 # - arguments: [--color, --cpp-simple, -XQuasiQuotes]
 - arguments:
   - --ignore-glob=notes/papers/iird/paper.lhs
+  - --ignore-glob=notes/style/haskell-style.lhs
+  - --ignore-glob=notes/papers/implicit/examples.lhs
   - -XBangPatterns
   - -XConstraintKinds
   - -XDefaultSignatures

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -130,10 +130,6 @@
   - -XTupleSections
   - -XTypeFamilies
   - -XTypeSynonymInstances
-  # hlint (3.1.6 anyway), seems to assume - -XTypeApplications,
-  # which causes a parsing error in some cases.
-  # (At the time of this note a parse error in Agda.TypeChecking.Generalize)
-  - -XNoTypeApplications
 
 # Control which extensions/flags/modules/functions can be used
 #


### PR DESCRIPTION
See #6442. Excluded two notes with parse errors and removed a workaround no longer needed with HLint v3.5. The version with the reported problem parsing type applications, HLint v3.1.6, was published 2020-06-24.

```
$ hlint src/full/Agda/TypeChecking/Generalize.hs
No hints
```