### PR TITLE
[ fix #6384 ] Use Alpine Linux to compile and statically link Agda

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -227,12 +227,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        path: artifacts
     - uses: actions/checkout@v4
       with:
         sparse-checkout: .
+    - uses: actions/download-artifact@v4
+      with:
+        path: artifacts
     - env:
         GITHUB_TOKEN: ${{ github.token }}
       if: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       LINUX_ARGS: --enable-executable-static  --enable-split-sections
       MACOS_ARGS: --flags=enable-cluster-counting
       WIN64_ARGS: --flags=enable-cluster-counting  --enable-split-sections
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     needs: auto-cancel
     outputs:
       sha: ${{ steps.vars.outputs.sha }}
@@ -35,34 +35,41 @@ jobs:
       name: Set up platform-dependent variables
       run: |
         sha="$(git rev-parse --short=7 HEAD)"
-        nightly=Agda-nightly
+
+        if [[ "$GITHUB_REF" == "refs/tags/"* ]]; then
+          suffix=${GITHUB_REF_NAME}
+        else
+          suffix=nightly-${sha}
+        fi
+
+        bindist=Agda-${suffix}
 
         echo sha="${sha}"                                           >> "${GITHUB_OUTPUT}"
-        echo nightly="${nightly}"                                   >> "${GITHUB_OUTPUT}"
+        echo bindist="${bindist}"                                   >> "${GITHUB_OUTPUT}"
 
         if [[ "$OSTYPE" == "msys"* ]]; then
 
-          filename="${nightly}-win64.zip"
+          filename="${bindist}-win64.zip"
           echo args="${ARGS} ${WIN64_ARGS}"                         >> "${GITHUB_OUTPUT}"
-          echo compress-cmd="7z a ${filename} ${nightly} -bb -mx=9" >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="7z a ${filename} ${bindist} -bb -mx=9" >> "${GITHUB_OUTPUT}"
           echo content-type="application/zip"                       >> "${GITHUB_OUTPUT}"
           echo exe="agda.exe"                                       >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
         elif [[ "$OSTYPE" == "darwin"* ]]; then
 
-          filename="${nightly}-macOS.tar.xz"
+          filename="${bindist}-macOS.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
-          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="tar -a -cvf ${filename} ${bindist}"    >> "${GITHUB_OUTPUT}"
           echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"
           echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
         elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 
-          filename="${nightly}-linux.tar.xz"
+          filename="${bindist}-linux.tar.xz"
           echo args="${ARGS} ${LINUX_ARGS}"                         >> "${GITHUB_OUTPUT}"
-          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="tar -a -cvf ${filename} ${bindist}"    >> "${GITHUB_OUTPUT}"
           echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"
           echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
@@ -70,15 +77,25 @@ jobs:
         fi
     - name: Display build variables
       run: |
-        echo "args         = ${{ steps.vars.outputs.args         }}"
-        echo "compress-cmd = ${{ steps.vars.outputs.compress-cmd }}"
-        echo "content-type = ${{ steps.vars.outputs.content-type }}"
-        echo "filename     = ${{ steps.vars.outputs.filename     }}"
-        echo "nightly      = ${{ steps.vars.outputs.nightly      }}"
+        echo "GITHUB_REF      = ${GITHUB_REF}"
+        echo "GITHUB_REF_NAME = ${GITHUB_REF_NAME}"
+
+        echo "args            = ${{ steps.vars.outputs.args         }}"
+        echo "compress-cmd    = ${{ steps.vars.outputs.compress-cmd }}"
+        echo "content-type    = ${{ steps.vars.outputs.content-type }}"
+        echo "filename        = ${{ steps.vars.outputs.filename     }}"
+        echo "bindist         = ${{ steps.vars.outputs.bindist      }}"
+    - if: ${{ runner.os == 'Linux' }}
+      name: Set up Alpine Linux with GHC and the static library for ICU
+      uses: jirutka/setup-alpine@v1
+      with:
+        packages: |
+          cabal g++ gcc icu-static ncurses-dev ncurses-static musl-dev zlib-static zlib-dev
     - id: setup-haskell
+      if: ${{ runner.os != 'Linux' }}
       uses: haskell-actions/setup@v2
       with:
-        cabal-version: latest
+        cabal-version: ${{ matrix.cabal-ver }}
         ghc-version: ${{ matrix.ghc-ver }}
     - name: Environment settings based on the Haskell setup
       run: |
@@ -89,10 +106,10 @@ jobs:
         echo "GHC_VER=${GHC_VER}"       >> "${GITHUB_ENV}"
         echo "CABAL_VER=${CABAL_VER}"   >> "${GITHUB_ENV}"
     - if: ${{ runner.os == 'Windows' }}
-      name: Install the ICU library (Windows)
+      name: Install the required packages (Windows)
       run: |
         $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-        pacman -v --noconfirm -S mingw-w64-x86_64-pkgconf mingw-w64-x86_64-icu
+        pacman -v --noconfirm -S mingw-w64-x86_64-pkgconf mingw-w64-x86_64-icu mingw-w64-x86_64-binutils
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
       shell: pwsh
     - if: ${{ runner.os == 'macOS' }}
@@ -112,11 +129,13 @@ jobs:
         ICU_MAJOR_VER=$(cut -d '.' -f 1 <<< "${ICU_VER}")
         echo "ICU_MAJOR_VER=${ICU_MAJOR_VER}"
         echo "ICU_MAJOR_VER=${ICU_MAJOR_VER}" >> "${GITHUB_ENV}"
-    - name: Configure the build plan
+    - if: ${{ runner.os != 'Linux' }}
+      name: Configure the build plan
       run: |
         cabal configure ${{ steps.vars.outputs.args }}
         cabal build --dry-run
     - id: cache
+      if: ${{ runner.os != 'Linux' }}
       name: Cache dependencies
       uses: actions/cache@v4
       with:
@@ -125,31 +144,41 @@ jobs:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
         restore-keys: deploy.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{
           env.CABAL_VER }}-
