### PR TITLE
Fix #7208: restore missing check for OverlappingProjects

### DIFF
--- a/test/Fail/Issue7208.agda
+++ b/test/Fail/Issue7208.agda
@@ -1,0 +1,10 @@
+-- Andreas, 2024-03-29, issue #7208
+-- Regression in 2.6.2: Internal error when importing an empty hierarchical module.
+
+import Issue7208.A
+
+-- Expected error:
+
+-- Issue7208/A.agda can be accessed via several project roots.
+-- Both A and Issue7208.A point to this file.
+-- when scope checking the declaration

--- a/test/Fail/Issue7208.err
+++ b/test/Fail/Issue7208.err
@@ -1,0 +1,6 @@
+Issue7208.agda:4,1-19
+The file Issue7208/A.agda can be
+accessed via several project roots. Both A and Issue7208.A point to
+this file.
+when scope checking the declaration
+  import Issue7208.A

--- a/test/Fail/Issue7208/A.agda
+++ b/test/Fail/Issue7208/A.agda
@@ -1,0 +1,1 @@
+-- This file is intentionally left empty


### PR DESCRIPTION
Fixes #7208 by partially reverting the change introduced in 6c29efdc8c0eb1d1fbaf2d2ef5a5eefb704a9525 .