### PR TITLE
Attempt on a doc-test suite using `doctest-parallel`

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -163,6 +163,13 @@ flag debug
   description:
     Enable debugging features that may slow Agda down.
 
+-- Automatic flag to turn off the DocTests suite if its dependencies are not available.
+flag doctests
+  default: True
+  manual:  False
+  description:
+    Enable the agda-doc-tests test-suite.
+
 flag enable-cluster-counting
   default: False
   description:
@@ -972,3 +979,22 @@ test-suite agda-tests
   -- Andreas (2021-10-11): tasty-silver < 3.3 does not work interactively under Windows
   if os(windows)
     build-depends: tasty-silver >= 3.3
+
+test-suite agda-doc-tests
+  import:           language
+
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test/
+  main-is:          DocTestMain.hs
+  build-depends:
+    , Agda
+    , base
+    , doctest-parallel ^>= 0.3.0
+        -- doctest-parallel-0.2.2 is the first to filter out autogen-modules
+
+  if !flag(doctests)
+    buildable: False
+
+  if impl(ghc >= 8.10)
+    ghc-options:
+      -Wno-unused-packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,6 +498,8 @@ Reflection
   The `blockOnMeta` builtin has been deprecated, and an implementation
   in terms of `blockTC` is given for backwards compatibility.
 
+* The `executables` file now allows entries of the form `name = path`
+  (whitespace around `=` needed) so that `execTC "name"` will invoke `path`.
 
 Other issues closed
 -------------------

--- a/Makefile
+++ b/Makefile
@@ -482,7 +482,7 @@ common :
 .PHONY : succeed ##
 succeed :
 	@$(call decorate, "Suite of successful tests", \
-		echo $(shell which $(AGDA_BIN)) > test/Succeed/exec-tc/executables && \
+		echo "agda = $(shell which $(AGDA_BIN))" > test/Succeed/exec-tc/executables && \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Succeed ; \
 		rm test/Succeed/exec-tc/executables )
 

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -870,3 +870,14 @@ For instance, to run the example above, you must add ``/bin/echo`` to this file:
 
 The executable can then be called by passing its basename to ``execTC``,
 subtracting the ``.exe`` on Windows.
+
+Since 2.6.4, lines of the form ``name = path`` are also allowed in the ``executables`` file.
+The equals sign must be surrounded by whitespace.
+The new form allows an executable to be available under a different name, for example:
+
+.. code-block:: text
+
+  # contents of ~/.agda/executables
+  agda = $HOME/.cabal/bin/agda-2.6.4
+
+Given this configuration, ``execTC "agda"`` will invoke ``agda-2.6.4`` located in ``$HOME/.cabal/bin``.

--- a/test/DocTestMain.hs
+++ b/test/DocTestMain.hs
@@ -1,0 +1,18 @@
+-- | `doctest-parallel` runner for the `Agda` library.
+module Main where
+
+import System.Environment
+         ( getArgs )
+import Test.DocTest
+         ( mainFromLibrary )
+import Test.DocTest.Helpers
+         ( extractSpecificCabalLibrary, findCabalPackage )
+
+-- | Doctest @Agda:Agda@.
+main :: IO ()
+main = do
+  args <- getArgs
+  pkg  <- findCabalPackage "Agda"
+  -- Need to give the library name, otherwise the parser does not find it.
+  lib  <- extractSpecificCabalLibrary Nothing pkg
+  mainFromLibrary lib args


### PR DESCRIPTION
Attempt on a doc-test suite using `doctest-parallel`.

Currently fails:
```
$ cabal test agda-doc-tests --enable-tests -O0
...
Test suite agda-doc-tests: RUNNING...

<no location info>: error: [GHC-82272]
    module ‘Agda.Syntax.Parser.Parser’ cannot be found locally
```
Trying to generate this module with `happy` and retrying I am getting the weird error:
```
$ cabal run agda-doc-tests --enable-tests -O0
Warning: this is a debug build of cabal-install with assertions enabled.

agda/src/full/Agda/Syntax/Parser/Parser.hs:1:1: error: [GHC-28623]
    File name does not match module name:
    Saw     : ‘Main’
    Expected: ‘Agda.Syntax.Parser.Parser’
```