### PR TITLE
Fix #6702: new warning `InlineNoExactSplit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,6 +351,9 @@ Pragmas and options
   This form is accepted by the termination checker;
   unlike the form before inlining, it does not admit any infinite reduction sequences.
 
+  If option `--exact-split` is on, the inlining will trigger a `InlineNoExactSplit` warning for `nats`.
+  This warning can be disabled as usual, with `-WnoInlineNoExactSplit`.
+
 Library management
 ------------------
 

--- a/doc/user-manual/language/pragmas.lagda.rst
+++ b/doc/user-manual/language/pragmas.lagda.rst
@@ -161,6 +161,11 @@ Example::
 
   {-# INLINE _o_ #-} -- force inlining
 
+Inlining constructor right-hand sides
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.6.4
+
 Constructors can also be marked ``INLINE`` (for types supporting co-pattern matching)::
 
   record Stream (A : Set) : Set where
@@ -184,6 +189,8 @@ is translated to::
 which passes termination-checking.
 
 This translation only works for fully-applied constructors at the root of a function definition's right-hand side.
+
+If :option:`--exact-split` is on, the inlining will trigger a :option:`InlineNoExactSplit` warning for ``nats``.
 
 .. _non_covering-pragma:
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1169,6 +1169,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
      Importing a file using e.g. :option:`--cubical` into one which
      doesn't.
 
+.. option:: InlineNoExactSplit
+
+     Failed exact split after inlining a constructor, see :ref:`inline-pragma`.
+
 .. option:: InstanceNoOutputTypeName
 
      Instance arguments whose type does not end in a named or variable

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -416,6 +416,7 @@ warningHighlighting' b w = case tcWarning w of
   UnreachableClauses _ rs    -> foldMap deadcodeHighlighting rs
   CoverageIssue{}            -> coverageErrorHighlighting $ getRange w
   CoverageNoExactSplit{}     -> catchallHighlighting $ getRange w
+  InlineNoExactSplit{}       -> catchallHighlighting $ getRange w
   UnsolvedConstraints cs     -> if b then constraintsHighlighting [] cs else mempty
   UnsolvedMetaVariables rs   -> if b then metasHighlighting rs          else mempty
   AbsurdPatternRequiresNoRHS{} -> deadcodeHighlighting w

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -12,6 +12,7 @@ module Agda.Interaction.Options.Warnings
        , unsolvedWarnings
        , incompleteMatchWarnings
        , errorWarnings
+       , exactSplitWarnings
        , defaultWarningMode
        , WarningModeError(..)
        , prettyWarningModeError
@@ -165,11 +166,19 @@ allWarnings :: Set WarningName
 allWarnings = Set.fromList [minBound..maxBound]
 
 usualWarnings :: Set WarningName
-usualWarnings = allWarnings Set.\\ Set.fromList
-              [ UnknownFixityInMixfixDecl_
-              , CoverageNoExactSplit_
-              , ShadowingInTelescope_
-              ]
+usualWarnings =
+  allWarnings Set.\\ exactSplitWarnings Set.\\ Set.fromList
+    [ UnknownFixityInMixfixDecl_
+    , ShadowingInTelescope_
+    ]
+
+-- | Warnings enabled by @--exact-split@.
+--
+exactSplitWarnings :: Set WarningName
+exactSplitWarnings = Set.fromList
+  [ CoverageNoExactSplit_
+  , InlineNoExactSplit_
+  ]
 
 -- | The @WarningName@ data enumeration is meant to have a one-to-one correspondance
 -- to existing warnings in the codebase.
@@ -227,6 +236,7 @@ data WarningName
   | ClashesViaRenaming_                -- issue #4154
   | CoverageIssue_
   | CoverageNoExactSplit_
+  | InlineNoExactSplit_
   | DeprecationWarning_
   | DuplicateUsing_
   | FixityInRenamingModule_
@@ -404,6 +414,7 @@ warningNameDescription = \case
   ClashesViaRenaming_              -> "Clashes introduced by `renaming'."  -- issue #4154
   CoverageIssue_                   -> "Failed coverage checks."
   CoverageNoExactSplit_            -> "Failed exact split checks."
+  InlineNoExactSplit_              -> "Failed exact split checks after inlining record constructor."
   DeprecationWarning_              -> "Feature deprecation."
   GenericNonFatalError_            -> ""
   GenericUseless_                  -> "Useless code."

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4084,6 +4084,9 @@ data Warning
   | CoverageIssue            QName [(Telescope, [NamedArg DeBruijnPattern])]
   -- ^ `CoverageIssue f pss` means that `pss` are not covered in `f`
   | CoverageNoExactSplit     QName [Clause]
+  | InlineNoExactSplit       QName Clause
+    -- ^ 'Clause' was turned into copattern matching clause(s) by an @{-# INLINE constructor #-}@
+    --   and thus is not a definitional equality any more.
   | NotStrictlyPositive      QName (Seq OccursWhere)
 
   | UnsolvedMetaVariables    [Range]  -- ^ Do not use directly with 'warning'
@@ -4235,6 +4238,7 @@ warningName = \case
   CantGeneralizeOverSorts{}    -> CantGeneralizeOverSorts_
   CoverageIssue{}              -> CoverageIssue_
   CoverageNoExactSplit{}       -> CoverageNoExactSplit_
+  InlineNoExactSplit{}         -> InlineNoExactSplit_
   DeprecationWarning{}         -> DeprecationWarning_
   EmptyRewritePragma           -> EmptyRewritePragma_
   EmptyWhere                   -> EmptyWhere_

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -35,6 +35,7 @@ import Agda.Utils.Monad
 import Agda.Utils.Maybe
 import Agda.Utils.Singleton
 import Agda.Utils.Tuple
+import Agda.Utils.Update
 
 import Agda.Utils.Impossible
 
@@ -47,6 +48,7 @@ class ( Functor m
   default getBuiltinThing :: (MonadTrans t, HasBuiltins n, t n ~ m) => SomeBuiltin -> m (Maybe (Builtin PrimFun))
   getBuiltinThing = lift . getBuiltinThing
 
+instance HasBuiltins m => HasBuiltins (ChangeT m)
 instance HasBuiltins m => HasBuiltins (ExceptT e m)
 instance HasBuiltins m => HasBuiltins (IdentityT m)
 instance HasBuiltins m => HasBuiltins (ListT m)

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -43,6 +43,7 @@ import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.Size
+import Agda.Utils.Update
 
 import Agda.Utils.Impossible
 
@@ -200,6 +201,7 @@ defaultAddCtx x a ret =
 withFreshName_ :: (MonadAddContext m) => ArgName -> (Name -> m a) -> m a
 withFreshName_ = withFreshName noRange
 
+instance MonadAddContext m => MonadAddContext (ChangeT m)
 instance MonadAddContext m => MonadAddContext (ExceptT e m)
 instance MonadAddContext m => MonadAddContext (IdentityT m)
 instance MonadAddContext m => MonadAddContext (MaybeT m)

--- a/src/full/Agda/TypeChecking/Monad/Pure.hs
+++ b/src/full/Agda/TypeChecking/Monad/Pure.hs
@@ -21,6 +21,7 @@ import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Signature
 
 import Agda.Utils.ListT
+import Agda.Utils.Update
 
 class
   ( HasBuiltins m
@@ -34,6 +35,7 @@ class
 
 instance PureTCM TCM where
 instance PureTCM m => PureTCM (BlockT m)
+instance PureTCM m => PureTCM (ChangeT m)
 instance PureTCM m => PureTCM (ExceptT e m)
 instance PureTCM m => PureTCM (IdentityT m)
 instance PureTCM m => PureTCM (ListT m)

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -118,6 +118,13 @@ prettyWarning = \case
            ) :
       map (nest 2 . prettyTCM . NamedClause f True) cs
 
+    InlineNoExactSplit f c -> vcat $
+      [ fsep $
+          pwords "Exact splitting is enabled, but the following clause" ++
+          pwords "is no longer a definitional equality because it was translated to a copattern match:"
+      , nest 2 . prettyTCM . NamedClause f True $ c
+      ]
+
     NotStrictlyPositive d ocs -> fsep $
       [prettyTCM d] ++ pwords "is not strictly positive, because it occurs"
       ++ [prettyTCM ocs]

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20230602 * 10 + 0
+currentInterfaceVersion = 20230724 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -92,6 +92,7 @@ instance EmbPrj Warning where
     NotAffectedByOpaque                   -> icodeN 43 NotAffectedByOpaque
     UnfoldTransparentName nm              -> icodeN 44 UnfoldTransparentName nm
     UselessOpaque                         -> icodeN 45 UselessOpaque
+    InlineNoExactSplit a b                -> icodeN 46 InlineNoExactSplit a b
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -140,6 +141,7 @@ instance EmbPrj Warning where
     [43]                 -> valuN NotAffectedByOpaque
     [44, a]              -> valuN UnfoldTransparentName a
     [45]                 -> valuN UselessOpaque
+    [46, a, b]           -> valuN InlineNoExactSplit a b
     _ -> malformed
 
 instance EmbPrj OptionWarning where
@@ -299,8 +301,8 @@ instance EmbPrj InfectiveCoinfective where
     valu _   = malformed
 
 instance EmbPrj PragmaOptions where
-  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll) =
-    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll
+  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm) =
+    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm
 
   value = valueN PragmaOptions
 
@@ -429,6 +431,7 @@ instance EmbPrj WarningName where
     NotAffectedByOpaque_                         -> 98
     UnfoldTransparentName_                       -> 99
     UselessOpaque_                               -> 100
+    InlineNoExactSplit_                          -> 101
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -532,6 +535,7 @@ instance EmbPrj WarningName where
     98  -> return NotAffectedByOpaque_
     99  -> return UnfoldTransparentName_
     100 -> return UselessOpaque_
+    101 -> return InlineNoExactSplit_
     _   -> malformed
 
 

--- a/test/Succeed/ConInlineTypeAlias.agda
+++ b/test/Succeed/ConInlineTypeAlias.agda
@@ -1,4 +1,5 @@
 {-# OPTIONS --cubical #-}
+
 module ConInlineTypeAlias where
 
 open import Agda.Builtin.Cubical.Path

--- a/test/Succeed/Issue6660-Pair.agda
+++ b/test/Succeed/Issue6660-Pair.agda
@@ -1,6 +1,10 @@
 -- Lawrence, 2023-06-19, issue #6660
+-- Andreas, 2023-07-24, issue #6702
+
+{-# OPTIONS --exact-split #-}
 
 open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
 
 record Pair (A B : Set) : Set where
   inductive
@@ -9,7 +13,10 @@ record Pair (A B : Set) : Set where
         snd : B
 open Pair
 
-{-# INLINE _,_ #-}  -- expected to succeed
+{-# INLINE _,_ #-}  -- expected to succeed without exact-split warning
 
 flip : ∀{A B} → Pair A B → Pair B A
 flip p = snd p , fst p
+
+_ : ∀{A B} {p : Pair A B} → flip p ≡ (snd p , fst p)
+_ = refl

--- a/test/Succeed/Issue6660-Stream.agda
+++ b/test/Succeed/Issue6660-Stream.agda
@@ -1,6 +1,7 @@
 -- Andreas, Lawrence, 2023-06-12 issue #6660:
 -- inline constructors to pass guardedness check
 
+{-# OPTIONS --exact-split #-}
 {-# OPTIONS --guardedness #-}
 
 open import Agda.Builtin.Nat
@@ -18,3 +19,5 @@ nats n = n ∷ nats (1 + n)
 
 map : {A B : Set} (f : A → B) → Stream A → Stream B
 map f s = f (head s) ∷ map f (tail s)
+
+-- Should give warnings about non-exact splitting

--- a/test/Succeed/Issue6660-Stream.warn
+++ b/test/Succeed/Issue6660-Stream.warn
@@ -1,4 +1,4 @@
-Issue6660-Stream.agda:9,16-23
+Issue6660-Stream.agda:10,16-23
 warning: -W[no]UselessPatternDeclarationForRecord
 'pattern' attribute ignored for coinductive record
 when scope checking the declaration
@@ -9,10 +9,24 @@ when scope checking the declaration
     field
       head : A
       tail : Stream A
+Issue6660-Stream.agda:18,1-26
+warning: -W[no]InlineNoExactSplit
+Exact splitting is enabled, but the following clause is no longer a
+definitional equality because it was translated to a copattern
+match:
+  nats n = n ∷ nats (1 + n)
+when checking the definition of nats
+Issue6660-Stream.agda:21,1-38
+warning: -W[no]InlineNoExactSplit
+Exact splitting is enabled, but the following clause is no longer a
+definitional equality because it was translated to a copattern
+match:
+  map f s = f (head s) ∷ map f (tail s)
+when checking the definition of map
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue6660-Stream.agda:9,16-23
+Issue6660-Stream.agda:10,16-23
 warning: -W[no]UselessPatternDeclarationForRecord
 'pattern' attribute ignored for coinductive record
 when scope checking the declaration
@@ -23,3 +37,19 @@ when scope checking the declaration
     field
       head : A
       tail : Stream A
+
+Issue6660-Stream.agda:18,1-26
+warning: -W[no]InlineNoExactSplit
+Exact splitting is enabled, but the following clause is no longer a
+definitional equality because it was translated to a copattern
+match:
+  nats n = n ∷ nats (1 + n)
+when checking the definition of nats
+
+Issue6660-Stream.agda:21,1-38
+warning: -W[no]InlineNoExactSplit
+Exact splitting is enabled, but the following clause is no longer a
+definitional equality because it was translated to a copattern
+match:
+  map f s = f (head s) ∷ map f (tail s)
+when checking the definition of map

--- a/test/Succeed/Issue6660-greet.agda
+++ b/test/Succeed/Issue6660-greet.agda
@@ -3,6 +3,8 @@
 -- to facilitate inlining of auxiliary function _>>_.
 
 {-# OPTIONS --guardedness #-}
+{-# OPTIONS --exact-split #-}
+{-# OPTIONS -WnoInlineNoExactSplit #-}
 
 open import Agda.Builtin.String
 open import Agda.Builtin.Unit


### PR DESCRIPTION
This warning is enabled with `--exact-split` (or `-WInlineNoExactSplit`).
If an `{-# INLINE c #-}` succeeds for a non-eta record constructor `c`, this warning is issued.

Complements #6660.
Closes #6702.
