### PR TITLE
Revert default to `--no-save-metas`

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1144,7 +1144,7 @@ Other features
      actually saved, and this option is more like an anticipation of possible
      future optimizations.
 
-     Default: :option:`--save-metas`.
+     Default: :option:`--no-save-metas`.
 
 Erasure
 ~~~~~~~

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -426,7 +426,7 @@ data PragmaOptions = PragmaOptions
       --   This is a stronger form of 'optImportSorts'.
   , _optAllowExec                 :: WithDefault 'False
       -- ^ Allow running external @executables@ from meta programs.
-  , _optSaveMetas                 :: WithDefault 'True
+  , _optSaveMetas                 :: WithDefault 'False
       -- ^ Save meta-variables to interface files.
   , _optShowIdentitySubstitutions :: WithDefault 'False
       -- ^ Show identity substitutions when pretty-printing terms


### PR DESCRIPTION
Agda 2.7.0 defaulted to `--save-metas` which caused performance regression #7452:
- #7452

Thus, we revert to `--no-save-metas` as default.
Closes #7452.
