### PR TITLE
Refactor: return `RecordData` instead of `Defn` from `isRecord`

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1388,7 +1388,7 @@ getRecordContents norm ce = do
   let notRecordType = typeError $ ShouldBeRecordType t
   (q, vs, defn) <- fromMaybeM notRecordType $ isRecordType t
   case defn of
-    Record{ recFields = fs, recTel = rtel } -> do
+    RecordData{ _recFields = fs, _recTel = rtel } -> do
       let xs   = map (nameConcrete . qnameName . unDom) fs
           tel  = apply rtel vs
           doms = flattenTel tel
@@ -1403,7 +1403,6 @@ getRecordContents norm ce = do
         ]
       ts <- mapM (normalForm norm . unDom) doms
       return ([], tel, zip xs ts)
-    _ -> __IMPOSSIBLE__
 
 -- | Returns the contents of the given module.
 

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -965,7 +965,7 @@ getRecordInfo typ = case unEl typ of
     Nothing -> return Nothing
     Just defn -> do
       fields <- getRecordFields qname
-      return $ Just (qname, argsFromElims elims, fields, recRecursive defn)
+      return $ Just (qname, argsFromElims elims, fields, recRecursive_ defn)
   _ -> return Nothing
 
 applyProj :: Args -> Component -> QName -> SM Component

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -41,7 +41,7 @@ appView' e = f (DL.toList es)
   where
   (f, es) = appView'' e
 
-  appView'' e = case e of
+  appView'' = \case
     App i e1 e2
       | Dot _ e2' <- unScope $ namedArg e2
       , Just f <- maybeProjTurnPostfix e2'
@@ -50,7 +50,7 @@ appView' e = f (DL.toList es)
     App i e1 arg | (f, es) <- appView'' e1 ->
       (f, es `DL.snoc` (fmap . fmap) (i,) arg)
     ScopedExpr _ e -> appView'' e
-    _              -> (Application e, mempty)
+    e              -> (Application e, mempty)
 
 maybeProjTurnPostfix :: Expr -> Maybe Expr
 maybeProjTurnPostfix e =

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -71,7 +71,10 @@ import Prelude hiding (null)
 
 import Control.DeepSeq
 
+import Data.Bifunctor   ( second )
+import Data.DList       ( DList )
 import qualified Data.DList as DL
+import Data.Function    ( (&) )
 import Data.Functor.Identity
 import Data.Maybe
 import Data.Set         ( Set  )
@@ -688,13 +691,12 @@ appView e = f (DL.toList ess)
   where
     (f, ess) = appView' e
 
+    appView' :: Expr -> ([NamedArg Expr] -> AppView, DList (NamedArg Expr))
     appView' = \case
