### PR TITLE
Guarded: @lock arguments must mention @lock variable(s)

### DIFF
--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1299,17 +1299,25 @@ instance LensAnnotation (Arg t) where
 -- * Locks
 ---------------------------------------------------------------------------
 
-data Lock = IsNotLock
-          | IsLock -- ^ In the future there might be different kinds of them.
-                   --   For now we assume lock weakening.
+data LockOrigin
+  = LockOLock -- ^ The user wrote @lock.
+  | LockOTick -- ^ The user wrote @tick.
   deriving (Show, Generic, Eq, Enum, Bounded, Ord)
+
+data Lock
+  = IsNotLock
+  | IsLock LockOrigin
+  -- ^ In the future there might be different kinds of them.
+  --   For now we assume lock weakening.
+  deriving (Show, Generic, Eq, Ord)
 
 defaultLock :: Lock
 defaultLock = IsNotLock
 
 instance NFData Lock where
-  rnf IsNotLock = ()
-  rnf IsLock    = ()
+  rnf IsNotLock          = ()
+  rnf (IsLock LockOLock) = ()
+  rnf (IsLock LockOTick) = ()
 
 class LensLock a where
 

--- a/src/full/Agda/Syntax/Concrete/Attribute.hs
+++ b/src/full/Agda/Syntax/Concrete/Attribute.hs
@@ -109,7 +109,8 @@ type Attributes = [(Attribute, Range, String)]
 lockAttributeTable :: [(String, Lock)]
 lockAttributeTable = concat
   [ map (, IsNotLock) [ "notlock" ] -- default, shouldn't be used much
-  , map (, IsLock) [ "lock", "tick" ] -- 🔓
+  , map (, IsLock LockOTick) [ "tick" ] -- @tick
+  , map (, IsLock LockOLock) [ "lock" ] -- @lock
   ]
 
 

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -85,6 +85,12 @@ prettyRelevance a = (pretty (getRelevance a) <>)
 prettyQuantity :: LensQuantity a => a -> Doc -> Doc
 prettyQuantity a = (pretty (getQuantity a) <+>)
 
+prettyLock :: LensLock a => a -> Doc -> Doc
+prettyLock a doc = case getLock a of
+  IsLock LockOLock -> "@lock" <+> doc
+  IsLock LockOTick -> "@tick" <+> doc
+  IsNotLock -> doc
+
 prettyErased :: Erased -> Doc -> Doc
 prettyErased = prettyQuantity . asQuantity
 
@@ -328,6 +334,7 @@ instance Pretty TypedBinding where
         $ prettyFiniteness (binderName $ namedArg y)
         $ prettyCohesion y
         $ prettyQuantity y
