### PR TITLE
Blocks in Concrete syntax: store Range of block keyword

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -543,8 +543,9 @@ library
       Agda.Syntax.Abstract
       Agda.Syntax.Builtin
       Agda.Syntax.Common
-      Agda.Syntax.Common.Pretty
       Agda.Syntax.Common.Aspect
+      Agda.Syntax.Common.KeywordRange
+      Agda.Syntax.Common.Pretty
       Agda.Syntax.Common.Pretty.ANSI
       Agda.Syntax.Concrete.Attribute
       Agda.Syntax.Concrete.Definitions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,30 @@ Interaction and emacs mode
 Backends
 --------
 
+API
+---
+
+Highlighting some changes to Agda as a library.
+
+* New module `Agda.Syntax.Common.KeywordRange` providing type `KwRange` isomorphic to `Range`
+  to indicate source positions that just span keywords.
+  The motiviation for `KwRange` is to distinguish such ranges from ranges for whole subtrees,
+  e.g. in data type `Agda.Syntax.Concrete.Declaration`.
+
+  API:
+  ```haskell
+  module Agda.Syntax.Common.KeywordRange where
+
+  type KwRange
+
+  -- From Range to KwRange
+  kwRange :: HasRange a => a -> KwRange
+
+  -- From KwRange to Range
+  instance HasRange KwRange where
+    getRange :: KwRange -> Range
+  ```
+
 Other issues closed
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Installation
 Pragmas and options
 -------------------
 
+* New warning `UselessMacro` when a `macro` block does not contain any function definitions.
+
 Syntax
 ------
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1516,6 +1516,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      ``instance`` blocks where they have no effect.
 
+.. option:: UselessMacro
+
+     ``macro`` blocks where they have no effect.
+
 .. option:: UselessOpaque
 
      ``opaque`` blocks that have no effect.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1538,7 +1538,7 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
 .. option:: UselessPublic
 
-     ``public`` blocks where they have no effect.
+     ``public`` directives where they have no effect.
 
 .. option:: UserWarning
 

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -514,6 +514,7 @@ warningHighlighting' b w = case tcWarning w of
       -- suggesting that it is not generalized over.
     UselessAbstract{}                -> deadcodeHighlighting w
     UselessInstance{}                -> deadcodeHighlighting w
+    UselessMacro{}                   -> deadcodeHighlighting w
     UselessPrivate{}                 -> deadcodeHighlighting w
     InvalidNoPositivityCheckPragma{} -> deadcodeHighlighting w
     InvalidNoUniverseCheckPragma{}   -> deadcodeHighlighting w

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -231,6 +231,7 @@ data WarningName
   | UnknownNamesInPolarityPragmas_
   | UselessAbstract_
   | UselessInstance_
+  | UselessMacro_
   | UselessPrivate_
   -- Scope and Type Checking Warnings
   | AbsurdPatternRequiresNoRHS_
@@ -423,6 +424,7 @@ warningNameDescription = \case
   UselessHiding_                   -> "Names in `hiding' directive that are anyway not imported."
   UselessInline_                   -> "`INLINE' pragmas where they have no effect."
   UselessInstance_                 -> "`instance' blocks where they have no effect."
+  UselessMacro_                    -> "`macro' blocks where they have no effect."
   UselessPrivate_                  -> "`private' blocks where they have no effect."
   UselessPublic_                   -> "`public' blocks where they have no effect."
   UselessPatternDeclarationForRecord_ -> "`pattern' attributes where they have no effect."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -426,7 +426,7 @@ warningNameDescription = \case
   UselessInstance_                 -> "`instance' blocks where they have no effect."
   UselessMacro_                    -> "`macro' blocks where they have no effect."
   UselessPrivate_                  -> "`private' blocks where they have no effect."
-  UselessPublic_                   -> "`public' blocks where they have no effect."
+  UselessPublic_                   -> "`public' directives that have no effect."
   UselessPatternDeclarationForRecord_ -> "`pattern' attributes where they have no effect."
   -- Scope and Type Checking Warnings
   AbsurdPatternRequiresNoRHS_      -> "Clauses with an absurd pattern that have a right hand side."

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -2,6 +2,7 @@
 -}
 module Agda.Syntax.Common
   ( module Agda.Syntax.Common
+  , module Agda.Syntax.Common.KeywordRange
   , module Agda.Syntax.TopLevelModuleName.Boot
   , Induction(..)
   )
@@ -30,6 +31,9 @@ import qualified Data.HashSet as HashSet
 
 import GHC.Generics (Generic)
 
+import Agda.Syntax.Common.Aspect (Induction(..))
+import Agda.Syntax.Common.KeywordRange
+import Agda.Syntax.Common.Pretty
 import Agda.Syntax.Position
 
 import Agda.Utils.BiMap (HasTag(..))
@@ -41,8 +45,6 @@ import Agda.Utils.Maybe
 import Agda.Utils.Null
 import Agda.Utils.PartialOrd
 import Agda.Utils.POMonoid
-import Agda.Syntax.Common.Aspect (Induction(..))
-import Agda.Syntax.Common.Pretty
 
 import Agda.Utils.Impossible
 
@@ -2327,18 +2329,18 @@ instance AnyIsAbstract a => AnyIsAbstract (Maybe a) where
 
 -- | Is this definition eligible for instance search?
 data IsInstance
-  = InstanceDef Range  -- ^ Range of the @instance@ keyword.
+  = InstanceDef KwRange  -- ^ Range of the @instance@ keyword.
   | NotInstanceDef
     deriving (Show, Eq, Ord)
 
 instance KillRange IsInstance where
   killRange = \case
-    InstanceDef _    -> InstanceDef noRange
+    InstanceDef _    -> InstanceDef empty
     i@NotInstanceDef -> i
 
 instance HasRange IsInstance where
   getRange = \case
-    InstanceDef r  -> r
+    InstanceDef r  -> getRange r
     NotInstanceDef -> noRange
 
 instance NFData IsInstance where

--- a/src/full/Agda/Syntax/Common/KeywordRange.hs
+++ b/src/full/Agda/Syntax/Common/KeywordRange.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | A abstract 'Range' type dedicated to keyword occurrences in the source.
+
+module Agda.Syntax.Common.KeywordRange
+  ( KwRange  -- Do not export the constructor.
+  , kwRange
+  ) where
+
+import Control.DeepSeq ( NFData(rnf) )
+
+import Agda.Syntax.Common.Pretty
+import Agda.Syntax.Position
+
+import Agda.Utils.Null
+
+-- | Range dedicated to a keyword or fixed token sequence.
+--
+-- Motivation: by lacking a 'SetRange' instance we indicate that it cannot be updated.
+
+newtype KwRange = KwRange { theKwRange :: Range }
+  deriving (Eq, Ord, Show, Null)
+
+-- | Create a keyword range.
+
+kwRange :: HasRange a => a -> KwRange
+kwRange = KwRange . getRange
+
+-- Instances
+
+instance HasRange KwRange where
+  getRange = theKwRange
+
+instance KillRange KwRange where
+  killRange _ = empty
+
+-- no SetRange instance!!
+
+instance NFData KwRange where
+  rnf _ = ()
+
+instance Pretty KwRange where
+  prettyPrec i = prettyPrec i . theKwRange

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -500,7 +500,7 @@ data Declaration
     -- ^ The 'KwRange' here only refers to the range of the
     --   @instance@ keyword.  The range of the whole block @InstanceB r ds@
     --   is @fuseRange r ds@.
-  | LoneConstructor Range [Declaration]
+  | LoneConstructor KwRange [Declaration]
   | Macro       Range [Declaration]
   | Postulate   Range [TypeSignatureOrInstanceBlock]
   | Primitive   Range [TypeSignature]
@@ -960,7 +960,7 @@ instance HasRange Declaration where
   getRange (RecordDirective r)     = getRange r
   getRange (Mutual r _)            = r
   getRange (InterleavedMutual r _) = r
-  getRange (LoneConstructor r _)   = r
+  getRange (LoneConstructor kwr ds)= fuseRange kwr ds
   getRange (Abstract kwr ds)       = fuseRange kwr ds
   getRange (Generalize r _)        = r
   getRange (Open r _ _)            = r
@@ -1117,7 +1117,7 @@ instance KillRange Declaration where
   killRange (PatternSyn _ n ns p)   = killRangeN (PatternSyn noRange) n ns p
   killRange (Mutual _ d)            = killRangeN (Mutual noRange) d
   killRange (InterleavedMutual _ d) = killRangeN (InterleavedMutual noRange) d
-  killRange (LoneConstructor _ d)   = killRangeN (LoneConstructor noRange) d
+  killRange (LoneConstructor _ d)   = killRangeN (LoneConstructor empty) d
   killRange (Abstract _ d)          = killRangeN (Abstract empty) d
   killRange (Private _ o d)         = killRangeN (Private empty) o d
   killRange (InstanceB _ d)         = killRangeN (InstanceB empty) d

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -475,7 +475,7 @@ data Declaration
       -- ^ Axioms and functions can be irrelevant. (Hiding should be NotHidden)
   | FieldSig IsInstance TacticAttribute Name (Arg Expr)
   | Generalize Range [TypeSignature] -- ^ Variables to be generalized, can be hidden and/or irrelevant.
-  | Field Range [FieldSignature]
+  | Field KwRange [FieldSignature]
   | FunClause LHS RHS WhereClause Bool
   | DataSig     Range Erased Name [LamBinding] Expr -- ^ lone data signature in mutual block
   | Data        Range Erased Name [LamBinding] Expr
@@ -949,7 +949,7 @@ instance HasRange RecordDirective where
 instance HasRange Declaration where
   getRange (TypeSig _ _ x t)       = fuseRange x t
   getRange (FieldSig _ _ x t)      = fuseRange x t
-  getRange (Field r _)             = r
+  getRange (Field kwr ds)          = fuseRange kwr ds
   getRange (FunClause lhs rhs wh _) = fuseRange lhs rhs `fuseRange` wh
   getRange (DataSig r _ _ _ _)     = r
   getRange (Data r _ _ _ _ _)      = r
@@ -1102,7 +1102,7 @@ instance KillRange Declaration where
   killRange (TypeSig i t n e)       = killRangeN (TypeSig i) t n e
   killRange (FieldSig i t n e)      = killRangeN FieldSig i t n e
   killRange (Generalize r ds )      = killRangeN (Generalize noRange) ds
-  killRange (Field r fs)            = killRangeN (Field noRange) fs
+  killRange (Field r fs)            = killRangeN (Field empty) fs
   killRange (FunClause l r w ca)    = killRangeN FunClause l r w ca
   killRange (DataSig _ er n l e)    = killRangeN (DataSig noRange) er n l e
   killRange (Data _ er n l e c)     = killRangeN (Data noRange) er n l e c

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -501,7 +501,7 @@ data Declaration
     --   @instance@ keyword.  The range of the whole block @InstanceB r ds@
     --   is @fuseRange r ds@.
   | LoneConstructor KwRange [Declaration]
