### PR TITLE
Fix #6795 by using generic traversal for C.Declaration

### DIFF
--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -16,6 +16,9 @@ module Agda.Syntax.Concrete
   , rawApp, rawAppP
   , isSingleIdentifierP, removeParenP
   , isPattern, isAbsurdP, isBinderP
+  , observeHiding
+  , observeRelevance
+  , observeModifiers
   , exprToPatternWithHoles
   , returnExpr
     -- * Bindings
@@ -39,10 +42,11 @@ module Agda.Syntax.Concrete
   , makePi
   , mkLam, mkLet, mkTLet
     -- * Declarations
-  , RecordDirective(..)
-  , isRecordDirective
-  , RecordDirectives
   , Declaration(..)
+  , isPragma
+  , isRecordDirective
+  , RecordDirective(..)
+  , RecordDirectives
   , ModuleApplication(..)
   , TypeSignature
   , TypeSignatureOrInstanceBlock
@@ -51,9 +55,6 @@ module Agda.Syntax.Concrete
   , AsName'(..), AsName
   , OpenShortHand(..), RewriteEqn, WithExpr
   , LHS(..), Pattern(..), LHSCore(..)
-  , observeHiding
-  , observeRelevance
-  , observeModifiers
   , LamClause(..)
   , RHS, RHS'(..), WhereClause, WhereClause'(..), ExprWhere(..)
   , DoStmt(..)
@@ -95,6 +96,7 @@ import qualified Agda.Utils.List1 as List1
 import Agda.Utils.List2       ( List2, pattern List2 )
 import Agda.Syntax.Common.Aspect (NameKind)
 import Agda.Utils.Null
+import Agda.Utils.Singleton
 
 import Agda.Utils.Impossible
 
@@ -515,6 +517,46 @@ isRecordDirective :: Declaration -> Maybe RecordDirective
 isRecordDirective (RecordDirective r) = Just r
 isRecordDirective (InstanceB r [RecordDirective (Constructor n p)]) = Just (Constructor n (InstanceDef r))
 isRecordDirective _ = Nothing
