### PR TITLE
More shell command fixes

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -8,10 +8,10 @@ ChoicesQuestion() {
     shift; shift; shift
     while true; do
         {   echo -n "$question ["
-            [ "$default" = "$first" ] && echo -n "$first" | tr 'a-z' 'A-Z' || echo -n "$first"
+            [ "$default" = "$first" ] && echo -n "$first" | tr '[:lower:]' '[:upper:]' || echo -n "$first"
             for c in "$@"; do
                 echo -n '/'
-                [ "$default" = "$c" ] && echo -n "$c" | tr 'a-z' 'A-Z' || echo -n "$c"
+                [ "$default" = "$c" ] && echo -n "$c" | tr '[:lower:]' '[:upper:]' || echo -n "$c"
             done
             echo -n '] '
             read -r ans;

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ue
 PATH=./.cabal-sandbox/bin${PATH:+:$PATH}

--- a/release.sh
+++ b/release.sh
@@ -27,7 +27,8 @@ ChoicesQuestion() {
     done
 }
 YesNoQuestion() {
-    local r=$(ChoicesQuestion "$1" "${2:-y}" y n)
+    local r
+    r=$(ChoicesQuestion "$1" "${2:-y}" y n)
     [ "$r" = y ]
 }
 

--- a/src/agda-bisect/Bisect.hs
+++ b/src/agda-bisect/Bisect.hs
@@ -488,7 +488,7 @@ main = do
     Just (DryRunCommit commit) -> do
       setupSandbox opts
 
-      let checkout c = callProcess "git" ["checkout", c]
+      let checkout c = callProcess "git" ["switch", "--detach", c]
       bracket currentCommit checkout $ \_ -> do
         checkout commit
 


### PR DESCRIPTION
This is a continuation of #6322 and #6323 to clean up all remaining issues in `release.sh` _and_ remove one hidden use of `git checkout` in the Haskell code. I changed my mind to use `[:lower:]` and `[:upper:]` anyways to satisfy ShellCheck.

PS: Here is the [documentation of `git switch --detach <commit>`,](https://git-scm.com/docs/git-switch#Documentation/git-switch.txt---detach) which is exactly what we wish to achieve with `git checkout <commit>`. For the masking of return values, see <https://www.shellcheck.net/wiki/SC2155>