### PR TITLE
#6802: Forget about opacity when complaining about an unaffected definition

### DIFF
--- a/test/Succeed/Issue6802.agda
+++ b/test/Succeed/Issue6802.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS -WnoNotAffectedByOpaque -WnoUselessOpaque #-}
 module Issue6802 where
 
 open import Agda.Builtin.Nat

--- a/test/Succeed/Issue6802.agda
+++ b/test/Succeed/Issue6802.agda
@@ -1,0 +1,15 @@
+{-# OPTIONS -WnoNotAffectedByOpaque -WnoUselessOpaque #-}
+module Issue6802 where
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+-- Test case by Matthias Hutzler
+
+opaque
+  module _ where
+    foo : Nat
+    foo = zero
+
+test : foo ≡ zero
+test = refl  -- was error: foo != zero of type Nat

--- a/test/Succeed/Issue6802.warn
+++ b/test/Succeed/Issue6802.warn
@@ -1,0 +1,38 @@
+Issue6802.agda:9,3-11,15
+warning: -W[no]NotAffectedByOpaque
+Only functions and primitives can be marked opaque. This
+declaration will be treated as transparent.
+when scope checking the declaration
+  module _ where
+    foo : Nat
+    foo = zero
+Issue6802.agda:8,1-11,15
+warning: -W[no]UselessOpaque
+This 'opaque' block has no effect.
+when scope checking the declaration
+  opaque
+    unfolding {}
+    module _ where
+      foo : Nat
+      foo = zero
+
+———— All done; warnings encountered ————————————————————————
+
+Issue6802.agda:9,3-11,15
+warning: -W[no]NotAffectedByOpaque
+Only functions and primitives can be marked opaque. This
+declaration will be treated as transparent.
+when scope checking the declaration
+  module _ where
+    foo : Nat
+    foo = zero
+
+Issue6802.agda:8,1-11,15
+warning: -W[no]UselessOpaque
+This 'opaque' block has no effect.
+when scope checking the declaration
+  opaque
+    unfolding {}
+    module _ where
+      foo : Nat
+      foo = zero

--- a/test/Succeed/Issue6802a.agda
+++ b/test/Succeed/Issue6802a.agda
@@ -1,0 +1,13 @@
+{-# OPTIONS -WnoNotAffectedByOpaque -WnoUselessOpaque #-}
+module Issue6802a where
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+opaque
+  record Foo : Set where
+    foo : Nat
+    foo = zero
+
+test : Foo.foo _ ≡ zero
+test = refl

--- a/test/Succeed/Issue6802a.agda
+++ b/test/Succeed/Issue6802a.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS -WnoNotAffectedByOpaque -WnoUselessOpaque #-}
 module Issue6802a where
 
 open import Agda.Builtin.Nat

--- a/test/Succeed/Issue6802a.warn
+++ b/test/Succeed/Issue6802a.warn
@@ -1,0 +1,42 @@
+Issue6802a.agda:7,3-9,15
+warning: -W[no]NotAffectedByOpaque
+Only functions and primitives can be marked opaque. This
+declaration will be treated as transparent.
+when scope checking the declaration
+  record Foo where
+    foo : Nat
+    foo = zero
+Issue6802a.agda:6,1-9,15
+warning: -W[no]UselessOpaque
+This 'opaque' block has no effect.
+when scope checking the declaration
+  opaque
+    unfolding {}
+    mutual
+      record Foo : Set
+      record Foo where
+        foo : Nat
+        foo = zero
+
+———— All done; warnings encountered ————————————————————————
+
+Issue6802a.agda:7,3-9,15
+warning: -W[no]NotAffectedByOpaque
+Only functions and primitives can be marked opaque. This
+declaration will be treated as transparent.
+when scope checking the declaration
+  record Foo where
+    foo : Nat
+    foo = zero
+
+Issue6802a.agda:6,1-9,15
+warning: -W[no]UselessOpaque
+This 'opaque' block has no effect.
+when scope checking the declaration
+  opaque
+    unfolding {}
+    mutual
+      record Foo : Set
+      record Foo where
+        foo : Nat
+        foo = zero


### PR DESCRIPTION
Not only modules, but also records. There's a test case for a definition in an "opaque record" module, which is also unaffected.

The danger of `git commit -m` is that you have no indication whether your commit message is too long...