### PR TITLE
Perf fixes and more benchmark data in TypeChecking.DeadCode

### DIFF
--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -50,7 +50,11 @@ data Phase
   | Serialization
     -- ^ Writing interface files.
   | DeadCode
-    -- ^ Deac code elimination.
+    -- ^ Dead code elimination.
+  | DeadCodeInstantiateFull
+    -- ^ Unfolding all metas before serialization.
+  | DeadCodeReachable
+    -- ^ Dead code reachable definitions subphase.
   | Graph
     -- ^ Subphase for 'Termination'.
   | RecCheck
@@ -146,3 +150,4 @@ billToIO = B.billTo
 -- | Benchmark a pure computation and bill it to the given account.
 billToPure :: Account -> a -> a
 billToPure acc a = unsafePerformIO $ billToIO acc $ return a
+{-# NOINLINE billToPure #-}

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -5,7 +5,6 @@
 module Agda.Syntax.Internal.Names where
 
 import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HMap
 import Data.Map (Map)
 import Data.Set (Set)
 
@@ -99,26 +98,34 @@ instance NamesIn a => NamesIn (Tele a)
 
 instance (NamesIn a, NamesIn b) => NamesIn (a, b) where
   namesAndMetasIn' sg (x, y) =
-    mappend (namesAndMetasIn' sg x) (namesAndMetasIn' sg y)
+    namesAndMetasIn' sg x <> namesAndMetasIn' sg y
+  {-# INLINE namesAndMetasIn' #-}
 
 instance (NamesIn a, NamesIn b, NamesIn c) => NamesIn (a, b, c) where
-  namesAndMetasIn' sg (x, y, z) = namesAndMetasIn' sg (x, (y, z))
+  namesAndMetasIn' sg (x, y, z) =
+    namesAndMetasIn' sg x <> namesAndMetasIn' sg y <> namesAndMetasIn' sg z
+  {-# INLINE namesAndMetasIn' #-}
 
 instance (NamesIn a, NamesIn b, NamesIn c, NamesIn d) => NamesIn (a, b, c, d) where
   namesAndMetasIn' sg (x, y, z, u) =
-    namesAndMetasIn' sg ((x, y), (z, u))
+    namesAndMetasIn' sg x <> namesAndMetasIn' sg y <> namesAndMetasIn' sg z <> namesAndMetasIn' sg u
+  {-# INLINE namesAndMetasIn' #-}
 
 instance
   (NamesIn a, NamesIn b, NamesIn c, NamesIn d, NamesIn e) =>
   NamesIn (a, b, c, d, e) where
   namesAndMetasIn' sg (x, y, z, u, v) =
-    namesAndMetasIn' sg ((x, y), (z, (u, v)))
+    namesAndMetasIn' sg x <> namesAndMetasIn' sg y <> namesAndMetasIn' sg z <> namesAndMetasIn' sg u
+    <> namesAndMetasIn' sg v
+  {-# INLINE namesAndMetasIn' #-}
 
 instance
   (NamesIn a, NamesIn b, NamesIn c, NamesIn d, NamesIn e, NamesIn f) =>
   NamesIn (a, b, c, d, e, f) where
   namesAndMetasIn' sg (x, y, z, u, v, w) =
-    namesAndMetasIn' sg ((x, (y, z)), (u, (v, w)))
+    namesAndMetasIn' sg x <> namesAndMetasIn' sg y <> namesAndMetasIn' sg z <> namesAndMetasIn' sg u
+    <> namesAndMetasIn' sg v <> namesAndMetasIn' sg w
+  {-# INLINE namesAndMetasIn' #-}
 
 instance NamesIn CompKit where
   namesAndMetasIn' sg (CompKit a b) = namesAndMetasIn' sg (a,b)
@@ -308,7 +315,7 @@ instance NamesIn RewriteRule where
       namesAndMetasIn' sg (a, b, c, d, e, f)
 
 instance (NamesIn a, NamesIn b) => NamesIn (HashMap a b) where
-  namesAndMetasIn' sg = namesAndMetasIn' sg . HMap.toList
+  namesAndMetasIn' sg map = foldMap (namesAndMetasIn' sg) map
 
 instance NamesIn System where
   namesAndMetasIn' sg (System tel cs) = namesAndMetasIn' sg (tel, cs)

--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -2,7 +2,7 @@
 
 module Agda.TypeChecking.DeadCode (eliminateDeadCode) where
 
-import qualified Control.Exception as E
+import Control.Monad ((<$!>))
 import Control.Monad.Trans
 
 import Data.Maybe
@@ -30,6 +30,9 @@ import Agda.TypeChecking.Reduce
 import Agda.Utils.Impossible
 import Agda.Utils.Lens
 
+import Agda.Utils.HashTable (HashTable)
+import qualified Agda.Utils.HashTable as HT
+
 -- | Run before serialisation to remove any definitions and
 -- meta-variables that are not reachable from the module's public
 -- interface.
@@ -41,11 +44,13 @@ eliminateDeadCode ::
   LocalMetaStore ->
   TCM (DisplayForms, Signature, RemoteMetaStore)
 eliminateDeadCode bs disp sig ms = Bench.billTo [Bench.DeadCode] $ do
-  patsyn <- getPatternSyns
-  public <- Set.mapMonotonic anameName . publicNames <$> getScope
-  save   <- optSaveMetas <$> pragmaOptions
-  defs   <- (if save then return else traverse instantiateFull)
-                 (sig ^. sigDefinitions)
+  !patsyn <- getPatternSyns
+  !public <- Set.mapMonotonic anameName . publicNames <$> getScope
+  !save   <- optSaveMetas <$> pragmaOptions
+  !defs   <- if save then return (sig ^. sigDefinitions)
+                     else Bench.billTo [Bench.DeadCode, Bench.DeadCodeInstantiateFull]
+                          (traverse (\x -> instantiateFull x) (sig ^. sigDefinitions))
+
   -- #2921: Eliminating definitions with attached COMPILE pragmas results in
   -- the pragmas not being checked. Simple solution: don't eliminate these.
   -- #6022 (Andreas, 2022-09-30): Eliminating cubical primitives can lead to crashes.
@@ -69,59 +74,69 @@ eliminateDeadCode bs disp sig ms = Bench.billTo [Bench.DeadCode] $ do
           , sig ^. sigRewriteRules
           , HMap.filterWithKey (\x _ -> Set.member x rootNames) disp
           )
-      (rns, rms) =
-        reachableFrom (rootNames, rootMetas) patsyn disp defs ms
-      dead  = Set.fromList (HMap.keys defs) `Set.difference` rns
-      valid = getAll . namesIn' (All . (`Set.notMember` dead))  -- no used name is dead
-      defs' = HMap.map ( \ d -> d { defDisplay = filter valid (defDisplay d) } )
-            $ HMap.filterWithKey (\ x _ -> Set.member x rns) defs
-      disp' = HMap.filter (not . null) $ HMap.map (filter valid) disp
-      ms'   = HMap.fromList $
-              mapMaybe
-                (\(m, mv) ->
-                  if not (Set.member m rms)
-                  then Nothing
-                  else Just (m, remoteMetaVariable mv)) $
-              MapS.toList ms
-  -- The hashmaps are forced to WHNF to ensure that the computations
-  -- are billed to the right account.
-  disp' <- liftIO $ E.evaluate disp'
-  defs' <- liftIO $ E.evaluate defs'
-  ms'   <- liftIO $ E.evaluate ms'
+
+  (!rns, !rms) <- Bench.billTo [Bench.DeadCode, Bench.DeadCodeReachable] $ liftIO $
+                    reachableFrom (rootNames, rootMetas) patsyn disp defs ms
+
+  let !dead  = Set.fromList (HMap.keys defs) `Set.difference` rns
+      !valid = getAll . namesIn' (All . (`Set.notMember` dead))  -- no used name is dead
+      !defs' = HMap.map ( \ d -> d { defDisplay = filter valid (defDisplay d) } )
+               $ HMap.filterWithKey (\ x _ -> Set.member x rns) defs
+      !disp' = HMap.filter (not . null) $ HMap.map (filter valid) disp
+      !ms'   = HMap.fromList $
+                mapMaybe
+                  (\(m, mv) ->
+                    if not (Set.member m rms)
+                    then Nothing
+                    else Just (m, remoteMetaVariable mv)) $
+                MapS.toList ms
+
   reportSLn "tc.dead" 10 $
     "Removed " ++ show (HMap.size defs - HMap.size defs') ++
     " unused definitions and " ++ show (MapS.size ms - HMap.size ms') ++
     " unused meta-variables."
-  return (disp', set sigDefinitions defs' sig, ms')
+  let !sig' = set sigDefinitions defs' sig
+  return (disp', sig', ms')
 
 reachableFrom
   :: (Set QName, Set MetaId)  -- ^ Roots.
   -> A.PatternSynDefns -> DisplayForms -> Definitions -> LocalMetaStore
-  -> (Set QName, Set MetaId)
-reachableFrom (ids, ms) psyns disp defs insts =
-  follow (ids, ms)
-    (map Left (Set.toList ids) ++ map Right (Set.toList ms))
-  where
-  follow seen        []       = seen
-  follow (!ids, !ms) (x : xs) =
-    follow (Set.union ids'' ids, Set.union ms'' ms)
-      (map Left  (Set.toList ids'') ++
-       map Right (Set.toList ms'')  ++
-       xs)
-    where
-    ids'' = ids' `Set.difference` ids
-    ms''  = ms'  `Set.difference` ms
+  -> IO (Set QName, Set MetaId)
+reachableFrom (ids, ms) psyns disp defs insts = do
 
-    (ids', ms') = case x of
-      Left x ->
-        namesAndMetasIn
-          ( HMap.lookup x defs
-          , PSyn <$> MapS.lookup x psyns
-          , HMap.lookup x disp
-          )
-      Right m -> case MapS.lookup m insts of
-        Nothing -> (Set.empty, Set.empty)
-        Just mv -> namesAndMetasIn (instBody (theInstantiation mv))
+  !seenNames <- HT.empty :: IO (HashTable QName ())
+  !seenMetas <- HT.empty :: IO (HashTable MetaId ())
+
+  let goName :: QName -> IO ()
+      goName !x = HT.lookup seenNames x >>= \case
+        Just _ ->
+          pure ()
+        Nothing -> do
+          HT.insert seenNames x ()
+          go (HMap.lookup x defs)
+          go (PSyn <$!> MapS.lookup x psyns)
+          go (HMap.lookup x disp)
+
+      goMeta :: MetaId -> IO ()
+      goMeta !m = HT.lookup seenMetas m >>= \case
+        Just _ ->
+          pure ()
+        Nothing -> do
+          HT.insert seenMetas m ()
+          case MapS.lookup m insts of
+            Nothing -> pure ()
+            Just mv -> go (instBody (theInstantiation mv))
+
+      go :: NamesIn a => a -> IO ()
+      go = namesAndMetasIn' (either goName goMeta)
+      {-# INLINE go #-}
+
+  foldMap goName ids
+  foldMap goMeta ms
+  !ids' <- HT.keySet seenNames
+  !ms'  <- HT.keySet seenMetas
+  pure (ids', ms')
+
 
 -- | Returns the instantiation.
 --

--- a/src/full/Agda/Utils/HashTable.hs
+++ b/src/full/Agda/Utils/HashTable.hs
@@ -10,6 +10,7 @@ module Agda.Utils.HashTable
   , insert
   , lookup
   , toList
+  , keySet
   ) where
 
 import Prelude hiding (lookup)
@@ -17,6 +18,9 @@ import Prelude hiding (lookup)
 import Data.Hashable
 import qualified Data.Vector.Hashtables as H
 import qualified Data.Vector.Mutable as VM
+import qualified Data.Vector as V
+import Data.Set (Set)
+import qualified Data.Set as Set
 
 -- | Hash tables.
 
@@ -45,11 +49,13 @@ empty = HashTable <$> H.initialize 0
 
 insert :: (Eq k, Hashable k) => HashTable k v -> k -> v -> IO ()
 insert (HashTable h) = H.insert h
+{-# INLINABLE insert #-}
 
 -- | Tries to find a value corresponding to the key in the hash table.
 
 lookup :: (Eq k, Hashable k) => HashTable k v -> k -> IO (Maybe v)
 lookup (HashTable h) = H.lookup h
+{-# INLINABLE lookup #-}
 
 -- | Converts the hash table to a list.
 --
@@ -57,3 +63,10 @@ lookup (HashTable h) = H.lookup h
 
 toList :: (Eq k, Hashable k) => HashTable k v -> IO [(k, v)]
 toList (HashTable h) = H.toList h
+{-# INLINABLE toList #-}
+
+keySet :: forall k v. Ord k => HashTable k v -> IO (Set k)
+keySet (HashTable h) = do
+  (ks :: V.Vector k) <- H.keys h
+  pure $! V.foldl' (flip Set.insert) mempty ks
+{-# INLINABLE keySet #-}


### PR DESCRIPTION
This commit reduces the DeadCode account std-lib time by a modest ~1.8s by optimizing the `reachableFrom` function in `TypeChecking.DeadCode`. It's a side product of an investigation into the slowness of DeadCode. My initial hypothesis was that since `reachableFrom` traverses everything, it should be the culprit.

Indeed, it was both poorly optimized and compiled: the Monoid instance was dynamically passed, the traversal was breadth-first and the result sets were built in a Writer-like fashion with overhead at every Term node, instead of in a State-like fashion. The new implementation is a bit over 2x faster and uses mutable hashtables and proper specialization of `namesAndMetasIn`.

However, the great majority of the DeadCode pass cost seems to actually come from `instantiateFull`, and to a lesser extent from forcing random thunks that pollute the definitions. Hence, fixing `reachableFrom` does not help much. I added a new Bench account for the instantiation, and also for the reachability calculation, to get a picture. On my machine:

    DeadCode.DeadCodeInstantiateFull  23,854ms
    DeadCode.DeadCodeReachable         1,603ms

Remark: the whole DeadCode setup could be ideally replaced with a fully strict simplifier pass that performs meta inlining in a smarter way, inlining small solutions while avoiding size explosion. Currently inlining is all or nothing, and `instantiateFull` appears to have massive overhead. In the meanwhile I think it's worth to just commit this smaller fix.