### PR TITLE
Migrate tests to `Agda.cabal`

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -882,24 +882,62 @@ executable agda-mode
     , process   >= 1.6.3.0  && < 1.7
   default-language: Haskell2010
 
--- Cabal testsuite integration has some serious bugs, but we
--- can still make it work. See also:
--- https://github.com/haskell/cabal/issues/1938
--- https://github.com/haskell/cabal/issues/2214
--- https://github.com/haskell/cabal/issues/1953
---
--- This test suite should only be run using the Makefile.
--- The Makefile sets up the required environment,
--- executing the tests using cabal directly is almost
--- guaranteed to fail. See also Issue 1490.
---
-test-suite agda-tests
-  import:           language
 
+-- Test suite
+-- Run all tests with `cabal test`
+-- Or read on to see specific `cabal run test-XXX` sub-targets
+----------------------------------------------------------
+
+-- Lawrence, 2024-03-04:
+--  The sub-test-suites have been designed for `cabal run`
+--  rather than `cabal test` because:
+--    * `cabal test` gobbles test output by default
+--      * Fix with `--test-show-details=direct`
+--      * Will change in Cabal 3.11:
+--          https://github.com/haskell/cabal/pull/8942
+--    * `cabal test` always recompiles tests when Agda.cabal changes (even for comments)
+--    * `cabal test` always prints recompilation info about all tests
+--    * Verbosity
+--      * `cabal test test-compiler --test-option="--help"`
+--      * `cabal run test-compiler -- --help`
+--      * The `test-` prefix is needed anyway for dis-ambiguation
+
+
+-- Small test suites & executables for linting etc.
+---------------------------------------------------
+
+-- `cabal run test-check-whitespace` gives a whitesapce report
+test-suite check-whitespace
+  hs-source-dirs:     dev/check-whitespace/
+  type:               exitcode-stdio-1.0
+  default-language:   Haskell2010
+  main-is:            Main.hs
+  build-tool-depends: fix-whitespace:fix-whitespace
+  build-depends:      base, process
+
+-- `cabal run fix-whitespace` fixes whitespace problems
+-- This doesn't need any extra config.
+
+-- Make sure that `Parser.y` is ASCII. [Issue #5465]
+test-suite check-encoding
+  hs-source-dirs:   dev/check-encoding/
   type:             exitcode-stdio-1.0
-  hs-source-dirs:   test/
+  default-language: Haskell2010
   main-is:          Main.hs
+  build-depends:    base
+
+-- Larger test suites using the `tasty` Haskell library
+-------------------------------------------------------
+
+-- Configuration shared by several cabal test-suites.
+-- In the future, we might want to split this up.
+-- However this is large refactoring:
+--  as of Feb 2024, there are 11k files in test/
+common tasty-common
+  import: language
+  hs-source-dirs: test/
   other-modules:
+      AgdaDisabledTests
       Bugs.Tests
       Compiler.Tests
       CubicalSucceed.Tests
@@ -964,12 +1002,13 @@ test-suite agda-tests
       Succeed.Tests
       UserManual.Tests
       Utils
-
-  -- Andreas, 2021-08-26, see https://github.com/haskell/cabal/issues/7577
-  -- Since 'agda-tests' wants to call 'agda', we have to add it here,
-  -- should we want to run 'cabal test'.
-  build-tool-depends: Agda:agda
-
+  -- Lawrence, 2024-02-28:
+  --  this is supposed to tell cabal to build `agda` before running tests,
+  --  but is broken because agda has a custom Setup.hs (see haskell/cabal#7577)
+  --  For now, it's the user's responsability to either:
+  --    * Point to an `agda` executable in PATH
+  --    * Point to an `agda` executable in AGDA_BIN
+  -- build-tool-depends: Agda:agda
   build-depends:
     , Agda
     , array
@@ -1002,3 +1041,86 @@ test-suite agda-tests
   -- Andreas (2021-10-11): tasty-silver < 3.3 does not work interactively under Windows
   if os(windows)
     build-depends: tasty-silver >= 3.3
+
+-- Tests where agda is supposed to succeed
+-- Run with `cabal run test-succeed`
+test-suite test-succeed
+  import:           tasty-common
+  hs-source-dirs:   dev/test-succeed
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+
+-- Tests where agda is supposed to fail
+-- Run with `cabal run test-fail`
+test-suite test-fail
+  import:           tasty-common
+  hs-source-dirs:   dev/test-fail
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+
+-- Tests for agda's interaction API
+-- Run with `cabal run test-interactive`
+test-suite test-interactive
+  import:           tasty-common
+  hs-source-dirs:   dev/test-interactive
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+
+-- Tests for the code in agda's user manual
+-- Run with `cabal run test-usermanual`
+test-suite test-usermanual
+  import:           tasty-common
+  hs-source-dirs:   dev/test-usermanual
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+
+-- Tests where agda is not supposed to fail,
+-- but is known to fail anyway due to a bug
+-- Run with `cabal run test-bugs`
+test-suite test-bugs
+  import:           tasty-common
+  hs-source-dirs:   dev/test-bugs
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+
+-- Tests for the LaTeX/HTML backends
+-- Run with `cabal run test-latexhtml`
+test-suite test-latexhtml
+  import:           tasty-common
+  hs-source-dirs:   dev/test-latexhtml
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+
+-- No-CLI unit tests via the Agda API
+-- Run with `cabal run test-internal`
+test-suite test-internal
+  import:           tasty-common
+  hs-source-dirs:   dev/test-internal
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+
+-- Tests for the MAlonzo agda backend
+-- Run with `cabal run test-compiler`
+test-suite test-compiler
+  import:           tasty-common
+  hs-source-dirs:   dev/test-compiler
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+
+-- Tests using the agda standard library,
+-- where agda should succeed
+-- Run with `cabal run test-libsucceed`
+test-suite test-libsucceed
+  import:           tasty-common
+  hs-source-dirs:   dev/test-libsucceed
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+
+-- Tests using the cubical agda standard library,
+-- where agda should succeed
+-- Run with `cabal run test-libsucceed`
+test-suite test-cubicalsucceed
+  import:           tasty-common
+  hs-source-dirs:   dev/test-cubicalsucceed
+  type: exitcode-stdio-1.0
+  main-is: Main.hs

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,2 @@
+
+This directory contains files backing various `cabal run` commands.

--- a/dev/check-encoding/Main.hs
+++ b/dev/check-encoding/Main.hs
@@ -1,0 +1,14 @@
+
+import System.Exit (die)
+import Control.Monad (unless)
+import Data.Char (isAscii)
+import Data.List (findIndices)
+
+main = do
+  f <- lines <$> readFile "src/full/Agda/Syntax/Parser/Parser.y"
+
+  let badLines = (+1) <$> findIndices (not . all isAscii) f
+
+  unless (badLines == []) $ die $
+    "Parser.y contains non-ASCII characters on lines "
+    <> show badLines

--- a/dev/check-whitespace/Main.hs
+++ b/dev/check-whitespace/Main.hs
@@ -1,0 +1,4 @@
+
+import System.Process (callCommand)
+
+main = callCommand "fix-whitespace --check"

--- a/dev/test-bugs/Main.hs
+++ b/dev/test-bugs/Main.hs
@@ -1,0 +1,6 @@
+
+import Bugs.Tests (tests)
+import AgdaDisabledTests (runTests)
+
+main :: IO ()
+main = runTests =<< tests

--- a/dev/test-compiler/Main.hs
+++ b/dev/test-compiler/Main.hs
@@ -1,0 +1,6 @@
+
+import Compiler.Tests (tests)
+import AgdaDisabledTests (runTests)
+
+main :: IO ()
+main = runTests =<< tests

--- a/dev/test-cubicalsucceed/Main.hs
+++ b/dev/test-cubicalsucceed/Main.hs
@@ -1,0 +1,6 @@
+
+import CubicalSucceed.Tests (tests)
+import AgdaDisabledTests (runTests)
+
+main :: IO ()
+main = runTests =<< tests

--- a/dev/test-fail/Main.hs
+++ b/dev/test-fail/Main.hs
@@ -1,0 +1,6 @@
+
+import Fail.Tests (tests)
+import AgdaDisabledTests (runTests)
+
+main :: IO ()
+main = runTests =<< tests

--- a/dev/test-interactive/Main.hs
+++ b/dev/test-interactive/Main.hs
@@ -1,0 +1,6 @@
+
+import Interactive.Tests (tests)
+import AgdaDisabledTests (runTests)
+
+main :: IO ()
+main = runTests tests

--- a/dev/test-internal/Main.hs
+++ b/dev/test-internal/Main.hs
@@ -1,0 +1,6 @@
+
+import Internal.Tests (tests)
+import AgdaDisabledTests (runTests)
+
+main :: IO ()
+main = runTests tests

--- a/dev/test-latexhtml/Main.hs
+++ b/dev/test-latexhtml/Main.hs
@@ -1,0 +1,6 @@
+
+import LaTeXAndHTML.Tests (tests)
+import AgdaDisabledTests (runTests)
+
+main :: IO ()
+main = runTests =<< tests

--- a/dev/test-libsucceed/Main.hs
+++ b/dev/test-libsucceed/Main.hs
@@ -1,0 +1,6 @@
+
+import LibSucceed.Tests (tests)
+import AgdaDisabledTests (runTests)
+
+main :: IO ()
+main = runTests =<< tests

--- a/dev/test-succeed/Main.hs
+++ b/dev/test-succeed/Main.hs
@@ -1,0 +1,6 @@
+
+import Succeed.Tests (tests)
+import AgdaDisabledTests (runTests)
+
+main :: IO ()
+main = runTests =<< tests

--- a/dev/test-usermanual/Main.hs
+++ b/dev/test-usermanual/Main.hs
@@ -1,0 +1,6 @@
+
+import UserManual.Tests (tests)
+import AgdaDisabledTests (runTests)
+
+main :: IO ()
+main = runTests =<< tests

--- a/test-migration-progress.md
+++ b/test-migration-progress.md
@@ -15,6 +15,12 @@
 | ✅      |    0 |    25 | LIBSUCCEED.tests      | `cabal run test-libsucceed`     |
 | ✅      |    0 |     1 | CUBICALSUCCEED.tests  | `cabal run test-cubicalsucceed` |
 
+Several tests (e.g. `RepeatedCase`) are failing because...
+
+* Tests set Agda's `-v` option
+* `-v` is silently ignored by Agda, unless it was built **with** the `debug` cabal flag
+* `cabal run test-succeed` insists on re-building Agda **without** the `debug` cabal flag
+
 ## Tests from the [`test : ` target of the `Makefile`]
 
 | Status |  Old name in `Makefile` |  How to run now |

--- a/test-migration-progress.md
+++ b/test-migration-progress.md
@@ -1,0 +1,66 @@
+# Test Migration Progress
+
+## Tests from tasty `Main.hs`
+
+| Status | Fail | Total | Old name in `Main.hs` |         How to run now          |
+| ------ | ---: | ----: | --------------------- | ------------------------------- |
+| 🛠️     |    4 |  1784 | SUCCEED.tests         | `cabal run test-succeed`        |
+| 🛠️     |   10 |  1552 | FAIL.tests            | `cabal run test-fail`           |
+| 🛠️     |    1 |    15 | BUGS.tests            | `cabal run test-bugs`           |
+| ✅      |    0 |     3 | INTERACTIVE.tests     | `cabal run test-interactive`    |
+| ✅      |    0 |    52 | USERMANUAL.tests      | `cabal run test-usermanual`     |
+| ✅      |    0 |    87 | LATEXHTML.tests       | `cabal run test-latexhtml`      |
+| ✅      |    0 |   505 | INTERNAL.tests        | `cabal run test-internal`       |
+| 🛠️     |   24 |   354 | COMPILER.tests        | `cabal run test-compiler`       |
+| ✅      |    0 |    25 | LIBSUCCEED.tests      | `cabal run test-libsucceed`     |
+| ✅      |    0 |     1 | CUBICALSUCCEED.tests  | `cabal run test-cubicalsucceed` |
+
+## Tests from the [`test : ` target of the `Makefile`]
+
+| Status |  Old name in `Makefile` |  How to run now |
+| ------ | ---------------------- |  ----------------------------- |
+| ✅ | check-whitespace       | `cabal run check-whitespace` |
+| ✅ | check-encoding         | `cabal run Emojicheck-encoding`   |
+| ❌ | common                 |                              |
+| 🫛 | succeed                | `cabal run test-succeed`     |
+| 🫛 | fail                   | `cabal run test-fail`        |
+| 🫛 | bugs                   | `cabal run test-bugs`        |
+| 🫛 | interaction            | `cabal run test-interaction` |
+| ❌ | examples               |                              |
+| ❌ | std-lib-test           |                              |
+| ❌ | cubical-test           |                              |
+| ❌ | interactive            |                              |
+| ❌ | latex-html-test        |                              |
+| ❌ | api-test               |                              |
+| 🫛 | internal-tests         | `cabal run test-internal`    |
+| ❌ | benchmark-without-logs |                              |
+| 🫛 | compiler-test          | `cabal run test-compiler`    |
+| ❌ | std-lib-compiler-test  |                              |
+| 🫛 | std-lib-succeed        | `cabal run test-libsucceed`  |
+| 🫛 | std-lib-interaction    | `cabal run test-interaction` |
+| 🫛 | user-manual-test       | `cabal run test-usermanual`  |
+| ❌ | doc-test               |                              |
+| ❌ | size-solver-test       |                              |
+
+## Tidy-up
+
+| Status |                   Task                    |
+| ------ | ----------------------------------------- |
+| ✅      | Update tasty `Main.hs`                    |
+| ❌      | Update `Makefile`                         |
+| ❌      | Update CI                                 |
+| ❌      | Update `HACKING.md`                       |
+| ❌      | Look for test duplication by `cabal test` |
+| ❌      | Minimize diff vs. `master`                |
+| ❌      | Delete this file, squash, merge           |
+
+## Legend
+
+| Emoji |  Meaning  |
+| ----- | --------- |
+| ❌     | not done  |
+| 🛠️    | WIP/buggy |
+| ✅     | done      |
+| 🫛     | duplicate |
+
+[`test : ` target of the `Makefile`]: Makefile#L444


### PR DESCRIPTION

This PR aims to decouple the test suite from the `Makefile`.

i.e. `cabal test` should test the user's `agda`, without further setup.

Progress is tracked in [`test-migration-progress.md`].

Relevant: #7124, #7164

[`test-migration-progress.md`]: https://github.com/lawcho/agda/blob/migrate-tests/test-migration-progress.md