### PR TITLE
Some named scope errors replacing GenericError

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -61,7 +61,7 @@ import Agda.Syntax.TopLevelModuleName
 
 import Agda.TypeChecking.Datatypes
 import Agda.TypeChecking.Primitive (getBuiltinName)
-import Agda.TypeChecking.Pretty hiding ((<>))
+import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Warnings

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -233,6 +233,7 @@ import Agda.Utils.Monad         ( tell1 )
 import Agda.Utils.Null
 import Agda.Utils.ProfileOptions
 import Agda.Utils.String        ( unwords1 )
+import qualified Agda.Utils.String       as String
 import Agda.Utils.Trie          ( Trie )
 import qualified Agda.Utils.Trie as Trie
 import Agda.Utils.TypeLits
@@ -1487,7 +1488,7 @@ standardOptions =
 
     , Option ['?']  ["help"]    (OptArg helpFlag "TOPIC") $ concat
                     [ "print help and exit; available "
-                    , singPlural allHelpTopics "TOPIC" "TOPICs"
+                    , String.pluralS allHelpTopics "TOPIC"
                     , ": "
                     , intercalate ", " $ map fst allHelpTopics
                     ]
@@ -1956,14 +1957,12 @@ getOptSimple argv opts fileArg = \ defaults ->
     (_, _, unrecognized, errs) -> throwError $ umsg ++ emsg
 
       where
-      ucap = "Unrecognized " ++ plural unrecognized "option" ++ ":"
-      ecap = plural errs "Option error" ++ ":"
+      ucap = "Unrecognized " ++ String.pluralS unrecognized "option" ++ ":"
+      ecap = String.pluralS errs "Option error" ++ ":"
       umsg = if null unrecognized then "" else unlines $
        ucap : map suggest unrecognized
       emsg = if null errs then "" else unlines $
        ecap : errs
-      plural [_] x = x
-      plural _   x = x ++ "s"
 
       -- Suggest alternatives that are at most 3 typos away
 

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -198,6 +198,7 @@ data ErrorName
   | PatternInPathLambda_
   | PatternInSystem_
   | PatternSynonymArgumentShadowsConstructorOrPatternSynonym_
+  | PrivateRecordField_
   | ProjectionIsIrrelevant_
   | QualifiedLocalModule_
   | QuantityMismatch_

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -107,6 +107,7 @@ data ErrorName
   | CubicalPrimitiveNotFullyApplied_
   | CyclicModuleDependency_
   | DeBruijnIndexOutOfScope_
+  | DeclarationsAfterTopLevelModule_
   | DefinitionInDifferentModule_
   | DefinitionIsErased_
   | DefinitionIsIrrelevant_

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -11,6 +11,16 @@ import Agda.Utils.Function    ( applyWhenJust )
 import Agda.Utils.List        ( initWithDefault )
 import Agda.Utils.Impossible  ( __IMPOSSIBLE__ )
 
+-- | What kind of declaration?
+--
+--   See also 'Agda.Syntax.Concrete.Definitions.Types.DataRecOrFun'.
+
+data DataRecOrFun_
+  = DataName_  -- ^ Name of a data type.
+  | RecName_   -- ^ Name of a record type.
+  | FunName_   -- ^ Name of a function.
+  deriving (Show, Generic, Enum, Bounded)
+
 -- | The reason for an 'ErasedDatatype' error.
 
 data ErasedDatatypeReason
@@ -158,6 +168,7 @@ data ErrorName
   | MetaIrrelevantSolution_
   | MetaOccursInItself_
   | MismatchedProjectionsError_
+  | MissingTypeSignature_ DataRecOrFun_
   | ModuleArityMismatch_
   | ModuleDefinedInOtherFile_
   | ModuleNameDoesntMatchFileName_
@@ -366,10 +377,17 @@ errorNameString = \case
   NicifierError_          err -> "Syntax." ++ declarationExceptionNameString err
   SplitError_             err -> "SplitError." ++ splitErrorNameString err
   UnquoteError_           err -> "Unquote." ++ unquoteErrorNameString err
+  MissingTypeSignature_    err -> "MissingTypeSignature." ++ dataRecOrFunString err
   NotAllowedInDotPatterns_ err -> "NotAllowedInDotPatterns." ++ notAllowedInDotPatternsString err
   NotAValidLetBinding_    merr -> applyWhenJust merr (\ err hd -> hd ++ "." ++ notAValidLetBindingString err) "NotAValidLetBinding"
   NotAValidLetExpression_  err -> "NotAValidLetExpression." ++ notAValidLetExpressionString err
   err -> defaultErrorNameString err
+
+dataRecOrFunString :: DataRecOrFun_ -> String
+dataRecOrFunString = \case
+  DataName_ -> "Data"
+  RecName_  -> "Record"
+  FunName_  -> "Function"
 
 declarationExceptionNameString :: DeclarationException_ -> String
 declarationExceptionNameString = \case

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -134,6 +134,7 @@ data ErrorName
   | IdiomBracketError_
   | InvalidDottedExpression_
   | IllTypedPatternAfterWithAbstraction_
