### PR TITLE
[ fix #7266 ] Check that constructor names match before projecting in `matchPattern`

### DIFF
--- a/test/Fail/Issue7266.agda
+++ b/test/Fail/Issue7266.agda
@@ -1,0 +1,11 @@
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Unit
+
+P : Bool → Set
+P true = ⊤
+P false = Σ Bool λ _ → Bool
+
+f : (A : Bool) → P A → P A
+f true _ = f true tt
+f false (true , _) = true , true

--- a/test/Fail/Issue7266.err
+++ b/test/Fail/Issue7266.err
@@ -1,0 +1,10 @@
+Issue7266.agda:10,1-11,19
+Incomplete pattern matching for f. Missing cases:
+  f false (false , snd₁)
+when checking the definition of f
+Issue7266.agda:9,1-11,33
+Termination checking failed for the following functions:
+  f
+Problematic calls:
+  f true tt
+    (at Issue7266.agda:10,12-13)


### PR DESCRIPTION
Fixes #7266