### PR TITLE
Re #6746: bump CI to GHC 9.8.1; treat `cache-hit` as string

### DIFF
--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -24,15 +24,13 @@ jobs:
     env:
       FLAGS: -O0 -f enable-cluster-counting
     needs: auto-cancel
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - id: setup-haskell
-      uses: haskell-actions/setup@v2
-      with:
-        cabal-update: true
-        cabal-version: ${{ matrix.cabal-ver }}
-        ghc-version: ${{ matrix.ghc-ver }}
+    - name: Set up cabal
+      run: |
+        mkdir -p ~/.cabal
+        cabal update
     - name: Environment settings based on the Haskell setup
       run: |
         GHC_VER=$(ghc --numeric-version)
@@ -47,36 +45,27 @@ jobs:
         cabal build --dry-run
     - env:
         key: cabal-install.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER
-          }}-
+          }}
       id: cache
       name: Restore cached dependencies
       uses: actions/cache/restore@v3
       with:
         key: ${{ env.key }}-${{ hashFiles('**/plan.json') }}
         path: ~/.cabal/store
-        restore-keys: ${{ env.key }}
-    - if: ${{ !steps.cache.outputs.cache-hit }}
+        restore-keys: ${{ env.key }}-
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Install dependencies
       run: |
         cabal build --only-dependencies
     - name: Install Agda
       run: |
         cabal install ${FLAGS}
-    - if: always() && !steps.cache.outputs.cache-hit
+    - if: ${{ always() && (steps.cache.outputs.cache-hit != 'true') }}
       name: Save cache
       uses: actions/cache/save@v3
       with:
         key: ${{ steps.cache.outputs.cache-primary-key }}
         path: ~/.cabal/store
-    strategy:
-      fail-fast: false
-      matrix:
-        cabal-ver:
-        - 3.10.1.0
-        ghc-ver:
-        - 9.6.3
-        os:
-        - ubuntu-latest
     timeout-minutes: 60
 name: Install (v2-cabal)
 'on':

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -25,7 +25,7 @@ jobs:
       CABAL_VER: ${{ matrix.cabal-ver || '3.10' }}
       FLAGS: ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting'
         }}
-      GHC_VER: ${{ matrix.ghc-ver || '9.6.3' }}
+      GHC_VER: ${{ matrix.ghc-ver || '9.8.1' }}
     name: Cabal ${{ matrix.description }}, ${{ matrix.ghc-ver }}
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
@@ -87,7 +87,7 @@ jobs:
           ${{ steps.setup-haskell.outputs.cabal-store }}
         restore-keys: cabal.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{
           env.CABAL_VER }}-
-    - if: ${{ !steps.cache.outputs.cache-hit }}
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Install dependencies
       run: |
         cabal build --only-dependencies
@@ -110,6 +110,7 @@ jobs:
         doctest:
         - false
         ghc-ver:
+        - 9.8.1
         - 9.6.3
         - 9.4.7
         - 9.2.8
@@ -121,22 +122,22 @@ jobs:
         - cabal-flags: --disable-tests
           description: Linux doctest
           doctest: true
-          ghc-ver: 9.6.3
+          ghc-ver: 9.8.1
           os: ubuntu-22.04
         - cabal-flags: --enable-tests -f debug
           description: Linux debug
-          ghc-ver: 9.6.3
+          ghc-ver: 9.8.1
           os: ubuntu-22.04
         - cabal-flags: |
             --enable-tests -f enable-cluster-counting -f debug -c containers>=0.7 --allow-newer=containers
           description: Linux containers 0.7
-          ghc-ver: 9.6.3
+          ghc-ver: 9.8.1
           os: ubuntu-22.04
         - description: macOS
-          ghc-ver: 9.6.3
+          ghc-ver: 9.8.1
           os: macos-12
         - description: Windows
-          ghc-ver: 9.6.3
+          ghc-ver: 9.8.1
           os: windows-2022
         os:
         - ubuntu-22.04

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,7 @@ jobs:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
         restore-keys: deploy.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{
           env.CABAL_VER }}-
-    - if: ${{ !steps.cache.outputs.cache-hit }}
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Build dependencies
       run: cabal build exe:agda exe:agda-mode --only-dependencies
     - name: Build Agda
@@ -192,7 +192,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc-ver:
-        - '9.6'
+        - '9.8'
         include:
         - ghc-ver: '9.4'
           os: ubuntu-20.04

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -45,7 +45,7 @@ jobs:
           ${{ steps.setup-haskell.outputs.cabal-store }}
         restore-keys: |
           haddock.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-
