### PR TITLE
Fix #7236: use context rather than telescope for lambda-bound variables in rewrite patterns

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -485,11 +485,12 @@ getContextNames = map (fst . unDom) <$> getContext
 
 -- | get type of bound variable (i.e. deBruijn index)
 --
+lookupBV_ :: Nat -> Context -> Maybe ContextEntry
+lookupBV_ n ctx = raise (n + 1) <$> ctx !!! n
+
 {-# SPECIALIZE lookupBV' :: Nat -> TCM (Maybe ContextEntry) #-}
 lookupBV' :: MonadTCEnv m => Nat -> m (Maybe ContextEntry)
-lookupBV' n = do
-  ctx <- getContext
-  return $ raise (n + 1) <$> ctx !!! n
+lookupBV' n = lookupBV_ n <$> getContext
 
 {-# SPECIALIZE lookupBV :: Nat -> TCM (Dom (Name, Type)) #-}
 lookupBV :: (MonadFail m, MonadTCEnv m) => Nat -> m (Dom (Name, Type))

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -119,10 +119,10 @@ tellSub r i a v = do
       | isIrrelevant r' -> nlmSub %= IntMap.insert i (r,v)
       | otherwise       -> whenJustM (equal a v v') matchingBlocked
 
-tellEq :: Telescope -> Telescope -> Type -> Term -> Term -> NLM ()
+tellEq :: Telescope -> Context -> Type -> Term -> Term -> NLM ()
 tellEq gamma k a u v = do
   traceSDoc "rewriting.match" 30 (sep
-               [ "adding equality between" <+> addContext (gamma `abstract` k) (prettyTCM u)
+               [ "adding equality between" <+> addContext gamma (addContext k $ prettyTCM u)
                , " and " <+> addContext k (prettyTCM v) ]) $ do
   nlmEqs %= (PostponedEquation k a u v:)
 
@@ -132,7 +132,7 @@ type Sub = IntMap (Relevance, Term)
 --   which we have to verify after applying
 --   the substitution computed by matching.
 data PostponedEquation = PostponedEquation
-  { eqFreeVars :: Telescope -- ^ Telescope of free variables in the equation
+  { eqFreeVars :: Context -- ^ Context of free variables in the equation
   , eqType :: Type    -- ^ Type of the equation, living in same context as the rhs.
   , eqLhs :: Term     -- ^ Term from pattern, living in pattern context.
   , eqRhs :: Term     -- ^ Term from scrutinee, living in context where matching was invoked.
@@ -145,7 +145,7 @@ type PostponedEquations = [PostponedEquation]
 class Match a b where
   match :: Relevance  -- ^ Are we currently matching in an irrelevant context?
         -> Telescope  -- ^ The telescope of pattern variables
-        -> Telescope  -- ^ The telescope of lambda-bound variables
+        -> Context    -- ^ The context of lambda-bound variables
         -> TypeOf b   -- ^ The type of the pattern
         -> a          -- ^ The pattern to match
         -> b          -- ^ The term to be matched against the pattern
@@ -161,7 +161,7 @@ instance Match [Elim' NLPat] Elims where
   match r gamma k (t, hd) _  [] = matchingBlocked $ NotBlocked ReallyNotBlocked ()
   match r gamma k (t, hd) (p:ps) (v:vs) =
    traceSDoc "rewriting.match" 50 (sep
-     [ "matching elimination " <+> addContext (gamma `abstract` k) (prettyTCM p)
+     [ "matching elimination " <+> addContext gamma (addContext k $ prettyTCM p)
      , "  with               " <+> addContext k (prettyTCM v)
      , "  eliminating head   " <+> addContext k (prettyTCM $ hd []) <+> ":" <+> addContext k (prettyTCM t)]) $ do
 
@@ -222,7 +222,7 @@ instance Match NLPSort Sort where
         yes = return ()
         no  = matchingBlocked $ NotBlocked ReallyNotBlocked ()
     traceSDoc "rewriting.match" 30 (sep
-      [ "matching pattern " <+> addContext (gamma `abstract` k) (prettyTCM p)
+      [ "matching pattern " <+> addContext gamma (addContext k $ prettyTCM p)
       , "  with sort      " <+> addContext k (prettyTCM s) ]) $ do
     case (p , s) of
       (PUniv u lp    , Univ u' l) | u == u'          -> match r gamma k () lp l
@@ -248,12 +248,19 @@ instance Match NLPat Level where
     match r gamma k t p v
 
 instance Match NLPat Term where
+  match :: Relevance  -- Are we currently matching in an irrelevant context?
+        -> Telescope  -- The telescope of pattern variables
+        -> Context    -- The context of lambda-bound variables
+        -> Type       -- The type of the pattern
+        -> NLPat      -- The pattern to match
+        -> Term       -- The term to be matched against the pattern
+        -> NLM ()
   match r0 gamma k t p v = do
     vbt <- addContext k $ reduceB (v,t)
     let n = size k
         b = void vbt
         (v,t) = ignoreBlocking vbt
-        prettyPat  = withShowAllArguments $ addContext (gamma `abstract` k) (prettyTCM p)
+        prettyPat  = withShowAllArguments $ addContext gamma $ addContext k $ prettyTCM p
         prettyTerm = withShowAllArguments $ addContext k $ prettyTCM v
         prettyType = withShowAllArguments $ addContext k $ prettyTCM t
     etaRecord <- addContext k $ isEtaRecordType t
@@ -293,14 +300,15 @@ instance Match NLPat Term where
           _          -> no ""
     case p of
       PVar i bvs -> traceSDoc "rewriting.match" 60 ("matching a PVar: " <+> text (show i)) $ do
+        let vars = map unArg bvs
         let allowedVars :: IntSet
-            allowedVars = IntSet.fromList (map unArg bvs)
+            allowedVars = IntSet.fromList vars
             badVars :: IntSet
             badVars = IntSet.difference (IntSet.fromList (downFrom n)) allowedVars
             perm :: Permutation
-            perm = Perm n $ reverse $ map unArg $ bvs
+            perm = Perm n $ reverse vars
             tel :: Telescope
-            tel = permuteTel perm k
+            tel = permuteContext perm k
         ok <- addContext k $ reallyFree badVars v
         case ok of
           Left b         -> block b
@@ -326,7 +334,7 @@ instance Match NLPat Term where
             let ai    = domInfo a
                 pbody = PDef f $ raise 1 ps ++ [ Apply $ Arg ai $ PTerm $ var 0 ]
                 body  = raise 1 v `apply` [ Arg (domInfo a) $ var 0 ]
-                k'    = ExtendTel a (Abs (absName b) k)
+            k' <- extendContext k (absName b) a
             match r gamma k' (absBody b) pbody body
           _ | Just (d, pars) <- etaRecord -> do
           -- If v is not of record constructor form but we are matching at record
@@ -349,17 +357,17 @@ instance Match NLPat Term where
       PLam i p' -> case unEl t of
         Pi a b -> do
           let body = raise 1 v `apply` [Arg i (var 0)]
-              k'   = ExtendTel a (Abs (absName b) k)
+          k' <- extendContext k (absName b) a
           match r gamma k' (absBody b) (absBody p') body
         _ | Left ((a,b),(x,y)) <- pview t -> do
           let body = raise 1 v `applyE` [ IApply (raise 1 x) (raise 1 y) $ var 0 ]
-              k'   = ExtendTel a (Abs "i" k)
+          k' <- extendContext k "i" a
           match r gamma k' (absBody b) (absBody p') body
         v -> maybeBlock v
       PPi pa pb -> case v of
         Pi a b -> do
           match r gamma k () pa a
-          let k' = ExtendTel a (Abs (absName b) k)
+          k' <- extendContext k (absName b) a
           match r gamma k' () (absBody pb) (absBody b)
         v -> maybeBlock v
       PSort ps -> case v of
@@ -367,13 +375,13 @@ instance Match NLPat Term where
         v -> maybeBlock v
       PBoundVar i ps -> case v of
         Var i' es | i == i' -> do
-          let ti = unDom $ indexWithDefault __IMPOSSIBLE__ (flattenTel k) i
+          let ti = maybe __IMPOSSIBLE__ (snd . unDom) $ lookupBV_ i k
           match r gamma k (ti , Var i) ps es
         _ | Pi a b <- unEl t -> do
           let ai    = domInfo a
               pbody = PBoundVar (1 + i) $ raise 1 ps ++ [ Apply $ Arg ai $ PTerm $ var 0 ]
               body  = raise 1 v `apply` [ Arg ai $ var 0 ]
-              k'    = ExtendTel a (Abs (absName b) k)
+          k' <- extendContext k (absName b) a
           match r gamma k' (absBody b) pbody body
         _ | Just (d, pars) <- etaRecord -> do
           def <- addContext k $ theDef <$> getConstInfo d
@@ -385,8 +393,12 @@ instance Match NLPat Term where
               match r gamma k (ct, Con c ci) (map Apply ps') (map Apply vs)
             Nothing -> no ""
         v -> maybeBlock v
-      PTerm u -> traceSDoc "rewriting.match" 60 ("matching a PTerm" <+> addContext (gamma `abstract` k) (prettyTCM u)) $
+      PTerm u -> traceSDoc "rewriting.match" 60 ("matching a PTerm" <+> addContext gamma (addContext k $ prettyTCM u)) $
         tellEq gamma k t u v
+
+extendContext :: MonadAddContext m => Context -> ArgName -> Dom Type -> m Context
+extendContext cxt x a = withFreshName empty x \ y -> return $ fmap (y,) a : cxt
+
 
 makeSubstitution :: Telescope -> Sub -> Maybe Substitution
 makeSubstitution gamma sub =
@@ -415,7 +427,7 @@ nonLinMatch gamma t p v = do
   let no msg b = traceSDoc "rewriting.match" 10 (sep
                    [ "matching failed during" <+> text msg
                    , "blocking: " <+> text (show b) ]) $ return (Left b)
-  caseEitherM (runNLM $ match Relevant gamma EmptyTel t p v) (no "matching") $ \ s -> do
+  caseEitherM (runNLM $ match Relevant gamma empty t p v) (no "matching") $ \ s -> do
     let msub = makeSubstitution gamma $ s ^. nlmSub
         eqs = s ^. nlmEqs
     traceSDoc "rewriting.match" 90 (text $ "msub = " ++ show msub) $ case msub of

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -17,6 +17,7 @@ import Data.Maybe
 import Data.Monoid
 
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
 
@@ -41,12 +42,22 @@ import qualified Agda.Utils.VarSet as VarSet
 
 import Agda.Utils.Impossible
 
--- | Flatten telescope: (Γ : Tel) -> [Type Γ]
+-- | Flatten telescope: @(Γ : Tel) -> [Type Γ]@
 flattenTel :: TermSubst a => Tele (Dom a) -> [Dom a]
 flattenTel EmptyTel          = []
 flattenTel (ExtendTel a tel) = raise (size tel + 1) a : flattenTel (absBody tel)
 
 {-# SPECIALIZE flattenTel :: Telescope -> [Dom Type] #-}
+
+-- | Turn a context into a flat telescope: all entries live in the whole context.
+-- @
+--    (Γ : Context) -> [Type Γ]
+-- @
+flattenContext :: Context -> [ContextEntry]
+flattenContext = loop 1 []
+  where
+    loop n tel []       = tel
+    loop n tel (ce:ctx) = loop (n + 1) (raise n ce : tel) ctx
 
 -- | Order a flattened telescope in the correct dependeny order: Γ ->
 --   Permutation (Γ -> Γ~)
@@ -161,6 +172,15 @@ permuteTel perm tel =
   let names = permute perm $ teleNames tel
       types = permute perm $ renameP impossible (flipP perm) $ flattenTel tel
   in  unflattenTel names types
+
+-- | Like 'permuteTel', but start with a context.
+--
+permuteContext :: Permutation -> Context -> Telescope
+permuteContext perm ctx = unflattenTel names types
+  where
+    flatTel = flattenContext ctx
+    names   = permute perm $ map (prettyShow . fst . unDom) flatTel
+    types   = permute perm $ renameP impossible (flipP perm) $ map (fmap snd) flatTel
 
 -- | Recursively computes dependencies of a set of variables in a given
 --   telescope. Any dependencies outside of the telescope are ignored.

--- a/test/Succeed/Issue7236.agda
+++ b/test/Succeed/Issue7236.agda
@@ -1,0 +1,113 @@
+-- Andreas, 2024-04-24, issue #7236
+-- Regression in higher-order rewriting
+-- introduced by commit 031c69df6ca2e4ae203a5809df0277c587f4f1a4
+-- Date:   Thu May 31 10:46:49 2018 +0200
+-- [ rewriting ] Make non-linear matching more type-directed
+--
+-- Problem: uses telescope for lambda-bound variables in higher-order pattern
+-- where a context would be correct.
+
+{-# OPTIONS --rewriting #-}
+
+-- {-# OPTIONS -v rewriting:60 #-}
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Agda.Builtin.List using (List; _∷_)
+
+postulate
+  ANY : {A : Set} → A
+
+data Ty : Set where
+    arr : Ty → Ty → Ty
+
+Ctx : Set
+Ctx = List Ty
+
+data Idx : Ctx → Ty → Set where
+    zero : {Γ : Ctx} {τ : Ty} → Idx (τ ∷ Γ) τ
+    suc : {Γ : Ctx} {τ₁ τ₂ : Ty} → Idx Γ τ₂ → Idx (τ₁ ∷ Γ) τ₂
+
+data Expr (Γ : Ctx) : Ty → Set where
+    var : {τ : Ty} → Idx Γ τ → Expr Γ τ
+    abstraction : {τ₁ τ₂ : Ty} → Expr (τ₁ ∷ Γ) τ₂ → Expr Γ (Ty.arr τ₁ τ₂)
+
+module Rename where
+
+    Rename : Ctx → Ctx → Set
+    Rename Γ Γ' = {τ : Ty} → Idx Γ τ → Idx Γ' τ
+
+    cons : {Γ Γ' : Ctx} {τ : Ty} → Idx Γ' τ → Rename Γ Γ' → Rename (τ ∷ Γ) Γ'
+    cons idx ρ Idx.zero = idx
+    cons idx ρ (Idx.suc idx') = ρ idx'
+
+    ext : {Γ Γ' : Ctx} {τ : Ty} → Rename Γ Γ' → Rename (τ ∷ Γ) (τ ∷ Γ')
+    ext ρ = cons Idx.zero (λ x → Idx.suc (ρ x))
+
+    rename : {Γ Γ' : Ctx} {τ : Ty} → Rename Γ Γ' → Expr Γ τ → Expr Γ' τ
+    rename ρ (Expr.var idx) = Expr.var (ρ idx)
+    rename ρ (Expr.abstraction e) = Expr.abstraction (rename (ext ρ) e)
+
+open Rename using (Rename)
+
+Subst : Ctx → Ctx → Set
+Subst Γ Γ' = {τ : Ty} → Idx Γ τ → Expr Γ' τ
+
+infixr 6 _•_
+_•_ : {Γ Γ' : Ctx} {τ : Ty} → Expr Γ' τ → Subst Γ Γ' → Subst (τ ∷ Γ) Γ'
+_•_ e σ Idx.zero = e
+_•_ e σ (Idx.suc idx) = σ idx
+
+⟰ : {Γ Γ' : Ctx} {τ : Ty} → Subst Γ Γ' → Subst Γ (τ ∷ Γ')
+⟰ σ idx = Rename.rename Idx.suc (σ idx)
+
+ext : {Γ Γ' : Ctx} {τ : Ty} → Subst Γ Γ' → Subst (τ ∷ Γ) (τ ∷ Γ')
+ext σ = Expr.var Idx.zero • ⟰ σ
+
+
+subst : {Γ Γ' : Ctx} {τ : Ty} (σ : Subst Γ Γ') → Expr Γ τ → Expr Γ' τ
+subst σ (Expr.var idx) = σ idx
+subst σ (Expr.abstraction e) = Expr.abstraction (subst (ext σ) e)
+
+ren : {Γ Γ' : Ctx} → Rename Γ Γ' → Subst Γ Γ'
+ren ρ x = Expr.var (ρ x)
+
+postulate
+
+    comp : {Γ Γ' Γ'' : Ctx} → Subst Γ Γ' → Subst Γ' Γ'' → Subst Γ Γ''
+    -- (σ ； σ') x = subst σ' (σ x)
+
+    seq-def : {Γ Γ' Γ'' : Ctx} {τ : Ty} (σ : Subst Γ Γ') (σ' : Subst Γ' Γ'') (idx : Idx Γ τ) → comp σ σ' idx ≡ subst σ' (σ idx)
+    -- seq-def σ σ' idx = refl
+
+{-# BUILTIN REWRITE _≡_ #-}
+{-# REWRITE seq-def #-}
+
+subst-ren : {Γ Γ' Γ'' : Ctx} {τ : Ty} (ρ : Rename Γ' Γ'') (σ : Subst Γ Γ') (e : Expr Γ τ) → subst (ren ρ) (subst σ e) ≡ subst (comp σ (ren ρ)) e
+subst-ren ρ σ (Expr.var idx) =  refl
+subst-ren ρ σ (Expr.abstraction e) with subst-ren (Rename.ext ρ) (ext σ) e
+... | x = ANY
+
+-- Error was:
+--
+--   Expected a hidden argument, but found a visible argument
+--   when checking that the type
+--   ...
+--   ≡
+--   abstraction
+--   (subst
+--    (var zero •
+--     (λ idx → Rename.rename suc (subst (λ z {τ} → var (ρ τ)) (σ idx))))
+--    e)
+--   of the generated with function is well-formed
+--
+-- Rewriting was faulty:
+--
+--   rewrote  comp σ (ren ρ) idx
+--        to  subst (λ z {τ} → var (ρ τ)) (σ idx)
+--
+-- Now:
+--
+--   rewrote  comp σ (ren ρ) idx
+--        to  subst (λ {τ} z → var (ρ z)) (σ idx)
+--
+-- Should succeed.


### PR DESCRIPTION
- **Debug #7236: print NLPat with hiding (was previously simply dropped)**
- **WIP: Fix #7236: context instead of telescope for lambda-bound pattern vars**

Closes #7236.