### PR TITLE
[ workflows ] Fix #6502: remove *.md from html

### DIFF
--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -24,12 +24,12 @@ jobs:
         ghc-version: ${{ matrix.ghc-ver }}
     - name: Environment settings based on the Haskell setup
       run: |
-        export GHC_VER=$(ghc --numeric-version)
-        export CABAL_VER=$(cabal --numeric-version)
+        GHC_VER=$(ghc --numeric-version)
+        CABAL_VER=$(cabal --numeric-version)
         echo "GHC_VER    = ${GHC_VER}"
         echo "CABLAL_VER = ${CABAL_VER}"
-        echo "GHC_VER=${GHC_VER}"         >> ${GITHUB_ENV}
-        echo "CABAL_VER=${CABAL_VER}"     >> ${GITHUB_ENV}
+        echo "GHC_VER=${GHC_VER}"         >> "${GITHUB_ENV}"
+        echo "CABAL_VER=${CABAL_VER}"     >> "${GITHUB_ENV}"
     - name: Configure the build plan
       run: |
         cabal update
@@ -55,6 +55,7 @@ jobs:
     - name: Prepare to upload built htmls
       run: |
         find dist-newstyle -path '*/doc/html/Agda' -type d -exec cp -R {} html \;
+        find html -name '*.md' -delete
         ls -R html
     - if: github.ref == 'refs/heads/master'
       name: Deploy haddock

--- a/src/github/workflows/haddock.yml
+++ b/src/github/workflows/haddock.yml
@@ -54,12 +54,12 @@ jobs:
 
     - name: Environment settings based on the Haskell setup
       run: |
-        export GHC_VER=$(ghc --numeric-version)
-        export CABAL_VER=$(cabal --numeric-version)
+        GHC_VER=$(ghc --numeric-version)
+        CABAL_VER=$(cabal --numeric-version)
         echo "GHC_VER    = ${GHC_VER}"
         echo "CABLAL_VER = ${CABAL_VER}"
-        echo "GHC_VER=${GHC_VER}"         >> ${GITHUB_ENV}
-        echo "CABAL_VER=${CABAL_VER}"     >> ${GITHUB_ENV}
+        echo "GHC_VER=${GHC_VER}"         >> "${GITHUB_ENV}"
+        echo "CABAL_VER=${CABAL_VER}"     >> "${GITHUB_ENV}"
       # From now on, use env.{GHC|CABAL}_VER rather than matrix.{ghc|cabal}-ver!
 
     - name: Configure the build plan
@@ -97,7 +97,9 @@ jobs:
     - name: Prepare to upload built htmls
       run: |
         find dist-newstyle -path '*/doc/html/Agda' -type d -exec cp -R {} html \;
+        find html -name '*.md' -delete
         ls -R html
+      # The last step is to fix #6502; the .md files can make Jekyll choke.
 
     - name: Deploy haddock
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Fix #6502: remove *.md from `cabal haddock`-generated html directory.

The `extra-doc-files` from `Agda.cabal` are copied into the generated haddockumentation by `cabal haddock` and then confuse Jekyll when deploying this to https://agda.github.io/agda.

The files that confuse Jekyll are `.md` files containing `{{ ... }}`. Thus we just delete all `.md` files (approximating the `extra-doc-files`).