### PR TITLE
Minor fixes to instance overlap + constraint postponement

### DIFF
--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -778,6 +778,7 @@ checkCandidates m t cands =
     reportSDoc "tc.instance.candidates" 20 $ nest 2 $ vcat
       [ "candidates", vcat (map debugCandidate cands) ]
 
+    t <- instantiateFull t
     cands'@(_, okay) <- filterResettingState m cands (checkCandidateForMeta m t)
 
     reportSDoc "tc.instance.candidates" 20 $ nest 2 $ vcat

--- a/test/Succeed/OverlapDupe.agda
+++ b/test/Succeed/OverlapDupe.agda
@@ -1,0 +1,47 @@
+module OverlapDupe where
+
+open import Agda.Builtin.Nat
+open import Agda.Primitive
+
+postulate
+  Foo : (l : Level) → Set → Set
+
+  instance
+    foo-nat : ∀ {ℓ} → Foo ℓ Nat
+    foo-any : ∀ {A : Set} → Foo lzero A
+
+  {-# INCOHERENT foo-any #-}
+
+instance
+  foo-nat' : ∀ {ℓ} → Foo ℓ Nat
+  foo-nat' = foo-nat
+
+auto : ∀ {ℓ} {A : Set ℓ} ⦃ _ : A ⦄ → A
+auto ⦃ x ⦄ = x
+
+{-
+
+Note:
+
+  Does foo-nat' specialise foo-any?
+    => NOT specialisation
+
+Therefore:
+
+  instances after resolving overlap:
+  - foo-nat' : {ℓ : Level} → Foo ℓ Nat
+  - foo-nat : {ℓ : Level} → Foo ℓ Nat
+  - INCOHERENT foo-any : {A : Set} → Foo lzero A
+
+But foo-nat and foo-nat' are the same candidate, so according to the
+rule
+
+> There is exactly one non-incoherent candidate, along with some number of
+> incoherent candidates. The non-incoherent candidate is chosen.
+
+we should choose foo-nat; hence incoherent candidates being sunk to the
+bottom and dealt with by dropSameCandidate.
+-}
+
+_ : Foo lzero Nat
+_ = auto


### PR DESCRIPTION
The instance overlap business has slightly funny interactions with postponement: if we run it too early, then we might end up discarding a less specific candidate which, after solving some more constraints, turns out to be the only viable one. To prevent this we restrict overlap resolution to only occur if *none* of the candidates introduced new blocking constraints on metas mentioned in the instance type.

The idea behind this restriction is that, if more than one candidate is blocking on metas in the goal type, then we should probably do a bit more elaboration, to work out the type a bit further. After these metas are solved, any "false" overlaps (where an invalid candidate beats out a valid one) should have been resolved by *discarding the invalid candidate*, as it should be.

As-was, this check could be easily fooled by simply generating some new metas:

```
  <=
    1Lab.HLevel.Closure.H-Level
      {_437@8270318457551244984 {@6} {@5} {@4} {@3} @2 @1}
      (_439@8270318457551244984 {@6} {@5} {@4} {@3} @2 @1 @0)
      (_438@8270318457551244984 {@6} {@5} {@4} {@3} @2 @1)
instance search: found solution for _441: H-Level-is-invertible
candidate H-Level-is-invertible okay for overlap? True
Cat.Morphism.is-invertible _C_449 _f_452 = x ∈ sieve : Type _ℓ'_424
  (blocked on _r_432, belongs to problems 640, 642)
```

Here the big `H-Level {...} ... ...` type is what we're trying to solve, the goal; Checking this candidate (which doesn't matter; it turns out to be invalid) blocks on `_r_432`, which does *not* appear in the goal type, so this candidate is okay for overlap. Right? Actually, no! If we instantiate the goal type, we get `H-Level (_∈_ ⦃ _r_432 ⦄ x sieve) 2`, which *does* mention `_r_432`. This instance isn't actually okay, either as a candidate *or* for overlap.

These failures of scheduling are pretty hard to reproduce, and worse, easy to work around in context. I could get around the issue with this diff, i.e. by forcing the search for an `H-Level` instance to run after the `_r_432` `Membership` instance.

```diff
-   to-presheaf {c} sieve .F₀ d = el! (Σ[ f ∈ C.Hom d c ] (f ∈ sieve))
+   to-presheaf {c} sieve .F₀ d = el (Σ[ f ∈ C.Hom d c ] (f ∈ sieve)) (hlevel 2)
```

@ncfavier encountered a similar issue [here](https://github.com/plt-amy/1lab/actions/runs/9372451062/job/25803940101?pr=374#step:8:1130), which is also fixed by this patch. Unfortunately both of these are quite heavy in dependencies, so I don't know how to minimize them. I hope the fix is justified by the intuitive explanation that "metas which appear in the instance goal" should be invariant under how solved the type has been at that point.