### PR TITLE
Data Error Refactor

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -307,6 +307,7 @@ errorString err = case err of
   BuiltinMustBeIsOne{}                     -> "BuiltinMustBeIsOne"
   IllegalRewriteRule{}                     -> "IllegalRewriteRule"
   IncorrectTypeForRewriteRelation{}        -> "IncorrectTypeForRewriteRelation"
+  UnexpectedParameter{}                    -> "UnexpectedParameter"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1519,6 +1520,9 @@ instance PrettyTCM TypeError where
         , "because its type does not end in a sort, but in "
           <+> do inTopContext $ addContext tel $ prettyTCM core
         ]
+
+    UnexpectedParameter par -> do
+      text "Unexpected parameter" <+> prettyA par
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -309,6 +309,7 @@ errorString err = case err of
   IncorrectTypeForRewriteRelation{}        -> "IncorrectTypeForRewriteRelation"
   UnexpectedParameter{}                    -> "UnexpectedParameter"
   NoParameterOfName{}                      -> "NoParameterOfName"
+  UnexpectedModalityAnnotationInParameter{} -> "UnexpectedModalityAnnotationInParameter"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1527,6 +1528,9 @@ instance PrettyTCM TypeError where
 
     NoParameterOfName x -> do
       text ("No parameter of name " ++ x)
+
+    UnexpectedModalityAnnotationInParameter par -> do
+      text "Unexpected modality/relevance annotation in" <+> prettyA par
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -308,6 +308,7 @@ errorString err = case err of
   IllegalRewriteRule{}                     -> "IllegalRewriteRule"
   IncorrectTypeForRewriteRelation{}        -> "IncorrectTypeForRewriteRelation"
   UnexpectedParameter{}                    -> "UnexpectedParameter"
+  NoParameterOfName{}                      -> "NoParameterOfName"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1523,6 +1524,9 @@ instance PrettyTCM TypeError where
 
     UnexpectedParameter par -> do
       text "Unexpected parameter" <+> prettyA par
+
+    NoParameterOfName x -> do
+      text ("No parameter of name " ++ x)
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -313,6 +313,7 @@ errorString err = case err of
   SortDoesNotAdmitDataDefinitions{}        -> "SortDoesNotAdmitDataDefinitions"
   SortCannotDependOnItsIndex{}             -> "SortCannotDependOnItsIndex"
   ExpectedBindingForParameter{}            -> "ExpectedBindingForParameter"
+  UnexpectedTypeSignatureForParameter{}    -> "UnexpectedTypeSignatureForParameter"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1553,6 +1554,11 @@ instance PrettyTCM TypeError where
       [ "Expected binding for parameter"
       , text (absName b) <+> text ":" <+> prettyTCM (unDom a)
       ]
+
+    UnexpectedTypeSignatureForParameter xs -> do
+      let s | length xs > 1 = "s"
+            | otherwise     = ""
+      text ("Unexpected type signature for parameter" ++ s) <+> sep (fmap prettyA xs)
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -311,6 +311,7 @@ errorString err = case err of
   NoParameterOfName{}                      -> "NoParameterOfName"
   UnexpectedModalityAnnotationInParameter{} -> "UnexpectedModalityAnnotationInParameter"
   SortDoesNotAdmitDataDefinitions{}        -> "SortDoesNotAdmitDataDefinitions"
+  SortCannotDependOnItsIndex{}             -> "SortCannotDependOnItsIndex"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1539,6 +1540,12 @@ instance PrettyTCM TypeError where
       , "of"
       , prettyTCM name
       , "does not admit data or record declarations"
+      ]
+
+    SortCannotDependOnItsIndex name t -> fsep
+      [ "The sort of" <+> prettyTCM name
+      , "cannot depend on its indices in the type"
+      , prettyTCM t
       ]
 
     where

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -312,6 +312,7 @@ errorString err = case err of
   UnexpectedModalityAnnotationInParameter{} -> "UnexpectedModalityAnnotationInParameter"
   SortDoesNotAdmitDataDefinitions{}        -> "SortDoesNotAdmitDataDefinitions"
   SortCannotDependOnItsIndex{}             -> "SortCannotDependOnItsIndex"
