### PR TITLE
New warning FixingRelevance instead of GenericError

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1346,6 +1346,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Face constraint patterns that are given as named arguments.
 
+.. option:: FixingRelevance
+
+     Invalid relevance annotations, automatically corrected.
+
 .. option:: FixityInRenamingModule
 
      Fixity annotations in ``renaming`` directives for a ``module``.

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -513,9 +513,6 @@ mazRTEFloatImport (UsesFloat b) = [ HS.ImportDecl mazRTEFloat True Nothing | b ]
 
 definition :: Definition -> HsCompileM (UsesFloat, [HS.Decl], Maybe CheckedMainFunctionDef)
 -- ignore irrelevant definitions
-{- Andreas, 2012-10-02: Invariant no longer holds
-definition kit (Defn NonStrict _ _  _ _ _ _ _ _) = __IMPOSSIBLE__
--}
 definition Defn{defArgInfo = info, defName = q} | not $ usableModality info = do
   reportSDoc "compile.ghc.definition" 10 $
     ("Not compiling" <+> prettyTCM q) <> "."

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -148,7 +148,7 @@ giveExpr force mii mi e = do
       reportSDoc "interaction.give" 40 $ "give: checked expression:" TP.<+> pure (pretty v)
       case mvInstantiation mv of
 
-        InstV{} -> unlessM ((Irrelevant ==) <$> viewTC eRelevance) $ do
+        InstV{} -> unlessM (isIrrelevant <$> viewTC eRelevance) $ do
           v' <- instantiate $ MetaV mi $ map Apply ctx
           reportSDoc "interaction.give" 20 $ TP.sep
             [ "meta was already set to value v' = " TP.<+> prettyTCM v'
@@ -425,7 +425,7 @@ instance Reify Constraint where
   reify (ValueCmp cmp AsTypes u v) = CmpTypes cmp <$> reify u <*> reify v
   reify (ValueCmpOnFace cmp p t u v) = CmpInType cmp <$> (reify =<< ty) <*> reify (lam_o u) <*> reify (lam_o v)
     where
-      lam_o = I.Lam (setRelevance Irrelevant defaultArgInfo) . NoAbs "_"
+      lam_o = I.Lam defaultIrrelevantArgInfo . NoAbs "_"
       ty = runNamesT [] $ do
         p <- open p
         t <- open t

--- a/src/full/Agda/Interaction/EmacsTop.hs
+++ b/src/full/Agda/Interaction/EmacsTop.hs
@@ -351,7 +351,7 @@ prettyResponseContext ii rev ctx = withInteractionId ii $ do
             -- Print relevance of hypothesis relative to relevance of the goal. (Issue #6706.)
           , [ text $ verbalize r
                              | let r = getRelevance mod `inverseComposeRelevance` getRelevance ai
-                             , r /= Relevant ]
+                             , not $ isRelevant r ]
             -- Print "instance" if variable is considered by instance search.
           , [ "instance"     | isInstance ai ]
           ]

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -435,6 +435,11 @@ warningHighlighting' b w = case tcWarning w of
   BuiltinDeclaresIdentifier{} -> mempty
   EmptyRewritePragma{}       -> deadcodeHighlighting w
   EmptyWhere{}               -> deadcodeHighlighting w
+  -- TODO: linearity
+  -- FixingQuantity _ q _       -> if null r then cosmeticHighlighting w else deadcodeHighlighting r
+  --   where r = getRange q
+  FixingRelevance _ q _      -> if null r then cosmeticProblemHighlighting w else deadcodeHighlighting r
+    where r = getRange q
   IllformedAsClause{}        -> deadcodeHighlighting w
   UselessPragma r _          -> deadcodeHighlighting r
   UselessPublic{}            -> deadcodeHighlighting w

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -264,6 +264,9 @@ data WarningName
   | InlineNoExactSplit_
   | DeprecationWarning_
   | DuplicateUsing_
+  | FixingRelevance_
+  -- TODO: linearity
+  -- -- | FixingQuantity_
   | FixityInRenamingModule_
   | InvalidCharacterLiteral_
   | UselessPragma_
@@ -488,6 +491,9 @@ warningNameDescription = \case
   CoverageNoExactSplit_            -> "Failed exact split checks."
   InlineNoExactSplit_              -> "Failed exact split checks after inlining record constructors."
   DeprecationWarning_              -> "Deprecated features."
+  -- TODO: linearity
+  -- FixingQuantity_                  -> "Correcting invalid user-written quantity."
+  FixingRelevance_                 -> "Correcting invalid user-written relevance."
   InvalidCharacterLiteral_         -> "Illegal character literals."
   UselessPragma_                   -> "Pragmas that get ignored."
   IllformedAsClause_               -> "Illformed `as'-clauses in `import' statements."

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1088,6 +1088,11 @@ instance NFData Quantity where
   rnf (Quantity1 o) = rnf o
   rnf (Quantityω o) = rnf o
 
+isQuantity0 :: LensQuantity a => a -> Bool
+isQuantity0 a = case getQuantity a of
+  Quantity0{} -> True
+  _ -> False
+
 isQuantityω :: LensQuantity a => a -> Bool
 isQuantityω a = case getQuantity a of
   Quantityω{} -> True

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1188,10 +1188,7 @@ data Relevance
                 --   - <https://dl.acm.org/doi/10.1145/3110277>
                 --   - <https://doi.org/10.1145/3209108.3209119>
   | Irrelevant  -- ^ The argument is irrelevant at compile- and runtime.
-    deriving (Show, Eq, Enum, Bounded, Generic)
-
-allRelevances :: [Relevance]
-allRelevances = [minBound..maxBound]
+    deriving (Show, Eq, Generic)
 
 instance HasRange Relevance where
   getRange _ = noRange
@@ -1228,6 +1225,15 @@ instance LensRelevance Relevance where
   getRelevance = id
   setRelevance = const
   mapRelevance = id
+
+relevant :: Relevance
+relevant = Relevant
+
+irrelevant :: Relevance
+irrelevant = Irrelevant
+
+shapeIrrelevant :: Relevance
+shapeIrrelevant = NonStrict
 
 isRelevant :: LensRelevance a => a -> Bool
 isRelevant a = getRelevance a == Relevant

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -739,7 +739,7 @@ observeHiding = \case
 observeRelevance :: Expr -> (Relevance, Expr)
 observeRelevance = \case
   Dot _ e       -> (Irrelevant, e)
-  DoubleDot _ e -> (NonStrict, e)
+  DoubleDot _ e -> (ShapeIrrelevant, e)
   e             -> (Relevant, e)
 
 -- | Observe various modifiers applied to an expression

