### PR TITLE
[ refactor ] Introduce new TypeOf type family

### DIFF
--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1054,6 +1054,26 @@ hasElims v =
     Dummy{}    -> Nothing
 
 ---------------------------------------------------------------------------
+-- * Type family for type-directed operations.
+---------------------------------------------------------------------------
+
+-- @TypeOf a@ contains sufficient type information to do
+-- a type-directed traversal of @a@.
+type family TypeOf a
+
+type instance TypeOf Term        = Type                  -- Type of the term
+type instance TypeOf Elims       = (Type, Elims -> Term) -- Head symbol type + constructor
+type instance TypeOf (Abs Term)  = (Dom Type, Abs Type)  -- Domain type + codomain type
+type instance TypeOf (Abs Type)  = Dom Type              -- Domain type
+type instance TypeOf (Arg a)     = Dom (TypeOf a)
+type instance TypeOf (Dom a)     = TypeOf a
+type instance TypeOf Type        = ()
+type instance TypeOf Sort        = ()
+type instance TypeOf Level       = ()
+type instance TypeOf [PlusLevel] = ()
+type instance TypeOf PlusLevel   = ()
+
+---------------------------------------------------------------------------
 -- * Null instances.
 ---------------------------------------------------------------------------
 

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -211,7 +211,7 @@ instance AbsTerm Sort where
     SSet n     -> SSet $ absS n
     SizeUniv   -> SizeUniv
     LockUniv   -> LockUniv
-    IntervalUniv -> LockUniv
+    IntervalUniv -> IntervalUniv
     PiSort a s1 s2 -> PiSort (absS a) (absS s1) (absS s2)
     FunSort s1 s2 -> FunSort (absS s1) (absS s2)
     UnivSort s -> UnivSort $ absS s

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -158,6 +158,7 @@ instance CheckInternal Term where
           Lam ai . Abs (absName vb) <$> checkInternal' action (absBody vb) cmp (absBody b)
       Pi a b     -> do
         s <- shouldBeSort t
+        reportSDoc "tc.check.internal" 30 $ "pi type should have sort" <+> prettyTCM s
         when (s == SizeUniv) $ typeError $ FunctionTypeInSizeUniv v
         let sa  = getSort a
             sb  = getSort (unAbs b)
@@ -245,7 +246,9 @@ checkModality action mod mod' = do
 
 -- | Infer type of a neutral term.
 infer :: (MonadCheckInternal m) => Term -> m Type
-infer = \case
+infer u = do
+  reportSDoc "tc.check.internal" 20 $ "CheckInternal.infer" <+> prettyTCM u
+  case u of
     Var i es -> do
       a <- typeOfBV i
       fst <$> inferSpine defaultAction a (Var i) es
@@ -279,9 +282,9 @@ inferSpine action t hd es = loop t hd id es
       let self = hd []
       reportSDoc "tc.check.internal" 30 $ sep
         [ "inferring spine: "
-        , "type t = " <+> pretty t
-        , "self  = " <+> pretty self
-        , "eliminated by e = " <+> pretty e
+        , "type t = " <+> prettyTCM t
+        , "self  = " <+> prettyTCM self
+        , "eliminated by e = " <+> prettyTCM e
         ]
       case e of
         IApply x y r -> do

--- a/src/full/Agda/TypeChecking/CheckInternal.hs-boot
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs-boot
@@ -28,9 +28,23 @@ data Action (m :: Hs.Type -> Hs.Type)
 defaultAction :: PureTCM m => Action m
 eraseUnusedAction :: Action TCM
 
+class CheckInternal a where
+  checkInternal' :: (MonadCheckInternal m) => Action m -> a -> Comparison -> TypeOf a -> m a
+
+  checkInternal :: (MonadCheckInternal m) => a -> Comparison -> TypeOf a -> m ()
+  checkInternal v cmp t = void $ checkInternal' defaultAction v cmp t
+
+  inferInternal' :: (MonadCheckInternal m, TypeOf a ~ ()) => Action m -> a -> m a
+  inferInternal' act v = checkInternal' act v CmpEq ()
+
+  inferInternal :: (MonadCheckInternal m, TypeOf a ~ ()) => a -> m ()
+  inferInternal v = checkInternal v CmpEq ()
+
+instance CheckInternal Term
+instance CheckInternal Type
+instance CheckInternal Sort
+instance CheckInternal Level
+instance CheckInternal Elims
+
 checkType :: (MonadCheckInternal m) => Type -> m ()
