### PR TITLE
add CSS rule for macro names

### DIFF
--- a/src/data/html/Agda.css
+++ b/src/data/html/Agda.css
@@ -19,6 +19,7 @@
 .Agda .Datatype               { color: #0000CD }
 .Agda .Field                  { color: #EE1289 }
 .Agda .Function               { color: #0000CD }
+.Agda .Macro                  { color: #0000CD }
 .Agda .Module                 { color: #A020F0 }
 .Agda .Postulate              { color: #0000CD }
 .Agda .Primitive              { color: #0000CD }


### PR DESCRIPTION
Fixes half of https://github.com/agda/agda/issues/7324 by picking a colour for macros, and sweeps the other half under the rug by picking the same colour as for functions.