### PR TITLE
Citation instructions 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -312,6 +312,7 @@ name: Build, Test, and Benchmark
     - '!hie*.yaml'
     - '!stack-*.yaml'
     - '!touchup.sh'
+    - '!CITATION.cff'
   push:
     branches:
     - master
@@ -345,4 +346,5 @@ name: Build, Test, and Benchmark
     - '!hie*.yaml'
     - '!stack-*.yaml'
     - '!touchup.sh'
+    - '!CITATION.cff'
   workflow_dispatch: null

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 authors:
-- name: "The Agda Team"
+- name: "Agda Developers"
 title: "Agda"
 version: 2.6.5
 license-url: "https://agda.readthedocs.io/en/v2.6.5/team.html"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,8 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- name: "The Agda Team"
+title: "Agda"
+version: 2.6.5
+license-url: "https://agda.readthedocs.io/en/v2.6.5/team.html"
+url: "https://agda.readthedocs.io/"

--- a/doc/user-manual/conf.py
+++ b/doc/user-manual/conf.py
@@ -21,7 +21,7 @@
 
 project = 'Agda'
 copyright = u'''2005–2024 remains with the authors.'''
-author = u'The Agda Team'
+author = u'Agda Developers'
 
 # The short X.Y version
 version = '2.6.5'

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -41,6 +41,7 @@ on:
     - '!hie*.yaml'
     - '!stack-*.yaml'
     - '!touchup.sh'
+    - '!CITATION.cff'
 
   pull_request:
     paths: *path_list

--- a/src/release-tools/change-version.bash
+++ b/src/release-tools/change-version.bash
@@ -9,6 +9,7 @@ old_version="$1"
 new_version="$2"
 
 files+='Agda.cabal '
+files+='CITATION.cff '
 files+='doc/user-manual/conf.py '
 files+='mk/versions.mk '
 files+='src/data/emacs-mode/agda2-mode.el '


### PR DESCRIPTION
GitHub has a built-in citation support. By placing the `CITATION.cff` file in the root of repostitory, GitHub will add a widget to the sidebar like this

<img width="376" alt="Screenshot 2023-01-18 at 21 51 45" src="https://user-images.githubusercontent.com/4060046/213188826-671c2cec-513f-42bd-9914-da100d95e1f3.png">

The file format is [here](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md)

It will be time-saving if it is clear how to cite Agda, so the remaing question is ... to agree on how Agda should be cited.

I draft one based on "Elaborating dependent (co)pattern matching: No pattern left behind" to kick off a discussion. 