### PR TITLE
Fix #7301 (loop in parser): move verifyRecordDirectives to scope checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Pragmas and options
 
 * New warning `UselessMacro` when a `macro` block does not contain any function definitions.
 
+* New warning `DuplicateRecordDirectives` if e.g. a `record` is declared both `inductive` and `coinductive`,
+  or declared `inductive` twice.
+
 * New warning `ConflictingPragmaOptions` if giving both `--this` and `--that`
   when `--this` implies `--no-that` (and analogous for `--no-this` implies
   `--that`, etc).

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1272,6 +1272,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      There exists both a local interface file and an interface file in ``_build``.
 
+.. option:: DuplicateRecordDirective
+
+     Conflicting directives in a record declaration.
+
 .. option:: DuplicateRewriteRule
 
      Duplicate declaration of a name as :ref:`REWRITE<rewriting>` rule.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1400,10 +1400,6 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      :ref:`NO_UNIVERSE_CHECK <no_universe_check-pragma>` pragmas before declarations other than ``data`` or ``record`` declarations.
 
-.. option:: InvalidRecordDirective
-
-     Record directives outside of record definition or below field declarations.
-
 .. option:: InvalidTerminationCheckPragma
 
      :ref:`Termination checking pragmas <terminating-pragma>` before non-function or ``mutual`` blocks.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -524,7 +524,6 @@ warningHighlighting' b w = case tcWarning w of
     InvalidCoverageCheckPragma{}     -> deadcodeHighlighting w
     InvalidConstructor{}             -> deadcodeHighlighting w
     InvalidConstructorBlock{}        -> deadcodeHighlighting w
-    InvalidRecordDirective{}         -> deadcodeHighlighting w
     OpenPublicAbstract{}             -> deadcodeHighlighting w
     OpenPublicPrivate{}              -> deadcodeHighlighting w
     SafeFlagEta                   {} -> errorWarningHighlighting w

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -422,6 +422,7 @@ warningHighlighting' b w = case tcWarning w of
   UnsolvedConstraints cs     -> if b then constraintsHighlighting [] cs else mempty
   UnsolvedMetaVariables rs   -> if b then metasHighlighting rs          else mempty
   AbsurdPatternRequiresNoRHS{} -> deadcodeHighlighting w
+  DuplicateRecordDirective{}   -> deadcodeHighlighting w
   ModuleDoesntExport _ _ _ xs  -> foldMap deadcodeHighlighting xs
   DuplicateUsing xs            -> foldMap deadcodeHighlighting xs
   FixityInRenamingModule rs    -> foldMap deadcodeHighlighting rs

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -235,7 +235,6 @@ data WarningName
   | InvalidCoverageCheckPragma_
   | InvalidNoPositivityCheckPragma_
   | InvalidNoUniverseCheckPragma_
-  | InvalidRecordDirective_
   | InvalidTerminationCheckPragma_
   | MissingDeclarations_
   | MissingDefinitions_
@@ -429,7 +428,6 @@ warningNameDescription = \case
   InvalidCoverageCheckPragma_      -> "Coverage checking pragmas before non-function or `mutual' blocks."
   InvalidNoPositivityCheckPragma_  -> "Positivity checking pragmas before non-`data', `record' or `mutual' blocks."
   InvalidNoUniverseCheckPragma_    -> "Universe checking pragmas before non-`data' or `record' declaration."
-  InvalidRecordDirective_          -> "Record directives outside of record definitions or below field declarations."
   InvalidTerminationCheckPragma_   -> "Termination checking pragmas before non-function or `mutual' blocks."
   MissingDeclarations_             -> "Definitions not associated to a declaration."
   MissingDefinitions_              -> "Declarations not associated to a definition."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -235,6 +235,7 @@ data WarningName
   | InvalidCoverageCheckPragma_
   | InvalidNoPositivityCheckPragma_
   | InvalidNoUniverseCheckPragma_
+  | DuplicateRecordDirective_
   | InvalidTerminationCheckPragma_
   | MissingDeclarations_
   | MissingDefinitions_
@@ -428,6 +429,7 @@ warningNameDescription = \case
   InvalidCoverageCheckPragma_      -> "Coverage checking pragmas before non-function or `mutual' blocks."
   InvalidNoPositivityCheckPragma_  -> "Positivity checking pragmas before non-`data', `record' or `mutual' blocks."
   InvalidNoUniverseCheckPragma_    -> "Universe checking pragmas before non-`data' or `record' declaration."
