### PR TITLE
Named Backend errors instead of GenericError

### DIFF
--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -39,7 +39,6 @@ import Agda.Interaction.FindFile
 import Agda.Interaction.Imports as CheckResult (CheckResult(CheckResult), crInterface, crWarnings, crMode)
 
 import Agda.Syntax.Common (BackendName)
-import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Syntax.Treeless
 
 import Agda.TypeChecking.Errors (getAllWarnings)
@@ -183,9 +182,7 @@ compilerMain backend isMain0 checkResult = inCompilerEnv checkResult $ do
     -- BEWARE: Do not use @optOnlyScopeChecking@ here; it does not authoritatively describe the type-checking mode!
     -- InteractionTop currently may invoke type-checking with scope checking regardless of that flag.
     when (not (scopeCheckingSuffices backend) && crMode checkResult == ModuleScopeChecked) $
-      genericDocError $
-        "The --only-scope-checking flag cannot be combined with" P.<+>
-        (P.pretty (backendName backend) <> ".")
+      typeError $ BackendDoesNotSupportOnlyScopeChecking $ backendName backend
 
     !i <- instantiateFull $ crInterface checkResult
     -- Andreas, 2017-08-23, issue #2714

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -24,9 +24,9 @@ import Control.DeepSeq
 import Control.Monad.Trans        ( lift )
 import Control.Monad.Trans.Maybe
 
-import qualified Data.List as List
 import Data.Maybe
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 
 import System.Console.GetOpt
 
@@ -75,12 +75,9 @@ callBackend name iMain checkResult = lookupBackend name >>= \case
   Just (Backend b) -> compilerMain b iMain checkResult
   Nothing -> do
     backends <- useTC stBackends
-    genericDocError $ P.vcat $ concat
-      [ [ P.hcat [ "No backend called '", P.pretty name, "' " ] ]
-      , [ "Installed backend(s):" ]
-      , map (("-" P.<+>) . P.pretty) $ List.sort $
+    let backendSet = Set.fromList $
           otherBackends ++ [ backendName b | Backend b <- backends ]
-      ]
+    typeError $ UnknownBackend name backendSet
 
 -- | Backends that are not included in the state, but still available
 --   to the user.

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -85,6 +85,7 @@ data ErrorName
   | AmbiguousTopLevelModuleName_
   | AsPatternInPatternSynonym_
   | AttributeKindNotEnabled_
+  | BackendDoesNotSupportOnlyScopeChecking_
   | BadArgumentsToPatternSynonym_
   | BuiltinInParameterisedModule_
   | BuiltinMustBeConstructor_

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -243,6 +243,7 @@ data ErrorName
   | UnexpectedParameter_
   | UnexpectedTypeSignatureForParameter_
   | UnexpectedWithPatterns_
+  | UnknownBackend_
   | UnusableAtModality_
   | UnusedVariableInPatternSynonym_
   | VariableIsErased_

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1466,6 +1466,12 @@ instance PrettyTCM TypeError where
 
     QualifiedLocalModule -> fwords "Local modules cannot have qualified names"
 
