### PR TITLE
Rename error warning `GenericNonFatalError` to `InvalidCharacterLiteral`

### DIFF
--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -450,7 +450,7 @@ warningHighlighting' b w = case tcWarning w of
   -- Andreas, 2020-03-21, issue #4456:
   -- Error warnings that do not have dedicated highlighting
   -- are highlighted as errors.
-  GenericNonFatalError{}                -> errorWarningHighlighting w
+  InvalidCharacterLiteral{}             -> errorWarningHighlighting w
   SafeFlagPostulate{}                   -> errorWarningHighlighting w
   SafeFlagPragma{}                      -> errorWarningHighlighting w
   SafeFlagWithoutKFlagPrimEraseEquality -> errorWarningHighlighting w

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -132,7 +132,7 @@ incompleteMatchWarnings = Set.fromList [ CoverageIssue_ ]
 errorWarnings :: Set WarningName
 errorWarnings = Set.fromList
   [ CoverageIssue_
-  , GenericNonFatalError_
+  , InvalidCharacterLiteral_
   , MissingDefinitions_
   , MissingDeclarations_
   , NotAllowedInMutual_
@@ -240,7 +240,7 @@ data WarningName
   | DeprecationWarning_
   | DuplicateUsing_
   | FixityInRenamingModule_
-  | GenericNonFatalError_
+  | InvalidCharacterLiteral_
   | UselessPragma_
   | GenericWarning_
   | IllformedAsClause_
@@ -419,7 +419,7 @@ warningNameDescription = \case
   CoverageNoExactSplit_            -> "Failed exact split checks."
   InlineNoExactSplit_              -> "Failed exact split checks after inlining record constructor."
   DeprecationWarning_              -> "Feature deprecation."
-  GenericNonFatalError_            -> ""
+  InvalidCharacterLiteral_         -> "Illegal character literals."
   UselessPragma_                   -> "Pragma that gets ignored."
   GenericWarning_                  -> ""
   IllformedAsClause_               -> "Illformed `as'-clauses in `import' statements."

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -436,10 +436,14 @@ checkOpen r mam x dir = do
 
 -- | Check a literal, issuing an error warning for bad literals.
 checkLiteral :: Literal -> ScopeM ()
-checkLiteral (LitChar c)
-  | isSurrogateCodePoint c = genericNonFatalError $ P.text $ "Invalid character literal " ++ show c ++
-                                                             " (surrogate code points are not supported)"
-checkLiteral _ = return ()
+checkLiteral = \case
+  LitChar   c   -> when (isSurrogateCodePoint c) $ warning $ InvalidCharacterLiteral c
+  LitNat    _   -> return ()
+  LitWord64 _   -> return ()
+  LitFloat  _   -> return ()
+  LitString _   -> return ()
+  LitQName  _   -> return ()
+  LitMeta   _ _ -> return ()
 
 {--------------------------------------------------------------------------
     Translation

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4118,6 +4118,8 @@ data Warning
     -- ^ If the user wrote something other than an unqualified name
     --   in the @as@ clause of an @import@ statement.
     --   The 'String' gives optionally extra explanation.
+  | InvalidCharacterLiteral Char
+    -- ^ A character literal Agda does not support, e.g. surrogate code points.
   | ClashesViaRenaming NameOrModule [C.Name]
     -- ^ If a `renaming' import directive introduces a name or module name clash
     --   in the exported names of a module.
@@ -4155,8 +4157,6 @@ data Warning
   -- Generic warnings for one-off things
   | GenericWarning           Doc
     -- ^ Harmless generic warning (not an error)
-  | GenericNonFatalError     Doc
-    -- ^ Generic error which doesn't abort proceedings (not a warning)
 
   -- Safe flag errors
   | SafeFlagPostulate C.Name
@@ -4249,7 +4249,7 @@ warningName = \case
   InstanceArgWithExplicitArg{} -> InstanceArgWithExplicitArg_
   DuplicateUsing{}             -> DuplicateUsing_
   FixityInRenamingModule{}     -> FixityInRenamingModule_
-  GenericNonFatalError{}       -> GenericNonFatalError_
+  InvalidCharacterLiteral{}    -> InvalidCharacterLiteral_
   UselessPragma{}              -> UselessPragma_
   GenericWarning{}             -> GenericWarning_
   InversionDepthReached{}      -> InversionDepthReached_

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -214,7 +214,9 @@ prettyWarning = \case
 
     GenericWarning d -> return d
 
-    GenericNonFatalError d -> return d
+    InvalidCharacterLiteral c -> fsep $
+      pwords "Invalid character literal" ++ [text $ show c] ++
+      pwords "(surrogate code points are not supported)"
 
     UselessPragma _r d -> return d
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -41,7 +41,7 @@ instance EmbPrj Warning where
     UselessPublic                         -> icodeN 3 UselessPublic
     UselessInline a                       -> icodeN 4 UselessInline a
     GenericWarning a                      -> icodeN 5 GenericWarning a
-    GenericNonFatalError a                -> __IMPOSSIBLE__
+    InvalidCharacterLiteral a             -> __IMPOSSIBLE__
     SafeFlagPostulate a                   -> __IMPOSSIBLE__
     SafeFlagPragma a                      -> __IMPOSSIBLE__
     SafeFlagWithoutKFlagPrimEraseEquality -> __IMPOSSIBLE__
@@ -384,7 +384,7 @@ instance EmbPrj WarningName where
     DeprecationWarning_                          -> 46
     DuplicateUsing_                              -> 47
     FixityInRenamingModule_                      -> 48
-    GenericNonFatalError_                        -> 49
+    InvalidCharacterLiteral_                     -> 49
     UselessPragma_                               -> 50
     GenericWarning_                              -> 51
     IllformedAsClause_                           -> 52
@@ -490,7 +490,7 @@ instance EmbPrj WarningName where
     46  -> return DeprecationWarning_
     47  -> return DuplicateUsing_
     48  -> return FixityInRenamingModule_
-    49  -> return GenericNonFatalError_
+    49  -> return InvalidCharacterLiteral_
     50  -> return UselessPragma_
     51  -> return GenericWarning_
     52  -> return IllformedAsClause_

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -2,7 +2,6 @@
 module Agda.TypeChecking.Warnings
   ( MonadWarning(..)
   , genericWarning
-  , genericNonFatalError
   , warning'_, warning_, warning', warning, warnings
   , raiseWarningsOnUsage
   , isUnsolvedWarning
@@ -83,10 +82,6 @@ instance MonadWarning TCM where
 {-# SPECIALIZE genericWarning :: P.Doc -> TCM () #-}
 genericWarning :: MonadWarning m => P.Doc -> m ()
 genericWarning = warning . GenericWarning
-
-{-# SPECIALIZE genericNonFatalError :: P.Doc -> TCM () #-}
-genericNonFatalError :: MonadWarning m => P.Doc -> m ()
-genericNonFatalError = warning . GenericNonFatalError
 
 {-# SPECIALIZE warning'_ :: CallStack -> Warning -> TCM TCWarning #-}
 warning'_ :: (MonadWarning m) => CallStack -> Warning -> m TCWarning


### PR DESCRIPTION
This is just an internal change, since these warnings cannot be switched by `-W`.

Closes #6808.
