### PR TITLE
[ fix #6643 ] Throw error if adding rewrite rule that is mutually defined with declared but not-yet-defined function

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1601,6 +1601,12 @@ instance PrettyTCM TypeError where
         , prettyTCM q
         , " cannot be added before the function definition"
         ]
+      BeforeMutualFunctionDefinition r -> hsep
+        [ "Rewrite rule from function "
+        , prettyTCM q
+        , " cannot be added before the definition of mutually defined"
+        , prettyTCM r
+        ]
       EmptyReason -> hsep
         [ prettyTCM q , " is not a legal rewrite rule" ]
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4939,6 +4939,7 @@ data IllegalRewriteRuleReason
   | RequiresDefinitions (Set QName)
   | DoesNotTargetRewriteRelation
   | BeforeFunctionDefinition
+  | BeforeMutualFunctionDefinition QName
   | EmptyReason
     deriving (Show, Generic)
 

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -196,7 +196,7 @@ checkRewriteRule q = do
     typeError $ IllegalRewriteRule q BeforeFunctionDefinition
   -- Issue 6643: Also check that there are no mututal definitions
   -- that are not yet defined.
-  whenJustM (asksTC envMutualBlock) $ \ mb -> do
+  whenJustM (asksTC envMutualBlock) \ mb -> do
     qs <- mutualNames <$> lookupMutualBlock mb
     when (Set.member q qs) $ forM_ qs $ \r -> do
       whenM (isEmptyFunction . theDef <$> getConstInfo r) $

--- a/test/Fail/Issue6042.err
+++ b/test/Fail/Issue6042.err
@@ -1,6 +1,3 @@
-Issue6042.agda:26,1-46,68
-Termination checking failed for the following functions:
-  Id
-Problematic calls:
-  Id (𝛌 (λ _ → Set)) (snd (snd aₓ)) (B ∙ fst aₓ) (B ∙ fst (snd aₓ))
-    (at Issue6042.agda:33,7-9)
+Issue6042.agda:35,1-29
+Rewrite rule from function  Id-const  cannot be added before the definition of mutually defined Id
+when checking the pragma REWRITE Id-const ＝-Π

--- a/test/Fail/Issue6643.agda
+++ b/test/Fail/Issue6643.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --rewriting --confluence-check #-}
+module Issue6643 where
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Bool
+
+{-# BUILTIN REWRITE _≡_ #-}
+
+p : true ≡ false
+q : true ≡ false
+p = q
+{-# REWRITE p #-}
+
+q = refl

--- a/test/Fail/Issue6643.err
+++ b/test/Fail/Issue6643.err
@@ -1,0 +1,3 @@
+Issue6643.agda:12,1-18
+Rewrite rule from function  p  cannot be added before the definition of mutually defined q
+when checking the pragma REWRITE p


### PR DESCRIPTION
Fixes #6643