### PR TITLE
[ workflows ] stack.yml: make ICU_VER part of the cache key

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -5,6 +5,8 @@
 ##  Edit source in /src/github/workflows/ instead!  ##
 ##                                                  ##
 ######################################################
+env:
+  GH_TOKEN: ${{ github.token }}
 jobs:
   auto-cancel:
     if: |
@@ -84,17 +86,15 @@ jobs:
         echo "GHC_VER           = ${GHC_VER}"
         echo "ICU_VER           = ${ICU_VER}"
     - id: cache
-      name: Cache dependencies
-      uses: actions/cache@v3
+      name: Restore cache
+      uses: actions/cache/restore@v3
       with:
-        key: |
-          ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}-${{ github.sha }}
+        key: ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{
+          env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
         path: |
           ${{ env.STACK_ROOT }}
           ${{ env.HOME }}/.stack-work
           ${{ env.HOME }}/.stack-work-fast
-        restore-keys: |
-          ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}-
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests`
@@ -102,6 +102,24 @@ jobs:
       run: stack build ${ARGS} ${EXTRA_ARGS} --work-dir=.stack-work-fast --test --no-run-tests
     - name: Build Agda with the non-default flags Agda.cabal.
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS}
+    - env:
+        KEY: ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{
+          env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+      if: ${{ steps.cache.outputs.cache-hit }}
+      name: Clear cache
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete ${{ env.KEY }} --confirm
+    - if: always()
+      name: Save cache
+      uses: actions/cache/save@v3
+      with:
+        key: ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{
+          env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+        path: |
+          ${{ env.STACK_ROOT }}
+          ${{ env.HOME }}/.stack-work
+          ${{ env.HOME }}/.stack-work-fast
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -40,7 +40,7 @@ jobs:
       name: Determine the ICU version (Linux, macOS)
       run: |
         uconv --version
-        export ICU_VER="$(uconv --version | sed -ne 's/uconv v.+ ICU \([0-9.]+\)/\1/p')"
+        export ICU_VER="$(uconv --version | sed -ne 's/uconv v.\+ ICU \([0-9.]\+\)/\1/p')"
         echo "ICU_VER=${ICU_VER}"
         echo "ICU_VER=${ICU_VER}" >> "${GITHUB_ENV}"
     - uses: actions/checkout@v3

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       EXTRA_ARGS: --fast
       ICU_URL: https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-icu-69.1-1-any.pkg.tar.zst
+      ICU_VER: '69.1'
       NON_DEFAULT_FLAGS: --flag Agda:enable-cluster-counting --flag Agda:cpphs --flag
         Agda:debug
     needs: auto-cancel
@@ -56,23 +57,12 @@ jobs:
         export GHC_VER=$(ghc --numeric-version)
         echo "GHC_VER=${GHC_VER}"                                       >> ${GITHUB_ENV}
         echo "ARGS=--stack-yaml=stack-${GHC_VER}.yaml --system-ghc --no-terminal"    >> ${GITHUB_ENV}
-    - name: Environment (review)
-      run: |
-        echo "STACK_ROOT (fix)  = ${STACK_ROOT}"
-        echo "STACK_VER         = ${STACK_VER}"
-        echo "GHC_VER           = ${GHC_VER}"
-    - id: cache
-      name: Cache dependencies
-      uses: actions/cache@v3
-      with:
-        key: |
-          ${{ runner.os }}-stack-20230120-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
-        path: ${{ steps.haskell-setup.outputs.stack-root }}
     - if: ${{ runner.os == 'macOS' }}
-      name: Set up pkg-config for the ICU library (macOS)
+      name: Set up for the ICU library (macOS)
       run: |
-        echo "PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
-      shell: bash
+        export ICU4C="$(brew --prefix)/opt/icu4c"
+        echo "PKG_CONFIG_PATH=${ICU4C}/lib/pkgconfig" >> "${GITHUB_ENV}"
+        echo "${ICU4C}/bin" >> "${GITHUB_PATH}"
     - if: ${{ runner.os == 'Windows' }}
       name: Install the icu library (Windows)
       run: |
@@ -80,8 +70,28 @@ jobs:
         stack exec ${ARGS} -- pacman --noconfirm -Sy msys2-keyring
         stack exec ${ARGS} -- bash -c "curl -LO ${ICU_URL} && pacman --noconfirm -U *.pkg.tar.zst"
         stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
-    - if: ${{ !steps.cache.outputs.cache-hit }}
-      name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
+    - if: ${{ runner.os != 'Windows' }}
+      name: Determine the ICU version (Linux, macOS)
+      run: |
+        echo "ICU_VER=$(uconv --version | sed -ne 's/uconv v.+ ICU \([0-9.]+\)/\1/p')" >> "${GITHUB_ENV}"
+    - name: Environment (review)
+      run: |
+        echo "STACK_ROOT (fix)  = ${STACK_ROOT}"
+        echo "STACK_VER         = ${STACK_VER}"
+        echo "GHC_VER           = ${GHC_VER}"
+        echo "ICU_VER           = ${ICU_VER}"
+    - id: cache
+      name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        key: |
+          ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}-${{ github.sha }}
+        path: |
+          ${{ env.STACK_ROOT }}
+          ${{ env.HOME }}/.stack-work
+        restore-keys: |
+          ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}-
+    - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests`
         (i.e. the test suite).
