### PR TITLE
Reform printing of parse error

### DIFF
--- a/src/full/Agda/Interaction/CommandLine.hs
+++ b/src/full/Agda/Interaction/CommandLine.hs
@@ -351,5 +351,4 @@ help cs = putStr $ unlines $
 readM :: Read a => String -> TCM a
 readM s = maybe err return $ readMaybe s
   where
-  err    = throwError $ strMsg $ "Cannot parse: " ++ s
-  strMsg = Exception noRange . text
+  err = throwError $ GenericException $ "Cannot parse: " ++ s

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -245,7 +245,7 @@ handleCommand wrap onFail cmd = handleNastyErrors $ wrap $ do
             toIO $ handleErr (Just Direct) $ IOException Nothing noRange e
 
           generalHandler (e :: E.SomeException) = Right <$> do
-            toIO $ handleErr (Just Direct) $ Exception noRange $ text $ showIOException e
+            toIO $ handleErr (Just Direct) $ GenericException $ showIOException e
 
       r <- (Right <$> toIO m)
              `E.catch` asyncHandler

--- a/src/full/Agda/Syntax/Parser/Monad.hs
+++ b/src/full/Agda/Syntax/Parser/Monad.hs
@@ -164,6 +164,13 @@ data ParseError
     }
   deriving Show
 
+instance NFData ParseError where
+  rnf = \case
+    ParseError _f _r inp tok msg  -> rnf inp `seq` rnf tok `seq` rnf msg
+    OverlappingTokensError _r     -> ()
+    InvalidExtensionError _r exts -> rnf exts
+    ReadFileError _r _err         -> ()
+
 -- | Warnings for parsing.
 data ParseWarning
   -- | Parse errors that concern a range in a file.
@@ -224,18 +231,20 @@ parseWarning w =
 
 instance Pretty ParseError where
   pretty ParseError{errPos,errSrcFile,errMsg,errPrevToken,errInput} = vcat
-      [ (pretty (errPos { srcFile = errSrcFile }) <> colon) <+>
-        text errMsg
-      , text $ errPrevToken ++ "<ERROR>"
-      , text $ take 30 errInput ++ "..."
+      [ (pretty errPos{ srcFile = errSrcFile } <> colon) <+> "error: [ParseError]"
+      , if not $ null errMsg then text errMsg else sep
+          -- Happy errors have no message, so we print the context instead
+          [ text $ errPrevToken ++ "<ERROR>"
+          , text $ take 30 errInput ++ "..."
+          ]
       ]
   pretty OverlappingTokensError{errRange} = vcat
-      [ (pretty errRange <> colon) <+>
-        "Multi-line comment spans one or more literate text blocks."
+      [ (pretty errRange <> colon) <+> "error: [OverlappingTokensError]"
+      , "Multi-line comment spans one or more literate text blocks."
       ]
   pretty InvalidExtensionError{errPath,errValidExts} = vcat
-      [ (pretty errPath <> colon) <+>
-        "Unsupported extension."
+      [ (pretty errPath <> colon) <+> "error: [InvalidExtensionError]"
+      , "Unsupported extension."
       , "Supported extensions are:" <+> prettyList_ errValidExts
       ]
   pretty ReadFileError{errPath,errIOError} = vcat

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1889,7 +1889,7 @@ parseDisplayPragma r pos s =
 
 -- | Required by Happy.
 happyError :: Parser a
-happyError = parseError "Parse error"
+happyError = parseError ""
 
 
 {--------------------------------------------------------------------------

--- a/src/full/Agda/TypeChecking/Conversion/Pure.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Pure.hs
@@ -78,6 +78,7 @@ runPureConversion (PureConversionT m) = locallyTC eCompareBlocked (const True) $
       return Nothing
     Left Exception{}   -> __IMPOSSIBLE__
     Left IOException{} -> __IMPOSSIBLE__
+    Left ParserError{} -> __IMPOSSIBLE__
     Right x            -> do
       debugResult "success"
       return $ Just x

--- a/src/full/Agda/TypeChecking/Conversion/Pure.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Pure.hs
@@ -73,13 +73,13 @@ runPureConversion (PureConversionT m) = locallyTC eCompareBlocked (const True) $
      | otherwise             -> do
          debugResult $ "blocked on" <+> prettyTCM block
          patternViolation block
-    Left TypeError{}   -> do
+    Left TypeError{}         -> do
       debugResult "type error"
       return Nothing
-    Left Exception{}   -> __IMPOSSIBLE__
-    Left IOException{} -> __IMPOSSIBLE__
-    Left ParserError{} -> __IMPOSSIBLE__
-    Right x            -> do
+    Left GenericException{}  -> __IMPOSSIBLE__
+    Left IOException{}       -> __IMPOSSIBLE__
+    Left ParserError{}       -> __IMPOSSIBLE__
+    Right x                  -> do
       debugResult "success"
       return $ Just x
   where

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -127,11 +127,11 @@ tcErrString :: TCErr -> String
 tcErrString err =
   unwords . filter (not . null) . (prettyShow (getRange err) :) $
     case err of
-      TypeError _ _ cl  -> [ errorString $ clValue cl ]
-      ParserError e     -> [ "ParserError" ]
-      Exception r s     -> [ prettyShow r, show s ]
-      IOException _ r e -> [ prettyShow r, showIOException e ]
-      PatternErr{}      -> [ "PatternErr" ]
+      TypeError _ _ cl     -> [ errorString $ clValue cl ]
+      ParserError e        -> [ "ParserError" ]
+      GenericException msg -> [ msg ]
+      IOException _ r e    -> [ prettyShow r, showIOException e ]
+      PatternErr{}         -> [ "PatternErr" ]
 
 errorString :: TypeError -> String
 errorString = \case
@@ -399,7 +399,7 @@ instance PrettyTCM TCErr where
         , prettyTCM (envCall $ clEnv e)
         ]
     ParserError err   -> pretty err
-    Exception r s     -> sayWhere r $ return s
+    GenericException msg -> fwords msg
     IOException _ r e -> sayWhere r $ fwords $ showIOException e
     PatternErr{}      -> sayWhere err $ panic "uncaught pattern violation"
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -128,6 +128,7 @@ tcErrString err =
   unwords . filter (not . null) . (prettyShow (getRange err) :) $
     case err of
       TypeError _ _ cl  -> [ errorString $ clValue cl ]
+      ParserError e     -> [ "ParserError" ]
       Exception r s     -> [ prettyShow r, show s ]
       IOException _ r e -> [ prettyShow r, showIOException e ]
       PatternErr{}      -> [ "PatternErr" ]
@@ -397,6 +398,7 @@ instance PrettyTCM TCErr where
         , prettyTCM e
         , prettyTCM (envCall $ clEnv e)
         ]
+    ParserError err   -> pretty err
     Exception r s     -> sayWhere r $ return s
     IOException _ r e -> sayWhere r $ fwords $ showIOException e
     PatternErr{}      -> sayWhere err $ panic "uncaught pattern violation"

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -155,6 +155,7 @@ blockOnError blocker f
     PatternErr blocker' -> throwError $ PatternErr $ unblockOnEither blocker blocker'
     err@Exception{}     -> throwError err
     err@IOException{}   -> throwError err
+    ParserError{}       -> __IMPOSSIBLE__
 
 -- | Instantiate something.
 --   Results in an open meta variable or a non meta.

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -153,7 +153,7 @@ blockOnError blocker f
   | otherwise               = f `catchError` \case
     TypeError{}         -> throwError $ PatternErr blocker
     PatternErr blocker' -> throwError $ PatternErr $ unblockOnEither blocker blocker'
-    err@Exception{}     -> throwError err
+    GenericException{}  -> __IMPOSSIBLE__
     err@IOException{}   -> throwError err
     ParserError{}       -> __IMPOSSIBLE__
 

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -219,5 +219,5 @@ runPM m = do
   (res, ws) <- runPMIO m
   mapM_ (warning . ParseWarning) ws
   case res of
-    Left  e -> throwError (Exception (getRange e) (P.pretty e))
+    Left  e -> throwError $ ParserError e
     Right a -> return a

--- a/test/Fail/AgdalightTelescopeSyntax.err
+++ b/test/Fail/AgdalightTelescopeSyntax.err
@@ -1,5 +1,4 @@
-AgdalightTelescopeSyntax.agda:6,15-15
-AgdalightTelescopeSyntax.agda:6,15: Parse error
+AgdalightTelescopeSyntax.agda:6,15: error: [ParseError]
 ;<ERROR>
  z : B x) -> A
 -- this is Agda...

--- a/test/Fail/AttributeConflict.err
+++ b/test/Fail/AttributeConflict.err
@@ -1,4 +1,2 @@
-AttributeConflict.agda:4,3-3
-AttributeConflict.agda:4,3: Conflicting attributes: 0 ω
-<EOF><ERROR>
-...
+AttributeConflict.agda:4,3: error: [ParseError]
+Conflicting attributes: 0 ω

--- a/test/Fail/AttributeUnparenthesized.err
+++ b/test/Fail/AttributeUnparenthesized.err
@@ -1,5 +1,4 @@
-AttributeUnparenthesized.agda:4,12-12
-AttributeUnparenthesized.agda:4,12: Parse error
+AttributeUnparenthesized.agda:4,12: error: [ParseError]
 @<ERROR>
 0 A → A → A
 

--- a/test/Fail/ConflictingRelevance.err
+++ b/test/Fail/ConflictingRelevance.err
@@ -1,5 +1,4 @@
-ConflictingRelevance.agda:4,34-34
-ConflictingRelevance.agda:4,34: Parse error
+ConflictingRelevance.agda:4,34: error: [ParseError]
 )<ERROR>
  → A
 

