### PR TITLE
Strengthen link between .el files in src/data/emacs and src/agda-mode

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -956,6 +956,7 @@ test-suite agda-tests
       Internal.Utils.List2
       Internal.Utils.ListT
       Internal.Utils.Maybe.Strict
+      Internal.Utils.Monad
       Internal.Utils.Monoid
       Internal.Utils.PartialOrd
       Internal.Utils.Permutation

--- a/src/data/emacs-mode/README.md
+++ b/src/data/emacs-mode/README.md
@@ -1,0 +1,2 @@
+The list of `.el` files is duplicated in `/src/agda-mode/Main.hs`, to instruct Emacs to compile these files.
+The exception is `agda2-mode-pkg.el`, which is just meta-information about the mode and need not be compiled.

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -173,7 +173,7 @@ dropWhileEndM p (x : xs) = ifNotNullM (dropWhileEndM p xs) (return . (x:)) $ {-e
 -- | A ``monadic'' version of @'partition' :: (a -> Bool) -> [a] -> ([a],[a])
 partitionM :: (Functor m, Applicative m) => (a -> m Bool) -> [a] -> m ([a], [a])
 partitionM f =
-  foldr (\ x mlr -> bool (first (x:)) (second (x:)) <$> f x <*> mlr)
+  foldr (\ x -> liftA2 (bool (second (x:)) (first (x:))) $ f x)
         (pure empty)
 
 -- MonadPlus -----------------------------------------------------------------

--- a/test/Internal/Tests.hs
+++ b/test/Internal/Tests.hs
@@ -46,6 +46,7 @@ import qualified Internal.Utils.List1                              as UtilList1 
 import qualified Internal.Utils.List2                              as UtilList2    ( tests )
 import qualified Internal.Utils.ListT                              as UtilListT    ( tests )
 import qualified Internal.Utils.Maybe.Strict                       as UtilMaybeS   ( tests )
+import qualified Internal.Utils.Monad                              as UtilMonad    ( tests )
 import qualified Internal.Utils.Monoid                             as UtilMonoid   ( tests )
 import qualified Internal.Utils.PartialOrd                         as UtilPOrd     ( tests )
 import qualified Internal.Utils.Permutation                        as UtilPerm     ( tests )
@@ -59,6 +60,7 @@ import qualified Internal.Utils.Warshall                           as UtilWarsh 
 tests :: TestTree
 tests = testGroup "Internal"
   [ CompEnco.tests
+  , UtilMonad.tests
   , IntePrec.tests
   , InteRang.tests
   , Library.tests

--- a/test/Internal/Utils/Monad.hs
+++ b/test/Internal/Utils/Monad.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP             #-}
+
+#if  __GLASGOW_HASKELL__ > 800
+{-# OPTIONS_GHC -Wno-error=missing-signatures #-}
+#endif
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module Internal.Utils.Monad ( tests ) where
+
+import Agda.Utils.Monad
+
+import Data.Functor.Identity
+import Data.List (partition)
+
+import Internal.Helpers
+
+------------------------------------------------------------------------------
+
+prop_partitionM_pure f xs =
+  partitionM (Identity . f) xs == Identity (partition f xs)
+
+------------------------------------------------------------------------
+-- * All tests
+------------------------------------------------------------------------
+
+-- Template Haskell hack to make the following $allProperties work
+-- under ghc-7.8.
+return [] -- KEEP!
+
+-- | All tests as collected by 'allProperties'.
+--
+-- Using 'allProperties' is convenient and superior to the manual
+-- enumeration of tests, since the name of the property is added
+-- automatically.
+
+tests :: TestTree
+tests = testProperties "Internal.Utils.Monad" $allProperties


### PR DESCRIPTION
- Add a README alerting of the duplication.
- Fail in `agda-mode compile` if one of the files is missing.

Closes #7215.
