### PR TITLE
Follow hlint suggestion: use gets

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -70,7 +70,6 @@
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use foldMap"} # 2 hints
 - ignore: {name: "Use fromMaybe"} # 1 hint
-- ignore: {name: "Use gets"} # 1 hint
 - ignore: {name: "Use id"} # 2 hints
 - ignore: {name: "Use infix"} # 1 hint
 - ignore: {name: "Use intercalate"} # 1 hint

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -19,23 +19,24 @@
 # Warnings currently triggered by your code
 - ignore: {name: "Avoid lambda"} # 50 hints
 - ignore: {name: "Avoid lambda using `infix`"} # 13 hints
-- ignore: {name: "Empty single-line comment"} # 197 hints
 - ignore: {name: "Eta reduce"} # 181 hints
 - ignore: {name: "Evaluate"} # 15 hints
-- ignore: {name: "Functor law"} # 2 hints
+- ignore: {name: "Functor law"} # 24 hints
 - ignore: {name: "Fuse foldr/map"} # 8 hints
 - ignore: {name: "Fuse mapM/map"} # 2 hints
+- ignore: {name: "Fuse traverse/<$>"} # 2 hints
 - ignore: {name: "Hoist not"} # 18 hints
 - ignore: {name: "Move brackets to avoid $"} # 1 hint
 - ignore: {name: "Move guards forward"} # 2 hints
 - ignore: {name: "Redundant $"} # 622 hints
-- ignore: {name: "Redundant <$>"} # 45 hints
-- ignore: {name: "Redundant <&>"} # 1 hint
+- ignore: {name: "Redundant <$>"} # 47 hints
+- ignore: {name: "Redundant <&>"} # 4 hints
 - ignore: {name: "Redundant True guards"} # 1 hint
 - ignore: {name: "Redundant bang pattern"} # 1 hint
-- ignore: {name: "Redundant bracket"} # 495 hints
+- ignore: {name: "Redundant bracket"} # 494 hints
 - ignore: {name: "Redundant case"} # 1 hint
 - ignore: {name: "Redundant flip"} # 4 hints
+- ignore: {name: "Redundant fmap"} # 1 hint
 - ignore: {name: "Redundant guard"} # 5 hints
 - ignore: {name: "Redundant id"} # 1 hint
 - ignore: {name: "Redundant if"} # 2 hints
@@ -59,6 +60,7 @@
 - ignore: {name: "Use >"} # 1 hint
 - ignore: {name: "Use Just"} # 2 hints
 - ignore: {name: "Use LANGUAGE pragmas"} # 7 hints
+- ignore: {name: "Use all"} # 1 hint
 - ignore: {name: "Use camelCase"} # 72 hints
 - ignore: {name: "Use concatMap"} # 2 hints
 - ignore: {name: "Use const"} # 79 hints
@@ -66,6 +68,7 @@
 - ignore: {name: "Use first"} # 1 hint
 - ignore: {name: "Use fmap"} # 6 hints
 - ignore: {name: "Use fold"} # 1 hint
+- ignore: {name: "Use foldMap"} # 2 hints
 - ignore: {name: "Use fromMaybe"} # 1 hint
 - ignore: {name: "Use gets"} # 1 hint
 - ignore: {name: "Use id"} # 2 hints
@@ -90,10 +93,11 @@
 - ignore: {name: "Use section"} # 21 hints
 - ignore: {name: "Use sequenceA"} # 3 hints
 - ignore: {name: "Use uncurry"} # 1 hint
-- ignore: {name: "Use unless"} # 3 hints
+- ignore: {name: "Use unless"} # 4 hints
 - ignore: {name: "Use void"} # 13 hints
 - ignore: {name: "Use zipWith"} # 2 hints
 - ignore: {name: "Use ||"} # 8 hints
+
 # Specify additional command line arguments
 - arguments:
     - --ignore-glob=notes/papers/iird/paper.lhs

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -463,7 +463,7 @@ invertFunction cmp blk (Inv f blkArgs hdMap) hd fallback err success = do
   where
     nextMeta :: (MonadState [Term] m) => m Term
     nextMeta = do
-      (m, ms) <- fromMaybe __IMPOSSIBLE__ . uncons <$> get
+      (m, ms) <- gets (fromMaybe __IMPOSSIBLE__ . uncons)
       put ms
       return m
 


### PR DESCRIPTION
Sorry @andreasabel. Yesterday I ran the following command to install `hlint-3.8` but somehow ended up with a local build that was not the published version (should have also checked the path to the exe was `~/.cabal/bin/hlint`) so there's an extra commit (that resets the "warnings triggered" properly) included with this pull request. The "Empty single-line comment" should have been a give away as that is part of https://github.com/ndmitchell/hlint/pull/1459 and not yet included in hlint. I was not being careful enough.

```
$ cabal install hlint-3.8 --overwrite-policy=always --ignore-project
```

The second commit follows the hlint suggestion to use `gets`.