### PR TITLE
Replace genericDocError errors in checkArgs for specific ones

### DIFF
--- a/test/Fail/Issue1202.err
+++ b/test/Fail/Issue1202.err
@@ -1,3 +1,4 @@
 Issue1202.agda:7,10-11
-Too many arguments to constructor c
+The constructor c expects 2 arguments (including hidden ones), but
+has been given 3 (including hidden ones)
 when checking that the pattern c a b has type D A

--- a/test/Fail/Issue2935.err
+++ b/test/Fail/Issue2935.err
@@ -1,4 +1,4 @@
 Issue2935.agda:9,5-8
-Too few arguments to constructor suc, expected 1 more explicit
-argument
+The constructor suc expects 1 arguments (including hidden ones),
+but has been given 0 (including hidden ones)
 when checking that the pattern suc has type ℕ

--- a/test/Fail/Issue3074.err
+++ b/test/Fail/Issue3074.err
@@ -1,3 +1,3 @@
 Issue3074.agda:11,13-14
-Expected an explicit argument instead of implicit argument {x}
+Unexpected implicit argument
 when checking that the pattern box {x} has type Box

--- a/test/Fail/WrongNumberOfConstructorArguments.err
+++ b/test/Fail/WrongNumberOfConstructorArguments.err
@@ -1,3 +1,4 @@
 WrongNumberOfConstructorArguments.agda:9,9-10
-Too many arguments to constructor zero
+The constructor zero expects 0 arguments (including hidden ones),
+but has been given 1 (including hidden ones)
 when checking that the pattern zero n has type Nat


### PR DESCRIPTION
`GenericDocError`-s were replaced with more specific ones, `WrongHidingInLHS` for wrong hidings, and `WrongNumberOfConstructorArguments` for wrong number of arguments.

Function `checkArgs` now takes additional two accumulator parameters, for purpose of counting arguments for `WrongNumberOfConstructorArguments` errors.