+  DuplicateRecordDirective_        -> "Conflicting directives in a record declaration."
   InvalidTerminationCheckPragma_   -> "Termination checking pragmas before non-function or `mutual' blocks."
   MissingDeclarations_             -> "Definitions not associated to a declaration."
   MissingDefinitions_              -> "Declarations not associated to a definition."

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -119,10 +119,14 @@ instance NFData Language
 
 data RecordDirectives' a = RecordDirectives
   { recInductive   :: Maybe (Ranged Induction)
-  , recHasEta      :: Maybe HasEta0
+  , recHasEta      :: Maybe (Ranged HasEta0)
   , recPattern     :: Maybe Range
   , recConstructor :: Maybe a
-  } deriving (Functor, Show, Eq)
+  } deriving (Functor, Show, Eq, Foldable, Traversable)
+
+instance Null (RecordDirectives' a) where
+  empty = emptyRecordDirectives
+  null (RecordDirectives a b c d) = and [null a, null b, null c, null d]
 
 emptyRecordDirectives :: RecordDirectives' a
 emptyRecordDirectives = RecordDirectives empty empty empty empty

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -63,6 +63,7 @@ module Agda.Syntax.Concrete
   , ThingWithFixity(..)
   , HoleContent, HoleContent'(..)
   , spanAllowedBeforeModule
+  , ungatherRecordDirectives
   )
   where
 
@@ -465,6 +466,15 @@ data RecordDirective
 
 type RecordDirectives = RecordDirectives' (Name, IsInstance)
 
+ungatherRecordDirectives :: RecordDirectives -> [RecordDirective]
+ungatherRecordDirectives (RecordDirectives ind eta pat con) = catMaybes
+  [ Induction <$> ind
+  , Eta <$> eta
+  , PatternOrCopattern <$> pat
+  , uncurry Constructor <$> con
+  ]
+
+
 {-| The representation type of a declaration. The comments indicate
     which type in the intended family the constructor targets.
 -}
@@ -481,8 +491,8 @@ data Declaration
                 [TypeSignatureOrInstanceBlock]
   | DataDef     Range Name [LamBinding] [TypeSignatureOrInstanceBlock]
   | RecordSig   Range Erased Name [LamBinding] Expr -- ^ lone record signature in mutual block
-  | RecordDef   Range Name RecordDirectives [LamBinding] [Declaration]
-  | Record      Range Erased Name RecordDirectives [LamBinding] Expr
+  | RecordDef   Range Name [RecordDirective] [LamBinding] [Declaration]
+  | Record      Range Erased Name [RecordDirective] [LamBinding] Expr
                 [Declaration]
   | Infix Fixity (List1 Name)
   | Syntax      Name Notation -- ^ notation declaration for a name

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -435,8 +435,6 @@ niceDeclarations fixs ds = do
                       (flip NiceRecSig defaultErased) return r x
                       ((tel,) <$> mt) (Just (tel, cs))
 
