### PR TITLE
More precise ranges for attributes; trigger error "tactic not allowed here"

### DIFF
--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -101,6 +101,7 @@ class Hilite a where
 instance Hilite a => Hilite [a]
 instance Hilite a => Hilite (List1 a)
 instance Hilite a => Hilite (Maybe a)
+instance Hilite a => Hilite (Ranged a)
 instance Hilite a => Hilite (WithHiding a)
 
 instance Hilite Void where

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -247,7 +247,7 @@ type TypeSignature  = Declaration
 type Constructor    = TypeSignature
 type Field          = TypeSignature
 
-type TacticAttr = Maybe Expr
+type TacticAttr = Maybe (Ranged Expr)
 
 -- A Binder @x\@p@, the pattern is optional
 data Binder' a = Binder

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -254,6 +254,7 @@ instance ExprLike Expr where
 instance ExprLike a => ExprLike (Arg a)
 instance ExprLike a => ExprLike (Maybe a)
 instance ExprLike a => ExprLike (Named x a)
+instance ExprLike a => ExprLike (Ranged a)
 instance ExprLike a => ExprLike [a]
 instance ExprLike a => ExprLike (List1 a)
 

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -272,7 +272,7 @@ data BoundName = BName
   }
   deriving Eq
 
-type TacticAttribute = Maybe Expr
+type TacticAttribute = Maybe (Ranged Expr)
 
 mkBoundName_ :: Name -> BoundName
 mkBoundName_ x = mkBoundName x noFixity'

--- a/src/full/Agda/Syntax/Concrete/Attribute.hs
+++ b/src/full/Agda/Syntax/Concrete/Attribute.hs
@@ -12,7 +12,7 @@ import qualified Data.Map as Map
 import Data.Maybe
 
 import Agda.Syntax.Common
-import Agda.Syntax.Concrete (Expr(..))
+import Agda.Syntax.Concrete (Expr(..), TacticAttribute)
 import Agda.Syntax.Concrete.Pretty () --instance only
 import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Position
@@ -26,7 +26,7 @@ import Agda.Utils.Impossible
 data Attribute
   = RelevanceAttribute Relevance
   | QuantityAttribute  Quantity
-  | TacticAttribute Expr
+  | TacticAttribute (Ranged Expr)
   | CohesionAttribute Cohesion
   | LockAttribute      Lock
   deriving (Show)
@@ -132,8 +132,9 @@ stringToAttribute = (`Map.lookup` attributesMap)
 -- | Parsing an expression into an attribute.
 
 exprToAttribute :: Expr -> Maybe Attribute
-exprToAttribute (Paren _ (Tactic _ t)) = Just $ TacticAttribute t
-exprToAttribute e = setRange (getRange e) $ stringToAttribute $ prettyShow e
+exprToAttribute = \case
+  e@(Paren _ (Tactic _ t)) -> Just $ TacticAttribute $ Ranged (getRange e) t
+  e -> setRange (getRange e) $ stringToAttribute $ prettyShow e
 
 -- | Setting an attribute (in e.g. an 'Arg').  Overwrites previous value.
 
@@ -214,7 +215,7 @@ isQuantityAttribute = \case
   QuantityAttribute q -> Just q
   _ -> Nothing
 
-isTacticAttribute :: Attribute -> Maybe Expr
+isTacticAttribute :: Attribute -> TacticAttribute
 isTacticAttribute (TacticAttribute t) = Just t
 isTacticAttribute _                   = Nothing
 

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -76,6 +76,7 @@ instance ExprLike a => ExprLike (Maybe a)
 
 instance ExprLike a => ExprLike (Arg a)
 instance ExprLike a => ExprLike (Named name a)
+instance ExprLike a => ExprLike (Ranged a)
 instance ExprLike a => ExprLike (WithHiding a)
 
 instance ExprLike a => ExprLike (MaybePlaceholder a)

--- a/src/full/Agda/Syntax/Info.hs
+++ b/src/full/Agda/Syntax/Info.hs
@@ -154,7 +154,7 @@ data DefInfo' t = DefInfo
   , defInstance :: IsInstance
   , defMacro    :: IsMacro
   , defInfo     :: DeclInfo
