### PR TITLE
[ fix #6867 ] Only consider arguments with @0 for forcing if --erasure is on

### DIFF
--- a/doc/user-manual/language/generalization-of-declared-variables.lagda.rst
+++ b/doc/user-manual/language/generalization-of-declared-variables.lagda.rst
@@ -61,7 +61,7 @@ Nested generalization
 
 ..
   ::
-  module _ where
+  module Nested where
 
 When generalizing a variable, any generalizable variables in its type are also generalized
 over. For instance, you can declare ``A`` to be a type at some level ``ℓ`` as
@@ -132,23 +132,23 @@ metavariable created for ``ℓ`` is solved to level 0 and is thus not generalize
 A typical case where this happens is when you have dependencies between different nested
 variables. For instance::
 
-  postulate
-    Con : Set
+    postulate
+      Con : Set
 
-  variable
-    Γ Δ Θ : Con
+    variable
+      Γ Δ Θ : Con
 
-  postulate
-    Sub : Con → Con → Set
+    postulate
+      Sub : Con → Con → Set
 
-    idS : Sub Γ Γ
-    _∘_ : Sub Γ Δ → Sub Δ Θ → Sub Γ Θ
+      idS : Sub Γ Γ
+      _∘_ : Sub Γ Δ → Sub Δ Θ → Sub Γ Θ
 
-  variable
-    δ σ γ : Sub Γ Δ
+    variable
+      δ σ γ : Sub Γ Δ
 
-  postulate
-    assoc : δ ∘ (σ ∘ γ) ≡ (δ ∘ σ) ∘ γ
+    postulate
+      assoc : δ ∘ (σ ∘ γ) ≡ (δ ∘ σ) ∘ γ
 
 In the type of ``assoc`` each substitution gets two nested variable metas for their contexts,
 but the type of ``_∘_`` requires the contexts of its arguments to match up, so some of
@@ -156,8 +156,8 @@ these metavariables are solved. The resulting type is
 
 .. code-block:: agda
 
-  assoc : {δ.Γ δ.Δ : Con} {δ : Sub δ.Γ δ.Δ} {σ.Δ : Con} {σ : Sub δ.Δ σ.Δ}
-          {γ.Δ : Con} {γ : Sub σ.Δ γ.Δ} → (δ ∘ (σ ∘ γ)) ≡ ((δ ∘ σ) ∘ γ)
+    assoc : {δ.Γ δ.Δ : Con} {δ : Sub δ.Γ δ.Δ} {σ.Δ : Con} {σ : Sub δ.Δ σ.Δ}
+            {γ.Δ : Con} {γ : Sub σ.Δ γ.Δ} → (δ ∘ (σ ∘ γ)) ≡ ((δ ∘ σ) ∘ γ)
 
 where we can see from the names that ``σ.Γ`` was unified with ``δ.Δ`` and ``γ.Γ`` with
 ``σ.Δ``. In general, when unifying two metavariables the "youngest" one is eliminated which
@@ -168,24 +168,24 @@ metas are generalized over. For instance,
 
 ..
   ::
-  sum : Vec Nat n → Nat
-  sum [] = 0
-  sum (x ∷ xs) = x + sum xs
+    sum : Vec Nat n → Nat
+    sum [] = 0
+    sum (x ∷ xs) = x + sum xs
 
 ::
 
-  variable
-    xs : Vec A n
+    variable
+      xs : Vec A n
 
-  head : Vec A (suc n) → A
-  head (x ∷ _) = x
+    head : Vec A (suc n) → A
+    head (x ∷ _) = x
 
-  -- lemma : {xs.n.1 : Nat} {xs : Vec Nat (suc xs.n.1)} → head xs ≡ 1 → (0 < sum xs) ≡ true
-  lemma : head xs ≡ 1 → (0 < sum xs) ≡ true
+    -- lemma : {xs.n.1 : Nat} {xs : Vec Nat (suc xs.n.1)} → head xs ≡ 1 → (0 < sum xs) ≡ true
+    lemma : head xs ≡ 1 → (0 < sum xs) ≡ true
 
 ..
   ::
-  lemma {xs = x ∷ _} refl = refl
+    lemma {xs = x ∷ _} refl = refl
 
 In the type of ``lemma`` a metavariable is created for the length of ``xs``, which
 the application ``head xs`` refines to ``suc _n``, for some new metavariable ``_n``.
@@ -219,7 +219,7 @@ The general naming scheme for nested generalized variables is
 
 .. code-block:: agda
 
-  id : {A.ℓ : Level} {A : Set ℓ} → A → A
+    id : {A.ℓ : Level} {A : Set ℓ} → A → A
 
 the name of the level variable is ``A.ℓ`` since the name of the nested variable is
 ``ℓ`` and its parent is the named variable ``A``. For multiple levels of nesting the
@@ -227,7 +227,7 @@ parent can be another nested variable as in the ``refl′`` case above
 
 .. code-block:: agda
 
-  refl′ : {x.A.ℓ : Level} {x.A : Set x.A.ℓ} {x : x.A} → x ≡ x
+    refl′ : {x.A.ℓ : Level} {x.A : Set x.A.ℓ} {x : x.A} → x ≡ x
 
 If a nested generalizable variable is solved with a term containing
 further metas, these are generalized over as explained in the ``lemma`` example
@@ -247,15 +247,15 @@ in. For example,
 
 ::
 
-  postulate
-    V : (A : Set) → Nat → Set
-    P : V A n → Set
+    postulate
+      V : (A : Set) → Nat → Set
+      P : V A n → Set
 
-  variable
-    v : V _ _
+    variable
+      v : V _ _
 
-  postulate
-    thm : P v
+    postulate
+      thm : P v
 
 Here there are two unnamed variables in the type of ``v``, namely the two arguments to ``V``.
 The first argument has the label ``A`` in the definition of ``V``, so this variable gets the name
@@ -293,14 +293,19 @@ The following rules are used to place generalized variables:
 Indexed datatypes
 -----------------
 
-When generalizing datatype parameters and indicies a variable is turned into
+When generalizing datatype parameters and indices a variable is turned into
 an index if it is only mentioned in indices and into a parameter otherwise.
 For instance,
 
 ..
   ::
 
-  module Vectors where
+  module Indexed where
+
+    variable
+      @0 A : Set
+      x : A
+      xs : Vec A n
 
 ::
 
@@ -320,7 +325,14 @@ Instance and irrelevant variables
 
 Generalized variables are introduced as implicit arguments by default, but this can be
 changed to :ref:`instance arguments <instance-arguments>`  or
-:ref:`irrelevant arguments <irrelevance>` by annotating the declaration of the variable::
+:ref:`irrelevant arguments <irrelevance>` by annotating the declaration of the variable
+
+..
+  ::
+
+  open Nested
+
+::
 
   record Eq (A : Set) : Set where
     field eq : A → A → Bool

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -104,6 +104,8 @@ computeForcingAnnotations c t =
     -- get to the actual data type.
     -- Also #2947: The type might reduce to a pi type.
     TelV tel (El _ a) <- telViewPath t
+    -- Jesper, 2023-09-20 (#6867): With --erasure, only arguments with @0 can be forced.
+    erasureOn <- optErasure <$> pragmaOptions
     let vs = case a of
           Def _ us -> us
           _        -> __IMPOSSIBLE__
@@ -120,7 +122,7 @@ computeForcingAnnotations c t =
         -- case it isn't really forced.
         isForced :: Modality -> Nat -> Bool
         isForced m i =
-               (hasQuantity0 m || noUserQuantity m)
+               (hasQuantity0 m || not erasureOn)
             && (getRelevance m /= Irrelevant)
             && case IntMap.lookup i xs' of
                  Nothing -> False

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -727,8 +727,9 @@ unfoldDefinitionStep v0 f es =
                           defaultResult -- non-terminating or delayed
         ([],[])        -> traceSLn "tc.reduce" 90 "reduceNormalE: no clauses or rewrite rules" $ do
           -- no definition for head
-          blk <- instantiate =<< do defBlocked <$> getConstInfo f
-          noReduction $ blk $> vfull
+          (defBlocked <$> getConstInfo f) >>= \case
+            Blocked{}    -> noReduction $ Blocked (UnblockOnDef f) vfull
+            NotBlocked{} -> defaultResult
         (cls,rewr)     -> do
           ev <- appDefE_ f v0 cls mcc rewr es
           debugReduce ev

--- a/test/Fail/BadForcedIrrelevance.err
+++ b/test/Fail/BadForcedIrrelevance.err
@@ -1,3 +1,0 @@
-BadForcedIrrelevance.agda:11,16-17
-Variable n is declared erased, so it cannot be used here
-when checking that the expression n has type Nat

--- a/test/Succeed/BadForcedIrrelevance.agda
+++ b/test/Succeed/BadForcedIrrelevance.agda
@@ -11,3 +11,6 @@ g : (@erased n : Nat) → V n → Nat
 g _ (cons n) = n
 --             ^ so we can't return n here, since we're really
 --               returning the erased one.
+
+-- Jesper, 2023-09-20 (#6867): Now we no longer mark `n` as forced, so this
+-- example is accepted.

--- a/test/Succeed/Issue6856.agda
+++ b/test/Succeed/Issue6856.agda
@@ -1,0 +1,45 @@
+data _＝_ {X : Set} : X → X → Set where
+ refl : {x : X} → x ＝ x
+
+record Σ {X : Set} (Y : X → Set) : Set  where
+ constructor
+  _,_
+ field
+  pr₁ : X
+  pr₂ : Y pr₁
+
+_×_ : Set → Set → Set
+X × Y = Σ λ (_ : X) → Y
+
+id : {X : Set} → X → X
+id x = x
+
+_∘_ : {X : Set} {Y : Set} {Z : Y → Set}
+    → ((y : Y) → Z y)
+    → (f : X → Y) (x : X) → Z (f x)
+g ∘ f = λ x → g (f x)
+
+_∼_ : {X : Set} {A : X → Set} → ((x : X) → A x) → ((x : X) → A x) → Set
+f ∼ g = ∀ x → f x ＝ g x
+
+_≅_ : Set → Set → Set
+X ≅ Y = Σ λ (f : X → Y) → Σ λ (g : Y → X) → (g ∘ f ∼ id) × (f ∘ g ∼ id)
+
+fact : (X Y : Set) (A : X → Set) (B : Y → Set) →
+       (Σ λ (x : X) → Σ λ (y : Y) → A x × B y)
+     ≅ ((Σ λ (x : X) → A x) × (Σ λ (y : Y) → B y))
+fact X Y A B = f , g , gf , fg
+  where
+   f : _
+   f (x , y , a , b) = ((x , a) , (y , b))
+   g : _
+   g ((x , a) , (y , b)) = x , y , a , b
+   fg : f ∘ g ∼ id
+   fg _ = refl
+   gf : g ∘ f ∼ id
+   gf _ = refl
+
+infixr 50 _,_
+infixl 5 _∘_
+infix  4 _∼_
+infixr 2 _×_

--- a/test/Succeed/Issue6867.agda
+++ b/test/Succeed/Issue6867.agda
@@ -1,0 +1,9 @@
+{-# OPTIONS --erasure #-}
+
+postulate A : Set
+
+data This : A → Set where
+  this : (x : A) → This x
+
+id-this : (@0 x : A) → This x → This x
+id-this _ (this x) = this x


### PR DESCRIPTION
This implements my suggested fix for #6867: when `--erasure` is on, we only consider arguments to be forced if they have a `@0` annotation. This is because forced arguments need to be reconstructible from the type, but the type lives at modality `@0`.