### PR TITLE
Occurs-checker optimization

### DIFF
--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -522,7 +522,7 @@ instance Occurs Term where
           MetaV m' es -> do
             m' <- metaCheck m'
             ctx <- ask
-            let fallback = return . Right $ MetaV m' es
+            let fallback = return . Left $ MetaV m' es
             -- if the meta is projected don't prune it, return fallback
             t <- caseMaybe (allApplyElims es) (fallback) $ \ vs -> do
               -- don't attempt pruning if we're in a flexible context
@@ -532,19 +532,19 @@ instance Occurs Term where
                  if (killResult == PrunedEverything) then do
                    reportSDoc "tc.meta.prune" 40 $ "Pruned everything"
                    -- we don't have to do occurs-check after everything was pruned
-                   return $ Left v
+                   return $ Right v
                  else do
                    reportSDoc "tc.meta.prune" 40 $ "Didn't manage to prune everything"
                    -- some variables was pruned, but not all, still have to do occurs-check after
-                   return $ Right v
+                   return $ Left v
                else fallback
             case t of
               -- The arguments of a meta are in a flexible position
-              (Right (MetaV m' es')) -> (MetaV m' <$> do flexibly $ occurs es')
+              (Left (MetaV m' es')) -> (MetaV m' <$> do flexibly $ occurs es')
               -- Sometimes instantiated meta is actually not a meta itself
-              (Right t) -> occurs t
+              (Left t) -> occurs t
               -- the PrunedEverything case
-              (Left v) -> return v
+              (Right v) -> return v
           where
             -- a data or record type constructor propagates strong occurrences
             -- since e.g. x = List x is unsolvable

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -523,7 +523,8 @@ instance Occurs Term where
             m' <- metaCheck m'
             ctx <- ask
             let fallback = return . Left $ MetaV m' es
-            -- if the meta is projected don't prune it, return fallback
+            -- Andreas, 2014-03-02, see issue 1070:
+            -- Do not prune when meta is projected!
             t <- caseMaybe (allApplyElims es) (fallback) $ \ vs -> do
               -- don't attempt pruning if we're in a flexible context
                if not (isFlexible ctx) then do

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -523,20 +523,27 @@ instance Occurs Term where
             m' <- metaCheck m'
             ctx <- ask
             let fallback = return . Right $ MetaV m' es
+            -- if the meta is projected don't prune it, return fallback
             t <- caseMaybe (allApplyElims es) (fallback) $ \ vs -> do
