### PR TITLE
Restrict pattern matching in binding position to eta-equality records

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -225,7 +225,7 @@ errorString err = case err of
   ShouldBePi{}                             -> "ShouldBePi"
   ShouldBePath{}                           -> "ShouldBePath"
   ShouldBeRecordType{}                     -> "ShouldBeRecordType"
-  ShouldBeEtaRecordPattern{}               -> "ShouldBeRecordEtaPattern"
+  ShouldBeEtaRecordPattern{}               -> "ShouldBeEtaRecordPattern"
   NotAProjectionPattern{}                  -> "NotAProjectionPattern"
   ShouldEndInApplicationOfTheDatatype{}    -> "ShouldEndInApplicationOfTheDatatype"
   SplitError{}                             -> "SplitError"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -225,7 +225,7 @@ errorString err = case err of
   ShouldBePi{}                             -> "ShouldBePi"
   ShouldBePath{}                           -> "ShouldBePath"
   ShouldBeRecordType{}                     -> "ShouldBeRecordType"
-  ShouldBeRecordPattern{}                  -> "ShouldBeRecordPattern"
+  ShouldBeEtaRecordPattern{}               -> "ShouldBeRecordEtaPattern"
   NotAProjectionPattern{}                  -> "NotAProjectionPattern"
   ShouldEndInApplicationOfTheDatatype{}    -> "ShouldEndInApplicationOfTheDatatype"
   SplitError{}                             -> "SplitError"
@@ -364,8 +364,13 @@ instance PrettyTCM TypeError where
     ShouldBeRecordType t -> fsep $
       pwords "Expected non-abstract record type, found " ++ [prettyTCM t]
 
-    ShouldBeRecordPattern p -> fsep $
-      pwords "Expected record pattern" -- ", found " ++ [prettyTCM p]
+    ShouldBeEtaRecordPattern why p -> fsep $
+      let
+        reason = case why of
+          NotEtaRecord -> pwords "record types with eta-equality, but this constructor belongs to a record type without eta-equality."
+          DataNotRecord -> pwords "record types, but this constructor belongs to a data type."
+      in pwords "Pattern matching in binders is only allowed for"
+          <> reason
 
     NotAProjectionPattern p -> fsep $
       pwords "Not a valid projection for a copattern: " ++ [ prettyA p ]

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4481,7 +4481,7 @@ data TypeError
             -- ^ The given type should have been a pi.
         | ShouldBePath Type
         | ShouldBeRecordType Type
-        | ShouldBeRecordPattern DeBruijnPattern
+        | ShouldBeEtaRecordPattern NotEtaRecord DeBruijnPattern
         | NotAProjectionPattern (NamedArg A.Pattern)
         | NotAProperTerm
         | InvalidTypeSort Sort
@@ -4659,6 +4659,14 @@ data TypeError
         | InstanceSearchDepthExhausted Term Type Int
         | TriedToCopyConstrainedPrim QName
           deriving (Show, Generic)
+
+-- | Distinguish between a failure of irrefutable record-pattern
+-- translation because the type is not a record, or because the type has
+-- no eta equality
+data NotEtaRecord
+  = DataNotRecord
+  | NotEtaRecord
+  deriving (Eq, Show, Generic)
 
 -- | Distinguish error message when parsing lhs or pattern synonym, resp.
 data LHSOrPatSyn = IsLHS | IsPatSyn
@@ -5690,4 +5698,5 @@ instance NFData NegativeUnification
 instance NFData UnificationFailure
 instance NFData UnquoteError
 instance NFData TypeError
+instance NFData NotEtaRecord
 instance NFData LHSOrPatSyn

--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -83,8 +83,7 @@ recordPatternToProjections p =
       reportSLn "tc.rec" 70 $ "  type raw: " ++ show t
       case unEl t of
         Def r _ -> fmap theDef (getConstInfo r) >>= \case
-          rt@Record { recFields = fields } | YesEta == recEtaEquality rt -> do
-            fields <- getRecordTypeFields t
+          rt@Record { recFields = fields } | YesEta == recEtaEquality rt ->
             concat <$> zipWithM comb (map proj fields) (map namedArg ps)
           _ -> typeError (ShouldBeEtaRecordPattern NotEtaRecord p)
         _ -> __IMPOSSIBLE_VERBOSE__ "recordPatternToProjections: ConP can only belong to a record or data type."

--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -60,29 +60,39 @@ import Agda.Utils.Impossible
 --
 --   E.g. for @(x , (y , z))@ we return @[ fst, fst . snd, snd . snd ]@.
 --
---   If it is not a record pattern, error 'ShouldBeRecordPattern' is raised.
+--   If it is not a record pattern, error 'ShouldBeEtaRecordPattern' is raised.
 recordPatternToProjections :: DeBruijnPattern -> TCM [Term -> Term]
 recordPatternToProjections p =
   case p of
     VarP{}       -> return [ id ]
-    LitP{}       -> typeError $ ShouldBeRecordPattern p
-    DotP{}       -> typeError $ ShouldBeRecordPattern p
+    LitP{}       -> impossible "LitP"
+
+    DotP{}       -> impossible "DotP"
+    IApplyP{}    -> impossible "IApplyP"
+    DefP{}       -> impossible "DefP"
+    ProjP{}      -> impossible "ProjP"
+
     ConP c ci ps -> do
       unless (conPRecord ci) $
