### PR TITLE
Trigger and improve error UnusedVariableInPatternSynonym

### DIFF
--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -3152,8 +3152,8 @@ instance ToAbstract C.Pattern where
         -- x <- bindPatternVariable x
       toAbstract (PatName (C.QName x) Nothing) >>= \case
         VarPatName x        -> A.AsP (PatRange r) (A.mkBindName x) <$> toAbstract p
-        ConPatName{}        -> ignoreAsPat False
-        PatternSynPatName{} -> ignoreAsPat True
+        ConPatName{}        -> ignoreAsPat IsLHS
+        PatternSynPatName{} -> ignoreAsPat IsPatSyn
       where
       -- An @-bound name which shadows a constructor is illegal and becomes dead code.
       ignoreAsPat b = do

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -140,6 +140,7 @@ errorString err = case err of
   BadArgumentsToPatternSynonym{}           -> "BadArgumentsToPatternSynonym"
   TooFewArgumentsToPatternSynonym{}        -> "TooFewArgumentsToPatternSynonym"
   CannotResolveAmbiguousPatternSynonym{}   -> "CannotResolveAmbiguousPatternSynonym"
+  PatternSynonymArgumentShadowsConstructorOrPatternSynonym{} -> "PatternSynonymArgumentShadowsConstructorOrPatternSynonym"
   UnboundVariablesInPatternSynonym{}       -> "UnboundVariablesInPatternSynonym"
   BothWithAndRHS                           -> "BothWithAndRHS"
   BuiltinInParameterisedModule{}           -> "BuiltinInParameterisedModule"
@@ -1084,6 +1085,20 @@ instance PrettyTCM TypeError where
         (x, _) = List1.head defs
         prDef (x, (xs, p)) = prettyA (A.PatternSynDef x (map (fmap BindName) xs) p) <?> ("at" <+> pretty r)
           where r = nameBindingSite $ qnameName x
+
+    PatternSynonymArgumentShadowsConstructorOrPatternSynonym kind x (y :| _ys) -> vcat
+      [ fsep $ concat
+        [ pwords "Pattern synonym variable"
+        , [ pretty x ]
+        , [ "shadows" ]
+        , case kind of
+            IsLHS -> [ "constructor" ]
+            IsPatSyn -> pwords "pattern synonym"
+        , pwords "defined at:"
+        ]
+      , pretty $ nameBindingSite $ qnameName $ anameName y
+      ]
+
 
     UnusedVariableInPatternSynonym x -> fsep $
       pwords "Unused variable in pattern synonym: " ++ [pretty x]

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -269,7 +269,7 @@ errorString err = case err of
   UninstantiatedDotPattern{}               -> "UninstantiatedDotPattern"
   ForcedConstructorNotInstantiated{}       -> "ForcedConstructorNotInstantiated"
   SolvedButOpenHoles{}                     -> "SolvedButOpenHoles"
-  UnusedVariableInPatternSynonym           -> "UnusedVariableInPatternSynonym"
+  UnusedVariableInPatternSynonym _         -> "UnusedVariableInPatternSynonym"
   UnquoteFailed{}                          -> "UnquoteFailed"
   DeBruijnIndexOutOfScope{}                -> "DeBruijnIndexOutOfScope"
   WithClausePatternMismatch{}              -> "WithClausePatternMismatch"
@@ -1085,8 +1085,8 @@ instance PrettyTCM TypeError where
         prDef (x, (xs, p)) = prettyA (A.PatternSynDef x (map (fmap BindName) xs) p) <?> ("at" <+> pretty r)
           where r = nameBindingSite $ qnameName x
 
-    UnusedVariableInPatternSynonym -> fsep $
-      pwords "Unused variable in pattern synonym."
+    UnusedVariableInPatternSynonym x -> fsep $
+      pwords "Unused variable in pattern synonym: " ++ [pretty x]
 
     UnboundVariablesInPatternSynonym xs -> fsep $
       pwords "Unbound variables in pattern synonym: " ++

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1099,15 +1099,10 @@ instance PrettyTCM TypeError where
       where
       prettyLhsOrPatSyn = pwords $ case lhsOrPatSyn of
         IsLHS    -> "left-hand side"
