### PR TITLE
Ad #6863: update `agda --version` output to new cabal flags

### DIFF
--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -282,10 +282,16 @@ printVersion backends PrintAgdaVersion = do
     "enable-cluster-counting: unicode cluster counting in LaTeX backend using the ICU library" :
 #endif
 #ifdef OPTIMISE_HEAVILY
-    "optimise-heavily: extra optimizations" :
+    "optimise-heavily: extra optimisations" :
 #endif
 #ifdef DEBUG
-    "debug: extra debug info" :
+    "debug: enable debug printing ('-v' verbosity flags)" :
+#endif
+#ifdef DEBUG_PARSING
+    "debug-parsing: enable printing grammars for operator parsing via '-v scope.grammar:10'"
+#endif
+#ifdef DEBUG_SERIALISATION
+    "debug-serialisation: extra debug info during serialisation into '.agdai' files"
 #endif
     []
 

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -365,7 +365,7 @@ buildParsers kind exprNames = do
               }
 
     -- Andreas, 2020-06-03 #4712
-    -- Note: needs Agda to be compiled with DEBUG to print the grammar.
+    -- Note: needs Agda to be compiled with DEBUG_PARSING to print the grammar.
     reportSDoc "scope.grammar" 10 $ return $
       "Operator grammar:" $$ nest 2 (grammar (pTop g))
 


### PR DESCRIPTION
Would be good if `cabal` provided introspection into the `.cabal` file
of an app for that app, then we could keep this in sync consistently.
