### PR TITLE
Support GHC 9.6.1 with cabal

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -31,6 +31,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
+    - if: ${{ runner.os == 'Linux' }}
+      name: Switch off XDG directories for cabal (Linux)
+      run: |
+        mkdir -p ~/.cabal
     - id: setup-haskell
       uses: haskell/actions/setup@v2
       with:

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -22,10 +22,10 @@ jobs:
         access_token: ${{ github.token }}
   cabal:
     env:
-      CABAL_VER: ${{ matrix.cabal-ver || '3.8' }}
+      CABAL_VER: ${{ matrix.cabal-ver || '3.10' }}
       FLAGS: ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting'
         }}
-      GHC_VER: ${{ matrix.ghc-ver || '9.4.4' }}
+      GHC_VER: ${{ matrix.ghc-ver || '9.6.1' }}
     name: Cabal ${{ matrix.description }}, ${{ matrix.ghc-ver }}
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
@@ -96,10 +96,11 @@ jobs:
         cabal-flags:
         - --enable-tests -f enable-cluster-counting
         cabal-ver:
-        - '3.8'
+        - '3.10'
         description:
         - Linux
         ghc-ver:
+        - 9.6.1
         - 9.4.4
         - 9.2.7
         - 9.0.2
@@ -109,26 +110,21 @@ jobs:
         include:
         - cabal-flags: --disable-tests
           description: Linux w/o tests
-          ghc-ver: 9.4.4
+          ghc-ver: 9.6.1
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f cpphs
           description: Linux cpphs
-          ghc-ver: 9.4.4
+          ghc-ver: 9.6.1
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f debug
           description: Linux debug
-          ghc-ver: 9.4.4
-          os: ubuntu-22.04
-        - cabal-flags: |
-            --enable-tests -f enable-cluster-counting -f debug -c mtl>=2.3.1
-          description: Linux mtl 2.3
-          ghc-ver: 9.4.4
+          ghc-ver: 9.6.1
           os: ubuntu-22.04
         - description: macOS
-          ghc-ver: 9.4.4
+          ghc-ver: 9.6.1
           os: macos-12
         - description: Windows
-          ghc-ver: 9.4.4
+          ghc-ver: 9.6.1
           os: windows-2022
         os:
         - ubuntu-22.04

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -192,9 +192,9 @@ jobs:
       fail-fast: false
       matrix:
         cabal-ver:
-        - '3.8'
+        - '3.10'
         ghc-ver:
-        - '9.4'
+        - '9.6'
         os:
         - windows-latest
         - macos-latest

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -68,9 +68,9 @@ jobs:
     strategy:
       matrix:
         cabal-ver:
-        - '3.8'
+        - '3.10'
         ghc-ver:
-        - 9.4.4
+        - 9.6.1
         os:
         - ubuntu-22.04
 name: Haddock

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -349,7 +349,7 @@ library
     build-depends:  text-icu >= 0.7.1.0
 
   if os(windows)
-    build-depends:  Win32 >= 2.6.1.0 && < 2.13
+    build-depends:  Win32 >= 2.6.1.0 && < 2.14
 
   -- Agda cannot be built with GHC 8.6.1 due to a compiler bug, see
   -- Agda Issue #3344.
@@ -401,7 +401,7 @@ library
     , split                >= 0.2.0.0   && < 0.2.4
     , stm                  >= 2.4.4     && < 2.6
     , STMonadTrans         >= 0.4.3     && < 0.5
-    , strict               >= 0.4.0.1   && < 0.5
+    , strict               >= 0.4.0.1   && < 0.6
     , text                 >= 1.2.3.1   && < 2.1
     , time                 >= 1.8.0.2   && < 1.13
     , time-compat          >= 1.9.2     && < 1.10
@@ -830,7 +830,7 @@ executable agda-mode
   main-is:          Main.hs
   other-modules:    Paths_Agda
   build-depends:
-    , base      >= 4.12.0.0 && < 4.18
+    , base      >= 4.12.0.0 && < 4.19
     , directory >= 1.3.3.0  && < 1.4
     , filepath  >= 1.4.2.1  && < 1.5
     , process   >= 1.6.3.0  && < 1.7
@@ -949,7 +949,7 @@ test-suite agda-tests
     , tasty-silver     >= 3.1.13  && < 3.4
     , temporary        >= 1.2.0.3 && < 1.4
     , text
-    , unix-compat      >= 0.4.3.1 && < 0.7
+    , unix-compat      >= 0.4.3.1 && < 0.8
     , unordered-containers
     , uri-encode
 

--- a/src/data/MAlonzo/src/MAlonzo/RTE.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE.hs
@@ -2,10 +2,18 @@
 
 module MAlonzo.RTE where
 
-import Unsafe.Coerce
-import qualified GHC.Exts as GHC (Any)
-import Data.Char
+import Prelude
+  ( Bool, Char, Double, Integer, String
+  , Enum(..), Eq(..), Ord(..), Integral(..), Num(..)
+  , ($), error, otherwise
+  , (++), fromIntegral
+  )
+
+import Data.Char ( GeneralCategory(Surrogate), generalCategory )
+import Data.Kind ( Type)
 import qualified Data.Word
+import qualified GHC.Exts as GHC ( Any )
+import Unsafe.Coerce ( unsafeCoerce )
 
 type AgdaAny = GHC.Any
 
@@ -109,5 +117,5 @@ lt64 = (<)
 
 -- Support for musical coinduction.
 
-data Inf                   a = Sharp { flat :: a }
-type Infinity (level :: *) a = Inf a
+data Inf                      a = Sharp { flat :: a }
+type Infinity (level :: Type) a = Inf a

