### PR TITLE
Fixup #7404 and test agdai-generation in cabal-install workflow

### DIFF
--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -54,6 +54,20 @@ jobs:
     - name: Install Agda
       run: |
         cabal install ${FLAGS} ${{ matrix.install_flags }}
+    - if: matrix.name != '--lib'
+      name: Debug
+      run: |
+        echo "PATH = ${PATH}"
+        ls -l ~/.cabal/bin
+        tree -L 3 ~/.cabal/store
+    - if: matrix.name != '--lib'
+      name: Check for Agda library interface files
+      run: |
+        AGDA_VERSION=$(agda --numeric-version)
+        AGDA_DATA_DIR=$(agda --print-agda-data-dir)
+        echo "AGDA_VERSION  = ${AGDA_VERSION}"
+        echo "AGDA_DATA_DIR = ${AGDA_DATA_DIR}"
+        ls -l "${AGDA_DATA_DIR}/lib/prim/_build/${AGDA_VERSION}/agda/Agda/Primitive.agdai"
     - if: always() && steps.cache.outputs.cache-hit != 'true'
       name: Save cache
       uses: actions/cache/save@v4

--- a/Setup.hs
+++ b/Setup.hs
@@ -163,7 +163,6 @@ generateInterfaces pd lbi = do
           ]
   env <- getEnvironment
   handle onIOError $ do
-    throw $ userError "FOO BAR"
     True <$ readCreateProcess
       (proc agda agdaArgs)
         { delegate_ctlc = True

--- a/src/github/workflows/cabal-install.yml
+++ b/src/github/workflows/cabal-install.yml
@@ -47,6 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+        # OBS: name also used in conditional below
         - name:  ""
           install_flags: ""
         - name:  "--lib"
@@ -92,6 +93,22 @@ jobs:
     - name: Install Agda
       run: |
         cabal install ${FLAGS} ${{ matrix.install_flags }}
+
+    - name: Debug
+      if: matrix.name != '--lib'
+      run: |
+        echo "PATH = ${PATH}"
+        ls -l ~/.cabal/bin
+        tree -L 3 ~/.cabal/store
+
+    - name: Check for Agda library interface files
+      if: matrix.name != '--lib'
+      run: |
+        AGDA_VERSION=$(agda --numeric-version)
+        AGDA_DATA_DIR=$(agda --print-agda-data-dir)
+        echo "AGDA_VERSION  = ${AGDA_VERSION}"
+        echo "AGDA_DATA_DIR = ${AGDA_DATA_DIR}"
+        ls -l "${AGDA_DATA_DIR}/lib/prim/_build/${AGDA_VERSION}/agda/Agda/Primitive.agdai"
 
     - name: Save cache
       uses: actions/cache/save@v4


### PR DESCRIPTION
The CI failure https://github.com/agda/agda/actions/runs/10201512448/job/28223527794?pr=7410 is likely a bug in `cabal install`:
- https://github.com/haskell/cabal/issues/10237