### PR TITLE
TypeChecking/Rules/Application.hs error refactor

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -290,6 +290,7 @@ errorString err = case err of
   NamedWhereModuleInRefinedContext{}       -> "NamedWhereModuleInRefinedContext"
   CubicalPrimitiveNotFullyApplied{}        -> "CubicalPrimitiveNotFullyApplied"
   TooManyArgumentsToLeveledSort{}          -> "TooManyArgumentsToLeveledSort"
+  TooManyArgumentsToUnivOmega{}            -> "TooManyArgumentsToUnivOmega"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1357,6 +1358,9 @@ instance PrettyTCM TypeError where
 
     TooManyArgumentsToLeveledSort q -> fsep $
       [ prettyTCM q , "cannot be applied to more than one argument" ]
+
+    TooManyArgumentsToUnivOmega q -> fsep $
+      [ prettyTCM q , "cannot be applied to an argument" ]
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -289,6 +289,7 @@ errorString err = case err of
   MacroResultTypeMismatch{}                -> "MacroResultTypeMismatch"
   NamedWhereModuleInRefinedContext{}       -> "NamedWhereModuleInRefinedContext"
   CubicalPrimitiveNotFullyApplied{}        -> "CubicalPrimitiveNotFullyApplied"
+  TooManyArgumentsToLeveledSort{}          -> "TooManyArgumentsToLeveledSort"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1353,6 +1354,9 @@ instance PrettyTCM TypeError where
 
     CubicalPrimitiveNotFullyApplied c ->
       prettyTCM c <+> "must be fully applied"
+
+    TooManyArgumentsToLeveledSort q -> fsep $
+      [ prettyTCM q , "cannot be applied to more than one argument" ]
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -288,6 +288,7 @@ errorString err = case err of
   CannotRewriteByNonEquation{}             -> "CannotRewriteByNonEquation"
   MacroResultTypeMismatch{}                -> "MacroResultTypeMismatch"
   NamedWhereModuleInRefinedContext{}       -> "NamedWhereModuleInRefinedContext"
+  CubicalPrimitiveNotFullyApplied{}        -> "CubicalPrimitiveNotFullyApplied"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1349,6 +1350,9 @@ instance PrettyTCM TypeError where
                   (if not (null args) then "s have" else " has") ++
                   " been refined to"
         , nest 2 $ vcat (zipWith pr names args) ]
+
+    CubicalPrimitiveNotFullyApplied c ->
+      prettyTCM c <+> "must be fully applied"
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4568,6 +4568,7 @@ data TypeError
         | NamedWhereModuleInRefinedContext [Term] [String]
         | CubicalPrimitiveNotFullyApplied QName
         | TooManyArgumentsToLeveledSort QName
+        | TooManyArgumentsToUnivOmega QName
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4567,6 +4567,7 @@ data TypeError
         | MacroResultTypeMismatch Type
         | NamedWhereModuleInRefinedContext [Term] [String]
         | CubicalPrimitiveNotFullyApplied QName
+        | TooManyArgumentsToLeveledSort QName
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4566,6 +4566,7 @@ data TypeError
         | CannotRewriteByNonEquation Type
         | MacroResultTypeMismatch Type
         | NamedWhereModuleInRefinedContext [Term] [String]
+        | CubicalPrimitiveNotFullyApplied QName
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1489,8 +1489,7 @@ inferUnivOmega u q suffix = \case
   [] -> do
     let n = suffixToLevel suffix
     return (Sort (Inf u n) , sort (Inf (univUniv u) $ 1 + n))
-  arg : _ -> typeError . GenericDocError =<< fsep
-        [ prettyTCM q , "cannot be applied to an argument" ]
+  arg : _ -> typeError $ TooManyArgumentsToUnivOmega q
 
 -----------------------------------------------------------------------------
 -- * Coinduction

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1612,7 +1612,7 @@ checkPrimComp c rs vs _ = do
           (Lam defaultArgInfo $ NoAbs "_" $ unArg a0)
           (apply (unArg u) [iz])
       return $ l : a : phi : u : a0 : rest
-    _ -> typeError . GenericDocError =<< prettyTCM c <+> "must be fully applied"
+    _ -> typeError $ CubicalPrimitiveNotFullyApplied c
 
 -- | @primHComp : ∀ {ℓ} {A : Set ℓ} {φ : I} (u : ∀ i → Partial φ A) (a : A) → A@
 --
@@ -1634,7 +1634,7 @@ checkPrimHComp c rs vs _ = do
             (Lam defaultArgInfo $ NoAbs "_" $ unArg a0)
             (apply (unArg u) [iz])
       return $ l : a : phi : u : a0 : rest
-    _ -> typeError . GenericDocError =<< prettyTCM c <+> "must be fully applied"
+    _ -> typeError $ CubicalPrimitiveNotFullyApplied c
 
 -- | @transp : ∀{ℓ} (A : (i : I) → Set (ℓ i)) (φ : I) (a0 : A i0) → A i1@
 --
