### PR TITLE
Add ⧺ in agda-input.el

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -302,6 +302,7 @@ order for the change to take effect."
   (":"         . ,(agda-input-to-string-list "∶⦂ː꞉˸፥፦：﹕︓"))
   (","         . ,(agda-input-to-string-list "ʻ،⸲⸴⹁⹉、︐︑﹐﹑，､"))
   (";"         . ,(agda-input-to-string-list "⨾⨟⁏፤꛶；︔﹔⍮⸵;"))
+  ("++"        . ("⧺"))
   ("::"        . ("∷"))
   ("::-"       . ("∺"))
   ("-:"        . ("∹"))


### PR DESCRIPTION
I often use the ⧺ symbol, and I believe others might as well. Therefore, I have added it to agda-input.el.