### PR TITLE
Refactor: use `SmallSet` for `funFlags`, make more boolean fields a `FunctionFlag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,14 +48,14 @@ Pragmas and options
   file where the function is used, and not necessarily in the file where it is defined.
   For example:
   ```agda
-  reverse-≡ : {l l' : List A} → reverse l ≡ reverse l' → reverse l ≡ reverse l'
-  reverse-≡ h = h
+  postulate
+    reverse-≡ : {l l' : List A} → reverse l ≡ reverse l' → reverse l ≡ reverse l'
 
-  []≡[] : {l l' : List A} → [] ≡ []
+  []≡[] : [] ≡ []
   []≡[] = reverse-≡ (refl {x = reverse []})
   ```
-  does not work since Agda won't solve `l` and `l'` for `[]`, even though it knows `reverse l = reverse []`. If `reverse` is
-  marked as injective with `{-# INJECTIVE_FOR_INFERENCE reverse #-}` this example will work.
+  does not work since Agda won't solve `l` and `l'` for `[]`, even though it knows `reverse l = reverse []`.
+  If `reverse` is marked as injective with `{-# INJECTIVE_FOR_INFERENCE reverse #-}` this example will work.
 
 Syntax
 ------

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -37,6 +37,7 @@ import Agda.Syntax.Common.Pretty
 import Agda.Syntax.Position
 
 import Agda.Utils.BiMap (HasTag(..))
+import Agda.Utils.Boolean (Boolean(fromBool), IsBool(toBool))
 import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List1  ( List1, pattern (:|), (<|) )
@@ -2382,6 +2383,14 @@ instance Semigroup IsAbstract where
 instance Monoid IsAbstract where
   mempty  = ConcreteDef
   mappend = (<>)
+
+instance Boolean IsAbstract where
+  fromBool True  = AbstractDef
+  fromBool False = ConcreteDef
+
+instance IsBool IsAbstract where
+  toBool AbstractDef = True
+  toBool ConcreteDef = False
 
 instance KillRange IsAbstract where
   killRange = id

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -161,7 +161,7 @@ instance NamesIn Defn where
     PrimitiveSort _ s  -> namesAndMetasIn' sg s
     AbstractDefn{}     -> __IMPOSSIBLE__
     -- Andreas 2017-07-27, Q: which names can be in @cc@ which are not already in @cl@?
-    Function cl cc _ _ _ _ _ _ _ _ _ el _ _ _
+    Function cl cc _ _ _ _ _ _ _ _ el _ _ _
       -> namesAndMetasIn' sg (cl, cc, el)
     Datatype _ _ cl cs s _ _ _ trX trD
       -> namesAndMetasIn' sg (cl, cs, s, trX, trD)

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -161,7 +161,7 @@ instance NamesIn Defn where
     PrimitiveSort _ s  -> namesAndMetasIn' sg s
     AbstractDefn{}     -> __IMPOSSIBLE__
     -- Andreas 2017-07-27, Q: which names can be in @cc@ which are not already in @cl@?
-    Function cl cc _ _ _ _ _ _ _ _ _ _ el _ _ _ _
+    Function cl cc _ _ _ _ _ _ _ _ _ _ el _ _ _
       -> namesAndMetasIn' sg (cl, cc, el)
     Datatype _ _ cl cs s _ _ _ trX trD
       -> namesAndMetasIn' sg (cl, cs, s, trX, trD)

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -161,7 +161,7 @@ instance NamesIn Defn where
     PrimitiveSort _ s  -> namesAndMetasIn' sg s
     AbstractDefn{}     -> __IMPOSSIBLE__
     -- Andreas 2017-07-27, Q: which names can be in @cc@ which are not already in @cl@?
-    Function cl cc _ _ _ _ _ _ _ _ _ _ el _ _ _
+    Function cl cc _ _ _ _ _ _ _ _ _ el _ _ _
       -> namesAndMetasIn' sg (cl, cc, el)
     Datatype _ _ cl cs s _ _ _ trX trD
       -> namesAndMetasIn' sg (cl, cs, s, trX, trD)

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -613,7 +613,7 @@ instance ToAbstract MaybeOldQName where
         return $ Just $ f $ AmbQ xs
 
       -- Note: user warnings on ambiguous names will be raised by the type checker,
-      -- see storeDiamsbiguatedName.
+      -- see 'storeDisambiguatedName'.
       raiseWarningsOnUsageIfUnambiguous :: List1 A.QName -> ScopeM ()
       raiseWarningsOnUsageIfUnambiguous = \case
         x :| [] -> raiseWarningsOnUsage x

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -54,6 +54,7 @@ import Agda.TypeChecking.Warnings (MonadWarning)
 import Agda.Interaction.Options
 
 import Agda.Utils.Functor
+import Agda.Utils.Lens
 import Agda.Utils.List1 (List1, pattern (:|))
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Monad
@@ -216,8 +217,8 @@ compareAs cmp a u v = do
           opts <- pragmaOptions
           let shortcut = case theDef def of
                 _ | optFirstOrder opts                       -> True
-                Function{funFirstOrder = True}
-                  | not $ optRequireUniqueMetaSolutions opts -> True
+                d@Function{}
+                  | not $ optRequireUniqueMetaSolutions opts -> d ^. funFirstOrder
                 _                                            -> False
           if not shortcut then fallback else unlessSubtyping $ do
           -- We do not shortcut projection-likes,

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -931,30 +931,18 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
   inTopContext $ forM_ (zip sortedMetas genRecFields) $ \ (meta, fld) -> do
     fieldTy <- getMetaType meta
     let field = unDom fld
-    addConstant' field (getArgInfo fld) field fieldTy $
-      let proj = Projection { projProper   = Just genRecName
-                            , projOrig     = field
-                            , projFromType = defaultArg genRecName
-                            , projIndex    = projIx
-                            , projLams     = ProjLams [defaultArg "gtel"] } in
-      Function { funClauses      = []
-               , funCompiled     = Nothing
-               , funSplitTree    = Nothing
-               , funTreeless     = Nothing
-               , funInv          = NotInjective
-               , funMutual       = Just []
-               , funAbstr        = ConcreteDef
-               , funProjection   = Right proj
-               , funErasure      = erasure
-               , funFlags        = Set.empty
-               , funTerminates   = Just True
-               , funExtLam       = Nothing
-               , funWith         = Nothing
-               , funCovering     = []
-               , funIsKanOp      = Nothing
-               , funOpaque       = TransparentDef
-               , funFirstOrder   = False
-               }
+    addConstant' field (getArgInfo fld) field fieldTy $ FunctionDefn $
+      (emptyFunctionData_ erasure)
+        { _funMutual     = Just []
+        , _funTerminates = Just True
+        , _funProjection = Right Projection
+          { projProper   = Just genRecName
+          , projOrig     = field
+          , projFromType = defaultArg genRecName
+          , projIndex    = projIx
+          , projLams     = ProjLams [defaultArg "gtel"]
+          }
+        }
   addConstant' (conName genRecCon) defaultArgInfo (conName genRecCon) __DUMMY_TYPE__ $ -- Filled in later
     Constructor { conPars   = 0
                 , conArity  = length genRecFields

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -283,9 +283,7 @@ markInjective :: QName -> TCM ()
 markInjective q = modifyGlobalDefinition q $ \def -> def { defInjective = True }
 
 markFirstOrder :: QName -> TCM ()
-markFirstOrder q = modifyGlobalDefinition q $ updateTheDef $ \case
-  def@Function{} -> def { funFirstOrder = True }
-  def            -> def
+markFirstOrder = setFunctionFlag FunFirstOrder True
 
 unionSignatures :: [Signature] -> Signature
 unionSignatures ss = foldr unionSignature emptySignature ss

--- a/src/full/Agda/TypeChecking/ProjectionLike.hs
+++ b/src/full/Agda/TypeChecking/ProjectionLike.hs
@@ -81,6 +81,7 @@ import Agda.TypeChecking.Telescope
 
 import Agda.TypeChecking.DropArgs
 
+import Agda.Utils.Lens
 import Agda.Utils.List
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
@@ -271,7 +272,7 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
     def@Function{funProjection = Left MaybeProjection, funClauses = cls,
                  funSplitTree = st0, funCompiled = cc0, funInv = NotInjective,
                  funMutual = Just [], -- Andreas, 2012-09-28: only consider non-mutual funs
-                 funAbstr = ConcreteDef, funOpaque = TransparentDef} -> do
+                 funOpaque = TransparentDef} | not (def ^. funAbstract) -> do
       ps0 <- filterM validProj $ candidateArgs [] t
       reportSLn "tc.proj.like" 30 $ if null ps0 then "  no candidates found"
                                                 else "  candidates: " ++ prettyShow ps0
@@ -326,7 +327,7 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
                                    }
     Function{funInv = Inverse{}} ->
       reportSLn "tc.proj.like" 30 $ "  injective functions can't be projections"
-    Function{funAbstr = AbstractDef} ->
+    d@Function{} | d ^. funAbstract ->
       reportSLn "tc.proj.like" 30 $ "  abstract functions can't be projections"
     Function{funOpaque = OpaqueDef _} ->
       reportSLn "tc.proj.like" 30 $ "  opaque functions can't be projections"
@@ -338,6 +339,7 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
       reportSLn "tc.proj.like" 30 $ "  mutual functions can't be projections"
     Function{funMutual = Nothing} ->
       reportSLn "tc.proj.like" 30 $ "  mutuality check has not run yet"
+    Function{} -> __IMPOSSIBLE__ -- match is complete, but GHC does not see this (because of d^.funAbstract)
     Axiom{}        -> reportSLn "tc.proj.like" 30 $ "  not a function, but Axiom"
     DataOrRecSig{} -> reportSLn "tc.proj.like" 30 $ "  not a function, but DataOrRecSig"
     GeneralizableVar{} -> reportSLn "tc.proj.like" 30 $ "  not a function, but GeneralizableVar"

--- a/src/full/Agda/TypeChecking/ReconstructParameters.hs
+++ b/src/full/Agda/TypeChecking/ReconstructParameters.hs
@@ -23,9 +23,10 @@ import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records
 import Agda.TypeChecking.Datatypes
 
-import Agda.Utils.Size
 import Agda.Utils.Either
 import Agda.Utils.Function (applyWhen)
+import Agda.Utils.Lens
+import Agda.Utils.Size
 
 import Agda.Utils.Impossible
 
@@ -156,8 +157,8 @@ extractParameters q ty = reduce (unEl ty) >>= \case
        -- Case: regular projection
        | isProperProjection (theDef info) ->
          case theDef info of
-           Function{ funErasure = e } ->
-             return $ map (mkParam e) postPs
+           d@Function{} ->
+             return $ map (mkParam (d ^. funErasure)) postPs
            _ -> __IMPOSSIBLE__
        -- Case: projection-like function
        | otherwise -> do

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -676,7 +676,8 @@ checkAxiom' gentel kind i info0 mp x e = whenAbstractFreezeMetasAfter i $ defaul
           RecName   -> DataOrRecSig npars
           AxiomName -> defaultAxiom     -- Old comment: NB: used also for data and record type sigs
           _         -> __IMPOSSIBLE__
-        where fun = FunctionDefn funD{ _funAbstr = Info.defAbstract i, _funOpaque = Info.defOpaque i }
+        where
+          fun = FunctionDefn $ set funAbstr_ (Info.defAbstract i) funD{ _funOpaque = Info.defOpaque i }
 
   addConstant x =<< do
     useTerPragma $ defn

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -192,9 +192,10 @@ checkAlias t ai i name e mc =
 
   -- Add the definition
   fun <- emptyFunctionData
-  addConstant' name ai name t $ set funMacro (Info.defMacro i == MacroDef) $
-      FunctionDefn fun
-          { _funClauses   = [ Clause  -- trivial clause @name = v@
+  addConstant' name ai name t $ FunctionDefn $
+    set funMacro_ (Info.defMacro i == MacroDef) $
+    set funAbstr_ (Info.defAbstract i) $
+      fun { _funClauses   = [ Clause  -- trivial clause @name = v@
               { clauseLHSRange    = getRange i
               , clauseFullRange   = getRange i
               , clauseTel         = EmptyTel
@@ -210,7 +211,6 @@ checkAlias t ai i name e mc =
               } ]
           , _funCompiled  = Just $ Done [] $ bodyMod v
           , _funSplitTree = Just $ SplittingDone 0
-          , _funAbstr     = Info.defAbstract i
           , _funOpaque    = Info.defOpaque i
           }
 
@@ -435,14 +435,14 @@ checkFunDefS t ai extlam with i name withSubAndLets cs = do
           -- If there was a pragma for this definition, we can set the
           -- funTerminates field directly.
           fun  <- emptyFunctionData
-          defn <- autoInline $
-             set funMacro (ismacro || Info.defMacro i == MacroDef) $
-             FunctionDefn fun
+          defn <- autoInline $ FunctionDefn $
+           set funMacro_ (ismacro || Info.defMacro i == MacroDef) $
+           set funAbstr_ (Info.defAbstract i) $
+           fun
              { _funClauses        = cs
              , _funCompiled       = Just cc
              , _funSplitTree      = mst
              , _funInv            = inv
-             , _funAbstr          = Info.defAbstract i
              , _funOpaque         = Info.defOpaque i
              , _funExtLam         = (\ e -> e { extLamSys = sys }) <$> extlam
              , _funWith           = with

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240411 * 10 + 0
+currentInterfaceVersion = 20240503 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -54,6 +54,7 @@ import Agda.Utils.List2 (List2(List2))
 import qualified Agda.Utils.List2 as List2
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Null
+import Agda.Utils.SmallSet (SmallSet(..))
 import Agda.Utils.Trie (Trie(..))
 import Agda.Utils.WithDefault
 
@@ -269,6 +270,10 @@ instance (Ord a, EmbPrj a) => EmbPrj (Set a) where
 instance EmbPrj IntSet where
   icod_ s = icode (IntSet.toAscList s)
   value s = IntSet.fromDistinctAscList <$!> value s
+
+instance Typeable a => EmbPrj (SmallSet a) where
+  icod_ (SmallSet a) = icodeN' SmallSet a
+  value = valueN SmallSet
 
 instance (Ord a, EmbPrj a, EmbPrj b) => EmbPrj (Trie a b) where
   icod_ (Trie a b)= icodeN' Trie a b

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -421,7 +421,7 @@ instance EmbPrj BuiltinSort where
 
 instance EmbPrj Defn where
   icod_ (Axiom       a)                                 = icodeN 0 Axiom a
-  icod_ (Function    a b s t u c d e f g h i j k l)     = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k l
+  icod_ (Function    a b s t u c d e f g h i j k)       = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k
   icod_ (Datatype    a b c d e f g h i j)               = icodeN 2 Datatype a b c d e f g h i j
   icod_ (Record      a b c d e f g h i j k l m)         = icodeN 3 Record a b c d e f g h i j k l m
   icod_ (Constructor a b c d e f g h i j k)             = icodeN 4 Constructor a b c d e f g h i j k
@@ -433,8 +433,8 @@ instance EmbPrj Defn where
 
   value = vcase valu where
     valu [0, a]                                        = valuN Axiom a
-    valu [1, a, b, s, u, c, d, e, f, g, h, i, j, k, l]
-                                                       = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k l
+    valu [1, a, b, s, u, c, d, e, f, g, h, i, j, k]
+                                                       = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k
     valu [2, a, b, c, d, e, f, g, h, i, j]             = valuN Datatype a b c d e f g h i j
     valu [3, a, b, c, d, e, f, g, h, i, j, k, l, m]    = valuN Record   a b c d e f g h i j k l m
     valu [4, a, b, c, d, e, f, g, h, i, j, k]          = valuN Constructor a b c d e f g h i j k

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -421,7 +421,7 @@ instance EmbPrj BuiltinSort where
 
 instance EmbPrj Defn where
   icod_ (Axiom       a)                                 = icodeN 0 Axiom a
-  icod_ (Function    a b s t u c d e f g h i j k l m)   = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k l m
+  icod_ (Function    a b s t u c d e f g h i j k l)     = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k l
   icod_ (Datatype    a b c d e f g h i j)               = icodeN 2 Datatype a b c d e f g h i j
   icod_ (Record      a b c d e f g h i j k l m)         = icodeN 3 Record a b c d e f g h i j k l m
   icod_ (Constructor a b c d e f g h i j k)             = icodeN 4 Constructor a b c d e f g h i j k
@@ -433,8 +433,8 @@ instance EmbPrj Defn where
 
   value = vcase valu where
     valu [0, a]                                        = valuN Axiom a
-    valu [1, a, b, s, u, c, d, e, f, g, h, i, j, k, l, m]
-                                                       = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k l m
+    valu [1, a, b, s, u, c, d, e, f, g, h, i, j, k, l]
+                                                       = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k l
     valu [2, a, b, c, d, e, f, g, h, i, j]             = valuN Datatype a b c d e f g h i j
     valu [3, a, b, c, d, e, f, g, h, i, j, k, l, m]    = valuN Record   a b c d e f g h i j k l m
     valu [4, a, b, c, d, e, f, g, h, i, j, k]          = valuN Constructor a b c d e f g h i j k

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -421,7 +421,7 @@ instance EmbPrj BuiltinSort where
 
 instance EmbPrj Defn where
   icod_ (Axiom       a)                                 = icodeN 0 Axiom a
-  icod_ (Function    a b s t u c d e f g h i j k l m o) = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k l m o
+  icod_ (Function    a b s t u c d e f g h i j k l m)   = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k l m
   icod_ (Datatype    a b c d e f g h i j)               = icodeN 2 Datatype a b c d e f g h i j
   icod_ (Record      a b c d e f g h i j k l m)         = icodeN 3 Record a b c d e f g h i j k l m
   icod_ (Constructor a b c d e f g h i j k)             = icodeN 4 Constructor a b c d e f g h i j k
@@ -433,8 +433,8 @@ instance EmbPrj Defn where
 
   value = vcase valu where
     valu [0, a]                                        = valuN Axiom a
-    valu [1, a, b, s, u, c, d, e, f, g, h, i, j, k, l, m, o]
-                                                       = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k l m o
+    valu [1, a, b, s, u, c, d, e, f, g, h, i, j, k, l, m]
+                                                       = valuN (\ a b s -> Function a b s Nothing) a b s u c d e f g h i j k l m
     valu [2, a, b, c, d, e, f, g, h, i, j]             = valuN Datatype a b c d e f g h i j
     valu [3, a, b, c, d, e, f, g, h, i, j, k, l, m]    = valuN Record   a b c d e f g h i j k l m
     valu [4, a, b, c, d, e, f, g, h, i, j, k]          = valuN Constructor a b c d e f g h i j k
@@ -472,16 +472,7 @@ instance EmbPrj a => EmbPrj (SplitTree' a) where
     valu [0, a, b, c] = valuN SplitAt a b c
     valu _            = malformed
 
-instance EmbPrj FunctionFlag where
-  icod_ FunStatic       = pure 0
-  icod_ FunInline       = pure 1
-  icod_ FunMacro        = pure 2
-
-  value = \case
-    0 -> pure FunStatic
-    1 -> pure FunInline
-    2 -> pure FunMacro
-    _ -> malformed
+instance EmbPrj FunctionFlag
 
 instance EmbPrj a => EmbPrj (WithArity a) where
   icod_ (WithArity a b) = icodeN' WithArity a b

--- a/src/full/Agda/Utils/Lens.hs
+++ b/src/full/Agda/Utils/Lens.hs
@@ -55,6 +55,9 @@ set l = over l . const
 over :: Lens' o i -> LensMap o i
 over l f o = runIdentity $ l (Identity . f) o
 
+-- | Build a lens out of an isomorphism.
+iso :: (o -> i) -> (i -> o) -> Lens' o i
+iso get set f = fmap set . f . get
 
 -- * State accessors and modifiers using 'StateT'.
 

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -15,7 +15,7 @@
 -- @
 
 module Agda.Utils.SmallSet
-  ( SmallSet()
+  ( SmallSet(..)
   , SmallSetElement
   , Ix
   , (\\)

--- a/test/Succeed/InjectiveForInferencePragma.agda
+++ b/test/Succeed/InjectiveForInferencePragma.agda
@@ -1,10 +1,15 @@
+-- Andre Knispel, Ulf, PR #6640, patched 2024-03-05 by Andreas
+
 {-# OPTIONS --no-require-unique-meta-solutions #-}
+
 module InjectiveForInferencePragma where
 
 open import Agda.Builtin.Equality
-open import Agda.Builtin.List
 
-module _ {A : Set} where
+module Concrete {A : Set} where
+
+  open import Agda.Builtin.List
+
   _++_ : List A → List A → List A
   []       ++ ys = ys
   (x ∷ xs) ++ ys = x ∷ (xs ++ ys)
@@ -15,8 +20,37 @@ module _ {A : Set} where
 
   {-# INJECTIVE_FOR_INFERENCE reverse #-}
 
-  reverse-≡ : {l l' : List A} → reverse l ≡ reverse l' → reverse l ≡ reverse l'
-  reverse-≡ h = h
+  postulate
+    reverse-≡ : {l l' : List A} → reverse l ≡ reverse l' → reverse l ≡ reverse l'
+    -- or define as: reverse-≡ h = h
 
-  []≡[] : {l l' : List A} → [] ≡ []
+  []≡[] : [] ≡ []
   []≡[] = reverse-≡ (refl {x = reverse []})
+
+  -- Without lossy unification for `reverse`, Agda won't solve `l` and `l'` for `[]`,
+  -- even though it knows `reverse l = reverse []`.
+
+module Abstract {A : Set} where
+
+  data List : Set where
+    [] : List
+    _∷_ : A → List → List
+
+  _++_ : List → List → List
+  []       ++ ys = ys
+  (x ∷ xs) ++ ys = x ∷ (xs ++ ys)
+
+  abstract
+    reverse : List → List
+    reverse []      = []
+    reverse (x ∷ l) = reverse l ++ (x ∷ [])
+
+  -- The pragma also works on abstract definitions.
+  {-# INJECTIVE_FOR_INFERENCE reverse #-}
+
+  postulate
+    reverse-≡ : {l l' : List} → reverse l ≡ reverse l' → reverse l ≡ reverse l'
+
+  abstract
+    []≡[] : [] ≡ []
+    []≡[] = reverse-≡ (refl {x = reverse []})


### PR DESCRIPTION
- enhanced test for #6640 
- optimize `FunctionData`: `SmallSet` for `funFlags`, make boolean fields into `FunctionFlag`s

Commits tested individually.