### PR TITLE
Fix #5992: Swap type argument order in Lens'

### DIFF
--- a/src/full/Agda/Auto/Options.hs
+++ b/src/full/Agda/Auto/Options.hs
@@ -40,27 +40,27 @@ initAutoOptions = AutoOptions
   , autoHintMode = AHMNone
   }
 
-aoHints :: Lens' Hints AutoOptions
+aoHints :: Lens' AutoOptions Hints
 aoHints f s =
   f (autoHints s) <&>
   \x -> s {autoHints = x}
 
-aoTimeOut :: Lens' TimeOut AutoOptions
+aoTimeOut :: Lens' AutoOptions TimeOut
 aoTimeOut f s =
   f (autoTimeOut s) <&>
   \x -> s {autoTimeOut = x}
 
-aoPick :: Lens' Int AutoOptions
+aoPick :: Lens' AutoOptions Int
 aoPick f s =
   f (autoPick s) <&>
   \x -> s {autoPick = x}
 
-aoMode :: Lens' Mode AutoOptions
+aoMode :: Lens' AutoOptions Mode
 aoMode f s =
   f (autoMode s) <&>
   \x -> s {autoMode = x}
 
-aoHintMode :: Lens' AutoHintMode AutoOptions
+aoHintMode :: Lens' AutoOptions AutoHintMode
 aoHintMode f s =
   f (autoHintMode s) <&>
   \x -> s {autoHintMode = x}

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -184,13 +184,13 @@ backendWithOpts (Backend backend) = Some (BackendWithOpts backend)
 forgetOpts :: BackendWithOpts opts -> Backend
 forgetOpts (BackendWithOpts backend) = Backend backend
 
-bOptions :: Lens' opts (BackendWithOpts opts)
+bOptions :: Lens' (BackendWithOpts opts) opts
 bOptions f (BackendWithOpts b) = f (options b) <&> \ opts -> BackendWithOpts b{ options = opts }
 
-embedFlag :: Lens' a b -> Flag a -> Flag b
+embedFlag :: Lens' b a -> Flag a -> Flag b
 embedFlag l flag = l flag
 
-embedOpt :: Lens' a b -> OptDescr (Flag a) -> OptDescr (Flag b)
+embedOpt :: Lens' b a -> OptDescr (Flag a) -> OptDescr (Flag b)
 embedOpt l = fmap (embedFlag l)
 
 parseBackendOptions :: [Backend] -> [String] -> CommandLineOptions -> OptM ([Backend], CommandLineOptions)

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -866,10 +866,10 @@ data CCEnv = CCEnv
 type NameSupply = [HS.Name]
 type CCContext  = [HS.Name]
 
-ccNameSupply :: Lens' NameSupply CCEnv
+ccNameSupply :: Lens' CCEnv NameSupply
 ccNameSupply f e =  (\ ns' -> e { _ccNameSupply = ns' }) <$> f (_ccNameSupply e)
 
-ccContext :: Lens' CCContext CCEnv
+ccContext :: Lens' CCEnv CCContext
 ccContext f e = (\ cxt -> e { _ccContext = cxt }) <$> f (_ccContext e)
 
 -- | Initial environment for expression generation.

--- a/src/full/Agda/Compiler/Treeless/Erase.hs
+++ b/src/full/Agda/Compiler/Treeless/Erase.hs
@@ -49,10 +49,10 @@ data ESt = ESt
       -- ^ Memoize computed `TypeInfo` for data/record types `QName`.
   }
 
-funMap :: Lens' (Map QName FunInfo) ESt
+funMap :: Lens' ESt (Map QName FunInfo)
 funMap f r = f (_funMap r) <&> \ a -> r { _funMap = a }
 
-typeMap :: Lens' (Map QName TypeInfo) ESt
+typeMap :: Lens' ESt (Map QName TypeInfo)
 typeMap f r = f (_typeMap r) <&> \ a -> r { _typeMap = a }
 
 -- | Eraser monad.

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -138,22 +138,22 @@ emptyLibFile = AgdaLibFile
 
 -- | Lenses for AgdaLibFile
 
-libName :: Lens' LibName AgdaLibFile
+libName :: Lens' AgdaLibFile LibName
 libName f a = f (_libName a) <&> \ x -> a { _libName = x }
 
-libFile :: Lens' FilePath AgdaLibFile
+libFile :: Lens' AgdaLibFile FilePath
 libFile f a = f (_libFile a) <&> \ x -> a { _libFile = x }
 
-libAbove :: Lens' Int AgdaLibFile
+libAbove :: Lens' AgdaLibFile Int
 libAbove f a = f (_libAbove a) <&> \ x -> a { _libAbove = x }
 
-libIncludes :: Lens' [FilePath] AgdaLibFile
+libIncludes :: Lens' AgdaLibFile [FilePath]
 libIncludes f a = f (_libIncludes a) <&> \ x -> a { _libIncludes = x }
 
-libDepends :: Lens' [LibName] AgdaLibFile
+libDepends :: Lens' AgdaLibFile [LibName]
 libDepends f a = f (_libDepends a) <&> \ x -> a { _libDepends = x }
 
-libPragmas :: Lens' OptionsPragma AgdaLibFile
+libPragmas :: Lens' AgdaLibFile OptionsPragma
 libPragmas f a = f (_libPragmas a) <&> \ x -> a { _libPragmas = x }
 
 

--- a/src/full/Agda/Interaction/Library/Parse.hs
+++ b/src/full/Agda/Interaction/Library/Parse.hs
@@ -80,12 +80,12 @@ data Field = forall a. Field
                  -- ^ Content parser for this field.
                  --
                  -- The range points to the start of the file.
-  , fSet      :: LensSet a AgdaLibFile
+  , fSet      :: LensSet AgdaLibFile a
     -- ^ Sets parsed content in 'AgdaLibFile' structure.
   }
 
 optionalField ::
-  String -> (Range -> [String] -> P a) -> Lens' a AgdaLibFile -> Field
+  String -> (Range -> [String] -> P a) -> Lens' AgdaLibFile a -> Field
 optionalField str p l = Field str True p (set l)
 
 -- | @.agda-lib@ file format with parsers and setters.

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -581,204 +581,204 @@ optWarningMode         = _optWarningMode
 -- Lenses for PragmaOptions
 -- N.B.: We use PartialTypeSignatures here to not repeat default values (DRY!).
 
-lensOptShowImplicit :: Lens' _ PragmaOptions
+lensOptShowImplicit :: Lens' PragmaOptions _
 lensOptShowImplicit f o = f (_optShowImplicit o) <&> \ i -> o{ _optShowImplicit = i }
 
-lensOptShowIrrelevant :: Lens' _ PragmaOptions
+lensOptShowIrrelevant :: Lens' PragmaOptions _
 lensOptShowIrrelevant f o = f (_optShowIrrelevant o) <&> \ i -> o{ _optShowIrrelevant = i }
 
-lensOptUseUnicode :: Lens' _ PragmaOptions
+lensOptUseUnicode :: Lens' PragmaOptions _
 lensOptUseUnicode f o = f (_optUseUnicode o) <&> \ i -> o{ _optUseUnicode = i }
 
-lensOptVerbose :: Lens' _ PragmaOptions
+lensOptVerbose :: Lens' PragmaOptions _
 lensOptVerbose f o = f (_optVerbose o) <&> \ i -> o{ _optVerbose = i }
 
-lensOptProfiling :: Lens' _ PragmaOptions
+lensOptProfiling :: Lens' PragmaOptions _
 lensOptProfiling f o = f (_optProfiling o) <&> \ i -> o{ _optProfiling = i }
 
-lensOptProp :: Lens' _ PragmaOptions
+lensOptProp :: Lens' PragmaOptions _
 lensOptProp f o = f (_optProp o) <&> \ i -> o{ _optProp = i }
 
-lensOptLevelUniverse :: Lens' _ PragmaOptions
+lensOptLevelUniverse :: Lens' PragmaOptions _
 lensOptLevelUniverse f o = f (_optLevelUniverse o) <&> \ i -> o{ _optLevelUniverse = i }
 
-lensOptTwoLevel :: Lens' _ PragmaOptions
+lensOptTwoLevel :: Lens' PragmaOptions _
 lensOptTwoLevel f o = f (_optTwoLevel o) <&> \ i -> o{ _optTwoLevel = i }
 
-lensOptAllowUnsolved :: Lens' _ PragmaOptions
+lensOptAllowUnsolved :: Lens' PragmaOptions _
 lensOptAllowUnsolved f o = f (_optAllowUnsolved o) <&> \ i -> o{ _optAllowUnsolved = i }
 
-lensOptAllowIncompleteMatch :: Lens' _ PragmaOptions
+lensOptAllowIncompleteMatch :: Lens' PragmaOptions _
 lensOptAllowIncompleteMatch f o = f (_optAllowIncompleteMatch o) <&> \ i -> o{ _optAllowIncompleteMatch = i }
 
-lensOptPositivityCheck :: Lens' _ PragmaOptions
+lensOptPositivityCheck :: Lens' PragmaOptions _
 lensOptPositivityCheck f o = f (_optPositivityCheck o) <&> \ i -> o{ _optPositivityCheck = i }
 
-lensOptTerminationCheck :: Lens' _ PragmaOptions
+lensOptTerminationCheck :: Lens' PragmaOptions _
 lensOptTerminationCheck f o = f (_optTerminationCheck o) <&> \ i -> o{ _optTerminationCheck = i }
 
-lensOptTerminationDepth :: Lens' _ PragmaOptions
+lensOptTerminationDepth :: Lens' PragmaOptions _
 lensOptTerminationDepth f o = f (_optTerminationDepth o) <&> \ i -> o{ _optTerminationDepth = i }
 
-lensOptUniverseCheck :: Lens' _ PragmaOptions
+lensOptUniverseCheck :: Lens' PragmaOptions _
 lensOptUniverseCheck f o = f (_optUniverseCheck o) <&> \ i -> o{ _optUniverseCheck = i }
 
-lensOptNoUniverseCheck :: Lens' _ PragmaOptions
+lensOptNoUniverseCheck :: Lens' PragmaOptions _
 lensOptNoUniverseCheck f o = f (mapValue not $ _optUniverseCheck o) <&> \ i -> o{ _optUniverseCheck = mapValue not i }
 
-lensOptOmegaInOmega :: Lens' _ PragmaOptions
+lensOptOmegaInOmega :: Lens' PragmaOptions _
 lensOptOmegaInOmega f o = f (_optOmegaInOmega o) <&> \ i -> o{ _optOmegaInOmega = i }
 
-lensOptCumulativity :: Lens' _ PragmaOptions
+lensOptCumulativity :: Lens' PragmaOptions _
 lensOptCumulativity f o = f (_optCumulativity o) <&> \ i -> o{ _optCumulativity = i }
 
-lensOptSizedTypes :: Lens' _ PragmaOptions
+lensOptSizedTypes :: Lens' PragmaOptions _
 lensOptSizedTypes f o = f (_optSizedTypes o) <&> \ i -> o{ _optSizedTypes = i }
 
-lensOptGuardedness :: Lens' _ PragmaOptions
+lensOptGuardedness :: Lens' PragmaOptions _
 lensOptGuardedness f o = f (_optGuardedness o) <&> \ i -> o{ _optGuardedness = i }
 
-lensOptInjectiveTypeConstructors :: Lens' _ PragmaOptions
+lensOptInjectiveTypeConstructors :: Lens' PragmaOptions _
 lensOptInjectiveTypeConstructors f o = f (_optInjectiveTypeConstructors o) <&> \ i -> o{ _optInjectiveTypeConstructors = i }
 
-lensOptUniversePolymorphism :: Lens' _ PragmaOptions
+lensOptUniversePolymorphism :: Lens' PragmaOptions _
 lensOptUniversePolymorphism f o = f (_optUniversePolymorphism o) <&> \ i -> o{ _optUniversePolymorphism = i }
 
-lensOptIrrelevantProjections :: Lens' _ PragmaOptions
+lensOptIrrelevantProjections :: Lens' PragmaOptions _
 lensOptIrrelevantProjections f o = f (_optIrrelevantProjections o) <&> \ i -> o{ _optIrrelevantProjections = i }
 
-lensOptExperimentalIrrelevance :: Lens' _ PragmaOptions
+lensOptExperimentalIrrelevance :: Lens' PragmaOptions _
 lensOptExperimentalIrrelevance f o = f (_optExperimentalIrrelevance o) <&> \ i -> o{ _optExperimentalIrrelevance = i }
 
-lensOptWithoutK :: Lens' _ PragmaOptions
+lensOptWithoutK :: Lens' PragmaOptions _
 lensOptWithoutK f o = f (_optWithoutK o) <&> \ i -> o{ _optWithoutK = i }
 
-lensOptCubicalCompatible :: Lens' _ PragmaOptions
+lensOptCubicalCompatible :: Lens' PragmaOptions _
 lensOptCubicalCompatible f o = f (_optCubicalCompatible o) <&> \ i -> o{ _optCubicalCompatible = i }
 
-lensOptCopatterns :: Lens' _ PragmaOptions
+lensOptCopatterns :: Lens' PragmaOptions _
 lensOptCopatterns f o = f (_optCopatterns o) <&> \ i -> o{ _optCopatterns = i }
 
