### PR TITLE
Unspine system projections when they have display forms

### DIFF
--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1049,12 +1049,12 @@ suggests (Suggestion x : xs) = fromMaybe (suggests xs) $ suggestName x
 
 -- | Convert top-level postfix projections into prefix projections.
 unSpine :: Term -> Term
-unSpine = unSpine' $ const True
+unSpine = unSpine' $ \_ _ -> True
 
 -- | Convert 'Proj' projection eliminations
 --   according to their 'ProjOrigin' into
 --   'Def' projection applications.
-unSpine' :: (ProjOrigin -> Bool) -> Term -> Term
+unSpine' :: (ProjOrigin -> QName -> Bool) -> Term -> Term
 unSpine' p v =
   case hasElims v of
     Just (h, es) -> loop h [] es
@@ -1063,9 +1063,9 @@ unSpine' p v =
     loop :: (Elims -> Term) -> Elims -> Elims -> Term
     loop h res es =
       case es of
-        []                   -> v
-        Proj o f : es' | p o -> loop (Def f) [Apply (defaultArg v)] es'
-        e        : es'       -> loop h (e : res) es'
+        []                     -> v
+        Proj o f : es' | p o f -> loop (Def f) [Apply (defaultArg v)] es'
+        e        : es'         -> loop h (e : res) es'
       where v = h $ reverse res
 
 -- | A view distinguishing the neutrals @Var@, @Def@, and @MetaV@ which

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -488,7 +488,7 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
 
   -- Amy, 2024-01-07: postfix and system projections should still be
   -- turned into head symbols *if* they have display forms attached.
