### PR TITLE
Fixes issue 6234 by updating documentation for Cubical Agda and removing links

### DIFF
--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -112,7 +112,7 @@ the following to the top of a file (this assumes that the
 
   open import Cubical.Core.Everything
 
-For detailed install instructions for ``agda/cubical`` see:
+Follow the instructions at https://github.com/agda/cubical to install the library.
 https://github.com/agda/cubical/blob/4de6b6939245ce281f02e47af02f2deb1cbd853e/INSTALL.md. In
 order to make this library visible to Agda add
 ``/path/to/cubical/cubical.agda-lib`` to ``.agda/libraries`` and

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -113,8 +113,7 @@ the following to the top of a file (this assumes that the
   open import Cubical.Core.Everything
 
 Follow the instructions at https://github.com/agda/cubical to install the library.
-https://github.com/agda/cubical/blob/4de6b6939245ce281f02e47af02f2deb1cbd853e/INSTALL.md. In
-order to make this library visible to Agda add
+In order to make this library visible to Agda add
 ``/path/to/cubical/cubical.agda-lib`` to ``.agda/libraries`` and
 ``cubical`` to ``.agda/defaults`` (where ``path/to`` is the absolute
 path to where the ``agda/cubical`` library has been installed). For

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -67,7 +67,8 @@ Theory that Agda implements is a variation of the `CCHM`_ Cubical Type
 Theory where the Kan composition operations are decomposed into
 homogeneous composition and generalized transport. This is what makes
 the general schema for higher inductive types work, following the
-`CHM`_ paper.
+`CHM`_ paper. There is also a research paper specifically about
+Cubical Agda at https://www.doi.org/10.1017/S0956796821000034.
 
 To use the cubical mode Agda needs to be run with the
 :option:`--cubical` command-line-option or with ``{-#
@@ -86,17 +87,22 @@ The cubical mode adds the following features to Agda:
 6. Higher inductive types
 7. Cubical identity types
 
-There is a standard ``agda/cubical`` library for Cubical Agda
-available at https://github.com/agda/cubical. This documentation uses
-the naming conventions of this library, for a detailed list of all of
-the built-in Cubical Agda files and primitives see
-:ref:`primitives-ref`. The main design choices of the core part of the
-library are explained in
-https://homotopytypetheory.org/2018/12/06/cubical-agda/
-(lagda rendered version:
-https://ice1000.org/2018/12-06-CubicalAgda.html).
+There are two major libraries for Cubical Agda:
 
-The recommended way to get access to the Cubical primitives is to add
+- ``agda/cubical``: originally intended as a standard library for
+  Cubical Agda available at https://github.com/agda/cubical. This
+  documentation uses the naming conventions of this library, for a
+  detailed list of all of the built-in Cubical Agda files and
+  primitives see :ref:`primitives-ref`.
+
+- ``1lab``: A formalised and cross linked reference resource for
+  cubical methods in Homotopy Type Theory which can be found at
+  https://1lab.dev/. Much better documented than the ``agda/cubical``
+  library and hence more accessible to newcomers. The sources can be
+  found at https://github.com/plt-amy/1lab.
+
+In this documentation we will rely on the ``agda/cubical`` library and
+the recommended way to get access to the cubical primitives is to add
 the following to the top of a file (this assumes that the
 ``agda/cubical`` library is installed and visible to Agda).
 
@@ -107,8 +113,8 @@ the following to the top of a file (this assumes that the
   open import Cubical.Core.Everything
 
 For detailed install instructions for ``agda/cubical`` see:
-https://github.com/agda/cubical/blob/master/INSTALL.md. In order to
-make this library visible to Agda add
+https://github.com/agda/cubical/blob/4de6b6939245ce281f02e47af02f2deb1cbd853e/INSTALL.md. In
+order to make this library visible to Agda add
 ``/path/to/cubical/cubical.agda-lib`` to ``.agda/libraries`` and
 ``cubical`` to ``.agda/defaults`` (where ``path/to`` is the absolute
 path to where the ``agda/cubical`` library has been installed). For
@@ -119,10 +125,6 @@ the relevant import statements at the top of their file (for details
 see :ref:`primitives-ref`). However, for beginners it is
 recommended that one uses at least the core part of the
 ``agda/cubical`` library.
-
-There is also an older version of the library available at
-https://github.com/Saizan/cubical-demo/. However this is relying on
-deprecated features and is not recommended to use.
 
 The interval and path types
 ===========================
@@ -562,7 +564,7 @@ The simplest example of an equivalence is the identity function.
 
 An important special case of equivalent types are isomorphic types
 (i.e. types with maps going back and forth which are mutually
-inverse): https://github.com/agda/cubical/blob/master/Cubical/Foundations/Isomorphism.agda.
+inverse).
 
 As everything has to work up to higher dimensions the Glue types take
 a partial family of types that are equivalent to the base type ``A``:
@@ -631,12 +633,8 @@ We have the following equalities:
    glue {φ = i1} t a = t 1=1
 
 
-For more results about Glue types and univalence see
-https://github.com/agda/cubical/blob/master/Cubical/Core/Glue.agda and
-https://github.com/agda/cubical/blob/master/Cubical/Foundations/Univalence.agda. For
-some examples of what can be done with this for working with binary
-and unary numbers see
-https://github.com/agda/cubical/blob/master/Cubical/Data/BinNat/BinNat.agda.
+For more results about Glue types and univalence see the files of Glue
+types and univalence in the ``agda/cubical`` library or the ``1lab``.
 
 
 Higher inductive types
@@ -733,8 +731,8 @@ is defined as:
   recPropTrunc Pprop f (squash x y i) =
     Pprop (recPropTrunc Pprop f x) (recPropTrunc Pprop f y) i
 
-For many more examples of higher inductive types see:
-https://github.com/agda/cubical/tree/master/Cubical/HITs.
+For many more examples of higher inductive types see the
+``agda/cubical`` library or the ``1lab``.
 
 .. _indexed-inductive-types:
 
@@ -941,114 +939,6 @@ relevant position.
 
 Any argument which is used in the result type, or appears after a forced
 (dot) pattern, must have a modality-correct type.
-
-Cubical identity types and computational HoTT/UF
-================================================
-
-As mentioned above the computation rule for ``J`` does not hold
-definitionally for path types. Cubical Agda solves this by introducing
-a cubical identity type. The
-https://github.com/agda/cubical/blob/master/Cubical/Core/Id.agda file
-exports all of the primitives for this type, including the notation
-``_≡_`` and a ``J`` eliminator that computes definitionally on
-``refl``.
-
-The cubical identity types and path types are equivalent, so all of
-the results for one can be transported to the other one (using
-univalence). Using this we have implemented an `interface to HoTT/UF <https://github.com/agda/cubical/blob/5de11df25b79ee49d5c084fbbe6dfc66e4147a2e/Cubical/Experiments/HoTT-UF.agda>`_
-which provides the user with the key primitives of Homotopy Type
-Theory and Univalent Foundations implemented using cubical primitives
-under the hood. This hence gives an axiom free version of HoTT/UF
-which computes properly.
-
-.. code-block:: agda
-
-  module Cubical.Core.HoTT-UF where
-
-  open import Cubical.Core.Id public
-     using ( _≡_            -- The identity type.
-           ; refl           -- Its constructor.
-           ; J              -- Its eliminator (can be defined by pattern matching)
-
-           ; transport      -- As in the HoTT Book.
-           ; ap
-           ; _∙_
-           ; _⁻¹
-
-           ; _≡⟨_⟩_         -- Standard equational reasoning.
-           ; _∎
-
-           ; funExt         -- Function extensionality
-                            -- (can also be derived from univalence).
-
-           ; Σ              -- Sum type. Needed to define contractible types, equivalences
-           ; _,_            -- and univalence.
-           ; pr₁            -- The eta rule is available.
-           ; pr₂
-
-           ; isProp         -- The usual notions of proposition, contractible type, set.
-           ; isContr
-           ; isSet
-
-           ; isEquiv        -- A map with contractible fibers
-                            -- (Voevodsky's version of the notion).
-           ; _≃_            -- The type of equivalences between two given types.
-           ; EquivContr     -- A formulation of univalence.
-
-           ; ∥_∥             -- Propositional truncation.
-           ; ∣_∣             -- Map into the propositional truncation.
-           ; ∥∥-isProp       -- A truncated type is a proposition.
-           ; ∥∥-recursion    -- Non-dependent elimination.
-           ; ∥∥-induction    -- Dependent elimination.
-           )
-
-In order to get access to only the HoTT/UF primitives start a file as
-follows:
-
-.. code-block:: agda
-
-  {-# OPTIONS --cubical #-}
-
-  open import Cubical.Core.HoTT-UF
-
-However, even though this interface exists, we recommend that users of
-cubical mode use the path types rather than the cubical identity types.
-Primarily, this is because many operations for path types are
-implemented directly, rather than by induction (e.g. ``ap``, ``funExt``,
-``happly``, ``sym``, etc), and thus enjoy better computational
-behaviour. In addition to using ``J`` directly, it is possible to match
-on the reflexivity constructor, as if ``Id`` were an inductive type:
-
-::
-
-  symId : ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → Id y x
-  symId reflId = reflId
-
-Cubical identity types are *not* inductively defined, and we may observe
-this using the primitives ``conid`` and ``primIdElim``. These primitives
-expose underlying representation: terms of the cubical identity type can
-be thought of pairs consisting of a path `p` and a cofibration `φ`, such
-that, under the cofibration `φ`, the path `p` is the reflexivty path.
-These primitives are very low-level, and their use is not recommended.
-
-::
-
-  apId : ∀ {ℓ ℓ′} {A : Set ℓ} {B : Set ℓ′} (f : A → B)
-       → {x y : A} → Id x y → Id (f x) (f y)
-  apId f {x = x} = primIdElim (λ y _ → Id (f x) (f y))
-    λ φ y w → conid φ λ i → f (outS w i)
-
-Even though it is possible to define the reflexivity path using
-``conid``, the name ``reflId`` is special, in that it is treated as a
-"matchable" constructor, whereas ``conid`` is not. Depending on your
-syntax highlighting scheme, this can be observed using agda-mode: they
-are different colours. However, for computation, they are treated as the
-same:
-
-::
-
-  _ : ∀ {ℓ} {A : Set ℓ} {x : A} → reflId ≡ conid i1 (λ _ → x)
-  _ = refl
 
 .. _erased-cubical:
 

--- a/doc/user-manual/language/cubical.lagda.rst
+++ b/doc/user-manual/language/cubical.lagda.rst
@@ -260,15 +260,19 @@ While path types are great for reasoning about equality they don't let
 us transport along paths between types or even compose paths, which in
 particular means that we cannot yet prove the induction principle for
 paths. In order to remedy this we also have a built-in (generalized)
-transport operation `transp` and homogeneous composition operations `hcomp`. The
-transport operation is generalized in the sense that it lets us
-specify where it is the identity function.
+transport operation `transp` and homogeneous composition operations
+`hcomp`. The transport operation is generalized in the sense that it
+lets us specify where it is the identity function.
 
 .. code-block:: agda
 
   transp : ∀ {ℓ} (A : I → Set ℓ) (r : I) (a : A i0) → A i1
 
-There is an additional side condition to be satisfied for a usage of ``transp`` to type-check: ``A`` should be a constant function whenever the constraint ``r = i1`` is satisfied. By constant here we mean that ``A`` is definitionally equal to ``λ _ → A i0``, which in turn requires ``A i0`` and ``A i1`` to be definitionally equal as well.
+There is an additional side condition to be satisfied for a usage of
+``transp`` to type-check: ``A`` should be a constant function whenever
+the constraint ``r = i1`` is satisfied. By constant here we mean that
+``A`` is definitionally equal to ``λ _ → A i0``, which in turn
+requires ``A i0`` and ``A i1`` to be definitionally equal as well.
 
 When ``r`` is ``i1``, ``transp A r`` will compute as the identity function.
 
@@ -276,7 +280,8 @@ When ``r`` is ``i1``, ``transp A r`` will compute as the identity function.
 
    transp A i1 a = a
 
-This is only sound if in such a case ``A`` is a trivial path, as the side condition requires.
+This is only sound if in such a case ``A`` is a trivial path, as the
+side condition requires.
 
 It might seems strange that the side condition expects ``r`` and
 ``A`` to interact, but both of them can depend on any of the
@@ -285,8 +290,9 @@ can affect what ``A`` looks like.
 
 Some examples of the side condition for different values of ``r``:
 
-* If ``r`` is some in-scope variable ``i``, on which ``A`` may depend as well, then ``A`` only needs to be
-  a constant function when substituting ``i1`` for ``i``.
+* If ``r`` is some in-scope variable ``i``, on which ``A`` may depend
+  as well, then ``A`` only needs to be a constant function when
+  substituting ``i1`` for ``i``.
 
 * If ``r`` is ``i0`` then there is no restrition on ``A``, since the side
   condition is vacuously true.
@@ -369,7 +375,8 @@ when ``IsOne φ``.  There is also a dependent version of this called
 
   PartialP : ∀ {ℓ} → (φ : I) → Partial φ (Set ℓ) → SSet ℓ
 
-There is a new form of pattern matching that can be used to introduce partial elements:
+There is a new form of pattern matching that can be used to introduce
+partial elements:
 
 ::
 
@@ -377,9 +384,9 @@ There is a new form of pattern matching that can be used to introduce partial el
   partialBool i (i = i0) = true
   partialBool i (i = i1) = false
 
-The term ``partialBool i`` should be thought of a boolean with different
-values when ``(i = i0)`` and ``(i = i1)``. Terms of type ``Partial φ
-A`` can also be introduced using a :ref:`pattern-lambda`.
+The term ``partialBool i`` should be thought of a boolean with
+different values when ``(i = i0)`` and ``(i = i1)``. Terms of type
+``Partial φ A`` can also be introduced using a :ref:`pattern-lambda`.
 
 ::
 
@@ -437,9 +444,9 @@ They satisfy the following equalities:
   outS {φ = i1} {u} _ = u 1=1
 
 
-Note that given ``a : A [ φ ↦ u ]`` and ``α : IsOne φ``, it is not the case
-that ``outS a = u α``; however, underneath the pattern binding ``(φ = i1)``,
-one has ``outS a = u 1=1``.
+Note that given ``a : A [ φ ↦ u ]`` and ``α : IsOne φ``, it is not the
+case that ``outS a = u α``; however, underneath the pattern binding
+``(φ = i1)``, one has ``outS a = u 1=1``.
 
 With all of this cubical infrastructure we can now describe the
 ``hcomp`` operations.
@@ -981,7 +988,6 @@ References
 
   Thierry Coquand, Simon Huber, Anders Mörtberg; `"On Higher Inductive
   Types in Cubical Type Theory" <https://arxiv.org/abs/1802.01170>`_.
-
 
 .. _primitives-ref:
 


### PR DESCRIPTION
As the title explains this fixes https://github.com/agda/agda/issues/6234 by updating the documentation for Cubical Agda. The main changes are:

- The 1lab is now also linked (@plt-amy please check what I wrote and suggest improvements if necessary!).
- Some links were removed to make the page easier to maintain (the few Github links that are still there are now permalinks as requested in the original issue).
- I deleted the part on "Cubical identity types and computational HoTT/UF" as it is outdated.
- Shortened some long lines.

Warning: I don't know how to render and check this locally, if there is an easy way to do this please let me know.

Andreas (@andreasabel) writes: @mortberg PRs are rendered by readthedocs, see checks/readthedocs/details.
Rendering here: https://agda--6977.org.readthedocs.build/en/6977/language/cubical.html