### PR TITLE
Separate parameters with space when pretty-printing

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -448,7 +448,7 @@ instance Pretty Declaration where
     DataSig _ erased x tel e ->
       sep [ hsep  [ "data"
                   , prettyErased erased (pretty x)
-                  , fcat (map pretty tel)
+                  , fsep (map pretty tel)
                   ]
           , nest 2 $ hsep
                   [ ":"
@@ -458,7 +458,7 @@ instance Pretty Declaration where
     Data _ erased x tel e cs ->
       sep [ hsep  [ "data"
                   , prettyErased erased (pretty x)
-                  , fcat (map pretty tel)
+                  , fsep (map pretty tel)
                   ]
           , nest 2 $ hsep
                   [ ":"
@@ -469,14 +469,14 @@ instance Pretty Declaration where
     DataDef _ x tel cs ->
       sep [ hsep  [ "data"
                   , pretty x
-                  , fcat (map pretty tel)
+                  , fsep (map pretty tel)
                   ]
           , nest 2 $ "where"
           ] $$ nest 2 (vcat $ map pretty cs)
     RecordSig _ erased x tel e ->
       sep [ hsep  [ "record"
                   , prettyErased erased (pretty x)
-                  , fcat (map pretty tel)
+                  , fsep (map pretty tel)
                   ]
           , nest 2 $ hsep
                   [ ":"
@@ -508,7 +508,7 @@ instance Pretty Declaration where
     Module _ erased x tel ds ->
       hsep [ "module"
            , prettyErased erased (pretty x)
-           , fcat (map pretty tel)
+           , fsep (map pretty tel)
            , "where"
            ] $$ nest 2 (vcat $ map pretty ds)
     ModuleMacro _ NotErased{} x (SectionApp _ [] e) DoOpen i
@@ -519,7 +519,7 @@ instance Pretty Declaration where
           ]
     ModuleMacro _ erased x (SectionApp _ tel e) open i ->
       sep [ pretty open <+> "module" <+>
-            prettyErased erased (pretty x) <+> fcat (map pretty tel)
+            prettyErased erased (pretty x) <+> fsep (map pretty tel)
           , nest 2 $ "=" <+> pretty e <+> pretty i
           ]
     ModuleMacro _ erased x (RecordModuleInstance _ rec) open i ->
@@ -572,7 +572,7 @@ pRecord erased x (RecordDirectives ind eta pat con) tel me ds = vcat
     [ sep
       [ hsep  [ "record"
               , prettyErased erased (pretty x)
-              , fcat (map pretty tel)
+              , fsep (map pretty tel)
               ]
       , nest 2 $ pType me
       ]

--- a/test/Fail/Issue6675.err
+++ b/test/Fail/Issue6675.err
@@ -2,6 +2,6 @@ Issue6675.agda:14,5-25
 Illegal declaration in data type definition
   {-# REWRITE refl #-}
 when scope checking the declaration
-  data Id Aa where
+  data Id A a where
     refl : Id A a a
     {-# REWRITE refl #-}

--- a/test/Fail/NoLetInRecordTele.err
+++ b/test/Fail/NoLetInRecordTele.err
@@ -1,4 +1,4 @@
 NoLetInRecordTele.agda:5,8-44
 p @ (ab) is not allowed in a telescope here.
 when scope checking the declaration
-  record R {A : Set}{B : A → Set}p @ (ab) : Set
+  record R {A : Set} {B : A → Set} p @ (ab) : Set

--- a/test/Fail/NoLetInRecordTele2.err
+++ b/test/Fail/NoLetInRecordTele2.err
@@ -1,4 +1,4 @@
 NoLetInRecordTele2.agda:5,8-43
 _ @ (p) is not allowed in a telescope here.
 when scope checking the declaration
-  record R {A : Set}{B : A → Set}_ @ (p) : Set
+  record R {A : Set} {B : A → Set} _ @ (p) : Set

--- a/test/Fail/TelescopingLetDataRecord.err
+++ b/test/Fail/TelescopingLetDataRecord.err
@@ -1,4 +1,4 @@
 TelescopingLetDataRecord.agda:4,8-34
 (let open Star) is not allowed in a telescope here.
 when scope checking the declaration
-  data D1 (let open Star)(A : ★) : ★
+  data D1 (let open Star) (A : ★) : ★

--- a/test/Succeed/Issue3989.warn
+++ b/test/Succeed/Issue3989.warn
@@ -2,7 +2,7 @@ Issue3989.agda:6,11-38
 warning: -W[no]ShadowingInTelescope
 Shadowing in telescope, repeated variable names: a
 when scope checking the declaration
-  data _~_ {a a : Level}{A : Set a}(a : A) : A → Set
+  data _~_ {a a : Level} {A : Set a} (a : A) : A → Set
 Issue3989.agda:16,24-40
 warning: -W[no]ShadowingInTelescope
 Shadowing in telescope, repeated variable names: A
@@ -26,7 +26,7 @@ Issue3989.agda:6,11-38
 warning: -W[no]ShadowingInTelescope
 Shadowing in telescope, repeated variable names: a
 when scope checking the declaration
-  data _~_ {a a : Level}{A : Set a}(a : A) : A → Set
+  data _~_ {a a : Level} {A : Set a} (a : A) : A → Set
 
 Issue3989.agda:16,24-40
 warning: -W[no]ShadowingInTelescope


### PR DESCRIPTION
Separate data, record, and module parameters with space when pretty-printing concrete syntax. Replaced every instance of `fcat` with `fsep`.

Previously, they were printed without separation, which caused variable names to run into each other. For example
```agda
record R (one : Set) (two : Set) (three : Set) : Set where
  module _ where
  field f : one
```
thew
```
This declaration is illegal in a record before the last field
when scope checking the declaration
  record R onetwothree where
    module _ where
    field f : one
```