### PR TITLE
stack-9.6.2.yaml: reenable size-solver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,10 @@ jobs:
       run: make install-deps
     - name: Build Agda
       run: make BUILD_DIR="${BUILD_DIR}" install-bin
+    - name: Run tests for the size solver
+      run: |
+        export PATH=${HOME}/.local/bin:${PATH}
+        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
     - name: Pack artifacts
       run: |
         strip ${BUILD_DIR}/build/agda-tests/agda-tests \

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -157,10 +157,10 @@ jobs:
     - name: "Build Agda"
       run: make BUILD_DIR="${BUILD_DIR}" install-bin
 
-    # - name: "Run tests for the size solver"
-    #   run: |
-    #     export PATH=${HOME}/.local/bin:${PATH}
-    #     make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
+    - name: "Run tests for the size solver"
+      run: |
+        export PATH=${HOME}/.local/bin:${PATH}
+        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
 
     - name: "Pack artifacts"
       # This step should go into the Makefile.

--- a/stack-9.6.2.yaml
+++ b/stack-9.6.2.yaml
@@ -1,10 +1,8 @@
-resolver: nightly-2023-08-21
+resolver: nightly-2023-08-23
 compiler: ghc-9.6.2
 compiler-check: match-exact
 
 # Local packages specified by relative directory name.
 packages:
 - '.'
-## 2023-07-17: Disable size-solver as dependency shelltestrunner isn't up to GHC 9.6 yet
-## https://github.com/simonmichael/shelltestrunner/pull/34
-# - 'src/size-solver'
+- 'src/size-solver'


### PR DESCRIPTION
Stackage nightly of 2023-08-23 has `shelltestrunner` back:
- commercialhaskell/stackage#7095