### PR TITLE
Turn on -fdebug in default make targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install dependencies for Agda and its test suites
       run: make install-deps
     - name: Build Agda
-      run: make BUILD_DIR="${BUILD_DIR}" install-bin-debug
+      run: make BUILD_DIR="${BUILD_DIR}" install-bin
     - name: Pack artifacts
       run: |
         strip "${BUILD_DIR}"/build/agda-tests/agda-tests \

--- a/Makefile
+++ b/Makefile
@@ -122,15 +122,15 @@ STACK_INSTALL_DEP_OPTS = --only-dependencies $(STACK_INSTALL_OPTS)
 
 # Options for building the Agda exectutable.
 # -j1 so that cabal will print built progress to stdout.
-CABAL_INSTALL_BIN_OPTS = -j1 --disable-library-profiling \
+CABAL_INSTALL_BIN_OPTS = -j1 --disable-library-profiling -fdebug \
                          $(CABAL_INSTALL_OPTS)
-CABAL_INSTALL_BIN_OPTS_DEBUG = -j1 --disable-library-profiling -fdebug \
+CABAL_INSTALL_BIN_OPTS_NODEBUG = -j1 --disable-library-profiling \
                                $(CABAL_INSTALL_OPTS)
 STACK_INSTALL_BIN_OPTS = --no-library-profiling \
+												 --flag Agda:debug \
                          $(STACK_INSTALL_OPTS)
-STACK_INSTALL_BIN_OPTS_DEBUG = --no-library-profiling \
-                               --flag Agda:debug \
-                               $(STACK_INSTALL_OPTS)
+STACK_INSTALL_BIN_OPTS_NODEBUG = --no-library-profiling \
+																 $(STACK_INSTALL_OPTS)
 
 CABAL_CONFIGURE_OPTS = $(SLOW_CABAL_INSTALL_OPTS) \
                        --disable-library-profiling \
@@ -184,11 +184,11 @@ else
 	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS) --program-suffix=$(AGDA_BIN_SUFFIX)
 endif
 
-.PHONY: install-bin-debug ## Install Agda and test suites with debug printing enabled
-install-bin-debug: install-deps ensure-hash-is-correct
+.PHONY: install-bin-no-debug ## Install Agda and test suites with debug printing disabled
+install-bin-no-debug: install-deps ensure-hash-is-correct
 ifdef HAS_STACK
 	@echo "===================== Installing using Stack with test suites ============"
-	time $(STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS_DEBUG)
+	time $(STACK_INSTALL) $(STACK_INSTALL_BIN_OPTS_NODEBUG)
 	mkdir -p $(BUILD_DIR)/build/
 	cp -r $(shell $(STACK) path --dist-dir)/build $(BUILD_DIR)
 	$(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)
@@ -196,7 +196,7 @@ else
 # `cabal new-install --enable-tests` emits the error message (bug?):
 # cabal: --enable-tests was specified, but tests can't be enabled in a remote package
 	@echo "===================== Installing using Cabal with test suites ============"
-	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS_DEBUG) --program-suffix=$(AGDA_BIN_SUFFIX)
+	time $(CABAL_INSTALL) $(CABAL_INSTALL_BIN_OPTS_NODEBUG) --program-suffix=$(AGDA_BIN_SUFFIX)
 endif
 
 .PHONY: v1-install ## Developer install goal without -foptimize-aggressively nor dependencies.
@@ -204,13 +204,13 @@ endif
 v1-install:  ensure-hash-is-correct
 ifdef HAS_STACK
 	@echo "===================== Installing using Stack with test suites ============"
-	time $(STACK_INSTALL_HELPER) $(STACK_INSTALL_BIN_OPTS_DEBUG) $(STACK_OPT_TESTS)
+	time $(STACK_INSTALL_HELPER) $(STACK_INSTALL_BIN_OPTS) $(STACK_OPT_TESTS)
 	mkdir -p $(BUILD_DIR)/build/
 	cp -r $(shell $(STACK) path --dist-dir)/build $(BUILD_DIR)
 	$(MAKE) copy-bins-with-suffix$(AGDA_BIN_SUFFIX)
 else
 	@echo "===================== Installing using Cabal with test suites ============"
-	time $(CABAL_INSTALL_HELPER) $(CABAL_INSTALL_BIN_OPTS_DEBUG) $(CABAL_OPT_TESTS) --builddir=$(BUILD_DIR) --program-suffix=$(AGDA_BIN_SUFFIX)
+	time $(CABAL_INSTALL_HELPER) $(CABAL_INSTALL_BIN_OPTS) $(CABAL_OPT_TESTS) --builddir=$(BUILD_DIR) --program-suffix=$(AGDA_BIN_SUFFIX)
 endif
 
 .PHONY: fast-install-bin ## Install Agda compiled with -O0 with tests
