### PR TITLE
Part of #2829: Allow instance arguments in pattern synonyms that are such in the pattern already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,32 @@ Additions to the Agda syntax.
   As in a `with`, multiple bindings can be separated by a `|`, and variables to
   the left are in scope in bindings to the right.
 
+* Pattern synonyms can now expose existing instance arguments
+  ([PR 7173](https://github.com/agda/agda/pull/7173)).
+  Example:
+  ```agda
+  data D : Set where
+    c : {{D}} → D
+
+  pattern p {{d}} = c {{d}}
+  ```
+  This allows us to explicitly bind these argument in a pattern match
+  and supply them explicitly when using the pattern synonym in an expression.
+  ```agda
+  f : D → D
+  f (p {{d = x}}) = p {{d = x}}
+  ```
+
+  We cannot create new instance arguments this way, though.
+  The following is rejected:
+  ```agda
+  data D : Set where
+    c : D → D
+
+  pattern p {{d}} = c d
+  ```
+
+
 Language
 --------
 

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -297,6 +297,7 @@ refine force ii mr e = do
                     -- should be something else.
                 , metaNumber = Nothing -- in order to print just as ?, not ?n
                 , metaNameSuggestion = ""
+                , metaKind           = Info.UnificationMeta
                 }
               metaVar = QuestionMark info ii
 
@@ -473,8 +474,7 @@ instance Reify Constraint where
           DoQuoteTerm cmp v t -> do
             tm <- A.App defaultAppInfo_ (A.QuoteTerm exprNoRange) . defaultNamedArg <$> reify v
             OfType tm <$> reify t
-        Open{}  -> __IMPOSSIBLE__
-        OpenInstance{}  -> __IMPOSSIBLE__
+        OpenMeta{}  -> __IMPOSSIBLE__
         InstV{} -> __IMPOSSIBLE__
   reify (FindInstance m mcands) = FindInstanceOF
     <$> reify (MetaV m [])
@@ -898,8 +898,7 @@ getSolvedInteractionPoints all norm = concat <$> do
             unsol = return []
         case mvInstantiation mv of
           InstV{}                        -> sol (MetaV m $ map Apply args)
-          Open{}                         -> unsol
-          OpenInstance{}                 -> unsol
+          OpenMeta{}                     -> unsol
           BlockedConst{}                 -> unsol
           PostponedTypeCheckingProblem{} -> unsol
 
@@ -957,8 +956,7 @@ typesOfHiddenMetas norm = liftTCM $ do
   implicit is x m =
     case mvInstantiation m of
       M.InstV{} -> __IMPOSSIBLE__
-      M.Open    -> x `notElem` is
-      M.OpenInstance -> x `notElem` is  -- OR: True !?
+      M.OpenMeta _ -> x `notElem` is  -- OR: True in case of InstanceMeta !?
       M.BlockedConst{} -> False
       M.PostponedTypeCheckingProblem{} -> False
 

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -142,11 +142,11 @@ parseVariables f cxt asb ii rng ss = do
       -- has been refined to a module parameter we do allow splitting
       -- on it, since the instantiation could as well have been the
       -- other way around (see #2183).
-      (Just (Var i []), PatternBound) -> return (i, C.InScope)
+      (Just (Var i []), PatternBound _) -> return (i, C.InScope)
       -- Case 1b: the variable has been refined.
-      (Just v         , PatternBound) -> failInstantiatedVar s v
+      (Just v         , PatternBound _) -> failInstantiatedVar s v
       -- Case 1c: the variable is bound locally (e.g. a record let)
-      (Nothing        , PatternBound) -> failCaseLet s
+      (Nothing        , PatternBound _) -> failCaseLet s
       -- Case 1d: module parameter
       (Just (Var i []), LambdaBound ) -> failModuleBound s
       -- Case 1e: locally lambda-bound variable

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -35,7 +35,7 @@ import Agda.Syntax.Abstract.Name (QName(..), Name(..))
 import Agda.Syntax.Common (InteractionId(..), MetaId(..), ArgInfo(..), defaultArgInfo, Origin(..), ConOrigin(..), Hiding(..), setOrigin, NameId, Nat, namedThing, Arg(..), setHiding, getHiding, ProjOrigin(..), rangedThing, woThing, nameOf, visible)
 import Agda.Syntax.Common.Pretty (Pretty, Doc, prettyShow, prettyList, render, pretty, braces, prettyList_, text, (<+>), nest, lbrace, rbrace, comma, ($$), vcat, ($+$), align, cat, parens)
 import qualified Agda.Syntax.Concrete.Name as C
-import Agda.Syntax.Info (exprNoRange)
+import Agda.Syntax.Info (pattern UnificationMeta, exprNoRange)
 import Agda.Syntax.Internal -- (Type, Type''(..), Term(..), Dom'(..), Abs(..), arity , ConHead(..), Sort'(..), Level, argFromDom, Level'(..), absurdBody, Dom, namedClausePats, Pattern'(..), dbPatVarIndex)
 import Agda.Syntax.Internal.MetaVars (AllMetas(..))
 import Agda.Syntax.Internal.Pattern (clausePerm)
@@ -730,7 +730,7 @@ runSearch options ii rng = withInteractionId ii $ do
 
       -- ctx <- getContextTelescope
       return metaIds
-    Open -> do
+    OpenMeta UnificationMeta -> do
       reportSLn "mimer.init" 20 "Interaction point not instantiated."
       return [metaId]
     _ -> __IMPOSSIBLE__

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -1081,8 +1081,7 @@ instance SubstExpr Expr where
     Macro{}         -> __IMPOSSIBLE__
 
 -- TODO: more informative failure
-insertImplicitPatSynArgs
-  :: forall a. HasRange a
+insertImplicitPatSynArgs :: forall a. HasRange a
   => (Range -> a)
        -- ^ Thing to insert (wildcard).
   -> Range

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -1082,7 +1082,7 @@ instance SubstExpr Expr where
 
 -- TODO: more informative failure
 insertImplicitPatSynArgs :: forall a. HasRange a
-  => (Range -> a)
+  => (Hiding -> Range -> a)
        -- ^ Thing to insert (wildcard).
   -> Range
        -- ^ Range of the whole pattern synonym expression/pattern.
@@ -1099,7 +1099,7 @@ insertImplicitPatSynArgs wild r ns as = matchArgs r ns as
       | not (null as)
       , matchNext n a  = return (namedArg a, as')
       | visible n      = Nothing
-      | otherwise      = return (wild r, as)
+      | otherwise      = return (wild (getHiding n) r, as)
 
     matchNext ::
          WithHiding Name  -- Pattern synonym parameter

--- a/src/full/Agda/Syntax/Info.hs
+++ b/src/full/Agda/Syntax/Info.hs
@@ -20,7 +20,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Position
 import Agda.Syntax.Concrete
 import Agda.Syntax.Fixity
-import Agda.Syntax.Scope.Base (ScopeInfo, emptyScopeInfo)
+import Agda.Syntax.Scope.Base (ScopeInfo)
 
 import Agda.Utils.Functor
 import Agda.Utils.Null
@@ -29,21 +29,51 @@ import Agda.Utils.Null
     Meta information
  --------------------------------------------------------------------------}
 
+-- | Kind of a meta: the method how to solve it.
+--
+data MetaKind
+  = InstanceMeta     -- ^ Meta variable solved by instance search.
+  | UnificationMeta  -- ^ Meta variable solved by unification (default).
+  deriving (Show, Eq, Generic)
+
+instance Null MetaKind where
+  empty = UnificationMeta
+
+instance NFData MetaKind
+
+-- | Default meta kind from its 'Hiding' context.
+--
+hidingToMetaKind :: Hiding -> MetaKind
+hidingToMetaKind = \case
+  Instance{} -> InstanceMeta
+  Hidden     -> UnificationMeta
+  NotHidden  -> UnificationMeta
+
+-- | Name suggestion for meta variable.  Empty string means no suggestion.
+type MetaNameSuggestion = String
+
+-- | Information associated to a meta variable in the abstract syntax.
+--
 data MetaInfo = MetaInfo
   { metaRange          :: Range
   , metaScope          :: ScopeInfo
   , metaNumber         :: Maybe MetaId
-  , metaNameSuggestion :: String
+  , metaNameSuggestion :: MetaNameSuggestion
+  , metaKind           :: MetaKind
   }
   deriving (Show, Eq, Generic)
 
 emptyMetaInfo :: MetaInfo
 emptyMetaInfo = MetaInfo
   { metaRange          = noRange
-  , metaScope          = emptyScopeInfo
+  , metaScope          = empty
   , metaNumber         = Nothing
   , metaNameSuggestion = ""
+  , metaKind           = empty
   }
+
+instance Null MetaInfo where
+  empty = emptyMetaInfo
 
 instance HasRange MetaInfo where
   getRange = metaRange
@@ -51,7 +81,8 @@ instance HasRange MetaInfo where
 instance KillRange MetaInfo where
   killRange m = m { metaRange = noRange }
 
-instance NFData MetaInfo
+instance NFData MetaInfo where
+  rnf (MetaInfo _ a b c d) = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
 
 {--------------------------------------------------------------------------
     General expression information

--- a/src/full/Agda/Syntax/Parser/Helpers.hs
+++ b/src/full/Agda/Syntax/Parser/Helpers.hs
@@ -517,11 +517,8 @@ patternSynArgs = mapM \ x -> do
         case ai of
 
           -- Benign case:
-          ArgInfo h (Modality Relevant (Quantityω _) Continuous) UserWritten UnknownFVs (Annotation IsNotLock)
-            | h `elem` [Hidden, NotHidden] ->
-                return $ WithHiding h n
-            | otherwise ->
-                abort "Instance arguments not allowed to pattern synonyms"
+          ArgInfo h (Modality Relevant (Quantityω _) Continuous) UserWritten UnknownFVs (Annotation IsNotLock) ->
+            return $ WithHiding h n
 
           -- Error cases:
           ArgInfo _ _ _ _ (Annotation (IsLock _)) ->

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -909,6 +909,7 @@ instance ToAbstract C.Expr where
              , metaScope  = scope
              , metaNumber = Nothing
              , metaNameSuggestion = ""
+             , metaKind   = UnificationMeta
              }
         return $ A.QuestionMark info ii
       C.Underscore r n -> do
@@ -918,6 +919,7 @@ instance ToAbstract C.Expr where
                     , metaScope  = scope
                     , metaNumber = __IMPOSSIBLE__ =<< n
                     , metaNameSuggestion = fromMaybe "" n
+                    , metaKind   = UnificationMeta
                     }
 
   -- Raw application

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -190,12 +190,14 @@ instance Reify MetaId where
     reifyWhen = reifyWhenE
     reify x = do
       b <- asksTC envPrintMetasBare
-      mi  <- mvInfo <$> lookupLocalMeta x
+      mvar <- lookupLocalMeta x
+      let mi  = mvInfo mvar
       let mi' = Info.MetaInfo
                  { metaRange          = getRange $ miClosRange mi
                  , metaScope          = clScope $ miClosRange mi
                  , metaNumber         = if b then Nothing else Just x
                  , metaNameSuggestion = if b then "" else miNameSuggestion mi
+                 , metaKind           =  metaInstantiationToMetaKind (mvInstantiation mvar)
                  }
           underscore = return $ A.Underscore mi'
       -- If we are printing a term that will be pasted into the user

--- a/src/full/Agda/Termination/RecCheck.hs
+++ b/src/full/Agda/Termination/RecCheck.hs
@@ -163,7 +163,6 @@ anyDefs include a = do
   where
   -- TODO: Is it bad to ignore the lambdas?
   inst (InstV i)                      = instBody i
-  inst Open                           = __IMPOSSIBLE__
-  inst OpenInstance                   = __IMPOSSIBLE__
+  inst OpenMeta{}                     = __IMPOSSIBLE__
   inst BlockedConst{}                 = __IMPOSSIBLE__
   inst PostponedTypeCheckingProblem{} = __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -285,9 +285,7 @@ solveConstraint_ (UnBlock m)                =   -- alwaysUnblock since these hav
       -- Ulf, 2018-04-30: The size solver shouldn't touch blocked terms! They have
       -- a twin meta that it's safe to solve.
       InstV{} -> __IMPOSSIBLE__
-      -- Open (whatever that means)
-      Open -> __IMPOSSIBLE__
-      OpenInstance -> __IMPOSSIBLE__
+      OpenMeta{} -> __IMPOSSIBLE__
 solveConstraint_ (FindInstance m cands) = findInstance m cands
 solveConstraint_ (ResolveInstanceHead q) = resolveInstanceHead q
 solveConstraint_ (CheckFunDef i q cs _err) = withoutCache $

--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -162,8 +162,7 @@ reachableFrom sections ids ms psyns disp defs insts = do
 theInstantiation :: MetaVariable -> Instantiation
 theInstantiation mv = case mvInstantiation mv of
   InstV inst                     -> inst
-  Open{}                         -> __IMPOSSIBLE__
-  OpenInstance{}                 -> __IMPOSSIBLE__
+  OpenMeta{}                     -> __IMPOSSIBLE__
   BlockedConst{}                 -> __IMPOSSIBLE__
   PostponedTypeCheckingProblem{} -> __IMPOSSIBLE__
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -270,6 +270,7 @@ errorString err = case err of
   UninstantiatedDotPattern{}               -> "UninstantiatedDotPattern"
   ForcedConstructorNotInstantiated{}       -> "ForcedConstructorNotInstantiated"
   SolvedButOpenHoles{}                     -> "SolvedButOpenHoles"
+  IllegalInstanceVariableInPatternSynonym _ -> "IllegalInstanceVariableInPatternSynonym"
   UnusedVariableInPatternSynonym _         -> "UnusedVariableInPatternSynonym"
   UnquoteFailed{}                          -> "UnquoteFailed"
   DeBruijnIndexOutOfScope{}                -> "DeBruijnIndexOutOfScope"
@@ -1086,6 +1087,12 @@ instance PrettyTCM TypeError where
         prDef (x, (xs, p)) = prettyA (A.PatternSynDef x (map (fmap BindName) xs) p) <?> ("at" <+> pretty r)
           where r = nameBindingSite $ qnameName x
 
+    IllegalInstanceVariableInPatternSynonym x -> fsep $ concat
+      [ pwords "Variable is bound as instance in pattern synonym,"
+      , pwords "but does not resolve as instance in pattern: "
+      , [pretty x]
+      ]
+
     PatternSynonymArgumentShadowsConstructorOrPatternSynonym kind x (y :| _ys) -> vcat
       [ fsep $ concat
         [ pwords "Pattern synonym variable"
@@ -1098,7 +1105,6 @@ instance PrettyTCM TypeError where
         ]
       , pretty $ nameBindingSite $ qnameName $ anameName y
       ]
-
 
     UnusedVariableInPatternSynonym x -> fsep $
       pwords "Unused variable in pattern synonym: " ++ [pretty x]

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -138,6 +138,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Common.Pretty (prettyShow, singPlural)
 import Agda.Syntax.Concrete.Name (LensInScope(..))
 import Agda.Syntax.Position
+import Agda.Syntax.Info          (MetaNameSuggestion)
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Generic
 import Agda.Syntax.Internal.MetaVars

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4713,6 +4713,11 @@ data TypeError
         | BadArgumentsToPatternSynonym A.AmbiguousQName
         | TooFewArgumentsToPatternSynonym A.AmbiguousQName
         | CannotResolveAmbiguousPatternSynonym (List1 (A.QName, A.PatternSynDefn))
+        | IllegalInstanceVariableInPatternSynonym C.Name
+            -- ^ This variable is bound in the lhs of the pattern synonym in instance position,
+            --   but not on the rhs.
+            --   This is forbidden because expansion of pattern synonyms would not be faithful
+            --   to availability of instances in instance search.
         | PatternSynonymArgumentShadowsConstructorOrPatternSynonym LHSOrPatSyn C.Name (List1 AbstractName)
             -- ^ A variable to be bound in the pattern synonym resolved on the rhs as name of
             --   a constructor or a pattern synonym.

--- a/src/full/Agda/TypeChecking/Patterns/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Abstract.hs
@@ -95,7 +95,7 @@ expandPatternSynonyms' = postTraverseAPatternM $ \case
       , "- patsyn parameters: " <+> (text . show) (killRange ns)
       , "- patsyn arguments:  " <+> (text . show) (fmap (fmap void) as)
       ]
