### PR TITLE
Postpone irrelevant/incoherent instance selection using the same logic as overlap

### DIFF
--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -717,7 +717,10 @@ dropSameCandidates m overlapOk cands0 = verboseBracket "tc.instance" 30 "dropSam
 
   case cands of
     [] -> return cands
-    cvd : _ | isIrrelevant rel -> do
+    -- If overlap is not OK, then picking the first instance if the meta is irrelevant
+    -- is also not OK for the same reason: more work might reveal that some of the
+    -- candidates are invalid.
+    cvd : _ | overlapOk, isIrrelevant rel -> do
       reportSLn "tc.instance" 30 "dropSameCandidates: Meta is irrelevant so any candidate will do."
       return [cvd]
     cvd@(_, v, _) : vas
@@ -829,7 +832,7 @@ checkCandidates m t cands =
           debugConstraints
 
           -- Apply hidden and instance arguments (in case of
-          -- --overlapping-instances, this performs recursive
+          -- --backtracking-instance-search, this performs recursive
           -- inst. search!).
           (args, t'') <- implicitArgs (-1) (\h -> notVisible h) t'
 

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -579,6 +579,8 @@ resolveInstanceOverlap
   -> TCM [item]
 resolveInstanceOverlap overlapOk rel itemC cands = wrapper where
   wrapper
+    | not overlapOk = pure cands
+
     -- If all the candidates are incoherent: choose the leftmost candidate.
     | all (isIncoherent . candidateOverlap . itemC) cands
     , (c:_) <- cands = pure [c]
@@ -590,8 +592,6 @@ resolveInstanceOverlap overlapOk rel itemC cands = wrapper where
     -- If none of the candidates have a special overlap mode: there's no
     -- reason to do any work.
     | all ((DefaultOverlap ==) . candidateOverlap . itemC) cands = pure cands
-
-    | not overlapOk = pure cands
 
     -- If some of the candidates are overlappable/overlapping, then we
     -- should do the work.
@@ -731,7 +731,7 @@ dropSameCandidates m overlapOk cands0 = verboseBracket "tc.instance" 30 "dropSam
       where
         equal :: (Candidate, Term, a) -> TCM Bool
         equal (c, v', _)
-            | isIncoherent c = return True   -- See 'sinkIncoherent'
+            | overlapOk, isIncoherent c = return True   -- See 'sinkIncoherent'
             | freshMetas v'  = return False  -- If there are fresh metas we can't compare
             | otherwise      =
           verboseBracket "tc.instance" 30 "dropSameCandidates: " $ do

--- a/test/Succeed/InvalidIncoherentInstance.agda
+++ b/test/Succeed/InvalidIncoherentInstance.agda
@@ -1,0 +1,33 @@
+open import Agda.Builtin.Equality
+open import Agda.Builtin.FromNat
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+open import Agda.Primitive renaming (Set to Type)
+
+is-prop : ∀ {ℓ} → Type ℓ → Type ℓ
+is-prop T = (x y : T) → x ≡ y
+
+is-hlevel : ∀ {ℓ} → Type ℓ → Nat → Type _
+is-hlevel A 0       = is-prop A
+is-hlevel A (suc n) = (x y : A) → is-hlevel (_≡_ {A = A} x y) n
+
+postulate
+  H-Level : ∀ {ℓ} (T : Type ℓ) (n : Nat) → Type ℓ
+  hlevel : ∀ {ℓ} {T : Type ℓ} n ⦃ x : H-Level T n ⦄ → is-hlevel T n
+
+instance
+  Number-Nat : Number Nat
+  Number-Nat .Number.Constraint _ = ⊤
+  Number-Nat .Number.fromNat n = n
+
+data ⊥ : Type where
+
+postulate instance
+  t2 : H-Level ⊤ 0
+  t1 : H-Level ⊥ 0
+  {-# INCOHERENT t1 t2 #-}
+
+postulate foo : (is-prop ⊥) → ⊤
+
+bar : ⊤
+bar = foo (hlevel 0)

--- a/test/Succeed/InvalidIrrelevantInstance.agda
+++ b/test/Succeed/InvalidIrrelevantInstance.agda
@@ -1,0 +1,32 @@
+open import Agda.Builtin.Equality
+open import Agda.Builtin.FromNat
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+open import Agda.Primitive renaming (Set to Type)
+
+is-prop : ∀ {ℓ} → Type ℓ → Type ℓ
+is-prop T = (x y : T) → x ≡ y
+
+is-hlevel : ∀ {ℓ} → Type ℓ → Nat → Type _
+is-hlevel A 0       = is-prop A
+is-hlevel A (suc n) = (x y : A) → is-hlevel (_≡_ {A = A} x y) n
+
+postulate
+  H-Level : ∀ {ℓ} (T : Type ℓ) (n : Nat) → Type ℓ
+  hlevel : ∀ {ℓ} {T : Type ℓ} n ⦃ x : H-Level T n ⦄ → is-hlevel T n
+
+instance
+  Number-Nat : Number Nat
+  Number-Nat .Number.Constraint _ = ⊤
+  Number-Nat .Number.fromNat n = n
+
+data ⊥ : Type where
+
+postulate instance
+  t2 : H-Level ⊤ 0
+  t1 : H-Level ⊥ 0
+
+postulate foo : .(is-prop ⊥) → ⊤
+
+bar : ⊤
+bar = foo (hlevel 0)

--- a/test/Succeed/IrrelevantOverlap.agda
+++ b/test/Succeed/IrrelevantOverlap.agda
@@ -1,0 +1,12 @@
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+postulate
+  NonZero : Nat → Set
+  instance
+    nonZero : ∀ {n} → NonZero (suc n)
+
+  foo : ∀ {m n o} .{{_ : NonZero o}} → m + o ≡ n + o
+
+bar : ∀ m o .{{_ : NonZero m}} → o + m ≡ o + m
+bar m o = foo


### PR DESCRIPTION
Fixes https://github.com/plt-amy/1lab/issues/407 and another similar bug.

This is still in the spirit of using `overlapOk` as a heuristic for "we now have a list of 'good enough' candidates that would all be equally suitable (save for additional constraints that do not mention the goal type), so we can proceed to thin down the list by applying overlap rules or picking an arbitrary candidate". The heuristic is not perfect but this can be remedied with `--backtracking-instance-search`; for example removing the `INCOHERENT` pragma from `Issue7364.agda` still fails as it always has.

Note that the `Number-Nat` nonsense in the test cases is required to trigger the bugs, as these are scheduling-sensitive issues.