### PR TITLE
CI deploy breaks with GHC 9.4.8 so stay on 9.4.7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,44 +37,44 @@ jobs:
         sha="$(git rev-parse --short=7 HEAD)"
         nightly=Agda-nightly
 
-        echo sha="${sha}"                                           >> ${GITHUB_OUTPUT}
-        echo nightly="${nightly}"                                   >> ${GITHUB_OUTPUT}
+        echo sha="${sha}"                                           >> "${GITHUB_OUTPUT}"
+        echo nightly="${nightly}"                                   >> "${GITHUB_OUTPUT}"
 
         if [[ "$OSTYPE" == "msys"* ]]; then
 
           filename="${nightly}-win64.zip"
-          echo args="${ARGS} ${WIN64_ARGS}"                         >> ${GITHUB_OUTPUT}
-          echo compress-cmd="7z a ${filename} ${nightly} -bb -mx=9" >> ${GITHUB_OUTPUT}
-          echo content-type="application/zip"                       >> ${GITHUB_OUTPUT}
-          echo exe="agda.exe"                                       >> ${GITHUB_OUTPUT}
-          echo filename="${filename}"                               >> ${GITHUB_OUTPUT}
+          echo args="${ARGS} ${WIN64_ARGS}"                         >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="7z a ${filename} ${nightly} -bb -mx=9" >> "${GITHUB_OUTPUT}"
+          echo content-type="application/zip"                       >> "${GITHUB_OUTPUT}"
+          echo exe="agda.exe"                                       >> "${GITHUB_OUTPUT}"
+          echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
         elif [[ "$OSTYPE" == "darwin"* ]]; then
 
           filename="${nightly}-macOS.tar.xz"
-          echo args="${ARGS} ${MACOS_ARGS}"                         >> ${GITHUB_OUTPUT}
-          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> ${GITHUB_OUTPUT}
-          echo content-type="application/x-xz"                      >> ${GITHUB_OUTPUT}
-          echo exe="agda"                                           >> ${GITHUB_OUTPUT}
-          echo filename="${filename}"                               >> ${GITHUB_OUTPUT}
+          echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> "${GITHUB_OUTPUT}"
+          echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"
+          echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
+          echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
         elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 
           filename="${nightly}-linux.tar.xz"
-          echo args="${ARGS} ${LINUX_ARGS}"                         >> ${GITHUB_OUTPUT}
-          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> ${GITHUB_OUTPUT}
-          echo content-type="application/x-xz"                      >> ${GITHUB_OUTPUT}
-          echo exe="agda"                                           >> ${GITHUB_OUTPUT}
-          echo filename="${filename}"                               >> ${GITHUB_OUTPUT}
+          echo args="${ARGS} ${LINUX_ARGS}"                         >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> "${GITHUB_OUTPUT}"
+          echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"
+          echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
+          echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
         fi
     - name: Display build variables
       run: |
-        echo args         = ${{ steps.vars.outputs.args         }}
-        echo compress-cmd = ${{ steps.vars.outputs.compress-cmd }}
-        echo content-type = ${{ steps.vars.outputs.content-type }}
-        echo filename     = ${{ steps.vars.outputs.filename     }}
-        echo nightly      = ${{ steps.vars.outputs.nightly      }}
+        echo "args         = ${{ steps.vars.outputs.args         }}"
+        echo "compress-cmd = ${{ steps.vars.outputs.compress-cmd }}"
+        echo "content-type = ${{ steps.vars.outputs.content-type }}"
+        echo "filename     = ${{ steps.vars.outputs.filename     }}"
+        echo "nightly      = ${{ steps.vars.outputs.nightly      }}"
     - id: setup-haskell
       uses: haskell-actions/setup@v2
       with:
