### PR TITLE
Add reference to Cornelis in the documentation

### DIFF
--- a/doc/user-manual/tools/emacs-mode.rst
+++ b/doc/user-manual/tools/emacs-mode.rst
@@ -6,12 +6,16 @@ Emacs Mode
 
 Agda programs are commonly edited using `Emacs
 <http://www.gnu.org/software/emacs/>`_ which is explained in this
-section.  Other editors with interactive support for Agda include Atom
-(`agda-mode on Atom <https://atom.io/packages/agda-mode>`_), Visual
-Studio Code (`agda-mode on VS Code
-<https://github.com/banacorn/agda-mode-vscode>`_), Neovim (`Cornelis
-<https://github.com/isovector/cornelis>`_), and Vim (`agda-vim
-<https://github.com/derekelkins/agda-vim>`_).
+section.  Other editors with interactive support for Agda include
+
+* Visual Studio Code (`agda-mode on VS Code
+  <https://github.com/banacorn/agda-mode-vscode>`_)
+
+* Neovim (`Cornelis
+  <https://github.com/isovector/cornelis>`_), and
+
+* Vim (`agda-vim
+  <https://github.com/derekelkins/agda-vim>`_)
 
 To edit a module in Emacs (assuming you have :ref:`installed
 <installation>` Agda and the Emacs mode properly), open a file ending

--- a/doc/user-manual/tools/emacs-mode.rst
+++ b/doc/user-manual/tools/emacs-mode.rst
@@ -9,7 +9,8 @@ Agda programs are commonly edited using `Emacs
 section.  Other editors with interactive support for Agda include Atom
 (`agda-mode on Atom <https://atom.io/packages/agda-mode>`_), Visual
 Studio Code (`agda-mode on VS Code
-<https://github.com/banacorn/agda-mode-vscode>`_), and Vim (`agda-vim
+<https://github.com/banacorn/agda-mode-vscode>`_), Neovim (`Cornelis
+<https://github.com/isovector/cornelis>`_), and Vim (`agda-vim
 <https://github.com/derekelkins/agda-vim>`_).
 
 To edit a module in Emacs (assuming you have :ref:`installed


### PR DESCRIPTION
This commit adds a reference to [Cornelis](https://github.com/isovector/cornelis) a mature and well maintained editor ecosystem for neovim agda editing.