+    BackendDoesNotSupportOnlyScopeChecking backend -> fsep $ concat
+      [ pwords "The backend"
+      , [ prettyTCM backend ]
+      , pwords "does not support --only-scope-checking."
+      ]
+
     UnknownBackend backend backends -> pure $ P.vcat $ concat
       [ [ P.hcat [ "No backend called '", P.pretty backend, "' " ] ]
       , [ "Installed backend(s):" ]

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1466,6 +1466,12 @@ instance PrettyTCM TypeError where
 
     QualifiedLocalModule -> fwords "Local modules cannot have qualified names"
 
+    UnknownBackend backend backends -> pure $ P.vcat $ concat
+      [ [ P.hcat [ "No backend called '", P.pretty backend, "' " ] ]
+      , [ "Installed backend(s):" ]
+      , map (("-" P.<+>) . P.pretty) $ Set.toAscList backends
+      ]
+
     CustomBackendError backend err -> (text backend <> ":") <?> pure err
 
     GHCBackendError err -> prettyTCM err

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -209,6 +209,7 @@ typeErrorName = \case
   UnexpectedParameter                                        {} -> UnexpectedParameter_
   UnexpectedTypeSignatureForParameter                        {} -> UnexpectedTypeSignatureForParameter_
   UnexpectedWithPatterns                                     {} -> UnexpectedWithPatterns_
+  UnknownBackend                                             {} -> UnknownBackend_
   UnusableAtModality                                         {} -> UnusableAtModality_
   UnusedVariableInPatternSynonym                             {} -> UnusedVariableInPatternSynonym_
   VariableIsErased                                           {} -> VariableIsErased_

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -54,6 +54,7 @@ typeErrorName = \case
   AmbiguousTopLevelModuleName                                {} -> AmbiguousTopLevelModuleName_
   AsPatternInPatternSynonym                                  {} -> AsPatternInPatternSynonym_
   AttributeKindNotEnabled                                    {} -> AttributeKindNotEnabled_
+  BackendDoesNotSupportOnlyScopeChecking                     {} -> BackendDoesNotSupportOnlyScopeChecking_
   BadArgumentsToPatternSynonym                               {} -> BadArgumentsToPatternSynonym_
   BuiltinInParameterisedModule                               {} -> BuiltinInParameterisedModule_
   BuiltinMustBeConstructor                                   {} -> BuiltinMustBeConstructor_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5025,6 +5025,8 @@ data TypeError
     -- Interaction errors
         | InteractionError InteractionError
     -- Backend errors
+        | BackendDoesNotSupportOnlyScopeChecking BackendName
+            -- ^ The given backend does not support @--only-scope-checking@.
         | CubicalCompilationNotSupported Cubical
             -- ^ NYI: Compilation of files using the given flavor of 'Cubical'.
         | CustomBackendError String Doc

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5031,6 +5031,8 @@ data TypeError
             -- ^ Used for backend-specific errors. The string is the backend name.
         | GHCBackendError GHCBackendError
             -- ^ Errors raised by the GHC backend.
+        | UnknownBackend BackendName (Set BackendName)
+            -- ^ Unknown backend requested, known ones are in the 'Set'.
           deriving (Show, Generic)
 
 -- | Errors raised in @--interaction@ mode.

--- a/test/Fail/OnlyScopeCheckingGHC.agda
+++ b/test/Fail/OnlyScopeCheckingGHC.agda
@@ -1,0 +1,6 @@
+-- Andreas, 2024-09-09 issue #5101 and commit 08c553acdc7d5aa1cde0842c287d73e5561b18c1
+-- Trigger error for backend not supporting --only-scope-checking
+-- that is not already caught in Agda.Main.getInteractor.
+
+-- Expected error:
+-- The backend GHC does not support --only-scope-checking.

--- a/test/Fail/OnlyScopeCheckingGHC.err
+++ b/test/Fail/OnlyScopeCheckingGHC.err
@@ -1,0 +1,2 @@
+error: [BackendDoesNotSupportOnlyScopeChecking]
+The backend GHC does not support --only-scope-checking.

--- a/test/Fail/OnlyScopeCheckingGHC.flags
+++ b/test/Fail/OnlyScopeCheckingGHC.flags
@@ -1,0 +1,1 @@
+--only-scope-checking --ghc

--- a/test/Fail/OnlyScopeCheckingJS.agda
+++ b/test/Fail/OnlyScopeCheckingJS.agda
@@ -1,0 +1,6 @@
+-- Andreas, 2024-09-09 issue #5101 and commit 08c553acdc7d5aa1cde0842c287d73e5561b18c1
+-- Trigger error for backend not supporting --only-scope-checking
+-- that is not already caught in Agda.Main.getInteractor.
+
+-- Expected error:
+-- The backend JS does not support --only-scope-checking.

--- a/test/Fail/OnlyScopeCheckingJS.err
+++ b/test/Fail/OnlyScopeCheckingJS.err
@@ -1,0 +1,2 @@
+error: [BackendDoesNotSupportOnlyScopeChecking]
+The backend JS does not support --only-scope-checking.

--- a/test/Fail/OnlyScopeCheckingJS.flags
+++ b/test/Fail/OnlyScopeCheckingJS.flags
@@ -1,0 +1,1 @@
+--only-scope-checking --js

--- a/test/interaction/Issue2905.out
+++ b/test/interaction/Issue2905.out
@@ -7,6 +7,6 @@
 (agda2-status-action "")
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
-(agda2-info-action "*Error*" "error: [GenericDocError] No backend called 'NonExistingBackend' Installed backend(s): - Dot - GHC - GHCNoMain - HTML - JS - LaTeX - QuickLaTeX" nil)
+(agda2-info-action "*Error*" "error: [UnknownBackend] No backend called 'NonExistingBackend' Installed backend(s): - Dot - GHC - GHCNoMain - HTML - JS - LaTeX - QuickLaTeX" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")


### PR DESCRIPTION
- **New error UnknownBackend instead of GenericError**
- **New error BackendDoesNotSupportOnlyScopeChecking plus reproducers**
