### PR TITLE
Overhaul dead code elimination, make --save-metas the default

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1135,10 +1135,13 @@ Other features
 
      .. versionadded:: 2.6.3
 
-     Save [or do not save] meta-variables in ``.agdai`` files. The
-     alternative is to expand the meta-variables to their definitions.
-     This option can affect performance. The default is to not save
-     the meta-variables.
+     Save [or do not save] meta-variables in ``.agdai`` files. Not saving means
+     that all meta-variable solutions are inlined into the interface. Currently,
+     even if :option:`--save-metas` is used, very few meta-variables are
+     actually saved, and this option is more like an anticipation of possible
+     future optimizations.
+
+     Default: :option:`--save-metas`.
 
 Erasure
 ~~~~~~~

--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -51,7 +51,7 @@ data Phase
     -- ^ Writing interface files.
   | DeadCode
     -- ^ Dead code elimination.
-  | DeadCodeInstantiateFull
+  | InterfaceInstantiateFull
     -- ^ Unfolding all metas before serialization.
   | DeadCodeReachable
     -- ^ Dead code reachable definitions subphase.

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -23,7 +23,6 @@ module Agda.Compiler.Backend
 import Agda.Compiler.Backend.Base
 
 import Control.DeepSeq
-import Control.Monad              ( (<=<) )
 import Control.Monad.Trans        ( lift )
 import Control.Monad.Trans.Maybe
 
@@ -186,11 +185,11 @@ compilerMain backend isMain0 checkResult = inCompilerEnv checkResult $ do
         "The --only-scope-checking flag cannot be combined with " ++
         backendName backend ++ "."
 
-    let i = crInterface checkResult
+    !i <- instantiateFull $ crInterface checkResult
     -- Andreas, 2017-08-23, issue #2714
     -- If the backend is invoked from Emacs, we can only get the --no-main
     -- pragma option now, coming from the interface file.
-    isMain <- ifM (optCompileNoMain <$> pragmaOptions)
+    !isMain <- ifM (optCompileNoMain <$> pragmaOptions)
       {-then-} (return NotMain)
       {-else-} (return isMain0)
 
@@ -220,7 +219,7 @@ compileModule backend env isMain i = do
     Skip m         -> return m
     Recompile menv -> do
       defs <- map snd . sortDefs <$> curDefs
