### PR TITLE
Fix #6476: don't crash on ill-typed applications in DISPLAY terms.

### DIFF
--- a/doc/user-manual/language/pragmas.lagda.rst
+++ b/doc/user-manual/language/pragmas.lagda.rst
@@ -66,7 +66,7 @@ The ``DISPLAY`` pragma
 ______________________
 
 
-Users can declare a ``DISPLAY`` pragma:
+Users can declare a display form via the ``DISPLAY`` pragma:
 
 .. code-block:: agda
 
@@ -87,15 +87,19 @@ the overloaded name:
 
   {-# DISPLAY natPlus a b = a + b #-}
 
-Limitations
+Limitations:
 
-  - Left-hand sides are restricted to variables, constructors, defined
+  - Left-hand sides of the display form are restricted to variables, constructors, defined
     functions or types, and literals. In particular, lambdas are not
     allowed in left-hand sides.
 
-  - Since `DISPLAY` pragmas are not type checked implicit argument
+  - Since display forms are not type checked, implicit argument
     insertion may not work properly if the type of `f` computes to an
     implicit function space after pattern matching.
+
+  - An ill-typed display form can make Agda crash with an internal error
+    when Agda tries to use it
+    (issue `#6476 <https://github.com/agda/agda/issues/6476>`).
 
 .. _injective-pragma:
 

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -260,8 +260,8 @@ instance NamesIn DisplayTerm where
     DWithApp v us es -> namesAndMetasIn' sg (v, us, es)
     DCon c _ vs      -> namesAndMetasIn' sg (c, vs)
     DDef f es        -> namesAndMetasIn' sg (f, es)
-    DDot v           -> namesAndMetasIn' sg v
-    DTerm v          -> namesAndMetasIn' sg v
+    DDot' v es       -> namesAndMetasIn' sg (v, es)
+    DTerm' v es      -> namesAndMetasIn' sg (v, es)
 
 instance NamesIn a => NamesIn (Builtin a) where
   namesAndMetasIn' sg = \case

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -201,11 +201,6 @@ instance Reify MetaId where
         Nothing     -> underscore
         Just ii     -> return $ A.QuestionMark mi' ii
 
--- Does not print with-applications correctly:
--- instance Reify DisplayTerm Expr where
---   reifyWhen = reifyWhenE
---   reify d = reifyTerm False $ dtermToTerm d
-
 instance Reify DisplayTerm where
   type ReifiesTo DisplayTerm = Expr
 

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -206,10 +206,10 @@ instance Reify DisplayTerm where
 
   reifyWhen = reifyWhenE
   reify = \case
-    DTerm v -> reifyTerm False v
-    DDot  v -> reify v
-    DCon c ci vs -> recOrCon (conName c) ci =<< reify vs
-    DDef f es -> elims (A.Def f) =<< reify es
+    DTerm' v es       -> elims ==<< (reifyTerm False v, reify es)
+    DDot'  v es       -> elims ==<< (reify v, reify es)
+    DCon c ci vs      -> recOrCon (conName c) ci =<< reify vs
+    DDef f es         -> elims (A.Def f) =<< reify es
     DWithApp u us es0 -> do
       (e, es) <- reify (u, us)
       elims (if null es then e else A.WithApp noExprInfo e es) =<< reify es0
@@ -272,22 +272,24 @@ reifyDisplayFormP f ps wps = do
     -- defined name applied to valid lhs eliminators (projections or
     -- applications to constructor patterns).
     okDisplayForm :: DisplayTerm -> Bool
-    okDisplayForm (DWithApp d ds es) =
-      okDisplayForm d && all okDisplayTerm ds  && all okToDropE es
-      -- Andreas, 2016-05-03, issue #1950.
-      -- We might drop trailing hidden trivial (=variable) patterns.
-    okDisplayForm (DTerm (I.Def f vs)) = all okElim vs
-    okDisplayForm (DDef f es)          = all okDElim es
-    okDisplayForm DDot{}               = False
-    okDisplayForm DCon{}               = False
-    okDisplayForm DTerm{}              = False
+    okDisplayForm = \case
+      DWithApp d ds es ->
+        okDisplayForm d && all okDisplayTerm ds  && all okToDropE es
+        -- Andreas, 2016-05-03, issue #1950.
+        -- We might drop trailing hidden trivial (=variable) patterns.
+      DTerm' (I.Def f es') es -> all okElim es' && all okElim es
+      DDef f es               -> all okDElim es
+      DDot'{}                 -> False
+      DCon{}                  -> False
+      DTerm'{}                -> False
 
     okDisplayTerm :: DisplayTerm -> Bool
