### PR TITLE
Re #6786: say "when checking module M" for "interesting" modules

### DIFF
--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -302,6 +302,10 @@ instance Hashable QName where
 instance IsNoName Name where
   isNoName = isNoName . nameConcrete
 
+-- | A module name is empty if all of its components are empty names.
+instance IsNoName ModuleName where
+  isNoName = isAnonymousModuleName
+
 instance NumHoles Name where
   numHoles = numHoles . nameConcrete
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3288,6 +3288,7 @@ data Call
   | CheckConfluence QName QName
   | CheckWithFunctionType Type
   | CheckSectionApplication Range Erased ModuleName A.ModuleApplication
+  | CheckModule ModuleName
   | CheckNamedWhere ModuleName
   -- | Checking a clause for confluence with endpoint reductions. Always
   -- @φ ⊢ f vs = rhs@ for now, but we store the simplifications of
@@ -3332,6 +3333,7 @@ instance Pretty Call where
     pretty CheckPragma{}             = "CheckPragma"
     pretty CheckPrimitive{}          = "CheckPrimitive"
     pretty CheckWithFunctionType{}   = "CheckWithFunctionType"
+    pretty CheckModule{}             = "CheckModule"
     pretty CheckNamedWhere{}         = "CheckNamedWhere"
     pretty ScopeCheckExpr{}          = "ScopeCheckExpr"
     pretty ScopeCheckDeclaration{}   = "ScopeCheckDeclaration"
@@ -3370,6 +3372,7 @@ instance HasRange Call where
     getRange (CheckPragma r _)                   = r
     getRange (CheckPrimitive i _ _)              = getRange i
     getRange CheckWithFunctionType{}             = noRange
+    getRange (CheckModule m)                     = getRange m
     getRange (CheckNamedWhere m)                 = getRange m
     getRange (ScopeCheckExpr e)                  = getRange e
     getRange (ScopeCheckDeclaration d)           = getRange d

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -71,6 +71,7 @@ interestingCall = \case
     CheckConfluence{}         -> True
     CheckWithFunctionType{}   -> True
     CheckSectionApplication{} -> True
+    CheckModule{}             -> True
     CheckNamedWhere{}         -> True
     ScopeCheckExpr{}          -> True
     ScopeCheckDeclaration{}   -> True
@@ -195,6 +196,7 @@ instance MonadTrace TCM where
       CheckIApplyConfluence{}   -> False
       CheckWithFunctionType{}   -> True
       CheckSectionApplication{} -> True
+      CheckModule{}             -> False
       CheckNamedWhere{}         -> False
       ScopeCheckExpr{}          -> False
       ScopeCheckDeclaration{}   -> False

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -174,6 +174,9 @@ instance PrettyTCM Call where
       pwords "when checking that the given dot pattern" ++ [prettyA e] ++
       pwords "matches the inferred value" ++ [prettyTCM v]
 
+    CheckModule m -> fsep $
+      pwords "when checking module" ++ [prettyA m]
+
     CheckNamedWhere m -> fsep $
       pwords "when checking the named where block" ++ [prettyA m]
 

--- a/test/Fail/Erased-modules-9.err
+++ b/test/Fail/Erased-modules-9.err
@@ -1,3 +1,4 @@
 Erased-modules-9.agda:11,3-39
 Not supported: open public in hard compile-time mode (for instance
 in erased modules)
+when checking module Bool

--- a/test/Fail/Issue1014.err
+++ b/test/Fail/Issue1014.err
@@ -6,6 +6,7 @@ Problematic calls:
     (at Issue1014.agda:23,28-29)
   bar A (proj₁ (h n An)) h (proj₂ (proj₂ (h n An)))
     (at Issue1014.agda:23,31-34)
+when checking module NoWith
 Issue1014.agda:30,3-34,82
 Termination checking failed for the following functions:
   CorrectlyRejected.bar'
@@ -15,6 +16,7 @@ Problematic calls:
     (at Issue1014.agda:34,61-62)
   bar' A h n' An'
     (at Issue1014.agda:34,64-68)
+when checking module CorrectlyRejected
 Issue1014.agda:41,3-43,63
 Termination checking failed for the following functions:
   CorrectlyRejected.bar
@@ -24,6 +26,7 @@ Problematic calls:
     (at Issue1014.agda:43,47-48)
   bar n' An'
     (at Issue1014.agda:43,50-53)
+when checking module CorrectlyRejected
 Issue1014.agda:48,3-52,81
 Termination checking failed for the following functions:
   WasAccepted1.bar
@@ -33,6 +36,7 @@ Problematic calls:
     (at Issue1014.agda:52,61-62)
   bar A n' h An'
     (at Issue1014.agda:52,64-67)
+when checking module WasAccepted1
 Issue1014.agda:63,1-65,63
 Termination checking failed for the following functions:
   bar