--- a/test/Fail/ConflictingRelevance1.err
+++ b/test/Fail/ConflictingRelevance1.err
@@ -1,5 +1,4 @@
-ConflictingRelevance1.agda:4,42-42
-ConflictingRelevance1.agda:4,42: Parse error
+ConflictingRelevance1.agda:4,42: error: [ParseError]
 )<ERROR>
  → A
 

--- a/test/Fail/ConflictingRelevance2.err
+++ b/test/Fail/ConflictingRelevance2.err
@@ -1,5 +1,4 @@
-ConflictingRelevance2.agda:4,37-37
-ConflictingRelevance2.agda:4,37: Parse error
+ConflictingRelevance2.agda:4,37: error: [ParseError]
 )<ERROR>
  → A
 

--- a/test/Fail/Consecutive-underscores.err
+++ b/test/Fail/Consecutive-underscores.err
@@ -1,5 +1,2 @@
-Consecutive-underscores.agda:2,6-6
-Consecutive-underscores.agda:2,6: a name cannot contain two consecutive underscores
-:<ERROR>
- Set
-...
+Consecutive-underscores.agda:2,6: error: [ParseError]
+a name cannot contain two consecutive underscores

--- a/test/Fail/InstanceArgumentsBraceSpaces.err
+++ b/test/Fail/InstanceArgumentsBraceSpaces.err
@@ -1,5 +1,2 @@
-InstanceArgumentsBraceSpaces.agda:5,19-19
-InstanceArgumentsBraceSpaces.agda:5,19: Expecting '}}', found separated '}'s.
-→<ERROR>
- B
-...
+InstanceArgumentsBraceSpaces.agda:5,19: error: [ParseError]
+Expecting '}}', found separated '}'s.

--- a/test/Fail/Invalid-name-part.err
+++ b/test/Fail/Invalid-name-part.err
@@ -1,5 +1,2 @@
-Invalid-name-part.agda:2,7-7
-Invalid-name-part.agda:2,7: in the name _→_, the part → is not valid because it is the function arrow
-:<ERROR>
- Set
-...
+Invalid-name-part.agda:2,7: error: [ParseError]
+in the name _→_, the part → is not valid because it is the function arrow

--- a/test/Fail/Invalid-name-part2.err
+++ b/test/Fail/Invalid-name-part2.err
@@ -1,4 +1,2 @@
-Invalid-name-part2.agda:2,7-7
-Invalid-name-part2.agda:2,7: in the name →, the part → is not valid because it is the function arrow
-<EOF><ERROR>
-...
+Invalid-name-part2.agda:2,7: error: [ParseError]
+in the name →, the part → is not valid because it is the function arrow

--- a/test/Fail/Invalid-polarity.err
+++ b/test/Fail/Invalid-polarity.err
@@ -1,5 +1,2 @@
-Invalid-polarity.agda:4,18-18
-Invalid-polarity.agda:4,18: Not a valid polarity: ⚄
-#-}<ERROR>
-
-...
+Invalid-polarity.agda:4,18: error: [ParseError]
+Not a valid polarity: ⚄

