### PR TITLE
Convert `SmallSet` to be a bitset

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3023,6 +3023,8 @@ data AllowedReduction
   | NonTerminatingReductions -- ^ Functions that have failed termination checking.
   deriving (Show, Eq, Ord, Enum, Bounded, Ix, Generic)
 
+instance SmallSet.SmallSetElement AllowedReduction
+
 type AllowedReductions = SmallSet AllowedReduction
 
 -- | Not quite all reductions (skip non-terminating reductions)

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -1,8 +1,6 @@
--- | Small sets represented as immutable bit arrays for fast membership checking.
+-- | Small sets represented as a bitmask for fast membership checking.
 --
--- Membership checking is O(1), but all other operations are O(n)
--- where n is the size of the element type.
--- The element type needs to implement 'Bounded' and 'Ix'.
+-- With the exception of converting to/from lists, all operations are O(1).
 --
 -- Mimics the interface of 'Data.Set'.
 --
@@ -14,9 +12,9 @@
 
 module Agda.Utils.SmallSet
   ( SmallSet()
+  , SmallSetElement
   , Ix
   , (\\)
-  , complement
   , delete
   , difference
   , elems
@@ -24,8 +22,6 @@ module Agda.Utils.SmallSet
   , fromList, fromAscList, fromDistinctAscList
   , insert
   , intersection
-  , isSubsetOf
-  , mapMembership
   , member
   , notMember
   , null
@@ -33,126 +29,96 @@ module Agda.Utils.SmallSet
   , toList, toAscList
   , total
   , union
-  , zipMembershipWith
   ) where
 
 import Prelude hiding (null)
 
 import Control.DeepSeq
 
