### PR TITLE
quickcheck cosmetics

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -198,7 +198,6 @@ common language
       -fspecialise-aggressively
 
   ghc-options:
-      -fprint-potential-instances
       -- ASR (2022-05-31). Workaround to Issue #5932.
       -Werror
       -Werror=cpp-undef

--- a/test/Internal/Helpers.hs
+++ b/test/Internal/Helpers.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP             #-}
-
 -- | Some functions, generators and instances suitable for writing
 -- QuickCheck properties.
 

--- a/test/Internal/TypeChecking/Free.hs
+++ b/test/Internal/TypeChecking/Free.hs
@@ -1,10 +1,4 @@
-{-# LANGUAGE TemplateHaskell           #-}
-{-# LANGUAGE CPP                       #-}
-
-#if  __GLASGOW_HASKELL__ > 800
-{-# OPTIONS_GHC -Wno-error=missing-signatures #-}
-#endif
-{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- | Tests for free variable computations.
 

--- a/test/Internal/Utils/AssocList.hs
+++ b/test/Internal/Utils/AssocList.hs
@@ -1,10 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE CPP             #-}
-
-#if  __GLASGOW_HASKELL__ > 800
-{-# OPTIONS_GHC -Wno-error=missing-signatures #-}
-#endif
-{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
 module Internal.Utils.AssocList ( tests ) where
 

--- a/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -1,10 +1,4 @@
-{-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE CPP                        #-}
-
-#if  __GLASGOW_HASKELL__ > 800
-{-# OPTIONS_GHC -Wno-error=missing-signatures #-}
-#endif
-{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- | Properties for graph library.
 

--- a/test/Internal/Utils/ListT.hs
+++ b/test/Internal/Utils/ListT.hs
@@ -1,10 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE CPP             #-}
-
-#if  __GLASGOW_HASKELL__ > 800
-{-# OPTIONS_GHC -Wno-error=missing-signatures #-}
-#endif
-{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
 -- | Quickcheck properties for 'Agda.Utils.ListT'.
 
@@ -13,6 +7,7 @@ module Internal.Utils.ListT ( tests ) where
 import Control.Applicative
 
 import Data.Functor.Identity
+import Data.Word (Word8)
 
 import Text.Show.Functions
 
@@ -35,10 +30,17 @@ fromList = foldr consListT nilListT
 toList :: List a -> [a]
 toList = foldList (:) []
 
+-- Pick a medium-sized type where collisions are not very unlikely.
+type A = Word8
+type B = Word8
+
+prop_concat :: [[A]] -> Bool
 prop_concat xxs = toList (concatListT (fromList (map fromList xxs))) == concat xxs
 
+prop_idiom :: [A -> B] -> [A] -> Bool
 prop_idiom fs xs = toList (fromList fs <*> fromList xs) == (fs <*> xs)
 
+prop_concatMap :: (A -> [B]) -> [A] -> Bool
 prop_concatMap f xs = toList (fromList . f =<< fromList xs) == (f =<< xs)
 
 ------------------------------------------------------------------------

--- a/test/Internal/Utils/Permutation.hs
+++ b/test/Internal/Utils/Permutation.hs
@@ -1,10 +1,4 @@
 {-# LANGUAGE TemplateHaskell    #-}
-{-# LANGUAGE CPP                #-}
-
-#if  __GLASGOW_HASKELL__ > 800
-{-# OPTIONS_GHC -Wno-error=missing-signatures #-}
-#endif
-{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
 module Internal.Utils.Permutation ( tests ) where
 


### PR DESCRIPTION
- Agda.cabal: remove -fprint-potential-instances
- [ testsuite ] cosmetics: remove some unused GHC flags
- [ testsuite ] type signatures for the Utils.ListT quickcheck props