-lensOptPatternMatching :: Lens' _ PragmaOptions
+lensOptPatternMatching :: Lens' PragmaOptions _
 lensOptPatternMatching f o = f (_optPatternMatching o) <&> \ i -> o{ _optPatternMatching = i }
 
-lensOptHiddenArgumentPuns :: Lens' _ PragmaOptions
+lensOptHiddenArgumentPuns :: Lens' PragmaOptions _
 lensOptHiddenArgumentPuns f o = f (_optHiddenArgumentPuns o) <&> \ i -> o{ _optHiddenArgumentPuns = i }
 
-lensOptEta :: Lens' _ PragmaOptions
+lensOptEta :: Lens' PragmaOptions _
 lensOptEta f o = f (_optEta o) <&> \ i -> o{ _optEta = i }
 
-lensOptForcing :: Lens' _ PragmaOptions
+lensOptForcing :: Lens' PragmaOptions _
 lensOptForcing f o = f (_optForcing o) <&> \ i -> o{ _optForcing = i }
 
-lensOptProjectionLike :: Lens' _ PragmaOptions
+lensOptProjectionLike :: Lens' PragmaOptions _
 lensOptProjectionLike f o = f (_optProjectionLike o) <&> \ i -> o{ _optProjectionLike = i }
 
-lensOptErasure :: Lens' _ PragmaOptions
+lensOptErasure :: Lens' PragmaOptions _
 lensOptErasure f o = f (_optErasure o) <&> \ i -> o{ _optErasure = i }
 
-lensOptErasedMatches :: Lens' _ PragmaOptions
+lensOptErasedMatches :: Lens' PragmaOptions _
 lensOptErasedMatches f o = f (_optErasedMatches o) <&> \ i -> o{ _optErasedMatches = i }
 
-lensOptEraseRecordParameters :: Lens' _ PragmaOptions
+lensOptEraseRecordParameters :: Lens' PragmaOptions _
 lensOptEraseRecordParameters f o = f (_optEraseRecordParameters o) <&> \ i -> o{ _optEraseRecordParameters = i }
 
-lensOptRewriting :: Lens' _ PragmaOptions
+lensOptRewriting :: Lens' PragmaOptions _
 lensOptRewriting f o = f (_optRewriting o) <&> \ i -> o{ _optRewriting = i }
 
-lensOptCubical :: Lens' _ PragmaOptions
+lensOptCubical :: Lens' PragmaOptions _
 lensOptCubical f o = f (_optCubical o) <&> \ i -> o{ _optCubical = i }
 
-lensOptGuarded :: Lens' _ PragmaOptions
+lensOptGuarded :: Lens' PragmaOptions _
 lensOptGuarded f o = f (_optGuarded o) <&> \ i -> o{ _optGuarded = i }
 
-lensOptFirstOrder :: Lens' _ PragmaOptions
+lensOptFirstOrder :: Lens' PragmaOptions _
 lensOptFirstOrder f o = f (_optFirstOrder o) <&> \ i -> o{ _optFirstOrder = i }
 
-lensOptPostfixProjections :: Lens' _ PragmaOptions
+lensOptPostfixProjections :: Lens' PragmaOptions _
 lensOptPostfixProjections f o = f (_optPostfixProjections o) <&> \ i -> o{ _optPostfixProjections = i }
 
-lensOptKeepPatternVariables :: Lens' _ PragmaOptions
+lensOptKeepPatternVariables :: Lens' PragmaOptions _
 lensOptKeepPatternVariables f o = f (_optKeepPatternVariables o) <&> \ i -> o{ _optKeepPatternVariables = i }
 
-lensOptInferAbsurdClauses :: Lens' _ PragmaOptions
+lensOptInferAbsurdClauses :: Lens' PragmaOptions _
 lensOptInferAbsurdClauses f o = f (_optInferAbsurdClauses o) <&> \ i -> o{ _optInferAbsurdClauses = i }
 
-lensOptInstanceSearchDepth :: Lens' _ PragmaOptions
+lensOptInstanceSearchDepth :: Lens' PragmaOptions _
 lensOptInstanceSearchDepth f o = f (_optInstanceSearchDepth o) <&> \ i -> o{ _optInstanceSearchDepth = i }
 
-lensOptOverlappingInstances :: Lens' _ PragmaOptions
+lensOptOverlappingInstances :: Lens' PragmaOptions _
 lensOptOverlappingInstances f o = f (_optOverlappingInstances o) <&> \ i -> o{ _optOverlappingInstances = i }
 
-lensOptQualifiedInstances :: Lens' _ PragmaOptions
+lensOptQualifiedInstances :: Lens' PragmaOptions _
 lensOptQualifiedInstances f o = f (_optQualifiedInstances o) <&> \ i -> o{ _optQualifiedInstances = i }
 
-lensOptInversionMaxDepth :: Lens' _ PragmaOptions
+lensOptInversionMaxDepth :: Lens' PragmaOptions _
 lensOptInversionMaxDepth f o = f (_optInversionMaxDepth o) <&> \ i -> o{ _optInversionMaxDepth = i }
 
-lensOptSafe :: Lens' _ PragmaOptions
+lensOptSafe :: Lens' PragmaOptions _
 lensOptSafe f o = f (_optSafe o) <&> \ i -> o{ _optSafe = i }
 
-lensOptDoubleCheck :: Lens' _ PragmaOptions
+lensOptDoubleCheck :: Lens' PragmaOptions _
 lensOptDoubleCheck f o = f (_optDoubleCheck o) <&> \ i -> o{ _optDoubleCheck = i }
 
-lensOptSyntacticEquality :: Lens' _ PragmaOptions
+lensOptSyntacticEquality :: Lens' PragmaOptions _
 lensOptSyntacticEquality f o = f (_optSyntacticEquality o) <&> \ i -> o{ _optSyntacticEquality = i }
 
-lensOptWarningMode :: Lens' _ PragmaOptions
+lensOptWarningMode :: Lens' PragmaOptions _
 lensOptWarningMode f o = f (_optWarningMode o) <&> \ i -> o{ _optWarningMode = i }
 
-lensOptCompileMain :: Lens' _ PragmaOptions
+lensOptCompileMain :: Lens' PragmaOptions _
 lensOptCompileMain f o = f (_optCompileMain o) <&> \ i -> o{ _optCompileMain = i }
 
-lensOptCaching :: Lens' _ PragmaOptions
+lensOptCaching :: Lens' PragmaOptions _
 lensOptCaching f o = f (_optCaching o) <&> \ i -> o{ _optCaching = i }
 
-lensOptCountClusters :: Lens' _ PragmaOptions
+lensOptCountClusters :: Lens' PragmaOptions _
 lensOptCountClusters f o = f (_optCountClusters o) <&> \ i -> o{ _optCountClusters = i }
 
-lensOptAutoInline :: Lens' _ PragmaOptions
+lensOptAutoInline :: Lens' PragmaOptions _
 lensOptAutoInline f o = f (_optAutoInline o) <&> \ i -> o{ _optAutoInline = i }
 
-lensOptPrintPatternSynonyms :: Lens' _ PragmaOptions
+lensOptPrintPatternSynonyms :: Lens' PragmaOptions _
 lensOptPrintPatternSynonyms f o = f (_optPrintPatternSynonyms o) <&> \ i -> o{ _optPrintPatternSynonyms = i }
 
-lensOptFastReduce :: Lens' _ PragmaOptions
+lensOptFastReduce :: Lens' PragmaOptions _
 lensOptFastReduce f o = f (_optFastReduce o) <&> \ i -> o{ _optFastReduce = i }
 
-lensOptCallByName :: Lens' _ PragmaOptions
+lensOptCallByName :: Lens' PragmaOptions _
 lensOptCallByName f o = f (_optCallByName o) <&> \ i -> o{ _optCallByName = i }
 
-lensOptConfluenceCheck :: Lens' _ PragmaOptions
+lensOptConfluenceCheck :: Lens' PragmaOptions _
 lensOptConfluenceCheck f o = f (_optConfluenceCheck o) <&> \ i -> o{ _optConfluenceCheck = i }
 
-lensOptCohesion :: Lens' _ PragmaOptions
+lensOptCohesion :: Lens' PragmaOptions _
 lensOptCohesion f o = f (_optCohesion o) <&> \ i -> o{ _optCohesion = i }
 
-lensOptFlatSplit :: Lens' _ PragmaOptions
+lensOptFlatSplit :: Lens' PragmaOptions _
 lensOptFlatSplit f o = f (_optFlatSplit o) <&> \ i -> o{ _optFlatSplit = i }
 
-lensOptImportSorts :: Lens' _ PragmaOptions
+lensOptImportSorts :: Lens' PragmaOptions _
 lensOptImportSorts f o = f (_optImportSorts o) <&> \ i -> o{ _optImportSorts = i }
 
-lensOptLoadPrimitives :: Lens' _ PragmaOptions
+lensOptLoadPrimitives :: Lens' PragmaOptions _
 lensOptLoadPrimitives f o = f (_optLoadPrimitives o) <&> \ i -> o{ _optLoadPrimitives = i }
 
-lensOptAllowExec :: Lens' _ PragmaOptions
+lensOptAllowExec :: Lens' PragmaOptions _
 lensOptAllowExec f o = f (_optAllowExec o) <&> \ i -> o{ _optAllowExec = i }
 
-lensOptSaveMetas :: Lens' _ PragmaOptions
+lensOptSaveMetas :: Lens' PragmaOptions _
 lensOptSaveMetas f o = f (_optSaveMetas o) <&> \ i -> o{ _optSaveMetas = i }
 
-lensOptShowIdentitySubstitutions :: Lens' _ PragmaOptions
+lensOptShowIdentitySubstitutions :: Lens' PragmaOptions _
 lensOptShowIdentitySubstitutions f o = f (_optShowIdentitySubstitutions o) <&> \ i -> o{ _optShowIdentitySubstitutions = i }
 
-lensOptKeepCoveringClauses :: Lens' _ PragmaOptions
+lensOptKeepCoveringClauses :: Lens' PragmaOptions _
 lensOptKeepCoveringClauses f o = f (_optKeepCoveringClauses o) <&> \ i -> o{ _optKeepCoveringClauses = i }
 
 -- Lenses for particular warnings
 
-lensOptExactSplit :: Lens' Bool PragmaOptions
+lensOptExactSplit :: Lens' PragmaOptions Bool
 lensOptExactSplit = lensOptWarningMode . lensSingleWarning CoverageNoExactSplit_
 
 
@@ -1433,7 +1433,7 @@ standardOptions =
 
 -- | Defined locally here since module ''Agda.Interaction.Options.Lenses''
 --   has cyclic dependency.
-lensPragmaOptions :: Lens' PragmaOptions CommandLineOptions
+lensPragmaOptions :: Lens' CommandLineOptions PragmaOptions
 lensPragmaOptions f st = f (optPragmaOptions st) <&> \ opts -> st { optPragmaOptions = opts }
 
 -- | Command line options of previous versions of Agda.
@@ -1453,7 +1453,7 @@ deadStandardOptions =
 pragmaFlag :: (IsBool a, KnownBool b)
   => String
        -- ^ Long option name.  Prepended with @no-@ for negative version.
-  -> Lens' (WithDefault' a b) PragmaOptions
+  -> Lens' PragmaOptions (WithDefault' a b)
        -- ^ Field to switch.
   -> String
        -- ^ Explanation for positive option.
@@ -1469,7 +1469,7 @@ pragmaFlag long field = pragmaFlag' long field (const return)
 pragmaFlag' :: (IsBool a, KnownBool b)
   => String
        -- ^ Long option name.  Prepended with @no-@ for negative version.
-  -> Lens' (WithDefault' a b) PragmaOptions
+  -> Lens' PragmaOptions (WithDefault' a b)
        -- ^ Field to switch.
   -> (a -> Flag PragmaOptions)
        -- ^ Given the new value, perform additional effect (can override field setting).
@@ -1488,7 +1488,7 @@ pragmaFlag' long field = pragmaFlagBool' long (field . lensCollapseDefault)
 pragmaFlagBool :: (IsBool a)
   => String
        -- ^ Long option name.  Prepended with @no-@ for negative version.
-  -> Lens' a PragmaOptions
+  -> Lens' PragmaOptions a
        -- ^ Field to switch.
   -> String
        -- ^ Explanation for positive option.
@@ -1504,7 +1504,7 @@ pragmaFlagBool long field = pragmaFlagBool' long field (const return)
 pragmaFlagBool' :: IsBool a
   => String
        -- ^ Long option name.  Prepended with @no-@ for negative version.
-  -> Lens' a PragmaOptions
+  -> Lens' PragmaOptions a
        -- ^ Field to switch.
   -> (a -> Flag PragmaOptions)
        -- ^ Given the new value, perform additional effect (can override field setting).

--- a/src/full/Agda/Interaction/Options/Lenses.hs
+++ b/src/full/Agda/Interaction/Options/Lenses.hs
@@ -30,7 +30,7 @@ class LensPragmaOptions a where
   getPragmaOptions  :: a -> PragmaOptions
   setPragmaOptions  :: PragmaOptions -> a -> a
   mapPragmaOptions  :: (PragmaOptions -> PragmaOptions) -> a -> a
