### PR TITLE
[ workflows ] shift workload from stack.yml to cabal.yml

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -106,8 +106,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        cabal-flags:
+        - --enable-tests -f enable-cluster-counting
         cabal-ver:
-        - 3,8
+        - '3.8'
         ghc-ver:
         - 9.4.4
         - 9.2.5
@@ -125,8 +127,8 @@ jobs:
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f debug
           os: ubuntu-22.04
-        - cabal-flags: --enable-tests -f enable-cluster-counting -f debug -c 'mtl
-            >= 2.3.1'
+        - cabal-flags: |
+            --enable-tests -f enable-cluster-counting -f debug -c 'mtl >= 2.3.1'
           os: ubuntu-22.04
         - os: macos-12
         - os: windows-2022

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -80,10 +80,11 @@ jobs:
           ${{ steps.setup-haskell.outputs.cabal-store }}
         restore-keys: cabal.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{
           env.CABAL_VER }}-
-    - name: Install dependencies
+    - if: ${{ !steps.cache.outputs.cache-hit }}
+      name: Install dependencies
       run: |
         cabal build --only-dependencies
-    - name: Build Agda with ${{ matrix.cabal-flags }}
+    - name: Build Agda
       run: |
         cabal build
     - continue-on-error: true

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -26,7 +26,7 @@ jobs:
       FLAGS: ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting'
         }}
       GHC_VER: ${{ matrix.ghc-ver || '9.4.4' }}
-    name: Cabal ${{ matrix.os }} ${{ matrix.ghc-ver }} ${{ matrix.description }}
+    name: Cabal ${{ matrix.description }}, ${{ matrix.ghc-ver }}
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
     steps:
@@ -111,6 +111,8 @@ jobs:
         - --enable-tests -f enable-cluster-counting
         cabal-ver:
         - '3.8'
+        description:
+        - Linux
         ghc-ver:
         - 9.4.4
         - 9.2.5
@@ -123,25 +125,27 @@ jobs:
         - 8.0.2
         include:
         - cabal-flags: --disable-tests
-          description: w/o tests
+          description: Linux w/o tests
           ghc-ver: 9.4.4
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f cpphs
-          description: -f cpphs
+          description: Linux cpphs
           ghc-ver: 9.4.4
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f debug
-          description: -f debug
+          description: Linux debug
           ghc-ver: 9.4.4
           os: ubuntu-22.04
         - cabal-flags: |
             --enable-tests -f enable-cluster-counting -f debug -c mtl>=2.3.1
-          description: mtl 2.3
+          description: Linux mtl 2.3
           ghc-ver: 9.4.4
           os: ubuntu-22.04
-        - ghc-ver: 9.4.4
+        - description: macOS
+          ghc-ver: 9.4.4
           os: macos-12
-        - ghc-ver: 9.4.4
+        - description: Windows
+          ghc-ver: 9.4.4
           os: windows-2022
         os:
         - ubuntu-22.04

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -22,7 +22,7 @@ jobs:
         access_token: ${{ github.token }}
   cabal:
     env:
-      FLAGS: -f enable-cluster-counting
+      ARGS: -O0 --enable-tests ${{ matrix.cabal-flags }}
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
     steps:
@@ -65,33 +65,52 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure ${FLAGS} -O0 ${{ matrix.cabal-flags }}
+        cabal configure ${ARGS} -f enable-cluster-counting
     - id: cache
-      name: Cache dependencies
-      uses: actions/cache@v3
+      name: Restore cache from approximate key
+      uses: actions/cache/restore@v3
       with:
-        key: ${{ runner.os }}-cabal-01-${{ env.GHC_VER }}-${{ env.CABAL_VER }}-${{
-          hashFiles('**/plan.json') }}
+        key: cabal.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER
+          }}-${{ hashFiles('**/plan.json') }}
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
-    - if: ${{ !steps.cache.outputs.cache-hit }}
-      name: Install dependencies
+        restore-keys: cabal.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{
+          env.CABAL_VER }}-
+    - name: Install dependencies
       run: |
         cabal build --only-dependencies
-    - name: Build Agda
+    - name: Build Agda with tests
       run: |
         cabal build
-    - name: Build Agda without enable-cluster-counting
+    - if: ${{ matrix.no-icu }}
+      name: Build Agda without flag enable-cluster-counting
       run: |
