### PR TITLE
Makefile: add doc-test goal.  Fix doctest errors.

### DIFF
--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -30,12 +30,13 @@ jobs:
     - id: setup-haskell
       uses: haskell/actions/setup@v2
       with:
+        cabal-update: false
         cabal-version: ${{ matrix.cabal-ver }}
         ghc-version: ${{ matrix.ghc-ver }}
     - name: Environment settings based on the Haskell setup
       run: |
-        export GHC_VER=$(ghc --numeric-version)
-        export CABAL_VER=$(cabal --numeric-version)
+        GHC_VER=$(ghc --numeric-version)
+        CABAL_VER=$(cabal --numeric-version)
         echo "GHC_VER   = ${GHC_VER}"
         echo "CABAL_VER = ${CABAL_VER}"
         echo "GHC_VER=${GHC_VER}"       >> ${GITHUB_ENV}
@@ -45,15 +46,16 @@ jobs:
         cabal update
         cabal configure ${FLAGS}
         cabal build --dry-run
-    - id: cache
-      name: Cache dependencies
-      uses: actions/cache@v3
-      with:
+    - env:
         key: cabal-install.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER
-          }}-${{ hashFiles('**/plan.json') }}
+          }}-
+      id: cache
+      name: Restore cached dependencies
+      uses: actions/cache/restore@v3
+      with:
+        key: ${{ env.key }}-${{ hashFiles('**/plan.json') }}
         path: ~/.cabal/store
-        restore-keys: cabal-install.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{
-          env.CABAL_VER }}-
+        restore-keys: ${{ env.key }}
     - if: ${{ !steps.cache.outputs.cache-hit }}
       name: Install dependencies
       run: |
@@ -61,6 +63,12 @@ jobs:
     - name: Install Agda
       run: |
         cabal install ${FLAGS}
+    - if: always() && !steps.cache.outputs.cache-hit
+      name: Save cache
+      uses: actions/cache/save@v3
+      with:
+        key: ${{ steps.cache.outputs.cache-primary-key }}
+        path: ~/.cabal/store
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -94,6 +94,10 @@ jobs:
     - name: Build Agda
       run: |
         cabal build
+    - if: ${{ matrix.doctest }}
+      name: Run doctest
+      run: |
+        make doc-test
     strategy:
       fail-fast: false
       matrix:
@@ -103,6 +107,8 @@ jobs:
         - '3.10'
         description:
         - Linux
+        doctest:
+        - false
         ghc-ver:
         - 9.6.2
         - 9.4.6
@@ -113,7 +119,8 @@ jobs:
         - 8.6.5
         include:
         - cabal-flags: --disable-tests
-          description: Linux w/o tests
+          description: Linux doctest
+          doctest: true
           ghc-ver: 9.6.2
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f debug

--- a/Makefile
+++ b/Makefile
@@ -437,6 +437,7 @@ test : check-whitespace \
        std-lib-succeed \
        std-lib-interaction \
        user-manual-test \
+       doc-test \
        size-solver-test
 
 .PHONY : test-using-std-lib ## Run all tests which use the standard library.
@@ -619,6 +620,19 @@ user-manual-test :
 testing-emacs-mode:
 	@$(call decorate, "Testing the Emacs mode", \
 	  $(AGDA_MODE) compile)
+
+.PHONY : doc-test ## Install and run doctest for the Agda library.
+doc-test: install-doctest run-doctest
+
+.PHONY : install-doctest ## Install doctest for the current ghc.
+install-doctest:
+	@$(call decorate, "Installing doctest", \
+	  $(CABAL) install doctest --ignore-project)
+
+.PHONY : run-doctest ## Run the doctests for the Agda library.
+run-doctest:
+	@$(call decorate, "Running doctest", \
+	  $(CABAL) repl Agda -w doctest --repl-options=-w)
 
 ##############################################################################
 ## Size solver

--- a/src/full/Agda/Syntax/Parser/Literate.hs
+++ b/src/full/Agda/Syntax/Parser/Literate.hs
@@ -81,9 +81,9 @@ atomizeLayers = (fmap <$> ((,) . fst) <*> snd) <=< unMkLayers
 --
 --   > f : Processor
 --
---   prop> f pos s /= []
+--   proposition> f pos s /= []
 --
---   prop> f pos s >>= layerContent == s
+--   proposition> f pos s >>= layerContent == s
 
 type Processor = Position -> String -> [Layer]
 

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -289,7 +289,7 @@ spanEnd p = snd . foldr f (True, ([], []))
 --   found.
 --
 --   >>> breakAfter1 even 1 [3,5,2,4,7,8]
---   ([1,3,5,2],[4,7,8])
+--   (1 :| [3,5,2],[4,7,8])
 
 breakAfter1 :: (a -> Bool) -> a -> [a] -> (List1 a, [a])
 breakAfter1 p = loop

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -14,8 +14,6 @@
 --
 --   @
 
-
-
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
   -- because of https://gitlab.haskell.org/ghc/ghc/issues/10339
 