-        RecordDirective r -> justWarning $ InvalidRecordDirective (getRange r)
-
         Mutual r ds' -> do
           -- The lone signatures encountered so far are not in scope
           -- for the mutual definition

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -100,8 +100,6 @@ data DeclarationWarning'
   | InvalidNoUniverseCheckPragma Range
       -- ^ A {-\# NO_UNIVERSE_CHECK \#-} pragma
       --   that does not apply to a data or record type.
-  | InvalidRecordDirective Range
-      -- ^ A record directive outside of a record / below existing fields.
   | InvalidTerminationCheckPragma Range
       -- ^ A {-\# TERMINATING \#-} and {-\# NON_TERMINATING \#-} pragma
       --   that does not apply to any function.
@@ -166,7 +164,6 @@ declarationWarningName' = \case
   InvalidConstructorBlock{}         -> InvalidConstructorBlock_
   InvalidNoPositivityCheckPragma{}  -> InvalidNoPositivityCheckPragma_
   InvalidNoUniverseCheckPragma{}    -> InvalidNoUniverseCheckPragma_
-  InvalidRecordDirective{}          -> InvalidRecordDirective_
   InvalidTerminationCheckPragma{}   -> InvalidTerminationCheckPragma_
   InvalidCoverageCheckPragma{}      -> InvalidCoverageCheckPragma_
   MissingDeclarations{}             -> MissingDeclarations_
@@ -217,7 +214,6 @@ unsafeDeclarationWarning' = \case
   InvalidConstructorBlock{}         -> False
   InvalidNoPositivityCheckPragma{}  -> False
   InvalidNoUniverseCheckPragma{}    -> False
-  InvalidRecordDirective{}          -> False
   InvalidTerminationCheckPragma{}   -> False
   InvalidCoverageCheckPragma{}      -> False
   MissingDeclarations{}             -> True  -- not safe
@@ -331,7 +327,6 @@ instance HasRange DeclarationWarning' where
     InvalidCoverageCheckPragma r       -> r
     InvalidNoPositivityCheckPragma r   -> r
     InvalidNoUniverseCheckPragma r     -> r
-    InvalidRecordDirective r           -> r
     InvalidTerminationCheckPragma r    -> r
     MissingDeclarations xs             -> getRange xs
     MissingDefinitions xs              -> getRange xs
@@ -478,9 +473,6 @@ instance Pretty DeclarationWarning' where
     EmptyField _ -> fsep $ pwords "Empty field block."
 
     HiddenGeneralize _ -> fsep $ pwords "Declaring a variable as hidden has no effect in a variable block. Generalization never introduces visible arguments."
-
-    InvalidRecordDirective{} -> fsep $
-      pwords "Record directives can only be used inside record definitions and before field declarations."
 
     InvalidTerminationCheckPragma _ -> fsep $
       pwords "Termination checking pragmas can only precede a function definition or a mutual block (that contains a function definition)."

--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -77,7 +77,7 @@ data NiceDeclaration
       --   An alias should know that it is an instance.
   | NiceDataDef Range Origin IsAbstract PositivityCheck UniverseCheck Name [LamBinding] [NiceConstructor]
   | NiceLoneConstructor KwRange [NiceConstructor]
-  | NiceRecDef Range Origin IsAbstract PositivityCheck UniverseCheck Name RecordDirectives [LamBinding] [Declaration]
+  | NiceRecDef Range Origin IsAbstract PositivityCheck UniverseCheck Name [RecordDirective] [LamBinding] [Declaration]
       -- ^ @(Maybe Range)@ gives range of the 'pattern' declaration.
   | NicePatternSyn Range Access Name [WithHiding Name] Pattern
   | NiceGeneralize Range Access ArgInfo TacticAttribute Name Expr

--- a/src/full/Agda/Syntax/Concrete/Fixity.hs
+++ b/src/full/Agda/Syntax/Concrete/Fixity.hs
@@ -14,6 +14,7 @@ import Prelude hiding (null)
 import Control.Monad
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as Set
 
@@ -222,8 +223,8 @@ declaredNames = \case
   DataDef _ _ _ cs      -> foldMap declaredNames cs
   Data _ _ x _ _ cs     -> declaresName x <> foldMap declaredNames cs
   RecordSig _ _ x _ _   -> declaresName x
-  RecordDef _ x d _ _   -> declaresNames $     foldMap (:[]) (fst <$> recConstructor d)
-  Record _ _ x d _ _ _  -> declaresNames $ x : foldMap (:[]) (fst <$> recConstructor d)
+  RecordDef _ x ds _ _  -> declaresNames $     maybeToList (recDirConstructor ds)
+  Record _ _ x ds _ _ _ -> declaresNames $ x : maybeToList (recDirConstructor ds)
   Infix _ _             -> mempty
   Syntax _ _            -> mempty
   PatternSyn _ x _ _    -> declaresName x
@@ -251,3 +252,8 @@ declaredNames = \case
   Pragma (BuiltinPragma _ b (QName x))
     | any isBuiltinNoDef . builtinById $ rangedThing b -> declaresName x
   Pragma{}             -> mempty
+
+recDirConstructor :: [RecordDirective] -> Maybe Name
+recDirConstructor = listToMaybe . mapMaybe \case
+  Constructor x _ -> Just x
+  _ -> Nothing

--- a/src/full/Agda/Syntax/Concrete/Fixity.hs
+++ b/src/full/Agda/Syntax/Concrete/Fixity.hs
@@ -171,7 +171,6 @@ fixitiesAndPolarities' = foldMap $ \case
   RecordSig       {}  -> mempty
   RecordDef       {}  -> mempty
   Record          {}  -> mempty
-  RecordDirective {}  -> mempty
   LoneConstructor {}  -> mempty
   PatternSyn      {}  -> mempty
   Postulate       {}  -> mempty
@@ -225,7 +224,6 @@ declaredNames = \case
   RecordSig _ _ x _ _   -> declaresName x
   RecordDef _ x d _ _   -> declaresNames $     foldMap (:[]) (fst <$> recConstructor d)
   Record _ _ x d _ _ _  -> declaresNames $ x : foldMap (:[]) (fst <$> recConstructor d)
-  RecordDirective _     -> mempty
   Infix _ _             -> mempty
   Syntax _ _            -> mempty
   PatternSyn _ x _ _    -> declaresName x

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -240,7 +240,6 @@ instance ExprLike Declaration where
      Record r er n dir tel e ds
                                -> Record r er n dir (mapE tel) (mapE e)
                                                                        $ mapE ds
-     e@RecordDirective{}       -> e
      e@Infix{}                 -> e
      e@Syntax{}                -> e
      e@PatternSyn{}            -> e
@@ -322,7 +321,6 @@ instance FoldDecl Declaration where
     Data _ _ _ _ _ _        -> mempty
     DataDef _ _ _ _         -> mempty
     RecordSig _ _ _ _ _     -> mempty
-    RecordDirective _       -> mempty
     Infix _ _               -> mempty
     Syntax _ _              -> mempty
     PatternSyn _ _ _ _      -> mempty
@@ -378,7 +376,6 @@ instance TraverseDecl Declaration where
       Data _ _ _ _ _ _           -> return d
       DataDef _ _ _ _            -> return d
       RecordSig _ _ _ _ _        -> return d
-      RecordDirective _          -> return d
       Infix _ _                  -> return d
       Syntax _ _                 -> return d
       PatternSyn _ _ _ _         -> return d

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -563,6 +563,9 @@ pHasEta0 = \case
   YesEta   -> "eta-equality"
   NoEta () -> "no-eta-equality"
 
+instance Pretty RecordDirective where
+  pretty = pRecordDirective
+
 pRecordDirective :: RecordDirective -> Doc
 pRecordDirective = \case
   Induction ind -> pretty (rangedThing ind)
@@ -576,12 +579,12 @@ pRecordDirective = \case
 pRecord
   :: Erased
   -> Name
-  -> RecordDirectives
+  -> [RecordDirective]
   -> [LamBinding]
   -> Maybe Expr
   -> [Declaration]
   -> Doc
-pRecord erased x (RecordDirectives ind eta pat con) tel me ds = vcat
+pRecord erased x directives tel me ds = vcat
     [ sep
       [ hsep  [ "record"
               , prettyErased erased (pretty x)
@@ -590,10 +593,7 @@ pRecord erased x (RecordDirectives ind eta pat con) tel me ds = vcat
       , nest 2 $ pType me
       ]
     , nest 2 $ vcat $ concat
-      [ pInd
-      , pEta
-      , pPat
-      , pCon
+      [ map pretty directives
       , map pretty ds
       ]
     ]
@@ -604,16 +604,6 @@ pRecord erased x (RecordDirectives ind eta pat con) tel me ds = vcat
                 ]
         pType Nothing  =
                   "where"
-        pInd = maybeToList $ pretty . rangedThing <$> ind
-        pEta = maybeToList $ eta <&> pHasEta0
-        pPat = maybeToList $ "pattern" <$ pat
-        -- pEta = caseMaybe eta [] $ \case
-        --   YesEta -> [ "eta-equality" ]
-        --   NoEta  -> "no-eta-equality" : pPat
-        -- pPat = \case
-        --   PatternMatching   -> [ "pattern" ]
-        --   CopatternMatching -> []
-        pCon = maybeToList $ (("constructor" <+>) . pretty) . fst <$> con
 
 instance Pretty OpenShortHand where
     pretty DoOpen = "open"

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -501,7 +501,6 @@ instance Pretty Declaration where
       pRecord erased x dir tel (Just e) cs
     RecordDef _ x dir tel cs ->
       pRecord defaultErased x dir tel Nothing cs
-    RecordDirective r -> pRecordDirective r
     Infix f xs  ->
       pretty f <+> fsep (punctuate comma $ fmap pretty xs)
     Syntax n xs -> "syntax" <+> pretty n <+> "..."

--- a/src/full/Agda/Syntax/Parser/Helpers.hs
+++ b/src/full/Agda/Syntax/Parser/Helpers.hs
@@ -440,7 +440,7 @@ verifyRecordDirectives ds =
   where
   errorFromList []  = []
   errorFromList [x] = []
-  errorFromList xs  = map getRange xs
+  errorFromList xs  = map (removeSrcFile . getRange) xs
   rs  = List.sort $ concat [ errorFromList is, errorFromList es', errorFromList cs, errorFromList ps ]
   es  = map rangedThing es'
   is  = [ i      | Induction i          <- ds ]
@@ -448,7 +448,39 @@ verifyRecordDirectives ds =
   cs  = [ (c, i) | Constructor c i      <- ds ]
   ps  = [ r      | PatternOrCopattern r <- ds ]
 
+  -- Andreas, 2024-06-01, issue #7301.
+  -- We need to remove SrcFile entries from ranges because they are black holes during parsing,
+  -- thanks to an @mdo@ introduced in the parser in f4e76394eb2ea10abf63aae57f2fe895e3f5806d.
+  -- The problems shows as soon as there are two @RecordDirective@s of the same kind,
+  -- necessitating looking at their content for sorting.
+  removeSrcFile :: Range -> Range
+  removeSrcFile = fmap $ const Strict.Nothing
 
+  -- tr = trace (unwords [ "verifyRecordDirectives", show $ length ds, showRecordDirective $ listToMaybe ds ])
+  -- -- The problem with ranges also shows when trying to debug print ds/
+  -- -- This piecemeal reimplemenation of @show@ was leading me towards the problem:
+  -- showRecordDirective = \case
+  --   Nothing -> "(nothing)"
+  --   Just d -> case d of
+  --     Constructor x i -> unwords
+  --       [ "Constructor"
+  --       , showName x
+  --       , show i
+  --       ]
+  --     Eta{}                -> "Eta"
+  --     Induction{}          -> "Induction"
+  --     PatternOrCopattern{} -> "PatternOrCopattern"
+
+  -- showName = \case
+  --   Name r sc xs -> paren $ unwords [ "Name", showRange r, show sc, "$", show xs ]
+  --   NoName{} -> "NoName"
+  -- showRange = \case
+  --   NoRange -> "NoRange"
+  --   Range f is -> paren $ unwords [ "Range", showFile f, "$", show is ]
+  -- showFile = \case
+  --   Strict.Nothing -> "Strict.Nothing"
+  --   Strict.Just f -> paren $ unwords [ "Strict.Just", "_" ]
+  -- paren x = concat ["(", x, ")"]
 
 {--------------------------------------------------------------------------
     Patterns

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1783,12 +1783,11 @@ ArgTypeSignatures0
     | {- empty -}                         { [] }
 
 -- Record declarations, including an optional record constructor name.
-RecordDeclarations :: { (RecordDirectives, [Declaration]) }
+RecordDeclarations :: { ([RecordDirective], [Declaration]) }
 RecordDeclarations
-    : vopen RecordDirectives close                    {% verifyRecordDirectives $2 <&> (,[]) }
-    | vopen RecordDirectives semi Declarations1 close {% verifyRecordDirectives $2 <&> (, List1.toList $4) }
-    | vopen Declarations1 close                       { (emptyRecordDirectives, List1.toList $2) }
-
+    : vopen RecordDirectives close                    { (reverse $2, []) }
+    | vopen RecordDirectives semi Declarations1 close { (reverse $2, List1.toList $4) }
+    | vopen Declarations1 close                       { ([], List1.toList $2) }
 
 RecordDirectives :: { [RecordDirective] }
 RecordDirectives

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4246,6 +4246,8 @@ data Warning
     -- ^ In `OldBuiltin old new`, the BUILTIN old has been replaced by new.
   | BuiltinDeclaresIdentifier BuiltinId
     -- ^ The builtin declares a new identifier, so it should not be in scope.
+  | DuplicateRecordDirective C.RecordDirective
+    -- ^ The given record directive is conflicting with a prior one in the same record declaration.
   | EmptyRewritePragma
     -- ^ If the user wrote just @{-\# REWRITE \#-}@.
   | EmptyWhere
@@ -4399,6 +4401,7 @@ warningName = \case
   CoverageNoExactSplit{}       -> CoverageNoExactSplit_
   InlineNoExactSplit{}         -> InlineNoExactSplit_
   DeprecationWarning{}         -> DeprecationWarning_
+  DuplicateRecordDirective{}   -> DuplicateRecordDirective_
   EmptyRewritePragma           -> EmptyRewritePragma_
   EmptyWhere                   -> EmptyWhere_
   IllformedAsClause{}          -> IllformedAsClause_

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -343,6 +343,9 @@ prettyWarning = \case
     DuplicateRewriteRule q ->
       "Rewrite rule " <+> prettyTCM q <+> " has already been added"
 
+    DuplicateRecordDirective dir ->
+      "Ignoring duplicate record directive: " <+> pretty dir
+
     PragmaCompileErased bn qn -> fsep $ concat
       [ pwords "The backend"
       , [ text bn

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -391,7 +391,7 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
   -- then switch on pattern matching for no-eta-equality.
   -- Default is no pattern matching, but definition by copatterns instead.
   patCopat = maybe CopatternMatching (const PatternMatching) pat
-  eta      = (patCopat <$) <$> eta0
+  eta      = ((patCopat <$) . rangedThing) <$> eta0
 
 
 addCompositionForRecord

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -36,6 +36,7 @@ import Data.Void
 import Agda.Syntax.Common
 import Agda.Syntax.Builtin
 import Agda.Syntax.Concrete.Name as C
+import Agda.Syntax.Concrete (RecordDirective(..))
 import qualified Agda.Syntax.Concrete as C
 import qualified Agda.Syntax.Abstract as A
 import Agda.Syntax.Position as P
@@ -758,3 +759,34 @@ instance EmbPrj SomeBuiltin where
     valu [0, x] = valuN BuiltinName x
     valu [1, x] = valuN PrimitiveName x
     valu _      = malformed
+
+instance EmbPrj IsInstance where
+  icod_ = \case
+    InstanceDef a  -> icodeN' InstanceDef a
+    NotInstanceDef -> icodeN' NotInstanceDef
+
+  value = vcase \case
+    [a] -> valuN InstanceDef a
+    []  -> valuN NotInstanceDef
+    _ -> malformed
+
+instance EmbPrj a => EmbPrj (RecordDirectives' a) where
+  icod_ (RecordDirectives a b c d) = icodeN' RecordDirectives a b c d
+
+  value = vcase \case
+    [a, b, c, d] -> valuN RecordDirectives a b c d
+    _ -> malformed
+
+instance EmbPrj RecordDirective where
+  icod_ = \case
+    Constructor a b      -> icodeN 0 Constructor a b
+    Eta a                -> icodeN 1 Eta a
+    Induction a          -> icodeN 2 Induction a
+    PatternOrCopattern a -> icodeN 3 PatternOrCopattern a
+
+  value = vcase \case
+    [0, a, b] -> valuN Constructor a b
+    [1, a]    -> valuN Eta a
+    [2, a]    -> valuN Induction a
+    [3, a]    -> valuN PatternOrCopattern a
+    _ -> malformed

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -239,7 +239,7 @@ instance EmbPrj DeclarationWarning' where
     OpenPublicAbstract r              -> icodeN 26 OpenPublicAbstract r
     OpenPublicPrivate r               -> icodeN 27 OpenPublicPrivate r
     EmptyConstructor a                -> icodeN 28 EmptyConstructor a
-    InvalidRecordDirective a          -> icodeN 29 InvalidRecordDirective a
+    -- 29 removed
     InvalidConstructor a              -> icodeN 30 InvalidConstructor a
     InvalidConstructorBlock a         -> icodeN 31 InvalidConstructorBlock a
     MissingDeclarations a             -> icodeN 32 MissingDeclarations a
@@ -284,7 +284,7 @@ instance EmbPrj DeclarationWarning' where
     [26,r]   -> valuN OpenPublicAbstract r
     [27,r]   -> valuN OpenPublicPrivate r
     [28,r]   -> valuN EmptyConstructor r
-    [29,r]   -> valuN InvalidRecordDirective r
+    -- 29 removed
     [30,r]   -> valuN InvalidConstructor r
     [31,r]   -> valuN InvalidConstructorBlock r
     [32,r]   -> valuN MissingDeclarations r
@@ -393,7 +393,7 @@ instance EmbPrj WarningName where
     InvalidCoverageCheckPragma_                  -> 20
     InvalidNoPositivityCheckPragma_              -> 21
     InvalidNoUniverseCheckPragma_                -> 22
-    InvalidRecordDirective_                      -> 23
+    -- 23 removed
     InvalidTerminationCheckPragma_               -> 24
     MissingDeclarations_                         -> 25
     MissingDefinitions_                          -> 26
@@ -512,7 +512,7 @@ instance EmbPrj WarningName where
     20  -> return InvalidCoverageCheckPragma_
     21  -> return InvalidNoPositivityCheckPragma_
     22  -> return InvalidNoUniverseCheckPragma_
-    23  -> return InvalidRecordDirective_
+    -- 23 removed
     24  -> return InvalidTerminationCheckPragma_
     25  -> return MissingDeclarations_
     26  -> return MissingDefinitions_

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -45,6 +45,7 @@ instance EmbPrj Warning where
     SafeFlagPostulate a                   -> __IMPOSSIBLE__
     SafeFlagPragma a                      -> __IMPOSSIBLE__
     SafeFlagWithoutKFlagPrimEraseEquality -> __IMPOSSIBLE__
+    DuplicateRecordDirective a            -> icodeN 5 DuplicateRecordDirective a
     DeprecationWarning a b c              -> icodeN 6 DeprecationWarning a b c
     NicifierIssue a                       -> icodeN 7 NicifierIssue a
     InversionDepthReached a               -> icodeN 8 InversionDepthReached a
@@ -108,6 +109,7 @@ instance EmbPrj Warning where
     [2]                  -> valuN EmptyRewritePragma
     [3]                  -> valuN UselessPublic
     [4, a]               -> valuN UselessInline a
+    [5, a]               -> valuN DuplicateRecordDirective a
     [6, a, b, c]         -> valuN DeprecationWarning a b c
     [7, a]               -> valuN NicifierIssue a
     [8, a]               -> valuN InversionDepthReached a
@@ -393,7 +395,7 @@ instance EmbPrj WarningName where
     InvalidCoverageCheckPragma_                  -> 20
     InvalidNoPositivityCheckPragma_              -> 21
     InvalidNoUniverseCheckPragma_                -> 22
-    -- 23 removed
+    DuplicateRecordDirective_                    -> 23
     InvalidTerminationCheckPragma_               -> 24
     MissingDeclarations_                         -> 25
     MissingDefinitions_                          -> 26
@@ -512,7 +514,7 @@ instance EmbPrj WarningName where
     20  -> return InvalidCoverageCheckPragma_
     21  -> return InvalidNoPositivityCheckPragma_
     22  -> return InvalidNoUniverseCheckPragma_
-    -- 23 removed
+    23  -> return DuplicateRecordDirective_
     24  -> return InvalidTerminationCheckPragma_
     25  -> return MissingDeclarations_
     26  -> return MissingDefinitions_

--- a/test/Succeed/Issue2553.warn
+++ b/test/Succeed/Issue2553.warn
@@ -3,9 +3,9 @@ warning: -W[no]UselessPatternDeclarationForRecord
 'pattern' attribute ignored for eta record
 when scope checking the declaration
   record R₁ _ where
-    eta-equality
     pattern
     constructor mkR₁
+    eta-equality
     field p : R₀ A
     X : Set
     X = R₀.proj₁ p
@@ -14,8 +14,8 @@ warning: -W[no]UselessPatternDeclarationForRecord
 'pattern' attribute ignored for eta record
 when scope checking the declaration
   record R₂ r where
-    eta-equality
     pattern
+    eta-equality
     field g : R₀ (R₁.X r)
 
 ———— All done; warnings encountered ————————————————————————
@@ -25,9 +25,9 @@ warning: -W[no]UselessPatternDeclarationForRecord
 'pattern' attribute ignored for eta record
 when scope checking the declaration
   record R₁ _ where
-    eta-equality
     pattern
     constructor mkR₁
+    eta-equality
     field p : R₀ A
     X : Set
     X = R₀.proj₁ p
@@ -37,6 +37,6 @@ warning: -W[no]UselessPatternDeclarationForRecord
 'pattern' attribute ignored for eta record
 when scope checking the declaration
   record R₂ r where
-    eta-equality
     pattern
+    eta-equality
     field g : R₀ (R₁.X r)

--- a/test/Succeed/Issue6660-Pair-pattern.agda
+++ b/test/Succeed/Issue6660-Pair-pattern.agda
@@ -1,12 +1,19 @@
 -- Lawrence, 2023-06-19, issue #6660
+-- Andreas, 2024-06-01, issue #7301
 
 open import Agda.Builtin.Nat
 
 record Pair (A B : Set) : Set where
   inductive; no-eta-equality; pattern   -- disables co-pattern matching
   constructor _,_
+  ------------------------------------------------------------------------
+  -- Some extra directives that should trigger dead-code warnings (issue #7301)
+  coinductive; eta-equality; no-eta-equality; pattern; inductive; constructor foo; constructor _,_
+  ----------------------------------------------------------------------------------
   field fst : A
         snd : B
 open Pair
 
-{-# INLINE _,_ #-} -- expected to fail
+{-# INLINE _,_ #-} -- #6660 expected to fail
+
+-- #7301: expected warnings about extra record directives

--- a/test/Succeed/Issue6660-Pair-pattern.warn
+++ b/test/Succeed/Issue6660-Pair-pattern.warn
@@ -1,11 +1,284 @@
-Issue6660-Pair-pattern.agda:12,1-19
+Issue6660-Pair-pattern.agda:11,3-14
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  coinductive
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+Issue6660-Pair-pattern.agda:11,16-28
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  eta-equality
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+Issue6660-Pair-pattern.agda:11,30-45
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  no-eta-equality
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+Issue6660-Pair-pattern.agda:11,47-54
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  pattern
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+Issue6660-Pair-pattern.agda:11,56-65
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  inductive
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+Issue6660-Pair-pattern.agda:11,79-82
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  constructor foo
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+Issue6660-Pair-pattern.agda:11,96-99
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  constructor _,_
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+Issue6660-Pair-pattern.agda:17,1-19
 warning: -W[no]UselessPragma
 INLINE directive only works on functions or constructors of records that allow copattern matching
 when checking the pragma INLINE _,_
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue6660-Pair-pattern.agda:12,1-19
+Issue6660-Pair-pattern.agda:11,3-14
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  coinductive
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+
+Issue6660-Pair-pattern.agda:11,16-28
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  eta-equality
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+
+Issue6660-Pair-pattern.agda:11,30-45
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  no-eta-equality
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+
+Issue6660-Pair-pattern.agda:11,47-54
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  pattern
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+
+Issue6660-Pair-pattern.agda:11,56-65
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  inductive
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+
+Issue6660-Pair-pattern.agda:11,79-82
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  constructor foo
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+
+Issue6660-Pair-pattern.agda:11,96-99
+warning: -W[no]DuplicateRecordDirective
+Ignoring duplicate record directive:  constructor _,_
+when scope checking the declaration
+  record Pair A B where
+    inductive
+    no-eta-equality
+    pattern
+    constructor _,_
+    coinductive
+    eta-equality
+    no-eta-equality
+    pattern
+    inductive
+    constructor foo
+    constructor _,_
+    field
+      fst : A
+      snd : B
+
+Issue6660-Pair-pattern.agda:17,1-19
 warning: -W[no]UselessPragma
 INLINE directive only works on functions or constructors of records that allow copattern matching
 when checking the pragma INLINE _,_


### PR DESCRIPTION
- commit 281bb125010873c2ea0f6c535b85902cfad3b98f

    Fix #7301: scope check record directives; warning DuplicateRecordDirective
    
    Not doing the check in the parser allows better error reporting.
    Also, we fix #7301 which is presently caused by blackholes in the ranges during parsing, introduced by commit f4e76394eb2ea10abf63aae57f2fe895e3f5806d.

- commit f3783415556c7d2128cf73c2ddd4c98743bc8ecf

    Hotfix for #7301: remove SrcFile blackholes.  Bad for error printing, though.

- commit 86d7eddaccd47f4976fe65a11433191db2c7e3ce

    Remove unused warning InvalidRecordDirective (leftover #5001 #5330) and unused constructor RecordDirective in Concrete.Syntax.Declaration