+  | IllegalDeclarationBeforeTopLevelModule_
   | IllegalDeclarationInDataDefinition_
   | IllegalHidingInPostfixProjection_
   | IllegalInstanceVariableInPatternSynonym_

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -202,6 +202,7 @@ data ErrorName
   | RecursiveRecordNeedsInductivity_
   | ReferencesFutureVariables_
   | RelevanceMismatch_
+  | RepeatedNamesInImportDirective_
   | RepeatedVariablesInPattern_
   | ShadowedModule_
   | ShouldBeASort_

--- a/src/full/Agda/Syntax/Common/Pretty.hs
+++ b/src/full/Agda/Syntax/Common/Pretty.hs
@@ -264,6 +264,9 @@ pshow = text . show
 singPlural :: Sized a => a -> c -> c -> c
 singPlural xs singular plural = if natSize xs == 1 then singular else plural
 
+pluralS :: Sized a => a -> Doc -> Doc
+pluralS xs d = singPlural xs d (d <> "s")
+
 -- | Used for with-like 'telescopes'
 
 prefixedThings :: Doc -> [Doc] -> Doc

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1366,8 +1366,7 @@ instance ToAbstract (TopLevel [C.Declaration]) where
                          void $ toAbstract (Declarations outsideDecls)
                          void $ toAbstract (Declarations ds0)
                          -- Fail with a crude error otherwise
-                         setCurrentRange ds0 $ genericError
-                           "Illegal declaration(s) before top-level module"
+                         setCurrentRange ds0 $ typeError IllegalDeclarationBeforeTopLevelModule
 
                     -- Otherwise, reconstruct the top-level module name
                     _ -> do

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1700,7 +1700,7 @@ instance ToAbstract NiceDeclaration where
 
   -- Fields
     C.NiceField r p a i tac x t -> do
-      unless (p == PublicAccess) $ genericError "Record fields can not be private"
+      unless (p == PublicAccess) $ typeError PrivateRecordField
       -- Interaction points for record fields have already been introduced
       -- when checking the type of the record constructor.
       -- To avoid introducing interaction points (IP) twice, we turn

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1799,8 +1799,7 @@ instance ToAbstract NiceDeclaration where
 
   -- Uncategorized function clauses
     C.NiceFunClause _ _ _ _ _ _ (C.FunClause lhs _ _ _) ->
-      genericError $
-        "Missing type signature for left hand side " ++ prettyShow lhs
+      typeError $ MissingTypeSignature $ MissingFunctionSignature lhs
     C.NiceFunClause{} -> __IMPOSSIBLE__
 
   -- Data definitions
@@ -1812,7 +1811,7 @@ instance ToAbstract NiceDeclaration where
             livesInCurrentModule ax  -- Andreas, 2017-12-04, issue #2862
             clashIfModuleAlreadyDefinedInCurrentModule x ax
             return (p, ax)
-          _ -> genericError $ "Missing type signature for data definition " ++ prettyShow x
+          _ -> typeError $ MissingTypeSignature $ MissingDataSignature x
         ensureNoLetStms pars
         withLocalVars $ do
           gvars <- bindGeneralizablesIfInserted o ax
@@ -1860,7 +1859,7 @@ instance ToAbstract NiceDeclaration where
           livesInCurrentModule ax  -- Andreas, 2017-12-04, issue #2862
           clashIfModuleAlreadyDefinedInCurrentModule x ax
           return (p, ax)
-        _ -> genericError $ "Missing type signature for record definition " ++ prettyShow x
+        _ -> typeError $ MissingTypeSignature $ MissingRecordSignature x
       ensureNoLetStms pars
       withLocalVars $ do
         gvars <- bindGeneralizablesIfInserted o ax

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1335,8 +1335,7 @@ instance ToAbstract (TopLevel [C.Declaration]) where
 
         -- If there are declarations after the top-level module
         -- we have to report a parse error here.