-  | Macro       Range [Declaration]
+  | Macro       KwRange [Declaration]
   | Postulate   Range [TypeSignatureOrInstanceBlock]
   | Primitive   Range [TypeSignature]
   | Open        Range QName ImportDirective
@@ -968,7 +968,7 @@ instance HasRange Declaration where
                                    = r
   getRange (Import r _ _ _ _)      = r
   getRange (InstanceB kwr _)       = getRange kwr
-  getRange (Macro r _)             = r
+  getRange (Macro kwr ds)          = fuseRange kwr ds
   getRange (Private kwr _ ds)      = fuseRange kwr ds
   getRange (Postulate r _)         = r
   getRange (Primitive r _)         = r
@@ -1121,7 +1121,7 @@ instance KillRange Declaration where
   killRange (Abstract _ d)          = killRangeN (Abstract empty) d
   killRange (Private _ o d)         = killRangeN (Private empty) o d
   killRange (InstanceB _ d)         = killRangeN (InstanceB empty) d
-  killRange (Macro _ d)             = killRangeN (Macro noRange) d
+  killRange (Macro _ d)             = killRangeN (Macro empty) d
   killRange (Postulate _ t)         = killRangeN (Postulate noRange) t
   killRange (Primitive _ t)         = killRangeN (Primitive noRange) t
   killRange (Open _ q i)            = killRangeN (Open noRange) q i

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -496,8 +496,8 @@ data Declaration
     -- ^ In "Agda.Syntax.Concrete.Definitions" we generate private blocks
     --   temporarily, which should be treated different that user-declared
     --   private blocks.  Thus the 'Origin'.
-  | InstanceB   Range [Declaration]
-    -- ^ The 'Range' here (exceptionally) only refers to the range of the
+  | InstanceB   KwRange [Declaration]
+    -- ^ The 'KwRange' here only refers to the range of the
     --   @instance@ keyword.  The range of the whole block @InstanceB r ds@
     --   is @fuseRange r ds@.
   | LoneConstructor Range [Declaration]
@@ -967,7 +967,7 @@ instance HasRange Declaration where
   getRange (ModuleMacro r _ _ _ _ _)
                                    = r
   getRange (Import r _ _ _ _)      = r
-  getRange (InstanceB r _)         = r
+  getRange (InstanceB kwr _)       = getRange kwr
   getRange (Macro r _)             = r
   getRange (Private r _ _)         = r
   getRange (Postulate r _)         = r
@@ -1120,7 +1120,7 @@ instance KillRange Declaration where
   killRange (LoneConstructor _ d)   = killRangeN (LoneConstructor noRange) d
   killRange (Abstract _ d)          = killRangeN (Abstract noRange) d
   killRange (Private _ o d)         = killRangeN (Private noRange) o d
-  killRange (InstanceB _ d)         = killRangeN (InstanceB noRange) d
+  killRange (InstanceB _ d)         = killRangeN (InstanceB empty) d
   killRange (Macro _ d)             = killRangeN (Macro noRange) d
   killRange (Postulate _ t)         = killRangeN (Postulate noRange) t
   killRange (Primitive _ t)         = killRangeN (Primitive noRange) t

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -474,7 +474,7 @@ data Declaration
   = TypeSig ArgInfo TacticAttribute Name Expr
       -- ^ Axioms and functions can be irrelevant. (Hiding should be NotHidden)
   | FieldSig IsInstance TacticAttribute Name (Arg Expr)
-  | Generalize Range [TypeSignature] -- ^ Variables to be generalized, can be hidden and/or irrelevant.
+  | Generalize KwRange [TypeSignature] -- ^ Variables to be generalized, can be hidden and/or irrelevant.
   | Field KwRange [FieldSignature]
   | FunClause LHS RHS WhereClause Bool
   | DataSig     Range Erased Name [LamBinding] Expr -- ^ lone data signature in mutual block
@@ -962,7 +962,7 @@ instance HasRange Declaration where
   getRange (InterleavedMutual kwr ds) = fuseRange kwr ds
   getRange (LoneConstructor kwr ds)= fuseRange kwr ds
   getRange (Abstract kwr ds)       = fuseRange kwr ds
-  getRange (Generalize r _)        = r
+  getRange (Generalize kwr ds)     = fuseRange kwr ds
   getRange (Open r _ _)            = r
   getRange (ModuleMacro r _ _ _ _ _)
                                    = r
@@ -1101,7 +1101,7 @@ instance KillRange RecordDirective where
 instance KillRange Declaration where
   killRange (TypeSig i t n e)       = killRangeN (TypeSig i) t n e
   killRange (FieldSig i t n e)      = killRangeN FieldSig i t n e
-  killRange (Generalize r ds )      = killRangeN (Generalize noRange) ds
+  killRange (Generalize r ds )      = killRangeN (Generalize empty) ds
   killRange (Field r fs)            = killRangeN (Field empty) fs
   killRange (FunClause l r w ca)    = killRangeN FunClause l r w ca
   killRange (DataSig _ er n l e)    = killRangeN (DataSig noRange) er n l e

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -502,7 +502,7 @@ data Declaration
     --   is @fuseRange r ds@.
   | LoneConstructor KwRange [Declaration]
   | Macro       KwRange [Declaration]
-  | Postulate   Range [TypeSignatureOrInstanceBlock]
+  | Postulate   KwRange [TypeSignatureOrInstanceBlock]
   | Primitive   KwRange [TypeSignature]
   | Open        Range QName ImportDirective
   | Import      Range QName (Maybe AsName) !OpenShortHand ImportDirective
@@ -970,7 +970,7 @@ instance HasRange Declaration where
   getRange (InstanceB kwr _)       = getRange kwr
   getRange (Macro kwr ds)          = fuseRange kwr ds
   getRange (Private kwr _ ds)      = fuseRange kwr ds
-  getRange (Postulate r _)         = r
+  getRange (Postulate kwr ds)      = fuseRange kwr ds
   getRange (Primitive kwr ds)      = fuseRange kwr ds
   getRange (Module r _ _ _ _)      = r
   getRange (Infix f _)             = getRange f
@@ -1122,7 +1122,7 @@ instance KillRange Declaration where
   killRange (Private _ o d)         = killRangeN (Private empty) o d
   killRange (InstanceB _ d)         = killRangeN (InstanceB empty) d
   killRange (Macro _ d)             = killRangeN (Macro empty) d
-  killRange (Postulate _ t)         = killRangeN (Postulate noRange) t
+  killRange (Postulate _ t)         = killRangeN (Postulate empty) t
   killRange (Primitive _ t)         = killRangeN (Primitive empty) t
   killRange (Open _ q i)            = killRangeN (Open noRange) q i
   killRange (Import _ q a o i)      = killRangeN (\q a -> Import noRange q a o) q a i

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -492,7 +492,7 @@ data Declaration
   | Mutual      Range [Declaration]  -- @Range@ of the whole @mutual@ block.
   | InterleavedMutual Range [Declaration]
   | Abstract    Range [Declaration]
-  | Private     Range Origin [Declaration]
+  | Private     KwRange Origin [Declaration]
     -- ^ In "Agda.Syntax.Concrete.Definitions" we generate private blocks
     --   temporarily, which should be treated different that user-declared
     --   private blocks.  Thus the 'Origin'.
@@ -969,7 +969,7 @@ instance HasRange Declaration where
   getRange (Import r _ _ _ _)      = r
   getRange (InstanceB kwr _)       = getRange kwr
   getRange (Macro r _)             = r
-  getRange (Private r _ _)         = r
+  getRange (Private kwr _ ds)      = fuseRange kwr ds
   getRange (Postulate r _)         = r
   getRange (Primitive r _)         = r
   getRange (Module r _ _ _ _)      = r
@@ -1119,7 +1119,7 @@ instance KillRange Declaration where
   killRange (InterleavedMutual _ d) = killRangeN (InterleavedMutual noRange) d
   killRange (LoneConstructor _ d)   = killRangeN (LoneConstructor noRange) d
   killRange (Abstract _ d)          = killRangeN (Abstract noRange) d
-  killRange (Private _ o d)         = killRangeN (Private noRange) o d
+  killRange (Private _ o d)         = killRangeN (Private empty) o d
   killRange (InstanceB _ d)         = killRangeN (InstanceB empty) d
   killRange (Macro _ d)             = killRangeN (Macro noRange) d
   killRange (Postulate _ t)         = killRangeN (Postulate noRange) t

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -503,7 +503,7 @@ data Declaration
   | LoneConstructor KwRange [Declaration]
   | Macro       KwRange [Declaration]
   | Postulate   Range [TypeSignatureOrInstanceBlock]
-  | Primitive   Range [TypeSignature]
+  | Primitive   KwRange [TypeSignature]
   | Open        Range QName ImportDirective
   | Import      Range QName (Maybe AsName) !OpenShortHand ImportDirective
   | ModuleMacro Range Erased  Name ModuleApplication !OpenShortHand
@@ -971,7 +971,7 @@ instance HasRange Declaration where
   getRange (Macro kwr ds)          = fuseRange kwr ds
   getRange (Private kwr _ ds)      = fuseRange kwr ds
   getRange (Postulate r _)         = r
-  getRange (Primitive r _)         = r
+  getRange (Primitive kwr ds)      = fuseRange kwr ds
   getRange (Module r _ _ _ _)      = r
   getRange (Infix f _)             = getRange f
   getRange (Syntax n _)            = getRange n
@@ -1123,7 +1123,7 @@ instance KillRange Declaration where
   killRange (InstanceB _ d)         = killRangeN (InstanceB empty) d
   killRange (Macro _ d)             = killRangeN (Macro empty) d
   killRange (Postulate _ t)         = killRangeN (Postulate noRange) t
-  killRange (Primitive _ t)         = killRangeN (Primitive noRange) t
+  killRange (Primitive _ t)         = killRangeN (Primitive empty) t
   killRange (Open _ q i)            = killRangeN (Open noRange) q i
   killRange (Import _ q a o i)      = killRangeN (\q a -> Import noRange q a o) q a i
   killRange (ModuleMacro _ e n m o i)

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -491,7 +491,7 @@ data Declaration
   | PatternSyn  Range Name [WithHiding Name] Pattern
   | Mutual      Range [Declaration]  -- @Range@ of the whole @mutual@ block.
   | InterleavedMutual Range [Declaration]
-  | Abstract    Range [Declaration]
+  | Abstract    KwRange [Declaration]
   | Private     KwRange Origin [Declaration]
     -- ^ In "Agda.Syntax.Concrete.Definitions" we generate private blocks
     --   temporarily, which should be treated different that user-declared
