### PR TITLE
Print CheckArguments differently when the function returns a dummy

### DIFF
--- a/test/Fail/Issue6627.agda
+++ b/test/Fail/Issue6627.agda
@@ -1,0 +1,9 @@
+module Issue6627 where
+
+record Foo : Set where
+record Bar ⦃ _ : Foo ⦄ : Set where
+postulate
+  i : Foo
+  b : Bar ⦃ i ⦄
+
+open Bar b

--- a/test/Fail/Issue6627.err
+++ b/test/Fail/Issue6627.err
@@ -1,0 +1,4 @@
+Issue6627.agda:9,1-11
+No instance of type Foo was found in scope.
+when checking that b is a valid argument to a function accepting
+arguments of type ⦃ _ = z : Foo ⦄ .(r : Bar)


### PR DESCRIPTION
Fixes #6627 