### PR TITLE
Implicitly import SSet from Agda.Primitive along with Prop & Set

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -99,13 +99,14 @@
     - --ignore-glob=notes/style/haskell-style.lhs
     - --ignore-glob=notes/papers/implicit/examples.lhs
     - -XBangPatterns
+    - -XBlockArguments
     - -XConstraintKinds
     - -XDefaultSignatures
-    - -XDeriveDataTypeable
     - -XDeriveFoldable
     - -XDeriveFunctor
     - -XDeriveGeneric
     - -XDeriveTraversable
+    - -XDerivingStrategies
     - -XExistentialQuantification
     - -XFlexibleContexts
     - -XFlexibleInstances
@@ -124,6 +125,7 @@
     - -XStandaloneDeriving
     - -XTupleSections
     - -XTypeFamilies
+    - -XTypeOperators
     - -XTypeSynonymInstances
 
 # Add custom hints for this project

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -284,6 +284,7 @@ common language
   --         .hlint.yaml
   default-extensions:
       BangPatterns
+      BlockArguments
       ConstraintKinds
       --L-T Chen (2019-07-15):
       -- Enabling DataKinds only locally makes the compile time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -368,3 +368,8 @@ Language
     _ : foo
     _ = 123
   ```
+
+* Unless `--no-import-sorts` is given, `Set` is in scope as before,
+  but `Prop` is only in scope when `--prop` is active.
+  Additionally `SSet` is now in scope when `--two-level` is active
+  (see [#6634](https://github.com/agda/agda/pull/6634)).

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -551,6 +551,8 @@ Experimental features
      (see :ref:`proof-irrelevant propositions <prop>`).
 
      Default: `--no-prop`.
+     In this case, ``Prop`` is since 2.6.4 not in scope
+     by default (:option:`--import-sorts`).
 
 .. option:: --rewriting
 
@@ -571,6 +573,7 @@ Experimental features
 
      Enable the use of strict (non-fibrant) type universes ``SSet``
      *(two-level type theory)*.
+     Since 2.6.4, brings ``SSet`` into scope unless :option:`--no-import-sorts`.
 
 .. option:: --no-two-level
 
@@ -957,7 +960,7 @@ Other features
      .. versionadded:: 2.6.2
 
      Disable the implicit statement
-     ``open import Agda.Primitive using (Set; Prop)``
+     ``open import Agda.Primitive using (Set; ...)``
      at the start of each top-level Agda module.
 
 .. option:: --import-sorts
@@ -965,6 +968,9 @@ Other features
      .. versionadded:: 2.6.4
 
      Default, opposite of :option:`--no-import-sorts`.
+
+     Brings ``Set`` into scope, and if :option:`--prop` is active,
+     also ``Prop``, and if :option:`--two-level` is active, even ``SSet``.
 
 .. option:: --no-load-primitives
 

--- a/test/Fail/Issue3207.err
+++ b/test/Fail/Issue3207.err
@@ -1,4 +1,5 @@
 Issue3207.agda:7,8-12
-Universe Prop is disabled (use options --prop and --no-prop to
-enable/disable Prop)
-when checking that the expression Prop has type _1
+Not in scope:
+  Prop at Issue3207.agda:7,8-12
+    (did you mean 'Agda.Primitive.Prop'?)
+when scope checking Prop

--- a/test/Fail/Optimised-open.err
+++ b/test/Fail/Optimised-open.err
@@ -6,7 +6,6 @@ ScopeInfo
     scope
       private
         names
-          Prop --> [Agda.Primitive.Prop]
           Set --> [Agda.Primitive.Set]
       imports
         [Agda.Primitive]
@@ -49,7 +48,6 @@ ScopeInfo
     scope
       private
         names
-          Prop --> [Agda.Primitive.Prop]
           Set --> [Agda.Primitive.Set]
       imports
         [Agda.Primitive]

--- a/test/Fail/Prop-Disabled.err
+++ b/test/Fail/Prop-Disabled.err
@@ -1,4 +1,6 @@
-Prop-Disabled.agda:8,18-24
-Universe Prop is disabled (use options --prop and --no-prop to
-enable/disable Prop)
-when checking that the expression Prop ℓ is a type
+Prop-Disabled.agda:8,18-22
+Not in scope:
+  Prop
+  at Prop-Disabled.agda:8,18-22
+    (did you mean 'Agda.Primitive.Prop'?)
+when scope checking Prop

--- a/test/Succeed/Issue5434.agda
+++ b/test/Succeed/Issue5434.agda
@@ -1,9 +1,7 @@
 {-# OPTIONS --two-level --cubical-compatible --erasure #-}
 
-open import Agda.Primitive
-
-data D₁ : SSet → SSet (lsuc lzero) where
+data D₁ : SSet → SSet₁ where
   c : (@0 A : SSet) → A → D₁ A
 
-data D₂ : Set → SSet (lsuc lzero) where
+data D₂ : Set → SSet₁ where
   c : (@0 A : Set) → A → D₂ A

--- a/test/Succeed/Issue6073.agda
+++ b/test/Succeed/Issue6073.agda
@@ -1,5 +1,5 @@
 {-# OPTIONS --cubical #-}
-open import Agda.Primitive
+
 open import Agda.Builtin.Cubical.Sub
 open import Agda.Primitive.Cubical
 open import Agda.Builtin.Nat
@@ -26,8 +26,8 @@ refl {x = x} i = x
 -- should be F (inS 42), since that's the only value that “unit” can
 -- have.
 
-bla7 : (F : “unit” → Set) ->
+bla7 : (F : “unit” → Set) →
   let X : Set
       X = _
-  in (z : “unit”) -> PathP (λ i → Set) X (F z)
+  in (z : “unit”) → PathP (λ i → Set) X (F z)
 bla7 F z = refl


### PR DESCRIPTION
Without any explicit imports, `Set` and `Prop` are in scope, but not `SSet` which requires `open Agda.Primitive`.

This patch rectifies this and puts `SSet` on par with `Set` and `Prop`.