### PR TITLE
Re #6919: also separate compilation warnings by newlines

### DIFF
--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -172,7 +172,12 @@ backendInteraction mainFile backends setup check = do
 
   -- print warnings that might have accumulated during compilation
   ws <- filter (not . isUnsolvedWarning . tcWarning) <$> getAllWarnings AllWarnings
-  unless (null ws) $ alwaysReportSDoc "warning" 1 $ P.vcat $ P.prettyTCM <$> ws
+  unless (null ws) $ alwaysReportSDoc "warning" 1 $
+    -- Andreas, 2024-09-06 start warning list by a newline
+    -- since type checker warnings are also newline separated.
+    -- See e.g. test/Succeed/CompileBuiltinListWarning.warn.
+    -- Also separate warnings by newlines (issue #6919).
+    P.vcat $ concatMap (\ w -> [ "", P.prettyTCM w ]) ws
 
 
 compilerMain :: Backend' opts env menv mod def -> IsMain -> CheckResult -> TCM ()

--- a/test/Compiler/simple/ExportAndUse.out
+++ b/test/Compiler/simple/ExportAndUse.out
@@ -1,6 +1,7 @@
 COMPILE_SUCCEEDED
 
 ret > ExitSuccess
+out >
 out > warning: -W[no]NoMain
 out > No main function defined in ExportAndUse.
 out > Use option --no-main to suppress this warning.

--- a/test/Compiler/simple/Issue2714.out
+++ b/test/Compiler/simple/Issue2714.out
@@ -1,6 +1,7 @@
 COMPILE_SUCCEEDED
 
 ret > ExitSuccess
+out >
 out > warning: -W[no]NoMain
 out > No main function defined in Issue2714.
 out > Use option --no-main to suppress this warning.

--- a/test/Succeed/CompileBuiltinListWarning.warn
+++ b/test/Succeed/CompileBuiltinListWarning.warn
@@ -65,9 +65,11 @@ when checking the pragma BUILTIN NIL []
 CompileBuiltinListWarning.agda:11,1-26: warning: -W[no]OldBuiltin
 Builtin CONS no longer exists. It is now bound by BUILTIN LIST
 when checking the pragma BUILTIN CONS _∷_
+
 CompileBuiltinListWarning.agda:7,1-44: warning: -W[no]PragmaCompileList
 Ignoring GHC pragma for builtin lists; they always compile to
 Haskell lists.
+
 CompileBuiltinListWarning.agda:17,1-45: warning: -W[no]PragmaCompileMaybe
 Ignoring GHC pragma for builtin MAYBE; it always compiles to
 Haskell Maybe.

--- a/test/Succeed/InlineCompiled.warn
+++ b/test/Succeed/InlineCompiled.warn
@@ -1,3 +1,4 @@
+
 InlineCompiled.agda:10,1-36: warning: -W[no]UselessInline
 It is pointless for INLINE'd function id to have a separate Haskell
 definition

--- a/test/Succeed/Issue2909-5.warn
+++ b/test/Succeed/Issue2909-5.warn
@@ -1,2 +1,3 @@
+
 Issue2909-5.agda:12,1-30: warning: -W[no]PragmaCompileWrong
 COMPILE GHC pragmas are not allowed for the FLAT builtin.

--- a/test/Succeed/Issue2909-6.warn
+++ b/test/Succeed/Issue2909-6.warn
@@ -1,2 +1,3 @@
+
 Issue2909-6.agda:13,1-34: warning: -W[no]PragmaCompileWrong
 COMPILE GHC pragmas are not allowed for the FLAT builtin.

--- a/test/Succeed/ParseErrorGHCPragma.warn
+++ b/test/Succeed/ParseErrorGHCPragma.warn
@@ -1,2 +1,3 @@
+
 ParseErrorGHCPragma.agda:9,1-22: warning: -W[no]PragmaCompileUnparsable
 Ignoring unparsable GHC pragma ''


### PR DESCRIPTION
Fix #6919: also separate compilation warnings by newlines