### PR TITLE
Reflection & erasure, improving quality of life

### DIFF
--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -325,7 +325,8 @@ below <reflection-tc-monad>`.
     data-type   : (pars : Nat) (cs : List Name) → Definition  -- parameters and constructors
     record-type : (c : Name) (fs : List (Arg Name)) →         -- c: name of record constructor
                   Definition                                  -- fs: fields
-    data-cons   : (d : Name) → Definition                     -- d: name of data type
+    data-cons   : (d : Name) (q : Quantity) → Definition      -- d: name of data type
+                                                              -- q: constructor quantity
     axiom       : Definition
     prim-fun    : Definition
 

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -247,7 +247,7 @@ data Definition : Set where
   function    : (cs : List Clause) → Definition
   data-type   : (pars : Nat) (cs : List Name) → Definition
   record-type : (c : Name) (fs : List (Arg Name)) → Definition
-  data-cons   : (d : Name) → Definition
+  data-cons   : (d : Name) (q : Quantity) → Definition
   axiom       : Definition
   prim-fun    : Definition
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3787,6 +3787,8 @@ data TCEnv =
           , envCurrentlyElaborating :: Bool
                 -- ^ Are we currently in the process of executing an
                 --   elaborate-and-give interactive command?
+          , envInsideReflection :: Bool
+                -- ^ Are we currently inside a macro or some other reflection code?
           , envSyntacticEqualityFuel :: !(Strict.Maybe Int)
                 -- ^ If this counter is 'Strict.Nothing', then
                 -- syntactic equality checking is unrestricted. If it
@@ -3865,6 +3867,7 @@ initEnv = TCEnv { envContext             = []
                 , envActiveBackendName      = Nothing
                 , envConflComputingOverlap  = False
                 , envCurrentlyElaborating   = False
+                , envInsideReflection       = False
                 , envSyntacticEqualityFuel  = Strict.Nothing
                 , envCurrentOpaqueId        = Nothing
                 }
@@ -4059,6 +4062,9 @@ eConflComputingOverlap f e = f (envConflComputingOverlap e) <&> \ x -> e { envCo
 
 eCurrentlyElaborating :: Lens' TCEnv Bool
 eCurrentlyElaborating f e = f (envCurrentlyElaborating e) <&> \ x -> e { envCurrentlyElaborating = x }
+
+eInsideReflection :: Lens' TCEnv Bool
+eInsideReflection f e = f (envInsideReflection e) <&> \ x -> e { envInsideReflection = x }
 
 {-# SPECIALISE currentModality :: TCM Modality #-}
 -- | The current modality.

--- a/src/full/Agda/TypeChecking/Monad/Modality.hs
+++ b/src/full/Agda/TypeChecking/Monad/Modality.hs
@@ -44,6 +44,11 @@ hideAndRelParams = hideOrKeepInstance . mapRelevance nonStrictToIrr
 
 -- * Operations on 'Context'.
 
+insideReflection :: (MonadTCEnv m, HasOptions m, MonadDebug m)
+                 => m a -> m a
+insideReflection cont = do
+  verboseBracket "tc.irr" 60 "insideReflection" $ localTC (\ e -> e { envInsideReflection = True }) cont
+
 -- | Modify the context whenever going from the l.h.s. (term side)
 --   of the typing judgement to the r.h.s. (type side).
 workOnTypes :: (MonadTCEnv m, HasOptions m, MonadDebug m)

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -339,8 +339,9 @@ quotingKit = do
             agdaDefinitionFunDef !@ quoteList (quoteClause (Left ())) cs
           Primitive{}   -> pure agdaDefinitionPrimitive
           PrimitiveSort{} -> pure agdaDefinitionPrimitive
-          Constructor{conData = d} ->
-            agdaDefinitionDataConstructor !@! quoteName d
+          Constructor{conData = d, conSrcCon = c} -> do
+            q <- getQuantity <$> getConstInfo (conName c)
+            agdaDefinitionDataConstructor !@! quoteName d @@ quoteQuantity q
 
   return $ QuotingKit quoteTerm quoteType (quoteDom quoteType) quoteDefn quoteList
 

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -927,7 +927,9 @@ checkConstructorApplication cmp org t c args = do
 
   cdef  <- getConInfo c
 
-  checkModality (conName c) cdef
+  ir <- asksTC envInsideReflection
+  let go = if ir then workOnTypes else id
+  go $ checkModality (conName c) cdef
 
   let paramsGiven = checkForParams args
   if paramsGiven then fallback else do

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -355,7 +355,7 @@ coreBuiltins =
                                                                   ,builtinAgdaDefinitionPrimitive])
   , (builtinAgdaDefinitionFunDef             |-> BuiltinDataCons (tlist tclause --> tdefn))
   , (builtinAgdaDefinitionDataDef            |-> BuiltinDataCons (tnat --> tlist tqname --> tdefn))
-  , (builtinAgdaDefinitionDataConstructor    |-> BuiltinDataCons (tqname --> tdefn))
+  , (builtinAgdaDefinitionDataConstructor    |-> BuiltinDataCons (tqname --> tquantity --> tdefn))
   , (builtinAgdaDefinitionRecordDef          |-> BuiltinDataCons (tqname --> tlist (targ tqname) --> tdefn))
   , (builtinAgdaDefinitionPostulate          |-> BuiltinDataCons tdefn)
   , (builtinAgdaDefinitionPrimitive          |-> BuiltinDataCons tdefn)

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -794,7 +794,7 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
     tcNormalise :: R.Term -> TCM Term
     tcNormalise v = do
       r <- isReconstructed
-      (v, t) <- locallyReduceAllDefs $ inferExpr  =<< toAbstract_ v
+      (v, t) <- workOnTypes $ locallyReduceAllDefs $ inferExpr  =<< toAbstract_ v
       if r then do
         v <- normalise v
         t <- normalise t
@@ -807,7 +807,7 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
     tcReduce :: R.Term -> TCM Term
     tcReduce v = do
       r <- isReconstructed
-      (v, t) <- locallyReduceAllDefs $ inferExpr =<< toAbstract_ v
+      (v, t) <- workOnTypes $ locallyReduceAllDefs $ inferExpr =<< toAbstract_ v
       if r then do
         v <- reduce =<< instantiateFull v
         t <- reduce =<< instantiateFull t
@@ -1068,7 +1068,7 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
       let
         i' = mkDefInfo (nameConcrete $ qnameName x) noFixity' accessDontCare ac noRange
         i = i' { Info.defOpaque = oc }
-      locallyReduceAllDefs $ checkFunDef i x cs
+      insideReflection $ locallyReduceAllDefs $ checkFunDef i x cs
       primUnitUnit
 
     tcPragmaForeign :: Text -> Text -> TCM Term

--- a/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
+++ b/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
@@ -186,7 +186,7 @@ data Definition : Set where
   function    : (cs : List Clause) → Definition
   data-type   : (pars : Nat) (cs : List Name) → Definition
   record-type : (c : Name) (fs : List (Arg Name)) → Definition
-  data-cons   : (d : Name) → Definition
+  data-cons   : (d : Name) (q : Quantity) → Definition
   axiom       : Definition
   prim-fun    : Definition
 

--- a/test/Succeed/Issue2165.agda
+++ b/test/Succeed/Issue2165.agda
@@ -10,8 +10,8 @@ infixl 5 _>>=_
 _>>=_ = bindTC
 
 defToTerm : Name → Definition → List (Arg Term) → Term
-defToTerm _ (function cs) as = pat-lam cs as
-defToTerm _ (data-cons d) as = con d as
+defToTerm _ (function cs)   as = pat-lam cs as
+defToTerm _ (data-cons d _) as = con d as
 defToTerm _ _ _ = unknown
 
 derefImmediate : Term → TC Term

--- a/test/Succeed/Issue2203.agda
+++ b/test/Succeed/Issue2203.agda
@@ -10,8 +10,8 @@ infixl 5 _>>=_
 _>>=_ = bindTC
 
 defToTerm : Name → Definition → List (Arg Term) → Term
-defToTerm _ (function cs) as = pat-lam cs as
-defToTerm _ (data-cons d) as = con d as
+defToTerm _ (function cs)   as = pat-lam cs as
+defToTerm _ (data-cons d _) as = con d as
 defToTerm _ _ _ = unknown
 
 data Tm : Set where

--- a/test/Succeed/Issue2226.agda
+++ b/test/Succeed/Issue2226.agda
@@ -93,8 +93,8 @@ bar₂-def =  refl
 --- Originally reported test case ---
 
 defToTerm : Name → Definition → List (Arg Term) → Term
-defToTerm _ (function cs) as = pat-lam cs as
-defToTerm _ (data-cons d) as = con d as
+defToTerm _ (function cs)   as = pat-lam cs as
+defToTerm _ (data-cons d _) as = con d as
 defToTerm _ _ _ = unknown
 
 derefImmediate : Term → TC Term

--- a/test/Succeed/Issue2404.agda
+++ b/test/Succeed/Issue2404.agda
@@ -10,8 +10,8 @@ pure = returnTC
 
 
 defToTerm : Name → Definition → List (Arg Term) → Term
-defToTerm _ (function cs) as = pat-lam cs as
-defToTerm _ (data-cons d) as = con d as
+defToTerm _ (function cs)   as = pat-lam cs as
+defToTerm _ (data-cons d _) as = con d as
 defToTerm _ _ _ = unknown
 
 derefImmediate : Term → TC Term

--- a/test/Succeed/ReflectionGetDef.agda
+++ b/test/Succeed/ReflectionGetDef.agda
@@ -1,0 +1,35 @@
+{-# OPTIONS --safe --cubical --erasure #-}
+module ReflectionGetDef where
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Unit
+open import Agda.Primitive
+
+_>>=_ : {a b : Level} {A : Set a} {B : Set b} → TC A → (A → TC B) → TC B
+_>>=_ = bindTC
+
+_>>_ : {a b : Level} {A : Set a} {B : Set b} → TC A → TC B → TC B
+_>>_ = λ mx my → bindTC mx λ _ → my
+
+refl : {a : Level} {A : Set a} {x : A} → x ≡ x
+refl {_} {_} {x} = λ i → x
+
+data S¹ : Set where
+  base : S¹
+  @0 loop : base ≡ base
+
+macro
+  erased? : Name → Term → TC ⊤
+  erased? n hole = do
+    data-cons d q ← getDefinition n
+      where _ → typeError []
+    `q ← quoteTC q
+    unify hole `q
+
+_ : erased? base ≡ quantity-ω
+_ = refl
+
+_ : erased? loop ≡ quantity-0
+_ = refl


### PR DESCRIPTION
* Fix `tcReduce`/`tcNormalise`/`tcDefineFun` handling of data constructor types with erased parameters
* Add TC env flag telling us whether we're typechecking reflected code
* Expose run-time irrelevance of constructors in the reflection interface

Now it's possible to generate eliminators for datatypes with erased params and _constructors_.

Related issues:
- #7234 
- #6400 

Please help me to improve this code. If it's safe, maybe it would be nice to replace some `workOnTypes` occurences by `insideReflection`, so the decision to set context quantity to zero is deferred somewhere deeper in the call tree. Also I didn't check if programmatically generating datatypes with erased constructors worked neither without nor with this patch.