### PR TITLE
Float DefP clauses above catch-alls

### DIFF
--- a/test/Fail/Issue7033a.agda
+++ b/test/Fail/Issue7033a.agda
@@ -1,0 +1,20 @@
+{-# OPTIONS --cubical --safe #-}
+module Issue7033a where
+
+open import Agda.Primitive.Cubical
+  renaming (primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primComp to comp ; primHComp to hcomp ; primTransp to transp)
+
+data ⊥ : Set where
+data ⊤ : Set where tt : ⊤
+data D : Set where
+  base  : D
+  loop  : PathP (λ _ → D) base base
+  other : D
+
+onS¹ : D → Set
+onS¹ base     = ⊤
+onS¹ (loop i) = ⊤
+onS¹ _        = ⊥
+
+JEEPERS! : ⊥
+JEEPERS! = transp (λ i → onS¹ (hcomp {φ = ~ i} (λ { j (i = i0) → base }) base)) i0 tt

--- a/test/Fail/Issue7033a.err
+++ b/test/Fail/Issue7033a.err
@@ -1,0 +1,7 @@
+Issue7033a.agda:20,12-86
+hcomp (λ i → isOneEmpty) (transp (λ i → Set) i0 (onS¹ base)) !=< ⊥
+when checking that the expression
+transp
+(λ i₁ → onS¹ (hcomp {φ = ~ i₁} (λ { j (i₁ = i0) → base }) base)) i0
+tt
+has type ⊥

--- a/test/Fail/Issue7033b.agda
+++ b/test/Fail/Issue7033b.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --cubical --safe #-}
+module Issue7033b where
+
+open import Agda.Primitive.Cubical
+  renaming (primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primComp to comp ; primHComp to hcomp ; primTransp to transp)
+
+data ⊥ : Set where
+data ⊤ : Set where tt : ⊤
+
+data D : ⊤ → Set where
+    c1 : D tt
+    c2 : D tt
+
+isC1 : {A : ⊤} → D A → Set
+isC1 c1 = ⊤
+isC1 _  = ⊥
+
+JEEPERS! : ⊥
+JEEPERS! = transp (λ i → isC1 (transp (λ j → D tt) (~ i) c1)) i0 tt

--- a/test/Fail/Issue7033b.err
+++ b/test/Fail/Issue7033b.err
@@ -1,0 +1,5 @@
+Issue7033b.agda:19,12-68
+⊤ !=< ⊥
+when checking that the expression
+transp (λ i₁ → isC1 (transp (λ j → D tt) (~ i₁) c1)) i0 tt has type
+⊥


### PR DESCRIPTION
Fixes #7033 by making the clause compiler rotate matching `DefP`s above inexact clauses, instead of duplicating the inexact clause's RHS. That is, instead of turning

```agda
f _ = X
f (hcomp u u0) = comp ...
```

into

```agda
f (hcomp u u0) = X
f _ = X
f (hcomp u u0) = comp ...
-- This is really the list of clauses that the clause compiler was using!
```

we instead rotate the generated `hcomp` clause above the user-written `f _` clause, to get

```agda
f (hcomp u u0) = comp ...
f _ = X
```

instead. It was easier to do this in the clause compiler, where we have a variable index to check for overlap on, than trying to sort the list of clauses when doing `addClause`.