### PR TITLE
Warn in test runner if -v not supported

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -180,6 +180,10 @@ Testing and documentation
     * You can also add `.flags` files to set Agda options.
     * You can also add `.vars` files to set environment variables (which may reference other environment variables, even those in the file appearing before them).
 
+* Track the dependencies of your test:
+  * Need Agda compiled with `-fdebug`? Add to `fdebugTestFilter` in `Main.hs`.
+  * Need other misc. setup by the `Makefile`? Add to `makefileDependentTests` in `Main.hs`.
+  * Need `node`, `ghc`, `latexmk`, etc.? Choose the appropriate sub-directory.
 
 * Run the test-suite, using `make test`.
   Maybe you want to build Agda first, using `make` or `make install-bin`.

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -111,6 +111,24 @@ disabledTests =
   ]
   where disable = RFInclude
 
+-- | Filtering out compiler tests that require Agda built with -fdebug.
+
+fdebugTestFilter :: [RegexFilter]
+fdebugTestFilter =
+-- This list was crafted using
+--    grep -RP '(?<!-- ){-# OPTIONS.* -v' | grep Compiler/
+--  and screening the results (e.g. for comments)
+  [ disable "Compiler/simple/UnusedArguments"
+  , disable "Compiler/simple/EraseRefl"
+  , disable "Compiler/simple/InlineRecursive"
+  , disable "Compiler/simple/Word"
+  , disable "Compiler/simple/CompileNumbers"
+  , disable "Compiler/simple/CaseOnCase"
+  , disable "Compiler/simple/CompareNat"
+  , disable "Compiler/simple/CompileCatchAll"
+  ]
+  where disable = RFInclude
+
 -- | Filtering out compiler tests using the Agda standard library.
 
 stdlibTestFilter :: [RegexFilter]

--- a/test/Fail/Tests.hs
+++ b/test/Fail/Tests.hs
@@ -20,6 +20,7 @@ import Test.Tasty.Silver.Advanced
 import Utils
 
 import Agda.Utils.Functor ((<&>), for)
+import Test.Tasty.Silver.Filter (RegexFilter (RFInclude))
 
 testDir :: FilePath
 testDir = "test" </> "Fail"
@@ -93,6 +94,30 @@ caseInsensitiveFileSystem4671 = do
     goldenFileSens    = dir </> "Issue4671.err.case-sensitive"
     goldenFileInsens  = dir </> "Issue4671.err.case-insensitive"
     goldenFileInsens' = dir </> "Issue4671.err.cAsE-inSensitive" -- case variant, to test file system
+
+
+-- | Filtering out fail-tests that require Agda built with -fdebug.
+
+fdebugTestFilter :: [RegexFilter]
+fdebugTestFilter =
+-- This list was crafted using
+--    grep -RP '(?<!-- ){-# OPTIONS.* -v' | grep Fail/
+--  and screening the results (e.g. for comments)
+  [ disable "Fail/Issue3590-2"
+  , disable "Fail/IndexInference"
+  , disable "Fail/DebugWith"
+  , disable "Fail/ImpossibleVerbose"
+  , disable "Fail/ConstructorHeadedPointlessForRecordPatterns"
+  , disable "Fail/Issue3590-1"
+  , disable "Fail/Issue1303"
+  , disable "Fail/ImpossibleVerboseReduceM"
+  , disable "Fail/Issue2018debug"
+  , disable "Fail/Issue1963DisplayWithPostfixCopattern"
+  , disable "Fail/Optimised-open"
+  , disable "Fail/Optimised-open"
+  , disable "Fail/Issue4175"
+  ]
+  where disable = RFInclude
 
 issue6465 :: TestTree
 issue6465 =

--- a/test/Interactive/Tests.hs
+++ b/test/Interactive/Tests.hs
@@ -13,9 +13,23 @@ import System.Exit
 
 import Agda.Utils.Monad
 import Utils
+import Test.Tasty.Silver.Filter (RegexFilter (RFInclude))
 
 testDir :: FilePath
 testDir = "test" </> "Interactive"
+
+-- | Filtering out interaction tests that require Agda built with -fdebug.
+
+fdebugTestFilter :: [RegexFilter]
+fdebugTestFilter =
+-- This list was crafted using
+--    grep -RP '(?<!-- ){-# OPTIONS.* -v' | grep interaction/
+--  and screening the results (e.g. for comments)
+  [ disable "interaction/Debug"
+  , disable "interaction/Issue1353"
+  , disable "interaction/Positivity"
+  ]
+  where disable = RFInclude
 
 tests :: TestTree
 tests = testGroup "Interactive"

