### PR TITLE
Export EmacsTop.prettyResponseContext for agda-language-server

### DIFF
--- a/src/full/Agda/Interaction/EmacsTop.hs
+++ b/src/full/Agda/Interaction/EmacsTop.hs
@@ -6,6 +6,7 @@ module Agda.Interaction.EmacsTop
     , showGoals
     , showInfoError
     , explainWhyInScope
+    , prettyResponseContext
     , prettyTypeOfMeta
     ) where
 

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -424,7 +424,7 @@ invertFunction cmp blk (Inv f blkArgs hdMap) hd fallback err success = do
             [ "meta patterns" <+> prettyList (map prettyTCM ms)
             , "  perm =" <+> text (show perm)
             , "  tel  =" <+> prettyTCM tel
-            , "  ps   =" <+> prettyList (map (text . show) ps)
+            , "  ps   =" <+> prettyList (map (text . prettyShow) ps)
             ]
           -- and this is the order the variables occur in the patterns
           let msAux = permute (invertP __IMPOSSIBLE__ $ compactP perm) ms


### PR DESCRIPTION
- [ debug ] Injectivity: prettyShow instead of show
- Export EmacsTop.prettyResponseContext for agda-language-server (cherry-picked to 2.6.4.1 release)
