### PR TITLE
explicit imports and inline types example: `Agda.Utils.Empty`

### DIFF
--- a/src/full/Agda/Utils/AffineHole.hs
+++ b/src/full/Agda/Utils/AffineHole.hs
@@ -16,8 +16,10 @@ data AffineHole r a
   deriving (Functor)
 
 instance Applicative (AffineHole r) where
+  pure :: a -> AffineHole r a
   pure = ZeroHoles
 
+  (<*>) :: AffineHole r (a -> b) -> AffineHole r a -> AffineHole r b
   ZeroHoles f <*> ZeroHoles a = ZeroHoles $ f a
   ZeroHoles f <*> OneHole g y = OneHole (f . g) y
   OneHole h x <*> ZeroHoles a = OneHole (`h` a) x

--- a/src/full/Agda/Utils/Applicative.hs
+++ b/src/full/Agda/Utils/Applicative.hs
@@ -9,7 +9,7 @@ module Agda.Utils.Applicative
        )
        where
 
-import Control.Applicative
+import Control.Applicative ( Alternative(empty) )
 import Data.Monoid ( Alt(..) )
 import Data.Traversable ( for )
 

--- a/src/full/Agda/Utils/AssocList.hs
+++ b/src/full/Agda/Utils/AssocList.hs
@@ -14,9 +14,9 @@ import Data.List (lookup)
 import qualified Data.List as List
 import qualified Data.Map  as Map
 
-import Agda.Utils.Tuple
+import Agda.Utils.Tuple ( mapFst )
 
-import Agda.Utils.Impossible
+import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 
 -- | A finite map, represented as a set of pairs.
 --

--- a/src/full/Agda/Utils/Bag.hs
+++ b/src/full/Agda/Utils/Bag.hs
@@ -11,11 +11,11 @@ import Text.Show.Functions () -- instance only
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Semigroup
+import Data.Semigroup ( Sum(Sum, getSum) )
 
-import Agda.Utils.Functor
+import Agda.Utils.Functor ( (<.>) )
 
-import Agda.Utils.Impossible
+import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 
 -- | A set with duplicates.
 --   Faithfully stores elements which are equal with regard to (==).
@@ -143,17 +143,23 @@ traverse' f = (Bag . Map.fromListWith (++)) <.> traverse trav . Map.elems . bag
 ------------------------------------------------------------------------
 
 instance Show a => Show (Bag a) where
+  showsPrec :: Show a => Int -> Bag a -> ShowS
   showsPrec _ (Bag b) = ("Agda.Utils.Bag.Bag (" ++) . shows b . (')':)
 
 instance Ord a => Semigroup (Bag a) where
+  (<>) :: Ord a => Bag a -> Bag a -> Bag a
   (<>) = union
 
 instance Ord a => Monoid (Bag a) where
+  mempty :: Ord a => Bag a
   mempty  = empty
+  mappend :: Ord a => Bag a -> Bag a -> Bag a
   mappend = (<>)
+  mconcat :: Ord a => [Bag a] -> Bag a
   mconcat = unions
 
 instance Foldable Bag where
+  foldMap :: Monoid m => (a -> m) -> Bag a -> m
   foldMap f = foldMap f . toList
 
 -- not a Functor (only works for 'Ord'ered types)

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -6,35 +6,30 @@ module Agda.Utils.Benchmark where
 
 import Prelude hiding (null)
 
-import Control.DeepSeq ( NFData )
+import Control.DeepSeq
 import qualified Control.Exception as E (evaluate)
 import Control.Monad.Except
-    ( MonadIO(..), MonadTrans(lift), ExceptT(..), runExceptT )
 import Control.Monad.Reader
-    ( MonadIO(..), MonadTrans(lift), ReaderT(..) )
 import Control.Monad.Writer
-    ( Sum(Sum, getSum), MonadIO(..), MonadTrans(lift), WriterT(..) )
 import Control.Monad.State
-    ( MonadIO(..), MonadTrans(lift), StateT(..) )
 import Control.Monad.IO.Class ( MonadIO(..) )
 
 
 import Data.Function (on)
 import qualified Data.List as List
-import Data.Monoid ( Sum(Sum, getSum) )
-import Data.Maybe ( fromMaybe )
+import Data.Monoid
+import Data.Maybe
 
 import GHC.Generics (Generic)
 
 import qualified Text.PrettyPrint.Boxes as Boxes
 