@@ -321,20 +321,6 @@ install-prof-bin : install-deps ensure-hash-is-correct
 	$(CABAL_INSTALL) -j1 \
           --enable-profiling $(PROFILING_DETAIL) \
           --program-suffix=-prof $(CABAL_INSTALL_OPTS)
-
-.PHONY : install-debug ## Install Agda with debug enabled
-# A separate build directory is used. The suffix "-debug" is used for the binaries.
-
-install-debug : install-deps ensure-hash-is-correct
-	$(CABAL_INSTALL) --disable-library-profiling \
-        -fdebug --program-suffix=-debug --builddir=$(DEBUG_BUILD_DIR) \
-        $(CABAL_INSTALL_BIN_OPTS)
-
-.PHONY : debug-install-quick ## Install Agda -O0 with debug enabled
-debug-install-quick : install-deps
-	$(QUICK_CABAL_INSTALL) --disable-library-profiling \
-        -fdebug --program-suffix=-debug-quick --builddir=$(QUICK_DEBUG_BUILD_DIR) \
-        $(CABAL_INSTALL_BIN_OPTS) --ghc-options=-O0
 
 ##############################################################################
 ## Agda mode for Emacs
@@ -471,8 +457,8 @@ test-using-std-lib : std-lib-test \
                      std-lib-succeed \
                      std-lib-interaction
 
-.PHONY : quicktest ## Run successful and failing tests.
-quicktest : common succeed fail
+.PHONY : test-quick ## Run successful and failing tests.
+test-quick : common succeed fail
 
 .PHONY : check-encoding ## Make sure that Parser.y is ASCII. [Issue #5465]
 check-encoding :
@@ -558,8 +544,8 @@ latex-test :
 	@$(call decorate, "Suite of tests for the LaTeX backend", \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/LaTeXAndHTML/LaTeX)
 
-.PHONY : quicklatex-test ##
-quicklatex-test :
+.PHONY : latex-test ##
+latex-test-quick :
 	@$(call decorate, "Suite of tests for the QuickLaTeX backend", \
 	  AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/LaTeXAndHTML/QuickLaTeX)
 
@@ -683,7 +669,8 @@ run-doctest:
 ##############################################################################
 ## Size solver
 
-# NB. It is necessary to install the Agda library (i.e run `make install-bin`)
+# NB. It is necessary to install the Agda library (i.e run `
+#		make install-bin`)
 # before installing the `size-solver` program.
 
 .PHONY : install-size-solver ## Install the size solver.
@@ -797,56 +784,56 @@ help: ## Display this information.
 	  	NF == 2 { printf "  \033[36m%-26s\033[0m %s\n", $$1, $$2};'
 
 debug : ## Print debug information.
