### PR TITLE
doc installation Fedora: fixup rst link markup

### DIFF
--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -292,8 +292,8 @@ Please report any bugs to Debian, using:
 Fedora / EPEL (Centos)
 ----------------------
 
-Agda is [packaged](https://src.fedoraproject.org/rpms/Agda) for Fedora Linux and EPEL.
-[Agda-stdlib](https://src.fedoraproject.org/rpms/Agda-stdlib/) is available for Fedora.
+Agda is `packaged <https://src.fedoraproject.org/rpms/Agda>`_ for Fedora Linux and EPEL.
+Agda-stdlib is `available <https://src.fedoraproject.org/rpms/Agda-stdlib/>`_ for Fedora.
 
 .. code-block:: bash
 


### PR DESCRIPTION
This should make the rst links in the [Fedora installation subsection](https://agda.readthedocs.io/en/latest/getting-started/installation.html#fedora-epel-centos) render correctly