### PR TITLE
Treat no-eta pattern records as data types in transp

### DIFF
--- a/test/Succeed/Issue6581.agda
+++ b/test/Succeed/Issue6581.agda
@@ -1,6 +1,7 @@
 {-# OPTIONS --safe --cubical #-}
 module Issue6581 where
 
+open import Agda.Builtin.Cubical.Sub
 open import Agda.Primitive.Cubical
 open import Agda.Builtin.Equality
 open import Agda.Builtin.Nat
@@ -15,11 +16,20 @@ record Σ (A : Set) (P : A → Set) : Set where
 
 open Σ public
 
-test : Σ Nat (λ _ → Nat)
-test = primTransp (λ _ → Σ Nat (λ _ → Nat)) i0 (zero , zero)
-
-f : Σ Nat (λ _ → Nat) → Nat
+f : ∀ {A P} → Σ A P → A
 f (x , y) = x
 
-_ : f test ≡ zero
-_ = refl -- f (primTransp (λ _ → Σ Nat (λ _ → Nat)) i0 (zero , zero)) != zeroodule Test9 where
+_ : f (primTransp (λ _ → Σ Nat (λ _ → Nat)) i0 (zero , zero)) ≡ zero
+_ = refl
+
+module
+  _ {A : Set} {P : A → Set} (φ : I)
+    (uf : I → Partial φ A) (us : (i : I) → PartialP φ (λ .o → P (uf i o) ))
+    (u0f : Sub A φ (uf i0)) (u0s : Sub (P (primSubOut u0f)) φ λ { (φ = i1) → us i0 itIsOne })
+  where
+
+  test : Σ A P
+  test = primHComp {A = Σ A P} {φ = φ} (λ i .o → uf i o , us i o) (primSubOut u0f , primSubOut u0s)
+
+  _ : f test ≡ primComp (λ _ → A) uf (primSubOut u0f)
+  _ = refl

--- a/test/Succeed/Issue6581.agda
+++ b/test/Succeed/Issue6581.agda
@@ -1,0 +1,25 @@
+{-# OPTIONS --safe --cubical #-}
+module Issue6581 where
+
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+record Σ (A : Set) (P : A → Set) : Set where
+  no-eta-equality
+  pattern
+  constructor _,_
+  field
+    fst : A
+    snd : P fst
+
+open Σ public
+
+test : Σ Nat (λ _ → Nat)
+test = primTransp (λ _ → Σ Nat (λ _ → Nat)) i0 (zero , zero)
+
+f : Σ Nat (λ _ → Nat) → Nat
+f (x , y) = x
+
+_ : f test ≡ zero
+_ = refl -- f (primTransp (λ _ → Σ Nat (λ _ → Nat)) i0 (zero , zero)) != zeroodule Test9 where


### PR DESCRIPTION
(also hcomp). For these records, we use the definition of Kan operations in terms of constructors (re-using the implementation for data types), and hold off on evaluating kan operations until the base is a constructor, to prevent eagerly expanding neutrals.

Fixes #6581.
Report/test case due to @szumixie in 
- #6581.