### PR TITLE
Testcase for fixed #6542

### DIFF
--- a/test/Succeed/Issue6542.agda
+++ b/test/Succeed/Issue6542.agda
@@ -1,0 +1,59 @@
+-- Andreas, 2023-05-29, issue #6542, test case by Oskar Eriksson
+-- Temporary regression in 2.6.4 (master).
+-- Fixed by rolling back type-directed occurs checker.
+
+open import Agda.Builtin.Sigma
+import Issue6542.Import as I
+
+module Issue6542 (M : Set) {{rel : I.R M}} where
+
+open I M
+
+escape : ∀ {A} → Γ ⊩ A → Γ ⊢ A
+escape (Tᵣ ⊢Γ) = Tⱼ ⊢Γ
+
+postulate
+  escape′ : ([A] : Γ ⊩ A)
+           → Γ ⊩ A / [A]
+           → Γ ⊢ A
+  magic : {A : Set} → A
+  liftSubstS : ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
+               ([A] : Γ ⊩ᵛ A / [Γ])
+               ([σ] : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
+             → (Δ ∙ subst σ A) ⊩ˢ liftSubst σ ∷ Γ ∙ A / [Γ] ∙ [A]
+                               / (⊢Δ ∙ escape (fst (unwrap [A] _ _ ⊢Δ [σ])))
+  liftSubstSEq : ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
+                 ([A] : Γ ⊩ᵛ A / [Γ])
+                 ([σ] : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
+                 ([σ]′ : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ / [σ])
+               → (Δ ∙ subst σ A) ⊩ˢ liftSubst σ ∷ Γ ∙ A / [Γ] ∙ [A]
+                             / (⊢Δ ∙ escape (fst (unwrap [A] _ _ ⊢Δ [σ])))
+                             / liftSubstS {A = A} [Γ] ⊢Δ [A] [σ]
+
+foo : ([Γ] : ⊩ᵛ Γ)
+    → (⊢Δ   : ⊢ Δ)
+      ([σ]  : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
+      ([A] : Γ ∙ T ⊩ᵛ A / [Γ] ∙ (Tᵛ [Γ]))
+      ([B] : Γ ∙ T ∙ A ⊩ᵛ B / [Γ] ∙ (Tᵛ [Γ]) ∙ [A])
+    → Set₁
+foo {Γ = Γ} {Δ = Δ} {σ} {A} {B} [Γ] ⊢Δ [σ] [A] [B] =
+  let [T] = Tᵛ [Γ]
+      ⊢T = Tⱼ ⊢Δ
+      [σA] = fst (unwrap [A] _ (liftSubst σ) (⊢Δ ∙ ⊢T)
+                             (liftSubstS {A = T} [Γ] ⊢Δ [T] [σ]))
+      ⊢A = escape [σA]
+      ⊢ΔT = ⊢Δ ∙ Tⱼ ⊢Δ
+      [ΓT] = [Γ] ∙ [T]
+      ⊢ΔTA = ⊢Δ ∙ ⊢T ∙ ⊢A
+      σA = subst (liftSubst σ) A
+      [σ⇑⇑] = liftSubstS {A = A} {σ = liftSubst σ} [ΓT] ⊢ΔT [A]
+                         (liftSubstS {A = T} {σ = σ} [Γ] ⊢Δ [T] [σ])
+      [σ⇑]′ : Δ ∙ T ⊩ˢ liftSubst σ ∷ Γ ∙ T / [ΓT] / ⊢ΔT
+                     / liftSubstS {A = T} {σ = σ} [Γ] ⊢Δ [T] [σ]
+      [σ⇑]′ = magic
+      [σ⇑⇑]′ = liftSubstSEq {A = A} [ΓT] ⊢ΔT [A]
+                            (liftSubstS {A = T} [Γ] ⊢Δ [T] [σ]) [σ⇑]′
+      [σB] =  fst (unwrap [B] _ (liftSubst (liftSubst σ)) ⊢ΔTA [σ⇑⇑])
+      qwer = snd (unwrap [B] _ _ ⊢ΔTA [σ⇑⇑]) [σ⇑⇑]′
+      qwe = escape′ [σB] qwer
+  in  Set

--- a/test/Succeed/Issue6542.flags
+++ b/test/Succeed/Issue6542.flags
@@ -1,0 +1,1 @@
+--no-double-check

--- a/test/Succeed/Issue6542/Import.agda
+++ b/test/Succeed/Issue6542/Import.agda
@@ -1,0 +1,87 @@
+module Issue6542.Import (M : Set) where
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Sigma
+
+data Term : Set where
+  var : (x : Nat) → Term
+  T : Term
+
+infixl 30 _∙_
+data Con : Set where
+  _∙_ : Con → Term → Con
+
+Subst : Set
+Subst = Nat → Term
+
+variable
+  t A B : Term
+  Γ Δ : Con
+  σ : Subst
+
+head : Subst → Term
+head σ = σ zero
+
+tail : Subst → Subst
+tail σ x = σ (suc x)
+
+liftSubst : (σ : Subst) → Subst
+liftSubst σ zero    = var zero
+liftSubst σ (suc x) = σ x
+
+subst : (σ : Subst) (t : Term) → Term
+subst σ (var x) = σ x
+subst σ T = T
+
+mutual
+  data ⊢_ : Con → Set where
+    _∙_ : ⊢ Γ → Γ ⊢ A → ⊢ Γ ∙ A
+
+  data _⊢_ (Γ : Con) : Term → Set where
+    Tⱼ : ⊢ Γ → Γ ⊢ T
+
+record R : Set where
+
+data _⊩T_ : (Γ : Con) (A : Term) → Set where
+  Tᵣ : ⊢ Γ → Γ ⊩T T
+
+_⊩_ : (Γ : Con) → Term → Set
+Γ ⊩ A = Γ ⊩T A
+
+_⊩_/_ : (Γ : Con) (A : Term) → Γ ⊩ A → Set
+Γ ⊩ A / Tᵣ x = Γ ⊩T A
+
+_⊩_∷_/_ : (Γ : Con) (t A : Term) → Γ ⊩ A → Set
+Γ ⊩ t ∷ .T / Tᵣ x = ⊤
+
+mutual
+  data ⊩ᵛ_ : Con → Set where
+    _∙_ : ∀ {A} ([Γ] : ⊩ᵛ Γ) → Γ ⊩ᵛ A / [Γ]
+        → ⊩ᵛ Γ ∙ A
+
+  record _⊩ᵛ_/_ (Γ : Con) (A : Term) ([Γ] : ⊩ᵛ Γ) : Set where
+    constructor wrap
+    field
+      unwrap :
+        ∀ (Δ : Con) σ (⊢Δ : ⊢ Δ) ([σ] : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
+        → Σ (Δ ⊩ subst σ A) (λ [Aσ]
+        → ([σ] : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ / [σ])
+        → Δ ⊩ subst σ A / [Aσ])
+
+  _⊩ˢ_∷_/_/_ : (Δ : Con) (σ : Subst) (Γ : Con) ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
+             → Set
+  Δ ⊩ˢ σ ∷ .(Γ ∙ A) / (_∙_ {Γ = Γ} {A} [Γ] [A]) / ⊢Δ =
+    Σ (Δ ⊩ˢ tail σ ∷ Γ / [Γ] / ⊢Δ) λ [tailσ] →
+      (Δ ⊩ head σ ∷ subst (tail σ) A / fst (_⊩ᵛ_/_.unwrap [A] _ _ ⊢Δ [tailσ]))
+
+  _⊩ˢ_∷_/_/_/_ : (Δ : Con) (σ : Subst) (Γ : Con) ([Γ] : ⊩ᵛ Γ)
+                 (⊢Δ : ⊢ Δ) ([σ] : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ) → Set
+  Δ ⊩ˢ σ ∷ .(Γ ∙ A) / (_∙_ {Γ = Γ} {A} [Γ] [A]) / ⊢Δ / [σ] =
+    Σ (Δ ⊩ˢ tail σ ∷ Γ / [Γ] / ⊢Δ / fst [σ]) λ _ →
+      (Δ ⊩ head σ ∷ subst (tail σ) A / fst (_⊩ᵛ_/_.unwrap [A] _ _ ⊢Δ (fst [σ])))
+
+open _⊩ᵛ_/_ public
+
+Tᵛ : ∀ ([Γ] : ⊩ᵛ Γ) → Γ ⊩ᵛ T / [Γ]
+Tᵛ [Γ] = wrap (λ Δ σ ⊢Δ [σ] → (Tᵣ ⊢Δ) , (λ [σ≡σ′] → Tᵣ ⊢Δ))


### PR DESCRIPTION
This test passed on my machine but broke CI: https://github.com/agda/agda/actions/runs/5113649657/jobs/9193539130#step:10:20
```
+out > Issue6542.agda:57,46-52
+out > The constructor _,_ does not construct an element of
+out > ((M I.⊩ˢ Δ ∙ T ∷ I.liftSubst M σ / rel / A) (⊢Δ ∙ Tⱼ ⊢Δ))
+out > when checking that the solution
+out > fst (liftSubstS [Γ] ⊢Δ (I.Tᵛ M [Γ]) [σ]) , Agda.Builtin.Unit.tt of
+out > metavariable _202 has the expected type
+out > (M I.⊩ˢ Δ ∙ T ∷ I.liftSubst M σ / rel / A) (⊢Δ ∙ Tⱼ ⊢Δ)
```

Test is from
- #6542

It breaks with `--double-check`.

We can either switch `--double-check` off for this case, or investigate the failure (possibly then for 2.6.5).