### PR TITLE
Add pretty printing for Compiled

### DIFF
--- a/src/full/Agda/Compiler/Treeless/Pretty.hs
+++ b/src/full/Agda/Compiler/Treeless/Pretty.hs
@@ -17,6 +17,13 @@ import Agda.Utils.Pretty
 
 import Agda.Utils.Impossible
 
+instance Pretty Compiled where
+  pretty Compiled {cTreeless, cArgUsage} =
+    "Compiled {" <?> vcat
+      [ "cTreeless   =" <?> pretty cTreeless
+      , "funCompiled =" <?> pshow cArgUsage
+      ] <?> "}"
+
 data PEnv = PEnv { pPrec :: Int
                  , pFresh :: [String]
                  , pBound :: [String] }

--- a/src/full/Agda/Compiler/Treeless/Pretty.hs-boot
+++ b/src/full/Agda/Compiler/Treeless/Pretty.hs-boot
@@ -1,0 +1,7 @@
+
+module Agda.Compiler.Treeless.Pretty () where
+
+import Agda.Syntax.Treeless
+import Agda.Utils.Pretty
+
+instance Pretty Compiled

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -60,6 +60,7 @@ import GHC.Generics (Generic)
 
 import Agda.Benchmarking (Benchmark, Phase)
 
+import {-# SOURCE #-} Agda.Compiler.Treeless.Pretty () -- Instances only
 import Agda.Syntax.Common
 import Agda.Syntax.Builtin (SomeBuiltin, BuiltinId, PrimitiveId)
 import qualified Agda.Syntax.Concrete as C
@@ -2777,7 +2778,7 @@ instance Pretty FunctionData where
       [ "funClauses      =" <?> vcat (map pretty funClauses)
       , "funCompiled     =" <?> pretty funCompiled
       , "funSplitTree    =" <?> pretty funSplitTree
-      , "funTreeless     =" <?> pshow funTreeless
+      , "funTreeless     =" <?> pretty funTreeless
       , "funInv          =" <?> pretty funInv
       , "funMutual       =" <?> pshow funMutual
       , "funAbstr        =" <?> pshow funAbstr


### PR DESCRIPTION
Hi! I wanted to make the following change to the pretty printing for `FunctionData`:
```haskell
-     , "funTreeless     =" <?> pshow funTreeless
+     , "funTreeless     =" <?> pretty funTreeless
```
However, this resulted in a lot of circular dependencies because of the orphaned instances in `Compiler/Treeless/Pretty` and `Compiler/Treeless/Subst`. I thought the best solution was to remove the orphaned instance by moving the instances (and all the other files in `Compiler/Treeless`) to the `Syntax` directory. This seems to better correspond with the other syntaxes (Abstract, Concrete, and Internal), and it also solves the "hack" in `Compiler/Backend.hs-boot`.

Alternatively, it is maybe feasible to solve this with `{-# SOURCE #-}` and `hs-boot` but I didn't find an easy way to do it.

Note: this is my first PR to Agda so I may be doing something wrong.