### PR TITLE
Agda input mode extension:  \box prefix for APL boxed characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,6 +273,9 @@ Emacs mode
 * Helper function (`C-c C-h`) does not abstract over module parameters anymore
   (see [#2271](https://github.com/agda/agda/issues/2271)).
 
+* New Agda input mode prefix `box` for APL boxed operators, e.g. `\box=` for ⌸;
+  see PR [#6510](https://github.com/agda/agda/pull/6510/files) for full list of bindings.
+
 Cubical Agda
 ------------
 

--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -340,6 +340,37 @@ order for the change to take effect."
   ("bx" . ("⊠"))
   ("b." . ("⊡"))
 
+  ;; APL boxed operators
+
+  ("box="       . ("⌸"))
+  ("box?"       . ("⍰"))
+  ("box'"       . ("⍞"))
+  ("box:"       . ("⍠"))
+  ("box/"       . ("⍁"))
+  ("box\\"      . ("⍂"))
+  ("box<"       . ("⍃"))
+  ("box>"       . ("⍄"))
+  ("boxo"       . ("⌻"))
+  ("boxO"       . ("⌼"))
+
+  ("boxcomp"    . ("⌻"))
+  ("boxcircle"  . ("⌼"))
+  ("boxeq"      . ("⌸"))
+  ("boxneq"     . ("⍯"))
+  ("boxeqn"     . ("⍯"))
+
+  ("boxl"       . ("⍇"))
+  ("boxr"       . ("⍈"))
+  ("boxu"       . ("⍐"))
+  ("boxd"       . ("⍗"))
+
+  ("boxdi"      . ("⌺"))
+  ("boxdiv"     . ("⌹"))
+  ("boxwedge"   . ("⍓"))
+  ("boxvee"     . ("⍌"))
+  ("boxdelta"   . ("⍍"))
+  ("boxnabla"   . ("⍔"))
+
   ;; Various symbols.
 
   ("integral" . ,(agda-input-to-string-list "∫∬∭∮∯∰∱∲∳"))


### PR DESCRIPTION
Agda input mode extension:  `\box` prefix for APL boxed characters (with @oskeri).

TODO:
- [x] changelog entry