### PR TITLE
[ fix #6636 ] Add --no-eta-singleton flag

### DIFF
--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -129,6 +129,7 @@ module Agda.Interaction.Options.Base
     , optPatternMatching
     , optHiddenArgumentPuns
     , optEta
+    , optEtaSingleton
     , optForcing
     , optProjectionLike
     , optErasure
@@ -344,6 +345,7 @@ data PragmaOptions = PragmaOptions
   , _optHiddenArgumentPuns        :: WithDefault 'False
       -- ^ Should patterns of the form @{x}@ or @⦃ x ⦄@ be interpreted as puns?
   , _optEta                       :: WithDefault 'True
+  , _optEtaSingleton              :: WithDefault 'True
   , _optForcing                   :: WithDefault 'True
       -- ^ Perform the forcing analysis on data constructors?
   , _optProjectionLike            :: WithDefault 'True
@@ -474,6 +476,7 @@ optCopatterns                :: PragmaOptions -> Bool
 optPatternMatching           :: PragmaOptions -> Bool
 optHiddenArgumentPuns        :: PragmaOptions -> Bool
 optEta                       :: PragmaOptions -> Bool
+optEtaSingleton              :: PragmaOptions -> Bool
 optForcing                   :: PragmaOptions -> Bool
 optProjectionLike            :: PragmaOptions -> Bool
 -- | 'optErasure' is implied by 'optEraseRecordParameters'.
@@ -535,6 +538,7 @@ optCopatterns                = collapseDefault . _optCopatterns
 optPatternMatching           = collapseDefault . _optPatternMatching
 optHiddenArgumentPuns        = collapseDefault . _optHiddenArgumentPuns
 optEta                       = collapseDefault . _optEta
+optEtaSingleton              = collapseDefault . _optEtaSingleton
 optForcing                   = collapseDefault . _optForcing
 optProjectionLike            = collapseDefault . _optProjectionLike
 -- --erase-record-parameters implies --erasure
@@ -690,6 +694,9 @@ lensOptHiddenArgumentPuns f o = f (_optHiddenArgumentPuns o) <&> \ i -> o{ _optH
 
 lensOptEta :: Lens' PragmaOptions _
 lensOptEta f o = f (_optEta o) <&> \ i -> o{ _optEta = i }
+
+lensOptEtaSingleton :: Lens' PragmaOptions _
+lensOptEtaSingleton f o = f (_optEta o) <&> \ i -> o{ _optEtaSingleton = i }
 
 lensOptForcing :: Lens' PragmaOptions _
 lensOptForcing f o = f (_optForcing o) <&> \ i -> o{ _optForcing = i }
@@ -875,6 +882,7 @@ defaultPragmaOptions = PragmaOptions
   , _optExactSplit                = Default
   , _optHiddenArgumentPuns        = Default
   , _optEta                       = Default
+  , _optEtaSingleton              = Default
   , _optForcing                   = Default
   , _optProjectionLike            = Default
   , _optErasure                   = Default
@@ -1168,6 +1176,7 @@ infectiveCoinfectiveOptions =
                                               "--no-universe-polymorphism"
   , coinfectiveOption (not . optCumulativity) "--no-cumulativity"
   , coinfectiveOption optLevelUniverse        "--level-universe"
+  , coinfectiveOption (not . optEtaSingleton) "--no-eta-singleton"
   , infectiveOption (isJust . optCubical)     "--cubical/--erased-cubical"
   , infectiveOption optGuarded                "--guarded"
   , infectiveOption optProp                   "--prop"
@@ -1676,6 +1685,9 @@ pragmaOptions = concat
   , pragmaFlag      "eta-equality" lensOptEta
                     "default records to eta-equality" ""
                     $ Just "default records to no-eta-equality"
+  , pragmaFlag      "eta-singleton" lensOptEtaSingleton
+                    "enable eta equality for record types with no fields, or only irrelevant/erased fields" ""
+                    $ Just "disable eta equality for record types with only irrelevant/erased fields"
   , pragmaFlag      "forcing" lensOptForcing
                     "enable the forcing analysis for data constructors" "(optimisation)"
                     $ Just "disable the forcing analysis"

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -308,8 +308,8 @@ instance EmbPrj InfectiveCoinfective where
     valu _   = malformed
 
 instance EmbPrj PragmaOptions where
-  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo) =
-    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo
+  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp) =
+    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp
 
   value = valueN PragmaOptions
 

--- a/test/Fail/NoEtaSingleton.agda
+++ b/test/Fail/NoEtaSingleton.agda
@@ -1,0 +1,10 @@
+{-# OPTIONS --no-eta-singleton #-}
+
+record ⊤ : Set where
+  constructor tt
+
+data _≡_ (x : ⊤) : ⊤ → Set where
+  refl : x ≡ x
+
+test : (x y : ⊤) → x ≡ y
+test x y = refl


### PR DESCRIPTION
This implements a basic version of #6636 by adding a `--no-eta-singleton` flag. Currently it actually disables *all* record that do not have at least one relevant field.

Currently it works by disabling eta-equality at the *definition site* of the record. This has the disadvantage that one cannot add this flag to `Agda.Builtin.Unit` (or other builtin files that import this), unless we are fine with breaking all code that imports it. A more flexible approach would be to only apply the flag at the *usage site*, but this would require a separate tag for each eta-record type to keep track of whether it has at least one relevant field.

TODO:
- [ ] Implement the usage-site version of this flag
- [ ] Add this flag to Builtin modules
- [ ] Also disallow record types with all fields in `Prop`
- [ ] Have variant of the flag that still allows records with at least one erased field
- [ ] Fix https://github.com/agda/agda/issues/5703 for when this flag is enabled