### PR TITLE
Make BackendName a Text

### DIFF
--- a/src/full/Agda/Compiler/Backend.hs-boot
+++ b/src/full/Agda/Compiler/Backend.hs-boot
@@ -10,6 +10,9 @@ module Agda.Compiler.Backend
 
 import Agda.Compiler.Backend.Base
 
+import Agda.Syntax.Abstract.Name (QName)
+import Agda.Syntax.Common (BackendName)
+
 -- Explicitly adding the Agda.Syntax.Treeless import to the .hs-boot file
 -- so that the `Args` symbol can be hidden by the `SOURCE` import in
 -- TypeChecking.Monad.Base.
@@ -23,8 +26,7 @@ import Agda.Compiler.Backend.Base
 -- the .hs-boot
 import Agda.Syntax.Treeless (TTerm, Args)
 
-import Agda.Syntax.Abstract.Name (QName)
-import {-# SOURCE #-} Agda.TypeChecking.Monad.Base (TCM, BackendName)
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Base (TCM)
 
 type Backend = Backend_boot TCM
 

--- a/src/full/Agda/Compiler/Backend/Base.hs
+++ b/src/full/Agda/Compiler/Backend/Base.hs
@@ -4,22 +4,25 @@ module Agda.Compiler.Backend.Base where
 
 import Agda.Interaction.Options (ArgDescr(..), OptDescr(..), Flag)
 import Agda.Syntax.Abstract.Name (QName)
-import Agda.Syntax.Common (IsMain)
+import Agda.Syntax.Common (BackendName, IsMain)
 import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Base (Definition)
 
 
 import Control.DeepSeq (NFData, rnf)
 import Data.Map (Map)
+import Data.Text (Text)
 
 import GHC.Generics (Generic)
+
+type BackendVersion = Text
 
 data Backend_boot tcm where
   Backend :: NFData opts => Backend'_boot tcm opts env menv mod def -> Backend_boot tcm
 
 data Backend'_boot tcm opts env menv mod def = Backend'
-  { backendName      :: String
-  , backendVersion   :: Maybe String
+  { backendName      :: BackendName
+  , backendVersion   :: Maybe BackendVersion
       -- ^ Optional version information to be printed with @--version@.
   , options          :: opts
       -- ^ Default options

--- a/src/full/Agda/Interaction/Base.hs
+++ b/src/full/Agda/Interaction/Base.hs
@@ -14,12 +14,13 @@ import qualified Data.List                    as List
 import           Data.Map                     (Map)
 import qualified Data.Map                     as Map
 import           Data.Maybe                   (listToMaybe)
+import qualified Data.Text                    as T
 
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Base
   (HighlightingLevel, HighlightingMethod, Comparison, Polarity)
 
 import           Agda.Syntax.Abstract         (QName)
-import           Agda.Syntax.Common           (InteractionId (..), Modality)
+import           Agda.Syntax.Common           (BackendName, InteractionId (..), Modality)
 import           Agda.Syntax.Internal         (ProblemId, Blocker)
 import           Agda.Syntax.Position
 import           Agda.Syntax.Scope.Base       (ScopeInfo)
@@ -422,7 +423,7 @@ instance Read a => Read (Position' a) where
 ---------------------------------------------------------
 -- | Available backends.
 
-data CompilerBackend = LaTeX | QuickLaTeX | OtherBackend String
+data CompilerBackend = LaTeX | QuickLaTeX | OtherBackend BackendName
     deriving (Eq)
 
 -- TODO 2021-08-25 get rid of custom Show instance
@@ -433,7 +434,7 @@ instance Pretty CompilerBackend where
   pretty = \case
     LaTeX          -> "LaTeX"
     QuickLaTeX     -> "QuickLaTeX"
-    OtherBackend s -> text s
+    OtherBackend s -> pretty s
 
 instance Read CompilerBackend where
   readsPrec _ s = do
@@ -441,7 +442,7 @@ instance Read CompilerBackend where
     let b = case t of
               "LaTeX"      -> LaTeX
               "QuickLaTeX" -> QuickLaTeX
-              _            -> OtherBackend t
+              _            -> OtherBackend $ T.pack t
     return (b, s)
 
 -- | Ordered ascendingly by degree of normalization.

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -13,6 +13,7 @@ import Control.Monad.IO.Class ( MonadIO(..) )
 
 import qualified Data.List as List
 import Data.Maybe
+import qualified Data.Text as T
 
 import System.Environment
 import System.Exit
@@ -179,7 +180,7 @@ getInteractor configuredBackends maybeInputFile opts =
     pluralize w []  = concat ["(no ", w, ")"]
     pluralize w [x] = concat [w, " ", x]
     pluralize w xs  = concat [w, "s (", List.intercalate ", " xs, ")"]
-    enabledBackendNames  = pluralize "backend" [ backendName b | Backend b <- enabledBackends ]
+    enabledBackendNames  = pluralize "backend" [ T.unpack $ backendName b | Backend b <- enabledBackends ]
     enabledFrontendNames = pluralize "frontend" (frontendFlagName <$> enabledFrontends)
     frontendFlagName = ("--" ++) . \case
       FrontEndEmacs -> "interaction"
@@ -260,7 +261,7 @@ printUsage backends hp = do
 
 backendUsage :: Backend -> String
 backendUsage (Backend b) =
-  usageInfo ("\n" ++ backendName b ++ " backend options") $
+  usageInfo ("\n" ++ T.unpack (backendName b) ++ " backend options") $
     map void (commandLineFlags b)
 
 -- | Print version information.
@@ -271,7 +272,7 @@ printVersion backends PrintAgdaVersion = do
   unless (null flags) $
     mapM_ putStrLn $ ("Built with flags (cabal -f)" :) $ map bullet flags
   mapM_ putStrLn
-    [ bullet $ name ++ " backend version " ++ ver
+    [ bullet $ T.unpack $ T.unwords [ name, "backend version", ver ]
     | Backend Backend'{ backendName = name, backendVersion = Just ver } <- backends ]
   where
   bullet = (" - " ++)

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -213,7 +213,7 @@ data Pragma
     --   but declare a name for an Agda concept.
   | RewritePragma Range [QName]
     -- ^ Range is range of REWRITE keyword.
-  | CompilePragma RString QName String
+  | CompilePragma (Ranged BackendName) QName String
   | StaticPragma QName
   | EtaPragma QName
     -- ^ For coinductive records, use pragma instead of regular

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -28,6 +28,7 @@ import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
+import Data.Text (Text)
 
 import GHC.Generics (Generic)
 
@@ -117,6 +118,12 @@ instance KillRange Language where
   killRange = id
 
 instance NFData Language
+
+---------------------------------------------------------------------------
+-- * Backends
+---------------------------------------------------------------------------
+
+type BackendName = Text
 
 ---------------------------------------------------------------------------
 -- * Record Directives
@@ -3011,6 +3018,7 @@ class LensFixity' a where
 
 instance LensFixity' Fixity' where
   lensFixity' = id
+
 ---------------------------------------------------------------------------
 -- * Import directive
 ---------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -592,8 +592,8 @@ data Pragma
   = OptionsPragma               Range [String]
   | BuiltinPragma               Range RString QName
   | RewritePragma               Range Range [QName]        -- ^ Second Range is for REWRITE keyword.
-  | ForeignPragma               Range RString String       -- ^ first string is backend name
-  | CompilePragma               Range RString QName String -- ^ first string is backend name
+  | ForeignPragma               Range (Ranged BackendName) String
+  | CompilePragma               Range (Ranged BackendName) QName String
   | StaticPragma                Range QName
   | InlinePragma                Range Bool QName  -- ^ INLINE or NOINLINE
 

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -644,9 +644,9 @@ instance Pretty Pragma where
     pretty (RewritePragma _ _ xs)    =
       hsep [ "REWRITE", hsep $ map pretty xs ]
     pretty (CompilePragma _ b x e) =
-      hsep [ "COMPILE", text (rangedThing b), pretty x, textNonEmpty e ]
+      hsep [ "COMPILE", pretty (rangedThing b), pretty x, textNonEmpty e ]
     pretty (ForeignPragma _ b s) =
-      vcat $ text ("FOREIGN " ++ rangedThing b) : map text (lines s)
+      vcat $ hsep [ "FOREIGN", pretty (rangedThing b) ] : map text (lines s)
     pretty (StaticPragma _ i) =
       hsep $ ["STATIC", pretty i]
     pretty (InjectivePragma _ i) =

--- a/src/full/Agda/Syntax/Parser/Helpers.hs
+++ b/src/full/Agda/Syntax/Parser/Helpers.hs
@@ -13,7 +13,8 @@ import Data.Char
 import qualified Data.List as List
 import Data.Maybe
 import Data.Semigroup ((<>), sconcat)
-import qualified Data.Traversable as T
+import Data.Text (Text)
+import qualified Data.Text as T
 
 import Agda.Syntax.Position
 import Agda.Syntax.Parser.Monad
@@ -158,6 +159,9 @@ mkDomainFree_ f p n = f $ defaultNamedArg $ Binder p $ mkBoundName_ n
 
 mkRString :: (Interval, String) -> RString
 mkRString (i, s) = Ranged (getRange i) s
+
+mkRText :: (Interval, String) -> Ranged Text
+mkRText (i, s) = Ranged (getRange i) $ T.pack s
 
 -- | Create a qualified name from a string (used in pragmas).
 --   Range of each name component is range of whole string.

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1654,13 +1654,13 @@ ForeignPragma :: { Pragma }
 ForeignPragma
   : '{-#' 'FOREIGN' string ForeignCode '#-}'
     { ForeignPragma (getRange ($1, $2, fst $3, $5))
-        (mkRString $3) (recoverLayout (DL.toList $4)) }
+        (mkRText $3) (recoverLayout (DL.toList $4)) }
 
 CompilePragma :: { Pragma }
 CompilePragma
   : '{-#' 'COMPILE' string PragmaQName PragmaStrings '#-}'
     { CompilePragma (getRange ($1, $2, fst $3, $4, map fst $5, $6))
-        (mkRString $3) $4 (unwords (map snd $5)) }
+        (mkRText $3) $4 (unwords (map snd $5)) }
 
 StaticPragma :: { Pragma }
 StaticPragma

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2234,8 +2234,6 @@ data CompilerPragma = CompilerPragma Range String
 instance HasRange CompilerPragma where
   getRange (CompilerPragma r _) = r
 
-type BackendName    = String
-
 jsBackendName, ghcBackendName :: BackendName
 jsBackendName  = "JS"
 ghcBackendName = "GHC"

--- a/src/full/Agda/TypeChecking/Monad/Base.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs-boot
@@ -39,8 +39,6 @@ type TCM = TCMT IO
 
 type ModuleToSource = Map TopLevelModuleName AbsolutePath
 
-type BackendName = String
-
 data Comparison
 data Polarity
 data IPFace' a

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -266,7 +266,7 @@ getUniqueCompilerPragma backend q = do
     (_:p1:_) ->
       setCurrentRange p1 $
             genericDocError =<< do
-                  hang (text ("Conflicting " ++ backend ++ " pragmas for") <+> pretty q <+> "at") 2 $
+                  hang (hsep [ "Conflicting", pretty backend, "pragmas for", pretty q, "at" ]) 2 $
                        vcat [ "-" <+> pretty (getRange p) | p <- ps ]
 
 setFunctionFlag :: FunctionFlag -> Bool -> QName -> TCM ()

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -11,13 +11,14 @@ import Control.Applicative  (liftA2)
 import Control.Monad
 import Control.Monad.Except
 
+import qualified Data.Foldable as Fold
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.Maybe
 import Data.String    ()
 import Data.Semigroup (Semigroup((<>)))
-import qualified Data.Foldable as Fold
+import Data.Text      (Text)
 
 import Agda.Syntax.Position
 import Agda.Syntax.Common
@@ -177,6 +178,7 @@ prettyTCMCtx :: (PrettyTCM a, MonadPretty m) => Precedence -> a -> m Doc
 prettyTCMCtx p = withContextPrecedence p . prettyTCM
 
 instance {-# OVERLAPPING #-} PrettyTCM String where prettyTCM = text
+instance PrettyTCM Text                       where prettyTCM = pretty
 instance PrettyTCM Bool                       where prettyTCM = pretty
 instance PrettyTCM C.Name                     where prettyTCM = pretty
 instance PrettyTCM C.QName                    where prettyTCM = pretty

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -442,7 +442,7 @@ prettyWarning = \case
 
     PragmaCompileErased bn qn -> fsep $ concat
       [ pwords "The backend"
-      , [ text bn
+      , [ prettyTCM bn
         , "erases"
         , prettyTCM qn
         ]

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -1100,13 +1100,13 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
 
     tcPragmaForeign :: Text -> Text -> TCM Term
     tcPragmaForeign backend code = do
-      addForeignCode (T.unpack backend) (T.unpack code)
+      addForeignCode backend (T.unpack code)
       primUnitUnit
 
     tcPragmaCompile :: Text -> QName -> Text -> TCM Term
     tcPragmaCompile backend name code = do
       modifySignature $ updateDefinition name $
-        addCompilerPragma (T.unpack backend) $ CompilerPragma noRange (T.unpack code)
+        addCompilerPragma backend $ CompilerPragma noRange (T.unpack code)
       primUnitUnit
 
     tcRunSpeculative :: Term -> UnquoteM Term

--- a/test/Fail/OnlyScopeCheckingEmacs.agda
+++ b/test/Fail/OnlyScopeCheckingEmacs.agda
@@ -1,0 +1,4 @@
+-- Issue #5101
+
+-- Expected error:
+-- The --only-scope-checking flag cannot be combined with ...

--- a/test/Fail/OnlyScopeCheckingJSON.agda
+++ b/test/Fail/OnlyScopeCheckingJSON.agda
@@ -1,0 +1,4 @@
+-- Issue #5101
+
+-- Expected error:
+-- The --only-scope-checking flag cannot be combined with ...

--- a/test/Fail/OnlyScopeCheckingRepl.agda
+++ b/test/Fail/OnlyScopeCheckingRepl.agda
@@ -1,0 +1,4 @@
+-- Issue #5101
+
+-- Expected error:
+-- The --only-scope-checking flag cannot be combined with ...

--- a/test/Fail/OnlyScopeCheckingVim.agda
+++ b/test/Fail/OnlyScopeCheckingVim.agda
@@ -1,0 +1,4 @@
+-- Issue #5101
+
+-- Expected error:
+-- The --only-scope-checking flag cannot be combined with ...

--- a/test/Fail/Tests.hs
+++ b/test/Fail/Tests.hs
@@ -40,7 +40,6 @@ tests = do
     [ testGroup "customised" $
         issue6465 :
         issue5508 :
-        issue5101 :
         issue4671 :
         issue2649 :
         nestedProjectRoots :
@@ -164,29 +163,6 @@ issue5508 =
       let agdaArgs file = [ "-v0", "--no-libraries", "-i" ++ dir, dir </> file ]
       runAgdaWithOptions "iSSue5508" (agdaArgs "iSSue5508.agda") Nothing Nothing
         <&> printTestResult . expectFail
-
--- The only customization here is that these do not have input .agda files,
--- because the front-end interactors do not accept them.
--- This runs the same as a normal test, but won't be auto-discovered because
--- currently test discovery searches only for the .agda source.
-issue5101 :: TestTree
-issue5101 = testGroup "Issue5101" $
-  for suffixes $ \s -> do
-    let testName = "OnlyScopeChecking" ++ s
-    let goldenFile = dir </> testName <.> "err"
-    let flagsFile = dir </> testName <.> "flags"
-    let agdaArgs = ["-v0", "--no-libraries", "-i" ++ dir]
-    let doRun = runAgdaWithOptions testName agdaArgs (Just flagsFile) Nothing <&> printTestResult . expectFail
-    goldenTest1
-      testName
-      (readTextFileMaybe goldenFile)
-      doRun
-      textDiff
-      ShowText
-      (writeTextFile goldenFile)
-  where
-  dir = testDir
-  suffixes = ["Repl", "Emacs", "JSON", "Vim"]
 
 issue2649 :: TestTree
 issue2649 =

--- a/test/interaction/Issue2905.agda
+++ b/test/interaction/Issue2905.agda
@@ -1,1 +1,1 @@
-
+-- Trigger error for non-existing backend

--- a/test/interaction/Issue2905.out
+++ b/test/interaction/Issue2905.out
@@ -7,6 +7,6 @@
 (agda2-status-action "")
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
-(agda2-info-action "*Error*" "error: [GenericError] No backend called 'NonExistingBackend' (installed backends: Dot, GHC, GHCNoMain, HTML, JS, LaTeX, QuickLaTeX)" nil)
+(agda2-info-action "*Error*" "error: [GenericDocError] No backend called 'NonExistingBackend' Installed backend(s): - Dot - GHC - GHCNoMain - HTML - JS - LaTeX - QuickLaTeX" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")


### PR DESCRIPTION
- **Testsuite: replace special logic for #5101 by empty .agda placeholders**
- **Make BackendName a Text rather than a String**

Main motivation for this refactoring was to consistently enforce the type synonym `BackendName`; so I changed it from `String` to `Text`.
In the long run, we should deprecate `String` for `Text` everywhere, but this will be another mammut refactoring.
Also changed the "installed backends" list into a bullet list in the error for non-existing backend.