### PR TITLE
Split --help=warning in benign/severe and sort alphabetically

### DIFF
--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -31,17 +31,18 @@ import Text.Read ( readMaybe )
 import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.HashMap.Strict as HMap
-import Data.List ( stripPrefix, intercalate )
+import Data.List ( stripPrefix, intercalate, partition, sort )
 
 import GHC.Generics (Generic)
 
 import Agda.Utils.Either ( maybeToEither )
+import Agda.Utils.Function
+import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List
 import Agda.Utils.Maybe
 
 import Agda.Utils.Impossible
-import Agda.Utils.Functor
 
 
 -- | A @WarningMode@ has two components: a set of warnings to be displayed
@@ -301,28 +302,37 @@ usageWarning = intercalate "\n"
     \ one of the following:"
   , ""
   , untable (fmap (fst &&& snd . snd) warningSets)
+
   , "Individual benign warnings can be turned on and off by -W Name and\
     \ -W noName, respectively, where Name comes from the following\
-    \ list (warnings marked with 'd' are turned on by default, and 'b'\
-    \ stands for \"benign warning\"):"
+    \ list (warnings marked with 'd' are turned on by default):"
   , ""
-  , untable $ forMaybe [minBound..maxBound] $ \ w ->
-    let wnd = warningNameDescription w in
-    ( warningName2String w
-    , (if w `Set.member` usualWarnings then "d" else " ") ++
-      (if not (w `Set.member` errorWarnings) then "b" else " ") ++
-      " " ++
-      wnd
-    ) <$ guard (not $ null wnd)
+  , warningTable True benign
+
+  , "Error warnings are always on and cannot be turned off:"
+  , ""
+  , warningTable False severe
   ]
 
   where
 
+    (severe, benign) = partition (`Set.member` errorWarnings) [minBound..maxBound]
+
+    warningTable printD ws =
+      untable $ forMaybe ws $ \ w ->
+        let wnd = warningNameDescription w in
+        ( warningName2String w
+        , applyWhen printD ((if w `Set.member` usualWarnings then "d" else " ") ++)
+          " " ++
+          wnd
+        ) <$ guard (not $ null wnd)
+
     untable :: [(String, String)] -> String
     untable rows =
       let len = maximum (map (length . fst) rows) in
-      unlines $ for rows $ \ (hdr, cnt) ->
+      unlines $ for (sort rows) $ \ (hdr, cnt) ->
         concat [ hdr, replicate (1 + len - length hdr) ' ', cnt ]
+
 
 -- | @WarningName@ descriptions used for generating usage information
 -- Leave String empty to skip that name.


### PR DESCRIPTION
Split `--help=warning in benign/severe` and sort alphabetically.

These options were in random order (at least to the outsider). I think it is clearer if we make two tables, one with warnings one can affect, one with warnings that are always on.