--- a/test/Fail/InvalidNamePartBar.err
+++ b/test/Fail/InvalidNamePartBar.err
@@ -1,5 +1,2 @@
-InvalidNamePartBar.agda:1,19-19
-InvalidNamePartBar.agda:1,19: in the name _|_, the part | is not valid because it is used for with-arguments
-→<ERROR>
- Set
-...
+InvalidNamePartBar.agda:1,19: error: [ParseError]
+in the name _|_, the part | is not valid because it is used for with-arguments

--- a/test/Fail/InvalidNamePartColon.err
+++ b/test/Fail/InvalidNamePartColon.err
@@ -1,5 +1,2 @@
-InvalidNamePartColon.agda:1,19-19
-InvalidNamePartColon.agda:1,19: in the name _:_, the part : is not valid because it is part of declaration syntax
-→<ERROR>
- Set
-...
+InvalidNamePartColon.agda:1,19: error: [ParseError]
+in the name _:_, the part : is not valid because it is part of declaration syntax

--- a/test/Fail/InvalidNamePartEquals.err
+++ b/test/Fail/InvalidNamePartEquals.err
@@ -1,5 +1,2 @@
-InvalidNamePartEquals.agda:1,19-19
-InvalidNamePartEquals.agda:1,19: in the name _=_, the part = is not valid because it is part of declaration syntax
-→<ERROR>
- Set
-...
+InvalidNamePartEquals.agda:1,19: error: [ParseError]
+in the name _=_, the part = is not valid because it is part of declaration syntax

--- a/test/Fail/InvalidNamePartIdiom.err
+++ b/test/Fail/InvalidNamePartIdiom.err
@@ -1,5 +1,2 @@
-InvalidNamePartIdiom.agda:1,19-19
-InvalidNamePartIdiom.agda:1,19: in the name _⦇_, the part ⦇ is not valid because it is an idiom bracket
-→<ERROR>
- Set
-...
+InvalidNamePartIdiom.agda:1,19: error: [ParseError]
+in the name _⦇_, the part ⦇ is not valid because it is an idiom bracket

--- a/test/Fail/InvalidNamePartInstance.err
+++ b/test/Fail/InvalidNamePartInstance.err
@@ -1,5 +1,2 @@
-InvalidNamePartInstance.agda:1,19-19
-InvalidNamePartInstance.agda:1,19: in the name _⦃_, the part ⦃ is not valid because it is used for instance arguments
-→<ERROR>
- Set
-...
+InvalidNamePartInstance.agda:1,19: error: [ParseError]
+in the name _⦃_, the part ⦃ is not valid because it is used for instance arguments

--- a/test/Fail/InvalidNamePartKeyword.err
+++ b/test/Fail/InvalidNamePartKeyword.err
@@ -1,5 +1,2 @@
-InvalidNamePartKeyword.agda:1,21-21
-InvalidNamePartKeyword.agda:1,21: in the name _let_, the part let is not valid because it is a keyword
-→<ERROR>
- Set
-...
+InvalidNamePartKeyword.agda:1,21: error: [ParseError]
+in the name _let_, the part let is not valid because it is a keyword

--- a/test/Fail/InvalidNamePartLambda.err
+++ b/test/Fail/InvalidNamePartLambda.err
@@ -1,5 +1,2 @@
-InvalidNamePartLambda.agda:1,19-19
-InvalidNamePartLambda.agda:1,19: in the name _λ_, the part λ is not valid because it is used for lambda-abstraction
-→<ERROR>
- Set
-...
+InvalidNamePartLambda.agda:1,19: error: [ParseError]
+in the name _λ_, the part λ is not valid because it is used for lambda-abstraction

--- a/test/Fail/InvalidNamePartLiteral.err
+++ b/test/Fail/InvalidNamePartLiteral.err
@@ -1,5 +1,2 @@
-InvalidNamePartLiteral.agda:1,19-19
-InvalidNamePartLiteral.agda:1,19: in the name _0_, the part 0 is not valid because it is a literal
-→<ERROR>
- Set
-...
+InvalidNamePartLiteral.agda:1,19: error: [ParseError]
+in the name _0_, the part 0 is not valid because it is a literal

--- a/test/Fail/InvalidNamePartMeta.err
+++ b/test/Fail/InvalidNamePartMeta.err
@@ -1,5 +1,2 @@
-InvalidNamePartMeta.agda:1,19-19
-InvalidNamePartMeta.agda:1,19: in the name _?_, the part ? is not valid because it is a meta variable
-→<ERROR>
- Set
-...
+InvalidNamePartMeta.agda:1,19: error: [ParseError]
+in the name _?_, the part ? is not valid because it is a meta variable

--- a/test/Fail/Issue1125.err
+++ b/test/Fail/Issue1125.err
@@ -1,5 +1,4 @@
-Issue1125.agda:6,4-4
-Issue1125.agda:6,4: Parse error
+Issue1125.agda:6,4: error: [ParseError]
 A-}<ERROR>
  = A-
 

--- a/test/Fail/Issue1145.err
+++ b/test/Fail/Issue1145.err
@@ -1,4 +1,3 @@
-Issue1145.agda:8,3-3
-Issue1145.agda:8,3: Parse error
+Issue1145.agda:8,3: error: [ParseError]
 Bad<ERROR>
  : Set                      --...

--- a/test/Fail/Issue1145b.err
+++ b/test/Fail/Issue1145b.err
@@ -1,4 +1,3 @@
-Issue1145b.agda:7,11-11
-Issue1145b.agda:7,11: Parse error
+Issue1145b.agda:7,11: error: [ParseError]
 :<ERROR>
  Set          -- Bad, should f...

--- a/test/Fail/Issue1391a.err
+++ b/test/Fail/Issue1391a.err
@@ -1,5 +1,2 @@
-Issue1391a.agda:5,16-16
-Issue1391a.agda:5,16: expected sequence of bound identifiers
-:<ERROR>
- Set} → Set
-...
+Issue1391a.agda:5,16: error: [ParseError]
+expected sequence of bound identifiers

--- a/test/Fail/Issue1391b.err
+++ b/test/Fail/Issue1391b.err
@@ -1,5 +1,4 @@
-Issue1391b.agda:5,14-14
-Issue1391b.agda:5,14: Parse error
+Issue1391b.agda:5,14: error: [ParseError]
 :<ERROR>
  Set} → Set
 ...

