### PR TITLE
Fix #6933: include size-solver-test back in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,6 +184,43 @@ jobs:
     - if: always()
       name: Suite of interaction tests
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
+  size-solver-test:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - id: setup-haskell
+      uses: haskell-actions/setup@v2
+      with:
+        enable-stack: true
+        ghc-version: ${{ env.GHC_VER }}
+        stack-version: latest
+    - uses: actions/download-artifact@v4
+      with:
+        name: agda-${{ runner.os }}-${{ github.sha }}
+    - name: Unpack artifacts
+      run: |
+        tar --use-compress-program zstd -xvf dist.tzst
+        tar --use-compress-program zstd -xvf stack-work.tzst
+    - name: Determine the ICU version
+      run: |
+        ICU_VER=$(pkg-config --modversion icu-i18n)
+        echo "ICU_VER=${ICU_VER}"
+        echo "ICU_VER=${ICU_VER}" >> "${GITHUB_ENV}"
+    - id: cache
+      name: Restore cache from exact key
+      uses: actions/cache/restore@v4
+      with:
+        key: test.yml-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
+          steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-plan-${{
+          hashFiles('Agda.cabal','stack.yaml') }}
+        path: ${{ steps.setup-haskell.outputs.stack-root }}
+    - name: Run tests for the size solver
+      run: |
+        export PATH=${HOME}/.local/bin:${PATH}
+        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
   stdlib-test:
     needs: build
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -676,7 +676,7 @@ run-doctest:
 .PHONY : install-size-solver ## Install the size solver.
 install-size-solver :
 	@$(call decorate, "Installing the size-solver program", \
-		$(MAKE) -C src/size-solver STACK_INSTALL_OPTS='$(SLOW_STACK_INSTALL_OPTS) $(STACK_INSTALL_OPTS)' CABAL_INSTALL_OPTS='$(SLOW_CABAL_INSTALL_OPTS) $(CABAL_INSTALL_OPTS)' install-bin)
+		$(MAKE) -C src/size-solver STACK_INSTALL_OPTS='$(SLOW_STACK_INSTALL_OPTS) $(STACK_INSTALL_BIN_OPTS)' CABAL_INSTALL_OPTS='$(SLOW_CABAL_INSTALL_OPTS) $(CABAL_INSTALL_OPTS)' install-bin)
 
 .PHONY : size-solver-test ##
 size-solver-test : install-size-solver

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -156,14 +156,6 @@ jobs:
     - name: "Build Agda"
       run: make BUILD_DIR="${BUILD_DIR}" install-bin
 
-    # Andreas, 2023-10-19: currently building the size-solver triggers a rebuild of Agda,
-    # likely because the cabal flags (`-f`) passed to `cabal build` have changed.
-    # So, deactivate this for now.
-    # - name: "Run tests for the size solver"
-    #   run: |
-    #     export PATH=${HOME}/.local/bin:${PATH}
-    #     make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
-
     - name: "Pack artifacts"
       # This step should go into the Makefile.
       run: |
@@ -379,3 +371,23 @@ jobs:
 
     - name: "Successful tests using the cubical library"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-succeed
+
+  # Step 2e: running size-solver-test
+  ###########################################################################
+
+  size-solver-test:
+    needs: build
+    runs-on: *runs_on
+
+    steps:
+    - *checkout
+    - *haskell_setup
+    - *download_artifact
+    - *unpack_artifact
+    - *icu
+    - *cache
+
+    - name: "Run tests for the size solver"
+      run: |
+        export PATH=${HOME}/.local/bin:${PATH}
+        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test

--- a/src/size-solver/Makefile
+++ b/src/size-solver/Makefile
@@ -14,7 +14,7 @@ ifdef HAS_STACK
 	mkdir -p dist/build/size-solver
 	cp $(shell $(STACK) path --local-install-root)/bin/size-solver dist/build/size-solver/size-solver
 else
-	$(CABAL) $(CABAL_INSTALL_CMD) $(CABAL_INSTALL_OPTS)
+	$(CABAL) $(CABAL_INSTALL_CMD)
 endif
 
 # Tested with shelltestrunner 1.9 and 1.10

--- a/src/size-solver/test/fail.test
+++ b/src/size-solver/test/fail.test
@@ -18,7 +18,7 @@ Size constraint solver (C) 2013 Andreas Abel and Felix Reihl
 Constraints
 j' < ∞
 j < X
-Error: size constraint j' < ∞ not consistent with size hypotheses
+Error: size constraint j' < ∞ is inconsistent
 >>>2
 >>>= 1
 


### PR DESCRIPTION
- Synchronize Agda builds flags between `make install-bin` and `make install-size-solver`
- Fix golden test in size solver that got out-of-date while it wasn't in CI
- Move size solver test out from the `build` step into its own CI step so it can run in parallel with other tests.

Closes #6933.