New output:
```
The -W or --warning option can be used to disable or enable different warnings. The flag -W error (or --warning=error) can be used to turn all warnings into errors, while -W noerror turns this off again.

A group of warnings can be enabled by -W group, where group is one of the following:

all    All of the existing warnings
ignore Ignore all the benign warnings
warn   Default warning level

Individual benign warnings can be turned on and off by -W Name and -W noName, respectively, where Name comes from the following list (warnings marked with 'd' are turned on by default):

AbsurdPatternRequiresNoRHS                  d A clause with an absurd pattern does not need a Right Hand Side.
AsPatternShadowsConstructorOrPatternSynonym d @-patterns that shadow constructors or pattern synonyms.
CantGeneralizeOverSorts                     d Attempt to generalize over sort metas in 'variable' declaration.
ClashesViaRenaming                          d Clashes introduced by `renaming'.
CoverageNoExactSplit                          Failed exact split checks.
DeprecationWarning                          d Feature deprecation.
DuplicateFieldsWarning                      d Record expression with duplicate field names.
DuplicateUsing                              d Repeated names in using directive.
EmptyAbstract                               d Empty `abstract' blocks.
EmptyConstructor                            d Empty `constructor' blocks.
EmptyField                                  d Empty `field` blocks.
EmptyGeneralize                             d Empty `variable' blocks.
EmptyInstance                               d Empty `instance' blocks.
EmptyMacro                                  d Empty `macro' blocks.
EmptyMutual                                 d Empty `mutual' blocks.
EmptyPostulate                              d Empty `postulate' blocks.
EmptyPrimitive                              d Empty `primitive' blocks.
EmptyPrivate                                d Empty `private' blocks.
EmptyRewritePragma                          d Empty `REWRITE' pragmas.
EmptyWhere                                  d Empty `where' blocks.
FixityInRenamingModule                      d Found fixity annotation in renaming directive for module.
GenericUseless                              d Useless code.
HiddenGeneralize                            d Hidden identifiers in variable blocks.
IllformedAsClause                           d Illformed `as'-clauses in `import' statements.
InstanceArgWithExplicitArg                  d instance arguments with explicit arguments are never considered by instance search.
InstanceNoOutputTypeName                    d instance arguments whose type does not end in a named or variable type are never considered by instance search.
InstanceWithExplicitArg                     d `instance` declarations with explicit arguments are never considered by instance search.
InteractionMetaBoundaries                   d Some interaction meta variables have boundary constraints.
InvalidCatchallPragma                       d `CATCHALL' pragmas before a non-function clause.
InvalidConstructor                          d `constructor' blocks may only contain type signatures for constructors.
InvalidConstructorBlock                     d No `constructor' blocks outside of `interleaved mutual' blocks.
InvalidCoverageCheckPragma                  d Coverage checking pragmas before non-function or `mutual' blocks.
InvalidNoPositivityCheckPragma              d No positivity checking pragmas before non-`data', `record' or `mutual' blocks.
InvalidNoUniverseCheckPragma                d No universe checking pragmas before non-`data' or `record' declaration.
InvalidRecordDirective                      d No record directive outside of record definition / below field declarations.
InvalidTerminationCheckPragma               d Termination checking pragmas before non-function or `mutual' blocks.
InversionDepthReached                       d Inversions of pattern-matching failed due to exhausted inversion depth.
LibUnknownField                             d Unknown field in library file.
ModuleDoesntExport                          d Imported name is not actually exported.
MultipleAttributes                          d Multiple attributes.
NoGuardednessFlag                           d Coinductive record but no --guardedness flag.
NotInScope                                  d Out of scope name.
OldBuiltin                                  d Deprecated `BUILTIN' pragmas.
OpenPublicAbstract                          d 'open public' directive in an 'abstract' block.
OpenPublicPrivate                           d 'open public' directive in a 'private' block.
OptionRenamed                               d Renamed options.
PlentyInHardCompileTimeMode                 d Use of @ω or @plenty in hard compile-time mode.
PolarityPragmasButNotPostulates             d Polarity pragmas for non-postulates.
PragmaCompileErased                         d `COMPILE' pragma targeting an erased symbol.
PragmaNoTerminationCheck                    d `NO_TERMINATION_CHECK' pragmas are deprecated
ShadowingInTelescope                          Repeated variable name in telescope.
TooManyFieldsWarning                        d Record expression with invalid field names.
UnknownFixityInMixfixDecl                     Mixfix names without an associated fixity declaration.
UnknownNamesInFixityDecl                    d Names not declared in the same scope as their syntax or fixity declaration.
UnknownNamesInPolarityPragmas               d Names not declared in the same scope as their polarity pragmas.
UnreachableClauses                          d Unreachable function clauses.
UnsupportedAttribute                        d Unsupported attributes.
UnsupportedIndexedMatch                     d Failed to compute full equivalence when splitting on indexed family.
UselessAbstract                             d `abstract' blocks where they have no effect.
UselessHiding                               d Names in `hiding' directive that are anyway not imported.
UselessInline                               d `INLINE' pragmas where they have no effect.
UselessInstance                             d `instance' blocks where they have no effect.
UselessPatternDeclarationForRecord          d `pattern' attributes where they have no effect.
UselessPrivate                              d `private' blocks where they have no effect.
UselessPublic                               d `public' blocks where they have no effect.
UserWarning                                 d User-defined warning added using one of the 'WARNING_ON_*' pragmas.
WithoutKFlagPrimEraseEquality               d `primEraseEquality' usages with the without-K flags.
WrongInstanceDeclaration                    d Instances that do not adhere to the required format.

Error warnings are always on and cannot be turned off:

CoInfectiveImport                      Importing a file not using e.g. `--safe'  from one which does.
CoverageIssue                          Failed coverage checks.
InfectiveImport                        Importing a file using e.g. `--cubical' into one which doesn't.
MissingDeclarations                    Definitions not associated to a declaration.
MissingDefinitions                     Declarations not associated to a definition.
NotAllowedInMutual                     Declarations not allowed in a mutual block.
NotStrictlyPositive                    Failed strict positivity checks.
OverlappingTokensWarning               Multi-line comments spanning one or more literate text blocks.
PragmaCompiled                         'COMPILE' pragmas not allowed in safe mode.
RewriteAmbiguousRules                  Failed global confluence check because of overlapping rules.
RewriteMaybeNonConfluent               Failed local confluence check while computing overlap.
RewriteMissingRule                     Failed global confluence check because of missing rule.
RewriteNonConfluent                    Failed local confluence check while joining critical pairs.
SafeFlagEta                            `ETA' pragmas with the safe flag.
SafeFlagInjective                      `INJECTIVE' pragmas with the safe flag.
SafeFlagNoCoverageCheck                `NON_COVERING` pragmas with the safe flag.
SafeFlagNoPositivityCheck              `NO_POSITIVITY_CHECK' pragmas with the safe flag.
SafeFlagNoUniverseCheck                `NO_UNIVERSE_CHECK' pragmas with the safe flag.
SafeFlagNonTerminating                 `NON_TERMINATING' pragmas with the safe flag.
SafeFlagPolarity                       `POLARITY' pragmas with the safe flag.
SafeFlagPostulate                      `postulate' blocks with the safe flag.
SafeFlagPragma                         Unsafe `OPTIONS' pragmas with the safe flag.
SafeFlagTerminating                    `TERMINATING' pragmas with the safe flag.
SafeFlagWithoutKFlagPrimEraseEquality  `primEraseEquality' used with the safe and without-K flags.
TerminationIssue                       Failed termination checks.
UnsolvedConstraints                    Unsolved constraints.
UnsolvedInteractionMetas               Unsolved interaction meta variables.
UnsolvedMetaVariables                  Unsolved meta variables.
```