### PR TITLE
Fix #7193: persistently remember what is a projection

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -262,6 +262,7 @@ errorString = \case
   SplitInProp{}                            -> "SplitInProp"
   DefinitionIsIrrelevant{}                 -> "DefinitionIsIrrelevant"
   DefinitionIsErased{}                     -> "DefinitionIsErased"
+  ProjectionIsIrrelevant{}                 -> "ProjectionIsIrrelevant"
   VariableIsIrrelevant{}                   -> "VariableIsIrrelevant"
   VariableIsErased{}                       -> "VariableIsErased"
   VariableIsOfUnusableCohesion{}           -> "VariableIsOfUnusableCohesion"
@@ -673,6 +674,11 @@ instance PrettyTCM TypeError where
 
     DefinitionIsErased x -> fsep $
       "Identifier" : prettyTCM x : pwords "is declared erased, so it cannot be used here"
+
+    ProjectionIsIrrelevant x -> vcat
+      [ fsep [ "Projection " , prettyTCM x, " is irrelevant." ]
+      , "Turn on option --irrelevant-projections to use it (unsafe)"
+      ]
 
     VariableIsIrrelevant x -> fsep $
       "Variable" : prettyTCM (nameConcrete x) : pwords "is declared irrelevant, so it cannot be used here"

--- a/src/full/Agda/TypeChecking/Modalities.hs
+++ b/src/full/Agda/TypeChecking/Modalities.hs
@@ -47,10 +47,7 @@ checkRelevance' x def = do
           ]
         return $ boolToMaybe (not $ drel `moreRelevant` rel) $ DefinitionIsIrrelevant x
   where
-  needIrrProj = Just . GenericDocError <$> do
-    sep [ "Projection " , prettyTCM x, " is irrelevant."
-        , " Turn on option --irrelevant-projections to use it (unsafe)."
-        ]
+  needIrrProj = return $ Just $ ProjectionIsIrrelevant x
 
 -- | The second argument is the definition of the first.
 --   Returns 'Nothing' if ok, otherwise the error message.

--- a/src/full/Agda/TypeChecking/Modalities.hs
+++ b/src/full/Agda/TypeChecking/Modalities.hs
@@ -22,6 +22,8 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Substitute
 
+import Agda.Utils.Function
+import Agda.Utils.Lens
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 
@@ -34,12 +36,14 @@ checkRelevance' x def = do
     drel -> do
       -- Andreas,, 2018-06-09, issue #2170
       -- irrelevant projections are only allowed if --irrelevant-projections
