### PR TITLE
Add 'Inference in Agda' to the list of tutorials

### DIFF
--- a/doc/user-manual/getting-started/tutorial-list.rst
+++ b/doc/user-manual/getting-started/tutorial-list.rst
@@ -28,6 +28,7 @@ Tutorials and lecture notes
   programmers. It starts from basic knowledge of Haskell and builds up
   to using equational reasoning to formally prove correctness of
   functional programs.
+- effectfully (2020). `Inference in Agda <https://github.com/effectfully/inference-in-agda>`__.
 - Musa Al-hassy (2019). `A slow-paced introduction to reflection in Agda <https://github.com/alhassy/gentle-intro-to-reflection>`__.
 - Jesper Cockx (2019). `Formalize all the things (in Agda) <https://jesper.sikanda.be/posts/formalize-all-the-things.html>`__.
 - Jan Malakhovski (2013). `Brutal [Meta]Introduction to Dependent


### PR DESCRIPTION
This PR adds my tutorial ([rendered](https://raw.githack.com/effectfully/inference-in-agda/master/InferenceInAgda.html)) on how Agda infers stuff to the list of tutorials on readthedocs. I preserved what seems to be the reverse chronological order, but do of course feel free to move the added line around, request changes or reject the PR altogether.