### PR TITLE
Make termination checking more permissive wrt non-exact clause reduction

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3856,6 +3856,9 @@ data TCEnv =
                 -- currently under, if any. Used by the scope checker
                 -- (to associate definitions to blocks), and by the type
                 -- checker (for unfolding control).
+          , envTermCheckReducing :: Bool
+                -- ^ Are we currently trying to reduce away function calls using
+                --   non-recursive clauses during termination checking?
           }
     deriving (Generic)
 
@@ -3922,6 +3925,7 @@ initEnv = TCEnv { envContext             = []
                 , envCurrentlyElaborating   = False
                 , envSyntacticEqualityFuel  = Strict.Nothing
                 , envCurrentOpaqueId        = Nothing
+                , envTermCheckReducing      = False
                 }
 
 class LensTCEnv a where

--- a/test/Succeed/TerminationNonExactClause.agda
+++ b/test/Succeed/TerminationNonExactClause.agda
@@ -1,0 +1,5 @@
+open import Agda.Builtin.Bool
+
+f : Bool → Bool
+f false = f true
+f _ = true


### PR DESCRIPTION
Currently, the termination checker completely ignores non-exact clauses when trying to reduce away function calls. Which means that in the code below, `f` passes termination check because `f true` reduces to just `true`, but `g` fails because `g true` is stuck:
```agda
f : Bool → Bool
f false = f true
f true = true

g : Bool → Bool
g false = g true
g _ = true
```
(This is also the reason the cubical library failed to typecheck for #7496)

The reason non-exact clauses are ignored is because clauses with recursive calls are also ignored. If only recursive clauses are ignored, then the following non-terminating function would pass termination check; without the first clause, `h false` incorrectly reduces to `true` (see #5065):
```agda
h : Bool → Bool
h false = h false
h _ = true
```

With this patch, the termination checker tries to reduce with all clauses, and blocks reduction only when a recursive clause is successfully matched. This way, a non-exact clause can still be used to reduce away a function call as long as the clauses before it don't match.
