### PR TITLE
Remove unknown-field.agda-lib from test/Succeed

### DIFF
--- a/test/Fail/Installed.err
+++ b/test/Fail/Installed.err
@@ -1,9 +1,6 @@
-warning: -W[no]LibUnknownField
-unknown-field.agda-lib: Unknown field 'this-field-does-not-exist'
 Library 'standard-library' not found.
 Add the path to its .agda-lib file to
   installed-libs/libraries'
 to install.
 Installed libraries:
   test-succeed (succeed2.agda-lib)
-  unknown-field (unknown-field.agda-lib)

--- a/test/Succeed/installed-libs/Installed.warn
+++ b/test/Succeed/installed-libs/Installed.warn
@@ -1,5 +1,0 @@
-
-———— All done; warnings encountered ————————————————————————
-
-warning: -W[no]LibUnknownField
-unknown-field.agda-lib: Unknown field 'this-field-does-not-exist'

--- a/test/Succeed/installed-libs/libraries
+++ b/test/Succeed/installed-libs/libraries
@@ -1,3 +1,2 @@
 test/Succeed/succeed2.agda-lib
 test/Succeed/succeed2.agda-lib
-test/Succeed/unknown-field.agda-lib

--- a/test/Succeed/unknown-field.agda-lib
+++ b/test/Succeed/unknown-field.agda-lib
@@ -1,6 +1,0 @@
-name: unknown-field
-
-include:
-  .
-
-this-field-does-not-exist: 17


### PR DESCRIPTION
It produces unknown field warnings for all tests in `Succeed` and is generally annoying. I'm not terribly concerned about a regression on allowing unknown fields, and even if we were the test for that should use a local agda-lib file that doesn't interfere with anything else.