### PR TITLE
GenericError crusade, continued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Installation
 Pragmas and options
 -------------------
 
-* New warning `RecursiveDisplayForm` instead of hard error
-  when a display form is recursive and thus illegal.
+* New warning `InvalidDisplayForm` instead of hard error
+  when a display form is illegal (and thus ignored).
 
 * New warning `WithClauseProjectionFixityMismatch` instead of hard error
   when in a with-clause a projection is used in a different fixity

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1496,9 +1496,9 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      :ref:`NO_TERMINATION_CHECK<terminating-pragma>` pragmas; such are deprecated.
 
-.. option:: RecursiveDisplayForm
+.. option:: InvalidDisplayForm
 
-     A recursive, thus illegal, :ref:`DISPLAY <display-pragma>` form; it will be ignored.
+     An illegal :ref:`DISPLAY <display-pragma>` form; it will be ignored.
 
 .. option:: RewriteLHSNotDefinitionOrConstructor
 

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -459,7 +459,7 @@ warningHighlighting' b w = case tcWarning w of
   SafeFlagWithoutKFlagPrimEraseEquality -> errorWarningHighlighting w
   InfectiveImport{}                     -> errorWarningHighlighting w
   CoInfectiveImport{}                   -> errorWarningHighlighting w
-  RecursiveDisplayForm{}                -> deadcodeHighlighting w
+  InvalidDisplayForm{}                  -> deadcodeHighlighting w
   TooManyArgumentsToSort _ args         -> errorWarningHighlighting args
   WithClauseProjectionFixityMismatch p _ _ _ -> cosmeticProblemHighlighting p
   WithoutKFlagPrimEraseEquality -> mempty

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -332,7 +332,7 @@ data WarningName
   | UselessPatternDeclarationForRecord_
   | UselessPublic_
   | UserWarning_
-  | RecursiveDisplayForm_
+  | InvalidDisplayForm_
   | WithClauseProjectionFixityMismatch_
   | WithoutKFlagPrimEraseEquality_
   | ConflictingPragmaOptions_
@@ -547,7 +547,7 @@ warningNameDescription = \case
   InteractionMetaBoundaries_       -> "Interaction meta variables that have unsolved boundary constraints."
   UnsolvedMetaVariables_           -> "Unsolved meta variables."
   UserWarning_                     -> "User-defined warnings via one of the 'WARNING_ON_*' pragmas."
-  RecursiveDisplayForm_            -> "Recursive display forms."
+  InvalidDisplayForm_              -> "Invalid display forms."
   TooManyArgumentsToSort_          -> "Extra arguments given to a sort."
   WithClauseProjectionFixityMismatch_ -> "With clauses using projections in different fixities than their parent clauses."
   WithoutKFlagPrimEraseEquality_   -> "Uses of `primEraseEquality' with the without-K flags."

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -198,8 +198,9 @@ errorString = \case
   ModuleNameDoesntMatchFileName {}         -> "ModuleNameDoesntMatchFileName"
   NeedOptionCopatterns{}                   -> "NeedOptionCopatterns"
   NeedOptionCubical{}                      -> "NeedOptionCubical"
-  NeedOptionRewriting{}                    -> "NeedOptionRewriting"
+  NeedOptionPatternMatching{}              -> "NeedOptionPatternMatching"
   NeedOptionProp{}                         -> "NeedOptionProp"
+  NeedOptionRewriting{}                    -> "NeedOptionRewriting"
   NeedOptionTwoLevel{}                     -> "NeedOptionTwoLevel"
   NeedOptionUniversePolymorphism{}         -> "NeedOptionUniversePolymorphism"
   NegativeLiteralInPattern{}               -> "NegativeLiteralInPattern"
@@ -1379,11 +1380,14 @@ instance PrettyTCM TypeError where
         CFull   -> [ "--cubical" ]
         CErased -> pwords $ "--cubical or --erased-cubical"
 
-    NeedOptionRewriting  -> fsep $
-      pwords "Option --rewriting needed to add and use rewrite rules"
+    NeedOptionPatternMatching -> fsep $
+      pwords "Pattern matching is disabled (use option --pattern-matching to enable it)"
 
     NeedOptionProp       -> fsep $
       pwords "Universe Prop is disabled (use options --prop and --no-prop to enable/disable Prop)"
+
+    NeedOptionRewriting  -> fsep $
+      pwords "Option --rewriting needed to add and use rewrite rules"
 
     NeedOptionTwoLevel   -> fsep $
       pwords "Universe SSet is disabled (use option --two-level to enable SSet)"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -197,6 +197,7 @@ errorString = \case
   ModuleNameUnexpected{}                   -> "ModuleNameUnexpected"
   ModuleNameDoesntMatchFileName {}         -> "ModuleNameDoesntMatchFileName"
   NeedOptionCopatterns{}                   -> "NeedOptionCopatterns"
+  NeedOptionCubical{}                      -> "NeedOptionCubical"
   NeedOptionRewriting{}                    -> "NeedOptionRewriting"
   NeedOptionProp{}                         -> "NeedOptionProp"
   NeedOptionTwoLevel{}                     -> "NeedOptionTwoLevel"
@@ -1371,6 +1372,12 @@ instance PrettyTCM TypeError where
 
     NeedOptionCopatterns -> fsep $
       pwords "Option --copatterns needed to enable destructor patterns"
+
+    NeedOptionCubical cubical -> fsep $ concat [ [ "Option" ], opt, [ "required" ] ]
+      where
+      opt = case cubical of
+        CFull   -> [ "--cubical" ]
+        CErased -> pwords $ "--cubical or --erased-cubical"
 
     NeedOptionRewriting  -> fsep $
       pwords "Option --rewriting needed to add and use rewrite rules"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -186,6 +186,7 @@ errorString = \case
   InvalidPattern{}                         -> "InvalidPattern"
   InvalidFileName{}                        -> "InvalidFileName"
   LibraryError{}                           -> "LibraryError"
+  LiteralTooBig{}                          -> "LiteralTooBig"
   LocalVsImportedModuleClash{}             -> "LocalVsImportedModuleClash"
   MetaCannotDependOn{}                     -> "MetaCannotDependOn"
   MetaOccursInItself{}                     -> "MetaOccursInItself"
@@ -200,6 +201,7 @@ errorString = \case
   NeedOptionProp{}                         -> "NeedOptionProp"
   NeedOptionTwoLevel{}                     -> "NeedOptionTwoLevel"
   NeedOptionUniversePolymorphism{}         -> "NeedOptionUniversePolymorphism"
+  NegativeLiteralInPattern{}               -> "NegativeLiteralInPattern"
   GeneralizeNotSupportedHere{}             -> "GeneralizeNotSupportedHere"
   GeneralizeCyclicDependency{}             -> "GeneralizeCyclicDependency"
   GeneralizedVarInLetOpenedModule{}        -> "GeneralizedVarInLetOpenedModule"
@@ -424,7 +426,6 @@ instance PrettyTCM TypeError where
     WrongHidingInProjection d ->
       sep [ "Wrong hiding used for projection " , prettyTCM d ]
 
-
     IllegalHidingInPostfixProjection arg -> fsep $
       pwords "Illegal hiding in postfix projection " ++
       [pretty arg]
@@ -472,6 +473,15 @@ instance PrettyTCM TypeError where
 
     IllformedProjectionPatternConcrete p -> fsep $
       pwords "Ill-formed projection pattern" ++ [pretty p]
+
+    LiteralTooBig -> fsep $ concat
+      [ pwords "Matching on natural number literals is done by expanding"
+      , pwords "the literal to the corresponding constructor pattern,"
+      , pwords "so you probably don't want to do it this way"
+      ]
+
+    NegativeLiteralInPattern -> fsep $
+      pwords "Negative literals are not supported in patterns"
 
     CannotEliminateWithPattern b p a -> do
       let isProj = isJust (isProjP p)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4676,6 +4676,10 @@ data TypeError
         | CantResolveOverloadedConstructorsTargetingSameDatatype QName (List1 QName)
           -- ^ Datatype, constructors.
         | ConstructorDoesNotTargetGivenType QName Type -- ^ constructor, type
+        | LiteralTooBig
+            -- ^ An integer literal that would be too costly to expand to unary.
+        | NegativeLiteralInPattern
+            -- ^ Negative literals are not supported in patterns.
         | WrongHidingInLHS
             -- ^ The left hand side of a function definition has a hidden argument
             --   where a non-hidden was expected.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4931,8 +4931,9 @@ data TypeError
     -- Language option errors
         | NeedOptionCopatterns
         | NeedOptionCubical Cubical
-        | NeedOptionRewriting
+        | NeedOptionPatternMatching
         | NeedOptionProp
+        | NeedOptionRewriting
         | NeedOptionTwoLevel
         | NeedOptionUniversePolymorphism
     -- Failure associated to warnings

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4930,6 +4930,7 @@ data TypeError
         | DeBruijnIndexOutOfScope Nat Telescope [Name]
     -- Language option errors
         | NeedOptionCopatterns
+        | NeedOptionCubical Cubical
         | NeedOptionRewriting
         | NeedOptionProp
         | NeedOptionTwoLevel

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -5,7 +5,7 @@ module Agda.TypeChecking.Monad.MetaVars where
 import Prelude hiding (null)
 
 import Control.Monad                ( (<=<), forM_, guard )
-import Control.Monad.Except         ( MonadError )
+import Control.Monad.Except         ( ExceptT, MonadError )
 import Control.Monad.State          ( StateT, execStateT, get, put )
 import Control.Monad.Trans          ( MonadTrans, lift )
 import Control.Monad.Trans.Identity ( IdentityT )
@@ -517,6 +517,7 @@ class (MonadTCEnv m, ReadTCState m) => MonadInteractionPoints m where
     => (InteractionPoints -> InteractionPoints) -> m ()
   modifyInteractionPoints = lift . modifyInteractionPoints
 
+instance MonadInteractionPoints m => MonadInteractionPoints (ExceptT e m)
 instance MonadInteractionPoints m => MonadInteractionPoints (IdentityT m)
 instance MonadInteractionPoints m => MonadInteractionPoints (ReaderT r m)
 instance MonadInteractionPoints m => MonadInteractionPoints (StateT s m)

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -747,7 +747,7 @@ addDisplayForm :: QName -> DisplayForm -> TCM ()
 addDisplayForm x df = do
   -- Check whether display form is recursive and thus illegal.
   xs <- chaseDisplayForms df Set.empty
-  if x `Set.member` xs then warning $ RecursiveDisplayForm x else do
+  if x `Set.member` xs then warning $ InvalidDisplayForm x "it is recursive" else do
   d <- makeOpen df
   let add = updateDefinition x $ \ def -> def{ defDisplay = d : defDisplay def }
   ifM (isLocal x)

--- a/src/full/Agda/TypeChecking/Patterns/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Abstract.hs
@@ -32,8 +32,8 @@ expandLitPattern
   => A.Pattern -> m A.Pattern
 expandLitPattern = \case
   A.LitP info (LitNat n)
-    | n < 0     -> negLit -- Andreas, issue #2365, negative literals not yet supported.
-    | n > 20    -> tooBig
+    | n < 0     -> typeError NegativeLiteralInPattern  -- Andreas, issue #2365, negative literals not yet supported.
+    | n > 20    -> typeError LiteralTooBig
     | otherwise -> do
       Con z _ _ <- primZero
       Con s _ _ <- primSuc
@@ -43,14 +43,6 @@ expandLitPattern = \case
           cinfo = A.ConPatInfo ConOCon info ConPatEager
       return $ foldr ($) zero $ List.genericReplicate n suc
   p -> return p
-
-  where
-    tooBig = typeError $ GenericError $
-      "Matching on natural number literals is done by expanding " ++
-      "the literal to the corresponding constructor pattern, so " ++
-      "you probably don't want to do it this way."
-    negLit = typeError $ GenericError $
-      "Negative literals are not supported in patterns"
 
 
 -- | Expand away (deeply) all pattern synonyms in a pattern.

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -501,9 +501,10 @@ prettyWarning = \case
 
     UselessOpaque -> "This `opaque` block has no effect."
 
-    RecursiveDisplayForm x -> fsep $ concat
-        [ pwords "Ignoring recursive display form for"
+    InvalidDisplayForm x reason -> fsep $ concat
+        [ pwords "Ignoring invalid display form for"
         , [ prettyTCM x ]
+        , if null reason then [] else "because" : pwords reason
         ]
 
     TooManyArgumentsToSort q args -> fsep $ concat

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -59,7 +59,7 @@ import Agda.TypeChecking.Primitive.Cubical.Id
 
 primPOr :: TCM PrimitiveImpl
 primPOr = do
-  requireCubical CErased ""
+  requireCubical CErased
   t    <- runNamesT [] $
           hPi' "a" (els (pure LevelUniv) (cl primLevel))    $ \ a  ->
           nPi' "i" primIntervalType $ \ i  ->
@@ -89,7 +89,7 @@ primPOr = do
 
 primPartial' :: TCM PrimitiveImpl
 primPartial' = do
-  requireCubical CErased ""
+  requireCubical CErased
   t <- runNamesT [] $
        hPi' "a" (els (pure LevelUniv) (cl primLevel)) (\ a ->
         nPi' "φ" primIntervalType $ \ _ ->
@@ -105,7 +105,7 @@ primPartial' = do
 
 primPartialP' :: TCM PrimitiveImpl
 primPartialP' = do
-  requireCubical CErased ""
+  requireCubical CErased
   t <- runNamesT [] $
        hPi' "a" (els (pure LevelUniv) (cl primLevel)) (\ a ->
         nPi' "φ" primIntervalType $ \ phi ->
@@ -120,7 +120,7 @@ primPartialP' = do
 
 primSubOut' :: TCM PrimitiveImpl
 primSubOut' = do
-  requireCubical CErased ""
+  requireCubical CErased
   t    <- runNamesT [] $
           hPi' "a" (els (pure LevelUniv) (cl primLevel)) $ \ a ->
           hPi' "A" (el' (cl primLevelSuc <@> a) (Sort . tmSort <$> a)) $ \ bA ->
@@ -144,7 +144,7 @@ primSubOut' = do
 
 primTrans' :: TCM PrimitiveImpl
 primTrans' = do
-  requireCubical CErased ""
+  requireCubical CErased
   t    <- runNamesT [] $
           hPi' "a" (primIntervalType --> els (pure LevelUniv) (cl primLevel)) $ \ a ->
           nPi' "A" (nPi' "i" primIntervalType $ \ i -> (sort . tmSort <$> (a <@> i))) $ \ bA ->
@@ -155,7 +155,7 @@ primTrans' = do
 
 primHComp' :: TCM PrimitiveImpl
 primHComp' = do
-  requireCubical CErased ""
+  requireCubical CErased
   t    <- runNamesT [] $
           hPi' "a" (els (pure LevelUniv) (cl primLevel)) $ \ a ->
           hPi' "A" (sort . tmSort <$> a) $ \ bA ->
@@ -723,7 +723,7 @@ primTransHComp cmd ts nelims = do
 -- The definition of it comes from 'mkComp'.
 primComp :: TCM PrimitiveImpl
 primComp = do
-  requireCubical CErased ""
+  requireCubical CErased
   t    <- runNamesT [] $
           hPi' "a" (primIntervalType --> els (pure LevelUniv) (cl primLevel)) $ \ a ->
           nPi' "A" (nPi' "i" primIntervalType $ \ i -> (sort . tmSort <$> (a <@> i))) $ \ bA ->
@@ -754,7 +754,7 @@ primComp = do
 -- TODO Andrea: keep reductions that happen under foralls?
 primFaceForall' :: TCM PrimitiveImpl
 primFaceForall' = do
-  requireCubical CErased ""
+  requireCubical CErased
   t <- (primIntervalType --> primIntervalType) --> primIntervalType
   return $ PrimImpl t $ primFun __IMPOSSIBLE__ 1 $ \case
     [phi] -> do

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
@@ -262,7 +262,7 @@ doGlueKanOp _ _ _ = __IMPOSSIBLE__
 -- element is defined.
 primGlue' :: TCM PrimitiveImpl
 primGlue' = do
-  requireCubical CFull ""
+  requireCubical CFull
   -- primGlue
   --   : {la lb : Level} (A : Type la) {φ : I}
   --   → (T : Partial φ (Type lb)
@@ -293,7 +293,7 @@ primGlue' = do
 -- types.
 prim_glue' :: TCM PrimitiveImpl
 prim_glue' = do
-  requireCubical CFull ""
+  requireCubical CFull
   t <- runNamesT [] $
        hPi' "la" (el $ cl primLevel) (\ la ->
        hPi' "lb" (el $ cl primLevel) $ \ lb ->
@@ -321,7 +321,7 @@ prim_glue' = do
 -- @Glue@ types.
 prim_unglue' :: TCM PrimitiveImpl
 prim_unglue' = do
-  requireCubical CFull ""
+  requireCubical CFull
   t <- runNamesT [] $
        hPi' "la" (el $ cl primLevel) (\ la ->
        hPi' "lb" (el $ cl primLevel) $ \ lb ->

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
@@ -198,7 +198,7 @@ prim_glueU' :: TCM PrimitiveImpl
 prim_glueU' = do
 -- TODO (Amy, 2022-08-17): Same thing about duplicated code with Glue
 -- applies here.
-  requireCubical CErased ""
+  requireCubical CErased
   t <- runNamesT [] $
        hPi' "la" (el $ cl primLevel) (\ la ->
        hPi' "φ" primIntervalType $ \ φ ->
@@ -225,7 +225,7 @@ prim_unglueU' :: TCM PrimitiveImpl
 prim_unglueU' = do
 -- TODO (Amy, 2022-08-17): Same thing about duplicated code with Glue
 -- applies here.
-  requireCubical CErased ""
+  requireCubical CErased
   t <- runNamesT [] $
        hPi' "la" (el $ cl primLevel) (\ la ->
        hPi' "φ" primIntervalType $ \ φ ->

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Id.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Id.hs
@@ -47,7 +47,7 @@ primIdElim' :: TCM PrimitiveImpl
 primIdElim' = do
   -- The implementation here looks terrible but most of it is actually
   -- the type.
-  requireCubical CErased ""
+  requireCubical CErased
   t <- runNamesT [] $
     hPi' "a" (el $ cl primLevel) $ \ a ->
     hPi' "c" (el $ cl primLevel) $ \ c ->
@@ -97,7 +97,7 @@ primIdElim' = do
 -- | Introduction form for the cubical identity types.
 primConId' :: TCM PrimitiveImpl
 primConId' = do
-  requireCubical CErased ""
+  requireCubical CErased
   t <- runNamesT [] $
     hPi' "a" (el $ cl primLevel) $ \ a ->
     hPi' "A" (sort . tmSort <$> a) $ \ bA ->
@@ -132,7 +132,7 @@ primConId' = do
 -- violates the cubical phase distinction.
 primIdFace' :: TCM PrimitiveImpl
 primIdFace' = do
-  requireCubical CErased ""
+  requireCubical CErased
   t <- runNamesT [] $
     hPi' "a" (el $ cl primLevel) $ \ a ->
     hPi' "A" (sort . tmSort <$> a) $ \ bA ->
@@ -155,7 +155,7 @@ primIdFace' = do
 -- cubical identity types.
 primIdPath' :: TCM PrimitiveImpl
 primIdPath' = do
-  requireCubical CErased ""
+  requireCubical CErased
   t <- runNamesT [] $
     hPi' "a" (el $ cl primLevel) $ \ a ->
     hPi' "A" (sort . tmSort <$> a) $ \ bA ->

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -66,7 +66,7 @@ builtinPostulate = BuiltinPostulate Relevant
 
 builtinPostulateC :: Cubical -> TCM Type -> BuiltinDescriptor
 builtinPostulateC c m =
-  BuiltinPostulate Relevant $ requireCubical c "" >> m
+  BuiltinPostulate Relevant $ requireCubical c >> m
 
 findBuiltinInfo :: BuiltinId -> Maybe BuiltinInfo
 findBuiltinInfo b = find ((b ==) . builtinName) coreBuiltins
@@ -112,7 +112,7 @@ coreBuiltins =
   , (builtinAgdaMeta                         |-> builtinPostulate tset)
   , (builtinIO                               |-> builtinPostulate (tset --> tset))
   , (builtinPath                             |-> BuiltinUnknown
-                                                             (Just $ requireCubical CErased "" >>
+                                                             (Just $ requireCubical CErased >>
                                                              hPi "a" (el primLevel) (
                                                               hPi "A" (return $ sort $ varSort 0) $
                                                               (El (varSort 1) <$> varM 0) -->
@@ -125,7 +125,7 @@ coreBuiltins =
                                                               (El (varSort 1) <$> varM 0 <@> primIOne) -->
                                                               return (sort $ varSort 1)))
   , (builtinIntervalUniv                     |-> BuiltinSort SortIntervalUniv)
-  , (builtinInterval                         |-> BuiltinData (requireCubical CErased "" >>
+  , (builtinInterval                         |-> BuiltinData (requireCubical CErased >>
                                                               return (sort IntervalUniv)) [builtinIZero,builtinIOne])
   , (builtinSub                              |-> builtinPostulateC CErased (runNamesT [] $ hPi' "a" (el $ cl primLevel) $ \ a ->
                                                                    nPi' "A" (el' (cl primLevelSuc <@> a) (Sort . tmSort <$> a)) $ \ bA ->
@@ -161,17 +161,17 @@ coreBuiltins =
                                                                    pPi' "o" (cl primIZero) (\ o ->
                                                                         el' l $ gApply' (setRelevance Irrelevant defaultArgInfo) bA o)))
 
-  , (builtinId                               |-> BuiltinData ((>>) (requireCubical CErased "") $ hPi "a" (el primLevel) $
+  , (builtinId                               |-> BuiltinData ((>>) (requireCubical CErased) $ hPi "a" (el primLevel) $
                                                               hPi "A" (return $ sort $ varSort 0) $
                                                               (El (varSort 1) <$> varM 0) -->
                                                               (El (varSort 1) <$> varM 0) -->
                                                              return (sort $ varSort 1)) [builtinReflId])
-  , (builtinReflId                           |-> BuiltinDataCons ((>>) (requireCubical CErased "") $ runNamesT [] $
+  , (builtinReflId                           |-> BuiltinDataCons ((>>) (requireCubical CErased) $ runNamesT [] $
                                                               hPi' "a" (el primLevel) $ \ l ->
                                                               hPi' "A" (sort . tmSort <$> l) $ \ bA ->
                                                               hPi' "x" (el' l bA) $ \ x ->
                                                               el' l (primId <#> l <#> bA <@> x <@> x)))
-  , (builtinEquiv                            |-> BuiltinUnknown (Just $ requireCubical CErased "" >> runNamesT [] (
+  , (builtinEquiv                            |-> BuiltinUnknown (Just $ requireCubical CErased >> runNamesT [] (
                                                                     hPi' "l" (el $ cl primLevel) $ \ a ->
                                                                     hPi' "l'" (el $ cl primLevel) $ \ b ->
                                                                     nPi' "A" (sort . tmSort <$> a) $ \bA ->
@@ -179,7 +179,7 @@ coreBuiltins =
                                                                     ((sort . tmSort) <$> (cl primLevelMax <@> a <@> b))
                                                                   ))
                                                                    (const $ const $ return ()))
-  , (builtinEquivFun                         |-> BuiltinUnknown (Just $ requireCubical CErased "" >> runNamesT [] (
+  , (builtinEquivFun                         |-> BuiltinUnknown (Just $ requireCubical CErased >> runNamesT [] (
                                                                  hPi' "l" (el $ cl primLevel) $ \ a ->
                                                                  hPi' "l'" (el $ cl primLevel) $ \ b ->
                                                                  hPi' "A" (sort . tmSort <$> a) $ \bA ->
@@ -188,7 +188,7 @@ coreBuiltins =
                                                                  (el' a bA --> el' b bB)
                                                                ))
                                                                 (const $ const $ return ()))
-  , (builtinEquivProof                       |-> BuiltinUnknown (Just $ requireCubical CErased "" >> runNamesT [] (
+  , (builtinEquivProof                       |-> BuiltinUnknown (Just $ requireCubical CErased >> runNamesT [] (
                                                                hPi' "l" (el $ cl primLevel) $ \ la ->
                                                                hPi' "l'" (el $ cl primLevel) $ \ lb ->
                                                                nPi' "A" (sort . tmSort <$> la) $ \ bA ->
@@ -208,7 +208,7 @@ coreBuiltins =
                                                                     el' lub (cl primSub <#> lub <#> fmap unEl fiber <@> phi <@> pfib)
                                                              ))
                                                               (const $ const $ return ()))
-  , (builtinTranspProof                       |-> BuiltinUnknown (Just $ requireCubical CErased "" >> runNamesT [] (
+  , (builtinTranspProof                       |-> BuiltinUnknown (Just $ requireCubical CErased >> runNamesT [] (
                                                                hPi' "l" (el $ cl primLevel) $ \ la -> do
                                                                nPi' "e" (cl tinterval --> (sort . tmSort <$> la)) $ \ e -> do
                                                                let lb = la; bA = e <@> cl primIZero; bB = e <@> cl primIOne
@@ -1065,7 +1065,7 @@ bindBuiltinNoDef b q = inTopContext $ do
           def = PrimitiveSort builtinSort s
       -- Check for the cubical flag if the sort requries it
       case builtinSort of
-        SortIntervalUniv -> requireCubical CErased ""
+        SortIntervalUniv -> requireCubical CErased
         _ -> return ()
       addConstant' q defaultArgInfo q (sort $ univSort s) def
       bindBuiltinName b $ Def q []

--- a/src/full/Agda/TypeChecking/Rules/Display.hs
+++ b/src/full/Agda/TypeChecking/Rules/Display.hs
@@ -2,6 +2,7 @@
 
 module Agda.TypeChecking.Rules.Display (checkDisplayPragma) where
 
+import Control.Monad.Except
 import Control.Monad.State
 import Data.Maybe
 
@@ -14,27 +15,36 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Pretty
+import Agda.TypeChecking.Warnings (warning)
 
-import Agda.Syntax.Common.Pretty (prettyShow)
+import Agda.Syntax.Common.Pretty (prettyShow, render)
 
 import Agda.Utils.Impossible
 
+-- | Add display pragma if well-formed.
+--   Otherwise, throw 'InvalidDisplayForm' warning and ignore it.
+--
 checkDisplayPragma :: QName -> [NamedArg A.Pattern] -> A.Expr -> TCM ()
 checkDisplayPragma f ps e = do
-  df <- inTopContext $ do
-          pappToTerm f id ps $ \ n args -> do
-            -- pappToTerm puts Var 0 for every variable. We get to know how many there were (n) so
-            -- now we can renumber them with decreasing deBruijn indices.
-            let lhs = renumberElims (n - 1) $ map I.Apply args
-            v <- exprToTerm e
-            return $ Display n lhs (DTerm v)
-  reportSLn "tc.display.pragma" 20 $ "Adding display form for " ++ prettyShow f
-  reportSLn "tc.display.pragma" 90 $ ": \n  " ++ show df
-  addDisplayForm f df
+  res <- inTopContext $ runExceptT do
+    pappToTerm f id ps $ \ n args -> do
+      -- pappToTerm puts Var 0 for every variable. We get to know how many there were (n) so
+      -- now we can renumber them with decreasing deBruijn indices.
+      let lhs = renumberElims (n - 1) $ map I.Apply args
+      Display n lhs <$> DTerm <$> exprToTerm e
+  case res of
+    Left reason -> warning $ InvalidDisplayForm f reason
+    Right df -> do
+      reportSLn "tc.display.pragma" 20 $ "Adding display form for " ++ prettyShow f
+      reportSLn "tc.display.pragma" 90 $ ": \n  " ++ show df
+      addDisplayForm f df
 
-type ToTm = StateT Nat TCM
+-- | The monad to check display forms.
+--   The 'String' contains the reason to reject the display form.
+--
+type M = ExceptT String TCM
 
-patternsToTerms :: Telescope -> [NamedArg A.Pattern] -> (Int -> Args -> TCM a) -> TCM a
+patternsToTerms :: Telescope -> [NamedArg A.Pattern] -> (Int -> Args -> M a) -> M a
 patternsToTerms _ [] ret = ret 0 []
 patternsToTerms EmptyTel (p : ps) ret =
   patternToTerm (namedArg p) $ \n v ->
@@ -50,7 +60,7 @@ patternsToTerms (ExtendTel a tel) (p : ps) ret
 inheritHiding :: LensHiding a => a -> b -> Arg b
 inheritHiding a b = setHiding (getHiding a) (defaultArg b)
 
-pappToTerm :: QName -> (Args -> b) -> [NamedArg A.Pattern] -> (Int -> b -> TCM a) -> TCM a
+pappToTerm :: QName -> (Args -> b) -> [NamedArg A.Pattern] -> (Int -> b -> M a) -> M a
 pappToTerm x f ps ret = do
   def <- getConstInfo x
   TelV tel _ <- telView $ defType def
@@ -64,7 +74,7 @@ pappToTerm x f ps ret = do
 
   patternsToTerms (dropTel pars tel) ps $ \ n vs -> ret n (f vs)
 
-patternToTerm :: A.Pattern -> (Nat -> Term -> TCM a) -> TCM a
+patternToTerm :: A.Pattern -> (Nat -> Term -> M a) -> M a
 patternToTerm p ret =
   case p of
     A.VarP A.BindName{unBind = x}   -> bindVar x $ ret 1 (Var 0 [])
@@ -79,43 +89,64 @@ patternToTerm p ret =
       | otherwise                   -> ambigErr "DefP" fs
     A.LitP _ l                      -> ret 0 $ Lit l
     A.WildP _                       -> bindWild $ ret 1 (Var 0 [])
-    _ -> genericDocError =<< vcat [ "Pattern not allowed in DISPLAY pragma:", prettyA p ]
+    A.AsP{}                         -> failP "an @-pattern"
+    A.DotP{}                        -> failP "a dot pattern"
+    A.AbsurdP{}                     -> failP "an absurd pattern"
+    A.PatternSynP{}                 -> __IMPOSSIBLE__
+    A.RecP{}                        -> failP "a record pattern"
+    A.EqualP{}                      -> failP "a system pattern"
+    A.WithP{}                       -> __IMPOSSIBLE__
+    A.AnnP{}                        -> __IMPOSSIBLE__
   where
+    fail = throwError . ("its left-hand side contains " ++)
+    failP s = fail . (s ++) . (": " ++) . render =<< prettyA p
     ambigErr thing (AmbQ xs) =
-      genericDocError =<< do
-        text ("Ambiguous " ++ thing ++ ":") <?>
+      fail . render =<< do
+        text ("an ambiguous " ++ thing ++ ":") <?>
           fsep (punctuate comma (fmap pretty xs))
 
-bindWild :: TCM a -> TCM a
+bindWild :: M a -> M a
 bindWild ret = do
   x <- freshNoName_
   bindVar x ret
 
-bindVar :: Name -> TCM a -> TCM a
+bindVar :: Name -> M a -> M a
 bindVar x ret = addContext x ret
 
-exprToTerm :: A.Expr -> TCM Term
+exprToTerm :: A.Expr -> M Term
 exprToTerm e =
   case unScope e of
-    A.Var x  -> fst <$> getVarInfo x
-    A.Def f  -> pure $ Def f []
-    A.Con c  -> pure $ Con (ConHead (headAmbQ c) IsData Inductive []) ConOCon [] -- Don't care too much about ambiguity here
-    A.Lit _ l  -> pure $ Lit l
-    A.App _ e arg  -> apply <$> exprToTerm e <*> ((:[]) . inheritHiding arg <$> exprToTerm (namedArg arg))
+    A.Var x          -> fst <$> getVarInfo x
+    A.Def' f NoSuffix-> pure $ Def f []
+    A.Def'{}         -> fail "suffix"
+    A.Con c          -> pure $ Con (ConHead (headAmbQ c) IsData Inductive []) ConOCon [] -- Don't care too much about ambiguity here
+    A.Lit _ l        -> pure $ Lit l
+    A.App _ e arg    -> apply <$> exprToTerm e <*> ((:[]) . inheritHiding arg <$> exprToTerm (namedArg arg))
 
-    A.Proj _ f -> pure $ Def (headAmbQ f) []   -- only for printing so we don't have to worry too much here
-    A.PatternSyn f -> pure $ Def (headAmbQ f) []
-    A.Macro f      -> pure $ Def f []
+    A.Proj _ f       -> pure $ Def (headAmbQ f) []   -- only for printing so we don't have to worry too much here
+    A.PatternSyn f   -> pure $ Def (headAmbQ f) []
+    A.Macro f        -> pure $ Def f []
 
-    A.WithApp{}      -> notAllowed "with application"
-    A.QuestionMark{} -> notAllowed "holes"
-    A.Underscore{}   -> notAllowed "metavariables"
-    A.Lam{}          -> notAllowed "lambdas"
-    A.AbsurdLam{}    -> notAllowed "lambdas"
-    A.ExtendedLam{}  -> notAllowed "lambdas"
-    _                -> typeError $ GenericError $ "TODO: exprToTerm " ++ show e
+    A.WithApp{}      -> fail "with application"
+    A.QuestionMark{} -> fail "hole"
+    A.Underscore{}   -> fail "metavariable"
+    A.Dot{}          -> fail "dotted expression"
+    A.Lam{}          -> fail "lambda"
+    A.AbsurdLam{}    -> fail "lambda"
+    A.ExtendedLam{}  -> fail "lambda"
+    A.Fun{}          -> fail "function type"
+    A.Pi{}           -> fail "function type"
+    A.Generalized{}  -> __IMPOSSIBLE__
+    A.Let{}          -> fail "let"
+    A.Rec{}          -> fail "record"
+    A.RecUpdate{}    -> fail "record update"
+    A.ScopedExpr{}   -> __IMPOSSIBLE__
+    A.Quote{}        -> fail "quotation"
+    A.QuoteTerm{}    -> fail "quotation"
+    A.Unquote{}      -> fail "unquote"
+    A.DontCare{}     -> __IMPOSSIBLE__
   where
-    notAllowed s = typeError $ GenericError $ "Not allowed in DISPLAY pragma right-hand side: " ++ s
+    fail = throwError . ("its right-hand side contains a " ++)
 
 renumberElims :: Nat -> Elims -> Elims
 renumberElims n es = evalState (renumbers es) n

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1034,7 +1034,7 @@ checkLHS mf = updateModality checkLHS_ where
       let pos = size tel - (i + 1)
           (delta1, tel'@(ExtendTel dom adelta2)) = splitTelescopeAt pos tel -- TODO:: tel' defined but not used
 
-      p <- liftTCM $ expandLitPattern p
+      p <- expandLitPattern p
       let splitOnPat = \case
             (A.LitP _ l)      -> splitLit delta1 dom adelta2 l
             p@A.RecP{}        -> splitCon delta1 dom adelta2 p Nothing

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -991,7 +991,7 @@ checkLHS mf = updateModality checkLHS_ where
 
     unlessM (optPatternMatching <$> getsTC getPragmaOptions) $
       unless (problemAllVariables problem) $
-        typeError $ GenericError $ "Pattern matching is disabled"
+        typeError NeedOptionPatternMatching
 
     let splitsToTry = splitStrategy $ problem ^. problemEqs
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -105,7 +105,7 @@ instance EmbPrj Warning where
     CustomBackendWarning a b                    -> icodeN 56 CustomBackendWarning a b
     CoinductiveEtaRecord a                      -> icodeN 57 CoinductiveEtaRecord a
     WithClauseProjectionFixityMismatch a b c d  -> icodeN 58 WithClauseProjectionFixityMismatch a b c d
-    RecursiveDisplayForm a                      -> icodeN 59 RecursiveDisplayForm a
+    InvalidDisplayForm a b                      -> icodeN 59 InvalidDisplayForm a b
     TooManyArgumentsToSort a b                  -> __IMPOSSIBLE__
 
   value = vcase $ \ case
@@ -168,7 +168,7 @@ instance EmbPrj Warning where
     [56, a, b]           -> valuN CustomBackendWarning a b
     [57, a]              -> valuN CoinductiveEtaRecord a
     [58, a, b, c, d]     -> valuN WithClauseProjectionFixityMismatch a b c d
-    [59, a]              -> valuN RecursiveDisplayForm a
+    [59, a, b]           -> valuN InvalidDisplayForm a b
     _ -> malformed
 
 instance EmbPrj IllegalRewriteRuleReason where
@@ -554,7 +554,7 @@ instance EmbPrj WarningName where
     RewriteBeforeFunctionDefinition_                  -> 133
     RewriteBeforeMutualFunctionDefinition_            -> 134
     WithClauseProjectionFixityMismatch_               -> 135
-    RecursiveDisplayForm_                             -> 136
+    InvalidDisplayForm_                             -> 136
     TooManyArgumentsToSort_                           -> 137
 
   value = \case
@@ -693,7 +693,7 @@ instance EmbPrj WarningName where
     133 -> return RewriteBeforeFunctionDefinition_
     134 -> return RewriteBeforeMutualFunctionDefinition_
     135 -> return WithClauseProjectionFixityMismatch_
-    136 -> return RecursiveDisplayForm_
+    136 -> return InvalidDisplayForm_
     137 -> return TooManyArgumentsToSort_
     _   -> malformed
 

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -414,7 +414,7 @@ stripWithClausePatterns cxtNames parent f t delta qs npars perm ps = do
         tell [ProblemEq (A.VarP x) v a]
         strip self t (fmap (p <$) p0 : ps) qs
     strip self t ps0@(p0 : ps) qs0@(q : qs) = do
-      p <- liftTCM $ (traverse . traverse) expandLitPattern p0
+      p <- (traverse . traverse) expandLitPattern p0
       reportSDoc "tc.with.strip" 15 $ vcat
         [ "strip"
         , nest 2 $ "ps0 =" <+> fsep (punctuate comma $ map prettyA ps0)

--- a/src/full/Agda/Utils/Semigroup.hs
+++ b/src/full/Agda/Utils/Semigroup.hs
@@ -8,9 +8,14 @@ import Data.Semigroup ( Semigroup, (<>) )
 
 import Control.Applicative (liftA2)
 
+import Control.Monad.Except (ExceptT)
 import Control.Monad.Reader (ReaderT)
 import Control.Monad.State  (StateT)
 import Control.Monad.Writer (WriterT)
+
+instance (Monad m, Semigroup doc)       => Semigroup (ExceptT e m doc) where
+  {-# INLINE (<>) #-}
+  (<>) = liftA2 (<>)
 
 instance (Applicative m, Semigroup doc) => Semigroup (ReaderT s m doc) where
   {-# INLINE (<>) #-}

--- a/src/full/Agda/Utils/String.hs
+++ b/src/full/Agda/Utils/String.hs
@@ -2,6 +2,7 @@
 
 module Agda.Utils.String where
 
+import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Writer
@@ -103,6 +104,9 @@ rtrim = List.dropWhileEnd isSpace
 -- | Remove leading and trailing whitesapce.
 trim :: String -> String
 trim = rtrim . ltrim
+
+instance (IsString (m a), Monad m) => IsString (ExceptT e m a) where
+  fromString = lift . fromString
 
 instance (IsString (m a), Monad m) => IsString (ReaderT r m a) where
   fromString = lift . fromString

--- a/test/Fail/IUnivWithoutCubical.err
+++ b/test/Fail/IUnivWithoutCubical.err
@@ -1,3 +1,3 @@
-IUnivWithoutCubical.agda:1,1-39: error: [GenericError]
-Missing option --cubical or --erased-cubical
+IUnivWithoutCubical.agda:1,1-39: error: [NeedOptionCubical]
+Option --cubical or --erased-cubical required
 when checking the pragma BUILTIN CUBEINTERVALUNIV IUniv

--- a/test/Fail/Issue1644.err
+++ b/test/Fail/Issue1644.err
@@ -1,6 +1,6 @@
 Issue1644.agda:8,1-22
-warning: -W[no]RecursiveDisplayForm
-Ignoring recursive display form for B
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for B because it is recursive
 when checking the pragma DISPLAY B = A
 Unsolved interaction metas at the following locations:
   Issue1644.agda:11,8-12

--- a/test/Fail/Issue1644b.err
+++ b/test/Fail/Issue1644b.err
@@ -1,6 +1,6 @@
 Issue1644b.agda:14,1-24
-warning: -W[no]RecursiveDisplayForm
-Ignoring recursive display form for N.A
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for N.A because it is recursive
 when checking the pragma DISPLAY N.A = A
 
 Issue1644b.agda:19,8-9: error: [UnequalTerms]

--- a/test/Fail/Issue2365.agda
+++ b/test/Fail/Issue2365.agda
@@ -27,7 +27,8 @@ test0 = refl
 test1 : lit -2 ≡ 1
 test1 = refl
 
--- Error WAS: Internal error in expandLitPattern
--- Error NOW: Type mismatch when checking that the pattern -20 has type Int
+-- Error WAS:  Internal error in expandLitPattern
+-- Error THEN: Type mismatch when checking that the pattern -20 has type Int
+-- Error NOW:  Negative literals are not supported in patterns
 
 -- Ideally, this would succeed.

--- a/test/Fail/Issue2365.err
+++ b/test/Fail/Issue2365.err
@@ -1,3 +1,3 @@
-Issue2365.agda:19,5-8: error: [GenericError]
+Issue2365.agda:19,5-8: error: [NegativeLiteralInPattern]
 Negative literals are not supported in patterns
 when checking that the pattern -20 has type Int

--- a/test/Fail/Issue2365a.agda
+++ b/test/Fail/Issue2365a.agda
@@ -1,7 +1,0 @@
-open import Agda.Builtin.Nat
-
--- Matching against negative numbers
-
-lit : Nat → Nat
-lit -20 = 0  -- Error thrown here
-lit _   = 1

--- a/test/Fail/Issue2365a.err
+++ b/test/Fail/Issue2365a.err
@@ -1,3 +1,0 @@
-Issue2365a.agda:6,5-8: error: [GenericError]
-Negative literals are not supported in patterns
-when checking that the pattern -20 has type Nat

--- a/test/Fail/Issue2788.err
+++ b/test/Fail/Issue2788.err
@@ -1,3 +1,3 @@
-Issue2788.agda:8,1-28: error: [GenericError]
-Missing option --cubical or --erased-cubical
+Issue2788.agda:8,1-28: error: [NeedOptionCubical]
+Option --cubical or --erased-cubical required
 when checking the pragma BUILTIN EQUIV Equiv

--- a/test/Fail/Issue2788a.err
+++ b/test/Fail/Issue2788a.err
@@ -1,3 +1,3 @@
-Issue2788a.agda:3,1-27: error: [GenericError]
-Missing option --cubical or --erased-cubical
+Issue2788a.agda:3,1-27: error: [NeedOptionCubical]
+Option --cubical or --erased-cubical required
 when checking the pragma BUILTIN INTERVAL I

--- a/test/Fail/Issue2788b.err
+++ b/test/Fail/Issue2788b.err
@@ -1,3 +1,3 @@
-Issue2788b.agda:4,3-15: error: [GenericError]
-Missing option --cubical
+Issue2788b.agda:4,3-15: error: [NeedOptionCubical]
+Option --cubical required
 when checking that the type of the primitive function primGlue is _

--- a/test/Fail/Issue2788c.err
+++ b/test/Fail/Issue2788c.err
@@ -1,3 +1,3 @@
-Issue2788c.agda:8,1-39: error: [GenericError]
-Missing option --cubical or --erased-cubical
+Issue2788c.agda:8,1-39: error: [NeedOptionCubical]
+Option --cubical or --erased-cubical required
 when checking the pragma BUILTIN PATHP PathP

--- a/test/Fail/LiteralTooBig.agda
+++ b/test/Fail/LiteralTooBig.agda
@@ -1,0 +1,14 @@
+-- Andreas, 2024-07-22
+-- Trigger error LiteralTooBig
+
+open import Agda.Builtin.Nat
+
+test : Nat → Set
+test 42 = Nat
+test _  = Nat
+
+-- Expected error:
+-- Matching on natural number literals is done by expanding the
+-- literal to the corresponding constructor pattern, so you probably
+-- don't want to do it this way
+-- when checking that the pattern 42 has type Nat

--- a/test/Fail/LiteralTooBig.err
+++ b/test/Fail/LiteralTooBig.err
@@ -1,0 +1,5 @@
+LiteralTooBig.agda:7,6-8: error: [LiteralTooBig]
+Matching on natural number literals is done by expanding the
+literal to the corresponding constructor pattern, so you probably
+don't want to do it this way
+when checking that the pattern 42 has type Nat

--- a/test/Fail/NoPatternMatching.agda
+++ b/test/Fail/NoPatternMatching.agda
@@ -8,4 +8,5 @@ data Unit : Set where
 
 fail : Unit → Set
 fail unit = Unit
--- Expected error: Pattern matching is disabled
+
+-- Expected error: Pattern matching is disabled (use option --pattern-matching to enable it)

--- a/test/Fail/NoPatternMatching.err
+++ b/test/Fail/NoPatternMatching.err
@@ -1,4 +1,5 @@
-NoPatternMatching.agda:10,1-10: error: [GenericError]
-Pattern matching is disabled
+NoPatternMatching.agda:10,1-10: error: [NeedOptionPatternMatching]
+Pattern matching is disabled (use option --pattern-matching to
+enable it)
 when checking the clause left hand side
 fail unit

--- a/test/Succeed/InvalidDisplayForm.agda
+++ b/test/Succeed/InvalidDisplayForm.agda
@@ -1,0 +1,56 @@
+-- Andreas, 2024-07-23
+-- Trigger warning InvalidDisplayForm
+
+-- Recursive display form.
+
+postulate R : Set
+
+{-# DISPLAY R = R #-}
+
+-- Invalid display form rhss.
+
+postulate
+  A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14 A15 : Set
+
+{-# DISPLAY A0  = Set₁               #-}
+{-# DISPLAY A1  = Set | Set          #-}
+{-# DISPLAY A2  = ?                  #-}
+{-# DISPLAY A3  = _                  #-}
+{-# DISPLAY A4  = .Set               #-}
+{-# DISPLAY A5  = λ x → x            #-}
+{-# DISPLAY A6  = λ()                #-}
+{-# DISPLAY A7  = λ{ x → x }         #-}
+{-# DISPLAY A8  = Set → Set          #-}
+{-# DISPLAY A9  = (X : Set) → X      #-}
+{-# DISPLAY A10 = let x = Set in Set #-}
+{-# DISPLAY A11 = record {}          #-}
+{-# DISPLAY A12 = record Set {}      #-}
+{-# DISPLAY A13 = quote Set          #-}
+{-# DISPLAY A14 = quoteTerm Set      #-}
+{-# DISPLAY A15 = unquote Set        #-}
+
+-- Invalid display form lhss.
+
+data D : Set where
+  c : D
+
+data E : Set where
+  c : E
+
+pattern p = c
+
+postulate
+  L0 L1 L2 L3 L4 L5 : D → Set
+
+{-# DISPLAY L0 x@y         = Set #-}
+{-# DISPLAY L1 .Set        = Set #-}
+{-# DISPLAY L2 ()          = Set #-}
+{-# DISPLAY L3 record{}    = Set #-}
+{-# DISPLAY L4 (Set = Set) = Set #-}
+{-# DISPLAY L5 p           = Set #-}
+
+
+-- Expected behavior:
+--
+-- All display forms in this file should trigger warning InvalidDisplayForm
+-- and be marked as dead code.

--- a/test/Succeed/InvalidDisplayForm.warn
+++ b/test/Succeed/InvalidDisplayForm.warn
@@ -1,0 +1,285 @@
+InvalidDisplayForm.agda:8,1-22
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for R because it is recursive
+when checking the pragma DISPLAY R = R
+
+InvalidDisplayForm.agda:15,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A0 because its right-hand side
+contains a suffix
+when checking the pragma DISPLAY A0 = Set₁
+
+InvalidDisplayForm.agda:16,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A1 because its right-hand side
+contains a with application
+when checking the pragma DISPLAY A1 = Set | Set
+
+InvalidDisplayForm.agda:17,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A2 because its right-hand side
+contains a hole
+when checking the pragma DISPLAY A2 = ?
+
+InvalidDisplayForm.agda:18,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A3 because its right-hand side
+contains a metavariable
+when checking the pragma DISPLAY A3 = _
+
+InvalidDisplayForm.agda:19,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A4 because its right-hand side
+contains a dotted expression
+when checking the pragma DISPLAY A4 = .Set
+
+InvalidDisplayForm.agda:20,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A5 because its right-hand side
+contains a lambda
+when checking the pragma DISPLAY A5 = λ x → x
+
+InvalidDisplayForm.agda:21,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A6 because its right-hand side
+contains a lambda
+when checking the pragma DISPLAY A6 = λ ()
+
+InvalidDisplayForm.agda:22,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A7 because its right-hand side
+contains a lambda
+when checking the pragma DISPLAY A7 = λ { x → x }
+
+InvalidDisplayForm.agda:23,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A8 because its right-hand side
+contains a function type
+when checking the pragma DISPLAY A8 = Set → Set
+
+InvalidDisplayForm.agda:24,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A9 because its right-hand side
+contains a function type
+when checking the pragma DISPLAY A9 = (X : Set) → X
+
+InvalidDisplayForm.agda:25,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A10 because its right-hand side
+contains a let
+when checking the pragma
+DISPLAY A10 =
+          let x : _
+              x = Set
+          in Set
+
+InvalidDisplayForm.agda:26,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A11 because its right-hand side
+contains a record
+when checking the pragma DISPLAY A11 = record {}
+
+InvalidDisplayForm.agda:27,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A12 because its right-hand side
+contains a record update
+when checking the pragma DISPLAY A12 = record Set {}
+
+InvalidDisplayForm.agda:28,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A13 because its right-hand side
+contains a quotation
+when checking the pragma DISPLAY A13 = quote Set
+
+InvalidDisplayForm.agda:29,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A14 because its right-hand side
+contains a quotation
+when checking the pragma DISPLAY A14 = quoteTerm Set
+
+InvalidDisplayForm.agda:30,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A15 because its right-hand side
+contains a unquote
+when checking the pragma DISPLAY A15 = unquote Set
+
+InvalidDisplayForm.agda:45,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L0 because its left-hand side
+contains an @-pattern: x@y
+when checking the pragma DISPLAY L0 x@y = Set
+
+InvalidDisplayForm.agda:46,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L1 because its left-hand side
+contains a dot pattern: .Set
+when checking the pragma DISPLAY L1 .Set = Set
+
+InvalidDisplayForm.agda:47,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L2 because its left-hand side
+contains an absurd pattern: ()
+when checking the pragma DISPLAY L2 () = Set
+
+InvalidDisplayForm.agda:48,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L3 because its left-hand side
+contains a record pattern: record {}
+when checking the pragma DISPLAY L3 record {} = Set
+
+InvalidDisplayForm.agda:49,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L4 because its left-hand side
+contains a system pattern: (Set = Set)
+when checking the pragma DISPLAY L4 (Set = Set) = Set
+
+InvalidDisplayForm.agda:50,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L5 because its left-hand side
+contains an ambiguous constructor: InvalidDisplayForm.D.c,
+InvalidDisplayForm.E.c
+when checking the pragma DISPLAY L5 p = Set
+
+———— All done; warnings encountered ————————————————————————
+
+InvalidDisplayForm.agda:8,1-22
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for R because it is recursive
+when checking the pragma DISPLAY R = R
+
+InvalidDisplayForm.agda:15,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A0 because its right-hand side
+contains a suffix
+when checking the pragma DISPLAY A0 = Set₁
+
+InvalidDisplayForm.agda:16,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A1 because its right-hand side
+contains a with application
+when checking the pragma DISPLAY A1 = Set | Set
+
+InvalidDisplayForm.agda:17,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A2 because its right-hand side
+contains a hole
+when checking the pragma DISPLAY A2 = ?
+
+InvalidDisplayForm.agda:18,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A3 because its right-hand side
+contains a metavariable
+when checking the pragma DISPLAY A3 = _
+
+InvalidDisplayForm.agda:19,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A4 because its right-hand side
+contains a dotted expression
+when checking the pragma DISPLAY A4 = .Set
+
+InvalidDisplayForm.agda:20,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A5 because its right-hand side
+contains a lambda
+when checking the pragma DISPLAY A5 = λ x → x
+
+InvalidDisplayForm.agda:21,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A6 because its right-hand side
+contains a lambda
+when checking the pragma DISPLAY A6 = λ ()
+
+InvalidDisplayForm.agda:22,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A7 because its right-hand side
+contains a lambda
+when checking the pragma DISPLAY A7 = λ { x → x }
+
+InvalidDisplayForm.agda:23,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A8 because its right-hand side
+contains a function type
+when checking the pragma DISPLAY A8 = Set → Set
+
+InvalidDisplayForm.agda:24,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A9 because its right-hand side
+contains a function type
+when checking the pragma DISPLAY A9 = (X : Set) → X
+
+InvalidDisplayForm.agda:25,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A10 because its right-hand side
+contains a let
+when checking the pragma
+DISPLAY A10 =
+          let x : _
+              x = Set
+          in Set
+
+InvalidDisplayForm.agda:26,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A11 because its right-hand side
+contains a record
+when checking the pragma DISPLAY A11 = record {}
+
+InvalidDisplayForm.agda:27,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A12 because its right-hand side
+contains a record update
+when checking the pragma DISPLAY A12 = record Set {}
+
+InvalidDisplayForm.agda:28,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A13 because its right-hand side
+contains a quotation
+when checking the pragma DISPLAY A13 = quote Set
+
+InvalidDisplayForm.agda:29,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A14 because its right-hand side
+contains a quotation
+when checking the pragma DISPLAY A14 = quoteTerm Set
+
+InvalidDisplayForm.agda:30,1-41
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for A15 because its right-hand side
+contains a unquote
+when checking the pragma DISPLAY A15 = unquote Set
+
+InvalidDisplayForm.agda:45,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L0 because its left-hand side
+contains an @-pattern: x@y
+when checking the pragma DISPLAY L0 x@y = Set
+
+InvalidDisplayForm.agda:46,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L1 because its left-hand side
+contains a dot pattern: .Set
+when checking the pragma DISPLAY L1 .Set = Set
+
+InvalidDisplayForm.agda:47,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L2 because its left-hand side
+contains an absurd pattern: ()
+when checking the pragma DISPLAY L2 () = Set
+
+InvalidDisplayForm.agda:48,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L3 because its left-hand side
+contains a record pattern: record {}
+when checking the pragma DISPLAY L3 record {} = Set
+
+InvalidDisplayForm.agda:49,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L4 because its left-hand side
+contains a system pattern: (Set = Set)
+when checking the pragma DISPLAY L4 (Set = Set) = Set
+
+InvalidDisplayForm.agda:50,1-37
+warning: -W[no]InvalidDisplayForm
+Ignoring invalid display form for L5 because its left-hand side
+contains an ambiguous constructor: InvalidDisplayForm.D.c,
+InvalidDisplayForm.E.c
+when checking the pragma DISPLAY L5 p = Set


### PR DESCRIPTION
- New errors LiteralTooBig and NegativeLiteralInPattern replacing GenericError
- New errors NeedOptionCubical and NeedOptionPattern matching
- Generalize RecursiveDisplayForm warning to InvalidDisplayFormWarning, cover reasons to reject DISPLAY forms
