### PR TITLE
Represent builtin sorts via an enum not strings

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2630,12 +2630,12 @@ pattern Primitive
   )
 
 data PrimitiveSortData = PrimitiveSortData
-  { _primSortName :: String
+  { _primSortName :: BuiltinSort
   , _primSortSort :: Sort
   } deriving (Show, Generic)
 
 pattern PrimitiveSort
-  :: String
+  :: BuiltinSort
   -> Sort
   -> Defn
 pattern PrimitiveSort
@@ -3339,11 +3339,21 @@ type TempInstanceTable = (InstanceTable , Set QName)
 -- ** Builtin things
 ---------------------------------------------------------------------------
 
+data BuiltinSort
+  = SortSet
+  | SortProp
+  | SortStrictSet
+  | SortSetOmega
+  | SortStrictSetOmega
+  | SortIntervalUniv
+  | SortLevelUniv
+  deriving (Show, Eq, Bounded, Enum, Generic)
+
 data BuiltinDescriptor
   = BuiltinData (TCM Type) [String]
   | BuiltinDataCons (TCM Type)
   | BuiltinPrim String (Term -> TCM ())
-  | BuiltinSort String
+  | BuiltinSort BuiltinSort
   | BuiltinPostulate Relevance (TCM Type)
   | BuiltinUnknown (Maybe (TCM Type)) (Term -> Type -> TCM ())
     -- ^ Builtin of any kind.
@@ -5353,6 +5363,9 @@ instance KillRange CompKit where
 instance KillRange ProjectionLikenessMissing where
   killRange = id
 
+instance KillRange BuiltinSort where
+  killRange = id
+
 instance KillRange Defn where
   killRange def =
     case def of
@@ -5512,6 +5525,7 @@ instance NFData PrimFun
 instance NFData c => NFData (FunctionInverse' c)
 instance NFData TermHead
 instance NFData Call
+instance NFData BuiltinSort
 instance NFData pf => NFData (Builtin pf)
 instance NFData HighlightingLevel
 instance NFData HighlightingMethod

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -665,11 +665,6 @@ mkPrimLevelMax = do
     b' <- levelView' $ unArg b
     redReturn $ Level $ levelLub a' b'
 
-mkPrimSetOmega :: IsFibrant -> TCM PrimitiveImpl
-mkPrimSetOmega f = do
-  let t = sort $ Inf f 1
-  return $ PrimImpl t $ primFun __IMPOSSIBLE__ 0 $ \_ -> redReturn $ Sort $ Inf f 0
-
 primLockUniv' :: TCM PrimitiveImpl
 primLockUniv' = do
   let t = sort $ Type $ levelSuc $ Max 0 []
@@ -857,10 +852,6 @@ primitiveFunctions = localTCStateSavingWarnings <$> Map.fromListWith __IMPOSSIBL
   , "primLevelZero"       |-> mkPrimLevelZero
   , "primLevelSuc"        |-> mkPrimLevelSuc
   , "primLevelMax"        |-> mkPrimLevelMax
-
-  -- Sorts
-  , "primSetOmega"        |-> mkPrimSetOmega IsFibrant
-  , "primStrictSetOmega"  |-> mkPrimSetOmega IsStrict
 
   -- Floating point functions
   --

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -123,7 +123,7 @@ coreBuiltins =
                                                               (El (varSort 1) <$> varM 0 <@> primIZero) -->
                                                               (El (varSort 1) <$> varM 0 <@> primIOne) -->
                                                               return (sort $ varSort 1)))
