### PR TITLE
Fix #7181: Allow matching to continue when stuck on lazy pattern

### DIFF
--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -37,7 +37,7 @@ import Agda.Utils.Impossible
 --   lazy pattern and whether it is due to a particular meta variable.
 data Match a = Yes Simplification (IntMap (Arg a))
              | No
-             | DontKnow Bool (Blocked ())
+             | DontKnow OnlyLazy (Blocked ())
   deriving Functor
 
 instance Null (Match a) where
@@ -64,7 +64,7 @@ buildSubstitution err n vs = foldr cons idS $ matchedArgs' n vs
 instance Semigroup (Match a) where
     -- @NotBlocked (StuckOn e)@ means blocked by a variable.
     -- In this case, no instantiation of meta-variables will make progress.
-    DontKnow l b <> DontKnow l' b' = DontKnow (l && l') (b <> b')
+    DontKnow l b <> DontKnow l' b' = DontKnow (l <> l') (b <> b')
     DontKnow l m <> _              = DontKnow l m
     _            <> DontKnow l m   = DontKnow l m
     -- One could imagine DontKnow _ _ <> No = No, but would break the
@@ -76,6 +76,18 @@ instance Semigroup (Match a) where
 instance Monoid (Match a) where
     mempty = empty
     mappend = (<>)
+
+-- | Whether the inconclusive matches are only on lazy patterns.
+data OnlyLazy = OnlyLazy | NonLazy
+
+instance Semigroup OnlyLazy where
+  NonLazy  <> _        = NonLazy
+  _        <> NonLazy  = NonLazy
+  OnlyLazy <> OnlyLazy = OnlyLazy
+
+instance Monoid OnlyLazy where
+  mempty = OnlyLazy
+  mappend = (<>)
 
 -- | Instead of 'zipWithM', we need to use this lazy version
 --   of combining pattern matching computations.
@@ -118,10 +130,10 @@ foldMatch match = loop where
             -- contain ill-typed terms due to eta-expansion at wrong
             -- type.
             return (r <> r', v' : vs)
-          DontKnow True _ -> do
+          DontKnow OnlyLazy _ -> do
             (r', _vs') <- loop ps vs
             return (r <> r', v' : vs)
