### PR TITLE
Provide a way to escape the current context in reflection

### DIFF
--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -65,7 +65,7 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinAgdaTCMTypeError, builtinAgdaTCMInferType,
   builtinAgdaTCMCheckType, builtinAgdaTCMNormalise, builtinAgdaTCMReduce,
   builtinAgdaTCMCatchError,
-  builtinAgdaTCMGetContext, builtinAgdaTCMExtendContext, builtinAgdaTCMInContext,
+  builtinAgdaTCMGetContext, builtinAgdaTCMExtendContext, builtinAgdaTCMInContext, builtinAgdaTCMInTopContext,
   builtinAgdaTCMFreshName, builtinAgdaTCMDeclareDef, builtinAgdaTCMDeclarePostulate, builtinAgdaTCMDeclareData, builtinAgdaTCMDefineData, builtinAgdaTCMDefineFun,
   builtinAgdaTCMGetType, builtinAgdaTCMGetDefinition,
   builtinAgdaTCMQuoteTerm, builtinAgdaTCMUnquoteTerm, builtinAgdaTCMQuoteOmegaTerm,
@@ -266,6 +266,7 @@ builtinAgdaTCMCatchError                 = "AGDATCMCATCHERROR"
 builtinAgdaTCMGetContext                 = "AGDATCMGETCONTEXT"
 builtinAgdaTCMExtendContext              = "AGDATCMEXTENDCONTEXT"
 builtinAgdaTCMInContext                  = "AGDATCMINCONTEXT"
+builtinAgdaTCMInTopContext               = "AGDATCMINTOPCONTEXT"
 builtinAgdaTCMFreshName                  = "AGDATCMFRESHNAME"
 builtinAgdaTCMDeclareDef                 = "AGDATCMDECLAREDEF"
 builtinAgdaTCMDeclarePostulate           = "AGDATCMDECLAREPOSTULATE"

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -238,7 +238,7 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primAgdaTCM, primAgdaTCMReturn, primAgdaTCMBind, primAgdaTCMUnify,
     primAgdaTCMTypeError, primAgdaTCMInferType, primAgdaTCMCheckType,
     primAgdaTCMNormalise, primAgdaTCMReduce,
-    primAgdaTCMCatchError, primAgdaTCMGetContext, primAgdaTCMExtendContext, primAgdaTCMInContext,
+    primAgdaTCMCatchError, primAgdaTCMGetContext, primAgdaTCMExtendContext, primAgdaTCMInContext, primAgdaTCMInTopContext,
     primAgdaTCMFreshName, primAgdaTCMDeclareDef, primAgdaTCMDeclarePostulate, primAgdaTCMDeclareData, primAgdaTCMDefineData, primAgdaTCMDefineFun,
     primAgdaTCMGetType, primAgdaTCMGetDefinition,
     primAgdaTCMQuoteTerm, primAgdaTCMUnquoteTerm, primAgdaTCMQuoteOmegaTerm,
@@ -435,6 +435,7 @@ primAgdaTCMCatchError                 = getBuiltin builtinAgdaTCMCatchError
 primAgdaTCMGetContext                 = getBuiltin builtinAgdaTCMGetContext
 primAgdaTCMExtendContext              = getBuiltin builtinAgdaTCMExtendContext
 primAgdaTCMInContext                  = getBuiltin builtinAgdaTCMInContext
+primAgdaTCMInTopContext               = getBuiltin builtinAgdaTCMInTopContext
 primAgdaTCMFreshName                  = getBuiltin builtinAgdaTCMFreshName
 primAgdaTCMDeclareDef                 = getBuiltin builtinAgdaTCMDeclareDef
 primAgdaTCMDeclarePostulate           = getBuiltin builtinAgdaTCMDeclarePostulate

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -374,6 +374,8 @@ coreBuiltins =
                                                                    tstring --> targ ttype --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMInContext                  |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
                                                                    ttelescope --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+  , builtinAgdaTCMInTopContext               |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
+                                                                   ttelescope --> tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMFreshName                  |-> builtinPostulate (tstring --> tTCM_ primQName)
   , builtinAgdaTCMDeclareDef                 |-> builtinPostulate (targ tqname --> ttype --> tTCM_ primUnit)
   , builtinAgdaTCMDeclarePostulate           |-> builtinPostulate (targ tqname --> ttype --> tTCM_ primUnit)

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -617,6 +617,7 @@ evalTCM v = do
              , (f `isDef` primAgdaTCMWithExpandLast,    tcWithExpandLast (unElim u) (unElim v))
              , (f `isDef` primAgdaTCMWithReduceDefs,    tcWithReduceDefs (unElim u) (unElim v))
              , (f `isDef` primAgdaTCMInContext,         tcInContext     (unElim u) (unElim v))
+             , (f `isDef` primAgdaTCMInTopContext,      tcInTopContext  (unElim u) (unElim v))
              ]
              failEval
     I.Def f [_, _, u, v, w] ->
@@ -844,6 +845,15 @@ evalTCM v = do
     tcInContext c m = do
       c <- unquote c
       inOriginalContext $ go c (evalTCM m)
+      where
+        go :: [(Text , Arg R.Type)] -> UnquoteM Term -> UnquoteM Term
+        go []             m = m
+        go ((s , a) : as) m = go as (extendCxt s a m)
+
+    tcInTopContext :: Term -> Term -> UnquoteM Term
+    tcInTopContext c m = do
+      c <- unquote c
+      inTopContext $ go c (evalTCM m)
       where
         go :: [(Text , Arg R.Type)] -> UnquoteM Term -> UnquoteM Term
         go []             m = m


### PR DESCRIPTION
Forked from https://github.com/agda/agda/issues/6009#issuecomment-1501781092

@jespercockx says:

> Perhaps it would make sense to instead expose escapeContext as a new primitive?

Taken at face value, this isn't enough: `escapeContext $ inContext ctx m` would still revert to the original context. We'd need to also replace `inContext` with `addContext` and expose `inOriginalContext` separately, or something.