-    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+    - if: ${{ runner.os == 'Linux' }}
+      name: Build dependencies (on Alpine Linux)
+      run: |
+        cabal update # Liang-Ting, 2024-01-26: Alpine Linux has its own GHC toolchain
+        cabal configure ${{ steps.vars.outputs.args }}
+        cabal build exe:agda exe:agda-mode --only-dependencies
+      shell: alpine.sh {0}
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != 'Linux' }}
       name: Build dependencies
       run: cabal build exe:agda exe:agda-mode --only-dependencies
-    - name: Build Agda
+    - if: ${{ runner.os == 'Linux' }}
+      name: Build Agda (on Alpine Linux)
       run: cabal build exe:agda exe:agda-mode
-    - name: Move artefacts to ${{ steps.vars.outputs.nightly }}
+      shell: alpine.sh {0}
+    - if: ${{ runner.os != 'Linux' }}
+      name: Build Agda
+      run: cabal build exe:agda exe:agda-mode
+    - name: Move artefacts to ${{ steps.vars.outputs.bindist }}
       run: |
-        nightly="${{ steps.vars.outputs.nightly }}"
-        mkdir -p "${nightly}"/bin
-        cp -a src/data "${nightly}"
+        bindist="${{ steps.vars.outputs.bindist }}"
+        mkdir -p "${bindist}"/bin
+        cp -a src/data "${bindist}"
 
         if [[ "$OSTYPE" == "msys"* ]]; then
 
