### PR TITLE
Remove Delayed clauses/definitions

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -484,7 +484,7 @@ instance Reify Constraint where
             (,,) <$> reify tm <*> reify tm <*> reify ty)
     reify (IsEmpty r a) = IsEmptyType <$> reify a
     reify (CheckSizeLtSat a) = SizeLtSat  <$> reify a
-    reify (CheckFunDef d i q cs err) = do
+    reify (CheckFunDef i q cs err) = do
       a <- reify =<< defType <$> getConstInfo q
       return $ PostponedCheckFunDef q a err
     reify (HasBiggerSort a) = OfType <$> reify a <*> reify (UnivSort a)

--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -208,7 +208,7 @@ instance Hilite A.Declaration where
                                                 hl a <> hl dir
       A.Import mi x dir                      -> hl mi <> hl x <> hl dir
       A.Open mi x dir                        -> hl mi <> hl x <> hl dir
-      A.FunDef _di x _delayed cs             -> hl x <> hl cs
+      A.FunDef _di x cs                      -> hl x <> hl cs
       A.DataSig _di er x tel e               -> hl er <> hl x <> hl tel <> hl e
       A.DataDef _di x _uc pars cs            -> hl x <> hl pars <> hl cs
       A.RecSig _di er x tel e                -> hl er <> hl x <> hl tel <> hl e

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -175,7 +175,7 @@ data Declaration
     -- ^ The @ImportDirective@ is for highlighting purposes.
   | Pragma     Range      Pragma
   | Open       ModuleInfo ModuleName ImportDirective
-  | FunDef     DefInfo QName Delayed [Clause] -- ^ sequence of function clauses
+  | FunDef     DefInfo QName [Clause] -- ^ sequence of function clauses
   | DataSig    DefInfo Erased QName GeneralizeTelescope Type -- ^ lone data signature
   | DataDef    DefInfo QName UniverseCheck DataDefParams [Constructor]
   | RecSig     DefInfo Erased QName GeneralizeTelescope Type -- ^ lone record signature
@@ -602,7 +602,7 @@ instance Eq Declaration where
   Import a1 b1 c1                == Import a2 b2 c2                = (a1, b1, c1) == (a2, b2, c2)
   Pragma a1 b1                   == Pragma a2 b2                   = (a1, b1) == (a2, b2)
   Open a1 b1 c1                  == Open a2 b2 c2                  = (a1, b1, c1) == (a2, b2, c2)
-  FunDef a1 b1 c1 d1             == FunDef a2 b2 c2 d2             = (a1, b1, c1, d1) == (a2, b2, c2, d2)
+  FunDef a1 b1 c1                == FunDef a2 b2 c2                = (a1, b1, c1) == (a2, b2, c2)
   DataSig a1 b1 c1 d1 e1         == DataSig a2 b2 c2 d2 e2         = (a1, b1, c1, d1, e1) == (a2, b2, c2, d2, e2)
   DataDef a1 b1 c1 d1 e1         == DataDef a2 b2 c2 d2 e2         = (a1, b1, c1, d1, e1) == (a2, b2, c2, d2, e2)
   RecSig a1 b1 c1 d1 e1          == RecSig a2 b2 c2 d2 e2          = (a1, b1, c1, d1, e1) == (a2, b2, c2, d2, e2)
@@ -680,7 +680,7 @@ instance HasRange Declaration where
     getRange (Pragma     i _        )  = getRange i
     getRange (Open       i _ _      )  = getRange i
     getRange (ScopedDecl _ d        )  = getRange d
-    getRange (FunDef     i _ _ _    )  = getRange i
+    getRange (FunDef     i _ _      )  = getRange i
     getRange (DataSig    i _ _ _ _  )  = getRange i
     getRange (DataDef    i _ _ _ _  )  = getRange i
     getRange (RecSig     i _ _ _ _  )  = getRange i
@@ -817,7 +817,7 @@ instance KillRange Declaration where
   killRange (Pragma     i a           ) = Pragma (killRange i) a
   killRange (Open       i x dir       ) = killRangeN Open       i x dir
   killRange (ScopedDecl a d           ) = killRangeN (ScopedDecl a) d