-      ifM (return (isJust $ isProjection_ $ theDef def) `and2M`
+      let isProj = theDef def ^. funProj
+      ifM (pure isProj `and2M`
            (not . optIrrelevantProjections <$> pragmaOptions)) {-then-} needIrrProj {-else-} $ do
         rel <- viewTC eRelevance
         reportSDoc "tc.irr" 50 $ vcat
           [ "declaration relevance =" <+> text (show drel)
           , "context     relevance =" <+> text (show rel)
+          , prettyTCM x <+> "is" <+> applyUnless isProj ("not" <+>) "a projection"
           ]
         return $ boolToMaybe (not $ drel `moreRelevant` rel) $ DefinitionIsIrrelevant x
   where

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4669,6 +4669,7 @@ data TypeError
         | SplitInProp DataOrRecordE
         | DefinitionIsIrrelevant QName
         | DefinitionIsErased QName
+        | ProjectionIsIrrelevant QName
         | VariableIsIrrelevant Name
         | VariableIsErased Name
         | VariableIsOfUnusableCohesion Name Cohesion

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2331,6 +2331,8 @@ data FunctionFlag
       -- (This can affect the type of a projection.)
   | FunAbstract
       -- ^ Is the function abstract?
+  | FunProj
+      -- ^ Is this function a descendant of a field (typically, a projection)?
   deriving (Eq, Ord, Enum, Show, Generic, Ix, Bounded)
 
 instance SmallSetElement FunctionFlag
@@ -3064,6 +3066,14 @@ funAbstract_ = funFlag_ FunAbstract
 -- | Toggle the 'FunAbstract' flag.
 funAbstr_ :: Lens' FunctionData IsAbstract
 funAbstr_ = funAbstract_ . iso fromBool toBool
+
+-- | Toggle the 'FunProj' flag.
+funProj :: Lens' Defn Bool
+funProj = funFlag FunProj
+
+-- | Toggle the 'FunProj' flag.
+funProj_ :: Lens' FunctionData Bool
+funProj_ = funFlag_ FunProj
 
 isMacro :: Defn -> Bool
 isMacro = (^. funMacro)

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -647,6 +647,7 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
                   (mst, _, cc) <- compileClauses Nothing [cl] -- Andreas, 2012-10-07 non need for record pattern translation
                   fun          <- emptyFunctionData
                   let newDef =
+                        set funProj   (oldDef ^. funProj) $
                         set funMacro  (oldDef ^. funMacro) $
                         set funStatic (oldDef ^. funStatic) $
                         set funInline True $

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -42,6 +42,7 @@ import {-# SOURCE #-} Agda.TypeChecking.Rules.Decl (checkDecl)
 
 import Agda.Utils.Boolean
 import Agda.Utils.Function ( applyWhen )
+import Agda.Utils.Lens
 import Agda.Utils.List (headWithDefault)
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
@@ -777,7 +778,8 @@ checkRecordProjections m r hasNamedCon con tel ftel fs = do
                       Quantityω _ -> Quantityω QωInferred
                       q           -> q
           addConstant projname $
-            (defaultDefn ai' projname (killRange finalt) lang $ FunctionDefn
+            (defaultDefn ai' projname (killRange finalt) lang $ FunctionDefn $
+             set funProj_ True $
               fun
                 { _funClauses        = [clause]
                 , _funCompiled       = Just cc

--- a/test/Fail/Issue7193.agda
+++ b/test/Fail/Issue7193.agda
@@ -1,0 +1,25 @@
+-- Andreas, 2024-05-10, issue #7193 by dolio
+
+{-# OPTIONS --no-irrelevant-projections #-}  -- default, but for clarity
+
+record ⊤ : Set where
+
+record TSquash (A : Set) : Set where
+  field
+    .extract : ⊤ → A
+
+  .tflat : ⊤ → A
+  tflat = extract
+
+-- Expected error:
+--
+-- Projection  extract  is irrelevant.
+-- Turn on option --irrelevant-projections to use it (unsafe).
+-- when checking that the expression extract has type ⊤ → A
+
+open TSquash
+
+.flat : ∀{A} → .A → A
+flat a = tflat (λ where .extract _ → a) _
+
+-- Should not pass without --irrelevant-projections

--- a/test/Fail/Issue7193.err
+++ b/test/Fail/Issue7193.err
@@ -1,0 +1,6 @@
+Issue7193.agda:12,11-18
+Projection 
+extract
+ is irrelevant.
+ Turn on option --irrelevant-projections to use it (unsafe).
+when checking that the expression extract has type ⊤ → A

--- a/test/Fail/Issue7193.err
+++ b/test/Fail/Issue7193.err
@@ -1,6 +1,4 @@
 Issue7193.agda:12,11-18
-Projection 
-extract
- is irrelevant.
- Turn on option --irrelevant-projections to use it (unsafe).
+Projection  extract  is irrelevant.
+Turn on option --irrelevant-projections to use it (unsafe)
 when checking that the expression extract has type ⊤ → A

--- a/test/Fail/ScopeIrrelevantRecordField.err
+++ b/test/Fail/ScopeIrrelevantRecordField.err
@@ -1,6 +1,4 @@
 ScopeIrrelevantRecordField.agda:11,9-17
-Projection 
-Bla.bla0
- is irrelevant.
- Turn on option --irrelevant-projections to use it (unsafe).
+Projection  Bla.bla0  is irrelevant.
+Turn on option --irrelevant-projections to use it (unsafe)
 when checking that the expression Bla.bla0 has type Bla → Set

--- a/test/Fail/ShapeIrrelevantField.err
+++ b/test/Fail/ShapeIrrelevantField.err
@@ -1,6 +1,4 @@
 ShapeIrrelevantField.agda:8,10-17
-Projection 
-Foo.foo
- is irrelevant.
- Turn on option --irrelevant-projections to use it (unsafe).
+Projection  Foo.foo  is irrelevant.
+Turn on option --irrelevant-projections to use it (unsafe)
 when checking that the expression Foo.foo has type Foo A → A


### PR DESCRIPTION
Introduces a new `FunctionFlag` `FunProj` that remembers whether this function is or came from a projection.  
This flag is more stable than the `funProjection` data which relies on arity.
This helps ruling out accessing irrelevant fields in irrelevant definitions without activating `--irrelevant-projections`.

Fixes #7193. (Hopefully, feels almost too good to be true.)