### PR TITLE
WIP: Recover from type errors

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -668,6 +668,7 @@ library
       Agda.TypeChecking.ReconstructParameters
       Agda.TypeChecking.RecordPatterns
       Agda.TypeChecking.Records
+      Agda.TypeChecking.Recover
       Agda.TypeChecking.Reduce
       Agda.TypeChecking.Reduce.Fast
       Agda.TypeChecking.Reduce.Monad

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -475,6 +475,7 @@ instance Reify Constraint where
               OfType tm <$> reify t
           Open{}  -> __IMPOSSIBLE__
           OpenInstance{}  -> __IMPOSSIBLE__
+          DeferredError{} -> __IMPOSSIBLE__
           InstV{} -> __IMPOSSIBLE__
     reify (FindInstance m mcands) = FindInstanceOF
       <$> reify (MetaV m [])
@@ -894,6 +895,7 @@ getSolvedInteractionPoints all norm = concat <$> do
           OpenInstance{}                 -> unsol
           BlockedConst{}                 -> unsol
           PostponedTypeCheckingProblem{} -> unsol
+          DeferredError{}                -> unsol
 
 typeOfMetaMI :: Rewrite -> MetaId -> TCM (OutputConstraint Expr NamedMeta)
 typeOfMetaMI norm mi =
@@ -951,6 +953,7 @@ typesOfHiddenMetas norm = liftTCM $ do
       M.InstV{} -> __IMPOSSIBLE__
       M.Open    -> x `notElem` is
       M.OpenInstance -> x `notElem` is  -- OR: True !?
+      M.DeferredError{} -> False
       M.BlockedConst{} -> False
       M.PostponedTypeCheckingProblem{} -> False
 

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -464,6 +464,7 @@ warningHighlighting' b w = case tcWarning w of
   SafeFlagNoUniverseCheck               -> errorWarningHighlighting w
   InfectiveImport{}                     -> errorWarningHighlighting w
   CoInfectiveImport{}                   -> errorWarningHighlighting w
+  DeferredTypeError{}                   -> errorWarningHighlighting w
   WithoutKFlagPrimEraseEquality -> mempty
   DeprecationWarning{}       -> mempty
   UserWarning{}              -> mempty
@@ -629,9 +630,7 @@ computeUnsolvedMetaWarnings = do
   --   * there is always at least one proper meta responsible for the blocking
   --   * in many cases the blocked term covers the highlighting for this meta
   --   * for the same reason we skip metas with a twin, since the twin will be blocked.
-  let notBlocked m = not <$> isBlockedTerm m
-  let notHasTwin m = not <$> hasTwinMeta m
-  ms <- filterM notHasTwin =<< filterM notBlocked =<< getOpenMetas
+  ms <- filterM isActionableMeta =<< getOpenMetas
 
   let extend = map (rToR . P.continuousPerLine)
 

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -160,6 +160,7 @@ errorWarnings = Set.fromList
   , RewriteMaybeNonConfluent_
   , RewriteAmbiguousRules_
   , RewriteMissingRule_
+  , DeferredTypeError_
   ]
 
 allWarnings :: Set WarningName
@@ -275,6 +276,7 @@ data WarningName
   | UserWarning_
   | WithoutKFlagPrimEraseEquality_
   | WrongInstanceDeclaration_
+  | DeferredTypeError_
   -- Checking consistency of options
   | CoInfectiveImport_
   | InfectiveImport_
@@ -448,6 +450,7 @@ warningNameDescription = \case
   UserWarning_                     -> "User-defined warning added using one of the 'WARNING_ON_*' pragmas."
   WithoutKFlagPrimEraseEquality_   -> "`primEraseEquality' usages with the without-K flags."
   WrongInstanceDeclaration_        -> "Instances that do not adhere to the required format."
+  DeferredTypeError_               -> "A type error happened, but it was deferred."
   -- Checking consistency of options
   CoInfectiveImport_               -> "Importing a file not using e.g. `--safe'  from one which does."
   InfectiveImport_                 -> "Importing a file using e.g. `--cubical' into one which doesn't."

--- a/src/full/Agda/Termination/RecCheck.hs
+++ b/src/full/Agda/Termination/RecCheck.hs
@@ -167,4 +167,5 @@ anyDefs include a = do
   inst Open                           = __IMPOSSIBLE__
   inst OpenInstance                   = __IMPOSSIBLE__
   inst BlockedConst{}                 = __IMPOSSIBLE__
+  inst DeferredError{}                = __IMPOSSIBLE__
   inst PostponedTypeCheckingProblem{} = __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -284,6 +284,7 @@ solveConstraint_ (UnBlock m)                =   -- alwaysUnblock since these hav
       -- Open (whatever that means)
       Open -> __IMPOSSIBLE__
       OpenInstance -> __IMPOSSIBLE__
+      DeferredError -> __IMPOSSIBLE__
 solveConstraint_ (FindInstance m cands) = findInstance m cands
 solveConstraint_ (CheckFunDef d i q cs _err) = withoutCache $
   -- re #3498: checking a fundef would normally be cached, but here it's

--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -133,6 +133,7 @@ theInstantiation mv = case mvInstantiation mv of
   Open{}                         -> __IMPOSSIBLE__
   OpenInstance{}                 -> __IMPOSSIBLE__
   BlockedConst{}                 -> __IMPOSSIBLE__
+  DeferredError{}                -> __IMPOSSIBLE__
   PostponedTypeCheckingProblem{} -> __IMPOSSIBLE__
 
 -- | Converts from 'MetaVariable' to 'RemoteMetaVariable'.

