### PR TITLE
Fix #6823: add ranges to the names lacking a definition

### DIFF
--- a/test/Fail/ImplicitMutualInterleavedMutual.err
+++ b/test/Fail/ImplicitMutualInterleavedMutual.err
@@ -1,5 +1,6 @@
 ImplicitMutualInterleavedMutual.agda:6,1-8,13
-The following name is declared, but not accompanied by a
-definition: test.
+The following names are declared, but not accompanied by a
+definition:
+- test (at ImplicitMutualInterleavedMutual.agda:5,1-5)
 Since 'interleaved mutual' blocks can not participate in mutual
-recursion, its definition must be given before this point.
+recursion, their definition must be given before this point.

--- a/test/Fail/ImplicitMutualMutual.err
+++ b/test/Fail/ImplicitMutualMutual.err
@@ -1,5 +1,6 @@
 ImplicitMutualMutual.agda:6,1-8,13
-The following name is declared, but not accompanied by a
-definition: test.
-Since 'mutual' blocks can not participate in mutual recursion, its
-definition must be given before this point.
+The following names are declared, but not accompanied by a
+definition:
+- test (at ImplicitMutualMutual.agda:5,1-5)
+Since 'mutual' blocks can not participate in mutual recursion,
+their definition must be given before this point.

--- a/test/Fail/ImplicitMutualOpaque.err
+++ b/test/Fail/ImplicitMutualOpaque.err
@@ -1,5 +1,6 @@
 ImplicitMutualOpaque.agda:6,1-8,13
-The following name is declared, but not accompanied by a
-definition: test.
-Since 'opaque' blocks can not participate in mutual recursion, its
-definition must be given before this point.
+The following names are declared, but not accompanied by a
+definition:
+- test (at ImplicitMutualOpaque.agda:5,1-5)
+Since 'opaque' blocks can not participate in mutual recursion,
+their definition must be given before this point.

--- a/test/Fail/Issue3932-2.err
+++ b/test/Fail/Issue3932-2.err
@@ -1,5 +1,6 @@
 Issue3932-2.agda:6,1-7,9
-The following name is declared, but not accompanied by a
-definition: f.
-Since 'mutual' blocks can not participate in mutual recursion, its
-definition must be given before this point.
+The following names are declared, but not accompanied by a
+definition:
+- f (at Issue3932-2.agda:4,1-2)
+Since 'mutual' blocks can not participate in mutual recursion,
+their definition must be given before this point.

--- a/test/Fail/Issue3932.err
+++ b/test/Fail/Issue3932.err
@@ -1,5 +1,6 @@
 Issue3932.agda:31,5-32,14
-The following name is declared, but not accompanied by a
-definition: A.
-Since 'mutual' blocks can not participate in mutual recursion, its
-definition must be given before this point.
+The following names are declared, but not accompanied by a
+definition:
+- A (at Issue3932.agda:29,5-6)
+Since 'mutual' blocks can not participate in mutual recursion,
+their definition must be given before this point.

--- a/test/Fail/MissingDefinitions.agda
+++ b/test/Fail/MissingDefinitions.agda
@@ -28,3 +28,16 @@ mutual
   data T₂ : U₂ → Set
   V₂ : (u₂ : U₂) → T₂ u₂ → Set
   data W₂ (u₂ : U₂) (t₂ : T₂ u₂) : V₂ u₂ t₂ → Set
+
+-- Andreas, 2023-09-07, issue #6823
+-- Updated error to include range of names that lack a definition
+
+-- MissingDefinitions.agda:25,1-30,50
+-- The following names are declared, but not accompanied by a definition:
+-- - Q (at MissingDefinitions.agda:5,1-2)
+-- - U (at MissingDefinitions.agda:7,6-7)
+-- - V (at MissingDefinitions.agda:13,1-2)
+-- - W (at MissingDefinitions.agda:14,1-2)
+-- - X (at MissingDefinitions.agda:18,3-4)
+-- Since 'mutual' blocks can not participate in mutual recursion,
+-- their definition must be given before this point.

--- a/test/Fail/MissingDefinitions.err
+++ b/test/Fail/MissingDefinitions.err
@@ -1,5 +1,10 @@
 MissingDefinitions.agda:25,1-30,50
 The following names are declared, but not accompanied by a
-definition: Q, U, V, W, X.
+definition:
+- Q (at MissingDefinitions.agda:5,1-2)
+- U (at MissingDefinitions.agda:7,6-7)
+- V (at MissingDefinitions.agda:13,1-2)
+- W (at MissingDefinitions.agda:14,1-2)
+- X (at MissingDefinitions.agda:18,3-4)
 Since 'mutual' blocks can not participate in mutual recursion,
 their definition must be given before this point.


### PR DESCRIPTION
The range in this case is already part of the `Name`, so we zap the extra (unused) ranges from `DisallowedInterleaveMutual`.

I also zapped the singular version because a singleton bullet list can also be introduced in plural.
Could be brought back using the `singPlural` combinator.

Closes #6823.

Prior art:
- #6622