-import Agda.Utils.ListT ( ListT(..) )
-import Agda.Utils.Null ( Null(..) )
-import Agda.Utils.Monad ( ifNotM )
+import Agda.Utils.ListT
+import Agda.Utils.Null
+import Agda.Utils.Monad hiding (finally)
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Syntax.Common.Pretty
-    ( text, prettyShow, Pretty(pretty) )
-import Agda.Utils.Time ( fromMilliseconds, getCPUTime, CPUTime )
+import Agda.Utils.Time
 import Agda.Utils.Trie (Trie)
 import qualified Agda.Utils.Trie as Trie
 
@@ -71,13 +66,11 @@ data Benchmark a = Benchmark
 
 -- | Initial benchmark structure (empty).
 instance Null (Benchmark a) where
-  empty :: Benchmark a
   empty = Benchmark
     { benchmarkOn = BenchmarkOff
     , currentAccount = Strict.Nothing
     , timings = empty
     }
-  null :: Benchmark a -> Bool
   null = null . timings
 
 -- | Semantic editor combinator.
@@ -156,7 +149,6 @@ getsBenchmark f = f <$> getBenchmark
 
 instance MonadBench m => MonadBench (ReaderT r m) where
   type BenchPhase (ReaderT r m) = BenchPhase m
-  getBenchmark :: MonadBench m => ReaderT r m (Benchmark (BenchPhase (ReaderT r m)))
   getBenchmark    = lift $ getBenchmark
   putBenchmark    = lift . putBenchmark
   modifyBenchmark = lift . modifyBenchmark

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -6,30 +6,35 @@ module Agda.Utils.Benchmark where
 
 import Prelude hiding (null)
 
-import Control.DeepSeq
+import Control.DeepSeq ( NFData )
 import qualified Control.Exception as E (evaluate)
 import Control.Monad.Except
+    ( MonadIO(..), MonadTrans(lift), ExceptT(..), runExceptT )
 import Control.Monad.Reader
+    ( MonadIO(..), MonadTrans(lift), ReaderT(..) )
 import Control.Monad.Writer
+    ( Sum(Sum, getSum), MonadIO(..), MonadTrans(lift), WriterT(..) )
 import Control.Monad.State
+    ( MonadIO(..), MonadTrans(lift), StateT(..) )
 import Control.Monad.IO.Class ( MonadIO(..) )
 
 
 import Data.Function (on)
 import qualified Data.List as List
-import Data.Monoid
-import Data.Maybe
+import Data.Monoid ( Sum(Sum, getSum) )
+import Data.Maybe ( fromMaybe )
 
 import GHC.Generics (Generic)
 
 import qualified Text.PrettyPrint.Boxes as Boxes
 
-import Agda.Utils.ListT
-import Agda.Utils.Null
-import Agda.Utils.Monad hiding (finally)
+import Agda.Utils.ListT ( ListT(..) )
+import Agda.Utils.Null ( Null(..) )
+import Agda.Utils.Monad ( ifNotM )
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Syntax.Common.Pretty
-import Agda.Utils.Time
+    ( text, prettyShow, Pretty(pretty) )
+import Agda.Utils.Time ( fromMilliseconds, getCPUTime, CPUTime )
 import Agda.Utils.Trie (Trie)
 import qualified Agda.Utils.Trie as Trie
 
@@ -66,11 +71,13 @@ data Benchmark a = Benchmark
 
 -- | Initial benchmark structure (empty).
 instance Null (Benchmark a) where
+  empty :: Benchmark a
   empty = Benchmark
     { benchmarkOn = BenchmarkOff
     , currentAccount = Strict.Nothing
     , timings = empty
     }
+  null :: Benchmark a -> Bool
   null = null . timings
 
 -- | Semantic editor combinator.
@@ -149,6 +156,7 @@ getsBenchmark f = f <$> getBenchmark
 
 instance MonadBench m => MonadBench (ReaderT r m) where
   type BenchPhase (ReaderT r m) = BenchPhase m
+  getBenchmark :: MonadBench m => ReaderT r m (Benchmark (BenchPhase (ReaderT r m)))
   getBenchmark    = lift $ getBenchmark
   putBenchmark    = lift . putBenchmark
   modifyBenchmark = lift . modifyBenchmark

