### PR TITLE
Resolve instance overlap for irrelevant metas

### DIFF
--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -579,10 +579,6 @@ resolveInstanceOverlap
   -> TCM [item]
 resolveInstanceOverlap overlapOk rel itemC cands = wrapper where
   wrapper
-    -- If the instance meta is irrelevant: anything will do, no reason
-    -- to do any work.
-    | isIrrelevant rel = pure cands
-
     -- If all the candidates are incoherent: choose the leftmost candidate.
     | all (isIncoherent . candidateOverlap . itemC) cands
     , (c:_) <- cands = pure [c]

--- a/test/Succeed/Issue7364.agda
+++ b/test/Succeed/Issue7364.agda
@@ -1,0 +1,14 @@
+postulate
+  ⊥ : Set
+  X : Set
+  C : Set → Set
+
+  instance
+    CA : ∀ {A : Set} ⦃ _ : ⊥ ⦄ → C A -- this instance must come first to trigger the bug
+    CX : C X
+  {-# INCOHERENT CA #-}
+
+  x! : .⦃ C X ⦄ → X
+
+x : X
+x = x!


### PR DESCRIPTION
Even for irrelevant metas, overlap resolution can discard incoherent instances that simply do not apply.

Fixes https://github.com/plt-amy/1lab/issues/405 where the following instances are overlapping:

```
- INCOHERENT H-Level-projection : {ℓ : Level} {A : Type ℓ}
                                  {n : Nat} {@(tactic hlevel-proj A n) inst : is-hlevel A n} →
                                  H-Level A n
- H-Level-⊥ : {n : Nat} → H-Level ⊥ (suc n)
```

The `hlevel-proj` tactic fails to apply to `⊥`, so it is crucial that we select the more specific instance `H-Level-⊥`.

I will try to add a test for this, but for now the minimal reproducer uses 1lab [`11f6113`](https://github.com/plt-amy/1lab/tree/11f611363c01d24e8c46d5d99622066d04a32597):

```agda
open import 1Lab.Type
open import 1Lab.HLevel.Closure
open import 1Lab.Reflection.HLevel

postulate
  foo : .⦃ H-Level ⊥ 1 ⦄ → ⊤

bar : ⊤
bar = foo
```