### PR TITLE
Bump stack CI to ghc-9.6.2

### DIFF
--- a/.github/workflows/stack-dry-run.yml
+++ b/.github/workflows/stack-dry-run.yml
@@ -71,6 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc-ver:
+        - 9.4.5
         - 9.2.8
         - 9.0.2
         - 8.10.7

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -106,9 +106,9 @@ jobs:
       fail-fast: false
       matrix:
         ghc-ver:
-        - 9.4.5
+        - 9.6.2
         include:
-        - ghc-ver: 9.4.5
+        - ghc-ver: 9.6.2
           os: windows-2022
         os:
         - ubuntu-22.04
@@ -121,7 +121,7 @@ name: Build (stack)
     - .github/workflows/stack.yml
     - Agda.cabal
     - Setup.hs
-    - stack-9.4.5.yaml
+    - stack-9.6.2.yaml
     - src/size-solver/size-solver.cabal
   push:
     branches:
@@ -132,6 +132,6 @@ name: Build (stack)
     - .github/workflows/stack.yml
     - Agda.cabal
     - Setup.hs
-    - stack-9.4.5.yaml
+    - stack-9.6.2.yaml
     - src/size-solver/size-solver.cabal
   workflow_dispatch: null

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@
 env:
   AGDA_TESTS_OPTIONS: -j${PARALLEL_TESTS} --hide-successes
   BUILD_DIR: dist
-  GHC_VER: 9.4.5
+  GHC_VER: 9.6.2
   PARALLEL_TESTS: 2
   STACK: stack --system-ghc
   STACK_VER: 2.11.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,10 +63,6 @@ jobs:
       run: make install-deps
     - name: Build Agda
       run: make BUILD_DIR="${BUILD_DIR}" install-bin
-    - name: Run tests for the size solver
-      run: |
-        export PATH=${HOME}/.local/bin:${PATH}
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
     - name: Pack artifacts
       run: |
         strip ${BUILD_DIR}/build/agda-tests/agda-tests \

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -86,6 +86,7 @@ extra-doc-files:
     doc/release-notes/2.2.0.md
 
 extra-source-files:
+    stack-9.6.2.yaml
     stack-9.4.5.yaml
     stack-9.2.8.yaml
     stack-9.0.2.yaml

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ ifeq ($(GHC_RTS_OPTS),)
 #
 ifeq ("$(shell $(GHC) --info | grep 'target word size' | cut -d\" -f4)","4")
 GHC_RTS_OPTS := -M2.3G
+else ifeq ($(GHC_VERSION),9.6)
+GHC_RTS_OPTS := -M6G
 else ifeq ($(GHC_VERSION),9.0)
 GHC_RTS_OPTS := -M6G
 else ifeq ($(GHC_VERSION),8.10)

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -222,7 +222,16 @@ reportSLn :: MonadDebug m => VerboseKey -> VerboseLevel -> String -> m ()
 reportSLn k n s = verboseS k n $ displayDebugMessage k n $ s ++ "\n"
 
 __IMPOSSIBLE_VERBOSE__ :: (HasCallStack, MonadDebug m) => String -> m a
-__IMPOSSIBLE_VERBOSE__ s = do { reportSLn "impossible" 10 s ; throwImpossible err }
+__IMPOSSIBLE_VERBOSE__ s = do
+  -- Andreas, 2023-07-19, issue #6728 is fixed by manually inlining reportSLn here.
+  -- reportSLn "impossible" 10 s
+  -- It seems like GHC 9.6 optimization does otherwise something that throws
+  -- away the debug message.
+  let k = "impossible"
+  let n = 10
+  verboseS k n $ displayDebugMessage k n $ s ++ "\n"
+
+  throwImpossible err
   where
     -- Create the "Impossible" error using *our* caller as the call site.
     err = withCallerCallStack Impossible

--- a/src/github/workflows/stack-dry-run.yml
+++ b/src/github/workflows/stack-dry-run.yml
@@ -46,7 +46,7 @@ jobs:
         os: [ubuntu-latest]
         stack-ver: ['latest']
         # Only LTS versions here:
