### PR TITLE
Replace interaction `Cmd_no_metas` by `Cmd_load_no_metas`

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -130,11 +130,9 @@ generateInterfaces pd lbi = do
         , "-Werror"
         , "-v0"
         ]
-  let loadBuiltinCmds = concat
-        [ [ cmd ("Cmd_load " ++ f ++ " []")
-          , cmd "Cmd_no_metas"
+  let loadBuiltinCmds =
+        [ cmd ("Cmd_load_no_metas " ++ f)
             -- Fail if any meta-variable is unsolved.
-          ]
         | b <- builtins
         , let f     = show (ddir </> b)
               cmd c = "IOTCM " ++ f ++ " None Indirect (" ++ c ++ ")"

--- a/src/full/Agda/Interaction/Base.hs
+++ b/src/full/Agda/Interaction/Base.hs
@@ -148,10 +148,11 @@ data Interaction' range
     -- show those instead.
   | Cmd_metas Rewrite
 
-    -- | A command that fails if there are any unsolved
+    -- | Load a file and fail if there are any unsolved
     -- meta-variables. By default no output is generated if the
     -- command is successful.
-  | Cmd_no_metas
+    -- (This command is used in Agda's installation script (Setup.hs)).
+  | Cmd_load_no_metas FilePath
 
     -- | Shows all the top-level names in the given module, along with
     -- their types. Uses the top-level scope.

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -19,6 +19,7 @@ module Agda.Interaction.Imports
   , scopeCheckImport
   , parseSource
   , typeCheckMain
+  , raiseNonFatalErrors
 
   -- Currently only used by test/api/Issue1168.hs:
   , readInterface
@@ -548,6 +549,15 @@ getInterface x isMain msrc =
             return modl
 
       either recheck pure stored
+
+-- | If checking produced non-benign warnings, error out.
+--
+raiseNonFatalErrors :: (HasOptions m, MonadTCError m)
+  => CheckResult  -- ^ E.g. obtained from 'typeCheckMain'.
+  -> m ()
+raiseNonFatalErrors result = do
+  unlessNullM (applyFlagsToTCWarnings (crWarnings result)) $ \ ws ->
+    typeError $ NonFatalErrors ws
 
 -- | Check if the options used for checking an imported module are
 --   compatible with the current options. Raises Non-fatal errors if

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -236,8 +236,7 @@ runAgdaWithOptions interactor progName opts = do
           result <- Imp.typeCheckMain mode =<< Imp.parseSource (SourceFile inputFile)
 
           unless (crMode result == ModuleScopeChecked) $
-            unlessNullM (applyFlagsToTCWarnings (crWarnings result)) $ \ ws ->
-              typeError $ NonFatalErrors ws
+            Imp.raiseNonFatalErrors result
 
           let i = crInterface result
           reportSDoc "main" 50 $ pretty i

--- a/test/interaction/Cmd_load_no_metas.agda
+++ b/test/interaction/Cmd_load_no_metas.agda
@@ -1,0 +1,5 @@
+-- Andreas, 2024-08-02, cover command Cmd_load_no_metas
+
+f = ?
+
+-- This should fail as no unsolved metas are allowed.

--- a/test/interaction/Cmd_load_no_metas.in
+++ b/test/interaction/Cmd_load_no_metas.in
@@ -1,0 +1,1 @@
+top_command (cmd_load_no_metas currentFile)

--- a/test/interaction/Cmd_load_no_metas.out
+++ b/test/interaction/Cmd_load_no_metas.out
@@ -1,0 +1,6 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-info-action "*Error*" "Unsolved metas at the following locations: Cmd_load_no_metas.agda:3,1-2 Unsolved interaction metas at the following locations: Cmd_load_no_metas.agda:3,5-6" nil)
+(agda2-highlight-load-and-delete-action)
+(agda2-status-action "")


### PR DESCRIPTION
`Cmd_no_metas` was only used in `Setup.hs`, had not reproducer in the testsuite and threw a `GenericError`.

Rather than a new error, we utilize the existing mechanism for erroring out on unsolved metas during checking now.
(`cmd_load'` already had an option whether to allow unsolved metas.)

The new `Cmd_load_no_metas` is also just used in `Setup.hs`, but now has a reproducer in the interaction test suite.
