### PR TITLE
toggle debug reporting via CPP

### DIFF
--- a/.github/workflows/stack-dry-run.yml
+++ b/.github/workflows/stack-dry-run.yml
@@ -23,7 +23,8 @@ jobs:
         shell: bash
     env:
       EXTRA_ARGS: --dry-run
-      NON_DEFAULT_FLAGS: --flag Agda:enable-cluster-counting --flag Agda:debug
+      NON_DEFAULT_FLAGS: --flag Agda:enable-cluster-counting --flag Agda:debug --flag
+        Agda:debug-serialisation --flag Agda:debug-parsing
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install dependencies for Agda and its test suites
       run: make install-deps
     - name: Build Agda
-      run: make BUILD_DIR="${BUILD_DIR}" install-bin
+      run: make BUILD_DIR="${BUILD_DIR}" install-bin-debug
     - name: Run tests for the size solver
       run: |
         export PATH=${HOME}/.local/bin:${PATH}

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -162,7 +162,19 @@ flag debug
   default: False
   manual: True
   description:
-    Enable debugging features that may slow Agda down.
+    Enable debug printing. This makes Agda slightly slower, and
+    building Agda slower as well. The --verbose=N option only
+    has an effect when Agda was built with this flag.
+
+flag debug-serialisation
+  default: False
+  description:
+    Enable debug mode in serialisation. This makes serialisation slower.
+
+flag debug-parsing
+  default: False
+  description:
+    Enable debug mode in parsing. This makes parsing slower.
 
 flag enable-cluster-counting
   default: False
@@ -350,6 +362,12 @@ library
 
   if flag(debug)
     cpp-options:    -DDEBUG
+
+  if flag(debug-serialisation)
+    cpp-options:    -DDEBUG_SERIALISATION
+
+  if flag(debug-parsing)
+    cpp-options:    -DDEBUG_PARSING
 
   if flag(enable-cluster-counting)
     cpp-options:    -DCOUNT_CLUSTERS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Installation
 
 * Agda supports GHC versions 8.6.5 to 9.6.3.
 
+* Verbose output printing via `-v` or `--verbose` is now only active if Agda is built with the `debug` cabal flag.
+  Without `debug`, no code is generated for verbose printing, which makes building Agda faster and Agda itself
+  faster as well.
+
+* Removed the cabal flag `cpphs` that enabled building Agda with `cpphs` instead of the default C preprocessor.
+
 Pragmas and options
 -------------------
 

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,13 @@ STACK_INSTALL_DEP_OPTS = --only-dependencies $(STACK_INSTALL_OPTS)
 # -j1 so that cabal will print built progress to stdout.
 CABAL_INSTALL_BIN_OPTS = -j1 --disable-library-profiling \
                          $(CABAL_INSTALL_OPTS)
+CABAL_INSTALL_BIN_OPTS_DEBUG = -j1 --disable-library-profiling -fdebug \
+                               $(CABAL_INSTALL_OPTS)
 STACK_INSTALL_BIN_OPTS = --no-library-profiling \
                          $(STACK_INSTALL_OPTS)
+STACK_INSTALL_BIN_OPTS_DEBUG = --no-library-profiling \
+                               --flag Agda:debug
+                               $(STACK_INSTALL_OPTS)
 
 CABAL_CONFIGURE_OPTS = $(SLOW_CABAL_INSTALL_OPTS) \
                        --disable-library-profiling \
@@ -175,6 +180,21 @@ else
 # cabal: --enable-tests was specified, but tests can't be enabled in a remote package
 	@echo "===================== Installing using Cabal with test suites ============"
 	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=$(AGDA_BIN_SUFFIX)
+endif
+
+.PHONY: install-bin-debug ## Install Agda and test suites with debug printing enabled
+install-bin-debug: install-deps ensure-hash-is-correct
+ifdef HAS_STACK
+	@echo "===================== Installing using Stack with test suites ============"
+	time $(STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS_DEBUG)
+	mkdir -p $(BUILD_DIR)/build/
+	cp -r $(shell $(STACK) path --dist-dir)/build $(BUILD_DIR)
+	$(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)
+else
+# `cabal new-install --enable-tests` emits the error message (bug?):
+# cabal: --enable-tests was specified, but tests can't be enabled in a remote package
+	@echo "===================== Installing using Cabal with test suites ============"
+	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS_DEBUG) --program-suffix=$(AGDA_BIN_SUFFIX)
 endif
 
 .PHONY: v1-install ## Developer install goal without -foptimize-aggressively nor dependencies.

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ STACK_OPT_NO_DOCS = --no-haddock
 CABAL_OPT_TESTS   = --enable-tests
 STACK_OPT_TESTS   = --test --no-run-tests
 