-  lensPragmaOptions :: Lens' PragmaOptions a
+  lensPragmaOptions :: Lens' a PragmaOptions
   -- lensPragmaOptions :: forall f. Functor f => (PragmaOptions -> f PragmaOptions) -> a -> f a
 
   -- default implementations

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -57,13 +57,13 @@ instance NFData WarningMode
 
 -- Lenses
 
-warningSet :: Lens' (Set WarningName) WarningMode
+warningSet :: Lens' WarningMode (Set WarningName)
 warningSet f o = (\ ws -> o { _warningSet = ws }) <$> f (_warningSet o)
 
-warn2Error :: Lens' Bool WarningMode
+warn2Error :: Lens' WarningMode Bool
 warn2Error f o = (\ ws -> o { _warn2Error = ws }) <$> f (_warn2Error o)
 
-lensSingleWarning :: WarningName -> Lens' Bool WarningMode
+lensSingleWarning :: WarningName -> Lens' WarningMode Bool
 lensSingleWarning w = warningSet . contains w
 
 -- | The @defaultWarningMode@ is a curated set of warnings covering non-fatal

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -317,7 +317,7 @@ instance NumHoles AmbiguousQName where
 -- * name lenses
 ------------------------------------------------------------------------
 
-lensQNameName :: Lens' Name QName
+lensQNameName :: Lens' QName Name
 lensQNameName f (QName m n) = QName m <$> f n
 
 ------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -533,13 +533,13 @@ instance NFData Modality where
 
 -- Lens stuff
 
-lModRelevance :: Lens' Relevance Modality
+lModRelevance :: Lens' Modality Relevance
 lModRelevance f m = f (modRelevance m) <&> \ r -> m { modRelevance = r }
 
-lModQuantity :: Lens' Quantity Modality
+lModQuantity :: Lens' Modality Quantity
 lModQuantity f m = f (modQuantity m) <&> \ q -> m { modQuantity = q }
 
-lModCohesion :: Lens' Cohesion Modality
+lModCohesion :: Lens' Modality Cohesion
 lModCohesion f m = f (modCohesion m) <&> \ q -> m { modCohesion = q }
 
 class LensModality a where
@@ -579,35 +579,35 @@ instance LensCohesion Modality where
 
 -- default accessors for Relevance
 
-getRelevanceMod :: LensModality a => LensGet Relevance a
+getRelevanceMod :: LensModality a => LensGet a Relevance
 getRelevanceMod = getRelevance . getModality
 
-setRelevanceMod :: LensModality a => LensSet Relevance a
+setRelevanceMod :: LensModality a => LensSet a Relevance
 setRelevanceMod = mapModality . setRelevance
 
-mapRelevanceMod :: LensModality a => LensMap Relevance a
+mapRelevanceMod :: LensModality a => LensMap a Relevance
 mapRelevanceMod = mapModality . mapRelevance
 
 -- default accessors for Quantity
 
-getQuantityMod :: LensModality a => LensGet Quantity a
+getQuantityMod :: LensModality a => LensGet a Quantity
 getQuantityMod = getQuantity . getModality
 
-setQuantityMod :: LensModality a => LensSet Quantity a
+setQuantityMod :: LensModality a => LensSet a Quantity
 setQuantityMod = mapModality . setQuantity
 
-mapQuantityMod :: LensModality a => LensMap Quantity a
+mapQuantityMod :: LensModality a => LensMap a Quantity
 mapQuantityMod = mapModality . mapQuantity
 
 -- default accessors for Cohesion
 
-getCohesionMod :: LensModality a => LensGet Cohesion a
+getCohesionMod :: LensModality a => LensGet a Cohesion
 getCohesionMod = getCohesion . getModality
 
-setCohesionMod :: LensModality a => LensSet Cohesion a
+setCohesionMod :: LensModality a => LensSet a Cohesion
 setCohesionMod = mapModality . setCohesion
 
-mapCohesionMod :: LensModality a => LensMap Cohesion a
+mapCohesionMod :: LensModality a => LensMap a Cohesion
 mapCohesionMod = mapModality . mapCohesion
 
 ---------------------------------------------------------------------------
@@ -1749,46 +1749,46 @@ defaultArgInfo =  ArgInfo
 
 -- default accessors for Hiding
 
-getHidingArgInfo :: LensArgInfo a => LensGet Hiding a
+getHidingArgInfo :: LensArgInfo a => LensGet a Hiding
 getHidingArgInfo = getHiding . getArgInfo
 
-setHidingArgInfo :: LensArgInfo a => LensSet Hiding a
+setHidingArgInfo :: LensArgInfo a => LensSet a Hiding
 setHidingArgInfo = mapArgInfo . setHiding
 
-mapHidingArgInfo :: LensArgInfo a => LensMap Hiding a
+mapHidingArgInfo :: LensArgInfo a => LensMap a Hiding
 mapHidingArgInfo = mapArgInfo . mapHiding
 
 -- default accessors for Modality
 
-getModalityArgInfo :: LensArgInfo a => LensGet Modality a
+getModalityArgInfo :: LensArgInfo a => LensGet a Modality
 getModalityArgInfo = getModality . getArgInfo
 
-setModalityArgInfo :: LensArgInfo a => LensSet Modality a
+setModalityArgInfo :: LensArgInfo a => LensSet a Modality
 setModalityArgInfo = mapArgInfo . setModality
 
-mapModalityArgInfo :: LensArgInfo a => LensMap Modality a
+mapModalityArgInfo :: LensArgInfo a => LensMap a Modality
 mapModalityArgInfo = mapArgInfo . mapModality
 
 -- default accessors for Origin
 
-getOriginArgInfo :: LensArgInfo a => LensGet Origin a
+getOriginArgInfo :: LensArgInfo a => LensGet a Origin
 getOriginArgInfo = getOrigin . getArgInfo
 
-setOriginArgInfo :: LensArgInfo a => LensSet Origin a
+setOriginArgInfo :: LensArgInfo a => LensSet a Origin
 setOriginArgInfo = mapArgInfo . setOrigin
 
-mapOriginArgInfo :: LensArgInfo a => LensMap Origin a
+mapOriginArgInfo :: LensArgInfo a => LensMap a Origin
 mapOriginArgInfo = mapArgInfo . mapOrigin
 
 -- default accessors for FreeVariables
 
-getFreeVariablesArgInfo :: LensArgInfo a => LensGet FreeVariables a
+getFreeVariablesArgInfo :: LensArgInfo a => LensGet a FreeVariables
 getFreeVariablesArgInfo = getFreeVariables . getArgInfo
 
-setFreeVariablesArgInfo :: LensArgInfo a => LensSet FreeVariables a
+setFreeVariablesArgInfo :: LensArgInfo a => LensSet a FreeVariables
 setFreeVariablesArgInfo = mapArgInfo . setFreeVariables
 
-mapFreeVariablesArgInfo :: LensArgInfo a => LensMap FreeVariables a
+mapFreeVariablesArgInfo :: LensArgInfo a => LensMap a FreeVariables
 mapFreeVariablesArgInfo = mapArgInfo . mapFreeVariables
 
 -- inserted hidden arguments
@@ -2003,10 +2003,10 @@ userNamed = Named . Just . WithOrigin UserWritten
 class LensNamed a where
   -- | The type of the name
   type NameOf a
-  lensNamed :: Lens' (Maybe (NameOf a)) a
+  lensNamed :: Lens' a (Maybe (NameOf a))
 
   -- Lenses lift through decorations:
-  default lensNamed :: (Decoration f, LensNamed b, NameOf b ~ NameOf a, f b ~ a) => Lens' (Maybe (NameOf a)) a
+  default lensNamed :: (Decoration f, LensNamed b, NameOf b ~ NameOf a, f b ~ a) => Lens' a (Maybe (NameOf a))
   lensNamed = traverseF . lensNamed
 
 instance LensNamed a => LensNamed (Arg a) where
@@ -2279,7 +2279,7 @@ instance KillRange IsAbstract where
 instance NFData IsAbstract
 
 class LensIsAbstract a where
-  lensIsAbstract :: Lens' IsAbstract a
+  lensIsAbstract :: Lens' a IsAbstract
 
 instance LensIsAbstract IsAbstract where
   lensIsAbstract = id
@@ -2593,16 +2593,16 @@ instance KillRange Fixity' where
 
 -- lenses
 
-_fixityAssoc :: Lens' Associativity Fixity
+_fixityAssoc :: Lens' Fixity Associativity
 _fixityAssoc f r = f (fixityAssoc r) <&> \x -> r { fixityAssoc = x }
 
-_fixityLevel :: Lens' FixityLevel Fixity
+_fixityLevel :: Lens' Fixity FixityLevel
 _fixityLevel f r = f (fixityLevel r) <&> \x -> r { fixityLevel = x }
 
 -- Lens focusing on Fixity
 
 class LensFixity a where
-  lensFixity :: Lens' Fixity a
+  lensFixity :: Lens' a Fixity
 
 instance LensFixity Fixity where
   lensFixity = id
@@ -2613,7 +2613,7 @@ instance LensFixity Fixity' where
 -- Lens focusing on Fixity'
 
 class LensFixity' a where
-  lensFixity' :: Lens' Fixity' a
+  lensFixity' :: Lens' a Fixity'
 
 instance LensFixity' Fixity' where
   lensFixity' = id

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -123,20 +123,20 @@ data ModuleAssignment  = ModuleAssignment
 type RecordAssignment  = Either FieldAssignment ModuleAssignment
 type RecordAssignments = [RecordAssignment]
 
-nameFieldA :: Lens' Name (FieldAssignment' a)
+nameFieldA :: Lens' (FieldAssignment' a) Name
 nameFieldA f r = f (_nameFieldA r) <&> \x -> r { _nameFieldA = x }
 
-exprFieldA :: Lens' a (FieldAssignment' a)
+exprFieldA :: Lens' (FieldAssignment' a) a
 exprFieldA f r = f (_exprFieldA r) <&> \x -> r { _exprFieldA = x }
 
 -- UNUSED Liang-Ting Chen 2019-07-16
---qnameModA :: Lens' QName ModuleAssignment
+--qnameModA :: Lens' ModuleAssignment QName
 --qnameModA f r = f (_qnameModA r) <&> \x -> r { _qnameModA = x }
 --
 --exprModA :: Lens' [Expr] ModuleAssignment
 --exprModA f r = f (_exprModA r) <&> \x -> r { _exprModA = x }
 --
---importDirModA :: Lens' ImportDirective ModuleAssignment
+--importDirModA :: Lens' ModuleAssignment ImportDirective
 --importDirModA f r = f (_importDirModA r) <&> \x -> r { _importDirModA = x }
 
 -- | Concrete expressions. Should represent exactly what the user wrote.

--- a/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
@@ -91,7 +91,7 @@ initNiceEnv = NiceEnv
   , _nameId   = NameId 1 noModuleNameHash
   }
 
-lensNameId :: Lens' NameId NiceEnv
+lensNameId :: Lens' NiceEnv NameId
 lensNameId f e = f (_nameId e) <&> \ i -> e { _nameId = i }
 
 nextNameId :: Nice NameId
@@ -104,7 +104,7 @@ nextNameId = do
 
 -- | Lens for field '_loneSigs'.
 
-loneSigs :: Lens' LoneSigs NiceEnv
+loneSigs :: Lens' NiceEnv LoneSigs
 loneSigs f e = f (_loneSigs e) <&> \ s -> e { _loneSigs = s }
 
 -- | Adding a lone signature to the state.
