### PR TITLE
Use a separate warning for duplicated interface files

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1229,6 +1229,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      ``record`` expression with duplicate field names.
 
+.. option:: DuplicateInterfaceFiles
+
+     There exists both a local interface file and an interface file in ``_build``.
+
 .. option:: DuplicateUsing
 
      Repeated names in ``using`` directive.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -539,6 +539,9 @@ warningHighlighting' b w = case tcWarning w of
     UnknownNamesInFixityDecl{}        -> mempty
     UnknownNamesInPolarityPragmas{}   -> mempty
 
+  -- Not source code related
+  DuplicateInterfaceFiles{} -> mempty
+
 recordFieldWarningHighlighting ::
   RecordFieldWarning -> HighlightingInfoBuilder
 recordFieldWarningHighlighting = \case

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -1266,7 +1266,7 @@ buildInterface src topLevel = do
     -- when expanding a pattern synonym.
     patsyns <- killRange <$> getPatternSyns
     let builtin' = Map.mapWithKey (\ x b -> primName x <$> b) builtin
-    warnings <- getAllWarnings AllWarnings
+    warnings <- filter (isSourceCodeWarning . warningName . tcWarning) <$> getAllWarnings AllWarnings
     let i = Interface
           { iSourceHash      = hashText source
           , iSource          = source

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -298,6 +298,8 @@ data WarningName
   -- Cubical
   | FaceConstraintCannotBeHidden_
   | FaceConstraintCannotBeNamed_
+  -- Not source code related
+  | DuplicateInterfaceFiles_
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Generic)
 
 instance NFData WarningName
@@ -479,3 +481,5 @@ warningNameDescription = \case
   -- Cubical
   FaceConstraintCannotBeHidden_    -> "Face constraint patterns that are given as implicit arguments."
   FaceConstraintCannotBeNamed_     -> "Face constraint patterns that are given as named arguments."
+  -- Not source code related
+  DuplicateInterfaceFiles_         -> "Duplicate interface files."

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4259,6 +4259,10 @@ data Warning
     -- ^ Face constraint patterns @(i = 0)@ must be visible arguments.
   | FaceConstraintCannotBeNamed NamedName
     -- ^ Face constraint patterns @(i = 0)@ must be unnamed arguments.
+
+  -- Not source code related
+  | DuplicateInterfaceFiles AbsolutePath AbsolutePath
+    -- ^ `DuplicateInterfaceFiles selectedInterfaceFile ignoredInterfaceFile`
   deriving (Show, Generic)
 
 recordFieldWarningToError :: RecordFieldWarning -> TypeError
@@ -4338,6 +4342,15 @@ warningName = \case
   -- Cubical
   FaceConstraintCannotBeHidden{} -> FaceConstraintCannotBeHidden_
   FaceConstraintCannotBeNamed{}  -> FaceConstraintCannotBeNamed_
+
+  -- Not source code related
+  DuplicateInterfaceFiles{}      -> DuplicateInterfaceFiles_
+
+-- Indicates wether changes in the source code can silence or influence the
+-- warning.
+isSourceCodeWarning :: WarningName -> Bool
+isSourceCodeWarning DuplicateInterfaceFiles_{} = False
+isSourceCodeWarning _ = True
 
 data TCWarning
   = TCWarning

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -45,6 +45,7 @@ import Agda.Syntax.Translation.InternalToAbstract
 import Agda.Interaction.Options
 import Agda.Interaction.Options.Warnings
 
+import Agda.Utils.FileName (filePath)
 import Agda.Utils.Lens
 import Agda.Utils.List ( editDistance )
 import qualified Agda.Utils.List1 as List1
@@ -238,6 +239,13 @@ prettyWarning = \case
     OptionWarning ow -> pretty ow
 
     ParseWarning pw -> pretty pw
+
+    DuplicateInterfaceFiles selected ignored -> vcat
+      [ fwords "There are two interface files:"
+      , nest 4 $ text $ filePath selected
+      , nest 4 $ text $ filePath ignored
+      , nest 2 $ fsep $ pwords "Using" ++ [text $ filePath selected] ++ pwords "for now but please remove at least one of them."
+      ]
 
     DeprecationWarning old new version -> fsep $
       [text old] ++ pwords "has been deprecated. Use" ++ [text new] ++ pwords

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240102 * 10 + 0
+currentInterfaceVersion = 20240102 * 10 + 1
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -89,6 +89,8 @@ instance EmbPrj Warning where
     FaceConstraintCannotBeHidden a        -> icodeN 47 FaceConstraintCannotBeHidden a
     FaceConstraintCannotBeNamed a         -> icodeN 48 FaceConstraintCannotBeNamed a
     PatternShadowsConstructor a b         -> icodeN 49 PatternShadowsConstructor a b
+    -- Not source code related, therefore they should never be serialized
+    DuplicateInterfaceFiles a b           -> __IMPOSSIBLE__
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -442,6 +444,7 @@ instance EmbPrj WarningName where
     FaceConstraintCannotBeHidden_                -> 102
     FaceConstraintCannotBeNamed_                 -> 103
     PatternShadowsConstructor_                   -> 104
+    DuplicateInterfaceFiles_                     -> 105
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -549,6 +552,7 @@ instance EmbPrj WarningName where
     102 -> return FaceConstraintCannotBeHidden_
     103 -> return FaceConstraintCannotBeNamed_
     104 -> return PatternShadowsConstructor_
+    105 -> return DuplicateInterfaceFiles_
     _   -> malformed
 
 


### PR DESCRIPTION
Fixes #7104 but I'm not sure if the `filter` for excluding `DuplicateInterfaceFiles` from serializing is too hacky or not. At least it seems to work.

Notice that I have increased `currentInterfaceVersion` because `DuplicateInterfaceFiles_` seems to be serialized nonetheless. (I have tested using `__IMPOSSIBLE__` but then I actually get that impossible error.) I'm not sure if I missed something that causes this serialization or if this will always happen. Do you have an idea why `DuplicateInterfaceFiles_` is serialized?

During testing I noticed that this warning is sometimes triggered twice if both interface files exist and the chosen one is out of date. I have started investigation on this issue (see the [deduplicate-duplicate-interface-warning branch](https://github.com/ibbem/agda/tree/deduplicate-duplicate-interface-warning)) but couldn't fix it completely yet. I will investigate this further when I have some more time (hopefully this weekend).