### PR TITLE
Fix #6783: error for @tactic on lambda

### DIFF
--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -613,7 +613,9 @@ instance Eq Declaration where
 
 instance Underscore Expr where
   underscore   = Underscore emptyMetaInfo
-  isUnderscore = __IMPOSSIBLE__
+  isUnderscore = \case
+    Underscore _ -> True
+    _ -> False
 
 instance LensHiding LamBinding where
   getHiding   (DomainFree _ x) = getHiding x

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -454,7 +454,6 @@ checkLambda' cmp r tac xps typ body target = do
     b = A.TBind r tac xps typ
     xs = fmap (updateNamedArg (A.unBind . A.binderName)) xps
     numbinds = length xps
-    isUnderscore = \case { A.Underscore{} -> True; _ -> False }
     possiblePath = numbinds == 1 && isUnderscore (unScope typ)
                    && isRelevant info && visible info
     info = getArgInfo $ List1.head xs

--- a/test/Fail/Issue6783.agda
+++ b/test/Fail/Issue6783.agda
@@ -1,0 +1,23 @@
+-- Andreas, 2024-20-22, issue #6783
+-- Error for @tactic in lambda, rather than silently dropping it.
+
+-- {-# OPTIONS -v tc.term.lambda:30 #-}
+
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+super-tac : Term → TC ⊤
+super-tac hole = unify hole (lit (nat 101))
+
+bar = λ {@(tactic super-tac) n : Nat} → n + n
+
+_ : bar ≡ 202
+_ = refl
+
+-- Expected error:
+
+-- The @tactic attribute is not allowed here
+-- when checking that the expression
+-- λ {@(tactic super-tac) n : Nat} → n + n has type _4

--- a/test/Fail/Issue6783.err
+++ b/test/Fail/Issue6783.err
@@ -1,0 +1,4 @@
+Issue6783.agda:14,11-29
+The @tactic attribute is not allowed here
+when checking that the expression
+λ {@(tactic super-tac) n : Nat} → n + n has type _4


### PR DESCRIPTION
- **[ refactor ] AbstractToConcrete: generic ToConcrete Maybe instance**
- **[ refactor ] remove redundancy in parameters of checkLambda' and checkPath**
- **[ refactor ] move isUnderscore :: A.Expr -> Bool to the Underscore instance**
- **Fix #6783: error for @tactic in a lambda.**
