### PR TITLE
[ emacs ] `string-trim` to combat recent change in `pp.el` adding newlines

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1702,7 +1702,7 @@ characters to the \\xNNNN notation used in Haskell strings."
   (let ((pp-escape-newlines t)
         (s2 (copy-sequence s)))
     (set-text-properties 0 (length s2) nil s2)
-    (mapconcat 'agda2-char-quote (pp-to-string s2) "")))
+    (mapconcat 'agda2-char-quote (string-trim (pp-to-string s2)) "")))
 
 (defun agda2-list-quote (strings)
   "Convert a list of STRINGS into a string representing it in Haskell syntax."


### PR DESCRIPTION
Fixes #6953 which reports the symptom and identifies `pp.el` as cause.
Closes #6983.
