### PR TITLE
Fix #6761: sort hashmap before serialization

### DIFF
--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20230724 * 10 + 0
+currentInterfaceVersion = 20230810 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -15,6 +15,7 @@ import qualified Data.Foldable as Fold
 import Data.Hashable
 import Data.Int (Int32)
 
+import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
@@ -465,8 +466,12 @@ instance EmbPrj OpaqueId where
 
   value = valueN OpaqueId
 
-instance (Eq k, Hashable k, EmbPrj k, EmbPrj v) => EmbPrj (HashMap k v) where
-  icod_ m = mapPairsIcode (HMap.toList m)
+instance (Eq k, Ord k, Hashable k, EmbPrj k, EmbPrj v) => EmbPrj (HashMap k v) where
+  icod_ m = mapPairsIcode $ List.sortOn fst $ HMap.toList m
+    -- Andreas, 2023-08-10, issue #6761.
+    -- Need to sort to get deterministic result.
+    -- Otherwise our interface file format depends on the non-PVP versioned
+    -- hashing algorithm of the @hashable@ package.
   value = vcase (fmap HMap.fromList . mapPairsValue)
 
 instance EmbPrj a => EmbPrj (WithHiding a) where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -3,8 +3,9 @@
 
 module Agda.TypeChecking.Serialise.Instances.Internal where
 
-import qualified Data.HashSet as HashSet
 import Control.Monad.IO.Class
+import qualified Data.HashSet as HashSet
+import qualified Data.List    as List
 
 import Agda.Syntax.Internal as I
 import Agda.Syntax.Position as P
@@ -466,12 +467,11 @@ instance EmbPrj a => EmbPrj (Case a) where
 -- compute the transitive closure during scope checking, never
 -- afterwards.
 instance EmbPrj OpaqueBlock where
-  icod_ (OpaqueBlock id uf _ _ r) =
-    icodeN' (\id uf ->
-      OpaqueBlock id (HashSet.fromList uf) mempty Nothing)
-    id (HashSet.toList uf) r
+  icod_ (OpaqueBlock oid uf _ _ r) =
+    icodeN' (\ oid uf -> OpaqueBlock oid (HashSet.fromList uf) mempty Nothing)
+      oid (List.sort $ HashSet.toList uf) r
 
-  value = valueN (\id uf -> OpaqueBlock id (HashSet.fromList uf) mempty Nothing)
+  value = valueN (\ oid uf -> OpaqueBlock oid (HashSet.fromList uf) mempty Nothing)
 
 instance EmbPrj CompiledClauses where
   icod_ (Fail a)   = icodeN' Fail a


### PR DESCRIPTION
This makes serialization a function from interface version and inputsto interface files.  Without it, the serialized bits are also dependent on the hash function (which is dependent on the build of Agda).

Closes #6761.