@@ -162,7 +162,7 @@ loneSigsFromLoneNames = Map.fromListWith __IMPOSSIBLE__ . map (\(r,x,k) -> (x, L
 
 -- | Lens for field '_termChk'.
 
-terminationCheckPragma :: Lens' TerminationCheck NiceEnv
+terminationCheckPragma :: Lens' NiceEnv TerminationCheck
 terminationCheckPragma f e = f (_termChk e) <&> \ s -> e { _termChk = s }
 
 withTerminationCheckPragma :: TerminationCheck -> Nice a -> Nice a
@@ -173,7 +173,7 @@ withTerminationCheckPragma tc f = do
   terminationCheckPragma .= tc_old
   return result
 
-coverageCheckPragma :: Lens' CoverageCheck NiceEnv
+coverageCheckPragma :: Lens' NiceEnv CoverageCheck
 coverageCheckPragma f e = f (_covChk e) <&> \ s -> e { _covChk = s }
 
 withCoverageCheckPragma :: CoverageCheck -> Nice a -> Nice a
@@ -186,7 +186,7 @@ withCoverageCheckPragma tc f = do
 
 -- | Lens for field '_posChk'.
 
-positivityCheckPragma :: Lens' PositivityCheck NiceEnv
+positivityCheckPragma :: Lens' NiceEnv PositivityCheck
 positivityCheckPragma f e = f (_posChk e) <&> \ s -> e { _posChk = s }
 
 withPositivityCheckPragma :: PositivityCheck -> Nice a -> Nice a
@@ -199,7 +199,7 @@ withPositivityCheckPragma pc f = do
 
 -- | Lens for field '_uniChk'.
 
-universeCheckPragma :: Lens' UniverseCheck NiceEnv
+universeCheckPragma :: Lens' NiceEnv UniverseCheck
 universeCheckPragma f e = f (_uniChk e) <&> \ s -> e { _uniChk = s }
 
 withUniverseCheckPragma :: UniverseCheck -> Nice a -> Nice a
@@ -218,7 +218,7 @@ getUniverseCheckFromSig x = maybe YesUniverseCheck universeCheck <$> getSig x
 
 -- | Lens for field '_catchall'.
 
-catchallPragma :: Lens' Catchall NiceEnv
+catchallPragma :: Lens' NiceEnv Catchall
 catchallPragma f e = f (_catchall e) <&> \ s -> e { _catchall = s }
 
 -- | Get current catchall pragma, and reset it for the next clause.

--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -138,7 +138,7 @@ simpleHole = Name noRange InScope $ singleton Hole
 ------------------------------------------------------------------------
 
 -- | Don't use on 'NoName{}'.
-lensNameParts :: Lens' NameParts Name
+lensNameParts :: Lens' Name NameParts
 lensNameParts f = \case
   n@Name{} -> f (nameNameParts n) <&> \ ps -> n { nameNameParts = ps }
   NoName{} -> __IMPOSSIBLE__
@@ -207,7 +207,7 @@ data NameInScope = InScope | NotInScope
   deriving (Eq, Show)
 
 class LensInScope a where
-  lensInScope :: Lens' NameInScope a
+  lensInScope :: Lens' a NameInScope
 
   isInScope :: a -> NameInScope
   isInScope x = x ^. lensInScope
@@ -269,7 +269,7 @@ nextName freshNameMode x@Name{} = setNotInScope $ over (lensNameParts . lastIdPa
 nextName             _ NoName{} = __IMPOSSIBLE__
 
 -- | Zoom on the last non-hole in a name.
-lastIdPart :: Lens' RawName NameParts
+lastIdPart :: Lens' NameParts RawName
 lastIdPart f = loop
   where
   loop = \case
@@ -289,7 +289,7 @@ firstNonTakenName freshNameMode taken x =
 -- | Lens for accessing and modifying the suffix of a name.
 --   The suffix of a @NoName@ is always @Nothing@, and should not be
 --   changed.
-nameSuffix :: Lens' (Maybe Suffix) Name
+nameSuffix :: Lens' Name (Maybe Suffix)
 nameSuffix (f :: Maybe Suffix -> f (Maybe Suffix)) = \case
 
   n@NoName{} -> f Nothing <&> \case
@@ -324,7 +324,7 @@ sameRoot = (==) `on` nameRoot
 ------------------------------------------------------------------------
 
 -- | Lens for the unqualified part of a QName
-lensQNameName :: Lens' Name QName
+lensQNameName :: Lens' QName Name
 lensQNameName f (QName n)  = QName <$> f n
 lensQNameName f (Qual m n) = Qual m <$> lensQNameName f n
 

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -266,7 +266,7 @@ instance Decoration (Type'' t) where
   traverseF f (El s a) = El s <$> f a
 
 class LensSort a where
-  lensSort ::  Lens' Sort a
+  lensSort ::  Lens' a Sort
   getSort  :: a -> Sort
   getSort a = a ^. lensSort
 
@@ -948,7 +948,7 @@ telToList (ExtendTel arg (Abs x tel)) = fmap (x,) arg : telToList tel
 telToList (ExtendTel _    NoAbs{}   ) = __IMPOSSIBLE__
 
 -- | Lens to edit a 'Telescope' as a list.
-listTel :: Lens' ListTel Telescope
+listTel :: Lens' Telescope ListTel
 listTel f = fmap telFromList . f . telToList
 
 -- | Drop the types from a telescope.

--- a/src/full/Agda/Syntax/Notation.hs
+++ b/src/full/Agda/Syntax/Notation.hs
@@ -374,7 +374,7 @@ isLambdaNotation n = any isBinder (notation n)
 
 -- | Lens for 'Fixity' in 'NewNotation'.
 
-_notaFixity :: Lens' Fixity NewNotation
+_notaFixity :: Lens' NewNotation Fixity
 _notaFixity f r = f (notaFixity r) <&> \x -> r { notaFixity = x }
 
 -- * Sections

--- a/src/full/Agda/Syntax/Parser/Alex.hs
+++ b/src/full/Agda/Syntax/Parser/Alex.hs
@@ -35,7 +35,7 @@ data AlexInput = AlexInput
   }
 
 -- | A lens for 'lexInput'.
-lensLexInput :: Lens' String AlexInput
+lensLexInput :: Lens' AlexInput String
 lensLexInput f r = f (lexInput r) <&> \ s -> r { lexInput = s }
 
 -- | Get the previously lexed character. Same as 'lexPrevChar'. Alex needs this

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -210,57 +210,57 @@ notShadowedLocals :: LocalVars -> AssocList C.Name A.Name
 notShadowedLocals = mapMaybe $ \ (c,x) -> (c,) <$> notShadowedLocal x
 
 -- | Lenses for ScopeInfo components
-scopeCurrent :: Lens' A.ModuleName ScopeInfo
+scopeCurrent :: Lens' ScopeInfo A.ModuleName
 scopeCurrent f s =
   f (_scopeCurrent s) <&>
   \x -> s { _scopeCurrent = x }
 
-scopeModules :: Lens' (Map A.ModuleName Scope) ScopeInfo
+scopeModules :: Lens' ScopeInfo (Map A.ModuleName Scope)
 scopeModules f s =
   f (_scopeModules s) <&>
   \x -> s { _scopeModules = x }
 
-scopeVarsToBind :: Lens' LocalVars ScopeInfo
+scopeVarsToBind :: Lens' ScopeInfo LocalVars
 scopeVarsToBind f s =
   f (_scopeVarsToBind s) <&>
   \x -> s { _scopeVarsToBind = x }
 
-scopeLocals :: Lens' LocalVars ScopeInfo
+scopeLocals :: Lens' ScopeInfo LocalVars
 scopeLocals f s =
   f (_scopeLocals s) <&>
   \x -> s { _scopeLocals = x }
 
-scopePrecedence :: Lens' PrecedenceStack ScopeInfo
+scopePrecedence :: Lens' ScopeInfo PrecedenceStack
 scopePrecedence f s =
   f (_scopePrecedence s) <&>
   \x -> s { _scopePrecedence = x }
 
-scopeInverseName :: Lens' NameMap ScopeInfo
+scopeInverseName :: Lens' ScopeInfo NameMap
 scopeInverseName f s =
   f (_scopeInverseName s) <&>
   \x -> s { _scopeInverseName = x }
 
-scopeInverseModule :: Lens' ModuleMap ScopeInfo
+scopeInverseModule :: Lens' ScopeInfo ModuleMap
 scopeInverseModule f s =
   f (_scopeInverseModule s) <&>
   \x -> s { _scopeInverseModule = x }
 
-scopeInScope :: Lens' InScopeSet ScopeInfo
+scopeInScope :: Lens' ScopeInfo InScopeSet
 scopeInScope f s =
   f (_scopeInScope s) <&>
   \x -> s { _scopeInScope = x }
 
-scopeFixities :: Lens' C.Fixities ScopeInfo
+scopeFixities :: Lens' ScopeInfo C.Fixities
 scopeFixities f s =
   f (_scopeFixities s) <&>
   \x -> s { _scopeFixities = x }
 
-scopePolarities :: Lens' C.Polarities ScopeInfo
+scopePolarities :: Lens' ScopeInfo C.Polarities
 scopePolarities f s =
   f (_scopePolarities s) <&>
   \x -> s { _scopePolarities = x }
 
-scopeFixitiesAndPolarities :: Lens' (C.Fixities, C.Polarities) ScopeInfo
+scopeFixitiesAndPolarities :: Lens' ScopeInfo (C.Fixities, C.Polarities)
 scopeFixitiesAndPolarities f s =
   f' (_scopeFixities s) (_scopePolarities s) <&>
   \ (fixs, pols) -> s { _scopeFixities = fixs, _scopePolarities = pols }
@@ -489,7 +489,7 @@ instance LensFixity AbstractName where
   lensFixity = lensAnameName . lensFixity
 
 -- | Van Laarhoven lens on 'anameName'.
-lensAnameName :: Lens' A.QName AbstractName
+lensAnameName :: Lens' AbstractName A.QName
 lensAnameName f am = f (anameName am) <&> \ m -> am { anameName = m }
 
 instance Eq AbstractModule where
@@ -499,7 +499,7 @@ instance Ord AbstractModule where
   compare = compare `on` amodName
 
 -- | Van Laarhoven lens on 'amodName'.
-lensAmodName :: Lens' A.ModuleName AbstractModule
+lensAmodName :: Lens' AbstractModule A.ModuleName
 lensAmodName f am = f (amodName am) <&> \ m -> am { amodName = m }
 
 

--- a/src/full/Agda/Syntax/TopLevelModuleName.hs
+++ b/src/full/Agda/Syntax/TopLevelModuleName.hs
@@ -180,7 +180,7 @@ instance NFData TopLevelModuleName where
 -- | A lens focusing on the 'moduleNameParts'.
 
 lensTopLevelModuleNameParts ::
-  Lens' TopLevelModuleNameParts TopLevelModuleName
+  Lens' TopLevelModuleName TopLevelModuleNameParts
 lensTopLevelModuleNameParts f m =
   f (moduleNameParts m) <&> \ xs -> m{ moduleNameParts = xs }
 

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -341,7 +341,7 @@ terUnguarded = terSetGuarded unknown
 
 -- | Lens for '_terSizeDepth'.
 
-terSizeDepth :: Lens' Int TerEnv
+terSizeDepth :: Lens' TerEnv Int
 terSizeDepth f e = f (_terSizeDepth e) <&> \ i -> e { _terSizeDepth = i }
 
 -- | Lens for 'terUsableVars'.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -137,7 +137,7 @@ data TCState = TCSt
 
 class Monad m => ReadTCState m where
   getTCState :: m TCState
-  locallyTCState :: Lens' a TCState -> (a -> a) -> m b -> m b
+  locallyTCState :: Lens' TCState a -> (a -> a) -> m b -> m b
 
   withTCState :: (TCState -> TCState) -> m a -> m a
   withTCState = locallyTCState id
@@ -147,7 +147,7 @@ class Monad m => ReadTCState m where
 
   default locallyTCState
     :: (MonadTransControl t, ReadTCState n, t n ~ m)
-    => Lens' a TCState -> (a -> a) -> m b -> m b
+    => Lens' TCState a -> (a -> a) -> m b -> m b
   locallyTCState l = liftThrough . locallyTCState l
 
 instance ReadTCState m => ReadTCState (ListT m) where
@@ -457,78 +457,78 @@ initState = TCSt
 -- * st-prefixed lenses
 ------------------------------------------------------------------------
 
-stTokens :: Lens' HighlightingInfo TCState
+stTokens :: Lens' TCState HighlightingInfo
 stTokens f s =
   f (stPreTokens (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreTokens = x}}
 
-stImports :: Lens' Signature TCState
+stImports :: Lens' TCState Signature
 stImports f s =
   f (stPreImports (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreImports = x}}
 
 stImportedModules ::
-  Lens' (HashSet TopLevelModuleName) TCState
+  Lens' TCState (HashSet TopLevelModuleName)
 stImportedModules f s =
   f (stPreImportedModules (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreImportedModules = x}}
 
-stModuleToSource :: Lens' ModuleToSource TCState
+stModuleToSource :: Lens' TCState ModuleToSource
 stModuleToSource f s =
   f (stPreModuleToSource (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreModuleToSource = x}}
 
-stVisitedModules :: Lens' VisitedModules TCState
+stVisitedModules :: Lens' TCState VisitedModules
 stVisitedModules f s =
   f (stPreVisitedModules (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreVisitedModules = x}}
 
-stScope :: Lens' ScopeInfo TCState
+stScope :: Lens' TCState ScopeInfo
 stScope f s =
   f (stPreScope (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreScope = x}}
 
-stPatternSyns :: Lens' A.PatternSynDefns TCState
+stPatternSyns :: Lens' TCState A.PatternSynDefns
 stPatternSyns f s =
   f (stPrePatternSyns (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPrePatternSyns = x}}
 
-stPatternSynImports :: Lens' A.PatternSynDefns TCState
+stPatternSynImports :: Lens' TCState A.PatternSynDefns
 stPatternSynImports f s =
   f (stPrePatternSynImports (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPrePatternSynImports = x}}
 
-stGeneralizedVars :: Lens' (Maybe (Set QName)) TCState
+stGeneralizedVars :: Lens' TCState (Maybe (Set QName))
 stGeneralizedVars f s =
   f (Strict.toLazy $ stPreGeneralizedVars (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreGeneralizedVars = Strict.toStrict x}}
 
-stPragmaOptions :: Lens' PragmaOptions TCState
+stPragmaOptions :: Lens' TCState PragmaOptions
 stPragmaOptions f s =
   f (stPrePragmaOptions (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPrePragmaOptions = x}}
 
-stImportedBuiltins :: Lens' (BuiltinThings PrimFun) TCState
+stImportedBuiltins :: Lens' TCState (BuiltinThings PrimFun)
 stImportedBuiltins f s =
   f (stPreImportedBuiltins (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreImportedBuiltins = x}}
 
-stForeignCode :: Lens' (Map BackendName ForeignCodeStack) TCState
+stForeignCode :: Lens' TCState (Map BackendName ForeignCodeStack)
 stForeignCode f s =
   f (stPreForeignCode (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreForeignCode = x}}
 
-stFreshInteractionId :: Lens' InteractionId TCState
+stFreshInteractionId :: Lens' TCState InteractionId
 stFreshInteractionId f s =
   f (stPreFreshInteractionId (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreFreshInteractionId = x}}
 
-stImportedUserWarnings :: Lens' (Map A.QName Text) TCState
+stImportedUserWarnings :: Lens' TCState (Map A.QName Text)
 stImportedUserWarnings f s =
   f (stPreImportedUserWarnings (stPreScopeState s)) <&>
   \ x -> s {stPreScopeState = (stPreScopeState s) {stPreImportedUserWarnings = x}}
 
-stLocalUserWarnings :: Lens' (Map A.QName Text) TCState
+stLocalUserWarnings :: Lens' TCState (Map A.QName Text)
 stLocalUserWarnings f s =
   f (stPreLocalUserWarnings (stPreScopeState s)) <&>
   \ x -> s {stPreScopeState = (stPreScopeState s) {stPreLocalUserWarnings = x}}
@@ -539,17 +539,17 @@ getUserWarnings = do
   luw <- useR stLocalUserWarnings
   return $ iuw `Map.union` luw
 
-stWarningOnImport :: Lens' (Maybe Text) TCState
+stWarningOnImport :: Lens' TCState (Maybe Text)
 stWarningOnImport f s =
   f (Strict.toLazy $ stPreWarningOnImport (stPreScopeState s)) <&>
   \ x -> s {stPreScopeState = (stPreScopeState s) {stPreWarningOnImport = Strict.toStrict x}}
 
-stImportedPartialDefs :: Lens' (Set QName) TCState
+stImportedPartialDefs :: Lens' TCState (Set QName)
 stImportedPartialDefs f s =
   f (stPreImportedPartialDefs (stPreScopeState s)) <&>
   \ x -> s {stPreScopeState = (stPreScopeState s) {stPreImportedPartialDefs = x}}
 
-stLocalPartialDefs :: Lens' (Set QName) TCState
+stLocalPartialDefs :: Lens' TCState (Set QName)
 stLocalPartialDefs f s =
   f (stPostLocalPartialDefs (stPostScopeState s)) <&>
   \ x -> s {stPostScopeState = (stPostScopeState s) {stPostLocalPartialDefs = x}}
@@ -560,104 +560,104 @@ getPartialDefs = do
   lpd <- useR stLocalPartialDefs
   return $ ipd `Set.union` lpd
 
-stLoadedFileCache :: Lens' (Maybe LoadedFileCache) TCState
+stLoadedFileCache :: Lens' TCState (Maybe LoadedFileCache)
 stLoadedFileCache f s =
   f (Strict.toLazy $ stPersistLoadedFileCache (stPersistentState s)) <&>
   \x -> s {stPersistentState = (stPersistentState s) {stPersistLoadedFileCache = Strict.toStrict x}}
 
-stBackends :: Lens' [Backend] TCState
+stBackends :: Lens' TCState [Backend]
 stBackends f s =
   f (stPersistBackends (stPersistentState s)) <&>
   \x -> s {stPersistentState = (stPersistentState s) {stPersistBackends = x}}
 
-stProjectConfigs :: Lens' (Map FilePath ProjectConfig) TCState
+stProjectConfigs :: Lens' TCState (Map FilePath ProjectConfig)
 stProjectConfigs f s =
   f (stPreProjectConfigs (stPreScopeState s)) <&>
   \ x -> s {stPreScopeState = (stPreScopeState s) {stPreProjectConfigs = x}}
 
-stAgdaLibFiles :: Lens' (Map FilePath AgdaLibFile) TCState
+stAgdaLibFiles :: Lens' TCState (Map FilePath AgdaLibFile)
 stAgdaLibFiles f s =
   f (stPreAgdaLibFiles (stPreScopeState s)) <&>
   \ x -> s {stPreScopeState = (stPreScopeState s) {stPreAgdaLibFiles = x}}
 
 stTopLevelModuleNames ::
-  Lens' (BiMap RawTopLevelModuleName ModuleNameHash) TCState
+  Lens' TCState (BiMap RawTopLevelModuleName ModuleNameHash)
 stTopLevelModuleNames f s =
   f (stPersistentTopLevelModuleNames (stPersistentState s)) <&>
   \ x -> s {stPersistentState =
               (stPersistentState s) {stPersistentTopLevelModuleNames = x}}
 
-stImportedMetaStore :: Lens' RemoteMetaStore TCState
+stImportedMetaStore :: Lens' TCState RemoteMetaStore
 stImportedMetaStore f s =
   f (stPreImportedMetaStore (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreImportedMetaStore = x}}
 
-stFreshNameId :: Lens' NameId TCState
+stFreshNameId :: Lens' TCState NameId
 stFreshNameId f s =
   f (stPostFreshNameId (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostFreshNameId = x}}
 
-stSyntaxInfo :: Lens' HighlightingInfo TCState
+stSyntaxInfo :: Lens' TCState HighlightingInfo
 stSyntaxInfo f s =
   f (stPostSyntaxInfo (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostSyntaxInfo = x}}
 
-stDisambiguatedNames :: Lens' DisambiguatedNames TCState
+stDisambiguatedNames :: Lens' TCState DisambiguatedNames
 stDisambiguatedNames f s =
   f (stPostDisambiguatedNames (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostDisambiguatedNames = x}}
 
-stOpenMetaStore :: Lens' LocalMetaStore TCState
+stOpenMetaStore :: Lens' TCState LocalMetaStore
 stOpenMetaStore f s =
   f (stPostOpenMetaStore (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostOpenMetaStore = x}}
 
-stSolvedMetaStore :: Lens' LocalMetaStore TCState
+stSolvedMetaStore :: Lens' TCState LocalMetaStore
 stSolvedMetaStore f s =
   f (stPostSolvedMetaStore (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostSolvedMetaStore = x}}
 
-stInteractionPoints :: Lens' InteractionPoints TCState
+stInteractionPoints :: Lens' TCState InteractionPoints
 stInteractionPoints f s =
   f (stPostInteractionPoints (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostInteractionPoints = x}}
 
-stAwakeConstraints :: Lens' Constraints TCState
+stAwakeConstraints :: Lens' TCState Constraints
 stAwakeConstraints f s =
   f (stPostAwakeConstraints (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostAwakeConstraints = x}}
 
-stSleepingConstraints :: Lens' Constraints TCState
+stSleepingConstraints :: Lens' TCState Constraints
 stSleepingConstraints f s =
   f (stPostSleepingConstraints (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostSleepingConstraints = x}}
 
-stDirty :: Lens' Bool TCState
+stDirty :: Lens' TCState Bool
 stDirty f s =
   f (stPostDirty (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostDirty = x}}
 
-stOccursCheckDefs :: Lens' (Set QName) TCState
+stOccursCheckDefs :: Lens' TCState (Set QName)
 stOccursCheckDefs f s =
   f (stPostOccursCheckDefs (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostOccursCheckDefs = x}}
 
-stSignature :: Lens' Signature TCState
+stSignature :: Lens' TCState Signature
 stSignature f s =
   f (stPostSignature (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostSignature = x}}
 
-stModuleCheckpoints :: Lens' (Map ModuleName CheckpointId) TCState
+stModuleCheckpoints :: Lens' TCState (Map ModuleName CheckpointId)
 stModuleCheckpoints f s =
   f (stPostModuleCheckpoints (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostModuleCheckpoints = x}}
 
-stImportsDisplayForms :: Lens' DisplayForms TCState
+stImportsDisplayForms :: Lens' TCState DisplayForms
 stImportsDisplayForms f s =
   f (stPostImportsDisplayForms (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostImportsDisplayForms = x}}
 
-stImportedDisplayForms :: Lens' DisplayForms TCState
+stImportedDisplayForms :: Lens' TCState DisplayForms
 stImportedDisplayForms f s =
   f (stPreImportedDisplayForms (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreImportedDisplayForms = x}}
@@ -665,7 +665,7 @@ stImportedDisplayForms f s =
 -- | Note that the lens is \"strict\".
 
 stCurrentModule ::
-  Lens' (Maybe (ModuleName, TopLevelModuleName)) TCState
+  Lens' TCState (Maybe (ModuleName, TopLevelModuleName))
 stCurrentModule f s =
   f (stPostCurrentModule (stPostScopeState s)) <&>
   \x -> s {stPostScopeState =
@@ -674,93 +674,93 @@ stCurrentModule f s =
                   Nothing         -> Nothing
                   Just (!m, !top) -> Just (m, top)}}
 
-stImportedInstanceDefs :: Lens' InstanceTable TCState
+stImportedInstanceDefs :: Lens' TCState InstanceTable
 stImportedInstanceDefs f s =
   f (stPreImportedInstanceDefs (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreImportedInstanceDefs = x}}
 
-stInstanceDefs :: Lens' TempInstanceTable TCState
+stInstanceDefs :: Lens' TCState TempInstanceTable
 stInstanceDefs f s =
   f (stPostInstanceDefs (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostInstanceDefs = x}}
 
-stConcreteNames :: Lens' ConcreteNames TCState
+stConcreteNames :: Lens' TCState ConcreteNames
 stConcreteNames f s =
   f (stPostConcreteNames (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostConcreteNames = x}}
 
-stUsedNames :: Lens' (Map RawName (DList RawName)) TCState
+stUsedNames :: Lens' TCState (Map RawName (DList RawName))
 stUsedNames f s =
   f (stPostUsedNames (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostUsedNames = x}}
 
-stShadowingNames :: Lens' (Map Name (DList RawName)) TCState
+stShadowingNames :: Lens' TCState (Map Name (DList RawName))
 stShadowingNames f s =
   f (stPostShadowingNames (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostShadowingNames = x}}
 
-stStatistics :: Lens' Statistics TCState
+stStatistics :: Lens' TCState Statistics
 stStatistics f s =
   f (stPostStatistics (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostStatistics = x}}
 
-stTCWarnings :: Lens' [TCWarning] TCState
+stTCWarnings :: Lens' TCState [TCWarning]
 stTCWarnings f s =
   f (stPostTCWarnings (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostTCWarnings = x}}
 
-stMutualBlocks :: Lens' (Map MutualId MutualBlock) TCState
+stMutualBlocks :: Lens' TCState (Map MutualId MutualBlock)
 stMutualBlocks f s =
   f (stPostMutualBlocks (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostMutualBlocks = x}}
 
-stLocalBuiltins :: Lens' (BuiltinThings PrimFun) TCState
+stLocalBuiltins :: Lens' TCState (BuiltinThings PrimFun)
 stLocalBuiltins f s =
   f (stPostLocalBuiltins (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostLocalBuiltins = x}}
 
-stFreshMetaId :: Lens' MetaId TCState
+stFreshMetaId :: Lens' TCState MetaId
 stFreshMetaId f s =
   f (stPostFreshMetaId (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostFreshMetaId = x}}
 
-stFreshMutualId :: Lens' MutualId TCState
+stFreshMutualId :: Lens' TCState MutualId
 stFreshMutualId f s =
   f (stPostFreshMutualId (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostFreshMutualId = x}}
 
-stFreshProblemId :: Lens' ProblemId TCState
+stFreshProblemId :: Lens' TCState ProblemId
 stFreshProblemId f s =
   f (stPostFreshProblemId (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostFreshProblemId = x}}
 
-stFreshCheckpointId :: Lens' CheckpointId TCState
+stFreshCheckpointId :: Lens' TCState CheckpointId
 stFreshCheckpointId f s =
   f (stPostFreshCheckpointId (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostFreshCheckpointId = x}}
 
-stFreshInt :: Lens' Int TCState
+stFreshInt :: Lens' TCState Int
 stFreshInt f s =
   f (stPostFreshInt (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostFreshInt = x}}
 
 -- use @areWeCaching@ from the Caching module instead.
-stAreWeCaching :: Lens' Bool TCState
+stAreWeCaching :: Lens' TCState Bool
 stAreWeCaching f s =
   f (stPostAreWeCaching (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostAreWeCaching = x}}
 
-stPostponeInstanceSearch :: Lens' Bool TCState
+stPostponeInstanceSearch :: Lens' TCState Bool
 stPostponeInstanceSearch f s =
   f (stPostPostponeInstanceSearch (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostPostponeInstanceSearch = x}}
 
-stConsideringInstance :: Lens' Bool TCState
+stConsideringInstance :: Lens' TCState Bool
 stConsideringInstance f s =
   f (stPostConsideringInstance (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostConsideringInstance = x}}
 
-stInstantiateBlocking :: Lens' Bool TCState
+stInstantiateBlocking :: Lens' TCState Bool
 stInstantiateBlocking f s =
   f (stPostInstantiateBlocking (stPostScopeState s)) <&>
   \x -> s {stPostScopeState = (stPostScopeState s) {stPostInstantiateBlocking = x}}
@@ -779,7 +779,7 @@ unionBuiltin = curry $ \case
 ------------------------------------------------------------------------
 
 class Enum i => HasFresh i where
-    freshLens :: Lens' i TCState
+    freshLens :: Lens' TCState i
     nextFresh' :: i -> i
     nextFresh' = succ
 
@@ -1042,7 +1042,7 @@ iFullHash i = combineHashes $ iSourceHash i : List.map snd (iImportedModules i)
 
 -- | A lens for the 'iSignature' field of the 'Interface' type.
 
-intSignature :: Lens' Signature Interface
+intSignature :: Lens' Interface Signature
 intSignature f i = f (iSignature i) <&> \s -> i { iSignature = s }
 
 ---------------------------------------------------------------------------
@@ -1064,10 +1064,10 @@ instance Show a => Show (Closure a) where
 instance HasRange a => HasRange (Closure a) where
   getRange = getRange . clValue
 
-class LensClosure a b | b -> a where
-  lensClosure :: Lens' (Closure a) b
+class LensClosure b a | b -> a where
+  lensClosure :: Lens' b (Closure a)
 
-instance LensClosure a (Closure a) where
+instance LensClosure (Closure a) a where
   lensClosure = id
 
 instance LensTCEnv (Closure a) where
@@ -1601,18 +1601,18 @@ getMetaSig m = clSignature $ getMetaInfo m
 
 -- Lenses
 
-metaFrozen :: Lens' Frozen MetaVariable
+metaFrozen :: Lens' MetaVariable Frozen
 metaFrozen f mv = f (mvFrozen mv) <&> \ x -> mv { mvFrozen = x }
 
-_mvInfo :: Lens' MetaInfo MetaVariable
+_mvInfo :: Lens' MetaVariable MetaInfo
 _mvInfo f mv = (f $! mvInfo mv) <&> \ mi -> mv { mvInfo = mi }
 
 -- Lenses onto Closure Range
 
-instance LensClosure Range MetaInfo where
+instance LensClosure MetaInfo Range where
   lensClosure f mi = (f $! miClosRange mi) <&> \ cl -> mi { miClosRange = cl }
 
-instance LensClosure Range MetaVariable where
+instance LensClosure MetaVariable Range where
   lensClosure = _mvInfo . lensClosure
 
 -- Lenses onto IsAbstract
@@ -1710,17 +1710,17 @@ data Signature = Sig
       }
   deriving (Show, Generic)
 