-checkType' :: (MonadCheckInternal m) => Type -> m Sort
-checkSort :: (MonadCheckInternal m) => Action m -> Sort -> m Sort
-checkInternal :: (MonadCheckInternal m) => Term -> Comparison -> Type -> m ()
-checkInternal' :: (MonadCheckInternal m) => Action m -> Term -> Comparison -> Type -> m Term
 infer :: (MonadCheckInternal m) => Term -> m Type

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -45,6 +45,7 @@ import Agda.TypeChecking.Level
 import Agda.TypeChecking.Implicit (implicitArgs)
 import Agda.TypeChecking.Irrelevance
 import Agda.TypeChecking.Primitive
+import Agda.TypeChecking.ProjectionLike
 import Agda.TypeChecking.Warnings (MonadWarning)
 import Agda.Interaction.Options
 
@@ -470,7 +471,10 @@ computeElimHeadType f es es' = do
     -- Infer its type.
     reportSDoc "tc.conv.infer" 30 $
       "inferring type of internal arg: " <+> prettyTCM arg
-    targ <- infer $ unArg arg
+    -- Jesper, 2023-02-06: infer crashes on non-inferable terms,
+    -- e.g. applications of projection-like functions. Hence we bring them
+    -- into postfix form.
+    targ <- infer =<< elimView EvenLone (unArg arg)
     reportSDoc "tc.conv.infer" 30 $
       "inferred type: " <+> prettyTCM targ
     -- getDefType wants the argument type reduced.

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1313,7 +1313,7 @@ checkSolutionForMeta x m v a = do
         prettyTCM x <+> ":=" <+> prettyTCM v <+> " is a sort"
       s <- shouldBeSort (El __DUMMY_SORT__ v)
       traceCall (CheckMetaSolution (getRange m) x (sort (univSort s)) (Sort s)) $