--- a/test/Fail/Issue1391c.err
+++ b/test/Fail/Issue1391c.err
@@ -1,5 +1,2 @@
-Issue1391c.agda:5,14-14
-Issue1391c.agda:5,14: Expected sequence of possibly hidden bound identifiers
-:<ERROR>
- Set) → Set
-...
+Issue1391c.agda:5,14: error: [ParseError]
+Expected sequence of possibly hidden bound identifiers

--- a/test/Fail/Issue1391d.err
+++ b/test/Fail/Issue1391d.err
@@ -1,5 +1,2 @@
-Issue1391d.agda:5,18-18
-Issue1391d.agda:5,18: Expected sequence of possibly hidden bound identifiers
-:<ERROR>
- Set) → Set
-...
+Issue1391d.agda:5,18: error: [ParseError]
+Expected sequence of possibly hidden bound identifiers

--- a/test/Fail/Issue1465-data.err
+++ b/test/Fail/Issue1465-data.err
@@ -1,5 +1,4 @@
-Issue1465-data.agda:1,8-8
-Issue1465-data.agda:1,8: Parse error
+Issue1465-data.agda:1,8: error: [ParseError]
 :<ERROR>
  Set where
 ...

--- a/test/Fail/Issue1465-record.err
+++ b/test/Fail/Issue1465-record.err
@@ -1,4 +1,2 @@
-Issue1465-record.agda:1,8-8
-Issue1465-record.agda:1,8: Not a valid identifier: _
-<EOF><ERROR>
-...
+Issue1465-record.agda:1,8: error: [ParseError]
+Not a valid identifier: _

--- a/test/Fail/Issue1484.err
+++ b/test/Fail/Issue1484.err
@@ -1,7 +1,2 @@
-Issue1484.agda:40,14-14
-Issue1484.agda:40,14: expected sequence of bound identifiers, not absurd pattern
-}<ERROR>
-}
-
--- Error WAS:
--- Internal p...
+Issue1484.agda:40,14: error: [ParseError]
+expected sequence of bound identifiers, not absurd pattern

--- a/test/Fail/Issue1609-negative-literal.err
+++ b/test/Fail/Issue1609-negative-literal.err
@@ -1,5 +1,2 @@
-Issue1609-negative-literal.agda:3,6-6
-Issue1609-negative-literal.agda:3,6: Illegal name in type signature: -1
-Set1<ERROR>
--1 = Set
-...
+Issue1609-negative-literal.agda:3,6: error: [ParseError]
+Illegal name in type signature: -1

--- a/test/Fail/Issue1609.err
+++ b/test/Fail/Issue1609.err
@@ -1,5 +1,2 @@
-Issue1609.agda:3,5-5
-Issue1609.agda:3,5: Illegal name in type signature: 1
-Set1<ERROR>
-1 = Set
-...
+Issue1609.agda:3,5: error: [ParseError]
+Illegal name in type signature: 1

--- a/test/Fail/Issue1609a.err
+++ b/test/Fail/Issue1609a.err
@@ -1,4 +1,2 @@
-Issue1609a.agda:3,19-19
-Issue1609a.agda:3,19: A type signature cannot have a where clause
-<EOF><ERROR>
-...
+Issue1609a.agda:3,19: error: [ParseError]
+A type signature cannot have a where clause

--- a/test/Fail/Issue1609b.err
+++ b/test/Fail/Issue1609b.err
@@ -1,4 +1,2 @@
-Issue1609b.agda:3,7-7
-Issue1609b.agda:3,7: The ellipsis ... cannot have a type signature
-<EOF><ERROR>
-...
+Issue1609b.agda:3,7: error: [ParseError]
+The ellipsis ... cannot have a type signature

--- a/test/Fail/Issue1609c.err
+++ b/test/Fail/Issue1609c.err
@@ -1,4 +1,2 @@
-Issue1609c.agda:3,9-9
-Issue1609c.agda:3,9: Illegal: with patterns in type signature
-<EOF><ERROR>
-...
+Issue1609c.agda:3,9: error: [ParseError]
+Illegal: with patterns in type signature

--- a/test/Fail/Issue1609d.err
+++ b/test/Fail/Issue1609d.err
@@ -1,4 +1,2 @@
-Issue1609d.agda:3,12-12
-Issue1609d.agda:3,12: Illegal: with in type signature
-<EOF><ERROR>
-...
+Issue1609d.agda:3,12: error: [ParseError]
+Illegal: with in type signature

--- a/test/Fail/Issue1609e.err
+++ b/test/Fail/Issue1609e.err
@@ -1,4 +1,2 @@
-Issue1609e.agda:3,15-15
-Issue1609e.agda:3,15: Illegal: rewrite in type signature
-<EOF><ERROR>
-...
+Issue1609e.agda:3,15: error: [ParseError]
+Illegal: rewrite in type signature

--- a/test/Fail/Issue1609f.err
+++ b/test/Fail/Issue1609f.err
@@ -1,5 +1,2 @@
-Issue1609f.agda:3,9-9
-Issue1609f.agda:3,9: Illegal name in type signature: (A B)
-Set1<ERROR>
-A B = Set
-...
+Issue1609f.agda:3,9: error: [ParseError]
+Illegal name in type signature: (A B)

--- a/test/Fail/Issue1698-field.err
+++ b/test/Fail/Issue1698-field.err
@@ -1,5 +1,4 @@
-Issue1698-field.agda:2,7-7
-Issue1698-field.agda:2,7: Parse error
+Issue1698-field.agda:2,7: error: [ParseError]
 =<ERROR>
  Set
 

--- a/test/Fail/Issue1698-primitive.err
+++ b/test/Fail/Issue1698-primitive.err
@@ -1,5 +1,4 @@
-Issue1698-primitive.agda:2,3-3
-Issue1698-primitive.agda:2,3: Parse error
+Issue1698-primitive.agda:2,3: error: [ParseError]
 data<ERROR>
  D : Set where
 

--- a/test/Fail/Issue2579.err
+++ b/test/Fail/Issue2579.err
@@ -1,4 +1,2 @@
-Issue2579.agda:4,1-1
-Issue2579.agda:4,1: An import statement with module instantiation is useless without either an 'open' keyword or an 'as' binding giving a name to the instantiated module.
-<EOF><ERROR>
-...
+Issue2579.agda:4,1: error: [ParseError]
+An import statement with module instantiation is useless without either an 'open' keyword or an 'as' binding giving a name to the instantiated module.

