### PR TITLE
Allow using equivalences in nonerased contexts

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -111,6 +111,7 @@ data-files:
     lib/prim/Agda/Builtin/Cubical/Id.agda
     lib/prim/Agda/Builtin/Cubical/Sub.agda
     lib/prim/Agda/Builtin/Cubical/Glue.agda
+    lib/prim/Agda/Builtin/Cubical/Equiv.agda
     lib/prim/Agda/Builtin/Cubical/HCompU.agda
     lib/prim/Agda/Builtin/Equality.agda
     lib/prim/Agda/Builtin/Equality/Erase.agda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,11 @@ Erasure
   names can be used in the application, as in the definition of `N`
   above.
 
+* Equivalence primitives no longer require full `--cubical` mode,
+  `--erased-cubical` suffices. Equivalence definition is moved out of
+  `Agda.Builtin.Cubical.Glue` into its own module `Agda.Builtin.Cubical.Equiv`,
+  the former reexports the latter.
+
 Syntax
 ------
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -1196,7 +1196,7 @@ The Cubical subtypes are exported by ``Agda.Builtin.Cubical.Sub``:
   primitive
     primSubOut : ∀ {ℓ} {A : Set ℓ} {φ : I} {u : Partial φ A} → Sub _ φ u → A
 
-The Glue types are exported by ``Agda.Builtin.Cubical.Glue``:
+Equivalences are exported by ``Agda.Builtin.Cubical.Equiv``:
 
 .. code-block:: agda
 