-          find dist-newstyle/build \( -name 'agda.exe' -o -name 'agda-mode.exe' \) -type f -exec cp {} "${nightly}"/bin \;
-          cp -a .github/*.bat "${nightly}"
-          cp /c/msys64/mingw64/bin/libicu*.dll "${nightly}"/bin/
-          ## Issue #6926: strip.exe not installed there.
-          ## Stripping step is optional, so we skip it.
-          # C:/ProgramData/Chocolatey/bin/strip.exe "${nightly}"/bin/*
+          find dist-newstyle/build \( -name 'agda.exe' -o -name 'agda-mode.exe' \) -type f -exec cp {} "${bindist}"/bin \;
+          cp -a .github/*.bat "${bindist}"
+          cp /c/msys64/mingw64/bin/libicu*.dll "${bindist}"/bin/
+          strip "${bindist}"/bin/*
 
         else
 
-          find dist-newstyle/build \( -name 'agda' -o -name 'agda-mode' \) -type f -exec cp {} "${nightly}"/bin \;
-          strip "${nightly}"/bin/*
-          cp -a .github/*.sh "${nightly}"
+          find dist-newstyle/build \( -name 'agda' -o -name 'agda-mode' \) -type f -exec cp {} "${bindist}"/bin \;
+          strip "${bindist}"/bin/*
+          cp -a .github/*.sh "${bindist}"
 
           if [[ "$OSTYPE" == "darwin"* ]]; then
 
@@ -159,26 +188,20 @@ jobs:
           # 2. @executable_path/../lib
           # 3. the default location of system-wide icu4c installed by homebrew, ie. /usr/local/opt/icu4c/lib
           #
-          mkdir "${nightly}"/lib
-          cp "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicudata.${ICU_MAJOR_VER}.dylib" "${nightly}"/lib
-          install_name_tool -change "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "@rpath/libicuuc.${ICU_MAJOR_VER}.dylib" "${nightly}"/bin/agda
-          install_name_tool -change "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "@rpath/libicui18n.${ICU_MAJOR_VER}.dylib" "${nightly}"/bin/agda
-          install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath "${ICU_DIR}" "${nightly}"/bin/agda
-          otool -L "${nightly}"/bin/agda
+          mkdir "${bindist}"/lib
+          cp "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicudata.${ICU_MAJOR_VER}.dylib" "${bindist}"/lib
+          install_name_tool -change "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "@rpath/libicuuc.${ICU_MAJOR_VER}.dylib" "${bindist}"/bin/agda
+          install_name_tool -change "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "@rpath/libicui18n.${ICU_MAJOR_VER}.dylib" "${bindist}"/bin/agda
+          install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath "${ICU_DIR}" "${bindist}"/bin/agda
+          otool -L "${bindist}"/bin/agda
 
           fi
         fi
 
-        file "${{ steps.vars.outputs.nightly }}/bin/agda"
-    - if: ${{ runner.os != 'macOS' }}
-      name: Compress the Agda executable
-      uses: svenstaro/upx-action@v2
-      with:
-        files: ${{ steps.vars.outputs.nightly }}/bin/${{ steps.vars.outputs.exe }}
-        strip: false
+        file "${{ steps.vars.outputs.bindist }}/bin/agda"
     - name: Display the version information
       run: |
-        ${{ steps.vars.outputs.nightly }}/bin/agda --version
+        ${{ steps.vars.outputs.bindist }}/bin/agda --version
     - name: Pack artefacts
       run: |
         ${{ steps.vars.outputs.compress-cmd }}
@@ -191,31 +214,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        cabal-ver:
+        - latest
         ghc-ver:
         - '9.8'
-        include:
-        - ghc-ver: 9.4.7
-          os: ubuntu-20.04
         os:
         - windows-latest
         - macos-latest
+        - ubuntu-latest
   deploy:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ !cancelled() }}
     needs: build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v4
       with:
         path: artifacts
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: .
     - env:
         GITHUB_TOKEN: ${{ github.token }}
+      if: ${{ github.ref == 'refs/heads/master' }}
       name: Create/replace the nightly release and upload artifacts as release assets
       run: |
-        gh release delete 'nightly' --repo agda/agda --cleanup-tag --yes || true
+        gh release delete 'nightly' --repo ${GITHUB_REPOSITORY} --cleanup-tag --yes || true
         ls -R artifacts
-        gh release create 'nightly' artifacts/**/* --repo agda/agda --generate-notes --notes-start-tag v2.6.4.3 --title "Nightly Build (${{ needs.build.outputs.sha }}@master)"
+        gh release create 'nightly' artifacts/**/* --repo ${GITHUB_REPOSITORY} --generate-notes --notes-start-tag v2.6.4.3 --prerelease --title "${{ needs.build.outputs.sha }}@master"
+    - env:
+        GITHUB_TOKEN: ${{ github.token }}
+      if: startsWith(github.ref, 'refs/tags/v')
+      name: Create a release with the bindist as release assets
+      run: |
+        echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}"
+        echo "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}"
+
+        gh release delete "${GITHUB_REF_NAME}" --repo ${GITHUB_REPOSITORY} --yes || true
+        gh release create "${GITHUB_REF_NAME}" -d --notes-file CHANGELOG.md --title "${GITHUB_REF_NAME}"
+        ls -R artifacts
+        gh release upload "${GITHUB_REF_NAME}" artifacts/**/* --repo ${GITHUB_REPOSITORY}
 name: Deploy
 'on':
+  push:
+    tags:
+    - v[2-9]+.*
   workflow_dispatch: null
   workflow_run:
     branches:

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -1,11 +1,16 @@
 name: Deploy
 
 on:
