### PR TITLE
Lossy instance fields

### DIFF
--- a/doc/user-manual/language/instance-arguments.lagda.rst
+++ b/doc/user-manual/language/instance-arguments.lagda.rst
@@ -486,11 +486,11 @@ notation:
 
 ::
 
-  record Membership {ℓ} (ℙA : Set ℓ) : Setω where
+  record Membership {ℓ} (PowA : Set ℓ) : Setω where
     field
       {ℓ-elem ℓ-fibre} : Level
       element : Set ℓ-elem
-      _∈_ : element → ℙA → Set ℓ-fibre
+      _∈_ : element → PowA → Set ℓ-fibre
 
   open Membership ⦃ ... ⦄ using (_∈_)
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -666,6 +666,12 @@ Experimental features
 
      Default, opposite of :option:`--two-level`.
 
+.. option:: --lossy-instance-fields, --no-lossy-instance-fields
+
+     .. versionadded:: 2.6.5
+
+     Allow instance search to happen even when local variables have
+     unsolved types, see :ref:`lossy-instance-fields`.
 
 
 Errors and warnings

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -104,6 +104,7 @@ module Agda.Interaction.Options.Base
     , lensOptSaveMetas
     , lensOptShowIdentitySubstitutions
     , lensOptKeepCoveringClauses
+    , lensOptLossyInstanceFields
     -- * Boolean accessors to 'PragmaOptions' collapsing default
     , optShowImplicit
     , optShowGeneralized
@@ -162,6 +163,7 @@ module Agda.Interaction.Options.Base
     , optKeepCoveringClauses
     , optLargeIndices
     , optForcedArgumentRecursion
+    , optLossyInstanceFields
     -- * Non-boolean accessors to 'PragmaOptions'
     , optConfluenceCheck
     , optCubical
@@ -431,6 +433,9 @@ data PragmaOptions = PragmaOptions
       -- constructors.
   , _optForcedArgumentRecursion   :: WithDefault 'True
       -- ^ Allow recursion on forced constructor arguments.
+  , _optLossyInstanceFields       :: WithDefault 'False
+      -- ^ Allow instance search to proceed even when the types of some
+      -- visible arguments in the context are still undetermined.
   }
   deriving (Show, Eq, Generic)
 
@@ -515,6 +520,7 @@ optShowIdentitySubstitutions :: PragmaOptions -> Bool
 optKeepCoveringClauses       :: PragmaOptions -> Bool
 optLargeIndices              :: PragmaOptions -> Bool
 optForcedArgumentRecursion   :: PragmaOptions -> Bool
+optLossyInstanceFields       :: PragmaOptions -> Bool
 
 optShowImplicit              = collapseDefault . _optShowImplicit
 optShowGeneralized           = collapseDefault . _optShowGeneralized
@@ -575,6 +581,7 @@ optSaveMetas                 = collapseDefault . _optSaveMetas
 optShowIdentitySubstitutions = collapseDefault . _optShowIdentitySubstitutions
 optKeepCoveringClauses       = collapseDefault . _optKeepCoveringClauses
 optLargeIndices              = collapseDefault . _optLargeIndices
+optLossyInstanceFields       = collapseDefault . _optLossyInstanceFields
 optForcedArgumentRecursion   = collapseDefault . _optForcedArgumentRecursion
 
 -- Collapse defaults (non-Bool)
@@ -805,6 +812,9 @@ lensOptShowIdentitySubstitutions f o = f (_optShowIdentitySubstitutions o) <&> \
 lensOptKeepCoveringClauses :: Lens' PragmaOptions _
 lensOptKeepCoveringClauses f o = f (_optKeepCoveringClauses o) <&> \ i -> o{ _optKeepCoveringClauses = i }
 
+lensOptLossyInstanceFields :: Lens' PragmaOptions _
+lensOptLossyInstanceFields f o = f (_optLossyInstanceFields o) <&> \ i -> o{ _optLossyInstanceFields = i }
+
 lensOptLargeIndices :: Lens' PragmaOptions _
 lensOptLargeIndices f o = f (_optLargeIndices o) <&> \ i -> o{ _optLargeIndices = i }
 
@@ -921,6 +931,7 @@ defaultPragmaOptions = PragmaOptions
   , _optKeepCoveringClauses       = Default
   , _optForcedArgumentRecursion   = Default
   , _optLargeIndices              = Default