-        checkSort defaultAction s
+        inferInternal s
 
 -- | Given two types @a@ and @b@ with @a <: b@, check that @a == b@.
 checkSubtypeIsEqual :: Type -> Type -> TCM ()

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1851,6 +1851,9 @@ data NLPat
   deriving (Show, Generic)
 type PElims = [Elim' NLPat]
 
+type instance TypeOf NLPat = Type
+type instance TypeOf [Elim' NLPat] = (Type, Elims -> Term)
+
 instance TermLike NLPat where
   traverseTermM f = \case
     p@PVar{}       -> return p

--- a/src/full/Agda/TypeChecking/ReconstructParameters.hs
+++ b/src/full/Agda/TypeChecking/ReconstructParameters.hs
@@ -143,9 +143,9 @@ extractParameters :: QName -> Type -> TCM Args
 extractParameters q ty = reduce (unEl ty) >>= \case
   Def d prePs -> do
     dt <- defType <$> getConstInfo d
-    reportSDoc "tc.reconstruct" 50 $ "Here we start infering spine"
-    ((_,Def _ postPs),_) <- inferSpine' reconstructAction dt (Def d []) (Def d []) prePs
-    reportSDoc "tc.reconstruct" 50 $ "The spine has been inferred:" <+> pretty postPs
+    reportSDoc "tc.reconstruct" 50 $ "Start traversing parameters: " <+> pretty prePs
+    postPs <- checkInternal' reconstructAction prePs CmpEq (dt , Def d)
+    reportSDoc "tc.reconstruct" 50 $ "Traversed parameters:" <+> pretty postPs
     info <- getConstInfo q
     let mkParam erasure =
             (if erasure then applyQuantity zeroQuantity else id)

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -288,7 +288,7 @@ checkRewriteRule q = do
         checkNoLhsReduction f hd es
 
         ps <- catchPatternErr failureBlocked $
-          patternFrom Relevant 0 (t , Def f []) es
+          patternFrom Relevant 0 (t , Def f) es
 
         reportSDoc "rewriting" 30 $
           "Pattern generated from lhs: " <+> prettyTCM (PDef f ps)

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -686,17 +686,16 @@ ohAddBV x a oh = oh { ohBoundVars = ExtendTel a $ Abs x $ ohBoundVars oh }
 -- ^ Given a @p : a@, @allHoles p@ lists all the possible
 --   decompositions @p = p'[(f ps)/x]@.
 class (TermSubst p, Free p) => AllHoles p where
-  type PType p
-  allHoles :: (Alternative m, PureTCM m) => PType p -> p -> m (OneHole p)
+  allHoles :: (Alternative m, PureTCM m) => TypeOf p -> p -> m (OneHole p)
 
 allHoles_
-  :: ( Alternative m , PureTCM m , AllHoles p , PType p ~ () )
+  :: ( Alternative m , PureTCM m , AllHoles p , TypeOf p ~ () )
   => p -> m (OneHole p)
 allHoles_ = allHoles ()
 
 allHolesList
   :: ( PureTCM m , AllHoles p)
-  => PType p -> p -> m [OneHole p]
+  => TypeOf p -> p -> m [OneHole p]
 allHolesList a = sequenceListT . allHoles a
 
 -- | Given a term @v : a@ and eliminations @es@, force eta-expansion
@@ -762,27 +761,22 @@ forceEtaExpansion a v (e:es) = case e of
 -- ^ Instances for @AllHoles@
 
 instance AllHoles p => AllHoles (Arg p) where
-  type PType (Arg p) = Dom (PType p)
   allHoles a x = fmap (x $>) <$> allHoles (unDom a) (unArg x)
 
 instance AllHoles p => AllHoles (Dom p) where
-  type PType (Dom p) = PType p
   allHoles a x = fmap (x $>) <$> allHoles a (unDom x)
 
 instance AllHoles (Abs Term) where
-  type PType (Abs Term) = (Dom Type , Abs Type)
   allHoles (dom , a) x = addContext (absName x , dom) $
     ohAddBV (absName a) dom . fmap (mkAbs $ absName x) <$>
       allHoles (absBody a) (absBody x)
 
 instance AllHoles (Abs Type) where
-  type PType (Abs Type) = Dom Type
   allHoles dom a = addContext (absName a , dom) $
     ohAddBV (absName a) dom . fmap (mkAbs $ absName a) <$>
       allHoles_ (absBody a)
 
 instance AllHoles Elims where
-  type PType Elims = (Type , Elims -> Term)
   allHoles (a,hd) [] = empty
   allHoles (a,hd) (e:es) = do
     reportSDoc "rewriting.confluence.hole" 65 $ fsep
@@ -804,12 +798,10 @@ instance AllHoles Elims where
       IApply x y u -> empty -- TODO: support --confluence-check + --cubical
 
 instance AllHoles Type where
-  type PType Type = ()
   allHoles _ (El s a) = workOnTypes $
     fmap (El s) <$> allHoles (sort s) a
 
 instance AllHoles Term where
-  type PType Term = Type
   allHoles a u = do
     reportSDoc "rewriting.confluence.hole" 60 $ fsep
       [ "Getting holes of term" , prettyTCM u , ":" , prettyTCM a ]
@@ -840,7 +832,6 @@ instance AllHoles Term where
       Dummy{}        -> empty
 
 instance AllHoles Sort where
-  type PType Sort = ()
   allHoles _ = \case
     Type l       -> fmap Type <$> allHoles_ l
     Prop l       -> fmap Prop <$> allHoles_ l
@@ -859,18 +850,15 @@ instance AllHoles Sort where
     DummyS{}     -> empty
 
 instance AllHoles Level where
-  type PType Level = ()
   allHoles _ (Max n ls) = fmap (Max n) <$> allHoles_ ls
 
 instance AllHoles [PlusLevel] where
-  type PType [PlusLevel] = ()
   allHoles _ []     = empty
   allHoles _ (l:ls) =
     (fmap (:ls) <$> allHoles_ l)
     <|> (fmap (l:) <$> allHoles_ ls)
 
 instance AllHoles PlusLevel where
-  type PType PlusLevel = ()
   allHoles _ (Plus n l) = do
     la <- levelType'
     fmap (Plus n) <$> allHoles la l


### PR DESCRIPTION
I found that we were repeating a similar pattern of doing a type-directed traversal:

- The `compareX` functions in `TypeChecking.Conversion`
- The `checkX` functions in `TypeChecking.CheckInternal`
- The `PatternFrom` class in `TypeChecking.Rewriting.NonLinPattern`
- The `Match` class in `TypeChecking.Rewriting.NonLinMatch`
- The `AllHoles` class in `TypeChecking.Rewriting.Confluence`

I found myself wanting to introduce a sixth one, so instead I decided to first factor out some of the common pattern into a type family. This PR unifies 4 out of the 5 type-directed traversals, the `compareX` functions from the conversion checker should also be possible but will take a bit more work.

Another further refactoring would be to introduce a module that collects all the functions that are needed for doing type-directed traversals, such as `typeOfBV`, `getFullyAppliedConType`, `ifPiType`, `pathView`, and `getDefType`, and packages them up in a nice way that makes it easy to write type-directed traversals (without relying on `checkInternal`, which is inefficient and doesn't always provide the right interface).

Yet another refactoring would be to split up the internal syntax type `Term` into `CheckTerm` (with `Con` and `Lam` constructors) and `InferTerm` (including `Var`, `Def`, `Sort`, `Lit`, `Pi`, `Level` and `Meta` constructors). This would allow us to be more precise in what kind of term we expect, and only demand a type when we really need it (at the cost of introducing more functions and/or classes).