+  push:
+    tags:
+      - v[2-9]+.*
+
   workflow_run:
     workflows: ["Build, Test, and Benchmark"]
     branches: [master]
     types:
       - completed
+
   workflow_dispatch:
 
 defaults:
@@ -22,7 +27,7 @@ jobs:
         access_token: ${{ github.token }}
 
   build:
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     needs: auto-cancel
     strategy:
       fail-fast: false
@@ -30,20 +35,10 @@ jobs:
         # Andreas, 2022-10-18
         # We stick to '-latest' virtual environments here in the sense of
         # "most canonical", since this is the deploy action.
-        # As of today, this is [windows-2022, macOS-11, ubuntu-20.04].
-        os: [windows-latest, macos-latest]
+        # As of today (2024-02-02), this is [windows-2022, macOS-11, ubuntu-22.04].
+        os: [windows-latest, macos-latest, ubuntu-latest]
         ghc-ver: ['9.8']
-        # Use default (= latest) cabal version
-        # cabal-ver: ['3.10']
-
-        # Andreas, 2022-12-05, issue #6384:
-        # Atm, building static executables with GHC 9.4 is broken on ubuntu-22.04,
-        # so, we downgrade to ubuntu-20.04.
-        # Andreas, 2023-03-16: GHC 9.6 does not seem to do static linking even on ubuntu-20.04.
-        # Andreas, 2023-11-12: GHC 9.4.8 also fails to do static linking on ubuntu-20.04.
-        include:
-        - os: ubuntu-20.04
-          ghc-ver: '9.4.7'
+        cabal-ver: [latest]
 
     env:
       ARGS: "--disable-executable-profiling --disable-library-profiling"
@@ -69,34 +64,41 @@ jobs:
       id: vars
       run: |
         sha="$(git rev-parse --short=7 HEAD)"
-        nightly=Agda-nightly
+
+        if [[ "$GITHUB_REF" == "refs/tags/"* ]]; then
+          suffix=${GITHUB_REF_NAME}
+        else
+          suffix=nightly-${sha}
+        fi
+
+        bindist=Agda-${suffix}
 
         echo sha="${sha}"                                           >> "${GITHUB_OUTPUT}"
-        echo nightly="${nightly}"                                   >> "${GITHUB_OUTPUT}"
+        echo bindist="${bindist}"                                   >> "${GITHUB_OUTPUT}"
 
         if [[ "$OSTYPE" == "msys"* ]]; then
 
-          filename="${nightly}-win64.zip"
+          filename="${bindist}-win64.zip"
           echo args="${ARGS} ${WIN64_ARGS}"                         >> "${GITHUB_OUTPUT}"
-          echo compress-cmd="7z a ${filename} ${nightly} -bb -mx=9" >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="7z a ${filename} ${bindist} -bb -mx=9" >> "${GITHUB_OUTPUT}"
           echo content-type="application/zip"                       >> "${GITHUB_OUTPUT}"
           echo exe="agda.exe"                                       >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
         elif [[ "$OSTYPE" == "darwin"* ]]; then
 
-          filename="${nightly}-macOS.tar.xz"
+          filename="${bindist}-macOS.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
-          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="tar -a -cvf ${filename} ${bindist}"    >> "${GITHUB_OUTPUT}"
           echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"
           echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
         elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 
-          filename="${nightly}-linux.tar.xz"
+          filename="${bindist}-linux.tar.xz"
           echo args="${ARGS} ${LINUX_ARGS}"                         >> "${GITHUB_OUTPUT}"
-          echo compress-cmd="tar -a -cvf ${filename} ${nightly}"    >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="tar -a -cvf ${filename} ${bindist}"    >> "${GITHUB_OUTPUT}"
           echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"
           echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
@@ -105,18 +107,36 @@ jobs:
 
     - name: Display build variables
       run: |
