### PR TITLE
[emacs] Drop dependency on pp module

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -34,7 +34,6 @@ Note that the same version of the Agda executable must be used.")
 
 (require 'cl-lib)
 (require 'compile)
-(require 'pp)
 (require 'time-date)
 (require 'eri)
 (require 'annotation)
@@ -1651,7 +1650,7 @@ text properties."
 (defun agda2-intersperse (sep xs)
   (let (ys)
     (while xs
-      (push (string-trim (pop xs)) ys)
+      (push (pop xs) ys)
       (push sep ys))
     (pop ys)
     (nreverse ys)))
@@ -1699,10 +1698,10 @@ points < 128) are converted to singleton strings."
 Removes any text properties, escapes newlines, double quotes,
 etc., adds surrounding double quotes, and converts non-ASCII
 characters to the \\xNNNN notation used in Haskell strings."
-  (let ((pp-escape-newlines t)
+  (let ((print-escape-newlines t)
         (s2 (copy-sequence s)))
     (set-text-properties 0 (length s2) nil s2)
-    (mapconcat 'agda2-char-quote (string-trim (pp-to-string s2)) "")))
+    (mapconcat 'agda2-char-quote (prin1-to-string s2) "")))
 
 (defun agda2-list-quote (strings)
   "Convert a list of STRINGS into a string representing it in Haskell syntax."


### PR DESCRIPTION
Use `prin1-to-string` and `print-escape-newlines` instead of `pp-to-string` and `pp-escape-newlines`. This should not require calls to `string-trim` and it should allow agda-mode to work for older emacsen.

Fixes #7005 and addresses properly #6954 and #6995.