### PR TITLE
Fix #7354 by making types of live metas live in DeadCode

### DIFF
--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -92,7 +92,9 @@ eliminateDeadCode !scope = Bench.billTo [Bench.DeadCode] $ do
           HT.insert seenMetas m ()
           case MapS.lookup m metas of
             Nothing -> pure ()
-            Just mv -> go (instBody (theInstantiation mv))
+            Just mv -> do
+              go (instBody (theInstantiation mv))
+              go (jMetaType (mvJudgement mv))
 
       go :: NamesIn a => a -> IO ()
       go !x = namesAndMetasIn' (either goName goMeta) x

--- a/test/Succeed/Issue7354/A.agda
+++ b/test/Succeed/Issue7354/A.agda
@@ -1,0 +1,29 @@
+{-# OPTIONS --safe --save-metas #-}
+module Issue7354.A where
+
+open import Agda.Primitive        public
+open import Agda.Builtin.Equality public
+open import Agda.Builtin.Sigma    public
+
+record Underlying {ℓ : Level} (T : Set ℓ) : Setω where
+  field
+    ℓ-underlying : Level
+    ⌞_⌟⁰         : T → Set ℓ-underlying
+
+infixr 6 Σ-syntax-und
+Σ-syntax-und
+  : ∀{ℓ ℓ' : Level}{A : Set ℓ}{{d : Underlying {ℓ} A ⦄
+    (X : A) (F : Underlying.⌞_⌟⁰ {ℓ} d X → Set ℓ')
+  → Set (ℓ' ⊔ Underlying.ℓ-underlying {ℓ} d)
+Σ-syntax-und {ℓ}{ℓ'}{A}{{d}} X F = Σ (Underlying.⌞_⌟⁰ {ℓ} d X) F
+
+instance
+  Underlying-Type : ∀{ℓ : Level} → Underlying {lsuc ℓ} (Set ℓ)
+  Underlying-Type {ℓ} .Underlying.ℓ-underlying = ℓ
+  Underlying-Type {ℓ} .Underlying.⌞_⌟⁰ x = x
+
+foo : ∀(ℓ : Level)(A : Set ℓ)(B : Set)(f : A → B) → Set ℓ
+foo ℓ A B f = A → B
+
+bleh : ∀ {ℓ : Level} → Set ℓ → Set → Set ℓ
+bleh {ℓ} A B = Σ-syntax-und {lsuc ℓ}{ℓ}{Set ℓ} (A → B) λ f → foo _ _ B f

--- a/test/Succeed/Issue7354/B.agda
+++ b/test/Succeed/Issue7354/B.agda
@@ -1,0 +1,10 @@
+
+{-# OPTIONS --safe #-}
+module Issue7354.B where
+
+open import Issue7354.A
+
+funny : ∀{X T : Set} → bleh {lzero} X T → bleh {lzero} X T
+funny {X}{T} (f , g) =
+  let res = f , g
+  in res


### PR DESCRIPTION
What the title says; the cause of the issue was that types of live metas weren't scanned by DeadCode which caused reachable metas to be erased.

Closes #7354