### PR TITLE
Drop suffix `Warning` from `DuplicateFields/TooManyFieldsWarning`

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -627,6 +627,7 @@ library
       Agda.TypeChecking.MetaVars.Occurs
       Agda.TypeChecking.Modalities
       Agda.TypeChecking.Monad.Base
+      Agda.TypeChecking.Monad.Base.Warning
       Agda.TypeChecking.Monad.Benchmark
       Agda.TypeChecking.Monad.Builtin
       Agda.TypeChecking.Monad.Caching

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,8 @@ Pragmas and options
   checking. This flag may be necessary for Agda to accept nontrivial
   uses of induction-induction.
 
+* The suffix `Warning` has been dropped from the warning names `DuplicateFieldsWarning` and `TooManyFieldsWarning`.
+
 Library management
 ------------------
 

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -49,6 +49,7 @@ import Agda.TypeChecking.MetaVars (isBlockedTerm, hasTwinMeta)
 import Agda.TypeChecking.Monad
   hiding (ModuleInfo, MetaInfo, Primitive, Constructor, Record, Function, Datatype)
 import qualified Agda.TypeChecking.Monad  as TCM
+import qualified Agda.TypeChecking.Monad.Base.Warning as W
 import qualified Agda.TypeChecking.Pretty as TCM
 import Agda.TypeChecking.Positivity.Occurrence
 import Agda.TypeChecking.Warnings ( raiseWarningsOnUsage, runPM )
@@ -537,8 +538,8 @@ warningHighlighting' b w = case tcWarning w of
 recordFieldWarningHighlighting ::
   RecordFieldWarning -> HighlightingInfoBuilder
 recordFieldWarningHighlighting = \case
-  DuplicateFieldsWarning xrs      -> dead xrs
-  TooManyFieldsWarning _q _ys xrs -> dead xrs
+  W.DuplicateFields xrs      -> dead xrs
+  W.TooManyFields _q _ys xrs -> dead xrs
   where
   dead :: [(C.Name, Range)] -> HighlightingInfoBuilder
   dead = mconcat . map deadcodeHighlighting

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -288,8 +288,8 @@ data WarningName
   | CoInfectiveImport_
   | InfectiveImport_
   -- Record field warnings
-  | DuplicateFieldsWarning_
-  | TooManyFieldsWarning_
+  | DuplicateFields_
+  | TooManyFields_
   -- Opaque/unfolding
   | NotAffectedByOpaque_
   | UnfoldTransparentName_
@@ -462,8 +462,8 @@ warningNameDescription = \case
   CoInfectiveImport_               -> "Importing a file not using e.g. `--safe'  from one which does."
   InfectiveImport_                 -> "Importing a file using e.g. `--cubical' into one which doesn't."
   -- Record field warnings
-  DuplicateFieldsWarning_          -> "Record expression with duplicate field names."
-  TooManyFieldsWarning_            -> "Record expression with invalid field names."
+  DuplicateFields_                 -> "Record expression with duplicate field names."
+  TooManyFields_                   -> "Record expression with invalid field names."
   -- Opaque/unfolding warnings
   NotAffectedByOpaque_             -> "Enclosing `opaque` block has no effect on this declaration."
   UnfoldTransparentName_           -> "Name mentioned in an `unfolding` clause is not `opaque`."

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5,6 +5,7 @@
 module Agda.TypeChecking.Monad.Base
   ( module Agda.TypeChecking.Monad.Base
   , HasOptions (..)
+  , RecordFieldWarning
   ) where
 
 import Prelude hiding (null)
@@ -78,6 +79,9 @@ import Agda.Syntax.Notation
 import Agda.Syntax.Position
 import Agda.Syntax.Scope.Base
 import qualified Agda.Syntax.Info as Info
+
+import qualified Agda.TypeChecking.Monad.Base.Warning as W
+import           Agda.TypeChecking.Monad.Base.Warning (RecordFieldWarning)
 
 import Agda.TypeChecking.CompiledClause
 import Agda.TypeChecking.Coverage.SplitTree
@@ -4218,18 +4222,10 @@ data Warning
   | UselessOpaque
   deriving (Show, Generic)
 
-data RecordFieldWarning
-  = DuplicateFieldsWarning [(C.Name, Range)]
-      -- ^ Each redundant field comes with a range of associated dead code.
-  | TooManyFieldsWarning QName [C.Name] [(C.Name, Range)]
-      -- ^ Record type, fields not supplied by user, non-fields but supplied.
-      --   The redundant fields come with a range of associated dead code.
-  deriving (Show, Generic)
-
 recordFieldWarningToError :: RecordFieldWarning -> TypeError
 recordFieldWarningToError = \case
