### PR TITLE
Fix #7167: type checking underapplied pattern synonyms

### DIFF
--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -1014,12 +1014,11 @@ patternToExpr = \case
 type PatternSynDefn = ([WithHiding Name], Pattern' Void)
 type PatternSynDefns = Map QName PatternSynDefn
 
-lambdaLiftExpr :: [Name] -> Expr -> Expr
-lambdaLiftExpr ns e
-  = foldr
-      (\ n -> Lam exprNoRange (mkDomainFree $ defaultNamedArg $ mkBinder_ n))
-      e
-      ns
+lambdaLiftExpr :: [WithHiding Name] -> Expr -> Expr
+lambdaLiftExpr ns e = foldr f e ns
+  where
+  f (WithHiding h n) = Lam exprNoRange $ setHiding h $ mkDomainFree $ defaultNamedArg $ mkBinder_ n
+
 
 -- NOTE: This is only used on expressions that come from right-hand sides of pattern synonyms, and
 -- thus does not have to handle all forms of expressions.

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -152,7 +152,7 @@ checkApplication cmp hd args e t =
         Nothing      -> typeError $ BadArgumentsToPatternSynonym n
         Just (s, ns) -> do
           let p' = A.patternToExpr p
-              e' = A.lambdaLiftExpr (map whThing ns) (A.substExpr s p')
+              e' = A.lambdaLiftExpr ns (A.substExpr s p')
           checkExpr' cmp e' t
 
     -- Subcase: macro

--- a/test/Succeed/Issue7167.agda
+++ b/test/Succeed/Issue7167.agda
@@ -1,0 +1,17 @@
+-- Andreas, 2024-03-05, issue #7167
+-- Underapplied pattern synonyms with hidden arguments.
+
+data D : Set where
+  c : D → {y : D} → D → D
+
+pattern p x {y} z = c x {y} z
+
+f : D → {y : D} → D → D
+f = p
+
+-- Error was:
+--
+-- (z : D) → D !=< D of type Set
+-- when checking that the expression λ z → c x {y} z has type D
+
+-- Should succeed.


### PR DESCRIPTION
- **Cosmetic changes in scope checker for pattern synonyms**
- **New: instance Null Hiding; small reorganization (code movements)**
- **Fix #7167: respect hiding in lambda abstracting underapplied pattern syn**
