### PR TITLE
Allow containers-0.7

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -127,6 +127,11 @@ jobs:
           description: Linux debug
           ghc-ver: 9.6.2
           os: ubuntu-22.04
+        - cabal-flags: |
+            --enable-tests -f enable-cluster-counting -f debug -c containers>=0.7 --allow-newer=containers
+          description: Linux containers 0.7
+          ghc-ver: 9.6.2
+          os: ubuntu-22.04
         - description: macOS
           ghc-ver: 9.6.2
           os: macos-12

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -380,7 +380,7 @@ library
     , boxes                >= 0.1.3     && < 0.2
     , bytestring           >= 0.10.8.2  && < 0.13
     , case-insensitive     >= 1.2.0.4   && < 1.3
-    , containers           >= 0.6.0.1   && < 0.7
+    , containers           >= 0.6.0.1   && < 0.8
     , data-hash            >= 0.2.0.0   && < 0.3
     , deepseq              >= 1.4.4.0   && < 1.6
     , directory            >= 1.3.3.0   && < 1.4

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -72,16 +72,15 @@ jobs:
             ghc-ver: '9.6.2'
             cabal-flags: '--enable-tests -f debug'
 
-          ## Andreas, 2023-03-15: Obsolete with GHC 9.6 which ships mtl-2.3
-          # # Linux, with mtl-2.3 and everything
-          # - os: ubuntu-22.04
-          #   description: Linux mtl 2.3
-          #   ghc-ver: '9.6.2'
-          #   ## Andreas, 2022-11-23: Test mtl-2.3.1 here which has breaking changes.
-          #   ## Note: -c 'mtl >= 2.3.1' with single quotes does not get communicated properly.
-          #   ## (The single quotes stay, and "-c 'mtl" is an option parse error for cabal.)
-          #   cabal-flags: |
-          #     --enable-tests -f enable-cluster-counting -f debug -c mtl>=2.3.1
+          # Linux, with containers-0.7 and everything
+          - os: ubuntu-22.04
+            description: Linux containers 0.7
+            ghc-ver: '9.6.2'
+            ## Andreas, 2023-09-28: Test containers-0.7 here which has breaking changes.
+            ## Note: -c 'containers >= 0.7' with single quotes does not get communicated properly.
+            ## (The single quotes stay, and "-c 'containers" is an option parse error for cabal.)
+            cabal-flags: |
+              --enable-tests -f enable-cluster-counting -f debug -c containers>=0.7 --allow-newer=containers
 
           # macOS with default flags
           - os: macos-12


### PR DESCRIPTION
Closes #6888, at least under `--allow-newer=containers`.