@@ -93,14 +103,6 @@ jobs:
       matrix:
         ghc-ver:
         - 9.4.4
-        - 9.2.5
-        - 9.0.2
-        - 8.10.7
-        - 8.8.4
-        - 8.6.5
-        - 8.4.4
-        - 8.2.2
-        - 8.0.2
         include:
         - ghc-ver: 9.4.4
           os: macos-12

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -109,7 +109,7 @@ jobs:
       name: Clear cache
       run: |
         gh extension install actions/gh-actions-cache
-        gh actions-cache delete ${{ env.KEY }} --confirm
+        gh actions-cache delete ${{ env.KEY }} --confirm || true
     - if: always()
       name: Save cache
       uses: actions/cache/save@v3
@@ -125,6 +125,14 @@ jobs:
       matrix:
         ghc-ver:
         - 9.4.4
+        - 9.2.5
+        - 9.0.2
+        - 8.10.7
+        - 8.8.4
+        - 8.6.5
+        - 8.4.4
+        - 8.2.2
+        - 8.0.2
         include:
         - ghc-ver: 9.4.4
           os: macos-12

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -93,8 +93,8 @@ jobs:
           env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
         path: |
           ${{ env.STACK_ROOT }}
-          ${{ env.HOME }}/.stack-work
-          ${{ env.HOME }}/.stack-work-fast
+          .stack-work
+          .stack-work-fast
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests`
@@ -118,8 +118,8 @@ jobs:
           env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
         path: |
           ${{ env.STACK_ROOT }}
-          ${{ env.HOME }}/.stack-work
-          ${{ env.HOME }}/.stack-work-fast
+          .stack-work
+          .stack-work-fast
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -92,13 +92,14 @@ jobs:
         path: |
           ${{ env.STACK_ROOT }}
           ${{ env.HOME }}/.stack-work
+          ${{ env.HOME }}/.stack-work-fast
         restore-keys: |
           ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}-
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests`
         (i.e. the test suite).
-      run: stack build ${ARGS} ${EXTRA_ARGS} --test --no-run-tests
+      run: stack build ${ARGS} ${EXTRA_ARGS} --work-dir=.stack-work-fast --test --no-run-tests
     - name: Build Agda with the non-default flags Agda.cabal.
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS}
     strategy:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -40,7 +40,7 @@ jobs:
       name: Determine the ICU version (Linux, macOS)
       run: |
         uconv --version
-        export ICU_VER="$(uconv --version | sed -ne 's/uconv v.\+ ICU \([0-9.]\+\)/\1/p')"
+        export ICU_VER="$(uconv --version | sed -ne 's/uconv v.* ICU \([0-9][0-9.]*\)/\1/p')"
         echo "ICU_VER=${ICU_VER}"
         echo "ICU_VER=${ICU_VER}" >> "${GITHUB_ENV}"
     - uses: actions/checkout@v3

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -30,6 +30,19 @@ jobs:
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
     steps:
+    - if: ${{ runner.os == 'macOS' }}
+      name: Set up for the ICU library (macOS)
+      run: |
+        export ICU4C="$(brew --prefix)/opt/icu4c"
+        echo "PKG_CONFIG_PATH=${ICU4C}/lib/pkgconfig" >> "${GITHUB_ENV}"
+        echo "${ICU4C}/bin" >> "${GITHUB_PATH}"
+    - if: ${{ runner.os != 'Windows' }}
+      name: Determine the ICU version (Linux, macOS)
+      run: |
+        uconv --version
+        export ICU_VER="$(uconv --version | sed -ne 's/uconv v.+ ICU \([0-9.]+\)/\1/p')"
+        echo "ICU_VER=${ICU_VER}"
+        echo "ICU_VER=${ICU_VER}" >> "${GITHUB_ENV}"
     - uses: actions/checkout@v3
       with:
         submodules: recursive
@@ -57,12 +70,6 @@ jobs:
         export GHC_VER=$(ghc --numeric-version)
         echo "GHC_VER=${GHC_VER}"                                       >> ${GITHUB_ENV}
         echo "ARGS=--stack-yaml=stack-${GHC_VER}.yaml --system-ghc --no-terminal"    >> ${GITHUB_ENV}
-    - if: ${{ runner.os == 'macOS' }}
-      name: Set up for the ICU library (macOS)
-      run: |
-        export ICU4C="$(brew --prefix)/opt/icu4c"
-        echo "PKG_CONFIG_PATH=${ICU4C}/lib/pkgconfig" >> "${GITHUB_ENV}"
-        echo "${ICU4C}/bin" >> "${GITHUB_PATH}"
     - if: ${{ runner.os == 'Windows' }}
       name: Install the icu library (Windows)
       run: |
@@ -70,10 +77,6 @@ jobs:
         stack exec ${ARGS} -- pacman --noconfirm -Sy msys2-keyring
         stack exec ${ARGS} -- bash -c "curl -LO ${ICU_URL} && pacman --noconfirm -U *.pkg.tar.zst"
         stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
-    - if: ${{ runner.os != 'Windows' }}
-      name: Determine the ICU version (Linux, macOS)
-      run: |
-        echo "ICU_VER=$(uconv --version | sed -ne 's/uconv v.+ ICU \([0-9.]+\)/\1/p')" >> "${GITHUB_ENV}"
     - name: Environment (review)
       run: |
         echo "STACK_ROOT (fix)  = ${STACK_ROOT}"

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -93,8 +93,6 @@ jobs:
           env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
         path: |
           ${{ env.STACK_ROOT }}
