### PR TITLE
GenericDocErrors to new errors LibraryError and RecursiveRecordNeedsInductivity

### DIFF
--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -109,9 +109,7 @@ mkLibM libs m = do
   (x, ews) <- lift $ lift $ runWriterT m
   let (errs, warns) = partitionEithers ews
   tell warns
-  unless (null errs) $ do
-    let doc = vcat $ map (formatLibError libs) errs
-    throwError doc
+  () <- List1.unlessNull errs \ errs -> throwError $ LibErrors libs errs
   return x
 
 ------------------------------------------------------------------------

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -29,6 +29,7 @@ import Agda.Syntax.Position
 import Agda.Utils.Lens
 import Agda.Utils.List1            ( List1, toList )
 import Agda.Utils.List2            ( List2, toList )
+import qualified Agda.Utils.List1  as List1
 import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty
 
@@ -42,7 +43,7 @@ data LibrariesFile = LibrariesFile
   , lfExists :: Bool
        -- ^ The libraries file might not exist,
        --   but we may print its assumed location in error messages.
-  } deriving (Show)
+  } deriving (Show, Generic)
 
 -- | A symbolic executable name.
 --
@@ -187,6 +188,7 @@ libraryWarningName (LibWarning c (UnknownField{})) = LibUnknownField_
 -- * Errors
 
 data LibError = LibError (Maybe LibPositionInfo) LibError'
+  deriving (Show, Generic)
 
 -- | Collected errors while processing library files.
 --
@@ -215,7 +217,7 @@ data LibError'
         -- ^ Name of the executable that is defined twice.
       (List2 (LineNumber, FilePath))
         -- ^ The resolutions of the executable.
-  -- deriving (Show)
+  deriving (Show, Generic)
 
 -- | Exceptions thrown by the @.agda-lib@ parser.
 --
@@ -237,6 +239,7 @@ data LibParseError
       -- ^ At the given line number, the given field is not followed by @:@.
   | ContentWithoutField LineNumber
       -- ^ At the given line number, indented text (content) is not preceded by a field.
+  deriving (Show, Generic)
 
 -- ** Raising warnings and errors
 
@@ -265,14 +268,21 @@ raiseErrors = tell . map Left . toList
 --
 type LibErrorIO = WriterT LibErrWarns (StateT LibState IO)
 
--- | Throws 'Doc' exceptions, still collects 'LibWarning's.
-type LibM = ExceptT Doc (WriterT [LibWarning] (StateT LibState IO))
+-- | Throws 'LibErrors' exceptions, still collects 'LibWarning's.
+type LibM = ExceptT LibErrors (WriterT [LibWarning] (StateT LibState IO))
 
 -- | Cache locations of project configurations and parsed @.agda-lib@ files.
 type LibState =
   ( Map FilePath ProjectConfig
   , Map FilePath AgdaLibFile
   )
+
+-- | Collected errors when processing an @.agda-lib@ file.
+--
+data LibErrors = LibErrors
+  { libErrorsInstalledLibraries :: [AgdaLibFile]
+  , libErrors                   :: List1 LibError
+  } deriving (Show, Generic)
 
 getCachedProjectConfig
   :: (MonadState LibState m, MonadIO m)
@@ -314,6 +324,12 @@ formatLibError installed (LibError mc e) =
     (Just c, LibParseError err) -> sep  [ formatLibPositionInfo c err, pretty e ]
     (_     , LibNotFound{}    ) -> vcat [ pretty e, prettyInstalledLibraries installed ]
     _ -> pretty e
+
+
+-- | Pretty-print 'LibErrors'.
+formatLibErrors :: LibErrors -> Doc
+formatLibErrors (LibErrors libs errs) =
+  vcat $  map (formatLibError libs) $ List1.toList errs
 
 -- | Does a parse error contain a line number?
 hasLineNumber :: LibParseError -> Maybe LineNumber
