### PR TITLE
Bump stack CI from GHC 9.4.6 to 9.4.7

### DIFF
--- a/.github/workflows/stack-dry-run.yml
+++ b/.github/workflows/stack-dry-run.yml
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc-ver:
-        - 9.4.6
+        - 9.4.7
         - 9.2.8
         - 9.0.2
         - 8.10.7

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -36,7 +36,7 @@ description:
 
 tested-with:
     GHC == 9.6.2
-    GHC == 9.4.6
+    GHC == 9.4.7
     GHC == 9.2.8
     GHC == 9.0.2
     GHC == 8.10.7
@@ -87,7 +87,7 @@ extra-doc-files:
 
 extra-source-files:
     stack-9.6.2.yaml
-    stack-9.4.6.yaml
+    stack-9.4.7.yaml
     stack-9.2.8.yaml
     stack-9.0.2.yaml
     stack-8.10.7.yaml

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -38,7 +38,7 @@ You need recent versions of the following programs to compile Agda:
 * GHC:           https://www.haskell.org/ghc/
 
   + Agda has been tested with GHC 8.6.5, 8.8.4,
-    8.10.7, 9.0.2, 9.2.8, 9.4.6 and 9.6.2.
+    8.10.7, 9.0.2, 9.2.8, 9.4.7 and 9.6.2.
 
 * cabal-install: https://www.haskell.org/cabal/
 * Alex:          https://www.haskell.org/alex/

--- a/src/github/workflows/stack-dry-run.yml
+++ b/src/github/workflows/stack-dry-run.yml
@@ -46,7 +46,7 @@ jobs:
         os: [ubuntu-latest]
         stack-ver: ['latest']
         # Only LTS versions here:
-        ghc-ver: [9.4.6, 9.2.8, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
+        ghc-ver: [9.4.7, 9.2.8, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
           # Andreas, 2022-03-26:
           # Note: ghc-ver needs to be spelled out with minor version, i.e., x.y.z
           # rather than x.y (which haskell-setup would resolve to a suitable .z)

--- a/src/size-solver/size-solver.cabal
+++ b/src/size-solver/size-solver.cabal
@@ -13,8 +13,9 @@ synopsis:        A solver for size constraints arising in sized types.
 description:
   See Felix Reihl, 2013, Bachelor thesis, Ludwig-Maximilians-University.
 tested-with:
-  GHC == 9.4.4
-  GHC == 9.2.5
+  GHC == 9.6.2
+  GHC == 9.4.7
+  GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4

--- a/stack-9.4.7.yaml
+++ b/stack-9.4.7.yaml
@@ -1,5 +1,5 @@
-resolver: lts-21.8
-compiler: ghc-9.4.6
+resolver: lts-21.13
+compiler: ghc-9.4.7
 compiler-check: match-exact
 
 # Local packages specified by relative directory name.

--- a/stack-9.6.2.yaml
+++ b/stack-9.6.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2023-08-23
+resolver: nightly-2023-09-25
 compiler: ghc-9.6.2
 compiler-check: match-exact
 


### PR DESCRIPTION
Fixes #6836.