### PR TITLE
Handle symlinks correctly when computing interface file locations

### DIFF
--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -92,24 +92,23 @@ toIFile (SourceFile src) = do
   mroot <- libToTCM $ findProjectRoot (takeDirectory fp)
   case mroot of
     Nothing   -> pure localIFile
-    Just root ->
+    Just root -> do
       let buildDir = root </> "_build" </> version </> "agda"
-          fileName = makeRelative root (filePath localIFile)
-          separatedIFile = mkAbsolute $ buildDir </> fileName
+      fileName <- liftIO $ makeRelativeCanonical root (filePath localIFile)
+      let separatedIFile = mkAbsolute $ buildDir </> fileName
           ifilePreference = ifM (optLocalInterfaces <$> commandLineOptions)
             (pure (localIFile, separatedIFile))
             (pure (separatedIFile, localIFile))
-      in do
-        separatedIFileExists <- liftIO $ doesFileExistCaseSensitive $ filePath separatedIFile
-        localIFileExists <- liftIO $ doesFileExistCaseSensitive $ filePath localIFile
-        case (separatedIFileExists, localIFileExists) of
-          (False, False) -> fst <$> ifilePreference
-          (False, True) -> pure localIFile
-          (True, False) -> pure separatedIFile
-          (True, True) -> do
-            ifiles <- ifilePreference
-            warning $ uncurry DuplicateInterfaceFiles ifiles
-            pure $ fst ifiles
+      separatedIFileExists <- liftIO $ doesFileExistCaseSensitive $ filePath separatedIFile
+      localIFileExists <- liftIO $ doesFileExistCaseSensitive $ filePath localIFile
+      case (separatedIFileExists, localIFileExists) of
+        (False, False) -> fst <$> ifilePreference
+        (False, True) -> pure localIFile
+        (True, False) -> pure separatedIFile
+        (True, True) -> do
+          ifiles <- ifilePreference
+          warning $ uncurry DuplicateInterfaceFiles ifiles
+          pure $ fst ifiles
 
 replaceModuleExtension :: String -> AbsolutePath -> AbsolutePath
 replaceModuleExtension ext@('.':_) = mkAbsolute . (++ ext) .  dropAgdaExtension . filePath

--- a/src/full/Agda/Utils/FileName.hs
+++ b/src/full/Agda/Utils/FileName.hs
@@ -11,6 +11,7 @@ module Agda.Utils.FileName
   , doesFileExistCaseSensitive
   , isNewerThan
   , relativizeAbsolutePath
+  , makeRelativeCanonical
   ) where
 
 import System.Directory
@@ -126,7 +127,7 @@ isNewerThan new old = do
 --   returning 'Nothing' if the given path cannot be relativized to the given @root@.
 relativizeAbsolutePath ::
      AbsolutePath
-       -- ^ The absolute path we see to relativize.
+       -- ^ The absolute path we seek to relativize.
   -> AbsolutePath
        -- ^ The root for relativization.
   -> Maybe FilePath
@@ -146,3 +147,9 @@ relativizeAbsolutePath apath aroot
     -- In our case, the @root@ is absolute, so we should expect @rest@ to
     -- always be different from @path@ if @path@ is relative to @root@.
     -- In the extreme case, @root = "/"@ and @path == "/" ++ rest@.
+
+-- | Makes a path relative to a root without assuming that either path is
+-- canonical.
+
+makeRelativeCanonical :: FilePath -> FilePath -> IO FilePath
+makeRelativeCanonical = liftA2 makeRelative `on` canonicalizePath


### PR DESCRIPTION
When type-checking a file whose path contains symlinks, `findProjectRoot` might return a more canonical version of the source path. Therefore, in order to make one relative to the other, we need to ensure both are canonical.