### PR TITLE
fix recRecursive when record isn't recursive

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2960,7 +2960,7 @@ instance Pretty ProjLams where
 
 -- | Is the record type recursive?
 recRecursive :: Defn -> Bool
-recRecursive (Record { recMutual = Just qs }) = not $ null qs
+recRecursive (Record { recMutual = mqs }) = any (not . null) mqs
 recRecursive _ = __IMPOSSIBLE__
 
 recEtaEquality :: Defn -> HasEta


### PR DESCRIPTION
A bug in agda/agda2hs#257 is caused by it relying on `TypeChecking/Monad/Base:recRecursive` which may fail when `recMutual` is set to `Nothing`.