### PR TITLE
Follow hlint suggestion: use empty

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -17,8 +17,8 @@
 # Warnings currently triggered by your code
 - ignore: {name: "Avoid lambda"} # 49 hints
 - ignore: {name: "Avoid lambda using `infix`"} # 13 hints
-- ignore: {name: "Eta reduce"} # 183 hints
-- ignore: {name: "Evaluate"} # 16 hints
+- ignore: {name: "Eta reduce"} # 182 hints
+- ignore: {name: "Evaluate"} # 15 hints
 - ignore: {name: "Functor law"} # 21 hints
 - ignore: {name: "Fuse foldMap/<$>"} # 2 hints
 - ignore: {name: "Fuse foldr/map"} # 8 hints
@@ -26,14 +26,14 @@
 - ignore: {name: "Fuse traverse/<$>"} # 2 hints
 - ignore: {name: "Hoist not"} # 18 hints
 - ignore: {name: "Move guards forward"} # 2 hints
-- ignore: {name: "Redundant $"} # 638 hints
-- ignore: {name: "Redundant <$>"} # 51 hints
-- ignore: {name: "Redundant <&>"} # 3 hints
+- ignore: {name: "Redundant $"} # 634 hints
+- ignore: {name: "Redundant <$>"} # 52 hints
+- ignore: {name: "Redundant <&>"} # 4 hints
 - ignore: {name: "Redundant True guards"} # 1 hint
 - ignore: {name: "Redundant bang pattern"} # 1 hint
-- ignore: {name: "Redundant bracket"} # 487 hints
+- ignore: {name: "Redundant bracket"} # 492 hints
 - ignore: {name: "Redundant case"} # 1 hint
-- ignore: {name: "Redundant flip"} # 2 hints
+- ignore: {name: "Redundant flip"} # 3 hints
 - ignore: {name: "Redundant fmap"} # 1 hint
 - ignore: {name: "Redundant guard"} # 5 hints
 - ignore: {name: "Redundant id"} # 1 hint
@@ -41,11 +41,11 @@
 - ignore: {name: "Redundant irrefutable pattern"} # 36 hints
 - ignore: {name: "Redundant lambda"} # 46 hints
 - ignore: {name: "Redundant map"} # 2 hints
-- ignore: {name: "Redundant multi-way if"} # 17 hints
+- ignore: {name: "Redundant multi-way if"} # 20 hints
 - ignore: {name: "Redundant return"} # 1 hint
 - ignore: {name: "Redundant section"} # 2 hints
-- ignore: {name: "Replace case with fromMaybe"} # 3 hints
-- ignore: {name: "Replace case with maybe"} # 3 hints
+- ignore: {name: "Replace case with fromMaybe"} # 4 hints
+- ignore: {name: "Replace case with maybe"} # 4 hints
 - ignore: {name: "Unused LANGUAGE pragma"} # 210 hints
 - ignore: {name: "Use &&"} # 4 hints
 - ignore: {name: "Use ++"} # 11 hints
@@ -64,7 +64,7 @@
 - ignore: {name: "Use concatMap"} # 2 hints
 - ignore: {name: "Use const"} # 79 hints
 - ignore: {name: "Use fewer imports"} # 6 hints
-- ignore: {name: "Use fmap"} # 5 hints
+- ignore: {name: "Use fmap"} # 6 hints
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use foldMap"} # 2 hints
 - ignore: {name: "Use fromMaybe"} # 1 hint
@@ -81,12 +81,12 @@
 - ignore: {name: "Use mapMaybe"} # 3 hints
 - ignore: {name: "Use maximum"} # 1 hint
 - ignore: {name: "Use negate"} # 1 hint
-- ignore: {name: "Use newtype instead of data"} # 30 hints
+- ignore: {name: "Use newtype instead of data"} # 31 hints
 - ignore: {name: "Use null"} # 5 hints
 - ignore: {name: "Use otherwise"} # 1 hint
-- ignore: {name: "Use record patterns"} # 90 hints
+- ignore: {name: "Use record patterns"} # 91 hints
 - ignore: {name: "Use second"} # 5 hints
-- ignore: {name: "Use section"} # 20 hints
+- ignore: {name: "Use section"} # 21 hints
 - ignore: {name: "Use sequenceA"} # 3 hints
 - ignore: {name: "Use uncurry"} # 1 hint
 - ignore: {name: "Use unless"} # 4 hints

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -63,7 +63,6 @@
 - ignore: {name: "Use camelCase"} # 72 hints
 - ignore: {name: "Use concatMap"} # 2 hints
 - ignore: {name: "Use const"} # 79 hints
-- ignore: {name: "Use empty"} # 1 hint
 - ignore: {name: "Use fewer imports"} # 6 hints
 - ignore: {name: "Use fmap"} # 5 hints
 - ignore: {name: "Use fold"} # 1 hint

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,6 +1,8 @@
 # HLint configuration file
 # https://github.com/ndmitchell/hlint#readme
 
+# We use hlint-3.8 and don't run HLint in CI.
+
 # Silence specific warnings
 - ignore:
     name: "Use curry"

--- a/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -747,7 +747,7 @@ g2 = Graph $ Map.fromList
 
 g3 = Graph $ Map.fromList
   [ (n 1, Map.fromList [(n 2,StrictPos)])
-  , (n 2, Map.fromList [])
+  , (n 2, Map.empty)
   , (n 4, Map.fromList [(n 1,StrictPos)])
   ]
 


### PR DESCRIPTION
See #6442. Follows use empty suggestion in a test.

On the one hand this disrupts the `Map.fromList` pattern in the test but on the other hand `Map.empty` is the same and is shorter (and skips the `[]` first pattern match of `Map.fromList`).