-        cabal configure -O0
+        cabal configure ${ARGS}
         cabal build
+    - continue-on-error: true
+      env:
+        GH_TOKEN: ${{ github.token }}
+        KEY: cabal.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER
+          }}-${{ hashFiles('**/plan.json') }}
+      if: ${{ steps.cache.outputs.cache-hit }}
+      name: Clear old cache
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete ${{ env.KEY }} --confirm
+    - if: always()
+      name: Save cache
+      uses: actions/cache/save@v3
+      with:
+        key: cabal.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER
+          }}-${{ hashFiles('**/plan.json') }}
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
     strategy:
       fail-fast: false
       matrix:
         cabal-ver:
         - '3.8'
         ghc-ver:
-        - 9.4.4
         - 9.2.5
         - 9.0.2
         - 8.10.7
@@ -101,6 +120,10 @@ jobs:
         - 8.2.2
         - 8.0.2
         include:
+        - cabal-ver: '3.8'
+          ghc-ver: 9.4.4
+          no-icu: true
+          os: ubuntu-22.04
         - cabal-flags: -c 'mtl >= 2.3.1'
           cabal-ver: '3.8'
           ghc-ver: 9.4.4

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -35,8 +35,8 @@ jobs:
     - id: setup-haskell
       uses: haskell/actions/setup@v2
       with:
-        cabal-version: ${{ matrix.cabal-ver }}
-        ghc-version: ${{ matrix.ghc-ver }}
+        cabal-version: ${{ env.CABAL-VER }}
+        ghc-version: ${{ env.GHC_VER }}
     - name: Environment settings based on the Haskell setup
       run: |
         export GHC_VER=$(ghc --numeric-version)
@@ -68,7 +68,7 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure -O0 ${{ matrix.cabal-flags }}
+        cabal configure -O0 ${FLAGS}
     - id: cache
       name: Restore cache from approximate key
       uses: actions/cache/restore@v3
@@ -107,7 +107,7 @@ jobs:
       fail-fast: false
       matrix:
         cabal-ver:
-        - '3.8'
+        - 3,8
         ghc-ver:
         - 9.4.4
         - 9.2.5
@@ -119,31 +119,17 @@ jobs:
         - 8.2.2
         - 8.0.2
         include:
-        - cabal-flags: ''
-          cabal-ver: '3.8'
-          ghc-ver: 9.4.4
+        - cabal-flags: --disable-tests
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f cpphs
-          cabal-ver: '3.8'
-          ghc-ver: 9.4.4
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f debug
-          cabal-ver: '3.8'
-          ghc-ver: 9.4.4
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f enable-cluster-counting -f debug -c 'mtl
             >= 2.3.1'
-          cabal-ver: '3.8'
-          ghc-ver: 9.4.4
           os: ubuntu-22.04
-        - cabal-flags: --enable-tests -f enable-cluster-counting
-          cabal-ver: '3.8'
-          ghc-ver: 9.4.4
-          os: macos-12
-        - cabal-flags: --enable-tests -f enable-cluster-counting
-          cabal-ver: '3.8'
-          ghc-ver: 9.4.4
-          os: windows-2022
+        - os: macos-12
+        - os: windows-2022
         os:
         - ubuntu-22.04
     timeout-minutes: 60

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -26,6 +26,7 @@ jobs:
       FLAGS: ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting'
         }}
       GHC_VER: ${{ matrix.ghc-ver || '9.4.4' }}
+    name: Cabal ${{ matrix.os }} ${{ matrix.ghc-ver }} ${{ matrix.description }}
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
     steps:
@@ -122,16 +123,26 @@ jobs:
         - 8.0.2
         include:
         - cabal-flags: --disable-tests
+          description: w/o tests
+          ghc-ver: 9.4.4
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f cpphs
+          description: -f cpphs
+          ghc-ver: 9.4.4
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f debug
+          description: -f debug
+          ghc-ver: 9.4.4
           os: ubuntu-22.04
         - cabal-flags: |
-            --enable-tests -f enable-cluster-counting -f debug -c 'mtl >= 2.3.1'
+            --enable-tests -f enable-cluster-counting -f debug -c mtl>=2.3.1
+          description: mtl 2.3
+          ghc-ver: 9.4.4
           os: ubuntu-22.04
