### PR TITLE
GenericError crusade goes on: NeedOptionSizedTypes etc.

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -206,6 +206,7 @@ errorString = \case
   NeedOptionTwoLevel{}                     -> "NeedOptionTwoLevel"
   NeedOptionUniversePolymorphism{}         -> "NeedOptionUniversePolymorphism"
   NegativeLiteralInPattern{}               -> "NegativeLiteralInPattern"
+  NoKnownRecordWithSuchFields{}            -> "NoKnownRecordWithSuchFields"
   GeneralizeNotSupportedHere{}             -> "GeneralizeNotSupportedHere"
   GeneralizeCyclicDependency{}             -> "GeneralizeCyclicDependency"
   GeneralizedVarInLetOpenedModule{}        -> "GeneralizedVarInLetOpenedModule"
@@ -416,6 +417,12 @@ instance PrettyTCM TypeError where
     GenericError s -> fwords s
 
     GenericDocError d -> return d
+
+    NoKnownRecordWithSuchFields fields -> fsep $
+      case fields of
+        []  -> pwords "There are no records in scope"
+        [f] -> pwords "There is no known record with the field" ++ [ pretty f ]
+        _   -> pwords "There is no known record with the fields" ++ map pretty fields
 
     ShouldEndInApplicationOfTheDatatype t -> fsep $
       pwords "The target of a constructor must be the datatype applied to its parameters,"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -321,6 +321,7 @@ errorString = \case
   MacroResultTypeMismatch{}                -> "MacroResultTypeMismatch"
   NamedWhereModuleInRefinedContext{}       -> "NamedWhereModuleInRefinedContext"
   CubicalPrimitiveNotFullyApplied{}        -> "CubicalPrimitiveNotFullyApplied"
+  PatternMatchingInSystem{}                -> "PatternMatchingInSystem"
   IllTypedPatternAfterWithAbstraction{}    -> "IllTypedPatternAfterWithAbstraction"
   ComatchingDisabledForRecord{}            -> "ComatchingDisabledForRecord"
   IncorrectTypeForRewriteRelation{}        -> "IncorrectTypeForRewriteRelation"
@@ -1545,6 +1546,9 @@ instance PrettyTCM TypeError where
 
     CubicalPrimitiveNotFullyApplied c ->
       prettyTCM c <+> "must be fully applied"
