### PR TITLE
Refactor `flake.nix`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+# Auto-load a development environment from flake.nix
+# when entering the root of the repository
+
+# This only affects users of the `direnv` tool
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,4 @@ stack*.yaml.lock
 trash.txt
 \#*\#
 .direnv
-
+result

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ stack.yaml
 stack*.yaml.lock
 trash.txt
 \#*\#
+.direnv
+

--- a/flake.lock
+++ b/flake.lock
@@ -17,16 +17,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680030621,
-        "narHash": "sha256-qQa1NeS5Rvk2lgK5lSk986PC6I72yIHejzM8PFu+dHs=",
+        "lastModified": 1702350026,
+        "narHash": "sha256-A+GNZFZdfl4JdDphYKBJ5Ef1HOiFsP18vQe9mqjmUis=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "402cc3633cc60dfc50378197305c984518b30773",
+        "rev": "9463103069725474698139ab10f17a9d125da859",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.lock
+++ b/flake.lock
@@ -17,16 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702350026,
-        "narHash": "sha256-A+GNZFZdfl4JdDphYKBJ5Ef1HOiFsP18vQe9mqjmUis=",
+        "lastModified": 1702346276,
+        "narHash": "sha256-eAQgwIWApFQ40ipeOjVSoK4TEHVd6nbSd9fApiHIw5A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9463103069725474698139ab10f17a9d125da859",
+        "rev": "cf28ee258fd5f9a52de6b9865cdb93a1f96d09b7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,20 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -31,9 +34,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,8 @@
       # TODO: also replace each haskell.packages.ghcXXX.agda
     };
     # Generate the overlays.default output from overlayAttrs above
