### PR TITLE
Do not reduce term of instance candidate

### DIFF
--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -988,7 +988,7 @@ instance Reduce e => Reduce (Map k e) where
   reduce' = traverse reduce'
 
 instance Reduce Candidate where
-  reduce' (Candidate q u t ov) = Candidate q <$> reduce' u <*> reduce' t <*> pure ov
+  reduce' (Candidate q u t ov) = Candidate q <$> pure u <*> reduce' t <*> pure ov
 
 instance Reduce EqualityView where
   reduce' (OtherType t)            = OtherType


### PR DESCRIPTION
This is a simple fix for #7449 that just handles the specific problem of instance solutions being reduced. I'm not sure how to write a test for this, as the Haskell code is functionally equivalent with or without this patch. Perhaps we could have a custom script that checks how often the string `1234567890123456789012345678901234567890` appears in the generated Haskell code, though I'm not sure how to do that.