### PR TITLE
emacs-mode: remove bundled sub-libraries from dependency list

### DIFF
--- a/src/data/emacs-mode/agda2-mode-pkg.el
+++ b/src/data/emacs-mode/agda2-mode-pkg.el
@@ -1,3 +1,3 @@
 (define-package "agda2-mode" "2.6.4"
   "interactive development for Agda, a dependently typed functional programming language"
-  '((emacs "24.3") (annotation "1.0") (eri "1.0")))
+  '((emacs "24.3"))) ;; dep defs for `annotation.el` and `eri.el` are not required if they are packaged together


### PR DESCRIPTION
If `agda2-mode` is distributed with `annotation.el` and `eri.el`, the defined dependencies will cause `package.el` to throw confusing errors. It fails to load `annotation.el` and `eri.el` even though they exist.

Fixes #6448 