### PR TITLE
Fix mutual information not being set properly by the positivity checker

### DIFF
--- a/test/Succeed/Test4687.agda
+++ b/test/Succeed/Test4687.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --overlapping-instances #-}
 
 open import Agda.Primitive
 open import Agda.Builtin.List

--- a/test/interaction/Issue7133.agda
+++ b/test/interaction/Issue7133.agda
@@ -1,0 +1,18 @@
+
+module _ where
+
+open import Agda.Primitive
+
+record Point (A : Set) : Set where
+  field
+    pt : A
+
+record PointedSet : Set₁ where
+  field
+    Carrier : Set
+    point   : Point Carrier
+
+module _ (sto : PointedSet) where
+
+  foo : Set
+  foo = {!!}

--- a/test/interaction/Issue7133.in
+++ b/test/interaction/Issue7133.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 0 cmd_autoOne ""

--- a/test/interaction/Issue7133.out
+++ b/test/interaction/Issue7133.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : Set " nil)
+((last . 1) . (agda2-goals-action '(0)))
+(agda2-give-action 0 "PointedSet.Carrier sto")
+((last . 1) . (agda2-goals-action '()))


### PR DESCRIPTION
Fixes #7133

_Note to future git-bisecters_

The missing mutual information caused some functions to not be considered for projection-likeness, so if you end up blaming this commit, there might be a bug with projection-likeness.