### PR TITLE
Restore cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+packages:
+  .
+  src/size-solver
+
+write-ghc-environment-files: always

--- a/src/size-solver/cabal.project
+++ b/src/size-solver/cabal.project
@@ -1,0 +1,1 @@
+packages: .


### PR DESCRIPTION
Undoes #4321.  It is more uniform if each cabal project also has the
minimal `cabal.project` file `packages: .`.
This enables the project to be in a subtree of another project.
