### PR TITLE
Re #6801: remove unused module TypeChecking.EtaExpand

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -604,7 +604,6 @@ library
       Agda.TypeChecking.DropArgs
       Agda.TypeChecking.Empty
       Agda.TypeChecking.EtaContract
-      Agda.TypeChecking.EtaExpand
       Agda.TypeChecking.Errors
       Agda.TypeChecking.Free
       Agda.TypeChecking.Free.Lazy

--- a/src/full/Agda/TypeChecking/EtaExpand.hs
+++ b/src/full/Agda/TypeChecking/EtaExpand.hs
@@ -1,35 +1,40 @@
-{-# OPTIONS_GHC -Wunused-imports #-}
+-- Andr(e)as, 2023-09-14, issue #6801
+-- This module is unused, but with -f optimise-heavily it takes 15 sec
+-- (top 5!) to compile.  So, removing it.
+-- https://andraskovacs.github.io/misc/agda-build-timings/optimise/report.html (accessed 2023-09-14)
 
--- | Compute eta long normal forms.
-module Agda.TypeChecking.EtaExpand where
+-- {-# OPTIONS_GHC -Wunused-imports #-}
 
-import Agda.Syntax.Common
-import Agda.Syntax.Internal
+-- -- | Compute eta long normal forms.
+-- module Agda.TypeChecking.EtaExpand where
 
-import Agda.TypeChecking.CheckInternal
-import Agda.TypeChecking.Monad
-import Agda.TypeChecking.Records
-import Agda.TypeChecking.Reduce
-import Agda.TypeChecking.Substitute
+-- import Agda.Syntax.Common
+-- import Agda.Syntax.Internal
 
--- | Eta-expand a term if its type is a function type or an eta-record type.
-etaExpandOnce :: PureTCM m => Type -> Term -> m Term
-etaExpandOnce a v = reduce a >>= \case
-  El _ (Pi a b) -> return $
-    Lam ai $ mkAbs (absName b) $ raise 1 v `apply` [ Arg ai $ var 0 ]
-    where ai = domInfo a
+-- import Agda.TypeChecking.CheckInternal
+-- import Agda.TypeChecking.Monad
+-- import Agda.TypeChecking.Records
+-- import Agda.TypeChecking.Reduce
+-- import Agda.TypeChecking.Substitute
 
-  a -> isEtaRecordType a >>= \case
-    Just (r, pars) -> do
-      def <- theDef <$> getConstInfo r
-      (_, con, ci, args) <- etaExpandRecord_ r pars def v
-      return $ mkCon con ci args
-    Nothing -> return v
+-- -- | Eta-expand a term if its type is a function type or an eta-record type.
+-- etaExpandOnce :: PureTCM m => Type -> Term -> m Term
+-- etaExpandOnce a v = reduce a >>= \case
+--   El _ (Pi a b) -> return $
+--     Lam ai $ mkAbs (absName b) $ raise 1 v `apply` [ Arg ai $ var 0 ]
+--     where ai = domInfo a
 
--- | Eta-expand functions and expressions of eta-record
--- type wherever possible.
-deepEtaExpand :: Term -> Type -> TCM Term
-deepEtaExpand v a = checkInternal' etaExpandAction v CmpLeq a
+--   a -> isEtaRecordType a >>= \case
+--     Just (r, pars) -> do
+--       def <- theDef <$> getConstInfo r
+--       (_, con, ci, args) <- etaExpandRecord_ r pars def v
+--       return $ mkCon con ci args
+--     Nothing -> return v
 
-etaExpandAction :: PureTCM m => Action m
-etaExpandAction = defaultAction { preAction = etaExpandOnce  }
+-- -- | Eta-expand functions and expressions of eta-record
+-- -- type wherever possible.
+-- deepEtaExpand :: Term -> Type -> TCM Term
+-- deepEtaExpand v a = checkInternal' etaExpandAction v CmpLeq a
+
+-- etaExpandAction :: PureTCM m => Action m
+-- etaExpandAction = defaultAction { preAction = etaExpandOnce  }


### PR DESCRIPTION
Remove unused module `TypeChecking.EtaExpand`.

Should save 15sec in build with `-f optimise-heavily`.
See: https://github.com/agda/agda/issues/6801#issuecomment-1719055864

Found this when investigating #6801 with @AndrasKovacs.
- #6801
