### PR TITLE
Some docs polishing for 2.7.0, contributor list update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,11 +96,14 @@ Pragmas and options
 
 ### Lossy unification
 
-* New option `--require-unique-meta-solutions` (turned on by default). Disabling it with
-  `--no-require-unique-meta-solutions` allows the type checker to take advantage of `INJECTIVE_FOR_INFERENCE` pragmas
-  (see below). The `--lossy-unification` flag implies `--no-require-unique-meta-solutions`.
+* [New option `--require-unique-meta-solutions`](https://agda.readthedocs.io/en/v2.7.0/tools/command-line-options.html#cmdoption-require-unique-meta-solutions)
+  (turned on by default).
+  Disabling it with `--no-require-unique-meta-solutions` allows the type checker
+  to take advantage of `INJECTIVE_FOR_INFERENCE` pragmas (see below).
+  The `--lossy-unification` flag implies `--no-require-unique-meta-solutions`.
 
-* New pragma `INJECTIVE_FOR_INFERENCE`, which treats functions as injective for inferring implicit arguments if
+* [New pragma `INJECTIVE_FOR_INFERENCE`](https://agda.readthedocs.io/en/latest/v2.7.0/pragmas.html#injective-for-inference-pragma)
+  which treats functions as injective for inferring implicit arguments if
   `--no-require-unique-meta-solutions` is given. The `--no-require-unique-meta-solutions` flag needs to be given in the
   file where the function is used, and not necessarily in the file where it is defined.
   For example:
@@ -119,7 +122,8 @@ Syntax
 
 Additions to the Agda syntax.
 
-* Left-hand side let: `using x ← e`
+* [Left-hand side let](https://agda.readthedocs.io/en/latest/v2.7.0/with-abstraction.html#left-hand-side-let-bindings):
+  `using x ← e`
   ([PR #7078](https://github.com/agda/agda/pull/7078))
 
   This new construct can be use in left-hand sides together with `with` and
@@ -220,8 +224,8 @@ Changes to the meta-programming facilities.
 Interaction and emacs mode
 --------------------------
 
-* [**Breaking**] The Auto command _Agsy_ has been replaced
-  by an entirely new implementation _Mimer_
+* [**Breaking**] [The Auto command](https://agda.readthedocs.io/en/v2.7.0/tools/auto.html)
+  _Agsy_ has been replaced by an entirely new implementation _Mimer_
   ([PR #6410](https://github.com/agda/agda/pull/6410)).
   This fixes problems where Auto would fail in the presence of language features
   it did not know about, such as copatterns or anything cubical.

--- a/LICENSE
+++ b/LICENSE
@@ -6,21 +6,24 @@ Cubical Agda was originally contributed by Andrea Vezzosi.
 
 Agda 2 is currently actively developed mainly by Andreas Abel,
 Guillaume Allais, Liang-Ting Chen, Jesper Cockx, Matthew Daggitt,
-Nils Anders Danielsson, Amélia Liao, Ulf Norell, and
-Andrés Sicard-Ramírez.
+Nils Anders Danielsson, Amélia Liao, and Ulf Norell.
 
 Further, Agda 2 has received contributions by, amongst others,
 Arthur Adjedj, Stevan Andjelkovic,
 Marcin Benke, Jean-Philippe Bernardy, Guillaume Brunerie,
-James Chapman, Jonathan Coates,
+James Chapman, Lawrence Chonavel, Jonathan Coates,
 Dominique Devriese, Péter Diviánszky, Robert Estelle,
-Olle Fredriksson, Adam Gundry, Daniel Gustafsson, Philipp Hausmann,
+Naïm Favier, Kuen-Bang Hou (Favonia), Olle Fredriksson,
+Adam Gundry, Daniel Gustafsson,
+Philipp Hausmann, Alex Haršáni,
 Alan Jeffrey, Phil de Joux,
-Wolfram Kahl, Wen Kokke, John Leo, Fredrik Lindblad,
-Víctor López Juan, Ting-Gan Lua, Francesco Mazzoli, Stefan Monnier,
-Guilhem Moulin, Konstantin Nisht, Fredrik Nordvall Forsberg,
-Josselin Poiret, Nicolas Pouillard, Jonathan Prieto, Christian Sattler,
-Makoto Takeyama, Andrea Vezzosi, Noam Zeilberger, and Tesla Ice Zhang.
+Wolfram Kahl, Andre Knispel, Wen Kokke, András Kovács,
+John Leo, Fredrik Lindblad, Víctor López Juan, Ting-Gan Lua,
+Francesco Mazzoli, Stefan Monnier, Guilhem Moulin,
+Konstantin Nisht, Fredrik Nordvall Forsberg, Andreas Nuyts,
+Josselin Poiret, Nicolas Pouillard, Jonathan Prieto,
+Christian Sattler, Michael Shulman, Andrés Sicard-Ramírez,
+Makoto Takeyama, Andrea Vezzosi, Szumi Xie, Noam Zeilberger, and Tesla Ice Zhang.
 The full list of contributors is available at
 https://github.com/agda/agda/graphs/contributors or from the git
 repository via ``git shortlog -sne``.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agda 2
 [![Documentation Status](https://readthedocs.org/projects/agda/badge/?version=latest)](http://agda.readthedocs.io/en/latest/?badge=latest)
 [![Agda Zulip](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://agda.zulipchat.com)
 
-![The official Agda logo](doc/user-manual/agda.svg)
+![The official Agda logo](https://raw.githubusercontent.com/agda/agda/master/doc/user-manual/agda.svg)
 
 Note that this README is only about Agda, not its standard
 library. See the [Agda Wiki][agdawiki] for information about the

--- a/doc/user-manual/team.rst
+++ b/doc/user-manual/team.rst
@@ -18,7 +18,6 @@ Agda 2 is currently actively developed mainly by (in alphabetical order):
 * Nils Anders Danielsson
 * Amélia Liao
 * Ulf Norell
-* Andrés Sicard-Ramírez
 
 Agda 2 has received major contributions by the following developers, amongst others.
 Some contributors have pioneered a feature which shall be mentioned here.
@@ -34,6 +33,8 @@ But many have worked on these features for improvements and maintenance.
 * Guillaume Brunerie
 * James Chapman
 * Liang-Ting Chen: *github workflows*
+* Lawrence Chonavel
+* Jonathan Coates: *performance*
 * Jesper Cockx: *rewriting, unification* :option:`--without-K`, *recursive instance search*, *reflection*, ``Prop``, *cumulativity*
 * Catarina Coquand: *Agda 1*
 * Jonathan Coates: *performance*
@@ -42,17 +43,21 @@ But many have worked on these features for improvements and maintenance.
 * Dominique Devriese: ``instance`` *arguments*
 * Péter Diviánszky: *web frontent,* ``variable`` *declarations*
 * Robert Estelle: *refactoring of backends, main driver*
+* Naïm Favier
 * Olle Fredriksson: *Epic compiler backend*
 * Paolo Giarrusso
 * Adam Gundry: *pattern synonyms*
 * Daniel Gustafsson: *Epic compiler backend*
+* Alex Haršáni: *GenericError refactorings*
 * Philipp Hausmann: *treeless compiler, UHC compiler backend, testsuite runner, Travis CI*
 * Kuen-Bang Hou "favonia"
 * Patrik Jansson
 * Alan Jeffrey: *JavaScript compiler backend*
 * Phil de Joux: some *hlinting*
 * Wolfram Kahl
+* Andre Knispel: *reflection, ``INJECTIVE_FOR_INFERENCE``*
 * Wen Kokke
+* András Kovács: *performance, serialization*
 * John Leo
 * Fredrik Lindblad: *Agsy proof search "Auto"*
 * Víctor López Juan: *"tog" prototype, markdown frontend, documentation*
@@ -64,13 +69,17 @@ But many have worked on these features for improvements and maintenance.
 * Fredrik Nordvall Forsberg: *pattern lambdas, warnings*
 * Konstantin Nisht
 * Ulf Norell: *Agda 2*
+* Andreas Nuyts
 * Josselin Poiret: some refactoring of *modalities*
 * Nicolas Pouillard: *module record expressions*
 * Jonathan Prieto: *Agda package manager*
 * Christian Sattler
+* Michael Shulman: *some Agda input key bindings*
 * Andrés Sicard-Ramírez: *Agda releases, stackage, Travis CI*
+* Lukas Skystedt: *Mimer proof search "Auto"*
 * Makoto Takeyama: *Agda 1, Emacs mode, "MAlonzo" compiler to Haskell, serialization*
 * Andrea Vezzosi: *Cubical Agda, Agda-flat, Agda-parametric, Guarded Cubical Agda*
+* Szumi Xie: *some bug fixes*
 * Noam Zeilberger: *pattern lambdas*
 * Tesla Ice Zhang
 

--- a/doc/user-manual/tools/auto.rst
+++ b/doc/user-manual/tools/auto.rst
@@ -18,6 +18,8 @@ Any solution coming from Auto is checked by Agda. Also, the main
 search algorithm has a timeout mechanism. Therefore, there is little
 harm in trying Auto and it might save you key presses.
 
+Auto was completely rewritten for Agda version 2.7.0.
+
 Usage
 =====
 
@@ -40,7 +42,7 @@ Option                   Meaning
 
 :samp:`-l`               List up to ten solutions, does not commit to any
 
-:samp:`-s {N}`           Skip the :samp:`{N}` th first solutions
+:samp:`-s {N}`           Skip the :samp:`{N}` first solutions
 =======================  =========================================================
 
 Giving no arguments is fine and results in a search with
@@ -104,13 +106,15 @@ ones.
 Dependencies between meta variables
 -----------------------------------
 
-If the goal type or type of local variables contain meta variables,
+The following feature is `missing <https://github.com/agda/agda/issues/7110>`_
+from Agda 2.7.0's implementation of Auto:
+*If the goal type or type of local variables contain meta variables,
 then the constraints for these are also included in the search. If a
 solution is found it means that Auto has also found solutions for the
 occurring meta variables. Those solutions will be inserted into your
 file along with that of the hole from where you called Auto. Also, any
 unsolved equality constraints that contain any of the involved meta
-variables are respected in the search.
+variables are respected in the search.*
 
 Limitations
 ===========


### PR DESCRIPTION
- **Update contributor list for 2.7.0**
- **Re #7110: document that Mimer does not take constraints into account**
- **README: make link to Agda logo absolute**
- **CHANGELOG: insert links to 2.7.0 docs**