--- a/test/Fail/Issue2870.err
+++ b/test/Fail/Issue2870.err
@@ -1,6 +1,2 @@
-Issue2870.agda:5,3-3
-Issue2870.agda:5,3: Lexical error (unprintable character):
-beforeHyphen<ERROR>
-­afterHyphen : Set
-
--- Expecte...
+Issue2870.agda:5,3: error: [ParseError]
+Lexical error (unprintable character):

--- a/test/Fail/Issue3007.err
+++ b/test/Fail/Issue3007.err
@@ -1,5 +1,2 @@
-Issue3007.agda:8,15-15
-Issue3007.agda:8,15: in the name _--, the part -- is not valid
-This<ERROR>
- is the end of the file!
-...
+Issue3007.agda:8,15: error: [ParseError]
+in the name _--, the part -- is not valid

--- a/test/Fail/Issue308b.err
+++ b/test/Fail/Issue308b.err
@@ -1,6 +1,2 @@
-Issue308b.agda:6,18-18
-Issue308b.agda:6,18: Malformed syntax declaration: syntax must not contain adjacent holes (x)
-x<ERROR>
-g : D → D
-g (d x) = e x
-...
+Issue308b.agda:6,18: error: [ParseError]
+Malformed syntax declaration: syntax must not contain adjacent holes (x)

--- a/test/Fail/Issue3090-as.err
+++ b/test/Fail/Issue3090-as.err
@@ -1,6 +1,2 @@
-Issue3090-as.agda:4,23-23
-Issue3090-as.agda:4,23: in the name @, the part @ is not valid because it is used for as-patterns
-#-}<ERROR>
-
-
--- Should fail with a parse ...
+Issue3090-as.agda:4,23: error: [ParseError]
+in the name @, the part @ is not valid because it is used for as-patterns

--- a/test/Fail/Issue3090-end-of-comment.err
+++ b/test/Fail/Issue3090-end-of-comment.err
@@ -1,6 +1,2 @@
-Issue3090-end-of-comment.agda:4,24-24
-Issue3090-end-of-comment.agda:4,24: in the name -}, the part -} is not valid because it is the end-of-comment brace
-#-}<ERROR>
-
-
--- Should fail with a parse ...
+Issue3090-end-of-comment.agda:4,24: error: [ParseError]
+in the name -}, the part -} is not valid because it is the end-of-comment brace

--- a/test/Fail/Issue3090-lbrace.err
+++ b/test/Fail/Issue3090-lbrace.err
@@ -1,6 +1,2 @@
-Issue3090-lbrace.agda:4,23-23
-Issue3090-lbrace.agda:4,23: in the name {, the part { is not valid because it is used for hidden arguments
-#-}<ERROR>
-
-
--- Should fail with a parse ...
+Issue3090-lbrace.agda:4,23: error: [ParseError]
+in the name {, the part { is not valid because it is used for hidden arguments

--- a/test/Fail/Issue3090-lparen.err
+++ b/test/Fail/Issue3090-lparen.err
@@ -1,6 +1,2 @@
-Issue3090-lparen.agda:4,23-23
-Issue3090-lparen.agda:4,23: in the name (, the part ( is not valid because it is used to parenthesize expressions
-#-}<ERROR>
-
-
--- Should fail with a parse ...
+Issue3090-lparen.agda:4,23: error: [ParseError]
+in the name (, the part ( is not valid because it is used to parenthesize expressions

--- a/test/Fail/Issue3090-rbrace.err
+++ b/test/Fail/Issue3090-rbrace.err
@@ -1,6 +1,2 @@
-Issue3090-rbrace.agda:4,23-23
-Issue3090-rbrace.agda:4,23: in the name }, the part } is not valid because it is used for hidden arguments
-#-}<ERROR>
-
-
--- Should fail with a parse ...
+Issue3090-rbrace.agda:4,23: error: [ParseError]
+in the name }, the part } is not valid because it is used for hidden arguments

--- a/test/Fail/Issue3090-rparen.err
+++ b/test/Fail/Issue3090-rparen.err
@@ -1,6 +1,2 @@
-Issue3090-rparen.agda:4,23-23
-Issue3090-rparen.agda:4,23: in the name ), the part ) is not valid because it is used to parenthesize expressions
-#-}<ERROR>
-
-
--- Should fail with a parse ...
+Issue3090-rparen.agda:4,23: error: [ParseError]
+in the name ), the part ) is not valid because it is used to parenthesize expressions

--- a/test/Fail/Issue3090-underscore.err
+++ b/test/Fail/Issue3090-underscore.err
@@ -1,6 +1,2 @@
-Issue3090-underscore.agda:4,23-23
-Issue3090-underscore.agda:4,23: in the name _, the part _ is not valid because it is used for anonymous identifiers
-#-}<ERROR>
-
-
--- Should fail with a parse ...
+Issue3090-underscore.agda:4,23: error: [ParseError]
+in the name _, the part _ is not valid because it is used for anonymous identifiers

--- a/test/Fail/Issue309a.err
+++ b/test/Fail/Issue309a.err
@@ -1,6 +1,2 @@
-Issue309a.agda:6,18-18
-Issue309a.agda:6,18: Malformed syntax declaration: syntax must use unique argument names
-x<ERROR>
-g : D → D
-g (d x) = e x
-...
+Issue309a.agda:6,18: error: [ParseError]
+Malformed syntax declaration: syntax must use unique argument names

--- a/test/Fail/Issue309b.err
+++ b/test/Fail/Issue309b.err
@@ -1,6 +1,2 @@
-Issue309b.agda:6,14-14
-Issue309b.agda:6,14: Malformed syntax declaration: syntax must use holes exactly once
-f<ERROR>
-g : D → D
-g (d x) = f
-...
+Issue309b.agda:6,14: error: [ParseError]
+Malformed syntax declaration: syntax must use holes exactly once

--- a/test/Fail/Issue3139.err
+++ b/test/Fail/Issue3139.err
@@ -1,5 +1,2 @@
-Issue3139.agda:3,9-9
-Issue3139.agda:3,9: in the name [_…_], the part … is not valid because it is used for function clauses
-:<ERROR>
- Set → Set → Set
-...
+Issue3139.agda:3,9: error: [ParseError]
+in the name [_…_], the part … is not valid because it is used for function clauses

