### PR TITLE
[ fix #7503 ] Use principal sort of datatype for checking if split is ok

### DIFF
--- a/test/Fail/PropCumulative.err
+++ b/test/Fail/PropCumulative.err
@@ -1,3 +1,3 @@
-PropCumulative.agda:32,20-22: error: [UnequalTerms]
-⊤ !=< (True _)
-when checking that the expression tt has type X _
+PropCumulative.agda:18,6-10: error: [SplitInProp]
+Cannot split on datatype in Prop unless target is in Prop
+when checking that the pattern true has type Bool


### PR DESCRIPTION
Fixes #7503 