-    okDisplayTerm (DTerm v) = okTerm v
-    okDisplayTerm DDot{}    = True
-    okDisplayTerm DCon{}    = True
-    okDisplayTerm DDef{}    = False
-    okDisplayTerm _         = False
+    okDisplayTerm = \case
+      DTerm' v es -> null es && okTerm v
+      DDot'{}     -> True
+      DCon{}      -> True
+      DDef{}      -> False
+      DWithApp{}  -> False
 
     okDElim :: Elim' DisplayTerm -> Bool
     okDElim (I.IApply x y r) = okDisplayTerm r
@@ -326,7 +328,7 @@ reifyDisplayFormP f ps wps = do
       let (f, es, ds0) = flattenWith d
       in  (f, es, ds0 ++ map (I.Apply . defaultArg) ds1 ++ map (fmap DTerm) es2)
     flattenWith (DDef f es) = (f, es, [])     -- .^ hacky, but we should only hit this when printing debug info
-    flattenWith (DTerm (I.Def f es)) = (f, map (fmap DTerm) es, [])
+    flattenWith (DTerm' (I.Def f es') es) = (f, map (fmap DTerm) $ es' ++ es, [])
     flattenWith _ = __IMPOSSIBLE__
 
     displayLHS
@@ -352,21 +354,26 @@ reifyDisplayFormP f ps wps = do
         termToPat :: MonadReify m => DisplayTerm -> m (Named_ A.Pattern)
 
         -- Main action HERE:
-        termToPat (DTerm (I.Var n [])) = return $ unArg $ fromMaybe __IMPOSSIBLE__ $ ps !!! n
+        termToPat (DTerm (I.Var n [])) =
+          return $ unArg $ fromMaybe __IMPOSSIBLE__ $ ps !!! n
 
         termToPat (DCon c ci vs)          = fmap unnamed <$> tryRecPFromConP =<< do
            A.ConP (ConPatInfo ci patNoRange ConPatEager) (unambiguous (conName c)) <$> mapM argToPat vs
 
-        termToPat (DTerm (I.Con c ci vs)) = fmap unnamed <$> tryRecPFromConP =<< do
-           A.ConP (ConPatInfo ci patNoRange ConPatEager) (unambiguous (conName c)) <$> mapM (elimToPat . fmap DTerm) vs
+        termToPat (DTerm' (I.Con c ci vs) es) = fmap unnamed <$> tryRecPFromConP =<< do
+           A.ConP (ConPatInfo ci patNoRange ConPatEager) (unambiguous (conName c)) <$>
+             mapM (elimToPat . fmap DTerm) (vs ++ es)
 
         termToPat (DTerm (I.Def _ [])) = return $ unnamed $ A.WildP patNoRange
         termToPat (DDef _ [])          = return $ unnamed $ A.WildP patNoRange
 
         termToPat (DTerm (I.Lit l))    = return $ unnamed $ A.LitP patNoRange l
 
-        termToPat (DDot v)             = unnamed . A.DotP patNoRange <$> termToExpr v
-        termToPat v                    = unnamed . A.DotP patNoRange <$> reify v
+        termToPat (DDot' v es) =
+          unnamed . A.DotP patNoRange <$> do elims ==<< (termToExpr v, reify es)
+
+        termToPat v =
+          unnamed . A.DotP patNoRange <$> reify v
 
         len = length ps
 
@@ -441,7 +448,11 @@ tryReifyAsLetBinding v fallback = ifM (asksTC $ not . envFoldLetBindings) fallba
     (_, name) : _ -> return $ A.Var name
     []            -> fallback
 
-reifyTerm :: MonadReify m => Bool -> Term -> m Expr
+reifyTerm ::
+      MonadReify m
+   => Bool           -- ^ Try to expand away anonymous definitions?
+   -> Term
+   -> m Expr
 reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
   -- Jesper 2018-11-02: If 'PrintMetasBare', drop all meta eliminations.
   metasBare <- asksTC envPrintMetasBare

--- a/src/full/Agda/TypeChecking/DisplayForm.hs
+++ b/src/full/Agda/TypeChecking/DisplayForm.hs
@@ -247,10 +247,10 @@ instance SubstWithOrigin Term where
 
 -- Do not go into dot pattern, otherwise interaction test #231 fails
 instance SubstWithOrigin DisplayTerm where
-  substWithOrigin rho ots dt =
-    case dt of
-      DTerm v        -> DTerm     $ substWithOrigin rho ots v
-      DDot  v        -> DDot      $ applySubst rho v
+  substWithOrigin rho ots =
+    \case
+      DTerm' v es    -> DTerm' (substWithOrigin rho ots v) $ substWithOrigin rho ots es
+      DDot'  v es    -> DDot'  (substWithOrigin rho ots v) $ substWithOrigin rho ots es
       DDef q es      -> DDef q    $ substWithOrigin rho ots es
       DCon c ci args -> DCon c ci $ substWithOrigin rho ots args
       DWithApp t ts es -> DWithApp
@@ -262,8 +262,8 @@ instance SubstWithOrigin DisplayTerm where
 instance SubstWithOrigin (Arg DisplayTerm) where
   substWithOrigin rho ots (Arg ai dt) =
     case dt of
-      DTerm v        -> fmap DTerm $ substWithOrigin rho ots $ Arg ai v
-      DDot  v        -> Arg ai $ DDot      $ applySubst rho v
+      DTerm' v es    -> substWithOrigin rho ots (Arg ai v) <&> (`DTerm'` substWithOrigin rho ots es)
+      DDot'  v es    -> Arg ai $ DDot' (applySubst rho v)  $ substWithOrigin rho ots es
       DDef q es      -> Arg ai $ DDef q    $ substWithOrigin rho ots es
       DCon c ci args -> Arg ai $ DCon c ci $ substWithOrigin rho ots args
       DWithApp t ts es -> Arg ai $ DWithApp

--- a/src/full/Agda/TypeChecking/DisplayForm.hs
+++ b/src/full/Agda/TypeChecking/DisplayForm.hs
@@ -30,16 +30,6 @@ import Agda.Utils.Pretty
 
 import Agda.Utils.Impossible
 
--- | Convert a 'DisplayTerm' into a 'Term'.
-dtermToTerm :: DisplayTerm -> Term
-dtermToTerm dt = case dt of
-  DWithApp d ds es ->
-    dtermToTerm d `apply` map (defaultArg . dtermToTerm) ds `applyE` es
-  DCon c ci args   -> Con c ci $ map (Apply . fmap dtermToTerm) args
-  DDef f es        -> Def f $ map (fmap dtermToTerm) es
-  DDot v           -> v
-  DTerm v          -> v
-
 -- | Get the arities of all display forms for a name.
 displayFormArities :: (HasConstInfo m, ReadTCState m) => QName -> m [Int]
 displayFormArities q = map (length . dfPats . dget) <$> getDisplayForms q

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -370,7 +370,7 @@ addDisplayForms x = do
 
   -- Turn unfoldings into display forms
   npars <- subtract (projectionArgs def) <$> getContextSize
-  let dfs = catMaybes $ map (displayForm npars v) vs
+  let dfs = map (displayForm npars v) vs
   reportSDoc "tc.display.section" 20 $ nest 2 $ vcat
     [ "displayForms:" <?> vcat [ "-" <+> (pretty y <+> "-->" <?> pretty df) | (y, df) <- dfs ] ]
 
@@ -385,14 +385,14 @@ addDisplayForms x = do
     -- Given an unfolding `top = λ xs → y es` generate a display form
     -- `y es ==> top xs`. The first `npars` variables in `xs` are module parameters
     -- and should not be pattern variables, but matched literally.
-    displayForm :: Nat -> Term -> Term -> Maybe (QName, DisplayForm)
+    displayForm :: Nat -> Term -> Term -> (QName, DisplayForm)
     displayForm npars top v =
       case view v of
-        (xs, Def y es)   -> (y,)         <$> mkDisplay xs es
-        (xs, Con h i es) -> (conName h,) <$> mkDisplay xs es
+        (xs, Def y es)   -> (y,)         $ mkDisplay xs es
+        (xs, Con h i es) -> (conName h,) $ mkDisplay xs es
         _ -> __IMPOSSIBLE__
       where
-        mkDisplay xs es = Just (Display (n - npars) es $ DTerm $ top `apply` args)
+        mkDisplay xs es = Display (n - npars) es $ DTerm $ top `apply` args
           where
             n    = length xs
             args = zipWith (\ x i -> var i <$ x) xs (downFrom n)

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -393,6 +393,8 @@ addDisplayForms x = do
         _ -> __IMPOSSIBLE__
       where
         mkDisplay xs es = Display (n - npars) es $ DTerm $ top `apply` args
+          -- Andreas, 2023-01-26, #6476:
+          -- I think this @apply@ is safe (rather than @DTerm' top (map Apply args)@).
           where
             n    = length xs
             args = zipWith (\ x i -> var i <$ x) xs (downFrom n)

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1584,8 +1584,8 @@ instance InstantiateFull DisplayForm where
   instantiateFull' (Display n ps v) = uncurry (Display n) <$> instantiateFull' (ps, v)
 
 instance InstantiateFull DisplayTerm where
-  instantiateFull' (DTerm v)       = DTerm <$> instantiateFull' v
-  instantiateFull' (DDot  v)       = DDot  <$> instantiateFull' v
+  instantiateFull' (DTerm' v es)   = DTerm' <$> instantiateFull' v <*> instantiateFull' es
+  instantiateFull' (DDot' v es)    = DDot'  <$> instantiateFull' v <*> instantiateFull' es
   instantiateFull' (DCon c ci vs)  = DCon c ci <$> instantiateFull' vs
   instantiateFull' (DDef c es)     = DDef c <$> instantiateFull' es
   instantiateFull' (DWithApp v vs ws) = uncurry3 DWithApp <$> instantiateFull' (v, vs, ws)

--- a/src/full/Agda/TypeChecking/Rules/Display.hs
+++ b/src/full/Agda/TypeChecking/Rules/Display.hs
@@ -30,12 +30,6 @@ checkDisplayPragma f ps e = do
   reportSLn "tc.display.pragma" 20 $ "Adding display form for " ++ prettyShow f ++ "\n  " ++ show df
   addDisplayForm f df
 
---UNUSED Liang-Ting 2019-07-16
----- Compute a left-hand side for a display form. Inserts implicits, but no type
----- checking so does the wrong thing if implicitness is computed. Binds variables.
---displayLHS :: Telescope -> [NamedArg A.Pattern] -> (Int -> [Term] -> TCM a) -> TCM a
---displayLHS tel ps ret = patternsToTerms tel ps $ \n vs -> ret n (map unArg vs)
-
 type ToTm = StateT Nat TCM
 
 patternsToTerms :: Telescope -> [NamedArg A.Pattern] -> (Int -> Args -> TCM a) -> TCM a
@@ -44,8 +38,6 @@ patternsToTerms EmptyTel (p : ps) ret =
   patternToTerm (namedArg p) $ \n v ->
   patternsToTerms EmptyTel ps     $ \m vs -> ret (n + m) (inheritHiding p v : vs)
 patternsToTerms (ExtendTel a tel) (p : ps) ret
-  -- Andreas, 2019-07-22, while #3353: we should use domName, not absName !!
-  -- WAS: -- | sameHiding p a, visible p || maybe True (absName tel ==) (bareNameOf p) =  -- no ArgName or same as p
   | fromMaybe __IMPOSSIBLE__ $ fittingNamedArg p a =
       patternToTerm (namedArg p) $ \n v ->
       patternsToTerms (unAbs tel) ps  $ \m vs -> ret (n + m) (inheritHiding p v : vs)

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -187,15 +187,15 @@ instance EmbPrj CheckpointId where
   value n                = CheckpointId `fmap` value n
 
 instance EmbPrj DisplayTerm where
-  icod_ (DTerm    a  )   = icodeN' DTerm a
-  icod_ (DDot     a  )   = icodeN 1 DDot a
+  icod_ (DTerm'   a b)   = icodeN' DTerm' a b
+  icod_ (DDot'    a b)   = icodeN 1 DDot' a b
   icod_ (DCon     a b c) = icodeN 2 DCon a b c
   icod_ (DDef     a b)   = icodeN 3 DDef a b
   icod_ (DWithApp a b c) = icodeN 4 DWithApp a b c
 
   value = vcase valu where
-    valu [a]          = valuN DTerm a
-    valu [1, a]       = valuN DDot a
+    valu [a, b]       = valuN DTerm' a b
+    valu [1, a, b]    = valuN DDot' a b
     valu [2, a, b, c] = valuN DCon a b c
     valu [3, a, b]    = valuN DDef a b
     valu [4, a, b, c] = valuN DWithApp a b c

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -525,14 +525,14 @@ instance Apply FunctionInverse where
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
 
 instance Apply DisplayTerm where
-  apply (DTerm v)          args = DTerm $ apply v args
-  apply (DDot v)           args = DDot  $ apply v args
-  apply (DCon c ci vs)     args = DCon c ci $ vs ++ map (fmap DTerm) args
-  apply (DDef c es)        args = DDef c $ es ++ map (Apply . fmap DTerm) args
+  apply (DTerm' v es)      args = DTerm' v       $ es ++ map Apply args
+  apply (DDot' v es)       args = DDot' v        $ es ++ map Apply args
+  apply (DCon c ci vs)     args = DCon c ci     $ vs ++ map (fmap DTerm) args
+  apply (DDef c es)        args = DDef c        $ es ++ map (Apply . fmap DTerm) args
   apply (DWithApp v ws es) args = DWithApp v ws $ es ++ map Apply args
 
-  applyE (DTerm v)           es = DTerm $ applyE v es
-  applyE (DDot v)            es = DDot  $ applyE v es
+  applyE (DTerm' v es')      es = DTerm' v $ es' ++ es
+  applyE (DDot' v es')       es = DDot' v $ es' ++ es
   applyE (DCon c ci vs)      es = DCon c ci $ vs ++ map (fmap DTerm) ws
     where ws = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
   applyE (DDef c es')        es = DDef c $ es' ++ map (fmap DTerm) es
@@ -1002,10 +1002,10 @@ instance Subst DisplayForm where
 
 instance Subst DisplayTerm where
   type SubstArg DisplayTerm = Term
-  applySubst rho (DTerm v)        = DTerm $ applySubst rho v
-  applySubst rho (DDot v)         = DDot  $ applySubst rho v
-  applySubst rho (DCon c ci vs)   = DCon c ci $ applySubst rho vs
-  applySubst rho (DDef c es)      = DDef c $ applySubst rho es
+  applySubst rho (DTerm' v es)      = DTerm' (applySubst rho v) $ applySubst rho es
+  applySubst rho (DDot' v es)       = DDot'  (applySubst rho v) $ applySubst rho es
+  applySubst rho (DCon c ci vs)     = DCon c ci $ applySubst rho vs
+  applySubst rho (DDef c es)        = DDef c $ applySubst rho es
   applySubst rho (DWithApp v vs es) = uncurry3 DWithApp $ applySubst rho (v, vs, es)
 
 instance Subst a => Subst (Tele a) where

--- a/test/Fail/Issue6476.agda
+++ b/test/Fail/Issue6476.agda
@@ -1,0 +1,23 @@
+-- Andreas, 2023-01-26, issue #6476 reported by @nad
+-- Do not crash on ill-typed display forms.
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+record R : Set where
+  constructor c
+  field
+    m n : Nat
+
+{-# DISPLAY c m = m #-}
+
+r : R
+r = c zero zero
+
+test : c 0 0 ≡ c 1 1
+test = refl
+
+-- Expected error:
+
+-- 0 != 1 of type Nat
+-- when checking that the expression refl has type 0 0 ≡ 1 1

--- a/test/Fail/Issue6476.err
+++ b/test/Fail/Issue6476.err
@@ -1,0 +1,3 @@
+Issue6476.agda:18,8-12
+0 != 1 of type Nat
+when checking that the expression refl has type 0 0 ≡ 1 1


### PR DESCRIPTION
Fix #6476 by introducing suspended eliminations in display terms.  This fixes the problem that an ill-typed elimination of a display term would crash Agda.

Also: warn about ill-typed DISPLAY forms in docs.