### PR TITLE
GH: Use Cabal 3.10 for the cabal-install job

### DIFF
--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -24,9 +24,14 @@ jobs:
     env:
       FLAGS: -O0 -f enable-cluster-counting
     needs: auto-cancel
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
+    - id: setup-haskell
+      uses: haskell/actions/setup@v2
+      with:
+        cabal-version: ${{ matrix.cabal-ver }}
+        ghc-version: ${{ matrix.ghc-ver }}
     - name: Environment settings based on the Haskell setup
       run: |
         export GHC_VER=$(ghc --numeric-version)
@@ -56,6 +61,15 @@ jobs:
     - name: Install Agda
       run: |
         cabal install ${FLAGS}
+    strategy:
+      fail-fast: false
+      matrix:
+        cabal-ver:
+        - 3.10.1.0
+        ghc-ver:
+        - 9.6.1
+        os:
+        - ubuntu-latest
     timeout-minutes: 60
 name: Install (v2-cabal)
 'on':

--- a/src/github/workflows/cabal-install.yml
+++ b/src/github/workflows/cabal-install.yml
@@ -40,19 +40,17 @@ jobs:
 
     timeout-minutes: 60
 
-    runs-on: ubuntu-latest
-
     ## Use preinstalled GHC and Cabal
     #
-    # runs-on: ${{ matrix.os }}
-    # strategy:
-    #   fail-fast: false
-    #   matrix:
-    #     os:
-    #       - ubuntu-22.04
-    #     ghc-ver: ['9.4.4']
-    #     cabal-ver: ['3.8']
-    #       # Use the versions preinstalled in the virtual environment, if possible.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ghc-ver: ['9.6.1']
+        cabal-ver: ['3.10.1.0']
+        # Use the versions preinstalled in the virtual environment, if possible.
 
     env:
       FLAGS: "-O0 -f enable-cluster-counting"
@@ -65,11 +63,11 @@ jobs:
     ## In case the ubuntu-22.04 environment moves GHC beyond
     ## what Agda supports, bring back the setup action.
     #
-    # - uses: haskell/actions/setup@v2
-    #   id: setup-haskell
-    #   with:
-    #     ghc-version: ${{ matrix.ghc-ver }}
-    #     cabal-version: ${{ matrix.cabal-ver }}
+    - uses: haskell/actions/setup@v2
+      id: setup-haskell
+      with:
+        ghc-version: ${{ matrix.ghc-ver }}
+        cabal-version: ${{ matrix.cabal-ver }}
 
     - name: Environment settings based on the Haskell setup
       run: |


### PR DESCRIPTION
Cherry-picked from #6544, otherwise cabal-install silently adds a bound `Cabal ≤ 3.8` which conflicts with GHC 9.6's included Cabal-3.10.