### PR TITLE
Refactor: remove `whatInduction` and `conInd`

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -1170,9 +1170,9 @@ condecl :: QName -> Induction -> HsCompileM HS.ConDecl
 condecl q _ind = do
   opts <- askGhcOpts
   def <- getConstInfo q
-  let Constructor{ conPars = np, conErased = erased } = theDef def
+  let Constructor{ conPars = np, conSrcCon, conErased = erased } = theDef def
   (argTypes0, _) <- hsTelApproximation (defType def)
-  let strict     = if conInd (theDef def) == Inductive &&
+  let strict     = if conInductive conSrcCon == Inductive &&
                       optGhcStrictData opts
                    then HS.Strict
                    else HS.Lazy

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -289,7 +289,7 @@ nameKinds hlLevel decl = do
                             | otherwise            = Function
   defnToKind   TCM.Datatype{}                        = Datatype
   defnToKind   TCM.Record{}                          = Record
-  defnToKind   TCM.Constructor{ TCM.conInd = i }       = Constructor i
+  defnToKind   TCM.Constructor{ TCM.conSrcCon = c }  = Constructor $ I.conInductive c
   defnToKind   TCM.Primitive{}                       = Primitive
   defnToKind   TCM.PrimitiveSort{}                   = Primitive
   defnToKind   TCM.AbstractDefn{}                    = __IMPOSSIBLE__

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -56,8 +56,7 @@ import Agda.TypeChecking.Warnings ( raiseWarningsOnUsage, runPM )
 
 import qualified Agda.Syntax.Abstract as A
 import Agda.Syntax.Concrete.Definitions as W ( DeclarationWarning(..), DeclarationWarning'(..) )
-import Agda.Syntax.Common (pattern Ranged)
-import qualified Agda.Syntax.Common as Common
+import Agda.Syntax.Common (Induction(..), pattern Ranged)
 import qualified Agda.Syntax.Concrete.Name as C
 import qualified Agda.Syntax.Internal as I
 import qualified Agda.Syntax.Literal as L
@@ -296,7 +295,7 @@ nameKinds hlLevel decl = do
   defnToKind   TCM.AbstractDefn{}                    = __IMPOSSIBLE__
 
   con :: NameKind
-  con = Constructor Common.Inductive
+  con = Constructor Inductive
 
 -- | The 'TCM.Axiom' constructor is used to represent various things
 -- which are not really axioms, so when maps are merged 'Postulate's
@@ -680,7 +679,7 @@ storeDisambiguatedField = storeDisambiguatedName Field
 storeDisambiguatedProjection :: A.QName -> TCM ()
 storeDisambiguatedProjection = storeDisambiguatedField
 
-storeDisambiguatedConstructor :: Common.Induction -> A.QName -> TCM ()
+storeDisambiguatedConstructor :: Induction -> A.QName -> TCM ()
 storeDisambiguatedConstructor i = storeDisambiguatedName $ Constructor i
 
 -- TODO: move the following function to a new module TypeChecking.Overloading

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -158,7 +158,7 @@ instance NamesIn Defn where
       -> namesAndMetasIn' sg (cl, cs, s, trX, trD)
     Record _ cl c _ fs recTel _ _ _ _ _ _ comp
       -> namesAndMetasIn' sg (cl, c, fs, recTel, comp)
-    Constructor _ _ c d _ _ kit fs _ _ _
+    Constructor _ _ c d _ kit fs _ _ _
       -> namesAndMetasIn' sg (c, d, kit, fs)
     Primitive _ _ cl _ cc _
       -> namesAndMetasIn' sg (cl, cc)

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -691,13 +691,9 @@ termClause clause = do
     parseDotP = \case
       DotP o t -> termToDBP t
       p        -> return p
-    stripCoCon p = case p of
-      ConP (ConHead c _ _ _) _ _ -> do
-        ifM ((Just c ==) <$> terGetSizeSuc) (return p) $ {- else -} do
-        whatInduction c >>= \case
-          Inductive   -> return p
-          CoInductive -> return unusedVar
-      _ -> return p
+    stripCoCon = \case
+      ConP (ConHead c _ CoInductive _) _ _ -> return unusedVar
+      p -> return p
     reportBody :: Term -> TerM ()
     reportBody v = verboseS "term.check.clause" 6 $ do
       f       <- terGetCurrent

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -835,7 +835,6 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
                 , conSrcCon = genRecCon
                 , conData   = genRecName
                 , conAbstr  = ConcreteDef
-                , conInd    = Inductive
                 , conComp   = emptyCompKit
                 , conProj   = Nothing
                 , conForced = []

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2581,8 +2581,6 @@ data ConstructorData = ConstructorData
   , _conData   :: QName
       -- ^ Name of datatype or record type.
   , _conAbstr  :: IsAbstract
-  , _conInd    :: Induction
-      -- ^ Inductive or coinductive?
   , _conComp   :: CompKit
       -- ^ Cubical composition.
   , _conProj   :: Maybe [QName]
@@ -2606,7 +2604,6 @@ pattern Constructor
   -> ConHead
   -> QName
   -> IsAbstract
-  -> Induction
   -> CompKit
   -> Maybe [QName]
   -> [IsForced]
@@ -2619,7 +2616,6 @@ pattern Constructor
   , conSrcCon
   , conData
   , conAbstr
-  , conInd
   , conComp
   , conProj
   , conForced
@@ -2631,7 +2627,6 @@ pattern Constructor
     conSrcCon
     conData
     conAbstr
-    conInd
     conComp
     conProj
     conForced
@@ -2855,7 +2850,6 @@ instance Pretty ConstructorData where
       conSrcCon
       conData
       conAbstr
-      conInd
       _conComp
       _conProj
       _conForced
@@ -2868,7 +2862,6 @@ instance Pretty ConstructorData where
       , "conSrcCon  =" <?> pretty conSrcCon
       , "conData    =" <?> pretty conData
       , "conAbstr   =" <?> pshow conAbstr
-      , "conInd     =" <?> pshow conInd
       , "conErased  =" <?> pshow conErased
       , "conErasure =" <?> pshow conErasure
       ] <?> "}"
