### PR TITLE
[ #6055, stackage ] Updated resolvers.

### DIFF
--- a/stack-9.2.5.yaml
+++ b/stack-9.2.5.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.8
+resolver: lts-20.9
 compiler: ghc-9.2.5
 compiler-check: match-exact
 

--- a/stack-9.4.4.yaml
+++ b/stack-9.4.4.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2023-01-23
+resolver: nightly-2023-01-29
 compiler: ghc-9.4.4
 compiler-check: match-exact
 


### PR DESCRIPTION
GHC 9.4.4 (nightly-2023-01-05 -> nightly-2023-01-29)
GHC 9.2.5 (20.8 -> 20.9)