### PR TITLE
cubical: Fix level in reduct of PathP transp

### DIFF
--- a/test/Succeed/TranspPathPLevel.agda
+++ b/test/Succeed/TranspPathPLevel.agda
@@ -1,0 +1,47 @@
+{-# OPTIONS --cubical --show-implicit --no-double-check #-}
+module TranspPathPLevel where
+-- Double checker disabled because it does not know you can apply Paths
+-- (it complains that _≡_ isn't a function type in the defn. of ex)
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Builtin.Cubical.Path
+open import Agda.Primitive.Cubical
+  renaming (primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primComp to comp ; primHComp to hcomp ; primTransp to transp)
+
+open import Agda.Builtin.Reflection hiding (Type)
+open import Agda.Builtin.Unit
+open import Agda.Builtin.List
+
+postulate
+  A : Type
+  p : A ≡ A
+  i : I
+
+-- Bug: this should compute to something like hcomp (λ i → primPOr {lsuc lzero} ...) ...
+--   previously, it computed to primPOr {λ _ → lsuc lzero} instead, which is wrong.
+ex : Type
+ex = transp {λ i → lsuc lzero} (λ i → A ≡ A) i0 p i
+
+_>>=_ = bindTC
+
+argN : ∀ {a} {A : Type a} → A → Arg A
+argN = arg (arg-info visible (modality relevant quantity-ω))
+
+u : ⊤
+u = unquote λ m → do
+  ex ← quoteTC ex
+
+  -- Checking the reflected normal form of a Kan operation essentially
+  -- always fails, since the normaliser freely assumes boundary
+  -- conditions in the arguments to primPOr, but "users" (= abstract
+  -- syntax) have to write (i = i0) patterns to get these.
+  (def (quote hcomp) (l ∷ a ∷ phi ∷ arg _ tm ∷ _)) ← normalise ex
+    where tm → typeError (strErr "test failed: transp in PathP applied did not evaluate to hcomp "∷ [])
+
+  -- But we can check that the system given to hcomp checks at the type
+  -- it should have, even if the hcomp wouldn't check:
+  let ty = quoteTerm (I → Partial (i ∨ ~ i) Type)
+  (lam _ _) ← checkType tm ty
+    where _ → typeError (strErr "checking reduced hcomp system did not result in a lambda" ∷ [])
+
+  unify m (quoteTerm tt)


### PR DESCRIPTION
Spotted by @jespercockx over in #5837, it turns out that the level(s) involved in transporting along a PathP can be very confusin; Especially if one tries to fix it by error-message whac-a-mole instead of sitting down and working out the context.

This bug is [ancient](https://github.com/agda/agda/commit/ca1ab2b22a7a1d8a8740920c7885972f9dd81ed6#diff-cfc2d6796702194e0448c2b66cc37b8a6c6ba5c45e8522aefb89a06621015a21L979), so it's interesting IMO that it evaded detection all these years. It's actually impossible to write an `hcomp` expression, even using `primPOr` (exported as `[_↦_,_↦_]` syntax), in a way that the arguments to primPOr (other than the "right-hand-sides" of those arrows) would be compared.

I wrote a test case which, using reflection, normalises `transp` of a path, pulls out the problematic system, and checks that it is (at least) a valid partial element. I don't think there's a less hacky way to test this. #4455 is starting to seem like something I should tackle at the upcoming AIM...