+
+-- | Return 'Pragma' if 'Declaration' is 'Pragma'.
+{-# SPECIALIZE isPragma :: Declaration -> Maybe Pragma #-}
+{-# SPECIALIZE isPragma :: Declaration -> [Pragma] #-}
+isPragma :: CMaybe Pragma m => Declaration -> m
+isPragma = \case
+    Pragma p                -> singleton p
+    Private  _ _ _          -> empty
+    Abstract _ _            -> empty
+    InstanceB _ _           -> empty
+    Mutual _ _              -> empty
+    Module _ _ _ _ _        -> empty
+    Macro _ _               -> empty
+    Record _ _ _ _ _ _ _    -> empty
+    RecordDef _ _ _ _ _     -> empty
+    TypeSig _ _ _ _         -> empty
+    FieldSig _ _ _ _        -> empty
+    Generalize _ _          -> empty
+    Field _ _               -> empty
+    FunClause _ _ _ _       -> empty
+    DataSig _ _ _ _ _       -> empty
+    Data _ _ _ _ _ _        -> empty
+    DataDef _ _ _ _         -> empty
+    RecordSig _ _ _ _ _     -> empty
+    RecordDirective _       -> empty
+    Infix _ _               -> empty
+    Syntax _ _              -> empty
+    PatternSyn _ _ _ _      -> empty
+    InterleavedMutual _ _   -> empty
+    LoneConstructor _ _     -> empty
+    Postulate _ _           -> empty
+    Primitive _ _           -> empty
+    Open _ _ _              -> empty
+    Import _ _ _ _ _        -> empty
+    ModuleMacro _ _ _ _ _ _ -> empty
+    UnquoteDecl _ _ _       -> empty
+    UnquoteDef _ _ _        -> empty
+    UnquoteData _ _ _ _     -> empty
+    Opaque _ _              -> empty
+    Unfolding _ _           -> empty
 
 data ModuleApplication
   = SectionApp Range Telescope Expr

--- a/src/full/Agda/Utils/Singleton.hs
+++ b/src/full/Agda/Utils/Singleton.hs
@@ -4,6 +4,7 @@
 module Agda.Utils.Singleton where
 
 import Data.Semigroup (Semigroup(..))
+import Data.Maybe
 import Data.Monoid (Endo(..))
 
 import Data.DList (DList)
@@ -26,6 +27,8 @@ import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Set (Set)
 import qualified Data.Set as Set
+
+import Agda.Utils.Null     (Null, empty)
 import Agda.Utils.SmallSet (SmallSet, SmallSetElement)
 import qualified Agda.Utils.SmallSet as SmallSet
 
@@ -58,6 +61,15 @@ instance (Eq k, Hashable k) =>
          Collection (k, a)  (HashMap k a) where fromList = HashMap.fromList
 
 instance SmallSetElement a => Collection a (SmallSet a) where fromList = SmallSet.fromList
+
+-- | Create-only collection with at most one element.
+
+class (Null coll, Singleton el coll) => CMaybe el coll | coll -> el where
+  cMaybe :: Maybe el -> coll
+  cMaybe = maybe empty singleton
+
+instance CMaybe a (Maybe a) where cMaybe = id
+instance CMaybe a [a]       where cMaybe = maybeToList
 
 -- | Overloaded @singleton@ constructor for collections.
 

--- a/test/Fail/Issue3983.agda
+++ b/test/Fail/Issue3983.agda
@@ -2,6 +2,13 @@
 
 data ⊥ : Set where
 
+E : Set₁
+E = Set where
+
+  {-# TERMINATING #-}
+  e : ⊥
+  e = e
+
 private
 
   {-# TERMINATING #-}
@@ -30,3 +37,39 @@ instance
   {-# TERMINATING #-}
   j : I
   j = j
+
+interleaved mutual
+
+  {-# TERMINATING #-}
+  k : ⊥
+  k = k
+
+opaque
+
+  {-# TERMINATING #-}
+  l : ⊥
+  l = l
+
+record M : Set where
+  interleaved mutual
+    {-# TERMINATING #-}
+    m : ⊥
+    m = m
+
+record N : Set where
+  opaque
+    {-# TERMINATING #-}
+    n : ⊥
+    n = n
+
+O : Set₁
+O = Set where
+  interleaved mutual
+    {-# TERMINATING #-}
+    o : ⊥
+    o = o
+
+  opaque
+    {-# TERMINATING #-}
+    o' : ⊥
+    o' = o'

--- a/test/Fail/Issue3983.err
+++ b/test/Fail/Issue3983.err
@@ -1,4 +1,14 @@
-Issue3983.agda:23,1-26,8
+Issue3983.agda:8,3-22
+warning: -W[no]GenericUseless
+Termination pragmas are ignored in where clauses
+(see https://github.com/agda/agda/issues/3355)
+when scope checking the declaration
+  E = Set
+    where
+      {-# TERMINATING #-}
+      e : ⊥
+      e = e
+Issue3983.agda:31,3-22
 warning: -W[no]GenericUseless
 Termination pragmas are ignored in record definitions
 (see https://github.com/agda/agda/issues/3008)
@@ -7,25 +17,103 @@ when scope checking the declaration
     {-# TERMINATING #-}
     i : ⊥
     i = i
-Issue3983.agda:7,3-22
+Issue3983.agda:55,5-24
+warning: -W[no]GenericUseless
+Termination pragmas are ignored in record definitions
+(see https://github.com/agda/agda/issues/3008)
+when scope checking the declaration
+  record M where
+    interleaved mutual
+      {-# TERMINATING #-}
+      m : ⊥
+      m = m
+Issue3983.agda:61,5-24
+warning: -W[no]GenericUseless
+Termination pragmas are ignored in record definitions
+(see https://github.com/agda/agda/issues/3008)
+when scope checking the declaration
+  record N where
+    opaque
+      {-# TERMINATING #-}
+      n : ⊥
+      n = n
+Issue3983.agda:68,5-24
+warning: -W[no]GenericUseless
+Termination pragmas are ignored in where clauses
+(see https://github.com/agda/agda/issues/3355)
+when scope checking the declaration
+  O = Set
+    where
+      interleaved mutual
+        {-# TERMINATING #-}
+        o : ⊥
+        o = o
+      opaque
+        {-# TERMINATING #-}
+        o' : ⊥
+        o' = o'
+Issue3983.agda:73,5-24
+warning: -W[no]GenericUseless
+Termination pragmas are ignored in where clauses
+(see https://github.com/agda/agda/issues/3355)
+when scope checking the declaration
+  O = Set
+    where
+      interleaved mutual
+        {-# TERMINATING #-}
+        o : ⊥
+        o = o
+      opaque
+        {-# TERMINATING #-}
+        o' : ⊥
+        o' = o'
+Issue3983.agda:14,3-22
 Cannot use TERMINATING pragma with safe flag.
-Issue3983.agda:13,3-22
+Issue3983.agda:20,3-22
 Cannot use TERMINATING pragma with safe flag.
-Issue3983.agda:19,3-22
+Issue3983.agda:26,3-22
 Cannot use TERMINATING pragma with safe flag.
-Issue3983.agda:24,3-22
+Issue3983.agda:31,3-22
 Cannot use TERMINATING pragma with safe flag.
-Issue3983.agda:30,3-22
+Issue3983.agda:37,3-22
 Cannot use TERMINATING pragma with safe flag.
-Issue3983.agda:24,3-22
+Issue3983.agda:8,3-22
+Cannot use TERMINATING pragma with safe flag.
+when scope checking the declaration
+  E = Set
+    where
+      {-# TERMINATING #-}
+      e : ⊥
+      e = e
+Issue3983.agda:31,3-22
 Cannot use TERMINATING pragma with safe flag.
 when scope checking the declaration
   record I where
     {-# TERMINATING #-}
     i : ⊥
     i = i
-Issue3983.agda:23,1-26,8
+Issue3983.agda:5,1-10,8
+Termination checking failed for the following functions:
+Problematic calls:
+  e (at Issue3983.agda:10,7-8)
+Issue3983.agda:30,1-33,8
 Termination checking failed for the following functions:
   I.i
 Problematic calls:
-  i (at Issue3983.agda:26,7-8)
+  i (at Issue3983.agda:33,7-8)
+Issue3983.agda:53,1-57,10
+Termination checking failed for the following functions:
+  M.m
+Problematic calls:
+  m (at Issue3983.agda:57,9-10)
+Issue3983.agda:59,1-63,10
+Termination checking failed for the following functions:
+  N.n
+Problematic calls:
+  n (at Issue3983.agda:63,9-10)
+Issue3983.agda:65,1-75,12
+Termination checking failed for the following functions:
+Problematic calls:
+  o (at Issue3983.agda:70,9-10)
+  o'
+    (at Issue3983.agda:75,10-12)

--- a/test/Succeed/Issue1137.warn
+++ b/test/Succeed/Issue1137.warn
@@ -1,4 +1,4 @@
-Issue1137.agda:10,1-14,10
+Issue1137.agda:12,3-22
 warning: -W[no]GenericUseless
 Termination pragmas are ignored in where clauses
 (see https://github.com/agda/agda/issues/3355)
@@ -11,7 +11,7 @@ when scope checking the declaration
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue1137.agda:10,1-14,10
+Issue1137.agda:12,3-22
 warning: -W[no]GenericUseless
 Termination pragmas are ignored in where clauses
 (see https://github.com/agda/agda/issues/3355)


### PR DESCRIPTION
New generic traversals `foldDecl` and `preTraverseDecl` for `C.Declaration`.
Use exhaustive pattern matches to avoid regressions.

Closes #6795.
