### PR TITLE
Fix search on readthedocs.org

### DIFF
--- a/doc/user-manual/conf.py
+++ b/doc/user-manual/conf.py
@@ -43,7 +43,8 @@ needs_sphinx = '6.0.0'
 extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
-    'sphinx.ext.imgconverter'
+    'sphinx.ext.imgconverter',
+    'sphinxcontrib.jquery'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -81,7 +82,7 @@ import sphinx_rtd_theme
 
 html_theme = "sphinx_rtd_theme"
 
-# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.

--- a/doc/user-manual/conf.py
+++ b/doc/user-manual/conf.py
@@ -81,7 +81,7 @@ import sphinx_rtd_theme
 
 html_theme = "sphinx_rtd_theme"
 
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.

--- a/doc/user-manual/requirements.txt
+++ b/doc/user-manual/requirements.txt
@@ -1,2 +1,2 @@
 Sphinx           >= 6.0.0
-sphinx_rtd_theme >= 1.2.0
+sphinx_rtd_theme >= 1.2.2

--- a/doc/user-manual/requirements.txt
+++ b/doc/user-manual/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx           >= 6.0.0
-sphinx_rtd_theme >= 1.2.2
+Sphinx           >= 7.2.5
+sphinx_rtd_theme >= 1.3.0


### PR DESCRIPTION
Searching the docs of Agda 2.6.4 RC1 seems to hang, see e.g. https://agda.readthedocs.io/en/v2.6.3.20230805/search.html?q=instance&check_keywords=yes&area=default#

Fix search on readthedocs.org by bumping sphinx_rtd_theme to 1.2.2.
1.2.2 includes https://github.com/readthedocs/sphinx_rtd_theme/pull/1448 which fixes the issue, https://github.com/readthedocs/sphinx_rtd_theme/issues/1452.

Test this on: https://agda--6821.org.readthedocs.build/en/6821/search.html?q=instance&check_keywords=yes&area=default
