### PR TITLE
Fix #6703: lift relevance restriction in recordExpressionToCopatterns

### DIFF
--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -293,12 +293,11 @@ recordExpressionsToCopatterns = \case
     cc@Fail{} -> return cc
     cc@(Done xs (Con c ConORec es)) -> do  -- don't translate if using the record /constructor/
       let vs = map unArg $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
-      irrProj <- optIrrelevantProjections <$> pragmaOptions
       getConstructorInfo (conName c) >>= \ case
         RecordCon CopatternMatching YesEta ar fs
           | ar > 0                                     -- only for eta-records with at least one field
           , length vs == ar                            -- where the constructor application is saturated
-          , irrProj || not (any isIrrelevant fs) -> do -- and irrelevant projections (if any) are allowed
+          -> do
               tellDirty
               Case (defaultArg $ length xs) <$> do
                 -- translate new cases recursively (there might be nested record expressions)


### PR DESCRIPTION
Not sure why this restriction was there in the first place, because
Agda accepts irrelevant projections on the lhs by default:
```agda
  record R : Set where field .f : Nat
  foo : R
  foo .R.f = 0
```
Closes #6703.