--- a/src/full/Agda/Syntax/Concrete/Attribute.hs
+++ b/src/full/Agda/Syntax/Concrete/Attribute.hs
@@ -64,9 +64,9 @@ type LensAttribute a = (LensRelevance a, LensQuantity a, LensCohesion a, LensLoc
 
 relevanceAttributeTable :: [(String, Relevance)]
 relevanceAttributeTable = concat
-  [ map (, Irrelevant)  [ "irr", "irrelevant" ]
-  , map (, NonStrict)   [ "shirr", "shape-irrelevant" ]
-  , map (, Relevant)    [ "relevant" ]
+  [ map (, Irrelevant)      [ "irr", "irrelevant" ]
+  , map (, ShapeIrrelevant) [ "shirr", "shape-irrelevant" ]
+  , map (, Relevant)        [ "relevant" ]
   ]
 
 -- | Modifiers for 'Quantity'.

--- a/src/full/Agda/Syntax/Concrete/Attribute.hs
+++ b/src/full/Agda/Syntax/Concrete/Attribute.hs
@@ -63,10 +63,12 @@ type LensAttribute a = (LensRelevance a, LensQuantity a, LensCohesion a, LensLoc
 -- | Modifiers for 'Relevance'.
 
 relevanceAttributeTable :: [(String, Relevance)]
-relevanceAttributeTable = concat
-  [ map (, Irrelevant)      [ "irr", "irrelevant" ]
-  , map (, ShapeIrrelevant) [ "shirr", "shape-irrelevant" ]
-  , map (, Relevant)        [ "relevant" ]
+relevanceAttributeTable =
+  [ ("irr"             , Irrelevant      $ OIrrIrr               noRange)
+  , ("irrelevant"      , Irrelevant      $ OIrrIrrelevant        noRange)
+  , ("shirr"           , ShapeIrrelevant $ OShIrrShIrr           noRange)
+  , ("shape-irrelevant", ShapeIrrelevant $ OShIrrShapeIrrelevant noRange)
+  , ("relevant"        , Relevant        $ ORelRelevant          noRange)
   ]
 
 -- | Modifiers for 'Quantity'.

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -729,7 +729,7 @@ validConPattern cons = loop
         | cons x      -> mapM_ loop ps
         | otherwise   -> failure
       QuoteP _ :| [_] -> ok
-      DotP _ e :| ps  -> mapM_ loop ps
+      DotP _ _ e :| ps  -> mapM_ loop ps
       _               -> failure
     where
     ok      = return ()

--- a/src/full/Agda/Syntax/Concrete/Pattern.hs
+++ b/src/full/Agda/Syntax/Concrete/Pattern.hs
@@ -198,7 +198,7 @@ instance CPatternLike Pattern where
       -- Nonrecursive cases:
       IdentP _ _      -> mempty
       WildP _         -> mempty
-      DotP _ _        -> mempty
+      DotP _ _ _      -> mempty
       AbsurdP _       -> mempty
       LitP _ _        -> mempty
       QuoteP _        -> mempty
@@ -219,7 +219,7 @@ instance CPatternLike Pattern where
       -- Nonrecursive cases:
       IdentP _ _      -> pure p0
       WildP _         -> pure p0
-      DotP _ _        -> pure p0
+      DotP _ _ _      -> pure p0
       AbsurdP _       -> pure p0
       LitP _ _        -> pure p0
       QuoteP _        -> pure p0
@@ -242,7 +242,7 @@ instance CPatternLike Pattern where
       -- Nonrecursive cases:
       IdentP _ _      -> return p0
       WildP _         -> return p0
-      DotP _ _        -> return p0
+      DotP _ _ _      -> return p0
       AbsurdP _       -> return p0
       LitP _ _        -> return p0
       QuoteP _        -> return p0
@@ -317,7 +317,7 @@ patternQNames p = foldCPattern f p `appEndo` []
     ParenP _ _     -> mempty
     WildP _        -> mempty
     AbsurdP _      -> mempty
-    DotP _ _       -> mempty
+    DotP _ _ _     -> mempty
     LitP _ _       -> mempty
     QuoteP _       -> mempty
     InstanceP _ _  -> mempty

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -126,7 +126,7 @@ instance Pretty a => Pretty (WithHiding a) where
 instance Pretty Relevance where
   pretty Relevant   = empty
   pretty Irrelevant = "."
-  pretty NonStrict  = ".."
+  pretty ShapeIrrelevant = ".."
 
 instance Pretty Q0Origin where
   pretty = \case
@@ -179,7 +179,7 @@ attributesForModality mod
     relevance = case getRelevance mod of
       Relevant   -> Nothing
       Irrelevant -> Just "@irrelevant"
-      NonStrict  -> Just "@shape-irrelevant"
+      ShapeIrrelevant -> Just "@shape-irrelevant"
     quantity = case getQuantity mod of
       Quantity0{} -> Just "@0"
       Quantity1{} -> Just "@1"

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -444,8 +444,8 @@ DoubleCloseBrace
 -- A possibly dotted identifier.
 MaybeDottedId :: { Arg Name }
 MaybeDottedId
-  : '..' Id { setRelevance ShapeIrrelevant $ defaultArg $2 }
-  | '.'  Id { setRelevance Irrelevant $ defaultArg $2 }
+  : '..' Id { defaultShapeIrrelevantArg $1 $2 }
+  | '.'  Id { defaultIrrelevantArg $1 $2 }
   | Id      { defaultArg $1 }
 
 -- Space separated list of one or more possibly dotted identifiers.
@@ -464,14 +464,14 @@ ArgIds
     | '{{' MaybeDottedIds DoubleCloseBrace        { fmap makeInstance $2 }
     | '{' MaybeDottedIds '}' ArgIds   { fmap hide $2 <> $4 }
     | '{' MaybeDottedIds '}'          { fmap hide $2 }
-    | '.' '{' SpaceIds '}' ArgIds     { fmap (hide . setRelevance Irrelevant . defaultArg) $3 <> $5 }
-    | '.' '{' SpaceIds '}'            { fmap (hide . setRelevance Irrelevant . defaultArg) $3 }
-    | '.' '{{' SpaceIds DoubleCloseBrace ArgIds   { fmap (makeInstance . setRelevance Irrelevant . defaultArg) $3 <> $5 }
-    | '.' '{{' SpaceIds DoubleCloseBrace          { fmap (makeInstance . setRelevance Irrelevant . defaultArg) $3 }
-    | '..' '{' SpaceIds '}' ArgIds    { fmap (hide . setRelevance ShapeIrrelevant . defaultArg) $3 <> $5 }
-    | '..' '{' SpaceIds '}'           { fmap (hide . setRelevance ShapeIrrelevant . defaultArg) $3 }
-    | '..' '{{' SpaceIds DoubleCloseBrace ArgIds  { fmap (makeInstance . setRelevance ShapeIrrelevant . defaultArg) $3 <> $5 }
-    | '..' '{{' SpaceIds DoubleCloseBrace         { fmap (makeInstance . setRelevance ShapeIrrelevant . defaultArg) $3 }
+    | '.' '{' SpaceIds '}' ArgIds     { fmap (hide . defaultIrrelevantArg $1) $3 <> $5 }
+    | '.' '{' SpaceIds '}'            { fmap (hide . defaultIrrelevantArg $1) $3 }
+    | '.' '{{' SpaceIds DoubleCloseBrace ArgIds   { fmap (makeInstance . defaultIrrelevantArg $1) $3 <> $5 }
+    | '.' '{{' SpaceIds DoubleCloseBrace          { fmap (makeInstance . defaultIrrelevantArg $1) $3 }
+    | '..' '{' SpaceIds '}' ArgIds    { fmap (hide . defaultShapeIrrelevantArg $1) $3 <> $5 }
+    | '..' '{' SpaceIds '}'           { fmap (hide . defaultShapeIrrelevantArg $1) $3 }
+    | '..' '{{' SpaceIds DoubleCloseBrace ArgIds  { fmap (makeInstance . defaultShapeIrrelevantArg $1) $3 <> $5 }
+    | '..' '{{' SpaceIds DoubleCloseBrace         { fmap (makeInstance . defaultShapeIrrelevantArg $1) $3 }
 
 -- Modalities preceeding identifiers
 
@@ -512,9 +512,9 @@ BId : Id    { $1 }
 -- A binding variable. Can be '_'
 MaybeDottedBId :: { (Relevance, Name) }
 MaybeDottedBId
-    : BId        { (Relevant  , $1) }
-    | '.' BId    { (Irrelevant, $2) }
-    | '..' BId   { (ShapeIrrelevant, $2) }
+    : BId        { (Relevant empty , $1) }
+    | '.' BId    { (Irrelevant (OIrrDot $ getRange $1), $2) }
+    | '..' BId   { (ShapeIrrelevant (OShIrrDotDot $ getRange $1), $2) }
 -}
 
 
@@ -725,8 +725,8 @@ Expr3NoCurly
     | '(|)'                             { IdiomBrackets (getRange $1) [] }
     | '(' ')'                           { Absurd (fuseRange $1 $2) }
     | Id '@' Expr3                      { As (getRange ($1,$2,$3)) $1 $3 }
-    | '.' Expr3                         { Dot (fuseRange $1 $2) $2 }
-    | '..' Expr3                        { DoubleDot (fuseRange $1 $2) $2 }
+    | '.' Expr3                         { Dot (kwRange $1) $2 }
+    | '..' Expr3                        { DoubleDot (kwRange $1) $2 }
     | 'record' '{' RecordAssignments '}' { Rec (getRange ($1,$2,$3,$4)) $3 }
     | 'record' Expr3NoCurly '{' FieldAssignments '}' { RecUpdate (getRange ($1,$2,$3,$4,$5)) $2 $4 }
     | '...'                             { Ellipsis (getRange $1) }
@@ -805,23 +805,23 @@ TypedBindings
 TypedBinding :: { TypedBinding }
 TypedBinding
     : '.' '(' TBindWithHiding ')'    { setRange (getRange ($2,$3,$4)) $
-                             setRelevance Irrelevant $3 }
+                             makeIrrelevant $1 $3 }
     | '.' '{' TBind '}'    { setRange (getRange ($2,$3,$4)) $
                              setHiding Hidden $
-                             setRelevance Irrelevant $3 }
+                             makeIrrelevant $1 $3 }
     | '.' '{{' TBind DoubleCloseBrace
                            { setRange (getRange ($2,$3,$4)) $
                              makeInstance $
-                             setRelevance Irrelevant $3 }
+                             makeIrrelevant $1 $3 }
     | '..' '(' TBindWithHiding ')'   { setRange (getRange ($2,$3,$4)) $
-                             setRelevance ShapeIrrelevant $3 }
+                             makeShapeIrrelevant $1 $3 }
     | '..' '{' TBind '}'   { setRange (getRange ($2,$3,$4)) $
                              setHiding Hidden $
-                             setRelevance ShapeIrrelevant $3 }
+                             makeShapeIrrelevant $1 $3 }
     | '..' '{{' TBind DoubleCloseBrace
                            { setRange (getRange ($2,$3,$4)) $
                              makeInstance $
-                             setRelevance ShapeIrrelevant $3 }
+                             makeShapeIrrelevant $1 $3 }
     | '(' TBindWithHiding ')'        { setRange (getRange ($1,$2,$3)) $2 }
     | '(' ModalTBindWithHiding ')'        { setRange (getRange ($1,$2,$3)) $2 }
     | '{{' TBind DoubleCloseBrace
@@ -987,8 +987,8 @@ MaybeAsPattern
 DomainFreeBindingAbsurd :: { Either (List1 (NamedArg Binder)) (List1 Expr)}
 DomainFreeBindingAbsurd
     : BId      MaybeAsPattern { Left . singleton $ mkDomainFree_ id $2 $1 }
-    | '.' BId  MaybeAsPattern { Left . singleton $ mkDomainFree_ (setRelevance Irrelevant) $3 $2 }
-    | '..' BId MaybeAsPattern { Left . singleton $ mkDomainFree_ (setRelevance ShapeIrrelevant) $3 $2 }
+    | '.' BId  MaybeAsPattern { Left . singleton $ mkDomainFree_ (makeIrrelevant $1) $3 $2 }
+    | '..' BId MaybeAsPattern { Left . singleton $ mkDomainFree_ (makeShapeIrrelevant $1) $3 $2 }
     | '(' Application ')'     {% exprToPattern (rawApp $2) >>= \ p ->
                                  pure . Left . singleton $ mkDomainFree_ id (Just p) $ simpleHole }
     | '(' Attributes1 CommaBIdAndAbsurds ')'
@@ -1003,10 +1003,10 @@ DomainFreeBindingAbsurd
     | '{{' Attributes1 CommaBIds DoubleCloseBrace
          {% applyAttrs1 $2 defaultArgInfo <&> \ ai ->
               Left $ fmap (makeInstance . setTacticAttr $2 . setArgInfo ai) $3 }