@@ -1223,6 +1223,12 @@ The Glue types are exported by ``Agda.Builtin.Cubical.Glue``:
   {-# BUILTIN EQUIVFUN   equivFun   #-}
   {-# BUILTIN EQUIVPROOF equivProof #-}
 
+The Glue types are exported by ``Agda.Builtin.Cubical.Glue``:
+
+.. code-block:: agda
+
+  open import Agda.Builtin.Cubical.Equiv public
+
   primitive
     primGlue    : ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I}
       → (T : Partial φ (Set ℓ')) → (e : PartialP φ (λ o → T o ≃ A))
@@ -1234,10 +1240,6 @@ The Glue types are exported by ``Agda.Builtin.Cubical.Glue``:
       → {T : Partial φ (Set ℓ')} → {e : PartialP φ (λ o → T o ≃ A)}
       → primGlue A T e → A
     primFaceForall : (I → I) → I
-
-  -- pathToEquiv proves that transport is an equivalence (for details
-  -- see Agda.Builtin.Cubical.Glue). This is needed internally.
-  {-# BUILTIN PATHTOEQUIV pathToEquiv #-}
 
 Note that the Glue types are uncurried in ``agda/cubical`` to make
 them more pleasant to use:

--- a/src/data/lib/prim/Agda/Builtin/Cubical/Equiv.agda
+++ b/src/data/lib/prim/Agda/Builtin/Cubical/Equiv.agda
@@ -1,0 +1,107 @@
+{-# OPTIONS --erased-cubical --safe --no-sized-types --no-guardedness #-}
+
+module Agda.Builtin.Cubical.Equiv where
+
+open import Agda.Primitive
+open import Agda.Builtin.Sigma
+open import Agda.Primitive.Cubical renaming (primINeg to ~_; primIMax to _∨_; primIMin to _∧_;
+                                             primHComp to hcomp; primTransp to transp; primComp to comp;
+                                             itIsOne to 1=1)
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_])
+import Agda.Builtin.Cubical.HCompU as HCompU
+
+module Helpers = HCompU.Helpers
+
+open Helpers
+
+
+-- We make this a record so that isEquiv can be proved using
+-- copatterns. This is good because copatterns don't get unfolded
+-- unless a projection is applied so it should be more efficient.
+record isEquiv {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) : Set (ℓ ⊔ ℓ') where
+  no-eta-equality
+  field
+    equiv-proof : (y : B) → isContr (fiber f y)
+
+open isEquiv public
+
+infix 4 _≃_
+
+_≃_ : ∀ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') → Set (ℓ ⊔ ℓ')
+A ≃ B = Σ (A → B) \ f → (isEquiv f)
+
+equivFun : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} → A ≃ B → A → B
+equivFun e = fst e
+
+-- Improved version of equivProof compared to Lemma 5 in CCHM. We put
+-- the (φ = i0) face in contr' making it be definitionally c in this
+-- case. This makes the computational behavior better, in particular
+-- for transp in Glue.
+equivProof : ∀ {la lt} (T : Set la) (A : Set lt) → (w : T ≃ A) → (a : A)
+           → ∀ ψ (f : Partial ψ (fiber (w .fst) a)) → fiber (w .fst) a [ ψ ↦ f ]
+equivProof A B w a ψ fb =
+  inS (contr' {A = fiber (w .fst) a} (w .snd .equiv-proof a) ψ fb)
+  where
+    contr' : ∀ {ℓ} {A : Set ℓ} → isContr A → (φ : I) → (u : Partial φ A) → A
+    contr' {A = A} (c , p) φ u = hcomp (λ i → λ { (φ = i1) → p (u 1=1) i
+                                                ; (φ = i0) → c }) c
+
+
+{-# BUILTIN EQUIV      _≃_        #-}
+{-# BUILTIN EQUIVFUN   equivFun   #-}
+{-# BUILTIN EQUIVPROOF equivProof #-}
+
+module _ {ℓ : I → Level} (P : (i : I) → Set (ℓ i)) where
+  private
+    E : (i : I) → Set (ℓ i)
+    E  = λ i → P i
+    ~E : (i : I) → Set (ℓ (~ i))
+    ~E = λ i → P (~ i)
+
+    A = P i0
+    B = P i1
+
+    f : A → B
+    f x = transp E i0 x
+
+    g : B → A
+    g y = transp ~E i0 y
+
+    u : ∀ i → A → E i
+    u i x = transp (λ j → E (i ∧ j)) (~ i) x
+
+    v : ∀ i → B → E i
+    v i y = transp (λ j → ~E ( ~ i ∧ j)) i y
+
+    fiberPath : (y : B) → (xβ0 xβ1 : fiber f y) → xβ0 ≡ xβ1
+    fiberPath y (x0 , β0) (x1 , β1) k = ω , λ j → δ (~ j) where
+      module _ (j : I) where
+        private
+          sys : A → ∀ i → PartialP (~ j ∨ j) (λ _ → E (~ i))
+          sys x i (j = i0) = v (~ i) y
+          sys x i (j = i1) = u (~ i) x
+        ω0 = comp ~E (sys x0) ((β0 (~ j)))
+        ω1 = comp ~E (sys x1) ((β1 (~ j)))
+        θ0 = fill ~E (sys x0) (inS (β0 (~ j)))
+        θ1 = fill ~E (sys x1) (inS (β1 (~ j)))
+      sys = λ {j (k = i0) → ω0 j ; j (k = i1) → ω1 j}
+      ω = hcomp sys (g y)
+      θ = hfill sys (inS (g y))
+      δ = λ (j : I) → comp E
+            (λ i → λ { (j = i0) → v i y ; (k = i0) → θ0 j (~ i)
+                     ; (j = i1) → u i ω ; (k = i1) → θ1 j (~ i) })
+             (θ j)
+
+    γ : (y : B) → y ≡ f (g y)
+    γ y j = comp E (λ i → λ { (j = i0) → v i y
+                            ; (j = i1) → u i (g y) }) (g y)
+
+  pathToisEquiv : isEquiv f
+  pathToisEquiv .equiv-proof y .fst .fst = g y
+  pathToisEquiv .equiv-proof y .fst .snd = sym (γ y)
+  pathToisEquiv .equiv-proof y .snd = fiberPath y _
+
+  pathToEquiv : A ≃ B
+  pathToEquiv .fst = f
+  pathToEquiv .snd = pathToisEquiv

--- a/src/data/lib/prim/Agda/Builtin/Cubical/Glue.agda
+++ b/src/data/lib/prim/Agda/Builtin/Cubical/Glue.agda
@@ -3,55 +3,8 @@
 module Agda.Builtin.Cubical.Glue where
 
 open import Agda.Primitive
-open import Agda.Builtin.Sigma
-open import Agda.Primitive.Cubical renaming (primINeg to ~_; primIMax to _∨_; primIMin to _∧_;
-                                             primHComp to hcomp; primTransp to transp; primComp to comp;
-                                             itIsOne to 1=1)
-open import Agda.Builtin.Cubical.Path
-open import Agda.Builtin.Cubical.Sub renaming (Sub to _[_↦_])
-import Agda.Builtin.Cubical.HCompU as HCompU
-
-module Helpers = HCompU.Helpers
-
-open Helpers
-
-
--- We make this a record so that isEquiv can be proved using
--- copatterns. This is good because copatterns don't get unfolded
--- unless a projection is applied so it should be more efficient.
-record isEquiv {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) : Set (ℓ ⊔ ℓ') where
-  no-eta-equality
-  field
-    equiv-proof : (y : B) → isContr (fiber f y)
-
-open isEquiv public
-
-infix 4 _≃_
-
-
-_≃_ : ∀ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') → Set (ℓ ⊔ ℓ')
-A ≃ B = Σ (A → B) \ f → (isEquiv f)
-
-equivFun : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} → A ≃ B → A → B
-equivFun e = fst e
-
--- Improved version of equivProof compared to Lemma 5 in CCHM. We put
--- the (φ = i0) face in contr' making it be definitionally c in this
--- case. This makes the computational behavior better, in particular
--- for transp in Glue.
-equivProof : ∀ {la lt} (T : Set la) (A : Set lt) → (w : T ≃ A) → (a : A)
-           → ∀ ψ (f : Partial ψ (fiber (w .fst) a)) → fiber (w .fst) a [ ψ ↦ f ]
-equivProof A B w a ψ fb =
-  inS (contr' {A = fiber (w .fst) a} (w .snd .equiv-proof a) ψ fb)
-  where
-    contr' : ∀ {ℓ} {A : Set ℓ} → isContr A → (φ : I) → (u : Partial φ A) → A
-    contr' {A = A} (c , p) φ u = hcomp (λ i → λ { (φ = i1) → p (u 1=1) i
-                                                ; (φ = i0) → c }) c
-
-
-{-# BUILTIN EQUIV      _≃_        #-}
-{-# BUILTIN EQUIVFUN   equivFun   #-}
-{-# BUILTIN EQUIVPROOF equivProof #-}
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Cubical.Equiv public
 
 primitive
     primGlue    : ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I}
@@ -63,59 +16,3 @@ primitive
     prim^unglue : ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I}
       → {T : Partial φ (Set ℓ')} → {e : PartialP φ (λ o → T o ≃ A)}
       → primGlue A T e → A
-
-
-
-module _ {ℓ : I → Level} (P : (i : I) → Set (ℓ i)) where
-  private
-    E : (i : I) → Set (ℓ i)
-    E  = λ i → P i
-    ~E : (i : I) → Set (ℓ (~ i))
-    ~E = λ i → P (~ i)
-
-    A = P i0
-    B = P i1
-
-    f : A → B
-    f x = transp E i0 x
-
-    g : B → A
-    g y = transp ~E i0 y
-
-    u : ∀ i → A → E i
-    u i x = transp (λ j → E (i ∧ j)) (~ i) x
-
-    v : ∀ i → B → E i
-    v i y = transp (λ j → ~E ( ~ i ∧ j)) i y
-
-    fiberPath : (y : B) → (xβ0 xβ1 : fiber f y) → xβ0 ≡ xβ1
-    fiberPath y (x0 , β0) (x1 , β1) k = ω , λ j → δ (~ j) where
-      module _ (j : I) where
-        private
-          sys : A → ∀ i → PartialP (~ j ∨ j) (λ _ → E (~ i))
-          sys x i (j = i0) = v (~ i) y
-          sys x i (j = i1) = u (~ i) x
-        ω0 = comp ~E (sys x0) ((β0 (~ j)))
-        ω1 = comp ~E (sys x1) ((β1 (~ j)))
-        θ0 = fill ~E (sys x0) (inS (β0 (~ j)))
-        θ1 = fill ~E (sys x1) (inS (β1 (~ j)))
-      sys = λ {j (k = i0) → ω0 j ; j (k = i1) → ω1 j}
-      ω = hcomp sys (g y)
-      θ = hfill sys (inS (g y))
-      δ = λ (j : I) → comp E
-            (λ i → λ { (j = i0) → v i y ; (k = i0) → θ0 j (~ i)
-                     ; (j = i1) → u i ω ; (k = i1) → θ1 j (~ i) })
-             (θ j)
-
-    γ : (y : B) → y ≡ f (g y)
-    γ y j = comp E (λ i → λ { (j = i0) → v i y
-                            ; (j = i1) → u i (g y) }) (g y)
-
-  pathToisEquiv : isEquiv f
-  pathToisEquiv .equiv-proof y .fst .fst = g y
-  pathToisEquiv .equiv-proof y .fst .snd = sym (γ y)
-  pathToisEquiv .equiv-proof y .snd = fiberPath y _
-
-  pathToEquiv : A ≃ B
-  pathToEquiv .fst = f
-  pathToEquiv .snd = pathToisEquiv

--- a/src/full/Agda/Interaction/Options/Lenses.hs
+++ b/src/full/Agda/Interaction/Options/Lenses.hs
@@ -146,6 +146,7 @@ builtinModulesWithSafePostulates =
   , "Agda" </> "Builtin" </> "Char.agda"
   , "Agda" </> "Builtin" </> "Char" </> "Properties.agda"
   , "Agda" </> "Builtin" </> "Coinduction.agda"
+  , "Agda" </> "Builtin" </> "Cubical" </> "Equiv.agda"
   , "Agda" </> "Builtin" </> "Cubical" </> "Glue.agda"
   , "Agda" </> "Builtin" </> "Cubical" </> "HCompU.agda"
   , "Agda" </> "Builtin" </> "Cubical" </> "Id.agda"

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -171,7 +171,7 @@ coreBuiltins =
                                                               hPi' "A" (sort . tmSort <$> l) $ \ bA ->
                                                               hPi' "x" (el' l bA) $ \ x ->
                                                               el' l (primId <#> l <#> bA <@> x <@> x)))
-  , (builtinEquiv                            |-> BuiltinUnknown (Just $ requireCubical CFull "" >> runNamesT [] (
+  , (builtinEquiv                            |-> BuiltinUnknown (Just $ requireCubical CErased "" >> runNamesT [] (
                                                                     hPi' "l" (el $ cl primLevel) $ \ a ->
                                                                     hPi' "l'" (el $ cl primLevel) $ \ b ->
                                                                     nPi' "A" (sort . tmSort <$> a) $ \bA ->
@@ -179,7 +179,7 @@ coreBuiltins =
                                                                     ((sort . tmSort) <$> (cl primLevelMax <@> a <@> b))
                                                                   ))
                                                                    (const $ const $ return ()))
-  , (builtinEquivFun                         |-> BuiltinUnknown (Just $ requireCubical CFull "" >> runNamesT [] (
+  , (builtinEquivFun                         |-> BuiltinUnknown (Just $ requireCubical CErased "" >> runNamesT [] (
                                                                  hPi' "l" (el $ cl primLevel) $ \ a ->
                                                                  hPi' "l'" (el $ cl primLevel) $ \ b ->
                                                                  hPi' "A" (sort . tmSort <$> a) $ \bA ->
@@ -188,7 +188,7 @@ coreBuiltins =
                                                                  (el' a bA --> el' b bB)
                                                                ))
                                                                 (const $ const $ return ()))
-  , (builtinEquivProof                       |-> BuiltinUnknown (Just $ requireCubical CFull "" >> runNamesT [] (
+  , (builtinEquivProof                       |-> BuiltinUnknown (Just $ requireCubical CErased "" >> runNamesT [] (
                                                                hPi' "l" (el $ cl primLevel) $ \ la ->
                                                                hPi' "l'" (el $ cl primLevel) $ \ lb ->
                                                                nPi' "A" (sort . tmSort <$> la) $ \ bA ->

--- a/test/Fail/Erased-cubical-Glue.err
+++ b/test/Fail/Erased-cubical-Glue.err
@@ -1,3 +1,3 @@
-Erased-cubical-Glue.agda:13,30-31
-Identifier _≃_ is declared erased, so it cannot be used here
-when checking that the expression B x ≃ A has type Set _a_4
+Erased-cubical-Glue.agda:14,3-11
+Identifier primGlue is declared erased, so it cannot be used here
+when checking that the expression primGlue A B f has type _7

--- a/test/Fail/Issue2788.err
+++ b/test/Fail/Issue2788.err
@@ -1,3 +1,3 @@
 Issue2788.agda:8,1-28
-Missing option --cubical
+Missing option --cubical or --erased-cubical
 when checking the pragma BUILTIN EQUIV Equiv


### PR DESCRIPTION
`Cubical.Foundations.*` transitive imports currently contain ~150 uses of `Glue` and `ua`. The change will make manual erasure annotation feasible for this restricted cubical library subset. Equivalences are ubiquitous and having them at runtime is highly desirable.