### PR TITLE
Restore agda-input for ordinary backslash (regression in #6769)

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -860,7 +860,7 @@ order for the change to take effect."
 
   ;; Other punctuation and symbols.
 
-  ("\\"         . ("＼"))
+  ("\\"         . ("\\"))
   ("en"         . ("–"))
   ("em"         . ("—"))
   ("!"          . ("！"))


### PR DESCRIPTION
We need to be able to type ordinary backslashes e.g. in regular expressions.

ATTN: @gallais @UlfNorell @fredrik-bakke 