### PR TITLE
Declare dependency `blaze-markup` directly to utilize `toHtml` for `String1`

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -377,6 +377,8 @@ library
     , base                 >= 4.12.0.0  && < 4.20
     , binary               >= 0.8.6.0   && < 0.9
     , blaze-html           >= 0.8       && < 0.10
+    , blaze-markup         >= 0.8.3     && < 0.9
+        -- blaze-markup-0.8.3 adds ToMarkup String1
     , boxes                >= 0.1.3     && < 0.2
     , bytestring           >= 0.10.8.2  && < 0.13
     , case-insensitive     >= 1.2.0.4   && < 1.3

--- a/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
@@ -36,6 +36,11 @@ import qualified Network.URI.Encode
 import System.FilePath
 import System.Directory
 
+-- Andreas, 2023-09-26, import ToMarkup instances from blaze-markup.
+-- This import statement is to prevent the unused-packages complaint from GHC,
+-- see https://github.com/jaspervdj/blaze-html/issues/142.
+import Text.Blaze ()
+
 import Text.Blaze.Html5
     ( preEscapedToHtml
     , toHtml
@@ -321,14 +326,14 @@ code onlyCode fileType = mconcat . if onlyCode
   mkHtml (pos, s, mi) =
     -- Andreas, 2017-06-16, issue #2605:
     -- Do not create anchors for whitespace.
-    applyUnless (mi == mempty) (annotate pos mi) $ toHtml $ List1.toList s
+    applyUnless (mi == mempty) (annotate pos mi) $ toHtml s
 
   -- Proposed in #3373, implemented in #3384
   mkRst :: [TokenInfo] -> Html
   mkRst = mconcat . (toHtml rstDelimiter :) . map go
     where
       go token@(_, s, mi) = if aspect mi == Just Background
-        then preEscapedToHtml $ List1.toList s
+        then preEscapedToHtml s
         else mkHtml token
 
   -- Proposed in #3137, implemented in #3313
@@ -337,7 +342,7 @@ code onlyCode fileType = mconcat . if onlyCode
   mkMd = mconcat . go
     where
       work token@(_, s, mi) = case aspect mi of
-        Just Background -> preEscapedToHtml $ List1.toList s
+        Just Background -> preEscapedToHtml s
         Just Markup     -> __IMPOSSIBLE__
         _               -> mkHtml token
       go [a, b] = [ mconcat $ work <$> a
@@ -358,7 +363,7 @@ code onlyCode fileType = mconcat . if onlyCode
       formatNonCode = map go tokens
 
       go token@(_, s, mi) = if aspect mi == Just Background
-        then preEscapedToHtml $ List1.toList s
+        then preEscapedToHtml s
         else mkHtml token
 
   -- Put anchors that enable referencing that token.


### PR DESCRIPTION
Simplify code using new `ToMarkup String1` instance:
- https://github.com/jaspervdj/blaze-markup/issues/63

This is a follow-up/fixup of 
- #6876.
