### PR TITLE
MAlonzo: coerce let body in RHS

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -1039,7 +1039,7 @@ noApplication = \case
   T.TLet t1 t2 -> do
     t1' <- term t1
     intros 1 $ \[x] -> do
-      hsLet x t1' <$> term t2
+      hsLet x t1' . hsCoerce <$> term t2
 
   T.TCase sc ct def alts -> do
     sc'   <- term $ T.TVar sc

--- a/test/Compiler/simple/Issue6530.agda
+++ b/test/Compiler/simple/Issue6530.agda
@@ -1,69 +1,52 @@
 {-# OPTIONS --erased-cubical --erasure --no-main #-}
 module Issue6530 where
 
-open import Agda.Primitive
-open import Agda.Builtin.Sigma
-open import Agda.Builtin.Nat
 open import Agda.Builtin.Cubical.Path
-
-open import Agda.Primitive.Cubical public
-  renaming ( primIMin       to _∧_  -- I → I → I
-           ; primIMax       to _∨_  -- I → I → I
-           ; primINeg       to ~_   -- I → I
-           ; isOneEmpty     to empty
-           ; primComp       to comp
-           ; primHComp      to hcomp
-           ; primTransp     to transp)
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Sigma
+open import Agda.Primitive
+open import Agda.Primitive.Cubical
 
 private variable
-  ℓ : Level
-  A : Set ℓ
-  x y w z : A
+  a b ℓ : Level
+  A : Set a
+  x y : A
+  B : A → Set b
 
-refl : x ≡ x
-refl {x = x} i = x
+is-of-hlevel : Nat → Set ℓ → Set ℓ
+is-of-hlevel 0 A = Σ A λ x → ∀ y → x ≡ y
+is-of-hlevel 1 A = (x y : A) → x ≡ y
+is-of-hlevel (suc (suc h)) A = (x y : A) → is-of-hlevel (suc h) (x ≡ y)
 
-sym : x ≡ y → y ≡ x
-sym p i = p (~ i)
+transport : {A B : Set ℓ} → A ≡ B → A → B
+transport p a = primTransp (λ i → p i) i0 a
 
-isContr : Set ℓ → Set ℓ
-isContr A = Σ A (λ x → ∀ y → x ≡ y)
+to-pathP : {A : I → Set ℓ} {x : A i0} {y : A i1} → transport (λ i → A i) x ≡ y → PathP A x y
+to-pathP {A = A} {x} p i = primHComp (λ j → λ { (i = i0) → x
+                                              ; (i = i1) → p j })
+                          (primTransp (λ j → A (primIMin i j)) (primINeg i) x)
 
-isProp : Set ℓ → Set ℓ
-isProp A = (x y : A) → x ≡ y
+J : (P : ∀ y → x ≡ y → Set ℓ) (d : P x (λ _ → x)) (p : x ≡ y) → P y p
+J P d p = transport (λ i → P (p i) (λ j → p (primIMin i j))) d
 
-isSet : Set ℓ → Set ℓ
-isSet A = (x y : A) → isProp (x ≡ y)
+is-prop→pathP : {B : I → Set ℓ}
+                (h : (i : I) → is-of-hlevel 1 (B i))
+              → (b₀ : B i0) (b₁ : B i1)
+              → PathP B b₀ b₁
+is-prop→pathP h b₀ b₁ = to-pathP (h i1 _ b₁)
 
+is-of-hlevel-dep : Nat → (A → Set ℓ) → Set _
+is-of-hlevel-dep 0 B =
+  ∀ {x y} (α : B x) (β : B y) (p : x ≡ y) → PathP (λ i → B (p i)) α β
+is-of-hlevel-dep (suc n) B =
+  ∀ {a₀ a₁} (b₀ : B a₀) (b₁ : B a₁)
+  → is-of-hlevel-dep {A = a₀ ≡ a₁} n (λ p → PathP (λ i → B (p i)) b₀ b₁)
 
-doubleComp-faces : {x y z w : A } (p : x ≡ y) (r : z ≡ w)
-                 → (i : I) (j : I) → Partial (i ∨ ~ i) A
-doubleComp-faces p r i j (i = i0) = p (~ j)
-doubleComp-faces p r i j (i = i1) = r j
-
-_∙∙_∙∙_ : w ≡ x → x ≡ y → y ≡ z → w ≡ z
-(p ∙∙ q ∙∙ r) i =
-  hcomp (doubleComp-faces p r i) (q i)
-
-_∙_ : x ≡ y → y ≡ z → x ≡ z
-p ∙ q = refl ∙∙ p ∙∙ q
-
-isContr→isProp : isContr A → isProp A
-isContr→isProp (x , p) a b = sym (p a) ∙ p b
-
-isProp→isSet : isProp A → isSet A
-isProp→isSet h a b p q j i =
-  hcomp (λ k → λ { (i = i0) → h a a k
-                 ; (i = i1) → h a b k
-                 ; (j = i0) → h a (p i) k
-                 ; (j = i1) → h a (q i) k }) a
-
-isOfHLevel : Nat → Set ℓ → Set ℓ
-isOfHLevel 0 A = isContr A
-isOfHLevel 1 A = isProp A
-isOfHLevel (suc (suc n)) A = (x y : A) → isOfHLevel (suc n) (x ≡ y)
-
-isOfHLevelSuc : (n : Nat) → isOfHLevel n A → isOfHLevel (suc n) A
-isOfHLevelSuc 0 = isContr→isProp
-isOfHLevelSuc 1 = isProp→isSet
-isOfHLevelSuc (suc (suc n)) h a b = isOfHLevelSuc (suc n) (h a b)
+is-of-hlevel→is-of-hlevel-dep
+  : (n : Nat) (hl : ((x : A) → is-of-hlevel (suc n) (B x)))
+  → is-of-hlevel-dep n B
+is-of-hlevel→is-of-hlevel-dep 0 hl α β p = is-prop→pathP (λ i → hl (p i)) α β
+is-of-hlevel→is-of-hlevel-dep {A = A} {B = B} (suc n) hl {a₀} {a₁} b₀ b₁ =
+  is-of-hlevel→is-of-hlevel-dep n λ p →
+    J (λ a₁ p → ∀ b₁ → is-of-hlevel (suc n) (PathP (λ i → B (p i)) b₀ b₁))
+    (hl a₀ b₀) p b₁


### PR DESCRIPTION
Issue #6530 resurfaced: somehow `let` expressions were generated without coercions (blame me for overlooking it last time). It affects variadic functions like `isOfHLevelDep`.