-  , (builtinIntervalUniv                     |-> BuiltinSort "primIntervalUniv")
+  , (builtinIntervalUniv                     |-> BuiltinSort SortIntervalUniv)
   , (builtinInterval                         |-> BuiltinData (requireCubical CErased "" >>
                                                               (return $ sort IntervalUniv)) [builtinIZero,builtinIOne])
   , (builtinSub                              |-> builtinPostulateC CErased (runNamesT [] $ hPi' "a" (el $ cl primLevel) $ \ a ->
@@ -329,15 +329,15 @@ coreBuiltins =
   , (builtinNatModSucAux                     |-> BuiltinPrim "primNatModSucAux" verifyModSucAux)
   , (builtinNatEquals                        |-> BuiltinPrim "primNatEquality" verifyEquals)
   , (builtinNatLess                          |-> BuiltinPrim "primNatLess" verifyLess)
-  , (builtinLevelUniv                        |-> BuiltinSort "primLevelUniv")
+  , (builtinLevelUniv                        |-> BuiltinSort SortLevelUniv)
   , (builtinLevelZero                        |-> BuiltinPrim "primLevelZero" (const $ return ()))
   , (builtinLevelSuc                         |-> BuiltinPrim "primLevelSuc" (const $ return ()))
   , (builtinLevelMax                         |-> BuiltinPrim "primLevelMax" verifyMax)
-  , (builtinSet                              |-> BuiltinSort "primSet")
-  , (builtinProp                             |-> BuiltinSort "primProp")
-  , (builtinSetOmega                         |-> BuiltinSort "primSetOmega")
-  , (builtinSSetOmega                        |-> BuiltinSort "primStrictSetOmega")
-  , (builtinStrictSet                        |-> BuiltinSort "primStrictSet")
+  , (builtinSet                              |-> BuiltinSort SortSet)
+  , (builtinProp                             |-> BuiltinSort SortProp)
+  , (builtinSetOmega                         |-> BuiltinSort SortSetOmega)
+  , (builtinSSetOmega                        |-> BuiltinSort SortStrictSetOmega)
+  , (builtinStrictSet                        |-> BuiltinSort SortStrictSet)
   , (builtinAgdaClause                       |-> BuiltinData tset [builtinAgdaClauseClause, builtinAgdaClauseAbsurd])
   , (builtinAgdaClauseClause                 |-> BuiltinDataCons (ttelescope --> tlist (targ tpat) --> tterm --> tclause))
   , (builtinAgdaClauseAbsurd                 |-> BuiltinDataCons (ttelescope --> tlist (targ tpat) --> tclause))
@@ -1036,20 +1036,19 @@ bindBuiltinNoDef b q = inTopContext $ do
               , dataTransp     = Nothing
               }
 
-    Just (BuiltinSort sortname) -> do
-      let s = case sortname of
-                "primSet"      -> mkType 0
-                "primProp"     -> mkProp 0
-                "primStrictSet" -> mkSSet 0
-                "primSetOmega" -> Inf IsFibrant 0
-                "primStrictSetOmega" -> Inf IsStrict 0
-                "primIntervalUniv" -> IntervalUniv
-                "primLevelUniv" -> LevelUniv
-                _              -> __IMPOSSIBLE__
-          def = PrimitiveSort sortname s
+    Just (BuiltinSort builtinSort) -> do
+      let s = case builtinSort of
+                SortSet -> mkType 0
+                SortProp -> mkProp 0
+                SortStrictSet -> mkSSet 0
+                SortSetOmega -> Inf IsFibrant 0
+                SortStrictSetOmega -> Inf IsStrict 0
+                SortIntervalUniv -> IntervalUniv
+                SortLevelUniv -> LevelUniv
+          def = PrimitiveSort builtinSort s
       -- Check for the cubical flag if the sort requries it
-      case sortname of
-        "primIntervalUniv" -> requireCubical CErased ""
+      case builtinSort of
+        SortIntervalUniv -> requireCubical CErased ""
         _ -> return ()
       addConstant' q defaultArgInfo q (sort $ univSort s) def
       bindBuiltinName b $ Def q []

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -700,9 +700,6 @@ checkPrimitive i x (Arg info e) =
           , "primLevelZero"
           , "primLevelSuc"
           , "primLevelMax"
-          , "primSetOmega"
-          , "primStrictSet"
-          , "primStrictSetOmega"
           ]
     when (name `elem` builtinPrimitives) $ do
       reportSDoc "tc.prim" 20 $ text name <+> "is a BUILTIN, not a primitive!"

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20230424 * 10 + 0
+currentInterfaceVersion = 20230511 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -373,6 +373,8 @@ instance EmbPrj EtaEquality where
 
 instance EmbPrj ProjectionLikenessMissing
 
+instance EmbPrj BuiltinSort
+
 instance EmbPrj Defn where
   icod_ (Axiom       a)                                 = icodeN 0 Axiom a
   icod_ (Function    a b s t u c d e f g h i j k l m)   = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k l m


### PR DESCRIPTION
These "primitives" aren't primitives in the Agda sense (you cannot include them in scope), but are instead just magic strings. We can replace them with an enum.