-        (_, C.Module{} : d : _) -> setCurrentRange d $
-          genericError $ "No declarations allowed after top-level module."
+        (_, C.Module{} : d : _) -> setCurrentRange d $ typeError DeclarationsAfterTopLevelModule
 
         -- Otherwise, proceed.
         (outsideDecls, [ C.Module r e m0 tel insideDecls ]) -> do

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -299,9 +299,11 @@ checkClauseTelescopeBindings :: MonadReflectedToAbstract m => [(Text, Arg R.Type
 checkClauseTelescopeBindings tel pats =
   case reverse [ x | ((x, _), i) <- zip (reverse tel) [0..], not $ Set.member i bs ] of
     [] -> return ()
-    xs -> genericDocError $ (singPlural xs id (<> "s") "Missing bindings for telescope variable") <?>
-                              (fsep (punctuate ", " $ map (text . Text.unpack) xs) <> ".") $$
-                             "All variables in the clause telescope must be bound in the left-hand side."
+    xs -> genericDocError $ vcat
+      [ fsep (pwords "Missing bindings for telescope" ++ [ pluralS xs "variable" ])
+        <?> (fsep (punctuate ", " $ map (text . Text.unpack) xs) <> ".")
+      , "All variables in the clause telescope must be bound in the left-hand side."
+      ]
   where
     bs = boundVars pats
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -867,6 +867,8 @@ instance PrettyTCM TypeError where
     FieldOutsideRecord -> fsep $
       pwords "Field appearing outside record declaration."
 
+    PrivateRecordField -> fwords "Record fields cannot be private"
+
     InvalidPattern p -> fsep $
       pretty p : pwords "is not a valid pattern"
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -873,6 +873,14 @@ instance PrettyTCM TypeError where
     RepeatedVariablesInPattern xs -> fsep $
       pwords "Repeated variables in pattern:" ++ map pretty xs
 
+    RepeatedNamesInImportDirective yss -> fsep
+      [ fsep $ concat
+         [ [ "Repeated" , pluralS yss "name" ]
+         , pwords "in import directive:"
+         ]
+      , fsep $ punctuate comma $ fmap (prettyTCM . List2.head) yss
+      ]
+
     NotAnExpression e -> fsep $
       pretty e : pwords "is not a valid expression."
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -887,6 +887,8 @@ instance PrettyTCM TypeError where
 
     IllegalDeclarationBeforeTopLevelModule -> fwords $ "Illegal declaration(s) before top-level module"
 
+    MissingTypeSignature info -> fwords "Missing type signature for" <+> prettyTCM info
+
     NotAnExpression e -> fsep $
       pretty e : pwords "is not a valid expression."
 
@@ -1632,6 +1634,13 @@ instance PrettyTCM UnquoteError where
       pwords "Cannot unquote pattern lambda without clauses. Use a single `absurd-clause` for absurd lambdas."
 
     UnquotePanic err -> __IMPOSSIBLE__
+
+instance PrettyTCM MissingTypeSignatureInfo where
+  prettyTCM = \case
+    MissingDataSignature x       -> fsep [ "data"  , "definition", prettyTCM x ]
+    MissingRecordSignature x     -> fsep [ "record", "definition", prettyTCM x ]
+    MissingFunctionSignature lhs -> fsep [ "left", "hand", "side", prettyTCM lhs ]
+
 
 notCmp :: MonadPretty m => Comparison -> m Doc
 notCmp cmp = "!" <> prettyTCM cmp

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -883,6 +883,8 @@ instance PrettyTCM TypeError where
 
     DeclarationsAfterTopLevelModule -> fwords $ "No declarations allowed after top-level module."
 
+    IllegalDeclarationBeforeTopLevelModule -> fwords $ "Illegal declaration(s) before top-level module"
+
     NotAnExpression e -> fsep $
       pretty e : pwords "is not a valid expression."
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -83,6 +83,7 @@ import Agda.Utils.Lens
 import Agda.Utils.List   ( initLast, lastMaybe )
 import Agda.Utils.List1 (List1, pattern (:|))
 import qualified Agda.Utils.List1 as List1
+import qualified Agda.Utils.List2 as List2
 import Agda.Utils.Maybe
 import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty ( prettyShow, render )
@@ -566,11 +567,12 @@ instance PrettyTCM TypeError where
 
     TooManyFields r missing xs -> prettyTooManyFields r missing xs
 
-    DuplicateConstructors xs -> fsep $
-      pwords "Duplicate" ++ constructors xs ++ punctuate comma (map pretty xs) ++
-      pwords "in datatype"
-      where
-      constructors ys = P.singPlural ys [text "constructor"] [text "constructors"]
+    DuplicateConstructors xs -> fsep $ concat
+      [ [ "Duplicate" ]
+      , [ pluralS xs "constructor" ]
+      , punctuate comma (map pretty xs)
+      , pwords "in datatype"
+      ]
 
     DuplicateFields xs -> prettyDuplicateFields xs
 
@@ -1402,9 +1404,7 @@ instance PrettyTCM TypeError where
       ]
 
     UnexpectedTypeSignatureForParameter xs -> do
-      let s | length xs > 1 = "s"
-            | otherwise     = ""
-      text ("Unexpected type signature for parameter" ++ s) <+> sep (fmap prettyA xs)
+      fsep (pwords "Unexpected type signature for" ++ [ pluralS xs "parameter" ]) <+> sep (fmap prettyA xs)
 
     UnusableAtModality why mod t -> do
       compatible <- cubicalCompatibleOption
@@ -1718,9 +1718,8 @@ instance PrettyTCM SplitError where
           ]
         , zipWith prEq cIxs gIxs
         , if null errs then [] else