-sigSections :: Lens' Sections Signature
+sigSections :: Lens' Signature Sections
 sigSections f s =
   f (_sigSections s) <&>
   \x -> s {_sigSections = x}
 
-sigDefinitions :: Lens' Definitions Signature
+sigDefinitions :: Lens' Signature Definitions
 sigDefinitions f s =
   f (_sigDefinitions s) <&>
   \x -> s {_sigDefinitions = x}
 
-sigRewriteRules :: Lens' RewriteRuleMap Signature
+sigRewriteRules :: Lens' Signature RewriteRuleMap
 sigRewriteRules f s =
   f (_sigRewriteRules s) <&>
   \x -> s {_sigRewriteRules = x}
@@ -1736,7 +1736,7 @@ newtype Section = Section { _secTelescope :: Telescope }
 instance Pretty Section where
   pretty = pretty . _secTelescope
 
-secTelescope :: Lens' Telescope Section
+secTelescope :: Lens' Section Telescope
 secTelescope f s =
   f (_secTelescope s) <&>
   \x -> s {_secTelescope = x}
@@ -2035,7 +2035,7 @@ data NumGeneralizableArgs
     --   'SomeGeneralizableArgs', also when the number is zero.
   deriving Show
 
-lensTheDef :: Lens' Defn Definition
+lensTheDef :: Lens' Definition Defn
 lensTheDef f d = f (theDef d) <&> \ df -> d { theDef = df }
 
 -- | Create a definition with sensible defaults.
