### PR TITLE
Raise warnings about unsafe pragmas already in the nicifier.

### DIFF
--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -453,15 +453,7 @@ warningHighlighting' b w = case tcWarning w of
   GenericNonFatalError{}                -> errorWarningHighlighting w
   SafeFlagPostulate{}                   -> errorWarningHighlighting w
   SafeFlagPragma{}                      -> errorWarningHighlighting w
-  SafeFlagNonTerminating                -> errorWarningHighlighting w
-  SafeFlagTerminating                   -> errorWarningHighlighting w
   SafeFlagWithoutKFlagPrimEraseEquality -> errorWarningHighlighting w
-  SafeFlagEta                           -> errorWarningHighlighting w
-  SafeFlagInjective                     -> errorWarningHighlighting w
-  SafeFlagNoCoverageCheck               -> errorWarningHighlighting w
-  SafeFlagNoPositivityCheck             -> errorWarningHighlighting w
-  SafeFlagPolarity                      -> errorWarningHighlighting w
-  SafeFlagNoUniverseCheck               -> errorWarningHighlighting w
   InfectiveImport{}                     -> errorWarningHighlighting w
   CoInfectiveImport{}                   -> errorWarningHighlighting w
   WithoutKFlagPrimEraseEquality -> mempty
@@ -521,6 +513,14 @@ warningHighlighting' b w = case tcWarning w of
     InvalidRecordDirective{}         -> deadcodeHighlighting w
     OpenPublicAbstract{}             -> deadcodeHighlighting w
     OpenPublicPrivate{}              -> deadcodeHighlighting w
+    SafeFlagEta                   {} -> errorWarningHighlighting w
+    SafeFlagInjective             {} -> errorWarningHighlighting w
+    SafeFlagNoCoverageCheck       {} -> errorWarningHighlighting w
+    SafeFlagNoPositivityCheck     {} -> errorWarningHighlighting w
+    SafeFlagNoUniverseCheck       {} -> errorWarningHighlighting w
+    SafeFlagNonTerminating        {} -> errorWarningHighlighting w
+    SafeFlagPolarity              {} -> errorWarningHighlighting w
+    SafeFlagTerminating           {} -> errorWarningHighlighting w
     W.ShadowingInTelescope nrs       -> foldMap
                                           (shadowingTelHighlighting . snd)
                                           nrs

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4161,16 +4161,8 @@ data Warning
   -- Safe flag errors
   | SafeFlagPostulate C.Name
   | SafeFlagPragma [String]                -- ^ Unsafe OPTIONS.
-  | SafeFlagNonTerminating
-  | SafeFlagTerminating
   | SafeFlagWithoutKFlagPrimEraseEquality
   | WithoutKFlagPrimEraseEquality
-  | SafeFlagNoPositivityCheck
-  | SafeFlagPolarity
-  | SafeFlagNoUniverseCheck
-  | SafeFlagNoCoverageCheck
-  | SafeFlagInjective
-  | SafeFlagEta                            -- ^ ETA pragma is unsafe.
   | OptionWarning            OptionWarning
   | ParseWarning             ParseWarning
   | LibraryWarning           LibWarning
@@ -4262,18 +4254,10 @@ warningName = \case
   NotStrictlyPositive{}        -> NotStrictlyPositive_
   UnsupportedIndexedMatch{}    -> UnsupportedIndexedMatch_
   OldBuiltin{}                 -> OldBuiltin_
-  SafeFlagNoPositivityCheck    -> SafeFlagNoPositivityCheck_
-  SafeFlagNonTerminating       -> SafeFlagNonTerminating_
-  SafeFlagNoUniverseCheck      -> SafeFlagNoUniverseCheck_
-  SafeFlagPolarity             -> SafeFlagPolarity_
   SafeFlagPostulate{}          -> SafeFlagPostulate_
   SafeFlagPragma{}             -> SafeFlagPragma_