--- a/test/Fail/Issue3285.err
+++ b/test/Fail/Issue3285.err
@@ -1,4 +1,2 @@
-Issue3285.agda:7,14-14
-Issue3285.agda:7,14: Malformed syntax declaration: syntax cannot be a single hole
-<EOF><ERROR>
-...
+Issue3285.agda:7,14: error: [ParseError]
+Malformed syntax declaration: syntax cannot be a single hole

--- a/test/Fail/Issue3480.err
+++ b/test/Fail/Issue3480.err
@@ -1,4 +1,3 @@
-Issue3480.agda:6,8-8
-Issue3480.agda:6,8: Parse error
+Issue3480.agda:6,8: error: [ParseError]
 <EOF><ERROR>
 ...

--- a/test/Fail/Issue394-1.err
+++ b/test/Fail/Issue394-1.err
@@ -1,4 +1,2 @@
-Issue394-1.agda:5,36-36
-Issue394-1.agda:5,36: Malformed syntax declaration: syntax must use binding holes exactly once
-<EOF><ERROR>
-...
+Issue394-1.agda:5,36: error: [ParseError]
+Malformed syntax declaration: syntax must use binding holes exactly once

--- a/test/Fail/Issue394-2.err
+++ b/test/Fail/Issue394-2.err
@@ -1,4 +1,2 @@
-Issue394-2.agda:5,42-42
-Issue394-2.agda:5,42: Malformed syntax declaration: syntax must use binding holes exactly once
-<EOF><ERROR>
-...
+Issue394-2.agda:5,42: error: [ParseError]
+Malformed syntax declaration: syntax must use binding holes exactly once

--- a/test/Fail/Issue394-3.err
+++ b/test/Fail/Issue394-3.err
@@ -1,4 +1,2 @@
-Issue394-3.agda:5,36-36
-Issue394-3.agda:5,36: Malformed syntax declaration: syntax must use holes exactly once
-<EOF><ERROR>
-...
+Issue394-3.agda:5,36: error: [ParseError]
+Malformed syntax declaration: syntax must use holes exactly once

--- a/test/Fail/Issue394-4.err
+++ b/test/Fail/Issue394-4.err
@@ -1,4 +1,2 @@
-Issue394-4.agda:5,32-32
-Issue394-4.agda:5,32: Malformed syntax declaration: syntax must not contain adjacent holes (A B)
-<EOF><ERROR>
-...
+Issue394-4.agda:5,32: error: [ParseError]
+Malformed syntax declaration: syntax must not contain adjacent holes (A B)

--- a/test/Fail/Issue3962.err
+++ b/test/Fail/Issue3962.err
@@ -1,9 +1,2 @@
-Issue3962.agda:12,8-8
-Issue3962.agda:12,8: Unterminated '{-'
-{<ERROR>
-x}}
-
-C : Set
-C = ?
-
--- WAS: pa...
+Issue3962.agda:12,8: error: [ParseError]
+Unterminated '{-'

--- a/test/Fail/Issue4132.err
+++ b/test/Fail/Issue4132.err
@@ -1,4 +1,2 @@
-Issue4132.agda:4,5-5
-Issue4132.agda:4,5: in the name 1, the part 1 is not valid because it is a literal
-<EOF><ERROR>
-...
+Issue4132.agda:4,5: error: [ParseError]
+in the name 1, the part 1 is not valid because it is a literal

--- a/test/Fail/Issue4399.err
+++ b/test/Fail/Issue4399.err
@@ -1,7 +1,2 @@
-Issue4399.agda:11,5-5
-Issue4399.agda:11,5: Not a valid named argument: _ = tt
-=<ERROR>
- A
-
--- Expected: Parse error
--...
+Issue4399.agda:11,5: error: [ParseError]
+Not a valid named argument: _ = tt

--- a/test/Fail/Issue4927-5.err
+++ b/test/Fail/Issue4927-5.err
@@ -1,5 +1,4 @@
-Issue4927-5.agda:2,8-8
-Issue4927-5.agda:2,8: Parse error
+Issue4927-5.agda:2,8: error: [ParseError]
 @<ERROR>
 flat Set
 F | _ = Set

--- a/test/Fail/Issue4927-7.err
+++ b/test/Fail/Issue4927-7.err
@@ -1,6 +1,3 @@
-Issue4927-7.agda:4,18-18
-Issue4927-7.agda:4,18: Illegal pattern synonym argument  x
+Issue4927-7.agda:4,18: error: [ParseError]
+Illegal pattern synonym argument  x
 (Cohesion annotations not allowed in pattern synonym arguments.)
-=<ERROR>
- c x
-...

--- a/test/Fail/Issue5055.err
+++ b/test/Fail/Issue5055.err
@@ -1,7 +1,3 @@
-Issue5055.agda:10,19-19
-Issue5055.agda:10,19: Illegal pattern synonym argument  _ @ (s , v)
+Issue5055.agda:10,19: error: [ParseError]
+Illegal pattern synonym argument  _ @ (s , v)
 (Arguments to pattern synonyms cannot be patterns themselves.)
-=<ERROR>
- c s , v
-
--- Should give some ...

--- a/test/Fail/Issue5201.err
+++ b/test/Fail/Issue5201.err
@@ -1,4 +1,2 @@
-Issue5201.agda:6,22-22
-Issue5201.agda:6,22: Malformed syntax declaration: syntax must not contain adjacent holes (f x)
-<EOF><ERROR>
-...
+Issue5201.agda:6,22: error: [ParseError]
+Malformed syntax declaration: syntax must not contain adjacent holes (f x)

--- a/test/Fail/Issue5365.err
+++ b/test/Fail/Issue5365.err
@@ -1,4 +1,2 @@
-Issue5365.agda:7,3-3
-Issue5365.agda:7,3: Incomplete binding x ←
-<EOF><ERROR>
-...
+Issue5365.agda:7,3: error: [ParseError]
+Incomplete binding x ←

--- a/test/Fail/Issue549.err
+++ b/test/Fail/Issue549.err
@@ -1,4 +1,2 @@
-Issue549.agda:4,8-8
-Issue549.agda:4,8: Not a valid identifier: M.R
-<EOF><ERROR>
-...
+Issue549.agda:4,8: error: [ParseError]
+Not a valid identifier: M.R

--- a/test/Fail/Issue7136.err
+++ b/test/Fail/Issue7136.err
@@ -1,6 +1,3 @@
-Issue7136.agda:7,19-19
-Issue7136.agda:7,19: Illegal pattern synonym argument  {x = y}
+Issue7136.agda:7,19: error: [ParseError]
+Illegal pattern synonym argument  {x = y}
 (Arguments to pattern synonyms cannot be named.)