-  killRange (FunDef  i a b c          ) = killRangeN FunDef  i a b c
+  killRange (FunDef  i a b            ) = killRangeN FunDef  i a b
   killRange (DataSig i a b c d        ) = killRangeN DataSig i a b c d
   killRange (DataDef i a b c d        ) = killRangeN DataDef i a b c d
   killRange (RecSig  i a b c d        ) = killRangeN RecSig  i a b c d
@@ -935,7 +935,7 @@ instance AnyAbstract Declaration where
   anyAbstract (Mutual     _ ds)      = anyAbstract ds
   anyAbstract (ScopedDecl _ ds)      = anyAbstract ds
   anyAbstract (Section _ _ _ _ ds)   = anyAbstract ds
-  anyAbstract (FunDef i _ _ _)       = defAbstract i == AbstractDef
+  anyAbstract (FunDef i _ _)         = defAbstract i == AbstractDef
   anyAbstract (DataDef i _ _ _ _)    = defAbstract i == AbstractDef
   anyAbstract (RecDef i _ _ _ _ _ _) = defAbstract i == AbstractDef
   anyAbstract (DataSig i _ _ _ _)    = defAbstract i == AbstractDef
@@ -1174,7 +1174,7 @@ declarationSpine = \case
   Import _ _ _            -> ImportS
   Pragma _ _              -> PragmaS
   Open _ _ _              -> OpenS
-  FunDef _ _ _ cs         -> FunDefS (map clauseSpine cs)
+  FunDef _ _ cs           -> FunDefS (map clauseSpine cs)
   DataSig _ _ _ _ _       -> DataSigS
   DataDef _ _ _ _ _       -> DataDefS
   RecSig _ _ _ _ _        -> RecSigS

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -441,7 +441,7 @@ instance ExprLike Declaration where
       Import{}                  -> pure d
       Pragma i p                -> Pragma i <$> rec p
       Open{}                    -> pure d
-      FunDef i f d cs           -> FunDef i f d <$> rec cs
+      FunDef i f cs             -> FunDef i f <$> rec cs
       DataSig i er d tel e      -> DataSig i er d <$> rec tel <*> rec e
       DataDef i d uc bs cs      -> DataDef i d uc <$> rec bs <*> rec cs
       RecSig i er r tel e       -> RecSig i er r <$> rec tel <*> rec e
@@ -514,7 +514,7 @@ instance DeclaredNames Declaration where
       UnquoteDecl _ _ qs _         -> fromList $ map (WithKind OtherDefName) qs  -- could be Fun or Axiom
       UnquoteDef _ qs _            -> fromList $ map (WithKind FunName) qs       -- cannot be Axiom
       UnquoteData _ d _ _ cs _     -> singleton (WithKind DataName d) <> (fromList $ map (WithKind ConName) cs) -- singleton _ <> map (WithKind ConName) cs
-      FunDef _ q _ cls             -> singleton (WithKind FunName q) <> declaredNames cls
+      FunDef _ q cls               -> singleton (WithKind FunName q) <> declaredNames cls
       ScopedDecl _ decls           -> declaredNames decls
       Section _ _ _ _ decls        -> declaredNames decls
       Pragma _ pragma              -> declaredNames pragma

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -47,19 +47,6 @@ type Nat    = Int
 type Arity  = Nat
 
 ---------------------------------------------------------------------------
--- * Delayed
----------------------------------------------------------------------------
-
--- | Used to specify whether something should be delayed.
-data Delayed = Delayed | NotDelayed
-  deriving (Show, Eq, Ord, Generic)
-
-instance KillRange Delayed where
-  killRange = id
-
-instance NFData Delayed
-
----------------------------------------------------------------------------
 -- * File
 ---------------------------------------------------------------------------
 

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -152,7 +152,7 @@ instance NamesIn Defn where
     PrimitiveSort _ s  -> namesAndMetasIn' sg s
     AbstractDefn{}     -> __IMPOSSIBLE__
     -- Andreas 2017-07-27, Q: which names can be in @cc@ which are not already in @cl@?