-    case A.insertImplicitPatSynArgs (A.WildP . PatRange) (getRange x) ns as of
+    case A.insertImplicitPatSynArgs (\ _h r -> A.WildP (PatRange r)) (getRange x) ns as of
       Nothing       -> typeError $ BadArgumentsToPatternSynonym x
       Just (_, _:_) -> typeError $ TooFewArgumentsToPatternSynonym x
       Just (s, [])  -> do

--- a/src/full/Agda/TypeChecking/Pretty/Constraint.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Constraint.hs
@@ -100,8 +100,7 @@ instance PrettyTCM Constraint where
               BlockedConst t -> prettyCmp ":=" m t
               PostponedTypeCheckingProblem cl -> enterClosure cl $ \p ->
                 prettyCmp ":=" m p
-              Open{}  -> __IMPOSSIBLE__
-              OpenInstance{} -> __IMPOSSIBLE__
+              OpenMeta{}  -> __IMPOSSIBLE__
               InstV{} -> empty
               -- Andreas, 2017-01-11, issue #2637:
               -- The size solver instantiates some metas with infinity

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -213,9 +213,7 @@ instance Instantiate Term where
          _ | Just m' <- mvTwin mv, blocking ->
            instantiate' (MetaV m' es)
 
-         Open -> return t
-
-         OpenInstance -> return t
+         OpenMeta _ -> return t
 
          BlockedConst u
            | blocking  -> instantiate' . unBrave $

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -986,8 +986,7 @@ reduceTm rEnv bEnv !constInfo normalisation =
               spine' <- elimsToSpine env es
               let (zs, env, !spine'') = buildEnv (instTel i) (spine' <> spine)
               runAM (evalClosure (lams zs (instBody i)) env spine'' ctrl)
-            Just Open{}                         -> __IMPOSSIBLE__
-            Just OpenInstance{}                 -> __IMPOSSIBLE__
+            Just OpenMeta{}                     -> __IMPOSSIBLE__
             Just BlockedConst{}                 -> __IMPOSSIBLE__
             Just PostponedTypeCheckingProblem{} -> __IMPOSSIBLE__
 

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -147,7 +147,7 @@ checkApplication cmp hd args e t =
       -- Expand the pattern synonym by substituting for
       -- the arguments we have got and lambda-lifting
       -- over the ones we haven't.
-      let meta r = A.Underscore $ A.emptyMetaInfo{ A.metaRange = r }   -- TODO: name suggestion
+      let meta h r = A.Underscore $ A.emptyMetaInfo{ A.metaRange = r, A.metaKind = A.hidingToMetaKind h }   -- TODO: name suggestion
       case A.insertImplicitPatSynArgs meta (getRange n) ns args of
         Nothing      -> typeError $ BadArgumentsToPatternSynonym n
         Just (s, ns) -> do

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -326,8 +326,8 @@ inferHead e = do
       -- So when applying the constructor throw away the parameters.
       return (applyE u . drop n, a)
     A.Con{} -> __IMPOSSIBLE__  -- inferHead will only be called on unambiguous constructors
-    A.QuestionMark i ii -> inferMeta (newQuestionMark ii) i
-    A.Underscore i   -> inferMeta (newValueMeta RunMetaOccursCheck) i
+    A.QuestionMark i ii -> inferMeta i (newQuestionMark ii)
+    A.Underscore i      -> inferMeta i (newValueMetaOfKind i RunMetaOccursCheck)
     e -> do
       (term, t) <- inferExpr e
       return (applyE term, t)

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -145,14 +145,15 @@ instance EmbPrj KindOfName where
   --   valu _   = malformed
 
 instance EmbPrj BindingSource where
-  icod_ LambdaBound   = pure 0
-  icod_ PatternBound  = pure 1
-  icod_ LetBound      = pure 2
-  icod_ WithBound     = pure 3
+  icod_ = \case
+    LambdaBound    -> pure 0
+    PatternBound _ -> pure 1
+    LetBound       -> pure 2
+    WithBound      -> pure 3
 
   value = \case
     0 -> pure LambdaBound
-    1 -> pure PatternBound
+    1 -> pure $ PatternBound empty
     2 -> pure LetBound
     3 -> pure WithBound
     _ -> malformed

--- a/test/Fail/Issue7136f.agda
+++ b/test/Fail/Issue7136f.agda
@@ -5,6 +5,7 @@ open import Agda.Builtin.Nat
 
 pattern p {{ x }} = suc x
 -- Should be rejected: instance argument in pattern synonym not supported.
+-- 2024-03-07 issue #2829: ...unless it is also an instance argument on the rhs.
 
 pred : Nat → Nat
 pred p = x

--- a/test/Fail/Issue7136f.err
+++ b/test/Fail/Issue7136f.err
@@ -1,6 +1,5 @@
-Issue7136f.agda:6,19-19
-Issue7136f.agda:6,19: Illegal pattern synonym argument  ⦃ x ⦄
-(Instance arguments not allowed to pattern synonyms.)
-=<ERROR>
- suc x
--- Should be rejected: ...
+Issue7136f.agda:6,14-15
+Variable is bound as instance in pattern synonym, but does not
+resolve as instance in pattern: x
+when scope checking the declaration
+  pattern p ⦃ x ⦄ = suc x

--- a/test/Succeed/PatternSynVarInstance.agda
+++ b/test/Succeed/PatternSynVarInstance.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2024-03-07, issue #2829.
+-- Allow instance variables in pattern synonym lhss
+-- if they are in instance position on the rhs.
+
+module _ where
+
+  data D : Set where
+    c : {{D}} → D
+
+  pattern p {{d}} = c {{d}}  -- Should be accepted.
+
+  f : D → D
+  f (p {{d = x}}) = x
+
+  g : D → D
+  g c = c
+
+  h : D → D
+  h p = c

--- a/test/Succeed/PatternSynVarInstance.agda
+++ b/test/Succeed/PatternSynVarInstance.agda
@@ -17,3 +17,9 @@ module _ where
 
   h : D → D
   h p = c
+
+  i : D → D
+  i p = p  -- Should solve.
+
+  j : D → D
+  j (p {{d}}) = p {{d = d}}


### PR DESCRIPTION
3 commits, checked by CI individually:

### 1. Refactor for https://github.com/agda/agda/issues/2829: Add MetaKind(InstanceMeta,UnificationMeta) to MetaInfo

We can now remember in the abstract syntax `Underscore` which kind of meta we want to generate: a `UnificationMeta` (default) or an `InstanceMeta`.  The latter is not used yet here but will be needed for `{{_}}` arguments created by the expansion of pattern synonyms.

Having `data MetaKind(InstanceMeta,UnificationMeta)` we also refactor `MetaInstantiation(Open,OpenInstance)` into a single parameterized constructor `OpenMeta MetaKind`.  This helps condensing pattern matching in several locations, where `Open` and `OpenInstance` behaved the same.
I considered keeping `Open` and `OpenInstance` as pattern synonym but it wasn't worth it.

There was already a type `MetaKind` for directing eta-expansion for metas.  This is a more obscure use than specifying the solution strategy for a meta, so I bumped this, calling it `MetaClass` now. This type is local to a only couple of modules, so renaming seems ok.

Changing the order of arguments in `Rules.Term.checkUnderscore` and friends seemed also natural.

Since `newInteractionMetaArg` was never used to create an instance meta, I simplified its code.

### 2. Allow instance arguments in pattern synonyms lhss...

... if they are instance arguments on the rhs as well.
To check this, we equip the scope checker with `Hiding` information for `PatternBound` local variables, and propagate the hiding info from `Arg` to the pattern scope checker by means of a new throw-away type `WithHidingInfo` (to not clash with the existing `WithHiding`).

This commit achieves that instance arguments that come to surface through pattern matching on a pattern synoym are available for instance search, just if one would match against the pattern the synonym stands for.

### 3. Make instance arguments in pattern synonyms work in expressions.

If a pattern synonym is used in an expression, we need to make sure that its instance arguments become instance metas.

Agda only turns an instance argument into an instance meta when the argument is _entirely omitted_.  That is, `{{_}}` does not create an instance meta, but this is exactly what the pattern synonym expansion produces in expressions.

Having added `metaKind` to the `MetaInfo` record, we can now create instance underscores in the abstract syntax, which fixes our dilemma.
