### PR TITLE
Some documentation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@
 .stack-work-*/
 .stack-work/
 .sw[a-p]
-.vscode/settings.json
 .\#*
 /benchmark/Create/hs-import-*
 /benchmark/Create/import-*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+  // Don't complain about unicode characters, but highlight invisible characters
+  "editor.unicodeHighlight.ambiguousCharacters": false,
+  "editor.unicodeHighlight.invisibleCharacters": true,
+
+  // Autoformatting rules
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+
+  "files.associations": {
+    "*.lock": "json" // Interpret `.lock`-files as json
+  },
+
+  "[json][jsonc]": {
+    "editor.tabSize": 2 // The indentation size in json files is two characters
+  },
+
+  "[lagda-rst]": {
+    "editor.rulers": [80] // Display a vertical ruler at the 80-character mark in literate agda reStructuredText files
+  },
+
+  "[restructuredtext]": {
+    "editor.rulers": [80] // Display a vertical ruler at the 80-character mark in reStructuredText files
+  }
+}

--- a/doc/user-manual/contribute/documentation.rst
+++ b/doc/user-manual/contribute/documentation.rst
@@ -209,9 +209,9 @@ shown again.
 File structure
 --------------
 
-Documentation literate files (``.lagda.*``) are type-checked as whole Agda
-files, as if all literate text was replaced by whitespace. Thus, **indentation**
-is interpreted globally.
+Documentation literate files (``.lagda.*``) are type-checked as whole Agda files,
+as if all literate text was replaced by whitespace. Thus, **indentation** is
+interpreted globally.
 
 
 Namespacing

--- a/doc/user-manual/contribute/documentation.rst
+++ b/doc/user-manual/contribute/documentation.rst
@@ -120,7 +120,7 @@ of this form: both *visible* and *valid*.
 
 
 
-.. warning:: Remember to always leave a blank like after the ``::``.
+.. warning:: Remember to always leave a blank line after the ``::``.
          Otherwise, the code will be checked by Agda, but it will appear
          as regular paragraph text in the documentation.
 
@@ -209,18 +209,18 @@ shown again.
 File structure
 --------------
 
-Documentation literate files (`.lagda.*`) are type-checked as whole Agda files,
-as if all literate text was replaced by whitespace. Thus, **indentation** is
-interpreted globally.
+Documentation literate files (``.lagda.*``) are type-checked as whole Agda
+files, as if all literate text was replaced by whitespace. Thus, **indentation**
+is interpreted globally.
 
 
 Namespacing
 -----------
 
-In the documentation, files are typechecked starting from the `doc/user-manual/`
-root. For example, the file `doc/user-manual/language/data-types.lagda.rst`
-should start with a hidden code block declaring the name of the module as
-`language.data-types`:
+In the documentation, files are typechecked starting from the
+``doc/user-manual/`` root. For example, the file
+``doc/user-manual/language/data-types.lagda.rst`` should start with a hidden
+code block declaring the name of the module as ``language.data-types``:
 
 .. code-block:: rst
 

--- a/doc/user-manual/language/built-ins.lagda.rst
+++ b/doc/user-manual/language/built-ins.lagda.rst
@@ -674,8 +674,7 @@ With this definition ``eqString "foo" "foo"`` computes to ``just refl``.
 Sorts
 -----
 
-The primitive sorts used in Agda's type system (`Set`, `Prop`, and
-`Setω`) are declared using ``BUILTIN`` pragmas in the
+The primitive sorts used in Agda's type system are declared using ``BUILTIN`` pragmas in the
 ``Agda.Primitive`` module. These pragmas should not be used directly
 in other modules, but it is possible to rename these builtin sorts
 when importing ``Agda.Primitive``.
@@ -686,11 +685,17 @@ when importing ``Agda.Primitive``.
 
 .. code-block:: agda
 
