### PR TITLE
Only elaborate once for inferred type + boundary

### DIFF
--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -776,8 +776,7 @@ interpret (Cmd_goal_type_context_infer norm ii rng s) = do
             else do
               liftLocalState $ withInteractionId ii $ do
                 parsed <- B.parseExprIn ii rng s
-                typ <- B.typeInMeta ii norm parsed
-                faces <- B.facesInMeta ii norm parsed
+                (typ, faces) <- B.typeAndFacesInMeta ii norm parsed
                 return (GoalAndHave typ faces)
   cmd_goal_type_context_and aux norm ii rng s
 

--- a/test/interaction/Issue6571.agda
+++ b/test/interaction/Issue6571.agda
@@ -1,0 +1,9 @@
+module Issue6571 where
+
+open import Agda.Builtin.Nat
+
+idf : (∀ {A : Set} → A → A) → Nat
+idf f = f 0
+
+_ : Nat → Nat
+_ = λ x → {! idf λ _ → ? !}

--- a/test/interaction/Issue6571.in
+++ b/test/interaction/Issue6571.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 0 (cmd_goal_type_context_infer Normalised) "idf λ _ → ?"

--- a/test/interaction/Issue6571.out
+++ b/test/interaction/Issue6571.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : Nat " nil)
+((last . 1) . (agda2-goals-action '(0)))
+(agda2-status-action "")
+(agda2-info-action "*Goal type etc.*" "Goal: Nat Have: Nat ———————————————————————————————————————————————————————————— x : Nat" nil)


### PR DESCRIPTION
Re-using the same abstract expression, with the same interaction point numbers, will fail elaboration the second time around, as long as the elaborator has generated fresh names *during elaboration of the interaction point* (e.g. for implicit insertion). Fixed by elaborating only once, in "typesAndFacesInMeta".

Fixes #6571. 