### PR TITLE
Test that the test suite covers all warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,6 +182,9 @@ jobs:
       name: User manual covers all warnings
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-covers-warnings
     - if: always()
+      name: Test suite covers all warnings
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" test-suite-covers-warnings
+    - if: always()
       name: Suite of interaction tests
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
   size-solver-test:

--- a/Makefile
+++ b/Makefile
@@ -632,23 +632,28 @@ benchmark-summary :
 	@$(call decorate, "Benchmark summary", \
 	  $(MAKE) -C benchmark summary)
 
-.PHONY : user-manual-test ##
+.PHONY : user-manual-test ## Check the Agda code embedded in the user manual.
 user-manual-test :
 	@$(call decorate, "User manual (test)", \
 		find doc/user-manual -type f -name '*.agdai' -delete; \
 		AGDA_BIN=$(AGDA_BIN) $(AGDA_TESTS_BIN) $(AGDA_TESTS_OPTIONS) --regex-include all/UserManual)
 
-.PHONY : user-manual-covers-options
+.PHONY : user-manual-covers-options ## Test that the user manual mentions all options.
 user-manual-covers-options :
 	@$(call decorate, "User manual should mention all options", \
           AGDA_BIN=$(AGDA_BIN) test/doc/user-manual-covers-options.sh)
 
-.PHONY : user-manual-covers-warnings
+.PHONY : user-manual-covers-warnings ## Test that the user manual mentions all warnings.
 user-manual-covers-warnings :
 	@$(call decorate, "User manual should mention all warnings", \
           AGDA_BIN=$(AGDA_BIN) test/doc/user-manual-covers-warnings.sh)
 
-.PHONY : testing-emacs-mode ##
+.PHONY : test-suite-covers-warnings ## Check whether the test suite covers all warnings.
+test-suite-covers-warnings :
+	@$(call decorate, "Test suite should cover all warnings", \
+          AGDA_BIN=$(AGDA_BIN) test/test-suite-covers-warnings.sh)
+
+.PHONY : testing-emacs-mode ## Compile the emacs mode and run basic tests.
 testing-emacs-mode:
 	@$(call decorate, "Testing the Emacs mode", \
 	  $(AGDA_MODE) compile)

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1540,10 +1540,6 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Rewrite rule LHS is not in weak-head normal form.
 
-.. option:: RewriteHeadSymbolIsProjection
-
-     Rewrite rule head symbol is a record projection.
-
 .. option:: RewriteHeadSymbolIsProjectionLikeFunction
 
      Rewrite rule head symbol is a projection-like function.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1389,10 +1389,6 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Illegal character literals such as surrogate code points.
 
-.. option:: InvalidConstructor
-
-     ``constructor`` blocks that contain declarations other type signatures for constructors.
-
 .. option:: InvalidConstructorBlock
 
      ``constructor`` blocks outside of ``interleaved mutual`` blocks.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -539,7 +539,6 @@ warningHighlighting' b w = case tcWarning w of
     InvalidNoUniverseCheckPragma{}   -> deadcodeHighlighting w
     InvalidTerminationCheckPragma{}  -> deadcodeHighlighting w
     InvalidCoverageCheckPragma{}     -> deadcodeHighlighting w
-    InvalidConstructor{}             -> deadcodeHighlighting w
     InvalidConstructorBlock{}        -> deadcodeHighlighting w
     OpenPublicAbstract{}             -> deadcodeHighlighting w
     OpenPublicPrivate{}              -> deadcodeHighlighting w

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -473,7 +473,7 @@ warningHighlighting' b w = case tcWarning w of
   RewriteMaybeNonConfluent{} -> confluenceErrorHighlighting w
   RewriteAmbiguousRules{}    -> confluenceErrorHighlighting w
   RewriteMissingRule{}       -> confluenceErrorHighlighting w
-  IllegalRewriteRule{}       -> deadcodeHighlighting w
+  IllegalRewriteRule x _     -> deadcodeHighlighting x
   NotARewriteRule x _        -> deadcodeHighlighting x
   PragmaCompileErased{}      -> deadcodeHighlighting w
   PragmaCompileList{}        -> deadcodeHighlighting w

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -534,6 +534,7 @@ warningHighlighting' b w = case tcWarning w of
     UselessInstance{}                -> deadcodeHighlighting w
     UselessMacro{}                   -> deadcodeHighlighting w
     UselessPrivate{}                 -> deadcodeHighlighting w
+    InvalidCatchallPragma{}          -> deadcodeHighlighting w
     InvalidNoPositivityCheckPragma{} -> deadcodeHighlighting w
     InvalidNoUniverseCheckPragma{}   -> deadcodeHighlighting w
     InvalidTerminationCheckPragma{}  -> deadcodeHighlighting w
@@ -556,7 +557,6 @@ warningHighlighting' b w = case tcWarning w of
     MissingDeclarations{}            -> missingDefinitionHighlighting w
     MissingDefinitions{}             -> missingDefinitionHighlighting w
     -- TODO: explore highlighting opportunities here!
-    InvalidCatchallPragma{}           -> mempty
     PolarityPragmasButNotPostulates{} -> mempty
     PragmaNoTerminationCheck{}        -> mempty
     PragmaCompiled{}                  -> errorWarningHighlighting w

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -231,7 +231,6 @@ data WarningName
   | EmptyWhere_
   | HiddenGeneralize_
   | InvalidCatchallPragma_
-  | InvalidConstructor_
   | InvalidConstructorBlock_
   | InvalidCoverageCheckPragma_
   | InvalidNoPositivityCheckPragma_
@@ -454,7 +453,6 @@ warningNameDescription = \case
   EmptyWhere_                      -> "Empty `where' blocks."
   HiddenGeneralize_                -> "Hidden identifiers in variable blocks."
   InvalidCatchallPragma_           -> "`CATCHALL' pragmas before a non-function clause."
-  InvalidConstructor_              -> "`constructor' blocks that contain declarations other than type signatures for constructors."
   InvalidConstructorBlock_         -> "`constructor' blocks outside of `interleaved mutual' blocks."
   InvalidCoverageCheckPragma_      -> "Coverage checking pragmas before non-function or `mutual' blocks."
   InvalidNoPositivityCheckPragma_  -> "Positivity checking pragmas before non-`data', `record' or `mutual' blocks."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -298,7 +298,6 @@ data WarningName
   | RewriteVariablesNotBoundByLHS_
   | RewriteVariablesBoundMoreThanOnce_
   | RewriteLHSReduces_
-  | RewriteHeadSymbolIsProjection_
   | RewriteHeadSymbolIsProjectionLikeFunction_
   | RewriteHeadSymbolIsTypeConstructor_
   | RewriteHeadSymbolContainsMetas_
@@ -523,7 +522,6 @@ warningNameDescription = \case
   RewriteVariablesNotBoundByLHS_                    -> "Rewrite rule does not bind all of its variables."
   RewriteVariablesBoundMoreThanOnce_                -> "Constructor-headed rewrite rule has non-linear parameters."
   RewriteLHSReduces_                                -> "Rewrite rule LHS is not in weak-head normal form."
