### PR TITLE
Build with GHC 9.10

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -200,10 +200,10 @@ flag optimise-heavily
 
 custom-setup
   setup-depends:
-    , base      >= 4.12.0.0 && < 4.20
-    , Cabal     >= 2.4.0.1  && < 3.11
+    , base      >= 4.12.0.0 && < 4.21
+    , Cabal     >= 2.4.0.1  && < 3.13
     , directory >= 1.3.3.0  && < 1.4
-    , filepath  >= 1.4.2.1  && < 1.5
+    , filepath  >= 1.4.2.1  && < 1.6
     , process   >= 1.6.3.0  && < 1.7
 
 -- Common stanzas
@@ -242,7 +242,6 @@ common language
       -Werror=overflowed-literals
       -Werror=overlapping-patterns
 --      -Werror=redundant-constraints
-      -Werror=semigroup
       -Werror=simplifiable-class-constraints
       -Werror=star-binder
       -Werror=star-is-type
@@ -266,6 +265,11 @@ common language
       -- See: https://gitlab.haskell.org/ghc/ghc/-/issues/13464
       -Wno-incomplete-patterns
       -Wno-overlapping-patterns
+
+  if impl(ghc < 9.10)
+    ghc-options:
+      -Werror=semigroup
+        -- The semigroup warning is deprecated in GHC 9.10
 
   if impl(ghc >= 8.8)
     ghc-options:
@@ -300,8 +304,12 @@ common language
 
   if impl(ghc >= 9.4)
     ghc-options:
-      -Werror=forall-identifier
       -Werror=type-equality-out-of-scope
+
+  if impl(ghc >= 9.4 && < 9.10)
+    ghc-options:
+      -Werror=forall-identifier
+        -- The forall-identifier warning is deprecated in GHC 9.10
 
   default-language: Haskell2010
 
@@ -403,7 +411,7 @@ library
     , ansi-terminal        >= 0.9       && < 1.2
     , array                >= 0.5.2.0   && < 0.6
     , async                >= 2.2       && < 2.3
-    , base                 >= 4.12.0.0  && < 4.20
+    , base                 >= 4.12.0.0  && < 4.21
     , binary               >= 0.8.6.0   && < 0.9
     , blaze-html           >= 0.8       && < 0.10
     , boxes                >= 0.1.3     && < 0.2
@@ -418,7 +426,7 @@ library
     , equivalence          >= 0.3.2     && < 0.5
     -- exceptions-0.8 instead of 0.10 because of stack
     , exceptions           >= 0.8       && < 0.11
-    , filepath             >= 1.4.2.1   && < 1.5
+    , filepath             >= 1.4.2.1   && < 1.6
     , ghc-compact          == 0.1.*
     , gitrev               >= 1.3.1     && < 2
     -- hashable 1.2.0.10 makes library-test 10x
@@ -441,7 +449,7 @@ library
     , STMonadTrans         >= 0.4.3     && < 0.5
     , strict               >= 0.4.0.1   && < 0.6
     , text                 >= 1.2.3.1   && < 2.2
-    , time                 >= 1.9.2     && < 1.13
+    , time                 >= 1.9.2     && < 1.15
     , transformers         >= 0.5.5.0   && < 0.7
     , unordered-containers >= 0.2.9.0   && < 0.3
         -- unordered-containers < 0.2.9 need base < 4.11
@@ -881,9 +889,9 @@ executable agda-mode
   autogen-modules:  Paths_Agda
   other-modules:    Paths_Agda
   build-depends:
-    , base      >= 4.12.0.0 && < 4.20
+    , base      >= 4.12.0.0 && < 4.21
     , directory >= 1.3.3.0  && < 1.4
-    , filepath  >= 1.4.2.1  && < 1.5
+    , filepath  >= 1.4.2.1  && < 1.6
     , process   >= 1.6.3.0  && < 1.7
   default-language: Haskell2010
 
@@ -988,7 +996,7 @@ test-suite agda-tests
     , mtl
     , process
     , process-extras   >= 0.3.0   && < 0.3.4 || >= 0.4.1.3 && < 0.5 || >= 0.7.1 && < 0.8
-    , QuickCheck       >= 2.14.1  && < 2.15
+    , QuickCheck       >= 2.14.1  && < 2.16
     , regex-tdfa
     , split
     , strict

--- a/src/full/Agda/Syntax/Parser/LexActions.hs
+++ b/src/full/Agda/Syntax/Parser/LexActions.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -Wunused-imports #-}
 
 {-| This module contains the building blocks used to construct the lexer.
@@ -24,7 +26,9 @@ import Control.Monad.State (modify)
 
 import Data.Bifunctor
 import Data.Char
+#if !MIN_VERSION_base(4,20,0)
 import Data.Foldable (foldl')
+#endif
 import Data.Maybe
 
 import Agda.Syntax.Common (pattern Ranged)

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -21,9 +21,10 @@ module Agda.Utils.List1
   ( module Agda.Utils.List1
   , module List1
   , module IsList
+  , module Unzip
   ) where
 
-import Prelude hiding (filter)
+import Prelude hiding (filter, unzip)
 
 import Control.Arrow ((&&&))
 import Control.Monad (filterM)
@@ -34,8 +35,15 @@ import Data.Function ( on )
 import qualified Data.List as List
 import qualified Data.Maybe as Maybe
 
-import Data.List.NonEmpty as List1 hiding (fromList, toList)
+import Data.List.NonEmpty as List1 hiding (fromList, toList, unzip)
 import qualified Data.List.NonEmpty as List1 (toList)
+
+-- Prevent warning -Wx-data-list-nonempty-unzip
+#if MIN_VERSION_base(4,19,0)
+import Data.Functor as Unzip (unzip)
+#else
+import Data.List.NonEmpty as Unzip (unzip)
+#endif
 
 import GHC.Exts as IsList ( IsList(..) )
 

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -Wunused-imports #-}
 
 -- | Small sets represented as a bitmask for fast membership checking.
@@ -39,7 +41,9 @@ import Prelude hiding (null)
 import Control.DeepSeq
 
 import Data.Word (Word64)
+#if !MIN_VERSION_base(4,20,0)
 import Data.List (foldl')
+#endif
 import Data.Bits hiding (complement)
 import qualified Data.Bits as Bits
 import Data.Ix


### PR DESCRIPTION
I built with GHC 9.10 locally, it seems that only warnings are affected, so 2.6.4.3 could be revised for GHC 9.10 as well.