### PR TITLE
Remove whitespace around substrings before concatenation

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1649,7 +1649,12 @@ text properties."
     (error "no process")))
 
 (defun agda2-intersperse (sep xs)
-  (let(ys)(while xs (push (pop xs) ys)(push sep ys))(pop ys)(nreverse ys)))
+  (let (ys)
+    (while xs
+      (push (string-trim (pop xs)) ys)
+      (push sep ys))
+    (pop ys)
+    (nreverse ys)))
 
 (defun agda2-goal-Range (o)
   "The Haskell Range of goal overlay O."


### PR DESCRIPTION
This is a workaround for agda/agda#6953.

It formats `agda2-intersperse` and calls `string-trim` before appending an element to the output list.

Fixes #6953.