-            fsep ( pwords "Possible" ++ pwords (P.singPlural errs "reason" "reasons") ++
-                     pwords "why unification failed:" ) :
-            map (nest 2 . prettyTCM) errs
+            (fsep $ [ "Possible", pluralS errs "reason" ] ++ pwords "why unification failed:")
+            : map (nest 2 . prettyTCM) errs
         ]
       where
         -- Andreas, 2019-08-08, issue #3943

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -881,6 +881,8 @@ instance PrettyTCM TypeError where
       , fsep $ punctuate comma $ fmap (prettyTCM . List2.head) yss
       ]
 
+    DeclarationsAfterTopLevelModule -> fwords $ "No declarations allowed after top-level module."
+
     NotAnExpression e -> fsep $
       pretty e : pwords "is not a valid expression."
 

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -168,6 +168,7 @@ typeErrorName = \case
   RecursiveRecordNeedsInductivity                            {} -> RecursiveRecordNeedsInductivity_
   ReferencesFutureVariables                                  {} -> ReferencesFutureVariables_
   RelevanceMismatch                                          {} -> RelevanceMismatch_
+  RepeatedNamesInImportDirective                             {} -> RepeatedNamesInImportDirective_
   RepeatedVariablesInPattern                                 {} -> RepeatedVariablesInPattern_
   ShadowedModule                                             {} -> ShadowedModule_
   ShouldBeASort                                              {} -> ShouldBeASort_

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -164,6 +164,7 @@ typeErrorName = \case
   PatternInPathLambda                                        {} -> PatternInPathLambda_
   PatternInSystem                                            {} -> PatternInSystem_
   PatternSynonymArgumentShadowsConstructorOrPatternSynonym   {} -> PatternSynonymArgumentShadowsConstructorOrPatternSynonym_
+  PrivateRecordField                                         {} -> PrivateRecordField_
   ProjectionIsIrrelevant                                     {} -> ProjectionIsIrrelevant_
   QualifiedLocalModule                                       {} -> QualifiedLocalModule_
   QuantityMismatch                                           {} -> QuantityMismatch_

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -23,6 +23,7 @@ typeErrorName = \case
   SplitError               err -> SplitError_            $ splitErrorName                 err
   UnquoteFailed            err -> UnquoteError_          $ unquoteErrorName               err
   -- Parametrized errors
+  MissingTypeSignature    what -> MissingTypeSignature_  $ missingTypeSignatureInfoName   what
   NotAllowedInDotPatterns what -> NotAllowedInDotPatterns_ what
   NotAValidLetBinding     what -> NotAValidLetBinding_     what
   NotAValidLetExpression  what -> NotAValidLetExpression_  what
@@ -273,6 +274,12 @@ interactionErrorName = \case
   NoActionForInteractionPoint{} -> NoActionForInteractionPoint_
   NoSuchInteractionPoint{}      -> NoSuchInteractionPoint_
   UnexpectedWhere{}             -> UnexpectedWhere_
+
+missingTypeSignatureInfoName :: MissingTypeSignatureInfo -> DataRecOrFun_
+missingTypeSignatureInfoName = \case
+  MissingDataSignature      {} -> DataName_
+  MissingRecordSignature    {} -> RecName_
+  MissingFunctionSignature  {} -> FunName_
 
 notAHaskellTypeErrorName :: WhyNotAHaskellType -> NotAHaskellType_
 notAHaskellTypeErrorName = \case

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -76,6 +76,7 @@ typeErrorName = \case
   CubicalPrimitiveNotFullyApplied                            {} -> CubicalPrimitiveNotFullyApplied_
   CyclicModuleDependency                                     {} -> CyclicModuleDependency_
   DeBruijnIndexOutOfScope                                    {} -> DeBruijnIndexOutOfScope_
+  DeclarationsAfterTopLevelModule                            {} -> DeclarationsAfterTopLevelModule_
   DefinitionInDifferentModule                                {} -> DefinitionInDifferentModule_
   DefinitionIsErased                                         {} -> DefinitionIsErased_
   DefinitionIsIrrelevant                                     {} -> DefinitionIsIrrelevant_

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -103,6 +103,7 @@ typeErrorName = \case
   IdiomBracketError                                          {} -> IdiomBracketError_
   InvalidDottedExpression                                    {} -> InvalidDottedExpression_
   IllTypedPatternAfterWithAbstraction                        {} -> IllTypedPatternAfterWithAbstraction_
+  IllegalDeclarationBeforeTopLevelModule                     {} -> IllegalDeclarationBeforeTopLevelModule_
   IllegalDeclarationInDataDefinition                         {} -> IllegalDeclarationInDataDefinition_
   IllegalHidingInPostfixProjection                           {} -> IllegalHidingInPostfixProjection_
   IllegalInstanceVariableInPatternSynonym                    {} -> IllegalInstanceVariableInPatternSynonym_

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -799,7 +799,7 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
         , nest 2 $ sep $ ["- Further information"
                          , nest 2 $ "-" <+> order ] ++
                          [ nest 2 $ "-" <+> fwords guess | not (null late), not (null early) ] ++