@@ -2648,24 +2648,24 @@ pattern PrimitiveSort
 
 -- TODO: lenses for all Defn variants
 
-lensFunction :: Lens' FunctionData Defn
+lensFunction :: Lens' Defn FunctionData
 lensFunction f = \case
   FunctionDefn d -> FunctionDefn <$> f d
   _ -> __IMPOSSIBLE__
 
-lensConstructor :: Lens' ConstructorData Defn
+lensConstructor :: Lens' Defn ConstructorData
 lensConstructor f = \case
   ConstructorDefn d -> ConstructorDefn <$> f d
   _ -> __IMPOSSIBLE__
 
-lensRecord :: Lens' RecordData Defn
+lensRecord :: Lens' Defn RecordData
 lensRecord f = \case
   RecordDefn d -> RecordDefn <$> f d
   _ -> __IMPOSSIBLE__
 
 -- Lenses for Record
 
-lensRecTel :: Lens' Telescope RecordData
+lensRecTel :: Lens' RecordData Telescope
 lensRecTel f r =
   f (_recTel r) <&> \ tel -> r { _recTel = tel }
 
@@ -2899,13 +2899,13 @@ emptyFunctionData = do
 emptyFunction :: HasOptions m => m Defn
 emptyFunction = FunctionDefn <$> emptyFunctionData
 
-funFlag :: FunctionFlag -> Lens' Bool Defn
+funFlag :: FunctionFlag -> Lens' Defn Bool
 funFlag flag f def@Function{ funFlags = flags } =
   f (Set.member flag flags) <&>
   \ b -> def{ funFlags = (if b then Set.insert else Set.delete) flag flags }
 funFlag _ f def = f False $> def
 
-funStatic, funInline, funMacro :: Lens' Bool Defn
+funStatic, funInline, funMacro :: Lens' Defn Bool
 funStatic       = funFlag FunStatic
 funInline       = funFlag FunInline
 funMacro        = funFlag FunMacro
@@ -3633,7 +3633,7 @@ initEnv = TCEnv { envContext             = []
                 }
 
 class LensTCEnv a where
-  lensTCEnv :: Lens' TCEnv a
+  lensTCEnv :: Lens' a TCEnv
 
 instance LensTCEnv TCEnv where
   lensTCEnv = id
@@ -3646,71 +3646,71 @@ defaultUnquoteFlags :: UnquoteFlags
 defaultUnquoteFlags = UnquoteFlags
   { _unquoteNormalise = False }
 
-unquoteNormalise :: Lens' Bool UnquoteFlags
+unquoteNormalise :: Lens' UnquoteFlags Bool
 unquoteNormalise f e = f (_unquoteNormalise e) <&> \ x -> e { _unquoteNormalise = x }
 
-eUnquoteNormalise :: Lens' Bool TCEnv
+eUnquoteNormalise :: Lens' TCEnv Bool
 eUnquoteNormalise = eUnquoteFlags . unquoteNormalise
 
 -- * e-prefixed lenses
 ------------------------------------------------------------------------
 
-eContext :: Lens' Context TCEnv
+eContext :: Lens' TCEnv Context
 eContext f e = f (envContext e) <&> \ x -> e { envContext = x }
 
-eLetBindings :: Lens' LetBindings TCEnv
+eLetBindings :: Lens' TCEnv LetBindings
 eLetBindings f e = f (envLetBindings e) <&> \ x -> e { envLetBindings = x }
 
-eCurrentModule :: Lens' ModuleName TCEnv
+eCurrentModule :: Lens' TCEnv ModuleName
 eCurrentModule f e = f (envCurrentModule e) <&> \ x -> e { envCurrentModule = x }
 
-eCurrentPath :: Lens' (Maybe AbsolutePath) TCEnv
+eCurrentPath :: Lens' TCEnv (Maybe AbsolutePath)
 eCurrentPath f e = f (envCurrentPath e) <&> \ x -> e { envCurrentPath = x }
 
-eAnonymousModules :: Lens' [(ModuleName, Nat)] TCEnv
+eAnonymousModules :: Lens' TCEnv [(ModuleName, Nat)]
 eAnonymousModules f e = f (envAnonymousModules e) <&> \ x -> e { envAnonymousModules = x }
 
-eImportPath :: Lens' [TopLevelModuleName] TCEnv
+eImportPath :: Lens' TCEnv [TopLevelModuleName]
 eImportPath f e = f (envImportPath e) <&> \ x -> e { envImportPath = x }
 
-eMutualBlock :: Lens' (Maybe MutualId) TCEnv
+eMutualBlock :: Lens' TCEnv (Maybe MutualId)
 eMutualBlock f e = f (envMutualBlock e) <&> \ x -> e { envMutualBlock = x }
 
-eTerminationCheck :: Lens' (TerminationCheck ()) TCEnv
+eTerminationCheck :: Lens' TCEnv (TerminationCheck ())
 eTerminationCheck f e = f (envTerminationCheck e) <&> \ x -> e { envTerminationCheck = x }
 
-eCoverageCheck :: Lens' CoverageCheck TCEnv
+eCoverageCheck :: Lens' TCEnv CoverageCheck
 eCoverageCheck f e = f (envCoverageCheck e) <&> \ x -> e { envCoverageCheck = x }
 
-eMakeCase :: Lens' Bool TCEnv
+eMakeCase :: Lens' TCEnv Bool
 eMakeCase f e = f (envMakeCase e) <&> \ x -> e { envMakeCase = x }
 
-eSolvingConstraints :: Lens' Bool TCEnv
+eSolvingConstraints :: Lens' TCEnv Bool
 eSolvingConstraints f e = f (envSolvingConstraints e) <&> \ x -> e { envSolvingConstraints = x }
 
-eCheckingWhere :: Lens' Bool TCEnv
+eCheckingWhere :: Lens' TCEnv Bool
 eCheckingWhere f e = f (envCheckingWhere e) <&> \ x -> e { envCheckingWhere = x }
 
-eWorkingOnTypes :: Lens' Bool TCEnv
+eWorkingOnTypes :: Lens' TCEnv Bool
 eWorkingOnTypes f e = f (envWorkingOnTypes e) <&> \ x -> e { envWorkingOnTypes = x }
 
-eAssignMetas :: Lens' Bool TCEnv
+eAssignMetas :: Lens' TCEnv Bool
 eAssignMetas f e = f (envAssignMetas e) <&> \ x -> e { envAssignMetas = x }
 
-eActiveProblems :: Lens' (Set ProblemId) TCEnv
+eActiveProblems :: Lens' TCEnv (Set ProblemId)
 eActiveProblems f e = f (envActiveProblems e) <&> \ x -> e { envActiveProblems = x }
 
-eAbstractMode :: Lens' AbstractMode TCEnv
+eAbstractMode :: Lens' TCEnv AbstractMode
 eAbstractMode f e = f (envAbstractMode e) <&> \ x -> e { envAbstractMode = x }
 
-eRelevance :: Lens' Relevance TCEnv
+eRelevance :: Lens' TCEnv Relevance
 eRelevance f e = f (envRelevance e) <&> \x -> e { envRelevance = x }
 
 -- | Note that this lens does not satisfy all lens laws: If hard
 -- compile-time mode is enabled, then quantities other than zero are
 -- replaced by '__IMPOSSIBLE__'.
 
-eQuantity :: Lens' Quantity TCEnv
+eQuantity :: Lens' TCEnv Quantity
 eQuantity f e =
   if envHardCompileTimeMode e
   then f (check (envQuantity e)) <&>
@@ -3721,108 +3721,108 @@ eQuantity f e =
     | hasQuantity0 q = q
     | otherwise      = __IMPOSSIBLE__
 
-eHardCompileTimeMode :: Lens' Bool TCEnv
+eHardCompileTimeMode :: Lens' TCEnv Bool
 eHardCompileTimeMode f e =
   f (envHardCompileTimeMode e) <&>
   \x -> e { envHardCompileTimeMode = x }
 
-eSplitOnStrict :: Lens' Bool TCEnv
+eSplitOnStrict :: Lens' TCEnv Bool
 eSplitOnStrict f e = f (envSplitOnStrict e) <&> \ x -> e { envSplitOnStrict = x }
 
-eDisplayFormsEnabled :: Lens' Bool TCEnv
+eDisplayFormsEnabled :: Lens' TCEnv Bool
 eDisplayFormsEnabled f e = f (envDisplayFormsEnabled e) <&> \ x -> e { envDisplayFormsEnabled = x }
 
-eFoldLetBindings :: Lens' Bool TCEnv
+eFoldLetBindings :: Lens' TCEnv Bool
 eFoldLetBindings f e = f (envFoldLetBindings e) <&> \ x -> e { envFoldLetBindings = x }
 
-eRange :: Lens' Range TCEnv
+eRange :: Lens' TCEnv Range
 eRange f e = f (envRange e) <&> \ x -> e { envRange = x }
 
-eHighlightingRange :: Lens' Range TCEnv
+eHighlightingRange :: Lens' TCEnv Range
 eHighlightingRange f e = f (envHighlightingRange e) <&> \ x -> e { envHighlightingRange = x }
 
-eCall :: Lens' (Maybe (Closure Call)) TCEnv
+eCall :: Lens' TCEnv (Maybe (Closure Call))
 eCall f e = f (envCall e) <&> \ x -> e { envCall = x }
 