-        echo "args         = ${{ steps.vars.outputs.args         }}"
-        echo "compress-cmd = ${{ steps.vars.outputs.compress-cmd }}"
-        echo "content-type = ${{ steps.vars.outputs.content-type }}"
-        echo "filename     = ${{ steps.vars.outputs.filename     }}"
-        echo "nightly      = ${{ steps.vars.outputs.nightly      }}"
+        echo "GITHUB_REF      = ${GITHUB_REF}"
+        echo "GITHUB_REF_NAME = ${GITHUB_REF_NAME}"
+
+        echo "args            = ${{ steps.vars.outputs.args         }}"
+        echo "compress-cmd    = ${{ steps.vars.outputs.compress-cmd }}"
+        echo "content-type    = ${{ steps.vars.outputs.content-type }}"
+        echo "filename        = ${{ steps.vars.outputs.filename     }}"
+        echo "bindist         = ${{ steps.vars.outputs.bindist      }}"
+
+    - name: Set up Alpine Linux with GHC and the static library for ICU
+      uses: jirutka/setup-alpine@v1
+      if:  ${{ runner.os == 'Linux' }}
+      with:
+        packages: >
+          cabal
+          g++
+          gcc
+          icu-static
+          ncurses-dev
+          ncurses-static
+          musl-dev
+          zlib-static
+          zlib-dev
 
     - uses: haskell-actions/setup@v2
       id: setup-haskell
+      if:  ${{ runner.os != 'Linux' }}
       with:
         ghc-version: ${{ matrix.ghc-ver }}
-        cabal-version: latest
-        # cabal-version: ${{ matrix.cabal-ver }}
+        cabal-version: ${{ matrix.cabal-ver }}
 
     - name: Environment settings based on the Haskell setup
       run: |
@@ -132,13 +152,13 @@ jobs:
     # pacman needs MSYS /usr/bin in PATH, but this breaks the latest cache action.
     # -  https://github.com/actions/cache/issues/1073
     # MSYS' pkg-config needs MSYS /mingw64/bin which we can safely add to the PATH
-    #
-    - name: Install the ICU library (Windows)
+
+    - name: Install the required packages (Windows)
       if: ${{ runner.os == 'Windows' }}
       shell: pwsh
       run: |
         $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-        pacman -v --noconfirm -S mingw-w64-x86_64-pkgconf mingw-w64-x86_64-icu
+        pacman -v --noconfirm -S mingw-w64-x86_64-pkgconf mingw-w64-x86_64-icu mingw-w64-x86_64-binutils
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
 
       ## Old method:
@@ -173,14 +193,8 @@ jobs:
         echo "ICU_MAJOR_VER=${ICU_MAJOR_VER}" >> "${GITHUB_ENV}"
       # The output of unconv --version looks like "uconv v2.1  ICU 72.1" from which we extract "72.1"
 
-    # Andreas, 2023-11-15: This did not fix the GHC 9.4.8 problem:
-    # (Suggested at https://gitlab.haskell.org/ghc/ghc/-/issues/24181#note_535333)
-    # - name: Switch off dynamic linking (Linux)
-    #   if:  runner.os == 'Linux'
-    #   run: |
-    #     echo "executable-dynamic: False" > cabal.project.local
-
     - name: Configure the build plan
+      if: ${{ runner.os != 'Linux' }}
       run: |
         cabal configure ${{ steps.vars.outputs.args }}
         cabal build --dry-run
@@ -188,52 +202,52 @@ jobs:
 
     - name: Cache dependencies
       uses: actions/cache@v4
+      if: ${{ runner.os != 'Linux' }}
       id: cache
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
         key:          deploy.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-${{ hashFiles('**/plan.json') }}
         restore-keys: deploy.yml-${{ runner.os }}-ghc-${{ env.GHC_VER }}-cabal-${{ env.CABAL_VER }}-
 
+    - name: Build dependencies (on Alpine Linux)
+      if: ${{ runner.os == 'Linux' }}
+      shell: "alpine.sh {0}"
+      run: |
+        cabal update # Liang-Ting, 2024-01-26: Alpine Linux has its own GHC toolchain
+        cabal configure ${{ steps.vars.outputs.args }}
+        cabal build exe:agda exe:agda-mode --only-dependencies
+
     - name: Build dependencies
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != 'Linux' }}
       run: cabal build exe:agda exe:agda-mode --only-dependencies
 
-    - name: Build Agda
+    - name: Build Agda (on Alpine Linux)
+      if: ${{ runner.os == 'Linux' }}
+      shell: "alpine.sh {0}"
       run: cabal build exe:agda exe:agda-mode
 
