### PR TITLE
Bugfixes for opaque definitions

### DIFF
--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1695,13 +1695,13 @@ instance ToAbstract NiceDeclaration where
       return [ A.Field info y t' ]
 
   -- Primitive function
-    PrimitiveFunction r p a x t -> do
+    PrimitiveFunction r p a x t -> notAffectedByOpaque $ do
       t' <- traverse (toAbstractCtx TopCtx) t
       f  <- getConcreteFixity x
       y  <- freshAbstractQName f x
       bindName p PrimName x y
       unfoldFunction y
-      di <- updateDefInfoOpacity (mkDefInfo x f p a r)
+      let di = mkDefInfo x f p a r
       return [ A.Primitive di y t' ]
 
   -- Definitions (possibly mutual)
@@ -2158,10 +2158,9 @@ instance ToAbstract NiceDeclaration where
       interestingOpaqueDecl (A.Mutual _ ds)     = any interestingOpaqueDecl ds
       interestingOpaqueDecl (A.ScopedDecl _ ds) = any interestingOpaqueDecl ds
 
-      interestingOpaqueDecl A.FunDef{} = True
+      interestingOpaqueDecl A.FunDef{}      = True
       interestingOpaqueDecl A.UnquoteDecl{} = True
-      interestingOpaqueDecl A.UnquoteDef{} = True
-      interestingOpaqueDecl A.Primitive{} = True
+      interestingOpaqueDecl A.UnquoteDef{}  = True
 
       interestingOpaqueDecl _ = False
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -222,6 +222,14 @@ data PreScopeState = PreScopeState
     -- ^ Contents of .agda-lib files that have already been parsed.
   , stPreImportedMetaStore :: !RemoteMetaStore
     -- ^ Used for meta-variables from other modules.
+  , stPreCopiedNames       :: !(HashMap A.QName A.QName)
+    -- ^ Associates a copied name (the key) to its original name (the
+    -- value). Computed by the scope checker, used to compute opaque
+    -- blocks.
+  , stPreNameCopies        :: !(HashMap A.QName (HashSet A.QName))
+    -- ^ Associates an original name (the key) to all its copies (the
+    -- value). Computed by the scope checker, used to compute opaque
+    -- blocks.
   }
   deriving Generic
 
@@ -424,6 +432,8 @@ initPreScopeState = PreScopeState
   , stPreProjectConfigs       = Map.empty
   , stPreAgdaLibFiles         = Map.empty
   , stPreImportedMetaStore    = HMap.empty
+  , stPreCopiedNames          = HMap.empty
+  , stPreNameCopies           = HMap.empty
   }
 
 initPostScopeState :: PostScopeState
@@ -609,6 +619,16 @@ stImportedMetaStore :: Lens' TCState RemoteMetaStore
 stImportedMetaStore f s =
   f (stPreImportedMetaStore (stPreScopeState s)) <&>
   \x -> s {stPreScopeState = (stPreScopeState s) {stPreImportedMetaStore = x}}
+
+stCopiedNames :: Lens' TCState (HashMap QName QName)
+stCopiedNames f s =
+  f (stPreCopiedNames (stPreScopeState s)) <&>
+  \x -> s {stPreScopeState = (stPreScopeState s) {stPreCopiedNames = x}}
+
+stNameCopies :: Lens' TCState (HashMap QName (HashSet QName))
+stNameCopies f s =
+  f (stPreNameCopies (stPreScopeState s)) <&>
+  \x -> s {stPreScopeState = (stPreScopeState s) {stPreNameCopies = x}}
 
 stFreshNameId :: Lens' TCState NameId
 stFreshNameId f s =

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1698,6 +1698,13 @@ instance LensIsAbstract (Closure a) where
 instance LensIsAbstract MetaInfo where
   lensIsAbstract = lensClosure . lensIsAbstract
 
