### PR TITLE
Add `record where` syntax sugar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Syntax
 
 Additions to the Agda syntax.
 
+* Records can now be created using module-like syntax in place of curly braces
+  and semicolons.
+
+  ```agda
+  p : Pair Nat Nat
+  p = record where
+    fst = 2
+    snd = 3
+  ```
+
+  See [#4275](https://github.com/agda/agda/issues/4275) for the proposal.
+
 Language
 --------
 

--- a/doc/user-manual/language/record-types.lagda.rst
+++ b/doc/user-manual/language/record-types.lagda.rst
@@ -69,6 +69,11 @@ Elements of record types can be defined using a record expression
    p23 : Pair Nat Nat
    p23 = record { fst = 2; snd = 3 }
 
+   p23' : Pair Nat Nat
+   p23' = record where
+     fst = 2
+     snd = 3
+
 or using :ref:`copatterns <copatterns>`. Copatterns may be used
 prefix
 
@@ -95,6 +100,17 @@ or using an :ref:`anonymous copattern-matching lambda <pattern-lambda>`
    p78 = λ where
      .Pair.fst → 7
      .Pair.snd → 8
+
+Bindings in the ``record where`` style of record expression have the semantics
+of let-bindings: for example, they may refer to each other, but they may not be
+recursive. Statements that open a module and are also legal in let expressions are
+used to define the values of fields as well, with two notable changes from their usual
+semantics:
+
+ - a ``using`` clause is mandatory (it may be empty, if all relevant names come
+   from a ``renaming`` clause)
+ - names imported inside the ``record where`` fully shadow names outside the
+   ``record where``, instead of being ambiguous
 
 If you use the ``constructor`` keyword, you can also use the named
 constructor to define elements of the record type:

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -163,6 +163,7 @@ data Expr
   | Fun Range (Arg Expr) Expr                  -- ^ ex: @e -> e@ or @.e -> e@ (NYI: @{e} -> e@)
   | Pi Telescope1 Expr                         -- ^ ex: @(xs:e) -> e@ or @{xs:e} -> e@
   | Rec Range RecordAssignments                -- ^ ex: @record {x = a; y = b}@, or @record { x = a; M1; M2 }@
+  | RecWhere Range [Declaration]               -- ^ ex: @record where { open M using (x; y) ; z arg = arg + x }@
   | RecUpdate Range Expr [FieldAssignment]     -- ^ ex: @record e {x = a; y = b}@
   | Let Range (List1 Declaration) (Maybe Expr) -- ^ ex: @let Ds in e@, missing body when parsing do-notation let
   | Paren Range Expr                           -- ^ ex: @(e)@
@@ -885,6 +886,7 @@ instance HasRange Expr where
       HiddenArg r _      -> r
       InstanceArg r _    -> r
       Rec r _            -> r
+      RecWhere r _       -> r
       RecUpdate r _ _    -> r
       Quote r            -> r
       QuoteTerm r        -> r
@@ -1145,6 +1147,7 @@ instance KillRange Expr where
   killRange (Fun _ e1 e2)          = killRangeN (Fun noRange) e1 e2
   killRange (Pi t e)               = killRangeN Pi t e
   killRange (Rec _ ne)             = killRangeN (Rec noRange) ne
+  killRange (RecWhere _ ne)        = killRangeN (RecWhere noRange) ne
   killRange (RecUpdate _ e ne)     = killRangeN (RecUpdate noRange) e ne
   killRange (Let _ d e)            = killRangeN (Let noRange) d e
   killRange (Paren _ e)            = killRangeN (Paren noRange) e
@@ -1265,6 +1268,7 @@ instance NFData Expr where
   rnf (Fun _ a b)         = rnf a `seq` rnf b
   rnf (Pi a b)            = rnf a `seq` rnf b
   rnf (Rec _ a)           = rnf a
+  rnf (RecWhere _ a)      = rnf a
   rnf (RecUpdate _ a b)   = rnf a `seq` rnf b
   rnf (Let _ a b)         = rnf a `seq` rnf b
   rnf (Paren _ a)         = rnf a

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -131,6 +131,7 @@ instance ExprLike Expr where
      Fun r a b               -> f $ Fun r     (mapE <$> a) $ mapE b
      Pi tel e                -> f $ Pi          (mapE tel) $ mapE e
      Rec r es                -> f $ Rec r                  $ mapE es
+     RecWhere r es           -> f $ RecWhere r             $ mapE es
      RecUpdate r e es        -> f $ RecUpdate r (mapE e)   $ mapE es
      Let r ds e              -> f $ Let r       (mapE ds)  $ mapE e
      Paren r e               -> f $ Paren r                $ mapE e

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -248,6 +248,7 @@ instance Pretty Expr where
             DoubleDot _ e  -> hlSymbol ".." <> pretty e
             Absurd _  -> hlSymbol "()"
             Rec _ xs  -> sep [hlKeyword "record", bracesAndSemicolons (map pretty xs)]
+            RecWhere _ xs -> sep [hlKeyword "record" <+> hlKeyword "where", nest 2 (vcat $ map pretty xs)]
             RecUpdate _ e xs ->
               sep [hlKeyword "record" <+> pretty e, bracesAndSemicolons (map pretty xs)]
             Quote _ -> hlKeyword "quote"

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -716,6 +716,7 @@ Expr3NoCurly
     | '.' Expr3                         { Dot (fuseRange $1 $2) $2 }
     | '..' Expr3                        { DoubleDot (fuseRange $1 $2) $2 }
     | 'record' '{' RecordAssignments '}' { Rec (getRange ($1,$2,$3,$4)) $3 }
+    | 'record' 'where' Declarations0    { RecWhere (getRange ($1,$2,$3)) $3 }
     | 'record' Expr3NoCurly '{' FieldAssignments '}' { RecUpdate (getRange ($1,$2,$3,$4,$5)) $2 $4 }
     | '...'                             { Ellipsis (getRange $1) }
     | ExprOrAttr                       { $1 }

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1006,6 +1006,62 @@ instance ToAbstract C.Expr where
             fs'' = map (mapRight fst) fs'
             i    = ExprRange r
         return $ A.mkLet i ds' (A.Rec i fs'')
+      C.RecWhere r ds0 -> do
+        let i = ExprRange r
+        -- We need to rewrite any opens or module applications opened in this
+        -- scope into a non-opening declaration and explicit bindings, so that
+        -- references inside this body refer unambiguously to things opened
+        -- here. Conveniently, this also homogenizes the things that need to be
+        -- made fields in the final `A.Rec`. If we get #3801, perhaps this
+        -- rewrite won't be necessary any more, but any `using` or `renaming`
+        -- clauses will still have to be made into field assignments somehow.
+        ds0' <- mapM' rewriteConcreteOpens ds0
+        List1.ifNull ds0' (return $ A.Rec i []) $ \ ds -> do
+          localToAbstract (LetDefs ds) $ \ ds' -> do
+            names <- forM' ds' $ \case
+              A.LetBind _ _ (A.BindName name) _ _ -> return [name]
+              A.LetPatBind _ p _ -> go p
+                where
+                  go = \case
+                    A.VarP (A.BindName name) -> return [name]
+                    A.ConP _ _ args -> mapM' (go . namedArg) args
+                    A.RecP _ fs -> mapM' (go . _exprFieldA) fs
+                    A.WildP _ -> return []
+                    -- Possibly more Pattern constructors can be supported
+                    other -> do
+                      doc <- prettyATop other
+                      genericError $ "Syntax error: pattern type not supported in 'record where' expressions: " ++ render doc
+              _ -> return []
+            let fs = [Left $ C.FieldAssignment (nameCanonical n) (A.Var n) | n <- names]
+            return $ A.mkLet i ds' (A.Rec i fs)
+        where
+          rewriteConcreteOpens :: C.Declaration -> ScopeM [C.Declaration]
+          rewriteConcreteOpens = \case
+            C.Open _ m dir -> handleOpen m dir
+            C.ModuleMacro r e m mapp DoOpen dir -> do
+              m' <- case m of
+                NoName r _ -> freshConcreteName r 0 ".modulemacro"
+                n -> return n
+              ds <- handleOpen (C.QName m') dir
+              return $ C.ModuleMacro r e m' mapp DontOpen defaultImportDir : ds
+
+            C.Private r o ds -> singleton . C.Private r o <$> mapM' rewriteConcreteOpens ds
+            d -> return [d]
+
+          handleOpen :: C.QName -> C.ImportDirective -> ScopeM [C.Declaration]
+          handleOpen m ImportDirective{ using, impRenaming } = case using of
+            UseEverything ->
+              genericError "Syntax error: 'open' in 'record where' expressions must provide a 'using' clause"
+            Using usingNames ->
+              return . map mkDef $
+                [(name, name) | ImportedName name <- usingNames] ++
+                [(name', name) | Renaming{ renFrom = ImportedName name, renTo = ImportedName name' } <- impRenaming]
+              where
+                mkDef (l, r) = C.FunClause
+                  (C.LHS (C.IdentP True (C.QName l)) [] [])
+                  (C.RHS (C.Ident (C.qualify m r)))
+                  NoWhere
+                  False
 
   -- Record update
       C.RecUpdate r e fs -> do

--- a/test/Fail/RecordWhere1.agda
+++ b/test/Fail/RecordWhere1.agda
@@ -1,0 +1,7 @@
+record Empty : Set where
+
+module M where
+
+foo : Empty
+foo = record where
+  open M

--- a/test/Fail/RecordWhere1.err
+++ b/test/Fail/RecordWhere1.err
@@ -1,0 +1,4 @@
+RecordWhere1.agda:6,7-7,9
+Syntax error: 'open' in 'record where' expressions must provide a
+'using' clause
+when scope checking record where open M

--- a/test/Fail/RecordWhere2.agda
+++ b/test/Fail/RecordWhere2.agda
@@ -1,0 +1,7 @@
+open import Common.Prelude
+open import Common.Product
+
+foo : Nat × Nat
+foo = record where
+  distraction = 1
+  proj₁ = 2

--- a/test/Fail/RecordWhere2.err
+++ b/test/Fail/RecordWhere2.err
@@ -1,0 +1,9 @@
+RecordWhere2.agda:5,7-7,12
+warning: -W[no]TooManyFields
+The record type Σ does not have the field distraction but it would
+have the field proj₂
+when checking that the expression
+record { distraction = distraction ; proj₁ = proj₃ } has type
+Nat × Nat
+Unsolved metas at the following locations:
+  RecordWhere2.agda:5,7-7,12

--- a/test/Succeed/RecordWhere.agda
+++ b/test/Succeed/RecordWhere.agda
@@ -1,0 +1,181 @@
+open import Common.Prelude
+open import Common.Equality
+
+record Empty : Set where
+
+ε : Empty
+ε = record where
+
+module M where
+  proj₁ = 3
+  distraction = false
+
+module WithAccessorsInScope where
+  open import Common.Product
+
+  pair₁ : Nat × Nat
+  pair₁ = record where
+    proj₁ = 4
+    proj₂ = 2
+
+  eq₁ : pair₁ ≡ (4 , 2)
+  eq₁ = refl
+
+  pair₂ : Nat × Nat
+  pair₂ = record where
+    proj₂ = 7
+    proj₁ = proj₂ + 3
+    distraction = false
+
+  eq₂ : pair₂ ≡ (10 , 7)
+  eq₂ = refl
+
+  pair₃ : (Nat → Nat) × Nat
+  pair₃ = record where
+    proj₁ x = x + 1
+    proj₂ = 10
+
+  eq₃․₁ : proj₁ pair₃ 1 ≡ 2
+  eq₃․₁ = refl
+
+  eq₃․₂ : proj₂ pair₃ ≡ 10
+  eq₃․₂ = refl
+
+  pair₄ : Nat × Nat
+  pair₄ = record where
+    open M using (proj₁; distraction)
+    proj₂ = 5
+
+  eq₄ : pair₄ ≡ (3 , 5)
+  eq₄ = refl
+
+  pair₅ : Nat × Nat
+  pair₅ = record where
+    open M using () renaming (proj₁ to proj₂)
+    proj₁ = 5
+
+  eq₅ : pair₅ ≡ (5 , 3)
+  eq₅ = refl
+
+  pair₆ : Nat × Nat
+  pair₆ = record where
+    open Σ pair₅ using (proj₁)
+    proj₂ = pair₅ .proj₂ + 1
+
+  eq₆ : pair₆ ≡ (5 , 4)
+  eq₆ = refl
+
+  pair₇ : Nat × Nat
+  pair₇ = record where
+    proj₁ = pair₅ .proj₂ + 1
+    open Σ pair₅ using () renaming (proj₁ to proj₂)
+
+  eq₇ : pair₇ ≡ (4 , 5)
+  eq₇ = refl
+
+  pair₈ : Nat × Nat
+  pair₈ = record where
+    proj₂ , proj₁ = pair₇
+
+  eq₈ : pair₈ ≡ (5 , 4)
+  eq₈ = refl
+
+  pair₉ : Nat × Nat
+  pair₉ = record where
+    _ , proj₁ = pair₇
+    proj₂ = 9
+
+  eq₉ : pair₉ ≡ (5 , 9)
+  eq₉ = refl
+
+  pair₁₀ : Nat × Nat
+  pair₁₀ = record where
+    record { proj₁ = proj₂ ; proj₂ = proj₁ } = pair₇
+
+  eq₁₀ : pair₁₀ ≡ (5 , 4)
+  eq₁₀ = refl
+
+module WithoutAccessorsInScope where
+  open import Common.Product hiding (proj₁; proj₂)
+
+  pair₁ : Nat × Nat
+  pair₁ = record where
+    proj₁ = 4
+    proj₂ = 2
+
+  eq₁ : pair₁ ≡ (4 , 2)
+  eq₁ = refl
+
+  pair₂ : Nat × Nat
+  pair₂ = record where
+    proj₂ = 7
+    proj₁ = proj₂ + 3
+    distraction = false
+
+  eq₂ : pair₂ ≡ (10 , 7)
+  eq₂ = refl
+
+  pair₃ : (Nat → Nat) × Nat
+  pair₃ = record where
+    proj₁ x = x + 1
+    proj₂ = 10
+
+  eq₃․₁ : Σ.proj₁ pair₃ 1 ≡ 2
+  eq₃․₁ = refl
+
+  eq₃․₂ : Σ.proj₂ pair₃ ≡ 10
+  eq₃․₂ = refl
+
+  pair₄ : Nat × Nat
+  pair₄ = record where
+    open M using (proj₁; distraction)
+    proj₂ = 5
+
+  eq₄ : pair₄ ≡ (3 , 5)
+  eq₄ = refl
+
+  pair₅ : Nat × Nat
+  pair₅ = record where
+    open M using () renaming (proj₁ to proj₂)
+    proj₁ = 5
+
+  eq₅ : pair₅ ≡ (5 , 3)
+  eq₅ = refl
+
+  pair₆ : Nat × Nat
+  pair₆ = record where
+    open Σ pair₅ using (proj₁)
+    proj₂ = pair₅ .Σ.proj₂ + 1
+
+  eq₆ : pair₆ ≡ (5 , 4)
+  eq₆ = refl
+
+  pair₇ : Nat × Nat
+  pair₇ = record where
+    proj₁ = pair₅ .Σ.proj₂ + 1
+    open Σ pair₅ using () renaming (proj₁ to proj₂)
+
+  eq₇ : pair₇ ≡ (4 , 5)
+  eq₇ = refl
+
+  pair₈ : Nat × Nat
+  pair₈ = record where
+    proj₂ , proj₁ = pair₇
+
+  eq₈ : pair₈ ≡ (5 , 4)
+  eq₈ = refl
+
+  pair₉ : Nat × Nat
+  pair₉ = record where
+    _ , proj₁ = pair₇
+    proj₂ = 9
+
+  eq₉ : pair₉ ≡ (5 , 9)
+  eq₉ = refl
+
+  pair₁₀ : Nat × Nat
+  pair₁₀ = record where
+    record { proj₁ = proj₂ ; proj₂ = proj₁ } = pair₇
+
+  eq₁₀ : pair₁₀ ≡ (5 , 4)
+  eq₁₀ = refl

--- a/test/Succeed/RecordWhere.warn
+++ b/test/Succeed/RecordWhere.warn
@@ -1,0 +1,62 @@
+RecordWhere.agda:25,11-28,24
+warning: -W[no]TooManyFields
+The record type Σ does not have the field distraction
+when checking that the expression
+record
+{ proj₂ = proj₃ ; proj₁ = proj₄ ; distraction = distraction }
+has type Nat × Nat
+RecordWhere.agda:45,11-47,14
+warning: -W[no]TooManyFields
+The record type Σ does not have the field distraction
+when checking that the expression
+record
+{ proj₁ = proj₃ ; distraction = distraction ; proj₂ = proj₄ }
+has type Nat × Nat
+RecordWhere.agda:110,11-113,24
+warning: -W[no]TooManyFields
+The record type Σ does not have the field distraction
+when checking that the expression
+record
+{ proj₂ = proj₂ ; proj₁ = proj₁ ; distraction = distraction }
+has type Nat × Nat
+RecordWhere.agda:130,11-132,14
+warning: -W[no]TooManyFields
+The record type Σ does not have the field distraction
+when checking that the expression
+record
+{ proj₁ = proj₁ ; distraction = distraction ; proj₂ = proj₂ }
+has type Nat × Nat
+
+———— All done; warnings encountered ————————————————————————
+
+RecordWhere.agda:25,11-28,24
+warning: -W[no]TooManyFields
+The record type Σ does not have the field distraction
+when checking that the expression
+record
+{ proj₂ = proj₃ ; proj₁ = proj₄ ; distraction = distraction }
+has type Nat × Nat
+
+RecordWhere.agda:45,11-47,14
+warning: -W[no]TooManyFields
+The record type Σ does not have the field distraction
+when checking that the expression
+record
+{ proj₁ = proj₃ ; distraction = distraction ; proj₂ = proj₄ }
+has type Nat × Nat
+
+RecordWhere.agda:110,11-113,24
+warning: -W[no]TooManyFields
+The record type Σ does not have the field distraction
+when checking that the expression
+record
+{ proj₂ = proj₂ ; proj₁ = proj₁ ; distraction = distraction }
+has type Nat × Nat
+
+RecordWhere.agda:130,11-132,14
+warning: -W[no]TooManyFields
+The record type Σ does not have the field distraction
+when checking that the expression
+record
+{ proj₁ = proj₁ ; distraction = distraction ; proj₂ = proj₂ }
+has type Nat × Nat


### PR DESCRIPTION
This PR implements some of the desired features in #4275; it adds a new `record where` expression which may hold bindings that would be valid in a `let`, and any names thus bound (including imported names and names inside LHS patterns) are used as fields in the record. The following

```agda
record where
  open <m> using (<using>) renaming (<x> to <y>)
  <lhs1> = <rhs1>
  <lhs2> = <rhs2>
```
desugars to

```agda
let
  <using> = <m>.<using>
  <y> = <m>.<x>
  <lhs1> = <rhs1>
  <lhs2> = <rhs2>
in record { <using> = <using> ; <y> = <y> ; <lhs1> = <lhs1> ; <lhs2> = <lhs2> }
```

This gives the following benefits:
* No type signatures required, even for functions
* Later bindings can use earlier bindings
* Extra declarations generate warnings
* Get a slightly verbose record update syntax at no additional cost:
```agda
p2 = record where
  open Pair p1 using (fst)
  snd = 0
```

It also bears some limitations:
* Everything that trips people up about the difference between `let` and `where` is relevant here. In particular, the proposed examples using `open import` don't work as written because `import` isn't valid in a `let`. `import Some.Module as M` in an outer scope and `open M using (x)` inside the record achieves the same thing. #6149 may interact with this feature in interesting (hopefully mostly positive, but who knows) ways.
* Most of what trips people up about shadowing names is relevant here, if the field accessor functions are imported in an outer scope. Note however that `open` statements are translated such that later references to names of imported fields refer unambiguously to the locally-bound field and not an outer imported accessor. #3801 would be a more complete fix for this and probably wouldn't break anything added here.
* The requested feature for automatically importing fixities from the record module doesn't seem practically achievable, as it would require the type of the record expression to be known during the concrete-to-abstract translation step, which is when fixities are relevant and AIUI strictly precedes type checking. An alternate syntax like `record MyRecord where`, where `MyRecord` is the name of the record module whence fixities can be read, might enable this feature; this PR doesn't preclude adding such a syntax in the future, though it's also the obvious niche for a not-verbose record update syntax in this style, and I'm currently agnostic as to which future feature seems more compelling.