### PR TITLE
Increase laziness of builtin access in `fastReduce`

### DIFF
--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -422,16 +422,26 @@ fastNormalise v = ignoreBlocking <$> fastReduce' NF v
 
 fastReduce' :: Normalisation -> Term -> ReduceM (Blocked Term)
 fastReduce' norm v = do
+  tcState <- getTCState
   let name (Con c _ _) = c
       name _         = __IMPOSSIBLE__
-  zero  <- fmap name <$> getBuiltin' builtinZero
-  suc   <- fmap name <$> getBuiltin' builtinSuc
-  true  <- fmap name <$> getBuiltin' builtinTrue
-  false <- fmap name <$> getBuiltin' builtinFalse
-  refl  <- fmap name <$> getBuiltin' builtinRefl
-  force <- fmap primFunName <$> getPrimitive' "primForce"
-  erase <- fmap primFunName <$> getPrimitive' "primErase"
-  let bEnv = BuiltinEnv { bZero = zero, bSuc = suc, bTrue = true, bFalse = false, bRefl = refl,
+
+      -- Gather builtins using 'BuiltinAccess' rather than with the default
+      -- 'HasBuiltins ReduceM' instance. This increases laziness, allowing us to
+      -- avoid costly builtin lookups unless needed.
+      builtinName   = fmap name . runBuiltinAccess tcState . getBuiltin'
+      primitiveName = fmap primFunName . runBuiltinAccess tcState . getPrimitive'
+
+      zero  = builtinName builtinZero
+      suc   = builtinName builtinSuc
+      true  = builtinName builtinTrue
+      false = builtinName builtinFalse
+      refl  = builtinName builtinRefl
+
+      force = primitiveName "primForce"
+      erase = primitiveName "primErase"
+
+      bEnv = BuiltinEnv { bZero = zero, bSuc = suc, bTrue = true, bFalse = false, bRefl = refl,
                           bPrimForce = force, bPrimErase = erase }
   allowedReductions <- asksTC envAllowedReductions
   rwr <- optRewriting <$> pragmaOptions


### PR DESCRIPTION
At the start of `fastReduce`, several builtins are looked up, to avoid repeated lookups during actual reduction. Ideally these lookups would be lazy, but `ReduceM`'s bind operator forces them, evaluating them to WHNF.

By instead reading the current `TCState` and looking up the builtins outside of the `ReduceM` monad, we can ensure these lookups are performed lazily. This brings a small (~3%) performance improvement to type checking.

---

Definitely open to alternative implementations here - I'm not thrilled about defining an extra type just for this one case.

---

There's probably work which could be done here to index builtins with an enum rather than string constants (which would help a little with lookup times), but that's a much more invasive change, so feel it's probably worth me rasing and discussing that first before I jump in :).

---

<details><summary>Performance measurements</summary>

Numbers were taken using GHC 9.2.7 and running Agda against `src/Data/Nat.lagda.md` from  https://github.com/plt-amy/1lab/commit/3b51679d95520c15ccd20accb9ab686e1eaa3c55. Agda was run under `perf stat` and with `+RTS -A128M -s -RTS --profile=internal`

### Master (791fb5e7b327d5e9b15146e5c234cfdbb6c5c14d)

```
Total                        32,597ms           
Miscellaneous                   122ms           
Typing                        1,317ms (22,605ms)
Typing.CheckRHS              10,147ms           
Typing.OccursCheck            5,761ms           
Typing.CheckLHS               1,504ms  (1,696ms)
Typing.CheckLHS.UnifyIndices    192ms           
Typing.TypeSig                1,594ms           
Typing.InstanceSearch         1,315ms           
Typing.Generalize               710ms           
Typing.With                      61ms           
Parsing                         385ms  (2,869ms)
Parsing.OperatorsExpr         1,983ms           
Parsing.OperatorsPattern        499ms           
Serialization                 1,530ms  (1,972ms)
Serialization.Compress          250ms           
Serialization.BinaryEncode      131ms           
Serialization.Sort               37ms           
Serialization.BuildInterface     22ms           
Scoping                         518ms  (1,530ms)
Scoping.InverseScopeLookup    1,011ms           
Deserialization                 671ms    (943ms)
Deserialization.Compaction      271ms           
Coverage                        925ms           
Highlighting                    548ms           
Positivity                      389ms           
DeadCode                        346ms           
Termination                     115ms    (217ms)
Termination.RecCheck             71ms           
Termination.Compare              16ms           
Termination.Graph                14ms           
Injectivity                      68ms           
Import                           58ms           
  60,075,994,392 bytes allocated in the heap
   2,025,767,248 bytes copied during GC
     102,845,184 bytes maximum residency (24 sample(s))
         509,128 bytes maximum slop
             343 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0       429 colls,     0 par    2.940s   2.943s     0.0069s    0.0422s
  Gen  1        24 colls,     0 par    0.663s   0.663s     0.0276s    0.0835s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.004s  (  0.004s elapsed)
  MUT     time   29.011s  ( 28.905s elapsed)
  GC      time    3.602s  (  3.606s elapsed)
  EXIT    time    0.001s  (  0.006s elapsed)
  Total   time   32.619s  ( 32.521s elapsed)

  Alloc rate    2,070,797,507 bytes per MUT second

  Productivity  88.9% of total user, 88.9% of total elapsed


 Performance counter stats for 'scratch/agda-791fb5e7b327d5e9b15146e5c234cfdbb6c5c14d src/Data/Nat.lagda.md +RTS -A128M -s -RTS --profile=internal':

         32,612.34 msec task-clock:u                     #    1.002 CPUs utilized             
                 0      context-switches:u               #    0.000 /sec                      
                 0      cpu-migrations:u                 #    0.000 /sec                      
           108,090      page-faults:u                    #    3.314 K/sec                     
   132,493,868,462      cycles:u                         #    4.063 GHz                         (83.09%)
     8,691,989,623      stalled-cycles-frontend:u        #    6.56% frontend cycles idle        (83.39%)
    26,582,563,560      stalled-cycles-backend:u         #   20.06% backend cycles idle         (83.36%)
   134,893,320,440      instructions:u                   #    1.02  insn per cycle            
                                                  #    0.20  stalled cycles per insn     (83.38%)
    25,729,291,857      branches:u                       #  788.943 M/sec                       (83.40%)
     1,003,666,757      branch-misses:u                  #    3.90% of all branches             (83.39%)

      32.544316751 seconds time elapsed

      32.137447000 seconds user
       0.505074000 seconds sys
```

### This PR
```
Total                        31,893ms           
Miscellaneous                   137ms           
Typing                        1,396ms (21,781ms)
Typing.CheckRHS               9,614ms           
Typing.OccursCheck            5,621ms           
Typing.CheckLHS               1,471ms  (1,678ms)
Typing.CheckLHS.UnifyIndices    206ms           
Typing.TypeSig                1,463ms           
Typing.InstanceSearch         1,248ms           
Typing.Generalize               674ms           
Typing.With                      84ms           
Parsing                         442ms  (2,918ms)
Parsing.OperatorsExpr         2,009ms           
Parsing.OperatorsPattern        466ms           
Serialization                 1,525ms  (1,988ms)
Serialization.Compress          249ms           
Serialization.BinaryEncode      152ms           
Serialization.Sort               39ms           
Serialization.BuildInterface     19ms           
Scoping                         495ms  (1,517ms)
Scoping.InverseScopeLookup    1,021ms           
Coverage                        932ms           
Deserialization                 653ms    (930ms)
Deserialization.Compaction      277ms           
Highlighting                    533ms           
Positivity                      430ms           
DeadCode                        393ms           
Termination                      91ms    (200ms)
Termination.RecCheck             71ms           
Termination.Compare              23ms           
Termination.Graph                14ms           
Injectivity                      71ms           
Import                           55ms           
  59,517,111,048 bytes allocated in the heap
   2,058,341,800 bytes copied during GC
      93,449,728 bytes maximum residency (24 sample(s))
         315,904 bytes maximum slop
             325 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0       426 colls,     0 par    2.955s   2.959s     0.0069s    0.0346s
  Gen  1        24 colls,     0 par    0.732s   0.733s     0.0305s    0.0671s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.004s  (  0.004s elapsed)
  MUT     time   28.222s  ( 28.131s elapsed)
  GC      time    3.687s  (  3.692s elapsed)
  EXIT    time    0.001s  (  0.004s elapsed)
  Total   time   31.914s  ( 31.830s elapsed)

  Alloc rate    2,108,918,508 bytes per MUT second

  Productivity  88.4% of total user, 88.4% of total elapsed


 Performance counter stats for 'scratch/agda-56e319d10b7919b2a4e4877e9815ac93a1ffbfc4 src/Data/Nat.lagda.md +RTS -A128M -s -RTS --profile=internal':

    11,254,657,255      cache-references:u                                                    
     2,182,039,408      cache-misses:u                   #   19.388 % of all cache refs       
   129,778,238,541      cycles:u                                                              
   124,341,276,784      instructions:u                   #    0.96  insn per cycle            
    23,762,694,589      branches:u                                                            
           103,522      faults:u                                                              
                 0      migrations:u                                                          

      31.854649186 seconds time elapsed

      31.360244000 seconds user
       0.578207000 seconds sys
```

</details>
