### PR TITLE
Hlint, replace flip map with Agda.Utils.Functor.for.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -45,6 +45,7 @@
 - ignore: {name: "Redundant section"} # 3 hints
 - ignore: {name: "Replace case with fromMaybe"} # 3 hints
 - ignore: {name: "Replace case with maybe"} # 2 hints
+- ignore: {name: "Replace flip map with for"} # 19 hints
 - ignore: {name: "Unused LANGUAGE pragma"} # 1 hint
 - ignore: {name: "Use &&"} # 4 hints
 - ignore: {name: "Use ++"} # 11 hints
@@ -148,9 +149,7 @@
 
 
 # Add custom hints for this project
-#
-# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
-# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+- hint: {lhs: flip map, rhs: for, name: Replace flip map with for, note: Prefer Agda.Utils.Functor.for over Data.Traversable.for}
 
 
 # Turn on hints that are off by default

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -45,7 +45,6 @@
 - ignore: {name: "Redundant section"} # 3 hints
 - ignore: {name: "Replace case with fromMaybe"} # 3 hints
 - ignore: {name: "Replace case with maybe"} # 2 hints
-- ignore: {name: "Replace flip map with for"} # 19 hints
 - ignore: {name: "Unused LANGUAGE pragma"} # 1 hint
 - ignore: {name: "Use &&"} # 4 hints
 - ignore: {name: "Use ++"} # 11 hints

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -41,6 +41,7 @@ import Agda.Utils.List
 import Agda.Utils.Maybe
 
 import Agda.Utils.Impossible
+import Agda.Utils.Functor
 
 
 -- | A @WarningMode@ has two components: a set of warnings to be displayed
@@ -319,7 +320,7 @@ usageWarning = intercalate "\n"
     untable :: [(String, String)] -> String
     untable rows =
       let len = maximum (map (length . fst) rows) in
-      unlines $ flip map rows $ \ (hdr, cnt) ->
+      unlines $ for rows $ \ (hdr, cnt) ->
         concat [ hdr, replicate (1 + len - length hdr) ' ', cnt ]
 
 -- | @WarningName@ descriptions used for generating usage information

--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -262,7 +262,7 @@ createMissingTrXTrXClause q_trX f n x old_sc = do
     abstractN (xTelI `applyN` g1) $ \ p -> do
     abstractT "ψ" (pure interval) $ \ psi -> do
     abstractN (xTelI `applyN` g1) $ \ q -> do
-    abstractT "x0" (pure dT `applyN` g1 `applyN` (flip map q $ \ f -> f <@> pure iz)) $ \ x0 -> do
+    abstractT "x0" (pure dT `applyN` g1 `applyN` (for q $ \ f -> f <@> pure iz)) $ \ x0 -> do
     deltaPat g1 phi p psi q x0
 
   ps_ty_rhs <- runNamesT [] $ do
@@ -339,15 +339,15 @@ createMissingTrXTrXClause q_trX f n x old_sc = do
       c <- mkComp $ bindN ["i","j"] $ \ [i,j] -> do
         Abs n (data_ty,lines) <- bind "k" $ \ k -> do
           let phi_k = max phi (neg k)
-          let p_k = flip map p $ \ p -> lam "h" $ \ h -> p <@> (min k h)
-          data_ty <- pure dT `applyN` g1 `applyN` (flip map p $ \ p -> p <@> k)
+          let p_k = for p $ \ p -> lam "h" $ \ h -> p <@> (min k h)
+          data_ty <- pure dT `applyN` g1 `applyN` (for p $ \ p -> p <@> k)
           line1 <- trX `applyN` g1 `applyN` (phi_k:p_k) `applyN` [x0]
 
           line2 <- trX `applyN` g1