-    | '.' '{' CommaBIds '}' { Left $ fmap (hide . setRelevance Irrelevant) $3 }
-    | '.' '{{' CommaBIds DoubleCloseBrace { Left $ fmap (makeInstance . setRelevance Irrelevant) $3 }
-    | '..' '{' CommaBIds '}' { Left $ fmap (hide . setRelevance ShapeIrrelevant) $3 }
-    | '..' '{{' CommaBIds DoubleCloseBrace { Left $ fmap (makeInstance . setRelevance ShapeIrrelevant) $3 }
+    | '.' '{' CommaBIds '}' { Left $ fmap (hide . makeIrrelevant $1) $3 }
+    | '.' '{{' CommaBIds DoubleCloseBrace { Left $ fmap (makeInstance . makeIrrelevant $1) $3 }
+    | '..' '{' CommaBIds '}' { Left $ fmap (hide . makeShapeIrrelevant $1) $3 }
+    | '..' '{{' CommaBIds DoubleCloseBrace { Left $ fmap (makeInstance . makeShapeIrrelevant $1) $3 }
 
 
 {--------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -444,7 +444,7 @@ DoubleCloseBrace
 -- A possibly dotted identifier.
 MaybeDottedId :: { Arg Name }
 MaybeDottedId
-  : '..' Id { setRelevance NonStrict $ defaultArg $2 }
+  : '..' Id { setRelevance ShapeIrrelevant $ defaultArg $2 }
   | '.'  Id { setRelevance Irrelevant $ defaultArg $2 }
   | Id      { defaultArg $1 }
 
@@ -468,10 +468,10 @@ ArgIds
     | '.' '{' SpaceIds '}'            { fmap (hide . setRelevance Irrelevant . defaultArg) $3 }
     | '.' '{{' SpaceIds DoubleCloseBrace ArgIds   { fmap (makeInstance . setRelevance Irrelevant . defaultArg) $3 <> $5 }
     | '.' '{{' SpaceIds DoubleCloseBrace          { fmap (makeInstance . setRelevance Irrelevant . defaultArg) $3 }
-    | '..' '{' SpaceIds '}' ArgIds    { fmap (hide . setRelevance NonStrict . defaultArg) $3 <> $5 }
-    | '..' '{' SpaceIds '}'           { fmap (hide . setRelevance NonStrict . defaultArg) $3 }
-    | '..' '{{' SpaceIds DoubleCloseBrace ArgIds  { fmap (makeInstance . setRelevance NonStrict . defaultArg) $3 <> $5 }
-    | '..' '{{' SpaceIds DoubleCloseBrace         { fmap (makeInstance . setRelevance NonStrict . defaultArg) $3 }
+    | '..' '{' SpaceIds '}' ArgIds    { fmap (hide . setRelevance ShapeIrrelevant . defaultArg) $3 <> $5 }
+    | '..' '{' SpaceIds '}'           { fmap (hide . setRelevance ShapeIrrelevant . defaultArg) $3 }
+    | '..' '{{' SpaceIds DoubleCloseBrace ArgIds  { fmap (makeInstance . setRelevance ShapeIrrelevant . defaultArg) $3 <> $5 }
+    | '..' '{{' SpaceIds DoubleCloseBrace         { fmap (makeInstance . setRelevance ShapeIrrelevant . defaultArg) $3 }
 
 -- Modalities preceeding identifiers
 
@@ -514,7 +514,7 @@ MaybeDottedBId :: { (Relevance, Name) }
 MaybeDottedBId
     : BId        { (Relevant  , $1) }
     | '.' BId    { (Irrelevant, $2) }
-    | '..' BId   { (NonStrict, $2) }
+    | '..' BId   { (ShapeIrrelevant, $2) }
 -}
 
 
@@ -814,14 +814,14 @@ TypedBinding
                              makeInstance $
                              setRelevance Irrelevant $3 }
     | '..' '(' TBindWithHiding ')'   { setRange (getRange ($2,$3,$4)) $
-                             setRelevance NonStrict $3 }
+                             setRelevance ShapeIrrelevant $3 }
     | '..' '{' TBind '}'   { setRange (getRange ($2,$3,$4)) $
                              setHiding Hidden $
-                             setRelevance NonStrict $3 }
+                             setRelevance ShapeIrrelevant $3 }
     | '..' '{{' TBind DoubleCloseBrace
                            { setRange (getRange ($2,$3,$4)) $
                              makeInstance $
-                             setRelevance NonStrict $3 }
+                             setRelevance ShapeIrrelevant $3 }
     | '(' TBindWithHiding ')'        { setRange (getRange ($1,$2,$3)) $2 }
     | '(' ModalTBindWithHiding ')'        { setRange (getRange ($1,$2,$3)) $2 }
     | '{{' TBind DoubleCloseBrace
@@ -988,7 +988,7 @@ DomainFreeBindingAbsurd :: { Either (List1 (NamedArg Binder)) (List1 Expr)}
 DomainFreeBindingAbsurd
     : BId      MaybeAsPattern { Left . singleton $ mkDomainFree_ id $2 $1 }
     | '.' BId  MaybeAsPattern { Left . singleton $ mkDomainFree_ (setRelevance Irrelevant) $3 $2 }
-    | '..' BId MaybeAsPattern { Left . singleton $ mkDomainFree_ (setRelevance NonStrict) $3 $2 }
+    | '..' BId MaybeAsPattern { Left . singleton $ mkDomainFree_ (setRelevance ShapeIrrelevant) $3 $2 }
     | '(' Application ')'     {% exprToPattern (rawApp $2) >>= \ p ->
                                  pure . Left . singleton $ mkDomainFree_ id (Just p) $ simpleHole }
     | '(' Attributes1 CommaBIdAndAbsurds ')'
@@ -1005,8 +1005,8 @@ DomainFreeBindingAbsurd
               Left $ fmap (makeInstance . setTacticAttr $2 . setArgInfo ai) $3 }
     | '.' '{' CommaBIds '}' { Left $ fmap (hide . setRelevance Irrelevant) $3 }
     | '.' '{{' CommaBIds DoubleCloseBrace { Left $ fmap (makeInstance . setRelevance Irrelevant) $3 }