-  DuplicateFieldsWarning    xrs -> DuplicateFields    $ map fst xrs
-  TooManyFieldsWarning q ys xrs -> TooManyFields q ys $ map fst xrs
+  W.DuplicateFields    xrs -> DuplicateFields    $ map fst xrs
+  W.TooManyFields q ys xrs -> TooManyFields q ys $ map fst xrs
 
 warningName :: Warning -> WarningName
 warningName = \case
@@ -4300,8 +4296,8 @@ warningName = \case
                                -> PlentyInHardCompileTimeMode_
   -- record field warnings
   RecordFieldWarning w -> case w of
-    DuplicateFieldsWarning{}   -> DuplicateFieldsWarning_
-    TooManyFieldsWarning{}     -> TooManyFieldsWarning_
+    W.DuplicateFields{}   -> DuplicateFields_
+    W.TooManyFields{}     -> TooManyFields_
 
   NotAffectedByOpaque{}   -> NotAffectedByOpaque_
   UselessOpaque{}         -> UselessOpaque_

--- a/src/full/Agda/TypeChecking/Monad/Base/Warning.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base/Warning.hs
@@ -1,0 +1,17 @@
+-- | Types related to warnings raised by Agda.
+
+module Agda.TypeChecking.Monad.Base.Warning where
+
+import           GHC.Generics               (Generic)
+
+import           Agda.Syntax.Abstract.Name
+import           Agda.Syntax.Position       (Range)
+import qualified Agda.Syntax.Concrete.Name  as C
+
+data RecordFieldWarning
+  = DuplicateFields [(C.Name, Range)]
+      -- ^ Each redundant field comes with a range of associated dead code.
+  | TooManyFields QName [C.Name] [(C.Name, Range)]
+      -- ^ Record type, fields not supplied by user, non-fields but supplied.
+      --   The redundant fields come with a range of associated dead code.
+  deriving (Show, Generic)

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -19,6 +19,7 @@ import qualified Data.List as List
 import qualified Data.Text as T
 
 import Agda.TypeChecking.Monad.Base
+import qualified Agda.TypeChecking.Monad.Base.Warning as W
 import Agda.TypeChecking.Monad.Builtin
 import {-# SOURCE #-} Agda.TypeChecking.Errors
 import Agda.TypeChecking.Monad.MetaVars
@@ -377,8 +378,8 @@ prettyWarning = \case
 
 prettyRecordFieldWarning :: MonadPretty m => RecordFieldWarning -> m Doc
 prettyRecordFieldWarning = \case
-  DuplicateFieldsWarning xrs    -> prettyDuplicateFields $ map fst xrs
-  TooManyFieldsWarning q ys xrs -> prettyTooManyFields q ys $ map fst xrs
+  W.DuplicateFields xrs    -> prettyDuplicateFields $ map fst xrs
+  W.TooManyFields q ys xrs -> prettyTooManyFields q ys $ map fst xrs
 
 prettyDuplicateFields :: MonadPretty m => [C.Name] -> m Doc
 prettyDuplicateFields xs = fsep $ concat

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -28,6 +28,7 @@ import Agda.Syntax.Scope.Base (isNameInScope)
 
 import Agda.TypeChecking.Irrelevance
 import Agda.TypeChecking.Monad
+import qualified Agda.TypeChecking.Monad.Base.Warning as W
 import Agda.TypeChecking.Pretty as TCM
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Reduce.Monad () --instance only
@@ -68,8 +69,8 @@ orderFields r fill axs fs = do
   --   , "  official fields: " <+> sep (map pretty xs)
   --   , "  provided fields: " <+> sep (map pretty ys)
   --   ]