-CABAL_OPT_FAST    = --ghc-options=-O0
-STACK_OPT_FAST    = --fast
+CABAL_OPT_FAST    = --ghc-options=-O0 -fdebug
+STACK_OPT_FAST    = --fast --flag Agda:debug
 
 CABAL_FLAG_ICU    = -fenable-cluster-counting
 STACK_FLAG_ICU    = --flag Agda:enable-cluster-counting

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ CABAL_INSTALL_BIN_OPTS_DEBUG = -j1 --disable-library-profiling -fdebug \
 STACK_INSTALL_BIN_OPTS = --no-library-profiling \
                          $(STACK_INSTALL_OPTS)
 STACK_INSTALL_BIN_OPTS_DEBUG = --no-library-profiling \
-                               --flag Agda:debug
+                               --flag Agda:debug \
                                $(STACK_INSTALL_OPTS)
 
 CABAL_CONFIGURE_OPTS = $(SLOW_CABAL_INSTALL_OPTS) \
@@ -202,13 +202,13 @@ endif
 v1-install:  ensure-hash-is-correct
 ifdef HAS_STACK
 	@echo "===================== Installing using Stack with test suites ============"
-	time $(STACK_INSTALL_HELPER) $(STACK_INSTALL_BIN_OPTS) $(STACK_OPT_TESTS)
+	time $(STACK_INSTALL_HELPER) $(STACK_INSTALL_BIN_OPTS_DEBUG) $(STACK_OPT_TESTS)
 	mkdir -p $(BUILD_DIR)/build/
 	cp -r $(shell $(STACK) path --dist-dir)/build $(BUILD_DIR)
 	$(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)
 else
 	@echo "===================== Installing using Cabal with test suites ============"
-	time $(CABAL_INSTALL_HELPER) $(CABAL_INSTALL_BIN_OPTS) $(CABAL_OPT_TESTS) --builddir=$(BUILD_DIR) --program-suffix=$(AGDA_BIN_SUFFIX)
+	time $(CABAL_INSTALL_HELPER) $(CABAL_INSTALL_BIN_OPTS_DEBUG) $(CABAL_OPT_TESTS) --builddir=$(BUILD_DIR) --program-suffix=$(AGDA_BIN_SUFFIX)
 endif
 
 .PHONY: fast-install-bin ## Install Agda compiled with -O0 with tests
@@ -786,26 +786,54 @@ help: ## Display this information.
 	  	NF == 2 { printf "  \033[36m%-26s\033[0m %s\n", $$1, $$2};'
 
 debug : ## Print debug information.
