### PR TITLE
Support Typst in literate mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,15 @@ Library management
 
 * Now supports reading files with extension `.lagda.typ`, and use the parser for
   markdown files to parse them.
+  To edit such files in Emacs with Agda support, one needs to add the line
+  ```elisp
+  (add-to-list 'auto-mode-alist '("\\.lagda.typ\\'" . agda2-mode))
+  ```
+  to `.emacs`.
+
+  Generation for highlighted code like HTML is unsupported for Typst.
+  One may generate HTML with typst input, but that makes little sense,
+  and markdown is recommended instead when HTML export is desired.
 
 Emacs mode
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,9 @@ Library management
 
   Previously such `.agda-lib` files were ignored.
 
+* Now supports reading files with extension `.lagda.typ`, and use the parser for
+  markdown files to parse them.
+
 Emacs mode
 ----------
 

--- a/doc/user-manual/tools/literate-programming.rst
+++ b/doc/user-manual/tools/literate-programming.rst
@@ -90,11 +90,14 @@ HTML or LaTeX using Sphinx_.
   the file as a whole must be a valid Agda file if all the literate
   text is replaced by white space.
 
-Literate Markdown
------------------
+Literate Markdown and Typst
+---------------------------
 
 Files ending in :file:`.lagda.md` are interpreted as literate
-Markdown_ files. Code blocks start with ``````` or `````agda`` on
+Markdown_ files, while files ending in :file:`.lagda.typ` are
+interpreted as literate Typst_ files. They use the same syntax
+for code blocks, and they are parsed the same way by Agda.
+Code blocks start with ``````` or `````agda`` on
 its own line, and end with ```````, also on its own line:
 
 .. code-block:: md
@@ -113,6 +116,8 @@ its own line, and end with ```````, also on its own line:
     zero : ℕ
     suc  : ℕ → ℕ
    ```
+
+For Typst, Agda does not yet support highlighting the code blocks.
 
 Markdown source files can be turned into many other formats such as
 HTML or LaTeX using PanDoc_.
@@ -133,7 +138,7 @@ Literate Org
 
 Files ending in :file:`.lagda.org` are interpreted as literate
 Org_ files. Code blocks are surrounded by two lines including only
-```#+begin_src agda2``` and ```#+end_src``` (case insensitive).
+```#+begin_src agda2``` and ```#+end_src``` (case-insensitive).
 
 .. code-block:: text
 
@@ -155,6 +160,7 @@ Org_ files. Code blocks are surrounded by two lines including only
 .. _reStructuredText: http://docutils.sourceforge.io/rst.html
 .. _Markdown: https://daringfireball.net/projects/markdown/
 .. _Org: https://orgmode.org
+.. _Typst: https://typst.app
 
 .. _lhs2TeX: https://www.andres-loeh.de/lhs2tex/
 .. _Sphinx: http://www.sphinx-doc.org/en/stable/

--- a/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
@@ -303,12 +303,13 @@ code onlyCode fileType = mconcat . if onlyCode
          -- Explicitly written all cases, so people
          -- get compile error when adding new file types
          -- when they forget to modify the code here
-         RstFileType  -> map mkRst . splitByMarkup
-         MdFileType   -> map mkMd . chunksOf 2 . splitByMarkup
-         AgdaFileType -> map mkHtml
-         -- Any points for using this option?
-         TexFileType  -> map mkMd . chunksOf 2 . splitByMarkup
-         OrgFileType  -> map mkOrg . splitByMarkup
+         RstFileType   -> map mkRst . splitByMarkup
+         MdFileType    -> map mkMd . chunksOf 2 . splitByMarkup
+         AgdaFileType  -> map mkHtml
+         OrgFileType   -> map mkOrg . splitByMarkup
+         -- Two useless cases, probably will never used by anyone
+         TexFileType   -> map mkMd . chunksOf 2 . splitByMarkup
+         TypstFileType -> map mkMd . chunksOf 2 . splitByMarkup
   else map mkHtml
   where
   trd (_, _, a) = a

--- a/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
@@ -107,11 +107,12 @@ instance NFData HtmlHighlight
 highlightOnlyCode :: HtmlHighlight -> FileType -> Bool
 highlightOnlyCode HighlightAll  _ = False
 highlightOnlyCode HighlightCode _ = True
