### PR TITLE
Add support for Emacs 28's `repeat-mode` for working with Holes

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -220,6 +220,29 @@ constituents.")
     m)
   "Bindings for `agda2-mode'.")
 
+(defvar agda2-movement-repeat-map
+  (let ((m (make-sparse-keymap)))
+    (define-key m (kbd "C-f")   #'agda2-next-goal)
+    (define-key m (kbd "C-b")   #'agda2-previous-goal)
+    (define-key m (kbd "C-SPC") #'agda2-give)
+    (define-key m (kbd "C-r")   #'agda2-refine)
+    (define-key m (kbd "C-c")   #'agda2-make-case)
+    (define-key m (kbd "C-,")   #'agda2-goal-and-context)
+    (define-key m (kbd "C-.")   #'agda2-goal-and-context-and-inferred)
+    (define-key m (kbd "C-;")   #'agda2-goal-and-context-and-checked)
+    m)
+  "Agda bindings to repeat in conjunction with `repeat-mode'.")
+
+(dolist (command '(agda2-next-goal
+                   agda2-previous-goal
+                   agda2-give
+                   agda2-refine
+                   agda2-make-case
+                   agda2-goal-and-context
+                   agda2-goal-and-context-and-inferred
+                   agda2-goal-and-context-and-checked))
+  (put command 'repeat-map agda2-movement-repeat-map))
+
 (defvar agda2-common-menu-items
   '(["Solve constraints" agda2-solve-maybe-all]
     ["Auto" agda2-auto-maybe-all]


### PR DESCRIPTION
Emacs 28 has a global minor mode called `repeat-mode` that allows commands to define temporary keymaps that should be enabled right after the command was invoked.  One example: `other-window` (<kbd>C-x o</kbd>) can be repeated with a single <kbd>o</kbd>, without the <kbd>C-x</kbd> prefix when the mode is enabled.

I proposed adding some basic support for Agda-mode as well.  The commands are defined in `agda2-movement-repeat-map` and the keys are just abbreviations of the default bindings.  This means that if `repeat-mode` is enabled, you can now step through the holes in a file by just pressing <kbd>C-f</kbd>.  I have currently implemented it in a way that you can switch back and forth between navigation, manipulation (case, refining, give) and querying.  If this is not considered to be a good idea, we can also split it up into disjunct repeat maps.

This was initially unintentionally incorrectly part of  #6536, but I have adjusted that pull request and extracted the changes into this one.