-=<ERROR>
- c y
--- Should be rejected: na...

--- a/test/Fail/Issue7136a.err
+++ b/test/Fail/Issue7136a.err
@@ -1,7 +1,3 @@
-Issue7136a.agda:11,33-33
-Issue7136a.agda:11,33: Illegal pattern synonym argument  {x}
+Issue7136a.agda:11,33: error: [ParseError]
+Illegal pattern synonym argument  {x}
 (Tactic annotations not allowed in pattern synonym arguments.)
-=<ERROR>
- suc x
-
--- Should complain abo...

--- a/test/Fail/Issue7136b.err
+++ b/test/Fail/Issue7136b.err
@@ -1,6 +1,3 @@
-Issue7136b.agda:8,18-18
-Issue7136b.agda:8,18: Illegal pattern synonym argument  x
+Issue7136b.agda:8,18: error: [ParseError]
+Illegal pattern synonym argument  x
 (Quantity annotations not allowed in pattern synonym arguments.)
-=<ERROR>
- suc x
--- Should be rejected: ...

--- a/test/Fail/Issue7136c.err
+++ b/test/Fail/Issue7136c.err
@@ -1,6 +1,3 @@
-Issue7136c.agda:6,14-14
-Issue7136c.agda:6,14: Illegal pattern synonym argument  x
+Issue7136c.agda:6,14: error: [ParseError]
+Illegal pattern synonym argument  x
 (Arguments to pattern synonyms must be relevant.)
-=<ERROR>
- suc x
--- Should be rejected: ...

--- a/test/Fail/Issue7136d.err
+++ b/test/Fail/Issue7136d.err
@@ -1,6 +1,3 @@
-Issue7136d.agda:6,18-18
-Issue7136d.agda:6,18: Illegal pattern synonym argument  x
+Issue7136d.agda:6,18: error: [ParseError]
+Illegal pattern synonym argument  x
 (Cohesion annotations not allowed in pattern synonym arguments.)
-=<ERROR>
- suc x
--- Should be rejected: ...

--- a/test/Fail/Issue7136e.err
+++ b/test/Fail/Issue7136e.err
@@ -1,6 +1,3 @@
-Issue7136e.agda:6,21-21
-Issue7136e.agda:6,21: Illegal pattern synonym argument  x
+Issue7136e.agda:6,21: error: [ParseError]
+Illegal pattern synonym argument  x
 (Lock annotations not allowed in pattern synonym arguments.)
-=<ERROR>
- suc x
--- Should be rejected: ...

--- a/test/Fail/Issue782.err
+++ b/test/Fail/Issue782.err
@@ -1,5 +1,4 @@
-Issue782.agda:4,43-43
-Issue782.agda:4,43: Parse error
+Issue782.agda:4,43: error: [ParseError]
 toz<ERROR>
 ; suc tos; Nat toℕ)
 

--- a/test/Fail/MisformedTypeSignature.err
+++ b/test/Fail/MisformedTypeSignature.err
@@ -1,4 +1,2 @@
-MisformedTypeSignature.agda:5,9-9
-MisformedTypeSignature.agda:5,9: Illegal name in type signature: (f g)
-<EOF><ERROR>
-...
+MisformedTypeSignature.agda:5,9: error: [ParseError]
+Illegal name in type signature: (f g)

--- a/test/Fail/NotAModuleExpr.err
+++ b/test/Fail/NotAModuleExpr.err
@@ -1,5 +1,4 @@
-NotAModuleExpr.agda:5,14-14
-NotAModuleExpr.agda:5,14: Parse error
+NotAModuleExpr.agda:5,14: error: [ParseError]
 /<ERROR>
 x -> x
 

--- a/test/Fail/NotationDoesNotUseAllBinders.err
+++ b/test/Fail/NotationDoesNotUseAllBinders.err
@@ -1,4 +1,2 @@
-NotationDoesNotUseAllBinders.agda:3,29-29
-NotationDoesNotUseAllBinders.agda:3,29: Malformed syntax declaration: syntax must use binding holes exactly once
-<EOF><ERROR>
-...
+NotationDoesNotUseAllBinders.agda:3,29: error: [ParseError]
+Malformed syntax declaration: syntax must use binding holes exactly once

--- a/test/Fail/ParseErrorDoubleDot.err
+++ b/test/Fail/ParseErrorDoubleDot.err
@@ -1,4 +1,3 @@
-ParseErrorDoubleDot.agda:4,5-5
-ParseErrorDoubleDot.agda:4,5: Parse error
+ParseErrorDoubleDot.agda:4,5: error: [ParseError]
 <EOF><ERROR>
 ...

--- a/test/Fail/ParseForallAbsurd.err
+++ b/test/Fail/ParseForallAbsurd.err
@@ -1,5 +1,4 @@
-ParseForallAbsurd.agda:5,22-22
-ParseForallAbsurd.agda:5,22: Parse error
+ParseForallAbsurd.agda:5,22: error: [ParseError]
 )<ERROR>
  -> Set1
 parseFails x = Set

--- a/test/Fail/Sections-6.err
+++ b/test/Fail/Sections-6.err
@@ -1,5 +1,2 @@
-Sections-6.agda:4,12-12
-Sections-6.agda:4,12: a name cannot contain two consecutive underscores
-2<ERROR>
-
-...
+Sections-6.agda:4,12: error: [ParseError]
+a name cannot contain two consecutive underscores

--- a/test/Fail/SyntaxForOperators.err
+++ b/test/Fail/SyntaxForOperators.err
@@ -1,4 +1,2 @@
-SyntaxForOperators.agda:5,22-22
-SyntaxForOperators.agda:5,22: Syntax declarations are allowed only for simple names (without holes)
-<EOF><ERROR>
-...
+SyntaxForOperators.agda:5,22: error: [ParseError]
+Syntax declarations are allowed only for simple names (without holes)

--- a/test/Fail/Tabs.err
+++ b/test/Fail/Tabs.err
@@ -1,6 +1,2 @@
-Tabs.agda:5,1-1
-Tabs.agda:5,1: Lexical error (you may want to replace tabs with spaces):
-tab:<ERROR>
-	 : Set₁
-tab:	 = Set
-...
+Tabs.agda:5,1: error: [ParseError]
+Lexical error (you may want to replace tabs with spaces):

