### PR TITLE
Re #6097: checkApplication: retry check target analysis less eagerly.

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -670,10 +670,14 @@ checkArgumentsE'
                   let skip k   = s{ sSkipCheck =
                                     SkipNext $ visiblePis - 1 - k
                                   }
-                      dontSkip = s
                   in return $ case reason of
-                    Permanent   -> skip 0
-                    Unspecified -> dontSkip
+                    Permanent   -> s{ sSkipCheck = Skip }
+                    Unspecified -> skip 0
+                      -- OR: dontSkip, (let dontSkip = s)
+                      -- but there is no evidence that the next argument
+                      -- will refine the target enough to make it rigid,
+                      -- and doing this analysis at every argument is expensive
+                      -- (Issue6097-5).
                     AVar x      ->
                       if x `IntSet.member` freeInTgt
                       then skip x
@@ -683,7 +687,11 @@ checkArgumentsE'
                   -- We need to check that the arity of the function type
                   -- is sufficient before checking the target,
                   -- otherwise the target is non-sensical.
-                  if visiblePis < sArgsLen then return s else do
+                  -- With Ulf, 2024-03-06:
+                  -- If the target is rigid, type checking will eventually fail,
+                  -- but we can skip the target check henceforth
+                  -- because the target will stay rigid.
+                  if visiblePis < sArgsLen then return s{ sSkipCheck = Skip } else do
 
                       -- Is any free variable in tgt less than
                       -- visiblePis?
@@ -820,12 +828,32 @@ data IsPermanent
     -- ^ Maybe, maybe not.
 
 -- | Is the type \"rigid\"?
+--
+-- Interpretation of results:
+--
+--   - @IsRigid@: Makes sense to check target now.
+--
+--   - @IsNotRigid Permanent@:
+--     don't try checking the target early, don't retry @isRigid@.
+--     Possible reasons:
+--       - not a type, type checking will fail
+--       - a sort, does not provide useful information
+--       - hidden Pi, needs argument insertion
+--
+--   - @IsNotRigid Unspecified@:
+--     target type could refine e.g. by solving a meta
+--     or providing one more function argument.
+--
+--   - @IsNotRigid (AVar x)@:
+--     target type can only refine by giving the specified function argument.
 
 isRigid :: CheckArgumentsE'State -> Type -> TCM IsRigid
 isRigid s t | PathType{} <- sPathView s t =
   -- Path is not rigid.
   return $ IsNotRigid Permanent
-isRigid _ (El _ t) = case t of
+isRigid _ (El _ t) = reduce t >>= \case
+    -- Note: reduce, because target out of telViewUpTo' could be non-reduced
+    -- if the requested number of domains could be split off.
   Var x _    -> return $ IsNotRigid (AVar x)
   Lam{}      -> return $ IsNotRigid Permanent
   Lit{}      -> return $ IsNotRigid Permanent

--- a/test/Succeed/Issue6097-5.agda
+++ b/test/Succeed/Issue6097-5.agda
@@ -1,9 +1,16 @@
+-- Issue #6097, test case by Nils Anders.
+--
+-- 2024-03-06: modified by Andreas and Ulf.
+-- Checking a long application is slow in Agda >= 2.5.4 && < 2.6.5
+-- because the analysis whether to check the target first
+-- is repeated at every step.
+
 open import Agda.Builtin.Unit
 
-mutual
+module _ where
 
   postulate
-    F :
+    F : {A : Set₁} →
       Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ →
       Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ →
       Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ →
@@ -104,11 +111,7 @@ mutual
       Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ →
       Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ →
       Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ → Set₁ →
-      {_ : ⊤} → Set₁ → _
-
-  -- If {_ : ⊤} → is removed above, then Agda type-checks the code
-  -- much more slowly (at the time of writing), because the target
-  -- type check in checkArgumentsE' is run repeatedly.
+      Set₁ → A
 
   _ : Set
   _ = F


### PR DESCRIPTION
Andreas & Ulf:
Only retry the analysis (`isRigid`) whether it makes sense to check
against the target first when there is evidence that it could be
successful the next time.

So far, the bias was in the other direction: retry unless there was
evidence it would not change.

Closes #6097, at least the OP (toy case, regression in 2.5.4).

NB: does not help with regression in 2.5.4 (serious case) reported in:
- #5066