-        - os: macos-12
-        - os: windows-2022
+        - ghc-ver: 9.4.4
+          os: macos-12
+        - ghc-ver: 9.4.4
+          os: windows-2022
         os:
         - ubuntu-22.04
     timeout-minutes: 60

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -22,7 +22,10 @@ jobs:
         access_token: ${{ github.token }}
   cabal:
     env:
-      ARGS: -O0 --enable-tests ${{ matrix.cabal-flags }}
+      CABAL_VER: ${{ matrix.cabal-ver || '3.8' }}
+      FLAGS: ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting'
+        }}
+      GHC_VER: ${{ matrix.ghc-ver || '9.4.4' }}
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
     steps:
@@ -65,7 +68,7 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure ${ARGS} -f enable-cluster-counting
+        cabal configure -O0 ${{ matrix.cabal-flags }}
     - id: cache
       name: Restore cache from approximate key
       uses: actions/cache/restore@v3
@@ -79,13 +82,8 @@ jobs:
     - name: Install dependencies
       run: |
         cabal build --only-dependencies
-    - name: Build Agda with tests
+    - name: Build Agda with ${{ matrix.cabal-flags }}
       run: |
-        cabal build
-    - if: ${{ matrix.no-icu }}
-      name: Build Agda without flag enable-cluster-counting
-      run: |
-        cabal configure ${ARGS}
         cabal build
     - continue-on-error: true
       env:
@@ -111,6 +109,7 @@ jobs:
         cabal-ver:
         - '3.8'
         ghc-ver:
+        - 9.4.4
         - 9.2.5
         - 9.0.2
         - 8.10.7
@@ -120,18 +119,29 @@ jobs:
         - 8.2.2
         - 8.0.2
         include:
-        - cabal-ver: '3.8'
-          ghc-ver: 9.4.4
-          no-icu: true
-          os: ubuntu-22.04
-        - cabal-flags: -c 'mtl >= 2.3.1'
+        - cabal-flags: ''
           cabal-ver: '3.8'
           ghc-ver: 9.4.4
           os: ubuntu-22.04
-        - cabal-ver: '3.8'
+        - cabal-flags: --enable-tests -f cpphs
+          cabal-ver: '3.8'
+          ghc-ver: 9.4.4
+          os: ubuntu-22.04
+        - cabal-flags: --enable-tests -f debug
+          cabal-ver: '3.8'
+          ghc-ver: 9.4.4
+          os: ubuntu-22.04
+        - cabal-flags: --enable-tests -f enable-cluster-counting -f debug -c 'mtl
+            >= 2.3.1'
+          cabal-ver: '3.8'
+          ghc-ver: 9.4.4
+          os: ubuntu-22.04
+        - cabal-flags: --enable-tests -f enable-cluster-counting
+          cabal-ver: '3.8'
           ghc-ver: 9.4.4
           os: macos-12
-        - cabal-ver: '3.8'
+        - cabal-flags: --enable-tests -f enable-cluster-counting
+          cabal-ver: '3.8'
           ghc-ver: 9.4.4
           os: windows-2022
         os:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -87,8 +87,9 @@ jobs:
       name: Restore cache
       uses: actions/cache/restore@v3
       with:
-        key: ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{
-          env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+        key: stack.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-stack-${{ env.STACK_VER
+          }}-icu-${{ env.ICU_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER))
+          }}
         path: |
           ${{ env.STACK_ROOT }}
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
@@ -101,8 +102,9 @@ jobs:
     - continue-on-error: true
       env:
         GH_TOKEN: ${{ github.token }}
-        KEY: ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{
-          env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+        KEY: stack.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-stack-${{ env.STACK_VER
+          }}-icu-${{ env.ICU_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER))
+          }}
       if: ${{ steps.cache.outputs.cache-hit }}
       name: Clear cache
       run: |
@@ -112,8 +114,9 @@ jobs:
       name: Save cache
       uses: actions/cache/save@v3
       with:
-        key: ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{
-          env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+        key: stack.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-stack-${{ env.STACK_VER
+          }}-icu-${{ env.ICU_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER))
+          }}
         path: |
           ${{ env.STACK_ROOT }}
     strategy:
@@ -149,11 +152,7 @@ name: Build (stack)
     - Agda.cabal
     - Setup.hs
     - stack*.yaml
-    - src/agda-mode/**
-    - src/full/**
-    - src/main/**
-    - src/size-solver/**
-    - test/**.hs
+    - src/size-solver/size-solver.cabal
   push:
     branches:
     - master
@@ -164,8 +163,5 @@ name: Build (stack)
     - Agda.cabal
     - Setup.hs
     - stack*.yaml
-    - src/agda-mode/**
-    - src/full/**
-    - src/main/**
-    - src/size-solver/**
-    - test/**.hs
+    - src/size-solver/size-solver.cabal
+  workflow_dispatch: null

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
         KEY: test.yml-ghc-${{ env.GHC_VER }}-stack-${{ env.STACK_VER }}-icu-${{ env.ICU_VER
           }}-${{ hashFiles('stack.yaml', 'Agda.cabal') }}
       if: ${{ steps.cache.outputs.cache-hit }}
-      name: Clear cache
+      name: Clear old cache
       run: |
         gh extension install actions/gh-actions-cache
         gh actions-cache delete ${{ env.KEY }} --confirm

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -45,32 +45,56 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        # Older GHCs:
-        ghc-ver: [9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        ghc-ver: [9.4.4, 9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
         cabal-ver: ['3.8']
+        # Andreas, 2023-01-27: The following line does not survive the roundtrip via JSON:
+        # The single quotes are removed, which makes it an illegal matrix range entry.
+        # cabal-flags: '--enable-tests -f enable-cluster-counting'
         include:
-          ## Latest GHC
-          # Linux, also without -f enable-cluster-counting
+          ## Latest GHC, special builds
+
+          # Linux, w/o tests
           - os: ubuntu-22.04
             ghc-ver: 9.4.4
             cabal-ver: '3.8'
-            no-icu: true
-          # Linux, with mtl-2.3
+            cabal-flags: ''
+
+          # Linux, with -f cpphs
+          - os: ubuntu-22.04
+            ghc-ver: 9.4.4
+            cabal-ver: '3.8'
+            cabal-flags: '--enable-tests -f cpphs'
+
+          # Linux, without -f enable-cluster-counting but with -f debug
+          - os: ubuntu-22.04
+            ghc-ver: 9.4.4
+            cabal-ver: '3.8'
+            cabal-flags: '--enable-tests -f debug'
+
+          # Linux, with mtl-2.3 and everything
           - os: ubuntu-22.04
             ghc-ver: 9.4.4
             cabal-ver: '3.8'
             ## Andreas, 2022-11-23: Test mtl-2.3.1 here which has breaking changes.
-            cabal-flags: "-c 'mtl >= 2.3.1'"
+            cabal-flags: '--enable-tests -f enable-cluster-counting -f debug -c ''mtl >= 2.3.1'''
+
           # macOS
           - os: macos-12
             ghc-ver: 9.4.4
             cabal-ver: '3.8'
+            cabal-flags: '--enable-tests -f enable-cluster-counting'
+
           # Windows
           - os: windows-2022
             ghc-ver: 9.4.4
             cabal-ver: '3.8'
+            cabal-flags: '--enable-tests -f enable-cluster-counting'
+
+    # Default values
     env:
-      ARGS: -O0 --enable-tests ${{ matrix.cabal-flags }}
+      GHC_VER:   ${{ matrix.ghc-ver || '9.4.4' }}
+      CABAL_VER: ${{ matrix.cabal-ver || '3.8' }}
+      FLAGS:     ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting' }}
 
     steps:
     - uses: actions/checkout@v3
@@ -120,7 +144,7 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure ${ARGS} -f enable-cluster-counting
+        cabal configure -O0 ${{ matrix.cabal-flags }}
 
     - name: Restore cache from approximate key
       uses: actions/cache/restore@v3
@@ -135,16 +159,8 @@ jobs:
       run: |
         cabal build --only-dependencies
 
-    - name: Build Agda with tests
+    - name: Build Agda with ${{ matrix.cabal-flags }}
       run: |
-        cabal build
-
-    - name: Build Agda without flag enable-cluster-counting
-      # Do this for at least one GHC version, so we covered the path where the flag is off.
-      # Doing it for all GHCs is a bit wasteful.
-      if: ${{ matrix.no-icu }}
-      run: |
-        cabal configure ${ARGS}
         cabal build
 
     - name: Clear old cache

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -40,15 +40,16 @@ jobs:
 
     timeout-minutes: 60
 
-    # In these fields, we cannot refer to env.
+    # In these fields, we cannot refer to `env` (or even `runner.os`).
     # Thus, we need redundant entries in the matrix.
-    name: Cabal ${{ matrix.os }} ${{ matrix.ghc-ver }} ${{ matrix.description }}
+    name: Cabal ${{ matrix.description }}, ${{ matrix.ghc-ver }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
+        description: [Linux]      ## This just for pretty-printing the job name.
         ghc-ver: [9.4.4, 9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
         # Need to mention "cabal-ver" at least once in the matrix, otherwise matrix.cabal-ver is an actionlint error.
         cabal-ver: ['3.8']
@@ -58,39 +59,41 @@ jobs:
 
           # Linux, w/o tests
           - os: ubuntu-22.04
+            description: Linux w/o tests
             ghc-ver: '9.4.4'
             # Can't leave cabal-flags empty here lest it becomes the default value.
             cabal-flags: '--disable-tests'
-            description: 'w/o tests'
 
           # Linux, with -f cpphs
           - os: ubuntu-22.04
+            description: Linux cpphs
             ghc-ver: '9.4.4'
             cabal-flags: '--enable-tests -f cpphs'
-            description: '-f cpphs'
 
           # Linux, without -f enable-cluster-counting but with -f debug
           - os: ubuntu-22.04
+            description: Linux debug
             ghc-ver: '9.4.4'
             cabal-flags: '--enable-tests -f debug'
-            description: '-f debug'
 
           # Linux, with mtl-2.3 and everything
           - os: ubuntu-22.04
+            description: Linux mtl 2.3
             ghc-ver: '9.4.4'
             ## Andreas, 2022-11-23: Test mtl-2.3.1 here which has breaking changes.
             ## Note: -c 'mtl >= 2.3.1' with single quotes does not get communicated properly.
             ## (The single quotes stay, and "-c 'mtl" is an option parse error for cabal.)
             cabal-flags: |
               --enable-tests -f enable-cluster-counting -f debug -c mtl>=2.3.1
-            description: 'mtl 2.3'
 
-          # macOS with default values
+          # macOS with default flags
           - os: macos-12
+            description: macOS
             ghc-ver: '9.4.4'
 
-          # Windows with default values
+          # Windows with default flags
           - os: windows-2022
+            description: Windows
             ghc-ver: '9.4.4'
 
     # Default values

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -162,10 +162,16 @@ jobs:
         restore-keys:   cabal.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-
 
     - name: Install dependencies
+      # Formally skip this when we successfully restored the cache, to shave a few seconds.
+      # Note that the dependencies will anyway be built in the `cabal build` step.
+      # So, strictly speaking, this step is superfluous anyways.
+      # However, we keep it here so that we do not clutter the output of the
+      # `cabal build` step too much in the ordinary case.
+      if:   ${{ !steps.cache.outputs.cache-hit }}
       run: |
         cabal build --only-dependencies
 
-    - name: Build Agda with ${{ matrix.cabal-flags }}
+    - name: Build Agda
       run: |
         cabal build
 

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -47,10 +47,8 @@ jobs:
         os: [ubuntu-22.04]
         ghc-ver: [9.4.4, 9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
         # Need to mention "cabal-ver" at least once in the matrix, otherwise matrix.cabal-ver is an actionlint error.
-        cabal-ver: ['3,8']
-        # Andreas, 2023-01-27: The following line does not survive the roundtrip via JSON:
-        # The single quotes are removed, which makes it an illegal matrix range entry.
-        # cabal-flags: '--enable-tests -f enable-cluster-counting'
+        cabal-ver: ['3.8']
+        cabal-flags: ['--enable-tests -f enable-cluster-counting']
         include:
           ## Latest GHC, special builds
 
@@ -70,7 +68,8 @@ jobs:
           # Linux, with mtl-2.3 and everything
           - os: ubuntu-22.04
             ## Andreas, 2022-11-23: Test mtl-2.3.1 here which has breaking changes.
-            cabal-flags: '--enable-tests -f enable-cluster-counting -f debug -c ''mtl >= 2.3.1'''
+            cabal-flags: |
+              --enable-tests -f enable-cluster-counting -f debug -c 'mtl >= 2.3.1'
 
           # macOS with default values
           - os: macos-12

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -45,11 +45,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        ghc-ver: [9.4.4, 9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        # Older GHCs:
+        ghc-ver: [9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
         cabal-ver: ['3.8']
         include:
           ## Latest GHC
-          # Linux
+          # Linux, also without -f enable-cluster-counting
+          - os: ubuntu-22.04
+            ghc-ver: 9.4.4
+            cabal-ver: '3.8'
+            no-icu: true
+          # Linux, with mtl-2.3
           - os: ubuntu-22.04
             ghc-ver: 9.4.4
             cabal-ver: '3.8'
@@ -64,8 +70,7 @@ jobs:
             ghc-ver: 9.4.4
             cabal-ver: '3.8'
     env:
-      FLAGS: "-f enable-cluster-counting"
-      # ICU_URL: 'https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-Win64-MSVC2019.zip'
+      ARGS: -O0 --enable-tests ${{ matrix.cabal-flags }}
 
     steps:
     - uses: actions/checkout@v3
@@ -112,53 +117,50 @@ jobs:
         echo "$ pkg-config --modversion icu-i18n"
         pkg-config --modversion icu-i18n
 
-    # Andreas, 2022-02-07: This step seem no longer necessary for Ubuntu 20.04.
-    # But keep it here commented-out, we might need it in the future again.
-    # - name: Install the icu library (Ubuntu)
-    #   if: ${{ runner.os == 'Linux' }}
-    #   run: |
-    #     sudo apt-get update -qq
-    #     sudo apt-get install libicu-dev -qq
-
-    # Andreas, 2022-02-07: Installing with pacman is easier.
-    # Keep this here commented out, in case we need it again.
-    # - name: Download the icu4c library from unicode-org (Windows)
-    #   if: ${{ runner.os == 'Windows' }}
-    #   env:
-    #     ICU_DIR: '/c/icu4c'
-    #     ICU_FILE: '/tmp/icu4c.zip'
-    #   run: |
-    #     curl -sSLo ${ICU_FILE} ${ICU_URL}
-    #     7z e ${ICU_FILE} -o${ICU_DIR}
-    #     mkdir -p ${ICU_DIR}/include/unicode
-    #     mv ${ICU_DIR}/*.h ${ICU_DIR}/include/unicode
-
-    #     cabal user-config update --augment="extra-lib-dirs: $(cygpath -w ${ICU_DIR})" --augment="extra-include-dirs: $(cygpath -w ${ICU_DIR}/include)"
-
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure ${FLAGS} -O0 ${{ matrix.cabal-flags }}
+        cabal configure ${ARGS} -f enable-cluster-counting
 
-    - uses: actions/cache@v3
-      name: Cache dependencies
+    - name: Restore cache from approximate key
+      uses: actions/cache/restore@v3
       id: cache
       with:
-        path: |
+        path: &cache_path |
           ${{ steps.setup-haskell.outputs.cabal-store }}
-        # The file `plan.json` contains the build information.
-        key: ${{ runner.os }}-cabal-01-${{ env.GHC_VER }}-${{ env.CABAL_VER }}-${{ hashFiles('**/plan.json') }}
+        key: &cache_key cabal.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-${{ hashFiles('**/plan.json') }}
+        restore-keys:   cabal.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-
 
     - name: Install dependencies
