### PR TITLE
Add XDG Base Directory support

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -111,13 +111,20 @@ General options
 
      Show just the version number.
 
-.. option:: --print-agda-dir
+.. option:: --print-agda-app-dir
+
+     .. versionadded:: 2.6.4
+
+     Outputs the (:envvar:`AGDA_DIR`) directory containing Agda's
+     application configuration files, such as the ``defaults`` and
+     ``libraries`` files, as described in :ref:`package-system`.
+
+.. option:: --print-agda-data-dir
 
      .. versionadded:: 2.6.2
 
-     Outputs the root (:envvar:`AGDA_DIR`)
-     of the directory structure holding Agda's data files
-     such as core libraries, style files for the backends etc.
+     Outputs the root of the directory structure holding Agda's data
+     files such as core libraries, style files for the backends etc.
 
 .. option:: --transliterate
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -130,7 +130,7 @@ General options
      .. versionadded:: 2.6.4
 
      Outputs the root of the directory structure holding Agda's data
-     files such as core libraries, style files for the backends etc.
+     files such as core libraries, style files for the backends, etc.
 
 .. option:: --transliterate
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -119,9 +119,15 @@ General options
      application configuration files, such as the ``defaults`` and
      ``libraries`` files, as described in :ref:`package-system`.
 
-.. option:: --print-agda-data-dir
+.. option:: --print-agda-dir
 
      .. versionadded:: 2.6.2
+
+     Alias of :option:`--print-agda-data-dir`.
+
+.. option:: --print-agda-data-dir
+
+     .. versionadded:: 2.6.4
 
      Outputs the root of the directory structure holding Agda's data
      files such as core libraries, style files for the backends etc.

--- a/doc/user-manual/tools/generating-html.rst
+++ b/doc/user-manual/tools/generating-html.rst
@@ -18,10 +18,10 @@ your own CSS file instead of the :download:`default, included one
 .. note::
 
   The :file:`Agda.css` shipped with Agda is located at
-  :file:`{${AGDA_DIR}}/html/Agda.css`.  Since version 2.6.2, the
-  :envvar:`AGDA_DIR` is printed by option :option:`--print-agda-dir`.
-  Thus, you can get hold of the CSS file via
-  :samp:`cat $(agda --print-agda-dir)/html/Agda.css`.
+  :file:`{${AGDA_DATA_DIR}}/html/Agda.css`.  Since version 2.6.2, the
+  Agda data directory is printed by option
+  :option:`--print-agda-data-dir`. Thus, you can get hold of the CSS
+  file via :samp:`cat $(agda --print-agda-data-dir)/html/Agda.css`.
 
 You can also get highlighting for all occurrences of the symbol the mouse pointer is
 hovering over in the HTML by adding the :option:`--highlight-occurrences` option.

--- a/doc/user-manual/tools/generating-latex.rst
+++ b/doc/user-manual/tools/generating-latex.rst
@@ -32,10 +32,10 @@ from :file:`agda.sty`.
 .. note::
 
   The :file:`agda.sty` shipped with Agda is located at
-  :file:`{${AGDA_DIR}}/latex/agda.sty`.  Since version 2.6.2, the
-  :envvar:`AGDA_DIR` is printed by option :option:`--print-agda-dir`.
-  Thus, you can get hold of the CSS file via
-  :samp:`cat $(agda --print-agda-dir)/latex/agda.sty`.
+  :file:`{${AGDA_DIR}}/latex/agda.  Since version 2.6.2, the
+  Agda data directory is printed by option
+  :option:`--print-agda-data-dir`. Thus, you can get hold of the class
+  file via :samp:`cat $(agda --print-agda-data-dir)/latex/agda.sty`.
 
 .. _unicode-latex:
 
@@ -544,7 +544,7 @@ issuing the command
 
 .. code-block:: console
 
-   $ cp $(agda --print-agda-dir)/latex/postprocess-latex.pl .
+   $ cp $(agda --print-agda-data-dir)/latex/postprocess-latex.pl .
 
 In order to generate a PDF, you can then do the following:
 

--- a/doc/user-manual/tools/package-system.rst
+++ b/doc/user-manual/tools/package-system.rst
@@ -37,8 +37,8 @@ to do two things:
 
    (Of course, replace ``AGDA_STDLIB`` by the actual path.)
 
-   The ``AGDA_DIR`` defaults to ``~/.agda`` on unix-like systems and
-   ``C:\Users\USERNAME\AppData\Roaming\agda`` or similar on Windows.
+   The ``AGDA_DIR`` defaults to ``~/.config/agda`` on unix-like systems
+   and ``C:\Users\USERNAME\AppData\Roaming\agda`` or similar on Windows.
    (More on ``AGDA_DIR`` below.)
 
    Remark: The ``libraries`` file informs Agda about the libraries you want it to know
