### PR TITLE
Fix `{modify,state}TCLensM` and `%==` and `%%=` (lost state effects)

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -964,6 +964,7 @@ test-suite agda-tests
       Internal.Utils.FileName
       Internal.Utils.Graph.AdjacencyMap.Unidirectional
       Internal.Utils.IntSet
+      Internal.Utils.Lens
       Internal.Utils.List
       Internal.Utils.List1
       Internal.Utils.List2

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -786,7 +786,7 @@ solveAwakeConstraints' = solveSomeAwakeConstraints (const True)
 {-# SPECIALIZE freezeMetas :: LocalMetaStore -> TCM (Set MetaId) #-}
 -- | Freeze the given meta-variables (but only if they are open) and
 -- return those that were not already frozen.
-freezeMetas :: forall m. MonadTCState m => LocalMetaStore -> m (Set MetaId)
+freezeMetas :: forall m. (MonadTCState m, ReadTCState m) => LocalMetaStore -> m (Set MetaId)
 freezeMetas ms =
   execWriterT $
   modifyTCLensM stOpenMetaStore $

--- a/src/full/Agda/Utils/Lens.hs
+++ b/src/full/Agda/Utils/Lens.hs
@@ -11,7 +11,6 @@ module Agda.Utils.Lens
 import Control.Applicative ( Const(Const), getConst )
 import Control.Monad.State
 import Control.Monad.Reader
-import Control.Monad.Writer
 
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -87,15 +86,15 @@ l %= f = modify $ over l f
 infix 4 %==
 -- | Modify a part of the state monadically.
 (%==) :: MonadState o m => Lens' o i -> (i -> m i) -> m ()
-l %== f = put =<< l f =<< get
+l %== f = use l >>= f >>= (l .=)
 
 infix 4 %%=
 -- | Modify a part of the state monadically, and return some result.
 (%%=) :: MonadState o m => Lens' o i -> (i -> m (i, r)) -> m r
 l %%= f = do
-  o <- get
-  (o', r) <- runWriterT $ l (WriterT . f) o
-  put o'
+  i <- use l
+  (i', r) <- f i
+  l .= i'
   return r
 
 -- | Modify a part of the state locally.

--- a/test/Internal/Tests.hs
+++ b/test/Internal/Tests.hs
@@ -41,6 +41,7 @@ import qualified Internal.Utils.Favorites                          as UtilFav   
 import qualified Internal.Utils.FileName                           as UtilFile     ( tests )
 import qualified Internal.Utils.Graph.AdjacencyMap.Unidirectional  as UtilGraphUni ( tests )
 import qualified Internal.Utils.IntSet                             as UtilIntSet   ( tests )
+import qualified Internal.Utils.Lens                               as UtilLens     ( tests )
 import qualified Internal.Utils.List                               as UtilList     ( tests )
 import qualified Internal.Utils.List1                              as UtilList1    ( tests )
 import qualified Internal.Utils.List2                              as UtilList2    ( tests )
@@ -59,7 +60,8 @@ import qualified Internal.Utils.Warshall                           as UtilWarsh 
 -- Keep this list in the import order, please!
 tests :: TestTree
 tests = testGroup "Internal"
-  [ CompEnco.tests
+  [ UtilLens.tests
+  , CompEnco.tests
   , UtilMonad.tests
   , IntePrec.tests
   , InteRang.tests

--- a/test/Internal/Utils/Lens.hs
+++ b/test/Internal/Utils/Lens.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Internal.Utils.Lens ( tests ) where
+
+import Control.Monad.State
+
+import Agda.Utils.Lens
+
+import Internal.Helpers
+
+------------------------------------------------------------------------------
+-- Properties
+
+-- Bug discovered in https://github.com/agda/agda/pull/7470#discussion_r1747232483
+prop_effectfully_modify :: (Eq a, Eq b) => a -> b -> a -> b -> Bool
+prop_effectfully_modify x0 y0 x1 y1 = execState p (x0, y0) == (x1, y1)
+  where
+    -- The change to @lSnd@ should not get lost by the use of @%==@.
+    p = lFst %== \ _ -> do
+          lSnd .= y1
+          return x1
+
+prop_effectfully_modify_and_value :: (Eq a, Eq b, Eq c) => a -> b -> a -> b -> c -> Bool
+prop_effectfully_modify_and_value x0 y0 x1 y1 z = runState p (x0, y0) == (z, (x1, y1))
+  where
+    -- The change to @lSnd@ should not get lost by the use of @%%=@.
+    p = lFst %%= \ _ -> do
+          lSnd .= y1
+          return (x1, z)
+
+
+------------------------------------------------------------------------
+-- * All tests
+------------------------------------------------------------------------
+
+-- Template Haskell hack to make the following $allProperties work
+-- under ghc-7.8.
+return [] -- KEEP!
+
+-- | All tests as collected by 'allProperties'.
+--
+-- Using 'allProperties' is convenient and superior to the manual
+-- enumeration of tests, since the name of the property is added
+-- automatically.
+
+tests :: TestTree
+tests = testProperties "Internal.Utils.Lens" $allProperties


### PR DESCRIPTION
Background: https://github.com/agda/agda/pull/7470#discussion_r1747232483
