### PR TITLE
[ workflow ] Allow a newer PATCH version for `cancel-workflow-action`

### DIFF
--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -17,7 +17,7 @@ jobs:
       && !contains(github.event.head_commit.message, '[skip github]')
     runs-on: ubuntu-latest
     steps:
-    - uses: styfle/cancel-workflow-action@0.12.0
+    - uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
   cabal-install:

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -17,7 +17,7 @@ jobs:
       && !contains(github.event.head_commit.message, '[skip github]')
     runs-on: Ubuntu-latest
     steps:
-    - uses: styfle/cancel-workflow-action@0.12.0
+    - uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
   cabal:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       == 'success' }}
     runs-on: Ubuntu-latest
     steps:
-    - uses: styfle/cancel-workflow-action@0.12.0
+    - uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
   build:

--- a/.github/workflows/stack-dry-run.yml
+++ b/.github/workflows/stack-dry-run.yml
@@ -14,7 +14,7 @@ jobs:
       && !contains(github.event.head_commit.message, '[skip github]')
     runs-on: Ubuntu-latest
     steps:
-    - uses: styfle/cancel-workflow-action@0.12.0
+    - uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
   stack:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,7 +14,7 @@ jobs:
       && !contains(github.event.head_commit.message, '[skip github]')
     runs-on: Ubuntu-latest
     steps:
-    - uses: styfle/cancel-workflow-action@0.12.0
+    - uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
   stack:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         echo "github.ref_name   = ${{ github.ref_name   }}"
         echo "github.ref_type   = ${{ github.ref_type   }}"
     - if: github.ref != 'refs/heads/master'
-      uses: styfle/cancel-workflow-action@0.12.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - uses: actions/checkout@v4

--- a/src/github/workflows/cabal-install.yml
+++ b/src/github/workflows/cabal-install.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest # Required, but it can be anything here.
 
     steps:
-    - uses: styfle/cancel-workflow-action@0.12.0
+    - uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
 

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: Ubuntu-latest # Required, but it can be anything here.
 
     steps:
-    - uses: styfle/cancel-workflow-action@0.12.0
+    - uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
 

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: Ubuntu-latest
     steps:
-    - uses: styfle/cancel-workflow-action@0.12.0
+    - uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
 

--- a/src/github/workflows/stack-dry-run.yml
+++ b/src/github/workflows/stack-dry-run.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: Ubuntu-latest # Required, but it can be anything here.
 
     steps:
-    - uses: styfle/cancel-workflow-action@0.12.0
+    - uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
   stack:

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: Ubuntu-latest # Required, but it can be anything here.
 
     steps:
-    - uses: styfle/cancel-workflow-action@0.12.0
+    - uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
   stack:

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
         echo "github.ref_name   = ${{ github.ref_name   }}"
         echo "github.ref_type   = ${{ github.ref_type   }}"
 
-    - uses: styfle/cancel-workflow-action@0.12.0
+    - uses: styfle/cancel-workflow-action@0.12.1
       # Andreas, 2022-12-05, issue #6388: do not cancel on `master`!
       if: github.ref != 'refs/heads/master'
       with:


### PR DESCRIPTION
#7073 suggests to update `styfle/cancel-workflow-action` to 0.12.1 in `.github/workflows/*.yml`, but we actually need to update `src/github/workflows/*.yml`. 