### PR TITLE
Split GenericWarning into individual warnings

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1225,6 +1225,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Incomplete confluence checks because of unsolved metas.
 
+.. option:: ConfluenceForCubicalNotSupported
+
+     Attempts to check confluence with :option:`--cubical`.
+
 .. option:: CoverageNoExactSplit
 
      Failed exact split checks.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1217,6 +1217,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Clashes introduced by ``renaming``.
 
+.. option:: ConfluenceCheckingIncompleteBecauseOfMeta
+
+     Incomplete confluence checks because of unsolved metas.
+
 .. option:: CoverageNoExactSplit
 
      Failed exact split checks.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1438,6 +1438,14 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      :ref:`COMPILE<foreign-function-interface>` pragma targeting an erased symbol.
 
+.. option:: PragmaCompileList
+
+     :ref:`COMPILE<foreign-function-interface>` pragma for GHC backend targeting lists.
+
+.. option:: PragmaCompileMaybe
+
+     :ref:`COMPILE<foreign-function-interface>` pragma for GHC backend targeting ``MAYBE``.
+
 .. option:: PragmaNoTerminationCheck
 
      :ref:`NO_TERMINATION_CHECK<terminating-pragma>` pragmas; such are deprecated.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1398,6 +1398,11 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Coinductive record but no :option:`--guardedness` flag.
 
+.. option:: NoMain
+
+     Invoking the compiler on a module without a ``main`` function.
+     See also :option:`--no-main`.
+
 .. option:: NotAffectedByOpaque
 
      Declarations that should not be inside ``opaque`` blocks.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1389,6 +1389,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Unknown fields in library files.
 
+.. option:: MissingTypeSignatureForOpaque
+
+     ``abstract`` or ``opaque`` definitions that lack a type signature.
+
 .. option:: ModuleDoesntExport
 
      Names mentioned in an import statement which are not exported by

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1245,6 +1245,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      There exists both a local interface file and an interface file in ``_build``.
 
+.. option:: DuplicateRewriteRule
+
+     Duplicate declaration of a name as :ref:`REWRITE<rewriting>` rule.
+
 .. option:: DuplicateUsing
 
      Repeated names in ``using`` directive.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1205,6 +1205,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      RHS given despite an absurd pattern in the LHS.
 
+.. option:: BuiltinDeclaresIdentifier
+
+     A ``BUILTIN`` pragma that declares an identifier, but has been given an existing one.
+
 .. option:: AsPatternShadowsConstructorOrPatternSynonym
 
      ``@``-patterns that shadow constructors or pattern synonyms.

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -1339,9 +1339,7 @@ callGHC = do
   let isMain = modIsMain && modHasMainFunc  -- both need to be IsMain
 
   -- Warn if no main function and not --no-main
-  when (modIsMain /= isMain) $
-    genericWarning =<< fsep (pwords "No main function defined in" ++ [prettyTCM agdaMod <> "."] ++
-                             pwords "Use --no-main to suppress this warning.")
+  when (modIsMain /= isMain) $ warning $ NoMain agdaMod
 
   let overridableArgs =
         [ "-O"] ++

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -567,8 +567,7 @@ definition def@Defn{defName = q, defType = ty, theDef = d} = do
       -- Compiling List
       Datatype{ dataPars = np } | is ghcEnvList -> do
         sequence_ [primNil, primCons] -- Just to get the proper error for missing NIL/CONS
-        caseMaybe pragma (return ()) $ \ p -> setCurrentRange p $ warning . GenericWarning =<< do
-          fsep $ pwords "Ignoring GHC pragma for builtin lists; they always compile to Haskell lists."
+        whenJust pragma $ \ p -> setCurrentRange p $ warning PragmaCompileList
         let d = dname q
             t = unqhname TypeK q
         Just nil  <- getBuiltinName builtinNil
@@ -582,8 +581,7 @@ definition def@Defn{defName = q, defType = ty, theDef = d} = do
       -- Compiling Maybe
       Datatype{ dataPars = np } | is ghcEnvMaybe -> do
         sequence_ [primNothing, primJust] -- Just to get the proper error for missing NOTHING/JUST
-        caseMaybe pragma (return ()) $ \ p -> setCurrentRange p $ warning . GenericWarning =<< do
-          fsep $ pwords "Ignoring GHC pragma for builtin maybe; they always compile to Haskell lists."
+        whenJust pragma $ \ p -> setCurrentRange p $ warning PragmaCompileMaybe
         let d = dname q
             t = unqhname TypeK q
         Just nothing <- getBuiltinName builtinNothing

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -460,6 +460,7 @@ warningHighlighting' b w = case tcWarning w of
   DeprecationWarning{}       -> mempty
   UserWarning{}              -> mempty
   LibraryWarning{}           -> mempty
+  ConfluenceCheckingIncompleteBecauseOfMeta{} -> confluenceErrorHighlighting w
   RewriteNonConfluent{}      -> confluenceErrorHighlighting w
   RewriteMaybeNonConfluent{} -> confluenceErrorHighlighting w
   RewriteAmbiguousRules{}    -> confluenceErrorHighlighting w

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -485,6 +485,7 @@ warningHighlighting' b w = case tcWarning w of
     Pa.UnsupportedAttribute{}     -> deadcodeHighlighting w
     Pa.MultipleAttributes{}       -> deadcodeHighlighting w
     Pa.OverlappingTokensWarning{} -> mempty
+  MissingTypeSignatureForOpaque{} -> errorWarningHighlighting w
   NotAffectedByOpaque{}           -> deadcodeHighlighting w
   UselessOpaque{}                 -> deadcodeHighlighting w
   UnfoldTransparentName r         -> deadcodeHighlighting r

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -462,6 +462,7 @@ warningHighlighting' b w = case tcWarning w of
   UserWarning{}              -> mempty
   LibraryWarning{}           -> mempty
   ConfluenceCheckingIncompleteBecauseOfMeta{} -> confluenceErrorHighlighting w
+  ConfluenceForCubicalNotSupported{} -> mempty
   RewriteNonConfluent{}      -> confluenceErrorHighlighting w
   RewriteMaybeNonConfluent{} -> confluenceErrorHighlighting w
   RewriteAmbiguousRules{}    -> confluenceErrorHighlighting w

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -447,7 +447,6 @@ warningHighlighting' b w = case tcWarning w of
   InstanceArgWithExplicitArg{} -> mempty
   InversionDepthReached{}    -> mempty
   NoGuardednessFlag{}        -> mempty
-  GenericWarning{}           -> mempty
   -- Andreas, 2020-03-21, issue #4456:
   -- Error warnings that do not have dedicated highlighting
   -- are highlighted as errors.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -470,6 +470,7 @@ warningHighlighting' b w = case tcWarning w of
   PragmaCompileErased{}      -> deadcodeHighlighting w
   PragmaCompileList{}        -> deadcodeHighlighting w
   PragmaCompileMaybe{}       -> deadcodeHighlighting w
+  NoMain{}                   -> mempty
   NotInScopeW{}              -> deadcodeHighlighting w
   UnsupportedIndexedMatch{}  -> mempty
   AsPatternShadowsConstructorOrPatternSynonym{}

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -429,6 +429,7 @@ warningHighlighting' b w = case tcWarning w of
   UnsolvedInteractionMetas{} -> mempty
   InteractionMetaBoundaries{} -> mempty
   OldBuiltin{}               -> mempty
+  BuiltinDeclaresIdentifier{} -> mempty
   EmptyRewritePragma{}       -> deadcodeHighlighting w
   EmptyWhere{}               -> deadcodeHighlighting w
   IllformedAsClause{}        -> deadcodeHighlighting w

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -468,6 +468,8 @@ warningHighlighting' b w = case tcWarning w of
   RewriteAmbiguousRules{}    -> confluenceErrorHighlighting w
   RewriteMissingRule{}       -> confluenceErrorHighlighting w
   PragmaCompileErased{}      -> deadcodeHighlighting w
