### PR TITLE
Minor user-manual improvements for confluency and modules

### DIFF
--- a/doc/user-manual/language/module-system.lagda.rst
+++ b/doc/user-manual/language/module-system.lagda.rst
@@ -299,3 +299,13 @@ to make the type checker able to figure out that you wanted the natural number s
 
 Also record declarations define a corresponding module, see
 :ref:`record-modules`.
+
+References
+----------
+
+The initial design of Agda 2 module system is covered
+in `Ulf Norell thesis <https://www.cse.chalmers.se/~ulfn/papers/thesis.pdf>`_.
+
+Survey on the module system implementation and its current
+semantics and performance problems was done recently (2023)
+by `Ivar de Bruin <https://repository.tudelft.nl/islandora/object/uuid:98b8fbf5-33f0-4470-88b0-39a9d526b115?collection=education>`_.

--- a/doc/user-manual/language/pragmas.lagda.rst
+++ b/doc/user-manual/language/pragmas.lagda.rst
@@ -129,6 +129,12 @@ Example::
 Aside from datatypes, this pragma can also be used to mark other
 definitions as being injective (for example postulates).
 
+At the moment it only gives you propositional injectivity,
+so you can pattern match on a proof of `Fin x ≡ Fin y` in example above,
+but does not give you definitional injectivity,
+so the constraint solver does not know how to solve the constraint `Fin x = Fin _`.
+Relevant issue: https://github.com/agda/agda/issues/4106#issuecomment-534904561
+
 .. _inline-pragma:
 
 The ``INLINE`` and ``NOINLINE`` pragmas

--- a/doc/user-manual/language/rewriting.lagda.rst
+++ b/doc/user-manual/language/rewriting.lagda.rst
@@ -9,6 +9,13 @@ Rewriting
 Rewrite rules allow you to extend Agda's evaluation relation with new
 computation rules.
 
+Rules are safe to use with ```Agda.Builtin.Equality``
+if :ref:`--confluence-check <confluence-check>` is enabled.
+Confluent but non-terminating rewrite rules can not break consistency,
+unlike to non-terminating functions.
+Those results were proven by `Cockx, Tabareau, and Winterhalter <https://hal.science/hal-02901011v2/document>`_,
+see section 3 for statements.
+
 .. note:: This page is about the :option:`--rewriting` option and the
   associated :ref:`REWRITE <builtin-rewrite>` builtin. You might be
   looking for the documentation on the :ref:`rewrite construct

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -309,7 +309,7 @@ checkPiDomain = checkDomain PiNotLam
 -- | Check a typed binding and extends the context with the bound variables.
 --   The telescope passed to the continuation is valid in the original context.
 --
---   Parametrized by a flag wether we check a typed lambda or a Pi. This flag
+--   Parametrized by a flag whether we check a typed lambda or a Pi. This flag
 --   is needed for irrelevance.
 
 checkTypedBindings :: LamOrPi -> A.TypedBinding -> (Telescope -> TCM a) -> TCM a


### PR DESCRIPTION
Commit names should explain changes.

Relevant discussion was in:

* https://github.com/agda/agda/issues/4106#issuecomment-1635641146
* Zulip question about rewriting, answered by @jespercockx 

(Andreas: Rendering of this PR at: https://agda--6736.org.readthedocs.build/en/6736/ )