-highlightOnlyCode HighlightAuto AgdaFileType = False
-highlightOnlyCode HighlightAuto MdFileType   = True
-highlightOnlyCode HighlightAuto RstFileType  = True
-highlightOnlyCode HighlightAuto OrgFileType  = True
-highlightOnlyCode HighlightAuto TexFileType  = False
+highlightOnlyCode HighlightAuto AgdaFileType  = False
+highlightOnlyCode HighlightAuto MdFileType    = True
+highlightOnlyCode HighlightAuto RstFileType   = True
+highlightOnlyCode HighlightAuto OrgFileType   = True
+highlightOnlyCode HighlightAuto TypstFileType = True
+highlightOnlyCode HighlightAuto TexFileType   = False
 
 -- | Determine the generated file extension
 
@@ -119,11 +120,12 @@ highlightedFileExt :: HtmlHighlight -> FileType -> String
 highlightedFileExt hh ft
   | not $ highlightOnlyCode hh ft = "html"
   | otherwise = case ft of
-      AgdaFileType -> "html"
-      MdFileType   -> "md"
-      RstFileType  -> "rst"
-      TexFileType  -> "tex"
-      OrgFileType  -> "org"
+      AgdaFileType  -> "html"
+      MdFileType    -> "md"
+      RstFileType   -> "rst"
+      TexFileType   -> "tex"
+      OrgFileType   -> "org"
+      TypstFileType -> "typ"
 
 -- | Options for HTML generation
 

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -50,7 +50,7 @@ type Arity  = Nat
 -- * File
 ---------------------------------------------------------------------------
 
-data FileType = AgdaFileType | MdFileType | RstFileType | TexFileType | OrgFileType
+data FileType = AgdaFileType | MdFileType | RstFileType | TexFileType | OrgFileType | TypstFileType
   deriving (Eq, Ord, Show, Generic)
 
 instance Pretty FileType where
@@ -60,6 +60,7 @@ instance Pretty FileType where
     RstFileType  -> "ReStructedText"
     TexFileType  -> "LaTeX"
     OrgFileType  -> "org-mode"
+    TypstFileType -> "Typst"
 
 instance NFData FileType
 

--- a/src/full/Agda/Syntax/Parser/Literate.hs
+++ b/src/full/Agda/Syntax/Parser/Literate.hs
@@ -103,6 +103,9 @@ literateProcessors =
     , (".tex", (literateTeX, TexFileType))
     , (".md",  (literateMd,  MdFileType ))
     , (".org", (literateOrg, OrgFileType))
+    -- For now, treat typst as markdown because they use the same
+    -- syntax for code blocks.
+    , (".typ", (literateMd,  TypstFileType))
     ]
 
 -- | Returns @True@ if the role corresponds to Agda code.

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -161,11 +161,12 @@ instance EmbPrj Bool where
   value _ = malformed
 
 instance EmbPrj FileType where
-  icod_ AgdaFileType = pure 0
-  icod_ MdFileType   = pure 1
-  icod_ RstFileType  = pure 2
-  icod_ TexFileType  = pure 3
-  icod_ OrgFileType  = pure 4
+  icod_ AgdaFileType  = pure 0
+  icod_ MdFileType    = pure 1
+  icod_ RstFileType   = pure 2
+  icod_ TexFileType   = pure 3
+  icod_ OrgFileType   = pure 4
+  icon_ TypstFileType = pure 5
 
   value = \case
     0 -> pure AgdaFileType
@@ -173,6 +174,7 @@ instance EmbPrj FileType where
     2 -> pure RstFileType
     3 -> pure TexFileType
     4 -> pure OrgFileType
+    5 -> pure TypstFileType
     _ -> malformed
 
 instance EmbPrj Cubical where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -166,7 +166,7 @@ instance EmbPrj FileType where
   icod_ RstFileType   = pure 2
   icod_ TexFileType   = pure 3
   icod_ OrgFileType   = pure 4
-  icon_ TypstFileType = pure 5
+  icod_ TypstFileType = pure 5
 
   value = \case
     0 -> pure AgdaFileType

--- a/test/interaction/Issue2224.out
+++ b/test/interaction/Issue2224.out
@@ -1,4 +1,4 @@
 Issue2224WrongExtension.agda.tex:1,1-1
 Issue2224WrongExtension.agda.tex: Unsupported extension.
 Supported extensions are: .agda, .lagda, .lagda.rst, .lagda.tex,
-.lagda.md, .lagda.org
+.lagda.md, .lagda.org, .lagda.typ


### PR DESCRIPTION
Typst uses the same syntax for code blocks, see https://typst.app/docs/reference/text/raw

Motivation: @Trebor-Huang asked about `.lagda.typ` so.
![image](https://github.com/agda/agda/assets/16398479/9c437c94-6fa6-45a8-8cdf-43ec6c94c6d4)
