### PR TITLE
[ workflows ] macOS: use $(brew --prefix) for PKG_CONFIG_PATH

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -54,7 +54,7 @@ jobs:
     - if: ${{ runner.os == 'macOS' }}
       name: Set up pkg-config for the ICU library (macOS)
       run: |
-        export PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
+        export PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig
         echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
         # print some information to debug pkg-config
         echo "$ export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
     - if: ${{ runner.os == 'macOS' }}
       name: Set up pkg-config for the ICU library (macOS)
       run: |
-        echo "PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
+        echo "PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
     - if: ${{ runner.os == 'Windows' }}
       name: Setup MSYS path (Windows)
       run: |

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -66,7 +66,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: |
-          ${{ runner.os }}-stack-20221229-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+          ${{ runner.os }}-stack-20230120-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
         path: ${{ steps.haskell-setup.outputs.stack-root }}
     - if: ${{ runner.os == 'macOS' }}
       name: Set up pkg-config for the ICU library (macOS)

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -71,7 +71,7 @@ jobs:
     - if: ${{ runner.os == 'macOS' }}
       name: Set up pkg-config for the ICU library (macOS)
       run: |
-        echo "PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
+        echo "PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
       shell: bash
     - if: ${{ runner.os == 'Windows' }}
       name: Install the icu library (Windows)

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Set up pkg-config for the ICU library (macOS)
       if: ${{ runner.os == 'macOS' }}
       run: |
-        export PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
+        export PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig
         echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
         # print some information to debug pkg-config
         echo "$ export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}"

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -113,7 +113,7 @@ jobs:
     - name: Set up pkg-config for the ICU library (macOS)
       if: ${{ runner.os == 'macOS' }}
       run: |
-        echo "PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
+        echo "PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
 
     # from: https://github.com/haskell/text-icu/blob/c73d7fe6f29e178d3ea40160e904ab39236e3c9d/.github/workflows/cabal-mac-win.yml#L29-L32
     - name: Setup MSYS path (Windows)

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -131,7 +131,7 @@ jobs:
         # A unique cache is used for each stack.yaml.
         # Note that matrix.stack-ver might be simply 'latest', so we use STACK_VER.
         key: |
-          ${{ runner.os }}-stack-20221229-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+          ${{ runner.os }}-stack-20230120-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
 
     - name: Set up pkg-config for the ICU library (macOS)
       if: ${{ runner.os == 'macOS' }}

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -137,7 +137,7 @@ jobs:
       if: ${{ runner.os == 'macOS' }}
       shell: bash
       run: |
-        echo "PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
+        echo "PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
 
     # Note that msys2 libraries have to be installed via
     #   stack exec ${ARGS} -- pacman ...


### PR DESCRIPTION
[ workflows ] macOS: use `$(brew --prefix)` to set up `PKG_CONFIG_PATH`.
See:
- https://github.com/haskell/text-icu/pull/84

Bump cache since cached build of `text-icu` seems to refer to ICU 0.71 while the virtual environment now has 0.72.