### PR TITLE
Always fast reduce

### DIFF
--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -520,11 +520,7 @@ instance Reduce Term where
   reduceB' = {-# SCC "reduce'<Term>" #-} maybeFastReduceTerm
 
 shouldTryFastReduce :: ReduceM Bool
-shouldTryFastReduce = (optFastReduce <$> pragmaOptions) `and2M` do
-  allowed <- asksTC envAllowedReductions
-  let optionalReductions = SmallSet.fromList [NonTerminatingReductions, UnconfirmedReductions]
-      requiredReductions = allReductions SmallSet.\\ optionalReductions
-  return $ (allowed SmallSet.\\ optionalReductions) == requiredReductions
+shouldTryFastReduce = optFastReduce <$> pragmaOptions
 
 maybeFastReduceTerm :: Term -> ReduceM (Blocked Term)
 maybeFastReduceTerm v = do

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -42,6 +42,8 @@ import Data.Bits hiding (complement)
 import qualified Data.Bits as Bits
 import Data.Ix
 
+import qualified Agda.Utils.Null as Null
+
 -- | An element in a small set.
 --
 -- This must implement 'Bounded' and 'Ix', and contain at most 64 values.
@@ -55,6 +57,10 @@ newtype SmallSet a = SmallSet { theSmallSet :: Word64 }
 -- | Time O(1).
 null :: SmallSetElement a => SmallSet a -> Bool
 null s = theSmallSet s == 0
+
+instance SmallSetElement a => Null.Null (SmallSet a) where
+  empty = empty
+  null = null
 
 -- | Time O(1).
 member :: SmallSetElement a => a -> SmallSet a -> Bool

--- a/test/Bugs/Issue3027.err
+++ b/test/Bugs/Issue3027.err
@@ -1,6 +1,7 @@
 AGDA_FAILURE
 
-ret > ExitFailure 154
-out > An internal error has occurred. Please report this as a bug.
-out > Location of the error: __IMPOSSIBLE__, called at src/full/Agda/TypeChecking/Reduce/Fast.hs:«line»:«col» in «Agda-package»:Agda.TypeChecking.Reduce.Fast
+ret > ExitFailure 42
+out > Issue3027.agda:40,13-17
+out > f false 1 != zero of type Nat
+out > when checking that the expression refl has type ?X 1 ≡ D 0
 out >

--- a/test/Bugs/Issue3027b.err
+++ b/test/Bugs/Issue3027b.err
@@ -1,6 +1,7 @@
 AGDA_FAILURE
 
-ret > ExitFailure 154
-out > An internal error has occurred. Please report this as a bug.
-out > Location of the error: __IMPOSSIBLE__, called at src/full/Agda/TypeChecking/Reduce/Fast.hs:«line»:«col» in «Agda-package»:Agda.TypeChecking.Reduce.Fast
+ret > ExitFailure 42
+out > Issue3027b.agda:30,13-17
+out > f false 1 != zero of type Nat
+out > when checking that the expression refl has type ?X 1 ≡ D 0
 out >

--- a/test/Fail/Issue3848.err
+++ b/test/Fail/Issue3848.err
@@ -1,10 +1,8 @@
-Issue3848.agda:19,13-17
-Global confluence check failed: f (c f₁) can be rewritten to either
-f₁ or f r.
-Possible fix: add a rewrite rule with left-hand side f (c f₁) to
-resolve the ambiguity.
-when checking confluence of the rewrite rule Issue3848.R.f-clause1
-with rew₁
+Issue3848.agda:19,1-21
+Global confluence check failed: f (c f₁) unfolds to f r which
+should further unfold to f₁ but it does not.
+Possible fix: add a rule to rewrite f r to f₁
+when checking the pragma REWRITE rew₁
 Issue3848.agda:30,1-21
 Global confluence check failed: g (f r) unfolds to g a which should
 further unfold to a but it does not.


### PR DESCRIPTION
I noticed that there is no reason we sometimes bail out of the fast reduction machinery, and with some small changes in how we build the `CompactDefn` we can just always use it. I don't expect this to have a big performance effect immediately, but it should make it easier to make heavier use of `AllowedReductions` without worrying about performance.