### PR TITLE
Refactor: use List1 and Set1 in warnings and errors

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -187,7 +187,7 @@ redoChecks (Just ii) = do
     IPClause{ipcQName = f} -> do
       mb <- mutualBlockOf f
       terErrs <- localTC (\ e -> e { envMutualBlock = Just mb }) $ termMutual []
-      unless (null terErrs) $ warning $ TerminationIssue terErrs
+      List1.unlessNull terErrs $ warning . TerminationIssue
   -- TODO redo positivity check!
 
 -- | Auxiliary definition for 'give' and 'elaborate_give'.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -582,8 +582,8 @@ recordFieldWarningHighlighting = \case
   W.DuplicateFields xrs      -> dead xrs
   W.TooManyFields _q _ys xrs -> dead xrs
   where
-  dead :: [(C.Name, Range)] -> HighlightingInfoBuilder
-  dead = mconcat . map deadcodeHighlighting
+  dead :: List1 (C.Name, Range) -> HighlightingInfoBuilder
+  dead = sconcat . fmap deadcodeHighlighting
   -- Andreas, 2020-03-27 #3684: This variant seems to only highlight @x@:
   -- dead = mconcat . map f
   -- f (x, r) = deadcodeHighlighting (getRange x) `mappend` deadcodeHighlighting r

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -591,7 +591,7 @@ recordFieldWarningHighlighting = \case
 -- | Generate syntax highlighting for termination errors.
 
 terminationErrorHighlighting ::
-  [TerminationError] -> HighlightingInfoBuilder
+  List1 TerminationError -> HighlightingInfoBuilder
 terminationErrorHighlighting termErrs = functionDefs `mappend` callSites
   where
     m            = parserBased { otherAspects = Set.singleton TerminationProblem }

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -98,6 +98,7 @@ import Agda.Utils.IO.Binary
 import Agda.Syntax.Common.Pretty hiding (Mode)
 import qualified Agda.Utils.ProfileOptions as Profile
 import Agda.Utils.Hash
+import qualified Agda.Utils.Set1 as Set1
 import qualified Agda.Utils.Trie as Trie
 
 import Agda.Utils.Impossible
@@ -556,7 +557,7 @@ raiseNonFatalErrors :: (HasOptions m, MonadTCError m)
   => CheckResult  -- ^ E.g. obtained from 'typeCheckMain'.
   -> m ()
 raiseNonFatalErrors result = do
-  unlessNullM (applyFlagsToTCWarnings (crWarnings result)) $ \ ws ->
+  Set1.unlessNullM (applyFlagsToTCWarnings (crWarnings result)) $ \ ws ->
     typeError $ NonFatalErrors ws
 
 -- | Check if the options used for checking an imported module are

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -123,7 +123,7 @@ data DeclarationWarning'
       --   that does not apply to any function.
   | MissingDeclarations [(Name, Range)]
       -- ^ Definitions (e.g. constructors or functions) without a declaration.
-  | MissingDefinitions [(Name, Range)]
+  | MissingDefinitions (List1 (Name, Range))
       -- ^ Declarations (e.g. type signatures) without a definition.
   | NotAllowedInMutual Range String
   | OpenPublicPrivate KwRange
@@ -446,7 +446,7 @@ instance Pretty DeclarationWarning' where
 
     MissingDefinitions xs -> fsep $
      pwords "The following names are declared but not accompanied by a definition:"
-     ++ punctuate comma (map (pretty . fst) xs)
+     ++ punctuate comma (fmap (pretty . fst) xs)
 
     NotAllowedInMutual r nd -> fsep $
       text nd : pwords "in mutual blocks are not supported.  Suggestion: get rid of the mutual block by manually ordering declarations"

--- a/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
@@ -4,7 +4,7 @@ module Agda.Syntax.Concrete.Definitions.Monad where
 
 import Prelude hiding ( null )
 
-import Control.Monad        ( unless )
+import Control.Monad        ()
 import Control.Monad.Except ( MonadError(..), ExceptT, runExceptT )
 import Control.Monad.Reader ( MonadReader, ReaderT, runReaderT )
 import Control.Monad.State  ( MonadState(..), modify, State, runState )
@@ -165,8 +165,8 @@ forgetLoneSigs = loneSigs .= Map.empty
 checkLoneSigs :: LoneSigs -> Nice ()
 checkLoneSigs xs = do
   forgetLoneSigs