@@ -451,8 +467,14 @@ instance Pretty LibWarning' where
 ------------------------------------------------------------------------
 
 instance NFData ExecutablesFile
+instance NFData LibrariesFile
 instance NFData ProjectConfig
 instance NFData AgdaLibFile
 instance NFData LibPositionInfo
 instance NFData LibWarning
 instance NFData LibWarning'
+instance NFData LibError
+instance NFData LibError'
+instance NFData LibErrors
+instance NFData LibParseError
+instance NFData E.IOException where rnf _ = ()

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -251,6 +251,7 @@ errorString = \case
   ImpossibleConstructor{}                  -> "ImpossibleConstructor"
   TooManyFields{}                          -> "TooManyFields"
   TooManyPolarities{}                      -> "TooManyPolarities"
+  RecursiveRecordNeedsInductivity{}        -> "RecursiveRecordNeedsInductivity"
   SplitOnIrrelevant{}                      -> "SplitOnIrrelevant"
   SplitOnUnusableCohesion{}                -> "SplitOnUnusableCohesion"
   -- UNUSED: -- SplitOnErased{}                          -> "SplitOnErased"
@@ -1326,6 +1327,12 @@ instance PrettyTCM TypeError where
       pwords "Too many polarities given in the POLARITY pragma for" ++
       [prettyTCM x] ++
       pwords "(at most" ++ [text (show n)] ++ pwords "allowed)."
