### PR TITLE
Fixes various syntax errors related to docstrings in agda-mode

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -530,7 +530,7 @@ process."
 Sends the list of strings ARGS to the Agda2 interpreter, waits
 for output and executes the responses, if any.
 
-If SAVE is 'save, then the buffer is saved first.
+If SAVE is \\='save, then the buffer is saved first.
 
 If HIGHLIGHT is non-nil, then the buffer's syntax highlighting
 may be updated. This is also the case if the Agda process is
@@ -759,13 +759,13 @@ The user input is computed as follows:
   contains whitespace, then the input is taken from the
   minibuffer. In this case WANT is used as the prompt string.
 
-* Otherwise (including if WANT is 'goal) the goal contents are
+* Otherwise (including if WANT is \\='goal) the goal contents are
   used.
 
 If the user input is not taken from the goal, then an empty goal
 range is given.
 
-If SAVE is 'save, then the buffer is saved just before the
+If SAVE is \\='save, then the buffer is saved just before the
 command is sent to Agda (if it is sent)."
   (cl-multiple-value-bind (o g) (agda2-goal-at (point))
     (unless g (error "For this command, please place the cursor in a goal"))
@@ -892,8 +892,8 @@ of new goals."
  (agda2-goal-cmd "Cmd_autoOne" 'save 'goal))
 
 (defun agda2-autoAll ()
-  (interactive)
   "Solves all goals by simple proof search."
+  (interactive)
   (agda2-go nil nil 'busy t "Cmd_autoAll")
 )
 
@@ -1949,7 +1949,7 @@ the argument is a positive number, otherwise turn it off."
 
 (defun agda2-get-agda-program-versions ()
   "Get \"version strings\" of executables starting with
-'agda-mode' in current path."
+\\='agda-mode\\=' in current path."
   (delete-dups
    (mapcar (lambda (path)
              ;; strip 'agda-mode' prefix


### PR DESCRIPTION
On emacs head agda-mode throws errors when attempting to natively compile to elc, which I am assuming are related to more strictly enforcing syntax requirements in docstrings by the new versions of emacs; This mainly concerns the use of `\x`, `'`, and one last error with the docstring appearing after `(interactive)`. 

A trivial fix. Log attached of the errors that came up on my terminal as I fixed them line by line.

[agda-mode-errors.log](https://github.com/agda/agda/files/11568085/agda-mode-errors.log)
