### PR TITLE
TypeChecking/Rules/Def.hs Error Refactor

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -281,6 +281,7 @@ errorString err = case err of
   DoesNotMentionTicks{}                    -> "DoesNotMentionTicks"
   MismatchedProjectionsError{}             -> "MismatchedProjectionsError"
   AttributeKindNotEnabled{}                -> "AttributeKindNotEnabled"
+  CannotRewriteByNonEquation{}             -> "CannotRewriteByNonEquation"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1310,6 +1311,9 @@ instance PrettyTCM TypeError where
       [text opt] ++
       pwords "to enable them):" ++
       [text s]
+
+    CannotRewriteByNonEquation t ->
+      "Cannot rewrite by equation of type" <+> prettyTCM t
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -282,6 +282,7 @@ errorString err = case err of
   MismatchedProjectionsError{}             -> "MismatchedProjectionsError"
   AttributeKindNotEnabled{}                -> "AttributeKindNotEnabled"
   CannotRewriteByNonEquation{}             -> "CannotRewriteByNonEquation"
+  MacroResultTypeMismatch{}                -> "MacroResultTypeMismatch"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1314,6 +1315,9 @@ instance PrettyTCM TypeError where
 
     CannotRewriteByNonEquation t ->
       "Cannot rewrite by equation of type" <+> prettyTCM t
+
+    MacroResultTypeMismatch expectedType ->
+      sep [ "Result type of a macro must be", nest 2 $ prettyTCM expectedType ]
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -283,6 +283,7 @@ errorString err = case err of
   AttributeKindNotEnabled{}                -> "AttributeKindNotEnabled"
   CannotRewriteByNonEquation{}             -> "CannotRewriteByNonEquation"
   MacroResultTypeMismatch{}                -> "MacroResultTypeMismatch"
+  NamedWhereModuleInRefinedContext{}       -> "NamedWhereModuleInRefinedContext"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1318,6 +1319,16 @@ instance PrettyTCM TypeError where
 
     MacroResultTypeMismatch expectedType ->
       sep [ "Result type of a macro must be", nest 2 $ prettyTCM expectedType ]
+
+    NamedWhereModuleInRefinedContext args names -> do
+      let pr x v = text (x ++ " =") <+> prettyTCM v
+      vcat
+        [ fsep (pwords $ "Named where-modules are not allowed when module parameters have been refined by pattern matching. " ++
+                          "See https://github.com/agda/agda/issues/2897.")
+        , text $ "In this case the module parameter" ++
+                  (if not (null args) then "s have" else " has") ++
+                  " been refined to"
+        , nest 2 $ vcat (zipWith pr names args) ]
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4565,6 +4565,7 @@ data TypeError
         | MismatchedProjectionsError QName QName
         | AttributeKindNotEnabled String String String
         | CannotRewriteByNonEquation Type
+        | MacroResultTypeMismatch Type
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4566,6 +4566,7 @@ data TypeError
         | AttributeKindNotEnabled String String String
         | CannotRewriteByNonEquation Type
         | MacroResultTypeMismatch Type
+        | NamedWhereModuleInRefinedContext [Term] [String]
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4564,6 +4564,7 @@ data TypeError
           -- does not mention any @lock variables.
         | MismatchedProjectionsError QName QName
         | AttributeKindNotEnabled String String String
+        | CannotRewriteByNonEquation Type
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -143,8 +143,7 @@ checkMacroType t = do
       resType = abstract (telFromList (drop (length telList - 1) telList)) tr
   expectedType <- el primAgdaTerm --> el (primAgdaTCM <#> primLevelZero <@> primUnit)
   equalType resType expectedType
-    `catchError` \ _ -> typeError . GenericDocError =<< sep [ "Result type of a macro must be"
-                                                            , nest 2 $ prettyTCM expectedType ]
+    `catchError` \ _ -> typeError $ MacroResultTypeMismatch expectedType
 
 -- | A single clause without arguments and without type signature is an alias.
 isAlias :: [A.Clause] -> Type -> Maybe (A.Expr, Maybe C.Expr, MetaId)

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -995,10 +995,8 @@ checkRHS i x aps t lhsResult@(LHSResult _ delta ps absurdPat trhs _ _asb _ _) rh
           s <- sortOf dom
           return (eqt, El s dom, unArg a, unArg b)
           -- Note: the sort _s of the equality need not be the sort of the type @dom@!
-        OtherType{} -> typeError . GenericDocError =<< do
-          "Cannot rewrite by equation of type" <+> prettyTCM t'
-        IdiomType{} -> typeError . GenericDocError =<< do
-          "Cannot rewrite by equation of type" <+> prettyTCM t'
+        OtherType{} -> typeError $ CannotRewriteByNonEquation t'
+        IdiomType{} -> typeError $ CannotRewriteByNonEquation t'
 
       reflPat <- getReflPattern
 


### PR DESCRIPTION
Refactor `GenericDocError`-s for concrete ones in `TypeChecking/Rules/Def.hs`. More specifically:

- Introduce an error `CannotRewriteByNonEquation`
- Introduce an error `MacroResultTypeMismatch`
- Introduce an error `NamedWhereModuleInRefinedContext`