### PR TITLE
Error Refactor in ConcreteToAbstract

### DIFF
--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2123,9 +2123,7 @@ instance ToAbstract NiceDeclaration where
          p <- noDotorEqPattern err p
          as <- (traverse . mapM) (unVarName <=< resolveName . C.QName) as
          unlessNull (patternVars p List.\\ map unArg as) $ \ xs -> do
-           typeError . GenericDocError =<< do
-             "Unbound variables in pattern synonym: " <+>
-               sep (map prettyA xs)
+           typeError $ UnboundVariablesInPatternSynonym xs
          return (as, p)
       y <- freshAbstractQName' n
       bindName a PatternSynName n y

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2895,9 +2895,7 @@ instance ToAbstract C.LHSCore where
           toAbstract (OldName x)
         A.LHSHead x <$> do mergeEqualPs =<< toAbstract ps
     toAbstract (C.LHSProj d ps1 l ps2) = do
-        unless (null ps1) $ typeError $ GenericDocError $
-          "Ill-formed projection pattern" P.<+>
-          P.pretty (foldl C.AppP (C.IdentP True d) ps1)
+        unless (null ps1) $ typeError $ IllformedProjectionPatternConcrete (foldl C.AppP (C.IdentP True d) ps1)
         qx <- resolveName d
         ds <- case qx of
                 FieldName ds -> return $ fmap anameName ds

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -3212,29 +3212,20 @@ checkAttributes ((attr, r, s) : attrs) =
     LockAttribute IsNotLock -> cont
     LockAttribute IsLock{}  -> do
       unlessM (optGuarded <$> pragmaOptions) $
-        err "Lock" "--guarded"
+        setCurrentRange r $ typeError $ AttributeKindNotEnabled "Lock" "--guarded" s
       cont
     QuantityAttribute Quantityω{} -> cont
     QuantityAttribute Quantity1{} -> __IMPOSSIBLE__
     QuantityAttribute Quantity0{} -> do
       unlessM (optErasure <$> pragmaOptions) $
-        err "Erasure" "--erasure"
+        setCurrentRange r $ typeError $ AttributeKindNotEnabled "Erasure" "--erasure" s
       cont
     CohesionAttribute{} -> do
       unlessM (optCohesion <$> pragmaOptions) $
-        err "Cohesion" "--cohesion"
+        setCurrentRange r $ typeError $ AttributeKindNotEnabled "Cohesion" "--cohesion" s
       cont
   where
   cont = checkAttributes attrs