-        typeError $ ShouldBeRecordPattern p
-      let t = unArg $ fromMaybe __IMPOSSIBLE__ $ conPType ci
+        typeError $ ShouldBeEtaRecordPattern DataNotRecord p
+      t <- reduce (unArg $ fromMaybe __IMPOSSIBLE__ $ conPType ci)
       reportSDoc "tc.rec" 45 $ vcat
         [ "recordPatternToProjections: "
         , nest 2 $ "constructor pattern " <+> prettyTCM p <+> " has type " <+> prettyTCM t
         ]
       reportSLn "tc.rec" 70 $ "  type raw: " ++ show t
-      fields <- getRecordTypeFields t
-      concat <$> zipWithM comb (map proj fields) (map namedArg ps)
-    ProjP{}      -> __IMPOSSIBLE__ -- copattern cannot appear here
-    IApplyP{}    -> typeError $ ShouldBeRecordPattern p
-    DefP{}       -> typeError $ ShouldBeRecordPattern p
+      case unEl t of
+        Def r _ -> fmap theDef (getConstInfo r) >>= \case
+          rt@Record { recFields = fields } | YesEta == recEtaEquality rt -> do
+            fields <- getRecordTypeFields t
+            concat <$> zipWithM comb (map proj fields) (map namedArg ps)
+          _ -> typeError (ShouldBeEtaRecordPattern NotEtaRecord p)
+        _ -> __IMPOSSIBLE_VERBOSE__ "recordPatternToProjections: ConP can only belong to a record or data type."
   where
     proj p = (`applyE` [Proj ProjSystem $ unDom p])
+
+    impossible pat = __IMPOSSIBLE_VERBOSE__ $ "recordPatternToProjections: " ++ pat ++ " is ruled out by checkValidLetPattern"
+
     comb :: (Term -> Term) -> DeBruijnPattern -> TCM [Term -> Term]
     comb prj p = map (\ f -> f . prj) <$> recordPatternToProjections p
 

--- a/test/Fail/LetPair.err
+++ b/test/Fail/LetPair.err
@@ -1,3 +1,4 @@
 LetPair.agda:17,7-18
-Expected record pattern
+Pattern matching in binders is only allowed for record types, but
+this constructor belongs to a data type.
 when checking the let binding a , b = p

--- a/test/Fail/LetPatternData.agda
+++ b/test/Fail/LetPatternData.agda
@@ -1,0 +1,10 @@
+module LetPatternData where
+
+open import Agda.Builtin.Equality
+
+data Wrap (A : Set) : Set where
+  wrap : A → Wrap A
+open Wrap
+
+fails : ∀ {A} → Wrap A → Set
+fails w = let wrap a = w in _

--- a/test/Fail/LetPatternData.err
+++ b/test/Fail/LetPatternData.err
@@ -1,4 +1,4 @@
-Issue4775.agda:16,11-24
+LetPatternData.agda:10,15-25
 Pattern matching in binders is only allowed for record types, but
 this constructor belongs to a data type.
-when checking the let binding y1 , isSuc y2 = .patternInTele0
+when checking the let binding wrap a = w

--- a/test/Fail/LetPatternEta.agda
+++ b/test/Fail/LetPatternEta.agda
@@ -1,0 +1,14 @@
+module LetPatternEta where
+
+open import Agda.Builtin.Equality
+
+record Wrap (A : Set) : Set where
+  constructor wrap; no-eta-equality; pattern
+  field unwrap : A
+open Wrap
+
+fails : ∀ {A} → Wrap A → Set
+fails = \(wrap a) → a
+
+-- fails : ∀ {A} → Wrap A → Set
+-- fails w = let wrap a = w in _

--- a/test/Fail/LetPatternEta.err
+++ b/test/Fail/LetPatternEta.err
@@ -1,0 +1,5 @@
+LetPatternEta.agda:11,11-17
+Pattern matching in binders is only allowed for record types with
+eta-equality, but this constructor belongs to a record type without
+eta-equality.
+when checking the let binding wrap a = .patternInTele0

--- a/test/Fail/TelescopePatternEta.agda
+++ b/test/Fail/TelescopePatternEta.agda
@@ -1,0 +1,10 @@
+module TelescopePatternEta where
+
+open import Agda.Builtin.Equality
+
+record Wrap (A : Set) : Set where
+  constructor wrap; no-eta-equality; pattern
+  field unwrap : A
+open Wrap
+
+module _ {A} (w@(wrap a) : Wrap A) where

--- a/test/Fail/TelescopePatternEta.err
+++ b/test/Fail/TelescopePatternEta.err
@@ -1,0 +1,5 @@
+TelescopePatternEta.agda:10,15-24
+Pattern matching in binders is only allowed for record types with
+eta-equality, but this constructor belongs to a record type without
+eta-equality.
+when checking the let binding wrap a = w


### PR DESCRIPTION
Takes the nuclear approach but fixes #6825. I also took the opportunity to improve the error messages for this failure and to mark several other cases as impossible (with an explanation).