--- a/src/full/Agda/Utils/BiMap.hs
+++ b/src/full/Agda/Utils/BiMap.hs
@@ -11,21 +11,26 @@ module Agda.Utils.BiMap where
 
 import Prelude hiding (null, lookup)
 
-import Control.Monad.Identity
+import Control.Monad.Identity ( Identity(Identity, runIdentity) )
 import Control.Monad.State
+    ( MonadTrans(lift),
+      StateT(runStateT),
+      runState,
+      MonadState(put),
+      State )
 
 import Data.Function (on)
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe
-import Data.Ord
-import Data.Tuple
+import Data.Maybe ( isJust )
+import Data.Ord ( comparing )
+import Data.Tuple ( swap )
 
 import GHC.Generics (Generic)
 
-import Agda.Utils.List
-import Agda.Utils.Null
+import Agda.Utils.List ( fastDistinct, sorted )
+import Agda.Utils.Null ( Null(..) )
 
 -- | Partial injections from a type to some tag type.
 --
@@ -81,6 +86,7 @@ biMapInvariant m@(BiMap t u) =
   tagInjectiveFor (map snd $ toList m)
 
 instance Null (BiMap k v) where
+  empty :: BiMap k v
   empty = BiMap Map.empty Map.empty
   null  = null . biMapThere
 
@@ -442,10 +448,13 @@ toDistinctAscendingLists (BiMap t b) =
 ------------------------------------------------------------------------
 
 instance (Eq k, Eq v) => Eq (BiMap k v) where
+  (==) :: (Eq k, Eq v) => BiMap k v -> BiMap k v -> Bool
   (==) = (==) `on` biMapThere
 
 instance (Ord k, Ord v) => Ord (BiMap k v) where
+  compare :: (Ord k, Ord v) => BiMap k v -> BiMap k v -> Ordering
   compare = compare `on` biMapThere
 
 instance (Show k, Show v) => Show (BiMap k v) where
+  show :: (Show k, Show v) => BiMap k v -> String
   show bimap = "Agda.Utils.BiMap.fromList " ++ show (toList bimap)

--- a/src/full/Agda/Utils/BoolSet.hs
+++ b/src/full/Agda/Utils/BoolSet.hs
@@ -38,7 +38,7 @@ module Agda.Utils.BoolSet
 
 import Prelude hiding (null)
 
-import Agda.Utils.Impossible
+import Agda.Utils.Impossible ( __IMPOSSIBLE__ )
 
 -- | Isomorphic to @'Set' 'Bool'@.
 data BoolSet = SetEmpty | SetTrue | SetFalse | SetBoth

--- a/src/full/Agda/Utils/Boolean.hs
+++ b/src/full/Agda/Utils/Boolean.hs
@@ -74,16 +74,24 @@ class (Boolean a, Eq a) => IsBool a where
   {-# MINIMAL toBool #-}
 
 instance Boolean Bool where
+  fromBool :: Bool -> Bool
   fromBool = id
 
 instance IsBool Bool where
+  toBool :: Bool -> Bool
   toBool = id
   -- optional
+  fromBool1 :: (Bool -> Bool) -> Bool -> Bool
   fromBool1 = id
+  fromBool2 :: (Bool -> Bool -> Bool) -> Bool -> Bool -> Bool
   fromBool2 = id
 
 instance Boolean b => Boolean (a -> b) where
+  fromBool :: Boolean b => Bool -> a -> b
   fromBool   = const . fromBool
+  not :: Boolean b => (a -> b) -> a -> b
   not f      = not . f
+  (&&) :: Boolean b => (a -> b) -> (a -> b) -> a -> b
   (f && g) a = f a && g a
+  (||) :: Boolean b => (a -> b) -> (a -> b) -> a -> b
   (f || g) a = f a || g a

--- a/src/full/Agda/Utils/Char.hs
+++ b/src/full/Agda/Utils/Char.hs
@@ -14,7 +14,7 @@
 
 module Agda.Utils.Char where
 
-import Data.Char
+import Data.Char ( generalCategory, GeneralCategory(Surrogate) )
 
 -- | The unicode replacement character � .
 replacementChar :: Char

--- a/src/full/Agda/Utils/Cluster.hs
+++ b/src/full/Agda/Utils/Cluster.hs
@@ -9,7 +9,7 @@ module Agda.Utils.Cluster
   , cluster'
   ) where
 