+    # N.B. This overlay is EXPERIMENTAL and untested.
+    # Please report bugs to the Agda issue tracker.
     imports = [ inputs.flake-parts.flakeModules.easyOverlay ];
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   description = "Agda is a dependently typed programming language / interactive theorem prover.";
 
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, flake-utils }: (flake-utils.lib.eachDefaultSystem (system: let

--- a/flake.nix
+++ b/flake.nix
@@ -2,51 +2,61 @@
   description = "Agda is a dependently typed programming language / interactive theorem prover.";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.flake-parts.url = "github:hercules-ci/flake-parts";
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = inputs:
+      inputs.flake-parts.lib.mkFlake { inputs = inputs; } {
     # Support all the OSes
-    (flake-utils.lib.eachDefaultSystem (system: let
+    systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+    perSystem = {pkgs, ...}: let
+      hlib = pkgs.haskell.lib.compose;
+      hpkgs = pkgs.haskellPackages;
 
-    pkgs = nixpkgs.legacyPackages.${system};
-    hlib = pkgs.haskell.lib.compose;
-    hpkgs = pkgs.haskellPackages;
+      # The `agda` and `agda-mode` programs, built with `cabal build`
+      # (and GHC & Haskell libraries from the nixpkgs snapshot)
+      agda-pkg = hpkgs.developPackage {
+          root = ./.;
+          modifier = hlib.dontCheck;
+          # TODO Make check phase work
+          # At least requires:
+          #   Setting AGDA_BIN (or using the Makefile, which at least requires cabal-install)
+          #   Making agda-stdlib available (or disabling the relevant tests somehow)
+        };
 
-    # The `agda` and `agda-mode` programs, built with `cabal build`
-    # (and GHC & Haskell libraries from the nixpkgs snapshot)
-    agda-pkg = hpkgs.developPackage {
-        root = ./.;
-        modifier = hlib.dontCheck;
-        # TODO Make check phase work
-        # At least requires:
-        #   Setting AGDA_BIN (or using the Makefile, which at least requires cabal-install)
-        #   Making agda-stdlib available (or disabling the relevant tests somehow)
+      # Development environment with tools for hacking on agda
+      agda-dev-shell = hpkgs.shellFor {
+        # Which haskell packages to prepare a dev env for
+        packages = _: [agda-pkg];
+        # Extra software to provide in the dev shell
+        nativeBuildInputs = [
+            # Tools for building agda
+            pkgs.cabal-install
+            pkgs.haskell-language-server
+            hpkgs.fix-whitespace
+            # Tools for building the agda docs
+            (pkgs.python3.withPackages (py3pkgs: [
+              py3pkgs.sphinx
+              py3pkgs.sphinx_rtd_theme
+            ]))
+          ];
+
+        # Include an offline-usable `hoogle` command
+        # pre-loaded with all the haskell dependencies
+        withHoogle = true;
       };
 
-    # Development environment with tools for hacking on agda
-    agda-dev-shell = hpkgs.shellFor {
-      # Which haskell packages to prepare a dev env for
-      packages = _: [agda-pkg];
-      # Extra software to provide in the dev shell
-      nativeBuildInputs = [
-          # Tools for building agda
-          pkgs.cabal-install
-          pkgs.haskell-language-server
-          hpkgs.fix-whitespace
-          # Tools for building the agda docs
-          (pkgs.python3.withPackages (py3pkgs: [
-            py3pkgs.sphinx
-            py3pkgs.sphinx_rtd_theme
-          ]))
-        ];
+    in {
+      packages.default = agda-pkg;        # Entry point for `nix build`
+      devShells.default = agda-dev-shell; # Entry point for `nix develop`
 
-      # Include an offline-usable `hoogle` command
-      # pre-loaded with all the haskell dependencies
-      withHoogle = true;
+      # Allow power users to set this flake's agda
+      # as a drop-in replacement for nixpkgs's agda
+      # (including as a dependency of other nixpkgs packages)
+      # See https://flake.parts/overlays for more info
+      overlayAttrs.packages.haskellPackages.agda = agda-pkg;
+      # TODO: also replace each haskell.packages.ghcXXX.agda
     };
-
-  in {
-    packages.default = agda-pkg;        # Entry point for `nix build`
-    devShells.default = agda-dev-shell; # Entry point for `nix develop`
-  }));
+    # Generate the overlays.default output from overlayAttrs above
+    imports = [ inputs.flake-parts.flakeModules.easyOverlay ];
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,59 +4,49 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }: (flake-utils.lib.eachDefaultSystem (system: let
-    pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
-  in {
-    packages = {
-      inherit (pkgs.haskellPackages) Agda;
+  outputs = { self, nixpkgs, flake-utils }:
+    # Support all the OSes
+    (flake-utils.lib.eachDefaultSystem (system: let
 
-      # TODO agda2-mode
-    };
+    pkgs = nixpkgs.legacyPackages.${system};
+    hlib = pkgs.haskell.lib.compose;
+    hpkgs = pkgs.haskellPackages;
 
-    packages.default = self.packages.${system}.Agda;
-
-    devShells.default = pkgs.haskellPackages.shellFor {
-      packages = ps: with ps; [ Agda ];
-      nativeBuildInputs = with pkgs; [
-        cabal-install
-        haskell-language-server
-        haskellPackages.fix-whitespace
-
-        # documentation
-        (python3.withPackages (ps: with ps; [
-          sphinx
-          sphinx_rtd_theme
-        ]))
-      ];
-    };
-  })) // {
-    overlay = final: prev: {
-      haskellPackages = prev.haskellPackages.override {
-        overrides = self.haskellOverlay;
+    # The `agda` and `agda-mode` programs, built with `cabal build`
+    # (and GHC & Haskell libraries from the nixpkgs snapshot)
+    agda-pkg = hpkgs.developPackage {
+        root = ./.;
+        modifier = hlib.dontCheck;
+        # TODO Make check phase work
+        # At least requires:
+        #   Setting AGDA_BIN (or using the Makefile, which at least requires cabal-install)
+        #   Making agda-stdlib available (or disabling the relevant tests somehow)
       };
+
+    # Development environment with tools for hacking on agda
+    agda-dev-shell = hpkgs.shellFor {
+      # Which haskell packages to prepare a dev env for
+      packages = _: [agda-pkg];
+      # Extra software to provide in the dev shell
+      nativeBuildInputs = [
+          # Tools for building agda
+          pkgs.cabal-install
+          pkgs.haskell-language-server
+          hpkgs.fix-whitespace
+          # Tools for building the agda docs
+          (pkgs.python3.withPackages (py3pkgs: [
+            py3pkgs.sphinx
+            py3pkgs.sphinx_rtd_theme
+          ]))
+        ];
+
+      # Include an offline-usable `hoogle` command
+      # pre-loaded with all the haskell dependencies
+      withHoogle = true;
     };
 
-    haskellOverlay = final: prev: let
-      inherit (final) callCabal2nixWithOptions;
-
-      shortRev = builtins.substring 0 9 self.rev;
-
-      postfix = if self ? revCount then "${toString self.revCount}_${shortRev}" else "Dirty";
-    in {
-      # TODO use separate evaluation system?
-      Agda = callCabal2nixWithOptions "Agda" ./. "--flag enable-cluster-counting --flag optimise-heavily" ({
-        mkDerivation = args: final.mkDerivation (args // {
-          version = "${args.version}-pre${postfix}";
-
-          postInstall = "$out/bin/agda-mode compile";
-
-          # TODO Make check phase work
-          # At least requires:
-          #   Setting AGDA_BIN (or using the Makefile, which at least requires cabal-install)
-          #   Making agda-stdlib available (or disabling the relevant tests somehow)
-          doCheck = false;
-        });
-      });
-    };
-  };
+  in {
+    packages.default = agda-pkg;        # Entry point for `nix build`
+    devShells.default = agda-dev-shell; # Entry point for `nix develop`
+  }));
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,9 @@
       # TODO agda2-mode
     };
 
-    defaultPackage = self.packages.${system}.Agda;
+    packages.default = self.packages.${system}.Agda;
 
-    devShell = pkgs.haskellPackages.shellFor {
+    devShells.default = pkgs.haskellPackages.shellFor {
       packages = ps: with ps; [ Agda ];
       nativeBuildInputs = with pkgs; [
         cabal-install

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Agda is a dependently typed programming language / interactive theorem prover.";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, flake-utils }:


### PR DESCRIPTION

I use the `flake.nix` file for hacking on agda.

This PR makes the following changes:

* Add a `.envrc` file to auto-load the `flake.nix` when I enter the repository
  * This helps with e.g. Haskell VSCode integration
  * Only affects users of `direnv`
  * An alternative would be to add `.envrc` to the `.gitignore`, and let each developer write their own `.envrc`

* Refactor the `flake.nix` file
  * Replace the [deprecated attributes](https://github.com/NixOS/nix/issues/5532) `defaultPackage` and `devShell`
  * Explicitly track the `nixpkgs` dependency
    * This seems to be the convention for most flakes I have viewed
  * Add comments
  * Stop using a nixpkg overlay
    * Overlays are verbose & not newbie-friendly
    * [Overlays are overkill here, and do not scale well](https://zimbatm.com/notes/1000-instances-of-nixpkgs)
  * Misc. refactoring to reduce length

I am quite new to `nix`, so might have missed some subtleties in the design of the old `flake.nix`
(do @shlevy or @ncfavier have any feedback?)

I have tested the following features of `flake.nix`:

* `nix develop` starts a sub-shell with `cabal`,etc. where I can build agda
* `nix build` produces binaries in `result/bin/`
