### PR TITLE
don't use `\x` in docstring (`agda-input.el`)

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -53,11 +53,11 @@ removing all space and newline characters."
 ;; Functions used to tweak translation pairs
 
 (defun agda-input-compose (f g)
-  "\x -> concatMap F (G x)"
+  "λ x -> concatMap F (G x)"
     (lambda (x) (agda-input-concat-map f (funcall g x))))
 
 (defun agda-input-or (f g)
-  "\x -> F x ++ G x"
+  "λ x -> F x ++ G x"
     (lambda (x) (append (funcall f x) (funcall g x))))
 
 (defun agda-input-nonempty ()


### PR DESCRIPTION
Emacs now enforces stricter escape syntax in docstrings. These two functions will break once the new emacs release lands in the near future. A trivial fix is to just not use the slash to represent λ.  
See https://github.com/HOL-Theorem-Prover/HOL/commit/e9e9506209e82b8037b8a4066b7fd672e961c08a and https://lists.gnu.org/archive/html/emacs-devel/2023-03/msg00867.html.