### PR TITLE
Get rid of some MonadFail in favor of __IMPOSSIBLE__

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -10,8 +10,7 @@ module Agda.Compiler.MAlonzo.HaskellTypes
 import Control.Monad         ( zipWithM )
 import Control.Monad.Except  ( ExceptT(ExceptT), runExceptT, mapExceptT, catchError, throwError )
 import Control.Monad.Trans   ( lift )
--- Control.Monad.Fail import is redundant since GHC 8.8.1
-import Control.Monad.Fail (MonadFail)
+
 import Data.Maybe (fromMaybe)
 import Data.List (intercalate)
 
@@ -117,7 +116,7 @@ isData q = do
     Record{}   -> True
     _          -> False
 
-getHsVar :: (MonadFail tcm, MonadTCM tcm) => Nat -> tcm HS.Name
+getHsVar :: (MonadDebug tcm, MonadTCM tcm) => Nat -> tcm HS.Name
 getHsVar i =
   HS.Ident . encodeString (VarK X) . prettyShow <$> nameOfBV i
 

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -33,10 +33,6 @@ import Control.Monad.State
 import Control.Monad.Trans.Maybe
 import qualified Control.Exception as E
 
-#if __GLASGOW_HASKELL__ < 808
-import Control.Monad.Fail (MonadFail)
-#endif
-
 import Data.Either
 import qualified Data.List as List
 import Data.Maybe
@@ -1200,7 +1196,7 @@ createInterface mname file isMain msrc = do
 -- 'MainInterface', the warnings definitely include also unsolved
 -- warnings.
 
-getAllWarnings' :: (MonadFail m, ReadTCState m, MonadWarning m, MonadTCM m) => MainInterface -> WhichWarnings -> m [TCWarning]
+getAllWarnings' :: (ReadTCState m, MonadWarning m, MonadTCM m) => MainInterface -> WhichWarnings -> m [TCWarning]
 getAllWarnings' (MainInterface _) = getAllWarningsPreserving unsolvedWarnings
 getAllWarnings' NotMainInterface  = getAllWarningsPreserving Set.empty
 

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -18,7 +18,6 @@ import qualified Control.Exception  as E
 import Control.Monad
 import Control.Monad.Except         ( MonadError(..), ExceptT(..), runExceptT )
 import Control.Monad.IO.Class       ( MonadIO(..) )
-import Control.Monad.Fail           ( MonadFail )
 import Control.Monad.State          ( MonadState(..), gets, modify, runStateT )
 import Control.Monad.STM
 import Control.Monad.State          ( StateT )
@@ -192,7 +191,7 @@ getOldInteractionScope :: InteractionId -> CommandM ScopeInfo
 getOldInteractionScope ii = do
   ms <- gets $ Map.lookup ii . oldInteractionScopes
   case ms of
-    Nothing    -> fail $ "not an old interaction point: " ++ show ii
+    Nothing    -> __IMPOSSIBLE_VERBOSE__ $ "not an old interaction point: " ++ show ii
     Just scope -> return scope
 
 -- | Do setup and error handling for a command.
@@ -1074,7 +1073,7 @@ highlightExpr e =
 -- | Sorts interaction points based on their ranges.
 
 sortInteractionPoints
-  :: (MonadInteractionPoints m, MonadError TCErr m, MonadFail m)
+  :: (MonadInteractionPoints m, MonadError TCErr m, MonadDebug m)
   => [InteractionId] -> m [InteractionId]
 sortInteractionPoints is =
   map fst . List.sortBy (compare `on` snd) <$> do

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -8,7 +8,6 @@ import Control.DeepSeq (force, NFData(..))
 import Control.Monad
 import Control.Monad.Except (catchError)
 import Control.Monad.Error.Class (MonadError)
-import Control.Monad.Fail (MonadFail)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT(..), runReaderT, asks, ask, lift)
 import Data.Function (on)
@@ -606,7 +605,7 @@ builtinLevelName = "Agda.Primitive.Level"
 -- some constructor, and if so which argument of the function they appeared in. This
 -- information is used when building recursive calls, where it's important that we don't try to
 -- construct non-terminating solutions.
-collectLHSVars :: (MonadFail tcm, ReadTCState tcm, MonadError TCErr tcm, MonadTCM tcm, HasConstInfo tcm)
+collectLHSVars :: (ReadTCState tcm, MonadError TCErr tcm, MonadTCM tcm, HasConstInfo tcm)
   => InteractionId -> tcm (Open [(Term, Maybe Int)])
 collectLHSVars ii = do
   ipc <- ipClause <$> lookupInteractionPoint ii

--- a/src/full/Agda/TypeChecking/CheckInternal.hs-boot
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs-boot
@@ -5,7 +5,6 @@
 module Agda.TypeChecking.CheckInternal where
 
 import Control.Monad.Except
-import qualified Control.Monad.Fail as Fail
 
 import qualified Data.Kind as Hs
 
@@ -22,7 +21,6 @@ type MonadCheckInternal m =
   , MonadStatistics m
   , MonadFresh ProblemId m
   , MonadFresh Int m
-  , Fail.MonadFail m
   )
 
 data Action (m :: Hs.Type -> Hs.Type)

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -10,8 +10,6 @@ module Agda.TypeChecking.Conversion where
 import Control.Arrow (second)
 import Control.Monad
 import Control.Monad.Except
--- Control.Monad.Fail import is redundant since GHC 8.8.1
-import Control.Monad.Fail (MonadFail)
 
 import Data.Function (on)
 import Data.Semigroup ((<>))
@@ -79,7 +77,6 @@ type MonadConversion m =
   , MonadStatistics m
   , MonadFresh ProblemId m
   , MonadFresh Int m
-  , MonadFail m
   )
 
 -- | Try whether a computation runs without errors or new constraints

--- a/src/full/Agda/TypeChecking/Conversion.hs-boot
+++ b/src/full/Agda/TypeChecking/Conversion.hs-boot
@@ -3,7 +3,6 @@
 module Agda.TypeChecking.Conversion where
 
 import Control.Monad.Except ( MonadError )
-import qualified Control.Monad.Fail as Fail
 
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad
@@ -18,7 +17,6 @@ type MonadConversion m =
   , MonadStatistics m
   , MonadFresh ProblemId m
   , MonadFresh Int m
-  , Fail.MonadFail m
   )
 
 compareTerm  :: MonadConversion m => Comparison -> Type -> Term -> Term -> m ()

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -173,7 +173,7 @@ newtype ForcedVariableCollection' a = ForcedVariableCollection
     ( Functor, Applicative, Monad
     , MonadReader ForcedVariableContext, MonadState ForcedVariableState
     -- Needed for HasConstInfo:
-    , MonadFail, MonadDebug, MonadTCEnv, HasOptions
+    , MonadDebug, MonadTCEnv, HasOptions
     , HasConstInfo
     -- Neded for MonadReduce:
     , ReadTCState

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -461,9 +461,9 @@ invertFunction cmp blk (Inv f blkArgs hdMap) hd fallback err success = do
                 ]
               return RollBackMetas
   where
-    nextMeta :: (MonadState [Term] m, MonadFail m) => m Term
+    nextMeta :: (MonadState [Term] m) => m Term
     nextMeta = do
-      m : ms <- get
+      (m, ms) <- fromMaybe __IMPOSSIBLE__ . uncons <$> get
       put ms
       return m
 
@@ -473,18 +473,18 @@ invertFunction cmp blk (Inv f blkArgs hdMap) hd fallback err success = do
       return $ applySubst sub v
 
     metaElim
-      :: (MonadState [Term] m, MonadReader Substitution m, HasConstInfo m, MonadFail m)
+      :: (MonadState [Term] m, MonadReader Substitution m, HasConstInfo m)
       => Arg DeBruijnPattern -> m Elim
     metaElim (Arg _ (ProjP o p))  = Proj o <$> getOriginalProjection p
     metaElim (Arg info p)         = Apply . Arg info <$> metaPat p
 
     metaArgs
-      :: (MonadState [Term] m, MonadReader Substitution m, MonadFail m)
+      :: (MonadState [Term] m, MonadReader Substitution m)
       => [NamedArg DeBruijnPattern] -> m Args
     metaArgs args = mapM (traverse $ metaPat . namedThing) args
 
     metaPat
-      :: (MonadState [Term] m, MonadReader Substitution m, MonadFail m)
+      :: (MonadState [Term] m, MonadReader Substitution m)
       => DeBruijnPattern -> m Term
     metaPat (DotP _ v)       = dotP v
     metaPat (VarP _ _)       = nextMeta

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -4,8 +4,6 @@ module Agda.TypeChecking.Monad.Signature where
 
 import Prelude hiding (null)
 
-import qualified Control.Monad.Fail as Fail
-
 import Control.Arrow                 ( first, second )
 import Control.Monad
 import Control.Monad.Except          ( ExceptT )
@@ -881,7 +879,6 @@ sigError a = \case
 
 class ( Functor m
       , Applicative m
-      , Fail.MonadFail m
       , HasOptions m
       , MonadDebug m
       , MonadTCEnv m

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
@@ -2,7 +2,6 @@
 
 module Agda.TypeChecking.Monad.Signature where
 
-import qualified Control.Monad.Fail as Fail
 import Control.Monad.Reader
 import Control.Monad.State
 
@@ -23,7 +22,6 @@ notSoPrettySigCubicalNotErasure :: QName -> String
 
 class ( Functor m
       , Applicative m
-      , Fail.MonadFail m
       , HasOptions m
       , MonadDebug m
       , MonadTCEnv m

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -5,9 +5,6 @@ import Prelude hiding ( null )
 
 import Control.Monad ( guard, filterM, (<=<) )
 
--- Control.Monad.Fail import is redundant since GHC 8.8.1
-import Control.Monad.Fail ( MonadFail )
-
 import Data.Char ( toLower )
 import Data.Function (on)
 import Data.IntSet (IntSet)
@@ -687,7 +684,7 @@ isBoundaryConstraint c =
     g (a, _, _, _) = getRange a
 
 {-# SPECIALIZE getAllUnsolvedWarnings :: TCM [TCWarning] #-}
-getAllUnsolvedWarnings :: (MonadFail m, ReadTCState m, MonadWarning m, MonadTCM m) => m [TCWarning]
+getAllUnsolvedWarnings :: (ReadTCState m, MonadWarning m, MonadTCM m) => m [TCWarning]
 getAllUnsolvedWarnings = do
   unsolvedInteractions <- getUnsolvedInteractionMetas
 
@@ -709,12 +706,12 @@ getAllUnsolvedWarnings = do
 -- | Collect all warnings that have accumulated in the state.
 
 {-# SPECIALIZE getAllWarnings :: WhichWarnings -> TCM [TCWarning] #-}
-getAllWarnings :: (MonadFail m, ReadTCState m, MonadWarning m, MonadTCM m) => WhichWarnings -> m [TCWarning]
+getAllWarnings :: (ReadTCState m, MonadWarning m, MonadTCM m) => WhichWarnings -> m [TCWarning]
 getAllWarnings = getAllWarningsPreserving Set.empty
 
 {-# SPECIALIZE getAllWarningsPreserving :: Set WarningName -> WhichWarnings -> TCM [TCWarning] #-}
 getAllWarningsPreserving ::
-  (MonadFail m, ReadTCState m, MonadWarning m, MonadTCM m) => Set WarningName -> WhichWarnings -> m [TCWarning]
+  (ReadTCState m, MonadWarning m, MonadTCM m) => Set WarningName -> WhichWarnings -> m [TCWarning]
 getAllWarningsPreserving keptWarnings ww = do
   unsolved            <- getAllUnsolvedWarnings
   collectedTCWarnings <- useTC stTCWarnings

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -792,7 +792,7 @@ etaExpandAtRecordType t u = do
 {-# SPECIALIZE etaContractRecord :: QName -> ConHead -> ConInfo -> Args -> ReduceM Term #-}
 etaContractRecord :: HasConstInfo m => QName -> ConHead -> ConInfo -> Args -> m Term
 etaContractRecord r c ci args = if all (not . usableModality) args then fallBack else do
-  Just RecordData{ _recFields = xs } <- isRecord r
+  RecordData{ _recFields = xs } <- fromMaybe __IMPOSSIBLE__ <$> isRecord r
   reportSDoc "tc.record.eta.contract" 20 $ vcat
     [ "eta contracting record"
     , nest 2 $ vcat

--- a/src/full/Agda/Utils/Cluster.hs
+++ b/src/full/Agda/Utils/Cluster.hs
@@ -12,7 +12,7 @@ module Agda.Utils.Cluster
 import Control.Monad
 
 -- An imperative union-find library:
-import Data.Equivalence.Monad ( runEquivT, equateAll, classDesc )
+import Data.Equivalence.Monad ( runEquivM, equateAll, classDesc )
 
 -- NB: We keep this module independent of Agda.Utils.List1
 import Data.List.NonEmpty     ( NonEmpty(..), nonEmpty, toList )
@@ -22,7 +22,6 @@ import qualified Data.Map.Strict as MapS
 
 import Agda.Utils.Functor
 import Agda.Utils.Singleton
-import Agda.Utils.Fail
 
 -- | Given a function @f :: a -> NonEmpty c@ which returns a non-empty list of
 --   characteristics of @a@, partition a list of @a@s into groups such
@@ -58,7 +57,7 @@ cluster1 f as = cluster1' $ fmap (\ a -> (a, f a)) as
 --   shares at least one characteristic with at least one other
 --   element of the group.
 cluster1' :: Ord c => NonEmpty (a, NonEmpty c) -> NonEmpty (NonEmpty a)
-cluster1' acs = runFail_ $ runEquivT id const $ do
+cluster1' acs = runEquivM id const $ do
   -- Construct the equivalence classes of characteristics.
   forM_ acs $ \ (_, c :| cs) -> equateAll $ c:cs
   -- Pair each element with its class.

--- a/test/interaction/Issue2552.out
+++ b/test/interaction/Issue2552.out
@@ -6,6 +6,6 @@
 ((last . 1) . (agda2-goals-action '()))
 (agda2-status-action "Checked")
 (agda2-info-action "*Inferred Type*" "Set" nil)
-(agda2-info-action "*Error*" "1,1-4: error: [InternalError] Panic: unbound variable foo (id: 2@ModuleNameHash 16937846059894629291) when inferring the type of foo" nil)
-(agda2-highlight-load-and-delete-action)
+(agda2-info-action "*Error*" "An internal error has occurred. Please report this as a bug. Location of the error: __IMPOSSIBLE_VERBOSE__, called at src/full/Agda/TypeChecking/Monad/Context.hs:«line»:«col» «Agda-package»:Agda.TypeChecking.Monad.Context" nil)
+(agda2-highlight-add-annotations 'nil)
 (agda2-status-action "")


### PR DESCRIPTION
Unbound variables and interaction points are no longer handled with `fail` but with `__IMPOSSIBLE__` or named errors.

Unfortunately, we have some unfixed internal error that will now reported as `__IMPOSSIBLE__`:
- #2552