### PR TITLE
Provide a `.agda-lib` for Agda builtins

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -108,6 +108,7 @@ data-files:
     JS/agda-rts.amd.js
     latex/agda.sty
     latex/postprocess-latex.pl
+    lib/prim/agda-builtins.agda-lib
     lib/prim/Agda/Builtin/Bool.agda
     lib/prim/Agda/Builtin/Char.agda
     lib/prim/Agda/Builtin/Char/Properties.agda

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -309,9 +309,9 @@ Imports and libraries
 
      .. versionadded:: 2.6.1
 
-     Read and write interface files next to the Agda files they
-     correspond to (i.e. do not attempt to regroup them in a
-     ``_build/`` directory at the project's root).
+     Prefer to read and write interface files next to the Agda files they
+     correspond to (i.e. do not attempt to regroup them in a ``_build/``
+     directory at the project's root, except if they already exist there).
 
 .. option:: --no-default-libraries
 

--- a/src/data/lib/prim/agda-builtins.agda-lib
+++ b/src/data/lib/prim/agda-builtins.agda-lib
@@ -1,0 +1,2 @@
+name: agda-builtins
+include: .

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -194,7 +194,10 @@ findProjectConfig' root = do
   getCachedProjectConfig root >>= \case
     Just conf -> return conf
     Nothing   -> do
-      libFiles <- liftIO $ filter ((== ".agda-lib") . takeExtension) <$> getDirectoryContents root
+      libFiles <- liftIO $ getDirectoryContents root >>=
+        filterM (\file -> and2M
+          (pure $ takeExtension file == ".agda-lib")
+          (doesFileExist (root </> file)))
       case libFiles of
         []     -> liftIO (upPath root) >>= \case
           Just up -> do

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -1476,7 +1476,7 @@ standardOptions =
     , Option []     ["ignore-interfaces"] (NoArg ignoreInterfacesFlag)
                     "ignore interface files (re-type check everything)"
     , Option []     ["local-interfaces"] (NoArg localInterfacesFlag)
-                    "put interface files next to the Agda files they correspond to"
+                    "put new interface files next to the Agda files they correspond to"
     , Option ['i']  ["include-path"] (ReqArg includeFlag "DIR")
                     "look for imports in DIR"
     , Option ['l']  ["library"] (ReqArg libraryFlag "LIB")

--- a/test/Fail/Issue641-all-interfaces.err
+++ b/test/Fail/Issue641-all-interfaces.err
@@ -20,7 +20,7 @@ Building interface...
 Finished serialization.
 Considering writing to interface file.
 Actually calling writeInterface.
-Writing interface file agda-default-include-path/Agda/Primitive.agdai.
+Writing interface file agda-default-include-path/_build/2.6.4.1/agda/Agda/Primitive.agdai.
 Wrote interface file.
 Finished writing to interface file.
 Accumulated statistics.
@@ -54,7 +54,7 @@ Building interface...
 Finished serialization.
 Considering writing to interface file.
 Actually calling writeInterface.
-Writing interface file agda-default-include-path/Agda/Primitive/Cubical.agdai.
+Writing interface file agda-default-include-path/_build/2.6.4.1/agda/Agda/Primitive/Cubical.agdai.
 Wrote interface file.
 Finished writing to interface file.
 Accumulated statistics.

--- a/test/Fail/Issue641.err
+++ b/test/Fail/Issue641.err
@@ -2,8 +2,8 @@ Importing the primitive modules.
   Getting interface for Agda.Primitive
   Check for cycle
   Agda.Primitive is up-to-date.
-  no stored version, reading agda-default-include-path/Agda/Primitive.agdai
-Loading  Agda.Primitive (agda-default-include-path/Agda/Primitive.agdai).
+  no stored version, reading agda-default-include-path/_build/2.6.4.1/agda/Agda/Primitive.agdai
+Loading  Agda.Primitive (agda-default-include-path/_build/2.6.4.1/agda/Agda/Primitive.agdai).
   imports: []
   New module. Let's check it out.
 Merging interface
@@ -11,8 +11,8 @@ Merging interface
   Getting interface for Agda.Primitive.Cubical
   Check for cycle
   Agda.Primitive.Cubical is up-to-date.
-  no stored version, reading agda-default-include-path/Agda/Primitive/Cubical.agdai
-Loading  Agda.Primitive.Cubical (agda-default-include-path/Agda/Primitive/Cubical.agdai).
+  no stored version, reading agda-default-include-path/_build/2.6.4.1/agda/Agda/Primitive/Cubical.agdai
+Loading  Agda.Primitive.Cubical (agda-default-include-path/_build/2.6.4.1/agda/Agda/Primitive/Cubical.agdai).
   imports: [(Agda.Primitive, 450520314077838934)]
   Already visited Agda.Primitive
   New module. Let's check it out.


### PR DESCRIPTION
In summary, this PR eliminates the performance problems caused by the path traversal used to find `.agda-lib` files which was reported in #4526, https://github.com/NixOS/cabal2nix/issues/447 and https://github.com/NixOS/nixpkgs/issues/83864. It continues the work of @gallais in #4616. In his PR the `Setup.hs` script still required some tweaking to create the interface files in the correct paths. Now, the `toIFile` function in `Setup.hs` implements the same logic as `Agda.Interaction.FindFile.toIFile` (except that the `--local-interfaces` option isn't handled).

I have tested these changes by running the test suit and used it during an Agda class in university. There are no related test cases in the current test suit. Thus, I didn't add any test cases for this behaviour but I'm open to add some if requested.

## Problematic options
When adding a `.agda-lib` file to the Agda builtins, #4613 reverses. So not using `--local-interfaces` would work when Agda is installed using the Nix package manager. However, when enabling `--local-interfaces`, Agda will try to write to the read-only Nix store. I can think of the following ways to resolve this issue:
- Do nothing. In this case the Agda builtins will be recompiled when `--local-interfaces` is in effect. This will render the `--local-interfaces` option useless if Agda is installed using the Nix package manager. This is not as bad as it sounds because, currently, flipping `--local-interfaces` on NixOS also doesn't work (the option is set by the nixpkgs wrapper for Agda).
- Let `--local-interfaces` only affect new interface files. In case the local or the separated interface file exists, the existing interface file will be used regardless of the `--local-interfaces` option. This would be backwards compatible (as far as I can tell) and would solve #4613 but may confuse users when they flip the `--local-interfaces` option without deleting the old interface files.
- Remove the `--local-interfaces` option. This is not backwards compatible. Though, I can't see any use case of `--local-interfaces` except for working around #4613 in nixpkgs. As noted in https://github.com/agda/agda/pull/4564#issuecomment-609057252, @gallais seems to prefer this approach.

Currently, I have implemented the second option for backwards compatibility. However, this doesn't conflict with the third option, for example after some deprecation period. I'm happy to amend the implementation if requested.

At first, I thought that `--no-libraries` would also break on NixOS but apparently it doesn't affect the interface location. In particular, if a `.agda-lib` file exists and the `--no-libraries` option is enabled, the interface file is still read and written to the separated interface file.

## History of a solution to #4526 and related issues
The first sketch of a fix for #4526 was proposed in #4564 but due to time constraints this PR was closed. A similar fix (which this PR is based on) is #4616. Both PRs attempt to add a `.agda-lib` file for the Agda builtins but differ in their solution to handling the local interface files of the builtins. Later @jespercockx added caching for the `.agda-lib` traversal in #4942 to reduce the runtime burden. Unfortunately, this caching is still too slow on my system (> 20s with Agda 2.6.4 vs. < 1s with this fix). Furthermore, there are issues with files accidentally ending with `.agda-lib` which can happen when using the Nix package manager as reported in #4613. Hence, the need for `--local-interfaces` on every invocation of Agda installed from nixpkgs which was introduced in https://github.com/NixOS/nixpkgs/pull/76653. Another ad-hoc solution was proposed in #6018 which hard coded the exclusion of the Nix store. However, hard coding the Nix store path is not a good idea, not least because the Nix store can actually be located at some different location.

There are also some ideas about choosing a single, fixed name for `.agda-lib` files (#6394) which would also eliminate the traversal overhead. However, in my opinion, such a change should be combined with adopting a more well-known configuration file format as suggested in #5553 if this is desired.