-          .stack-work
-          .stack-work-fast
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests`
@@ -118,8 +116,6 @@ jobs:
           env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
         path: |
           ${{ env.STACK_ROOT }}
-          .stack-work
-          .stack-work-fast
     strategy:
       fail-fast: false
       matrix:

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -19,6 +19,10 @@ on:
   pull_request:
     paths: *trigger_path_list
 
+# Github token needed to delete caches with gh
+env:
+  GH_TOKEN: ${{ github.token }}
+
 jobs:
   auto-cancel:
     if: |
@@ -162,20 +166,17 @@ jobs:
         echo "GHC_VER           = ${GHC_VER}"
         echo "ICU_VER           = ${ICU_VER}"
 
-    - uses: actions/cache@v3
-      name: Cache dependencies
-      id: cache
+    - name: Restore cache
+      uses: actions/cache/restore@v3
+      id:   cache
       with:
-        path: |
+        path: &cache_pathes |
           ${{ env.STACK_ROOT }}
           ${{ env.HOME }}/.stack-work
           ${{ env.HOME }}/.stack-work-fast
         # A unique cache is used for each stack.yaml.
         # Note that matrix.stack-ver might be simply 'latest', so we use STACK_VER.
-        key: |
-          ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}-
+        key: &cache_key ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
 
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
       # if: ${{ !steps.cache.outputs.cache-hit }}
@@ -186,3 +187,18 @@ jobs:
 
     - name: Build Agda with the non-default flags Agda.cabal.
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS}
+
+    - name: Clear cache
+      if:   ${{ steps.cache.outputs.cache-hit }}
+      env:
+        KEY: *cache_key
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete ${{ env.KEY }} --confirm
+
+    - name: Save cache
+      uses: actions/cache/save@v3
+      if:   always()  # save cache even when build fails
+      with:
+        path: *cache_pathes
+        key:  *cache_key

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -171,8 +171,8 @@ jobs:
       with:
         path: &cache_pathes |
           ${{ env.STACK_ROOT }}
-          ${{ env.HOME }}/.stack-work
-          ${{ env.HOME }}/.stack-work-fast
+          .stack-work
+          .stack-work-fast
         # A unique cache is used for each stack.yaml.
         # Note that matrix.stack-ver might be simply 'latest', so we use STACK_VER.
         key: &cache_key ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -44,7 +44,8 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         stack-ver: ['2.9.3']
-        ghc-ver: [9.4.4, 9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        ghc-ver: [9.4.4]
+          #, 9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
           # Andreas, 2022-03-26:
           # Note: ghc-ver needs to be spelled out with minor version, i.e., x.y.z
           # rather than x.y (which haskell-setup would resolve to a suitable .z)
@@ -75,6 +76,8 @@ jobs:
       # Use a known-good version of ICU from the msys2 repository since
       # GHC does not work with ICU ≠ 69
       ICU_URL: "https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-icu-69.1-1-any.pkg.tar.zst"
+      ICU_VER: "69.1"
+      # Andreas, 2022-01-21: the ICU_VER is needed for Windows, it is automatically determined on Linux/macOS.
 
     # Need bash on Windows for piping and evaluation.
     defaults:
@@ -116,28 +119,12 @@ jobs:
         echo "ARGS=--stack-yaml=stack-${GHC_VER}.yaml --system-ghc --no-terminal"    >> ${GITHUB_ENV}
     # From now on, use env.GHC_VER rather than matrix.ghc-ver
 
-    # In a second step we can inspect and use the GITHUB_ENV set in the previous step:
-    - name: Environment (review)
-      run: |
-        echo "STACK_ROOT (fix)  = ${STACK_ROOT}"
-        echo "STACK_VER         = ${STACK_VER}"
-        echo "GHC_VER           = ${GHC_VER}"
-
-    - uses: actions/cache@v3
-      name: Cache dependencies
-      id: cache
-      with:
-        path: ${{ steps.haskell-setup.outputs.stack-root }}
-        # A unique cache is used for each stack.yaml.
-        # Note that matrix.stack-ver might be simply 'latest', so we use STACK_VER.
-        key: |
-          ${{ runner.os }}-stack-20230120-${{ env.STACK_VER }}-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
-
-    - name: Set up pkg-config for the ICU library (macOS)
+    - name: Set up for the ICU library (macOS)
       if: ${{ runner.os == 'macOS' }}
-      shell: bash
       run: |
-        echo "PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
+        export ICU4C="$(brew --prefix)/opt/icu4c"
+        echo "PKG_CONFIG_PATH=${ICU4C}/lib/pkgconfig" >> "${GITHUB_ENV}"
+        echo "${ICU4C}/bin" >> "${GITHUB_PATH}"
 
     # Note that msys2 libraries have to be installed via
     #   stack exec ${ARGS} -- pacman ...
@@ -159,13 +146,35 @@ jobs:
         stack exec ${ARGS} -- bash -c "curl -LO ${ICU_URL} && pacman --noconfirm -U *.pkg.tar.zst"
         stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
 
-    # - name: Install the numa library (Ubuntu, GHC 8.4.4)
-    #   if: ${{ runner.os == 'Linux' && env.GHC_VER == '8.4.4' }}
-    #   run: |
-    #     sudo apt-get install libnuma-dev -qq
+    - name: Determine the ICU version (Linux, macOS)
+      if: ${{ runner.os != 'Windows' }}
+      run: |
+        echo "ICU_VER=$(uconv --version | sed -ne 's/uconv v.+ ICU \([0-9.]+\)/\1/p')" >> "${GITHUB_ENV}"
+      # The output of unconv --version looks like "uconv v2.1  ICU 72.1" from which we extract "72.1"
+
+    - name: Environment (review)
+      run: |
+        echo "STACK_ROOT (fix)  = ${STACK_ROOT}"
+        echo "STACK_VER         = ${STACK_VER}"
+        echo "GHC_VER           = ${GHC_VER}"
+        echo "ICU_VER           = ${ICU_VER}"
+
+    - uses: actions/cache@v3
+      name: Cache dependencies
+      id: cache
+      with:
+        path: |
+          ${{ env.STACK_ROOT }}
+          ${{ env.HOME }}/.stack-work
+        # A unique cache is used for each stack.yaml.
+        # Note that matrix.stack-ver might be simply 'latest', so we use STACK_VER.
+        key: |
+          ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}-
 
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
-      if: ${{ !steps.cache.outputs.cache-hit }}
+      # if: ${{ !steps.cache.outputs.cache-hit }}
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies
 
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests` (i.e. the test suite).

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -97,7 +97,7 @@ jobs:
       if: ${{ runner.os != 'Windows' }}
       run: |
         uconv --version
