### PR TITLE
Fix Mimer trying bad recursive calls

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -133,6 +133,7 @@
     - -XTypeFamilies
     - -XTypeOperators
     - -XTypeSynonymInstances
+    - -XViewPatterns
 
 # Add custom hints for this project
 - hint:

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -342,6 +342,7 @@ common language
       TypeFamilies
       TypeOperators
       TypeSynonymInstances
+      ViewPatterns
 
   other-extensions:
       CPP

--- a/src/full/Agda/TypeChecking/Substitute/Class.hs
+++ b/src/full/Agda/TypeChecking/Substitute/Class.hs
@@ -111,6 +111,9 @@ instance Subst QName where
   type SubstArg QName = Term
   applySubst _ q = q
 
+-- | Wrapper for types that do not contain variables (so applying a substitution is the identity).
+--   Useful if you have a structure of types that support substitution mixed with types that don't
+--   and need to apply a substitution to the full structure.
 newtype NoSubst t a = NoSubst { unNoSubst :: a }
   deriving (Generic, NFData, Functor)
 

--- a/src/full/Agda/TypeChecking/Substitute/Class.hs
+++ b/src/full/Agda/TypeChecking/Substitute/Class.hs
@@ -3,6 +3,8 @@
 module Agda.TypeChecking.Substitute.Class where
 
 import Control.Arrow ((***), second)
+import Control.DeepSeq
+import GHC.Generics
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
@@ -108,6 +110,13 @@ isNoAbs (Abs _ b)
 instance Subst QName where
   type SubstArg QName = Term
   applySubst _ q = q
+
+newtype NoSubst t a = NoSubst { unNoSubst :: a }
+  deriving (Generic, NFData, Functor)
+
+instance DeBruijn t => Subst (NoSubst t a) where
+  type SubstArg (NoSubst t a) = t
+  applySubst _ x = x
 
 ---------------------------------------------------------------------------
 -- * Explicit substitutions

--- a/test/interaction/Issue7116.agda
+++ b/test/interaction/Issue7116.agda
@@ -1,0 +1,21 @@
+module _ (A : Set) where
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Sigma
+
+data Color : Set where
+  black : Color
+
+data Tree' : Color → Nat → Set where
+  nb : ∀ (a : A) {c} {n}
+     → Tree' c n
+     → Tree' black n
+     → Tree' black (suc n)
+
+test : ∀ (a : A) {n} (l : Tree' black (suc n)) → Σ _ λ c → Tree' c (suc n)
+test a (nb b l r) = {!!}   -- C-c C-a
+-- was: internal error
+-- should be: black , nb a r r
+
+-- An internal error has occurred. Please report this as a bug.
+-- Location of the error: __IMPOSSIBLE__, called at src/full/Agda/TypeChecking/CompiledClause/Match.hs:87:73

--- a/test/interaction/Issue7116.in
+++ b/test/interaction/Issue7116.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 0 cmd_autoOne ""

--- a/test/interaction/Issue7116.out
+++ b/test/interaction/Issue7116.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : Σ Color (λ c → Tree' c (suc n)) " nil)
+((last . 1) . (agda2-goals-action '(0)))
+(agda2-give-action 0 "black , nb a r r")
+((last . 1) . (agda2-goals-action '()))


### PR DESCRIPTION
Fixes #7116

There were two problems:
- When attempting a recursive call for the second time, the same meta was reused, resulting in trying to solve `_X` with `foo _X`, constructing an infinite term
- Recursive calls were not guaranteed to be terminating, resulting in loops like:
  ```
  foo x (c y) = _1
  _1 := foo y _2  -- Mimer considered this an ok recursive calls because y is under a constructor
  _2 := c y       -- Constructor applied to variables is always a good solution
  ```
The first problem was caused by a minor oversight in how recursive call components were reused and easy to fix.

The second problem is fixed by restricting variables in recursive calls to their original argument position. In the example above only `foo _2 y` would be considered a valid recursive call.

This PR also improves the debug logging of Mimer, introducing a `mimer.trace` debug level (between 10 and 60) that produces a human readable trace of what the proof search is doing.