### PR TITLE
Add `-*- lexical-binding: t; -*-` to the first lines of agda-mode files

### DIFF
--- a/src/data/emacs-mode/agda2-abbrevs.el
+++ b/src/data/emacs-mode/agda2-abbrevs.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 ;; agda2-abbrevs.el --- Default Agda abbrevs
 ;; SPDX-License-Identifier: MIT License
 

--- a/src/data/emacs-mode/agda2-highlight.el
+++ b/src/data/emacs-mode/agda2-highlight.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; agda2-highlight.el --- Syntax highlighting for Agda (version ≥ 2)
 ;; SPDX-License-Identifier: MIT License
 

--- a/src/data/emacs-mode/agda2-mode-pkg.el
+++ b/src/data/emacs-mode/agda2-mode-pkg.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 (define-package "agda2-mode" "2.6.5"
   "interactive development for Agda, a dependently typed functional programming language"
   '((emacs "24.3"))) ;; dep defs for `annotation.el` and `eri.el` are not required if they are packaged together

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; agda2-mode.el --- Major mode for Agda
 ;; SPDX-License-Identifier: MIT License
 

--- a/src/data/emacs-mode/agda2-queue.el
+++ b/src/data/emacs-mode/agda2-queue.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; agda2-queue.el --- Simple FIFO character queues.
 ;; SPDX-License-Identifier: MIT License
 

--- a/src/data/emacs-mode/agda2.el
+++ b/src/data/emacs-mode/agda2.el
@@ -1,4 +1,4 @@
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; -*- lexical-binding: t; -*-
 ;; Agda mode code which should run before the first Agda file is
 ;; loaded
 ;; SPDX-License-Identifier: MIT License

--- a/src/data/emacs-mode/annotation.el
+++ b/src/data/emacs-mode/annotation.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; annotation.el --- Functions for annotating text with faces and help bubbles
 
 ;; Version: 1.0

--- a/src/data/emacs-mode/eri.el
+++ b/src/data/emacs-mode/eri.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; eri.el --- Enhanced relative indentation (eri)
 
 ;; SPDX-License-Identifier: MIT License


### PR DESCRIPTION
Add `-*- lexical-binding: t; -*-` to the first lines of agda-mode files.

Otherwise emacs 30 will report errors like this:
```
/home/vitalyr/projects/dev/agda-projects/agda/dist-2.6.5-ghc-9.8.2/build/agda-mode/agda-mode compile

In toplevel form:
~/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/agda2-abbrevs.el:1:1: Error: file has no ‘lexical-binding’ directive on its first line

In toplevel form:
~/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/annotation.el:1:1: Error: file has no ‘lexical-binding’ directive on its first line

In toplevel form:
~/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/agda2-queue.el:1:1: Error: file has no ‘lexical-binding’ directive on its first line

In toplevel form:
~/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/eri.el:1:1: Error: file has no ‘lexical-binding’ directive on its first line

In toplevel form:
~/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/agda2.el:1:1: Error: file has no ‘lexical-binding’ directive on its first line

In toplevel form:
~/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/agda2-highlight.el:1:1: Error: file has no ‘lexical-binding’ directive on its first line

In toplevel form:
~/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/agda2-mode.el:1:1: Error: file has no ‘lexical-binding’ directive on its first line
Loading quail/latin-ltx (native compiled elisp)...


Unable to compile the following Emacs Lisp files:
  /home/vitalyr/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/agda2-abbrevs.el
  /home/vitalyr/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/annotation.el
  /home/vitalyr/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/agda2-queue.el
  /home/vitalyr/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/eri.el
  /home/vitalyr/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/agda2.el
  /home/vitalyr/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/agda2-highlight.el
  /home/vitalyr/.cabal/share/x86_64-linux-ghc-9.8.2/Agda-2.6.5/emacs-mode/agda2-mode.el
```