### PR TITLE
CI user_manual.yml: add xcolor to latex packages

### DIFF
--- a/.github/workflows/user_manual.yml
+++ b/.github/workflows/user_manual.yml
@@ -34,7 +34,7 @@ jobs:
         packages: scheme-basic anyfontsize bbm bbm-macros booktabs capt-of cmap colortbl
           dvipng ellipse etoolbox fancyvrb float fncychap framed keystroke latexmk
           mathtools needspace parskip pict2e psnfss stmaryrd tabulary tex-gyre titlesec
-          upquote varwidth wrapfig zapfchan
+          upquote varwidth wrapfig xcolor zapfchan
     - name: Build User Manual in HTML
       run: |
         export PATH=$HOME/texlive/bin/x86_64-linux:$PATH

--- a/src/github/workflows/user_manual.yml
+++ b/src/github/workflows/user_manual.yml
@@ -74,6 +74,7 @@ jobs:
           upquote
           varwidth
           wrapfig
+          xcolor
           zapfchan
 
     - name: Build User Manual in HTML


### PR DESCRIPTION
Since we want CI to be functional, this has to be cherry-picked onto 2.7.0 in case we need another RC.