### PR TITLE
Re #6746: bump tested-with etc to GHC 9.8.1; bump deps in tools

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -35,6 +35,7 @@ description:
     packages.
 
 tested-with:
+    GHC == 9.8.1
     GHC == 9.6.3
     GHC == 9.4.7
     GHC == 9.2.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Highlights
 Installation
 ------------
 
-* Agda supports GHC versions 8.6.5 to 9.6.3.
+* Agda supports GHC versions 8.6.5 to 9.8.1.
 
 * Verbose output printing via `-v` or `--verbose` is now only active if Agda is built with the `debug` cabal flag.
   Without `debug`, no code is generated for verbose printing, which makes building Agda faster and Agda itself

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -38,7 +38,7 @@ You need recent versions of the following programs to compile Agda:
 * GHC:           https://www.haskell.org/ghc/
 
   + Agda has been tested with GHC 8.6.5, 8.8.4,
-    8.10.7, 9.0.2, 9.2.8, 9.4.7 and 9.6.3.
+    8.10.7, 9.0.2, 9.2.8, 9.4.7, 9.6.3, and 9.8.1.
 
 * cabal-install: https://www.haskell.org/cabal/
 * Alex:          https://www.haskell.org/alex/

--- a/src/agda-bisect/agda-bisect.cabal
+++ b/src/agda-bisect/agda-bisect.cabal
@@ -5,28 +5,29 @@ cabal-version: >= 1.10
 author: Nils Anders Danielsson
 build-type: Simple
 tested-with:
-  GHC == 8.0.2
-  GHC == 8.2.2
-  GHC == 8.4.4
-  GHC == 8.6.5
-  GHC == 8.8.4
-  GHC == 8.10.7
+  GHC == 9.8.1
+  GHC == 9.6.3
+  GHC == 9.4.7
+  GHC == 9.2.8
   GHC == 9.0.2
-  GHC == 9.2.5
-  GHC == 9.4.4
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
 
 executable agda-bisect
   main-is:          Bisect.hs
   build-depends:
-      base                 >= 4.9.0.0 && < 4.18
-    , ansi-wl-pprint       >= 0.6.7.3 && < 0.7
+      base                 >= 4.9.0.0 && < 4.20
+    , ansi-wl-pprint       >= 0.6.7.3 && < 1.1
     , directory            >= 1.2.6.2 && < 1.4
     , filepath             >= 1.4.1.0 && < 1.5
-    , optparse-applicative >= 0.13    && < 0.18
+    , optparse-applicative >= 0.13    && < 0.19
     , process              >= 1.4.2.0 && < 1.7
     , time                 >= 1.6.0.1 && < 1.13
-    , unix                 >= 2.7.2.0 && < 2.8
-        -- TODO: unix < 2.9 (not yet supported by process as of 2022-08-19)
+    , unix                 >= 2.7.2.0 && < 2.9
   default-language: Haskell2010
   other-extensions: NamedFieldPuns
   ghc-options:      -threaded

--- a/src/agda-bisect/cabal.project
+++ b/src/agda-bisect/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/src/release-tools/closed-issues-for-milestone/closed-issues-for-milestone.cabal
+++ b/src/release-tools/closed-issues-for-milestone/closed-issues-for-milestone.cabal
@@ -12,8 +12,9 @@ build-type:          Simple
 cabal-version:       >= 1.10
 
 tested-with:
-  GHC == 9.6.2
-  GHC == 9.4.5
+  GHC == 9.8.1
+  GHC == 9.6.3
+  GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
@@ -23,10 +24,10 @@ executable closed-issues-for-milestone
   main-is:          Main.hs
   default-language: Haskell2010
 
-  build-depends:  base       >= 4.13.0.0  && < 4.19
-                , bytestring >= 0.10.9.0  && < 0.12
+  build-depends:  base       >= 4.13.0.0  && < 4.20
+                , bytestring >= 0.10.9.0  && < 0.13
                 , github     >= 0.29      && < 0.30
-                , text       >= 1.2.3     && < 2.1
+                , text       >= 1.2.3     && < 2.2
                 , vector     >= 0.12.0.3  && < 0.14
 
   ghc-options:

--- a/src/size-solver/size-solver.cabal
+++ b/src/size-solver/size-solver.cabal
@@ -13,7 +13,8 @@ synopsis:        A solver for size constraints arising in sized types.
 description:
   See Felix Reihl, 2013, Bachelor thesis, Ludwig-Maximilians-University.
 tested-with:
-  GHC == 9.6.2
+  GHC == 9.8.1
+  GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
@@ -31,7 +32,7 @@ executable size-solver
   build-depends:
     Agda == 2.6.5
     , base       >= 4.12.0.0 && < 5
-    , containers >= 0.5.7.1  && < 0.7
+    , containers >= 0.5.7.1  && < 0.8
     , mtl        >= 2.2.1    && < 2.4
     , parsec     >= 3.1      && < 3.2
   other-modules:


### PR DESCRIPTION
Bumps in:
- Agda.cabal (only `tested-with`)
- agda-bisect
- cifm
- size-solver

Closes #6746.

Follow up to:
- #6924
