### PR TITLE
Follow hlint suggestion: use maximum

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -82,7 +82,6 @@
 - ignore: {name: "Use map with tuple-section"} # 4 hints
 - ignore: {name: "Use mapAndUnzipM"} # 1 hint
 - ignore: {name: "Use mapMaybe"} # 3 hints
-- ignore: {name: "Use maximum"} # 1 hint
 - ignore: {name: "Use newtype instead of data"} # 31 hints
 - ignore: {name: "Use null"} # 5 hints
 - ignore: {name: "Use otherwise"} # 1 hint

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -28,7 +28,7 @@
 - ignore: {name: "Hoist not"} # 18 hints
 - ignore: {name: "Move brackets to avoid $"} # 1 hint
 - ignore: {name: "Move guards forward"} # 2 hints
-- ignore: {name: "Redundant $"} # 622 hints
+- ignore: {name: "Redundant $"} # 618 hints
 - ignore: {name: "Redundant <$>"} # 47 hints
 - ignore: {name: "Redundant <&>"} # 4 hints
 - ignore: {name: "Redundant True guards"} # 1 hint
@@ -49,7 +49,7 @@
 - ignore: {name: "Replace case with maybe"} # 4 hints
 - ignore: {name: "Unused LANGUAGE pragma"} # 210 hints
 - ignore: {name: "Use &&"} # 4 hints
-- ignore: {name: "Use ++"} # 13 hints
+- ignore: {name: "Use ++"} # 14 hints
 - ignore: {name: "Use /="} # 1 hint
 - ignore: {name: "Use :"} # 17 hints
 - ignore: {name: "Use <$"} # 4 hints
@@ -61,7 +61,6 @@
 - ignore: {name: "Use >=>"} # 1 hint
 - ignore: {name: "Use Just"} # 2 hints
 - ignore: {name: "Use LANGUAGE pragmas"} # 7 hints
-- ignore: {name: "Use all"} # 1 hint
 - ignore: {name: "Use camelCase"} # 72 hints
 - ignore: {name: "Use concatMap"} # 2 hints
 - ignore: {name: "Use const"} # 79 hints
@@ -75,7 +74,7 @@
 - ignore: {name: "Use infix"} # 1 hint
 - ignore: {name: "Use intercalate"} # 1 hint
 - ignore: {name: "Use isNothing"} # 2 hints
-- ignore: {name: "Use join"} # 2 hints
+- ignore: {name: "Use join"} # 3 hints
 - ignore: {name: "Use lambda-case"} # 11 hints
 - ignore: {name: "Use list literal"} # 12 hints
 - ignore: {name: "Use list literal pattern"} # 1 hint

--- a/src/full/Agda/TypeChecking/Level.hs
+++ b/src/full/Agda/TypeChecking/Level.hs
@@ -121,10 +121,10 @@ reallyUnLevelView :: (HasBuiltins m) => Level -> m Term
 reallyUnLevelView nv = (`unlevelWithKit` nv) <$> builtinLevelKit
 
 unlevelWithKit :: LevelKit -> Level -> Term
-unlevelWithKit LevelKit{ lvlZero = zer, lvlSuc = suc, lvlMax = max } = \case
+unlevelWithKit LevelKit{ lvlZero = zer, lvlSuc = suc, lvlMax } = \case
   Max m []  -> unConstV zer suc m
   Max 0 [a] -> unPlusV suc a
-  Max m as  -> foldl1 max $ [ unConstV zer suc m | m > 0 ] ++ map (unPlusV suc) as
+  Max m as  -> foldl1 lvlMax $ [ unConstV zer suc m | m > 0 ] ++ map (unPlusV suc) as
 
 unConstV :: Term -> (Term -> Term) -> Integer -> Term
 unConstV zer suc n = foldr ($) zer (List.genericReplicate n suc)


### PR DESCRIPTION
Both `foldl1` and `maximum` have partial warnings:

* [foldl1](https://hackage.haskell.org/package/base-4.20.0.1/docs/Prelude.html#v:foldl1)
> A variant of foldl that has no base case, and thus may only be applied to non-empty structures.
>
> This function is non-total and will raise a runtime exception if the structure happens to be empty.


* [maximum](https://hackage.haskell.org/package/base-4.20.0.1/docs/Prelude.html#v:maximum)
> The largest element of a non-empty structure.
>
> This function is non-total and will raise a runtime exception if the structure happens to be empty. A structure that supports random access and maintains its elements in order should provide a specialised implementation to return the maximum in faster than linear time.