### PR TITLE
New error warning `ConstructorDoesNotFitInData` instead of hard error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Pragmas and options
   when `--this` implies `--no-that` (and analogous for `--no-this` implies
   `--that`, etc).
 
+* New error warning `ConstructorDoesNotFitInData` when a constructor parameter
+  is too big (in the sense of universe level) for the target data type of the constructor.
+  Used to be a hard error.
+
 * [**Breaking**] The option `--overlapping-instances`, which allows
   backtracking during instance search, has been renamed to
   `--backtracking-instance-search`.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1594,6 +1594,10 @@ Such *error warnings* are always on, they cannot be toggled by :option:`-W`.
 
      Importing a file not using e.g. :option:`--safe` from one which does.
 
+.. option:: ConstructorDoesNotFitInData
+
+     Constructor with arguments in a universe higher than the one of its data type.
+
 .. option:: CoverageIssue
 
      Failed coverage checks.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -412,6 +412,7 @@ warningHighlighting' :: Bool -- ^ should we generate highlighting for unsolved m
 warningHighlighting' b w = case tcWarning w of
   TerminationIssue terrs     -> terminationErrorHighlighting terrs
   NotStrictlyPositive d ocs  -> positivityErrorHighlighting d ocs
+  ConstructorDoesNotFitInData c s1 s2 err -> errorWarningHighlighting c
   -- #3965 highlight each unreachable clause independently: they
   -- may be interleaved with actually reachable clauses!
   UnreachableClauses _ rs    -> foldMap deadcodeHighlighting rs

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -154,6 +154,7 @@ errorWarnings = Set.fromList
   , MissingDeclarations_
   , NotAllowedInMutual_
   , NotStrictlyPositive_
+  , ConstructorDoesNotFitInData_
   , OverlappingTokensWarning_
   , PragmaCompiled_
   , SafeFlagPostulate_
@@ -276,6 +277,7 @@ data WarningName
   | NoGuardednessFlag_
   | NotInScope_
   | NotStrictlyPositive_
+  | ConstructorDoesNotFitInData_
   | UnsupportedIndexedMatch_
   | OldBuiltin_
   | BuiltinDeclaresIdentifier_
@@ -472,6 +474,7 @@ warningNameDescription = \case
   FixityInRenamingModule_          -> "Fixity annotations in `renaming' directive for `module'."
   NotInScope_                      -> "Out of scope names."
   NotStrictlyPositive_             -> "Failed strict positivity checks."
+  ConstructorDoesNotFitInData_     -> "Failed constructor size checks."
   UnsupportedIndexedMatch_         -> "Failures to compute full equivalence when splitting on indexed family."
   OldBuiltin_                      -> "Deprecated `BUILTIN' pragmas."
   BuiltinDeclaresIdentifier_       -> "`BUILTIN' pragmas that declare a new identifier but have been given an existing one."