-    | '..' '{' CommaBIds '}' { Left $ fmap (hide . setRelevance NonStrict) $3 }
-    | '..' '{{' CommaBIds DoubleCloseBrace { Left $ fmap (makeInstance . setRelevance NonStrict) $3 }
+    | '..' '{' CommaBIds '}' { Left $ fmap (hide . setRelevance ShapeIrrelevant) $3 }
+    | '..' '{{' CommaBIds DoubleCloseBrace { Left $ fmap (makeInstance . setRelevance ShapeIrrelevant) $3 }
 
 
 {--------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -960,10 +960,11 @@ instance ToConcrete A.Expr where
              -- TODO: print attributes
         where
             ctx = if isRelevant a then FunctionSpaceDomainCtx else DotPatternCtx
-            addRel a e = case getRelevance a of
-                           Irrelevant -> C.Dot (getRange a) e
-                           NonStrict  -> C.DoubleDot (getRange a) e
-                           _          -> e
+            addRel a e =
+              case getRelevance a of
+                Irrelevant      {} -> C.Dot (getRange a) e
+                ShapeIrrelevant {} -> C.DoubleDot (getRange a) e
+                Relevant        {} -> e
             mkArg (Arg info e) = case getHiding info of
                                           Hidden     -> HiddenArg   (getRange e) (unnamed e)
                                           Instance{} -> InstanceArg (getRange e) (unnamed e)

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -743,7 +743,7 @@ toAbstractDotHiding mr mh prec e = do
         | Nothing <- mr -> toAbstractDotHiding (Just Irrelevant) mh prec e
 
       C.DoubleDot _ e
-        | Nothing <- mr -> toAbstractDotHiding (Just NonStrict) mh prec e
+        | Nothing <- mr -> toAbstractDotHiding (Just ShapeIrrelevant) mh prec e
 
       C.HiddenArg _ (Named Nothing e)
         | Nothing <- mh -> toAbstractDotHiding mr (Just Hidden) TopCtx e

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -935,7 +935,7 @@ instance Reify i => Reify (Arg i) where
 
   reify (Arg info i) = Arg info <$> (flip reifyWhen i =<< condition)
     where condition = (return (argInfoHiding info /= Hidden) `or2M` showImplicitArguments)
-              `and2M` (return (getRelevance info /= Irrelevant) `or2M` showIrrelevantArguments)
+              `and2M` (return (not $ isIrrelevant info) `or2M` showIrrelevantArguments)
   reifyWhen b i = traverse (reifyWhen b) i
 {-# SPECIALIZE reify :: Reify i => Arg i -> TCM (ReifiesTo (Arg i)) #-}
 

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -193,7 +193,7 @@ instance CheckInternal Term where
             -- Preserve NoAbs
             goInside = case b of
               Abs{}   -> addContext $ (absName b,) $
-                applyWhen experimental (mapRelevance irrToNonStrict) a
+                applyWhen experimental (mapRelevance irrelevantToShapeIrrelevant) a
               NoAbs{} -> id
         a <- mkDom <$> checkInternal' action (unEl $ unDom a) CmpLeq (sort sa)
         v' <- goInside $ Pi a . mkRng <$> checkInternal' action (unEl $ unAbs b) CmpLeq (sort sb)

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -146,7 +146,7 @@ equalType = compareType CmpEq
 -- | Ignore errors in irrelevant context.
 convError :: TypeError -> TCM ()
 convError err =
-  ifM ((==) Irrelevant <$> viewTC eRelevance)
+  ifM (isIrrelevant <$> viewTC eRelevance)
     (return ())
     (typeError err)
 
@@ -834,7 +834,7 @@ compareDom cmp0
      | otherwise -> do
       let r = max (getRelevance dom1) (getRelevance dom2)
               -- take "most irrelevant"
-          dependent = (r /= Irrelevant) && isBinderUsed b2
+          dependent = not (isIrrelevant r) && isBinderUsed b2
       pid <- newProblem_ $ compareType cmp0 a1 a2
       dom <- if dependent
              then (\ a -> dom1 {unDom = a}) <$> blockTypeOnProblem a1 pid

--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -876,7 +876,7 @@ createMissingTrXConClause q_trX f n x old_sc c (UE gamma gamma' xTel u v rho tau
     ]
 
   let mod =
-        setRelevance Irrelevant $  -- See #5611.
+        setRelevance irrelevant $  -- See #5611.
         getModality $ fromMaybe __IMPOSSIBLE__ $ scTarget old_sc
   -- we follow what `cover` does when updating the modality from the target.
   applyModalityToContext mod $ do

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1855,9 +1855,9 @@ instance Verbalize Hiding where
 instance Verbalize Relevance where
   verbalize r =
     case r of
-      Relevant   -> "relevant"
-      Irrelevant -> "irrelevant"
-      NonStrict  -> "shape-irrelevant"
+      Relevant        {} -> "relevant"
+      Irrelevant      {} -> "irrelevant"
+      ShapeIrrelevant {} -> "shape-irrelevant"
 
 instance Verbalize Quantity where
   verbalize = \case

--- a/src/full/Agda/TypeChecking/Errors.hs-boot
+++ b/src/full/Agda/TypeChecking/Errors.hs-boot
@@ -2,6 +2,7 @@
 
 module Agda.TypeChecking.Errors where
 
+import Agda.Syntax.Common (Relevance)
 import Agda.Syntax.Abstract.Name
 
 import Agda.TypeChecking.Monad.Base
@@ -16,3 +17,8 @@ instance PrettyTCM TCErr
 renderError :: MonadTCM tcm => TCErr -> tcm String
 
 topLevelModuleDropper :: (MonadDebug m, MonadTCEnv m, ReadTCState m) => m (QName -> QName)
+
+class Verbalize a where
+  verbalize :: a -> String
+
+instance Verbalize Relevance where

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -124,7 +124,7 @@ computeForcingAnnotations c t =
             if (erasureOn `implies` hasQuantity0 m)
             -- Also the argument shouldn't be irrelevant, since in that
             -- case it isn't really forced.
-            && (getRelevance m /= Irrelevant)
+            && (not $ isIrrelevant m)
             then Just m else Nothing
           | m <- map getModality $ reverse $ telToList tel
           ]

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -539,7 +539,7 @@ instance Free Term where
     Sort s       -> freeVars' s
     Level l      -> freeVars' l
     MetaV m ts   -> underFlexRig (Flexible $ singleton m) $ freeVars' ts
-    DontCare mt  -> underModality (Modality Irrelevant unitQuantity unitCohesion) $ freeVars' mt
+    DontCare mt  -> underModality (Modality irrelevant unitQuantity unitCohesion) $ freeVars' mt
     Dummy{}      -> mempty
 
 instance Free t => Free (Type' t) where

--- a/src/full/Agda/TypeChecking/Implicit.hs
+++ b/src/full/Agda/TypeChecking/Implicit.hs
@@ -141,7 +141,7 @@ newMetaArg
 newMetaArg kind info x cmp a = do
   prp <- runBlocked $ isPropM a
   let irrelevantIfProp =
-        applyWhen (prp == Right True) $ applyRelevanceToContext Irrelevant
+        applyWhen (prp == Right True) $ applyRelevanceToContext irrelevant
   applyModalityToContext info $ irrelevantIfProp $
     newMeta (argNameToString x) kind a
   where

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -970,10 +970,10 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
       -- even though the lhs is not a pattern, we can prune the y from _2
 
       let
-                vars        = freeVars args
-                relVL       = filterVarMapToList isRelevant  vars
-                nonstrictVL = filterVarMapToList isNonStrict vars
-                irrVL       = filterVarMapToList (liftM2 (&&) isIrrelevant isUnguarded) vars
+                vars              = freeVars args
+                relevantVL        = filterVarMapToList isRelevant vars
+                shapeIrrelevantVL = filterVarMapToList isShapeIrrelevant vars
+                irrelevantVL      = filterVarMapToList (liftM2 (&&) isIrrelevant isUnguarded) vars
             -- Andreas, 2011-10-06 only irrelevant vars that are direct
             -- arguments to the meta, hence, can be abstracted over, may
             -- appear on the rhs.  (test/fail/Issue483b)
@@ -996,9 +996,9 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
               pr _          = ".."
           in vcat
                [ "mvar args:" <+> sep (map (pr . unArg) args)
-               , "fvars lhs (rel):" <+> sep (map (text . show) relVL)
-               , "fvars lhs (nonstrict):" <+> sep (map (text . show) nonstrictVL)
-               , "fvars lhs (irr):" <+> sep (map (text . show) irrVL)
+               , "fvars lhs (relevant)        :" <+> sep (map (text . show) relevantVL)
+               , "fvars lhs (shape-irrelevant):" <+> sep (map (text . show) shapeIrrelevantVL)
+               , "fvars lhs (irrelevant)      :" <+> sep (map (text . show) irrelevantVL)
                ]
 
       -- Check that the x doesn't occur in the right hand side.
@@ -1006,7 +1006,7 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
       -- Herein, distinguish relevant and irrelevant vars,
       -- since when abstracting irrelevant lhs vars, they may only occur
       -- irrelevantly on rhs.
-      -- v <- liftTCM $ occursCheck x (relVL, nonstrictVL, irrVL) v
+      -- v <- liftTCM $ occursCheck x (relevantVL, nonstrictVL, irrelevantVL) v
       v <- liftTCM $ occursCheck x vars v
 
       reportSLn "tc.meta.assign" 15 "passed occursCheck"

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -518,7 +518,7 @@ instance Occurs Term where
             definitionCheck (conName c)
             Con c ci <$> conArgs vs (occurs vs)  -- if strongly rigid, remain so, except with unreduced IApply arguments.
           Pi a b      -> Pi <$> occurs_ a <*> occurs b
-          Sort s      -> Sort <$> do underRelevance NonStrict $ occurs_ s
+          Sort s      -> Sort <$> do underRelevance shapeIrrelevant $ occurs_ s
           MetaV m' es -> do
             m' <- metaCheck m'
             -- The arguments of a meta are in a flexible position

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -510,7 +510,7 @@ instance Occurs Term where
           Lit l       -> return v
           Dummy{}     -> return v
           DontCare v  -> dontCare <$> do
-            onlyReduceTypes $ underRelevance Irrelevant $ occurs v
+            onlyReduceTypes $ underRelevance irrelevant $ occurs v
           Def d es    -> do
             definitionCheck d
             Def d <$> occDef d es
@@ -911,12 +911,11 @@ instance (Subst a, AnyRigid a) => AnyRigid (Abs a) where
 
 instance AnyRigid a => AnyRigid (Arg a) where
   anyRigid f a =
-    case getRelevance a of
       -- Irrelevant arguments are definitionally equal to
       -- values, so the variables there are not considered
       -- "definitely rigid".
-      Irrelevant -> return False
-      _          -> anyRigid f $ unArg a
+    if isIrrelevant a then return False else
+      anyRigid f $ unArg a
 
 instance AnyRigid a => AnyRigid (Dom a) where
   anyRigid f dom = anyRigid f $ unDom dom

--- a/src/full/Agda/TypeChecking/Modalities.hs
+++ b/src/full/Agda/TypeChecking/Modalities.hs
@@ -31,7 +31,7 @@ import Agda.Utils.Monad
 checkRelevance' :: (MonadConversion m) => QName -> Definition -> m (Maybe TypeError)
 checkRelevance' x def = do
   case getRelevance def of
-    Relevant -> return Nothing -- relevance functions can be used in any context.
+    Relevant{} -> return Nothing -- relevance functions can be used in any context.
     drel -> do
       -- Andreas,, 2018-06-09, issue #2170
       -- irrelevant projections are only allowed if --irrelevant-projections

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4291,6 +4291,11 @@ data Warning
     -- ^ If the user wrote just @{-\# REWRITE \#-}@.
   | EmptyWhere
     -- ^ An empty @where@ block is dead code.
+  -- TODO: linearity
+  -- -- | FixingQuantity String Quantity Quantity
+  -- --   -- ^ Auto-correcting quantity pertaining to 'String' /from/ /to/.
+  | FixingRelevance String Relevance Relevance
+    -- ^ Auto-correcting relevance pertaining to 'String' /from/ /to/.
   | IllformedAsClause String
     -- ^ If the user wrote something other than an unqualified name
     --   in the @as@ clause of an @import@ statement.
@@ -4476,6 +4481,9 @@ warningName = \case
   DuplicateRecordDirective{}   -> DuplicateRecordDirective_
   EmptyRewritePragma           -> EmptyRewritePragma_
   EmptyWhere                   -> EmptyWhere_
+  -- TODO: linearity
+  -- FixingQuantity{}             -> FixingQuantity_
+  FixingRelevance{}            -> FixingRelevance_
   IllformedAsClause{}          -> IllformedAsClause_
   WrongInstanceDeclaration{}   -> WrongInstanceDeclaration_
   InstanceWithExplicitArg{}    -> InstanceWithExplicitArg_

--- a/src/full/Agda/TypeChecking/Monad/Modality.hs
+++ b/src/full/Agda/TypeChecking/Monad/Modality.hs
@@ -40,7 +40,7 @@ import Agda.Utils.Monad
 -- | Prepare parts of a parameter telescope for abstraction in constructors
 --   and projections.
 hideAndRelParams :: (LensHiding a, LensRelevance a) => a -> a
-hideAndRelParams = hideOrKeepInstance . mapRelevance nonStrictToIrr
+hideAndRelParams = hideOrKeepInstance . mapRelevance shapeIrrelevantToIrrelevant
 
 -- * Operations on 'Context'.
 
@@ -56,7 +56,7 @@ workOnTypes cont = do
 --   as argument.
 workOnTypes' :: (MonadTCEnv m) => Bool -> m a -> m a
 workOnTypes' experimental
-  = applyWhen experimental (modifyContextInfo $ mapRelevance irrToNonStrict)
+  = applyWhen experimental (modifyContextInfo $ mapRelevance irrelevantToShapeIrrelevant)
   . applyQuantityToJudgement zeroQuantity
   . typeLevelReductions
   . localTC (\ e -> e { envWorkingOnTypes = True })

--- a/src/full/Agda/TypeChecking/Monad/Modality.hs
+++ b/src/full/Agda/TypeChecking/Monad/Modality.hs
@@ -69,10 +69,10 @@ workOnTypes' experimental
 --   Also allow the use of irrelevant definitions.
 applyRelevanceToContext :: (MonadTCEnv tcm, LensRelevance r) => r -> tcm a -> tcm a
 applyRelevanceToContext thing =
-  case getRelevance thing of
-    Relevant -> id
-    rel      -> applyRelevanceToContextOnly   rel
-              . applyRelevanceToJudgementOnly rel
+  applyUnless (isRelevant rel)
+   $ applyRelevanceToContextOnly   rel
+   . applyRelevanceToJudgementOnly rel
+  where rel = getRelevance thing
 
 -- | (Conditionally) wake up irrelevant variables and make them relevant.
 --   For instance,
@@ -98,7 +98,7 @@ applyRelevanceToJudgementOnly = localTC . over eRelevance . composeRelevance
 applyRelevanceToContextFunBody :: (MonadTCM tcm, LensRelevance r) => r -> tcm a -> tcm a
 applyRelevanceToContextFunBody thing cont =
   case getRelevance thing of
-    Relevant -> cont
+    Relevant{} -> cont
     rel -> applyWhenM (optIrrelevantProjections <$> pragmaOptions)
       (applyRelevanceToContextOnly rel) $    -- enable local irr. defs only when option
       applyRelevanceToJudgementOnly rel cont -- enable global irr. defs alway
@@ -198,5 +198,5 @@ applyModalityToContextFunBody thing cont = do
 --   Also set the current quantity to 0.
 wakeIrrelevantVars :: (MonadTCEnv tcm) => tcm a -> tcm a
 wakeIrrelevantVars
-  = applyRelevanceToContextOnly Irrelevant
+  = applyRelevanceToContextOnly irrelevant
   . applyQuantityToJudgement zeroQuantity

--- a/src/full/Agda/TypeChecking/Names.hs
+++ b/src/full/Agda/TypeChecking/Names.hs
@@ -148,7 +148,7 @@ lam n f = glam defaultArgInfo n f
 
 ilam :: Monad m
     => ArgName -> (NamesT m Term -> NamesT m Term) -> NamesT m Term
-ilam n f = glam (setRelevance Irrelevant defaultArgInfo) n f
+ilam n f = glam defaultIrrelevantArgInfo n f
 
 
 -- * Combinators for n-ary binders.

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -180,6 +180,16 @@ prettyWarning = \case
 
     EmptyWhere         -> fsep . pwords $ "Empty `where' block (ignored)"
 
+    -- TODO: linearity
+    -- FixingQuantity s q q' -> fsep $ concat
+    --   [ pwords "Replacing illegal quantity", [ pretty q ], pwords s, [ "by", pretty q' ] ]
+
+    FixingRelevance s r r' ->  fsep $ concat
+      [ pwords "Replacing illegal relevance", [ p r ]
+      , pwords s, [ "by", p r' ]
+      ]
+      where p r = text $ "`" ++ verbalize r ++ "'"
+
     IllformedAsClause s -> fsep . pwords $
       "`as' must be followed by an identifier" ++ s
 

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -213,9 +213,9 @@ instance ToTerm ArgInfo where
           Hidden     -> hid
           Instance{} -> ins
       , case getRelevance i of
-          Relevant   -> rel
-          Irrelevant -> irr
-          NonStrict  -> rel
+          Relevant        {} -> rel
+          Irrelevant      {} -> irr
+          ShapeIrrelevant {} -> rel
       ]
 
 instance ToTerm Fixity' where

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -34,8 +34,8 @@ infixr 4 ..-->
 
 (-->), (.-->), (..-->) :: Applicative m => m Type -> m Type -> m Type
 a --> b = garr id a b
-a .--> b = garr (const $ irrelevant) a b
-a ..--> b = garr (const $ shapeIrrelevant) a b
+a .--> b = garr (const irrelevant) a b
+a ..--> b = garr (const shapeIrrelevant) a b
 
 garr :: Applicative m => (Relevance -> Relevance) -> m Type -> m Type -> m Type
 garr f a b = do
@@ -77,7 +77,7 @@ pPi' n phi b = toFinitePi <$> nPi' n (elSSet $ cl isOne <@> phi) b
 -- function.
 toFinitePi :: Type -> Type
 toFinitePi (El s (Pi d b)) = El s $ Pi
-  (setRelevance Irrelevant $ d { domIsFinite = True })
+  (setRelevance irrelevant d{ domIsFinite = True })
   b
 toFinitePi _ = __IMPOSSIBLE__
 
@@ -116,7 +116,7 @@ gApply' info a b = do
 (<@>),(<#>),(<..>) :: Applicative m => m Term -> m Term -> m Term
 (<@>) = gApply NotHidden
 (<#>) = gApply Hidden
-(<..>) = gApply' (setRelevance Irrelevant defaultArgInfo)
+(<..>) = gApply' defaultIrrelevantArgInfo
 
 (<@@>) :: Applicative m => m Term -> (m Term,m Term,m Term) -> m Term
 t <@@> (x,y,r) = do

--- a/src/full/Agda/TypeChecking/Primitive/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Base.hs
@@ -34,8 +34,8 @@ infixr 4 ..-->
 
 (-->), (.-->), (..-->) :: Applicative m => m Type -> m Type -> m Type
 a --> b = garr id a b
-a .--> b = garr (const $ Irrelevant) a b
-a ..--> b = garr (const $ NonStrict) a b
+a .--> b = garr (const $ irrelevant) a b
+a ..--> b = garr (const $ shapeIrrelevant) a b
 
 garr :: Applicative m => (Relevance -> Relevance) -> m Type -> m Type -> m Type
 garr f a b = do

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -582,7 +582,7 @@ primTransHComp cmd ts nelims = do
     allComponentsBack unview phi u p = do
             let
               boolToI b = if b then unview IOne else unview IZero
-              lamlam t = Lam defaultArgInfo (Abs "i" (Lam (setRelevance Irrelevant defaultArgInfo) (Abs "o" t)))
+              lamlam t = Lam defaultArgInfo (Abs "i" (Lam defaultIrrelevantArgInfo (Abs "o" t)))
             as <- decomposeInterval phi
             (flags,t_alphas) <- fmap unzip . forM as $ \ (bs,ts) -> do
                  let u' = listS bs' `applySubst` u

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
@@ -47,7 +47,7 @@ import Agda.TypeChecking.Reduce (Reduce(..), reduceB', reduce', reduce)
 import Agda.TypeChecking.Names (NamesT, runNamesT, ilam, lam)
 
 import Agda.Syntax.Common
-  (Cubical(..), Arg(..), Relevance(..), setRelevance, defaultArgInfo, hasQuantity0)
+  (Cubical(..), Arg(..), relevant, irrelevant, setRelevance, defaultArgInfo, hasQuantity0)
 
 import Agda.TypeChecking.Primitive.Base
   (SigmaKit(..), (-->), nPi', pPi', (<@>), (<#>), (<..>), argN, getSigmaKit)
@@ -420,10 +420,10 @@ decomposeInterval' t = do
 reduce2Lam :: Term -> ReduceM (Blocked Term)
 reduce2Lam t = do
   t <- reduce' t
-  case lam2Abs Relevant t of
+  case lam2Abs relevant t of
     t -> underAbstraction_ t $ \ t -> do
       t <- reduce' t
-      case lam2Abs Irrelevant t of
+      case lam2Abs irrelevant t of
         t -> underAbstraction_ t reduceB'
   where
     lam2Abs rel (Lam _ t) = absBody t <$ t

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Glue.hs
@@ -27,8 +27,7 @@ import Agda.TypeChecking.Substitute
 import Agda.Syntax.Common
   ( Cubical(..), Arg(..)
   , ConOrigin(..), ProjOrigin(..)
-  , Relevance(..)
-  , setRelevance
+  , irrelevant, setRelevance
   )
 import Agda.Syntax.Internal
 
@@ -362,7 +361,7 @@ prim_unglue' = do
         -- and we must produce @unglue b : A [ i1 → e b ]@. But that's
         -- just @e b@!
         IOne -> do
-          let argOne = setRelevance Irrelevant $ argN one
+          let argOne = setRelevance irrelevant $ argN one
           tEFun <- getTerm (getBuiltinId builtin_unglue) builtinEquivFun
           redReturn $ tEFun `apply` [lb,la,argH $ unArg bT `apply` [argOne],bA, argN $ unArg e `apply` [argOne],b]
 

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -129,9 +129,10 @@ quotingKit = do
       quoteHiding NotHidden  = pure visible
 
       quoteRelevance :: Relevance -> ReduceM Term
-      quoteRelevance Relevant   = pure relevant
-      quoteRelevance Irrelevant = pure irrelevant
-      quoteRelevance NonStrict  = pure relevant
+      quoteRelevance = \case
+        Relevant        {} -> pure relevant
+        Irrelevant      {} -> pure irrelevant
+        ShapeIrrelevant {} -> pure relevant
 
       quoteQuantity :: Quantity -> ReduceM Term
       quoteQuantity (Quantity0 _) = pure quantity0

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -821,7 +821,7 @@ etaContractRecord r c ci args = if all (not . usableModality) args then fallBack
   -- @a@ is the constructor argument, @ax@ the corr. record field name
     -- skip irrelevant record fields by returning DontCare
     case (getRelevance a, hasElims $ unArg a) of
-      (Irrelevant, _)   -> Just Nothing
+      (Irrelevant{}, _)   -> Just Nothing
       -- if @a@ is the record field name applied to a single argument
       -- then it passes the check
       (_, Just (_, [])) -> Nothing  -- not a projection

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -485,9 +485,9 @@ instance Reduce t => Reduce (Maybe t) where
 
 instance Reduce t => Reduce (Arg t) where
     reduce' a = case getRelevance a of
-      Irrelevant -> return a             -- Don't reduce' irr. args!?
-                                         -- Andreas, 2018-03-03, caused #2989.
-      _          -> traverse reduce' a
+      Irrelevant{} -> return a             -- Don't reduce' irr. args!?
+                                           -- Andreas, 2018-03-03, caused #2989.
+      _ -> traverse reduce' a
 
     reduceB' t = traverse id <$> traverse reduceB' t
 

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -275,7 +275,7 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
 
         ps <- fromRightM failureBlocked $ lift $
           catchPatternErr (pure . Left) $
-            Right <$> patternFrom Relevant 0 (t , Def f) es
+            Right <$> patternFrom relevant 0 (t , Def f) es
 
         reportSDoc "rewriting" 30 $
           "Pattern generated from lhs: " <+> prettyTCM (PDef f ps)

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -55,6 +55,7 @@ import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Primitive.Cubical.Base
 
 import Agda.Utils.Either
+import Agda.Utils.Function (applyWhen)
 import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List
@@ -266,7 +267,7 @@ instance Match NLPat Term where
     etaRecord <- addContext k $ isEtaRecordType t
     pview <- pathViewAsPi'whnf
     prop <- fromRight __IMPOSSIBLE__ <.> runBlocked . addContext k $ isPropM t
-    let r = if prop then Irrelevant else r0
+    let r = if prop then irrelevant else r0
     traceSDoc "rewriting.match" 30 (sep
       [ "matching pattern " <+> prettyPat
       , "  with term      " <+> prettyTerm
@@ -279,7 +280,7 @@ instance Match NLPat Term where
       [ "pattern vars:   " <+> prettyTCM gamma
       , "bound vars:     " <+> prettyTCM k ]) $ do
     let yes = return ()
-        no msg = if r == Irrelevant then yes else do
+        no msg = if isIrrelevant r then yes else do
           traceSDoc "rewriting.match" 10 (sep
             [ "mismatch between" <+> prettyPat
             , " and " <+> prettyTerm
@@ -288,7 +289,7 @@ instance Match NLPat Term where
           traceSDoc "rewriting.match" 30 (sep
             [ "blocking tag from reduction: " <+> text (show b) ]) $ do
           matchingBlocked b
-        block b' = if r == Irrelevant then yes else do
+        block b' = if isIrrelevant r then yes else do
           traceSDoc "rewriting.match" 10 (sep
             [ "matching blocked on meta"
             , text (show b') ]) $ do
@@ -404,10 +405,7 @@ makeSubstitution :: Telescope -> Sub -> Maybe Substitution
 makeSubstitution gamma sub =
   parallelS <$> traverse val [0 .. size gamma-1]
     where
-      val i = case IntMap.lookup i sub of
-                Just (Irrelevant, v) -> Just $ dontCare v
-                Just (_         , v) -> Just v
-                Nothing              -> Nothing
+      val i = IntMap.lookup i sub <&> \ (rel, v) -> applyWhen (isIrrelevant rel) dontCare v
 
 {-# SPECIALIZE checkPostponedEquations :: Substitution -> PostponedEquations -> TCM (Maybe Blocked_) #-}
 checkPostponedEquations :: PureTCM m
@@ -427,7 +425,7 @@ nonLinMatch gamma t p v = do
   let no msg b = traceSDoc "rewriting.match" 10 (sep
                    [ "matching failed during" <+> text msg
                    , "blocking: " <+> text (show b) ]) $ return (Left b)
-  caseEitherM (runNLM $ match Relevant gamma empty t p v) (no "matching") $ \ s -> do
+  caseEitherM (runNLM $ match relevant gamma empty t p v) (no "matching") $ \ s -> do
     let msub = makeSubstitution gamma $ s ^. nlmSub
         eqs = s ^. nlmEqs
     traceSDoc "rewriting.match" 90 (text $ "msub = " ++ show msub) $ case msub of

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -123,7 +123,7 @@ instance PatternFrom Term NLPat where
     t <- abortIfBlocked t
     etaRecord <- isEtaRecordType t
     prop <- isPropM t
-    let r = if prop then Irrelevant else r0
+    let r = if prop then irrelevant else r0
     v <- unLevel =<< abortIfBlocked v
     reportSDoc "rewriting.build" 60 $ sep
       [ "building a pattern from term v = " <+> prettyTCM v

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1728,7 +1728,6 @@ check_glue c rs vs _ = do
   case vs of
    -- WAS: [la, lb, bA, phi, bT, e, t, a] -> do
    la : lb : bA : phi : bT : e : t : a : rest -> do
-      let iinfo = setRelevance Irrelevant defaultArgInfo
       v <- runNamesT [] $ do
             lb  <- open . unArg $ lb
             la  <- open . unArg $ la
@@ -1738,13 +1737,13 @@ check_glue c rs vs _ = do
             e   <- open . unArg $ e
             t   <- open . unArg $ t
             let f o = cl primEquivFun <#> lb <#> la <#> (bT <..> o) <#> bA <@> (e <..> o)
-            glam iinfo "o" $ \ o -> f o <@> (t <..> o)
+            glam defaultIrrelevantArgInfo "o" $ \ o -> f o <@> (t <..> o)
       ty <- runNamesT [] $ do
             lb  <- open . unArg $ lb
             phi <- open . unArg $ phi
             bA  <- open . unArg $ bA
-            el's lb $ cl primPartialP <#> lb <@> phi <@> glam iinfo "o" (\ _ -> bA)
-      let a' = Lam iinfo (NoAbs "o" $ unArg a)
+            el's lb $ cl primPartialP <#> lb <@> phi <@> glam defaultIrrelevantArgInfo "o" (\ _ -> bA)
+      let a' = Lam defaultIrrelevantArgInfo (NoAbs "o" $ unArg a)
       ta <- el' (pure $ unArg la) (pure $ unArg bA)
       a <- blockArg ta (rs !!! 7) a $ equalTerm ty a' v
       return $ la : lb : bA : phi : bT : e : t : a : rest
@@ -1762,7 +1761,6 @@ check_glueU c rs vs _ = do
   case vs of
    -- WAS: [la, lb, bA, phi, bT, e, t, a] -> do
    la : phi : bT : bA : t : a : rest -> do
-      let iinfo = setRelevance Irrelevant defaultArgInfo
       v <- runNamesT [] $ do
             la  <- open . unArg $ la
             phi <- open . unArg $ phi
@@ -1770,13 +1768,13 @@ check_glueU c rs vs _ = do
             bA  <- open . unArg $ bA
             t   <- open . unArg $ t
             let f o = cl primTrans <#> lam "i" (const la) <@> lam "i" (\ i -> bT <@> (cl primINeg <@> i) <..> o) <@> cl primIZero
-            glam iinfo "o" $ \ o -> f o <@> (t <..> o)
+            glam defaultIrrelevantArgInfo "o" $ \ o -> f o <@> (t <..> o)
       ty <- runNamesT [] $ do
             la  <- open . unArg $ la
             phi <- open . unArg $ phi
             bT  <- open . unArg $ bT
             pPi' "o" phi $ \ o -> el' la (bT <@> cl primIZero <..> o)
-      let a' = Lam iinfo (NoAbs "o" $ unArg a)
+      let a' = Lam defaultIrrelevantArgInfo (NoAbs "o" $ unArg a)
       ta <- runNamesT [] $ do
             la  <- open . unArg $ la
             phi <- open . unArg $ phi

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -1478,7 +1478,7 @@ inferLeveledSort u q suffix = \case
     unless (visible arg) $ typeError $ WrongHidingInApplication $ sort $ Univ u $ ClosedLevel 0
     unlessM hasUniversePolymorphism $ typeError NeedOptionUniversePolymorphism
     List1.unlessNull args $ warning . TooManyArgumentsToSort q
-    l <- applyRelevanceToContext NonStrict $ checkLevel arg
+    l <- applyRelevanceToContext shapeIrrelevant $ checkLevel arg
     return (Sort $ Univ u l , sort (Univ (univUniv u) $ levelSuc l))
 
 inferUnivOmega ::

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -62,11 +62,11 @@ import Agda.Utils.Impossible
 ---------------------------------------------------------------------------
 
 builtinPostulate :: TCM Type -> BuiltinDescriptor
-builtinPostulate = BuiltinPostulate Relevant
+builtinPostulate = BuiltinPostulate relevant
 
 builtinPostulateC :: Cubical -> TCM Type -> BuiltinDescriptor
 builtinPostulateC c m =
-  BuiltinPostulate Relevant $ requireCubical c >> m
+  builtinPostulate $ requireCubical c >> m
 
 findBuiltinInfo :: BuiltinId -> Maybe BuiltinInfo
 findBuiltinInfo b = find ((b ==) . builtinName) coreBuiltins
@@ -159,7 +159,7 @@ coreBuiltins =
                                                                    hPi' "A" (pPi' "o" (cl primIZero) $ \ _ ->
                                                                                   el' (cl primLevelSuc <@> l) (Sort . tmSort <$> l)) $ \ bA ->
                                                                    pPi' "o" (cl primIZero) (\ o ->
-                                                                        el' l $ gApply' (setRelevance Irrelevant defaultArgInfo) bA o)))
+                                                                        el' l $ gApply' defaultIrrelevantArgInfo bA o)))
 
   , (builtinId                               |-> BuiltinData ((>>) (requireCubical CErased) $ hPi "a" (el primLevel) $
                                                               hPi "A" (return $ sort $ varSort 0) $

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1150,7 +1150,7 @@ defineConClause trD' isHIT mtrX npars nixs xTel' telI sigma dT' cnames = do
               bs <- bndry `applyN` ts
               xs <- mapM (\(phi,u) -> (,) <$> open phi <*> open u) $ do
                 (i,(l,r)) <- bs
-                let pElem t = Lam (setRelevance Irrelevant defaultArgInfo) $ NoAbs "o" t
+                let pElem t = Lam defaultIrrelevantArgInfo $ NoAbs "o" t
                 [(tINeg `apply` [argN i],pElem l),(i,pElem r)]
               combineSys' l ty xs
             (,) <$> open (fst <$> p) <*> open (snd <$> p)

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -62,6 +62,7 @@ import Agda.TypeChecking.Rules.Term
 import Agda.TypeChecking.Rules.LHS                 ( checkLeftHandSide, LHSResult(..), bindAsPatterns )
 import {-# SOURCE #-} Agda.TypeChecking.Rules.Decl ( checkDecls )
 
+import Agda.Utils.Function ( applyWhen )
 import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List
@@ -186,9 +187,7 @@ checkAlias t ai i name e mc =
     -- (test/succeed/Issue655.agda)
 
   -- compute body modification for irrelevant definitions, see issue 610
-  let bodyMod = case getRelevance ai of
-        Irrelevant -> dontCare
-        _          -> id
+  let bodyMod = applyWhen (isIrrelevant ai) dontCare
 
   -- Add the definition
   fun <- emptyFunctionData
@@ -775,9 +774,7 @@ checkClause t withSubAndLets c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats r
 
         -- compute body modification for irrelevant definitions, see issue 610
         rel <- viewTC eRelevance
-        let bodyMod body = case rel of
-              Irrelevant -> dontCare <$> body
-              _          -> body
+        let bodyMod = applyWhen (isIrrelevant rel) (fmap dontCare)
 
         -- absurd clauses don't define computational behaviour, so it's fine to
         -- treat them as catchalls.

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -849,7 +849,7 @@ solutionStep retry s
   let eqrel  = getRelevance dom
       eqmod  = getModality dom
       varmod = getModality dom'
-      mod    = applyUnless (NonStrict `moreRelevant` eqrel) (setRelevance eqrel)
+      mod    = applyUnless (shapeIrrelevant `moreRelevant` eqrel) (setRelevance eqrel)
              $ applyUnless (usableQuantity envmod) (setQuantity zeroQuantity)
              $ varmod
   reportSDoc "tc.lhs.unify" 65 $ text $ "Equation modality: " ++ show (getModality dom)

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -194,13 +194,13 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
 
           -- A record is irrelevant if all of its fields are.
           -- In this case, the associated module parameter will be irrelevant.
-          -- See issue 392.
+          -- See issue #392.
           -- Unless it's been declared coinductive or no-eta-equality (#2607).
           recordRelevance
-            | Just NoEta{} <- eta         = Relevant
-            | CoInductive <- conInduction = Relevant
-            | null (telToList ftel)       = Relevant    -- #6270: eta unit types don't need to be irrelevant
-            | otherwise                   = minimum $ Irrelevant : map getRelevance (telToList ftel)
+            | Just NoEta{} <- eta         = relevant
+            | CoInductive <- conInduction = relevant
+            | null (telToList ftel)       = relevant    -- #6270: eta unit types don't need to be irrelevant
+            | otherwise                   = minimum $ irrelevant : map getRelevance (telToList ftel)
 
       -- Andreas, 2017-01-26, issue #2436
       -- Disallow coinductive records with eta-equality
@@ -502,7 +502,7 @@ defineKanOperationR cmd name params fsT fns rect = do
                   -- Γ = Δ, CompRArgs
                   -- pats = ... | phi = i1
                   -- body = u i1 itIsOne
-                  DoHComp  -> (2,Var 1 [] `apply` [argN io, setRelevance Irrelevant $ argN one])
+                  DoHComp  -> (2,Var 1 [] `apply` [argN io, setRelevance irrelevant $ argN one])
 
               p = ConP (ConHead io_name IsData Inductive [])
                        (noConPatternInfo { conPType = Just (Arg defaultArgInfo tInterval)

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -702,10 +702,7 @@ checkRecordProjections m r hasNamedCon con tel ftel fs = do
         -- 2012-04-02: DontCare instead of irrAxiom
 
         -- compute body modification for irrelevant projections
-        let bodyMod = case rel of
-              Relevant   -> id
-              NonStrict  -> id
-              Irrelevant -> dontCare
+        let bodyMod = applyWhen (isIrrelevant rel) dontCare
 
         let -- Andreas, 2010-09-09: comment for existing code
             -- split the telescope into parameters (ptel) and the type or the record

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -151,9 +151,9 @@ isType_ e = traceCall (IsType_ e) $ do
         Just (USmall, u) <- isNameOfUniv x -> do
       univChecks u
       unlessM hasUniversePolymorphism $ typeError NeedOptionUniversePolymorphism
-      -- allow NonStrict variables when checking level
-      --   Set : (NonStrict) Level -> Set\omega
-      applyRelevanceToContext NonStrict $
+      -- allow ShapeIrrelevant variables when checking level
+      --   Set : (ShapeIrrelevant) Level -> Set\omega
+      applyRelevanceToContext shapeIrrelevant $
         sort . Univ u <$> checkLevel arg
 
     -- Issue #707: Check an existing interaction point
@@ -361,7 +361,7 @@ checkTypedBindings lamOrPi (A.TBind r tac xps e) ret = do
         -- modify the new context entries
         modEnv LamNotPi = workOnTypes
         modEnv _        = id
-        modMod PiNotLam xp = applyWhen xp $ mapRelevance irrToNonStrict
+        modMod PiNotLam xp = applyWhen xp $ mapRelevance irrelevantToShapeIrrelevant
         modMod _        _  = id
 
 checkTypedBindings lamOrPi (A.TLet _ lbs) ret = do

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -604,15 +604,55 @@ instance EmbPrj Modality where
     [a, b, c] -> valuN Modality a b c
     _ -> malformed
 
-instance EmbPrj Relevance where
-  icod_ Relevant        = return 0
-  icod_ Irrelevant      = return 1
-  icod_ ShapeIrrelevant = return 2
+instance EmbPrj OriginRelevant where
+  icod_ = \case
+    ORelInferred   -> return 0
+    ORelRelevant _ -> return 1
 
-  value 0 = return Relevant
-  value 1 = return Irrelevant
-  value 2 = return ShapeIrrelevant
-  value _ = malformed
+  value = \case
+    0 -> return $ ORelInferred
+    1 -> return $ ORelRelevant noRange
+    _ -> malformed
+
+instance EmbPrj OriginIrrelevant where
+  icod_ = \case
+    OIrrInferred     -> return 0
+    OIrrDot _        -> return 1
+    OIrrIrr _        -> return 2
+    OIrrIrrelevant _ -> return 3
+
+  value = \case
+    0 -> return $ OIrrInferred
+    1 -> return $ OIrrDot        noRange
+    2 -> return $ OIrrIrr        noRange
+    3 -> return $ OIrrIrrelevant noRange
+    _ -> malformed
+
+instance EmbPrj OriginShapeIrrelevant where
+  icod_ = \case
+    OShIrrInferred          -> return 0
+    OShIrrDotDot _          -> return 1
+    OShIrrShIrr _           -> return 2
+    OShIrrShapeIrrelevant _ -> return 3
+
+  value = \case
+    0 -> return $ OShIrrInferred
+    1 -> return $ OShIrrDotDot          noRange
+    2 -> return $ OShIrrShIrr           noRange
+    3 -> return $ OShIrrShapeIrrelevant noRange
+    _ -> malformed
+
+instance EmbPrj Relevance where
+  icod_ = \case
+    Relevant   a      -> icodeN' Relevant a
+    Irrelevant a      -> icodeN 0 Irrelevant a
+    ShapeIrrelevant a -> icodeN 1 ShapeIrrelevant a
+
+  value = vcase \case
+    [a]    -> valuN Relevant a
+    [0, a] -> valuN Irrelevant a
+    [1, a] -> valuN ShapeIrrelevant a
+    _      -> malformed
 
 instance EmbPrj Annotation where
   icod_ (Annotation l) = icodeN' Annotation l

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -605,13 +605,13 @@ instance EmbPrj Modality where
     _ -> malformed
 
 instance EmbPrj Relevance where
-  icod_ Relevant       = return 0
-  icod_ Irrelevant     = return 1
-  icod_ NonStrict      = return 2
+  icod_ Relevant        = return 0
+  icod_ Irrelevant      = return 1
+  icod_ ShapeIrrelevant = return 2
 
   value 0 = return Relevant
   value 1 = return Irrelevant
-  value 2 = return NonStrict
+  value 2 = return ShapeIrrelevant
   value _ = malformed
 
 instance EmbPrj Annotation where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -127,6 +127,9 @@ instance EmbPrj Warning where
       icodeN 65 PragmaExpectsUnambiguousProjectionOrFunction a b c
     PragmaExpectsDefinedSymbol a b              -> icodeN 66 PragmaExpectsDefinedSymbol a b
     UnfoldingWrongName a                        -> icodeN 67 UnfoldingWrongName a
+    -- TODO: linearity
+    -- FixingQuantity a b c                        -> icodeN 68 FixingQuantity a b c
+    FixingRelevance a b c                       -> icodeN 69 FixingRelevance a b c
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -197,6 +200,9 @@ instance EmbPrj Warning where
     [65, a, b, c]        -> valuN PragmaExpectsUnambiguousProjectionOrFunction a b c
     [66, a, b]           -> valuN PragmaExpectsDefinedSymbol a b
     [67, a]              -> valuN UnfoldingWrongName a
+    -- TODO: linearity
+    -- [68, a, b, c]        -> valuN FixingQuantity a b c
+    [69, a, b, c]        -> valuN FixingRelevance a b c
     _ -> malformed
 
 instance EmbPrj IllegalRewriteRuleReason where

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -49,6 +49,7 @@ import Agda.TypeChecking.Substitute.DeBruijn
 
 import Agda.Utils.Either
 import Agda.Utils.Empty
+import Agda.Utils.Function (applyWhen)
 import Agda.Utils.Functor
 import Agda.Utils.List
 import Agda.Utils.List1 (List1, pattern (:|))
@@ -187,9 +188,7 @@ argToDontCare :: Arg Term -> Term
 argToDontCare (Arg ai v) = relToDontCare ai v
 
 relToDontCare :: LensRelevance a => a -> Term -> Term
-relToDontCare ai v
-  | Irrelevant <- getRelevance ai = dontCare v
-  | otherwise                     = v
+relToDontCare ai = applyWhen (isIrrelevant ai) dontCare
 
 -- Andreas, 2016-01-19: In connection with debugging issue #1783,
 -- I consider the Apply instance for Type harmful, as piApply is not

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -378,8 +378,8 @@ instance Unquote Relevance where
     case t of
       Con c _ [] ->
         choice
-          [(c `isCon` getBuiltin' builtinRelevant,   return Relevant)
-          ,(c `isCon` getBuiltin' builtinIrrelevant, return Irrelevant)]
+          [(c `isCon` getBuiltin' builtinRelevant,   return relevant)
+          ,(c `isCon` getBuiltin' builtinIrrelevant, return irrelevant)]
           __IMPOSSIBLE__
       Con c _ vs -> __IMPOSSIBLE__
       _        -> throwError $ NonCanonical "relevance" t

--- a/test/Fail/IrrelevantConstructor.agda
+++ b/test/Fail/IrrelevantConstructor.agda
@@ -1,6 +1,0 @@
--- Andreas, 2016-02-11. Irrelevant constructors are not (yet?) supported
-
-data D : Set where
-  .c : D
-
--- Should fail, e.g., with parse error.

--- a/test/Fail/IrrelevantConstructor.err
+++ b/test/Fail/IrrelevantConstructor.err
@@ -1,3 +1,0 @@
-IrrelevantConstructor.agda:4,4-9: error: [GenericError]
-Irrelevant constructors are not supported
-when checking the constructor c in the declaration of D

--- a/test/Fail/Issue4390irrelevance.agda
+++ b/test/Fail/Issue4390irrelevance.agda
@@ -4,8 +4,8 @@ postulate
   A : Set
 
 mutual
-  I : (A -> A) → .A → A
+  I : (A → A) → .A → A
   I f = _
 
-  testQ : {f : .A -> A} → I f ≡ f
+  testQ : {f : .A → A} → I f ≡ f
   testQ = refl

--- a/test/Fail/Issue4390irrelevance.err
+++ b/test/Fail/Issue4390irrelevance.err
@@ -1,4 +1,4 @@
-Issue4390irrelevance.agda:10,29-30: error: [UnequalRelevance]
+Issue4390irrelevance.agda:10,28-29: error: [UnequalRelevance]
 (.A → A) !=< (A → A) because one is a relevant function type and
 the other is an irrelevant function type
 when checking that the expression f has type A → A

--- a/test/Fail/LinearConstructor.agda
+++ b/test/Fail/LinearConstructor.agda
@@ -1,0 +1,7 @@
+-- Andreas, 2024-08-24, error wrong quantity for constructor
+
+data LinD : Set where
+  @1 c : LinD
+
+-- should fail, e.g. parse error
+-- or trigger warning FixingQuantity

--- a/test/Fail/LinearConstructor.err
+++ b/test/Fail/LinearConstructor.err
@@ -1,0 +1,2 @@
+LinearConstructor.agda:4,4: error: [ParseError]
+Unknown attribute: 1

--- a/test/Fail/Relevance-subtyping-3.agda
+++ b/test/Fail/Relevance-subtyping-3.agda
@@ -1,2 +1,0 @@
-f : {A B : Set} → (A → B) → .A → B
-f g = g

--- a/test/Fail/Relevance-subtyping-3.err
+++ b/test/Fail/Relevance-subtyping-3.err
@@ -1,4 +1,0 @@
-Relevance-subtyping-3.agda:2,7-8: error: [UnequalRelevance]
-A → B !=< .A → B because one is a relevant function type and the
-other is an irrelevant function type
-when checking that the expression g has type .A → B

--- a/test/Fail/ShapeIrrelevantConstructor.err
+++ b/test/Fail/ShapeIrrelevantConstructor.err
@@ -1,3 +1,0 @@
-ShapeIrrelevantConstructor.agda:4,21-38: error: [GenericError]
-Shape-irrelevant constructors are not supported
-when checking the constructor wrap in the declaration of Wrap

--- a/test/Internal/Syntax/Common.hs
+++ b/test/Internal/Syntax/Common.hs
@@ -61,7 +61,12 @@ instance Arbitrary Quantity where
   --   , Quantityω <$> arbitrary
   --   ]
 
-instance CoArbitrary Relevance
+instance CoArbitrary Relevance where
+  coarbitrary = \case
+    Relevant{}        -> variant 0
+    Irrelevant{}      -> variant 1
+    ShapeIrrelevant{} -> variant 2
+
 instance Arbitrary Relevance where
   arbitrary = elements [ relevant, irrelevant, shapeIrrelevant ]
 
@@ -147,10 +152,10 @@ prop_Galois_Relevance_comp :: Prop3 (UnderComposition Relevance)
 prop_Galois_Relevance_comp = isGaloisConnection
 
 prop_left_identity_invcomp_Relevance :: Relevance -> Bool
-prop_left_identity_invcomp_Relevance x = Relevant `inverseComposeRelevance` x == x
+prop_left_identity_invcomp_Relevance x = relevant `inverseComposeRelevance` x == x
 
 prop_right_absorptive_invcomp_Relevance :: Relevance -> Bool
-prop_right_absorptive_invcomp_Relevance x = x `inverseComposeRelevance` Relevant == Relevant
+prop_right_absorptive_invcomp_Relevance x = isRelevant $ x `inverseComposeRelevance` relevant
 
 prop_monoid_Relevance_add :: Property3 (UnderAddition Relevance)
 prop_monoid_Relevance_add = isMonoid

--- a/test/Internal/Syntax/Common.hs
+++ b/test/Internal/Syntax/Common.hs
@@ -63,7 +63,7 @@ instance Arbitrary Quantity where
 
 instance CoArbitrary Relevance
 instance Arbitrary Relevance where
-  arbitrary = elements allRelevances
+  arbitrary = elements [ relevant, irrelevant, shapeIrrelevant ]
 
 instance CoArbitrary Cohesion
 instance Arbitrary Cohesion where

--- a/test/Internal/TypeChecking/Free.hs
+++ b/test/Internal/TypeChecking/Free.hs
@@ -326,16 +326,16 @@ prop_isSemimodule_withVarOcc2_not_a_counterexample =
   where
     occ r = VarOcc StronglyRigid $ Modality r topQuantity topCohesion
     r, s  :: VarOcc
-    r     = occ Irrelevant
-    s     = occ NonStrict
+    r     = occ irrelevant
+    s     = occ shapeIrrelevant
     m     :: VarMap
     m     = VarMap $ Map.fromList [(0, occ Irrelevant)]
   -- LHS:
-  --   r <> s                = min Irrelevant NonStrict = NonStrict
-  --   withVarOcc (r <> s) m = max NonStrict Irrelevant = Irrelevant
+  --   r <> s                = min Irrelevant ShapeIrrelevant = ShapeIrrelevant
+  --   withVarOcc (r <> s) m = max ShapeIrrelevant Irrelevant = Irrelevant
   -- RHS:
   --   withVarOcc r m = max Irrelevant Irrelevant = Irrelevant
-  --   withVarOcc s m = max NonStrict  Irrelevant = Irrelevant
+  --   withVarOcc s m = max ShapeIrrelevant  Irrelevant = Irrelevant
   --   withVarOcc r m <> withVarOcc s m
   --                  = min Irrelevant Irrelevant = Irrelevant
 

--- a/test/Internal/TypeChecking/Free.hs
+++ b/test/Internal/TypeChecking/Free.hs
@@ -329,7 +329,7 @@ prop_isSemimodule_withVarOcc2_not_a_counterexample =
     r     = occ irrelevant
     s     = occ shapeIrrelevant
     m     :: VarMap
-    m     = VarMap $ Map.fromList [(0, occ Irrelevant)]
+    m     = VarMap $ Map.fromList [(0, occ irrelevant)]
   -- LHS:
   --   r <> s                = min Irrelevant ShapeIrrelevant = ShapeIrrelevant
   --   withVarOcc (r <> s) m = max ShapeIrrelevant Irrelevant = Irrelevant

--- a/test/Succeed/IrrelevantConstructor.agda
+++ b/test/Succeed/IrrelevantConstructor.agda
@@ -1,3 +1,10 @@
+-- Andreas, 2016-02-11. Irrelevant constructors are not (yet?) supported
+
+data D : Set where
+  .c : D
+
+-- warning: -W[no]FixingRelevance
+
 -- Andreas, 2018-06-14, issue #2513, surviving shape-irrelevance annotations.
 
 data Wrap (A : Set) : Set where

--- a/test/Succeed/IrrelevantConstructor.warn
+++ b/test/Succeed/IrrelevantConstructor.warn
@@ -1,0 +1,25 @@
+IrrelevantConstructor.agda:4,4-9: warning: -W[no]FixingRelevance
+Replacing illegal relevance 'irrelevant' of constructor by
+'relevant'
+when scope checking the declaration
+  .c : D
+
+IrrelevantConstructor.agda:11,21-38: warning: -W[no]FixingRelevance
+Replacing illegal relevance 'shape-irrelevant' of constructor by
+'relevant'
+when scope checking the declaration
+  ..wrap : A → Wrap A
+
+———— All done; warnings encountered ————————————————————————
+
+IrrelevantConstructor.agda:4,4-9: warning: -W[no]FixingRelevance
+Replacing illegal relevance 'irrelevant' of constructor by
+'relevant'
+when scope checking the declaration
+  .c : D
+
+IrrelevantConstructor.agda:11,21-38: warning: -W[no]FixingRelevance
+Replacing illegal relevance 'shape-irrelevant' of constructor by
+'relevant'
+when scope checking the declaration
+  ..wrap : A → Wrap A

--- a/test/Succeed/IrrelevantConstructor.warn
+++ b/test/Succeed/IrrelevantConstructor.warn
@@ -8,7 +8,7 @@ IrrelevantConstructor.agda:11,21-38: warning: -W[no]FixingRelevance
 Replacing illegal relevance 'shape-irrelevant' of constructor by
 'relevant'
 when scope checking the declaration
-  ..wrap : A → Wrap A
+  @shape-irrelevant wrap : A → Wrap A
 
 ———— All done; warnings encountered ————————————————————————
 
@@ -22,4 +22,4 @@ IrrelevantConstructor.agda:11,21-38: warning: -W[no]FixingRelevance
 Replacing illegal relevance 'shape-irrelevant' of constructor by
 'relevant'
 when scope checking the declaration
-  ..wrap : A → Wrap A
+  @shape-irrelevant wrap : A → Wrap A

--- a/test/Succeed/ShapeIrrelevantField.agda
+++ b/test/Succeed/ShapeIrrelevantField.agda
@@ -1,18 +1,18 @@
 {-# OPTIONS --experimental-irrelevance #-}
 
-record NonStrict (A : Set) : Set where
+record ShapeIrrelevant (A : Set) : Set where
   constructor [_]
   field
     ..! : A
 
-open NonStrict
+open ShapeIrrelevant
 
-map-ns : {A B : Set} (f : A → B) → NonStrict A → NonStrict B
+map-ns : {A B : Set} (f : A → B) → ShapeIrrelevant A → ShapeIrrelevant B
 map-ns f [ x ] = [ f x ]
 
 open import Agda.Builtin.Nat
 
-data Vec (A : Set) : NonStrict Nat → Set where
+data Vec (A : Set) : ShapeIrrelevant Nat → Set where
   []  : Vec A [ 0 ]
   _∷_ : .{n : Nat} → A → Vec A [ n ] → Vec A [ suc n ]
 

--- a/test/doc/user-manual-covers-warnings.sh
+++ b/test/doc/user-manual-covers-warnings.sh
@@ -10,10 +10,20 @@ DOC=doc/user-manual/tools/command-line-options.rst
 # To use the 'comm' tool to this end, we need to store those in intermediate files.
 TMPDIR=$(mktemp -d)
 DOCWARNS=$TMPDIR/documented-warnings.txt
+COVEREDWARNS=$TMPDIR/covered-warnings.txt
+IGNOREDWARNS=$TMPDIR/ignored-warnings.txt
 HELPWARNS=$TMPDIR/help-text-warnings.txt
 
-# Documented warnings
+# Documented warnings.
 sed -nr 's/^.. option:: ([A-Z][A-Za-z]*)/\1/p' $DOC | sort > $DOCWARNS
+
+# Ignored warnings (e.g. future warnings, not yet triggered).
+cat > $IGNOREDWARNS <<EOF
+FixingQuantity
+EOF
+
+# Covered warnigns
+cat $DOCWARNS $IGNOREDWARNS | sort | uniq > $COVEREDWARNS
 
 # Existing warnings.
 # Those are printed by `agda --help=warning` at line beginnings and follow
@@ -22,18 +32,18 @@ $AGDA_BIN --help=warning | sed -nr 's/^([A-Z][a-z]+[A-Z][A-Za-z]+).*/\1/p' | sor
 
 # Warnings that are documented but don't exist any longer.
 REMOVED=$(comm -23 $DOCWARNS $HELPWARNS)
-  ## -23 means only column 1 of output (additions in $DOCWARNS), not 2 and 3.
+  ## -23 means only column 1 of output (additions in $COVEREDWARNS), not 2 and 3.
 
 # Warn about non-existing warnings.
 if [ "x$REMOVED" != "x" ]; then
-  echo "Warning: The following warnings have been removed from Agda but are still documentation in $DOC:"
+  echo "Warning: The following warnings have been removed from Agda but are still documented in $DOC:"
   for i in $REMOVED; do
     echo "- $i"
   done
 fi
 
 # Warnings that exist but are undocumented.
-UNDOCUMENTED=$(comm -13 $DOCWARNS $HELPWARNS)
+UNDOCUMENTED=$(comm -13 $COVEREDWARNS $HELPWARNS)
   ## -13 means only column 2 of output (additions in $HELPWARNS), not 1 and 3.
 
 # Print undocumented warnings and error out if we have one.

--- a/test/test-suite-covers-warnings.sh
+++ b/test/test-suite-covers-warnings.sh
@@ -28,6 +28,11 @@ DuplicateInterfaceFiles
 LibUnknownField
 EOF
 
+# Warnings we ignore (e.g. that are still impossible).
+#
+cat >> $BENIGNWARNS <<EOF
+EOF
+
 # Warnings we currently do not cover by the testsuite (TODO!).
 #
 cat >> $BENIGNWARNS <<EOF


### PR DESCRIPTION
A relevance annotation on a constructor declaration can be ignored.
To give proper `Range` and dead code highlighting to the new warning `FixingRelevance`, I equip `Relevance` with origin information just as `Quantity` already has.

Commits:
- New warning `FixingRelevance` instead of `GenericError`
- Refactor: remove instance `Enum`, `Bounded` for `Relevance`
- Refactor: hand-implement `Eq Relevance` via `sameRelevance`
- Refactor: rename `NonStrict` to `ShapeIrrelevant`
- Add origin information to `Relevance`
- Remove testcase subsumed by `test/Fail/UnequalRelevance`