-        IsPatSyn -> "pattern synonym"
+        IsPatSyn -> "pattern synonym right-hand side"
       prettyErrs = case errs of
         []     -> empty
         p0 : _ -> fsep $ pwords "Problematic expression:" ++ [pretty p0]
-
-{- UNUSED
-    NoParseForPatternSynonym p -> fsep $
-      pwords "Could not parse the pattern synonym" ++ [pretty p]
--}
 
     AmbiguousParseForLHS lhsOrPatSyn p ps -> do
       d <- pretty p

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4715,8 +4715,10 @@ data TypeError
         | BadArgumentsToPatternSynonym A.AmbiguousQName
         | TooFewArgumentsToPatternSynonym A.AmbiguousQName
         | CannotResolveAmbiguousPatternSynonym (List1 (A.QName, A.PatternSynDefn))
-        | UnusedVariableInPatternSynonym
+        | UnusedVariableInPatternSynonym C.Name
+            -- ^ This variable is only bound on the lhs of the pattern synonym, not on the rhs.
         | UnboundVariablesInPatternSynonym [A.Name]
+            -- ^ These variables are only bound on the rhs of the pattern synonym, not on the lhs.
     -- Operator errors
         | NoParseForApplication (List2 C.Expr)
         | AmbiguousParseForApplication (List2 C.Expr) (List1 C.Expr)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4251,9 +4251,9 @@ data Warning
     -- ^ Out of scope error we can recover from.
   | UnsupportedIndexedMatch Doc
     -- ^ Was not able to compute a full equivalence when splitting.
-  | AsPatternShadowsConstructorOrPatternSynonym Bool
-    -- ^ The as-name in an as-pattern may not shadow a constructor (@False@)
-    --   or pattern synonym name (@True@),
+  | AsPatternShadowsConstructorOrPatternSynonym LHSOrPatSyn
+    -- ^ The as-name in an as-pattern may not shadow a constructor ('IsLHS')
+    --   or pattern synonym name ('IsPatSyn'),
     --   because this can be confusing to read.
   | PatternShadowsConstructor C.Name A.QName
     -- ^ A pattern variable has the name of a constructor
@@ -4787,7 +4787,7 @@ data IncorrectTypeForRewriteRelationReason
 
 -- | Distinguish error message when parsing lhs or pattern synonym, resp.
 data LHSOrPatSyn = IsLHS | IsPatSyn
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Bounded, Enum)
 
 -- | Type-checking errors.
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4715,6 +4715,10 @@ data TypeError
         | BadArgumentsToPatternSynonym A.AmbiguousQName
         | TooFewArgumentsToPatternSynonym A.AmbiguousQName
         | CannotResolveAmbiguousPatternSynonym (List1 (A.QName, A.PatternSynDefn))
+        | PatternSynonymArgumentShadowsConstructorOrPatternSynonym LHSOrPatSyn C.Name (List1 AbstractName)
+            -- ^ A variable to be bound in the pattern synonym resolved on the rhs as name of
+            --   a constructor or a pattern synonym.
+            --   The resolvents are given in the list.
         | UnusedVariableInPatternSynonym C.Name
             -- ^ This variable is only bound on the lhs of the pattern synonym, not on the rhs.
         | UnboundVariablesInPatternSynonym [A.Name]

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -373,7 +373,9 @@ prettyWarning = \case
 
     AsPatternShadowsConstructorOrPatternSynonym patsyn -> fsep $ concat
       [ pwords "Name bound in @-pattern ignored because it shadows"
-      , if patsyn then pwords "pattern synonym" else [ "constructor" ]
+      , case patsyn of
+          IsPatSyn -> pwords "pattern synonym"
+          IsLHS    -> [ "constructor" ]
       ]
 
     PatternShadowsConstructor x c -> fsep $

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240303 * 10 + 0
+currentInterfaceVersion = 20240306 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -333,7 +333,9 @@ instance EmbPrj ProfileOptions where
   icod_ opts = icode (profileOptionsToList opts)
   value = fmap profileOptionsFromList . value
 