--- a/src/data/MAlonzo/src/MAlonzo/RTE/Float.hs
+++ b/src/data/MAlonzo/src/MAlonzo/RTE/Float.hs
@@ -2,6 +2,15 @@
 
 module MAlonzo.RTE.Float where
 
+import Prelude
+  ( Bool, Double, Int, Integer, Maybe(..), Ordering(..)
+  , Eq(..), Ord(..), Functor(..)
+  , Floating(..), Fractional(..), Integral(..), Num(..), Real(..), RealFloat(..), RealFrac(..)
+  , ($), (.), otherwise, uncurry, undefined
+  , (&&), fst, snd
+  , (^), even, fromIntegral
+  )
+
 import Data.Bifunctor   ( bimap, second )
 import Data.Function    ( on )
 import Data.Maybe       ( fromMaybe )

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -50,9 +50,9 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         description: [Linux]      ## This just for pretty-printing the job name.
-        ghc-ver: [9.4.4, 9.2.7, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
+        ghc-ver: [9.6.1, 9.4.4, 9.2.7, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
         # Need to mention "cabal-ver" at least once in the matrix, otherwise matrix.cabal-ver is an actionlint error.
-        cabal-ver: ['3.8']
+        cabal-ver: ['3.10']
         cabal-flags: ['--enable-tests -f enable-cluster-counting']
         include:
           ## Latest GHC, special builds
@@ -60,46 +60,47 @@ jobs:
           # Linux, w/o tests
           - os: ubuntu-22.04
             description: Linux w/o tests
-            ghc-ver: '9.4.4'
+            ghc-ver: '9.6.1'
             # Can't leave cabal-flags empty here lest it becomes the default value.
             cabal-flags: '--disable-tests'
 
           # Linux, with -f cpphs
           - os: ubuntu-22.04
             description: Linux cpphs
-            ghc-ver: '9.4.4'
+            ghc-ver: '9.6.1'
             cabal-flags: '--enable-tests -f cpphs'
 
           # Linux, without -f enable-cluster-counting but with -f debug
           - os: ubuntu-22.04
             description: Linux debug
-            ghc-ver: '9.4.4'
+            ghc-ver: '9.6.1'
             cabal-flags: '--enable-tests -f debug'
 
-          # Linux, with mtl-2.3 and everything
-          - os: ubuntu-22.04
-            description: Linux mtl 2.3
-            ghc-ver: '9.4.4'
-            ## Andreas, 2022-11-23: Test mtl-2.3.1 here which has breaking changes.
-            ## Note: -c 'mtl >= 2.3.1' with single quotes does not get communicated properly.
-            ## (The single quotes stay, and "-c 'mtl" is an option parse error for cabal.)
-            cabal-flags: |
-              --enable-tests -f enable-cluster-counting -f debug -c mtl>=2.3.1
+          ## Andreas, 2023-03-15: Obsolete with GHC 9.6 which ships mtl-2.3
+          # # Linux, with mtl-2.3 and everything
+          # - os: ubuntu-22.04
+          #   description: Linux mtl 2.3
+          #   ghc-ver: '9.6.1'
+          #   ## Andreas, 2022-11-23: Test mtl-2.3.1 here which has breaking changes.
+          #   ## Note: -c 'mtl >= 2.3.1' with single quotes does not get communicated properly.
+          #   ## (The single quotes stay, and "-c 'mtl" is an option parse error for cabal.)
+          #   cabal-flags: |
+          #     --enable-tests -f enable-cluster-counting -f debug -c mtl>=2.3.1
 
           # macOS with default flags
           - os: macos-12
             description: macOS
-            ghc-ver: '9.4.4'
+            ghc-ver: '9.6.1'
 
           # Windows with default flags
           - os: windows-2022
             description: Windows
-            ghc-ver: '9.4.4'
+            ghc-ver: '9.6.1'
 
     # Default values
     env:
-      GHC_VER:   ${{ matrix.ghc-ver || '9.4.4' }}
-      CABAL_VER: ${{ matrix.cabal-ver || '3.8' }}
+      GHC_VER:   ${{ matrix.ghc-ver || '9.6.1' }}
+      CABAL_VER: ${{ matrix.cabal-ver || '3.10' }}
       FLAGS:     ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting' }}
 
     steps:

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -106,6 +106,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Switch off XDG directories for cabal (Linux)
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        mkdir -p ~/.cabal
+      # The presence of ~/.cabal should switch cabal 3.10 to not use the XDG layout.
+
     - uses: haskell/actions/setup@v2
       id: setup-haskell
       with:

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -35,8 +35,8 @@ jobs:
         # Atm, building static executables with GHC 9.4 is broken on ubuntu-22.04,
         # so, we downgrade to ubuntu-20.04.
         os: [windows-latest, macos-latest, ubuntu-20.04]
-        ghc-ver: ['9.4']
-        cabal-ver: ['3.8']
+        ghc-ver: ['9.6']
+        cabal-ver: ['3.10']
 
     env:
       ARGS: "--disable-executable-profiling --disable-library-profiling"

--- a/src/github/workflows/haddock.yml
+++ b/src/github/workflows/haddock.yml
@@ -25,8 +25,8 @@ jobs:
         # not for the virtual environments, and also haskell/action/setup
         # is usually not up-to-date.
         os: [ubuntu-22.04]
-        ghc-ver: ['9.4.4']
-        cabal-ver: ['3.8']
+        ghc-ver: ['9.6.1']
+        cabal-ver: ['3.10']
           # Use the versions the come with the virtual environment, if possible.
 
     if: |


### PR DESCRIPTION
- bump `base`, `unix-compat`, `strict`
- bump cabal CIs to GHC 9.6.1 and cabal 3.10
- remove `star-is-type` problem in `MAlonzo/RTE.hs`
- work around
  * https://github.com/haskell/actions/issues/210

Fixes #6521 
- #6521