### PR TITLE
CI stack: bump to lts-20.26 and lts-21.0

### DIFF
--- a/.github/workflows/stack-dry-run.yml
+++ b/.github/workflows/stack-dry-run.yml
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc-ver:
-        - 9.2.7
+        - 9.2.8
         - 9.0.2
         - 8.10.7
         - 8.8.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ env:
   GHC_VER: 9.4.5
   PARALLEL_TESTS: 2
   STACK: stack --system-ghc
-  STACK_VER: 2.9.3
+  STACK_VER: 2.11.1
   TASTY_ANSI_TRICKS: 'false'
 jobs:
   build:

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -35,9 +35,9 @@ description:
     packages.
 
 tested-with:
-    GHC == 9.6.1
+    GHC == 9.6.2
     GHC == 9.4.5
-    GHC == 9.2.7
+    GHC == 9.2.8
     GHC == 9.0.2
     GHC == 8.10.7
     GHC == 8.8.4
@@ -87,7 +87,7 @@ extra-doc-files:
 
 extra-source-files:
     stack-9.4.5.yaml
-    stack-9.2.7.yaml
+    stack-9.2.8.yaml
     stack-9.0.2.yaml
     stack-8.10.7.yaml
     stack-8.8.4.yaml

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -38,7 +38,7 @@ You need recent versions of the following programs to compile Agda:
 * GHC:           https://www.haskell.org/ghc/
 
   + Agda has been tested with GHC 8.6.5, 8.8.4,
-    8.10.7, 9.0.2, 9.2.7, 9.4.5 and 9.6.1.
+    8.10.7, 9.0.2, 9.2.8, 9.4.5 and 9.6.2.
 
 * cabal-install: https://www.haskell.org/cabal/
 * Alex:          https://www.haskell.org/alex/

--- a/src/github/workflows/stack-dry-run.yml
+++ b/src/github/workflows/stack-dry-run.yml
@@ -46,7 +46,7 @@ jobs:
         os: [ubuntu-latest]
         stack-ver: ['latest']
         # Only LTS versions here:
-        ghc-ver: [9.2.7, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
+        ghc-ver: [9.2.8, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
           # Andreas, 2022-03-26:
           # Note: ghc-ver needs to be spelled out with minor version, i.e., x.y.z
           # rather than x.y (which haskell-setup would resolve to a suitable .z)

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -50,7 +50,7 @@ env:
 
   # Andreas, 2022-11-24, set the stack version here so that it is easily
   # shared between the jobs.
-  STACK_VER: "2.9.3"
+  STACK_VER: "2.11.1"
   # Andreas, 2022-03-26, 2022-11-28:
   # GHC_VER should be given as x.y.z (as opposed to x.y only)
   # because it is used verbatim when referring to stack-x.y.z.yaml.

--- a/stack-9.2.8.yaml
+++ b/stack-9.2.8.yaml
@@ -1,11 +1,8 @@
-resolver: lts-20.23
-compiler: ghc-9.2.7
+resolver: lts-20.26
+compiler: ghc-9.2.8
 compiler-check: match-exact
 
 # Local packages specified by relative directory name.
 packages:
 - '.'
 - 'src/size-solver'
-
-extra-deps:
-- vector-hashtables-0.1.1.1

--- a/stack-9.4.5.yaml
+++ b/stack-9.4.5.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2023-05-31
+resolver: lts-21.0
 compiler: ghc-9.4.5
 compiler-check: match-exact
 


### PR DESCRIPTION
Stackage released LTS 21.0 for GHC 9.4.5.