### PR TITLE
Expose the names of generated record constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ Language
   It is possible again to use proofs as termination arguments.
   (See [issue #6930](https://github.com/agda/agda/issues/6930).)
 
+* It is now always possible to refer to the name of a record type's
+  constructor, even if a name was not explicitly specified. This is done
+  using the new `(Record name).constructor` syntax; See [issue
+  #6964](https://github.com/agda/agda/issues/6964) for the motivation.
+
+
 Reflection
 ----------
 

--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -195,6 +195,11 @@ instance (Hilite a, Hilite b) => Hilite (a, b) where
 instance Hilite A.RecordDirectives where
   hilite (RecordDirectives _ _ _ c) = hilite c
 
+instance Hilite A.RecordConName where
+  hilite = \case
+    A.NamedRecCon x -> hilite x
+    A.FreshRecCon{} -> mempty
+
 instance Hilite A.Declaration where
   hilite = \case
       A.Axiom _ax _di ai _occ x e            -> hl ai <> hl x <> hl e

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -493,7 +493,9 @@ instance DeclaredNames KName where
 
 instance DeclaredNames RecordDirectives where
   declaredNames (RecordDirectives i _ _ c) = kc where
-    kc = maybe mempty (singleton . WithKind k) c
+    kc = case c of
+      NamedRecCon c -> singleton $ WithKind k c
+      FreshRecCon{} -> mempty
     k  = maybe ConName (conKindOfName . rangedThing) i
 
 instance DeclaredNames Declaration where

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -101,10 +101,10 @@ data RecordDirectives' a = RecordDirectives
   { recInductive   :: Maybe (Ranged Induction)
   , recHasEta      :: Maybe HasEta0
   , recPattern     :: Maybe Range
-  , recConstructor :: Maybe a
+  , recConstructor :: a
   } deriving (Functor, Show, Eq)
 
-emptyRecordDirectives :: RecordDirectives' a
+emptyRecordDirectives :: Null a => RecordDirectives' a
 emptyRecordDirectives = RecordDirectives empty empty empty empty
 
 instance HasRange a => HasRange (RecordDirectives' a) where

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -454,7 +454,7 @@ data RecordDirective
        -- ^ If declaration @pattern@ is present, give its range.
    deriving (Eq, Show)
 
-type RecordDirectives = RecordDirectives' (Name, IsInstance)
+type RecordDirectives = RecordDirectives' (Maybe (Name, IsInstance))
 
 {-| The representation type of a declaration. The comments indicate
     which type in the intended family the constructor targets.

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1920,23 +1920,39 @@ figureOutTopLevelModule ds =
       -- We use the beginning of the file as beginning of the top level module.
       r = beginningOfFile $ getRange ds1
 
--- | Create a name from a string.
+-- | Create a name from a string. The boolean indicates whether a part
+-- of the name can be token 'constructor'.
+mkName' :: Bool -> (Interval, String) -> Parser Name
+mkName' constructor' (i, s) = do
+    let
+      xs = C.stringNameParts s
 
-mkName :: (Interval, String) -> Parser Name
-mkName (i, s) = do
-    let xs = C.stringNameParts s
-    mapM_ isValidId xs
+      -- The keyword constructor can appear as the only NamePart in the
+      -- last segment of a qualified name --- Foo.constructor refers to
+      -- the constructor of the record Foo.
+      constructor = case xs of
+        _ :| [] -> constructor'
+        _       -> False
+      --  The constructor' argument to mkName' determines whether this
+      --  is the last segment of a QName, the local variable constructor
+      --  additionally takes whether it's the only NamePart into
+      --  consideration.
+
+    mapM_ (isValidId constructor) xs
     unless (alternating xs) $ parseError $ "a name cannot contain two consecutive underscores"
     return $ Name (getRange i) InScope xs
     where
-        isValidId Hole   = return ()
-        isValidId (Id y) = do
+        isValidId constructor Hole   = return ()
+        isValidId constructor (Id y) = do
           let x = rawNameToString y
               err = "in the name " ++ s ++ ", the part " ++ x ++ " is not valid"
           case parse defaultParseFlags [0] (lexer return) x of
             ParseOk _ TokId{}  -> return ()
             ParseFailed{}      -> parseError err
             ParseOk _ TokEOF{} -> parseError err
+
+            ParseOk _ (TokKeyword KwConstructor _) | constructor -> pure ()
+
             ParseOk _ t   -> parseError . ((err ++ " because it is ") ++) $ case t of
               TokId{}       -> __IMPOSSIBLE__
               TokQId{}      -> __IMPOSSIBLE__ -- "qualified"
@@ -1981,11 +1997,17 @@ mkName (i, s) = do
         alternating (_    :| x   : xs) = alternating $ x :| xs
         alternating (_    :|       []) = True
 
+mkName :: (Interval, String) -> Parser Name
+mkName = mkName' False
+
 -- | Create a qualified name from a list of strings
 mkQName :: [(Interval, String)] -> Parser QName
 mkQName ss = do
-    xs <- mapM mkName ss
-    return $ foldr Qual (QName $ last xs) (init xs)
+  let ss0 = init ss
+      ss1 = last ss
+  ss0 <- mapM mkName ss0
+  ss1 <- mkName' True ss1
+  return $ foldr Qual (QName ss1) ss0
 
 mkDomainFree_ :: (NamedArg Binder -> NamedArg Binder) -> Maybe Pattern -> Name -> NamedArg Binder
 mkDomainFree_ f p n = f $ defaultNamedArg $ Binder p $ mkBoundName_ n

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -702,6 +702,13 @@ copyScope oldc new0 s = (inScopeBecause (Applied oldc) *** memoToScopeInfo) <$> 
           i <- lift fresh
           return $ x { A.nameId = i }
 
+        copyRecordConstr :: A.QName -> A.QName -> WSM ()
+        copyRecordConstr from to = getRecordConstructor from >>= \case
+          Just con -> do
+            con' <- renName con
+            lift (setRecordConstructor to con')
+          Nothing  -> pure ()
+
         -- Change a binding M.x -> old.M'.y to M.x -> new.M'.y
         renName :: A.QName -> WSM A.QName
         renName x = do
@@ -738,6 +745,7 @@ copyScope oldc new0 s = (inScopeBecause (Applied oldc) *** memoToScopeInfo) <$> 
           lift $ reportSLn "scope.copy" 50 $ "  Copying " ++ prettyShow x ++ " to " ++ prettyShow y
           addName x y
           lift (copyName x y)
+          copyRecordConstr x y
           return y
 
         -- Change a binding M.x -> old.M'.y to M.x -> new.M'.y

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -301,6 +301,7 @@ errorString err = case err of
   IllTypedPatternAfterWithAbstraction{}    -> "IllTypedPatternAfterWithAbstraction"
   ComatchingDisabledForRecord{}            -> "ComatchingDisabledForRecord"
   BuiltinMustBeIsOne{}                     -> "BuiltinMustBeIsOne"
+  IllegalAnonymousConstrReference{}        -> "IllegalAnonymousConstrReference"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1439,6 +1440,11 @@ instance PrettyTCM TypeError where
 
     BuiltinMustBeIsOne builtin ->
       prettyTCM builtin <+> " is not IsOne."
+
+    IllegalAnonymousConstrReference recr -> fsep $
+      pwords "Can not refer to constructor of record type"
+        ++ [prettyTCM recr]
+        ++ pwords "using an anonymous reference, since it has a declared name."
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4654,6 +4654,7 @@ data TypeError
         | GeneralizedVarInLetOpenedModule A.QName
         | MultipleFixityDecls [(C.Name, [Fixity'])]
         | MultiplePolarityPragmas [C.Name]
+        | IllegalAnonymousConstrReference I.QName
     -- Concrete to Abstract errors
         | NotAModuleExpr C.Expr
             -- ^ The expr was used in the right hand side of an implicit module

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -489,8 +489,8 @@ isEtaRecordType a = case unEl a of
     ifM (isEtaRecord d) (return $ Just (d, vs)) (return Nothing)
   _        -> return Nothing
 
--- | Check if a name refers to a record constructor.
---   If yes, return record definition.
+-- | Check if a name refers to a record constructor. If yes, return
+-- record definition. Assumes that the name is in scope.
 isRecordConstructor :: HasConstInfo m => QName -> m (Maybe (QName, Defn))
 isRecordConstructor c = getConstInfo' c >>= \case
   Left (SigUnknown err)     -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -46,7 +46,6 @@ import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Utils.POMonoid
-import Agda.Syntax.Common.Pretty (render)
 import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Utils.Size
 
@@ -154,15 +153,16 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
 
       -- Obtain name of constructor (if present).
       (hasNamedCon, conName) <- case con of
-        Just c  -> return (True, c)
-        Nothing -> do
-          m <- killRange <$> currentModule
-          -- Andreas, 2020-06-01, AIM XXXII
-          -- Using prettyTCM here jinxes the printer, see PR #4699.
-          -- r <- prettyTCM name
-          let r = P.pretty $ qnameName name
-          c <- qualify m <$> freshName_ (render r ++ ".constructor")
-          return (False, c)
+        A.NamedRecCon c -> return (True, c)
+        A.FreshRecCon c -> return (False, c)
+        -- Nothing -> do
+        --   m <- killRange <$> currentModule
+        --   -- Andreas, 2020-06-01, AIM XXXII
+        --   -- Using prettyTCM here jinxes the printer, see PR #4699.
+        --   -- r <- prettyTCM name
+        --   let r = P.pretty $ qnameName name
+        --   c <- qualify m <$> freshName_ (render r ++ ".constructor")
+        --   return (False, c)
 
       -- Add record type to signature.
       reportSDoc "tc.rec" 15 $ "adding record type to signature"

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20231019 * 10 + 0
+currentInterfaceVersion = 20231109 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -237,8 +237,8 @@ instance EmbPrj Precedence where
     valu _         = malformed
 
 instance EmbPrj ScopeInfo where
-  icod_ (ScopeInfo a b c d e f g h i j) = icodeN' (\ a b c d e -> ScopeInfo a b c d e f g h i j) a b c d e
+  icod_ (ScopeInfo a b c d e f g h i j k) = icodeN' (\ a b c d e -> ScopeInfo a b c d e f g h i j k) a b c d e
 
-  value = valueN (\ a b c d e -> ScopeInfo a b c d e Map.empty Map.empty Set.empty Map.empty Map.empty)
+  value = valueN (\ a b c d e -> ScopeInfo a b c d e Map.empty Map.empty Set.empty Map.empty Map.empty Map.empty)
 
 instance EmbPrj NameOrModule

--- a/test/Fail/AnonymousRecConstrAbstract.agda
+++ b/test/Fail/AnonymousRecConstrAbstract.agda
@@ -1,0 +1,11 @@
+module AnonymousRecConstrAbstract where
+
+-- Tests that you can't use Record.constructor syntax to bypass
+-- 'abstract' hiding the constructor.
+
+abstract record Foo : Set₁ where
+  field
+    x : Set
+
+_ : Set → Foo
+_ = Foo.constructor

--- a/test/Fail/AnonymousRecConstrAbstract.err
+++ b/test/Fail/AnonymousRecConstrAbstract.err
@@ -1,0 +1,4 @@
+AnonymousRecConstrAbstract.agda:11,5-20
+Constructor Foo.constructor is abstract, thus, not in scope here
+when checking that the expression Foo.constructor has type
+Set → Foo

--- a/test/Fail/AnonymousRecConstrInline.agda
+++ b/test/Fail/AnonymousRecConstrInline.agda
@@ -1,0 +1,21 @@
+module AnonymousRecConstrInline where
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+-- Tests that constructor → copattern inlining works even if the
+-- constructor is not named.
+
+record R : Set₁ where
+  no-eta-equality
+  field
+    x : Set
+
+{-# INLINE R.constructor #-}
+
+t1 t2 : R
+t1 = record { x = Nat }
+t2 = record { x = Nat }
+
+_ : t1 ≡ t2
+_ = refl

--- a/test/Fail/AnonymousRecConstrInline.err
+++ b/test/Fail/AnonymousRecConstrInline.err
@@ -1,0 +1,3 @@
+AnonymousRecConstrInline.agda:21,5-9
+t1 != t2 of type R
+when checking that the expression refl has type t1 ≡ t2

--- a/test/Fail/AnonymousRecConstrNamed.agda
+++ b/test/Fail/AnonymousRecConstrNamed.agda
@@ -1,0 +1,14 @@
+module AnonymousRecConstrNamed where
+
+open import Agda.Builtin.Nat
+
+-- Tests that you can't use Record.constructor syntax if the record has
+-- a named constructor.
+
+record Foo : Set where
+  constructor foo
+  field
+    x : Nat
+
+_ : Nat → Foo
+_ = Foo.constructor

--- a/test/Fail/AnonymousRecConstrNamed.err
+++ b/test/Fail/AnonymousRecConstrNamed.err
@@ -1,0 +1,4 @@
+AnonymousRecConstrNamed.agda:14,5-20
+Can not refer to constructor of record type Foo using an anonymous
+reference, since it has a declared name.
+when scope checking Foo.constructor

--- a/test/Fail/AnonymousRecConstrParse.agda
+++ b/test/Fail/AnonymousRecConstrParse.agda
@@ -1,0 +1,3 @@
+module AnonymousRecConstrParse where
+
+_ = constructor

--- a/test/Fail/AnonymousRecConstrParse.err
+++ b/test/Fail/AnonymousRecConstrParse.err
@@ -1,0 +1,5 @@
+AnonymousRecConstrParse.agda:3,5-5
+AnonymousRecConstrParse.agda:3,5: Parse error
+constructor<ERROR>
+
+...

--- a/test/Fail/AnonymousRecConstrParse1.agda
+++ b/test/Fail/AnonymousRecConstrParse1.agda
@@ -1,0 +1,3 @@
+module AnonymousRecConstrParse1 where
+
+_ = Foo.constructor.bar

--- a/test/Fail/AnonymousRecConstrParse1.err
+++ b/test/Fail/AnonymousRecConstrParse1.err
@@ -1,0 +1,4 @@
+AnonymousRecConstrParse1.agda:3,5-5
+AnonymousRecConstrParse1.agda:3,5: in the name constructor, the part constructor is not valid because it is a keyword
+<EOF><ERROR>
+...

--- a/test/Fail/IUnivNotFibrant.err
+++ b/test/Fail/IUnivNotFibrant.err
@@ -1,5 +1,4 @@
 IUnivNotFibrant.agda:4,8-12
 SSet₁ is not less or equal than Set₁
 when checking that the type IUniv of an argument to the constructor
-IUnivNotFibrant.Wrap.constructor fits in the sort Set₁ of the
-datatype.
+Wrap.constructor fits in the sort Set₁ of the datatype.

--- a/test/Fail/Issue1035.err
+++ b/test/Fail/Issue1035.err
@@ -3,6 +3,6 @@ Termination checking failed for the following functions:
   M.to-∈-intersection′
 Problematic calls:
   to-∈-intersection′ Key x h | intersection′-₁ x
-  Issue1035.M.with-48 (prop h)
+  Issue1035.M.with-50 (prop h)
   to-∈-intersection′ ! !
     (at Issue1035.agda:25,50-68)

--- a/test/Fail/Issue2998-illtyped.err
+++ b/test/Fail/Issue2998-illtyped.err
@@ -2,4 +2,4 @@ Issue2998-illtyped.agda:12,1-10
 Ill-typed pattern after with abstraction:  r
 (perhaps you can replace it by '_'?)
 when checking the clause left hand side
-Issue2998-illtyped.with-14 x _
+Issue2998-illtyped.with-16 x _

--- a/test/Fail/Issue4637.err
+++ b/test/Fail/Issue4637.err
@@ -3,6 +3,6 @@ Termination checking failed for the following functions:
   test
 Problematic calls:
   test r | bar r
-  Issue4637.with-14 r (record { foo = x }) | bar x
+  Issue4637.with-16 r (record { foo = x }) | bar x
   test x
     (at Issue4637.agda:16,35-39)

--- a/test/Fail/Issue555c.err
+++ b/test/Fail/Issue555c.err
@@ -1,4 +1,4 @@
 Issue555c.agda:7,8-9
 Set a is not less or equal than Set
 when checking that the type A of an argument to the constructor
-Issue555c.R.constructor fits in the sort Set of the datatype.
+R.constructor fits in the sort Set of the datatype.

--- a/test/Succeed/AnonymousRecConstr.agda
+++ b/test/Succeed/AnonymousRecConstr.agda
@@ -1,0 +1,13 @@
+module AnonymousRecConstr where
+
+-- Basic test about referring to the constructor of a record with no
+-- 'constructor' directive.
+
+open import Agda.Builtin.Nat
+
+record Bar : Set where
+  field
+    x : Nat
+
+_ : Nat → Bar
+_ = Bar.constructor

--- a/test/Succeed/AnonymousRecConstrAbstract.agda
+++ b/test/Succeed/AnonymousRecConstrAbstract.agda
@@ -1,0 +1,12 @@
+module AnonymousRecConstrAbstract where
+
+-- Tests that you can refer to the constructor of an abstract record
+-- using Record.constructor syntax as long as you're in AbstractMode.
+
+abstract record Foo : Set₁ where
+  field
+    x : Set
+
+abstract
+  _ : Set → Foo
+  _ = Foo.constructor

--- a/test/Succeed/AnonymousRecConstrCopy.agda
+++ b/test/Succeed/AnonymousRecConstrCopy.agda
@@ -1,0 +1,8 @@
+module AnonymousRecConstrCopy where
+
+module Foo (A : Set₁) where
+  record Bar : Set where
+
+open Foo Set
+
+_ = Bar.constructor

--- a/test/Succeed/AnonymousRecConstrCopy2.agda
+++ b/test/Succeed/AnonymousRecConstrCopy2.agda
@@ -1,0 +1,7 @@
+module AnonymousRecConstrCopy2 where
+
+module Foo (A : Set₁) where
+  record Bar : Set where
+
+module _ (let open Foo Set) where
+  _ = Bar.constructor

--- a/test/Succeed/AnonymousRecConstrCopy3a.agda
+++ b/test/Succeed/AnonymousRecConstrCopy3a.agda
@@ -1,0 +1,3 @@
+module AnonymousRecConstrCopy3a (A : Set₁) where
+
+record Bar : Set where

--- a/test/Succeed/AnonymousRecConstrCopy3b.agda
+++ b/test/Succeed/AnonymousRecConstrCopy3b.agda
@@ -1,0 +1,5 @@
+module AnonymousRecConstrCopy3b where
+
+open import AnonymousRecConstrCopy3a Set
+
+_ = Bar.constructor

--- a/test/Succeed/AnonymousRecConstrImport.agda
+++ b/test/Succeed/AnonymousRecConstrImport.agda
@@ -1,0 +1,7 @@
+module AnonymousRecConstrImport where
+
+open import AnonymousRecConstr
+
+-- Tests that Record.constructor syntax works across imports.
+
+_ = Bar.constructor

--- a/test/Succeed/AnonymousRecConstrInline.agda
+++ b/test/Succeed/AnonymousRecConstrInline.agda
@@ -1,0 +1,13 @@
+module AnonymousRecConstrInline where
+
+-- Tests that you can mark the constructor of a no-eta-equality record
+-- as INLINE even if the constructor is not named.
+
+open import Agda.Builtin.Nat
+
+record R : Set₁ where
+  no-eta-equality
+  field
+    x : Set
+
+{-# INLINE R.constructor #-}

--- a/test/Succeed/AnonymousRecConstrQual.agda
+++ b/test/Succeed/AnonymousRecConstrQual.agda
@@ -1,0 +1,14 @@
+module AnonymousRecConstrQual where
+
+open import Agda.Builtin.Nat
+
+-- Tests that Record.constructor syntax works even if the constructor is
+-- in scope qualified.
+
+module Foo where
+  record Bar : Set where
+    field
+      x : Nat
+
+_ : Nat → Foo.Bar
+_ = Foo.Bar.constructor

--- a/test/Succeed/AnonymousRecConstrQuote.agda
+++ b/test/Succeed/AnonymousRecConstrQuote.agda
@@ -1,0 +1,13 @@
+module AnonymousRecConstrQuote where
+
+open import Agda.Builtin.Reflection
+
+-- Tests that you can quote a name obtained through Record.constructor
+-- syntax.
+
+record Bar : Set₁ where
+  field
+    x : Set
+
+_ : Name
+_ = quote Bar.constructor

--- a/test/Succeed/AnonymousRecConstrRename.agda
+++ b/test/Succeed/AnonymousRecConstrRename.agda
@@ -1,0 +1,13 @@
+module AnonymousRecConstrRename where
+
+-- Tests that Record.constructor syntax works even if the record has
+-- been renamed.
+
+module Foo where
+  record Bar : Set₁ where
+    field
+      x : Set
+
+open Foo renaming (Bar to Baz)
+
+_ = Baz.constructor


### PR DESCRIPTION
The keyword `constructor` can appear as the last token in a qualified name, as long as it's the only name part. So `Foo.constructor`, `Foo.Bar.constructor` are both valid, but `constructor` and `Foo.constructor.bar` are still syntax errors.

The `Foo.constructor` syntax is actual _syntax_. It looks like a name, but there's no `constructor` name in the module `Foo`. That would be incorrect anyway, since the record module is parametrized by a value of the record type, but the constructor isn't; see #4189. Because of this, it's not possible to control the visibility of `Foo.constructor`: if you want that, give the constructor an actual name.

If the constructor has a declared name, the `Foo.constructor` syntax is also disabled, with an error message explaining that the declared name should be used instead.

To resolve `Foo.constructor`, we look up `Foo` as an unambiguous record name, and then resolve to the _actual_ name of the constructor, which is still kept internal. This means that `Foo.constructor` is in scope as long as `Foo` is, so this doesn't reintroduce #282. It also means that renaming _the record_ will also "rename" the constructor, as expected.