@@ -961,7 +961,7 @@ instance HasRange Declaration where
   getRange (Mutual r _)            = r
   getRange (InterleavedMutual r _) = r
   getRange (LoneConstructor r _)   = r
-  getRange (Abstract r _)          = r
+  getRange (Abstract kwr ds)       = fuseRange kwr ds
   getRange (Generalize r _)        = r
   getRange (Open r _ _)            = r
   getRange (ModuleMacro r _ _ _ _ _)
@@ -1118,7 +1118,7 @@ instance KillRange Declaration where
   killRange (Mutual _ d)            = killRangeN (Mutual noRange) d
   killRange (InterleavedMutual _ d) = killRangeN (InterleavedMutual noRange) d
   killRange (LoneConstructor _ d)   = killRangeN (LoneConstructor noRange) d
-  killRange (Abstract _ d)          = killRangeN (Abstract noRange) d
+  killRange (Abstract _ d)          = killRangeN (Abstract empty) d
   killRange (Private _ o d)         = killRangeN (Private empty) o d
   killRange (InstanceB _ d)         = killRangeN (InstanceB empty) d
   killRange (Macro _ d)             = killRangeN (Macro noRange) d

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -1259,7 +1259,7 @@ niceDeclarations fixs ds = do
         return ds -- no change!
 
     instanceBlock
-      :: Range  -- Range of @instance@ keyword.
+      :: KwRange  -- Range of @instance@ keyword.
       -> [NiceDeclaration]
       -> Nice [NiceDeclaration]
     instanceBlock r ds = do
@@ -1270,7 +1270,7 @@ niceDeclarations fixs ds = do
 
     -- Make a declaration eligible for instance search.
     mkInstance
-      :: Range  -- Range of @instance@ keyword.
+      :: KwRange  -- Range of @instance@ keyword.
       -> Updater NiceDeclaration
     mkInstance r0 = \case
         Axiom r p a i rel x e          -> (\ i -> Axiom r p a i rel x e) <$> setInstance r0 i
@@ -1298,7 +1298,7 @@ niceDeclarations fixs ds = do
         d@NiceUnquoteData{}            -> return d
 
     setInstance
-      :: Range  -- Range of @instance@ keyword.
+      :: KwRange  -- Range of @instance@ keyword.
       -> Updater IsInstance
     setInstance r0 = \case
       i@InstanceDef{} -> return i

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -990,7 +990,7 @@ niceDeclarations fixs ds = do
           case d of
             NiceDataSig{}                -> oneOff $ [] <$ addDataType d
             NiceDataDef r _ _ _ _ n _ ds -> oneOff $ [] <$ addDataConstructors (Just r) (Just n) ds
-            NiceLoneConstructor r ds     -> oneOff $ [] <$ addDataConstructors Nothing Nothing ds
+            NiceLoneConstructor _ ds     -> oneOff $ [] <$ addDataConstructors Nothing Nothing ds
             FunSig{}                     -> oneOff $ [] <$ addFunType d
             FunDef _ _ _  _ _ _ n cs
                       | not (isNoName n) -> oneOff $ [] <$ addFunDef d

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -308,7 +308,7 @@ niceDeclarations fixs ds = do
         FieldSig{} -> __IMPOSSIBLE__
 
         Generalize r [] -> justWarning $ EmptyGeneralize r
-        Generalize r sigs -> do
+        Generalize _ sigs -> do
           gs <- forM sigs $ \case
             sig@(TypeSig info tac x t) -> do
               -- Andreas, 2022-03-25, issue #5850:
@@ -1511,7 +1511,7 @@ notSoNiceDeclarations = \case
     NiceDataDef r _ _ _ _ x bs cs  -> [DataDef r x bs $ concatMap notSoNiceDeclarations cs]
     NiceRecDef r _ _ _ _ x dir bs ds -> [RecordDef r x dir bs ds]
     NicePatternSyn r _ n as p      -> [PatternSyn r n as p]
-    NiceGeneralize r _ i tac n e   -> [Generalize r [TypeSig i tac n e]]
+    NiceGeneralize _ _ i tac n e   -> [Generalize empty [TypeSig i tac n e]]
     NiceUnquoteDecl r _ _ i _ _ x e -> inst i [UnquoteDecl r x e]
     NiceUnquoteDef r _ _ _ _ x e    -> [UnquoteDef r x e]
     NiceUnquoteData r _ _ _ _ x xs e  -> [UnquoteData r x xs e]

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -1244,9 +1244,13 @@ niceDeclarations fixs ds = do
         -- A mutual block cannot have a measure,
         -- but it can skip termination check.
 
