### PR TITLE
Fix #7495: Check extra split clause patterns are trivial for exactness

### DIFF
--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -300,8 +300,15 @@ cover f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
     Yes (i,mps) -> do
       reportSLn "tc.cover.cover" 10 $ "pattern covered by clause " ++ show i
       reportSDoc "tc.cover.cover" 20 $ text "with mps = " <+> do addContext tel $ pretty mps
-      exact <- allM mps $ isTrivialPattern . snd
       let cl0 = indexWithDefault __IMPOSSIBLE__ cs i
+      -- Szumi, 2024-09-15, issue #7495: If the split clause has more
+      -- patterns than the function clause, then the extra patterns need to
+      -- be trivial for the clause to be exact
+      let extra = drop (length $ namedClausePats cl0) ps
+      exact <-
+        and2M
+          (allM mps $ isTrivialPattern . snd)
+          (allM extra $ isTrivialPattern . namedArg)
       cl <- applyCl sc cl0 mps
       return $ CoverResult
         { coverSplitTree      = SplittingDone (size tel)

--- a/test/Fail/Issue7495.agda
+++ b/test/Fail/Issue7495.agda
@@ -1,0 +1,6 @@
+{-# OPTIONS --exact-split -Werror #-}
+open import Agda.Builtin.Bool
+
+not : Bool → Bool
+not false = true
+not = λ _ → false

--- a/test/Fail/Issue7495.err
+++ b/test/Fail/Issue7495.err
@@ -1,0 +1,6 @@
+Issue7495.agda:6,1-4: warning: -W[no]CoverageNoExactSplit
+Exact splitting is enabled, but the following clause could not be
+preserved as definitional equalities in the translation to a case
+tree:
+  not = λ _ → false
+when checking the definition of not

--- a/test/Fail/Issue7495b.agda
+++ b/test/Fail/Issue7495b.agda
@@ -1,0 +1,5 @@
+open import Agda.Builtin.Bool
+
+bad : Bool → Bool
+bad true = bad true
+bad = λ _ → true

--- a/test/Fail/Issue7495b.err
+++ b/test/Fail/Issue7495b.err
@@ -1,0 +1,6 @@
+Issue7495b.agda:3,1-5,17: error: [TerminationIssue]
+Termination checking failed for the following functions:
+  bad
+Problematic calls:
+  bad true
+    (at Issue7495b.agda:4,12-15)


### PR DESCRIPTION
Fixes #7495 by checking that the leftover patterns in a split clause are trivial, only then is the clause exact.
