### PR TITLE
Fix #6739: testing GHC backend: use separate -outputdir to avoid races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,6 +511,13 @@ succeed :
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Succeed ; \
 		rm test/Succeed/exec-tc/executables )
 
+.PHONY : fast-succeed ##
+fast-succeed :
+	@$(call decorate, "Suite of successful tests (using agda-fast)", \
+		echo $(shell which $(AGDA_FAST_BIN)) > test/Succeed/exec-tc/executables && \
+		AGDA_FAST_BIN=$(AGDA_FAST_BIN) $(AGDA_FAST_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/Succeed ; \
+		rm test/Succeed/exec-tc/executables )
+
 .PHONY : fail ##
 fail :
 	@$(call decorate, "Suite of failing tests", \

--- a/test/Succeed/Tests.hs
+++ b/test/Succeed/Tests.hs
@@ -82,13 +82,13 @@ mkSucceedTest extraOpts dir agdaFile =
 
   updGolden = Just $ writeTextFile warnFile
 
-  doRun = do
+  doRun = withSystemTempDirectory testName \ compDir -> do
 
     let agdaArgs = [ "-v0", "-i" ++ dir, "-itest/", agdaFile
                    , "-vimpossible:10" -- BEWARE: no spaces allowed here
                    , "-vwarning:1"
                    , "--double-check"
-                   -- , "--ghc-flag=-outputdir=ghc-" ++ testName
+                   , "--ghc-flag=-outputdir=" ++ compDir
                    -- , "-vcompile.cmd:1"
                    ] ++
                    [ if testName == "Issue481"

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Utils (module Utils,
               AgdaError(..)) where
@@ -27,7 +28,7 @@ import System.Exit
 import System.FilePath
 import qualified System.FilePath.Find as Find
 import System.FilePath.GlobPattern
--- import System.IO                     ( hPutStrLn, stderr )
+import System.IO                     ( hPutStrLn, stderr )
 import System.IO.Temp
 import System.PosixCompat.Time       ( epochTime )
 import System.PosixCompat.Files      ( modificationTime, touchFile )
@@ -77,8 +78,9 @@ readAgdaProcessWithExitCode extraEnv args inp = do
   home <- getHomeDirectory
   let env = expandEnvVarTelescope home $ maybe origEnv (origEnv ++) extraEnv
   let envArgs = maybe [] words $ lookup "AGDA_ARGS" env
+  let agdaBin = getAgdaBin env
   -- hPutStrLn stderr $ unwords $ agdaBin : envArgs ++ args
-  let agdaProc = (proc (getAgdaBin env) (envArgs ++ args))
+  let agdaProc = (proc agdaBin (envArgs ++ args))
         { create_group = True
         , env          = Just env
         , cwd          = Just "."


### PR DESCRIPTION
Hopefully fixes #6739 (time will tell as races only show up sometimes).
