### PR TITLE
emacs: load agda-mode for `.lagda.(tex|md|rst|org|typ)` files

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -368,9 +368,9 @@ Note that this variable is not buffer-local.")
 ;;;; agda2-mode
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.l?agda\\'" . agda2-mode))
+(add-to-list 'auto-mode-alist '("\\.\\(l?agda\\|lagda\\.\\(tex\\|md\\|rst\\|org\\|typ\\)\\)\\'" . agda2-mode))
 ;;;###autoload
-(modify-coding-system-alist 'file "\\.l?agda\\'" 'utf-8)
+(modify-coding-system-alist 'file "\\.\\(l?agda\\|lagda\\.\\(tex\\|md\\|rst\\|org\\|typ\\)\\)\\'" 'utf-8)
 ;;;###autoload
 (define-derived-mode agda2-mode prog-mode "Agda"
   "Major mode for Agda files.

--- a/src/data/emacs-mode/agda2.el
+++ b/src/data/emacs-mode/agda2.el
@@ -10,7 +10,7 @@
 
 (autoload 'agda2-mode "agda2-mode"
   "Major mode for editing Agda files (version ≥ 2)." t)
-(add-to-list 'auto-mode-alist '("\\.l?agda\\'" . agda2-mode))
-(modify-coding-system-alist 'file "\\.l?agda\\'" 'utf-8)
+(add-to-list 'auto-mode-alist '("\\.\\(l?agda\\|lagda\\.\\(tex\\|md\\|rst\\|org\\|typ\\)\\)\\'" . agda2-mode))
+(modify-coding-system-alist 'file "\\.\\(l?agda\\|lagda\\.\\(tex\\|md\\|rst\\|org\\|typ\\)\\)\\'" 'utf-8)
 
 (provide 'agda2)


### PR DESCRIPTION
Finish fixing https://github.com/agda/agda/issues/2837

Documentation for the regex format: https://www.emacswiki.org/emacs/AutoModeAlist

There's some unfortunate duplication there but I'd rather not mess with variables given the `;;;###autoload` dark magic.