### PR TITLE
Fix #6667: case not `__IMPOSSIBLE__` for nullary syntax

### DIFF
--- a/test/Succeed/Issue6667.agda
+++ b/test/Succeed/Issue6667.agda
@@ -1,0 +1,16 @@
+-- Andreas, 2024-03-01, issue #6667
+-- Reported by @Soares, MWE by @szumixie
+
+postulate
+  A : Set
+  F : Set → Set
+
+-- Nullary syntax definition caused internal error in scope checker.
+
+syntax A = S
+
+B = F S
+
+-- WAS: internal error.
+
+-- Should succeed.


### PR DESCRIPTION
Return `[]` instead of `__IMPOSSIBLE__`.
Closes #6667.