### PR TITLE
Draft: Add let expressions to internal syntax

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -198,6 +198,7 @@ haskellType' t = runToHs (unEl t) (fromType t)
         Sort{}     -> return hsUnit
         MetaV{}    -> throwError (BadMeta v)
         DontCare{} -> throwError (BadDontCare v)
+        Let{}      -> __IMPOSSIBLE__
         Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 
 haskellType :: QName -> HsCompileM HS.Type

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -199,6 +199,7 @@ haskellType' t = runToHs (unEl t) (fromType t)
         MetaV{}    -> throwError (BadMeta v)
         DontCare{} -> throwError (BadDontCare v)
         Let{}      -> __IMPOSSIBLE__
+        LetV{}     -> __IMPOSSIBLE__
         Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 
 haskellType :: QName -> HsCompileM HS.Type

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -199,7 +199,6 @@ haskellType' t = runToHs (unEl t) (fromType t)
         MetaV{}    -> throwError (BadMeta v)
         DontCare{} -> throwError (BadDontCare v)
         Let{}      -> __IMPOSSIBLE__
-        LetVar{}   -> __IMPOSSIBLE__
         Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 
 haskellType :: QName -> HsCompileM HS.Type

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -199,7 +199,7 @@ haskellType' t = runToHs (unEl t) (fromType t)
         MetaV{}    -> throwError (BadMeta v)
         DontCare{} -> throwError (BadDontCare v)
         Let{}      -> __IMPOSSIBLE__
-        LetV{}     -> __IMPOSSIBLE__
+        LetVar{}   -> __IMPOSSIBLE__
         Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 
 haskellType :: QName -> HsCompileM HS.Type

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -521,7 +521,7 @@ substTerm term = normaliseStatic term >>= \ term ->
     I.Pi _ _ -> return C.TUnit
     I.Sort _  -> return C.TSort
     I.Let _ u v -> C.TLet <$> substTerm u <*> substAbs v
-    I.LetV x es -> do
+    I.LetVar x es -> do
       ind <- asks (lookupIndex x . ccCxt)
       let args = fromMaybe __IMPOSSIBLE__ $ I.allApplyElims es
       C.mkTApp (C.TVar ind) <$> substArgs args

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -521,10 +521,6 @@ substTerm term = normaliseStatic term >>= \ term ->
     I.Pi _ _ -> return C.TUnit
     I.Sort _  -> return C.TSort
     I.Let _ (I.LetAbs x u v) -> C.TLet <$> substTerm u <*> substAbs (Abs x v)
-    I.LetVar x es -> do
-      ind <- asks (lookupIndex x . ccCxt)
-      let args = fromMaybe __IMPOSSIBLE__ $ I.allApplyElims es
-      C.mkTApp (C.TVar ind) <$> substArgs args
     I.MetaV x _ -> return $ C.TError $ C.TMeta $ prettyShow x
     I.DontCare _ -> return C.TErased
     I.Dummy{} -> __IMPOSSIBLE__

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -521,6 +521,10 @@ substTerm term = normaliseStatic term >>= \ term ->
     I.Pi _ _ -> return C.TUnit
     I.Sort _  -> return C.TSort
     I.Let _ u v -> C.TLet <$> substTerm u <*> substAbs v