-      res  <- mapM (compileDef' backend env menv isMain <=< instantiateFull) defs
+      res  <- mapM (compileDef' backend env menv isMain) defs
       postModule backend env menv isMain (iTopLevelModuleName i) res
 
 compileDef' :: Backend' opts env menv mod def -> env -> menv -> IsMain -> Definition -> TCM def

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -425,7 +425,7 @@ data PragmaOptions = PragmaOptions
       --   This is a stronger form of 'optImportSorts'.
   , _optAllowExec                 :: WithDefault 'False
       -- ^ Allow running external @executables@ from meta programs.
-  , _optSaveMetas                 :: WithDefault 'False
+  , _optSaveMetas                 :: WithDefault 'True
       -- ^ Save meta-variables to interface files.
   , _optShowIdentitySubstitutions :: WithDefault 'False
       -- ^ Show identity substitutions when pretty-printing terms

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -192,7 +192,7 @@ instance NamesIn (Pattern' a) where
     VarP _ _        -> mempty
     LitP _ l        -> namesAndMetasIn' sg l
     DotP _ v        -> namesAndMetasIn' sg v
-    ConP c _ args   -> namesAndMetasIn' sg (c, args)
+    ConP c cpi args -> namesAndMetasIn' sg (c, cpi, args)
     DefP o q args   -> namesAndMetasIn' sg (q, args)
     ProjP _ f       -> namesAndMetasIn' sg f
     IApplyP _ t u _ -> namesAndMetasIn' sg (t, u)
@@ -372,6 +372,9 @@ instance NamesIn Compiled where
 newtype PSyn = PSyn A.PatternSynDefn
 instance NamesIn PSyn where
   namesAndMetasIn' sg (PSyn (_args, p)) = namesAndMetasIn' sg p
+
+instance NamesIn ConPatternInfo where
+  namesAndMetasIn' sg (ConPatternInfo _ _ _ ty _) = namesAndMetasIn' sg ty
 
 instance NamesIn (A.Pattern' a) where
   namesAndMetasIn' sg = \case

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -1079,6 +1079,9 @@ publicNames scope =
   Set.fromList $ List1.concat $ Map.elems $
   exportedNamesInScope $ mergeScopes $ Map.elems $ publicModules scope
 
+publicNamesOfModules :: Map A.ModuleName Scope -> [AbstractName]
+publicNamesOfModules = List1.concat . Map.elems . exportedNamesInScope . mergeScopes . Map.elems
+
 everythingInScope :: ScopeInfo -> NameSpace
 everythingInScope scope = allThingsInScope $ mergeScopes $
     (s0 :) $ map look $ scopeParents s0

--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -2,24 +2,15 @@
 
 module Agda.TypeChecking.DeadCode (eliminateDeadCode) where
 
-import Control.Monad ((<$!>))
+import Control.Monad ((<$!>), filterM)
 import Control.Monad.Trans
 
 import Data.Maybe
-import Data.Monoid (All(..))
-import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Map.Strict as MapS
-import Data.Set (Set)
-import qualified Data.Set as Set
 import qualified Data.HashMap.Strict as HMap
 
-import Agda.Interaction.Options
-
-import qualified Agda.Syntax.Abstract as A
-
 import Agda.Syntax.Common
-import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Names
 import Agda.Syntax.Scope.Base
@@ -28,100 +19,61 @@ import qualified Agda.Benchmarking as Bench
 import qualified Agda.TypeChecking.Monad.Benchmark as Bench
 
 import Agda.TypeChecking.Monad
-import Agda.TypeChecking.Reduce
 
+import Agda.Utils.Monad (mapMaybeM)
 import Agda.Utils.Impossible
 import Agda.Utils.Lens
 
 import Agda.Utils.HashTable (HashTable)
 import qualified Agda.Utils.HashTable as HT
 
--- | Run before serialisation to remove any definitions and
--- meta-variables that are not reachable from the module's public
--- interface.
---
--- Things that are reachable only from warnings are removed.
-
-eliminateDeadCode ::
-     Map ModuleName a
-       -- ^ Exported modules whose telescopes should not be mutilated by the dead-code removal.
-  -> BuiltinThings PrimFun
-  -> DisplayForms
-  -> Signature
-  -> LocalMetaStore
-  -> TCM (DisplayForms, Signature, RemoteMetaStore)
-eliminateDeadCode publicModules bs disp sig ms = Bench.billTo [Bench.DeadCode] $ do
-  !patsyn <- getPatternSyns
-  !public <- Set.mapMonotonic anameName . publicNames <$> getScope
-  !save   <- optSaveMetas <$> pragmaOptions
-  !defs   <- if save then return (sig ^. sigDefinitions)
-                     else Bench.billTo [Bench.DeadCode, Bench.DeadCodeInstantiateFull]
-                          (traverse (\x -> instantiateFull x) (sig ^. sigDefinitions))
+-- | Run before serialisation to remove data that's not reachable from the
+--   public interface. We do not compute reachable data precisely, because that
+--   would be very expensive, mainly because of rewrite rules. The following
+--   things are assumed to be "roots":
+--     - public names (for definitions and pattern synonyms)
+--     - definitions marked as primitive
+--     - definitions with COMPILE pragma
+--     - parameter sections of public modules
+--     - local builtins
+--     - all rewrite rules
+--   We only ever prune dead metavariables and definitions. The reachable ones
+--   are returned from this function.
+eliminateDeadCode :: ScopeInfo -> TCM (RemoteMetaStore, Definitions)
+eliminateDeadCode !scope = Bench.billTo [Bench.DeadCode] $ do
+  !sig <- getSignature
+  let !defs = sig ^. sigDefinitions
+  !psyns <- getPatternSyns
+  !metas <- useR stSolvedMetaStore
 
   -- #2921: Eliminating definitions with attached COMPILE pragmas results in
   -- the pragmas not being checked. Simple solution: don't eliminate these.
   -- #6022 (Andreas, 2022-09-30): Eliminating cubical primitives can lead to crashes.
-   -- Simple solution: retain all primitives (shouldn't be many).
+  -- Simple solution: retain all primitives (shouldn't be many).
   let hasCompilePragma = not . MapS.null . defCompiledRep
+
       isPrimitive = \case
         Primitive{}     -> True
         PrimitiveSort{} -> True
-        _ -> False
+        _               -> False
+
       extraRootsFilter (name, def)
         | hasCompilePragma def || isPrimitive (theDef def) = Just name
         | otherwise = Nothing
-      extraRoots =
-        Set.fromList $ mapMaybe extraRootsFilter $ HMap.toList defs
 
-      rootSections = Map.elems $ (sig ^. sigSections) `Map.intersection` publicModules
-      rootNames = Set.union public extraRoots
-      rootMetas =
-        if not save then Set.empty else metasIn
-          ( bs
-          , sig ^. sigSections
-          , sig ^. sigRewriteRules
-          , HMap.filterWithKey (\x _ -> Set.member x rootNames) disp
-          )
+  let !pubModules = publicModules scope
 
-  (!rns, !rms) <- Bench.billTo [Bench.DeadCode, Bench.DeadCodeReachable] $ liftIO $
-                    reachableFrom rootSections rootNames rootMetas patsyn disp defs ms
+  let !rootPubNames  = map anameName $ publicNamesOfModules pubModules
+  let !rootExtraDefs = mapMaybe extraRootsFilter $ HMap.toList defs
+  let !rootRewrites  = sig ^. sigRewriteRules
 
-  let !dead  = Set.fromList (HMap.keys defs) `Set.difference` rns
-      !valid = getAll . namesIn' (All . (`Set.notMember` dead))  -- no used name is dead
-      !defs' = HMap.map ( \ d -> d { defDisplay = filter valid (defDisplay d) } )
-               $ HMap.filterWithKey (\ x _ -> Set.member x rns) defs
-      !disp' = HMap.filter (not . null) $ HMap.map (filter valid) disp
-      !ms'   = HMap.fromList $
-                mapMaybe
-                  (\(m, mv) ->
-                    if not (Set.member m rms)
-                    then Nothing
-                    else Just (m, remoteMetaVariable mv)) $
-                MapS.toList ms
+  -- Andreas, Oskar, 2023-10-19, issue #6931:
+  -- Needed to avoid deleting parameter sections of empty modules.
+  let !rootModSections = (sig ^. sigSections) `Map.intersection` pubModules
+  !rootBuiltins <- useTC stLocalBuiltins
 
-  reportSLn "tc.dead" 10 $
-    "Removed " ++ show (HMap.size defs - HMap.size defs') ++
-    " unused definitions and " ++ show (MapS.size ms - HMap.size ms') ++
-    " unused meta-variables."
-  reportSLn "tc.dead" 90 $ unlines $
-    "Removed the following definitions from the signature:" :
-    map (("- " ++) . prettyShow) (Set.toList dead)
-  let !sig' = set sigDefinitions defs' sig
-  return (disp', sig', ms')
-
-reachableFrom ::
-     [Section]      -- ^ Root modules.
-  -> Set QName      -- ^ Root names.
-  -> Set MetaId     -- ^ Root metas.
-  -> A.PatternSynDefns
-  -> DisplayForms
-  -> Definitions
-  -> LocalMetaStore
-  -> IO (Set QName, Set MetaId)
-reachableFrom sections ids ms psyns disp defs insts = do
-
-  !seenNames <- HT.empty :: IO (HashTable QName ())
-  !seenMetas <- HT.empty :: IO (HashTable MetaId ())
+  !seenNames <- liftIO HT.empty :: TCM (HashTable QName ())
+  !seenMetas <- liftIO HT.empty :: TCM (HashTable MetaId ())
 
   let goName :: QName -> IO ()
       goName !x = HT.lookup seenNames x >>= \case
@@ -131,7 +83,6 @@ reachableFrom sections ids ms psyns disp defs insts = do
           HT.insert seenNames x ()
           go (HMap.lookup x defs)
           go (PSyn <$!> MapS.lookup x psyns)
-          go (HMap.lookup x disp)
 
       goMeta :: MetaId -> IO ()
       goMeta !m = HT.lookup seenMetas m >>= \case
@@ -139,26 +90,37 @@ reachableFrom sections ids ms psyns disp defs insts = do
           pure ()
         Nothing -> do
           HT.insert seenMetas m ()
-          case MapS.lookup m insts of
+          case MapS.lookup m metas of
             Nothing -> pure ()
             Just mv -> go (instBody (theInstantiation mv))
 
       go :: NamesIn a => a -> IO ()
-      go = namesAndMetasIn' (either goName goMeta)
+      go !x = namesAndMetasIn' (either goName goMeta) x
       {-# INLINE go #-}
 
-  go sections
-  foldMap goName ids
-  foldMap goMeta ms
-  !ids' <- HT.keySet seenNames
-  !ms'  <- HT.keySet seenMetas
-  pure (ids', ms')
+  Bench.billTo [Bench.DeadCode, Bench.DeadCodeReachable] $ liftIO $ do
+    foldMap goName rootPubNames
+    foldMap goName rootExtraDefs
+    go rootRewrites
+    go rootModSections
+    go rootBuiltins
 
+  let filterMeta :: (MetaId, MetaVariable) -> IO (Maybe (MetaId, RemoteMetaVariable))
+      filterMeta (!i, !m) = HT.lookup seenMetas i >>= \case
+        Nothing -> pure Nothing
+        Just _  -> let !m' = remoteMetaVariable m in pure $ Just (i, m')
+
+      filterDef :: (QName, Definition) -> IO Bool
+      filterDef (!x, !d) = HT.lookup seenNames x >>= \case
+        Nothing -> pure False
+        Just _  -> pure True
+
+  !metas <- liftIO $ HMap.fromList <$> mapMaybeM filterMeta (MapS.toList metas)
+  !defs  <- liftIO $ HMap.fromList <$> filterM filterDef (HMap.toList defs)
+  pure (metas, defs)
 
 -- | Returns the instantiation.
---
--- Precondition: The instantiation must be of the form @'InstV' inst@.
-
+--   Precondition: The instantiation must be of the form @'InstV' inst@.
 theInstantiation :: MetaVariable -> Instantiation
 theInstantiation mv = case mvInstantiation mv of
   InstV inst                     -> inst
@@ -167,11 +129,9 @@ theInstantiation mv = case mvInstantiation mv of
   PostponedTypeCheckingProblem{} -> __IMPOSSIBLE__
 
 -- | Converts from 'MetaVariable' to 'RemoteMetaVariable'.
---
--- Precondition: The instantiation must be of the form @'InstV' inst@.
-
+--   Precondition: The instantiation must be of the form @'InstV' inst@.
 remoteMetaVariable :: MetaVariable -> RemoteMetaVariable
-remoteMetaVariable mv = RemoteMetaVariable
+remoteMetaVariable !mv = RemoteMetaVariable
   { rmvInstantiation = theInstantiation mv
   , rmvModality      = getModality mv
   , rmvJudgement     = mvJudgement mv

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1034,7 +1034,7 @@ newtype ForeignCodeStack = ForeignCodeStack
   } deriving (Show, Generic, NFData)
 
 data Interface = Interface
-  { iSourceHash      :: Hash
+  { iSourceHash      :: !Hash
     -- ^ Hash of the source code.
   , iSource          :: TL.Text
     -- ^ The source code. The source code is stored so that the HTML

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -2,13 +2,13 @@
 module Agda.Utils.Monad
     ( module Agda.Utils.Monad
     , when, unless, MonadPlus(..)
-    , (<$>), (<*>)
+    , (<$>), (<*>), (<$!>)
     , (<$)
     )
     where
 
 import Control.Applicative    ( liftA2 )
-import Control.Monad          ( MonadPlus(..), guard, unless, when )
+import Control.Monad          ( MonadPlus(..), guard, unless, when, (<$!>) )
 import Control.Monad.Except   ( MonadError(catchError, throwError) )
 import Control.Monad.Identity ( runIdentity )
 import Control.Monad.State    ( MonadState(get, put) )
@@ -33,6 +33,15 @@ import Agda.Utils.Impossible
 -- | Binary bind.
 (==<<) :: Monad m => (a -> b -> m c) -> (m a, m b) -> m c
 k ==<< (ma, mb) = ma >>= \ a -> k a =<< mb
+
+-- | Strict `ap`
+(<*!>) :: Monad m => m (a -> b) -> m a -> m b
+(<*!>) mf ma = do
+  f <- mf
+  a <- ma
+  pure $! f a
+{-# INLINE (<*!>) #-}
+infixl 4 <*!>
 
 -- Conditionals and monads ------------------------------------------------
 
@@ -144,11 +153,17 @@ concatMapM f xs = concat <$> Trav.mapM f xs
 
 -- | A monadic version of @'mapMaybe' :: (a -> Maybe b) -> [a] -> [b]@.
 mapMaybeM :: Monad m => (a -> m (Maybe b)) -> [a] -> m [b]
-mapMaybeM f xs = catMaybes <$> Trav.mapM f xs
+mapMaybeM f = go where
+  go []     = return []
+  go (a:as) = f a >>= \case
+    Nothing -> go as
+    Just b  -> do {!bs <- go as; pure (b : bs)}
+{-# INLINE mapMaybeM #-}
 
 -- | A version of @'mapMaybeM'@ with a computation for the input list.
 mapMaybeMM :: Monad m => (a -> m (Maybe b)) -> m [a] -> m [b]
 mapMaybeMM f m = mapMaybeM f =<< m
+{-# INLINE mapMaybeMM #-}
 
 -- | The @for@ version of 'mapMaybeM'.
 forMaybeM :: Monad m => [a] -> (a -> m (Maybe b)) -> m [b]

--- a/test/Succeed/Issue7058/ModParamA.agda
+++ b/test/Succeed/Issue7058/ModParamA.agda
@@ -1,0 +1,5 @@
+
+-- A.agda
+module Issue7058.ModParamA where
+private P = Set₁
+module M (x : P) where

--- a/test/Succeed/Issue7058/ModParamB.agda
+++ b/test/Succeed/Issue7058/ModParamB.agda
@@ -1,0 +1,5 @@
+
+-- B.agda
+module Issue7058.ModParamB where
+open import Issue7058.ModParamA
+module M' = M Set

--- a/test/Succeed/Issue7058/RewriteA.agda
+++ b/test/Succeed/Issue7058/RewriteA.agda
@@ -1,0 +1,15 @@
+
+-- A.agda
+{-# OPTIONS --rewriting #-}
+module Issue7058.RewriteA where
+
+postulate Rel : ∀{i}{A : Set i}(x y : A) → Set
+{-# BUILTIN REWRITE Rel #-}
+
+postulate a : Set₁
+
+private
+  b : Set₁
+  b = Set
+  postulate a~> : Rel a b
+  {-# REWRITE a~> #-}

--- a/test/Succeed/Issue7058/RewriteB.agda
+++ b/test/Succeed/Issue7058/RewriteB.agda
@@ -1,0 +1,11 @@
+
+-- B.agda
+{-# OPTIONS --rewriting #-}
+
+module Issue7058.RewriteB where
+open import Issue7058.RewriteA
+
+postulate c : Set
+
+_ : a
+_ = c


### PR DESCRIPTION
- Fix #7058 by rewriting most of dead code elimination.
- Make `--save-metas` the default.

Dead code elimination now does the following:
- `eliminateDeadCode` computes and returns collections of reachable definitions and metas. It does not instantiate anything and has no side effect. The roots for reachability are the following:
   - Public definitions and pattern synonyms
   - Definitions with COMPILE pragma
   - Primitive definitions
   - Parameter sections of public modules
   - Local builtins
   - All rewrite rules 
- In `buildInterface`, we `instantiateFull` the output interface if we have `--no-save-metas`. 

Moreover, `--save-metas` is now made default. Reasons for doing so:
- Future optimizations of meta instantiations critically depend on `--save-metas`, and `--no-save-metas` should eventually become deprecated in favor of finer control over meta inlining.
- Hence, `--save-metas` should be the config that's being continuously tested. While making this branch, I discovered that `make test` actually failed with `--save-metas` because of an unrelated bug in `NamesIn` (which is fixed here).
- Benchmarks on my machine (AMD 7700X, DDR5 6000):
  - std-lib: checking time 5.4% shorter (204.27 -> 192.8 s), interface size +1.83% (168.9M -> 172M).
  - cubical lib checking time 0.7% longer (622.600 -> 627.2 s), interface size +4.6% (153M -> 160M).

In short there's a significant performance win in `std-lib` and an insignificant loss in `cubical`. I'd consider the interface size diffs to be also insignificant.

Right now, part of the small impact of `--save-metas` is that all definition bodies are `instantiateFull`-ed by elaboration in `Agda.TypeChecking.Rules.Def`. So far, I think that the following metas can survive elaboration: those in function clause LHS-es, rewrite rules, display forms, module parameter sections, and some metas in definitions bodies, those that become solved later by elaborating other things in a mutual group. 