### PR TITLE
Replace genericDocError error for MismatchedProjectionsError in compareElims

### DIFF
--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1011,7 +1011,7 @@ compareElims pols0 fors0 a v els01 els02 =
 
     -- case: f == f' are projections
     (Proj o f : els1, Proj _ f' : els2)
-      | f /= f'   -> typeError . GenericDocError =<< prettyTCM f <+> "/=" <+> prettyTCM f'
+      | f /= f'   -> typeError $ MismatchedProjectionsError f f'
       | otherwise -> do
         a   <- abortIfBlocked a
         res <- projectTyped v a o f -- fails only if f is proj.like but parameters cannot be retrieved

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -272,6 +272,7 @@ errorString err = case err of
   SortOfSplitVarError{}                    -> "SortOfSplitVarError"
   ReferencesFutureVariables{}              -> "ReferencesFutureVariables"
   DoesNotMentionTicks{}                    -> "DoesNotMentionTicks"
+  MismatchedProjectionsError{}             -> "MismatchedProjectionsError"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1271,6 +1272,12 @@ instance PrettyTCM TypeError where
         , nest 2 (prettyTCM term <+> ":" <+> prettyTCM ty)
         , fsep (pwords ("can not be used as a " ++ mod ++ " argument, since it does not mention any " ++ mod ++ " variables."))
         ]
+
+    MismatchedProjectionsError left right -> fsep $
+      pwords "The projections" ++ [prettyTCM left] ++
+      pwords "and" ++ [prettyTCM right] ++
+      pwords "do not match"
+
     where
     mpar n args
       | n > 0 && not (null args) = parens

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4416,6 +4416,7 @@ data TypeError
         | DoesNotMentionTicks Term Type (Arg Term)
           -- ^ Arguments: later term, its type, lock term. The lock term
           -- does not mention any @lock variables.
+        | MismatchedProjectionsError QName QName
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/test/Fail/Issue933.err
+++ b/test/Fail/Issue933.err
@@ -1,3 +1,3 @@
 Issue933.agda:20,38-47
-RGraph.R /= RGraph.O
+The projections RGraph.R and RGraph.O do not match
 when checking that the expression Γ.refl γo has type Γ.O


### PR DESCRIPTION
`GenericDocError` was replaced with the new `MismatchedProjectionsError` in function `compareElims`.

Type error `MismatchedProjectionsError` was added. It takes two arguments of type `QName`, representing names of projections that caused the error.