### PR TITLE
[ fix #6976 ] Add constraint for resolving the head of an instance

### DIFF
--- a/src/full/Agda/Interaction/Base.hs
+++ b/src/full/Agda/Interaction/Base.hs
@@ -476,6 +476,7 @@ data OutputConstraint a b
       | IsEmptyType a
       | SizeLtSat a
       | FindInstanceOF b a [(a,a,a)]
+      | ResolveInstanceOF QName
       | PTSInstance b b
       | PostponedCheckFunDef QName a TCErr
       | CheckLock b b

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -242,6 +242,9 @@ encodeOC f encPrettyTCM = \case
           [ "value"  #= encPrettyTCM v
           , "type"   #= encPrettyTCM t
           ]
+ ResolveInstanceOF q -> kind "ResolveInstanceOF"
+  [ "name"           @= encodePretty q
+  ]
  PTSInstance a b -> kind "PTSInstance"
   [ "constraintObjs" #= traverse f [a, b]
   ]

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -23,7 +23,6 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.LevelConstraints
 import Agda.TypeChecking.SizedTypes
 import Agda.TypeChecking.Sort
-import Agda.TypeChecking.Telescope ( resolveInstanceHead )
 import Agda.TypeChecking.Warnings
 
 import Agda.TypeChecking.Irrelevance

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -23,6 +23,7 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.LevelConstraints
 import Agda.TypeChecking.SizedTypes
 import Agda.TypeChecking.Sort
+import Agda.TypeChecking.Telescope ( resolveInstanceHead )
 import Agda.TypeChecking.Warnings
 
 import Agda.TypeChecking.Irrelevance
@@ -289,6 +290,7 @@ solveConstraint_ (UnBlock m)                =   -- alwaysUnblock since these hav
       Open -> __IMPOSSIBLE__
       OpenInstance -> __IMPOSSIBLE__
 solveConstraint_ (FindInstance m cands) = findInstance m cands
+solveConstraint_ (ResolveInstanceHead q) = resolveInstanceHead q
 solveConstraint_ (CheckFunDef i q cs _err) = withoutCache $
   -- re #3498: checking a fundef would normally be cached, but here it's
   -- happening out of order so it would only corrupt the caching log.

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -113,6 +113,7 @@ instance MentionsMeta Constraint where
                                   -- problem and we don't have a handle on
                                   -- what metas it depends on
     FindInstance{}      -> True   -- this needs to be woken up for any meta
+    ResolveInstanceHead q -> True -- TODO
     IsEmpty r t         -> mm t
     CheckSizeLtSat t    -> mm t
     CheckFunDef{}       -> True   -- not sure what metas this depends on

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1205,6 +1205,8 @@ data Constraint
   | FindInstance MetaId (Maybe [Candidate])
     -- ^ the first argument is the instance argument and the second one is the list of candidates
     --   (or Nothing if we haven’t determined the list of candidates yet)
+  | ResolveInstanceHead QName
+    -- ^ Resolve the head symbol of the type that the given instance targets
   | CheckFunDef A.DefInfo QName [A.Clause] TCErr
     -- ^ Last argument is the error causing us to postpone.
   | UnquoteTactic Term Term Type   -- ^ First argument is computation and the others are hole and goal type
@@ -1239,6 +1241,7 @@ instance Free Constraint where
       IsEmpty _ t           -> freeVars' t
       CheckSizeLtSat u      -> freeVars' u
       FindInstance _ cs     -> freeVars' cs
+      ResolveInstanceHead q -> mempty
       CheckFunDef{}         -> mempty
       HasBiggerSort s       -> freeVars' s
       HasPTSRule a s        -> freeVars' (a , s)
@@ -1262,6 +1265,7 @@ instance TermLike Constraint where
       UnBlock _              -> mempty
       CheckLockedVars a b c d -> foldTerm f (a, b, c, d)
       FindInstance _ _       -> mempty
+      ResolveInstanceHead q  -> mempty
       CheckFunDef{}          -> mempty
       HasBiggerSort s        -> foldTerm f s
       HasPTSRule a s         -> foldTerm f (a, Sort <$> s)

--- a/src/full/Agda/TypeChecking/Monad/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Monad/Constraints.hs
@@ -191,6 +191,7 @@ addConstraintTo bucket unblock c = do
       SortCmp{}        -> False
       LevelCmp{}       -> False
       FindInstance{}   -> False
+      ResolveInstanceHead{} -> False
       HasBiggerSort{}  -> False
       HasPTSRule{}     -> False
       CheckDataSort{}  -> False

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -418,6 +418,7 @@ constraintMetas = \case
         -- We keep instance constraints even if the meta is solved, to check that it could indeed
         -- be filled by instance search. If it's solved, look in the solution.
         caseMaybeM (isInstantiatedMeta' x) (return $ Set.singleton x) $ return . allMetas Set.singleton
+      ResolveInstanceHead{}    -> return mempty
       IsEmpty{}                -> return mempty
       CheckFunDef{}            -> return mempty
       CheckSizeLtSat{}         -> return mempty

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -532,9 +532,9 @@ getAllInstanceDefs = do
 getAnonInstanceDefs :: TCM (Set QName)
 getAnonInstanceDefs = snd <$> getAllInstanceDefs
 
--- | Remove all instances whose type is still unresolved.
-clearAnonInstanceDefs :: TCM ()
-clearAnonInstanceDefs = modifyInstanceDefs $ mapSnd $ const Set.empty
+-- | Remove an instance from the set of unresolved instances.
+clearUnknownInstance :: QName -> TCM ()
+clearUnknownInstance q = modifyInstanceDefs $ mapSnd $ Set.delete q
 
 -- | Add an instance whose type is still unresolved.
 addUnknownInstance :: QName -> TCM ()

--- a/src/full/Agda/TypeChecking/Pretty/Constraint.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Constraint.hs
@@ -133,6 +133,8 @@ instance PrettyTCM Constraint where
                             prettyTCM (candidateType c) | c <- cnds ]
               where overlap c | candidateOverlappable c = "overlap"
                               | otherwise               = empty
+        ResolveInstanceHead q ->
+            "Resolve target type of instance: " <?> prettyTCM q
         IsEmpty r t ->
             "Is empty:" <?> prettyTCMCtx TopCtx t
         CheckSizeLtSat t ->

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -303,6 +303,7 @@ instance Instantiate Constraint where
   instantiate' (SortCmp cmp a b)    = uncurry (SortCmp cmp) <$> instantiate' (a,b)
   instantiate' (UnBlock m)          = return $ UnBlock m
   instantiate' (FindInstance m cs)  = FindInstance m <$> mapM instantiate' cs
+  instantiate' (ResolveInstanceHead q) = return $ ResolveInstanceHead q
   instantiate' (IsEmpty r t)        = IsEmpty r <$> instantiate' t
   instantiate' (CheckSizeLtSat t)   = CheckSizeLtSat <$> instantiate' t
   instantiate' c@CheckFunDef{}      = return c
@@ -959,6 +960,7 @@ instance Reduce Constraint where
   reduce' (SortCmp cmp a b)     = uncurry (SortCmp cmp) <$> reduce' (a,b)
   reduce' (UnBlock m)           = return $ UnBlock m
   reduce' (FindInstance m cs)   = FindInstance m <$> mapM reduce' cs
+  reduce' (ResolveInstanceHead q) = return $ ResolveInstanceHead q
   reduce' (IsEmpty r t)         = IsEmpty r <$> reduce' t
   reduce' (CheckSizeLtSat t)    = CheckSizeLtSat <$> reduce' t
   reduce' c@CheckFunDef{}       = return c
@@ -1125,6 +1127,7 @@ instance Simplify Constraint where
   simplify' (SortCmp cmp a b)     = uncurry (SortCmp cmp) <$> simplify' (a,b)
   simplify' (UnBlock m)           = return $ UnBlock m
   simplify' (FindInstance m cs)   = FindInstance m <$> mapM simplify' cs
+  simplify' (ResolveInstanceHead q) = return $ ResolveInstanceHead q
   simplify' (IsEmpty r t)         = IsEmpty r <$> simplify' t
   simplify' (CheckSizeLtSat t)    = CheckSizeLtSat <$> simplify' t
   simplify' c@CheckFunDef{}       = return c
@@ -1306,6 +1309,7 @@ instance Normalise Constraint where
   normalise' (SortCmp cmp a b)     = uncurry (SortCmp cmp) <$> normalise' (a,b)
   normalise' (UnBlock m)           = return $ UnBlock m
   normalise' (FindInstance m cs)   = FindInstance m <$> mapM normalise' cs
+  normalise' (ResolveInstanceHead q) = return $ ResolveInstanceHead q
   normalise' (IsEmpty r t)         = IsEmpty r <$> normalise' t
   normalise' (CheckSizeLtSat t)    = CheckSizeLtSat <$> normalise' t
   normalise' c@CheckFunDef{}       = return c
@@ -1546,6 +1550,7 @@ instance InstantiateFull Constraint where
     SortCmp cmp a b     -> uncurry (SortCmp cmp) <$> instantiateFull' (a,b)
     UnBlock m           -> return $ UnBlock m
     FindInstance m cs   -> FindInstance m <$> mapM instantiateFull' cs
+    ResolveInstanceHead q -> return $ ResolveInstanceHead q
     IsEmpty r t         -> IsEmpty r <$> instantiateFull' t
     CheckSizeLtSat t    -> CheckSizeLtSat <$> instantiateFull' t
     c@CheckFunDef{}     -> return c

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -34,6 +34,7 @@ import Agda.TypeChecking.Conversion
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Generalize
 import Agda.TypeChecking.Implicit
+import Agda.TypeChecking.InstanceArguments
 import Agda.TypeChecking.MetaVars
 import Agda.TypeChecking.Names
 import Agda.TypeChecking.Reduce

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -37,6 +37,7 @@ import Agda.TypeChecking.Conversion
 import Agda.TypeChecking.IApplyConfluence
 import Agda.TypeChecking.Generalize
 import Agda.TypeChecking.Injectivity
+import Agda.TypeChecking.InstanceArguments
 import Agda.TypeChecking.Level.Solve
 import Agda.TypeChecking.Positivity
 import Agda.TypeChecking.Positivity.Occurrence

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -47,6 +47,7 @@ import Agda.TypeChecking.With
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Telescope.Path
 import Agda.TypeChecking.Injectivity
+import Agda.TypeChecking.InstanceArguments
 import Agda.TypeChecking.SizedTypes.Solve
 import Agda.TypeChecking.Rewriting.Confluence
 import Agda.TypeChecking.CompiledClause (CompiledClauses'(..), hasProjectionPatterns)

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -30,6 +30,7 @@ import Agda.TypeChecking.Polarity
 import Agda.TypeChecking.Warnings
 import Agda.TypeChecking.CompiledClause (hasProjectionPatterns)
 import Agda.TypeChecking.CompiledClause.Compile
+import Agda.TypeChecking.InstanceArguments
 
 import Agda.TypeChecking.Rules.Data
   ( getGeneralizedParameters, bindGeneralizedParameters, bindParameters

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -41,7 +41,7 @@ import Agda.TypeChecking.Datatypes
 import Agda.TypeChecking.EtaContract
 import Agda.TypeChecking.Generalize
 import Agda.TypeChecking.Implicit
-import Agda.TypeChecking.InstanceArguments (solveAwakeInstanceConstraints)
+import Agda.TypeChecking.InstanceArguments
 import Agda.TypeChecking.Irrelevance
 import Agda.TypeChecking.IApplyConfluence
 import Agda.TypeChecking.Level

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1030,6 +1030,7 @@ instance Subst Constraint where
     IsEmpty r a              -> IsEmpty r (rf a)
     CheckSizeLtSat t         -> CheckSizeLtSat (rf t)
     FindInstance m cands     -> FindInstance m (rf cands)
+    ResolveInstanceHead q    -> ResolveInstanceHead (rf q)
     c@UnBlock{}              -> c
     c@CheckFunDef{}          -> c
     HasBiggerSort s          -> HasBiggerSort (rf s)

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -25,7 +25,6 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Free
-import Agda.TypeChecking.Warnings
 
 import Agda.Utils.CallStack ( withCallerCallStack )
 import Agda.Utils.Either
@@ -691,82 +690,3 @@ typeArity :: Type -> TCM Nat
 typeArity t = do
   TelV tel _ <- telView t
   return (size tel)
-
----------------------------------------------------------------------------
--- * Instance definitions
----------------------------------------------------------------------------
-
-data OutputTypeName
-  = OutputTypeName QName
-  | OutputTypeVar
-  | OutputTypeVisiblePi
-  | OutputTypeNameNotYetKnown Blocker
-  | NoOutputTypeName
-
--- | Strips all hidden and instance Pi's and return the argument
---   telescope and head definition name, if possible.
-getOutputTypeName :: Type -> TCM (Telescope, OutputTypeName)
--- 2023-10-26, Jesper, issue #6941: To make instance search work correctly for
--- abstract or opaque instances, we need to ignore abstract mode when computing
--- the output type name.
-getOutputTypeName t = ignoreAbstractMode $ do
-  TelV tel t' <- telViewUpTo' (-1) notVisible t
-  ifBlocked (unEl t') (\ b _ -> return (tel , OutputTypeNameNotYetKnown b)) $ \ _ v ->
-    case v of
-      -- Possible base types:
-      Def n _  -> return (tel , OutputTypeName n)
-      Sort{}   -> return (tel , NoOutputTypeName)
-      Var n _  -> return (tel , OutputTypeVar)
-      Pi{}     -> return (tel , OutputTypeVisiblePi)
-      -- Not base types:
-      Con{}    -> __IMPOSSIBLE__
-      Lam{}    -> __IMPOSSIBLE__
-      Lit{}    -> __IMPOSSIBLE__
-      Level{}  -> __IMPOSSIBLE__
-      MetaV{}  -> __IMPOSSIBLE__
-      DontCare{} -> __IMPOSSIBLE__
-      Dummy s _ -> __IMPOSSIBLE_VERBOSE__ s
-
-
--- | Register the definition with the given type as an instance.
---   Issue warnings if instance is unusable.
-addTypedInstance ::
-     MonadConstraint TCM
-  => QName  -- ^ Name of instance.
-  -> Type   -- ^ Type of instance.
-  -> TCM ()
-addTypedInstance = addTypedInstance' True
-
--- | Register the definition with the given type as an instance.
-addTypedInstance' ::
-     MonadConstraint TCM
-  => Bool   -- ^ Should we print warnings for unusable instance declarations?
-  -> QName  -- ^ Name of instance.
-  -> Type   -- ^ Type of instance.
-  -> TCM ()
-addTypedInstance' w x t = do
-  (tel , n) <- getOutputTypeName t
-  case n of
-    OutputTypeName n            -> addNamedInstance x n
-    OutputTypeNameNotYetKnown b -> do
-      addUnknownInstance x
-      addConstraint b $ ResolveInstanceHead x
-    NoOutputTypeName            -> when w $ warning $ WrongInstanceDeclaration
-    OutputTypeVar               -> when w $ warning $ WrongInstanceDeclaration
-    OutputTypeVisiblePi         -> when w $ warning $ InstanceWithExplicitArg x
-
-resolveInstanceHead :: MonadConstraint TCM => QName -> TCM ()
-resolveInstanceHead q = do
-    clearUnknownInstance q
-    -- Andreas, 2022-12-04, issue #6380:
-    -- Do not warn about unusable instances here.
-    addTypedInstance' False q =<< typeOfConst q
-
--- | Try to solve the instance definitions whose type is not yet known, report
---   an error if it doesn't work and return the instance table otherwise.
-getInstanceDefs :: TCM InstanceTable
-getInstanceDefs = do
-  insts <- getAllInstanceDefs
-  unless (null $ snd insts) $
-    typeError $ GenericError $ "There are instances whose type is still unsolved"
-  return $ fst insts

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -51,7 +51,7 @@ import Agda.TypeChecking.EtaContract
 import Agda.TypeChecking.Primitive
 import Agda.TypeChecking.ReconstructParameters
 import Agda.TypeChecking.CheckInternal
-import Agda.TypeChecking.InstanceArguments ( getInstanceCandidates )
+import Agda.TypeChecking.InstanceArguments
 
 import {-# SOURCE #-} Agda.TypeChecking.Rules.Term
 import {-# SOURCE #-} Agda.TypeChecking.Rules.Def

--- a/test/Succeed/Issue6976.agda
+++ b/test/Succeed/Issue6976.agda
@@ -1,0 +1,20 @@
+_∋_ : (A : Set) → A → A
+A ∋ x = x
+
+it : {A : Set} → ⦃ A ⦄ → A
+it ⦃ x ⦄ = x
+
+postulate DecidableEquality : Set → Set
+
+record DecEq (A : Set) : Set where
+  field _≟_ : DecidableEquality A
+
+module M where
+  postulate A : Set; _≟_ : DecidableEquality A
+
+instance
+  --DecEq-A : DecEq _
+  DecEq-A = DecEq _ ∋ record {M}
+    where putAnythingHere!! = Set
+
+-- _ = DecEq A ∋ it where open M

--- a/test/Succeed/Issue6976b.agda
+++ b/test/Succeed/Issue6976b.agda
@@ -1,0 +1,4 @@
+
+open import Issue6976
+
+_ = DecEq A ∋ it where open M


### PR DESCRIPTION
This fixes #6976 by adding a new constraint that ensures that the target type of each instance with a blocked type gets resolved eventually, and adds it to the instance table when that is the case.