### PR TITLE
Aggressively inline VALU typeclass methods

### DIFF
--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -428,18 +428,20 @@ class VALU t b where
                Proxy t -> Node -> Maybe (Products (Constant Int32 (Domains t)))
 
 instance VALU t 'True where
-
+  {-# INLINE valuN' #-}
   valuN' c () = return c
 
+  {-# INLINE valueArgs #-}
   valueArgs _ xs = case xs of
     [] -> Just ()
     _  -> Nothing
 
 
 instance VALU t (IsBase t) => VALU (a -> t) 'False where
-
+  {-# INLINE valuN' #-}
   valuN' c (a, as) = value a >>= \ v -> valuN' (c v) as
 
+  {-# INLINE valueArgs #-}
   valueArgs _ xs = case xs of
     (x : xs') -> (x,) <$> valueArgs (Proxy :: Proxy t) xs'
     _         -> Nothing


### PR DESCRIPTION
This aggressively inlines `VALU` typeclass methods. This is the smallest change with the biggest impact, so may be the only change worth pulling. This reduces allocations by 20%, resulting in a corresponding 20% reduction in deserialisation time.
