### PR TITLE
Serialization optimizations

### DIFF
--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -65,7 +65,7 @@ import Agda.Utils.Impossible
 
 -- TODO: do not export @SourceFile@ and force users to check the
 -- @AbsolutePath@ does exist.
-newtype SourceFile    = SourceFile    { srcFilePath :: AbsolutePath } deriving (Eq, Ord)
+newtype SourceFile    = SourceFile    { srcFilePath :: AbsolutePath } deriving (Eq, Ord, Show)
 newtype InterfaceFile = InterfaceFile { intFilePath :: AbsolutePath }
 
 instance Pretty SourceFile    where pretty = pretty . srcFilePath
@@ -114,6 +114,7 @@ data FindError
     --
     -- Invariant: The list of matching files has at least two
     -- elements.
+  deriving Show
 
 -- | Given the module name which the error applies to this function
 -- converts a 'FindError' to a 'TypeError'.

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -213,7 +213,7 @@ decode s = do
     when (not (null s)) $ E.throwIO $ E.ErrorCall "Garbage at end."
     let nL' = ar nL
     st <- St nL' (ar ltL) (ar stL) (ar bL) (ar iL) (ar dL)
-            <$> liftIO (newArray (bounds nL') mempty)
+            <$> liftIO (newArray (bounds nL') MEEmpty)
             <*> return mf <*> return incs
     (r, st) <- runStateT (value r) st
     let !mf = modFile st

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -207,24 +207,30 @@ decode s = do
   -- The decoder is (intended to be) strict enough to ensure that all
   -- such errors can be caught by the handler here.
 
-  (mf, r) <- liftIO $ E.handle (\(E.ErrorCall s) -> noResult s) $ do
-
+  res <- liftIO $ E.handle (\(E.ErrorCall s) -> pure Nothing) $ do
     ((r, nL, ltL, stL, bL, iL, dL), s, _) <- return $ runGetState B.get s 0
-    if not (null s)
-     then noResult "Garbage at end."
-     else do
+    let ar = unListLike
+    when (not (null s)) $ E.throwIO $ E.ErrorCall "Garbage at end."
+    let nL' = ar nL
+    st <- St nL' (ar ltL) (ar stL) (ar bL) (ar iL) (ar dL)
+            <$> liftIO (newArray (bounds nL') mempty)
+            <*> return mf <*> return incs
+    (r, st) <- runStateT (value r) st
+    let !mf = modFile st
+    return $ Just (mf, r)
 
-      let nL' = ar nL
-      st <- St nL' (ar ltL) (ar stL) (ar bL) (ar iL) (ar dL)
-              <$> liftIO (newArray (bounds nL') mempty)
-              <*> return mf <*> return incs
-      (r, st) <- runStateT (runExceptT (value r)) st
-      return (Just $ modFile st, r)
+  case res of
+    Nothing -> do
+      reportSLn "import.iface" 5 $ "Error when decoding interface file"
+      -- Andreas, 2014-06-11 deactivated debug printing
+      -- in order to get rid of dependency of Serialize on TCM.Pretty
+      -- reportSDoc "import.iface" 5 $
+      --   "Error when decoding interface file:"
+      --   $+$ nest 2 (prettyTCM err)
+      pure Nothing
 
-  forM_ mf (setTCLens stModuleToSource)
-
-  case r of
-    Right x -> do
+    Just (mf, x) -> do
+      setTCLens stModuleToSource mf
 #if __GLASGOW_HASKELL__ >= 804
       -- "Compact" the interfaces (without breaking sharing) to
       -- reduce the amount of memory that is traversed by the
@@ -234,19 +240,7 @@ decode s = do
 #else
       return (Just x)
 #endif
-    Left err -> do
-      reportSLn "import.iface" 5 $ "Error when decoding interface file"
-      -- Andreas, 2014-06-11 deactivated debug printing
-      -- in order to get rid of dependency of Serialize on TCM.Pretty
-      -- reportSDoc "import.iface" 5 $
-      --   "Error when decoding interface file:"
-      --   $+$ nest 2 (prettyTCM err)
-      return Nothing
 
-  where
-  ar = unListLike
-
-  noResult s = return (Nothing, Left $ GenericError s)
 
 encodeInterface :: Interface -> TCM Encoded
 encodeInterface i = do

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -7,6 +7,7 @@
 
 module Agda.TypeChecking.Serialise.Base where
 
+import qualified Control.Exception as E
 import Control.Monad.Except
 import Control.Monad.IO.Class     ( MonadIO(..) )
 import Control.Monad.Reader
@@ -209,13 +210,13 @@ type S a = ReaderT Dict IO a
 -- 'TCM' is not used because the associated overheads would make
 -- decoding slower.
 
-type R a = ExceptT TypeError (StateT St IO) a
+type R = StateT St IO
 
 -- | Throws an error which is suitable when the data stream is
 -- malformed.
 
 malformed :: R a
-malformed = throwError $ GenericError "Malformed input."
+malformed = liftIO $ E.throwIO $ E.ErrorCall "Malformed input."
 {-# noinline malformed #-}
 
 class Typeable a => EmbPrj a where

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE UndecidableInstances #-} -- Due to ICODE vararg typeclass
+{-# LANGUAGE MagicHash            #-}
+{-# LANGUAGE UnboxedTuples        #-}
 
 module Agda.TypeChecking.Serialise.Base where
 
@@ -25,6 +27,8 @@ import qualified Data.Text      as T
 import qualified Data.Text.Lazy as TL
 import Data.Typeable ( cast, Typeable, TypeRep, typeRep )
 
+import GHC.Exts (Word(..), timesWord2#, xor#)
+
 import Agda.Syntax.Common (NameId)
 import Agda.Syntax.Internal (Term, QName(..), ModuleName(..), nameId)
 import Agda.TypeChecking.Monad.Base (TypeError(GenericError), ModuleToSource)
@@ -39,8 +43,47 @@ import Agda.Utils.Pointer
 import Agda.Utils.TypeLevel
 
 -- | Constructor tag (maybe omitted) and argument indices.
+data Node = Empty | Cons !Int32 !Node deriving Eq
 
-type Node = [Int32]
+instance Hashable Node where
+  hashWithSalt h n = fromIntegral (go (fromIntegral h) n) where
+    xor (W# x) (W# y) = W# (xor# x y)
+
+    foldedMul :: Word -> Word -> Word
+    foldedMul (W# x) (W# y) = case timesWord2# x y of (# hi, lo #) -> W# (xor# hi lo)
+
+    combine :: Word -> Word -> Word
+    combine x y = foldedMul (xor x y) 11400714819323198549
+
+    go :: Word -> Node -> Word
+    go !h Empty       = h
+    go  h (Cons n ns) = go (combine h (fromIntegral n)) ns
+
+  hash = hashWithSalt 3032525626373534813
+
+instance B.Binary Node where
+
+  get = do {n :: Int <- B.get; go n} where
+
+    go :: Int -> B.Get Node
+    go n | n <= 0 =
+      pure Empty
+    go n = do
+      x    <- B.get
+      node <- go (n - 1)
+      pure $ Cons x node
+
+  put n = B.put (len n) <> go n where
+
+    len :: Node -> Int
+    len = go 0 where
+      go !acc Empty     = acc
+      go acc (Cons _ n) = go (acc + 1) n
+
+    go :: Node -> B.Put
+    go Empty = mempty
+    go (Cons n ns) = B.put n <> go ns
+
 
 -- | Structure providing fresh identifiers for hash map
 --   and counting hash map hits (i.e. when no fresh identifier required).
@@ -142,7 +185,7 @@ type Memo = IOArray Int32 (Hm.HashMap TypeRep U) -- node index -> (type rep -> v
 
 -- | State of the decoder.
 data St = St
-  { nodeE     :: !(Array Int32 Node)     -- ^ Obtained from interface file.
+  { nodeE     :: !(Array Int32 [Int32])  -- ^ Obtained from interface file.
   , stringE   :: !(Array Int32 String)   -- ^ Obtained from interface file.
   , lTextE    :: !(Array Int32 TL.Text)  -- ^ Obtained from interface file.
   , sTextE    :: !(Array Int32 T.Text)   -- ^ Obtained from interface file.
@@ -181,8 +224,9 @@ class Typeable a => EmbPrj a where
   value :: Int32 -> R a  -- ^ Deserialization.
 
   icode a = do
+    !n <- icod_ a
     tickICode a
-    icod_ a
+    pure n
 
   -- Simple enumeration types can be (de)serialized using (from/to)Enum.
 
@@ -367,7 +411,7 @@ icodeMemo getDict getCounter a icodeP = do
 --   via the @valu@ function and stores it in 'nodeMemo'.
 --   If @ix@ is present in 'nodeMemo', @valu@ is not used, but
 --   the thing is read from 'nodeMemo' instead.
-vcase :: forall a . EmbPrj a => (Node -> R a) -> Int32 -> R a
+vcase :: forall a . EmbPrj a => ([Int32] -> R a) -> Int32 -> R a
 vcase valu = \ix -> do
     memo <- gets nodeMemo
     -- compute run-time representation of type a
@@ -389,16 +433,16 @@ vcase valu = \ix -> do
 
 class ICODE t b where
   icodeArgs :: IsBase t ~ b => All EmbPrj (Domains t) =>
-               Proxy t -> StrictProducts (Domains t) -> S [Int32]
+               Proxy t -> StrictProducts (Domains t) -> S Node
 
 instance IsBase t ~ 'True => ICODE t 'True where
-  icodeArgs _ _  = return []
+  icodeArgs _ _  = return Empty
   {-# inline icodeArgs #-}
 
 instance ICODE t (IsBase t) => ICODE (a -> t) 'False where
   icodeArgs _ (Pair a as) = icode a >>= \ !hd -> do
     !node <- icodeArgs (Proxy :: Proxy t) as
-    pure $! hd : node
+    pure $! Cons hd node
   {-# inline icodeArgs #-}
 
 -- | @icodeN tag t a1 ... an@ serialises the arguments @a1@, ..., @an@ of the
@@ -413,7 +457,7 @@ icodeN :: forall t. ICODE t (IsBase t) => StrictCurrying (Domains t) (S Int32) =
 icodeN tag _ =
   strictCurrys (Proxy :: Proxy (Domains t)) (Proxy :: Proxy (S Int32)) $ \ !args -> do
     !node <- icodeArgs (Proxy :: Proxy t) args
-    icodeNode $! tag : node
+    icodeNode $! Cons tag node
 
 -- | @icodeN'@ is the same as @icodeN@ except that there is no tag
 {-# INLINE icodeN' #-}
@@ -437,7 +481,7 @@ class VALU t b where
 
   valueArgs :: b ~ IsBase t =>
                All EmbPrj (CoDomain t ': Domains t) =>
-               Proxy t -> Node -> Maybe (StrictProducts (Constant Int32 (Domains t)))
+               Proxy t -> [Int32] -> Maybe (StrictProducts (Constant Int32 (Domains t)))
 
 instance VALU t 'True where
   {-# INLINE valuN' #-}
@@ -455,8 +499,8 @@ instance VALU t (IsBase t) => VALU (a -> t) 'False where
 
   {-# INLINE valueArgs #-}
   valueArgs _ xs = case xs of
-    (x : xs') -> do {!node <- valueArgs (Proxy :: Proxy t) xs'; pure (Pair x node)}
-    _         -> Nothing
+    x : xs' -> do {!node <- valueArgs (Proxy :: Proxy t) xs'; pure (Pair x node)}
+    _       -> Nothing
 
 {-# INLINE valuN #-}
 valuN :: forall t. VALU t (IsBase t) =>

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -222,7 +222,6 @@ instance {-# OVERLAPPABLE #-} EmbPrj a => EmbPrj [a] where
 
   value = vcase (mapM value)
 
-
 instance EmbPrj a => EmbPrj (List1 a) where
   icod_ = icod_ . List1.toList
   value = maybe malformed return . List1.nonEmpty <=< value
@@ -253,14 +252,14 @@ mapPairsValue :: (EmbPrj k, EmbPrj v) => [Int32] -> R [(k, v)]
 mapPairsValue = convert [] where
   convert ys [] = return ys
   convert ys (start:entry:xs) = do
-    start <- value start
-    entry <- value entry
+    !start <- value start
+    !entry <- value entry
     convert ((start, entry):ys) xs
   convert _ _ = malformed
 
 instance (Ord a, EmbPrj a, EmbPrj b) => EmbPrj (Map a b) where
   icod_ m = mapPairsIcode (Map.toAscList m)
-  value = vcase ((<$!>) Map.fromDistinctAscList . mapPairsValue)
+  value = vcase ((Map.fromDistinctAscList <$!>) . mapPairsValue)
 
 instance (Ord a, EmbPrj a) => EmbPrj (Set a) where
   icod_ s = icode (Set.toAscList s)
@@ -468,7 +467,7 @@ instance EmbPrj OpaqueId where
 
 instance (Eq k, Hashable k, EmbPrj k, EmbPrj v) => EmbPrj (HashMap k v) where
   icod_ m = mapPairsIcode (HMap.toList m)
-  value = vcase ((<$!>) HMap.fromList . mapPairsValue)
+  value = vcase ((HMap.fromList <$!>) . mapPairsValue)
 
 instance EmbPrj a => EmbPrj (WithHiding a) where
   icod_ (WithHiding a b) = icodeN' WithHiding a b

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -3,6 +3,7 @@
 
 module Agda.TypeChecking.Serialise.Instances.Common (SerialisedRange(..)) where
 
+import qualified Control.Exception as E
 import Control.Monad              ( (<=<), (<$!>) )
 import Control.Monad.IO.Class     ( MonadIO(..) )
 import Control.Monad.Except       ( MonadError(..) )
@@ -295,7 +296,7 @@ instance EmbPrj RangeFile where
     (r, mf) <- liftIO $ findFile'' incs m mf
     modify $ \s -> s { modFile = mf }
     case r of
-      Left err -> throwError $ findErrorToTypeError m err
+      Left err -> liftIO $ E.throwIO $ E.ErrorCall $ "file not found: " ++ show m
       Right f  -> let !sfp = srcFilePath f in return $ RangeFile sfp (Just m)
 
 -- | Ranges are always deserialised as 'noRange'.

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -295,7 +295,7 @@ instance EmbPrj RangeFile where
     (r, mf) <- liftIO $ findFile'' incs m mf
     modify $ \s -> s { modFile = mf }
     case r of
-      Left err -> liftIO $ E.throwIO $ E.ErrorCall $ "file not found: " ++ show m
+      Left err -> liftIO $ E.throwIO $ E.ErrorCall $ "file not found: " ++ show err
       Right f  -> let !sfp = srcFilePath f in return $ RangeFile sfp (Just m)
 
 -- | Ranges are always deserialised as 'noRange'.

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
@@ -6,6 +6,7 @@ module Agda.TypeChecking.Serialise.Instances.Highlighting where
 
 import qualified Data.Map.Strict as Map
 import Data.Strict.Tuple (Pair(..))
+import Data.Int (Int32)
 
 import qualified Agda.Interaction.Highlighting.Range   as HR
 import qualified Agda.Interaction.Highlighting.Precise as HP
@@ -125,6 +126,7 @@ instance EmbPrj a => EmbPrj (RM.RangeMap a) where
   -- like Map, we need to call `convert' in the tail position and so the output
   -- list is written (and read) in reverse order.
   icod_ (RM.RangeMap f) = icodeNode =<< convert Empty (Map.toAscList f) where
+    convert :: Node -> [(Int, RM.PairInt a)] -> S Node
     convert !ys [] = return ys
     convert  ys ((start, RM.PairInt (end :!: entry)):xs) = do
       !start <- icode start
@@ -133,8 +135,9 @@ instance EmbPrj a => EmbPrj (RM.RangeMap a) where
       convert (Cons start (Cons end (Cons entry ys))) xs
 
   value = vcase (fmap (RM.RangeMap . Map.fromDistinctAscList) . convert []) where
-    convert ys [] = return ys
-    convert ys (start:end:entry:xs) = do
+    convert :: [(Int, RM.PairInt a)] -> [Int32] -> R [(Int, RM.PairInt a)]
+    convert !ys [] = return ys
+    convert  ys (start:end:entry:xs) = do
       !start <- value start
       !end <- value end
       !entry <- value entry

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
@@ -127,17 +127,17 @@ instance EmbPrj a => EmbPrj (RM.RangeMap a) where
   icod_ (RM.RangeMap f) = icodeNode =<< convert Empty (Map.toAscList f) where
     convert !ys [] = return ys
     convert  ys ((start, RM.PairInt (end :!: entry)):xs) = do
-      start <- icode start
-      end <- icode end
-      entry <- icode entry
+      !start <- icode start
+      !end <- icode end
+      !entry <- icode entry
       convert (Cons start (Cons end (Cons entry ys))) xs
 
   value = vcase (fmap (RM.RangeMap . Map.fromDistinctAscList) . convert []) where
     convert ys [] = return ys
     convert ys (start:end:entry:xs) = do
-      start <- value start
-      end <- value end
-      entry <- value entry
+      !start <- value start
+      !end <- value end
+      !entry <- value entry
       convert ((start, RM.PairInt (end :!: entry)):ys) xs
     convert _ _ = malformed
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
@@ -124,13 +124,13 @@ instance EmbPrj a => EmbPrj (RM.RangeMap a) where
   -- Write the RangeMap as flat list rather than a list of (Int, (Int, x)). Much
   -- like Map, we need to call `convert' in the tail position and so the output
   -- list is written (and read) in reverse order.
-  icod_ (RM.RangeMap f) = icodeNode =<< convert [] (Map.toAscList f) where
-    convert ys [] = return ys
-    convert ys ((start, RM.PairInt (end :!: entry)):xs) = do
+  icod_ (RM.RangeMap f) = icodeNode =<< convert Empty (Map.toAscList f) where
+    convert !ys [] = return ys
+    convert  ys ((start, RM.PairInt (end :!: entry)):xs) = do
       start <- icode start
       end <- icode end
       entry <- icode entry
-      convert (start:end:entry:ys) xs
+      convert (Cons start (Cons end (Cons entry ys))) xs
 
   value = vcase (fmap (RM.RangeMap . Map.fromDistinctAscList) . convert []) where
     convert ys [] = return ys

--- a/src/full/Agda/Utils/TypeLevel.hs
+++ b/src/full/Agda/Utils/TypeLevel.hs
@@ -72,6 +72,17 @@ type family Constant (b :: l) (as :: [k]) :: [l] where
 type Arrows   (as :: [Type]) (r :: Type) = Foldr (->) r as
 type Products (as :: [Type])             = Foldr (,) () as
 
+data StrictPair a b = Pair a b
+type StrictProducts (as :: [Type]) = Foldr StrictPair () as
+
+strictCurry :: (StrictPair a b -> c) -> (a -> b -> c)
+strictCurry f = \ !a !b -> f (Pair a b)
+{-# inline strictCurry #-}
+
+strictUncurry :: (a -> b -> c) -> (StrictPair a b -> c)
+strictUncurry f = \ !(Pair a b) -> f a b
+{-# inline strictUncurry #-}
+
 -- | @IsBase t@ is @'True@ whenever @t@ is *not* a function space.
 
 type family IsBase (t :: Type) :: Bool where
@@ -112,6 +123,21 @@ instance Currying '[] b where
 instance Currying as b => Currying (a ': as) b where
   uncurrys _ p f = uncurry $ uncurrys (Proxy :: Proxy as) p . f
   currys   _ p f = currys (Proxy :: Proxy as) p . curry f
+
+
+class StrictCurrying as b where
+  strictUncurrys :: Proxy as -> Proxy b -> Arrows as b -> StrictProducts as -> b
+  strictCurrys   :: Proxy as -> Proxy b -> (StrictProducts as -> b) -> Arrows as b
+
+instance StrictCurrying '[] b where
+  strictUncurrys _ _ f = \ () -> f; {-# inline strictUncurrys #-}
+  strictCurrys   _ _ f = f ();      {-# inline strictCurrys #-}
+
+instance StrictCurrying as b => StrictCurrying (a ': as) b where
+  strictUncurrys _ p f = strictUncurry $ strictUncurrys (Proxy :: Proxy as) p . f
+  {-# inline strictUncurrys #-}
+  strictCurrys   _ p f = strictCurrys (Proxy :: Proxy as) p . strictCurry f
+  {-# inline strictCurrys #-}
 
 ------------------------------------------------------------------
 -- DEFUNCTIONALISATION

--- a/src/full/Agda/Utils/TypeLevel.hs
+++ b/src/full/Agda/Utils/TypeLevel.hs
@@ -77,11 +77,11 @@ type StrictProducts (as :: [Type]) = Foldr StrictPair () as
 
 strictCurry :: (StrictPair a b -> c) -> (a -> b -> c)
 strictCurry f = \ !a !b -> f (Pair a b)
-{-# inline strictCurry #-}
+{-# INLINE strictCurry #-}
 
 strictUncurry :: (a -> b -> c) -> (StrictPair a b -> c)
 strictUncurry f = \ !(Pair a b) -> f a b
-{-# inline strictUncurry #-}
+{-# INLINE strictUncurry #-}
 
 -- | @IsBase t@ is @'True@ whenever @t@ is *not* a function space.
 
@@ -130,14 +130,14 @@ class StrictCurrying as b where
   strictCurrys   :: Proxy as -> Proxy b -> (StrictProducts as -> b) -> Arrows as b
 
 instance StrictCurrying '[] b where
-  strictUncurrys _ _ f = \ () -> f; {-# inline strictUncurrys #-}
-  strictCurrys   _ _ f = f ();      {-# inline strictCurrys #-}
+  strictUncurrys _ _ f = \ () -> f; {-# INLINE strictUncurrys #-}
+  strictCurrys   _ _ f = f ();      {-# INLINE strictCurrys #-}
 
 instance StrictCurrying as b => StrictCurrying (a ': as) b where
   strictUncurrys _ p f = strictUncurry $ strictUncurrys (Proxy :: Proxy as) p . f
-  {-# inline strictUncurrys #-}
+  {-# INLINE strictUncurrys #-}
   strictCurrys   _ p f = strictCurrys (Proxy :: Proxy as) p . strictCurry f
-  {-# inline strictCurrys #-}
+  {-# INLINE strictCurrys #-}
 
 ------------------------------------------------------------------
 -- DEFUNCTIONALISATION


### PR DESCRIPTION
Cut down total serialization + deserialization time for the stdlib benchmark by around 30%. Build times are also improved for serialization modules.

- Fixing strictness bugs. The `icodeN` function previously always failed to specialize. Making it properly specialize yields most of the speedups here.
- Moving `tickICode` logic out of line.
- Removing `ExceptT TypeError` from deserialization and using native `ErrorCall` exceptions instead. Nothing in the existing code actually relied on the richer type information in `TypeError`, nor on `ExceptT`. 
- Using unboxed `Int32` lists as `Node` instead of `[Int32]`. This reduces `Node` heap size by 40%.  
- Using simple association lists instead of `HashTable` in `Memo` in deserialization. These can never get large so it makes sense to use the lightest data representation.