-import Data.Array.IArray (Ix, Array)
-import qualified Data.Array.IArray as Array
+import Data.Word (Word64)
+import Data.List (foldl')
+import Data.Bits
+import Data.Ix
 
--- Note: we might want to use unboxed arrays, but they have no Data instance
+-- | An element in a small set.
 --
--- Update: There is currently no need for a Data instance. An attempt
--- was made to replace Array with Data.Array.Unboxed.UArray. Limited
--- testing suggested that this does not make much of a difference in
--- practice (at least not when it comes to type-checking the standard
--- library up to and including Data.Nat, with Agda compiled without
--- -foptimise-heavily).
+-- This must implement 'Bounded' and 'Ix', and contain at most 64 values.
+class (Bounded a, Ix a) => SmallSetElement a where
 
--- | Let @n@ be the size of type @a@.
-type SmallSetElement a = (Bounded a, Ix a)
-newtype SmallSet a = SmallSet { theSmallSet :: Array a Bool }
+newtype SmallSet a = SmallSet { theSmallSet :: Word64 }
   deriving (Eq, Ord, Show, NFData)
 
 -- * Query
 
--- | Time O(n)!
+-- | Time O(1).
 null :: SmallSetElement a => SmallSet a -> Bool
-null = all (== False) . Array.elems . theSmallSet
+null s = theSmallSet s == 0
 
 -- | Time O(1).
 member :: SmallSetElement a => a -> SmallSet a -> Bool
-member a s = theSmallSet s Array.! a
+member a s = theSmallSet s `testBit` idx a
 
 -- | @not . member a@.  Time O(1).
 notMember :: SmallSetElement a => a -> SmallSet a -> Bool
 notMember a = not . member a
 
--- | Time O(n).
-isSubsetOf ::  SmallSetElement a => SmallSet a -> SmallSet a -> Bool
-isSubsetOf s t = and $ toBoolListZipWith implies s t
-  where implies a b = if a then b else True
-
 -- * Construction
 
--- | The empty set.  Time O(n).
+-- | The empty set.  Time O(1).
 empty :: SmallSetElement a => SmallSet a
-empty = fromBoolList (repeat False)
+empty = SmallSet 0
 
--- | The full set.  Time O(n).
-total :: SmallSetElement a => SmallSet a
-total = fromBoolList (repeat True)
+-- | The full set.  Time O(1).
+total :: forall a. SmallSetElement a => SmallSet a
+total = SmallSet mask where
+  size = rangeSize (bounds :: (a, a))
+  mask = (1 `shiftL` size) - 1
 
--- | A singleton set.  Time O(n).
+-- | A singleton set.  Time O(1).
 singleton :: SmallSetElement a => a -> SmallSet a
-singleton a = fromList [a]
+singleton a = SmallSet $ bit (idx a)
 
--- | Time O(n).
+-- | Time O(1).
 insert :: SmallSetElement a => a -> SmallSet a -> SmallSet a
-insert a = update [(a,True)]
+insert a s = SmallSet $ theSmallSet s `setBit` idx a
 
--- | Time O(n).
+-- | Time O(1).
 delete :: SmallSetElement a => a -> SmallSet a -> SmallSet a
-delete a = update [(a,False)]
+delete a s = SmallSet $ theSmallSet s `clearBit` idx a
 
 -- * Combine
 
--- | Time O(n).
-complement :: SmallSetElement a => SmallSet a -> SmallSet a
-complement = mapMembership not
-
--- | Time O(n).
+-- | Time O(1).
 difference, (\\) :: SmallSetElement a => SmallSet a -> SmallSet a -> SmallSet a
-difference = zipMembershipWith $ \ b c -> b && not c
+difference s t = SmallSet $ theSmallSet s .&. complement (theSmallSet t)
 (\\)       = difference
 
--- | Time O(n).
+-- | Time O(1).
 intersection ::  SmallSetElement a => SmallSet a -> SmallSet a -> SmallSet a
-intersection = zipMembershipWith (&&)
+intersection s t = SmallSet $ theSmallSet s .&. theSmallSet t
 
 -- | Time O(n).
 union ::  SmallSetElement a => SmallSet a -> SmallSet a -> SmallSet a
-union = zipMembershipWith (||)
-
--- | Time O(n).
-mapMembership :: SmallSetElement a => (Bool -> Bool) -> SmallSet a -> SmallSet a
-mapMembership f = SmallSet . Array.amap f . theSmallSet
-
--- | Time O(n).
-zipMembershipWith :: SmallSetElement a => (Bool -> Bool -> Bool) -> SmallSet a -> SmallSet a -> SmallSet a
-zipMembershipWith f s t = fromBoolList $ toBoolListZipWith f s t
+union s t = SmallSet $ theSmallSet s .|. theSmallSet t
 
 -- * Conversion
 
 -- | Time O(n).
 elems, toList, toAscList :: SmallSetElement a => SmallSet a -> [a]
-elems     = map fst . filter snd . Array.assocs . theSmallSet
+elems s   = filter (\i -> theSmallSet s `testBit` idx i) (range bounds)
 toList    = elems
 toAscList = elems
 
 -- | Time O(n).
 fromList, fromAscList, fromDistinctAscList :: SmallSetElement a => [a] -> SmallSet a
-fromList            = flip update empty . map (,True)
+fromList            = foldl' (flip insert) empty
 fromAscList         = fromList
 fromDistinctAscList = fromList
 
--- * Internal
+-- * Internals
 
--- | Time O(n).  Assumes @Bool@-vector of length @n@.
-fromBoolList :: SmallSetElement a => [Bool] -> SmallSet a
-fromBoolList = SmallSet . Array.listArray (minBound, maxBound)
+bounds :: SmallSetElement a => (a, a)
+bounds = (minBound, maxBound)
 
--- | Time O(n).  Produces @Bool@-vector of length @n@.
-toBoolList :: SmallSetElement a => SmallSet a -> [Bool]
-toBoolList = Array.elems . theSmallSet
-
--- | Time O(n).  Produces @Bool@-vector of length @n@.
-toBoolListZipWith :: SmallSetElement a => (Bool -> Bool -> Bool) -> SmallSet a -> SmallSet a -> [Bool]
-toBoolListZipWith f s t = zipWith f (toBoolList s) (toBoolList t)
-
--- | Time O(n).  Bulk insert/delete.
-update :: SmallSetElement a => [(a,Bool)] -> SmallSet a -> SmallSet a
-update u s = SmallSet $ theSmallSet s Array.// u
+idx :: SmallSetElement a => a -> Int
+idx a = index bounds a

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -15,6 +15,7 @@ module Agda.Utils.SmallSet
   , SmallSetElement
   , Ix
   , (\\)
+  , complement
   , delete
   , difference
   , elems
@@ -37,7 +38,8 @@ import Control.DeepSeq
 
 import Data.Word (Word64)
 import Data.List (foldl')
-import Data.Bits
+import Data.Bits hiding (complement)
+import qualified Data.Bits as Bits
 import Data.Ix
 
 -- | An element in a small set.
@@ -70,9 +72,7 @@ empty = SmallSet 0
 
 -- | The full set.  Time O(1).
 total :: forall a. SmallSetElement a => SmallSet a
-total = SmallSet mask where
-  size = rangeSize (bounds :: (a, a))
-  mask = (1 `shiftL` size) - 1
+total = SmallSet $ Bits.complement 0
 
 -- | A singleton set.  Time O(1).
 singleton :: SmallSetElement a => a -> SmallSet a
@@ -88,9 +88,13 @@ delete a s = SmallSet $ theSmallSet s `clearBit` idx a
 
 -- * Combine
 
+-- | Time O(n).
+complement :: SmallSetElement a => SmallSet a -> SmallSet a
+complement = SmallSet . Bits.complement . theSmallSet
+
 -- | Time O(1).
 difference, (\\) :: SmallSetElement a => SmallSet a -> SmallSet a -> SmallSet a
-difference s t = SmallSet $ theSmallSet s .&. complement (theSmallSet t)
+difference s t = SmallSet $ theSmallSet s .&. Bits.complement (theSmallSet t)
 (\\)       = difference
 
 -- | Time O(1).

--- a/test/Internal/Utils/SmallSet.hs
+++ b/test/Internal/Utils/SmallSet.hs
@@ -21,6 +21,8 @@ import Internal.Helpers
 data A = A0 | A1 | A2 | A3 | A4 | A5
   deriving (Eq, Ord, Enum, Bounded, Ix, Show, Read)
 
+instance SmallSet.SmallSetElement A
+
 instance Arbitrary A where
   -- Ideally,
   -- arbitrary = chooseAny
@@ -50,7 +52,6 @@ rel2 f g as bs = rel1 (f $ SmallSet.fromList as) (g $ Set.fromList as) bs
 prop_null        = test1 (SmallSet.null)        (Set.null)
 prop_member a    = test1 (SmallSet.member a)    (Set.member a)
 prop_notMember a = test1 (SmallSet.notMember a) (Set.notMember a)
-prop_isSubsetOf  = test2 (SmallSet.isSubsetOf)  (Set.isSubsetOf)
 
 prop_empty       = rel0  (SmallSet.empty)       (Set.empty)
 prop_singleton a = rel0  (SmallSet.singleton a) (Set.singleton a)


### PR DESCRIPTION
This was discussed when originally implemented in bda742e7, and after some profiling it feels like it's worth it, reducing time taken in type-checking by ~2%.

This does have the limitation that types with at most 64 values can be used as set elements. I don't think that's an issue in practice - the previous implementation would have been expensive with this many elements - but have changed it so you need to implement `SmallSetElement` explicitly, to make this requirement more clear.

This also drops a couple of unused SmallSet methods (`complement`, `isSubsetOf`) which didn't feel worth implementing. Happy to add those back if preferred.

<details><summary>Performance measurements</summary>

Numbers were taken using GHC 9.2.7 and running Agda against `src/Data/Nat.lagda.md` from  https://github.com/plt-amy/1lab/commit/3b51679d95520c15ccd20accb9ab686e1eaa3c55. Agda was run under `perf stat` and with `+RTS -A128M -s -RTS --profile=internal`

### Master (791fb5e7b327d5e9b15146e5c234cfdbb6c5c14d)

```
Total                        32,597ms           
Miscellaneous                   122ms           
Typing                        1,317ms (22,605ms)
Typing.CheckRHS              10,147ms           
Typing.OccursCheck            5,761ms           
Typing.CheckLHS               1,504ms  (1,696ms)
Typing.CheckLHS.UnifyIndices    192ms           
Typing.TypeSig                1,594ms           
Typing.InstanceSearch         1,315ms           
Typing.Generalize               710ms           
Typing.With                      61ms           
Parsing                         385ms  (2,869ms)
Parsing.OperatorsExpr         1,983ms           
Parsing.OperatorsPattern        499ms           
Serialization                 1,530ms  (1,972ms)
Serialization.Compress          250ms           
Serialization.BinaryEncode      131ms           
Serialization.Sort               37ms           
Serialization.BuildInterface     22ms           
Scoping                         518ms  (1,530ms)
Scoping.InverseScopeLookup    1,011ms           
Deserialization                 671ms    (943ms)
Deserialization.Compaction      271ms           
Coverage                        925ms           
Highlighting                    548ms           
Positivity                      389ms           
DeadCode                        346ms           
Termination                     115ms    (217ms)
Termination.RecCheck             71ms           
Termination.Compare              16ms           
Termination.Graph                14ms           
Injectivity                      68ms           
Import                           58ms           
  60,075,994,392 bytes allocated in the heap
   2,025,767,248 bytes copied during GC
     102,845,184 bytes maximum residency (24 sample(s))
         509,128 bytes maximum slop
             343 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0       429 colls,     0 par    2.940s   2.943s     0.0069s    0.0422s
  Gen  1        24 colls,     0 par    0.663s   0.663s     0.0276s    0.0835s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.004s  (  0.004s elapsed)
  MUT     time   29.011s  ( 28.905s elapsed)
  GC      time    3.602s  (  3.606s elapsed)
  EXIT    time    0.001s  (  0.006s elapsed)
  Total   time   32.619s  ( 32.521s elapsed)

  Alloc rate    2,070,797,507 bytes per MUT second

  Productivity  88.9% of total user, 88.9% of total elapsed


 Performance counter stats for 'scratch/agda-791fb5e7b327d5e9b15146e5c234cfdbb6c5c14d src/Data/Nat.lagda.md +RTS -A128M -s -RTS --profile=internal':

         32,612.34 msec task-clock:u                     #    1.002 CPUs utilized             
                 0      context-switches:u               #    0.000 /sec                      
                 0      cpu-migrations:u                 #    0.000 /sec                      
           108,090      page-faults:u                    #    3.314 K/sec                     
   132,493,868,462      cycles:u                         #    4.063 GHz                         (83.09%)
     8,691,989,623      stalled-cycles-frontend:u        #    6.56% frontend cycles idle        (83.39%)
    26,582,563,560      stalled-cycles-backend:u         #   20.06% backend cycles idle         (83.36%)
   134,893,320,440      instructions:u                   #    1.02  insn per cycle            
                                                  #    0.20  stalled cycles per insn     (83.38%)
    25,729,291,857      branches:u                       #  788.943 M/sec                       (83.40%)
     1,003,666,757      branch-misses:u                  #    3.90% of all branches             (83.39%)

      32.544316751 seconds time elapsed

      32.137447000 seconds user
       0.505074000 seconds sys
```

### This PR
```
Total                        31,964ms           
Miscellaneous                   128ms           
Typing                        1,263ms (21,818ms)
Typing.CheckRHS               9,785ms           
Typing.OccursCheck            5,420ms           
Typing.CheckLHS               1,504ms  (1,686ms)
Typing.CheckLHS.UnifyIndices    181ms           
Typing.TypeSig                1,591ms           
Typing.InstanceSearch         1,311ms           
Typing.Generalize               713ms           
Typing.With                      45ms           
Parsing                         418ms  (2,904ms)
Parsing.OperatorsExpr         2,011ms           
Parsing.OperatorsPattern        474ms           
Serialization                 1,681ms  (2,147ms)
Serialization.Compress          251ms           
Serialization.BinaryEncode      145ms           
Serialization.Sort               47ms           
Serialization.BuildInterface     20ms           
Scoping                         513ms  (1,495ms)
Scoping.InverseScopeLookup      982ms           
Deserialization                 617ms    (897ms)
Deserialization.Compaction      280ms           
Coverage                        894ms           
Highlighting                    549ms           
DeadCode                        406ms           
Positivity                      395ms           
Termination                      90ms    (203ms)
Termination.RecCheck             71ms           
Termination.Compare              26ms           
Termination.Graph                14ms           
Injectivity                      66ms           
Import                           57ms           
  56,391,638,208 bytes allocated in the heap
   2,115,290,920 bytes copied during GC
     121,565,144 bytes maximum residency (21 sample(s))
         495,656 bytes maximum slop
             396 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0       405 colls,     0 par    2.955s   2.958s     0.0073s    0.0382s
  Gen  1        21 colls,     0 par    0.782s   0.782s     0.0373s    0.1090s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.004s  (  0.004s elapsed)
  MUT     time   28.243s  ( 28.111s elapsed)
  GC      time    3.737s  (  3.740s elapsed)
  EXIT    time    0.001s  (  0.005s elapsed)
  Total   time   31.986s  ( 31.860s elapsed)

  Alloc rate    1,996,627,860 bytes per MUT second

  Productivity  88.3% of total user, 88.2% of total elapsed


 Performance counter stats for 'scratch/agda-c45cdd75d95b05f89dc42eceda96bc129b5f2e01 src/Data/Nat.lagda.md +RTS -A128M -s -RTS --profile=internal':

         31,965.14 msec task-clock:u                     #    1.003 CPUs utilized             
                 0      context-switches:u               #    0.000 /sec                      
                 0      cpu-migrations:u                 #    0.000 /sec                      
           120,868      page-faults:u                    #    3.781 K/sec                     
   129,293,504,726      cycles:u                         #    4.045 GHz                         (83.31%)
     7,465,832,160      stalled-cycles-frontend:u        #    5.77% frontend cycles idle        (83.31%)
    28,042,847,329      stalled-cycles-backend:u         #   21.69% backend cycles idle         (83.34%)
   131,288,667,216      instructions:u                   #    1.02  insn per cycle            
                                                  #    0.21  stalled cycles per insn     (83.33%)
    25,027,260,626      branches:u                       #  782.955 M/sec                       (83.32%)
       982,319,879      branch-misses:u                  #    3.92% of all branches             (83.38%)

      31.885410422 seconds time elapsed

      31.475750000 seconds user
       0.535415000 seconds sys
```

</details>