### PR TITLE
Testcase for duplicate executables, use line numbers in reporting the error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -492,6 +492,11 @@ fail :
 	@$(call decorate, "Suite of failing tests", \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Fail)
 
+.PHONY : fast-fail ##
+fast-fail :
+	@$(call decorate, "Suite of failing tests (using agda-fast)", \
+		AGDA_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Fail)
+
 .PHONY : interaction ##
 interaction :
 	@$(call decorate, "Suite of interaction tests", \

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -213,7 +213,7 @@ data LibError'
         -- ^ Name of the @executables@ file.
       Text
         -- ^ Name of the executable that is defined twice.
-      (List2 FilePath)
+      (List2 (LineNumber, FilePath))
         -- ^ The resolutions of the executable.
   -- deriving (Show)
 
@@ -406,7 +406,7 @@ instance Pretty LibError' where
 
     DuplicateExecutable exeFile exe paths -> vcat $
       hcat [ "Duplicate entries for executable '", (text . unpack) exe, "' in ", text exeFile, ":" ] :
-      map (nest 2 . ("-" <+>) . text) (toList paths)
+      map (\ (ln, fp) -> nest 2 $ (pretty ln <> colon) <+> text fp) (toList paths)
 
 -- | Print library file parse error without position info.
 --

--- a/src/full/Agda/Utils/Tuple.hs
+++ b/src/full/Agda/Utils/Tuple.hs
@@ -67,11 +67,11 @@ mapPairM :: (Applicative m) => (a -> m c) -> (b -> m d) -> (a,b) -> m (c,d)
 mapPairM f g ~(a,b) = (,) <$> f a <*> g b
 
 -- | Monadic 'mapFst'.
-mapFstM :: (Applicative m) => (a -> m c) -> (a,b) -> m (c,b)
+mapFstM :: Functor m => (a -> m c) -> (a,b) -> m (c,b)
 mapFstM f ~(a,b) = (,b) <$> f a
 
 -- | Monadic 'mapSnd'.
-mapSndM :: (Applicative m) => (b -> m d) -> (a,b) -> m (a,d)
+mapSndM :: Functor m => (b -> m d) -> (a,b) -> m (a,d)
 mapSndM f ~(a,b) = (a,) <$> f b
 
 data Pair a = Pair a a

--- a/test/Fail/DuplicateExecutable.agda
+++ b/test/Fail/DuplicateExecutable.agda
@@ -1,0 +1,25 @@
+-- Andreas, 2023-08-23
+-- Trigger error DuplicateExecutable
+--
+-- See also:
+-- * DuplicateExecutable.vars
+-- * DuplicateExecutable/executables
+
+{-# OPTIONS --allow-exec #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.List
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.String
+open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
+open import Agda.Builtin.Reflection.External
+
+macro
+  echo : List String → Term → TC ⊤
+  echo args hole = do
+    (exitCode , (stdOut , stdErr)) ← execTC "echo" args ""
+    unify hole (lit (string stdOut))
+
+_ : echo ("hello" ∷ "world" ∷ []) ≡ "hello world\n"
+_ = refl

--- a/test/Fail/DuplicateExecutable.err
+++ b/test/Fail/DuplicateExecutable.err
@@ -1,0 +1,3 @@
+Duplicate entries for executable 'echo' in DuplicateExecutable/executables:
+  2: /bin/echo
+  3: /bin/echo

--- a/test/Fail/DuplicateExecutable.vars
+++ b/test/Fail/DuplicateExecutable.vars
@@ -1,0 +1,1 @@
+AGDA_DIR=$PWD/test/Fail/DuplicateExecutable

--- a/test/Fail/DuplicateExecutable/executables
+++ b/test/Fail/DuplicateExecutable/executables
@@ -1,0 +1,3 @@
+-- Duplicate definitions of an executable (here: "echo") should raise an error.
+/bin/echo
+/bin/echo

--- a/test/Fail/Tests.hs
+++ b/test/Fail/Tests.hs
@@ -64,8 +64,10 @@ mkFailTest agdaFile =
     (Just updGolden)
   where
   testName   = asTestName testDir agdaFile
-  goldenFile = dropAgdaExtension agdaFile <.> "err"
-  flagFile   = dropAgdaExtension agdaFile <.> "flags"
+  baseName   = dropAgdaExtension agdaFile
+  varFile    = baseName <.> "vars"
+  flagFile   = baseName <.> "flags"
+  goldenFile = baseName <.> "err"
 
   readGolden = readTextFileMaybe goldenFile
   updGolden  = writeTextFile goldenFile
@@ -75,7 +77,7 @@ mkFailTest agdaFile =
                    , "--ignore-interfaces", "--no-libraries"
                    , "--double-check"
                    ]
-    runAgdaWithOptions testName agdaArgs (Just flagFile) Nothing
+    runAgdaWithOptions testName agdaArgs (Just flagFile) (Just varFile)
       <&> expectFail
 
 -- | A test for case-insensitivity of the file system.


### PR DESCRIPTION
- Makefile: new goal fail-fast to run failed tests with agda-fast
- Utils: generalize mapFstM and mapSndM from Applicative to Functor
- Testsuite: honor .vars file also in failed tests
- Test for DuplicateExecutables; print duplicates with line numbers