@@ -1658,7 +1658,7 @@ checkPrimTrans c rs vs _ = do
           (unArg a)
           (Lam defaultArgInfo $ NoAbs "_" $ apply (unArg a) [iz])
       return $ l : a : phi : rest
-    _ -> typeError . GenericDocError =<< prettyTCM c <+> "must be fully applied"
+    _ -> typeError $ CubicalPrimitiveNotFullyApplied c
 
 blockArg :: HasRange r => Type -> r -> Arg Term -> TCM () -> TCM (Arg Term)
 blockArg t r a m =
@@ -1684,7 +1684,7 @@ checkConId c rs vs t1 = do
       --   equalTerm (El s (unArg a)) (unArg x) (unArg y) -- precondition for cx being well-typed at ty
       --   cx <- pathAbs iv (NoAbs (stringToArgName "_") (applySubst alpha (unArg x)))
       --   equalTerm ty (applySubst alpha (unArg p)) cx   -- G, phi |- p = \ i . x
-   _ -> typeError . GenericDocError =<< prettyTCM c <+> "must be fully applied"
+   _ -> typeError $ CubicalPrimitiveNotFullyApplied c
 
 
 -- The following comment contains silly ' escapes to calm CPP about ∨ (\vee).
@@ -1713,7 +1713,7 @@ checkPOr c rs vs _ = do
         -- ' φ₁ ∧ φ₂  ⊢ u , v : PartialP (φ₁ ∨ φ₂) \ o → a o
         equalTermOnFace phi t1 (unArg u) (unArg v)
       return $ l : phi1 : phi2 : a : u : v : rest
-   _ -> typeError . GenericDocError =<< prettyTCM c <+> "must be fully applied"
+   _ -> typeError $ CubicalPrimitiveNotFullyApplied c
 
 -- | @prim^glue : ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I}
 --              → {T : Partial φ (Set ℓ')} → {e : PartialP φ (λ o → T o ≃ A)}
@@ -1737,7 +1737,7 @@ check_glue c rs vs _ = do
       ta <- el' (pure $ unArg la) (pure $ unArg bA)
       a <- blockArg ta (rs !!! 7) a $ equalTerm ty a' v
       return $ la : lb : bA : phi : bT : e : t : a : rest
-   _ -> typeError . GenericDocError =<< prettyTCM c <+> "must be fully applied"
+   _ -> typeError $ CubicalPrimitiveNotFullyApplied c
 
 
 -- | @prim^glueU : ∀ {ℓ} {φ : I}
@@ -1765,4 +1765,4 @@ check_glueU c rs vs _ = do
             el' la (cl primSubOut <#> (cl primLevelSuc <@> la) <#> (Sort . tmSort <$> la) <#> phi <#> (bT <@> cl primIZero) <@> bA)
       a <- blockArg ta (rs !!! 5) a $ equalTerm ty a' v
       return $ la : phi : bT : bA : t : a : rest
-   _ -> typeError . GenericDocError =<< prettyTCM c <+> "must be fully applied"
+   _ -> typeError $ CubicalPrimitiveNotFullyApplied c

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1477,8 +1477,7 @@ inferLeveledSort u q suffix = \case
       "Use --universe-polymorphism to enable level arguments to Set"
     l <- applyRelevanceToContext NonStrict $ checkLevel arg
     return (Sort $ Univ u l , sort (Univ (univUniv u) $ levelSuc l))
-  arg : _ -> typeError . GenericDocError =<< fsep
-    [ prettyTCM q , "cannot be applied to more than one argument" ]
+  arg : _ -> typeError $ TooManyArgumentsToLeveledSort q
 
 inferUnivOmega ::
      Univ                -- ^ The universe type.

--- a/test/Fail/CubicalPrimitiveNotFullyApplied.agda
+++ b/test/Fail/CubicalPrimitiveNotFullyApplied.agda
@@ -1,0 +1,6 @@
+module CubicalPrimitiveNotFullyApplied where
+
+open import Agda.Primitive.Cubical
+
+test : Set
+test = primPOr

--- a/test/Fail/CubicalPrimitiveNotFullyApplied.err
+++ b/test/Fail/CubicalPrimitiveNotFullyApplied.err
@@ -1,0 +1,3 @@
+CubicalPrimitiveNotFullyApplied.agda:6,8-15
+primPOr must be fully applied
+when checking that the expression primPOr has type Set


### PR DESCRIPTION
Refactor `GenericDocError`-s for concrete ones in `TypeChecking/Rules/Application.hs`. Add new test. More specifically:
- Add a new test case to trigger error `"must be fully applied"` for cubical primitives(`primPOr` as an example)
- Introduce an error `CubicalPrimitiveNotFullyApplied`
- Introduce an error `TooManyArgumentsToLeveledSort`
- Introduce an error `TooManyArgumentsToUnivOmega`