-                         [ nest 2 $ "-" <+> sep [ fwords "The dependency I error is", prettyTCM err' ] ]
+                         [ nest 2 $ "-" <+> sep [ fwords "The dependency error is", prettyTCM err' ] ]
         ]
 
     addNamedVariablesToScope cxt =

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -788,7 +788,8 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
                         nest 2 $ fwords (unwords names) ]
           guess = unwords
             [ "After constraint solving it looks like", commas late
-            , singPlural late (++ "s") id "actually depend"
+            , "actually"
+            , singPlural late (<> "s") id "depend"  -- NB: this is a singular "s"
             , "on", commas $ Set.toList early
             ]
       genericDocError =<< vcat

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4959,6 +4959,7 @@ data TypeError
         | MultipleFixityDecls [(C.Name, [Fixity'])]
         | MultiplePolarityPragmas [C.Name]
     -- Concrete to Abstract errors
+        | DeclarationsAfterTopLevelModule
         | NotAnExpression C.Expr
         | NotAValidLetBinding (Maybe NotAValidLetBinding)
         | NotAValidLetExpression NotAValidLetExpression

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4961,6 +4961,7 @@ data TypeError
     -- Concrete to Abstract errors
         | DeclarationsAfterTopLevelModule
         | IllegalDeclarationBeforeTopLevelModule
+        | MissingTypeSignature MissingTypeSignatureInfo
         | NotAnExpression C.Expr
         | NotAValidLetBinding (Maybe NotAValidLetBinding)
         | NotAValidLetExpression NotAValidLetExpression
@@ -5069,6 +5070,16 @@ data GHCBackendError
       -- ^ GHC backend fails to represent given Agda type in Haskell.
   | WrongTypeOfMain QName Type
       -- ^ The type of @main@ should be @IO _@ ('QName') but is instead 'Type'.
+  deriving (Show, Generic)
+
+-- | Extra information for 'MissingTypeSignature' error.
+data MissingTypeSignatureInfo
+  = MissingDataSignature     C.Name
+      -- ^ The @data@ definition for 'C.Name' lacks a data signature.
+  | MissingRecordSignature   C.Name
+      -- ^ The @record@ definition for 'C.Name' lacks a record signature.
+  | MissingFunctionSignature C.LHS
+      -- ^ The function lhs misses a type signature.
   deriving (Show, Generic)
 
 -- | Extra information for 'NotAHaskellType' error.
@@ -6272,6 +6283,7 @@ instance NFData InductionAndEta
 instance NFData IllegalRewriteRuleReason
 instance NFData IncorrectTypeForRewriteRelationReason
 instance NFData GHCBackendError
+instance NFData MissingTypeSignatureInfo
 instance NFData WhyNotAHaskellType
 instance NFData InteractionError
 instance NFData IsAmbiguous

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4968,6 +4968,7 @@ data TypeError
         | NothingAppliedToHiddenArg C.Expr
         | NothingAppliedToInstanceArg C.Expr
         | OpenEverythingInRecordWhere
+        | PrivateRecordField
         | QualifiedLocalModule
     -- Pattern synonym errors
         | AsPatternInPatternSynonym

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4951,6 +4951,8 @@ data TypeError
             -- ^ The given data/record definition rests in a different module than its signature.
         | DuplicateImports C.QName [C.ImportedName]
         | InvalidPattern C.Pattern
+        | RepeatedNamesInImportDirective (List1 (List2 C.ImportedName))
+            -- ^ Some names are bound several times by an @import@/@open@ directive.
         | RepeatedVariablesInPattern [C.Name]
         | GeneralizeNotSupportedHere A.QName
         | GeneralizedVarInLetOpenedModule A.QName

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4960,6 +4960,7 @@ data TypeError
         | MultiplePolarityPragmas [C.Name]
     -- Concrete to Abstract errors
         | DeclarationsAfterTopLevelModule
+        | IllegalDeclarationBeforeTopLevelModule
         | NotAnExpression C.Expr
         | NotAValidLetBinding (Maybe NotAValidLetBinding)
         | NotAValidLetExpression NotAValidLetExpression

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -22,6 +22,8 @@ import Data.Text      (Text)
 
 import Agda.Syntax.Position
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty ( Pretty, prettyShow )
+import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Syntax.Fixity
 import Agda.Syntax.Internal
 import Agda.Syntax.Literal
@@ -55,10 +57,8 @@ import Agda.Utils.Maybe
 import Agda.Utils.Null
 import Agda.Utils.Trie
 import Agda.Utils.Permutation ( Permutation )
-import Agda.Syntax.Common.Pretty      ( Pretty, prettyShow )
-import qualified Agda.Syntax.Common.Pretty as P
 import qualified Agda.Utils.Maybe.Strict as S
-import Agda.Utils.Size        ( natSize )
+import Agda.Utils.Size ( Sized, natSize )
 
 import Agda.Utils.Impossible
 
@@ -133,6 +133,9 @@ quotes         d = P.quotes         <$> d
 
 pshow :: (Applicative m, Show a) => a -> m Doc
 pshow = pure . P.pshow
+
+pluralS :: (Functor m, Sized a) => a -> m Doc -> m Doc
+pluralS xs = (P.pluralS xs <$>)
 
 -- | Comma-separated list in brackets.
 prettyList :: (Applicative m, Semigroup (m Doc), Foldable t) => t (m Doc) -> m Doc

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -186,6 +186,7 @@ instance PrettyTCM Bool                       where prettyTCM = pretty
 instance PrettyTCM C.Name                     where prettyTCM = pretty
 instance PrettyTCM C.QName                    where prettyTCM = pretty
 instance PrettyTCM C.ImportedName             where prettyTCM = pretty
+instance PrettyTCM C.LHS                      where prettyTCM = pretty
 instance PrettyTCM TopLevelModuleName         where prettyTCM = pretty
 instance PrettyTCM Comparison                 where prettyTCM = pretty
 instance PrettyTCM Literal                    where prettyTCM = pretty
@@ -202,6 +203,7 @@ instance PrettyTCM InteractionId              where prettyTCM = pretty
 {-# SPECIALIZE prettyTCM :: C.Name             -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: C.QName            -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: C.ImportedName     -> TCM Doc #-}
+{-# SPECIALIZE prettyTCM :: C.LHS              -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: TopLevelModuleName -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: Comparison         -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: Literal            -> TCM Doc #-}

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -185,6 +185,7 @@ instance PrettyTCM Text                       where prettyTCM = pretty
 instance PrettyTCM Bool                       where prettyTCM = pretty
 instance PrettyTCM C.Name                     where prettyTCM = pretty
 instance PrettyTCM C.QName                    where prettyTCM = pretty
+instance PrettyTCM C.ImportedName             where prettyTCM = pretty
 instance PrettyTCM TopLevelModuleName         where prettyTCM = pretty
 instance PrettyTCM Comparison                 where prettyTCM = pretty
 instance PrettyTCM Literal                    where prettyTCM = pretty
@@ -200,6 +201,7 @@ instance PrettyTCM InteractionId              where prettyTCM = pretty
 {-# SPECIALIZE prettyTCM :: Bool               -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: C.Name             -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: C.QName            -> TCM Doc #-}
+{-# SPECIALIZE prettyTCM :: C.ImportedName     -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: TopLevelModuleName -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: Comparison         -> TCM Doc #-}
 {-# SPECIALIZE prettyTCM :: Literal            -> TCM Doc #-}

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -1,7 +1,6 @@
 
 module Agda.TypeChecking.Pretty
     ( module Agda.TypeChecking.Pretty
-    , module Data.Semigroup -- This re-export can be removed once <GHC-8.4 is dropped.
     , module Reexport
     ) where
 

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -7,11 +7,12 @@ import Prelude hiding ( null )
 import Agda.Syntax.Abstract as A
 import Agda.Syntax.Abstract.Views
 import Agda.Syntax.Common
-import Agda.Syntax.Fixity
+import qualified Agda.Syntax.Common.Pretty as P
 import qualified Agda.Syntax.Concrete.Definitions as D
 import qualified Agda.Syntax.Info as A
-import Agda.Syntax.Position
+import Agda.Syntax.Fixity
 import Agda.Syntax.Internal
+import Agda.Syntax.Position
 import Agda.Syntax.Scope.Monad
 import Agda.Syntax.Translation.AbstractToConcrete
 
@@ -23,7 +24,6 @@ import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Pretty
 
 import Agda.Utils.Null
-import qualified Agda.Syntax.Common.Pretty as P
 
 import Agda.Utils.Impossible
 
@@ -193,13 +193,10 @@ instance PrettyTCM Call where
     ScopeCheckExpr e -> fsep $ pwords "when scope checking" ++ [pretty e]
 
     ScopeCheckDeclaration d ->
-      fwords ("when scope checking the declaration" ++ suffix) $$
+      fsep (pwords "when scope checking the" ++ [ pluralS ds "declaration" ]) $$
       nest 2 (vcat $ map pretty ds)
       where
       ds     = D.notSoNiceDeclarations d
-      suffix = case ds of
-        [_] -> ""
-        _   -> "s"
 
     ScopeCheckLHS x p ->
       fsep $ pwords "when scope checking the left-hand side" ++ [pretty p] ++

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -408,7 +408,7 @@ data ElimType
 instance PrettyTCM ElimType where
   prettyTCM (ArgT a)    = prettyTCM a
   prettyTCM (ProjT a b) =
-    "." TCM.<> parens (prettyTCM a <+> "->" <+> prettyTCM b)
+    "." <> parens (prettyTCM a <+> "->" <+> prettyTCM b)
 
 -- | Given a head and its type, compute the types of the eliminations.
 

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -582,8 +582,8 @@ fastDistinct xs = Set.size (Set.fromList xs) == length xs
 duplicates :: Ord a => [a] -> [a]
 duplicates = mapMaybe dup . Bag.groups . Bag.fromList
   where
-    dup (a : _ : _) = Just a
-    dup _           = Nothing
+    dup (a :| _ : _) = Just a
+    dup _            = Nothing
 
 -- | Remove the first representative for each list element.
 --   Thus, returns all duplicate copies.
@@ -591,7 +591,7 @@ duplicates = mapMaybe dup . Bag.groups . Bag.fromList
 --
 --   @allDuplicates xs == sort $ xs \\ nub xs@.
 allDuplicates :: Ord a => [a] -> [a]
-allDuplicates = concatMap (drop 1 . reverse) . Bag.groups . Bag.fromList
+allDuplicates = concatMap (List1.tail . List1.reverse) . Bag.groups . Bag.fromList
   -- The reverse is necessary to actually remove the *first* occurrence
   -- of each element.
 

--- a/src/full/Agda/Utils/String.hs
+++ b/src/full/Agda/Utils/String.hs
@@ -12,8 +12,10 @@ import Data.Char
 import qualified Data.List as List
 import Data.String
 
+import Agda.Utils.Function (applyUnless)
 import Agda.Utils.List
 import Agda.Utils.List1 (String1, fromList)
+import Agda.Utils.Size  (Sized, natSize)
 
 instance IsString String1 where
   fromString = fromList
@@ -88,6 +90,11 @@ indent i = unlines . map (List.genericReplicate i ' ' ++) . lines
 
 unwords1 :: [String] -> String
 unwords1 = unwords . filter (not . null)
+
+-- | Append an @"s"@ to the second argument if the first has cardinality @/= 1@.
+
+pluralS :: Sized a => a -> String -> String
+pluralS xs = applyUnless (natSize xs == 1) (++ "s")
 
 -- | Show a number using comma to separate powers of 1,000.
 

--- a/test/Bugs/NakedEllipsisWeirdError.err
+++ b/test/Bugs/NakedEllipsisWeirdError.err
@@ -1,7 +1,7 @@
 AGDA_FAILURE
 
 ret > ExitFailure 42
-out > NakedEllipsisWeirdError.agda:3,1-4: error: [GenericError]
+out > NakedEllipsisWeirdError.agda:3,1-4: error: [MissingTypeSignature.Function]
 out > Missing type signature for left hand side ...
 out > when scope checking the declaration
 out >   ...

--- a/test/Fail/Issue1077.err
+++ b/test/Fail/Issue1077.err
@@ -1,2 +1,2 @@
-Issue1077.agda:6,1-10: error: [GenericError]
+Issue1077.agda:6,1-10: error: [IllegalDeclarationBeforeTopLevelModule]
 Illegal declaration(s) before top-level module

--- a/test/Fail/Issue1077Main.err
+++ b/test/Fail/Issue1077Main.err
@@ -1,4 +1,4 @@
-Issue1077.agda:6,1-10: error: [GenericError]
+Issue1077.agda:6,1-10: error: [IllegalDeclarationBeforeTopLevelModule]
 Illegal declaration(s) before top-level module
 when scope checking the declaration
   open import Issue1077

--- a/test/Fail/Issue1388.agda
+++ b/test/Fail/Issue1388.agda
@@ -4,4 +4,7 @@ module Issue1388 where
 
   indented = Set
 
-not-indented = Set  -- This should be a parse error.
+not-indented = Set
+
+-- Expected error:
+-- No declarations allowed after top-level module.

--- a/test/Fail/Issue1388.err
+++ b/test/Fail/Issue1388.err
@@ -1,2 +1,2 @@
-Issue1388.agda:7,1-19: error: [GenericError]
+Issue1388.agda:7,1-19: error: [DeclarationsAfterTopLevelModule]
 No declarations allowed after top-level module.

--- a/test/Fail/Issue2576MissingData.err
+++ b/test/Fail/Issue2576MissingData.err
@@ -1,4 +1,4 @@
-Issue2576MissingData.agda:3,1-13: error: [GenericError]
+Issue2576MissingData.agda:3,1-13: error: [MissingTypeSignature.Data]
 Missing type signature for data definition A
 when scope checking the declaration
   data A where

--- a/test/Fail/Issue2808.err
+++ b/test/Fail/Issue2808.err
@@ -1,2 +1,2 @@
-Issue2808.agda:6,1-18: error: [GenericError]
+Issue2808.agda:6,1-18: error: [IllegalDeclarationBeforeTopLevelModule]
 Illegal declaration(s) before top-level module

--- a/test/Fail/Issue3331.err
+++ b/test/Fail/Issue3331.err
@@ -1,4 +1,4 @@
-Issue3331.agda:5,38-58: error: [GenericError]
+Issue3331.agda:5,38-58: error: [RepeatedNamesInImportDirective]
 Repeated name in import directive: true
 when scope checking the declaration
   open import Agda.Builtin.Bool using (true) renaming (true to tt)

--- a/test/Fail/Issue3655b.agda
+++ b/test/Fail/Issue3655b.agda
@@ -17,3 +17,6 @@ variable
 
 postulate
   f : D x → (P : F b → Set) → P x
+
+-- Expected error:
+-- Variable generalization failed.

--- a/test/Fail/Issue3655b.err
+++ b/test/Fail/Issue3655b.err
@@ -10,7 +10,7 @@ Variable generalization failed.
   - Further information
     - Dependency analysis suggested this (likely incorrect) order: x b
     - After constraint solving it looks like x actually depends on b
-    - The dependency I error is
+    - The dependency error is
       Issue3655b.agda:19,9-10: error: [GenericDocError]
       Cannot instantiate the metavariable _x.b_21 to solution b
       since it contains the variable genTel

--- a/test/Fail/Issue477.err
+++ b/test/Fail/Issue477.err
@@ -1,4 +1,4 @@
-Issue477.agda:4,1-5,8: error: [GenericError]
+Issue477.agda:4,1-5,8: error: [MissingTypeSignature.Data]
 Missing type signature for data definition D
 when scope checking the declaration
   data D where

--- a/test/Fail/Issue477b.err
+++ b/test/Fail/Issue477b.err
@@ -1,4 +1,4 @@
-Issue477b.agda:4,1-5,16: error: [GenericError]
+Issue477b.agda:4,1-5,16: error: [MissingTypeSignature.Record]
 Missing type signature for record definition D
 when scope checking the declaration
   record D where

--- a/test/Fail/Issue4888.err
+++ b/test/Fail/Issue4888.err
@@ -1,4 +1,4 @@
-Issue4888.agda:3,1-23: error: [GenericError]
+Issue4888.agda:3,1-23: error: [MissingTypeSignature.Function]
 Missing type signature for left hand side impor Agda.Builtin.Nat
 when scope checking the declaration
   impor Agda.Builtin.Nat

--- a/test/Fail/Issue580.err
+++ b/test/Fail/Issue580.err
@@ -1,4 +1,4 @@
-Issue580.agda:5,17-24: error: [GenericError]
-Record fields can not be private
+Issue580.agda:5,17-24: error: [PrivateRecordField]
+Record fields cannot be private
 when scope checking the declaration
   A : Set

--- a/test/Fail/MissingTypeSignature.err
+++ b/test/Fail/MissingTypeSignature.err
@@ -1,4 +1,4 @@
-MissingTypeSignature.agda:8,1-20: error: [GenericError]
+MissingTypeSignature.agda:8,1-20: error: [MissingTypeSignature.Function]
 Missing type signature for left hand side pred zero
 when scope checking the declaration
   pred zero = zero

--- a/test/Fail/MissingTypeSignatureInMutual.err
+++ b/test/Fail/MissingTypeSignatureInMutual.err
@@ -1,4 +1,4 @@
-MissingTypeSignatureInMutual.agda:9,3-22: error: [GenericError]
+MissingTypeSignatureInMutual.agda:9,3-22: error: [MissingTypeSignature.Function]
 Missing type signature for left hand side pred zero
 when scope checking the declaration
   pred zero = zero

--- a/test/Fail/NoTerminationCheck3.err
+++ b/test/Fail/NoTerminationCheck3.err
@@ -1,4 +1,4 @@
-NoTerminationCheck3.agda:10,1-16: error: [GenericError]
+NoTerminationCheck3.agda:10,1-16: error: [MissingTypeSignature.Function]
 Missing type signature for left hand side f false
 when scope checking the declaration
   f false = false

--- a/test/Fail/ParseError.err
+++ b/test/Fail/ParseError.err
@@ -1,4 +1,4 @@
-ParseError.agda:1,1-23: error: [GenericError]
+ParseError.agda:1,1-23: error: [MissingTypeSignature.Function]
 Missing type signature for left hand side modle ParseError
 when scope checking the declaration
   modle ParseError


### PR DESCRIPTION
New scope errors:

- DeclarationsAfterTopLevelModule
- IllegalDeclarationBeforeTopLevelModule 
- MissingTypeSignature 
- PrivateRecordField  
- RepeatedNamesInImportDirective 

Additional refactorings:
- Agda.Utils.Bag: use List1 to enforce non-emptiness of groups
- Helper Agda.Utils.String.pluralS for default English plural
- No longer reexport Data.Semigroup from Agda.TypeChecking.Pretty