+
+    RecursiveRecordNeedsInductivity q -> fsep $ concat
+      [ pwords "Recursive record"
+      , [ prettyTCM q ]
+      , pwords "needs to be declared as either inductive or coinductive"
+      ]
 
     InstanceNoCandidate t errs -> vcat $
       [ fsep $ pwords "No instance of type" ++ [prettyTCM t] ++ pwords "was found in scope."

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -69,6 +69,8 @@ import Agda.TypeChecking.SizedTypes.Pretty ()
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Reduce (instantiate)
 
+import Agda.Interaction.Library.Base (formatLibErrors)
+
 import Agda.Utils.FileName
 import Agda.Utils.Float  ( toStringWithoutDotZero )
 import Agda.Utils.Function
@@ -184,6 +186,7 @@ errorString = \case
   InternalError{}                          -> "InternalError"
   InvalidPattern{}                         -> "InvalidPattern"
   InvalidFileName{}                        -> "InvalidFileName"
+  LibraryError{}                           -> "LibraryError"
   LocalVsImportedModuleClash{}             -> "LocalVsImportedModuleClash"
   MetaCannotDependOn{}                     -> "MetaCannotDependOn"
   MetaOccursInItself{}                     -> "MetaOccursInItself"
@@ -871,6 +874,8 @@ instance PrettyTCM TypeError where
     NoRHSRequiresAbsurdPattern ps -> fwords $
       "The right-hand side can only be omitted if there " ++
       "is an absurd pattern, () or {}, in the left-hand side."
+
+    LibraryError err -> return $ formatLibErrors err
 
     LocalVsImportedModuleClash m -> fsep $
       pwords "The module" ++ [prettyTCM m] ++

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -107,6 +107,7 @@ import Agda.Interaction.Response.Base (Response_boot(..))
 import Agda.Interaction.Highlighting.Precise
   (HighlightingInfo, NameKind)
 import Agda.Interaction.Library
+import Agda.Interaction.Library.Base (LibErrors)
 
 import Agda.Utils.Benchmark (MonadBench(..))
 import Agda.Utils.BiMap (BiMap, HasTag(..))
@@ -4791,6 +4792,8 @@ data TypeError
             -- ^ This term, a function type constructor, lives in
             --   @SizeUniv@, which is not allowed.
     -- Import errors
+        | LibraryError LibErrors
+            -- ^ Collected errors when processing the @.agda-lib@ file.
         | LocalVsImportedModuleClash ModuleName
         | SolvedButOpenHoles
           -- ^ Some interaction points (holes) have not been filled by user.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4775,6 +4775,9 @@ data TypeError
         | ImpossibleConstructor QName NegativeUnification
     -- Positivity errors
         | TooManyPolarities QName Int
+        | RecursiveRecordNeedsInductivity QName
+            -- ^ A record type inferred as recursive needs a manual declaration
+            --   whether it should be inductively or coinductively.
     -- Sized type errors
         | CannotSolveSizeConstraints (List1 (ProblemConstraint, HypSizeConstraint)) Doc
             -- ^ The list of constraints is given redundantly as pairs of

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -139,8 +139,13 @@ bindBuiltinRewriteRelation x =
     Map.insertWith unionBuiltin (BuiltinName builtinRewrite) (BuiltinRewriteRelations $ singleton x)
 
 -- | Get the currently registered rewrite relation symbols.
-getBuiltinRewriteRelations :: HasBuiltins m => m (Maybe (Set QName))
-getBuiltinRewriteRelations = fmap rels <$> getBuiltinThing (BuiltinName builtinRewrite)
+getBuiltinRewriteRelations :: (HasBuiltins m, MonadTCError m) => m (Set QName)
+getBuiltinRewriteRelations =
+  fromMaybeM (typeError $ NoBindingForBuiltin builtinRewrite) getBuiltinRewriteRelations'
+
+-- | Get the currently registered rewrite relation symbols, if any.
+getBuiltinRewriteRelations' :: HasBuiltins m => m (Maybe (Set QName))
+getBuiltinRewriteRelations' = fmap rels <$> getBuiltinThing (BuiltinName builtinRewrite)
   where
   rels = \case
     BuiltinRewriteRelations xs -> xs

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -121,7 +121,7 @@ libToTCM m = do
 
   unless (null warns) $ warnings $ map LibraryWarning warns
   case z of
-    Left s  -> typeError $ GenericDocError s
+    Left s  -> typeError $ LibraryError s
     Right x -> return x
 
 -- | Returns the library files for a given file.

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -201,9 +201,7 @@ checkStrictlyPositive mi qset = do
         -- 'Inductive' or 'Coinductive'.  Otherwise, error.
         unlessM (isJust . recInduction . theDef <$> getConstInfo q) $
           setCurrentRange (nameBindingSite $ qnameName q) $
-            typeError . GenericDocError =<<
-              "Recursive record" <+> prettyTCM q <+>
-              "needs to be declared as either inductive or coinductive"
+            typeError $ RecursiveRecordNeedsInductivity q
 
     occ (Edge o _) = o
 

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -184,9 +184,7 @@ rewriteRelationDom rel = do
 checkRewriteRule :: QName -> TCM RewriteRule
 checkRewriteRule q = do
   requireOptionRewriting
-  let failNoBuiltin = typeError $ GenericError $
-        "Cannot add rewrite rule without prior BUILTIN REWRITE"
-  rels <- fromMaybeM failNoBuiltin getBuiltinRewriteRelations
+  rels <- getBuiltinRewriteRelations
   reportSDoc "rewriting.relations" 40 $ vcat
     [ "Rewrite relations:"
     , prettyList $ map prettyTCM $ toList rels

--- a/test/Fail/Issue2467.err
+++ b/test/Fail/Issue2467.err
@@ -1,3 +1,4 @@
 Issue2467.agda:8,1-18
-Cannot add rewrite rule without prior BUILTIN REWRITE
+No binding for builtin thing REWRITE, use {-# BUILTIN REWRITE name
+#-} to bind it to 'name'
 when checking the pragma REWRITE A


### PR DESCRIPTION
- **[ refactor ] New error RecursiveRecordNeedsInductivity instead of GenericError**
- **Use NoBindingForBuiltinError instead of GenericError for BUILTIN REWRITE**
- **LibraryError instead of GenericError**
