### PR TITLE
Fix #6957: user-manual: link to std-lib installation instructions

### DIFF
--- a/doc/user-manual/getting-started/a-taste-of-agda.lagda.rst
+++ b/doc/user-manual/getting-started/a-taste-of-agda.lagda.rst
@@ -20,7 +20,7 @@ Preliminaries
 
 Before proceeding, make sure that you :ref:`installed Agda <installation>`
 and a compatible version of the `standard library
-<https://github.com/agda/agda-stdlib/blob/master/notes/installation-guide.md>`_.
+<https://github.com/agda/agda-stdlib/blob/master/doc/installation-guide.md>`_.
 
 Agda programs are typically developed *interactively*, which means
 that one can type check code which is not yet complete but contain

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -231,7 +231,7 @@ Step 4 : Installing the standard library
 ----------------------------------------
 
 Installing the standard library, should you choose to use it,
-is an additional step using `a separate repository <https://github.com/agda/agda-stdlib/blob/master/notes/installation-guide.md>`_.
+is an additional step using `a separate repository <https://github.com/agda/agda-stdlib/blob/master/doc/installation-guide.md>`_.
 
 
 .. _prebuilt-packages:


### PR DESCRIPTION
Not using a permalink since the content it points to could get outdated.
Rather risking that the link will break as a whole again in the future.

Closes #6957.