-        export ICU_VER="$(uconv --version | sed -ne 's/uconv v.\+ ICU \([0-9.]\+\)/\1/p')"
+        export ICU_VER="$(uconv --version | sed -ne 's/uconv v.* ICU \([0-9][0-9.]*\)/\1/p')"
         echo "ICU_VER=${ICU_VER}"
         echo "ICU_VER=${ICU_VER}" >> "${GITHUB_ENV}"
       # The output of unconv --version looks like "uconv v2.1  ICU 72.1" from which we extract "72.1"

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -97,7 +97,7 @@ jobs:
       if: ${{ runner.os != 'Windows' }}
       run: |
         uconv --version
-        export ICU_VER="$(uconv --version | sed -ne 's/uconv v.+ ICU \([0-9.]+\)/\1/p')"
+        export ICU_VER="$(uconv --version | sed -ne 's/uconv v.\+ ICU \([0-9.]\+\)/\1/p')"
         echo "ICU_VER=${ICU_VER}"
         echo "ICU_VER=${ICU_VER}" >> "${GITHUB_ENV}"
       # The output of unconv --version looks like "uconv v2.1  ICU 72.1" from which we extract "72.1"

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -80,7 +80,7 @@ jobs:
       # GHC does not work with ICU ≠ 69
       ICU_URL: "https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-icu-69.1-1-any.pkg.tar.zst"
       ICU_VER: "69.1"
-      # Andreas, 2022-01-21: the ICU_VER is needed for Windows, it is automatically determined on Linux/macOS.
+      # Andreas, 2023-01-21: the ICU_VER is needed for Windows, it is automatically determined on Linux/macOS.
 
     # Need bash on Windows for piping and evaluation.
     defaults:
@@ -169,13 +169,15 @@ jobs:
       uses: actions/cache/restore@v3
       id:   cache
       with:
-        path: &cache_pathes |
-          ${{ env.STACK_ROOT }}
-          .stack-work
-          .stack-work-fast
         # A unique cache is used for each stack.yaml.
         # Note that matrix.stack-ver might be simply 'latest', so we use STACK_VER.
-        key: &cache_key ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+        key:  &cache_key ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+        path: &cache_pathes |
+          ${{ env.STACK_ROOT }}
+        # Andreas, 2023-01-23: also caching the two work dirs balloons a cache entry from 300MB to 800MB,
+        # which is more than we can tolerate with out total cache size of mac 10GB.
+          # .stack-work
+          # .stack-work-fast
 
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
       # if: ${{ !steps.cache.outputs.cache-hit }}
@@ -200,5 +202,5 @@ jobs:
       uses: actions/cache/save@v3
       if:   always()  # save cache even when build fails
       with:
-        path: *cache_pathes
         key:  *cache_key
+        path: *cache_pathes

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -169,6 +169,7 @@ jobs:
         path: |
           ${{ env.STACK_ROOT }}
           ${{ env.HOME }}/.stack-work
+          ${{ env.HOME }}/.stack-work-fast
         # A unique cache is used for each stack.yaml.
         # Note that matrix.stack-ver might be simply 'latest', so we use STACK_VER.
         key: |