-    # - name: Build Agda
-    #   uses: nick-invision/retry@v2
-    #   # Liang-Ting (2020-12-8):
-    #   # Due to a ghc bug on Windows, it is necessary to build Agda twice (or more)
-    #   # See:
-    #   #   - https://github.com/agda/agda/issues/4543
-    #   #   - https://gitlab.haskell.org/ghc/ghc/-/issues/18634
-    #   with:
-    #     max_attempts: 3
-    #     timeout_minutes: 60
-    #     retry_on: error
-    #     command: cabal build exe:agda exe:agda-mode
+    - name: Build Agda
+      if: ${{ runner.os != 'Linux' }}
+      run: cabal build exe:agda exe:agda-mode
 
-    - name: Move artefacts to ${{ steps.vars.outputs.nightly }}
+    - name: Move artefacts to ${{ steps.vars.outputs.bindist }}
       run: |
-        nightly="${{ steps.vars.outputs.nightly }}"
-        mkdir -p "${nightly}"/bin
-        cp -a src/data "${nightly}"
+        bindist="${{ steps.vars.outputs.bindist }}"
+        mkdir -p "${bindist}"/bin
+        cp -a src/data "${bindist}"
 
         if [[ "$OSTYPE" == "msys"* ]]; then
 
-          find dist-newstyle/build \( -name 'agda.exe' -o -name 'agda-mode.exe' \) -type f -exec cp {} "${nightly}"/bin \;
-          cp -a .github/*.bat "${nightly}"
-          cp /c/msys64/mingw64/bin/libicu*.dll "${nightly}"/bin/
-          ## Issue #6926: strip.exe not installed there.
-          ## Stripping step is optional, so we skip it.
-          # C:/ProgramData/Chocolatey/bin/strip.exe "${nightly}"/bin/*
+          find dist-newstyle/build \( -name 'agda.exe' -o -name 'agda-mode.exe' \) -type f -exec cp {} "${bindist}"/bin \;
+          cp -a .github/*.bat "${bindist}"
+          cp /c/msys64/mingw64/bin/libicu*.dll "${bindist}"/bin/
+          strip "${bindist}"/bin/*
 
         else
 
-          find dist-newstyle/build \( -name 'agda' -o -name 'agda-mode' \) -type f -exec cp {} "${nightly}"/bin \;
-          strip "${nightly}"/bin/*
-          cp -a .github/*.sh "${nightly}"
+          find dist-newstyle/build \( -name 'agda' -o -name 'agda-mode' \) -type f -exec cp {} "${bindist}"/bin \;
+          strip "${bindist}"/bin/*
+          cp -a .github/*.sh "${bindist}"
 
           if [[ "$OSTYPE" == "darwin"* ]]; then
 
@@ -243,32 +257,21 @@ jobs:
           # 2. @executable_path/../lib
           # 3. the default location of system-wide icu4c installed by homebrew, ie. /usr/local/opt/icu4c/lib
           #
-          mkdir "${nightly}"/lib
-          cp "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicudata.${ICU_MAJOR_VER}.dylib" "${nightly}"/lib
-          install_name_tool -change "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "@rpath/libicuuc.${ICU_MAJOR_VER}.dylib" "${nightly}"/bin/agda
-          install_name_tool -change "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "@rpath/libicui18n.${ICU_MAJOR_VER}.dylib" "${nightly}"/bin/agda
-          install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath "${ICU_DIR}" "${nightly}"/bin/agda
-          otool -L "${nightly}"/bin/agda
+          mkdir "${bindist}"/lib
+          cp "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "${ICU_DIR}/libicudata.${ICU_MAJOR_VER}.dylib" "${bindist}"/lib
+          install_name_tool -change "${ICU_DIR}/libicuuc.${ICU_MAJOR_VER}.dylib" "@rpath/libicuuc.${ICU_MAJOR_VER}.dylib" "${bindist}"/bin/agda
+          install_name_tool -change "${ICU_DIR}/libicui18n.${ICU_MAJOR_VER}.dylib" "@rpath/libicui18n.${ICU_MAJOR_VER}.dylib" "${bindist}"/bin/agda
+          install_name_tool -add_rpath @executable_path -add_rpath @executable_path/../lib -add_rpath "${ICU_DIR}" "${bindist}"/bin/agda
+          otool -L "${bindist}"/bin/agda
 
           fi
         fi
 
-        file "${{ steps.vars.outputs.nightly }}/bin/agda"
-
-    - name: Compress the Agda executable
-      # UPX does not support macOS Big Sur.
-      # Liang-Ting Chen (2020-01-04):
-      #   Executables compressed by UPX are not usable on macOS 11 (Big Sur),
-      #   see https://github.com/upx/upx/issues/424
-      if: ${{ runner.os != 'macOS' }}
-      uses: svenstaro/upx-action@v2
-      with:
-        files: ${{ steps.vars.outputs.nightly }}/bin/${{ steps.vars.outputs.exe }}
-        strip: false
+        file "${{ steps.vars.outputs.bindist }}/bin/agda"
 
     - name: Display the version information
       run: |
-        ${{ steps.vars.outputs.nightly }}/bin/agda --version
+        ${{ steps.vars.outputs.bindist }}/bin/agda --version
 
     - name: Pack artefacts
       run: |
@@ -281,22 +284,40 @@ jobs:
         if-no-files-found: error
         retention-days: 3
 
-  deploy: # release a nightly build if triggered on master }}
-    if: ${{ github.ref == 'refs/heads/master' }}
+  deploy: # release a bindist if triggered on master or by a tag }}
     # Andreas, 2023-02-13: Also run this part when manually triggered ('workflow_dispatch')
     # if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'workflow_run' }}
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     steps:
 
     - uses: actions/download-artifact@v4
       with:
         path: artifacts
 
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: .
+
     - name: Create/replace the nightly release and upload artifacts as release assets
+      if: ${{ github.ref == 'refs/heads/master' }}
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        gh release delete 'nightly' --repo agda/agda --cleanup-tag --yes || true
+        gh release delete 'nightly' --repo ${GITHUB_REPOSITORY} --cleanup-tag --yes || true
         ls -R artifacts
-        gh release create 'nightly' artifacts/**/* --repo agda/agda --generate-notes --notes-start-tag v2.6.4.3 --title "Nightly Build (${{ needs.build.outputs.sha }}@master)"
+        gh release create 'nightly' artifacts/**/* --repo ${GITHUB_REPOSITORY} --generate-notes --notes-start-tag v2.6.4.3 --prerelease --title "${{ needs.build.outputs.sha }}@master"
+
+    - name: Create a release with the bindist as release assets
+      if: startsWith(github.ref, 'refs/tags/v')
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}"
+        echo "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}"
+
+        gh release delete "${GITHUB_REF_NAME}" --repo ${GITHUB_REPOSITORY} --yes || true
+        gh release create "${GITHUB_REF_NAME}" -d --notes-file CHANGELOG.md --title "${GITHUB_REF_NAME}"
+        ls -R artifacts
+        gh release upload "${GITHUB_REF_NAME}" artifacts/**/* --repo ${GITHUB_REPOSITORY}

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -35,7 +35,8 @@ jobs:
         # Andreas, 2022-10-18
         # We stick to '-latest' virtual environments here in the sense of
         # "most canonical", since this is the deploy action.
