### PR TITLE
Fix #6829: "pattern variable shadows constructor" for record constructors

### DIFF
--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -154,6 +154,11 @@ data DataOrRecord
   | IsRecord PatternOrCopattern
   deriving (Show, Eq, Generic)
 
+instance PatternMatchingAllowed DataOrRecord where
+  patternMatchingAllowed = \case
+    IsData -> True
+    IsRecord patCopat -> patternMatchingAllowed patCopat
+
 instance CopatternMatchingAllowed DataOrRecord where
   copatternMatchingAllowed = \case
     IsData -> False

--- a/src/full/Agda/TypeChecking/Datatypes.hs
+++ b/src/full/Agda/TypeChecking/Datatypes.hs
@@ -254,9 +254,9 @@ isDataOrRecordType d = do
     _          -> return $ Nothing
 
 -- | Precodition: 'Term' is 'reduce'd.
-isDataOrRecord :: Term -> TCM (Maybe QName)
+isDataOrRecord :: Term -> TCM (Maybe (QName, DataOrRecord))
 isDataOrRecord = \case
-    Def d _ -> fmap (const d) <$> isDataOrRecordType d
+    Def d _ -> fmap (d,) <$> isDataOrRecordType d
     _       -> return Nothing
 
 getNumberOfParameters :: HasConstInfo m => QName -> m (Maybe Nat)

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1051,7 +1051,7 @@ disambiguateConstructor cs0 args t = do
          "target type: " <+> prettyTCM t1
        -- If we don't have a target type yet, try to look at the argument types.
        ifBlocked t1 (\ b _ -> disambiguateByArgs dcs $ return $ Left b) $ \ _ t' ->
-         caseMaybeM (isDataOrRecord $ unEl t') (badCon t') $ \ d -> do
+         caseMaybeM (isDataOrRecord $ unEl t') (badCon t') $ \ (d, _) -> do
            let dcs' = filter ((d ==) . fst3) dcs
            case map thd3 dcs' of
              [c] -> decideOn c

--- a/test/Fail/PatternShadowsRecordConstructor.agda
+++ b/test/Fail/PatternShadowsRecordConstructor.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2023-09-08, issue #6829
+-- The "pattern variable shadow constructor" alert should also be raised
+-- for pattern record constructors.
+
+module PatternShadowsRecordConstructor where
+
+module A where
+
+  record B : Set where
+    constructor x; no-eta-equality; pattern
+
+  data C : Set where
+    c : B → C
+
+open A using (C; c)
+
+f : C → C
+f (c x) = c x
+
+-- Expected alert:
+--
+-- The pattern variable x has the same name as the constructor A.x
+-- when checking the clause left hand side
+-- f (c x)

--- a/test/Fail/PatternShadowsRecordConstructor.err
+++ b/test/Fail/PatternShadowsRecordConstructor.err
@@ -1,0 +1,4 @@
+PatternShadowsRecordConstructor.agda:18,6-7
+The pattern variable x has the same name as the constructor A.x
+when checking the clause left hand side
+f (c x)

--- a/test/Succeed/PatternShadowsRecordConstructor.agda
+++ b/test/Succeed/PatternShadowsRecordConstructor.agda
@@ -1,0 +1,20 @@
+-- Andreas, 2023-09-08, issue #6829
+-- The "pattern variable shadow constructor" alert should not be raised
+-- for record constructors that do not allow pattern matching.
+
+module PatternShadowsRecordConstructor where
+
+module A where
+
+  record B : Set where
+    constructor x; no-eta-equality -- no 'pattern' directive here!
+
+  data C : Set where
+    c : B → C
+
+open A using (C; c)
+
+f : C → C
+f (c x) = c x
+
+-- Should succeed without warning.


### PR DESCRIPTION
The check that no pattern variable shadows a constructor (from 2009) did not cover record constructors (which could be matched on from 2010, Agda 2.2.8).

This (modular) rewrite adds the check for pattern record constructors.
Record constructors you cannot match on are not considered, as this would result in unjustified alerts.
(Remember that the motivation for this check is to prevent unintended behavior changes of Agda code when bringing more constructors into scope.)

Closes #6829.
