### PR TITLE
Potential optimization in forcing analysis: use magma instead of DList

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -795,6 +795,7 @@ library
       Agda.Utils.IO.TempFile
       Agda.Utils.IO.UTF8
       Agda.Utils.IORef
+      Agda.Utils.LeafTree
       Agda.Utils.Lens
       Agda.Utils.Lens.Examples
       Agda.Utils.List

--- a/src/full/Agda/Utils/LeafTree.hs
+++ b/src/full/Agda/Utils/LeafTree.hs
@@ -1,0 +1,16 @@
+-- | Free magma: unbalanced binary leaf trees.
+
+module Agda.Utils.LeafTree where
+
+import Agda.Utils.Singleton
+
+data LeafTree a
+  = Leaf a
+  | Branch (LeafTree a) (LeafTree a)
+  deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
+
+instance Semigroup (LeafTree a) where
+  (<>) = Branch
+
+instance Singleton a (LeafTree a) where
+  singleton = Leaf


### PR DESCRIPTION
See https://github.com/agda/agda/commit/b36173cd10c257330496d77d7081c5e5c67626ea#r143572386 .
This commit introduced a difference list to collect some modalities. (Probably to avoid the costs associated with wrong nesting of `++` for lists.  These might be minor, but let's not talk about premature optimization here.)
Since the only thing that is done with the modality collection is a fold (`any`), we can as well just use a binary leaf-labelled tree for the collection (the free semigroup sans laws, so, the free magma).

(Got distracted when reading the forcing analysis code for https://github.com/agda/agda/issues/6744.)
