### PR TITLE
Redirect std-lib submodule to master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "std-lib"]
 	path = std-lib
 	url = https://github.com/agda/agda-stdlib
-	branch = release-v1.7.2
+	branch = master
 [submodule "cubical"]
 	path = cubical
 	url = https://github.com/agda/cubical

--- a/benchmark/std-lib/Any.agda
+++ b/benchmark/std-lib/Any.agda
@@ -2,6 +2,8 @@
 -- Properties related to Any
 ------------------------------------------------------------------------
 
+{-# OPTIONS --allow-unsolved-metas #-}
+
 -- The other modules under Data.List.Any also contain properties
 -- related to Any.
 
@@ -367,37 +369,37 @@ private
     }
   }
 
--- return.
+-- pure.
 
 private
 
-  return⁺ : ∀ {a p} {A : Set a} {P : A → Set p} {x} →
-            P x → Any P (return x)
-  return⁺ = here
+  pure⁺ : ∀ {a p} {A : Set a} {P : A → Set p} {x} →
+            P x → Any P (pure x)
+  pure⁺ = here
 
-  return⁻ : ∀ {a p} {A : Set a} {P : A → Set p} {x} →
-            Any P (return x) → P x
-  return⁻ (here p)   = p
-  return⁻ (there ())
+  pure⁻ : ∀ {a p} {A : Set a} {P : A → Set p} {x} →
+            Any P (pure x) → P x
+  pure⁻ (here p)   = p
+  pure⁻ (there ())
 
-  return⁺∘return⁻ : ∀ {a p} {A : Set a} {P : A → Set p} {x}
-                    (p : Any P (return x)) →
-                    return⁺ (return⁻ p) ≡ p
-  return⁺∘return⁻ (here p)   = refl
-  return⁺∘return⁻ (there ())
+  pure⁺∘pure⁻ : ∀ {a p} {A : Set a} {P : A → Set p} {x}
+                    (p : Any P (pure x)) →
+                    pure⁺ (pure⁻ p) ≡ p
+  pure⁺∘pure⁻ (here p)   = refl
+  pure⁺∘pure⁻ (there ())
 
-  return⁻∘return⁺ : ∀ {a p} {A : Set a} (P : A → Set p) {x} (p : P x) →
-                    return⁻ {P = P} (return⁺ p) ≡ p
-  return⁻∘return⁺ P p = refl
+  pure⁻∘pure⁺ : ∀ {a p} {A : Set a} (P : A → Set p) {x} (p : P x) →
+                    pure⁻ {P = P} (pure⁺ p) ≡ p
+  pure⁻∘pure⁺ P p = refl
 