@@ -135,9 +135,13 @@ To be found by Agda a library file has to be listed (with its full path) in a
 - ``AGDA_DIR/libraries``
 
 where ``VERSION`` is the Agda version (for instance ``2.5.1``). The
-``AGDA_DIR`` defaults to ``~/.agda`` on unix-like systems and
+``AGDA_DIR`` defaults to ``~/.config/agda`` on unix-like systems and
 ``C:\Users\USERNAME\AppData\Roaming\agda`` or similar on Windows, and can be
-overridden by setting the ``AGDA_DIR`` environment variable.
+overridden by setting the :envvar:``AGDA_DIR`` environment variable.
+
+The ``AGDA_DIR`` will fall-back to ``~/.agda``, if it exists, for
+backward compatibility reasons. You can find the precise location of
+``AGDA_DIR``  by running ``agda --print-agda-app-dir``.
 
 Each line of the libraries file shall be the absolute file system path to
 the root of a library, or a comment line starting with ``--`` followed by a space character.

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -1,7 +1,7 @@
 # The Agda data directory
 
 After installation, this directory is replicated under the location
-given by `agda --print-agda-dir`.
+given by `agda --print-agda-data-dir`.
 
 It contains files needed by Agda, its backends, and the Emacs mode.
 

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -20,6 +20,7 @@
 --
 module Agda.Interaction.Library
   ( findProjectRoot
+  , getAgdaAppDir
   , getDefaultLibraries
   , getInstalledLibraries
   , getTrustedExecutables
@@ -126,7 +127,10 @@ mkLibM libs m = do
 getAgdaAppDir :: IO FilePath
 getAgdaAppDir = do
   -- System-specific command to build the path to ~/.agda (Unix) or %APPDATA%\agda (Win)
-  let agdaDir = getAppUserDataDirectory "agda"
+  let agdaDir = getAppUserDataDirectory "agda" >>= \legacyAgdaDir ->
+        ifM (doesDirectoryExist legacyAgdaDir)
+            (pure legacyAgdaDir)
+            (getXdgDirectory XdgConfig "agda")
   -- The default can be overwritten by setting the AGDA_DIR environment variable
   caseMaybeM (lookupEnv "AGDA_DIR") agdaDir $ \ dir ->
       ifM (doesDirectoryExist dir) (canonicalizePath dir) $ do

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -1439,11 +1439,15 @@ standardOptions =
                     , intercalate ", " $ map fst allHelpTopics
                     ]
 
-    , Option []     ["print-agda-data-dir"] (NoArg printAgdaDataDirFlag)
-                    ("print Agda data directory exit")
+    , Option []     ["print-agda-dir"] (NoArg printAgdaDataDirFlag)
+                    ("print the Agda data directory exit")
 
     , Option []     ["print-agda-app-dir"] (NoArg printAgdaAppDirFlag)
                     ("print $AGDA_DIR and exit")
+
+    , Option []     ["print-agda-data-dir"] (NoArg printAgdaDataDirFlag)
+                    ("print the Agda data directory exit")
+
 
     , Option ['I']  ["interactive"] (NoArg interactiveFlag)
                     "start in interactive mode"

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -279,7 +279,8 @@ data CommandLineOptions = Options
        -- ^ Configure notifications about imported modules.
   , optTrustedExecutables    :: Map ExeName FilePath
        -- ^ Map names of trusted executables to absolute paths.
-  , optPrintAgdaDir          :: Bool
+  , optPrintAgdaDataDir      :: Bool
+  , optPrintAgdaAppDir       :: Bool
   , optPrintVersion          :: Maybe PrintAgdaVersion
   , optPrintHelp             :: Maybe Help
   , optInteractive           :: Bool
@@ -826,7 +827,8 @@ defaultOptions = Options
   , optUseLibs               = True
   , optTraceImports          = 1
   , optTrustedExecutables    = Map.empty
-  , optPrintAgdaDir          = False
+  , optPrintAgdaDataDir      = False
+  , optPrintAgdaAppDir       = False
   , optPrintVersion          = Nothing
   , optPrintHelp             = Nothing
   , optInteractive           = False
@@ -1205,8 +1207,11 @@ inputFlag f o =
         Nothing  -> return $ o { optInputFile = Just f }
         Just _   -> throwError "only one input file allowed"
 
