### PR TITLE
Expose constructor erasure in reflection interface

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "std-lib"]
 	path = std-lib
-	url = https://github.com/cmcmA20/agda-stdlib
-	branch = reflection-and-erasure
+	url = https://github.com/agda/agda-stdlib
+	branch = issue7322-compat
 [submodule "cubical"]
 	path = cubical
 	url = https://github.com/agda/cubical

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "std-lib"]
 	path = std-lib
-	url = https://github.com/agda/agda-stdlib
-	branch = master
+	url = https://github.com/cmcmA20/agda-stdlib
+	branch = reflection-and-erasure
 [submodule "cubical"]
 	path = cubical
 	url = https://github.com/agda/cubical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,9 +194,10 @@ Changes to the meta-programming facilities.
   typeOfComma = testM
   ```
 
-* Quantity argument was added to `AGDADEFINITIONDATACONSTRUCTOR`. For erased
-  constructors this argument has a value of `quantity-0`, otherwise it's
-  `quantity-ω`.
+* Erased constructors are now supported in reflection machinery.
+  Quantity argument was added to `data-cons`. For erased constructors this
+  argument has a value of `quantity-0`, otherwise it's `quantity-ω`.
+  `defineData` now requires setting quantity for each constructor.
 
 Library management
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,10 @@ Changes to the meta-programming facilities.
   typeOfComma = testM
   ```
 
+* Quantity argument was added to `AGDADEFINITIONDATACONSTRUCTOR`. For erased
+  constructors this argument has a value of `quantity-0`, otherwise it's
+  `quantity-ω`.
+
 Library management
 ------------------
 

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -478,9 +478,9 @@ following primitive operations::
     declareData      : Name → Nat → Type → TC ⊤
 
     -- Define a declared datatype. The datatype must have been declared using
-    -- 'declareData`. The second argument is a list of pairs in which each pair
-    -- is the name of a constructor and its type.
-    defineData       : Name → List (Σ Name (λ _ → Type)) → TC ⊤
+    -- 'declareData`. The second argument is a list of triples in which each triple
+    -- is the name of a constructor, its erasure status and its type.
+    defineData       : Name → List (Σ Name (λ _ → Σ Quantity (λ _ → Type))) → TC ⊤
 
     -- Define a declared function. The function may have been declared using
     -- 'declareDef' or with an explicit type signature in the program.