+  PragmaCompileList{}        -> deadcodeHighlighting w
+  PragmaCompileMaybe{}       -> deadcodeHighlighting w
   NotInScopeW{}              -> deadcodeHighlighting w
   UnsupportedIndexedMatch{}  -> mempty
   AsPatternShadowsConstructorOrPatternSynonym{}

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -467,6 +467,7 @@ warningHighlighting' b w = case tcWarning w of
   RewriteMaybeNonConfluent{} -> confluenceErrorHighlighting w
   RewriteAmbiguousRules{}    -> confluenceErrorHighlighting w
   RewriteMissingRule{}       -> confluenceErrorHighlighting w
+  DuplicateRewriteRule{}     -> deadcodeHighlighting w
   PragmaCompileErased{}      -> deadcodeHighlighting w
   PragmaCompileList{}        -> deadcodeHighlighting w
   PragmaCompileMaybe{}       -> deadcodeHighlighting w

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -263,6 +263,7 @@ data WarningName
   | PlentyInHardCompileTimeMode_
   | PragmaCompileErased_
   | ConfluenceCheckingIncompleteBecauseOfMeta_
+  | ConfluenceForCubicalNotSupported_
   | RewriteMaybeNonConfluent_
   | RewriteNonConfluent_
   | RewriteAmbiguousRules_
@@ -451,6 +452,7 @@ warningNameDescription = \case
   PlentyInHardCompileTimeMode_     -> "Uses of @ω or @plenty in hard compile-time mode."
   PragmaCompileErased_             -> "`COMPILE' pragmas targeting an erased symbol."
   ConfluenceCheckingIncompleteBecauseOfMeta_ -> "Incomplete confluence checks because of unsolved metas."
+  ConfluenceForCubicalNotSupported_ -> "Incomplete confluence checks because of `--cubical'."
   RewriteMaybeNonConfluent_        -> "Failed local confluence checks while computing overlap."
   RewriteNonConfluent_             -> "Failed local confluence checks while joining critical pairs."
   RewriteAmbiguousRules_           -> "Failed global confluence checks because of overlapping rules."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -262,6 +262,8 @@ data WarningName
   | BuiltinDeclaresIdentifier_
   | PlentyInHardCompileTimeMode_
   | PragmaCompileErased_
+  | PragmaCompileList_
+  | PragmaCompileMaybe_
   | ConfluenceCheckingIncompleteBecauseOfMeta_
   | ConfluenceForCubicalNotSupported_
   | RewriteMaybeNonConfluent_
@@ -451,6 +453,8 @@ warningNameDescription = \case
   BuiltinDeclaresIdentifier_       -> "`BUILTIN' pragmas that declare a new identifier but have been given an existing one."
   PlentyInHardCompileTimeMode_     -> "Uses of @ω or @plenty in hard compile-time mode."
   PragmaCompileErased_             -> "`COMPILE' pragmas targeting an erased symbol."
+  PragmaCompileList_               -> "`COMPILE GHC' pragmas for lists."
+  PragmaCompileMaybe_              -> "`COMPILE GHC' pragmas for `MAYBE'."
   ConfluenceCheckingIncompleteBecauseOfMeta_ -> "Incomplete confluence checks because of unsolved metas."
   ConfluenceForCubicalNotSupported_ -> "Incomplete confluence checks because of `--cubical'."
   RewriteMaybeNonConfluent_        -> "Failed local confluence checks while computing overlap."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -259,6 +259,7 @@ data WarningName
   | NotStrictlyPositive_
   | UnsupportedIndexedMatch_
   | OldBuiltin_
+  | BuiltinDeclaresIdentifier_
   | PlentyInHardCompileTimeMode_
   | PragmaCompileErased_
   | ConfluenceCheckingIncompleteBecauseOfMeta_
@@ -446,6 +447,7 @@ warningNameDescription = \case
   NotStrictlyPositive_             -> "Failed strict positivity checks."
   UnsupportedIndexedMatch_         -> "Failures to compute full equivalence when splitting on indexed family."
   OldBuiltin_                      -> "Deprecated `BUILTIN' pragmas."
+  BuiltinDeclaresIdentifier_       -> "`BUILTIN' pragmas that declare a new identifier but have been given an existing one."
   PlentyInHardCompileTimeMode_     -> "Uses of @ω or @plenty in hard compile-time mode."
   PragmaCompileErased_             -> "`COMPILE' pragmas targeting an erased symbol."
   ConfluenceCheckingIncompleteBecauseOfMeta_ -> "Incomplete confluence checks because of unsolved metas."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -271,6 +271,7 @@ data WarningName
   | RewriteNonConfluent_
   | RewriteAmbiguousRules_
   | RewriteMissingRule_
+  | DuplicateRewriteRule_
   | SafeFlagEta_
   | SafeFlagInjective_
   | SafeFlagNoCoverageCheck_
@@ -463,6 +464,7 @@ warningNameDescription = \case
   RewriteNonConfluent_             -> "Failed local confluence checks while joining critical pairs."
   RewriteAmbiguousRules_           -> "Failed global confluence checks because of overlapping rules."
   RewriteMissingRule_              -> "Failed global confluence checks because of missing rule."
+  DuplicateRewriteRule_            -> "Duplicate rewrite rules."
   SafeFlagEta_                     -> "`ETA' pragmas with the safe flag."
   SafeFlagInjective_               -> "`INJECTIVE' pragmas with the safe flag."
   SafeFlagNoCoverageCheck_         -> "`NON_COVERING` pragmas with the safe flag."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -156,6 +156,9 @@ errorWarnings = Set.fromList
   , UnsolvedConstraints_
   , InfectiveImport_
   , CoInfectiveImport_
+  -- Andreas, 2024-02-15: the following warning used to be a GenericWarning (not an error warning).
+  -- Maybe revisit.
+  -- , ConfluenceCheckingIncompleteBecauseOfMeta_
   , RewriteNonConfluent_
   , RewriteMaybeNonConfluent_
   , RewriteAmbiguousRules_
@@ -258,6 +261,7 @@ data WarningName
   | OldBuiltin_
   | PlentyInHardCompileTimeMode_
   | PragmaCompileErased_
+  | ConfluenceCheckingIncompleteBecauseOfMeta_
   | RewriteMaybeNonConfluent_
   | RewriteNonConfluent_
   | RewriteAmbiguousRules_
@@ -444,6 +448,7 @@ warningNameDescription = \case
   OldBuiltin_                      -> "Deprecated `BUILTIN' pragmas."
   PlentyInHardCompileTimeMode_     -> "Uses of @ω or @plenty in hard compile-time mode."
   PragmaCompileErased_             -> "`COMPILE' pragmas targeting an erased symbol."
+  ConfluenceCheckingIncompleteBecauseOfMeta_ -> "Incomplete confluence checks because of unsolved metas."
   RewriteMaybeNonConfluent_        -> "Failed local confluence checks while computing overlap."
   RewriteNonConfluent_             -> "Failed local confluence checks while joining critical pairs."
   RewriteAmbiguousRules_           -> "Failed global confluence checks because of overlapping rules."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -246,7 +246,6 @@ data WarningName
   | FixityInRenamingModule_
   | InvalidCharacterLiteral_
   | UselessPragma_
-  | GenericWarning_
   | IllformedAsClause_
   | InstanceArgWithExplicitArg_
   | InstanceWithExplicitArg_
@@ -439,7 +438,6 @@ warningNameDescription = \case
   DeprecationWarning_              -> "Deprecated features."
   InvalidCharacterLiteral_         -> "Illegal character literals."
   UselessPragma_                   -> "Pragmas that get ignored."
