### PR TITLE
Code specialization

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -496,10 +496,12 @@ instance Reify Constraint where
       OfType <$> reify (MetaV m []) <*> reify t
     reify (CheckType t) = JustType <$> reify t
     reify (UsableAtModality _ _ mod t) = UsableAtMod mod <$> reify t
+    {-# SPECIALIZE reify :: Constraint -> TCM (ReifiesTo Constraint) #-}
 
 instance (Pretty a, Pretty b) => PrettyTCM (OutputForm a b) where
   prettyTCM (OutputForm r pids unblock c) =
     prettyRangeConstraint r pids unblock (pretty c)
+  {-# SPECIALIZE prettyTCM :: (Pretty a, Pretty b) => (OutputForm a b) -> TCM Doc #-}
 
 instance (Pretty a, Pretty b) => Pretty (OutputForm a b) where
   pretty (OutputForm r pids unblock c) =
@@ -718,6 +720,7 @@ stripConstraintPids cs = List.sortBy (compare `on` isBlocked) $ map stripPids cs
     interestingPids = Set.unions $ map (allBlockingProblems . constraintUnblocker) cs
     stripPids (PConstr pids unblock c) = PConstr (Set.intersection pids interestingPids) unblock c
 
+{-# SPECIALIZE interactionIdToMetaId :: InteractionId -> TCM MetaId #-}
 -- | Converts an 'InteractionId' to a 'MetaId'.
 
 interactionIdToMetaId :: ReadTCState m => InteractionId -> m MetaId

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NondecreasingIndentation #-}
-
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Agda.Interaction.BasicOps where
@@ -426,77 +425,77 @@ reifyElimToExpr = \case
     appl s v = A.App defaultAppInfo_ (A.Lit empty (LitString s)) $ fmap unnamed v
 
 instance Reify Constraint where
-    type ReifiesTo Constraint = OutputConstraint Expr Expr
+  type ReifiesTo Constraint = OutputConstraint Expr Expr
 
-    reify (ValueCmp cmp (AsTermsOf t) u v) = CmpInType cmp <$> reify t <*> reify u <*> reify v
-    reify (ValueCmp cmp AsSizes u v) = CmpInType cmp <$> (reify =<< sizeType) <*> reify u <*> reify v
-    reify (ValueCmp cmp AsTypes u v) = CmpTypes cmp <$> reify u <*> reify v
-    reify (ValueCmpOnFace cmp p t u v) = CmpInType cmp <$> (reify =<< ty) <*> reify (lam_o u) <*> reify (lam_o v)
-      where
-        lam_o = I.Lam (setRelevance Irrelevant defaultArgInfo) . NoAbs "_"
-        ty = runNamesT [] $ do
-          p <- open p
-          t <- open t
-          pPi' "o" p (\ o -> t)
-    reify (ElimCmp cmp _ t v es1 es2) =
-      CmpElim cmp <$> reify t <*> mapM reifyElimToExpr es1
-                              <*> mapM reifyElimToExpr es2
-    reify (LevelCmp cmp t t')    = CmpLevels cmp <$> reify t <*> reify t'
-    reify (SortCmp cmp s s')     = CmpSorts cmp <$> reify s <*> reify s'
-    reify (UnquoteTactic tac _ goal) = do
-        tac <- A.App defaultAppInfo_ (A.Unquote exprNoRange) . defaultNamedArg <$> reify tac
-        OfType tac <$> reify goal
-    reify (UnBlock m) = do
-        mi <- lookupMetaInstantiation m
-        m' <- reify (MetaV m [])
-        case mi of
-          BlockedConst t -> do
-            e  <- reify t
-            return $ Assign m' e
-          PostponedTypeCheckingProblem cl -> enterClosure cl $ \case
-            CheckExpr cmp e a -> do
-                a  <- reify a
-                return $ TypedAssign m' e a
-            CheckLambda cmp (Arg ai (xs, mt)) body target -> do
-              domType <- maybe (return underscore) reify mt
-              target  <- reify target
-              let mkN (WithHiding h x) = setHiding h $ defaultNamedArg $ A.mkBinder_ x
-                  bs = mkTBind noRange (fmap mkN xs) domType
-                  e  = A.Lam Info.exprNoRange (DomainFull bs) body
-              return $ TypedAssign m' e target
-            CheckArgs _ _ _ args t0 t1 _ -> do
-              t0 <- reify t0
-              t1 <- reify t1
-              return $ PostponedCheckArgs m' (map (namedThing . unArg) args) t0 t1
-            CheckProjAppToKnownPrincipalArg cmp e _ _ _ t _ _ _ _ -> TypedAssign m' e <$> reify t
-            DoQuoteTerm cmp v t -> do
-              tm <- A.App defaultAppInfo_ (A.QuoteTerm exprNoRange) . defaultNamedArg <$> reify v
-              OfType tm <$> reify t
-          Open{}  -> __IMPOSSIBLE__
-          OpenInstance{}  -> __IMPOSSIBLE__
-          InstV{} -> __IMPOSSIBLE__
-    reify (FindInstance m mcands) = FindInstanceOF
-      <$> reify (MetaV m [])
-      <*> (reify =<< getMetaType m)
-      <*> forM (fromMaybe [] mcands) (\ (Candidate q tm ty _) -> do
-            (,,) <$> reify tm <*> reify tm <*> reify ty)
-    reify (IsEmpty r a) = IsEmptyType <$> reify a
-    reify (CheckSizeLtSat a) = SizeLtSat  <$> reify a
-    reify (CheckFunDef i q cs err) = do
-      a <- reify =<< defType <$> getConstInfo q
-      return $ PostponedCheckFunDef q a err
-    reify (HasBiggerSort a) = OfType <$> reify a <*> reify (UnivSort a)
-    reify (HasPTSRule a b) = do
-      (a,(x,b)) <- reify (unDom a,b)
-      return $ PTSInstance a b
-    reify (CheckDataSort q s) = DataSort q <$> reify s
-    reify (CheckLockedVars t _ lk _) = CheckLock <$> reify t <*> reify (unArg lk)
-    reify (CheckMetaInst m) = do
-      t <- jMetaType . mvJudgement <$> lookupLocalMeta m
-      OfType <$> reify (MetaV m []) <*> reify t
-    reify (CheckType t) = JustType <$> reify t
-    reify (UsableAtModality _ _ mod t) = UsableAtMod mod <$> reify t
-    {-# SPECIALIZE reify :: Constraint -> TCM (ReifiesTo Constraint) #-}
+  reify (ValueCmp cmp (AsTermsOf t) u v) = CmpInType cmp <$> reify t <*> reify u <*> reify v
+  reify (ValueCmp cmp AsSizes u v) = CmpInType cmp <$> (reify =<< sizeType) <*> reify u <*> reify v
+  reify (ValueCmp cmp AsTypes u v) = CmpTypes cmp <$> reify u <*> reify v
+  reify (ValueCmpOnFace cmp p t u v) = CmpInType cmp <$> (reify =<< ty) <*> reify (lam_o u) <*> reify (lam_o v)
+    where
+      lam_o = I.Lam (setRelevance Irrelevant defaultArgInfo) . NoAbs "_"
+      ty = runNamesT [] $ do
+        p <- open p
+        t <- open t
+        pPi' "o" p (\ o -> t)
+  reify (ElimCmp cmp _ t v es1 es2) =
+    CmpElim cmp <$> reify t <*> mapM reifyElimToExpr es1
+                            <*> mapM reifyElimToExpr es2
+  reify (LevelCmp cmp t t')    = CmpLevels cmp <$> reify t <*> reify t'
+  reify (SortCmp cmp s s')     = CmpSorts cmp <$> reify s <*> reify s'
+  reify (UnquoteTactic tac _ goal) = do
+      tac <- A.App defaultAppInfo_ (A.Unquote exprNoRange) . defaultNamedArg <$> reify tac
+      OfType tac <$> reify goal
+  reify (UnBlock m) = do
+      mi <- lookupMetaInstantiation m
+      m' <- reify (MetaV m [])
+      case mi of
+        BlockedConst t -> do
+          e  <- reify t
+          return $ Assign m' e
+        PostponedTypeCheckingProblem cl -> enterClosure cl $ \case
+          CheckExpr cmp e a -> do
+              a  <- reify a
+              return $ TypedAssign m' e a
+          CheckLambda cmp (Arg ai (xs, mt)) body target -> do
+            domType <- maybe (return underscore) reify mt
+            target  <- reify target
+            let mkN (WithHiding h x) = setHiding h $ defaultNamedArg $ A.mkBinder_ x
+                bs = mkTBind noRange (fmap mkN xs) domType
+                e  = A.Lam Info.exprNoRange (DomainFull bs) body
+            return $ TypedAssign m' e target
+          CheckArgs _ _ _ args t0 t1 _ -> do
+            t0 <- reify t0
+            t1 <- reify t1
+            return $ PostponedCheckArgs m' (map (namedThing . unArg) args) t0 t1
+          CheckProjAppToKnownPrincipalArg cmp e _ _ _ t _ _ _ _ -> TypedAssign m' e <$> reify t
+          DoQuoteTerm cmp v t -> do
+            tm <- A.App defaultAppInfo_ (A.QuoteTerm exprNoRange) . defaultNamedArg <$> reify v
+            OfType tm <$> reify t
+        Open{}  -> __IMPOSSIBLE__
+        OpenInstance{}  -> __IMPOSSIBLE__
+        InstV{} -> __IMPOSSIBLE__
+  reify (FindInstance m mcands) = FindInstanceOF
+    <$> reify (MetaV m [])
+    <*> (reify =<< getMetaType m)
+    <*> forM (fromMaybe [] mcands) (\ (Candidate q tm ty _) -> do
+          (,,) <$> reify tm <*> reify tm <*> reify ty)
+  reify (IsEmpty r a) = IsEmptyType <$> reify a
+  reify (CheckSizeLtSat a) = SizeLtSat  <$> reify a
+  reify (CheckFunDef i q cs err) = do
+    a <- reify =<< defType <$> getConstInfo q
+    return $ PostponedCheckFunDef q a err
+  reify (HasBiggerSort a) = OfType <$> reify a <*> reify (UnivSort a)
+  reify (HasPTSRule a b) = do
+    (a,(x,b)) <- reify (unDom a,b)
+    return $ PTSInstance a b
+  reify (CheckDataSort q s) = DataSort q <$> reify s
+  reify (CheckLockedVars t _ lk _) = CheckLock <$> reify t <*> reify (unArg lk)
+  reify (CheckMetaInst m) = do
+    t <- jMetaType . mvJudgement <$> lookupLocalMeta m
+    OfType <$> reify (MetaV m []) <*> reify t
+  reify (CheckType t) = JustType <$> reify t
+  reify (UsableAtModality _ _ mod t) = UsableAtMod mod <$> reify t
+  {-# SPECIALIZE reify :: Constraint -> TCM (ReifiesTo Constraint) #-}
 
 instance (Pretty a, Pretty b) => PrettyTCM (OutputForm a b) where
   prettyTCM (OutputForm r pids unblock c) =
@@ -722,7 +721,6 @@ stripConstraintPids cs = List.sortBy (compare `on` isBlocked) $ map stripPids cs
 
 {-# SPECIALIZE interactionIdToMetaId :: InteractionId -> TCM MetaId #-}
 -- | Converts an 'InteractionId' to a 'MetaId'.
-
 interactionIdToMetaId :: ReadTCState m => InteractionId -> m MetaId
 interactionIdToMetaId i = do
   h <- currentModuleNameHash

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -339,6 +339,7 @@ class HasRange a where
 
   default getRange :: (Foldable t, HasRange b, t b ~ a) => a -> Range
   getRange = Fold.foldr fuseRange noRange
+  {-# INLINABLE getRange #-}
 
 instance HasRange Interval where
     getRange i =
@@ -701,6 +702,7 @@ fuseRanges (Range f is1) (Range _ is2) = Range f (fuse is1 is2)
     where
     r1' = Seq.dropWhileL (\s -> iEnd s <= iEnd s2) r1
 
+{-# INLINE fuseRange #-}
 -- | Precondition: The ranges must point to the same file (or be
 -- empty).
 fuseRange :: (HasRange u, HasRange t) => u -> t -> Range

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -737,7 +737,7 @@ x `withRangeOf` y = setRange (getRange y) x
 --   ending position is placed first. If both tie, the element from the
 --   first list is placed first.
 interleaveRanges :: (HasRange a) => [a] -> [a] -> ([a], [(a,a)])
-interleaveRanges as bs = runWriter$ go as bs
+interleaveRanges as bs = runWriter $ go as bs
   where
     go []         as = return as
     go as         [] = return as

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP          #-}
+{-# LANGUAGE CPP #-}
 
 -- {-# OPTIONS -fwarn-unused-binds #-}
 

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -236,8 +236,9 @@ reifyDisplayForm f es fallback =
 --   rewrite a lhs with a display form.
 --
 --   Note: we are not necessarily in the empty context upon entry!
-reifyDisplayFormP
-  :: MonadReify m
+reifyDisplayFormP ::
+     forall m.
+     MonadReify m
   => QName         -- ^ LHS head symbol
   -> A.Patterns    -- ^ Patterns to be taken into account to find display form.
   -> A.Patterns    -- ^ Remaining trailing patterns ("with patterns").
@@ -933,7 +934,6 @@ removeNameUnlessUserWritten a
   | (getOrigin <$> getNameOf a) == Just UserWritten = a
   | otherwise = setNameOf Nothing a
 
-
 {-# SPECIALIZE stripImplicits :: Set Name  -> A.Patterns -> A.Patterns -> TCM A.Patterns #-}
 -- | Removes implicit arguments that are not needed, that is, that don't bind
 --   any variables that are actually used and doesn't do pattern matching.
@@ -1205,7 +1205,6 @@ instance Binder a => Binder (Maybe a)
 instance (Binder a, Binder b) => Binder (a, b) where
   varsBoundIn (x, y) = varsBoundIn x `Set.union` varsBoundIn y
 
-
 {-# SPECIALIZE reifyPatterns :: [NamedArg I.DeBruijnPattern] -> TCM [NamedArg A.Pattern] #-}
 -- | Assumes that pattern variables have been added to the context already.
 --   Picks pattern variable names from context.
@@ -1304,7 +1303,6 @@ reifyPatterns = mapM $ (stripNameFromExplicit . stripHidingFromPostfixProj) <.>
 
     addAsBindings :: Functor m => [A.Name] -> m A.Pattern -> m A.Pattern
     addAsBindings xs p = foldr (fmap . AsP patNoRange . mkBindName) p xs
-
 
 {-# SPECIALIZE tryRecPFromConP :: A.Pattern -> TCM A.Pattern #-}
 -- | If the record constructor is generated or the user wrote a record pattern,
@@ -1441,6 +1439,7 @@ instance Reify Sort where
     type ReifiesTo Sort = Expr
 
     reifyWhen = reifyWhenE
+
     reify s = do
       s <- instantiateFull s
       SortKit{..} <- infallibleSortKit

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -108,6 +108,7 @@ class CheckInternal a where
 {-# SPECIALIZE checkInternal' :: Action TCM -> Elims -> Comparison -> TypeOf Type -> TCM Elims #-}
 {-# SPECIALIZE checkInternal  :: Term -> Comparison -> TypeOf Term -> TCM () #-}
 {-# SPECIALIZE checkInternal  :: Type -> Comparison -> TypeOf Type -> TCM () #-}
+
 instance CheckInternal Type where
   checkInternal' action (El s t) cmp _ = do
     t' <- checkInternal' action t cmp (sort s)
@@ -225,8 +226,8 @@ checkArgInfo action ai ai' = do
   mod <- checkModality action (getModality ai)  (getModality ai')
   return $ setModality mod ai
 
-checkHiding    :: (MonadCheckInternal m) => Hiding -> Hiding -> m ()
-checkHiding    h h' = unless (sameHiding h h') $ typeError $ HidingMismatch h h'
+checkHiding :: (MonadCheckInternal m) => Hiding -> Hiding -> m ()
+checkHiding h h' = unless (sameHiding h h') $ typeError $ HidingMismatch h h'
 
 -- | @checkRelevance action term type@.
 --

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -134,6 +134,7 @@ stealConstraintsTCM pid = do
   modifySleepingConstraints $ List.map rename
 
 
+{-# SPECIALIZE noConstraints :: TCM a -> TCM a #-}
 -- | Don't allow the argument to produce any blocking constraints.
 --
 -- WARNING: this does not mean that the given computation cannot
@@ -164,6 +165,7 @@ nonConstraining ::
   ) => m a -> m a
 nonConstraining = dontAssignMetas . noConstraints
 
+{-# SPECIALIZE newProblem :: TCM a -> TCM (ProblemId, a) #-}
 -- | Create a fresh problem for the given action.
 newProblem
   :: (MonadFresh ProblemId m, MonadConstraint m)
@@ -176,6 +178,7 @@ newProblem action = do
   solveAwakeConstraints
   return (pid, x)
 
+{-# SPECIALIZE newProblem_ :: TCM a -> TCM ProblemId #-}
 newProblem_
   :: (MonadFresh ProblemId m, MonadConstraint m)
   => m a -> m ProblemId
@@ -202,6 +205,7 @@ whenConstraints action handler =
     stealConstraints pid
     handler
 
+{-# SPECIALIZE wakeupConstraints :: MetaId -> TCM () #-}
 -- | Wake up the constraints depending on the given meta.
 wakeupConstraints :: MonadMetaSolver m => MetaId -> m ()
 wakeupConstraints x = do

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -152,10 +152,12 @@ convError err =
     (return ())
     (typeError err)
 
+
 -- | Type directed equality on values.
 --
 compareTerm :: forall m. MonadConversion m => Comparison -> Type -> Term -> Term -> m ()
 compareTerm cmp a u v = compareAs cmp (AsTermsOf a) u v
+
 
 {-# SPECIALIZE compareAs :: Comparison -> CompareAs -> Term -> Term -> TCM ()  #-}
 -- | Type directed equality on terms or types.

--- a/src/full/Agda/TypeChecking/Conversion/Pure.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Pure.hs
@@ -33,26 +33,30 @@ newtype PureConversionT m a = PureConversionT
   { unPureConversionT :: ExceptT TCErr (StateT FreshThings m) a }
   deriving (Functor, Applicative, Monad, MonadError TCErr, MonadState FreshThings, PureTCM)
 
+{-# SPECIALIZE pureEqualTerm :: Type -> Term -> Term -> TCM Bool #-}
 pureEqualTerm
   :: (PureTCM m, MonadBlock m)
   => Type -> Term -> Term -> m Bool
 pureEqualTerm a u v =
   isJust <$> runPureConversion (equalTerm a u v)
 
+{-# SPECIALIZE pureEqualType :: Type -> Type -> TCM Bool #-}
 pureEqualType
   :: (PureTCM m, MonadBlock m)
   => Type -> Type -> m Bool
 pureEqualType a b =
   isJust <$> runPureConversion (equalType a b)
 
+{-# SPECIALIZE pureCompareAs :: Comparison -> CompareAs -> Term -> Term -> TCM Bool #-}
 pureCompareAs
   :: (PureTCM m, MonadBlock m)
   => Comparison -> CompareAs -> Term -> Term -> m Bool
 pureCompareAs cmp a u v =
   isJust <$> runPureConversion (compareAs cmp a u v)
 
+{-# SPECIALIZE runPureConversion :: PureConversionT TCM a -> TCM (Maybe a) #-}
 runPureConversion
-  :: (MonadBlock m, PureTCM m, Show a)
+  :: (MonadBlock m, PureTCM m)
   => PureConversionT m a -> m (Maybe a)
 runPureConversion (PureConversionT m) = locallyTC eCompareBlocked (const True) $
   verboseBracket "tc.conv.pure" 40 "runPureConversion" $ do

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -310,8 +310,6 @@ choice m m' = m >>= \case
     No         -> return $ Block r xs
   No    -> m'
 
--- | @matchClause qs i c@ checks whether clause @c@
---   covers a split clause with patterns @qs@.
 {-# SPECIALIZE matchClause :: [NamedArg SplitPattern] -> Clause -> TCM MatchResult #-}
 matchClause
   :: PureTCM m
@@ -323,7 +321,6 @@ matchClause
      -- ^ Result.
      --   If 'Yes' the instantiation @rs@ such that @(namedClausePats c)[rs] == qs@.
 matchClause qs c = matchPats (namedClausePats c) qs
-
 
 {-# SPECIALIZE matchPats :: DeBruijn a => [NamedArg (Pattern' a)] -> [NamedArg SplitPattern] -> TCM MatchResult #-}
 -- | @matchPats ps qs@ checks whether a function clause with patterns

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -97,6 +97,7 @@ type BlockingVars = [BlockingVar]
 --   clause to match 'SplitClause'.
 type SplitInstantiation = [(Nat,SplitPattern)]
 
+{-# SPECIALIZE match :: [Clause] -> [NamedArg SplitPattern] -> TCM (Match (Nat, SplitInstantiation)) #-}
 -- | Match the given patterns against a list of clauses.
 --
 -- If successful, return the index of the covering clause.
@@ -209,6 +210,7 @@ instance Subst SplitPattern where
         p -> p
 
 
+{-# SPECIALIZE isTrivialPattern :: Pattern' a -> TCM Bool #-}
 -- | A pattern that matches anything (modulo eta).
 isTrivialPattern :: (HasConstInfo m) => Pattern' a -> m Bool
 isTrivialPattern = \case
@@ -310,6 +312,7 @@ choice m m' = m >>= \case
 
 -- | @matchClause qs i c@ checks whether clause @c@
 --   covers a split clause with patterns @qs@.
+{-# SPECIALIZE matchClause :: [NamedArg SplitPattern] -> Clause -> TCM MatchResult #-}
 matchClause
   :: PureTCM m
   => [NamedArg SplitPattern]
@@ -322,6 +325,7 @@ matchClause
 matchClause qs c = matchPats (namedClausePats c) qs
 
 
+{-# SPECIALIZE matchPats :: DeBruijn a => [NamedArg (Pattern' a)] -> [NamedArg SplitPattern] -> TCM MatchResult #-}
 -- | @matchPats ps qs@ checks whether a function clause with patterns
 --   @ps@ covers a split clause with patterns @qs@.
 --
@@ -389,6 +393,7 @@ combine m m' = m >>= \case
       Block s ys -> return $ Block (anyBlockedOnResult r s) (xs ++ ys)
       Yes{} -> return x
 
+{-# SPECIALIZE matchPat :: DeBruijn a => Pattern' a -> SplitPattern -> TCM MatchResult #-}
 -- | @matchPat p q@ checks whether a function clause pattern @p@
 --   covers a split clause pattern @q@.  There are three results:
 --
@@ -462,6 +467,7 @@ matchPat p q = case p of
     ProjP{}   -> __IMPOSSIBLE__  -- excluded by typing
     IApplyP _ _ _ x -> __IMPOSSIBLE__ -- blockedOnConstructor (splitPatVarIndex x) c
 
+{-# SPECIALIZE unDotP :: DeBruijn a => Pattern' a -> TCM (Pattern' a) #-}
 -- | Unfold one level of a dot pattern to a proper pattern if possible.
 unDotP :: (MonadReduce m, DeBruijn a) => Pattern' a -> m (Pattern' a)
 unDotP (DotP o v) = reduce v >>= \case
@@ -473,6 +479,7 @@ unDotP (DotP o v) = reduce v >>= \case
   v     -> return $ dotP v
 unDotP p = return p
 
+{-# SPECIALIZE isLitP :: Pattern' a -> TCM (Maybe Literal) #-}
 isLitP :: PureTCM m => Pattern' a -> m (Maybe Literal)
 isLitP (LitP _ l) = return $ Just l
 isLitP (DotP _ u) = reduce u >>= \case
@@ -494,6 +501,7 @@ isLitP (ConP c ci [a]) | visible a && isRelevant a = do
     inc _ = __IMPOSSIBLE__
 isLitP _ = return Nothing
 
+{-# SPECIALIZE unLitP :: Pattern' a -> TCM (Pattern' a) #-}
 unLitP :: HasBuiltins m => Pattern' a -> m (Pattern' a)
 unLitP (LitP info l@(LitNat n)) | n >= 0 = do
   Con c ci es <- constructorForm' (fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinZero)

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -381,6 +381,7 @@ isPropM a = do
     Prop{} -> True
     _      -> False
 
+{-# SPECIALIZE isIrrelevantOrPropM :: Dom Type -> TCM Bool #-}
 isIrrelevantOrPropM
   :: (LensRelevance a, LensSort a, PrettyTCM a, PureTCM m, MonadBlock m)
   => a -> m Bool

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -43,11 +43,13 @@ levelType =
   -- Otherwise, we might run into an __IMPOSSIBLE__ later,
   -- e.g. if only BUILTIN LEVEL was defined by reallyUnLevelView requires all builtins.
 
+{-# SPECIALIZE levelType' :: TCM Type #-}
 -- | Get the 'primLevel' as a 'Type'.  Unsafe, crashes if the BUILTIN LEVEL is undefined.
 levelType' :: (HasBuiltins m) => m Type
 levelType' =
   El LevelUniv . fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevel
 
+{-# SPECIALIZE isLevelType :: Type -> TCM Bool #-}
 isLevelType :: PureTCM m => Type -> m Bool
 isLevelType a = reduce (unEl a) >>= \case
   Def f [] -> do
@@ -140,6 +142,7 @@ maybePrimDef prim = tryMaybe $ do
     Def f [] <- prim
     return f
 
+{-# SPECIALIZE levelView :: Term -> TCM Level #-}
 levelView :: PureTCM m => Term -> m Level
 levelView a = do
   reportSLn "tc.level.view" 50 $ "{ levelView " ++ show a
@@ -147,6 +150,7 @@ levelView a = do
   reportSLn "tc.level.view" 50 $ "  view: " ++ show v ++ "}"
   return v
 
+{-# SPECIALIZE levelView' :: Term -> TCM Level #-}
 levelView' :: PureTCM m => Term -> m Level
 levelView' a = do
   Def lzero [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelZero

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1586,6 +1586,7 @@ type LocalMetaStore = Map MetaId MetaVariable
 
 {-# SPECIALIZE Map.insert :: MetaId -> v -> Map MetaId v -> Map MetaId v #-}
 {-# SPECIALIZE Map.lookup :: MetaId -> Map MetaId v -> Maybe v #-}
+
 -- | Used for meta-variables from other modules (and in 'Interface's).
 
 type RemoteMetaStore = HashMap MetaId RemoteMetaVariable
@@ -1778,6 +1779,7 @@ type DisplayForms = HashMap QName [LocalDisplayForm]
 
 {-# SPECIALIZE HMap.insert :: QName -> v -> HashMap QName v -> HashMap QName v #-}
 {-# SPECIALIZE HMap.lookup :: QName -> HashMap QName v -> Maybe v #-}
+
 newtype Section = Section { _secTelescope :: Telescope }
   deriving (Show, NFData)
 
@@ -3929,12 +3931,9 @@ eConflComputingOverlap f e = f (envConflComputingOverlap e) <&> \ x -> e { envCo
 eCurrentlyElaborating :: Lens' TCEnv Bool
 eCurrentlyElaborating f e = f (envCurrentlyElaborating e) <&> \ x -> e { envCurrentlyElaborating = x }
 
--- | The current modality.
---
--- Note that the returned cohesion component is always 'unitCohesion'.
-
 {-# SPECIALISE currentModality :: TCM Modality #-}
-
+-- | The current modality.
+--   Note that the returned cohesion component is always 'unitCohesion'.
 currentModality :: MonadTCEnv m => m Modality
 currentModality = do
   r <- viewTC eRelevance
@@ -4782,6 +4781,7 @@ reduceSt f s = f (redSt s) <&> \ e -> s { redSt = e }
 newtype ReduceM a = ReduceM { unReduceM :: ReduceEnv -> a }
 --  deriving (Functor, Applicative, Monad)
 
+
 onReduceEnv :: (ReduceEnv -> ReduceEnv) -> ReduceM a -> ReduceM a
 onReduceEnv f (ReduceM m) = ReduceM (m . f)
 {-# INLINE onReduceEnv #-}
@@ -4801,6 +4801,7 @@ apReduce (ReduceM f) (ReduceM x) = ReduceM $ \ e ->
   in  g `pseq` a `pseq` g a
 {-# INLINE apReduce #-}
 
+
 -- Andreas, 2021-05-12, issue #5379
 -- Since the MonadDebug instance of ReduceM is implemented via
 -- unsafePerformIO, we need to force results that later
@@ -4808,6 +4809,7 @@ apReduce (ReduceM f) (ReduceM x) = ReduceM $ \ e ->
 thenReduce :: ReduceM a -> ReduceM b -> ReduceM b
 thenReduce (ReduceM x) (ReduceM y) = ReduceM $ \ e -> x e `pseq` y e
 {-# INLINE thenReduce #-}
+
 
 -- Andreas, 2021-05-14:
 -- `seq` does not force evaluation order, the optimizier is allowed to replace
@@ -5006,7 +5008,6 @@ instance (Monoid w, MonadTCState m) => MonadTCState (WriterT w m)
 
 {-# INLINE getsTC #-}
 -- ** @TCState@ accessors (no lenses)
-
 getsTC :: ReadTCState m => (TCState -> a) -> m a
 getsTC f = f <$> getTCState
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -816,10 +816,12 @@ class Enum i => HasFresh i where
     nextFresh' :: i -> i
     nextFresh' = succ
 
+{-# INLINE nextFresh #-}
 nextFresh :: HasFresh i => TCState -> (i, TCState)
 nextFresh s =
   let !c = s^.freshLens
-  in (c, set freshLens (nextFresh' c) s)
+      !next = set freshLens (nextFresh' c) s
+  in (c, next)
 
 class Monad m => MonadFresh i m where
   fresh :: m i
@@ -838,6 +840,7 @@ instance HasFresh i => MonadFresh i TCM where
         let (!c , !s') = nextFresh s
         putTC s'
         return c
+  {-# INLINE fresh #-}
 
 instance HasFresh MetaId where
   freshLens = stFreshMetaId
@@ -1113,6 +1116,7 @@ instance LensClosure (Closure a) a where
 instance LensTCEnv (Closure a) where
   lensTCEnv f cl = (f $! clEnv cl) <&> \ env -> cl { clEnv = env }
 
+{-# SPECIALIZE buildClosure :: a -> TCM (Closure a)  #-}
 buildClosure :: (MonadTCEnv m, ReadTCState m) => a -> m (Closure a)
 buildClosure x = do
     env   <- askTC
@@ -1580,6 +1584,8 @@ instance Pretty NamedMeta where
 
 type LocalMetaStore = Map MetaId MetaVariable
 
+{-# SPECIALIZE Map.insert :: MetaId -> v -> Map MetaId v -> Map MetaId v #-}
+{-# SPECIALIZE Map.lookup :: MetaId -> Map MetaId v -> Maybe v #-}
 -- | Used for meta-variables from other modules (and in 'Interface's).
 
 type RemoteMetaStore = HashMap MetaId RemoteMetaVariable
@@ -1770,6 +1776,8 @@ type Definitions = HashMap QName Definition
 type RewriteRuleMap = HashMap QName RewriteRules
 type DisplayForms = HashMap QName [LocalDisplayForm]
 
+{-# SPECIALIZE HMap.insert :: QName -> v -> HashMap QName v -> HashMap QName v #-}
+{-# SPECIALIZE HMap.lookup :: QName -> HashMap QName v -> Maybe v #-}
 newtype Section = Section { _secTelescope :: Telescope }
   deriving (Show, NFData)
 
@@ -3820,9 +3828,7 @@ eQuantity f e =
     | otherwise      = __IMPOSSIBLE__
 
 eHardCompileTimeMode :: Lens' TCEnv Bool
-eHardCompileTimeMode f e =
-  f (envHardCompileTimeMode e) <&>
-  \x -> e { envHardCompileTimeMode = x }
+eHardCompileTimeMode f e = f (envHardCompileTimeMode e) <&> \x -> e { envHardCompileTimeMode = x }
 
 eSplitOnStrict :: Lens' TCEnv Bool
 eSplitOnStrict f e = f (envSplitOnStrict e) <&> \ x -> e { envSplitOnStrict = x }
@@ -4706,29 +4712,36 @@ instance E.Exception TCErr
 
 instance MonadIO m => HasOptions (TCMT m) where
   pragmaOptions = useTC stPragmaOptions
+  {-# INLINE pragmaOptions #-}
 
   commandLineOptions = do
     p  <- useTC stPragmaOptions
     cl <- stPersistentOptions . stPersistentState <$> getTC
     return $ cl { optPragmaOptions = p }
+  {-# SPECIALIZE commandLineOptions :: TCM CommandLineOptions #-}
 
 -- HasOptions lifts through monad transformers
 -- (see default signatures in the HasOptions class).
 
 sizedTypesOption :: HasOptions m => m Bool
 sizedTypesOption = optSizedTypes <$> pragmaOptions
+{-# INLINE sizedTypesOption #-}
 
 guardednessOption :: HasOptions m => m Bool
 guardednessOption = optGuardedness <$> pragmaOptions
+{-# INLINE guardednessOption #-}
 
 withoutKOption :: HasOptions m => m Bool
 withoutKOption = optWithoutK <$> pragmaOptions
+{-# INLINE withoutKOption #-}
 
 cubicalCompatibleOption :: HasOptions m => m Bool
 cubicalCompatibleOption = optCubicalCompatible <$> pragmaOptions
+{-# INLINE cubicalCompatibleOption #-}
 
 enableCaching :: HasOptions m => m Bool
 enableCaching = optCaching <$> pragmaOptions
+{-# INLINE enableCaching #-}
 
 -----------------------------------------------------------------------------
 -- * The reduce monad
@@ -4746,26 +4759,32 @@ data ReduceEnv = ReduceEnv
 
 mapRedEnv :: (TCEnv -> TCEnv) -> ReduceEnv -> ReduceEnv
 mapRedEnv f s = s { redEnv = f (redEnv s) }
+{-# INLINE mapRedEnv #-}
 
 mapRedSt :: (TCState -> TCState) -> ReduceEnv -> ReduceEnv
 mapRedSt f s = s { redSt = f (redSt s) }
+{-# INLINE mapRedSt #-}
 
 mapRedEnvSt :: (TCEnv -> TCEnv) -> (TCState -> TCState) -> ReduceEnv
             -> ReduceEnv
 mapRedEnvSt f g (ReduceEnv e s p) = ReduceEnv (f e) (g s) p
+{-# INLINE mapRedEnvSt #-}
 
 -- Lenses
 reduceEnv :: Lens' ReduceEnv TCEnv
 reduceEnv f s = f (redEnv s) <&> \ e -> s { redEnv = e }
+{-# INLINE reduceEnv #-}
 
 reduceSt :: Lens' ReduceEnv TCState
 reduceSt f s = f (redSt s) <&> \ e -> s { redSt = e }
+{-# INLINE reduceSt #-}
 
 newtype ReduceM a = ReduceM { unReduceM :: ReduceEnv -> a }
 --  deriving (Functor, Applicative, Monad)
 
 onReduceEnv :: (ReduceEnv -> ReduceEnv) -> ReduceM a -> ReduceM a
 onReduceEnv f (ReduceM m) = ReduceM (m . f)
+{-# INLINE onReduceEnv #-}
 
 fmapReduce :: (a -> b) -> ReduceM a -> ReduceM b
 fmapReduce f (ReduceM m) = ReduceM $ \ e -> f $! m e
@@ -4874,12 +4893,15 @@ useR :: (ReadTCState m) => Lens' TCState a -> m a
 useR l = do
   !x <- (^.l) <$> getTCState
   return x
+{-# INLINE useR #-}
 
 askR :: ReduceM ReduceEnv
 askR = ReduceM ask
+{-# INLINE askR #-}
 
 localR :: (ReduceEnv -> ReduceEnv) -> ReduceM a -> ReduceM a
 localR f = ReduceM . local f . unReduceM
+{-# INLINE localR #-}
 
 instance HasOptions ReduceM where
   pragmaOptions      = useR stPragmaOptions
@@ -4940,12 +4962,15 @@ instance (Monoid w, MonadTCEnv m) => MonadTCEnv (WriterT w m)
 instance MonadTCEnv m => MonadTCEnv (ListT m) where
   localTC = mapListT . localTC
 
+{-# INLINE asksTC #-}
 asksTC :: MonadTCEnv m => (TCEnv -> a) -> m a
 asksTC f = f <$> askTC
 
+{-# INLINE viewTC #-}
 viewTC :: MonadTCEnv m => Lens' TCEnv a -> m a
 viewTC l = asksTC (^. l)
 
+{-# INLINE locallyTC #-}
 -- | Modify the lens-indicated part of the @TCEnv@ in a subcomputation.
 locallyTC :: MonadTCEnv m => Lens' TCEnv a -> (a -> a) -> m b -> m b
 locallyTC l = localTC . over l
@@ -4979,11 +5004,13 @@ instance MonadTCState m => MonadTCState (ChangeT m)
 instance MonadTCState m => MonadTCState (IdentityT m)
 instance (Monoid w, MonadTCState m) => MonadTCState (WriterT w m)
 
+{-# INLINE getsTC #-}
 -- ** @TCState@ accessors (no lenses)
 
 getsTC :: ReadTCState m => (TCState -> a) -> m a
 getsTC f = f <$> getTCState
 
+{-# INLINE modifyTC' #-}
 -- | A variant of 'modifyTC' in which the computation is strict in the
 -- new state.
 modifyTC' :: MonadTCState m => (TCState -> TCState) -> m ()
@@ -4998,6 +5025,7 @@ modifyTC' f = do
 
 -- ** @TCState@ accessors via lenses
 
+{-# INLINE useTC #-}
 useTC :: ReadTCState m => Lens' TCState a -> m a
 useTC l = do
   !x <- getsTC (^. l)
@@ -5005,32 +5033,39 @@ useTC l = do
 
 infix 4 `setTCLens`
 
+{-# INLINE setTCLens #-}
 -- | Overwrite the part of the 'TCState' focused on by the lens.
 setTCLens :: MonadTCState m => Lens' TCState a -> a -> m ()
 setTCLens l = modifyTC . set l
 
+{-# INLINE setTCLens' #-}
 -- | Overwrite the part of the 'TCState' focused on by the lens
 -- (strictly).
 setTCLens' :: MonadTCState m => Lens' TCState a -> a -> m ()
 setTCLens' l = modifyTC' . set l
 
+{-# INLINE modifyTCLens #-}
 -- | Modify the part of the 'TCState' focused on by the lens.
 modifyTCLens :: MonadTCState m => Lens' TCState a -> (a -> a) -> m ()
 modifyTCLens l = modifyTC . over l
 
+{-# INLINE modifyTCLens' #-}
 -- | Modify the part of the 'TCState' focused on by the lens
 -- (strictly).
 modifyTCLens' :: MonadTCState m => Lens' TCState a -> (a -> a) -> m ()
 modifyTCLens' l = modifyTC' . over l
 
+{-# INLINE modifyTCLensM #-}
 -- | Modify a part of the state monadically.
 modifyTCLensM :: MonadTCState m => Lens' TCState a -> (a -> m a) -> m ()
 modifyTCLensM l f = putTC =<< l f =<< getTC
 
+{-# INLINE stateTCLens #-}
 -- | Modify the part of the 'TCState' focused on by the lens, and return some result.
 stateTCLens :: MonadTCState m => Lens' TCState a -> (a -> (r , a)) -> m r
 stateTCLens l f = stateTCLensM l $ return . f
 
+{-# INLINE stateTCLensM #-}
 -- | Modify a part of the state monadically, and return some result.
 stateTCLensM :: MonadTCState m => Lens' TCState a -> (a -> m (r , a)) -> m r
 stateTCLensM l f = do
@@ -5075,6 +5110,7 @@ instance Monad m => MonadBlock (ExceptT TCErr m) where
 
 runBlocked :: Monad m => BlockT m a -> m (Either Blocker a)
 runBlocked = runExceptT . unBlockT
+{-# INLINE runBlocked #-}
 
 instance MonadBlock m => MonadBlock (MaybeT m) where
   catchPatternErr h m = MaybeT $ catchPatternErr (runMaybeT . h) $ runMaybeT m
@@ -5102,6 +5138,7 @@ pureTCM :: MonadIO m => (TCState -> TCEnv -> a) -> TCMT m a
 pureTCM f = TCM $ \ r e -> do
   s <- liftIO $ readIORef r
   return (f s e)
+{-# INLINE pureTCM #-}
 
 -- One goal of the definitions and pragmas below is to inline the
 -- monad operations as much as possible. This doesn't seem to have a
@@ -5126,22 +5163,22 @@ thenTCMT = \(TCM m1) (TCM m2) -> TCM $ \r e -> m1 r e *> m2 r e
 {-# INLINE thenTCMT #-}
 
 instance Functor m => Functor (TCMT m) where
-  fmap = fmapTCMT
+  fmap = fmapTCMT; {-# INLINE fmap #-}
 
 fmapTCMT :: Functor m => (a -> b) -> TCMT m a -> TCMT m b
 fmapTCMT = \f (TCM m) -> TCM $ \r e -> fmap f (m r e)
 {-# INLINE fmapTCMT #-}
 
 instance Applicative m => Applicative (TCMT m) where
-  pure  = returnTCMT
-  (<*>) = apTCMT
+  pure  = returnTCMT; {-# INLINE pure #-}
+  (<*>) = apTCMT; {-# INLINE (<*>) #-}
 
 apTCMT :: Applicative m => TCMT m (a -> b) -> TCMT m a -> TCMT m b
 apTCMT = \(TCM mf) (TCM m) -> TCM $ \r e -> mf r e <*> m r e
 {-# INLINE apTCMT #-}
 
 instance MonadTrans TCMT where
-    lift m = TCM $ \_ _ -> m
+    lift m = TCM $ \_ _ -> m; {-# INLINE lift #-}
 
 -- We want a special monad implementation of fail.
 #if __GLASGOW_HASKELL__ < 806
@@ -5152,9 +5189,9 @@ instance MonadIO m => Monad (TCMT m) where
 -- if we want @instance MonadTrans TCMT@.
 instance Monad m => Monad (TCMT m) where
 #endif
-    return = pure
-    (>>=)  = bindTCMT
-    (>>)   = (*>)
+    return = pure; {-# INLINE return #-}
+    (>>=)  = bindTCMT; {-# INLINE (>>=) #-}
+    (>>)   = (*>); {-# INLINE (>>) #-}
 #if __GLASGOW_HASKELL__ < 806
     fail   = Fail.fail
 #endif
@@ -5182,17 +5219,17 @@ instance ( MonadFix m
     return x
 
 instance MonadIO m => MonadTCEnv (TCMT m) where
-  askTC             = TCM $ \ _ e -> return e
-  localTC f (TCM m) = TCM $ \ s e -> m s (f e)
+  askTC             = TCM $ \ _ e -> return e; {-# INLINE askTC #-}
+  localTC f (TCM m) = TCM $ \ s e -> m s (f e); {-# INLINE localTC #-}
 
 instance MonadIO m => MonadTCState (TCMT m) where
-  getTC   = TCM $ \ r _e -> liftIO (readIORef r)
-  putTC s = TCM $ \ r _e -> liftIO (writeIORef r s)
-  modifyTC f = putTC . f =<< getTC
+  getTC   = TCM $ \ r _e -> liftIO (readIORef r); {-# INLINE getTC #-}
+  putTC s = TCM $ \ r _e -> liftIO (writeIORef r s); {-# INLINE putTC #-}
+  modifyTC f = putTC . f =<< getTC; {-# INLINE modifyTC #-}
 
 instance MonadIO m => ReadTCState (TCMT m) where
-  getTCState = getTC
-  locallyTCState l f = bracket_ (useTC l <* modifyTCLens l f) (setTCLens l)
+  getTCState = getTC; {-# INLINE getTCState #-}
+  locallyTCState l f = bracket_ (useTC l <* modifyTCLens l f) (setTCLens l); {-# INLINE locallyTCState #-}
 
 instance MonadBlock TCM where
   patternViolation b = throwError (PatternErr b)
@@ -5236,7 +5273,7 @@ instance CatchImpossible TCM where
       unTCM (h err) r e
 
 instance MonadIO m => MonadReduce (TCMT m) where
-  liftReduce = liftTCM . runReduceM
+  liftReduce = liftTCM . runReduceM; {-# INLINE liftReduce #-}
 
 instance (IsString a, MonadIO m) => IsString (TCMT m a) where
   fromString s = return (fromString s)
@@ -5287,10 +5324,12 @@ class ( Applicative tcm, MonadIO tcm
 
     default liftTCM :: (MonadTCM m, MonadTrans t, tcm ~ t m) => TCM a -> tcm a
     liftTCM = lift . liftTCM
+    {-# INLINE liftTCM #-}
 
 {-# RULES "liftTCM/id" liftTCM = id #-}
 instance MonadIO m => MonadTCM (TCMT m) where
     liftTCM = mapTCMT liftIO
+    {-# INLINE liftTCM #-}
 
 instance MonadTCM tcm => MonadTCM (ChangeT tcm)
 instance MonadTCM tcm => MonadTCM (ExceptT err tcm)

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -178,6 +178,7 @@ getPrimitiveTerm :: (HasBuiltins m, MonadError TCErr m, MonadTCEnv m, ReadTCStat
                  => PrimitiveId -> m Term
 getPrimitiveTerm x = (`Def` []) . primFunName <$> getPrimitive x
 
+
 getPrimitiveTerm' :: HasBuiltins m => PrimitiveId -> m (Maybe Term)
 getPrimitiveTerm' x = fmap (`Def` []) <$> getPrimitiveName' x
 

--- a/src/full/Agda/TypeChecking/Monad/Closure.hs
+++ b/src/full/Agda/TypeChecking/Monad/Closure.hs
@@ -10,6 +10,7 @@ import Agda.TypeChecking.Monad.State
 
 import Agda.Utils.Lens
 
+{-# INLINE enterClosure #-}
 enterClosure :: (MonadTCEnv m, ReadTCState m, LensClosure c a)
              => c -> (a -> m b) -> m b
 enterClosure c k | Closure _sig env scope cps x <- c ^. lensClosure = do
@@ -19,8 +20,10 @@ enterClosure c k | Closure _sig env scope cps x <- c ^. lensClosure = do
     $ withEnv env{ envIsDebugPrinting = isDbg }
     $ k x
 
+{-# INLINE withClosure  #-}
 withClosure :: (MonadTCEnv m, ReadTCState m) => Closure a -> (a -> m b) -> m (Closure b)
 withClosure cl k = enterClosure cl $ k >=> buildClosure
 
+{-# INLINE mapClosure  #-}
 mapClosure :: (MonadTCEnv m, ReadTCState m) => (a -> m b) -> Closure a -> m (Closure b)
 mapClosure = flip withClosure

--- a/src/full/Agda/TypeChecking/Monad/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Monad/Constraints.hs
@@ -39,6 +39,7 @@ isProblemSolved pid =
   and2M (not . Set.member pid <$> asksTC envActiveProblems)
         (not . any (Set.member pid . constraintProblems) <$> getAllConstraints)
 
+{-# SPECIALIZE getConstraintsForProblem :: ProblemId -> TCM Constraints #-}
 getConstraintsForProblem :: ReadTCState m => ProblemId -> m Constraints
 getConstraintsForProblem pid = List.filter (Set.member pid . constraintProblems) <$> getAllConstraints
 

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -348,6 +348,7 @@ class IsInstantiatedMeta a where
 
 {-# SPECIALIZE isInstantiatedMeta :: Term -> TCM Bool #-}
 {-# SPECIALIZE isInstantiatedMeta :: Type -> TCM Bool #-}
+
 instance IsInstantiatedMeta MetaId where
   isInstantiatedMeta m = isJust <$> isInstantiatedMeta' m
 
@@ -774,15 +775,13 @@ solveAwakeConstraints' = solveSomeAwakeConstraints (const True)
 {-# SPECIALIZE freezeMetas :: LocalMetaStore -> TCM (Set MetaId) #-}
 -- | Freeze the given meta-variables (but only if they are open) and
 -- return those that were not already frozen.
-freezeMetas :: MonadTCState m => LocalMetaStore -> m (Set MetaId)
+freezeMetas :: forall m. MonadTCState m => LocalMetaStore -> m (Set MetaId)
 freezeMetas ms =
   execWriterT $
   modifyTCLensM stOpenMetaStore $
   execStateT (mapM_ freeze $ MapS.keys ms)
   where
-  freeze ::
-    Monad m =>
-    MetaId -> StateT LocalMetaStore (WriterT (Set MetaId) m) ()
+  freeze :: MetaId -> StateT LocalMetaStore (WriterT (Set MetaId) m) ()
   freeze m = do
     store <- get
     case MapS.lookup m store of
@@ -807,8 +806,8 @@ isFrozen x = do
   mvar <- lookupLocalMeta x
   return $ mvFrozen mvar == Frozen
 
-withFrozenMetas
-  :: (MonadMetaSolver m, MonadTCState m)
+withFrozenMetas ::
+    (MonadMetaSolver m, MonadTCState m)
   => m a -> m a
 withFrozenMetas act = do
   openMetas <- useR stOpenMetaStore

--- a/src/full/Agda/TypeChecking/Monad/Modality.hs
+++ b/src/full/Agda/TypeChecking/Monad/Modality.hs
@@ -131,6 +131,7 @@ splittableCohesion a = do
   let c = getCohesion a
   pure (usableCohesion c) `and2M` (pure (c /= Flat) `or2M` do optFlatSplit <$> pragmaOptions)
 
+{-# SPECIALIZE applyModalityToContext :: Modality -> TCM a -> TCM a #-}
 -- | (Conditionally) wake up irrelevant variables and make them relevant.
 --   For instance,
 --   in an irrelevant function argument otherwise irrelevant variables

--- a/src/full/Agda/TypeChecking/Monad/Modality.hs
+++ b/src/full/Agda/TypeChecking/Monad/Modality.hs
@@ -131,6 +131,7 @@ splittableCohesion a = do
   let c = getCohesion a
   pure (usableCohesion c) `and2M` (pure (c /= Flat) `or2M` do optFlatSplit <$> pragmaOptions)
 
+
 {-# SPECIALIZE applyModalityToContext :: Modality -> TCM a -> TCM a #-}
 -- | (Conditionally) wake up irrelevant variables and make them relevant.
 --   For instance,

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -870,6 +870,7 @@ class ( Functor m
 
 {-# SPECIALIZE getConstInfo :: QName -> TCM Definition #-}
 
+{-# SPECIALIZE getOriginalConstInfo :: QName -> TCM Definition #-}
 -- | The computation 'getConstInfo' sometimes tweaks the returned
 -- 'Definition', depending on the current 'Language' and the
 -- 'Language' of the 'Definition'. This variant of 'getConstInfo' does

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -875,7 +875,6 @@ class ( Functor m
 -- 'Definition', depending on the current 'Language' and the
 -- 'Language' of the 'Definition'. This variant of 'getConstInfo' does
 -- not perform any tweaks.
-
 getOriginalConstInfo ::
   (ReadTCState m, HasConstInfo m) => QName -> m Definition
 getOriginalConstInfo q = do

--- a/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
@@ -141,6 +141,7 @@ sizeUniv = sort $ sizeSort
 sizeType_ :: QName -> Type
 sizeType_ size = El sizeSort $ Def size []
 
+{-# SPECIALIZE sizeType :: TCM Type #-}
 -- | The built-in type @SIZE@.
 sizeType :: (HasBuiltins m, MonadTCEnv m, ReadTCState m) => m Type
 sizeType = El sizeSort . fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSize
@@ -153,6 +154,7 @@ sizeSucName = do
       Just (Def x []) -> return $ Just x
       _               -> return Nothing
 
+{-# SPECIALIZE sizeSuc :: Nat -> Term -> TCM Term #-}
 sizeSuc :: HasBuiltins m => Nat -> Term -> m Term
 sizeSuc n v | n < 0     = __IMPOSSIBLE__
             | n == 0    = return v

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -181,6 +181,7 @@ matchCopattern _       elim@Proj{}    = return (No , elim)
 matchCopattern p       (Apply v) = mapSnd Apply <$> matchPattern p v
 matchCopattern p       e@(IApply x y r) = mapSnd (mergeElim e) <$> matchPattern p (defaultArg r)
 
+{-# SPECIALIZE matchPatterns :: [NamedArg DeBruijnPattern] -> [Arg Term] -> TCM (Match Term, [Arg Term]) #-}
 matchPatterns :: MonadMatch m
               => [NamedArg DeBruijnPattern]
               -> [Arg Term]

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -166,17 +166,16 @@ prettyTCMCtx :: (PrettyTCM a, MonadPretty m) => Precedence -> a -> m Doc
 prettyTCMCtx p = withContextPrecedence p . prettyTCM
 
 instance {-# OVERLAPPING #-} PrettyTCM String where prettyTCM = text
-instance PrettyTCM Bool        where prettyTCM = pretty
-instance PrettyTCM C.Name      where prettyTCM = pretty
-instance PrettyTCM C.QName     where prettyTCM = pretty
-instance PrettyTCM TopLevelModuleName
-                               where prettyTCM = pretty
-instance PrettyTCM Comparison  where prettyTCM = pretty
-instance PrettyTCM Literal     where prettyTCM = pretty
-instance PrettyTCM Nat         where prettyTCM = pretty
-instance PrettyTCM ProblemId   where prettyTCM = pretty
-instance PrettyTCM Range       where prettyTCM = pretty
-instance PrettyTCM CheckpointId where prettyTCM = pretty
+instance PrettyTCM Bool                       where prettyTCM = pretty
+instance PrettyTCM C.Name                     where prettyTCM = pretty
+instance PrettyTCM C.QName                    where prettyTCM = pretty
+instance PrettyTCM TopLevelModuleName         where prettyTCM = pretty
+instance PrettyTCM Comparison                 where prettyTCM = pretty
+instance PrettyTCM Literal                    where prettyTCM = pretty
+instance PrettyTCM Nat                        where prettyTCM = pretty
+instance PrettyTCM ProblemId                  where prettyTCM = pretty
+instance PrettyTCM Range                      where prettyTCM = pretty
+instance PrettyTCM CheckpointId               where prettyTCM = pretty
 -- instance PrettyTCM Interval where prettyTCM = pretty
 -- instance PrettyTCM Position where prettyTCM = pretty
 
@@ -191,6 +190,7 @@ instance PrettyTCM CheckpointId where prettyTCM = pretty
 {-# SPECIALIZE prettyTCM :: ProblemId          -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: Range              -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: CheckpointId       -> TCM Doc #-}
+
 instance PrettyTCM a => PrettyTCM (Closure a) where
   prettyTCM cl = enterClosure cl prettyTCM
 
@@ -198,19 +198,23 @@ instance {-# OVERLAPPABLE #-} PrettyTCM a => PrettyTCM [a] where
   prettyTCM = prettyList . map prettyTCM
 
 {-# SPECIALIZE prettyTCM :: PrettyTCM a => [a] -> TCM Doc #-}
+
 instance {-# OVERLAPPABLE #-} PrettyTCM a => PrettyTCM (Maybe a) where
   prettyTCM = maybe empty prettyTCM
 
 {-# SPECIALIZE prettyTCM :: PrettyTCM a => Maybe a -> TCM Doc #-}
+
 instance (PrettyTCM a, PrettyTCM b) => PrettyTCM (a,b) where
   prettyTCM (a, b) = parens $ prettyTCM a <> comma <> prettyTCM b
 
 {-# SPECIALIZE prettyTCM :: (PrettyTCM a, PrettyTCM b) => (a, b) -> TCM Doc #-}
+
 instance (PrettyTCM a, PrettyTCM b, PrettyTCM c) => PrettyTCM (a,b,c) where
   prettyTCM (a, b, c) = parens $
     prettyTCM a <> comma <> prettyTCM b <> comma <> prettyTCM c
 
 {-# SPECIALIZE prettyTCM :: (PrettyTCM a, PrettyTCM b, PrettyTCM c) => (a, b, c) -> TCM Doc #-}
+
 instance PrettyTCM Term               where prettyTCM = prettyA <=< reify
 instance PrettyTCM Type               where prettyTCM = prettyA <=< reify
 instance PrettyTCM Sort               where prettyTCM = prettyA <=< reify
@@ -227,10 +231,10 @@ instance PrettyTCM (NamedArg A.Expr)  where prettyTCM = prettyA <=< reify
 instance PrettyTCM (NamedArg Term)    where prettyTCM = prettyA <=< reify
 instance PrettyTCM (Dom Type)         where prettyTCM = prettyA <=< reify
 instance PrettyTCM ContextEntry       where prettyTCM = prettyA <=< reify
+instance PrettyTCM Permutation        where prettyTCM = text . show
+instance PrettyTCM Polarity           where prettyTCM = text . show
+instance PrettyTCM IsForced           where prettyTCM = text . show
 
-instance PrettyTCM Permutation where prettyTCM = text . show
-instance PrettyTCM Polarity    where prettyTCM = text . show
-instance PrettyTCM IsForced    where prettyTCM = text . show
 {-# SPECIALIZE prettyTCM :: Term              -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: Type              -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: Sort              -> TCM Doc #-}

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -45,6 +45,7 @@ instance PrettyTCM CallInfo where
     if null $ P.pretty r
       then call
       else call $$ nest 2 ("(at" <+> prettyTCM r) <> ")"
+  {-# SPECIALIZE prettyTCM :: CallInfo -> TCM Doc #-}
 
 instance PrettyTCM Call where
   prettyTCM = withContextPrecedence TopCtx . \case
@@ -238,3 +239,4 @@ instance PrettyTCM Call where
     hPretty a = do
       withContextPrecedence (ArgumentCtx PreferParen) $
         pretty =<< abstractToConcreteHiding a a
+  {-# SPECIALIZE prettyTCM :: Call -> TCM Doc #-}

--- a/src/full/Agda/TypeChecking/Pretty/Constraint.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Constraint.hs
@@ -51,12 +51,10 @@ prettyInterestingConstraints cs = mapM (prettyConstraint . stripPids) $ List.sor
     cs' = filter interestingConstraint cs
     interestingPids = Set.unions $ map (allBlockingProblems . constraintUnblocker) cs'
     stripPids (PConstr pids unblock c) = PConstr (Set.intersection pids interestingPids) unblock c
-
 {-# SPECIALIZE prettyInterestingConstraints :: [ProblemConstraint] -> TCM [Doc] #-}
 
 prettyRangeConstraint ::
-  (MonadPretty m, Foldable f, Null (f ProblemId)) =>
-  Range -> f ProblemId -> Blocker -> Doc -> m Doc
+  (MonadPretty m, Foldable f, Null (f ProblemId)) => Range -> f ProblemId -> Blocker -> Doc -> m Doc
 prettyRangeConstraint r pids unblock c =
   return c <?>
   sep [ prange r

--- a/src/full/Agda/TypeChecking/Pretty/Constraint.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Constraint.hs
@@ -37,6 +37,7 @@ prettyConstraint c = f (locallyTCState stInstantiateBlocking (const True) $ pret
     f d = if null $ P.pretty r
           then d
           else d $$ nest 4 ("[ at" <+> prettyTCM r <+> "]")
+{-# SPECIALIZE prettyConstraint :: ProblemConstraint -> TCM Doc #-}
 
 interestingConstraint :: ProblemConstraint -> Bool
 interestingConstraint pc = go $ clValue (theConstraint pc) where
@@ -51,6 +52,7 @@ prettyInterestingConstraints cs = mapM (prettyConstraint . stripPids) $ List.sor
     interestingPids = Set.unions $ map (allBlockingProblems . constraintUnblocker) cs'
     stripPids (PConstr pids unblock c) = PConstr (Set.intersection pids interestingPids) unblock c
 
+{-# SPECIALIZE prettyInterestingConstraints :: [ProblemConstraint] -> TCM [Doc] #-}
 
 prettyRangeConstraint ::
   (MonadPretty m, Foldable f, Null (f ProblemId)) =>

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -508,11 +508,8 @@ applyFlagsToTCWarningsPreserving additionalKeptWarnings ws = do
 applyFlagsToTCWarnings :: HasOptions m => [TCWarning] -> m [TCWarning]
 applyFlagsToTCWarnings = applyFlagsToTCWarningsPreserving Set.empty
 
-isBoundaryConstraint
-  :: (ReadTCState m, MonadTCM m)
-  => ProblemConstraint
-  -> m (Maybe Range)
 {-# SPECIALIZE isBoundaryConstraint :: ProblemConstraint -> TCM (Maybe Range) #-}
+isBoundaryConstraint :: (ReadTCState m, MonadTCM m) => ProblemConstraint -> m (Maybe Range)
 isBoundaryConstraint c =
   enterClosure (theConstraint c) $ \case
     ValueCmp _ _ (MetaV mid xs) y | Just xs <- allApplyElims xs ->
@@ -549,10 +546,9 @@ getAllUnsolvedWarnings = do
 getAllWarnings :: (MonadFail m, ReadTCState m, MonadWarning m, MonadTCM m) => WhichWarnings -> m [TCWarning]
 getAllWarnings = getAllWarningsPreserving Set.empty
 
-getAllWarningsPreserving
-  :: (MonadFail m, ReadTCState m, MonadWarning m, MonadTCM m)
-  => Set WarningName -> WhichWarnings -> m [TCWarning]
 {-# SPECIALIZE getAllWarningsPreserving :: Set WarningName -> WhichWarnings -> TCM [TCWarning] #-}
+getAllWarningsPreserving ::
+  (MonadFail m, ReadTCState m, MonadWarning m, MonadTCM m) => Set WarningName -> WhichWarnings -> m [TCWarning]
 getAllWarningsPreserving keptWarnings ww = do
   unsolved            <- getAllUnsolvedWarnings
   collectedTCWarnings <- useTC stTCWarnings

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -67,6 +67,7 @@ hPi', nPi' :: (MonadFail m, MonadAddContext m, MonadDebug m)
 hPi' s a b = hPi s a (bind' s (\ x -> b x))
 nPi' s a b = nPi s a (bind' s (\ x -> b x))
 
+{-# INLINABLE pPi' #-}
 pPi' :: (MonadAddContext m, HasBuiltins m, MonadDebug m)
      => String -> NamesT m Term -> (NamesT m Term -> NamesT m Type) -> NamesT m Type
 pPi' n phi b = toFinitePi <$> nPi' n (elSSet $ cl isOne <@> phi) b

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
@@ -372,6 +372,7 @@ hfill la bA phi u u0 i = do
         ])
     <@> u0
 
+{-# SPECIALIZE decomposeInterval :: Term -> TCM [(IntMap Bool, [Term])] #-}
 -- | Decompose an interval expression @i : I@ as in
 -- 'decomposeInterval'', but discard any inconsistent mappings.
 decomposeInterval :: HasBuiltins m => Term -> m [(IntMap Bool, [Term])]
@@ -379,6 +380,7 @@ decomposeInterval t = do
   decomposeInterval' t <&> \xs ->
     [ (bm, ts) | (bsm, ts) <- xs, bm <- maybeToList $ traverse BoolSet.toSingleton bsm ]
 
+{-# SPECIALIZE decomposeInterval' :: Term -> TCM [(IntMap BoolSet, [Term])] #-}
 -- | Decompose an interval expression @φ : I@ into a set of possible
 -- assignments for the variables mentioned in @φ@, together any leftover
 -- neutral terms that could not be put into 'IntervalView' form.

--- a/src/full/Agda/TypeChecking/ProjectionLike.hs
+++ b/src/full/Agda/TypeChecking/ProjectionLike.hs
@@ -132,6 +132,7 @@ projView v = do
 
     _ -> fallback
 
+{-# SPECIALIZE reduceProjectionLike :: Term -> TCM Term #-}
 -- | Reduce away top-level projection like functions.
 --   (Also reduces projections, but they should not be there,
 --   since Internal is in lambda- and projection-beta-normal form.)
@@ -149,6 +150,7 @@ reduceProjectionLike v = do
 data ProjEliminator = EvenLone | ButLone | NoPostfix
   deriving Eq
 
+{-# SPECIALIZE elimView :: ProjEliminator -> Term -> TCM Term #-}
 -- | Turn prefix projection-like function application into postfix ones.
 --   This does just one layer, such that the top spine contains
 --   the projection-like functions as projections.
@@ -179,6 +181,7 @@ elimView pe v = do
           | otherwise     -> return v
         ProjectionView f a es -> (`applyE` (Proj ProjPrefix f : es)) <$> elimView pe (unArg a)
 
+{-# SPECIALIZE eligibleForProjectionLike :: QName -> TCM Bool #-}
 -- | Which @Def@types are eligible for the principle argument
 --   of a projection-like function?
 eligibleForProjectionLike :: (HasConstInfo m) => QName -> m Bool
@@ -427,6 +430,7 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
         candidateRec NoAbs{}   = []
         candidateRec (Abs x t) = candidateArgs (var (size vs) : vs) t
 
+{-# SPECIALIZE inferNeutral :: Term -> TCM Type #-}
 -- | Infer type of a neutral term.
 --   See also @infer@ in @Agda.TypeChecking.CheckInternal@, which has a very similar
 --   logic but also type checks all arguments.
@@ -465,6 +469,7 @@ inferNeutral u = do
           ifJustM (projectTyped (hd []) t o f) (\(_,_,t') -> return t') __IMPOSSIBLE__
       loop t' (hd . (e:)) es
 
+{-# SPECIALIZE computeDefType :: QName -> Elims -> TCM Type #-}
 -- | Compute the head type of a Def application. For projection-like functions
 --   this requires inferring the type of the principal argument.
 computeDefType :: (PureTCM m, MonadBlock m) => QName -> Elims -> m Type

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -459,6 +459,7 @@ isEtaRecord r = do
         currentQ     <- viewTC eQuantity
         return $ constructorQ `moreQuantity` currentQ
 
+{-# SPECIALIZE isEtaCon :: QName -> TCM Bool #-}
 isEtaCon :: HasConstInfo m => QName -> m Bool
 isEtaCon c = getConstInfo' c >>= \case
   Left (SigUnknown err)     -> __IMPOSSIBLE__
@@ -815,6 +816,7 @@ etaContractRecord r c ci args = if all (not . usableModality) args then fallBack
         , unDom ax == f -> Just $ Just $ h es
       _                 -> Nothing
 
+{-# SPECIALIZE isSingletonRecord :: QName -> Args -> TCM Bool #-}
 -- | Is the type a hereditarily singleton record type? May return a
 -- blocking metavariable.
 --
@@ -933,6 +935,7 @@ isSingletonType' regardIrrelevance t rs = do
 
       (<|>) <$> record <*> subtype
 
+{-# SPECIALIZE isEtaVar :: Term -> Type -> TCM (Maybe Int) #-}
 -- | Checks whether the given term (of the given type) is beta-eta-equivalent
 --   to a variable. Returns just the de Bruijn-index of the variable if it is,
 --   or nothing otherwise.

--- a/src/full/Agda/TypeChecking/Rewriting/Clause.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Clause.hs
@@ -20,6 +20,7 @@ import Agda.Syntax.Common.Pretty
 -- * Converting clauses to rewrite rules
 ------------------------------------------------------------------------
 
+{-# INLINABLE getClausesAsRewriteRules #-}
 -- | Get all the clauses of a definition and convert them to rewrite
 --   rules.
 getClausesAsRewriteRules :: (HasConstInfo m, MonadFresh NameId m) => QName -> m [RewriteRule]
@@ -29,12 +30,14 @@ getClausesAsRewriteRules f = do
     clname <- clauseQName f i
     return $ clauseToRewriteRule f clname cl
 
+{-# INLINABLE clauseQName #-}
 -- | Generate a sensible name for the given clause
 clauseQName :: (HasConstInfo m, MonadFresh NameId m) => QName -> Int -> m QName
 clauseQName f i = QName (qnameModule f) <$> clauseName (qnameName f) i
   where
     clauseName n i = freshName noRange (prettyShow n ++ "-clause" ++ show i)
 
+{-# INLINABLE clauseToRewriteRule #-}
 -- | @clauseToRewriteRule f q cl@ converts the clause @cl@ of the
 --   function @f@ to a rewrite rule with name @q@. Returns @Nothing@
 --   if @clauseBody cl@ is @Nothing@. Precondition: @clauseType cl@ is

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -397,6 +397,7 @@ makeSubstitution gamma sub =
                 Just (_         , v) -> Just v
                 Nothing              -> Nothing
 
+{-# SPECIALIZE checkPostponedEquations :: Substitution -> PostponedEquations -> TCM (Maybe Blocked_) #-}
 checkPostponedEquations :: PureTCM m
                         => Substitution -> PostponedEquations -> m (Maybe Blocked_)
 checkPostponedEquations sub eqs = forM' eqs $

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
@@ -429,6 +429,7 @@ buildEquiv (UnificationStep st step output) _ = do
     Cycle{}       -> __IMPOSSIBLE__
     _ -> unsupported
 
+{-# SPECIALIZE explainStep :: UnifyStep -> TCM Doc #-}
 explainStep :: MonadPretty m => UnifyStep -> m Doc
 explainStep Injectivity{injectConstructor = ch} =
   "injectivity of the data constructor" <+> prettyTCM (conName ch)

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/Types.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/Types.hs
@@ -77,12 +77,14 @@ data UnifyState = UState
 
 lensVarTel   :: Lens' UnifyState Telescope
 lensVarTel   f s = f (varTel s) <&> \ tel -> s { varTel = tel }
+{-# INLINE lensVarTel #-}
 --UNUSED Liang-Ting Chen 2019-07-16
 --lensFlexVars :: Lens' UnifyState FlexibleVars
 --lensFlexVars f s = f (flexVars s) <&> \ flex -> s { flexVars = flex }
 
 lensEqTel    :: Lens' UnifyState Telescope
 lensEqTel    f s = f (eqTel s) <&> \ x -> s { eqTel = x }
+{-# INLINE lensEqTel #-}
 
 --UNUSED Liang-Ting Chen 2019-07-16
 --lensEqLHS    :: Lens' UnifyState Args

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -298,6 +298,7 @@ sizeMaxView v = do
 -- * Size comparison that might add constraints.
 ------------------------------------------------------------------------
 
+{-# SPECIALIZE compareSizes :: Comparison -> Term -> Term -> TCM () #-}
 -- | Compare two sizes.
 compareSizes :: (MonadConversion m) => Comparison -> Term -> Term -> m ()
 compareSizes cmp u v = verboseBracket "tc.conv.size" 10 "compareSizes" $ do

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -203,7 +203,7 @@ shouldBeSort t = ifIsSort t return (typeError $ ShouldBeASort t)
 --
 --   Precondition: given term is a well-sorted type.
 sortOf
-  :: forall m. (PureTCM m, MonadBlock m,MonadConstraint m)
+  :: forall m. (PureTCM m, MonadBlock m, MonadConstraint m)
   => Term -> m Sort
 sortOf t = do
   reportSDoc "tc.sort" 60 $ "sortOf" <+> prettyTCM t

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -855,6 +855,9 @@ instance Subst Term where
   type SubstArg Term = Term
   applySubst = applySubstTerm
 
+-- András 2023-09-25: we can only put this here, because at the original definition site there's no Subst Term instance.
+{-# SPECIALIZE lookupS :: Substitution' Term -> Nat -> Term #-}
+
 instance Subst BraveTerm where
   type SubstArg BraveTerm = BraveTerm
   applySubst = applySubstTerm
@@ -1074,6 +1077,7 @@ instance (Subst a, Subst b, SubstArg a ~ SubstArg b) => Subst (Dom' a b) where
   applySubst IdS dom = dom
   applySubst rho dom = setFreeVariables unknownFreeVariables $
     fmap (applySubst rho) dom{ domTactic = applySubst rho (domTactic dom) }
+  {-# INLINABLE applySubst #-}
 
 instance Subst LetBinding where
   type SubstArg LetBinding = Term

--- a/src/full/Agda/TypeChecking/Substitute/Class.hs
+++ b/src/full/Agda/TypeChecking/Substitute/Class.hs
@@ -283,6 +283,7 @@ lookupS rho i = case rho of
 
 -- | lookupS (listS [(x0,t0)..(xn,tn)]) xi = ti, assuming x0 < .. < xn.
 
+
 listS :: EndoSubst a => [(Int,a)] -> Substitution' a
 listS ((i,t):ts) = singletonS i t `composeS` listS ts
 listS []         = IdS

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -370,6 +370,7 @@ expandTelescopeVar gamma k delta c = (tel', rho)
 
     tel'        = gamma1 `abstract` (delta `abstract` gamma2')
 
+
 {-# INLINE telView #-}
 -- | Gather leading Πs of a type in a telescope.
 telView :: (MonadReduce m, MonadAddContext m) => Type -> m TelView
@@ -419,6 +420,7 @@ telViewUpToPath n t = if n == 0 then done t else do
 -- | [[ (i,(x,y)) ]] = [(i=0) -> x, (i=1) -> y]
 type Boundary = Boundary' (Term,Term)
 type Boundary' a = [(Term,a)]
+
 
 {-# SPECIALIZE telViewUpToPathBoundary' :: Int -> Type -> TCM (TelView, Boundary) #-}
 -- | Like @telViewUpToPath@ but also returns the @Boundary@ expected

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -115,6 +115,7 @@ teleDoms tel = zipWith (\ i dom -> deBruijnVar i <$ dom) (downFrom $ size l) l
 teleNamedArgs :: (DeBruijn a) => Tele (Dom t) -> [NamedArg a]
 teleNamedArgs = map namedArgFromDom . teleDoms
 
+{-# INLINABLE tele2NamedArgs #-}
 -- | A variant of `teleNamedArgs` which takes the argument names (and the argument info)
 --   from the first telescope and the variable names from the second telescope.
 --
@@ -369,15 +370,18 @@ expandTelescopeVar gamma k delta c = (tel', rho)
 
     tel'        = gamma1 `abstract` (delta `abstract` gamma2')
 
+{-# INLINE telView #-}
 -- | Gather leading Πs of a type in a telescope.
 telView :: (MonadReduce m, MonadAddContext m) => Type -> m TelView
 telView = telViewUpTo (-1)
 
+{-# INLINE telViewUpTo #-}
 -- | @telViewUpTo n t@ takes off the first @n@ function types of @t@.
 -- Takes off all if @n < 0@.
 telViewUpTo :: (MonadReduce m, MonadAddContext m) => Int -> Type -> m TelView
 telViewUpTo n t = telViewUpTo' n (const True) t
 
+{-# SPECIALIZE telViewUpTo' :: Int -> (Dom Type -> Bool) -> Type -> TCM TelView #-}
 -- | @telViewUpTo' n p t@ takes off $t$
 --   the first @n@ (or arbitrary many if @n < 0@) function domains
 --   as long as they satify @p@.
@@ -393,9 +397,11 @@ telViewUpTo' n p t = do
         underAbstractionAbs a b $ \b -> telViewUpTo' (n - 1) p b
     _ -> return $ TelV EmptyTel t
 
+{-# INLINE telViewPath #-}
 telViewPath :: PureTCM m => Type -> m TelView
 telViewPath = telViewUpToPath (-1)
 
+{-# SPECIALIZE telViewUpToPath :: Int -> Type -> TCM TelView #-}
 -- | @telViewUpToPath n t@ takes off $t$
 --   the first @n@ (or arbitrary many if @n < 0@) function domains or Path types.
 --
@@ -414,6 +420,7 @@ telViewUpToPath n t = if n == 0 then done t else do
 type Boundary = Boundary' (Term,Term)
 type Boundary' a = [(Term,a)]
 
+{-# SPECIALIZE telViewUpToPathBoundary' :: Int -> Type -> TCM (TelView, Boundary) #-}
 -- | Like @telViewUpToPath@ but also returns the @Boundary@ expected
 -- by the Path types encountered. The boundary terms live in the
 -- telescope given by the @TelView@.
@@ -445,6 +452,7 @@ fullBoundary tel bs =
        l  = size tel
    in map (\ (t@(Var i []), xy) -> (t, xy `applyE` (drop (l - i) es))) bs
 
+{-# SPECIALIZE telViewUpToPathBoundary :: Int -> Type -> TCM (TelView, Boundary) #-}
 -- | @(TelV Γ b, [(i,t_i,u_i)]) <- telViewUpToPathBoundary n a@
 --  Input:  Δ ⊢ a
 --  Output: ΔΓ ⊢ b
@@ -455,6 +463,7 @@ telViewUpToPathBoundary i a = do
    (telv@(TelV tel b), bs) <- telViewUpToPathBoundary' i a
    return $ (telv, fullBoundary tel bs)
 
+{-# INLINE telViewUpToPathBoundaryP #-}
 -- | @(TelV Γ b, [(i,t_i,u_i)]) <- telViewUpToPathBoundaryP n a@
 --  Input:  Δ ⊢ a
 --  Output: Δ.Γ ⊢ b
@@ -465,6 +474,7 @@ telViewUpToPathBoundary i a = do
 telViewUpToPathBoundaryP :: PureTCM m => Int -> Type -> m (TelView,Boundary)
 telViewUpToPathBoundaryP = telViewUpToPathBoundary'
 
+{-# INLINE telViewPathBoundaryP #-}
 telViewPathBoundaryP :: PureTCM m => Type -> m (TelView,Boundary)
 telViewPathBoundaryP = telViewUpToPathBoundaryP (-1)
 
@@ -489,17 +499,20 @@ teleElims tel boundary = recurse (teleArgs tel)
         Just i | Just (t,u) <- matchVar i -> IApply t u p
         _                                 -> Apply a
 
+{-# SPECIALIZE pathViewAsPi :: Type -> TCM (Either (Dom Type, Abs Type) Type) #-}
 -- | Reduces 'Type'.
 pathViewAsPi
   :: PureTCM m => Type -> m (Either (Dom Type, Abs Type) Type)
 pathViewAsPi t = either (Left . fst) Right <$> pathViewAsPi' t
 
+{-# SPECIALIZE pathViewAsPi' :: Type -> TCM (Either ((Dom Type, Abs Type), (Term,Term)) Type) #-}
 -- | Reduces 'Type'.
 pathViewAsPi'
   :: PureTCM m => Type -> m (Either ((Dom Type, Abs Type), (Term,Term)) Type)
 pathViewAsPi' t = do
   pathViewAsPi'whnf <*> reduce t
 
+{-# SPECIALIZE pathViewAsPi'whnf :: TCM (Type -> Either ((Dom Type, Abs Type), (Term,Term)) Type) #-}
 pathViewAsPi'whnf
   :: (HasBuiltins m)
   => m (Type -> Either ((Dom Type, Abs Type), (Term,Term)) Type)
@@ -546,6 +559,7 @@ isPath t = ifPath t (\a b -> return $ Just (a,b)) (const $ return Nothing)
 ifPath :: PureTCM m => Type -> (Dom Type -> Abs Type -> m a) -> (Type -> m a) -> m a
 ifPath t yes no = ifPathB t yes $ no . ignoreBlocking
 
+{-# SPECIALIZE ifPathB :: Type -> (Dom Type -> Abs Type -> TCM a) -> (Blocked Type -> TCM a) -> TCM a #-}
 ifPathB :: PureTCM m => Type -> (Dom Type -> Abs Type -> m a) -> (Blocked Type -> m a) -> m a
 ifPathB t yes no = ifBlocked t
   (\b t -> no $ Blocked b t)
@@ -651,9 +665,13 @@ class PiApplyM a where
 
   piApplyM :: (MonadReduce m, HasBuiltins m) => Type -> a -> m Type
   piApplyM = piApplyM' __IMPOSSIBLE__
+  {-# INLINE piApplyM #-}
 
 instance PiApplyM Term where
   piApplyM' err t v = ifNotPiOrPathType t (\_ -> absurd <$> err) {-else-} $ \ _ b -> return $ absApp b v
+  {-# INLINABLE piApplyM' #-}
+
+{-# SPECIALIZE piApplyM' :: TCM Empty -> Type -> Term -> TCM Type #-}
 
 instance PiApplyM a => PiApplyM (Arg a) where
   piApplyM' err t = piApplyM' err t . unArg

--- a/src/full/Agda/TypeChecking/Telescope/Path.hs
+++ b/src/full/Agda/TypeChecking/Telescope/Path.hs
@@ -118,6 +118,7 @@ instance IApplyVars p => IApplyVars (NamedArg p) where
 instance IApplyVars p => IApplyVars [p] where
   iApplyVars = concatMap iApplyVars
 
+{-# SPECIALIZE isInterval :: Type -> TCM Bool #-}
 -- | Check whether a type is the built-in interval type.
 isInterval :: (MonadTCM m, MonadReduce m) => Type -> m Bool
 isInterval t = liftTCM $ do

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -216,6 +216,7 @@ reset = modifyBenchmark $
   mapCurrentAccount (const Strict.Nothing) .
   mapTimings (const Trie.empty)
 
+{-# INLINABLE billTo #-}
 -- | Bill a computation to a specific account.
 --   Works even if the computation is aborted by an exception.
 

--- a/src/full/Agda/Utils/Update.hs
+++ b/src/full/Agda/Utils/Update.hs
@@ -59,14 +59,17 @@ instance Monad m => MonadChange (ChangeT m) where
 -- | Run a 'ChangeT' computation, returning result plus change flag.
 runChangeT :: Functor m => ChangeT m a -> m (a, Bool)
 runChangeT = fmap (mapSnd getAny) . runWriterT . fromChangeT
+{-# INLINE runChangeT #-}
 
 -- | Run a 'ChangeT' computation, but ignore change flag.
 execChangeT :: Functor m => ChangeT m a -> m a -- A library function, so keep
 execChangeT = fmap fst . runChangeT
+{-# INLINE execChangeT #-}
 
 -- | Map a 'ChangeT' computation (monad transformer action).
 mapChangeT :: (m (a, Any) -> n (b, Any)) -> ChangeT m a -> ChangeT n b
 mapChangeT f (ChangeT m) = ChangeT (mapWriterT f m)
+{-# INLINE mapChangeT #-}
 
 -- Don't actually track changes with the identity monad:
 
@@ -110,6 +113,7 @@ dirty :: Monad m => UpdaterT m a
 dirty a = do
   tellDirty
   return a
+{-# INLINE dirty #-}
 
 {-# SPECIALIZE ifDirty :: Change a -> (a -> Change b) -> (a -> Change b) -> Change b #-}
 {-# SPECIALIZE ifDirty :: Identity a -> (a -> Identity b) -> (a -> Identity b) -> Identity b #-}
@@ -125,10 +129,12 @@ sharing :: Monad m => UpdaterT m a -> UpdaterT m a
 sharing f a = do
   (a', changed) <- listenDirty $ f a
   return $ if changed then a' else a
+{-# INLINE sharing #-}
 
 -- | Eval an updater (using 'sharing').
 evalUpdater :: Updater a -> EndoFun a
 evalUpdater f a = fst $ runChange $ sharing f a
+{-# INLINE evalUpdater #-}
 
 -- END REAL STUFF
 


### PR DESCRIPTION
Decrease `-foptimise-heavily` build time by 15-17% by adding a bunch of `SPECIALIZE` pragmas. Also add a bunch of `INLINE` and `INLINABLE` pragmas. `-foptimise-heavily` runtime performance is unchanged within margin of error. 

Pragmas are placed based on the following information:
- Module build times displayed with https://github.com/codedownio/time-ghc-modules and `-ddump-timings -ddump-to-file` GHC options. 
- Core printed with `-ddump-simpl -dsuppress-all -dno-suppress-type-signatures -ddump-to-file`.
- Failed specializations printed with `-Wall-missed-specializations` when we build without `-foptimise-heavily`. 

Only the worst offending and most visible instances of code duplication are addressed here; there is definitely a large amount that's still there.