### PR TITLE
Remove duplicate imports and pragmas in MAlonzo

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -439,9 +439,9 @@ ghcPostModule _cenv menv _isMain _moduleName ghcDefs = do
     hsModuleName <- curHsMod
     writeModule $ HS.Module
       hsModuleName
-      (map HS.OtherPragma headerPragmas)
+      (map HS.OtherPragma $ List.nub headerPragmas)
       imps
-      (map fakeDecl (hsImps ++ code) ++ decls)
+      (map fakeDecl (List.nub hsImps ++ code) ++ decls)
 
   return $ GHCModule menv mainDefs
 


### PR DESCRIPTION
When generating foreign pragmas from reflection you sometimes also need to generate corresponding imports/language pragmas. For instance, when generating data types, you often want `deriving (Generic)` which needs an import.

The most convenient thing to do is to generate the import in the same place in the reflection code, so the user doesn't have to worry about it. This means you get one import for each data type you generate, which GHC doesn't have a problem with, but it feels nicer to not repeat the same import 15 times.