--- a/src/full/Agda/TypeChecking/Errors.hs-boot
+++ b/src/full/Agda/TypeChecking/Errors.hs-boot
@@ -6,6 +6,9 @@ import Agda.Syntax.Abstract.Name
 
 import Agda.TypeChecking.Monad.Base
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug (MonadDebug)
+import {-# SOURCE #-} Agda.TypeChecking.Pretty (PrettyTCM)
+
+instance PrettyTCM TCErr
 
 -- Misplaced SPECIALISE pragma:
 -- {-# SPECIALIZE renderError :: TCErr -> TCM String #-}

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4234,6 +4234,9 @@ data Warning
     -- ^ 'Clause' was turned into copattern matching clause(s) by an @{-# INLINE constructor #-}@
     --   and thus is not a definitional equality any more.
   | NotStrictlyPositive      QName (Seq OccursWhere)
+  | ConstructorDoesNotFitInData QName Sort Sort TCErr
+      -- ^ Checking whether constructor 'QName' 'Sort' fits into @data@ 'Sort'
+      --   produced 'TCErr'
 
   | UnsolvedMetaVariables    [Range]  -- ^ Do not use directly with 'warning'
   | UnsolvedInteractionMetas [Range]  -- ^ Do not use directly with 'warning'
@@ -4418,6 +4421,7 @@ warningName = \case
   NoGuardednessFlag{}          -> NoGuardednessFlag_
   NotInScopeW{}                -> NotInScope_
   NotStrictlyPositive{}        -> NotStrictlyPositive_
+  ConstructorDoesNotFitInData{}-> ConstructorDoesNotFitInData_
   UnsupportedIndexedMatch{}    -> UnsupportedIndexedMatch_
   OldBuiltin{}                 -> OldBuiltin_
   BuiltinDeclaresIdentifier{}  -> BuiltinDeclaresIdentifier_

--- a/src/full/Agda/TypeChecking/Monad/Pure.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Pure.hs-boot
@@ -10,7 +10,7 @@ import Control.Monad.Writer ( WriterT )
 import Agda.TypeChecking.Monad.Base
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Builtin
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Context
-import Agda.TypeChecking.Monad.Debug
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Signature
 
 class

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
@@ -13,7 +13,7 @@ import Agda.TypeChecking.Monad.Base
   ( TCM, ReadTCState, HasOptions, MonadTCEnv
   , Definition, RewriteRules
   )
-import Agda.TypeChecking.Monad.Debug (MonadDebug)
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug (MonadDebug)
 
 import Agda.Syntax.Common.Pretty (prettyShow)
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -133,6 +133,8 @@ prettyWarning = \case
       [prettyTCM d] ++ pwords "is not strictly positive, because it occurs"
       ++ [prettyTCM ocs]
 
+    ConstructorDoesNotFitInData c s1 s2 err -> prettyTCM err
+
     UnsupportedIndexedMatch doc -> vcat
       [ fsep (pwords "This clause uses pattern-matching features that are not yet supported by Cubical Agda,"
            ++ pwords "the function to which it belongs will not compute when applied to transports."

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240503 * 10 + 0
+currentInterfaceVersion = 20240526 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -32,6 +32,7 @@ instance EmbPrj Warning where
     UnreachableClauses a b                -> icodeN 0 UnreachableClauses a b
     CoverageIssue a b                     -> __IMPOSSIBLE__
     NotStrictlyPositive a b               -> __IMPOSSIBLE__
+    ConstructorDoesNotFitInData{}         -> __IMPOSSIBLE__
     UnsolvedMetaVariables a               -> __IMPOSSIBLE__
     UnsolvedInteractionMetas a            -> __IMPOSSIBLE__
     UnsolvedConstraints a                 -> __IMPOSSIBLE__
@@ -485,6 +486,7 @@ instance EmbPrj WarningName where
     UselessMacro_                                -> 114
     WarningProblem_                              -> 115
     ConflictingPragmaOptions_                    -> 116
+    ConstructorDoesNotFitInData_                 -> 117
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -603,6 +605,7 @@ instance EmbPrj WarningName where
     114 -> return UselessMacro_
     115 -> return WarningProblem_
     116 -> return ConflictingPragmaOptions_
+    117 -> return ConstructorDoesNotFitInData_
     _   -> malformed
 
 

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -84,10 +84,18 @@ warning'_ loc w = do
   r <- viewTC eRange
   c <- viewTC eCall
   b <- areWeCaching
-  -- NicifierIssues come with their own error locations.
-  let r' = case w of { NicifierIssue w0 -> getRange w0 ; _ -> r }
+  let r' = case w of
+        -- NicifierIssues come with their own error locations.
+        NicifierIssue w0 -> getRange w0
+        -- ConstructorDoesNotFitInData packages a full TCErr, so skip the sayWhen/Where here.
+        ConstructorDoesNotFitInData{} -> noRange
+        _ -> r
+  let c' = case w of
+        -- ConstructorDoesNotFitInData packages a full TCErr, so skip the sayWhen/Where here.
+        ConstructorDoesNotFitInData{} -> Nothing
+        _ -> c
   let wn = warningName w
-  p <- sayWhen r' c $
+  p <- sayWhen r' c' $
     -- Only benign warnings can be deactivated with -WnoXXX, so don't
     -- display hint for error warnings.
     applyUnless (wn `elem` errorWarnings) (prettyWarningName wn $$) $

--- a/test/Fail/Issue5706.err
+++ b/test/Fail/Issue5706.err
@@ -2,3 +2,11 @@ Issue5706.agda:32,3-6
 Set₁₈₄₄₆₇₄₄₀₇₃₇₀₉₅₅₁₆₁₆ is not less or equal than Set
 when checking that the type Set₁₈₄₄₆₇₄₄₀₇₃₇₀₉₅₅₁₆₁₅ of an argument
 to the constructor set fits in the sort Set of the datatype.
+Issue5706.agda:32,3-6
+Set₁₈₄₄₆₇₄₄₀₇₃₇₀₉₅₅₁₆₁₅ is not less or equal than Set
+when checking that the type X → SET of an argument to the
+constructor set fits in the sort Set of the datatype.
+Issue5706.agda:37,15-16
+Set₁₈₄₄₆₇₄₄₀₇₃₇₀₉₅₅₁₆₁₅ != Set
+when checking that the solution X of metavariable _A_21 has the
+expected type Set

--- a/test/Fail/Issue776.err
+++ b/test/Fail/Issue776.err
@@ -2,3 +2,11 @@ Issue776.agda:7,3-8
 Set (lsuc l) is not less or equal than Set₁
 when checking that the type Set l → Set l of an argument to the
 constructor proof fits in the sort Set₁ of the datatype.
+Issue776.agda:7,3-8
+Set l is not less or equal than Set₁
+when checking that the type F A of an argument to the constructor
+proof fits in the sort Set₁ of the datatype.
+Issue776.agda:7,3-8
+Set l is not less or equal than Set₁
+when checking that the type F B of an argument to the constructor
+proof fits in the sort Set₁ of the datatype.

--- a/test/Fail/LargeIndicesWithoutK.err
+++ b/test/Fail/LargeIndicesWithoutK.err
@@ -2,3 +2,6 @@ LargeIndicesWithoutK.agda:5,3-6
 Set a is not less or equal than Set
 when checking that the type A of an argument to the constructor [_]
 fits in the sort Set of the datatype.
+LargeIndicesWithoutK.agda:4,6-15
+Set a is not less or equal than Set
+when checking the definition of Singleton

--- a/test/Fail/UnsolvableLevelConstraintsInDataDef.err
+++ b/test/Fail/UnsolvableLevelConstraintsInDataDef.err
@@ -2,3 +2,12 @@ UnsolvableLevelConstraintsInDataDef.agda:7,3-6
 Set₂ is not less or equal than Set₁
 when checking that the type Set₁ of an argument to the constructor
 abs fits in the sort Set₁ of the datatype.
+UnsolvableLevelConstraintsInDataDef.agda:7,3-6
+Set₂ is not less or equal than Set₁
+when checking that the type D ≡ E of an argument to the constructor
+abs fits in the sort Set₁ of the datatype.
+UnsolvableLevelConstraintsInDataDef.agda:6,1-7,34
+D is not strictly positive, because it occurs
+in the third argument of _≡_
+in the type of the constructor abs
+in the definition of D.


### PR DESCRIPTION
When we check that the sort of the constructor (resp. constructor argument) fits into the sort of the data type, we now catch the error and wrap it into the `ConstructorDoesNotFitData` warning.

This warning is not benign and cannot be turned off, but one can continue coding interactively now as this is no longer a
hard error.