+        $ prettyLock y
         $ prettyTactic (binderName $ namedArg y) $
         sep [ fsep (map (pretty . NamedBinding False) ys)
             , ":" <+> pretty e ]

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -104,6 +104,10 @@ instance LensArgInfo (Dom' t e) where
   setArgInfo ai dom = dom { domInfo = ai }
   mapArgInfo f  dom = dom { domInfo = f $ domInfo dom }
 
+instance LensLock (Dom' t e) where
+  getLock = getLock . getArgInfo
+  setLock = mapArgInfo . setLock
+
 -- The other lenses are defined through LensArgInfo
 
 instance LensHiding        (Dom' t e) where
@@ -1330,10 +1334,12 @@ instance Pretty t => Pretty (Abs t) where
   pretty (NoAbs x t) = "NoAbs" <+> (text x <> ".") <+> pretty t
 
 instance (Pretty t, Pretty e) => Pretty (Dom' t e) where
-  pretty dom = pTac <+> pDom dom (pretty $ unDom dom)
+  pretty dom = pLock <+> pTac <+> pDom dom (pretty $ unDom dom)
     where
       pTac | Just t <- domTactic dom = "@" <> parens ("tactic" <+> pretty t)
            | otherwise               = empty
+      pLock | IsLock{} <- getLock dom = "@lock"
+            | otherwise = empty
 
 pDom :: LensHiding a => a -> Doc -> Doc
 pDom i =

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -3226,7 +3226,7 @@ checkAttributes ((attr, r, s) : attrs) =
     RelevanceAttribute{}    -> cont
     TacticAttribute{}       -> cont
     LockAttribute IsNotLock -> cont
-    LockAttribute IsLock    -> do
+    LockAttribute IsLock{}  -> do
       unlessM (optGuarded <$> pragmaOptions) $
         err "Lock" "--guarded"
       cont

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -24,7 +24,7 @@ module Agda.TypeChecking.Errors
 import Prelude hiding ( null, foldl )
 
 import qualified Control.Exception as E
-import Control.Monad ((>=>))
+import Control.Monad ((>=>), (<=<))
 import Control.Monad.Except
 
 import qualified Data.CaseInsensitive as CaseInsens

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -270,6 +270,8 @@ errorString err = case err of
   InstanceSearchDepthExhausted{}           -> "InstanceSearchDepthExhausted"
   TriedToCopyConstrainedPrim{}             -> "TriedToCopyConstrainedPrim"
   SortOfSplitVarError{}                    -> "SortOfSplitVarError"
+  ReferencesFutureVariables{}              -> "ReferencesFutureVariables"
+  DoesNotMentionTicks{}                    -> "DoesNotMentionTicks"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1215,8 +1217,60 @@ instance PrettyTCM TypeError where
 
     TriedToCopyConstrainedPrim q -> fsep $
       pwords "Cannot create a module containing a copy of" ++ [prettyTCM q]
+
     SortOfSplitVarError _ doc -> return doc
 
+    ReferencesFutureVariables term (disallowed :| _) lock leftmost
+      | disallowed == leftmost
+      -> fsep $ pwords "The lock variable"
+             ++ pure (prettyTCM =<< nameOfBV disallowed)
+             ++ pwords "can not appear simultaneously in the \"later\" term"
+             ++ pure (prettyTCM term)
+             ++ pwords "and in the lock term"
+             ++ pure (prettyTCM lock <> ".")
+
+    ReferencesFutureVariables term (disallowed :| rest) lock leftmost -> do
+      explain <- (/=) <$> prettyTCM lock <*> (prettyTCM =<< nameOfBV leftmost)
+      let
+        name = prettyTCM =<< nameOfBV leftmost
+        mod = case getLock lock of
+          IsLock LockOLock -> "@lock"
+          IsLock LockOTick -> "@tick"
+          _ -> __IMPOSSIBLE__
+      vcat $ concat
+        [ pure . fsep $ concat
+          [ pwords "The variable", pure (prettyTCM =<< nameOfBV disallowed), pwords "can not be mentioned here,"
+          , pwords "since it was not introduced before the variable", pure (name <> ".")
+          ]
+        , [ fsep ( pwords "Variables introduced after"
+                ++ pure name
+                ++ pwords "can not be used, since that is the leftmost" ++ pure mod ++ pwords "variable in the locking term"
+                ++ pure (prettyTCM lock <> "."))
+          | explain
+          ]
+        , [ fsep ( pwords "The following"
+                  ++ P.singPlural rest (pwords "variable is") (pwords "variables are")
+                  ++ pwords "not allowed here, either:"
+                  ++ punctuate comma (map (prettyTCM <=< nameOfBV) rest))
+          | not (null rest)
+          ]
+        ]
+
+    DoesNotMentionTicks term ty lock ->
+      let
+        mod = case getLock lock of
+          IsLock LockOLock -> "@lock"
+          IsLock LockOTick -> "@tick"
+          _ -> __IMPOSSIBLE__
+      in
+        vcat
+        [ fsep $
+            pwords "The term"
+            ++ [prettyTCM lock <> ","]
+            ++ pwords "given as an argument to the guarded value"
+        , nest 2 (prettyTCM term <+> ":" <+> prettyTCM ty)
+        , fsep (pwords ("can not be used as a " ++ mod ++ " argument, since it does not mention any " ++ mod ++ " variables."))
+        ]
     where
     mpar n args
       | n > 0 && not (null args) = parens

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -25,10 +25,12 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute.Class
 import Agda.TypeChecking.Free
 
+import qualified Agda.Utils.List1 as List1
+import qualified Agda.Utils.VarSet as VSet
+import Agda.Utils.Functor
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Size
-import Agda.Utils.VarSet as VSet
 
 import Agda.Utils.Impossible
 
@@ -53,7 +55,7 @@ checkLockedVars t ty lk lk_ty = catchConstraint (CheckLockedVars t ty lk lk_ty) 
 
   -- Strategy: compute allowed variables, check that @t@ doesn't use more.
   mi <- getLockVar (unArg lk)
-  caseMaybe mi (return ()) $ \ i -> do
+  caseMaybe mi (typeError (DoesNotMentionTicks t ty lk)) $ \ i -> do
 
   cxt <- getContext
   let toCheck = zip [0..] $ zipWith raise [1..] (take i cxt)
@@ -83,8 +85,9 @@ checkLockedVars t ty lk lk_ty = catchConstraint (CheckLockedVars t ty lk lk_ty) 
     -- flexVars = flexibleVars fv
     -- blockingMetas = map (`lookupVarMap` flexVars) (ISet.toList $ termVars ISet.\\ allowedVars)
     patternViolation alwaysUnblock
-  else do
-    notAllowedVarsError (unArg lk) (ISet.toList illegalVars)
+  else
+    typeError $ ReferencesFutureVariables t (List1.fromList (ISet.toList illegalVars)) lk i
+    -- List1.fromList is guarded by not (null illegalVars)
 
 
 getLockVar :: Term -> TCMT IO (Maybe Int)
@@ -93,9 +96,13 @@ getLockVar lk = do
     fv = freeVarsIgnore IgnoreInAnnotations lk
     flex = flexibleVars fv
 
+    isLock i = fmap (getLock . domInfo) (lookupBV i) <&> \case
+      IsLock{} -> True
+      IsNotLock{} -> False
+
   unless (IMap.null flex) $ do
     let metas = Set.unions $ map (foldrMetaSet Set.insert Set.empty) $ IMap.elems flex
-    patternViolation $ unblockOnAnyMeta $ metas
+    patternViolation $ unblockOnAnyMeta metas
 
   is <- filterM isLock $ ISet.toList $ rigidVars fv
 
@@ -105,12 +112,7 @@ getLockVar lk = do
   let mi | Prelude.null is   = Nothing
          | otherwise = Just $ maximum is
 
-  return $ mi
-
-  where
-   isLock i = do
-     islock <- getLock . domInfo <$> lookupBV i
-     return $ islock == IsLock
+  pure mi
 
 isTimeless :: Type -> TCM Bool
 isTimeless t = do
@@ -126,7 +128,7 @@ notAllowedVarsError lk is = do
          ("The following vars are not allowed in a later value applied to"
           <+> prettyTCM lk <+> ":" <+> prettyTCM (map var $ is))
 
-checkEarlierThan :: Term -> VarSet -> TCM ()
+checkEarlierThan :: Term -> VSet.VarSet -> TCM ()
 checkEarlierThan lk fvs = do
   mv <- getLockVar lk
   caseMaybe mv (return ()) $ \ i -> do

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1031,7 +1031,9 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
             TelV tel' _ <- telViewUpToPath (length args) t
             forM_ ids $ \(i,u) -> do
               d <- lookupBV i
-              when (getLock (getArgInfo d) == IsLock) $ do
+              case getLock (getArgInfo d) of
+                IsNotLock -> pure ()
+                IsLock{} -> do
                 let us = IntSet.unions $ map snd $ filter (earlierThan i . fst) idvars
                 -- us Earlier than u
                 addContext tel' $ checkEarlierThan u us

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4399,6 +4399,13 @@ data TypeError
         | ModuleArityMismatch A.ModuleName Telescope [NamedArg A.Expr]
         | GeneralizeCyclicDependency
         | GeneralizeUnsolvedMeta
+        | ReferencesFutureVariables Term (List1.NonEmpty Int) (Arg Term) Int
+          -- ^ The first term references the given list of variables,
+          -- which are in "the future" with respect to the given lock
+          -- (and its leftmost variable)
+        | DoesNotMentionTicks Term Type (Arg Term)
+          -- ^ Arguments: later term, its type, lock term. The lock term
+          -- does not mention any @lock variables.
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -832,11 +832,12 @@ checkArgumentsE'
                   let e' = e { nameOf = (nameOf e) <|> dname }
                   checkNamedArg (Arg info' e') a
 
-                let c | IsLock == getLock info' =
-                        Just $ Abs "t" $
+                let
+                  c = case getLock info' of
+                    IsLock{} -> Just $ Abs "t" $
                         CheckLockedVars (Var 0 []) (raise 1 sFun)
                           (raise 1 $ Arg info' u) (raise 1 a)
-                      | otherwise = Nothing
+                    _ -> Nothing
                 lift $ reportSDoc "tc.term.lock" 40 $ text "lock =" <+> text (show $ getLock info')
                 lift $ reportSDoc "tc.term.lock" 40 $
                   addContext (defaultDom $ sFun) $

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -327,7 +327,7 @@ checkDomain lamOrPi xs e = do
          applyCohesionToContext c $
          modEnv lamOrPi $ isType_ e
     -- Andrea TODO: also make sure that LockUniv implies IsLock
-    when (any (\ x -> getLock x == IsLock) xs) $ do
+    when (any (\x -> case getLock x of { IsLock{} -> True ; _ -> False }) xs) $ do
          -- Solves issue #5033
         unlessM (isJust <$> getName' builtinLockUniv) $ do
           genericDocError $ "Missing binding for primLockUniv primitive."

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20230124 * 10 + 0
+currentInterfaceVersion = 20230313 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -607,11 +607,13 @@ instance EmbPrj Annotation where
     _ -> malformed
 
 instance EmbPrj Lock where
-  icod_ IsNotLock = return 0
-  icod_ IsLock    = return 1
+  icod_ IsNotLock          = pure 0
+  icod_ (IsLock LockOTick) = pure 1
+  icod_ (IsLock LockOLock) = pure 2
 
-  value 0 = return IsNotLock
-  value 1 = return IsLock
+  value 0 = pure IsNotLock
+  value 1 = pure (IsLock LockOTick)
+  value 2 = pure (IsLock LockOLock)
   value _ = malformed
 
 instance EmbPrj Origin where

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -168,7 +168,7 @@ varDependencies tel = addLocks . allDependencies IntSet.empty
     addLocks s | IntSet.null s = s
                | otherwise = IntSet.union s $ IntSet.fromList $ filter (>= m) locks
       where
-        locks = catMaybes [ deBruijnView (unArg a) | (a :: Arg Term) <- teleArgs tel, getLock a == IsLock]
+        locks = catMaybes [ deBruijnView (unArg a) | (a :: Arg Term) <- teleArgs tel, IsLock{} <- pure (getLock a)]
         m = IntSet.findMin s
     n  = size tel
     ts = flattenTel tel

--- a/test/Fail/Issue6523.agda
+++ b/test/Fail/Issue6523.agda
@@ -1,0 +1,44 @@
+{-# OPTIONS --guarded #-}
+module Issue6523 where
+
+open import Agda.Primitive
+
+module Prims where
+  primitive
+    primLockUniv : Set₁
+
+open Prims renaming (primLockUniv to LockU) public
+
+private
+  variable
+    l : Level
+    A B : Set l
+
+-- We postulate Tick as it is supposed to be an abstract sort.
+postulate
+  Tick : LockU
+
+▹_ : ∀ {l} → Set l → Set l
+▹_ A = (@tick x : Tick) → A
+
+▸_ : ∀ {l} → ▹ Set l → Set l
+▸ A = (@tick x : Tick) → A x
+
+next : A → ▹ A
+next x _ = x
+
+_⊛_ : ▹ (A → B) → ▹ A → ▹ B
+_⊛_ f x a = f a (x a)
+
+----------------------------------
+-- The bug
+
+-- definition of untic is illegal: since tic is not marked @tic we have
+-- no idea where to split the context to check the function
+untic : ∀ {ℓ} {X : Set ℓ} → Tick → ▹ X → X
+untic tic later = later tic
+
+-- This shouldn't be possible for Later
+-- The call to untic should be forbidden
+join : ∀ {A : Set} → ▹ (▹ A) → ▹ A
+join x tic = untic tic (x tic)

--- a/test/Fail/Issue6523.err
+++ b/test/Fail/Issue6523.err
@@ -1,0 +1,6 @@
+Issue6523.agda:39,19-28
+The term tic, given as an argument to the guarded value
+  later : Tick → X
+can not be used as a @tick argument, since it does not mention any
+@tick variables.
+when checking that the expression later tic has type X

--- a/test/Fail/TickConstants.err
+++ b/test/Fail/TickConstants.err
@@ -1,4 +1,4 @@
 TickConstants.agda:13,10-25
-The following vars are not allowed in a later value applied to c
-                                                               x : [x]
+The lock variable x can not appear simultaneously in the "later"
+term foo (c x) and in the lock term c x.
 when checking that the expression foo (c x) (c x) has type Set

--- a/test/Fail/TickJoin.agda
+++ b/test/Fail/TickJoin.agda
@@ -1,0 +1,13 @@
+{-# OPTIONS --guarded #-}
+module TickJoin where
+
+open import Agda.Builtin.Nat
+
+primitive primLockUniv : Set₁
+postulate Tick : primLockUniv
+
+▹_ : ∀ {l} → Set l → Set l
+▹_ A = (@tick x : Tick) → A
+
+join : ∀ {A : Set} → ▹ ▹ A → ▹ A
+join x tic = x tic tic

--- a/test/Fail/TickJoin.err
+++ b/test/Fail/TickJoin.err
@@ -1,0 +1,4 @@
+TickJoin.agda:13,14-23
+The lock variable tic can not appear simultaneously in the "later"
+term x tic and in the lock term tic.
+when checking that the expression x tic tic has type A

--- a/test/Fail/TickVariableAfter.agda
+++ b/test/Fail/TickVariableAfter.agda
@@ -1,0 +1,13 @@
+{-# OPTIONS --guarded #-}
+module TickVariableAfter where
+
+open import Agda.Builtin.Nat
+
+primitive primLockUniv : Set₁
+postulate Tick : primLockUniv
+
+▹_ : ∀ {l} → Set l → Set l
+▹_ A = (@tick x : Tick) → A
+
+illegal : ∀ {A : Set} → @lock Tick → ▹ A → A
+illegal tic later = later tic

--- a/test/Fail/TickVariableAfter.err
+++ b/test/Fail/TickVariableAfter.err
@@ -1,0 +1,4 @@
+TickVariableAfter.agda:13,21-30
+The variable later can not be mentioned here, since it was not
+introduced before the variable tic.
+when checking that the expression later tic has type A

--- a/test/Fail/TickVariableAfterTerm.agda
+++ b/test/Fail/TickVariableAfterTerm.agda
@@ -1,0 +1,16 @@
+{-# OPTIONS --guarded #-}
+module TickVariableAfterTerm where
+
+open import Agda.Builtin.Nat
+
+primitive primLockUniv : Set₁
+postulate
+  Tick : primLockUniv
+  endo : Tick → Tick
+
+▹_ : ∀ {l} → Set l → Set l
+▹_ A = (@tick x : Tick) → A
+
+
+illegal : ∀ {A : Set} → @lock Tick → ▹ A → A
+illegal tic later = later (endo tic)

--- a/test/Fail/TickVariableAfterTerm.err
+++ b/test/Fail/TickVariableAfterTerm.err
@@ -1,0 +1,6 @@
+TickVariableAfterTerm.agda:16,21-37
+The variable later can not be mentioned here, since it was not
+introduced before the variable tic.
+Variables introduced after tic can not be used, since that is the
+leftmost @tick variable in the locking term endo tic.
+when checking that the expression later (endo tic) has type A

--- a/test/Fail/TickVariablesAfter.agda
+++ b/test/Fail/TickVariablesAfter.agda
@@ -1,0 +1,13 @@
+{-# OPTIONS --guarded #-}
+module TickVariablesAfter where
+
+open import Agda.Builtin.Nat
+
+primitive primLockUniv : Set₁
+postulate Tick : primLockUniv
+
+▹_ : ∀ {l} → Set l → Set l
+▹_ A = (@tick x : Tick) → A
+
+illegal : ∀ {A B : Set} → @lock Tick → (A → ▹ B) → A → B
+illegal tic func arg = func arg tic

--- a/test/Fail/TickVariablesAfter.err
+++ b/test/Fail/TickVariablesAfter.err
@@ -1,0 +1,5 @@
+TickVariablesAfter.agda:13,24-36
+The variable arg can not be mentioned here, since it was not
+introduced before the variable tic.
+The following variable is not allowed here, either: func
+when checking that the expression func arg tic has type B


### PR DESCRIPTION
Closes #6523 by disallowing the definition of `untic`, since in the (approximate) typing rule

```
Γ ⊢ f : (@lock t : T) → A
---
Γ , @lock a : T , Γ ⊢ f a : A
```

we have to figure out what `a` is to split the context into allowed/forbidden variables. Previously an `@lock` _argument_ mentioning no `@lock` _variables_ was just ignored. I also took this opportunity to polish the error messages and add more test cases.