### PR TITLE
[ #6406 ] Add test cases from discussion on this issue

### DIFF
--- a/test/interaction/Issue6406.agda
+++ b/test/interaction/Issue6406.agda
@@ -6,3 +6,18 @@ record R (A : Set) : Set where
 
 works : (@0 A : Set) → R A → A
 works _ record{ x = x } = x
+
+fails : (@0 A : Set) → R A → A
+fails = λ (@0 A) → R.x
+
+fails' : (@0 A : Set) → R A → A
+fails' = λ (@0 A) r → R.x r
+
+data D (A : Set) : Set where
+  c : A → D A
+
+works2 : (@0 A : Set) → A → D A
+works2 _ x = c x
+
+fails2 : (@0 A : Set) → A → D A
+fails2 A x = c {A = A} x


### PR DESCRIPTION
I am looking again at issue #6406, and it seem that with the version of https://github.com/agda/agda/pull/6405 that got merged, the subject reduction problems discussed in that issue are no longer present. So I propose we add these tests and close the issue. 