### PR TITLE
Fix #6829 also for record constructors not explicitly marked as `pattern`

### DIFF
--- a/test/Fail/PatternShadowsRecordConstructor2.agda
+++ b/test/Fail/PatternShadowsRecordConstructor2.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2023-09-08, issue #6829
+-- The "pattern variable shadow constructor" alert should also be raised
+-- for pattern record constructors.
+
+module PatternShadowsRecordConstructor2 where
+
+module A where
+
+  record B : Set where
+    constructor x
+
+  data C : Set where
+    c : B → C
+
+open A using (C; c)
+
+f : C → C
+f (c x) = c x
+
+-- Expected alert:
+--
+-- The pattern variable x has the same name as the constructor A.x
+-- when checking the clause left hand side
+-- f (c x)

--- a/test/Fail/PatternShadowsRecordConstructor2.err
+++ b/test/Fail/PatternShadowsRecordConstructor2.err
@@ -1,0 +1,4 @@
+PatternShadowsRecordConstructor2.agda:18,6-7
+The pattern variable x has the same name as the constructor A.x
+when checking the clause left hand side
+f (c x)


### PR DESCRIPTION
Fix #6829 also for record constructors not explicitly marked as `pattern`.

PR #6831 did not include generation of warnings for shadowing of pattern variables by record constructors that were only _inferred_ to be matchable.

The problem was that the information in `IsRecord` on whether pattern matching is allowed was not taking the latest information contained in `recEtaEquality'` into account.

Fixed this and added a test case.