### PR TITLE
Actually, --exact-split is not really on by default

### DIFF
--- a/doc/release-notes/2.7.0.md
+++ b/doc/release-notes/2.7.0.md
@@ -12,7 +12,7 @@ Highlights
   Additionally, users can now control how instances should be selected
   in the case multiple candidates exist.
 
-* User-facing options `--exact-split`, `--keep-pattern-variables`, and `--postfix-projections`
+* User-facing options ~~`--exact-split`,~~ `--keep-pattern-variables`, and `--postfix-projections`
   are now on by default.
 
 Installation
@@ -43,7 +43,7 @@ Pragmas and options
 
 * These options are now on by default:
 
-  * `--exact-split`: Warn about clauses that are not definitional equalities.
+  * ~~`--exact-split`: Warn about clauses that are not definitional equalities.~~
   * `--keep-pattern-variables`: Do not introduce dot patterns in interactive splitting.
   * `--postfix-projections`: Print projections and projection patterns in postfix.
   * `--save-metas`: Try to not unfold metavariable solutions in interface files.

--- a/doc/user-manual/language/function-definitions.lagda.rst
+++ b/doc/user-manual/language/function-definitions.lagda.rst
@@ -267,4 +267,5 @@ be marked as such, for instance: ::
 
 The :option:`--no-exact-split` flag can be used to override a global
 :option:`--exact-split` in a file, by adding a pragma
-``{-# OPTIONS --no-exact-split #-}``.
+``{-# OPTIONS --no-exact-split #-}``. This option is enabled by
+default.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -750,7 +750,7 @@ Pattern matching and equality
      definitional equalities unless marked ``CATCHALL`` (see
      :ref:`case-trees`).
 
-     Default since 2.7.0: ``--exact-split``.
+     Default: ``--no-exact-split``.
 
 .. option:: --hidden-argument-puns, --no-hidden-argument-puns
 

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -349,7 +349,7 @@ data PragmaOptions = PragmaOptions
       -- ^ Allow definitions by copattern matching?
   , _optPatternMatching           :: WithDefault 'True
       -- ^ Is pattern matching allowed in the current file?
-  , _optExactSplit                :: WithDefault 'True
+  , _optExactSplit                :: WithDefault 'False
   , _optHiddenArgumentPuns        :: WithDefault 'False
       -- ^ Should patterns of the form @{x}@ or @⦃ x ⦄@ be interpreted as puns?
   , _optEta                       :: WithDefault 'True


### PR DESCRIPTION
Partially reverts "Turn on --exact-split by default", commit af86c20d15614342e5a3b15009490ecd42269199.

Closes #7443 
- #7443