### PR TITLE
Encode enums as "raw" ints, rather than a node

### DIFF
--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20230313 * 10 + 0
+currentInterfaceVersion = 20230412 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -189,10 +189,14 @@ class Typeable a => EmbPrj a where
 
   -- Simple enumeration types can be (de)serialized using (from/to)Enum.
 
-  default value :: (Enum a) => Int32 -> R a
-  value i = liftIO (evaluate (toEnum (fromIntegral i))) `catchAll` const malformed
+  default value :: (Enum a, Bounded a) => Int32 -> R a
+  value i =
+    let i' = fromIntegral i in
+    if i' >= fromEnum (minBound :: a) && i' <= fromEnum (maxBound :: a)
+    then pure (toEnum i')
+    else malformed
 
-  default icod_ :: (Enum a) => a -> S Int32
+  default icod_ :: (Enum a, Bounded a) => a -> S Int32
   icod_ = return . fromIntegral . fromEnum
 
 -- | Increase entry for @a@ in 'stats'.

--- a/src/full/Agda/TypeChecking/Serialise/Instances.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances.hs
@@ -28,8 +28,5 @@ instance EmbPrj Interface where
       icodeN' interface a b c (fromImportedModules d) e f g h i j k l m n o p q r s t u v
     where interface a b c = Interface a b c . toImportedModules
 
-  value = vcase valu where
-    valu [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v] =
-        valuN interface a b c d e f g h i j k l m n o p q r s t u v
-      where interface a b c = Interface a b c . toImportedModules
-    valu _ = malformed
+  value = valueN interface
+    where interface a b c = Interface a b c . toImportedModules

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -30,35 +30,35 @@ instance EmbPrj Scope where
   value = valueN Scope
 
 instance EmbPrj DataOrRecordModule where
-  icod_ IsDataModule   = icodeN' IsDataModule
-  icod_ IsRecordModule = icodeN 0 IsRecordModule
+  icod_ IsDataModule   = pure 0
+  icod_ IsRecordModule = pure 1
 
-  value = vcase $ \case
-    []  -> valuN IsDataModule
-    [0] -> valuN IsRecordModule
-    _   -> malformed
+  value = \case
+    0 -> pure IsDataModule
+    1 -> pure IsRecordModule
+    _ -> malformed
 
 instance EmbPrj NameSpaceId where
-  icod_ PublicNS        = icodeN' PublicNS
-  icod_ PrivateNS       = icodeN 1 PrivateNS
-  icod_ ImportedNS      = icodeN 2 ImportedNS
+  icod_ PublicNS        = pure 0
+  icod_ PrivateNS       = pure 1
+  icod_ ImportedNS      = pure 2
 
-  value = vcase valu where
-    valu []  = valuN PublicNS
-    valu [1] = valuN PrivateNS
-    valu [2] = valuN ImportedNS
-    valu _   = malformed
+  value = \case
+    0 -> pure PublicNS
+    1 -> pure PrivateNS
+    2 -> pure ImportedNS
+    _ -> malformed
 
 instance EmbPrj Access where
-  icod_ (PrivateAccess UserWritten) = icodeN 0 ()
-  icod_ PrivateAccess{}             = icodeN 1 ()
-  icod_ PublicAccess                = icodeN' PublicAccess
+  icod_ (PrivateAccess UserWritten) = pure 0
+  icod_ PrivateAccess{}             = pure 1
+  icod_ PublicAccess                = pure 2
 
-  value = vcase valu where
-    valu [0] = valuN $ PrivateAccess UserWritten
-    valu [1] = valuN $ PrivateAccess Inserted
-    valu []  = valuN PublicAccess
-    valu _   = malformed
+  value = \case
+    0 -> pure $ PrivateAccess UserWritten
+    1 -> pure $ PrivateAccess Inserted
+    2 -> pure PublicAccess
+    _ -> malformed
 
 instance EmbPrj NameSpace where
   icod_ (NameSpace a b c) = icodeN' NameSpace a b c
@@ -143,17 +143,17 @@ instance EmbPrj KindOfName where
   --   valu _   = malformed
 
 instance EmbPrj BindingSource where
-  icod_ LambdaBound   = icodeN' LambdaBound
-  icod_ PatternBound  = icodeN 1 PatternBound
-  icod_ LetBound      = icodeN 2 LetBound
-  icod_ WithBound     = icodeN 3 WithBound
+  icod_ LambdaBound   = pure 0
+  icod_ PatternBound  = pure 1
+  icod_ LetBound      = pure 2
+  icod_ WithBound     = pure 3
 
-  value = vcase valu where
-    valu []  = valuN LambdaBound
-    valu [1] = valuN PatternBound
-    valu [2] = valuN LetBound
-    valu [3] = valuN WithBound
-    valu _   = malformed
+  value = \case
+    0 -> pure LambdaBound
+    1 -> pure PatternBound
+    2 -> pure LetBound
+    3 -> pure WithBound
+    _ -> malformed
 
 instance EmbPrj LocalVar where
   icod_ (LocalVar a b c)  = icodeN' LocalVar a b c

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -109,11 +109,10 @@ instance EmbPrj Void where
   value = vcase valu where valu _ = malformed
 
 instance EmbPrj () where
-  icod_ () = icodeN' ()
+  icod_ () = pure 0
 
-  value = vcase valu where
-    valu [] = valuN ()
-    valu _  = malformed
+  value 0 = pure ()
+  value _ = malformed
 
 instance (EmbPrj a, EmbPrj b) => EmbPrj (a, b) where
   icod_ (a, b) = icodeN' (,) a b
@@ -153,28 +152,27 @@ instance EmbPrj a => EmbPrj (Strict.Maybe a) where
   value m = Strict.toStrict `fmap` value m
 
 instance EmbPrj Bool where
-  icod_ True  = icodeN' True
-  icod_ False = icodeN 0 False
+  icod_ False = pure 0
+  icod_ True  = pure 1
 
-  value = vcase valu where
-    valu []  = valuN True
-    valu [0] = valuN False
-    valu _   = malformed
+  value 0 = pure False
+  value 1 = pure True
+  value _ = malformed
 
 instance EmbPrj FileType where
-  icod_ AgdaFileType = icodeN'  AgdaFileType
-  icod_ MdFileType   = icodeN 0 MdFileType
-  icod_ RstFileType  = icodeN 1 RstFileType
-  icod_ TexFileType  = icodeN 2 TexFileType
-  icod_ OrgFileType  = icodeN 3 OrgFileType
+  icod_ AgdaFileType = pure 0
+  icod_ MdFileType   = pure 1
+  icod_ RstFileType  = pure 2
+  icod_ TexFileType  = pure 3
+  icod_ OrgFileType  = pure 4
 
-  value = vcase $ \case
-    []  -> valuN AgdaFileType
-    [0] -> valuN MdFileType
-    [1] -> valuN RstFileType
-    [2] -> valuN TexFileType
-    [3] -> valuN OrgFileType
-    _   -> malformed
+  value = \case
+    0 -> pure AgdaFileType
+    1 -> pure MdFileType
+    2 -> pure RstFileType
+    3 -> pure TexFileType
+    4 -> pure OrgFileType
+    _ -> malformed
 
 instance EmbPrj Cubical where
   icod_ CErased = icodeN'  CErased
@@ -366,15 +364,15 @@ instance (EmbPrj a, EmbPrj b) => EmbPrj (ImportedName' a b) where
     valu _ = malformed
 
 instance EmbPrj Associativity where
-  icod_ LeftAssoc  = icodeN' LeftAssoc
-  icod_ RightAssoc = icodeN 1 RightAssoc
-  icod_ NonAssoc   = icodeN 2 NonAssoc
+  icod_ LeftAssoc  = pure 0
+  icod_ RightAssoc = pure 1
+  icod_ NonAssoc   = pure 2
 
-  value = vcase valu where
-    valu []  = valuN LeftAssoc
-    valu [1] = valuN RightAssoc
-    valu [2] = valuN NonAssoc
-    valu _   = malformed
+  value = \case
+    0 -> pure LeftAssoc
+    1 -> pure RightAssoc
+    2 -> pure NonAssoc
+    _ -> malformed
 
 instance EmbPrj FixityLevel where
   icod_ Unrelated   = icodeN' Unrelated

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -310,13 +310,9 @@ instance EmbPrj Range where
 newtype SerialisedRange = SerialisedRange { underlyingRange :: Range }
 
 instance EmbPrj SerialisedRange where
-  icod_ (SerialisedRange r) =
-    icodeN' (undefined :: SrcFile -> [IntervalWithoutFile] -> SerialisedRange)
-            (P.rangeFile r) (P.rangeIntervals r)
+  icod_ (SerialisedRange r) = icodeN' P.intervalsToRange (P.rangeFile r) (P.rangeIntervals r)
 
-  value = vcase valu where
-    valu [a, b] = SerialisedRange <$> valuN P.intervalsToRange a b
-    valu _      = malformed
+  value i = SerialisedRange <$> valueN P.intervalsToRange i
 
 instance EmbPrj C.Name where
   icod_ (C.NoName a b)     = icodeN 0 C.NoName a b
@@ -600,9 +596,7 @@ instance EmbPrj Relevance where
 instance EmbPrj Annotation where
   icod_ (Annotation l) = icodeN' Annotation l
 
-  value = vcase $ \case
-    [l] -> valuN Annotation l
-    _ -> malformed
+  value = valueN Annotation
 
 instance EmbPrj Lock where
   icod_ IsNotLock          = pure 0

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -293,14 +293,10 @@ instance EmbPrj InfectiveCoinfective where
     valu _   = malformed
 
 instance EmbPrj PragmaOptions where
-  icod_ = \case
-    PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm ->
-      icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm
+  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm) =
+    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm
 
-  value = vcase $ \case
-    [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, bb, cc, dd, ee, ff, gg, hh, ii, jj, kk, ll, mm, nn, oo, pp, qq, rr, ss, tt, uu, vv, ww, xx, yy, zz, aaa, bbb, ccc, ddd, eee, fff, ggg, hhh, iii, jjj, kkk, lll, mmm] ->
-      valuN PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm
-    _ -> malformed
+  value = valueN PragmaOptions
 
 instance EmbPrj ProfileOptions where
   icod_ opts = icode (profileOptionsToList opts)
@@ -320,12 +316,9 @@ instance EmbPrj ConfluenceCheck where
     valu _   = malformed
 
 instance EmbPrj WarningMode where
-  icod_ = \case
-    WarningMode a b -> icodeN' WarningMode a b
+  icod_ (WarningMode a b) = icodeN' WarningMode a b
 
-  value = vcase $ \case
-    [a, b]   -> valuN WarningMode a b
-    _ -> malformed
+  value = valueN WarningMode
 
 instance EmbPrj WarningName where
   icod_ = return . \case

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -307,11 +307,6 @@ instance EmbPrj ProfileOptions where
   value = fmap profileOptionsFromList . value
 
 instance EmbPrj ProfileOption where
-  icod_ = icode . fromEnum
-  value = value >=> \ n -> if lo <= n && n <= hi then pure (toEnum n) else malformed
-    where
-      lo = fromEnum (minBound :: ProfileOption)
-      hi = fromEnum (maxBound :: ProfileOption)
 
 instance EmbPrj UnicodeOrAscii
 
@@ -395,7 +390,7 @@ instance EmbPrj WarningName where
     NoGuardednessFlag_                           -> 58
     NotInScope_                                  -> 59
     NotStrictlyPositive_                         -> 60
-    UnsupportedIndexedMatch_                        -> 61
+    UnsupportedIndexedMatch_                     -> 61
     OldBuiltin_                                  -> 62
     PragmaCompileErased_                         -> 63
     RewriteMaybeNonConfluent_                    -> 64

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
@@ -74,39 +74,39 @@ instance EmbPrj HP.Aspect where
     valu _          = malformed
 
 instance EmbPrj HP.OtherAspect where
-  icod_ HP.Error                = icodeN 0 ()
-  icod_ HP.ErrorWarning         = icodeN 1 ()
-  icod_ HP.DottedPattern        = icodeN' HP.DottedPattern
-  icod_ HP.UnsolvedMeta         = icodeN 2 ()
-  icod_ HP.TerminationProblem   = icodeN 3 ()
-  icod_ HP.IncompletePattern    = icodeN 4 ()
-  icod_ HP.TypeChecks           = icodeN 5 ()
-  icod_ HP.UnsolvedConstraint   = icodeN 6 ()
-  icod_ HP.PositivityProblem    = icodeN 7 ()
-  icod_ HP.Deadcode             = icodeN 8 ()
-  icod_ HP.CoverageProblem      = icodeN 9 ()
-  icod_ HP.CatchallClause       = icodeN 10 ()
-  icod_ HP.ConfluenceProblem    = icodeN 11 ()
-  icod_ HP.MissingDefinition    = icodeN 12 ()
-  icod_ HP.ShadowingInTelescope = icodeN 13 ()
+  icod_ HP.Error                = pure 0
+  icod_ HP.ErrorWarning         = pure 1
+  icod_ HP.DottedPattern        = pure 2
+  icod_ HP.UnsolvedMeta         = pure 3
+  icod_ HP.TerminationProblem   = pure 4
+  icod_ HP.IncompletePattern    = pure 5
+  icod_ HP.TypeChecks           = pure 6
+  icod_ HP.UnsolvedConstraint   = pure 7
+  icod_ HP.PositivityProblem    = pure 8
+  icod_ HP.Deadcode             = pure 9
+  icod_ HP.CoverageProblem      = pure 10
+  icod_ HP.CatchallClause       = pure 11
+  icod_ HP.ConfluenceProblem    = pure 12
+  icod_ HP.MissingDefinition    = pure 13
+  icod_ HP.ShadowingInTelescope = pure 14
 
-  value = vcase valu where
-    valu [0] = valuN HP.Error
-    valu [1] = valuN HP.ErrorWarning
-    valu []  = valuN HP.DottedPattern
-    valu [2] = valuN HP.UnsolvedMeta
-    valu [3] = valuN HP.TerminationProblem
-    valu [4] = valuN HP.IncompletePattern
-    valu [5] = valuN HP.TypeChecks
-    valu [6] = valuN HP.UnsolvedConstraint
-    valu [7] = valuN HP.PositivityProblem
-    valu [8] = valuN HP.Deadcode
-    valu [9] = valuN HP.CoverageProblem
-    valu [10] = valuN HP.CatchallClause
-    valu [11] = valuN HP.ConfluenceProblem
-    valu [12] = valuN HP.MissingDefinition
-    valu [13] = valuN HP.ShadowingInTelescope
-    valu _   = malformed
+  value = \case
+    0  -> pure HP.Error
+    1  -> pure HP.ErrorWarning
+    2  -> pure HP.DottedPattern
+    3  -> pure HP.UnsolvedMeta
+    4  -> pure HP.TerminationProblem
+    5  -> pure HP.IncompletePattern
+    6  -> pure HP.TypeChecks
+    7  -> pure HP.UnsolvedConstraint
+    8  -> pure HP.PositivityProblem
+    9  -> pure HP.Deadcode
+    10 -> pure HP.CoverageProblem
+    11 -> pure HP.CatchallClause
+    12 -> pure HP.ConfluenceProblem
+    13 -> pure HP.MissingDefinition
+    14 -> pure HP.ShadowingInTelescope
+    _  -> malformed
 
 instance EmbPrj HP.Aspects where
   icod_ (HP.Aspects a b c d e) = icodeN' HP.Aspects a b c d e
@@ -140,10 +140,10 @@ instance EmbPrj a => EmbPrj (RM.RangeMap a) where
     convert _ _ = malformed
 
 instance EmbPrj HP.TokenBased where
-  icod_ HP.TokenBased        = icodeN 0 ()
-  icod_ HP.NotOnlyTokenBased = icodeN' HP.NotOnlyTokenBased
+  icod_ HP.TokenBased        = pure 0
+  icod_ HP.NotOnlyTokenBased = pure 1
 
-  value = vcase valu where
-    valu [0] = valuN HP.TokenBased
-    valu []  = valuN HP.NotOnlyTokenBased
-    valu _   = malformed
+  value = \case
+    0 -> pure HP.TokenBased
+    1 -> pure HP.NotOnlyTokenBased
+    _ -> malformed

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -427,15 +427,15 @@ instance EmbPrj a => EmbPrj (SplitTree' a) where
     valu _            = malformed
 
 instance EmbPrj FunctionFlag where
-  icod_ FunStatic       = icodeN 0 FunStatic
-  icod_ FunInline       = icodeN 1 FunInline
-  icod_ FunMacro        = icodeN 2 FunMacro
+  icod_ FunStatic       = pure 0
+  icod_ FunInline       = pure 1
+  icod_ FunMacro        = pure 2
 
-  value = vcase valu where
-    valu [0] = valuN FunStatic
-    valu [1] = valuN FunInline
-    valu [2] = valuN FunMacro
-    valu _   = malformed
+  value = \case
+    0 -> pure FunStatic
+    1 -> pure FunInline
+    2 -> pure FunMacro
+    _ -> malformed
 
 instance EmbPrj a => EmbPrj (WithArity a) where
   icod_ (WithArity a b) = icodeN' WithArity a b


### PR DESCRIPTION
This avoids one layer of indirection in serialisation/deserialisation, slightly reducing the allocation rate and CPU time.

## Performance
Numbers were taken using GHC 9.4.3 and testing against an already type-checked version of https://github.com/plt-amy/1lab/commit/bb69dd0df729135e978f302984c0d65abbcfb2b2. Agda was run under `perf stat` and with `--profile=internal +RTS -s -RTS`

<details><summary>master (<code>6206624eef597afea711120110c219e266562a26</code>)</summary>

```
Total                      13,564ms
Miscellaneous                   4ms
Deserialization             9,422ms (13,408ms)
Deserialization.Compaction  3,986ms
Import                        116ms
Parsing                        35ms
  12,231,231,312 bytes allocated in the heap
   4,972,604,800 bytes copied during GC
     619,710,368 bytes maximum residency (24 sample(s))
       1,194,080 bytes maximum slop
            1055 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      2551 colls,     0 par    5.415s   5.426s     0.0021s    0.0207s
  Gen  1        24 colls,     0 par    0.336s   0.337s     0.0140s    0.0350s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    7.850s  (  7.797s elapsed)
  GC      time    5.751s  (  5.763s elapsed)
  EXIT    time    0.001s  (  0.010s elapsed)
  Total   time   13.604s  ( 13.571s elapsed)

  Alloc rate    1,558,042,514 bytes per MUT second

  Productivity  57.7% of total user, 57.5% of total elapsed


 Performance counter stats for '/home/squid/Documents/software/local-copies/agda/dist-newstyle/build/x86_64-linux/ghc-9.4.3/Agda-2.6.4/build/agda/agda _build/all-pages.agda --profile=internal +RTS -s -RTS':

         13,625.22 msec task-clock:u                     #    1.001 CPUs utilized
                 0      context-switches:u               #    0.000 /sec
                 0      cpu-migrations:u                 #    0.000 /sec
           411,508      page-faults:u                    #   30.202 K/sec
    52,848,740,179      cycles:u                         #    3.879 GHz                         (83.13%)
     2,287,938,016      stalled-cycles-frontend:u        #    4.33% frontend cycles idle        (83.32%)
    21,536,235,871      stalled-cycles-backend:u         #   40.75% backend cycles idle         (83.40%)
    69,248,026,539      instructions:u                   #    1.31  insn per cycle
                                                  #    0.31  stalled cycles per insn     (83.38%)
    13,113,978,085      branches:u                       #  962.478 M/sec                       (83.36%)
       295,320,153      branch-misses:u                  #    2.25% of all branches             (83.40%)

      13.616020670 seconds time elapsed

      12.790328000 seconds user
       0.858570000 seconds sys
```

</details>

<details><summary>This commit</summary>

```
Total                      13,388ms           
Miscellaneous                  11ms           
Deserialization             9,041ms (13,251ms)
Deserialization.Compaction  4,209ms           
Import                        108ms           
Parsing                        17ms           
  12,103,302,296 bytes allocated in the heap
   4,930,846,360 bytes copied during GC
     612,042,352 bytes maximum residency (22 sample(s))
       1,542,416 bytes maximum slop
            1087 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      2523 colls,     0 par    5.377s   5.402s     0.0021s    0.0169s
  Gen  1        22 colls,     0 par    0.371s   0.372s     0.0169s    0.0716s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    7.681s  (  7.618s elapsed)
  GC      time    5.747s  (  5.774s elapsed)
  EXIT    time    0.001s  (  0.007s elapsed)
  Total   time   13.431s  ( 13.400s elapsed)

  Alloc rate    1,575,659,199 bytes per MUT second

  Productivity  57.2% of total user, 56.8% of total elapsed


 Performance counter stats for '/home/squid/Documents/software/local-copies/agda/dist-newstyle/build/x86_64-linux/ghc-9.4.3/Agda-2.6.4/build/agda/agda _build/all-pages.agda --profile=internal +RTS -s -RTS':

         13,473.99 msec task-clock:u                     #    1.002 CPUs utilized             
                 0      context-switches:u               #    0.000 /sec                      
                 0      cpu-migrations:u                 #    0.000 /sec                      
           430,910      page-faults:u                    #   31.981 K/sec                     
    51,990,949,231      cycles:u                         #    3.859 GHz                         (83.41%)
     2,059,375,865      stalled-cycles-frontend:u        #    3.96% frontend cycles idle        (83.41%)
    21,527,709,644      stalled-cycles-backend:u         #   41.41% backend cycles idle         (83.48%)
    68,180,447,464      instructions:u                   #    1.31  insn per cycle            
                                                  #    0.32  stalled cycles per insn     (83.44%)
    12,927,895,239      branches:u                       #  959.470 M/sec                       (83.40%)
       294,750,935      branch-misses:u                  #    2.28% of all branches             (82.85%)

      13.452032460 seconds time elapsed

      12.695894000 seconds user
       0.786864000 seconds sys
```

</details>

There's about a 1% reduction in allocations and instruction count. Running with `+RTS -A128 -RTS` shows similar improvements, though obviously with less GC pressure.

My computer is really not set up for benchmarking, and so the CPU time varies wildly. The above numbers are a best of 5 runs.

## Misc notes
`EmbPrj` does include a default implementation for `Enum`s already, which is used in a couple of places. There was some discussion about using them more widely in #5977 - I know there were concerns about forgetting to bump the interface version when changing enums.

It does feel a shame not to use the default methods here, but also I don't really have any good ideas about enforcing bumping the interface version - mostly noting this for context!