-      App r e1 e2      -> vApp (appView' e1) e2
+      App r e1 e2      -> appView' e1 & second (`DL.snoc` e2)
       RawApp _ (List2 e1 e2 es)
                        -> (AppView e1, DL.fromList (map arg (e2 : es)))
       e                -> (AppView e, mempty)
-
-    vApp (f, es) arg = (f, es `DL.snoc` arg)
 
     arg (HiddenArg   _ e) = hide         $ defaultArg e
     arg (InstanceArg _ e) = makeInstance $ defaultArg e

--- a/src/full/Agda/Syntax/Parser/Helpers.hs
+++ b/src/full/Agda/Syntax/Parser/Helpers.hs
@@ -10,8 +10,6 @@ import Control.Monad.State
 
 import Data.Bifunctor (first, second)
 import Data.Char
-import Data.DList (DList)
-import qualified Data.DList as DL
 import qualified Data.List as List
 import Data.Maybe
 import Data.Semigroup ((<>), sconcat)

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1338,7 +1338,7 @@ tryRecPFromConP p = do
           -- If the record constructor is generated or the user wrote a record pattern,
           -- print record pattern.
           -- Otherwise, print constructor pattern.
-          if recNamedCon def && conPatOrigin ci /= ConORec then fallback else do
+          if _recNamedCon def && conPatOrigin ci /= ConORec then fallback else do
             fs <- fromMaybe __IMPOSSIBLE__ <$> getRecordFieldNames_ r
             unless (length fs == length ps) __IMPOSSIBLE__
             return $ A.RecP ci $ zipWith mkFA fs ps
@@ -1357,7 +1357,7 @@ recOrCon c co es = do
     -- If the record constructor is generated or the user wrote a record expression,
     -- print record expression.
     -- Otherwise, print constructor expression.
-    if recNamedCon def && co /= ConORec then fallback else do
+    if _recNamedCon def && co /= ConORec then fallback else do
       fs <- fromMaybe __IMPOSSIBLE__ <$> getRecordFieldNames_ r
       unless (length fs == length es) __IMPOSSIBLE__
       return $ A.Rec empty $ zipWith mkFA fs es

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -427,7 +427,7 @@ isCoinductiveProjection mustBeRecursive q = liftTCM $ do
       Just Projection{ projProper = Just{}, projFromType = Arg _ r, projIndex = n } ->
         caseMaybeM (isRecord r) __IMPOSSIBLE__ $ \ rdef -> do
           -- no for inductive or non-recursive record
-          if recInduction rdef /= Just CoInductive then return False else do
+          if _recInduction rdef /= Just CoInductive then return False else do
             reportSLn "term.guardedness" 40 $ prettyShow q ++ " is coinductive; record type is " ++ prettyShow r
             if not mustBeRecursive then return True else do
               reportSLn "term.guardedness" 40 $ prettyShow q ++ " must be recursive"
@@ -439,7 +439,7 @@ isCoinductiveProjection mustBeRecursive q = liftTCM $ do
                 -- Get the type of the field by dropping record parameters and record argument.
                 let TelV tel core = telView' (defType pdef)
                     (pars, tel') = splitAt n $ telToList tel
-                    mut = fromMaybe __IMPOSSIBLE__ $ recMutual rdef
+                    mut = fromMaybe __IMPOSSIBLE__ $ _recMutual rdef
                 -- Check if any recursive symbols appear in the record type.
                 -- Q (2014-07-01): Should we normalize the type?
                 -- A (2017-01-13): Yes, since we also normalize during positivity check?
@@ -476,8 +476,8 @@ isCoinductiveProjection mustBeRecursive q = liftTCM $ do
   -- that has not happened.  To avoid crashing (as in Agda 2.5.3),
   -- we rather give the possibly wrong answer here,
   -- restoring the behavior of Agda 2.5.2.  TODO: fix record declaration checking.
-  safeRecRecursive :: Defn -> Bool
-  safeRecRecursive (Record { recMutual = Just qs }) = not $ null qs
+  safeRecRecursive :: RecordData -> Bool
+  safeRecRecursive RecordData{ _recMutual = Just qs } = not $ null qs
   safeRecRecursive _ = False
 
 -- * De Bruijn pattern stuff

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1033,10 +1033,10 @@ instance ExtractCalls Term where
           caseMaybeM (isRecordConstructor c) inductive $ \ (q, def) -> do
             reportSLn "term.check.term" 50 $ "constructor " ++ prettyShow c ++ " has record type " ++ prettyShow q
             -- inductive record constructors are not guarding
-            if recInduction def /= Just CoInductive then inductive else do
+            if _recInduction def /= Just CoInductive then inductive else do
             -- coinductive constructors unrelated to the mutually
             -- constructed inhabitants of coinductive types are not guarding
-            ifM (targetElem . fromMaybe __IMPOSSIBLE__ $ recMutual def)
+            ifM (targetElem . fromMaybe __IMPOSSIBLE__ $ _recMutual def)
                {-then-} coinductive
                {-else-} inductive
         constructor c ind argsg

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -1460,7 +1460,7 @@ splitResultRecord f sc@(SClause tel ps _ _ target) = do
   caseMaybe target (failure CosplitNoTarget) $ \ t -> do
     isR <- addContext tel $ isRecordType $ unDom t
     case isR of
-      Just (_r, vs, Record{ recFields = fs }) -> do
+      Just (_r, vs, RecordData{ _recFields = fs }) -> do
         reportSDoc "tc.cover" 20 $ sep
           [ text $ "we are of record type _r = " ++ prettyShow _r
           , text   "applied to parameters vs =" <+> addContext tel (prettyTCM vs)

--- a/src/full/Agda/TypeChecking/Empty.hs
+++ b/src/full/Agda/TypeChecking/Empty.hs
@@ -101,7 +101,7 @@ checkEmptyType range t = do
     -- If t is a record type, see if any of the field types is empty
     Right (r, pars, def) -> do
       ifNotM (isEtaRecordDef def) (return $ Left Fail) $
-         void <$> do checkEmptyTel range $ recTel def `apply` pars
+         void <$> do checkEmptyTel range $ _recTel def `apply` pars
 
 -- | Check whether one of the types in the given telescope is constructor-less
 --   and if yes, return its index in the telescope (0 = leftmost).

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1678,7 +1678,7 @@ inverseSubst' skip args = map (mapFst unArg) <$> loop (zip args terms)
              | otherwise         = failure tm
         irrProj <- optIrrelevantProjections <$> pragmaOptions
         lift (isEtaRecordConstructor $ conName c) >>= \case
-          Just (_, r@Record{ recFields = fs })
+          Just (_, RecordData{ _recFields = fs })
             | length fs == length es
             , hasQuantity0 info || all usableQuantity fs     -- Andreas, 2019-11-12/17, issue #4168b
             , irrProj || all isRelevant fs -> do

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2990,11 +2990,18 @@ instance Pretty ProjLams where
 
 -- | Is the record type recursive?
 recRecursive :: Defn -> Bool
-recRecursive (Record { recMutual = Just qs }) = not $ null qs
+recRecursive (RecordDefn d) = recRecursive_ d
 recRecursive _ = __IMPOSSIBLE__
+
+recRecursive_ :: RecordData -> Bool
+recRecursive_ RecordData{ _recMutual = Just qs } = not $ null qs
+recRecursive_ _ = __IMPOSSIBLE__
 
 recEtaEquality :: Defn -> HasEta
 recEtaEquality = theEtaEquality . recEtaEquality'
+
+_recEtaEquality :: RecordData -> HasEta
+_recEtaEquality = theEtaEquality . _recEtaEquality'
 
 -- | A template for creating 'Function' definitions, with sensible
 -- defaults.

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -251,7 +251,7 @@ matchPattern p u = case (p, u) of
         -- Case: Eta record constructor.
         -- This case is necessary if we want to use the clauses before
         -- record pattern translation (e.g., in type-checking definitions by copatterns).
-        let fs = map argFromDom $ recFields def
+        let fs = map argFromDom $ _recFields def
         unless (size fs == size ps) __IMPOSSIBLE__
         mapSnd (Arg info . Con c (fromConPatternInfo cpi) . map Apply) <$> do
           matchPatterns ps $ for fs $ \ (Arg ai f) -> Arg ai $ v `applyE` [Proj ProjSystem f]

--- a/src/full/Agda/TypeChecking/Records.hs-boot
+++ b/src/full/Agda/TypeChecking/Records.hs-boot
@@ -6,9 +6,9 @@ import Agda.Syntax.Internal
 import qualified Agda.Syntax.Concrete.Name as C
 import Agda.TypeChecking.Monad
 
-isRecord :: HasConstInfo m => QName -> m (Maybe Defn)
+isRecord :: HasConstInfo m => QName -> m (Maybe RecordData)
 isEtaRecord :: HasConstInfo m => QName -> m Bool
 getRecordFieldNames_ :: (HasConstInfo m, ReadTCState m) => QName -> m (Maybe [Dom C.Name])
 etaContractRecord :: HasConstInfo m => QName -> ConHead -> ConInfo -> Args -> m Term
 isGeneratedRecordConstructor :: (MonadTCEnv m, HasConstInfo m) => QName -> m Bool
-isRecordConstructor :: HasConstInfo m => QName -> m (Maybe (QName, Defn))
+isRecordConstructor :: HasConstInfo m => QName -> m (Maybe (QName, RecordData))

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -731,15 +731,16 @@ forceEtaExpansion a v (e:es) = case e of
     reportSDoc "rewriting.confluence.eta" 40 $ fsep
       [ "Forcing" , prettyTCM v , ":" , prettyTCM a , "to be projectible by" , prettyTCM f ]
     r <- fromMaybe __IMPOSSIBLE__ <$> getRecordOfField f
-    rdef <- getConstInfo r
-    let ra = defType rdef
+    def <- getConstInfo r
+    let ra = defType def
+    let RecordDefn rdef = theDef def
     pars <- newArgsMeta ra
     s <- ra `piApplyM` pars >>= \s -> ifIsSort s return __IMPOSSIBLE__
     equalType a $ El s (Def r $ map Apply pars)
 
     -- Eta-expand v at record type r, and get field corresponding to f
-    (_ , c , ci , fields) <- etaExpandRecord_ r pars (theDef rdef) v
-    let fs        = map argFromDom $ recFields $ theDef rdef
+    (_ , c , ci , fields) <- etaExpandRecord_ r pars rdef v
+    let fs        = map argFromDom $ _recFields rdef
         i         = fromMaybe __IMPOSSIBLE__ $ elemIndex f $ map unArg fs
         fContent  = unArg $ fromMaybe __IMPOSSIBLE__ $ fields !!! i
         fUpdate w = Con c ci $ map Apply $ updateAt i (w <$) fields

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -340,11 +340,11 @@ instance Match NLPat Term where
           -- If v is not of record constructor form but we are matching at record
           -- type, e.g., we eta-expand both v to (c vs) and
           -- the pattern (p = PDef f ps) to @c (p .f1) ... (p .fn)@.
-            def <- addContext k $ theDef <$> getConstInfo d
+            RecordDefn def <- addContext k $ theDef <$> getConstInfo d
             (tel, c, ci, vs) <- addContext k $ etaExpandRecord_ d pars def v
             addContext k (getFullyAppliedConType c t) >>= \case
               Just (_ , ct) -> do
-                let flds = map argFromDom $ recFields def
+                let flds = map argFromDom $ _recFields def
                     mkField fld = PDef f (ps ++ [Proj ProjSystem fld])
                     -- Issue #3335: when matching against the record constructor,
                     -- don't add projections but take record field directly.
@@ -384,11 +384,11 @@ instance Match NLPat Term where
           k' <- extendContext k (absName b) a
           match r gamma k' (absBody b) pbody body
         _ | Just (d, pars) <- etaRecord -> do
-          def <- addContext k $ theDef <$> getConstInfo d
+          RecordDefn def <- addContext k $ theDef <$> getConstInfo d
           (tel, c, ci, vs) <- addContext k $ etaExpandRecord_ d pars def v
           addContext k (getFullyAppliedConType c t) >>= \case
             Just (_ , ct) -> do
-              let flds = map argFromDom $ recFields def
+              let flds = map argFromDom $ _recFields def
                   ps'  = map (fmap $ \fld -> PBoundVar i (ps ++ [Proj ProjSystem fld])) flds
               match r gamma k (ct, Con c ci) (map Apply ps') (map Apply vs)
             Nothing -> no ""

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -164,7 +164,7 @@ instance PatternFrom Term NLPat where
              _ -> done
        | otherwise -> done
       (_ , _ ) | Just (d, pars) <- etaRecord -> do
-        def <- theDef <$> getConstInfo d
+        RecordDefn def <- theDef <$> getConstInfo d
         (tel, c, ci, vs) <- etaExpandRecord_ d pars def v
         ct <- assertConOf c t
         PDef (conName c) <$> patternFrom r k (ct , Con c ci) (map Apply vs)

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1269,9 +1269,8 @@ inferOrCheckProjApp e o ds args mt = do
       ifBlocked core (\ m _ -> postpone m) $ {-else-} \ _ core -> do
       ifNotPiType core (\ _ -> refuseProjNotApplied ds) $ {-else-} \ dom _b -> do
       ifBlocked (unDom dom) (\ m _ -> postpone m) $ {-else-} \ _ ta -> do
-      caseMaybeM (isRecordType ta) (refuseProjNotRecordType ds Nothing ta) $ \ (_q, _pars, defn) -> do
-      case defn of
-        Record { recFields = fs } -> do
+      caseMaybeM (isRecordType ta) (refuseProjNotRecordType ds Nothing ta)
+        \ (_q, _pars, RecordData{ _recFields = fs }) -> do
           case forMaybe fs $ \ f -> Fold.find (unDom f ==) ds of
             [] -> refuseProjNoMatching ds
             [d] -> do
@@ -1280,7 +1279,6 @@ inferOrCheckProjApp e o ds args mt = do
               (, t, CheckedTarget Nothing) <$>
                 checkHeadApplication cmp e t (A.Proj o $ unambiguous d) args
             _ -> __IMPOSSIBLE__
-        _ -> __IMPOSSIBLE__
 
     -- Case: we have a visible argument
     ((k, arg) : _) -> do

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -817,11 +817,10 @@ checkPragma r p = do
 
         A.EtaPragma q -> isRecord q >>= \case
             Nothing -> noRecord
-            Just Record{ recInduction = ind, recEtaEquality' = eta }
+            Just RecordData{ _recInduction = ind, _recEtaEquality' = eta }
               | ind /= Just CoInductive  -> noRecord
               | Specified NoEta{} <- eta -> uselessPragma "ETA pragma conflicts with no-eta-equality declaration"
               | otherwise -> modifyRecEta q $ const $ Specified YesEta
-            _ -> __IMPOSSIBLE__
           where
             noRecord = uselessPragma "ETA pragma is only applicable to coinductive records"
 

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -683,8 +683,8 @@ unifyStep s Cycle
 
 unifyStep s EtaExpandVar{ expandVar = fi, expandVarRecordType = d , expandVarParameters = pars } = do
   recd <- fromMaybe __IMPOSSIBLE__ <$> isRecord d
-  let delta = recTel recd `apply` pars
-      c     = recConHead recd
+  let delta = _recTel recd `apply` pars
+      c     = _recConHead recd
   let nfields         = size delta
       (varTel', rho)  = expandTelescopeVar (varTel s) (m-1-i) delta c
       projectFlexible = [ FlexibleVar (getArgInfo fi) (flexForced fi) (projFlexKind j) (flexPos fi) (i + j) | j <- [0 .. nfields - 1] ]
@@ -715,8 +715,8 @@ unifyStep s EtaExpandVar{ expandVar = fi, expandVarRecordType = d , expandVarPar
 
 unifyStep s EtaExpandEquation{ expandAt = k, expandRecordType = d, expandParameters = pars } = do
   recd  <- fromMaybe __IMPOSSIBLE__ <$> isRecord d
-  let delta = recTel recd `apply` pars
-      c     = recConHead recd
+  let delta = _recTel recd `apply` pars
+      c     = _recConHead recd
   lhs   <- expandKth $ eqLHS s
   rhs   <- expandKth $ eqRHS s
   let (tel, sigma) = expandTelescopeVar (eqTel s) k delta c

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -967,10 +967,10 @@ checkRecordExpression cmp mfs e t = do
           -- Just field names.
           xs   = map unArg cxs
           -- Record constructor.
-          con  = killRange $ recConHead def
+          con  = killRange $ _recConHead def
       reportSDoc "tc.term.rec" 20 $ vcat
         [ "  xs  = " <> return (P.pretty xs)
-        , "  ftel= " <> prettyTCM (recTel def)
+        , "  ftel= " <> prettyTCM (_recTel def)
         , "  con = " <> return (P.pretty con)
         ]
 
@@ -986,7 +986,7 @@ checkRecordExpression cmp mfs e t = do
       -- Andreas, 2018-09-06, issue #3122.
       -- Associate the concrete record field names used in the record expression
       -- to their counterpart in the record type definition.
-      disambiguateRecordFields (map _nameFieldA $ lefts mfs) (map unDom $ recFields def)
+      disambiguateRecordFields (map _nameFieldA $ lefts mfs) (map unDom $ _recFields def)
 
       -- Compute the list of given fields, decorated with the ArgInfo from the record def.
       -- Andreas, 2019-03-18, issue #3122, also pick up non-visible fields from the modules.
@@ -1001,7 +1001,7 @@ checkRecordExpression cmp mfs e t = do
       -- are still left out and inserted later by checkArguments_.
       es <- insertMissingFieldsWarn r meta fs cxs
 
-      args <- checkArguments_ cmp ExpandLast re es (recTel def `apply` vs) >>= \case
+      args <- checkArguments_ cmp ExpandLast re es (_recTel def `apply` vs) >>= \case
         (elims, remainingTel) | null remainingTel
                               , Just args <- allApplyElims elims -> return args
         _ -> __IMPOSSIBLE__
@@ -1077,7 +1077,7 @@ checkRecordUpdate cmp ei recexpr fs eupd t = do
       name <- freshNoName $ getRange recexpr
       addLetBinding defaultArgInfo Inserted name v t' $ do
 
-        let projs = map argFromDom $ recFields defn
+        let projs = map argFromDom $ _recFields defn
 
         -- Andreas, 2018-09-06, issue #3122.
         -- Associate the concrete record field names used in the record expression


### PR DESCRIPTION
Commits:
- **Cosmetics around DList**
- **Refactor: `isRecord` return `RecordData`**
