### PR TITLE
Fix #6919: separate warnings by empty line

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -699,7 +699,7 @@ getStoredInterface x file msrc = do
         let ws = filter ((Strict.Just (Just x) ==) .
                          fmap rangeFileName . tcWarningOrigin) $
                  iWarnings i
-        unless (null ws) $ alwaysReportSDoc "warning" 1 $ P.vcat $ P.prettyTCM <$> ws
+        unless (null ws) $ alwaysReportSDoc "warning" 1 $ P.vsep $ map P.prettyTCM ws
 
         loadDecodedModule file $ ModuleInfo
           { miInterface = i
@@ -971,7 +971,7 @@ createInterface mname file isMain msrc = do
                                      fmap rangeFileName . tcWarningOrigin) $
                              tcWarnings classified
                    unless (null wa') $
-                     alwaysReportSDoc "warning" 1 $ P.vcat $ P.prettyTCM <$> wa'
+                     alwaysReportSDoc "warning" 1 $ P.vsep $ map P.prettyTCM wa'
                    when (null (nonFatalErrors classified)) $ chaseMsg "Finished" x Nothing)
 
   withMsgs $

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -330,7 +330,7 @@ runTCMPrettyErrors tcm = do
           `catchError` \err -> do
             s2s <- prettyTCWarnings' =<< getAllWarningsOfTCErr err
             s1  <- prettyError err
-            ANSI.putDoc (P.vcat s2s P.$+$ s1)
+            ANSI.putDoc $ P.vsep $ s2s ++ [ s1 ]
             liftIO $ do
               helpForLocaleError err
             return (Just TCMError)

--- a/src/full/Agda/Syntax/Common/Pretty.hs
+++ b/src/full/Agda/Syntax/Common/Pretty.hs
@@ -10,6 +10,7 @@ module Agda.Syntax.Common.Pretty
 
 import Prelude hiding (null)
 
+import qualified Data.List as List
 import qualified Data.Foldable as Fold
 import qualified Data.IntSet as IntSet
 import qualified Data.IntMap as IntMap
@@ -182,6 +183,9 @@ punctuate :: Foldable t => Doc -> t Doc -> [Doc]
 punctuate d = P.punctuate d . Fold.toList
 
 -- * 'Doc' utilities
+
+vsep :: [Doc] -> Doc
+vsep = vcat . List.intersperse ""
 
 pwords :: String -> [Doc]
 pwords = map text . words

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -97,12 +97,13 @@ pwords s = map pure $ P.pwords s
 fwords :: Applicative m => String -> m Doc
 fwords s = pure $ P.fwords s
 
-sep, fsep, hsep, hcat, vcat :: (Applicative m, Foldable t) => t (m Doc) -> m Doc
+sep, fsep, hsep, hcat, vcat, vsep :: (Applicative m, Foldable t) => t (m Doc) -> m Doc
 sep ds  = P.sep  <$> sequenceA (Fold.toList ds)
 fsep ds = P.fsep <$> sequenceA (Fold.toList ds)
 hsep ds = P.hsep <$> sequenceA (Fold.toList ds)
 hcat ds = P.hcat <$> sequenceA (Fold.toList ds)
 vcat ds = P.vcat <$> sequenceA (Fold.toList ds)
+vsep ds = P.vsep <$> sequenceA (Fold.toList ds)
 
 hang :: Applicative m => m Doc -> Int -> m Doc -> m Doc
 hang p n q = P.hang <$> p <*> pure n <*> q


### PR DESCRIPTION
Closes #6919.

Adding whitespace to the warnings output of batch-Agda is not tracked by the testsuite, since it does some normalization when comparing golden values.  So you have to take my word for it or do some manual testing.