-      if: ${{ !steps.cache.outputs.cache-hit }}
       run: |
         cabal build --only-dependencies
 
-    - name: Build Agda
+    - name: Build Agda with tests
       run: |
         cabal build
 
-    - name: Build Agda without enable-cluster-counting
+    - name: Build Agda without flag enable-cluster-counting
+      # Do this for at least one GHC version, so we covered the path where the flag is off.
+      # Doing it for all GHCs is a bit wasteful.
+      if: ${{ matrix.no-icu }}
       run: |
-        cabal configure -O0
+        cabal configure ${ARGS}
         cabal build
+
+    - name: Clear old cache
+      if:   ${{ steps.cache.outputs.cache-hit }}
+      env:
+        KEY: *cache_key
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete ${{ env.KEY }} --confirm
+      # Don't fail if cache cannot be deleted
+      continue-on-error: true
+
+    - name: Save cache
+      uses: actions/cache/save@v3
+      if:   always()  # save cache even when build fails
+      with:
+        key:  *cache_key
+        path: *cache_path

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -40,7 +40,11 @@ jobs:
 
     timeout-minutes: 60
 
-    runs-on: ${{ matrix.os }} # Can't have env value here, so no defaults for matrix.os
+    # In these fields, we cannot refer to env.
+    # Thus, we need redundant entries in the matrix.
+    name: Cabal ${{ matrix.os }} ${{ matrix.ghc-ver }} ${{ matrix.description }}
+    runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -54,28 +58,40 @@ jobs:
 
           # Linux, w/o tests
           - os: ubuntu-22.04
