### PR TITLE
`univSort _ = SetOmega` should solve to `_ = SizeUniv`

### DIFF
--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1964,14 +1964,6 @@ equalSort s1 s2 = do
           -- Anything else: postpone
           _        -> postpone
 
-      -- check if the given sort @s0@ is a (closed) bottom sort
-      -- i.e. @piSort a b == s0@ implies @b == s0@.
-      isBottomSort :: Bool -> Sort -> Bool
-      isBottomSort propEnabled (Prop (ClosedLevel 0)) = True
-      isBottomSort propEnabled (Type (ClosedLevel 0)) = not propEnabled
-      isBottomSort propEnabled _                      = False
-      -- (NB: Defined but not currently used)
-
       forceUniv :: Univ -> Sort -> m Level
       forceUniv u = \case
         Univ u' l | u == u' -> return l
@@ -1991,26 +1983,6 @@ equalSort s1 s2 = do
         TypeError{} -> fail
         err         -> throwError err
 
-
--- -- This should probably represent face maps with a more precise type
--- toFaceMaps :: Term -> TCM [[(Int,Term)]]
--- toFaceMaps t = do
---   view <- intervalView'
---   iz <- primIZero
---   io <- primIOne
---   ineg <- (\ q t -> Def q [Apply $ Arg defaultArgInfo t]) <$> fromMaybe __IMPOSSIBLE__ <$> getPrimitiveName' "primINeg"
-
---   let f IZero = mzero
---       f IOne  = return []
---       f (IMin x y) = do xs <- (f . view . unArg) x; ys <- (f . view . unArg) y; return (xs ++ ys)
---       f (IMax x y) = msum $ map (f . view . unArg) [x,y]
---       f (INeg x)   = map (id -*- not) <$> (f . view . unArg) x
---       f (OTerm (Var i [])) = return [(i,True)]
---       f (OTerm _) = return [] -- what about metas? we should suspend? maybe no metas is a precondition?
---       isConsistent xs = all (\ xs -> natSize xs == 1) . map nub . Map.elems $ xs  -- optimize by not doing generate + filter
---       as = map (map (id -*- head) . Map.toAscList) . filter isConsistent . map (Map.fromListWith (++) . map (id -*- (:[]))) $ (f (view t))
---   xs <- mapM (mapM (\ (i,b) -> (,) i <$> intervalUnview (if b then IOne else IZero))) as
---   return xs
 
 forallFaceMaps
   :: MonadConversion m

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1772,6 +1772,15 @@ equalSort s1 s2 = do
           ]
         let postpone = patternViolation blocker
         case s1 of
+          -- @Prop l@, @SizeUniv@ and @LevelUniv@ are not successor sorts.
+          Prop{}      -> no
+          Inf UProp _ -> no
+          SizeUniv{}  -> no
+          LevelUniv{} -> no
+          -- Neither are @LockUniv@ or @IntervalUniv@.
+          LockUniv{}     -> no
+          IntervalUniv{} -> no
+
           -- @Set l1@ is the successor sort of either @Set l2@ or
           -- @Prop l2@ where @l1 == lsuc l2@.
           Type l1 -> do
@@ -1812,11 +1821,7 @@ equalSort s1 s2 = do
                 _     -> postpone
           Inf u n | n > 0, invertibleSort propEnabled u ->
             equalSort (Inf u $ n - 1) s2
-          -- @Prop l@, @SizeUniv@ and @LevelUniv@ are not successor sorts
-          Prop{}      -> no
-          Inf UProp _ -> no
-          SizeUniv{}  -> no
-          LevelUniv{} -> no
+
           -- Anything else: postpone
           _ -> postpone
 

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1784,12 +1784,17 @@ equalSort s1 s2 = do
           -- @Set l1@ is the successor sort of either @Set l2@ or
           -- @Prop l2@ where @l1 == lsuc l2@.
           Type l1 -> do
+            levelUnivEnabled <- optLevelUniverse <$> pragmaOptions
+            guardedEnabled   <- optGuarded       <$> pragmaOptions
                -- @s2@ is definitely not @Inf n@ or @SizeUniv@
