### PR TITLE
Eagerly break unsupported implicit mutual blocks

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -51,6 +51,10 @@ data DeclarationException'
   | OpaqueInMutual Range
       -- ^ @opaque@ block nested in a @mutual@ block. This can never
       -- happen, even with reordering.
+  | DisallowedInterleavedMutual Range String [(Name, Range)]
+      -- ^ A declaration that breaks an implicit mutual block (named by
+      -- the String argument) was present while the given lone type
+      -- signatures were still without their definitions.
     deriving Show
 
 ------------------------------------------------------------------------
@@ -230,6 +234,7 @@ instance HasRange DeclarationException' where
   getRange (BadMacroDef d)                      = getRange d
   getRange (UnfoldingOutsideOpaque r)           = r
   getRange (OpaqueInMutual r)                   = r
+  getRange (DisallowedInterleavedMutual r _ _)  = r
 
 instance HasRange DeclarationWarning where
   getRange (DeclarationWarning _ w) = getRange w
@@ -316,6 +321,16 @@ instance Pretty DeclarationException' where
     "Unfolding declarations can only appear as the first declaration immediately contained in an opaque block."
   pretty (OpaqueInMutual _) = fsep $
     pwords "Opaque blocks can not participate in mutual recursion. If the opaque definitions are to be mutually recursive, move the `mutual` block inside the `opaque` block."
+  pretty (DisallowedInterleavedMutual _ what [(n, _)]) = vcat
+    [ fsep (pwords "The following name is declared, but not accompanied by a definition:" ++ [pretty n])
+        <> "."
+    , fwords ("Since " ++ what ++ " can not participate in mutual recursion, its definition must be given before this point.")
+    ]
+  pretty (DisallowedInterleavedMutual _ what xs) = vcat
+    [ fsep (pwords "The following names are declared, but not accompanied by a definition:" ++ punctuate comma (map (pretty . fst) xs))
+        <> "."
+    , fwords ("Since " ++ what ++ " can not participate in mutual recursion, their definition must be given before this point.")
+    ]
 
 instance Pretty DeclarationWarning where
   pretty (DeclarationWarning _ w) = pretty w

--- a/test/Fail/ImplicitMutualInterleavedMutual.agda
+++ b/test/Fail/ImplicitMutualInterleavedMutual.agda
@@ -1,0 +1,9 @@
+module ImplicitMutualInterleavedMutual where
+
+open import Agda.Builtin.Nat
+
+test : Nat
+interleaved mutual
+  foo : Nat
+  foo = test
+test = 2

--- a/test/Fail/ImplicitMutualInterleavedMutual.err
+++ b/test/Fail/ImplicitMutualInterleavedMutual.err
@@ -1,0 +1,5 @@
+ImplicitMutualInterleavedMutual.agda:6,1-8,13
+The following name is declared, but not accompanied by a
+definition: test.
+Since 'interleaved mutual' blocks can not participate in mutual
+recursion, its definition must be given before this point.

--- a/test/Fail/ImplicitMutualMutual.agda
+++ b/test/Fail/ImplicitMutualMutual.agda
@@ -1,0 +1,9 @@
+module ImplicitMutualMutual where
+
+open import Agda.Builtin.Nat
+
+test : Nat
+mutual
+  foo : Nat
+  foo = test
+test = 2

--- a/test/Fail/ImplicitMutualMutual.err
+++ b/test/Fail/ImplicitMutualMutual.err
@@ -1,5 +1,5 @@
-Issue3932-2.agda:6,1-7,9
+ImplicitMutualMutual.agda:6,1-8,13
 The following name is declared, but not accompanied by a
-definition: f.
+definition: test.
 Since 'mutual' blocks can not participate in mutual recursion, its
 definition must be given before this point.

--- a/test/Fail/ImplicitMutualOpaque.agda
+++ b/test/Fail/ImplicitMutualOpaque.agda
@@ -1,0 +1,9 @@
+module ImplicitMutualOpaque where
+
+open import Agda.Builtin.Nat
+
+test : Nat
+opaque
+  foo : Nat
+  foo = test
+test = 2

--- a/test/Fail/ImplicitMutualOpaque.err
+++ b/test/Fail/ImplicitMutualOpaque.err
@@ -1,0 +1,5 @@
+ImplicitMutualOpaque.agda:6,1-8,13
+The following name is declared, but not accompanied by a
+definition: test.
+Since 'opaque' blocks can not participate in mutual recursion, its
+definition must be given before this point.

--- a/test/Fail/Issue3932.err
+++ b/test/Fail/Issue3932.err
@@ -1,20 +1,5 @@
-Issue3932.agda:13,5-15,12
-mutual blocks in mutual blocks are not supported. Suggestion: get
-rid of the mutual block by manually ordering declarations
-when scope checking the declaration
-  module M where
-Issue3932.agda:23,5-24,14
-mutual blocks in mutual blocks are not supported. Suggestion: get
-rid of the mutual block by manually ordering declarations
-when scope checking the declaration
-  module N where
-Issue3932.agda:29,5-6
-The following names are declared but not accompanied by a
-definition: A
-when scope checking the declaration
-  module O where
 Issue3932.agda:31,5-32,14
-mutual blocks in mutual blocks are not supported. Suggestion: get
-rid of the mutual block by manually ordering declarations
-when scope checking the declaration
-  module O where
+The following name is declared, but not accompanied by a
+definition: A.
+Since 'mutual' blocks can not participate in mutual recursion, its
+definition must be given before this point.

--- a/test/Fail/MissingDefinitions.err
+++ b/test/Fail/MissingDefinitions.err
@@ -1,11 +1,5 @@
-MissingDefinitions.agda:27,3-30,50
-The following names are declared but not accompanied by a
-definition: T₂, U₂, V₂, W₂
-MissingDefinitions.agda:5,1-18,4
-The following names are declared but not accompanied by a
-definition: Q, U, V, W, X
-MissingDefinitions.agda:22,3-23,4
-The following names are declared but not accompanied by a
-definition: A, B
-when scope checking the declaration
-  module AB where
+MissingDefinitions.agda:25,1-30,50
+The following names are declared, but not accompanied by a
+definition: Q, U, V, W, X.
+Since 'mutual' blocks can not participate in mutual recursion,
+their definition must be given before this point.


### PR DESCRIPTION
Closes #6622 by making sure that there are no pending decls before we get to a block that's not supported in mutual recursion (otherwise, you get both the lone signature turned into a postulate, and the actual user-written declaration).