### PR TITLE
Remove cabal flag `cpphs`

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -116,10 +116,6 @@ jobs:
           description: Linux w/o tests
           ghc-ver: 9.6.1
           os: ubuntu-22.04
-        - cabal-flags: --enable-tests -f cpphs
-          description: Linux cpphs
-          ghc-ver: 9.6.1
-          os: ubuntu-22.04
         - cabal-flags: --enable-tests -f debug
           description: Linux debug
           ghc-ver: 9.6.1

--- a/.github/workflows/stack-dry-run.yml
+++ b/.github/workflows/stack-dry-run.yml
@@ -23,8 +23,7 @@ jobs:
         shell: bash
     env:
       EXTRA_ARGS: --dry-run
-      NON_DEFAULT_FLAGS: --flag Agda:enable-cluster-counting --flag Agda:cpphs --flag
-        Agda:debug
+      NON_DEFAULT_FLAGS: --flag Agda:enable-cluster-counting --flag Agda:debug
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -24,8 +24,7 @@ jobs:
     env:
       EXTRA_ARGS: --fast
       ICU_URL: https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-icu-69.1-1-any.pkg.tar.zst
-      NON_DEFAULT_FLAGS: --flag Agda:enable-cluster-counting --flag Agda:cpphs --flag
-        Agda:debug
+      NON_DEFAULT_FLAGS: --flag Agda:enable-cluster-counting --flag Agda:debug
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
     steps:

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -157,11 +157,6 @@ source-repository this
 -- Build flags
 ---------------------------------------------------------------------------
 
-flag cpphs
-  default:     False
-  manual:      True
-  description: Use cpphs instead of cpp.
-
 flag debug
   default: False
   manual: True
@@ -343,13 +338,6 @@ library
   --
   -- An exceptions are packages that are only needed for certain configurations,
   -- like for flags, Windows, etc.
-
-  if flag(cpphs)
-    -- We don't write an upper bound for cpphs because the
-    -- `build-tool-depends` field can not be modified in Hackage.
-
-    build-tool-depends: cpphs:cpphs >= 1.20.9
-    ghc-options:        -pgmP cpphs -optP --cpp
 
   if flag(debug)
     cpp-options:    -DDEBUG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Release notes for Agda version 2.6.4
 ====================================
 
+Installation
+------------
+
+* Removed the cabal flag `cpphs` that enabled building Agda with `cpphs` instead of the default C preprocessor.
+
 Reflection
 ----------
 

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -472,11 +472,6 @@ Installation Flags
 
 When installing Agda the following flags can be used:
 
-.. option:: cpphs
-
-     Use `cpphs <https://hackage.haskell.org/package/cpphs>`_ instead
-     of cpp. Default: off.
-
 .. option:: debug
 
      Enable debugging features that may slow Agda down. Default: off.

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -64,12 +64,6 @@ jobs:
             # Can't leave cabal-flags empty here lest it becomes the default value.
             cabal-flags: '--disable-tests'
 
-          # Linux, with -f cpphs
-          - os: ubuntu-22.04
-            description: Linux cpphs
-            ghc-ver: '9.6.1'
-            cabal-flags: '--enable-tests -f cpphs'
-
           # Linux, without -f enable-cluster-counting but with -f debug
           - os: ubuntu-22.04
             description: Linux debug

--- a/src/github/workflows/stack-dry-run.yml
+++ b/src/github/workflows/stack-dry-run.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       EXTRA_ARGS: "--dry-run"
         # stack build --only-configure also installs dependencies, so we need --dry-run
-      NON_DEFAULT_FLAGS: "--flag Agda:enable-cluster-counting --flag Agda:cpphs --flag Agda:debug"
+      NON_DEFAULT_FLAGS: "--flag Agda:enable-cluster-counting --flag Agda:debug"
 
     defaults:
       run:

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -76,7 +76,7 @@ jobs:
       ## ARGS is set later, depending on the actually picked GHC version
       # ARGS: "--stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal"
       EXTRA_ARGS: "--fast"
-      NON_DEFAULT_FLAGS: "--flag Agda:enable-cluster-counting --flag Agda:cpphs --flag Agda:debug"
+      NON_DEFAULT_FLAGS: "--flag Agda:enable-cluster-counting --flag Agda:debug"
 
       # Liang-Ting Chen (2021-08-18):
       # Let pacman choose the file name for ICU4C.


### PR DESCRIPTION
Haskell's `cpphs` has not been actively maintained since 2020 and does not work correctly under Windows in some setups.

- https://github.com/hackage-trustees/malcolm-wallace-universe/pull/20

Starting 2018 we have not been building with `cpphs` by default, but with the system CPP; no problems have been reported since then. Then, we already discussed removing cpphs entirely.

- https://github.com/agda/agda/issues/3223

I think we can go through with it now.