@@ -44,6 +42,10 @@ import GHC.Exts as IsList ( IsList(..) )
 import Agda.Utils.Functor ((<.>))
 import Agda.Utils.Null (Null(..))
 import qualified Agda.Utils.List as List
+
+-- Set up doctest.
+-- $setup
+-- >>> :seti -XOverloadedLists
 
 type List1 = NonEmpty
 type String1 = List1 Char
@@ -140,7 +142,7 @@ wordsBy p = loop
 --   found.
 --
 --   >>> breakAfter even [1,3,5,2,4,7,8]
---   ([1,3,5,2],[4,7,8])
+--   (1 :| [3,5,2],[4,7,8])
 
 breakAfter :: (a -> Bool) -> List1 a -> (List1 a, [a])
 breakAfter p (x :| xs) = List.breakAfter1 p x xs

--- a/src/github/workflows/cabal-install.yml
+++ b/src/github/workflows/cabal-install.yml
@@ -58,21 +58,28 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    ## Disable the setup action: Use preinstalled GHC and Cabal.
-    ##
-    ## In case the ubuntu-22.04 environment moves GHC beyond
-    ## what Agda supports, bring back the setup action.
+    # ## Disable the setup action: Use preinstalled GHC and Cabal.
+    # ##
+    # ## In case the ubuntu-22.04 environment moves GHC beyond
+    # ## what Agda supports, bring back the setup action.
+    #
+    # 2023-08-21: skipping setup does no work out of the box
+    # since then cabal uses the XDG directory structure.
+    # In particular, the ~/.cabal/store is somewhere else.
+    # We also need to reset the cache then so cabal does not get
+    # confused if there is both the restored .cabal/store and the XDG store.
     #
     - uses: haskell/actions/setup@v2
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc-ver }}
         cabal-version: ${{ matrix.cabal-ver }}
+        cabal-update: false
 
     - name: Environment settings based on the Haskell setup
       run: |
-        export GHC_VER=$(ghc --numeric-version)
-        export CABAL_VER=$(cabal --numeric-version)
+        GHC_VER=$(ghc --numeric-version)
+        CABAL_VER=$(cabal --numeric-version)
         echo "GHC_VER   = ${GHC_VER}"
         echo "CABAL_VER = ${CABAL_VER}"
         echo "GHC_VER=${GHC_VER}"       >> ${GITHUB_ENV}
@@ -87,15 +94,17 @@ jobs:
       # Keep a watch on this `cabal-3.9 build --dry-run` bug:
       # https://github.com/haskell/cabal/issues/8706
 
-    - name: Cache dependencies
-      uses: actions/cache@v3
+    - name: Restore cached dependencies
+      uses: actions/cache/restore@v3
       id: cache
+      env:
+        key: cabal-install.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-
       with:
-        path: ~/.cabal/store
+        path: &cache_path ~/.cabal/store
         # ${{ steps.setup-haskell.outputs.cabal-store }}
         # The file `plan.json` contains the build information.
-        key:          cabal-install.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-${{ hashFiles('**/plan.json') }}
-        restore-keys: cabal-install.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-
+        key:          ${{ env.key }}-${{ hashFiles('**/plan.json') }}
+        restore-keys: ${{ env.key }}
 
     - name: Install dependencies
       if: ${{ !steps.cache.outputs.cache-hit }}
@@ -105,3 +114,11 @@ jobs:
     - name: Install Agda
       run: |
         cabal install ${FLAGS}
+
+    - name: Save cache
+      uses: actions/cache/save@v3
+      if:   always() && !steps.cache.outputs.cache-hit
+            # save cache even when build fails
+      with:
+        key:  ${{ steps.cache.outputs.cache-primary-key }}
+        path: *cache_path

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -54,15 +54,17 @@ jobs:
         # Need to mention "cabal-ver" at least once in the matrix, otherwise matrix.cabal-ver is an actionlint error.
         cabal-ver: ['3.10']
         cabal-flags: ['--enable-tests -f enable-cluster-counting']
+        doctest: [false]
         include:
           ## Latest GHC, special builds
 
-          # Linux, w/o tests
+          # Linux, without tests but with doctest
           - os: ubuntu-22.04
-            description: Linux w/o tests
+            description: Linux doctest
             ghc-ver: '9.6.2'
             # Can't leave cabal-flags empty here lest it becomes the default value.
             cabal-flags: '--disable-tests'
+            doctest: true
 
           # Linux, without -f enable-cluster-counting but with -f debug
           - os: ubuntu-22.04
@@ -192,6 +194,11 @@ jobs:
     - name: Build Agda
       run: |
         cabal build
+
+    - name: Run doctest
+      if: ${{ matrix.doctest }}
+      run: |
+        make doc-test
 
     # - name: Clear old cache
     #   if:   ${{ steps.cache.outputs.cache-hit }}


### PR DESCRIPTION
This commit contributes running doctests via

    make doc-test

Currently we have few doctests, but this paves the way for adding more.

Unfortunately, running the doctests takes 2min on a contemporary laptop,
presumably because all 430 modules of the Agda library are loaded into the repl
even if only few of them contain doctests.