@@ -5510,7 +5503,7 @@ instance KillRange Defn where
         killRangeN Function a b c d e f g h i j k l m n o p q
       Datatype a b c d e f g h i j   -> killRangeN Datatype a b c d e f g h i j
       Record a b c d e f g h i j k l m -> killRangeN Record a b c d e f g h i j k l m
-      Constructor a b c d e f g h i j k -> killRangeN Constructor a b c d e f g h i j k
+      Constructor a b c d e f g h i j -> killRangeN Constructor a b c d e f g h i j
       Primitive a b c d e f          -> killRangeN Primitive a b c d e f
       PrimitiveSort a b              -> killRangeN PrimitiveSort a b
 

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -784,22 +784,6 @@ sameDef d1 d2 = do
   c2 <- canonicalName d2
   if (c1 == c2) then return $ Just c1 else return Nothing
 
--- | Can be called on either a (co)datatype, a record type or a
---   (co)constructor.
-whatInduction :: MonadTCM tcm => QName -> tcm Induction
-whatInduction c = liftTCM $ do
-  def <- theDef <$> getConstInfo c
-  mz <- getBuiltinName' builtinIZero
-  mo <- getBuiltinName' builtinIOne
-  case def of
-    Datatype{}                    -> return Inductive
-    Record{} | not (recRecursive def) -> return Inductive
-    Record{ recInduction = i    } -> return $ fromMaybe Inductive i
-    Constructor{ conInd = i }     -> return i
-    _ | Just c == mz || Just c == mo
-                                  -> return Inductive
-    _                             -> __IMPOSSIBLE__
-
 -- | Does the given constructor come from a single-constructor type?
 --
 -- Precondition: The name has to refer to a constructor.

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -287,10 +287,7 @@ matchPattern p u = case (p, u) of
         w <- reduceB v
         -- Unfold delayed (corecursive) definitions one step. This is
         -- only necessary if c is a coinductive constructor, but
