### PR TITLE
Fix #7146: printing of cohesion and lock attributes

### DIFF
--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -27,7 +27,7 @@ import           Agda.Interaction.Highlighting.Range   ( rToR )  -- Range is amb
 import           Agda.Syntax.Abstract                ( IsProjP(..) )
 import qualified Agda.Syntax.Abstract      as A
 import           Agda.Syntax.Common        as Common
-import           Agda.Syntax.Concrete                ( FieldAssignment'(..) )
+import           Agda.Syntax.Concrete                ( FieldAssignment'(..), TacticAttribute' )
 import qualified Agda.Syntax.Concrete.Name as C
 import           Agda.Syntax.Info                    ( ModuleInfo(..) )
 import           Agda.Syntax.Literal
@@ -102,6 +102,7 @@ instance Hilite a => Hilite [a]
 instance Hilite a => Hilite (List1 a)
 instance Hilite a => Hilite (Maybe a)
 instance Hilite a => Hilite (Ranged a)
+instance Hilite a => Hilite (TacticAttribute' a)
 instance Hilite a => Hilite (WithHiding a)
 
 instance Hilite Void where

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -13,7 +13,7 @@ import Data.Void
 
 import Agda.Syntax.Common
 import Agda.Syntax.Abstract as A
-import Agda.Syntax.Concrete (FieldAssignment', exprFieldA)
+import Agda.Syntax.Concrete (FieldAssignment', exprFieldA, TacticAttribute')
 import Agda.Syntax.Info
 import Agda.Syntax.Scope.Base (KindOfName(..), conKindOfName, WithKind(..))
 
@@ -257,6 +257,7 @@ instance ExprLike a => ExprLike (Named x a)
 instance ExprLike a => ExprLike (Ranged a)
 instance ExprLike a => ExprLike [a]
 instance ExprLike a => ExprLike (List1 a)
+instance ExprLike a => ExprLike (TacticAttribute' a)
 
 instance (ExprLike a, ExprLike b) => ExprLike (a, b) where
   recurseExpr f (x, y) = (,) <$> recurseExpr f x <*> recurseExpr f y

--- a/src/full/Agda/Syntax/Common/Pretty.hs
+++ b/src/full/Agda/Syntax/Common/Pretty.hs
@@ -102,7 +102,7 @@ instance Pretty () where
   pretty _ = P.empty
 
 instance Pretty a => Pretty (Maybe a) where
-  prettyPrec p Nothing  = "(nothing)"
+  prettyPrec p Nothing  = P.empty
   prettyPrec p (Just x) = prettyPrec p x
 
 instance Pretty a => Pretty [a] where

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -271,8 +271,10 @@ dropTypeAndModality (DomainFree x) = [DomainFree $ setModality defaultModality x
 data BoundName = BName
   { boundName       :: Name
   , bnameFixity     :: Fixity'
-  , bnameTactic     :: TacticAttribute -- From @tactic attribute
+  , bnameTactic     :: TacticAttribute
+      -- ^ From @\@tactic@ attribute.
   , bnameIsFinite   :: Bool
+      -- ^ The @\@finite@ cannot be parsed, it comes from the builtin @Partial@ only.
   }
   deriving Eq
 

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -37,6 +37,7 @@ module Agda.Syntax.Concrete
   , ModuleAssignment(..)
   , BoundName(..), mkBoundName_, mkBoundName
   , TacticAttribute
+  , TacticAttribute'(..)
   , Telescope, Telescope1
   , lamBindingsToTelescope
   , makePi
@@ -72,6 +73,7 @@ import Control.DeepSeq
 
 import qualified Data.DList as DL
 import Data.Functor.Identity
+import Data.Maybe
 import Data.Set         ( Set  )
 import Data.Text        ( Text )
 -- import Data.Traversable ( forM )
@@ -274,13 +276,19 @@ data BoundName = BName
   }
   deriving Eq
 
-type TacticAttribute = Maybe (Ranged Expr)
+newtype TacticAttribute' a = TacticAttribute { theTacticAttribute :: Maybe (Ranged a) }
+  deriving (Eq, Show, NFData, Functor, Foldable, Traversable, KillRange)
+type TacticAttribute = TacticAttribute' Expr
+
+instance Null (TacticAttribute' a) where
+  null = isNothing . theTacticAttribute
+  empty = TacticAttribute Nothing
 
 mkBoundName_ :: Name -> BoundName
 mkBoundName_ x = mkBoundName x noFixity'
 
 mkBoundName :: Name -> Fixity' -> BoundName
-mkBoundName x f = BName x f Nothing False
+mkBoundName x f = BName x f empty False
 
 -- | A typed binding.
 

--- a/src/full/Agda/Syntax/Concrete/Attribute.hs
+++ b/src/full/Agda/Syntax/Concrete/Attribute.hs
@@ -13,6 +13,7 @@ import Data.Maybe
 
 import Agda.Syntax.Common
 import Agda.Syntax.Concrete (Expr(..), TacticAttribute)
+import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Concrete.Pretty () --instance only
 import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Position
@@ -216,8 +217,9 @@ isQuantityAttribute = \case
   _ -> Nothing
 
 isTacticAttribute :: Attribute -> TacticAttribute
-isTacticAttribute (TacticAttribute t) = Just t
-isTacticAttribute _                   = Nothing
+isTacticAttribute = C.TacticAttribute . \case
+  TacticAttribute t -> Just t
+  _ -> Nothing
 
 relevanceAttributes :: [Attribute] -> [Attribute]
 relevanceAttributes = filter $ isJust . isRelevanceAttribute
@@ -226,4 +228,4 @@ quantityAttributes :: [Attribute] -> [Attribute]
 quantityAttributes = filter $ isJust . isQuantityAttribute
 
 tacticAttributes :: [Attribute] -> [Attribute]
-tacticAttributes = filter $ isJust . isTacticAttribute
+tacticAttributes = filter $ isJust . C.theTacticAttribute . isTacticAttribute

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -1466,9 +1466,9 @@ instance MakePrivate WhereClause where
 -- 'Declaration's.
 notSoNiceDeclarations :: NiceDeclaration -> [Declaration]
 notSoNiceDeclarations = \case
-    Axiom _ _ _ i rel x e          -> inst i [TypeSig rel Nothing x e]
+    Axiom _ _ _ i rel x e          -> inst i [TypeSig rel empty x e]
     NiceField _ _ _ i tac x argt   -> [FieldSig i tac x argt]
-    PrimitiveFunction r _ _ x e    -> [Primitive r [TypeSig (argInfo e) Nothing x (unArg e)]]
+    PrimitiveFunction r _ _ x e    -> [Primitive r [TypeSig (argInfo e) empty x (unArg e)]]
     NiceMutual r _ _ _ ds          -> [Mutual r $ concatMap notSoNiceDeclarations ds]
     NiceLoneConstructor r ds       -> [LoneConstructor r $ concatMap notSoNiceDeclarations ds]
     NiceModule r _ _ e x tel ds    -> [Module r e x tel ds]
@@ -1480,7 +1480,7 @@ notSoNiceDeclarations = \case
     NiceRecSig r er _ _ _ _ x bs e -> [RecordSig r er x bs e]
     NiceDataSig r er _ _ _ _ x bs e -> [DataSig r er x bs e]
     NiceFunClause _ _ _ _ _ _ d    -> [d]
-    FunSig _ _ _ i _ rel _ _ x e   -> inst i [TypeSig rel Nothing x e]
+    FunSig _ _ _ i _ rel _ _ x e   -> inst i [TypeSig rel empty x e]
     FunDef _ ds _ _ _ _ _ _        -> ds
     NiceDataDef r _ _ _ _ x bs cs  -> [DataDef r x bs $ concatMap notSoNiceDeclarations cs]
     NiceRecDef r _ _ _ _ x dir bs ds -> [RecordDef r x dir bs ds]

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -87,6 +87,7 @@ instance ExprLike a => ExprLike (WithHiding a)
 
 instance ExprLike a => ExprLike (MaybePlaceholder a)
 instance ExprLike a => ExprLike (RHS' a)
+instance ExprLike a => ExprLike (TacticAttribute' a)
 instance ExprLike a => ExprLike (TypedBinding' a)
 instance ExprLike a => ExprLike (WhereClause' a)
 

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -105,8 +105,11 @@ prettyFiniteness name
   | otherwise = id
 
 prettyTactic' :: TacticAttribute -> Doc -> Doc
-prettyTactic' Nothing  d = d
-prettyTactic' (Just t) d = "@" <> (parens ("tactic" <+> pretty t) <+> d)
+prettyTactic' t = (pretty t <+>)
+
+instance Pretty a => Pretty (TacticAttribute' a) where
+  pretty (TacticAttribute t) =
+    ifNull (pretty t) empty \ d -> "@" <> parens ("tactic" <+> d)
 
 instance (Pretty a, Pretty b) => Pretty (a, b) where
     pretty (a, b) = parens $ (pretty a <> comma) <+> pretty b
@@ -318,7 +321,7 @@ instance Pretty NamedBinding where
         | otherwise = id
     -- Parentheses are needed when an attribute @... is present
     mparens
-      | noUserQuantity x, Nothing <- bnameTactic bn = id
+      | noUserQuantity x, null (bnameTactic bn) = id
       | otherwise = parens
 
 instance Pretty LamBinding where

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -84,11 +84,14 @@ prettyRelevance a = (pretty (getRelevance a) <>)
 prettyQuantity :: LensQuantity a => a -> Doc -> Doc
 prettyQuantity a = (pretty (getQuantity a) <+>)
 
+instance Pretty Lock where
+  pretty = \case
+    IsLock LockOLock -> "@lock"
+    IsLock LockOTick -> "@tick"
+    IsNotLock -> empty
+
 prettyLock :: LensLock a => a -> Doc -> Doc
-prettyLock a doc = case getLock a of
-  IsLock LockOLock -> "@lock" <+> doc
-  IsLock LockOTick -> "@tick" <+> doc
-  IsNotLock -> doc
+prettyLock a = (pretty (getLock a) <+>)
 
 prettyErased :: Erased -> Doc -> Doc
 prettyErased = prettyQuantity . asQuantity
@@ -285,8 +288,10 @@ instance Pretty LamClause where
       pretty' (RHS e)   = arrow <+> pretty e
       pretty' AbsurdRHS = empty
 
+-- Andreas, 2024-02-25
+-- Q: Can we always ignore the tactic and the finiteness here?
 instance Pretty BoundName where
-  pretty BName{ boundName = x } = pretty x
+  pretty (BName x _fix _tac _fin) = pretty x
 
 data NamedBinding = NamedBinding
   { withHiding   :: Bool
@@ -300,29 +305,31 @@ isLabeled x
   | otherwise              = Nothing
 
 instance Pretty a => Pretty (Binder' a) where
-  pretty (Binder mpat n) = let d = pretty n in case mpat of
-    Nothing  -> d
-    Just pat -> d <+> "@" <+> parens (pretty pat)
+  pretty (Binder mpat n) =
+    applyWhenJust mpat (\ pat -> (<+> ("@" <+> parens (pretty pat)))) $ pretty n
 
 instance Pretty NamedBinding where
-  pretty (NamedBinding withH x) = prH $
-    if | Just l <- isLabeled x -> text l <+> "=" <+> pretty xb
-       | otherwise             -> pretty xb
-
+  pretty (NamedBinding withH
+           x@(Arg (ArgInfo h (Modality r q c) _o _fv (Annotation lock))
+               (Named _mn xb@(Binder _mp (BName _y _fix t _fin))))) =
+    applyWhen withH prH $
+    applyWhenJust (isLabeled x) (\ l -> (text l <+>) . ("=" <+>)) (pretty xb)
+      -- isLabeled looks at _mn and _y
+      -- pretty xb prints also the pattern _mp
     where
+    prH = (pretty r <>)
+        . prettyHiding h mparens
+        . (coh <+>)
+        . (qnt <+>)
+        . (lck <+>)
+        . (tac <+>)
+    coh = pretty c
+    qnt = pretty q
+    tac = pretty t
+    lck = pretty lock
+    -- Parentheses are needed when an attribute @... is printed
+    mparens = applyUnless (null coh && null qnt && null lck && null tac) parens
 
-    xb = namedArg x
-    bn = binderName xb
-    prH | withH     = prettyRelevance x
-                    . prettyHiding x mparens
-                    . prettyCohesion x
-                    . prettyQuantity x
-                    . prettyTactic bn
-        | otherwise = id
-    -- Parentheses are needed when an attribute @... is present
-    mparens
-      | noUserQuantity x, null (bnameTactic bn) = id
-      | otherwise = parens
 
 instance Pretty LamBinding where
     pretty (DomainFree x) = pretty (NamedBinding True x)

--- a/src/full/Agda/Syntax/Info.hs
+++ b/src/full/Agda/Syntax/Info.hs
@@ -154,7 +154,7 @@ data DefInfo' t = DefInfo
   , defInstance :: IsInstance
   , defMacro    :: IsMacro
   , defInfo     :: DeclInfo
-  , defTactic   :: Maybe (Ranged t)
+  , defTactic   :: TacticAttribute' t
   }
   deriving (Show, Eq, Generic)
 
@@ -163,7 +163,7 @@ mkDefInfo x f a ab r = mkDefInfoInstance x f a ab NotInstanceDef NotMacroDef r
 
 -- | Same as @mkDefInfo@ but where we can also give the @IsInstance@
 mkDefInfoInstance :: Name -> Fixity' -> Access -> IsAbstract -> IsInstance -> IsMacro -> Range -> DefInfo' t
-mkDefInfoInstance x f a ab i m r = DefInfo f a ab TransparentDef i m (DeclInfo x r) Nothing
+mkDefInfoInstance x f a ab i m r = DefInfo f a ab TransparentDef i m (DeclInfo x r) empty
 
 instance HasRange (DefInfo' t) where
   getRange = getRange . defInfo

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -39,7 +39,7 @@ import Data.Maybe
 import Data.Void
 
 import Agda.Syntax.Concrete as C
-import Agda.Syntax.Concrete.Attribute
+import Agda.Syntax.Concrete.Attribute as CA
 import Agda.Syntax.Concrete.Generic
 import Agda.Syntax.Concrete.Operators
 import Agda.Syntax.Concrete.Pattern
@@ -1110,10 +1110,11 @@ instance ToAbstract C.TypedBinding where
 
   toAbstract (C.TBind r xs t) = do
     t' <- toAbstractCtx TopCtx t
-    tac <- traverse toAbstract $
+    tac <- C.TacticAttribute <$> do
+     traverse toAbstract $
       -- Invariant: all tactics are the same
       -- (distributed in the parser, TODO: don't)
-      case List1.mapMaybe (bnameTactic . C.binderName . namedArg) xs of
+      case List1.mapMaybe (theTacticAttribute . bnameTactic . C.binderName . namedArg) xs of
         []      -> Nothing
         tac : _ -> Just tac
 
@@ -3279,7 +3280,7 @@ checkAttributes []                     = return ()
 checkAttributes ((attr, r, s) : attrs) =
   case attr of
     RelevanceAttribute{}    -> cont
-    TacticAttribute{}       -> cont
+    CA.TacticAttribute{}    -> cont
     LockAttribute IsNotLock -> cont
     LockAttribute IsLock{}  -> do
       unlessM (optGuarded <$> pragmaOptions) $

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -40,7 +40,7 @@ import Agda.Syntax.Literal
 import Agda.Syntax.Position
 import Agda.Syntax.Common
 import qualified Agda.Syntax.Concrete.Name as C
-import Agda.Syntax.Concrete (FieldAssignment'(..))
+import Agda.Syntax.Concrete (FieldAssignment'(..), TacticAttribute'(..))
 import Agda.Syntax.Info as Info
 import Agda.Syntax.Abstract as A hiding (Binder)
 import qualified Agda.Syntax.Abstract as A
@@ -594,7 +594,7 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
             {- else -} (reify a)
       where
         mkPi b (Arg info a') = ifM (skipGeneralizedParameter info) (snd <$> reify b) $ do
-          tac <- traverse (Ranged noRange <.> reify) $ domTactic a
+          tac <- TacticAttribute <$> do traverse (Ranged noRange <.> reify) $ domTactic a
           (x, b) <- reify b
           let xs = singleton $ Arg info $ Named (domName a) $ mkBinder_ x
           return $ A.Pi noExprInfo
@@ -1532,7 +1532,7 @@ instance Reify I.Telescope where
     (x, bs)  <- reify tel
     let r    = getRange e
         name = domName arg
-    tac <- traverse (Ranged noRange <.> reify) $ domTactic arg
+    tac <- TacticAttribute <$> do traverse (Ranged noRange <.> reify) $ domTactic arg
     let xs = singleton $ Arg info $ Named name $ A.mkBinder_ x
     return $ TBind r (TypedBindingInfo tac (domIsFinite arg)) xs e : bs
 {-# SPECIALIZE reify :: I.Telescope -> TCM (ReifiesTo I.Telescope) #-}

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -145,7 +145,7 @@ instance (ToAbstract r, AbsOfRef r ~ A.Expr) => ToAbstract (Dom r, Name) where
     -- TODO(Amy): Anyone know why this discards the tactic? It was like
     -- that when I got here!
     return $ A.TBind noRange
-      (A.TypedBindingInfo Nothing isfin)
+      (A.TypedBindingInfo empty isfin)
       (singleton $ unnamedArg i $ A.mkBinder_ name)
       dom
 

--- a/src/full/Agda/Utils/Null.hs
+++ b/src/full/Agda/Utils/Null.hs
@@ -182,3 +182,6 @@ whenNullM ma k = ma >>= (`whenNull` k)
 
 unlessNullM :: (Monad m, Null a) => m a -> (a -> m ()) -> m ()
 unlessNullM ma k = ma >>= (`unlessNull` k)
+
+applyUnlessNull :: (Null a) => a -> (a -> b -> b) -> (b -> b)
+applyUnlessNull a f = if null a then id else f a

--- a/test/Fail/Issue3945.err
+++ b/test/Fail/Issue3945.err
@@ -1,4 +1,4 @@
 Issue3945.agda:10,8-25
 Incorrect cohesion annotation in lambda
-when checking that the expression λ @♭ a → flat a has type
+when checking that the expression λ (@♭ a) → flat a has type
 A → Flat A

--- a/test/Fail/Issue5033.err
+++ b/test/Fail/Issue5033.err
@@ -1,3 +1,3 @@
 Issue5033.agda:4,10-29
 Missing binding for primLockUniv primitive.
-when checking that the expression ∀ _ → Set is a type
+when checking that the expression ∀ (@tick _) → Set is a type

--- a/test/Fail/Issue7146.agda
+++ b/test/Fail/Issue7146.agda
@@ -1,0 +1,34 @@
+-- Andreas, 2024-02-25, issue #7146, printer bugs:
+-- Missing parenthesis in domain-free module parameter with cohesion.
+-- Missing printing of @lock attribute.
+
+{-# OPTIONS --cohesion --erasure --guarded #-}
+
+import Agda.Builtin.Bool
+open import Agda.Builtin.Sigma
+
+primitive
+  primLockUniv : Set₁
+
+postulate
+  Tick : primLockUniv
+  Foo  : @♭ Set → Tick → Set
+
+module @0 Bool where
+
+  -- Trigger an error here printing the module telescope, e.g.
+  -- "Not supported: open public in hard compile-time mode".
+
+  open module M (@♭ A) (@lock l) (_ : Foo A l) {@ω B = C : Set} {D : C → Set} {p@(u , v) : Σ C D}
+    = Agda.Builtin.Bool public
+
+-- Expect to fail.
+--
+-- Error was:
+-- when checking the module application
+-- module M @♭ A l (_ : Foo A l) ...
+--
+-- This misprints the module parameters, correct is:
+-- module M (@♭ A) (@lock l) ...
+--
+-- Should print the module telescope correctly.

--- a/test/Fail/Issue7146.err
+++ b/test/Fail/Issue7146.err
@@ -1,0 +1,7 @@
+Issue7146.agda:22,3-23,31
+Not supported: open public in hard compile-time mode (for instance
+in erased modules)
+when checking the module application
+module M (@♭ A) (@lock l) (_ : Foo A l) {@ω B = C : Set}
+         {D : C → Set} {p @ (u , v) : Σ C D}
+  = Agda.Builtin.Bool


### PR DESCRIPTION
- Refactor: introduce `newtype TacticAnnotation`
- Close #7146, bug discovered during the refactoring