+            ghc-ver: '9.4.4'
             # Can't leave cabal-flags empty here lest it becomes the default value.
             cabal-flags: '--disable-tests'
+            description: 'w/o tests'
 
           # Linux, with -f cpphs
           - os: ubuntu-22.04
+            ghc-ver: '9.4.4'
             cabal-flags: '--enable-tests -f cpphs'
+            description: '-f cpphs'
 
           # Linux, without -f enable-cluster-counting but with -f debug
           - os: ubuntu-22.04
+            ghc-ver: '9.4.4'
             cabal-flags: '--enable-tests -f debug'
+            description: '-f debug'
 
           # Linux, with mtl-2.3 and everything
           - os: ubuntu-22.04
+            ghc-ver: '9.4.4'
             ## Andreas, 2022-11-23: Test mtl-2.3.1 here which has breaking changes.
+            ## Note: -c 'mtl >= 2.3.1' with single quotes does not get communicated properly.
+            ## (The single quotes stay, and "-c 'mtl" is an option parse error for cabal.)
             cabal-flags: |
-              --enable-tests -f enable-cluster-counting -f debug -c 'mtl >= 2.3.1'
+              --enable-tests -f enable-cluster-counting -f debug -c mtl>=2.3.1
+            description: 'mtl 2.3'
 
           # macOS with default values
           - os: macos-12
