### PR TITLE
Rewriting Error Refactor

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1495,6 +1495,13 @@ instance PrettyTCM TypeError where
         [ prettyTCM q , " is not a legal rewrite rule, since"
         , "it requires the definition(s) of", prettyList_ (map prettyTCM $ Set.toList qs)
         ]
+      DoesNotTargetRewriteRelation -> hsep
+        [ prettyTCM q , " does not target rewrite relation" ]
+      BeforeFunctionDefinition -> hsep
+        [ "Rewrite rule from function "
+        , prettyTCM q
+        , " cannot be added before the function definition"
+        ]
       EmptyReason -> hsep
         [ prettyTCM q , " is not a legal rewrite rule" ]
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -306,6 +306,7 @@ errorString err = case err of
   ComatchingDisabledForRecord{}            -> "ComatchingDisabledForRecord"
   BuiltinMustBeIsOne{}                     -> "BuiltinMustBeIsOne"
   IllegalRewriteRule{}                     -> "IllegalRewriteRule"
+  IncorrectTypeForRewriteRelation{}        -> "IncorrectTypeForRewriteRelation"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1497,6 +1498,20 @@ instance PrettyTCM TypeError where
       EmptyReason -> hsep
         [ prettyTCM q , " is not a legal rewrite rule" ]
 
+    IncorrectTypeForRewriteRelation v reason -> case reason of
+      ShouldAcceptAtLeastTwoArguments -> sep
+        [ prettyTCM v <+> " does not have the right type for a rewriting relation"
+        , "because it should accept at least two arguments"
+        ]
+      FinalTwoArgumentsNotVisible -> sep
+        [ prettyTCM v <+> " does not have the right type for a rewriting relation"
+        , "because its two final arguments are not both visible."
+        ]
+      TypeDoesNotEndInSort core tel -> sep
+        [ prettyTCM v <+> " does not have the right type for a rewriting relation"
+        , "because its type does not end in a sort, but in "
+          <+> do inTopContext $ addContext tel $ prettyTCM core
+        ]
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4615,6 +4615,7 @@ data TypeError
         | ComatchingDisabledForRecord QName
         | BuiltinMustBeIsOne Term
         | IllegalRewriteRule QName IllegalRewriteRuleReason
+        | IncorrectTypeForRewriteRelation Term IncorrectTypeForRewriteRelationReason
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError
@@ -4730,6 +4731,12 @@ data IllegalRewriteRuleReason
   | EmptyReason
     deriving (Show, Generic)
 
+-- Reason, why type for rewrite rule is incorrect
+data IncorrectTypeForRewriteRelationReason
+  = ShouldAcceptAtLeastTwoArguments
+  | FinalTwoArgumentsNotVisible
+  | TypeDoesNotEndInSort Type Telescope
+    deriving (Show, Generic)
 
 -- | Distinguish error message when parsing lhs or pattern synonym, resp.
 data LHSOrPatSyn = IsLHS | IsPatSyn
@@ -5787,3 +5794,4 @@ instance NFData LHSOrPatSyn
 instance NFData DataOrRecordE
 instance NFData InductionAndEta
 instance NFData IllegalRewriteRuleReason
+instance NFData IncorrectTypeForRewriteRelationReason

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -37,6 +37,8 @@ import Data.Function (on)
 import Data.Int
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
 import qualified Data.List as List
 import Data.Maybe
 import Data.Map (Map)
@@ -50,6 +52,8 @@ import qualified Data.HashSet as HashSet
 import Data.Hashable
 import Data.HashSet (HashSet)
 import Data.Semigroup ( Semigroup, (<>)) --, Any(..) )
+import Data.Set (Set)
+import qualified Data.Set as Set
 import Data.String
 import Data.Text (Text)
 import qualified Data.Text.Lazy as TL
@@ -4610,6 +4614,7 @@ data TypeError
         | TooManyArgumentsToUnivOmega QName
         | ComatchingDisabledForRecord QName
         | BuiltinMustBeIsOne Term
+        | IllegalRewriteRule QName IllegalRewriteRuleReason
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError
@@ -4708,6 +4713,23 @@ data InductionAndEta = InductionAndEta
   { recordInduction   :: Maybe Induction
   , recordEtaEquality :: EtaEquality
   } deriving (Show, Generic)