-  GenericWarning_                  -> ""
   IllformedAsClause_               -> "Illformed `as'-clauses in `import' statements."
   InstanceNoOutputTypeName_        -> "Instance arguments whose type does not end in a named or variable type; those are never considered by instance search."
   InstanceArgWithExplicitArg_      -> "Instance arguments with explicit arguments; those are never considered by instance search."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -264,6 +264,7 @@ data WarningName
   | PragmaCompileErased_
   | PragmaCompileList_
   | PragmaCompileMaybe_
+  | NoMain_
   | ConfluenceCheckingIncompleteBecauseOfMeta_
   | ConfluenceForCubicalNotSupported_
   | RewriteMaybeNonConfluent_
@@ -455,6 +456,7 @@ warningNameDescription = \case
   PragmaCompileErased_             -> "`COMPILE' pragmas targeting an erased symbol."
   PragmaCompileList_               -> "`COMPILE GHC' pragmas for lists."
   PragmaCompileMaybe_              -> "`COMPILE GHC' pragmas for `MAYBE'."
+  NoMain_                          -> "Compilation of modules that do not define `main'."
   ConfluenceCheckingIncompleteBecauseOfMeta_ -> "Incomplete confluence checks because of unsolved metas."
   ConfluenceForCubicalNotSupported_ -> "Incomplete confluence checks because of `--cubical'."
   RewriteMaybeNonConfluent_        -> "Failed local confluence checks while computing overlap."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -302,6 +302,7 @@ data WarningName
   | DuplicateFields_
   | TooManyFields_
   -- Opaque/unfolding
+  | MissingTypeSignatureForOpaque_
   | NotAffectedByOpaque_
   | UnfoldTransparentName_
   | UselessOpaque_
@@ -492,6 +493,7 @@ warningNameDescription = \case
   DuplicateFields_                 -> "Record expressions with duplicate field names."
   TooManyFields_                   -> "Record expressions with invalid field names."
   -- Opaque/unfolding warnings
+  MissingTypeSignatureForOpaque_   -> "Definitions that are `abstract` or `opaque` yet lack type signatures."
   NotAffectedByOpaque_             -> "Declarations unaffected by enclosing `opaque` blocks."
   UnfoldTransparentName_           -> "Non-`opaque` names mentioned in an `unfolding` clause."
   UselessOpaque_                   -> "`opaque` blocks that have no effect."

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2473,9 +2473,7 @@ instance ToAbstract C.Pragma where
               -- The name shouldn't exist yet. If it does, we raise a warning
               -- and drop the existing definition.
               unlessM ((UnknownName ==) <$> resolveName qx) $ do
-                genericWarning $ P.text $
-                   "BUILTIN " ++ getBuiltinId b' ++ " declares an identifier " ++
-                   "(no longer expects an already defined identifier)"
+                warning $ BuiltinDeclaresIdentifier b'
                 modifyCurrentScope $ removeNameFromScope PublicNS x
               -- We then happily bind the name
               y <- freshAbstractQName' x

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4221,6 +4221,9 @@ data Warning
     -- ^ Importing a file using an infective option into one which doesn't
   | CoInfectiveImport Doc
     -- ^ Importing a file not using a coinfective option from one which does
+  | ConfluenceCheckingIncompleteBecauseOfMeta QName
+    -- ^ Confluence checking incomplete because the definition of the 'QName'
+    --   contains unsolved metavariables.
   | RewriteNonConfluent Term Term Term Doc
     -- ^ Confluence checker found critical pair and equality checking
     --   resulted in a type error
@@ -4323,6 +4326,7 @@ warningName = \case
   UserWarning{}                -> UserWarning_
   InfectiveImport{}            -> InfectiveImport_
   CoInfectiveImport{}          -> CoInfectiveImport_
+  ConfluenceCheckingIncompleteBecauseOfMeta{} -> ConfluenceCheckingIncompleteBecauseOfMeta_
   RewriteNonConfluent{}        -> RewriteNonConfluent_
   RewriteMaybeNonConfluent{}   -> RewriteMaybeNonConfluent_
   RewriteAmbiguousRules{}      -> RewriteAmbiguousRules_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4241,6 +4241,8 @@ data Warning
   | RewriteMissingRule Term Term Term
     -- ^ The global confluence checker found a term @u@ that reduces
     --   to @v@, but @v@ does not reduce to @rho(u)@.
+  | DuplicateRewriteRule QName
+    -- ^ This rewrite rule has already been added.
   | PragmaCompileErased BackendName QName
     -- ^ COMPILE directive for an erased symbol.
   | PragmaCompileList
@@ -4343,6 +4345,7 @@ warningName = \case
   RewriteMaybeNonConfluent{}   -> RewriteMaybeNonConfluent_
   RewriteAmbiguousRules{}      -> RewriteAmbiguousRules_
   RewriteMissingRule{}         -> RewriteMissingRule_
+  DuplicateRewriteRule{}       -> DuplicateRewriteRule_
   PragmaCompileErased{}        -> PragmaCompileErased_
   PragmaCompileList{}          -> PragmaCompileList_
   PragmaCompileMaybe{}         -> PragmaCompileMaybe_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4147,7 +4147,9 @@ data Warning
   | CantGeneralizeOverSorts [MetaId]
   | AbsurdPatternRequiresNoRHS [NamedArg DeBruijnPattern]
   | OldBuiltin               BuiltinId BuiltinId
