### PR TITLE
CI cosmetics: keep --dependencies-only step even when cache hit

### DIFF
--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -53,8 +53,7 @@ jobs:
         key: ${{ env.key }}-${{ hashFiles('**/plan.json') }}
         path: ~/.cabal/store
         restore-keys: ${{ env.key }}-
-    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      name: Install dependencies
+    - name: Install dependencies
       run: |
         cabal build --only-dependencies
     - name: Install Agda

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -80,8 +80,7 @@ jobs:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
         restore-keys: ${{ env.key }}
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Install dependencies
+    - name: Install dependencies
       run: |
         cabal build --only-dependencies
     - name: Build Agda

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -90,8 +90,7 @@ jobs:
         path: |
           ${{ env.STACK_ROOT }}
         restore-keys: ${{ env.key}}-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
+    - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests`
         (i.e. the test suite).

--- a/src/github/workflows/cabal-install.yml
+++ b/src/github/workflows/cabal-install.yml
@@ -110,7 +110,9 @@ jobs:
         restore-keys: ${{ env.key }}-
 
     - name: Install dependencies
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      # Since we save the cache even when building failed, it may be incomplete.
+      # Thus, do not skip this step:
+      # if: steps.cache.outputs.cache-hit != 'true'
       run: |
         cabal build --only-dependencies
 

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -171,12 +171,9 @@ jobs:
         key: cabal.yml-${{ runner.os }}-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-cabal-${{ steps.setup-haskell.outputs.cabal-version }}
 
     - name: Install dependencies
-      # Formally skip this when we successfully restored the cache, to shave a few seconds.
-      # Note that the dependencies will anyway be built in the `cabal build` step.
-      # So, strictly speaking, this step is superfluous anyways.
-      # However, we keep it here so that we do not clutter the output of the
-      # `cabal build` step too much in the ordinary case.
-      if: steps.cache.outputs.cache-hit != 'true'
+      # Since we save the cache even when building failed, it may be incomplete.
+      # Thus, do not skip this step:
+      # if: steps.cache.outputs.cache-hit != 'true'
       run: |
         cabal build --only-dependencies
 

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -198,7 +198,9 @@ jobs:
           # .stack-work-fast
 
     - name: Install dependencies for Agda and `agda-tests` (i.e. the test suite).
-      if: steps.cache.outputs.cache-hit != 'true'
+      # Since we save the cache even when building failed, it may be incomplete.
+      # Thus, do not skip this step:
+      # if: steps.cache.outputs.cache-hit != 'true'
       run: stack build ${ARGS} ${EXTRA_ARGS} ${NON_DEFAULT_FLAGS} --test --only-dependencies
 
     - name: Build Agda with the default flags in Agda.cabal. Also build `agda-tests` (i.e. the test suite).


### PR DESCRIPTION
The cache might originate from a failed build, so it may be incomplete.
