### PR TITLE
Code quality: replace `List.group*` by `List1.group*`

### DIFF
--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -219,8 +219,8 @@ import Agda.Utils.FileName      ( AbsolutePath )
 import Agda.Utils.Function      ( applyWhen, applyUnless )
 import Agda.Utils.Functor       ( (<&>) )
 import Agda.Utils.Lens          ( Lens', (^.), over, set )
-import Agda.Utils.List          ( groupOn, headWithDefault, initLast1 )
-import Agda.Utils.List1         ( String1, toList )
+import Agda.Utils.List          ( headWithDefault, initLast1 )
+import Agda.Utils.List1         ( List1, String1, pattern (:|), toList )
 import qualified Agda.Utils.List1        as List1
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Monad         ( tell1 )
@@ -1898,17 +1898,17 @@ getOptSimple argv opts fileArg = \ defaults ->
       closeopts :: String -> [(Int, String)]
       closeopts s = mapMaybe (close s) longopts
 
-      alts :: String -> [[String]]
-      alts s = map (map snd) $ groupOn fst $ closeopts s
+      alts :: String -> [List1 String]
+      alts s = map (fmap snd) $ List1.groupOn fst $ closeopts s
 
       suggest :: String -> String
       suggest s = case alts s of
         []     -> s
         as : _ -> s ++ " (did you mean " ++ sugs as ++ " ?)"
 
-      sugs :: [String] -> String
-      sugs [a] = a
-      sugs as  = "any of " ++ unwords as
+      sugs :: List1 String -> String
+      sugs (a :| []) = a
+      sugs as  = "any of " ++ List1.unwords as
 
 -- | Parse options from an options pragma.
 parsePragmaOptions

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -25,7 +25,6 @@ import Control.Monad.Except (throwError)
 
 import Data.Either (partitionEithers)
 import qualified Data.Foldable as Fold
-import Data.Function (on)
 import qualified Data.Function
 import qualified Data.List as List
 import Data.Maybe
@@ -307,9 +306,8 @@ buildParsers kind exprNames = do
         -- level comes first.
         relatedOperators :: [(PrecedenceLevel, [NotationSection])]
         relatedOperators =
-          map (\((l, ns) : rest) -> (l, ns ++ concatMap snd rest)) .
-          List.groupBy ((==) `on` fst) .
-          List.sortBy (compare `on` fst) .
+          map (\((l, ns) :| rest) -> (l, ns ++ concatMap snd rest)) .
+          List1.groupOn fst .
           mapMaybe (\n -> case level n of
                             Unrelated     -> Nothing
                             r@(Related l) ->

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -59,7 +59,7 @@ import Agda.TypeChecking.Telescope
 import Agda.Utils.Either
 import Agda.Utils.Functor
 import Agda.Utils.Lens
-import Agda.Utils.List  ( (!!!), groupOn, initWithDefault )
+import Agda.Utils.List  ( (!!!), initWithDefault )
 import qualified Agda.Utils.List as List
 import Agda.Utils.List1 ( List1, pattern (:|) )
 import qualified Agda.Utils.List1 as List1
@@ -1384,15 +1384,14 @@ inferOrCheckProjAppToKnownPrincipalArg e o ds args mt k v0 ta mpatm = do
             guard =<< do isNothing <$> do lift $ checkModality' d def
             return (orig, (d, (pars, (dom, u, tb))))
 
-      cands <- groupOn fst . List1.catMaybes <$> mapM (runMaybeT . try) ds
+      cands <- List1.groupOn fst . List1.catMaybes <$> mapM (runMaybeT . try) ds
       case cands of
         [] -> refuseProjNoMatching ds
-        [[]] -> refuseProjNoMatching ds
         (_:_:_) -> refuseProj ds $ fwords "several matching candidates can be applied."
         -- case: just one matching projection d
         -- the term u = d v
         -- the type tb is the type of this application
-        [ (_orig, (d, (pars, (_dom,u,tb)))) : _ ] -> do
+        [ (_orig, (d, (pars, (_dom,u,tb)))) :| _ ] -> do
           storeDisambiguatedProjection d
 
           -- Check parameters

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -26,7 +26,6 @@ import Agda.Utils.Functor  ((<.>))
 import Agda.Utils.Tuple
 
 import {-# SOURCE #-} Agda.Utils.List1 (List1)
-import {-# SOURCE #-} qualified Agda.Utils.List1 as List1 (groupOn)
 
 import Agda.Utils.Impossible
 
@@ -493,27 +492,8 @@ findOverlap xs ys =
     | otherwise                = Nothing
 
 ---------------------------------------------------------------------------
--- * Groups and chunks
+-- * Chunks
 ---------------------------------------------------------------------------
-
--- | @'groupOn' f = 'groupBy' (('==') \`on\` f) '.' 'List.sortBy' ('compare' \`on\` f)@.
--- O(n log n).
-groupOn :: Ord b => (a -> b) -> [a] -> [[a]]
-groupOn f = map List1.toList . List1.groupOn f
-
--- | A variant of 'List.groupBy' which applies the predicate to consecutive
--- pairs.
--- O(n).
--- DEPRECATED in favor of 'Agda.Utils.List1.groupBy''.
-groupBy' :: (a -> a -> Bool) -> [a] -> [[a]]
-groupBy' _ []           = []
-groupBy' p xxs@(x : xs) = grp x $ zipWith (\x y -> (p x y, y)) xxs xs
-  where
-  grp x ys = (x : map snd xs) : tail
-    where (xs, rest) = span fst ys
-          tail = case rest of
-                   []            -> []
-                   ((_, z) : zs) -> grp z zs
 
 -- | Chop up a list in chunks of a given length.
 -- O(n).

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -39,7 +39,7 @@ import qualified Data.List.NonEmpty as List1 (toList)
 
 import GHC.Exts as IsList ( IsList(..) )
 
-import Agda.Utils.Functor ((<.>))
+import Agda.Utils.Functor ((<.>), (<&>))
 import Agda.Utils.Null (Null(..))
 import qualified Agda.Utils.List as List
 
@@ -257,3 +257,29 @@ foldr f g (x :| xs) = loop x xs
   where
   loop x []       = g x
   loop x (y : ys) = f x $ loop y ys
+
+-- | Update the first element of a non-empty list.
+--   O(1).
+updateHead :: (a -> a) -> List1 a -> List1 a
+updateHead f (a :| as) = f a :| as
+
+-- | Update the last element of a non-empty list.
+--   O(n).
+updateLast :: (a -> a) -> List1 a -> List1 a
+updateLast f (a :| as) = loop a as
+  where
+  loop a []       = singleton $ f a
+  loop a (b : bs) = cons a $ loop b bs
+
+-- | Focus on the first element of a non-empty list.
+--   O(1).
+lensHead :: Functor f => (a -> f a) -> List1 a -> f (List1 a)
+lensHead f (a :| as) = f a <&> (:| as)
+
+-- | Focus on the last element of a non-empty list.
+--   O(n).
+lensLast :: Functor f => (a -> f a) -> List1 a -> f (List1 a)
+lensLast f (a :| as) = loop a as
+  where
+  loop a []       = singleton <$> f a
+  loop a (b : bs) = cons a <$> loop b bs

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -230,6 +230,10 @@ lefts = Either.lefts  . List1.toList
 rights :: List1 (Either a b) -> [b]
 rights = Either.rights  . List1.toList
 
+-- | Like 'Data.List.unwords'.
+
+unwords :: List1 String -> String
+unwords = List.unwords . List1.toList
 
 -- | Non-efficient, monadic 'nub'.
 -- O(n²).

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -124,6 +124,24 @@ groupBy' p xxs@(x : xs) = grp x $ List.zipWith (\ x y -> (p x y, y)) xxs xs
       []                 -> []
       ((_false, z) : zs) -> grp z zs
 
+-- | Group consecutive items that share the same first component.
+--
+groupByFst :: forall a b. Eq a => [(a,b)] -> [(a, List1 b)]
+groupByFst =
+    List.map (\ ((tag, b) :| xs) -> (tag, b :| List.map snd xs))
+      -- Float the grouping to the top level
+  . List1.groupBy ((==) `on` fst)
+      -- Group together characters in the same role.
+
+-- | Group consecutive items that share the same first component.
+--
+groupByFst1 :: forall a b. Eq a => List1 (a, b) -> List1 (a, List1 b)
+groupByFst1 =
+    fmap (\ ((tag, b) :| xs) -> (tag, b :| List.map snd xs))
+      -- Float the grouping to the top level
+  . List1.groupBy1 ((==) `on` fst)
+      -- Group together characters in the same role.
+
 -- | Split a list into sublists. Generalisation of the prelude function
 --   @words@.
 --   Same as 'Data.List.Split.wordsBy' and 'Data.List.Extra.wordsBy',

--- a/src/full/Agda/Utils/List1.hs-boot
+++ b/src/full/Agda/Utils/List1.hs-boot
@@ -3,5 +3,3 @@ module Agda.Utils.List1 where
 import qualified Data.List.NonEmpty (NonEmpty)
 
 type List1 = Data.List.NonEmpty.NonEmpty
-
-groupOn :: Ord b => (a -> b) -> [a] -> [List1 a]

--- a/test/Internal/Utils/List.hs
+++ b/test/Internal/Utils/List.hs
@@ -94,19 +94,6 @@ prop_allDuplicates xs = allDuplicates xs `sameList` sort (xs \\ nub xs)
   sameList xs ys = and $ zipWith same xs ys
   same (Decorate i a) (Decorate j b) = i == j && a == b
 
-prop_groupBy' :: (Bool -> Bool -> Bool) -> [Bool] -> Property
-prop_groupBy' p xs =
-  classify (length xs - length gs >= 3) "interesting" $
-    concat gs == xs
-    &&
-    and [not (null zs) | zs <- gs]
-    &&
-    and [and (pairInitTail zs zs) | zs <- gs]
-    &&
-    (null gs || not (or (pairInitTail (map last gs) (map head gs))))
-  where gs = groupBy' p xs
-        pairInitTail xs ys = zipWith p (init xs) (tail ys)
-
 prop_genericElemIndex :: Integer -> [Integer] -> Property
 prop_genericElemIndex x xs =
   classify (x `elem` xs) "members" $

--- a/test/Internal/Utils/List1.hs
+++ b/test/Internal/Utils/List1.hs
@@ -5,7 +5,8 @@ module Internal.Utils.List1 ( tests ) where
 import qualified Data.List       as List
 import qualified Data.List.Split as Split
 
-import Agda.Utils.List1 as List1
+import           Agda.Utils.List1 (List1, (<|))
+import qualified Agda.Utils.List1 as List1
 
 import Internal.Helpers
 
@@ -13,11 +14,11 @@ import Internal.Helpers
 -- * Properties
 ------------------------------------------------------------------------
 
-prop_NonemptyList_roundtrip :: Eq a => NonEmpty a -> Bool
-prop_NonemptyList_roundtrip l = maybe False (l ==) $ nonEmpty $ List1.toList l
+prop_NonemptyList_roundtrip :: Eq a => List1 a -> Bool
+prop_NonemptyList_roundtrip l = maybe False (l ==) $ List1.nonEmpty $ List1.toList l
 
 prop_foldr_id :: List1 Int -> Bool
-prop_foldr_id xs = List1.foldr (<|) singleton xs == xs
+prop_foldr_id xs = List1.foldr (<|) List1.singleton xs == xs
 
 -- A type with few elements.
 type Four = (Bool, Bool)
@@ -27,8 +28,22 @@ zero4 = (False, False)
 
 -- | Our 'wordsBy' conforms to 'Split.wordsBy'.
 prop_wordsBy :: [Four] -> Bool
-prop_wordsBy xs = Split.wordsBy p xs == List.map toList (List1.wordsBy p xs)
+prop_wordsBy xs = Split.wordsBy p xs == List.map List1.toList (List1.wordsBy p xs)
   where p = (== zero4)
+
+prop_groupBy' :: (Bool -> Bool -> Bool) -> [Bool] -> Property
+prop_groupBy' p xs =
+  classify (length xs - length gs >= 3) "interesting" $
+    List1.concat gs == xs
+    &&
+    all (\ zs -> and (pairInitTail zs zs)) gs
+    &&
+    (List1.ifNull gs True \ gs1 -> not (or (pairInitTail (fmap List1.last gs1) (fmap List1.head gs1))))
+  where
+    gs :: [List1 Bool]
+    gs = List1.groupBy' p xs
+    pairInitTail :: List1 Bool -> List1 Bool -> [Bool]
+    pairInitTail xs ys = zipWith p (List1.init xs) (List1.tail ys)
 
 ------------------------------------------------------------------------
 -- * All tests


### PR DESCRIPTION
Make type more precise.  Triggered by #6873.

Gets rid of some `__IMPOSSIBLE__`s and incomplete matches.