+
+-- Reason, why rewrite rule is invalid
+data IllegalRewriteRuleReason
+  = LHSNotDefOrConstr
+  | VariablesNotBoundByLHS IntSet
+  | VariablesBoundMoreThanOnce IntSet
+  | LHSReducesTo Term Term
+  | HeadSymbolIsProjection QName
+  | HeadSymbolIsProjectionLikeFunction QName
+  | HeadSymbolNotPostulateFunctionConstructor QName
+  | ConstructorParamsNotGeneral ConHead Args
+  | ContainsUnsolvedMetaVariables (Set MetaId)
+  | BlockedOnProblems (Set ProblemId)
+  | RequiresDefinitions (Set QName)
+  | EmptyReason
+    deriving (Show, Generic)
+
 
 -- | Distinguish error message when parsing lhs or pattern synonym, resp.
 data LHSOrPatSyn = IsLHS | IsPatSyn
@@ -5764,3 +5786,4 @@ instance NFData TypeError
 instance NFData LHSOrPatSyn
 instance NFData DataOrRecordE
 instance NFData InductionAndEta
+instance NFData IllegalRewriteRuleReason

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4728,6 +4728,8 @@ data IllegalRewriteRuleReason
   | ContainsUnsolvedMetaVariables (Set MetaId)
   | BlockedOnProblems (Set ProblemId)
   | RequiresDefinitions (Set QName)
+  | DoesNotTargetRewriteRelation
+  | BeforeFunctionDefinition
   | EmptyReason
     deriving (Show, Generic)
 

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -203,8 +203,6 @@ checkRewriteRule q = do
     , prettyTCM gamma1
     , " |- " <+> do addContext gamma1 $ prettyTCM core
     ]
-  let failureWrongTarget :: TCM a
-      failureWrongTarget = typeError $ IllegalRewriteRule q DoesNotTargetRewriteRelation
   let failureBlocked :: Blocker -> TCM a
       failureBlocked b
         | not (null ms) = typeError $ IllegalRewriteRule q (ContainsUnsolvedMetaVariables ms)
@@ -215,8 +213,6 @@ checkRewriteRule q = do
           ms = allBlockingMetas b
           ps = allBlockingProblems b
           qs = allBlockingDefs b
-  let failureNotDefOrCon :: TCM a
-      failureNotDefOrCon = typeError $ IllegalRewriteRule q LHSNotDefOrConstr
   let failureFreeVars :: IntSet -> TCM a
       failureFreeVars xs = typeError $ IllegalRewriteRule q (VariablesNotBoundByLHS xs)
   let failureNonLinearPars :: IntSet -> TCM a
@@ -258,7 +254,7 @@ checkRewriteRule q = do
           ~(Just ((_ , _ , pars) , t)) <- getFullyAppliedConType c $ unDom b
           pars <- addContext gamma1 $ checkParametersAreGeneral c pars
           return (conName c , hd , t , pars , vs)
-        _        -> failureNotDefOrCon
+        _        -> typeError $ IllegalRewriteRule q LHSNotDefOrConstr
 
       ifNotAlreadyAdded f $ do
 
@@ -312,7 +308,7 @@ checkRewriteRule q = do
 
         return rew
 
-    _ -> failureWrongTarget
+    _ -> typeError $ IllegalRewriteRule q DoesNotTargetRewriteRelation
 
   where
     checkNoLhsReduction :: QName -> (Elims -> Term)  -> Elims -> TCM ()

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -195,11 +195,7 @@ checkRewriteRule q = do
   -- Issue 1651: Check that we are not adding a rewrite rule
   -- for a type signature whose body has not been type-checked yet.
   when (isEmptyFunction $ theDef def) $
-    typeError . GenericDocError =<< hsep
-      [ "Rewrite rule from function "
-      , prettyTCM q
-      , " cannot be added before the function definition"
-      ]
+    typeError $ IllegalRewriteRule q BeforeFunctionDefinition
   -- Get rewrite rule (type of q).
   TelV gamma1 core <- telView $ defType def
   reportSDoc "rewriting" 30 $ vcat
@@ -208,8 +204,7 @@ checkRewriteRule q = do
     , " |- " <+> do addContext gamma1 $ prettyTCM core
     ]
   let failureWrongTarget :: TCM a
-      failureWrongTarget = typeError . GenericDocError =<< hsep
-        [ prettyTCM q , " does not target rewrite relation" ]
+      failureWrongTarget = typeError $ IllegalRewriteRule q DoesNotTargetRewriteRelation
   let failureBlocked :: Blocker -> TCM a
       failureBlocked b
         | not (null ms) = typeError $ IllegalRewriteRule q (ContainsUnsolvedMetaVariables ms)


### PR DESCRIPTION
Refactor `GenericDocError`-s for concrete ones in `TypeChecking/Rewriting.hs`

- introduce `IllegalRewriteRule`: this error has a parameter for reason why the rewrite rule is illegal, this moves the error message definition to `Errors.hs`
- introduce `IncorrectTypeForRewriteRule`: similar to the previous with regards to the reason parameter