### PR TITLE
[ fix #6140 ] Remember arity of List and Maybe in GHC backend

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -299,6 +299,10 @@ ghcPreCompile flags = do
       HashSet.fromList $
       catMaybes builtins
 
+  let defArity q = arity . defType <$> getConstInfo q
+  listArity <- traverse defArity mlist
+  maybeArity <- traverse defArity mmaybe
+
   return $ GHCEnv
     { ghcEnvOpts        = ghcOpts
     , ghcEnvBool        = mbool
@@ -330,6 +334,8 @@ ghcPreCompile flags = do
     , ghcEnvId          = mid
     , ghcEnvConId       = mconid
     , ghcEnvIsTCBuiltin = istcbuiltin
+    , ghcEnvListArity   = listArity
+    , ghcEnvMaybeArity  = maybeArity
     }
 
 ghcPostCompile ::

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -172,7 +172,8 @@ haskellType' t = runToHs (unEl t) (fromType t)
     fromType = fromTerm . unEl
     fromTerm v = do
       v   <- liftTCM $ unSpine <$> reduce v
-      reportSLn "compile.haskell.type" 50 $ "toHaskellType " ++ show v
+      reportSDoc "compile.haskell.type" 25 $ "toHaskellType " <+> prettyTCM v
+      reportSDoc "compile.haskell.type" 50 $ "toHaskellType " <+> pretty v
       kit <- liftTCM coinductionKit
       case v of
         Var x es -> do
@@ -253,6 +254,8 @@ hsTypeApproximation poly fv t = do
       rteCon = HS.TyCon . HS.Qual mazRTE . HS.Ident
       tyVar n i = HS.TyVar $ HS.Ident $ "a" ++ show (n - i)
   let go n t = do
+        reportSDoc "compile.haskell.type" 25 $ "hsTypeApproximation " <+> prettyTCM t
+        reportSDoc "compile.haskell.type" 50 $ "hsTypeApproximation " <+> pretty t
         t <- unSpine <$> reduce t
         case t of
           Var i _ | poly == PolyApprox -> return $ tyVar n i
@@ -260,10 +263,12 @@ hsTypeApproximation poly fv t = do
             where k = case b of Abs{} -> 1; NoAbs{} -> 0
           Def q els
             | q `is` ghcEnvList
-            , Apply t <- last1 (Proj ProjSystem __IMPOSSIBLE__) els ->
+            , Just k <- ghcEnvListArity env
+            , [Apply t] <- drop (k-1) els ->
               HS.TyApp (tyCon "[]") <$> go n (unArg t)
             | q `is` ghcEnvMaybe
-            , Apply t <- last1 (Proj ProjSystem __IMPOSSIBLE__) els ->
+            , Just k <- ghcEnvMaybeArity env
+            , [Apply t] <- drop (k-1) els ->
               HS.TyApp (tyCon "Maybe") <$> go n (unArg t)
             | q `is` ghcEnvBool    -> return $ tyCon "Bool"
             | q `is` ghcEnvInteger -> return $ tyCon "Integer"

--- a/src/full/Agda/Compiler/MAlonzo/Misc.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Misc.hs
@@ -101,7 +101,8 @@ data GHCEnv = GHCEnv
     :: Maybe QName
     -- Various (possibly) builtin names.
   , ghcEnvIsTCBuiltin :: QName -> Bool
-    -- ^ Is the given name a @TC@ builtin (except for @TC@ itself)?
+  , ghcEnvListArity   :: Maybe Int
+  , ghcEnvMaybeArity  :: Maybe Int
   }
 
 -- | Module compilation environment, bundling the overall

--- a/test/Compiler/simple/Issue6140.agda
+++ b/test/Compiler/simple/Issue6140.agda
@@ -1,0 +1,14 @@
+module Issue6140 where
+
+open import Agda.Builtin.List using (List)
+
+import Issue6140.A
+
+List-Functor = Issue6140.A.List-Functor
+
+open import Common.Bool
+open import Common.IO
+open import Common.Unit
+
+main : IO Unit
+main = printBool true

--- a/test/Compiler/simple/Issue6140.out
+++ b/test/Compiler/simple/Issue6140.out
@@ -1,0 +1,4 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > true

--- a/test/Compiler/simple/Issue6140/A.agda
+++ b/test/Compiler/simple/Issue6140/A.agda
@@ -1,0 +1,14 @@
+module Issue6140.A where
+
+open import Agda.Builtin.List using (List)
+
+postulate
+    Functor : (Set -> Set) -> Set
+
+{-# FOREIGN GHC data AgdaFunctor f = Functor f => AgdaFunctor #-}
+{-# COMPILE GHC Functor = type AgdaFunctor #-}
+
+postulate
+    List-Functor : Functor List
+
+{-# COMPILE GHC List-Functor = AgdaFunctor #-}


### PR DESCRIPTION
This fixes #6140 by properly dealing with the arity of the builtin `List` and `Maybe` types.