-	@echo "AGDA_BIN              = $(AGDA_BIN)"
-	@echo "AGDA_BIN_SUFFIX       = $(AGDA_BIN_SUFFIX)"
-	@echo "AGDA_TESTS_BIN        = $(AGDA_TESTS_BIN)"
-	@echo "AGDA_TESTS_OPTIONS    = $(AGDA_TESTS_OPTIONS)"
-	@echo "BUILD_DIR             = $(BUILD_DIR)"
-	@echo "CABAL_BUILD_CMD       = $(CABAL_BUILD_CMD)"
-	@echo "CABAL_CLEAN_CMD       = $(CABAL_CLEAN_CMD)"
-	@echo "CABAL                 = $(CABAL)"
-	@echo "CABAL_CONFIGURE_CMD   = $(CABAL_CONFIGURE_CMD)"
-	@echo "CABAL_CONFIGURE_OPTS  = $(CABAL_CONFIGURE_OPTS)"
-	@echo "CABAL_HADDOCK_CMD     = $(CABAL_HADDOCK_CMD)"
-	@echo "CABAL_INSTALL_CMD     = $(CABAL_INSTALL_CMD)"
-	@echo "CABAL_INSTALL_OPTS    = $(CABAL_INSTALL_OPTS)"
-	@echo "CABAL_OPTS            = $(CABAL_OPTS)"
-	@echo "GHC_VER               = $(GHC_VER)"
-	@echo "GHC_VERSION           = $(GHC_VERSION)"
-	@echo "PARALLEL_TESTS        = $(PARALLEL_TESTS)"
-	@echo "STACK                 = $(STACK)"
-	@echo "STACK_INSTALL_OPTS    = $(STACK_INSTALL_OPTS)"
-	@echo "STACK_OPTS            = $(STACK_OPTS)"
+	@echo "AGDA_BIN                     = $(AGDA_BIN)"
+	@echo "AGDA_BIN_SUFFIX              = $(AGDA_BIN_SUFFIX)"
+	@echo "AGDA_TESTS_BIN               = $(AGDA_TESTS_BIN)"
+	@echo "AGDA_TESTS_OPTIONS           = $(AGDA_TESTS_OPTIONS)"
+	@echo "BUILD_DIR                    = $(BUILD_DIR)"
+	@echo "CABAL                        = $(CABAL)"
+	@echo "CABAL_BUILD_CMD              = $(CABAL_BUILD_CMD)"
+	@echo "CABAL_CLEAN_CMD              = $(CABAL_CLEAN_CMD)"
+	@echo "CABAL_CONFIGURE_CMD          = $(CABAL_CONFIGURE_CMD)"
+	@echo "CABAL_CONFIGURE_OPTS         = $(CABAL_CONFIGURE_OPTS)"
+	@echo "CABAL_CONFIGURE_OPTS         = $(CABAL_CONFIGURE_OPTS)"
+	@echo "CABAL_FLAG_ICU               = $(CABAL_FLAG_ICU)"
+	@echo "CABAL_FLAG_OPTIM_HEAVY       = $(CABAL_FLAG_OPTIM_HEAVY)"
+	@echo "CABAL_HADDOCK_CMD            = $(CABAL_HADDOCK_CMD)"
+	@echo "CABAL_INSTALL                = $(CABAL_INSTALL)"
+	@echo "CABAL_INSTALL_BIN_OPTS       = $(CABAL_INSTALL_BIN_OPTS)"
+	@echo "CABAL_INSTALL_BIN_OPTS_DEBUG = $(CABAL_INSTALL_BIN_OPTS_DEBUG)"
+	@echo "CABAL_INSTALL_CMD            = $(CABAL_INSTALL_CMD)"
+	@echo "CABAL_INSTALL_DEP_OPTS       = $(CABAL_INSTALL_DEP_OPTS)"
+	@echo "CABAL_INSTALL_HELPER         = $(CABAL_INSTALL_HELPER)"
+	@echo "CABAL_INSTALL_OPTS           = $(CABAL_INSTALL_OPTS)"
+	@echo "CABAL_OPTS                   = $(CABAL_OPTS)"
+	@echo "CABAL_OPT_FAST               = $(CABAL_OPT_FAST)"
+	@echo "CABAL_OPT_NO_DOCS            = $(CABAL_OPT_NO_DOCS)"
+	@echo "FAST_CABAL_INSTALL           = $(FAST_CABAL_INSTALL)"
+	@echo "FAST_STACK_INSTALL           = $(FAST_STACK_INSTALL)"
+	@echo "GHC_OPTS                     = $(GHC_OPTS)"
+	@echo "GHC_RTS_OPTS                 = $(GHC_RTS_OPTS)"
+	@echo "GHC_VER                      = $(GHC_VER)"
+	@echo "GHC_VERSION                  = $(GHC_VERSION)"
+	@echo "PARALLEL_TESTS               = $(PARALLEL_TESTS)"
+	@echo "QUICK_CABAL_INSTALL          = $(QUICK_CABAL_INSTALL)"
+	@echo "QUICK_STACK_INSTALL          = $(QUICK_STACK_INSTALL)"
+	@echo "SLOW_CABAL_INSTALL_OPTS      = $(SLOW_CABAL_INSTALL_OPTS)"
+	@echo "SLOW_STACK_INSTALL_OPTS      = $(SLOW_STACK_INSTALL_OPTS)"
+	@echo "STACK                        = $(STACK)"
+	@echo "STACK_FLAG_ICU               = $(STACK_FLAG_ICU)"
+	@echo "STACK_FLAG_OPTIM_HEAVY       = $(STACK_FLAG_OPTIM_HEAVY)"
+	@echo "STACK_INSTALL                = $(STACK_INSTALL)"
+	@echo "STACK_INSTALL_BIN_OPTS       = $(STACK_INSTALL_BIN_OPTS)"
+	@echo "STACK_INSTALL_BIN_OPTS_DEBUG = $(STACK_INSTALL_BIN_OPTS_DEBUG)"
+	@echo "STACK_INSTALL_DEP_OPTS       = $(STACK_INSTALL_DEP_OPTS)"
+	@echo "STACK_INSTALL_HELPER         = $(STACK_INSTALL_HELPER)"
+	@echo "STACK_INSTALL_OPTS           = $(STACK_INSTALL_OPTS)"
+	@echo "STACK_OPTS                   = $(STACK_OPTS)"
+	@echo "STACK_OPT_FAST               = $(STACK_OPT_FAST)"
+	@echo "STACK_OPT_NO_DOCS            = $(STACK_OPT_NO_DOCS)"
+	@echo "PROFILEOPTS                  = $(PROFILEOPTS)"
 	@echo
 	@echo "Run \`make -pq\` to get a detailed report."
 	@echo

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -475,7 +475,20 @@ When installing Agda the following flags can be used:
 
 .. option:: debug
 
