### PR TITLE
Check the section application in `noMutualBlock`

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -931,7 +931,7 @@ checkSectionApplication'
   -> A.ScopeCopyInfo     -- ^ Imported names and modules
   -> TCM ()
 checkSectionApplication'
-  i er m1 (A.SectionApp ptel m2 args) copyInfo = do
+  i er m1 (A.SectionApp ptel m2 args) copyInfo = noMutualBlock $ do
   -- If the section application is erased, then hard compile-time mode
   -- is entered.
   warnForPlentyInHardCompileTimeMode er

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1687,7 +1687,7 @@ checkLetBinding (A.LetApply i erased x modapp copyInfo dir) ret = do
     , "module  =" <+> (prettyTCM =<< currentModule)
     , "fv      =" <+> text (show fv)
     ]
-  checkSectionApplication i erased x modapp copyInfo
+  noMutualBlock $ checkSectionApplication i erased x modapp copyInfo
     -- Some other part of the code ensures that "open public" is
     -- ignored in let expressions. Thus there is no need for
     -- checkSectionApplication to throw an error if the import

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1687,7 +1687,7 @@ checkLetBinding (A.LetApply i erased x modapp copyInfo dir) ret = do
     , "module  =" <+> (prettyTCM =<< currentModule)
     , "fv      =" <+> text (show fv)
     ]
-  noMutualBlock $ checkSectionApplication i erased x modapp copyInfo
+  checkSectionApplication i erased x modapp copyInfo
     -- Some other part of the code ensures that "open public" is
     -- ignored in let expressions. Thus there is no need for
     -- checkSectionApplication to throw an error if the import


### PR DESCRIPTION
Prompted by @knisht :
```agda
{-# OPTIONS -v term:40 #-}

module _ where

module M (A : Set) where
  postulate
    id : A → A

foo : (A : Set) → A → A
foo A = let open M A in id
```
The termination checker reports here:
```
Termination checking mutual block MutId 1
Termination checking {NoMutualBlockLetApply.foo, NoMutualBlockLetApply._.id}
```
Maybe we do not need the contents of `M A` in the mutual block for `foo`?

This PR makes the experiment to check the contents of `M A` in `noMutualBlock`.