-instance EmbPrj ProfileOption where
+instance EmbPrj ProfileOption
+
+instance EmbPrj LHSOrPatSyn
 
 instance EmbPrj UnicodeOrAscii
 

--- a/test/Fail/PatternSynVarShadowsConstructor.agda
+++ b/test/Fail/PatternSynVarShadowsConstructor.agda
@@ -1,0 +1,23 @@
+-- Andreas, 2023-03-06, issue #7170
+-- Better error when pattern synonym parameter shadows constructor.
+
+data D : Set where
+  x : D
+  c : D → D
+
+pattern p x = c x
+
+test : D → D
+test (p x) = x
+
+-- Error WAS:
+--
+-- Unused variable in pattern synonym: x
+-- when scope checking the declaration
+--   pattern p x = c x
+--
+-- Expected error:
+-- Pattern synonym variable x shadows constructor defined at:
+-- <<Position>>
+-- when scope checking the declaration
+--   pattern p x = c x

--- a/test/Fail/PatternSynVarShadowsConstructor.err
+++ b/test/Fail/PatternSynVarShadowsConstructor.err
@@ -1,0 +1,5 @@
+PatternSynVarShadowsConstructor.agda:8,11-12
+Pattern synonym variable x shadows constructor defined at:
+PatternSynVarShadowsConstructor.agda:5,3-4
+when scope checking the declaration
+  pattern p x = c x

--- a/test/Fail/PatternSynVarShadowsPatternSyn.agda
+++ b/test/Fail/PatternSynVarShadowsPatternSyn.agda
@@ -1,0 +1,25 @@
+-- Andreas, 2023-03-06, issue #7170
+-- Better error when pattern synonym parameter shadows pattern synonym name.
+
+data D : Set where
+  z : D
+  c : D → D
+
+pattern x = z
+pattern p x = c x
+
+test : D → D
+test (p x) = x
+
+-- Error WAS:
+--
+-- Unused variable in pattern synonym: x
+-- when scope checking the declaration
+--   pattern p x = c x
+--
+-- Expected error:
+--
+-- Pattern synonym variable x shadows pattern synonym defined at:
+-- <<Position>>
+-- when scope checking the declaration
+--   pattern p x = c x

--- a/test/Fail/PatternSynVarShadowsPatternSyn.err
+++ b/test/Fail/PatternSynVarShadowsPatternSyn.err
@@ -1,0 +1,5 @@
+PatternSynVarShadowsPatternSyn.agda:9,11-12
+Pattern synonym variable x shadows pattern synonym defined at:
+PatternSynVarShadowsPatternSyn.agda:8,9-10
+when scope checking the declaration
+  pattern p x = c x

--- a/test/Fail/PatternSynonymNoParse.err
+++ b/test/Fail/PatternSynonymNoParse.err
@@ -1,5 +1,5 @@
 PatternSynonymNoParse.agda:3,1-18
-Could not parse the pattern synonym a b
+Could not parse the pattern synonym right-hand side a b
 Problematic expression: (a b)
 Operators used in the grammar:
   None

--- a/test/Fail/UnusedPatternSynonymVariable.agda
+++ b/test/Fail/UnusedPatternSynonymVariable.agda
@@ -1,0 +1,16 @@
+-- Andreas, 2023-03-06
+-- Trigger error UnusedVariableInPatternSynonym.
+
+data D : Set where
+  c : D
+
+pattern p x = c
+
+test : D → D
+test (p x) = x
+
+-- Expected error:
+--
+-- Unused variable in pattern synonym: x
+-- when scope checking the declaration
+--   pattern p x = c

--- a/test/Fail/UnusedPatternSynonymVariable.err
+++ b/test/Fail/UnusedPatternSynonymVariable.err
@@ -1,0 +1,4 @@
+UnusedPatternSynonymVariable.agda:7,11-12
+Unused variable in pattern synonym: x
+when scope checking the declaration
+  pattern p x = c


### PR DESCRIPTION
Trigger and improve error `UnusedVariableInPatternSynonym`.
Error was not covered by the testsuite.

Closes #7170.