-     Enable debugging features that may slow Agda down. Default: off.
+     Enable debug printing. This makes Agda slightly slower, and
+     building Agda slower as well. The :option:`--verbose={N}` option
+     only has an effect when Agda was installed with this flag.
+     Default: off.
+
+.. option:: debug-serialisation
+
+     Enable debug mode in serialisation. This makes serialisation slower.
+     Default: off.
+
+.. option:: debug-parsing
+
+     Enable debug mode in the parser. This makes parsing slower.
+     Default: off.
 
 .. option:: enable-cluster-counting
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -450,7 +450,8 @@ Printing and debugging
 
 .. option:: --verbose={N}, -v={N}
 
-     Set verbosity level to ``N``.
+     Set verbosity level to ``N``. This only has an effect if
+     Agda was installed with the :option:`debug` flag.
 
 .. option:: --profile={PROF}
 

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -234,7 +234,7 @@ backendInteraction mainFile backends setup check = do
 
   -- print warnings that might have accumulated during compilation
   ws <- filter (not . isUnsolvedWarning . tcWarning) <$> getAllWarnings AllWarnings
-  unless (null ws) $ reportSDoc "warning" 1 $ P.vcat $ P.prettyTCM <$> ws
+  unless (null ws) $ alwaysReportSDoc "warning" 1 $ P.vcat $ P.prettyTCM <$> ws
 
 
 compilerMain :: Backend' opts env menv mod def -> IsMain -> CheckResult -> TCM ()

--- a/src/full/Agda/Compiler/CallCompiler.hs
+++ b/src/full/Agda/Compiler/CallCompiler.hs
@@ -47,7 +47,7 @@ callCompiler doCall cmd args cwd enc =
       Nothing     -> return ()
       Just errors -> typeError (CompilationError errors)
   else
-    reportSLn "compile.cmd" 1 $ "NOT calling: " ++ unwords (cmd : args)
+    alwaysReportSLn "compile.cmd" 1 $ "NOT calling: " ++ unwords (cmd : args)
 
 -- | Generalisation of @callCompiler@ where the raised exception is
 -- returned.
@@ -64,7 +64,7 @@ callCompiler'
      -- from the process (stdout and stderr).
   -> TCM (Maybe String)
 callCompiler' cmd args cwd enc = do