-  unlessNull alien     $ warn $ TooManyFieldsWarning r missing
-  unlessNull duplicate $ warn $ DuplicateFieldsWarning
+  unlessNull alien     $ warn $ W.TooManyFields r missing
+  unlessNull duplicate $ warn $ W.DuplicateFields
   return $ for axs $ \ ax -> fromMaybe (fill ax) $ lookup (unArg ax) uniq
   where
     (uniq, duplicate) = nubAndDuplicatesOn fst fs   -- separating duplicate fields

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -11,6 +11,7 @@ import Agda.TypeChecking.Serialise.Instances.Abstract () --instance only
 import Agda.Syntax.Concrete.Definitions (DeclarationWarning(..), DeclarationWarning'(..))
 import Agda.Syntax.Parser.Monad
 import Agda.TypeChecking.Monad.Base
+import qualified Agda.TypeChecking.Monad.Base.Warning as W
 import Agda.Interaction.Options
 import Agda.Interaction.Options.Warnings
 import Agda.Interaction.Library.Base
@@ -166,12 +167,12 @@ instance EmbPrj ParseWarning where
 
 instance EmbPrj RecordFieldWarning where
   icod_ = \case
-    DuplicateFieldsWarning a   -> icodeN 0 DuplicateFieldsWarning a
-    TooManyFieldsWarning a b c -> icodeN 1 TooManyFieldsWarning a b c
+    W.DuplicateFields a   -> icodeN 0 W.DuplicateFields a
+    W.TooManyFields a b c -> icodeN 1 W.TooManyFields a b c
 
   value = vcase $ \case
-    [0, a]       -> valuN DuplicateFieldsWarning a
-    [1, a, b, c] -> valuN TooManyFieldsWarning a b c
+    [0, a]       -> valuN W.DuplicateFields a
+    [1, a, b, c] -> valuN W.TooManyFields a b c
     _ -> malformed
 
 instance EmbPrj DeclarationWarning where
@@ -423,8 +424,8 @@ instance EmbPrj WarningName where
     WrongInstanceDeclaration_                    -> 90
     CoInfectiveImport_                           -> 91
     InfectiveImport_                             -> 92
-    DuplicateFieldsWarning_                      -> 93
-    TooManyFieldsWarning_                        -> 94
+    DuplicateFields_                             -> 93
+    TooManyFields_                               -> 94
     OptionRenamed_                               -> 95
     PlentyInHardCompileTimeMode_                 -> 96
     InteractionMetaBoundaries_                   -> 97
@@ -527,8 +528,8 @@ instance EmbPrj WarningName where
     90  -> return WrongInstanceDeclaration_
     91  -> return CoInfectiveImport_
     92  -> return InfectiveImport_
-    93  -> return DuplicateFieldsWarning_
-    94  -> return TooManyFieldsWarning_
+    93  -> return DuplicateFields_
+    94  -> return TooManyFields_
     95  -> return OptionRenamed_
     96  -> return PlentyInHardCompileTimeMode_
     97  -> return InteractionMetaBoundaries_

--- a/test/Succeed/DuplicateFields.warn
+++ b/test/Succeed/DuplicateFields.warn
@@ -1,5 +1,5 @@
 DuplicateFields.agda:12,9-31
-warning: -W[no]DuplicateFieldsWarning
+warning: -W[no]DuplicateFields
 Duplicate field x in record
 when checking that the expression record { x = x ; x = y } has type
 D
@@ -7,7 +7,7 @@ D
 ———— All done; warnings encountered ————————————————————————
 
 DuplicateFields.agda:12,9-31
-warning: -W[no]DuplicateFieldsWarning
+warning: -W[no]DuplicateFields
 Duplicate field x in record
 when checking that the expression record { x = x ; x = y } has type
 D

--- a/test/Succeed/Issue3684-alien-duplicate-fields.warn
+++ b/test/Succeed/Issue3684-alien-duplicate-fields.warn
@@ -1,10 +1,10 @@
 Issue3684-alien-duplicate-fields.agda:6,5-32
-warning: -W[no]TooManyFieldsWarning
+warning: -W[no]TooManyFields
 The record type R does not have the fields f, f
 when checking that the expression record { f = Set ; f = Set } has
 type R
 Issue3684-alien-duplicate-fields.agda:6,5-32
-warning: -W[no]DuplicateFieldsWarning
+warning: -W[no]DuplicateFields
 Duplicate field f in record
 when checking that the expression record { f = Set ; f = Set } has
 type R
@@ -12,13 +12,13 @@ type R
 ———— All done; warnings encountered ————————————————————————
 
 Issue3684-alien-duplicate-fields.agda:6,5-32
-warning: -W[no]TooManyFieldsWarning
+warning: -W[no]TooManyFields
 The record type R does not have the fields f, f
 when checking that the expression record { f = Set ; f = Set } has
 type R
 
 Issue3684-alien-duplicate-fields.agda:6,5-32
-warning: -W[no]DuplicateFieldsWarning
+warning: -W[no]DuplicateFields
 Duplicate field f in record
 when checking that the expression record { f = Set ; f = Set } has
 type R

--- a/test/Succeed/Issue3684.warn
+++ b/test/Succeed/Issue3684.warn
@@ -1,5 +1,5 @@
 Issue3684.agda:13,10-17,4
-warning: -W[no]TooManyFieldsWarning
+warning: -W[no]TooManyFields
 The record type R does not have the fields bar, far but it would
 have the fields foo, boo
 when checking that the expression
@@ -8,7 +8,7 @@ record { moo = A ; bar = A ; far = A } has type R
 ———— All done; warnings encountered ————————————————————————
 
 Issue3684.agda:13,10-17,4
-warning: -W[no]TooManyFieldsWarning
+warning: -W[no]TooManyFields
 The record type R does not have the fields bar, far but it would
 have the fields foo, boo
 when checking that the expression

--- a/test/Succeed/RecordUpdateSyntax.warn
+++ b/test/Succeed/RecordUpdateSyntax.warn
@@ -1,22 +1,22 @@
 RecordUpdateSyntax.agda:60,5-36
-warning: -W[no]TooManyFieldsWarning
+warning: -W[no]TooManyFields
 The record type R does not have the field invalidField but it would
 have the fields i, p, s
 when checking that the expression record old { invalidField = 1 }
 has type R
 RecordUpdateSyntax.agda:61,5-32
-warning: -W[no]DuplicateFieldsWarning
+warning: -W[no]DuplicateFields
 Duplicate field s in record
 when checking that the expression record old { s = 1 ; s = 0 } has
 type R
 RecordUpdateSyntax.agda:62,5-50
-warning: -W[no]TooManyFieldsWarning
+warning: -W[no]TooManyFields
 The record type R does not have the fields foo, bar but it would
 have the fields i, p
 when checking that the expression
 record old { foo = 1 ; bar = 0 ; s = 1 ; s = 0 } has type R
 RecordUpdateSyntax.agda:62,5-50
-warning: -W[no]DuplicateFieldsWarning
+warning: -W[no]DuplicateFields
 Duplicate field s in record
 when checking that the expression
 record old { foo = 1 ; bar = 0 ; s = 1 ; s = 0 } has type R
@@ -24,27 +24,27 @@ record old { foo = 1 ; bar = 0 ; s = 1 ; s = 0 } has type R
 ———— All done; warnings encountered ————————————————————————
 
 RecordUpdateSyntax.agda:60,5-36
-warning: -W[no]TooManyFieldsWarning
+warning: -W[no]TooManyFields
 The record type R does not have the field invalidField but it would
 have the fields i, p, s
 when checking that the expression record old { invalidField = 1 }
 has type R
 
 RecordUpdateSyntax.agda:61,5-32
-warning: -W[no]DuplicateFieldsWarning
+warning: -W[no]DuplicateFields
 Duplicate field s in record
 when checking that the expression record old { s = 1 ; s = 0 } has
 type R
 
 RecordUpdateSyntax.agda:62,5-50
-warning: -W[no]TooManyFieldsWarning
+warning: -W[no]TooManyFields
 The record type R does not have the fields foo, bar but it would
 have the fields i, p
 when checking that the expression
 record old { foo = 1 ; bar = 0 ; s = 1 ; s = 0 } has type R
 
 RecordUpdateSyntax.agda:62,5-50
-warning: -W[no]DuplicateFieldsWarning
+warning: -W[no]DuplicateFields
 Duplicate field s in record
 when checking that the expression
 record old { foo = 1 ; bar = 0 ; s = 1 ; s = 0 } has type R

--- a/test/Succeed/TooManyFields.warn
+++ b/test/Succeed/TooManyFields.warn
@@ -1,5 +1,5 @@
 TooManyFields.agda:12,7-28
-warning: -W[no]TooManyFieldsWarning
+warning: -W[no]TooManyFields
 The record type D does not have the field y
 when checking that the expression record { x = x ; y = x } has type
 D
@@ -7,7 +7,7 @@ D
 ———— All done; warnings encountered ————————————————————————
 
 TooManyFields.agda:12,7-28
-warning: -W[no]TooManyFieldsWarning
+warning: -W[no]TooManyFields
 The record type D does not have the field y
 when checking that the expression record { x = x ; y = x } has type
 D


### PR DESCRIPTION
The warning names are part of Agda's CLI, so they need to be sensibly named.
Thus, dropping the `Warning` suffix for the above mentioned warnings.

Dropping the suffix from `DuplicateFieldsWarning` generates clashes with constructors named `DuplicateFields` for other two types.
These clashes are resolved by moving the two changed warnings to a separate module `Agda.TypeChecking.Monad.Base.Warning`.