+  ExpectedBindingForParameter{}            -> "ExpectedBindingForParameter"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1546,6 +1547,11 @@ instance PrettyTCM TypeError where
       [ "The sort of" <+> prettyTCM name
       , "cannot depend on its indices in the type"
       , prettyTCM t
+      ]
+
+    ExpectedBindingForParameter a b -> sep
+      [ "Expected binding for parameter"
+      , text (absName b) <+> text ":" <+> prettyTCM (unDom a)
       ]
 
     where

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -310,6 +310,7 @@ errorString err = case err of
   UnexpectedParameter{}                    -> "UnexpectedParameter"
   NoParameterOfName{}                      -> "NoParameterOfName"
   UnexpectedModalityAnnotationInParameter{} -> "UnexpectedModalityAnnotationInParameter"
+  SortDoesNotAdmitDataDefinitions{}        -> "SortDoesNotAdmitDataDefinitions"
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of
@@ -1531,6 +1532,14 @@ instance PrettyTCM TypeError where
 
     UnexpectedModalityAnnotationInParameter par -> do
       text "Unexpected modality/relevance annotation in" <+> prettyA par
+
+    SortDoesNotAdmitDataDefinitions name s ->fsep
+      [ "The universe"
+      , prettyTCM s
+      , "of"
+      , prettyTCM name
+      , "does not admit data or record declarations"
+      ]
 
     where
     mpar n args

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4621,6 +4621,7 @@ data TypeError
         | NoParameterOfName ArgName
         | UnexpectedModalityAnnotationInParameter A.LamBinding
         | SortDoesNotAdmitDataDefinitions QName Sort
+        | SortCannotDependOnItsIndex QName Type
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4616,6 +4616,8 @@ data TypeError
         | BuiltinMustBeIsOne Term
         | IllegalRewriteRule QName IllegalRewriteRuleReason
         | IncorrectTypeForRewriteRelation Term IncorrectTypeForRewriteRelationReason
+    -- Data errors
+        | UnexpectedParameter A.LamBinding
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4618,6 +4618,7 @@ data TypeError
         | IncorrectTypeForRewriteRelation Term IncorrectTypeForRewriteRelationReason
     -- Data errors
         | UnexpectedParameter A.LamBinding
+        | NoParameterOfName ArgName
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4620,6 +4620,7 @@ data TypeError
         | UnexpectedParameter A.LamBinding
         | NoParameterOfName ArgName
         | UnexpectedModalityAnnotationInParameter A.LamBinding
+        | SortDoesNotAdmitDataDefinitions QName Sort
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4621,6 +4621,7 @@ data TypeError
         | NoParameterOfName ArgName
         | UnexpectedModalityAnnotationInParameter A.LamBinding
         | ExpectedBindingForParameter (Dom Type) (Abs Type)
+        | UnexpectedTypeSignatureForParameter (List1 (NamedArg A.Binder))
         | SortDoesNotAdmitDataDefinitions QName Sort
         | SortCannotDependOnItsIndex QName Type
     -- Coverage errors

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4619,6 +4619,7 @@ data TypeError
     -- Data errors
         | UnexpectedParameter A.LamBinding
         | NoParameterOfName ArgName
+        | UnexpectedModalityAnnotationInParameter A.LamBinding
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4620,6 +4620,7 @@ data TypeError
         | UnexpectedParameter A.LamBinding
         | NoParameterOfName ArgName
         | UnexpectedModalityAnnotationInParameter A.LamBinding
+        | ExpectedBindingForParameter (Dom Type) (Abs Type)
         | SortDoesNotAdmitDataDefinitions QName Sort
         | SortCannotDependOnItsIndex QName Type
     -- Coverage errors

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1700,8 +1700,7 @@ bindParameters _ (A.DomainFull A.TLet{} : _) _ _ = __IMPOSSIBLE__
 
 bindParameters _ (par@(A.DomainFree _ arg) : ps) _ _
   | getModality arg /= defaultModality = setCurrentRange par $
-     typeError . GenericDocError =<< do
-       text "Unexpected modality/relevance annotation in" <+> prettyA par
+      typeError $ UnexpectedModalityAnnotationInParameter par
 
 bindParameters npars ps0@(par@(A.DomainFree _ arg) : ps) t ret = do
   let x          = namedArg arg

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1712,8 +1712,7 @@ bindParameters npars ps0@(par@(A.DomainFree _ arg) : ps) t ret = do
     BadImplicits   -> setCurrentRange par $
       typeError $ UnexpectedParameter par
     NoSuchName x   -> setCurrentRange par $
