### PR TITLE
Use compareAs for assignE even in compareAtom

### DIFF
--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -569,7 +569,7 @@ compareAtom cmp t m n =
         dir = fromCmp cmp
         rid = flipCmp dir     -- The reverse direction.  Bad name, I know.
 
-        assign dir x es v = assignE dir x es v t $ compareAtomDir dir t
+        assign dir x es v = assignE dir x es v t $ compareAsDir dir t
 
     reportSDoc "tc.conv.atom" 30 $
       "compareAtom" <+> fsep [ prettyTCM mb <+> prettyTCM cmp

--- a/test/Succeed/EtaSingletonField.agda
+++ b/test/Succeed/EtaSingletonField.agda
@@ -1,0 +1,28 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+module EtaSingletonField where
+
+open import Agda.Builtin.Reflection renaming (bindTC to _>>=_)
+open import Agda.Builtin.Unit
+open import Agda.Builtin.List
+
+postulate wit : Set
+
+record Hom (X Y : Set) : Set where
+  field
+    hom : X → Y
+    it : wit
+
+argN : ∀ {ℓ} {A : Set ℓ} → A → Arg A
+argN = arg (arg-info visible (modality relevant quantity-ω))
+
+postulate fun : Hom ⊤ ⊤
+
+id : ∀ {ℓ} {A : Set ℓ} → A → A
+id x = x
+
+_ : ⊤
+_ = unquote λ goal → do
+  tm ← checkType unknown (quoteTerm (Hom ⊤ ⊤))
+  tm' ← checkType
+    (def (quote id) (argN (def (quote Hom.hom) (argN tm ∷ argN (quoteTerm tt) ∷ [])) ∷ [])) (quoteTerm ⊤)
+  unify (quoteTerm (Hom.hom fun tt)) tm'


### PR DESCRIPTION
I'm struggling to actually describe the bug that this fixes — I ran into it in the wild and divined a reproducer based on the logs (with 14 different verbosity flags...!). I guess literally the problem is this: if we `compareAtom` a neutral value in a singleton record against a projected metavariable, the field should be `compareAs`'d, to account for eta again.

The reproducer uses reflection to set up the elaborate ritual. We need:

- A comparison of a neutral against a projected metavariable, which does not trigger the meta shortcut;
- In an eta record type with one singleton field and one non-eta field.

The comparison against a projected meta lands us in `applyE`, which eta-expands the meta and compares the corresponding field in the expansion against the original thing. If you set things up just right you get fireworks:

```
Checking Test138 (/home/amelia/default/Projects/agda/Test138.agda).
/home/amelia/default/Projects/agda/Test138.agda:23,5-27,41
tt != Hom.hom fun tt of type ⊤
```

Anyway, the fix is just to `compareAs` the field, so that whatever applicable eta rules can fire again.