### PR TITLE
[ workflow ] Use the latest stable release as the start tag

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -57,6 +57,9 @@ updateVersion() {
     sed -ri "s/(\(\s*defvar\s+agda2-version\s+)\"[0-9.]+\"/\1\"$version\"/" \
         src/data/emacs-mode/agda2-mode.el
 
+    # Update the tag in the deployment workflow
+    sed -ri "s/--notes-start-tag v[0-9.]+/--notes-start-tag v$version/" deploy.yml
+
     sed -ri "s/^(VERSION\s+=\s+).*/\1$version/" mk/paths.mk
 
     sed -ri "s/\"Agda version [0-9.]+\"/\"Agda version $version\"/" \

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -294,4 +294,4 @@ jobs:
       run: |
         gh release delete 'nightly' --repo agda/agda --cleanup-tag --yes || true
         ls -R artifacts
-        gh release create 'nightly' artifacts/**/* --repo agda/agda --generate-notes --title "Nightly Build (${{ needs.build.outputs.sha }}@master)"
+        gh release create 'nightly' artifacts/**/* --repo agda/agda --generate-notes --notes-start-tag v2.6.3 --title "Nightly Build (${{ needs.build.outputs.sha }}@master)"


### PR DESCRIPTION
Just to make the release note for nightly builds more helpful.