### PR TITLE
ES6 modules

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -105,6 +105,7 @@ data-files:
     emacs-mode/*.el
     html/Agda.css
     html/highlight-hover.js
+    JS/agda-rts.mjs
     JS/agda-rts.js
     JS/agda-rts.amd.js
     latex/agda.sty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Pragmas and options
 * Warning `AbsurdPatternRequiresNoRHS` has been renamed to
   `AbsurdPatternRequiresAbsentRHS`.
 
+* New option `--js-es6` for generating JavaScript with ES6 module syntax.
+
 Syntax
 ------
 

--- a/doc/user-manual/tools/compilers.lagda.rst
+++ b/doc/user-manual/tools/compilers.lagda.rst
@@ -155,8 +155,9 @@ Options
 
 .. option:: --js-es6
 
+    .. versionadded:: 2.8.0
+
     Produce ES6 style modules (supported natively by browsers and NodeJS since 2020).
-    This option is supported by Agda since 2.8.0.
 
 .. option:: --js-amd
 

--- a/doc/user-manual/tools/compilers.lagda.rst
+++ b/doc/user-manual/tools/compilers.lagda.rst
@@ -140,13 +140,7 @@ typically faster and less readable.
 The :option:`--js-minify` flag makes the generated JavaScript code
 smaller and less readable.
 
-Agda can currently generate JavaScript modules in several flavours:
-
-The :option:`--js-es6` generates ES6-style modules (supported natively by browsers and NodeJS since 2020)
-
-The :option:`--js-cjs` (default) generates CommonJS-style modules (supported natively by NodeJS)
-
-The :option:`--js-amd` generates AMD-style modules, which are supported (for in-browser usage with a wrapper like `require.js`).
+Agda can currently generate JavaScript modules in ES6, AMD, or CommonJS style.
 
 Options
 ~~~~~~~
@@ -156,6 +150,10 @@ Options
      Compile to JavaScript, placing translation of module :samp:`{M}` into file :samp:`jAgda.{M}.js`.
      The files will be placed into the root directory of the compiled Agda project,
      or into the directory given by :option:`--compile-dir`.
+
+.. option:: --js-es6
+
+    Produce ES6 style modules.
 
 .. option:: --js-amd
 

--- a/doc/user-manual/tools/compilers.lagda.rst
+++ b/doc/user-manual/tools/compilers.lagda.rst
@@ -148,7 +148,8 @@ Options
 
 .. option:: --js
 
-     Compile to JavaScript, placing translation of module :samp:`{M}` into file :samp:`jAgda.{M}.js`.
+     Compile to JavaScript, placing translation of module :samp:`{M}` into file :samp:`jAgda.{M}.js`
+     (or :samp:`jAgda.{M}.mjs`, if the option :option:`--js-es6` is passed).
      The files will be placed into the root directory of the compiled Agda project,
      or into the directory given by :option:`--compile-dir`.
 

--- a/doc/user-manual/tools/compilers.lagda.rst
+++ b/doc/user-manual/tools/compilers.lagda.rst
@@ -140,9 +140,13 @@ typically faster and less readable.
 The :option:`--js-minify` flag makes the generated JavaScript code
 smaller and less readable.
 
-Agda can currently generate either CommonJS (used by NodeJS) flavour modules or
-AMD (for in-browser usage) flavour modules which can be toggled by :option:`--js-cjs`
-(default) and :option:`--js-amd` flags.
+Agda can currently generate JavaScript modules in several flavours:
+
+The :option:`--js-es6` generates ES6-style modules (supported natively by browsers and NodeJS since 2020)
+
+The :option:`--js-cjs` (default) generates CommonJS-style modules (supported natively by NodeJS)
+
+The :option:`--js-amd` generates AMD-style modules, which are supported (for in-browser usage with a wrapper like `require.js`).
 
 Options
 ~~~~~~~

--- a/doc/user-manual/tools/compilers.lagda.rst
+++ b/doc/user-manual/tools/compilers.lagda.rst
@@ -140,7 +140,8 @@ typically faster and less readable.
 The :option:`--js-minify` flag makes the generated JavaScript code
 smaller and less readable.
 
-Agda can currently generate JavaScript modules in ES6, AMD, or CommonJS style.
+Agda generates JavaScript modules in CommonJS style by default (:option:`--js-cjs`),
+but can also generate modules in ES6 style (:option:`--js-es6`) or AMD style (:option:`--js-amd`).
 
 Options
 ~~~~~~~
@@ -153,15 +154,16 @@ Options
 
 .. option:: --js-es6
 
-    Produce ES6 style modules.
+    Produce ES6 style modules (supported natively by browsers and NodeJS since 2020).
+    This option is supported by Agda since 2.8.0.
 
 .. option:: --js-amd
 
-     Produce AMD style modules.
+     Produce AMD style modules (for in-browser usage with a wrapper like `require.js`).
 
 .. option:: --js-cjs
 
-     Produce CommonJS style modules.
+     Produce CommonJS style modules (supported natively by NodeJS).
      This is the default.
 
 .. option:: --js-minify

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702346276,
-        "narHash": "sha256-eAQgwIWApFQ40ipeOjVSoK4TEHVd6nbSd9fApiHIw5A=",
+        "lastModified": 1723282977,
+        "narHash": "sha256-oTK91aOlA/4IsjNAZGMEBz7Sq1zBS0Ltu4/nIQdYDOg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf28ee258fd5f9a52de6b9865cdb93a1f96d09b7",
+        "rev": "a781ff33ae258bbcfd4ed6e673860c3e923bf2cc",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,8 @@
               py3pkgs.sphinx
               py3pkgs.sphinx_rtd_theme
             ]))
+            # Tools for running the agda test-suite
+            pkgs.nodejs_22
           ];
 
         # Include an offline-usable `hoogle` command

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Agda is a dependently typed programming language / interactive theorem prover.";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
   inputs.flake-parts.url = "github:hercules-ci/flake-parts";
 
   outputs = inputs:

--- a/src/data/JS/agda-rts.mjs
+++ b/src/data/JS/agda-rts.mjs
@@ -1,0 +1,397 @@
+// Contains *most* of the primitives required by the JavaScript backend.
+// (Some, e.g., those using Agda types like Maybe, are defined in their
+// respective builtin modules.)
+//
+// Primitives prefixed by 'u' are uncurried variants, which are sometimes
+// emitted by the JavaScript backend. Whenever possible, the curried primitives
+// should be implemented in terms of the uncurried ones.
+//
+// Primitives prefixed by '_' are internal variants, usually for those primitives
+// which return Agda types like Maybe. These are never emitted by the compiler,
+// but can be used internally to define other prefixes.
+
+const exports = {};
+
+// Integers
+
+// primIntegerFromString : String -> Int
+exports.primIntegerFromString = BigInt;
+
+// primShowInteger : Int -> String
+exports.primShowInteger = x => x.toString();
+
+// uprimIntegerPlus : (Int, Int) -> Int
+exports.uprimIntegerPlus = (x, y) => x + y;
+
+// uprimIntegerMinus : (Int, Int) -> Int
+exports.uprimIntegerMinus = (x, y) => x - y;
+
+// uprimIntegerMultiply : (Int, Int) -> Int
+exports.uprimIntegerMultiply = (x, y) => x * y;
+
+// uprimIntegerRem : (Int, Int) -> Int
+exports.uprimIntegerRem = (x, y) => x % y;
+
+// uprimIntegerQuot : (Int, Int) -> Int
+exports.uprimIntegerQuot = (x, y) => x / y;
+
+// uprimIntegerEqual : (Int, Int) -> Bool
+exports.uprimIntegerEqual = (x, y) => x === y;
+
+// uprimIntegerGreaterOrEqualThan : (Int, Int) -> Bool
+exports.uprimIntegerGreaterOrEqualThan = (x, y) => x >= y;
+
+// uprimIntegerLessThan : (Int, Int) -> Bool
+exports.uprimIntegerLessThan = (x, y) => x < y;
+
+// Words
+const WORD64_MAX_VALUE = 18446744073709552000n;
+
+// primWord64ToNat : Word64 -> Nat
+exports.primWord64ToNat = x => x;
+
+// primWord64FromNat : Nat -> Word64
+exports.primWord64FromNat = x => x % WORD64_MAX_VALUE;
+
+// uprimWord64Plus : (Word64, Word64) -> Word64
+exports.uprimWord64Plus = (x, y) => (x + y) % WORD64_MAX_VALUE;
+
+// uprimWord64Minus : (Word64, Word64) -> Word64
+exports.uprimWord64Minus = (x, y) => (x + WORD64_MAX_VALUE - y) % WORD64_MAX_VALUE;
+
+// uprimWord64Multiply : (Word64, Word64) -> Word64
+exports.uprimWord64Multiply = (x, y) => (x * y) % WORD64_MAX_VALUE;
+
+// Natural numbers
+
+// primNatMinus : Nat -> Nat -> Nat
+exports.primNatMinus = x => y => {
+  const z = x - y;
+  return z < 0n ? 0n : z;
+};
+
+// Floating-point numbers
+var _primFloatGreatestCommonFactor = function(x, y) {
+    var z;
+    x = Math.abs(x);
+    y = Math.abs(y);
+    while (y) {
+        z = x % y;
+        x = y;
+        y = z;
+    }
+    return x;
+};
+exports._primFloatRound = function(x) {
+    if (exports.primFloatIsNaN(x) || exports.primFloatIsInfinite(x)) {
+        return null;
+    }
+    else {
+        return Math.round(x);
+    }
+};
+exports._primFloatFloor = function(x) {
+    if (exports.primFloatIsNaN(x) || exports.primFloatIsInfinite(x)) {
+        return null;
+    }
+    else {
+        return Math.floor(x);
+    }
+};
+exports._primFloatCeiling = function(x) {
+    if (exports.primFloatIsNaN(x) || exports.primFloatIsInfinite(x)) {
+        return null;
+    }
+    else {
+        return Math.ceil(x);
+    }
+};
+exports._primFloatToRatio = function(x) {
+    if (exports.primFloatIsNaN(x)) {
+        return {numerator: 0.0, denominator: 0.0};
+    }
+    else if (x < 0.0 && exports.primFloatIsInfinite(x)) {
+        return {numerator: -1.0, denominator: 0.0};
+    }
+    else if (x > 0.0 && exports.primFloatIsInfinite(x)) {
+        return {numerator: 1.0, denominator: 0.0};
+    }
+    else if (exports.primFloatIsNegativeZero(x)) {
+        return {numerator: 0.0, denominator: 1.0};
+    }
+    else if (x == 0.0) {
+        return {numerator: 0.0, denominator: 1.0};
+    }
+    else {
+        var numerator = Math.round(x*1e9);
+        var denominator = 1e9;
+        var gcf = _primFloatGreatestCommonFactor(numerator, denominator);
+        numerator /= gcf;
+        denominator /= gcf;
+        return {numerator: numerator, denominator: denominator};
+    }
+};
+exports._primFloatDecode = function(x) {
+    if (exports.primFloatIsNaN(x)) {
+        return null;
+    }
+    else if (x < 0.0 && exports.primFloatIsInfinite(x)) {
+        return null;
+    }
+    else if (x > 0.0 && exports.primFloatIsInfinite(x)) {
+        return null;
+    }
+    else {
+        var mantissa = x, exponent = 0;
+        while (!Number.isInteger(mantissa)) {
+            mantissa *= 2.0;
+            exponent -= 1;
+        };
+        while (mantissa % 2.0 === 0) {
+            mantissa /= 2.0;
+            exponent += 1;
+        }
+        return {mantissa: mantissa, exponent: exponent};
+    }
+};
+exports.uprimFloatEquality = function(x, y) {
+    return x === y;
+};
+exports.primFloatEquality = function(x) {
+    return function(y) {
+        return exports.uprimFloatEquality(x, y);
+    };
+};
+exports.primFloatInequality = function(x) {
+    return function(y) {
+        return x <= y;
+    };
+};
+exports.primFloatLess = function(x) {
+    return function(y) {
+        return x < y;
+    };
+};
+exports.primFloatIsInfinite = function(x) {
+    return !Number.isNaN(x) && !Number.isFinite(x);
+};
+exports.primFloatIsNaN = function(x) {
+    return Number.isNaN(x);
+};
+exports.primFloatIsNegativeZero = function(x) {
+    return Object.is(x,-0.0);
+};
+exports.primFloatIsSafeInteger = function(x) {
+    return Number.isSafeInteger(x);
+};
+
+
+// These WORD64 values were obtained via `castDoubleToWord64` in Haskell:
+const WORD64_POS_INF  = 9218868437227405312n;
+const WORD64_NEG_INF  = 18442240474082181120n;
+const WORD64_POS_ZERO = 0n;
+const WORD64_NEG_ZERO = 9223372036854775808n;
+
+exports.primFloatToWord64 = function(x) {
+    if (exports.primFloatIsNaN(x)) {
+        return null;
+    }
+    else if (x < 0.0 && exports.primFloatIsInfinite(x)) {
+        return WORD64_NEG_INF;
+    }
+    else if (x > 0.0 && exports.primFloatIsInfinite(x)) {
+        return WORD64_POS_INF;
+    }
+    else if (exports.primFloatIsNegativeZero(x)) {
+        return WORD64_NEG_ZERO;
+    }
+    else if (x == 0.0) {
+        return WORD64_POS_ZERO;
+    }
+    else {
+        var mantissa, exponent;
+        ({mantissa, exponent} = exports._primFloatDecode(x));
+        var sign = Math.sign(mantissa);
+        console.log(mantissa);
+        mantissa *= sign;
+        sign = (sign === -1 ? "1" : "0");
+        mantissa = (mantissa.toString(2)).padStart(11, "0");
+        exponent = (mantissa.toString(2)).padStart(52, "0");
+        return BigInt(parseInt(sign + mantissa + exponent, 2));
+    }
+};
+
+// primNatToFloat : Nat -> Float
+exports.primNatToFloat = Number;
+
+// primIntToFloat : Int -> Float
+exports.primIntToFloat = Number;
+
+// primRatioToFloat : Int -> Int -> Float
+exports.primRatioToFloat = x => y => Number(x) / Number(y);
+
+// uprimFloatEncode : (Int, Int) -> Maybe Float
+exports.uprimFloatEncode = (x, y) => {
+  const mantissa = Number(x);
+  const exponent = Number(y);
+
+  if (Number.isSafeInteger(mantissa) && -1024 <= exponent && exponent <= 1024) {
+    return mantissa * (2 ** exponent);
+  }
+
+  else {
+    return null;
+  }
+};
+
+exports.primShowFloat = function(x) {
+    // See Issue #2192.
+    if (Number.isInteger(x)) {
+        if (exports.primFloatIsNegativeZero(x)) {
+            return ("-0.0");
+        } else {
+            return (x.toString() + ".0");
+        }
+    } else {
+        return x.toString();
+    }
+};
+exports.primFloatPlus = function(x) {
+    return function(y) {
+        return x + y;
+    };
+};
+exports.primFloatMinus = function(x) {
+    return function(y) {
+        return x - y;
+    };
+};
+exports.primFloatTimes = function(x) {
+    return function(y) {
+        return x * y;
+    };
+};
+exports.primFloatNegate = function(x) {
+    return -x;
+};
+exports.primFloatDiv = function(x) {
+  return function(y) {
+    return x / y;
+  };
+};
+exports.primFloatPow = function(x) {
+    return function(y) {
+        return x ** y;
+    };
+};
+exports.primFloatSqrt = function(x) {
+    return Math.sqrt(x);
+};
+exports.primFloatExp = function(x) {
+    return Math.exp(x);
+};
+exports.primFloatLog = function(x) {
+    return Math.log(x);
+};
+exports.primFloatSin = function(x) {
+    return Math.sin(x);
+};
+exports.primFloatCos = function(x) {
+    return Math.cos(x);
+};
+exports.primFloatTan = function(x) {
+    return Math.tan(x);
+};
+exports.primFloatASin = function(x) {
+    return Math.asin(x);
+};
+exports.primFloatACos = function(x) {
+    return Math.acos(x);
+};
+exports.primFloatATan = function(x) {
+    return Math.atan(x);
+};
+exports.primFloatATan2 = function(x) {
+    return function(y){
+        return Math.atan2(x, y);
+    };
+};
+exports.primFloatSinh = function(x) {
+    return Math.sinh(x);
+};
+exports.primFloatCosh = function(x) {
+    return Math.cosh(x);
+};
+exports.primFloatTanh = function(x) {
+    return Math.tanh(x);
+};
+exports.primFloatASinh = function(x) {
+    return Math.asinh(x);
+};
+exports.primFloatACosh = function(x) {
+    return Math.acosh(x);
+};
+exports.primFloatATanh = function(x) {
+    return Math.atanh(x);
+};
+
+// Cubical primitives.
+exports.primIMin = x => y => x && y;
+exports.primIMax = x => y => x || y;
+exports.primINeg = x => !x;
+exports.primPartial = _ => _ => x => x;
+exports.primPartialP = _ => _ => x => x;
+exports.primPOr = _ => i => _ => _ => x => y => i ? x : y;
+exports.primComp = _ => _ => _ => _ => x => x;
+exports.primTransp = _ => _ => _ => x => x;
+exports.primHComp = _ => _ => _ => _ => x => x;
+exports.primSubOut = _ => _ => _ => _ => x => x;
+exports.prim_glueU = _ => _ => _ => _ => _ => x => x;
+exports.prim_unglueU = _ => _ => _ => _ => x => x;
+exports.primFaceForall = f => f(true) == true && f(false) == false;
+exports.primDepIMin =
+    i => f => i ? f({ "tt" : a => a["tt"]() }) : false;
+exports.primConId = _ => _ => _ => _ => i => p => { return { "i" : i, "p" : p } };
+exports.primIdFace = _ => _ => _ => _ => x => x["i"];
+exports.primIdPath = _ => _ => _ => _ => x => x["p"];
+exports.primIdElim =
+    _ => _ => _ => _ => _ => f => x => y => f(y["i"])(x)(y["p"]);
+
+// Other stuff
+
+// primSeq : (X, Y) -> Y
+exports.primSeq = (x, y) => y;
+
+// uprimQNameEquality : (Name, Name) -> Bool
+exports.uprimQNameEquality = (x, y) => x['id'] === y['id'] && x['moduleId'] === y['moduleId'];
+
+// primQNameEquality : Name -> Name -> Bool
+exports.primQNameEquality = x => y => exports.uprimQNameEquality(x, y);
+
+// primQNameLess : Name -> Name -> Bool
+exports.primQNameLess = x => y => x['id'] === y['id'] ? x['moduleId'] < y['moduleId'] : x['id'] < y['id'];
+
+// primShowQName : Name -> String
+exports.primShowQName = x => x['name'];
+
+// primQNameFixity : Name -> Fixity
+exports.primQNameFixity = x => x['fixity'];
+
+// Meta
+
+// primShowMeta : Meta -> String
+//   Should be kept in sync with version in `primitiveFunctions` in
+//   Agda.TypeChecking.Primitive
+exports.primShowMeta = x => "_" + x['id'] + "@" + x['module'];
+
+// primMetaToNat : Meta -> Nat
+//   Should be kept in sync with `metaToNat` in Agda.TypeChecking.Primitive
+exports.primMetaToNat = x => x['module'] * 2^64 + x['id'];
+
+// primMetaEquality : Meta -> Meta -> Bool
+exports.primMetaEquality = x => y => x['id'] === y['id'] && x['module'] === y['module'];
+
+// primMetaLess : Meta -> Meta -> Bool
+exports.primMetaLess = x => y => x['id'] === y['id'] ? x['module'] < y['module'] : x['id'] < y['id'];
+
+export default exports;

--- a/src/full/Agda/Compiler/JS/Pretty.hs
+++ b/src/full/Agda/Compiler/JS/Pretty.hs
@@ -323,7 +323,7 @@ instance Pretty Module where
     , pretty opt callMain
     ]
     $+$ ""
-    where 
+    where
       imports = vcat [
         "var " <> indent (pretty opt e) <+> "=" <+> "require(\"" <> modname e <> "\");"
         | e <- toList (globals es <> Set.fromList is)

--- a/src/full/Agda/Compiler/JS/Pretty.hs
+++ b/src/full/Agda/Compiler/JS/Pretty.hs
@@ -37,7 +37,7 @@ import Agda.Compiler.JS.Syntax hiding (exports)
 --  standard pretty printers.
 --- This library code is only used in this module, and it is specialized to pretty
 --- print JavaScript code for the Agda backend, so I think its best place is in this module.
-data JSModuleStyle = JSCJS | JSAMD
+data JSModuleStyle = JSES6 | JSCJS | JSAMD
   deriving Generic
 
 data Doc
@@ -280,7 +280,7 @@ block n e = mparens (doNest e) $ pretty n e
     doNest _ = False
 
 modname :: GlobalId -> Doc
-modname (GlobalId ms) = text $ "\"" ++ intercalate "." ms ++ "\""
+modname (GlobalId ms) = text $ intercalate "." ms
 
 exports :: (Nat, Bool, JSModuleStyle) -> Set JSQName -> [Export] -> Doc
 exports n lss [] = Empty
@@ -301,6 +301,21 @@ instance Pretty [(GlobalId, Export)] where
            | (g, Export ls e) <- es ]
 
 instance Pretty Module where
+  pretty opt@(n, min, JSES6) (Module m is es callMain) = vsep
+    [ "import agdaRTS from \"./agda-rts.mjs\";"
+    , imports
+    , "const exports = {};"
+    , exports opt Set.empty es
+    , pretty opt callMain
+    , ";export default exports;"
+    ]
+    $+$ ""
+    where
+      imports = vcat [
+        "import " <> indent (pretty opt e) <+> " from \"./" <> modname e <> ".mjs\";"
+        | e <- toList (globals es <> Set.fromList is)
+        ]
+      les = toList (globals es <> Set.fromList is)
   pretty opt@(n, min, JSCJS) (Module m is es callMain) = vsep
     [ "var agdaRTS" <+> "=" <+> "require(\"agda-rts\");"
     , imports
@@ -308,15 +323,15 @@ instance Pretty Module where
     , pretty opt callMain
     ]
     $+$ ""
-    where
+    where 
       imports = vcat [
-        "var " <> indent (pretty opt e) <+> "=" <+> "require(" <> modname e <> ");"
+        "var " <> indent (pretty opt e) <+> "=" <+> "require(\"" <> modname e <> "\");"
         | e <- toList (globals es <> Set.fromList is)
         ]
       les = toList (globals es <> Set.fromList is)
   pretty opt@(n, min, JSAMD) (Module m is es callMain) = vsep
     [ "define(['agda-rts'"
-      <+> hcat [ ", " <+> modname e | e <- les ]
+      <+> hcat [ ", " <+> ("\"" <> modname e <> "\"") | e <- les ]
       <+> "],"
     , "function(agdaRTS"
       <+> hcat [ ", " <+> pretty opt e | e <- les ]

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -68,7 +68,7 @@ data TestOptions
 
 allCompilers :: [Compiler]
 allCompilers
-  =  [ MAlonzo strict | strict <- [minBound..]]
+  =  [ MAlonzo strict | strict <- [Lazy, StrictData, Strict]]
   ++ [ JS style opt   | opt <- [minBound..], style <- [minBound..] ]
 
 defaultOptions :: TestOptions

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -41,12 +41,17 @@ data ExecResult
   deriving (Show, Read, Eq)
 
 data CodeOptimization = NonOptimized | Optimized | MinifiedOptimized
-  deriving (Show, Read, Eq)
+  deriving (Show, Read, Eq, Enum, Bounded)
 
 data Strict = Strict | StrictData | Lazy
-  deriving (Show, Read, Eq)
+  deriving (Show, Read, Eq, Enum, Bounded)
 
-data Compiler = MAlonzo Strict | JS CodeOptimization
+data JSModuleStyle = ES6 | CJS | AMD
+  deriving (Show, Read, Eq, Enum, Bounded)
+
+data Compiler
+  = MAlonzo Strict
+  | JS JSModuleStyle CodeOptimization
   deriving (Show, Read, Eq)
 
 data CompilerOptions
@@ -62,9 +67,9 @@ data TestOptions
     } deriving (Show, Read)
 
 allCompilers :: [Compiler]
-allCompilers =
-  map MAlonzo [Lazy, StrictData, Strict] ++
-  map JS [NonOptimized, Optimized, MinifiedOptimized]
+allCompilers
+  =  [ MAlonzo strict | strict <- [minBound..]]
+  ++ [ JS style opt   | opt <- [minBound..], style <- [minBound..] ]
 
 defaultOptions :: TestOptions
 defaultOptions = TestOptions
@@ -131,9 +136,10 @@ tests = do
         | s <- [Lazy, StrictData] ++
                [Strict | ghcVersionAtLeast9]
         ] ++
-        [ JS opt
+        [ JS style opt
         | isJust nodeBin
-        , opt <- [NonOptimized, Optimized, MinifiedOptimized]
+        , opt   <- [minBound..]
+        , style <- [CJS,ES6]
         ]
   _ <- case nodeBin of
     Nothing -> putStrLn "No JS node binary found, skipping JS tests."
@@ -295,10 +301,15 @@ agdaRunProgGoldenTest1 dir comp extraArgs inp opts cont
           Lazy       -> []
           StrictData -> ["--ghc-strict-data"]
           Strict     -> ["--ghc-strict"]
-        argsForComp (JS o)  = [ "--js", "--js-verify" ] ++ case o of
-          NonOptimized      -> []
-          Optimized         -> [ "--js-optimize" ]
-          MinifiedOptimized -> [ "--js-optimize", "--js-minify" ]
+        argsForComp (JS style opt) = [ "--js", "--js-verify" ]
+          ++ case style of
+            ES6 -> ["--js-es6"]
+            AMD -> ["--js-amd"]
+            CJS -> ["--js-cjs"]
+          ++ case opt of
+            NonOptimized      -> []
+            Optimized         -> [ "--js-optimize" ]
+            MinifiedOptimized -> [ "--js-optimize", "--js-minify" ]
 
         removePaths ps = \case
           CompileFailed    r -> CompileFailed    (removePaths' r)
@@ -326,7 +337,9 @@ cleanUpOptions = filter clean
 
 -- gets the generated executable path
 getExecForComp :: Compiler -> FilePath -> FilePath -> FilePath
-getExecForComp JS{} compDir inpFile = compDir </> ("jAgda." ++ takeFileName (dropAgdaOrOtherExtension inpFile) ++ ".js")
+getExecForComp (JS style opt) compDir inpFile
+  = compDir </> ("jAgda." ++ takeFileName (dropAgdaOrOtherExtension inpFile) ++ ext)
+    where ext = if style == ES6 then ".mjs" else ".js"
 getExecForComp _ compDir inpFile = compDir </> takeFileName (dropAgdaOrOtherExtension inpFile)
 
 printExecResult :: ExecResult -> T.Text


### PR DESCRIPTION

This PR adds an option for generating [ES6-style JavaScript modules].

Agda could already generate AMD-style and CommonJS-style modules,
but I'd like Agda to support ES6-style modules, because these are easier for users to consume:

* Browsers support ES6 modules natively (unlike AMD, CommonJs)
* Node.js supports ES6 modules natively (unlike AMD)
* Users don't need `require.js`
* Users don't need `webpack`
* Users don't need `npm`
* Embedding the compiled Agda is very simple:
  ```html
  <script type="module">
    import compiledAgda from "./compile_dir/jAgda.Main.mjs"
    alert("Agda says " + compiledAgda.greet("javascript"))
  </script>
  ```

Implementation Notes:

* Changes based on #5825
* `agda-rts.amd.js` has drifted out of date with `agda-rts.js`
* I based `agda-rts.mjs` on the most recently updated (`agda-rts.js`)
* #6040 has similar features, but stalled

Feedback wanted:

* Flag naming: `--js-esm`, `--js-es6`, or something else?
* Avoiding data races: is putting the `export` keyword at the end of the file enough?

[ES6-style JavaScript modules]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
