### PR TITLE
Fix #6931: dead code: include module telescopes in reachability analysis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,10 +63,6 @@ jobs:
       run: make install-deps
     - name: Build Agda
       run: make BUILD_DIR="${BUILD_DIR}" install-bin-debug
-    - name: Run tests for the size solver
-      run: |
-        export PATH=${HOME}/.local/bin:${PATH}
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
     - name: Pack artifacts
       run: |
         strip ${BUILD_DIR}/build/agda-tests/agda-tests \

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -205,7 +205,7 @@ mnameToQName :: ModuleName -> QName
 mnameToQName = qnameFromList . mnameToList1
 
 showQNameId :: QName -> String
-showQNameId q = show ns ++ "@" ++ show (List1.head ms)
+showQNameId q = show (List1.toList ns) ++ "@" ++ show (List1.head ms)
   where
     (ns, ms) = List1.unzip $ fmap (unNameId . nameId) $ List1.snoc (mnameToList $ qnameModule q) (qnameName q)
     unNameId (NameId n m) = (n, m)

--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -17,6 +17,7 @@ import Agda.Interaction.Options
 import qualified Agda.Syntax.Abstract as A
 
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Names
 import Agda.Syntax.Scope.Base

--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -95,6 +95,9 @@ eliminateDeadCode bs disp sig ms = Bench.billTo [Bench.DeadCode] $ do
     "Removed " ++ show (HMap.size defs - HMap.size defs') ++
     " unused definitions and " ++ show (MapS.size ms - HMap.size ms') ++
     " unused meta-variables."
+  reportSLn "tc.dead" 90 $ unlines $
+    "Removed the following definitions from the signature:" :
+    map (("- " ++) . prettyShow) (Set.toList dead)
   let !sig' = set sigDefinitions defs' sig
   return (disp', sig', ms')
 

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -153,7 +153,7 @@ checkDecl d = setCurrentRange d $ do
       A.Primitive i x e        -> meta $ checkPrimitive i x e
       A.Mutual i ds            -> mutual i ds $ checkMutual i ds
       A.Section _r er x tel ds -> meta $ checkSection er x tel ds
-      A.Apply i e x mapp ci d  -> meta $ checkSectionApplication i e x mapp ci d
+      A.Apply i er x mapp ci d -> meta $ checkSectionApplication i er x mapp ci d
       A.Import _ _ dir         -> none $ checkImportDirective dir
       A.Pragma i p             -> none $ checkPragma i p
       A.ScopedDecl scope ds    -> none $ setScope scope >> mapM_ checkDeclCached ds
@@ -912,14 +912,14 @@ checkSectionApplication
   -> A.ScopeCopyInfo     -- ^ Imported names and modules
   -> A.ImportDirective
   -> TCM ()
-checkSectionApplication i e m1 modapp copyInfo dir =
-  traceCall (CheckSectionApplication (getRange i) e m1 modapp) $ do
+checkSectionApplication i er m1 modapp copyInfo dir =
+  traceCall (CheckSectionApplication (getRange i) er m1 modapp) $ do
   checkImportDirective dir
   -- A (non-erased) section application is type-checked in a
   -- non-erased context (#5410), except if hard compile-time mode is
   -- enabled (#4743).
   setRunTimeModeUnlessInHardCompileTimeMode $
-    checkSectionApplication' i e m1 modapp copyInfo
+    checkSectionApplication' i er m1 modapp copyInfo
 
 -- | Check an application of a section. (Do not invoke this procedure
 -- directly, use 'checkSectionApplication'.)
@@ -931,11 +931,11 @@ checkSectionApplication'
   -> A.ScopeCopyInfo     -- ^ Imported names and modules
   -> TCM ()
 checkSectionApplication'
-  i e m1 (A.SectionApp ptel m2 args) copyInfo = do
+  i er m1 (A.SectionApp ptel m2 args) copyInfo = do
   -- If the section application is erased, then hard compile-time mode
   -- is entered.
-  warnForPlentyInHardCompileTimeMode e
-  setHardCompileTimeModeIfErased e $ do
+  warnForPlentyInHardCompileTimeMode er
+  setHardCompileTimeModeIfErased er $ do
   -- Module applications can appear in lets, in which case we treat
   -- lambda-bound variables as additional parameters to the module.
   extraParams <- do

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -967,15 +967,21 @@ checkSectionApplication'
     etaTel <- checkModuleArity m2 tel' args
     -- Take the module parameters that will be instantiated by @args@.
     let tel'' = telFromList $ take (size tel' - size etaTel) $ telToList tel'
-    reportSDoc "tc.mod.apply" 15 $ vcat
-      [ "applying section" <+> prettyTCM m2
-      , nest 2 $ "args =" <+> sep (map prettyA args)
-      , nest 2 $ "ptel =" <+> escapeContext impossible (size ptel) (prettyTCM ptel)
-      , nest 2 $ "tel  =" <+> prettyTCM tel
-      , nest 2 $ "tel' =" <+> prettyTCM tel'
-      , nest 2 $ "tel''=" <+> prettyTCM tel''
-      , nest 2 $ "eta  =" <+> escapeContext impossible (size ptel) (addContext tel'' $ prettyTCM etaTel)
-      ]
+    reportSDoc "tc.mod.apply" 15 $
+        "applying section" <+> prettyTCM m2
+    reportSDoc "tc.mod.apply" 15 $
+        nest 2 $ "args =" <+> sep (map prettyA args)
+    reportSDoc "tc.mod.apply" 15 $
+        nest 2 $ "ptel =" <+> escapeContext impossible (size ptel) (prettyTCM ptel)
+    reportSDoc "tc.mod.apply" 15 $
+        nest 2 $ "tel  =" <+> prettyTCM tel
+    reportSDoc "tc.mod.apply" 15 $
+        nest 2 $ "tel' =" <+> prettyTCM tel'
+    reportSDoc "tc.mod.apply" 15 $
+        nest 2 $ "tel''=" <+> prettyTCM tel''
+    reportSDoc "tc.mod.apply" 15 $
+        nest 2 $ "eta  =" <+> escapeContext impossible (size ptel) (addContext tel'' $ prettyTCM etaTel)
+
     -- Now, type check arguments.
     ts <- noConstraints (checkArguments_ CmpEq DontExpandLast (getRange i) args tel') >>= \case
       (ts', etaTel') | (size etaTel == size etaTel')

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20230930 * 10 + 0
+currentInterfaceVersion = 20231019 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -160,10 +160,13 @@ jobs:
     - name: "Build Agda"
       run: make BUILD_DIR="${BUILD_DIR}" install-bin-debug
 
-    - name: "Run tests for the size solver"
-      run: |
-        export PATH=${HOME}/.local/bin:${PATH}
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
+    # Andreas, 2023-10-19: currently building the size-solver triggers a rebuild of Agda,
+    # likely because the cabal flags (`-f`) passed to `cabal build` have changed.
+    # So, deactivate this for now.
+    # - name: "Run tests for the size solver"
+    #   run: |
+    #     export PATH=${HOME}/.local/bin:${PATH}
+    #     make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
 
     - name: "Pack artifacts"
       # This step should go into the Makefile.

--- a/test/Succeed/Issue6931.agda
+++ b/test/Succeed/Issue6931.agda
@@ -1,0 +1,12 @@
+-- Andreas, Oskar, issue #6931:
+-- Dead code analysis should not prune telescopes of empty modules.
+
+module _ where
+
+postulate A : Set
+
+open import Issue6931.One A
+import Issue6931.Three as Three
+
+module M = Three.Public A b
+module N = Three.HasPrivate A b

--- a/test/Succeed/Issue6931/One.agda
+++ b/test/Succeed/Issue6931/One.agda
@@ -1,0 +1,4 @@
+module Issue6931.One (A : Set) where
+
+  data B : Set where
+    b : B

--- a/test/Succeed/Issue6931/Three.agda
+++ b/test/Succeed/Issue6931/Three.agda
@@ -1,0 +1,18 @@
+import Issue6931.One as One
+
+module Issue6931.Three (A : Set) where
+
+  module Public
+    (open One A)
+    (x : B) where
+
+    -- must be empty
+
+  module HasPrivate
+    (open One A)
+    (x : B) where
+
+    -- or just have private definitions
+    private
+      postulate
+        priv : B

--- a/test/Succeed/Issue6931/Two.agda
+++ b/test/Succeed/Issue6931/Two.agda
@@ -1,0 +1,7 @@
+import Issue6931.One as One
+
+module Issue6931.Two (A : Set)
+  (let module M = One A)
+  (x : M.B) where
+
+  -- must be empty


### PR DESCRIPTION
- Cosmetics: use `er` for erasure instead of `e` (which is usually an `Expr`)
- Extra debug printing for #6931
- Fix `showQNameId` to not use the `show` function of `List1`
- Fix #6931: dead code: include module telescopes in reachability analysis
