### PR TITLE
[ fix #6446 ] By reducing level arguments when reducing a sort

### DIFF
--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -426,10 +426,10 @@ instance Reduce Sort where
           NotBlocked _ s1' -> case univSort' s1' of
             Left b -> return $ Blocked b $ UnivSort s1'
             Right s -> reduceB' s
-        Prop l     -> done
-        Type l     -> done
+        Prop l     -> notBlocked . Prop <$> reduce l
+        Type l     -> notBlocked . Type <$> reduce l
         Inf f n    -> done
-        SSet l     -> done
+        SSet l     -> notBlocked . SSet <$> reduce l
         SizeUniv   -> done
         LockUniv   -> done
         IntervalUniv -> done

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -175,7 +175,7 @@ sortOf t = do
         let a = unEl $ unDom adom
         sa <- sortOf a
         sb <- mapAbstraction adom (sortOf . unEl) b
-        return $ piSort (unEl <$> adom) sa sb
+        inferPiSort (adom $> El sa a) sb
       Sort s     -> return $ univSort s
       Var i es   -> do
         a <- typeOfBV i

--- a/test/Succeed/Issue6446.agda
+++ b/test/Succeed/Issue6446.agda
@@ -1,0 +1,14 @@
+-- Test case reported by EDT4.
+open import Agda.Primitive
+
+Seti : (ℓ : Level) → Set(lsuc ℓ)
+Seti ℓ = Set ℓ
+
+lvl : ∀{ℓ} → Seti ℓ → Level
+lvl{ℓ} _ = ℓ
+
+type : {T : Set} → T → Seti(lvl T)
+type{T} _ = T
+
+R : {T : Set} → (P : T → Set) → (∀ x → P x) → Set
+R P p = ∀ x → type(p x)


### PR DESCRIPTION
This is a less invasive fix of #6446 that reverts a small part of https://github.com/agda/agda/commit/931edcc11e0d1bfb8bc48678993ed4cc9df4cf44.