-eHighlightingLevel :: Lens' HighlightingLevel TCEnv
+eHighlightingLevel :: Lens' TCEnv HighlightingLevel
 eHighlightingLevel f e = f (envHighlightingLevel e) <&> \ x -> e { envHighlightingLevel = x }
 
-eHighlightingMethod :: Lens' HighlightingMethod TCEnv
+eHighlightingMethod :: Lens' TCEnv HighlightingMethod
 eHighlightingMethod f e = f (envHighlightingMethod e) <&> \ x -> e { envHighlightingMethod = x }
 
-eExpandLast :: Lens' ExpandHidden TCEnv
+eExpandLast :: Lens' TCEnv ExpandHidden
 eExpandLast f e = f (envExpandLast e) <&> \ x -> e { envExpandLast = x }
 
-eExpandLastBool :: Lens' Bool TCEnv
+eExpandLastBool :: Lens' TCEnv Bool
 eExpandLastBool f e = f (isExpandLast $ envExpandLast e) <&> \ x -> e { envExpandLast = toExpandLast x }
 
-eAppDef :: Lens' (Maybe QName) TCEnv
+eAppDef :: Lens' TCEnv (Maybe QName)
 eAppDef f e = f (envAppDef e) <&> \ x -> e { envAppDef = x }
 
-eSimplification :: Lens' Simplification TCEnv
+eSimplification :: Lens' TCEnv Simplification
 eSimplification f e = f (envSimplification e) <&> \ x -> e { envSimplification = x }
 
-eAllowedReductions :: Lens' AllowedReductions TCEnv
+eAllowedReductions :: Lens' TCEnv AllowedReductions
 eAllowedReductions f e = f (envAllowedReductions e) <&> \ x -> e { envAllowedReductions = x }
 
-eReduceDefs :: Lens' ReduceDefs TCEnv
+eReduceDefs :: Lens' TCEnv ReduceDefs
 eReduceDefs f e = f (envReduceDefs e) <&> \ x -> e { envReduceDefs = x }
 
-eReduceDefsPair :: Lens' (Bool, [QName]) TCEnv
+eReduceDefsPair :: Lens' TCEnv (Bool, [QName])
 eReduceDefsPair f e = f (fromReduceDefs $ envReduceDefs e) <&> \ x -> e { envReduceDefs = toReduceDefs x }
 
-eReconstructed :: Lens' Bool TCEnv
+eReconstructed :: Lens' TCEnv Bool
 eReconstructed f e = f (envReconstructed e) <&> \ x -> e { envReconstructed = x }
 
-eInjectivityDepth :: Lens' Int TCEnv
+eInjectivityDepth :: Lens' TCEnv Int
 eInjectivityDepth f e = f (envInjectivityDepth e) <&> \ x -> e { envInjectivityDepth = x }
 
-eCompareBlocked :: Lens' Bool TCEnv
+eCompareBlocked :: Lens' TCEnv Bool
 eCompareBlocked f e = f (envCompareBlocked e) <&> \ x -> e { envCompareBlocked = x }
 
-ePrintDomainFreePi :: Lens' Bool TCEnv
+ePrintDomainFreePi :: Lens' TCEnv Bool
 ePrintDomainFreePi f e = f (envPrintDomainFreePi e) <&> \ x -> e { envPrintDomainFreePi = x }
 
-ePrintMetasBare :: Lens' Bool TCEnv
+ePrintMetasBare :: Lens' TCEnv Bool
 ePrintMetasBare f e = f (envPrintMetasBare e) <&> \ x -> e { envPrintMetasBare = x }
 
-eInsideDotPattern :: Lens' Bool TCEnv
+eInsideDotPattern :: Lens' TCEnv Bool
 eInsideDotPattern f e = f (envInsideDotPattern e) <&> \ x -> e { envInsideDotPattern = x }
 
-eUnquoteFlags :: Lens' UnquoteFlags TCEnv
+eUnquoteFlags :: Lens' TCEnv UnquoteFlags
 eUnquoteFlags f e = f (envUnquoteFlags e) <&> \ x -> e { envUnquoteFlags = x }
 
-eInstanceDepth :: Lens' Int TCEnv
+eInstanceDepth :: Lens' TCEnv Int
 eInstanceDepth f e = f (envInstanceDepth e) <&> \ x -> e { envInstanceDepth = x }
 
-eIsDebugPrinting :: Lens' Bool TCEnv
+eIsDebugPrinting :: Lens' TCEnv Bool
 eIsDebugPrinting f e = f (envIsDebugPrinting e) <&> \ x -> e { envIsDebugPrinting = x }
 
-ePrintingPatternLambdas :: Lens' [QName] TCEnv
+ePrintingPatternLambdas :: Lens' TCEnv [QName]
 ePrintingPatternLambdas f e = f (envPrintingPatternLambdas e) <&> \ x -> e { envPrintingPatternLambdas = x }
 
-eCallByNeed :: Lens' Bool TCEnv
+eCallByNeed :: Lens' TCEnv Bool
 eCallByNeed f e = f (envCallByNeed e) <&> \ x -> e { envCallByNeed = x }
 
-eCurrentCheckpoint :: Lens' CheckpointId TCEnv
+eCurrentCheckpoint :: Lens' TCEnv CheckpointId
 eCurrentCheckpoint f e = f (envCurrentCheckpoint e) <&> \ x -> e { envCurrentCheckpoint = x }
 
-eCheckpoints :: Lens' (Map CheckpointId Substitution) TCEnv
+eCheckpoints :: Lens' TCEnv (Map CheckpointId Substitution)
 eCheckpoints f e = f (envCheckpoints e) <&> \ x -> e { envCheckpoints = x }
 
-eGeneralizeMetas :: Lens' DoGeneralize TCEnv
+eGeneralizeMetas :: Lens' TCEnv DoGeneralize
 eGeneralizeMetas f e = f (envGeneralizeMetas e) <&> \ x -> e { envGeneralizeMetas = x }
 
-eGeneralizedVars :: Lens' (Map QName GeneralizedValue) TCEnv
+eGeneralizedVars :: Lens' TCEnv (Map QName GeneralizedValue)
 eGeneralizedVars f e = f (envGeneralizedVars e) <&> \ x -> e { envGeneralizedVars = x }
 
-eActiveBackendName :: Lens' (Maybe BackendName) TCEnv
+eActiveBackendName :: Lens' TCEnv (Maybe BackendName)
 eActiveBackendName f e = f (envActiveBackendName e) <&> \ x -> e { envActiveBackendName = x }
 
-eConflComputingOverlap :: Lens' Bool TCEnv
+eConflComputingOverlap :: Lens' TCEnv Bool
 eConflComputingOverlap f e = f (envConflComputingOverlap e) <&> \ x -> e { envConflComputingOverlap = x }
 
-eCurrentlyElaborating :: Lens' Bool TCEnv
+eCurrentlyElaborating :: Lens' TCEnv Bool
 eCurrentlyElaborating f e = f (envCurrentlyElaborating e) <&> \ x -> e { envCurrentlyElaborating = x }
 
 -- | The current modality.
@@ -4602,10 +4602,10 @@ mapRedEnvSt :: (TCEnv -> TCEnv) -> (TCState -> TCState) -> ReduceEnv
 mapRedEnvSt f g (ReduceEnv e s p) = ReduceEnv (f e) (g s) p
 
 -- Lenses
-reduceEnv :: Lens' TCEnv ReduceEnv
+reduceEnv :: Lens' ReduceEnv TCEnv
 reduceEnv f s = f (redEnv s) <&> \ e -> s { redEnv = e }
 
-reduceSt :: Lens' TCState ReduceEnv
+reduceSt :: Lens' ReduceEnv TCState
 reduceSt f s = f (redSt s) <&> \ e -> s { redSt = e }
 
 newtype ReduceM a = ReduceM { unReduceM :: ReduceEnv -> a }
@@ -4717,7 +4717,7 @@ instance MonadTCEnv ReduceM where
 --   this usually prevents retaining the whole structure when we only need a field.
 --
 -- This fixes (or contributes to the fix of) the space leak issue #1829 (caching).
-useR :: (ReadTCState m) => Lens' a TCState -> m a
+useR :: (ReadTCState m) => Lens' TCState a -> m a
 useR l = do
   !x <- (^.l) <$> getTCState
   return x
@@ -4790,11 +4790,11 @@ instance MonadTCEnv m => MonadTCEnv (ListT m) where
 asksTC :: MonadTCEnv m => (TCEnv -> a) -> m a
 asksTC f = f <$> askTC
 
-viewTC :: MonadTCEnv m => Lens' a TCEnv -> m a
+viewTC :: MonadTCEnv m => Lens' TCEnv a -> m a
 viewTC l = asksTC (^. l)
 
 -- | Modify the lens-indicated part of the @TCEnv@ in a subcomputation.
-locallyTC :: MonadTCEnv m => Lens' a TCEnv -> (a -> a) -> m b -> m b
+locallyTC :: MonadTCEnv m => Lens' TCEnv a -> (a -> a) -> m b -> m b
 locallyTC l = localTC . over l
 
 ---------------------------------------------------------------------------
@@ -4845,7 +4845,7 @@ modifyTC' f = do
 
 -- ** @TCState@ accessors via lenses
 
-useTC :: ReadTCState m => Lens' a TCState -> m a
+useTC :: ReadTCState m => Lens' TCState a -> m a
 useTC l = do
   !x <- getsTC (^. l)
   return x
@@ -4853,33 +4853,33 @@ useTC l = do
 infix 4 `setTCLens`
 
 -- | Overwrite the part of the 'TCState' focused on by the lens.
-setTCLens :: MonadTCState m => Lens' a TCState -> a -> m ()
+setTCLens :: MonadTCState m => Lens' TCState a -> a -> m ()
 setTCLens l = modifyTC . set l
 
 -- | Overwrite the part of the 'TCState' focused on by the lens
 -- (strictly).
-setTCLens' :: MonadTCState m => Lens' a TCState -> a -> m ()
+setTCLens' :: MonadTCState m => Lens' TCState a -> a -> m ()
 setTCLens' l = modifyTC' . set l
 
 -- | Modify the part of the 'TCState' focused on by the lens.
-modifyTCLens :: MonadTCState m => Lens' a TCState -> (a -> a) -> m ()
+modifyTCLens :: MonadTCState m => Lens' TCState a -> (a -> a) -> m ()
 modifyTCLens l = modifyTC . over l
 
 -- | Modify the part of the 'TCState' focused on by the lens
 -- (strictly).
-modifyTCLens' :: MonadTCState m => Lens' a TCState -> (a -> a) -> m ()
+modifyTCLens' :: MonadTCState m => Lens' TCState a -> (a -> a) -> m ()
 modifyTCLens' l = modifyTC' . over l
 
 -- | Modify a part of the state monadically.
-modifyTCLensM :: MonadTCState m => Lens' a TCState -> (a -> m a) -> m ()
+modifyTCLensM :: MonadTCState m => Lens' TCState a -> (a -> m a) -> m ()
 modifyTCLensM l f = putTC =<< l f =<< getTC
 
 -- | Modify the part of the 'TCState' focused on by the lens, and return some result.
-stateTCLens :: MonadTCState m => Lens' a TCState -> (a -> (r , a)) -> m r
+stateTCLens :: MonadTCState m => Lens' TCState a -> (a -> (r , a)) -> m r
 stateTCLens l f = stateTCLensM l $ return . f
 
 -- | Modify a part of the state monadically, and return some result.
-stateTCLensM :: MonadTCState m => Lens' a TCState -> (a -> m (r , a)) -> m r
+stateTCLensM :: MonadTCState m => Lens' TCState a -> (a -> m (r , a)) -> m r
 stateTCLensM l f = do
   s <- getTC
   (result , x) <- f $ s ^. l

--- a/src/full/Agda/TypeChecking/Monad/Closure.hs
+++ b/src/full/Agda/TypeChecking/Monad/Closure.hs
@@ -8,7 +8,7 @@ import Agda.TypeChecking.Monad.State
 
 import Agda.Utils.Lens
 
-enterClosure :: (MonadTCEnv m, ReadTCState m, LensClosure a c)
+enterClosure :: (MonadTCEnv m, ReadTCState m, LensClosure c a)
              => c -> (a -> m b) -> m b
 enterClosure c k | Closure _sig env scope cps x <- c ^. lensClosure = do
   isDbg <- viewTC eIsDebugPrinting

--- a/src/full/Agda/TypeChecking/Monad/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Monad/Constraints.hs
@@ -180,7 +180,7 @@ addConstraint' = addConstraintTo stSleepingConstraints
 addAwakeConstraint' :: Blocker -> Constraint -> TCM ()
 addAwakeConstraint' = addConstraintTo stAwakeConstraints
 
-addConstraintTo :: Lens' Constraints TCState -> Blocker -> Constraint -> TCM ()
+addConstraintTo :: Lens' TCState Constraints -> Blocker -> Constraint -> TCM ()
 addConstraintTo bucket unblock c = do
     pc <- build
     stDirty `setTCLens` True

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -169,7 +169,7 @@ metasCreatedBy m = do
   ss        <- created stSolvedMetaStore nextMeta
   return (a, LocalMetaStores { openMetas = os, solvedMetas = ss })
   where
