### PR TITLE
test double check

### DIFF
--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -16,6 +16,9 @@ jobs:
     - name: Check encoding of Parser.y
       run: |
         make check-encoding
+    - name: Check invariants of the testsuite
+      run: |
+        make check-testsuite
     - name: Check building the source tarball
       run: |
         cabal sdist

--- a/Makefile
+++ b/Makefile
@@ -419,6 +419,7 @@ workflows :
 .PHONY : test ## Run all test suites.
 test : check-whitespace \
        check-encoding \
+       check-testsuite \
        common \
        succeed \
        fail \
@@ -621,10 +622,15 @@ user-manual-test :
 		find doc/user-manual -type f -name '*.agdai' -delete; \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/UserManual)
 
-.PHONY : user-manual-covers-warnings
+.PHONY : user-manual-covers-warnings ## Check that the user manual documents all Agda warnings.
 user-manual-covers-warnings :
 	@$(call decorate, "User manual should mention all warnings", \
           AGDA_BIN=$(AGDA_BIN) test/doc/user-manual-covers-warnings.sh)
+
+.PHONY : check-testsuite ## Check various invariants of the testsuite.
+check-testsuite :
+	@$(call decorate, "Successful and failing tests do not touch --double-check", \
+	  test/no-option-double-check.sh)
 
 .PHONY : testing-emacs-mode ##
 testing-emacs-mode:

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -161,7 +161,7 @@ findFile'' dirs m modFile =
   case Map.lookup m modFile of
     Just f  -> return (Right (SourceFile f), modFile)
     Nothing -> do
-      files          <- fileList acceptableFileExts
+      files          <- fileList agdaFileExtensions
       existingFiles  <-
         liftIO $ filterM (doesFileExistCaseSensitive . filePath . srcFilePath) files
       case nubOn id existingFiles of
@@ -278,7 +278,7 @@ parseFileExtsShortList = ".agda" : literateExtsShortList
 
 dropAgdaExtension :: String -> String
 dropAgdaExtension s = case catMaybes [ stripSuffix ext s
-                                     | ext <- acceptableFileExts ] of
+                                     | ext <- agdaFileExtensions ] of
     [name] -> name
     _      -> __IMPOSSIBLE__
 

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -23,6 +23,7 @@ import Prelude hiding (null)
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Trans
+import Data.Functor ( (<&>) )
 import Data.Maybe (catMaybes)
 import qualified Data.Map as Map
 import qualified Data.Text as T
@@ -161,13 +162,12 @@ findFile'' dirs m modFile =
     Just f  -> return (Right (SourceFile f), modFile)
     Nothing -> do
       files          <- fileList acceptableFileExts
-      filesShortList <- fileList parseFileExtsShortList
       existingFiles  <-
         liftIO $ filterM (doesFileExistCaseSensitive . filePath . srcFilePath) files