-
-  err kind opt =
-    setCurrentRange r $
-    typeError $ GenericDocError $ P.fsep $
-    [P.text kind] ++
-    P.pwords "attributes have not been enabled (use" ++
-    [P.text opt] ++
-    P.pwords "to enable them):" ++
-    [P.text s]
 
 {--------------------------------------------------------------------------
     Things we parse but are not part of the Agda file syntax

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -581,9 +581,7 @@ instance ToAbstract MaybeOldQName where
                           -- (Issue 3354).
                 Just s -> stGeneralizedVars `setTCLens` Just (s `Set.union` Set.singleton (anameName d))
                 Nothing -> typeError $ GeneralizeNotSupportedHere $ anameName d
-          DisallowedGeneralizeName -> do
-            typeError . GenericDocError =<<
-              text "Cannot use generalized variable from let-opened module:" <+> prettyTCM (anameName d)
+          DisallowedGeneralizeName -> typeError $ GeneralizedVarInLetOpenedModule $ anameName d
           _ -> return ()
         -- and then we return the name
         return $ withSuffix suffix $ nameToExpr d

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1846,7 +1846,7 @@ instance ToAbstract NiceDeclaration where
           return [ A.DataDef (mkDefInfo x f PublicAccess a r) x' uc (DataDefParams gvars pars) cons ]
       where
         conName (C.Axiom _ _ _ _ _ c _) = return c
-        conName d = errorNotConstrDecl d
+        conName d = __IMPOSSIBLE__
 
   -- Record definitions (mucho interesting)
     C.NiceRecDef r o a _ uc x (RecordDirectives ind eta pat cm) pars fields -> do
@@ -2335,12 +2335,7 @@ instance ToAbstract DataConstrDecl where
         printScope "con" 15 "bound constructor"
         return $ A.Axiom ConName (mkDefInfoInstance x f p a i NotMacroDef r)
                          info Nothing y t'
-      _ -> errorNotConstrDecl d
-
-errorNotConstrDecl :: C.NiceDeclaration -> ScopeM a
-errorNotConstrDecl d = typeError . GenericDocError $
-        "Illegal declaration in data type definition " P.$$
-        P.nest 2 (P.vcat $ map pretty (notSoNiceDeclarations d))
+      _ -> __IMPOSSIBLE__
 
 instance ToAbstract C.Pragma where
   type AbsOfCon C.Pragma = [A.Pragma]

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -277,6 +277,7 @@ errorString err = case err of
   ReferencesFutureVariables{}              -> "ReferencesFutureVariables"
   DoesNotMentionTicks{}                    -> "DoesNotMentionTicks"
   MismatchedProjectionsError{}             -> "MismatchedProjectionsError"
+  AttributeKindNotEnabled{}                -> "AttributeKindNotEnabled"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1296,6 +1297,13 @@ instance PrettyTCM TypeError where
       pwords "The projections" ++ [prettyTCM left] ++
       pwords "and" ++ [prettyTCM right] ++
       pwords "do not match"
+
+    AttributeKindNotEnabled kind opt s -> fsep $
+      [text kind] ++
+      pwords "attributes have not been enabled (use" ++
+      [text opt] ++
+      pwords "to enable them):" ++
+      [text s]
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -156,7 +156,8 @@ errorString err = case err of
   GenericError{}                           -> "GenericError"
   GenericDocError{}                        -> "GenericDocError"
   InstanceNoCandidate{}                    -> "InstanceNoCandidate"
-  IllformedProjectionPattern{}             -> "IllformedProjectionPattern"
+  IllformedProjectionPatternAbstract{}     -> "IllformedProjectionPatternAbstract"
+  IllformedProjectionPatternConcrete{}     -> "IllformedProjectionPatternConcrete"
   CannotEliminateWithPattern{}             -> "CannotEliminateWithPattern"
   IllegalLetInTelescope{}                  -> "IllegalLetInTelescope"
   IllegalPatternInTelescope{}              -> "IllegalPatternInTelescope"
@@ -398,8 +399,11 @@ instance PrettyTCM TypeError where
       pwords "Failed to infer that constructor pattern "
       ++ [prettyA p] ++ pwords " is forced"
 
-    IllformedProjectionPattern p -> fsep $
+    IllformedProjectionPatternAbstract p -> fsep $
       pwords "Ill-formed projection pattern " ++ [prettyA p]
+
+    IllformedProjectionPatternConcrete p -> fsep $
+      pwords "Ill-formed projection pattern" ++ [pretty p]
 
     CannotEliminateWithPattern b p a -> do
       let isProj = isJust (isProjP p)

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -131,6 +131,7 @@ errorString err = case err of
   BadArgumentsToPatternSynonym{}           -> "BadArgumentsToPatternSynonym"
   TooFewArgumentsToPatternSynonym{}        -> "TooFewArgumentsToPatternSynonym"
   CannotResolveAmbiguousPatternSynonym{}   -> "CannotResolveAmbiguousPatternSynonym"
+  UnboundVariablesInPatternSynonym{}       -> "UnboundVariablesInPatternSynonym"
   BothWithAndRHS                           -> "BothWithAndRHS"
   BuiltinInParameterisedModule{}           -> "BuiltinInParameterisedModule"
   BuiltinMustBeConstructor{}               -> "BuiltinMustBeConstructor"
@@ -971,6 +972,10 @@ instance PrettyTCM TypeError where
 
     UnusedVariableInPatternSynonym -> fsep $
       pwords "Unused variable in pattern synonym."
+
+    UnboundVariablesInPatternSynonym xs -> fsep $
+      pwords "Unbound variables in pattern synonym: " ++
+      [sep (map prettyA xs)]
 
     NoParseForLHS lhsOrPatSyn errs p -> vcat
       [ fsep $ pwords "Could not parse the" ++ prettyLhsOrPatSyn ++ [pretty p]

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -178,6 +178,7 @@ errorString err = case err of
   GeneralizeNotSupportedHere{}             -> "GeneralizeNotSupportedHere"
   GeneralizeCyclicDependency{}             -> "GeneralizeCyclicDependency"
   GeneralizeUnsolvedMeta{}                 -> "GeneralizeUnsolvedMeta"
+  GeneralizedVarInLetOpenedModule{}        -> "GeneralizedVarInLetOpenedModule"
   MultipleFixityDecls{}                    -> "MultipleFixityDecls"
   MultiplePolarityPragmas{}                -> "MultiplePolarityPragmas"
   NoBindingForBuiltin{}                    -> "NoBindingForBuiltin"
@@ -1199,6 +1200,10 @@ instance PrettyTCM TypeError where
 
     GeneralizeUnsolvedMeta -> fsep $
       pwords "Unsolved meta not generalized"
+
+    GeneralizedVarInLetOpenedModule x -> fsep $
+      pwords "Cannot use generalized variable from let-opened module: " ++
+      [prettyTCM x]
 
     MultipleFixityDecls xs ->
       sep [ fsep $ pwords "Multiple fixity or syntax declarations for"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -261,6 +261,7 @@ errorString err = case err of
   WrongHidingInApplication{}               -> "WrongHidingInApplication"
   WrongHidingInLHS{}                       -> "WrongHidingInLHS"
   WrongHidingInLambda{}                    -> "WrongHidingInLambda"
+  IllegalHidingInPostfixProjection{}       -> "IllegalHidingInPostfixProjection"
   WrongIrrelevanceInLambda{}               -> "WrongIrrelevanceInLambda"
   WrongQuantityInLambda{}                  -> "WrongQuantityInLambda"
   WrongCohesionInLambda{}                  -> "WrongCohesionInLambda"
@@ -360,6 +361,10 @@ instance PrettyTCM TypeError where
 
     WrongHidingInLambda t ->
       fwords "Found an implicit lambda where an explicit lambda was expected"
+
+    IllegalHidingInPostfixProjection arg -> fsep $
+      pwords "Illegal hiding in postfix projection " ++
+      [pretty arg]
 
     WrongIrrelevanceInLambda ->
       fwords "Found a non-strict lambda where a irrelevant lambda was expected"

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4475,6 +4475,7 @@ data TypeError
         | TooFewArgumentsToPatternSynonym A.AmbiguousQName
         | CannotResolveAmbiguousPatternSynonym (List1 (A.QName, A.PatternSynDefn))
         | UnusedVariableInPatternSynonym
+        | UnboundVariablesInPatternSynonym [A.Name]
     -- Operator errors
         | NoParseForApplication (List2 C.Expr)
         | AmbiguousParseForApplication (List2 C.Expr) (List1 C.Expr)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4420,6 +4420,7 @@ data TypeError
           -- ^ Arguments: later term, its type, lock term. The lock term
           -- does not mention any @lock variables.
         | MismatchedProjectionsError QName QName
+        | AttributeKindNotEnabled String String String
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4314,6 +4314,7 @@ data TypeError
             -- ^ Expected a non-hidden function and found a hidden lambda.
         | WrongHidingInApplication Type
             -- ^ A function is applied to a hidden argument where a non-hidden was expected.
+        | IllegalHidingInPostfixProjection (NamedArg C.Expr)
         | WrongNamedArgument (NamedArg A.Expr) [NamedName]
             -- ^ A function is applied to a hidden named argument it does not have.
             -- The list contains names of possible hidden arguments at this point.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4458,6 +4458,7 @@ data TypeError
         | InvalidPattern C.Pattern
         | RepeatedVariablesInPattern [C.Name]
         | GeneralizeNotSupportedHere A.QName
+        | GeneralizedVarInLetOpenedModule A.QName
         | MultipleFixityDecls [(C.Name, [Fixity'])]
         | MultiplePolarityPragmas [C.Name]
     -- Concrete to Abstract errors

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4331,7 +4331,8 @@ data TypeError
             -- ^ The given relevance does not correspond to the expected relevane.
         | UninstantiatedDotPattern A.Expr
         | ForcedConstructorNotInstantiated A.Pattern
-        | IllformedProjectionPattern A.Pattern
+        | IllformedProjectionPatternAbstract A.Pattern
+        | IllformedProjectionPatternConcrete C.Pattern
         | CannotEliminateWithPattern (Maybe Blocker) (NamedArg A.Pattern) Type
         | WrongNumberOfConstructorArguments QName Nat Nat
         | ShouldBeEmpty Type [DeBruijnPattern]

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -196,7 +196,7 @@ updateProblemEqs eqs = do
 
     update :: ProblemEq -> TCM [ProblemEq]
     update eq@(ProblemEq A.WildP{} _ _) = return []
-    update eq@(ProblemEq p@A.ProjP{} _ _) = typeError $ IllformedProjectionPattern p
+    update eq@(ProblemEq p@A.ProjP{} _ _) = typeError $ IllformedProjectionPatternAbstract p
     update eq@(ProblemEq p@(A.AsP info x p') v a) =
       (ProblemEq (A.VarP x) v a :) <$> update (ProblemEq p' v a)
 

--- a/test/Fail/Issue1639.agda
+++ b/test/Fail/Issue1639.agda
@@ -7,8 +7,5 @@ data D : Set1 where
 -- WAS: Internal error (on master)
 
 -- NOW:
--- Illegal declaration in data type definition
---   field A : Set
--- when scope checking the declaration
---   data D where
---     field A : Set
+-- A data definition can only contain type signatures, possibly under
+-- keyword instance


### PR DESCRIPTION
Refactor `GenericDocError`-s for concrete ones in `ConcreteToAbstract.hs`. More specifically:
- Introduce an error `GeneralizedVarInLetOpenedModule` 
- Introduce an error `UnboundVariablesInPatternSynonym `
- Renamed existing `IllformedProjectionPattern` to `IllformedProjectionPatternAbstract` and introduced `IllformedProjectionPatternConcrete`, for abstract and concrete syntax respectively
- Introduce an error `IllegalHidingInPostfixProjection`
- Remove `errorNotConstrDecl`, this one should be impossible to reach as parser catches the error first, also updated the error documentation in test `Issue1639.agda`
- Introduce an error `AttributeKindNotEnabled`