+  , _optLossyInstanceFields       = Default
   }
 
 -- | The options parse monad 'OptM' collects warnings that are not discarded
@@ -1810,6 +1821,9 @@ pragmaOptions = concat
                     $ Just "always check that constructor arguments live in universes compatible with that of the datatype"
   , pragmaFlag      "forced-argument-recursion" lensOptForcedArgumentRecursion
                     "allow recursion on forced constructor arguments" ""
+                    Nothing
+  , pragmaFlag      "lossy-instance-fields" lensOptLossyInstanceFields
+                    "allow instance search even when local variables have unsolved types" ""
                     Nothing
   ]
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4078,7 +4078,7 @@ toExpandLast True  = ExpandLast
 toExpandLast False = DontExpandLast
 
 data CandidateKind
-  = LocalCandidate
+  = LocalCandidate Hiding
   | GlobalCandidate QName
   deriving (Show, Generic)
 

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -202,7 +202,11 @@ instance {-# OVERLAPPABLE #-} PrettyTCM a => PrettyTCM [a] where
 instance {-# OVERLAPPABLE #-} PrettyTCM a => PrettyTCM (Maybe a) where
   prettyTCM = maybe empty prettyTCM
 
-{-# SPECIALIZE prettyTCM :: PrettyTCM a => Maybe a -> TCM Doc #-}
+instance {-# OVERLAPPABLE #-} (PrettyTCM a, PrettyTCM b) => PrettyTCM (Either a b) where
+  prettyTCM (Left e)  = parens $ "left" <+> prettyTCM e
+  prettyTCM (Right e) = parens $ "right" <+> prettyTCM e
+
+{-# SPECIALIZE prettyTCM :: (PrettyTCM a, PrettyTCM) => Either a b -> TCM Doc #-}
 
 instance (PrettyTCM a, PrettyTCM b) => PrettyTCM (a,b) where
   prettyTCM (a, b) = parens $ prettyTCM a <> comma <> prettyTCM b
@@ -570,5 +574,5 @@ instance PrettyTCM SplitTag where
 instance PrettyTCM Candidate where
   prettyTCM c = case candidateKind c of
     (GlobalCandidate q) -> prettyTCM q
-    LocalCandidate      -> prettyTCM $ candidateTerm c
+    LocalCandidate _    -> prettyTCM $ candidateTerm c
 {-# SPECIALIZE prettyTCM :: Candidate -> TCM Doc #-}

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240102 * 10 + 0
+currentInterfaceVersion = 20240131 * 10 + 1
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -308,8 +308,8 @@ instance EmbPrj InfectiveCoinfective where
     valu _   = malformed
 
 instance EmbPrj PragmaOptions where
-  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp) =
-    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp
+  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq) =
+    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq
 
   value = valueN PragmaOptions
 

--- a/test/Fail/LossyInstanceFields1.agda
+++ b/test/Fail/LossyInstanceFields1.agda
@@ -1,0 +1,29 @@
+module LossyInstanceFields1 where
+
+open import Agda.Builtin.List
+open import Agda.Builtin.Nat
+
+open Agda.Primitive renaming (Set to Type ; Setω to Typeω)
+
+record Membership {ℓ} (ℙA : Type ℓ) : Typeω where
+  field
+    {ℓ-elem ℓ-fibre} : Level
+    element : Type ℓ-elem
+    _∈_ : element → ℙA → Type ℓ-fibre
+
+open Membership ⦃ ... ⦄ using (_∈_)
+
+data _∈ₗ_ {ℓ} {A : Type ℓ} : A → List A → Type ℓ where
+  here  : ∀ {x xs}   → x ∈ₗ (x ∷ xs)
+  there : ∀ {x y xs} → x ∈ₗ xs → x ∈ₗ (y ∷ xs)
+
+instance
+  Membership-predicate : ∀ {ℓ ℓ'} {A : Type ℓ} → Membership (A → Type ℓ')
+  Membership-predicate {A = A} = record { element = A ; _∈_ = λ x f → f x }
+
+  Membership-list : ∀ {ℓ} {A : Type ℓ} → Membership (List A)
+  Membership-list {A = A} = record { element = A ; _∈_ = _∈ₗ_ }
+
+-- local instance arguments are not chosen:
+test1 : ∀ {ℓ} {A : Type ℓ} ⦃ memb : Membership A ⦄ → A → A → Type _
+test1 S T = ∀ x → x ∈ S → x ∈ T

--- a/test/Fail/LossyInstanceFields1.err
+++ b/test/Fail/LossyInstanceFields1.err
@@ -1,0 +1,27 @@
+Failed to solve the following constraints:
+  piSort (Type _76)
+  (λ x →
+     Type
+     (Membership.ℓ-fibre (_r_63 (S = S) (T = T) (x = x)) ⊔
+      Membership.ℓ-fibre (_r_69 (S = S) (T = T) (x = x))))
+    =< Type (_75 ⊔ _76)
+    (blocked on any(_r_63, _r_69))
+  Membership.ℓ-elem _r_63 = _76 (blocked on any(_r_63, _76))
+  Membership.ℓ-elem _r_69 = _76 (blocked on any(_r_69, _76))
+  Membership.ℓ-fibre (_r_63 (S = S) (T = T) (x = x)) ⊔
+  Membership.ℓ-fibre (_r_69 (S = S) (T = T) (x = x))
+    = _75
+    (blocked on _75)
+  Resolve instance argument _r_63 : Membership A No candidates yet
+    (blocked on _59)
+  Resolve instance argument _r_69 : Membership A No candidates yet
+    (blocked on _59)
+  _59 =< Membership.element _r_69 (blocked on any(_59, _r_69))
+  _59 =< Membership.element _r_63 (blocked on any(_59, _r_63))
+Unsolved metas at the following locations:
+  LossyInstanceFields1.agda:29,15-16
+  LossyInstanceFields1.agda:29,21-22
+  LossyInstanceFields1.agda:29,19-20
+  LossyInstanceFields1.agda:29,29-30
+  LossyInstanceFields1.agda:29,27-28
+  LossyInstanceFields1.agda:29,15-32

--- a/test/Fail/LossyInstanceFields2.agda
+++ b/test/Fail/LossyInstanceFields2.agda
@@ -1,0 +1,29 @@
+module LossyInstanceFields2 where
+
+open import Agda.Builtin.List
+open import Agda.Builtin.Nat
+
+open Agda.Primitive renaming (Set to Type ; Setω to Typeω)
+
+record Membership {ℓ} (ℙA : Type ℓ) : Typeω where
+  field
+    {ℓ-elem ℓ-fibre} : Level
+    element : Type ℓ-elem
+    _∈_ : element → ℙA → Type ℓ-fibre
+
+open Membership ⦃ ... ⦄ using (_∈_)
+
+data _∈ₗ_ {ℓ} {A : Type ℓ} : A → List A → Type ℓ where
+  here  : ∀ {x xs}   → x ∈ₗ (x ∷ xs)
+  there : ∀ {x y xs} → x ∈ₗ xs → x ∈ₗ (y ∷ xs)
+
+instance
+  Membership-predicate : ∀ {ℓ ℓ'} {A : Type ℓ} → Membership (A → Type ℓ')
+  Membership-predicate {A = A} = record { element = A ; _∈_ = λ x f → f x }
+
+  Membership-list : ∀ {ℓ} {A : Type ℓ} → Membership (List A)
+  Membership-list {A = A} = record { element = A ; _∈_ = _∈ₗ_ }
+
+-- global instance candidates are not chosen:
+test2 : ∀ {ℓ ℓ'} {A : Type ℓ} → (A → Type ℓ') → (A → Type ℓ') → Type _
+test2 S T = ∀ x → x ∈ S → x ∈ T

--- a/test/Fail/LossyInstanceFields2.err
+++ b/test/Fail/LossyInstanceFields2.err
@@ -1,0 +1,29 @@
+Failed to solve the following constraints:
+  piSort (Type _76)
+  (λ x →
+     Type
+     (Membership.ℓ-fibre (_r_63 (S = S) (T = T) (x = x)) ⊔
+      Membership.ℓ-fibre (_r_69 (S = S) (T = T) (x = x))))
+    =< Type (_75 ⊔ _76)
+    (blocked on any(_r_63, _r_69))
+  Membership.ℓ-elem _r_63 = _76 (blocked on any(_r_63, _76))
+  Membership.ℓ-elem _r_69 = _76 (blocked on any(_r_69, _76))
+  Membership.ℓ-fibre (_r_63 (S = S) (T = T) (x = x)) ⊔
+  Membership.ℓ-fibre (_r_69 (S = S) (T = T) (x = x))
+    = _75
+    (blocked on _75)
+  Resolve instance argument _r_63 : Membership (A → Type ℓ')
+  No candidates yet
+    (blocked on _59)
+  Resolve instance argument _r_69 : Membership (A → Type ℓ')
+  No candidates yet
+    (blocked on _59)
+  _59 =< Membership.element _r_69 (blocked on any(_59, _r_69))
+  _59 =< Membership.element _r_63 (blocked on any(_59, _r_63))
+Unsolved metas at the following locations:
+  LossyInstanceFields2.agda:29,15-16
+  LossyInstanceFields2.agda:29,21-22
+  LossyInstanceFields2.agda:29,19-20
+  LossyInstanceFields2.agda:29,29-30
+  LossyInstanceFields2.agda:29,27-28
+  LossyInstanceFields2.agda:29,15-32

--- a/test/Fail/LossyInstanceFields3.agda
+++ b/test/Fail/LossyInstanceFields3.agda
@@ -1,0 +1,12 @@
+module LossyInstanceFields3 where
+
+open Agda.Primitive renaming (Set to Type ; Setω to Typeω)
+
+record Membership {ℓ ℓ'} (ℙA : Type ℓ) (A : Type ℓ') ℓ'' : Typeω where
+  field
+    _∈_ : A → ℙA → Type ℓ''
+
+open Membership ⦃ ... ⦄ using (_∈_)
+
+test1 : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {ℙA : Type ℓ'} ⦃ memb : Membership ℙA A ℓ'' ⦄ → ℙA → ℙA → Type _
+test1 S T = ∀ x → x ∈ S → x ∈ T

--- a/test/Fail/LossyInstanceFields3.err
+++ b/test/Fail/LossyInstanceFields3.err
@@ -1,0 +1,11 @@
+Failed to solve the following constraints:
+  Resolve instance argument _r_28 : Membership ℙA _21 _ℓ''_42
+  No candidates yet
+    (blocked on _21)
+  Resolve instance argument _r_36 : Membership ℙA _21 _ℓ''_43
+  No candidates yet
+    (blocked on _21)
+Unsolved metas at the following locations:
+  LossyInstanceFields3.agda:12,15-16
+  LossyInstanceFields3.agda:12,21-22
+  LossyInstanceFields3.agda:12,29-30

--- a/test/Succeed/LossyInstanceFields.agda
+++ b/test/Succeed/LossyInstanceFields.agda
@@ -1,0 +1,34 @@
+{-# OPTIONS --lossy-instance-fields #-}
+module LossyInstanceFields where
+
+open import Agda.Builtin.List
+open import Agda.Builtin.Nat
+
+open Agda.Primitive renaming (Set to Type ; Setω to Typeω)
+
+record Membership {ℓ} (ℙA : Type ℓ) : Typeω where
+  field
+    {ℓ-elem ℓ-fibre} : Level
+    element : Type ℓ-elem
+    _∈_ : element → ℙA → Type ℓ-fibre
+
+open Membership ⦃ ... ⦄ using (_∈_)
+
+data _∈ₗ_ {ℓ} {A : Type ℓ} : A → List A → Type ℓ where
+  here  : ∀ {x xs}   → x ∈ₗ (x ∷ xs)
+  there : ∀ {x y xs} → x ∈ₗ xs → x ∈ₗ (y ∷ xs)
+
+instance
+  Membership-predicate : ∀ {ℓ ℓ'} {A : Type ℓ} → Membership (A → Type ℓ')
+  Membership-predicate {A = A} = record { element = A ; _∈_ = λ x f → f x }
+
+  Membership-list : ∀ {ℓ} {A : Type ℓ} → Membership (List A)
+  Membership-list {A = A} = record { element = A ; _∈_ = _∈ₗ_ }
+
+-- local instance arguments are still chosen:
+test1 : ∀ {ℓ} {A : Type ℓ} ⦃ memb : Membership A ⦄ → A → A → Type _
+test1 S T = ∀ x → x ∈ S → x ∈ T
+
+-- global instance candidates are also chosen:
+test2 : ∀ {ℓ ℓ'} {A : Type ℓ} → (A → Type ℓ') → (A → Type ℓ') → Type _
+test2 S T = ∀ x → x ∈ S → x ∈ T

--- a/test/Succeed/LossyInstanceFields1.agda
+++ b/test/Succeed/LossyInstanceFields1.agda
@@ -1,0 +1,22 @@
+{-# OPTIONS --lossy-instance-fields #-}
+module LossyInstanceFields1 where
+
+open import Agda.Builtin.List
+open import Agda.Builtin.Nat
+
+open Agda.Primitive renaming (Set to Type ; Setω to Typeω)
+
+-- Alternative definition of membership where the blocking meta might
+-- appear in the instance type
+--
+-- Does not affect the current implementation but might allow a finer,
+-- per-class choice in the future (functional dependencies??)
+
+record Membership {ℓ ℓ'} (ℙA : Type ℓ) (A : Type ℓ') ℓ'' : Typeω where
+  field
+    _∈_ : A → ℙA → Type ℓ''
+
+open Membership ⦃ ... ⦄ using (_∈_)
+
+test1 : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {ℙA : Type ℓ'} ⦃ memb : Membership ℙA A ℓ'' ⦄ → ℙA → ℙA → Type _
+test1 S T = ∀ x → x ∈ S → x ∈ T


### PR DESCRIPTION
This PR implements a pretty heavy-handed solution to the awkward situation where having a local, *visible* variable with unresolved type can block instance search, by allowing the user to specify those should be ignored; it's called `lossy-instance-fields` by analogy with `lossy-unification`, and also because instance fields in those variables won't be considered.

The motivation is the following:

```agda
record Membership {ℓ ℓ'} (ℙA : Type ℓ) (A : Type ℓ') ℓ'' : Typeω where
  field _∈_ : A → ℙA → Type ℓ''

open Membership {{ ... }}

test1 : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {ℙA : Type ℓ'} ⦃ memb : Membership ℙA A ℓ'' ⦄ → ℙA → ℙA → Type _
test1 S T = ∀ x → x ∈ S → x ∈ T
```

To the user, it appears that Agda has blocked _itself_ from solving the instance:

- The instance search is (literally, internally) blocked on resolving the type of `x : ?0`;
- The user thinks that `?0` would be solvable by picking the `memb` instance.

Of course, to the type checker, `?0` doesn't have anything to do with the instance. Changing `Membership` from "multi-param typeclass" style to "associated type" style does not help, either. In addition to being annoying, this behaviour is confusing even to people who I would refer to as expert users of Agda. It's not even possible to implement custom instance-search behaviour using `getInstances` + a macro here, since the context *itself* is poisoned by `x : ?0`.

With `lossy-instance-fields`, when populating the instance table with information from the context, we try looking for instance fields in every argument, but if a visible/hidden local has an undetermined type, it's simply dropped. If the context has an _instance_ local with undetermined type, we'll still block on that. This means that enabling `lossy-instance-fields` makes the code above work, but the trade-off is that the test case for #3358 will fail again:

```agda
-- see test/Succeed/Issue3358.agda
variable G : Group
postulate
  fails : (x : [ G ]) → (x ∙ x) ≡ x
```

Since the generalization telescope has an unresolved type when instance search runs, it's ignored, as can be confirmed by setting `-vtc.instance.fields:30`:

```
local variable genTel (visibility visible) has blocked type:
  [ _14 ]_14@17565323282194622980
it will not be considered for instance fields
```

There's no user-visible feedback to indicate that the `lossy-instance-fields` flag is to blame for the failure of instance search, and I think it'd be tricky to implement this without false positives --- knowing whether disabling the flag would fix anything would mean blocking on those metas anyway, and my head is spinning from the idea of doing this in an error handler. It would be possible to add a note to the error whenever the flag is enabled *and* some candidates were skipped, but then we might get bug reports like

> Agda told me to disable this flag, I disabled it, and my code is still broken!

so I'm split on whether or not it would be a good idea to have the hint. Since the flag is disabled by default, and there's nothing telling the user to consider it, I'm hoping that it'll only be enabled by users who understand the possible consequences :sweat_smile: