### PR TITLE
New warning `RecursiveDisplayForm` instead of hard error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Installation
 Pragmas and options
 -------------------
 
+* New warning `RecursiveDisplayForm` instead of hard error
+  when a display form is recursive and thus illegal.
+
 * New warning `WithClauseProjectionFixityMismatch` instead of hard error
   when in a with-clause a projection is used in a different fixity
   (prefix vs. postfix) than in its parent clause.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1496,6 +1496,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      :ref:`NO_TERMINATION_CHECK<terminating-pragma>` pragmas; such are deprecated.
 
+.. option:: RecursiveDisplayForm
+
+     A recursive, thus illegal, :ref:`DISPLAY <display-pragma>` form; it will be ignored.
+
 .. option:: RewriteLHSNotDefinitionOrConstructor
 
      Rewrite rule head symbol is not a defined symbol or constructor.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -459,6 +459,7 @@ warningHighlighting' b w = case tcWarning w of
   SafeFlagWithoutKFlagPrimEraseEquality -> errorWarningHighlighting w
   InfectiveImport{}                     -> errorWarningHighlighting w
   CoInfectiveImport{}                   -> errorWarningHighlighting w
+  RecursiveDisplayForm{}                -> deadcodeHighlighting w
   WithClauseProjectionFixityMismatch p _ _ _ -> cosmeticProblemHighlighting p
   WithoutKFlagPrimEraseEquality -> mempty
   ConflictingPragmaOptions{} -> mempty

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -330,6 +330,7 @@ data WarningName
   | UselessPatternDeclarationForRecord_
   | UselessPublic_
   | UserWarning_
+  | RecursiveDisplayForm_
   | WithClauseProjectionFixityMismatch_
   | WithoutKFlagPrimEraseEquality_
   | ConflictingPragmaOptions_
@@ -544,6 +545,7 @@ warningNameDescription = \case
   InteractionMetaBoundaries_       -> "Interaction meta variables that have unsolved boundary constraints."
   UnsolvedMetaVariables_           -> "Unsolved meta variables."
   UserWarning_                     -> "User-defined warnings via one of the 'WARNING_ON_*' pragmas."
+  RecursiveDisplayForm_            -> "Recursive display forms."
   WithClauseProjectionFixityMismatch_ -> "With clauses using projections in different fixities than their parent clauses."
   WithoutKFlagPrimEraseEquality_   -> "Uses of `primEraseEquality' with the without-K flags."
   WrongInstanceDeclaration_        -> "Instances that do not adhere to the required format."

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4389,6 +4389,7 @@ data Warning
   | UselessOpaque
 
   -- Type checker warnings
