### PR TITLE
Optimize forcing analysis and prepare for ReduceM

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -788,6 +788,7 @@ library
       Agda.Utils.Hash
       Agda.Utils.HashTable
       Agda.Utils.Haskell.Syntax
+      Agda.Utils.IArray
       Agda.Utils.Impossible
       Agda.Utils.IndexedList
       Agda.Utils.IntSet.Infinite

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -63,11 +63,14 @@ module Agda.TypeChecking.Forcing
     isForced,
     nextIsForced ) where
 
+import Control.Monad
+import Control.Monad.Reader
+import Control.Monad.State
+
 import Data.Bifunctor
-import Data.DList (DList)
-import qualified Data.DList as DL
-import Data.IntMap (IntMap)
-import qualified Data.IntMap as IntMap
+import Data.Function ((&))
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
 import Data.Monoid -- for (<>) in GHC 8.0.2
 
 import Agda.Interaction.Options
@@ -80,10 +83,15 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 
+import Agda.Utils.Boolean (implies)
+import Agda.Utils.IArray (Array, listArray)
+import qualified Agda.Utils.IArray as Array
 import Agda.Utils.List
+import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Utils.Size
+import Agda.Utils.Singleton
 
 import Agda.Utils.Impossible
 
@@ -104,47 +112,99 @@ computeForcingAnnotations c t =
     -- get to the actual data type.
     -- Also #2947: The type might reduce to a pi type.
     TelV tel (El _ a) <- telViewPath t
