### PR TITLE
Order instance candidates for getInstances

### DIFF
--- a/test/Succeed/ReflectionInstanceOrdering.agda
+++ b/test/Succeed/ReflectionInstanceOrdering.agda
@@ -1,0 +1,42 @@
+module ReflectionInstanceOrdering where
+
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Bool
+open import Agda.Builtin.List
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+
+postulate
+  F : Set → Set
+  G : Set → Set
+  instance
+    F-nat : ∀ {b} → F (Nat → b)
+    F-fn  : ∀ {a b} → ⦃ _ : G b ⦄ → F (a → b)
+    F-nat-nat : F (Nat → Nat)
+
+_>>=_ : ∀ {a b} {A : Set a} {B : Set b} → TC A → (A → TC B) → TC B
+_>>=_ = bindTC
+
+pattern argN x = arg (arg-info visible (modality relevant quantity-ω)) x
+
+list : List Term → Term
+list []              = con (quote []) []
+list (def x [] ∷ xs) = con (quote _∷_) (argN (lit (name x)) ∷ argN (list xs) ∷ [])
+list (_ ∷ _)         = con (quote zero) []
+
+instances : TC Term
+instances = runSpeculative do
+  meta mv _ ← checkType unknown (def (quote F) (argN unknown ∷ []))
+    where _ → typeError []
+  xs ← getInstances mv
+  returnTC (list xs , false)
+
+names : List Name
+names = unquote λ goal → do
+  xs ← instances
+  unify goal xs
+
+_ : names ≡ quote F-nat-nat ∷ quote F-nat ∷ quote F-fn ∷ []
+_ = refl


### PR DESCRIPTION
Closes #6944. The implementation is fairly minimally invasive: after filtering the instance candidates in `getInstanceCandidates` (the worker for `tcGetInstances`), they're sorted with insertion-sort according to the specificity ordering. The implementation defers to the conversion checker through `leqType`, but the comparisons are done in a fresh TC state and disallowing recursive instance search.

I went shopping for a quicker algorithm to implement the specificity ordering, but surprisingly, even [GHC calls out to its conversion checker](https://github.com/ghc/ghc/blob/master/compiler/GHC/Core/InstEnv.hs#L1378-L1379). I went with this implementation of comparison and _insertion sort_ for the ordering, under the heuristic assumption that most overlap sets will be small — they have been in my experience, and I'm hoping that generalizes.

Since the list is sorted only for the reflection endpoint, this does not change the solving of instance metas at all.