### PR TITLE
Do final checks before freezing metas

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -220,14 +220,13 @@ checkDecl d = setCurrentRange d $ do
         checkingWhere <- asksTC envCheckingWhere
         solveSizeConstraints $ if checkingWhere then DontDefaultToInfty else DefaultToInfty
         wakeupConstraints_   -- Size solver might have unblocked some constraints
+        theMutualChecks
 
         case d of
           A.Generalize{} -> pure ()
           _ -> do
             reportSLn "tc.decl" 20 $ "Freezing all open metas."
             void $ freezeMetas (openMetas metas)
-
-        theMutualChecks
 
     where
 

--- a/test/Fail/Issue5848.err
+++ b/test/Fail/Issue5848.err
@@ -3,13 +3,6 @@ warning: -W[no]ConfluenceCheckingIncompleteBecauseOfMeta
 Confluence checking incomplete because the definition of l1
 contains unsolved metavariables.
 when checking the definition of l1
-Failed to solve the following constraints:
-  ?2 = ?3 (i = Agda.Primitive.Cubical.i1)
-    : ?0 Agda.Primitive.Cubical.i1
-    (blocked on any(_4, _5))
-  ?1 = ?3 (i = Agda.Primitive.Cubical.i0)
-    : ?0 Agda.Primitive.Cubical.i0
-    (blocked on any(_3, _5))
 Unsolved metas at the following locations:
   Issue5848.agda:5,6-11
 Unsolved interaction metas at the following locations:


### PR DESCRIPTION
Forked from https://github.com/agda/agda/issues/6009#issuecomment-1501781092

@jespercockx says:

> I don't see any immediate negative effects of doing this, but I'd want to check with @UlfNorell or @andreasabel first. We did have some discussions in the past on the desirability of having the definition of a function affect the metavariables from its type signature, but this a separate concern (though it could mean that your example is not guaranteed to keep working in future versions of Agda).