### PR TITLE
New literate programming backend forester, `*.lagda.tree`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Syntax
 
 Additions to the Agda syntax.
 
+* Add new literate agda: forester, see [#7403](https://github.com/agda/agda/pull/7403)
 * Records can now be created using module-like syntax in place of curly braces
   and semicolons.
 

--- a/doc/user-manual/tools/literate-programming.rst
+++ b/doc/user-manual/tools/literate-programming.rst
@@ -159,7 +159,7 @@ Literate Forester
 -----------------
 
 Files ending in :file:`.lagda.tree` are interpreted as literate
-Forester_ files. Literate forester use `\agda{...}` for code blocks.
+Forester_ files. Literate forester use ```\agda{...}``` for code blocks.
 
 .. code-block:: text
 

--- a/doc/user-manual/tools/literate-programming.rst
+++ b/doc/user-manual/tools/literate-programming.rst
@@ -172,7 +172,7 @@ Forester_ files. Literate forester use `\agda{...}` for code blocks.
 
    \p{Here is another code block:}
 
-   \agda
+   \agda{
    data ℕ : Set where
     zero : ℕ
     suc  : ℕ → ℕ

--- a/doc/user-manual/tools/literate-programming.rst
+++ b/doc/user-manual/tools/literate-programming.rst
@@ -155,12 +155,35 @@ Org_ files. Code blocks are surrounded by two lines including only
   final document may be placed in source blocks without the ``agda2``
   label.
 
+Literate Forester
+-----------------
+
+Files ending in :file:`.lagda.tree` are interpreted as literate
+Forester_ files. Literate forester use `\agda{...}` for code blocks.
+
+.. code-block:: tree
+
+   \p{This line is ordinary text, which is ignored by Agda.}
+
+   \agda{
+   module Whatever where
+   -- Agda code goes here
+   }
+
+   \p{Here is another code block:}
+
+   \agda
+   data ℕ : Set where
+    zero : ℕ
+    suc  : ℕ → ℕ
+   }
 
 .. _TeX: http://tug.org/
 .. _reStructuredText: http://docutils.sourceforge.io/rst.html
 .. _Markdown: https://daringfireball.net/projects/markdown/
 .. _Org: https://orgmode.org
 .. _Typst: https://typst.app
+.. _Forester: https://sr.ht/~jonsterling/forester/
 
 .. _lhs2TeX: https://www.andres-loeh.de/lhs2tex/
 .. _Sphinx: http://www.sphinx-doc.org/en/stable/

--- a/doc/user-manual/tools/literate-programming.rst
+++ b/doc/user-manual/tools/literate-programming.rst
@@ -161,7 +161,7 @@ Literate Forester
 Files ending in :file:`.lagda.tree` are interpreted as literate
 Forester_ files. Literate forester use `\agda{...}` for code blocks.
 
-.. code-block:: tree
+.. code-block:: text
 
    \p{This line is ordinary text, which is ignored by Agda.}
 

--- a/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
@@ -113,6 +113,7 @@ highlightOnlyCode HighlightAuto MdFileType    = True
 highlightOnlyCode HighlightAuto RstFileType   = True
 highlightOnlyCode HighlightAuto OrgFileType   = True
 highlightOnlyCode HighlightAuto TypstFileType = True
+highlightOnlyCode HighlightAuto TreeFileType  = True
 highlightOnlyCode HighlightAuto TexFileType   = False
 
 -- | Determine the generated file extension
@@ -127,6 +128,7 @@ highlightedFileExt hh ft
       TexFileType   -> "tex"
       OrgFileType   -> "org"
       TypstFileType -> "typ"
+      TreeFileType  -> "tree"
 
 -- | Options for HTML generation
 
@@ -306,6 +308,7 @@ code onlyCode fileType = mconcat . if onlyCode
          MdFileType    -> map mkMd . splitByMarkup
          AgdaFileType  -> map mkHtml
          OrgFileType   -> map mkOrg . splitByMarkup
+         TreeFileType  -> map mkMd . splitByMarkup
          -- Two useless cases, probably will never used by anyone
          TexFileType   -> map mkMd . splitByMarkup
          TypstFileType -> map mkMd . splitByMarkup

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -78,7 +78,7 @@ instance Monoid IsMain where
 -- * File
 ---------------------------------------------------------------------------
 
-data FileType = AgdaFileType | MdFileType | RstFileType | TexFileType | OrgFileType | TypstFileType
+data FileType = AgdaFileType | MdFileType | RstFileType | TexFileType | OrgFileType | TypstFileType | TreeFileType
   deriving (Eq, Ord, Show, Generic)
 
 instance Pretty FileType where
@@ -89,6 +89,7 @@ instance Pretty FileType where
     TexFileType  -> "LaTeX"
     OrgFileType  -> "org-mode"
     TypstFileType -> "Typst"
+    TreeFileType -> "Forester"
 
 instance NFData FileType
 

--- a/src/full/Agda/Syntax/Parser/Literate.hs
+++ b/src/full/Agda/Syntax/Parser/Literate.hs
@@ -316,7 +316,7 @@ literateOrg pos s = mkLayers pos $ org s
   -- Source blocks start with `#+begin_src` but the casing does not matter.
   rex' = makeRegexOpts blankCompOpt{newSyntax = True, caseSensitive = False} blankExecOpt
 
--- | Preprocessor for Froester documents
+-- | Preprocessor for Forester documents
 
 literateTree :: Position -> String -> [Layer]
 literateTree pos s = mkLayers pos (tree s)

--- a/src/full/Agda/Syntax/Parser/Literate.hs
+++ b/src/full/Agda/Syntax/Parser/Literate.hs
@@ -105,6 +105,7 @@ literateProcessors =
     , (".tex", (literateTeX, TexFileType))
     , (".md",  (literateMd,  MdFileType ))
     , (".org", (literateOrg, OrgFileType))
+    , (".tree", (literateTree, TreeFileType))
     -- For now, treat typst as markdown because they use the same
     -- syntax for code blocks.
     , (".typ", (literateMd,  TypstFileType))
@@ -314,3 +315,29 @@ literateOrg pos s = mkLayers pos $ org s
   rex' :: String -> Regex
   -- Source blocks start with `#+begin_src` but the casing does not matter.
   rex' = makeRegexOpts blankCompOpt{newSyntax = True, caseSensitive = False} blankExecOpt
+
+-- | Preprocessor for Froester documents
+
+literateTree :: Position -> String -> [Layer]
+literateTree pos s = mkLayers pos (tree s)
+  where
+  tree :: String -> [(LayerRole, String)]
+  tree = caseLine [] $ \ line rest ->
+    case tree_begin `matchM` line of
+      Just (getAllTextSubmatches -> [_, pre, _, markup, whitespace]) ->
+        (Comment, pre) : (Markup, markup) :
+        (Code, whitespace) : code rest
+      Just _  -> __IMPOSSIBLE__
+      Nothing -> (Comment, line) : tree rest
+
+  tree_begin = rex "(([^\\%]|\\\\.)*)(\\\\agda\\{[^\n]*)(\n)?"
+
+  code :: String -> [(LayerRole, String)]
+  code = caseLine [] $ \ line rest ->
+    case tree_end `matchM` line of
+      Just (getAllTextSubmatches -> [_, code, markup, post]) ->
+        (Code, code) : (Markup, markup) : (Comment, post) : tree rest
+      Just _  -> __IMPOSSIBLE__
+      Nothing -> (Code, line) : code rest
+
+  tree_end = rex "([[:blank:]]*)(\\})(.*)"

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -171,6 +171,7 @@ instance EmbPrj FileType where
   icod_ TexFileType   = pure 3
   icod_ OrgFileType   = pure 4
   icod_ TypstFileType = pure 5
+  icod_ TreeFileType  = pure 6
 
   value = \case
     0 -> pure AgdaFileType
@@ -179,6 +180,7 @@ instance EmbPrj FileType where
     3 -> pure TexFileType
     4 -> pure OrgFileType
     5 -> pure TypstFileType
+    6 -> pure TreeFileType
     _ -> malformed
 
 instance EmbPrj Cubical where

--- a/test/Fail/BadCode.lagda.tree
+++ b/test/Fail/BadCode.lagda.tree
@@ -1,3 +1,4 @@
+% The typo is intended.
 \agda{
 posulate X :
 }

--- a/test/Fail/BadCode.lagda.tree
+++ b/test/Fail/BadCode.lagda.tree
@@ -1,0 +1,3 @@
+\agda{
+posulate X :
+}

--- a/test/LaTeXAndHTML/succeed/Simple.lagda.tree
+++ b/test/LaTeXAndHTML/succeed/Simple.lagda.tree
@@ -1,0 +1,13 @@
+\title{simple}
+
+\p{This is test file}
+\agda{
+module M where
+
+  data Bool : Set where
+            true : Bool
+            false : Bool
+
+  a : Bool
+  a = true
+}

--- a/test/LaTeXAndHTML/succeed/TreeOneLine.lagda.tree
+++ b/test/LaTeXAndHTML/succeed/TreeOneLine.lagda.tree
@@ -1,0 +1,1 @@
+\p{Hello, this is} \agda{postulate Truth : Set}

--- a/test/interaction/Issue2224.out
+++ b/test/interaction/Issue2224.out
@@ -1,4 +1,4 @@
 Issue2224WrongExtension.agda.tex: error: [InvalidExtensionError]
 Unsupported extension.
 Supported extensions are: .agda, .lagda, .lagda.rst, .lagda.tex,
-.lagda.md, .lagda.org, .lagda.typ
+.lagda.md, .lagda.org, .lagda.tree, .lagda.typ


### PR DESCRIPTION
[forester](https://sr.ht/~jonsterling/forester/) is a tool to manage forests of evergreen notes, each note is a file with suffix `.tree`.

Here I propose a basic support to treat files `*.lagda.tree` as a literate programming sources, follow structure of others literate languages, hope the format is proper.