-  SafeFlagEta                  -> SafeFlagEta_
-  SafeFlagInjective            -> SafeFlagInjective_
-  SafeFlagNoCoverageCheck      -> SafeFlagNoCoverageCheck_
   SafeFlagWithoutKFlagPrimEraseEquality -> SafeFlagWithoutKFlagPrimEraseEquality_
   WithoutKFlagPrimEraseEquality -> WithoutKFlagPrimEraseEquality_
-  SafeFlagTerminating          -> SafeFlagTerminating_
   TerminationIssue{}           -> TerminationIssue_
   UnreachableClauses{}         -> UnreachableClauses_
   UnsolvedInteractionMetas{}   -> UnsolvedInteractionMetas_

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -227,33 +227,9 @@ prettyWarning = \case
       , [ fwords "with safe flag." ]
       ]
 
-    SafeFlagNonTerminating -> fsep $
-      pwords "Cannot use NON_TERMINATING pragma with safe flag."
-
-    SafeFlagTerminating -> fsep $
-      pwords "Cannot use TERMINATING pragma with safe flag."
-
     SafeFlagWithoutKFlagPrimEraseEquality -> fsep (pwords "Cannot use primEraseEquality with safe and without-K flags.")
 
     WithoutKFlagPrimEraseEquality -> fsep (pwords "Using primEraseEquality with the without-K flag is inconsistent.")
-
-    SafeFlagNoPositivityCheck -> fsep $
-      pwords "Cannot use NO_POSITIVITY_CHECK pragma with safe flag."
-
-    SafeFlagPolarity -> fsep $
-      pwords "Cannot use POLARITY pragma with safe flag."
-
-    SafeFlagNoUniverseCheck -> fsep $
-      pwords "Cannot use NO_UNIVERSE_CHECK pragma with safe flag."
-
-    SafeFlagEta -> fsep $
-      pwords "Cannot use ETA pragma with safe flag."
-
-    SafeFlagInjective -> fsep $
-      pwords "Cannot use INJECTIVE pragma with safe flag."
-
-    SafeFlagNoCoverageCheck -> fsep $
-      pwords "Cannot use NON_COVERING pragma with safe flag."
 
     OptionWarning ow -> pretty ow
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -44,15 +44,7 @@ instance EmbPrj Warning where
     GenericNonFatalError a                -> __IMPOSSIBLE__
     SafeFlagPostulate a                   -> __IMPOSSIBLE__
     SafeFlagPragma a                      -> __IMPOSSIBLE__
-    SafeFlagNonTerminating                -> __IMPOSSIBLE__
-    SafeFlagTerminating                   -> __IMPOSSIBLE__
     SafeFlagWithoutKFlagPrimEraseEquality -> __IMPOSSIBLE__
-    SafeFlagNoPositivityCheck             -> __IMPOSSIBLE__
-    SafeFlagPolarity                      -> __IMPOSSIBLE__
-    SafeFlagNoUniverseCheck               -> __IMPOSSIBLE__
-    SafeFlagNoCoverageCheck               -> __IMPOSSIBLE__
-    SafeFlagInjective                     -> __IMPOSSIBLE__
-    SafeFlagEta                           -> __IMPOSSIBLE__
     DeprecationWarning a b c              -> icodeN 6 DeprecationWarning a b c
     NicifierIssue a                       -> icodeN 7 NicifierIssue a
     InversionDepthReached a               -> icodeN 8 InversionDepthReached a
@@ -217,6 +209,14 @@ instance EmbPrj DeclarationWarning' where
     InvalidConstructorBlock a         -> icodeN 31 InvalidConstructorBlock a
     MissingDeclarations a             -> icodeN 32 MissingDeclarations a
     HiddenGeneralize r                -> icodeN 33 HiddenGeneralize r