-  RewriteHeadSymbolIsProjection_                    -> "Rewrite rule head symbol is a record projection."
   RewriteHeadSymbolIsProjectionLikeFunction_        -> "Rewrite rule head symbol is a projection-like function."
   RewriteHeadSymbolIsTypeConstructor_               -> "Rewrite rule head symbol is a type constructor."
   RewriteHeadSymbolContainsMetas_                   -> "Definition of rewrite rule head symbol contains unsolved metas."

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -771,11 +771,8 @@ niceDeclarations fixs ds = do
     -- Turn function clauses into nice function clauses.
     mkClauses :: Name -> [Declaration] -> Catchall -> Nice [Clause]
     mkClauses _ [] _ = return []
-    mkClauses x (Pragma (CatchallPragma r) : cs) True  = do
-      declarationWarning $ InvalidCatchallPragma r
-      mkClauses x cs True
-    mkClauses x (Pragma (CatchallPragma r) : cs) False = do
-      when (null cs) $ declarationWarning $ InvalidCatchallPragma r
+    mkClauses x (Pragma (CatchallPragma r) : cs) catchall = do
+      when (catchall || null cs) $ declarationWarning $ InvalidCatchallPragma r
       mkClauses x cs True
 
     mkClauses x (FunClause lhs rhs wh ca : cs) catchall

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -108,8 +108,6 @@ data DeclarationWarning'
   | InvalidCatchallPragma Range
       -- ^ A {-\# CATCHALL \#-} pragma
       --   that does not precede a function clause.
-  | InvalidConstructor Range
-      -- ^ Invalid definition in a constructor block
   | InvalidConstructorBlock Range
       -- ^ Invalid constructor block (not inside an interleaved mutual block)
   | InvalidCoverageCheckPragma Range
@@ -180,7 +178,6 @@ declarationWarningName' = \case
   EmptyPrimitive{}                  -> EmptyPrimitive_
   HiddenGeneralize{}                -> HiddenGeneralize_
   InvalidCatchallPragma{}           -> InvalidCatchallPragma_
-  InvalidConstructor{}              -> InvalidConstructor_
   InvalidConstructorBlock{}         -> InvalidConstructorBlock_
   InvalidNoPositivityCheckPragma{}  -> InvalidNoPositivityCheckPragma_
   InvalidNoUniverseCheckPragma{}    -> InvalidNoUniverseCheckPragma_
@@ -230,7 +227,6 @@ unsafeDeclarationWarning' = \case
   EmptyPrimitive{}                  -> False
   HiddenGeneralize{}                -> False
   InvalidCatchallPragma{}           -> False
-  InvalidConstructor{}              -> False
   InvalidConstructorBlock{}         -> False
   InvalidNoPositivityCheckPragma{}  -> False
   InvalidNoUniverseCheckPragma{}    -> False
@@ -342,7 +338,6 @@ instance HasRange DeclarationWarning' where
     EmptyPrivate kwr                   -> getRange kwr
     HiddenGeneralize r                 -> r
     InvalidCatchallPragma r            -> r
-    InvalidConstructor r               -> r
     InvalidConstructorBlock r          -> r
     InvalidCoverageCheckPragma r       -> r
     InvalidNoPositivityCheckPragma r   -> r
@@ -496,9 +491,6 @@ instance Pretty DeclarationWarning' where
 
     InvalidTerminationCheckPragma _ -> fsep $
       pwords "Termination checking pragmas can only precede a function definition or a mutual block (that contains a function definition)."
-
-    InvalidConstructor{} -> fsep $
-      pwords "`data _ where' blocks may only contain type signatures for constructors."
 
     InvalidConstructorBlock{} -> fsep $
       pwords "No `data _ where' blocks outside of `interleaved mutual' blocks."

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4562,22 +4562,22 @@ warningName = \case
 
 illegalRewriteWarningName :: IllegalRewriteRuleReason -> WarningName
 illegalRewriteWarningName = \case
-  LHSNotDefinitionOrConstructor{} -> RewriteLHSNotDefinitionOrConstructor_
-  VariablesNotBoundByLHS{} -> RewriteVariablesNotBoundByLHS_
-  VariablesBoundMoreThanOnce{} -> RewriteVariablesBoundMoreThanOnce_
-  LHSReduces{} -> RewriteLHSReduces_
-  HeadSymbolIsProjection{} -> RewriteHeadSymbolIsProjection_
+  LHSNotDefinitionOrConstructor{}      -> RewriteLHSNotDefinitionOrConstructor_
+  VariablesNotBoundByLHS{}             -> RewriteVariablesNotBoundByLHS_
+  VariablesBoundMoreThanOnce{}         -> RewriteVariablesBoundMoreThanOnce_
+  LHSReduces{}                         -> RewriteLHSReduces_
+  HeadSymbolIsProjection{}             -> RewriteHeadSymbolIsProjection_
   HeadSymbolIsProjectionLikeFunction{} -> RewriteHeadSymbolIsProjectionLikeFunction_
-  HeadSymbolIsTypeConstructor{} -> RewriteHeadSymbolIsTypeConstructor_
-  HeadSymbolContainsMetas{} -> RewriteHeadSymbolContainsMetas_
-  ConstructorParametersNotGeneral{} -> RewriteConstructorParametersNotGeneral_
-  ContainsUnsolvedMetaVariables{} -> RewriteContainsUnsolvedMetaVariables_
-  BlockedOnProblems{} -> RewriteBlockedOnProblems_
-  RequiresDefinitions{} -> RewriteRequiresDefinitions_
-  DoesNotTargetRewriteRelation -> RewriteDoesNotTargetRewriteRelation_
-  BeforeFunctionDefinition -> RewriteBeforeFunctionDefinition_
-  BeforeMutualFunctionDefinition{} -> RewriteBeforeMutualFunctionDefinition_
-  DuplicateRewriteRule -> DuplicateRewriteRule_
+  HeadSymbolIsTypeConstructor{}        -> RewriteHeadSymbolIsTypeConstructor_
+  HeadSymbolContainsMetas{}            -> RewriteHeadSymbolContainsMetas_
+  ConstructorParametersNotGeneral{}    -> RewriteConstructorParametersNotGeneral_
+  ContainsUnsolvedMetaVariables{}      -> RewriteContainsUnsolvedMetaVariables_
+  BlockedOnProblems{}                  -> RewriteBlockedOnProblems_
+  RequiresDefinitions{}                -> RewriteRequiresDefinitions_
+  DoesNotTargetRewriteRelation         -> RewriteDoesNotTargetRewriteRelation_
+  BeforeFunctionDefinition             -> RewriteBeforeFunctionDefinition_
+  BeforeMutualFunctionDefinition{}     -> RewriteBeforeMutualFunctionDefinition_
+  DuplicateRewriteRule                 -> DuplicateRewriteRule_
 
 -- | Should warnings of that type be serialized?
 --

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4566,7 +4566,6 @@ illegalRewriteWarningName = \case
   VariablesNotBoundByLHS{}             -> RewriteVariablesNotBoundByLHS_
   VariablesBoundMoreThanOnce{}         -> RewriteVariablesBoundMoreThanOnce_
   LHSReduces{}                         -> RewriteLHSReduces_
-  HeadSymbolIsProjection{}             -> RewriteHeadSymbolIsProjection_
   HeadSymbolIsProjectionLikeFunction{} -> RewriteHeadSymbolIsProjectionLikeFunction_
   HeadSymbolIsTypeConstructor{}        -> RewriteHeadSymbolIsTypeConstructor_
   HeadSymbolContainsMetas{}            -> RewriteHeadSymbolContainsMetas_
@@ -5089,7 +5088,6 @@ data IllegalRewriteRuleReason
   | VariablesNotBoundByLHS IntSet
   | VariablesBoundMoreThanOnce IntSet
   | LHSReduces Term Term
-  | HeadSymbolIsProjection QName
   | HeadSymbolIsProjectionLikeFunction QName
   | HeadSymbolIsTypeConstructor QName
   | HeadSymbolContainsMetas QName

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -327,10 +327,6 @@ prettyWarning = \case
       LHSReduces v v' -> fsep
         [ prettyTCM q <+> " is not a legal rewrite rule, since the left-hand side "
         , prettyTCM v <+> " reduces to " <+> prettyTCM v' ]
-      HeadSymbolIsProjection f -> hsep
-        [ prettyTCM q , " is not a legal rewrite rule, since the head symbol"
-        , prettyTCM f , "is a projection"
-        ]
       HeadSymbolIsProjectionLikeFunction f -> hsep
         [ prettyTCM q , " is not a legal rewrite rule, since the head symbol"
         , hd , "is a projection-like function."

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -185,7 +185,7 @@ rewriteRelationDom rel = do
 --   @rel us : (lhs rhs : A[us/Δ]) → Set i@.
 --   Returns the checked rewrite rule to be added to the signature.
 checkRewriteRule :: QName -> TCM (Maybe RewriteRule)
-checkRewriteRule q = runMaybeT $ do
+checkRewriteRule q = runMaybeT $ setCurrentRange q do
   lift requireOptionRewriting
   rels <- lift getBuiltinRewriteRelations
   reportSDoc "rewriting.relations" 40 $ vcat

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -317,7 +317,7 @@ instance EmbPrj DeclarationWarning' where
     OpenPublicPrivate r               -> icodeN 27 OpenPublicPrivate r
     EmptyConstructor a                -> icodeN 28 EmptyConstructor a
     -- 29 removed
-    InvalidConstructor a              -> icodeN 30 InvalidConstructor a
+    -- 30 removed
     InvalidConstructorBlock a         -> icodeN 31 InvalidConstructorBlock a
     MissingDeclarations a             -> icodeN 32 MissingDeclarations a
     HiddenGeneralize r                -> icodeN 33 HiddenGeneralize r
@@ -362,7 +362,7 @@ instance EmbPrj DeclarationWarning' where
     [27,r]   -> valuN OpenPublicPrivate r
     [28,r]   -> valuN EmptyConstructor r
     -- 29 removed
-    [30,r]   -> valuN InvalidConstructor r
+    -- 30 removed
     [31,r]   -> valuN InvalidConstructorBlock r
     [32,r]   -> valuN MissingDeclarations r
     [33,r]   -> valuN HiddenGeneralize r

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -205,7 +205,7 @@ instance EmbPrj IllegalRewriteRuleReason where
     VariablesNotBoundByLHS a                    -> icodeN 1 VariablesNotBoundByLHS a
     VariablesBoundMoreThanOnce a                -> icodeN 2 VariablesBoundMoreThanOnce a
     LHSReduces a b                              -> icodeN 3 LHSReduces a b
-    HeadSymbolIsProjection a                    -> icodeN 4 HeadSymbolIsProjection a
+    -- 4 was HeadSymbolIsProjection
     HeadSymbolIsProjectionLikeFunction a        -> icodeN 5 HeadSymbolIsProjectionLikeFunction a
     HeadSymbolIsTypeConstructor a               -> icodeN 6 HeadSymbolIsTypeConstructor a
     HeadSymbolContainsMetas a                   -> icodeN 7 HeadSymbolContainsMetas a
@@ -223,7 +223,7 @@ instance EmbPrj IllegalRewriteRuleReason where
     [1, a]    -> valuN VariablesNotBoundByLHS a
     [2, a]    -> valuN VariablesBoundMoreThanOnce a
     [3, a, b] -> valuN LHSReduces a b
-    [4, a]    -> valuN HeadSymbolIsProjection a
+    -- 4 was HeadSymbolIsProjection
     [5, a]    -> valuN HeadSymbolIsProjectionLikeFunction a
     [6, a]    -> valuN HeadSymbolIsTypeConstructor a
     [7, a]    -> valuN HeadSymbolContainsMetas a

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -345,6 +345,10 @@ jobs:
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-covers-warnings
       if: always() # run test even if a previous test failed
 
+    - name: "Test suite covers all warnings"
+      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" test-suite-covers-warnings
+      if: always() # run test even if a previous test failed
+
     - name: "Suite of interaction tests"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
       if: always() # run test even if a previous test failed

--- a/test/Fail/Issue1651.err
+++ b/test/Fail/Issue1651.err
@@ -1,4 +1,4 @@
-Issue1651.agda:14,1-18: warning: -W[no]RewriteBeforeFunctionDefinition
+Issue1651.agda:14,13-14: warning: -W[no]RewriteBeforeFunctionDefinition
 Rewrite rule from function  r  cannot be added before the function definition
 when checking the pragma REWRITE r
 

--- a/test/Fail/Issue1994.err
+++ b/test/Fail/Issue1994.err
@@ -1,8 +1,8 @@
-Issue1994.agda:36,1-20: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue1994.agda:36,13-16: warning: -W[no]RewriteVariablesNotBoundByLHS
 feq  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  r
 when checking the pragma REWRITE feq
 
-Issue1994.agda:37,1-20: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue1994.agda:37,13-16: warning: -W[no]RewriteVariablesNotBoundByLHS
 seq  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  r
 when checking the pragma REWRITE seq
 

--- a/test/Fail/Issue2059.err
+++ b/test/Fail/Issue2059.err
@@ -1,4 +1,4 @@
-Issue2059.agda:32,1-24: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue2059.agda:32,13-20: warning: -W[no]RewriteVariablesNotBoundByLHS
 obvious  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  p
 when checking the pragma REWRITE obvious
 

--- a/test/Fail/Issue2059i.err
+++ b/test/Fail/Issue2059i.err
@@ -1,4 +1,4 @@
-Issue2059i.agda:29,1-26: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue2059i.agda:29,13-20: warning: -W[no]RewriteVariablesNotBoundByLHS
 obvious  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  p
 when checking the pragma REWRITE obvious
 

--- a/test/Fail/Issue2467.err
+++ b/test/Fail/Issue2467.err
@@ -1,4 +1,4 @@
-Issue2467.agda:8,1-18: error: [NoBindingForBuiltin]
+Issue2467.agda:8,13-14: error: [NoBindingForBuiltin]
 No binding for builtin thing REWRITE, use {-# BUILTIN REWRITE name
 #-} to bind it to 'name'
 when checking the pragma REWRITE A

--- a/test/Fail/Issue3846.err
+++ b/test/Fail/Issue3846.err
@@ -1,4 +1,4 @@
-Issue3846.agda:14,1-20: warning: -W[no]RewriteHeadSymbolIsTypeConstructor
+Issue3846.agda:14,13-16: warning: -W[no]RewriteHeadSymbolIsTypeConstructor
 rew  is not a legal rewrite rule, since the head symbol Nat is a type constructor.
 when checking the pragma REWRITE rew
 

--- a/test/Fail/Issue4371.err
+++ b/test/Fail/Issue4371.err
@@ -1,4 +1,4 @@
-Issue4371.agda:19,1-19: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue4371.agda:19,13-15: warning: -W[no]RewriteVariablesNotBoundByLHS
 ok  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  p
 when checking the pragma REWRITE ok
 

--- a/test/Fail/Issue4755a.err
+++ b/test/Fail/Issue4755a.err
@@ -1,4 +1,4 @@
-Issue4755a.agda:23,1-20: warning: -W[no]RewriteVariablesBoundMoreThanOnce
+Issue4755a.agda:23,13-16: warning: -W[no]RewriteVariablesBoundMoreThanOnce
 rew  is not a legal rewrite rule, since the following parameters are bound more than once on the left hand side:  A. Perhaps you can use a postulate instead of a constructor as the head symbol?
 when checking the pragma REWRITE rew
 

--- a/test/Fail/Issue4755b.err
+++ b/test/Fail/Issue4755b.err
@@ -1,4 +1,4 @@
-Issue4755b.agda:17,1-20: warning: -W[no]RewriteVariablesBoundMoreThanOnce
+Issue4755b.agda:17,13-16: warning: -W[no]RewriteVariablesBoundMoreThanOnce
 rew  is not a legal rewrite rule, since the following parameters are bound more than once on the left hand side:  A. Perhaps you can use a postulate instead of a constructor as the head symbol?
 when checking the pragma REWRITE rew
 

--- a/test/Fail/Issue4755c.err
+++ b/test/Fail/Issue4755c.err
@@ -1,4 +1,4 @@
-Issue4755c.agda:19,1-19: warning: -W[no]RewriteVariablesBoundMoreThanOnce
+Issue4755c.agda:19,13-15: warning: -W[no]RewriteVariablesBoundMoreThanOnce
 Λη  is not a legal rewrite rule, since the following parameters are bound more than once on the left hand side:  B , A. Perhaps you can use a postulate instead of a constructor as the head symbol?
 when checking the pragma REWRITE Λη
 error: [UnsolvedInteractionMetas]

--- a/test/Fail/Issue5238.err
+++ b/test/Fail/Issue5238.err
@@ -1,4 +1,4 @@
-Issue5238.agda:15,3-22: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue5238.agda:15,15-18: warning: -W[no]RewriteVariablesNotBoundByLHS
 foo  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  x
 when checking the pragma REWRITE foo
 

--- a/test/Fail/Issue5891.agda
+++ b/test/Fail/Issue5891.agda
@@ -12,6 +12,7 @@ data ⊥ : Set where
 -- Original exploit:
 -- data False : SizeUniv where
 
+{-# NO_UNIVERSE_CHECK #-}  -- InvalidNoUniverseCheckPragma, the pragma does not apply to definitions
 False : SizeUniv
 False = (X : SizeUniv) → X
 

--- a/test/Fail/Issue5891.err
+++ b/test/Fail/Issue5891.err
@@ -1,4 +1,8 @@
-Issue5891.agda:16,9-27: error: [UnequalSorts]
+Issue5891.agda:15,1-26: warning: -W[no]InvalidNoUniverseCheckPragma
+NO_UNIVERSE_CHECKING pragmas can only precede a data/record
+definition.
+
+Issue5891.agda:17,9-27: error: [UnequalSorts]
 Setω != SizeUniv
 when checking that the expression (X : SizeUniv) → X has type
 SizeUniv

--- a/test/Fail/Issue6006.agda
+++ b/test/Fail/Issue6006.agda
@@ -13,7 +13,7 @@ postulate
   F : T → T
 
 a : T → T
-a x = ?
+a x = _
 
 postulate
   r : ∀ x → F (a x) ≡ C

--- a/test/Fail/Issue6006.err
+++ b/test/Fail/Issue6006.err
@@ -1,6 +1,6 @@
-Issue6006.agda:21,1-18: warning: -W[no]RewriteContainsUnsolvedMetaVariables
+Issue6006.agda:21,13-14: warning: -W[no]RewriteContainsUnsolvedMetaVariables
 r  is not a legal rewrite rule, since it contains the unsolved meta variable(s) _10
 when checking the pragma REWRITE r
-error: [UnsolvedInteractionMetas]
-Unsolved interaction metas at the following locations:
+error: [UnsolvedMetaVariables]
+Unsolved metas at the following locations:
   Issue6006.agda:16,7-8

--- a/test/Fail/Issue6042.err
+++ b/test/Fail/Issue6042.err
@@ -1,8 +1,8 @@
-Issue6042.agda:35,1-29: warning: -W[no]RewriteBeforeMutualFunctionDefinition
+Issue6042.agda:35,13-21: warning: -W[no]RewriteBeforeMutualFunctionDefinition
 Rewrite rule from function  Id-const  cannot be added before the definition of mutually defined Id
 when checking the pragma REWRITE Id-const ＝-Π
 
-Issue6042.agda:35,1-29: warning: -W[no]RewriteBeforeMutualFunctionDefinition
+Issue6042.agda:35,22-25: warning: -W[no]RewriteBeforeMutualFunctionDefinition
 Rewrite rule from function  ＝-Π  cannot be added before the definition of mutually defined Id
 when checking the pragma REWRITE Id-const ＝-Π
 

--- a/test/Fail/Issue6112.err
+++ b/test/Fail/Issue6112.err
@@ -1,4 +1,4 @@
-Issue6112.agda:22,1-19: error: [GenericDocError]
+Issue6112.agda:22,13-15: error: [GenericDocError]
 ★ should be a constructor of type G ★ but it isn't.
 Do you have any non-confluent rewrite rules?
 when checking the pragma REWRITE G2

--- a/test/Fail/Issue6643.err
+++ b/test/Fail/Issue6643.err
@@ -1,4 +1,4 @@
-Issue6643.agda:12,1-18: warning: -W[no]RewriteBeforeMutualFunctionDefinition
+Issue6643.agda:12,13-14: warning: -W[no]RewriteBeforeMutualFunctionDefinition
 Rewrite rule from function  p  cannot be added before the definition of mutually defined q
 when checking the pragma REWRITE p
 

--- a/test/Fail/Issue7029.err
+++ b/test/Fail/Issue7029.err
@@ -1,4 +1,4 @@
-Issue7029.agda:13,1-20: warning: -W[no]RewriteHeadSymbolContainsMetas
+Issue7029.agda:13,13-16: warning: -W[no]RewriteHeadSymbolContainsMetas
 UIP is not a legal rewrite rule, since the definition of the head symbol myrefl contains unsolved metavariables and confluence checking is enabled.
 when checking the pragma REWRITE UIP
 error: [UnsolvedConstraints]

--- a/test/Fail/LocalRewritingNotConfluent.agda
+++ b/test/Fail/LocalRewritingNotConfluent.agda
@@ -1,0 +1,25 @@
+-- Jesper, 2019-05-21 Add some failing test cases for confluence checker.
+-- Andreas, 2024-08-20 Even fails in local confluence check, trigger RewriteNonConfluent.
+
+{-# OPTIONS --rewriting --local-confluence-check #-}
+
+open import Agda.Builtin.Nat using (Nat; zero; suc)
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+variable
+  k l m n : Nat
+
+postulate
+  max : Nat → Nat → Nat
+  max-0l : max 0 n ≡ n
+  max-0r : max m 0 ≡ m
+  max-diag : max m m ≡ m
+  max-ss : max (suc m) (suc n) ≡ suc (max m n)
+  max-assoc : max (max k l) m ≡ max k (max l m)
+
+{-# REWRITE max-0l #-}
+{-# REWRITE max-0r #-}
+{-# REWRITE max-diag #-}
+{-# REWRITE max-ss #-}
+{-# REWRITE max-assoc #-} -- not confluent!

--- a/test/Fail/LocalRewritingNotConfluent.err
+++ b/test/Fail/LocalRewritingNotConfluent.err
@@ -1,0 +1,18 @@
+LocalRewritingNotConfluent.agda:25,13-22: error: [RewriteNonConfluent]
+Local confluence check failed: max (max k l) (max k l)
+reduces to both max k (max l (max k l)) and max k l
+which are not equal because max l (max k l) != l of type Nat
+when checking confluence of the rewrite rule max-assoc with
+max-diag
+LocalRewritingNotConfluent.agda:25,13-22: error: [RewriteNonConfluent]
+Local confluence check failed: max (max (suc m) (suc n)) m₁
+reduces to both max (suc m) (max (suc n) m₁) and
+max (suc (max m n)) m₁ which are not equal because
+m != max m n of type Nat
+when checking confluence of the rewrite rule max-assoc with max-ss
+LocalRewritingNotConfluent.agda:25,13-22: error: [RewriteNonConfluent]
+Local confluence check failed: max (max k k) m reduces to both
+max k (max k m) and max k m which are not equal because
+max k m != m of type Nat
+when checking confluence of the rewrite rule max-assoc with
+max-diag

--- a/test/Fail/RewriteRuleOpenMeta.err
+++ b/test/Fail/RewriteRuleOpenMeta.err
@@ -1,4 +1,4 @@
-RewriteRuleOpenMeta.agda:13,1-18: warning: -W[no]RewriteContainsUnsolvedMetaVariables
+RewriteRuleOpenMeta.agda:13,13-14: warning: -W[no]RewriteContainsUnsolvedMetaVariables
 r  is not a legal rewrite rule, since it contains the unsolved meta variable(s) _7
 when checking the pragma REWRITE r
 error: [UnsolvedMetaVariables]

--- a/test/Fail/SafeFlagNoUniverseCheck.agda
+++ b/test/Fail/SafeFlagNoUniverseCheck.agda
@@ -1,0 +1,63 @@
+-- Andreas, 2024-08-20, issue #7439, trigger SafeFlagNoUniverseCheck
+
+{-# OPTIONS --safe #-}
+
+module _ where
+
+data ⊥ : Set where
+
+{-# NO_UNIVERSE_CHECK #-}  -- rejected with --safe
+record Type : Set where
+  constructor inn
+  field out : Set
+open Type
+
+-- The rest is Hurken's paradox.
+
+⊥′ : Type
+⊥′ = inn ((A : Type) → out A)
+
+_⇒_ : (A B : Type) → Type
+inn A ⇒ inn B = inn (A → B)
+
+Π : (A : Type) (B : out A → Type) → Type
+Π A B = inn ((x : out A) → out (B x))
+
+¬_ : Type → Type
+¬ A = A ⇒ ⊥′
+
+P : Type → Type
+P A = inn (out A → Type)
+
+U : Type
+U = inn ((X : Type) → out ((P (P X) ⇒ X) ⇒ P (P X)))
+
+τ : out (P (P U) ⇒ U)
+τ t = λ X f p → t λ x → p (f (x X f))
+
+σ : out (U ⇒ P (P U))
+σ s pu = s U (λ t → τ t) pu
+
+Δ : out (P U)
+Δ = λ y → ¬ (Π (P U) λ p → σ y p ⇒ p (τ (σ y)))
+
+Ω : out U
+Ω X t px = τ (λ p → Π U λ x → σ x p ⇒ p x) X t px
+
+D : Type
+D = Π (P U) λ p → σ Ω p ⇒ p (τ (σ Ω))
+
+lem₁ : out (Π (P U) λ p → (Π U λ x → σ x p ⇒ p x) ⇒ p Ω)
+lem₁ p H1 = H1 Ω λ x → H1 (τ (σ x))
+
+lem₂ : out (¬ D)
+lem₂ d A = lem₁ Δ (λ x H2 H3 → H3 Δ H2 λ p → H3 λ y → p (τ (σ y))) d A
+
+lem₃ : out D
+lem₃ p = lem₁ λ y → p (τ (σ y))
+
+loop : out ⊥′
+loop = λ A → lem₂ lem₃ A
+
+absurd : ⊥
+absurd = loop (inn ⊥)

--- a/test/Fail/SafeFlagNoUniverseCheck.err
+++ b/test/Fail/SafeFlagNoUniverseCheck.err
@@ -1,0 +1,2 @@
+SafeFlagNoUniverseCheck.agda:9,1-26: error: [SafeFlagNoUniverseCheck]
+Cannot use NO_UNIVERSE_CHECK pragma with safe flag.

--- a/test/Succeed/ExactSplit.agda
+++ b/test/Succeed/ExactSplit.agda
@@ -15,14 +15,17 @@ data ℕ : Set where
   zero : ℕ
   suc  : ℕ → ℕ
 
+{-# CATCHALL #-}  -- InvalidCatchallPragma, ignored
 _+_ : ℕ → ℕ → ℕ
 zero    + n    = zero
 (suc m) + n    = suc (m + n)
+{-# CATCHALL #-}  -- InvalidCatchallPragma, ignored
 
 eq : ℕ → ℕ → Bool
 eq zero    zero    = true
 eq (suc m) (suc n) = eq m n
 {-# CATCHALL #-}
+{-# CATCHALL #-}  -- InvalidCatchallPragma, ignored
 eq _       _       = false
 
 -- See also fail/ExactSplitMin.agda

--- a/test/Succeed/ExactSplit.warn
+++ b/test/Succeed/ExactSplit.warn
@@ -1,0 +1,19 @@
+ExactSplit.agda:18,1-17: warning: -W[no]InvalidCatchallPragma
+The CATCHALL pragma can only precede a function clause.
+
+ExactSplit.agda:22,1-17: warning: -W[no]InvalidCatchallPragma
+The CATCHALL pragma can only precede a function clause.
+
+ExactSplit.agda:28,1-17: warning: -W[no]InvalidCatchallPragma
+The CATCHALL pragma can only precede a function clause.
+
+———— All done; warnings encountered ————————————————————————
+
+ExactSplit.agda:18,1-17: warning: -W[no]InvalidCatchallPragma
+The CATCHALL pragma can only precede a function clause.
+
+ExactSplit.agda:22,1-17: warning: -W[no]InvalidCatchallPragma
+The CATCHALL pragma can only precede a function clause.
+
+ExactSplit.agda:28,1-17: warning: -W[no]InvalidCatchallPragma
+The CATCHALL pragma can only precede a function clause.

--- a/test/Succeed/Issue1652-2.warn
+++ b/test/Succeed/Issue1652-2.warn
@@ -1,9 +1,9 @@
-Issue1652-2.agda:16,3-25: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue1652-2.agda:16,15-21: warning: -W[no]RewriteVariablesNotBoundByLHS
 plus0p  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  A
 when checking the pragma REWRITE plus0p
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue1652-2.agda:16,3-25: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue1652-2.agda:16,15-21: warning: -W[no]RewriteVariablesNotBoundByLHS
 plus0p  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  A
 when checking the pragma REWRITE plus0p

--- a/test/Succeed/Issue1980.agda
+++ b/test/Succeed/Issue1980.agda
@@ -1,5 +1,7 @@
 {-# OPTIONS --rewriting #-}
 
+-- {-# OPTIONS -v rewriting.rule.check:30 #-}
+
 open import Agda.Builtin.Bool
 open import Agda.Builtin.Equality
 
@@ -8,4 +10,25 @@ open import Agda.Builtin.Equality
 funny : true ≡ false → true ≡ false
 funny x = x
 
-{-# REWRITE funny #-}
+{-# REWRITE funny #-}  -- RewriteVariablesNotBoundByLHS
+
+-- Andreas, 2024-08-20
+-- More cases of illegal rewrite rules.
+
+{-# REWRITE refl #-}   -- RewriteLHSNotDefinitionOrConstructor
+
+record R : Set1 where
+  field f : Set
+
+postulate
+  proj : ∀ A → R.f ≡ A
+
+{-# REWRITE proj #-}   -- RewriteLHSNotDefinitionOrConstructor
+                       -- because Agda sees it as (λ x → x .R.f)
+postulate
+  A : Set
+  a : A
+  f g : A → A
+  f=g : (λ x → f a) ≡ g
+
+{-# REWRITE f=g #-}   -- RewriteLHSNotDefinitionOrConstructor (lambda)

--- a/test/Succeed/Issue1980.warn
+++ b/test/Succeed/Issue1980.warn
@@ -1,9 +1,9 @@
-Issue1980.agda:11,1-22: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue1980.agda:11,13-18: warning: -W[no]RewriteVariablesNotBoundByLHS
 funny  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  x
 when checking the pragma REWRITE funny
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue1980.agda:11,1-22: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue1980.agda:11,13-18: warning: -W[no]RewriteVariablesNotBoundByLHS
 funny  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  x
 when checking the pragma REWRITE funny

--- a/test/Succeed/Issue1980.warn
+++ b/test/Succeed/Issue1980.warn
@@ -1,9 +1,33 @@
-Issue1980.agda:11,13-18: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue1980.agda:13,13-18: warning: -W[no]RewriteVariablesNotBoundByLHS
 funny  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  x
 when checking the pragma REWRITE funny
+
+Issue1980.agda:18,13-17: warning: -W[no]RewriteLHSNotDefinitionOrConstructor
+refl  is not a legal rewrite rule, since the left-hand side is neither a defined symbol nor a constructor
+when checking the pragma REWRITE refl
+
+Issue1980.agda:26,13-17: warning: -W[no]RewriteLHSNotDefinitionOrConstructor
+proj  is not a legal rewrite rule, since the left-hand side is neither a defined symbol nor a constructor
+when checking the pragma REWRITE proj
+
+Issue1980.agda:34,13-16: warning: -W[no]RewriteLHSNotDefinitionOrConstructor
+f=g  is not a legal rewrite rule, since the left-hand side is neither a defined symbol nor a constructor
+when checking the pragma REWRITE f=g
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue1980.agda:11,13-18: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue1980.agda:13,13-18: warning: -W[no]RewriteVariablesNotBoundByLHS
 funny  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  x
 when checking the pragma REWRITE funny
+
+Issue1980.agda:18,13-17: warning: -W[no]RewriteLHSNotDefinitionOrConstructor
+refl  is not a legal rewrite rule, since the left-hand side is neither a defined symbol nor a constructor
+when checking the pragma REWRITE refl
+
+Issue1980.agda:26,13-17: warning: -W[no]RewriteLHSNotDefinitionOrConstructor
+proj  is not a legal rewrite rule, since the left-hand side is neither a defined symbol nor a constructor
+when checking the pragma REWRITE proj
+
+Issue1980.agda:34,13-16: warning: -W[no]RewriteLHSNotDefinitionOrConstructor
+f=g  is not a legal rewrite rule, since the left-hand side is neither a defined symbol nor a constructor
+when checking the pragma REWRITE f=g

--- a/test/Succeed/Issue1997.warn
+++ b/test/Succeed/Issue1997.warn
@@ -1,9 +1,9 @@
-Issue1997.agda:30,1-22: warning: -W[no]DuplicateRewriteRule
+Issue1997.agda:30,13-18: warning: -W[no]DuplicateRewriteRule
 Rewrite rule  plus0  has already been added
 when checking the pragma REWRITE plus0
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue1997.agda:30,1-22: warning: -W[no]DuplicateRewriteRule
+Issue1997.agda:30,13-18: warning: -W[no]DuplicateRewriteRule
 Rewrite rule  plus0  has already been added
 when checking the pragma REWRITE plus0

--- a/test/Succeed/Issue2451.warn
+++ b/test/Succeed/Issue2451.warn
@@ -1,9 +1,9 @@
-Issue2451.agda:23,1-23: warning: -W[no]RewriteDoesNotTargetRewriteRelation
+Issue2451.agda:23,13-19: warning: -W[no]RewriteDoesNotTargetRewriteRelation
 plus0p  does not target rewrite relation
 when checking the pragma REWRITE plus0p
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue2451.agda:23,1-23: warning: -W[no]RewriteDoesNotTargetRewriteRelation
+Issue2451.agda:23,13-19: warning: -W[no]RewriteDoesNotTargetRewriteRelation
 plus0p  does not target rewrite relation
 when checking the pragma REWRITE plus0p

--- a/test/Succeed/Issue2925.warn
+++ b/test/Succeed/Issue2925.warn
@@ -1,9 +1,9 @@
-Issue2925.agda:12,1-20: warning: -W[no]DuplicateRewriteRule
+Issue2925.agda:12,13-16: warning: -W[no]DuplicateRewriteRule
 Rewrite rule  rew  has already been added
 when checking the pragma REWRITE rew
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue2925.agda:12,1-20: warning: -W[no]DuplicateRewriteRule
+Issue2925.agda:12,13-16: warning: -W[no]DuplicateRewriteRule
 Rewrite rule  rew  has already been added
 when checking the pragma REWRITE rew

--- a/test/Succeed/Issue5238-unbound-parameter.warn
+++ b/test/Succeed/Issue5238-unbound-parameter.warn
@@ -1,9 +1,9 @@
-Issue5238-unbound-parameter.agda:23,1-20: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue5238-unbound-parameter.agda:23,13-16: warning: -W[no]RewriteVariablesNotBoundByLHS
 rew  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  A
 when checking the pragma REWRITE rew
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue5238-unbound-parameter.agda:23,1-20: warning: -W[no]RewriteVariablesNotBoundByLHS
+Issue5238-unbound-parameter.agda:23,13-16: warning: -W[no]RewriteVariablesNotBoundByLHS
 rew  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  A
 when checking the pragma REWRITE rew

--- a/test/Succeed/Issue5462.warn
+++ b/test/Succeed/Issue5462.warn
@@ -1,9 +1,9 @@
-Issue5462.agda:85,1-21: warning: -W[no]RewriteHeadSymbolIsProjectionLikeFunction
+Issue5462.agda:85,13-17: warning: -W[no]RewriteHeadSymbolIsProjectionLikeFunction
 ≀₁id  is not a legal rewrite rule, since the head symbol _≀₁_ is a projection-like function. You can turn off the projection-like optimization for _≀₁_ with the pragma {-# NOT_PROJECTION_LIKE _≀₁_ #-} or globally with the flag --no-projection-like
 when checking the pragma REWRITE ≀₁id
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue5462.agda:85,1-21: warning: -W[no]RewriteHeadSymbolIsProjectionLikeFunction
+Issue5462.agda:85,13-17: warning: -W[no]RewriteHeadSymbolIsProjectionLikeFunction
 ≀₁id  is not a legal rewrite rule, since the head symbol _≀₁_ is a projection-like function. You can turn off the projection-like optimization for _≀₁_ with the pragma {-# NOT_PROJECTION_LIKE _≀₁_ #-} or globally with the flag --no-projection-like
 when checking the pragma REWRITE ≀₁id

--- a/test/Succeed/Issue5784.agda
+++ b/test/Succeed/Issue5784.agda
@@ -1,12 +1,19 @@
 -- Andreas, 2022-03-02, issue #5784, reported by Trebor-Huang
 -- Test case by Ulf Norell
-
--- primEraseEquality needs to normalized the sides of the equation,
+--
+-- primEraseEquality needs to normalize the sides of the equation,
 -- not just reduce them.
+
+-- Andreas, 2024-08-20, trigger warning WithoutKFlagPrimEraseEquality
+{-# OPTIONS --without-K #-}
 
 open import Agda.Builtin.Nat
 open import Agda.Builtin.Equality
-open import Agda.Builtin.Equality.Erase
+
+primitive
+  primEraseEquality : ∀ {a} {A : Set a} {x y : A} → x ≡ y → x ≡ y
+  -- Warning:
+  -- Using primEraseEquality with the without-K flag is inconsistent.
 
 data Wrap : Set where
   wrap : Nat → Wrap

--- a/test/Succeed/Issue5784.warn
+++ b/test/Succeed/Issue5784.warn
@@ -1,0 +1,11 @@
+Issue5784.agda:14,3-66: warning: -W[no]WithoutKFlagPrimEraseEquality
+Using primEraseEquality with the without-K flag is inconsistent.
+when checking that the type of the primitive function
+primEraseEquality is ∀ {a} {A : Set a} {x y : A} → x ≡ y → x ≡ y
+
+———— All done; warnings encountered ————————————————————————
+
+Issue5784.agda:14,3-66: warning: -W[no]WithoutKFlagPrimEraseEquality
+Using primEraseEquality with the without-K flag is inconsistent.
+when checking that the type of the primitive function
+primEraseEquality is ∀ {a} {A : Set a} {x y : A} → x ≡ y → x ≡ y

--- a/test/Succeed/NoTerminationCheck5.agda
+++ b/test/Succeed/NoTerminationCheck5.agda
@@ -1,6 +1,5 @@
 -- 2012-03-08 Andreas
-module _ where
+-- 2024-08-20 Andreas, add NO_COVERAGE_CHECK
 
-{-# TERMINATING #-}
-
--- error: misplaced pragma
+{-# TERMINATING  #-}  -- warning: -W[no]InvalidTerminationCheckPragma
+{-# NON_COVERING #-}  -- warning: -W[no]InvalidCoverageCheckPragma

--- a/test/Succeed/NoTerminationCheck5.warn
+++ b/test/Succeed/NoTerminationCheck5.warn
@@ -1,9 +1,17 @@
-NoTerminationCheck5.agda:4,1-20: warning: -W[no]InvalidTerminationCheckPragma
+NoTerminationCheck5.agda:4,1-21: warning: -W[no]InvalidTerminationCheckPragma
 Termination checking pragmas can only precede a function definition
 or a mutual block (that contains a function definition).
+
+NoTerminationCheck5.agda:5,1-21: warning: -W[no]InvalidCoverageCheckPragma
+Coverage checking pragmas can only precede a function definition or
+a mutual block (that contains a function definition).
 
 ———— All done; warnings encountered ————————————————————————
 
-NoTerminationCheck5.agda:4,1-20: warning: -W[no]InvalidTerminationCheckPragma
+NoTerminationCheck5.agda:4,1-21: warning: -W[no]InvalidTerminationCheckPragma
 Termination checking pragmas can only precede a function definition
 or a mutual block (that contains a function definition).
+
+NoTerminationCheck5.agda:5,1-21: warning: -W[no]InvalidCoverageCheckPragma
+Coverage checking pragmas can only precede a function definition or
+a mutual block (that contains a function definition).

--- a/test/Succeed/RewriteConstructorParsNotGeneral.warn
+++ b/test/Succeed/RewriteConstructorParsNotGeneral.warn
@@ -1,4 +1,4 @@
-RewriteConstructorParsNotGeneral.agda:12,1-20: warning: -W[no]RewriteConstructorParametersNotGeneral
+RewriteConstructorParsNotGeneral.agda:12,13-16: warning: -W[no]RewriteConstructorParametersNotGeneral
 rew  is not a legal rewrite rule, since the constructor parameters are not fully general:
   Constructor:  c
   Parameters:  [Bool]
@@ -6,7 +6,7 @@ when checking the pragma REWRITE rew
 
 ———— All done; warnings encountered ————————————————————————
 
-RewriteConstructorParsNotGeneral.agda:12,1-20: warning: -W[no]RewriteConstructorParametersNotGeneral
+RewriteConstructorParsNotGeneral.agda:12,13-16: warning: -W[no]RewriteConstructorParametersNotGeneral
 rew  is not a legal rewrite rule, since the constructor parameters are not fully general:
   Constructor:  c
   Parameters:  [Bool]

--- a/test/Succeed/RewriteLhsReduction.warn
+++ b/test/Succeed/RewriteLhsReduction.warn
@@ -1,11 +1,11 @@
-RewriteLhsReduction.agda:17,1-21: warning: -W[no]RewriteLHSReduces
+RewriteLhsReduction.agda:17,13-17: warning: -W[no]RewriteLHSReduces
 f≡g'  is not a legal rewrite rule, since the left-hand side 
 f a  reduces to  g a
 when checking the pragma REWRITE f≡g'
 
 ———— All done; warnings encountered ————————————————————————
 
-RewriteLhsReduction.agda:17,1-21: warning: -W[no]RewriteLHSReduces
+RewriteLhsReduction.agda:17,13-17: warning: -W[no]RewriteLHSReduces
 f≡g'  is not a legal rewrite rule, since the left-hand side 
 f a  reduces to  g a
 when checking the pragma REWRITE f≡g'

--- a/test/Succeed/RewriteRuleNotTargetRelation.warn
+++ b/test/Succeed/RewriteRuleNotTargetRelation.warn
@@ -1,9 +1,9 @@
-RewriteRuleNotTargetRelation.agda:10,1-18: warning: -W[no]RewriteDoesNotTargetRewriteRelation
+RewriteRuleNotTargetRelation.agda:10,13-14: warning: -W[no]RewriteDoesNotTargetRewriteRelation
 R  does not target rewrite relation
 when checking the pragma REWRITE R
 
 ———— All done; warnings encountered ————————————————————————
 
-RewriteRuleNotTargetRelation.agda:10,1-18: warning: -W[no]RewriteDoesNotTargetRewriteRelation
+RewriteRuleNotTargetRelation.agda:10,13-14: warning: -W[no]RewriteDoesNotTargetRewriteRelation
 R  does not target rewrite relation
 when checking the pragma REWRITE R

--- a/test/Succeed/RewriteRuleUnboundVars.warn
+++ b/test/Succeed/RewriteRuleUnboundVars.warn
@@ -1,9 +1,9 @@
-RewriteRuleUnboundVars.agda:12,1-28: warning: -W[no]RewriteVariablesNotBoundByLHS
+RewriteRuleUnboundVars.agda:12,13-24: warning: -W[no]RewriteVariablesNotBoundByLHS
 boolTrivial  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  c
 when checking the pragma REWRITE boolTrivial
 
 ———— All done; warnings encountered ————————————————————————
 
-RewriteRuleUnboundVars.agda:12,1-28: warning: -W[no]RewriteVariablesNotBoundByLHS
+RewriteRuleUnboundVars.agda:12,13-24: warning: -W[no]RewriteVariablesNotBoundByLHS
 boolTrivial  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  c
 when checking the pragma REWRITE boolTrivial

--- a/test/Succeed/RewritingIgnoreUnusedParameter.warn
+++ b/test/Succeed/RewritingIgnoreUnusedParameter.warn
@@ -1,9 +1,9 @@
-RewritingIgnoreUnusedParameter.agda:11,1-20: warning: -W[no]RewriteVariablesNotBoundByLHS
+RewritingIgnoreUnusedParameter.agda:11,13-16: warning: -W[no]RewriteVariablesNotBoundByLHS
 rew  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  A
 when checking the pragma REWRITE rew
 
 ———— All done; warnings encountered ————————————————————————
 
-RewritingIgnoreUnusedParameter.agda:11,1-20: warning: -W[no]RewriteVariablesNotBoundByLHS
+RewritingIgnoreUnusedParameter.agda:11,13-16: warning: -W[no]RewriteVariablesNotBoundByLHS
 rew  is not a legal rewrite rule, since the following variables are not bound by the left hand side:  A
 when checking the pragma REWRITE rew

--- a/test/doc/user-manual-covers-warnings.sh
+++ b/test/doc/user-manual-covers-warnings.sh
@@ -15,7 +15,9 @@ HELPWARNS=$TMPDIR/help-text-warnings.txt
 # Documented warnings
 sed -nr 's/^.. option:: ([A-Z][A-Za-z]*)/\1/p' $DOC | sort > $DOCWARNS
 
-# Existing warnings
+# Existing warnings.
+# Those are printed by `agda --help=warning` at line beginnings and follow
+# the camel-case convention, with at least two capital letters.
 $AGDA_BIN --help=warning | sed -nr 's/^([A-Z][a-z]+[A-Z][A-Za-z]+).*/\1/p' | sort > $HELPWARNS
 
 # Warnings that are documented but don't exist any longer.

--- a/test/test-suite-covers-warnings.sh
+++ b/test/test-suite-covers-warnings.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+# Andreas, end of August 2024
+# A shell script to check whether all Agda warnings are covered by the testsuite.
+
+# We want to compute differences between the lists of existing and documented warnings.
+# To use the 'comm' tool to this end, we need to store those in intermediate files.
+#
+TMPDIR=$(mktemp -d)
+HELPWARNS=$TMPDIR/help-text-warnings.txt
+BENIGNWARNS=$TMPDIR/benign-warnings.txt
+ERRORS=$TMPDIR/errors.txt
+COVERED=$TMPDIR/covered.txt
+
+# Existing warnings.
+#
+# Those are printed by `agda --help=warning` at line beginnings and follow
+# the camel-case convention, with at least two capital letters.
+#
+${AGDA_BIN:-agda} --help=warning | sed -nr 's/^([A-Z][a-z]+[A-Z][A-Za-z]+).*/\1/p' | sort > $HELPWARNS
+
+# Warnings we do not need to cover by the testsuite.
+#
+cat > $BENIGNWARNS <<EOF
+CustomBackendWarning
+DeprecationWarning
+DuplicateInterfaceFiles
+LibUnknownField
+EOF
+
+# Warnings we currently do not cover by the testsuite (TODO!).
+#
+cat >> $BENIGNWARNS <<EOF
+RewriteBlockedOnProblems
+RewriteRequiresDefinitions
+EOF
+
+# Warnings covered by the testsuite.
+
+# Testsuite golden value files.
+#
+FILES=$(find \( -name "*.warn" -o -name "*.err" -o -name "*.out" \))
+
+# Names $WARNINGNAME of benign warnings are CamelCase and printed in this form:
+#
+#    ... warning: -W[no]$WARNINGNAME
+#
+sed --silent --regexp-extended --expression='s/.*warning: -W\[no\]([A-Z][a-z]+[A-Z][A-Za-z]+).*/\1/p' $FILES | sort | uniq >> $BENIGNWARNS
+
+# Names $NAME of errors and error warnings are CamelCase and printed in that form:
+#
+#    ... error: [$NAME]
+#
+sed --silent --regexp-extended --expression='s/.*error: \[([A-Z][a-z]+[A-Z][A-Za-z]+)\].*/\1/p' $FILES | sort | uniq > $ERRORS
+
+cat $BENIGNWARNS $ERRORS | sort | uniq > $COVERED
+
+# Warnings that exist but are not covered by the testsuite.
+#
+UNCOVERED=$(comm -13 $COVERED $HELPWARNS)
+  ## -13 means only column 2 of output (additions in $HELPWARNS), not 1 and 3.
+
+# Print uncovered warnings and error out if we have one.
+#
+if [ "x$UNCOVERED" != "x" ]; then
+  echo "Error: The following Agda warnings are not covered by the testsuite:"
+  for i in $UNCOVERED; do
+    echo "- $i"
+  done
+  exit 1
+fi


### PR DESCRIPTION
- **Re #7439: test warning InvalidCatchallPragma**
- **Re #7439: remove unused warning InvalidConstructor**
- **Re #7439: test warning InvalidCoverageCheckPragma**
- **Re #7439: test warning InvalidNoUniverseCheckPragma**
- **Re #7439: trigger error warning SafeFlagNoUniverseCheck**
- **Re #7439: trigger warning WithoutKFlagPrimEraseEquality**
- **More precise Range for IllegalRewriteRule warning**
- **Re #7439: test warning RewriteLHSNotDefinitionOrConstructor**
- **Re #7439: remove untriggerable warning RewriteHeadSymbolIsProjection**
- **Re #7439: test warning RewriteNonConfluent**
- **Makefile: new goal test-suite-covers-warnings (runs in CI)**

Closes #7439 
