### PR TITLE
hotfix: Reduce type when inlining constructors

### DIFF
--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -247,6 +247,7 @@ coinductiveRecordRHSsToCopatterns cls = do
 
           -- Only expand constructors labelled @{-# INLINE c #-}@.
         -> ifNotM (inlineConstructor c) (return [cl]) {-else-} do
+          mt <- traverse reduce mt
 
           -- Iterate the translation for nested constructor rhss.
           coinductiveRecordRHSsToCopatterns =<< do

--- a/test/Succeed/ConInlineTypeAlias.agda
+++ b/test/Succeed/ConInlineTypeAlias.agda
@@ -1,0 +1,24 @@
+{-# OPTIONS --cubical #-}
+module ConInlineTypeAlias where
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.Nat
+
+record Foo : Set where
+  constructor mk-foo
+  field
+    x : Nat
+    p : x ≡ 0
+
+{-# INLINE mk-foo #-}
+
+Foo′ : Set
+Foo′ = Foo
+
+-- Inlining constructors didn't reduce the type of the original clause,
+-- making projectTyped fail, resulting in the *generated* clause having
+-- no type. If the generated clause has IApply copatterns and no type,
+-- IApplyConfluence throws an __IMPOSSIBLE__.
+
+test : Foo′
+test = record { x = 0 ; p = λ i → 0 }


### PR DESCRIPTION
The type of the record expression was not reduced when inlining a record constructor, so we could not figure out the types of the fields --- leading the generated clauses to have no type. So if you had a record `T` containing paths, and you defined `S = T`, trying to inline `T`'s constructor at type `S` would give you a clause with path binders _and no type_, which makes IApplyConfluence very unhappy.