### PR TITLE
Replace warning `GenericUseless` by three specific warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,11 @@ Pragmas and options
   checking. This flag may be necessary for Agda to accept nontrivial
   uses of induction-induction.
 
-* The suffix `Warning` has been dropped from the warning names `DuplicateFieldsWarning` and `TooManyFieldsWarning`.
+* The suffix `Warning` has been dropped from the warning names
+  `DuplicateFieldsWarning` and `TooManyFieldsWarning`.
+
+* The warning `GenericUseless` has been split into the three warnings
+  `UselessPragma`, `FaceConstraintCannotBeHidden` and `FaceConstraintCannotBeNamed`.
 
 Library management
 ------------------

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -432,6 +432,7 @@ warningHighlighting' b w = case tcWarning w of
   EmptyRewritePragma{}       -> deadcodeHighlighting w
   EmptyWhere{}               -> deadcodeHighlighting w
   IllformedAsClause{}        -> deadcodeHighlighting w
+  UselessPragma r _          -> deadcodeHighlighting r
   UselessPublic{}            -> deadcodeHighlighting w
   UselessHiding xs           -> foldMap deadcodeHighlighting xs
   UselessInline{}            -> mempty
@@ -446,7 +447,6 @@ warningHighlighting' b w = case tcWarning w of
   InversionDepthReached{}    -> mempty
   NoGuardednessFlag{}        -> mempty
   GenericWarning{}           -> mempty
-  GenericUseless r _         -> deadcodeHighlighting r
   -- Andreas, 2020-03-21, issue #4456:
   -- Error warnings that do not have dedicated highlighting
   -- are highlighted as errors.
@@ -480,6 +480,9 @@ warningHighlighting' b w = case tcWarning w of
   NotAffectedByOpaque{}           -> deadcodeHighlighting w
   UselessOpaque{}                 -> deadcodeHighlighting w
   UnfoldTransparentName r         -> deadcodeHighlighting r
+  FaceConstraintCannotBeHidden{}  -> deadcodeHighlighting w
+  FaceConstraintCannotBeNamed{}   -> deadcodeHighlighting w
+
   NicifierIssue (DeclarationWarning _ w) -> case w of
     -- we intentionally override the binding of `w` here so that our pattern of
     -- using `getRange w` still yields the most precise range information we

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -241,7 +241,7 @@ data WarningName
   | DuplicateUsing_
   | FixityInRenamingModule_
   | GenericNonFatalError_
-  | GenericUseless_
+  | UselessPragma_
   | GenericWarning_
   | IllformedAsClause_
   | InstanceArgWithExplicitArg_
@@ -294,6 +294,9 @@ data WarningName
   | NotAffectedByOpaque_
   | UnfoldTransparentName_
   | UselessOpaque_
+  -- Cubical
+  | FaceConstraintCannotBeHidden_
+  | FaceConstraintCannotBeNamed_
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Generic)
 
 instance NFData WarningName
@@ -417,7 +420,7 @@ warningNameDescription = \case
   InlineNoExactSplit_              -> "Failed exact split checks after inlining record constructor."
   DeprecationWarning_              -> "Feature deprecation."
   GenericNonFatalError_            -> ""
-  GenericUseless_                  -> "Useless code."
+  UselessPragma_                   -> "Pragma that gets ignored."
   GenericWarning_                  -> ""
   IllformedAsClause_               -> "Illformed `as'-clauses in `import' statements."
   InstanceNoOutputTypeName_        -> "instance arguments whose type does not end in a named or variable type are never considered by instance search."
@@ -468,3 +471,6 @@ warningNameDescription = \case
   NotAffectedByOpaque_             -> "Enclosing `opaque` block has no effect on this declaration."
   UnfoldTransparentName_           -> "Name mentioned in an `unfolding` clause is not `opaque`."
   UselessOpaque_                   -> "This `opaque` block has no effect."