-  , defTactic   :: Maybe t
+  , defTactic   :: Maybe (Ranged t)
   }
   deriving (Show, Eq, Generic)
 

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -699,9 +699,13 @@ instance ToConcrete a => ToConcrete (WithHiding a) where
 
 instance ToConcrete a => ToConcrete (Named name a)  where
     type ConOfAbs (Named name a) = Named name (ConOfAbs a)
-
-    toConcrete (Named n x) = Named n <$> toConcrete x
+    toConcrete = traverse toConcrete
     bindToConcrete (Named n x) ret = bindToConcrete x $ ret . Named n
+
+instance ToConcrete a => ToConcrete (Ranged a)  where
+    type ConOfAbs (Ranged a) = Ranged (ConOfAbs a)
+    toConcrete = traverse toConcrete
+    bindToConcrete (Ranged r x) ret = bindToConcrete x $ ret . Ranged r
 
 -- Names ------------------------------------------------------------------
 

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -3035,7 +3035,11 @@ instance ToAbstract c => ToAbstract (Arg c) where
 
 instance ToAbstract c => ToAbstract (Named name c) where
     type AbsOfCon (Named name c) = Named name (AbsOfCon c)
-    toAbstract (Named n e) = Named n <$> toAbstract e
+    toAbstract = traverse toAbstract
+
+instance ToAbstract c => ToAbstract (Ranged c) where
+    type AbsOfCon (Ranged c) = Ranged (AbsOfCon c)
+    toAbstract = traverse toAbstract
 
 {- DOES NOT WORK ANYMORE with pattern synonyms
 instance ToAbstract c a => ToAbstract (A.LHSCore' c) (A.LHSCore' a) where

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -568,7 +568,7 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
             {- else -} (reify a)
       where
         mkPi b (Arg info a') = do
-          tac <- traverse reify $ domTactic a
+          tac <- traverse (Ranged noRange <.> reify) $ domTactic a
           (x, b) <- reify b
           let xs = singleton $ Arg info $ Named (domName a) $ mkBinder_ x
           return $ A.Pi noExprInfo
@@ -1493,7 +1493,7 @@ instance Reify I.Telescope where
     (x, bs)  <- reify tel
     let r    = getRange e
         name = domName arg
-    tac <- traverse reify $ domTactic arg
+    tac <- traverse (Ranged noRange <.> reify) $ domTactic arg
     let xs = singleton $ Arg info $ Named name $ A.mkBinder_ x
     return $ TBind r (TypedBindingInfo tac (domIsFinite arg)) xs e : bs
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -367,9 +367,10 @@ addTypedPatterns xps ret = do
       where r = fuseRange p n
 
 -- | Check a tactic attribute. Should have type Term → TC ⊤.
-checkTacticAttribute :: LamOrPi -> A.Expr -> TCM Term
-checkTacticAttribute LamNotPi e = genericDocError =<< "The @tactic attribute is not allowed here"
-checkTacticAttribute PiNotLam e = do
+checkTacticAttribute :: LamOrPi -> Ranged A.Expr -> TCM Term
+checkTacticAttribute LamNotPi (Ranged r e) = setCurrentRange r $
+  genericDocError =<< "The @tactic attribute is not allowed here"
+checkTacticAttribute PiNotLam (Ranged r e) = do
   expectedType <- el primAgdaTerm --> el (primAgdaTCM <#> primLevelZero <@> primUnit)
   checkExpr e expectedType
 

--- a/test/Fail/Issue4927-1.err
+++ b/test/Fail/Issue4927-1.err
@@ -1,3 +1,3 @@
-Issue4927-1.agda:2,4-8
+Issue4927-1.agda:2,3-8
 Cohesion attributes have not been enabled (use --cohesion to enable
 them): flat

--- a/test/Fail/Issue4927-2.err
+++ b/test/Fail/Issue4927-2.err
@@ -1,3 +1,3 @@
-Issue4927-2.agda:2,9-13
+Issue4927-2.agda:2,8-13
 Cohesion attributes have not been enabled (use --cohesion to enable
 them): flat

--- a/test/Fail/Issue4927-3.err
+++ b/test/Fail/Issue4927-3.err
@@ -1,3 +1,3 @@
-Issue4927-3.agda:1,6-7
+Issue4927-3.agda:1,5-7
 Cohesion attributes have not been enabled (use --cohesion to enable
 them): ♭

--- a/test/Fail/Issue4927-4.err
+++ b/test/Fail/Issue4927-4.err
@@ -1,3 +1,3 @@
-Issue4927-4.agda:3,6-10
+Issue4927-4.agda:3,5-10
 Cohesion attributes have not been enabled (use --cohesion to enable
 them): flat

--- a/test/Fail/Issue4927-6.err
+++ b/test/Fail/Issue4927-6.err
@@ -1,3 +1,3 @@
-Issue4927-6.agda:2,4-5
+Issue4927-6.agda:2,3-5
 Cohesion attributes have not been enabled (use --cohesion to enable
 them): ♭

--- a/test/Fail/Issue4927-7.err
+++ b/test/Fail/Issue4927-7.err
@@ -1,3 +1,3 @@
-Issue4927-7.agda:4,13-14
+Issue4927-7.agda:4,12-14
 Cohesion attributes have not been enabled (use --cohesion to enable
 them): ♭

--- a/test/Fail/Issue5034-1.err
+++ b/test/Fail/Issue5034-1.err
@@ -1,3 +1,3 @@
-Issue5034-1.agda:2,4-8
+Issue5034-1.agda:2,3-8
 Lock attributes have not been enabled (use --guarded to enable
 them): lock

--- a/test/Fail/Issue5034-2.err
+++ b/test/Fail/Issue5034-2.err
@@ -1,3 +1,3 @@
-Issue5034-2.agda:2,4-8
+Issue5034-2.agda:2,3-8
 Lock attributes have not been enabled (use --guarded to enable
 them): tick

--- a/test/Fail/Issue5034-3.err
+++ b/test/Fail/Issue5034-3.err
@@ -1,3 +1,3 @@
-Issue5034-3.agda:2,8-12
+Issue5034-3.agda:2,7-12
 Lock attributes have not been enabled (use --guarded to enable
 them): lock

--- a/test/Fail/Issue5034-4.err
+++ b/test/Fail/Issue5034-4.err
@@ -1,3 +1,3 @@
-Issue5034-4.agda:2,8-12
+Issue5034-4.agda:2,7-12
 Lock attributes have not been enabled (use --guarded to enable
 them): tick

--- a/test/Fail/Issue6349-1.err
+++ b/test/Fail/Issue6349-1.err
@@ -1,3 +1,3 @@
-Issue6349-1.agda:1,2-3
+Issue6349-1.agda:1,1-3
 Erasure attributes have not been enabled (use --erasure to enable
 them): 0

--- a/test/Fail/TacticNotAllowed.agda
+++ b/test/Fail/TacticNotAllowed.agda
@@ -1,0 +1,21 @@
+-- Andreas, 2023-08-23, re PR #6777
+-- Trigger error "The @tactic attribute is not allowed here".
+-- Should highlight exactly the attribute.
+
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Unit
+
+nothing : Term → TC ⊤
+nothing hole = returnTC _
+
+module M (A : Set) {@(tactic nothing) f : A → A} where
+  -- The following code is only to make the module bigger.
+  -- Originally, the whole module was highlighted.
+  postulate
+    a : A
+  b = f a
+
+-- Expected error:
+-- The @tactic attribute is not allowed here
+--
+-- Exactly the tactic attribute should be highlighted.

--- a/test/Fail/TacticNotAllowed.err
+++ b/test/Fail/TacticNotAllowed.err
@@ -1,0 +1,2 @@
+TacticNotAllowed.agda:11,22-38
+The @tactic attribute is not allowed here


### PR DESCRIPTION
This adds a `Range` to `TacticAttribute` and a test for the "tactic not allowed here" error.

Previously:

- Just the range of the tactic expression was used for the tactic attribute, which did not include the `@` nor the `tactic` keyword.

- There was no test case for the error "tactic not allowed here", which is triggered if you put a tactic in a module parameter.

This work has been triggered by PR #6777.