-  hasDisplay <- unKleisliTCM hasDisplayForms
+  hasDisplay <- liftReduce $ unKleisli hasDisplayForms
   let
     prefixize orig name
       | havePfp   = (orig == ProjPrefix)  || hasDisplay name

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -481,12 +481,21 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
   -- Ulf 2014-07-10: Don't expand anonymous when display forms are disabled
   -- (i.e. when we don't care about nice printing)
   expandAnonDefs <- return expandAnonDefs0 `and2M` displayFormsEnabled
+
   -- Andreas, 2016-07-21 if --postfix-projections
   -- then we print system-generated projections as postfix, else prefix.
   havePfp <- optPostfixProjections <$> pragmaOptions
-  let pred = if havePfp then (== ProjPrefix) else (/= ProjPostfix)
-  reportSDoc "reify.term" 80 $ pure $ "reifyTerm (unSpine v) = " <+> pretty (unSpine' pred v)
-  case unSpine' pred v of
+
+  -- Amy, 2024-01-07: postfix and system projections should still be
+  -- turned into head symbols *if* they have display forms attached.
+  hasDisplay <- unKleisliTCM hasDisplayForms
+  let
+    prefixize orig name
+      | havePfp   = (orig == ProjPrefix)  || hasDisplay name
+      | otherwise = (orig /= ProjPostfix) || hasDisplay name
+  reportSDoc "reify.term" 80 $ pure $ "reifyTerm (unSpine v) = " <+> pretty (unSpine' prefixize v)
+
+  case unSpine' prefixize v of
     -- Hack to print generalized field projections with nicer names. Should
     -- only show up in errors. Check the spined form!
     _ | I.Var n (I.Proj _ p : es) <- v,

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4872,6 +4872,8 @@ reduceSt f s = f (redSt s) <&> \ e -> s { redSt = e }
 newtype ReduceM a = ReduceM { unReduceM :: ReduceEnv -> a }
 --  deriving (Functor, Applicative, Monad)
 
+unKleisli :: (a -> ReduceM b) -> ReduceM (a -> b)
+unKleisli f = ReduceM $ \ env x -> unReduceM (f x) env
 
 onReduceEnv :: (ReduceEnv -> ReduceEnv) -> ReduceM a -> ReduceM a
 onReduceEnv f (ReduceM m) = ReduceM (m . f)

--- a/src/full/Agda/TypeChecking/Monad/Pure.hs
+++ b/src/full/Agda/TypeChecking/Monad/Pure.hs
@@ -23,6 +23,8 @@ import Agda.TypeChecking.Monad.Signature
 import Agda.Utils.ListT
 import Agda.Utils.Update
 
+import System.IO.Unsafe
+
 class
   ( HasBuiltins m
   , HasConstInfo m
@@ -43,3 +45,9 @@ instance PureTCM m => PureTCM (MaybeT m)
 instance PureTCM m => PureTCM (ReaderT r m)
 instance (PureTCM m, Monoid w) => PureTCM (WriterT w m)
 instance PureTCM m => PureTCM (StateT s m)
+
+unKleisliTCM :: forall m a b. PureTCM m => (forall n. PureTCM n => a -> n b) -> m (a -> b)
+unKleisliTCM k = do
+  state <- getTCState
+  env <- askTC
+  pure $ \a -> unsafePerformIO (fst <$> runTCM env state (k a))

--- a/src/full/Agda/TypeChecking/Monad/Pure.hs
+++ b/src/full/Agda/TypeChecking/Monad/Pure.hs
@@ -23,8 +23,6 @@ import Agda.TypeChecking.Monad.Signature
 import Agda.Utils.ListT
 import Agda.Utils.Update
 
-import System.IO.Unsafe
-
 class
   ( HasBuiltins m
   , HasConstInfo m
@@ -45,9 +43,3 @@ instance PureTCM m => PureTCM (MaybeT m)
 instance PureTCM m => PureTCM (ReaderT r m)
 instance (PureTCM m, Monoid w) => PureTCM (WriterT w m)
 instance PureTCM m => PureTCM (StateT s m)
-
-unKleisliTCM :: forall m a b. PureTCM m => (forall n. PureTCM n => a -> n b) -> m (a -> b)
-unKleisliTCM k = do
-  state <- getTCState
-  env <- askTC
-  pure $ \a -> unsafePerformIO (fst <$> runTCM env state (k a))

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -743,6 +743,9 @@ getDisplayForms q = do
   ifM (isLocal q) (return $ ds ++ ds1 ++ ds2)
                   (return $ ds1 ++ ds ++ ds2)
 
+hasDisplayForms :: (HasConstInfo m, ReadTCState m) => QName -> m Bool
+hasDisplayForms = fmap (not . null) . getDisplayForms
+
 -- | Find all names used (recursively) by display forms of a given name.
 chaseDisplayForms :: QName -> TCM (Set QName)
 chaseDisplayForms q = go Set.empty [q]

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -467,9 +467,6 @@ fastReduce' norm v = do
     compactDef bEnv info rewr
   ReduceM $ \ redEnv -> reduceTm redEnv bEnv (memoQName constInfo) norm v
 
-unKleisli :: (a -> ReduceM b) -> ReduceM (a -> b)
-unKleisli f = ReduceM $ \ env x -> unReduceM (f x) env
-
 -- * Closures
 
 -- | The abstract machine represents terms as closures containing a 'Term', an environment, and a

--- a/test/Fail/PostfixProjDisplay.agda
+++ b/test/Fail/PostfixProjDisplay.agda
@@ -1,0 +1,25 @@
+{-# OPTIONS --postfix-projections #-}
+module PostfixProjDisplay where
+
+open import Agda.Builtin.Equality
+
+postulate
+  A : Set
+  a : A
+
+record Foo : Set where
+  field
+    _+_ : A → A → A
+
+record Bar : Set where
+  field
+    foo : Foo
+  open Foo foo public
+
+module M1 (X : Bar) where
+  open Bar X
+
+  -- Error message should show a + a
+  -- Used to show foo .Foo._+_ a a
+  it : a + a ≡ a
+  it = refl

--- a/test/Fail/PostfixProjDisplay.err
+++ b/test/Fail/PostfixProjDisplay.err
@@ -1,0 +1,3 @@
+PostfixProjDisplay.agda:25,8-12
+a + a != a of type A
+when checking that the expression refl has type (a + a) ≡ a


### PR DESCRIPTION
Consider:

```agda
open import Agda.Builtin.Equality

postulate
  A : Set
  a b : A

record Foo : Set where
  field
    _+_ : A → A → A

record Bar : Set where
  field
    foo : Foo
  open Foo foo public

module M1 (X : Bar) where
  open Bar X
  _ = {! a + a !} -- print normal form here
```

If we change the internal pretty-printer so it mentions the origin of each projection, the term being reified looks like `@0 .Bar.foo@PRE .Foo._+_@SYS a a`, where the first projection is prefix because [it comes from a field name](https://github.com/agda/agda/blob/master/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs#L603) --- that's another bug (maybe).

The opening of `Bar X` adds a display form

```
    - Test112.Foo._+_ -->
        Display 0 [Bar.foo @0] (Test112.M1._._+_ @0)
```

However, the normal form of `a + a` is printed as `foo .Foo._+_ a a`. This is because [system projections should be reified postfix](https://github.com/agda/agda/blob/master/src/full/Agda/Syntax/Translation/InternalToAbstract.hs#L486-L487), meaning the term undergoes this evolution:

```
@0 .Bar.foo@PRE .Foo._+_@SYS a a --> (unspine)
(Bar.foo @0) .Foo._+_@SYS a a    --> (display form)
foo .Foo._+_@SYS a a           
```

Since `Foo._+_` is never at the head of the term, the display form never has a chance to fire! This PR fixes that by also turning system projections to prefix projections when they have display forms. This is perhaps a bit overzealous; it would be more correct to only do this if one of the display forms would have a chance to match. But that's a lot more expensive than just looking up if any display forms are around.