### PR TITLE
Add HoTTEST Summer School 2022 to tutorial list

### DIFF
--- a/doc/user-manual/getting-started/tutorial-list.rst
+++ b/doc/user-manual/getting-started/tutorial-list.rst
@@ -114,6 +114,8 @@ Courses using Agda
   EUTYPES Summer School '19 in Ohrid.
 - `Lectures on Agda <https://www.mathstat.dal.ca/~selinger/agda-lectures/>`__,
   a course by Peter Selinger at Dalhousie University, Winter 2021.
+- `HoTTEST Summer School 2022 <https://www.uwo.ca/math/faculty/kapulkin/seminars/hottest_summer_school_2022.html>`__,
+  online lectures by assorted instructors.
 
 Miscellaneous
 =============


### PR DESCRIPTION
Added "HoTTEST Summer School 2022" to the list of tutorials.

HoTTEST Summer School 2022 was an online course by assorted instructors on doing Homotopy Type Theory in Agda. There are lectures on purely HoTT as well as HoTT in Agda. The course homepage is here: https://www.uwo.ca/math/faculty/kapulkin/seminars/hottest_summer_school_2022.html

I attended this course and found it to be a great into to Agda.
