### PR TITLE
Fix #7070: remove built-in max heap setting -M3.5G for Agda

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -861,8 +861,9 @@ executable agda
   -- been idle for 0.3 s. This feature turned out to be annoying, so
   -- the idle GC is now by default turned off (-I0).
   ghc-options:
-    -threaded -rtsopts
-    "-with-rtsopts=-M3.5G -I0"
+    -threaded
+    -rtsopts
+    -with-rtsopts=-I0
 
 -- agda-mode executable
 ---------------------------------------------------------------------------


### PR DESCRIPTION
Remove built-in max heap setting `-M3.5G` for Agda. This pre-setting makes Agda run out of heap when it could allocate more.

Closes #7070.
