### PR TITLE
Fix #6805: Propagate surrounding opacity to type signatures

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -232,7 +232,7 @@ instance Pretty NiceDeclaration where
     NiceField _ _ _ _ _ x _        -> text "field" <+> pretty x
     PrimitiveFunction _ _ _ x _    -> text "primitive" <+> pretty x
     NiceMutual{}                   -> text "mutual"
-    NiceOpaque{}                   -> text "opaque"
+    NiceOpaque _ _ ds              -> text "opaque" <+> nest 2 (vcat (map pretty ds))
     NiceModule _ _ _ _ x _ _       -> text "module" <+> pretty x <+> text "where"
     NiceModuleMacro _ _ _ x _ _ _  -> text "module" <+> pretty x <+> text "= ..."
     NiceOpen _ x _                 -> text "open" <+> pretty x

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2149,7 +2149,8 @@ instance ToAbstract NiceDeclaration where
         let isMacro | kind == MacroName = MacroDef
                     | otherwise         = NotMacroDef
         bindName p kind x y
-        return $ A.Axiom kind (mkDefInfoInstance x f p a i isMacro r) info mp y t'
+        definfo <- updateDefInfoOpacity $ mkDefInfoInstance x f p a i isMacro r
+        return $ A.Axiom kind definfo info mp y t'
       toAbstractNiceAxiom _ _ = __IMPOSSIBLE__
 
       interestingOpaqueDecl :: A.Declaration -> Bool

--- a/test/Fail/Issue6805.agda
+++ b/test/Fail/Issue6805.agda
@@ -1,0 +1,4 @@
+module Issue6805 where
+
+opaque
+  A = Set

--- a/test/Fail/Issue6805.err
+++ b/test/Fail/Issue6805.err
@@ -1,0 +1,11 @@
+Issue6805.agda:4,3-10
+warning: -W[no]GenericWarning
+Missing type signature for opaque definition A.
+Types of opaque definitions are never inferred since this would
+leak information that should be opaque.
+Failed to solve the following constraints:
+  Set₂ = _0 (blocked on _0)
+  Set₁ =< _1 (blocked on _1)
+Unsolved metas at the following locations:
+  Issue6805.agda:4,3-4
+  Issue6805.agda:4,7-10


### PR DESCRIPTION
Freezing metas that are created in a type signature only happens if _the type signature itself_ is marked opaque; not if the name is marked opaque. That makes sense, and wasn't happening before.

Fixes #6805 