### PR TITLE
Require ETA pragma instead of eta-equality directive in unguarded records

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -453,8 +453,8 @@ library
     , text                 >= 1.2.3.1   && < 2.2
     , time                 >= 1.9.2     && < 1.15
     , transformers         >= 0.5.5.0   && < 0.7
-    , unordered-containers >= 0.2.9.0   && < 0.3
-        -- unordered-containers < 0.2.9 need base < 4.11
+    , unordered-containers >= 0.2.10.0  && < 0.3
+        -- unordered-containers >= 0.2.10 needed for HashMap.alterF
     , uri-encode           >= 1.5.0.4   && < 1.6
     , vector               >= 0.12      && < 0.14
     , vector-hashtables    >= 0.1.1.1   && < 0.2

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1808,6 +1808,10 @@ Such *error warnings* are always on, they cannot be toggled by :option:`-W`.
 
      Failed termination checks.
 
+.. option:: UnguardedEtaRecord
+
+     Declaring ``eta-equality`` for a recursive ``record`` type that fails the guardedness check.
+
 .. option:: UnsolvedConstraints
 
      Unsolved constraints.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -413,7 +413,7 @@ warningHighlighting' b w = case tcWarning w of
   TerminationIssue terrs     -> terminationErrorHighlighting terrs
   NotStrictlyPositive d ocs  -> positivityErrorHighlighting d ocs
   ConstructorDoesNotFitInData c s1 s2 err -> errorWarningHighlighting c
-  CoinductiveEtaRecord _x    -> deadcodeHighlighting w
+  IllicitEtaRecord _ _x      -> deadcodeHighlighting w
   -- #3965 highlight each unreachable clause independently: they
   -- may be interleaved with actually reachable clauses!
   UnreachableClauses _ rs    -> foldMap deadcodeHighlighting rs

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -282,6 +282,7 @@ data WarningName
   | NotStrictlyPositive_
   | ConstructorDoesNotFitInData_
   | CoinductiveEtaRecord_
+  | UnguardedEtaRecord_
   | UnsupportedIndexedMatch_
   | OldBuiltin_
   | BuiltinDeclaresIdentifier_
@@ -509,6 +510,7 @@ warningNameDescription = \case
   NotStrictlyPositive_             -> "Failed strict positivity checks."
   ConstructorDoesNotFitInData_     -> "Failed constructor size checks."
   CoinductiveEtaRecord_            -> "Record type declared as both coinductive and having eta-equality."
+  UnguardedEtaRecord_              -> "Unguarded recursive record type declared with eta-equality."
   UnsupportedIndexedMatch_         -> "Failures to compute full equivalence when splitting on indexed family."
   OldBuiltin_                      -> "Deprecated `BUILTIN' pragmas."
   BuiltinDeclaresIdentifier_       -> "`BUILTIN' pragmas that declare a new identifier but have been given an existing one."

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -40,9 +40,10 @@ import Agda.TypeChecking.Positivity.Occurrence
 import Agda.TypeChecking.CompiledClause
 
 import qualified Agda.Utils.BiMap as BiMap
+import Agda.Utils.Functor ( (<.>) )
 import Agda.Utils.Lens
 import qualified Agda.Utils.List1 as List1
-import Agda.Utils.Monad (bracket_)
+import Agda.Utils.Monad   ( bracket_ )
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.Tuple
 
@@ -305,6 +306,9 @@ lookupDefinition q sig = HMap.lookup q $ sig ^. sigDefinitions
 
 updateDefinitions :: (Definitions -> Definitions) -> Signature -> Signature
 updateDefinitions = over sigDefinitions