-            if | Inf _ _n <- s2 -> no
-               | SizeUniv <- s2 -> no
-               -- If @Prop@ is not used, then @s2@ must be of the form
-               -- @Set l2@
-               | not propEnabled -> do
+            if | Inf _ _n <- s2 -> __IMPOSSIBLE__
+               | SizeUniv <- s2 -> __IMPOSSIBLE__
+               -- The predecessor @s2@ is can also not be @SSet _@ or @IntervalUniv@
+               | Univ USSet _ <- s2 -> __IMPOSSIBLE__
+               | IntervalUniv <- s2 -> __IMPOSSIBLE__
+               -- If @Prop@ is not used, then @s2@ must be of the form @Set l2@,
+               -- except when l1 == 1, then it could also be @LockUniv@ or @LevelUniv@.
+               | not (propEnabled || guardedEnabled || levelUnivEnabled) -> do
                    l2 <- case subLevel 1 l1 of
                      Just l2 -> return l2
                      Nothing -> do

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1706,9 +1706,6 @@ checkPOr c rs vs _ = do
    l : phi1 : phi2 : a : u : v : rest -> do
       phi <- intervalUnview (IMin phi1 phi2)
       reportSDoc "tc.term.por" 10 $ text (show phi)
-      -- phi <- reduce phi
-      -- alphas <- toFaceMaps phi
-      -- reportSDoc "tc.term.por" 10 $ text (show alphas)
       t1 <- runNamesT [] $ do
              [l,a] <- mapM (open . unArg) [l,a]
              psi <- open =<< intervalUnview (IMax phi1 phi2)

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -115,7 +115,7 @@ isType_ e = traceCall (IsType_ e) $ do
     A.Fun i (Arg info t) b -> do
       a <- setArgInfo info . defaultDom <$> checkPiDomain (info :| []) t
       b <- isType_ b