-  reportSLn "compile.cmd" 1 $ "Calling: " ++ unwords (cmd : args)
+  alwaysReportSLn "compile.cmd" 1 $ "Calling: " ++ unwords (cmd : args)
   (_, out, err, p) <-
     liftIO $ createProcess
                (proc cmd args) { std_err = CreatePipe
@@ -83,7 +83,7 @@ callCompiler' cmd args cwd enc = do
         Nothing  -> return ()
         Just enc -> liftIO $ hSetEncoding out enc
       progressInfo <- liftIO $ hGetContents out
-      mapM_ (reportSLn "compile.output" 1) $ lines progressInfo
+      mapM_ (alwaysReportSLn "compile.output" 1) $ lines progressInfo
 
   errors <- liftIO $ case err of
     Nothing  -> __IMPOSSIBLE__

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -244,7 +244,7 @@ jsPreModule _opts _ m mifile = do
     yesComp compile = do
       m   <- prettyShow <$> curMName
       out <- outFile_
-      reportSLn "compile.js" 1 $ repl [m, ifileDesc, out] "Compiling <<0>> in <<1>> to <<2>>"
+      alwaysReportSLn "compile.js" 1 $ repl [m, ifileDesc, out] "Compiling <<0>> in <<1>> to <<2>>"
       kit <- coinductionKit
       return $ Recompile $ JSModuleEnv
         { jsCoinductionKit = kit

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -407,7 +407,7 @@ ghcPreModule cenv isMain m mifile =
     yesComp = do
       m   <- prettyShow <$> curMName
       out <- curOutFile
-      reportSLn "compile.ghc" 1 $ repl [m, ifileDesc, out] "Compiling <<0>> in <<1>> to <<2>>"
+      alwaysReportSLn "compile.ghc" 1 $ repl [m, ifileDesc, out] "Compiling <<0>> in <<1>> to <<2>>"
       asks Recompile
 
 ghcPostModule

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -691,7 +691,7 @@ getStoredInterface x file msrc = do
         let ws = filter ((Strict.Just (Just x) ==) .
                          fmap rangeFileName . tcWarningOrigin) $
                  iWarnings i
-        unless (null ws) $ reportSDoc "warning" 1 $ P.vcat $ P.prettyTCM <$> ws
+        unless (null ws) $ alwaysReportSDoc "warning" 1 $ P.vcat $ P.prettyTCM <$> ws
 
         loadDecodedModule file $ ModuleInfo
           { miInterface = i
@@ -833,7 +833,7 @@ createInterfaceIsolated x file msrc = do
       -- NOTE: This attempts to type-check FOREVER if for some
       -- reason it continually fails to validate interface.
       let recheckOnError = \msg -> do
-            reportSLn "import.iface" 1 $ "Failed to validate just-loaded interface: " ++ msg
+            alwaysReportSLn "import.iface" 1 $ "Failed to validate just-loaded interface: " ++ msg
             createInterfaceIsolated x file msrc
 
       either recheckOnError pure validated
@@ -857,7 +857,7 @@ chaseMsg kind x file = do
            | List.isPrefixOf "Loading" kind
              && traceImports > 2 = 1
            | otherwise = 2
-  reportSLn "import.chase" vLvl $ concat
+  alwaysReportSLn "import.chase" vLvl $ concat
     [ indentation, kind, " ", prettyShow x, maybeFile ]
 
 -- | Print the highlighting information contained in the given interface.
@@ -897,7 +897,7 @@ readInterface file = do
   where
     handler = \case
       IOException _ _ e -> do
-        reportSLn "" 0 $ "IO exception: " ++ show e
+        alwaysReportSLn "" 0 $ "IO exception: " ++ show e
         return Nothing   -- Work-around for file locking bug.
                          -- TODO: What does this refer to? Please
                          -- document.
@@ -932,7 +932,7 @@ writeInterface file i = let fp = filePath file in do
     return filteredIface
 #endif
   `catchError` \e -> do
-    reportSLn "" 1 $
+    alwaysReportSLn "" 1 $
       "Failed to write interface " ++ fp ++ "."
     liftIO $
       whenM (doesFileExist fp) $ removeFile fp
@@ -965,7 +965,7 @@ createInterface mname file isMain msrc = do
                                      fmap rangeFileName . tcWarningOrigin) $
                              tcWarnings classified
                    unless (null wa') $
-                     reportSDoc "warning" 1 $ P.vcat $ P.prettyTCM <$> wa'
+                     alwaysReportSDoc "warning" 1 $ P.vcat $ P.prettyTCM <$> wa'
                    when (null (nonFatalErrors classified)) $ chaseMsg "Finished" x Nothing)
 
   withMsgs $

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -1597,7 +1597,7 @@ pragmaOptions = concat
                     "use unicode characters when printing terms" ""
                     Nothing
   , [ Option ['v']  ["verbose"] (ReqArg verboseFlag "N")
-                    "set verbosity level to N"
+                    "set verbosity level to N. Only has an effect if Agda was built with the \"debug\" flag."
     , Option []     ["profile"] (ReqArg profileFlag "TYPE")
                     ("turn on profiling for TYPE (where TYPE=" ++ intercalate "|" validProfileOptionStrings ++ ")")
     ]

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -241,7 +241,7 @@ runAgdaWithOptions interactor progName opts = do
           -- Print accumulated warnings
           unlessNullM (tcWarnings . classifyWarnings <$> getAllWarnings AllWarnings) $ \ ws -> do
             let banner = text $ "\n" ++ delimiter "All done; warnings encountered"
-            reportSDoc "warning" 1 $
+            alwaysReportSDoc "warning" 1 $
               vcat $ punctuate "\n" $ banner : (prettyTCM <$> ws)
 
           return result

--- a/src/full/Agda/Syntax/Concrete/Operators/Parser/Monad.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators/Parser/Monad.hs
@@ -43,7 +43,7 @@ instance Hashable MemoKey
 -- | The parser monad.
 
 type Parser tok a =
-#ifdef DEBUG
+#ifdef DEBUG_PARSING
   Parser.ParserWithGrammar
 #else
   Parser.Parser

--- a/src/full/Agda/Syntax/Internal/SanityCheck.hs
+++ b/src/full/Agda/Syntax/Internal/SanityCheck.hs
@@ -21,7 +21,7 @@ sanityCheckVars tel v =
   case filter bad (Set.toList $ allFreeVars v) of
     [] -> return ()
     xs -> do
-      reportSDoc "impossible" 1 . return $
+      alwaysReportSDoc "impossible" 1 . return $
         sep [ hang "Sanity check failed for" 2
                    (hang (pretty tel <+> "|-") 2 (pretty v))
             , text $ "out of scope: " ++ show xs ]
@@ -70,7 +70,7 @@ sanityCheckSubst gamma rho delta = go gamma rho delta
     dropLastN n = telFromList . dropEnd n . telToList
 
     err reason = do
-      reportSDoc "impossible" 1 . return $
+      alwaysReportSDoc "impossible" 1 . return $
         sep [ hang "Sanity check failed for" 2 $
               hang (pretty gamma <+> "|-") 2 $
               hang (pretty rho <+> ":") 2 $

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 
 module Agda.TypeChecking.Monad.Debug
   ( module Agda.TypeChecking.Monad.Debug
@@ -216,10 +217,26 @@ instance ReportS [String]  where reportS k n = reportSLn  k n . unlines
 instance ReportS [Doc]     where reportS k n = reportSLn  k n . render . vcat
 instance ReportS Doc       where reportS k n = reportSLn  k n . render
 
+#ifdef DEBUG
+
 -- | Conditionally println debug string.
 {-# SPECIALIZE reportSLn :: VerboseKey -> VerboseLevel -> String -> TCM () #-}
 reportSLn :: MonadDebug m => VerboseKey -> VerboseLevel -> String -> m ()
 reportSLn k n s = verboseS k n $ displayDebugMessage k n $ s ++ "\n"
+
+#else
+
+{-# INLINE reportSLn #-}
+reportSLn :: MonadDebug m => VerboseKey -> VerboseLevel -> String -> m ()
+reportSLn _ _ _ = pure ()
+
+#endif
+
+-- | Conditionally println debug string. Works regardless of the debug flag.
+{-# SPECIALIZE reportSLn :: VerboseKey -> VerboseLevel -> String -> TCM () #-}
+alwaysReportSLn :: MonadDebug m => VerboseKey -> VerboseLevel -> String -> m ()
+alwaysReportSLn k n s = verboseS k n $ displayDebugMessage k n $ s ++ "\n"
+
 
 __IMPOSSIBLE_VERBOSE__ :: (HasCallStack, MonadDebug m) => String -> m a
 __IMPOSSIBLE_VERBOSE__ s = do
@@ -236,6 +253,8 @@ __IMPOSSIBLE_VERBOSE__ s = do
     -- Create the "Impossible" error using *our* caller as the call site.
     err = withCallerCallStack Impossible
 
+#ifdef DEBUG
+
 -- | Conditionally render debug 'Doc' and print it.
 {-# SPECIALIZE reportSDoc :: VerboseKey -> VerboseLevel -> TCM Doc -> TCM () #-}
 reportSDoc :: MonadDebug m => VerboseKey -> VerboseLevel -> TCM Doc -> m ()
@@ -247,6 +266,26 @@ reportResult :: MonadDebug m => VerboseKey -> VerboseLevel -> (a -> TCM Doc) -> 
 reportResult k n debug action = do
   x <- action
   x <$ reportSDoc k n (debug x)
+
+#else
+
+-- | Conditionally render debug 'Doc' and print it.
+{-# INLINE reportSDoc #-}
+reportSDoc :: MonadDebug m => VerboseKey -> VerboseLevel -> TCM Doc -> m ()
+reportSDoc _ _ _ = pure ()
+
+-- | Debug print the result of a computation.
+{-# INLINE reportResult #-}
+reportResult :: MonadDebug m => VerboseKey -> VerboseLevel -> (a -> TCM Doc) -> m a -> m a
+reportResult _ _ _ action = action
+
+#endif
+
+-- | Conditionally render debug 'Doc' and print it. Works regardless of the debug flag.
+{-# SPECIALIZE reportSDoc :: VerboseKey -> VerboseLevel -> TCM Doc -> TCM () #-}
+alwaysReportSDoc :: MonadDebug m => VerboseKey -> VerboseLevel -> TCM Doc -> m ()
+alwaysReportSDoc k n d = verboseS k n $ do
+  displayDebugMessage k n . (++ "\n") =<< formatDebugMessage k n (locallyTC eIsDebugPrinting (const True) d)
 
 unlessDebugPrinting :: MonadDebug m => m () -> m ()
 unlessDebugPrinting = unlessM isDebugPrinting
@@ -272,6 +311,9 @@ instance TraceS [String]  where traceS k n = traceSLn  k n . unlines
 instance TraceS [Doc]     where traceS k n = traceSLn  k n . render . vcat
 instance TraceS Doc       where traceS k n = traceSLn  k n . render
 
+
+#ifdef DEBUG
+
 traceSLn :: MonadDebug m => VerboseKey -> VerboseLevel -> String -> m a -> m a
 traceSLn k n s = applyWhenVerboseS k n $ traceDebugMessage k n $ s ++ "\n"
 
@@ -280,6 +322,20 @@ traceSDoc :: MonadDebug m => VerboseKey -> VerboseLevel -> TCM Doc -> m a -> m a
 traceSDoc k n d = applyWhenVerboseS k n $ \cont -> do
   s <- formatDebugMessage k n $ locallyTC eIsDebugPrinting (const True) d
   traceDebugMessage k n (s ++ "\n") cont
+
+#else
+
+{-# INLINE traceSLn #-}
+traceSLn :: MonadDebug m => VerboseKey -> VerboseLevel -> String -> m a -> m a
+traceSLn _ _ _ action = action
+
+-- | Conditionally render debug 'Doc', print it, and then continue.
+{-# INLINE traceSDoc #-}
+traceSDoc :: MonadDebug m => VerboseKey -> VerboseLevel -> TCM Doc -> m a -> m a
+traceSDoc _ _ _ action = action
+
+#endif
+
 
 openVerboseBracket :: MonadDebug m => VerboseKey -> VerboseLevel -> String -> m ()
 openVerboseBracket k n s = displayDebugMessage k n $ "{ " ++ s ++ "\n"

--- a/src/full/Agda/TypeChecking/Monad/Statistics.hs
+++ b/src/full/Agda/TypeChecking/Monad/Statistics.hs
@@ -89,6 +89,6 @@ printStatistics mmname stats = do
         -- Second column (right aligned) is numbers.
         col2 = Boxes.vcat Boxes.right $ map (Boxes.text . showThousandSep . snd) stats
         table = Boxes.hsep 1 Boxes.left [col1, col2]
-    reportSLn "" 1 $ caseMaybe mmname "Accumulated statistics" $ \ mname ->
+    alwaysReportSLn "" 1 $ caseMaybe mmname "Accumulated statistics" $ \ mname ->
       "Statistics for " ++ prettyShow mname
-    reportSLn "" 1 $ Boxes.render table
+    alwaysReportSLn "" 1 $ Boxes.render table

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wunused-imports #-}
-
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Agda.TypeChecking.Reduce.Monad
@@ -24,7 +24,9 @@ import Agda.TypeChecking.Substitute
 
 import Agda.Utils.Lens
 import Agda.Utils.Maybe
+#ifdef DEBUG
 import Agda.Utils.Monad
+#endif
 import Agda.Syntax.Common.Pretty () --instance only
 
 
@@ -86,8 +88,13 @@ instance MonadDebug ReduceM where
       (s , _) <- runTCM env st $ formatDebugMessage k n d
       return $ return s
 
+#ifdef DEBUG
   verboseBracket k n s = applyWhenVerboseS k n $
     bracket_ (openVerboseBracket k n s) (const $ closeVerboseBracket k n)
+#else
+  verboseBracket k n s ma = ma
+  {-# INLINE verboseBracket #-}
+#endif
 
   getVerbosity      = defaultGetVerbosity
   getProfileOptions = defaultGetProfileOptions

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -148,12 +148,12 @@ encode a = do
     statistics :: String -> IORef FreshAndReuse -> TCM ()
     statistics kind ioref = do
       FreshAndReuse fresh
-#ifdef DEBUG
+#ifdef DEBUG_SERIALISATION
                           reused
 #endif
                                  <- liftIO $ readIORef ioref
       tickN (kind ++ "  (fresh)") $ fromIntegral fresh
-#ifdef DEBUG
+#ifdef DEBUG_SERIALISATION
       tickN (kind ++ " (reused)") $ fromIntegral reused
 #endif
 

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -123,7 +123,7 @@ lookupME proxy fprint me found notfound = go fprint me where
 
 -- | Structure providing fresh identifiers for hash map
 --   and counting hash map hits (i.e. when no fresh identifier required).
-#ifdef DEBUG
+#ifdef DEBUG_SERIALISATION
 data FreshAndReuse = FreshAndReuse
   { farFresh :: !Int32 -- ^ Number of hash map misses.
   , farReuse :: !Int32 -- ^ Number of hash map hits.
@@ -136,7 +136,7 @@ newtype FreshAndReuse = FreshAndReuse
 
 farEmpty :: FreshAndReuse
 farEmpty = FreshAndReuse 0
-#ifdef DEBUG
+#ifdef DEBUG_SERIALISATION
                            0
 #endif
 
@@ -144,7 +144,7 @@ lensFresh :: Lens' FreshAndReuse Int32
 lensFresh f r = f (farFresh r) <&> \ i -> r { farFresh = i }
 {-# INLINE lensFresh #-}
 
-#ifdef DEBUG
+#ifdef DEBUG_SERIALISATION
 lensReuse :: Lens' FreshAndReuse Int32
 lensReuse f r = f (farReuse r) <&> \ i -> r { farReuse = i }
 {-# INLINE lensReuse #-}
@@ -336,7 +336,7 @@ icodeX dict counter key = do
     mi <- H.lookup d key
     case mi of
       Just i  -> do
-#ifdef DEBUG
+#ifdef DEBUG_SERIALISATION
         modifyIORef' c $ over lensReuse (+1)
 #endif
         return $! i
@@ -357,7 +357,7 @@ icodeInteger key = do
     mi <- H.lookup d key
     case mi of
       Just i  -> do
-#ifdef DEBUG
+#ifdef DEBUG_SERIALISATION
         modifyIORef' c $ over lensReuse (+1)
 #endif
         return $! i
@@ -374,7 +374,7 @@ icodeDouble key = do
     mi <- H.lookup d key
     case mi of
       Just i  -> do
-#ifdef DEBUG
+#ifdef DEBUG_SERIALISATION
         modifyIORef' c $ over lensReuse (+1)
 #endif
         return $! i
@@ -391,7 +391,7 @@ icodeString key = do
     mi <- H.lookup d key
     case mi of
       Just i  -> do
-#ifdef DEBUG
+#ifdef DEBUG_SERIALISATION
         modifyIORef' c $ over lensReuse (+1)
 #endif
         return i
@@ -408,7 +408,7 @@ icodeNode key = do
     mi <- H.lookup d key
     case mi of
       Just i  -> do
-#ifdef DEBUG
+#ifdef DEBUG_SERIALISATION
         modifyIORef' c $ over lensReuse (+1)
 #endif
         return $! i
@@ -434,7 +434,7 @@ icodeMemo getDict getCounter a icodeP = do
     st <- asks getCounter
     case mi of
       Just i  -> liftIO $ do
-#ifdef DEBUG
+#ifdef DEBUG_SERIALISATION
         modifyIORef' st $ over lensReuse (+ 1)
 #endif
         return $! i

--- a/src/github/workflows/stack-dry-run.yml
+++ b/src/github/workflows/stack-dry-run.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       EXTRA_ARGS: "--dry-run"
         # stack build --only-configure also installs dependencies, so we need --dry-run
-      NON_DEFAULT_FLAGS: "--flag Agda:enable-cluster-counting --flag Agda:debug"
+      NON_DEFAULT_FLAGS: "--flag Agda:enable-cluster-counting --flag Agda:debug --flag Agda:debug-serialisation --flag Agda:debug-parsing"
 
     defaults:
       run:

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
       ## but printing stuff might not hurt here.
 
     - name: "Build Agda"
-      run: make BUILD_DIR="${BUILD_DIR}" install-bin
+      run: make BUILD_DIR="${BUILD_DIR}" install-bin-debug
 
     - name: "Run tests for the size solver"
       run: |


### PR DESCRIPTION
Disable generating any code for reporting functions in Agda.TypeChecking.Monad.Debug if the DEBUG flag is not enabled. This yields noticable build time and runtime speedups.

Previously the DEBUG flag was only used in serialization. That usage is now relegated to the new DEBUG_SERIALISATION flag.

There are two new functions, `alwaysReportSLn` and `alwaysReportSDoc`, which are always active, regardless of the DEBUG flag. These are used wherever we previously printed with verbosity 1, so default printing output is unchanged.