### PR TITLE
hard drop GHC 8.4

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -420,7 +420,7 @@ library
         -- unordered-containers < 0.2.9 need base < 4.11
     , uri-encode           >= 1.5.0.4   && < 1.6
     , vector               >= 0.12      && < 0.14
-    , vector-hashtables    == 0.1.*
+    , vector-hashtables    >= 0.1.1.1   && < 0.2
     , zlib                 == 0.6.*
 
   -- We don't write upper bounds for Alex nor Happy because the

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 import Data.Maybe
@@ -8,9 +7,8 @@ import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Setup
 import Distribution.Simple.BuildPaths (exeExtension)
 import Distribution.PackageDescription
-#if MIN_VERSION_Cabal(2,3,0)
 import Distribution.System ( buildPlatform )
-#endif
+
 import System.FilePath
 import System.Directory (makeAbsolute, removeFile)
 import System.Environment (getEnvironment)
@@ -140,8 +138,4 @@ generateInterfaces pd lbi = do
   return ()
 
 agdaExeExtension :: String
-#if MIN_VERSION_Cabal(2,3,0)
 agdaExeExtension = exeExtension buildPlatform
-#else
-agdaExeExtension = exeExtension
-#endif

--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -1,7 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
-{-# LANGUAGE CPP #-}
-
 module Agda.Compiler.Common where
 
 import Prelude hiding ((!!))
@@ -13,9 +11,6 @@ import qualified Data.Set as Set
 import qualified Data.HashMap.Strict as HMap
 import Data.Char
 import Data.Function (on)
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 
 import Control.Monad
 import Control.Monad.State

--- a/src/full/Agda/Compiler/MAlonzo/Misc.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Misc.hs
@@ -1,7 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
-{-# LANGUAGE CPP #-}
-
 module Agda.Compiler.MAlonzo.Misc where
 
 import Control.Monad.Reader ( ask )
@@ -18,10 +16,6 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
-
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup
-#endif
 
 import qualified Agda.Utils.Haskell.Syntax as HS
 

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -22,9 +22,6 @@ import Data.Char
 import Data.Maybe
 import Data.Function (on)
 import Data.Foldable (toList)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup (Semigroup(..))
-#endif
 
 import Control.Exception.Base (IOException, try)
 import Control.Monad (forM_, mapM_, unless, when)

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -926,11 +926,7 @@ writeInterface file i = let fp = filePath file in do
       "Writing interface file with hash " ++ show (iFullHash filteredIface) ++ "."
     encodedIface <- encodeFile fp filteredIface
     reportSLn "import.iface.write" 5 "Wrote interface file."
-#if __GLASGOW_HASKELL__ >= 804
     fromMaybe __IMPOSSIBLE__ <$> (Bench.billTo [Bench.Deserialization] (decode encodedIface))
-#else
-    return filteredIface
-#endif
   `catchError` \e -> do
     reportSLn "" 1 $
       "Failed to write interface " ++ fp ++ "."

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 {-| Some common syntactic entities are defined in this module.
 -}
 module Agda.Syntax.Common
@@ -17,9 +15,6 @@ import Control.DeepSeq
 import Control.Arrow ((&&&))
 import Control.Applicative ((<|>), liftA2)
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup hiding (Arg)
-#endif
 import Data.Bifunctor
 import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as ByteString

--- a/src/full/Agda/Syntax/Concrete/Fixity.hs
+++ b/src/full/Agda/Syntax/Concrete/Fixity.hs
@@ -1,8 +1,8 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
-{-# LANGUAGE CPP                        #-}
 -- | Collecting fixity declarations (and polarity pragmas) for concrete
 --   declarations.
+
 module Agda.Syntax.Concrete.Fixity
   ( Fixities, Polarities, MonadFixityError(..)
   , DoWarn(..)
@@ -16,9 +16,6 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 
 import Agda.Syntax.Builtin (builtinById, isBuiltinNoDef)
 import Agda.Syntax.Common

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 
 module Agda.Syntax.Internal
     ( module Agda.Syntax.Internal
@@ -767,10 +766,7 @@ pattern EqualityType
 pattern EqualityType{ eqtSort, eqtName, eqtParams, eqtType, eqtLhs, eqtRhs } =
   EqualityViewType (EqualityTypeData eqtSort eqtName eqtParams eqtType eqtLhs eqtRhs)
 
--- The COMPLETE pragma is new in GHC 8.2
-#if __GLASGOW_HASKELL__ >= 802
 {-# COMPLETE EqualityType, OtherType, IdiomType #-}
-#endif
 
 isEqualityType :: EqualityView -> Bool
 isEqualityType EqualityType{} = True

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -1,12 +1,8 @@
-{-# LANGUAGE CPP          #-}
 
 -- | Tree traversal for internal syntax.
 
 module Agda.Syntax.Internal.Generic where
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Monoid ((<>))
-#endif
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.Utils.Functor

--- a/src/full/Agda/Termination/CallGraph.hs
+++ b/src/full/Agda/Termination/CallGraph.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ImplicitParams             #-}
 
 -- | Call graphs and related concepts, more or less as defined in
@@ -28,9 +27,6 @@ module Agda.Termination.CallGraph
 import Prelude hiding (null)
 
 import qualified Data.List as List
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 import Data.Set (Set)
 
 import Agda.Termination.CallMatrix (CallMatrix, CallMatrixAug(..), CMSet(..), CallComb(..))

--- a/src/full/Agda/Termination/CallMatrix.hs
+++ b/src/full/Agda/Termination/CallMatrix.hs
@@ -1,7 +1,6 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
 {-# LANGUAGE ImplicitParams             #-}
-{-# LANGUAGE CPP                        #-}
 
 module Agda.Termination.CallMatrix where
 
@@ -12,9 +11,6 @@ module Agda.Termination.CallMatrix where
 --   , tests
 --   ) where
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 
 import Agda.Termination.CutOff
 import Agda.Termination.Order as Order

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2294,12 +2294,9 @@ data Defn
   | PrimitiveSortDefn PrimitiveSortData
     deriving (Show, Generic)
 
--- The COMPLETE pragma is new in GHC 8.2
-#if __GLASGOW_HASKELL__ >= 802
 {-# COMPLETE
   Axiom, DataOrRecSig, GeneralizableVar, AbstractDefn,
   Function, Datatype, Record, Constructor, Primitive, PrimitiveSort #-}
-#endif
 
 data AxiomData = AxiomData
   { _axiomConstTransp :: Bool
@@ -4870,9 +4867,6 @@ instance Monad ReduceM where
   return = pure
   (>>=) = bindReduce
   (>>) = (*>)
-#if __GLASGOW_HASKELL__ < 806
-  fail = Fail.fail
-#endif
 
 instance Fail.MonadFail ReduceM where
   fail = error
@@ -5200,20 +5194,13 @@ instance MonadTrans TCMT where
     lift m = TCM $ \_ _ -> m; {-# INLINE lift #-}
 
 -- We want a special monad implementation of fail.
-#if __GLASGOW_HASKELL__ < 806
-instance MonadIO m => Monad (TCMT m) where
-#else
 -- Andreas, 2022-02-02, issue #5659:
 -- @transformers-0.6@ requires exactly a @Monad@ superclass constraint here
 -- if we want @instance MonadTrans TCMT@.
 instance Monad m => Monad (TCMT m) where
-#endif
     return = pure; {-# INLINE return #-}
     (>>=)  = bindTCMT; {-# INLINE (>>=) #-}
     (>>)   = (*>); {-# INLINE (>>) #-}
-#if __GLASGOW_HASKELL__ < 806
-    fail   = Fail.fail
-#endif
 
 instance MonadIO m => Fail.MonadFail (TCMT m) where
   fail = internalError
@@ -5229,9 +5216,6 @@ instance MonadIO m => MonadIO (TCMT m) where
         E.throwIO $ IOException s r err
 
 instance ( MonadFix m
-#if __GLASGOW_HASKELL__ < 806
-         , MonadIO m
-#endif
          ) => MonadFix (TCMT m) where
   mfix f = TCM $ \s env -> mdo
     x <- unTCM (f x) s env

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -51,9 +51,6 @@ import qualified Data.Binary.Get as B
 import qualified Data.Binary.Put as B
 import qualified Data.List as List
 import Data.Function (on)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup((<>))
-#endif
 
 import qualified Codec.Compression.GZip as G
 import qualified Codec.Compression.Zlib.Internal as Z

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -58,9 +58,7 @@ import Data.Semigroup((<>))
 import qualified Codec.Compression.GZip as G
 import qualified Codec.Compression.Zlib.Internal as Z
 
-#if __GLASGOW_HASKELL__ >= 804
 import GHC.Compact as C
-#endif
 
 import qualified Agda.TypeChecking.Monad.Benchmark as Bench
 
@@ -226,15 +224,11 @@ decode s = do
 
     Right (mf, x) -> do
       setTCLens stModuleToSource mf
-#if __GLASGOW_HASKELL__ >= 804
       -- "Compact" the interfaces (without breaking sharing) to
       -- reduce the amount of memory that is traversed by the
       -- garbage collector.
       Bench.billTo [Bench.Deserialization, Bench.Compaction] $
         liftIO (Just . C.getCompact <$> C.compactWithSharing x)
-#else
-      return (Just x)
-#endif
 
 
 encodeInterface :: Interface -> TCM Encoded

--- a/src/full/Agda/Utils/Cluster.hs
+++ b/src/full/Agda/Utils/Cluster.hs
@@ -1,7 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
-{-# LANGUAGE CPP #-}
-
 -- | Create clusters of non-overlapping things.
 
 module Agda.Utils.Cluster
@@ -21,9 +19,6 @@ import Data.List.NonEmpty     ( NonEmpty(..), nonEmpty, toList )
 import Data.Maybe             ( fromMaybe )
 
 import qualified Data.Map.Strict as MapS
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 
 import Agda.Utils.Functor
 import Agda.Utils.Singleton

--- a/src/full/Agda/Utils/Favorites.hs
+++ b/src/full/Agda/Utils/Favorites.hs
@@ -1,7 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
-{-# LANGUAGE CPP                        #-}
-
 -- | Maintaining a list of favorites of some partially ordered type.
 --   Only the best elements are kept.
 --
@@ -15,9 +13,6 @@ module Agda.Utils.Favorites where
 
 import Prelude hiding ( null )
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 import qualified Data.List as List
 import qualified Data.Set as Set
 

--- a/src/full/Agda/Utils/Float.hs
+++ b/src/full/Agda/Utils/Float.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE CPP #-}
 
 -- | Logically consistent comparison of floating point numbers.
+
 module Agda.Utils.Float
   ( asFinite
   , isPosInf
@@ -55,25 +55,8 @@ import Data.Word        ( Word64 )
 
 import Agda.Utils.List  ( stripSuffix )
 
-#if __GLASGOW_HASKELL__ >= 804
 import GHC.Float (castDoubleToWord64, castWord64ToDouble)
-#else
-import System.IO.Unsafe (unsafePerformIO)
-import qualified Foreign          as F
-import qualified Foreign.Storable as F
-#endif
 
-#if __GLASGOW_HASKELL__ < 804
-castDoubleToWord64 :: Double -> Word64
-castDoubleToWord64 float = unsafePerformIO $ F.alloca $ \buf -> do
-  F.poke (F.castPtr buf) float
-  F.peek buf
-
-castWord64ToDouble :: Word64 -> Double
-castWord64ToDouble word = unsafePerformIO $ F.alloca $ \buf -> do
-  F.poke (F.castPtr buf) word
-  F.peek buf
-#endif
 
 {-# INLINE doubleEq #-}
 doubleEq :: Double -> Double -> Bool

--- a/src/full/Agda/Utils/Functor.hs
+++ b/src/full/Agda/Utils/Functor.hs
@@ -11,17 +11,13 @@ module Agda.Utils.Functor
   -- From Data.Functor:
   , (<$>)
   , ($>)
-  -- Defined identically as in Data.Functor.
-  -- Should be simply re-exported (vs redefined) once
-  -- MIN_VERSION_base >= 4.11.0.0
-  -- At time of this writing, we support 4.9.0.0.
   , (<&>)
   )
   where
 
 import Control.Applicative ( Const(Const), getConst )
 
-import Data.Functor (($>))
+import Data.Functor (($>), (<&>))
 import Data.Functor.Identity
 import Data.Functor.Compose
 
@@ -37,13 +33,6 @@ infixr 9 <.>
 for :: Functor m => m a -> (a -> b) -> m b
 for a b = fmap b a
 {-# INLINE for #-}
-
-infixl 1 <&>
-
--- | Infix version of 'for'.
-(<&>) :: Functor m => m a -> (a -> b) -> m b
-(<&>) a b = fmap b a
-{-# INLINE (<&>) #-}
 
 -- | A decoration is a functor that is traversable into any functor.
 --

--- a/src/full/Agda/Utils/IntSet/Infinite.hs
+++ b/src/full/Agda/Utils/IntSet/Infinite.hs
@@ -1,9 +1,9 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
-{-# LANGUAGE CPP #-}
 -- |  Possibly infinite sets of integers (but with finitely many consecutive
 --    segments). Used for checking guard coverage in int/nat cases in the
 --    treeless compiler.
+
 module Agda.Utils.IntSet.Infinite
   ( IntSet
   , empty, full, below, above, singleton
@@ -11,9 +11,6 @@ module Agda.Utils.IntSet.Infinite
   , invariant )
   where
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup hiding (All(..))
-#endif
 
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -170,4 +167,3 @@ invariant xs =
     invAbove hi (Some xs)    = all (< hi - 1) xs
     invAbove hi Above{}      = False
     invAbove hi (Below lo r) = lo < hi && invAbove hi r
-

--- a/src/full/Agda/Utils/ListT.hs
+++ b/src/full/Agda/Utils/ListT.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP  #-}
 {-# LANGUAGE UndecidableInstances  #-} -- Due MonadReader/MonadState fundep
 
 -- | @ListT@ done right,
@@ -16,10 +15,6 @@ import Control.Monad.Fail as Fail
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.IO.Class ( MonadIO(..) )
-
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup (Semigroup(..))
-#endif
 
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
@@ -123,10 +118,7 @@ instance Monad m => Semigroup (ListT m a) where
   l1 <> l2 = ListT $ foldListT (unmapListT . consListT) (runListT l2) l1
 
 instance Monad m => Monoid (ListT m a) where
-  mempty        = nilListT
-#if !(MIN_VERSION_base(4,11,0))
-  mappend = (<>)
-#endif
+  mempty = nilListT
 
 instance (Functor m, Applicative m, Monad m) => Alternative (ListT m) where
   empty = mempty

--- a/src/full/Agda/Utils/Map.hs
+++ b/src/full/Agda/Utils/Map.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 module Agda.Utils.Map where
 
 import Data.Functor.Compose
@@ -14,14 +12,9 @@ import Agda.Utils.Impossible
 
 -- | Update monadically the value at one position (must exist!).
 adjustM :: (Functor f, Ord k) => (v -> f v) -> k -> Map k v -> f (Map k v)
-#if MIN_VERSION_containers(0,5,8)
 adjustM f = Map.alterF $ \case
   Nothing -> __IMPOSSIBLE__
   Just v  -> Just <$> f v
-#else
-adjustM f k m =
-  f (Map.findWithDefault __IMPOSSIBLE__ k m) <&> \ v -> Map.insert k v m
-#endif
 
 -- | Wrapper for 'adjustM' for convenience.
 adjustM' :: (Functor f, Ord k) => (v -> f (a, v)) -> k -> Map k v -> f (a, Map k v)

--- a/src/full/Agda/Utils/Monoid.hs
+++ b/src/full/Agda/Utils/Monoid.hs
@@ -1,15 +1,8 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
-{-# LANGUAGE CPP  #-}
-
 -- | More monoids.
 
 module Agda.Utils.Monoid where
-
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup (Semigroup(..))
-#endif
-
 
 -- | Maximum of on-negative (small) natural numbers.
 
@@ -21,8 +14,5 @@ instance Semigroup MaxNat where
 
 instance Monoid MaxNat where
   mempty     = 0
-#if !(MIN_VERSION_base(4,11,0))
-  mappend    = (<>)
-#endif
   mconcat [] = 0
   mconcat ms = maximum ms

--- a/src/full/Agda/Utils/POMonoid.hs
+++ b/src/full/Agda/Utils/POMonoid.hs
@@ -1,13 +1,8 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
-{-# LANGUAGE CPP #-}
 -- | Partially ordered monoids.
 
 module Agda.Utils.POMonoid where
-
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 
 import Agda.Utils.PartialOrd
 

--- a/src/full/Agda/Utils/PartialOrd.hs
+++ b/src/full/Agda/Utils/PartialOrd.hs
@@ -1,13 +1,8 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
-{-# LANGUAGE CPP #-}
 module Agda.Utils.PartialOrd where
 
-
 import Data.Maybe
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 import Data.Set (Set)
 import qualified Data.Set as Set
 

--- a/test/Bugs/Issue4569/Setup.hs
+++ b/test/Bugs/Issue4569/Setup.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 import Data.Maybe
@@ -8,9 +7,8 @@ import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Setup
 import Distribution.Simple.BuildPaths (exeExtension)
 import Distribution.PackageDescription
-#if MIN_VERSION_Cabal(2,3,0)
 import Distribution.System ( buildPlatform )
-#endif
+
 import System.FilePath
 import System.Directory (makeAbsolute, removeFile)
 import System.Environment (getEnvironment)
@@ -51,8 +49,4 @@ buildHook' pd lbi hooks flags = do
     ExitFailure _ -> die $ "Error: failed to run hello from installer"
 
 helloExeExtension :: String
-#if MIN_VERSION_Cabal(2,3,0)
 helloExeExtension = exeExtension buildPlatform
-#else
-helloExeExtension = exeExtension
-#endif


### PR DESCRIPTION
- Remove `#if`s for GHC < 8.6
- Remove `#if`s for versions of dependencies we no longer support.
- More precise lower bound for `vector-hashtables`
