### PR TITLE
Fix issue 7262: Range of the lhs modality check

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -687,7 +687,7 @@ checkClauseLHS t withSub c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats rhs0 
       unless (null strippedPats) $ reportSDoc "tc.lhs.top" 50 $
         "strippedPats:" <+> vcat [ prettyA p <+> "=" <+> prettyTCM v <+> ":" <+> prettyTCM a | A.ProblemEq p v a <- strippedPats ]
       closed_t <- flip abstract t <$> getContextTelescope
-      checkLeftHandSide (CheckLHS lhs) (Just x) aps t withSub strippedPats ret
+      checkLeftHandSide (CheckLHS lhs) (getRange lhs) (Just x) aps t withSub strippedPats ret
 
 -- | Type check a function clause.
 

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -839,13 +839,13 @@ checkLeftHandSide call f ps a withSub' strippedPats =
 -- transported, which is probably an overestimate.
 conSplitModalityCheck
   :: Modality
-  -- ^ Modality to check at
+       -- ^ Modality to check at.
   -> PatternSubstitution
-  -- ^ Substitution resulting from index unification. @Γ ⊢ ρ : Δ'@,
-  -- where @Δ'@ is the context we're in, and @Γ@ is the clause telescope
-  -- before unification.
-  -> Int       -- ^ Variable x at which we split
-  -> Telescope -- ^ The telescope @Γ@ itself
+      -- ^ Substitution resulting from index unification. @Γ ⊢ ρ : Δ'@,
+      -- where @Δ'@ is the context we're in, and @Γ@ is the clause telescope
+      -- before unification.
+  -> Int       -- ^ Variable @x@ at which we split.
+  -> Telescope -- ^ The telescope @Γ@ itself.
   -> Type      -- ^ Target type of the clause.
   -> TCM ()
 conSplitModalityCheck mod rho blocking gamma target = when (any ((/= defaultModality) . getModality) gamma) $ do
@@ -858,8 +858,7 @@ conSplitModalityCheck mod rho blocking gamma target = when (any ((/= defaultModa
     , "Δ'target: " <+> prettyTCM (applyPatSubst rho target)
     , "blocking:" <+> prettyTCM blocking
     ]
-  case firstForced rho (length gamma) of
-    Just ix -> do
+  whenJust (firstForced rho (length gamma)) \ ix -> do
       -- We've found a forced argument. This means that the unifier has
       -- decided to kill a unification variable, and any of its
       -- occurrences in the generated term will be replaced by an
@@ -912,7 +911,6 @@ conSplitModalityCheck mod rho blocking gamma target = when (any ((/= defaultModa
         argn <- name arg
         when docheck $
           usableAtModality (IndexedClauseArg forced argn) mod ty'
-    Nothing -> pure ()
 
   -- ALways check the target clause type. Specifically, we check it both
   -- in Δ' and in Γ. The check in Δ' will sometimes let slip by a

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1642,7 +1642,7 @@ checkLetBinding b@(A.LetPatBind i p e) ret =
         ]
       ]
     fvs <- getContextSize
-    checkLeftHandSide (CheckPattern p EmptyTel t) Nothing [p0] t0 Nothing [] $ \ (LHSResult _ delta0 ps _ _t _ asb _ _) -> bindAsPatterns asb $ do
+    checkLeftHandSide (CheckPattern p EmptyTel t) noRange Nothing [p0] t0 Nothing [] $ \ (LHSResult _ delta0 ps _ _t _ asb _ _) -> bindAsPatterns asb $ do
           -- After dropping the free variable patterns there should be a single pattern left.
       let p = case drop fvs ps of [p] -> namedArg p; _ -> __IMPOSSIBLE__
           -- Also strip the context variables from the telescope

--- a/test/Fail/Issue5448-1.err
+++ b/test/Fail/Issue5448-1.err
@@ -1,4 +1,4 @@
-Issue5448-1.agda:8,9-13
+Issue5448-1.agda:8,1-15
 This clause has target type P x which is not usable at the required
 modality @ω.
 

--- a/test/Fail/Issue5448-2.err
+++ b/test/Fail/Issue5448-2.err
@@ -1,4 +1,4 @@
-Issue5448-2.agda:8,9-13
+Issue5448-2.agda:8,1-15
 This clause has target type P x which is not usable at the required
 modality @ω.
 

--- a/test/Fail/Issue5448-3.err
+++ b/test/Fail/Issue5448-3.err
@@ -1,4 +1,4 @@
-Issue5448-3.agda:8,9-13
+Issue5448-3.agda:8,1-15
 This clause has target type P x which is not usable at the required
 modality @ω.
 

--- a/test/Fail/Issue5448-4-noK.err
+++ b/test/Fail/Issue5448-4-noK.err
@@ -1,4 +1,4 @@
-Issue5448-4-noK.agda:8,9-13
+Issue5448-4-noK.agda:8,1-15
 This clause has target type P x which is not usable at the required
 modality @ω.
 when checking that the pattern refl has type x ≡ y

--- a/test/Fail/Issue5448-4.err
+++ b/test/Fail/Issue5448-4.err
@@ -1,4 +1,4 @@
-Issue5448-4.agda:8,9-13
+Issue5448-4.agda:8,1-15
 This clause has target type P x which is not usable at the required
 modality @ω.
 

--- a/test/Fail/Issue5468.agda
+++ b/test/Fail/Issue5468.agda
@@ -32,6 +32,10 @@ data Box : @0 Set → Set₁ where
 unbox : ∀ {@0 A} → Box A → A
 unbox [ x ] = x
 
+-- Expected error: Highlighting of the entire lhs (#7262) and message:
+--
+-- This clause has target type A which is not usable at the required modality @ω.
+
 postulate
   @0 not : Bool ≡ Bool
 

--- a/test/Fail/Issue5468.err
+++ b/test/Fail/Issue5468.err
@@ -1,4 +1,4 @@
-Issue5468.agda:33,7-12
+Issue5468.agda:33,1-12
 This clause has target type A which is not usable at the required
 modality @ω.
 


### PR DESCRIPTION
- **Refactor: Rules.LHS: import Agda.Syntax.Info qualified**
- **Cosmetics: use whenJust**
- **Fix #7262 by remembering the `lhsRange` in the lhs checker**