-                       `applyN` (max phi_k j      : (flip map p_k $ \ p -> lam "h" $ \ h -> p <@> (max h j)))
+                       `applyN` (max phi_k j      : (for p_k $ \ p -> lam "h" $ \ h -> p <@> (max h j)))
                        `applyN`
                   [trX `applyN` g1
-                       `applyN` (max phi_k (neg j): (flip map p_k $ \ p -> lam "h" $ \ h -> p <@> (min h j)))
+                       `applyN` (max phi_k (neg j): (for p_k $ \ p -> lam "h" $ \ h -> p <@> (min h j)))
                        `applyN` [x0]]
           pure (data_ty,[line1,line2])
         data_ty <- open $ Abs n data_ty
@@ -546,7 +546,7 @@ createMissingTrXHCompClause q_trX f n x old_sc = do
             bindN (map unArg $ ([defaultArg "phi"] ++ xTelIArgNames)) $ \ phi_p -> do
             bindN ["psi","u","u0"] $ \ x0 -> do
             let trX = trX' `applyN` g1
-            let p0 = flip map (tail phi_p) $ \ p -> p <@> pure iz
+            let p0 = for (tail phi_p) $ \ p -> p <@> pure iz
             trX `applyN` phi_p `applyN` [hcompD' g1 p0 `applyN` x0]
       pat = (fmap . fmap . fmap) patternToTerm <$> pat'
   let deltaPat g1 phi p x0 =
@@ -556,7 +556,7 @@ createMissingTrXHCompClause q_trX f n x old_sc = do
     abstractN (pure gamma1) $ \ g1 -> do
     abstractT "φ" (pure interval) $ \ phi -> do
     abstractN (xTelI `applyN` g1) $ \ p -> do
-    let p0 = flip map p $ \ p -> p <@> pure iz
+    let p0 = for p $ \ p -> p <@> pure iz
     let ty = pure dT `applyN` g1 `applyN` p0
     abstractT "ψ" (pure interval) $ \ psi -> do
     abstractT "u" (pure interval --> pPi' "o" psi (\ _ -> ty)) $ \ u -> do
@@ -587,7 +587,7 @@ createMissingTrXHCompClause q_trX f n x old_sc = do
     -- Ξ ⊢ pat-rec[i] := trX .. (hfill ... (~ i))
     pat_rec <- (open =<<) $ bind "i" $ \ i -> do
           let tr x = trX `applyN` g1 `applyN` (phi:p) `applyN` [x]
-          let p0 = flip map p $ \ p -> p <@> pure iz
+          let p0 = for p $ \ p -> p <@> pure iz
           tr (hcomp (pure dT `applyN` g1 `applyN` p0)
                     [(psi,lam "j" $ \ j -> u <@> (min j (neg i)))
                     ,(i  ,lam "j" $ \ _ -> ilam "o" $ \ _ -> u0)]

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1050,7 +1050,7 @@ defineConClause trD' isHIT mtrX npars nixs xTel' telI sigma dT' cnames = do
                      ixsI <- open $ AbsN (teleNames parI) ixsI
                      parI <- open parI
                      abstract_trD $ \ delta _ _ -> do
-                     let delta0_refl = flip map delta $ \ p -> lam "i" $ \ _ -> p <@> pure iz
+                     let delta0_refl = for delta $ \ p -> lam "i" $ \ _ -> p <@> pure iz
                      abstractN (ixsI `applyN` delta0_refl) $ \ x' -> do
                      abstractN (pure $ intervalTel "phi'") $ \ _ -> do
                      ty <- dT `applyN` (delta0_refl ++ x' ++ [pure iz])
@@ -1088,13 +1088,13 @@ defineConClause trD' isHIT mtrX npars nixs xTel' telI sigma dT' cnames = do
                 let [t] = map (fmap unArg) as0
                 let [phi'] = phi's
                 let telXdeltai = bind "i" $ \ i -> applyN xTel (map (<@> i) delta)
-                let reflx1 = flip map x $ \ q -> lam "i" $ \ _ -> q <@> pure io
-                let symx' = flip map x' $ \ q' -> lam "i" $ \ i -> q' <@> neg i
+                let reflx1 = for x $ \ q -> lam "i" $ \ _ -> q <@> pure io
+                let symx' = for x' $ \ q' -> lam "i" $ \ i -> q' <@> neg i
                 x_tr <- mapM (open . unArg) =<< transpPathTel' telXdeltai symx' reflx1 phi' x
                 let baseTrX = trD `applyN` delta `applyN` x_tr `applyN` [phi `min` phi',t]
                 let sideTrX = lam "j" $ \ j -> ilam "o" $ \ _ -> do
-                      let trD_f = trD `applyN` (flip map delta $ \ p -> lam "i" $ \ i -> p <@> (i `min` neg j))
-                                      `applyN` (flip map x_tr  $ \ p -> lam "i" $ \ i -> p <@> (i `min` neg j))
+                      let trD_f = trD `applyN` (for delta $ \ p -> lam "i" $ \ i -> p <@> (i `min` neg j))
+                                      `applyN` (for x_tr  $ \ p -> lam "i" $ \ i -> p <@> (i `min` neg j))
                                       `applyN` [(phi `min` phi') `max` j,t]
                       let x_tr_f = fmap (fmap (\ (Abs n (Arg i t)) -> Arg i $ Lam defaultArgInfo (Abs n t)) . sequence) $
                            bind "i" $ \ i -> do
@@ -1257,7 +1257,7 @@ defineConClause trD' isHIT mtrX npars nixs xTel' telI sigma dT' cnames = do
                 let squeezedv0 = ilam "o" $ \ o -> do
                       let
                         delta_f :: [NamesT TCM Term]
-                        delta_f = flip map delta $ \ p -> lam "j" $ \ j -> p <@> (j `max` i)
+                        delta_f = for delta $ \ p -> lam "j" $ \ j -> p <@> (j `max` i)
                       x_f <- (mapM open =<<) $ lamTel $ bind "j" $ \ j ->
                                  (absApp <$> q2_f <*> j) `appTel` i
                       trD `applyN` delta_f `applyN` x_f `applyN` [phi `max` i, v0 <..> o]

--- a/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -103,6 +103,7 @@ import Agda.Utils.SemiRing
 import Agda.Utils.Tuple
 
 import Agda.Utils.Impossible
+import Agda.Utils.Functor
 
 ------------------------------------------------------------------------
 -- Graphs and edges
@@ -502,7 +503,7 @@ filterNodesKeepingEdges p g =
             case Map.lookup n' remove of
               Nothing -> []
               Just es ->
-                flip map (Map.toList es) $ \(n', e') -> Edge
+                for (Map.toList es) $ \(n', e') -> Edge
                   { source = n
                   , target = n'
                   , label  = e `otimes` e'
@@ -516,7 +517,7 @@ filterNodesKeepingEdges p g =
       , Map.insert
           n
           (Map.unionsWith oplus $
-           flip map (neighbours n g) $ \(n', e) ->
+           for (neighbours n g) $ \(n', e) ->
              case Map.lookup n' remove of
                Nothing -> Map.singleton n' e
                Just es -> fmap (e `otimes`) es)
@@ -898,7 +899,7 @@ longestPaths g =
 
     candidates :: [Map n (Int, Seq [Edge n e])]
     candidates =
-      flip map (neighbours n g) $ \(n', e) ->
+      for (neighbours n g) $ \(n', e) ->
       let edge = Edge
             { source = n
             , target = n'


### PR DESCRIPTION
See #6442.

@andreasabel on #6461 you suggested replacing `flip map` with `Agda.Utils.Functor.for`. This is that change. I added a custom hint for this in the `.hlint.yaml` configuration. With the custom hint but before making the replacement, the output looked like:

```
$ hlint .
...
src/full/Agda/Interaction/Options/Warnings.hs:322:17-24: Suggestion: Replace flip map with for
Found:
  flip map
Perhaps:
  for
Note: Prefer Agda.Utils.Functor.for over Data.Traversable.for
...
```