### PR TITLE
Named scope errors instead of GenericError

### DIFF
--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -212,7 +212,7 @@ data ErrorName
   | OverlappingProjects_
   | PatternInPathLambda_
   | PatternInSystem_
-  | PatternSynonymArgumentShadowsConstructorOrPatternSynonym_
+  | PatternSynonymArgumentShadows_ ConstructorOrPatternSynonym
   | PrivateRecordField_
   | ProjectionIsIrrelevant_
   | QualifiedLocalModule_
@@ -386,6 +386,7 @@ errorNameString = \case
   NotAllowedInDotPatterns_ err -> "NotAllowedInDotPatterns." ++ notAllowedInDotPatternsString err
   NotAValidLetBinding_    merr -> applyWhenJust merr (\ err hd -> hd ++ "." ++ notAValidLetBindingString err) "NotAValidLetBinding"
   NotAValidLetExpression_  err -> "NotAValidLetExpression." ++ notAValidLetExpressionString err
+  PatternSynonymArgumentShadows_ err -> "PatternSynonymArgumentShadows." ++ constructorOrPatternSynonymNameString err
   err -> defaultErrorNameString err
 
 constructorOrPatternSynonymNameString :: ConstructorOrPatternSynonym -> String

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -113,6 +113,7 @@ data ErrorName
   | ConstructorDoesNotTargetGivenType_
   | ConstructorPatternInWrongDatatype_
   | ContradictorySizeConstraint_
+  | CopatternHeadNotProjection_
   | CubicalCompilationNotSupported_
   | CubicalPrimitiveNotFullyApplied_
   | CyclicModuleDependency_

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -7,6 +7,8 @@ import Data.List              ( sort )
 import Generic.Data           ( FiniteEnumeration(..) )
 import GHC.Generics           ( Generic )
 
+import Agda.Syntax.Common     ( ConstructorOrPatternSynonym(..) )
+
 import Agda.Utils.Function    ( applyWhenJust )
 import Agda.Utils.List        ( initWithDefault )
 import Agda.Utils.Impossible  ( __IMPOSSIBLE__ )
@@ -160,6 +162,7 @@ data ErrorName
   | InvalidModalTelescopeUse_
   | InvalidPattern_
   | InvalidProjectionParameter_
+  | InvalidPun_ ConstructorOrPatternSynonym
   | InvalidTypeSort_
   | LibTooFarDown_
   | LiteralTooBig_
@@ -378,11 +381,17 @@ errorNameString = \case
   NicifierError_          err -> "Syntax." ++ declarationExceptionNameString err
   SplitError_             err -> "SplitError." ++ splitErrorNameString err
   UnquoteError_           err -> "Unquote." ++ unquoteErrorNameString err
+  InvalidPun_              err -> "InvalidPun." ++ constructorOrPatternSynonymNameString err
   MissingTypeSignature_    err -> "MissingTypeSignature." ++ dataRecOrFunString err
   NotAllowedInDotPatterns_ err -> "NotAllowedInDotPatterns." ++ notAllowedInDotPatternsString err
   NotAValidLetBinding_    merr -> applyWhenJust merr (\ err hd -> hd ++ "." ++ notAValidLetBindingString err) "NotAValidLetBinding"
   NotAValidLetExpression_  err -> "NotAValidLetExpression." ++ notAValidLetExpressionString err
   err -> defaultErrorNameString err
+
+constructorOrPatternSynonymNameString :: ConstructorOrPatternSynonym -> String
+constructorOrPatternSynonymNameString = \case
+  IsConstructor    -> "Constructor"
+  IsPatternSynonym -> "PatternSynonym"
 
 dataRecOrFunString :: DataRecOrFun_ -> String
 dataRecOrFunString = \case

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -126,6 +126,22 @@ instance NFData Language
 type BackendName = Text
 
 ---------------------------------------------------------------------------
+-- * Some enums
+---------------------------------------------------------------------------
+
+-- | Distinguish constructors from pattern synonyms.
+
+data ConstructorOrPatternSynonym = IsConstructor | IsPatternSynonym
+  deriving (Show, Generic, Enum, Bounded)
+
+instance Pretty ConstructorOrPatternSynonym where
+  pretty = \case
+    IsConstructor    -> "constructor"
+    IsPatternSynonym -> "pattern synonym"
+
+instance NFData ConstructorOrPatternSynonym
+
+---------------------------------------------------------------------------
 -- * Record Directives
 ---------------------------------------------------------------------------
 

