### PR TITLE
Fix for #6856

### DIFF
--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -727,8 +727,9 @@ unfoldDefinitionStep v0 f es =
                           defaultResult -- non-terminating or delayed
         ([],[])        -> traceSLn "tc.reduce" 90 "reduceNormalE: no clauses or rewrite rules" $ do
           -- no definition for head
-          blk <- instantiate =<< do defBlocked <$> getConstInfo f
-          noReduction $ blk $> vfull
+          (defBlocked <$> getConstInfo f) >>= \case
+            Blocked{}    -> noReduction $ Blocked (UnblockOnDef f) vfull
+            NotBlocked{} -> defaultResult
         (cls,rewr)     -> do
           ev <- appDefE_ f v0 cls mcc rewr es
           debugReduce ev

--- a/test/Succeed/Issue6856.agda
+++ b/test/Succeed/Issue6856.agda
@@ -1,0 +1,45 @@
+data _＝_ {X : Set} : X → X → Set where
+ refl : {x : X} → x ＝ x
+
+record Σ {X : Set} (Y : X → Set) : Set  where
+ constructor
+  _,_
+ field
+  pr₁ : X
+  pr₂ : Y pr₁
+
+_×_ : Set → Set → Set
+X × Y = Σ λ (_ : X) → Y
+
+id : {X : Set} → X → X
+id x = x
+
+_∘_ : {X : Set} {Y : Set} {Z : Y → Set}
+    → ((y : Y) → Z y)
+    → (f : X → Y) (x : X) → Z (f x)
+g ∘ f = λ x → g (f x)
+
+_∼_ : {X : Set} {A : X → Set} → ((x : X) → A x) → ((x : X) → A x) → Set
+f ∼ g = ∀ x → f x ＝ g x
+
+_≅_ : Set → Set → Set
+X ≅ Y = Σ λ (f : X → Y) → Σ λ (g : Y → X) → (g ∘ f ∼ id) × (f ∘ g ∼ id)
+
+fact : (X Y : Set) (A : X → Set) (B : Y → Set) →
+       (Σ λ (x : X) → Σ λ (y : Y) → A x × B y)
+     ≅ ((Σ λ (x : X) → A x) × (Σ λ (y : Y) → B y))
+fact X Y A B = f , g , gf , fg
+  where
+   f : _
+   f (x , y , a , b) = ((x , a) , (y , b))
+   g : _
+   g ((x , a) , (y , b)) = x , y , a , b
+   fg : f ∘ g ∼ id
+   fg _ = refl
+   gf : g ∘ f ∼ id
+   gf _ = refl
+
+infixr 50 _,_
+infixl 5 _∘_
+infix  4 _∼_
+infixr 2 _×_


### PR DESCRIPTION
As described in my comment https://github.com/agda/agda/issues/6856#issuecomment-1737271229, when a conversion check is blocked on a definition, we should wait until that definition has actually been checked and added to the signature before we can retry the conversion problem.