### PR TITLE
Re #7081: add build with debug-{serialisation,parsing} flags to cabal CI

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -128,8 +128,8 @@ jobs:
           description: Linux debug
           ghc-ver: 9.8.1
           os: ubuntu-22.04
-        - cabal-flags: |
-            --enable-tests -f enable-cluster-counting -f debug -c containers>=0.7 --allow-newer=containers
+        - cabal-flags: --enable-tests -f enable-cluster-counting -f debug -f debug-serialisation
+            -f debug-parsing -c containers>=0.7 --allow-newer=containers
           description: Linux containers 0.7
           ghc-ver: 9.8.1
           os: ubuntu-22.04

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -393,7 +393,7 @@ library
   build-depends:
     -- Please keep in alphabetical order!
     , aeson                >= 1.1.2.0   && < 2.3
-    , ansi-terminal        >= 0.9       && < 1.1
+    , ansi-terminal        >= 0.9       && < 1.2
     , array                >= 0.5.2.0   && < 0.6
     , async                >= 2.2       && < 2.3
     , base                 >= 4.12.0.0  && < 4.20

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -79,8 +79,9 @@ jobs:
             ## Andreas, 2023-09-28: Test containers-0.7 here which has breaking changes.
             ## Note: -c 'containers >= 0.7' with single quotes does not get communicated properly.
             ## (The single quotes stay, and "-c 'containers" is an option parse error for cabal.)
-            cabal-flags: |
-              --enable-tests -f enable-cluster-counting -f debug -c containers>=0.7 --allow-newer=containers
+            cabal-flags: >-
+              --enable-tests -f enable-cluster-counting -f debug -f debug-serialisation -f debug-parsing
+              -c containers>=0.7 --allow-newer=containers
 
           # macOS with default flags
           - os: macos-12


### PR DESCRIPTION
- add build with debug-{serialisation,parsing} flags to cabal CI
- allow `ansi-terminal-1.1``

Closes #7081