+
+lensDefinition :: QName -> Lens' Definitions Definition
+lensDefinition q f = HMap.alterF (maybe __IMPOSSIBLE__ (Just <.> f)) q
 
 updateDefinition :: QName -> (Definition -> Definition) -> Signature -> Signature
 updateDefinition q f = updateDefinitions $ HMap.adjust f q

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -36,6 +36,7 @@ import {-# SOURCE #-} Agda.TypeChecking.MetaVars
 
 import Agda.Syntax.Common
   ( ImportedName'(..), fromImportedName, partitionImportedNames
+  , pattern Inductive, pattern CoInductive
   , IsOpaque(OpaqueDef, TransparentDef)
   , ProjOrigin(..)
   , getHiding
@@ -144,8 +145,12 @@ prettyWarning = \case
           , ("does not fit into data type of sort" <+> prettyTCM s2) <> "."
           ]
 
-    CoinductiveEtaRecord name -> vcat
-      [ fsep $ pwords "Not switching on eta-equality for coinductive records."
+    IllicitEtaRecord ind name -> vcat
+      [ fsep $ concat
+        [ pwords "Not switching on eta-equality for"
+        , case ind of CoInductive -> [ "coinductive" ]; Inductive -> [ "unguarded", "recursive" ]
+        , [ "records." ]
+        ]
       , fsep $ pwords "If you must, use pragma" ++ [ "{-# ETA", prettyTCM name, "#-}" ]
       ]
 

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -510,7 +510,17 @@ isEtaRecordConstructor c = isRecordConstructor c >>= \case
 -- | Turn off eta for unguarded recursive records.
 --   Projections do not preserve guardedness.
 unguardedRecord :: QName -> PatternOrCopattern -> TCM ()
-unguardedRecord q pat = modifyRecEta q \ eta -> setEtaEquality eta $ NoEta pat
+unguardedRecord q pat =
+  (stSignature . sigDefinitions . lensDefinition q . lensTheDef . lensRecord . lensRecEta)
+    `modifyTCLensM` \case
+      YesEtaPragma            -> return YesEtaPragma -- cannot overwrite
+      e@(Specified _ NoEta{}) -> pure e
+      Specified r YesEta      -> setCurrentRange r do
+        warning $ IllicitEtaRecord Inductive q
+        noEta
+      Inferred _              -> noEta
+  where
+    noEta = pure $ Inferred $ NoEta pat
 
 -- | Turn on eta for non-recursive and inductive guarded recursive records,
 --   unless user declared otherwise.

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -510,17 +510,37 @@ isEtaRecordConstructor c = isRecordConstructor c >>= \case
 -- | Turn off eta for unguarded recursive records.
 --   Projections do not preserve guardedness.
 unguardedRecord :: QName -> PatternOrCopattern -> TCM ()
-unguardedRecord q pat =
-  (stSignature . sigDefinitions . lensDefinition q . lensTheDef . lensRecord . lensRecEta)
-    `modifyTCLensM` \case
-      YesEtaPragma            -> return YesEtaPragma -- cannot overwrite
-      e@(Specified _ NoEta{}) -> pure e
+unguardedRecord q pat = do
+    change <- useTC (lensSigRecEta q) >>= \case
+      YesEtaPragma            -> return False  -- cannot overwrite
+      Specified _ NoEta{}     -> return False
+      Inferred    NoEta{}     -> return False
       Specified r YesEta      -> setCurrentRange r do
         warning $ IllicitEtaRecord Inductive q
-        noEta
-      Inferred _              -> noEta
-  where
-    noEta = pure $ Inferred $ NoEta pat
+        pure True
+      Inferred    YesEta      -> pure True
+    when change $ setTCLens (lensSigRecEta q) $ Inferred $ NoEta pat
+  -- Andreas, 2024-09-07:
+  -- The original implementation did originally not work because modifyTCLensM
+  -- dropped changes to the TCState introduced by the 'warning' effect:
+  -- Thus, highlighting worked, but the warning did not to enter the 'TCState'.
+  -- With PR #7474 this problem is fixed so we could bring back this implementation:
+  -- However, it will do needless identity updates in the signature,
+  -- so the new implementation is likely superior.
+  --
+  -- lensSigRecEta q
+  --   `modifyTCLensM` \case
+  --     YesEtaPragma            -> return YesEtaPragma -- cannot overwrite
+  --     e@(Specified _ NoEta{}) -> pure e
+  --     Specified r YesEta      -> setCurrentRange r do
+  --       warning $ IllicitEtaRecord Inductive q
+  --       noEta
+  --     Inferred _              -> noEta
+  -- where
+  --   noEta = pure $ Inferred $ NoEta pat
+
+lensSigRecEta :: QName -> Lens' TCState EtaEquality
+lensSigRecEta q = stSignature . sigDefinitions . lensDefinition q . lensTheDef . lensRecord . lensRecEta
 
 -- | Turn on eta for non-recursive and inductive guarded recursive records,
 --   unless user declared otherwise.

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -159,7 +159,7 @@ bindBuiltinFlat x =
     fun <- emptyFunctionData
     addConstant flat $
       flatDefn { defPolarity       = []
-               , defArgOccurrences = [StrictPos]  -- changing that to [Mixed] destroys monotonicity of 'Rec' in test/succeed/GuardednessPreservingTypeConstructors
+               , defArgOccurrences = [StrictPos]
                , defCopatternLHS = hasProjectionPatterns cc
                , theDef = FunctionDefn fun
                    { _funClauses      = [clause]

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -807,12 +807,13 @@ checkPragma r p = do
 
         A.EtaPragma q -> isRecord q >>= \case
             Nothing -> noRecord
-            Just RecordData{ _recInduction = ind, _recEtaEquality' = eta }
-              | ind /= Just CoInductive  -> noRecord
-              | Specified NoEta{} <- eta -> uselessPragma "ETA pragma conflicts with no-eta-equality declaration"
-              | otherwise -> modifyRecEta q $ const $ Specified YesEta
+            Just RecordData{ _recEtaEquality' = eta } ->
+              case eta of
+                YesEtaPragma        -> uselessPragma "Ignoring duplicate ETA pragma"
+                Specified _ NoEta{} -> uselessPragma "ETA pragma conflicts with no-eta-equality declaration"
+                _ -> modifyRecEta q $ const YesEtaPragma
           where
-            noRecord = uselessPragma "ETA pragma is only applicable to coinductive records"
+            noRecord = uselessPragma "ETA pragma is only applicable to records"
 
 -- | Type check a bunch of mutual inductive recursive definitions.
 --

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -189,7 +189,7 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
           -- Eta is inferred by the positivity checker.
           -- We should turn it off until it is proven to be safe.
           noEta    = Inferred $ NoEta patCopat
-          haveEta0 = maybe noEta Specified eta
+          haveEta0 = maybe noEta (Specified $ getRange eta0) eta
           con = ConHead conName (IsRecord patCopat) conInduction $ map argFromDom fs
 
           -- A record is irrelevant if all of its fields are.
@@ -209,7 +209,7 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
       haveEta <-
         if (conInduction == CoInductive && theEtaEquality haveEta0 == YesEta) then do
           noEta <$ do
-            setCurrentRange eta0 $ warning $ CoinductiveEtaRecord name
+            setCurrentRange eta0 $ warning $ IllicitEtaRecord CoInductive name
         else pure haveEta0
       reportSDoc "tc.rec" 30 $ "record constructor is " <+> prettyTCM con
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240816 * 10 + 0
+currentInterfaceVersion = 20240903 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -113,7 +113,7 @@ instance EmbPrj Warning where
     MissingTypeSignatureForOpaque a b           -> icodeN 54 MissingTypeSignatureForOpaque a b
     ConflictingPragmaOptions a b                -> icodeN 55 ConflictingPragmaOptions a b
     CustomBackendWarning a b                    -> icodeN 56 CustomBackendWarning a b
-    CoinductiveEtaRecord a                      -> icodeN 57 CoinductiveEtaRecord a
+    IllicitEtaRecord a b                        -> icodeN 57 IllicitEtaRecord a b
     WithClauseProjectionFixityMismatch a b c d  -> icodeN 58 WithClauseProjectionFixityMismatch a b c d
     InvalidDisplayForm a b                      -> icodeN 59 InvalidDisplayForm a b
     TooManyArgumentsToSort a b                  -> __IMPOSSIBLE__
@@ -189,7 +189,7 @@ instance EmbPrj Warning where
     [54, a, b]           -> valuN MissingTypeSignatureForOpaque a b
     [55, a, b]           -> valuN ConflictingPragmaOptions a b
     [56, a, b]           -> valuN CustomBackendWarning a b
-    [57, a]              -> valuN CoinductiveEtaRecord a
+    [57, a, b]           -> valuN IllicitEtaRecord a b
     [58, a, b, c, d]     -> valuN WithClauseProjectionFixityMismatch a b c d
     [59, a, b]           -> valuN InvalidDisplayForm a b
     [60, a, b]           -> valuN NotARewriteRule a b

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -395,13 +395,16 @@ instance EmbPrj Occurrence where
   value _ = malformed
 
 instance EmbPrj EtaEquality where
-  icod_ (Specified a) = icodeN 0 Specified a
-  icod_ (Inferred a)  = icodeN 1 Inferred a
+  icod_ = \case
+    Specified _ a -> icodeN 0 (Specified noRange) a
+    Inferred a    -> icodeN 1 Inferred a
+    YesEtaPragma  -> icodeN' YesEtaPragma
 
-  value = vcase valu where
-    valu [0,a] = valuN Specified a
-    valu [1,a] = valuN Inferred a
-    valu _     = malformed
+  value = vcase \case
+    [0,a] -> valuN (Specified noRange) a
+    [1,a] -> valuN Inferred a
+    []    -> valuN YesEtaPragma
+    _     -> malformed
 
 instance EmbPrj ProjectionLikenessMissing
 

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -76,7 +76,7 @@ instance MonadWarning TCM where
       w' = tcWarning tcwarn
 
       add w tcwarn tcwarns
-        | onlyOnce w && elem tcwarn tcwarns = tcwarns -- Eq on TCWarning only checks head constructor
+        | onlyOnce w && elem tcwarn tcwarns = tcwarns -- Eq on TCWarning only checks for same warning Doc
         | otherwise                         = tcwarn : tcwarns
 
 -- * Raising warnings

--- a/test/Fail/AbsurdPatternUnguardedRecord.agda
+++ b/test/Fail/AbsurdPatternUnguardedRecord.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2024-09-04
+-- Refuse directive eta-equality for unguarded records
+-- Re: https://github.com/agda/agda/issues/7467#issuecomment-2326548333
+
+-- {-# OPTIONS -v tc.pos.record:5 #-}
+
+data ⊥ : Set where
+
+record R : Set where
+  eta-equality
+  inductive
+  field f : R
+
+f : R → ⊥
+f ()
+
+-- WAS: Agda loops in type emptiness check
+--
+-- Expected:

--- a/test/Fail/AbsurdPatternUnguardedRecord.err
+++ b/test/Fail/AbsurdPatternUnguardedRecord.err
@@ -1,0 +1,8 @@
+AbsurdPatternUnguardedRecord.agda:10,3-15: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA R #-}
+
+AbsurdPatternUnguardedRecord.agda:15,1-5: error: [ShouldBeEmpty]
+R should be empty, but that's not obvious to me
+when checking the clause left hand side
+f ()

--- a/test/Fail/EtaData.err
+++ b/test/Fail/EtaData.err
@@ -3,7 +3,7 @@ ETA pragma conflicts with no-eta-equality declaration
 when checking the pragma ETA R
 
 EtaData.agda:17,1-17: warning: -W[no]UselessPragma
-ETA pragma is only applicable to coinductive records
+ETA pragma is only applicable to records
 when checking the pragma ETA Prod
 
 EtaData.agda:34,10-14: error: [UnequalTerms]

--- a/test/Fail/Issue5823.err
+++ b/test/Fail/Issue5823.err
@@ -1,6 +1,20 @@
-Issue5823.agda:26,1-27,91: error: [TerminationIssue]
-Termination checking failed for the following functions:
-  isPropAcc
-Problematic calls:
-  isPropAcc (x n p) (y n p)
-    (at Issue5823.agda:27,65-74)
+Issue5823.agda:18,14-21: warning: -W[no]UselessPatternDeclarationForRecord
+'pattern' attribute ignored for eta record
+when scope checking the declaration
+  record Acc {a} {A} {r} R x where
+    inductive
+    pattern
+    eta-equality
+    constructor acc
+    field step : ∀ y → R y x → Acc R y
+
+Issue5823.agda:18,23-35: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA Acc #-}
+
+Issue5823.agda:27,12-17: error: [SplitOnNonEtaRecord]
+Pattern matching on no-eta record type Acc
+(defined at Issue5823.agda:17,8-11)
+is not allowed
+(to activate, add declaration 'pattern' to record definition)
+when checking that the pattern acc x has type Acc R x

--- a/test/Fail/Issue5823ETA.agda
+++ b/test/Fail/Issue5823ETA.agda
@@ -15,10 +15,12 @@ postulate
   funExt : ∀{a b}{A : Set a} {B : (x : A) → Set b} {f g : (x : A) → B x} → (∀ (x : A) → f x ≡ g x) → f ≡ g
 
 record Acc {a} {A : Set a} {r} (R : A → A → Set r) (x : A) : Set (a ⊔ r) where
-  inductive; pattern; eta-equality
+  inductive; eta-equality
   constructor acc
   field step : ∀ y → R y x → Acc R y
 open Acc public
+
+{-# ETA Acc #-}
 
 -- Naively testing Acc R x for being a singleton will infinitely unfold its definition.
 -- We need to keep track of which record types we already unfolded!

--- a/test/Fail/Issue5823ETA.err
+++ b/test/Fail/Issue5823ETA.err
@@ -1,0 +1,9 @@
+Issue5823ETA.agda:18,14-26: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA Acc #-}
+Issue5823ETA.agda:28,1-29,91: error: [TerminationIssue]
+Termination checking failed for the following functions:
+  isPropAcc
+Problematic calls:
+  isPropAcc (x n p) (y n p)
+    (at Issue5823ETA.agda:29,65-74)

--- a/test/Succeed/AbsurdPatternGuardedRecord.agda
+++ b/test/Succeed/AbsurdPatternGuardedRecord.agda
@@ -1,0 +1,18 @@
+-- Andreas, 2024-09-04
+-- Ensure that type emptiness check works with guarded records
+-- Re: https://github.com/agda/agda/issues/7467#issuecomment-2327177373
+
+open import Agda.Builtin.Maybe
+
+data ⊥ : Set where
+
+record NEList (A : Set) : Set where
+  inductive
+  field
+    hd : A
+    tl : Maybe (NEList A)
+
+f : NEList ⊥ → ⊥
+f ()
+
+-- Should succeed.

--- a/test/Succeed/EtaPragmaUnguardedRecord.agda
+++ b/test/Succeed/EtaPragmaUnguardedRecord.agda
@@ -1,0 +1,36 @@
+-- Andreas, 2024-09-04
+-- Unguarded records need ETA pragma rather than eta-equality directive.
+
+-- {-# OPTIONS --safe #-}  -- Safe forbids ETA pragmas.
+
+open import Agda.Builtin.Bool
+
+data ⊥ : Set where
+
+-- Guarding.
+data Wrap (A : Set) : Set where
+  wrap : A → Wrap A
+
+-- Only T true is guarding, not T false.
+T : Bool → Set → Set
+T true = Wrap
+T false A = A
+
+-- R is not recognized as guarded record, so should not have eta.
+record R : Set where
+  inductive
+  eta-equality         -- Should be ignored with a warning
+  field
+    tag : Bool
+    possibly-unguarded : T tag R
+    absurd : ⊥
+
+-- Forcing eta for R.
+
+{-# ETA R #-}
+{-# ETA R #-}  -- Duplicate, thus useless, should trigger warning.
+
+test : R → ⊥
+test ()
+
+-- Should succeed.

--- a/test/Succeed/EtaPragmaUnguardedRecord.warn
+++ b/test/Succeed/EtaPragmaUnguardedRecord.warn
@@ -1,0 +1,17 @@
+EtaPragmaUnguardedRecord.agda:22,3-15: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA R #-}
+
+EtaPragmaUnguardedRecord.agda:31,1-14: warning: -W[no]UselessPragma
+Ignoring duplicate ETA pragma
+when checking the pragma ETA R
+
+———— All done; warnings encountered ————————————————————————
+
+EtaPragmaUnguardedRecord.agda:22,3-15: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA R #-}
+
+EtaPragmaUnguardedRecord.agda:31,1-14: warning: -W[no]UselessPragma
+Ignoring duplicate ETA pragma
+when checking the pragma ETA R

--- a/test/Succeed/EtaUnguardedRecord.agda
+++ b/test/Succeed/EtaUnguardedRecord.agda
@@ -1,0 +1,20 @@
+-- Andreas, 2024-09-04, example by Ulf
+-- Unguarded eta records could make the type checker loop
+
+{-# OPTIONS --allow-unsolved-metas #-}
+
+open import Agda.Builtin.Equality
+
+record R : Set where
+  eta-equality         -- Should be ignored with a warning
+  inductive
+  field f : R
+
+open R
+
+loop : (let X = _) → X .f ≡ X .f → Set
+loop refl = _
+
+-- WAS: type checker loops
+
+-- Should succeed with unsolved metas

--- a/test/Succeed/EtaUnguardedRecord.warn
+++ b/test/Succeed/EtaUnguardedRecord.warn
@@ -1,0 +1,9 @@
+EtaUnguardedRecord.agda:9,3-15: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA R #-}
+
+———— All done; warnings encountered ————————————————————————
+
+EtaUnguardedRecord.agda:9,3-15: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA R #-}

--- a/test/Succeed/Issue376Loop.agda
+++ b/test/Succeed/Issue376Loop.agda
@@ -10,6 +10,7 @@ record R : Set where
   field
     r : R
 
+{-# ETA R #-}
 
 postulate F : (R → Set) → Set
 

--- a/test/Succeed/Issue376Loop.warn
+++ b/test/Succeed/Issue376Loop.warn
@@ -1,0 +1,9 @@
+Issue376Loop.agda:7,3-15: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA R #-}
+
+———— All done; warnings encountered ————————————————————————
+
+Issue376Loop.agda:7,3-15: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA R #-}

--- a/test/Succeed/Issue5823.agda
+++ b/test/Succeed/Issue5823.agda
@@ -34,6 +34,8 @@ mutual
   T zero = ⊤
   T (suc n) = T n × S n
 
+{-# ETA S #-}
+
 -- S n is a eta singleton type for each n because it is terminating.
 
 inh5 : S 5

--- a/test/Succeed/Issue5823.warn
+++ b/test/Succeed/Issue5823.warn
@@ -1,0 +1,9 @@
+Issue5823.agda:30,16-28: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA S #-}
+
+———— All done; warnings encountered ————————————————————————
+
+Issue5823.agda:30,16-28: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA S #-}

--- a/test/Succeed/Issue7245.warn
+++ b/test/Succeed/Issue7245.warn
@@ -118,7 +118,7 @@ when scope checking the declaration
   {-# NOINLINE not-in-scope #-}
 
 Issue7245.agda:12,1-36: warning: -W[no]UselessPragma
-ETA pragma is only applicable to coinductive records
+ETA pragma is only applicable to records
 when checking the pragma ETA foo
 
 Issue7245.agda:14,1-36: warning: -W[no]UselessPragma
@@ -263,7 +263,7 @@ when scope checking the declaration
   {-# NOINLINE not-in-scope #-}
 
 Issue7245.agda:12,1-36: warning: -W[no]UselessPragma
-ETA pragma is only applicable to coinductive records
+ETA pragma is only applicable to records
 when checking the pragma ETA foo
 
 Issue7245.agda:14,1-36: warning: -W[no]UselessPragma

--- a/test/Succeed/Issue840a.agda
+++ b/test/Succeed/Issue840a.agda
@@ -55,6 +55,8 @@ mutual
   Record-fun ∅             = ⊤
   Record-fun (Sig , ℓ ∶ A) = Σ (Record Sig) A
 
+{-# ETA Record #-}
+
 _∈_ : String → Signature → Set
 ℓ ∈ ∅              = ⊥
 ℓ ∈ (Sig , ℓ′ ∶ A) with primStringEquality ℓ ℓ′

--- a/test/Succeed/Issue840a.warn
+++ b/test/Succeed/Issue840a.warn
@@ -1,0 +1,9 @@
+Issue840a.agda:49,5-17: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA Record #-}
+
+———— All done; warnings encountered ————————————————————————
+
+Issue840a.agda:49,5-17: warning: -W[no]UnguardedEtaRecord
+Not switching on eta-equality for unguarded recursive records.
+If you must, use pragma {-# ETA Record #-}


### PR DESCRIPTION
Fixes #7477.
- #7477

From: https://github.com/agda/agda/issues/7467#issuecomment-2327177373
> should overwrite the user directive, mark it as dead code, cast an [error] warning and point the user toward the ETA pragma.

This PR implements the plan.  
Breaking change, because the ETA pragma is not allowed with `--safe`, but the `eta-equality` directive is.
Previously, the ETA pragma was reserved for `coinductive` records where having eta would be weird anyway.
Now, there might be legit uses of ETA, overriding Agda's guardedness check for record types.
There are no consistency hazards, only looping of Agda.
(Maybe eta coinductive records are no consistency hazard either, just leading to subject reduction problems.)