### PR TITLE
TypeChecking/Rules/Term.hs Error Refactor

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -282,6 +282,7 @@ errorString err = case err of
   MismatchedProjectionsError{}             -> "MismatchedProjectionsError"
   AttributeKindNotEnabled{}                -> "AttributeKindNotEnabled"
   InvalidProjectionParameter{}             -> "InvalidProjectionParameter"
+  TacticAttributeNotAllowed{}              -> "TacticAttributeNotAllowed"
   CannotRewriteByNonEquation{}             -> "CannotRewriteByNonEquation"
   MacroResultTypeMismatch{}                -> "MacroResultTypeMismatch"
   NamedWhereModuleInRefinedContext{}       -> "NamedWhereModuleInRefinedContext"
@@ -1318,6 +1319,9 @@ instance PrettyTCM TypeError where
     InvalidProjectionParameter arg -> fsep $
       pwords "Invalid projection parameter " ++
       [prettyA arg]
+
+    TacticAttributeNotAllowed -> fsep $
+      pwords "The @tactic attribute is not allowed here"
 
     CannotRewriteByNonEquation t ->
       "Cannot rewrite by equation of type" <+> prettyTCM t

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -125,6 +125,7 @@ errorString :: TypeError -> String
 errorString err = case err of
   AmbiguousModule{}                        -> "AmbiguousModule"
   AmbiguousName{}                          -> "AmbiguousName"
+  AmbiguousField{}                         -> "AmbiguousField"
   AmbiguousParseForApplication{}           -> "AmbiguousParseForApplication"
   AmbiguousParseForLHS{}                   -> "AmbiguousParseForLHS"
   AmbiguousProjectionError{}               -> "AmbiguousProjectionError"
@@ -874,6 +875,10 @@ instance PrettyTCM TypeError where
             IsDataModule   -> return $ "(datatype module)"
             IsRecordModule -> return $ "(record module)"
           sep [prettyTCM m, anno ]
+
+    AmbiguousField field modules -> vcat $
+      "Ambiguity: the field" <+> prettyTCM field
+        <+> "appears in the following modules: " : map prettyTCM modules
 
     ClashingDefinition x y suggestion -> fsep $
       pwords "Multiple definitions of" ++ [pretty x <> "."] ++

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -281,6 +281,7 @@ errorString err = case err of
   DoesNotMentionTicks{}                    -> "DoesNotMentionTicks"
   MismatchedProjectionsError{}             -> "MismatchedProjectionsError"
   AttributeKindNotEnabled{}                -> "AttributeKindNotEnabled"
+  InvalidProjectionParameter{}             -> "InvalidProjectionParameter"
   CannotRewriteByNonEquation{}             -> "CannotRewriteByNonEquation"
   MacroResultTypeMismatch{}                -> "MacroResultTypeMismatch"
   NamedWhereModuleInRefinedContext{}       -> "NamedWhereModuleInRefinedContext"
@@ -1313,6 +1314,10 @@ instance PrettyTCM TypeError where
       [text opt] ++
       pwords "to enable them):" ++
       [text s]
+
+    InvalidProjectionParameter arg -> fsep $
+      pwords "Invalid projection parameter " ++
+      [prettyA arg]
 
     CannotRewriteByNonEquation t ->
       "Cannot rewrite by equation of type" <+> prettyTCM t

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -188,6 +188,7 @@ errorString err = case err of
   MultipleFixityDecls{}                    -> "MultipleFixityDecls"
   MultiplePolarityPragmas{}                -> "MultiplePolarityPragmas"
   NoBindingForBuiltin{}                    -> "NoBindingForBuiltin"
+  NoBindingForPrimitive{}                  -> "NoBindingForPrimitive"
   NoParseForApplication{}                  -> "NoParseForApplication"
   NoParseForLHS{}                          -> "NoParseForLHS"
 --  NoParseForPatternSynonym{}               -> "NoParseForPatternSynonym"
@@ -712,6 +713,11 @@ instance PrettyTCM TypeError where
       | otherwise -> fsep $
         pwords "No binding for builtin thing" ++ [pretty x <> comma] ++
         pwords ("use {-# BUILTIN " ++ getBuiltinId x ++ " name #-} to bind it to 'name'")
+
+    NoBindingForPrimitive x -> fsep $
+      pwords "Missing binding for" ++
+      [pretty x] ++
+      pwords "primitive."
 
     DuplicatePrimitiveBinding b x y -> fsep $
       pwords "Duplicate binding for primitive thing" ++ [pretty b <> comma] ++

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4596,6 +4596,7 @@ data TypeError
         | NoSuchModule C.QName
         | AmbiguousName C.QName AmbiguousNameReason
         | AmbiguousModule C.QName (List1 A.ModuleName)
