### PR TITLE
Fix #6524: strip UTF8 BOM when reading a text file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,10 @@ Erasure
 Syntax
 ------
 
+* Agda now skips the UTF8 byte order mark (BOM) at beginning of files
+  (see [#6524](https://github.com/agda/agda/issues/6524)).
+  Previously, the BOM caused a parse error.
+
 * If the new option `--hidden-argument-puns` is used, then the pattern
   `{x}` is interpreted as `{x = x}`, and the pattern `⦃ x ⦄` is
   interpreted as `⦃ x = x ⦄` (see

--- a/doc/user-manual/language/lexical-structure.lagda.rst
+++ b/doc/user-manual/language/lexical-structure.lagda.rst
@@ -10,10 +10,12 @@
 Lexical Structure
 *****************
 
-Agda code is written in UTF-8 encoded plain text files with the
-extension ``.agda``. Most unicode characters can be used in
-identifiers and whitespace is important, see :ref:`names` and
-:ref:`lexical-structure-layout` below.
+Agda code is written in UTF-8 encoded plain text files with the extension ``.agda``;
+more file extensions are supported for :ref:`literate-programming`.
+A UTF-8 byte order mark (BOM) is ignored at the beginning of a file.
+
+Most unicode characters can be used in identifiers, see section :ref:`names`.
+Whitespace is important, see section :ref:`lexical-structure-layout`.
 
 Tokens
 ------

--- a/src/full/Agda/Utils/IO/UTF8.hs
+++ b/src/full/Agda/Utils/IO/UTF8.hs
@@ -9,11 +9,12 @@ module Agda.Utils.IO.UTF8
   ) where
 
 import Control.Exception
+import Data.Maybe (fromMaybe)
 import Data.Text.Lazy (Text)
 import qualified Data.Text.Lazy as T
 import qualified Data.Text.Lazy.Encoding as T
 import qualified Data.Text.Lazy.IO as T
-import qualified Data.ByteString.Lazy as B
+import qualified Data.ByteString.Lazy as BS
 import qualified System.IO as IO
 import qualified System.IO.Error as E
 
@@ -36,6 +37,14 @@ convertLineEndings = T.map convert . convertCRLF
   -- Not a line ending (or '\x000A'):
   convert c        = c
 
+-- | Strip the byte order mark (BOM) from a Text.
+--
+-- - https://github.com/agda/agda/issues/6524
+-- - https://github.com/haskell-hvr/cassava/issues/106#issuecomment-373986176
+--
+stripUtf8Bom :: BS.ByteString -> BS.ByteString
+stripUtf8Bom bs = fromMaybe bs (BS.stripPrefix "\239\187\191" bs)
+
 -- | A kind of exception that can be thrown by 'readTextFile' and
 -- 'readFile'.
 newtype ReadException
@@ -56,7 +65,7 @@ instance Exception ReadException where
 
 readTextFile :: FilePath -> IO Text
 readTextFile file = do
-  s <- T.decodeUtf8' <$> B.readFile file
+  s <- T.decodeUtf8' . stripUtf8Bom <$> BS.readFile file
   case s of
     Right s -> return $ convertLineEndings s
     Left _  -> throw $ DecodingError file

--- a/test/Succeed/Whitespace.agda
+++ b/test/Succeed/Whitespace.agda
@@ -1,9 +1,12 @@
+﻿-- This file starts with an (invisible) byte order mark (BOM) for utf-8.
+-- (Andreas, 2023-05-08, added for issue #6524.)
+
 module Whitespace where
 
 -- The following definition contains several different whitespace
 -- characters, and they are all treated as whitespace.
 
-foo :  Set -> Set  ->  Set
+foo :  Set → Set  →  Set
 foo x _ =  x
 
 -- Tab characters are not treated as white space, but are still


### PR DESCRIPTION
Fix #6524: strip UTF8 BOM when reading a text file.