### PR TITLE
Instantiate all metas before retrieving blockers in `getLockVar`.

### DIFF
--- a/test/Fail/Issue6913.agda
+++ b/test/Fail/Issue6913.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2023-10-23, issue #6913, testcase and fix by Jonathan Chan
+-- Was an internal error in Constraints.hs (Agda 2.6.4)..
+
+{-# OPTIONS --guarded #-}
+
+primitive primLockUniv : Set₁
+
+variable κ₀ : primLockUniv
+postulate ✓ : κ₀
+
+force : {P : primLockUniv → Set} → (∀ κ → (@tick t : κ) → (P κ)) → (∀ κ → P κ)
+force f κ = f κ ✓
+
+-- Expected error:
+
+-- The term ✓, given as an argument to the guarded value
+--   f κ : κ → P κ
+-- can not be used as a @tick argument, since it does not mention any @tick variables.
+-- when checking that the expression f κ ✓ has type P κ

--- a/test/Fail/Issue6913.err
+++ b/test/Fail/Issue6913.err
@@ -1,0 +1,6 @@
+Issue6913.agda:12,13-18
+The term ✓, given as an argument to the guarded value
+  f κ : κ → P κ
+can not be used as a @tick argument, since it does not mention any
+@tick variables.
+when checking that the expression f κ ✓ has type P κ


### PR DESCRIPTION
Fixes #6913 (internal error in `Constraints.hs`).
