### PR TITLE
Fix #7436: make display forms of imported names DeadCode roots

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -1255,19 +1255,13 @@ buildInterface src topLevel = do
 
     let !scope = topLevelScope topLevel
 
-    (!solvedMetas, !definitions) <- eliminateDeadCode scope
+    (!solvedMetas, !definitions, !displayForms) <- eliminateDeadCode scope
     !sig <- set sigDefinitions definitions <$> getSignature
 
     -- Andreas, 2015-02-09 kill ranges in pattern synonyms before
     -- serialization to avoid error locations pointing to external files
     -- when expanding a pattern synonym.
     !patsyns <- killRange <$> getPatternSyns
-
-    -- Ulf, 2016-04-12:
-    -- Non-closed display forms are not applicable outside the module anyway,
-    -- and should be dead-code eliminated (#1928).
-    !importedDisplayForms <-
-        HMap.filter (not . null) . HMap.map (filter isClosed) <$> useTC stImportsDisplayForms
 
     !userwarns   <- useTC stLocalUserWarnings
     !importwarn  <- useTC stWarningOnImport
@@ -1300,7 +1294,7 @@ buildInterface src topLevel = do
           , iInsideScope          = scope
           , iSignature            = sig
           , iMetaBindings         = solvedMetas
-          , iDisplayForms         = importedDisplayForms
+          , iDisplayForms         = displayForms
           , iUserWarnings         = userwarns
           , iImportWarning        = importwarn
           , iBuiltin              = builtin

--- a/test/interaction/Issue7436.agda
+++ b/test/interaction/Issue7436.agda
@@ -1,0 +1,11 @@
+-- Andreas, 2024-09-02, regression #7436 in dead code removal.
+-- Shrank original reproducer by mechvel.
+
+{-# OPTIONS --no-main #-}
+
+open import Issue7436.Import Set
+
+-- WAS: Internal error (unbound identifier) during compilation,
+-- only reliably reproduceable from the command line.
+
+-- Should succeed.

--- a/test/interaction/Issue7436.sh
+++ b/test/interaction/Issue7436.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Andreas, 2024-09-02, issue #7436
+
+AGDA=$1
+
+# First build the interface files:
+$AGDA Issue7436.agda --ignore-interfaces -v0
+
+# The second invocation of agda, asking to compile, crashed with internal error,
+# due to a dangling name that deadcode removal had introduced.
+$AGDA Issue7436.agda --ghc --ghc-dont-call-ghc -v0

--- a/test/interaction/Issue7436/Base.agda
+++ b/test/interaction/Issue7436/Base.agda
@@ -1,0 +1,11 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Basic auxiliary definitions for magma-like structures
+------------------------------------------------------------------------
+-- Andreas, 2024-09-02, helper for Issue7436
+
+module Issue7436.Base where
+
+record R : Set where
+  constructor cons

--- a/test/interaction/Issue7436/Import.agda
+++ b/test/interaction/Issue7436/Import.agda
@@ -1,0 +1,5 @@
+-- Andreas, 2024-09-02, helper for Issue7436
+
+module Issue7436.Import (_ : Set1) where
+
+open import Issue7436.Base public using (cons)


### PR DESCRIPTION
PR #7248 erroneously removed them from the root set.