### PR TITLE
Allow entries `name = path` in the `executables` file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,6 +498,8 @@ Reflection
   The `blockOnMeta` builtin has been deprecated, and an implementation
   in terms of `blockTC` is given for backwards compatibility.
 
+* The `executables` file now allows entries of the form `name = path`
+  (whitespace around `=` needed) so that `execTC "name"` will invoke `path`.
 
 Other issues closed
 -------------------

--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ common :
 .PHONY : succeed ##
 succeed :
 	@$(call decorate, "Suite of successful tests", \
-		echo $(shell which $(AGDA_BIN)) > test/Succeed/exec-tc/executables && \
+		echo "agda = $(shell which $(AGDA_BIN))" > test/Succeed/exec-tc/executables && \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Succeed ; \
 		rm test/Succeed/exec-tc/executables )
 

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -870,3 +870,14 @@ For instance, to run the example above, you must add ``/bin/echo`` to this file:
 
 The executable can then be called by passing its basename to ``execTC``,
 subtracting the ``.exe`` on Windows.
+
+Since 2.6.4, lines of the form ``name = path`` are also allowed in the ``executables`` file.
+The equals sign must be surrounded by whitespace.
+The new form allows an executable to be available under a different name, for example:
+
+.. code-block:: text
+
+  # contents of ~/.agda/executables
+  agda = $HOME/.cabal/bin/agda-2.6.4
+
+Given this configuration, ``execTC "agda"`` will invoke ``agda-2.6.4`` located in ``$HOME/.cabal/bin``.

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -79,12 +79,14 @@ import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.Singleton
-import Agda.Utils.String ( trim )
+import Agda.Utils.String ( trim, ltrim )
 
 import Agda.Version
 
 -- Paths_Agda.hs is in $(BUILD_DIR)/build/autogen/.
 import Paths_Agda ( getDataFileName )
+
+import Agda.Utils.Impossible
 
 ------------------------------------------------------------------------
 -- * Types and Monads
@@ -392,8 +394,7 @@ getTrustedExecutables = mkLibM [] $ do
     if not (efExists file) then return Map.empty else do
       es    <- liftIO $ stripCommentLines <$> UTF8.readFile (efPath file)
       files <- liftIO $ sequence [ (i, ) <$> expandEnvironmentVariables s | (i, s) <- es ]
-      tmp   <- parseExecutablesFile file $ nubOn snd files
-      return tmp
+      parseExecutablesFile file $ nubOn snd files
   `catchIO` \ e -> do
     raiseErrors' [ ReadError e "Failed to read trusted executables." ]
     return Map.empty
@@ -402,16 +403,14 @@ getTrustedExecutables = mkLibM [] $ do
 --
 parseExecutablesFile
   :: ExecutablesFile
-  -> [(LineNumber, FilePath)]
+  -> [(LineNumber, String)]
   -> LibErrorIO (Map ExeName FilePath)
 parseExecutablesFile ef files = do
-  executables <- forM files $ \(ln, fp) -> do
+  executables <- forM files $ \(ln, line) -> do
     -- Compute canonical executable name and absolute filepath.
-    let strExeName  = takeFileName fp
-    let strExeName' = fromMaybe strExeName $ stripExtension exeExtension strExeName
-    let txtExeName  = T.pack strExeName'
+    let (exeName, fp) = parseExecutablesLine $ trim line
     exePath <- liftIO $ makeAbsolute fp
-    return (txtExeName, exePath)
+    return (T.pack exeName, exePath)
 
   -- Create a map from executable names to their location(s).
   let exeMap1 :: Map ExeName (List1 FilePath)
@@ -426,6 +425,35 @@ parseExecutablesFile ef files = do
 
   -- Return non-ambiguous mappings.
   return exeMap
+
+-- |
+-- Accept either @name = filepath@ (whitespace around @=@)
+-- or just a @filepath@ analysed as @path/name[.exe]@.
+-- In both cases, the mapping @(name, filepath)@ is returned.
+--
+-- Precondition: the argument is trimmed.
+--
+-- >>> parseExecutablesLine "name = filepath"
+-- ("name","filepath")
+--
+-- >>> parseExecutablesLine "name = file path"
+-- ("name","file path")
+--
+-- >>> parseExecutablesLine "name=file path"
+-- ("name=file path","name=file path")
+--
+-- >>> parseExecutablesLine "path/name"
+-- ("name","path/name")
+--
+parseExecutablesLine :: String -> (String, FilePath)
+parseExecutablesLine fp =
+  case words fp of
+    name : "=" : _ ->
+      case break (== '=') fp of
+        (_, '=':rest) -> (name, ltrim rest)
+        _ -> __IMPOSSIBLE__
+    _ -> (fromMaybe strExeName $ stripExtension exeExtension strExeName, fp)
+      where strExeName  = takeFileName fp
 
 ------------------------------------------------------------------------
 -- * Resolving library names to include pathes


### PR DESCRIPTION
This is mainly motivated by the testsuite where

    make AGDA_BIN=agda-quicker succeed

would error because `execTC` wants to invoke `agda` but the `executables` file will naturally allow invocation of `agda-quicker`.

A workaround would be to use symbolic links.
However, since Agda anyway constructs a `name ↦ path` map, it feels natural to allow the user to specify this map explicitly.

Rendering of the docs here: https://agda--6780.org.readthedocs.build/en/6780/language/reflection.html#system-calls