### PR TITLE
Instantiate terms before traversing them in tcExtendContext

### DIFF
--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -847,6 +847,8 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
       a <- unquote a
       fmap (strengthen impossible) $ extendCxt s a $ do
         v <- evalTCM $ raise 1 m
+        -- 2024-04-20: free variable analysis only really makes sense on normal forms; see #7227
+        v <- normalise v
         when (freeIn 0 v) $ liftTCM $ genericDocError =<<
           hcat ["Local variable '", prettyTCM (var 0), "' escaping in result of extendContext:"]
             <?> prettyTCM v

--- a/test/Succeed/Issue7231.agda
+++ b/test/Succeed/Issue7231.agda
@@ -1,0 +1,21 @@
+open import Agda.Builtin.List
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Reflection
+  renaming (bindTC to _>>=_; returnTC to return)
+
+pattern vArg t = arg (arg-info visible (modality relevant quantity-ω)) t
+
+const : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} → A → B → A
+const a b = a
+
+macro
+  test : Term → TC ⊤
+  test _ = do
+    _ ← extendContext "a" (vArg (quoteTerm Nat)) do
+      x ← unquoteTC {A = Nat} (var 0 [])
+      return {A = Nat} (const 0 x)
+    return tt
+
+_ : ⊤
+_ = test


### PR DESCRIPTION
Originally for https://github.com/agda/agda/issues/7227. I narrowed the issue down to the `freeIn` call in `tcExtendContext` sometimes hanging and consuming unbounded memory:

https://github.com/agda/agda/blob/00f4bb499e049201317f56d60e0a5660f7b9681a/src/full/Agda/TypeChecking/Unquote.hs#L850-L852

I don't know what exactly causes this, but @plt-amy suggested on IRC to `instantiateFull` the term, and indeed that solves the issue. [Here's](https://gist.github.com/ncfavier/b0e6aba03e4b415ef6695ea0df8684e0) an example of the reduction in size (note that the log file is truncated, you need to click "view the full file").

The problematic `extend-context` call is [here](https://github.com/plt-amy/1lab/blob/caf71247aa81493629cb89767e19103647ace0f2/src/1Lab/Reflection/Induction.agda#L242-L243): the returned value `v` in this case consists of three lists.