+    SafeFlagEta                    {} -> __IMPOSSIBLE__
+    SafeFlagInjective              {} -> __IMPOSSIBLE__
+    SafeFlagNoCoverageCheck        {} -> __IMPOSSIBLE__
+    SafeFlagNoPositivityCheck      {} -> __IMPOSSIBLE__
+    SafeFlagNoUniverseCheck        {} -> __IMPOSSIBLE__
+    SafeFlagNonTerminating         {} -> __IMPOSSIBLE__
+    SafeFlagPolarity               {} -> __IMPOSSIBLE__
+    SafeFlagTerminating            {} -> __IMPOSSIBLE__
 
   value = vcase $ \case
     [0, a]   -> valuN UnknownNamesInFixityDecl a

--- a/test/Fail/Issue2250-2.err
+++ b/test/Fail/Issue2250-2.err
@@ -2,11 +2,3 @@ Issue2250-2.agda:24,5-24
 Cannot use INJECTIVE pragma with safe flag.
 when scope checking the declaration
   module Abstract where
-Issue2250-2.agda:42,3-22
-Cannot use INJECTIVE pragma with safe flag.
-when scope checking the declaration
-  module Mutual where
-Issue2250-2.agda:65,3-22
-Cannot use INJECTIVE pragma with safe flag.
-when scope checking the declaration
-  module Data where