-          DontKnow False m -> return (DontKnow False m, v' : vs)
+          DontKnow NonLazy m -> return (DontKnow NonLazy m, v' : vs)
           Yes{} -> do
             (r', vs') <- loop ps vs
             return (r <> r', v' : vs')
@@ -225,15 +237,16 @@ matchPattern p u = case (p, u) of
       NotBlocked _ (Lit l')
           | l == l'            -> return (Yes YesSimplification empty , arg')
           | otherwise          -> return (No                          , arg')
-      Blocked b _              -> return (DontKnow False $ Blocked b ()     , arg')
-      NotBlocked r t           -> return (DontKnow False $ NotBlocked r' () , arg')
+      Blocked b _              -> return (DontKnow NonLazy $ Blocked b ()     , arg')
+      NotBlocked r t           -> return (DontKnow NonLazy $ NotBlocked r' () , arg')
         where r' = stuckOn (Apply arg') r
 
   -- Case constructor pattern.
   (ConP c cpi ps, Arg info v) -> do
-    if not (conPRecord cpi) then fallback c (conPLazy cpi) ps (Arg info v) else do
+    let lazy = if conPLazy cpi then OnlyLazy else NonLazy
+    if not (conPRecord cpi) then fallback c lazy ps (Arg info v) else do
     isEtaRecordCon (conName c) >>= \case
-      Nothing -> fallback c (conPLazy cpi) ps (Arg info v)
+      Nothing -> fallback c lazy ps (Arg info v)
       Just fs -> do
         -- Case: Eta record constructor.
         -- This case is necessary if we want to use the clauses before
@@ -253,11 +266,11 @@ matchPattern p u = case (p, u) of
   (DefP o q ps, v) -> do
     let f (Def q' vs) | q == q' = Just (Def q, vs)
         f _                     = Nothing
-    fallback' f False ps v
+    fallback' f NonLazy ps v
  where
     -- Default: not an eta record constructor.
   fallback :: MonadMatch m
-           => ConHead -> Bool -> [NamedArg DeBruijnPattern] -> Arg Term -> m (Match Term, Arg Term)
+           => ConHead -> OnlyLazy -> [NamedArg DeBruijnPattern] -> Arg Term -> m (Match Term, Arg Term)
   fallback c lazy ps v = do
     let f (Con c' ci' vs) | c == c' = Just (Con c' ci',vs)
         f _                         = Nothing
@@ -282,7 +295,7 @@ matchPattern p u = case (p, u) of
   -- DefP hcomp and ConP matching.
   fallback' :: MonadMatch m
             => (Term -> Maybe (Elims -> Term , Elims))
-            -> Bool
+            -> OnlyLazy
             -> [NamedArg DeBruijnPattern]
             -> Arg Term
             -> m (Match Term, Arg Term)

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -33,11 +33,11 @@ import Agda.Utils.Tuple
 
 import Agda.Utils.Impossible
 
--- | If matching is inconclusive (@DontKnow@) we want to know whether
---   it is due to a particular meta variable.
+-- | If matching is inconclusive (@DontKnow@) we want to know whether it is on a
+--   lazy pattern and whether it is due to a particular meta variable.
 data Match a = Yes Simplification (IntMap (Arg a))
              | No
-             | DontKnow (Blocked ())
+             | DontKnow Bool (Blocked ())
   deriving Functor
 
 instance Null (Match a) where
@@ -64,10 +64,10 @@ buildSubstitution err n vs = foldr cons idS $ matchedArgs' n vs
 instance Semigroup (Match a) where
     -- @NotBlocked (StuckOn e)@ means blocked by a variable.
     -- In this case, no instantiation of meta-variables will make progress.
-    DontKnow b <> DontKnow b'      = DontKnow $ b <> b'
-    DontKnow m <> _                = DontKnow m
-    _          <> DontKnow m       = DontKnow m
-    -- One could imagine DontKnow _ <> No = No, but would break the
+    DontKnow l b <> DontKnow l' b' = DontKnow (l && l') (b <> b')
+    DontKnow l m <> _              = DontKnow l m
+    _            <> DontKnow l m   = DontKnow l m
+    -- One could imagine DontKnow _ _ <> No = No, but would break the
     -- equivalence to case-trees (Issue 2964).
     No         <> _                = No
     _          <> No               = No
@@ -118,7 +118,10 @@ foldMatch match = loop where
             -- contain ill-typed terms due to eta-expansion at wrong
             -- type.
             return (r <> r', v' : vs)
-          DontKnow m -> return (DontKnow m, v' : vs)
+          DontKnow True _ -> do
+            (r', _vs') <- loop ps vs
+            return (r <> r', v' : vs)
+          DontKnow False m -> return (DontKnow False m, v' : vs)
           Yes{} -> do
             (r', vs') <- loop ps vs
             return (r <> r', v' : vs')
@@ -222,15 +225,15 @@ matchPattern p u = case (p, u) of
       NotBlocked _ (Lit l')
           | l == l'            -> return (Yes YesSimplification empty , arg')
           | otherwise          -> return (No                          , arg')
-      Blocked b _              -> return (DontKnow $ Blocked b ()     , arg')
-      NotBlocked r t           -> return (DontKnow $ NotBlocked r' () , arg')
+      Blocked b _              -> return (DontKnow False $ Blocked b ()     , arg')
+      NotBlocked r t           -> return (DontKnow False $ NotBlocked r' () , arg')
         where r' = stuckOn (Apply arg') r
 
   -- Case constructor pattern.
   (ConP c cpi ps, Arg info v) -> do
-    if not (conPRecord cpi) then fallback c ps (Arg info v) else do
+    if not (conPRecord cpi) then fallback c (conPLazy cpi) ps (Arg info v) else do
     isEtaRecordCon (conName c) >>= \case
-      Nothing -> fallback c ps (Arg info v)
+      Nothing -> fallback c (conPLazy cpi) ps (Arg info v)
       Just fs -> do
         -- Case: Eta record constructor.
         -- This case is necessary if we want to use the clauses before
@@ -250,15 +253,15 @@ matchPattern p u = case (p, u) of
   (DefP o q ps, v) -> do
     let f (Def q' vs) | q == q' = Just (Def q, vs)
         f _                     = Nothing
-    fallback' f ps v
+    fallback' f False ps v
  where
     -- Default: not an eta record constructor.
   fallback :: MonadMatch m
-           => ConHead -> [NamedArg DeBruijnPattern] -> Arg Term -> m (Match Term, Arg Term)
-  fallback c ps v = do
+           => ConHead -> Bool -> [NamedArg DeBruijnPattern] -> Arg Term -> m (Match Term, Arg Term)
+  fallback c lazy ps v = do
     let f (Con c' ci' vs) | c == c' = Just (Con c' ci',vs)
         f _                         = Nothing
-    fallback' f ps v
+    fallback' f lazy ps v
 
   -- Regardless of blocking, constructors and a properly applied @hcomp@
   -- can be matched on.
@@ -279,10 +282,11 @@ matchPattern p u = case (p, u) of
   -- DefP hcomp and ConP matching.
   fallback' :: MonadMatch m
             => (Term -> Maybe (Elims -> Term , Elims))
+            -> Bool
             -> [NamedArg DeBruijnPattern]
             -> Arg Term
             -> m (Match Term, Arg Term)
-  fallback' mtc ps (Arg info v) = do
+  fallback' mtc lazy ps (Arg info v) = do
         isMatchable <- isMatchable'
 
         w <- reduceB v
@@ -314,8 +318,8 @@ matchPattern p u = case (p, u) of
                 return (yesSimplification m, Arg info $ bld (mergeElims vs vs1))
               Nothing
                                     -> return (No                          , arg)
-          Blocked b _               -> return (DontKnow $ Blocked b ()     , arg)
-          NotBlocked r _            -> return (DontKnow $ NotBlocked r' () , arg)
+          Blocked b _               -> return (DontKnow lazy $ Blocked b ()     , arg)
+          NotBlocked r _            -> return (DontKnow lazy $ NotBlocked r' () , arg)
             where r' = stuckOn (Apply arg) r
 
 yesSimplification :: Match a -> Match a

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
@@ -11,7 +11,9 @@ import Agda.TypeChecking.Substitute (DeBruijn)
 
 import Agda.Utils.Impossible
 
-data Match a = Yes Simplification (IntMap (Arg a)) | No | DontKnow Bool (Blocked ())
+data Match a = Yes Simplification (IntMap (Arg a)) | No | DontKnow OnlyLazy (Blocked ())
+
+data OnlyLazy = OnlyLazy | NonLazy
 
 buildSubstitution :: (DeBruijn a) => Impossible -> Int -> IntMap (Arg a) -> Substitution' a
 

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs-boot
@@ -11,7 +11,7 @@ import Agda.TypeChecking.Substitute (DeBruijn)
 
 import Agda.Utils.Impossible
 
-data Match a = Yes Simplification (IntMap (Arg a)) | No | DontKnow (Blocked ())
+data Match a = Yes Simplification (IntMap (Arg a)) | No | DontKnow Bool (Blocked ())
 
 buildSubstitution :: (DeBruijn a) => Impossible -> Int -> IntMap (Arg a) -> Substitution' a
 

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -931,8 +931,8 @@ appDefE'' v cls rewr es = traceSDoc "tc.reduce" 90 ("appDefE' v = " <+> pretty v
               -- should be fine to continue matching on the next clause.
               -- This assumes it's impossible for a lazy match to be stuck if
               -- all non-lazy matches succeed.
-              DontKnow True  _ -> goCls cls es
-              DontKnow False b -> rewrite b (applyE v) rewr es
+              DontKnow OnlyLazy _ -> goCls cls es
+              DontKnow NonLazy  b -> rewrite b (applyE v) rewr es
               Yes simpl vs -- vs is the subst. for the variables bound in body
                 | Just w <- body -> do -- clause has body?
                     -- TODO: let matchPatterns also return the reduced forms

--- a/test/Succeed/Issue7181.agda
+++ b/test/Succeed/Issue7181.agda
@@ -1,0 +1,66 @@
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Nat
+
+-- Copatterns
+
+data D : Nat → Set where
+  c1 : (x : Nat) → D (suc x)
+  c2 : (x : Nat) → D x
+
+f : (x : Nat) → D x → Σ Set (λ A → A)
+
+fst (f .(suc x) (c1 x)) = Nat
+snd (f .(suc x) (c1 x)) = zero
+
+fst (f .x (c2 x)) = Nat
+snd (f .x (c2 x)) = zero
+
+g : (x : Nat) → fst (f x (c2 x))
+g x = zero
+
+-- Indexed induction-recursion
+
+postulate P : Nat → Set
+
+data U : Nat → Set
+El : (x : Nat) → U x → Set
+
+data U where
+  c1 : (x : Nat) → U (suc x)
+  c2 : (x : Nat) → U x
+  c3 : (x : Nat) → El x (c2 x) → U x
+
+El .(suc x) (c1 x)   = Nat
+El .x       (c2 x)   = Nat
+El .x       (c3 x y) = P y
+
+-- Induction-induction
+
+data D1 : Nat → Set
+data D2 : (x : Nat) → D1 x → Set
+
+data D1 where
+  c1 : (x : Nat) → D1 (suc x)
+  c2 : (x : Nat) → D1 x
+  c3 : (x : Nat) → D2 x (c2 x) → D1 x
+
+data D2 where
+  c4 : (x : Nat) → D2 x (c2 x)
+
+module _
+  (P1 : Nat → Set)
+  (P2 : (x : Nat) → P1 x → Set)
+  (p1 : (x : Nat) → P1 (suc x))
+  (p2 : (x : Nat) → P1 x)
+  (p3 : (x : Nat) → P2 x (p2 x) → P1 x)
+  (p4 : (x : Nat) → P2 x (p2 x))
+  where
+
+  rec1 : (x : Nat) → D1 x → P1 x
+  rec2 : (x : Nat) (d1 : D1 x) → D2 x d1 → P2 x (rec1 x d1)
+
+  rec1 .(suc x) (c1 x)    = p1 x
+  rec1 .x       (c2 x)    = p2 x
+  rec1 .x       (c3 x d2) = p3 x (rec2 x (c2 x) d2)
+
+  rec2 .x .(c2 x) (c4 x) = p4 x


### PR DESCRIPTION
Fixes #7181 by allowing reduction to continue matching on the next clause when left-to-right matching is stuck on a lazy pattern while all non-lazy matches fail or succeed.