@@ -142,7 +142,7 @@ jobs:
 
           find dist-newstyle/build \( -name 'agda.exe' -o -name 'agda-mode.exe' \) -type f -exec cp {} "${nightly}"/bin \;
           cp -a .github/*.bat "${nightly}"
-          cp ${DLL} "${nightly}"/bin/
+          cp "${DLL}" "${nightly}"/bin/
           ## Issue #6926: strip.exe not installed there.
           ## Stripping step is optional, so we skip it.
           # C:/ProgramData/Chocolatey/bin/strip.exe "${nightly}"/bin/*
@@ -162,21 +162,21 @@ jobs:
           # 3. the default location of system-wide icu4c installed by homebrew, ie. /usr/local/opt/icu4c/lib
           #
           mkdir "${nightly}"/lib
-          cp ${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib ${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib ${ICU_DIR}/libicudata.${ICU_MAJOR_VER}.dylib "${nightly}"/lib
-          install_name_tool -change ${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib @rpath/libicuuc.${ICU_MAJOR_VER}.dylib "${nightly}"/bin/agda
-          install_name_tool -change ${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib @rpath/libicui18n.${ICU_MAJOR_VER}.dylib "${nightly}"/bin/agda
-          install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath ${ICU_DIR} "${nightly}"/bin/agda
+          cp "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicudata.${ICU_MAJOR_VER}.dylib" "${nightly}"/lib
+          install_name_tool -change "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "@rpath/libicuuc.${ICU_MAJOR_VER}.dylib" "${nightly}"/bin/agda
+          install_name_tool -change "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "@rpath/libicui18n.${ICU_MAJOR_VER}.dylib" "${nightly}"/bin/agda
+          install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath "${ICU_DIR}" "${nightly}"/bin/agda
           otool -L "${nightly}"/bin/agda
 
           fi
         fi
 
-        file ${{ steps.vars.outputs.nightly }}/bin/agda
+        file "${{ steps.vars.outputs.nightly }}/bin/agda"
     - if: ${{ runner.os != 'macOS' }}
       name: Compress the Agda executable
       uses: svenstaro/upx-action@v2
       with:
-        file: ${{ steps.vars.outputs.nightly }}/bin/${{ steps.vars.outputs.exe }}
+        files: ${{ steps.vars.outputs.nightly }}/bin/${{ steps.vars.outputs.exe }}
         strip: false
     - name: Display the version information
       run: |
@@ -196,7 +196,7 @@ jobs:
         ghc-ver:
         - '9.8'
         include:
-        - ghc-ver: '9.4'
+        - ghc-ver: 9.4.7
           os: ubuntu-20.04
         os:
         - windows-latest

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -40,9 +40,10 @@ jobs:
         # Atm, building static executables with GHC 9.4 is broken on ubuntu-22.04,
         # so, we downgrade to ubuntu-20.04.
         # Andreas, 2023-03-16: GHC 9.6 does not seem to do static linking even on ubuntu-20.04.
+        # Andreas, 2023-11-12: GHC 9.4.8 also fails to do static linking on ubuntu-20.04.
         include:
           - os: ubuntu-20.04
-            ghc-ver: '9.4'
+            ghc-ver: '9.4.7'
 
     env:
       ARGS: "--disable-executable-profiling --disable-library-profiling"
@@ -70,45 +71,45 @@ jobs:
         sha="$(git rev-parse --short=7 HEAD)"
         nightly=Agda-nightly
 
-        echo sha="${sha}"                                           >> ${GITHUB_OUTPUT}
-        echo nightly="${nightly}"                                   >> ${GITHUB_OUTPUT}
+        echo sha="${sha}"                                           >> "${GITHUB_OUTPUT}"
+        echo nightly="${nightly}"                                   >> "${GITHUB_OUTPUT}"
 
         if [[ "$OSTYPE" == "msys"* ]]; then
 
           filename="${nightly}-win64.zip"
-          echo args="${ARGS} ${WIN64_ARGS}"                         >> ${GITHUB_OUTPUT}
-          echo compress-cmd="7z a ${filename} ${nightly} -bb -mx=9" >> ${GITHUB_OUTPUT}
-          echo content-type="application/zip"                       >> ${GITHUB_OUTPUT}
-          echo exe="agda.exe"                                       >> ${GITHUB_OUTPUT}
-          echo filename="${filename}"                               >> ${GITHUB_OUTPUT}
+          echo args="${ARGS} ${WIN64_ARGS}"                         >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="7z a ${filename} ${nightly} -bb -mx=9" >> "${GITHUB_OUTPUT}"
+          echo content-type="application/zip"                       >> "${GITHUB_OUTPUT}"
+          echo exe="agda.exe"                                       >> "${GITHUB_OUTPUT}"
+          echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
         elif [[ "$OSTYPE" == "darwin"* ]]; then
 
           filename="${nightly}-macOS.tar.xz"
-          echo args="${ARGS} ${MACOS_ARGS}"                         >> ${GITHUB_OUTPUT}
-          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> ${GITHUB_OUTPUT}
-          echo content-type="application/x-xz"                      >> ${GITHUB_OUTPUT}
-          echo exe="agda"                                           >> ${GITHUB_OUTPUT}
-          echo filename="${filename}"                               >> ${GITHUB_OUTPUT}
+          echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> "${GITHUB_OUTPUT}"
+          echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"
+          echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
+          echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
         elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 
           filename="${nightly}-linux.tar.xz"
-          echo args="${ARGS} ${LINUX_ARGS}"                         >> ${GITHUB_OUTPUT}
-          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> ${GITHUB_OUTPUT}
-          echo content-type="application/x-xz"                      >> ${GITHUB_OUTPUT}
-          echo exe="agda"                                           >> ${GITHUB_OUTPUT}
-          echo filename="${filename}"                               >> ${GITHUB_OUTPUT}
+          echo args="${ARGS} ${LINUX_ARGS}"                         >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> "${GITHUB_OUTPUT}"
+          echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"
+          echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
+          echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
         fi
 
     - name: Display build variables
       run: |
-        echo args         = ${{ steps.vars.outputs.args         }}
-        echo compress-cmd = ${{ steps.vars.outputs.compress-cmd }}
-        echo content-type = ${{ steps.vars.outputs.content-type }}
-        echo filename     = ${{ steps.vars.outputs.filename     }}
-        echo nightly      = ${{ steps.vars.outputs.nightly      }}
+        echo "args         = ${{ steps.vars.outputs.args         }}"
+        echo "compress-cmd = ${{ steps.vars.outputs.compress-cmd }}"
+        echo "content-type = ${{ steps.vars.outputs.content-type }}"
+        echo "filename     = ${{ steps.vars.outputs.filename     }}"
+        echo "nightly      = ${{ steps.vars.outputs.nightly      }}"
 
     - uses: haskell-actions/setup@v2
       id: setup-haskell
@@ -219,7 +220,7 @@ jobs:
 
           find dist-newstyle/build \( -name 'agda.exe' -o -name 'agda-mode.exe' \) -type f -exec cp {} "${nightly}"/bin \;
           cp -a .github/*.bat "${nightly}"
-          cp ${DLL} "${nightly}"/bin/
+          cp "${DLL}" "${nightly}"/bin/
           ## Issue #6926: strip.exe not installed there.
           ## Stripping step is optional, so we skip it.
           # C:/ProgramData/Chocolatey/bin/strip.exe "${nightly}"/bin/*
@@ -239,16 +240,16 @@ jobs:
           # 3. the default location of system-wide icu4c installed by homebrew, ie. /usr/local/opt/icu4c/lib
           #
           mkdir "${nightly}"/lib
-          cp ${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib ${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib ${ICU_DIR}/libicudata.${ICU_MAJOR_VER}.dylib "${nightly}"/lib
-          install_name_tool -change ${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib @rpath/libicuuc.${ICU_MAJOR_VER}.dylib "${nightly}"/bin/agda
-          install_name_tool -change ${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib @rpath/libicui18n.${ICU_MAJOR_VER}.dylib "${nightly}"/bin/agda
-          install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath ${ICU_DIR} "${nightly}"/bin/agda
+          cp "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicudata.${ICU_MAJOR_VER}.dylib" "${nightly}"/lib
+          install_name_tool -change "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "@rpath/libicuuc.${ICU_MAJOR_VER}.dylib" "${nightly}"/bin/agda
+          install_name_tool -change "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "@rpath/libicui18n.${ICU_MAJOR_VER}.dylib" "${nightly}"/bin/agda
+          install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath "${ICU_DIR}" "${nightly}"/bin/agda
           otool -L "${nightly}"/bin/agda
 
           fi
         fi
 
-        file ${{ steps.vars.outputs.nightly }}/bin/agda
+        file "${{ steps.vars.outputs.nightly }}/bin/agda"
 
     - name: Compress the Agda executable
       # UPX does not support macOS Big Sur.
@@ -258,7 +259,7 @@ jobs:
       if: ${{ runner.os != 'macOS' }}
       uses: svenstaro/upx-action@v2
       with:
-        file: ${{ steps.vars.outputs.nightly }}/bin/${{ steps.vars.outputs.exe }}
+        files: ${{ steps.vars.outputs.nightly }}/bin/${{ steps.vars.outputs.exe }}
         strip: false
 
     - name: Display the version information


### PR DESCRIPTION
Also fix some warnings (deprecation and shell-check)
