### PR TITLE
#7402: mimer failing on higher order goal

### DIFF
--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -723,7 +723,9 @@ runSearch norm options ii rng = withInteractionId ii $ do
                                        , "with args" <+> pretty (instTel inst) ]
 
       -- ctx <- getContextTelescope
-      return metaIds
+      -- #7402: still solve the top-level meta, because we don't have the correct contexts for the
+      --        submetas
+      return [metaId | not $ null metaIds]
     OpenMeta UnificationMeta -> do
       reportSLn "mimer.init" 20 "Interaction point not instantiated."
       return [metaId]
@@ -1122,7 +1124,6 @@ tryLamAbs :: Goal -> Type -> SearchBranch -> SM (Either Expr (Goal, Type, Search
 tryLamAbs goal goalType branch =
   case unEl goalType of
     Pi dom abs -> do
-     e <- isEmptyType (unDom dom)
      isEmptyType (unDom dom) >>= \case -- TODO: Is this the correct way of checking if absurd lambda is applicable?
       True -> do
         let argInf = defaultArgInfo{argInfoOrigin = Inserted} -- domInfo dom

--- a/test/interaction/Issue7402.agda
+++ b/test/interaction/Issue7402.agda
@@ -1,0 +1,7 @@
+postulate
+  A : Set
+  x : A
+  f : (P : A → Set) → P x
+
+g : (P : ((A → A) → A) → Set) → P (λ h → h x)
+g P = f (λ y → P ?)

--- a/test/interaction/Issue7402.in
+++ b/test/interaction/Issue7402.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 0 (cmd_autoOne AsIs) ""

--- a/test/interaction/Issue7402.out
+++ b/test/interaction/Issue7402.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals, Errors*" "?0 : (A → A) → A _8 : (A → A) → A [ at Issue7402.agda:7,18-19 ] ———— Error ————————————————————————————————————————————————— Failed to solve the following constraints: _8 (y = x) h = h x : A (blocked on _8)" nil)
+((last . 1) . (agda2-goals-action '(0)))
+(agda2-give-action 0 "λ z → y")
+((last . 1) . (agda2-goals-action '()))


### PR DESCRIPTION
fixes #7402

The problem arises when the goal is already partially instantiated. In that case Mimer tried to solve the metas of the instantiation, but without computing the correct context for those metas. The fix is to have Mimer solve the original goal instead. Currently that means that we might get a solution that disagrees with the existing instantiation, but that should get fixed with #7110.