### PR TITLE
CI Windows ICU install: drop `-y` flag from `pacman` invocation.

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -52,7 +52,7 @@ jobs:
       name: Install the ICU library (Windows)
       run: |
         $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-        pacman --noconfirm -Sy msys2-keyring mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
+        pacman --noconfirm -S msys2-keyring mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
       shell: pwsh
     - if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -52,7 +52,7 @@ jobs:
       name: Install the ICU library (Windows)
       run: |
         $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-        pacman --noconfirm -S msys2-keyring mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
+        pacman --noconfirm -S msys2-keyring mingw-w64-x86_64-pkgconf mingw-w64-x86_64-icu
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
       shell: pwsh
     - if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
       name: Install the ICU library (Windows)
       run: |
         $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-        pacman -v --noconfirm -Sy mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
+        pacman -v --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
       shell: pwsh
     - if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
       name: Install the ICU library (Windows)
       run: |
         $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-        pacman -v --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
+        pacman -v --noconfirm -S mingw-w64-x86_64-pkgconf mingw-w64-x86_64-icu
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
       shell: pwsh
     - if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -63,7 +63,7 @@ jobs:
       name: Install the icu library (Windows)
       run: |
         # stack exec ${ARGS} -- pacman --noconfirm -Syuu
-        stack exec ${ARGS} -- pacman --noconfirm -Sy msys2-keyring
+        stack exec ${ARGS} -- pacman --noconfirm -S msys2-keyring
         stack exec ${ARGS} -- bash -c "curl -LO ${ICU_URL} && pacman --noconfirm -U *.pkg.tar.zst"
         stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
     - name: Determine the ICU version

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -63,9 +63,9 @@ jobs:
       name: Install the icu library (Windows)
       run: |
         # stack exec ${ARGS} -- pacman --noconfirm -Syuu
-        stack exec ${ARGS} -- pacman --noconfirm -S msys2-keyring
+        # stack exec ${ARGS} -- pacman --noconfirm -S msys2-keyring
         stack exec ${ARGS} -- bash -c "curl -LO ${ICU_URL} && pacman --noconfirm -U *.pkg.tar.zst"
-        stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
+        stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkgconf
     - name: Determine the ICU version
       run: |
         ICU_VER=$(stack exec ${ARGS} -- pkg-config --modversion icu-i18n)

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -134,7 +134,7 @@ jobs:
       shell: pwsh
       run: |
         $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-        pacman --noconfirm -S msys2-keyring mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
+        pacman --noconfirm -S msys2-keyring mingw-w64-x86_64-pkgconf mingw-w64-x86_64-icu
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
 
     - name: Set up pkg-config for the ICU library (macOS)

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -134,7 +134,7 @@ jobs:
       shell: pwsh
       run: |
         $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-        pacman --noconfirm -Sy msys2-keyring mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
+        pacman --noconfirm -S msys2-keyring mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
 
     - name: Set up pkg-config for the ICU library (macOS)

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -137,7 +137,7 @@ jobs:
       shell: pwsh
       run: |
         $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-        pacman -v --noconfirm -Sy mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
+        pacman -v --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
 
       ## Old method:

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -137,7 +137,7 @@ jobs:
       shell: pwsh
       run: |
         $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-        pacman -v --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
+        pacman -v --noconfirm -S mingw-w64-x86_64-pkgconf mingw-w64-x86_64-icu
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
 
       ## Old method:

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -161,9 +161,9 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
       run: |
         # stack exec ${ARGS} -- pacman --noconfirm -Syuu
-        stack exec ${ARGS} -- pacman --noconfirm -S msys2-keyring
+        # stack exec ${ARGS} -- pacman --noconfirm -S msys2-keyring
         stack exec ${ARGS} -- bash -c "curl -LO ${ICU_URL} && pacman --noconfirm -U *.pkg.tar.zst"
-        stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
+        stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkgconf
 
     - name: Determine the ICU version
       run: |

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -161,7 +161,7 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
       run: |
         # stack exec ${ARGS} -- pacman --noconfirm -Syuu
-        stack exec ${ARGS} -- pacman --noconfirm -Sy msys2-keyring
+        stack exec ${ARGS} -- pacman --noconfirm -S msys2-keyring
         stack exec ${ARGS} -- bash -c "curl -LO ${ICU_URL} && pacman --noconfirm -U *.pkg.tar.zst"
         stack exec ${ARGS} -- pacman --noconfirm -S mingw-w64-x86_64-pkg-config
 


### PR DESCRIPTION
- Drop `-y` from `pacman` invocation.
  Hint contributed by @vpolikarpov-akvelon at https://github.com/actions/runner-images/issues/8412#issuecomment-1741021921.
- Prefer `pkgconf` over `pkg-config`.
  Suggested by @mmuetzel in https://github.com/actions/runner-images/issues/8412#issuecomment-1741270161

Closes #6890.
