### PR TITLE
Option --version: also print cabal flags used in the build

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -194,6 +194,8 @@ custom-setup
 common language
 
   if flag(optimise-heavily)
+    cpp-options:
+      -DOPTIMISE_HEAVILY
     ghc-options:
       -fexpose-all-unfoldings
       -fspecialise-aggressively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,9 @@ Pragmas and options
 
 * New command-line option `--numeric-version` to just print the version number of Agda.
 
+* Option `--version` now also prints the cabal flags active in this build of Agda
+  (e.g. whether Agda was built with `-f enable-cluster-counting`).
+
 * New command-line option `--trace-imports` to switch on notification messages
   on the end of compilation of an imported module
   or on access to an interface file during the type-checking.

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 
 {-| Agda main module.
 -}
@@ -261,9 +262,25 @@ printVersion :: [Backend] -> PrintAgdaVersion -> IO ()
 printVersion _ PrintAgdaNumericVersion = putStrLn versionWithCommitInfo
 printVersion backends PrintAgdaVersion = do
   putStrLn $ "Agda version " ++ versionWithCommitInfo
+  unless (null flags) $
+    mapM_ putStrLn $ ("Built with flags (cabal -f)" :) $ map bullet flags
   mapM_ putStrLn
-    [ "  - " ++ name ++ " backend version " ++ ver
+    [ bullet $ name ++ " backend version " ++ ver
     | Backend Backend'{ backendName = name, backendVersion = Just ver } <- backends ]
+  where
+  bullet = (" - " ++)
+  -- Print cabal flags that were involved in compilation.
+  flags =
+#ifdef COUNT_CLUSTERS
+    "enable-cluster-counting: unicode cluster counting in LaTeX backend using the ICU library" :
+#endif
+#ifdef OPTIMISE_HEAVILY
+    "optimise-heavily: extra optimizations" :
+#endif
+#ifdef DEBUG
+    "debug: extra debug info" :
+#endif
+    []
 
 printAgdaDir :: IO ()
 printAgdaDir = putStrLn =<< getDataDir


### PR DESCRIPTION
Option `--version` now also prints cabal flags used in the build:
```shell-session
$ agda --version
Agda version 2.6.4-f4a3e72-dirty
Built with flags (cabal -f)
 - enable-cluster-counting: unicode cluster counting in LaTeX backend using the ICU library
 - optimise-heavily: extra optimizations
```