### PR TITLE
Fix issue 7029

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1485,6 +1485,10 @@ instance PrettyTCM TypeError where
         [ prettyTCM q , " is not a legal rewrite rule, since the head symbol"
         , prettyTCM f , "is not a postulate, a function, or a constructor"
         ]
+      HeadSymbolDefContainsMetas f -> hsep
+        [ prettyTCM q , "is not a legal rewrite rule, since the definition of the head symbol"
+        , prettyTCM f , "contains unsolved metavariables and confluence checking is enabled."
+        ]
       ConstructorParamsNotGeneral c vs -> vcat
         [ prettyTCM q <+> text " is not a legal rewrite rule, since the constructor parameters are not fully general:"
         , nest 2 $ text "Constructor: " <+> prettyTCM c

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4736,6 +4736,7 @@ data IllegalRewriteRuleReason
   | HeadSymbolIsProjection QName
   | HeadSymbolIsProjectionLikeFunction QName
   | HeadSymbolNotPostulateFunctionConstructor QName
+  | HeadSymbolDefContainsMetas QName
   | ConstructorParamsNotGeneral ConHead Args
   | ContainsUnsolvedMetaVariables (Set MetaId)
   | BlockedOnProblems (Set ProblemId)

--- a/test/Fail/Issue7029.agda
+++ b/test/Fail/Issue7029.agda
@@ -1,0 +1,13 @@
+{-# OPTIONS --rewriting --confluence-check --with-K #-}
+
+open import Agda.Builtin.Equality
+
+{-# BUILTIN REWRITE _≡_ #-}
+
+myrefl : ∀ {ℓ} {A : Set ℓ} {x : A} → x ≡ x
+myrefl = ?
+
+UIP : ∀ {ℓ} {A : Set ℓ} {x : A} → myrefl {ℓ} {A} {x} ≡ refl
+UIP with refl ← myrefl = refl
+
+{-# REWRITE UIP #-}

--- a/test/Fail/Issue7029.err
+++ b/test/Fail/Issue7029.err
@@ -1,0 +1,3 @@
+Issue7029.agda:13,1-20
+UIP is not a legal rewrite rule, since the definition of the head symbol myrefl contains unsolved metavariables and confluence checking is enabled.
+when checking the pragma REWRITE UIP


### PR DESCRIPTION
This fixes #7029 in the simplest way possible: just require that a function does not have unsolved metavariables when we add a rewrite rule to its definition.