-  created :: Lens' LocalMetaStore TCState -> MetaId -> m LocalMetaStore
+  created :: Lens' TCState LocalMetaStore -> MetaId -> m LocalMetaStore
   created store next = do
     ms <- useTC store
     return $ case MapS.splitLookup next ms of

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -140,7 +140,7 @@ freshTCM m = do
 -- * Lens for persistent states and its fields
 ---------------------------------------------------------------------------
 
-lensPersistentState :: Lens' PersistentTCState TCState
+lensPersistentState :: Lens' TCState PersistentTCState
 lensPersistentState f s =
   f (stPersistentState s) <&> \ p -> s { stPersistentState = p }
 
@@ -153,11 +153,11 @@ modifyPersistentState = modifyTC . updatePersistentState
 
 -- | Lens for 'stAccumStatistics'.
 
-lensAccumStatisticsP :: Lens' Statistics PersistentTCState
+lensAccumStatisticsP :: Lens' PersistentTCState Statistics
 lensAccumStatisticsP f s = f (stAccumStatistics s) <&> \ a ->
   s { stAccumStatistics = a }
 
-lensAccumStatistics :: Lens' Statistics TCState
+lensAccumStatistics :: Lens' TCState Statistics
 lensAccumStatistics =  lensPersistentState . lensAccumStatisticsP
 
 ---------------------------------------------------------------------------
@@ -181,11 +181,11 @@ modifyScope :: MonadTCState m => (ScopeInfo -> ScopeInfo) -> m ()
 modifyScope f = modifyScope_ (recomputeInverseScopeMaps . f)
 
 -- | Get a part of the current scope.
-useScope :: ReadTCState m => Lens' a ScopeInfo -> m a
+useScope :: ReadTCState m => Lens' ScopeInfo a -> m a
 useScope l = useR $ stScope . l
 
 -- | Run a computation in a modified scope.
-locallyScope :: ReadTCState m => Lens' a ScopeInfo -> (a -> a) -> m b -> m b
+locallyScope :: ReadTCState m => Lens' ScopeInfo a -> (a -> a) -> m b -> m b
 locallyScope l = locallyTCState $ stScope . l
 
 -- | Run a computation in a local scope.

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -39,7 +39,7 @@ constructorForm v = do
   ms <- getBuiltin' builtinSuc
   return $ fromMaybe v $ constructorForm' mz ms v
 
-enterClosure :: LensClosure a c => c -> (a -> ReduceM b) -> ReduceM b
+enterClosure :: LensClosure c a => c -> (a -> ReduceM b) -> ReduceM b
 enterClosure c | Closure _sig env scope cps x <- c ^. lensClosure = \case
   -- The \case is a hack to correctly associate the where block to the rhs
   -- rather than to the expression in the pattern guard.

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -93,10 +93,10 @@ instance Null NLMState where
   empty  = NLMState { _nlmSub = empty , _nlmEqs = empty }
   null s = null (s^.nlmSub) && null (s^.nlmEqs)
 
-nlmSub :: Lens' Sub NLMState
+nlmSub :: Lens' NLMState Sub
 nlmSub f s = f (_nlmSub s) <&> \x -> s {_nlmSub = x}
 
-nlmEqs :: Lens' PostponedEquations NLMState
+nlmEqs :: Lens' NLMState PostponedEquations
 nlmEqs f s = f (_nlmEqs s) <&> \x -> s {_nlmEqs = x}
 
 runNLM :: (MonadReduce m) => NLM () -> m (Either Blocked_ NLMState)

--- a/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
@@ -201,13 +201,13 @@ data Problem a = Problem
   }
   deriving Show
 
-problemEqs :: Lens' [ProblemEq] (Problem a)
+problemEqs :: Lens' (Problem a) [ProblemEq]
 problemEqs f p = f (_problemEqs p) <&> \x -> p {_problemEqs = x}
 
-problemRestPats :: Lens' [NamedArg A.Pattern] (Problem a)
+problemRestPats :: Lens' (Problem a) [NamedArg A.Pattern]
 problemRestPats f p = f (_problemRestPats p) <&> \x -> p {_problemRestPats = x}
 
-problemCont :: Lens' (LHSState a -> TCM a) (Problem a)
+problemCont :: Lens' (Problem a) (LHSState a -> TCM a)
 problemCont f p = f (_problemCont p) <&> \x -> p {_problemCont = x}
 
 problemInPats :: Problem a -> [A.Pattern]
@@ -240,21 +240,17 @@ data LHSState a = LHSState
     -- ^ Have we split on any indexed inductive types?
   }
 
-lhsTel :: Lens' Telescope (LHSState a)
+lhsTel :: Lens' (LHSState a) Telescope
 lhsTel f p = f (_lhsTel p) <&> \x -> p {_lhsTel = x}
 
-lhsOutPat :: Lens' [NamedArg DeBruijnPattern] (LHSState a)
+lhsOutPat :: Lens' (LHSState a) [NamedArg DeBruijnPattern]
 lhsOutPat f p = f (_lhsOutPat p) <&> \x -> p {_lhsOutPat = x}
 
-lhsProblem :: Lens' (Problem a) (LHSState a)
+lhsProblem :: Lens' (LHSState a) (Problem a)
 lhsProblem f p = f (_lhsProblem p) <&> \x -> p {_lhsProblem = x}
 
-lhsTarget :: Lens' (Arg Type) (LHSState a)
+lhsTarget :: Lens' (LHSState a) (Arg Type)
 lhsTarget f p = f (_lhsTarget p) <&> \x -> p {_lhsTarget = x}
-
--- UNUSED Liang-Ting Chen 2019-07-16
---lhsPartialSplit :: Lens' [Maybe Int] (LHSState a)
---lhsPartialSplit f p = f (_lhsPartialSplit p) <&> \x -> p {_lhsPartialSplit = x}
 
 data PatVarPosition = PVLocal | PVParam
   deriving (Show, Eq)

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/Types.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/Types.hs
@@ -106,21 +106,21 @@ data UnifyState = UState
   } deriving (Show)
 -- Issues #3578 and #4125: avoid unnecessary reduction in unifier.
 
-lensVarTel   :: Lens' Telescope UnifyState
+lensVarTel   :: Lens' UnifyState Telescope
 lensVarTel   f s = f (varTel s) <&> \ tel -> s { varTel = tel }
 --UNUSED Liang-Ting Chen 2019-07-16
---lensFlexVars :: Lens' FlexibleVars UnifyState
+--lensFlexVars :: Lens' UnifyState FlexibleVars
 --lensFlexVars f s = f (flexVars s) <&> \ flex -> s { flexVars = flex }
 
-lensEqTel    :: Lens' Telescope UnifyState
+lensEqTel    :: Lens' UnifyState Telescope
 lensEqTel    f s = f (eqTel s) <&> \ x -> s { eqTel = x }
 
 --UNUSED Liang-Ting Chen 2019-07-16
---lensEqLHS    :: Lens' Args UnifyState
+--lensEqLHS    :: Lens' UnifyState Args
 --lensEqLHS    f s = f (eqLHS s) <&> \ x -> s { eqLHS = x }
 
 --UNUSED Liang-Ting Chen 2019-07-16
---lensEqRHS    :: Lens' Args UnifyState
+--lensEqRHS    :: Lens' UnifyState Args
 --lensEqRHS    f s = f (eqRHS s) <&> \ x -> s { eqRHS = x }
 
 -- UNUSED Andreas, 2019-10-14

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -64,11 +64,11 @@ farEmpty = FreshAndReuse 0
                            0
 #endif
 
-lensFresh :: Lens' Int32 FreshAndReuse
+lensFresh :: Lens' FreshAndReuse Int32
 lensFresh f r = f (farFresh r) <&> \ i -> r { farFresh = i }
 
 #ifdef DEBUG
-lensReuse :: Lens' Int32 FreshAndReuse
+lensReuse :: Lens' FreshAndReuse Int32
 lensReuse f r = f (farReuse r) <&> \ i -> r { farReuse = i }
 #endif
 

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -645,10 +645,10 @@ evalTCM v = do
     tcCatchError m h =
       liftU2 (\ m1 m2 -> m1 `catchError` \ _ -> m2) (evalTCM m) (evalTCM h)
 
-    tcAskLens :: ToTerm a => Lens' a TCEnv -> UnquoteM Term
+    tcAskLens :: ToTerm a => Lens' TCEnv a -> UnquoteM Term
     tcAskLens l = liftTCM (toTerm <*> asksTC (\ e -> e ^. l))
 
-    tcWithLens :: Unquote a => Lens' a TCEnv -> Term -> Term -> UnquoteM Term
+    tcWithLens :: Unquote a => Lens' TCEnv a -> Term -> Term -> UnquoteM Term
     tcWithLens l b m = do
       v <- unquote b
       liftU1 (locallyTC l $ const v) (evalTCM m)

--- a/src/full/Agda/Utils/IndexedList.hs
+++ b/src/full/Agda/Utils/IndexedList.hs
@@ -50,7 +50,7 @@ mapWithIndex f Nil = Nil
 mapWithIndex f (Cons p ps) = Cons (f Zero p) $ mapWithIndex (f . Suc) ps
 
 -- | If you have an index you can get a lens for the given element.
-lIndex :: Index xs x -> Lens' (p x) (All p xs)
+lIndex :: Index xs x -> Lens' (All p xs) (p x)
 lIndex Zero    f (Cons x xs) = f x           <&> \ x  -> Cons x xs
 lIndex (Suc i) f (Cons x xs) = lIndex i f xs <&> \ xs -> Cons x xs
 
@@ -66,4 +66,3 @@ lookupIndex = flip ix
 -- | All indices into an indexed list.
 allIndices :: All p xs -> All (Index xs) xs
 allIndices = mapWithIndex const
-

--- a/src/full/Agda/Utils/Lens/Examples.hs
+++ b/src/full/Agda/Utils/Lens/Examples.hs
@@ -11,8 +11,8 @@ data Record a b = Record
   }
 
 -- | (View source:) This is how you implement a lens for a record field.
-lensField1 :: Lens' a (Record a b)
+lensField1 :: Lens' (Record a b) a
 lensField1 f r = f (field1 r) <&> \ a -> r { field1 = a }
 
-lensField2 :: Lens' b (Record a b)
+lensField2 :: Lens' (Record a b) b
 lensField2 f r = f (field2 r) <&> \ b -> r { field2 = b }

--- a/src/full/Agda/Utils/Memo.hs
+++ b/src/full/Agda/Utils/Memo.hs
@@ -13,7 +13,7 @@ import Agda.Utils.Lens
 -- Simple memoisation in a state monad
 
 -- | Simple, non-reentrant memoisation.
-memo :: MonadState s m => Lens' (Maybe a) s -> m a -> m a
+memo :: MonadState s m => Lens' s (Maybe a) -> m a -> m a
 memo tbl compute = do
   mv <- use tbl
   case mv of
@@ -24,7 +24,7 @@ memo tbl compute = do
 
 -- | Recursive memoisation, second argument is the value you get
 --   on recursive calls.
-memoRec :: MonadState s m => Lens' (Maybe a) s -> a -> m a -> m a
+memoRec :: MonadState s m => Lens' s (Maybe a) -> a -> m a -> m a
 memoRec tbl ih compute = do
   mv <- use tbl
   case mv of
@@ -63,4 +63,3 @@ memoUnsafeH f = unsafePerformIO $ do
           let y = f x
           writeIORef tbl (HMap.insert x y m)
           return y
-

--- a/src/full/Agda/Utils/Trie.hs
+++ b/src/full/Agda/Utils/Trie.hs
@@ -162,7 +162,7 @@ filter p (Trie mv ts) = Trie mv' (Map.filter (not . null) $ filter p <$> ts)
         _                   -> Strict.Nothing
 
 -- | Key lens.
-valueAt :: Ord k => [k] -> Lens' (Maybe v) (Trie k v)
+valueAt :: Ord k => [k] -> Lens' (Trie k v) (Maybe v)
 valueAt path f t = f (lookup path t) <&> \ case
   Nothing -> delete path t
   Just v  -> insert path v t

--- a/src/full/Agda/Utils/WithDefault.hs
+++ b/src/full/Agda/Utils/WithDefault.hs
@@ -68,12 +68,12 @@ collapseDefault = \case
 
 -- | Focus, overwriting 'Default'.
 --
-lensCollapseDefault :: (Boolean a, KnownBool b) => Lens' a (WithDefault' a b)
+lensCollapseDefault :: (Boolean a, KnownBool b) => Lens' (WithDefault' a b) a
 lensCollapseDefault f w = Value <$> f (collapseDefault w)
 
 -- | Update, but keep 'Default' when new value is default value.
 --
-lensKeepDefault :: (Boolean a, Eq a, KnownBool b) => Lens' a (WithDefault' a b)
+lensKeepDefault :: (Boolean a, Eq a, KnownBool b) => Lens' (WithDefault' a b) a
 lensKeepDefault f = \case
   Value b   -> Value <$> f b
   w@Default -> f b <&> \ b' -> if b == b' then Default else Value b'


### PR DESCRIPTION
Fix #5992: Swap type argument order in `Lens'`.

This refactoring is to conform to the `Lens'` types in the `lens`, `microlens`, `optics` etc. packages.