+  -- Cubical
+  FaceConstraintCannotBeHidden_    -> "Face constraint patterns that are given as implicit arguments."
+  FaceConstraintCannotBeNamed_     -> "Face constraint patterns that are given as named arguments."

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -218,10 +218,13 @@ data Hiding  = Hidden | Instance Overlappable | NotHidden
   deriving (Show, Eq, Ord)
 
 instance Pretty Hiding where
-  pretty = \case
-    Hidden     -> "hidden"
-    NotHidden  -> "visible"
-    Instance{} -> "instance"
+  pretty = text . hidingToString
+
+hidingToString :: Hiding -> String
+hidingToString = \case
+  Hidden     -> "hidden"
+  NotHidden  -> "visible"
+  Instance{} -> "instance"
 
 -- | Just for the 'Hiding' instance. Should never combine different
 --   overlapping.
@@ -390,11 +393,11 @@ instance Applicative UnderComposition where
   (<*>) (UnderComposition f) (UnderComposition a) = pure (f a)
 
 -- | We have a tuple of modalities, which might not be fully orthogonal.
---   For instance, irrelevant stuff is also run-time irrelevant.
+--   For example, irrelevant stuff is also run-time irrelevant.
 data Modality = Modality
   { modRelevance :: Relevance
       -- ^ Legacy irrelevance.
-      --   See Pfenning, LiCS 2001; Abel/Vezzosi/Winterhalter, ICFP 2017.
+      --   See Pfenning, LiCS 2001; Abel, Vezzosi and Winterhalter, ICFP 2017.
   , modQuantity  :: Quantity
       -- ^ Cardinality / runtime erasure.
       --   See Conor McBride, I got plenty o' nutting, Wadlerfest 2016.

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1649,11 +1649,7 @@ class Verbalize a where
   verbalize :: a -> String
 
 instance Verbalize Hiding where
-  verbalize h =
-    case h of
-      Hidden     -> "hidden"
-      NotHidden  -> "visible"
-      Instance{} -> "instance"
+  verbalize = hidingToString
 
 instance Verbalize Relevance where
   verbalize r =

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4126,6 +4126,9 @@ data Warning
     -- ^ The 'pattern' declaration is useless in the presence
     --   of either @coinductive@ or @eta-equality@.
     --   Content of 'String' is "coinductive" or "eta", resp.
+  | UselessPragma Range Doc
+    -- ^ Warning when pragma is useless and thus ignored.
+    --   'Range' is for dead code highlighting.
   | UselessPublic
     -- ^ If the user opens a module public before the module header.
     --   (See issue #2377.)
@@ -4154,9 +4157,6 @@ data Warning
     -- ^ Harmless generic warning (not an error)
   | GenericNonFatalError     Doc
     -- ^ Generic error which doesn't abort proceedings (not a warning)
-  | GenericUseless  Range    Doc
-    -- ^ Generic warning when code is useless and thus ignored.
-    --   'Range' is for dead code highlighting.
 
   -- Safe flag errors
   | SafeFlagPostulate C.Name
@@ -4212,6 +4212,12 @@ data Warning
   | NotAffectedByOpaque
   | UnfoldTransparentName QName
   | UselessOpaque
+
+  -- Cubical
+  | FaceConstraintCannotBeHidden ArgInfo
+    -- ^ Face constraint patterns @(i = 0)@ must be visible arguments.
+  | FaceConstraintCannotBeNamed NamedName
+    -- ^ Face constraint patterns @(i = 0)@ must be unnamed arguments.
   deriving (Show, Generic)
 
 recordFieldWarningToError :: RecordFieldWarning -> TypeError
@@ -4244,7 +4250,7 @@ warningName = \case
   DuplicateUsing{}             -> DuplicateUsing_
   FixityInRenamingModule{}     -> FixityInRenamingModule_
   GenericNonFatalError{}       -> GenericNonFatalError_
-  GenericUseless{}             -> GenericUseless_
+  UselessPragma{}              -> UselessPragma_
   GenericWarning{}             -> GenericWarning_
   InversionDepthReached{}      -> InversionDepthReached_
   InteractionMetaBoundaries{}  -> InteractionMetaBoundaries_{}
@@ -4286,6 +4292,10 @@ warningName = \case
   NotAffectedByOpaque{}   -> NotAffectedByOpaque_
   UselessOpaque{}         -> UselessOpaque_
   UnfoldTransparentName{} -> UnfoldTransparentName_
+
+  -- Cubical
+  FaceConstraintCannotBeHidden{} -> FaceConstraintCannotBeHidden_
+  FaceConstraintCannotBeNamed{}  -> FaceConstraintCannotBeNamed_
 
 data TCWarning
   = TCWarning

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -35,7 +35,7 @@ import {-# SOURCE #-} Agda.TypeChecking.Pretty.Constraint (prettyInterestingCons
 import Agda.TypeChecking.Warnings (MonadWarning, isUnsolvedWarning, onlyShowIfUnsolved, classifyWarning, WhichWarnings(..), warning_)
 import {-# SOURCE #-} Agda.TypeChecking.MetaVars
 
-import Agda.Syntax.Common ( ImportedName'(..), fromImportedName, partitionImportedNames )
+import Agda.Syntax.Common ( getHiding, ImportedName'(..), fromImportedName, partitionImportedNames )
 import Agda.Syntax.Position
 import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Scope.Base ( concreteNamesInScope, NameOrModule(..) )
@@ -216,7 +216,7 @@ prettyWarning = \case
 
     GenericNonFatalError d -> return d
 
-    GenericUseless _r d -> return d
+    UselessPragma _r d -> return d
 
     SafeFlagPostulate e -> fsep $
       pwords "Cannot postulate" ++ [pretty e] ++ pwords "with safe flag"
@@ -351,6 +351,12 @@ prettyWarning = \case
       pwords "The name" ++ [prettyTCM qn <> ","] ++ pwords "mentioned by an unfolding clause, does not belong to an opaque block. This has no effect."
 
     UselessOpaque -> "This `opaque` block has no effect."
+
+    FaceConstraintCannotBeHidden ai -> fsep $
+      pwords "Face constraint patterns cannot be" ++ [ pretty (getHiding ai), "arguments"]
+
+    FaceConstraintCannotBeNamed x -> fsep $
+      pwords "Ignoring name" ++ ["`" <> pretty x <> "`"] ++ pwords "given to face constraint pattern"
 
 prettyRecordFieldWarning :: MonadPretty m => RecordFieldWarning -> m Doc
 prettyRecordFieldWarning = \case

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -82,7 +82,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20230724 * 10 + 0
+currentInterfaceVersion = 20230829 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -74,7 +74,7 @@ instance EmbPrj Warning where
     AsPatternShadowsConstructorOrPatternSynonym a -> icodeN 32 AsPatternShadowsConstructorOrPatternSynonym a
     DuplicateUsing a                      -> icodeN 33 DuplicateUsing a
     UselessHiding a                       -> icodeN 34 UselessHiding a
-    GenericUseless a b                    -> icodeN 35 GenericUseless a b
+    UselessPragma a b                     -> icodeN 35 UselessPragma a b
     RewriteAmbiguousRules a b c           -> icodeN 36 RewriteAmbiguousRules a b c
     RewriteMissingRule a b c              -> icodeN 37 RewriteMissingRule a b c
     ParseWarning a                        -> icodeN 38 ParseWarning a
@@ -86,6 +86,8 @@ instance EmbPrj Warning where
     UnfoldTransparentName nm              -> icodeN 44 UnfoldTransparentName nm
     UselessOpaque                         -> icodeN 45 UselessOpaque
     InlineNoExactSplit a b                -> icodeN 46 InlineNoExactSplit a b
+    FaceConstraintCannotBeHidden a        -> icodeN 47 FaceConstraintCannotBeHidden a
+    FaceConstraintCannotBeNamed a         -> icodeN 48 FaceConstraintCannotBeNamed a
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -123,7 +125,7 @@ instance EmbPrj Warning where
     [32, a]              -> valuN AsPatternShadowsConstructorOrPatternSynonym a
     [33, a]              -> valuN DuplicateUsing a
     [34, a]              -> valuN UselessHiding a
-    [35, a, b]           -> valuN GenericUseless a b
+    [35, a, b]           -> valuN UselessPragma a b
     [36, a, b, c]        -> valuN RewriteAmbiguousRules a b c
     [37, a, b, c]        -> valuN RewriteMissingRule a b c
     [38, a]              -> valuN ParseWarning a
@@ -135,6 +137,8 @@ instance EmbPrj Warning where
     [44, a]              -> valuN UnfoldTransparentName a
     [45]                 -> valuN UselessOpaque
     [46, a, b]           -> valuN InlineNoExactSplit a b
+    [47, a]              -> valuN FaceConstraintCannotBeHidden a
+    [48, a]              -> valuN FaceConstraintCannotBeNamed a
     _ -> malformed
 
 instance EmbPrj OptionWarning where
@@ -381,7 +385,7 @@ instance EmbPrj WarningName where
     DuplicateUsing_                              -> 47
     FixityInRenamingModule_                      -> 48
     GenericNonFatalError_                        -> 49
-    GenericUseless_                              -> 50
+    UselessPragma_                               -> 50
     GenericWarning_                              -> 51
     IllformedAsClause_                           -> 52
     InstanceArgWithExplicitArg_                  -> 53
@@ -433,6 +437,8 @@ instance EmbPrj WarningName where
     UnfoldTransparentName_                       -> 99
     UselessOpaque_                               -> 100
     InlineNoExactSplit_                          -> 101
+    FaceConstraintCannotBeHidden_                -> 102
+    FaceConstraintCannotBeNamed_                 -> 103
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -485,7 +491,7 @@ instance EmbPrj WarningName where
     47  -> return DuplicateUsing_
     48  -> return FixityInRenamingModule_
     49  -> return GenericNonFatalError_
-    50  -> return GenericUseless_
+    50  -> return UselessPragma_
     51  -> return GenericWarning_
     52  -> return IllformedAsClause_
     53  -> return InstanceArgWithExplicitArg_
@@ -537,6 +543,8 @@ instance EmbPrj WarningName where
     99  -> return UnfoldTransparentName_
     100 -> return UselessOpaque_
     101 -> return InlineNoExactSplit_
+    102 -> return FaceConstraintCannotBeHidden_
+    103 -> return FaceConstraintCannotBeNamed_
     _   -> malformed
 
 

--- a/test/Fail/Issue6795.err
+++ b/test/Fail/Issue6795.err
@@ -1,5 +1,5 @@
 Issue6795.agda:13,3-22
-warning: -W[no]GenericUseless
+warning: -W[no]UselessPragma
 Termination pragmas are ignored in where clauses
 (see https://github.com/agda/agda/issues/3355)
 when scope checking the declaration
@@ -9,7 +9,7 @@ when scope checking the declaration
       e : ⊥
       e = e
 Issue6795.agda:36,3-22
-warning: -W[no]GenericUseless
+warning: -W[no]UselessPragma
 Termination pragmas are ignored in record definitions
 (see https://github.com/agda/agda/issues/3008)
 when scope checking the declaration
@@ -18,7 +18,7 @@ when scope checking the declaration
     i : ⊥
     i = i
 Issue6795.agda:60,5-24
-warning: -W[no]GenericUseless
+warning: -W[no]UselessPragma
 Termination pragmas are ignored in record definitions
 (see https://github.com/agda/agda/issues/3008)
 when scope checking the declaration
@@ -28,7 +28,7 @@ when scope checking the declaration
       m : ⊥
       m = m
 Issue6795.agda:66,5-24
-warning: -W[no]GenericUseless
+warning: -W[no]UselessPragma
 Termination pragmas are ignored in record definitions
 (see https://github.com/agda/agda/issues/3008)
 when scope checking the declaration
@@ -38,7 +38,7 @@ when scope checking the declaration
       n : ⊥
       n = n
 Issue6795.agda:73,5-24
-warning: -W[no]GenericUseless
+warning: -W[no]UselessPragma
 Termination pragmas are ignored in where clauses
 (see https://github.com/agda/agda/issues/3355)
 when scope checking the declaration
@@ -53,7 +53,7 @@ when scope checking the declaration
         o' : ⊥
         o' = o'
 Issue6795.agda:78,5-24
-warning: -W[no]GenericUseless
+warning: -W[no]UselessPragma
 Termination pragmas are ignored in where clauses
 (see https://github.com/agda/agda/issues/3355)
 when scope checking the declaration

--- a/test/Succeed/Issue1137.warn
+++ b/test/Succeed/Issue1137.warn
@@ -1,5 +1,5 @@
 Issue1137.agda:12,3-22
-warning: -W[no]GenericUseless
+warning: -W[no]UselessPragma
 Termination pragmas are ignored in where clauses
 (see https://github.com/agda/agda/issues/3355)
 when scope checking the declaration
@@ -12,7 +12,7 @@ when scope checking the declaration
 ———— All done; warnings encountered ————————————————————————
 
 Issue1137.agda:12,3-22
-warning: -W[no]GenericUseless
+warning: -W[no]UselessPragma
 Termination pragmas are ignored in where clauses
 (see https://github.com/agda/agda/issues/3355)
 when scope checking the declaration

--- a/test/Succeed/Issue4769.warn
+++ b/test/Succeed/Issue4769.warn
@@ -1,12 +1,13 @@
 Issue4769.agda:11,46-52
-warning: -W[no]GenericUseless
+warning: -W[no]FaceConstraintCannotBeHidden
 Face constraint patterns cannot be instance arguments
 when scope checking the left-hand side
 foo i j ((i = i0)) ⦃ agdaDoesNotSeeThisName = ((j = i1)) ⦄ in the
 definition of foo
 Issue4769.agda:11,20-42
-warning: -W[no]GenericUseless
-Ignoring name 'agdaDoesNotSeeThisName' given to face constraint pattern
+warning: -W[no]FaceConstraintCannotBeNamed
+Ignoring name 'agdaDoesNotSeeThisName' given to face constraint
+pattern
 when scope checking the left-hand side
 foo i j ((i = i0)) ⦃ agdaDoesNotSeeThisName = ((j = i1)) ⦄ in the
 definition of foo
@@ -14,15 +15,16 @@ definition of foo
 ———— All done; warnings encountered ————————————————————————
 
 Issue4769.agda:11,46-52
-warning: -W[no]GenericUseless
+warning: -W[no]FaceConstraintCannotBeHidden
 Face constraint patterns cannot be instance arguments
 when scope checking the left-hand side
 foo i j ((i = i0)) ⦃ agdaDoesNotSeeThisName = ((j = i1)) ⦄ in the
 definition of foo
 
 Issue4769.agda:11,20-42
-warning: -W[no]GenericUseless
-Ignoring name 'agdaDoesNotSeeThisName' given to face constraint pattern
+warning: -W[no]FaceConstraintCannotBeNamed
+Ignoring name 'agdaDoesNotSeeThisName' given to face constraint
+pattern
 when scope checking the left-hand side
 foo i j ((i = i0)) ⦃ agdaDoesNotSeeThisName = ((j = i1)) ⦄ in the
 definition of foo


### PR DESCRIPTION
 The warning `GenericUseless` has been split into the three warnings `UselessPragma`, `FaceConstraintCannotBeHidden` and `FaceConstraintCannotBeNamed`.