### PR TITLE
Fix #6662 plural in "Cannot set OPTIONS pragma" warning

### DIFF
--- a/fix-whitespace.yaml
+++ b/fix-whitespace.yaml
@@ -19,7 +19,7 @@
 # 3) included-files is a white-list of files,
 # 4) excluded-files is a black-list of included-files.
 #
-# The extended glob pattern can be used to specify file/direcotory names.
+# The extended glob pattern can be used to specify file/directory names.
 # For details, see http://hackage.haskell.org/package/filemanip-0.3.6.3/docs/System-FilePath-GlobPattern.html
 #
 included-dirs:

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -216,7 +216,7 @@ prettyWarning = \case
       pwords "Cannot postulate" ++ [pretty e] ++ pwords "with safe flag"
 
     SafeFlagPragma xs -> fsep $ concat
-      [ [ fwords $ singPlural xs id (++ "s") "Cannot set OPTIONS pragma" ]
+      [ [ fwords $ singPlural (words =<< xs) id (++ "s") "Cannot set OPTIONS pragma" ]
       , map text xs
       , [ fwords "with safe flag." ]
       ]

--- a/test/Fail/Issue2790-b.err
+++ b/test/Fail/Issue2790-b.err
@@ -9,5 +9,5 @@ Reason: It relies on the K rule, which is incompatible with
 
 when checking the definition of uip
 Issue2790-b.agda:1,1-42
-Cannot set OPTIONS pragma --cubical-compatible and --with-K
+Cannot set OPTIONS pragmas --cubical-compatible and --with-K
 with safe flag.

--- a/test/Fail/Issue6238-safe.err
+++ b/test/Fail/Issue6238-safe.err
@@ -8,5 +8,5 @@ Reason: It splits on a @♭ argument
 
 when checking the definition of CommFlatId
 Issue6238-safe.agda:1,1-46
-Cannot set OPTIONS pragma --without-K and --flat-split
+Cannot set OPTIONS pragmas --without-K and --flat-split
 with safe flag.


### PR DESCRIPTION
- Fix typo in fix-whitespace.yaml
- Fix #6662 pluralization issue in warning text