-    Function cl cc _ _ _ _ _ _ _ _ _ _ _ el _ _ _
+    Function cl cc _ _ _ _ _ _ _ _ _ _ el _ _ _
       -> namesAndMetasIn' sg (cl, cc, el)
     Datatype _ _ cl cs s _ _ _ trX trD
       -> namesAndMetasIn' sg (cl, cs, s, trX, trD)

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1214,7 +1214,7 @@ instance ToConcrete A.Declaration where
       return [C.Primitive (getRange i) [C.TypeSig (argInfo t') Nothing x' (unArg t')]]
         -- Primitives are always relevant.
 
-  toConcrete (A.FunDef i _ _ cs) =
+  toConcrete (A.FunDef i _ cs) =
     withAbstractPrivate i $ concat <$> toConcrete cs
 
   toConcrete (A.DataSig i erased x bs t) =

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1818,7 +1818,6 @@ instance ToAbstract NiceDeclaration where
         -- Andreas, 2017-12-04 the name must reside in the current module
         unlessM ((A.qnameModule x' ==) <$> getCurrentModule) $
           __IMPOSSIBLE__
-        -- (delayed, cs) <- translateCopatternClauses cs -- TODO
         f <- getConcreteFixity x
 
         unfoldFunction x'

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -844,7 +844,7 @@ scopeCheckExtendedLam r e cs = do
 
   -- Create the abstract syntax for the extended lambda.
   case scdef of
-    A.ScopedDecl si [A.FunDef di qname' NotDelayed cs] -> do
+    A.ScopedDecl si [A.FunDef di qname' cs] -> do
       setScope si  -- This turns into an A.ScopedExpr si $ A.ExtendedLam...
       return $
         A.ExtendedLam (ExprRange r) di e qname' $
@@ -1818,13 +1818,12 @@ instance ToAbstract NiceDeclaration where
         -- Andreas, 2017-12-04 the name must reside in the current module
         unlessM ((A.qnameModule x' ==) <$> getCurrentModule) $
           __IMPOSSIBLE__
-        let delayed = NotDelayed
         -- (delayed, cs) <- translateCopatternClauses cs -- TODO
         f <- getConcreteFixity x
 
         unfoldFunction x'
         di <- updateDefInfoOpacity (mkDefInfoInstance x f PublicAccess a i NotMacroDef r)
-        return [ A.FunDef di x' delayed cs ]
+        return [ A.FunDef di x' cs ]
 
   -- Uncategorized function clauses
     C.NiceFunClause _ _ _ _ _ _ (C.FunClause lhs _ _ _) ->

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -106,8 +106,6 @@ data TerEnv = TerEnv
   , terTarget  :: Target
     -- ^ Target type of the function we are currently termination checking.
     --   Only the constructors of 'Target' are considered guarding.
-  , terDelayed :: Delayed
-    -- ^ Are we checking a delayed definition?
   , terMaskArgs :: [Bool]
     -- ^ Only consider the 'notMasked' 'False' arguments for establishing termination.
     --   See issue #1023.
@@ -157,7 +155,6 @@ defaultTerEnv = TerEnv
   , terCurrent                  = __IMPOSSIBLE__ -- needs to be set!
   , terHaveInlinedWith          = False
   , terTarget                   = TargetOther
-  , terDelayed                  = NotDelayed
   , terMaskArgs                 = repeat False   -- use all arguments (mask none)
   , terMaskResult               = False          -- use result (do not mask)
   , _terSizeDepth               = __IMPOSSIBLE__ -- needs to be set!
@@ -296,12 +293,6 @@ terGetHaveInlinedWith = terAsks terHaveInlinedWith
 
 terSetHaveInlinedWith :: TerM a -> TerM a
 terSetHaveInlinedWith = terLocal $ \ e -> e { terHaveInlinedWith = True }
-
-terGetDelayed :: TerM Delayed
-terGetDelayed = terAsks terDelayed
-
-terSetDelayed :: Delayed -> TerM a -> TerM a
-terSetDelayed b = terLocal $ \ e -> e { terDelayed = b }
 
 terGetMaskArgs :: TerM [Bool]
 terGetMaskArgs = terAsks terMaskArgs

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -285,10 +285,10 @@ solveConstraint_ (UnBlock m)                =   -- alwaysUnblock since these hav
       Open -> __IMPOSSIBLE__
       OpenInstance -> __IMPOSSIBLE__
 solveConstraint_ (FindInstance m cands) = findInstance m cands
-solveConstraint_ (CheckFunDef d i q cs _err) = withoutCache $
+solveConstraint_ (CheckFunDef i q cs _err) = withoutCache $
   -- re #3498: checking a fundef would normally be cached, but here it's
   -- happening out of order so it would only corrupt the caching log.
-  checkFunDef d i q cs
+  checkFunDef i q cs
 solveConstraint_ (CheckLockedVars a b c d)   = checkLockedVars a b c d
 solveConstraint_ (HasBiggerSort a)      = hasBiggerSort a
 solveConstraint_ (HasPTSRule a b)       = hasPTSRule a b

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -818,7 +818,6 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
                , funInv          = NotInjective
                , funMutual       = Just []
                , funAbstr        = ConcreteDef
-               , funDelayed      = NotDelayed
                , funProjection   = Right proj
                , funErasure      = erasure
                , funFlags        = Set.empty

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -451,7 +451,7 @@ invertFunction cmp blk (Inv f blkArgs hdMap) hd fallback err success = do
           compareElims pol fs fTy (Def f []) margs blkArgs'
 
           -- Check that we made progress.
-          r <- liftReduce $ unfoldDefinitionStep False (Def f []) f blkArgs
+          r <- liftReduce $ unfoldDefinitionStep (Def f []) f blkArgs
           case r of
             YesReduction _ blk' -> do
               reportSDoc "tc.inj.invert.success" 20 $ hsep ["Successful inversion of", prettyTCM f, "at", pretty hd]

--- a/src/full/Agda/TypeChecking/Pretty/Constraint.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Constraint.hs
@@ -137,7 +137,7 @@ instance PrettyTCM Constraint where
             "Is empty:" <?> prettyTCMCtx TopCtx t
         CheckSizeLtSat t ->
             "Is not empty type of sizes:" <?> prettyTCMCtx TopCtx t
-        CheckFunDef d i q cs err -> do
+        CheckFunDef i q cs err -> do
             t <- defType <$> getConstInfo q
             vcat [ "Check definition of" <+> prettyTCM q <+> ":" <+> prettyTCM t
                  , nest 2 $ "stuck because" <?> prettyTCM err ]

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1559,7 +1559,7 @@ checkSharpApplication e t c args = do
         (defaultDefn ai c' forcedType lang fun)
         { defMutual = i }
 
-    checkFunDef NotDelayed info c' [clause]
+    checkFunDef info c' [clause]
 
     reportSDoc "tc.term.expr.coind" 15 $ do
       def <- theDef <$> getConstInfo c'
@@ -1568,8 +1568,6 @@ checkSharpApplication e t c args = do
         , nest 2 $ prettyTCM mod <> (prettyTCM c' <+> ":")
         , nest 4 $ prettyTCM t
         , nest 2 $ prettyA clause
-        , ("The definition is" <+> text (show $ funDelayed def)) <>
-          "."
         ]
     return c'
 

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -155,7 +155,7 @@ checkDecl d = setCurrentRange d $ do
       A.Import _ _ dir         -> none $ checkImportDirective dir
       A.Pragma i p             -> none $ checkPragma i p
       A.ScopedDecl scope ds    -> none $ setScope scope >> mapM_ checkDeclCached ds
-      A.FunDef i x delayed cs  -> impossible $ check x i $ checkFunDef delayed i x cs
+      A.FunDef i x cs          -> impossible $ check x i $ checkFunDef i x cs
       A.DataDef i x uc ps cs   -> impossible $ check x i $ checkDataDef i x uc ps cs
       A.RecDef i x uc dir ps tel cs -> impossible $ check x i $ do
                                     checkRecDef i x uc dir ps tel cs

--- a/src/full/Agda/TypeChecking/Rules/Def.hs-boot
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs-boot
@@ -5,9 +5,9 @@ import Agda.Syntax.Common
 import Agda.TypeChecking.Monad
 import qualified Agda.Syntax.Internal as I
 
-checkFunDef :: Delayed -> DefInfo -> QName -> [Clause] -> TCM ()
+checkFunDef :: DefInfo -> QName -> [Clause] -> TCM ()
 
-checkFunDef' :: I.Type -> ArgInfo -> Delayed -> Maybe ExtLamInfo -> Maybe QName -> DefInfo -> QName -> [Clause] -> TCM ()
+checkFunDef' :: I.Type -> ArgInfo -> Maybe ExtLamInfo -> Maybe QName -> DefInfo -> QName -> [Clause] -> TCM ()
 
 newSection ::
    Erased -> ModuleName -> A.GeneralizeTelescope -> TCM a -> TCM a

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -788,7 +788,7 @@ checkExtendedLambda cmp i di erased qname cs e t = do
          useTerPragma $
            (defaultDefn info qname t lang fun)
              { defMutual = j }
-       checkFunDef' t info NotDelayed (Just $ ExtLamInfo lamMod False empty) Nothing di qname $
+       checkFunDef' t info (Just $ ExtLamInfo lamMod False empty) Nothing di qname $
          List1.toList cs
        whenNothingM (asksTC envMutualBlock) $
          -- Andrea 10-03-2018: Should other checks be performed here too? e.g. termination/positivity/..

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -703,15 +703,6 @@ instance EmbPrj IsOpaque where
     valu []  = valuN TransparentDef
     valu _   = malformed
 
-instance EmbPrj Delayed where
-  icod_ Delayed    = icodeN 0 Delayed
-  icod_ NotDelayed = icodeN' NotDelayed
-
-  value = vcase valu where
-    valu [0] = valuN Delayed
-    valu []  = valuN NotDelayed
-    valu _   = malformed
-
 instance EmbPrj SrcLoc where
   icod_ (SrcLoc p m f sl sc el ec) = icodeN' SrcLoc p m f sl sc el ec
   value = valueN SrcLoc

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -389,7 +389,7 @@ instance EmbPrj BuiltinSort where
 
 instance EmbPrj Defn where
   icod_ (Axiom       a)                                 = icodeN 0 Axiom a
-  icod_ (Function    a b s t u c d e f g h i j k l m n) = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k l m n
+  icod_ (Function    a b s t u c d e f g h i j k l m)   = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k l m
   icod_ (Datatype    a b c d e f g h i j)               = icodeN 2 Datatype a b c d e f g h i j
   icod_ (Record      a b c d e f g h i j k l m)         = icodeN 3 Record a b c d e f g h i j k l m
   icod_ (Constructor a b c d e f g h i j)               = icodeN 4 Constructor a b c d e f g h i j
@@ -401,8 +401,8 @@ instance EmbPrj Defn where
 
   value = vcase valu where
     valu [0, a]                                        = valuN Axiom a
-    valu [1, a, b, s, u, c, d, e, f, g, h, i, j, k, l, m, n]
-                                                       = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k l m n
+    valu [1, a, b, s, u, c, d, e, f, g, h, i, j, k, l, m]
+                                                       = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k l m
     valu [2, a, b, c, d, e, f, g, h, i, j]             = valuN Datatype a b c d e f g h i j
     valu [3, a, b, c, d, e, f, g, h, i, j, k, l, m]    = valuN Record   a b c d e f g h i j k l m
     valu [4, a, b, c, d, e, f, g, h, i, j]             = valuN Constructor a b c d e f g h i j

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -1048,7 +1048,7 @@ evalTCM v = do
       let accessDontCare = __IMPOSSIBLE__  -- or ConcreteDef, value not looked at
       ac <- asksTC (^. lensIsAbstract)     -- Issue #4012, respect AbstractMode
       let i = mkDefInfo (nameConcrete $ qnameName x) noFixity' accessDontCare ac noRange
-      locallyReduceAllDefs $ checkFunDef NotDelayed i x cs
+      locallyReduceAllDefs $ checkFunDef i x cs
       primUnitUnit
 
     tcPragmaForeign :: Text -> Text -> TCM Term


### PR DESCRIPTION
As far as I can tell, delayed clauses were only ever used for an ancient implementation of corecursion (that I can find no more information on). No function is ever marked `Delayed`, but we still keep this flag around everywhere.