### PR TITLE
Add flags for large indices and recursion on forced arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,6 +354,20 @@ Pragmas and options
   If option `--exact-split` is on, the inlining will trigger a `InlineNoExactSplit` warning for `nats`.
   This warning can be disabled as usual, with `-WnoInlineNoExactSplit`.
 
+* New option `--large-indices`, controlling whether constructors of
+  indexed data types are allowed to refer to data that would be "too
+  large" to fit in their declared sort. Large indices are allowed by
+  default when the K rule is on, but disallowed when `--without-K` is
+  enabled (this would be inconsistent).
+
+  Negation: `--no-large-indices`.
+
+* New option `--forced-argument-recursion`, off by default, controlling
+  whether forced constructor arguments are usable for termination
+  checking. See the [language changes](#language) for the details.
+
+  Negation: `--no-forced-argument-recursion`.
+
 Library management
 ------------------
 
@@ -408,6 +422,21 @@ Cubical Agda
 
 Language
 --------
+
+* [**Breaking**] Forced constructor arguments are no longer usable as
+  termination measures when the K rule is enabled (this is the default).
+  This fixes a particular instance of the incompatibility between
+  structural recursion and impredicativity, which could previously be
+  exploited through the use of large data-type indices.
+  (see [#6654](https://github.com/agda/agda/issues/6654)).
+
+  Forced argument recursion is controlled by the
+  `--forced-argument-recursion` flag (or its negation). When the K rule
+  is enabled, forced argument recursion is off by default, but it is
+  *on* by default when `--without-K` is given.
+
+  Using forced argument recursion and large indices in the same module
+  is incompatible with `--safe`.
 
 * Added [`opaque` definitions](https://agda.readthedocs.io/en/v2.6.4/language/opaque-definitions.html),
   a mechanism for finer-grained control of unfolding. Unlike `abstract`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,17 +356,13 @@ Pragmas and options
 
 * New option `--large-indices`, controlling whether constructors of
   indexed data types are allowed to refer to data that would be "too
-  large" to fit in their declared sort. Large indices are allowed by
-  default when the K rule is on, but disallowed when `--without-K` is
-  enabled (this would be inconsistent).
+  large" to fit in their declared sort. Large indices are disallowed by
+  default; see the [language changes](#language) for details.
 
-  Negation: `--no-large-indices`.
-
-* New option `--forced-argument-recursion`, off by default, controlling
+* New option `--forced-argument-recursion`, on by default, controlling
   whether forced constructor arguments are usable for termination
-  checking. See the [language changes](#language) for the details.
-
-  Negation: `--no-forced-argument-recursion`.
+  checking. This flag may be necessary for Agda to accept nontrivial
+  uses of induction-induction.
 
 Library management
 ------------------
@@ -423,20 +419,22 @@ Cubical Agda
 Language
 --------
 
-* [**Breaking**] Forced constructor arguments are no longer usable as
-  termination measures when the K rule is enabled (this is the default).
+* [**Breaking**] Constructor arguments are no longer allowed to store
+  values of a type larger than their own sort, even when these values
+  are forced by the indices of a constructor.
+
   This fixes a particular instance of the incompatibility between
   structural recursion and impredicativity, which could previously be
   exploited through the use of large data-type indices.
   (see [#6654](https://github.com/agda/agda/issues/6654)).
 
-  Forced argument recursion is controlled by the
-  `--forced-argument-recursion` flag (or its negation). When the K rule
-  is enabled, forced argument recursion is off by default, but it is
-  *on* by default when `--without-K` is given.
-
-  Using forced argument recursion and large indices in the same module
-  is incompatible with `--safe`.
+  This behaviour can be controlled with the flag `--large-indices`. Note
+  that, when `--large-indices` is enabled, forced constructor arguments
+  should not be used for termination checking. The flag
+  `--[no-]forced-argument-recursion` makes the termination checker skip
+  these arguments entirely. When `--safe` is given, `--large-indices` is
+  incompatible with `--without-K` _and_ incompatible with
+  `--forced-argument-recursion`.
 
 * Added [`opaque` definitions](https://agda.readthedocs.io/en/v2.6.4/language/opaque-definitions.html),
   a mechanism for finer-grained control of unfolding. Unlike `abstract`

--- a/doc/user-manual/language/generalization-of-declared-variables.lagda.rst
+++ b/doc/user-manual/language/generalization-of-declared-variables.lagda.rst
@@ -1,6 +1,6 @@
 ..
   ::
-  {-# OPTIONS --allow-unsolved-metas --erasure #-}
+  {-# OPTIONS --allow-unsolved-metas --erasure --large-indices #-}
   module language.generalization-of-declared-variables where
 
   open import Agda.Primitive

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -785,6 +785,37 @@ Pattern matching and equality
 
      Default: ``--infer-absurd-clauses``.
 
+.. option:: --forced-argument-recursion
+
+     .. versionadded:: 2.6.4
+
+     Allow the use of forced constructor arguments as termination metrics. This is inconsistent when combined with :option:`--large-indices`.
+     Since forced arguments are fixed by the constructor's type, when the K rule is enabled, they are "not really there". Thus, they do not provide enough justification to assert a recursive call is size-decreasing.
+
+     Forced argument recursion is disabled by the default when the K rule is enabled, and are enabled by default if :option:`--without-K` is given.
+
+.. option:: --no-forced-argument-recursion
+
+     .. versionadded:: 2.6.4
+
+     Opposite of :option:`--forced-argument-recursion`.
+
+.. option:: --large-indices
+
+     .. versionadded:: 2.6.4
+
+     Allow constructors to store values of types whose sort is larger than that being defined, when these arguments are forced by the constructor's type.
+     This is a form of propositional resizing for equality, so it is only consistent if the K rule is enabled.
+     When :option`:`--no-forcing` is given, this option is redundant.
+
+     Large indices are enabled by the default when the K rule is enabled, and are disabled if :option:`--without-K` is given.
+
+.. option:: --no-large-indices
+
+     .. versionadded:: 2.6.4
+
+     Opposite of :option:`--large-indices`.
+
 Search depth and instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -789,20 +789,27 @@ Pattern matching and equality
 
      .. versionadded:: 2.6.4
 
-     Allow the use of forced constructor arguments as termination metrics. This is inconsistent when combined with :option:`--large-indices`.
-     Since forced arguments are fixed by the constructor's type, when the K rule is enabled, they are "not really there". Thus, they do not provide enough justification to assert a recursive call is size-decreasing.
+     Allow the use of forced constructor arguments as termination
+     metrics. This flag may be necessary for Agda to accept nontrivial
+     uses of induction-induction.
 
-     Forced argument recursion is disabled by the default when the K rule is enabled, and are enabled by default if :option:`--without-K` is given.
+     Default: ``--forced-argument-recursion``.
 
 .. option:: --large-indices, --no-large-indices
 
      .. versionadded:: 2.6.4
 
-     Allow constructors to store values of types whose sort is larger than that being defined, when these arguments are forced by the constructor's type.
-     This is a form of propositional resizing for equality, so it is only consistent if the K rule is enabled.
-     When :option`:`--no-forcing` is given, this option is redundant.
+     Allow constructors to store values of types whose sort is larger
+     than that being defined, when these arguments are forced by the
+     constructor's type.
 
-     Large indices are enabled by the default when the K rule is enabled, and are disabled if :option:`--without-K` is given.
+     When :option:`--safe` is given, this flag can not be combined with
+     :option:`--without-K` or :option:`--forced-argument-recursion`,
+     since both of these combinations are known to be inconsistent.
+
+     When :option:`--no-forcing` is given, this option is redundant.
+
+     Default: ``--no-large-indices``.
 
 Search depth and instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -785,7 +785,7 @@ Pattern matching and equality
 
      Default: ``--infer-absurd-clauses``.
 
-.. option:: --forced-argument-recursion
+.. option:: --forced-argument-recursion, --no-forced-argument-recursion
 
      .. versionadded:: 2.6.4
 
@@ -794,13 +794,7 @@ Pattern matching and equality
 
      Forced argument recursion is disabled by the default when the K rule is enabled, and are enabled by default if :option:`--without-K` is given.
 
-.. option:: --no-forced-argument-recursion
-
-     .. versionadded:: 2.6.4
-
-     Opposite of :option:`--forced-argument-recursion`.
-
-.. option:: --large-indices
+.. option:: --large-indices, --no-large-indices
 
      .. versionadded:: 2.6.4
 
@@ -809,12 +803,6 @@ Pattern matching and equality
      When :option`:`--no-forcing` is given, this option is redundant.
 
      Large indices are enabled by the default when the K rule is enabled, and are disabled if :option:`--without-K` is given.
-
-.. option:: --no-large-indices
-
-     .. versionadded:: 2.6.4
-
-     Opposite of :option:`--large-indices`.
 
 Search depth and instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -422,10 +422,10 @@ data PragmaOptions = PragmaOptions
   , _optKeepCoveringClauses       :: WithDefault 'False
       -- ^ Do not discard clauses constructed by the coverage checker
       --   (needed for some external backends).
-  , _optLargeIndices              :: WithDefault 'True
+  , _optLargeIndices              :: WithDefault 'False
       -- ^ Allow large indices, and large forced arguments in
       -- constructors.
-  , _optForcedArgumentRecursion   :: WithDefault 'False
+  , _optForcedArgumentRecursion   :: WithDefault 'True
       -- ^ Allow recursion on forced constructor arguments.
   }
   deriving (Show, Eq, Generic)
@@ -1304,8 +1304,6 @@ withoutKFlag o = return $ o
   { _optWithoutK                = Value True
   , _optFlatSplit               = setDefault False $ _optFlatSplit o
   , _optErasedMatches           = setDefault False $ _optErasedMatches o
-  , _optLargeIndices            = setDefault False $ _optLargeIndices o
-  , _optForcedArgumentRecursion = setDefault True  $ _optForcedArgumentRecursion o
   }
 
 firstOrderFlag :: Flag PragmaOptions
@@ -1318,8 +1316,6 @@ cubicalCompatibleFlag o =
   , _optWithoutK                = setDefault True  $ _optWithoutK o
   , _optFlatSplit               = setDefault False $ _optFlatSplit o
   , _optErasedMatches           = setDefault False $ _optErasedMatches o
-  , _optLargeIndices            = setDefault False $ _optLargeIndices o
-  , _optForcedArgumentRecursion = setDefault True  $ _optForcedArgumentRecursion o
   }
 
 cubicalFlag
@@ -1333,8 +1329,6 @@ cubicalFlag variant o =
   , _optTwoLevel                = setDefault True  $ _optTwoLevel o
   , _optFlatSplit               = setDefault False $ _optFlatSplit o
   , _optErasedMatches           = setDefault False $ _optErasedMatches o
-  , _optLargeIndices            = setDefault False $ _optLargeIndices o
-  , _optForcedArgumentRecursion = setDefault True  $ _optForcedArgumentRecursion o
   }
 
 instanceDepthFlag :: String -> Flag PragmaOptions

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -159,6 +159,8 @@ module Agda.Interaction.Options.Base
     , optSaveMetas
     , optShowIdentitySubstitutions
     , optKeepCoveringClauses
+    , optLargeIndices
+    , optForcedArgumentRecursion
     -- * Non-boolean accessors to 'PragmaOptions'
     , optConfluenceCheck
     , optCubical
@@ -420,6 +422,11 @@ data PragmaOptions = PragmaOptions
   , _optKeepCoveringClauses       :: WithDefault 'False
       -- ^ Do not discard clauses constructed by the coverage checker
       --   (needed for some external backends).
+  , _optLargeIndices              :: WithDefault 'True
+      -- ^ Allow large indices, and large forced arguments in
+      -- constructors.
+  , _optForcedArgumentRecursion   :: WithDefault 'False
+      -- ^ Allow recursion on forced constructor arguments.
   }
   deriving (Show, Eq, Generic)
 
@@ -501,6 +508,8 @@ optAllowExec                 :: PragmaOptions -> Bool
 optSaveMetas                 :: PragmaOptions -> Bool
 optShowIdentitySubstitutions :: PragmaOptions -> Bool
 optKeepCoveringClauses       :: PragmaOptions -> Bool
+optLargeIndices              :: PragmaOptions -> Bool
+optForcedArgumentRecursion   :: PragmaOptions -> Bool
 
 optShowImplicit              = collapseDefault . _optShowImplicit
 optShowIrrelevant            = collapseDefault . _optShowIrrelevant
@@ -559,6 +568,8 @@ optAllowExec                 = collapseDefault . _optAllowExec
 optSaveMetas                 = collapseDefault . _optSaveMetas
 optShowIdentitySubstitutions = collapseDefault . _optShowIdentitySubstitutions
 optKeepCoveringClauses       = collapseDefault . _optKeepCoveringClauses
+optLargeIndices              = collapseDefault . _optLargeIndices
+optForcedArgumentRecursion   = collapseDefault . _optForcedArgumentRecursion
 
 -- Collapse defaults (non-Bool)
 
@@ -788,6 +799,12 @@ lensOptShowIdentitySubstitutions f o = f (_optShowIdentitySubstitutions o) <&> \
 lensOptKeepCoveringClauses :: Lens' PragmaOptions _
 lensOptKeepCoveringClauses f o = f (_optKeepCoveringClauses o) <&> \ i -> o{ _optKeepCoveringClauses = i }
 
+lensOptLargeIndices :: Lens' PragmaOptions _
+lensOptLargeIndices f o = f (_optLargeIndices o) <&> \ i -> o{ _optLargeIndices = i }
+
+lensOptForcedArgumentRecursion :: Lens' PragmaOptions _
+lensOptForcedArgumentRecursion f o = f (_optForcedArgumentRecursion o) <&> \ i -> o{ _optForcedArgumentRecursion = i }
+
 
 -- | Map a function over the long options. Also removes the short options.
 --   Will be used to add the plugin name to the plugin options.
@@ -894,6 +911,8 @@ defaultPragmaOptions = PragmaOptions
   , _optSaveMetas                 = Default
   , _optShowIdentitySubstitutions = Default
   , _optKeepCoveringClauses       = Default
+  , _optForcedArgumentRecursion   = Default
+  , _optLargeIndices              = Default
   }
 
 -- | The options parse monad 'OptM' collects warnings that are not discarded
@@ -1032,6 +1051,9 @@ unsafePragmaOptions opts =
   [ "--cumulativity"                    | optCumulativity opts                              ] ++
   [ "--allow-exec"                      | optAllowExec opts                                 ] ++
   [ "--no-load-primitives"              | not $ optLoadPrimitives opts                      ] ++
+  [ "--without-K and --large-indices"   | optWithoutK opts, optLargeIndices opts            ] ++
+  [ "--large-indices and --forced-argument-recursion"
+  | optLargeIndices opts, optForcedArgumentRecursion opts ] ++
   []
 
 -- | This function returns 'True' if the file should be rechecked.
@@ -1279,9 +1301,11 @@ withKFlag =
 
 withoutKFlag :: Flag PragmaOptions
 withoutKFlag o = return $ o
-  { _optWithoutK      = Value True
-  , _optFlatSplit     = setDefault False (_optFlatSplit o)
-  , _optErasedMatches = setDefault False (_optErasedMatches o)
+  { _optWithoutK                = Value True
+  , _optFlatSplit               = setDefault False $ _optFlatSplit o
+  , _optErasedMatches           = setDefault False $ _optErasedMatches o
+  , _optLargeIndices            = setDefault False $ _optLargeIndices o
+  , _optForcedArgumentRecursion = setDefault True  $ _optForcedArgumentRecursion o
   }
 
 firstOrderFlag :: Flag PragmaOptions
@@ -1290,10 +1314,12 @@ firstOrderFlag o = return $ o { _optFirstOrder = Value True }
 cubicalCompatibleFlag :: Flag PragmaOptions
 cubicalCompatibleFlag o =
   return $ o
-  { _optCubicalCompatible = Value True
-  , _optWithoutK          = setDefault True  $ _optWithoutK o
-  , _optFlatSplit         = setDefault False $ _optFlatSplit o
-  , _optErasedMatches     = setDefault False $ _optErasedMatches o
+  { _optCubicalCompatible       = Value True
+  , _optWithoutK                = setDefault True  $ _optWithoutK o
+  , _optFlatSplit               = setDefault False $ _optFlatSplit o
+  , _optErasedMatches           = setDefault False $ _optErasedMatches o
+  , _optLargeIndices            = setDefault False $ _optLargeIndices o
+  , _optForcedArgumentRecursion = setDefault True  $ _optForcedArgumentRecursion o
   }
 
 cubicalFlag
@@ -1301,12 +1327,14 @@ cubicalFlag
   -> Flag PragmaOptions
 cubicalFlag variant o =
   return $ o
-  { _optCubical           = Just variant
-  , _optCubicalCompatible = setDefault True  $ _optCubicalCompatible o
-  , _optWithoutK          = setDefault True  $ _optWithoutK o
-  , _optTwoLevel          = setDefault True  $ _optTwoLevel o
-  , _optFlatSplit         = setDefault False $ _optFlatSplit o
-  , _optErasedMatches     = setDefault False $ _optErasedMatches o
+  { _optCubical                 = Just variant
+  , _optCubicalCompatible       = setDefault True  $ _optCubicalCompatible o
+  , _optWithoutK                = setDefault True  $ _optWithoutK o
+  , _optTwoLevel                = setDefault True  $ _optTwoLevel o
+  , _optFlatSplit               = setDefault False $ _optFlatSplit o
+  , _optErasedMatches           = setDefault False $ _optErasedMatches o
+  , _optLargeIndices            = setDefault False $ _optLargeIndices o
+  , _optForcedArgumentRecursion = setDefault True  $ _optForcedArgumentRecursion o
   }
 
 instanceDepthFlag :: String -> Flag PragmaOptions
@@ -1764,6 +1792,12 @@ pragmaOptions = concat
   , pragmaFlag      "keep-covering-clauses" lensOptKeepCoveringClauses
                     "do not discard covering clauses" "(required for some external backends)"
                     $ Just "discard covering clauses"
+  , pragmaFlag      "large-indices" lensOptLargeIndices
+                    "allow constructors with large indices" ""
+                    $ Just "always check that constructor arguments live in universes compatible with that of the datatype"
+  , pragmaFlag      "forced-argument-recursion" lensOptForcedArgumentRecursion
+                    "allow recursion on forced constructor arguments" ""
+                    Nothing
   ]
 
 pragmaOptionDefault :: KnownBool b => (PragmaOptions -> WithDefault b) -> Bool -> String

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3276,7 +3276,7 @@ data Call
   | CheckDataDef Range QName [A.LamBinding] [A.Constructor]
   | CheckRecDef Range QName [A.LamBinding] [A.Constructor]
   | CheckConstructor QName Telescope Sort A.Constructor
-  | CheckConstructorFitsIn QName Type Sort
+  | CheckConArgFitsIn QName Bool Type Sort
   | CheckFunDefCall Range QName [A.Clause] Bool
     -- ^ Highlight (interactively) if and only if the boolean is 'True'.
   | CheckPragma Range A.Pragma
@@ -3324,7 +3324,7 @@ instance Pretty Call where
     pretty CheckDataDef{}            = "CheckDataDef"
     pretty CheckRecDef{}             = "CheckRecDef"
     pretty CheckConstructor{}        = "CheckConstructor"
-    pretty CheckConstructorFitsIn{}  = "CheckConstructorFitsIn"
+    pretty CheckConArgFitsIn{}       = "CheckConArgFitsIn"
     pretty CheckFunDefCall{}         = "CheckFunDefCall"
     pretty CheckPragma{}             = "CheckPragma"
     pretty CheckPrimitive{}          = "CheckPrimitive"
@@ -3362,7 +3362,7 @@ instance HasRange Call where
     getRange (CheckDataDef i _ _ _)              = getRange i
     getRange (CheckRecDef i _ _ _)               = getRange i
     getRange (CheckConstructor _ _ _ c)          = getRange c
-    getRange (CheckConstructorFitsIn c _ _)      = getRange c
+    getRange (CheckConArgFitsIn c _ _ _)         = getRange c
     getRange (CheckFunDefCall i _ _ _)           = getRange i
     getRange (CheckPragma r _)                   = r
     getRange (CheckPrimitive i _ _)              = getRange i

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -63,7 +63,7 @@ interestingCall = \case
     CheckRecDef{}             -> True
     CheckConstructor{}        -> True
     CheckIApplyConfluence{}   -> True
-    CheckConstructorFitsIn{}  -> True
+    CheckConArgFitsIn{}       -> True
     CheckFunDefCall{}         -> True
     CheckPragma{}             -> True
     CheckPrimitive{}          -> True
@@ -186,7 +186,7 @@ instance MonadTrace TCM where
       CheckDataDef{}            -> True
       CheckRecDef{}             -> True
       CheckConstructor{}        -> True
-      CheckConstructorFitsIn{}  -> False
+      CheckConArgFitsIn{}       -> False
       CheckFunDefCall _ _ _ h   -> h
       CheckPragma{}             -> True
       CheckPrimitive{}          -> True

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -139,11 +139,20 @@ instance PrettyTCM Call where
 
     CheckConstructor{} -> __IMPOSSIBLE__
 
-    CheckConstructorFitsIn c t s -> fsep $
-      pwords "when checking that the type" ++ [prettyTCM t] ++
-      pwords "of the constructor" ++ [prettyTCM c] ++
-      pwords "fits in the sort" ++ [prettyTCM s] ++
-      pwords "of the datatype."
+    CheckConArgFitsIn c f t s -> do
+      woK <- withoutKOption
+      let
+        hint = fsep (pwords "Note: this argument is forced by the indices of" ++ [prettyTCM c <> comma] ++ pwords "so this definition would be allowed under --large-indices.")
+        -- Only add hint about large-indices when --with-K
+        addh d
+          | f && not woK = d $$ empty $$ hint
+          | otherwise    = d
+
+      addh $ fsep $
+        pwords "when checking that the type" ++ [prettyTCM t] ++
+        pwords "of an argument to the constructor" ++ [prettyTCM c] ++
+        pwords "fits in the sort" ++ [prettyTCM s] ++
+        pwords "of the datatype."
 
     CheckFunDefCall _ f _ _ ->
       fsep $ pwords "when checking the definition of" ++ [prettyTCM f]

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1753,9 +1753,10 @@ fitsIn uc forceds t s = do
     q <- viewTC eQuantity
     usableAtModality' (Just s) ConstructorType (setQuantity q unitModality) (unEl t)
 
-  fitsIn' withoutK forceds t s
+  li <- optLargeIndices <$> pragmaOptions
+  fitsIn' li forceds t s
   where
-  fitsIn' withoutK forceds t s = do
+  fitsIn' li forceds t s = do
     vt <- do
       t <- pathViewAsPi t
       return $ case t of
@@ -1765,13 +1766,13 @@ fitsIn uc forceds t s = do
                     _              -> Nothing
     case vt of
       Just (isPath, dom, b) -> do
-        let (forced,forceds') = nextIsForced forceds
-        unless (isForced forced && not withoutK) $ do
+        let (forced, forceds') = nextIsForced forceds
+        unless (isForced forced && li) $ do
           sa <- reduce $ getSort dom
           unless (isPath || uc == NoUniverseCheck || sa == SizeUniv) $
             sa `leqSort` s
         addContext (absName b, dom) $ do
-          succ <$> fitsIn' withoutK forceds' (absBody b) (raise 1 s)
+          succ <$> fitsIn' li forceds' (absBody b) (raise 1 s)
       _ -> do
         getSort t `leqSort` s
         return 0

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -278,7 +278,7 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
         NotInstanceDef -> pure ()
 
       -- Check that the fields fit inside the sort
-      _ <- fitsIn uc [] contype s
+      _ <- fitsIn conName uc [] contype s
 
       -- Check that the sort admits record declarations.
       checkDataSort name s

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -301,8 +301,8 @@ instance EmbPrj InfectiveCoinfective where
     valu _   = malformed
 
 instance EmbPrj PragmaOptions where
-  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm) =
-    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm
+  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo) =
+    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo
 
   value = valueN PragmaOptions
 

--- a/test/Fail/IUnivNotFibrant.err
+++ b/test/Fail/IUnivNotFibrant.err
@@ -1,3 +1,5 @@
 IUnivNotFibrant.agda:4,8-12
 SSet₁ is not less or equal than Set₁
-when checking the definition of Wrap
+when checking that the type IUniv of an argument to the constructor
+IUnivNotFibrant.Wrap.constructor fits in the sort Set₁ of the
+datatype.

--- a/test/Fail/Issue1075.err
+++ b/test/Fail/Issue1075.err
@@ -2,20 +2,19 @@ Issue1075.agda:283,1-444,54
 Termination checking failed for the following functions:
   cut⁺, cut⁻, rsubst+, lsubst
 Problematic calls:
-  cut⁺ pfΓ pf (z ∷ LA) (id⁺ v ∷ Values) N | pfΓ v
   rsubst+ Γ' pfΓ pf [] LA- LT [] (focL pf₁ x Sp)
   | fromctxGen Γ' (map Pers LA-) x
-  cut⁺ (conssusp pfΓ) pf LA (wken-all-rfoc Values) N
-    (at Issue1075.agda:338,40-44)
   rsubst+ [] pfΓ pf LA (A ∷ []) (N ∷ []) Values N'
     (at Issue1075.agda:340,3-10)
+  cut⁺ pfΓ pf (B ∷ LA) (V₂ ∷ Values)
+  (cut⁺ pfΓ pf (A ∷ []) (V₁ ∷ []) N)
+    (at Issue1075.agda:345,60-64)
   cut⁺ pfΓ pf (A ∷ []) (V₁ ∷ []) N
     (at Issue1075.agda:345,96-100)
   lsubst pfΓ pf N₁ N₂
     (at Issue1075.agda:360,60-66)
-  cut⁻ pfΓ pf (x₁ ∷ LA) refl
-  (cut⁺ pfΓ unit (x ∷ []) (V ∷ []) N₁ ∷ LExp) (Sp ∷ LExp')
-    (at Issue1075.agda:363,3-7)
+  cut⁺ pfΓ unit (x ∷ []) (V ∷ []) N₁
+    (at Issue1075.agda:363,32-36)
   cut⁻ pfΓ (pf₁ , pf) (A ∷ []) refl
   (?0 (Γ' = Γ') (LA- = LA-) (x = x) (x₁ = x₁) (pfΓ = pfΓ) (pf = pf)
    (LT = LT) (pf₁ = pf₁) (Sp = Sp))
@@ -23,3 +22,5 @@ Problematic calls:
     (at Issue1075.agda:382,3-7)
   cut⁺ pfΓ (proj₂ pf) (A ∷ []) (V ∷ []) N
     (at Issue1075.agda:431,32-36)
+  lsubst (conspers pfΓ) pf M (wken N)
+    (at Issue1075.agda:434,30-36)

--- a/test/Fail/Issue1075.err
+++ b/test/Fail/Issue1075.err
@@ -2,19 +2,20 @@ Issue1075.agda:283,1-444,54
 Termination checking failed for the following functions:
   cut⁺, cut⁻, rsubst+, lsubst
 Problematic calls:
+  cut⁺ pfΓ pf (z ∷ LA) (id⁺ v ∷ Values) N | pfΓ v
   rsubst+ Γ' pfΓ pf [] LA- LT [] (focL pf₁ x Sp)
   | fromctxGen Γ' (map Pers LA-) x
+  cut⁺ (conssusp pfΓ) pf LA (wken-all-rfoc Values) N
+    (at Issue1075.agda:338,40-44)
   rsubst+ [] pfΓ pf LA (A ∷ []) (N ∷ []) Values N'
     (at Issue1075.agda:340,3-10)
-  cut⁺ pfΓ pf (B ∷ LA) (V₂ ∷ Values)
-  (cut⁺ pfΓ pf (A ∷ []) (V₁ ∷ []) N)
-    (at Issue1075.agda:345,60-64)
   cut⁺ pfΓ pf (A ∷ []) (V₁ ∷ []) N
     (at Issue1075.agda:345,96-100)
   lsubst pfΓ pf N₁ N₂
     (at Issue1075.agda:360,60-66)
-  cut⁺ pfΓ unit (x ∷ []) (V ∷ []) N₁
-    (at Issue1075.agda:363,32-36)
+  cut⁻ pfΓ pf (x₁ ∷ LA) refl
+  (cut⁺ pfΓ unit (x ∷ []) (V ∷ []) N₁ ∷ LExp) (Sp ∷ LExp')
+    (at Issue1075.agda:363,3-7)
   cut⁻ pfΓ (pf₁ , pf) (A ∷ []) refl
   (?0 (Γ' = Γ') (LA- = LA-) (x = x) (x₁ = x₁) (pfΓ = pfΓ) (pf = pf)
    (LT = LT) (pf₁ = pf₁) (Sp = Sp))
@@ -22,5 +23,3 @@ Problematic calls:
     (at Issue1075.agda:382,3-7)
   cut⁺ pfΓ (proj₂ pf) (A ∷ []) (V ∷ []) N
     (at Issue1075.agda:431,32-36)
-  lsubst (conspers pfΓ) pf M (wken N)
-    (at Issue1075.agda:434,30-36)

--- a/test/Fail/Issue1406.agda
+++ b/test/Fail/Issue1406.agda
@@ -2,6 +2,7 @@
 -- Agda with K again is inconsistent with classical logic
 
 -- {-# OPTIONS --cubical-compatible #-}
+{-# OPTIONS --large-indices #-}
 
 open import Common.Level
 open import Common.Prelude

--- a/test/Fail/Issue1406.err
+++ b/test/Fail/Issue1406.err
@@ -1,4 +1,4 @@
-Issue1406.agda:33,24-28
+Issue1406.agda:34,24-28
 I'm not sure if there should be a case for the constructor refl,
 because I get stuck when trying to solve the following unification
 problems (inferred index ≟ expected index):

--- a/test/Fail/Issue1441.err
+++ b/test/Fail/Issue1441.err
@@ -1,5 +1,4 @@
 Issue1441.agda:13,3-7
 Set₂ is not less or equal than Set₁
-when checking that the type
-(A : Type) → (A → ∃ Tree') → Tree' (Box A) of the constructor sup'
-fits in the sort Set₁ of the datatype.
+when checking that the type Type of an argument to the constructor
+sup' fits in the sort Set₁ of the datatype.

--- a/test/Fail/Issue203.err
+++ b/test/Fail/Issue203.err
@@ -1,4 +1,4 @@
 Issue203.agda:8,3-6
 Set a is not less or equal than Set b
-when checking that the type (x : A) → Bad A of the constructor [_]
+when checking that the type A of an argument to the constructor [_]
 fits in the sort Set b of the datatype.

--- a/test/Fail/Issue3044.agda
+++ b/test/Fail/Issue3044.agda
@@ -1,4 +1,4 @@
-
+{-# OPTIONS --large-indices #-}
 -- The error on Agda 2.5.3 was:
 -- An internal error has occurred. Please report this as a bug.
 -- Location of the error: src/full/Agda/TypeChecking/Substitute/Class.hs:209

--- a/test/Fail/Issue3131.err
+++ b/test/Fail/Issue3131.err
@@ -1,4 +1,4 @@
 Issue3131.agda:3,3-4
 Set₂ is not less or equal than Set
-when checking that the type (S : Set₁) → A S of the constructor C
-fits in the sort Set of the datatype.
+when checking that the type Set₁ of an argument to the constructor
+C fits in the sort Set of the datatype.

--- a/test/Fail/Issue3327.err
+++ b/test/Fail/Issue3327.err
@@ -1,3 +1,4 @@
-Issue3327.agda:18,8-12
+Issue3327.agda:19,15-18
 Set₁ is not less or equal than Set
-when checking the definition of Type
+when checking that the type Set of an argument to the constructor
+inn fits in the sort Set of the datatype.

--- a/test/Fail/Issue3541EqualityNotPositive.agda
+++ b/test/Fail/Issue3541EqualityNotPositive.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --large-indices #-}
 -- Andreas, 2020-02-15
 -- Test case by Jesper to prevent regressions when fixing #3541.
 

--- a/test/Fail/Issue3541EqualityNotPositive.err
+++ b/test/Fail/Issue3541EqualityNotPositive.err
@@ -1,19 +1,19 @@
-Issue3541EqualityNotPositive.agda:15,3-16,18
+Issue3541EqualityNotPositive.agda:16,3-17,18
 D is not strictly positive, because it occurs
 in the first argument of _≡_
 in the type of the constructor c
 in the definition of D.
-Issue3541EqualityNotPositive.agda:18,3-19,18
+Issue3541EqualityNotPositive.agda:19,3-20,18
 E is not strictly positive, because it occurs
 in the second argument of _≡_
 in the type of the constructor c
 in the definition of E.
-Issue3541EqualityNotPositive.agda:26,3-27,18
+Issue3541EqualityNotPositive.agda:27,3-28,18
 D is not strictly positive, because it occurs
 in the first argument of _≡_
 in the type of the constructor c
 in the definition of D.
-Issue3541EqualityNotPositive.agda:29,3-30,18
+Issue3541EqualityNotPositive.agda:30,3-31,18
 E is not strictly positive, because it occurs
 in the second argument of _≡_
 in the type of the constructor c

--- a/test/Fail/Issue4461.err
+++ b/test/Fail/Issue4461.err
@@ -1,4 +1,4 @@
 Issue4461.agda:3,3-4
 Agda.Primitive.lzero != Agda.Primitive.lsuc _7
-when checking that the type (I : _4) → (I → M) → M of the
-constructor m fits in the sort Set of the datatype.
+when checking that the type _4 of an argument to the constructor m
+fits in the sort Set of the datatype.

--- a/test/Fail/Issue4638-2.err
+++ b/test/Fail/Issue4638-2.err
@@ -1,4 +1,3 @@
-Issue4638-2.agda:4,3-5
+Issue4638-2.agda:4,3-18
 A → E A is not usable at the required modality @ω
-when checking that the type A → E A of the constructor c₁ fits in
-the sort Set of the datatype.
+when checking the constructor c₁ in the declaration of E

--- a/test/Fail/Issue4784b.err
+++ b/test/Fail/Issue4784b.err
@@ -1,4 +1,3 @@
-Issue4784b.agda:15,3-6
+Issue4784b.agda:15,3-29
 (@0 x : A) → B x → D is not usable at the required modality @ω
-when checking that the type (@0 x : A) → B x → D of the constructor
-con fits in the sort Set of the datatype.
+when checking the constructor con in the declaration of D

--- a/test/Fail/Issue5410-3.err
+++ b/test/Fail/Issue5410-3.err
@@ -1,4 +1,3 @@
-Issue5410-3.agda:7,3-4
+Issue5410-3.agda:7,3-12
 {@0 A : Set} → A → D is not usable at the required modality @ω
-when checking that the type {@0 A : Set} → A → D of the constructor
-c fits in the sort Set₁ of the datatype.
+when checking the constructor c in the declaration of D

--- a/test/Fail/Issue5434-1.err
+++ b/test/Fail/Issue5434-1.err
@@ -1,4 +1,3 @@
-Issue5434-1.agda:4,3-4
+Issue5434-1.agda:4,3-25
 (@0 A : Set) → D A is not usable at the required modality @ω
-when checking that the type (@0 A : Set) → D A of the constructor c
-fits in the sort Set₁ of the datatype.
+when checking the constructor c in the declaration of D

--- a/test/Fail/Issue5434-2.err
+++ b/test/Fail/Issue5434-2.err
@@ -1,4 +1,3 @@
-Issue5434-2.agda:6,3-4
+Issue5434-2.agda:6,3-27
 (@0 x y : D) → x ≡ y is not usable at the required modality @ω
-when checking that the type (@0 x y : D) → x ≡ y of the constructor
-c fits in the sort Set of the datatype.
+when checking the constructor c in the declaration of D

--- a/test/Fail/Issue5434-3.err
+++ b/test/Fail/Issue5434-3.err
@@ -1,4 +1,3 @@
-Issue5434-3.agda:6,5-6
+Issue5434-3.agda:6,5-31
 (@0 A : Set) → A → D A is not usable at the required modality @ω
-when checking that the type (@0 A : Set) → A → D A of the
-constructor c fits in the sort Set₁ of the datatype.
+when checking the constructor c in the declaration of D

--- a/test/Fail/Issue555c.err
+++ b/test/Fail/Issue555c.err
@@ -1,3 +1,4 @@
 Issue555c.agda:7,8-9
 Set a is not less or equal than Set
-when checking the definition of R
+when checking that the type A of an argument to the constructor
+Issue555c.R.constructor fits in the sort Set of the datatype.

--- a/test/Fail/Issue5706.agda
+++ b/test/Fail/Issue5706.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --large-indices #-}
 -- Andreas, 2021-12-22, issue #5706 reported by Trebor-Huang
 -- In Agda <= 2.6.2.1, Int overflow can be exploited.
 

--- a/test/Fail/Issue5706.err
+++ b/test/Fail/Issue5706.err
@@ -1,5 +1,4 @@
-Issue5706.agda:31,3-6
+Issue5706.agda:32,3-6
 Set₁₈₄₄₆₇₄₄₀₇₃₇₀₉₅₅₁₆₁₆ is not less or equal than Set
-when checking that the type
-(X : Set₁₈₄₄₆₇₄₄₀₇₃₇₀₉₅₅₁₆₁₅) → (X → SET) → SET of the constructor
-set fits in the sort Set of the datatype.
+when checking that the type Set₁₈₄₄₆₇₄₄₀₇₃₇₀₉₅₅₁₆₁₅ of an argument
+to the constructor set fits in the sort Set of the datatype.

--- a/test/Fail/Issue5920b.err
+++ b/test/Fail/Issue5920b.err
@@ -1,4 +1,3 @@
-Issue5920b.agda:7,3-4
+Issue5920b.agda:7,3-10
 P c is not usable at the required modality @ω
-when checking that the type P c of the constructor d fits in the
-sort Set of the datatype.
+when checking the constructor d in the declaration of P

--- a/test/Fail/Issue6654a.agda
+++ b/test/Fail/Issue6654a.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --forced-argument-recursion --no-large-indices --safe #-}
+module Issue6654a where
+
+-- Fails: to have safe forced argument recursion, large indices can not
+-- be used, so the defn of Bad is rejected
+
+data ⊥ : Set where
+
+data Bad : ((P : Set) → P → P) → Set where
+  b : (f : (P : Set) → P → P) → Bad f
+
+bad : Bad _
+bad = b λ P p → p
+
+no-bad : ∀ {x} → Bad x → ⊥
+no-bad (b x) = no-bad (x _ bad)
+
+very-bad : ⊥
+very-bad = no-bad bad

--- a/test/Fail/Issue6654a.err
+++ b/test/Fail/Issue6654a.err
@@ -1,0 +1,4 @@
+Issue6654a.agda:10,3-4
+Set₁ is not less or equal than Set
+when checking that the type (f : (P : Set) → P → P) → Bad f of the
+constructor b fits in the sort Set of the datatype.

--- a/test/Fail/Issue6654a.err
+++ b/test/Fail/Issue6654a.err
@@ -1,4 +1,6 @@
 Issue6654a.agda:10,3-4
 Set₁ is not less or equal than Set
-when checking that the type (f : (P : Set) → P → P) → Bad f of the
+when checking that the type (P : Set) → P → P of an argument to the
 constructor b fits in the sort Set of the datatype.
+Note: this argument is forced by the indices of b, so this
+definition would be allowed under --large-indices.

--- a/test/Fail/Issue6654b.agda
+++ b/test/Fail/Issue6654b.agda
@@ -1,7 +1,7 @@
-{-# OPTIONS --with-K --safe #-}
+{-# OPTIONS --with-K --large-indices --no-forced-argument-recursion --safe #-}
 module Issue6654b where
 
--- Fails: the default is no forced argument recursion, so the
+-- Fails: we asked for large indices and no forced argument recursion, so the
 -- termination checker complains about no-bad
 
 data ⊥ : Set where

--- a/test/Fail/Issue6654b.agda
+++ b/test/Fail/Issue6654b.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --with-K --safe #-}
+module Issue6654b where
+
+-- Fails: the default is no forced argument recursion, so the
+-- termination checker complains about no-bad
+
+data ⊥ : Set where
+
+data Bad : ((P : Set) → P → P) → Set where
+  b : (f : (P : Set) → P → P) → Bad f
+
+bad : Bad _
+bad = b λ P p → p
+
+no-bad : ∀ {x} → Bad x → ⊥
+no-bad (b x) = no-bad (x _ bad)
+
+very-bad : ⊥
+very-bad = no-bad bad

--- a/test/Fail/Issue6654b.err
+++ b/test/Fail/Issue6654b.err
@@ -1,0 +1,6 @@
+Issue6654b.agda:15,1-16,32
+Termination checking failed for the following functions:
+  no-bad
+Problematic calls:
+  no-bad (x (Bad (λ P p → p)) bad)
+    (at Issue6654b.agda:16,16-22)

--- a/test/Fail/Issue6654c.agda
+++ b/test/Fail/Issue6654c.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --forced-argument-recursion --large-indices --safe #-}
+module Issue6654c where
+
+-- Fails: having both of these options would allow the program to go
+-- through, but they're not --safe together
+
+data ⊥ : Set where
+
+data Bad : ((P : Set) → P → P) → Set where
+  b : (f : (P : Set) → P → P) → Bad f
+
+bad : Bad _
+bad = b λ P p → p
+
+no-bad : ∀ {x} → Bad x → ⊥
+no-bad (b x) = no-bad (x _ bad)
+
+very-bad : ⊥
+very-bad = no-bad bad

--- a/test/Fail/Issue6654c.err
+++ b/test/Fail/Issue6654c.err
@@ -1,0 +1,3 @@
+Issue6654c.agda:1,1-67
+Cannot set OPTIONS pragma
+--large-indices and --forced-argument-recursion with safe flag.

--- a/test/Fail/Issue6654c.err
+++ b/test/Fail/Issue6654c.err
@@ -1,3 +1,3 @@
 Issue6654c.agda:1,1-67
-Cannot set OPTIONS pragma
+Cannot set OPTIONS pragmas
 --large-indices and --forced-argument-recursion with safe flag.

--- a/test/Fail/Issue689.err
+++ b/test/Fail/Issue689.err
@@ -1,4 +1,4 @@
 Issue689.agda:8,3-4
 Set₂ is not less or equal than Set₁
-when checking that the type Set₁ → Bad of the constructor c fits in
-the sort Set₁ of the datatype.
+when checking that the type Set₁ of an argument to the constructor
+c fits in the sort Set₁ of the datatype.

--- a/test/Fail/Issue776.err
+++ b/test/Fail/Issue776.err
@@ -1,5 +1,4 @@
 Issue776.agda:7,3-8
 Set (lsuc l) is not less or equal than Set₁
-when checking that the type
-{F : Set l → Set l} → F A → F B → A :=: B of the constructor proof
-fits in the sort Set₁ of the datatype.
+when checking that the type Set l → Set l of an argument to the
+constructor proof fits in the sort Set₁ of the datatype.

--- a/test/Fail/Issue830.err
+++ b/test/Fail/Issue830.err
@@ -1,4 +1,4 @@
 Issue830.agda:8,3-6
 Set₁ is not less or equal than Set
-when checking that the type Set ⟶ ⟨Set⟩ of the constructor [_] fits
-in the sort Set of the datatype.
+when checking that the type Set of an argument to the constructor
+[_] fits in the sort Set of the datatype.

--- a/test/Fail/Issue998e.err
+++ b/test/Fail/Issue998e.err
@@ -1,4 +1,4 @@
 Issue998e.agda:7,3-4
 Set (lsuc ℓ₁) is not less or equal than Set (lsuc ℓ)
-when checking that the type (ℓ₁ : Level) → Set ℓ₁ → D of the
+when checking that the type Set ℓ₁ of an argument to the
 constructor c fits in the sort Set (lsuc ℓ) of the datatype.

--- a/test/Fail/LargeIndices.err
+++ b/test/Fail/LargeIndices.err
@@ -1,4 +1,4 @@
 LargeIndices.agda:5,3-6
 Set a is not less or equal than Set
-when checking that the type (x : A) → Img f (f x) of the
-constructor inv fits in the sort Set of the datatype.
+when checking that the type A of an argument to the constructor inv
+fits in the sort Set of the datatype.

--- a/test/Fail/LargeIndicesWithoutK.err
+++ b/test/Fail/LargeIndicesWithoutK.err
@@ -1,4 +1,4 @@
 LargeIndicesWithoutK.agda:5,3-6
 Set a is not less or equal than Set
-when checking that the type (x : A) → Singleton x of the
-constructor [_] fits in the sort Set of the datatype.
+when checking that the type A of an argument to the constructor [_]
+fits in the sort Set of the datatype.

--- a/test/Fail/NotLeqSort.err
+++ b/test/Fail/NotLeqSort.err
@@ -1,4 +1,4 @@
 NotLeqSort.agda:5,3-6
 Set₁ is not less or equal than Set
-when checking that the type Set → Err of the constructor err fits
-in the sort Set of the datatype.
+when checking that the type Set of an argument to the constructor
+err fits in the sort Set of the datatype.

--- a/test/Fail/UnsolvableLevelConstraintsInDataDef.err
+++ b/test/Fail/UnsolvableLevelConstraintsInDataDef.err
@@ -1,4 +1,4 @@
 UnsolvableLevelConstraintsInDataDef.agda:7,3-6
 Set₂ is not less or equal than Set₁
-when checking that the type (E : Set₁) → D ≡ E → (E → D) → D of the
-constructor abs fits in the sort Set₁ of the datatype.
+when checking that the type Set₁ of an argument to the constructor
+abs fits in the sort Set₁ of the datatype.

--- a/test/Succeed/Issue1833.agda
+++ b/test/Succeed/Issue1833.agda
@@ -1,4 +1,4 @@
-
+{-# OPTIONS --large-indices #-}
 module _ where
 
 open import Common.Prelude hiding (_>>=_)

--- a/test/Succeed/Issue2386BuiltinEqualityUniverseLub.agda
+++ b/test/Succeed/Issue2386BuiltinEqualityUniverseLub.agda
@@ -1,5 +1,5 @@
 -- Andreas, 2017-01-12, issue #2386
-
+{-# OPTIONS --large-indices #-}
 open import Agda.Primitive
 
 data _≡_ {a b} {A : Set (a ⊔ b)} : (x y : A) → Set where

--- a/test/Succeed/Issue2883.agda
+++ b/test/Succeed/Issue2883.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --allow-unsolved-metas #-}
+{-# OPTIONS --allow-unsolved-metas --large-indices #-}
 module _ where
 
 open import Agda.Builtin.Nat

--- a/test/Succeed/Issue3296.agda
+++ b/test/Succeed/Issue3296.agda
@@ -1,4 +1,4 @@
-
+{-# OPTIONS --large-indices #-}
 -- Generalized variables in datatype (and record) parameters
 
 module _ where

--- a/test/Succeed/Issue4946.agda
+++ b/test/Succeed/Issue4946.agda
@@ -2,7 +2,7 @@
 -- More liberal type signatures for constructors of sized types.
 
 -- {-# OPTIONS -v tc.polarity:20 #-}
-{-# OPTIONS --sized-types #-}
+{-# OPTIONS --sized-types --large-indices #-}
 
 open import Agda.Builtin.Size
 

--- a/test/Succeed/Issue689-stevana.agda
+++ b/test/Succeed/Issue689-stevana.agda
@@ -1,5 +1,5 @@
 -- Andreas, 2017-10-04, issue #689, test case by stevana
-
+{-# OPTIONS --large-indices #-}
 -- {-# OPTIONS -v tc.data:50 #-}
 -- {-# OPTIONS -v tc.force:100 #-}
 -- {-# OPTIONS -v tc.constr:50 #-}

--- a/test/Succeed/LargeIndices.agda
+++ b/test/Succeed/LargeIndices.agda
@@ -1,4 +1,4 @@
-
+{-# OPTIONS --large-indices #-}
 -- Forced constructor arguments don't count towards the size of the datatype
 -- (only if not --withoutK).
 

--- a/test/Succeed/TerminationInductionInduction.agda
+++ b/test/Succeed/TerminationInductionInduction.agda
@@ -1,6 +1,7 @@
 -- Andreas, 2018-08-14, re issue #1556
 -- Termination checking functions over inductive-inductive types
 
+{-# OPTIONS --forced-argument-recursion #-}
 -- {-# OPTIONS -v term:40 #-}
 
 mutual


### PR DESCRIPTION
Fixes #6654, closes #6653.

The minimal-breakage solution I worked out was to have a flag for large indices, a flag for recursion on forced arguments, and to make their conjunction incompatible with `--safe`.

For backwards compatibility with the standard library (which uses large indices but, as far as I know, no forced argument recursion), the default is `--large-indices --no-forced-argument-recursion`.

At least one of these flags should be (co?)infective; I'm not sure which, but it's probably --large-indices.