### PR TITLE
Various symbol additions to agda-input

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -341,6 +341,7 @@ order for the change to take effect."
   ("b-"  . ("⊟"))
   ("bx"  . ("⊠"))
   ("b."  . ("⊡"))
+
   ("b/"  . ("⧄"))
   ("b\\" . ("⧅"))
   ("b*"  . ("⧆"))
@@ -851,10 +852,7 @@ order for the change to take effect."
 
   ("note"    . ,(agda-input-to-string-list "♩♪♫♬"))
   ("b"       . ("♭"))
-  ("flat"    . ("♭"))
   ("#"       . ("♯"))
-  ("sharp"   . ("♯"))
-  ("natural" . ("♮"))
   ("bb"      . ("𝄫"))
   ("##"      . ("𝄪"))
 

--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -313,10 +313,10 @@ order for the change to take effect."
   ("surd4"     . ("∜"))
   ("increment" . ("∆"))
   ("inf"       . ("∞"))
-  ("&"         . ("⅋﹠＆"))
+  ("&"         . ,(agda-input-to-string-list "⅋﹠＆"))
   ("z;"        . ,(agda-input-to-string-list "⨟⨾"))
   ("z:"        . ("⦂"))
-  ("at"        . ("@﹫＠"))
+  ("at"        . ,(agda-input-to-string-list "@﹫＠"))
 
   ;; Circled operators.
 

--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -347,7 +347,7 @@ order for the change to take effect."
   ("bo"  . ("⧇"))
   ("bsq" . ("⧈"))
 
-  ;; APL boxed operators
+  ;; APL boxed operators.
 
   ("box="       . ("⌸"))
   ("box?"       . ("⍰"))
@@ -698,7 +698,7 @@ order for the change to take effect."
   ("B8"   . ("𝟖"))
   ("B9"   . ("𝟗"))
 
-  ;; Fullwidth letters
+  ;; Fullwidth letters.
 
   ("FA"   . ("Ａ"))
   ("FB"   . ("Ｂ"))
@@ -753,7 +753,7 @@ order for the change to take effect."
   ("Fy"   . ("ｙ"))
   ("Fz"   . ("ｚ"))
 
-  ;; Fullwidth digits
+  ;; Fullwidth digits.
 
   ("F0"   . ("０"))
   ("F1"   . ("１"))
@@ -766,7 +766,7 @@ order for the change to take effect."
   ("F8"   . ("８"))
   ("F9"   . ("９"))
 
-  ;; Fullwidth symbols
+  ;; Fullwidth symbols.
 
   ("F!"   . ("！"))
   ("F\""  . ("＂"))
@@ -933,7 +933,7 @@ order for the change to take effect."
   ("Gp"  . ("ψ"))  ("GP"  . ("Ψ"))
   ("Go"  . ("ω"))  ("GO"  . ("Ω"))
 
-  ;; Mathematical characters
+  ;; Mathematical characters.
 
   ("MiA" . ("𝐴"))
   ("MiB" . ("𝐵"))
@@ -1196,7 +1196,7 @@ order for the change to take effect."
   ("Mfy" . ("𝔶"))
   ("Mfz" . ("𝔷"))
 
-  ;; (Sub / Super) scripts
+  ;; (Sub / Super) scripts.
   ;;
   ;; Unicode 12.1 omits several latin characters from sub/superscript.
   ;; https://www.quora.com/Why-is-there-no-character-for-superscript-q-in-Unicode

--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -851,8 +851,12 @@ order for the change to take effect."
 
   ("note"    . ,(agda-input-to-string-list "♩♪♫♬"))
   ("b"       . ("♭"))
+  ("flat"    . ("♭"))
   ("#"       . ("♯"))
+  ("sharp"   . ("♯"))
   ("natural" . ("♮"))
+  ("bb"      . ("𝄫"))
+  ("##"      . ("𝄪"))
 
   ;; Other punctuation and symbols.
 

--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -308,13 +308,15 @@ order for the change to take effect."
   ("+ "        . ("⊹"))
   ("+"         . ("＋"))
   ("sqrt"      . ("√"))
+  ("surd"      . ("√"))
   ("surd3"     . ("∛"))
   ("surd4"     . ("∜"))
   ("increment" . ("∆"))
   ("inf"       . ("∞"))
-  ("&"         . ("⅋"))
+  ("&"         . ("⅋﹠＆"))
   ("z;"        . ,(agda-input-to-string-list "⨟⨾"))
   ("z:"        . ("⦂"))
+  ("at"        . ("@﹫＠"))
 
   ;; Circled operators.
 
@@ -335,10 +337,15 @@ order for the change to take effect."
 
   ;; Boxed operators.
 
-  ("b+" . ("⊞"))
-  ("b-" . ("⊟"))
-  ("bx" . ("⊠"))
-  ("b." . ("⊡"))
+  ("b+"  . ("⊞"))
+  ("b-"  . ("⊟"))
+  ("bx"  . ("⊠"))
+  ("b."  . ("⊡"))
+  ("b/"  . ("⧄"))
+  ("b\\" . ("⧅"))
+  ("b*"  . ("⧆"))
+  ("bo"  . ("⧇"))
+  ("bsq" . ("⧈"))
 
   ;; APL boxed operators
 
@@ -376,6 +383,7 @@ order for the change to take effect."
   ("integral" . ,(agda-input-to-string-list "∫∬∭∮∯∰∱∲∳"))
   ("angle"    . ,(agda-input-to-string-list "∟∡∢⊾⊿"))
   ("join"     . ,(agda-input-to-string-list "⋈⋉⋊⋋⋌⨝⟕⟖⟗"))