--- a/src/full/Agda/TypeChecking/Errors.hs-boot
+++ b/src/full/Agda/TypeChecking/Errors.hs-boot
@@ -5,9 +5,12 @@ import Agda.Syntax.Common
 
 import Agda.TypeChecking.Monad.Base
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug (MonadDebug)
+import {-# SOURCE #-} Agda.TypeChecking.Pretty (PrettyTCM)
 
 -- Misplaced SPECIALISE pragma:
 -- {-# SPECIALIZE prettyError :: TCErr -> TCM String #-}
 prettyError :: MonadTCM tcm => TCErr -> tcm String
 
 topLevelModuleDropper :: (MonadDebug m, MonadTCEnv m, ReadTCState m) => m (QName -> QName)
+
+instance PrettyTCM TypeError

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -465,7 +465,7 @@ checkCandidates m t cands =
       k
 
     checkCandidateForMeta :: MetaId -> Type -> Candidate -> TCM YesNo
-    checkCandidateForMeta m t (Candidate q term t' _) = checkDepth term t' $ do
+    checkCandidateForMeta m t (Candidate q term t' _) = disallowRecovery $ checkDepth term t' $ do
       -- Andreas, 2015-02-07: New metas should be created with range of the
       -- current instance meta, thus, we set the range.
       mv <- lookupLocalMeta m

--- a/src/full/Agda/TypeChecking/Monad/Pure.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Pure.hs-boot
@@ -9,7 +9,7 @@ import Control.Monad.Writer ( WriterT )
 import Agda.TypeChecking.Monad.Base
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Builtin
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Context
-import Agda.TypeChecking.Monad.Debug
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Signature
 
 class

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
@@ -12,7 +12,7 @@ import Agda.TypeChecking.Monad.Base
   ( TCM, ReadTCState, HasOptions, MonadTCEnv
   , Definition, RewriteRules
   )
-import Agda.TypeChecking.Monad.Debug (MonadDebug)
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug (MonadDebug)
 
 import Agda.Utils.Pretty (prettyShow)
 

--- a/src/full/Agda/TypeChecking/Pretty.hs-boot
+++ b/src/full/Agda/TypeChecking/Pretty.hs-boot
@@ -13,7 +13,7 @@ import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad.Base
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Builtin
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Context (MonadAddContext)
-import Agda.TypeChecking.Monad.Debug (MonadDebug)
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug (MonadDebug)
 import {-# SOURCE #-} Agda.TypeChecking.Monad.MetaVars (MonadInteractionPoints)
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Pure (PureTCM)
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Signature (HasConstInfo)

--- a/src/full/Agda/TypeChecking/Pretty/Constraint.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Constraint.hs
@@ -102,6 +102,7 @@ instance PrettyTCM Constraint where
                 prettyCmp ":=" m p
               Open{}  -> __IMPOSSIBLE__
               OpenInstance{} -> __IMPOSSIBLE__
+              DeferredError{} -> __IMPOSSIBLE__
               InstV{} -> empty
               -- Andreas, 2017-01-11, issue #2637:
               -- The size solver instantiates some metas with infinity

--- a/src/full/Agda/TypeChecking/Recover.hs
+++ b/src/full/Agda/TypeChecking/Recover.hs
@@ -1,0 +1,78 @@
+-- | Implements recovery from type errors.
+module Agda.TypeChecking.Recover where
+
+import Control.Monad.Except
+
+import qualified Data.Set as Set
+
+import Agda.Syntax.Position
+import Agda.Syntax.Internal
+
+import Agda.TypeChecking.Constraints
+import Agda.TypeChecking.Substitute
+import Agda.TypeChecking.Warnings
+import Agda.TypeChecking.Pretty
+import Agda.TypeChecking.Errors
+import Agda.TypeChecking.Monad
+
+import Agda.Utils.Permutation
+import Agda.Utils.Monad
+import Agda.Utils.Size
+import Agda.Utils.Lens
+
+-- import GHC.Stack (CallStack)
+
+deferCheckingError :: Type -> TCM Term -> TCM Term
+deferCheckingError ty continue = ifM (asksTC envRecoveryAllowed) recover continue where
+  recover = continue `catchError` \case
+    TypeError loc state err -> do
+      reportSDoc "tc.error.defer" 20 $ vcat
+        [ "Deferring type error:" $$ prettyTCM (TypeError loc state err)
+        , "Current task:" $$ (text . show =<< asksTC envCurrentTask)
+        ]
+
+      setTCLens stTCWarnings (state ^. stTCWarnings)
+
+      printed <- prettyTCM (TypeError loc state err)
+      addWarning TCWarning
+        { tcWarningLocation       = loc
+        , tcWarningRange          = envRange $ clEnv err
+        , tcWarning               = DeferredTypeError loc state err
+        , tcWarningPrintedWarning = printed
+        , tcWarningCached         = True
+        }
+      asksTC envCurrentTask >>=
+        modifyTCLens' stFailedTasks . Set.insert
+
+      -- Create the metavariable standing for the expression that failed.
+      -- Note: the context for the meta is not the context of the type
+      -- error; it is the context of the type-checking computation. The
+      -- type error may have happened in a different context, e.g. from
+      -- the conversion checker introducing a lambda.
+      newDeferralToken ty
+    e -> throwError e
+
+newDeferralToken :: Type -> TCM Term
+newDeferralToken ty = do
+  vs  <- getContextArgs
+  tel <- getContextTelescope
+  i <- createMetaInfo' DontRunMetaOccursCheck
+  m <- newMeta' DeferredError Instantiable i normalMetaPriority (idP (size tel))
+      $ HasType () CmpLeq $ telePi_ tel ty
+  let token = MetaV m $ map Apply vs
+  reportSDoc "tc.error.defer" 20 $ "Deferral token:" <+> prettyTCM token
+  pure token
+
+inNewTask :: TCM a -> TCM a
+inNewTask cont = do
+  tid <- fresh
+  localTC (\e -> e { envCurrentTask = tid }) cont
+
+-- TODO: Use the current task instead? What if a parent task failed?
+hasDeferredErrors :: TCM Bool
+hasDeferredErrors = do
+  warns <- useTC stTCWarnings
+  let
+    is TCWarning { tcWarning = DeferredTypeError{} } = True
+    is _ = False
+  pure $ any is warns

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -207,6 +207,8 @@ instance Instantiate Term where
 
          Open -> return t
 
+         DeferredError -> return t
+
          OpenInstance -> return t
 
          BlockedConst u

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -1000,6 +1000,7 @@ reduceTm rEnv bEnv !constInfo normalisation =
             Just Open{}                         -> __IMPOSSIBLE__
             Just OpenInstance{}                 -> __IMPOSSIBLE__
             Just BlockedConst{}                 -> __IMPOSSIBLE__
+            Just DeferredError{}                -> __IMPOSSIBLE__
             Just PostponedTypeCheckingProblem{} -> __IMPOSSIBLE__
 
         -- Case: unsupported. These terms are not handled by the abstract machine, so we fall back

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -787,9 +787,9 @@ bindBuiltinInfo (BuiltinInfo s d) e = do
 
       BuiltinDataCons t -> do
 
-        let name (Lam h b)  = name (absBody b)
-            name (Con c ci _) = Con c ci []
-            name _          = __IMPOSSIBLE__
+        let name (Lam h b)    = name (absBody b)
+            name (Con c ci _) = pure $ Con c ci []
+            name _            = typeError $ BuiltinMustBeConstructor s e
 
         v0 <- checkExpr e =<< t
 
@@ -797,7 +797,7 @@ bindBuiltinInfo (BuiltinInfo s d) e = do
           A.Con{} -> return ()
           _       -> typeError $ BuiltinMustBeConstructor s e
 
-        let v@(Con h _ []) = name v0
+        v@(Con h _ []) <- name v0
 
         bindBuiltinName s v
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -63,6 +63,7 @@ import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Unquote
 import Agda.TypeChecking.Warnings
+import Agda.TypeChecking.Recover
 
 import {-# SOURCE #-} Agda.TypeChecking.Empty ( ensureEmptyType )
 import {-# SOURCE #-} Agda.TypeChecking.Rules.Def (checkFunDef', useTerPragma)
@@ -1130,7 +1131,7 @@ checkExpr' cmp e t =
   reportResult "tc.term.expr.top" 15 (\ v -> vcat
                                               [ "checkExpr" <?> fsep [ prettyTCM e, ":", prettyTCM t ]
                                               , "  returns" <?> prettyTCM v ]) $
-  traceCall (CheckExprCall cmp e t) $ localScope $ doExpandLast $ unfoldInlined =<< do
+  traceCall (CheckExprCall cmp e t) $ deferCheckingError t $ localScope $ doExpandLast $ unfoldInlined =<< do
     reportSDoc "tc.term.expr.top" 15 $
         "Checking" <+> sep
           [ fsep [ prettyTCM e, ":", prettyTCM t ]

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -52,6 +52,7 @@ instance EmbPrj Warning where
     SafeFlagNoCoverageCheck               -> __IMPOSSIBLE__
     SafeFlagInjective                     -> __IMPOSSIBLE__
     SafeFlagEta                           -> __IMPOSSIBLE__
+    DeferredTypeError{}                   -> __IMPOSSIBLE__
     DeprecationWarning a b c              -> icodeN 6 DeprecationWarning a b c
     NicifierIssue a                       -> icodeN 7 NicifierIssue a
     InversionDepthReached a               -> icodeN 8 InversionDepthReached a
@@ -429,6 +430,7 @@ instance EmbPrj WarningName where
     NotAffectedByOpaque_                         -> 98
     UnfoldTransparentName_                       -> 99
     UselessOpaque_                               -> 100
+    DeferredTypeError_                           -> 101
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -532,6 +534,7 @@ instance EmbPrj WarningName where
     98  -> return NotAffectedByOpaque_
     99  -> return UnfoldTransparentName_
     100 -> return UselessOpaque_
+    101 -> return DeferredTypeError_
     _   -> malformed
 
 

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -642,7 +642,7 @@ evalTCM v = do
     -- Don't catch Unquote errors!
     tcCatchError :: Term -> Term -> UnquoteM Term
     tcCatchError m h =
-      liftU2 (\ m1 m2 -> m1 `catchError` \ _ -> m2) (evalTCM m) (evalTCM h)
+      liftU2 (\ m1 m2 -> disallowRecovery m1 `catchError` \ _ -> m2) (evalTCM m) (evalTCM h)
 
     tcAskLens :: ToTerm a => Lens' TCEnv a -> UnquoteM Term
     tcAskLens l = liftTCM (toTerm <*> asksTC (\ e -> e ^. l))

--- a/test/Fail/BuiltinSharpBadType.err
+++ b/test/Fail/BuiltinSharpBadType.err
@@ -1,3 +1,6 @@
 BuiltinSharpBadType.agda:10,22-24
 A !=< _A_17 → ⊥
 when checking that the expression ♯_ has type A → ∞ A
+BuiltinSharpBadType.agda:11,22-23
+A → ⊥ !=< A
+when checking that the expression ♭ has type ∞ A → A

--- a/test/Fail/CoinductiveBuiltinList.err
+++ b/test/Fail/CoinductiveBuiltinList.err
@@ -1,3 +1,6 @@
 CoinductiveBuiltinList.agda:11,18-22
 List A !=< ∞ (List A)
 when checking that the expression _∷_ has type A → List A → List A
+CoinductiveBuiltinList.agda:11,1-26
+_∷_ must be a constructor in the binding to builtin CONS
+when checking the pragma BUILTIN LIST List

--- a/test/Fail/CoinductiveBuiltinNatural.err
+++ b/test/Fail/CoinductiveBuiltinNatural.err
@@ -1,3 +1,6 @@
 CoinductiveBuiltinNatural.agda:11,21-22
 ℕ !=< ∞ ℕ
 when checking that the expression suc has type ℕ → ℕ
+CoinductiveBuiltinNatural.agda:11,1-29
+suc must be a constructor in the binding to builtin SUC
+when checking the pragma BUILTIN NATURAL ℕ

--- a/test/Fail/ConstructorHeadedDivergenceIn2-2-10.err
+++ b/test/Fail/ConstructorHeadedDivergenceIn2-2-10.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   ℕ × f n =< f _14 (blocked on _14)
 Unsolved metas at the following locations:
   ConstructorHeadedDivergenceIn2-2-10.agda:27,5-6
-  ConstructorHeadedDivergenceIn2-2-10.agda:30,8-20

--- a/test/Fail/ConstructorHeadedPointlessForRecordPatterns.err
+++ b/test/Fail/ConstructorHeadedPointlessForRecordPatterns.err
@@ -1,6 +1,11 @@
 checkFunDef': checking injectivity...
 Injectivity of ConstructorHeadedPointlessForRecordPatterns.swap would be pointless.
 Injectivity of ConstructorHeadedPointlessForRecordPatterns.swap would be pointless.
+checkFunDef': checking injectivity...
+Injectivity of ConstructorHeadedPointlessForRecordPatterns.CRASH would be pointless.
+Injectivity of ConstructorHeadedPointlessForRecordPatterns.CRASH would be pointless.
 ConstructorHeadedPointlessForRecordPatterns.agda:27,9-12
 Set₁ != Set
 when checking that the expression Set has type Set
+Unsolved metas at the following locations:
+  ConstructorHeadedPointlessForRecordPatterns.agda:12,19-20

--- a/test/Fail/ConstructorRewriteConfluenceFail.err
+++ b/test/Fail/ConstructorRewriteConfluenceFail.err
@@ -1,14 +1,14 @@
 ConstructorRewriteConfluenceFail.agda:31,1-10
-Global confluence check failed: count-suc (pred (suc x)) can be
-rewritten to either count-suc (suc x) or count-suc x.
-Possible fix: add a rewrite rule with left-hand side
-count-suc (pred (suc x)) to resolve the ambiguity.
-when checking confluence of the rewrite rule
-ConstructorRewriteConfluenceFail.count-suc-clause2 with pred-suc
-ConstructorRewriteConfluenceFail.agda:31,1-10
 Global confluence check failed: count-suc (suc (pred x)) can be
 rewritten to either 1 +ℕ count-suc (pred x) or count-suc x.
 Possible fix: add a rewrite rule with left-hand side
 count-suc (suc (pred x)) to resolve the ambiguity.
 when checking confluence of the rewrite rule
 ConstructorRewriteConfluenceFail.count-suc-clause3 with suc-pred
+ConstructorRewriteConfluenceFail.agda:31,1-10
+Global confluence check failed: count-suc (pred (suc x)) can be
+rewritten to either count-suc (suc x) or count-suc x.
+Possible fix: add a rewrite rule with left-hand side
+count-suc (pred (suc x)) to resolve the ambiguity.
+when checking confluence of the rewrite rule
+ConstructorRewriteConfluenceFail.count-suc-clause2 with pred-suc

--- a/test/Fail/Cumulativity-bad-meta-solution.err
+++ b/test/Fail/Cumulativity-bad-meta-solution.err
@@ -2,3 +2,5 @@ Cumulativity-bad-meta-solution.agda:7,18-19
 Set₁ is not less or equal than Set
 when checking that the solution X of metavariable _X_3 has the
 expected type Set
+Unsolved metas at the following locations:
+  Cumulativity-bad-meta-solution.agda:7,18-19

--- a/test/Fail/Cumulativity-bad-meta-solution2.err
+++ b/test/Fail/Cumulativity-bad-meta-solution2.err
@@ -2,3 +2,5 @@ Cumulativity-bad-meta-solution2.agda:7,7-8
 Set₁ is not less or equal than Set
 when checking that the solution Set of metavariable _3 has the
 expected type Set
+Unsolved metas at the following locations:
+  Cumulativity-bad-meta-solution2.agda:7,7-8

--- a/test/Fail/DontPrune.err
+++ b/test/Fail/DontPrune.err
@@ -3,5 +3,3 @@ Failed to solve the following constraints:
   _8 (A = A) true a b = a : A (blocked on _8)
 Unsolved metas at the following locations:
   DontPrune.agda:12,12-13
-  DontPrune.agda:15,14-18
-  DontPrune.agda:15,21-25

--- a/test/Fail/Erased-cubical-Glue.err
+++ b/test/Fail/Erased-cubical-Glue.err
@@ -1,3 +1,6 @@
 Erased-cubical-Glue.agda:14,3-11
 Identifier primGlue is declared erased, so it cannot be used here
 when checking that the expression primGlue A B f has type _7
+Unsolved metas at the following locations:
+  Erased-cubical-Glue.agda:14,3-17
+  Erased-cubical-Glue.agda:12,3-14,17

--- a/test/Fail/Erased-cubical-Import-without---erasure.err
+++ b/test/Fail/Erased-cubical-Import-without---erasure.err
@@ -2,3 +2,9 @@ Erased-cubical-Import-without---erasure.agda:11,21-26
 The name ∥_∥ which was defined in Cubical Agda can only be used in
 Erased Cubical Agda if the option --erasure is used
 when checking that the expression ∥ A ∥ has type _1
+Erased-cubical-Import-without---erasure.agda:12,5-8
+The name ∣_∣ which was defined in Cubical Agda can only be used in
+Erased Cubical Agda if the option --erasure is used
+when checking that the expression ∣_∣ has type A → _2
+Unsolved metas at the following locations:
+  Erased-cubical-Import-without---erasure.agda:11,21-26

--- a/test/Fail/ExistentialsProjections.err
+++ b/test/Fail/ExistentialsProjections.err
@@ -1,3 +1,10 @@
 ExistentialsProjections.agda:12,18-26
 Variable fwitness is declared irrelevant, so it cannot be used here
 when checking that the expression fwitness has type A
+ExistentialsProjections.agda:19,50-57
+Identifier witness is declared irrelevant, so it cannot be used
+here
+when checking that the expression witness x has type A
+Failed to solve the following constraints:
+  _5 (A = A) (P = P) (fwitness = _) = _19 (x = (exists _ p)) : A
+    (blocked on any(_5, _19))

--- a/test/Fail/FrozenMVar.err
+++ b/test/Fail/FrozenMVar.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _10 = suc zero : ℕ (blocked on _10)
 Unsolved metas at the following locations:
   FrozenMVar.agda:14,7-8
-  FrozenMVar.agda:17,9-13

--- a/test/Fail/FrozenMVar2.err
+++ b/test/Fail/FrozenMVar2.err
@@ -10,4 +10,3 @@ Failed to solve the following constraints:
   _A_28 =< ℕ (blocked on _A_28)
 Unsolved metas at the following locations:
   FrozenMVar2.agda:20,1-28
-  FrozenMVar2.agda:32,23-26

--- a/test/Fail/FunSort-SSet-X-PropOmega.err
+++ b/test/Fail/FunSort-SSet-X-PropOmega.err
@@ -1,3 +1,5 @@
 FunSort-SSet-X-PropOmega.agda:6,13-18
 Propω != funSort SSet _4
 when checking that the expression A → B has type Propω
+Unsolved metas at the following locations:
+  FunSort-SSet-X-PropOmega.agda:5,12-13

--- a/test/Fail/FunSort-SSet-X-SetOmega.err
+++ b/test/Fail/FunSort-SSet-X-SetOmega.err
@@ -1,3 +1,5 @@
 FunSort-SSet-X-SetOmega.agda:6,13-18
 Setω != funSort SSet _4
 when checking that the expression A → B has type Setω
+Unsolved metas at the following locations:
+  FunSort-SSet-X-SetOmega.agda:5,12-13

--- a/test/Fail/FunSort-X-Prop-SetOmega.err
+++ b/test/Fail/FunSort-X-Prop-SetOmega.err
@@ -1,3 +1,5 @@
 FunSort-X-Prop-SetOmega.agda:6,13-18
 Setω != funSort _3 Prop
 when checking that the expression A → B has type Setω
+Unsolved metas at the following locations:
+  FunSort-X-Prop-SetOmega.agda:5,5-6

--- a/test/Fail/FunSort-X-SSet-PropOmega.err
+++ b/test/Fail/FunSort-X-SSet-PropOmega.err
@@ -1,3 +1,5 @@
 FunSort-X-SSet-PropOmega.agda:6,13-18
 Propω != funSort _3 SSet
 when checking that the expression A → B has type Propω
+Unsolved metas at the following locations:
+  FunSort-X-SSet-PropOmega.agda:5,5-6

--- a/test/Fail/FunSort-X-SSet-SetOmega.err
+++ b/test/Fail/FunSort-X-SSet-SetOmega.err
@@ -1,3 +1,5 @@
 FunSort-X-SSet-SetOmega.agda:6,13-18
 Setω != funSort _3 SSet
 when checking that the expression A → B has type Setω
+Unsolved metas at the following locations:
+  FunSort-X-SSet-SetOmega.agda:5,5-6

--- a/test/Fail/FunSort-X-SSetOmega-PropOmega.err
+++ b/test/Fail/FunSort-X-SSetOmega-PropOmega.err
@@ -1,3 +1,5 @@
 FunSort-X-SSetOmega-PropOmega.agda:6,13-18
 Propω != funSort _3 SSetω
 when checking that the expression A → B has type Propω
+Unsolved metas at the following locations:
+  FunSort-X-SSetOmega-PropOmega.agda:5,5-6

--- a/test/Fail/FunSort-X-SSetOmega-SetOmega.err
+++ b/test/Fail/FunSort-X-SSetOmega-SetOmega.err
@@ -1,3 +1,5 @@
 FunSort-X-SSetOmega-SetOmega.agda:6,13-18
 Setω != funSort _3 SSetω
 when checking that the expression A → B has type Setω
+Unsolved metas at the following locations:
+  FunSort-X-SSetOmega-SetOmega.agda:5,5-6

--- a/test/Fail/FunSort-X-Set-Prop.err
+++ b/test/Fail/FunSort-X-Set-Prop.err
@@ -1,3 +1,5 @@
 FunSort-X-Set-Prop.agda:6,13-18
 Prop != Set _5
 when checking that the expression A → B has type Set
+Unsolved metas at the following locations:
+  FunSort-X-Set-Prop.agda:5,5-6

--- a/test/Fail/FunSort-X-Set-PropOmega.err
+++ b/test/Fail/FunSort-X-Set-PropOmega.err
@@ -1,3 +1,5 @@
 FunSort-X-Set-PropOmega.agda:6,13-18
 Propω != funSort _3 Set
 when checking that the expression A → B has type Propω
+Unsolved metas at the following locations:
+  FunSort-X-Set-PropOmega.agda:5,5-6

--- a/test/Fail/FunSort-X-SetOmega-PropOmega.err
+++ b/test/Fail/FunSort-X-SetOmega-PropOmega.err
@@ -1,3 +1,5 @@
 FunSort-X-SetOmega-PropOmega.agda:6,13-18
 Propω != funSort _3 Setω
 when checking that the expression A → B has type Propω
+Unsolved metas at the following locations:
+  FunSort-X-SetOmega-PropOmega.agda:5,5-6

--- a/test/Fail/IUnivNoHComp.err
+++ b/test/Fail/IUnivNoHComp.err
@@ -1,4 +1,8 @@
 IUnivNoHComp.agda:4,12-21
+IUniv != Set _ℓ_3
+when checking that the solution J of metavariable _A_4 has the
+expected type Set _ℓ_3
+IUnivNoHComp.agda:4,12-21
 IUniv != (Set _ℓ_3)
 when checking that the solution J of metavariable _A_4 has the
 expected type Set _ℓ_3

--- a/test/Fail/ImpossibleVerboseReduceM.err
+++ b/test/Fail/ImpossibleVerboseReduceM.err
@@ -1,5 +1,4 @@
 ret > ExitFailure 154
-out > ReduceM should also print this debug message.
 out > An internal error has occurred. Please report this as a bug.
 out > Location of the error: __IMPOSSIBLE_VERBOSE__, called at src/full/Agda/ImpossibleTest.hs:«line»:«col» in «Agda-package»:Agda.ImpossibleTest
 out >   impossibleTestReduceM, called at src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs:«line»:«col» in «Agda-package»:Agda.Syntax.Translation.ConcreteToAbstract

--- a/test/Fail/InferRecordTypes-1.err
+++ b/test/Fail/InferRecordTypes-1.err
@@ -1,3 +1,5 @@
 InferRecordTypes-1.agda:5,7-17
 There are no records in scope
 when checking that the expression record {} has type _1
+Unsolved metas at the following locations:
+  InferRecordTypes-1.agda:5,1-4

--- a/test/Fail/InferRecordTypes-2.err
+++ b/test/Fail/InferRecordTypes-2.err
@@ -1,3 +1,5 @@
 InferRecordTypes-2.agda:10,7-26
 There is no known record with the field x₃
 when checking that the expression record { x₃ = Set } has type _1
+Unsolved metas at the following locations:
+  InferRecordTypes-2.agda:10,1-4

--- a/test/Fail/InferRecordTypes-3.err
+++ b/test/Fail/InferRecordTypes-3.err
@@ -2,3 +2,5 @@ InferRecordTypes-3.agda:17,7-33
 There is no known record with the fields x₂ x₃
 when checking that the expression record { x₂ = A ; x₃ = A } has
 type _1
+Unsolved metas at the following locations:
+  InferRecordTypes-3.agda:17,1-4

--- a/test/Fail/InjectivityHITs.err
+++ b/test/Fail/InjectivityHITs.err
@@ -4,7 +4,5 @@ Failed to solve the following constraints:
 Unsolved metas at the following locations:
   InjectivityHITs.agda:34,7-8
   InjectivityHITs.agda:34,9-10
-  InjectivityHITs.agda:35,5-9
   InjectivityHITs.agda:49,7-8
   InjectivityHITs.agda:49,9-10
-  InjectivityHITs.agda:50,5-9

--- a/test/Fail/InstanceErrorMessageMultiple.err
+++ b/test/Fail/InstanceErrorMessageMultiple.err
@@ -7,4 +7,3 @@ Failed to solve the following constraints:
   (_r_30 Semiring.+ a) c = c +N a : Nat (blocked on _r_30)
 Unsolved metas at the following locations:
   InstanceErrorMessageMultiple.agda:32,16-17
-  InstanceErrorMessageMultiple.agda:32,22-26

--- a/test/Fail/IrrelevantFamilyIndex.err
+++ b/test/Fail/IrrelevantFamilyIndex.err
@@ -1,3 +1,7 @@
 IrrelevantFamilyIndex.agda:26,9-10
 Variable n is declared irrelevant, so it cannot be used here
 when checking that the expression n has type Nat
+IrrelevantFamilyIndex.agda:26,5-10
+suc _21 != n of type Nat
+when checking that the given dot pattern suc n₁ matches the
+inferred value n

--- a/test/Fail/IrrelevantFin.err
+++ b/test/Fail/IrrelevantFin.err
@@ -1,3 +1,9 @@
 IrrelevantFin.agda:10,33-34
 Variable n is declared irrelevant, so it cannot be used here
 when checking that the expression n has type Nat
+IrrelevantFin.agda:11,28-29
+Variable n is declared irrelevant, so it cannot be used here
+when checking that the expression n has type Nat
+IrrelevantFin.agda:11,42-43
+Variable n is declared irrelevant, so it cannot be used here
+when checking that the expression n has type Nat

--- a/test/Fail/IrrelevantLambda.err
+++ b/test/Fail/IrrelevantLambda.err
@@ -1,3 +1,5 @@
 IrrelevantLambda.agda:8,5-16
 Found a non-strict lambda where a irrelevant lambda was expected
 when checking that the expression λ .x → P x has type _2 → Set
+Unsolved metas at the following locations:
+  IrrelevantLambda.agda:7,5-6

--- a/test/Fail/IrrelevantLevelHurkens.err
+++ b/test/Fail/IrrelevantLevelHurkens.err
@@ -1,3 +1,20 @@
 IrrelevantLevelHurkens.agda:12,31-32
 Variable i is declared irrelevant, so it cannot be used here
 when checking that the expression i has type Level
+IrrelevantLevelHurkens.agda:18,23-24
+Variable i is declared irrelevant, so it cannot be used here
+when checking that the expression i has type Level
+IrrelevantLevelHurkens.agda:21,20-21
+Variable i is declared irrelevant, so it cannot be used here
+when checking that the expression i has type Level
+IrrelevantLevelHurkens.agda:22,22-23
+Variable i is declared irrelevant, so it cannot be used here
+when checking that the expression i has type Level
+Failed to solve the following constraints:
+  lsuc zero = _21 (blocked on _21)
+Unsolved metas at the following locations:
+  IrrelevantLevelHurkens.agda:21,11-12
+  IrrelevantLevelHurkens.agda:22,66-67
+  IrrelevantLevelHurkens.agda:41,6-7
+  IrrelevantLevelHurkens.agda:47,7-8
+  IrrelevantLevelHurkens.agda:50,5-6

--- a/test/Fail/IrrelevantModuleParameter.err
+++ b/test/Fail/IrrelevantModuleParameter.err
@@ -1,3 +1,5 @@
 IrrelevantModuleParameter.agda:4,7-8
 Variable A is declared irrelevant, so it cannot be used here
 when checking that the expression A has type _0
+Unsolved metas at the following locations:
+  IrrelevantModuleParameter.agda:4,7-8

--- a/test/Fail/Issue1003.err
+++ b/test/Fail/Issue1003.err
@@ -9,3 +9,11 @@ Issue1003.agda:10,38-44
 Instance search can only be used to find elements in a named type
 when checking that y is a valid argument to a function of type
 ⦃ T : Set ⦄ → T → Set
+Issue1003.agda:10,38-44
+Instance search can only be used to find elements in a named type
+when checking that y is a valid argument to a function of type
+⦃ T : Set ⦄ → T → Set
+Failed to solve the following constraints:
+  A =< _3 (y = y) (blocked on _3)
+Unsolved metas at the following locations:
+  Issue1003.agda:10,38-46

--- a/test/Fail/Issue118Comment9.err
+++ b/test/Fail/Issue118Comment9.err
@@ -4,5 +4,3 @@ Failed to solve the following constraints:
 Unsolved metas at the following locations:
   Issue118Comment9.agda:17,11-12
   Issue118Comment9.agda:20,11-12
-  Issue118Comment9.agda:25,16-19
-  Issue118Comment9.agda:28,15-24

--- a/test/Fail/Issue1209-4.err
+++ b/test/Fail/Issue1209-4.err
@@ -1,10 +1,10 @@
 Issue1209-4.agda:3,1-30
-Importing module Agda.Builtin.Size not using the --safe flag from a
-module which does.
+Importing module Agda.Builtin.Size using the --sized-types flag
+from a module which does not.
 when scope checking the declaration
   open import Agda.Builtin.Size
 Issue1209-4.agda:3,1-30
-Importing module Agda.Builtin.Size using the --sized-types flag
-from a module which does not.
+Importing module Agda.Builtin.Size not using the --safe flag from a
+module which does.
 when scope checking the declaration
   open import Agda.Builtin.Size

--- a/test/Fail/Issue1213.err
+++ b/test/Fail/Issue1213.err
@@ -1,3 +1,5 @@
 Issue1213.agda:23,8-10
 ⊤ !=< ⊥
 when checking that the expression tt has type IsZero (suc _15)
+Unsolved metas at the following locations:
+  Issue1213.agda:22,20-21

--- a/test/Fail/Issue1258-2.err
+++ b/test/Fail/Issue1258-2.err
@@ -3,3 +3,6 @@ Foo _28 != Bool of type Set
 when checking that the expression refl has type
 f (Bool × Wrap Nat) (true , wrap zero) ==
 f (Stuck × Stuck) (Beta , Beta)
+Unsolved metas at the following locations:
+  Issue1258-2.agda:36,9-10
+  Issue1258-2.agda:37,9-10

--- a/test/Fail/Issue1258.err
+++ b/test/Fail/Issue1258.err
@@ -3,5 +3,3 @@ Failed to solve the following constraints:
   Bool =< Foo _15 (blocked on _15)
 Unsolved metas at the following locations:
   Issue1258.agda:20,9-10
-  Issue1258.agda:21,8-13
-  Issue1258.agda:22,8-12

--- a/test/Fail/Issue1322.err
+++ b/test/Fail/Issue1322.err
@@ -1,16 +1,16 @@
-Issue1322.agda:16,5-38
-warning: -W[no]InstanceArgWithExplicitArg
-Instance arguments with explicit arguments are never considered by
-instance search, so having an instance argument
-⦃ p : n == zero → ⊥ ⦄ has no effect.
-when checking that the expression (n : ℕ) ⦃ p : n == zero → ⊥ ⦄ → ℕ
-is a type
 Issue1322.agda:19,5-38
 warning: -W[no]InstanceArgWithExplicitArg
 Instance arguments with explicit arguments are never considered by
 instance search, so having an instance argument
 ⦃ q : n == zero → ⊥ ⦄ has no effect.
 when checking that the expression (n : ℕ) ⦃ q : n == zero → ⊥ ⦄ → ℕ
+is a type
+Issue1322.agda:16,5-38
+warning: -W[no]InstanceArgWithExplicitArg
+Instance arguments with explicit arguments are never considered by
+instance search, so having an instance argument
+⦃ p : n == zero → ⊥ ⦄ has no effect.
+when checking that the expression (n : ℕ) ⦃ p : n == zero → ⊥ ⦄ → ℕ
 is a type
 Issue1322.agda:20,19-21
 Instance search cannot be used to find elements in an explicit

--- a/test/Fail/Issue1467.err
+++ b/test/Fail/Issue1467.err
@@ -1,3 +1,5 @@
 Issue1467.agda:25,14-19
 (D → D) × D != D → D of type Set
 when checking that the expression bar H has type P (foo H)
+Unsolved metas at the following locations:
+  Issue1467.agda:24,11-12

--- a/test/Fail/Issue1692.err
+++ b/test/Fail/Issue1692.err
@@ -1,4 +1,14 @@
+Issue1692.agda:30,12-29
+v₂ != v₁ of type Value k₂
+when checking that the expression anyOf t₁→t₂ t₂→t₁ has type
+k ∼ v ∈ node k₂ v₁ → k ∼ v ∈ node k₂ v₁
 Issue1692.agda:30,24-29
 v₁ != v₂ of type (Value k₂)
 when checking that the expression t₂→t₁ has type
 _k_51 ∼ _v_52 ∈ node k₂ v₁ → _k_51 ∼ _v_52 ∈ node k₂ v₂
+Issue1692.agda:60,24-29
+v₁ != v₂ of type (Value k₂)
+when checking that the expression t₂→t₁ has type
+_k_78 ∼ _v_79 ∈ node k₂ v₁ → _k_78 ∼ _v_79 ∈ node k₂ v₁
+Unsolved metas at the following locations:
+  Issue1692.agda:30,8-9

--- a/test/Fail/Issue1692a.err
+++ b/test/Fail/Issue1692a.err
@@ -1,3 +1,6 @@
 Issue1692a.agda:14,30-33
 a != b of type A
 when checking that the expression f b has type b ≡ b
+Issue1692a.agda:24,29-32
+a != b of type A
+when checking that the expression f b has type b ≡ b

--- a/test/Fail/Issue1815.err
+++ b/test/Fail/Issue1815.err
@@ -1,3 +1,6 @@
 Issue1815.agda:20,24-25
 Set !=< (R2 _A_11)
 when checking that the expression A has type R2 _A_11
+Unsolved metas at the following locations:
+  Issue1815.agda:20,18-23
+  Issue1815.agda:20,18-27

--- a/test/Fail/Issue1946-5.err
+++ b/test/Fail/Issue1946-5.err
@@ -1,3 +1,21 @@
 Issue1946-5.agda:16,16-23
 SizeUniv != Set
 when checking that the expression Size< i has type Set
+Issue1946-5.agda:20,1-22,24
+Termination checking failed for the following functions:
+  empty
+Problematic calls:
+  empty i x | force x
+  empty ∞ y
+    (at Issue1946-5.agda:22,15-20)
+Issue1946-5.agda:24,1-25,28
+Termination checking failed for the following functions:
+  inh
+Problematic calls:
+  λ { .force → _20 , inh }
+    (at Issue1946-5.agda:25,7-28)
+  inh
+    (at Issue1946-5.agda:25,23-26)
+Failed to solve the following constraints:
+  Size =< _8 (i = ∞) (blocked on _8)
+  _8 (i = i) =< Size (blocked on _8)

--- a/test/Fail/Issue1952.err
+++ b/test/Fail/Issue1952.err
@@ -170,28 +170,14 @@ Failed to solve the following constraints:
   Structure.Type C =< Structure.Type _r_51 (blocked on _r_51)
 Unsolved metas at the following locations:
   Issue1952.agda:29,25-26
-  Issue1952.agda:29,23-24
-  Issue1952.agda:29,27-28
   Issue1952.agda:29,39-40
-  Issue1952.agda:29,31-38
-  Issue1952.agda:29,41-48
   Issue1952.agda:31,41-42
   Issue1952.agda:31,31-32
-  Issue1952.agda:31,23-30
-  Issue1952.agda:31,33-40
-  Issue1952.agda:31,23-40
   Issue1952.agda:31,49-50
-  Issue1952.agda:31,47-48
-  Issue1952.agda:31,51-52
-  Issue1952.agda:31,47-52
-  Issue1952.agda:31,43-54
   Issue1952.agda:33,103-104
   Issue1952.agda:33,58-59
   Issue1952.agda:33,40-57
   Issue1952.agda:33,44-47
-  Issue1952.agda:33,53-54
-  Issue1952.agda:33,44-54
-  Issue1952.agda:33,40-57
   Issue1952.agda:33,66-67
   Issue1952.agda:33,60-65
   Issue1952.agda:33,97-98
@@ -201,15 +187,8 @@ Unsolved metas at the following locations:
   Issue1952.agda:33,81-82
   Issue1952.agda:33,78-80
   Issue1952.agda:33,83-85
-  Issue1952.agda:33,78-85
   Issue1952.agda:33,91-92
   Issue1952.agda:33,88-90
   Issue1952.agda:33,93-95
-  Issue1952.agda:33,88-95
-  Issue1952.agda:33,78-95
-  Issue1952.agda:33,69-95
   Issue1952.agda:33,99-101
-  Issue1952.agda:33,69-101
-  Issue1952.agda:33,60-101
-  Issue1952.agda:33,40-101
   Issue1952.agda:33,105-108

--- a/test/Fail/Issue1963I380.err
+++ b/test/Fail/Issue1963I380.err
@@ -5,3 +5,5 @@ when checking that the inferred type of an application
   Σ _A_35 _B_36
 matches the expected type
   z .proj₁ ≡ y .proj₁ → _proj₂_32 (y = y) (z = z) ≡ z .proj₂
+Unsolved metas at the following locations:
+  Issue1963I380.agda:11,11-12

--- a/test/Fail/Issue1967.err
+++ b/test/Fail/Issue1967.err
@@ -9,3 +9,5 @@ Issue1967.agda:5,22-23
 Set should be a function type, but it isn't
 when checking that A is a valid argument to a function of type
 ⦃ A = A₁ : Set ⦄ → Set
+Unsolved metas at the following locations:
+  Issue1967.agda:5,22-25

--- a/test/Fail/Issue199.err
+++ b/test/Fail/Issue199.err
@@ -12,4 +12,3 @@ Failed to solve the following constraints:
   D A =< _T_13 _A_12 (blocked on _T_13)
 Unsolved metas at the following locations:
   Issue199.agda:10,25-26
-  Issue199.agda:10,27-28

--- a/test/Fail/Issue2001.err
+++ b/test/Fail/Issue2001.err
@@ -3,3 +3,7 @@ Cannot eliminate type P x with constructor pattern {nat n} (did you
 supply too many arguments?)
 when checking the clause left hand side
 .extendedlambda0 {nat n}
+Failed to solve the following constraints:
+  _22 = p : P (bool true) (blocked on _22)
+Unsolved metas at the following locations:
+  Issue2001.agda:23,11-12

--- a/test/Fail/Issue2101.err
+++ b/test/Fail/Issue2101.err
@@ -1,3 +1,5 @@
 Issue2101.agda:27,31-32
 B !=< (Wrap _A_5)
 when checking that the expression b has type Wrap _A_5
+Unsolved metas at the following locations:
+  Issue2101.agda:27,16-17

--- a/test/Fail/Issue2120.err
+++ b/test/Fail/Issue2120.err
@@ -3,4 +3,3 @@ Failed to solve the following constraints:
 Unsolved metas at the following locations:
   Issue2120.agda:16,10-36
   Issue2120.agda:16,48-49
-  Issue2120.agda:16,50-54

--- a/test/Fail/Issue2170-unify.err
+++ b/test/Fail/Issue2170-unify.err
@@ -3,3 +3,7 @@ Issue2170-unify.agda:19,39-45
 one is a relevant function type and the other is an irrelevant
 function type
 when checking that the expression squash has type A → Squash A
+Failed to solve the following constraints:
+  _15 (p = (_14 a)) = a : A (blocked on _15)
+Unsolved metas at the following locations:
+  Issue2170-unify.agda:20,42-43

--- a/test/Fail/Issue2170.err
+++ b/test/Fail/Issue2170.err
@@ -3,3 +3,7 @@ Issue2170.agda:32,16-19
 is a relevant function type and the other is an irrelevant function
 type
 when checking that the expression irr has type Bool → Irr Bool
+Issue2170.agda:32,22-27
+(.(Irr _A_14) → _A_14) !=< (Irr Bool → Bool) because one is a
+relevant function type and the other is an irrelevant function type
+when checking that the expression unirr has type Irr Bool → Bool

--- a/test/Fail/Issue2269.err
+++ b/test/Fail/Issue2269.err
@@ -2,3 +2,5 @@ Issue2269.agda:13,8-10
 Instance search depth exhausted (max depth: 10) for candidate
 weaken : ⦃ _ = z : Eq ⊥ ⦄ → Eq _5
 when checking that the expression it has type Eq ⊥
+Unsolved metas at the following locations:
+  Issue2269.agda:10,40-41

--- a/test/Fail/Issue228.err
+++ b/test/Fail/Issue228.err
@@ -1,3 +1,5 @@
 Issue228.agda:19,5-18
 Set (lsuc lzero ⊔ ∞) != Set
 when checking that the expression Large × Small has type Set
+Failed to solve the following constraints:
+  Large × Small =< _15 (blocked on _15)

--- a/test/Fail/Issue2285.err
+++ b/test/Fail/Issue2285.err
@@ -4,4 +4,3 @@ Failed to solve the following constraints:
   _7 is a sort (blocked on _4)
 Unsolved metas at the following locations:
   Issue2285.agda:13,8-11
-  Issue2285.agda:14,29-32

--- a/test/Fail/Issue2301.err
+++ b/test/Fail/Issue2301.err
@@ -2,3 +2,34 @@ Issue2301.agda:12,11-15
 _A_8 → Box _A_8 !=< .A → Box A because one is a relevant function
 type and the other is an irrelevant function type
 when checking that the expression wrap has type .A → Box A
+Issue2301.agda:24,27-34
+._19 → Box _19 !=< Box _A_18
+when checking that the expression weird a has type Box _A_18
+Issue2301.agda:24,33-34
+Variable a is declared irrelevant, so it cannot be used here
+when checking that the expression a has type Set
+Issue2301.agda:40,23-25
+Bool !=< Set
+when checking that the expression tt has type Set
+Issue2301.agda:40,34-36
+Bool !=< Set
+when checking that the expression ff has type Set
+Issue2301.agda:46,18-20
+Bool !=< Set
+when checking that the expression tt has type Set
+Issue2301.agda:46,29-31
+Bool !=< Set
+when checking that the expression ff has type Set
+Issue2301.agda:47,19-24
+((A : Set) → .A → Box A) !=< (._A_47 → _B_48) because one is a
+relevant function type and the other is an irrelevant function type
+when checking that the expression weird has type ._A_47 → _B_48
+Failed to solve the following constraints:
+  Is empty: weird _31 ≡ _51 _ (blocked on any(_31, _y_50, _51))
+      [ at Issue2301.agda:41,15-17 ]
+  _8 (A = _43) _ = _8 (A = _31) _ : Box _43
+    (blocked on any(_8, _31, _43))
+  _43 = _31 : Set (blocked on any(_31, _43))
+  _31 = _43 (blocked on any(_31, _43))
+Unsolved metas at the following locations:
+  Issue2301.agda:47,12-18

--- a/test/Fail/Issue2350-constructor-parameter-ignored.err
+++ b/test/Fail/Issue2350-constructor-parameter-ignored.err
@@ -4,3 +4,9 @@ when checking that the inferred type of an application
   D _A_13
 matches the expected type
   D A
+Failed to solve the following constraints:
+  Resolve instance argument _a_12 : Agda.Primitive.Level
+  Candidates
+    ℓ' : Agda.Primitive.Level
+    ℓ : Agda.Primitive.Level
+    (stuck)

--- a/test/Fail/Issue2372.err
+++ b/test/Fail/Issue2372.err
@@ -7,3 +7,5 @@ when checking the definition of i
 Issue2372.agda:21,5-6
 No instance of type R was found in scope.
 when checking that the expression r has type Set
+Unsolved metas at the following locations:
+  Issue2372.agda:21,5-6

--- a/test/Fail/Issue2450.err
+++ b/test/Fail/Issue2450.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _20 true _ = g (Y _ y) : A (blocked on _20)
 Unsolved metas at the following locations:
   Issue2450.agda:14,7-8
-  Issue2450.agda:20,11-15

--- a/test/Fail/Issue2480-experimental-irrelevance.err
+++ b/test/Fail/Issue2480-experimental-irrelevance.err
@@ -3,3 +3,27 @@ tt != ff of type Bool
 when checking that the expression
 refl {x = ap {A = Bool→cBool} (λ f → f tt) p} has type
 ap (λ f → f tt) p ≡ ap (λ f → f ff) p
+Failed to solve the following constraints:
+  _41 (f = swap) (x = ff) (y = tt) = ff
+    : _A_39 (f = swap) (x = ff) (y = tt)
+    (blocked on _41)
+  _41 (f = swap) (x = ff) (y = tt) = tt
+    : _A_39 (f = swap) (x = ff) (y = tt)
+    (blocked on _41)
+  _A_39 (f = swap) (x = ff) (y = tt) = Bool
+    : Set (_a_38 (f = swap) (x = ff) (y = tt))
+    (blocked on _A_39)
+  _a_38 (f = swap) (x = ff) (y = tt) = Agda.Primitive.lzero
+    (blocked on _a_38)
+  Check definition of swap : Bool→cBool
+    stuck because
+      Issue2480-experimental-irrelevance.agda:31,6-8
+      Cannot eliminate type _33 with constructor pattern tt (did you
+      supply too many arguments?)
+      when checking the clause left hand side
+      swap tt
+    (blocked on _33)
+Unsolved metas at the following locations:
+  Issue2480-experimental-irrelevance.agda:22,16-17
+  Issue2480-experimental-irrelevance.agda:27,48-49
+  Issue2480-experimental-irrelevance.agda:27,44-47

--- a/test/Fail/Issue2480false.err
+++ b/test/Fail/Issue2480false.err
@@ -3,3 +3,27 @@ tt != ff of type Bool
 when checking that the expression
 refl {x = ap {A = Bool→cBool} (λ f → f tt) p} has type
 ap (λ f → f tt) p ≡ ap (λ f → f ff) p
+Failed to solve the following constraints:
+  _41 (f = swap) (x = ff) (y = tt) = ff
+    : _A_39 (f = swap) (x = ff) (y = tt)
+    (blocked on _41)
+  _41 (f = swap) (x = ff) (y = tt) = tt
+    : _A_39 (f = swap) (x = ff) (y = tt)
+    (blocked on _41)
+  _A_39 (f = swap) (x = ff) (y = tt) = Bool
+    : Set (_a_38 (f = swap) (x = ff) (y = tt))
+    (blocked on _A_39)
+  _a_38 (f = swap) (x = ff) (y = tt) = Agda.Primitive.lzero
+    (blocked on _a_38)
+  Check definition of swap : Bool→cBool
+    stuck because
+      Issue2480false.agda:29,6-8
+      Cannot eliminate type _33 with constructor pattern tt (did you
+      supply too many arguments?)
+      when checking the clause left hand side
+      swap tt
+    (blocked on _33)
+Unsolved metas at the following locations:
+  Issue2480false.agda:20,16-17
+  Issue2480false.agda:25,48-49
+  Issue2480false.agda:25,44-47

--- a/test/Fail/Issue2487.err
+++ b/test/Fail/Issue2487.err
@@ -1,10 +1,10 @@
 Issue2487/b.agda:5,1-24
-Importing module Issue2487.c not using the --safe flag from a
-module which does.
+Importing module Issue2487.c using the --cubical/--erased-cubical
+flag from a module which does not.
 when scope checking the declaration
   open import Issue2487.c
 Issue2487/b.agda:5,1-24
-Importing module Issue2487.c using the --cubical/--erased-cubical
-flag from a module which does not.
+Importing module Issue2487.c not using the --safe flag from a
+module which does.
 when scope checking the declaration
   open import Issue2487.c

--- a/test/Fail/Issue2640.err
+++ b/test/Fail/Issue2640.err
@@ -11,8 +11,4 @@ Failed to solve the following constraints:
   _b_21 = n : Bool (blocked on _b_21)
 Unsolved metas at the following locations:
   Issue2640.agda:20,22-23
-  Issue2640.agda:20,20-23
-  Issue2640.agda:27,26-28
-  Issue2640.agda:27,41-42
   Issue2640.agda:31,15-16
-  Issue2640.agda:31,17-21

--- a/test/Fail/Issue2650.err
+++ b/test/Fail/Issue2650.err
@@ -1,3 +1,5 @@
 Issue2650.agda:16,14-18
 a != b of type A
 when checking that the expression refl has type _10 i ≡ b
+Unsolved metas at the following locations:
+  Issue2650.agda:15,54-55

--- a/test/Fail/Issue2710.err
+++ b/test/Fail/Issue2710.err
@@ -1,6 +1,4 @@
 Failed to solve the following constraints:
   ?0 =< Loop → Loop (blocked on _3)
-Unsolved metas at the following locations:
-  Issue2710.agda:8,13-14
 Unsolved interaction metas at the following locations:
   Issue2710.agda:4,10-14

--- a/test/Fail/Issue2791.err
+++ b/test/Fail/Issue2791.err
@@ -2,3 +2,9 @@ Issue2791.agda:28,9-13
 Nat != Bool of type Set
 when checking that the expression refl has type
 F Bool true Nat ?Y ≡ F IFb ?X IFb ?X
+Failed to solve the following constraints:
+  _13 + 1 = 3 : Nat (blocked on _13)
+Unsolved metas at the following locations:
+  Issue2791.agda:17,8-9
+  Issue2791.agda:22,8-9
+  Issue2791.agda:25,8-9

--- a/test/Fail/Issue2944.err
+++ b/test/Fail/Issue2944.err
@@ -5,10 +5,6 @@ Failed to solve the following constraints:
   bla pred _23 = 0 : Nat (blocked on _23)
 Unsolved metas at the following locations:
   Issue2944.agda:38,17-18
-  Issue2944.agda:38,8-26
   Issue2944.agda:42,22-23
-  Issue2944.agda:42,13-28
   Issue2944.agda:52,20-21
-  Issue2944.agda:52,8-27
   Issue2944.agda:61,14-15
-  Issue2944.agda:61,9-25

--- a/test/Fail/Issue2993.err
+++ b/test/Fail/Issue2993.err
@@ -22,8 +22,6 @@ Failed to solve the following constraints:
   F B =< _F_180 _B_164 (blocked on _F_180)
 Unsolved metas at the following locations:
   Issue2993.agda:66,80-83
-  Issue2993.agda:66,84-85
-  Issue2993.agda:66,80-87
   Issue2993.agda:62,40-43
 Unsolved interaction metas at the following locations:
   Issue2993.agda:51,19-23

--- a/test/Fail/Issue3114.err
+++ b/test/Fail/Issue3114.err
@@ -1,6 +1,4 @@
 Failed to solve the following constraints:
   ?0 a x x₁ = ?0 b x x₁ : A (blocked on _9)
-Unsolved metas at the following locations:
-  Issue3114.agda:13,7-11
 Unsolved interaction metas at the following locations:
   Issue3114.agda:10,10-11

--- a/test/Fail/Issue3340.err
+++ b/test/Fail/Issue3340.err
@@ -2,6 +2,5 @@ Failed to solve the following constraints:
   f x = _47 : _f.P_46 x (blocked on _47)
   _f.P_46 y =< _f.P_46 x (blocked on _f.P_46)
 Unsolved metas at the following locations:
-  Issue3340.agda:12,22-25
   Issue3340.agda:12,16-17
-  Issue3340.agda:13,13-17
+  Issue3340.agda:12,22-25

--- a/test/Fail/Issue3404.err
+++ b/test/Fail/Issue3404.err
@@ -2,3 +2,6 @@ Issue3404.agda:42,22-26
 x != y of type Nat
 when checking that the expression refl has type
 primWord64FromNat x ≡ primWord64FromNat y
+Issue3404.agda:62,17-20
+1 != 0 of type Nat
+when checking that the expression 2^1 has type 2^ 0 ≡ 2

--- a/test/Fail/Issue3431.err
+++ b/test/Fail/Issue3431.err
@@ -6,6 +6,5 @@ Failed to solve the following constraints:
   _a_74 =< lsuc lzero (blocked on _a_74)
 Unsolved metas at the following locations:
   Issue3431.agda:49,24-28
-  Issue3431.agda:49,21-49
 Unsolved interaction metas at the following locations:
   Issue3431.agda:49,32-36

--- a/test/Fail/Issue3553.err
+++ b/test/Fail/Issue3553.err
@@ -2,3 +2,5 @@ Issue3553.agda:23,8-18
 The value of f is x₀
 when checking that the expression unquote (getValue (quote f)) has
 type _19
+Unsolved metas at the following locations:
+  Issue3553.agda:23,1-5

--- a/test/Fail/Issue3590-1.err
+++ b/test/Fail/Issue3590-1.err
@@ -1,4 +1,5 @@
 Termination checking mutual block MutId 0
+Termination checking mutual block MutId 3
 Issue3590-1.agda:23,7-10
 Set₁ != Set
 when checking that the expression Set has type Set

--- a/test/Fail/Issue3590-2.err
+++ b/test/Fail/Issue3590-2.err
@@ -1,4 +1,5 @@
 Termination checking mutual block MutId 0
+Termination checking mutual block MutId 3
 Issue3590-2.agda:27,7-10
 Set₁ != Set
 when checking that the expression Set has type Set

--- a/test/Fail/Issue3606.err
+++ b/test/Fail/Issue3606.err
@@ -1,6 +1,4 @@
 Failed to solve the following constraints:
   fst ?0 = fst x : A (blocked on _5)
-Unsolved metas at the following locations:
-  Issue3606.agda:14,10-18
 Unsolved interaction metas at the following locations:
   Issue3606.agda:14,14-18

--- a/test/Fail/Issue3676.err
+++ b/test/Fail/Issue3676.err
@@ -1,12 +1,3 @@
 Issue3676.agda:24,11-12
-No instance of type Monad _M_16 was found in scope.
-- F-monad was ruled out because
-  Issue3676.agda:24,11-12
-  Nat should be a function type, but it isn't
-  when checking that n is a valid argument to a function of type Nat
-- G-monad was ruled out because
-  Issue3676.agda:23,11-19
-  G (Σ Nat (λ _ → Nat)) !=< F _A_14
-  when checking that the expression return p has type F _A_14
-when checking that p is a valid argument to a function of type
-{M : Set → Set} ⦃ r : Monad M ⦄ {A : Set} → A → M A
+Nat should be a function type, but it isn't
+when checking that n is a valid argument to a function of type Nat

--- a/test/Fail/Issue3744.err
+++ b/test/Fail/Issue3744.err
@@ -1,3 +1,6 @@
 Issue3744.agda:18,12-13
 Constructor d is abstract, thus, not in scope here
 when checking that the expression d has type D
+Failed to solve the following constraints:
+  _8 = d′ : D (blocked on _8)
+  d = _8 : D (blocked on _8)

--- a/test/Fail/Issue376Fail.err
+++ b/test/Fail/Issue376Fail.err
@@ -4,3 +4,5 @@ since it contains the variable snd(z)
 which is not in scope of the metavariable
 when checking that the expression refl has type
 _7 (A = A) (B = B) (fst z) ≡ z
+Unsolved metas at the following locations:
+  Issue376Fail.agda:16,11-12

--- a/test/Fail/Issue380.err
+++ b/test/Fail/Issue380.err
@@ -5,3 +5,5 @@ when checking that the inferred type of an application
   Sigma _A_27 _B_28
 matches the expected type
   fst z == fst y → _snd_26 (y = y) (z = z) == snd z
+Unsolved metas at the following locations:
+  Issue380.agda:19,11-12

--- a/test/Fail/Issue3855b.err
+++ b/test/Fail/Issue3855b.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _x_8 = A : Set (blocked on _x_8)
 Unsolved metas at the following locations:
   Issue3855b.agda:15,34-35
-  Issue3855b.agda:15,29-35

--- a/test/Fail/Issue3855c.err
+++ b/test/Fail/Issue3855c.err
@@ -1,6 +1,4 @@
 Failed to solve the following constraints:
   b =< ?0 : Bool (blocked on _b_5)
-Unsolved metas at the following locations:
-  Issue3855c.agda:15,36-37
 Unsolved interaction metas at the following locations:
   Issue3855c.agda:15,29-34

--- a/test/Fail/Issue3855d.err
+++ b/test/Fail/Issue3855d.err
@@ -2,3 +2,5 @@ Issue3855d.agda:27,15-18
 (@0 erased₁ : _A_11) → Erased _A_11 !=< A → Erased A because one is
 a non-erased function type and the other is an erased function type
 when checking that the expression [_] has type A → Erased A
+Unsolved metas at the following locations:
+  Issue3855d.agda:28,15-16

--- a/test/Fail/Issue3882.err
+++ b/test/Fail/Issue3882.err
@@ -56,4 +56,3 @@ Failed to solve the following constraints:
 Unsolved metas at the following locations:
   Issue3882.agda:72,72-75
   Issue3882.agda:78,19-33
-  Issue3882.agda:78,19-34

--- a/test/Fail/Issue3966.err
+++ b/test/Fail/Issue3966.err
@@ -1,3 +1,703 @@
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷ʳ_,
+        which is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷ʳ_,
+        which is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷ʳ_,
+        which is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: it relies on higher-dimensional unification, which is not
+        yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
+Issue3966.agda:28,1-36,52
+warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: It relies on injectivity of the data constructor _∷_, which
+        is not yet supported
+
+when checking the definition of test
 Issue3966.agda:17,1-19,56
 warning: -W[no]UnsupportedIndexedMatch
 This clause uses pattern-matching features that are not yet
@@ -18,706 +718,6 @@ Reason: It relies on injectivity of the data constructor _∷_, which
         is not yet supported
 
 when checking the definition of ⊆-trans
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷ʳ_,
-        which is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷ʳ_,
-        which is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷ʳ_,
-        which is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: it relies on higher-dimensional unification, which is not
-        yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
-Issue3966.agda:28,1-36,52
-warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on injectivity of the data constructor _∷_, which
-        is not yet supported
-
-when checking the definition of test
 Issue3966.agda:34,1-43
 I'm not sure if there should be a case for the constructor refl,
 because I get stuck when trying to solve the following unification

--- a/test/Fail/Issue3982.err
+++ b/test/Fail/Issue3982.err
@@ -2,7 +2,6 @@ Failed to solve the following constraints:
   _105 (us = us) =< us ⊆ us (blocked on _105)
 Unsolved metas at the following locations:
   Issue3982.agda:30,8-12
-  Issue3982.agda:24,3-43
 Unsolved interaction metas at the following locations:
   Issue3982.agda:30,8-12
   Issue3982.agda:31,11-15

--- a/test/Fail/Issue3983.err
+++ b/test/Fail/Issue3983.err
@@ -15,12 +15,12 @@ Issue3983.agda:19,3-22
 Cannot use TERMINATING pragma with safe flag.
 Issue3983.agda:24,3-22
 Cannot use TERMINATING pragma with safe flag.
-Issue3983.agda:30,3-22
-Cannot use TERMINATING pragma with safe flag.
-Issue3983.agda:24,3-22
-Cannot use TERMINATING pragma with safe flag.
 when scope checking the declaration
   record I where
     {-# TERMINATING #-}
     i : ⊥
     i = f
+Issue3983.agda:24,3-22
+Cannot use TERMINATING pragma with safe flag.
+Issue3983.agda:30,3-22
+Cannot use TERMINATING pragma with safe flag.

--- a/test/Fail/Issue399.err
+++ b/test/Fail/Issue399.err
@@ -21,5 +21,3 @@ Unsolved metas at the following locations:
   Issue399.agda:9,30-33
   Issue399.agda:9,36-39
   Issue399.agda:30,32-37
-  Issue399.agda:31,37-49
-  Issue399.agda:32,38-50

--- a/test/Fail/Issue4118.err
+++ b/test/Fail/Issue4118.err
@@ -2,6 +2,5 @@ Failed to solve the following constraints:
   a _ab_20 = a ab : A (blocked on _ab_20)
 Unsolved metas at the following locations:
   Issue4118.agda:47,14-15
-  Issue4118.agda:47,12-15
 Unsolved interaction metas at the following locations:
   Issue4118.agda:37,35-39

--- a/test/Fail/Issue4120-loop.err
+++ b/test/Fail/Issue4120-loop.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _12 = f (g (loop y)) : A (blocked on _12)
 Unsolved metas at the following locations:
   Issue4120-loop.agda:17,7-8
-  Issue4120-loop.agda:20,12-16

--- a/test/Fail/Issue4134.err
+++ b/test/Fail/Issue4134.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _12 (x true) x₁ = f x x₁ : A (blocked on _12)
 Unsolved metas at the following locations:
   Issue4134.agda:12,7-8
-  Issue4134.agda:15,12-16

--- a/test/Fail/Issue4154.err
+++ b/test/Fail/Issue4154.err
@@ -1,13 +1,13 @@
-Issue4154.agda:14,1-31
-warning: -W[no]ClashesViaRenaming
-Name clashes introduced by 'renaming': B
-when scope checking the declaration
-  module N = M renaming (A to B)
 Issue4154.agda:15,1-25
 warning: -W[no]ClashesViaRenaming
 Name clashes introduced by 'renaming': B
 when scope checking the declaration
   open M renaming (A to B)
+Issue4154.agda:14,1-31
+warning: -W[no]ClashesViaRenaming
+Name clashes introduced by 'renaming': B
+when scope checking the declaration
+  module N = M renaming (A to B)
 Issue4154.agda:20,8-9
 Ambiguous name B. It could refer to any one of
   M.B bound at

--- a/test/Fail/Issue418.err
+++ b/test/Fail/Issue418.err
@@ -1,11 +1,11 @@
-Issue418.agda:30,3-10
-warning: -W[no]GenericWarning
-Missing type signature for abstract definition B.
-Types of abstract definitions are never inferred since this would
-leak information that should be abstract.
 Issue418.agda:33,3-10
 warning: -W[no]GenericWarning
 Missing type signature for abstract definition C.
+Types of abstract definitions are never inferred since this would
+leak information that should be abstract.
+Issue418.agda:30,3-10
+warning: -W[no]GenericWarning
+Missing type signature for abstract definition B.
 Types of abstract definitions are never inferred since this would
 leak information that should be abstract.
 Failed to solve the following constraints:
@@ -17,10 +17,6 @@ Failed to solve the following constraints:
   Set₁ =< _11 (blocked on _11)
 Unsolved metas at the following locations:
   Issue418.agda:13,18-19
-  Issue418.agda:14,14-18
   Issue418.agda:25,26-27
-  Issue418.agda:26,22-26
   Issue418.agda:30,3-4
-  Issue418.agda:30,7-10
   Issue418.agda:32,7-8
-  Issue418.agda:33,7-10

--- a/test/Fail/Issue4267a.err
+++ b/test/Fail/Issue4267a.err
@@ -1,3 +1,5 @@
 Issue4267a.agda:4,7-24
 There is no known record with the field f
 when checking that the expression record { f = Set } has type _1
+Unsolved metas at the following locations:
+  Issue4267a.agda:4,1-4

--- a/test/Fail/Issue4283.err
+++ b/test/Fail/Issue4283.err
@@ -2,5 +2,4 @@ Failed to solve the following constraints:
   _43 (p = refl) = refl : Id l A (w/e l A) (w/e l A) (blocked on _43)
 Unsolved metas at the following locations:
   Issue4283.agda:38,60-61
-  Issue4283.agda:38,14-110
   Issue4283.agda:41,12-13

--- a/test/Fail/Issue4390erasure.err
+++ b/test/Fail/Issue4390erasure.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _11 (f = (λ (@ω x₁) → f x₁)) x = f x : X (blocked on _11)
 Unsolved metas at the following locations:
   Issue4390erasure.agda:11,16-17
-  Issue4390erasure.agda:14,13-17

--- a/test/Fail/Issue4390flat.err
+++ b/test/Fail/Issue4390flat.err
@@ -2,3 +2,7 @@ Issue4390flat.agda:12,28-29
 (A → A) !=< (@♭ A → A) because one is a non-flat function type and
 the other is a flat function type
 when checking that the expression f has type @♭ A → A
+Failed to solve the following constraints:
+  _10 (f = _9) x = f x : A (blocked on _10)
+Unsolved metas at the following locations:
+  Issue4390flat.agda:10,9-10

--- a/test/Fail/Issue4390irrelevance.err
+++ b/test/Fail/Issue4390irrelevance.err
@@ -2,3 +2,7 @@ Issue4390irrelevance.agda:10,29-30
 (.A → A) !=< (A → A) because one is a relevant function type and
 the other is an irrelevant function type
 when checking that the expression f has type A → A
+Failed to solve the following constraints:
+  _10 (f = _9) _ = f _ : A (blocked on _10)
+Unsolved metas at the following locations:
+  Issue4390irrelevance.agda:8,9-10

--- a/test/Fail/Issue4401.err
+++ b/test/Fail/Issue4401.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _4 (f = f) (x = x) = f x : Set (blocked on _4)
 Unsolved metas at the following locations:
   Issue4401.agda:8,12-13
-  Issue4401.agda:11,14-18

--- a/test/Fail/Issue4481.err
+++ b/test/Fail/Issue4481.err
@@ -2,3 +2,5 @@ Issue4481.agda:25,14-15
 Unexpected implicit argument
 when checking that the expression λ {C = B} {A} → A has type
 {A B : Set} → Set
+Unsolved metas at the following locations:
+  Issue4481.agda:20,22-23

--- a/test/Fail/Issue4743-1.err
+++ b/test/Fail/Issue4743-1.err
@@ -4,3 +4,5 @@ Cannot instantiate the metavariable _7 to solution
 since (part of) the solution was created in an erased context
 when checking that the expression refl has type
 f ≡ (λ @0 { unit → unit })
+Unsolved metas at the following locations:
+  Issue4743-1.agda:13,7-8

--- a/test/Fail/Issue4743-2.err
+++ b/test/Fail/Issue4743-2.err
@@ -2,3 +2,5 @@ Issue4743-2.agda:28,8-12
 Cannot instantiate the metavariable _17 to solution Issue4743-2.A
 since (part of) the solution was created in an erased context
 when checking that the expression refl has type B ≡ Issue4743-2.A
+Unsolved metas at the following locations:
+  Issue4743-2.agda:25,7-8

--- a/test/Fail/Issue4743-3.err
+++ b/test/Fail/Issue4743-3.err
@@ -2,3 +2,5 @@ Issue4743-3.agda:15,7-11
 Cannot instantiate the metavariable _7 to solution Issue4743-3.♯-0
 since (part of) the solution was created in an erased context
 when checking that the expression refl has type x ≡ Issue4743-3.♯-0
+Unsolved metas at the following locations:
+  Issue4743-3.agda:12,7-8

--- a/test/Fail/Issue4743-4.err
+++ b/test/Fail/Issue4743-4.err
@@ -2,3 +2,5 @@ Issue4743-4.agda:15,7-11
 Cannot instantiate the metavariable _5 to solution (λ ()) x
 since (part of) the solution was created in an erased context
 when checking that the expression refl has type h ≡ (λ ())
+Unsolved metas at the following locations:
+  Issue4743-4.agda:12,7-8

--- a/test/Fail/Issue483.err
+++ b/test/Fail/Issue483.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _x_15 = resurrect _ : ⊥ (blocked on _x_15)
 Unsolved metas at the following locations:
   Issue483.agda:17,7-8
-  Issue483.agda:17,16-20

--- a/test/Fail/Issue483a.err
+++ b/test/Fail/Issue483a.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _10 _ = abort _ : A (blocked on _10)
 Unsolved metas at the following locations:
   Issue483a.agda:16,16-17
-  Issue483a.agda:18,10-14

--- a/test/Fail/Issue483b.err
+++ b/test/Fail/Issue483b.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _10 _ = f _ : A (blocked on _10)
 Unsolved metas at the following locations:
   Issue483b.agda:12,16-17
-  Issue483b.agda:14,10-14

--- a/test/Fail/Issue483c.err
+++ b/test/Fail/Issue483c.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _15 _ = refute _ : ⊥ (blocked on _15)
 Unsolved metas at the following locations:
   Issue483c.agda:20,9-10
-  Issue483c.agda:21,9-13

--- a/test/Fail/Issue485.err
+++ b/test/Fail/Issue485.err
@@ -2,3 +2,7 @@ Issue485.agda:6,12-13
 Set₁ != Set
 when checking that the solution Set of metavariable _A_2 has the
 expected type Set
+Issue485.agda:6,12-13
+Set₁ != Set
+when checking that the solution Set of metavariable _A_2 has the
+expected type Set

--- a/test/Fail/Issue5434-3.err
+++ b/test/Fail/Issue5434-3.err
@@ -2,3 +2,11 @@ Issue5434-3.agda:6,5-6
 (@0 A : Set) → A → D A is not usable at the required modality @ω
 when checking that the type (@0 A : Set) → A → D A of the
 constructor c fits in the sort Set₁ of the datatype.
+Failed to solve the following constraints:
+  _3 (A = A) =< Set₁ (blocked on _3)
+  Is usable at default modality: (@0 A : Set) →
+                                 _4 (A = A) → D (_6 (A = A))
+    (blocked on _4)
+Unsolved metas at the following locations:
+  Issue5434-3.agda:6,24-25
+  Issue5434-3.agda:6,30-31

--- a/test/Fail/Issue5434-4.err
+++ b/test/Fail/Issue5434-4.err
@@ -1,3 +1,9 @@
 Issue5434-4.agda:5,10-11
 (@0 A : Set) (x : A) → R is not usable at the required modality @ω
 when checking the definition of R
+Failed to solve the following constraints:
+  _2 (A = A) =< Set₁ (blocked on _2)
+  Is usable at default modality: (@0 A : Set) (x : _3 (A = A)) → R
+    (blocked on _3)
+Unsolved metas at the following locations:
+  Issue5434-4.agda:9,14-15

--- a/test/Fail/Issue543a.err
+++ b/test/Fail/Issue543a.err
@@ -1,3 +1,17 @@
 Issue543a.agda:34,50-54
 true != (unsquash _) of type Bool
 when checking that the expression refl has type true ≡ unsquash _
+Issue543a.agda:37,52-56
+(unsquash _) != false of type Bool
+when checking that the expression refl has type unsquash _ ≡ false
+Issue543a.agda:44,10-19
+Type bad1 !=< true ≡ _y_33
+when checking that the expression elem bad1 has type true ≡ _y_33
+Issue543a.agda:44,27-35
+(.(Squash _A_40) → _A_40) !=< (_A_38 → _B_39) because one is a
+relevant function type and the other is an irrelevant function type
+when checking that the expression unsquash has type _A_38 → _B_39
+Issue543a.agda:44,46-55
+Type bad2 !=< _40 (squash _) ≡ false
+when checking that the expression elem bad2 has type
+_40 (squash _) ≡ false

--- a/test/Fail/Issue551.err
+++ b/test/Fail/Issue551.err
@@ -1,3 +1,6 @@
 Issue551.agda:30,17-25
 No instance of type PackBool was found in scope.
 when checking that the expression implicit has type PackBool
+Failed to solve the following constraints:
+  unpack (_25 (x = _)) = false : Bool (blocked on _25)
+  unpack (_25 (x = _)) = true : Bool (blocked on _25)

--- a/test/Fail/Issue5531.err
+++ b/test/Fail/Issue5531.err
@@ -2,3 +2,7 @@ Issue5531.agda:50,23-31
 ap (λ z → Σ (_A_208 z) (B z)) _239 (ab _δ₀_236) (ab _δ₁_237) !=<
 Σ _A_232 _B_233
 when checking that the expression ap ab δ₂ has type Σ _A_232 _B_233
+Unsolved metas at the following locations:
+  Issue5531.agda:50,16-17
+  Issue5531.agda:49,16-54
+  Issue5531.agda:50,18-21

--- a/test/Fail/Issue5558.err
+++ b/test/Fail/Issue5558.err
@@ -1,6 +1,6 @@
-Issue5558.agda:3,3-15
-The following names are defined but not accompanied by a
-declaration: A
 Issue5558.agda:6,3-7,10
 The following names are defined but not accompanied by a
 declaration: B
+Issue5558.agda:3,3-15
+The following names are defined but not accompanied by a
+declaration: A

--- a/test/Fail/Issue5699b.err
+++ b/test/Fail/Issue5699b.err
@@ -16,3 +16,5 @@ lam visible
      arg (arg-info visible (modality relevant quantity-ω)) (var 0 []) ∷
      [])))))
 when checking that the expression unquote m has type _27
+Unsolved metas at the following locations:
+  Issue5699b.agda:20,1-5

--- a/test/Fail/Issue5705.err
+++ b/test/Fail/Issue5705.err
@@ -2,3 +2,5 @@ Issue5705.agda:5,15-37
 Set₉₂₂₃₃₇₂₀₃₆₈₅₄₇₇₅₈₀₉ != Set₁
 when checking that the expression Set₉₂₂₃₃₇₂₀₃₆₈₅₄₇₇₅₈₀₈ has type
 Set₁
+Failed to solve the following constraints:
+  Set = _3 : Set₁ (blocked on _3)

--- a/test/Fail/Issue5805.err
+++ b/test/Fail/Issue5805.err
@@ -8,9 +8,7 @@ Failed to solve the following constraints:
 Unsolved metas at the following locations:
   Issue5805.agda:20,19-30
   Issue5805.agda:28,20-21
-  Issue5805.agda:28,23-24
   Issue5805.agda:30,17-21
-  Issue5805.agda:30,27-31
 Unsolved interaction metas at the following locations:
   Issue5805.agda:19,13-17
   Issue5805.agda:30,22-26

--- a/test/Fail/Issue5810.err
+++ b/test/Fail/Issue5810.err
@@ -1,3 +1,6 @@
 Issue5810.agda:8,15-24
 funSort Set LevelUniv is not a valid sort
 when checking that the expression ⊤ → Level is a type
+Unsolved metas at the following locations:
+  Issue5810.agda:8,8-43
+  Issue5810.agda:8,7-58

--- a/test/Fail/Issue585-11.err
+++ b/test/Fail/Issue585-11.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   f₁ n (f₃ n i) = _24 (x = n) (x = i) : D₁ (blocked on _24)
 Unsolved metas at the following locations:
   Issue585-11.agda:20,17-18
-  Issue585-11.agda:23,17-30

--- a/test/Fail/Issue585t.err
+++ b/test/Fail/Issue585t.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _x_13 = inn (out _x_13) : B (blocked on _x_13)
 Unsolved metas at the following locations:
   Issue585t.agda:24,9-10
-  Issue585t.agda:24,7-10

--- a/test/Fail/Issue5891.err
+++ b/test/Fail/Issue5891.err
@@ -2,3 +2,15 @@ Issue5891.agda:16,9-27
 Setω != SizeUniv
 when checking that the expression (X : SizeUniv) → X has type
 SizeUniv
+Issue5891.agda:27,7-19
+Setω != SizeUniv
+when checking that the expression S → SizeUniv has type SizeUniv
+Issue5891.agda:30,7-47
+Setω != SizeUniv
+when checking that the expression
+(X : SizeUniv) → (℘ (℘ X) → X) → ℘ (℘ X) has type SizeUniv
+Issue5891.agda:63,15-30
+Cannot solve size constraints
+[i] ↑ _334 ≤ i
+Reason: inconsistent upper bound for _334
+when checking that the expression false (Size< i) has type Size< i

--- a/test/Fail/Issue610-module.err
+++ b/test/Fail/Issue610-module.err
@@ -2,3 +2,6 @@ Issue610-module.agda:29,8-40
 ack (set _) !=< ⊥
 when checking that the expression subst (λ x → x) (cong ack hah) _
 has type ⊥
+Issue610-module.agda:34,11-30
+ack (set _) !=< ⊥
+when checking that the expression subst (λ x → x) q _ has type ⊥

--- a/test/Fail/Issue610.err
+++ b/test/Fail/Issue610.err
@@ -2,3 +2,7 @@ Issue610.agda:25,9-17
 Identifier R.helper is declared irrelevant, so it cannot be used
 here
 when checking that the expression R.helper x x has type Set
+Failed to solve the following constraints:
+  _4 (x = (set _)) =< ⊥ (blocked on _4)
+Unsolved metas at the following locations:
+  Issue610.agda:35,29-30

--- a/test/Fail/Issue659.err
+++ b/test/Fail/Issue659.err
@@ -2,3 +2,5 @@ Issue659.agda:32,7-10
 Agda.Primitive.Setω != (Set _a_29)
 when checking that the solution (ℓ : Level) → R ℓ of metavariable
 _A_30 has the expected type Set _a_29
+Unsolved metas at the following locations:
+  Issue659.agda:32,7-10

--- a/test/Fail/Issue6633.err
+++ b/test/Fail/Issue6633.err
@@ -2,3 +2,22 @@ Issue6633.agda:32,47-48
 SSet != Set
 when checking that the solution x ≡ˢ y of metavariable _A_33 has
 the expected type Set
+Issue6633.agda:32,47-48
+SSet != Set
+when checking that the solution x ≡ˢ y of metavariable _A_33 has
+the expected type Set
+Issue6633.agda:37,9-15
+SSet != Set
+when checking that the expression x ≡ˢ y has type Set
+Issue6633.agda:42,10-11
+SSet != Set
+when checking that the expression A has type Set
+Failed to solve the following constraints:
+  _34 (p = reflˢ) (q = reflˢ) = _35 (p = reflˢ) (q = reflˢ)
+    : _A_33 (p = reflˢ) (q = reflˢ)
+    (blocked on any(_34, _35))
+Unsolved metas at the following locations:
+  Issue6633.agda:32,47-48
+  Issue6633.agda:38,17-22
+  Issue6633.agda:38,27-45
+  Issue6633.agda:39,5-9

--- a/test/Fail/Issue6651-UnivPred-SizeUniv.err
+++ b/test/Fail/Issue6651-UnivPred-SizeUniv.err
@@ -2,3 +2,10 @@ Issue6651-UnivPred-SizeUniv.agda:17,5-9
 Setω != Set₁
 when checking that the solution SizeUniv of metavariable _0 has the
 expected type Set₁
+Failed to solve the following constraints:
+  univSort _3 = Set₁ (blocked on _3)
+  univSort _3 =< Set₁ (blocked on _3)
+Unsolved metas at the following locations:
+  Issue6651-UnivPred-SizeUniv.agda:19,16-17
+Unsolved interaction metas at the following locations:
+  Issue6651-UnivPred-SizeUniv.agda:17,5-9

--- a/test/Fail/Issue6651-UnivSort-IUniv.err
+++ b/test/Fail/Issue6651-UnivSort-IUniv.err
@@ -1,4 +1,14 @@
 Issue6651-UnivSort-IUniv.agda:15,5-6
+univSort _10 != IUniv
+when checking that the solution _10 of metavariable _6 has the
+expected type IUniv
+Issue6651-UnivSort-IUniv.agda:15,5-6
 univSort _8 != IUniv
 when checking that the solution _8 of metavariable _6 has the
 expected type IUniv
+Failed to solve the following constraints:
+  _9 (A = A) =< _11 (A = A) (blocked on any(_9, _11))
+Unsolved metas at the following locations:
+  Issue6651-UnivSort-IUniv.agda:15,5-6
+  Issue6651-UnivSort-IUniv.agda:17,16-17
+  Issue6651-UnivSort-IUniv.agda:17,20-21

--- a/test/Fail/Issue6651-UnivSort-LevelUniv.err
+++ b/test/Fail/Issue6651-UnivSort-LevelUniv.err
@@ -1,4 +1,14 @@
 Issue6651-UnivSort-LevelUniv.agda:14,5-6
+univSort _10 != LevelUniv
+when checking that the solution _10 of metavariable _6 has the
+expected type LevelUniv
+Issue6651-UnivSort-LevelUniv.agda:14,5-6
 univSort _8 != LevelUniv
 when checking that the solution _8 of metavariable _6 has the
 expected type LevelUniv
+Failed to solve the following constraints:
+  _9 (A = A) =< _11 (A = A) (blocked on any(_9, _11))
+Unsolved metas at the following locations:
+  Issue6651-UnivSort-LevelUniv.agda:14,5-6
+  Issue6651-UnivSort-LevelUniv.agda:16,16-17
+  Issue6651-UnivSort-LevelUniv.agda:16,20-21

--- a/test/Fail/Issue6651-UnivSort-LockUniv.err
+++ b/test/Fail/Issue6651-UnivSort-LockUniv.err
@@ -1,4 +1,14 @@
 Issue6651-UnivSort-LockUniv.agda:17,5-6
+univSort _12 != primLockUniv
+when checking that the solution _12 of metavariable _8 has the
+expected type primLockUniv
+Issue6651-UnivSort-LockUniv.agda:17,5-6
 univSort _10 != primLockUniv
 when checking that the solution _10 of metavariable _8 has the
 expected type primLockUniv
+Failed to solve the following constraints:
+  _11 (A = A) =< _13 (A = A) (blocked on any(_11, _13))
+Unsolved metas at the following locations:
+  Issue6651-UnivSort-LockUniv.agda:17,5-6
+  Issue6651-UnivSort-LockUniv.agda:19,16-17
+  Issue6651-UnivSort-LockUniv.agda:19,20-21

--- a/test/Fail/Issue6651-UnivSort-PropOmega.err
+++ b/test/Fail/Issue6651-UnivSort-PropOmega.err
@@ -1,4 +1,14 @@
 Issue6651-UnivSort-PropOmega.agda:15,5-6
+univSort _9 != Propω
+when checking that the solution _9 of metavariable _5 has the
+expected type Propω
+Issue6651-UnivSort-PropOmega.agda:15,5-6
 univSort _7 != Propω
 when checking that the solution _7 of metavariable _5 has the
 expected type Propω
+Failed to solve the following constraints:
+  _8 (A = A) =< _10 (A = A) (blocked on any(_8, _10))
+Unsolved metas at the following locations:
+  Issue6651-UnivSort-PropOmega.agda:15,5-6
+  Issue6651-UnivSort-PropOmega.agda:17,16-17
+  Issue6651-UnivSort-PropOmega.agda:17,20-21

--- a/test/Fail/Issue6651-UnivSort-SetOmega-Prop.err
+++ b/test/Fail/Issue6651-UnivSort-SetOmega-Prop.err
@@ -4,4 +4,3 @@ Failed to solve the following constraints:
   _9 is a sort (blocked on _8)
 Unsolved metas at the following locations:
   Issue6651-UnivSort-SetOmega-Prop.agda:17,16-17
-  Issue6651-UnivSort-SetOmega-Prop.agda:17,20-21

--- a/test/Fail/Issue6651-UnivSort-SetOmega.err
+++ b/test/Fail/Issue6651-UnivSort-SetOmega.err
@@ -1,4 +1,14 @@
 Issue6651-UnivSort-SetOmega.agda:9,5-6
+univSort _4 != Setω
+when checking that the solution _4 of metavariable _0 has the
+expected type Setω
+Issue6651-UnivSort-SetOmega.agda:9,5-6
 univSort _2 != Setω
 when checking that the solution _2 of metavariable _0 has the
 expected type Setω
+Failed to solve the following constraints:
+  _3 (A = A) =< _5 (A = A) (blocked on any(_3, _5))
+Unsolved metas at the following locations:
+  Issue6651-UnivSort-SetOmega.agda:9,5-6
+  Issue6651-UnivSort-SetOmega.agda:11,16-17
+  Issue6651-UnivSort-SetOmega.agda:11,20-21

--- a/test/Fail/Issue6651-UnivSort-SetOmega1-Prop.err
+++ b/test/Fail/Issue6651-UnivSort-SetOmega1-Prop.err
@@ -4,4 +4,3 @@ Failed to solve the following constraints:
   _9 is a sort (blocked on _8)
 Unsolved metas at the following locations:
   Issue6651-UnivSort-SetOmega1-Prop.agda:16,16-17
-  Issue6651-UnivSort-SetOmega1-Prop.agda:16,20-21

--- a/test/Fail/Issue6651-UnivSort-SizeUniv.err
+++ b/test/Fail/Issue6651-UnivSort-SizeUniv.err
@@ -1,4 +1,14 @@
 Issue6651-UnivSort-SizeUniv.agda:15,5-6
+univSort _10 != SizeUniv
+when checking that the solution _10 of metavariable _6 has the
+expected type SizeUniv
+Issue6651-UnivSort-SizeUniv.agda:15,5-6
 univSort _8 != SizeUniv
 when checking that the solution _8 of metavariable _6 has the
 expected type SizeUniv
+Failed to solve the following constraints:
+  _9 (A = A) =< _11 (A = A) (blocked on any(_9, _11))
+Unsolved metas at the following locations:
+  Issue6651-UnivSort-SizeUniv.agda:15,5-6
+  Issue6651-UnivSort-SizeUniv.agda:17,16-17
+  Issue6651-UnivSort-SizeUniv.agda:17,20-21

--- a/test/Fail/Issue691.err
+++ b/test/Fail/Issue691.err
@@ -6,4 +6,3 @@ Failed to solve the following constraints:
     (blocked on _12)
 Unsolved metas at the following locations:
   Issue691.agda:21,11-12
-  Issue691.agda:26,10-14

--- a/test/Fail/Issue735.err
+++ b/test/Fail/Issue735.err
@@ -1,3 +1,26 @@
 Issue735.agda:16,12-16
 ((A₁ : Set _a_10) → Set _a_10) should be a sort, but it isn't
 when checking that the expression List has type _9
+Issue735.agda:16,19-23
+((A₁ : Set _a_12) → Set _a_12) should be a sort, but it isn't
+when checking that the expression List has type _11
+Issue735.agda:16,26-30
+(A₁ : Set _a_14) → Set _a_14 should be a sort, but it isn't
+when checking that the expression List has type _13
+Failed to solve the following constraints:
+  _14 =< List Nat (blocked on _14)
+  List Nat =< _12 (blocked on _12)
+  List Nat =< _10 (blocked on _10)
+  Check definition of _++_ : {a = a₁ : Agda.Primitive.Level}
+                             {A = A₁ : Set a₁} →
+                             _10 → _12 → _14
+    stuck because
+      Issue735.agda:17,5-7
+      Cannot split on argument of unresolved type _10
+      when checking that the pattern [] has type _10
+    (blocked on _10)
+Unsolved metas at the following locations:
+  Issue735.agda:16,12-16
+  Issue735.agda:16,19-23
+  Issue735.agda:16,26-30
+  Issue735.agda:24,17-19

--- a/test/Fail/Issue783b.err
+++ b/test/Fail/Issue783b.err
@@ -1,3 +1,6 @@
 Issue783b.agda:3,11-14
 Set₁ !=< Agda.Primitive.Level
 when checking that the expression Set has type Agda.Primitive.Level
+Issue783b.agda:3,11-14
+Set₁ !=< Agda.Primitive.Level
+when checking that the expression Set has type Agda.Primitive.Level

--- a/test/Fail/Issue796.err
+++ b/test/Fail/Issue796.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   A' =< [ _u_13 ] (blocked on _u_13)
 Unsolved metas at the following locations:
   Issue796.agda:34,11-12
-  Issue796.agda:34,13-14

--- a/test/Fail/Issue796o.err
+++ b/test/Fail/Issue796o.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   A' =< [ _u_13 ] (blocked on _u_13)
 Unsolved metas at the following locations:
   Issue796o.agda:27,9-10
-  Issue796o.agda:27,11-12

--- a/test/Fail/Issue821.err
+++ b/test/Fail/Issue821.err
@@ -1,3 +1,6 @@
+Issue821.agda:26,7-10
+Set != Set₁
+when checking that the expression Q p has type Set₁
 Issue821.agda:26,9-10
 x != (f _ x) of type (D A)
 when checking that the expression p has type P (f _ x)

--- a/test/Fail/Issue878.err
+++ b/test/Fail/Issue878.err
@@ -6,4 +6,3 @@ Failed to solve the following constraints:
   _r.P_25 tt = ⊤ : Set (blocked on _r.P_25)
 Unsolved metas at the following locations:
   Issue878.agda:30,7-10
-  Issue878.agda:30,7-13

--- a/test/Fail/Issue892a.agda
+++ b/test/Fail/Issue892a.agda
@@ -9,5 +9,4 @@ record R : Set₁ where
 -- The type of R.g should print as (r : R) → Set
 -- rather than ( : R) → Set.
 bad : R.g
-bad = ?
-
+bad = {!   !}

--- a/test/Fail/Issue892a.err
+++ b/test/Fail/Issue892a.err
@@ -1,3 +1,7 @@
 Issue892a.agda:11,7-10
 R → Set should be a sort, but it isn't
 when checking that the expression R.g has type _0
+Unsolved metas at the following locations:
+  Issue892a.agda:11,7-10
+Unsolved interaction metas at the following locations:
+  Issue892a.agda:12,7-8

--- a/test/Fail/Issue892b.err
+++ b/test/Fail/Issue892b.err
@@ -1,3 +1,7 @@
 Issue892b.agda:10,7-10
 (r : R) → R.A r → Set should be a sort, but it isn't
 when checking that the expression R.B has type _1
+Unsolved metas at the following locations:
+  Issue892b.agda:10,7-10
+Unsolved interaction metas at the following locations:
+  Issue892b.agda:11,7-8

--- a/test/Fail/Issue920.err
+++ b/test/Fail/Issue920.err
@@ -1,6 +1,4 @@
 Failed to solve the following constraints:
   ?0 (B = A) = x : A (blocked on _7)
-Unsolved metas at the following locations:
-  Issue920.agda:16,11-50
 Unsolved interaction metas at the following locations:
   Issue920.agda:16,42-47

--- a/test/Fail/Issue920a.err
+++ b/test/Fail/Issue920a.err
@@ -2,6 +2,4 @@ Failed to solve the following constraints:
   x = _63 (A' = A) : A (blocked on _63)
   _63 (A' = A) = x : A (blocked on _63)
 Unsolved metas at the following locations:
-  Issue920a.agda:26,52-56
   Issue920a.agda:26,49-50
-  Issue920a.agda:26,23-58

--- a/test/Fail/Issue949.err
+++ b/test/Fail/Issue949.err
@@ -2,3 +2,5 @@ Issue949.agda:8,9-10
 Function does not accept argument {B = _} (possible arguments: A)
 when checking that {B = S} is a valid argument to a function of
 type {A : Set} → Set
+Unsolved metas at the following locations:
+  Issue949.agda:8,9-17

--- a/test/Fail/JasonReedPruning.err
+++ b/test/Fail/JasonReedPruning.err
@@ -3,4 +3,3 @@ Failed to solve the following constraints:
 Unsolved metas at the following locations:
   JasonReedPruning.agda:23,11-12
   JasonReedPruning.agda:21,11-12
-  JasonReedPruning.agda:26,19-23

--- a/test/Fail/LevelUnivFunSorts.err
+++ b/test/Fail/LevelUnivFunSorts.err
@@ -1,3 +1,5 @@
 LevelUnivFunSorts.agda:5,5-16
 funSort Set₁ LevelUniv is not a valid sort
 when checking that the expression Set → Level is a type
+Unsolved metas at the following locations:
+  LevelUnivFunSorts.agda:5,1-2

--- a/test/Fail/MdSpanningComment.err
+++ b/test/Fail/MdSpanningComment.err
@@ -1,2 +1,2 @@
-MdSpanningComment.lagda.md:2,4-6,19: Multi-line comment spans one or more literate text blocks.
 MdSpanningComment.lagda.md:10,3-16,7: Multi-line comment spans one or more literate text blocks.
+MdSpanningComment.lagda.md:2,4-6,19: Multi-line comment spans one or more literate text blocks.

--- a/test/Fail/MetaCannotDependOn.err
+++ b/test/Fail/MetaCannotDependOn.err
@@ -3,3 +3,5 @@ Cannot instantiate the metavariable _A_10 to solution Vec n Nat
 since it contains the variable n
 which is not in scope of the metavariable
 when checking that the expression xs has type Vec n Nat
+Unsolved metas at the following locations:
+  MetaCannotDependOn.agda:13,9-10

--- a/test/Fail/MetaOccursInItself.err
+++ b/test/Fail/MetaOccursInItself.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _A_11 =< List _A_11 (blocked on _A_11)
 Unsolved metas at the following locations:
   MetaOccursInItself.agda:18,9-10
-  MetaOccursInItself.agda:18,18-19

--- a/test/Fail/ModuleInMutual.err
+++ b/test/Fail/ModuleInMutual.err
@@ -1,6 +1,6 @@
-ModuleInMutual.agda:7,3-9,12
+ModuleInMutual.agda:11,3-13,12
 Module definitions in mutual blocks are not supported. Suggestion:
 get rid of the mutual block by manually ordering declarations
-ModuleInMutual.agda:11,3-13,12
+ModuleInMutual.agda:7,3-9,12
 Module definitions in mutual blocks are not supported. Suggestion:
 get rid of the mutual block by manually ordering declarations

--- a/test/Fail/NoBindingForBuiltin.err
+++ b/test/Fail/NoBindingForBuiltin.err
@@ -2,3 +2,5 @@ NoBindingForBuiltin.agda:3,7-9
 No binding for builtin ZERO, use {-# BUILTIN NATURAL name #-} to
 bind builtin natural numbers to the type 'name'
 when checking that the expression 42 has type _1
+Unsolved metas at the following locations:
+  NoBindingForBuiltin.agda:3,1-4

--- a/test/Fail/NonLinearConstraint.err
+++ b/test/Fail/NonLinearConstraint.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _1 A A = A : Set (blocked on _1)
 Unsolved metas at the following locations:
   NonLinearConstraint.agda:7,16-17
-  NonLinearConstraint.agda:9,10-14

--- a/test/Fail/NotStrictlyPositiveInMutual.err
+++ b/test/Fail/NotStrictlyPositiveInMutual.err
@@ -1,14 +1,14 @@
 NotStrictlyPositiveInMutual.agda:4,1-9,36
+Oops is not strictly positive, because it occurs
+in the type of the constructor cheat
+in the definition of Cheat, which occurs
+                          to the left of an arrow
+                          in the type of the constructor oops
+                          in the definition of Oops.
+NotStrictlyPositiveInMutual.agda:4,1-9,36
 Cheat is not strictly positive, because it occurs
 to the left of an arrow
 in the type of the constructor oops
 in the definition of Oops, which occurs
-in the type of the constructor cheat
-in the definition of Cheat.
-NotStrictlyPositiveInMutual.agda:4,1-9,36
-Oops is not strictly positive, because it occurs
-in the type of the constructor cheat
-in the definition of Cheat, which occurs
-to the left of an arrow
-in the type of the constructor oops
-in the definition of Oops.
+                         in the type of the constructor cheat
+                         in the definition of Cheat.

--- a/test/Fail/NotStronglyRigidOccurrence.err
+++ b/test/Fail/NotStronglyRigidOccurrence.err
@@ -3,4 +3,3 @@ Failed to solve the following constraints:
     (blocked on _14)
 Unsolved metas at the following locations:
   NotStronglyRigidOccurrence.agda:14,16-17
-  NotStronglyRigidOccurrence.agda:16,12-16

--- a/test/Fail/OccursCheck1.err
+++ b/test/Fail/OccursCheck1.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _11 = suc _11 : Nat (blocked on _11)
 Unsolved metas at the following locations:
   OccursCheck1.agda:18,11-12
-  OccursCheck1.agda:20,8-12

--- a/test/Fail/Polarity-pragma-in-safe-mode.err
+++ b/test/Fail/Polarity-pragma-in-safe-mode.err
@@ -1,6 +1,6 @@
-Polarity-pragma-in-safe-mode.agda:5,1-22
-Cannot use POLARITY pragma with safe flag.
 Polarity-pragma-in-safe-mode.agda:3,11-24
 Cannot postulate F with safe flag
 when scope checking the declaration
   F : Set → Set
+Polarity-pragma-in-safe-mode.agda:5,1-22
+Cannot use POLARITY pragma with safe flag.

--- a/test/Fail/PositivityCheckNeedsLinearityCheck.err
+++ b/test/Fail/PositivityCheckNeedsLinearityCheck.err
@@ -1,3 +1,9 @@
 PositivityCheckNeedsLinearityCheck.agda:17,13-16
 Set₁ != Set₂
 when checking that the expression Set has type Set₂
+PositivityCheckNeedsLinearityCheck.agda:21,5-11
+Set₁ != Set₂
+when checking that the solution Set of metavariable _S'_10 has the
+expected type Set₂
+Failed to solve the following constraints:
+  Set₁ = _6 : Set₂ (blocked on _6)

--- a/test/Fail/PropCumulative.err
+++ b/test/Fail/PropCumulative.err
@@ -1,3 +1,6 @@
+PropCumulative.agda:32,9-22
+True _ !=< ⊥
+when checking that the expression true≡false tt has type ⊥
 PropCumulative.agda:32,20-22
 ⊤ !=< (True _)
 when checking that the expression tt has type X _

--- a/test/Fail/PruningNonMillerPatternFail.err
+++ b/test/Fail/PruningNonMillerPatternFail.err
@@ -6,6 +6,3 @@ Failed to solve the following constraints:
 Unsolved metas at the following locations:
   PruningNonMillerPatternFail.agda:13,17-18
   PruningNonMillerPatternFail.agda:15,17-18
-  PruningNonMillerPatternFail.agda:22,15-19
-  PruningNonMillerPatternFail.agda:22,20-24
-  PruningNonMillerPatternFail.agda:22,25-29

--- a/test/Fail/RewritingNonConfluent1.err
+++ b/test/Fail/RewritingNonConfluent1.err
@@ -5,19 +5,6 @@ Possible fix: add a rewrite rule with left-hand side
 max (suc m) (suc m) to resolve the ambiguity.
 when checking confluence of the rewrite rule max-ss with max-diag
 RewritingNonConfluent1.agda:23,13-22
-Global confluence check failed: max (max k l) (max k l) can be
-rewritten to either max k (max l (max k l)) or max k l.
-Possible fix: add a rewrite rule with left-hand side
-max (max k l) (max k l) to resolve the ambiguity.
-when checking confluence of the rewrite rule max-assoc with
-max-diag
-RewritingNonConfluent1.agda:23,13-22
-Global confluence check failed: max (max k l) 0 can be rewritten to
-either max k (max l 0) or max k l.
-Possible fix: add a rewrite rule with left-hand side
-max (max k l) 0 to resolve the ambiguity.
-when checking confluence of the rewrite rule max-assoc with max-0r
-RewritingNonConfluent1.agda:23,13-22
 Global confluence check failed: max (max (max k l) l₁) m can be
 rewritten to either max (max k l) (max l₁ m) or
 max (max k (max l l₁)) m.
@@ -25,12 +12,17 @@ Possible fix: add a rewrite rule with left-hand side
 max (max (max k l) l₁) m to resolve the ambiguity.
 when checking confluence of the rewrite rule max-assoc with itself
 RewritingNonConfluent1.agda:23,13-22
-Global confluence check failed: max (max (suc m) (suc n)) m₁ can be
-rewritten to either max (suc m) (max (suc n) m₁) or
-max (suc (max m n)) m₁.
+Global confluence check failed: max (max 0 l) m can be rewritten to
+either max 0 (max l m) or max l m.
 Possible fix: add a rewrite rule with left-hand side
-max (max (suc m) (suc n)) m₁ to resolve the ambiguity.
-when checking confluence of the rewrite rule max-assoc with max-ss
+max (max 0 l) m to resolve the ambiguity.
+when checking confluence of the rewrite rule max-assoc with max-0l
+RewritingNonConfluent1.agda:23,13-22
+Global confluence check failed: max (max k 0) m can be rewritten to
+either max k (max 0 m) or max k m.
+Possible fix: add a rewrite rule with left-hand side
+max (max k 0) m to resolve the ambiguity.
+when checking confluence of the rewrite rule max-assoc with max-0r
 RewritingNonConfluent1.agda:23,13-22
 Global confluence check failed: max (max k k) m can be rewritten to
 either max k (max k m) or max k m.
@@ -39,17 +31,12 @@ max (max k k) m to resolve the ambiguity.
 when checking confluence of the rewrite rule max-assoc with
 max-diag
 RewritingNonConfluent1.agda:23,13-22
-Global confluence check failed: max (max k 0) m can be rewritten to
-either max k (max 0 m) or max k m.
+Global confluence check failed: max (max (suc m) (suc n)) m₁ can be
+rewritten to either max (suc m) (max (suc n) m₁) or
+max (suc (max m n)) m₁.
 Possible fix: add a rewrite rule with left-hand side
-max (max k 0) m to resolve the ambiguity.
-when checking confluence of the rewrite rule max-assoc with max-0r
-RewritingNonConfluent1.agda:23,13-22
-Global confluence check failed: max (max 0 l) m can be rewritten to
-either max 0 (max l m) or max l m.
-Possible fix: add a rewrite rule with left-hand side
-max (max 0 l) m to resolve the ambiguity.
-when checking confluence of the rewrite rule max-assoc with max-0l
+max (max (suc m) (suc n)) m₁ to resolve the ambiguity.
+when checking confluence of the rewrite rule max-assoc with max-ss
 RewritingNonConfluent1.agda:23,13-22
 Global confluence check failed: max (max (max k l) l₁) m can be
 rewritten to either max (max k l) (max l₁ m) or
@@ -57,3 +44,16 @@ max (max k (max l l₁)) m.
 Possible fix: add a rewrite rule with left-hand side
 max (max (max k l) l₁) m to resolve the ambiguity.
 when checking confluence of the rewrite rule max-assoc with itself
+RewritingNonConfluent1.agda:23,13-22
+Global confluence check failed: max (max k l) 0 can be rewritten to
+either max k (max l 0) or max k l.
+Possible fix: add a rewrite rule with left-hand side
+max (max k l) 0 to resolve the ambiguity.
+when checking confluence of the rewrite rule max-assoc with max-0r
+RewritingNonConfluent1.agda:23,13-22
+Global confluence check failed: max (max k l) (max k l) can be
+rewritten to either max k (max l (max k l)) or max k l.
+Possible fix: add a rewrite rule with left-hand side
+max (max k l) (max k l) to resolve the ambiguity.
+when checking confluence of the rewrite rule max-assoc with
+max-diag

--- a/test/Fail/RewritingNonConfluent2.err
+++ b/test/Fail/RewritingNonConfluent2.err
@@ -6,19 +6,19 @@ resolve the ambiguity.
 when checking confluence of the rewrite rule plus-suc-l with
 plus-0r
 RewritingNonConfluent2.agda:21,13-23
-Global confluence check failed: suc m + suc n can be rewritten to
-either suc (suc m + n) or suc (m + suc n).
-Possible fix: add a rewrite rule with left-hand side suc m + suc n
-to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-suc-r with
-plus-suc-l
-RewritingNonConfluent2.agda:21,13-23
 Global confluence check failed: 0 + suc n can be rewritten to
 either suc (0 + n) or suc n.
 Possible fix: add a rewrite rule with left-hand side 0 + suc n to
 resolve the ambiguity.
 when checking confluence of the rewrite rule plus-suc-r with
 plus-0l
+RewritingNonConfluent2.agda:21,13-23
+Global confluence check failed: suc m + suc n can be rewritten to
+either suc (suc m + n) or suc (m + suc n).
+Possible fix: add a rewrite rule with left-hand side suc m + suc n
+to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-r with
+plus-suc-l
 RewritingNonConfluent2.agda:36,13-23
 Global confluence check failed: suc m * 0 can be rewritten to
 either 0 + (m * 0) or 0.
@@ -27,16 +27,16 @@ resolve the ambiguity.
 when checking confluence of the rewrite rule mult-suc-l with
 mult-0r
 RewritingNonConfluent2.agda:37,13-23
-Global confluence check failed: suc m * suc n can be rewritten to
-either (suc m * n) + suc m or suc n + (m * suc n).
-Possible fix: add a rewrite rule with left-hand side suc m * suc n
-to resolve the ambiguity.
-when checking confluence of the rewrite rule mult-suc-r with
-mult-suc-l
-RewritingNonConfluent2.agda:37,13-23
 Global confluence check failed: 0 * suc n can be rewritten to
 either (0 * n) + 0 or 0.
 Possible fix: add a rewrite rule with left-hand side 0 * suc n to
 resolve the ambiguity.
 when checking confluence of the rewrite rule mult-suc-r with
 mult-0l
+RewritingNonConfluent2.agda:37,13-23
+Global confluence check failed: suc m * suc n can be rewritten to
+either (suc m * n) + suc m or suc n + (m * suc n).
+Possible fix: add a rewrite rule with left-hand side suc m * suc n
+to resolve the ambiguity.
+when checking confluence of the rewrite rule mult-suc-r with
+mult-suc-l

--- a/test/Fail/RewritingNonConfluent3.err
+++ b/test/Fail/RewritingNonConfluent3.err
@@ -6,60 +6,25 @@ resolve the ambiguity.
 when checking confluence of the rewrite rule plus-suc-l with
 plus-0r
 RewritingNonConfluent3.agda:21,13-23
-Global confluence check failed: suc m + suc n can be rewritten to
-either suc (suc m + n) or suc (m + suc n).
-Possible fix: add a rewrite rule with left-hand side suc m + suc n
-to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-suc-r with
-plus-suc-l
-RewritingNonConfluent3.agda:21,13-23
 Global confluence check failed: 0 + suc n can be rewritten to
 either suc (0 + n) or suc n.
 Possible fix: add a rewrite rule with left-hand side 0 + suc n to
 resolve the ambiguity.
 when checking confluence of the rewrite rule plus-suc-r with
 plus-0l
-RewritingNonConfluent3.agda:22,13-23
-Global confluence check failed: (k + l) + suc n can be rewritten to
-either k + (l + suc n) or suc ((k + l) + n).
-Possible fix: add a rewrite rule with left-hand side
-(k + l) + suc n to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-assoc with
-plus-suc-r
-RewritingNonConfluent3.agda:22,13-23
-Global confluence check failed: (k + l) + 0 can be rewritten to
-either k + (l + 0) or k + l.
-Possible fix: add a rewrite rule with left-hand side (k + l) + 0 to
-resolve the ambiguity.
-when checking confluence of the rewrite rule plus-assoc with
-plus-0r
+RewritingNonConfluent3.agda:21,13-23
+Global confluence check failed: suc m + suc n can be rewritten to
+either suc (suc m + n) or suc (m + suc n).
+Possible fix: add a rewrite rule with left-hand side suc m + suc n
+to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-r with
+plus-suc-l
 RewritingNonConfluent3.agda:22,13-23
 Global confluence check failed: ((k + l) + l₁) + m can be rewritten
 to either (k + l) + (l₁ + m) or (k + (l + l₁)) + m.
 Possible fix: add a rewrite rule with left-hand side
 ((k + l) + l₁) + m to resolve the ambiguity.
 when checking confluence of the rewrite rule plus-assoc with itself
-RewritingNonConfluent3.agda:22,13-23
-Global confluence check failed: (k + suc n) + m can be rewritten to
-either k + (suc n + m) or suc (k + n) + m.
-Possible fix: add a rewrite rule with left-hand side
-(k + suc n) + m to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-assoc with
-plus-suc-r
-RewritingNonConfluent3.agda:22,13-23
-Global confluence check failed: (suc m + l) + m₁ can be rewritten
-to either suc m + (l + m₁) or suc (m + l) + m₁.
-Possible fix: add a rewrite rule with left-hand side
-(suc m + l) + m₁ to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-assoc with
-plus-suc-l
-RewritingNonConfluent3.agda:22,13-23
-Global confluence check failed: (k + 0) + m can be rewritten to
-either k + (0 + m) or k + m.
-Possible fix: add a rewrite rule with left-hand side (k + 0) + m to
-resolve the ambiguity.
-when checking confluence of the rewrite rule plus-assoc with
-plus-0r
 RewritingNonConfluent3.agda:22,13-23
 Global confluence check failed: (0 + l) + m can be rewritten to
 either 0 + (l + m) or l + m.
@@ -68,11 +33,46 @@ resolve the ambiguity.
 when checking confluence of the rewrite rule plus-assoc with
 plus-0l
 RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: (k + 0) + m can be rewritten to
+either k + (0 + m) or k + m.
+Possible fix: add a rewrite rule with left-hand side (k + 0) + m to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-0r
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: (suc m + l) + m₁ can be rewritten
+to either suc m + (l + m₁) or suc (m + l) + m₁.
+Possible fix: add a rewrite rule with left-hand side
+(suc m + l) + m₁ to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-l
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: (k + suc n) + m can be rewritten to
+either k + (suc n + m) or suc (k + n) + m.
+Possible fix: add a rewrite rule with left-hand side
+(k + suc n) + m to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-r
+RewritingNonConfluent3.agda:22,13-23
 Global confluence check failed: ((k + l) + l₁) + m can be rewritten
 to either (k + l) + (l₁ + m) or (k + (l + l₁)) + m.
 Possible fix: add a rewrite rule with left-hand side
 ((k + l) + l₁) + m to resolve the ambiguity.
 when checking confluence of the rewrite rule plus-assoc with itself
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: (k + l) + 0 can be rewritten to
+either k + (l + 0) or k + l.
+Possible fix: add a rewrite rule with left-hand side (k + l) + 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-0r
+RewritingNonConfluent3.agda:22,13-23
+Global confluence check failed: (k + l) + suc n can be rewritten to
+either k + (l + suc n) or suc ((k + l) + n).
+Possible fix: add a rewrite rule with left-hand side
+(k + l) + suc n to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-r
 RewritingNonConfluent3.agda:36,13-23
 Global confluence check failed: suc m * 0 can be rewritten to
 either 0 + (m * 0) or 0.
@@ -81,54 +81,26 @@ resolve the ambiguity.
 when checking confluence of the rewrite rule mult-suc-l with
 mult-0r
 RewritingNonConfluent3.agda:37,13-23
-Global confluence check failed: suc m * suc n can be rewritten to
-either (suc m * n) + suc m or suc n + (m * suc n).
-Possible fix: add a rewrite rule with left-hand side suc m * suc n
-to resolve the ambiguity.
-when checking confluence of the rewrite rule mult-suc-r with
-mult-suc-l
-RewritingNonConfluent3.agda:37,13-23
 Global confluence check failed: 0 * suc n can be rewritten to
 either (0 * n) + 0 or 0.
 Possible fix: add a rewrite rule with left-hand side 0 * suc n to
 resolve the ambiguity.
 when checking confluence of the rewrite rule mult-suc-r with
 mult-0l
-RewritingNonConfluent3.agda:38,13-30
-Global confluence check failed: suc m * (l + m₁) can be rewritten
-to either (suc m * l) + (suc m * m₁) or (l + m₁) + (m * (l + m₁)).
-Possible fix: add a rewrite rule with left-hand side
-suc m * (l + m₁) to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-mult-distr-l with
+RewritingNonConfluent3.agda:37,13-23
+Global confluence check failed: suc m * suc n can be rewritten to
+either (suc m * n) + suc m or suc n + (m * suc n).
+Possible fix: add a rewrite rule with left-hand side suc m * suc n
+to resolve the ambiguity.
+when checking confluence of the rewrite rule mult-suc-r with
 mult-suc-l
 RewritingNonConfluent3.agda:38,13-30
-Global confluence check failed: 0 * (l + m) can be rewritten to
-either (0 * l) + (0 * m) or 0.
-Possible fix: add a rewrite rule with left-hand side 0 * (l + m) to
+Global confluence check failed: k * (0 + m) can be rewritten to
+either (k * 0) + (k * m) or k * m.
+Possible fix: add a rewrite rule with left-hand side k * (0 + m) to
 resolve the ambiguity.
 when checking confluence of the rewrite rule plus-mult-distr-l with
-mult-0l
-RewritingNonConfluent3.agda:38,13-30
-Global confluence check failed: k * ((k₁ + l) + m) can be rewritten
-to either (k * (k₁ + l)) + (k * m) or k * (k₁ + (l + m)).
-Possible fix: add a rewrite rule with left-hand side
-k * ((k₁ + l) + m) to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-mult-distr-l with
-plus-assoc
-RewritingNonConfluent3.agda:38,13-30
-Global confluence check failed: k * (l + suc n) can be rewritten to
-either (k * l) + (k * suc n) or k * suc (l + n).
-Possible fix: add a rewrite rule with left-hand side
-k * (l + suc n) to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-mult-distr-l with
-plus-suc-r
-RewritingNonConfluent3.agda:38,13-30
-Global confluence check failed: k * (suc m + m₁) can be rewritten
-to either (k * suc m) + (k * m₁) or k * suc (m + m₁).
-Possible fix: add a rewrite rule with left-hand side
-k * (suc m + m₁) to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-mult-distr-l with
-plus-suc-l
+plus-0l
 RewritingNonConfluent3.agda:38,13-30
 Global confluence check failed: k * (l + 0) can be rewritten to
 either (k * l) + (k * 0) or k * l.
@@ -137,9 +109,37 @@ resolve the ambiguity.
 when checking confluence of the rewrite rule plus-mult-distr-l with
 plus-0r
 RewritingNonConfluent3.agda:38,13-30
-Global confluence check failed: k * (0 + m) can be rewritten to
-either (k * 0) + (k * m) or k * m.
-Possible fix: add a rewrite rule with left-hand side k * (0 + m) to
+Global confluence check failed: k * (suc m + m₁) can be rewritten
+to either (k * suc m) + (k * m₁) or k * suc (m + m₁).
+Possible fix: add a rewrite rule with left-hand side
+k * (suc m + m₁) to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-mult-distr-l with
+plus-suc-l
+RewritingNonConfluent3.agda:38,13-30
+Global confluence check failed: k * (l + suc n) can be rewritten to
+either (k * l) + (k * suc n) or k * suc (l + n).
+Possible fix: add a rewrite rule with left-hand side
+k * (l + suc n) to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-mult-distr-l with
+plus-suc-r
+RewritingNonConfluent3.agda:38,13-30
+Global confluence check failed: k * ((k₁ + l) + m) can be rewritten
+to either (k * (k₁ + l)) + (k * m) or k * (k₁ + (l + m)).
+Possible fix: add a rewrite rule with left-hand side
+k * ((k₁ + l) + m) to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-mult-distr-l with
+plus-assoc
+RewritingNonConfluent3.agda:38,13-30
+Global confluence check failed: 0 * (l + m) can be rewritten to
+either (0 * l) + (0 * m) or 0.
+Possible fix: add a rewrite rule with left-hand side 0 * (l + m) to
 resolve the ambiguity.
 when checking confluence of the rewrite rule plus-mult-distr-l with
-plus-0l
+mult-0l
+RewritingNonConfluent3.agda:38,13-30
+Global confluence check failed: suc m * (l + m₁) can be rewritten
+to either (suc m * l) + (suc m * m₁) or (l + m₁) + (m * (l + m₁)).
+Possible fix: add a rewrite rule with left-hand side
+suc m * (l + m₁) to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-mult-distr-l with
+mult-suc-l

--- a/test/Fail/RewritingNonConfluent4.err
+++ b/test/Fail/RewritingNonConfluent4.err
@@ -6,60 +6,25 @@ resolve the ambiguity.
 when checking confluence of the rewrite rule plus-suc-l with
 plus-0r
 RewritingNonConfluent4.agda:21,13-23
-Global confluence check failed: suc m + suc n can be rewritten to
-either suc (suc m + n) or suc (m + suc n).
-Possible fix: add a rewrite rule with left-hand side suc m + suc n
-to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-suc-r with
-plus-suc-l
-RewritingNonConfluent4.agda:21,13-23
 Global confluence check failed: 0 + suc n can be rewritten to
 either suc (0 + n) or suc n.
 Possible fix: add a rewrite rule with left-hand side 0 + suc n to
 resolve the ambiguity.
 when checking confluence of the rewrite rule plus-suc-r with
 plus-0l
-RewritingNonConfluent4.agda:22,13-23
-Global confluence check failed: (k + l) + suc n can be rewritten to
-either k + (l + suc n) or suc ((k + l) + n).
-Possible fix: add a rewrite rule with left-hand side
-(k + l) + suc n to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-assoc with
-plus-suc-r
-RewritingNonConfluent4.agda:22,13-23
-Global confluence check failed: (k + l) + 0 can be rewritten to
-either k + (l + 0) or k + l.
-Possible fix: add a rewrite rule with left-hand side (k + l) + 0 to
-resolve the ambiguity.
-when checking confluence of the rewrite rule plus-assoc with
-plus-0r
+RewritingNonConfluent4.agda:21,13-23
+Global confluence check failed: suc m + suc n can be rewritten to
+either suc (suc m + n) or suc (m + suc n).
+Possible fix: add a rewrite rule with left-hand side suc m + suc n
+to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-suc-r with
+plus-suc-l
 RewritingNonConfluent4.agda:22,13-23
 Global confluence check failed: ((k + l) + l₁) + m can be rewritten
 to either (k + l) + (l₁ + m) or (k + (l + l₁)) + m.
 Possible fix: add a rewrite rule with left-hand side
 ((k + l) + l₁) + m to resolve the ambiguity.
 when checking confluence of the rewrite rule plus-assoc with itself
-RewritingNonConfluent4.agda:22,13-23
-Global confluence check failed: (k + suc n) + m can be rewritten to
-either k + (suc n + m) or suc (k + n) + m.
-Possible fix: add a rewrite rule with left-hand side
-(k + suc n) + m to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-assoc with
-plus-suc-r
-RewritingNonConfluent4.agda:22,13-23
-Global confluence check failed: (suc m + l) + m₁ can be rewritten
-to either suc m + (l + m₁) or suc (m + l) + m₁.
-Possible fix: add a rewrite rule with left-hand side
-(suc m + l) + m₁ to resolve the ambiguity.
-when checking confluence of the rewrite rule plus-assoc with
-plus-suc-l
-RewritingNonConfluent4.agda:22,13-23
-Global confluence check failed: (k + 0) + m can be rewritten to
-either k + (0 + m) or k + m.
-Possible fix: add a rewrite rule with left-hand side (k + 0) + m to
-resolve the ambiguity.
-when checking confluence of the rewrite rule plus-assoc with
-plus-0r
 RewritingNonConfluent4.agda:22,13-23
 Global confluence check failed: (0 + l) + m can be rewritten to
 either 0 + (l + m) or l + m.
@@ -68,11 +33,46 @@ resolve the ambiguity.
 when checking confluence of the rewrite rule plus-assoc with
 plus-0l
 RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: (k + 0) + m can be rewritten to
+either k + (0 + m) or k + m.
+Possible fix: add a rewrite rule with left-hand side (k + 0) + m to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-0r
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: (suc m + l) + m₁ can be rewritten
+to either suc m + (l + m₁) or suc (m + l) + m₁.
+Possible fix: add a rewrite rule with left-hand side
+(suc m + l) + m₁ to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-l
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: (k + suc n) + m can be rewritten to
+either k + (suc n + m) or suc (k + n) + m.
+Possible fix: add a rewrite rule with left-hand side
+(k + suc n) + m to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-r
+RewritingNonConfluent4.agda:22,13-23
 Global confluence check failed: ((k + l) + l₁) + m can be rewritten
 to either (k + l) + (l₁ + m) or (k + (l + l₁)) + m.
 Possible fix: add a rewrite rule with left-hand side
 ((k + l) + l₁) + m to resolve the ambiguity.
 when checking confluence of the rewrite rule plus-assoc with itself
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: (k + l) + 0 can be rewritten to
+either k + (l + 0) or k + l.
+Possible fix: add a rewrite rule with left-hand side (k + l) + 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-0r
+RewritingNonConfluent4.agda:22,13-23
+Global confluence check failed: (k + l) + suc n can be rewritten to
+either k + (l + suc n) or suc ((k + l) + n).
+Possible fix: add a rewrite rule with left-hand side
+(k + l) + suc n to resolve the ambiguity.
+when checking confluence of the rewrite rule plus-assoc with
+plus-suc-r
 RewritingNonConfluent4.agda:36,13-23
 Global confluence check failed: suc m * 0 can be rewritten to
 either 0 + (m * 0) or 0.
@@ -81,60 +81,25 @@ resolve the ambiguity.
 when checking confluence of the rewrite rule mult-suc-l with
 mult-0r
 RewritingNonConfluent4.agda:37,13-23
-Global confluence check failed: suc m * suc n can be rewritten to
-either (suc m * n) + suc m or suc n + (m * suc n).
-Possible fix: add a rewrite rule with left-hand side suc m * suc n
-to resolve the ambiguity.
-when checking confluence of the rewrite rule mult-suc-r with
-mult-suc-l
-RewritingNonConfluent4.agda:37,13-23
 Global confluence check failed: 0 * suc n can be rewritten to
 either (0 * n) + 0 or 0.
 Possible fix: add a rewrite rule with left-hand side 0 * suc n to
 resolve the ambiguity.
 when checking confluence of the rewrite rule mult-suc-r with
 mult-0l
-RewritingNonConfluent4.agda:38,13-23
-Global confluence check failed: (k * l) * suc n can be rewritten to
-either k * (l * suc n) or ((k * l) * n) + (k * l).
-Possible fix: add a rewrite rule with left-hand side
-(k * l) * suc n to resolve the ambiguity.
-when checking confluence of the rewrite rule mult-assoc with
-mult-suc-r
-RewritingNonConfluent4.agda:38,13-23
-Global confluence check failed: (k * l) * 0 can be rewritten to
-either k * (l * 0) or 0.
-Possible fix: add a rewrite rule with left-hand side (k * l) * 0 to
-resolve the ambiguity.
-when checking confluence of the rewrite rule mult-assoc with
-mult-0r
+RewritingNonConfluent4.agda:37,13-23
+Global confluence check failed: suc m * suc n can be rewritten to
+either (suc m * n) + suc m or suc n + (m * suc n).
+Possible fix: add a rewrite rule with left-hand side suc m * suc n
+to resolve the ambiguity.
+when checking confluence of the rewrite rule mult-suc-r with
+mult-suc-l
 RewritingNonConfluent4.agda:38,13-23
 Global confluence check failed: ((k * l) * l₁) * m can be rewritten
 to either (k * l) * (l₁ * m) or (k * (l * l₁)) * m.
 Possible fix: add a rewrite rule with left-hand side
 ((k * l) * l₁) * m to resolve the ambiguity.
 when checking confluence of the rewrite rule mult-assoc with itself
-RewritingNonConfluent4.agda:38,13-23
-Global confluence check failed: (k * suc n) * m can be rewritten to
-either k * (suc n * m) or ((k * n) + k) * m.
-Possible fix: add a rewrite rule with left-hand side
-(k * suc n) * m to resolve the ambiguity.
-when checking confluence of the rewrite rule mult-assoc with
-mult-suc-r
-RewritingNonConfluent4.agda:38,13-23
-Global confluence check failed: (suc m * l) * m₁ can be rewritten
-to either suc m * (l * m₁) or (l + (m * l)) * m₁.
-Possible fix: add a rewrite rule with left-hand side
-(suc m * l) * m₁ to resolve the ambiguity.
-when checking confluence of the rewrite rule mult-assoc with
-mult-suc-l
-RewritingNonConfluent4.agda:38,13-23
-Global confluence check failed: (k * 0) * m can be rewritten to
-either k * (0 * m) or 0 * m.
-Possible fix: add a rewrite rule with left-hand side (k * 0) * m to
-resolve the ambiguity.
-when checking confluence of the rewrite rule mult-assoc with
-mult-0r
 RewritingNonConfluent4.agda:38,13-23
 Global confluence check failed: (0 * l) * m can be rewritten to
 either 0 * (l * m) or 0 * m.
@@ -143,8 +108,43 @@ resolve the ambiguity.
 when checking confluence of the rewrite rule mult-assoc with
 mult-0l
 RewritingNonConfluent4.agda:38,13-23
+Global confluence check failed: (k * 0) * m can be rewritten to
+either k * (0 * m) or 0 * m.
+Possible fix: add a rewrite rule with left-hand side (k * 0) * m to
+resolve the ambiguity.
+when checking confluence of the rewrite rule mult-assoc with
+mult-0r
+RewritingNonConfluent4.agda:38,13-23
+Global confluence check failed: (suc m * l) * m₁ can be rewritten
+to either suc m * (l * m₁) or (l + (m * l)) * m₁.
+Possible fix: add a rewrite rule with left-hand side
+(suc m * l) * m₁ to resolve the ambiguity.
+when checking confluence of the rewrite rule mult-assoc with
+mult-suc-l
+RewritingNonConfluent4.agda:38,13-23
+Global confluence check failed: (k * suc n) * m can be rewritten to
+either k * (suc n * m) or ((k * n) + k) * m.
+Possible fix: add a rewrite rule with left-hand side
+(k * suc n) * m to resolve the ambiguity.
+when checking confluence of the rewrite rule mult-assoc with
+mult-suc-r
+RewritingNonConfluent4.agda:38,13-23
 Global confluence check failed: ((k * l) * l₁) * m can be rewritten
 to either (k * l) * (l₁ * m) or (k * (l * l₁)) * m.
 Possible fix: add a rewrite rule with left-hand side
 ((k * l) * l₁) * m to resolve the ambiguity.
 when checking confluence of the rewrite rule mult-assoc with itself
+RewritingNonConfluent4.agda:38,13-23
+Global confluence check failed: (k * l) * 0 can be rewritten to
+either k * (l * 0) or 0.
+Possible fix: add a rewrite rule with left-hand side (k * l) * 0 to
+resolve the ambiguity.
+when checking confluence of the rewrite rule mult-assoc with
+mult-0r
+RewritingNonConfluent4.agda:38,13-23
+Global confluence check failed: (k * l) * suc n can be rewritten to
+either k * (l * suc n) or ((k * l) * n) + (k * l).
+Possible fix: add a rewrite rule with left-hand side
+(k * l) * suc n to resolve the ambiguity.
+when checking confluence of the rewrite rule mult-assoc with
+mult-suc-r

--- a/test/Fail/RsTSpanningComment.err
+++ b/test/Fail/RsTSpanningComment.err
@@ -1,2 +1,2 @@
-RsTSpanningComment.lagda.rst:2,4-5,19: Multi-line comment spans one or more literate text blocks.
 RsTSpanningComment.lagda.rst:8,3-13,7: Multi-line comment spans one or more literate text blocks.
+RsTSpanningComment.lagda.rst:2,4-5,19: Multi-line comment spans one or more literate text blocks.

--- a/test/Fail/Sections-2.agda
+++ b/test/Fail/Sections-2.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS -vtc.error:666 -verror:20 -vtc.term:30 #-}
 open import Common.Prelude
 
 postulate

--- a/test/Fail/Sections-2.err
+++ b/test/Fail/Sections-2.err
@@ -1,4 +1,242 @@
-Sections-2.agda:7,16-17
+{ checkExpr
+Checking Bool : _0
+           at  Sections-2.agda:5,19-23
+    -->  _0
+inferDef Bool
+  absolute type:     Set
+  instantiated type: Set
+  free vars:
+inferred def  Bool
+  : Set
+  --> Bool
+implicitNamedArgs Set
+checkApplication: checkHeadApplication returned
+  v =  Bool
+checkExpr Bool : Set
+  returns Bool
+}
+isType_ Bool
+  returns Bool
+{ checkExpr
+Checking if b then Nat else Bool : _1
+           at  Sections-2.agda:5,27-50
+    -->  _1
+inferDef if_then_else_
+  absolute type:     ({a : Agda.Primitive.Level} {A : Set a} →
+                      Bool → A → A → A)
+  instantiated type: ({a : Agda.Primitive.Level} {A : Set a} →
+                      Bool → A → A → A)
+  free vars:
+inferred def  if_then_else_
+  : ({a : Agda.Primitive.Level} {A : Set a} → Bool → A → A → A)
+  --> if_then_else_
+checkArgumentsE
+  e     = b
+  sFun  = ({a : Agda.Primitive.Level} {A : Set a} → Bool → A → A → A)
+  sApp  = _1
+calling implicitNamedArgs
+  sFun =  ({a : Agda.Primitive.Level} {A : Set a} → Bool → A → A → A)
+  hx   =  NotHidden
+  mx   =  nothing
+implicitNamedArgs ({a : Agda.Primitive.Level} {A : Set a} →
+                   Bool → A → A → A)
+implicitNamedArgs ({A : Set _a_2} → Bool → A → A → A)
+implicitNamedArgs (Bool → _A_3 → _A_3 → _A_3)
+Checking named arg b : Bool
+{ checkExpr
+Checking b : Bool
+           at  Sections-2.agda:5,30-31
+    -->  Bool
+variable b ( Var 0 [] ) has type: Bool
+implicitNamedArgs Bool
+checkApplication: checkHeadApplication returned
+  v =  b
+checkExpr b : Bool
+  returns b
+}
+checkArgumentsE
+  e     = Nat
+  sFun  = (_A_3 → _A_3 → _A_3)
+  sApp  = _1
+calling implicitNamedArgs
+  sFun =  (_A_3 → _A_3 → _A_3)
+  hx   =  NotHidden
+  mx   =  nothing
+implicitNamedArgs (_A_3 → _A_3 → _A_3)
+Checking named arg Nat : _A_3
+{ checkExpr
+Checking Nat : _A_3
+           at  Sections-2.agda:5,37-40
+    -->  _A_3
+inferDef Nat
+  absolute type:     Set
+  instantiated type: Set
+  free vars:
+inferred def  Nat
+  : Set
+  --> Nat
+implicitNamedArgs Set
+checkApplication: checkHeadApplication returned
+  v =  Nat
+checkExpr Nat : Set
+  returns Nat
+}
+checkArgumentsE
+  e     = Bool
+  sFun  = (Set → Set)
+  sApp  = _1
+calling implicitNamedArgs
+  sFun =  (Set → Set)
+  hx   =  NotHidden
+  mx   =  nothing
+implicitNamedArgs (Set → Set)
+Checking named arg Bool : Set
+{ checkExpr
+Checking Bool : Set
+           at  Sections-2.agda:5,46-50
+    -->  Set
+inferDef Bool
+  absolute type:     Set
+  instantiated type: Set
+  free vars:
+inferred def  Bool
+  : Set
+  --> Bool
+implicitNamedArgs Set
+checkApplication: checkHeadApplication returned
+  v =  Bool
+checkExpr Bool : Set
+  returns Bool
+}
+implicitNamedArgs Set
+checkApplication: checkHeadApplication returned
+  v =  if b then Nat else Bool
+checkExpr if b then Nat else Bool : Set
+  returns if b then Nat else Bool
+}
+isType_ if b then Nat else Bool
+  returns if b then Nat else Bool
+isType_ Set
+  returns Set
+isType_ if b then Nat else Bool → Set
+  returns if b then Nat else Bool → Set
+isType_ (b : Bool) → if b then Nat else Bool → Set
+  returns (b : Bool) → if b then Nat else Bool → Set
+isType_ Set
+  returns Set
+{ checkExpr
+Checking foo_bar 5 : Set
+           at  Sections-2.agda:8,8-17
+    -->  Set
+{ checkExpr
+Checking λ section → foo section bar 5 : Set
+           at  Sections-2.agda:8,8-17
+    -->  Set
+checkLambda before insertion xs = [section]
+insertImplicitBindersT
+  bs  =  [section]
+  tel = 
+  ty  =  Set
+checkLambda xs = [section]
+possiblePath   = True
+numbinds       = 1
+typ            = _
+{ checkExpr
+Checking _ : _4
+           at  Sections-2.agda:8,8-17
+    -->  _4
+checkExpr _ : _4
+  returns _section_5
+}
+isType_ _
+  returns _section_5
+dontUseTargetType tel = (section : _5@5468061560674487983)
+{ checkExpr
+Checking foo section bar 5 : _7
+           at  Sections-2.agda:8,8-17
+    -->  _7
+inferDef foo_bar_
+  absolute type:     (b : Bool) → if b then Nat else Bool → Set
+  instantiated type: (b : Bool) → if b then Nat else Bool → Set
+  free vars:
+inferred def  foo_bar_
+  : (b : Bool) → if b then Nat else Bool → Set
+  --> foo_bar_
+checkArgumentsE
+  e     = section
+  sFun  = (b : Bool) → if b then Nat else Bool → Set
+  sApp  = _7
+calling implicitNamedArgs
+  sFun =  (b : Bool) → if b then Nat else Bool → Set
+  hx   =  NotHidden
+  mx   =  nothing
+implicitNamedArgs (b : Bool) → if b then Nat else Bool → Set
+Checking named arg b = section : Bool
+{ checkExpr
+Checking section : Bool
+           at  Sections-2.agda:8,8-15
+    -->  Bool
+variable section ( Var 0 [] ) has type: _section_5
+implicitNamedArgs _section_5
+checkApplication: checkHeadApplication returned
+  v =  section
+checkExpr section : Bool
+  returns section
+}
+checkArgumentsE
+  e     = 5
+  sFun  = if section then Nat else Bool → Set
+  sApp  = _7
+calling implicitNamedArgs
+  sFun =  if section then Nat else Bool → Set
+  hx   =  NotHidden
+  mx   =  nothing
+implicitNamedArgs if section then Nat else Bool → Set
+Checking named arg 5 : if section then Nat else Bool
+{ checkExpr
+Checking 5 : if section then Nat else Bool
+           at  Sections-2.agda:8,16-17
+    -->  if section then Nat else Bool
+Error raised at typeError, called at src/full/Agda/TypeChecking/SizedTypes.hs:«line»:«col» in «Agda-package»:Agda.TypeChecking.SizedTypes
+Deferring type error:
+Sections-2.agda:8,16-17
+Nat != (if section then Nat else Bool)
+when checking that the expression 5 has type
+if section then Nat else Bool
+Current task:
+TaskId {getTaskId = 12}
+Error raised at typeError, called at src/full/Agda/TypeChecking/SizedTypes.hs:«line»:«col» in «Agda-package»:Agda.TypeChecking.SizedTypes
+Deferral token: _8
+checkExpr 5 : if section then Nat else Bool
+  returns _8
+}
+implicitNamedArgs Set
+checkApplication: checkHeadApplication returned
+  v =  foo section bar _8
+checkExpr foo section bar 5 : Set
+  returns foo section bar _8
+}
+Error raised at typeError, called at src/full/Agda/TypeChecking/Conversion.hs:«line»:«col» in «Agda-package»:Agda.TypeChecking.Conversion
+Deferring type error:
+Sections-2.agda:8,8-17
+(section : Bool) → Set !=< Set
+when checking that the expression λ section → foo section bar 5 has
+type Set
+Current task:
+TaskId {getTaskId = 12}
+Error raised at typeError, called at src/full/Agda/TypeChecking/Conversion.hs:«line»:«col» in «Agda-package»:Agda.TypeChecking.Conversion
+Deferral token: _4
+checkExpr λ section → foo section bar 5 : Set
+  returns _4
+}
+checkExpr foo_bar 5 : Set
+  returns _4
+}
+Sections-2.agda:8,8-17
+(section : Bool) → Set !=< Set
+when checking that the expression λ section → foo section bar 5 has
+type Set
+Sections-2.agda:8,16-17
 Nat != (if section then Nat else Bool)
 when checking that the expression 5 has type
 if section then Nat else Bool

--- a/test/Fail/SetOmega.err
+++ b/test/Fail/SetOmega.err
@@ -1,3 +1,5 @@
 SetOmega.agda:6,22-31
 Agda.Primitive.Setω != Set _a_3
 when checking that the expression ∀ a → Set a has type Set _a_3
+Unsolved metas at the following locations:
+  SetOmega.agda:6,12-18

--- a/test/Fail/ShapeIrrelevantParameterNoBecauseOfRecursion.err
+++ b/test/Fail/ShapeIrrelevantParameterNoBecauseOfRecursion.err
@@ -1,3 +1,10 @@
 ShapeIrrelevantParameterNoBecauseOfRecursion.agda:15,12-13
 Variable b is declared irrelevant, so it cannot be used here
 when checking that the expression b has type Bool
+ShapeIrrelevantParameterNoBecauseOfRecursion.agda:26,14-15
+a != b of type Bool
+when checking that the expression x has type D b
+Failed to solve the following constraints:
+  _8 (b = b) = b : Bool (blocked on _8)
+Unsolved metas at the following locations:
+  ShapeIrrelevantParameterNoBecauseOfRecursion.agda:29,33-34

--- a/test/Fail/ShouldBePi.err
+++ b/test/Fail/ShouldBePi.err
@@ -1,3 +1,12 @@
 ShouldBePi.agda:8,8-15
 (x : _4) → _4 !=< One
 when checking that the expression λ x → x has type One
+ShouldBePi.agda:11,8-11
+One should be a function type, but it isn't
+when checking that one is a valid argument to a function of type
+One
+ShouldBePi.agda:14,6-7
+Cannot eliminate type One with variable pattern x (did you supply
+too many arguments?)
+when checking the clause left hand side
+err3 x

--- a/test/Fail/StaleMetaLiteral.err
+++ b/test/Fail/StaleMetaLiteral.err
@@ -2,3 +2,5 @@ StaleMetaLiteral.agda:14,7-28
 Can't unquote stale metavariable Imports.StaleMetaLiteral._14
 when checking that the expression unquote (unquoteMeta staleMeta)
 has type _A_4
+Failed to solve the following constraints:
+  _5 = 42 : Nat (blocked on _5)

--- a/test/Fail/StronglyRigidOccurrence.err
+++ b/test/Fail/StronglyRigidOccurrence.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _11 = suc _11 : Nat (blocked on _11)
 Unsolved metas at the following locations:
   StronglyRigidOccurrence.agda:13,25-26
-  StronglyRigidOccurrence.agda:14,8-12

--- a/test/Fail/SubjectReduction.err
+++ b/test/Fail/SubjectReduction.err
@@ -1,5 +1,20 @@
+SubjectReduction.agda:26,18-46
+SubjectReduction.♯-3 eq P Px t != SubjectReduction.♯-2 of type
+∞ Stream
+when checking that the expression eq (λ s → P (tick (♯ s))) Px has
+type P (tick SubjectReduction.♯-2)
 SubjectReduction.agda:26,44-46
 SubjectReduction.♯-1 != (SubjectReduction.♯-3 eq P Px s) of type
 (∞ Stream)
 when checking that the expression Px has type
 P (tick (SubjectReduction.♯-3 eq P Px s))
+SubjectReduction.agda:35,6-67
+SubjectReduction.♯-3 != SubjectReduction.♯-6 of type ∞ Stream
+when checking that the expression
+((_ → Eq (tick (♯ ticks)) (tick (♯ tick (♯ ticks)))) ∶ l₂) l₁ has
+type Goal
+SubjectReduction.agda:35,61-63
+SubjectReduction.♯-6 != SubjectReduction.♯-1 of type ∞ Stream
+when checking that the expression l₂ has type
+Eq _s_56 _t_57 →
+Eq (tick SubjectReduction.♯-6) (tick SubjectReduction.♯-7)

--- a/test/Fail/TermSplicing1.err
+++ b/test/Fail/TermSplicing1.err
@@ -1,3 +1,6 @@
 TermSplicing1.agda:6,19-22
 Set₁ !=< Term
 when checking that the expression Set has type Term
+Unsolved metas at the following locations:
+  TermSplicing1.agda:6,1-2
+  TermSplicing1.agda:6,5-23

--- a/test/Fail/UnequalTerms.err
+++ b/test/Fail/UnequalTerms.err
@@ -1,3 +1,7 @@
 UnequalTerms.agda:8,8-11
 One !=< Zero
 when checking that the expression one has type Zero
+UnequalTerms.agda:11,8-26
+One !=< Zero
+when checking that the expression λ (x : Zero) → one has type
+One → One

--- a/test/Fail/UnifyWithIrrelevantArgument.err
+++ b/test/Fail/UnifyWithIrrelevantArgument.err
@@ -2,4 +2,3 @@ Failed to solve the following constraints:
   _8 (A = A) _ = x : A (blocked on _8)
 Unsolved metas at the following locations:
   UnifyWithIrrelevantArgument.agda:9,16-17
-  UnifyWithIrrelevantArgument.agda:11,12-16


### PR DESCRIPTION
_I will write a better description ✨  tomorrow ✨._

Implements the elaborator half of #6659 by catching type errors at every checkExpr call and turning them into warnings instead. A metavariable with a special instantiation is created to stand for the failed elaboration result.

Deferred errors are printed first in the warning list, and they're printed in source order (sorted by range); Constraints generated by definitions _containing hard errors_ are suppressed from the output to prevent blowup (e.g. in the case where `A → B → ... → C` and `C` has an error, you get a pile of HasPTSRule constraints)

TODO:
- Aesthetic improvements eg by merging errors of the same kind: `test/Fail/IrrelevantLevelHurkens.err`
- Some of our test cases have multiple typing issues that were buried behind an early failure eg `test/Fail/Issue2301.err`
- Some typing-related tests eg the recent Propω stuff seem to check multiple times?
- I forgot to remove some of my debug prints from the test cases
- Improve granularity of unsolved constraint suppression