-      s <- inferFunSort (getSort a) (getSort b)
+      s <- inferFunSort a (getSort b)
       let t' = El s $ Pi a $ NoAbs underscore b
       checkTelePiSort t'
       --noFunctionsIntoSize t'

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -112,7 +112,7 @@ inferFunSort s1 s2 = do
     Right s -> return s
     Left b -> do
       let b' = unblockOnEither (getBlocker s1') (getBlocker s2')
-      addConstraint (unblockOnEither b b') $ HasPTSRule (defaultDom (El (univSort s1) (Sort s1))) (mkAbs "_" $ ignoreBlocking s2')
+      addConstraint (unblockOnEither b b') $ HasPTSRule (defaultDom $ sort s1) (mkAbs "_" $ ignoreBlocking s2')
       return $ FunSort s1 s2
 
 hasPTSRule :: Dom Type -> Abs Sort -> TCM ()

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1547,7 +1547,7 @@ univSort' :: Sort -> Either Blocker Sort
 univSort' (Univ u l)   = Right $ Univ (univUniv u) $ levelSuc l
 univSort' (Inf u n)    = Right $ Inf (univUniv u) $ 1 + n
 univSort' SizeUniv     = Right $ Inf UType 0
-univSort' LockUniv     = Right $ Inf UType 0 -- lock polymorphism is not actually supported
+univSort' LockUniv     = Right $ Type $ ClosedLevel 1
 univSort' LevelUniv    = Right $ Type $ ClosedLevel 1
 univSort' IntervalUniv = Right $ SSet $ ClosedLevel 1
 univSort' (MetaS m _)  = Left neverUnblock

--- a/test/Fail/Issue5810.agda
+++ b/test/Fail/Issue5810.agda
@@ -6,3 +6,8 @@ record ⊤ : Set where
 
 bad : Setω
 bad = (λ (ℓ : ⊤ → Level) → ∀ t → Set (ℓ t)) (λ _ → lzero)
+
+-- Error:
+--
+-- funSort Set LevelUniv is not a valid sort
+-- when checking that the expression ⊤ → Level is a type

--- a/test/Fail/Issue6651-UnivPred-SizeUniv.agda
+++ b/test/Fail/Issue6651-UnivPred-SizeUniv.agda
@@ -1,0 +1,36 @@
+-- Andreas, 2023-05-19, issue #6651
+
+{-# OPTIONS --sized-types #-}
+{-# OPTIONS --guarded #-}
+-- {-# OPTIONS --level-universe #-}  -- LevelUniv is an alternative to LockUniv
+-- {-# OPTIONS --prop #-}  -- with Prop, Agda knows that Set₁ is not invertible
+
+open import Agda.Primitive
+open import Agda.Builtin.Size
+
+primitive
+  primLockUniv : Set₁
+
+mutual-block : Set₁
+
+Ω : Set₁
+Ω = {!!}
+
+Id : (S : Ω) → S → SizeUniv
+Id S _ = S
+
+mutual-block = Set
+
+-- Agda 2.6.2.2 and 2.6.3 give an error that is not valid:
+--
+-- Set != SizeUniv
+-- when checking that the expression S has type SizeUniv
+--
+-- Giving this error means that Agda solved Ω = Set
+-- which is not the unique solution if we have one of
+-- Prop, LevelUniv or LockUniv.
+
+-- Expect error like this:
+--
+-- Setω != Set₁
+-- when checking that the solution SizeUniv of metavariable _0 has the expected type Set₁

--- a/test/Fail/Issue6651-UnivPred-SizeUniv.err
+++ b/test/Fail/Issue6651-UnivPred-SizeUniv.err
@@ -1,0 +1,4 @@
+Issue6651-UnivPred-SizeUniv.agda:17,5-9
+Setω != Set₁
+when checking that the solution SizeUniv of metavariable _0 has the
+expected type Set₁

--- a/test/Fail/Issue6651-UnivSort-IUniv.agda
+++ b/test/Fail/Issue6651-UnivSort-IUniv.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2023-05-19, issue #6651
+-- IUniv is not a successor sort
+
+{-# OPTIONS --cubical #-}
+
+open import Agda.Primitive
+open import Agda.Primitive.Cubical
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+Ω : IUniv
+Ω = _ -- No solution
+
+id : (A : Ω) → A → A
+id A x = x
+
+mutual-block = END
+
+-- Expect a hard error, rather than just unsolved constraints:
+--
+-- univSort _ != IUniv

--- a/test/Fail/Issue6651-UnivSort-IUniv.err
+++ b/test/Fail/Issue6651-UnivSort-IUniv.err
@@ -1,0 +1,4 @@
+Issue6651-UnivSort-IUniv.agda:15,5-6
+univSort _8 != IUniv
+when checking that the solution _8 of metavariable _6 has the
+expected type IUniv

--- a/test/Fail/Issue6651-UnivSort-LevelUniv.agda
+++ b/test/Fail/Issue6651-UnivSort-LevelUniv.agda
@@ -1,0 +1,23 @@
+-- Andreas, 2023-05-19, issue #6651
+-- LevelUniv is not a successor sort
+
+{-# OPTIONS --level-universe #-}
+
+open import Agda.Primitive
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+Ω : LevelUniv
+Ω = _ -- No solution
+
+id : (A : Ω) → A → A
+id A x = x
+
+mutual-block = END
+
+-- Expect a hard error, rather than just unsolved constraints:
+--
+-- univSort _ != LevelUniv

--- a/test/Fail/Issue6651-UnivSort-LevelUniv.err
+++ b/test/Fail/Issue6651-UnivSort-LevelUniv.err
@@ -1,0 +1,4 @@
+Issue6651-UnivSort-LevelUniv.agda:14,5-6
+univSort _8 != LevelUniv
+when checking that the solution _8 of metavariable _6 has the
+expected type LevelUniv

--- a/test/Fail/Issue6651-UnivSort-LockUniv.agda
+++ b/test/Fail/Issue6651-UnivSort-LockUniv.agda
@@ -1,0 +1,26 @@
+-- Andreas, 2023-05-19, issue #6651
+-- LockUniv is not a successor sort
+
+{-# OPTIONS --guarded #-}
+
+open import Agda.Primitive
+
+BEGIN = Set₁
+END   = Set
+
+primitive
+  primLockUniv : _
+
+mutual-block : BEGIN
+
+Ω : primLockUniv
+Ω = _ -- No solution
+
+id : (A : Ω) → A → A
+id A x = x
+
+mutual-block = END
+
+-- Expect a hard error, rather than just unsolved constraints:
+--
+-- univSort _ != primLockUniv

--- a/test/Fail/Issue6651-UnivSort-LockUniv.err
+++ b/test/Fail/Issue6651-UnivSort-LockUniv.err
@@ -1,0 +1,4 @@
+Issue6651-UnivSort-LockUniv.agda:17,5-6
+univSort _10 != primLockUniv
+when checking that the solution _10 of metavariable _8 has the
+expected type primLockUniv

--- a/test/Fail/Issue6651-UnivSort-PropOmega.agda
+++ b/test/Fail/Issue6651-UnivSort-PropOmega.agda
@@ -1,0 +1,25 @@
+-- Andreas, 2023-05-19, issue #6651
+-- Propω does not have a predecessor sort, even with --omega-in-omega.
+
+{-# OPTIONS --omega-in-omega #-}
+{-# OPTIONS --prop #-}
+
+open import Agda.Primitive
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+Ω : Propω
+Ω = _ -- No solution
+
+id : (A : Ω) → A → A
+id A x = x
+
+mutual-block = END
+
+-- Expect a hard error:
+--
+-- univSort _2 != Propω
+-- when checking that the solution _2 of metavariable _0 has the expected type Setω

--- a/test/Fail/Issue6651-UnivSort-PropOmega.err
+++ b/test/Fail/Issue6651-UnivSort-PropOmega.err
@@ -1,0 +1,4 @@
+Issue6651-UnivSort-PropOmega.agda:15,5-6
+univSort _7 != Propω
+when checking that the solution _7 of metavariable _5 has the
+expected type Propω

--- a/test/Fail/Issue6651-UnivSort-SetOmega-Prop.agda
+++ b/test/Fail/Issue6651-UnivSort-SetOmega-Prop.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2023-05-19, issue #6651
+-- In Agda without extensions, Setω does not have a predecessor sort.
+
+{-# OPTIONS --omega-in-omega #-}
+{-# OPTIONS --prop #-}
+
+open import Agda.Primitive
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+Ω : Setω
+Ω = _ -- Ambiguous, can be Setω or Propω
+
+id : (A : Ω) → A → A
+id A x = x
+
+mutual-block = END
+
+-- Expected error:
+-- Failed to solve the following constraints:
+--   univSort _3 = Setω (blocked on _3)

--- a/test/Fail/Issue6651-UnivSort-SetOmega-Prop.err
+++ b/test/Fail/Issue6651-UnivSort-SetOmega-Prop.err
@@ -1,0 +1,7 @@
+Failed to solve the following constraints:
+  univSort _8 =< Setω (blocked on _8)
+  univSort _8 = Setω (blocked on _8)
+  _9 is a sort (blocked on _8)
+Unsolved metas at the following locations:
+  Issue6651-UnivSort-SetOmega-Prop.agda:17,16-17
+  Issue6651-UnivSort-SetOmega-Prop.agda:17,20-21

--- a/test/Fail/Issue6651-UnivSort-SetOmega-SizedTypes.agda
+++ b/test/Fail/Issue6651-UnivSort-SetOmega-SizedTypes.agda
@@ -1,0 +1,26 @@
+-- Andreas, 2023-05-19, issue #6651
+-- Predecessors of Setω if --omega-in-omega and --sized-types
+
+{-# OPTIONS --omega-in-omega #-}  -- or --type-in-type
+{-# OPTIONS --sized-types #-}     -- SizeUniv : Setω destroys unicity of solution
+
+open import Agda.Primitive
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+Ω : Setω
+Ω = {!!} -- should stay unsolved, since we have two solutions
+
+test : (A : {!!}) → A → Ω
+test A _ = A
+
+mutual-block = END
+
+-- Should error out with unsolved constraints (not with hard error)!
+
+-- Expected error:
+-- Failed to solve the following constraints:
+--   univSort _4 = Setω (blocked on _4)

--- a/test/Fail/Issue6651-UnivSort-SetOmega-SizedTypes.err
+++ b/test/Fail/Issue6651-UnivSort-SetOmega-SizedTypes.err
@@ -1,0 +1,8 @@
+Failed to solve the following constraints:
+  univSort _9 = Setω (blocked on _9)
+  univSort _9 =< Setω (blocked on _9)
+Unsolved metas at the following locations:
+  Issue6651-UnivSort-SetOmega-SizedTypes.agda:17,21-22
+Unsolved interaction metas at the following locations:
+  Issue6651-UnivSort-SetOmega-SizedTypes.agda:15,5-9
+  Issue6651-UnivSort-SetOmega-SizedTypes.agda:17,13-17

--- a/test/Fail/Issue6651-UnivSort-SetOmega.agda
+++ b/test/Fail/Issue6651-UnivSort-SetOmega.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2023-05-19, issue #6651
+-- In Agda without extensions, Setω does not have a predecessor sort.
+
+open import Agda.Primitive
+
+mutual-block : Set₁
+
+Ω : Setω
+Ω = _ -- No solution
+
+id : (A : Ω) → A → A
+id A x = x
+
+mutual-block = Set
+
+-- Expect a hard error:
+--
+-- univSort _2 != Setω
+-- when checking that the solution _2 of metavariable _0 has the expected type Setω

--- a/test/Fail/Issue6651-UnivSort-SetOmega.err
+++ b/test/Fail/Issue6651-UnivSort-SetOmega.err
@@ -1,0 +1,4 @@
+Issue6651-UnivSort-SetOmega.agda:9,5-6
+univSort _2 != Setω
+when checking that the solution _2 of metavariable _0 has the
+expected type Setω

--- a/test/Fail/Issue6651-UnivSort-SetOmega1-Prop.agda
+++ b/test/Fail/Issue6651-UnivSort-SetOmega1-Prop.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2023-05-19, issue #6651
+-- Only in Agda without --prop, Setω₁ has exactly one predecessor sort.
+
+{-# OPTIONS --prop #-}
+
+open import Agda.Primitive
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+Ω : Setω₁
+Ω = _ -- Setω
+
+id : (A : Ω) → A → A
+id A x = x
+
+mutual-block = END
+
+-- Expected error:
+--
+-- Failed to solve the following constraints:
+--   univSort _3 = Setω₁ (blocked on _3)

--- a/test/Fail/Issue6651-UnivSort-SetOmega1-Prop.err
+++ b/test/Fail/Issue6651-UnivSort-SetOmega1-Prop.err
@@ -1,0 +1,7 @@
+Failed to solve the following constraints:
+  univSort _8 =< Setω₁ (blocked on _8)
+  univSort _8 = Setω₁ (blocked on _8)
+  _9 is a sort (blocked on _8)
+Unsolved metas at the following locations:
+  Issue6651-UnivSort-SetOmega1-Prop.agda:16,16-17
+  Issue6651-UnivSort-SetOmega1-Prop.agda:16,20-21

--- a/test/Fail/Issue6651-UnivSort-SizeUniv.agda
+++ b/test/Fail/Issue6651-UnivSort-SizeUniv.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2023-05-19, issue #6651
+-- SizeUniv is not a successor sort
+
+{-# OPTIONS --sized-types #-}
+
+open import Agda.Primitive
+open import Agda.Builtin.Size
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+Ω : SizeUniv
+Ω = _ -- No solution
+
+id : (A : Ω) → A → A
+id A x = x
+
+mutual-block = END
+
+-- Expect a hard error, rather than just unsolved constraints:
+--
+-- univSort _ != SizeUniv

--- a/test/Fail/Issue6651-UnivSort-SizeUniv.err
+++ b/test/Fail/Issue6651-UnivSort-SizeUniv.err
@@ -1,0 +1,4 @@
+Issue6651-UnivSort-SizeUniv.agda:15,5-6
+univSort _8 != SizeUniv
+when checking that the solution _8 of metavariable _6 has the
+expected type SizeUniv

--- a/test/Fail/LevelUnivFunSorts.agda
+++ b/test/Fail/LevelUnivFunSorts.agda
@@ -1,6 +1,10 @@
 {-# OPTIONS --level-universe #-}
 
-open import Common.Level
 open import Agda.Primitive
 
-_ = Set -> Level
+_ = Set → Level
+
+-- Error:
+--
+-- funSort Set₁ LevelUniv is not a valid sort
+-- when checking that the expression Set → Level is a type

--- a/test/Fail/LevelUnivFunSorts.err
+++ b/test/Fail/LevelUnivFunSorts.err
@@ -1,3 +1,3 @@
-LevelUnivFunSorts.agda:6,5-17
+LevelUnivFunSorts.agda:5,5-16
 funSort Set₁ LevelUniv is not a valid sort
 when checking that the expression Set → Level is a type

--- a/test/Fail/noLevelUnivData.agda
+++ b/test/Fail/noLevelUnivData.agda
@@ -1,4 +1,8 @@
 {-# OPTIONS --level-universe #-}
-open import Common.Level
 
-data foo : LevelUniv where
+open import Agda.Primitive
+
+data D : LevelUniv where
+
+-- Error:
+-- The universe LevelUniv of D does not admit data or record declarations

--- a/test/Fail/noLevelUnivData.err
+++ b/test/Fail/noLevelUnivData.err
@@ -1,4 +1,4 @@
-noLevelUnivData.agda:4,6-9
-The universe LevelUniv of foo
+noLevelUnivData.agda:5,6-7
+The universe LevelUniv of D
 does not admit data or record declarations
-when checking the definition of foo
+when checking the definition of D

--- a/test/Fail/noLevelUnivToSet.agda
+++ b/test/Fail/noLevelUnivToSet.agda
@@ -1,7 +1,12 @@
 {-# OPTIONS --level-universe #-}
 
-open import Common.Level
-open import Common.Equality
+open import Agda.Primitive
+open import Agda.Builtin.Equality
 
 _ : LevelUniv ≡ Set
 _ = refl
+
+-- Error:
+--
+-- LevelUniv != Set
+-- when checking that the expression refl has type LevelUniv ≡ Set

--- a/test/Succeed/Issue6651-LevelUniv.agda
+++ b/test/Succeed/Issue6651-LevelUniv.agda
@@ -1,0 +1,29 @@
+-- Andreas, 2023-05-20, issue #6651
+-- Do not solve ? : Set₁ to ? = Set if we have LevelUniv.
+
+{-# OPTIONS --level-universe #-}
+
+-- {-# OPTIONS -v tc.term:10 #-}
+-- {-# OPTIONS -v tc.term.assign:15 #-}
+-- {-# OPTIONS -v tc.conv.sort:35 #-}
+-- {-# OPTIONS -v tc.conv:35 #-}
+-- {-# OPTIONS -v tc:35 #-}
+
+open import Agda.Primitive
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+L-U : Set₁
+L-U = _ -- solves to LevelUniv
+
+L : L-U
+L = _ -- solves to Level
+-- WAS Error: LevelUniv != Set
+
+foo : L → L
+foo ℓ = lsuc ℓ
+
+mutual-block = END

--- a/test/Succeed/Issue6651-LockUniv.agda
+++ b/test/Succeed/Issue6651-LockUniv.agda
@@ -1,0 +1,33 @@
+-- Andreas, 2023-05-20, issue #6651
+-- Do not solve ? : Set₁ to ? = Set if we have LockUniv.
+
+{-# OPTIONS --guarded #-}
+
+-- {-# OPTIONS -v tc.term:10 #-}
+-- {-# OPTIONS -v tc.conv.sort:35 #-}
+-- {-# OPTIONS -v tc.conv:35 #-}
+-- {-# OPTIONS -v tc:45 #-}
+
+open import Agda.Primitive
+
+primitive
+  primLockUniv : Set₁
+
+postulate
+  Tick : primLockUniv
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+L-U : Set₁
+L-U = _ -- solves to primLockUniv
+
+T : L-U
+T = _ -- solves to Tick
+
+foo : T → Tick
+foo t = t
+
+mutual-block = END

--- a/test/Succeed/Issue6651-SizeUniv-Prop.agda
+++ b/test/Succeed/Issue6651-SizeUniv-Prop.agda
@@ -1,0 +1,25 @@
+-- Andreas, 2023-05-19, issue #6651
+-- SizeUniv can be a predecessor of Setω
+
+{-# OPTIONS --sized-types #-}
+{-# OPTIONS --prop #-}  -- should also work with Prop on
+
+open import Agda.Primitive
+open import Agda.Builtin.Size
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+S-U : Setω
+S-U = _ -- should solve to SizeUniv
+        -- Error WAS: univSort _3 != Setω
+
+S : S-U
+S = _   -- should solve to Size
+
+foo : S → S
+foo i = ∞
+
+mutual-block = END

--- a/test/Succeed/Issue6651-SizeUniv.agda
+++ b/test/Succeed/Issue6651-SizeUniv.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2023-05-19, issue #6651
+-- SizeUniv can be a predecessor of Setω
+
+{-# OPTIONS --sized-types #-}
+
+open import Agda.Primitive
+open import Agda.Builtin.Size
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+S-U : Setω
+S-U = _ -- should solve to SizeUniv
+        -- Error WAS: univSort _3 != Setω
+
+S : S-U
+S = _   -- should solve to Size
+
+foo : S → S
+foo i = ∞
+
+mutual-block = END

--- a/test/Succeed/Issue6651-UnivSort-SetOmega-PropOmega.agda
+++ b/test/Succeed/Issue6651-UnivSort-SetOmega-PropOmega.agda
@@ -1,0 +1,21 @@
+-- Andreas, 2023-05-19, issue #6651
+-- Propω can be a predecessor of Setω if --omega-in-omega
+
+{-# OPTIONS --omega-in-omega #-}  -- or --type-in-type
+{-# OPTIONS --prop #-}            -- for Propω
+{-# OPTIONS --sized-types #-}     -- SizeUniv : Setω should not make a difference
+
+open import Agda.Primitive
+
+BEGIN = Set₁
+END   = Set
+
+mutual-block : BEGIN
+
+Ω : Setω
+Ω = _ -- should solve to Propω later
+
+test : (A : Propω) → A → Ω
+test A _ = A
+
+mutual-block = END

--- a/test/Succeed/Issue6651-UnivSort-SetOmega-SizedTypes.agda
+++ b/test/Succeed/Issue6651-UnivSort-SetOmega-SizedTypes.agda
@@ -1,0 +1,35 @@
+-- Andreas, 2023-05-19, issue #6651
+-- Predecessors of Setω if --omega-in-omega and --sized-types
+
+{-# OPTIONS --omega-in-omega #-}  -- or --type-in-type
+{-# OPTIONS --sized-types #-}     -- axiom SizeUniv : Setω destroys unicity of solution
+
+open import Agda.Primitive
+
+BEGIN = Set₁
+END   = Set
+
+module SetOmega where
+
+  mutual-block : BEGIN
+
+  Ω : Setω
+  Ω = _ -- should solve to Setω later
+
+  test : (A : Setω) → A → Ω
+  test A _ = A
+
+  mutual-block = END
+
+module SizeUniv where
+  open import Agda.Builtin.Size
+
+  mutual-block : BEGIN
+
+  Ω : Setω
+  Ω = _ -- should solve to SizeUniv later
+
+  test : (A : SizeUniv) → A → Ω
+  test A _ = A
+
+  mutual-block = END

--- a/test/Succeed/Issue6651-UnivSort-SetOmega.agda
+++ b/test/Succeed/Issue6651-UnivSort-SetOmega.agda
@@ -1,0 +1,60 @@
+-- Andreas, 2023-05-19, issue #6651
+-- With --type-in-type or --omega-in-omega and without --prop,
+-- Setω has exactly one canonical precedessor.
+-- Setω₁ has exactly one canonical precedessor always without --prop.
+
+{-# OPTIONS --omega-in-omega #-}
+{-# OPTIONS --two-level #-}
+
+open import Agda.Primitive
+
+BEGIN = Set₁
+END   = Set
+
+module SetOmega where
+
+  mutual-block : BEGIN
+
+  Ω : Setω
+  Ω = _ -- can only be Setω (or equivalent)
+
+  id : (A : Ω) → A → A
+  id A x = x
+
+  mutual-block = END
+
+module SetOmega1 where
+
+  mutual-block : BEGIN
+
+  Ω : Setω₁
+  Ω = _ -- can only be Setω (or equivalent)
+
+  id : (A : Ω) → A → A
+  id A x = x
+
+  mutual-block = END
+
+module SSetOmega where
+
+  mutual-block : BEGIN
+
+  Ω : SSetω
+  Ω = _ -- can only be SSetω (or equivalent)
+
+  id : (A : Ω) → A → A
+  id A x = x
+
+  mutual-block = END
+
+module SSetOmega1 where
+
+  mutual-block : BEGIN
+
+  Ω : SSetω₁
+  Ω = _ -- can only be SSetω (or equivalent)
+
+  id : (A : Ω) → A → A
+  id A x = x
+
+  mutual-block = END

--- a/test/interaction/Issue3312.out
+++ b/test/interaction/Issue3312.out
@@ -2,7 +2,7 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 (agda2-status-action "")
-(agda2-info-action "*All Goals, Errors*" "?0 : _64 ?1 : ?0 (at = at) Sort _64 [ at Issue3312.agda:30,89-103 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: Has PTS rule: (Fin (length xs) , _64 (at = at)) (blocked on _64) Has PTS rule: ({List I} , funSort Set (piSort Set (λ at → _64 (at = at)))) (blocked on _64) Has PTS rule: ({I → Set} , piSort Set (λ xs → funSort Set (piSort Set (λ at → _64 (at = at))))) (blocked on _64) Has PTS rule: ({Set} , piSort Set₁ (λ T → piSort Set (λ xs → funSort Set (piSort Set (λ at → _64 (at = at)))))) (blocked on _64) Has PTS rule: (Set , piSort Set (λ at → _64 (at = at))) (blocked on _64) " nil)
+(agda2-info-action "*All Goals, Errors*" "?0 : _64 ?1 : ?0 (at = at) Sort _64 [ at Issue3312.agda:30,89-103 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: Has PTS rule: (Fin (length xs) , _64 (at = at)) (blocked on _64) Has PTS rule: ({List I} , funSort Set (piSort Set (λ at → _64 (at = at)))) (blocked on _64) Has PTS rule: ({I → Set} , piSort Set (λ xs → funSort Set (piSort Set (λ at → _64 (at = at))))) (blocked on _64) Has PTS rule: ({Set} , piSort Set₁ (λ T → piSort Set (λ xs → funSort Set (piSort Set (λ at → _64 (at = at)))))) (blocked on _64) " nil)
 ((last . 1) . (agda2-goals-action '(0 1)))
 (agda2-status-action "")
 (agda2-info-action "*Intro*" "No introduction forms found." nil)

--- a/test/interaction/Issue3735.out
+++ b/test/interaction/Issue3735.out
@@ -2,7 +2,7 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 (agda2-status-action "")
-(agda2-info-action "*All Goals, Errors*" "?0 : _9 Sort _9 [ at Issue3735.agda:9,31-36 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: Has PTS rule: ({Set} , _9) (blocked on _9) Has PTS rule: (Set (lsuc a) , piSort Set₁ (λ a → _9)) (blocked on _9) " nil)
+(agda2-info-action "*All Goals, Errors*" "?0 : _9 Sort _9 [ at Issue3735.agda:9,31-36 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: Has PTS rule: ({Set} , _9) (blocked on _9) " nil)
 ((last . 1) . (agda2-goals-action '(0)))
 (agda2-give-action 0 "a")
 (agda2-status-action "")

--- a/test/interaction/Issue5210.out
+++ b/test/interaction/Issue5210.out
@@ -2,7 +2,7 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 (agda2-status-action "")
-(agda2-info-action "*All Goals, Errors*" "?0 : _9 ?1 : ?0 (n = n) Sort _9 [ at Issue5210.agda:9,20-27 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: Has PTS rule: (Nat , funSort Prop (_9 (n = n))) (blocked on _9) Has PTS rule: (Prop , _9 (n = _)) (blocked on _9) " nil)
+(agda2-info-action "*All Goals, Errors*" "?0 : _9 ?1 : ?0 (n = n) Sort _9 [ at Issue5210.agda:9,20-27 ] ———— Errors ———————————————————————————————————————————————— Failed to solve the following constraints: Has PTS rule: (Nat , funSort Prop (_9 (n = n))) (blocked on _9) " nil)
 ((last . 1) . (agda2-goals-action '(0 1)))
 (agda2-info-action "*Error*" "Issue5210.agda:10,12-20 Cannot split on datatype in Prop unless target is in Prop when checking that the expression ? has type ?0 (n = n)" nil)
 ((last . 3) . (agda2-maybe-goto '("Issue5210.agda" . 151)))


### PR DESCRIPTION
Fixes the following problems:
- `TC.Conversion.univSortEquals` was not in sync with `TC.Substitute.univSort'`.  Added tests for `univSort` to surface problems.
- Inverting `univSort` would sometimes not find and sometimes lose unique solutions.
- Determine `LockUniv : Set1` (in `univSort'` it said `SetOmega`).
- Fix a bug introduced in #6505 that surfaced during trying to fix the OP of #6651.
- Cosmetic changes to `inferPiSort`, `inferFunSort`, `hasPTSRule` in connection with the last point.

Closes #6651.
- #6651