### PR TITLE
Fix #6945: warn about useless private even in absense of nice decls

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -1244,7 +1244,6 @@ niceDeclarations fixs ds = do
         -- A mutual block cannot have a measure,
         -- but it can skip termination check.
 
-    abstractBlock _ [] = return []
     abstractBlock r ds = do
       (ds', anyChange) <- runChangeT $ mkAbstract ds
       let inherited = r == noRange
@@ -1253,7 +1252,6 @@ niceDeclarations fixs ds = do
         unless inherited $ declarationWarning $ UselessAbstract r
         return ds -- no change!
 
-    privateBlock _ _ [] = return []
     privateBlock r o ds = do
       (ds', anyChange) <- runChangeT $ mkPrivate o ds
       if anyChange then return ds' else do
@@ -1264,7 +1262,6 @@ niceDeclarations fixs ds = do
       :: Range  -- Range of @instance@ keyword.
       -> [NiceDeclaration]
       -> Nice [NiceDeclaration]
-    instanceBlock _ [] = return []
     instanceBlock r ds = do
       let (ds', anyChange) = runChange $ mapM (mkInstance r) ds
       if anyChange then return ds' else do

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -473,10 +473,10 @@ instance Pretty DeclarationWarning' where
       pwords "Termination checking pragmas can only precede a function definition or a mutual block (that contains a function definition)."
 
     InvalidConstructor{} -> fsep $
-      pwords "`constructor' blocks may only contain type signatures for constructors."
+      pwords "`data _ where' blocks may only contain type signatures for constructors."
 
     InvalidConstructorBlock{} -> fsep $
-      pwords "No `constructor' blocks outside of `interleaved mutual' blocks."
+      pwords "No `data _ where' blocks outside of `interleaved mutual' blocks."
 
     InvalidCoverageCheckPragma _ -> fsep $
       pwords "Coverage checking pragmas can only precede a function definition or a mutual block (that contains a function definition)."

--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -244,7 +244,7 @@ instance Pretty NiceDeclaration where
     FunSig _ _ _ _ _ _ _ _ x _     -> pretty x <+> colon <+> text "_"
     FunDef _ _ _ _ _ _ x _         -> pretty x <+> text "= _"
     NiceDataDef _ _ _ _ _ x _ _    -> text "data" <+> pretty x <+> text "where"
-    NiceLoneConstructor _ ds       -> text "constructor"
+    NiceLoneConstructor _ _        -> text "data _ where"
     NiceRecDef _ _ _ _ _ x  _ _ _  -> text "record" <+> pretty x <+> text "where"
     NicePatternSyn _ _ x _ _       -> text "pattern" <+> pretty x
     NiceGeneralize _ _ _ _ x _     -> text "variable" <+> pretty x

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -505,7 +505,7 @@ instance Pretty Declaration where
                              <+> "=" <+> pretty p
     Mutual _ ds     -> namedBlock "mutual" ds
     InterleavedMutual _ ds  -> namedBlock "interleaved mutual" ds
-    LoneConstructor _ ds -> namedBlock "constructor" ds
+    LoneConstructor _ ds -> namedBlock "data _ where" ds
     Abstract _ ds   -> namedBlock "abstract" ds
     Private _ _ ds  -> namedBlock "private" ds
     InstanceB _ ds  -> namedBlock "instance" ds

--- a/test/Succeed/Issue2759.agda
+++ b/test/Succeed/Issue2759.agda
@@ -1,39 +1,51 @@
 -- Andreas, 2017-09-16, issue #2759
 -- Allow empty declaration blocks in the parser.
+--
+-- Andreas, 2024-03-02, issue #6945
 
-open import Agda.Builtin.Nat
+--------------------------------------------------------------
+-- Empty blocks should be accepted, but trigger a warning.
 
-x0 = zero
-mutual
-x1 = suc x0
 abstract
-x2 = suc x1
-private
-x3 = suc x2
+data _ where
 instance
-x4 = suc x3
+interleaved mutual
 macro
-x5 = suc x4
+mutual
+opaque
+opaque unfolding
 postulate
-x6 = suc x5
+primitive
+private
+variable
 
--- Expected: 6 warnings about empty blocks
+--------------------------------------------------------------
+-- Empty blocks are also tolerated in lets and lambdas.
+
+_ = λ (let abstract          ) → let abstract           in Set
+_ = λ (let data _ where      ) → let data _ where       in Set
+_ = λ (let instance          ) → let instance           in Set
+_ = λ (let interleaved mutual) → let interleaved mutual in Set
+_ = λ (let macro             ) → let macro              in Set
+_ = λ (let mutual            ) → let mutual             in Set
+_ = λ (let postulate         ) → let postulate          in Set
+_ = λ (let primitive         ) → let primitive          in Set
+_ = λ (let private           ) → let private            in Set
+_ = λ (let variable          ) → let variable           in Set
+
+-- N.B.: Opaque is not allowed in let blocks.
+-- _ = λ (let opaque) → let opaque in Set
+
+--------------------------------------------------------------
+-- Nesting blocks.
 
 mutual
   postulate
 
--- Empty postulate block.
+-- Expected: Empty postulate block.
 
 abstract private instance macro
 
+-- Expected:
 -- Empty macro block.
-
--- Empty blocks are also tolerated in lets and lambdas.
-
-_ = λ (let abstract ) → let abstract  in Set
-_ = λ (let field    ) → let field     in Set
-_ = λ (let instance ) → let instance  in Set
-_ = λ (let macro    ) → let macro     in Set
-_ = λ (let mutual   ) → let mutual    in Set
-_ = λ (let postulate) → let postulate in Set
-_ = λ (let private  ) → let private   in Set
+-- Useless abstract private instance blocks.

--- a/test/Succeed/Issue2759.warn
+++ b/test/Succeed/Issue2759.warn
@@ -1,184 +1,323 @@
-Issue2759.agda:7,1-7
-warning: -W[no]EmptyMutual
-Empty mutual block.
 Issue2759.agda:9,1-9
 warning: -W[no]EmptyAbstract
 Empty abstract block.
-Issue2759.agda:11,1-8
-warning: -W[no]EmptyPrivate
-Empty private block.
-Issue2759.agda:13,1-9
+Issue2759.agda:10,1-5
+warning: -W[no]EmptyConstructor
+Empty constructor block.
+Issue2759.agda:11,1-9
 warning: -W[no]EmptyInstance
 Empty instance block.
-Issue2759.agda:15,1-6
+Issue2759.agda:12,1-19
+warning: -W[no]EmptyMutual
+Empty mutual block.
+Issue2759.agda:13,1-6
 warning: -W[no]EmptyMacro
 Empty macro block.
+Issue2759.agda:14,1-7
+warning: -W[no]EmptyMutual
+Empty mutual block.
 Issue2759.agda:17,1-10
 warning: -W[no]EmptyPostulate
 Empty postulate block.
-Issue2759.agda:23,3-12
+Issue2759.agda:18,1-10
+warning: -W[no]EmptyPrimitive
+Empty primitive block.
+Issue2759.agda:19,1-8
+warning: -W[no]EmptyPrivate
+Empty private block.
+Issue2759.agda:20,1-9
+warning: -W[no]EmptyGeneralize
+Empty variable block.
+Issue2759.agda:43,3-12
 warning: -W[no]EmptyPostulate
 Empty postulate block.
-Issue2759.agda:27,27-32
+Issue2759.agda:47,27-32
 warning: -W[no]EmptyMacro
 Empty macro block.
-Issue2759.agda:33,12-20
+Issue2759.agda:47,18-26
+warning: -W[no]UselessInstance
+Using instance here has no effect. Instance applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and axioms.
+Issue2759.agda:47,10-26
+warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+Issue2759.agda:47,1-26
+warning: -W[no]UselessAbstract
+Using abstract here has no effect. Abstract applies to only
+definitions like data definitions, record type definitions and
+function clauses.
+Issue2759.agda:15,1-7
+warning: -W[no]UselessOpaque
+This 'opaque' block has no effect.
+when scope checking the declaration
+  opaque unfolding {}
+Issue2759.agda:16,1-17
+warning: -W[no]UselessOpaque
+This 'opaque' block has no effect.
+when scope checking the declaration
+  opaque unfolding {}
+Issue2759.agda:25,12-20
 warning: -W[no]EmptyAbstract
 Empty abstract block.
 when scope checking λ (let abstract) → let abstract in Set
-Issue2759.agda:33,29-37
+Issue2759.agda:25,38-46
 warning: -W[no]EmptyAbstract
 Empty abstract block.
 when scope checking let abstract in Set
-Issue2759.agda:34,12-17
-warning: -W[no]EmptyField
-Empty field block.
-when scope checking λ (let field) → let field in Set
-Issue2759.agda:34,29-34
-warning: -W[no]EmptyField
-Empty field block.
-when scope checking let field in Set
-Issue2759.agda:35,12-20
+Issue2759.agda:26,12-16
+warning: -W[no]EmptyConstructor
+Empty constructor block.
+when scope checking λ (let data _ where) → let data _ where in Set
+Issue2759.agda:26,38-42
+warning: -W[no]EmptyConstructor
+Empty constructor block.
+when scope checking let data _ where in Set
+Issue2759.agda:27,12-20
 warning: -W[no]EmptyInstance
 Empty instance block.
 when scope checking λ (let instance) → let instance in Set
-Issue2759.agda:35,29-37
+Issue2759.agda:27,38-46
 warning: -W[no]EmptyInstance
 Empty instance block.
 when scope checking let instance in Set
-Issue2759.agda:36,12-17
+Issue2759.agda:28,12-30
+warning: -W[no]EmptyMutual
+Empty mutual block.
+when scope checking
+λ (let interleaved mutual) → let interleaved mutual in Set
+Issue2759.agda:28,38-56
+warning: -W[no]EmptyMutual
+Empty mutual block.
+when scope checking let interleaved mutual in Set
+Issue2759.agda:29,12-17
 warning: -W[no]EmptyMacro
 Empty macro block.
 when scope checking λ (let macro) → let macro in Set
-Issue2759.agda:36,29-34
+Issue2759.agda:29,38-43
 warning: -W[no]EmptyMacro
 Empty macro block.
 when scope checking let macro in Set
-Issue2759.agda:37,12-18
+Issue2759.agda:30,12-18
 warning: -W[no]EmptyMutual
 Empty mutual block.
 when scope checking λ (let mutual) → let mutual in Set
-Issue2759.agda:37,29-35
+Issue2759.agda:30,38-44
 warning: -W[no]EmptyMutual
 Empty mutual block.
 when scope checking let mutual in Set
-Issue2759.agda:38,12-21
+Issue2759.agda:31,12-21
 warning: -W[no]EmptyPostulate
 Empty postulate block.
 when scope checking λ (let postulate) → let postulate in Set
-Issue2759.agda:38,29-38
+Issue2759.agda:31,38-47
 warning: -W[no]EmptyPostulate
 Empty postulate block.
 when scope checking let postulate in Set
-Issue2759.agda:39,12-19
+Issue2759.agda:32,12-21
+warning: -W[no]EmptyPrimitive
+Empty primitive block.
+when scope checking λ (let primitive) → let primitive in Set
+Issue2759.agda:32,38-47
+warning: -W[no]EmptyPrimitive
+Empty primitive block.
+when scope checking let primitive in Set
+Issue2759.agda:33,12-19
 warning: -W[no]EmptyPrivate
 Empty private block.
 when scope checking λ (let private) → let private in Set
-Issue2759.agda:39,29-36
+Issue2759.agda:33,38-45
 warning: -W[no]EmptyPrivate
 Empty private block.
 when scope checking let private in Set
+Issue2759.agda:34,12-20
+warning: -W[no]EmptyGeneralize
+Empty variable block.
+when scope checking λ (let variable) → let variable in Set
+Issue2759.agda:34,38-46
+warning: -W[no]EmptyGeneralize
+Empty variable block.
+when scope checking let variable in Set
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue2759.agda:7,1-7
-warning: -W[no]EmptyMutual
-Empty mutual block.
-
 Issue2759.agda:9,1-9
 warning: -W[no]EmptyAbstract
 Empty abstract block.
 
-Issue2759.agda:11,1-8
-warning: -W[no]EmptyPrivate
-Empty private block.
+Issue2759.agda:10,1-5
+warning: -W[no]EmptyConstructor
+Empty constructor block.
 
-Issue2759.agda:13,1-9
+Issue2759.agda:11,1-9
 warning: -W[no]EmptyInstance
 Empty instance block.
 
-Issue2759.agda:15,1-6
+Issue2759.agda:12,1-19
+warning: -W[no]EmptyMutual
+Empty mutual block.
+
+Issue2759.agda:13,1-6
 warning: -W[no]EmptyMacro
 Empty macro block.
+
+Issue2759.agda:14,1-7
+warning: -W[no]EmptyMutual
+Empty mutual block.
 
 Issue2759.agda:17,1-10
 warning: -W[no]EmptyPostulate
 Empty postulate block.
 
-Issue2759.agda:23,3-12
+Issue2759.agda:18,1-10
+warning: -W[no]EmptyPrimitive
+Empty primitive block.
+
+Issue2759.agda:19,1-8
+warning: -W[no]EmptyPrivate
+Empty private block.
+
+Issue2759.agda:20,1-9
+warning: -W[no]EmptyGeneralize
+Empty variable block.
+
+Issue2759.agda:43,3-12
 warning: -W[no]EmptyPostulate
 Empty postulate block.
 
-Issue2759.agda:27,27-32
+Issue2759.agda:47,27-32
 warning: -W[no]EmptyMacro
 Empty macro block.
 
-Issue2759.agda:33,12-20
+Issue2759.agda:47,18-26
+warning: -W[no]UselessInstance
+Using instance here has no effect. Instance applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and axioms.
+
+Issue2759.agda:47,10-26
+warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+
+Issue2759.agda:47,1-26
+warning: -W[no]UselessAbstract
+Using abstract here has no effect. Abstract applies to only
+definitions like data definitions, record type definitions and
+function clauses.
+
+Issue2759.agda:15,1-7
+warning: -W[no]UselessOpaque
+This 'opaque' block has no effect.
+when scope checking the declaration
+  opaque unfolding {}
+
+Issue2759.agda:16,1-17
+warning: -W[no]UselessOpaque
+This 'opaque' block has no effect.
+when scope checking the declaration
+  opaque unfolding {}
+
+Issue2759.agda:25,12-20
 warning: -W[no]EmptyAbstract
 Empty abstract block.
 when scope checking λ (let abstract) → let abstract in Set
 
-Issue2759.agda:33,29-37
+Issue2759.agda:25,38-46
 warning: -W[no]EmptyAbstract
 Empty abstract block.
 when scope checking let abstract in Set
 
-Issue2759.agda:34,12-17
-warning: -W[no]EmptyField
-Empty field block.
-when scope checking λ (let field) → let field in Set
+Issue2759.agda:26,12-16
+warning: -W[no]EmptyConstructor
+Empty constructor block.
+when scope checking λ (let data _ where) → let data _ where in Set
 
-Issue2759.agda:34,29-34
-warning: -W[no]EmptyField
-Empty field block.
-when scope checking let field in Set
+Issue2759.agda:26,38-42
+warning: -W[no]EmptyConstructor
+Empty constructor block.
+when scope checking let data _ where in Set
 
-Issue2759.agda:35,12-20
+Issue2759.agda:27,12-20
 warning: -W[no]EmptyInstance
 Empty instance block.
 when scope checking λ (let instance) → let instance in Set
 
-Issue2759.agda:35,29-37
+Issue2759.agda:27,38-46
 warning: -W[no]EmptyInstance
 Empty instance block.
 when scope checking let instance in Set
 
-Issue2759.agda:36,12-17
+Issue2759.agda:28,12-30
+warning: -W[no]EmptyMutual
+Empty mutual block.
+when scope checking
+λ (let interleaved mutual) → let interleaved mutual in Set
+
+Issue2759.agda:28,38-56
+warning: -W[no]EmptyMutual
+Empty mutual block.
+when scope checking let interleaved mutual in Set
+
+Issue2759.agda:29,12-17
 warning: -W[no]EmptyMacro
 Empty macro block.
 when scope checking λ (let macro) → let macro in Set
 
-Issue2759.agda:36,29-34
+Issue2759.agda:29,38-43
 warning: -W[no]EmptyMacro
 Empty macro block.
 when scope checking let macro in Set
 
-Issue2759.agda:37,12-18
+Issue2759.agda:30,12-18
 warning: -W[no]EmptyMutual
 Empty mutual block.
 when scope checking λ (let mutual) → let mutual in Set
 
-Issue2759.agda:37,29-35
+Issue2759.agda:30,38-44
 warning: -W[no]EmptyMutual
 Empty mutual block.
 when scope checking let mutual in Set
 
-Issue2759.agda:38,12-21
+Issue2759.agda:31,12-21
 warning: -W[no]EmptyPostulate
 Empty postulate block.
 when scope checking λ (let postulate) → let postulate in Set
 
-Issue2759.agda:38,29-38
+Issue2759.agda:31,38-47
 warning: -W[no]EmptyPostulate
 Empty postulate block.
 when scope checking let postulate in Set
 
-Issue2759.agda:39,12-19
+Issue2759.agda:32,12-21
+warning: -W[no]EmptyPrimitive
+Empty primitive block.
+when scope checking λ (let primitive) → let primitive in Set
+
+Issue2759.agda:32,38-47
+warning: -W[no]EmptyPrimitive
+Empty primitive block.
+when scope checking let primitive in Set
+
+Issue2759.agda:33,12-19
 warning: -W[no]EmptyPrivate
 Empty private block.
 when scope checking λ (let private) → let private in Set
 
-Issue2759.agda:39,29-36
+Issue2759.agda:33,38-45
 warning: -W[no]EmptyPrivate
 Empty private block.
 when scope checking let private in Set
+
+Issue2759.agda:34,12-20
+warning: -W[no]EmptyGeneralize
+Empty variable block.
+when scope checking λ (let variable) → let variable in Set
+
+Issue2759.agda:34,38-46
+warning: -W[no]EmptyGeneralize
+Empty variable block.
+when scope checking let variable in Set

--- a/test/Succeed/Issue2858-invalid.warn
+++ b/test/Succeed/Issue2858-invalid.warn
@@ -1,8 +1,8 @@
 Issue2858-invalid.agda:3,1-5,18
 warning: -W[no]InvalidConstructorBlock
-No 'constructor' blocks outside of 'interleaved mutual' blocks.
+No 'data _ where' blocks outside of 'interleaved mutual' blocks.
 when scope checking the declaration
-  constructor
+  data _ where
     zero : Nat
     suc : Nat → Nat
 
@@ -10,8 +10,8 @@ when scope checking the declaration
 
 Issue2858-invalid.agda:3,1-5,18
 warning: -W[no]InvalidConstructorBlock
-No 'constructor' blocks outside of 'interleaved mutual' blocks.
+No 'data _ where' blocks outside of 'interleaved mutual' blocks.
 when scope checking the declaration
-  constructor
+  data _ where
     zero : Nat
     suc : Nat → Nat

--- a/test/Succeed/Issue6945.agda
+++ b/test/Succeed/Issue6945.agda
@@ -1,0 +1,51 @@
+-- Andreas, 2024-03-02, issue #6945:
+-- Reported and original testcase by Matthias Hutzler.
+-- Missing warnings for useless private and other useless block.
+
+postulate
+  Nat : Set
+
+module M where
+
+  f : Nat → Nat
+  f x = x
+
+  private
+    syntax f x = [ x ]
+
+  -- Expected: Warning about useless private.
+
+h : Nat → Nat
+h x = M.[ x ]  -- This is accepted, showing that the [ ] syntax is not private.
+
+postulate
+  _#_ : Nat → Nat → Nat
+
+private
+  infixl 5 _#_
+
+-- Expected: Warning about useless private.
+
+private
+  {-# POLARITY _#_ #-}
+
+-- Expected: Warning about useless private.
+
+---------------------------------------------------------------------------
+-- Similar warnings for other blocks.
+
+postulate A : Set
+abstract
+  infix 0 A
+
+postulate I : Set
+instance
+  infix 0 I
+
+postulate M : Set
+macro
+  infix 0 M
+
+postulate O : Set
+opaque
+  infix 0 O

--- a/test/Succeed/Issue6945.warn
+++ b/test/Succeed/Issue6945.warn
@@ -1,0 +1,72 @@
+Issue6945.agda:24,1-25,15
+warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+Issue6945.agda:29,1-30,23
+warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+Issue6945.agda:38,1-39,12
+warning: -W[no]UselessAbstract
+Using abstract here has no effect. Abstract applies to only
+definitions like data definitions, record type definitions and
+function clauses.
+Issue6945.agda:42,1-9
+warning: -W[no]UselessInstance
+Using instance here has no effect. Instance applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and axioms.
+Issue6945.agda:13,3-14,13
+warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+when scope checking the declaration
+  module M where
+Issue6945.agda:50,1-51,12
+warning: -W[no]UselessOpaque
+This 'opaque' block has no effect.
+when scope checking the declaration
+  opaque unfolding {}
+
+———— All done; warnings encountered ————————————————————————
+
+Issue6945.agda:24,1-25,15
+warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+
+Issue6945.agda:29,1-30,23
+warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+
+Issue6945.agda:38,1-39,12
+warning: -W[no]UselessAbstract
+Using abstract here has no effect. Abstract applies to only
+definitions like data definitions, record type definitions and
+function clauses.
+
+Issue6945.agda:42,1-9
+warning: -W[no]UselessInstance
+Using instance here has no effect. Instance applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and axioms.
+
+Issue6945.agda:13,3-14,13
+warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+when scope checking the declaration
+  module M where
+
+Issue6945.agda:50,1-51,12
+warning: -W[no]UselessOpaque
+This 'opaque' block has no effect.
+when scope checking the declaration
+  opaque unfolding {}


### PR DESCRIPTION
The "useless private" warning did not kick in for declarations like `infix` and `syntax` which have no representation in the `NiceDeclaration` variant.

Also: update test for #2759 to current set of block constructions.

Fixes #6945.