+    I.LetV x es -> do
+      ind <- asks (lookupIndex x . ccCxt)
+      let args = fromMaybe __IMPOSSIBLE__ $ I.allApplyElims es
+      C.mkTApp (C.TVar ind) <$> substArgs args
     I.MetaV x _ -> return $ C.TError $ C.TMeta $ prettyShow x
     I.DontCare _ -> return C.TErased
     I.Dummy{} -> __IMPOSSIBLE__

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -520,7 +520,7 @@ substTerm term = normaliseStatic term >>= \ term ->
         C.mkTApp (C.TCon c') <$> substArgs args
     I.Pi _ _ -> return C.TUnit
     I.Sort _  -> return C.TSort
-    I.Let _ u v -> C.TLet <$> substTerm u <*> substAbs v
+    I.Let _ (I.LetAbs x u v) -> C.TLet <$> substTerm u <*> substAbs (Abs x v)
     I.LetVar x es -> do
       ind <- asks (lookupIndex x . ccCxt)
       let args = fromMaybe __IMPOSSIBLE__ $ I.allApplyElims es

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -974,7 +974,8 @@ metaHelperType norm ii rng s = case words s of
 
     -- Konstantin, 2022-10-23: We don't want to print section parameters in helper type.
     freeVars <- getCurrentModuleFreeVars
-    contextForAbstracting <- drop freeVars . reverse <$> getContext
+    ctx <- getContext
+    let contextForAbstracting = take (size ctx - freeVars) ctx
 
     -- Andreas, 2019-10-11: I actually prefer pi-types over ->.
     let runInPrintingEnvironment = localTC (\e -> e { envPrintDomainFreePi = True, envPrintMetasBare = True })
@@ -989,8 +990,8 @@ metaHelperType norm ii rng s = case words s of
      -- We simply make exactly the given arguments visible and all other hidden.
      Just xs -> do
       let inXs = hasElem xs
-      let hideButXs dom = setHiding (if inXs $ fst $ unDom dom then NotHidden else Hidden) dom
-      let tel = telFromList . map (fmap (first nameToArgName) . hideButXs) $ contextForAbstracting
+      let hideButXs ce = setHiding (if inXs (ctxEntryName ce) then NotHidden else Hidden) ce
+      let tel = contextToTel . map hideButXs $ contextForAbstracting
       OfType' h <$> do
         runInPrintingEnvironment $ reify $ telePiVisible tel a0
 
@@ -998,7 +999,7 @@ metaHelperType norm ii rng s = case words s of
      Nothing -> do
       -- cleanupType relies on with arguments being named 'w',
       -- so we'd better rename any actual 'w's to avoid confusion.
-      let tel = runIdentity . onNamesTel unW . telFromList' nameToArgName $ contextForAbstracting
+      let tel = runIdentity . onNamesTel unW . contextToTel $ contextForAbstracting
       let a = runIdentity . onNames unW $ a0
       vtys <- mapM (\ a -> fmap (Arg (getArgInfo a) . fmap OtherType) $ inferExpr $ namedArg a) args
       -- Remember the arity of a
@@ -1124,13 +1125,14 @@ contextOfMeta ii norm = withInteractionId ii $ do
 
   where
     mkVar :: ContextEntry -> TCM (Maybe ResponseContextEntry)
-    mkVar Dom{ domInfo = ai, unDom = (name, t) } = do
+    mkVar (CtxVar name Dom{ domInfo = ai, unDom = t }) = do
       if shouldHide ai name then return Nothing else Just <$> do
         let n = nameConcrete name
         x  <- abstractToConcrete_ name
         let s = C.isInScope x
         ty <- reifyUnblocked =<< normalForm norm t
         return $ ResponseContextEntry n x (Arg ai ty) Nothing s
+    mkVar CtxLet{} = __IMPOSSIBLE__
 
     mkLet :: (Name, Open M.LetBinding) -> TCM (Maybe ResponseContextEntry)
     mkLet (name, lb) = do

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1078,7 +1078,7 @@ metaHelperType norm ii rng s = case words s of
       I.Lam i b    -> I.Lam i <$> onNamesAbs f onNamesTm b
       I.Pi a b     -> I.Pi <$> traverse (onNames f) a <*> onNamesAbs f onNames b
       I.DontCare v -> I.DontCare <$> onNamesTm f v
-      I.Let a u v  -> I.Let <$> traverse (onNames f) a <*> onNamesTm f u <*> onNamesAbs f onNamesTm v
+      I.Let a u    -> I.Let <$> traverse (onNames f) a <*> onNamesLetAbs f onNamesTm u
       I.LetVar x es -> I.LetVar x <$> onNamesElims f es
       v@I.Lit{}    -> pure v
       v@I.Sort{}   -> pure v
@@ -1090,6 +1090,10 @@ metaHelperType norm ii rng s = case words s of
     onNamesAbs f   = onNamesAbs' f (stringToArgName <.> f . argNameToString)
     onNamesAbs' f f' nd (Abs   s x) = Abs   <$> f' s <*> nd f x
     onNamesAbs' f f' nd (NoAbs s x) = NoAbs <$> f' s <*> nd f x
+    onNamesLetAbs f nd (LetAbs s u v) =
+      (\u ~(Abs s v) -> LetAbs s u v)
+        <$> onNamesTm f u
+        <*> onNamesAbs f nd (Abs s v)
 
     unW "w" = return ".w"
     unW s   = return s

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1079,7 +1079,6 @@ metaHelperType norm ii rng s = case words s of
       I.Pi a b     -> I.Pi <$> traverse (onNames f) a <*> onNamesAbs f onNames b
       I.DontCare v -> I.DontCare <$> onNamesTm f v
       I.Let a u    -> I.Let <$> traverse (onNames f) a <*> onNamesLetAbs f onNamesTm u
-      I.LetVar x es -> I.LetVar x <$> onNamesElims f es
       v@I.Lit{}    -> pure v
       v@I.Sort{}   -> pure v
       v@I.Level{}  -> pure v

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1078,6 +1078,7 @@ metaHelperType norm ii rng s = case words s of
       I.Lam i b    -> I.Lam i <$> onNamesAbs f onNamesTm b
       I.Pi a b     -> I.Pi <$> traverse (onNames f) a <*> onNamesAbs f onNames b
       I.DontCare v -> I.DontCare <$> onNamesTm f v
+      I.Let a u v  -> I.Let <$> traverse (onNames f) a <*> onNamesTm f u <*> onNamesAbs f onNamesTm v
       v@I.Lit{}    -> pure v
       v@I.Sort{}   -> pure v
       v@I.Level{}  -> pure v

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1079,7 +1079,7 @@ metaHelperType norm ii rng s = case words s of
       I.Pi a b     -> I.Pi <$> traverse (onNames f) a <*> onNamesAbs f onNames b
       I.DontCare v -> I.DontCare <$> onNamesTm f v
       I.Let a u v  -> I.Let <$> traverse (onNames f) a <*> onNamesTm f u <*> onNamesAbs f onNamesTm v
-      I.LetV x es  -> I.LetV x <$> onNamesElims f es
+      I.LetVar x es -> I.LetVar x <$> onNamesElims f es
       v@I.Lit{}    -> pure v
       v@I.Sort{}   -> pure v
       v@I.Level{}  -> pure v

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1079,6 +1079,7 @@ metaHelperType norm ii rng s = case words s of
       I.Pi a b     -> I.Pi <$> traverse (onNames f) a <*> onNamesAbs f onNames b
       I.DontCare v -> I.DontCare <$> onNamesTm f v
       I.Let a u v  -> I.Let <$> traverse (onNames f) a <*> onNamesTm f u <*> onNamesAbs f onNamesTm v
+      I.LetV x es  -> I.LetV x <$> onNamesElims f es
       v@I.Lit{}    -> pure v
       v@I.Sort{}   -> pure v
       v@I.Level{}  -> pure v

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -121,7 +121,7 @@ parseVariables f cxt asb ii rng ss = do
   -- Step 2: Resolve each abstract name to a de Bruijn index.
 
   -- First, get context names of the clause.
-  let clauseCxtNames = map (fst . unDom) cxt
+  let clauseCxtNames = contextNames' cxt
 
   -- Valid names to split on are pattern variables of the clause,
   -- plus as-bindings that refer to a variable.
@@ -382,7 +382,7 @@ makeCase hole rng s = withInteractionId hole $ locallyTC eMakeCase (const True) 
 
     -- If any of the split variables is hidden by the ellipsis, we
     -- should force the expansion of the ellipsis.
-    let splitNames = map (\i -> fst $ unDom $ clauseCxt !! i) toSplit
+    let splitNames = map (\i -> ctxEntryName $ clauseCxt !! i) toSplit
     shouldExpandEllipsis <- return (not $ null toShow) `or2M` anyEllipsisVar f absCl splitNames
     let ell' | shouldExpandEllipsis = NoEllipsis
              | otherwise            = ell

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -1483,10 +1483,10 @@ getLocalVarTerms localCxt = do
   contextTerms <- getContextTerms
   contextTypes <- flattenTel <$> getContextTelescope
   let inScope i _ | i < localCxt = pure True   -- Ignore scope for variables we inserted ourselves
-      inScope _ Dom{ unDom = (name, _) } = do
+      inScope _ Dom{ unDom = name } = do
         x <- abstractToConcrete_ name
         pure $ C.isInScope x == C.InScope
-  scope <- mapM (uncurry inScope) . reverse . zip [0..] =<< getContext
+  scope <- mapM (uncurry inScope) =<< getContextVars
   return [ e | (True, e) <- zip scope $ zip contextTerms contextTypes ]
 
 

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1791,6 +1791,7 @@ class LensArgInfo a where
   setArgInfo ai = mapArgInfo (const ai)
   mapArgInfo :: (ArgInfo -> ArgInfo) -> a -> a
   mapArgInfo f a = setArgInfo (f $ getArgInfo a) a
+  {-# MINIMAL getArgInfo , (setArgInfo | mapArgInfo) #-}
 
 instance LensArgInfo ArgInfo where
   getArgInfo = id

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1372,7 +1372,7 @@ instance Pretty Term where
             , pretty u <+> "in"
             , nest 2 $ pretty v
             ]
-      LetVar x es -> text ("@" ++ show x) `pApp` es
+      LetVar x es -> text ("'" ++ show x) `pApp` es
       MetaV x els -> pretty x `pApp` els
       DontCare v  -> prettyPrec p v
       Dummy s es  -> parens (text s) `pApp` es

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -226,7 +226,6 @@ data Term = Var {-# UNPACK #-} !Int Elims -- ^ @x es@ neutral
           | Sort Sort
           | Level Level
           | Let (Dom Type) (LetAbs Term) -- ^ @let x : a = u in v@
-          | LetVar {-# UNPACK #-} !Int Elims
           | MetaV {-# UNPACK #-} !MetaId Elims
           | DontCare Term
             -- ^ Irrelevant stuff in relevant position, but created
@@ -1086,7 +1085,6 @@ hasElims v =
     Var   i es -> Just (Var   i, es)
     Def   f es -> Just (Def   f, es)
     MetaV x es -> Just (MetaV x, es)
-    LetVar x es -> Just (LetVar x , es)
     Con{}      -> Nothing
     Lit{}      -> Nothing
     Lam{}      -> Nothing
@@ -1199,7 +1197,6 @@ instance TermSize Term where
     Pi a b      -> 1 + tsize a + tsize b
     Sort s      -> tsize s
     Let a u     -> 1 + tsize a + tsize u
-    LetVar x vs -> 1 + tsize vs
     DontCare mv -> tsize mv
     Dummy{}     -> 1
 
@@ -1254,7 +1251,6 @@ instance KillRange Term where
     Pi a b      -> killRangeN Pi a b
     Sort s      -> killRangeN Sort s
     Let a u     -> killRangeN Let a u
-    LetVar x es -> killRangeN LetVar x es
     DontCare mv -> killRangeN DontCare mv
     v@Dummy{}   -> v
 
@@ -1372,7 +1368,6 @@ instance Pretty Term where
             , pretty u <+> "in"
             , nest 2 $ pretty v
             ]
-      LetVar x es -> text ("'" ++ show x) `pApp` es
       MetaV x els -> pretty x `pApp` els
       DontCare v  -> prettyPrec p v
       Dummy s es  -> parens (text s) `pApp` es
@@ -1505,7 +1500,6 @@ instance NFData Term where
     Sort s     -> rnf s
     Level l    -> rnf l
     Let a u    -> rnf (a, u)
-    LetVar _ es -> rnf es
     MetaV _ es -> rnf es
     DontCare v -> rnf v
     Dummy _ es -> rnf es

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -226,7 +226,7 @@ data Term = Var {-# UNPACK #-} !Int Elims -- ^ @x es@ neutral
           | Sort Sort
           | Level Level
           | Let (Dom Type) Term (Abs Term) -- ^ @let x : a = u in v@
-          | LetV {-# UNPACK #-} !Int Elims
+          | LetVar {-# UNPACK #-} !Int Elims
           | MetaV {-# UNPACK #-} !MetaId Elims
           | DontCare Term
             -- ^ Irrelevant stuff in relevant position, but created
@@ -1078,7 +1078,7 @@ hasElims v =
     Var   i es -> Just (Var   i, es)
     Def   f es -> Just (Def   f, es)
     MetaV x es -> Just (MetaV x, es)
-    LetV x es  -> Just (LetV x , es)
+    LetVar x es -> Just (LetVar x , es)
     Con{}      -> Nothing
     Lit{}      -> Nothing
     Lam{}      -> Nothing
@@ -1191,7 +1191,7 @@ instance TermSize Term where
     Pi a b      -> 1 + tsize a + tsize b
     Sort s      -> tsize s
     Let a u v   -> 1 + tsize a + tsize u + tsize v
-    LetV x vs   -> 1 + tsize vs
+    LetVar x vs -> 1 + tsize vs
     DontCare mv -> tsize mv
     Dummy{}     -> 1
 
@@ -1246,7 +1246,7 @@ instance KillRange Term where
     Pi a b      -> killRangeN Pi a b
     Sort s      -> killRangeN Sort s
     Let a u v   -> killRangeN Let a u v
-    LetV x es   -> killRangeN LetV x es
+    LetVar x es -> killRangeN LetVar x es
     DontCare mv -> killRangeN DontCare mv
     v@Dummy{}   -> v
 
@@ -1361,7 +1361,7 @@ instance Pretty Term where
             , text (absName v) <+> "in"
             , nest 2 $ pretty (unAbs v)
             ]
-      LetV x es   -> text ("@" ++ show x) `pApp` es
+      LetVar x es -> text ("@" ++ show x) `pApp` es
       MetaV x els -> pretty x `pApp` els
       DontCare v  -> prettyPrec p v
       Dummy s es  -> parens (text s) `pApp` es
@@ -1494,7 +1494,7 @@ instance NFData Term where
     Sort s     -> rnf s
     Level l    -> rnf l
     Let a u v  -> rnf (a, u, v)
-    LetV _ es  -> rnf es
+    LetVar _ es -> rnf es
     MetaV _ es -> rnf es
     DontCare v -> rnf v
     Dummy _ es -> rnf es

--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -66,7 +66,6 @@ instance GetDefs Term where
     Sort s     -> getDefs s
     Level l    -> getDefs l
     Let a u    -> getDefs a >> getDefs u
-    LetVar x es -> getDefs es
     MetaV x vs -> getDefs x >> getDefs vs
     DontCare v -> getDefs v
     Dummy{}    -> return ()

--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -12,7 +12,6 @@ import qualified Data.Foldable as Fold
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 
-import Agda.Utils.Impossible
 
 -- | @getDefs' lookup emb a@ extracts all used definitions
 --   (functions, data/record types) from @a@, embedded into a monoid via @emb@.
@@ -66,8 +65,8 @@ instance GetDefs Term where
     Pi a b     -> getDefs a >> getDefs b
     Sort s     -> getDefs s
     Level l    -> getDefs l
-    LetVar x es -> __IMPOSSIBLE__ -- TODO
     Let a u    -> getDefs a >> getDefs u
+    LetVar x es -> getDefs es
     MetaV x vs -> getDefs x >> getDefs vs
     DontCare v -> getDefs v
     Dummy{}    -> return ()

--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -67,7 +67,7 @@ instance GetDefs Term where
     Sort s     -> getDefs s
     Level l    -> getDefs l
     Let a u v  -> getDefs a >> getDefs u >> getDefs v
-    LetV x es  -> __IMPOSSIBLE__ -- TODO
+    LetVar x es -> __IMPOSSIBLE__ -- TODO
     MetaV x vs -> getDefs x >> getDefs vs
     DontCare v -> getDefs v
     Dummy{}    -> return ()

--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -66,8 +66,8 @@ instance GetDefs Term where
     Pi a b     -> getDefs a >> getDefs b
     Sort s     -> getDefs s
     Level l    -> getDefs l
-    Let a u v  -> getDefs a >> getDefs u >> getDefs v
     LetVar x es -> __IMPOSSIBLE__ -- TODO
+    Let a u    -> getDefs a >> getDefs u
     MetaV x vs -> getDefs x >> getDefs vs
     DontCare v -> getDefs v
     Dummy{}    -> return ()
@@ -107,6 +107,7 @@ instance GetDefs a => GetDefs (Elim' a) where
 instance GetDefs a => GetDefs (Arg a)   where
 instance GetDefs a => GetDefs (Dom a)   where
 instance GetDefs a => GetDefs (Abs a)   where
+instance GetDefs a => GetDefs (LetAbs a) where
 
 instance (GetDefs a, GetDefs b) => GetDefs (a,b) where
   getDefs (a,b) = getDefs a >> getDefs b

--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -12,6 +12,8 @@ import qualified Data.Foldable as Fold
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 
+import Agda.Utils.Impossible
+
 -- | @getDefs' lookup emb a@ extracts all used definitions
 --   (functions, data/record types) from @a@, embedded into a monoid via @emb@.
 --   Instantiations of meta variables are obtained via @lookup@.
@@ -65,6 +67,7 @@ instance GetDefs Term where
     Sort s     -> getDefs s
     Level l    -> getDefs l
     Let a u v  -> getDefs a >> getDefs u >> getDefs v
+    LetV x es  -> __IMPOSSIBLE__ -- TODO
     MetaV x vs -> getDefs x >> getDefs vs
     DontCare v -> getDefs v
     Dummy{}    -> return ()

--- a/src/full/Agda/Syntax/Internal/Defs.hs
+++ b/src/full/Agda/Syntax/Internal/Defs.hs
@@ -64,6 +64,7 @@ instance GetDefs Term where
     Pi a b     -> getDefs a >> getDefs b
     Sort s     -> getDefs s
     Level l    -> getDefs l
+    Let a u v  -> getDefs a >> getDefs u >> getDefs v
     MetaV x vs -> getDefs x >> getDefs vs
     DontCare v -> getDefs v
     Dummy{}    -> return ()

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -94,7 +94,6 @@ instance TermLike Term where
     t@Lit{}     -> f t
     Sort s      -> f =<< Sort <$> traverseTermM f s
     Let a u     -> f =<< uncurry Let <$> traverseTermM f (a, u)
-    LetVar i xs -> f =<< LetVar i <$> traverseTermM f xs
     DontCare mv -> f =<< DontCare <$> traverseTermM f mv
     Dummy s xs  -> f =<< Dummy s <$> traverseTermM f xs
 
@@ -109,7 +108,6 @@ instance TermLike Term where
     Lit _       -> mempty
     Sort s      -> foldTerm f s
     Let a u     -> foldTerm f (a, u)
-    LetVar i xs -> foldTerm f xs
     DontCare mv -> foldTerm f mv
     Dummy _ xs  -> foldTerm f xs
 

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -93,7 +93,7 @@ instance TermLike Term where
     t@Lit{}     -> f t
     Sort s      -> f =<< Sort <$> traverseTermM f s
     Let a u v   -> f =<< uncurry3 Let <$> traverseTermM f (a, u, v)
-    LetV i xs   -> f =<< LetV i <$> traverseTermM f xs
+    LetVar i xs -> f =<< LetVar i <$> traverseTermM f xs
     DontCare mv -> f =<< DontCare <$> traverseTermM f mv
     Dummy s xs  -> f =<< Dummy s <$> traverseTermM f xs
 
@@ -108,7 +108,7 @@ instance TermLike Term where
     Lit _       -> mempty
     Sort s      -> foldTerm f s
     Let a u v   -> foldTerm f (a, u, v)
-    LetV i xs   -> foldTerm f xs
+    LetVar i xs -> foldTerm f xs
     DontCare mv -> foldTerm f mv
     Dummy _ xs  -> foldTerm f xs
 

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -93,6 +93,7 @@ instance TermLike Term where
     t@Lit{}     -> f t
     Sort s      -> f =<< Sort <$> traverseTermM f s
     Let a u v   -> f =<< uncurry3 Let <$> traverseTermM f (a, u, v)
+    LetV i xs   -> f =<< LetV i <$> traverseTermM f xs
     DontCare mv -> f =<< DontCare <$> traverseTermM f mv
     Dummy s xs  -> f =<< Dummy s <$> traverseTermM f xs
 
@@ -107,6 +108,7 @@ instance TermLike Term where
     Lit _       -> mempty
     Sort s      -> foldTerm f s
     Let a u v   -> foldTerm f (a, u, v)
+    LetV i xs   -> foldTerm f xs
     DontCare mv -> foldTerm f mv
     Dummy _ xs  -> foldTerm f xs
 

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -6,6 +6,7 @@ module Agda.Syntax.Internal.Generic where
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.Utils.Functor
+import Agda.Utils.Tuple
 
 -- | Generic term traversal.
 --
@@ -91,6 +92,7 @@ instance TermLike Term where
     Level l     -> f =<< Level <$> traverseTermM f l
     t@Lit{}     -> f t
     Sort s      -> f =<< Sort <$> traverseTermM f s
+    Let a u v   -> f =<< uncurry3 Let <$> traverseTermM f (a, u, v)
     DontCare mv -> f =<< DontCare <$> traverseTermM f mv
     Dummy s xs  -> f =<< Dummy s <$> traverseTermM f xs
 
@@ -104,6 +106,7 @@ instance TermLike Term where
     Level l     -> foldTerm f l
     Lit _       -> mempty
     Sort s      -> foldTerm f s
+    Let a u v   -> foldTerm f (a, u, v)
     DontCare mv -> foldTerm f mv
     Dummy _ xs  -> foldTerm f xs
 

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -61,6 +61,7 @@ instance TermLike a => TermLike [a]            where
 instance TermLike a => TermLike (Maybe a)      where
 instance TermLike a => TermLike (Blocked a)    where
 instance TermLike a => TermLike (Abs a)        where
+instance TermLike a => TermLike (LetAbs a)     where
 instance TermLike a => TermLike (Tele a)       where
 instance TermLike a => TermLike (WithHiding a) where
 
@@ -92,7 +93,7 @@ instance TermLike Term where
     Level l     -> f =<< Level <$> traverseTermM f l
     t@Lit{}     -> f t
     Sort s      -> f =<< Sort <$> traverseTermM f s
-    Let a u v   -> f =<< uncurry3 Let <$> traverseTermM f (a, u, v)
+    Let a u     -> f =<< uncurry Let <$> traverseTermM f (a, u)
     LetVar i xs -> f =<< LetVar i <$> traverseTermM f xs
     DontCare mv -> f =<< DontCare <$> traverseTermM f mv
     Dummy s xs  -> f =<< Dummy s <$> traverseTermM f xs
@@ -107,7 +108,7 @@ instance TermLike Term where
     Level l     -> foldTerm f l
     Lit _       -> mempty
     Sort s      -> foldTerm f s
-    Let a u v   -> foldTerm f (a, u, v)
+    Let a u     -> foldTerm f (a, u)
     LetVar i xs -> foldTerm f xs
     DontCare mv -> foldTerm f mv
     Dummy _ xs  -> foldTerm f xs

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -225,6 +225,7 @@ instance NamesIn Term where
     Pi a b       -> namesAndMetasIn' sg (a, b)
     Sort s       -> namesAndMetasIn' sg s
     Level l      -> namesAndMetasIn' sg l
+    Let a u v    -> namesAndMetasIn' sg (a, u, v)
     MetaV x args -> namesAndMetasIn' sg (x, args)
     DontCare v   -> namesAndMetasIn' sg v
     Dummy _ args -> namesAndMetasIn' sg args

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -226,8 +226,8 @@ instance NamesIn Term where
     Pi a b       -> namesAndMetasIn' sg (a, b)
     Sort s       -> namesAndMetasIn' sg s
     Level l      -> namesAndMetasIn' sg l
-    LetVar x es  -> __IMPOSSIBLE__ -- TODO LetVar
     Let a u      -> namesAndMetasIn' sg (a, u)
+    LetVar _ es  -> namesAndMetasIn' sg es
     MetaV x args -> namesAndMetasIn' sg (x, args)
     DontCare v   -> namesAndMetasIn' sg v
     Dummy _ args -> namesAndMetasIn' sg args

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -82,6 +82,7 @@ instance NamesIn a => NamesIn (Map k a)
 instance NamesIn a => NamesIn (Arg a)
 instance NamesIn a => NamesIn (Named n a)
 instance NamesIn a => NamesIn (Abs a)
+instance NamesIn a => NamesIn (LetAbs a)
 instance NamesIn a => NamesIn (WithArity a)
 instance NamesIn a => NamesIn (Open a)
 instance NamesIn a => NamesIn (C.FieldAssignment' a)
@@ -225,8 +226,8 @@ instance NamesIn Term where
     Pi a b       -> namesAndMetasIn' sg (a, b)
     Sort s       -> namesAndMetasIn' sg s
     Level l      -> namesAndMetasIn' sg l
-    Let a u v    -> namesAndMetasIn' sg (a, u, v)
     LetVar x es  -> __IMPOSSIBLE__ -- TODO LetVar
+    Let a u      -> namesAndMetasIn' sg (a, u)
     MetaV x args -> namesAndMetasIn' sg (x, args)
     DontCare v   -> namesAndMetasIn' sg v
     Dummy _ args -> namesAndMetasIn' sg args

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -227,7 +227,6 @@ instance NamesIn Term where
     Sort s       -> namesAndMetasIn' sg s
     Level l      -> namesAndMetasIn' sg l
     Let a u      -> namesAndMetasIn' sg (a, u)
-    LetVar _ es  -> namesAndMetasIn' sg es
     MetaV x args -> namesAndMetasIn' sg (x, args)
     DontCare v   -> namesAndMetasIn' sg v
     Dummy _ args -> namesAndMetasIn' sg args

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -226,7 +226,7 @@ instance NamesIn Term where
     Sort s       -> namesAndMetasIn' sg s
     Level l      -> namesAndMetasIn' sg l
     Let a u v    -> namesAndMetasIn' sg (a, u, v)
-    LetV x es    -> __IMPOSSIBLE__ -- TODO LetV
+    LetVar x es  -> __IMPOSSIBLE__ -- TODO LetVar
     MetaV x args -> namesAndMetasIn' sg (x, args)
     DontCare v   -> namesAndMetasIn' sg v
     Dummy _ args -> namesAndMetasIn' sg args

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -226,6 +226,7 @@ instance NamesIn Term where
     Sort s       -> namesAndMetasIn' sg s
     Level l      -> namesAndMetasIn' sg l
     Let a u v    -> namesAndMetasIn' sg (a, u, v)
+    LetV x es    -> __IMPOSSIBLE__ -- TODO LetV
     MetaV x args -> namesAndMetasIn' sg (x, args)
     DontCare v   -> namesAndMetasIn' sg v
     Dummy _ args -> namesAndMetasIn' sg args

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -119,7 +119,7 @@ makeEnv scope = do
         Just v | Just q <- name v,
                  noScopeCheck b || isNameInScope q scope -> return [(b, q)]
         _                                                -> return []
-  ctxVars <- map (fst . I.unDom) <$> asksTC envContext
+  ctxVars <- getContextNames'
   letVars <- Map.keys <$> asksTC envLetBindings
   let vars = ctxVars ++ letVars
 

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -283,8 +283,8 @@ instance HasConstInfo AbsToCon where
 instance MonadAddContext AbsToCon where
   addCtx a b c = AbsToCon (addCtx a b (unAbsToCon c))
 
-  addLetBinding' o a b c d =
-    AbsToCon (addLetBinding' o a b c (unAbsToCon d))
+  addLetBinding' il o a b c d =
+    AbsToCon (addLetBinding' il o a b c (unAbsToCon d))
 
   updateContext a b c = AbsToCon (updateContext a b (unAbsToCon c))
 

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -618,7 +618,9 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
       let bindx = LetBind (LetRange noRange) info (mkBindName x) ea eu
       return $ A.Let exprNoRange (singleton bindx) ev
 
-    I.LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
+    I.LetVar x es -> do
+      x <- fromMaybeM (freshName_ $ "'" ++ show x) $ nameOfLV' x
+      elims (A.Var x) =<< reify es
 
     I.MetaV x es -> do
           x' <- reify x

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -618,10 +618,6 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
       let bindx = LetBind (LetRange noRange) info (mkBindName x) ea eu
       return $ A.Let exprNoRange (singleton bindx) ev
 
-    I.LetVar x es -> do
-      x <- fromMaybeM (freshName_ $ "'" ++ show x) $ nameOfLV' x
-      elims (A.Var x) =<< reify es
-
     I.MetaV x es -> do
           x' <- reify x
 

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -612,6 +612,13 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
         skipGeneralizedParameter info = (not <$> showGeneralizedArguments) <&> (&& (argInfoOrigin info == Generalization))
 
     I.Sort s     -> reify s
+    I.Let a u v  -> do
+      Arg info ea <- reify a
+      eu     <- reify u
+      (x,ev) <- reify v
+      let bindx = LetBind (LetRange noRange) info (mkBindName x) ea eu
+      return $ A.Let exprNoRange (singleton bindx) ev
+
     I.MetaV x es -> do
           x' <- reify x
 

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -619,7 +619,7 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
       let bindx = LetBind (LetRange noRange) info (mkBindName x) ea eu
       return $ A.Let exprNoRange (singleton bindx) ev
 
-    I.LetV x es -> __IMPOSSIBLE__ -- TODO LetV
+    I.LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
 
     I.MetaV x es -> do
           x' <- reify x

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1538,9 +1538,11 @@ instance (Free i, Reify i) => Reify (Abs i) where
 instance (Free i, Reify i) => Reify (LetAbs i) where
   type ReifiesTo (LetAbs i) = (Name, A.Expr, ReifiesTo i)
 
-  reify (LetAbs s u v) = do
+  reify abs@(LetAbs s u v) = do
     eu <- reify u
-    (x,ev) <- reify (Abs s v)
+    s <- return $ if isUnderscore s && 0 `freeIn` v then "z" else s
+    x <- C.setNotInScope <$> freshName_ s
+    ev <- addContext (CtxLet x __DUMMY_DOM__ u) $ reify v
     return (x,eu,ev)
 {-# SPECIALIZE reify :: (Free i, Reify i) -> LetAbs i -> TCM (ReifiesTo (LetAbs i)) #-}
 

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -619,6 +619,8 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
       let bindx = LetBind (LetRange noRange) info (mkBindName x) ea eu
       return $ A.Let exprNoRange (singleton bindx) ev
 
+    I.LetV x es -> __IMPOSSIBLE__ -- TODO LetV
+
     I.MetaV x es -> do
           x' <- reify x
 

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1545,6 +1545,24 @@ instance Reify i => Reify (Dom i) where
     reify (Dom{domInfo = info, unDom = i}) = Arg info <$> reify i
     {-# INLINE reify #-}
 
+
+instance Reify ContextEntry where
+  type ReifiesTo ContextEntry = A.TypedBinding
+
+  reify (CtxVar x a) = do
+    Arg info (y,t) <- reify $ (x,) <$> a
+    let r = getRange x
+        name = domName a
+        xs = singleton $ Arg info $ Named name $ A.mkBinder_ y
+    tac <- TacticAttribute <$> do traverse (Ranged noRange <.> reify) $ domTactic a
+    return $ TBind r (TypedBindingInfo tac (domIsFinite a)) xs t
+  reify (CtxLet x a v) = do
+    Arg info (y,t) <- reify $ (x,) <$> a
+    v <- reify v
+    let r = getRange x
+    return $ TLet r $ singleton $
+      LetBind (LetRange noRange) info (mkBindName y) t v
+
 instance Reify i => Reify (I.Elim' i)  where
   type ReifiesTo (I.Elim' i) = I.Elim' (ReifiesTo i)
 

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -22,6 +22,7 @@ import Agda.Syntax.Abstract
   , isNoName, nameConcrete, nextName, qualify, unambiguous
   )
 import qualified Agda.Syntax.Abstract as A
+import Agda.Syntax.Abstract.Views (deepUnscope)
 import Agda.Syntax.Abstract.Pattern
 import Agda.Syntax.Reflected as R
 import Agda.Syntax.Internal (Dom,Dom'(..))
@@ -123,7 +124,7 @@ toAbstractWithoutImplicit ::
   , HasConstInfo m
   ) => r -> m (AbsOfRef r)
 toAbstractWithoutImplicit x = do
-  xs <- killRange <$> getContextNames
+  xs <- killRange <$> getContextNames'
   let ctx = zip xs $ repeat R.Unknown
   runReaderT (toAbstract x) ctx
 

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -535,8 +535,8 @@ termRecTel npars tel = do
       extract $ telFromList fields
   where
   -- create n variable patterns
-  mkPats n  = zipWith mkPat (downFrom n) <$> getContextNames
-  mkPat i x = notMasked $ VarP defaultPatternInfo $ DBPatVar (prettyShow x) i
+  mkPats n  = map mkPat <$> getContextVars
+  mkPat (i, x) = notMasked $ VarP defaultPatternInfo $ DBPatVar (prettyShow x) i
 
 -- | Collect calls in type signature @f : (x1:A1)...(xn:An) -> B@.
 --   It is treated as if there were the additional function clauses.
@@ -564,8 +564,8 @@ termType = return mempty
         extract dom `mappend` underAbstractionAbs dom absB (loop $! n + 1)
 
   -- create n variable patterns
-  mkPats n  = zipWith mkPat (downFrom n) <$> getContextNames
-  mkPat i x = notMasked $ VarP defaultPatternInfo $ DBPatVar (prettyShow x) i
+  mkPats n  = map mkPat <$> getContextVars
+  mkPat (i, x) = notMasked $ VarP defaultPatternInfo $ DBPatVar (prettyShow x) i
 
 -- | Mask arguments and result for termination checking
 --   according to type of function.

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1067,6 +1067,10 @@ instance ExtractCalls Term where
       -- Sort.
       Sort s -> extract s
 
+      Let a u v ->
+        mconcat <$> sequence
+          [ extract a, extract u, extract v ]
+
       -- Unsolved metas are not considered termination problems, there
       -- will be a warning for them anyway.
       MetaV x args -> return empty

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1071,6 +1071,8 @@ instance ExtractCalls Term where
         mconcat <$> sequence
           [ extract a, extract u, extract v ]
 
+      LetV x es -> __IMPOSSIBLE__ -- TODO LetV
+
       -- Unsolved metas are not considered termination problems, there
       -- will be a warning for them anyway.
       MetaV x args -> return empty

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1074,7 +1074,7 @@ instance ExtractCalls Term where
 
       Let a u -> CallGraph.union <$> extract a <*> extract u
 
-      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
+      LetVar x es -> extract es
 
       -- Unsolved metas are not considered termination problems, there
       -- will be a warning for them anyway.

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1074,8 +1074,6 @@ instance ExtractCalls Term where
 
       Let a u -> CallGraph.union <$> extract a <*> extract u
 
-      LetVar x es -> extract es
-
       -- Unsolved metas are not considered termination problems, there
       -- will be a warning for them anyway.
       MetaV x args -> return empty

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1071,7 +1071,7 @@ instance ExtractCalls Term where
         mconcat <$> sequence
           [ extract a, extract u, extract v ]
 
-      LetV x es -> __IMPOSSIBLE__ -- TODO LetV
+      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
 
       -- Unsolved metas are not considered termination problems, there
       -- will be a warning for them anyway.

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -196,7 +196,7 @@ instance AbsTerm Term where
       Level l     -> Level $ absT l
       Sort s      -> Sort $ absT s
       Let a u v   -> uncurry3 Let $ absT (a, u, v)
-      LetV x es   -> __IMPOSSIBLE__ -- TODO LetV
+      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
       MetaV m vs  -> MetaV m $ absT vs
       DontCare mv -> DontCare $ absT mv
       Dummy s es   -> Dummy s $ absT es

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -196,6 +196,7 @@ instance AbsTerm Term where
       Level l     -> Level $ absT l
       Sort s      -> Sort $ absT s
       Let a u v   -> uncurry3 Let $ absT (a, u, v)
+      LetV x es   -> __IMPOSSIBLE__ -- TODO LetV
       MetaV m vs  -> MetaV m $ absT vs
       DontCare mv -> DontCare $ absT mv
       Dummy s es   -> Dummy s $ absT es

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -194,8 +194,8 @@ instance AbsTerm Term where
       Lit l       -> Lit l
       Level l     -> Level $ absT l
       Sort s      -> Sort $ absT s
-      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
       Let a u     -> uncurry Let $ absT (a, u)
+      LetVar x es -> LetVar (x + 1) $ absT es
       MetaV m vs  -> MetaV m $ absT vs
       DontCare mv -> DontCare $ absT mv
       Dummy s es   -> Dummy s $ absT es

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -25,7 +25,6 @@ import Agda.TypeChecking.Telescope
 
 import Agda.Utils.Functor
 import Agda.Utils.List ( splitExactlyAt, dropEnd )
-import Agda.Utils.Tuple
 import Agda.Utils.Impossible
 
 -- | @abstractType a v b[v] = b@ where @a : v@.
@@ -195,8 +194,8 @@ instance AbsTerm Term where
       Lit l       -> Lit l
       Level l     -> Level $ absT l
       Sort s      -> Sort $ absT s
-      Let a u v   -> uncurry3 Let $ absT (a, u, v)
       LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
+      Let a u     -> uncurry Let $ absT (a, u)
       MetaV m vs  -> MetaV m $ absT vs
       DontCare mv -> DontCare $ absT mv
       Dummy s es   -> Dummy s $ absT es
@@ -249,6 +248,10 @@ instance AbsTerm a => AbsTerm (Maybe a) where
 instance (TermSubst a, AbsTerm a) => AbsTerm (Abs a) where
   absTerm u (NoAbs x v) = NoAbs x $ absTerm u v
   absTerm u (Abs   x v) = Abs x $ swap01 $ absTerm (raise 1 u) v
+
+instance (TermSubst a, AbsTerm a) => AbsTerm (LetAbs a) where
+  absTerm u (LetAbs x v w) =
+    LetAbs x (absTerm u v) $ swap01 $ absTerm (raise 1 u) w
 
 instance (AbsTerm a, AbsTerm b) => AbsTerm (a, b) where
   absTerm u (x, y) = (absTerm u x, absTerm u y)

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -195,7 +195,6 @@ instance AbsTerm Term where
       Level l     -> Level $ absT l
       Sort s      -> Sort $ absT s
       Let a u     -> uncurry Let $ absT (a, u)
-      LetVar x es -> LetVar (x + 1) $ absT es
       MetaV m vs  -> MetaV m $ absT vs
       DontCare mv -> DontCare $ absT mv
       Dummy s es   -> Dummy s $ absT es

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -25,6 +25,7 @@ import Agda.TypeChecking.Telescope
 
 import Agda.Utils.Functor
 import Agda.Utils.List ( splitExactlyAt, dropEnd )
+import Agda.Utils.Tuple
 import Agda.Utils.Impossible
 
 -- | @abstractType a v b[v] = b@ where @a : v@.
@@ -194,6 +195,7 @@ instance AbsTerm Term where
       Lit l       -> Lit l
       Level l     -> Level $ absT l
       Sort s      -> Sort $ absT s
+      Let a u v   -> uncurry3 Let $ absT (a, u, v)
       MetaV m vs  -> MetaV m $ absT vs
       DontCare mv -> DontCare $ absT mv
       Dummy s es   -> Dummy s $ absT es
@@ -249,6 +251,9 @@ instance (TermSubst a, AbsTerm a) => AbsTerm (Abs a) where
 
 instance (AbsTerm a, AbsTerm b) => AbsTerm (a, b) where
   absTerm u (x, y) = (absTerm u x, absTerm u y)
+
+instance (AbsTerm a, AbsTerm b, AbsTerm c) => AbsTerm (a, b, c) where
+  absTerm u (x, y, z) = (absTerm u x, absTerm u y, absTerm u z)
 
 -- | This swaps @var 0@ and @var 1@.
 swap01 :: TermSubst a => a -> a

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -217,16 +217,6 @@ instance CheckInternal Term where
         u <- checkInternal' action u CmpLeq (unDom a)
         v <- underLetBinding NoInlineLet a abs $ \v -> checkInternal' action v cmp t
         return $ Let a (LetAbs name u v)
-      LetVar x es -> do
-        d <- domOfLV x
-        n <- nameOfLV x
-        -- see Var case
-        unless (usableCohesion d) $
-          typeError $ VariableIsOfUnusableCohesion n (getCohesion d)
-        reportSDoc "tc.check.internal" 30 $ fsep
-          [ "let variable" , prettyTCM (var x) , "has type" , prettyTCM (unDom d)
-          , "and modality", pretty (getModality d) ]
-        checkSpine action (unDom d) (LetVar x) es cmp t
       DontCare v -> DontCare <$> checkInternal' action v cmp t
       -- Jesper, 2023-02-23: these can appear because of eta-expansion of
       -- records with irrelevant fields

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -210,6 +210,15 @@ instance CheckInternal Term where
         lt <- levelType'
         compareType cmp lt t
         return $ Level l
+      Let a u v -> do
+        let sa = getSort a
+            mkDom = (<$ a)
+            name = absName v
+        a <- El sa <$> checkInternal' action (unEl $ unDom a) CmpLeq (sort sa)
+        u <- checkInternal' action u CmpLeq a
+        -- TODO: have a way to add a let-bound variable to the context
+        -- that gives it a de Bruijn index (rather than an abstract name)
+        checkInternal' action (absApp v u) cmp t
       DontCare v -> DontCare <$> checkInternal' action v cmp t
       -- Jesper, 2023-02-23: these can appear because of eta-expansion of
       -- records with irrelevant fields

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -215,7 +215,7 @@ instance CheckInternal Term where
             mkDom = (<$ a)
         a <- mkDom . El sa <$> checkInternal' action (unEl $ unDom a) CmpLeq (sort sa)
         u <- checkInternal' action u CmpLeq (unDom a)
-        v <- underLetBinding a abs $ \v -> checkInternal' action v cmp t
+        v <- underLetBinding NoInlineLet a abs $ \v -> checkInternal' action v cmp t
         return $ Let a (LetAbs name u v)
       LetVar x es -> do
         d <- domOfLV x

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -219,6 +219,7 @@ instance CheckInternal Term where
         -- TODO: have a way to add a let-bound variable to the context
         -- that gives it a de Bruijn index (rather than an abstract name)
         checkInternal' action (absApp v u) cmp t
+      LetV x es -> __IMPOSSIBLE__ -- TODO LetV
       DontCare v -> DontCare <$> checkInternal' action v cmp t
       -- Jesper, 2023-02-23: these can appear because of eta-expansion of
       -- records with irrelevant fields

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -213,11 +213,20 @@ instance CheckInternal Term where
       Let a abs@(LetAbs name u v) -> do
         let sa = getSort a
             mkDom = (<$ a)
-      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
         a <- mkDom . El sa <$> checkInternal' action (unEl $ unDom a) CmpLeq (sort sa)
         u <- checkInternal' action u CmpLeq (unDom a)
         v <- underLetBinding a abs $ \v -> checkInternal' action v cmp t
         return $ Let a (LetAbs name u v)
+      LetVar x es -> do
+        d <- domOfLV x
+        n <- nameOfLV x
+        -- see Var case
+        unless (usableCohesion d) $
+          typeError $ VariableIsOfUnusableCohesion n (getCohesion d)
+        reportSDoc "tc.check.internal" 30 $ fsep
+          [ "let variable" , prettyTCM (var x) , "has type" , prettyTCM (unDom d)
+          , "and modality", pretty (getModality d) ]
+        checkSpine action (unDom d) (LetVar x) es cmp t
       DontCare v -> DontCare <$> checkInternal' action v cmp t
       -- Jesper, 2023-02-23: these can appear because of eta-expansion of
       -- records with irrelevant fields

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -219,7 +219,7 @@ instance CheckInternal Term where
         -- TODO: have a way to add a let-bound variable to the context
         -- that gives it a de Bruijn index (rather than an abstract name)
         checkInternal' action (absApp v u) cmp t
-      LetV x es -> __IMPOSSIBLE__ -- TODO LetV
+      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
       DontCare v -> DontCare <$> checkInternal' action v cmp t
       -- Jesper, 2023-02-23: these can appear because of eta-expansion of
       -- records with irrelevant fields

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -97,7 +97,8 @@ compileClauses mt cs = do
         [ "compiled clauses of " <+> prettyTCM q
         , nest 2 $ return $ P.pretty cc
         ]
-      return (Just splitTree, becameCopatternLHS, fmap precomputeFreeVars_ cc)
+      cc <- traverse precomputeFreeVars_ cc
+      return (Just splitTree, becameCopatternLHS, cc)
 
 -- | Stripped-down version of 'Agda.Syntax.Internal.Clause'
 --   used in clause compiler.

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -2117,7 +2117,7 @@ forallFaceMaps t kb k = do
       let t = foldr (\ x r -> and `apply` [argN x,argN r]) io ts
       ifBlocked t blocked unblocked
     addBindings [] m = m
-    addBindings (((nm,Dom{domInfo = info,unDom = ty}),t):bs) m = addLetBinding info Inserted nm t ty (addBindings bs m)
+    addBindings (((nm,Dom{domInfo = info,unDom = ty}),t):bs) m = addLetBinding YesInlineLet info Inserted nm t ty (addBindings bs m)
 
     substContextN :: MonadConversion m => Context -> [(Int,Term)] -> m (Context , Substitution)
     substContextN c [] = return (c, idS)

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -2117,7 +2117,7 @@ forallFaceMaps t kb k = do
       let t = foldr (\ x r -> and `apply` [argN x,argN r]) io ts
       ifBlocked t blocked unblocked
     addBindings [] m = m
-    addBindings ((Dom{domInfo = info,unDom = (nm,ty)},t):bs) m = addLetBinding info Inserted nm t ty (addBindings bs m)
+    addBindings (((nm,Dom{domInfo = info,unDom = ty}),t):bs) m = addLetBinding info Inserted nm t ty (addBindings bs m)
 
     substContextN :: MonadConversion m => Context -> [(Int,Term)] -> m (Context , Substitution)
     substContextN c [] = return (c, idS)

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -2117,7 +2117,8 @@ forallFaceMaps t kb k = do
       let t = foldr (\ x r -> and `apply` [argN x,argN r]) io ts
       ifBlocked t blocked unblocked
     addBindings [] m = m
-    addBindings (((nm,Dom{domInfo = info,unDom = ty}),t):bs) m = addLetBinding YesInlineLet info Inserted nm t ty (addBindings bs m)
+    addBindings ((CtxVar nm ty,t):bs) m = addLetBinding YesInlineLet (getArgInfo ty) Inserted nm t (unDom ty) (addBindings bs m)
+    addBindings ((CtxLet{},t):bs) m = __IMPOSSIBLE__
 
     substContextN :: MonadConversion m => Context -> [(Int,Term)] -> m (Context , Substitution)
     substContextN c [] = return (c, idS)

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -42,8 +42,8 @@ binAppView t = case t of
   Lam _ _    -> noApp
   Pi _ _     -> noApp
   Sort _     -> noApp
-  Let _ _ _  -> noApp   -- ???
   LetVar x es -> __IMPOSSIBLE__
+  Let _ _    -> noApp   -- TODO: is this ok???
   MetaV _ _  -> noApp
   DontCare _ -> noApp
   Dummy{}    -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -43,6 +43,7 @@ binAppView t = case t of
   Pi _ _     -> noApp
   Sort _     -> noApp
   Let _ _ _  -> noApp   -- ???
+  LetV x es  -> __IMPOSSIBLE__
   MetaV _ _  -> noApp
   DontCare _ -> noApp
   Dummy{}    -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -43,7 +43,6 @@ binAppView t = case t of
   Pi _ _     -> noApp
   Sort _     -> noApp
   Let _ _    -> noApp   -- TODO: is this ok???
-  LetVar _ _ -> noApp  -- TODO: is this ok?
   MetaV _ _  -> noApp
   DontCare _ -> noApp
   Dummy{}    -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -42,8 +42,8 @@ binAppView t = case t of
   Lam _ _    -> noApp
   Pi _ _     -> noApp
   Sort _     -> noApp
-  LetVar x es -> __IMPOSSIBLE__
   Let _ _    -> noApp   -- TODO: is this ok???
+  LetVar _ _ -> noApp  -- TODO: is this ok?
   MetaV _ _  -> noApp
   DontCare _ -> noApp
   Dummy{}    -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -42,6 +42,7 @@ binAppView t = case t of
   Lam _ _    -> noApp
   Pi _ _     -> noApp
   Sort _     -> noApp
+  Let _ _ _  -> noApp   -- ???
   MetaV _ _  -> noApp
   DontCare _ -> noApp
   Dummy{}    -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -43,7 +43,7 @@ binAppView t = case t of
   Pi _ _     -> noApp
   Sort _     -> noApp
   Let _ _ _  -> noApp   -- ???
-  LetV x es  -> __IMPOSSIBLE__
+  LetVar x es -> __IMPOSSIBLE__
   MetaV _ _  -> noApp
   DontCare _ -> noApp
   Dummy{}    -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -539,8 +539,8 @@ instance Free Term where
     Pi a b       -> freeVars' (a,b)
     Sort s       -> freeVars' s
     Level l      -> freeVars' l
-    LetVar x es  -> __IMPOSSIBLE__ -- TODO
     Let a u      -> freeVars' (a,u)
+    LetVar x es  -> variable x `mappend` do underFlexRig WeaklyRigid $ freeVars' es
     MetaV m ts   -> underFlexRig (Flexible $ singleton m) $ freeVars' ts
     DontCare mt  -> underModality (Modality Irrelevant unitQuantity unitCohesion) $ freeVars' mt
     Dummy{}      -> mempty

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -540,7 +540,6 @@ instance Free Term where
     Sort s       -> freeVars' s
     Level l      -> freeVars' l
     Let a u      -> freeVars' (a,u)
-    LetVar x es  -> variable x `mappend` do underFlexRig WeaklyRigid $ freeVars' es
     MetaV m ts   -> underFlexRig (Flexible $ singleton m) $ freeVars' ts
     DontCare mt  -> underModality (Modality Irrelevant unitQuantity unitCohesion) $ freeVars' mt
     Dummy{}      -> mempty

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -539,8 +539,8 @@ instance Free Term where
     Pi a b       -> freeVars' (a,b)
     Sort s       -> freeVars' s
     Level l      -> freeVars' l
-    Let a u v    -> freeVars' (a,u,v)
     LetVar x es  -> __IMPOSSIBLE__ -- TODO
+    Let a u      -> freeVars' (a,u)
     MetaV m ts   -> underFlexRig (Flexible $ singleton m) $ freeVars' ts
     DontCare mt  -> underModality (Modality Irrelevant unitQuantity unitCohesion) $ freeVars' mt
     Dummy{}      -> mempty
@@ -600,6 +600,9 @@ instance Free t => Free (Dom t) where
 instance Free t => Free (Abs t) where
   freeVars' (Abs   _ b) = underBinder $ freeVars' b
   freeVars' (NoAbs _ b) = freeVars' b
+
+instance Free t => Free (LetAbs t) where
+  freeVars' (LetAbs _ u b) = freeVars' u <> underBinder (freeVars' b)
 
 instance Free t => Free (Tele t) where
   freeVars' EmptyTel          = mempty

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -76,6 +76,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Internal
 
 import Agda.Utils.Functor
+import Agda.Utils.Impossible
 import Agda.Utils.Lens
 import Agda.Utils.Monad
 import Agda.Utils.Null
@@ -539,6 +540,7 @@ instance Free Term where
     Sort s       -> freeVars' s
     Level l      -> freeVars' l
     Let a u v    -> freeVars' (a,u,v)
+    LetV x es    -> __IMPOSSIBLE__ -- TODO
     MetaV m ts   -> underFlexRig (Flexible $ singleton m) $ freeVars' ts
     DontCare mt  -> underModality (Modality Irrelevant unitQuantity unitCohesion) $ freeVars' mt
     Dummy{}      -> mempty

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -538,6 +538,7 @@ instance Free Term where
     Pi a b       -> freeVars' (a,b)
     Sort s       -> freeVars' s
     Level l      -> freeVars' l
+    Let a u v    -> freeVars' (a,u,v)
     MetaV m ts   -> underFlexRig (Flexible $ singleton m) $ freeVars' ts
     DontCare mt  -> underModality (Modality Irrelevant unitQuantity unitCohesion) $ freeVars' mt
     Dummy{}      -> mempty

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -540,7 +540,7 @@ instance Free Term where
     Sort s       -> freeVars' s
     Level l      -> freeVars' l
     Let a u v    -> freeVars' (a,u,v)
-    LetV x es    -> __IMPOSSIBLE__ -- TODO
+    LetVar x es  -> __IMPOSSIBLE__ -- TODO
     MetaV m ts   -> underFlexRig (Flexible $ singleton m) $ freeVars' ts
     DontCare mt  -> underModality (Modality Irrelevant unitQuantity unitCohesion) $ freeVars' mt
     Dummy{}      -> mempty

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -12,7 +12,6 @@ import qualified Data.IntSet as IntSet
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad.Base
-import Agda.Utils.Tuple
 
 
 
@@ -58,6 +57,11 @@ instance PrecomputeFreeVars a => PrecomputeFreeVars (Abs a) where
     censor (IntSet.map (subtract 1) . IntSet.delete 0) $
       Abs x <$> precomputeFreeVars b
 
+instance PrecomputeFreeVars a => PrecomputeFreeVars (LetAbs a) where
+  precomputeFreeVars (LetAbs x a b) =
+    LetAbs x <$> precomputeFreeVars a <*>
+      censor (IntSet.map (subtract 1) . IntSet.delete 0) (precomputeFreeVars b)
+
 instance PrecomputeFreeVars Term where
   precomputeFreeVars t =
     case t of
@@ -71,7 +75,7 @@ instance PrecomputeFreeVars Term where
       Pi a b     -> uncurry Pi <$> precomputeFreeVars (a, b)
       Sort s     -> Sort       <$> precomputeFreeVars s
       Level l    -> Level      <$> precomputeFreeVars l
-      Let a u v  -> uncurry3 Let <$> precomputeFreeVars (a, u, v)
+      Let a u    -> uncurry Let <$> precomputeFreeVars (a, u)
       LetVar x es -> undefined -- TODO
       MetaV x es -> MetaV x    <$> precomputeFreeVars es
       DontCare t -> DontCare   <$> precomputeFreeVars t

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -69,6 +69,7 @@ instance PrecomputeFreeVars Term where
       Sort s     -> Sort       <$> precomputeFreeVars s
       Level l    -> Level      <$> precomputeFreeVars l
       Let a u v  -> uncurry3 Let <$> precomputeFreeVars (a, u, v)
+      LetV x es  -> undefined -- TODO
       MetaV x es -> MetaV x    <$> precomputeFreeVars es
       DontCare t -> DontCare   <$> precomputeFreeVars t
       Dummy{}    -> pure t

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -11,6 +11,7 @@ import qualified Data.IntSet as IntSet
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
+import Agda.Utils.Tuple
 
 
 
@@ -67,6 +68,7 @@ instance PrecomputeFreeVars Term where
       Pi a b     -> uncurry Pi <$> precomputeFreeVars (a, b)
       Sort s     -> Sort       <$> precomputeFreeVars s
       Level l    -> Level      <$> precomputeFreeVars l
+      Let a u v  -> uncurry3 Let <$> precomputeFreeVars (a, u, v)
       MetaV x es -> MetaV x    <$> precomputeFreeVars es
       DontCare t -> DontCare   <$> precomputeFreeVars t
       Dummy{}    -> pure t
@@ -113,3 +115,6 @@ instance PrecomputeFreeVars a => PrecomputeFreeVars (Maybe a) where
 
 instance (PrecomputeFreeVars a, PrecomputeFreeVars b) => PrecomputeFreeVars (a, b) where
   precomputeFreeVars (x, y) = (,) <$> precomputeFreeVars x <*> precomputeFreeVars y
+
+instance (PrecomputeFreeVars a, PrecomputeFreeVars b, PrecomputeFreeVars c) => PrecomputeFreeVars (a, b, c) where
+  precomputeFreeVars (x, y, z) = (,,) <$> precomputeFreeVars x <*> precomputeFreeVars y <*> precomputeFreeVars z

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -72,7 +72,7 @@ instance PrecomputeFreeVars Term where
       Sort s     -> Sort       <$> precomputeFreeVars s
       Level l    -> Level      <$> precomputeFreeVars l
       Let a u v  -> uncurry3 Let <$> precomputeFreeVars (a, u, v)
-      LetV x es  -> undefined -- TODO
+      LetVar x es -> undefined -- TODO
       MetaV x es -> MetaV x    <$> precomputeFreeVars es
       DontCare t -> DontCare   <$> precomputeFreeVars t
       Dummy{}    -> pure t

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -76,7 +76,9 @@ instance PrecomputeFreeVars Term where
       Sort s     -> Sort       <$> precomputeFreeVars s
       Level l    -> Level      <$> precomputeFreeVars l
       Let a u    -> uncurry Let <$> precomputeFreeVars (a, u)
-      LetVar x es -> undefined -- TODO
+      LetVar x es -> do
+        tell (IntSet.singleton x)
+        Var x <$> precomputeFreeVars es
       MetaV x es -> MetaV x    <$> precomputeFreeVars es
       DontCare t -> DontCare   <$> precomputeFreeVars t
       Dummy{}    -> pure t

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -76,9 +76,6 @@ instance PrecomputeFreeVars Term where
       Sort s     -> Sort       <$> precomputeFreeVars s
       Level l    -> Level      <$> precomputeFreeVars l
       Let a u    -> uncurry Let <$> precomputeFreeVars (a, u)
-      LetVar x es -> do
-        tell (IntSet.singleton x)
-        Var x <$> precomputeFreeVars es
       MetaV x es -> MetaV x    <$> precomputeFreeVars es
       DontCare t -> DontCare   <$> precomputeFreeVars t
       Dummy{}    -> pure t

--- a/src/full/Agda/TypeChecking/Free/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Free/Reduce.hs
@@ -48,7 +48,7 @@ forceNotFree xs a = do
   -- Initially, all variables are marked as `NotFree`. This is changed
   -- to `MaybeFree` when we find an occurrence.
   let mxs = IntMap.fromSet (const NotFree) xs
-  (a, mxs) <- runStateT (runReaderT (forceNotFreeR $ precomputeFreeVars_ a) mempty) mxs
+  (a, mxs) <- runStateT (runReaderT (forceNotFreeR =<< precomputeFreeVars_ a) mempty) mxs
   return (mxs, a)
 
 -- | Checks if the given term contains any free variables that are in
@@ -105,11 +105,11 @@ reduceIfFreeVars :: (Reduce a, ForceNotFree a, MonadFreeRed m)
                  => (a -> m a) -> a -> m a
 reduceIfFreeVars k a = do
   xs <- varsToForceNotFree
-  let fvs     = precomputedFreeVars a
-      notfree = IntSet.disjoint xs fvs
+  fvs <- precomputedFreeVars a
+  let notfree = IntSet.disjoint xs fvs
   if notfree
     then return a
-    else k . precomputeFreeVars_ =<< reduce a
+    else k =<< precomputeFreeVars_ =<< reduce a
 
 -- Careful not to define forceNotFree' = forceNotFreeR since that would loop.
 forceNotFreeR :: (Reduce a, ForceNotFree a, MonadFreeRed m)

--- a/src/full/Agda/TypeChecking/Free/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Free/Reduce.hs
@@ -18,6 +18,7 @@ import qualified Data.IntMap as IntMap
 import Data.IntMap (IntMap)
 import qualified Data.IntSet as IntSet
 import Data.IntSet (IntSet)
+import Data.Maybe (fromMaybe)
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
@@ -27,6 +28,7 @@ import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Free
 import Agda.TypeChecking.Free.Precompute
 
+import Agda.Utils.Impossible
 import Agda.Utils.Monad
 import Agda.Utils.Null
 
@@ -167,8 +169,8 @@ instance ForceNotFree Term where
     Pi a b     -> Pi       <$> forceNotFree' a <*> forceNotFree' b  -- Dom and Abs do reduceIf so not needed here
     Sort s     -> Sort     <$> forceNotFree' s
     Level l    -> Level    <$> forceNotFree' l
-    LetVar x es -> LetVar x   <$> forceNotFree' es -- TODO: check body of x!!
     Let a u    -> Let      <$> forceNotFree' a <*> forceNotFree' u
+    LetVar x es -> forceNotFree' . (`applyE` es) . fromMaybe __IMPOSSIBLE__ =<< valueOfLV' x
     DontCare t -> DontCare <$> forceNotFreeR t  -- Reduction stops at DontCare so reduceIf
     t@Lit{}    -> return t
     t@Dummy{}  -> return t

--- a/src/full/Agda/TypeChecking/Free/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Free/Reduce.hs
@@ -162,7 +162,7 @@ instance ForceNotFree Term where
     Sort s     -> Sort     <$> forceNotFree' s
     Level l    -> Level    <$> forceNotFree' l
     Let a u v  -> Let      <$> forceNotFree' a <*> forceNotFree' u <*> forceNotFree' v
-    LetV x es  -> LetV x   <$> forceNotFree' es -- TODO: check body of x!!
+    LetVar x es -> LetVar x   <$> forceNotFree' es -- TODO: check body of x!!
     DontCare t -> DontCare <$> forceNotFreeR t  -- Reduction stops at DontCare so reduceIf
     t@Lit{}    -> return t
     t@Dummy{}  -> return t

--- a/src/full/Agda/TypeChecking/Free/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Free/Reduce.hs
@@ -161,6 +161,7 @@ instance ForceNotFree Term where
     Pi a b     -> Pi       <$> forceNotFree' a <*> forceNotFree' b  -- Dom and Abs do reduceIf so not needed here
     Sort s     -> Sort     <$> forceNotFree' s
     Level l    -> Level    <$> forceNotFree' l
+    Let a u v  -> Let      <$> forceNotFree' a <*> forceNotFree' u <*> forceNotFree' v
     DontCare t -> DontCare <$> forceNotFreeR t  -- Reduction stops at DontCare so reduceIf
     t@Lit{}    -> return t
     t@Dummy{}  -> return t

--- a/src/full/Agda/TypeChecking/Free/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Free/Reduce.hs
@@ -162,6 +162,7 @@ instance ForceNotFree Term where
     Sort s     -> Sort     <$> forceNotFree' s
     Level l    -> Level    <$> forceNotFree' l
     Let a u v  -> Let      <$> forceNotFree' a <*> forceNotFree' u <*> forceNotFree' v
+    LetV x es  -> LetV x   <$> forceNotFree' es -- TODO: check body of x!!
     DontCare t -> DontCare <$> forceNotFreeR t  -- Reduction stops at DontCare so reduceIf
     t@Lit{}    -> return t
     t@Dummy{}  -> return t

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -218,7 +218,7 @@ generalizeTelescope vars typecheckAction ret = billTo [Typing, Generalize] $ wit
   -- And modules created in the telescope (#6916)
   --   TODO
   letbinds' <- applySubst (liftS (size tel) sub) <$> instantiateFull letbinds
-  let addLet (x, LetBinding o v dom) = addLetBinding' o x v dom
+  let addLet (x, LetBinding o v dom) = addLetBinding' YesInlineLet o x v dom
 
   updateContext sub ((genTelCxt ++) . drop 1) $
     updateContext (raiseS (size tel')) (newTelCxt ++) $

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -131,7 +131,6 @@ headSymbol v = do -- ignoreAbstractMode $ do
     MetaV{} -> return Nothing
     DontCare{} -> return Nothing
     Let{}   -> __IMPOSSIBLE__
-    LetVar{}  -> __IMPOSSIBLE__
     Dummy s _ -> __IMPOSSIBLE_VERBOSE__ s
 
 -- | Is this a matchable definition, or constructor, which reduces based
@@ -181,7 +180,6 @@ headSymbol' v = do
       Level{}    -> return Nothing
       DontCare{} -> return Nothing
       Let{}      -> __IMPOSSIBLE__
-      LetVar{}   -> __IMPOSSIBLE__
       MetaV{}    -> __IMPOSSIBLE__
       Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -131,7 +131,7 @@ headSymbol v = do -- ignoreAbstractMode $ do
     MetaV{} -> return Nothing
     DontCare{} -> return Nothing
     Let{}   -> __IMPOSSIBLE__
-    LetV{}  -> __IMPOSSIBLE__
+    LetVar{}  -> __IMPOSSIBLE__
     Dummy s _ -> __IMPOSSIBLE_VERBOSE__ s
 
 -- | Is this a matchable definition, or constructor, which reduces based
@@ -181,7 +181,7 @@ headSymbol' v = do
       Level{}    -> return Nothing
       DontCare{} -> return Nothing
       Let{}      -> __IMPOSSIBLE__
-      LetV{}     -> __IMPOSSIBLE__
+      LetVar{}   -> __IMPOSSIBLE__
       MetaV{}    -> __IMPOSSIBLE__
       Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -130,6 +130,7 @@ headSymbol v = do -- ignoreAbstractMode $ do
     Level{} -> return Nothing
     MetaV{} -> return Nothing
     DontCare{} -> return Nothing
+    Let{}   -> __IMPOSSIBLE__
     Dummy s _ -> __IMPOSSIBLE_VERBOSE__ s
 
 -- | Is this a matchable definition, or constructor, which reduces based
@@ -178,6 +179,7 @@ headSymbol' v = do
       Lam{}      -> return Nothing
       Level{}    -> return Nothing
       DontCare{} -> return Nothing
+      Let{}      -> __IMPOSSIBLE__
       MetaV{}    -> __IMPOSSIBLE__
       Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -131,6 +131,7 @@ headSymbol v = do -- ignoreAbstractMode $ do
     MetaV{} -> return Nothing
     DontCare{} -> return Nothing
     Let{}   -> __IMPOSSIBLE__
+    LetV{}  -> __IMPOSSIBLE__
     Dummy s _ -> __IMPOSSIBLE_VERBOSE__ s
 
 -- | Is this a matchable definition, or constructor, which reduces based
@@ -180,6 +181,7 @@ headSymbol' v = do
       Level{}    -> return Nothing
       DontCare{} -> return Nothing
       Let{}      -> __IMPOSSIBLE__
+      LetV{}     -> __IMPOSSIBLE__
       MetaV{}    -> __IMPOSSIBLE__
       Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -572,7 +572,6 @@ insidePi t ret = reduce (unEl t) >>= \case
     Lit{}      -> __IMPOSSIBLE__
     Level{}    -> __IMPOSSIBLE__
     Let{}      -> __IMPOSSIBLE__
-    LetVar{}   -> __IMPOSSIBLE__
     MetaV{}    -> __IMPOSSIBLE__
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
@@ -1046,7 +1045,6 @@ getOutputTypeName t = ignoreAbstractMode $ do
       Lit{}    -> __IMPOSSIBLE__
       Level{}  -> __IMPOSSIBLE__
       Let{}    -> __IMPOSSIBLE__
-      LetVar{} -> __IMPOSSIBLE__
       MetaV{}  -> __IMPOSSIBLE__
       DontCare{} -> __IMPOSSIBLE__
       Dummy s _ -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -571,6 +571,7 @@ insidePi t ret = reduce (unEl t) >>= \case
     Lam{}      -> __IMPOSSIBLE__
     Lit{}      -> __IMPOSSIBLE__
     Level{}    -> __IMPOSSIBLE__
+    Let{}      -> __IMPOSSIBLE__
     MetaV{}    -> __IMPOSSIBLE__
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
@@ -1043,6 +1044,7 @@ getOutputTypeName t = ignoreAbstractMode $ do
       Lam{}    -> __IMPOSSIBLE__
       Lit{}    -> __IMPOSSIBLE__
       Level{}  -> __IMPOSSIBLE__
+      Let{}    -> __IMPOSSIBLE__
       MetaV{}  -> __IMPOSSIBLE__
       DontCare{} -> __IMPOSSIBLE__
       Dummy s _ -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -572,6 +572,7 @@ insidePi t ret = reduce (unEl t) >>= \case
     Lit{}      -> __IMPOSSIBLE__
     Level{}    -> __IMPOSSIBLE__
     Let{}      -> __IMPOSSIBLE__
+    LetV{}     -> __IMPOSSIBLE__
     MetaV{}    -> __IMPOSSIBLE__
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
@@ -1045,6 +1046,7 @@ getOutputTypeName t = ignoreAbstractMode $ do
       Lit{}    -> __IMPOSSIBLE__
       Level{}  -> __IMPOSSIBLE__
       Let{}    -> __IMPOSSIBLE__
+      LetV{}   -> __IMPOSSIBLE__
       MetaV{}  -> __IMPOSSIBLE__
       DontCare{} -> __IMPOSSIBLE__
       Dummy s _ -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -572,7 +572,7 @@ insidePi t ret = reduce (unEl t) >>= \case
     Lit{}      -> __IMPOSSIBLE__
     Level{}    -> __IMPOSSIBLE__
     Let{}      -> __IMPOSSIBLE__
-    LetV{}     -> __IMPOSSIBLE__
+    LetVar{}   -> __IMPOSSIBLE__
     MetaV{}    -> __IMPOSSIBLE__
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
@@ -1046,7 +1046,7 @@ getOutputTypeName t = ignoreAbstractMode $ do
       Lit{}    -> __IMPOSSIBLE__
       Level{}  -> __IMPOSSIBLE__
       Let{}    -> __IMPOSSIBLE__
-      LetV{}   -> __IMPOSSIBLE__
+      LetVar{} -> __IMPOSSIBLE__
       MetaV{}  -> __IMPOSSIBLE__
       DontCare{} -> __IMPOSSIBLE__
       Dummy s _ -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -129,7 +129,7 @@ instance UsableRelevance Term where
     Sort s   -> usableRel rel s
     Level l  -> return True
     Let a u v -> usableRel rel (a,u,v)
-    LetV x es -> __IMPOSSIBLE__ -- TODO LetV
+    LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
     MetaV m vs -> do
       mrel <- getRelevance <$> lookupMetaModality m
       return (mrel `moreRelevant` rel) `and2M` usableRel rel vs
@@ -255,7 +255,7 @@ instance UsableModality Term where
         -- TODO: remove code duplication with Pi
         domMod = mapQuantity (composeQuantity $ getQuantity a) $
                  mapCohesion (composeCohesion $ getCohesion a) mod
-    LetV x es -> __IMPOSSIBLE__ -- TODO LetV
+    LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
     MetaV m vs -> do
       mmod <- lookupMetaModality m
       let ok = mmod `moreUsableModality` mod

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -194,6 +194,7 @@ instance (Subst a, UsableRelevance a) => UsableRelevance (Abs a) where
   usableRel rel abs = underAbstraction_ abs $ \u -> usableRel rel u
 
 instance (Subst a, UsableRelevance a) => UsableRelevance (LetAbs a) where
+  -- No need to check let-bound value, since it will be checked at use site
   usableRel rel abs = underLetBinding_ abs $ \u -> usableRel rel u
 
 -- | Check whether something can be used in a position of the given modality.
@@ -257,7 +258,8 @@ instance UsableModality Term where
     Level l  -> return True
     Let a u -> andM
       [ usableMod domMod (unEl $ unDom a)
-      , underLetBinding a u $ usableMod mod
+        -- No need to check let-bound value, since it will be checked at use site
+      , underLetBinding NoInlineLet a u $ usableMod mod
       ]
       where
         -- TODO: remove code duplication with Pi

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -128,14 +128,6 @@ instance UsableRelevance Term where
     Sort s   -> usableRel rel s
     Level l  -> return True
     Let a u  -> usableRel rel (a,u)
-    LetVar x es -> do
-      xrel <- getRelevance <$> domOfLV x
-      let ok = xrel `moreRelevant` rel
-      reportSDoc "tc.irr" 50 $
-        "Let variable" <+> prettyTCM (var x) <+>
-        text ("has relevance " ++ show xrel ++ ", which is " ++
-              (if ok then "" else "NOT ") ++ "more relevant than " ++ show rel)
-      return ok `and2M` usableRel rel es
     MetaV m vs -> do
       mrel <- getRelevance <$> lookupMetaModality m
       return (mrel `moreRelevant` rel) `and2M` usableRel rel vs
@@ -265,14 +257,6 @@ instance UsableModality Term where
         -- TODO: remove code duplication with Pi
         domMod = mapQuantity (composeQuantity $ getQuantity a) $
                  mapCohesion (composeCohesion $ getCohesion a) mod
-    LetVar x es -> do
-      xmod <- getModality <$> domOfBV x
-      let ok = xmod `moreUsableModality` mod
-      reportSDoc "tc.irr" 50 $
-        "Let variable" <+> prettyTCM (var x) <+>
-        text ("has modality " ++ show xmod ++ ", which is a " ++
-              (if ok then "" else "NOT ") ++ "more usable modality than " ++ show mod)
-      return ok `and2M` usableMod mod es
     MetaV m vs -> do
       mmod <- lookupMetaModality m
       let ok = mmod `moreUsableModality` mod

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -86,6 +86,7 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute.Class
 
 import Agda.Utils.Lens
+import Agda.Utils.Impossible
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 
@@ -128,6 +129,7 @@ instance UsableRelevance Term where
     Sort s   -> usableRel rel s
     Level l  -> return True
     Let a u v -> usableRel rel (a,u,v)
+    LetV x es -> __IMPOSSIBLE__ -- TODO LetV
     MetaV m vs -> do
       mrel <- getRelevance <$> lookupMetaModality m
       return (mrel `moreRelevant` rel) `and2M` usableRel rel vs
@@ -253,6 +255,7 @@ instance UsableModality Term where
         -- TODO: remove code duplication with Pi
         domMod = mapQuantity (composeQuantity $ getQuantity a) $
                  mapCohesion (composeCohesion $ getCohesion a) mod
+    LetV x es -> __IMPOSSIBLE__ -- TODO LetV
     MetaV m vs -> do
       mmod <- lookupMetaModality m
       let ok = mmod `moreUsableModality` mod

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -86,7 +86,6 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute.Class
 
 import Agda.Utils.Lens
-import Agda.Utils.Impossible
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 
@@ -128,8 +127,15 @@ instance UsableRelevance Term where
     Pi a b   -> usableRel rel (a,b)
     Sort s   -> usableRel rel s
     Level l  -> return True
-    LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
     Let a u  -> usableRel rel (a,u)
+    LetVar x es -> do
+      xrel <- getRelevance <$> domOfLV x
+      let ok = xrel `moreRelevant` rel
+      reportSDoc "tc.irr" 50 $
+        "Let variable" <+> prettyTCM (var x) <+>
+        text ("has relevance " ++ show xrel ++ ", which is " ++
+              (if ok then "" else "NOT ") ++ "more relevant than " ++ show rel)
+      return ok `and2M` usableRel rel es
     MetaV m vs -> do
       mrel <- getRelevance <$> lookupMetaModality m
       return (mrel `moreRelevant` rel) `and2M` usableRel rel vs
@@ -257,7 +263,14 @@ instance UsableModality Term where
         -- TODO: remove code duplication with Pi
         domMod = mapQuantity (composeQuantity $ getQuantity a) $
                  mapCohesion (composeCohesion $ getCohesion a) mod
-    LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
+    LetVar x es -> do
+      xmod <- getModality <$> domOfBV x
+      let ok = xmod `moreUsableModality` mod
+      reportSDoc "tc.irr" 50 $
+        "Let variable" <+> prettyTCM (var x) <+>
+        text ("has modality " ++ show xmod ++ ", which is a " ++
+              (if ok then "" else "NOT ") ++ "more usable modality than " ++ show mod)
+      return ok `and2M` usableMod mod es
     MetaV m vs -> do
       mmod <- lookupMetaModality m
       let ok = mmod `moreUsableModality` mod

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -72,8 +72,8 @@ checkLockedVars t ty lk lk_ty = catchConstraint (CheckLockedVars t ty lk lk_ty) 
     earlierVars = ISet.fromList [i + 1 .. size cxt - 1]
   if termVars `ISet.isSubsetOf` earlierVars then return () else do
 
-  checked <- fmap catMaybes . forM toCheck $ \ (j,dom) -> do
-    ifM (isTimeless (snd . unDom $ dom))
+  checked <- fmap catMaybes . forM toCheck $ \ (j,ce) -> do
+    ifM (isTimeless (ctxEntryType ce))
         (return $ Just j)
         (return $ Nothing)
 

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -101,7 +101,7 @@ getLockVar lk = do
     fv = freeVarsIgnore IgnoreInAnnotations lk
     flex = flexibleVars fv
 
-    isLock i = fmap (getLock . domInfo) (lookupBV i) <&> \case
+    isLock i = fmap (getLock . domInfo . snd) (lookupBV i) <&> \case
       IsLock{} -> True
       IsNotLock{} -> False
 

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -101,7 +101,7 @@ getLockVar lk = do
     fv = freeVarsIgnore IgnoreInAnnotations lk
     flex = flexibleVars fv
 
-    isLock i = fmap (getLock . domInfo . snd) (lookupBV i) <&> \case
+    isLock i = fmap (getLock . domInfo . ctxEntryDom) (lookupBV i) <&> \case
       IsLock{} -> True
       IsNotLock{} -> False
 

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -439,10 +439,10 @@ newQuestionMark' new ii cmp t = lookupInteractionMeta ii >>= \case
     -- we base our decisions on the names of the context entries.
     -- Ideally, Agda would organize contexts in ancestry trees
     -- with substitutions to move between parent and child.
-    let glen = length gamma
-    let dlen = length delta
-    let gxs  = map (fst . unDom) gamma
-    let dxs  = map (fst . unDom) delta
+    let gxs  = contextNames' gamma
+    let dxs  = contextNames' delta
+    let glen = length gxs
+    let dlen = length dxs
     reportSDoc "tc.interaction" 20 $ vcat
       [ "reusing meta"
       , nest 2 $ "creation context:" <+> pretty gxs
@@ -515,7 +515,7 @@ newQuestionMark' new ii cmp t = lookupInteractionMeta ii >>= \case
         let numFields = glen - g1len - g0len
         if numFields <= 0 then return $ vs1 ++ vs0 else do
           -- Get the record type.
-          let t = snd . unDom . fromMaybe __IMPOSSIBLE__ $ delta !!! k
+          let t = (unDom . ctxEntryDom) $ fromMaybe __IMPOSSIBLE__ $ delta !!! k
           -- Get the record field names.
           fs <- getRecordTypeFields t
           -- Field arguments to the original meta are projections from the record var.
@@ -524,7 +524,7 @@ newQuestionMark' new ii cmp t = lookupInteractionMeta ii >>= \case
           return $ vs1 ++ reverse (take numFields vfs) ++ vs0
 
     -- Use ArgInfo from Γ.
-    let args = reverse $ zipWith (<$) rev_args $ map argFromDom gamma
+    let args = zipWith (<$) (reverse rev_args) $ contextArgs gamma
     -- Take the permutation into account (see TC.Monad.MetaVars.getMetaContextArgs).
     let vs = permute (takeP (length args) p) args
     reportSDoc "tc.interaction" 20 $ vcat

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1074,7 +1074,7 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
             TelV tel' _ <- telViewUpToPath (length args) t
             forM_ ids $ \(i,u) -> do
               d <- lookupBV i
-              case getLock (getArgInfo d) of
+              case getLock (getArgInfo $ snd d) of
                 IsNotLock -> pure ()
                 IsLock{} -> do
                 let us = IntSet.unions $ map snd $ filter (earlierThan i . fst) idvars

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1723,7 +1723,7 @@ inverseSubst' skip args = map (mapFst unArg) <$> loop (zip args terms)
       Sort{}     -> neutralArg
       Level{}    -> neutralArg
       Let{}      -> __IMPOSSIBLE__
-      LetV{}     -> __IMPOSSIBLE__
+      LetVar{}   -> __IMPOSSIBLE__
       DontCare{} -> __IMPOSSIBLE__ -- Ruled out by stripDontCare
       Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1723,6 +1723,7 @@ inverseSubst' skip args = map (mapFst unArg) <$> loop (zip args terms)
       Sort{}     -> neutralArg
       Level{}    -> neutralArg
       Let{}      -> __IMPOSSIBLE__
+      LetV{}     -> __IMPOSSIBLE__
       DontCare{} -> __IMPOSSIBLE__ -- Ruled out by stripDontCare
       Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1074,7 +1074,7 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
             TelV tel' _ <- telViewUpToPath (length args) t
             forM_ ids $ \(i,u) -> do
               d <- lookupBV i
-              case getLock (getArgInfo $ snd d) of
+              case getLock (getArgInfo d) of
                 IsNotLock -> pure ()
                 IsLock{} -> do
                 let us = IntSet.unions $ map snd $ filter (earlierThan i . fst) idvars
@@ -1723,7 +1723,6 @@ inverseSubst' skip args = map (mapFst unArg) <$> loop (zip args terms)
       Sort{}     -> neutralArg
       Level{}    -> neutralArg
       Let{}      -> __IMPOSSIBLE__
-      LetVar{}   -> __IMPOSSIBLE__
       DontCare{} -> __IMPOSSIBLE__ -- Ruled out by stripDontCare
       Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1722,6 +1722,7 @@ inverseSubst' skip args = map (mapFst unArg) <$> loop (zip args terms)
       Pi{}       -> neutralArg
       Sort{}     -> neutralArg
       Level{}    -> neutralArg
+      Let{}      -> __IMPOSSIBLE__
       DontCare{} -> __IMPOSSIBLE__ -- Ruled out by stripDontCare
       Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -10,6 +10,8 @@ import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad
 
+import Agda.Utils.Impossible
+
 class MentionsMeta t where
   mentionsMetas :: HashSet MetaId -> t -> Bool
 
@@ -27,6 +29,7 @@ instance MentionsMeta Term where
     Sort s       -> mm s
     Level l      -> mm l
     Let a u v    -> mm (a, u, v)
+    LetV x es    -> __IMPOSSIBLE__ -- TODO LetV
     Dummy{}      -> False
     DontCare v   -> False   -- we don't have to look inside don't cares when deciding to wake constraints
     MetaV y args -> HashSet.member y xs || mm args   -- TODO: we really only have to look one level deep at meta args

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -28,8 +28,8 @@ instance MentionsMeta Term where
     Pi a b       -> mm (a, b)
     Sort s       -> mm s
     Level l      -> mm l
-    Let a u v    -> mm (a, u, v)
     LetVar x es  -> __IMPOSSIBLE__ -- TODO LetVar
+    Let a u      -> mm (a, u)
     Dummy{}      -> False
     DontCare v   -> False   -- we don't have to look inside don't cares when deciding to wake constraints
     MetaV y args -> HashSet.member y xs || mm args   -- TODO: we really only have to look one level deep at meta args
@@ -70,6 +70,9 @@ instance MentionsMeta Sort where
 
 instance MentionsMeta t => MentionsMeta (Abs t) where
   mentionsMetas xs = mentionsMetas xs . unAbs
+
+instance MentionsMeta t => MentionsMeta (LetAbs t) where
+  mentionsMetas xs (LetAbs _ a b) = mentionsMetas xs (a, b)
 
 instance MentionsMeta t => MentionsMeta (Arg t) where
   mentionsMetas xs a | isIrrelevant a = False

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -28,7 +28,6 @@ instance MentionsMeta Term where
     Sort s       -> mm s
     Level l      -> mm l
     Let a u      -> mm (a, u)
-    LetVar x es  -> mm es
     Dummy{}      -> False
     DontCare v   -> False   -- we don't have to look inside don't cares when deciding to wake constraints
     MetaV y args -> HashSet.member y xs || mm args   -- TODO: we really only have to look one level deep at meta args

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -29,7 +29,7 @@ instance MentionsMeta Term where
     Sort s       -> mm s
     Level l      -> mm l
     Let a u v    -> mm (a, u, v)
-    LetV x es    -> __IMPOSSIBLE__ -- TODO LetV
+    LetVar x es  -> __IMPOSSIBLE__ -- TODO LetVar
     Dummy{}      -> False
     DontCare v   -> False   -- we don't have to look inside don't cares when deciding to wake constraints
     MetaV y args -> HashSet.member y xs || mm args   -- TODO: we really only have to look one level deep at meta args

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -10,7 +10,6 @@ import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad
 
-import Agda.Utils.Impossible
 
 class MentionsMeta t where
   mentionsMetas :: HashSet MetaId -> t -> Bool
@@ -28,8 +27,8 @@ instance MentionsMeta Term where
     Pi a b       -> mm (a, b)
     Sort s       -> mm s
     Level l      -> mm l
-    LetVar x es  -> __IMPOSSIBLE__ -- TODO LetVar
     Let a u      -> mm (a, u)
+    LetVar x es  -> mm es
     Dummy{}      -> False
     DontCare v   -> False   -- we don't have to look inside don't cares when deciding to wake constraints
     MetaV y args -> HashSet.member y xs || mm args   -- TODO: we really only have to look one level deep at meta args

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -26,6 +26,7 @@ instance MentionsMeta Term where
     Pi a b       -> mm (a, b)
     Sort s       -> mm s
     Level l      -> mm l
+    Let a u v    -> mm (a, u, v)
     Dummy{}      -> False
     DontCare v   -> False   -- we don't have to look inside don't cares when deciding to wake constraints
     MetaV y args -> HashSet.member y xs || mm args   -- TODO: we really only have to look one level deep at meta args

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -519,8 +519,8 @@ instance Occurs Term where
             Con c ci <$> conArgs vs (occurs vs)  -- if strongly rigid, remain so, except with unreduced IApply arguments.
           Pi a b      -> Pi <$> occurs_ a <*> occurs b
           Sort s      -> Sort <$> do underRelevance NonStrict $ occurs_ s
-          LetVar x es -> __IMPOSSIBLE__ -- TODO
           Let a u     -> strengthen __IMPOSSIBLE__ . unLetAbs <$> occurs u
+          LetVar x es -> occurs . (`applyE` es) =<< valueOfLV x
           MetaV m' es -> do
             m' <- metaCheck m'
             -- The arguments of a meta are in a flexible position
@@ -569,9 +569,9 @@ instance Occurs Term where
       Def d vs   -> metaOccurs2 m d vs
       Con c _ vs -> metaOccurs m vs
       Pi a b     -> metaOccurs2 m a b
-      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
       Sort s     -> metaOccurs m s
       Let a u    -> metaOccurs2 m a u
+      LetVar x es -> metaOccurs m . (`applyE` es) =<< valueOfLV x
               -- vv m is already an unblocker
       MetaV m' vs | m == m'   -> patternViolation' neverUnblock 50 $ "Found occurrence of " ++ prettyShow m
                   | otherwise -> addOrUnblocker (unblockOnMeta m') $ metaOccurs m vs

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -520,6 +520,7 @@ instance Occurs Term where
           Pi a b      -> Pi <$> occurs_ a <*> occurs b
           Sort s      -> Sort <$> do underRelevance NonStrict $ occurs_ s
           Let a u v   -> Let <$> occurs_ a <*> occurs u <*> occurs v
+          LetV x es   -> __IMPOSSIBLE__ -- TODO
           MetaV m' es -> do
             m' <- metaCheck m'
             -- The arguments of a meta are in a flexible position
@@ -570,6 +571,7 @@ instance Occurs Term where
       Pi a b     -> metaOccurs2 m a b
       Sort s     -> metaOccurs m s              -- vv m is already an unblocker
       Let a u v  -> metaOccurs3 m a u v
+      LetV x es  -> __IMPOSSIBLE__ -- TODO LetV
       MetaV m' vs | m == m'   -> patternViolation' neverUnblock 50 $ "Found occurrence of " ++ prettyShow m
                   | otherwise -> addOrUnblocker (unblockOnMeta m') $ metaOccurs m vs
 
@@ -802,6 +804,7 @@ hasBadRigid xs t = do
     MetaV{}      -> failure -- potentially matchable
     Dummy{}      -> return False
     Let{}        -> __IMPOSSIBLE__
+    LetV{}       -> __IMPOSSIBLE__
 
 -- | Check whether a term @Def f es@ is finally stuck.
 --   Currently, we give only a crude approximation.
@@ -884,6 +887,7 @@ instance AnyRigid Term where
       DontCare{} -> return False
       Dummy{}    -> return False
       Let{}      -> __IMPOSSIBLE__
+      LetV{}     -> __IMPOSSIBLE__
 
 instance AnyRigid Type where
   anyRigid f (El s t) = anyRigid f (s,t)

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -520,7 +520,7 @@ instance Occurs Term where
           Pi a b      -> Pi <$> occurs_ a <*> occurs b
           Sort s      -> Sort <$> do underRelevance NonStrict $ occurs_ s
           Let a u v   -> Let <$> occurs_ a <*> occurs u <*> occurs v
-          LetV x es   -> __IMPOSSIBLE__ -- TODO
+          LetVar x es -> __IMPOSSIBLE__ -- TODO
           MetaV m' es -> do
             m' <- metaCheck m'
             -- The arguments of a meta are in a flexible position
@@ -571,7 +571,7 @@ instance Occurs Term where
       Pi a b     -> metaOccurs2 m a b
       Sort s     -> metaOccurs m s              -- vv m is already an unblocker
       Let a u v  -> metaOccurs3 m a u v
-      LetV x es  -> __IMPOSSIBLE__ -- TODO LetV
+      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
       MetaV m' vs | m == m'   -> patternViolation' neverUnblock 50 $ "Found occurrence of " ++ prettyShow m
                   | otherwise -> addOrUnblocker (unblockOnMeta m') $ metaOccurs m vs
 
@@ -804,7 +804,7 @@ hasBadRigid xs t = do
     MetaV{}      -> failure -- potentially matchable
     Dummy{}      -> return False
     Let{}        -> __IMPOSSIBLE__
-    LetV{}       -> __IMPOSSIBLE__
+    LetVar{}     -> __IMPOSSIBLE__
 
 -- | Check whether a term @Def f es@ is finally stuck.
 --   Currently, we give only a crude approximation.
@@ -887,7 +887,7 @@ instance AnyRigid Term where
       DontCare{} -> return False
       Dummy{}    -> return False
       Let{}      -> __IMPOSSIBLE__
-      LetV{}     -> __IMPOSSIBLE__
+      LetVar{}   -> __IMPOSSIBLE__
 
 instance AnyRigid Type where
   anyRigid f (El s t) = anyRigid f (s,t)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3166,6 +3166,7 @@ reduced b = MaybeRed (Reduced $ () <$ b) $ ignoreBlocking b
 data AllowedReduction
   = ProjectionReductions     -- ^ (Projection and) projection-like functions may be reduced.
   | InlineReductions         -- ^ Functions marked INLINE may be reduced.
+  | LetReductions            -- ^ Inlining of @let@ expressions.
   | CopatternReductions      -- ^ Copattern definitions may be reduced.
   | FunctionReductions       -- ^ Non-recursive functions and primitives may be reduced.
   | RecursiveReductions      -- ^ Even recursive functions may be reduced.

--- a/src/full/Agda/TypeChecking/Monad/Base/Types.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base/Types.hs
@@ -4,7 +4,11 @@
 
 module Agda.TypeChecking.Monad.Base.Types where
 
+import Control.DeepSeq
+import GHC.Generics
+
 import Agda.Syntax.Internal
+import Agda.Syntax.Common (LensArgInfo(..), LensModality, LensRelevance, LensCohesion, LensOrigin, LensQuantity, LensHiding)
 
 ---------------------------------------------------------------------------
 -- ** Context
@@ -12,6 +16,32 @@ import Agda.Syntax.Internal
 
 -- | The @Context@ is a stack of 'ContextEntry's.
 type Context      = [ContextEntry]
-type ContextEntry = Dom (Name, Type)
+data ContextEntry
+  = CtxVar Name (Dom Type)
+  | CtxLet Name (Dom Type) Term
+  deriving (Show, Generic)
+
+isCtxVar :: ContextEntry -> Maybe (Name, Dom Type)
+isCtxVar (CtxVar x a) = Just (x,a)
+isCtxVar CtxLet{} = Nothing
+
+isCtxLet :: ContextEntry -> Maybe (Name, Dom Type, Term)
+isCtxLet CtxVar{} = Nothing
+isCtxLet (CtxLet x a v) = Just (x,a,v)
+
+instance LensArgInfo ContextEntry where
+  getArgInfo (CtxVar _ a) = getArgInfo a
+  getArgInfo (CtxLet _ a _) = getArgInfo a
+  mapArgInfo f (CtxVar x a) = CtxVar x $ mapArgInfo f a
+  mapArgInfo f (CtxLet x a v) = CtxLet x (mapArgInfo f a) v
+
+instance LensModality ContextEntry where
+instance LensRelevance ContextEntry where
+instance LensCohesion ContextEntry where
+instance LensOrigin ContextEntry where
+instance LensQuantity ContextEntry where
+instance LensHiding ContextEntry where
+
+instance NFData ContextEntry
 
 -- Feel free to move more types from Agda.TypeChecking.Monad.Base here when needed...

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -436,7 +436,7 @@ getLetBindings = do
   forM (Map.toList bs) $ \ (n, o) -> (,) n <$> getOpen o
 
 -- | Add a let bound variable
-{-# SPECIALIZE addLetBinding' :: Origin -> Name -> Term -> Dom Type -> TCM a -> TCM a #-}
+{-# SPECIALIZE defaultAddLetBinding' :: Origin -> Name -> Term -> Dom Type -> TCM a -> TCM a #-}
 defaultAddLetBinding' :: (ReadTCState m, MonadTCEnv m) => Origin -> Name -> Term -> Dom Type -> m a -> m a
 defaultAddLetBinding' o x v t ret = do
     vt <- makeOpen $ LetBinding o v t

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -575,7 +575,7 @@ lookupBV_ :: Nat -> Context -> Maybe (Name, Dom Type)
 lookupBV_ n ctx = fromMaybe __IMPOSSIBLE__ . isCtxVar <$> lookupCtx_ n ctx
 
 {-# SPECIALIZE lookupBV' :: Nat -> TCM (Maybe (Name, Dom Type)) #-}
-lookupBV' :: (MonadFail m, MonadTCEnv m) => Nat -> m (Maybe (Name, Dom Type))
+lookupBV' :: (MonadTCEnv m) => Nat -> m (Maybe (Name, Dom Type))
 lookupBV' n = (isCtxVar =<<) <$> lookupCtx' n
 
 {-# SPECIALIZE lookupBV :: Nat -> TCM (Name, Dom Type) #-}
@@ -586,7 +586,7 @@ lookupLV_ :: Nat -> Context -> Maybe (Name, Dom Type, Term)
 lookupLV_ n ctx = fromMaybe __IMPOSSIBLE__ . isCtxLet <$> lookupCtx_ n ctx
 
 {-# SPECIALIZE lookupLV' :: Nat -> TCM (Maybe (Name, Dom Type, Term)) #-}
-lookupLV' :: (MonadFail m, MonadTCEnv m) => Nat -> m (Maybe (Name, Dom Type, Term))
+lookupLV' :: (MonadTCEnv m) => Nat -> m (Maybe (Name, Dom Type, Term))
 lookupLV' n = (isCtxLet =<<) <$> lookupCtx' n
 
 {-# SPECIALIZE lookupLV :: Nat -> TCM (Name, Dom Type, Term) #-}
@@ -605,40 +605,44 @@ ctxEntryType :: ContextEntry -> Type
 ctxEntryType = unDom . ctxEntryDom
 
 {-# SPECIALIZE domOfBV :: Nat -> TCM (Dom Type) #-}
-domOfBV :: (Applicative m, MonadFail m, MonadTCEnv m) => Nat -> m (Dom Type)
+domOfBV :: (MonadFail m, MonadTCEnv m) => Nat -> m (Dom Type)
 domOfBV n = snd <$> lookupBV n
 
 {-# SPECIALIZE typeOfBV :: Nat -> TCM Type #-}
-typeOfBV :: (Applicative m, MonadFail m, MonadTCEnv m) => Nat -> m Type
+typeOfBV :: (MonadFail m, MonadTCEnv m) => Nat -> m Type
 typeOfBV i = unDom <$> domOfBV i
 
 {-# SPECIALIZE nameOfBV' :: Nat -> TCM (Maybe Name) #-}
-nameOfBV' :: (Applicative m, MonadFail m, MonadTCEnv m) => Nat -> m (Maybe Name)
+nameOfBV' :: (MonadTCEnv m) => Nat -> m (Maybe Name)
 nameOfBV' n = fmap fst <$> lookupBV' n
 
 {-# SPECIALIZE nameOfBV :: Nat -> TCM Name #-}
-nameOfBV :: (Applicative m, MonadFail m, MonadTCEnv m) => Nat -> m Name
+nameOfBV :: (MonadFail m, MonadTCEnv m) => Nat -> m Name
 nameOfBV n = fst <$> lookupBV n
 
 {-# SPECIALIZE domOfLV :: Nat -> TCM (Dom Type) #-}
-domOfLV :: (Applicative m, MonadFail m, MonadTCEnv m) => Nat -> m (Dom Type)
+domOfLV :: (MonadFail m, MonadTCEnv m) => Nat -> m (Dom Type)
 domOfLV n = snd3 <$> lookupLV n
 
 {-# SPECIALIZE typeOfLV :: Nat -> TCM Type #-}
-typeOfLV :: (Applicative m, MonadFail m, MonadTCEnv m) => Nat -> m Type
+typeOfLV :: (MonadFail m, MonadTCEnv m) => Nat -> m Type
 typeOfLV i = unDom <$> domOfLV i
 
 {-# SPECIALIZE nameOfLV' :: Nat -> TCM (Maybe Name) #-}
-nameOfLV' :: (Applicative m, MonadFail m, MonadTCEnv m) => Nat -> m (Maybe Name)
+nameOfLV' :: (MonadTCEnv m) => Nat -> m (Maybe Name)
 nameOfLV' n = fmap fst3 <$> lookupLV' n
 
 {-# SPECIALIZE nameOfLV :: Nat -> TCM Name #-}
-nameOfLV :: (Applicative m, MonadFail m, MonadTCEnv m) => Nat -> m Name
+nameOfLV :: (MonadFail m, MonadTCEnv m) => Nat -> m Name
 nameOfLV n = fst3 <$> lookupLV n
 
 {-# SPECIALIZE valueOfLV :: Nat -> TCM Term #-}
-valueOfLV :: (Applicative m, MonadFail m, MonadTCEnv m) => Nat -> m Term
+valueOfLV :: (MonadFail m, MonadTCEnv m) => Nat -> m Term
 valueOfLV n = thd3 <$> lookupLV n
+
+{-# SPECIALIZE valueOfLV :: Nat -> TCM Term #-}
+valueOfLV' :: (MonadTCEnv m) => Nat -> m (Maybe Term)
+valueOfLV' n = fmap thd3 <$> lookupLV' n
 
 
 -- | Get the term corresponding to a named variable. If it is a lambda bound

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -666,9 +666,10 @@ getVarInfo :: (MonadFail m, MonadTCEnv m) => Name -> m (Term, Dom Type)
 getVarInfo x =
     do  ctx <- getContext
         def <- asksTC envLetBindings
-        case findWithIndex ((== x) . ctxEntryName) ctx of
-            Just (CtxVar x t, i) -> return (var i, t)
-            Just (CtxLet x t v, i) -> return (LetVar i [], t)
+        case List.findIndex ((== x) . ctxEntryName) ctx of
+            Just i -> lookupCtx i >>= \case
+              CtxVar _ t -> return (var i, t)
+              CtxLet _ t _ -> return (LetVar i [], t)
             _       -> do
                 case Map.lookup x def of
                     Just vt -> do

--- a/src/full/Agda/TypeChecking/Monad/Context.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs-boot
@@ -14,9 +14,11 @@ import Agda.TypeChecking.Monad.Base
 
 checkpointSubstitution :: MonadTCEnv tcm => CheckpointId -> tcm Substitution
 
+data InlineLet = YesInlineLet | NoInlineLet
+
 class MonadTCEnv m => MonadAddContext m where
   addCtx :: Name -> Dom Type -> m a -> m a
-  addLetBinding' :: Origin -> Name -> Term -> Dom Type -> m a -> m a
+  addLetBinding' :: InlineLet -> Origin -> Name -> Term -> Dom Type -> m a -> m a
   updateContext :: Substitution -> (Context -> Context) -> m a -> m a
   withFreshName :: Range -> ArgName -> (Name -> m a) -> m a
 
@@ -27,8 +29,8 @@ class MonadTCEnv m => MonadAddContext m where
 
   default addLetBinding'
     :: (MonadAddContext n, MonadTransControl t, t n ~ m)
-    => Origin -> Name -> Term -> Dom Type -> m a -> m a
-  addLetBinding' o x u a = liftThrough $ addLetBinding' o x u a
+    => InlineLet -> Origin -> Name -> Term -> Dom Type -> m a -> m a
+  addLetBinding' il o x u a = liftThrough $ addLetBinding' il o x u a
 
   default updateContext
     :: (MonadAddContext n, MonadTransControl t, t n ~ m)

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -1242,11 +1242,11 @@ instantiateDef
 instantiateDef d = do
   vs  <- freeVarsToApply $ defName d
   verboseS "tc.sig.inst" 30 $ do
-    ctx <- getContext
+    ctx <- getContextNames
     m   <- currentModule
     reportSDoc "tc.sig.inst" 30 $
       "instDef in" <+> pretty m <> ":" <+> pretty (defName d) <+>
-      fsep (map pretty $ zipWith (<$) (reverse $ map (fst . unDom) ctx) vs)
+      fsep (map pretty $ zipWith (<$) ctx vs)
   return $ d `apply` vs
 
 instantiateRewriteRule :: (Functor m, HasConstInfo m, HasOptions m,

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -425,6 +425,7 @@ instance HasPolarity Term where
     Pi a b        -> polarity' i (neg p) a <> polarity' i p b
     Sort s        -> mempty -- polarity' i p s -- mempty
     Let a u v     -> polarity' i p (a,u,v)
+    LetV x es     -> __IMPOSSIBLE__ -- TODO LetV
     MetaV _ ts    -> polarity' i Invariant ts
     DontCare t    -> polarity' i p t -- mempty
     Dummy{}       -> mempty

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -427,8 +427,10 @@ instance HasPolarity Term where
     Con _ _ ts    -> polarity' i p ts   -- Constructors can be seen as monotone in all args.
     Pi a b        -> polarity' i (neg p) a <> polarity' i p b
     Sort s        -> mempty -- polarity' i p s -- mempty
-    LetVar x es   -> __IMPOSSIBLE__ -- TODO LetVar
     Let a u       -> polarity' i p (a,u)
+    LetVar x ts
+      | x == i    -> singleton p <> polarity' i Invariant ts
+      | otherwise -> polarity' i Invariant ts
     MetaV _ ts    -> polarity' i Invariant ts
     DontCare t    -> polarity' i p t -- mempty
     Dummy{}       -> mempty

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -428,9 +428,6 @@ instance HasPolarity Term where
     Pi a b        -> polarity' i (neg p) a <> polarity' i p b
     Sort s        -> mempty -- polarity' i p s -- mempty
     Let a u       -> polarity' i p (a,u)
-    LetVar x ts
-      | x == i    -> singleton p <> polarity' i Invariant ts
-      | otherwise -> polarity' i Invariant ts
     MetaV _ ts    -> polarity' i Invariant ts
     DontCare t    -> polarity' i p t -- mempty
     Dummy{}       -> mempty

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -425,7 +425,7 @@ instance HasPolarity Term where
     Pi a b        -> polarity' i (neg p) a <> polarity' i p b
     Sort s        -> mempty -- polarity' i p s -- mempty
     Let a u v     -> polarity' i p (a,u,v)
-    LetV x es     -> __IMPOSSIBLE__ -- TODO LetV
+    LetVar x es   -> __IMPOSSIBLE__ -- TODO LetVar
     MetaV _ ts    -> polarity' i Invariant ts
     DontCare t    -> polarity' i p t -- mempty
     Dummy{}       -> mempty

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -401,6 +401,9 @@ instance HasPolarity a => HasPolarity (Type'' t a)
 instance (HasPolarity a, HasPolarity b) => HasPolarity (a, b) where
   polarity' i p (x, y) = polarity' i p x <> polarity' i p y
 
+instance (HasPolarity a, HasPolarity b, HasPolarity c) => HasPolarity (a, b, c) where
+  polarity' i p (x, y, z) = polarity' i p x <> polarity' i p y <> polarity' i p z
+
 instance HasPolarity a => HasPolarity (Abs a) where
   polarity' i p (Abs   _ b) = polarity' (i + 1) p b
   polarity' i p (NoAbs _ v) = polarity' i p v
@@ -421,6 +424,7 @@ instance HasPolarity Term where
     Con _ _ ts    -> polarity' i p ts   -- Constructors can be seen as monotone in all args.
     Pi a b        -> polarity' i (neg p) a <> polarity' i p b
     Sort s        -> mempty -- polarity' i p s -- mempty
+    Let a u v     -> polarity' i p (a,u,v)
     MetaV _ ts    -> polarity' i Invariant ts
     DontCare t    -> polarity' i p t -- mempty
     Dummy{}       -> mempty

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -408,6 +408,9 @@ instance HasPolarity a => HasPolarity (Abs a) where
   polarity' i p (Abs   _ b) = polarity' (i + 1) p b
   polarity' i p (NoAbs _ v) = polarity' i p v
 
+instance HasPolarity a => HasPolarity (LetAbs a) where
+  polarity' i p (LetAbs _ a b) = polarity' i p a <> polarity' (i + 1) p b
+
 instance HasPolarity Term where
   polarity' i p v = instantiate v >>== \case
     -- Andreas, 2012-09-06: taking the polarity' of the arguments
@@ -424,8 +427,8 @@ instance HasPolarity Term where
     Con _ _ ts    -> polarity' i p ts   -- Constructors can be seen as monotone in all args.
     Pi a b        -> polarity' i (neg p) a <> polarity' i p b
     Sort s        -> mempty -- polarity' i p s -- mempty
-    Let a u v     -> polarity' i p (a,u,v)
     LetVar x es   -> __IMPOSSIBLE__ -- TODO LetVar
+    Let a u       -> polarity' i p (a,u)
     MetaV _ ts    -> polarity' i Invariant ts
     DontCare t    -> polarity' i p t -- mempty
     Dummy{}       -> mempty

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -454,7 +454,6 @@ instance ComputeOccurrences Term where
     Lit{}        -> mempty
     Sort{}       -> mempty
     Let a u      -> occurrences (a, u)
-    LetVar x es  -> occurrences es
     -- Jesper, 2020-01-12: this information is also used for the
     -- occurs check, so we need to look under DontCare (see #4371)
     DontCare v   -> occurrences v
@@ -572,7 +571,6 @@ computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do
                   | otherwise -> __IMPOSSIBLE__  -- this ought to be impossible now (but hasn't been before, see #4447)
                 Pi{}       -> __IMPOSSIBLE__  -- eliminated by telView
                 Let{}      -> __IMPOSSIBLE__  -- eliminated by telView
-                LetVar{}   -> __IMPOSSIBLE__  -- eliminated by telView
                 MetaV{}    -> __IMPOSSIBLE__  -- not a constructor target; should have been solved by now
                 Var{}      -> __IMPOSSIBLE__  -- not a constructor target
                 Sort{}     -> __IMPOSSIBLE__  -- not a constructor target

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -453,8 +453,8 @@ instance ComputeOccurrences Term where
     Level l      -> occurrences l
     Lit{}        -> mempty
     Sort{}       -> mempty
-    Let a u v    -> occurrences (a, u, v)
     LetVar x es  -> __IMPOSSIBLE__ -- TODO LetVar
+    Let a u      -> occurrences (a, u)
     -- Jesper, 2020-01-12: this information is also used for the
     -- occurs check, so we need to look under DontCare (see #4371)
     DontCare v   -> occurrences v
@@ -476,6 +476,10 @@ instance ComputeOccurrences a => ComputeOccurrences (Tele a) where
 instance ComputeOccurrences a => ComputeOccurrences (Abs a) where
   occurrences (Abs   _ b) = withExtendedOccEnv Nothing $ occurrences b
   occurrences (NoAbs _ b) = occurrences b
+
+instance ComputeOccurrences a => ComputeOccurrences (LetAbs a) where
+  occurrences (LetAbs _ a b) =
+    occurrences a <> withExtendedOccEnv Nothing (occurrences b)
 
 instance ComputeOccurrences a => ComputeOccurrences (Elim' a) where
   occurrences Proj{}         = __IMPOSSIBLE__  -- unSpine

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -454,7 +454,7 @@ instance ComputeOccurrences Term where
     Lit{}        -> mempty
     Sort{}       -> mempty
     Let a u v    -> occurrences (a, u, v)
-    LetV x es    -> __IMPOSSIBLE__ -- TODO LetV
+    LetVar x es  -> __IMPOSSIBLE__ -- TODO LetVar
     -- Jesper, 2020-01-12: this information is also used for the
     -- occurs check, so we need to look under DontCare (see #4371)
     DontCare v   -> occurrences v
@@ -568,7 +568,7 @@ computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do
                   | otherwise -> __IMPOSSIBLE__  -- this ought to be impossible now (but hasn't been before, see #4447)
                 Pi{}       -> __IMPOSSIBLE__  -- eliminated by telView
                 Let{}      -> __IMPOSSIBLE__  -- eliminated by telView
-                LetV{}     -> __IMPOSSIBLE__  -- eliminated by telView
+                LetVar{}   -> __IMPOSSIBLE__  -- eliminated by telView
                 MetaV{}    -> __IMPOSSIBLE__  -- not a constructor target; should have been solved by now
                 Var{}      -> __IMPOSSIBLE__  -- not a constructor target
                 Sort{}     -> __IMPOSSIBLE__  -- not a constructor target

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -453,6 +453,7 @@ instance ComputeOccurrences Term where
     Level l      -> occurrences l
     Lit{}        -> mempty
     Sort{}       -> mempty
+    Let a u v    -> occurrences (a, u, v)
     -- Jesper, 2020-01-12: this information is also used for the
     -- occurs check, so we need to look under DontCare (see #4371)
     DontCare v   -> occurrences v
@@ -487,6 +488,9 @@ instance ComputeOccurrences a => ComputeOccurrences (Maybe a) where
 
 instance (ComputeOccurrences a, ComputeOccurrences b) => ComputeOccurrences (a, b) where
   occurrences (x, y) = occurrences x <> occurrences y
+
+instance (ComputeOccurrences a, ComputeOccurrences b, ComputeOccurrences c) => ComputeOccurrences (a, b, c) where
+  occurrences (x, y, z) = occurrences x <> occurrences y <> occurrences z
 
 -- | Computes the number of occurrences of different 'Item's in the
 -- given definition.
@@ -561,7 +565,8 @@ computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do
                       let indices = fromMaybe __IMPOSSIBLE__ $ allApplyElims $ drop np vs
                       OccursAs (IndArgType c) . OnlyVarsUpTo np <$> getOccurrences varsTel indices
                   | otherwise -> __IMPOSSIBLE__  -- this ought to be impossible now (but hasn't been before, see #4447)
-                Pi{}       -> __IMPOSSIBLE__  -- eliminated  by telView
+                Pi{}       -> __IMPOSSIBLE__  -- eliminated by telView
+                Let{}      -> __IMPOSSIBLE__  -- eliminated by telView
                 MetaV{}    -> __IMPOSSIBLE__  -- not a constructor target; should have been solved by now
                 Var{}      -> __IMPOSSIBLE__  -- not a constructor target
                 Sort{}     -> __IMPOSSIBLE__  -- not a constructor target

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -454,6 +454,7 @@ instance ComputeOccurrences Term where
     Lit{}        -> mempty
     Sort{}       -> mempty
     Let a u v    -> occurrences (a, u, v)
+    LetV x es    -> __IMPOSSIBLE__ -- TODO LetV
     -- Jesper, 2020-01-12: this information is also used for the
     -- occurs check, so we need to look under DontCare (see #4371)
     DontCare v   -> occurrences v
@@ -567,6 +568,7 @@ computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do
                   | otherwise -> __IMPOSSIBLE__  -- this ought to be impossible now (but hasn't been before, see #4447)
                 Pi{}       -> __IMPOSSIBLE__  -- eliminated by telView
                 Let{}      -> __IMPOSSIBLE__  -- eliminated by telView
+                LetV{}     -> __IMPOSSIBLE__  -- eliminated by telView
                 MetaV{}    -> __IMPOSSIBLE__  -- not a constructor target; should have been solved by now
                 Var{}      -> __IMPOSSIBLE__  -- not a constructor target
                 Sort{}     -> __IMPOSSIBLE__  -- not a constructor target

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -453,8 +453,8 @@ instance ComputeOccurrences Term where
     Level l      -> occurrences l
     Lit{}        -> mempty
     Sort{}       -> mempty
-    LetVar x es  -> __IMPOSSIBLE__ -- TODO LetVar
     Let a u      -> occurrences (a, u)
+    LetVar x es  -> occurrences es
     -- Jesper, 2020-01-12: this information is also used for the
     -- occurs check, so we need to look under DontCare (see #4371)
     DontCare v   -> occurrences v

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -442,7 +442,7 @@ instance PrettyTCM Telescope where
 newtype PrettyContext = PrettyContext Context
 
 instance PrettyTCM PrettyContext where
-  prettyTCM (PrettyContext ctx) = prettyTCM $ telFromList' nameToArgName $ reverse ctx
+  prettyTCM (PrettyContext ctx) = prettyTCM $ contextToTel ctx -- TODO: include let bindings?
 {-# SPECIALIZE prettyTCM :: PrettyContext -> TCM Doc #-}
 
 instance PrettyTCM DBPatVar where

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -629,6 +629,7 @@ genPrimForce b ret = do
                     Record{}   -> True
                     _          -> False
                 Var{}      -> return False
+                Let{}      -> __IMPOSSIBLE__
                 MetaV{}    -> __IMPOSSIBLE__
                 Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
         ifM (isWHNF u)

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -630,7 +630,6 @@ genPrimForce b ret = do
                     _          -> False
                 Var{}      -> return False
                 Let{}      -> __IMPOSSIBLE__
-                LetVar{}   -> __IMPOSSIBLE__
                 MetaV{}    -> __IMPOSSIBLE__
                 Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
         ifM (isWHNF u)

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -630,7 +630,7 @@ genPrimForce b ret = do
                     _          -> False
                 Var{}      -> return False
                 Let{}      -> __IMPOSSIBLE__
-                LetV{}     -> __IMPOSSIBLE__
+                LetVar{}   -> __IMPOSSIBLE__
                 MetaV{}    -> __IMPOSSIBLE__
                 Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
         ifM (isWHNF u)

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -630,6 +630,7 @@ genPrimForce b ret = do
                     _          -> False
                 Var{}      -> return False
                 Let{}      -> __IMPOSSIBLE__
+                LetV{}     -> __IMPOSSIBLE__
                 MetaV{}    -> __IMPOSSIBLE__
                 Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
         ifM (isWHNF u)

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -298,6 +298,7 @@ quotingKit = do
           Level l    -> quoteTerm (unlevelWithKit lkit l)
           Lit l      -> lit !@ quoteLit l
           Sort s     -> sort !@ quoteSort s
+          Let a u v  -> quoteTerm $ lazyAbsApp v u -- TODO: add let to reflected syntax
           MetaV x es -> meta !@! quoteMeta currentModule x
                               @@ quoteArgs vs
             where vs = fromMaybe __IMPOSSIBLE__ $ allApplyElims es

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -298,8 +298,8 @@ quotingKit = do
           Level l    -> quoteTerm (unlevelWithKit lkit l)
           Lit l      -> lit !@ quoteLit l
           Sort s     -> sort !@ quoteSort s
-          LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
           Let a u    -> quoteTerm $ inlineLet u -- TODO: add let to reflected syntax
+          LetVar x es -> quoteTerm . (`applyE` es) =<< valueOfLV x
           MetaV x es -> meta !@! quoteMeta currentModule x
                               @@ quoteArgs vs
             where vs = fromMaybe __IMPOSSIBLE__ $ allApplyElims es

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -298,7 +298,7 @@ quotingKit = do
           Level l    -> quoteTerm (unlevelWithKit lkit l)
           Lit l      -> lit !@ quoteLit l
           Sort s     -> sort !@ quoteSort s
-          Let a u    -> quoteTerm $ inlineLet u -- TODO: add let to reflected syntax
+          Let a u    -> quoteTerm $ inlineLetAbs u -- TODO: add let to reflected syntax
           LetVar x es -> quoteTerm . (`applyE` es) =<< valueOfLV x
           MetaV x es -> meta !@! quoteMeta currentModule x
                               @@ quoteArgs vs

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -299,7 +299,7 @@ quotingKit = do
           Lit l      -> lit !@ quoteLit l
           Sort s     -> sort !@ quoteSort s
           Let a u v  -> quoteTerm $ lazyAbsApp v u -- TODO: add let to reflected syntax
-          LetV x es  -> __IMPOSSIBLE__ -- TODO LetV
+          LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
           MetaV x es -> meta !@! quoteMeta currentModule x
                               @@ quoteArgs vs
             where vs = fromMaybe __IMPOSSIBLE__ $ allApplyElims es

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -254,7 +254,7 @@ quotingKit = do
 
       quoteTerm :: Term -> ReduceM Term
       quoteTerm v = do
-        v <- instantiate' v
+        v <- reduceLetVar v
         case unSpine v of
           Var n es   ->
              let ts = fromMaybe __IMPOSSIBLE__ $ allApplyElims es
@@ -299,7 +299,6 @@ quotingKit = do
           Lit l      -> lit !@ quoteLit l
           Sort s     -> sort !@ quoteSort s
           Let a u    -> quoteTerm $ inlineLetAbs u -- TODO: add let to reflected syntax
-          LetVar x es -> quoteTerm . (`applyE` es) =<< valueOfLV x
           MetaV x es -> meta !@! quoteMeta currentModule x
                               @@ quoteArgs vs
             where vs = fromMaybe __IMPOSSIBLE__ $ allApplyElims es

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -298,8 +298,8 @@ quotingKit = do
           Level l    -> quoteTerm (unlevelWithKit lkit l)
           Lit l      -> lit !@ quoteLit l
           Sort s     -> sort !@ quoteSort s
-          Let a u v  -> quoteTerm $ lazyAbsApp v u -- TODO: add let to reflected syntax
           LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
+          Let a u    -> quoteTerm $ inlineLet u -- TODO: add let to reflected syntax
           MetaV x es -> meta !@! quoteMeta currentModule x
                               @@ quoteArgs vs
             where vs = fromMaybe __IMPOSSIBLE__ $ allApplyElims es

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -299,6 +299,7 @@ quotingKit = do
           Lit l      -> lit !@ quoteLit l
           Sort s     -> sort !@ quoteSort s
           Let a u v  -> quoteTerm $ lazyAbsApp v u -- TODO: add let to reflected syntax
+          LetV x es  -> __IMPOSSIBLE__ -- TODO LetV
           MetaV x es -> meta !@! quoteMeta currentModule x
                               @@ quoteArgs vs
             where vs = fromMaybe __IMPOSSIBLE__ $ allApplyElims es

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1515,6 +1515,10 @@ instance (Subst a, InstantiateFull a) => InstantiateFull (Abs a) where
 instance (InstantiateFull t, InstantiateFull e) => InstantiateFull (Dom' t e) where
     instantiateFull' (Dom i n b tac x) = Dom i n b <$> instantiateFull' tac <*> instantiateFull' x
 
+instance InstantiateFull ContextEntry where
+  instantiateFull' (CtxVar x a) = CtxVar x <$> instantiateFull' a
+  instantiateFull' (CtxLet x a v) = CtxLet x <$> instantiateFull' a <*> instantiateFull' v
+
 instance InstantiateFull LetBinding where
   instantiateFull' (LetBinding o v t) = LetBinding o <$> instantiateFull' v <*> instantiateFull' t
 

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -576,6 +576,7 @@ slowReduceTerm v = do
                  $ unfoldDefinitionE reduceB' (Con c ci []) (conName c) es
           traverse reduceNat v
       Let a u v  -> reduceB' $ lazyAbsApp v u
+      LetV x es -> __IMPOSSIBLE__ -- TODO LetV
       Sort s   -> done
       Level l  -> ifM (SmallSet.member LevelReductions <$> asksTC envAllowedReductions)
                     {- then -} (fmap levelTm <$> reduceB' l)
@@ -1070,6 +1071,7 @@ instance Simplify Term where
       Var i vs   -> iapp vs $ Var i    <$> simplify' vs
       Lam h v    -> Lam h    <$> simplify' v
       Let a u v  -> Let      <$> simplify' a <*> simplify' u <*> simplify' v
+      LetV x es  -> LetV x   <$> simplify' es
       DontCare v -> dontCare <$> simplify' v
       Dummy{}    -> return v
 
@@ -1265,6 +1267,7 @@ slowNormaliseArgs = \case
   Sort s      -> Sort       <$> normalise' s
   Pi a b      -> uncurry Pi <$> normalise' (a, b)
   Let{}       -> __IMPOSSIBLE__
+  LetV{}      -> __IMPOSSIBLE__
   v@DontCare{}-> return v
   v@Dummy{}   -> return v
 
@@ -1480,6 +1483,7 @@ instance InstantiateFull Term where
           Sort s      -> Sort <$> instantiateFull' s
           Pi a b      -> uncurry Pi <$> instantiateFull' (a,b)
           Let a u v   -> uncurry3 Let <$> instantiateFull' (a,u,v)
+          LetV x es   -> LetV x <$> instantiateFull' es
           DontCare v  -> dontCare <$> instantiateFull' v
           v@Dummy{}   -> return v
 

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -576,7 +576,7 @@ slowReduceTerm v = do
                  $ unfoldDefinitionE reduceB' (Con c ci []) (conName c) es
           traverse reduceNat v
       Let a u v  -> reduceB' $ lazyAbsApp v u
-      LetV x es -> __IMPOSSIBLE__ -- TODO LetV
+      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
       Sort s   -> done
       Level l  -> ifM (SmallSet.member LevelReductions <$> asksTC envAllowedReductions)
                     {- then -} (fmap levelTm <$> reduceB' l)
@@ -1071,7 +1071,7 @@ instance Simplify Term where
       Var i vs   -> iapp vs $ Var i    <$> simplify' vs
       Lam h v    -> Lam h    <$> simplify' v
       Let a u v  -> Let      <$> simplify' a <*> simplify' u <*> simplify' v
-      LetV x es  -> LetV x   <$> simplify' es
+      LetVar x es -> LetVar x   <$> simplify' es
       DontCare v -> dontCare <$> simplify' v
       Dummy{}    -> return v
 
@@ -1267,7 +1267,7 @@ slowNormaliseArgs = \case
   Sort s      -> Sort       <$> normalise' s
   Pi a b      -> uncurry Pi <$> normalise' (a, b)
   Let{}       -> __IMPOSSIBLE__
-  LetV{}      -> __IMPOSSIBLE__
+  LetVar{}    -> __IMPOSSIBLE__
   v@DontCare{}-> return v
   v@Dummy{}   -> return v
 
@@ -1483,7 +1483,7 @@ instance InstantiateFull Term where
           Sort s      -> Sort <$> instantiateFull' s
           Pi a b      -> uncurry Pi <$> instantiateFull' (a,b)
           Let a u v   -> uncurry3 Let <$> instantiateFull' (a,u,v)
-          LetV x es   -> LetV x <$> instantiateFull' es
+          LetVar x es -> LetVar x <$> instantiateFull' es
           DontCare v  -> dontCare <$> instantiateFull' v
           v@Dummy{}   -> return v
 

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -963,12 +963,10 @@ reduceTm rEnv bEnv !constInfo normalisation =
             getArg Proj{}         = __IMPOSSIBLE__
 
         -- Case: let.
-        Let a u v -> do
+        Let a (LetAbs x u v) -> do
           let i = getArgInfo a
-          ptr <- createThunk (closure env (getFreeVariables i) t)
-          case v of
-            Abs   _ v -> runAM (evalClosure v (ptr `extendEnv` env) spine ctrl)
-            NoAbs _ v -> runAM (evalClosure v env spine ctrl)
+          ptr <- createThunk (closure env (getFreeVariables i) u)
+          runAM (evalClosure v (ptr `extendEnv` env) spine ctrl)
 
         LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
 

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -968,7 +968,14 @@ reduceTm rEnv bEnv !constInfo normalisation =
           ptr <- createThunk (closure env (getFreeVariables i) u)
           runAM (evalClosure v (ptr `extendEnv` env) spine ctrl)
 
-        LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
+        LetVar x [] ->
+          evalIApplyAM spine ctrl $
+          case lookupEnv x env of
+            Nothing -> do
+              let ctx = envContext . redEnv $ rEnv
+                  (_,_,v) = fromMaybe __IMPOSSIBLE__ $ lookupLV_ x ctx
+              runAM (evalClosure v env spine ctrl)
+            Just p  -> evalPointerAM p spine ctrl
 
         -- Case: values. Literals and function types are already in weak-head normal form.
         -- We throw away the environment for literals mostly to make debug printing less verbose.
@@ -982,6 +989,7 @@ reduceTm rEnv bEnv !constInfo normalisation =
         Def f   es -> shiftElims (Def f   []) emptyEnv env es
         Con c i es -> shiftElims (Con c i []) emptyEnv env es
         Var x   es -> shiftElims (Var x   []) env      env es
+        LetVar x es -> shiftElims (LetVar x []) env    env es
 
         -- Case: metavariable. If it's instantiated evaluate the value. Meta instantiations are open
         -- terms with a specified list of free variables. buildEnv constructs the appropriate

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -970,6 +970,8 @@ reduceTm rEnv bEnv !constInfo normalisation =
             Abs   _ v -> runAM (evalClosure v (ptr `extendEnv` env) spine ctrl)
             NoAbs _ v -> runAM (evalClosure v env spine ctrl)
 
+        LetV x es -> __IMPOSSIBLE__ -- TODO LetV
+
         -- Case: values. Literals and function types are already in weak-head normal form.
         -- We throw away the environment for literals mostly to make debug printing less verbose.
         -- And we know the spine is empty since literals cannot be applied or projected.
@@ -1111,6 +1113,7 @@ reduceTm rEnv bEnv !constInfo normalisation =
           MetaV{}    -> False
           Var{}      -> False
           Let{}      -> False
+          LetV{}     -> False
           Def q _  -- Type constructors (data/record) are considered canonical for 'primForce'.
             | CTyCon <- cdefDef (constInfo q) -> True
             | otherwise                       -> False

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -970,7 +970,7 @@ reduceTm rEnv bEnv !constInfo normalisation =
             Abs   _ v -> runAM (evalClosure v (ptr `extendEnv` env) spine ctrl)
             NoAbs _ v -> runAM (evalClosure v env spine ctrl)
 
-        LetV x es -> __IMPOSSIBLE__ -- TODO LetV
+        LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
 
         -- Case: values. Literals and function types are already in weak-head normal form.
         -- We throw away the environment for literals mostly to make debug printing less verbose.
@@ -1113,7 +1113,7 @@ reduceTm rEnv bEnv !constInfo normalisation =
           MetaV{}    -> False
           Var{}      -> False
           Let{}      -> False
-          LetV{}     -> False
+          LetVar{}   -> False
           Def q _  -- Type constructors (data/record) are considered canonical for 'primForce'.
             | CTyCon <- cdefDef (constInfo q) -> True
             | otherwise                       -> False

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -584,6 +584,7 @@ instance ParallelReduce Term where
     -- Interesting cases
     (Def f es) -> (topLevelReductions (Def f) es) <|> (Def f <$> parReduce es)
     (Con c ci es) -> (topLevelReductions (Con c ci) es) <|> (Con c ci <$> parReduce es)
+    (Let a u v) -> return $ lazyAbsApp v u
 
     -- Congruence cases
     Lam i u  -> Lam i <$> parReduce u
@@ -822,6 +823,7 @@ instance AllHoles Term where
         (fmap (\b -> Pi a b) <$> allHoles a b)
       Sort s         -> fmap Sort <$> allHoles_ s
       Level l        -> fmap Level <$> allHoles_ l
+      Let{}          -> __IMPOSSIBLE__
       MetaV{}        -> __IMPOSSIBLE__
       DontCare{}     -> empty
       Dummy{}        -> empty
@@ -890,6 +892,7 @@ instance MetasToVars Term where
     Pi a b     -> Pi       <$> metasToVars a <*> metasToVars b
     Sort s     -> Sort     <$> metasToVars s
     Level l    -> Level    <$> metasToVars l
+    Let a u v  -> Let      <$> metasToVars a <*> metasToVars u <*> metasToVars v
     MetaV x es -> asks ($ x) >>= \case
       Just i   -> Var i    <$> metasToVars es
       Nothing  -> MetaV x  <$> metasToVars es

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -600,7 +600,6 @@ instance ParallelReduce Term where
 
     -- Impossible cases
     (Let a u)  -> __IMPOSSIBLE__
-    (LetVar{}) -> __IMPOSSIBLE__
     MetaV{}    -> __IMPOSSIBLE__
 
 instance ParallelReduce Sort where
@@ -825,7 +824,6 @@ instance AllHoles Term where
       Sort s         -> fmap Sort <$> allHoles_ s
       Level l        -> fmap Level <$> allHoles_ l
       Let{}          -> __IMPOSSIBLE__
-      LetVar{}       -> __IMPOSSIBLE__
       MetaV{}        -> __IMPOSSIBLE__
       DontCare{}     -> empty
       Dummy{}        -> empty
@@ -898,7 +896,6 @@ instance MetasToVars Term where
     Sort s     -> Sort     <$> metasToVars s
     Level l    -> Level    <$> metasToVars l
     Let a u    -> Let      <$> metasToVars a <*> metasToVars u
-    LetVar x es -> LetVar x   <$> metasToVars es
     MetaV x es -> asks ($ x) >>= \case
       Just i   -> Var i    <$> metasToVars es
       Nothing  -> MetaV x  <$> metasToVars es

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -585,7 +585,7 @@ instance ParallelReduce Term where
     (Def f es) -> (topLevelReductions (Def f) es) <|> (Def f <$> parReduce es)
     (Con c ci es) -> (topLevelReductions (Con c ci) es) <|> (Con c ci <$> parReduce es)
     (Let a u v) -> return $ lazyAbsApp v u
-    (LetV{}) -> __IMPOSSIBLE__ -- TODO LetV
+    (LetVar{}) -> __IMPOSSIBLE__ -- TODO LetVar
 
     -- Congruence cases
     Lam i u  -> Lam i <$> parReduce u
@@ -825,7 +825,7 @@ instance AllHoles Term where
       Sort s         -> fmap Sort <$> allHoles_ s
       Level l        -> fmap Level <$> allHoles_ l
       Let{}          -> __IMPOSSIBLE__
-      LetV{}         -> __IMPOSSIBLE__
+      LetVar{}       -> __IMPOSSIBLE__
       MetaV{}        -> __IMPOSSIBLE__
       DontCare{}     -> empty
       Dummy{}        -> empty
@@ -895,7 +895,7 @@ instance MetasToVars Term where
     Sort s     -> Sort     <$> metasToVars s
     Level l    -> Level    <$> metasToVars l
     Let a u v  -> Let      <$> metasToVars a <*> metasToVars u <*> metasToVars v
-    LetV x es  -> LetV x   <$> metasToVars es
+    LetVar x es -> LetVar x   <$> metasToVars es
     MetaV x es -> asks ($ x) >>= \case
       Just i   -> Var i    <$> metasToVars es
       Nothing  -> MetaV x  <$> metasToVars es

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -585,6 +585,7 @@ instance ParallelReduce Term where
     (Def f es) -> (topLevelReductions (Def f) es) <|> (Def f <$> parReduce es)
     (Con c ci es) -> (topLevelReductions (Con c ci) es) <|> (Con c ci <$> parReduce es)
     (Let a u v) -> return $ lazyAbsApp v u
+    (LetV{}) -> __IMPOSSIBLE__ -- TODO LetV
 
     -- Congruence cases
     Lam i u  -> Lam i <$> parReduce u
@@ -824,6 +825,7 @@ instance AllHoles Term where
       Sort s         -> fmap Sort <$> allHoles_ s
       Level l        -> fmap Level <$> allHoles_ l
       Let{}          -> __IMPOSSIBLE__
+      LetV{}         -> __IMPOSSIBLE__
       MetaV{}        -> __IMPOSSIBLE__
       DontCare{}     -> empty
       Dummy{}        -> empty
@@ -893,6 +895,7 @@ instance MetasToVars Term where
     Sort s     -> Sort     <$> metasToVars s
     Level l    -> Level    <$> metasToVars l
     Let a u v  -> Let      <$> metasToVars a <*> metasToVars u <*> metasToVars v
+    LetV x es  -> LetV x   <$> metasToVars es
     MetaV x es -> asks ($ x) >>= \case
       Just i   -> Var i    <$> metasToVars es
       Nothing  -> MetaV x  <$> metasToVars es

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -584,7 +584,6 @@ instance ParallelReduce Term where
     -- Interesting cases
     (Def f es) -> (topLevelReductions (Def f) es) <|> (Def f <$> parReduce es)
     (Con c ci es) -> (topLevelReductions (Con c ci) es) <|> (Con c ci <$> parReduce es)
-    (LetVar{}) -> __IMPOSSIBLE__ -- TODO LetVar
 
     -- Congruence cases
     Lam i u  -> Lam i <$> parReduce u
@@ -601,6 +600,7 @@ instance ParallelReduce Term where
 
     -- Impossible cases
     (Let a u)  -> __IMPOSSIBLE__
+    (LetVar{}) -> __IMPOSSIBLE__
     MetaV{}    -> __IMPOSSIBLE__
 
 instance ParallelReduce Sort where

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -397,7 +397,7 @@ instance Match NLPat Term where
         tellEq gamma k t u v
 
 extendContext :: MonadAddContext m => Context -> ArgName -> Dom Type -> m Context
-extendContext cxt x a = withFreshName empty x \ y -> return $ fmap (y,) a : cxt
+extendContext cxt x a = withFreshName empty x \ y -> return $ CtxVar y a : cxt
 
 
 makeSubstitution :: Telescope -> Sub -> Maybe Substitution

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -375,7 +375,7 @@ instance Match NLPat Term where
         v -> maybeBlock v
       PBoundVar i ps -> case v of
         Var i' es | i == i' -> do
-          let ti = maybe __IMPOSSIBLE__ (snd . unDom) $ lookupBV_ i k
+          let ti = maybe __IMPOSSIBLE__ (unDom . snd) $ lookupBV_ i k
           match r gamma k (ti , Var i) ps es
         _ | Pi a b <- unEl t -> do
           let ai    = domInfo a

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -375,7 +375,7 @@ instance Match NLPat Term where
         v -> maybeBlock v
       PBoundVar i ps -> case v of
         Var i' es | i == i' -> do
-          let ti = maybe __IMPOSSIBLE__ (unDom . snd) $ lookupBV_ i k
+          let ti = fromMaybe __IMPOSSIBLE__ $ typeOfBV_ i k
           match r gamma k (ti , Var i) ps es
         _ | Pi a b <- unEl t -> do
           let ai    = domInfo a

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -192,6 +192,7 @@ instance PatternFrom Term NLPat where
       (_ , Sort s)     -> PSort <$> patternFrom r k () s
       (_ , Level l)    -> __IMPOSSIBLE__
       (_ , Let{})      -> __IMPOSSIBLE__
+      (_ , LetV{})     -> __IMPOSSIBLE__
       (_ , DontCare{}) -> __IMPOSSIBLE__
       (_ , MetaV m _)  -> __IMPOSSIBLE__
       (_ , Dummy s _)  -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -192,7 +192,6 @@ instance PatternFrom Term NLPat where
       (_ , Sort s)     -> PSort <$> patternFrom r k () s
       (_ , Level l)    -> __IMPOSSIBLE__
       (_ , Let{})      -> __IMPOSSIBLE__
-      (_ , LetVar{})   -> __IMPOSSIBLE__
       (_ , DontCare{}) -> __IMPOSSIBLE__
       (_ , MetaV m _)  -> __IMPOSSIBLE__
       (_ , Dummy s _)  -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -191,6 +191,7 @@ instance PatternFrom Term NLPat where
         return $ PPi pa (Abs (absName b) pb)
       (_ , Sort s)     -> PSort <$> patternFrom r k () s
       (_ , Level l)    -> __IMPOSSIBLE__
+      (_ , Let{})      -> __IMPOSSIBLE__
       (_ , DontCare{}) -> __IMPOSSIBLE__
       (_ , MetaV m _)  -> __IMPOSSIBLE__
       (_ , Dummy s _)  -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -192,7 +192,7 @@ instance PatternFrom Term NLPat where
       (_ , Sort s)     -> PSort <$> patternFrom r k () s
       (_ , Level l)    -> __IMPOSSIBLE__
       (_ , Let{})      -> __IMPOSSIBLE__
-      (_ , LetV{})     -> __IMPOSSIBLE__
+      (_ , LetVar{})   -> __IMPOSSIBLE__
       (_ , DontCare{}) -> __IMPOSSIBLE__
       (_ , MetaV m _)  -> __IMPOSSIBLE__
       (_ , Dummy s _)  -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -835,7 +835,6 @@ isRigid _ (El _ t) = case t of
   Sort{}     -> return $ IsNotRigid Permanent
   Level{}    -> return $ IsNotRigid Permanent
   Let{}      -> return $ IsNotRigid Permanent
-  LetVar{}   -> return $ IsNotRigid Permanent
   MetaV{}    -> return $ IsNotRigid Unspecified
   DontCare{} -> return $ IsNotRigid Permanent
   Dummy{}    -> return $ IsNotRigid Permanent

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -834,6 +834,7 @@ isRigid _ (El _ t) = case t of
                 if visible dom then IsRigid else IsNotRigid Permanent
   Sort{}     -> return $ IsNotRigid Permanent
   Level{}    -> return $ IsNotRigid Permanent
+  Let{}      -> return $ IsNotRigid Permanent
   MetaV{}    -> return $ IsNotRigid Unspecified
   DontCare{} -> return $ IsNotRigid Permanent
   Dummy{}    -> return $ IsNotRigid Permanent

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -280,7 +280,7 @@ inferHead e = do
       (u, a) <- getVarInfo x
       reportSDoc "tc.term.var" 20 $ hsep
         [ "variable" , prettyTCM x
-        , "(" , text (show u) , ")"
+        , "(" , pretty u , ")"
         , "has type:" , prettyTCM a
         ]
       unless (usableRelevance a) $

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -835,6 +835,7 @@ isRigid _ (El _ t) = case t of
   Sort{}     -> return $ IsNotRigid Permanent
   Level{}    -> return $ IsNotRigid Permanent
   Let{}      -> return $ IsNotRigid Permanent
+  LetV{}     -> return $ IsNotRigid Permanent
   MetaV{}    -> return $ IsNotRigid Unspecified
   DontCare{} -> return $ IsNotRigid Permanent
   Dummy{}    -> return $ IsNotRigid Permanent

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -835,7 +835,7 @@ isRigid _ (El _ t) = case t of
   Sort{}     -> return $ IsNotRigid Permanent
   Level{}    -> return $ IsNotRigid Permanent
   Let{}      -> return $ IsNotRigid Permanent
-  LetV{}     -> return $ IsNotRigid Permanent
+  LetVar{}   -> return $ IsNotRigid Permanent
   MetaV{}    -> return $ IsNotRigid Unspecified
   DontCare{} -> return $ IsNotRigid Permanent
   Dummy{}    -> return $ IsNotRigid Permanent

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1872,6 +1872,7 @@ isCoinductive t = do
     Con   {} -> __IMPOSSIBLE__
     Pi    {} -> return (Just False)
     Sort  {} -> return (Just False)
+    Let   {} -> __IMPOSSIBLE__
     MetaV {} -> return Nothing
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1873,6 +1873,7 @@ isCoinductive t = do
     Pi    {} -> return (Just False)
     Sort  {} -> return (Just False)
     Let   {} -> __IMPOSSIBLE__
+    LetV  {} -> __IMPOSSIBLE__
     MetaV {} -> return Nothing
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1873,7 +1873,7 @@ isCoinductive t = do
     Pi    {} -> return (Just False)
     Sort  {} -> return (Just False)
     Let   {} -> __IMPOSSIBLE__
-    LetV  {} -> __IMPOSSIBLE__
+    LetVar{} -> __IMPOSSIBLE__
     MetaV {} -> return Nothing
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1873,7 +1873,6 @@ isCoinductive t = do
     Pi    {} -> return (Just False)
     Sort  {} -> return (Just False)
     Let   {} -> __IMPOSSIBLE__
-    LetVar{} -> __IMPOSSIBLE__
     MetaV {} -> return Nothing
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -699,7 +699,7 @@ checkClause
 
 checkClause t withSubAndLets c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats rhs0 wh catchall) = do
   let withSub       = fst <$> withSubAndLets
-  cxtNames <- reverse . map (fst . unDom) <$> getContext
+  cxtNames <- getContextNames
   checkClauseLHS t withSub c $ \ lhsResult@(LHSResult npars delta ps absurdPat trhs patSubst asb psplit ixsplit) -> do
 
     let installInheritedLets k

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -926,7 +926,7 @@ checkRHS i x aps t lhsResult@(LHSResult _ delta ps absurdPat trhs _ _asb _ _) rh
     usingEqnRHS :: [(A.Pattern, A.Expr)] -> [A.RewriteEqn] -> TCM (Maybe Term, WithFunctionProblem)
     usingEqnRHS pes rs = do
       let letBindings = for (List1.toList pes) $ \(p, e) -> A.LetPatBind (LetRange $ getRange e) p e
-      checkLetBindings letBindings $ rewriteEqnsRHS rs strippedPats rhs wh
+      checkLetBindings YesInlineLet letBindings $ \_ces -> rewriteEqnsRHS rs strippedPats rhs wh
 
     -- @invert@ clauses
     invertEqnRHS :: QName -> [Named A.BindName (A.Pattern,A.Expr)] -> [A.RewriteEqn] -> TCM (Maybe Term, WithFunctionProblem)

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1667,7 +1667,6 @@ isDataOrRecordType a0 = ifBlocked a0 blocked $ \case
     Con{}      -> __IMPOSSIBLE__
     Level{}    -> __IMPOSSIBLE__
     Let{}      -> __IMPOSSIBLE__
-    LetVar{}   -> __IMPOSSIBLE__
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -590,7 +590,7 @@ bindAsPatterns (AsB x v a m : asb) ret = do
     sep [ ":" <+> prettyTCM a
         , "=" <+> prettyTCM v
         ]
-  addLetBinding (setModality m defaultArgInfo) Inserted x v a $ bindAsPatterns asb ret
+  addLetBinding YesInlineLet (setModality m defaultArgInfo) Inserted x v a $ bindAsPatterns asb ret
 
 -- | Since with-abstraction can change the type of a variable, we have to
 --   recheck the stripped with patterns when checking a with function.

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1667,6 +1667,7 @@ isDataOrRecordType a0 = ifBlocked a0 blocked $ \case
     Con{}      -> __IMPOSSIBLE__
     Level{}    -> __IMPOSSIBLE__
     Let{}      -> __IMPOSSIBLE__
+    LetV{}     -> __IMPOSSIBLE__
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1667,7 +1667,7 @@ isDataOrRecordType a0 = ifBlocked a0 blocked $ \case
     Con{}      -> __IMPOSSIBLE__
     Level{}    -> __IMPOSSIBLE__
     Let{}      -> __IMPOSSIBLE__
-    LetV{}     -> __IMPOSSIBLE__
+    LetVar{}   -> __IMPOSSIBLE__
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1666,6 +1666,7 @@ isDataOrRecordType a0 = ifBlocked a0 blocked $ \case
     Lit{}      -> __IMPOSSIBLE__
     Con{}      -> __IMPOSSIBLE__
     Level{}    -> __IMPOSSIBLE__
+    Let{}      -> __IMPOSSIBLE__
     DontCare{} -> __IMPOSSIBLE__
     Dummy s _  -> __IMPOSSIBLE_VERBOSE__ s
 

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -447,7 +447,7 @@ etaExpandEquationStrategy k s = do
 
       Var _ _    -> return False
       Let a u v  -> shouldProject $ lazyAbsApp v u
-      LetV x es  -> __IMPOSSIBLE__ -- TODO
+      LetVar x es -> __IMPOSSIBLE__ -- TODO
       Lam _ _    -> __IMPOSSIBLE__
       Lit _      -> __IMPOSSIBLE__
       Pi _ _     -> __IMPOSSIBLE__
@@ -1002,4 +1002,4 @@ patternBindingForcedVars forced v = do
 
         -- Reduced away
         Let{}       -> __IMPOSSIBLE__
-        LetV{}      -> __IMPOSSIBLE__
+        LetVar{}    -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -447,6 +447,7 @@ etaExpandEquationStrategy k s = do
 
       Var _ _    -> return False
       Let a u v  -> shouldProject $ lazyAbsApp v u
+      LetV x es  -> __IMPOSSIBLE__ -- TODO
       Lam _ _    -> __IMPOSSIBLE__
       Lit _      -> __IMPOSSIBLE__
       Pi _ _     -> __IMPOSSIBLE__
@@ -999,3 +1000,4 @@ patternBindingForcedVars forced v = do
 
         -- Reduced away
         Let{}       -> __IMPOSSIBLE__
+        LetV{}      -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -948,10 +948,12 @@ unify s strategy = if isUnifyStateSolved s
 --   non-forced positions).
 patternBindingForcedVars :: PureTCM m => IntMap Modality -> Term -> m (DeBruijnPattern, IntMap Modality)
 patternBindingForcedVars forced v = do
-  let v' = precomputeFreeVars_ v
+  v' <- precomputeFreeVars_ v
   runWriterT (evalStateT (go unitModality v') forced)
   where
-    noForced v = gets $ IntSet.disjoint (precomputedFreeVars v) . IntMap.keysSet
+    noForced v = do
+      v' <- precomputedFreeVars v
+      gets $ IntSet.disjoint v' . IntMap.keysSet
 
     bind md i = do
       gets (IntMap.lookup i) >>= \case

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -446,8 +446,8 @@ etaExpandEquationStrategy k s = do
       Con c _ _  -> isJust <$> isRecordConstructor (conName c)
 
       Var _ _    -> return False
-      LetVar x es -> __IMPOSSIBLE__ -- TODO
       Let a u    -> shouldProject $ inlineLet u
+      LetVar x es -> shouldProject . (`applyE` es) =<< valueOfLV x
       Lam _ _    -> __IMPOSSIBLE__
       Lit _      -> __IMPOSSIBLE__
       Pi _ _     -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -446,8 +446,8 @@ etaExpandEquationStrategy k s = do
       Con c _ _  -> isJust <$> isRecordConstructor (conName c)
 
       Var _ _    -> return False
-      Let a u v  -> shouldProject $ lazyAbsApp v u
       LetVar x es -> __IMPOSSIBLE__ -- TODO
+      Let a u    -> shouldProject $ inlineLet u
       Lam _ _    -> __IMPOSSIBLE__
       Lit _      -> __IMPOSSIBLE__
       Pi _ _     -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -447,7 +447,6 @@ etaExpandEquationStrategy k s = do
 
       Var _ _    -> return False
       Let a u    -> shouldProject $ inlineLetAbs u
-      LetVar x es -> shouldProject . (`applyE` es) =<< valueOfLV x
       Lam _ _    -> __IMPOSSIBLE__
       Lit _      -> __IMPOSSIBLE__
       Pi _ _     -> __IMPOSSIBLE__
@@ -1002,4 +1001,3 @@ patternBindingForcedVars forced v = do
 
         -- Reduced away
         Let{}       -> __IMPOSSIBLE__
-        LetVar{}    -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -446,6 +446,7 @@ etaExpandEquationStrategy k s = do
       Con c _ _  -> isJust <$> isRecordConstructor (conName c)
 
       Var _ _    -> return False
+      Let a u v  -> shouldProject $ lazyAbsApp v u
       Lam _ _    -> __IMPOSSIBLE__
       Lit _      -> __IMPOSSIBLE__
       Pi _ _     -> __IMPOSSIBLE__
@@ -995,3 +996,6 @@ patternBindingForcedVars forced v = do
           -- It would be if we had reduced to `constructorForm`,
           -- however, turning a `LitNat` into constructors would only result in churn,
           -- since literals have no variables that could be bound.
+
+        -- Reduced away
+        Let{}       -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -446,7 +446,7 @@ etaExpandEquationStrategy k s = do
       Con c _ _  -> isJust <$> isRecordConstructor (conName c)
 
       Var _ _    -> return False
-      Let a u    -> shouldProject $ inlineLet u
+      Let a u    -> shouldProject $ inlineLetAbs u
       LetVar x es -> shouldProject . (`applyE` es) =<< valueOfLV x
       Lam _ _    -> __IMPOSSIBLE__
       Lit _      -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -369,7 +369,7 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
           -- See test/Succeed/ProjectionsTakeModuleTelAsParameters.agda.
           tel' <- do
             r <- headWithDefault __IMPOSSIBLE__ <$> getContext
-            return $ telFromList' nameToArgName $ reverse $ r : params
+            return $ contextToTel $ r : params
           setModuleCheckpoint m
           checkRecordProjections m name hasNamedCon con tel' ftel fields
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1641,7 +1641,7 @@ checkLetBinding b@(A.LetPatBind i p e) ret =
         , "cxtQnt=" <+> do pretty =<< viewTC eQuantity
         ]
       ]
-    fvs <- getContextSize
+    fvs <- getContextVarsSize
     checkLeftHandSide (CheckPattern p EmptyTel t) Nothing [p0] t0 Nothing [] $ \ (LHSResult _ delta0 ps _ _t _ asb _ _) -> bindAsPatterns asb $ do
           -- After dropping the free variable patterns there should be a single pattern left.
       let p = case drop fvs ps of [p] -> namedArg p; _ -> __IMPOSSIBLE__
@@ -1688,7 +1688,7 @@ checkLetBinding b@(A.LetPatBind i p e) ret =
         -- and relevances.
         let infos = map domInfo tsl
         -- We get list of names of the let-bound vars from the context.
-        let xs   = map (fst . unDom) (reverse binds)
+        let xs   = map ctxEntryName $ reverse binds
         -- We add all the bindings to the context.
         foldr (uncurry4 $ flip addLetBinding UserWritten) ret $ List.zip4 infos xs sigma ts
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1698,9 +1698,8 @@ checkLetBinding il b@(A.LetPatBind i p e) ret =
         -- We get list of names of the let-bound vars from the context.
         let xs   = map ctxEntryName $ reverse binds
         -- We add all the bindings to the context.
-        let makeEntry info x u t = CtxLet x (setOrigin UserWritten $ defaultArgDom info t) u
-            ces = List.zipWith4 makeEntry infos xs sigma ts
-        addContext ces $ ret ces
+        -- TODO: handle NoInlineLet
+        foldr (\(i,x,u,t) -> addLetBinding YesInlineLet i UserWritten x u t) (ret []) $ List.zip4 infos xs sigma ts
 
 checkLetBinding il (A.LetApply i erased x modapp copyInfo dir) ret = do
   -- Any variables in the context that doesn't belong to the current

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -238,8 +238,8 @@ leqType_ t t' = workOnTypes $ leqType t t'
 -- * Telescopes
 ---------------------------------------------------------------------------
 
-checkGeneralizeTelescope ::
-     Maybe ModuleName
+checkGeneralizeTelescope
+  :: Maybe ModuleName
        -- ^ The module the telescope belongs to (if any).
   -> A.GeneralizeTelescope
        -- ^ Telescope to check and add to the context for the continuation.
@@ -364,14 +364,14 @@ checkTypedBindings lamOrPi (A.TBind r tac xps e) ret = do
         modMod _        _  = id
 
 checkTypedBindings lamOrPi (A.TLet _ lbs) ret = do
-    checkLetBindings lbs (ret EmptyTel)
+    checkLetBindings YesInlineLet lbs (\_ces -> ret EmptyTel)
 
 -- | After a typed binding has been checked, add the patterns it binds
 addTypedPatterns :: List1 (NamedArg A.Binder) -> TCM a -> TCM a
 addTypedPatterns xps ret = do
   let ps  = List1.mapMaybe (A.extractPattern . namedArg) xps
   let lbs = map letBinding ps
-  checkLetBindings lbs ret
+  checkLetBindings YesInlineLet lbs $ \_ces -> ret
   where
     letBinding :: (A.Pattern, A.BindName) -> A.LetBinding
     letBinding (p, n) = A.LetPatBind (A.LetRange r) p (A.Var $ A.unBind n)
@@ -416,7 +416,7 @@ checkPath xp typ body ty = do
 --   "checkLambda bs e ty"  means  (\ bs -> e) : ty
 checkLambda :: Comparison -> A.TypedBinding -> A.Expr -> Type -> TCM Term
 checkLambda cmp (A.TLet _ lbs) body target =
-  checkLetBindings lbs (checkExpr body target)
+  checkLetBindings NoInlineLet lbs $ \ces -> ctxEntriesToLets ces <$> checkExpr body target
 checkLambda cmp b@(A.TBind r tac xps0 typ) body target = do
   reportSDoc "tc.term.lambda" 30 $ vcat
     [ "checkLambda before insertion xs =" <+> prettyA xps0
@@ -1075,7 +1075,8 @@ checkRecordUpdate cmp ei recexpr fs eupd t = do
       -- Bind the record value (before update) to a fresh @name@.
       v <- checkExpr' cmp recexpr t'
       name <- freshNoName $ getRange recexpr
-      addLetBinding defaultArgInfo Inserted name v t' $ do
+      let ce = CtxLet name (defaultDom t') v
+      addLetBinding NoInlineLet defaultArgInfo Inserted name v t' $ ctxEntryToLet ce <$> do
 
         let projs = map argFromDom $ recFields defn
 
@@ -1206,7 +1207,8 @@ checkExpr' cmp e t =
           | otherwise -> typeError $ NotImplemented "named arguments in lambdas"
 
         A.Lit _ lit  -> checkLiteral lit t
-        A.Let i ds e -> checkLetBindings ds $ checkExpr' cmp e t
+        A.Let i ds e -> checkLetBindings NoInlineLet ds $ \ces ->
+          ctxEntriesToLets ces <$> checkExpr' cmp e t
         e@A.Pi{} -> do
             t' <- isType_ e
             let s = getSort t'
@@ -1611,21 +1613,27 @@ inferExprForWith (Arg info e) = verboseBracket "tc.with.infer" 20 "inferExprForW
 -- * Let bindings
 ---------------------------------------------------------------------------
 
-checkLetBindings :: Foldable t => t A.LetBinding -> TCM a -> TCM a
-checkLetBindings = foldr ((.) . checkLetBinding) id
+checkLetBindings :: Foldable t => InlineLet -> t A.LetBinding -> ([ContextEntry] -> TCM a) -> TCM a
+checkLetBindings il = foldr (\b f ret -> checkLetBinding il b $ \ces -> f (ret . (ces ++))) ($ [])
 
-checkLetBinding :: A.LetBinding -> TCM a -> TCM a
+-- checkLetBindingsList :: [A.LetBinding] -> ([ContextEntry] -> TCM a) -> TCM a
+-- checkLetBindingsList [] ret = ret []
+-- checkLetBindingsList (b:bs) ret = checkLetBinding b $ \ces -> checkLetBindingsList bs (ret . (ces ++))
 
-checkLetBinding b@(A.LetBind i info x t e) ret =
+checkLetBinding :: InlineLet -> A.LetBinding -> ([ContextEntry] -> TCM a) -> TCM a
+
+checkLetBinding il b@(A.LetBind i info x t e) ret =
   traceCall (CheckLetBinding b) $ do
     -- #4131: Only DontExpandLast if no user written type signature
     let check | getOrigin info == Inserted = checkDontExpandLast
               | otherwise                  = checkExpr'
     t <- workOnTypes $ isType_ t
     v <- applyModalityToContext info $ check CmpLeq e t
-    addLetBinding info UserWritten (A.unBind x) v t ret
+    let name = A.unBind x
+        ce = CtxLet name (setOrigin UserWritten $ defaultArgDom info t) v
+    addLetBinding il info UserWritten name v t $ ret [ce | il == NoInlineLet]
 
-checkLetBinding b@(A.LetPatBind i p e) ret =
+checkLetBinding il b@(A.LetPatBind i p e) ret =
   traceCall (CheckLetBinding b) $ do
     p <- expandPatternSynonyms p
     (v, t) <- inferExpr' ExpandLast e
@@ -1690,9 +1698,11 @@ checkLetBinding b@(A.LetPatBind i p e) ret =
         -- We get list of names of the let-bound vars from the context.
         let xs   = map ctxEntryName $ reverse binds
         -- We add all the bindings to the context.
-        foldr (uncurry4 $ flip addLetBinding UserWritten) ret $ List.zip4 infos xs sigma ts
+        let makeEntry info x u t = CtxLet x (setOrigin UserWritten $ defaultArgDom info t) u
+            ces = List.zipWith4 makeEntry infos xs sigma ts
+        addContext ces $ ret ces
 
-checkLetBinding (A.LetApply i erased x modapp copyInfo dir) ret = do
+checkLetBinding il (A.LetApply i erased x modapp copyInfo dir) ret = do
   -- Any variables in the context that doesn't belong to the current
   -- module should go with the new module.
   -- Example: @f x y = let open M t in u@.
@@ -1713,7 +1723,7 @@ checkLetBinding (A.LetApply i erased x modapp copyInfo dir) ret = do
     -- checkSectionApplication to throw an error if the import
     -- directive does contain "open public".
     dir{ publicOpen = Nothing }
-  withAnonymousModule x new ret
+  withAnonymousModule x new $ ret []
 -- LetOpen and LetDeclaredVariable are only used for highlighting.
-checkLetBinding A.LetOpen{} ret = ret
-checkLetBinding (A.LetDeclaredVariable _) ret = ret
+checkLetBinding il A.LetOpen{} ret = ret []
+checkLetBinding il (A.LetDeclaredVariable _) ret = ret []

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240503 * 10 + 0
+currentInterfaceVersion = 20240513 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -121,8 +121,7 @@ instance EmbPrj I.Term where
   icod_ (DontCare a  ) = icodeN 8 DontCare a
   icod_ (Level    a  ) = icodeN 9 Level a
   icod_ (Let      a b) = icodeN 10 Let a b
-  icod_ (LetVar   a b) = icodeN 11 LetVar a b
-  icod_ (Dummy    a b) = icodeN 12 Dummy a b
+  icod_ (Dummy    a b) = icodeN 11 Dummy a b
 
   value = vcase valu where
     valu [a]       = valuN var   a
@@ -137,8 +136,7 @@ instance EmbPrj I.Term where
     valu [8, a]    = valuN DontCare a
     valu [9, a]    = valuN Level a
     valu [10, a, b] = valuN Let a b
-    valu [11, a, b] = valuN LetVar a b
-    valu [12, a, b] = valuN Dummy a b
+    valu [11, a, b] = valuN Dummy a b
     valu _         = malformed
 
 instance EmbPrj Level where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -115,7 +115,8 @@ instance EmbPrj I.Term where
   icod_ (Sort     a  ) = icodeN 7 Sort a
   icod_ (DontCare a  ) = icodeN 8 DontCare a
   icod_ (Level    a  ) = icodeN 9 Level a
-  icod_ (Dummy    a b) = icodeN 10 Dummy a b
+  icod_ (Let      a b c) = icodeN 10 Let a b c
+  icod_ (Dummy    a b) = icodeN 11 Dummy a b
 
   value = vcase valu where
     valu [a]       = valuN var   a
@@ -129,7 +130,8 @@ instance EmbPrj I.Term where
     valu [7, a]    = valuN Sort  a
     valu [8, a]    = valuN DontCare a
     valu [9, a]    = valuN Level a
-    valu [10, a, b] = valuN Dummy a b
+    valu [10, a, b, c] = valuN Let a b c
+    valu [11, a, b] = valuN Dummy a b
     valu _         = malformed
 
 instance EmbPrj Level where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -115,8 +115,8 @@ instance EmbPrj I.Term where
   icod_ (Sort     a  ) = icodeN 7 Sort a
   icod_ (DontCare a  ) = icodeN 8 DontCare a
   icod_ (Level    a  ) = icodeN 9 Level a
-  icod_ (Let      a b c) = icodeN 10 Let a b c
-  icod_ (LetV     a b) = icodeN 11 LetV a b
+  icod_ (Let    a b c) = icodeN 10 Let a b c
+  icod_ (LetVar   a b) = icodeN 11 LetVar a b
   icod_ (Dummy    a b) = icodeN 12 Dummy a b
 
   value = vcase valu where
@@ -132,7 +132,7 @@ instance EmbPrj I.Term where
     valu [8, a]    = valuN DontCare a
     valu [9, a]    = valuN Level a
     valu [10, a, b, c] = valuN Let a b c
-    valu [11, a, b] = valuN LetV a b
+    valu [11, a, b] = valuN LetVar a b
     valu [12, a, b] = valuN Dummy a b
     valu _         = malformed
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -116,7 +116,8 @@ instance EmbPrj I.Term where
   icod_ (DontCare a  ) = icodeN 8 DontCare a
   icod_ (Level    a  ) = icodeN 9 Level a
   icod_ (Let      a b c) = icodeN 10 Let a b c
-  icod_ (Dummy    a b) = icodeN 11 Dummy a b
+  icod_ (LetV     a b) = icodeN 11 LetV a b
+  icod_ (Dummy    a b) = icodeN 12 Dummy a b
 
   value = vcase valu where
     valu [a]       = valuN var   a
@@ -131,7 +132,8 @@ instance EmbPrj I.Term where
     valu [8, a]    = valuN DontCare a
     valu [9, a]    = valuN Level a
     valu [10, a, b, c] = valuN Let a b c
-    valu [11, a, b] = valuN Dummy a b
+    valu [11, a, b] = valuN LetV a b
+    valu [12, a, b] = valuN Dummy a b
     valu _         = malformed
 
 instance EmbPrj Level where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -103,6 +103,11 @@ instance EmbPrj a => EmbPrj (I.Abs a) where
     valu [0, a, b] = valuN NoAbs a b
     valu _         = malformed
 
+instance (EmbPrj a) => EmbPrj (I.LetAbs a) where
+  icod_ (LetAbs a b c) = icodeN' LetAbs a b c
+
+  value = valueN LetAbs
+
 instance EmbPrj I.Term where
   icod_ (Var     a []) = icodeN' (\ a -> Var a []) a
   icod_ (Var      a b) = icodeN 0 Var a b
@@ -115,7 +120,7 @@ instance EmbPrj I.Term where
   icod_ (Sort     a  ) = icodeN 7 Sort a
   icod_ (DontCare a  ) = icodeN 8 DontCare a
   icod_ (Level    a  ) = icodeN 9 Level a
-  icod_ (Let    a b c) = icodeN 10 Let a b c
+  icod_ (Let      a b) = icodeN 10 Let a b
   icod_ (LetVar   a b) = icodeN 11 LetVar a b
   icod_ (Dummy    a b) = icodeN 12 Dummy a b
 
@@ -131,7 +136,7 @@ instance EmbPrj I.Term where
     valu [7, a]    = valuN Sort  a
     valu [8, a]    = valuN DontCare a
     valu [9, a]    = valuN Level a
-    valu [10, a, b, c] = valuN Let a b c
+    valu [10, a, b] = valuN Let a b
     valu [11, a, b] = valuN LetVar a b
     valu [12, a, b] = valuN Dummy a b
     valu _         = malformed

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -136,7 +136,7 @@ checkSizeVarNeverZero i = do
   -- Looking for the minimal value for size variable i,
   -- we can restrict to the last i
   -- entries, as only these can contain i in an upper bound.
-  ts <- map (snd . unDom) . take i <$> getContext
+  ts <- map ctxEntryType . take i <$> getContext
   -- If we encountered a blocking meta in the context, we cannot
   -- say ``no'' for sure.
   (n, blockers) <- runWriterT $ minSizeValAux ts $ repeat 0

--- a/src/full/Agda/TypeChecking/SizedTypes/Pretty.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Pretty.hs
@@ -8,7 +8,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad.Base.Types
 import Agda.TypeChecking.Monad.Builtin (HasBuiltins, builtinSizeInf, getBuiltin')
-import Agda.TypeChecking.Monad.Context (unsafeModifyContext)
+import Agda.TypeChecking.Monad.Context (unsafeModifyContext, contextNames)
 import Agda.TypeChecking.Monad.SizedTypes
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.SizedTypes.Syntax
@@ -42,7 +42,7 @@ instance PrettyTCM (SizeConstraint) where
 instance PrettyTCM HypSizeConstraint where
   prettyTCM (HypSizeConstraint cxt _ hs c) =
     unsafeModifyContext (const cxt) $ do
-      let cxtNames = reverse $ map (fst . unDom) cxt
+      let cxtNames = contextNames cxt
       -- text ("[#cxt=" ++ show (size cxt) ++ "]") <+> do
       prettyList (map prettyTCM cxtNames) <+> do
         applyUnless (null hs)

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -229,9 +229,6 @@ sortOf t = do
         sortOfE a (MetaV x) es
       Let a u    ->
         sortOfT $ inlineLetAbs u
-      LetVar x es -> do
-        a <- typeOfLV x
-        sortOfE a (LetVar x) es
       Lam{}      -> __IMPOSSIBLE__
       Con{}      -> __IMPOSSIBLE__
       Lit{}      -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -228,6 +228,7 @@ sortOf t = do
         a <- metaType x
         sortOfE a (MetaV x) es
       Let a u v  -> sortOf $ lazyAbsApp v u
+      LetV x es  -> __IMPOSSIBLE__ -- TODO LetV
       Lam{}      -> __IMPOSSIBLE__
       Con{}      -> __IMPOSSIBLE__
       Lit{}      -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -227,8 +227,9 @@ sortOf t = do
       MetaV x es -> do
         a <- metaType x
         sortOfE a (MetaV x) es
-      Let a u v  -> sortOf $ lazyAbsApp v u
       LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
+      Let a u    ->
+        inlineLet' 0 (letAbsValue u) <$> underLetBinding a u sortOfT
       Lam{}      -> __IMPOSSIBLE__
       Con{}      -> __IMPOSSIBLE__
       Lit{}      -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -227,9 +227,11 @@ sortOf t = do
       MetaV x es -> do
         a <- metaType x
         sortOfE a (MetaV x) es
-      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
       Let a u    ->
         inlineLet' 0 (letAbsValue u) <$> underLetBinding a u sortOfT
+      LetVar x es -> do
+        a <- typeOfLV x
+        sortOfE a (LetVar x) es
       Lam{}      -> __IMPOSSIBLE__
       Con{}      -> __IMPOSSIBLE__
       Lit{}      -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -228,7 +228,7 @@ sortOf t = do
         a <- metaType x
         sortOfE a (MetaV x) es
       Let a u v  -> sortOf $ lazyAbsApp v u
-      LetV x es  -> __IMPOSSIBLE__ -- TODO LetV
+      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
       Lam{}      -> __IMPOSSIBLE__
       Con{}      -> __IMPOSSIBLE__
       Lit{}      -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -228,7 +228,7 @@ sortOf t = do
         a <- metaType x
         sortOfE a (MetaV x) es
       Let a u    ->
-        inlineLet' 0 (letAbsValue u) <$> underLetBinding a u sortOfT
+        sortOfT $ inlineLetAbs u
       LetVar x es -> do
         a <- typeOfLV x
         sortOfE a (LetVar x) es

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -227,6 +227,7 @@ sortOf t = do
       MetaV x es -> do
         a <- metaType x
         sortOfE a (MetaV x) es
+      Let a u v  -> sortOf $ lazyAbsApp v u
       Lam{}      -> __IMPOSSIBLE__
       Con{}      -> __IMPOSSIBLE__
       Lit{}      -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1085,6 +1085,11 @@ instance Subst LetBinding where
   type SubstArg LetBinding = Term
   applySubst rho (LetBinding o v t) = LetBinding o (applySubst rho v) (applySubst rho t)
 
+instance Subst ContextEntry where
+  type SubstArg ContextEntry = Term
+  applySubst rho (CtxVar x a)   = CtxVar x $ applySubst rho a
+  applySubst rho (CtxLet x a v) = CtxLet x (applySubst rho a) (applySubst rho v)
+
 instance Subst a => Subst (Maybe a) where
   type SubstArg (Maybe a) = SubstArg a
 

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -91,7 +91,7 @@ applyTermE err' m es = coerce $
         case v of
           Abs x v   -> Abs x $ applyTermE err' v $ raise 1 es
           NoAbs x v -> NoAbs x $ applyTermE err' v es
-      LetV x es   -> __IMPOSSIBLE__ -- TODO LetV
+      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
       Dummy s es' -> Dummy s (es' ++ es)
       DontCare mv -> dontCare $ mv `app` es  -- Andreas, 2011-10-02
         -- need to go under DontCare, since "with" might resurrect irrelevant term
@@ -847,7 +847,7 @@ applySubstTerm rho t    = coerce $ case coerce t of
     Pi a b      -> uncurry Pi $ subPi (a,b)
     Sort s      -> Sort $ sub @(Sort' t) s
     Let a u v   -> uncurry3 Let $ subLet (a,u,v)
-    LetV x es   -> __IMPOSSIBLE__ -- TODO LetV
+    LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
     DontCare mv -> dontCare $ sub @t mv
     Dummy s es  -> Dummy s $ subE es
  where
@@ -1504,9 +1504,9 @@ instance Ord Term where
   Let a b c  `compare` Let x y z  = compare (a, b, c) (x, y, z)
   Let{}      `compare` _          = LT
   _          `compare` Let{}      = GT
-  LetV a b   `compare` LetV x y   = compare (a, b) (x, y)
-  LetV{}     `compare` _          = LT
-  _          `compare` LetV{}     = GT
+  LetVar a b `compare` LetVar x y = compare (a, b) (x, y)
+  LetVar{}   `compare` _          = LT
+  _          `compare` LetVar{}   = GT
   MetaV a b  `compare` MetaV x y  = compare (a, b) (x, y)
   MetaV{}    `compare` _          = LT
   _          `compare` MetaV{}    = GT

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -91,6 +91,7 @@ applyTermE err' m es = coerce $
         case v of
           Abs x v   -> Abs x $ applyTermE err' v $ raise 1 es
           NoAbs x v -> NoAbs x $ applyTermE err' v es
+      LetV x es   -> __IMPOSSIBLE__ -- TODO LetV
       Dummy s es' -> Dummy s (es' ++ es)
       DontCare mv -> dontCare $ mv `app` es  -- Andreas, 2011-10-02
         -- need to go under DontCare, since "with" might resurrect irrelevant term
@@ -846,6 +847,7 @@ applySubstTerm rho t    = coerce $ case coerce t of
     Pi a b      -> uncurry Pi $ subPi (a,b)
     Sort s      -> Sort $ sub @(Sort' t) s
     Let a u v   -> uncurry3 Let $ subLet (a,u,v)
+    LetV x es   -> __IMPOSSIBLE__ -- TODO LetV
     DontCare mv -> dontCare $ sub @t mv
     Dummy s es  -> Dummy s $ subE es
  where
@@ -1502,6 +1504,9 @@ instance Ord Term where
   Let a b c  `compare` Let x y z  = compare (a, b, c) (x, y, z)
   Let{}      `compare` _          = LT
   _          `compare` Let{}      = GT
+  LetV a b   `compare` LetV x y   = compare (a, b) (x, y)
+  LetV{}     `compare` _          = LT
+  _          `compare` LetV{}     = GT
   MetaV a b  `compare` MetaV x y  = compare (a, b) (x, y)
   MetaV{}    `compare` _          = LT
   _          `compare` MetaV{}    = GT

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -88,10 +88,10 @@ applyTermE err' m es = coerce $
       Level{}     -> err __IMPOSSIBLE__
       Pi _ _      -> err __IMPOSSIBLE__
       Sort s      -> Sort $ s `applyE` es
-      LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
       Let a b     -> Let a $
         case b of
           LetAbs x u v -> LetAbs x u $ applyTermE err' v $ raise 1 es
+      LetVar x es' -> LetVar x (es' ++ es)
       Dummy s es' -> Dummy s (es' ++ es)
       DontCare mv -> dontCare $ mv `app` es  -- Andreas, 2011-10-02
         -- need to go under DontCare, since "with" might resurrect irrelevant term
@@ -846,8 +846,10 @@ applySubstTerm rho t    = coerce $ case coerce t of
     Level l     -> levelTm $ sub @(Level' t) l
     Pi a b      -> uncurry Pi $ subPi (a,b)
     Sort s      -> Sort $ sub @(Sort' t) s
-    LetVar x es -> __IMPOSSIBLE__ -- TODO LetVar
     Let a u     -> uncurry Let $ subLet (a, u)
+    LetVar x es -> case coerce (lookupS rho x) of
+      LetVar y [] -> LetVar y $ subE es
+      _           -> __IMPOSSIBLE__
     DontCare mv -> dontCare $ sub @t mv
     Dummy s es  -> Dummy s $ subE es
  where

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -91,7 +91,6 @@ applyTermE err' m es = coerce $
       Let a b     -> Let a $
         case b of
           LetAbs x u v -> LetAbs x u $ applyTermE err' v $ raise 1 es
-      LetVar x es' -> LetVar x (es' ++ es)
       Dummy s es' -> Dummy s (es' ++ es)
       DontCare mv -> dontCare $ mv `app` es  -- Andreas, 2011-10-02
         -- need to go under DontCare, since "with" might resurrect irrelevant term
@@ -847,7 +846,6 @@ applySubstTerm rho t    = coerce $ case coerce t of
     Pi a b      -> uncurry Pi $ subPi (a,b)
     Sort s      -> Sort $ sub @(Sort' t) s
     Let a u     -> uncurry Let $ subLet (a, u)
-    LetVar x es -> coerce $ lookupS rho x  `applyE` subE es
     DontCare mv -> dontCare $ sub @t mv
     Dummy s es  -> Dummy s $ subE es
  where
@@ -1511,9 +1509,6 @@ instance Ord Term where
   Let a b    `compare` Let x y    = compare (a, b) (x, y)
   Let{}      `compare` _          = LT
   _          `compare` Let{}      = GT
-  LetVar a b `compare` LetVar x y = compare (a, b) (x, y)
-  LetVar{}   `compare` _          = LT
-  _          `compare` LetVar{}   = GT
   MetaV a b  `compare` MetaV x y  = compare (a, b) (x, y)
   MetaV{}    `compare` _          = LT
   _          `compare` MetaV{}    = GT

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -17,7 +17,6 @@ import Data.Maybe
 import Data.Monoid
 
 import Agda.Syntax.Common
-import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
 
@@ -176,11 +175,7 @@ permuteTel perm tel =
 -- | Like 'permuteTel', but start with a context.
 --
 permuteContext :: Permutation -> Context -> Telescope
-permuteContext perm ctx = unflattenTel names types
-  where
-    flatTel = flattenContext ctx
-    names   = permute perm $ map (prettyShow . fst . unDom) flatTel
-    types   = permute perm $ renameP impossible (flipP perm) $ map (fmap snd) flatTel
+permuteContext perm ctx = permuteTel perm $ contextToTel ctx
 
 -- | Recursively computes dependencies of a set of variables in a given
 --   telescope. Any dependencies outside of the telescope are ignored.

--- a/test/Internal/TypeChecking/Generators.hs
+++ b/test/Internal/TypeChecking/Generators.hs
@@ -504,7 +504,6 @@ instance ShrinkC Term where
   shrinkC conf DontCare{}  = []
   shrinkC conf Dummy{}     = []
   shrinkC conf Let{}       = []
-  shrinkC conf LetVar{}    = []
   shrinkC conf t           = filter validType $ case t of
     Var i es     -> map unArg (argsFromElims es) ++
                     (uncurry Var <$> shrinkC conf (VarName i, NoType es))
@@ -523,7 +522,6 @@ instance ShrinkC Term where
                     (MetaV m <$> shrinkC conf (NoType es))
 #if __GLASGOW_HASKELL__ < 900
     Let{}        -> __IMPOSSIBLE__
-    LetVar{}     -> __IMPOSSIBLE__
     DontCare _   -> __IMPOSSIBLE__
     Dummy{}      -> __IMPOSSIBLE__
 #endif
@@ -558,9 +556,6 @@ instance KillVar Term where
     Pi a b                 -> uncurry Pi  $ killVar i (a, b)
     MetaV m args           -> MetaV m     $ killVar i args
     Let a u                -> uncurry Let $ killVar i (a, u)
-    LetVar j args | j == i    -> DontCare (LetVar j [])
-                  | j >  i    -> LetVar (j - 1) $ killVar i args
-                  | otherwise -> LetVar j       $ killVar i args
     DontCare mv            -> DontCare    $ killVar i mv
     Dummy{}                -> t
 


### PR DESCRIPTION
Currently there is no way to preserve `let`-bindings in the internal syntax, which is bad because it destroys sharing and prevents us from pretty-printing terms as the user wrote them. The goal of this PR is to work towards fixing that.