-import Control.Monad
+import Control.Monad ( forM_, forM )
 
 -- An imperative union-find library:
 import Data.Equivalence.Monad (runEquivT, equateAll, classDesc)
@@ -20,9 +20,9 @@ import qualified Data.Map.Strict as MapS
 import Data.Semigroup
 #endif
 
-import Agda.Utils.Functor
-import Agda.Utils.Singleton
-import Agda.Utils.Fail
+import Agda.Utils.Functor ( (<&>) )
+import Agda.Utils.Singleton ( Singleton(singleton) )
+import Agda.Utils.Fail ( runFail_ )
 
 -- | Given a function @f :: a -> NonEmpty c@ which returns a non-empty list of
 --   characteristics of @a@, partition a list of @a@s into groups such

--- a/src/full/Agda/Utils/Either.hs
+++ b/src/full/Agda/Utils/Either.hs
@@ -23,7 +23,7 @@ module Agda.Utils.Either
   , swapEither
   ) where
 
-import Data.Bifunctor
+import Data.Bifunctor ( Bifunctor(first, second) )
 import Data.Either (isLeft, isRight)
 import Data.List   (unfoldr)
 

--- a/src/full/Agda/Utils/Empty.hs
+++ b/src/full/Agda/Utils/Empty.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+
 -- | An empty type with some useful instances.
 module Agda.Utils.Empty where
 

--- a/src/full/Agda/Utils/Empty.hs
+++ b/src/full/Agda/Utils/Empty.hs
@@ -1,12 +1,11 @@
-{-# OPTIONS_GHC -Wunused-imports #-}
-
 -- | An empty type with some useful instances.
 module Agda.Utils.Empty where
 
-import Control.DeepSeq
+import Control.DeepSeq ( NFData(..) )
 import Control.Exception (evaluate)
 
 import Agda.Utils.Impossible
+    ( CatchImpossible(catchImpossible), Impossible, __IMPOSSIBLE__ )
 
 
 data Empty
@@ -15,15 +14,19 @@ data Empty
 -- a constructor argument in 'Agda.Syntax.Internal.Substitution''.
 
 instance NFData Empty where
+  rnf :: Empty -> ()
   rnf _ = ()
 
 instance Eq Empty where
+  (==) :: Empty -> Empty -> Bool
   _ == _ = True
 
 instance Ord Empty where
+  compare :: Empty -> Empty -> Ordering
   compare _ _ = EQ
 
 instance Show Empty where
+  showsPrec :: Int -> Empty -> ShowS
   showsPrec p _ = showParen (p > 9) $ showString "error \"Agda.Utils.Empty.Empty\""
 
 absurd :: Empty -> a

--- a/src/full/Agda/Utils/Environment.hs
+++ b/src/full/Agda/Utils/Environment.hs
@@ -7,9 +7,9 @@ module Agda.Utils.Environment
   , expandEnvVarTelescope
   ) where
 
-import Data.Char
-import Data.Maybe
-import System.Environment
+import Data.Char ( isAlpha, isAlphaNum )
+import Data.Maybe ( fromMaybe )
+import System.Environment ( getEnvironment )
 import System.Directory ( getHomeDirectory )
 
 expandEnvironmentVariables :: String -> IO String


### PR DESCRIPTION
Summary of Changes:
- Removed the unused GHC pragma (-Wunused-imports).
- Added explicit imports for improved code clarity.
- Included inline type signatures to enhance code readability.

Motivation:
- I believe that explicit imports and inline type signatures can make the code more readable and maintainable.
- By removing the unused pragma, we're also ensuring cleaner code.

Testing:
- I've run the project with Stack to ensure that these changes didn't introduce any build or runtime errors.

Request for Feedback:
- I'd appreciate feedback on these changes.
- Are they in line with the project's coding standards and goals?
- If there are any adjustments or additional considerations needed, please let me know.

Potential Scope of Refinements:
- I've noticed that similar improvements (removal of unused pragmas, inclusion of inline types, and explicit imports) could be applied to several other files in the project.
- If this change is well-received, I am willing to make similar updates across the codebase, or I'd recommend considering it for future refactorings.