### PR TITLE
Handle copied definitions in unfolding clauses

### DIFF
--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1294,7 +1294,7 @@ instance ToConcrete A.Declaration where
     (:[]) . C.UnquoteDef (getRange i) xs <$> toConcrete e
 
   toConcrete (A.UnquoteData i xs uc j cs e) = __IMPOSSIBLE__
-  toConcrete (A.UnfoldingDecl r ns) = __IMPOSSIBLE__
+  toConcrete (A.UnfoldingDecl r ns) = pure []
 
 data RangeAndPragma = RangeAndPragma Range A.Pragma
 

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1372,7 +1372,7 @@ instance ToAbstract (TopLevel [C.Declaration]) where
           -- encountered several (possibly nested) opaque blocks. We
           -- must now ensure that these have transitively-closed
           -- unfolding sets.
-          saturateOpaqueBlocks
+          saturateOpaqueBlocks (outsideDecls ++ [ insideDecl ])
 
           return $ TopLevelInfo (primitiveImport ++ outsideDecls ++ [ insideDecl ]) scope
 

--- a/test/Succeed/OpaqueCopy.agda
+++ b/test/Succeed/OpaqueCopy.agda
@@ -1,0 +1,28 @@
+module OpaqueCopy where
+
+open import Agda.Builtin.Nat
+  using (Nat; zero; suc)
+open import Agda.Builtin.Equality
+
+module Opaque where
+
+module M2 (A : Set) where
+  opaque
+    _+_ : Nat → Nat → Nat
+    zero  + m = m
+    suc n + m = suc (n + m)
+
+module M3 (A : Set) where
+  open M2 Nat public
+
+module M4 where
+  open M3 Nat public
+
+module M5 where
+  open M4
+
+  opaque
+    unfolding _+_
+
+    _ : 1 + 1 ≡ 2
+    _ = refl


### PR DESCRIPTION
Fixes #6665.

Opening (or declaring) a module application generates fresh copies of definitions, which did not previously retain the link with the opaque block of their underlying definition. Note that this only affects attempting to give the copied name in an unfolding clause --- since modules can not be opaque, the generated copies are always transparent.

The fix is to associate the copied names with the same opaque id as their underlying definition; this requires knowing what opaque ids are associated with each name-that-has-been-copied. To avoid a nasty knot-tie, we build a map sending copy → original before handling unfolding clauses.