### PR TITLE
Allow preventing Agda input method from resizing the minibuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,4 +79,23 @@ For 2.6.5, the following issues were also
 [closed](https://github.com/agda/agda/issues?q=is%3Aissue+milestone%3A2.6.5+is%3Aclosed)
 (see [bug tracker](https://github.com/agda/agda/issues)):
 
-NOTE: This section will be filled by output produced with `closed-issues-for-milestone 2.6.5`.
+* Helper function (`C-c C-h`) does not abstract over module parameters anymore
+  (see [#2271](https://github.com/agda/agda/issues/2271)).
+
+* New user option `agda-input-single-line` allows instructing the Agda
+  input method from resizing the minibuffer.
+
+Cubical Agda
+------------
+
+* Cubical Agda will now report boundary information for interaction
+  points which are not at the top-level of their respective clauses.
+  This includes bodies of `Path`-typed values, the faces of a partial
+  element, arguments to functions returning paths, etc.
+
+  Since this information is available in a structured way _during
+  interaction_, the "goal type, context, and inferred type" command will
+  also display the value of the expression at each relevant face.
+
+  See also [PR #6529](https://github.com/agda/agda/pull/6529) for a
+  deeper explanation and a demo video.

--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -1433,5 +1433,29 @@ Suitable for use in the :set field of `defcustom'."
 
 (agda-input-setup)
 
+;; Fix unintentional resizing of minibuffer:
+
+(defun agda-input--fix-quail-newline (arglist)
+  "Argument-filtering advice for `quail-minibuffer-message'.
+This function takes the argument list ARGLIST before it is
+applied to `quail-minibuffer-message', and makes sure the first
+and only argument has no newline.  This only has an effect if the
+Agda input method is active."
+  (if (equal current-input-method "Agda")
+      (list (replace-regexp-in-string "\n" " " (car arglist)))
+    arglist))
+
+(defcustom agda-input-single-line nil
+  "Avoid the Agda input method from resizing the minibuffer."
+  :set (lambda (var val)
+         (if val
+             (advice-add 'quail-minibuffer-message :filter-args
+                         #'agda-input--fix-quail-newline)
+           (advice-remove 'quail-minibuffer-message
+                          #'agda-input--fix-quail-newline))
+         (custom-set-default var val))
+  :initialize #'custom-initialize-set
+  :type 'boolean)
+
 (provide 'agda-input)
 ;;; agda-input.el ends here


### PR DESCRIPTION
By default, when the Agda input method is active in the minibuffer Emacs adds a newline for the "Quail guidance string".  The result is that the minibuffer is resized.

I am not sure if it is only me who doesn't like this behavior, but I think there should be an option to disable it.  Sadly there is no direct way to do this, but since the code in core has not been touched in almost 20 years, advising the proper functions is a legitimate solution for the problem.  This hack only affects the Agda input method, so we could also enable it by default.

This change is not related to #6123.