+            ghc-ver: '9.4.4'
 
           # Windows with default values
           - os: windows-2022
+            ghc-ver: '9.4.4'
 
     # Default values
     env:

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -40,13 +40,14 @@ jobs:
 
     timeout-minutes: 60
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }} # Can't have env value here, so no defaults for matrix.os
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
         ghc-ver: [9.4.4, 9.2.5, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
-        cabal-ver: ['3.8']
+        # Need to mention "cabal-ver" at least once in the matrix, otherwise matrix.cabal-ver is an actionlint error.
+        cabal-ver: ['3,8']
         # Andreas, 2023-01-27: The following line does not survive the roundtrip via JSON:
         # The single quotes are removed, which makes it an illegal matrix range entry.
         # cabal-flags: '--enable-tests -f enable-cluster-counting'
@@ -55,40 +56,27 @@ jobs:
 
           # Linux, w/o tests
           - os: ubuntu-22.04
-            ghc-ver: 9.4.4
-            cabal-ver: '3.8'
-            cabal-flags: ''
+            # Can't leave cabal-flags empty here lest it becomes the default value.
+            cabal-flags: '--disable-tests'
 
           # Linux, with -f cpphs
           - os: ubuntu-22.04
-            ghc-ver: 9.4.4
-            cabal-ver: '3.8'
             cabal-flags: '--enable-tests -f cpphs'
 
           # Linux, without -f enable-cluster-counting but with -f debug
           - os: ubuntu-22.04
-            ghc-ver: 9.4.4
-            cabal-ver: '3.8'
             cabal-flags: '--enable-tests -f debug'
 
           # Linux, with mtl-2.3 and everything
           - os: ubuntu-22.04
-            ghc-ver: 9.4.4
-            cabal-ver: '3.8'
             ## Andreas, 2022-11-23: Test mtl-2.3.1 here which has breaking changes.
             cabal-flags: '--enable-tests -f enable-cluster-counting -f debug -c ''mtl >= 2.3.1'''
 
-          # macOS
+          # macOS with default values
           - os: macos-12
-            ghc-ver: 9.4.4
-            cabal-ver: '3.8'
-            cabal-flags: '--enable-tests -f enable-cluster-counting'
 
-          # Windows
+          # Windows with default values
           - os: windows-2022
-            ghc-ver: 9.4.4
-            cabal-ver: '3.8'
-            cabal-flags: '--enable-tests -f enable-cluster-counting'
 
     # Default values
     env:
@@ -104,8 +92,8 @@ jobs:
     - uses: haskell/actions/setup@v2
       id: setup-haskell
       with:
-        ghc-version: ${{ matrix.ghc-ver }}
-        cabal-version: ${{ matrix.cabal-ver }}
+        ghc-version: ${{ env.GHC_VER }}
+        cabal-version: ${{ env.CABAL-VER }}
 
     - name: Environment settings based on the Haskell setup
       run: |
@@ -115,7 +103,7 @@ jobs:
         echo "CABAL_VER = ${CABAL_VER}"
         echo "GHC_VER=${GHC_VER}"       >> ${GITHUB_ENV}
         echo "CABAL_VER=${CABAL_VER}"   >> ${GITHUB_ENV}
-      # From now on, use env.{GHC|CABAL}_VER rather than matrix.{ghc|cabal}-ver!
+      # From now on, env.{GHC|CABAL}_VER are the precise versions.
 
     # from: https://github.com/haskell/text-icu/blob/c73d7fe6f29e178d3ea40160e904ab39236e3c9d/.github/workflows/cabal-mac-win.yml#L29-L32
     - name: Setup MSYS path (Windows)
@@ -144,7 +132,7 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure -O0 ${{ matrix.cabal-flags }}
+        cabal configure -O0 ${FLAGS}
 
     - name: Restore cache from approximate key
       uses: actions/cache/restore@v3

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -6,18 +6,26 @@ on:
     - master
     - ci-*
     - release*
+
     paths: &trigger_path_list
     - '.github/workflows/stack.yml'
     - 'Agda.cabal'
     - 'Setup.hs'
     - 'stack*.yaml'
-    - 'src/agda-mode/**'
-    - 'src/full/**'
-    - 'src/main/**'
-    - 'src/size-solver/**'
-    - 'test/**.hs'
+    - 'src/size-solver/size-solver.cabal'
+    # Andreas, 2023-01-27, issue #8460:
+    # Restrict this workflow to changes in the *.cabal and stack*.yaml files
+    # - 'src/agda-mode/**'
+    # - 'src/full/**'
+    # - 'src/main/**'
+    # - 'src/size-solver/**'
+    # - 'test/**.hs'
+
   pull_request:
     paths: *trigger_path_list
+
+  # Allow manual runs
+  workflow_dispatch:
 
 jobs:
   auto-cancel:
@@ -167,7 +175,7 @@ jobs:
       with:
         # A unique cache is used for each stack.yaml.
         # Note that matrix.stack-ver might be simply 'latest', so we use STACK_VER.
-        key:  &cache_key ${{ runner.os }}-icu-${{ env.ICU_VER }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+        key:  &cache_key stack.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-stack-${{ env.STACK_VER }}-icu-${{ env.ICU_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
         path: &cache_pathes |
           ${{ env.STACK_ROOT }}
         # Andreas, 2023-01-23: also caching the two work dirs balloons a cache entry from 300MB to 800MB,

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
           dist.tzst
           stack-work.tzst
 
-    - name: Clear cache
+    - name: Clear old cache
       if:   ${{ steps.cache.outputs.cache-hit }}
       env:
         KEY: *cache_key


### PR DESCRIPTION
Fixes #6480.

1. The `stack` workflow is restricted to changes in `*.cabal` and `stack*.yaml`.
2. The responsibility to test build of Agda in all variants (of flags and GHC versions) is shifted to the `cabal` workflow.

So, special builds like `-f cpphs` and `-f debug` are now also done in the `cabal.yml` workflow, because the `stack.yml` workflow will not run by default anymore (too cache hungry).

Caches are now always updated, regardless whether the workflow succeeded or not.
This way, if the dependencies were built successfully but not Agda itself, the next try will go faster.

Note: `~/.cabal/store` might grow over time in the caches as there is no garbage collection in cabal.  So maybe once in a while we have to delete the caches manually.