--- a/test/Fail/Issue3983.err
+++ b/test/Fail/Issue3983.err
@@ -1,119 +1,12 @@
-Issue3983.agda:8,3-22
-warning: -W[no]GenericUseless
-Termination pragmas are ignored in where clauses
-(see https://github.com/agda/agda/issues/3355)
-when scope checking the declaration
-  E = Set
-    where
-      {-# TERMINATING #-}
-      e : ⊥
-      e = e
-Issue3983.agda:31,3-22
-warning: -W[no]GenericUseless
-Termination pragmas are ignored in record definitions
-(see https://github.com/agda/agda/issues/3008)
-when scope checking the declaration
-  record I where
-    {-# TERMINATING #-}
-    i : ⊥
-    i = i
-Issue3983.agda:55,5-24
-warning: -W[no]GenericUseless
-Termination pragmas are ignored in record definitions
-(see https://github.com/agda/agda/issues/3008)
-when scope checking the declaration
-  record M where
-    interleaved mutual
-      {-# TERMINATING #-}
-      m : ⊥
-      m = m
-Issue3983.agda:61,5-24
-warning: -W[no]GenericUseless
-Termination pragmas are ignored in record definitions
-(see https://github.com/agda/agda/issues/3008)
-when scope checking the declaration
-  record N where
-    opaque
-      {-# TERMINATING #-}
-      n : ⊥
-      n = n
-Issue3983.agda:68,5-24
-warning: -W[no]GenericUseless
-Termination pragmas are ignored in where clauses
-(see https://github.com/agda/agda/issues/3355)
-when scope checking the declaration
-  O = Set
-    where
-      interleaved mutual
-        {-# TERMINATING #-}
-        o : ⊥
-        o = o
-      opaque
-        {-# TERMINATING #-}
-        o' : ⊥
-        o' = o'
-Issue3983.agda:73,5-24
-warning: -W[no]GenericUseless
-Termination pragmas are ignored in where clauses
-(see https://github.com/agda/agda/issues/3355)
-when scope checking the declaration
-  O = Set
-    where
-      interleaved mutual
-        {-# TERMINATING #-}
-        o : ⊥
-        o = o
-      opaque
-        {-# TERMINATING #-}
-        o' : ⊥
-        o' = o'
 Issue3983.agda:14,3-22
 Cannot use TERMINATING pragma with safe flag.
 Issue3983.agda:20,3-22
 Cannot use TERMINATING pragma with safe flag.
 Issue3983.agda:26,3-22
 Cannot use TERMINATING pragma with safe flag.
-Issue3983.agda:31,3-22
-Cannot use TERMINATING pragma with safe flag.
 Issue3983.agda:37,3-22
 Cannot use TERMINATING pragma with safe flag.
-Issue3983.agda:8,3-22
+Issue3983.agda:43,3-22
 Cannot use TERMINATING pragma with safe flag.
-when scope checking the declaration
-  E = Set
-    where
-      {-# TERMINATING #-}
-      e : ⊥
-      e = e
-Issue3983.agda:31,3-22
+Issue3983.agda:49,3-22
 Cannot use TERMINATING pragma with safe flag.
-when scope checking the declaration
-  record I where
-    {-# TERMINATING #-}
-    i : ⊥
-    i = i
-Issue3983.agda:5,1-10,8
-Termination checking failed for the following functions:
-Problematic calls:
-  e (at Issue3983.agda:10,7-8)
-Issue3983.agda:30,1-33,8
-Termination checking failed for the following functions:
-  I.i
-Problematic calls:
-  i (at Issue3983.agda:33,7-8)
-Issue3983.agda:53,1-57,10
-Termination checking failed for the following functions:
-  M.m
-Problematic calls:
-  m (at Issue3983.agda:57,9-10)
-Issue3983.agda:59,1-63,10
-Termination checking failed for the following functions:
-  N.n
-Problematic calls:
-  n (at Issue3983.agda:63,9-10)
-Issue3983.agda:65,1-75,12
-Termination checking failed for the following functions:
-Problematic calls:
-  o (at Issue3983.agda:70,9-10)
-  o'
-    (at Issue3983.agda:75,10-12)

--- a/test/Fail/Issue6795.agda
+++ b/test/Fail/Issue6795.agda
@@ -1,0 +1,85 @@
+-- Andreas, 2023-08-28, issues #3008, #4400, #6795
+-- Test adapted from #3983.
+--
+-- Alert the user when a TERMINATION pragma is ignored by Agda:
+-- * in records
+-- * in where blocks
+
+data ⊥ : Set where
+
+E : Set₁
+E = Set where
+
+  {-# TERMINATING #-}
+  e : ⊥
+  e = e
+
+private
+
+  {-# TERMINATING #-}
+  f : ⊥
+  f = f
+
+mutual
+
+  {-# TERMINATING #-}
+  g : ⊥
+  g = g
+
+abstract
+
+  {-# TERMINATING #-}
+  h : ⊥
+  h = h
+
+record I : Set where
+  {-# TERMINATING #-}
+  i : ⊥
+  i = i
+
+instance
+
+  {-# TERMINATING #-}
+  j : I
+  j = j
+
+interleaved mutual
+
+  {-# TERMINATING #-}
+  k : ⊥
+  k = k
+
+opaque
+
+  {-# TERMINATING #-}
+  l : ⊥
+  l = l
+
+record M : Set where
+  interleaved mutual
+    {-# TERMINATING #-}
+    m : ⊥
+    m = m
+
+record N : Set where
+  opaque
+    {-# TERMINATING #-}
+    n : ⊥
+    n = n
+
+O : Set₁
+O = Set where
+  interleaved mutual
+    {-# TERMINATING #-}
+    o : ⊥
+    o = o
+
+  opaque
+    {-# TERMINATING #-}
+    o' : ⊥
+    o' = o'
+
+-- A warning about ignoring a TERMINATING pragma should be emitted
+-- for exactly those functions the termination checker complains about:
+--
+--   e, i, m, n, o, o'

--- a/test/Fail/Issue6795.err
+++ b/test/Fail/Issue6795.err
@@ -1,0 +1,94 @@
+Issue6795.agda:13,3-22
+warning: -W[no]GenericUseless
+Termination pragmas are ignored in where clauses
+(see https://github.com/agda/agda/issues/3355)
+when scope checking the declaration
+  E = Set
+    where
+      {-# TERMINATING #-}
+      e : ⊥
+      e = e
+Issue6795.agda:36,3-22
+warning: -W[no]GenericUseless
+Termination pragmas are ignored in record definitions
+(see https://github.com/agda/agda/issues/3008)
+when scope checking the declaration
+  record I where
+    {-# TERMINATING #-}
+    i : ⊥
+    i = i
+Issue6795.agda:60,5-24
+warning: -W[no]GenericUseless
+Termination pragmas are ignored in record definitions
+(see https://github.com/agda/agda/issues/3008)
+when scope checking the declaration
+  record M where
+    interleaved mutual
+      {-# TERMINATING #-}
+      m : ⊥
+      m = m
+Issue6795.agda:66,5-24
+warning: -W[no]GenericUseless
+Termination pragmas are ignored in record definitions
+(see https://github.com/agda/agda/issues/3008)
+when scope checking the declaration
+  record N where
+    opaque
+      {-# TERMINATING #-}
+      n : ⊥
+      n = n
+Issue6795.agda:73,5-24
+warning: -W[no]GenericUseless
+Termination pragmas are ignored in where clauses
+(see https://github.com/agda/agda/issues/3355)
+when scope checking the declaration
+  O = Set
+    where
+      interleaved mutual
+        {-# TERMINATING #-}
+        o : ⊥
+        o = o
+      opaque
+        {-# TERMINATING #-}
+        o' : ⊥
+        o' = o'
+Issue6795.agda:78,5-24
+warning: -W[no]GenericUseless
+Termination pragmas are ignored in where clauses
+(see https://github.com/agda/agda/issues/3355)
+when scope checking the declaration
+  O = Set
+    where
+      interleaved mutual
+        {-# TERMINATING #-}
+        o : ⊥
+        o = o
+      opaque
+        {-# TERMINATING #-}
+        o' : ⊥
+        o' = o'
+Issue6795.agda:10,1-15,8
+Termination checking failed for the following functions:
+Problematic calls:
+  e (at Issue6795.agda:15,7-8)
+Issue6795.agda:35,1-38,8
+Termination checking failed for the following functions:
+  I.i
+Problematic calls:
+  i (at Issue6795.agda:38,7-8)
+Issue6795.agda:58,1-62,10
+Termination checking failed for the following functions:
+  M.m
+Problematic calls:
+  m (at Issue6795.agda:62,9-10)
+Issue6795.agda:64,1-68,10
+Termination checking failed for the following functions:
+  N.n
+Problematic calls:
+  n (at Issue6795.agda:68,9-10)
+Issue6795.agda:70,1-80,12
+Termination checking failed for the following functions:
+Problematic calls:
+  o (at Issue6795.agda:75,9-10)
+  o'
+    (at Issue6795.agda:80,10-12)

--- a/test/Fail/Polarity-pragma-in-safe-mode.err
+++ b/test/Fail/Polarity-pragma-in-safe-mode.err
@@ -1,6 +1,2 @@
 Polarity-pragma-in-safe-mode.agda:5,1-22
 Cannot use POLARITY pragma with safe flag.
-Polarity-pragma-in-safe-mode.agda:3,11-24
-Cannot postulate F with safe flag
-when scope checking the declaration
-  F : Set → Set


### PR DESCRIPTION
So far, for checking `--safe`, only `PragmaCompiled` was raised in the nicifier.  The other unsafe pragmas were checked in a (now buggy #6794) separate pass in the scope checker.  
These are now also checked in the nicifier when we first go over the pragmas.

Since nicifier errors take precedence over scope errors, you won't see the scope errors anymore you had together with an unsafe pragma. E.g. `Polarity-pragma-in-safe-mode.agda` will now only trigger the unsafe pragma error, and no longer triggers the unsafe postulate error.

Internal changes:

- Some `SafeFlag*` warnings are now `DeclarationWarning`s.

- `Nice` monad now has a `Reader` component for parametrization.
  We use it to pass to the nicifier whether it should check for unsafe pragmas.  (Previously, unsafe pragma warnings were anyway raised and then filtered out, probably the technical reason that one cannot access the options in the `Nice` monad.)

- The parameters are collected in `NiceEnv`, the previous `NiceEnv` has been renamed to `NiceState` (to match `TCEnv` and `TCState`).

Fixes #6794.
