### PR TITLE
Fix for issue #7113

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1558,11 +1558,11 @@ inferExprForWith (Arg info e) = verboseBracket "tc.with.infer" 20 "inferExprForW
     reportSDoc "tc.with.infer" 20 $ "inferExprforWith " <+> prettyTCM e
     reportSLn  "tc.with.infer" 80 $ "inferExprforWith " ++ show (deepUnscope e)
     traceCall (InferExpr e) $ do
-      v0 <- reduce v
       (v, t) <- inferExpr e
+      v <- reduce v
       -- Andreas 2014-11-06, issue 1342.
       -- Check that we do not `with` on a module parameter!
-      case v0 of
+      case v of
         Var i [] -> whenM (isModuleFreeVar i) $ do
           reportSDoc "tc.with.infer" 80 $ vcat
             [ text $ "with expression is variable " ++ show i
@@ -1571,7 +1571,7 @@ inferExprForWith (Arg info e) = verboseBracket "tc.with.infer" 20 "inferExprForW
             , "context size = " <+> do text . show =<< getContextSize
             , "current context = " <+> do prettyTCM =<< getContextTelescope
             ]
-          typeError $ WithOnFreeVariable e v0
+          typeError $ WithOnFreeVariable e v
         _        -> return ()
       -- Possibly insert hidden arguments.
       TelV tel t0 <- telViewUpTo' (-1) (not . visible) t

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1558,9 +1558,8 @@ inferExprForWith (Arg info e) = verboseBracket "tc.with.infer" 20 "inferExprForW
     reportSDoc "tc.with.infer" 20 $ "inferExprforWith " <+> prettyTCM e
     reportSLn  "tc.with.infer" 80 $ "inferExprforWith " ++ show (deepUnscope e)
     traceCall (InferExpr e) $ do
-      -- With wants type and term fully instantiated!
-      (v, t) <- instantiateFull =<< inferExpr e
       v0 <- reduce v
+      (v, t) <- inferExpr e
       -- Andreas 2014-11-06, issue 1342.
       -- Check that we do not `with` on a module parameter!
       case v0 of

--- a/test/Succeed/Issue7113.agda
+++ b/test/Succeed/Issue7113.agda
@@ -1,0 +1,17 @@
+open import Agda.Builtin.Equality
+
+record Semiring : Set₁ where
+  field
+    Carrier   : Set
+    one       : Carrier
+    mul       : Carrier → Carrier → Carrier
+    left-unit : (r : Carrier) → mul one r ≡ r
+
+open Semiring {{...}}
+
+
+
+foo : {{R : Semiring}} (r : Carrier) → mul one r ≡ r
+foo r with mul one r | left-unit r
+...      | .r        | refl          = refl
+


### PR DESCRIPTION
This fixes #7113 by always solving awake constraints after checking a `with`-expression, thus solving any instance arguments contained therein.