### PR TITLE
Fix #7401: do not fail hard in Setup.hs if library interface files cannot be built

### DIFF
--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -23,6 +23,7 @@ jobs:
   cabal-install:
     env:
       FLAGS: -O0 -f enable-cluster-counting
+    name: cabal install ${{ matrix.name }}
     needs: auto-cancel
     runs-on: ubuntu-24.04
     steps:
@@ -32,7 +33,7 @@ jobs:
       with:
         cabal-update: true
         cabal-version: latest
-        ghc-version: '9.8'
+        ghc-version: '9.10'
     - name: Configure the build plan
       run: |
         cabal configure ${FLAGS}
@@ -52,13 +53,21 @@ jobs:
         cabal build --only-dependencies
     - name: Install Agda
       run: |
-        cabal install ${FLAGS}
+        cabal install ${FLAGS} ${{ matrix.install_flags }}
     - if: always() && steps.cache.outputs.cache-hit != 'true'
       name: Save cache
       uses: actions/cache/save@v4
       with:
         key: ${{ steps.cache.outputs.cache-primary-key }}
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - install_flags: ''
+          name: ''
+        - install_flags: --lib
+          name: --lib
     timeout-minutes: 60
 name: Install (v2-cabal)
 'on':

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ Installation
   so Agda can be more reliably used as a library.
   Major releases will now bump the second number in the version tuple: 2.7.0, 2.8.0, 2.9.0, ...
 
+* When the creation of the Agda library interface files fails during installation,
+  a warning is emitted rather than aborting installation.
+  The absence of these interface files is not a problem if the Agda installation
+  resides in user space; they will be created on the fly then.
+  Yet for system-wide installations in root space or packaging,
+  the interface files should be created.
+  This can be achieved by a manual invocation of Agda on the library source files
+  (i.e., primitive and builtin modules `Agda.*`).
+  (See [Issue #7401](https://github.com/agda/agda/issues/7401) and [PR #7404](https://github.com/agda/agda/pull/7404).)
+
 * Agda supports GHC versions 8.6.5 to 9.10.1.
 
 Pragmas and options

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NondecreasingIndentation #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 import Data.List
 import Data.Maybe
@@ -18,8 +18,8 @@ import System.Exit
 import System.IO
 import System.IO.Error (isDoesNotExistError)
 
-import Control.Monad (forM_, unless)
-import Control.Exception (bracket, catch, throwIO)
+import Control.Monad
+import Control.Exception
 
 main :: IO ()
 main = defaultMainWithHooks userhooks
@@ -44,9 +44,9 @@ copyHook' pd lbi hooks flags = do
   copyHook simpleUserHooks pd lbi hooks flags
   unless (skipInterfaces lbi) $ do
     -- Generate .agdai files.
-    generateInterfaces pd lbi
+    success <- generateInterfaces pd lbi
     -- Copy again, now including the .agdai files.
-    copyHook simpleUserHooks pd' lbi hooks flags
+    when success $ copyHook simpleUserHooks pd' lbi hooks flags
   where
   pd' = pd
     { dataFiles = concatMap (expandAgdaExt pd) $ dataFiles pd
@@ -89,7 +89,9 @@ toIFile pd file = buildDir </> fileName where
 skipInterfaces :: LocalBuildInfo -> Bool
 skipInterfaces lbi = fromPathTemplate (progSuffix lbi) == "-quicker"
 
-generateInterfaces :: PackageDescription -> LocalBuildInfo -> IO ()
+-- | Returns 'True' if call to Agda executes without error.
+--
+generateInterfaces :: PackageDescription -> LocalBuildInfo -> IO Bool
 generateInterfaces pd lbi = do
 
   -- for debugging, these are examples how you can inspect the flags...
@@ -121,6 +123,13 @@ generateInterfaces pd lbi = do
 
   -- Type-check all builtin modules (in a single Agda session to take
   -- advantage of caching).
+  let agdaDirEnvVar = "Agda_datadir"
+  let agdaArgs =
+        [ "--interaction"
+        , "--interaction-exit-on-error"
+        , "-Werror"
+        , "-v0"
+        ]
   let loadBuiltinCmds = concat
         [ [ cmd ("Cmd_load " ++ f ++ " []")
           , cmd "Cmd_no_metas"
@@ -130,21 +139,40 @@ generateInterfaces pd lbi = do
         , let f     = show (ddir </> b)
               cmd c = "IOTCM " ++ f ++ " None Indirect (" ++ c ++ ")"
         ]
+  let callLines = concat
+        [ [ unwords $ concat
+            [ [ concat [ agdaDirEnvVar, "=", ddir ] ]
+            , [ agda ]
+            , agdaArgs
+            , [ "<<EOF" ]
+            ]
+          ]
+        , loadBuiltinCmds
+        , [ "EOF" ]
+        ]
+  let onIOError (e :: IOException) = False <$ do
+        putStr $ unlines $ concat
+          [ [ "*** Warning!"
+            , "*** Could not generate Agda library interface files."
+            , "*** Reason:"
+            , show e
+            , "*** The attempted call to Agda was:"
+            ]
+          , callLines
+          , [ "*** Ignoring error, continuing installation..." ]
+          ]
   env <- getEnvironment
-  _output <- readCreateProcess
-      (proc agda
-          [ "--interaction"
-          , "--interaction-exit-on-error"
-          , "-Werror"
-          , "-v0"
-          ])
+  handle onIOError $ do
+    throw $ userError "FOO BAR"
+    True <$ readCreateProcess
+      (proc agda agdaArgs)
         { delegate_ctlc = True
                           -- Make Agda look for data files in a
                           -- certain place.
-        , env           = Just (("Agda_datadir", ddir) : env)
+        , env           = Just ((agdaDirEnvVar, ddir) : env)
         }
       (unlines loadBuiltinCmds)
-  return ()
+
 
 agdaExeExtension :: String
 agdaExeExtension = exeExtension buildPlatform

--- a/src/github/workflows/cabal-install.yml
+++ b/src/github/workflows/cabal-install.yml
@@ -40,7 +40,17 @@ jobs:
 
     timeout-minutes: 60
 
+    name: cabal install ${{ matrix.name }}
     runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name:  ""
+          install_flags: ""
+        - name:  "--lib"
+          install_flags: "--lib"
 
     env:
       FLAGS: "-O0 -f enable-cluster-counting"
@@ -51,7 +61,7 @@ jobs:
     - uses: haskell-actions/setup@v2
       id: setup-haskell
       with:
-        ghc-version:   '9.8'
+        ghc-version:   '9.10'
         cabal-version: latest
         cabal-update:  true
 
@@ -81,7 +91,7 @@ jobs:
 
     - name: Install Agda
       run: |
-        cabal install ${FLAGS}
+        cabal install ${FLAGS} ${{ matrix.install_flags }}
 
     - name: Save cache
       uses: actions/cache/save@v4


### PR DESCRIPTION
- **Bump cubical to latest to include agda/cubical#1143**
- **Workaround for `cabal install --lib` (#7401)**
