### PR TITLE
Fixes to the current Agda modalities

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -616,6 +616,7 @@ library
       Agda.TypeChecking.MetaVars
       Agda.TypeChecking.MetaVars.Mention
       Agda.TypeChecking.MetaVars.Occurs
+      Agda.TypeChecking.Modalities
       Agda.TypeChecking.Monad.Base
       Agda.TypeChecking.Monad.Benchmark
       Agda.TypeChecking.Monad.Builtin

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -458,7 +458,7 @@ moreUsableModality :: Modality -> Modality -> Bool
 moreUsableModality m m' = related m POLE m'
 
 usableModality :: LensModality a => a -> Bool
-usableModality a = usableRelevance m && usableQuantity m
+usableModality a = usableRelevance m && usableQuantity m && usableCohesion m
   where m = getModality a
 
 -- | Multiplicative monoid (standard monoid).
@@ -1458,7 +1458,7 @@ inverseComposeCohesion r x =
   case (r, x) of
     (Continuous  , x) -> x          -- going to continous arg.: nothing changes
                                     -- because Continuous is comp.-neutral
-    (Squash, x)       -> Squash     -- artificial case, should not be needed.
+    (Squash, x)       -> Flat       -- in squash position everything is usable
     (Flat , Flat)     -> Flat       -- otherwise: Flat things remain Flat
     (Flat , _)        -> Squash     -- but everything else becomes unusable.
 

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1069,6 +1069,16 @@ data Relevance
   | NonStrict   -- ^ The argument may never flow into evaluation position.
                 --   Therefore, it is irrelevant at run-time.
                 --   It is treated relevantly during equality checking.
+                --
+                --   The above comment is probably obsolete, as we currently have
+                --   erasure (/at/0, @Quantity0@) for that. What's described here is probably
+                --   shape-irrelevance (..). If you enable @--experimental-irrelevance@,
+                --   then the type of an irrelevant function is forced to be shape-irrelevant.
+                --   See:
+                --   - <https://doi.org/10.2168/LMCS-8(1:29)2012> example 2.8
+                --     (Not enforcing shape-irrelevant codomains can break subject reduction!)
+                --   - <https://dl.acm.org/doi/10.1145/3110277>
+                --   - <https://doi.org/10.1145/3209108.3209119>
   | Irrelevant  -- ^ The argument is irrelevant at compile- and runtime.
     deriving (Show, Eq, Enum, Bounded, Generic)
 

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -909,7 +909,9 @@ instance ToConcrete A.Expr where
         bracket piBrackets
         $ do a' <- toConcreteCtx ctx a
              b' <- toConcreteTop b