-        # As of today (2024-02-02), this is [windows-2022, macOS-11, ubuntu-22.04].
+        # As of today (2024-02-05), the actual version information can be found in
+        # https://github.com/actions/runner-images#available-images
         os: [windows-latest, macos-latest, ubuntu-latest]
         ghc-ver: ['9.8']
         cabal-ver: [latest]

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -292,13 +292,13 @@ jobs:
     if: ${{ !cancelled() }}
     steps:
 
-    - uses: actions/download-artifact@v4
-      with:
-        path: artifacts
-
     - uses: actions/checkout@v4
       with:
         sparse-checkout: .
+
+    - uses: actions/download-artifact@v4
+      with:
+        path: artifacts
 
     - name: Create/replace the nightly release and upload artifacts as release assets
       if: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
This PR addresses #6384 and goals discussed during AIMXVII:

1. Alpine Linux is used as a shell to compile Agda on Ubuntu. Here are some catches, though:
    - Cache is disabled on Ubuntu.
    - The `shell` property of a step does not have the context `matrix`, and I didn't find a way to unify different steps based on the host OS. 
2. Nightly builds are now published as pre-releases, making it a bit more unobtrusive on GitHub.
3. The workflow can be triggered by pushing a tag like `v2.*`.
    - ~~The condition for triggering the final job has been moved from the job to one of its step accordingly, so it should start the job at least. Mysteriously, the `deploy` job is always skipped if triggered by pushing a tag, for example, see https://github.com/L-TChen/agda/actions/runs/7754241647.~~

~~Maybe someone can take a look of the third point and figure out how to fix it.~~