-    -- Jesper, 2023-09-20 (#6867): With --erasure, only arguments with @0 can be forced.
     erasureOn <- optErasure <$> pragmaOptions
+    -- Modalities of constructor arguments:
+    let n = size tel
+        -- Candidates for forced arguments, indexed by their de Bruijn index.
+        -- 'Nothing' means cannot possibly be forced.
+        forcedArgCands :: ForcedVariableCandidates
+        forcedArgCands = listArray (0,n-1)
+          [ -- Jesper, 2023-09-20 (#6867): With --erasure, only arguments with @0 can be forced.
+            if (erasureOn `implies` hasQuantity0 m)
+            -- Also the argument shouldn't be irrelevant, since in that
+            -- case it isn't really forced.
+            && (getRelevance m /= Irrelevant)
+            then Just m else Nothing
+          | m <- map getModality $ reverse $ telToList tel
+          ]
+    -- Computation of forced arguments:
     let vs = case a of
           Def _ us -> us
           _        -> __IMPOSSIBLE__
-        n = size tel
-        xs :: [(Modality, Nat)]
-        xs = DL.toList $ forcedVariables vs
-        xs' :: IntMap [Modality]
-        xs' = IntMap.map DL.toList $ IntMap.fromListWith (<>) $
-              map (\(m, i) -> (i, DL.singleton m)) xs
-        -- #2819: We can only mark an argument as forced if it appears in the
-        -- type with a relevance below (i.e. more relevant) than the one of the
-        -- constructor argument. Otherwise we can't actually get the value from
-        -- the type. Also the argument shouldn't be irrelevant, since in that
-        -- case it isn't really forced.
-        isForced :: Modality -> Nat -> Bool
-        isForced m i =
-               (hasQuantity0 m || not erasureOn)
-            && (getRelevance m /= Irrelevant)
-            && case IntMap.lookup i xs' of
-                 Nothing -> False
-                 Just ms -> any (`moreUsableModality` m) ms
-        forcedArgs =
-          [ if isForced m i then Forced else NotForced
-          | (i, m) <- zip (downFrom n) $ map getModality (telToList tel)
+    let forcedVars = execForcedVariableCollection forcedArgCands $ forcedVariables vs
+    let forcedArgs =
+          [ if IntSet.member i forcedVars then Forced else NotForced
+          | i <- downFrom n
           ]
     reportS "tc.force" 60
       [ "Forcing analysis for " ++ prettyShow c
-      , "  xs          = " ++ show (map snd xs)
+      , "  forcedVars  = " ++ show (IntSet.toList forcedVars)
       , "  forcedArgs  = " ++ show forcedArgs
       ]
     return forcedArgs
 
+-- | Candidates for forced constructor arguments (@Just m@) with their modality (@m@)
+--   in the constructor telescope.
+--
+type ForcedVariableCandidates = Array Nat (Maybe Modality)
+
+-- | Environment for forced variable collection.
+--
+data ForcedVariableContext = ForcedVariableContext
+  { fvcModality   :: Modality
+      -- ^ Modality of current position.  (Accumulated from traversed 'Arg's.)
+  , fvcCandidates :: ForcedVariableCandidates
+      -- ^ Candidates for forced variables.  (Immutable.)
+  }
+
+-- | Which candidates are actually forced?
+--
+type ForcedVariableState = IntSet
+
+-- | Monad for forced variable analysis.
+--
+newtype ForcedVariableCollection' a = ForcedVariableCollection
+  { runForcedVariableCollection :: ReaderT ForcedVariableContext (State ForcedVariableState) a }
+  deriving (Functor, Applicative, Monad, MonadReader ForcedVariableContext, MonadState ForcedVariableState)
+
+type ForcedVariableCollection = ForcedVariableCollection' ()
+
+instance Semigroup ForcedVariableCollection where
+  ForcedVariableCollection m <> ForcedVariableCollection m' = ForcedVariableCollection (m >> m')
+
+instance Monoid ForcedVariableCollection where
+  mempty = ForcedVariableCollection $ pure ()
+
+instance Singleton (Nat, Modality) ForcedVariableCollection where
+  singleton (i, m) = ForcedVariableCollection do
+    ForcedVariableContext mc cands <- ask
+    whenJust (join $ cands Array.!? i) \ m0 -> do
+      -- #2819: We can only mark an argument as forced if it appears in the
+      -- type with a relevance below (i.e. more relevant) than the one of the
+      -- constructor argument. Otherwise we can't actually get the value from
+      -- the type.
+      when (composeModality mc m `moreUsableModality` m0) do
+        modify $ IntSet.insert i
+
+-- | Step into an argument labelled with the given modality.
+--
+underModality :: Modality -> ForcedVariableCollection -> ForcedVariableCollection
+underModality m = local \ (ForcedVariableContext mc cands) -> ForcedVariableContext (composeModality mc m) cands
+
+-- | Run the forced variable analysis monad.
+execForcedVariableCollection :: ForcedVariableCandidates -> ForcedVariableCollection -> ForcedVariableState
+execForcedVariableCollection cands (ForcedVariableCollection m) =
+  m & (`runReaderT` cxt)
+    & (`execState` IntSet.empty)
+  where cxt = ForcedVariableContext unitModality cands
+
 -- | Compute the pattern variables of a term or term-like thing.
 class ForcedVariables a where
-  forcedVariables :: a -> DList (Modality, Nat)
+  forcedVariables :: a -> ForcedVariableCollection
 
   default forcedVariables ::
     (ForcedVariables b, Foldable t, a ~ t b) =>
-    a -> DList (Modality, Nat)
+    a -> ForcedVariableCollection
   forcedVariables = foldMap forcedVariables
 
 instance ForcedVariables a => ForcedVariables [a] where
@@ -157,13 +217,13 @@ instance ForcedVariables a => ForcedVariables (Elim' a) where
 
 instance ForcedVariables a => ForcedVariables (Arg a) where
   forcedVariables x =
-    fmap (first (composeModality m)) (forcedVariables (unArg x))
+    underModality m $ forcedVariables $ unArg x
     where m = getModality x
 
 -- | Assumes that the term is in normal form.
 instance ForcedVariables Term where
   forcedVariables = \case
-    Var i []   -> DL.singleton (unitModality, i)
+    Var i []   -> singleton (i, unitModality)
     Con _ _ vs -> forcedVariables vs
     _          -> mempty
 

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -131,7 +131,10 @@ computeForcingAnnotations c t =
     let vs = case a of
           Def _ us -> us
           _        -> __IMPOSSIBLE__
-    let forcedVars = execForcedVariableCollection forcedArgCands $ forcedVariables vs
+    let forcedVars
+          -- No candidates, no winners!
+          | all isNothing forcedArgCands = IntSet.empty
+          | otherwise = execForcedVariableCollection forcedArgCands $ forcedVariables vs
     let forcedArgs =
           [ if IntSet.member i forcedVars then Forced else NotForced
           | i <- downFrom n

--- a/src/full/Agda/Utils/IArray.hs
+++ b/src/full/Agda/Utils/IArray.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE CPP #-}
+
+{-# OPTIONS_GHC -Wno-dodgy-exports #-} -- don't complain about empty exports for Agda.Utils.IArray
+
+-- | Array utilities.
+
+module Agda.Utils.IArray (module Agda.Utils.IArray, module Data.Array.IArray) where
+
+import Data.Array.IArray
+import Data.Array.Base   ( IArray(..) )
+import Data.Ix           ( inRange )
+
+#if MIN_VERSION_base(4,14,0)
+import GHC.Ix            ( unsafeIndex )
+#endif
+
+-- Backported from array-0.5.6:
+
+#if !MIN_VERSION_array(0,5,6)
+
+{-# INLINE (!?) #-}
+-- | Returns 'Just' the element of an immutable array at the specified index,
+-- or 'Nothing' if the index is out of bounds.
+--
+(!?) :: (IArray a e, Ix i) => a i e -> i -> Maybe e
+(!?) arr i
+  | inRange b i = Just $ unsafeAt arr $
+#if MIN_VERSION_base(4,14,0)
+    unsafeIndex b i
+#else
+    index b i
+#endif
+  | otherwise   = Nothing
+  where b = bounds arr
+
+#endif

--- a/test/Bugs/Issue3898.err
+++ b/test/Bugs/Issue3898.err
@@ -2,7 +2,7 @@ AGDA_FAILURE
 
 ret > ExitFailure 42
 out > Forcing analysis for Issue3898.FSet.sg
-out >   xs          = [2,1]
+out >   forcedVars  = []
 out >   forcedArgs  = [NotForced]
 out >
 out > Unsolved interaction metas at the following locations:


### PR DESCRIPTION
Rather than first extracting pattern variables from target, directly calculate whether they make a constructor argument forced.

This refactoring uses a custom Monoid and is similar to the structure of the free variable analysis.

From here, one can rather easily include `reduce` in the forced variable extraction to try to fix | #6744.
- #6744
