### PR TITLE
User manual: Improve documentation of options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,9 @@ jobs:
       name: User manual (test)
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-test
     - if: always()
+      name: User manual covers all options
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-covers-options
+    - if: always()
       name: User manual covers all warnings
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-covers-warnings
     - if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Pragmas and options
   - `--no-guarded`
   - `--no-injective-type-constructors`
   - `--no-keep-covering-clauses`
+  - `--no-lossy-unification`
   - `--no-keep-pattern-variables`
   - `--no-omega-in-omega`
   - `--no-postfix-projections`

--- a/Makefile
+++ b/Makefile
@@ -621,6 +621,11 @@ user-manual-test :
 		find doc/user-manual -type f -name '*.agdai' -delete; \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/UserManual)
 
+.PHONY : user-manual-covers-options
+user-manual-covers-options :
+	@$(call decorate, "User manual should mention all options", \
+          AGDA_BIN=$(AGDA_BIN) test/doc/user-manual-covers-options.sh)
+
 .PHONY : user-manual-covers-warnings
 user-manual-covers-warnings :
 	@$(call decorate, "User manual should mention all warnings", \

--- a/doc/user-manual/language/lossy-unification.lagda.rst
+++ b/doc/user-manual/language/lossy-unification.lagda.rst
@@ -5,7 +5,7 @@
 Lossy Unification
 *****************
 
-The option ``--lossy-unification`` enables an
+The option :option:`--lossy-unification` enables an
 experimental heuristic in the unification checker intended to improve
 its performance for unification problems of the form ``f es₀ = f es₁``,
 i.e. unifying two applications of the same defined function, here

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -202,6 +202,17 @@ Generating highlighted source code
      to ``M`` (even if ``M``'s file cannot be found via the
      ``include`` paths given in the ``.agda-lib`` file).
 
+.. option:: --highlight-occurrences
+
+     .. versionadded:: 2.6.2
+
+     When :ref:`generating HTML <generating-html>`,
+     place the :file:`highlight-hover.js` script
+     in the output directory (see :option:`--html-dir`).
+     In the presence of the script,
+     hovering over an identifier in the rendering of the HTML
+     will highlight all occurrences of the same identifier on the page.
+
 .. option:: --html
 
      .. versionadded:: 2.2.0

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -68,7 +68,7 @@ General options
          - | Use the effect of ``2``, but also print `Loading ...`
            | when a compiled module (interface) is accessed during the type-checking.
 
-.. option:: --colour[=(auto|always|never)]
+.. option:: --colour[=(auto|always|never)], --color[=(auto|always|never)]
 
     .. versionadded:: 2.6.4
 
@@ -105,7 +105,11 @@ General options
 
 .. option:: --version, -V
 
-     Show version number.
+     Show version number and cabal flags used in this build of Agda.
+
+.. option:: --numeric-version
+
+     Show just the version number.
 
 .. option:: --print-agda-dir
 
@@ -521,12 +525,14 @@ Experimental features
 
      Default, opposite of :option:`--allow-exec`.
 
-.. option:: --confluence-check, --local-confluence-check
+.. option:: --confluence-check, --local-confluence-check, --no-confluence-check
 
      .. versionadded:: 2.6.1
 
      Enable optional (global or local) confluence checking of REWRITE
      rules (see :ref:`confluence-check`).
+
+     Default is :option:`--no-confluence-check`.
 
 .. option:: --cubical
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -581,6 +581,16 @@ Experimental features
 
      Default, opposite of :option:`--injective-type-constructors`.
 
+.. option:: --irrelevant-projections, --no-irrelevant-projections
+
+     .. versionadded:: 2.5.4
+
+     Enable [disable] projection of irrelevant record fields (see
+     :ref:`irrelevance`). The option ``--irrelevant-projections``
+     makes Agda inconsistent.
+
+     Default (since version 2.6.1): ``--no-irrelevant-projections``.
+
 .. option:: --prop, --no-prop
 
      .. versionadded:: 2.6.0
@@ -951,16 +961,6 @@ Other features
      :option:`--sized-types`.
 
      Default: ``--no-guardedness`` (since 2.6.2).
-
-.. option:: --irrelevant-projections, --no-irrelevant-projections
-
-     .. versionadded:: 2.5.4
-
-     Enable [disable] projection of irrelevant record fields (see
-     :ref:`irrelevance`). The option ``--irrelevant-projections``
-     makes Agda inconsistent.
-
-     Default (since version 2.6.1): ``--no-irrelevant-projections``.
 
 .. option:: --no-print-pattern-synonyms
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -822,6 +822,65 @@ Pattern matching and equality
 
      Default: ``--no-large-indices``.
 
+Sorts and universes
+~~~~~~~~~~~~~~~~~~~
+
+.. option:: --type-in-type
+
+     Ignore universe levels (this makes Agda inconsistent; see
+     :ref:`type-in-type <type-in-type>`).
+
+.. option:: --no-type-in-type
+
+     .. versionadded:: 2.6.4
+
+     Default, opposite of :option:`--type-in-type`.
+
+.. option:: --omega-in-omega
+
+     .. versionadded:: 2.6.0
+
+     Enable typing rule ``Setω : Setω`` (this makes Agda inconsistent;
+     see :ref:`omega-in-omega <omega-in-omega>`).
+
+.. option:: --no-omega-in-omega
+
+     .. versionadded:: 2.6.4
+
+     Default, opposite of :option:`--omega-in-omega`.
+
+.. option:: --level-universe, --no-level-universe
+
+     .. versionadded:: 2.6.4
+
+     Makes ``Level`` live in its own universe ``LevelUniv`` and
+     disallows having levels depend on terms that are not levels themselves.
+     When this option is turned off, ``LevelUniv`` still exists,
+     but reduces to ``Set`` (see :ref:`level-universe <level-universe>`).
+
+     Note: While compatible with the :option:`--cubical` option, this option is
+     currently not compatible with cubical builtin files.
+
+     Default: :option:`--no-level-universe`.
+
+.. option:: --universe-polymorphism, --no-universe-polymorphism
+
+     .. versionadded:: 2.3.0
+
+     Enable [disable] universe polymorphism (see
+     :ref:`universe-levels`).
+
+     Default: ``--universe-polymorphism``.
+
+.. option:: --cumulativity, --no-cumulativity
+
+     .. versionadded:: 2.6.1
+
+     Enable [disable] cumulative subtyping of universes, i.e.,
+     if ``A : Set i`` then also ``A : Set j`` for all ``j >= i``.
+
+     Default: ``--no-cumulativity``.
+
 Search depth and instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -963,62 +1022,6 @@ Other features
      and :option:`--guardedness`.
 
      Default: ``--no-sized-types`` (since 2.6.2).
-
-.. option:: --type-in-type
-
-     Ignore universe levels (this makes Agda inconsistent; see
-     :ref:`type-in-type <type-in-type>`).
-
-.. option:: --no-type-in-type
-
-     .. versionadded:: 2.6.4
-
-     Default, opposite of :option:`--type-in-type`.
-
-.. option:: --omega-in-omega
-
-     .. versionadded:: 2.6.0
-
-     Enable typing rule ``Setω : Setω`` (this makes Agda inconsistent;
-     see :ref:`omega-in-omega <omega-in-omega>`).
-
-.. option:: --no-omega-in-omega
-
-     .. versionadded:: 2.6.4
-
-     Default, opposite of :option:`--omega-in-omega`.
-
-.. option:: --level-universe, --no-level-universe
-
-     .. versionadded:: 2.6.4
-
-     Makes ``Level`` live in its own universe ``LevelUniv`` and
-     disallows having levels depend on terms that are not levels themselves.
-     When this option is turned off, ``LevelUniv`` still exists,
-     but reduces to ``Set`` (see :ref:`level-universe <level-universe>`).
-
-     Note: While compatible with the :option:`--cubical` option, this option is
-     currently not compatible with cubical builtin files.
-
-     Default: :option:`--no-level-universe`.
-
-.. option:: --universe-polymorphism, --no-universe-polymorphism
-
-     .. versionadded:: 2.3.0
-
-     Enable [disable] universe polymorphism (see
-     :ref:`universe-levels`).
-
-     Default: ``--universe-polymorphism``.
-
-.. option:: --cumulativity, --no-cumulativity
-
-     .. versionadded:: 2.6.1
-
-     Enable [disable] cumulative subtyping of universes, i.e.,
-     if ``A : Set i`` then also ``A : Set j`` for all ``j >= i``.
-
-     Default: ``--no-cumulativity``.
 
 .. option:: --no-import-sorts
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1079,6 +1079,9 @@ Other features
      This option can affect performance. The default is to not save
      the meta-variables.
 
+Erasure
+~~~~~~~
+
 .. option:: --erasure, --no-erasure
 
      .. versionadded:: 2.6.4

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -602,7 +602,12 @@ Experimental features
      .. versionadded:: 2.6.2
 
      Enable a constraint-solving heuristic akin to first-order unification, see :ref:`lossy-unification`.
-     Off by default.
+
+.. option:: --no-lossy-unification
+
+     .. versionadded:: 2.6.4
+
+     Default, opposite of :option:`--lossy-unification`.
 
 .. option:: --prop, --no-prop
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -991,6 +991,19 @@ Other features
 
      Opposite of :option:`--double-check`.  On by default.
 
+.. option:: --keep-covering-clauses
+
+     .. versionadded:: 2.6.3
+
+     Save function clauses computed by the coverage checker to the interface file.
+     Required by some external backends.
+
+.. option:: --no-keep-covering-clauses
+
+     .. versionadded:: 2.6.4
+
+     Opposite of :option:`--keep-covering-clauses`, default.
+
 .. option:: --no-print-pattern-synonyms
 
      .. versionadded:: 2.5.4
@@ -1687,9 +1700,9 @@ again, the source file is re-typechecked instead:
 * :option:`--instance-search-depth`
 * :option:`--inversion-max-depth`
 * :option:`--irrelevant-projections`
-* ``--keep-covering-clauses``
+* :option:`--keep-covering-clauses`
 * :option:`--local-confluence-check`
-* ``--lossy-unification``
+* :option:`--lossy-unification`
 * :option:`--no-auto-inline`
 * :option:`--no-eta-equality`
 * :option:`--no-fast-reduce`

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -591,6 +591,13 @@ Experimental features
 
      Default (since version 2.6.1): ``--no-irrelevant-projections``.
 
+.. option:: --lossy-unification, --no-lossy-unification
+
+     .. versionadded:: 2.6.2
+
+     Enable a constraint-solving heuristic akin to first-order unification, see :ref:`lossy-unification`.
+     Off by default.
+
 .. option:: --prop, --no-prop
 
      .. versionadded:: 2.6.0

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -813,16 +813,6 @@ Pattern matching and equality
 
      Default: ``--infer-absurd-clauses``.
 
-.. option:: --forced-argument-recursion, --no-forced-argument-recursion
-
-     .. versionadded:: 2.6.4
-
-     Allow the use of forced constructor arguments as termination
-     metrics. This flag may be necessary for Agda to accept nontrivial
-     uses of induction-induction.
-
-     Default: ``--forced-argument-recursion``.
-
 .. option:: --large-indices, --no-large-indices
 
      .. versionadded:: 2.6.4
@@ -838,6 +828,52 @@ Pattern matching and equality
      When :option:`--no-forcing` is given, this option is redundant.
 
      Default: ``--no-large-indices``.
+
+Recursion
+~~~~~~~~~
+
+.. option:: --forced-argument-recursion, --no-forced-argument-recursion
+
+     .. versionadded:: 2.6.4
+
+     Allow the use of forced constructor arguments as termination
+     metrics. This flag may be necessary for Agda to accept nontrivial
+     uses of induction-induction.
+
+     Default: ``--forced-argument-recursion``.
+
+.. option:: --guardedness, --no-guardedness
+
+     .. versionadded:: 2.6.0
+
+     Enable [disable] constructor-based guarded corecursion (see
+     :ref:`coinduction`).
+
+     The option ``--guardedness`` is inconsistent with sized types,
+     thus, it cannot be used with both :option:`--safe` and
+     :option:`--sized-types`.
+
+     Default: ``--no-guardedness`` (since 2.6.2).
+
+.. option:: --sized-types, --no-sized-types
+
+     .. versionadded:: 2.2.0
+
+     Enable [disable] sized types (see :ref:`sized-types`).
+
+     The option ``--sized-types`` is inconsistent with
+     constructor-based guarded corecursion,
+     thus, it cannot be used with both :option:`--safe`
+     and :option:`--guardedness`.
+
+     Default: ``--no-sized-types`` (since 2.6.2).
+
+.. option:: --termination-depth={N}
+
+     .. versionadded:: 2.2.8
+
+     Allow termination checker to count decrease/increase upto ``N``
+     (default: 1; see :ref:`termination-checking`).
 
 Sorts and universes
 ~~~~~~~~~~~~~~~~~~~
@@ -915,13 +951,6 @@ Search depth and instances
      Set maximum depth for pattern match inversion to ``N`` (default:
      50). Should only be needed in pathological cases.
 
-.. option:: --termination-depth={N}
-
-     .. versionadded:: 2.2.8
-
-     Allow termination checker to count decrease/increase upto ``N``
-     (default: 1; see :ref:`termination-checking`).
-
 .. option:: --overlapping-instances, --no-overlapping-instances
 
      .. versionadded:: 2.6.0
@@ -955,19 +984,6 @@ Other features
      .. versionadded:: 2.6.2
 
      Opposite of :option:`--double-check`.  On by default.
-
-.. option:: --guardedness, --no-guardedness
-
-     .. versionadded:: 2.6.0
-
-     Enable [disable] constructor-based guarded corecursion (see
-     :ref:`coinduction`).
-
-     The option ``--guardedness`` is inconsistent with sized types,
-     thus, it cannot be used with both :option:`--safe` and
-     :option:`--sized-types`.
-
-     Default: ``--no-guardedness`` (since 2.6.2).
 
 .. option:: --no-print-pattern-synonyms
 
@@ -1016,19 +1032,6 @@ Other features
      and ``primTrustMe``. Prevents to have both :option:`--sized-types` and
      :option:`--guardedness` on.
      Further reading: :ref:`safe-agda`.
-
-.. option:: --sized-types, --no-sized-types
-
-     .. versionadded:: 2.2.0
-
-     Enable [disable] sized types (see :ref:`sized-types`).
-
-     The option ``--sized-types`` is inconsistent with
-     constructor-based guarded corecursion,
-     thus, it cannot be used with both :option:`--safe`
-     and :option:`--guardedness`.
-
-     Default: ``--no-sized-types`` (since 2.6.2).
 
 .. option:: --no-import-sorts
 

--- a/doc/user-manual/tools/compilers.lagda.rst
+++ b/doc/user-manual/tools/compilers.lagda.rst
@@ -29,26 +29,52 @@ The GHC backend translates Agda programs into GHC Haskell programs.
 Usage
 ^^^^^
 
-The backend can be invoked from the command line using the flag
-``--compile``:
+The GHC backend can be invoked from the command line using the flag
+:option:`--compile` or :option:`--ghc`:
 
 .. code-block:: bash
 
   agda --compile [--compile-dir=<DIR>] [--ghc-flag=<FLAG>]
     [--ghc-strict-data] [--ghc-strict] <FILE>.agda
 
-When the flag ``--ghc-strict-data`` is used inductive data and record
-constructors are compiled to constructors with strict arguments. (This
-does not apply to certain builtin types—lists, the maybe type, and
+When the flag :option:`--ghc-strict-data` is used, inductive data and record
+constructors are compiled to constructors with strict arguments.
+(This does not apply to certain builtin types—lists, the maybe type, and
 some types related to reflection—and might not apply to types with
 ``COMPILE GHC … = data …`` pragmas.)
 
-When the flag ``--ghc-strict`` is used the GHC backend generates
-mostly strict code. Note that functions might not be strict in unused
+When the flag :option:`--ghc-strict` is used, the GHC backend generates
+mostly strict code.  Note that functions might not be strict in unused
 arguments, and that function definitions coming from ``COMPILE GHC``
-pragmas are not affected. This flag implies ``--ghc-strict-data``, and
-the exceptions of that flag applies to this flag as well. (Note that
-this option requires the use of GHC 9 or later.)
+pragmas are not affected. This flag implies :option:`--ghc-strict-data`,
+and the exceptions of that flag applies to this flag as well.
+(Note that this option requires the use of GHC 9 or later.)
+
+Options
+~~~~~~~
+
+.. option:: --compile, --ghc
+
+     Compile to GHC Haskell placing the files in subdirectory ``MAlonzo`` or the directory given by :option:`--compile-dir`.
+     Then invoke ``ghc`` (or the compiler given by :option:`--with-compiler`) on the main file,
+     unless option :option:`--ghc-dont-call-ghc` is given.
+
+.. option:: --ghc-dont-call-ghc
+
+     Only produce Haskell files, skip the compilation to binary.
+
+.. option:: --ghc-flag={GHC-FLAG}
+
+     Pass flag :samp:`{GHC-FLAG}` to the Haskell compiler.  This option can be given several times.
+
+.. option:: --ghc-strict-data
+
+     Compile Agda constructor to strict Haskell constructors.
+
+.. option:: --ghc-strict
+
+     Generate strict Haskell code.
+
 
 Pragmas
 ^^^^^^^
@@ -86,7 +112,8 @@ you can run the HelloWorld program which prints ``Hello, World!``.
 
 .. warning:: Frequent error when compiling: ``Float`` requires the
   `ieee754 <http://hackage.haskell.org/package/ieee754>`_ haskell library.
-  Usually ``cabal install ieee754`` in the command line does the trick.
+  Usually ``cabal v1-install ieee754`` or ``cabal v2-install --lib ieee754``
+  in the command line does the trick.
 
 .. _javascript-backend:
 
@@ -98,22 +125,52 @@ The JavaScript backend translates Agda code to JavaScript code.
 Usage
 ^^^^^
 
-The backend can be invoked from the command line using the flag
-``--js``:
+The JavaScript backend can be invoked from the command line using the flag :option:`--js`:
 
 .. code-block:: bash
 
   agda --js [--js-optimize] [--js-minify] [--compile-dir=<DIR>] <FILE>.agda
 
-The ``--js-optimize`` flag makes the generated JavaScript code
+The :option:`--js-optimize` flag makes the generated JavaScript code
 typically faster and less readable.
 
-The ``--js-minify`` flag makes the generated JavaScript code
+The :option:`--js-minify` flag makes the generated JavaScript code
 smaller and less readable.
 
 Agda can currently generate either CommonJS (used by NodeJS) flavour modules or
-AMD (for in-browser usage) flavour modules which can be toggled by ``--js-cjs``
-(default) and ``--js-amd`` flags.
+AMD (for in-browser usage) flavour modules which can be toggled by :option:`--js-cjs`
+(default) and :option:`--js-amd` flags.
+
+Options
+~~~~~~~
+
+.. option:: --js
+
+     Compile to JavaScript, placing translation of module :samp:`{M}` into file :samp:`jAgda.{M}.js`.
+     The files will be placed into the root directory of the compiled Agda project,
+     or into the directory given by :option:`--compile-dir`.
+
+.. option:: --js-amd
+
+     Produce AMD style modules.
+
+.. option:: --js-cjs
+
+     Produce CommonJS style modules.
+     This is the default.
+
+.. option:: --js-minify
+
+     Produce minified JavaScript (e.g. omitting whitespace where possible).
+
+.. option:: --js-optimize
+
+     Produce optimized JavaScript.
+
+.. option:: --js-verify
+
+     Except for the main module, run the generated modules through ``node``,
+     to verify absence of syntax errors.
 
 
 Optimizations

--- a/doc/user-manual/tools/generating-html.rst
+++ b/doc/user-manual/tools/generating-html.rst
@@ -55,14 +55,14 @@ files, use ``--html-highlight=auto``, which means auto-detection.
 Options
 -------
 
-:samp:`--html-dir={directory}`
+:option:`--html-dir={DIR}`
   Changes the directory where the output is placed to
-  :samp:`{directory}`. Default: ``html``.
+  :samp:`{DIR}`. Default: ``html``.
 
-:samp:`--css={URL}`
+:option:`--css={URL}`
   The CSS_ file used by the HTML files (:samp:`{URL}` can be relative).
 
-:samp:`--html-highlight=[code,all,auto]`
+:option:`--html-highlight=[code,all,auto]`
   Highlight Agda code only or everything in the generated HTML files.
   Default: ``all``.
 

--- a/doc/user-manual/tools/generating-html.rst
+++ b/doc/user-manual/tools/generating-html.rst
@@ -23,11 +23,9 @@ your own CSS file instead of the :download:`default, included one
   Thus, you can get hold of the CSS file via
   :samp:`cat $(agda --print-agda-dir)/html/Agda.css`.
 
-You can also highlight all the occurrences of the symbol your mouse is
-hovering in the HTML by adding the ``--highlight-occurrences`` option.
-The default behaviour only highlight the single symbol your mouse is
-hovering. Note that this feature may cause browser performance problem,
-please enable it carefully (not recommended for huge files).
+You can also get highlighting for all occurrences of the symbol the mouse pointer is
+hovering over in the HTML by adding the :option:`--highlight-occurrences` option.
+The default behaviour is to only highlight the single symbol under the mouse pointer.
 
 If you're using Literate Agda with Markdown or reStructedText and you
 want to highlight your Agda codes with Agda's HTML backend and render

--- a/doc/user-manual/tools/generating-latex.rst
+++ b/doc/user-manual/tools/generating-latex.rst
@@ -156,9 +156,9 @@ Options
 The following command-line options change the behaviour of the LaTeX
 backend:
 
-``--latex-dir={directory}``
+:option:`--latex-dir={DIR}`
   Changes the output directory where :file:`agda.sty` and the output
-  :file:`.tex` file are placed to :samp:`{directory}`. Default:
+  :file:`.tex` file are placed to :samp:`{DIR}`. Default:
   ``latex``.
 
 :option:`--only-scope-checking`

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -1490,6 +1490,9 @@ deadStandardOptions =
     , removedOption "no-sharing" msgSharing
     , Option []     ["ignore-all-interfaces"] (NoArg ignoreAllInterfacesFlag) -- not deprecated! Just hidden
                     "ignore all interface files (re-type check everything, including builtin files)"
+      -- https://github.com/agda/agda/issues/3522#issuecomment-461010898
+      -- The option is "developer only", so it is hidden.
+      -- However, it is documented in the user manual.
     ] ++ map (fmap lensPragmaOptions) deadPragmaOptions
   where
     msgSharing = "(in favor of the Agda abstract machine)"

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -352,6 +352,10 @@ jobs:
       if: always() # run test even if a previous test failed
       #    13s (2022-06-17)
 
+    - name: "User manual covers all options"
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-covers-options
+      if: always() # run test even if a previous test failed
+
     - name: "User manual covers all warnings"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-covers-warnings
       if: always() # run test even if a previous test failed

--- a/test/doc/user-manual-covers-options.sh
+++ b/test/doc/user-manual-covers-options.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Andreas, 2023-09-01
+# A shell script to check whether all Agda options are documented in the user manual.
+
+# Options are documented in the following files of the user manual:
+DOC="doc/user-manual/tools/command-line-options.rst doc/user-manual/tools/compilers.lagda.rst"
+
+# 'agda --help' omits some options which are mentioned in the user manual:
+HIDDEN_OPTIONS="--ignore-all-interfaces" # https://github.com/agda/agda/issues/3522#issuecomment-461010898
+
+# We want to compute differences between the lists of existing and documented options.
+# To use the 'comm' tool to this end, we need to store those in intermediate files.
+TMPDIR=$(mktemp -d)
+DOCOPTS=$TMPDIR/documented-options.txt
+HELPOPTS=$TMPDIR/help-text-options.txt
+
+# Documented options
+grep -e '^.. option:: --\.*' $DOC | grep -oe '--[a-zA-Z-]\+' | sort | uniq > $DOCOPTS
+
+# Existing options
+(echo $HIDDEN_OPTIONS; $AGDA_BIN --help | grep -oe '--[a-zA-Z-]\+') | sort | uniq > $HELPOPTS
+
+# Options that are documented but don't exist any longer.
+REMOVED=$(comm -23 $DOCOPTS $HELPOPTS)
+  ## -23 means only column 1 of output (additions in $DOCOPTS), not 2 and 3.
+
+# Warn about non-existing options.
+if [ "x$REMOVED" != "x" ]; then
+  echo "Warning: The following options are not contained in the Agda help text but are still documentation in $DOC:"
+  for i in $REMOVED; do
+    echo "- $i"
+  done
+fi
+
+# Options that exist but are undocumented.
+UNDOCUMENTED=$(comm -13 $DOCOPTS $HELPOPTS)
+  ## -13 means only column 2 of output (additions in $HELPOPTS), not 1 and 3.
+
+# Print undocumented options and error out if we have one.
+if [ "x$UNDOCUMENTED" != "x" ]; then
+  echo "Error: The following Agda options lack a documentation in $DOC:"
+  for i in $UNDOCUMENTED; do
+    echo "- $i"
+  done
+  exit 1
+fi


### PR DESCRIPTION
- User manual HTML/LaTeX: properly link to options
- User manual: list option `--highlight-occurrences`
- User manual: compilers: list options
- User manual: new section for options related to universes/sorts
- User manual: move `--irrelevant-projections` to the experimental options list
- User manual: list option `--lossy-unification`
- User manual: separate section for erasure
- User manual: separate section for recursion (termination/guardedness)
- User manual: add some (formally) missing options and `--numeric-version`
- User manual: doc option `--keep-covering-clauses`

Rendering:
- https://agda--6816.org.readthedocs.build/en/6816/tools/command-line-options.html
- https://agda--6816.org.readthedocs.build/en/6816/tools/compilers.html#options
- https://agda--6816.org.readthedocs.build/en/6816/tools/compilers.html#id5

Closes #6269.
