### PR TITLE
Rewrite highlight-hover.js from scratch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -43,32 +43,3 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------
-
-The file src/data/html/highlight-hover.js (and the following licence
-text?) seems to use the following licence:
-
-Copyright 2002-2010, Simon Marlow.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
-IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/data/html/highlight-hover.js
+++ b/src/data/html/highlight-hover.js
@@ -5,18 +5,18 @@
 // To this end, we create a map from identifier to all of its occurrences in the beginning.
 
 // A dictionary from hrefs to 'a'-elements that have this href.
-var dict = new Map();
+const dict = new Map();
 
 window.onload = function () {
 
   // Get all 'a' tags with an 'href' attribute.
   // We call those "objects".
-  const objs  = [...document.getElementsByTagName('a')].filter((obj) => obj.hasAttribute('href'));
+  const objs  = document.getSelectorAll('a[href]');
 
   // Build a dictionary mapping a href to a set of objects that have this href.
   for (const obj of objs) {
     const key = obj.href;
-    var set = dict.get(key); if (set === undefined) { set = new Set(); }
+    const set = dict.get(key) ?? new Set();
     set.add(obj);
     dict.set(key, set);
   }

--- a/src/data/html/highlight-hover.js
+++ b/src/data/html/highlight-hover.js
@@ -1,32 +1,35 @@
-// Copyright 2002-2010, Simon Marlow.  All rights reserved.
-// https://github.com/haskell/haddock/blob/ghc-8.8/LICENSE
-// Slightly modified by Tesla Ice Zhang
+// Copyright 2023, Andreas Abel.
+// Falls under the Agda license at https://github.com/agda/agda/blob/master/LICENSE
 
-var highlight = function (on) {
-  return function () {
-    var links = document.getElementsByTagName('a');
-    for (var i = 0; i < links.length; i++) {
-      var that = links[i];
+// When we hover over an Agda identifier, we highlight all occurrences of this identifier on the page.
+// To this end, we create a map from identifier to all of its occurrences in the beginning.
 
-      if (this.href != that.href) {
-        continue;
-      }
-
-      if (on) {
-        that.classList.add("hover-highlight");
-      } else {
-        that.classList.remove("hover-highlight");
-      }
-    }
-  }
-};
+// A dictionary from hrefs to 'a'-elements that have this href.
+var dict = new Map();
 
 window.onload = function () {
-  var links = document.getElementsByTagName('a');
-  for (var i = 0; i < links.length; i++) {
-    var link = links[i];
-    if (!link.hasAttribute("href")) continue;
-    link.onmouseover = highlight(true);
-    link.onmouseout = highlight(false);
+
+  // Get all 'a' tags with an 'href' attribute.
+  // We call those "objects".
+  const objs  = [...document.getElementsByTagName('a')].filter((obj) => obj.hasAttribute('href'));
+
+  // Build a dictionary mapping a href to a set of objects that have this href.
+  for (const obj of objs) {
+    const key = obj.href;
+    var set = dict.get(key); if (set === undefined) { set = new Set(); }
+    set.add(obj);
+    dict.set(key, set);
+  }
+
+  // Install 'onmouseover' and 'onmouseout' event handlers for all objects.
+  for (const obj of objs) {
+    // 'onmouseover' for an object adds attribute 'hover-highlight' to all objects with the same href.
+    obj.onmouseover = function () {
+      for (const o of dict.get(this.href)) { o.classList.add('hover-highlight'); }
+    }
+    // 'onmouseover' removes the added 'hover-highlight' attributes again.
+    obj.onmouseout = function () {
+      for (const o of dict.get(this.href)) { o.classList.remove('hover-highlight'); }
+    }
   }
 };


### PR DESCRIPTION
The new implementation is noticeably faster for large `.html` files as it does not per event iterate through _all_ 'a' HTML elements on a page, but only those it needs to modify.

This is achieved by the use of the data structures natural to the problem.  We organize the 'a' elements in a map from their 'href' to the set of all 'a' elements that have the same 'href'.

Closes #6755 (again) by removing the alien license for the old `highlight-hover.js`.