-    -- ^ In `OldBuiltin old new`, the BUILTIN old has been replaced by new
+    -- ^ In `OldBuiltin old new`, the BUILTIN old has been replaced by new.
+  | BuiltinDeclaresIdentifier BuiltinId
+    -- ^ The builtin declares a new identifier, so it should not be in scope.
   | EmptyRewritePragma
     -- ^ If the user wrote just @{-\# REWRITE \#-}@.
   | EmptyWhere
@@ -4309,6 +4311,7 @@ warningName = \case
   NotStrictlyPositive{}        -> NotStrictlyPositive_
   UnsupportedIndexedMatch{}    -> UnsupportedIndexedMatch_
   OldBuiltin{}                 -> OldBuiltin_
+  BuiltinDeclaresIdentifier{}  -> BuiltinDeclaresIdentifier_
   SafeFlagPostulate{}          -> SafeFlagPostulate_
   SafeFlagPragma{}             -> SafeFlagPragma_
   SafeFlagWithoutKFlagPrimEraseEquality -> SafeFlagWithoutKFlagPrimEraseEquality_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4242,9 +4242,13 @@ data Warning
     -- ^ The global confluence checker found a term @u@ that reduces
     --   to @v@, but @v@ does not reduce to @rho(u)@.
   | PragmaCompileErased BackendName QName
-    -- ^ COMPILE directive for an erased symbol
+    -- ^ COMPILE directive for an erased symbol.
+  | PragmaCompileList
+    -- ^ @COMPILE GHC@ pragma for lists; ignored.
+  | PragmaCompileMaybe
+    -- ^ @COMPILE GHC@ pragma for @MAYBE@; ignored.
   | NotInScopeW [C.QName]
-    -- ^ Out of scope error we can recover from
+    -- ^ Out of scope error we can recover from.
   | UnsupportedIndexedMatch Doc
     -- ^ Was not able to compute a full equivalence when splitting.
   | AsPatternShadowsConstructorOrPatternSynonym Bool
@@ -4338,6 +4342,8 @@ warningName = \case
   RewriteAmbiguousRules{}      -> RewriteAmbiguousRules_
   RewriteMissingRule{}         -> RewriteMissingRule_
   PragmaCompileErased{}        -> PragmaCompileErased_
+  PragmaCompileList{}          -> PragmaCompileList_
+  PragmaCompileMaybe{}         -> PragmaCompileMaybe_
   PlentyInHardCompileTimeMode{}
                                -> PlentyInHardCompileTimeMode_
   -- record field warnings

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4226,6 +4226,8 @@ data Warning
   | ConfluenceCheckingIncompleteBecauseOfMeta QName
     -- ^ Confluence checking incomplete because the definition of the 'QName'
     --   contains unsolved metavariables.
+  | ConfluenceForCubicalNotSupported
+    -- ^ Confluence checking with @--cubical@ might be incomplete.
   | RewriteNonConfluent Term Term Term Doc
     -- ^ Confluence checker found critical pair and equality checking
     --   resulted in a type error
@@ -4330,6 +4332,7 @@ warningName = \case
   InfectiveImport{}            -> InfectiveImport_
   CoInfectiveImport{}          -> CoInfectiveImport_
   ConfluenceCheckingIncompleteBecauseOfMeta{} -> ConfluenceCheckingIncompleteBecauseOfMeta_
+  ConfluenceForCubicalNotSupported{}          -> ConfluenceForCubicalNotSupported_
   RewriteNonConfluent{}        -> RewriteNonConfluent_
   RewriteMaybeNonConfluent{}   -> RewriteMaybeNonConfluent_
   RewriteAmbiguousRules{}      -> RewriteAmbiguousRules_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4194,10 +4194,6 @@ data Warning
   -- ^ A coinductive record was declared but neither --guardedness nor
   --   --sized-types is enabled.
 
-  -- Generic warnings for one-off things
-  | GenericWarning           Doc
-    -- ^ Harmless generic warning (not an error)
-
   -- Safe flag errors
   | SafeFlagPostulate C.Name
   | SafeFlagPragma [String]                -- ^ Unsafe OPTIONS.
@@ -4315,7 +4311,6 @@ warningName = \case
   FixityInRenamingModule{}     -> FixityInRenamingModule_
   InvalidCharacterLiteral{}    -> InvalidCharacterLiteral_
   UselessPragma{}              -> UselessPragma_
-  GenericWarning{}             -> GenericWarning_
   InversionDepthReached{}      -> InversionDepthReached_
   InteractionMetaBoundaries{}  -> InteractionMetaBoundaries_{}
   ModuleDoesntExport{}         -> ModuleDoesntExport_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4247,6 +4247,8 @@ data Warning
     -- ^ @COMPILE GHC@ pragma for lists; ignored.
   | PragmaCompileMaybe
     -- ^ @COMPILE GHC@ pragma for @MAYBE@; ignored.
+  | NoMain TopLevelModuleName
+    -- ^ Compiler run on module that does not have a @main@ function.
   | NotInScopeW [C.QName]
     -- ^ Out of scope error we can recover from.
   | UnsupportedIndexedMatch Doc
@@ -4344,6 +4346,7 @@ warningName = \case
   PragmaCompileErased{}        -> PragmaCompileErased_
   PragmaCompileList{}          -> PragmaCompileList_
   PragmaCompileMaybe{}         -> PragmaCompileMaybe_
+  NoMain{}                     -> NoMain_
   PlentyInHardCompileTimeMode{}
                                -> PlentyInHardCompileTimeMode_
   -- record field warnings

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4265,6 +4265,9 @@ data Warning
   | PlentyInHardCompileTimeMode QωOrigin
     -- ^ Explicit use of @@ω@ or @@plenty@ in hard compile-time mode.
   | RecordFieldWarning RecordFieldWarning
+
+  | MissingTypeSignatureForOpaque QName IsOpaque
+    -- ^ An @abstract@ or @opaque@ definition lacks a type signature.
   | NotAffectedByOpaque
   | UnfoldTransparentName QName
   | UselessOpaque
@@ -4357,6 +4360,7 @@ warningName = \case
     W.DuplicateFields{}   -> DuplicateFields_
     W.TooManyFields{}     -> TooManyFields_
 
+  MissingTypeSignatureForOpaque{} -> MissingTypeSignatureForOpaque_
   NotAffectedByOpaque{}   -> NotAffectedByOpaque_
   UselessOpaque{}         -> UselessOpaque_
   UnfoldTransparentName{} -> UnfoldTransparentName_

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -332,6 +332,9 @@ prettyWarning = \case
         ]
       ]
 
