### PR TITLE
Remove MonadFail from NamesT and HasBuiltins

### DIFF
--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1484,7 +1484,7 @@ instance Reify Sort where
         I.Inf u 0 -> return $ A.Def' (nameOfUniv ULarge u) A.NoSuffix
         I.Inf u n -> return $ A.Def' (nameOfUniv ULarge u) (A.Suffix n)
         I.SizeUniv  -> do
-          I.Def sizeU [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSizeUniv
+          sizeU <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinSizeUniv
           return $ A.Def sizeU
         I.LockUniv  -> do
           lockU <- fromMaybe __IMPOSSIBLE__ <$> getName' builtinLockUniv

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -11,8 +11,6 @@ import Prelude hiding (null)
 
 import Control.Applicative hiding (empty)
 
-import qualified Control.Monad.Fail as Fail
-
 import Control.Monad          ( forM )
 import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.Except
@@ -179,7 +177,6 @@ newtype TerM a = TerM { terM :: ReaderT TerEnv TCM a }
   deriving ( Functor
            , Applicative
            , Monad
-           , Fail.MonadFail
            , MonadError TCErr
            , MonadStatistics
            , HasOptions

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -165,10 +165,12 @@ instance CheckInternal Term where
       Con c ci vs -> do
         -- We need to fully apply the constructor to make getConType work!
         fullyApplyCon c vs t $ \ _d _dt _pars a vs' tel t -> do
-          Con c ci vs2 <- checkSpine action a (Con c ci) vs' cmp t
-          -- Strip away the extra arguments
-          return $ applySubst (strengthenS impossible (size tel))
-            $ Con c ci $ take (length vs) vs2
+          checkSpine action a (Con c ci) vs' cmp t >>= \case
+            Con c ci vs2 ->
+              -- Strip away the extra arguments
+              return $ applySubst (strengthenS impossible (size tel))
+                $ Con c ci $ take (length vs) vs2
+            _ -> __IMPOSSIBLE__
       Lit l      -> do
         lt <- litType l
         compareType cmp lt t

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -718,7 +718,10 @@ compareAtom cmp t m n =
                   s = tmSort $ unArg la
                   sucla = lsuc <$> la
               bA <- runNamesT [] $ do
-                [la,phi,bT,bAS] <- mapM (open . unArg) [la,phi,bT,bAS]
+                la  <- open . unArg $ la
+                phi <- open . unArg $ phi
+                bT  <- open . unArg $ bT
+                bAS <- open . unArg $ bAS
                 (pure tSubOut <#> (pure tLSuc <@> la) <#> (Sort . tmSort <$> la) <#> phi <#> (bT <@> primIZero) <@> bAS)
               compareAtom cmp (AsTermsOf $ El (tmSort . unArg $ sucla) $ apply tHComp $ [sucla, argH (Sort s), phi] ++ [argH (unArg bT), argH bA])
                               (unArg b) (unArg b')
@@ -785,7 +788,8 @@ compareMetas cmp t x xArgs y yArgs | x == y = blockOnError (unblockOnMeta x) $ d
          -- not all relevant arguments are variables
          Nothing -> fallback
 compareMetas cmp t x xArgs y yArgs = do
-  [p1, p2] <- mapM getMetaPriority [x,y]
+  p1 <- getMetaPriority x
+  p2 <- getMetaPriority y
   let dir = fromCmp cmp
       rid = flipCmp dir     -- The reverse direction.  Bad name, I know.
       retry = patternViolation alwaysUnblock

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -483,13 +483,13 @@ isLitP (DotP _ u) = reduce u >>= \case
   Lit l -> return $ Just l
   _ -> return $ Nothing
 isLitP (ConP c ci []) = do
-  Con zero _ [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinZero
-  if c == zero
+  zero <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinZero
+  if conName c == zero
     then return $ Just $ LitNat 0
     else return Nothing
 isLitP (ConP c ci [a]) | visible a && isRelevant a = do
-  Con suc _ [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSuc
-  if c == suc
+  suc <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinSuc
+  if conName c == suc
     then fmap inc <$> isLitP (namedArg a)
     else return Nothing
   where

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -53,7 +53,7 @@ levelType' =
 isLevelType :: PureTCM m => Type -> m Bool
 isLevelType a = reduce (unEl a) >>= \case
   Def f [] -> do
-    Def lvl [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevel
+    lvl <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinLevel
     return $ f == lvl
   _ -> return False
 
@@ -61,38 +61,38 @@ isLevelType a = reduce (unEl a) >>= \case
 {-# SPECIALIZE builtinLevelKit :: ReduceM LevelKit #-}
 builtinLevelKit :: (HasBuiltins m) => m LevelKit
 builtinLevelKit = do
-    level@(Def l [])     <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevel
-    zero@(Def z [])      <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelZero
-    suc@(Def s [])       <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelSuc
-    max@(Def m [])       <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelMax
+    level <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinLevel
+    zero  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinLevelZero
+    suc   <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinLevelSuc
+    max   <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinLevelMax
     return $ LevelKit
-      { lvlType  = level
-      , lvlSuc   = \ a -> suc `apply1` a
-      , lvlMax   = \ a b -> max `applys` [a, b]
-      , lvlZero  = zero
-      , typeName = l
-      , sucName  = s
-      , maxName  = m
-      , zeroName = z
+      { lvlType  = Def level []
+      , lvlSuc   = \ a -> Def suc [] `apply1` a
+      , lvlMax   = \ a b -> Def max [] `applys` [a, b]
+      , lvlZero  = Def zero []
+      , typeName = level
+      , sucName  = suc
+      , maxName  = max
+      , zeroName = zero
       }
 
 {-# SPECIALIZE requireLevels :: TCM LevelKit #-}
 -- | Raises an error if no level kit is available.
 requireLevels :: (HasBuiltins m, MonadTCError m) => m LevelKit
 requireLevels = do
-    level@(Def l [])     <- getBuiltin builtinLevel
-    zero@(Def z [])      <- getBuiltin builtinLevelZero
-    suc@(Def s [])       <- getBuiltin builtinLevelSuc
-    max@(Def m [])       <- getBuiltin builtinLevelMax
+    level <- getBuiltinName_ builtinLevel
+    zero  <- getBuiltinName_ builtinLevelZero
+    suc   <- getBuiltinName_ builtinLevelSuc
+    max   <- getBuiltinName_ builtinLevelMax
     return $ LevelKit
-      { lvlType  = level
-      , lvlSuc   = \ a -> suc `apply1` a
-      , lvlMax   = \ a b -> max `applys` [a, b]
-      , lvlZero  = zero
-      , typeName = l
-      , sucName  = s
-      , maxName  = m
-      , zeroName = z
+      { lvlType  = Def level []
+      , lvlSuc   = \ a -> Def suc [] `apply1` a
+      , lvlMax   = \ a b -> Def max [] `applys` [a, b]
+      , lvlZero  = Def zero []
+      , typeName = level
+      , sucName  = suc
+      , maxName  = max
+      , zeroName = zero
       }
 
 -- | Checks whether level kit is fully available.
@@ -132,16 +132,6 @@ unConstV zer suc n = foldr ($) zer (List.genericReplicate n suc)
 unPlusV :: (Term -> Term) -> PlusLevel -> Term
 unPlusV suc (Plus n a) = foldr ($) a (List.genericReplicate n suc)
 
-maybePrimCon :: TCM Term -> TCM (Maybe ConHead)
-maybePrimCon prim = tryMaybe $ do
-    Con c ci [] <- prim
-    return c
-
-maybePrimDef :: TCM Term -> TCM (Maybe QName)
-maybePrimDef prim = tryMaybe $ do
-    Def f [] <- prim
-    return f
-
 {-# SPECIALIZE levelView :: Term -> TCM Level #-}
 levelView :: PureTCM m => Term -> m Level
 levelView a = do
@@ -153,9 +143,9 @@ levelView a = do
 {-# SPECIALIZE levelView' :: Term -> TCM Level #-}
 levelView' :: PureTCM m => Term -> m Level
 levelView' a = do
-  Def lzero [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelZero
-  Def lsuc  [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelSuc
-  Def lmax  [] <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinLevelMax
+  lzero <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinLevelZero
+  lsuc  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinLevelSuc
+  lmax  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinLevelMax
   let view a = do
         ba <- reduceB a
         case ignoreBlocking ba of

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -41,7 +41,7 @@ import Agda.Utils.Impossible
 
 class ( Functor m
       , Applicative m
-      , Fail.MonadFail m
+      , Monad m
       ) => HasBuiltins m where
   getBuiltinThing :: SomeBuiltin -> m (Maybe (Builtin PrimFun))
 
@@ -152,6 +152,21 @@ getBuiltinRewriteRelations' = fmap rels <$> getBuiltinThing (BuiltinName builtin
     Prim{}    -> __IMPOSSIBLE__
     Builtin{} -> __IMPOSSIBLE__
 
+{-# INLINABLE getBuiltinName_ #-}
+getBuiltinName_ :: (HasBuiltins m, MonadTCError m)
+  => BuiltinId -> m QName
+getBuiltinName_ x =
+  fromMaybeM (typeError $ NoBindingForBuiltin x) $ getBuiltinName' x
+
+-- {-# INLINABLE getBuiltinName' #-}
+-- -- | Returns 'Nothing' if built-in is not bound or bound to a 'Prim' or anything other than a 'Def'.
+-- getBuiltinName' :: HasBuiltins m => BuiltinId -> m (Maybe Term)
+-- getBuiltinName' x = (getBuiltinName =<<) <$> getBuiltin' x
+--   where
+--     getBuiltinName = \case
+--       Def f [] -> Just f
+--       _        -> Nothing
+
 {-# INLINABLE getBuiltin #-}
 getBuiltin :: (HasBuiltins m, MonadTCError m)
            => BuiltinId -> m Term
@@ -159,19 +174,24 @@ getBuiltin x =
   fromMaybeM (typeError $ NoBindingForBuiltin x) $ getBuiltin' x
 
 {-# INLINABLE getBuiltin' #-}
+-- | Returns 'Nothing' if built-in is not bound or bound to a 'Prim'.
 getBuiltin' :: HasBuiltins m => BuiltinId -> m (Maybe Term)
-getBuiltin' x = (getBuiltin =<<) <$> getBuiltinThing (BuiltinName x) where
-  getBuiltin BuiltinRewriteRelations{} = __IMPOSSIBLE__
-  getBuiltin (Builtin t)               = Just $ killRange t
-  getBuiltin _                         = Nothing
+getBuiltin' x = (getBuiltin =<<) <$> getBuiltinThing (BuiltinName x)
+  where
+    getBuiltin = \case
+      Builtin t                 -> Just $ killRange t
+      Prim{}                    -> Nothing
+      BuiltinRewriteRelations{} -> __IMPOSSIBLE__
 
 {-# INLINABLE getPrimitive' #-}
+-- | Returns 'Nothing' if primitive is not bound or bound to a 'Builtin'.
 getPrimitive' :: HasBuiltins m => PrimitiveId -> m (Maybe PrimFun)
 getPrimitive' x = (getPrim =<<) <$> getBuiltinThing (PrimitiveName x)
   where
-    getPrim (Prim pf) = return pf
-    getPrim BuiltinRewriteRelations{} = __IMPOSSIBLE__
-    getPrim _         = Nothing
+    getPrim = \case
+      Prim pf                   -> return pf
+      Builtin{}                 -> Nothing
+      BuiltinRewriteRelations{} -> __IMPOSSIBLE__
 
 {-# INLINABLE getPrimitive #-}
 getPrimitive :: (HasBuiltins m, MonadError TCErr m, MonadTCEnv m, ReadTCState m)
@@ -529,9 +549,9 @@ data CoinductionKit = CoinductionKit
 
 coinductionKit' :: TCM CoinductionKit
 coinductionKit' = do
-  Def inf   _ <- primInf
-  Def sharp _ <- primSharp
-  Def flat  _ <- primFlat
+  inf   <- getBuiltinName_ builtinInf
+  sharp <- getBuiltinName_ builtinSharp
+  flat  <- getBuiltinName_ builtinFlat
   return $ CoinductionKit
     { nameOfInf   = inf
     , nameOfSharp = sharp
@@ -574,12 +594,12 @@ mkSortKit prop set sset propomega setomega ssetomega = SortKit
 -- we report a type error rather than exploding.
 sortKit :: (HasBuiltins m, MonadTCError m, HasOptions m) => m SortKit
 sortKit = do
-  Def prop     _  <- getBuiltin builtinProp
-  Def set      _  <- getBuiltin builtinSet
-  Def sset     _  <- getBuiltin builtinStrictSet
-  Def propomega _ <- getBuiltin builtinPropOmega
-  Def setomega _  <- getBuiltin builtinSetOmega
-  Def ssetomega _ <- getBuiltin builtinSSetOmega
+  prop      <- getBuiltinName_ builtinProp
+  set       <- getBuiltinName_ builtinSet
+  sset      <- getBuiltinName_ builtinStrictSet
+  propomega <- getBuiltinName_ builtinPropOmega
+  setomega  <- getBuiltinName_ builtinSetOmega
+  ssetomega <- getBuiltinName_ builtinSSetOmega
   return $ mkSortKit prop set sset propomega setomega ssetomega
 
 -- | Compute a 'SortKit' in contexts that do not support failure (e.g.
@@ -588,12 +608,12 @@ sortKit = do
 -- checking.
 infallibleSortKit :: HasBuiltins m => m SortKit
 infallibleSortKit = do
-  Def prop     _  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinProp
-  Def set      _  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSet
-  Def sset     _  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinStrictSet
-  Def propomega _ <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinPropOmega
-  Def setomega _  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSetOmega
-  Def ssetomega _ <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSSetOmega
+  prop      <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinProp
+  set       <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinSet
+  sset      <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinStrictSet
+  propomega <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinPropOmega
+  setomega  <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinSetOmega
+  ssetomega <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinSSetOmega
   return $ mkSortKit prop set sset propomega setomega ssetomega
 
 ------------------------------------------------------------------------
@@ -753,7 +773,6 @@ conidView' = do
 
 -- | Get the name of the equality type.
 primEqualityName :: TCM QName
--- primEqualityName = getDef =<< primEquality  -- LEADS TO IMPORT CYCLE
 primEqualityName = do
   eq <- primEquality
   -- Andreas, 2014-05-17 moved this here from TC.Rules.Def

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs-boot
@@ -7,14 +7,12 @@ import Control.Monad.State          ( StateT )
 import Control.Monad.Trans.Identity ( IdentityT )
 import Control.Monad.Trans          ( MonadTrans, lift )
 
-import qualified Control.Monad.Fail as Fail
-
 import Agda.TypeChecking.Monad.Base (TCMT, Builtin, PrimFun)
 import Agda.Syntax.Builtin (SomeBuiltin)
 
 class ( Functor m
       , Applicative m
-      , Fail.MonadFail m
+      , Monad m
       ) => HasBuiltins m where
   getBuiltinThing :: SomeBuiltin -> m (Maybe (Builtin PrimFun))
   default getBuiltinThing :: (MonadTrans t, HasBuiltins n, t n ~ m) => SomeBuiltin -> m (Maybe (Builtin PrimFun))

--- a/src/full/Agda/TypeChecking/Names.hs
+++ b/src/full/Agda/TypeChecking/Names.hs
@@ -19,9 +19,6 @@ runNames [] $ do
 -}
 module Agda.TypeChecking.Names where
 
--- Control.Monad.Fail import is redundant since GHC 8.8.1
-import Control.Monad.Fail (MonadFail)
-
 import Control.Monad          ( liftM2, unless )
 import Control.Monad.Except   ( MonadError )
 import Control.Monad.Identity ( Identity, runIdentity )
@@ -48,7 +45,6 @@ newtype NamesT m a = NamesT { unName :: ReaderT Names m a }
   deriving ( Functor
            , Applicative
            , Monad
-           , MonadFail
            , MonadTrans
            , MonadState s
            , MonadIO

--- a/src/full/Agda/TypeChecking/Patterns/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Abstract.hs
@@ -35,11 +35,11 @@ expandLitPattern = \case
     | n < 0     -> typeError NegativeLiteralInPattern  -- Andreas, issue #2365, negative literals not yet supported.
     | n > 20    -> typeError LiteralTooBig
     | otherwise -> do
-      Con z _ _ <- primZero
-      Con s _ _ <- primSuc
+      z <- getBuiltinName_ builtinZero
+      s <- getBuiltinName_ builtinSuc
       let r     = getRange info
-      let zero  = A.ConP cinfo (unambiguous $ setRange r $ conName z) []
-          suc p = A.ConP cinfo (unambiguous $ setRange r $ conName s) [defaultNamedArg p]
+      let zero  = A.ConP cinfo (unambiguous $ setRange r z) []
+          suc p = A.ConP cinfo (unambiguous $ setRange r s) [defaultNamedArg p]
           cinfo = A.ConPatInfo ConOCon info ConPatEager
       return $ foldr ($) zero $ List.genericReplicate n suc
   p -> return p

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -284,7 +284,8 @@ matchPattern p u = case (p, u) of
   -- can be matched on.
   isMatchable' :: HasBuiltins m => m (Blocked Term -> Maybe Term)
   isMatchable' = do
-    [mhcomp,mconid] <- mapM getName' [builtinHComp, builtinConId]
+    mhcomp <- getName' builtinHComp
+    mconid <- getName' builtinConId
     return $ \ r ->
       case ignoreBlocking r of
         t@Con{} -> Just t

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -835,7 +835,7 @@ instance PrettyTCM (Seq OccursWhere) where
                           [prettyTCM q]
         UnderInf     -> pwords "under" ++
                         [do -- this cannot fail if an 'UnderInf' has been generated
-                            Def inf _ <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinInf
+                            inf <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinInf
                             prettyTCM inf]
         VarArg       -> pwords "in an argument of a bound variable"
         MetaArg      -> pwords "in an argument of a metavariable"

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -3,8 +3,6 @@
 module Agda.TypeChecking.Primitive.Base where
 
 import Control.Monad             ( mzero )
-import Control.Monad.Fail        ( MonadFail )
-  -- Control.Monad.Fail import is redundant since GHC 8.8.1
 import Control.Monad.Trans.Maybe ( MaybeT(..), runMaybeT )
 
 import qualified Data.Map as Map
@@ -62,7 +60,7 @@ hPi, nPi :: (MonadAddContext m, MonadDebug m)
 hPi = gpi $ setHiding Hidden defaultArgInfo
 nPi = gpi defaultArgInfo
 
-hPi', nPi' :: (MonadFail m, MonadAddContext m, MonadDebug m)
+hPi', nPi' :: (MonadAddContext m, MonadDebug m)
            => String -> NamesT m Type -> (NamesT m Term -> NamesT m Type) -> NamesT m Type
 hPi' s a b = hPi s a (bind' s (\ x -> b x))
 nPi' s a b = nPi s a (bind' s (\ x -> b x))

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -428,7 +428,8 @@ primTransHComp cmd ts nelims = do
             -- regardless of how big the original term is, and
             -- isOneEmpty is *tiny*, so let's use that:
             IZero -> fmap (reduced . notBlocked . argN) . runNamesT [] $ do
-                [l,c] <- mapM (open . unArg) [famThing l, ignoreBlocking sc]
+                l <- open . unArg . famThing $ l
+                c <- open . unArg . ignoreBlocking $ sc
                 lam "i" $ \ i -> clP builtinIsOneEmpty <#> l <#> ilam "o" (\ _ -> c)
 
             -- Otherwise we have some interesting formula (though
@@ -618,7 +619,8 @@ primTransHComp cmd ts nelims = do
             where
               su' = case view phi of
                      IZero -> notBlocked $ argN $ runNames [] $ do
-                                 [l,c] <- mapM (open . unArg) [l,ignoreBlocking sc]
+                                 l <- open . unArg $ l
+                                 c <- open . unArg . ignoreBlocking $ sc
                                  lam "i" $ \ i -> pure tEmpty <#> l
                                                               <#> ilam "o" (\ _ -> c)
                      _     -> su

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
@@ -111,8 +111,15 @@ doGlueKanOp (HCompOp psi u u0) (IsNot (la, lb, bA, phi, bT, e)) tpos = do
   view     <- intervalView'
 
   runNamesT [] $ do
-    [psi, u, u0] <- mapM (open . unArg) [ignoreBlocking psi, u, u0]
-    [la, lb, bA, phi, bT, e] <- mapM (open . unArg) [la, lb, bA, phi, bT, e]
+    psi <- open . unArg $ ignoreBlocking psi
+    u   <- open . unArg $ u
+    u0  <- open . unArg $ u0
+    la  <- open . unArg $ la
+    lb  <- open . unArg $ lb
+    bA  <- open . unArg $ bA
+    phi <- open . unArg $ phi
+    bT  <- open . unArg $ bT
+    e   <- open . unArg $ e
 
     ifM (headStop tpos phi) (return Nothing) $ Just <$> do
     let
@@ -164,8 +171,15 @@ doGlueKanOp (TranspOp psi u0) (IsFam (la, lb, bA, phi, bT, e)) tpos = do
                       <@> lam "j" (\ j -> bA <@> imin i j)
                       <@> (imax phi (ineg i))
                       <@> u0
-    [psi,u0] <- mapM (open . unArg) [ignoreBlocking psi,u0]
-    [la, lb, bA, phi, bT, e] <- mapM (\ a -> open . runNames [] $ lam "i" (const (pure $ unArg a))) [la, lb, bA, phi, bT, e]
+    psi <- open . unArg $ ignoreBlocking psi
+    u0  <- open . unArg $ u0
+    let lami = open . runNames [] . lam "i" . const . pure . unArg
+    la  <- lami la
+    lb  <- lami lb
+    bA  <- lami bA
+    phi <- lami phi
+    bT  <- lami bT
+    e   <- lami e
 
     -- Andreas, 2022-03-24, fixing #5838
     -- Following the updated note

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/HCompU.hs
@@ -63,8 +63,13 @@ doHCompUKanOp (HCompOp psi u u0) (IsNot (la, phi, bT, bA)) tpos = do
   tSubIn   <- getTermLocal builtinSubIn
   tItIsOne <- getTermLocal builtinItIsOne
   runNamesT [] $ do
-    [psi, u, u0] <- mapM (open . unArg) [ignoreBlocking psi, u, u0]
-    [la, phi, bT, bA] <- mapM (open . unArg) [la, phi, bT, bA]
+    psi <- open . unArg $ ignoreBlocking psi
+    u   <- open . unArg $ u
+    u0  <- open . unArg $ u0
+    la  <- open . unArg $ la
+    phi <- open . unArg $ phi
+    bT  <- open . unArg $ bT
+    bA  <- open . unArg $ bA
 
     ifM (headStop tpos phi) (return Nothing) $ Just <$> do
 
@@ -122,9 +127,14 @@ doHCompUKanOp (TranspOp psi u0) (IsFam (la, phi, bT, bA)) tpos = do
         <@> (imax phi (ineg i))
         <@> u0
 
-    [psi, u0] <- mapM (open . unArg) [ignoreBlocking psi, u0]
+    psi <- open . unArg . ignoreBlocking $ psi
+    u0  <- open . unArg $ u0
 
-    [la, phi, bT, bA] <- mapM (\a -> open . runNames [] $ lam "i" (const (pure $ unArg a))) [la, phi, bT, bA]
+    let lami = open . runNames [] . lam "i" . const . pure . unArg
+    la  <- lami la
+    phi <- lami phi
+    bT  <- lami bT
+    bA  <- lami bA
 
     -- Andreas, 2022-03-25, issue #5838.
     -- Port the fix of @unglueTranspGlue@ and @doGlueKanOp DoTransp@
@@ -253,7 +263,9 @@ prim_unglueU' = do
           iNeg    <- getTerm (getBuiltinId builtin_unglueU) builtinINeg
           iZ      <- getTerm (getBuiltinId builtin_unglueU) builtinIZero
           redReturn <=< runNamesT [] $ do
-            [la,bT,b] <- mapM (open . unArg) [la,bT,b]
+            la <- open . unArg $ la
+            bT <- open . unArg $ bT
+            b  <- open . unArg $ b
             pure tTransp <#> lam "i" (\ _ -> la) <@> lam "i" (\ i -> bT <@> ineg i <..> pure one)
               <@> pure iZ <@> b
 

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Id.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Id.hs
@@ -263,11 +263,19 @@ doIdKanOp kanOp l bA_x_y = do
         -- Similarly to the fake line of levels above, fake lines of
         -- everything even when we're doing composition, for uniformity
         -- of eval.
-        [bA, x, y] <- case bA_x_y of
-          IsFam (bA, x, y) -> for [bA, x, y] $ \a ->
-            open $ runNames [] $ lam "i" (const (pure $ unArg a))
-          IsNot (bA, x, y) -> for [bA, x, y] $ \a ->
-            open (Lam defaultArgInfo $ NoAbs "_" $ unArg a)
+        (bA, x, y) <- case bA_x_y of
+          IsFam (bA, x, y) -> do
+            let lami = open . runNames [] . lam "i" . const . pure . unArg
+            bA <- lami bA
+            x  <- lami x
+            y  <- lami y
+            pure (bA, x, y)
+          IsNot (bA, x, y) -> do
+            let lam_ = open . Lam defaultArgInfo . NoAbs "_" . unArg
+            bA <- lam_ bA
+            x  <- lam_ x
+            y  <- lam_ y
+            pure (bA, x, y)
 
         -- The resulting path is constant when when
         --    @Σ φ λ o → -- primIdFace p i1 o@

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -178,7 +178,7 @@ instance Match [Elim' NLPat] Elims where
 
     (IApply x y p , IApply u v i) -> addContext k (pathView =<< reduce t) >>= \case
       PathType s q l b _u _v -> do
-        Right interval <- runExceptT primIntervalType
+        interval <- fromRight __IMPOSSIBLE__ <$> runExceptT primIntervalType
         match r gamma k interval p i
         let t' = El s $ unArg b `apply` [ defaultArg i ]
         let hd' = hd . (IApply u v i:)

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1702,11 +1702,15 @@ checkPOr c rs vs _ = do
       phi <- intervalUnview (IMin phi1 phi2)
       reportSDoc "tc.term.por" 10 $ text (show phi)
       t1 <- runNamesT [] $ do
-             [l,a] <- mapM (open . unArg) [l,a]
+             l <- open . unArg $ l
+             a <- open . unArg $ a
              psi <- open =<< intervalUnview (IMax phi1 phi2)
              pPi' "o" psi $ \ o -> el' l (a <..> o)
       tv <- runNamesT [] $ do
-             [l,a,phi1,phi2] <- mapM (open . unArg) [l,a,phi1,phi2]
+             l    <- open . unArg $ l
+             a    <- open . unArg $ a
+             phi1 <- open . unArg $ phi1
+             phi2 <- open . unArg $ phi2
              pPi' "o" phi2 $ \ o -> el' l (a <..> (cl primIsOne2 <@> phi1 <@> phi2 <@> o))
       v <- blockArg tv (rs !!! 5) v $ do
         -- ' φ₁ ∧ φ₂  ⊢ u , v : PartialP (φ₁ ∨ φ₂) \ o → a o
@@ -1726,11 +1730,19 @@ check_glue c rs vs _ = do
    la : lb : bA : phi : bT : e : t : a : rest -> do
       let iinfo = setRelevance Irrelevant defaultArgInfo
       v <- runNamesT [] $ do
-            [lb, la, bA, phi, bT, e, t] <- mapM (open . unArg) [lb, la, bA, phi, bT, e, t]
+            lb  <- open . unArg $ lb
+            la  <- open . unArg $ la
+            bA  <- open . unArg $ bA
+            phi <- open . unArg $ phi
+            bT  <- open . unArg $ bT
+            e   <- open . unArg $ e
+            t   <- open . unArg $ t
             let f o = cl primEquivFun <#> lb <#> la <#> (bT <..> o) <#> bA <@> (e <..> o)
             glam iinfo "o" $ \ o -> f o <@> (t <..> o)
       ty <- runNamesT [] $ do
-            [lb, phi, bA] <- mapM (open . unArg) [lb, phi, bA]
+            lb  <- open . unArg $ lb
+            phi <- open . unArg $ phi
+            bA  <- open . unArg $ bA
             el's lb $ cl primPartialP <#> lb <@> phi <@> glam iinfo "o" (\ _ -> bA)
       let a' = Lam iinfo (NoAbs "o" $ unArg a)
       ta <- el' (pure $ unArg la) (pure $ unArg bA)
@@ -1752,15 +1764,24 @@ check_glueU c rs vs _ = do
    la : phi : bT : bA : t : a : rest -> do
       let iinfo = setRelevance Irrelevant defaultArgInfo
       v <- runNamesT [] $ do
-            [la, phi, bT, bA, t] <- mapM (open . unArg) [la, phi, bT, bA, t]
+            la  <- open . unArg $ la
+            phi <- open . unArg $ phi
+            bT  <- open . unArg $ bT
+            bA  <- open . unArg $ bA
+            t   <- open . unArg $ t
             let f o = cl primTrans <#> lam "i" (const la) <@> lam "i" (\ i -> bT <@> (cl primINeg <@> i) <..> o) <@> cl primIZero
             glam iinfo "o" $ \ o -> f o <@> (t <..> o)
       ty <- runNamesT [] $ do
-            [la, phi, bT] <- mapM (open . unArg) [la, phi, bT]
+            la  <- open . unArg $ la
+            phi <- open . unArg $ phi
+            bT  <- open . unArg $ bT
             pPi' "o" phi $ \ o -> el' la (bT <@> cl primIZero <..> o)
       let a' = Lam iinfo (NoAbs "o" $ unArg a)
       ta <- runNamesT [] $ do
-            [la, phi, bT, bA] <- mapM (open . unArg) [la, phi, bT, bA]
+            la  <- open . unArg $ la
+            phi <- open . unArg $ phi
+            bT  <- open . unArg $ bT
+            bA  <- open . unArg $ bA
             el' la (cl primSubOut <#> (cl primLevelSuc <@> la) <#> (Sort . tmSort <$> la) <#> phi <#> (bT <@> cl primIZero) <@> bA)
       a <- blockArg ta (rs !!! 5) a $ equalTerm ty a' v
       return $ la : phi : bT : bA : t : a : rest

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
@@ -25,6 +25,7 @@ import Agda.TypeChecking.Records
 import Agda.TypeChecking.Rules.LHS.Problem
 import Agda.TypeChecking.Rules.LHS.Unify.Types
 
+import Agda.Utils.Either (fromRight)
 import Agda.Utils.List
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
@@ -198,7 +199,8 @@ composeRetract (prob0,rho0,tau0,leftInv0) phi0 (prob1,rho1,tau1,leftInv1) = do
   interval <- primIntervalType
   max <- primIMax
   neg <- primINeg
-  Right leftInv <- fmap sequenceA $ addContext prob0 $ runNamesT (teleNames prob0) $ do
+  leftInv <- fromRight __IMPOSSIBLE__ . sequenceA <$> do
+    addContext prob0 $ runNamesT (teleNames prob0) $ do
              phi <- open phi0
              g0 <- open $ raise (size prob0) prob0
              step0 <- open $ Abs "i" $ step0 `applySubst` teleArgs prob0
@@ -251,8 +253,8 @@ buildEquiv (UnificationStep st step@(Solution k ty fx tm side) output) next = ru
           ]
         (tau,leftInv,phi) <- addContext working_tel $ runNamesT [] $ do
           let raiseFrom tel x = raise (size working_tel - size tel) x
-
-          [u,v] <- mapM (open . raiseFrom gamma . unArg) [u,v]
+          u <- open . raiseFrom gamma . unArg $ u
+          v <- open . raiseFrom gamma . unArg $ v
           -- φ
           let phi = raiseFrom gamma_phis $ var 0
           -- working_tel ⊢ γ₁,x,γ₂,φ,eqs


### PR DESCRIPTION
- Remove use of `fail` from the `NamesT` toolkit
- Remove `MonadFail` from `HasBuiltins`