-        -- 1) it does not hurt to do it all the time, and
-        -- 2) whatInduction c sometimes crashes because c may point to
-        --    an axiom at this stage (if we are checking the
-        --    projection functions for a record type).
+        -- it does not hurt to do it all the time.
 {-
         w <- case w of
                NotBlocked r (Def f es) ->   -- Andreas, 2014-06-12 TODO: r == ReallyNotBlocked sufficient?

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -309,20 +309,18 @@ matchPattern p u = case (p, u) of
           b | Just t <- isMatchable b ->
             case mtc t of
               Just (bld, vs) -> do
-                (m, vs1) <- yesSimplification <$> matchPatterns ps (fromMaybe __IMPOSSIBLE__ $ allApplyElims vs)
-                return (m, Arg info $ bld (mergeElims vs vs1))
+                (m, vs1) <- matchPatterns ps (fromMaybe __IMPOSSIBLE__ $ allApplyElims vs)
+                return (yesSimplification m, Arg info $ bld (mergeElims vs vs1))
               Nothing
                                     -> return (No                          , arg)
           Blocked b _               -> return (DontKnow $ Blocked b ()     , arg)
           NotBlocked r _            -> return (DontKnow $ NotBlocked r' () , arg)
             where r' = stuckOn (Apply arg) r
 
--- ASR (08 November 2014). The type of the function could be
---
--- @(Match Term, [Arg Term]) -> (Match Term, [Arg Term])@.
-yesSimplification :: (Match a, b) -> (Match a, b)
-yesSimplification (Yes _ vs, us) = (Yes YesSimplification vs, us)
-yesSimplification r              = r
+yesSimplification :: Match a -> Match a
+yesSimplification = \case
+  Yes _ vs -> Yes YesSimplification vs
+  m -> m
 
 -- Matching patterns against patterns -------------------------------------
 

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -478,7 +478,7 @@ isEtaOrCoinductiveRecordConstructor c =
       -- If in doubt about coinductivity, then yes.
 
 -- | Check if a name refers to a record which is not coinductive.  (Projections are then size-preserving)
-isInductiveRecord :: QName -> TCM Bool
+isInductiveRecord :: HasConstInfo m => QName -> m Bool
 isInductiveRecord r = maybe False ((Just CoInductive /=) . recInduction) <$> isRecord r
 
 -- | Check if a type is an eta expandable record and return the record identifier and the parameters.

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -1008,7 +1008,6 @@ bindBuiltinNoDef b q = inTopContext $ do
               , conSrcCon = ch
               , conData   = d
               , conAbstr  = ConcreteDef
-              , conInd    = Inductive
               , conComp   = emptyCompKit
               , conProj   = Nothing
               , conForced = []

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -99,7 +99,6 @@ bindBuiltinSharp x =
                     , conSrcCon = ConHead sharp (IsRecord CopatternMatching) CoInductive [] -- flat is added as field later
                     , conData   = defName infDefn
                     , conAbstr  = ConcreteDef
-                    , conInd    = CoInductive
                     , conComp   = emptyCompKit
                     , conProj   = Nothing
                     , conForced = []

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -360,7 +360,6 @@ checkConstructor d uc tel nofIxs s con@(A.Axiom _ i ai Nothing c e) =
               , conSrcCon = con
               , conData   = d
               , conAbstr  = Info.defAbstract i
-              , conInd    = Inductive
               , conComp   = comp
               , conProj   = projNames
               , conForced = forcedArgs

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -263,7 +263,6 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
               , conSrcCon = con
               , conData   = name
               , conAbstr  = Info.defAbstract i
-              , conInd    = conInduction
               , conComp   = emptyCompKit  -- filled in later
               , conProj   = Nothing       -- filled in later
               , conForced = []

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20230515 * 10 + 0
+currentInterfaceVersion = 20230526 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -392,7 +392,7 @@ instance EmbPrj Defn where
   icod_ (Function    a b s t u c d e f g h i j k l m n) = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k l m n
   icod_ (Datatype    a b c d e f g h i j)               = icodeN 2 Datatype a b c d e f g h i j
   icod_ (Record      a b c d e f g h i j k l m)         = icodeN 3 Record a b c d e f g h i j k l m
-  icod_ (Constructor a b c d e f g h i j k)             = icodeN 4 Constructor a b c d e f g h i j k
+  icod_ (Constructor a b c d e f g h i j)               = icodeN 4 Constructor a b c d e f g h i j
   icod_ (Primitive   a b c d e f)                       = icodeN 5 Primitive a b c d e f
   icod_ (PrimitiveSort a b)                             = icodeN 6 PrimitiveSort a b
   icod_ AbstractDefn{}                                  = __IMPOSSIBLE__
@@ -405,7 +405,7 @@ instance EmbPrj Defn where
                                                        = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k l m n
     valu [2, a, b, c, d, e, f, g, h, i, j]             = valuN Datatype a b c d e f g h i j
     valu [3, a, b, c, d, e, f, g, h, i, j, k, l, m]    = valuN Record   a b c d e f g h i j k l m
-    valu [4, a, b, c, d, e, f, g, h, i, j, k]          = valuN Constructor a b c d e f g h i j k
+    valu [4, a, b, c, d, e, f, g, h, i, j]             = valuN Constructor a b c d e f g h i j
     valu [5, a, b, c, d, e, f]                         = valuN Primitive   a b c d e f
     valu [6, a, b]                                     = valuN PrimitiveSort a b
     valu [7]                                           = valuN GeneralizableVar


### PR DESCRIPTION
`ConHead` carries the `Induction` flag, so we can remove:
- `conInd` from the `Constructor` `Defn`
- the `whatInduction` function.