### PR TITLE
Testsuite: fix check for GHC backend invocation

### DIFF
--- a/test/Succeed/ForeignPragma.flags
+++ b/test/Succeed/ForeignPragma.flags
@@ -1,1 +1,1 @@
--c --no-main
+--ghc --no-main

--- a/test/Succeed/GHCInfixConstructor.flags
+++ b/test/Succeed/GHCInfixConstructor.flags
@@ -1,1 +1,1 @@
--c --no-main
+--ghc --no-main

--- a/test/Succeed/InlineCompiled.flags
+++ b/test/Succeed/InlineCompiled.flags
@@ -1,1 +1,1 @@
--c --no-main
+--ghc --no-main

--- a/test/Succeed/Issue1988.flags
+++ b/test/Succeed/Issue1988.flags
@@ -1,1 +1,1 @@
---compile --no-main
+--ghc --no-main

--- a/test/Succeed/Issue2248.flags
+++ b/test/Succeed/Issue2248.flags
@@ -1,1 +1,1 @@
--c --no-main
+--ghc --no-main

--- a/test/Succeed/Issue2571.flags
+++ b/test/Succeed/Issue2571.flags
@@ -1,1 +1,1 @@
--c --no-main --ghc-dont-call-ghc -v treeless:20
+--ghc --no-main --ghc-dont-call-ghc -v treeless:20

--- a/test/Succeed/Issue2908.flags
+++ b/test/Succeed/Issue2908.flags
@@ -1,1 +1,1 @@
--c -v0 -v treeless:20 --no-main
+--ghc -v0 -v treeless:20 --no-main

--- a/test/Succeed/Issue2913.flags
+++ b/test/Succeed/Issue2913.flags
@@ -1,1 +1,1 @@
--c --no-main
+--ghc --no-main

--- a/test/Succeed/Issue2916.flags
+++ b/test/Succeed/Issue2916.flags
@@ -1,1 +1,1 @@
--c --no-main
+--ghc --no-main

--- a/test/Succeed/Issue2953.flags
+++ b/test/Succeed/Issue2953.flags
@@ -1,1 +1,1 @@
--c --no-main
+--ghc --no-main

--- a/test/Succeed/Issue296.flags
+++ b/test/Succeed/Issue296.flags
@@ -1,1 +1,1 @@
---compile
+--ghc

--- a/test/Succeed/Issue3536.flags
+++ b/test/Succeed/Issue3536.flags
@@ -1,1 +1,1 @@
--c --no-main
+--ghc --no-main

--- a/test/Succeed/Issue3651.flags
+++ b/test/Succeed/Issue3651.flags
@@ -1,1 +1,1 @@
--c --no-main
+--ghc --no-main

--- a/test/Succeed/Issue3731.flags
+++ b/test/Succeed/Issue3731.flags
@@ -1,1 +1,1 @@
---compile --no-main
+--ghc --no-main

--- a/test/Succeed/Issue867.flags
+++ b/test/Succeed/Issue867.flags
@@ -1,1 +1,1 @@
---compile
+--ghc

--- a/test/Succeed/Options-in-right-order.flags
+++ b/test/Succeed/Options-in-right-order.flags
@@ -1,1 +1,1 @@
---compile --ghc-flag=+RTS --ghc-flag=-H10M --ghc-flag=-RTS
+--ghc --ghc-flag=+RTS --ghc-flag=-H10M --ghc-flag=-RTS

--- a/test/Succeed/RepeatedCase.flags
+++ b/test/Succeed/RepeatedCase.flags
@@ -1,1 +1,1 @@
--c --no-main --ghc-dont-call-ghc
+--ghc --no-main --ghc-dont-call-ghc

--- a/test/Succeed/SuperClasses.flags
+++ b/test/Succeed/SuperClasses.flags
@@ -1,1 +1,1 @@
--c --ghc-dont-call-ghc --no-main
+--ghc --ghc-dont-call-ghc --no-main

--- a/test/Succeed/Tests.hs
+++ b/test/Succeed/Tests.hs
@@ -88,6 +88,8 @@ mkSucceedTest extraOpts dir agdaFile =
                    , "-vimpossible:10" -- BEWARE: no spaces allowed here
                    , "-vwarning:1"
                    , "--double-check"
+                   -- , "--ghc-flag=-outputdir=ghc-" ++ testName
+                   -- , "-vcompile.cmd:1"
                    ] ++
                    [ if testName == "Issue481"
                      then "--no-default-libraries"

--- a/test/Succeed/WErrorOverride.flags
+++ b/test/Succeed/WErrorOverride.flags
@@ -1,2 +1,2 @@
---compile
+--ghc
 --ghc-flag=-Wwarn

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -12,6 +12,7 @@ import Data.Bifunctor
 import qualified Data.ByteString as BS
 import Data.Char
 import Data.List (intercalate, sortBy)
+import qualified Data.List as List
 import Data.Maybe
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -39,7 +40,8 @@ import Test.Tasty.Silver.Advanced ( GDiff(..), pattern ShowText, goldenTest1, re
 import qualified Text.Regex.TDFA as R
 import qualified Text.Regex.TDFA.Text as RT ( compile )
 
-import Agda.Interaction.ExitCode (AgdaError(..), agdaErrorFromInt)
+import Agda.Compiler.MAlonzo.Compiler ( ghcInvocationStrings )
+import Agda.Interaction.ExitCode      ( AgdaError(..), agdaErrorFromInt )
 import Agda.Utils.Maybe
 import Agda.Utils.Environment
 import Agda.Utils.Functor
@@ -102,7 +104,7 @@ runAgdaWithOptions testName opts mflag mvars = do
   let runAgda  = \ extraArgs -> let args = agdaArgs ++ extraArgs in
                                 readAgdaProcessWithExitCode args T.empty
   (ret, stdOut, stdErr) <- do
-    if "--compile" `elem` agdaArgs
+    if not $ null $ List.intersect agdaArgs ghcInvocationStrings
       -- Andreas, 2017-04-14, issue #2317
       -- Create temporary files in system temp directory.
       -- This has the advantage that upon Ctrl-C no junk is left behind

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -27,6 +27,7 @@ import System.Exit
 import System.FilePath
 import qualified System.FilePath.Find as Find
 import System.FilePath.GlobPattern
+-- import System.IO                     ( hPutStrLn, stderr )
 import System.IO.Temp
 import System.PosixCompat.Time       ( epochTime )
 import System.PosixCompat.Files      ( modificationTime, touchFile )
@@ -70,6 +71,7 @@ readAgdaProcessWithExitCode :: AgdaArgs -> Text
 readAgdaProcessWithExitCode args inp = do
   agdaBin <- getAgdaBin
   envArgs <- getEnvAgdaArgs
+  -- hPutStrLn stderr $ unwords $ agdaBin : envArgs ++ args
   let agdaProc = (proc agdaBin (envArgs ++ args)) { create_group = True }
   PT.readCreateProcessWithExitCode agdaProc inp
 


### PR DESCRIPTION
Re #6739: future-proof check for `-c`/`--compile`/`--ghc` in test runner
    
Maybe a cause for #6739 was that the check was for `--compile` only but the `.flags` files in `test/Succeed` also used `-c`.
This PR updates the check and prevents it from bitrotting.