+        | AmbiguousField C.Name [A.ModuleName]
         | ClashingDefinition C.QName A.QName (Maybe NiceDeclaration)
         | ClashingModule A.ModuleName A.ModuleName
         | ClashingImport C.Name A.QName

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4560,6 +4560,7 @@ data TypeError
           -- does not mention any @lock variables.
         | MismatchedProjectionsError QName QName
         | AttributeKindNotEnabled String String String
+        | InvalidProjectionParameter (NamedArg A.Expr)
         | CannotRewriteByNonEquation Type
         | MacroResultTypeMismatch Type
         | NamedWhereModuleInRefinedContext [Term] [String]

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4530,6 +4530,7 @@ data TypeError
         | NoSuchBuiltinName String
         | DuplicateBuiltinBinding BuiltinId Term Term
         | NoBindingForBuiltin BuiltinId
+        | NoBindingForPrimitive PrimitiveId
         | NoSuchPrimitiveFunction String
         | DuplicatePrimitiveBinding PrimitiveId QName QName
         | WrongArgInfoForPrimitive PrimitiveId ArgInfo ArgInfo

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4561,6 +4561,7 @@ data TypeError
         | MismatchedProjectionsError QName QName
         | AttributeKindNotEnabled String String String
         | InvalidProjectionParameter (NamedArg A.Expr)
+        | TacticAttributeNotAllowed
         | CannotRewriteByNonEquation Type
         | MacroResultTypeMismatch Type
         | NamedWhereModuleInRefinedContext [Term] [String]

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -290,7 +290,7 @@ checkDomain lamOrPi xs e = do
     when (any (\x -> case getLock x of { IsLock{} -> True ; _ -> False }) xs) $ do
          -- Solves issue #5033
         unlessM (isJust <$> getName' builtinLockUniv) $ do
-          genericDocError $ "Missing binding for primLockUniv primitive."
+          typeError $ NoBindingForPrimitive builtinLockUniv
 
         equalSort (getSort t) LockUniv
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -672,8 +672,7 @@ insertHiddenLambdas h target postpone ret = do
             Lam (setOrigin Inserted $ domInfo dom) . Abs x <$> do
               addContext (x, dom) $ insertHiddenLambdas h (absBody b) postpone ret
 
-      _ -> typeError . GenericDocError =<< do
-        "Expected " <+> prettyTCM target <+> " to be a function type"
+      _ -> typeError $ ShouldBePi target
 
 -- | @checkAbsurdLambda i h e t@ checks absurd lambda against type @t@.
 --   Precondition: @e = AbsurdLam i h@

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -369,7 +369,7 @@ addTypedPatterns xps ret = do
 -- | Check a tactic attribute. Should have type Term → TC ⊤.
 checkTacticAttribute :: LamOrPi -> Ranged A.Expr -> TCM Term
 checkTacticAttribute LamNotPi (Ranged r e) = setCurrentRange r $
-  genericDocError =<< "The @tactic attribute is not allowed here"
+  typeError $ TacticAttributeNotAllowed
 checkTacticAttribute PiNotLam (Ranged r e) = do
   expectedType <- el primAgdaTerm --> el (primAgdaTCM <#> primLevelZero <@> primUnit)
   checkExpr e expectedType

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -908,10 +908,7 @@ expandModuleAssigns mfs xs = do
     case catMaybes pms of
       []        -> return Nothing
       [(_, fa)] -> return (Just fa)
-      mfas      -> typeError . GenericDocError =<< do
-        vcat $
-          "Ambiguity: the field" <+> prettyTCM f
-            <+> "appears in the following modules: " : map (prettyTCM . fst) mfas
+      mfas      -> typeError $ AmbiguousField f (map fst mfas)
   return (fs ++ catMaybes fs')
 
 -- | @checkRecordExpression fs e t@ checks record construction against type @t@.

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1448,8 +1448,7 @@ checkKnownArgument
   -> Args               -- ^ Inferred arguments (including hidden ones).
   -> Type               -- ^ Type of the head (must be Pi-type with enough domains).
   -> TCM (Args, Type)   -- ^ Remaining inferred arguments, remaining type.
-checkKnownArgument arg [] _ = genericDocError =<< do
-  "Invalid projection parameter " <+> prettyA arg
+checkKnownArgument arg [] _ = typeError $ InvalidProjectionParameter arg
 -- Andreas, 2019-07-22, while #3353: we should use domName, not absName !!
 -- WAS:
 -- checkKnownArgument arg@(Arg info e) (Arg _infov v : vs) t = do


### PR DESCRIPTION
Refactor `GenericDocError`-s for concrete ones in `TypeChecking/Rules/Term.hs`. More specifically:

- Introduce an error `InvalidProjectionParameter`
- Introduce an error `TacticAttributeNotAllowed`
- Introduce an error `AmbiguousField`
- Replace `GenericDocError` by already existing error `ShouldBePi`, therefore also error message slightly changed
- Introduce an error `NoBindingForPrimitive`