### PR TITLE
Skip inserted clauses in IApplyConfluence

### DIFF
--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -732,11 +732,7 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
         -- Since these are always automatically derived, printing them
         -- is noise, and shows up even in non-cubical modules, as long
         -- as an imported extended lambda is defined cubical-compatibly.
-        let
-          isDefP I.DefP{} = True
-          isDefP _ = False
-
-          insClause = any (isDefP . namedArg) . namedClausePats
+        let insClause = hasDefP . namedClausePats
         case extLam of
           Just (pars, sys) | df, x `notElem` alreadyPrinting ->
             locallyTC ePrintingPatternLambdas (x :) $

--- a/src/full/Agda/TypeChecking/IApplyConfluence.hs
+++ b/src/full/Agda/TypeChecking/IApplyConfluence.hs
@@ -73,8 +73,7 @@ checkIApplyConfluence f cl = case cl of
       Clause {clauseBody = Nothing} -> return ()
       Clause {clauseType = Nothing} -> __IMPOSSIBLE__
       -- Inserted clause, will respect boundaries whenever the
-      -- user-written clauses do. Saves work, and the inserted clauses
-      -- are sometimes loopy in IApplyConfluence (#6715)
+      -- user-written clauses do. Saves a ton of work!
       Clause {namedClausePats = ps} | hasDefP ps -> pure ()
       cl@Clause { clauseTel = clTel
                 , namedClausePats = ps
@@ -99,6 +98,9 @@ checkIApplyConfluence f cl = case cl of
 
             let
               k :: Substitution -> Comparison -> Type -> Term -> Term -> TCM ()
+              -- TODO (Amy, 2023-07-08): Simplifying the LHS of a
+              -- generated clause in its context is loopy, see #6722
+              k phi cmp ty u v | hasDefP ps = compareTerm cmp ty u v
               k phi cmp ty u v = do
                 u_e <- simplify u
                 ty_e <- simplify ty

--- a/src/full/Agda/TypeChecking/IApplyConfluence.hs
+++ b/src/full/Agda/TypeChecking/IApplyConfluence.hs
@@ -72,6 +72,10 @@ checkIApplyConfluence :: QName -> Clause -> TCM ()
 checkIApplyConfluence f cl = case cl of
       Clause {clauseBody = Nothing} -> return ()
       Clause {clauseType = Nothing} -> __IMPOSSIBLE__
+      -- Inserted clause, will respect boundaries whenever the
+      -- user-written clauses do. Saves work, and the inserted clauses
+      -- are sometimes loopy in IApplyConfluence (#6715)
+      Clause {namedClausePats = ps} | hasDefP ps -> pure ()
       cl@Clause { clauseTel = clTel
                 , namedClausePats = ps
                 , clauseType = Just t
@@ -89,9 +93,9 @@ checkIApplyConfluence f cl = case cl of
             let es = patternsToElims ps
             let lhs = Def f es
 
-            reportSDoc "tc.iapply" 40 $ text "clause:" <+> pretty ps <+> "->" <+> pretty body
-            reportSDoc "tc.iapply" 20 $ "body =" <+> prettyTCM body
-            inTopContext $ reportSDoc "tc.iapply" 20 $ "Γ =" <+> prettyTCM clTel
+            reportSDoc "tc.cover.iapply" 40 $ text "clause:" <+> pretty ps <+> "->" <+> pretty body
+            reportSDoc "tc.cover.iapply" 20 $ "body =" <+> prettyTCM body
+            inTopContext $ reportSDoc "tc.cover.iapply" 20 $ "Γ =" <+> prettyTCM clTel
 
             let
               k :: Substitution -> Comparison -> Type -> Term -> Term -> TCM ()

--- a/test/Succeed/Issue6715.agda
+++ b/test/Succeed/Issue6715.agda
@@ -1,0 +1,20 @@
+{-# OPTIONS --cubical #-}
+module Issue6715 where
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Primitive.Cubical
+  renaming (primTransp to transp; primIMin to _∧_; primINeg to ~_)
+
+data U : Set where
+  a : U
+  squash : ∀ x y → x ≡ y
+
+data IsA : U → Set where
+  is-a : IsA a
+
+
+t : {x : U} → IsA x → IsA x
+t is-a = transp (λ i → IsA (squash a a i)) i0 is-a
+
+lemma : {x : U} (p : IsA x) → PathP (λ i → IsA (squash x x i)) p (t p)
+lemma is-a i = transp (λ j → IsA (squash a a (i ∧ j))) (~ i) is-a


### PR DESCRIPTION
Fixes #6715, but in a hurried way. I will work on a proper fix, but since it requires understanding the cubical parts of the coverage checker, there's no way I can get that done before the release.