+instance LensIsOpaque TCEnv where
+  lensIsOpaque f env =
+    (f $! case envCurrentOpaqueId env of { Just x -> OpaqueDef x ; Nothing -> TransparentDef })
+    <&> \case { OpaqueDef x    -> env { envCurrentOpaqueId = Just x }
+              ; TransparentDef -> env { envCurrentOpaqueId = Nothing }
+              }
+
 ---------------------------------------------------------------------------
 -- ** Interaction meta variables
 ---------------------------------------------------------------------------

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -353,7 +353,7 @@ prettyWarning = \case
 
     RecordFieldWarning w -> prettyRecordFieldWarning w
 
-    NotAffectedByOpaque -> fwords "Only functions and primitives can be marked opaque. This declaration will be treated as transparent."
+    NotAffectedByOpaque -> fwords "Only function definitions can be marked opaque. This definition will be treated as transparent."
 
     UnfoldTransparentName qn -> fsep $
       pwords "The name" ++ [prettyTCM qn <> ","] ++ pwords "mentioned by an unfolding clause, does not belong to an opaque block. This has no effect."

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -31,7 +31,7 @@ import Agda.Syntax.Abstract.Views
 import Agda.Syntax.Translation.InternalToAbstract
 import Agda.Syntax.Literal
 import Agda.Syntax.Position
-import Agda.Syntax.Info
+import Agda.Syntax.Info as Info
 import Agda.Syntax.Translation.ReflectedToAbstract
 import Agda.Syntax.Scope.Base (KindOfName(ConName, DataName))
 
@@ -1062,7 +1062,7 @@ evalTCM v = do
       oc <- asksTC (^. lensIsOpaque)       -- Issue #6959, respect current opaque block
       let
         i' = mkDefInfo (nameConcrete $ qnameName x) noFixity' accessDontCare ac noRange
-        i = i' { defOpaque = oc }
+        i = i' { Info.defOpaque = oc }
       locallyReduceAllDefs $ checkFunDef i x cs
       primUnitUnit
 

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -1059,7 +1059,10 @@ evalTCM v = do
       alwaysReportSDoc "tc.unquote.def" 10 $ vcat $ map prettyA cs
       let accessDontCare = __IMPOSSIBLE__  -- or ConcreteDef, value not looked at
       ac <- asksTC (^. lensIsAbstract)     -- Issue #4012, respect AbstractMode
-      let i = mkDefInfo (nameConcrete $ qnameName x) noFixity' accessDontCare ac noRange
+      oc <- asksTC (^. lensIsOpaque)       -- Issue #6959, respect current opaque block
+      let
+        i' = mkDefInfo (nameConcrete $ qnameName x) noFixity' accessDontCare ac noRange
+        i = i' { defOpaque = oc }
       locallyReduceAllDefs $ checkFunDef i x cs
       primUnitUnit
 

--- a/test/Fail/Issue6959a.agda
+++ b/test/Fail/Issue6959a.agda
@@ -1,0 +1,21 @@
+module Issue6959a where
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+
+open Agda.Primitive
+
+data D : Set where
+  c : D
+
+opaque
+  unquoteDecl c′ =
+     bindTC
+       (declareDef
+          (arg (arg-info visible (modality relevant quantity-ω)) c′)
+          (def (quote D) [])) λ _ →
+     defineFun c′ (clause [] [] (con (quote c) []) ∷ [])
+
+_ : c ≡ c′
+_ = refl

--- a/test/Fail/Issue6959a.err
+++ b/test/Fail/Issue6959a.err
@@ -1,0 +1,3 @@
+Issue6959a.agda:21,5-9
+c != c′ of type D
+when checking that the expression refl has type c ≡ c′

--- a/test/Fail/Issue6959b.agda
+++ b/test/Fail/Issue6959b.agda
@@ -1,0 +1,18 @@
+module Issue6959b where
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+
+open Agda.Primitive
+
+data D : Set where
+  c : D
+
+opaque
+  c″ : D
+  unquoteDef c″ =
+    defineFun c″ (clause [] [] (con (quote c) []) ∷ [])
+
+_ : c ≡ c″
+_ = refl

--- a/test/Fail/Issue6959b.err
+++ b/test/Fail/Issue6959b.err
@@ -1,0 +1,3 @@
+Issue6959b.agda:18,5-9
+c != c″ of type D
+when checking that the expression refl has type c ≡ c″

