### PR TITLE
Follow hlint suggestion: redundant section

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -45,7 +45,6 @@
 - ignore: {name: "Redundant map"} # 2 hints
 - ignore: {name: "Redundant multi-way if"} # 20 hints
 - ignore: {name: "Redundant return"} # 1 hint
-- ignore: {name: "Redundant section"} # 2 hints
 - ignore: {name: "Replace case with fromMaybe"} # 4 hints
 - ignore: {name: "Replace case with maybe"} # 4 hints
 - ignore: {name: "Unused LANGUAGE pragma"} # 210 hints

--- a/src/full/Agda/TypeChecking/CompiledClause/Match.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Match.hs
@@ -156,7 +156,7 @@ match' ((c, es, patch) : stack) = do
             --    mo <- getBuiltinName' builtinIOne
             --    return $ Set.fromList $ catMaybes [mi,mo]
 
-            fallThrough <- return $ (Just True ==) (fallThrough bs) && isJust (catchAllBranch bs)
+            fallThrough <- return $ Just True == fallThrough bs && isJust (catchAllBranch bs)
 
             let
               isCon b =

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -394,7 +394,7 @@ fastCase env (Branches proj con _ lit wild fT _) =
     , fconBranches    = Map.mapKeysMonotonic (nameId . qnameName) $ fmap (fastCompiledClauses env . content) (stripSuc con)
     , fsucBranch      = fmap (fastCompiledClauses env . content) $ flip Map.lookup con . conName =<< bSuc env
     , flitBranches    = fmap (fastCompiledClauses env) lit
-    , ffallThrough    = (Just True ==) fT
+    , ffallThrough    = Just True == fT
     , fcatchAllBranch = fmap (fastCompiledClauses env) wild }
   where
     stripSuc | Just c <- bSuc env = Map.delete (conName c)


### PR DESCRIPTION
See #6442. Applies the redundant section suggestion of HLint.

Removing the `*.CompiledClause.Match` module redundant section exposed one more redundant bracket. Rather than have that count increase, I removed the redundant bracket too.