+    DuplicateRewriteRule q ->
+      "Rewrite rule " <+> prettyTCM q <+> " has already been added"
+
     PragmaCompileErased bn qn -> fsep $ concat
       [ pwords "The backend"
       , [ text bn

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -287,6 +287,9 @@ prettyWarning = \case
       , text "contains unsolved metavariables."
       ]
 
+    ConfluenceForCubicalNotSupported -> fsep $ pwords $
+      "Confluence checking for --cubical is not yet supported, confluence checking might be incomplete"
+
     RewriteNonConfluent lhs rhs1 rhs2 err -> fsep
       [ "Local confluence check failed:"
       , prettyTCM lhs , "reduces to both"

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -341,6 +341,12 @@ prettyWarning = \case
       , pwords "so the COMPILE pragma will be ignored."
       ]
 
+    PragmaCompileList -> fsep $ pwords
+      "Ignoring GHC pragma for builtin lists; they always compile to Haskell lists."
+
+    PragmaCompileMaybe -> fsep $ pwords
+      "Ignoring GHC pragma for builtin MAYBE; it always compiles to Haskell Maybe."
+
     NotInScopeW xs -> vcat
       [ fsep $ pwords "Not in scope:"
       , do

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -35,7 +35,7 @@ import {-# SOURCE #-} Agda.TypeChecking.Pretty.Constraint (prettyInterestingCons
 import Agda.TypeChecking.Warnings (MonadWarning, isUnsolvedWarning, onlyShowIfUnsolved, classifyWarning, WhichWarnings(..), warning_)
 import {-# SOURCE #-} Agda.TypeChecking.MetaVars
 
-import Agda.Syntax.Common ( getHiding, ImportedName'(..), fromImportedName, partitionImportedNames )
+import Agda.Syntax.Common ( IsOpaque(OpaqueDef, TransparentDef), getHiding, ImportedName'(..), fromImportedName, partitionImportedNames )
 import Agda.Syntax.Position
 import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Scope.Base ( concreteNamesInScope, NameOrModule(..) )
@@ -387,6 +387,18 @@ prettyWarning = \case
       pwords "in hard compile-time mode"
 
     RecordFieldWarning w -> prettyRecordFieldWarning w
+
+    MissingTypeSignatureForOpaque name isOpaque -> vcat
+        [ "Missing type signature for" <+> text what <+> "definition" <+> (prettyTCM name <> ".")
+        , fsep $ pwords $
+            "Types of " ++ what ++ " definitions are never inferred since this would leak " ++
+            "information that should be " ++ what ++ "."
+        ]
+      where
+        what = case isOpaque of
+          TransparentDef -> "abstract"
+          OpaqueDef _    -> "opaque"
+
 
     NotAffectedByOpaque -> fwords "Only function definitions can be marked opaque. This definition will be treated as transparent."
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -219,8 +219,6 @@ prettyWarning = \case
              pwords "this type will likely be rejected by the termination" ++
              pwords "checker unless this flag is enabled."
 
-    GenericWarning d -> return d
-
     InvalidCharacterLiteral c -> fsep $
       pwords "Invalid character literal" ++ [text $ show c] ++
       pwords "(surrogate code points are not supported)"

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -277,6 +277,12 @@ prettyWarning = \case
 
     CoInfectiveImport msg -> return msg
 
+    ConfluenceCheckingIncompleteBecauseOfMeta f -> fsep
+      [ "Confluence checking incomplete because the definition of"
+      , prettyTCM f
+      , text "contains unsolved metavariables."
+      ]
+
     RewriteNonConfluent lhs rhs1 rhs2 err -> fsep
       [ "Local confluence check failed:"
       , prettyTCM lhs , "reduces to both"

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -347,6 +347,11 @@ prettyWarning = \case
     PragmaCompileMaybe -> fsep $ pwords
       "Ignoring GHC pragma for builtin MAYBE; it always compiles to Haskell Maybe."
 
+    NoMain topLevelModule -> vcat
+      [ fsep $ pwords "No main function defined in" ++ [prettyTCM topLevelModule <> "."]
+      , fsep $ pwords "Use option --no-main to suppress this warning."
+      ]
+
     NotInScopeW xs -> vcat
       [ fsep $ pwords "Not in scope:"
       , do

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -156,6 +156,10 @@ prettyWarning = \case
       "Builtin " ++ getBuiltinId old ++ " no longer exists. " ++
       "It is now bound by BUILTIN " ++ getBuiltinId new
 
+    BuiltinDeclaresIdentifier b -> fwords $
+      "BUILTIN " ++ getBuiltinId b ++ " declares an identifier " ++
+      "(no longer expects an already defined identifier)"
+
     EmptyRewritePragma -> fsep . pwords $ "Empty REWRITE pragma"
 
     EmptyWhere         -> fsep . pwords $ "Empty `where' block (ignored)"

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -357,10 +357,7 @@ checkRewriteRule q = do
       rews <- getRewriteRulesFor f
       -- check if q is already an added rewrite rule
       case List.find ((q ==) . rewName) rews of
-        Just rew -> do
-          genericWarning =<< do
-            "Rewrite rule " <+> prettyTCM q <+> " has already been added"
-          return rew
+        Just rew -> rew <$ do warning $ DuplicateRewriteRule q
         Nothing -> cont
 
     usedArgs :: Definition -> IntSet

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -152,8 +152,7 @@ addRewriteRules qs = do
   -- (should be done after adding all rules, see #3795)
   whenJustM (optConfluenceCheck <$> pragmaOptions) $ \confChk -> do
     -- Warn if --cubical is enabled
-    whenJustM (optCubical <$> pragmaOptions) $ \_ -> genericWarning
-      "Confluence checking for --cubical is not yet supported, confluence checking might be incomplete"
+    whenJustM (optCubical <$> pragmaOptions) $ \_ -> warning ConfluenceForCubicalNotSupported
     -- Global confluence checker requires rules to be sorted
     -- according to the generality of their lhs
     when (confChk == GlobalConfluenceCheck) $

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -99,11 +99,7 @@ checkConfluenceOfClauses confChk f = do
   rews <- getClausesAsRewriteRules f
   let noMetasInPats rew
         | noMetas (rewPats rew) = return True
-        | otherwise             = do
-            genericWarning =<< do
-              text "Confluence checking incomplete because the definition of" <+>
-                prettyTCM f <+> text "contains unsolved metavariables."
-            return False
+        | otherwise             = False <$ do warning $ ConfluenceCheckingIncompleteBecauseOfMeta f
   rews <- filterM noMetasInPats rews
   let matchables = map getMatchables rews
   reportSDoc "rewriting.confluence" 30 $

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -34,7 +34,7 @@ import Agda.Syntax.Info hiding (defAbstract)
 
 import Agda.TypeChecking.Monad
 import qualified Agda.TypeChecking.Monad.Benchmark as Bench
-import Agda.TypeChecking.Warnings ( warning, genericWarning )
+import Agda.TypeChecking.Warnings ( warning )
 
 import Agda.TypeChecking.Constraints
 import Agda.TypeChecking.Conversion

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -117,15 +117,8 @@ checkFunDef i name cs = do
               -- blocks you might actually have solved the type of an alias by the time you get to
               -- the definition. See test/Succeed/SizeInfinity.agda for an example where this
               -- happens.
-              let
-                what
-                  | Info.defOpaque i == TransparentDef = "abstract"
-                  | otherwise                          = "opaque"
               whenM (isOpenMeta <$> lookupMetaInstantiation x) $
-                setCurrentRange i $ genericWarning =<<
-                  "Missing type signature for" <+> text what <+> "definition" <+> (prettyTCM name <> ".") $$
-                  fsep (pwords ("Types of " ++ what ++ " definitions are never inferred since this would leak") ++
-                        pwords ("information that should be " ++ what ++ "."))
+                setCurrentRange i $ warning $ MissingTypeSignatureForOpaque name (Info.defOpaque i)
               checkFunDef' t info Nothing Nothing i name cs
           _ -> checkFunDef' t info Nothing Nothing i name cs
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240102 * 10 + 1
+currentInterfaceVersion = 20240215 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -98,6 +98,7 @@ instance EmbPrj Warning where
     PragmaCompileList                           -> __IMPOSSIBLE__
     PragmaCompileMaybe                          -> __IMPOSSIBLE__
     NoMain _                                    -> __IMPOSSIBLE__
+    DuplicateRewriteRule a                      -> icodeN 53 DuplicateRewriteRule a
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -153,6 +154,7 @@ instance EmbPrj Warning where
     [50, a]              -> valuN ConfluenceCheckingIncompleteBecauseOfMeta a
     [51, a]              -> valuN BuiltinDeclaresIdentifier a
     [52]                 -> valuN ConfluenceForCubicalNotSupported
+    [53, a]              -> valuN DuplicateRewriteRule a
     _ -> malformed
 
 instance EmbPrj OptionWarning where
@@ -461,6 +463,7 @@ instance EmbPrj WarningName where
     PragmaCompileList_                           -> 109
     PragmaCompileMaybe_                          -> 110
     NoMain_                                      -> 111
+    DuplicateRewriteRule_                        -> 112
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -575,6 +578,7 @@ instance EmbPrj WarningName where
     109 -> return PragmaCompileList_
     110 -> return PragmaCompileMaybe_
     111 -> return NoMain_
+    112 -> return DuplicateRewriteRule_
     _   -> malformed
 
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -40,7 +40,6 @@ instance EmbPrj Warning where
     EmptyRewritePragma                    -> icodeN 2 EmptyRewritePragma
     UselessPublic                         -> icodeN 3 UselessPublic
     UselessInline a                       -> icodeN 4 UselessInline a
-    GenericWarning a                      -> icodeN 5 GenericWarning a
     InvalidCharacterLiteral a             -> __IMPOSSIBLE__
     SafeFlagPostulate a                   -> __IMPOSSIBLE__
     SafeFlagPragma a                      -> __IMPOSSIBLE__
@@ -107,7 +106,6 @@ instance EmbPrj Warning where
     [2]                  -> valuN EmptyRewritePragma
     [3]                  -> valuN UselessPublic
     [4, a]               -> valuN UselessInline a
-    [5, a]               -> valuN GenericWarning a
     [6, a, b, c]         -> valuN DeprecationWarning a b c
     [7, a]               -> valuN NicifierIssue a
     [8, a]               -> valuN InversionDepthReached a
@@ -404,7 +402,6 @@ instance EmbPrj WarningName where
     FixityInRenamingModule_                      -> 48
     InvalidCharacterLiteral_                     -> 49
     UselessPragma_                               -> 50
-    GenericWarning_                              -> 51
     IllformedAsClause_                           -> 52
     InstanceArgWithExplicitArg_                  -> 53
     InstanceWithExplicitArg_                     -> 54
@@ -520,7 +517,6 @@ instance EmbPrj WarningName where
     48  -> return FixityInRenamingModule_
     49  -> return InvalidCharacterLiteral_
     50  -> return UselessPragma_
-    51  -> return GenericWarning_
     52  -> return IllformedAsClause_
     53  -> return InstanceArgWithExplicitArg_
     54  -> return InstanceWithExplicitArg_

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -97,6 +97,7 @@ instance EmbPrj Warning where
     -- We do not need to serialize compiler warnings:
     PragmaCompileList                           -> __IMPOSSIBLE__
     PragmaCompileMaybe                          -> __IMPOSSIBLE__
+    NoMain _                                    -> __IMPOSSIBLE__
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -459,6 +460,7 @@ instance EmbPrj WarningName where
     ConfluenceForCubicalNotSupported_            -> 108
     PragmaCompileList_                           -> 109
     PragmaCompileMaybe_                          -> 110
+    NoMain_                                      -> 111
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -572,6 +574,7 @@ instance EmbPrj WarningName where
     108 -> return ConfluenceForCubicalNotSupported_
     109 -> return PragmaCompileList_
     110 -> return PragmaCompileMaybe_
+    111 -> return NoMain_
     _   -> malformed
 
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -94,6 +94,9 @@ instance EmbPrj Warning where
     ConfluenceCheckingIncompleteBecauseOfMeta a -> icodeN 50 ConfluenceCheckingIncompleteBecauseOfMeta a
     BuiltinDeclaresIdentifier a                 -> icodeN 51 BuiltinDeclaresIdentifier a
     ConfluenceForCubicalNotSupported            -> icodeN 52 ConfluenceForCubicalNotSupported
+    -- We do not need to serialize compiler warnings:
+    PragmaCompileList                           -> __IMPOSSIBLE__
+    PragmaCompileMaybe                          -> __IMPOSSIBLE__
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -454,6 +457,8 @@ instance EmbPrj WarningName where
     ConfluenceCheckingIncompleteBecauseOfMeta_   -> 106
     BuiltinDeclaresIdentifier_                   -> 107
     ConfluenceForCubicalNotSupported_            -> 108
+    PragmaCompileList_                           -> 109
+    PragmaCompileMaybe_                          -> 110
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -565,6 +570,8 @@ instance EmbPrj WarningName where
     106 -> return ConfluenceCheckingIncompleteBecauseOfMeta_
     107 -> return BuiltinDeclaresIdentifier_
     108 -> return ConfluenceForCubicalNotSupported_
+    109 -> return PragmaCompileList_
+    110 -> return PragmaCompileMaybe_
     _   -> malformed
 
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -99,6 +99,7 @@ instance EmbPrj Warning where
     PragmaCompileMaybe                          -> __IMPOSSIBLE__
     NoMain _                                    -> __IMPOSSIBLE__
     DuplicateRewriteRule a                      -> icodeN 53 DuplicateRewriteRule a
+    MissingTypeSignatureForOpaque a b           -> icodeN 54 MissingTypeSignatureForOpaque a b
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -155,6 +156,7 @@ instance EmbPrj Warning where
     [51, a]              -> valuN BuiltinDeclaresIdentifier a
     [52]                 -> valuN ConfluenceForCubicalNotSupported
     [53, a]              -> valuN DuplicateRewriteRule a
+    [54, a, b]           -> valuN MissingTypeSignatureForOpaque a b
     _ -> malformed
 
 instance EmbPrj OptionWarning where
@@ -464,6 +466,7 @@ instance EmbPrj WarningName where
     PragmaCompileMaybe_                          -> 110
     NoMain_                                      -> 111
     DuplicateRewriteRule_                        -> 112
+    MissingTypeSignatureForOpaque_               -> 113
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -579,6 +582,7 @@ instance EmbPrj WarningName where
     110 -> return PragmaCompileMaybe_
     111 -> return NoMain_
     112 -> return DuplicateRewriteRule_
+    113 -> return MissingTypeSignatureForOpaque_
     _   -> malformed
 
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -92,6 +92,7 @@ instance EmbPrj Warning where
     -- Not source code related, therefore they should never be serialized
     DuplicateInterfaceFiles a b           -> __IMPOSSIBLE__
     ConfluenceCheckingIncompleteBecauseOfMeta a -> icodeN 50 ConfluenceCheckingIncompleteBecauseOfMeta a
+    BuiltinDeclaresIdentifier a                 -> icodeN 51 BuiltinDeclaresIdentifier a
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -145,6 +146,7 @@ instance EmbPrj Warning where
     [48, a]              -> valuN FaceConstraintCannotBeNamed a
     [49, a, b]           -> valuN PatternShadowsConstructor a b
     [50, a]              -> valuN ConfluenceCheckingIncompleteBecauseOfMeta a
+    [51, a]              -> valuN BuiltinDeclaresIdentifier a
     _ -> malformed
 
 instance EmbPrj OptionWarning where
@@ -448,6 +450,7 @@ instance EmbPrj WarningName where
     PatternShadowsConstructor_                   -> 104
     DuplicateInterfaceFiles_                     -> 105
     ConfluenceCheckingIncompleteBecauseOfMeta_   -> 106
+    BuiltinDeclaresIdentifier_                   -> 107
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -557,6 +560,7 @@ instance EmbPrj WarningName where
     104 -> return PatternShadowsConstructor_
     105 -> return DuplicateInterfaceFiles_
     106 -> return ConfluenceCheckingIncompleteBecauseOfMeta_
+    107 -> return BuiltinDeclaresIdentifier_
     _   -> malformed
 
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -91,6 +91,7 @@ instance EmbPrj Warning where
     PatternShadowsConstructor a b         -> icodeN 49 PatternShadowsConstructor a b
     -- Not source code related, therefore they should never be serialized
     DuplicateInterfaceFiles a b           -> __IMPOSSIBLE__
+    ConfluenceCheckingIncompleteBecauseOfMeta a -> icodeN 50 ConfluenceCheckingIncompleteBecauseOfMeta a
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -143,6 +144,7 @@ instance EmbPrj Warning where
     [47, a]              -> valuN FaceConstraintCannotBeHidden a
     [48, a]              -> valuN FaceConstraintCannotBeNamed a
     [49, a, b]           -> valuN PatternShadowsConstructor a b
+    [50, a]              -> valuN ConfluenceCheckingIncompleteBecauseOfMeta a
     _ -> malformed
 
 instance EmbPrj OptionWarning where
@@ -445,6 +447,7 @@ instance EmbPrj WarningName where
     FaceConstraintCannotBeNamed_                 -> 103
     PatternShadowsConstructor_                   -> 104
     DuplicateInterfaceFiles_                     -> 105
+    ConfluenceCheckingIncompleteBecauseOfMeta_   -> 106
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -553,6 +556,7 @@ instance EmbPrj WarningName where
     103 -> return FaceConstraintCannotBeNamed_
     104 -> return PatternShadowsConstructor_
     105 -> return DuplicateInterfaceFiles_
+    106 -> return ConfluenceCheckingIncompleteBecauseOfMeta_
     _   -> malformed
 
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -93,6 +93,7 @@ instance EmbPrj Warning where
     DuplicateInterfaceFiles a b           -> __IMPOSSIBLE__
     ConfluenceCheckingIncompleteBecauseOfMeta a -> icodeN 50 ConfluenceCheckingIncompleteBecauseOfMeta a
     BuiltinDeclaresIdentifier a                 -> icodeN 51 BuiltinDeclaresIdentifier a
+    ConfluenceForCubicalNotSupported            -> icodeN 52 ConfluenceForCubicalNotSupported
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -147,6 +148,7 @@ instance EmbPrj Warning where
     [49, a, b]           -> valuN PatternShadowsConstructor a b
     [50, a]              -> valuN ConfluenceCheckingIncompleteBecauseOfMeta a
     [51, a]              -> valuN BuiltinDeclaresIdentifier a
+    [52]                 -> valuN ConfluenceForCubicalNotSupported
     _ -> malformed
 
 instance EmbPrj OptionWarning where
@@ -451,6 +453,7 @@ instance EmbPrj WarningName where
     DuplicateInterfaceFiles_                     -> 105
     ConfluenceCheckingIncompleteBecauseOfMeta_   -> 106
     BuiltinDeclaresIdentifier_                   -> 107
+    ConfluenceForCubicalNotSupported_            -> 108
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -561,6 +564,7 @@ instance EmbPrj WarningName where
     105 -> return DuplicateInterfaceFiles_
     106 -> return ConfluenceCheckingIncompleteBecauseOfMeta_
     107 -> return BuiltinDeclaresIdentifier_
+    108 -> return ConfluenceForCubicalNotSupported_
     _   -> malformed
 
 

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -1,7 +1,6 @@
 
 module Agda.TypeChecking.Warnings
   ( MonadWarning(..)
-  , genericWarning
   , warning'_, warning_, warning', warning, warnings
   , raiseWarningsOnUsage
   , isUnsolvedWarning
@@ -78,10 +77,6 @@ instance MonadWarning TCM where
 
 -- * Raising warnings
 ---------------------------------------------------------------------------
-
-{-# SPECIALIZE genericWarning :: P.Doc -> TCM () #-}
-genericWarning :: MonadWarning m => P.Doc -> m ()
-genericWarning = warning . GenericWarning
 
 {-# SPECIALIZE warning'_ :: CallStack -> Warning -> TCM TCWarning #-}
 warning'_ :: (MonadWarning m) => CallStack -> Warning -> m TCWarning

--- a/test/Compiler/simple/ExportAndUse.out
+++ b/test/Compiler/simple/ExportAndUse.out
@@ -1,7 +1,7 @@
 COMPILE_SUCCEEDED
 
 ret > ExitSuccess
-out > warning: -W[no]GenericWarning
-out > No main function defined in ExportAndUse. Use --no-main to suppress
-out > this warning.
+out > warning: -W[no]NoMain
+out > No main function defined in ExportAndUse.
+out > Use option --no-main to suppress this warning.
 out >

--- a/test/Compiler/simple/Issue2714.out
+++ b/test/Compiler/simple/Issue2714.out
@@ -1,7 +1,7 @@
 COMPILE_SUCCEEDED
 
 ret > ExitSuccess
-out > warning: -W[no]GenericWarning
-out > No main function defined in Issue2714. Use --no-main to suppress
-out > this warning.
+out > warning: -W[no]NoMain
+out > No main function defined in Issue2714.
+out > Use option --no-main to suppress this warning.
 out >

--- a/test/Fail/Issue418.err
+++ b/test/Fail/Issue418.err
@@ -1,10 +1,10 @@
 Issue418.agda:30,3-10
-warning: -W[no]GenericWarning
+warning: -W[no]MissingTypeSignatureForOpaque
 Missing type signature for abstract definition B.
 Types of abstract definitions are never inferred since this would
 leak information that should be abstract.
 Issue418.agda:33,3-10
-warning: -W[no]GenericWarning
+warning: -W[no]MissingTypeSignatureForOpaque
 Missing type signature for abstract definition C.
 Types of abstract definitions are never inferred since this would
 leak information that should be abstract.

--- a/test/Fail/Issue5589c.agda
+++ b/test/Fail/Issue5589c.agda
@@ -1,13 +1,15 @@
 {-# OPTIONS --cubical --rewriting --confluence-check #-}
-open import Agda.Builtin.Cubical.Path using (PathP ; _≡_)
+
+open import Agda.Builtin.Cubical.Path using (PathP; _≡_)
 open import Agda.Builtin.Nat renaming (Nat to ℕ; zero to Z; suc to S)
+
 {-# BUILTIN REWRITE _≡_ #-}
 
 _+ℕ_ : ℕ → ℕ → ℕ
-x +ℕ Z = x
+x +ℕ Z     = x
 x +ℕ (S y) = S (x +ℕ y)
 
 +ℕ-id : ∀ x → Z +ℕ x ≡ x
-+ℕ-id Z i = Z
-+ℕ-id (S x)i  = S (+ℕ-id x i)
++ℕ-id Z     i = Z
++ℕ-id (S x) i = S (+ℕ-id x i)
 {-# REWRITE +ℕ-id #-}

--- a/test/Fail/Issue5589c.err
+++ b/test/Fail/Issue5589c.err
@@ -1,8 +1,9 @@
-Issue5589c.agda:13,1-22
-warning: -W[no]GenericWarning
-Confluence checking for --cubical is not yet supported, confluence checking might be incomplete
+Issue5589c.agda:15,1-22
+warning: -W[no]ConfluenceForCubicalNotSupported
+Confluence checking for --cubical is not yet supported, confluence
+checking might be incomplete
 when checking the pragma REWRITE +ℕ-id
-Issue5589c.agda:13,13-18
+Issue5589c.agda:15,13-18
 Global confluence check failed: 0 +ℕ S y can be rewritten to either
 S y or S (0 +ℕ y).
 Possible fix: add a rewrite rule with left-hand side 0 +ℕ S y to

--- a/test/Fail/Issue5848.err
+++ b/test/Fail/Issue5848.err
@@ -1,6 +1,7 @@
 Issue5848.agda:6,1-12
-warning: -W[no]GenericWarning
-Confluence checking incomplete because the definition of l1 contains unsolved metavariables.
+warning: -W[no]ConfluenceCheckingIncompleteBecauseOfMeta
+Confluence checking incomplete because the definition of l1
+contains unsolved metavariables.
 when checking the definition of l1
 Failed to solve the following constraints:
   ?2 = ?3 (i = Agda.Primitive.Cubical.i1)

--- a/test/Fail/Issue6805.err
+++ b/test/Fail/Issue6805.err
@@ -1,5 +1,5 @@
 Issue6805.agda:4,3-10
-warning: -W[no]GenericWarning
+warning: -W[no]MissingTypeSignatureForOpaque
 Missing type signature for opaque definition A.
 Types of opaque definitions are never inferred since this would
 leak information that should be opaque.

--- a/test/Fail/OpaqueTypeSig.err
+++ b/test/Fail/OpaqueTypeSig.err
@@ -1,5 +1,5 @@
 OpaqueTypeSig.agda:7,3-9
-warning: -W[no]GenericWarning
+warning: -W[no]MissingTypeSignatureForOpaque
 Missing type signature for opaque definition _.
 Types of opaque definitions are never inferred since this would
 leak information that should be opaque.

--- a/test/Succeed/CompileBuiltinListWarning.agda
+++ b/test/Succeed/CompileBuiltinListWarning.agda
@@ -5,6 +5,17 @@ data List (A : Set) : Set where
   _∷_ : A → List A → List A
 
 {-# COMPILE GHC List = data Non (Sense) #-} -- should result in warning when compiling
+
 {-# BUILTIN LIST List #-}
 {-# BUILTIN NIL  []   #-}
 {-# BUILTIN CONS _∷_  #-}
+
+data Maybe (A : Set) : Set where
+  nothing : Maybe A
+  just : A → Maybe A
+
+{-# COMPILE GHC Maybe = data Non (Sense) #-} -- should result in warning when compiling
+
+{-# BUILTIN MAYBE   Maybe   #-}
+-- {-# BUILTIN NOTHING nothing #-}
+-- {-# BUILTIN JUST    just    #-}

--- a/test/Succeed/CompileBuiltinListWarning.warn
+++ b/test/Succeed/CompileBuiltinListWarning.warn
@@ -1,24 +1,28 @@
-CompileBuiltinListWarning.agda:9,1-26
+CompileBuiltinListWarning.agda:10,1-26
 warning: -W[no]OldBuiltin
 Builtin NIL no longer exists. It is now bound by BUILTIN LIST
 when checking the pragma BUILTIN NIL []
-CompileBuiltinListWarning.agda:10,1-26
+CompileBuiltinListWarning.agda:11,1-26
 warning: -W[no]OldBuiltin
 Builtin CONS no longer exists. It is now bound by BUILTIN LIST
 when checking the pragma BUILTIN CONS _∷_
 
 ———— All done; warnings encountered ————————————————————————
 
-CompileBuiltinListWarning.agda:9,1-26
+CompileBuiltinListWarning.agda:10,1-26
 warning: -W[no]OldBuiltin
 Builtin NIL no longer exists. It is now bound by BUILTIN LIST
 when checking the pragma BUILTIN NIL []
 
-CompileBuiltinListWarning.agda:10,1-26
+CompileBuiltinListWarning.agda:11,1-26
 warning: -W[no]OldBuiltin
 Builtin CONS no longer exists. It is now bound by BUILTIN LIST
 when checking the pragma BUILTIN CONS _∷_
 CompileBuiltinListWarning.agda:7,1-44
-warning: -W[no]GenericWarning
+warning: -W[no]PragmaCompileList
 Ignoring GHC pragma for builtin lists; they always compile to
 Haskell lists.
+CompileBuiltinListWarning.agda:17,1-45
+warning: -W[no]PragmaCompileMaybe
+Ignoring GHC pragma for builtin MAYBE; it always compiles to
+Haskell Maybe.

--- a/test/Succeed/Issue1997.warn
+++ b/test/Succeed/Issue1997.warn
@@ -1,11 +1,11 @@
 Issue1997.agda:30,1-22
-warning: -W[no]GenericWarning
+warning: -W[no]DuplicateRewriteRule
 Rewrite rule  plus0  has already been added
 when checking the pragma REWRITE plus0
 
 ———— All done; warnings encountered ————————————————————————
 
 Issue1997.agda:30,1-22
-warning: -W[no]GenericWarning
+warning: -W[no]DuplicateRewriteRule
 Rewrite rule  plus0  has already been added
 when checking the pragma REWRITE plus0

--- a/test/Succeed/Issue2814.warn
+++ b/test/Succeed/Issue2814.warn
@@ -1,20 +1,24 @@
 Issue2814.agda:32,3-25
-warning: -W[no]GenericWarning
-Confluence checking for --cubical is not yet supported, confluence checking might be incomplete
+warning: -W[no]ConfluenceForCubicalNotSupported
+Confluence checking for --cubical is not yet supported, confluence
+checking might be incomplete
 when checking the pragma REWRITE unit-β
 Issue2814.agda:52,3-25
-warning: -W[no]GenericWarning
-Confluence checking for --cubical is not yet supported, confluence checking might be incomplete
+warning: -W[no]ConfluenceForCubicalNotSupported
+Confluence checking for --cubical is not yet supported, confluence
+checking might be incomplete
 when checking the pragma REWRITE unit-β
 
 ———— All done; warnings encountered ————————————————————————
 
 Issue2814.agda:32,3-25
-warning: -W[no]GenericWarning
-Confluence checking for --cubical is not yet supported, confluence checking might be incomplete
+warning: -W[no]ConfluenceForCubicalNotSupported
+Confluence checking for --cubical is not yet supported, confluence
+checking might be incomplete
 when checking the pragma REWRITE unit-β
 
 Issue2814.agda:52,3-25
-warning: -W[no]GenericWarning
-Confluence checking for --cubical is not yet supported, confluence checking might be incomplete
+warning: -W[no]ConfluenceForCubicalNotSupported
+Confluence checking for --cubical is not yet supported, confluence
+checking might be incomplete
 when checking the pragma REWRITE unit-β

--- a/test/Succeed/Issue2925.warn
+++ b/test/Succeed/Issue2925.warn
@@ -1,11 +1,11 @@
 Issue2925.agda:12,1-20
-warning: -W[no]GenericWarning
+warning: -W[no]DuplicateRewriteRule
 Rewrite rule  rew  has already been added
 when checking the pragma REWRITE rew
 
 ———— All done; warnings encountered ————————————————————————
 
 Issue2925.agda:12,1-20
-warning: -W[no]GenericWarning
+warning: -W[no]DuplicateRewriteRule
 Rewrite rule  rew  has already been added
 when checking the pragma REWRITE rew

--- a/test/Succeed/Issue3382.warn
+++ b/test/Succeed/Issue3382.warn
@@ -1,11 +1,13 @@
 Issue3382.agda:15,1-30
-warning: -W[no]GenericWarning
-Confluence checking for --cubical is not yet supported, confluence checking might be incomplete
+warning: -W[no]ConfluenceForCubicalNotSupported
+Confluence checking for --cubical is not yet supported, confluence
+checking might be incomplete
 when checking the pragma REWRITE hcompIntEmpty
 
 ———— All done; warnings encountered ————————————————————————
 
 Issue3382.agda:15,1-30
-warning: -W[no]GenericWarning
-Confluence checking for --cubical is not yet supported, confluence checking might be incomplete
+warning: -W[no]ConfluenceForCubicalNotSupported
+Confluence checking for --cubical is not yet supported, confluence
+checking might be incomplete
 when checking the pragma REWRITE hcompIntEmpty

--- a/test/Succeed/WarnBuiltinDeclaresIdentifier.agda
+++ b/test/Succeed/WarnBuiltinDeclaresIdentifier.agda
@@ -1,0 +1,17 @@
+-- Andreas, 2024-02-15, trigger warning BuiltinDeclaresIdentifier
+
+{-# OPTIONS --sized-types #-}
+
+{-# BUILTIN SIZEUNIV SizeUniv #-}
+{-# BUILTIN SIZE     Size     #-}
+
+postulate
+  ∞ : Size
+
+{-# BUILTIN SIZEINF  ∞        #-}
+
+-- Expected warning:
+
+-- BUILTIN SIZEINF declares an identifier (no longer expects an already defined identifier)
+-- when scope checking the declaration
+--   {-# BUILTIN SIZEINF ∞ #-}

--- a/test/Succeed/WarnBuiltinDeclaresIdentifier.warn
+++ b/test/Succeed/WarnBuiltinDeclaresIdentifier.warn
@@ -1,0 +1,15 @@
+WarnBuiltinDeclaresIdentifier.agda:11,1-34
+warning: -W[no]BuiltinDeclaresIdentifier
+BUILTIN SIZEINF declares an identifier (no longer expects an
+already defined identifier)
+when scope checking the declaration
+  {-# BUILTIN SIZEINF ∞ #-}
+
+———— All done; warnings encountered ————————————————————————
+
+WarnBuiltinDeclaresIdentifier.agda:11,1-34
+warning: -W[no]BuiltinDeclaresIdentifier
+BUILTIN SIZEINF declares an identifier (no longer expects an
+already defined identifier)
+when scope checking the declaration
+  {-# BUILTIN SIZEINF ∞ #-}


### PR DESCRIPTION
This clears 6 hours of technical dept.  Deleting `GenericWarning` will prevent new unclassified warnings as we saw in #6988 (fixed in #7112).

Commits:
- Warning ConfluenceCheckingIncompleteBecauseOfMeta instead of GenericWarning
- Warning BuiltinDeclaresIdentifier instead of GenericWarning
- Warning ConfluenceForCubicalNotSupported instead of GenericWarning
- Warnings PragmaCompile{List,Maybe} instead of GenericWarning
- Warning NoMain instead of GenericWarning
- Warning DuplicateRewriteRule instead of GenericWarning
- Warning MissingTypeSignatureForOpaque instead of GenericWarning
- Eradicate GenericWarning
