### PR TITLE
Add a note for distinct, identical-looking extended lambdas

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1326,6 +1326,8 @@ prettyInEqual t1 t2 = do
         (I.Def{}, I.Var{}) -> varDef
         (I.Var{}, I.Con{}) -> varCon
         (I.Con{}, I.Var{}) -> varCon
+        (I.Def x _, I.Def y _)
+          | isExtendedLambdaName x, isExtendedLambdaName y -> extLamExtLam x y
         _                  -> empty
   where
     varDef, varCon, generic :: MonadPretty m => m Doc
@@ -1337,6 +1339,15 @@ prettyInEqual t1 t2 = do
     varVar i j = parens $ fwords $
                    "because one has de Bruijn index " ++ show i
                    ++ " and the other " ++ show j
+
+    extLamExtLam :: MonadPretty m => QName -> QName -> m Doc
+    extLamExtLam a b = vcat
+      [ fwords "Because they are distinct extended lambdas: one is defined at"
+      , "  " <+> pretty (nameBindingSite (qnameName a))
+      , fwords "and the other at"
+      , "  " <+> (pretty (nameBindingSite (qnameName b)) <> ",")
+      , fwords "so they have different internal representations."
+      ]
 
 class PrettyUnequal a where
   prettyUnequal :: MonadPretty m => a -> m Doc -> a -> m Doc

--- a/test/Fail/ExtLamNotEqual.agda
+++ b/test/Fail/ExtLamNotEqual.agda
@@ -1,0 +1,11 @@
+module ExtLamNotEqual where
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+f g : Nat → Nat
+f = λ { zero → zero ; (suc n) → suc n }
+g = λ { zero → zero ; (suc n) → suc n }
+
+_ : f ≡ g
+_ = refl

--- a/test/Fail/ExtLamNotEqual.err
+++ b/test/Fail/ExtLamNotEqual.err
@@ -1,0 +1,9 @@
+ExtLamNotEqual.agda:11,5-9
+(λ { zero → zero ; (suc n) → suc n }) x !=
+(λ { zero → zero ; (suc n) → suc n }) x of type Nat
+Because they are distinct extended lambdas: one is defined at
+   ExtLamNotEqual.agda:7,5-40
+and the other at
+   ExtLamNotEqual.agda:8,5-40,
+so they have different internal representations.
+when checking that the expression refl has type f ≡ g


### PR DESCRIPTION
Same handling as all the other "x != x" errors: if two Defs are the same and both their names are extended-lambda names, add a note mentioning their binding sites.