+              -- don't attempt pruning if we're in a flexible context
                if not (isFlexible ctx) then do
                  killResult <- lift . prune m' vs =<< allowedVars
                  v <- instantiate (MetaV m' es)
                  if (killResult == PrunedEverything) then do
                    reportSDoc "tc.meta.prune" 40 $ "Pruned everything"
+                   -- we don't have to do occurs-check after everything was pruned
                    return $ Left v
                  else do
                    reportSDoc "tc.meta.prune" 40 $ "Didn't manage to prune everything"
+                   -- some variables was pruned, but not all, still have to do occurs-check after
                    return $ Right v
                else fallback
             case t of
+              -- The arguments of a meta are in a flexible position
               (Right (MetaV m' es')) -> (MetaV m' <$> do flexibly $ occurs es')
+              -- Sometimes instantiated meta is actually not a meta itself
               (Right t) -> occurs t
+              -- the PrunedEverything case
               (Left v) -> return v
           where
             -- a data or record type constructor propagates strong occurrences

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -536,7 +536,7 @@ instance Occurs Term where
                    return $ Right v
                  else do
                    reportSDoc "tc.meta.prune" 40 $ "Didn't manage to prune everything"
-                   -- some variables was pruned, but not all, still have to do occurs-check after
+                   -- some variables were pruned, but not all, still have to do occurs-check after
                    return $ Left v
                else fallback
             case t of


### PR DESCRIPTION
At the moment we do occurs-check twice on the arguments to the meta, once on line 525 and if that fails, we prune and check again:
https://github.com/agda/agda/blob/a0c0e586d2cbf9a2bc8ac3597fbf6733c98fc8f7/src/full/Agda/TypeChecking/MetaVars/Occurs.hs#L525-L545

This change introduces eager pruning and does occurs check afterwards only when pruning didn't manage to remove all offending variables.

The test suite passes.
Unless something has gone wrong with the tests and the reported number is off, we can get a (significant?) speedup.
std-lib test time goes from 12min22s to 10min44s. Cubical goes up from 28min16s to 27min2s.

<details> 
  <summary>std-lib test summary <b>without</b> changes, total "real time" is 12min </summary>
  
```
Total                        743,043ms            
Miscellaneous                  6,703ms            
Typing                        41,847ms (313,277ms)
Typing.CheckRHS              101,892ms            
Typing.CheckLHS               25,035ms  (80,181ms)
Typing.CheckLHS.UnifyIndices  55,145ms            
Typing.Generalize             27,722ms            
Typing.TypeSig                26,037ms            
Typing.OccursCheck            22,431ms            
Typing.With                   11,342ms            
Typing.InstanceSearch          1,821ms            
Coverage                     112,918ms            
Serialization                 87,394ms (105,123ms)
Serialization.Compress         8,493ms            
Serialization.BinaryEncode     6,498ms            
Serialization.Sort             1,925ms            
Serialization.BuildInterface     811ms            
DeadCode                      46,651ms            
Parsing                        5,343ms  (41,749ms)
Parsing.OperatorsExpr         30,028ms            
Parsing.OperatorsPattern       6,376ms            
Deserialization               29,869ms  (40,962ms)
Deserialization.Compaction    11,092ms            
Scoping                        8,282ms  (34,770ms)
Scoping.InverseScopeLookup    26,487ms            
Positivity                    26,094ms            
Termination                    2,370ms   (7,063ms)
Termination.RecCheck           3,518ms            
Termination.Compare              829ms            
Termination.Graph                344ms            
Highlighting                   4,792ms            
Injectivity                    1,412ms            
Import                         1,270ms            
ProjectionLikeness               212ms            
ModuleName                        40ms            
 918,679,447,304 bytes allocated in the heap
 103,950,975,624 bytes copied during GC
   1,545,617,576 bytes maximum residency (163 sample(s))
       4,712,144 bytes maximum slop
            2256 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     218520 colls,     0 par   148.770s  149.016s     0.0007s    0.0435s
  Gen  1       163 colls,     0 par   21.507s  21.509s     0.1320s    0.9957s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.000s elapsed)
  MUT     time  572.902s  (571.633s elapsed)
  GC      time  170.277s  (170.526s elapsed)
  EXIT    time    0.001s  (  0.001s elapsed)
  Total   time  743.180s  (742.160s elapsed)

  Alloc rate    1,603,555,129 bytes per MUT second

  Productivity  77.1% of total user, 77.0% of total elapsed


real	12m22,337s
user	12m15,298s
sys	0m8,060s
  ```
  
</details>

<details> 
  <summary>std-lib test summary <b>with</b> changes, total "real time" is 10min44s </summary>

```
Total                        644,843ms            
Miscellaneous                  5,616ms            
Typing                        36,933ms (270,357ms)
Typing.CheckRHS               82,973ms            
Typing.CheckLHS               20,895ms  (72,077ms)
Typing.CheckLHS.UnifyIndices  51,182ms            
Typing.Generalize             26,403ms            
Typing.TypeSig                22,605ms            
Typing.OccursCheck            19,254ms            
Typing.With                    8,317ms            
Typing.InstanceSearch          1,793ms            
Coverage                     100,873ms            
Serialization                 72,565ms  (89,835ms)
Serialization.Compress         7,944ms            
Serialization.BinaryEncode     7,002ms            
Serialization.Sort             1,620ms            
Serialization.BuildInterface     702ms            
DeadCode                      43,504ms            
Parsing                        4,483ms  (34,415ms)
Parsing.OperatorsExpr         24,855ms            
Parsing.OperatorsPattern       5,076ms            
Deserialization               23,416ms  (32,723ms)
Deserialization.Compaction     9,307ms            
Scoping                        7,029ms  (31,732ms)
Scoping.InverseScopeLookup    24,702ms            
Positivity                    23,874ms            
Termination                    1,919ms   (5,939ms)
Termination.RecCheck           3,069ms            
Termination.Compare              674ms            
Termination.Graph                275ms            
Highlighting                   3,641ms            
Injectivity                    1,223ms            
Import                           900ms            
ProjectionLikeness               181ms            
ModuleName                        21ms            
 918,836,033,880 bytes allocated in the heap
 103,728,040,952 bytes copied during GC
   1,545,894,712 bytes maximum residency (166 sample(s))
       5,105,040 bytes maximum slop
            2255 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     218551 colls,     0 par   128.029s  128.206s     0.0006s    0.0371s
  Gen  1       166 colls,     0 par   20.849s  20.851s     0.1256s    1.0150s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time  496.091s  (495.418s elapsed)
  GC      time  148.878s  (149.056s elapsed)
  EXIT    time    0.001s  (  0.005s elapsed)
  Total   time  644.971s  (644.480s elapsed)

  Alloc rate    1,852,151,892 bytes per MUT second

  Productivity  76.9% of total user, 76.9% of total elapsed


real	10m44,650s
user	10m38,482s
sys	0m6,659s
```
</details>

<details> 
  <summary>cubical test summary <b>without</b> changes, total "real time" is 28min16s </summary>
  
```
———— All done; warnings encountered ————————————————————————

/home/bohdan/delft/agda/agda/cubical/Cubical/Tactics/Reflection.agda:92,5-19
warning: -W[no]UserWarning
DEPRECATED: Use `withReduceDefs` instead of `dontReduceDefs`
when scope checking dontReduceDefs
make[2]: Leaving directory '/home/bohdan/delft/agda/agda/cubical'
make[1]: Leaving directory '/home/bohdan/delft/agda/agda/cubical'

real	28m16,383s
user	28m13,232s
sys	0m4,640s
```
  
</details>

<details> 
  <summary>cubical test summary <b>with</b> changes, total "real time" is 27min2s </summary>
  
```
———— All done; warnings encountered ————————————————————————

/home/bohdan/delft/agda/agda/cubical/Cubical/Tactics/Reflection.agda:92,5-19
warning: -W[no]UserWarning
DEPRECATED: Use `withReduceDefs` instead of `dontReduceDefs`
when scope checking dontReduceDefs
make[2]: Leaving directory '/home/bohdan/delft/agda/agda/cubical'
make[1]: Leaving directory '/home/bohdan/delft/agda/agda/cubical'

real	27m2,328s
user	26m59,405s
sys	0m4,051s
```

</details>