### PR TITLE
Reconcile PR #7510 with commit ac2888a7ad: add Maybe Induction to scopeRecords

### DIFF
--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -120,8 +120,8 @@ data ScopeInfo = ScopeInfo
       , _scopeInScope       :: InScopeSet
       , _scopeFixities      :: C.Fixities    -- ^ Maps concrete names C.Name to fixities
       , _scopePolarities    :: C.Polarities  -- ^ Maps concrete names C.Name to polarities
-      , _scopeRecords       :: Map A.QName A.QName
-        -- ^ Maps the name of a record to the name of its constructor.
+      , _scopeRecords       :: Map A.QName (A.QName, Maybe Induction)
+        -- ^ Maps the name of a record to the name of its (co)constructor.
       }
   deriving (Show, Generic)
 
@@ -270,7 +270,7 @@ scopePolarities f s =
   f (_scopePolarities s) <&>
   \x -> s { _scopePolarities = x }
 
-scopeRecords :: Lens' ScopeInfo (Map A.QName A.QName)
+scopeRecords :: Lens' ScopeInfo (Map A.QName (A.QName, Maybe Induction))
 scopeRecords f s =
   f (_scopeRecords s) <&>
   \x -> s { _scopeRecords = x }

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1910,7 +1910,7 @@ instance ToAbstract NiceDeclaration where
               freshAbstractQName noFixity' $ simpleName "constructor"
             pure $ FreshRecCon constr
 
-        setRecordConstructor x' (recordConName cm')
+        setRecordConstructor x' (recordConName cm', fmap rangedThing ind)
 
         let inst = caseMaybe cm NotInstanceDef snd
         printScope "rec" 25 "record complete"


### PR DESCRIPTION
This PR fixes the compilation failure caused by merging #7512 after #7510 (they were not syntactically, but semantically conflicted): https://github.com/agda/agda/actions/runs/11060030949/job/30729684499#step:11:270

Since ConstructorName can no longer take an empty set (commit ac2888a7ad), we need to store the inductivity of a record in the new `scopeRecords` component.
