### PR TITLE
[ fix #5315 ] Remove erased and irrelevant arguments completely in GHC backend

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -480,6 +480,7 @@ library
       Agda.Compiler.Treeless.AsPatterns
       Agda.Compiler.Treeless.Builtin
       Agda.Compiler.Treeless.Compare
+      Agda.Compiler.Treeless.DropArgs
       Agda.Compiler.Treeless.EliminateDefaults
       Agda.Compiler.Treeless.EliminateLiteralPatterns
       Agda.Compiler.Treeless.Erase

--- a/src/data/lib/prim/Agda/Builtin/Size.agda
+++ b/src/data/lib/prim/Agda/Builtin/Size.agda
@@ -10,12 +10,8 @@ module Agda.Builtin.Size where
 {-# BUILTIN SIZEINF  ∞        #-}
 {-# BUILTIN SIZEMAX  _⊔ˢ_     #-}
 
-{-# FOREIGN GHC
-  type SizeLT i = ()
-  #-}
-
 {-# COMPILE GHC Size   = type ()     #-}
-{-# COMPILE GHC Size<_ = type SizeLT #-}
+{-# COMPILE GHC Size<_ = type ()     #-}
 {-# COMPILE GHC ↑_     = \_ -> ()    #-}
 {-# COMPILE GHC ∞      = ()          #-}
 {-# COMPILE GHC _⊔ˢ_   = \_ _ -> ()  #-}

--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -596,7 +596,7 @@ compileTerm kit t = go t
       T.TPrim p -> return $ compilePrim p
       T.TUnit -> unit
       T.TSort -> unit
-      T.TErased -> unit
+      T.TErased{} -> unit
       T.TError T.TUnreachable -> return Undefined
       T.TError T.TMeta{}      -> return Undefined
       T.TCoerce t -> go t
@@ -657,7 +657,7 @@ compileAlt kit = \case
 eraseLocalVars :: [Bool] -> T.TTerm -> T.TTerm
 eraseLocalVars [] x = x
 eraseLocalVars (False: es) x = eraseLocalVars es x
-eraseLocalVars (True: es) x = eraseLocalVars es (TC.subst (length es) T.TErased x)
+eraseLocalVars (True: es) x = eraseLocalVars es (TC.subst (length es) (T.TErased T.ErasedInferred) x)
 
 visitorName :: QName -> TCM MemberId
 visitorName q = do (m,ls) <- global q; return (List1.last ls)

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -854,7 +854,7 @@ definition def@Defn{defName = q, defType = ty, theDef = d} = do
             in [tydecl f ts' t, funbind f ps b]
 
       -- The definition of the non-stripped function
-      (ps0, _) <- lamView <$> closedTerm_ (foldr ($) T.TErased $ replicate (length used) T.TLam)
+      (ps0, _) <- lamView <$> closedTerm_ (foldr ($) (T.TErased T.ErasedInferred) $ replicate (length used) T.TLam)
       let b0 = foldl HS.App (hsVarUQ $ duname q) [ hsVarUQ x | (~(HS.PVar x), ArgUsed) <- zip ps0 used ]
           ps0' = zipWith (\p u -> case u of
                                     ArgUsed   -> p
@@ -1060,7 +1060,7 @@ noApplication = \case
   T.TPrim p   -> return $ compilePrim p
   T.TUnit     -> return $ HS.unit_con
   T.TSort     -> return $ HS.unit_con
-  T.TErased   -> return $ hsVarUQ $ HS.Ident mazErasedName
+  T.TErased{} -> return $ hsVarUQ $ HS.Ident mazErasedName
   T.TError e  -> return $ case e of
     T.TUnreachable -> rtmUnreachableError
     T.TMeta s      -> rtmHole s

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -300,5 +300,5 @@ hsTelApproximation = hsTelApproximation' NoPolyApprox
 hsTelApproximation' :: PolyApprox -> Type -> HsCompileM ([HS.Type], HS.Type)
 hsTelApproximation' poly t = do
   TelV tel res <- telViewPath t
-  let args = map (snd . unDom) (telToList tel)
+  let args = map (snd . unDom) $ filter usableModality $ telToList tel
   (,) <$> zipWithM (hsTypeApproximation poly) [0..] args <*> hsTypeApproximation poly (length args) res

--- a/src/full/Agda/Compiler/Treeless/AsPatterns.hs
+++ b/src/full/Agda/Compiler/Treeless/AsPatterns.hs
@@ -49,7 +49,7 @@ recover t =
       f  <- recover f
       vs <- mapM recover vs
       tApp f vs
-    TLam b -> TLam <$> underBinds 1 (recover b)
+    TLam i b -> TLam i <$> underBinds 1 (recover b)
     TCon{} -> tApp t []   -- need to recover nullary constructors as well (to make deep @-patterns work)
     TLet v b -> TLet <$> recover v <*> underBinds 1 (recover b)
     TCase x ct d bs -> TCase x ct <$> recover d <*> mapM (recoverAlt x) bs

--- a/src/full/Agda/Compiler/Treeless/Builtin.hs
+++ b/src/full/Agda/Compiler/Treeless/Builtin.hs
@@ -79,9 +79,9 @@ transform BuiltinKit{..} = tr
     tr = \case
 
       TCon c | isZero c   -> tInt 0
-             | isSuc c    -> TLam (tPlusK 1 (TVar 0))
-             | isPos c    -> TLam (TVar 0)
-             | isNegSuc c -> TLam $ tNegPlusK 1 (TVar 0)
+             | isSuc c    -> TLam Nothing (tPlusK 1 (TVar 0))
+             | isPos c    -> TLam Nothing (TVar 0)
+             | isNegSuc c -> TLam Nothing $ tNegPlusK 1 (TVar 0)
 
       TDef f | isPlus f   -> TPrim PAdd
              | isTimes f  -> TPrim PMul
@@ -171,7 +171,7 @@ transform BuiltinKit{..} = tr
 
       TCoerce a -> TCoerce (tr a)
 
-      TLam b                  -> TLam (tr b)
+      TLam i b                -> TLam i (tr b)
       TApp a bs               -> TApp (tr a) (map tr bs)
       TLet e b                -> TLet (tr e) (tr b)
 

--- a/src/full/Agda/Compiler/Treeless/Compare.hs
+++ b/src/full/Agda/Compiler/Treeless/Compare.hs
@@ -18,7 +18,7 @@ equalTerms u v =
     (u, v) | u == v                  -> True
     (TApp f us, TApp g vs)           -> eqList equalTerms (f : us) (g : vs)
     (TCase x _ d as, TCase y _ e bs) -> x == y && equalTerms d e && eqList equalAlts as bs
-    (TLam u, TLam v)                 -> equalTerms u v
+    (TLam i u, TLam j v)             -> i == j && equalTerms u v
     _                                -> False
 
 equalAlts :: TAlt -> TAlt -> Bool

--- a/src/full/Agda/Compiler/Treeless/DropArgs.hs
+++ b/src/full/Agda/Compiler/Treeless/DropArgs.hs
@@ -1,0 +1,22 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+
+module Agda.Compiler.Treeless.DropArgs ( dropArgs ) where
+
+import Agda.Syntax.Treeless
+import Agda.TypeChecking.Monad as I
+
+dropArgs :: TTerm -> TCM TTerm
+dropArgs t = return $ go t
+  where
+    isErasedAnnotated :: TTerm -> Bool
+    isErasedAnnotated (TErased ErasedAnnotated) = True
+    isErasedAnnotated _ = False
+
+    go :: TTerm -> TTerm
+    go t = case tAppView t of
+      (h , vs) -> tApp h $ map go $ filter (not . isErasedAnnotated) vs
+
+    tApp f []                  = f
+    tApp (TErased i) _         = TErased i
+    tApp f _ | isUnreachable f = tUnreachable
+    tApp f es                  = mkTApp f es

--- a/src/full/Agda/Compiler/Treeless/EliminateDefaults.hs
+++ b/src/full/Agda/Compiler/Treeless/EliminateDefaults.hs
@@ -44,7 +44,7 @@ eliminateCaseDefaults = tr
       t@TError{}  -> return t
 
       TCoerce a               -> TCoerce <$> tr a
-      TLam b                  -> TLam <$> tr b
+      TLam i b                -> TLam i <$> tr b
       TApp a bs               -> TApp <$> tr a <*> mapM tr bs
       TLet e b                -> TLet <$> tr e <*> tr b
 

--- a/src/full/Agda/Compiler/Treeless/GuardsToPrims.hs
+++ b/src/full/Agda/Compiler/Treeless/GuardsToPrims.hs
@@ -45,7 +45,7 @@ convertGuards = tr
       t@TError{}  -> t
 
       TCoerce a               -> TCoerce (tr a)
-      TLam b                  -> TLam (tr b)
+      TLam i b                -> TLam i (tr b)
       TApp a bs               -> TApp (tr a) (map tr bs)
       TLet e b                -> TLet (tr e) (tr b)
 

--- a/src/full/Agda/Compiler/Treeless/Identity.hs
+++ b/src/full/Agda/Compiler/Treeless/Identity.hs
@@ -55,7 +55,7 @@ recursiveIdentity q t =
 
         proj x args = indexWithDefault __IMPOSSIBLE__ (reverse args) x
 
-        match TErased              _  = True
+        match (TErased _)          _ = True
         match (TVar z)             y = z == y
         match (TApp (TDef f) args) y = f == q && length args == n && match (proj x args) y
         match _                    _ = False

--- a/src/full/Agda/Compiler/Treeless/Pretty.hs
+++ b/src/full/Agda/Compiler/Treeless/Pretty.hs
@@ -192,6 +192,6 @@ pTerm = \case
 
   TUnit -> pure "()"
   TSort -> pure "Set"
-  TErased -> pure "_"
+  TErased _ -> pure "_"
   TError err -> paren 9 $ pure $ "error" <+> text (show (show err))
   TCoerce t -> paren 9 $ ("coe" <+>) <$> pTerm' 10 t

--- a/src/full/Agda/Compiler/Treeless/Simplify.hs
+++ b/src/full/Agda/Compiler/Treeless/Simplify.hs
@@ -104,7 +104,7 @@ simplify FunctionKit{..} = simpl
         f  <- simpl f
         es <- traverse simpl es
         maybeMinusToPrim f es
-      TLam b    -> TLam <$> underLam (simpl b)
+      TLam i b  -> TLam i <$> underLam (simpl b)
       t@TLit{}  -> pure t
       t@TCon{}  -> pure t
       TLet e b  -> do
@@ -148,7 +148,7 @@ simplify FunctionKit{..} = simpl
 
       t@TUnit    -> pure t
       t@TSort    -> pure t
-      t@TErased  -> pure t
+      t@TErased{}-> pure t
       t@TError{} -> pure t
 
     conView (TCon c)    = Just (c, [])
@@ -415,8 +415,8 @@ simplify FunctionKit{..} = simpl
         TLam{} -> tApp v es   -- could blow up the code
         _      -> pure $ mkTApp (TVar x) es
     tApp f [] = pure f
-    tApp (TLam b) (TVar i : es) = tApp (subst 0 (TVar i) b) es
-    tApp (TLam b) (e : es) = tApp (TLet e b) es
+    tApp (TLam li b) (TVar i : es) = tApp (subst 0 (TVar i) b) es
+    tApp (TLam li b) (e : es) = tApp (TLet e b) es
     tApp f es = pure $ TApp f es
 
     tAppAlt (TACon c a b) es = TACon c a <$> underLams a (tApp b (raise a es))

--- a/src/full/Agda/Compiler/Treeless/Subst.hs
+++ b/src/full/Agda/Compiler/Treeless/Subst.hs
@@ -32,7 +32,7 @@ instance Subst TTerm where
       t@TError{}  -> t
       TVar i         -> lookupS rho i
       TApp f ts      -> tApp (applySubst rho f) (applySubst rho ts)
-      TLam b         -> TLam (applySubst (liftS 1 rho) b)
+      TLam i b       -> TLam i (applySubst (liftS 1 rho) b)
       TLet e b       -> TLet (applySubst rho e) (applySubst (liftS 1 rho) b)
       TCase i t d bs ->
         case applySubst rho (TVar i) of
@@ -41,7 +41,7 @@ instance Subst TTerm where
             where rho' = wkS 1 rho
       TCoerce e -> TCoerce (applySubst rho e)
     where
-      tApp (TPrim PSeq) [TErased, b] = b
+      tApp (TPrim PSeq) [TErased _, b] = b
       tApp f ts = TApp f ts
 
 instance Subst TAlt where
@@ -122,7 +122,7 @@ instance HasFree TTerm where
     TVar i         -> freeVars i
     TApp (TPrim PSeq) [TVar x, b] -> freeVars (InSeq x, b)
     TApp f ts      -> freeVars (f, ts)
-    TLam b         -> underLambda <$> freeVars (Binder 1 b)
+    TLam i b       -> underLambda <$> freeVars (Binder 1 b)
     TLet e b       -> freeVars (e, Binder 1 b)
     TCase i _ d bs -> freeVars (i, (d, bs))
     TCoerce t      -> freeVars t

--- a/src/full/Agda/Compiler/Treeless/Uncase.hs
+++ b/src/full/Agda/Compiler/Treeless/Uncase.hs
@@ -20,7 +20,7 @@ uncase t = case t of
   TPrim{}   -> t
   TDef{}    -> t
   TApp f es -> tApp (uncase f) (map uncase es)
-  TLam b    -> TLam $ uncase b
+  TLam i b  -> TLam i $ uncase b
   TLit{}    -> t
   TCon{}    -> t
   TLet e b  -> tLet (uncase e) (uncase b)
@@ -55,7 +55,7 @@ uncase t = case t of
     equalTo x t (TACon c a b)
       | Just b' <- tryStrengthen a b = equalTerms (subst x v t) (subst x v b')
       | otherwise                    = False
-      where v = mkTApp (TCon c) (replicate a TErased)
+      where v = mkTApp (TCon c) (replicate a (TErased ErasedInferred))
     equalTo x t (TALit l b)   = equalTerms (subst x (TLit l) t) (subst x (TLit l) b)
     equalTo x t (TAGuard _ b) = equalTerms t b
 

--- a/src/full/Agda/Compiler/Treeless/Unused.hs
+++ b/src/full/Agda/Compiler/Treeless/Unused.hs
@@ -63,7 +63,7 @@ computeUnused q t = iterateUntilM (==) $ \ used -> do
         Set.unions <$> sequence [ go t | (t, ArgUsed) <- zip ts $ used ++ repeat ArgUsed ]
 
       TApp f ts -> Set.unions <$> mapM go (f : ts)
-      TLam b    -> underBinder <$> go b
+      TLam i b  -> underBinder <$> go b
       TLet e b  -> do
         uses <- go b
         if | Set.member 0 uses -> Set.union (underBinder uses) <$> go e
@@ -99,6 +99,6 @@ stripUnusedArguments used t = mkTLam m $ applySubst rho b
     m      = length $ filter (== ArgUsed) used'
     used'  = reverse $ take n $ used ++ repeat ArgUsed
     rho = computeSubst used'
-    computeSubst (ArgUnused : bs) = TErased :# computeSubst bs
+    computeSubst (ArgUnused : bs) = TErased ErasedInferred :# computeSubst bs
     computeSubst (ArgUsed   : bs) = liftS 1 $ computeSubst bs
     computeSubst []               = idS

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -334,14 +334,14 @@ instance NamesIn TTerm where
     TPrim _        -> mempty
     TDef x         -> namesAndMetasIn' sg x
     TApp t xs      -> namesAndMetasIn' sg (t, xs)
-    TLam t         -> namesAndMetasIn' sg t
+    TLam _ t       -> namesAndMetasIn' sg t
     TLit l         -> namesAndMetasIn' sg l
     TCon x         -> namesAndMetasIn' sg x
     TLet t1 t2     -> namesAndMetasIn' sg (t1, t2)
     TCase _ c t ts -> namesAndMetasIn' sg (c, t, ts)
     TUnit          -> mempty
     TSort          -> mempty
-    TErased        -> mempty
+    TErased _      -> mempty
     TCoerce t      -> namesAndMetasIn' sg t
     TError _       -> mempty
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1777,7 +1777,7 @@ type Definitions = HashMap QName Definition
 type RewriteRuleMap = HashMap QName RewriteRules
 type DisplayForms = HashMap QName [LocalDisplayForm]
 
-{-# SPECIALIZE HMap.insert :: QName -> v -> HashMap QName v -> HashMap QName v #-}
+--{-# SPECIALIZE HMap.insert :: QName -> v -> HashMap QName v -> HashMap QName v #-}
 {-# SPECIALIZE HMap.lookup :: QName -> HashMap QName v -> Maybe v #-}
 
 newtype Section = Section { _secTelescope :: Telescope }

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -685,13 +685,6 @@ instance PiApplyM a => PiApplyM [a] where
   piApplyM' err t = foldl (\ mt v -> mt >>= \t -> (piApplyM' err t v)) (return t)
 
 
--- | Compute type arity
-
-typeArity :: Type -> TCM Nat
-typeArity t = do
-  TelV tel _ <- telView t
-  return (size tel)
-
 ---------------------------------------------------------------------------
 -- * Instance definitions
 ---------------------------------------------------------------------------

--- a/test/Compiler/simple/Issue5315.agda
+++ b/test/Compiler/simple/Issue5315.agda
@@ -19,5 +19,10 @@ data Foo : Set where
 {-# FOREIGN GHC data Foo = Foo #-}
 {-# COMPILE GHC Foo = data Foo (Foo) #-}
 
+f : (@0 Bar → Foo) → Bar → Foo
+f g x = g x
+
+test = f foo bar
+
 main : IO ⊤
 main = return _

--- a/test/Compiler/simple/Issue5315.agda
+++ b/test/Compiler/simple/Issue5315.agda
@@ -1,0 +1,23 @@
+{-# OPTIONS --erasure #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Unit
+open import Common.IO
+
+data D : @0 Nat → Set where
+  c : ∀ {@0 n} → D (n + n)
+
+{-# FOREIGN GHC data D = C #-}
+{-# COMPILE GHC D = data D (C) #-}
+
+data Bar : Set where
+  bar : Bar
+
+data Foo : Set where
+  foo : @0 Bar → Foo
+
+{-# FOREIGN GHC data Foo = Foo #-}
+{-# COMPILE GHC Foo = data Foo (Foo) #-}
+
+main : IO ⊤
+main = return _

--- a/test/Compiler/simple/Issue5315.out
+++ b/test/Compiler/simple/Issue5315.out
@@ -1,0 +1,3 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess


### PR DESCRIPTION
As noted in the title, this removes arguments annotated with `@0` (and `.`) completely when compiling with MAlonzo, instead of replacing them by dummy values. One could argue whether this should also be enabled for the strict GHC backend, but I think that if the user asked explicitly for the argument to be erased then it is not unreasonable to actually erase it.