-        ghc-ver: [9.2.8, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
+        ghc-ver: [9.4.5, 9.2.8, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
           # Andreas, 2022-03-26:
           # Note: ghc-ver needs to be spelled out with minor version, i.e., x.y.z
           # rather than x.y (which haskell-setup would resolve to a suitable .z)

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -11,7 +11,7 @@ on:
     - '.github/workflows/stack.yml'
     - 'Agda.cabal'
     - 'Setup.hs'
-    - 'stack-9.4.5.yaml'
+    - 'stack-9.6.2.yaml'
       # !!! MATCH THIS WITH ghc_ver IN THE matrix BELOW !!!
       #
     - 'src/size-solver/size-solver.cabal'
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04,macos-12]
-        ghc-ver: [9.4.5]
+        ghc-ver: [9.6.2]
           # !!! MAKE SURE THIS GHC VERSION IS IN SYNC WITH trigger_path_list !!!
           #
           # The LTS snapshots are covered in workflow stack-dry-run.yml.
@@ -66,7 +66,7 @@ jobs:
           # adding the respective stack-x.y.z.yaml file.
         include:
         - os: windows-2022
-          ghc-ver: 9.4.5
+          ghc-ver: 9.6.2
           # !!! MAKE SURE THIS GHC VERSION IS IN SYNC WITH trigger_path_list !!!
 
     # # Try "allowed-failure" for Windows with GHC 9.2

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -157,10 +157,10 @@ jobs:
     - name: "Build Agda"
       run: make BUILD_DIR="${BUILD_DIR}" install-bin
 
-    - name: "Run tests for the size solver"
-      run: |
-        export PATH=${HOME}/.local/bin:${PATH}
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
+    # - name: "Run tests for the size solver"
+    #   run: |
+    #     export PATH=${HOME}/.local/bin:${PATH}
+    #     make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
 
     - name: "Pack artifacts"
       # This step should go into the Makefile.

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -54,7 +54,7 @@ env:
   # Andreas, 2022-03-26, 2022-11-28:
   # GHC_VER should be given as x.y.z (as opposed to x.y only)
   # because it is used verbatim when referring to stack-x.y.z.yaml.
-  GHC_VER: "9.4.5"
+  GHC_VER: "9.6.2"
 
   # Part 2: Variables that should not have to be changed
   ###########################################################################

--- a/stack-9.6.2.yaml
+++ b/stack-9.6.2.yaml
@@ -1,0 +1,14 @@
+resolver: nightly-2023-07-17
+compiler: ghc-9.6.2
+compiler-check: match-exact
+
+# Local packages specified by relative directory name.
+packages:
+- '.'
+- 'src/size-solver'
+
+# flags:
+#   mintty:
+#     win32-2-13-1: false
+#   ansi-terminal:
+#     win32-2-13-1: false

--- a/stack-9.6.2.yaml
+++ b/stack-9.6.2.yaml
@@ -5,7 +5,9 @@ compiler-check: match-exact
 # Local packages specified by relative directory name.
 packages:
 - '.'
-- 'src/size-solver'
+## 2023-07-17: Disable size-solver as dependency shelltestrunner isn't up to GHC 9.6 yet
+## https://github.com/simonmichael/shelltestrunner/pull/34
+# - 'src/size-solver'
 
 # flags:
 #   mintty:

--- a/test/api/ScopeFromInterface.hs
+++ b/test/api/ScopeFromInterface.hs
@@ -11,6 +11,8 @@ module Main where
 -- Haskell imports
 
 import qualified Control.Exception as E
+import Control.Monad               ( forM_ )
+import Control.Monad.IO.Class      ( liftIO )
 import Control.Monad.Except
 
 import qualified Data.ByteString.Lazy as BS


### PR DESCRIPTION
Blocked on:
- [x] https://github.com/commercialhaskell/stackage/pull/7026
- [x] https://github.com/commercialhaskell/stackage/issues/7036
- [x] https://github.com/simonmichael/shelltestrunner/issues/33
- [ ] https://github.com/simonmichael/shelltestrunner/pull/34
- [x] https://github.com/agda/agda/issues/6728
- [x] https://github.com/agda/agda/issues/6731

Fixes #6728.