### PR TITLE
Fix for issue #6841 and related changes

### DIFF
--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -76,9 +76,11 @@ piAbstract (Arg info (v, IdiomType a)) b = do
                     , defaultArg (raise 1 v)
                     , defaultArg (var 0)
                     ]
+    -- Since the result of this function will be type-checked in
+    -- `withFunctionType`, we can be a little lazy here and put
+    -- a meta for the sort.
     sort <- newSortMeta
-    let ty = El sort eq
-    ty <$ checkType ty
+    return $ El sort eq
 
   pure $ mkPi (setHiding (getHiding info) $ defaultDom ("w", a))
        $ mkPi (setHiding NotHidden        $ defaultDom ("eq", eq))

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -64,7 +64,7 @@ piAbstract (Arg info (v, IdiomType a)) b = do
     eqTy <- defType <$> getConstInfo eqName
     -- E.g. @eqTy = eqTel → Set a@ where @eqTel = {a : Level} {A : Set a} (x y : A)@.
     TelV eqTel _ <- telView eqTy
-    tel  <- newTelMeta (telFromList $ dropEnd 2 $ telToList eqTel)
+    tel  <- newTelMeta (telFromList $ dropEnd 3 $ telToList eqTel)
     let eq = Def eqName $ map Apply
                  $ map (setHiding Hidden) tel
                  -- we write `v ≡ w` because this equality is typically used to
@@ -72,7 +72,8 @@ piAbstract (Arg info (v, IdiomType a)) b = do
                  -- in a with-clause.
                  -- If we were to write `w ≡ v`, we would often need to take the
                  -- symmetric of the proof we get to make use of `rewrite`.
-                 ++ [ defaultArg (raise 1 v)
+                 ++ [ setHiding Hidden $ defaultArg $ raise 1 $ unEl a
+                    , defaultArg (raise 1 v)
                     , defaultArg (var 0)
                     ]
     sort <- newSortMeta

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -1204,7 +1204,10 @@ checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs n
   setCurrentRange cs $
     traceCall NoHighlighting $   -- To avoid flicker.
     traceCall (CheckWithFunctionType withFunType) $
-    checkType withFunType
+    -- Jesper, 2024-07-10, issue $6841:
+    -- Having an ill-typed type can lead to problems in the
+    -- coverage checker, so we ensure there are no constraints here.
+    noConstraints $ checkType withFunType
 
   -- With display forms are closed
   df <- inTopContext $ makeOpen =<< withDisplayForm f aux delta1 delta2 n qs perm' perm

--- a/test/Fail/Issue5805.err
+++ b/test/Fail/Issue5805.err
@@ -1,16 +1,11 @@
+Issue5805.agda:29,1-31,6
 Failed to solve the following constraints:
   (ff≡f : (f ∘ f) ≡ f) →
   ?1 (ff≡f = ff≡f) (λ x → f (f x)) ≡ ?1 (ff≡f = ff≡f) f →
   Set is a well-formed type
     (blocked on _A_56)
-  (x : _47) → _47 = _A_56 : Set (blocked on _A_56)
-  _47 =< _47 (blocked on any(_47, _X_51))
-Unsolved metas at the following locations:
-  Issue5805.agda:20,19-30
-  Issue5805.agda:28,20-21
-  Issue5805.agda:28,23-24
-  Issue5805.agda:30,17-21
-  Issue5805.agda:30,27-31
-Unsolved interaction metas at the following locations:
-  Issue5805.agda:19,13-17
-  Issue5805.agda:30,22-26
+when checking that the type
+(ff≡f : (_53 ∘ _53) ≡ _53) →
+?1 (ff≡f = ff≡f) (λ x → _53 (_53 x)) ≡ ?1 (ff≡f = ff≡f) _53 → Set
+of the generated with function is well-formed
+(https://agda.readthedocs.io/en/v2.6.5/language/with-abstraction.html#ill-typed-with-abstractions)

--- a/test/Succeed/Issue6841.agda
+++ b/test/Succeed/Issue6841.agda
@@ -1,0 +1,11 @@
+open import Agda.Builtin.Equality
+
+postulate A : Set; a : A
+
+data MaybeA : Set where
+  just : A → MaybeA
+  nothing : MaybeA
+
+withIn-bug : A
+withIn-bug with just a in eq
+... | just y = y


### PR DESCRIPTION
This PR consists of three changes:
- It fixes the root issue causing #6841 by providing the type of equations when generating a with-function type.
- It removes a redundant call to `checkType` in `piAbstract`: the whole result of `withFunctionType` is anyway type-checked again.
- It adds a call to `noConstraints` to the check that the type of the with-function is well-formed, which should help to provide better error messages when other mistakes in the with-function type generation pop up in the future.