### PR TITLE
Match display forms in the right context

### DIFF
--- a/src/full/Agda/TypeChecking/DisplayForm.hs
+++ b/src/full/Agda/TypeChecking/DisplayForm.hs
@@ -122,7 +122,7 @@ matchDisplayForm d@(Display n ps v) es
       --
       -- should work (it didn't; see LiftDisplayIntermediate). In
       -- effect, this is because the LHS patterns are in some context
-      -- "Γ . @0", but the LHS term is only in context Γ.
+      -- "Γ . @0", but the RHS term is only in context Γ.
       --
       -- Therefore, we should raise the RHS term by the number of
       -- pattern variables, to bring it into the context of the

--- a/test/Fail/LiftDisplayIntermediate.agda
+++ b/test/Fail/LiftDisplayIntermediate.agda
@@ -1,0 +1,26 @@
+module LiftDisplayIntermediate where
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+open Agda.Primitive renaming (Set to Type)
+
+record Foo : Type where
+  field
+    f : Nat
+
+module _ (f : Nat → Foo) where
+  module _ n where
+    open Foo (f n) renaming (f to g) public
+    -- we get a display form [0] Foo.f (@1 @0) --> g @0
+
+  -- out here, we have [1] Foo.f (@1 @0) --> g @0, with the 'n' argument
+  -- of the inner module having become a pattern variable
+
+  _ : g zero ≡ zero
+  _ = refl
+
+  -- the nontrivial term above is Foo.f (@0 zero), and should display as g zero
+  -- previously, this would fail matching, since @1 (on the pattern) ≠ @0 (on the rhs).
+  -- however, note that the lhs of the display form has one more variable than the scope we're trying to use it in!
+  -- so really we should match [@1 @0] = [@1 zero], lifting the rhs by 1, which does succeed with @0 := zero
+  -- so the error printed should be g zero != zero of type Nat

--- a/test/Fail/LiftDisplayIntermediate.err
+++ b/test/Fail/LiftDisplayIntermediate.err
@@ -1,0 +1,3 @@
+LiftDisplayIntermediate.agda:20,7-11: error: [UnequalTerms]
+g zero != zero of type Nat
+when checking that the expression refl has type g zero ≡ zero


### PR DESCRIPTION
Surprisingly, in

```agda

module _ (f : Nat → Foo) where
  module _ n where open Foo (f n) renaming (f to g) public
  _ = {! g 10  !}
```

the normal form of `g 10` prints as `Foo.f (f 10)` rather than `g 10`. Display form matching is trying to compare (I've lined up the pattern and the actual eliminations)

```
name        : wip.test110.Foo.f
displayForms: [Display 1 [@1 @0] (wip.test110._._._.f @1 @0)]
arguments   :            [@0 10]
```

which fails, since 0 ≠ 1. The display form has correctly been generalised over `n`, as per #958. However, the pattern and the RHS *exist in different contexts* --- the RHS exists in a context with one variable less than the display form (which binds the pattern variable `@0`). So we really should be lifting the term to the context of the patterns before trying to do matching, and making sure that the matching doesn't depend on the pattern variables later.