--- a/src/full/Agda/Syntax/Concrete/Pattern.hs
+++ b/src/full/Agda/Syntax/Concrete/Pattern.hs
@@ -169,8 +169,8 @@ class CPatternLike p where
   traverseCPatternA = traverse . traverseCPatternA
 
   -- | Traverse pattern.
-  traverseCPatternM
-    :: Monad m => (Pattern -> m Pattern)  -- ^ @pre@: Modification before recursion.
+  traverseCPatternM :: Monad m
+    => (Pattern -> m Pattern)  -- ^ @pre@: Modification before recursion.
     -> (Pattern -> m Pattern)  -- ^ @post@: Modification after recursion.
     -> p -> m p
 

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -3298,8 +3298,8 @@ instance ToAbstract C.Pattern where
         -- x <- bindPatternVariable x
       toAbstract (PatName (C.QName x) Nothing empty) >>= \case
         VarPatName x        -> A.AsP (PatRange r) (A.mkBindName x) <$> toAbstract p
-        ConPatName{}        -> ignoreAsPat IsLHS
-        PatternSynPatName{} -> ignoreAsPat IsPatSyn
+        ConPatName{}        -> ignoreAsPat IsConstructor
+        PatternSynPatName{} -> ignoreAsPat IsPatternSynonym
       where
       -- An @-bound name which shadows a constructor is illegal and becomes dead code.
       ignoreAsPat b = do

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2130,8 +2130,8 @@ instance ToAbstract NiceDeclaration where
             VarName a (PatternBound h')
               | isInstance h, not (isInstance h') -> err $ IllegalInstanceVariableInPatternSynonym x
               | otherwise -> return $ WithHiding h a
-            ConstructorName _ ys -> err $ PatternSynonymArgumentShadowsConstructorOrPatternSynonym IsLHS x ys
-            PatternSynResName ys -> err $ PatternSynonymArgumentShadowsConstructorOrPatternSynonym IsPatSyn x ys
+            ConstructorName _ ys -> err $ PatternSynonymArgumentShadows IsConstructor x ys
+            PatternSynResName ys -> err $ PatternSynonymArgumentShadows IsPatternSynonym x ys
             UnknownName -> err $ UnusedVariableInPatternSynonym x
             -- Other cases are impossible because parsing the pattern syn rhs would have failed.
             _ -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -987,14 +987,12 @@ instance PrettyTCM TypeError where
       , [pretty x]
       ]
 
-    PatternSynonymArgumentShadowsConstructorOrPatternSynonym kind x (y :| _ys) -> vcat
+    PatternSynonymArgumentShadows kind x (y :| _ys) -> vcat
       [ fsep $ concat
         [ pwords "Pattern synonym variable"
         , [ pretty x ]
         , [ "shadows" ]
-        , case kind of
-            IsLHS -> [ "constructor" ]
-            IsPatSyn -> pwords "pattern synonym"
+        , [ pretty kind ]
         , pwords "defined at:"
         ]
       , pretty $ nameBindingSite $ qnameName $ anameName y

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -805,6 +805,12 @@ instance PrettyTCM TypeError where
       , prettyTCM q
       ] ++ pwords "is abstract, thus, not in scope here"
 
+    CopatternHeadNotProjection x -> fsep $ concat
+      [ pwords "Head of copattern needs to be a projection, but"
+      , [ prettyTCM x ]
+      , pwords "isn't one"
+      ]
+
     NotAllowedInDotPatterns what -> fsep $ verb what ++ pwords "are not allowed in dot patterns"
       where
       verb = \case

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -878,6 +878,12 @@ instance PrettyTCM TypeError where
     InvalidPattern p -> fsep $
       pretty p : pwords "is not a valid pattern"
 
+    InvalidPun kind x -> fsep $ concat
+      [ pwords "A pun must not use the"
+      , [ pure $ P.pretty kind ]
+      , [ prettyTCM x ]
+      ]
+
     RepeatedVariablesInPattern xs -> fsep $
       pwords "Repeated variables in pattern:" ++ map pretty xs
 

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -24,6 +24,7 @@ typeErrorName = \case
   UnquoteFailed            err -> UnquoteError_          $ unquoteErrorName               err
   -- Parametrized errors
   MissingTypeSignature    what -> MissingTypeSignature_  $ missingTypeSignatureInfoName   what
+  InvalidPun            kind _ -> InvalidPun_              kind
   NotAllowedInDotPatterns what -> NotAllowedInDotPatterns_ what
   NotAValidLetBinding     what -> NotAValidLetBinding_     what
   NotAValidLetExpression  what -> NotAValidLetExpression_  what

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -28,6 +28,7 @@ typeErrorName = \case
   NotAllowedInDotPatterns what -> NotAllowedInDotPatterns_ what
   NotAValidLetBinding     what -> NotAValidLetBinding_     what
   NotAValidLetExpression  what -> NotAValidLetExpression_  what
+  PatternSynonymArgumentShadows what _ _ -> PatternSynonymArgumentShadows_ what
   -- Wrappers
   OperatorInformation _    err -> typeErrorName err
   -- Generic errors (alphabetically)
@@ -166,7 +167,6 @@ typeErrorName = \case
   OverlappingProjects                                        {} -> OverlappingProjects_
   PatternInPathLambda                                        {} -> PatternInPathLambda_
   PatternInSystem                                            {} -> PatternInSystem_
-  PatternSynonymArgumentShadowsConstructorOrPatternSynonym   {} -> PatternSynonymArgumentShadowsConstructorOrPatternSynonym_
   PrivateRecordField                                         {} -> PrivateRecordField_
   ProjectionIsIrrelevant                                     {} -> ProjectionIsIrrelevant_
   QualifiedLocalModule                                       {} -> QualifiedLocalModule_

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -73,6 +73,7 @@ typeErrorName = \case
   ConstructorDoesNotTargetGivenType                          {} -> ConstructorDoesNotTargetGivenType_
   ConstructorPatternInWrongDatatype                          {} -> ConstructorPatternInWrongDatatype_
   ContradictorySizeConstraint                                {} -> ContradictorySizeConstraint_
+  CopatternHeadNotProjection                                 {} -> CopatternHeadNotProjection_
   CubicalCompilationNotSupported                             {} -> CubicalCompilationNotSupported_
   CubicalPrimitiveNotFullyApplied                            {} -> CubicalPrimitiveNotFullyApplied_
   CyclicModuleDependency                                     {} -> CyclicModuleDependency_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4985,7 +4985,7 @@ data TypeError
             --   but not on the rhs.
             --   This is forbidden because expansion of pattern synonyms would not be faithful
             --   to availability of instances in instance search.
-        | PatternSynonymArgumentShadowsConstructorOrPatternSynonym LHSOrPatSyn C.Name (List1 AbstractName)
+        | PatternSynonymArgumentShadows ConstructorOrPatternSynonym C.Name (List1 AbstractName)
             -- ^ A variable to be bound in the pattern synonym resolved on the rhs as name of
             --   a constructor or a pattern synonym.
             --   The resolvents are given in the list.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4413,9 +4413,9 @@ data Warning
     -- ^ Out of scope error we can recover from.
   | UnsupportedIndexedMatch Doc
     -- ^ Was not able to compute a full equivalence when splitting.
-  | AsPatternShadowsConstructorOrPatternSynonym LHSOrPatSyn
-    -- ^ The as-name in an as-pattern may not shadow a constructor ('IsLHS')
-    --   or pattern synonym name ('IsPatSyn'),
+  | AsPatternShadowsConstructorOrPatternSynonym ConstructorOrPatternSynonym
+    -- ^ The as-name in an as-pattern may not shadow a constructor
+    --   or pattern synonym name,
     --   because this can be confusing to read.
   | PatternShadowsConstructor C.Name A.QName
     -- ^ A pattern variable has the name of a constructor

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4952,6 +4952,8 @@ data TypeError
             -- ^ The given data/record definition rests in a different module than its signature.
         | DuplicateImports C.QName [C.ImportedName]
         | InvalidPattern C.Pattern
+        | InvalidPun ConstructorOrPatternSynonym C.QName
+            -- ^ Expected the identifier to be a variable, not a constructor or pattern synonym.
         | RepeatedNamesInImportDirective (List1 (List2 C.ImportedName))
             -- ^ Some names are bound several times by an @import@/@open@ directive.
         | RepeatedVariablesInPattern [C.Name]

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4938,6 +4938,7 @@ data TypeError
           -- ^ The file name does not correspond to a module name.
     -- Scope errors
         | AbstractConstructorNotInScope A.QName
+        | CopatternHeadNotProjection C.QName
         | NotAllowedInDotPatterns NotAllowedInDotPatterns
         | NotInScope [C.QName]
         | NoSuchModule C.QName

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -512,10 +512,8 @@ prettyWarning = \case
         s = P.prettyShow x
 
     AsPatternShadowsConstructorOrPatternSynonym patsyn -> fsep $ concat
-      [ pwords "Name bound in @-pattern ignored because it shadows"
-      , case patsyn of
-          IsPatSyn -> pwords "pattern synonym"
-          IsLHS    -> [ "constructor" ]
+      [ pwords "Name bound in @-pattern ignored because it shadows a"
+      , [ pure $ P.pretty patsyn ]
       ]
 
     PatternShadowsConstructor x c -> fsep $

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240816 * 10 + 0
+currentInterfaceVersion = 20240911 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -160,6 +160,8 @@ instance EmbPrj Bool where
   value 1 = pure True
   value _ = malformed
 
+instance EmbPrj ConstructorOrPatternSynonym
+
 instance EmbPrj FileType where
   icod_ AgdaFileType  = pure 0
   icod_ MdFileType    = pure 1

--- a/test/Fail/CopatternWithoutFieldName.err
+++ b/test/Fail/CopatternWithoutFieldName.err
@@ -1,4 +1,4 @@
-CopatternWithoutFieldName.agda:13,3-8: error: [GenericError]
-head of copattern needs to be a field identifier, but f isn't one
+CopatternWithoutFieldName.agda:13,3-8: error: [CopatternHeadNotProjection]
+Head of copattern needs to be a projection, but f isn't one
 when scope checking the left-hand side f bla in the definition of
 bla

--- a/test/Fail/Issue4631AsPatternShadowsConstructor.err
+++ b/test/Fail/Issue4631AsPatternShadowsConstructor.err
@@ -1,5 +1,5 @@
 Issue4631AsPatternShadowsConstructor.agda:8,6-10: warning: -W[no]AsPatternShadowsConstructorOrPatternSynonym
-Name bound in @-pattern ignored because it shadows constructor
+Name bound in @-pattern ignored because it shadows a constructor
 when scope checking the left-hand side test true@_ in the
 definition of test
 

--- a/test/Fail/Issue6325-1.err
+++ b/test/Fail/Issue6325-1.err
@@ -1,4 +1,4 @@
-Issue6325-1.agda:19,9-13: error: [GenericError]
+Issue6325-1.agda:19,9-13: error: [InvalidPun.Constructor]
 A pun must not use the constructor zero
 when scope checking the left-hand side length {zero} {(A)} _ in the
 definition of length

--- a/test/Fail/Issue6325-2.err
+++ b/test/Fail/Issue6325-2.err
@@ -1,4 +1,4 @@
-Issue6325-2.agda:19,10-14: error: [GenericError]
+Issue6325-2.agda:19,10-14: error: [InvalidPun.Constructor]
 A pun must not use the constructor zero
 when scope checking the left-hand side length ⦃ zero ⦄ {(A)} _ in
 the definition of length

--- a/test/Fail/Issue6325-3.err
+++ b/test/Fail/Issue6325-3.err
@@ -1,4 +1,4 @@
-Issue6325-3.agda:22,6-9: error: [GenericError]
+Issue6325-3.agda:22,6-9: error: [InvalidPun.PatternSynonym]
 A pun must not use the pattern synonym one
 when scope checking the left-hand side
 .extendedlambda0 _ {one} {(A)} _ in the definition of

--- a/test/Fail/PatternSynVarShadowsConstructor.err
+++ b/test/Fail/PatternSynVarShadowsConstructor.err
@@ -1,4 +1,4 @@
-PatternSynVarShadowsConstructor.agda:8,11-12: error: [PatternSynonymArgumentShadowsConstructorOrPatternSynonym]
+PatternSynVarShadowsConstructor.agda:8,11-12: error: [PatternSynonymArgumentShadows.Constructor]
 Pattern synonym variable x shadows constructor defined at:
 PatternSynVarShadowsConstructor.agda:5,3-4
 when scope checking the declaration

--- a/test/Fail/PatternSynVarShadowsPatternSyn.err
+++ b/test/Fail/PatternSynVarShadowsPatternSyn.err
@@ -1,4 +1,4 @@
-PatternSynVarShadowsPatternSyn.agda:9,11-12: error: [PatternSynonymArgumentShadowsConstructorOrPatternSynonym]
+PatternSynVarShadowsPatternSyn.agda:9,11-12: error: [PatternSynonymArgumentShadows.PatternSynonym]
 Pattern synonym variable x shadows pattern synonym defined at:
 PatternSynVarShadowsPatternSyn.agda:8,9-10
 when scope checking the declaration


### PR DESCRIPTION
New errors:
- `CopatternHeadNotProjection` 
- `InvalidPun`

Changes:
- Re #6325: refactor: `expandPuns` is an instance of `mapCPattern`; factor out `expandPunsOpt`
- Use bool `ConstructorOrPatternSynonym` as parameter in warning `AsPatternShadowsConstructorOrPatternSynonym`
- Parametrize error name `PatternSynonymArgumentShadows` on `ConstructorOrPatternSynonym`
