### PR TITLE
LHS Error Refactor

### DIFF
--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -149,10 +149,12 @@ defaultNamedArgDom info s x = (defaultArgDom info x) { domName = Just $ WithOrig
 type Args       = [Arg Term]
 type NamedArgs  = [NamedArg Term]
 
-data DataOrRecord
+data DataOrRecord' p
   = IsData
-  | IsRecord PatternOrCopattern
+  | IsRecord p
   deriving (Show, Eq, Generic)
+
+type DataOrRecord = DataOrRecord' PatternOrCopattern
 
 instance PatternMatchingAllowed DataOrRecord where
   patternMatchingAllowed = \case

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -32,14 +32,14 @@ import qualified Data.IntSet as IntSet
 
 import Agda.Syntax.Common
 import Agda.Syntax.Position
-import Agda.Syntax.Internal hiding (DataOrRecord(..))
+import Agda.Syntax.Internal hiding (DataOrRecord)
 import Agda.Syntax.Internal.Pattern
 import Agda.Syntax.Translation.InternalToAbstract (NamedClause(..))
 
 import Agda.TypeChecking.Primitive hiding (Nat)
 import Agda.TypeChecking.Monad
 
-import Agda.TypeChecking.Rules.LHS (DataOrRecord(..), checkSortOfSplitVar)
+import Agda.TypeChecking.Rules.LHS (DataOrRecord, checkSortOfSplitVar)
 import Agda.TypeChecking.Rules.LHS.Problem (allFlexVars)
 import Agda.TypeChecking.Rules.LHS.Unify
 import Agda.TypeChecking.Rules.Term (unquoteTactic)
@@ -734,7 +734,7 @@ isDatatype ind at = do
           | i == Just CoInductive && ind /= CoInductive ->
               throw CoinductiveDatatype
           | otherwise ->
-              return (IsRecord i recEtaEquality', d, args, [], [conName con], False)
+              return (IsRecord InductionAndEta { recordInduction=i, recordEtaEquality=recEtaEquality' }, d, args, [], [conName con], False)
         _ -> throw NotADatatype
     _ -> throw NotADatatype
 
@@ -1320,8 +1320,8 @@ split' checkEmpty ind allowPartialCover inserttrailing
       erasedMatches   = optErasedMatches opts
       isRecordWithEta = case dr of
         IsData       -> False
-        IsRecord{..} ->
-          case theEtaEquality recordEtaEquality of
+        IsRecord r ->
+          case theEtaEquality (recordEtaEquality r) of
             YesEta{} -> True
             NoEta{}  -> False
 

--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -14,7 +14,7 @@ import qualified Data.IntSet as IntSet
 
 import Agda.Syntax.Common
 import Agda.Syntax.Position
-import Agda.Syntax.Internal hiding (DataOrRecord(..))
+import Agda.Syntax.Internal hiding (DataOrRecord)
 import Agda.Syntax.Internal.Pattern
 import Agda.Syntax.Common.Pretty (prettyShow)
 

--- a/src/full/Agda/TypeChecking/Coverage/SplitClause.hs
+++ b/src/full/Agda/TypeChecking/Coverage/SplitClause.hs
@@ -13,7 +13,7 @@ import qualified Data.IntSet as IntSet
 
 import Agda.Syntax.Common
 import Agda.Syntax.Common.Pretty (prettyShow)
-import Agda.Syntax.Internal hiding (DataOrRecord(..))
+import Agda.Syntax.Internal hiding (DataOrRecord)
 
 import Agda.TypeChecking.Coverage.Match
 import Agda.TypeChecking.Coverage.SplitTree

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -164,6 +164,7 @@ errorString err = case err of
   IllformedProjectionPatternAbstract{}     -> "IllformedProjectionPatternAbstract"
   IllformedProjectionPatternConcrete{}     -> "IllformedProjectionPatternConcrete"
   CannotEliminateWithPattern{}             -> "CannotEliminateWithPattern"
+  CannotEliminateWithProjection{}          -> "CannotEliminateWithProjection"
   IllegalDeclarationInDataDefinition{}     -> "IllegalDeclarationInDataDefinition"
   IllegalLetInTelescope{}                  -> "IllegalLetInTelescope"
   IllegalPatternInTelescope{}              -> "IllegalPatternInTelescope"
@@ -477,6 +478,16 @@ instance PrettyTCM TypeError where
         A.AsP _ _ p -> kindOfPattern p
         A.PatternSynP{} -> __IMPOSSIBLE__
         A.AnnP _ _ p -> kindOfPattern p
+
+    CannotEliminateWithProjection ty isAmbiguous projection -> sep
+        [ "Cannot eliminate type "
+        , prettyTCM (unArg ty)
+        , " with projection "
+        , if isAmbiguous then
+            text $ prettyShow projection
+          else
+            prettyTCM projection
+        ]
 
     WrongNumberOfConstructorArguments c expect given -> fsep $
       pwords "The constructor" ++ [prettyTCM c] ++

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -296,6 +296,7 @@ errorString err = case err of
   TooManyArgumentsToUnivOmega{}            -> "TooManyArgumentsToUnivOmega"
   IllTypedPatternAfterWithAbstraction{}    -> "IllTypedPatternAfterWithAbstraction"
   ComatchingDisabledForRecord{}            -> "ComatchingDisabledForRecord"
+  BuiltinMustBeIsOne{}                     -> "BuiltinMustBeIsOne"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1383,6 +1384,9 @@ instance PrettyTCM TypeError where
 
     ComatchingDisabledForRecord recName ->
       "Copattern matching is disabled for record" <+> prettyTCM recName
+
+    BuiltinMustBeIsOne builtin ->
+      prettyTCM builtin <+> " is not IsOne."
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -266,6 +266,7 @@ errorString err = case err of
   WrongHidingInApplication{}               -> "WrongHidingInApplication"
   WrongHidingInLHS{}                       -> "WrongHidingInLHS"
   WrongHidingInLambda{}                    -> "WrongHidingInLambda"
+  WrongHidingInProjection{}                -> "WrongHidingInProjection"
   IllegalHidingInPostfixProjection{}       -> "IllegalHidingInPostfixProjection"
   WrongIrrelevanceInLambda{}               -> "WrongIrrelevanceInLambda"
   WrongQuantityInLambda{}                  -> "WrongQuantityInLambda"
@@ -375,6 +376,10 @@ instance PrettyTCM TypeError where
 
     WrongHidingInLambda t ->
       fwords "Found an implicit lambda where an explicit lambda was expected"
+
+    WrongHidingInProjection d ->
+      sep [ "Wrong hiding used for projection " , prettyTCM d ]
+
 
     IllegalHidingInPostfixProjection arg -> fsep $
       pwords "Illegal hiding in postfix projection " ++

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -128,7 +128,7 @@ errorString err = case err of
   AmbiguousField{}                         -> "AmbiguousField"
   AmbiguousParseForApplication{}           -> "AmbiguousParseForApplication"
   AmbiguousParseForLHS{}                   -> "AmbiguousParseForLHS"
-  AmbiguousProjectionError{}               -> "AmbiguousProjectionError"
+  AmbiguousOverloadedProjection{}          -> "AmbiguousOverloadedProjection"
 --  AmbiguousParseForPatternSynonym{}        -> "AmbiguousParseForPatternSynonym"
   AmbiguousTopLevelModuleName {}           -> "AmbiguousTopLevelModuleName"
   BadArgumentsToPatternSynonym{}           -> "BadArgumentsToPatternSynonym"
@@ -820,7 +820,7 @@ instance PrettyTCM TypeError where
              pwords "could refer to any of the following files:"
            ) $$ nest 2 (vcat $ map (text . filePath) files)
 
-    AmbiguousProjectionError ds reason -> do
+    AmbiguousOverloadedProjection ds reason -> do
       let nameRaw = pretty $ A.nameConcrete $ A.qnameName $ List1.head ds
       vcat
         [ fsep

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -242,6 +242,7 @@ errorString err = case err of
   SplitOnAbstract{}                        -> "SplitOnAbstract"
   SplitOnUnchecked{}                       -> "SplitOnUnchecked"
   SplitOnPartial{}                         -> "SplitOnPartial"
+  SplitInProp{}                            -> "SplitInProp"
   DefinitionIsIrrelevant{}                 -> "DefinitionIsIrrelevant"
   DefinitionIsErased{}                     -> "DefinitionIsErased"
   VariableIsIrrelevant{}                   -> "VariableIsIrrelevant"
@@ -602,6 +603,19 @@ instance PrettyTCM TypeError where
 
     SplitOnPartial dom -> vcat
       [ "Splitting on partial elements is only allowed at the type Partial, but the domain here is", nest 2 $ prettyTCM $ unDom dom ]
+
+    SplitInProp dr -> fsep
+      [ text "Cannot split on"
+      , text $ kindOfData dr
+      , text "in Prop unless target is in Prop"
+      ]
+      where
+        kindOfData :: DataOrRecordE -> String
+        kindOfData IsData                                                          = "datatype"
+        kindOfData (IsRecord InductionAndEta {recordInduction=Nothing})            = "record type"
+        kindOfData (IsRecord InductionAndEta {recordInduction=(Just Inductive)})   =  "inductive record type"
+        kindOfData (IsRecord InductionAndEta {recordInduction=(Just CoInductive)}) = "coinductive record type"
+
 
     DefinitionIsIrrelevant x -> fsep $
       "Identifier" : prettyTCM x : pwords "is declared irrelevant, so it cannot be used here"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -239,6 +239,7 @@ errorString err = case err of
   SplitOnNonEtaRecord{}                    -> "SplitOnNonEtaRecord"
   SplitOnAbstract{}                        -> "SplitOnAbstract"
   SplitOnUnchecked{}                       -> "SplitOnUnchecked"
+  SplitOnPartial{}                         -> "SplitOnPartial"
   DefinitionIsIrrelevant{}                 -> "DefinitionIsIrrelevant"
   DefinitionIsErased{}                     -> "DefinitionIsErased"
   VariableIsIrrelevant{}                   -> "VariableIsIrrelevant"
@@ -582,6 +583,9 @@ instance PrettyTCM TypeError where
 
     SplitOnUnchecked d ->
       "Cannot split on data type" <+> prettyTCM d <+> "whose definition has not yet been checked"
+
+    SplitOnPartial dom -> vcat
+      [ "Splitting on partial elements is only allowed at the type Partial, but the domain here is", nest 2 $ prettyTCM $ unDom dom ]
 
     DefinitionIsIrrelevant x -> fsep $
       "Identifier" : prettyTCM x : pwords "is declared irrelevant, so it cannot be used here"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -237,6 +237,7 @@ errorString err = case err of
   -- UNUSED: -- SplitOnErased{}                          -> "SplitOnErased"
   SplitOnNonVariable{}                     -> "SplitOnNonVariable"
   SplitOnNonEtaRecord{}                    -> "SplitOnNonEtaRecord"
+  SplitOnAbstract{}                        -> "SplitOnAbstract"
   DefinitionIsIrrelevant{}                 -> "DefinitionIsIrrelevant"
   DefinitionIsErased{}                     -> "DefinitionIsErased"
   VariableIsIrrelevant{}                   -> "VariableIsIrrelevant"
@@ -567,6 +568,9 @@ instance PrettyTCM TypeError where
       , [ parens "to activate, add declaration `pattern` to record definition" ]
       ]
       where r = nameBindingSite $ qnameName q
+
+    SplitOnAbstract d ->
+      "Cannot split on abstract data type" <+> prettyTCM d
 
     DefinitionIsIrrelevant x -> fsep $
       "Identifier" : prettyTCM x : pwords "is declared irrelevant, so it cannot be used here"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -294,6 +294,7 @@ errorString err = case err of
   TooManyArgumentsToLeveledSort{}          -> "TooManyArgumentsToLeveledSort"
   TooManyArgumentsToUnivOmega{}            -> "TooManyArgumentsToUnivOmega"
   IllTypedPatternAfterWithAbstraction{}    -> "IllTypedPatternAfterWithAbstraction"
+  ComatchingDisabledForRecord{}            -> "ComatchingDisabledForRecord"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1375,6 +1376,9 @@ instance PrettyTCM TypeError where
       [ "Ill-typed pattern after with abstraction: " <+> prettyA p
       , "(perhaps you can replace it by `_`?)"
       ]
+
+    ComatchingDisabledForRecord recName ->
+      "Copattern matching is disabled for record" <+> prettyTCM recName
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -238,6 +238,7 @@ errorString err = case err of
   SplitOnNonVariable{}                     -> "SplitOnNonVariable"
   SplitOnNonEtaRecord{}                    -> "SplitOnNonEtaRecord"
   SplitOnAbstract{}                        -> "SplitOnAbstract"
+  SplitOnUnchecked{}                       -> "SplitOnUnchecked"
   DefinitionIsIrrelevant{}                 -> "DefinitionIsIrrelevant"
   DefinitionIsErased{}                     -> "DefinitionIsErased"
   VariableIsIrrelevant{}                   -> "VariableIsIrrelevant"
@@ -576,6 +577,9 @@ instance PrettyTCM TypeError where
 
     SplitOnAbstract d ->
       "Cannot split on abstract data type" <+> prettyTCM d
+
+    SplitOnUnchecked d ->
+      "Cannot split on data type" <+> prettyTCM d <+> "whose definition has not yet been checked"
 
     DefinitionIsIrrelevant x -> fsep $
       "Identifier" : prettyTCM x : pwords "is declared irrelevant, so it cannot be used here"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -293,6 +293,7 @@ errorString err = case err of
   CubicalPrimitiveNotFullyApplied{}        -> "CubicalPrimitiveNotFullyApplied"
   TooManyArgumentsToLeveledSort{}          -> "TooManyArgumentsToLeveledSort"
   TooManyArgumentsToUnivOmega{}            -> "TooManyArgumentsToUnivOmega"
+  IllTypedPatternAfterWithAbstraction{}    -> "IllTypedPatternAfterWithAbstraction"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1369,6 +1370,11 @@ instance PrettyTCM TypeError where
 
     TooManyArgumentsToUnivOmega q -> fsep $
       [ prettyTCM q , "cannot be applied to an argument" ]
+
+    IllTypedPatternAfterWithAbstraction p -> vcat
+      [ "Ill-typed pattern after with abstraction: " <+> prettyA p
+      , "(perhaps you can replace it by `_`?)"
+      ]
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4497,6 +4497,7 @@ data TypeError
         | SplitOnNonVariable Term Type
         | SplitOnNonEtaRecord QName
         | SplitOnAbstract QName
+        | SplitOnUnchecked QName
         | DefinitionIsIrrelevant QName
         | DefinitionIsErased QName
         | VariableIsIrrelevant Name

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4551,6 +4551,7 @@ data TypeError
         | WithOnFreeVariable A.Expr Term
         | UnexpectedWithPatterns [A.Pattern]
         | WithClausePatternMismatch A.Pattern (NamedArg DeBruijnPattern)
+        | IllTypedPatternAfterWithAbstraction A.Pattern
         | FieldOutsideRecord
         | ModuleArityMismatch A.ModuleName Telescope [NamedArg A.Expr]
         | GeneralizeCyclicDependency

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4499,6 +4499,7 @@ data TypeError
         | SplitOnAbstract QName
         | SplitOnUnchecked QName
         | SplitOnPartial (Dom Type)
+        | SplitInProp DataOrRecordE
         | DefinitionIsIrrelevant QName
         | DefinitionIsErased QName
         | VariableIsIrrelevant Name
@@ -4667,6 +4668,13 @@ data TypeError
         | InstanceSearchDepthExhausted Term Type Int
         | TriedToCopyConstrainedPrim QName
           deriving (Show, Generic)
+
+type DataOrRecordE = DataOrRecord' InductionAndEta
+
+data InductionAndEta = InductionAndEta
+  { recordInduction   :: Maybe Induction
+  , recordEtaEquality :: EtaEquality
+  } deriving (Show, Generic)
 
 -- | Distinguish error message when parsing lhs or pattern synonym, resp.
 data LHSOrPatSyn = IsLHS | IsPatSyn
@@ -5699,3 +5707,5 @@ instance NFData UnificationFailure
 instance NFData UnquoteError
 instance NFData TypeError
 instance NFData LHSOrPatSyn
+instance NFData DataOrRecordE
+instance NFData InductionAndEta

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4573,6 +4573,7 @@ data TypeError
         | CubicalPrimitiveNotFullyApplied QName
         | TooManyArgumentsToLeveledSort QName
         | TooManyArgumentsToUnivOmega QName
+        | ComatchingDisabledForRecord QName
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4498,6 +4498,7 @@ data TypeError
         | SplitOnNonEtaRecord QName
         | SplitOnAbstract QName
         | SplitOnUnchecked QName
+        | SplitOnPartial (Dom Type)
         | DefinitionIsIrrelevant QName
         | DefinitionIsErased QName
         | VariableIsIrrelevant Name

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4642,7 +4642,7 @@ data TypeError
             --   If it is non-empty, the first entry could be printed as error hint.
         | AmbiguousParseForLHS LHSOrPatSyn C.Pattern [C.Pattern]
             -- ^ Pattern and its possible interpretations.
-        | AmbiguousProjectionError (List1 QName) Doc
+        | AmbiguousOverloadedProjection (List1 QName) Doc
         | OperatorInformation [NotationSection] TypeError
 {- UNUSED
         | NoParseForPatternSynonym C.Pattern

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4495,6 +4495,7 @@ data TypeError
         -- UNUSED: -- | SplitOnErased (Dom Type)
         | SplitOnNonVariable Term Type
         | SplitOnNonEtaRecord QName
+        | SplitOnAbstract QName
         | DefinitionIsIrrelevant QName
         | DefinitionIsErased QName
         | VariableIsIrrelevant Name

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4608,6 +4608,7 @@ data TypeError
         | AmbiguousName C.QName AmbiguousNameReason
         | AmbiguousModule C.QName (List1 A.ModuleName)
         | AmbiguousField C.Name [A.ModuleName]
+        | AmbiguousConstructor QName [QName]
         | ClashingDefinition C.QName A.QName (Maybe NiceDeclaration)
         | ClashingModule A.ModuleName A.ModuleName
         | ClashingImport C.Name A.QName
@@ -4642,6 +4643,7 @@ data TypeError
             --   If it is non-empty, the first entry could be printed as error hint.
         | AmbiguousParseForLHS LHSOrPatSyn C.Pattern [C.Pattern]
             -- ^ Pattern and its possible interpretations.
+        | AmbiguousProjection QName [QName]
         | AmbiguousOverloadedProjection (List1 QName) Doc
         | OperatorInformation [NotationSection] TypeError
 {- UNUSED

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4473,6 +4473,7 @@ data TypeError
         | IllformedProjectionPatternAbstract A.Pattern
         | IllformedProjectionPatternConcrete C.Pattern
         | CannotEliminateWithPattern (Maybe Blocker) (NamedArg A.Pattern) Type
+        | CannotEliminateWithProjection (Arg Type) Bool QName
         | WrongNumberOfConstructorArguments QName Nat Nat
         | ShouldBeEmpty Type [DeBruijnPattern]
         | ShouldBeASort Type

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4575,6 +4575,7 @@ data TypeError
         | TooManyArgumentsToLeveledSort QName
         | TooManyArgumentsToUnivOmega QName
         | ComatchingDisabledForRecord QName
+        | BuiltinMustBeIsOne Term
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4451,6 +4451,7 @@ data TypeError
             -- ^ Expected a non-hidden function and found a hidden lambda.
         | WrongHidingInApplication Type
             -- ^ A function is applied to a hidden argument where a non-hidden was expected.
+        | WrongHidingInProjection QName
         | IllegalHidingInPostfixProjection (NamedArg C.Expr)
         | WrongNamedArgument (NamedArg A.Expr) [NamedName]
             -- ^ A function is applied to a hidden named argument it does not have.

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1417,9 +1417,9 @@ inferOrCheckProjAppToKnownPrincipalArg e o ds args mt k v0 ta mpatm = do
 
               return (v, tc, NotCheckedTarget)
 
--- | Throw 'AmbiguousProjectionError' with additional explanation.
+-- | Throw 'AmbiguousOverloadedProjection' with additional explanation.
 refuseProj :: List1 QName -> TCM Doc -> TCM a
-refuseProj ds reason = typeError . AmbiguousProjectionError ds =<< reason
+refuseProj ds reason = typeError . AmbiguousOverloadedProjection ds =<< reason
 
 refuseProjNotApplied, refuseProjNoMatching :: List1 QName -> TCM a
 refuseProjNotApplied    ds = refuseProj ds $ fwords "it is not applied to a visible argument"

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1754,15 +1754,8 @@ disambiguateProjection h ambD@(AmbQ ds) b = do
 
     wrongProj :: (MonadTCM m, MonadError TCErr m, ReadTCState m) => QName -> m a
     wrongProj d = softTypeError =<< do
-      liftTCM $ GenericDocError <$> sep
-        [ "Cannot eliminate type "
-        , prettyTCM (unArg b)
-        , " with projection "
-        , if isAmbiguous ambD then
-            text . prettyShow =<< dropTopLevelModule d
-          else
-            prettyTCM d
-        ]
+      liftTCM $ if isAmbiguous ambD then CannotEliminateWithProjection b True <$> dropTopLevelModule d
+                else pure $ CannotEliminateWithProjection b False d
 
     tryProj
       :: Bool                 -- Are we allowed to create new constraints?

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -596,10 +596,7 @@ bindAsPatterns (AsB x v a m : asb) ret = do
 --   recheck the stripped with patterns when checking a with function.
 recheckStrippedWithPattern :: ProblemEq -> TCM ()
 recheckStrippedWithPattern (ProblemEq p v a) = checkInternal v CmpLeq (unDom a)
-  `catchError` \_ -> typeError . GenericDocError =<< vcat
-    [ "Ill-typed pattern after with abstraction: " <+> prettyA p
-    , "(perhaps you can replace it by `_`?)"
-    ]
+  `catchError` \_ -> typeError $ IllTypedPatternAfterWithAbstraction p
 
 -- | Result of checking the LHS of a clause.
 data LHSResult = LHSResult

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1204,8 +1204,7 @@ checkLHS mf = updateModality checkLHS_ where
                        getBuiltinName' builtinIsOne
                      case a of
                        Def q [Apply phi] | q == isone -> return (unArg phi)
-                       _           -> typeError . GenericDocError =<< do
-                         prettyTCM a <+> " is not IsOne."
+                       _           -> typeError $ BuiltinMustBeIsOne a
 
                    _  -> foldl (\ x y -> primIMin <@> x <@> y) primIOne (map pure ts)
          reportSDoc "tc.lhs.split.partial" 10 $ text "phi           =" <+> prettyTCM phi

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1644,8 +1644,7 @@ isDataOrRecordType a0 = ifBlocked a0 blocked $ \case
         return (IsRecord recInduction recEtaEquality', d, pars, [])
 
       -- Issue #2253: the data type could be abstract.
-      AbstractDefn{} -> hardTypeError . GenericDocError =<< do
-        liftTCM $ "Cannot split on abstract data type" <+> prettyTCM d
+      AbstractDefn{} -> hardTypeError $ SplitOnAbstract d
 
       -- the type could be an axiom
       Axiom{} -> hardTypeError =<< notData

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1781,11 +1781,6 @@ disambiguateProjection h ambD@(AmbQ ds) b = do
             prettyTCM d
         ]
 
-    wrongHiding :: (MonadTCM m, MonadError TCErr m, ReadTCState m) => QName -> m a
-    wrongHiding d = softTypeError =<< do
-      liftTCM $ GenericDocError <$> sep
-        [ "Wrong hiding used for projection " , prettyTCM d ]
-
     tryProj
       :: Bool                 -- Are we allowed to create new constraints?
       -> [Dom QName]          -- Fields of record type under consideration.
@@ -1832,7 +1827,8 @@ disambiguateProjection h ambD@(AmbQ ds) b = do
         -- Andreas, 2016-12-31, issue #2374:
         -- We can also disambiguate by hiding info.
         -- Andreas, 2018-10-18, issue #3289: postfix projections have no hiding info.
-        unless (caseMaybe h True $ sameHiding $ projArgInfo proj) $ wrongHiding d
+        unless (caseMaybe h True $ sameHiding $ projArgInfo proj) $
+          softTypeError $ WrongHidingInProjection d
 
         -- Andreas, 2016-12-31, issue #1976: Check parameters.
         let chk = checkParameters qr r vs

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1650,8 +1650,7 @@ isDataOrRecordType a0 = ifBlocked a0 blocked $ \case
       Axiom{} -> hardTypeError =<< notData
 
       -- Can't match before we have the definition
-      DataOrRecSig{} -> hardTypeError . GenericDocError =<< do
-        liftTCM $ "Cannot split on data type" <+> prettyTCM d <+> "whose definition has not yet been checked"
+      DataOrRecSig{} -> hardTypeError $ SplitOnUnchecked d
 
       -- Issue #2997: the type could be a Def that does not reduce for some reason
       -- (abstract, failed termination checking, NON_TERMINATING, ...)

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1149,8 +1149,7 @@ checkLHS mf = updateModality checkLHS_ where
     splitPartial delta1 dom adelta2 ts = do
 
       unless (domIsFinite dom) $ liftTCM $ addContext delta1 $
-        softTypeError . GenericDocError =<<
-        vcat [ "Splitting on partial elements is only allowed at the type Partial, but the domain here is" , nest 2 $ prettyTCM $ unDom dom ]
+        softTypeError $ SplitOnPartial dom
 
       tInterval <- liftTCM $ primIntervalType
 

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1073,8 +1073,7 @@ checkLHS mf = updateModality checkLHS_ where
         addContext tel $ disambiguateProjection h ambProjName target
 
       unless comatchingAllowed $ do
-        hardTypeError . GenericDocError =<< do
-          liftTCM $ "Copattern matching is disabled for record" <+> prettyTCM recName
+        hardTypeError $ ComatchingDisabledForRecord recName
 
       -- Compute the new rest type by applying the projection type to 'self'.
       -- Note: we cannot be in a let binding.


### PR DESCRIPTION
Refactor `GenericDocError`-s for concrete ones in `TypeChecking/Rules/LHS.hs`
- Introduce new types of type errors
- Rename error `AmbiguousProjectionError` to `AmbiguousOverloadedProjection`