--- a/doc/user-manual/language/reflection.lagda.rst
+++ b/doc/user-manual/language/reflection.lagda.rst
@@ -325,7 +325,8 @@ below <reflection-tc-monad>`.
     data-type   : (pars : Nat) (cs : List Name) → Definition  -- parameters and constructors
     record-type : (c : Name) (fs : List (Arg Name)) →         -- c: name of record constructor
                   Definition                                  -- fs: fields
-    data-cons   : (d : Name) → Definition                     -- d: name of data type
+    data-cons   : (d : Name) (q : Quantity) → Definition      -- d: name of data type
+                                                              -- q: constructor quantity
     axiom       : Definition
     prim-fun    : Definition
 

--- a/notes/reflection/ReflectionWellScoped.agda
+++ b/notes/reflection/ReflectionWellScoped.agda
@@ -902,7 +902,7 @@ declareData : Name → (pars : Nat) → Type n → TC n ⊤
 declareData x pars t .unTC = R.declareData x pars (unscopeTerm t)
 
 defineData : Name → (pars : Nat) → List (Σ Name (λ _ → Type (n + pars))) → TC n ⊤
-defineData x pars args .unTC = R.defineData x (map (λ (n , t) → n , unscopeTerm t) args)
+defineData x pars args .unTC = R.defineData x (map (λ (n , t) → n , quantity-ω , unscopeTerm t) args)
 
 defineFun : Name → List (Clause n) → TC n ⊤
 defineFun n lc .unTC = R.defineFun n (map unscopeClause lc)

--- a/notes/reflection/ReflectionWellScopedList.agda
+++ b/notes/reflection/ReflectionWellScopedList.agda
@@ -893,7 +893,7 @@ declareData : Name → (pars : Nat) → Type n → TC n ⊤
 declareData x pars t .unTC = R.declareData x pars (unscopeTerm t)
 
 defineData : Name → (pars : Context) → List (Σ Name (λ _ → Type (n +<+ pars))) → TC n ⊤
-defineData x pars args .unTC = R.defineData x (map (λ (n , t) → n , unscopeTerm t) args)
+defineData x pars args .unTC = R.defineData x (map (λ (n , t) → n , quantity-ω , unscopeTerm t) args)
 
 defineFun : Name → List (Clause n) → TC n ⊤
 defineFun n lc .unTC = R.defineFun n (map unscopeClause lc)

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -247,7 +247,7 @@ data Definition : Set where
   function    : (cs : List Clause) → Definition
   data-type   : (pars : Nat) (cs : List Name) → Definition
   record-type : (c : Name) (fs : List (Arg Name)) → Definition
-  data-cons   : (d : Name) → Definition
+  data-cons   : (d : Name) (q : Quantity) → Definition
   axiom       : Definition
   prim-fun    : Definition
 

--- a/src/data/lib/prim/Agda/Builtin/Reflection.agda
+++ b/src/data/lib/prim/Agda/Builtin/Reflection.agda
@@ -296,7 +296,7 @@ postulate
   declareDef       : Arg Name → Type → TC ⊤
   declarePostulate : Arg Name → Type → TC ⊤
   declareData      : Name → Nat → Type → TC ⊤
-  defineData       : Name → List (Σ Name (λ _ → Type)) → TC ⊤
+  defineData       : Name → List (Σ Name (λ _ → Σ Quantity (λ _ → Type))) → TC ⊤
   defineFun        : Name → List Clause → TC ⊤
   getType          : Name → TC Type
   getDefinition    : Name → TC Definition

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -343,8 +343,9 @@ quotingKit = do
             agdaDefinitionFunDef !@ quoteList (quoteClause (Left ())) cs
           Primitive{}   -> pure agdaDefinitionPrimitive
           PrimitiveSort{} -> pure agdaDefinitionPrimitive
-          Constructor{conData = d} ->
-            agdaDefinitionDataConstructor !@! quoteName d
+          Constructor{conData = d, conSrcCon = c} -> do
+            q <- getQuantity <$> getConstInfo (conName c)
+            agdaDefinitionDataConstructor !@! quoteName d @@ quoteQuantity q
 
   return $ QuotingKit quoteTerm quoteType (quoteDom quoteType) quoteDefn quoteList
 

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -383,7 +383,7 @@ coreBuiltins =
   , builtinAgdaTCMDeclareDef                 |-> builtinPostulate (targ tqname --> ttype --> tTCM_ primUnit)
   , builtinAgdaTCMDeclarePostulate           |-> builtinPostulate (targ tqname --> ttype --> tTCM_ primUnit)
   , builtinAgdaTCMDeclareData                |-> builtinPostulate (tqname --> tnat --> ttype --> tTCM_ primUnit)
-  , builtinAgdaTCMDefineData                 |-> builtinPostulate (tqname --> tlist (tpair primLevelZero primLevelZero tqname ttype) --> tTCM_ primUnit)
+  , builtinAgdaTCMDefineData                 |-> builtinPostulate (tqname --> tlist (tpair primLevelZero primLevelZero tqname (tpair primLevelZero primLevelZero tquantity ttype)) --> tTCM_ primUnit)
   , builtinAgdaTCMDefineFun                  |-> builtinPostulate (tqname --> tlist tclause --> tTCM_ primUnit)
   , builtinAgdaTCMGetType                    |-> builtinPostulate (tqname --> tTCM_ primAgdaTerm)
   , builtinAgdaTCMGetDefinition              |-> builtinPostulate (tqname --> tTCM_ primAgdaDefinition)

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -355,7 +355,7 @@ coreBuiltins =
                                                                   ,builtinAgdaDefinitionPrimitive])
   , (builtinAgdaDefinitionFunDef             |-> BuiltinDataCons (tlist tclause --> tdefn))
   , (builtinAgdaDefinitionDataDef            |-> BuiltinDataCons (tnat --> tlist tqname --> tdefn))
-  , (builtinAgdaDefinitionDataConstructor    |-> BuiltinDataCons (tqname --> tdefn))
+  , (builtinAgdaDefinitionDataConstructor    |-> BuiltinDataCons (tqname --> tquantity --> tdefn))
   , (builtinAgdaDefinitionRecordDef          |-> BuiltinDataCons (tqname --> tlist (targ tqname) --> tdefn))
   , (builtinAgdaDefinitionPostulate          |-> BuiltinDataCons tdefn)
   , (builtinAgdaDefinitionPrimitive          |-> BuiltinDataCons tdefn)

--- a/test/Fail/UnquoteDataClash.agda
+++ b/test/Fail/UnquoteDataClash.agda
@@ -24,7 +24,7 @@ defineD D c =
         (quoteTerm Set))))) >>= λ _ →
   defineData D
     -- c : (xs : List A) → D A (length xs)
-    [(c , pi (vArg (def (quote List) [ vArg (var 0 []) ])) (abs ""
+    [(c , quantity-ω , pi (vArg (def (quote List) [ vArg (var 0 []) ])) (abs ""
             (def D (  vArg (var 1 [])
                     ∷ vArg (def (quote length) [ vArg (var 0 []) ])
                     ∷ [])))

--- a/test/Fail/UnquoteDataErased.agda
+++ b/test/Fail/UnquoteDataErased.agda
@@ -1,0 +1,22 @@
+{-# OPTIONS --erasure #-}
+module UnquoteDataErased where
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Reflection
+open import Common.Reflection
+open import Common.List
+
+
+defineD : Name → Name → Quantity → TC _
+defineD n c q =
+  declareData n 0 (quoteTerm Set) >>= λ _ →
+  defineData n ((c , q
+                   , pi (vArg (def (quote Nat) []))
+                       (abs "" (def n []))) ∷ [])
+
+unquoteDecl data newD0 constructor newC0 = defineD newD0 newC0 quantity-0
+
+a : newD0
+a = newC0 7

--- a/test/Fail/UnquoteDataErased.err
+++ b/test/Fail/UnquoteDataErased.err
@@ -1,0 +1,3 @@
+UnquoteDataErased.agda:22,5-12
+Identifier newC0 is declared erased, so it cannot be used here
+when checking that the expression newC0 7 has type newD0

--- a/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
+++ b/test/Succeed/Inlining-Builtin-Reflection-did-not-work.agda
@@ -186,7 +186,7 @@ data Definition : Set where
   function    : (cs : List Clause) → Definition
   data-type   : (pars : Nat) (cs : List Name) → Definition
   record-type : (c : Name) (fs : List (Arg Name)) → Definition
-  data-cons   : (d : Name) → Definition
+  data-cons   : (d : Name) (q : Quantity) → Definition
   axiom       : Definition
   prim-fun    : Definition
 

--- a/test/Succeed/Issue2165.agda
+++ b/test/Succeed/Issue2165.agda
@@ -10,8 +10,8 @@ infixl 5 _>>=_
 _>>=_ = bindTC
 
 defToTerm : Name → Definition → List (Arg Term) → Term
-defToTerm _ (function cs) as = pat-lam cs as
-defToTerm _ (data-cons d) as = con d as
+defToTerm _ (function cs)   as = pat-lam cs as
+defToTerm _ (data-cons d _) as = con d as
 defToTerm _ _ _ = unknown
 
 derefImmediate : Term → TC Term

--- a/test/Succeed/Issue2203.agda
+++ b/test/Succeed/Issue2203.agda
@@ -10,8 +10,8 @@ infixl 5 _>>=_
 _>>=_ = bindTC
 
 defToTerm : Name → Definition → List (Arg Term) → Term
-defToTerm _ (function cs) as = pat-lam cs as
-defToTerm _ (data-cons d) as = con d as
+defToTerm _ (function cs)   as = pat-lam cs as
+defToTerm _ (data-cons d _) as = con d as
 defToTerm _ _ _ = unknown
 
 data Tm : Set where

--- a/test/Succeed/Issue2226.agda
+++ b/test/Succeed/Issue2226.agda
@@ -93,8 +93,8 @@ bar₂-def =  refl
 --- Originally reported test case ---
 
 defToTerm : Name → Definition → List (Arg Term) → Term
-defToTerm _ (function cs) as = pat-lam cs as
-defToTerm _ (data-cons d) as = con d as
+defToTerm _ (function cs)   as = pat-lam cs as
+defToTerm _ (data-cons d _) as = con d as
 defToTerm _ _ _ = unknown
 
 derefImmediate : Term → TC Term

--- a/test/Succeed/Issue2404.agda
+++ b/test/Succeed/Issue2404.agda
@@ -10,8 +10,8 @@ pure = returnTC
 
 
 defToTerm : Name → Definition → List (Arg Term) → Term
-defToTerm _ (function cs) as = pat-lam cs as
-defToTerm _ (data-cons d) as = con d as
+defToTerm _ (function cs)   as = pat-lam cs as
+defToTerm _ (data-cons d _) as = con d as
 defToTerm _ _ _ = unknown
 
 derefImmediate : Term → TC Term

--- a/test/Succeed/ReflectionGetDef.agda
+++ b/test/Succeed/ReflectionGetDef.agda
@@ -1,0 +1,35 @@
+{-# OPTIONS --safe --cubical --erasure #-}
+module ReflectionGetDef where
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Unit
+open import Agda.Primitive
+
+_>>=_ : {a b : Level} {A : Set a} {B : Set b} → TC A → (A → TC B) → TC B
+_>>=_ = bindTC
+
+_>>_ : {a b : Level} {A : Set a} {B : Set b} → TC A → TC B → TC B
+_>>_ = λ mx my → bindTC mx λ _ → my
+
+refl : {a : Level} {A : Set a} {x : A} → x ≡ x
+refl {_} {_} {x} _ = x
+
+data S¹ : Set where
+  base : S¹
+  @0 loop : base ≡ base
+
+macro
+  erased? : Name → Term → TC ⊤
+  erased? n hole = do
+    data-cons d q ← getDefinition n
+      where _ → typeError []
+    `q ← quoteTC q
+    unify hole `q
+
+_ : erased? base ≡ quantity-ω
+_ = refl
+
+_ : erased? loop ≡ quantity-0
+_ = refl

--- a/test/Succeed/UnquoteDeclData.agda
+++ b/test/Succeed/UnquoteDeclData.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --erasure #-}
 module UnquoteDeclData where
 
 open import Agda.Builtin.Nat
@@ -8,21 +9,26 @@ open import Common.Reflection
 open import Common.List
 
 
-defineD : Name → Name → TC _
-defineD n c =
+defineD : Name → Name → Quantity → TC _
+defineD n c q =
   declareData n 1 (pi (vArg (quoteTerm Set))
                       (abs "" (pi (vArg (quoteTerm Nat))
                                   (abs "" (quoteTerm Set))))) >>= λ _ →
-  defineData n ((c , pi (vArg (def (quote List) (vArg (var 0 []) ∷ [])))
+  defineData n ((c , q
+                   , pi (vArg (def (quote List) (vArg (var 0 []) ∷ [])))
                        (abs "" (def n (vArg (var 1 [])
                                       ∷ vArg (def (quote length)
                                                   (vArg (var 0 []) ∷ []))
                                         ∷ [])))) ∷ [])
 
-unquoteDecl data newD constructor newC = defineD newD newC
+unquoteDecl data newD  constructor newC  = defineD newD  newC  quantity-ω
+unquoteDecl data newD0 constructor newC0 = defineD newD0 newC0 quantity-0
 
 j : newD Nat 0
 j = newC []
 
 k : newD Nat 2
 k = newC (10 ∷ 20 ∷ [])
+
+@0 j0 : newD0 Nat 0
+j0 = newC0 []


### PR DESCRIPTION
Currently there's no way to distinguish erased constructors from normal ones. I couldn't find the corresponding issue, please link it with this PR.

Continuation of (abandoned) #7247 but with a limited scope.