--- a/test/Fail/Issue1035.err
+++ b/test/Fail/Issue1035.err
@@ -6,3 +6,4 @@ Problematic calls:
   Issue1035.M.with-48 (prop h)
   to-∈-intersection′ ! !
     (at Issue1035.agda:25,50-68)
+when checking module M

--- a/test/Fail/Issue1140.err
+++ b/test/Fail/Issue1140.err
@@ -3,8 +3,10 @@ Termination checking failed for the following functions:
   M.f
 Problematic calls:
   f (at Issue1140.agda:7,7-8)
+when checking module M
 Issue1140.agda:10,3-11,8
 Termination checking failed for the following functions:
   N.f
 Problematic calls:
   f (at Issue1140.agda:11,7-8)
+when checking module N

--- a/test/Fail/Issue3541EqualityNotPositive.err
+++ b/test/Fail/Issue3541EqualityNotPositive.err
@@ -3,18 +3,22 @@ D is not strictly positive, because it occurs
 in the first argument of _≡_
 in the type of the constructor c
 in the definition of D.
+when checking module EqualityAsPredicate
 Issue3541EqualityNotPositive.agda:19,3-20,18
 E is not strictly positive, because it occurs
 in the second argument of _≡_
 in the type of the constructor c
 in the definition of E.
+when checking module EqualityAsPredicate
 Issue3541EqualityNotPositive.agda:27,3-28,18
 D is not strictly positive, because it occurs
 in the first argument of _≡_
 in the type of the constructor c
 in the definition of D.
+when checking module EqualityAsRelation
 Issue3541EqualityNotPositive.agda:30,3-31,18
 E is not strictly positive, because it occurs
 in the second argument of _≡_
 in the type of the constructor c
 in the definition of E.
+when checking module EqualityAsRelation

--- a/test/Fail/Issue59-RemovedInlining.err
+++ b/test/Fail/Issue59-RemovedInlining.err
@@ -7,3 +7,4 @@ Problematic calls:
     (at Issue59-RemovedInlining.agda:15,46-51)
   merge (x₁ ∷ xs) (y ∷ ys)
     (at Issue59-RemovedInlining.agda:17,46-51)
+when checking module Order

--- a/test/Fail/MixingCoPatternsAndCoConstructors.err
+++ b/test/Fail/MixingCoPatternsAndCoConstructors.err
@@ -4,9 +4,11 @@ Termination checking failed for the following functions:
 Problematic calls:
   weird'' zero
     (at MixingCoPatternsAndCoConstructors.agda:31,28-35)
+when checking module MStream
 MixingCoPatternsAndCoConstructors.agda:37,3-39,40
 Termination checking failed for the following functions:
   MStream.repeat
 Problematic calls:
   tail (repeat a)
     (at MixingCoPatternsAndCoConstructors.agda:39,31-37)
+when checking module MStream

--- a/test/Fail/SizedBTree.err
+++ b/test/Fail/SizedBTree.err
@@ -8,6 +8,7 @@ Problematic calls:
     (at SizedBTree.agda:39,38-43)
   deep2 {↑ i} {A} (node {_} {i} l2 r2)
     (at SizedBTree.agda:41,22-27)
+when checking module Old
 SizedBTree.agda:64,3-69,40
 Termination checking failed for the following functions:
   New.deep2
@@ -18,3 +19,4 @@ Problematic calls:
     (at SizedBTree.agda:67,34-39)
   deep2 {↑ i'} {A} (node {_} {_} {i'} l2 r2)
     (at SizedBTree.agda:69,22-27)
+when checking module New

--- a/test/Fail/TacticNotAllowed.err
+++ b/test/Fail/TacticNotAllowed.err
@@ -1,2 +1,3 @@
 TacticNotAllowed.agda:11,22-38
 The @tactic attribute is not allowed here
+when checking module M

--- a/test/Fail/TerminationWithInsufficientDepth.err
+++ b/test/Fail/TerminationWithInsufficientDepth.err
@@ -6,6 +6,7 @@ Problematic calls:
     (at TerminationWithInsufficientDepth.agda:25,21-22)
   f (suc n)
     (at TerminationWithInsufficientDepth.agda:27,11-12)
+when checking module Depth2
 TerminationWithInsufficientDepth.agda:39,3-47,24
 Termination checking failed for the following functions:
   Depth3.f, Depth3.g
@@ -14,3 +15,4 @@ Problematic calls:
     (at TerminationWithInsufficientDepth.agda:45,27-28)
   f (suc (suc n))
     (at TerminationWithInsufficientDepth.agda:47,9-10)
+when checking module Depth3


### PR DESCRIPTION
This adds a trace `CheckModule` that is added in the type checker when
entering a non-anonymous module other than the top-level module.

As a consequence, if there is no other interesting context around the
error, Agda will say "<ERROR> when checking module <Module>".