-      typeError . GenericDocError =<< do
-        text ("No parameter of name " ++ x)
+      typeError $ NoParameterOfName x
   where
     Pi dom@(Dom{domInfo = info', unDom = a}) b = unEl t -- TODO:: Defined but not used: info', a
     continue ps x = bindParameter npars ps x dom b ret

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1676,8 +1676,7 @@ bindParameters
 bindParameters 0 [] a ret = ret EmptyTel a
 
 bindParameters 0 (par : _) _ _ = setCurrentRange par $
-  typeError . GenericDocError =<< do
-    text "Unexpected parameter" <+> prettyA par
+  typeError $ UnexpectedParameter par
 
 bindParameters npars [] t ret =
   case unEl t of
@@ -1711,8 +1710,7 @@ bindParameters npars ps0@(par@(A.DomainFree _ arg) : ps) t ret = do
     NoInsertNeeded -> continue ps $ A.unBind $ A.binderName x
     ImpInsert _    -> continue ps0 =<< freshName_ (absName b)
     BadImplicits   -> setCurrentRange par $
-     typeError . GenericDocError =<< do
-       text "Unexpected parameter" <+> prettyA par
+      typeError $ UnexpectedParameter par
     NoSuchName x   -> setCurrentRange par $
       typeError . GenericDocError =<< do
         text ("No parameter of name " ++ x)

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1674,9 +1674,7 @@ bindParameters npars [] t ret =
               x <- freshName_ (absName b)
               bindParameter npars [] x a b ret
            | otherwise ->
-              typeError . GenericDocError =<<
-                sep [ "Expected binding for parameter"
-                    , text (absName b) <+> text ":" <+> prettyTCM (unDom a) ]
+              typeError $ ExpectedBindingForParameter a b
     _ -> __IMPOSSIBLE__
 
 bindParameters npars par@(A.DomainFull (A.TBind _ _ xs e) : bs) a ret =

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1679,10 +1679,7 @@ bindParameters npars [] t ret =
 
 bindParameters npars par@(A.DomainFull (A.TBind _ _ xs e) : bs) a ret =
   setCurrentRange par $
-  typeError . GenericDocError =<< do
-    let s | length xs > 1 = "s"
-          | otherwise     = ""
-    text ("Unexpected type signature for parameter" ++ s) <+> sep (fmap prettyA xs)
+  typeError $ UnexpectedTypeSignatureForParameter xs
 
 bindParameters _ (A.DomainFull A.TLet{} : _) _ _ = __IMPOSSIBLE__
 

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -217,13 +217,7 @@ checkDataSort name s = setCurrentRange name $ do
       yes :: TCM ()
       yes = return ()
       no  :: TCM ()
-      no  = typeError . GenericDocError =<<
-              fsep [ "The universe"
-                   , prettyTCM s
-                   , "of"
-                   , prettyTCM name
-                   , "does not admit data or record declarations"
-                   ]
+      no  = typeError $ SortDoesNotAdmitDataDefinitions name s
     case s of
       -- Sorts that admit data definitions.
       Univ _ _     -> yes

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -113,11 +113,7 @@ checkDataDef i name uc (A.DataDefParams gpars ps) cs =
               -- in case of a suspected dependency.
               s <- newSortMetaBelowInf
               catchError_ (addContext ixTel $ equalType s0 $ raise nofIxs $ sort s) $ \ err ->
-                  if any (`freeIn` s0) [0..nofIxs - 1] then typeError . GenericDocError =<<
-                     fsep [ "The sort of" <+> prettyTCM name
-                          , "cannot depend on its indices in the type"
-                          , prettyTCM t0
-                          ]
+                  if any (`freeIn` s0) [0..nofIxs - 1] then typeError $ SortCannotDependOnItsIndex name t0
                   else throwError err
               reduce s
 


### PR DESCRIPTION
Refactor `GenericDocError`-s for concrete ones in `TypeChecking/Rules/Data.hs`
- Introduce new types of type errors:
  - `UnexpectedParameter`
  - `NoParameterOfName`
  - `UnexpectedModalityAnnotationInParameter`
  - `ExpectedBindingForParameter`
  - `UnexpectedTypeSignatureForParameter`
  - `SortDoesNotAdmitDataDefinitions`
  - `SortCannotDependOnItsIndex`