+    abstractBlock
+      :: KwRange  -- Range of @abstract@ keyword.
+      -> [NiceDeclaration]
+      -> Nice [NiceDeclaration]
     abstractBlock r ds = do
       (ds', anyChange) <- runChangeT $ mkAbstract ds
-      let inherited = r == noRange
+      let inherited = null r
       if anyChange then return ds' else do
         -- hack to avoid failing on inherited abstract blocks in where clauses
         unless inherited $ declarationWarning $ UselessAbstract r
@@ -1381,12 +1385,15 @@ instance MakeAbstract Clause where
     Clause x catchall lhs rhs <$> mkAbstract wh <*> mkAbstract with
 
 -- | Contents of a @where@ clause are abstract if the parent is.
+--
+--   These are inherited 'Abstract' blocks, indicated by an empty range
+--   for the @abstract@ keyword.
 instance MakeAbstract WhereClause where
   mkAbstract  NoWhere               = return $ NoWhere
   mkAbstract (AnyWhere r ds)        = dirty $ AnyWhere r
-                                                [Abstract noRange ds]
+                                                [Abstract empty ds]
   mkAbstract (SomeWhere r e m a ds) = dirty $ SomeWhere r e m a
-                                                [Abstract noRange ds]
+                                                [Abstract empty ds]
 
 -- | Make a declaration private.
 --

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -1494,7 +1494,7 @@ notSoNiceDeclarations :: NiceDeclaration -> [Declaration]
 notSoNiceDeclarations = \case
     Axiom _ _ _ i rel x e          -> inst i [TypeSig rel empty x e]
     NiceField _ _ _ i tac x argt   -> [FieldSig i tac x argt]
-    PrimitiveFunction r _ _ x e    -> [Primitive r [TypeSig (argInfo e) empty x (unArg e)]]
+    PrimitiveFunction _ _ _ x e    -> [Primitive empty [TypeSig (argInfo e) empty x (unArg e)]]
     NiceMutual r _ _ _ ds          -> [Mutual r $ concatMap notSoNiceDeclarations ds]
     NiceLoneConstructor r ds       -> [LoneConstructor r $ concatMap notSoNiceDeclarations ds]
     NiceModule r _ _ e x tel ds    -> [Module r e x tel ds]

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -80,7 +80,7 @@ data DeclarationWarning'
   | EmptyMutual KwRange    -- ^ Empty @mutual@    block.
   | EmptyPostulate Range   -- ^ Empty @postulate@ block.
   | EmptyPrivate KwRange   -- ^ Empty @private@   block.
-  | EmptyPrimitive Range   -- ^ Empty @primitive@ block.
+  | EmptyPrimitive KwRange   -- ^ Empty @primitive@ block.
   | HiddenGeneralize Range
       -- ^ A 'Hidden' identifier in a @variable@ declaration.
       --   Hiding has no effect there as generalized variables are always hidden
@@ -320,7 +320,7 @@ instance HasRange DeclarationWarning' where
     EmptyMacro kwr                     -> getRange kwr
     EmptyMutual kwr                    -> getRange kwr
     EmptyPostulate r                   -> r
-    EmptyPrimitive r                   -> r
+    EmptyPrimitive kwr                 -> getRange kwr
     EmptyPrivate kwr                   -> getRange kwr
     HiddenGeneralize r                 -> r
     InvalidCatchallPragma r            -> r

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -74,7 +74,7 @@ data DeclarationWarning'
   = EmptyAbstract KwRange  -- ^ Empty @abstract@  block.
   | EmptyConstructor KwRange -- ^ Empty @data _ where@ block.
   | EmptyField KwRange       -- ^ Empty @field@     block.
-  | EmptyGeneralize Range  -- ^ Empty @variable@  block.
+  | EmptyGeneralize KwRange  -- ^ Empty @variable@  block.
   | EmptyInstance KwRange  -- ^ Empty @instance@  block
   | EmptyMacro KwRange     -- ^ Empty @macro@     block.
   | EmptyMutual KwRange    -- ^ Empty @mutual@    block.
@@ -315,7 +315,7 @@ instance HasRange DeclarationWarning' where
     EmptyAbstract kwr                  -> getRange kwr
     EmptyConstructor kwr               -> getRange kwr
     EmptyField kwr                     -> getRange kwr
-    EmptyGeneralize r                  -> r
+    EmptyGeneralize kwr                -> getRange kwr
     EmptyInstance kwr                  -> getRange kwr
     EmptyMacro kwr                     -> getRange kwr
     EmptyMutual kwr                    -> getRange kwr

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -44,16 +44,17 @@ data DeclarationException'
       -- ^ In an interleaved mutual block, a constructor could belong to any of the data signatures ('Name')
   | InvalidMeasureMutual Range
       -- ^ In a mutual block, all or none need a MEASURE pragma.
-      --   Range is of mutual block.
+      --   'Range' is the one of the offending pragma or the mutual block.
   | UnquoteDefRequiresSignature (List1 Name)
   | BadMacroDef NiceDeclaration
-  | UnfoldingOutsideOpaque Range
+  | UnfoldingOutsideOpaque KwRange
     -- ^ An unfolding declaration was not the first declaration
     -- contained in an opaque block.
-  | OpaqueInMutual Range
-      -- ^ @opaque@ block nested in a @mutual@ block. This can never
-      -- happen, even with reordering.
-  | DisallowedInterleavedMutual Range String (List1 Name)
+  | OpaqueInMutual KwRange
+      -- ^ @opaque@ block nested in a @mutual@ block.
+      -- This can never happen, even with reordering.
+      -- The 'KwRange' is the one of the @opaque@ keyword.
+  | DisallowedInterleavedMutual KwRange String (List1 Name)
       -- ^ A declaration that breaks an implicit mutual block (named by
       -- the String argument) was present while the given lone type
       -- signatures were still without their definitions.
@@ -76,7 +77,7 @@ data DeclarationWarning'
   | EmptyGeneralize Range  -- ^ Empty @variable@  block.
   | EmptyInstance KwRange  -- ^ Empty @instance@  block
   | EmptyMacro KwRange     -- ^ Empty @macro@     block.
-  | EmptyMutual Range      -- ^ Empty @mutual@    block.
+  | EmptyMutual KwRange    -- ^ Empty @mutual@    block.
   | EmptyPostulate Range   -- ^ Empty @postulate@ block.
   | EmptyPrivate KwRange   -- ^ Empty @private@   block.
   | EmptyPrimitive Range   -- ^ Empty @primitive@ block.
@@ -302,9 +303,9 @@ instance HasRange DeclarationException' where
   getRange (InvalidMeasureMutual r)             = r
   getRange (UnquoteDefRequiresSignature x)      = getRange x
   getRange (BadMacroDef d)                      = getRange d
-  getRange (UnfoldingOutsideOpaque r)           = r
-  getRange (OpaqueInMutual r)                   = r
-  getRange (DisallowedInterleavedMutual r _ _)  = r
+  getRange (UnfoldingOutsideOpaque kwr)         = getRange kwr
+  getRange (OpaqueInMutual kwr)                 = getRange kwr
+  getRange (DisallowedInterleavedMutual kwr _ _)= getRange kwr
 
 instance HasRange DeclarationWarning where
   getRange (DeclarationWarning _ w) = getRange w
@@ -317,7 +318,7 @@ instance HasRange DeclarationWarning' where
     EmptyGeneralize r                  -> r
     EmptyInstance kwr                  -> getRange kwr
     EmptyMacro kwr                     -> getRange kwr
-    EmptyMutual r                      -> r
+    EmptyMutual kwr                    -> getRange kwr
     EmptyPostulate r                   -> r
     EmptyPrimitive r                   -> r
     EmptyPrivate kwr                   -> getRange kwr

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -74,7 +74,7 @@ data DeclarationWarning'
   | EmptyConstructor Range -- ^ Empty @constructor@ block.
   | EmptyField Range       -- ^ Empty @field@     block.
   | EmptyGeneralize Range  -- ^ Empty @variable@  block.
-  | EmptyInstance Range    -- ^ Empty @instance@  block
+  | EmptyInstance KwRange  -- ^ Empty @instance@  block
   | EmptyMacro Range       -- ^ Empty @macro@     block.
   | EmptyMutual Range      -- ^ Empty @mutual@    block.
   | EmptyPostulate Range   -- ^ Empty @postulate@ block.
@@ -133,7 +133,7 @@ data DeclarationWarning'
   | UnknownNamesInPolarityPragmas [Name]
   | UselessAbstract Range
       -- ^ @abstract@ block with nothing that can (newly) be made abstract.
-  | UselessInstance Range
+  | UselessInstance KwRange
       -- ^ @instance@ block with nothing that can (newly) become an instance.
   | UselessPrivate Range
       -- ^ @private@ block with nothing that can (newly) be made private.
@@ -309,7 +309,7 @@ instance HasRange DeclarationWarning' where
     EmptyConstructor r                 -> r
     EmptyField r                       -> r
     EmptyGeneralize r                  -> r
-    EmptyInstance r                    -> r
+    EmptyInstance kwr                  -> getRange kwr
     EmptyMacro r                       -> r
     EmptyMutual r                      -> r
     EmptyPostulate r                   -> r
@@ -345,7 +345,7 @@ instance HasRange DeclarationWarning' where
     UnknownNamesInFixityDecl xs        -> getRange xs
     UnknownNamesInPolarityPragmas xs   -> getRange xs
     UselessAbstract r                  -> r
-    UselessInstance r                  -> r
+    UselessInstance kwr                -> getRange kwr
     UselessPrivate r                   -> r
 
 -- These error messages can (should) be terminated by a dot ".",

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -75,7 +75,7 @@ data DeclarationWarning'
   | EmptyField Range       -- ^ Empty @field@     block.
   | EmptyGeneralize Range  -- ^ Empty @variable@  block.
   | EmptyInstance KwRange  -- ^ Empty @instance@  block
-  | EmptyMacro Range       -- ^ Empty @macro@     block.
+  | EmptyMacro KwRange     -- ^ Empty @macro@     block.
   | EmptyMutual Range      -- ^ Empty @mutual@    block.
   | EmptyPostulate Range   -- ^ Empty @postulate@ block.
   | EmptyPrivate KwRange   -- ^ Empty @private@   block.
@@ -312,7 +312,7 @@ instance HasRange DeclarationWarning' where
     EmptyField r                       -> r
     EmptyGeneralize r                  -> r
     EmptyInstance kwr                  -> getRange kwr
-    EmptyMacro r                       -> r
+    EmptyMacro kwr                     -> getRange kwr
     EmptyMutual r                      -> r
     EmptyPostulate r                   -> r
     EmptyPrimitive r                   -> r

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -73,7 +73,7 @@ data DeclarationWarning'
   -- Please keep in alphabetical order.
   = EmptyAbstract KwRange  -- ^ Empty @abstract@  block.
   | EmptyConstructor KwRange -- ^ Empty @data _ where@ block.
-  | EmptyField Range       -- ^ Empty @field@     block.
+  | EmptyField KwRange       -- ^ Empty @field@     block.
   | EmptyGeneralize Range  -- ^ Empty @variable@  block.
   | EmptyInstance KwRange  -- ^ Empty @instance@  block
   | EmptyMacro KwRange     -- ^ Empty @macro@     block.
@@ -314,7 +314,7 @@ instance HasRange DeclarationWarning' where
   getRange = \case
     EmptyAbstract kwr                  -> getRange kwr
     EmptyConstructor kwr               -> getRange kwr
-    EmptyField r                       -> r
+    EmptyField kwr                     -> getRange kwr
     EmptyGeneralize r                  -> r
     EmptyInstance kwr                  -> getRange kwr
     EmptyMacro kwr                     -> getRange kwr

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -71,7 +71,7 @@ data DeclarationWarning = DeclarationWarning
 data DeclarationWarning'
   -- Please keep in alphabetical order.
   = EmptyAbstract KwRange  -- ^ Empty @abstract@  block.
-  | EmptyConstructor Range -- ^ Empty @constructor@ block.
+  | EmptyConstructor KwRange -- ^ Empty @data _ where@ block.
   | EmptyField Range       -- ^ Empty @field@     block.
   | EmptyGeneralize Range  -- ^ Empty @variable@  block.
   | EmptyInstance KwRange  -- ^ Empty @instance@  block
@@ -308,7 +308,7 @@ instance HasRange DeclarationWarning where
 instance HasRange DeclarationWarning' where
   getRange = \case
     EmptyAbstract kwr                  -> getRange kwr
-    EmptyConstructor r                 -> r
+    EmptyConstructor kwr               -> getRange kwr
     EmptyField r                       -> r
     EmptyGeneralize r                  -> r
     EmptyInstance kwr                  -> getRange kwr

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -70,7 +70,7 @@ data DeclarationWarning = DeclarationWarning
 -- | Non-fatal errors encountered in the Nicifier.
 data DeclarationWarning'
   -- Please keep in alphabetical order.
-  = EmptyAbstract Range    -- ^ Empty @abstract@  block.
+  = EmptyAbstract KwRange  -- ^ Empty @abstract@  block.
   | EmptyConstructor Range -- ^ Empty @constructor@ block.
   | EmptyField Range       -- ^ Empty @field@     block.
   | EmptyGeneralize Range  -- ^ Empty @variable@  block.
@@ -133,7 +133,7 @@ data DeclarationWarning'
   | UnknownFixityInMixfixDecl [Name]
   | UnknownNamesInFixityDecl [Name]
   | UnknownNamesInPolarityPragmas [Name]
-  | UselessAbstract Range
+  | UselessAbstract KwRange
       -- ^ @abstract@ block with nothing that can (newly) be made abstract.
   | UselessInstance KwRange
       -- ^ @instance@ block with nothing that can (newly) become an instance.
@@ -307,7 +307,7 @@ instance HasRange DeclarationWarning where
 
 instance HasRange DeclarationWarning' where
   getRange = \case
-    EmptyAbstract r                    -> r
+    EmptyAbstract kwr                  -> getRange kwr
     EmptyConstructor r                 -> r
     EmptyField r                       -> r
     EmptyGeneralize r                  -> r
@@ -346,7 +346,7 @@ instance HasRange DeclarationWarning' where
     UnknownFixityInMixfixDecl xs       -> getRange xs
     UnknownNamesInFixityDecl xs        -> getRange xs
     UnknownNamesInPolarityPragmas xs   -> getRange xs
-    UselessAbstract r                  -> r
+    UselessAbstract kwr                -> getRange kwr
     UselessInstance kwr                -> getRange kwr
     UselessPrivate kwr                 -> getRange kwr
 

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -78,7 +78,7 @@ data DeclarationWarning'
   | EmptyMacro Range       -- ^ Empty @macro@     block.
   | EmptyMutual Range      -- ^ Empty @mutual@    block.
   | EmptyPostulate Range   -- ^ Empty @postulate@ block.
-  | EmptyPrivate Range     -- ^ Empty @private@   block.
+  | EmptyPrivate KwRange   -- ^ Empty @private@   block.
   | EmptyPrimitive Range   -- ^ Empty @primitive@ block.
   | HiddenGeneralize Range
       -- ^ A 'Hidden' identifier in a @variable@ declaration.
@@ -109,10 +109,12 @@ data DeclarationWarning'
   | MissingDefinitions [(Name, Range)]
       -- ^ Declarations (e.g. type signatures) without a definition.
   | NotAllowedInMutual Range String
-  | OpenPublicPrivate Range
+  | OpenPublicPrivate KwRange
       -- ^ @private@ has no effect on @open public@.  (But the user might think so.)
-  | OpenPublicAbstract Range
+      --   'KwRange' is the range of the @public@ keyword.
+  | OpenPublicAbstract KwRange
       -- ^ @abstract@ has no effect on @open public@.  (But the user might think so.)
+      --   'KwRange' is the range of the @public@ keyword.
   | PolarityPragmasButNotPostulates [Name]
   | PragmaNoTerminationCheck Range
       -- ^ Pragma @{-\# NO_TERMINATION_CHECK \#-}@ has been replaced
@@ -135,7 +137,7 @@ data DeclarationWarning'
       -- ^ @abstract@ block with nothing that can (newly) be made abstract.
   | UselessInstance KwRange
       -- ^ @instance@ block with nothing that can (newly) become an instance.
-  | UselessPrivate Range
+  | UselessPrivate KwRange
       -- ^ @private@ block with nothing that can (newly) be made private.
   deriving (Show, Generic)
 
@@ -314,7 +316,7 @@ instance HasRange DeclarationWarning' where
     EmptyMutual r                      -> r
     EmptyPostulate r                   -> r
     EmptyPrimitive r                   -> r
-    EmptyPrivate r                     -> r
+    EmptyPrivate kwr                   -> getRange kwr
     HiddenGeneralize r                 -> r
     InvalidCatchallPragma r            -> r
     InvalidConstructor r               -> r
@@ -327,8 +329,8 @@ instance HasRange DeclarationWarning' where
     MissingDeclarations xs             -> getRange xs
     MissingDefinitions xs              -> getRange xs
     NotAllowedInMutual r x             -> r
-    OpenPublicAbstract r               -> r
-    OpenPublicPrivate r                -> r
+    OpenPublicAbstract kwr             -> getRange kwr
+    OpenPublicPrivate kwr              -> getRange kwr
     PolarityPragmasButNotPostulates xs -> getRange xs
     PragmaCompiled r                   -> r
     PragmaNoTerminationCheck r         -> r
@@ -346,7 +348,7 @@ instance HasRange DeclarationWarning' where
     UnknownNamesInPolarityPragmas xs   -> getRange xs
     UselessAbstract r                  -> r
     UselessInstance kwr                -> getRange kwr
-    UselessPrivate r                   -> r
+    UselessPrivate kwr                 -> getRange kwr
 
 -- These error messages can (should) be terminated by a dot ".",
 -- there is no error context printed after them.

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -78,7 +78,7 @@ data DeclarationWarning'
   | EmptyInstance KwRange  -- ^ Empty @instance@  block
   | EmptyMacro KwRange     -- ^ Empty @macro@     block.
   | EmptyMutual KwRange    -- ^ Empty @mutual@    block.
-  | EmptyPostulate Range   -- ^ Empty @postulate@ block.
+  | EmptyPostulate KwRange -- ^ Empty @postulate@ block.
   | EmptyPrivate KwRange   -- ^ Empty @private@   block.
   | EmptyPrimitive KwRange   -- ^ Empty @primitive@ block.
   | HiddenGeneralize Range
@@ -319,7 +319,7 @@ instance HasRange DeclarationWarning' where
     EmptyInstance kwr                  -> getRange kwr
     EmptyMacro kwr                     -> getRange kwr
     EmptyMutual kwr                    -> getRange kwr
-    EmptyPostulate r                   -> r
+    EmptyPostulate kwr                 -> getRange kwr
     EmptyPrimitive kwr                 -> getRange kwr
     EmptyPrivate kwr                   -> getRange kwr
     HiddenGeneralize r                 -> r

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -137,6 +137,8 @@ data DeclarationWarning'
       -- ^ @abstract@ block with nothing that can (newly) be made abstract.
   | UselessInstance KwRange
       -- ^ @instance@ block with nothing that can (newly) become an instance.
+  | UselessMacro KwRange
+      -- ^ @macro@ block with nothing that can (newly) be made macro.
   | UselessPrivate KwRange
       -- ^ @private@ block with nothing that can (newly) be made private.
   deriving (Show, Generic)
@@ -188,6 +190,7 @@ declarationWarningName' = \case
   UnknownNamesInPolarityPragmas{}   -> UnknownNamesInPolarityPragmas_
   UselessAbstract{}                 -> UselessAbstract_
   UselessInstance{}                 -> UselessInstance_
+  UselessMacro{}                    -> UselessMacro_
   UselessPrivate{}                  -> UselessPrivate_
 
 -- | Nicifier warnings turned into errors in @--safe@ mode.
@@ -238,6 +241,7 @@ unsafeDeclarationWarning' = \case
   UnknownNamesInPolarityPragmas{}   -> False
   UselessAbstract{}                 -> False
   UselessInstance{}                 -> False
+  UselessMacro{}                    -> False
   UselessPrivate{}                  -> False
 
 -- | Pragmas not allowed in @--safe@ mode produce an 'unsafeDeclarationWarning'.
@@ -348,6 +352,7 @@ instance HasRange DeclarationWarning' where
     UnknownNamesInPolarityPragmas xs   -> getRange xs
     UselessAbstract kwr                -> getRange kwr
     UselessInstance kwr                -> getRange kwr
+    UselessMacro kwr                   -> getRange kwr
     UselessPrivate kwr                 -> getRange kwr
 
 -- These error messages can (should) be terminated by a dot ".",
@@ -445,6 +450,9 @@ instance Pretty DeclarationWarning' where
 
     UselessInstance _ -> fsep $
       pwords "Using instance here has no effect. Instance applies only to declarations that introduce new identifiers into the module, like type signatures and axioms."
+
+    UselessMacro _ -> fsep $
+      pwords "Using a macro block here has no effect. `macro' applies only to function definitions."
 
     EmptyMutual    _ -> fsep $ pwords "Empty mutual block."
 

--- a/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
@@ -171,7 +171,7 @@ checkLoneSigs xs = do
 -- | Ensure that all forward declarations have been given a definition,
 -- raising an error indicating *why* they would have had to have been
 -- defined.
-breakImplicitMutualBlock :: Range -> String -> Nice ()
+breakImplicitMutualBlock :: KwRange -> String -> Nice ()
 breakImplicitMutualBlock r why = do
   m <- use loneSigs
   List1.unlessNull (Map.elems m) $ \ xs ->

--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -52,7 +52,7 @@ data NiceDeclaration
       --   ('Hiding' should be 'NotHidden'.)
   | NiceField Range Access IsAbstract IsInstance TacticAttribute Name (Arg Expr)
   | PrimitiveFunction Range Access IsAbstract Name (Arg Expr)
-  | NiceMutual Range TerminationCheck CoverageCheck PositivityCheck [NiceDeclaration]
+  | NiceMutual KwRange TerminationCheck CoverageCheck PositivityCheck [NiceDeclaration]
   | NiceModule Range Access IsAbstract Erased QName Telescope
       [Declaration]
   | NiceModuleMacro Range Access Erased Name ModuleApplication
@@ -84,7 +84,7 @@ data NiceDeclaration
   | NiceUnquoteDecl Range Access IsAbstract IsInstance TerminationCheck CoverageCheck [Name] Expr
   | NiceUnquoteDef Range Access IsAbstract TerminationCheck CoverageCheck [Name] Expr
   | NiceUnquoteData Range Access IsAbstract PositivityCheck UniverseCheck Name [Name] Expr
-  | NiceOpaque Range [QName] [NiceDeclaration]
+  | NiceOpaque KwRange [QName] [NiceDeclaration]
   deriving (Show, Generic)
 
 instance NFData NiceDeclaration
@@ -204,7 +204,7 @@ data KindOfBlock
 instance HasRange NiceDeclaration where
   getRange (Axiom r _ _ _ _ _ _)           = r
   getRange (NiceField r _ _ _ _ _ _)       = r
-  getRange (NiceMutual r _ _ _ _)          = r
+  getRange (NiceMutual kwr _ _ _ ds)       = fuseRange kwr ds
   getRange (NiceModule r _ _ _ _ _ _ )     = r
   getRange (NiceModuleMacro r _ _ _ _ _ _) = r
   getRange (NiceOpen r _ _)                = r
@@ -214,7 +214,7 @@ instance HasRange NiceDeclaration where
   getRange (FunSig r _ _ _ _ _ _ _ _ _)    = r
   getRange (FunDef r _ _ _ _ _ _ _)        = r
   getRange (NiceDataDef r _ _ _ _ _ _ _)   = r
-  getRange (NiceLoneConstructor r ds)      = fuseRange r ds
+  getRange (NiceLoneConstructor kwr ds)    = fuseRange kwr ds
   getRange (NiceRecDef r _ _ _ _ _ _ _ _)  = r
   getRange (NiceRecSig r _ _ _ _ _ _ _ _)  = r
   getRange (NiceDataSig r _ _ _ _ _ _ _ _) = r
@@ -224,7 +224,7 @@ instance HasRange NiceDeclaration where
   getRange (NiceUnquoteDecl r _ _ _ _ _ _ _) = r
   getRange (NiceUnquoteDef r _ _ _ _ _ _)  = r
   getRange (NiceUnquoteData r _ _ _ _ _ _ _) = r
-  getRange (NiceOpaque r _ _)                = r
+  getRange (NiceOpaque kwr xs ds)          = getRange (kwr, xs, ds)
 
 instance Pretty NiceDeclaration where
   pretty = \case

--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -76,7 +76,7 @@ data NiceDeclaration
       --   Andreas, 2017-01-01: Because of issue #2372, we add 'IsInstance' here.
       --   An alias should know that it is an instance.
   | NiceDataDef Range Origin IsAbstract PositivityCheck UniverseCheck Name [LamBinding] [NiceConstructor]
-  | NiceLoneConstructor Range [NiceConstructor]
+  | NiceLoneConstructor KwRange [NiceConstructor]
   | NiceRecDef Range Origin IsAbstract PositivityCheck UniverseCheck Name RecordDirectives [LamBinding] [Declaration]
       -- ^ @(Maybe Range)@ gives range of the 'pattern' declaration.
   | NicePatternSyn Range Access Name [WithHiding Name] Pattern
@@ -214,7 +214,7 @@ instance HasRange NiceDeclaration where
   getRange (FunSig r _ _ _ _ _ _ _ _ _)    = r
   getRange (FunDef r _ _ _ _ _ _ _)        = r
   getRange (NiceDataDef r _ _ _ _ _ _ _)   = r
-  getRange (NiceLoneConstructor r _)       = r
+  getRange (NiceLoneConstructor r ds)      = fuseRange r ds
   getRange (NiceRecDef r _ _ _ _ _ _ _ _)  = r
   getRange (NiceRecSig r _ _ _ _ _ _ _ _)  = r
   getRange (NiceDataSig r _ _ _ _ _ _ _ _) = r

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -387,10 +387,14 @@ instance Pretty WhereClause where
                        = vcat [ "where", nest 2 (vcat $ map pretty ds) ]
   pretty (AnyWhere _ ds) = vcat [ "where", nest 2 (vcat $ map pretty ds) ]
   pretty (SomeWhere _ erased m a ds) =
-    vcat [ hsep $ applyWhen (a == PrivateAccess UserWritten) ("private" :)
+    vcat [ hsep $ privateWhenUserWritten a
              [ "module", prettyErased erased (pretty m), "where" ]
          , nest 2 (vcat $ map pretty ds)
          ]
+    where
+      privateWhenUserWritten = \case
+        PrivateAccess _ UserWritten -> ("private" :)
+        _ -> id
 
 instance Pretty LHS where
   pretty (LHS p eqs es) = sep

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1271,7 +1271,7 @@ Constructor : 'data' '_' 'where' Declarations0
 -- Declaration of record constructor name.
 RecordConstructorName :: { (Name, IsInstance) }
 RecordConstructorName :                  'constructor' Id       { ($2, NotInstanceDef) }
-                      | 'instance' vopen 'constructor' Id close { ($4, InstanceDef (getRange $1)) }
+                      | 'instance' vopen 'constructor' Id close { ($4, InstanceDef (kwRange $1)) }
 
 
 -- Fixity declarations.
@@ -1285,17 +1285,10 @@ Fields :: { Declaration }
 Fields : 'field' ArgTypeSignaturesOrEmpty
             { let
                 inst i = case getHiding i of
-                           Instance _ -> InstanceDef noRange  -- no @instance@ keyword here
+                           Instance _ -> InstanceDef empty  -- no @instance@ keyword here
                            _          -> NotInstanceDef
                 toField (Arg info (TypeSig info' tac x t)) = FieldSig (inst info') tac x (Arg info t)
               in Field (fuseRange $1 $2) $ map toField $2 }
-  -- | 'field' ModalArgTypeSignatures
-  --           { let
-  --               inst i = case getHiding i of
-  --                          Instance _ -> InstanceDef
-  --                          _          -> NotInstanceDef
-  --               toField (Arg info (TypeSig info' x t)) = FieldSig (inst info') x (Arg info t)
-  --             in Field (fuseRange $1 $2) $ map toField $2 }
 
 -- Variable declarations for automatic generalization
 Generalize :: { Declaration }
@@ -1321,7 +1314,7 @@ Private : 'private' Declarations0        { Private (fuseRange $1 $2) UserWritten
 
 -- Instance declarations.
 Instance :: { Declaration }
-Instance : 'instance' Declarations0  { InstanceB (getRange $1) $2 }
+Instance : 'instance' Declarations0  { InstanceB (kwRange $1) $2 }
 
 
 -- Macro declarations.

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1025,7 +1025,7 @@ ImportDirective
   | {- empty -}                      { mempty }
 
 ImportDirective1 :: { ImportDirective }
-  : 'public'      { defaultImportDir { importDirRange = getRange $1, publicOpen = Just (getRange $1) } }
+  : 'public'      { defaultImportDir { importDirRange = getRange $1, publicOpen = Just (kwRange $1) } }
   | Using         { defaultImportDir { importDirRange = snd $1, using    = fst $1 } }
   | Hiding        { defaultImportDir { importDirRange = snd $1, hiding   = fst $1 } }
   | RenamingDir   { defaultImportDir { importDirRange = snd $1, impRenaming = fst $1 } }
@@ -1309,7 +1309,7 @@ Abstract : 'abstract' Declarations0  { Abstract (fuseRange $1 $2) $2 }
 
 -- Private can only appear on the top-level (or rather the module level).
 Private :: { Declaration }
-Private : 'private' Declarations0        { Private (fuseRange $1 $2) UserWritten $2 }
+Private : 'private' Declarations0        { Private (kwRange $1) UserWritten $2 }
 
 
 -- Instance declarations.
@@ -1431,7 +1431,7 @@ Open : MaybeOpen 'import' ModuleName OpenArgs ImportDirective {%
     ; fresh' = Name mr NotInScope $ singleton $ Id $ stringToRawName $ ".#" ++ prettyShow m ++ "-" ++ show (unique + 1)
     ; impStm asR = Import noRange m (Just (AsName (Right fresh) asR)) DontOpen defaultImportDir
     ; appStm m' es =
-        Private r Inserted
+        Private empty Inserted
           [ ModuleMacro r defaultErased m'
              (SectionApp (getRange es) []
                (rawApp (Ident (QName fresh) :| es)))
@@ -1478,7 +1478,7 @@ Open : MaybeOpen 'import' ModuleName OpenArgs ImportDirective {%
     } in singleton $
       case es of
       { []  -> Open r m dir
-      ; _   -> Private r Inserted
+      ; _   -> Private empty Inserted
                  [ ModuleMacro r defaultErased
                      (noName $ beginningOf $ getRange m)
                      (SectionApp (getRange (m , es)) []
@@ -1489,7 +1489,7 @@ Open : MaybeOpen 'import' ModuleName OpenArgs ImportDirective {%
   }
   | 'open' ModuleName '{{' '...' DoubleCloseBrace ImportDirective {
     let r = getRange $2 in singleton $
-      Private r Inserted
+      Private empty Inserted
       [ ModuleMacro r defaultErased (noName $ beginningOf $ getRange $2)
           (RecordModuleInstance r $2) DoOpen $6
       ]

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1295,7 +1295,7 @@ Generalize :: { Declaration }
 Generalize : 'variable' ArgTypeSignaturesOrEmpty
             { let
                 toGeneralize (Arg info (TypeSig _ tac x t)) = TypeSig info tac x t
-              in Generalize (fuseRange $1 $2) (map toGeneralize $2) }
+              in Generalize (kwRange $1) (map toGeneralize $2) }
 
 -- Mutually recursive declarations.
 Mutual :: { Declaration }

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1288,7 +1288,7 @@ Fields : 'field' ArgTypeSignaturesOrEmpty
                            Instance _ -> InstanceDef empty  -- no @instance@ keyword here
                            _          -> NotInstanceDef
                 toField (Arg info (TypeSig info' tac x t)) = FieldSig (inst info') tac x (Arg info t)
-              in Field (fuseRange $1 $2) $ map toField $2 }
+              in Field (kwRange $1) $ map toField $2 }
 
 -- Variable declarations for automatic generalization
 Generalize :: { Declaration }

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1319,7 +1319,7 @@ Instance : 'instance' Declarations0  { InstanceB (kwRange $1) $2 }
 
 -- Macro declarations.
 Macro :: { Declaration }
-Macro : 'macro' Declarations0 { Macro (fuseRange $1 $2) $2 }
+Macro : 'macro' Declarations0 { Macro (kwRange $1) $2 }
 
 
 -- Postulates.

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1304,7 +1304,7 @@ Mutual : 'mutual' Declarations0  { Mutual (fuseRange $1 $2) $2 }
 
 -- Abstract declarations.
 Abstract :: { Declaration }
-Abstract : 'abstract' Declarations0  { Abstract (fuseRange $1 $2) $2 }
+Abstract : 'abstract' Declarations0  { Abstract (kwRange $1) $2 }
 
 
 -- Private can only appear on the top-level (or rather the module level).

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1299,8 +1299,8 @@ Generalize : 'variable' ArgTypeSignaturesOrEmpty
 
 -- Mutually recursive declarations.
 Mutual :: { Declaration }
-Mutual : 'mutual' Declarations0  { Mutual (fuseRange $1 $2) $2 }
-       | 'interleaved' 'mutual' Declarations0 { InterleavedMutual (getRange ($1,$2,$3)) $3 }
+Mutual : 'mutual' Declarations0  { Mutual (kwRange $1) $2 }
+       | 'interleaved' 'mutual' Declarations0 { InterleavedMutual (kwRange ($1,$2)) $3 }
 
 -- Abstract declarations.
 Abstract :: { Declaration }
@@ -1800,10 +1800,10 @@ RecordInduction
     | 'coinductive' { Ranged (getRange $1) CoInductive }
 
 Opaque :: { Declaration }
-  : 'opaque' Declarations0     { Opaque (getRange ($1, $2)) $2 }
+  : 'opaque' Declarations0     { Opaque (kwRange $1) $2 }
 
 Unfolding :: { Declaration }
-  : 'unfolding' UnfoldingNames { Unfolding (getRange ($1, $2)) $2 }
+  : 'unfolding' UnfoldingNames { Unfolding (kwRange $1) $2 }
 
 UnfoldingNames :: { [QName] }
 UnfoldingNames

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1324,7 +1324,7 @@ Macro : 'macro' Declarations0 { Macro (kwRange $1) $2 }
 
 -- Postulates.
 Postulate :: { Declaration }
-Postulate : 'postulate' Declarations0 { Postulate (fuseRange $1 $2) $2 }
+Postulate : 'postulate' Declarations0 { Postulate (kwRange $1) $2 }
 
 -- Primitives. Can only contain type signatures.
 Primitive :: { Declaration }

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1266,7 +1266,7 @@ RecordSig
 
 Constructor :: { Declaration }
 Constructor : 'data' '_' 'where' Declarations0
-  { LoneConstructor (getRange ($1,$4)) $4 }
+  { LoneConstructor (kwRange ($1,$2,$3)) $4 }
 
 -- Declaration of record constructor name.
 RecordConstructorName :: { (Name, IsInstance) }

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1331,7 +1331,7 @@ Primitive :: { Declaration }
 Primitive : 'primitive' ArgTypeSignaturesOrEmpty  {
   let { setArg (Arg info (TypeSig _ tac x t)) = TypeSig info tac x t
       ; setArg _ = __IMPOSSIBLE__ } in
-  Primitive (fuseRange $1 $2) (map setArg $2) }
+  Primitive (kwRange $1) (map setArg $2) }
 
 -- Unquoting declarations.
 UnquoteDecl :: { Declaration }

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -86,7 +86,7 @@ localNameSpace PublicAccess    = PublicNS
 localNameSpace PrivateAccess{} = PrivateNS
 
 nameSpaceAccess :: NameSpaceId -> Access
-nameSpaceAccess PrivateNS = PrivateAccess Inserted
+nameSpaceAccess PrivateNS = privateAccessInserted
 nameSpaceAccess _         = PublicAccess
 
 -- | Get a 'NameSpace' from 'Scope'.

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -567,7 +567,7 @@ withAbstractPrivate i m =
         priv (PrivateAccess kwr UserWritten)
                          ds = [ C.Private kwr UserWritten ds ]
         priv _           ds = ds
-        abst AbstractDef ds = [ C.Abstract (getRange ds) ds ]
+        abst AbstractDef ds = [ C.Abstract empty ds ]
         abst ConcreteDef ds = ds
 
 addInstanceB :: Maybe KwRange -> [C.Declaration] -> [C.Declaration]

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1211,7 +1211,7 @@ instance ToConcrete A.Declaration where
         (case mp of
            Nothing   -> []
            Just occs -> [C.Pragma (PolarityPragma noRange x' occs)]) ++
-        [C.Postulate (getRange i) [C.TypeSig info empty x' t']]
+        [C.Postulate empty [C.TypeSig info empty x' t']]
 
   toConcrete (A.Generalize s i j x t) = do
     x' <- unsafeQNameToName <$> toConcrete x

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -570,7 +570,7 @@ withAbstractPrivate i m =
         abst AbstractDef ds = [ C.Abstract (getRange ds) ds ]
         abst ConcreteDef ds = ds
 
-addInstanceB :: Maybe Range -> [C.Declaration] -> [C.Declaration]
+addInstanceB :: Maybe KwRange -> [C.Declaration] -> [C.Declaration]
 addInstanceB (Just r) ds = [ C.InstanceB r ds ]
 addInstanceB Nothing  ds = ds
 
@@ -1055,7 +1055,7 @@ instance ToConcrete A.LetBinding where
     bindToConcrete (A.LetBind i info x t e) ret =
         bindToConcrete x $ \ x ->
         do (t, (e, [], [], [])) <- toConcrete (t, A.RHS e Nothing)
-           ret $ addInstanceB (if isInstance info then Just noRange else Nothing) $
+           ret $ addInstanceB (if isInstance info then Just empty else Nothing) $
                [ C.TypeSig info empty (C.boundName x) t
                , C.FunClause
                    (C.LHS (C.IdentP True $ C.QName $ C.boundName x) [] [])

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1234,7 +1234,7 @@ instance ToConcrete A.Declaration where
     withAbstractPrivate i $
       withInfixDecl i x'  $ do
       t' <- traverse toConcreteTop t
-      return [C.Primitive (getRange i) [C.TypeSig (argInfo t') empty x' (unArg t')]]
+      return [C.Primitive empty [C.TypeSig (argInfo t') empty x' (unArg t')]]
         -- Primitives are always relevant.
 
   toConcrete (A.FunDef i _ cs) =

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -564,8 +564,8 @@ withAbstractPrivate i m =
       . addInstanceB (case A.defInstance i of InstanceDef r -> Just r; NotInstanceDef -> Nothing)
       <$> m
     where
-        priv (PrivateAccess UserWritten)
-                         ds = [ C.Private  (getRange ds) UserWritten ds ]
+        priv (PrivateAccess kwr UserWritten)
+                         ds = [ C.Private kwr UserWritten ds ]
         priv _           ds = ds
         abst AbstractDef ds = [ C.Abstract (getRange ds) ds ]
         abst ConcreteDef ds = ds

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1268,7 +1268,7 @@ instance ToConcrete A.Declaration where
       (x',cs') <- first unsafeQNameToName <$> toConcrete (x, map Constr cs)
       return [ C.RecordDef (getRange i) x' (dir { recConstructor = Nothing }) (catMaybes tel') cs' ]
 
-  toConcrete (A.Mutual i ds) = pure . C.Mutual noRange <$> declsToConcrete ds
+  toConcrete (A.Mutual i ds) = pure . C.Mutual empty <$> declsToConcrete ds
 
   toConcrete (A.Section i erased x (A.GeneralizeTel _ tel) ds) = do
     x <- toConcrete x

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1219,7 +1219,7 @@ instance ToConcrete A.Declaration where
     withAbstractPrivate i $
       withInfixDecl i x'  $ do
       t' <- toConcreteTop t
-      return [C.Generalize (getRange i) [C.TypeSig j tac x' $ C.Generalized t']]
+      return [C.Generalize empty [C.TypeSig j tac x' $ C.Generalized t']]
 
   toConcrete (A.Field i x t) = do
     x' <- unsafeQNameToName <$> toConcrete x

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240220 * 10 + 0
+currentInterfaceVersion = 20240303 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -18,6 +18,7 @@ import Agda.TypeChecking.Serialise.Instances.Common () --instance only
 
 import Agda.Utils.Functor
 import Agda.Utils.Lens
+import Agda.Utils.Null
 import Agda.Utils.Impossible
 
 -- Don't serialize the tactic.
@@ -51,13 +52,13 @@ instance EmbPrj NameSpaceId where
     _ -> malformed
 
 instance EmbPrj Access where
-  icod_ (PrivateAccess UserWritten) = pure 0
-  icod_ PrivateAccess{}             = pure 1
-  icod_ PublicAccess                = pure 2
+  icod_ (PrivateAccess _ UserWritten) = pure 0
+  icod_ PrivateAccess{}               = pure 1
+  icod_ PublicAccess                  = pure 2
 
   value = \case
-    0 -> pure $ PrivateAccess UserWritten
-    1 -> pure $ PrivateAccess Inserted
+    0 -> pure $ PrivateAccess empty UserWritten
+    1 -> pure $ privateAccessInserted
     2 -> pure PublicAccess
     _ -> malformed
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -53,6 +53,7 @@ import qualified Agda.Utils.List1 as List1
 import Agda.Utils.List2 (List2(List2))
 import qualified Agda.Utils.List2 as List2
 import qualified Agda.Utils.Maybe.Strict as Strict
+import Agda.Utils.Null
 import Agda.Utils.Trie (Trie(..))
 import Agda.Utils.WithDefault
 
@@ -303,6 +304,10 @@ instance EmbPrj RangeFile where
 instance EmbPrj Range where
   icod_ _ = icodeN' ()
   value _ = return noRange
+
+instance EmbPrj KwRange where
+  icod_ _ = icodeN' ()
+  value _ = return empty
 
 -- | Ranges that should be serialised properly.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -229,6 +229,7 @@ instance EmbPrj DeclarationWarning' where
     InvalidConstructorBlock a         -> icodeN 31 InvalidConstructorBlock a
     MissingDeclarations a             -> icodeN 32 MissingDeclarations a
     HiddenGeneralize r                -> icodeN 33 HiddenGeneralize r
+    UselessMacro r                    -> icodeN 34 UselessMacro r
     SafeFlagEta                    {} -> __IMPOSSIBLE__
     SafeFlagInjective              {} -> __IMPOSSIBLE__
     SafeFlagNoCoverageCheck        {} -> __IMPOSSIBLE__
@@ -273,6 +274,7 @@ instance EmbPrj DeclarationWarning' where
     [31,r]   -> valuN InvalidConstructorBlock r
     [32,r]   -> valuN MissingDeclarations r
     [33,r]   -> valuN HiddenGeneralize r
+    [34,r]   -> valuN UselessMacro r
     _ -> malformed
 
 instance EmbPrj LibWarning where
@@ -464,6 +466,7 @@ instance EmbPrj WarningName where
     NoMain_                                      -> 111
     DuplicateRewriteRule_                        -> 112
     MissingTypeSignatureForOpaque_               -> 113
+    UselessMacro_                                -> 114
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -579,6 +582,7 @@ instance EmbPrj WarningName where
     111 -> return NoMain_
     112 -> return DuplicateRewriteRule_
     113 -> return MissingTypeSignatureForOpaque_
+    114 -> return UselessMacro_
     _   -> malformed
 
 

--- a/test/Fail/AbstractModuleMacro.err
+++ b/test/Fail/AbstractModuleMacro.err
@@ -1,4 +1,4 @@
-AbstractModuleMacro.agda:7,1-8,19
+AbstractModuleMacro.agda:7,1-9
 warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and

--- a/test/Fail/ImplicitMutualInterleavedMutual.err
+++ b/test/Fail/ImplicitMutualInterleavedMutual.err
@@ -1,4 +1,4 @@
-ImplicitMutualInterleavedMutual.agda:6,1-8,13
+ImplicitMutualInterleavedMutual.agda:6,1-19
 The following names are declared, but not accompanied by a
 definition:
 - test (at ImplicitMutualInterleavedMutual.agda:5,1-5)

--- a/test/Fail/ImplicitMutualMutual.err
+++ b/test/Fail/ImplicitMutualMutual.err
@@ -1,4 +1,4 @@
-ImplicitMutualMutual.agda:6,1-8,13
+ImplicitMutualMutual.agda:6,1-7
 The following names are declared, but not accompanied by a
 definition:
 - test (at ImplicitMutualMutual.agda:5,1-5)

--- a/test/Fail/ImplicitMutualOpaque.err
+++ b/test/Fail/ImplicitMutualOpaque.err
@@ -1,4 +1,4 @@
-ImplicitMutualOpaque.agda:6,1-8,13
+ImplicitMutualOpaque.agda:6,1-7
 The following names are declared, but not accompanied by a
 definition:
 - test (at ImplicitMutualOpaque.agda:5,1-5)

--- a/test/Fail/Issue278.err
+++ b/test/Fail/Issue278.err
@@ -1,4 +1,4 @@
-Issue278.agda:7,1-14,19
+Issue278.agda:7,1-9
 warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and

--- a/test/Fail/Issue3932-2.err
+++ b/test/Fail/Issue3932-2.err
@@ -1,4 +1,4 @@
-Issue3932-2.agda:6,1-7,9
+Issue3932-2.agda:6,1-7
 The following names are declared, but not accompanied by a
 definition:
 - f (at Issue3932-2.agda:4,1-2)

--- a/test/Fail/Issue3932.err
+++ b/test/Fail/Issue3932.err
@@ -1,4 +1,4 @@
-Issue3932.agda:31,5-32,14
+Issue3932.agda:31,5-11
 The following names are declared, but not accompanied by a
 definition:
 - A (at Issue3932.agda:29,5-6)

--- a/test/Fail/Issue476a.err
+++ b/test/Fail/Issue476a.err
@@ -1,4 +1,4 @@
-Issue476a.agda:8,1-9,10
+Issue476a.agda:8,1-8
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like

--- a/test/Fail/Issue476b.err
+++ b/test/Fail/Issue476b.err
@@ -1,4 +1,4 @@
-Issue476b.agda:7,1-8,15
+Issue476b.agda:7,1-9
 warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and

--- a/test/Fail/Issue6729.err
+++ b/test/Fail/Issue6729.err
@@ -1,4 +1,4 @@
-Issue6729.agda:1,1-2,13
+Issue6729.agda:1,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration

--- a/test/Fail/MissingDefinitions.err
+++ b/test/Fail/MissingDefinitions.err
@@ -1,4 +1,4 @@
-MissingDefinitions.agda:25,1-30,50
+MissingDefinitions.agda:25,1-7
 The following names are declared, but not accompanied by a
 definition:
 - Q (at MissingDefinitions.agda:5,1-2)

--- a/test/Fail/OpaqueMutual.err
+++ b/test/Fail/OpaqueMutual.err
@@ -1,4 +1,4 @@
-OpaqueMutual.agda:4,3-6,12
+OpaqueMutual.agda:4,3-9
 Opaque blocks can not participate in mutual recursion. If the
 opaque definitions are to be mutually recursive, move the 'mutual'
 block inside the 'opaque' block.

--- a/test/Fail/OpaqueUseless.err
+++ b/test/Fail/OpaqueUseless.err
@@ -1,4 +1,4 @@
-OpaqueUseless.agda:4,1-5,23
+OpaqueUseless.agda:4,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration

--- a/test/Fail/OpaqueWhereOpaqueData.err
+++ b/test/Fail/OpaqueWhereOpaqueData.err
@@ -1,4 +1,4 @@
-OpaqueWhereOpaqueData.agda:11,5-12,27
+OpaqueWhereOpaqueData.agda:11,5-11
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration

--- a/test/Fail/UselessAbstractAbstract.err
+++ b/test/Fail/UselessAbstractAbstract.err
@@ -1,4 +1,4 @@
-UselessAbstractAbstract.agda:6,1-8,12
+UselessAbstractAbstract.agda:6,1-9
 warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and

--- a/test/Fail/UselessAbstractField.err
+++ b/test/Fail/UselessAbstractField.err
@@ -1,4 +1,4 @@
-UselessAbstractField.agda:6,3-7,18
+UselessAbstractField.agda:6,3-11
 warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and

--- a/test/Fail/UselessAbstractPrimitive.err
+++ b/test/Fail/UselessAbstractPrimitive.err
@@ -1,4 +1,4 @@
-UselessAbstractPrimitive.agda:9,1-11,40
+UselessAbstractPrimitive.agda:9,1-9
 warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and

--- a/test/Fail/UselessPrivateImport.err
+++ b/test/Fail/UselessPrivateImport.err
@@ -1,4 +1,4 @@
-UselessPrivateImport.agda:5,1-6,29
+UselessPrivateImport.agda:5,1-8
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like

--- a/test/Fail/UselessPrivateImport2.err
+++ b/test/Fail/UselessPrivateImport2.err
@@ -1,4 +1,4 @@
-UselessPrivateImport2.agda:5,1-6,52
+UselessPrivateImport2.agda:5,1-8
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like

--- a/test/Fail/UselessPrivateImportAs.err
+++ b/test/Fail/UselessPrivateImportAs.err
@@ -1,4 +1,4 @@
-UselessPrivateImportAs.agda:5,1-6,29
+UselessPrivateImportAs.agda:5,1-8
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like

--- a/test/Fail/UselessPrivatePragma.err
+++ b/test/Fail/UselessPrivatePragma.err
@@ -1,4 +1,4 @@
-UselessPrivatePragma.agda:7,1-8,28
+UselessPrivatePragma.agda:7,1-8
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like

--- a/test/Fail/UselessPrivatePrivate.err
+++ b/test/Fail/UselessPrivatePrivate.err
@@ -1,4 +1,4 @@
-UselessPrivatePrivate.agda:5,1-8,14
+UselessPrivatePrivate.agda:5,1-8
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like

--- a/test/Succeed/Issue2759.warn
+++ b/test/Succeed/Issue2759.warn
@@ -1,7 +1,7 @@
 Issue2759.agda:9,1-9
 warning: -W[no]EmptyAbstract
 Empty abstract block.
-Issue2759.agda:10,1-5
+Issue2759.agda:10,1-13
 warning: -W[no]EmptyConstructor
 Empty constructor block.
 Issue2759.agda:11,1-9
@@ -67,11 +67,11 @@ Issue2759.agda:25,38-46
 warning: -W[no]EmptyAbstract
 Empty abstract block.
 when scope checking let abstract in Set
-Issue2759.agda:26,12-16
+Issue2759.agda:26,12-24
 warning: -W[no]EmptyConstructor
 Empty constructor block.
 when scope checking λ (let data _ where) → let data _ where in Set
-Issue2759.agda:26,38-42
+Issue2759.agda:26,38-50
 warning: -W[no]EmptyConstructor
 Empty constructor block.
 when scope checking let data _ where in Set
@@ -147,7 +147,7 @@ Issue2759.agda:9,1-9
 warning: -W[no]EmptyAbstract
 Empty abstract block.
 
-Issue2759.agda:10,1-5
+Issue2759.agda:10,1-13
 warning: -W[no]EmptyConstructor
 Empty constructor block.
 
@@ -231,12 +231,12 @@ warning: -W[no]EmptyAbstract
 Empty abstract block.
 when scope checking let abstract in Set
 
-Issue2759.agda:26,12-16
+Issue2759.agda:26,12-24
 warning: -W[no]EmptyConstructor
 Empty constructor block.
 when scope checking λ (let data _ where) → let data _ where in Set
 
-Issue2759.agda:26,38-42
+Issue2759.agda:26,38-50
 warning: -W[no]EmptyConstructor
 Empty constructor block.
 when scope checking let data _ where in Set

--- a/test/Succeed/Issue2759.warn
+++ b/test/Succeed/Issue2759.warn
@@ -54,7 +54,7 @@ warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
   opaque unfolding {}
-Issue2759.agda:16,1-17
+Issue2759.agda:16,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
@@ -215,7 +215,7 @@ This 'opaque' block has no effect.
 when scope checking the declaration
   opaque unfolding {}
 
-Issue2759.agda:16,1-17
+Issue2759.agda:16,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration

--- a/test/Succeed/Issue2759.warn
+++ b/test/Succeed/Issue2759.warn
@@ -39,7 +39,7 @@ warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and axioms.
-Issue2759.agda:47,10-26
+Issue2759.agda:47,10-17
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
@@ -197,7 +197,7 @@ Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and axioms.
 
-Issue2759.agda:47,10-26
+Issue2759.agda:47,10-17
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like

--- a/test/Succeed/Issue2759.warn
+++ b/test/Succeed/Issue2759.warn
@@ -44,7 +44,7 @@ warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and data, record, and module declarations.
-Issue2759.agda:47,1-26
+Issue2759.agda:47,1-9
 warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and
@@ -203,7 +203,7 @@ Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and data, record, and module declarations.
 
-Issue2759.agda:47,1-26
+Issue2759.agda:47,1-9
 warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and

--- a/test/Succeed/Issue6802.warn
+++ b/test/Succeed/Issue6802.warn
@@ -6,7 +6,7 @@ when scope checking the declaration
   module _ where
     foo : Nat
     foo = zero
-Issue6802.agda:8,1-11,15
+Issue6802.agda:8,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
@@ -27,7 +27,7 @@ when scope checking the declaration
     foo : Nat
     foo = zero
 
-Issue6802.agda:8,1-11,15
+Issue6802.agda:8,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration

--- a/test/Succeed/Issue6802a.warn
+++ b/test/Succeed/Issue6802a.warn
@@ -6,7 +6,7 @@ when scope checking the declaration
   record Foo where
     foo : Nat
     foo = zero
-Issue6802a.agda:6,1-9,15
+Issue6802a.agda:6,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
@@ -29,7 +29,7 @@ when scope checking the declaration
     foo : Nat
     foo = zero
 
-Issue6802a.agda:6,1-9,15
+Issue6802a.agda:6,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration

--- a/test/Succeed/Issue6945.warn
+++ b/test/Succeed/Issue6945.warn
@@ -18,6 +18,10 @@ warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and axioms.
+Issue6945.agda:46,1-6
+warning: -W[no]UselessMacro
+Using a macro block here has no effect. 'macro' applies only to
+function definitions.
 Issue6945.agda:13,3-10
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
@@ -56,6 +60,11 @@ warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and axioms.
+
+Issue6945.agda:46,1-6
+warning: -W[no]UselessMacro
+Using a macro block here has no effect. 'macro' applies only to
+function definitions.
 
 Issue6945.agda:13,3-10
 warning: -W[no]UselessPrivate

--- a/test/Succeed/Issue6945.warn
+++ b/test/Succeed/Issue6945.warn
@@ -1,9 +1,9 @@
-Issue6945.agda:24,1-25,15
+Issue6945.agda:24,1-8
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and data, record, and module declarations.
-Issue6945.agda:29,1-30,23
+Issue6945.agda:29,1-8
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
@@ -18,7 +18,7 @@ warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and axioms.
-Issue6945.agda:13,3-14,13
+Issue6945.agda:13,3-10
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
@@ -33,13 +33,13 @@ when scope checking the declaration
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue6945.agda:24,1-25,15
+Issue6945.agda:24,1-8
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and data, record, and module declarations.
 
-Issue6945.agda:29,1-30,23
+Issue6945.agda:29,1-8
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
@@ -57,7 +57,7 @@ Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and axioms.
 
-Issue6945.agda:13,3-14,13
+Issue6945.agda:13,3-10
 warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like

--- a/test/Succeed/Issue6945.warn
+++ b/test/Succeed/Issue6945.warn
@@ -29,7 +29,7 @@ declarations that introduce new identifiers into the module, like
 type signatures and data, record, and module declarations.
 when scope checking the declaration
   module M where
-Issue6945.agda:50,1-51,12
+Issue6945.agda:50,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
@@ -74,7 +74,7 @@ type signatures and data, record, and module declarations.
 when scope checking the declaration
   module M where
 
-Issue6945.agda:50,1-51,12
+Issue6945.agda:50,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration

--- a/test/Succeed/Issue6945.warn
+++ b/test/Succeed/Issue6945.warn
@@ -8,7 +8,7 @@ warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and data, record, and module declarations.
-Issue6945.agda:38,1-39,12
+Issue6945.agda:38,1-9
 warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and
@@ -45,7 +45,7 @@ Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and data, record, and module declarations.
 
-Issue6945.agda:38,1-39,12
+Issue6945.agda:38,1-9
 warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and

--- a/test/Succeed/OpaqueUselessNested.warn
+++ b/test/Succeed/OpaqueUselessNested.warn
@@ -1,4 +1,4 @@
-OpaqueUselessNested.agda:4,15-5,23
+OpaqueUselessNested.agda:4,15-21
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
@@ -7,7 +7,7 @@ when scope checking the declaration
     mutual
       data Foo : Set
       data Foo where
-OpaqueUselessNested.agda:4,8-5,23
+OpaqueUselessNested.agda:4,8-14
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
@@ -18,7 +18,7 @@ when scope checking the declaration
       mutual
         data Foo : Set
         data Foo where
-OpaqueUselessNested.agda:4,1-5,23
+OpaqueUselessNested.agda:4,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
@@ -34,7 +34,7 @@ when scope checking the declaration
 
 ———— All done; warnings encountered ————————————————————————
 
-OpaqueUselessNested.agda:4,15-5,23
+OpaqueUselessNested.agda:4,15-21
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
@@ -44,7 +44,7 @@ when scope checking the declaration
       data Foo : Set
       data Foo where
 
-OpaqueUselessNested.agda:4,8-5,23
+OpaqueUselessNested.agda:4,8-14
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
@@ -56,7 +56,7 @@ when scope checking the declaration
         data Foo : Set
         data Foo where
 
-OpaqueUselessNested.agda:4,1-5,23
+OpaqueUselessNested.agda:4,1-7
 warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration


### PR DESCRIPTION
Store source position of block keyword as `KwRange` in blocks, rather than range of the whole block (which can be computed).
This allows more precise ranges in highlighting, errors and warnings such as `UselessPrivate`.

API is:
```haskell
type KwRange
-- to
kwRange :: HasRange a => a -> KwRange
-- from
instance HasRange KwRange where
  getRange :: KwRange -> Range
```

The commits have been tested individually:

Commit [Refactor: newtype KwRange for Ranges that just span keywords](https://github.com/agda/agda/pull/7162/commits/a61a7b4372e646320a23e4101d32402fa13b308c)
- Motivation: in concrete syntax for blocks, we can either store the range of the block keyword or the range of the whole block. 
- To not confuse these, we introduce here a newtype `KwRange` for the former.
- Currently, this is only utilized by the `InstanceB` block, but we would like to rework the other block constructors to also make use of it.
- Passes CI.

Commit [In warnings "useless/empty private", only highlight the private kw](https://github.com/agda/agda/pull/7162/commits/e8bfb1e2e1c64358b1119ca251926199ca409e09)
- Only store position of `private` keyword in `Private` block constructor.
- Conforming to `InstanceB`.
- Passes CI.

Etc.