-      return $ case nubOn id existingFiles of
-        []     -> (Left (NotFound filesShortList), modFile)
-        [file] -> (Right file, Map.insert m (srcFilePath file) modFile)
-        files  -> (Left (Ambiguous existingFiles), modFile)
+      case nubOn id existingFiles of
+        []     -> fileList parseFileExtsShortList <&> \ fs -> (Left (NotFound fs), modFile)
+        [file] -> return (Right file, Map.insert m (srcFilePath file) modFile)
+        files  -> return (Left (Ambiguous existingFiles), modFile)
   where
     fileList exts = mapM (fmap SourceFile . absolute)
                     [ filePath dir </> file

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -240,13 +240,16 @@ runAgdaWithOptions interactor progName opts = do
 
           -- Print accumulated warnings
           unlessNullM (tcWarnings . classifyWarnings <$> getAllWarnings AllWarnings) $ \ ws -> do
-            let banner = text $ "\n" ++ delimiter "All done; warnings encountered"
             reportSDoc "warning" 1 $
-              vcat $ punctuate "\n" $ banner : (prettyTCM <$> ws)
+              vcat $ ("" :) $ punctuate "\n" $ text warningsBanner : (prettyTCM <$> ws)
 
           return result
 
-
+-- | A banner preceding the printout of accumulated warnings.
+-- (Recognized by the testsuite.)
+--
+warningsBanner :: String
+warningsBanner = delimiter "All done; warnings encountered"
 
 -- | Print usage information.
 printUsage :: [Backend] -> Help -> IO ()

--- a/src/full/Agda/Syntax/Parser.hs
+++ b/src/full/Agda/Syntax/Parser.hs
@@ -9,7 +9,7 @@ module Agda.Syntax.Parser
       -- * Parsers
     , moduleParser
     , moduleNameParser
-    , acceptableFileExts
+    , agdaFileExtensions
     , exprParser
     , exprWhereParser
     , holeContentParser
@@ -171,10 +171,14 @@ parsePosString ::
   Parser a -> Position -> String -> PM (a, Attributes)
 parsePosString p pos = wrapM . return . M.parsePosString pos (parseFlags p) normalLexState (parser p)
 
--- | Extensions supported by `parseFile`.
+-- | List of valid extensions of Agda source files.
+--
+--   These extensions are supported by 'parseFile'.
+--
+--   Towards single source of truth: this list is also used by the test suite.
 
-acceptableFileExts :: [String]
-acceptableFileExts = ".agda" : (fst <$> literateProcessors)
+agdaFileExtensions :: [String]
+agdaFileExtensions = ".agda" : (fst <$> literateProcessors)
 
 parseFile
   :: Show a
@@ -195,7 +199,7 @@ parseFile p file input =
 
     go [] = throwError InvalidExtensionError
                    { errPath = file
-                   , errValidExts = acceptableFileExts
+                   , errValidExts = agdaFileExtensions
                    }
     go ((ext, (po, ft)) : pos)
       | ext `List.isSuffixOf` path =

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -739,14 +739,13 @@ checkClause t withSub c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats rhs0 wh 
 
         body <- return $ body `mplus` wbody
 
-        whenM (optDoubleCheck <$> pragmaOptions) $ case body of
-          Just v  -> do
+        whenM (optDoubleCheck <$> pragmaOptions) $
+          whenJust body $ \ v -> do
             reportSDoc "tc.lhs.top" 30 $ vcat
               [ "double checking rhs"
               , nest 2 (prettyTCM v <+> " : " <+> prettyTCM (unArg trhs))
               ]
             noConstraints $ withFrozenMetas $ checkInternal v CmpLeq $ unArg trhs
-          Nothing -> return ()
 
         reportSDoc "tc.lhs.top" 10 $ vcat
           [ "Clause before translation:"

--- a/src/github/workflows/whitespace.yml
+++ b/src/github/workflows/whitespace.yml
@@ -22,6 +22,10 @@ jobs:
       run: |
         make check-encoding
 
+    - name: Check invariants of the testsuite
+      run: |
+        make check-testsuite
+
     - name: Check building the source tarball
       run: |
         cabal sdist

--- a/test/Fail/Issue4283.agda
+++ b/test/Fail/Issue4283.agda
@@ -1,5 +1,7 @@
---{-# OPTIONS -vtc:50 #-}
-{-# OPTIONS --double-check #-}
+-- Hot fix (Jesper, 2019-12-14)of de Bruijn issue in
+-- https://github.com/agda/agda/commit/a30c7be25a3085246154f41cbb472119e229b580
+-- "Replace one use of inTopContext with unsafeInTopContext"
+-- "TODO: find the fundamental cause and switch back to inTopContext"
 
 open import Agda.Primitive
 
@@ -39,3 +41,8 @@ module _ (l : Level) (BADNESS : Set) (A : Set l) (r : R l A) where
   -- ^ works if definition of lemma is removed
 
   test = λ _ → unbox _ _ boxed
+
+-- Expected error:
+--
+-- Failed to solve the following constraints:
+--   _43 (p = refl) = refl : Id l A (w/e l A) (w/e l A) (blocked on _43)

--- a/test/Fail/Issue4283.err
+++ b/test/Fail/Issue4283.err
@@ -1,6 +1,6 @@
 Failed to solve the following constraints:
   _43 (p = refl) = refl : Id l A (w/e l A) (w/e l A) (blocked on _43)
 Unsolved metas at the following locations:
-  Issue4283.agda:38,60-61
-  Issue4283.agda:38,14-110
-  Issue4283.agda:41,12-13
+  Issue4283.agda:40,60-61
+  Issue4283.agda:40,14-110
+  Issue4283.agda:43,12-13

--- a/test/Succeed/AntiUnifyBug.agda
+++ b/test/Succeed/AntiUnifyBug.agda
@@ -1,8 +1,6 @@
 -- Jesper, 2019-07-27. Cut down this example from a latent bug in
 -- @antiUnify@, which was using @unAbs@ instead of @absBody@.
 
-{-# OPTIONS --double-check #-}
-
 open import Agda.Primitive
 
 postulate

--- a/test/Succeed/Issue4158.agda
+++ b/test/Succeed/Issue4158.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --rewriting --confluence-check --double-check #-}
+{-# OPTIONS --rewriting --confluence-check #-}
 
 data _==_ {A : Set} : (x y : A) → Set where
   refl : {a : A} → a == a

--- a/test/Succeed/Issue5478.agda
+++ b/test/Succeed/Issue5478.agda
@@ -1,7 +1,6 @@
 -- Andreas, 2021-07-25, issue #5478 reported by mrohman
 
 {-# OPTIONS --allow-unsolved-metas #-}
-{-# OPTIONS --double-check #-}
 
 -- {-# OPTIONS -v impossible:70 #-}
 -- {-# OPTIONS -v tc:20 #-}

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,6 +1,9 @@
 
-module Utils (module Utils,
-              AgdaError(..)) where
+module Utils
+  ( module Utils
+  , AgdaError(..)
+  , agdaFileExtensions
+  ) where
 
 import Control.Applicative
 import Control.Arrow ((&&&))
@@ -41,6 +44,7 @@ import Test.Tasty.Silver.Advanced ( GDiff(..), pattern ShowText, goldenTest1, re
 import qualified Text.Regex.TDFA as R
 import qualified Text.Regex.TDFA.Text as RT ( compile )
 
+import Agda.Syntax.Parser             ( agdaFileExtensions )
 import Agda.Compiler.MAlonzo.Compiler ( ghcInvocationStrings )
 import Agda.Interaction.ExitCode      ( AgdaError(..), agdaErrorFromInt )
 import Agda.Utils.Maybe
@@ -154,17 +158,6 @@ getEnvVar :: String -> IO (Maybe String)
 getEnvVar v =
   lookup v <$> getEnvironment
 
--- | List of possible extensions of agda files.
-agdaExtensions :: [String]
-agdaExtensions =
-  [ ".agda"
-  , ".lagda"
-  , ".lagda.tex"
-  , ".lagda.rst"
-  , ".lagda.md"
-  , ".lagda.org"
-  ]
-
 -- | List of files paired with agda files by the test suites.
 -- E.g. files recording the accepted output or error message.
 helperExtensions :: [String]
@@ -180,7 +173,7 @@ stripAnyOfExtensions :: [String] -> FilePath -> Maybe FilePath
 stripAnyOfExtensions exts p = listToMaybe $ catMaybes $ map (`stripExtension` p) exts
 
 stripAgdaExtension :: FilePath -> Maybe FilePath
-stripAgdaExtension = stripAnyOfExtensions agdaExtensions
+stripAgdaExtension = stripAnyOfExtensions agdaFileExtensions
 
 stripHelperExtension :: FilePath -> Maybe FilePath
 stripHelperExtension = stripAnyOfExtensions helperExtensions

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -44,6 +44,7 @@ import Test.Tasty.Silver.Advanced ( GDiff(..), pattern ShowText, goldenTest1, re
 import qualified Text.Regex.TDFA as R
 import qualified Text.Regex.TDFA.Text as RT ( compile )
 
+import Agda.Main                      ( warningsBanner )
 import Agda.Syntax.Parser             ( agdaFileExtensions )
 import Agda.Compiler.MAlonzo.Compiler ( ghcInvocationStrings )
 import Agda.Interaction.ExitCode      ( AgdaError(..), agdaErrorFromInt )
@@ -107,8 +108,7 @@ runAgdaWithOptions testName opts mflag mvars = do
       pure backup
 
   let agdaArgs = opts ++ words flags
-  let runAgda  = \ extraArgs -> let args = agdaArgs ++ extraArgs in
-                                readAgdaProcessWithExitCode args T.empty
+  let runAgda extraArgs = readAgdaProcessWithExitCode (agdaArgs ++ extraArgs) T.empty
   (ret, stdOut, stdErr) <- do
     if not $ null $ List.intersect agdaArgs ghcInvocationStrings
       -- Andreas, 2017-04-14, issue #2317
@@ -135,11 +135,11 @@ runAgdaWithOptions testName opts mflag mvars = do
         -- Andreas, 2020-09-22: according to the documentation of getEnvironment,
         -- a missing '=' might mean to set the variable to the empty string.
 
-hasWarning :: Text -> Bool
-hasWarning t =
- "———— All done; warnings encountered ————————————————————————"
- `T.isInfixOf` t
 
+-- | Check whether Agda output contains warnings.
+--
+hasWarning :: Text -> Bool
+hasWarning = T.isInfixOf $ T.pack warningsBanner
 
 getEnvAgdaArgs :: IO AgdaArgs
 getEnvAgdaArgs = maybe [] words <$> getEnvVar "AGDA_ARGS"

--- a/test/no-option-double-check.sh
+++ b/test/no-option-double-check.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Andreas, 2023-09-03, error on '--double-check' in 'Succeed' and 'Fail' suites.
+#
+# No test in Succeed or Fail should turn on --double-check manually.
+# This would override the control by the test suite runners.
+#
+# Run this script from the Agda repo root.
+
+# On macOS, 'grep -R' is a magnitude faster than 'find -exec grep'.
+BAD=$(grep -R -l -e '--double-check' --include=\*.{agda,lagda,lagda.\*,flags} test/Succeed test/Fail)
+
+if [ "x$BAD" != "x" ]; then
+  echo "Error: the following files supply the --double-check option which is already given by the test runner."
+  for i in $BAD; do
+    echo "- $i"
+  done
+  echo "Please remove this option from these files so that it can be controlled by the runner."
+  exit 1
+fi


### PR DESCRIPTION
- Cosmetics: use `whenJust`
- Cosmetics: computation of `filesShortList` only when needed
- Use a single definition of Agda file extensions for agda and testsuite.
- Re #6818: remove redundant `--double-check`; always on in Succeed/ Fail/