-  {-# BUILTIN TYPE Set #-}
-  {-# BUILTIN PROP Prop #-}
-  {-# BUILTIN SETOMEGA Setω #-}
+{-# BUILTIN PROP           Prop      #-}
+{-# BUILTIN TYPE           Set       #-}
+{-# BUILTIN STRICTSET      SSet      #-}
 
-The primitive sorts `Set` and `Prop` are automatically imported at the
+{-# BUILTIN PROPOMEGA      Propω     #-}
+{-# BUILTIN SETOMEGA       Setω      #-}
+{-# BUILTIN STRICTSETOMEGA SSetω     #-}
+
+{-# BUILTIN LEVELUNIV      LevelUniv #-}
+
+The primitive sort `Set` is automatically imported at the
 top of every top-level Agda module, unless the
 :option:`--no-import-sorts` flag is enabled.
 
@@ -713,7 +718,7 @@ reference these are the bindings:
 .. code-block:: agda
 
   postulate
-    Level : Set
+    Level : LevelUniv
     lzero : Level
     lsuc  : Level → Level
     _⊔_   : Level → Level → Level
@@ -722,6 +727,9 @@ reference these are the bindings:
   {-# BUILTIN LEVELZERO lzero #-}
   {-# BUILTIN LEVELSUC  lsuc  #-}
   {-# BUILTIN LEVELMAX  _⊔_   #-}
+
+Note that if the flag :option:`--level-universe` is not set, then ``LevelUniv``
+will be ``Set``.
 
 .. _builtin_sized_types:
 

--- a/doc/user-manual/language/cubical-compatible.rst
+++ b/doc/user-manual/language/cubical-compatible.rst
@@ -24,7 +24,7 @@ can not be imported from :option:`--cubical` modules.
 Compatibility with Cubical Agda consists of:
 
 - No reasoning principles incompatible with univalent type theory may
-  be used. This behaviour is controlled by the the :ref:`without-K`
+  be used. This behaviour is controlled by the :ref:`without-K`
   flag (:option:`--without-K`), which :option:`--cubical-compatible` implies.
 
 - Due to specifics of the Cubical Agda implementation, several kinds of

--- a/doc/user-manual/language/flat.lagda.rst
+++ b/doc/user-manual/language/flat.lagda.rst
@@ -24,7 +24,7 @@ modality modeled after `Spatial Type Theory
 <https://arxiv.org/abs/1509.07584/>`_ and `Crisp Type Theory
 <https://arxiv.org/abs/1801.07664/>`_. It is similar to a necessity modality.
 
-This attribute is enabled using the flag :option:`--cohesion`.
+This attribute is enabled using the infective flag :option:`--cohesion`.
 
 We can define ``♭ A`` as a type for any ``(@♭ A : Set l)`` via an
 inductive definition:
@@ -82,3 +82,7 @@ Note that in Cubical Agda functions that match on an argument marked
 with ``@♭`` trigger the ``UnsupportedIndexedMatch`` warning (see
 :ref:`indexed-inductive-types`), and the code might not compute
 properly.
+
+Also note that the :option:`--cohesion` flag does not include a sharp modality
+or shape modality as in `Cohesive Homotopy Type Theory
+<https://arxiv.org/abs/1509.07584>`_.

--- a/doc/user-manual/language/lexical-structure.lagda.rst
+++ b/doc/user-manual/language/lexical-structure.lagda.rst
@@ -60,6 +60,7 @@ keywords
   ``module``
   ``mutual``
   ``no-eta-equality``
+  ``opaque``
   ``open``
   :ref:`overlap <instance-fields>`
   ``pattern``
@@ -72,9 +73,9 @@ keywords
   ``record``
   ``renaming``
   ``rewrite``
-  ``Set``
   ``syntax``
   ``tactic``
+  ``unfolding``
   :ref:`unquote <macros>`
   :ref:`unquoteDecl <unquoting-declarations>`
   :ref:`unquoteDef <unquoting-declarations>`
@@ -83,14 +84,11 @@ keywords
   ``where``
   ``with``
 
-  The ``Set`` keyword can appear with a natural number suffix, optionally
-  subscripted (see :ref:`sort-system`). For instance ``Set42`` and
-  ``Set₄₂`` are both keywords.
-
 keywords in ``renaming`` directives
-  The following words are only reserved in ``renaming`` directives:
+  The word ``to`` is only reserved in ``renaming`` directives.
 
-  ``to``
+keywords in ``import`` statements
+  The word `as` has a special meaning in ``import`` statements, although it is not reserved.
 
 .. _names:
 
@@ -261,6 +259,7 @@ layout keywords:
    let
    macro
    mutual
+   opaque
    postulate
    primitive
    private
@@ -312,8 +311,8 @@ tools like LaTeX, Markdown and reStructuredText. For instance, with LaTeX,
 everything in a file is a comment unless enclosed in ``\begin{code}``,
 ``\end{code}``. Literate Agda files have special file extensions, like
 ``.lagda`` and ``.lagda.tex`` for LaTeX, ``.lagda.md`` for Markdown,
-``.lagda.rst`` for reStructuredText instead of ``.agda``. The main use case
-for literate Agda is to generate LaTeX documents from Agda code. See
+``.lagda.rst`` for reStructuredText instead of ``.agda``. One use case
+for literate Agda files is to generate documents including Agda code. See
 :any:`generating-html` and :any:`generating-latex` for more information.
 
 .. code-block:: latex

--- a/doc/user-manual/language/lexical-structure.lagda.rst
+++ b/doc/user-manual/language/lexical-structure.lagda.rst
@@ -88,7 +88,7 @@ keywords in ``renaming`` directives
   The word ``to`` is only reserved in ``renaming`` directives.
 
 keywords in ``import`` statements
-  The word `as` has a special meaning in ``import`` statements, although it is not reserved.
+  The word ``as`` has a special meaning in ``import`` statements, although it is not reserved.
 
 .. _names:
 

--- a/doc/user-manual/language/safe-agda.lagda.rst
+++ b/doc/user-manual/language/safe-agda.lagda.rst
@@ -34,10 +34,7 @@ Here is a list of the features :option:`--safe` is incompatible with:
 * :option:`--injective-type-constructors`; together with excluded
   middle leads to an inconsistency via Chung-Kil Hur's construction.
 
-* :option:`--guardedness` together with :option:`--sized-types`;
-  currently can be used to define a type which is both inductive and
-  coinductive, which leads to an inconsistency. This might be fixed in
-  the future.
+* :option:`--sized-types`
 
 * :option:`--experimental-irrelevance` and
   :option:`--irrelevant-projections`; enables potentially unsound
@@ -47,9 +44,11 @@ Here is a list of the features :option:`--safe` is incompatible with:
 * :option:`--rewriting`; turns any equation into one that holds
   definitionally.  It can at the very least break convergence.
 
-* :option:`--cubical` together with :option:`--with-K`; the univalence
-  axiom is provable using cubical constructions, which falsifies the K
-  axiom.
+* :option:`--cubical-compatible` together with :option:`--with-K`;
+  the univalence axiom is provable using cubical constructions,
+  which falsifies the K axiom.
+
+* :option:`--without-K` together with :option:`--flat-split`
 
 * The ``primEraseEquality`` primitive together with
   :option:`--without-K`; using ``primEraseEquality``, one can derive
@@ -59,6 +58,13 @@ Here is a list of the features :option:`--safe` is incompatible with:
 
 * :option:`--no-load-primitives`; allows the user to bind the sort
   and level primitives manually.
+
+* :option:`--cumulativity`; due to its poor heuristic for solving universe
+  levels.
+
+* :option:`--large-indices` together with :option:`--without-K` or
+  :option:`--forced-argument-recursion`; both of these combinations are known to
+  be inconsistent.
 
 The option :option:`--safe` is coinfective (see
 :ref:`consistency-checking-options`); if a module is declared safe,

--- a/doc/user-manual/language/safe-agda.lagda.rst
+++ b/doc/user-manual/language/safe-agda.lagda.rst
@@ -34,7 +34,8 @@ Here is a list of the features :option:`--safe` is incompatible with:
 * :option:`--injective-type-constructors`; together with excluded
   middle leads to an inconsistency via Chung-Kil Hur's construction.
 
-* :option:`--sized-types`
+* :option:`--sized-types`; lacks some checks that rule out improper,
+  inconsistent uses of sizes.
 
 * :option:`--experimental-irrelevance` and
   :option:`--irrelevant-projections`; enables potentially unsound

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -179,7 +179,7 @@ findFile'' dirs m modFile =
 -- | Finds the interface file corresponding to a given top-level
 -- module file. The returned paths are absolute.
 --
--- Raises 'Nothing' if the the interface file cannot be found.
+-- Raises 'Nothing' if the interface file cannot be found.
 
 findInterfaceFile'
   :: SourceFile                 -- ^ Path to the source file

--- a/src/full/Agda/TypeChecking/IApplyConfluence.hs
+++ b/src/full/Agda/TypeChecking/IApplyConfluence.hs
@@ -200,7 +200,7 @@ unifyElims vs ts k = do
                          else Just c) .
     zipWith (\i c -> (i, dropS (i + 1) s `applySubst` c)) [0..]
 
--- | Like @unifyElims@ but @Γ@ is from the the meta's @MetaInfo@ and
+-- | Like @unifyElims@ but @Γ@ is from the meta's @MetaInfo@ and
 -- the context extension @Δ@ is taken from the @Closure@.
 unifyElimsMeta :: MetaId -> Args -> Closure Constraint -> ([(Term,Term)] -> Constraint -> TCM a) -> TCM a
 unifyElimsMeta m es_m cl k = ifM (isNothing . optCubical <$> pragmaOptions) (enterClosure cl $ k []) $ do


### PR DESCRIPTION
### Summary

- Add a remark about `--cohesion` not including the full set-up for cohesive homotopy type theory
- Update lexical structure
  - The word `Set` is not a reserved keyword
  - The words `opaque` and `unfolding` are reserved keywords
  - The word `as` has special meaning in `import` statements
- Update the list of `doc/user-manual/language/safe-agda` to be accurate and complete, based on `unsafePragmaOptions` and discussion I could find.
- Make list of primitive sorts complete in `doc/user-manual/language/built-ins`, and remark on `LevelUniv`.
- Fix some miscellaneous typos.
- Add vscode workspace settings.

### Remarks / Questions

- The file `.vscode/settings.json` was added to `.gitignore` under the justification that the repository should not hold user settings, but this file is meant for repository-wide settings that help homogenize the contribution experience. For instance, the documentation seems to have a working line character limit of about 80 characters. This file allows you to add settings gently informing contributors about this with the setting
  ```json
  "editor.rulers": [80]
  ```
- The update to `doc/user-manual/language/safe-agda` leaves some justification missing. I would for instance love to know why `--flat-split` together with `--without-K` is disallowed. All the discussion I could find seemed to be about cubical. Also, I don't know what's up with `--sized-types`.

_Apologies in advance if any of the changes are unwelcome!_