-printAgdaDirFlag :: Flag CommandLineOptions
-printAgdaDirFlag o = return $ o { optPrintAgdaDir = True }
+printAgdaDataDirFlag :: Flag CommandLineOptions
+printAgdaDataDirFlag o = return $ o { optPrintAgdaDataDir = True }
+
+printAgdaAppDirFlag :: Flag CommandLineOptions
+printAgdaAppDirFlag o = return $ o { optPrintAgdaAppDir = True }
 
 versionFlag :: Flag CommandLineOptions
 versionFlag o = return $ o { optPrintVersion = Just PrintAgdaVersion }
@@ -1434,7 +1439,10 @@ standardOptions =
                     , intercalate ", " $ map fst allHelpTopics
                     ]
 
-    , Option []     ["print-agda-dir"] (NoArg printAgdaDirFlag)
+    , Option []     ["print-agda-data-dir"] (NoArg printAgdaDataDirFlag)
+                    ("print Agda data directory exit")
+
+    , Option []     ["print-agda-app-dir"] (NoArg printAgdaAppDirFlag)
                     ("print $AGDA_DIR and exit")
 
     , Option ['I']  ["interactive"] (NoArg interactiveFlag)

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -51,6 +51,7 @@ import Agda.Utils.Monad
 import Agda.Utils.Null
 
 import Agda.Utils.Impossible
+import Agda.Interaction.Library (getAgdaAppDir)
 
 -- | The main function
 runAgda :: [Backend] -> IO ()
@@ -90,10 +91,11 @@ runAgda' backends = runTCMPrettyErrors $ do
           IO.hSetEncoding IO.stderr enc
 
       case mode of
-        MainModePrintHelp hp   -> liftIO $ printUsage bs hp
-        MainModePrintVersion o -> liftIO $ printVersion bs o
-        MainModePrintAgdaDir   -> liftIO $ printAgdaDir
-        MainModeRun interactor -> do
+        MainModePrintHelp hp     -> liftIO $ printUsage bs hp
+        MainModePrintVersion o   -> liftIO $ printVersion bs o
+        MainModePrintAgdaDataDir -> liftIO $ printAgdaDataDir
+        MainModePrintAgdaAppDir  -> liftIO $ printAgdaAppDir
+        MainModeRun interactor   -> do
           setTCLens stBackends bs
           runAgdaWithOptions interactor progName opts
 
@@ -102,7 +104,8 @@ data MainMode
   = MainModeRun (Interactor ())
   | MainModePrintHelp Help
   | MainModePrintVersion PrintAgdaVersion
-  | MainModePrintAgdaDir
+  | MainModePrintAgdaDataDir
+  | MainModePrintAgdaAppDir
 
 -- | Determine the main execution mode to run, based on the configured backends and command line options.
 -- | This is pure.
@@ -110,7 +113,8 @@ getMainMode :: MonadError String m => [Backend] -> Maybe AbsolutePath -> Command
 getMainMode configuredBackends maybeInputFile opts
   | Just hp <- optPrintHelp opts    = return $ MainModePrintHelp hp
   | Just o  <- optPrintVersion opts = return $ MainModePrintVersion o
-  | optPrintAgdaDir opts            = return $ MainModePrintAgdaDir
+  | optPrintAgdaDataDir opts        = return $ MainModePrintAgdaDataDir
+  | optPrintAgdaAppDir opts         = return $ MainModePrintAgdaAppDir
   | otherwise = do
       mi <- getInteractor configuredBackends maybeInputFile opts
       -- If there was no selection whatsoever (e.g. just invoked "agda"), we just show help and exit.
@@ -285,8 +289,11 @@ printVersion backends PrintAgdaVersion = do
 #endif
     []
 
-printAgdaDir :: IO ()
-printAgdaDir = putStrLn =<< getDataDir
+printAgdaDataDir :: IO ()
+printAgdaDataDir = putStrLn =<< getDataDir
+
+printAgdaAppDir :: IO ()
+printAgdaAppDir = putStrLn =<< getAgdaAppDir
 
 -- | What to do for bad options.
 optionError :: String -> IO ()


### PR DESCRIPTION
Test plan:
---------
```
> mkdir ~/.agda
> cabal run agda -- --print-agda-app-dir
/home/pounce/.agda

> rmdir ~/.agda
> cabal run agda -- --print-agda-app-dir
/home/pounce/.config/agda

> AGDA_DIR=/tmp cabal run agda -- --print-agda-app-dir
/tmp

> cabal run agda -- --print-agda-data-dir
/home/pounce/programming/agda/./src/data
```

fixes #6852