### PR TITLE
Coerce `unquote` applications

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -203,18 +203,17 @@ checkApplication cmp hd args e t =
           -- Example: unquote v a b : A
           --  Create meta H : (x : X) (y : Y x) → Z x y for the hole
           --  Check a : X, b : Y a
-          --  Unify Z a b == A
           --  Run the tactic on H
+          --  Check H a b : A
           tel    <- metaTel args                    -- (x : X) (y : Y x)
-          target <- addContext tel newTypeMeta_      -- Z x y
+          target <- addContext tel newTypeMeta_     -- Z x y
           let holeType = telePi_ tel target         -- (x : X) (y : Y x) → Z x y
           (Just vs, EmptyTel) <- mapFst allApplyElims <$> checkArguments_ CmpLeq ExpandLast (getRange args) args tel
                                                     -- a b : (x : X) (y : Y x)
-          let rho = reverse (map unArg vs) ++# IdS  -- [x := a, y := b]
-          equalType (applySubst rho target) t       -- Z a b == A
           (_, hole) <- newValueMeta RunMetaOccursCheck CmpLeq holeType
           unquoteM (namedArg arg) hole holeType
-          return $ apply hole vs
+          let rho = reverse (map unArg vs) ++# IdS  -- [x := a, y := b]
+          coerce CmpEq (apply hole vs) (applySubst rho target) t -- H a b : A
       where
         metaTel :: [Arg a] -> TCM Telescope
         metaTel []           = pure EmptyTel


### PR DESCRIPTION
Forked from https://github.com/agda/agda/issues/6009#issuecomment-1501781092

@jespercockx says:

> I think using coerce here actually more sensible than equalType, since it will also work with subtyping (e.g. --sized-types or --cumulativity).