### PR TITLE
GenericError replacements

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -363,13 +363,14 @@ interactionErrorString = \case
 
 unquoteErrorString :: UnquoteError -> String
 unquoteErrorString = \case
-  BadVisibility        {} -> "BadVisibility"
-  ConInsteadOfDef      {} -> "ConInsteadOfDef"
-  DefInsteadOfCon      {} -> "DefInsteadOfCon"
-  NonCanonical         {} -> "NonCanonical"
-  BlockedOnMeta        {} -> "BlockedOnMeta"
-  PatLamWithoutClauses {} -> "PatLamWithoutClauses"
-  UnquotePanic         {} -> "UnquotePanic"
+  BadVisibility               {} -> "BadVisibility"
+  CannotDeclareHiddenFunction {} -> "CannotDeclareHiddenFunction"
+  ConInsteadOfDef             {} -> "ConInsteadOfDef"
+  DefInsteadOfCon             {} -> "DefInsteadOfCon"
+  NonCanonical                {} -> "NonCanonical"
+  BlockedOnMeta               {} -> "BlockedOnMeta"
+  PatLamWithoutClauses        {} -> "PatLamWithoutClauses"
+  UnquotePanic                {} -> "UnquotePanic"
 
 
 instance PrettyTCM TCErr where
@@ -1812,6 +1813,9 @@ instance PrettyTCM UnquoteError where
 
     BadVisibility msg arg -> fsep $
       pwords $ "Unable to unquote the argument. It should be `" ++ msg ++ "'."
+
+    CannotDeclareHiddenFunction f -> fsep $
+      pwords "Cannot declare hidden function" ++ [ prettyTCM f ]
 
     ConInsteadOfDef x def con -> fsep $
       pwords ("Use " ++ con ++ " instead of " ++ def ++ " for constructor") ++

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -37,6 +37,7 @@ import qualified Data.List as List
 import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as Set
+import System.FilePath
 import qualified Text.PrettyPrint.Boxes as Boxes
 
 import Agda.Interaction.Options
@@ -69,13 +70,14 @@ import Agda.TypeChecking.SizedTypes.Pretty ()
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Reduce (instantiate)
 
-import Agda.Interaction.Library.Base (formatLibErrors)
+import Agda.Interaction.Library.Base (formatLibErrors, libFile)
 
 import Agda.Utils.FileName
 import Agda.Utils.Float  ( toStringWithoutDotZero )
 import Agda.Utils.Function
 import Agda.Utils.Functor( for )
 import Agda.Utils.IO     ( showIOException )
+import Agda.Utils.Lens
 import Agda.Utils.List   ( initLast, lastMaybe )
 import Agda.Utils.List1 (List1, pattern (:|))
 import qualified Agda.Utils.List1 as List1
@@ -183,6 +185,7 @@ errorString = \case
   InvalidPattern{}                         -> "InvalidPattern"
   InvalidFileName{}                        -> "InvalidFileName"
   LibraryError{}                           -> "LibraryError"
+  LibTooFarDown{}                          -> "LibTooFarDown"
   LiteralTooBig{}                          -> "LiteralTooBig"
   LocalVsImportedModuleClash{}             -> "LocalVsImportedModuleClash"
   MetaCannotDependOn{}                     -> "MetaCannotDependOn"
@@ -904,6 +907,11 @@ instance PrettyTCM TypeError where
       "is an absurd pattern, () or {}, in the left-hand side."
 
     LibraryError err -> return $ formatLibErrors err
+
+    LibTooFarDown m lib -> vcat
+      [ text "A .agda-lib file for" <+> pretty m
+      , text "must not be located in the directory" <+> text (takeDirectory (lib ^. libFile))
+      ]
 
     LocalVsImportedModuleClash m -> fsep $
       pwords "The module" ++ [prettyTCM m] ++

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4663,6 +4663,8 @@ data UnificationFailure
 
 data UnquoteError
   = BadVisibility String (Arg I.Term)
+  | CannotDeclareHiddenFunction QName
+      -- ^ Attempt to @unquoteDecl@ with 'Hiding' other than 'NotHidden'.
   | ConInsteadOfDef QName String String
   | DefInsteadOfCon QName String String
   | NonCanonical String I.Term
@@ -5794,6 +5796,9 @@ typeError_ = withCallerCallStack . flip typeError'_
 
 interactionError :: (HasCallStack, MonadTCError m) => InteractionError -> m a
 interactionError = locatedTypeError InteractionError
+
+unquoteError :: (HasCallStack, MonadTCError m) => UnquoteError -> m a
+unquoteError = locatedTypeError UnquoteFailed
 
 -- | Running the type checking monad (most general form).
 {-# SPECIALIZE runTCM :: TCEnv -> TCState -> TCM a -> IO (a, TCState) #-}

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4873,6 +4873,8 @@ data TypeError
     -- Import errors
         | LibraryError LibErrors
             -- ^ Collected errors when processing the @.agda-lib@ file.
+        | LibTooFarDown TopLevelModuleName AgdaLibFile
+            -- ^ The @.agda-lib@ file for the given module is not on the right level.
         | LocalVsImportedModuleClash ModuleName
         | SolvedButOpenHoles
           -- ^ Some interaction points (holes) have not been filled by user.

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -169,10 +169,7 @@ checkLibraryFileNotTooFarDown ::
   AgdaLibFile ->
   TCM ()
 checkLibraryFileNotTooFarDown m lib =
-  when (lib ^. libAbove < size m - 1) $ typeError $ GenericError $
-    "A .agda-lib file for " ++ prettyShow m ++
-    " must not be located in the directory " ++
-    takeDirectory (lib ^. libFile)
+  when (lib ^. libAbove < size m - 1) $ typeError $ LibTooFarDown m lib
 
 -- | Returns the library options for a given file.
 

--- a/test/Fail/Issue1228.err
+++ b/test/Fail/Issue1228.err
@@ -1,2 +1,2 @@
-Issue1228.agda:40,1-45: error: [UnquoteFailed]
+Issue1228.agda:40,1-45: error: [Unquote.DefInsteadOfCon]
 Use def instead of con for non-constructor tt

--- a/test/Fail/Issue1228b.err
+++ b/test/Fail/Issue1228b.err
@@ -1,2 +1,2 @@
-Issue1228b.agda:40,1-45: error: [UnquoteFailed]
+Issue1228b.agda:40,1-45: error: [Unquote.ConInsteadOfDef]
 Use con instead of def for constructor refl

--- a/test/Fail/Issue7326.err
+++ b/test/Fail/Issue7326.err
@@ -1,4 +1,4 @@
-Issue7326.agda:13,7-12: error: [UnquoteFailed]
+Issue7326.agda:13,7-12: error: [Unquote.PatLamWithoutClauses]
 Cannot unquote pattern lambda without clauses. Use a single
 'absurd-clause' for absurd lambdas.
 when checking that the expression unquote magic has type ⊥ → ⊤

--- a/test/Fail/PostulateMacro.err
+++ b/test/Fail/PostulateMacro.err
@@ -1,4 +1,4 @@
-PostulateMacro.agda:15,8-19: error: [UnquoteFailed]
+PostulateMacro.agda:15,8-19: error: [Unquote.NonCanonical]
 Cannot unquote non-canonical type checking computation
   stuck
 when checking that the expression unquote not-so-good has type Nat

--- a/test/Fail/StrangeRecursiveUnquote.err
+++ b/test/Fail/StrangeRecursiveUnquote.err
@@ -1,4 +1,4 @@
-StrangeRecursiveUnquote.agda:12,13-33: error: [UnquoteFailed]
+StrangeRecursiveUnquote.agda:12,13-33: error: [Unquote.NonCanonical]
 Cannot unquote non-canonical term
   f n
 when checking that the expression unquote (give (f n)) has type

--- a/test/Fail/UnquoteCannotDeclareHiddenFunction.agda
+++ b/test/Fail/UnquoteCannotDeclareHiddenFunction.agda
@@ -1,0 +1,8 @@
+
+open import Common.Prelude
+open import Common.Reflection
+
+pattern `Nat = def (quote Nat) []
+
+unquoteDecl x =
+  define (hArg x) (funDef `Nat (clause [] [] (quoteTerm 15) ∷ []))

--- a/test/Fail/UnquoteCannotDeclareHiddenFunction.err
+++ b/test/Fail/UnquoteCannotDeclareHiddenFunction.err
@@ -1,0 +1,2 @@
+UnquoteCannotDeclareHiddenFunction.agda:7,1-8,67: error: [Unquote.CannotDeclareHiddenFunction]
+Cannot declare hidden function x

--- a/test/Fail/customised/Issue6465.err
+++ b/test/Fail/customised/Issue6465.err
@@ -1,5 +1,5 @@
-customised/Issue6465.agda:1,1-11: error: [GenericError]
-A .agda-lib file for A.B must not be located in the directory
-customised/Issue6465/A
+customised/Issue6465.agda:1,1-11: error: [LibTooFarDown]
+A .agda-lib file for A.B
+must not be located in the directory customised/Issue6465/A
 when scope checking the declaration
   import A.B


### PR DESCRIPTION
- New UnquoteError CannotDeclareHiddenFunction with reproducer
- Print UnquoteError names rather than just name "UnquoteFailed"
- New error LibTooFarDown instead of GenericError