### PR TITLE
Fix #7176: turn absurd pattern in instance position to instance meta

### DIFF
--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -994,23 +994,6 @@ mkLet :: ExprInfo -> [LetBinding] -> Expr -> Expr
 mkLet _ []     e = e
 mkLet i (d:ds) e = Let i (d :| ds) e
 
-patternToExpr :: Pattern -> Expr
-patternToExpr = \case
-  VarP x             -> Var (unBind x)
-  ConP _ c ps        -> Con c `app` map (fmap (fmap patternToExpr)) ps
-  ProjP _ o ds       -> Proj o ds
-  DefP _ fs ps       -> Def (headAmbQ fs) `app` map (fmap (fmap patternToExpr)) ps
-  WildP _            -> Underscore emptyMetaInfo
-  AsP _ _ p          -> patternToExpr p
-  DotP _ e           -> e
-  AbsurdP _          -> Underscore emptyMetaInfo  -- TODO: could this happen?
-  LitP (PatRange r) l-> Lit (ExprRange r) l
-  PatternSynP _ c ps -> PatternSyn c `app` (map . fmap . fmap) patternToExpr ps
-  RecP _ as          -> Rec exprNoRange $ map (Left . fmap patternToExpr) as
-  EqualP{}           -> __IMPOSSIBLE__  -- Andrea TODO: where is this used?
-  WithP r p          -> __IMPOSSIBLE__
-  AnnP _ _ p         -> patternToExpr p
-
 type PatternSynDefn = ([WithHiding Name], Pattern' Void)
 type PatternSynDefns = Map QName PatternSynDefn
 

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -415,7 +415,7 @@ reifyDisplayFormP f ps wps = do
               -- even the pattern variables @n < len@ can be
               -- applied to some args @vs@.
               e <- if n < len
-                   then return $ A.patternToExpr $ namedArg $ indexWithDefault __IMPOSSIBLE__ ps n
+                   then return $ patternToExpr $ namedArg $ indexWithDefault __IMPOSSIBLE__ ps n
                    else reify (I.var (n - len))
               apps e =<< argsToExpr vs
             _ -> return underscore

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -28,6 +28,7 @@ import Agda.Interaction.Highlighting.Generate
   ( storeDisambiguatedConstructor, storeDisambiguatedProjection )
 
 import qualified Agda.Syntax.Abstract as A
+import Agda.Syntax.Abstract.Pattern (patternToExpr)
 import Agda.Syntax.Abstract.Views as A
 import qualified Agda.Syntax.Info as A
 import Agda.Syntax.Concrete.Pretty () -- only Pretty instances
@@ -151,7 +152,7 @@ checkApplication cmp hd args e t =
       case A.insertImplicitPatSynArgs meta (getRange n) ns args of
         Nothing      -> typeError $ BadArgumentsToPatternSynonym n
         Just (s, ns) -> do
-          let p' = A.patternToExpr p
+          let p' = patternToExpr p
               e' = A.lambdaLiftExpr ns (A.substExpr s p')
           checkExpr' cmp e' t
 

--- a/test/Succeed/PatternSynonyms.agda
+++ b/test/Succeed/PatternSynonyms.agda
@@ -279,6 +279,32 @@ data ⊥ : Set where
 ⊥-elim absurd
 
 ------------------------------------------------------------------------
+-- Andreas, 2024-03-12, issue #7176:
+-- preserve instanceness in absurd pattern on rhs
+
+module Issue7176 where
+
+  data D : Set where
+    c : {{ i : 0 ≡ 1 }} → D
+
+  pattern ff = c {{ () }}
+
+  works : D → D
+  works ff
+
+  works' : D → D
+  works' c = c
+
+  issue7176 : D → D
+  issue7176 c = ff
+
+  -- Problem was:
+  -- Unsolved meta in last rhs:
+  -- _i : 0 ≡ 1
+
+  -- Should succeed.
+
+------------------------------------------------------------------------
 -- ambiguous constructors
 
 data ℕ2 : Set where


### PR DESCRIPTION
Fix #7176: turn absurd pattern in instance position to instance meta rather than unification meta.
So when we use a pattern synonym like `pattern p = c {{()}}` in an expression, the absurd pattern becomes an instance meta.
