### PR TITLE
Use non-empty collections in TypeError arguments

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1720,9 +1720,9 @@ Such *error warnings* are always on, they cannot be toggled by :option:`-W`.
 
      Importing a file using e.g. :option:`--cubical` into one which does not.
 
-.. option:: MissingDeclarations
+.. option:: MissingDataDeclaration
 
-     Definitions not associated to a declaration.
+     Constructor definitions not associated to a data declaration.
 
 .. option:: MissingDefinitions
 

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -55,6 +55,7 @@ import Agda.Utils.List  ( stripSuffix, nubOn )
 import Agda.Utils.List1 ( List1, pattern (:|) )
 import Agda.Utils.List2 ( List2, pattern List2 )
 import qualified Agda.Utils.List1 as List1
+import qualified Agda.Utils.List2 as List2
 import Agda.Utils.Monad ( ifM, unlessM )
 import Agda.Syntax.Common.Pretty ( Pretty(..), prettyShow )
 import qualified Agda.Syntax.Common.Pretty as P
@@ -175,7 +176,7 @@ findFile'' dirs m modFile =
     Just f  -> return (Right (SourceFile f), modFile)
     Nothing -> do
       files          <- fileList acceptableFileExts
-      filesShortList <- fileList parseFileExtsShortList
+      filesShortList <- fileList $ List2.toList parseFileExtsShortList
       existingFiles  <-
         liftIO $ filterM (doesFileExistCaseSensitive . filePath . srcFilePath) files
       return $ case nubOn id existingFiles of
@@ -284,8 +285,8 @@ moduleName file parsedModule = billTo [Bench.ModuleName] $ do
             }
     else return raw
 