-	@echo "AGDA_BIN                     = $(AGDA_BIN)"
-	@echo "AGDA_BIN_SUFFIX              = $(AGDA_BIN_SUFFIX)"
-	@echo "AGDA_MODE                    = $(AGDA_MODE)"
-	@echo "AGDA_OPTS                    = $(AGDA_OPTS)"
-	@echo "AGDA_TESTS_BIN               = $(AGDA_TESTS_BIN)"
-	@echo "AGDA_TESTS_OPTIONS           = $(AGDA_TESTS_OPTIONS)"
-	@echo "BUILD_DIR                    = $(BUILD_DIR)"
-	@echo "CABAL                        = $(CABAL)"
-	@echo "CABAL_BUILD_CMD              = $(CABAL_BUILD_CMD)"
-	@echo "CABAL_CLEAN_CMD              = $(CABAL_CLEAN_CMD)"
-	@echo "CABAL_CONFIGURE_CMD          = $(CABAL_CONFIGURE_CMD)"
-	@echo "CABAL_CONFIGURE_OPTS         = $(CABAL_CONFIGURE_OPTS)"
-	@echo "CABAL_CONFIGURE_OPTS         = $(CABAL_CONFIGURE_OPTS)"
-	@echo "CABAL_FLAG_ICU               = $(CABAL_FLAG_ICU)"
-	@echo "CABAL_FLAG_OPTIM_HEAVY       = $(CABAL_FLAG_OPTIM_HEAVY)"
-	@echo "CABAL_HADDOCK_CMD            = $(CABAL_HADDOCK_CMD)"
-	@echo "CABAL_INSTALL                = $(CABAL_INSTALL)"
-	@echo "CABAL_INSTALL_BIN_OPTS       = $(CABAL_INSTALL_BIN_OPTS)"
-	@echo "CABAL_INSTALL_BIN_OPTS_DEBUG = $(CABAL_INSTALL_BIN_OPTS_DEBUG)"
-	@echo "CABAL_INSTALL_CMD            = $(CABAL_INSTALL_CMD)"
-	@echo "CABAL_INSTALL_DEP_OPTS       = $(CABAL_INSTALL_DEP_OPTS)"
-	@echo "CABAL_INSTALL_HELPER         = $(CABAL_INSTALL_HELPER)"
-	@echo "CABAL_INSTALL_OPTS           = $(CABAL_INSTALL_OPTS)"
-	@echo "CABAL_OPTS                   = $(CABAL_OPTS)"
-	@echo "CABAL_OPT_FAST               = $(CABAL_OPT_FAST)"
-	@echo "CABAL_OPT_NO_DOCS            = $(CABAL_OPT_NO_DOCS)"
-	@echo "FAST_CABAL_INSTALL           = $(FAST_CABAL_INSTALL)"
-	@echo "FAST_STACK_INSTALL           = $(FAST_STACK_INSTALL)"
-	@echo "GHC_OPTS                     = $(GHC_OPTS)"
-	@echo "GHC_RTS_OPTS                 = $(GHC_RTS_OPTS)"
-	@echo "GHC_VER                      = $(GHC_VER)"
-	@echo "GHC_VERSION                  = $(GHC_VERSION)"
-	@echo "PARALLEL_TESTS               = $(PARALLEL_TESTS)"
-	@echo "QUICK_CABAL_INSTALL          = $(QUICK_CABAL_INSTALL)"
-	@echo "QUICK_STACK_INSTALL          = $(QUICK_STACK_INSTALL)"
-	@echo "SLOW_CABAL_INSTALL_OPTS      = $(SLOW_CABAL_INSTALL_OPTS)"
-	@echo "SLOW_STACK_INSTALL_OPTS      = $(SLOW_STACK_INSTALL_OPTS)"
-	@echo "STACK                        = $(STACK)"
-	@echo "STACK_FLAG_ICU               = $(STACK_FLAG_ICU)"
-	@echo "STACK_FLAG_OPTIM_HEAVY       = $(STACK_FLAG_OPTIM_HEAVY)"
-	@echo "STACK_INSTALL                = $(STACK_INSTALL)"
-	@echo "STACK_INSTALL_BIN_OPTS       = $(STACK_INSTALL_BIN_OPTS)"
-	@echo "STACK_INSTALL_BIN_OPTS_DEBUG = $(STACK_INSTALL_BIN_OPTS_DEBUG)"
-	@echo "STACK_INSTALL_DEP_OPTS       = $(STACK_INSTALL_DEP_OPTS)"
-	@echo "STACK_INSTALL_HELPER         = $(STACK_INSTALL_HELPER)"
-	@echo "STACK_INSTALL_OPTS           = $(STACK_INSTALL_OPTS)"
-	@echo "STACK_OPTS                   = $(STACK_OPTS)"
-	@echo "STACK_OPT_FAST               = $(STACK_OPT_FAST)"
-	@echo "STACK_OPT_NO_DOCS            = $(STACK_OPT_NO_DOCS)"
-	@echo "PROFILEOPTS                  = $(PROFILEOPTS)"
+	@echo "AGDA_BIN                       = $(AGDA_BIN)"
+	@echo "AGDA_BIN_SUFFIX                = $(AGDA_BIN_SUFFIX)"
+	@echo "AGDA_MODE                      = $(AGDA_MODE)"
+	@echo "AGDA_OPTS                      = $(AGDA_OPTS)"
+	@echo "AGDA_TESTS_BIN                 = $(AGDA_TESTS_BIN)"
+	@echo "AGDA_TESTS_OPTIONS             = $(AGDA_TESTS_OPTIONS)"
+	@echo "BUILD_DIR                      = $(BUILD_DIR)"
+	@echo "CABAL                          = $(CABAL)"
+	@echo "CABAL_BUILD_CMD                = $(CABAL_BUILD_CMD)"
+	@echo "CABAL_CLEAN_CMD                = $(CABAL_CLEAN_CMD)"
+	@echo "CABAL_CONFIGURE_CMD            = $(CABAL_CONFIGURE_CMD)"
+	@echo "CABAL_CONFIGURE_OPTS           = $(CABAL_CONFIGURE_OPTS)"
+	@echo "CABAL_CONFIGURE_OPTS           = $(CABAL_CONFIGURE_OPTS)"
+	@echo "CABAL_FLAG_ICU                 = $(CABAL_FLAG_ICU)"
+	@echo "CABAL_FLAG_OPTIM_HEAVY         = $(CABAL_FLAG_OPTIM_HEAVY)"
+	@echo "CABAL_HADDOCK_CMD              = $(CABAL_HADDOCK_CMD)"
+	@echo "CABAL_INSTALL                  = $(CABAL_INSTALL)"
+	@echo "CABAL_INSTALL_BIN_OPTS         = $(CABAL_INSTALL_BIN_OPTS)"
+	@echo "CABAL_INSTALL_BIN_OPTS_NODEBUG = $(CABAL_INSTALL_BIN_OPTS_NODEBUG)"
+	@echo "CABAL_INSTALL_CMD              = $(CABAL_INSTALL_CMD)"
+	@echo "CABAL_INSTALL_DEP_OPTS         = $(CABAL_INSTALL_DEP_OPTS)"
+	@echo "CABAL_INSTALL_HELPER           = $(CABAL_INSTALL_HELPER)"
+	@echo "CABAL_INSTALL_OPTS             = $(CABAL_INSTALL_OPTS)"
+	@echo "CABAL_OPTS                     = $(CABAL_OPTS)"
+	@echo "CABAL_OPT_FAST                 = $(CABAL_OPT_FAST)"
+	@echo "CABAL_OPT_NO_DOCS              = $(CABAL_OPT_NO_DOCS)"
+	@echo "FAST_CABAL_INSTALL             = $(FAST_CABAL_INSTALL)"
+	@echo "FAST_STACK_INSTALL             = $(FAST_STACK_INSTALL)"
+	@echo "GHC_OPTS                       = $(GHC_OPTS)"
+	@echo "GHC_RTS_OPTS                   = $(GHC_RTS_OPTS)"
+	@echo "GHC_VER                        = $(GHC_VER)"
+	@echo "GHC_VERSION                    = $(GHC_VERSION)"
+	@echo "PARALLEL_TESTS                 = $(PARALLEL_TESTS)"
+	@echo "QUICK_CABAL_INSTALL            = $(QUICK_CABAL_INSTALL)"
+	@echo "QUICK_STACK_INSTALL            = $(QUICK_STACK_INSTALL)"
+	@echo "SLOW_CABAL_INSTALL_OPTS        = $(SLOW_CABAL_INSTALL_OPTS)"
+	@echo "SLOW_STACK_INSTALL_OPTS        = $(SLOW_STACK_INSTALL_OPTS)"
+	@echo "STACK                          = $(STACK)"
+	@echo "STACK_FLAG_ICU                 = $(STACK_FLAG_ICU)"
+	@echo "STACK_FLAG_OPTIM_HEAVY         = $(STACK_FLAG_OPTIM_HEAVY)"
+	@echo "STACK_INSTALL                  = $(STACK_INSTALL)"
+	@echo "STACK_INSTALL_BIN_OPTS         = $(STACK_INSTALL_BIN_OPTS)"
+	@echo "STACK_INSTALL_BIN_OPTS_NODEBUG = $(STACK_INSTALL_BIN_OPTS_NODEBUG)"
+	@echo "STACK_INSTALL_DEP_OPTS         = $(STACK_INSTALL_DEP_OPTS)"
+	@echo "STACK_INSTALL_HELPER           = $(STACK_INSTALL_HELPER)"
+	@echo "STACK_INSTALL_OPTS             = $(STACK_INSTALL_OPTS)"
+	@echo "STACK_OPTS                     = $(STACK_OPTS)"
+	@echo "STACK_OPT_FAST                 = $(STACK_OPT_FAST)"
+	@echo "STACK_OPT_NO_DOCS              = $(STACK_OPT_NO_DOCS)"
+	@echo "PROFILEOPTS                    = $(PROFILEOPTS)"
 	@echo
 	@echo "Run \`make -pq\` to get a detailed report."
 	@echo

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -154,7 +154,7 @@ jobs:
       ## but printing stuff might not hurt here.
 
     - name: "Build Agda"
-      run: make BUILD_DIR="${BUILD_DIR}" install-bin-debug
+      run: make BUILD_DIR="${BUILD_DIR}" install-bin
 
     # Andreas, 2023-10-19: currently building the size-solver triggers a rebuild of Agda,
     # likely because the cabal flags (`-f`) passed to `cabal build` have changed.


### PR DESCRIPTION
- Turns on `-fdebug` for `install-bin` and `quicker-install-bin`
- Adds `install-bin-no-debug`
- Removes `install-bin-debug`, `install-debug`, and `debug-install-quick`
- Renames some test targets starting with `quick` to improve tab completion

Motivation: the Makefile is used (almost) exclusively by developers and we always want debug printing enabled.

Closes #7114.