-    - if: ${{ !steps.cache.outputs.cache-hit }}
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Install dependencies
       run: |
         cabal build --dependencies-only
@@ -70,7 +70,7 @@ jobs:
         cabal-ver:
         - '3.10'
         ghc-ver:
-        - 9.6.3
+        - 9.8.1
         os:
         - ubuntu-22.04
 name: Haddock

--- a/.github/workflows/stack-dry-run.yml
+++ b/.github/workflows/stack-dry-run.yml
@@ -72,6 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc-ver:
+        - 9.6.3
         - 9.4.7
         - 9.2.8
         - 9.0.2
@@ -91,6 +92,7 @@ name: Stack check snapshots
     - Agda.cabal
     - Setup.hs
     - stack-*.yaml
+    - '!stack-9.8.1.yaml'
     - src/size-solver/size-solver.cabal
   push:
     branches:
@@ -102,5 +104,6 @@ name: Stack check snapshots
     - Agda.cabal
     - Setup.hs
     - stack-*.yaml
+    - '!stack-9.8.1.yaml'
     - src/size-solver/size-solver.cabal
   workflow_dispatch: null

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@
 env:
   AGDA_TESTS_OPTIONS: -j${PARALLEL_TESTS} --hide-successes
   BUILD_DIR: dist
-  GHC_VER: 9.6.3
+  GHC_VER: 9.8.1
   PARALLEL_TESTS: 2
   STACK: stack --system-ghc
-  STACK_VER: 2.11.1
+  STACK_VER: 2.13.1
   TASTY_ANSI_TRICKS: 'false'
 jobs:
   build:

--- a/src/github/workflows/cabal-install.yml
+++ b/src/github/workflows/cabal-install.yml
@@ -40,17 +40,18 @@ jobs:
 
     timeout-minutes: 60
 
+    runs-on: ubuntu-latest
     ## Use preinstalled GHC and Cabal
     #
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        ghc-ver: ['9.6.3']
-        cabal-ver: ['3.10.1.0']
-        # Use the versions preinstalled in the virtual environment, if possible.
+    # runs-on: ${{ matrix.os }}
+    # strategy:
+    #   fail-fast: false
+    #   matrix:
+    #     os:
+    #       - ubuntu-latest
+    #     ghc-ver: ['9.8.1']
+    #     cabal-ver: ['3.10.1.0']
+    #     # Use the versions preinstalled in the virtual environment, if possible.
 
     env:
       FLAGS: "-O0 -f enable-cluster-counting"
@@ -58,23 +59,28 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # ## Disable the setup action: Use preinstalled GHC and Cabal.
-    # ##
-    # ## In case the ubuntu-22.04 environment moves GHC beyond
-    # ## what Agda supports, bring back the setup action.
-    #
+    ## Disable the setup action: Use preinstalled GHC and Cabal.
+    ##
+    ## In case the ubuntu-22.04 environment moves GHC beyond
+    ## what Agda supports, bring back the setup action.
+    # - uses: haskell-actions/setup@v2
+    #   id: setup-haskell
+    #   with:
+    #     ghc-version:   ${{ matrix.ghc-ver }}
+    #     cabal-version: ${{ matrix.cabal-ver }}
+    #     cabal-update:  true
+
     # 2023-08-21: skipping setup does no work out of the box
     # since then cabal uses the XDG directory structure.
     # In particular, the ~/.cabal/store is somewhere else.
-    # We also need to reset the cache then so cabal does not get
+    # A workaround is to create the .cabal directory.
+    # In case we switch to XDG we need to reset the cache then so cabal does not get
     # confused if there is both the restored .cabal/store and the XDG store.
-    #
-    - uses: haskell-actions/setup@v2
-      id: setup-haskell
-      with:
-        ghc-version:   ${{ matrix.ghc-ver }}
-        cabal-version: ${{ matrix.cabal-ver }}
-        cabal-update:  true
+
+    - name: Set up cabal
+      run: |
+        mkdir -p ~/.cabal
+        cabal update
 
     - name: Environment settings based on the Haskell setup
       run: |
@@ -90,23 +96,21 @@ jobs:
         cabal configure ${FLAGS}
         cabal build --dry-run
       # cabal build --dry-run creates dist-newstyle/cache/plan.json
-      # Keep a watch on this `cabal-3.9 build --dry-run` bug:
-      # https://github.com/haskell/cabal/issues/8706
 
     - name: Restore cached dependencies
       uses: actions/cache/restore@v3
       id: cache
       env:
-        key: cabal-install.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-
+        key: cabal-install.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}
       with:
         path: &cache_path ~/.cabal/store
         # ${{ steps.setup-haskell.outputs.cabal-store }}
         # The file `plan.json` contains the build information.
         key:          ${{ env.key }}-${{ hashFiles('**/plan.json') }}
-        restore-keys: ${{ env.key }}
+        restore-keys: ${{ env.key }}-
 
     - name: Install dependencies
-      if: ${{ !steps.cache.outputs.cache-hit }}
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: |
         cabal build --only-dependencies
 
@@ -116,7 +120,7 @@ jobs:
 
     - name: Save cache
       uses: actions/cache/save@v3
-      if:   always() && !steps.cache.outputs.cache-hit
+      if:   ${{ always() && (steps.cache.outputs.cache-hit != 'true') }}
             # save cache even when build fails
       with:
         key:  ${{ steps.cache.outputs.cache-primary-key }}

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         description: [Linux]      ## This just for pretty-printing the job name.
-        ghc-ver: [9.6.3, 9.4.7, 9.2.8, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
+        ghc-ver: [9.8.1, 9.6.3, 9.4.7, 9.2.8, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
         # Need to mention "cabal-ver" at least once in the matrix, otherwise matrix.cabal-ver is an actionlint error.
         cabal-ver: ['3.10']
         cabal-flags: ['--enable-tests -f enable-cluster-counting']
@@ -61,7 +61,7 @@ jobs:
           # Linux, without tests but with doctest
           - os: ubuntu-22.04
             description: Linux doctest
-            ghc-ver: '9.6.3'
+            ghc-ver: '9.8.1'
             # Can't leave cabal-flags empty here lest it becomes the default value.
             cabal-flags: '--disable-tests'
             doctest: true
@@ -69,13 +69,13 @@ jobs:
           # Linux, without -f enable-cluster-counting but with -f debug
           - os: ubuntu-22.04
             description: Linux debug
-            ghc-ver: '9.6.3'
+            ghc-ver: '9.8.1'
             cabal-flags: '--enable-tests -f debug'
 
           # Linux, with containers-0.7 and everything
           - os: ubuntu-22.04
             description: Linux containers 0.7
-            ghc-ver: '9.6.3'
+            ghc-ver: '9.8.1'
             ## Andreas, 2023-09-28: Test containers-0.7 here which has breaking changes.
             ## Note: -c 'containers >= 0.7' with single quotes does not get communicated properly.
             ## (The single quotes stay, and "-c 'containers" is an option parse error for cabal.)
@@ -85,16 +85,16 @@ jobs:
           # macOS with default flags
           - os: macos-12
             description: macOS
-            ghc-ver: '9.6.3'
+            ghc-ver: '9.8.1'
 
           # Windows with default flags
           - os: windows-2022
             description: Windows
-            ghc-ver: '9.6.3'
+            ghc-ver: '9.8.1'
 
     # Default values
     env:
-      GHC_VER:   ${{ matrix.ghc-ver || '9.6.3' }}
+      GHC_VER:   ${{ matrix.ghc-ver || '9.8.1' }}
       CABAL_VER: ${{ matrix.cabal-ver || '3.10' }}
       FLAGS:     ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting' }}
 
@@ -186,7 +186,7 @@ jobs:
       # So, strictly speaking, this step is superfluous anyways.
       # However, we keep it here so that we do not clutter the output of the
       # `cabal build` step too much in the ordinary case.
-      if:   ${{ !steps.cache.outputs.cache-hit }}
+      if:   ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: |
         cabal build --only-dependencies
 
@@ -200,7 +200,7 @@ jobs:
         make doc-test
 
     # - name: Clear old cache
-    #   if:   ${{ steps.cache.outputs.cache-hit }}
+    #   if:   ${{ steps.cache.outputs.cache-hit == 'true' }}
     #   env:
     #     KEY: ${{ steps.cache.outputs.cache-matched-key }}
     #     GH_TOKEN: ${{ github.token }}

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         # "most canonical", since this is the deploy action.
         # As of today, this is [windows-2022, macOS-11, ubuntu-20.04].
         os: [windows-latest, macos-latest]
-        ghc-ver: ['9.6']
+        ghc-ver: ['9.8']
         # Use default (= latest) cabal version
         # cabal-ver: ['3.10']
 
@@ -189,7 +189,7 @@ jobs:
         restore-keys: deploy.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-
 
     - name: Build dependencies
-      if: ${{ !steps.cache.outputs.cache-hit }}
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: cabal build exe:agda exe:agda-mode --only-dependencies
 
     - name: Build Agda

--- a/src/github/workflows/haddock.yml
+++ b/src/github/workflows/haddock.yml
@@ -25,7 +25,7 @@ jobs:
         # not for the virtual environments, and also haskell/action/setup
         # is usually not up-to-date.
         os: [ubuntu-22.04]
-        ghc-ver: ['9.6.3']
+        ghc-ver: ['9.8.1']
         cabal-ver: ['3.10']
           # Use the versions the come with the virtual environment, if possible.
 
@@ -83,7 +83,7 @@ jobs:
              haddock.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-
 
     - name: Install dependencies
-      if: ${{ !steps.cache.outputs.cache-hit }}
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: |
         cabal build --dependencies-only
       # cabal build --dependencies-only --force-reinstalls

--- a/src/github/workflows/stack-dry-run.yml
+++ b/src/github/workflows/stack-dry-run.yml
@@ -12,6 +12,7 @@ on:
     - 'Agda.cabal'
     - 'Setup.hs'
     - 'stack-*.yaml'
+    - '!stack-9.8.1.yaml'
     - 'src/size-solver/size-solver.cabal'
 
   pull_request:
@@ -45,8 +46,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         stack-ver: ['latest']
-        # Only LTS versions here:
-        ghc-ver: [9.4.7, 9.2.8, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
+        # Note: when adding a version here, check that it is not excluded in the triggers above.
+        ghc-ver: [9.6.3, 9.4.7, 9.2.8, 9.0.2, 8.10.7, 8.8.4, 8.6.5]
           # Andreas, 2022-03-26:
           # Note: ghc-ver needs to be spelled out with minor version, i.e., x.y.z
           # rather than x.y (which haskell-setup would resolve to a suitable .z)

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -195,7 +195,7 @@ jobs:
           # .stack-work-fast
 
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
-      # if: ${{ !steps.cache.outputs.cache-hit }}
+      # if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies
 
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests` (i.e. the test suite).
@@ -207,7 +207,7 @@ jobs:
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS}
 
     # - name: Clear cache
-    #   if:   ${{ steps.cache.outputs.cache-hit }}
+    #   if:   ${{ steps.cache.outputs.cache-hit == 'true' }}
     #   env:
     #     KEY: ${{ steps.cache.outputs.cache-matched-key }}
     #     GH_TOKEN: ${{ github.token }}

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -53,11 +53,11 @@ env:
 
   # Andreas, 2022-11-24, set the stack version here so that it is easily
   # shared between the jobs.
-  STACK_VER: "2.11.1"
+  STACK_VER: "2.13.1"
   # Andreas, 2022-03-26, 2022-11-28:
   # GHC_VER should be given as x.y.z (as opposed to x.y only)
   # because it is used verbatim when referring to stack-x.y.z.yaml.
-  GHC_VER: "9.6.3"
+  GHC_VER: "9.8.1"
 
   # Part 2: Variables that should not have to be changed
   ###########################################################################
@@ -152,7 +152,7 @@ jobs:
 
     - name: "Install dependencies for Agda and its test suites"
       ## Always do this step, even if we got a cache hit.  Should be fast in case we got a hit.
-      # if: ${{ !steps.cache.outputs.cache-hit }}
+      # if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: make install-deps
       ## This used to be: make STACK_OPTS=--silent install-deps
       ## but printing stuff might not hurt here.
@@ -190,7 +190,7 @@ jobs:
           stack-work.tzst
 
     # - name: Clear old cache
-    #   if:   ${{ steps.cache.outputs.cache-hit }}
+    #   if:   ${{ steps.cache.outputs.cache-hit == 'true' }}
     #   env:
     #     KEY: ${{ steps.cache.outputs.cache-matched-key }}
     #     GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- Bump workflows except stack workflows (done already) to 9.8.1.

- `!steps.cache.output.cache-hit` does not do the expected thing:
  https://github.com/actions/cache/issues/1262
  Thus, use `!= 'true'` instead.

- Let the workflow `cabal-install.yml` use the preinstalled GHC and Cabal.

Closes #6746.

Complements:
- #6923 

Cool: `cabal-install.yml` can now finish in 1min if the whole `Agda` library can be reused unchanged: https://github.com/agda/agda/actions/runs/6552198134/job/17795001365