+  | RecursiveDisplayForm QName
   | WithClauseProjectionFixityMismatch
     { withClausePattern          :: NamedArg A.Pattern
     , withClauseProjectionOrigin :: ProjOrigin
@@ -4497,6 +4498,7 @@ warningName = \case
   UnfoldTransparentName{} -> UnfoldTransparentName_
 
   -- Type checking
+  RecursiveDisplayForm{}               -> RecursiveDisplayForm_
   WithClauseProjectionFixityMismatch{} -> WithClauseProjectionFixityMismatch_
 
   -- Cubical

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -501,6 +501,11 @@ prettyWarning = \case
 
     UselessOpaque -> "This `opaque` block has no effect."
 
+    RecursiveDisplayForm x -> fsep $ concat
+        [ pwords "Ignoring recursive display form for"
+        , [ prettyTCM x ]
+        ]
+
     WithClauseProjectionFixityMismatch p0 o' q o -> fsep $ concat
         [ pwords "With clause pattern"
         , [ prettyA p0 ]

--- a/src/full/Agda/TypeChecking/Rules/Display.hs
+++ b/src/full/Agda/TypeChecking/Rules/Display.hs
@@ -28,7 +28,8 @@ checkDisplayPragma f ps e = do
             let lhs = renumberElims (n - 1) $ map I.Apply args
             v <- exprToTerm e
             return $ Display n lhs (DTerm v)
-  reportSLn "tc.display.pragma" 20 $ "Adding display form for " ++ prettyShow f ++ "\n  " ++ show df
+  reportSLn "tc.display.pragma" 20 $ "Adding display form for " ++ prettyShow f
+  reportSLn "tc.display.pragma" 90 $ ": \n  " ++ show df
   addDisplayForm f df
 
 type ToTm = StateT Nat TCM

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -105,6 +105,7 @@ instance EmbPrj Warning where
     CustomBackendWarning a b                    -> icodeN 56 CustomBackendWarning a b
     CoinductiveEtaRecord a                      -> icodeN 57 CoinductiveEtaRecord a
     WithClauseProjectionFixityMismatch a b c d  -> icodeN 58 WithClauseProjectionFixityMismatch a b c d
+    RecursiveDisplayForm a                      -> icodeN 59 RecursiveDisplayForm a
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -166,6 +167,7 @@ instance EmbPrj Warning where
     [56, a, b]           -> valuN CustomBackendWarning a b
     [57, a]              -> valuN CoinductiveEtaRecord a
     [58, a, b, c, d]     -> valuN WithClauseProjectionFixityMismatch a b c d
+    [59, a]              -> valuN RecursiveDisplayForm a
     _ -> malformed
 
 instance EmbPrj IllegalRewriteRuleReason where
@@ -551,6 +553,7 @@ instance EmbPrj WarningName where
     RewriteBeforeFunctionDefinition_                  -> 133
     RewriteBeforeMutualFunctionDefinition_            -> 134
     WithClauseProjectionFixityMismatch_               -> 135
+    RecursiveDisplayForm_                             -> 136
 
   value = \case
     0   -> return OverlappingTokensWarning_
@@ -688,6 +691,7 @@ instance EmbPrj WarningName where
     133 -> return RewriteBeforeFunctionDefinition_
     134 -> return RewriteBeforeMutualFunctionDefinition_
     135 -> return WithClauseProjectionFixityMismatch_
+    136 -> return RecursiveDisplayForm_
     _   -> malformed
 
 

--- a/test/Fail/Issue1644.agda
+++ b/test/Fail/Issue1644.agda
@@ -1,5 +1,5 @@
-
-module _ where
+-- {-# OPTIONS -v tc.display:20 #-}
+-- {-# OPTIONS -v tc.display.recursive:90 #-}
 
 postulate
   A B : Set
@@ -9,3 +9,5 @@ postulate
 
 loop : A
 loop = {!!}
+
+-- Should fail with unsolved metas.

--- a/test/Fail/Issue1644.err
+++ b/test/Fail/Issue1644.err
@@ -1,3 +1,6 @@
 Issue1644.agda:8,1-22
-Cannot add recursive display form for Issue1644.B
+warning: -W[no]RecursiveDisplayForm
+Ignoring recursive display form for B
 when checking the pragma DISPLAY B = A
+Unsolved interaction metas at the following locations:
+  Issue1644.agda:11,8-12

--- a/test/Fail/Issue1644b.agda
+++ b/test/Fail/Issue1644b.agda
@@ -11,7 +11,11 @@ open M
 postulate
   a : A
 
-{-# DISPLAY N.A = A #-} -- Makes Agda loop
+{-# DISPLAY N.A = A #-}
+  -- Makes Agda loop.
+  -- Display form should be ignored with a warning.
 
 test : Set
 test = a
+
+-- Should fail with error N.A !=< Set

--- a/test/Fail/Issue1644b.err
+++ b/test/Fail/Issue1644b.err
@@ -1,3 +1,8 @@
 Issue1644b.agda:14,1-24
-Cannot add recursive display form for Issue1644b.N.A
+warning: -W[no]RecursiveDisplayForm
+Ignoring recursive display form for N.A
 when checking the pragma DISPLAY N.A = A
+
+Issue1644b.agda:19,8-9
+N.A !=< Set
+when checking that the expression a has type Set


### PR DESCRIPTION
Recursive DISPLAY forms are now ignored as dead code.

NB: Needed to refactor `chaseDisplayForms` because now the display form is not added before the recursion check.