--- a/test/Fail/OpaqueData.err
+++ b/test/Fail/OpaqueData.err
@@ -1,7 +1,7 @@
 OpaqueData.agda:5,3-6,14
 warning: -W[no]NotAffectedByOpaque
-Only functions and primitives can be marked opaque. This
-declaration will be treated as transparent.
+Only function definitions can be marked opaque. This definition
+will be treated as transparent.
 when scope checking the declaration
   data Foo where
     foo : Foo

--- a/test/Fail/OpaquePrimitive.agda
+++ b/test/Fail/OpaquePrimitive.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS -Werror #-}
+module OpaquePrimitive where
+
+open import Agda.Builtin.Equality
+
+postulate Char : Set
+
+{-# BUILTIN CHAR Char #-}
+
+opaque primitive
+  primToUpper : Char → Char
+
+_ : primToUpper 'a' ≡ 'A'
+_ = refl

--- a/test/Fail/OpaquePrimitive.err
+++ b/test/Fail/OpaquePrimitive.err
@@ -1,0 +1,6 @@
+OpaquePrimitive.agda:11,3-28
+warning: -W[no]NotAffectedByOpaque
+Only function definitions can be marked opaque. This definition
+will be treated as transparent.
+when scope checking the declaration
+  primitive primToUpper : Char → Char

--- a/test/Fail/OpaqueRecord.err
+++ b/test/Fail/OpaqueRecord.err
@@ -1,7 +1,7 @@
 OpaqueRecord.agda:5,3-8,16
 warning: -W[no]NotAffectedByOpaque
-Only functions and primitives can be marked opaque. This
-declaration will be treated as transparent.
+Only function definitions can be marked opaque. This definition
+will be treated as transparent.
 when scope checking the declaration
   record Foo where
     inductive

--- a/test/Succeed/Issue6745.agda
+++ b/test/Succeed/Issue6745.agda
@@ -1,0 +1,15 @@
+module Issue6745 where
+
+module M (A : Set₂) where
+
+  opaque
+    X : Set₂
+    X = A
+
+module N (let open M Set₁) where
+
+  opaque
+    unfolding X
+
+    Y : X
+    Y = Set

--- a/test/Succeed/Issue6802.warn
+++ b/test/Succeed/Issue6802.warn
@@ -1,7 +1,7 @@
 Issue6802.agda:9,3-11,15
 warning: -W[no]NotAffectedByOpaque
-Only functions and primitives can be marked opaque. This
-declaration will be treated as transparent.
+Only function definitions can be marked opaque. This definition
+will be treated as transparent.
 when scope checking the declaration
   module _ where
     foo : Nat
@@ -20,8 +20,8 @@ when scope checking the declaration
 
 Issue6802.agda:9,3-11,15
 warning: -W[no]NotAffectedByOpaque
-Only functions and primitives can be marked opaque. This
-declaration will be treated as transparent.
+Only function definitions can be marked opaque. This definition
+will be treated as transparent.
 when scope checking the declaration
   module _ where
     foo : Nat

--- a/test/Succeed/Issue6802a.warn
+++ b/test/Succeed/Issue6802a.warn
@@ -1,7 +1,7 @@
 Issue6802a.agda:7,3-9,15
 warning: -W[no]NotAffectedByOpaque
-Only functions and primitives can be marked opaque. This
-declaration will be treated as transparent.
+Only function definitions can be marked opaque. This definition
+will be treated as transparent.
 when scope checking the declaration
   record Foo where
     foo : Nat
@@ -22,8 +22,8 @@ when scope checking the declaration
 
 Issue6802a.agda:7,3-9,15
 warning: -W[no]NotAffectedByOpaque
-Only functions and primitives can be marked opaque. This
-declaration will be treated as transparent.
+Only function definitions can be marked opaque. This definition
+will be treated as transparent.
 when scope checking the declaration
   record Foo where
     foo : Nat


### PR DESCRIPTION
Hat trick! Fixes #6958 (considers primitives uninteresting when generating the warning), #6959 (propagates the opacity information from the environment to any definitions generated by reflection), and #6745 (has the scope checker write down what names are copies instead of trying to reinvent them).

Fixes #6959. Fixes #6745.