### PR TITLE
Fix #7346 by not considering HIT-constructor arguments forced

### DIFF
--- a/test/Fail/Issue7346.agda
+++ b/test/Fail/Issue7346.agda
@@ -1,0 +1,32 @@
+-- Andreas, 2024-07-07, issue #7346
+-- Reported by Mikkel Kragh Mathiesen, test case simplified by Szumi Xie.
+
+{-# OPTIONS --cubical --safe #-}
+
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Cubical.Path
+
+data ⊥ : Set where
+
+data N : Set where
+  zero : N
+  suc  : N → N
+  eq   : (x : N) → suc x ≡ x
+
+data IsSuc : N → Set where
+  is-suc : (x : N) → IsSuc (suc x)
+  -- x should not be forced, since N is a HIT.
+
+all-sucs : (x : N) → IsSuc x
+all-sucs x = primTransp (λ i → IsSuc (eq x i)) i0 (is-suc x)
+
+-- This should not termination check,
+-- since dot-pattern termination is off without-K.
+not-suc : (x : N) → IsSuc x → ⊥
+not-suc .(suc x) (is-suc x) = not-suc x (all-sucs x)
+  -- This would be changed by forcing to the following,
+  -- passing the termination check:
+  -- not-suc (suc x) (is-suc .x) = not-suc x (all-sucs x)
+
+nope : ⊥
+nope = not-suc zero (all-sucs zero)

--- a/test/Fail/Issue7346.err
+++ b/test/Fail/Issue7346.err
@@ -1,0 +1,6 @@
+Issue7346.agda:25,1-26,53
+Termination checking failed for the following functions:
+  not-suc
+Problematic calls:
+  not-suc x (all-sucs x)
+    (at Issue7346.agda:26,31-38)


### PR DESCRIPTION
As suggested by @jespercockx , we no longer consider variables under HIT constructors forced.
Closes #7346.

Complements 98bb386c643cc595391d54499ca79596f3e0748a.