### PR TITLE
Fixup #7265: restore passing arguments from goal to Mimer

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1382,7 +1382,7 @@ Either only one if point is a goal, or all of them."
   agda2-mimer
   "Run proof search on a goal."
   "Cmd_autoOne"
-  nil
+  'goal
 )
 
 (agda2-maybe-normalised-toplevel-asis-noprompt


### PR DESCRIPTION
Fixup https://github.com/agda/agda/issues/7265: restore passing arguments from goal to Mimer.
Problem was: hole contents were ignored.

Closes #7212 (again).