+
+    PatternMatchingInSystem ->
+      fwords $ "Pattern matching or path copatterns not allowed in systems"
 
     IllTypedPatternAfterWithAbstraction p -> vcat
       [ "Ill-typed pattern after with abstraction: " <+> prettyA p

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -202,6 +202,7 @@ errorString = \case
   NeedOptionPatternMatching{}              -> "NeedOptionPatternMatching"
   NeedOptionProp{}                         -> "NeedOptionProp"
   NeedOptionRewriting{}                    -> "NeedOptionRewriting"
+  NeedOptionSizedTypes{}                   -> "NeedOptionSizedTypes"
   NeedOptionTwoLevel{}                     -> "NeedOptionTwoLevel"
   NeedOptionUniversePolymorphism{}         -> "NeedOptionUniversePolymorphism"
   NegativeLiteralInPattern{}               -> "NegativeLiteralInPattern"
@@ -1404,6 +1405,9 @@ instance PrettyTCM TypeError where
 
     NeedOptionRewriting  -> fsep $
       pwords "Option --rewriting needed to add and use rewrite rules"
+
+    NeedOptionSizedTypes reason -> fsep $
+      pwords "Option --sized-types needed" ++ pwords reason
 
     NeedOptionTwoLevel   -> fsep $
       pwords "Universe SSet is disabled (use option --two-level to enable SSet)"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -321,6 +321,7 @@ errorString = \case
   MacroResultTypeMismatch{}                -> "MacroResultTypeMismatch"
   NamedWhereModuleInRefinedContext{}       -> "NamedWhereModuleInRefinedContext"
   CubicalPrimitiveNotFullyApplied{}        -> "CubicalPrimitiveNotFullyApplied"
+  ExpectedIntervalLiteral{}                -> "ExpectedIntervalLiteral"
   PatternMatchingInSystem{}                -> "PatternMatchingInSystem"
   IllTypedPatternAfterWithAbstraction{}    -> "IllTypedPatternAfterWithAbstraction"
   ComatchingDisabledForRecord{}            -> "ComatchingDisabledForRecord"
@@ -1546,6 +1547,16 @@ instance PrettyTCM TypeError where
 
     CubicalPrimitiveNotFullyApplied c ->
       prettyTCM c <+> "must be fully applied"
+
+    ExpectedIntervalLiteral e -> do
+      i0 <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinIZero
+      i1 <- fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinIOne
+      fsep $ concat
+        [ pwords "Expected an interval literal"
+        , [ parens $ fsep [ prettyTCM i0, "or", prettyTCM i1 ] ]
+        , pwords "but found:"
+        , [ prettyTCM e ]
+        ]
 
     PatternMatchingInSystem ->
       fwords $ "Pattern matching or path copatterns not allowed in systems"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1391,7 +1391,10 @@ instance PrettyTCM TypeError where
     NeedOptionCopatterns -> fsep $
       pwords "Option --copatterns needed to enable destructor patterns"
 
-    NeedOptionCubical cubical -> fsep $ concat [ [ "Option" ], opt, [ "required" ] ]
+    NeedOptionCubical cubical reason -> fsep $ concat
+        [ [ "Option" ], opt, [ "required" ]
+        , pwords reason
+        ]
       where
       opt = case cubical of
         CFull   -> [ "--cubical" ]

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4948,6 +4948,8 @@ data TypeError
         | NeedOptionPatternMatching
         | NeedOptionProp
         | NeedOptionRewriting
+        | NeedOptionSizedTypes String
+            -- ^ Need @--sized-types@ for the given reason.
         | NeedOptionTwoLevel
         | NeedOptionUniversePolymorphism
     -- Failure associated to warnings

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4823,6 +4823,8 @@ data TypeError
         | ComatchingDisabledForRecord QName
         | IncorrectTypeForRewriteRelation Term IncorrectTypeForRewriteRelationReason
     -- Cubical errors
+        | ExpectedIntervalLiteral A.Expr
+            -- ^ Expected an interval literal (0 or 1) but found 'A.Expr'.
         | PatternMatchingInSystem
             -- ^ Attempt to pattern or copattern match in a system.
     -- Data errors

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4674,6 +4674,9 @@ data TypeError
         | NotImplemented String
         | NotSupported String
         | CompilationError String
+        | NoKnownRecordWithSuchFields [C.Name]
+            -- ^ The user has given a record expression with the given fields,
+            --   but no record type known to type inference has all these fields.
         | ShouldEndInApplicationOfTheDatatype Type
             -- ^ The target of a constructor isn't an application of its
             -- datatype. The 'Type' records what it does target.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4822,6 +4822,9 @@ data TypeError
         | CubicalPrimitiveNotFullyApplied QName
         | ComatchingDisabledForRecord QName
         | IncorrectTypeForRewriteRelation Term IncorrectTypeForRewriteRelationReason
+    -- Cubical errors
+        | PatternMatchingInSystem
+            -- ^ Attempt to pattern or copattern match in a system.
     -- Data errors
         | UnexpectedParameter A.LamBinding
         | NoParameterOfName ArgName

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4944,7 +4944,8 @@ data TypeError
     -- Language option errors
         | NeedOptionAllowExec
         | NeedOptionCopatterns
-        | NeedOptionCubical Cubical
+        | NeedOptionCubical Cubical String
+            -- ^ Flavor of cubical needed for the given reason.
         | NeedOptionPatternMatching
         | NeedOptionProp
         | NeedOptionRewriting

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
@@ -61,13 +61,20 @@ import Agda.Syntax.Internal
 requireCubical
   :: Cubical -- ^ Which variant of Cubical Agda is required?
   -> TCM ()
-requireCubical wanted = do
+requireCubical wanted = requireCubical' wanted ""
+
+-- | Generalization of 'requireCubical' supplying a reason.
+requireCubical'
+  :: Cubical -- ^ Which variant of Cubical Agda is required?
+  -> String  -- ^ Why, exactly, do we need Cubical to be enabled?
+  -> TCM ()
+requireCubical' wanted reason = do
   cubical         <- cubicalOption
   inErasedContext <- hasQuantity0 <$> viewTC eQuantity
   case cubical of
     Just CFull -> return ()
     Just CErased | wanted == CErased || inErasedContext -> return ()
-    _ -> typeError $ NeedOptionCubical wanted
+    _ -> typeError $ NeedOptionCubical wanted reason
 
 -- | Our good friend the interval type.
 primIntervalType :: (HasBuiltins m, MonadError TCErr m, MonadTCEnv m, ReadTCState m) => m Type

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -967,8 +967,8 @@ bindUntypedBuiltin b = \case
 -- We simply ignore the parameters.
 bindBuiltinNoDef :: BuiltinId -> A.QName -> TCM ()
 bindBuiltinNoDef b q = inTopContext $ do
-  when (b `elem` sizeBuiltins) $ unlessM sizedTypesOption $
-    genericError $ "Cannot declare size BUILTIN " ++ getBuiltinId b ++ " with option --no-sized-types"
+  when (b `elem` sizeBuiltins) $
+    requireOptionSizedTypes $ "to declare size BUILTIN " ++ getBuiltinId b
   case builtinDesc <$> findBuiltinInfo b of
 
     Just (BuiltinPostulate rel mt) -> do

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -464,17 +464,6 @@ checkPositivity_ mi names = Bench.billTo [Bench.Positivity] $ do
   -- positivity check, so it needs happen after the positivity check.
   computePolarity $ Set.toList names
 
--- | Check that all coinductive records are actually recursive.
---   (Otherwise, one can implement invalid recursion schemes just like
---   for the old coinduction.)
-checkCoinductiveRecords :: [A.Declaration] -> TCM ()
-checkCoinductiveRecords ds = forM_ ds $ \case
-  A.RecDef _ q _ dir _ _ _
-    | Just (Ranged r CoInductive) <- recInductive dir -> setCurrentRange r $ do
-    unlessM (isRecursiveRecord q) $ typeError $ GenericError $
-      "Only recursive records can be coinductive"
-  _ -> return ()
-
 -- | Check a set of mutual names for constructor-headedness.
 checkInjectivity_ :: Set QName -> TCM ()
 checkInjectivity_ names = Bench.billTo [Bench.Injectivity] $ do

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1009,10 +1009,7 @@ checkRecordExpression cmp mfs e t = do
       reportSDoc "tc.term.rec" 30 $ "Possible records for" <+> prettyTCM t <+> "are" <?> pretty rs
       case rs of
           -- If there are no records with the right fields we might as well fail right away.
-        [] -> case fields of
-          []  -> genericError "There are no records in scope"
-          [f] -> genericError $ "There is no known record with the field " ++ prettyShow f
-          _   -> genericError $ "There is no known record with the fields " ++ unwords (map prettyShow fields)
+        [] -> typeError $ NoKnownRecordWithSuchFields fields
           -- If there's only one record with the appropriate fields, go with that.
         [r] -> do
           -- #5198: Don't generate metas for parameters of the current module. In most cases they
@@ -1037,8 +1034,6 @@ checkRecordExpression cmp mfs e t = do
           let inferred = El s $ Def r $ map Apply (ps ++ vs)
           v <- checkExpr e inferred
           coerce cmp v inferred t
-          -- Andreas 2012-04-21: OLD CODE, WRONG DIRECTION, I GUESS:
-          -- blockTerm t $ v <$ leqType_ t inferred
 
           -- If there are more than one possible record we postpone
         _:_:_ -> do

--- a/test/Fail/ExpectedIntervalLiteral.err
+++ b/test/Fail/ExpectedIntervalLiteral.err
@@ -1,0 +1,4 @@
+ExpectedIntervalLiteral.agda:16,9-16: error: [ExpectedIntervalLiteral]
+Expected an interval literal (i0 or i1) but found: foo
+when checking that the pattern (i = foo) has type
+IsOne (_φ_15 (p = p) (q = q) (i = i))

--- a/test/Fail/InferRecordTypes-1.err
+++ b/test/Fail/InferRecordTypes-1.err
@@ -1,3 +1,3 @@
-InferRecordTypes-1.agda:5,7-17: error: [GenericError]
+InferRecordTypes-1.agda:5,7-17: error: [NoKnownRecordWithSuchFields]
 There are no records in scope
 when checking that the expression record {} has type _1

--- a/test/Fail/InferRecordTypes-2.err
+++ b/test/Fail/InferRecordTypes-2.err
@@ -1,3 +1,3 @@
-InferRecordTypes-2.agda:10,7-26: error: [GenericError]
+InferRecordTypes-2.agda:10,7-26: error: [NoKnownRecordWithSuchFields]
 There is no known record with the field x₃
 when checking that the expression record { x₃ = Set } has type _1

--- a/test/Fail/InferRecordTypes-3.err
+++ b/test/Fail/InferRecordTypes-3.err
@@ -1,4 +1,4 @@
-InferRecordTypes-3.agda:17,7-33: error: [GenericError]
+InferRecordTypes-3.agda:17,7-33: error: [NoKnownRecordWithSuchFields]
 There is no known record with the fields x₂ x₃
 when checking that the expression record { x₂ = A ; x₃ = A } has
 type _1

--- a/test/Fail/Issue3451.err
+++ b/test/Fail/Issue3451.err
@@ -1,3 +1,3 @@
-Issue3451.agda:5,1-30: error: [GenericError]
-Cannot declare size BUILTIN SIZE with option --no-sized-types
+Issue3451.agda:5,1-30: error: [NeedOptionSizedTypes]
+Option --sized-types needed to declare size BUILTIN SIZE
 when checking the pragma BUILTIN SIZE Size

--- a/test/Fail/Issue4267a.agda
+++ b/test/Fail/Issue4267a.agda
@@ -1,4 +1,10 @@
 import Issue4267.M using ()
 
--- foo : {!Issue4267.M.R!} -- cannot give, but this is the solution
+-- foo : {!Issue4267.M.R!} -- WAS: cannot give, but this is the solution
 foo = record { f = Set}
+
+-- Expected error:
+--
+-- There is no known record with the field f
+--
+-- (The record field is not imported, not even in scope qualified.)

--- a/test/Fail/Issue4267a.err
+++ b/test/Fail/Issue4267a.err
@@ -1,3 +1,3 @@
-Issue4267a.agda:4,7-24: error: [GenericError]
+Issue4267a.agda:4,7-24: error: [NoKnownRecordWithSuchFields]
 There is no known record with the field f
 when checking that the expression record { f = Set } has type _1

--- a/test/Fail/PatternMatchingInSystem.agda
+++ b/test/Fail/PatternMatchingInSystem.agda
@@ -1,0 +1,26 @@
+-- Andreas, 2024-08-01
+-- Trigger error PatternMatchingInSystem
+
+{-# OPTIONS --cubical #-}
+
+open import Agda.Primitive            using ()
+  renaming (Set to Type)
+open import Agda.Primitive.Cubical    using (I; i0; i1)
+  renaming (primHComp to hcomp ; primTransp to transp)
+open import Agda.Builtin.Cubical.Path using (PathP; _≡_)
+
+data S¹ : Type where
+  base : S¹
+  loop : base ≡ base
+
+trigger : PathP _ _ _
+trigger j =
+  transp (λ _ → S¹ → S¹) i0
+    (hcomp (λ { i (j = i0) base → base
+              ; i (j = i1) base → base
+              })
+           _)
+
+-- Expected error:
+--
+-- Pattern matching or path copatterns not allowed in systems

--- a/test/Fail/PatternMatchingInSystem.err
+++ b/test/Fail/PatternMatchingInSystem.err
@@ -1,0 +1,3 @@
+PatternMatchingInSystem.agda:19,13-21,16: error: [PatternMatchingInSystem]
+Pattern matching or path copatterns not allowed in systems
+when checking the definition of .extendedlambda0


### PR DESCRIPTION
New error names:
- ExpectedIntervalLiteral
- NeedOptionSizedTypes
- NoKnownRecordWithSuchFields
- PatternMatchingInSystem

Updated:
- NeedOptionCubical now also takes a `reason : String`

Also removed two unreachable occurrences of `GenericError`.