@@ -181,7 +182,7 @@ jobs:
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies
 
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests` (i.e. the test suite).
-      run: stack build ${ARGS} ${EXTRA_ARGS} --test --no-run-tests
+      run: stack build ${ARGS} ${EXTRA_ARGS} --work-dir=.stack-work-fast --test --no-run-tests
 
     - name: Build Agda with the non-default flags Agda.cabal.
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS}

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -86,6 +86,22 @@ jobs:
 
     steps:
 
+    - name: Set up for the ICU library (macOS)
+      if: ${{ runner.os == 'macOS' }}
+      run: |
+        export ICU4C="$(brew --prefix)/opt/icu4c"
+        echo "PKG_CONFIG_PATH=${ICU4C}/lib/pkgconfig" >> "${GITHUB_ENV}"
+        echo "${ICU4C}/bin" >> "${GITHUB_PATH}"
+
+    - name: Determine the ICU version (Linux, macOS)
+      if: ${{ runner.os != 'Windows' }}
+      run: |
+        uconv --version
+        export ICU_VER="$(uconv --version | sed -ne 's/uconv v.+ ICU \([0-9.]+\)/\1/p')"
+        echo "ICU_VER=${ICU_VER}"
+        echo "ICU_VER=${ICU_VER}" >> "${GITHUB_ENV}"
+      # The output of unconv --version looks like "uconv v2.1  ICU 72.1" from which we extract "72.1"
+
     # Checkout is needed before the first call to stack exec ${ARGS}
     # because it provides the stack-*.yaml file.
     - uses: actions/checkout@v3
@@ -119,13 +135,6 @@ jobs:
         echo "ARGS=--stack-yaml=stack-${GHC_VER}.yaml --system-ghc --no-terminal"    >> ${GITHUB_ENV}
     # From now on, use env.GHC_VER rather than matrix.ghc-ver
 
-    - name: Set up for the ICU library (macOS)
-      if: ${{ runner.os == 'macOS' }}
-      run: |
-        export ICU4C="$(brew --prefix)/opt/icu4c"
-        echo "PKG_CONFIG_PATH=${ICU4C}/lib/pkgconfig" >> "${GITHUB_ENV}"
-        echo "${ICU4C}/bin" >> "${GITHUB_PATH}"
-
     # Note that msys2 libraries have to be installed via
     #   stack exec ${ARGS} -- pacman ...
     # because stack comes with its own msys2 instance, see
@@ -145,12 +154,6 @@ jobs:
         stack exec ${ARGS} -- pacman --noconfirm -Sy msys2-keyring
         stack exec ${ARGS} -- bash -c "curl -LO ${ICU_URL} && pacman --noconfirm -U *.pkg.tar.zst"
         stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
-
-    - name: Determine the ICU version (Linux, macOS)
-      if: ${{ runner.os != 'Windows' }}
-      run: |
-        echo "ICU_VER=$(uconv --version | sed -ne 's/uconv v.+ ICU \([0-9.]+\)/\1/p')" >> "${GITHUB_ENV}"
-      # The output of unconv --version looks like "uconv v2.1  ICU 72.1" from which we extract "72.1"
 
     - name: Environment (review)
       run: |

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -48,8 +48,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         stack-ver: ['2.9.3']
-        ghc-ver: [9.4.4]
-          #, 9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        ghc-ver: [9.4.4, 9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
           # Andreas, 2022-03-26:
           # Note: ghc-ver needs to be spelled out with minor version, i.e., x.y.z
           # rather than x.y (which haskell-setup would resolve to a suitable .z)
@@ -194,7 +193,8 @@ jobs:
         KEY: *cache_key
       run: |
         gh extension install actions/gh-actions-cache
-        gh actions-cache delete ${{ env.KEY }} --confirm
+        gh actions-cache delete ${{ env.KEY }} --confirm || true
+      # Don't fail if cache cannot be deleted
 
     - name: Save cache
       uses: actions/cache/save@v3


### PR DESCRIPTION
Workflow `stack.yaml`:
- make `ICU_VER` part of the cache key
- use `--work-dir .stack-work-fast` for build without `text-icu`
- ~~add `.stack-work` and `.stack-work-fast` to cache to enable faster builds~~
- always write cache at the end of the action, replacing the old cache