### PR TITLE
Respect DontCare in termination checker

### DIFF
--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1313,7 +1313,7 @@ instance StripAllProjections Term where
         -- c <- fromRightM (\ err -> return c) $ getConForm (conName c)
         Con c ci <$> stripAllProjections ts
       Def d es   -> Def d <$> stripAllProjections es
-      DontCare t -> stripAllProjections t
+      DontCare t -> DontCare <$> stripAllProjections t
       _ -> return t
 
 -- | Normalize outermost constructor name in a pattern.
@@ -1340,8 +1340,7 @@ compareTerm' v mp@(Masked m p) = do
     (Var i es, _) | Just{} <- allApplyElims es ->
       compareVar i mp
 
-    (DontCare t, _) ->
-      compareTerm' t mp
+    (DontCare t, _) -> pure Order.unknown
 
     -- Andreas, 2014-09-22, issue 1281:
     -- For metas, termination checking should be optimistic.


### PR DESCRIPTION
This change makes it so that `DontCare` is always assigned the unknown ordering in the termination checker. This means that irrelevant and propositional arguments are never considered structurally smaller than their corresponding patterns. The failure of termination checking in the presence of impredicative `Prop` is then addressed:

```agda
{-# OPTIONS --prop --type-in-type #-}
module Test19 where

data ⊥ : Prop where

data Bad : Prop where
  b : ((P : Prop) → P → P) → Bad

bad : Bad
bad = b (λ P p → p)

no-bad : Bad → ⊥
no-bad (b x) = no-bad (x Bad bad)

very-bad : ⊥
very-bad = no-bad bad
```

Fails with

```
/Users/amelia/Projects/agda/Test19.agda:12,1-13,34
Termination checking failed for the following functions:
  no-bad
Problematic calls:
  no-bad _
    (at /Users/amelia/Projects/agda/Test19.agda:13,16-22)
```