--- a/test/Fail/TabsInPragmas.err
+++ b/test/Fail/TabsInPragmas.err
@@ -1,6 +1,2 @@
-TabsInPragmas.agda:1,5-5
-TabsInPragmas.agda:1,5: Lexical error (you may want to replace tabs with spaces):
-OPTIONS<ERROR>
-	--type-in-type #-}
-
-module Ta...
+TabsInPragmas.agda:1,5: error: [ParseError]
+Lexical error (you may want to replace tabs with spaces):

--- a/test/Fail/UselessOverlap.err
+++ b/test/Fail/UselessOverlap.err
@@ -1,4 +1,2 @@
-UselessOverlap.agda:6,5-5
-UselessOverlap.agda:6,5: The 'overlap' keyword only applies to instance fields (fields marked with {{ }})
-<EOF><ERROR>
-...
+UselessOverlap.agda:6,5: error: [ParseError]
+The 'overlap' keyword only applies to instance fields (fields marked with {{ }})

--- a/test/Fail/issue5072.err
+++ b/test/Fail/issue5072.err
@@ -1,5 +1,4 @@
-issue5072.agda:3,3-3
-issue5072.agda:3,3: Parse error
+issue5072.agda:3,3: error: [ParseError]
 no-eta-equality<ERROR>
 
 ...

--- a/test/LaTeXAndHTML/fail/Issue2453.html
+++ b/test/LaTeXAndHTML/fail/Issue2453.html
@@ -1,3 +1,3 @@
 AGDA_COMPILE_FAILED
 
-ret > ExitFailure 42 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14-14 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14: Missing body for lambda out > <EOF><ERROR> out > ... out >
+ret > ExitFailure 42 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14: error: [ParseError] out > Missing body for lambda out >

--- a/test/LaTeXAndHTML/fail/Issue2453.quick.tex
+++ b/test/LaTeXAndHTML/fail/Issue2453.quick.tex
@@ -1,3 +1,3 @@
 AGDA_COMPILE_FAILED
 
-ret > ExitFailure 42 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14-14 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14: Missing body for lambda out > <EOF><ERROR> out > ... out >
+ret > ExitFailure 42 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14: error: [ParseError] out > Missing body for lambda out >

--- a/test/LaTeXAndHTML/fail/Issue2453.tex
+++ b/test/LaTeXAndHTML/fail/Issue2453.tex
@@ -1,3 +1,3 @@
 AGDA_COMPILE_FAILED
 
-ret > ExitFailure 42 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14-14 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14: Missing body for lambda out > <EOF><ERROR> out > ... out >
+ret > ExitFailure 42 out > ../LaTeXAndHTML/fail/Issue2453.lagda:10,14: error: [ParseError] out > Missing body for lambda out >

--- a/test/api/Makefile
+++ b/test/api/Makefile
@@ -7,7 +7,7 @@ AGDA = $(AGDA_BIN) -v0 --no-libraries
 .PHONY: all
 all : Issue1168.api PrettyInterface.api PrintImports.run ScopeFromInterface.api
 
-%.agdai : %.agda $(AGDA_BIN)
+%.agdai : %.agda $(which $(AGDA_BIN))
 	$(AGDA) $<
 
 .PHONY: %.api
@@ -17,7 +17,7 @@ all : Issue1168.api PrettyInterface.api PrintImports.run ScopeFromInterface.api
 .PHONY: %.run
 %.run : %.hs
 	$(eval tmpdir = $(shell mktemp -d /tmp/api-test.XXXX))
-	$(GHC) -Wall -Werror -package Agda-$(VERSION) -o $(tmpdir)/$* $*.hs
+	$(GHC) -Wall -Werror -package bytestring -package containers -package mtl -package Agda-$(VERSION) -o $(tmpdir)/$* $*.hs
 	$(tmpdir)/$*
 	rm -r $(tmpdir)
 

--- a/test/api/ScopeFromInterface.hs
+++ b/test/api/ScopeFromInterface.hs
@@ -38,7 +38,6 @@ import Agda.TypeChecking.Serialise.Base
 import Agda.Utils.Functor
 import Agda.Utils.Hash           ( Hash )
 import Agda.Utils.IO.Binary      ( readBinaryFile' )
-import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.Impossible
 
@@ -77,7 +76,7 @@ mainTCM args = do
   let f = fromMaybe "ScopeFromInterface.agdai" $ listToMaybe args
   readTruncatedInterface f >>= \case
     Just i -> processInterface i
-    Nothing -> throwError $ Exception empty $ text "Cannot read interface file"
+    Nothing -> throwError $ GenericException "Cannot read interface file"
 
 processInterface :: TruncatedInterface -> TCM ()
 processInterface i = liftIO $ do

--- a/test/interaction/FileNotFound.out
+++ b/test/interaction/FileNotFound.out
@@ -1,7 +1,7 @@
 (agda2-status-action "")
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
-(agda2-info-action "*Error*" "NonExistingFile.agda:1,1-1 Cannot read file NonExistingFile.agda Error: NonExistingFile.agda: openBinaryFile: does not exist (No such file or directory)" nil)
+(agda2-info-action "*Error*" "Cannot read file NonExistingFile.agda Error: NonExistingFile.agda: openBinaryFile: does not exist (No such file or directory)" nil)
 ((last . 3) . (agda2-maybe-goto '("NonExistingFile.agda" . 1)))
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")

--- a/test/interaction/FileThatDoesNotExist.out
+++ b/test/interaction/FileThatDoesNotExist.out
@@ -1,3 +1,2 @@
-FileThatDoesNotExist-ForReals.agda:1,1-1
 Cannot read file FileThatDoesNotExist-ForReals.agda
 Error: FileThatDoesNotExist-ForReals.agda: openBinaryFile: does not exist (No such file or directory)

--- a/test/interaction/Issue2224.out
+++ b/test/interaction/Issue2224.out
@@ -1,4 +1,4 @@
-Issue2224WrongExtension.agda.tex:1,1-1
-Issue2224WrongExtension.agda.tex: Unsupported extension.
+Issue2224WrongExtension.agda.tex: error: [InvalidExtensionError]
+Unsupported extension.
 Supported extensions are: .agda, .lagda, .lagda.rst, .lagda.tex,
 .lagda.md, .lagda.org, .lagda.typ


### PR DESCRIPTION
- use a dedicated `ParserError` constructor instead of generic `Exception`
- print location only once (closes #7434)
- prefix with error name
- only print token context for Happy errors (those that have no explanation)