-return↔ : ∀ {a p} {A : Set a} {P : A → Set p} {x} →
-          P x ↔ Any P (return x)
-return↔ {P = P} = record
-  { to         = P.→-to-⟶ $ return⁺ {P = P}
-  ; from       = P.→-to-⟶ $ return⁻ {P = P}
+pure↔ : ∀ {a p} {A : Set a} {P : A → Set p} {x} →
+          P x ↔ Any P (pure x)
+pure↔ {P = P} = record
+  { to         = P.→-to-⟶ $ pure⁺ {P = P}
+  ; from       = P.→-to-⟶ $ pure⁻ {P = P}
   ; inverse-of = record
-    { left-inverse-of  = return⁻∘return⁺ P
-    ; right-inverse-of = return⁺∘return⁻
+    { left-inverse-of  = pure⁻∘pure⁺ P
+    ; right-inverse-of = pure⁺∘pure⁻
     }
   }
 
@@ -406,7 +408,7 @@ return↔ {P = P} = record
 ∷↔ : ∀ {a p} {A : Set a} (P : A → Set p) {x xs} →
      (P x ⊎ Any P xs) ↔ Any P (x ∷ xs)
 ∷↔ P {x} {xs} =
-  (P x         ⊎ Any P xs)  ↔⟨ return↔ {P = P} ⊎-cong (Any P xs ∎) ⟩
+  (P x         ⊎ Any P xs)  ↔⟨ pure↔ {P = P} ⊎-cong (Any P xs ∎) ⟩
   (Any P [ x ] ⊎ Any P xs)  ↔⟨ ++↔ {P = P} {xs = [ x ]} ⟩
   Any P (x ∷ xs)            ∎
 
@@ -482,10 +484,13 @@ concat↔ {P = P} {xss = xss} = record
        {fs : List (A → B)} {xs : List A} →
      Any (λ f → Any (P ∘ f) xs) fs ↔ Any P (fs ⊛ xs)
 ⊛↔ {ℓ} {P = P} {fs} {xs} =
-  Any (λ f → Any (P ∘ f) xs) fs               ↔⟨ Any-cong (λ _ → Any-cong (λ _ → return↔ {a = ℓ} {p = ℓ}) (_ ∎)) (_ ∎) ⟩
-  Any (λ f → Any (Any P ∘ return ∘ f) xs) fs  ↔⟨ Any-cong (λ _ → >>=↔ {ℓ = ℓ} {p = ℓ}) (_ ∎) ⟩
-  Any (λ f → Any P (xs >>= return ∘ f)) fs    ↔⟨ >>=↔ {ℓ = ℓ} {p = ℓ} ⟩
-  Any P (fs ⊛ xs)                             ∎
+  Any (λ f → Any (P ∘ f) xs) fs             ↔⟨ Any-cong (λ _ → Any-cong (λ _ → pure↔ {a = ℓ} {p = ℓ}) (_ ∎)) (_ ∎) ⟩
+  Any (λ f → Any (Any P ∘ pure ∘ f) xs) fs  ↔⟨ Any-cong (λ _ → >>=↔ {ℓ = ℓ} {p = ℓ}) (_ ∎) ⟩
+  Any (λ f → Any P (xs >>= pure ∘ f)) fs    ↔⟨ Any-cong (λ f → Any-cong (λ x → {!!}) {!!})  (_ ∎) ⟩  -- need right monad unit here
+  Any (λ f → Any P (f <$> xs)) fs           ↔⟨⟩
+  Any (Any P ∘ (_<$> xs)) fs                ↔⟨ >>=↔ {ℓ = ℓ} {p = ℓ} ⟩
+  Any P (fs >>= (_<$> xs))                  ↔⟨⟩
+  Any P (fs ⊛ xs)                           ∎
 
 -- An alternative introduction rule for _⊛_.
 
@@ -502,9 +507,10 @@ concat↔ {P = P} {xss = xss} = record
        {xs : List A} {ys : List B} →
      Any (λ x → Any (λ y → P (x , y)) ys) xs ↔ Any P (xs ⊗ ys)
 ⊗↔ {ℓ} {P = P} {xs} {ys} =
-  Any (λ x → Any (λ y → P (x , y)) ys) xs                             ↔⟨ return↔ {a = ℓ} {p = ℓ} ⟩
-  Any (λ _,_ → Any (λ x → Any (λ y → P (x , y)) ys) xs) (return _,_)  ↔⟨ ⊛↔ ⟩
-  Any (λ x, → Any (P ∘ x,) ys) (_,_ <$> xs)                           ↔⟨ ⊛↔ ⟩
+  Any (λ x → Any (λ y → P (x , y)) ys) xs                             ↔⟨ pure↔ {a = ℓ} {p = ℓ} ⟩
+  Any (λ _,_ → Any (λ x → Any (λ y → P (x , y)) ys) xs) (pure _,_)    ↔⟨ ⊛↔ ⟩
+  {!!}                                                                ↔⟨ {!!} ⟩
+  Any (λ x, → Any (P ∘ x,) ys) (_,_ <$> xs)                           ↔⟨  ⊛↔  ⟩
   Any P (xs ⊗ ys)                                                     ∎
 
 ⊗↔′ : {A B : Set} {P : A → Set} {Q : B → Set}

--- a/test/Compiler/with-stdlib/dimensions.agda
+++ b/test/Compiler/with-stdlib/dimensions.agda
@@ -264,5 +264,5 @@ printPoint : point → IO {0ℓ} ⊤
 printPoint p = putStrLn ((Nat.show (val (x p))) +s+ ";" +s+ Nat.show (val (y p)))
 
 main : IO.Primitive.IO ⊤
-main = run (Colist.mapM printPoint (Codata.Musical.Colist.fromList trace) >> return _)
+main = run (Colist.mapM printPoint (Codata.Musical.Colist.fromList trace) >> pure _)
   where trace = V.toList $ throw 15 ⟨ 1 ∶ s ⟩ base

--- a/test/LibSucceed/InstanceArguments/09-higherOrderClasses.agda
+++ b/test/LibSucceed/InstanceArguments/09-higherOrderClasses.agda
@@ -12,7 +12,7 @@ lift : ∀ {a b c} {A : Set a} {C : Set c} {B : A → Set b} →
 lift m f {{x}} = m {{f x}}
 
 monadToApplicative : ∀ {l} {M : Set l → Set l} → RawMonad M → RawApplicative M
-monadToApplicative = RawIMonad.rawIApplicative
+monadToApplicative = RawMonad.rawApplicative
 
 liftAToM : ∀ {l} {V : Set l} {M : Set l → Set l} → ({{appM : RawApplicative M}} → M V) →
            {{monadM : RawMonad M}} → M V

--- a/test/LibSucceed/InstanceArguments/11-monads.agda
+++ b/test/LibSucceed/InstanceArguments/11-monads.agda
@@ -14,7 +14,7 @@ open import Effect.Monad.Indexed using (RawIMonad; module RawIMonad)
 -- identityMonad often makes monadic code ambiguous.
 --open import Effect.Monad.Identity using (IdentityMonad)
 open import Effect.Monad.Partiality using (_⊥; now; isNow; never; run_for_steps) renaming (monad to partialityMonad)
-open import Effect.Monad.State using (StateMonad)
+open import Effect.Monad.State using (RawMonadState)
 open import Effect.Applicative.Indexed using (IFun)
 open import Function using (_$_)
 open import Function.Reasoning
@@ -34,7 +34,8 @@ module RawMonadExt {li f} {I : Set li} {M : IFun I f} (m : RawIMonad M) where
 instance i⊥ = partialityMonad
          iList = listMonad
 
-stateMonad = StateMonad ℕ
+stateMonad : (Set → Set) → Set₁
+stateMonad = RawMonadState ℕ
 
 nToList : ℕ → List ℕ
 nToList 0 = [ 0 ]
@@ -42,29 +43,29 @@ nToList (suc n) = n ∷ nToList n
 
 test′ : ℕ → (List ℕ) ⊥
 test′ k = let open RawMonad partialityMonad
-          in do x ← return (k ∷ k + 1 ∷ [])
-                return x
+          in do x ← pure (k ∷ k + 1 ∷ [])
+                pure x
 
 test2′ : ℕ → (List ℕ) ⊥
 test2′ k =  let open RawMonad partialityMonad
                 open RawMonad listMonad using () renaming (_>>=_ to _l>>=_)
-            in do x ← return [ k ]
-                  if ⌊ k ≟ 4 ⌋ then return (x l>>= nToList) else never
+            in do x ← pure [ k ]
+                  if ⌊ k ≟ 4 ⌋ then pure (x l>>= nToList) else never
 
 open RawMonad {{...}}
 open RawMonadExt {{...}}
 
 test1 : ℕ → ℕ ⊥
-test1 k =  do x ← return k
-              if ⌊ x ≟ 4 ⌋ then return 10 else never
+test1 k =  do x ← pure k
+              if ⌊ x ≟ 4 ⌋ then pure 10 else never
 
 test2 : ℕ → (List ℕ) ⊥
-test2 k =  do x ← return [ k ]
-              if ⌊ k ≟ 4 ⌋ then return ((x ∶ List ℕ) >>= nToList) else never
+test2 k =  do x ← pure [ k ]
+              if ⌊ k ≟ 4 ⌋ then pure ((x ∶ List ℕ) >>= nToList) else never
 test' : ℕ → (List ℕ) ⊥
-test' k = do x ← return (k ∷ k + 1 ∷ [])
-             if null x then never else return (x >>= nToList)
+test' k = do x ← pure (k ∷ k + 1 ∷ [])
+             if null x then never else pure (x >>= nToList)
 
 test3 : List ℕ
 test3 = do x ← 1 ∷ 2 ∷ 3 ∷ []
-           return $ x + 1
+           pure $ x + 1


### PR DESCRIPTION
- Redirect submodule std-lib to master
- Migrate compiler tests to latest std-lib, fixes #6731 

See also:
- #5605