-parseFileExtsShortList :: [String]
-parseFileExtsShortList = ".agda" : literateExtsShortList
+parseFileExtsShortList :: List2 String
+parseFileExtsShortList = List2.cons ".agda" literateExtsShortList
 
 dropAgdaExtension :: String -> String
 dropAgdaExtension s = case catMaybes [ stripSuffix ext s

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -560,7 +560,7 @@ warningHighlighting' b w = case tcWarning w of
     W.ShadowingInTelescope nrs       -> foldMap
                                           (shadowingTelHighlighting . snd)
                                           nrs
-    MissingDeclarations{}            -> missingDefinitionHighlighting w
+    MissingDataDeclaration{}         -> missingDefinitionHighlighting w
     MissingDefinitions{}             -> missingDefinitionHighlighting w
     -- TODO: explore highlighting opportunities here!
     PolarityPragmasButNotPostulates{} -> mempty

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -151,7 +151,7 @@ errorWarnings = Set.fromList
   [ CoverageIssue_
   , InvalidCharacterLiteral_
   , MissingDefinitions_
-  , MissingDeclarations_
+  , MissingDataDeclaration_
   , NotAllowedInMutual_
   , NotStrictlyPositive_
   , ConstructorDoesNotFitInData_
@@ -237,7 +237,7 @@ data WarningName
   | InvalidNoUniverseCheckPragma_
   | DuplicateRecordDirective_
   | InvalidTerminationCheckPragma_
-  | MissingDeclarations_
+  | MissingDataDeclaration_
   | MissingDefinitions_
   | NotAllowedInMutual_
   | OpenPublicAbstract_
@@ -461,7 +461,7 @@ warningNameDescription = \case
   InvalidNoUniverseCheckPragma_    -> "Universe checking pragmas before non-`data' or `record' declaration."
   DuplicateRecordDirective_        -> "Conflicting directives in a record declaration."
   InvalidTerminationCheckPragma_   -> "Termination checking pragmas before non-function or `mutual' blocks."
-  MissingDeclarations_             -> "Definitions not associated to a declaration."
+  MissingDataDeclaration_          -> "Constructor definitions not associated to a data declaration."
   MissingDefinitions_              -> "Declarations not associated to a definition."
   NotAllowedInMutual_              -> "Declarations not allowed in a mutual block."
   OpenPublicAbstract_              -> "'open public' directives in 'abstract' blocks."

--- a/src/full/Agda/Syntax/Abstract/Pattern.hs
+++ b/src/full/Agda/Syntax/Abstract/Pattern.hs
@@ -27,6 +27,8 @@ import Agda.Syntax.Position
 
 import Agda.Utils.Functor
 import Agda.Utils.List
+import Agda.Utils.List1 (List1)
+import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Null
 
 import Agda.Utils.Impossible
@@ -248,9 +250,9 @@ containsAsPattern = containsAPattern $ \case
 -- | Check if any user-written pattern variables occur more than once,
 --   and throw the given error if they do.
 checkPatternLinearity :: (Monad m, APatternLike p)
-                      => p -> ([C.Name] -> m ()) -> m ()
-checkPatternLinearity ps err =
-  unlessNull (duplicates $ map nameConcrete $ patternVars ps) $ \ys -> err ys
+  => p -> (List1 C.Name -> m ()) -> m ()
+checkPatternLinearity =
+  List1.unlessNull . duplicates . map nameConcrete . patternVars
 
 
 -- * Specific traversals

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -903,11 +903,7 @@ niceDeclarations fixs ds = do
                     Nothing        -> ((i , ds :| [] ), i + 1)
                     Just (i1, ds1) -> ((i1, ds <| ds1), i)
               put (Map.insert n (InterleavedData i0 sig (Just cs')) m, checks, i')
-            _ -> lift $ declarationWarning $ MissingDeclarations $ case mr of
-                   Just r -> [(n, r)]
-                   Nothing -> flip foldMap ds $ \case
-                     Axiom r _ _ _ _ n _ -> [(n, r)]
-                     _ -> __IMPOSSIBLE__
+            _ -> lift $ declarationWarning $ MissingDataDeclaration n
 
         addDataConstructors mr Nothing [] = pure ()
 

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -17,6 +17,8 @@ import Agda.Utils.CallStack ( CallStack )
 import Agda.Utils.List1 (List1, pattern (:|))
 import Agda.Utils.List2 (List2, pattern List2)
 import qualified Agda.Utils.List1 as List1
+import Agda.Utils.Set1 (Set1)
+import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Singleton
 
 ------------------------------------------------------------------------
@@ -132,7 +134,7 @@ data DeclarationWarning'
   | OpenPublicAbstract KwRange
       -- ^ @abstract@ has no effect on @open public@.  (But the user might think so.)
       --   'KwRange' is the range of the @public@ keyword.
-  | PolarityPragmasButNotPostulates [Name]
+  | PolarityPragmasButNotPostulates (Set1 Name)
   | PragmaNoTerminationCheck Range
       -- ^ Pragma @{-\# NO_TERMINATION_CHECK \#-}@ has been replaced
       --   by @{-\# TERMINATING \#-}@ and @{-\# NON_TERMINATING \#-}@.
@@ -147,9 +149,9 @@ data DeclarationWarning'
   | SafeFlagPolarity          Range -- ^ @POLARITY@            pragma is unsafe.
   | SafeFlagTerminating       Range -- ^ @TERMINATING@         pragma is unsafe.
   | ShadowingInTelescope (List1 (Name, List2 Range))
-  | UnknownFixityInMixfixDecl [Name]
-  | UnknownNamesInFixityDecl [Name]
-  | UnknownNamesInPolarityPragmas [Name]
+  | UnknownFixityInMixfixDecl (Set1 Name)
+  | UnknownNamesInFixityDecl (Set1 Name)
+  | UnknownNamesInPolarityPragmas (Set1 Name)
   | UselessAbstract KwRange
       -- ^ @abstract@ block with nothing that can (newly) be made abstract.
   | UselessInstance KwRange
@@ -430,15 +432,15 @@ instance Pretty DeclarationWarning' where
 
     UnknownNamesInFixityDecl xs -> fsep $
       pwords "The following names are not declared in the same scope as their syntax or fixity declaration (i.e., either not in scope at all, imported from another module, or declared in a super module):"
-      ++ punctuate comma (map pretty xs)
+      ++ punctuate comma (fmap pretty $ Set1.toList xs)
 
     UnknownFixityInMixfixDecl xs -> fsep $
       pwords "The following mixfix names do not have an associated fixity declaration:"
-      ++ punctuate comma (map pretty xs)
+      ++ punctuate comma (fmap pretty $ Set1.toList xs)
 
     UnknownNamesInPolarityPragmas xs -> fsep $
       pwords "The following names are not declared in the same scope as their polarity pragmas (they could for instance be out of scope, imported from another module, or declared in a super module):"
-      ++ punctuate comma  (map pretty xs)
+      ++ punctuate comma (fmap pretty $ Set1.toList xs)
 
     MissingDeclarations xs -> fsep $
      pwords "The following names are defined but not accompanied by a declaration:"
@@ -453,7 +455,7 @@ instance Pretty DeclarationWarning' where
 
     PolarityPragmasButNotPostulates xs -> fsep $
       pwords "Polarity pragmas have been given for the following identifiers which are not postulates:"
-      ++ punctuate comma (map pretty xs)
+      ++ punctuate comma (fmap pretty $ Set1.toList xs)
 
     UselessPrivate _ -> fsep $
       pwords "Using private here has no effect. Private applies only to declarations that introduce new identifiers into the module, like type signatures and data, record, and module declarations."

--- a/src/full/Agda/Syntax/Concrete/Fixity.hs
+++ b/src/full/Agda/Syntax/Concrete/Fixity.hs
@@ -26,8 +26,11 @@ import Agda.TypeChecking.Positivity.Occurrence (Occurrence)
 
 import Agda.Utils.CallStack (HasCallStack)
 import Agda.Utils.Functor
+import Agda.Utils.List1 (List1)
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Null
+import Agda.Utils.Tuple (Pair(Pair))
+
 import Agda.Utils.Impossible
 
 
@@ -35,7 +38,7 @@ type Fixities   = Map Name Fixity'
 type Polarities = Map Name [Occurrence]
 
 class Monad m => MonadFixityError m where
-  throwMultipleFixityDecls            :: [(Name, [Fixity'])] -> m a
+  throwMultipleFixityDecls            :: List1 (Name, Pair Fixity') -> m a
   throwMultiplePolarityPragmas        :: [Name] -> m a
   warnUnknownNamesInFixityDecl        :: HasCallStack => [Name] -> m ()
   warnUnknownNamesInPolarityPragmas   :: HasCallStack => [Name] -> m ()
@@ -48,7 +51,7 @@ class Monad m => MonadFixityError m where
 plusFixities :: MonadFixityError m => Fixities -> Fixities -> m Fixities
 plusFixities m1 m2
     -- If maps are not disjoint, report conflicts as exception.
-    | not (null isect) = throwMultipleFixityDecls isect
+    | Just ds <- List1.nonEmpty isect = throwMultipleFixityDecls ds
     -- Otherwise, do the union.
     | otherwise        = return $ Map.unionWithKey mergeFixites m1 m2
   where
@@ -62,7 +65,7 @@ plusFixities m1 m2
                       | otherwise = __IMPOSSIBLE__
 
     -- Compute a list of conflicts in a format suitable for error reporting.
-    isect = [ (x, map (Map.findWithDefault __IMPOSSIBLE__ x) [m1,m2])
+    isect = [ (x, fmap (Map.findWithDefault __IMPOSSIBLE__ x) $ Pair m1 m2)
             | (x, False) <- Map.assocs $ Map.intersectionWith compatible m1 m2 ]
 
     -- Check for no conflict.

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -597,15 +597,15 @@ parseLHS' lhsOrPatSyn top p = do
       [ "Possible parses for lhs:" ] ++ map (nest 2 . pretty . snd) results
     case results of
         -- Unique result.
-        [(_,lhs)] -> do reportS "scope.operators" 50 $ "Parsed lhs:" <+> pretty lhs
-                        return (lhs, operators patP)
+        [(_,lhs)] -> (lhs, operators patP) <$ do
+                       reportS "scope.operators" 50 $ "Parsed lhs:" <+> pretty lhs
         -- No result.
-        []        -> typeError $ OperatorInformation (operators patP)
-                               $ NoParseForLHS lhsOrPatSyn (catMaybes errs) p
+        []        -> typeError $ OperatorInformation (operators patP) $
+                       NoParseForLHS lhsOrPatSyn (catMaybes errs) p
         -- Ambiguous result.
-        rs        -> typeError $ OperatorInformation (operators patP)
-                               $ AmbiguousParseForLHS lhsOrPatSyn p $
-                       map (fullParen . fst) rs
+        r0:r1:rs  -> typeError $ OperatorInformation (operators patP) $
+                       AmbiguousParseForLHS lhsOrPatSyn p $
+                         fmap (fullParen . fst) $ List2 r0 r1 rs
     where
         getNames kinds flat =
           map (notaName . List1.head) $ getDefinedNames kinds flat

--- a/src/full/Agda/Syntax/Parser/Literate.hs
+++ b/src/full/Agda/Syntax/Parser/Literate.hs
@@ -35,7 +35,9 @@ import Agda.Syntax.Common
 import Agda.Syntax.Position
 
 import Agda.Utils.List
+import Agda.Utils.List1 (List1)
 import qualified Agda.Utils.List1 as List1
+import Agda.Utils.Singleton
 
 import Agda.Utils.Impossible
 
@@ -146,8 +148,8 @@ isBlank = (&&) <$> isSpace <*> (/= '\n')
 -- | Short list of extensions for literate Agda files.
 --   For display purposes.
 
-literateExtsShortList :: [String]
-literateExtsShortList = [".lagda"]
+literateExtsShortList :: List1 String
+literateExtsShortList = singleton ".lagda"
 
 -- | Returns a tuple consisting of the first line of the input, and the rest
 --   of the input.

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -445,8 +445,7 @@ getConcretePolarity x = Map.lookup x <$> useScope scopePolarities
 
 instance MonadFixityError ScopeM where
   throwMultipleFixityDecls xs         = case xs of
-    (x, _) : _ -> setCurrentRange (getRange x) $ typeError $ MultipleFixityDecls xs
-    []         -> __IMPOSSIBLE__
+    (x, _) :| _ -> setCurrentRange (getRange x) $ typeError $ MultipleFixityDecls xs
   throwMultiplePolarityPragmas xs     = case xs of
     x : _ -> setCurrentRange (getRange x) $ typeError $ MultiplePolarityPragmas xs
     []    -> __IMPOSSIBLE__

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -447,8 +447,7 @@ instance MonadFixityError ScopeM where
   throwMultipleFixityDecls xs         = case xs of
     (x, _) :| _ -> setCurrentRange (getRange x) $ typeError $ MultipleFixityDecls xs
   throwMultiplePolarityPragmas xs     = case xs of
-    x : _ -> setCurrentRange (getRange x) $ typeError $ MultiplePolarityPragmas xs
-    []    -> __IMPOSSIBLE__
+    x :| _ -> setCurrentRange (getRange x) $ typeError $ MultiplePolarityPragmas xs
   warnUnknownNamesInFixityDecl        = scopeWarning . UnknownNamesInFixityDecl
   warnUnknownNamesInPolarityPragmas   = scopeWarning . UnknownNamesInPolarityPragmas
   warnUnknownFixityInMixfixDecl       = scopeWarning . UnknownFixityInMixfixDecl

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -885,7 +885,7 @@ instance PrettyTCM TypeError where
       ]
 
     RepeatedVariablesInPattern xs -> fsep $
-      pwords "Repeated variables in pattern:" ++ map pretty xs
+      pwords "Repeated variables in pattern:" ++ map pretty (List1.toList xs)
 
     RepeatedNamesInImportDirective yss -> fsep
       [ fsep $ concat

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -733,7 +733,7 @@ instance PrettyTCM TypeError where
       fsep ( pwords "Ambiguous module name. The module name" ++
              [pretty x] ++
              pwords "could refer to any of the following files:"
-           ) $$ nest 2 (vcat $ map (text . filePath) files)
+           ) $$ nest 2 (vcat $ fmap (text . filePath) files)
 
     AmbiguousProjection d disambs -> vcat
       [ "Ambiguous projection " <> prettyTCM d <> "."

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -265,7 +265,7 @@ instance PrettyTCM TypeError where
       ++ [prettyTCM a] -- ++ pwords " (wrong argument name)"
       ++ [parens $ fsep $ text "possible arguments:" : map pretty xs | not (null xs)]
       where
-      xs = filter (not . isNoName) xs0
+      xs = List1.filter (not . isNoName) xs0
 
     WrongHidingInApplication t ->
       fwords "Found an implicit application where an explicit application was expected"

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -817,9 +817,9 @@ instance PrettyTCM TypeError where
         LetExpressions -> pwords "Let expressions"
         PatternLambdas -> pwords "Pattern lambdas"
 
-    NotInScope xs ->
+    NotInScope x ->
       -- using the warning version to avoid code duplication
-      prettyWarning (NotInScopeW xs)
+      prettyWarning $ NotInScopeW x
 
     NoSuchModule x -> fsep $ pwords "No module" ++ [pretty x] ++ pwords "in scope"
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -674,7 +674,7 @@ instance PrettyTCM TypeError where
 
     IllegalDeclarationInDataDefinition ds -> vcat
       [ "Illegal declaration in data type definition"
-      , nest 2 $ vcat $ map pretty ds
+      , nest 2 $ vcat $ fmap pretty ds
       ]
 
     IllegalLetInTelescope tb -> fsep $

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -845,8 +845,8 @@ instance PrettyTCM TypeError where
           sep [prettyTCM m, anno ]
 
     AmbiguousField field modules -> vcat $
-      "Ambiguity: the field" <+> prettyTCM field
-        <+> "appears in the following modules: " : map prettyTCM modules
+      hsep [ "Ambiguity: the field", prettyTCM field, "appears in the following modules:" ]
+      : map prettyTCM (List2.toList modules)
 
     ClashingDefinition x y suggestion -> fsep $
       pwords "Multiple definitions of" ++ [pretty x <> "."] ++

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -738,7 +738,7 @@ instance PrettyTCM TypeError where
     AmbiguousProjection d disambs -> vcat
       [ "Ambiguous projection " <> prettyTCM d <> "."
       , "It could refer to any of"
-      , nest 2 $ vcat $ (map prettyDisambProj disambs)
+      , nest 2 $ vcat $ fmap prettyDisambProj $ List2.cons d disambs
       ]
 
     AmbiguousOverloadedProjection ds reason -> do

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -83,7 +83,8 @@ import Agda.Utils.Functor( for )
 import Agda.Utils.IO     ( showIOException )
 import Agda.Utils.Lens
 import Agda.Utils.List   ( initLast, lastMaybe )
-import Agda.Utils.List1 (List1, pattern (:|))
+import Agda.Utils.List1  ( List1, pattern (:|) )
+import Agda.Utils.List2  ( pattern List2 )
 import qualified Agda.Utils.List1 as List1
 import qualified Agda.Utils.List2 as List2
 import Agda.Utils.Maybe
@@ -701,9 +702,9 @@ instance PrettyTCM TypeError where
       pwords "Module cannot be imported since it has open interaction points" ++
       pwords "(consider adding {-# OPTIONS --allow-unsolved-metas #-} to this module)"
 
-    CyclicModuleDependency ms ->
+    CyclicModuleDependency (List2 m0 m1 ms) ->
       fsep (pwords "cyclic module dependency:")
-      $$ nest 2 (vcat $ map pretty ms)
+      $$ nest 2 (vcat $ (pretty m0 :) $ map (("importing" <+>) . pretty) (m1 : ms))
 
     FileNotFound x files ->
       fsep ( pwords "Failed to find source of module" ++ [pretty x] ++

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1240,10 +1240,10 @@ instance PrettyTCM TypeError where
 
     MultipleFixityDecls xs ->
       sep [ fsep $ pwords "Multiple fixity or syntax declarations for"
-          , vcat $ map f xs
+          , vcat $ fmap f xs
           ]
       where
-        f (x, fs) = (pretty x <> ": ") <+> fsep (map pretty fs)
+        f (x, fs) = (pretty x <> ": ") <+> fsep (fmap pretty fs)
 
     MultiplePolarityPragmas xs -> fsep $
       pwords "Multiple polarity pragmas for" ++ map pretty xs

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1246,7 +1246,7 @@ instance PrettyTCM TypeError where
         f (x, fs) = (pretty x <> ": ") <+> fsep (fmap pretty fs)
 
     MultiplePolarityPragmas xs -> fsep $
-      pwords "Multiple polarity pragmas for" ++ map pretty xs
+      pwords "Multiple polarity pragmas for" ++ map pretty (List1.toList xs)
 
     NonFatalErrors ws -> vsep $ fmap prettyTCM $ Set1.toAscList ws
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1025,7 +1025,7 @@ instance PrettyTCM TypeError where
             pwords "Could mean any one of:"
         ]
           ++
-        map (nest 2 . pretty' d) ps
+        map (nest 2 . pretty' d) (List2.toList ps)
       where
         pretty' :: MonadPretty m => Doc -> C.Pattern -> m Doc
         pretty' d1 p' = do

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -759,7 +759,7 @@ instance PrettyTCM TypeError where
     AmbiguousConstructor c disambs -> vcat
       [ "Ambiguous constructor " <> pretty (qnameName c) <> "."
       , "It could refer to any of"
-      , nest 2 $ vcat $ map prettyDisambCons disambs
+      , nest 2 $ vcat $ fmap prettyDisambCons disambs
       ]
 
     InvalidFileName file reason -> fsep $

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4947,7 +4947,8 @@ data TypeError
             -- ^ The cycle starts and ends with the same module.
         | FileNotFound TopLevelModuleName [AbsolutePath]
         | OverlappingProjects AbsolutePath TopLevelModuleName TopLevelModuleName
-        | AmbiguousTopLevelModuleName TopLevelModuleName [AbsolutePath]
+        | AmbiguousTopLevelModuleName TopLevelModuleName (List2 AbsolutePath)
+            -- ^ The given module has at least 2 file locations.
         | ModuleNameUnexpected TopLevelModuleName TopLevelModuleName
           -- ^ Found module name, expected module name.
         | ModuleNameDoesntMatchFileName TopLevelModuleName [AbsolutePath]

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4274,9 +4274,9 @@ data ArgsCheckState a = ACState
 data Warning
   = NicifierIssue            DeclarationWarning
   | TerminationIssue         (List1 TerminationError)
-  | UnreachableClauses       QName [Range]
-  -- ^ `UnreachableClauses f rs` means that the clauses in `f` whose ranges are rs
-  --   are unreachable
+  | UnreachableClauses       QName (List1 Range)
+  -- ^ @UnreachableClauses f rs@ means that the clauses in @f@ whose ranges are @rs@
+  --   are unreachable.
   | CoverageIssue            QName (List1 (Telescope, [NamedArg DeBruijnPattern]))
   -- ^ `CoverageIssue f pss` means that `pss` are not covered in `f`
   | CoverageNoExactSplit     QName (List1 Clause)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4966,7 +4966,8 @@ data TypeError
         | AmbiguousName C.QName AmbiguousNameReason
         | AmbiguousModule C.QName (List1 A.ModuleName)
         | AmbiguousField C.Name (List2 A.ModuleName)
-        | AmbiguousConstructor QName [QName]
+        | AmbiguousConstructor QName (List2 QName)
+            -- ^ The list contains all interpretations of the name.
         | ClashingDefinition C.QName A.QName (Maybe NiceDeclaration)
         | ClashingModule A.ModuleName A.ModuleName
         | DefinitionInDifferentModule A.QName

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -143,6 +143,7 @@ import Agda.Utils.SmallSet (SmallSet, SmallSetElement)
 import qualified Agda.Utils.SmallSet as SmallSet
 import Agda.Utils.Set1 (Set1)
 import Agda.Utils.Singleton
+import Agda.Utils.Tuple (Pair)
 import Agda.Utils.Update
 
 import Agda.Utils.Impossible
@@ -4981,7 +4982,7 @@ data TypeError
         | RepeatedVariablesInPattern (List1 C.Name)
         | GeneralizeNotSupportedHere A.QName
         | GeneralizedVarInLetOpenedModule A.QName
-        | MultipleFixityDecls [(C.Name, [Fixity'])]
+        | MultipleFixityDecls (List1 (C.Name, Pair Fixity'))
         | MultiplePolarityPragmas [C.Name]
     -- Concrete to Abstract errors
         | DeclarationsAfterTopLevelModule

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4773,7 +4773,7 @@ data TypeError
             -- ^ A function is applied to a hidden argument where a non-hidden was expected.
         | WrongHidingInProjection QName
         | IllegalHidingInPostfixProjection (NamedArg C.Expr)
-        | WrongNamedArgument (NamedArg A.Expr) [NamedName]
+        | WrongNamedArgument (NamedArg A.Expr) (List1 NamedName)
             -- ^ A function is applied to a hidden named argument it does not have.
             -- The list contains names of possible hidden arguments at this point.
         | WrongAnnotationInLambda

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4978,7 +4978,7 @@ data TypeError
             -- ^ Expected the identifier to be a variable, not a constructor or pattern synonym.
         | RepeatedNamesInImportDirective (List1 (List2 C.ImportedName))
             -- ^ Some names are bound several times by an @import@/@open@ directive.
-        | RepeatedVariablesInPattern [C.Name]
+        | RepeatedVariablesInPattern (List1 C.Name)
         | GeneralizeNotSupportedHere A.QName
         | GeneralizedVarInLetOpenedModule A.QName
         | MultipleFixityDecls [(C.Name, [Fixity'])]

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4872,9 +4872,9 @@ data TypeError
         | TooFewPatternsInWithClause
         | TooManyPatternsInWithClause
         | FieldOutsideRecord
-        | ModuleArityMismatch A.ModuleName Telescope [NamedArg A.Expr]
+        | ModuleArityMismatch A.ModuleName Telescope (List1 (NamedArg A.Expr))
         | GeneralizeCyclicDependency
-        | ReferencesFutureVariables Term (List1.NonEmpty Int) (Arg Term) Int
+        | ReferencesFutureVariables Term (List1 Int) (Arg Term) Int
           -- ^ The first term references the given list of variables,
           -- which are in "the future" with respect to the given lock
           -- (and its leftmost variable)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4751,6 +4751,7 @@ data TypeError
         | NoKnownRecordWithSuchFields [C.Name]
             -- ^ The user has given a record expression with the given fields,
             --   but no record type known to type inference has all these fields.
+            --   The list can be empty.
         | ShouldEndInApplicationOfTheDatatype Type
             -- ^ The target of a constructor isn't an application of its
             -- datatype. The 'Type' records what it does target.
@@ -4797,6 +4798,7 @@ data TypeError
         | CannotEliminateWithProjection (Arg Type) Bool QName
         | WrongNumberOfConstructorArguments QName Nat Nat
         | ShouldBeEmpty Type [DeBruijnPattern]
+            -- ^ Type should be empty. The list gives possible patterns that match, but can be empty.
         | ShouldBeASort Type
             -- ^ The given type should have been a sort.
         | ShouldBePi Type
@@ -4889,6 +4891,8 @@ data TypeError
         | CannotRewriteByNonEquation Type
         | MacroResultTypeMismatch Type
         | NamedWhereModuleInRefinedContext [Term] [String]
+            -- ^ The lists should have the same length.
+            --   TODO: enforce this by construction.
         | CubicalPrimitiveNotFullyApplied QName
         | ComatchingDisabledForRecord QName
         | IncorrectTypeForRewriteRelation Term IncorrectTypeForRewriteRelationReason
@@ -4947,12 +4951,14 @@ data TypeError
         | CyclicModuleDependency (List2 TopLevelModuleName)
             -- ^ The cycle starts and ends with the same module.
         | FileNotFound TopLevelModuleName [AbsolutePath]
+            -- ^ The list can be empty.
         | OverlappingProjects AbsolutePath TopLevelModuleName TopLevelModuleName
         | AmbiguousTopLevelModuleName TopLevelModuleName (List2 AbsolutePath)
             -- ^ The given module has at least 2 file locations.
         | ModuleNameUnexpected TopLevelModuleName TopLevelModuleName
           -- ^ Found module name, expected module name.
         | ModuleNameDoesntMatchFileName TopLevelModuleName [AbsolutePath]
+            -- ^ The list can be empty.
         | ModuleDefinedInOtherFile TopLevelModuleName AbsolutePath AbsolutePath
           -- ^ Module name, file from which it was loaded, file which
           -- the include path says contains the module.
@@ -5027,6 +5033,7 @@ data TypeError
         | AmbiguousProjection QName [QName]
         | AmbiguousOverloadedProjection (List1 QName) Doc
         | OperatorInformation [NotationSection] TypeError
+            -- ^ The list of notations can be empty.
 {- UNUSED
         | NoParseForPatternSynonym C.Pattern
         | AmbiguousParseForPatternSynonym C.Pattern [C.Pattern]
@@ -5034,9 +5041,11 @@ data TypeError
     -- Usage errors
     -- Instance search errors
         | InstanceNoCandidate Type [(Term, TCErr)]
+            -- ^ The list can be empty.
     -- Reflection errors
         | UnquoteFailed UnquoteError
         | DeBruijnIndexOutOfScope Nat Telescope [Name]
+            -- ^ The list can be empty.
     -- Language option errors
         | NeedOptionAllowExec
         | NeedOptionCopatterns

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5030,7 +5030,8 @@ data TypeError
             --   If it is non-empty, the first entry could be printed as error hint.
         | AmbiguousParseForLHS LHSOrPatSyn C.Pattern (List2 C.Pattern)
             -- ^ Pattern and its possible interpretations.
-        | AmbiguousProjection QName [QName]
+        | AmbiguousProjection QName (List1 QName)
+            -- ^ The list contains alternative interpretations of the name.
         | AmbiguousOverloadedProjection (List1 QName) Doc
         | OperatorInformation [NotationSection] TypeError
             -- ^ The list of notations can be empty.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4983,7 +4983,7 @@ data TypeError
         | GeneralizeNotSupportedHere A.QName
         | GeneralizedVarInLetOpenedModule A.QName
         | MultipleFixityDecls (List1 (C.Name, Pair Fixity'))
-        | MultiplePolarityPragmas [C.Name]
+        | MultiplePolarityPragmas (List1 C.Name)
     -- Concrete to Abstract errors
         | DeclarationsAfterTopLevelModule
         | IllegalDeclarationBeforeTopLevelModule

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5028,7 +5028,7 @@ data TypeError
         | NoParseForLHS LHSOrPatSyn [C.Pattern] C.Pattern
             -- ^ The list contains patterns that failed to be interpreted.
             --   If it is non-empty, the first entry could be printed as error hint.
-        | AmbiguousParseForLHS LHSOrPatSyn C.Pattern [C.Pattern]
+        | AmbiguousParseForLHS LHSOrPatSyn C.Pattern (List2 C.Pattern)
             -- ^ Pattern and its possible interpretations.
         | AmbiguousProjection QName [QName]
         | AmbiguousOverloadedProjection (List1 QName) Doc

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4425,7 +4425,7 @@ data Warning
     -- ^ Pragma 'String' with name 'C.QName' that is not an unambiguous projection or function.
   | NoMain TopLevelModuleName
     -- ^ Compiler run on module that does not have a @main@ function.
-  | NotInScopeW [C.QName]
+  | NotInScopeW C.QName
     -- ^ Out of scope error we can recover from.
   | UnsupportedIndexedMatch Doc
     -- ^ Was not able to compute a full equivalence when splitting.
@@ -4962,7 +4962,7 @@ data TypeError
         | AbstractConstructorNotInScope A.QName
         | CopatternHeadNotProjection C.QName
         | NotAllowedInDotPatterns NotAllowedInDotPatterns
-        | NotInScope [C.QName]
+        | NotInScope C.QName
         | NoSuchModule C.QName
         | AmbiguousName C.QName AmbiguousNameReason
         | AmbiguousModule C.QName (List1 A.ModuleName)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4943,7 +4943,8 @@ data TypeError
           --   There are not 'UnsolvedMetas' since unification solved them.
           --   This is an error, since interaction points are never filled
           --   without user interaction.
-        | CyclicModuleDependency [TopLevelModuleName]
+        | CyclicModuleDependency (List2 TopLevelModuleName)
+            -- ^ The cycle starts and ends with the same module.
         | FileNotFound TopLevelModuleName [AbsolutePath]
         | OverlappingProjects AbsolutePath TopLevelModuleName TopLevelModuleName
         | AmbiguousTopLevelModuleName TopLevelModuleName [AbsolutePath]

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4965,7 +4965,7 @@ data TypeError
         | NoSuchModule C.QName
         | AmbiguousName C.QName AmbiguousNameReason
         | AmbiguousModule C.QName (List1 A.ModuleName)
-        | AmbiguousField C.Name [A.ModuleName]
+        | AmbiguousField C.Name (List2 A.ModuleName)
         | AmbiguousConstructor QName [QName]
         | ClashingDefinition C.QName A.QName (Maybe NiceDeclaration)
         | ClashingModule A.ModuleName A.ModuleName

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4855,7 +4855,7 @@ data TypeError
         | WrongArgInfoForPrimitive PrimitiveId ArgInfo ArgInfo
         | ShadowedModule C.Name (List1 A.ModuleName)
         | BuiltinInParameterisedModule BuiltinId
-        | IllegalDeclarationInDataDefinition [C.Declaration]
+        | IllegalDeclarationInDataDefinition (List1 C.Declaration)
             -- ^ The declaration list comes from a single 'C.NiceDeclaration'.
         | IllegalLetInTelescope C.TypedBinding
         | IllegalPatternInTelescope C.Binder

--- a/src/full/Agda/TypeChecking/Monad/Imports.hs
+++ b/src/full/Agda/TypeChecking/Monad/Imports.hs
@@ -24,11 +24,13 @@ import Control.Monad   ( when )
 import qualified Data.Set as Set
 import qualified Data.Map as Map
 
+import Agda.Syntax.Common.Pretty
 import Agda.Syntax.TopLevelModuleName
 import Agda.TypeChecking.Monad.Base
 
 import Agda.Utils.List ( caseListM )
-import Agda.Syntax.Common.Pretty
+import qualified Agda.Utils.List1 as List1
+import qualified Agda.Utils.List2 as List2
 
 import Agda.Utils.Impossible
 
@@ -103,5 +105,6 @@ withImportPath path = localTC $ \e -> e { envImportPath = path }
 checkForImportCycle :: TCM ()
 checkForImportCycle = do
   caseListM getImportPath __IMPOSSIBLE__ $ \ m ms -> do
-    when (m `elem` ms) $ typeError $ CyclicModuleDependency
-                                   $ dropWhile (/= m) $ reverse (m:ms)
+    when (m `elem` ms) $ typeError $ CyclicModuleDependency $
+      List2.snoc (List1.fromListSafe __IMPOSSIBLE__ $ dropWhile (/= m) $ reverse ms) m
+        -- NB: we know that ms contains m, so even after dropWhile the list is not empty.

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -216,12 +216,12 @@ localScope m = do
 notInScopeError :: C.QName -> TCM a
 notInScopeError x = do
   printScope "unbound" 25 ""
-  typeError $ NotInScope [x]
+  typeError $ NotInScope x
 
 notInScopeWarning :: C.QName -> TCM ()
 notInScopeWarning x = do
   printScope "unbound" 25 ""
-  warning $ NotInScopeW [x]
+  warning $ NotInScopeW x
 
 -- | Debug print the scope.
 printScope :: String -> Int -> String -> TCM ()

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -194,7 +194,7 @@ instance PrettyTCM Call where
 
     ScopeCheckDeclaration d ->
       fsep (pwords "when scope checking the" ++ [ pluralS ds "declaration" ]) $$
-      nest 2 (vcat $ map pretty ds)
+      nest 2 (vcat $ fmap pretty ds)
       where
       ds     = D.notSoNiceDeclarations d
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -503,11 +503,11 @@ prettyWarning = \case
       , fsep $ pwords "Use option --no-main to suppress this warning."
       ]
 
-    NotInScopeW xs -> vcat
+    NotInScopeW x -> vcat
       [ fsep $ pwords "Not in scope:"
       , do
         inscope <- Set.toList . concreteNamesInScope <$> getScope
-        prettyNotInScopeNames True (suggestion inscope) xs
+        prettyNotInScopeNames True (suggestion inscope) $ singleton x
       ]
       where
       suggestion inscope x = nest 2 $ par $ concat

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -68,6 +68,7 @@ import Agda.Termination.TermCheck
 import Agda.Utils.Function ( applyUnless )
 import Agda.Utils.Functor
 import Agda.Utils.Lens
+import Agda.Utils.List1 ( pattern (:|) )
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
@@ -882,36 +883,41 @@ checkSection e x tel ds =
 --   Returns the remaining module parameters as an open telescope.
 --   Warning: the returned telescope is /not/ the final result,
 --   an actual instantiation of the parameters does not occur.
-checkModuleArity
-  :: ModuleName           -- ^ Name of applied module.
+checkModuleArity ::
+     ModuleName           -- ^ Name of applied module.
   -> Telescope            -- ^ The module parameters.
-  -> [NamedArg A.Expr]  -- ^ The arguments this module is applied to.
+  -> [NamedArg A.Expr]    -- ^ The arguments this module is applied to.
   -> TCM Telescope        -- ^ The remaining module parameters (has free de Bruijn indices!).
-checkModuleArity m tel args = check tel args
-  where
-    bad = typeError $ ModuleArityMismatch m tel args
+checkModuleArity m tel = \case
+  []   -> return tel
+  a:as -> check1 tel a as
+    where
+    bad = typeError $ ModuleArityMismatch m tel (a :| as)
 
     check :: Telescope -> [NamedArg A.Expr] -> TCM Telescope
     check tel []             = return tel
-    check EmptyTel (_:_)     = bad
-    check (ExtendTel dom@Dom{domInfo = info} btel) args0@(Arg info' arg : args) =
+    check tel (a : as)       = check1 tel a as
+
+    check1 :: Telescope -> NamedArg A.Expr -> [NamedArg A.Expr] -> TCM Telescope
+    check1 EmptyTel _ _ = bad
+    check1 (ExtendTel dom@Dom{domInfo = info} btel) arg0@(Arg info' arg) args = do
       let name = bareNameOf arg
           my   = bareNameOf dom
-          tel  = absBody btel in
+          tel  = absBody btel
       case (argInfoHiding info, argInfoHiding info', name) of
-        (Instance{}, NotHidden, _)        -> check tel args0
-        (Instance{}, Hidden, _)           -> check tel args0
-        (Instance{}, Instance{}, Nothing) -> check tel args
+        (Instance{}, NotHidden, _)        -> check1 tel arg0 args
+        (Instance{}, Hidden, _)           -> check1 tel arg0 args
+        (Instance{}, Instance{}, Nothing) -> check  tel args
         (Instance{}, Instance{}, Just x)
-          | Just x == my                  -> check tel args
-          | otherwise                     -> check tel args0
-        (Hidden, NotHidden, _)            -> check tel args0
-        (Hidden, Instance{}, _)           -> check tel args0
-        (Hidden, Hidden, Nothing)         -> check tel args
+          | Just x == my                  -> check  tel args
+          | otherwise                     -> check1 tel arg0 args
+        (Hidden, NotHidden, _)            -> check1 tel arg0 args
+        (Hidden, Instance{}, _)           -> check1 tel arg0 args
+        (Hidden, Hidden, Nothing)         -> check  tel args
         (Hidden, Hidden, Just x)
-          | Just x == my                  -> check tel args
-          | otherwise                     -> check tel args0
-        (NotHidden, NotHidden, _)         -> check tel args
+          | Just x == my                  -> check  tel args
+          | otherwise                     -> check1 tel arg0 args
+        (NotHidden, NotHidden, _)         -> check  tel args
         (NotHidden, Hidden, _)            -> bad
         (NotHidden, Instance{}, _)        -> bad
 

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -81,7 +81,9 @@ import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List
 import Agda.Utils.List1 (List1, pattern (:|))
+import Agda.Utils.List2 (pattern List2)
 import qualified Agda.Utils.List1 as List1
+import qualified Agda.Utils.List2 as List2
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
@@ -1836,8 +1838,8 @@ disambiguateConstructor ambC@(AmbQ cs) d pars = do
         -- meaning that only the parameters may differ,
         -- then throw more specific error.
         (_    , [_]) -> typeError $ CantResolveOverloadedConstructorsTargetingSameDatatype d cs
-        (_    , disambs@(((c,_,_) :| _) : _)) -> typeError $
-          AmbiguousConstructor c (map (conName . snd3) $ List1.concat disambs)
+        (_    , (d0@((c,_,_) :| _) : d1 : ds)) -> typeError $
+          AmbiguousConstructor c $ fmap (conName . snd3) $ List2.concat21 $ List2 d0 d1 ds
 
   where
     tryDisambiguate

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -73,6 +73,7 @@ import Agda.Utils.Function
 import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List1  ( List1, pattern (:|) )
+import Agda.Utils.List2  ( pattern List2 )
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
@@ -928,7 +929,7 @@ expandModuleAssigns mfs xs = do
     case catMaybes pms of
       []        -> return Nothing
       [(_, fa)] -> return (Just fa)
-      mfas      -> typeError $ AmbiguousField f (map fst mfas)
+      x:y:zs    -> typeError $ AmbiguousField f $ fmap fst $ List2 x y zs
   return (fs ++ catMaybes fs')
 
 -- | @checkRecordExpression fs e t@ checks record construction against type @t@.

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240914 * 10 + 1
+currentInterfaceVersion = 20240916 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -326,7 +326,7 @@ instance EmbPrj DeclarationWarning' where
     -- 29 removed
     -- 30 removed
     InvalidConstructorBlock a         -> icodeN 31 InvalidConstructorBlock a
-    MissingDeclarations a             -> icodeN 32 MissingDeclarations a
+    MissingDataDeclaration a          -> icodeN 32 MissingDataDeclaration a
     HiddenGeneralize r                -> icodeN 33 HiddenGeneralize r
     UselessMacro r                    -> icodeN 34 UselessMacro r
     SafeFlagEta                    {} -> __IMPOSSIBLE__
@@ -371,7 +371,7 @@ instance EmbPrj DeclarationWarning' where
     -- 29 removed
     -- 30 removed
     [31,r]   -> valuN InvalidConstructorBlock r
-    [32,r]   -> valuN MissingDeclarations r
+    [32,r]   -> valuN MissingDataDeclaration r
     [33,r]   -> valuN HiddenGeneralize r
     [34,r]   -> valuN UselessMacro r
     _ -> malformed

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -78,7 +78,7 @@ instance EmbPrj Warning where
     RewriteMaybeNonConfluent a b c        -> icodeN 24 RewriteMaybeNonConfluent a b c
     PragmaCompileErased a b               -> icodeN 25 PragmaCompileErased a b
     FixityInRenamingModule a              -> icodeN 26 FixityInRenamingModule a
-    NotInScopeW ns                        -> icodeN 27 NotInScopeW ns
+    NotInScopeW a                         -> icodeN 27 NotInScopeW a
     ClashesViaRenaming a b                -> icodeN 28 ClashesViaRenaming a b
     RecordFieldWarning a                  -> icodeN 29 RecordFieldWarning a
     UselessPatternDeclarationForRecord a  -> icodeN 30 UselessPatternDeclarationForRecord a
@@ -160,7 +160,7 @@ instance EmbPrj Warning where
     [24, a, b, c]        -> valuN RewriteMaybeNonConfluent a b c
     [25, a, b]           -> valuN PragmaCompileErased a b
     [26, a]              -> valuN FixityInRenamingModule a
-    [27, ns]             -> valuN NotInScopeW ns
+    [27, a]              -> valuN NotInScopeW a
     [28, a, b]           -> valuN ClashesViaRenaming a b
     [29, a]              -> valuN RecordFieldWarning a
     [30, a]              -> valuN UselessPatternDeclarationForRecord a

--- a/src/full/Agda/Utils/List2.hs
+++ b/src/full/Agda/Utils/List2.hs
@@ -17,6 +17,7 @@ import Control.DeepSeq
 import Control.Monad                   ( (<=<) )
 
 import qualified Data.List as List
+import Data.Semigroup (sconcat)
 
 import GHC.Exts                        ( IsList(..) )
 import qualified GHC.Exts  as Reexport ( toList )
@@ -94,6 +95,10 @@ append (x :| xs) ys = cons x $ List1.prependList xs ys
 -- | O(length first list).
 appendList :: List2 a -> [a] -> List2 a
 appendList (List2 x y ys) zs = List2 x y $ mappend ys zs
+
+-- | Concatenate at least 2 lists of length at least 1.
+concat21 :: List2 (List1 a) -> List2 a
+concat21 (List2 xs ys zss) = append xs $ sconcat $ ys :| zss
 
 -- * Destruction
 

--- a/src/full/Agda/Utils/List2.hs
+++ b/src/full/Agda/Utils/List2.hs
@@ -81,6 +81,12 @@ toList1Either = \case
 cons :: a -> List1 a -> List2 a
 cons x (y :| ys) = List2 x y ys
 
+-- | O(n).
+snoc :: List1 a -> a -> List2 a
+snoc (x :| xs) z = List2 x y ys
+  where
+    y :| ys = List1.snoc xs z
+
 -- | O(length first list).
 append :: List1 a -> List1 a -> List2 a
 append (x :| xs) ys = cons x $ List1.prependList xs ys

--- a/src/full/Agda/Utils/Set1.hs
+++ b/src/full/Agda/Utils/Set1.hs
@@ -20,6 +20,9 @@ import Data.Set.NonEmpty as Set1
 
 type Set1 = Set1.NESet
 
+ifNull :: Set a -> b -> (Set1 a -> b) -> b
+ifNull s b f = Set1.withNonEmpty b f s
+
 -- | A more general type would be @Null m => Set a -> (Set1 a -> m) -> m@
 --   but this type is problematic as we do not have a general
 --   @instance Applicative m => Null (m ())@.

--- a/src/full/Agda/Utils/Tuple.hs
+++ b/src/full/Agda/Utils/Tuple.hs
@@ -17,9 +17,13 @@ module Agda.Utils.Tuple
   , Pair(..)
   ) where
 
-import Control.Arrow  ((&&&))
-import Data.Bifunctor (bimap, first, second)
-import Data.Tuple (swap)
+import Control.Arrow   ( (&&&) )
+import Control.DeepSeq ( NFData )
+
+import Data.Bifunctor  ( bimap, first, second )
+import Data.Tuple      ( swap )
+
+import GHC.Generics    ( Generic )
 
 infix 2 -*-
 infix 3 /\ -- backslashes at EOL interact badly with CPP...
@@ -75,8 +79,10 @@ mapSndM :: Functor m => (b -> m d) -> (a,b) -> m (a,d)
 mapSndM f ~(a,b) = (a,) <$> f b
 
 data Pair a = Pair a a
-  deriving (Eq, Functor, Foldable, Traversable)
+  deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 instance Applicative Pair where
   pure a                  = Pair a a
   Pair f f' <*> Pair a a' = Pair (f a) (f' a')
+
+instance NFData a => NFData (Pair a)

--- a/test/Fail/CyclicModuleDependency.err
+++ b/test/Fail/CyclicModuleDependency.err
@@ -1,6 +1,6 @@
 CyclicModuleDependency.agda:3,1-30: error: [CyclicModuleDependency]
 cyclic module dependency:
   CyclicModuleDependency
-  CyclicModuleDependency
+  importing CyclicModuleDependency
 when scope checking the declaration
   import CyclicModuleDependency

--- a/test/Fail/CyclicModuleDependency1.agda
+++ b/test/Fail/CyclicModuleDependency1.agda
@@ -1,0 +1,3 @@
+module CyclicModuleDependency1 where
+
+import CyclicModuleDependency2

--- a/test/Fail/CyclicModuleDependency1.err
+++ b/test/Fail/CyclicModuleDependency1.err
@@ -1,0 +1,8 @@
+CyclicModuleDependency3.agda:3,1-31: error: [CyclicModuleDependency]
+cyclic module dependency:
+  CyclicModuleDependency1
+  importing CyclicModuleDependency2
+  importing CyclicModuleDependency3
+  importing CyclicModuleDependency1
+when scope checking the declaration
+  import CyclicModuleDependency1

--- a/test/Fail/CyclicModuleDependency2.agda
+++ b/test/Fail/CyclicModuleDependency2.agda
@@ -1,0 +1,3 @@
+module CyclicModuleDependency2 where
+
+import CyclicModuleDependency3

--- a/test/Fail/CyclicModuleDependency2.err
+++ b/test/Fail/CyclicModuleDependency2.err
@@ -1,0 +1,8 @@
+CyclicModuleDependency1.agda:3,1-31: error: [CyclicModuleDependency]
+cyclic module dependency:
+  CyclicModuleDependency2
+  importing CyclicModuleDependency3
+  importing CyclicModuleDependency1
+  importing CyclicModuleDependency2
+when scope checking the declaration
+  import CyclicModuleDependency2

--- a/test/Fail/CyclicModuleDependency3.agda
+++ b/test/Fail/CyclicModuleDependency3.agda
@@ -1,0 +1,3 @@
+module CyclicModuleDependency3 where
+
+import CyclicModuleDependency1

--- a/test/Fail/CyclicModuleDependency3.err
+++ b/test/Fail/CyclicModuleDependency3.err
@@ -1,0 +1,8 @@
+CyclicModuleDependency2.agda:3,1-31: error: [CyclicModuleDependency]
+cyclic module dependency:
+  CyclicModuleDependency3
+  importing CyclicModuleDependency1
+  importing CyclicModuleDependency2
+  importing CyclicModuleDependency3
+when scope checking the declaration
+  import CyclicModuleDependency3

--- a/test/Fail/Issue5558.err
+++ b/test/Fail/Issue5558.err
@@ -1,6 +1,5 @@
-Issue5558.agda:3,3-15: error: [MissingDeclarations]
-The following names are defined but not accompanied by a
-declaration: A
-Issue5558.agda:6,3-7,10: error: [MissingDeclarations]
-The following names are defined but not accompanied by a
-declaration: B
+Issue5558.agda:3,8-9: error: [MissingDataDeclaration]
+Data definition A misses a data declaration
+
+Issue5558.agda:6,8-9: error: [MissingDataDeclaration]
+Data definition B misses a data declaration


### PR DESCRIPTION
Continues
- #7494

Replaces warning `MissingDeclarations` by `MissingDataDeclaration`.
Makes error message for cyclic imports clearer.