-  unless (Map.null xs) $ declarationWarning $ MissingDefinitions $
-    map (\s -> (loneSigName s , loneSigRange s)) $ Map.elems xs
+  List1.unlessNull (Map.elems xs) \ ss -> declarationWarning $ MissingDefinitions $
+    fmap (\s -> (loneSigName s , loneSigRange s)) ss
 
 -- | Ensure that all forward declarations have been given a definition,
 -- raising an error indicating *why* they would have had to have been

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -810,7 +810,7 @@ applyImportDirectiveM m (ImportDirective rng usn' hdn' ren' public) scope0 = do
 
     -- Check for duplicate imports in a single import directive.
     -- @dup@ : To be imported names that are mentioned more than once.
-    unlessNull (allDuplicates targetNames) $ \ dup ->
+    () <- List1.unlessNull (allDuplicates targetNames) $ \ dup ->
       typeError $ DuplicateImports m dup
 
     -- Apply the import directive.

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -28,6 +28,7 @@ import Agda.Interaction.Options
 import Agda.Interaction.Options.Warnings
 
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty
 import Agda.Syntax.Position
 import Agda.Syntax.Fixity
 import Agda.Syntax.Notation
@@ -62,7 +63,7 @@ import qualified Agda.Utils.List2 as List2
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import Agda.Syntax.Common.Pretty
+import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Singleton
 import Agda.Utils.Suffix as C
 
@@ -817,10 +818,10 @@ applyImportDirectiveM m (ImportDirective rng usn' hdn' ren' public) scope0 = do
 
     -- Andreas, 2019-11-08, issue #4154, report clashes
     -- introduced by the @renaming@.
-    unless (null nameClashes) $
-      warning $ ClashesViaRenaming NameNotModule $ Set.toList nameClashes
-    unless (null moduleClashes) $
-      warning $ ClashesViaRenaming ModuleNotName $ Set.toList moduleClashes
+    Set1.unlessNull nameClashes \ nameClashes ->
+      warning $ ClashesViaRenaming NameNotModule nameClashes
+    Set1.unlessNull moduleClashes \ moduleClashes ->
+      warning $ ClashesViaRenaming ModuleNotName moduleClashes
 
     -- Look up the defined names in the new scope.
     let namesInScope'   = (allNamesInScope scope' :: ThingsInScope AbstractName)

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -779,9 +779,9 @@ applyImportDirectiveM m (ImportDirective rng usn' hdn' ren' public) scope0 = do
     -- We start by checking that all of the names talked about in the import
     -- directive do exist.  If some do not then we remove them and raise a warning.
     let (missingExports, namesA) = checkExist $ usingList ++ hdn' ++ map renFrom ren'
-    unless (null missingExports) $ setCurrentRange rng $ do
+    () <- List1.unlessNull missingExports \ missingExports1 -> setCurrentRange rng do
       reportSLn "scope.import.apply" 30 $ "non existing names: " ++ prettyShow missingExports
-      warning $ ModuleDoesntExport m (Map.keys namesInScope) (Map.keys modulesInScope) missingExports
+      warning $ ModuleDoesntExport m (Map.keys namesInScope) (Map.keys modulesInScope) missingExports1
 
     -- We can now define a cleaned-up version of the import directive.
     let notMissing = not . (missingExports `hasElem`)  -- #3997, efficient lookup in missingExports

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -868,7 +868,7 @@ applyImportDirectiveM m (ImportDirective rng usn' hdn' ren' public) scope0 = do
           let useless = \case
                 ImportedName{}   -> True
                 ImportedModule y -> notMentioned (ImportedName y)
-          unlessNull (filter useless ys) $ warning . UselessHiding
+          () <- List1.unlessNull (filter useless ys) $ warning . UselessHiding
           -- We can empty @hiding@ now, since there is an explicit @using@ directive
           -- and @hiding@ served its purpose to prevent modules to enter the @Using@ list.
           return dir{ hiding = [] }

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -1029,9 +1029,9 @@ openModule kind mam cm dir = do
               ]
               where ks = fmap anameKind qs
         -- We report the first clashing exported identifier.
-        unlessNull (filter defClash defClashes) $
-          \ ((x, q :| _) : _) -> typeError $ ClashingDefinition (C.QName x) (anameName q) Nothing
+        () <- List1.unlessNull (filter defClash defClashes) $
+          \ ((x, q :| _) :| _) -> typeError $ ClashingDefinition (C.QName x) (anameName q) Nothing
 
-        unlessNull modClashes $ \ ((_, ms) : _) -> do
+        List1.unlessNull modClashes $ \ ((_, ms) :| _) -> do
           caseMaybe (List1.last2 ms) __IMPOSSIBLE__ $ \ (m0, m1) -> do
             typeError $ ClashingModule (amodName m0) (amodName m1)

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1816,7 +1816,7 @@ instance ToAbstract NiceDeclaration where
           gvars <- bindGeneralizablesIfInserted o ax
           -- Check for duplicate constructors
           do cs <- mapM conName cons
-             unlessNull (duplicates cs) $ \ dups -> do
+             List1.unlessNull (duplicates cs) $ \ dups -> do
                let bad = filter (`elem` dups) cs
                setCurrentRange bad $
                  typeError $ DuplicateConstructors dups

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1465,7 +1465,7 @@ niceDecls warn ds ret = setCurrentRange ds $ computeFixitiesAndPolarities warn d
       let (errs, ws) = List.partition unsafeDeclarationWarning warns
       -- If some of them are, we fail
       List1.unlessNull errs \ errs -> do
-        warnings $ map NicifierIssue ws
+        List1.unlessNull ws \ ws -> warnings $ fmap NicifierIssue ws
         tcerrs <- mapM (warning_ . NicifierIssue) errs
         setCurrentRange errs $ typeError $ NonFatalErrors $ Set1.fromList tcerrs
     -- Otherwise we simply record the warnings

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -41,6 +41,9 @@ import qualified Data.HashSet as HashSet
 import Data.Maybe
 import Data.Void
 
+import Agda.Syntax.Common
+import qualified Agda.Syntax.Common.Pretty as P
+import Agda.Syntax.Common.Pretty (render, Pretty, pretty, prettyShow)
 import Agda.Syntax.Concrete as C
 import Agda.Syntax.Concrete.Attribute as CA
 import Agda.Syntax.Concrete.Generic
@@ -53,7 +56,6 @@ import Agda.Syntax.Abstract.Pretty
 import qualified Agda.Syntax.Internal as I
 import Agda.Syntax.Position
 import Agda.Syntax.Literal
-import Agda.Syntax.Common
 import Agda.Syntax.Info as Info
 import Agda.Syntax.Concrete.Definitions as C
 import Agda.Syntax.Fixity
@@ -106,8 +108,7 @@ import qualified Agda.Utils.Map as Map
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import qualified Agda.Syntax.Common.Pretty as P
-import Agda.Syntax.Common.Pretty (render, Pretty, pretty, prettyShow)
+import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Singleton
 import Agda.Utils.Tuple
 
@@ -1463,10 +1464,10 @@ niceDecls warn ds ret = setCurrentRange ds $ computeFixitiesAndPolarities warn d
     when isSafe $ do
       let (errs, ws) = List.partition unsafeDeclarationWarning warns
       -- If some of them are, we fail
-      unless (null errs) $ do
+      List1.unlessNull errs \ errs -> do
         warnings $ map NicifierIssue ws
         tcerrs <- mapM (warning_ . NicifierIssue) errs
-        setCurrentRange errs $ typeError $ NonFatalErrors $ Set.fromList tcerrs
+        setCurrentRange errs $ typeError $ NonFatalErrors $ Set1.fromList tcerrs
     -- Otherwise we simply record the warnings
     mapM_ (\ w -> warning' (dwLocation w) $ NicifierIssue w) warns
   case result of

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1888,7 +1888,7 @@ instance ToAbstract NiceDeclaration where
                    C.FieldSig _ _ f _ -> f
                    _ -> __IMPOSSIBLE__
                  _ -> Nothing
-           unlessNull (duplicates fs) $ \ dups -> do
+           List1.unlessNull (duplicates fs) $ \ dups -> do
              let bad = filter (`elem` dups) fs
              setCurrentRange bad $
                typeError $ DuplicateFields dups

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2113,7 +2113,7 @@ instance ToAbstract NiceDeclaration where
          bindVarsToBind
          p <- A.noDotOrEqPattern (typeError DotPatternInPatternSynonym) p
          as <- mapM checkPatSynParam as
-         unlessNull (patternVars p List.\\ map whThing as) $ \ xs -> do
+         List1.unlessNull (patternVars p List.\\ map whThing as) $ \ xs -> do
            typeError $ UnboundVariablesInPatternSynonym xs
          return (as, p)
       y <- freshAbstractQName' n

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -744,12 +744,11 @@ freshQModule m x = A.qualifyM m . mnameFromList1 . singleton <$> freshAbstractNa
 checkForModuleClash :: C.Name -> ScopeM ()
 checkForModuleClash x = do
   ms :: [AbstractModule] <- scopeLookup (C.QName x) <$> getScope
-  unless (null ms) $ do
+  List1.unlessNull ms \ ms -> do
     reportSLn "scope.clash" 40 $ "clashing modules ms = " ++ prettyShow ms
     reportSLn "scope.clash" 60 $ "clashing modules ms = " ++ show ms
     setCurrentRange x $
-      typeError $ ShadowedModule x $
-                map ((`withRangeOf` x) . amodName) ms
+      typeError $ ShadowedModule x $ fmap ((`withRangeOf` x) . amodName) ms
 
 instance ToAbstract NewModuleName where
   type AbsOfCon NewModuleName = A.ModuleName

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -247,9 +247,9 @@ coverageCheck f t cs = do
   let noexclauses = forMaybe noex $ \ i -> do
         let cl = indexWithDefault __IMPOSSIBLE__ cs1 i
         if clauseCatchall cl then Nothing else Just cl
-  unless (null noexclauses) $ do
-      setCurrentRange (map clauseLHSRange noexclauses) $
-        warning $ CoverageNoExactSplit f $ noexclauses
+  List1.unlessNull noexclauses \ noexclauses -> do
+      setCurrentRange (fmap clauseLHSRange noexclauses) $
+        warning $ CoverageNoExactSplit f noexclauses
   return splitTree
 
 -- | Top-level function for eliminating redundant clauses in the interactive

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -33,6 +33,7 @@ import qualified Data.IntSet as IntSet
 import qualified Agda.Benchmarking as Bench
 
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Position
 import Agda.Syntax.Internal hiding (DataOrRecord)
 import Agda.Syntax.Internal.Pattern
@@ -71,11 +72,11 @@ import Agda.Utils.Either
 import Agda.Utils.Function
 import Agda.Utils.Functor
 import Agda.Utils.List
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Utils.Permutation
-import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Utils.Singleton
 import Agda.Utils.Size
 import Agda.Utils.Tuple
@@ -208,7 +209,7 @@ coverageCheck f t cs = do
       return False
 
   -- report a warning if there are uncovered cases,
-  unless (null pss) $ do
+  List1.unlessNull pss \ pss -> do
     stLocalPartialDefs `modifyTCLens` Set.insert f
     whenM ((YesCoverageCheck ==) <$> viewTC eCoverageCheck) $
       setCurrentRange cs $ warning $ CoverageIssue f pss

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -688,7 +688,7 @@ instance PrettyTCM TypeError where
       pretty bd :
       pwords " is not allowed in a telescope here."
 
-    AbsentRHSRequiresAbsurdPattern ps -> fwords $
+    AbsentRHSRequiresAbsurdPattern -> fwords $
       "The right-hand side can only be omitted if there " ++
       "is an absurd pattern, () or {}, in the left-hand side."
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -865,7 +865,7 @@ instance PrettyTCM TypeError where
 
     DuplicateImports m xs -> fsep $
       pwords "Ambiguous imports from module" ++ [pretty m] ++ pwords "for" ++
-      punctuate comma (map pretty xs)
+      punctuate comma (fmap pretty xs)
 
     DefinitionInDifferentModule _x -> fsep $
       pwords "Definition in different module than its type signature"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -356,16 +356,14 @@ instance PrettyTCM TypeError where
       [prettyTCM c] ++ pwords "is not a constructor of the datatype"
       ++ [prettyTCM d]
 
-    ShadowedModule x [] -> __IMPOSSIBLE__
-
-    ShadowedModule x ms@(m0 : _) -> do
+    ShadowedModule x ms@(m0 :| _) -> do
       -- Clash! Concrete module name x already points to the abstract names ms.
       (r, m) <- do
         -- Andreas, 2017-07-28, issue #719.
         -- First, we try to find whether one of the abstract names @ms@ points back to @x@
         scope <- getScope
         -- Get all pairs (y,m) such that y points to some m ∈ ms.
-        let xms0 = ms >>= \ m -> map (,m) $ inverseScopeLookupModule m scope
+        let xms0 = concat $ ms <&> \ m -> map (,m) $ inverseScopeLookupModule m scope
         reportSLn "scope.clash.error" 30 $ "candidates = " ++ prettyShow xms0
 
         -- Try to find x (which will have a different Range, if it has one (#2649)).
@@ -376,7 +374,7 @@ instance PrettyTCM TypeError where
         ifJust (listToMaybe xms) (\ (x', m) -> return (getRange x', m)) $ {-else-} do
 
         -- If that failed, we pick the first m from ms which has a nameBindingSite.
-        let rms = ms >>= \ m -> map (,m) $
+        let rms = concat $ ms <&> \ m -> map (,m) $
               filter (noRange /=) $ map nameBindingSite $ reverse $ mnameToList m
               -- Andreas, 2017-07-25, issue #2649
               -- Take the first nameBindingSite we can get hold of.

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -571,7 +571,7 @@ instance PrettyTCM TypeError where
     DuplicateConstructors xs -> fsep $ concat
       [ [ "Duplicate" ]
       , [ pluralS xs "constructor" ]
-      , punctuate comma (map pretty xs)
+      , punctuate comma $ fmap pretty xs
       , pwords "in datatype"
       ]
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1004,7 +1004,7 @@ instance PrettyTCM TypeError where
 
     UnboundVariablesInPatternSynonym xs -> fsep $
       pwords "Unbound variables in pattern synonym: " ++
-      [sep (map prettyA xs)]
+      [sep (fmap prettyA xs)]
 
     NoParseForLHS lhsOrPatSyn errs p -> vcat
       [ fsep $ pwords "Could not parse the" ++ prettyLhsOrPatSyn ++ [pretty p]

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -44,6 +44,8 @@ import Agda.Interaction.Options
 import Agda.Interaction.Options.Errors
 
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty ( prettyShow, render )
+import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Syntax.Concrete.Definitions (notSoNiceDeclarations)
 import Agda.Syntax.Concrete.Definitions.Errors (declarationExceptionString)
 import Agda.Syntax.Concrete.Pretty (attributesForModality, prettyHiding, prettyRelevance)
@@ -86,8 +88,7 @@ import qualified Agda.Utils.List1 as List1
 import qualified Agda.Utils.List2 as List2
 import Agda.Utils.Maybe
 import Agda.Utils.Null
-import Agda.Syntax.Common.Pretty ( prettyShow, render )
-import qualified Agda.Syntax.Common.Pretty as P
+import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Size
 
 import Agda.Utils.Impossible
@@ -143,7 +144,7 @@ instance PrettyTCM TCErr where
     -- fact that  ̀ws` is non-empty.
     TypeError loc _ Closure{ clValue = NonFatalErrors ws } -> do
       reportSLn "error" 2 $ "Error raised at " ++ prettyShow loc
-      vsep $ map prettyTCM $ Set.toAscList ws
+      vsep $ fmap prettyTCM $ Set1.toAscList ws
     -- Andreas, 2014-03-23
     -- This use of withTCState seems ok since we do not collect
     -- Benchmark info during printing errors.
@@ -1248,7 +1249,7 @@ instance PrettyTCM TypeError where
     MultiplePolarityPragmas xs -> fsep $
       pwords "Multiple polarity pragmas for" ++ map pretty xs
 
-    NonFatalErrors ws -> vsep $ map prettyTCM $ Set.toAscList ws
+    NonFatalErrors ws -> vsep $ fmap prettyTCM $ Set1.toAscList ws
 
     InstanceSearchDepthExhausted c a d -> fsep $
       pwords ("Instance search depth exhausted (max depth: " ++ show d ++ ") for candidate") ++

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -387,16 +387,16 @@ computeGeneralization genRecMeta nameMap allmetas = postponeInstanceConstraints 
         metas <- filterM canGeneralize . Set.toList .
                  allMetas Set.singleton =<<
                  instantiateFull (instBody inst)
-        unless (null metas) $
+        unless (null metas) do
           reportSDoc "tc.generalize" 40 $
             hcat ["Inherited metas from ", prettyTCM x, ":"] <?> prettyList_ (map prettyTCM metas)
-        -- #4291: Override existing meta name suggestion.
-        -- Don't suggest names for explicitly named generalizable metas.
-        case filter (`Map.notMember` nameMap) metas of
-          -- If we solved the parent with a new meta use the parent name for that.
-          [m] | MetaV{} <- instBody inst -> setMetaNameSuggestion m parentName
-          -- Otherwise suffix with a number.
-          ms -> zipWithM_ (\ i m -> setMetaNameSuggestion m (parentName ++ "." ++ show i)) [1..] ms
+          -- #4291: Override existing meta name suggestion.
+          -- Don't suggest names for explicitly named generalizable metas.
+          case filter (`Map.notMember` nameMap) metas of
+            -- If we solved the parent with a new meta use the parent name for that.
+            [m] | MetaV{} <- instBody inst -> setMetaNameSuggestion m parentName
+            -- Otherwise suffix with a number.
+            ms -> zipWithM_ (\ i m -> setMetaNameSuggestion m (parentName ++ "." ++ show i)) [1..] ms
         return $ Set.fromList metas
       _ -> __IMPOSSIBLE__
 

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -163,9 +163,11 @@ import Agda.Utils.Functor
 import Agda.Utils.Impossible
 import Agda.Utils.Lens
 import Agda.Utils.List (downFrom, hasElem)
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
+import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Size
 import Agda.Utils.Permutation
 
@@ -344,8 +346,8 @@ computeGeneralization genRecMeta nameMap allmetas = postponeInstanceConstraints 
     ]
 
   -- Issue 3301: We can't generalize over sorts
-  unlessNull openSortMetas $ \ ms ->
-    warning $ CantGeneralizeOverSorts $ map fst ms
+  List1.unlessNull openSortMetas $ \ ms ->
+    warning $ CantGeneralizeOverSorts $ Set1.fromList $ fmap fst ms
 
   -- Any meta in the solution of a generalizable meta should be generalized over (if possible).
   cp <- viewTC eCurrentCheckpoint

--- a/src/full/Agda/TypeChecking/LevelConstraints.hs
+++ b/src/full/Agda/TypeChecking/LevelConstraints.hs
@@ -3,7 +3,7 @@
 module Agda.TypeChecking.LevelConstraints ( simplifyLevelConstraint ) where
 
 import qualified Data.List as List
-import Data.Maybe
+
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Substitute
@@ -12,6 +12,7 @@ import Agda.TypeChecking.Level
 
 import Agda.Utils.Impossible
 import Agda.Utils.List (nubOn)
+import Agda.Utils.List1 (List1)
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Update
 
@@ -24,7 +25,7 @@ import Agda.Utils.Update
 --   takes care of renaming variables when checking for matches.
 simplifyLevelConstraint
   :: Constraint          -- ^ Constraint @c@ to simplify.
-  -> [Constraint]        -- ^ Other constraints, enable simplification.
+  -> List1 Constraint    -- ^ Other constraints, enable simplification.
   -> Maybe [Constraint]  -- ^ @Just@: list of constraints equal to the original @c@.
                          --   @Nothing@: no simplification possible.
 simplifyLevelConstraint c others = do
@@ -38,7 +39,7 @@ simplifyLevelConstraint c others = do
     simpl (a :=< b)
       | any (matchLeq (b :=< a)) leqs = dirty  $ LevelCmp CmpEq  (unSingleLevel a) (unSingleLevel b)
       | otherwise                     = return $ LevelCmp CmpLeq (unSingleLevel a) (unSingleLevel b)
-    leqs = concat $ mapMaybe inequalities others
+    leqs = concat $ List1.mapMaybe inequalities others
 
 data Leq = SingleLevel :=< SingleLevel
   deriving (Show, Eq)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4853,7 +4853,7 @@ data TypeError
         | NoSuchPrimitiveFunction String
         | DuplicatePrimitiveBinding PrimitiveId QName QName
         | WrongArgInfoForPrimitive PrimitiveId ArgInfo ArgInfo
-        | ShadowedModule C.Name [A.ModuleName]
+        | ShadowedModule C.Name (List1 A.ModuleName)
         | BuiltinInParameterisedModule BuiltinId
         | IllegalDeclarationInDataDefinition [C.Declaration]
             -- ^ The declaration list comes from a single 'C.NiceDeclaration'.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4859,7 +4859,7 @@ data TypeError
             -- ^ The declaration list comes from a single 'C.NiceDeclaration'.
         | IllegalLetInTelescope C.TypedBinding
         | IllegalPatternInTelescope C.Binder
-        | AbsentRHSRequiresAbsurdPattern [NamedArg A.Pattern]
+        | AbsentRHSRequiresAbsurdPattern
         | TooManyFields QName [C.Name] (List1 C.Name)
           -- ^ Record type, fields not supplied by user, possibly non-fields but supplied.
         | DuplicateFields (List1 C.Name)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4296,7 +4296,7 @@ data Warning
   | InteractionMetaBoundaries (Set1 Range)
     -- ^ Do not use directly with 'warning'
 
-  | CantGeneralizeOverSorts [MetaId]
+  | CantGeneralizeOverSorts (Set1 MetaId)
   | AbsurdPatternRequiresAbsentRHS [NamedArg DeBruijnPattern]
   | OldBuiltin               BuiltinId BuiltinId
     -- ^ In `OldBuiltin old new`, the BUILTIN old has been replaced by new.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4297,7 +4297,7 @@ data Warning
     -- ^ Do not use directly with 'warning'
 
   | CantGeneralizeOverSorts (Set1 MetaId)
-  | AbsurdPatternRequiresAbsentRHS [NamedArg DeBruijnPattern]
+  | AbsurdPatternRequiresAbsentRHS
   | OldBuiltin               BuiltinId BuiltinId
     -- ^ In `OldBuiltin old new`, the BUILTIN old has been replaced by new.
   | BuiltinDeclaresIdentifier BuiltinId

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5137,9 +5137,9 @@ data IllegalRewriteRuleReason
   | HeadSymbolIsTypeConstructor QName
   | HeadSymbolContainsMetas QName
   | ConstructorParametersNotGeneral ConHead Args
-  | ContainsUnsolvedMetaVariables (Set MetaId)
-  | BlockedOnProblems (Set ProblemId)
-  | RequiresDefinitions (Set QName)
+  | ContainsUnsolvedMetaVariables (Set1 MetaId)
+  | BlockedOnProblems (Set1 ProblemId)
+  | RequiresDefinitions (Set1 QName)
   | DoesNotTargetRewriteRelation
   | BeforeFunctionDefinition
   | BeforeMutualFunctionDefinition QName

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4969,7 +4969,7 @@ data TypeError
         | ClashingModule A.ModuleName A.ModuleName
         | DefinitionInDifferentModule A.QName
             -- ^ The given data/record definition rests in a different module than its signature.
-        | DuplicateImports C.QName [C.ImportedName]
+        | DuplicateImports C.QName (List1 C.ImportedName)
         | InvalidPattern C.Pattern
         | InvalidPun ConstructorOrPatternSynonym C.QName
             -- ^ Expected the identifier to be a variable, not a constructor or pattern synonym.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4278,7 +4278,7 @@ data Warning
   --   are unreachable
   | CoverageIssue            QName (List1 (Telescope, [NamedArg DeBruijnPattern]))
   -- ^ `CoverageIssue f pss` means that `pss` are not covered in `f`
-  | CoverageNoExactSplit     QName [Clause]
+  | CoverageNoExactSplit     QName (List1 Clause)
   | InlineNoExactSplit       QName Clause
     -- ^ 'Clause' was turned into copattern matching clause(s) by an @{-# INLINE constructor #-}@
     --   and thus is not a definitional equality any more.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5010,7 +5010,7 @@ data TypeError
             --   The resolvents are given in the list.
         | UnusedVariableInPatternSynonym C.Name
             -- ^ This variable is only bound on the lhs of the pattern synonym, not on the rhs.
-        | UnboundVariablesInPatternSynonym [A.Name]
+        | UnboundVariablesInPatternSynonym (List1 A.Name)
             -- ^ These variables are only bound on the rhs of the pattern synonym, not on the lhs.
     -- Operator errors
         | NoParseForApplication (List2 C.Expr)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4333,7 +4333,7 @@ data Warning
   | UselessPublic
     -- ^ If the user opens a module public before the module header.
     --   (See issue #2377.)
-  | UselessHiding [C.ImportedName]
+  | UselessHiding (List1 C.ImportedName)
     -- ^ Names in `hiding` directive that don't hide anything
     --   imported by a `using` directive.
   | UselessInline            QName

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4863,7 +4863,7 @@ data TypeError
         | TooManyFields QName [C.Name] (List1 C.Name)
           -- ^ Record type, fields not supplied by user, possibly non-fields but supplied.
         | DuplicateFields (List1 C.Name)
-        | DuplicateConstructors [C.Name]
+        | DuplicateConstructors (List1 C.Name)
         | DuplicateOverlapPragma QName OverlapMode OverlapMode
         | WithOnFreeVariable A.Expr Term
         | UnexpectedWithPatterns (List1 A.Pattern)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4319,7 +4319,7 @@ data Warning
     --   The 'String' gives optionally extra explanation.
   | InvalidCharacterLiteral Char
     -- ^ A character literal Agda does not support, e.g. surrogate code points.
-  | ClashesViaRenaming NameOrModule [C.Name]
+  | ClashesViaRenaming NameOrModule (Set1 C.Name)
     -- ^ If a `renaming' import directive introduces a name or module name clash
     --   in the exported names of a module.
     --   (See issue #4154.)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4374,7 +4374,7 @@ data Warning
     -- ^ Duplicate mentions of the same name in @using@ directive(s).
   | FixityInRenamingModule (List1 Range)
     -- ^ Fixity of modules cannot be changed via renaming (since modules have no fixity).
-  | ModuleDoesntExport C.QName [C.Name] [C.Name] [C.ImportedName]
+  | ModuleDoesntExport C.QName [C.Name] [C.Name] (List1 C.ImportedName)
     -- ^ Some imported names are not actually exported by the source module.
     --   The second argument is the names that could be exported.
     --   The third  argument is the module names that could be exported.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4477,8 +4477,8 @@ data Warning
 
 recordFieldWarningToError :: RecordFieldWarning -> TypeError
 recordFieldWarningToError = \case
-  W.DuplicateFields    xrs -> DuplicateFields    $ map fst xrs
-  W.TooManyFields q ys xrs -> TooManyFields q ys $ map fst xrs
+  W.DuplicateFields    xrs -> DuplicateFields    $ fmap fst xrs
+  W.TooManyFields q ys xrs -> TooManyFields q ys $ fmap fst xrs
 
 warningName :: Warning -> WarningName
 warningName = \case
@@ -4860,9 +4860,9 @@ data TypeError
         | IllegalLetInTelescope C.TypedBinding
         | IllegalPatternInTelescope C.Binder
         | AbsentRHSRequiresAbsurdPattern [NamedArg A.Pattern]
-        | TooManyFields QName [C.Name] [C.Name]
-          -- ^ Record type, fields not supplied by user, non-fields but supplied.
-        | DuplicateFields [C.Name]
+        | TooManyFields QName [C.Name] (List1 C.Name)
+          -- ^ Record type, fields not supplied by user, possibly non-fields but supplied.
+        | DuplicateFields (List1 C.Name)
         | DuplicateConstructors [C.Name]
         | DuplicateOverlapPragma QName OverlapMode OverlapMode
         | WithOnFreeVariable A.Expr Term

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5046,7 +5046,7 @@ data TypeError
         | NeedOptionTwoLevel
         | NeedOptionUniversePolymorphism
     -- Failure associated to warnings
-        | NonFatalErrors (Set TCWarning)
+        | NonFatalErrors (Set1 TCWarning)
     -- Instance search errors
         | InstanceSearchDepthExhausted Term Type Int
         | TriedToCopyConstrainedPrim QName

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4276,7 +4276,7 @@ data Warning
   | UnreachableClauses       QName [Range]
   -- ^ `UnreachableClauses f rs` means that the clauses in `f` whose ranges are rs
   --   are unreachable
-  | CoverageIssue            QName [(Telescope, [NamedArg DeBruijnPattern])]
+  | CoverageIssue            QName (List1 (Telescope, [NamedArg DeBruijnPattern]))
   -- ^ `CoverageIssue f pss` means that `pss` are not covered in `f`
   | CoverageNoExactSplit     QName [Clause]
   | InlineNoExactSplit       QName Clause

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4272,7 +4272,7 @@ data ArgsCheckState a = ACState
 
 data Warning
   = NicifierIssue            DeclarationWarning
-  | TerminationIssue         [TerminationError]
+  | TerminationIssue         (List1 TerminationError)
   | UnreachableClauses       QName [Range]
   -- ^ `UnreachableClauses f rs` means that the clauses in `f` whose ranges are rs
   --   are unreachable

--- a/src/full/Agda/TypeChecking/Monad/Base/Warning.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base/Warning.hs
@@ -8,10 +8,12 @@ import           Agda.Syntax.Abstract.Name
 import           Agda.Syntax.Position       (Range)
 import qualified Agda.Syntax.Concrete.Name  as C
 
+import           Agda.Utils.List1           (List1)
+
 data RecordFieldWarning
-  = DuplicateFields [(C.Name, Range)]
+  = DuplicateFields (List1 (C.Name, Range))
       -- ^ Each redundant field comes with a range of associated dead code.
-  | TooManyFields QName [C.Name] [(C.Name, Range)]
+  | TooManyFields QName [C.Name] (List1 (C.Name, Range))
       -- ^ Record type, fields not supplied by user, non-fields but supplied.
       --   The redundant fields come with a range of associated dead code.
   deriving (Show, Generic)

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -40,6 +40,7 @@ import Agda.Utils.FileName
 import qualified Agda.Utils.Graph.AdjacencyMap.Unidirectional as G
 import Agda.Utils.Lens
 import Agda.Utils.List
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.Size
@@ -120,7 +121,7 @@ libToTCM m = do
   modifyTCLens stProjectConfigs $ const cachedConfs'
   modifyTCLens stAgdaLibFiles   $ const cachedLibs'
 
-  unless (null warns) $ warnings $ map LibraryWarning warns
+  List1.unlessNull warns \ warns -> warnings $ fmap LibraryWarning warns
   case z of
     Left s  -> typeError $ LibraryError s
     Right x -> return x

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -250,6 +250,10 @@ instance {-# OVERLAPPABLE #-} PrettyTCM a => PrettyTCM [a] where
   prettyTCM = prettyList . map prettyTCM
 {-# SPECIALIZE prettyTCM :: PrettyTCM a => [a] -> TCM Doc #-}
 
+instance {-# OVERLAPPABLE #-} PrettyTCM a => PrettyTCM (List1 a) where
+  prettyTCM = prettyList . fmap prettyTCM
+{-# SPECIALIZE prettyTCM :: PrettyTCM a => [a] -> TCM Doc #-}
+
 instance {-# OVERLAPPABLE #-} PrettyTCM a => PrettyTCM (Maybe a) where
   prettyTCM = maybe empty prettyTCM
 {-# SPECIALIZE prettyTCM :: PrettyTCM a => Maybe a -> TCM Doc #-}

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -54,6 +54,7 @@ import Agda.Utils.FileName ( filePath )
 import Agda.Utils.Functor  ( (<.>) )
 import Agda.Utils.Lens
 import Agda.Utils.List ( editDistance )
+import Agda.Utils.List1 ( pattern (:|) )
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Null
 import Agda.Utils.Singleton
@@ -680,7 +681,7 @@ tcWarningsToError :: [TCWarning] -> TCM ()
 tcWarningsToError mws = case (unsolvedHoles, otherWarnings) of
    ([], [])                   -> return ()
    (_unsolvedHoles@(_:_), []) -> typeError SolvedButOpenHoles
-   (_, ws@(_:_))              -> typeError $ NonFatalErrors $ Set.fromList ws
+   (_ , w : ws)               -> typeError $ NonFatalErrors $ Set1.fromList (w :| ws)
    where
    -- filter out unsolved interaction points for imported module so
    -- that we get the right error message (see test case Fail/Issue1296)

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -93,14 +93,16 @@ prettyWarning = \case
 
     TerminationIssue because -> do
       dropTopLevel <- topLevelModuleDropper
-      fwords "Termination checking failed for the following functions:"
-        $$ nest 2 (fsep $ punctuate comma $
-             map (pretty . dropTopLevel) $
-               concatMap termErrFunctions because)
-        $$ fwords "Problematic calls:"
-        $$ nest 2 (fmap (P.vcat . List.nub) $
-              mapM prettyTCM $ List.sortOn getRange $
-              concatMap termErrCalls because)
+      vcat
+        [ fwords "Termination checking failed for the following functions:"
+        , nest 2 $ fsep $ punctuate comma $
+            map (pretty . dropTopLevel) $
+              concatMap termErrFunctions because
+        , fwords "Problematic calls:"
+        , nest 2 $ fmap (P.vcat . List.nub) $
+            mapM prettyTCM $ List.sortOn getRange $
+              concatMap termErrCalls because
+        ]
 
     UnreachableClauses _f pss -> "Unreachable" <+> pluralS pss "clause"
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -205,7 +205,7 @@ prettyWarning = \case
 
     UselessHiding xs -> fsep $ concat
       [ pwords "Ignoring names in `hiding' directive:"
-      , punctuate "," $ map pretty xs
+      , punctuate "," $ fmap pretty xs
       ]
 
     UselessInline q -> fsep $

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -162,7 +162,7 @@ prettyWarning = \case
             , fsep $ pwords "Suggestion: add a `variable Any : Set _` and replace unsolved metas by Any"
             ]
 
-    AbsurdPatternRequiresAbsentRHS ps -> fwords $
+    AbsurdPatternRequiresAbsentRHS -> fwords $
       "The right-hand side must be omitted if there " ++
       "is an absurd pattern, () or {}, in the left-hand side."
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -54,7 +54,7 @@ import Agda.Utils.FileName ( filePath )
 import Agda.Utils.Functor  ( (<.>) )
 import Agda.Utils.Lens
 import Agda.Utils.List ( editDistance )
-import Agda.Utils.List1 ( pattern (:|) )
+import Agda.Utils.List1 ( pattern (:|), (<|) )
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Null
 import Agda.Utils.Singleton
@@ -121,8 +121,8 @@ prettyWarning = \case
     CoverageNoExactSplit f cs -> vcat $
       fsep (pwords "Exact splitting is enabled, but the following" ++ [ pluralS cs "clause" ] ++
             pwords "could not be preserved as definitional equalities in the translation to a case tree:"
-           ) :
-      map (nest 2 . prettyTCM . NamedClause f True) cs
+           ) <|
+      fmap (nest 2 . prettyTCM . NamedClause f True) cs
 
     InlineNoExactSplit f c -> vcat $
       [ fsep $

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -194,7 +194,7 @@ prettyWarning = \case
     ClashesViaRenaming nm xs -> fsep $ concat $
       [ [ case nm of NameNotModule -> "Name"; ModuleNotName -> "Module" ]
       , pwords "clashes introduced by `renaming':"
-      , map prettyTCM xs
+      , map prettyTCM $ Fold.toList xs
       ]
 
     UselessPatternDeclarationForRecord s -> fwords $ unwords

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -106,10 +106,15 @@ prettyWarning = \case
 
     UnreachableClauses _f pss -> "Unreachable" <+> pluralS pss "clause"
 
-    CoverageIssue f pss -> fsep (
-      pwords "Incomplete pattern matching for" ++ [prettyTCM f <> "."] ++
-      pwords "Missing cases:") $$ nest 2 (vcat $ map display pss)
-        where
+    CoverageIssue f pss -> vcat
+        [ fsep $ concat
+          [ pwords "Incomplete pattern matching for"
+          , [ prettyTCM f <> "." ]
+          , pwords "Missing cases:"
+          ]
+        , nest 2 $ vcat $ fmap display pss
+        ]
+      where
         display (tel, ps) = prettyTCM $ NamedClause f True $
           empty { clauseTel = tel, namedClausePats = ps }
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -3,9 +3,10 @@ module Agda.TypeChecking.Pretty.Warning where
 
 import Prelude hiding ( null )
 
-import Control.Monad ( guard, filterM, (<=<) )
+import Control.Monad ( guard, filterM, forM, (<=<) )
 
 import Data.Char ( toLower )
+import qualified Data.Foldable as Fold
 import Data.Function (on)
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
@@ -153,9 +154,11 @@ prettyWarning = \case
       , ""
       ]
 
-    CantGeneralizeOverSorts ms -> vcat
+    CantGeneralizeOverSorts ms -> do
+      rms <- forM (Fold.toList ms) \ x -> (,x) <$> getMetaRange x
+      vcat
             [ text "Cannot generalize over unsolved sort metas:"
-            , nest 2 $ vcat [ prettyTCM x <+> text "at" <+> (pretty =<< getMetaRange x) | x <- ms ]
+            , nest 2 $ vcat [ prettyTCM x <+> text "at" <+> pretty r | (r,x) <- List.sort rms ]
             , fsep $ pwords "Suggestion: add a `variable Any : Set _` and replace unsolved metas by Any"
             ]
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -298,7 +298,7 @@ prettyWarning = \case
       ys, ms :: [C.ImportedName]
       ys            = map ImportedName   ys0
       ms            = map ImportedModule ms0
-      (ys0, ms0)    = partitionImportedNames xs
+      (ys0, ms0)    = partitionImportedNames $ List1.toList xs
       suggestion zs = maybe empty parens . didYouMean (map C.QName zs) fromImportedName
 
     DuplicateUsing xs -> fsep $ pwords "Duplicates in `using` directive:" ++ map pretty (List1.toList xs)

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -361,15 +361,15 @@ prettyWarning = \case
         ]
       ContainsUnsolvedMetaVariables ms -> hsep
         [ prettyTCM q , " is not a legal rewrite rule, since"
-        , "it contains the unsolved meta variable(s)", prettyList_ (map prettyTCM $ Set.toList ms)
+        , "it contains the unsolved meta variable(s)", prettyList_ (fmap prettyTCM $ Set1.toList ms)
         ]
       BlockedOnProblems ps -> hsep
         [ prettyTCM q , " is not a legal rewrite rule, since"
-        , "it is blocked on problem(s)", prettyList_ (map prettyTCM $ Set.toList ps)
+        , "it is blocked on problem(s)", prettyList_ (fmap prettyTCM $ Set1.toList ps)
         ]
       RequiresDefinitions qs -> hsep
         [ prettyTCM q , " is not a legal rewrite rule, since"
-        , "it requires the definition(s) of", prettyList_ (map prettyTCM $ Set.toList qs)
+        , "it requires the definition(s) of", prettyList_ (fmap prettyTCM $ Set1.toList qs)
         ]
       DoesNotTargetRewriteRelation -> hsep
         [ prettyTCM q , " does not target rewrite relation" ]

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -54,7 +54,7 @@ import Agda.Utils.FileName ( filePath )
 import Agda.Utils.Functor  ( (<.>) )
 import Agda.Utils.Lens
 import Agda.Utils.List ( editDistance )
-import Agda.Utils.List1 ( pattern (:|), (<|) )
+import Agda.Utils.List1 ( List1, pattern (:|), (<|) )
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Null
 import Agda.Utils.Singleton
@@ -595,24 +595,24 @@ prettyWarning = \case
 {-# SPECIALIZE prettyRecordFieldWarning :: RecordFieldWarning -> TCM Doc #-}
 prettyRecordFieldWarning :: MonadPretty m => RecordFieldWarning -> m Doc
 prettyRecordFieldWarning = \case
-  W.DuplicateFields xrs    -> prettyDuplicateFields $ map fst xrs
-  W.TooManyFields q ys xrs -> prettyTooManyFields q ys $ map fst xrs
+  W.DuplicateFields xrs    -> prettyDuplicateFields    $ fmap fst xrs
+  W.TooManyFields q ys xrs -> prettyTooManyFields q ys $ fmap fst xrs
 
-prettyDuplicateFields :: MonadPretty m => [C.Name] -> m Doc
+prettyDuplicateFields :: MonadPretty m => List1 C.Name -> m Doc
 prettyDuplicateFields xs = fsep $ concat
     [ [ "Duplicate", pluralS xs "field" ]
-    , punctuate comma (map pretty xs)
+    , punctuate comma (fmap pretty xs)
     , pwords "in record"
     ]
 
-{-# SPECIALIZE prettyTooManyFields :: QName -> [C.Name] -> [C.Name] -> TCM Doc  #-}
-prettyTooManyFields :: MonadPretty m => QName -> [C.Name] -> [C.Name] -> m Doc
+{-# SPECIALIZE prettyTooManyFields :: QName -> [C.Name] -> List1 C.Name -> TCM Doc  #-}
+prettyTooManyFields :: MonadPretty m => QName -> [C.Name] -> List1 C.Name -> m Doc
 prettyTooManyFields r missing xs = fsep $ concat
     [ pwords "The record type"
     , [prettyTCM r]
     , pwords "does not have the"
     , fields xs
-    , punctuate comma (map pretty xs)
+    , punctuate comma (fmap pretty xs)
     , if null missing then [] else concat
       [ pwords "but it would have the"
       , fields missing

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -44,6 +44,7 @@ import Agda.Utils.Function (applyWhen)
 import Agda.Utils.Functor (for, ($>), (<&>))
 import Agda.Utils.Lens
 import Agda.Utils.List
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
@@ -75,15 +76,15 @@ orderFields style r fill axs fs = do
   --   , "  provided fields: " <+> sep (map pretty ys)
   --   ]
   unless (style == A.RecStyleWhere) $   -- Don't warn about unknown fields for `record where`
-    unlessNull alien     $ warn $ W.TooManyFields r missing
-  unlessNull duplicate $ warn $ W.DuplicateFields
+    List1.unlessNull alien   $ warn $ W.TooManyFields r missing
+  List1.unlessNull duplicate $ warn $ W.DuplicateFields
   return $ for axs $ \ ax -> fromMaybe (fill ax) $ lookup (unArg ax) uniq
   where
     (uniq, duplicate) = nubAndDuplicatesOn fst fs   -- separating duplicate fields
     xs        = map unArg axs                       -- official fields (accord. record type)
     missing   = filter (not . hasElem (map fst fs)) xs  -- missing  fields
     alien     = filter (not . hasElem xs . fst) fs      -- spurious fields
-    warn w    = tell . singleton . w . map (second getRange)
+    warn w    = tell . singleton . w . fmap (second getRange)
 
 -- | Raise generated 'RecordFieldWarning's as warnings.
 warnOnRecordFieldWarnings :: Writer [RecordFieldWarning] a -> TCM a

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -84,6 +84,7 @@ import Agda.Utils.List
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
+import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Size
 import qualified Agda.Utils.SmallSet as SmallSet
 
@@ -215,14 +216,10 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
     ]
   let failureBlocked :: Blocker -> MaybeT TCM a
       failureBlocked b
-        | not (null ms) = illegalRule $ ContainsUnsolvedMetaVariables ms
-        | not (null ps) = illegalRule $ BlockedOnProblems ps
-        | not (null qs) = illegalRule $ RequiresDefinitions qs
+        | Set1.IsNonEmpty ms <- allBlockingMetas    b = illegalRule $ ContainsUnsolvedMetaVariables ms
+        | Set1.IsNonEmpty ps <- allBlockingProblems b = illegalRule $ BlockedOnProblems ps
+        | Set1.IsNonEmpty qs <- allBlockingDefs     b = illegalRule $ RequiresDefinitions qs
         | otherwise = __IMPOSSIBLE__
-        where
-          ms = allBlockingMetas b
-          ps = allBlockingProblems b
-          qs = allBlockingDefs b
   let failureFreeVars :: IntSet -> MaybeT TCM a
       failureFreeVars xs = illegalRule $ VariablesNotBoundByLHS xs
   let failureNonLinearPars :: IntSet -> MaybeT TCM a

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -68,6 +68,7 @@ import Agda.Termination.TermCheck
 import Agda.Utils.Function ( applyUnless )
 import Agda.Utils.Functor
 import Agda.Utils.Lens
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
@@ -450,7 +451,7 @@ checkTermination_ d = Bench.billTo [Bench.Termination] $ do
   reportSLn "tc.decl" 20 $ "checkDecl: checking termination..."
   -- If there are some termination errors, we throw a warning.
   -- The termination checker already marked non-terminating functions as such.
-  unlessNullM (termDecl d) $ \ termErrs -> do
+  List1.unlessNullM (termDecl d) \ termErrs -> do
     warning $ TerminationIssue termErrs
 
 -- | Check a set of mutual names for positivity.

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -847,7 +847,7 @@ checkRHS i x aps t lhsResult@(LHSResult _ delta ps absurdPat trhs _ _asb _ _) rh
   -- Absurd case: no right hand side
   noRHS :: TCM (Maybe Term, WithFunctionProblem)
   noRHS = do
-    unless absurdPat $ typeError $ AbsentRHSRequiresAbsurdPattern aps
+    unless absurdPat $ typeError AbsentRHSRequiresAbsurdPattern
     return (Nothing, NoWithFunction)
 
   -- With case: @f xs with {a} in eqa | b in eqb | {{c}} | ...; ... | ps1 = rhs1; ... | ps2 = rhs2; ...@

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -840,9 +840,7 @@ checkRHS i x aps t lhsResult@(LHSResult _ delta ps absurdPat trhs _ _asb _ _) rh
     -- one we complain, ignore it and return the same @(Nothing, NoWithFunction)@
     -- as the case dealing with @A.AbsurdRHS@.
     mv <- if absurdPat
-          then do
-            ps <- instantiateFull ps
-            Nothing <$ setCurrentRange e (warning $ AbsurdPatternRequiresAbsentRHS ps)
+          then Nothing <$ do setCurrentRange e $ warning AbsurdPatternRequiresAbsentRHS
           else Just <$> checkExpr e (unArg trhs)
     return (mv, NoWithFunction)
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240914 * 10 + 0
+currentInterfaceVersion = 20240914 * 10 + 1
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -56,6 +56,8 @@ import qualified Agda.Utils.List2 as List2
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Null
 import Agda.Utils.SmallSet (SmallSet(..))
+import Agda.Utils.Set1 (Set1)
+import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Trie (Trie(..))
 import Agda.Utils.WithDefault
 
@@ -269,6 +271,10 @@ instance (Ord a, EmbPrj a, EmbPrj b) => EmbPrj (Map a b) where
 instance (Ord a, EmbPrj a) => EmbPrj (Set a) where
   icod_ s = icode (Set.toAscList s)
   value s = Set.fromDistinctAscList <$!> value s
+
+instance (Ord a, EmbPrj a) => EmbPrj (Set1 a) where
+  icod_ s = icode (Set1.toAscList s)
+  value s = Set1.fromDistinctAscList <$!> value s
 
 instance EmbPrj IntSet where
   icod_ s = icode (IntSet.toAscList s)

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -61,7 +61,7 @@ instance EmbPrj Warning where
     NicifierIssue a                       -> icodeN 7 NicifierIssue a
     InversionDepthReached a               -> icodeN 8 InversionDepthReached a
     UserWarning a                         -> icodeN 9 UserWarning a
-    AbsurdPatternRequiresAbsentRHS a      -> icodeN 10 AbsurdPatternRequiresAbsentRHS a
+    AbsurdPatternRequiresAbsentRHS        -> icodeN 10 AbsurdPatternRequiresAbsentRHS
     ModuleDoesntExport a b c d            -> icodeN 11 ModuleDoesntExport a b c d
     LibraryWarning a                      -> icodeN 12 LibraryWarning a
     CoverageNoExactSplit a b              -> icodeN 13 CoverageNoExactSplit a b
@@ -143,7 +143,7 @@ instance EmbPrj Warning where
     [7, a]               -> valuN NicifierIssue a
     [8, a]               -> valuN InversionDepthReached a
     [9, a]               -> valuN UserWarning a
-    [10, a]              -> valuN AbsurdPatternRequiresAbsentRHS a
+    [10]                 -> valuN AbsurdPatternRequiresAbsentRHS
     [11, a, b, c, d]     -> valuN ModuleDoesntExport a b c d
     [12, a]              -> valuN LibraryWarning a
     [13, a, b]           -> valuN CoverageNoExactSplit a b

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -36,6 +36,7 @@ import {-# SOURCE #-} Agda.TypeChecking.Pretty.Call
 import {-# SOURCE #-} Agda.TypeChecking.Pretty.Warning ( prettyWarning )
 
 import Agda.Syntax.Abstract.Name ( QName )
+import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Syntax.Position
 import Agda.Syntax.Parser
 
@@ -46,8 +47,9 @@ import {-# SOURCE #-} Agda.Interaction.Highlighting.Generate (highlightWarning)
 import Agda.Utils.CallStack ( CallStack, HasCallStack, withCallerCallStack )
 import Agda.Utils.Function  ( applyUnless )
 import Agda.Utils.Lens
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
-import qualified Agda.Syntax.Common.Pretty as P
+import qualified Agda.Utils.Set1 as Set1
 
 import Agda.Utils.Impossible
 
@@ -133,8 +135,7 @@ warnings' loc ws = do
     then pure (Just tcwarn)
     else Nothing <$ addWarning tcwarn
 
-  let errs = catMaybes merrs
-  unless (null errs) $ typeError' loc $ NonFatalErrors $ Set.fromList errs
+  List1.unlessNull (catMaybes merrs) \ errs -> typeError' loc $ NonFatalErrors $ Set1.fromList errs
 
 {-# SPECIALIZE warnings :: HasCallStack => [Warning] -> TCM () #-}
 warnings :: (HasCallStack, MonadWarning m) => [Warning] -> m ()

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -210,6 +210,9 @@ unlessNull :: Applicative m => [a] -> (List1 a -> m ()) -> m ()
 unlessNull []       _ = pure ()
 unlessNull (x : xs) f = f $ x :| xs
 
+unlessNullM :: Monad m => m [a] -> (List1 a -> m ()) -> m ()
+unlessNullM m k = m >>= (`unlessNull` k)
+
 -- * List functions with no special behavior for non-empty lists.
 
 -- | Checks if all the elements in the list are equal. Assumes that

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -203,8 +203,11 @@ ifNotNull :: [a] -> (List1 a -> b) -> b -> b
 ifNotNull []       _ b = b
 ifNotNull (a : as) f _ = f $ a :| as
 
-unlessNull :: Null m => [a] -> (List1 a -> m) -> m
-unlessNull []       _ = empty
+-- | The more general type @Null m => [a] -> (List1 a -> m) -> m@
+--   often causes type inference to fail, as we do not in general have
+--   @instance Applicative m => Null (m ())@.
+unlessNull :: Applicative m => [a] -> (List1 a -> m ()) -> m ()
+unlessNull []       _ = pure ()
 unlessNull (x : xs) f = f $ x :| xs
 
 -- * List functions with no special behavior for non-empty lists.

--- a/src/full/Agda/Utils/Set1.hs
+++ b/src/full/Agda/Utils/Set1.hs
@@ -27,3 +27,7 @@ type Set1 = Set1.NESet
 unlessNull :: Applicative m => Set a -> (Set1 a -> m ()) -> m ()
 unlessNull = flip $ Set1.withNonEmpty $ pure ()
 {-# INLINE unlessNull #-}
+
+unlessNullM :: Monad m => m (Set a) -> (Set1 a -> m ()) -> m ()
+unlessNullM m k = m >>= (`unlessNull` k)
+{-# INLINE unlessNullM #-}

--- a/src/full/Agda/Utils/Set1.hs
+++ b/src/full/Agda/Utils/Set1.hs
@@ -15,6 +15,15 @@ module Agda.Utils.Set1
   , module Set1
   ) where
 
+import Data.Set (Set)
 import Data.Set.NonEmpty as Set1
 
 type Set1 = Set1.NESet
+
+-- | A more general type would be @Null m => Set a -> (Set1 a -> m) -> m@
+--   but this type is problematic as we do not have a general
+--   @instance Applicative m => Null (m ())@.
+--
+unlessNull :: Applicative m => Set a -> (Set1 a -> m ()) -> m ()
+unlessNull = flip $ Set1.withNonEmpty $ pure ()
+{-# INLINE unlessNull #-}


### PR DESCRIPTION
Make some types (mostly of errors and warnings) more precise by using `List1` and `Set1`.
This refactoring was mostly fuelled by grepping for uses of "unless null" and replacing them by `List1.unlessNull` or `Set1.unlessNull` which statically ensure non-emptiness in the continuation.