-             let dom = setQuantity (getQuantity a') $ defaultArg $ addRel a' $ mkArg a'
+             -- NOTE We set relevance to Relevant in arginfo because we wrap
+             -- with C.Dot or C.DoubleDot using addRel instead.
+             let dom = setRelevance Relevant $ setModality (getModality a') $ defaultArg $ addRel a' $ mkArg a'
              return $ C.Fun (getRange i) dom b'
              -- Andreas, 2018-06-14, issue #2513
              -- TODO: print attributes

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -192,7 +192,7 @@ errorString err = case err of
   NoSuchModule{}                           -> "NoSuchModule"
   DuplicatePrimitiveBinding{}              -> "DuplicatePrimitiveBinding"
   NoSuchPrimitiveFunction{}                -> "NoSuchPrimitiveFunction"
-  WrongModalityForPrimitive{}              -> "WrongModalityForPrimitive"
+  WrongArgInfoForPrimitive{}               -> "WrongArgInfoForPrimitive"
   NotAModuleExpr{}                         -> "NotAModuleExpr"
   NotAProperTerm                           -> "NotAProperTerm"
   InvalidType{}                            -> "InvalidType"
@@ -711,16 +711,14 @@ instance PrettyTCM TypeError where
     NoSuchPrimitiveFunction x -> fsep $
       pwords "There is no primitive function called" ++ [text x]
 
-    WrongModalityForPrimitive x got expect ->
-      vcat [ fsep $ pwords "Wrong modality for primitive" ++ [pretty x]
+    WrongArgInfoForPrimitive x got expect ->
+      vcat [ fsep $ pwords "Wrong definition properties for primitive" ++ [pretty x]
            , nest 2 $ text $ "Got:      " ++ intercalate ", " gs
            , nest 2 $ text $ "Expected: " ++ intercalate ", " es ]
       where
         (gs, es) = unzip [ p | p@(g, e) <- zip (things got) (things expect), g /= e ]
         things i = [verbalize $ getHiding i,
-                    verbalize $ getRelevance i,
-                    verbalize $ getQuantity i,
-                    verbalize $ getCohesion i]
+                    "at modality " ++ verbalize (getModality i)]
 
     BuiltinInParameterisedModule x -> fwords $
       "The BUILTIN pragma cannot appear inside a bound context " ++
@@ -1620,7 +1618,7 @@ instance Verbalize Cohesion where
 
 instance Verbalize Modality where
   verbalize mod | mod == defaultModality = "default"
-  verbalize (Modality rel qnt coh) = intercalate "," $
+  verbalize (Modality rel qnt coh) = intercalate ", " $
     [ verbalize rel | rel /= defaultRelevance ] ++
     [ verbalize qnt | qnt /= defaultQuantity ] ++
     [ verbalize coh | coh /= defaultCohesion ]

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -756,7 +756,7 @@ createGenValue x = setCurrentRange x $ do
   -- instantiated, and set the quantity of the meta to the declared
   -- quantity of the generalisable variable.
   updateMetaVar m $ \ mv ->
-    setQuantity (getQuantity (defArgInfo def)) $
+    setModality (getModality (defArgInfo def)) $
     mv { mvFrozen = Frozen }
 
   -- Set up names of arg metas

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -220,7 +220,9 @@ instance UsableModality Term where
       return ok `and2M` usableMod mod vs
     Def f vs -> do
       fmod <- modalityOfConst f
-      let ok = fmod `moreUsableModality` mod
+      -- Pure modalities don't matter here, only positional ones, hence remove
+      -- them from the equation.
+      let ok = setCohesion Flat fmod `moreUsableModality` mod
       reportSDoc "tc.irr" 50 $
         "Definition" <+> prettyTCM (Def f []) <+>
         text ("has modality " ++ show fmod ++ ", which is a " ++

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -252,6 +252,9 @@ metaCheck m = do
     -- - If it is in a top-level position, we can instead solve the
     --   equation by instantiating the other way around, so promotion
     --   is not necessary.
+
+    -- Actually, this is not the case anymore, no new meta is created and
+    -- instead the metavar itself gets modified with the new modality.
     let fail reason = do
           reportSDoc "tc.meta.occurs" 20 $ "Meta occurs check found bad relevance"
           reportSDoc "tc.meta.occurs" 20 $ "aborting because" <+> reason
@@ -263,6 +266,7 @@ metaCheck m = do
     when (isUnguarded cxt)                   $ fail "occurrence is unguarded"
 
     reportSDoc "tc.meta.occurs" 20 $ "Promoting meta" <+> prettyTCM m <+> "to modality" <+> prettyTCM mmod'
+    -- The meta gets updated here
     updateMetaVar m $ \ mv -> mv { mvInfo = setModality mmod' $ mvInfo mv }
     etaExpandListeners m
     wakeupConstraints m

--- a/src/full/Agda/TypeChecking/Modalities.hs
+++ b/src/full/Agda/TypeChecking/Modalities.hs
@@ -1,0 +1,101 @@
+module Agda.TypeChecking.Modalities
+  ( checkModality'
+  , checkModality
+  , checkModalityArgs
+  ) where
+
+import Control.Monad
+import Control.Monad.Except
+import Control.Applicative ((<|>))
+
+import Agda.Utils.Maybe
+import Agda.Utils.Monad
+import Agda.Utils.Lens
+
+import Agda.Interaction.Options
+
+import Agda.Syntax.Common
+import Agda.Syntax.Internal
+import Agda.Syntax.Abstract.Name
+
+import Agda.TypeChecking.Conversion
+import Agda.TypeChecking.Free
+import Agda.TypeChecking.Free.Lazy
+import Agda.TypeChecking.Monad
+import Agda.TypeChecking.Pretty
+import Agda.TypeChecking.Substitute
+
+-- | The second argument is the definition of the first.
+--   Returns 'Nothing' if ok, otherwise the error message.
+checkRelevance' :: (MonadConversion m) => QName -> Definition -> m (Maybe TypeError)
+checkRelevance' x def = do
+  case getRelevance def of
+    Relevant -> return Nothing -- relevance functions can be used in any context.
+    drel -> do
+      -- Andreas,, 2018-06-09, issue #2170
+      -- irrelevant projections are only allowed if --irrelevant-projections
+      ifM (return (isJust $ isProjection_ $ theDef def) `and2M`
+           (not . optIrrelevantProjections <$> pragmaOptions)) {-then-} needIrrProj {-else-} $ do
+        rel <- viewTC eRelevance
+        reportSDoc "tc.irr" 50 $ vcat
+          [ "declaration relevance =" <+> text (show drel)
+          , "context     relevance =" <+> text (show rel)
+          ]
+        return $ boolToMaybe (not $ drel `moreRelevant` rel) $ DefinitionIsIrrelevant x
+  where
+  needIrrProj = Just . GenericDocError <$> do
+    sep [ "Projection " , prettyTCM x, " is irrelevant."
+        , " Turn on option --irrelevant-projections to use it (unsafe)."
+        ]
+
+-- | The second argument is the definition of the first.
+--   Returns 'Nothing' if ok, otherwise the error message.
+checkQuantity' :: (MonadConversion m) => QName -> Definition -> m (Maybe TypeError)
+checkQuantity' x def = do
+  case getQuantity def of
+    dq@Quantityω{} -> do
+      reportSDoc "tc.irr" 50 $ vcat
+        [ "declaration quantity =" <+> text (show dq)
+        -- , "context     quantity =" <+> text (show q)
+        ]
+      return Nothing -- Abundant definitions can be used in any context.
+    dq -> do
+      q <- viewTC eQuantity
+      reportSDoc "tc.irr" 50 $ vcat
+        [ "declaration quantity =" <+> text (show dq)
+        , "context     quantity =" <+> text (show q)
+        ]
+      return $ boolToMaybe (not $ dq `moreQuantity` q) $ DefinitionIsErased x
+
+-- | The second argument is the definition of the first.
+checkModality' :: (MonadConversion m) => QName -> Definition -> m (Maybe TypeError)
+checkModality' x def = do
+  relOk <- checkRelevance' x def
+  qtyOk <- checkQuantity' x def
+  return $ relOk <|> qtyOk
+
+-- | The second argument is the definition of the first.
+checkModality :: (MonadConversion m) => QName -> Definition -> m ()
+checkModality x def = checkModality' x def >>= mapM_ typeError
+
+-- | Checks that the given implicitely inserted arguments, are used in a modally
+--   correct way.
+checkModalityArgs :: (MonadConversion m) => Args -> m ()
+checkModalityArgs vs = do
+  let
+    vmap :: VarMap
+    vmap = freeVars vs
+
+  -- we iterate over all vars in the context and their ArgInfo,
+  -- checking for each that "vs" uses them as allowed.
+  as <- getContextArgs
+  forM_ as $ \ (Arg avail t) -> do
+    let m = do
+          v <- deBruijnView t
+          varModality <$> lookupVarMap v vmap
+    whenJust m $ \ used -> do
+        unless (getCohesion avail `moreCohesion` getCohesion used) $
+           (genericDocError =<<) $ fsep $
+                ["Variable" , prettyTCM t]
+             ++ pwords "is used as" ++ [text $ show $ getModality used]
+             ++ pwords "but only available as" ++ [text $ show $ getModality avail]

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4525,7 +4525,7 @@ data TypeError
         | NoBindingForBuiltin BuiltinId
         | NoSuchPrimitiveFunction String
         | DuplicatePrimitiveBinding PrimitiveId QName QName
-        | WrongModalityForPrimitive PrimitiveId ArgInfo ArgInfo
+        | WrongArgInfoForPrimitive PrimitiveId ArgInfo ArgInfo
         | ShadowedModule C.Name [A.ModuleName]
         | BuiltinInParameterisedModule BuiltinId
         | IllegalLetInTelescope C.TypedBinding

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -44,6 +44,7 @@ import Agda.TypeChecking.Injectivity
 import Agda.TypeChecking.InstanceArguments (postponeInstanceConstraints)
 import Agda.TypeChecking.Level
 import Agda.TypeChecking.MetaVars
+import Agda.TypeChecking.Modalities
 import Agda.TypeChecking.Names
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Primitive hiding (Nat)
@@ -368,10 +369,10 @@ inferDef mkTerm x =
             v = mkTerm vs -- applies x to vs, dropping parameters
 
         -- Andrea 2019-07-16, Check that the supplied arguments
-        -- respect the cohesion modalities of the current context.
-        -- Cohesion is purely based on left-division, so it does not
-        -- rely on "position" like Relevance/Quantity.
-        checkCohesionArgs vs
+        -- respect the pure modalities of the current context.
+        -- Pure modalities are based on left-division, so it does not
+        -- rely on "position" like positional modalities.
+        checkModalityArgs vs
 
         debug vs t v
         return (v, t)
@@ -384,81 +385,6 @@ inferDef mkTerm x =
         [ "inferred def " <+> prettyTCM x <+> hsep (map prettyTCM vs)
         , nest 2 $ ":" <+> prettyTCM t
         , nest 2 $ "-->" <+> prettyTCM v ]
-
-checkCohesionArgs :: Args -> TCM ()
-checkCohesionArgs vs = do
-  let
-    vmap :: VarMap
-    vmap = freeVars vs
-
-  -- we iterate over all vars in the context and their ArgInfo,
-  -- checking for each that "vs" uses them as allowed.
-  as <- getContextArgs
-  forM_ as $ \ (Arg avail t) -> do
-    let m = do
-          v <- deBruijnView t
-          varModality <$> lookupVarMap v vmap
-    whenJust m $ \ used -> do
-        unless (getCohesion avail `moreCohesion` getCohesion used) $
-           (genericDocError =<<) $ fsep $
-                ["Variable" , prettyTCM t]
-             ++ pwords "is used as" ++ [text $ show $ getCohesion used]
-             ++ pwords "but only available as" ++ [text $ show $ getCohesion avail]
-
--- | The second argument is the definition of the first.
---   Returns 'Nothing' if ok, otherwise the error message.
-checkRelevance' :: QName -> Definition -> TCM (Maybe TypeError)
-checkRelevance' x def = do
-  case getRelevance def of
-    Relevant -> return Nothing -- relevance functions can be used in any context.
-    drel -> do
-      -- Andreas,, 2018-06-09, issue #2170
-      -- irrelevant projections are only allowed if --irrelevant-projections
-      ifM (return (isJust $ isProjection_ $ theDef def) `and2M`
-           (not . optIrrelevantProjections <$> pragmaOptions)) {-then-} needIrrProj {-else-} $ do
-        rel <- viewTC eRelevance
-        reportSDoc "tc.irr" 50 $ vcat
-          [ "declaration relevance =" <+> text (show drel)
-          , "context     relevance =" <+> text (show rel)
-          ]
-        return $ if (drel `moreRelevant` rel) then Nothing else Just $ DefinitionIsIrrelevant x
-  where
-  needIrrProj = Just . GenericDocError <$> do
-    sep [ "Projection " , prettyTCM x, " is irrelevant."
-        , " Turn on option --irrelevant-projections to use it (unsafe)."
-        ]
-
--- | The second argument is the definition of the first.
---   Returns 'Nothing' if ok, otherwise the error message.
-checkQuantity' :: QName -> Definition -> TCM (Maybe TypeError)
-checkQuantity' x def = do
-  case getQuantity def of
-    dq@Quantityω{} -> do
-      reportSDoc "tc.irr" 50 $ vcat
-        [ "declaration quantity =" <+> text (show dq)
-        -- , "context     quantity =" <+> text (show q)
-        ]
-      return Nothing -- Abundant definitions can be used in any context.
-    dq -> do
-      q <- viewTC eQuantity
-      reportSDoc "tc.irr" 50 $ vcat
-        [ "declaration quantity =" <+> text (show dq)
-        , "context     quantity =" <+> text (show q)
-        ]
-      return $ if (dq `moreQuantity` q) then Nothing else Just $ DefinitionIsErased x
-
--- | The second argument is the definition of the first.
-checkModality' :: QName -> Definition -> TCM (Maybe TypeError)
-checkModality' x def = do
-  checkRelevance' x def >>= \case
-    Nothing    -> checkQuantity' x def
-    err@Just{} -> return err
-
--- | The second argument is the definition of the first.
-checkModality :: QName -> Definition -> TCM ()
-checkModality x def = justToError $ checkModality' x def
-  where
-  justToError m = maybe (return ()) typeError =<< m
 
 -- | @checkHeadApplication e t hd args@ checks that @e@ has type @t@,
 -- assuming that @e@ has the form @hd args@. The corresponding

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -372,7 +372,7 @@ inferDef mkTerm x =
         -- respect the pure modalities of the current context.
         -- Pure modalities are based on left-division, so it does not
         -- rely on "position" like positional modalities.
-        checkModalityArgs vs
+        checkModalityArgs d0 vs
 
         debug vs t v
         return (v, t)

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1757,7 +1757,7 @@ fitsIn uc forceds t s = do
   withoutK <- withoutKOption
   when withoutK $ do
     q <- viewTC eQuantity
-    usableAtModality' (Just s) ConstructorType (setQuantity q defaultModality) (unEl t)
+    usableAtModality' (Just s) ConstructorType (setQuantity q unitModality) (unEl t)
 
   fitsIn' withoutK forceds t s
   where

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -719,15 +719,16 @@ checkPrimitive i x (Arg info e) =
     t <- isType_ e
     noConstraints $ equalType t t'
     let s  = prettyShow $ qnameName x
-    -- Checking the modality. Currently all primitives require default
-    -- modalities, and likely very few will have different modalities in the
-    -- future. Thus, rather than, the arguably nicer solution of adding a
-    -- modality to PrimImpl we simply check the few special primitives here.
+    -- Checking the ArgInfo. Currently all primitive definitions require default
+    -- ArgInfos, and likely very few will have different ArgInfos in the
+    -- future. Thus, rather than, the arguably nicer solution of adding an
+    -- ArgInfo to PrimImpl we simply check the few special primitives here.
     let expectedInfo =
           case name of
             -- Currently no special primitives
             _ -> defaultArgInfo
-    unless (info == expectedInfo) $ typeError $ WrongModalityForPrimitive name info expectedInfo
+    unless (info == expectedInfo) $
+      typeError $ WrongArgInfoForPrimitive name info expectedInfo
     bindPrimitive name pf
     addConstant' x info x t $
         Primitive { primAbstr    = Info.defAbstract i

--- a/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
@@ -104,7 +104,7 @@ initLHSState delta eqs ps a ret = do
   let problem = Problem eqs ps ret
       qs0     = teleNamedArgs delta
 
-  updateProblemRest $ LHSState delta qs0 problem (defaultArg a) [] False
+  updateProblemRest $ LHSState delta qs0 problem (Arg (defaultArgInfo { argInfoModality = unitModality }) a) [] False
 
 -- | Try to move patterns from the problem rest into the problem.
 --   Possible if type of problem rest has been updated to a function type.

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -957,7 +957,7 @@ unify s strategy = if isUnifyStateSolved s
 patternBindingForcedVars :: PureTCM m => IntMap Modality -> Term -> m (DeBruijnPattern, IntMap Modality)
 patternBindingForcedVars forced v = do
   let v' = precomputeFreeVars_ v
-  runWriterT (evalStateT (go defaultModality v') forced)
+  runWriterT (evalStateT (go unitModality v') forced)
   where
     noForced v = gets $ IntSet.disjoint (precomputedFreeVars v) . IntMap.keysSet
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -318,6 +318,8 @@ checkTelescope' lamOrPi (b : tel) ret =
 --   Used in @checkTypedBindings@ and to typecheck @A.Fun@ cases.
 checkDomain :: (LensLock a, LensModality a) => LamOrPi -> List1 a -> A.Expr -> TCM Type
 checkDomain lamOrPi xs e = do
+    -- Get cohesion and quantity of arguments, which should all be equal because
+    -- they come from the same annotated Π-type.
     let (c :| cs) = fmap (getCohesion . getModality) xs
     unless (all (c ==) cs) $ __IMPOSSIBLE__
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1186,7 +1186,7 @@ checkExpr' cmp e t =
 
     irrelevantIfProp <- (runBlocked $ isPropM t) >>= \case
       Right True  -> do
-        let mod = defaultModality { modRelevance = Irrelevant }
+        let mod = unitModality { modRelevance = Irrelevant }
         return $ fmap dontCare . applyModalityToContext mod
       _ -> return id
 

--- a/test/Fail/FlatDomInequality-1.err
+++ b/test/Fail/FlatDomInequality-1.err
@@ -1,4 +1,4 @@
 FlatDomInequality-1.agda:12,5-6
-A → A !=< A → A because one is a non-flat function type and the
+A → A !=< @♭ A → A because one is a non-flat function type and the
 other is a flat function type
-when checking that the expression g has type A → A
+when checking that the expression g has type @♭ A → A

--- a/test/Fail/FlatDomInequality-2.err
+++ b/test/Fail/FlatDomInequality-2.err
@@ -1,4 +1,4 @@
 FlatDomInequality-2.agda:12,5-6
-A → A !=< A → A because one is a non-flat function type and the
+@♭ A → A !=< A → A because one is a non-flat function type and the
 other is a flat function type
 when checking that the expression h has type A → A

--- a/test/Fail/Issue4390flat.err
+++ b/test/Fail/Issue4390flat.err
@@ -1,4 +1,4 @@
 Issue4390flat.agda:12,28-29
-(A → A) !=< (A → A) because one is a non-flat function type and the
-other is a flat function type
-when checking that the expression f has type A → A
+(A → A) !=< (@♭ A → A) because one is a non-flat function type and
+the other is a flat function type
+when checking that the expression f has type @♭ A → A

--- a/test/Fail/WrongPrimitiveModality.agda
+++ b/test/Fail/WrongPrimitiveModality.agda
@@ -12,7 +12,7 @@ postulate
 primitive
   @0 ⦃ primShowNat ⦄ : Nat → String
 
--- Wrong modality for primitive primShowNat
+-- Wrong definition properties for primitive primShowNat
 --   Got:      instance, erased
 --   Expected: visible, unrestricted
 -- when checking that the type of the primitive function primShowNat

--- a/test/Fail/WrongPrimitiveModality.err
+++ b/test/Fail/WrongPrimitiveModality.err
@@ -1,6 +1,6 @@
 WrongPrimitiveModality.agda:13,8-36
-Wrong modality for primitive primShowNat
-  Got:      instance, erased
-  Expected: visible, unrestricted
+Wrong definition properties for primitive primShowNat
+  Got:      instance, at modality erased
+  Expected: visible, at modality default
 when checking that the type of the primitive function primShowNat
 is Nat → String

--- a/test/Fail/cohesion-module-telescope.agda
+++ b/test/Fail/cohesion-module-telescope.agda
@@ -1,0 +1,16 @@
+{-# OPTIONS --cohesion #-}
+
+module _ where
+
+data Unit : Set where
+  tt : Unit
+
+module M (continuous : Unit) where
+  @♭ flat : Unit
+  flat = tt
+
+module N (continuous : Unit) where
+  open M continuous public
+
+wrong-signature : Unit → Unit
+wrong-signature = N.flat

--- a/test/Fail/cohesion-module-telescope.err
+++ b/test/Fail/cohesion-module-telescope.err
@@ -1,0 +1,4 @@
+cohesion-module-telescope.agda:16,19-25
+(@⊤ continuous : Unit) → Unit !=< Unit → Unit because one is a
+non-flat function type and the other is a flat function type
+when checking that the expression N.flat has type Unit → Unit


### PR DESCRIPTION
Hi everyone,

This is a spin-off of #6385, with only the modality fixes, so that the changes can be reviewed in two batches. This PR is mostly concerned with solidifying the current implementation of modalities, with some logic bugs fixed that aren't currently impactful (these were needed to get the polarity annotations working). The two exceptions to this are related to cohesion: with 0300dd89e49e11afb3438584e69f8f9186822ac2 cohesion annotations are now translated back into concrete syntax for error display, see the changed tests for the improved behavior, and with 9c51cd3291af2a6fdf25a82f1c72a3f04648a005 module telescope substitution properly accounts for the specificities of definition annotations with cohesion (and "pure modalities" in general).

LMKWYT