--- a/test/Succeed/Tests.hs
+++ b/test/Succeed/Tests.hs
@@ -39,6 +39,56 @@ tests = do
   -- -- Put @ExecAgda@ last.
   -- reorder = uncurry (++) . List.partition (not . ("ExecAgda" `List.isInfixOf`))
 
+-- | Filtering out succed-tests that require Agda built with -fdebug.
+
+fdebugTestFilter :: [RegexFilter]
+fdebugTestFilter =
+-- This list was crafted using
+--    grep -RP '(?<!-- ){-# OPTIONS.* -v' | grep Succeed/
+--  and screening the results (e.g. for comments)
+  [ disable "Succeed/Issue1809"
+  , disable "Succeed/Issue5730"
+  , disable "Succeed/Issue1701II"
+  , disable "Succeed/Issue1407"
+  , disable "Succeed/ForcedConstructorPattern"
+  , disable "Succeed/Issue2292"
+  , disable "Succeed/Issue4016"
+  , disable "Succeed/Issue2434"
+  , disable "Succeed/NotProjectionLike"
+  , disable "Succeed/Issue5989"
+  , disable "Succeed/Issue2717"
+  , disable "Succeed/Issue7286"
+  , disable "Succeed/Issue778b"
+  , disable "Succeed/Issue1597/Main2"
+  , disable "Succeed/RepeatedCase"
+  , disable "Succeed/Issue6298-d"
+  , disable "Succeed/Issue1770"
+  , disable "Succeed/Issue578"
+  , disable "Succeed/Issue2300"
+  , disable "Succeed/Issue882a"
+  , disable "Succeed/Issue1009"
+  , disable "Succeed/Issue3933"
+  , disable "Succeed/Issue3933"
+  , disable "Succeed/Issue5506"
+  , disable "Succeed/Issue1595"
+  , disable "Succeed/Issue365"
+  , disable "Succeed/Issue1914"
+  , disable "Succeed/Issue2257b"
+  , disable "Succeed/Issue1344"
+  , disable "Succeed/Issue4148"
+  , disable "Succeed/CheckIApplyConfluenceOnlyWhenCubical"
+  , disable "Succeed/OpaqueImport/C"
+  , disable "Succeed/OpaqueImport/B"
+  , disable "Succeed/OpaqueImport/A"
+  , disable "Succeed/Issue2223-constraints-in-frontmatter"
+  , disable "Succeed/Issue4211"
+  , disable "Succeed/Issue4211"
+  , disable "Succeed/Issue3971"
+  , disable "Succeed/Issue1740"
+  , disable "Succeed/Issue4020"
+  ]
+  where disable = RFInclude
+
 -- | Tests that get special preparation from the Makefile.
 makefileDependentTests :: [RegexFilter]
 makefileDependentTests =

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -401,3 +401,14 @@ goldenVsAction' name ref act toTxt =
     textDiff
     ShowText
     (BS.writeFile ref . encodeUtf8)
+
+-- | Scrapes the output of @agda --version@
+-- to determine whether agda was built with or without
+-- the @-fdebug@ cabal flag.
+wasAgdaCompiledWithFDebug :: IO Bool
+wasAgdaCompiledWithFDebug = do
+  (_code , out, _err) <-
+    readAgdaProcessWithExitCode
+      Nothing ["--version"] ""
+  let flines = dropWhile (/= "Built with flags (cabal -f)") $ T.lines out
+  return $ " - debug: enable debug printing ('-v' verbosity flags)" `elem` flines


### PR DESCRIPTION

This PR makes the tester check that Agda was built with `-fdebug`,
before running tests that depend on Agda supporting `-v` for debug output.

The motivation is to make the test suite more developer-friendly:
I often forget to build Agda with `-fdebug`, and then am surprised when (seemingly arbitrary) tests fail on my machine (but not CI).

Related tickets:

* #3395 implemented a similar check for tests that need the `node` binary
* #7114 reports the problem with `-v` and testing
* #7256 makes Agda itself warn if `-v` is passed but not supported
  * This had unwanted side-effects
* #7308 avoids the problem for Makefile-built Agda
  * But does not help for testing non-Makefile-built Agda, e.g. from `cabal build`, `nix build`


