### PR TITLE
Add `workOnTypes` reflection primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,21 @@ Changes to the meta-programming facilities.
     solveInstanceConstraints : TC ⊤
   ```
 
+* A new reflection primitive `workOnTypes : TC A → TC A` was added to
+  `Agda.Builtin.Reflection`. This runs the given computation at the type level,
+  which enables the use of erased things. In particular, this is needed when
+  working with (dependent) function types with erased arguments. For example,
+  one can get the type of the tuple constructor `_,_` (which now takes its type
+  parameters as erased arguments, see above) and unify it with the current goal
+  as follows:
+  ```agda
+  macro
+    testM : Term → TC ⊤
+    testM hole = bindTC (getType (quote _,_)) (λ t → workOnTypes (unify hole t))
+
+  typeOfComma = testM
+  ```
+
 Library management
 ------------------
 

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -536,6 +536,9 @@ following primitive operations::
     -- "blocking" constraints.
     noConstraints : ∀ {a} {A : Set a} → TC A → TC A
 
+    -- Run the given computation at the type level, allowing use of erased things.
+    workOnTypes : ∀ {a} {A : Set a} → TC A → TC A
+
     -- Run the given TC action and return the first component. Resets to
     -- the old TC state if the second component is 'false', or keep the
     -- new TC state if it is 'true'.
@@ -587,6 +590,7 @@ following primitive operations::
   {-# BUILTIN AGDATCMASKREDUCEDEFS              askReduceDefs              #-}
   {-# BUILTIN AGDATCMDEBUGPRINT                 debugPrint                 #-}
   {-# BUILTIN AGDATCMNOCONSTRAINTS              noConstraints              #-}
+  {-# BUILTIN AGDATCMWORKONTYPES                workOnTypes                #-}
   {-# BUILTIN AGDATCMRUNSPECULATIVE             runSpeculative             #-}
   {-# BUILTIN AGDATCMGETINSTANCES               getInstances               #-}
   {-# BUILTIN AGDATCMSOLVEINSTANCES             solveInstanceConstraints   #-}

--- a/doc/user-manual/language/runtime-irrelevance.lagda.rst
+++ b/doc/user-manual/language/runtime-irrelevance.lagda.rst
@@ -268,9 +268,9 @@ mode:
   ("``M …``").
 - Applications of ``♯`` (see :ref:`old-coinduction`).
 
-.. note::
-  The text above should be extended with information about how the
-  reflection machinery interacts with run-time irrelevance.
+The reflection API provides a primitive function
+`workOnTypes : TC A → TC A` that manually switches the type-checker
+from run-time mode to compile-time mode.
 
 .. _references:
 

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -334,6 +334,9 @@ postulate
   -- "blocking" constraints.
   noConstraints : ∀ {a} {A : Set a} → TC A → TC A
 
+  -- Run the given computation at the type level, allowing use of erased things.
+  workOnTypes : ∀ {a} {A : Set a} → TC A → TC A
+
   -- Run the given TC action and return the first component. Resets to
   -- the old TC state if the second component is 'false', or keep the
   -- new TC state if it is 'true'.
@@ -389,6 +392,7 @@ postulate
 {-# BUILTIN AGDATCMFORMATERRORPARTS           formatErrorParts           #-}
 {-# BUILTIN AGDATCMDEBUGPRINT                 debugPrint                 #-}
 {-# BUILTIN AGDATCMNOCONSTRAINTS              noConstraints              #-}
+{-# BUILTIN AGDATCMWORKONTYPES                workOnTypes                #-}
 {-# BUILTIN AGDATCMRUNSPECULATIVE             runSpeculative             #-}
 {-# BUILTIN AGDATCMGETINSTANCES               getInstances               #-}
 {-# BUILTIN AGDATCMSOLVEINSTANCES             solveInstanceConstraints   #-}

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -305,6 +305,7 @@ ghcPreCompile flags = do
       , builtinAgdaTCMFormatErrorParts
       , builtinAgdaTCMDebugPrint
       , builtinAgdaTCMNoConstraints
+      , builtinAgdaTCMWorkOnTypes
       , builtinAgdaTCMRunSpeculative
       , builtinAgdaTCMExec
       , builtinAgdaTCMGetInstances

--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -237,6 +237,7 @@ data BuiltinId
   | BuiltinAgdaTCMFormatErrorParts
   | BuiltinAgdaTCMDebugPrint
   | BuiltinAgdaTCMNoConstraints
+  | BuiltinAgdaTCMWorkOnTypes
   | BuiltinAgdaTCMRunSpeculative
   | BuiltinAgdaTCMExec
   | BuiltinAgdaTCMGetInstances
@@ -457,6 +458,7 @@ instance IsBuiltin BuiltinId where
     BuiltinAgdaTCMFormatErrorParts           -> "AGDATCMFORMATERRORPARTS"
     BuiltinAgdaTCMDebugPrint                 -> "AGDATCMDEBUGPRINT"
     BuiltinAgdaTCMNoConstraints              -> "AGDATCMNOCONSTRAINTS"
+    BuiltinAgdaTCMWorkOnTypes                -> "AGDATCMWORKONTYPES"
     BuiltinAgdaTCMRunSpeculative             -> "AGDATCMRUNSPECULATIVE"
     BuiltinAgdaTCMExec                       -> "AGDATCMEXEC"
     BuiltinAgdaTCMGetInstances               -> "AGDATCMGETINSTANCES"
@@ -582,6 +584,7 @@ builtinNat, builtinSuc, builtinZero, builtinNatPlus, builtinNatMinus,
   builtinAgdaTCMAskNormalisation, builtinAgdaTCMAskReconstructed,
   builtinAgdaTCMAskExpandLast, builtinAgdaTCMAskReduceDefs,
   builtinAgdaTCMNoConstraints,
+  builtinAgdaTCMWorkOnTypes,
   builtinAgdaTCMRunSpeculative,
   builtinAgdaTCMExec,
   builtinAgdaTCMGetInstances,
@@ -782,6 +785,7 @@ builtinAgdaTCMAskReduceDefs              = BuiltinAgdaTCMAskReduceDefs
 builtinAgdaTCMFormatErrorParts           = BuiltinAgdaTCMFormatErrorParts
 builtinAgdaTCMDebugPrint                 = BuiltinAgdaTCMDebugPrint
 builtinAgdaTCMNoConstraints              = BuiltinAgdaTCMNoConstraints
+builtinAgdaTCMWorkOnTypes                = BuiltinAgdaTCMWorkOnTypes
 builtinAgdaTCMRunSpeculative             = BuiltinAgdaTCMRunSpeculative
 builtinAgdaTCMExec                       = BuiltinAgdaTCMExec
 builtinAgdaTCMGetInstances               = BuiltinAgdaTCMGetInstances

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -291,6 +291,7 @@ primInteger, primIntegerPos, primIntegerNegSuc,
     primAgdaTCMAskNormalisation, primAgdaTCMAskReconstructed,
     primAgdaTCMAskExpandLast, primAgdaTCMAskReduceDefs,
     primAgdaTCMNoConstraints,
+    primAgdaTCMWorkOnTypes,
     primAgdaTCMRunSpeculative,
     primAgdaTCMExec,
     primAgdaTCMGetInstances,
@@ -508,6 +509,7 @@ primAgdaTCMAskReduceDefs              = getBuiltin builtinAgdaTCMAskReduceDefs
 primAgdaTCMFormatErrorParts           = getBuiltin builtinAgdaTCMFormatErrorParts
 primAgdaTCMDebugPrint                 = getBuiltin builtinAgdaTCMDebugPrint
 primAgdaTCMNoConstraints              = getBuiltin builtinAgdaTCMNoConstraints
+primAgdaTCMWorkOnTypes                = getBuiltin builtinAgdaTCMWorkOnTypes
 primAgdaTCMRunSpeculative             = getBuiltin builtinAgdaTCMRunSpeculative
 primAgdaTCMExec                       = getBuiltin builtinAgdaTCMExec
 primAgdaTCMGetInstances               = getBuiltin builtinAgdaTCMGetInstances

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -405,6 +405,7 @@ coreBuiltins =
   , builtinAgdaTCMDebugPrint                 |-> builtinPostulate (tstring --> tnat --> tlist terrorpart --> tTCM_ primUnit)
 
   , builtinAgdaTCMNoConstraints              |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tTCM 1 (varM 0) --> tTCM 1 (varM 0))
+  , builtinAgdaTCMWorkOnTypes                |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $ tTCM 1 (varM 0) --> tTCM 1 (varM 0))
   , builtinAgdaTCMRunSpeculative             |-> builtinPostulate (hPi "a" tlevel $ hPi "A" (tsetL 0) $
                                                                    tTCM 1 (primSigma <#> varM 1 <#> primLevelZero <@> varM 0 <@> (Lam defaultArgInfo . Abs "_" <$> primBool)) --> tTCM 1 (varM 0))
   , builtinAgdaTCMExec                       |-> builtinPostulate (tstring --> tlist tstring --> tstring -->

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -126,14 +126,14 @@ inOriginalContext m =
     n <- getContextSize
     escapeContext __IMPOSSIBLE__ (n - length cxt) $ unpackUnquoteM m cxt s
 
-isCon :: ConHead -> TCM Term -> UnquoteM Bool
+isCon :: ConHead -> TCM (Maybe Term) -> UnquoteM Bool
 isCon con tm = do t <- liftTCM tm
                   case t of
-                    Con con' _ _ -> return (con == con')
+                    Just (Con con' _ _) -> return (con == con')
                     _ -> return False
 
-isDef :: QName -> TCM Term -> UnquoteM Bool
-isDef f tm = loop <$> liftTCM tm
+isDef :: QName -> TCM (Maybe Term) -> UnquoteM Bool
+isDef f tm = maybe False loop <$> liftTCM tm
   where
     loop (Def g _) = f == g
     loop (Lam _ b) = loop $ unAbs b
@@ -202,7 +202,7 @@ instance Unquote Modality where
     case t of
       Con c _ es | Just [r,q] <- allApplyElims es ->
         choice
-          [(c `isCon` primModalityConstructor,
+          [(c `isCon` getBuiltin' builtinModalityConstructor,
               Modality <$> unquoteN r
                        <*> unquoteN q
                        <*> pure defaultCohesion)]
@@ -216,7 +216,7 @@ instance Unquote ArgInfo where
     case t of
       Con c _ es | Just [h,m] <- allApplyElims es ->
         choice
-          [(c `isCon` primArgArgInfo,
+          [(c `isCon` getBuiltin' builtinArgArgInfo,
               ArgInfo <$> unquoteN h
                       <*> unquoteN m
                       <*> pure Reflected
@@ -232,7 +232,7 @@ instance Unquote a => Unquote (Arg a) where
     case t of
       Con c _ es | Just [info,x] <- allApplyElims es ->
         choice
-          [(c `isCon` primArgArg, Arg <$> unquoteN info <*> unquoteN x)]
+          [(c `isCon` getBuiltin' builtinArgArg, Arg <$> unquoteN info <*> unquoteN x)]
           __IMPOSSIBLE__
       Con c _ _ -> __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "arg" t
@@ -247,8 +247,8 @@ instance Unquote Bool where
     t <- reduceQuotedTerm t
     case t of
       Con c _ [] ->
-        choice [ (c `isCon` primTrue,  pure True)
-               , (c `isCon` primFalse, pure False) ]
+        choice [ (c `isCon` getBuiltin' builtinTrue,  pure True)
+               , (c `isCon` getBuiltin' builtinFalse, pure False) ]
                __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "boolean" t
 
@@ -326,10 +326,10 @@ instance Unquote ErrorPart where
     t <- reduceQuotedTerm t
     case t of
       Con c _ es | Just [x] <- allApplyElims es ->
-        choice [ (c `isCon` primAgdaErrorPartString, StrPart . T.unpack <$> unquoteNString x)
-               , (c `isCon` primAgdaErrorPartTerm,   TermPart <$> ((liftTCM . toAbstractWithoutImplicit) =<< (unquoteN x :: UnquoteM R.Term)))
-               , (c `isCon` primAgdaErrorPartPatt,   PattPart <$> ((liftTCM . toAbstractWithoutImplicit) =<< (unquoteN x :: UnquoteM R.Pattern)))
-               , (c `isCon` primAgdaErrorPartName,   NamePart <$> unquoteN x) ]
+        choice [ (c `isCon` getBuiltin' builtinAgdaErrorPartString, StrPart . T.unpack <$> unquoteNString x)
+               , (c `isCon` getBuiltin' builtinAgdaErrorPartTerm,   TermPart <$> ((liftTCM . toAbstractWithoutImplicit) =<< (unquoteN x :: UnquoteM R.Term)))
+               , (c `isCon` getBuiltin' builtinAgdaErrorPartPatt,   PattPart <$> ((liftTCM . toAbstractWithoutImplicit) =<< (unquoteN x :: UnquoteM R.Pattern)))
+               , (c `isCon` getBuiltin' builtinAgdaErrorPartName,   NamePart <$> unquoteN x) ]
                __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "error part" t
 
@@ -339,11 +339,11 @@ instance Unquote a => Unquote [a] where
     case t of
       Con c _ es | Just [x,xs] <- allApplyElims es ->
         choice
-          [(c `isCon` primCons, (:) <$> unquoteN x <*> unquoteN xs)]
+          [(c `isCon` getBuiltin' builtinCons, (:) <$> unquoteN x <*> unquoteN xs)]
           __IMPOSSIBLE__
       Con c _ [] ->
         choice
-          [(c `isCon` primNil, return [])]
+          [(c `isCon` getBuiltin' builtinNil, return [])]
           __IMPOSSIBLE__
       Con c _ _ -> __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "list" t
@@ -365,9 +365,9 @@ instance Unquote Hiding where
     case t of
       Con c _ [] ->
         choice
-          [(c `isCon` primHidden,  return Hidden)
-          ,(c `isCon` primInstance, return (Instance NoOverlap))
-          ,(c `isCon` primVisible, return NotHidden)]
+          [(c `isCon` getBuiltin' builtinHidden,  return Hidden)
+          ,(c `isCon` getBuiltin' builtinInstance, return (Instance NoOverlap))
+          ,(c `isCon` getBuiltin' builtinVisible, return NotHidden)]
           __IMPOSSIBLE__
       Con c _ vs -> __IMPOSSIBLE__
       _        -> throwError $ NonCanonical "visibility" t
@@ -378,8 +378,8 @@ instance Unquote Relevance where
     case t of
       Con c _ [] ->
         choice
-          [(c `isCon` primRelevant,   return Relevant)
-          ,(c `isCon` primIrrelevant, return Irrelevant)]
+          [(c `isCon` getBuiltin' builtinRelevant,   return Relevant)
+          ,(c `isCon` getBuiltin' builtinIrrelevant, return Irrelevant)]
           __IMPOSSIBLE__
       Con c _ vs -> __IMPOSSIBLE__
       _        -> throwError $ NonCanonical "relevance" t
@@ -390,8 +390,8 @@ instance Unquote Quantity where
     case t of
       Con c _ [] ->
         choice
-          [(c `isCon` primQuantityω, return $ Quantityω QωInferred)
-          ,(c `isCon` primQuantity0, return $ Quantity0 Q0Inferred)]
+          [(c `isCon` getBuiltin' builtinQuantityω, return $ Quantityω QωInferred)
+          ,(c `isCon` getBuiltin' builtinQuantity0, return $ Quantity0 Q0Inferred)]
           __IMPOSSIBLE__
       Con c _ vs -> __IMPOSSIBLE__
       _        -> throwError $ NonCanonical "quantity" t
@@ -409,7 +409,7 @@ instance Unquote a => Unquote (R.Abs a) where
     case t of
       Con c _ es | Just [x,y] <- allApplyElims es ->
         choice
-          [(c `isCon` primAbsAbs, R.Abs <$> (hint . T.unpack <$> unquoteNString x) <*> unquoteN y)]
+          [(c `isCon` getBuiltin' builtinAbsAbs, R.Abs <$> (hint . T.unpack <$> unquoteNString x) <*> unquoteN y)]
           __IMPOSSIBLE__
       Con c _ _ -> __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "abstraction" t
@@ -423,9 +423,9 @@ instance Unquote Blocker where
     case t of
       Con c _ es | Just [x] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaBlockerAny, UnblockOnAny . Set.fromList <$> unquoteN x)
-          , (c `isCon` primAgdaBlockerAll, UnblockOnAll . Set.fromList <$> unquoteN x)
-          , (c `isCon` primAgdaBlockerMeta, UnblockOnMeta <$> unquoteN x)]
+          [ (c `isCon` getBuiltin' builtinAgdaBlockerAny, UnblockOnAny . Set.fromList <$> unquoteN x)
+          , (c `isCon` getBuiltin' builtinAgdaBlockerAll, UnblockOnAll . Set.fromList <$> unquoteN x)
+          , (c `isCon` getBuiltin' builtinAgdaBlockerMeta, UnblockOnMeta <$> unquoteN x)]
           __IMPOSSIBLE__
       Con c _ _ -> __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "blocker" t
@@ -452,15 +452,15 @@ instance Unquote R.Sort where
     case t of
       Con c _ [] ->
         choice
-          [(c `isCon` primAgdaSortUnsupported, return R.UnknownS)]
+          [(c `isCon` getBuiltin' builtinAgdaSortUnsupported, return R.UnknownS)]
           __IMPOSSIBLE__
       Con c _ es | Just [u] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaSortSet, R.SetS <$> unquoteN u)
-          , (c `isCon` primAgdaSortLit, R.LitS <$> unquoteN u)
-          , (c `isCon` primAgdaSortProp, R.PropS <$> unquoteN u)
-          , (c `isCon` primAgdaSortPropLit, R.PropLitS <$> unquoteN u)
-          , (c `isCon` primAgdaSortInf, R.InfS <$> unquoteN u)
+          [ (c `isCon` getBuiltin' builtinAgdaSortSet, R.SetS <$> unquoteN u)
+          , (c `isCon` getBuiltin' builtinAgdaSortLit, R.LitS <$> unquoteN u)
+          , (c `isCon` getBuiltin' builtinAgdaSortProp, R.PropS <$> unquoteN u)
+          , (c `isCon` getBuiltin' builtinAgdaSortPropLit, R.PropLitS <$> unquoteN u)
+          , (c `isCon` getBuiltin' builtinAgdaSortInf, R.InfS <$> unquoteN u)
           ]
           __IMPOSSIBLE__
       Con c _ _ -> __IMPOSSIBLE__
@@ -472,12 +472,12 @@ instance Unquote Literal where
     case t of
       Con c _ es | Just [x] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaLitNat,    LitNat    <$> unquoteN x)
-          , (c `isCon` primAgdaLitFloat,  LitFloat  <$> unquoteN x)
-          , (c `isCon` primAgdaLitChar,   LitChar   <$> unquoteN x)
-          , (c `isCon` primAgdaLitString, LitString <$> unquoteNString x)
-          , (c `isCon` primAgdaLitQName,  LitQName  <$> unquoteN x)
-          , (c `isCon` primAgdaLitMeta,
+          [ (c `isCon` getBuiltin' builtinAgdaLitNat,    LitNat    <$> unquoteN x)
+          , (c `isCon` getBuiltin' builtinAgdaLitFloat,  LitFloat  <$> unquoteN x)
+          , (c `isCon` getBuiltin' builtinAgdaLitChar,   LitChar   <$> unquoteN x)
+          , (c `isCon` getBuiltin' builtinAgdaLitString, LitString <$> unquoteNString x)
+          , (c `isCon` getBuiltin' builtinAgdaLitQName,  LitQName  <$> unquoteN x)
+          , (c `isCon` getBuiltin' builtinAgdaLitMeta,
              LitMeta
                <$> (fromMaybe __IMPOSSIBLE__ <$> currentTopLevelModule)
                <*> unquoteN x)
@@ -492,25 +492,25 @@ instance Unquote R.Term where
     case t of
       Con c _ [] ->
         choice
-          [ (c `isCon` primAgdaTermUnsupported, return R.Unknown) ]
+          [ (c `isCon` getBuiltin' builtinAgdaTermUnsupported, return R.Unknown) ]
           __IMPOSSIBLE__
 
       Con c _ es | Just [x] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaTermSort,      R.Sort      <$> unquoteN x)
-          , (c `isCon` primAgdaTermLit,       R.Lit       <$> unquoteN x)
+          [ (c `isCon` getBuiltin' builtinAgdaTermSort,      R.Sort      <$> unquoteN x)
+          , (c `isCon` getBuiltin' builtinAgdaTermLit,       R.Lit       <$> unquoteN x)
           ]
           __IMPOSSIBLE__
 
       Con c _ es | Just [x, y] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaTermVar,     R.Var     <$> (fromInteger <$> unquoteN x) <*> unquoteN y)
-          , (c `isCon` primAgdaTermCon,     R.Con     <$> (ensureCon =<< unquoteN x) <*> unquoteN y)
-          , (c `isCon` primAgdaTermDef,     R.Def     <$> (ensureDef =<< unquoteN x) <*> unquoteN y)
-          , (c `isCon` primAgdaTermMeta,    R.Meta    <$> unquoteN x <*> unquoteN y)
-          , (c `isCon` primAgdaTermLam,     R.Lam     <$> unquoteN x <*> unquoteN y)
-          , (c `isCon` primAgdaTermPi,      mkPi      <$> unquoteN x <*> unquoteN y)
-          , (c `isCon` primAgdaTermExtLam,  R.ExtLam  <$> (List1.fromListSafe __IMPOSSIBLE__ <$> unquoteN x) <*> unquoteN y)
+          [ (c `isCon` getBuiltin' builtinAgdaTermVar,     R.Var     <$> (fromInteger <$> unquoteN x) <*> unquoteN y)
+          , (c `isCon` getBuiltin' builtinAgdaTermCon,     R.Con     <$> (ensureCon =<< unquoteN x) <*> unquoteN y)
+          , (c `isCon` getBuiltin' builtinAgdaTermDef,     R.Def     <$> (ensureDef =<< unquoteN x) <*> unquoteN y)
+          , (c `isCon` getBuiltin' builtinAgdaTermMeta,    R.Meta    <$> unquoteN x <*> unquoteN y)
+          , (c `isCon` getBuiltin' builtinAgdaTermLam,     R.Lam     <$> unquoteN x <*> unquoteN y)
+          , (c `isCon` getBuiltin' builtinAgdaTermPi,      mkPi      <$> unquoteN x <*> unquoteN y)
+          , (c `isCon` getBuiltin' builtinAgdaTermExtLam,  R.ExtLam  <$> (List1.fromListSafe __IMPOSSIBLE__ <$> unquoteN x) <*> unquoteN y)
           ]
           __IMPOSSIBLE__
         where
@@ -532,15 +532,15 @@ instance Unquote R.Pattern where
     case t of
       Con c _ es | Just [x] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaPatVar,    R.VarP    . fromInteger <$> unquoteN x)
-          , (c `isCon` primAgdaPatAbsurd, R.AbsurdP . fromInteger <$> unquoteN x)
-          , (c `isCon` primAgdaPatDot,    R.DotP  <$> unquoteN x)
-          , (c `isCon` primAgdaPatProj,   R.ProjP <$> unquoteN x)
-          , (c `isCon` primAgdaPatLit,    R.LitP  <$> unquoteN x) ]
+          [ (c `isCon` getBuiltin' builtinAgdaPatVar,    R.VarP    . fromInteger <$> unquoteN x)
+          , (c `isCon` getBuiltin' builtinAgdaPatAbsurd, R.AbsurdP . fromInteger <$> unquoteN x)
+          , (c `isCon` getBuiltin' builtinAgdaPatDot,    R.DotP  <$> unquoteN x)
+          , (c `isCon` getBuiltin' builtinAgdaPatProj,   R.ProjP <$> unquoteN x)
+          , (c `isCon` getBuiltin' builtinAgdaPatLit,    R.LitP  <$> unquoteN x) ]
           __IMPOSSIBLE__
       Con c _ es | Just [x, y] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaPatCon, R.ConP <$> unquoteN x <*> unquoteN y) ]
+          [ (c `isCon` getBuiltin' builtinAgdaPatCon, R.ConP <$> unquoteN x <*> unquoteN y) ]
           __IMPOSSIBLE__
       Con c _ _ -> __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "pattern" t
@@ -551,11 +551,11 @@ instance Unquote R.Clause where
     case t of
       Con c _ es | Just [x, y] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaClauseAbsurd, R.AbsurdClause <$> unquoteN x <*> unquoteN y) ]
+          [ (c `isCon` getBuiltin' builtinAgdaClauseAbsurd, R.AbsurdClause <$> unquoteN x <*> unquoteN y) ]
           __IMPOSSIBLE__
       Con c _ es | Just [x, y, z] <- allApplyElims es ->
         choice
-          [ (c `isCon` primAgdaClauseClause, R.Clause <$> unquoteN x <*> unquoteN y <*> unquoteN z) ]
+          [ (c `isCon` getBuiltin' builtinAgdaClauseClause, R.Clause <$> unquoteN x <*> unquoteN y <*> unquoteN z) ]
           __IMPOSSIBLE__
       Con c _ _ -> __IMPOSSIBLE__
       _ -> throwError $ NonCanonical "clause" t
@@ -579,67 +579,67 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
 
   case v of
     I.Def f [] ->
-      choice [ (f `isDef` primAgdaTCMGetContext,       tcGetContext)
-             , (f `isDef` primAgdaTCMCommit,           tcCommit)
-             , (f `isDef` primAgdaTCMAskNormalisation, tcAskNormalisation)
-             , (f `isDef` primAgdaTCMAskReconstructed, tcAskReconstructed)
-             , (f `isDef` primAgdaTCMAskExpandLast,    tcAskExpandLast)
-             , (f `isDef` primAgdaTCMAskReduceDefs,    tcAskReduceDefs)
-             , (f `isDef` primAgdaTCMSolveInstances,   tcSolveInstances)
+      choice [ (f `isDef` getBuiltin' builtinAgdaTCMGetContext,       tcGetContext)
+             , (f `isDef` getBuiltin' builtinAgdaTCMCommit,           tcCommit)
+             , (f `isDef` getBuiltin' builtinAgdaTCMAskNormalisation, tcAskNormalisation)
+             , (f `isDef` getBuiltin' builtinAgdaTCMAskReconstructed, tcAskReconstructed)
+             , (f `isDef` getBuiltin' builtinAgdaTCMAskExpandLast,    tcAskExpandLast)
+             , (f `isDef` getBuiltin' builtinAgdaTCMAskReduceDefs,    tcAskReduceDefs)
+             , (f `isDef` getBuiltin' builtinAgdaTCMSolveInstances,   tcSolveInstances)
              ]
              failEval
     I.Def f [u] ->
-      choice [ (f `isDef` primAgdaTCMInferType,                  tcFun1 tcInferType                  u)
-             , (f `isDef` primAgdaTCMNormalise,                  tcFun1 tcNormalise                  u)
-             , (f `isDef` primAgdaTCMReduce,                     tcFun1 tcReduce                     u)
-             , (f `isDef` primAgdaTCMGetType,                    tcFun1 tcGetType                    u)
-             , (f `isDef` primAgdaTCMGetDefinition,              tcFun1 tcGetDefinition              u)
-             , (f `isDef` primAgdaTCMFormatErrorParts,           tcFun1 tcFormatErrorParts           u)
-             , (f `isDef` primAgdaTCMIsMacro,                    tcFun1 tcIsMacro                    u)
-             , (f `isDef` primAgdaTCMFreshName,                  tcFun1 tcFreshName                  u)
-             , (f `isDef` primAgdaTCMGetInstances,               uqFun1 tcGetInstances               u)
+      choice [ (f `isDef` getBuiltin' builtinAgdaTCMInferType,                  tcFun1 tcInferType                  u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMNormalise,                  tcFun1 tcNormalise                  u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMReduce,                     tcFun1 tcReduce                     u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMGetType,                    tcFun1 tcGetType                    u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMGetDefinition,              tcFun1 tcGetDefinition              u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMFormatErrorParts,           tcFun1 tcFormatErrorParts           u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMIsMacro,                    tcFun1 tcIsMacro                    u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMFreshName,                  tcFun1 tcFreshName                  u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMGetInstances,               uqFun1 tcGetInstances               u)
              ]
              failEval
     I.Def f [u, v] ->
-      choice [ (f `isDef` primAgdaTCMUnify,      tcFun2 tcUnify      u v)
-             , (f `isDef` primAgdaTCMCheckType,  tcFun2 tcCheckType  u v)
-             , (f `isDef` primAgdaTCMDeclareDef, uqFun2 tcDeclareDef u v)
-             , (f `isDef` primAgdaTCMDeclarePostulate, uqFun2 tcDeclarePostulate u v)
-             , (f `isDef` primAgdaTCMDefineData, uqFun2 tcDefineData u v)
-             , (f `isDef` primAgdaTCMDefineFun,  uqFun2 tcDefineFun  u v)
-             , (f `isDef` primAgdaTCMQuoteOmegaTerm, tcQuoteTerm (sort $ Inf UType 0) (unElim v))
-             , (f `isDef` primAgdaTCMPragmaForeign, tcFun2 tcPragmaForeign u v)
+      choice [ (f `isDef` getBuiltin' builtinAgdaTCMUnify,      tcFun2 tcUnify      u v)
+             , (f `isDef` getBuiltin' builtinAgdaTCMCheckType,  tcFun2 tcCheckType  u v)
+             , (f `isDef` getBuiltin' builtinAgdaTCMDeclareDef, uqFun2 tcDeclareDef u v)
+             , (f `isDef` getBuiltin' builtinAgdaTCMDeclarePostulate, uqFun2 tcDeclarePostulate u v)
+             , (f `isDef` getBuiltin' builtinAgdaTCMDefineData, uqFun2 tcDefineData u v)
+             , (f `isDef` getBuiltin' builtinAgdaTCMDefineFun,  uqFun2 tcDefineFun  u v)
+             , (f `isDef` getBuiltin' builtinAgdaTCMQuoteOmegaTerm, tcQuoteTerm (sort $ Inf UType 0) (unElim v))
+             , (f `isDef` getBuiltin' builtinAgdaTCMPragmaForeign, tcFun2 tcPragmaForeign u v)
              ]
              failEval
     I.Def f [l, a, u] ->
-      choice [ (f `isDef` primAgdaTCMReturn,             return (unElim u))
-             , (f `isDef` primAgdaTCMTypeError,          tcFun1 tcTypeError   u)
-             , (f `isDef` primAgdaTCMQuoteTerm,          tcQuoteTerm (mkT (unElim l) (unElim a)) (unElim u))
-             , (f `isDef` primAgdaTCMUnquoteTerm,        tcFun1 (tcUnquoteTerm (mkT (unElim l) (unElim a))) u)
-             , (f `isDef` primAgdaTCMBlock,              uqFun1 tcBlock u)
-             , (f `isDef` primAgdaTCMDebugPrint,         tcFun3 tcDebugPrint l a u)
-             , (f `isDef` primAgdaTCMNoConstraints,      tcNoConstraints (unElim u))
-             , (f `isDef` primAgdaTCMDeclareData, uqFun3 tcDeclareData l a u)
-             , (f `isDef` primAgdaTCMRunSpeculative,     tcRunSpeculative (unElim u))
-             , (f `isDef` primAgdaTCMExec, tcFun3 tcExec l a u)
-             , (f `isDef` primAgdaTCMPragmaCompile, tcFun3 tcPragmaCompile l a u)
+      choice [ (f `isDef` getBuiltin' builtinAgdaTCMReturn,             return (unElim u))
+             , (f `isDef` getBuiltin' builtinAgdaTCMTypeError,          tcFun1 tcTypeError   u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMQuoteTerm,          tcQuoteTerm (mkT (unElim l) (unElim a)) (unElim u))
+             , (f `isDef` getBuiltin' builtinAgdaTCMUnquoteTerm,        tcFun1 (tcUnquoteTerm (mkT (unElim l) (unElim a))) u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMBlock,              uqFun1 tcBlock u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMDebugPrint,         tcFun3 tcDebugPrint l a u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMNoConstraints,      tcNoConstraints (unElim u))
+             , (f `isDef` getBuiltin' builtinAgdaTCMDeclareData, uqFun3 tcDeclareData l a u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMRunSpeculative,     tcRunSpeculative (unElim u))
+             , (f `isDef` getBuiltin' builtinAgdaTCMExec, tcFun3 tcExec l a u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMPragmaCompile, tcFun3 tcPragmaCompile l a u)
              ]
              failEval
     I.Def f [_, _, u, v] ->
-      choice [ (f `isDef` primAgdaTCMCatchError,        tcCatchError    (unElim u) (unElim v))
-             , (f `isDef` primAgdaTCMWithNormalisation, tcWithNormalisation (unElim u) (unElim v))
-             , (f `isDef` primAgdaTCMWithReconstructed, tcWithReconstructed (unElim u) (unElim v))
-             , (f `isDef` primAgdaTCMWithExpandLast,    tcWithExpandLast (unElim u) (unElim v))
-             , (f `isDef` primAgdaTCMWithReduceDefs,    tcWithReduceDefs (unElim u) (unElim v))
-             , (f `isDef` primAgdaTCMInContext,         tcInContext     (unElim u) (unElim v))
+      choice [ (f `isDef` getBuiltin' builtinAgdaTCMCatchError,        tcCatchError    (unElim u) (unElim v))
+             , (f `isDef` getBuiltin' builtinAgdaTCMWithNormalisation, tcWithNormalisation (unElim u) (unElim v))
+             , (f `isDef` getBuiltin' builtinAgdaTCMWithReconstructed, tcWithReconstructed (unElim u) (unElim v))
+             , (f `isDef` getBuiltin' builtinAgdaTCMWithExpandLast,    tcWithExpandLast (unElim u) (unElim v))
+             , (f `isDef` getBuiltin' builtinAgdaTCMWithReduceDefs,    tcWithReduceDefs (unElim u) (unElim v))
+             , (f `isDef` getBuiltin' builtinAgdaTCMInContext,         tcInContext     (unElim u) (unElim v))
              ]
              failEval
     I.Def f [_, _, u, v, w] ->
-      choice [ (f `isDef` primAgdaTCMExtendContext, tcExtendContext (unElim u) (unElim v) (unElim w))
+      choice [ (f `isDef` getBuiltin' builtinAgdaTCMExtendContext, tcExtendContext (unElim u) (unElim v) (unElim w))
              ]
              failEval
     I.Def f [_, _, _, _, m, k] ->
-      choice [ (f `isDef` primAgdaTCMBind, tcBind (unElim m) (unElim k)) ]
+      choice [ (f `isDef` getBuiltin' builtinAgdaTCMBind, tcBind (unElim m) (unElim k)) ]
              failEval
     _ -> failEval
   where

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -623,6 +623,7 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
              , (f `isDef` getBuiltin' builtinAgdaTCMRunSpeculative,     tcRunSpeculative (unElim u))
              , (f `isDef` getBuiltin' builtinAgdaTCMExec, tcFun3 tcExec l a u)
              , (f `isDef` getBuiltin' builtinAgdaTCMPragmaCompile, tcFun3 tcPragmaCompile l a u)
+             , (f `isDef` getBuiltin' builtinAgdaTCMWorkOnTypes, tcWorkOnTypes (unElim u))
              ]
              failEval
     I.Def f [_, _, u, v] ->
@@ -749,6 +750,9 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
 
     tcNoConstraints :: Term -> UnquoteM Term
     tcNoConstraints m = liftU1 reallyNoConstraints (evalTCM m)
+
+    tcWorkOnTypes :: Term -> UnquoteM Term
+    tcWorkOnTypes m = liftU1 workOnTypes (evalTCM m)
 
     tcInferType :: R.Term -> TCM Term
     tcInferType v = do

--- a/test/Fail/TranspErasedPi-lhs.agda
+++ b/test/Fail/TranspErasedPi-lhs.agda
@@ -1,0 +1,26 @@
+-- This test case verifies that we cannot transport along an erased pi
+-- type where the codomain depends on the argument in a non-erased
+-- way.
+
+{-# OPTIONS --erasure --erased-cubical #-}
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive.Cubical
+  renaming (primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primTransp to transp)
+open import Agda.Builtin.Cubical.Sub
+  renaming (primSubOut to outS)
+open import Agda.Builtin.Cubical.Path
+
+refl : ∀ {ℓ} {A : Type ℓ} {x : A} → x ≡ x
+refl {x = x} i = x
+
+module
+  _ {ℓ ℓ′} {A0 : Type ℓ} {B0 : A0 → Type ℓ′}
+    (φ : I)
+    {A : I → Sub (Type ℓ) φ (λ ._ → A0)}
+    {B : ∀ i → (x : outS (A i)) → Sub (Type ℓ′) φ (λ { (φ = i1) → B0 x })}
+    (f : (@0 x : outS (A i0)) → outS (B i0 x))
+  where
+
+  lhs : (@0 x : outS (A i1)) → outS (B i1 x)
+  lhs = transp (λ i → (@0 x : outS (A i)) → outS (B i x)) φ f

--- a/test/Fail/TranspErasedPi-lhs.err
+++ b/test/Fail/TranspErasedPi-lhs.err
@@ -1,0 +1,3 @@
+TranspErasedPi-lhs.agda:26,55-56
+Variable x is declared erased, so it cannot be used here
+when checking that the expression x has type outS (A i)

--- a/test/Fail/TranspErasedPi-rhs.agda
+++ b/test/Fail/TranspErasedPi-rhs.agda
@@ -1,0 +1,28 @@
+-- This test case contains the reduct of the would-be transport in
+-- TranspErasedPi-lhs.agda (which should not be well-typed).
+
+{-# OPTIONS --erasure --erased-cubical #-}
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive.Cubical
+  renaming (primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primTransp to transp)
+open import Agda.Builtin.Cubical.Sub
+  renaming (primSubOut to outS)
+open import Agda.Builtin.Cubical.Path
+
+refl : ∀ {ℓ} {A : Type ℓ} {x : A} → x ≡ x
+refl {x = x} i = x
+
+module
+  _ {ℓ ℓ′} {A0 : Type ℓ} {B0 : A0 → Type ℓ′}
+    (φ : I)
+    {A : I → Sub (Type ℓ) φ (λ ._ → A0)}
+    {B : ∀ i → (x : outS (A i)) → Sub (Type ℓ′) φ (λ { (φ = i1) → B0 x })}
+    (f : (@0 x : outS (A i0)) → outS (B i0 x))
+  where
+
+  rhs : (@0 x : outS (A i1)) → outS (B i1 x)
+  rhs = λ x → transp (λ i → outS (B i (transp (λ j → outS (A (i ∨ ~ j))) (φ ∨ i) x))) φ
+    --                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    --                                transpFill (λ i → outS (A i)) φ x but inlined
+              (f (transp (λ i → outS (A (~ i))) φ x))

--- a/test/Fail/TranspErasedPi-rhs.err
+++ b/test/Fail/TranspErasedPi-rhs.err
@@ -1,0 +1,3 @@
+TranspErasedPi-rhs.agda:25,82-83
+Variable x is declared erased, so it cannot be used here
+when checking that the expression x has type outS (A (i ∨ ~ i0))

--- a/test/Succeed/Issue6124.agda
+++ b/test/Succeed/Issue6124.agda
@@ -1,0 +1,26 @@
+open import Agda.Primitive
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+--open import Agda.Builtin.Reflection.External
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Sigma
+
+id : (@0 A : Set) → A → A
+id _ x = x
+
+macro
+  @0 Unit : Term → TC ⊤
+  Unit goal =
+    bindTC (inferType (def (quote id) [])) λ t →
+    bindTC (workOnTypes (reduce t)) λ _ →
+    unify goal (def (quote ⊤) [])
+
+_ : Set
+_ = Unit
+
+macro
+  testM : Term → TC ⊤
+  testM hole = bindTC (getType (quote _,_)) (λ t → workOnTypes (unify hole t))
+
+test : Setω
+test = testM

--- a/test/Succeed/Issue6124.agda
+++ b/test/Succeed/Issue6124.agda
@@ -1,7 +1,8 @@
+{-# OPTIONS --erasure #-}
+
 open import Agda.Primitive
 open import Agda.Builtin.List
 open import Agda.Builtin.Reflection
---open import Agda.Builtin.Reflection.External
 open import Agda.Builtin.Unit
 open import Agda.Builtin.Sigma
 

--- a/test/Succeed/TranspErasedPi.agda
+++ b/test/Succeed/TranspErasedPi.agda
@@ -1,0 +1,29 @@
+-- This test verifies that transp has the correct computational
+-- behaviour on erased pi types (test case constructed by Amélia Liao)
+
+{-# OPTIONS --erasure --erased-cubical #-}
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive.Cubical
+  renaming (primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primTransp to transp)
+open import Agda.Builtin.Cubical.Sub
+  renaming (primSubOut to outS)
+open import Agda.Builtin.Cubical.Path
+
+refl : ∀ {ℓ} {A : Type ℓ} {x : A} → x ≡ x
+refl {x = x} i = x
+
+module
+  _ {ℓ ℓ′} {A0 : Type ℓ} {B0 : @0 A0 → Type ℓ′}
+    (φ : I)
+    {A : I → Sub (Type ℓ) φ (λ ._ → A0)}
+    {B : ∀ i → (@0 x : outS (A i)) → Sub (Type ℓ′) φ (λ { (φ = i1) → B0 x })}
+    (f : (@0 x : outS (A i0)) → outS (B i0 x))
+  where
+
+  _ : transp (λ i → (@0 x : outS (A i)) → outS (B i x)) φ f
+    ≡ λ x → transp (λ i → outS (B i (transp (λ j → outS (A (i ∨ ~ j))) (φ ∨ i) x))) φ
+    --                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    --                                transpFill (λ i → outS (A i)) φ x but inlined
+              (f (transp (λ i → outS (A (~ i))) φ x))
+  _ = refl


### PR DESCRIPTION
Somehow, the PR https://github.com/agda/agda/pull/6399 never got merged even though I could've sworn we had the `workOnTypes` primitive already. Since https://github.com/agda/agda/issues/6124 is not actually fixed without this feature, I am resurrecting this PR here.