+  ("esh"      . ("ʃ"))
 
   ;; Arrows.
 
@@ -758,6 +766,42 @@ order for the change to take effect."
   ("F8"   . ("８"))
   ("F9"   . ("９"))
 
+  ;; Fullwidth symbols
+
+  ("F!"   . ("！"))
+  ("F\""  . ("＂"))
+  ("F#"   . ("＃"))
+  ("F$"   . ("＄"))
+  ("F%"   . ("％"))
+  ("F&"   . ("＆"))
+  ("F'"   . ("＇"))
+  ("F("   . ("（"))
+  ("F)"   . ("）"))
+  ("F*"   . ("＊"))
+  ("F+"   . ("＋"))
+  ("F,"   . ("，"))
+  ("F-"   . ("－"))
+  ("F."   . ("．"))
+  ("F/"   . ("／"))
+  ("F:"   . ("："))
+  ("F;"   . ("；"))
+  ("F<"   . ("＜"))
+  ("F="   . ("＝"))
+  ("F>"   . ("＞"))
+  ("F?"   . ("？"))
+  ("F@"   . ("＠"))
+  ("F["   . ("［"))
+  ("F\\"  . ("＼"))
+  ("F]"   . ("］"))
+  ("F_"   . ("＿"))
+  ("F{"   . ("｛"))
+  ("F|"   . ("｜"))
+  ("F}"   . ("｝"))
+  ("F~"   . ("～"))
+  ("F(("  . ("｟"))
+  ("F))"  . ("｠"))
+  ("Fneg" . ("￢"))
+
   ;; Parentheses.
 
   ("(" . ,(agda-input-to-string-list "([{⁅⁽₍〈⎴⟅⟦⟨⟪⦃〈《「『【〔〖〚︵︷︹︻︽︿﹁﹃﹙﹛﹝（［｛｢❪❬❰❲❴⟮⦅⦗⧼⸨❮⦇⦉"))
@@ -805,13 +849,14 @@ order for the change to take effect."
 
   ;; Musical symbols.
 
-  ("note" . ,(agda-input-to-string-list "♩♪♫♬"))
-  ("b"    . ("♭"))
-  ("#"    . ("♯"))
+  ("note"    . ,(agda-input-to-string-list "♩♪♫♬"))
+  ("b"       . ("♭"))
+  ("#"       . ("♯"))
+  ("natural" . ("♮"))
 
   ;; Other punctuation and symbols.
 
-  ("\\"         . ("\\"))
+  ("\\"         . ("＼"))
   ("en"         . ("–"))
   ("em"         . ("—"))
   ("!"          . ("！"))

--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -277,6 +277,8 @@ order for the change to take effect."
   ("exn" . ("∄"))
   ("0"   . ("∅"))
   ("C"   . ("∁"))
+  ("uin"    . ("⟒"))
+  ("din"    . ("⫙"))
 
   ;; Corners, ceilings and floors.
 

--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -989,6 +989,7 @@ order for the change to take effect."
   ("Mix" . ("𝑥"))
   ("Miy" . ("𝑦"))
   ("Miz" . ("𝑧"))
+
   ("MIA" . ("𝑨"))
   ("MIB" . ("𝑩"))
   ("MIC" . ("𝑪"))
@@ -1015,6 +1016,7 @@ order for the change to take effect."
   ("MIX" . ("𝑿"))
   ("MIY" . ("𝒀"))
   ("MIZ" . ("𝒁"))
+
   ("MIa" . ("𝒂"))
   ("MIb" . ("𝒃"))
   ("MIc" . ("𝒄"))
@@ -1041,6 +1043,7 @@ order for the change to take effect."
   ("MIx" . ("𝒙"))
   ("MIy" . ("𝒚"))
   ("MIz" . ("𝒛"))
+
   ("McA" . ("𝒜"))
   ("McB" . ("ℬ"))
   ("McC" . ("𝒞"))
@@ -1093,6 +1096,7 @@ order for the change to take effect."
   ("Mcx" . ("𝓍"))
   ("Mcy" . ("𝓎"))
   ("Mcz" . ("𝓏"))
+
   ("MCA" . ("𝓐"))
   ("MCB" . ("𝓑"))
   ("MCC" . ("𝓒"))
@@ -1145,6 +1149,7 @@ order for the change to take effect."
   ("MCx" . ("𝔁"))
   ("MCy" . ("𝔂"))
   ("MCz" . ("𝔃"))
+
   ("MfA" . ("𝔄"))
   ("MfB" . ("𝔅"))
   ("MfC" . ("ℭ"))
@@ -1294,13 +1299,17 @@ order for the change to take effect."
   ;; ("^Y" . ("Y"))
   ;; ("^Z" . ("Z"))
 
+  ("^Ga" . ("ᵅ"))
   ("^Gb" . ("ᵝ"))
   ("^Gg" . ("ᵞ"))
   ("^Gd" . ("ᵟ"))
   ("^Ge" . ("ᵋ"))
   ("^Gth" . ("ᶿ"))
+  ("^Gi" . ("ᶥ"))
   ("^Gf" . ("ᵠ"))
   ("^Gc" . ("ᵡ"))
+
+  ("^GF" . ("ᶲ"))
 
   ;; Some ISO8859-1 characters.
 


### PR DESCRIPTION
This PR adds a range of symbols to `agda-input` including
- Non-alphanumeric fullwidth symbols
- Boxed operators `⧄⧅⧆⧇⧈`
- Esh `ʃ`
- At `@﹫＠`

The boxed circle operator introduces a conflict with the blackboard boldface o. Is this okay, or should it be rebound to `boxo` or `bcirc`?