### PR TITLE
Fix typos in test case for #3983

### DIFF
--- a/test/Fail/Issue3983.agda
+++ b/test/Fail/Issue3983.agda
@@ -12,18 +12,18 @@ mutual
 
   {-# TERMINATING #-}
   g : ⊥
-  g = f
+  g = g
 
 abstract
 
   {-# TERMINATING #-}
   h : ⊥
-  h = f
+  h = h
 
 record I : Set where
   {-# TERMINATING #-}
   i : ⊥
-  i = f
+  i = i
 
 instance
 

--- a/test/Fail/Issue3983.err
+++ b/test/Fail/Issue3983.err
@@ -6,7 +6,7 @@ when scope checking the declaration
   record I where
     {-# TERMINATING #-}
     i : ⊥
-    i = f
+    i = i
 Issue3983.agda:7,3-22
 Cannot use TERMINATING pragma with safe flag.
 Issue3983.agda:13,3-22
@@ -23,4 +23,9 @@ when scope checking the declaration
   record I where
     {-# TERMINATING #-}
     i : ⊥
-    i = f
+    i = i
+Issue3983.agda:23,1-26,8
+Termination checking failed for the following functions:
+  I.i
+Problematic calls:
+  i (at Issue3983.agda:26,7-8)


### PR DESCRIPTION
Some copy and paste error rendered this test less useful, as some functions intended to be non-terminating became non-recursive.

With the fix the termination error is now part of the `.err` file.

Re:
- #3983 
- #3008