### PR TITLE
add \crossmark to emacs input mode

### DIFF
--- a/src/data/emacs-mode/agda-input.el
+++ b/src/data/emacs-mode/agda-input.el
@@ -886,12 +886,13 @@ order for the change to take effect."
   ("@"          . ("＠"))
   ("__"         . ("＿"))
   ("\""         . ("＂"))
+  ("crossmark"  . ("✗"))
 
   ;; Some combining characters.
   ;;
   ;; The following combining characters also have (other)
   ;; translations:
-  ;; ̀ ́ ̂ ̃ ̄ ̆ ̇ ̈ ̋ ̌ ̣ ̧ ̱
+  ;;
 
   ("^--" . ,(agda-input-to-string-list"̅̿"))
   ("_--" . ,(agda-input-to-string-list"̲̳"))


### PR DESCRIPTION
fixes #6433