### PR TITLE
New error CannotQuote instead of GenericError

### DIFF
--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -106,6 +106,7 @@ data ErrorName
   | CannotEliminateWithProjection_
   | CannotGenerateHCompClause_
   | CannotGenerateTransportClause_
+  | CannotQuote_ CannotQuote_
   | CannotResolveAmbiguousPatternSynonym_
   | CannotRewriteByNonEquation_
   | CannotSolveSizeConstraints_
@@ -360,6 +361,14 @@ data SplitError_
   deriving (Show, Generic)
   deriving (Enum, Bounded) via (FiniteEnumeration SplitError_)
 
+data CannotQuote_
+  = CannotQuoteAmbiguous_
+  | CannotQuoteExpression_
+  | CannotQuoteHidden_
+  | CannotQuoteNothing_
+  | CannotQuotePattern_
+  deriving (Show, Generic, Enum, Bounded)
+
 data UnquoteError_
   = BadVisibility_
   | CannotDeclareHiddenFunction_
@@ -389,6 +398,7 @@ errorNameString = \case
   NicifierError_          err -> "Syntax." ++ declarationExceptionNameString err
   SplitError_             err -> "SplitError." ++ splitErrorNameString err
   UnquoteError_           err -> "Unquote." ++ unquoteErrorNameString err
+  CannotQuote_             err -> "CannotQuote." ++ cannotQuoteNameString err
   InvalidPun_              err -> "InvalidPun." ++ constructorOrPatternSynonymNameString err
   MissingTypeSignature_    err -> "MissingTypeSignature." ++ dataRecOrFunString err
   NotAllowedInDotPatterns_ err -> "NotAllowedInDotPatterns." ++ notAllowedInDotPatternsString err
@@ -443,6 +453,14 @@ splitErrorNameString :: SplitError_ -> String
 splitErrorNameString = \case
   ErasedDatatype_ err -> "ErasedDatatype." ++ erasedDatatypeReasonString err
   err -> defaultErrorNameString err
+
+cannotQuoteNameString :: CannotQuote_ -> String
+cannotQuoteNameString = \case
+  CannotQuoteAmbiguous_  -> "Ambiguous"
+  CannotQuoteExpression_ -> "Expression"
+  CannotQuoteHidden_     -> "Hidden"
+  CannotQuoteNothing_    -> "Nothing"
+  CannotQuotePattern_    -> "Pattern"
 
 unquoteErrorNameString :: UnquoteError_ -> String
 unquoteErrorNameString = defaultErrorNameString

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -382,6 +382,7 @@ data UnquoteError_
   | CannotDeclareHiddenFunction_
   | ConInsteadOfDef_
   | DefInsteadOfCon_
+  | NakedUnquote_
   | NonCanonical_
   | BlockedOnMeta_
   | PatLamWithoutClauses_

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -13,6 +13,13 @@ import Agda.Utils.Function    ( applyWhenJust )
 import Agda.Utils.List        ( initWithDefault )
 import Agda.Utils.Impossible  ( __IMPOSSIBLE__ )
 
+-- | Extra information for error 'CannotQuoteTerm'.
+
+data CannotQuoteTerm
+  = CannotQuoteTermHidden
+  | CannotQuoteTermNothing
+  deriving (Show, Generic, Enum, Bounded)
+
 -- | What kind of declaration?
 --
 --   See also 'Agda.Syntax.Concrete.Definitions.Types.DataRecOrFun'.
@@ -107,6 +114,7 @@ data ErrorName
   | CannotGenerateHCompClause_
   | CannotGenerateTransportClause_
   | CannotQuote_ CannotQuote_
+  | CannotQuoteTerm_ CannotQuoteTerm
   | CannotResolveAmbiguousPatternSynonym_
   | CannotRewriteByNonEquation_
   | CannotSolveSizeConstraints_
@@ -399,6 +407,7 @@ errorNameString = \case
   SplitError_             err -> "SplitError." ++ splitErrorNameString err
   UnquoteError_           err -> "Unquote." ++ unquoteErrorNameString err
   CannotQuote_             err -> "CannotQuote." ++ cannotQuoteNameString err
+  CannotQuoteTerm_         err -> "CannotQuoteTerm." ++ cannotQuoteTermNameString err
   InvalidPun_              err -> "InvalidPun." ++ constructorOrPatternSynonymNameString err
   MissingTypeSignature_    err -> "MissingTypeSignature." ++ dataRecOrFunString err
   NotAllowedInDotPatterns_ err -> "NotAllowedInDotPatterns." ++ notAllowedInDotPatternsString err
@@ -462,6 +471,11 @@ cannotQuoteNameString = \case
   CannotQuoteNothing_    -> "Nothing"
   CannotQuotePattern_    -> "Pattern"
 
+cannotQuoteTermNameString :: CannotQuoteTerm -> String
+cannotQuoteTermNameString = \case
+  CannotQuoteTermHidden      -> "Hidden"
+  CannotQuoteTermNothing     -> "Nothing"
+
 unquoteErrorNameString :: UnquoteError_ -> String
 unquoteErrorNameString = defaultErrorNameString
 
@@ -502,6 +516,7 @@ deriving via (FiniteEnumeration (Maybe a))
 deriving via (FiniteEnumeration (Maybe a))
   instance (Bounded a, Enum a) => Bounded (Maybe a)
 
+instance NFData CannotQuoteTerm
 instance NFData ErasedDatatypeReason
 instance NFData NotAllowedInDotPatterns
 instance NFData NotAValidLetBinding

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -226,7 +226,7 @@ data Pattern
   | ParenP Range Pattern                   -- ^ @(p)@
   | WildP Range                            -- ^ @_@
   | AbsurdP Range                          -- ^ @()@
-  | AsP Range Name Pattern                 -- ^ @x\@p@ unused
+  | AsP Range Name Pattern                 -- ^ @x\@p@
   | DotP KwRange Range Expr                -- ^ @.e@, the 'KwRange' is for the dot,
                                            --   the 'Range' for the whole thing (including the dot).
   | LitP Range Literal                     -- ^ @0@, @1@, etc.

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -3306,7 +3306,7 @@ instance ToAbstract C.Pattern where
     toAbstract p@(C.WildP r)    = return $ A.WildP (PatRange r)
     -- Andreas, 2015-05-28 futile attempt to fix issue 819: repeated variable on lhs "_"
     -- toAbstract p@(C.WildP r)    = A.VarP <$> freshName r "_"
-    toAbstract (C.ParenP _ p)   = toAbstract p
+    toAbstract (C.ParenP _ p)   = toAbstract p  -- Andreas, 2024-09-27 not impossible
     toAbstract (C.LitP r l)     = setCurrentRange r $ A.LitP (PatRange r) l <$ checkLiteral l
 
     toAbstract p0@(C.AsP r x p) = do

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1290,6 +1290,15 @@ instance PrettyTCM TypeError where
             _ ->
               pwords "a compound pattern"
 
+    CannotQuoteTerm what -> do
+      fwords "`quoteTerm' expects a single visible argument," $$ do
+      fsep $ pwords "but has been given" ++
+        case what of
+          CannotQuoteTermNothing ->
+            pwords "none"
+          CannotQuoteTermHidden ->
+            pwords "an implicit one"
+
 
     ConstructorNameOfNonRecord res -> case res of
       UnknownName -> __IMPOSSIBLE__ -- Turned into NotInScope when the name is resolved

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1723,6 +1723,8 @@ instance PrettyTCM UnquoteError where
       pwords ("Use " ++ def ++ " instead of " ++ con ++ " for non-constructor")
       ++ [prettyTCM x]
 
+    NakedUnquote -> fwords "`unquote' must be applied to a term"
+
     NonCanonical kind t ->
       fwords ("Cannot unquote non-canonical " ++ kind)
       $$ nest 2 (prettyTCM t)

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -24,6 +24,7 @@ typeErrorName = \case
   SplitError               err -> SplitError_            $ splitErrorName                 err
   UnquoteFailed            err -> UnquoteError_          $ unquoteErrorName               err
   -- Parametrized errors
+  CannotQuote             what -> CannotQuote_           $ unquotableName                 what
   MissingTypeSignature    what -> MissingTypeSignature_  $ missingTypeSignatureInfoName   what
   InvalidPun            kind _ -> InvalidPun_              kind
   NotAllowedInDotPatterns what -> NotAllowedInDotPatterns_ what
@@ -74,6 +75,7 @@ typeErrorName = \case
   ClashingModule                                             {} -> ClashingModule_
   ComatchingDisabledForRecord                                {} -> ComatchingDisabledForRecord_
   ConstructorDoesNotTargetGivenType                          {} -> ConstructorDoesNotTargetGivenType_
+  ConstructorNameOfNonRecord                                 {} -> ConstructorNameOfNonRecord_
   ConstructorPatternInWrongDatatype                          {} -> ConstructorPatternInWrongDatatype_
   ContradictorySizeConstraint                                {} -> ContradictorySizeConstraint_
   CopatternHeadNotProjection                                 {} -> CopatternHeadNotProjection_
@@ -138,7 +140,6 @@ typeErrorName = \case
   ModuleNameUnexpected                                       {} -> ModuleNameUnexpected_
   MultipleFixityDecls                                        {} -> MultipleFixityDecls_
   MultiplePolarityPragmas                                    {} -> MultiplePolarityPragmas_
-  ConstructorNameOfNonRecord                                 {} -> ConstructorNameOfNonRecord_
   NamedWhereModuleInRefinedContext                           {} -> NamedWhereModuleInRefinedContext_
   NeedOptionAllowExec                                        {} -> NeedOptionAllowExec_
   NeedOptionCopatterns                                       {} -> NeedOptionCopatterns_
@@ -311,6 +312,14 @@ splitErrorName = \case
   CosplitNoTarget           {} -> CosplitNoTarget_
   NotADatatype              {} -> NotADatatype_
   UnificationStuck          {} -> UnificationStuck_
+
+unquotableName :: CannotQuote -> CannotQuote_
+unquotableName = \case
+  CannotQuoteAmbiguous         {} -> CannotQuoteAmbiguous_
+  CannotQuoteExpression        {} -> CannotQuoteExpression_
+  CannotQuoteHidden            {} -> CannotQuoteHidden_
+  CannotQuoteNothing           {} -> CannotQuoteNothing_
+  CannotQuotePattern           {} -> CannotQuotePattern_
 
 unquoteErrorName :: UnquoteError -> UnquoteError_
 unquoteErrorName = \case

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -27,6 +27,7 @@ typeErrorName = \case
   CannotQuote             what -> CannotQuote_           $ unquotableName                 what
   MissingTypeSignature    what -> MissingTypeSignature_  $ missingTypeSignatureInfoName   what
   InvalidPun            kind _ -> InvalidPun_              kind
+  CannotQuoteTerm         what -> CannotQuoteTerm_         what
   NotAllowedInDotPatterns what -> NotAllowedInDotPatterns_ what
   NotAValidLetBinding     what -> NotAValidLetBinding_     what
   NotAValidLetExpression  what -> NotAValidLetExpression_  what

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -328,6 +328,7 @@ unquoteErrorName = \case
   CannotDeclareHiddenFunction {} -> CannotDeclareHiddenFunction_
   ConInsteadOfDef             {} -> ConInsteadOfDef_
   DefInsteadOfCon             {} -> DefInsteadOfCon_
+  NakedUnquote                {} -> NakedUnquote_
   NonCanonical                {} -> NonCanonical_
   BlockedOnMeta               {} -> BlockedOnMeta_
   PatLamWithoutClauses        {} -> PatLamWithoutClauses_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -106,7 +106,8 @@ import Agda.Compiler.Backend.Base
 import Agda.Interaction.Options
 import qualified Agda.Interaction.Options.Errors as ErrorName
 import Agda.Interaction.Options.Errors as X
-  ( ErasedDatatypeReason(..)
+  ( CannotQuoteTerm(..)
+  , ErasedDatatypeReason(..)
   , NotAValidLetBinding(..)
   , NotAValidLetExpression(..)
   , NotAllowedInDotPatterns(..)
@@ -4996,6 +4997,7 @@ data TypeError
         | ConstructorNameOfNonRecord ResolvedName
     -- Concrete to Abstract errors
         | CannotQuote CannotQuote
+        | CannotQuoteTerm CannotQuoteTerm
         | DeclarationsAfterTopLevelModule
         | IllegalDeclarationBeforeTopLevelModule
         | MissingTypeSignature MissingTypeSignatureInfo

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4728,6 +4728,7 @@ data UnquoteError
       -- ^ Attempt to @unquoteDecl@ with 'Hiding' other than 'NotHidden'.
   | ConInsteadOfDef QName String String
   | DefInsteadOfCon QName String String
+  | NakedUnquote
   | NonCanonical String I.Term
   | BlockedOnMeta TCState Blocker
   | PatLamWithoutClauses I.Term

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4995,6 +4995,7 @@ data TypeError
         | MultiplePolarityPragmas (List1 C.Name)
         | ConstructorNameOfNonRecord ResolvedName
     -- Concrete to Abstract errors
+        | CannotQuote CannotQuote
         | DeclarationsAfterTopLevelModule
         | IllegalDeclarationBeforeTopLevelModule
         | MissingTypeSignature MissingTypeSignatureInfo
@@ -5182,6 +5183,20 @@ data IncorrectTypeForRewriteRelationReason
   = ShouldAcceptAtLeastTwoArguments
   | FinalTwoArgumentsNotVisible
   | TypeDoesNotEndInSort Type Telescope
+    deriving (Show, Generic)
+
+-- | Extra information for error 'CannotQuote'.
+data CannotQuote
+  = CannotQuoteAmbiguous (List2 A.QName)
+      -- ^ @quote@ is applied to an ambiguous name.
+  | CannotQuoteExpression A.Expr
+      -- ^ @quote@ is applied to an expression that is not an unambiguous defined name.
+  | CannotQuoteHidden
+      -- ^ @quote@ is applied to a non-visible argument.
+  | CannotQuoteNothing
+      -- ^ @quote@ is unapplied.
+  | CannotQuotePattern (NamedArg C.Pattern)
+      -- ^ @quote@ is applied to a pattern that is not an unambiguous defined name.
     deriving (Show, Generic)
 
 -- | Distinguish error message when parsing lhs or pattern synonym, resp.
@@ -6329,3 +6344,4 @@ instance NFData MissingTypeSignatureInfo
 instance NFData WhyNotAHaskellType
 instance NFData InteractionError
 instance NFData IsAmbiguous
+instance NFData CannotQuote

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -25,26 +25,26 @@ import Agda.TypeChecking.Substitute
 import Agda.Utils.Impossible
 import Agda.Utils.Functor
 import Agda.Utils.List
-import Agda.Syntax.Common.Pretty (prettyShow)
+import Agda.Utils.List1 ( pattern (:|) )
+import Agda.Utils.List2 ( pattern List2 )
 import Agda.Utils.Size
 import qualified Agda.Utils.Maybe.Strict as Strict
 
 -- | Parse @quote@.
 quotedName :: (MonadTCError m, MonadAbsToCon m) => A.Expr -> m QName
 quotedName = \case
-  A.Var x          -> genericError $ "Cannot quote a variable " ++ prettyShow x
-  A.Def x          -> return x
-  A.Macro x        -> return x
-  A.Proj _o p      -> unambiguous p
-  A.Con c          -> unambiguous c
-  A.ScopedExpr _ e -> quotedName e
-  e -> genericDocError =<< do
-    text "Can only quote defined names, but encountered" <+> prettyA e
+  -- Andreas, 2024-09-27, issue #7514
+  -- Is it intended to be able to quote Set but not Set1?
+  A.Def' x NoSuffix -> return x
+  A.Macro x         -> return x
+  A.Proj _o p       -> unambiguous p
+  A.Con c           -> unambiguous c
+  A.ScopedExpr _ e  -> quotedName e
+  e -> typeError $ CannotQuote $ CannotQuoteExpression e
   where
-  unambiguous xs
-    | Just x <- getUnambiguous xs = return x
-    | otherwise =
-        genericError $ "quote: Ambiguous name: " ++ prettyShow (unAmbQ xs)
+    unambiguous (AmbQ (x :| xs)) = case xs of
+      []   -> return x
+      y:ys -> typeError $ CannotQuote $ CannotQuoteAmbiguous $ List2 x y ys
 
 
 data QuotingKit = QuotingKit

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1178,11 +1178,13 @@ checkExpr' cmp e t =
              else typeError $ CannotQuote CannotQuoteHidden
 
           | A.QuoteTerm _ <- unScope q -> do
-             (et, _) <- inferExpr (namedThing e)
-             doQuoteTerm cmp et t
+             if visible ai then do
+               (et, _) <- inferExpr (namedThing e)
+               doQuoteTerm cmp et t
+             else typeError $ CannotQuoteTerm CannotQuoteTermHidden
 
         A.Quote{}     -> typeError $ CannotQuote CannotQuoteNothing
-        A.QuoteTerm{} -> genericError "quoteTerm must be applied to a term"
+        A.QuoteTerm{} -> typeError $ CannotQuoteTerm CannotQuoteTermNothing
         A.Unquote{}   -> genericError "unquote must be applied to a term"
 
         A.AbsurdLam i h -> checkAbsurdLambda cmp i h e t

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1170,16 +1170,18 @@ checkExpr' cmp e t =
         A.WithApp _ e es -> typeError $ NotImplemented "type checking of with application"
 
         e0@(A.App i q (Arg ai e))
-          | A.Quote _ <- unScope q, visible ai -> do
-          x <- quotedName $ namedThing e
-          ty <- qNameType
-          coerce cmp (quoteName x) ty t
+          | A.Quote _ <- unScope q -> do
+             if visible ai then do
+               x  <- quotedName $ namedThing e
+               ty <- qNameType
+               coerce cmp (quoteName x) ty t
+             else typeError $ CannotQuote CannotQuoteHidden
 
           | A.QuoteTerm _ <- unScope q -> do
              (et, _) <- inferExpr (namedThing e)
              doQuoteTerm cmp et t
 
-        A.Quote{}     -> genericError "quote must be applied to a defined name"
+        A.Quote{}     -> typeError $ CannotQuote CannotQuoteNothing
         A.QuoteTerm{} -> genericError "quoteTerm must be applied to a term"
         A.Unquote{}   -> genericError "unquote must be applied to a term"
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1185,7 +1185,7 @@ checkExpr' cmp e t =
 
         A.Quote{}     -> typeError $ CannotQuote CannotQuoteNothing
         A.QuoteTerm{} -> typeError $ CannotQuoteTerm CannotQuoteTermNothing
-        A.Unquote{}   -> genericError "unquote must be applied to a term"
+        A.Unquote{}   -> unquoteError NakedUnquote
 
         A.AbsurdLam i h -> checkAbsurdLambda cmp i h e t
 

--- a/test/Fail/AmbiguousQuote.agda
+++ b/test/Fail/AmbiguousQuote.agda
@@ -9,3 +9,8 @@ data A2 : Set where
 
 -- AC is ambiguous, could refer to the one coming from A1 or A2
 test = quote AC
+
+-- Expected error:
+--
+-- `quote' expects an unambiguous defined name, but here the argument
+-- is ambiguous: AmbiguousQuote.A1.AC | AmbiguousQuote.A2.AC

--- a/test/Fail/AmbiguousQuote.err
+++ b/test/Fail/AmbiguousQuote.err
@@ -1,3 +1,4 @@
-AmbiguousQuote.agda:11.8-16: error: [GenericError]
-quote: Ambiguous name: [AmbiguousQuote.A1.AC, AmbiguousQuote.A2.AC]
+AmbiguousQuote.agda:11.8-16: error: [CannotQuote.Ambiguous]
+'quote' expects an unambiguous defined name, but here the argument
+is ambiguous: AmbiguousQuote.A1.AC | AmbiguousQuote.A2.AC
 when checking that the expression quote AC has type _5

--- a/test/Fail/Issue4534.agda
+++ b/test/Fail/Issue4534.agda
@@ -6,5 +6,6 @@ open import Agda.Builtin.Reflection
 quote₀ : Set → Name
 quote₀ X = quote X
 
--- Cannot quote a variable X
+-- `quote' expects an unambiguous defined name,
+-- but here the argument is a variable: X
 -- when checking that the expression quote X has type Name

--- a/test/Fail/Issue4534.err
+++ b/test/Fail/Issue4534.err
@@ -1,3 +1,4 @@
-Issue4534.agda:7.12-19: error: [GenericError]
-Cannot quote a variable X
+Issue4534.agda:7.12-19: error: [CannotQuote.Expression]
+'quote' expects an unambiguous defined name, but here the argument
+is a variable: X
 when checking that the expression quote X has type Name

--- a/test/Fail/QuoteHidden.agda
+++ b/test/Fail/QuoteHidden.agda
@@ -1,0 +1,9 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Reflection
+
+_ : Name
+_ = quote { Set }
+
+-- `quote' expects an unambiguous defined name,
+-- but here the argument is implicit

--- a/test/Fail/QuoteHidden.err
+++ b/test/Fail/QuoteHidden.err
@@ -1,0 +1,4 @@
+QuoteHidden.agda:6.5-16: error: [CannotQuote.Hidden]
+'quote' expects an unambiguous defined name,
+but here the argument is implicit
+when checking that the expression quote {Set} has type Name

--- a/test/Fail/QuoteLiteral.agda
+++ b/test/Fail/QuoteLiteral.agda
@@ -1,0 +1,11 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Reflection
+
+_ : Name
+_ = quote 42
+
+-- `quote' expects an unambiguous defined name,
+-- but here the argument is a literal: 42
+-- when checking that the expression quote 42 has type Name

--- a/test/Fail/QuoteLiteral.err
+++ b/test/Fail/QuoteLiteral.err
@@ -1,0 +1,4 @@
+QuoteLiteral.agda:7.5-13: error: [CannotQuote.Expression]
+'quote' expects an unambiguous defined name,
+but here the argument is a literal: 42
+when checking that the expression quote 42 has type Name

--- a/test/Fail/QuoteMeta.agda
+++ b/test/Fail/QuoteMeta.agda
@@ -1,0 +1,11 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Reflection
+
+_ : Name
+_ = quote ?
+
+-- `quote' expects an unambiguous defined name,
+-- but here the argument is a metavariable
+-- when checking that the expression quote 42 has type Name

--- a/test/Fail/QuoteMeta.err
+++ b/test/Fail/QuoteMeta.err
@@ -1,0 +1,4 @@
+QuoteMeta.agda:7.5-12: error: [CannotQuote.Expression]
+'quote' expects an unambiguous defined name,
+but here the argument is a metavariable
+when checking that the expression quote ? has type Name

--- a/test/Fail/QuoteMustBeAppliedToIdentifier.agda
+++ b/test/Fail/QuoteMustBeAppliedToIdentifier.agda
@@ -1,0 +1,8 @@
+-- Andreas, 2024-09-27
+-- Trigger error "quote must be applied to an identifier".
+
+test : Set → Set₁
+test quote = Set
+
+-- `quote' expects an unambiguous defined name, but here the argument is missing
+-- when scope checking the left-hand side test quote in the definition of test

--- a/test/Fail/QuoteMustBeAppliedToIdentifier.err
+++ b/test/Fail/QuoteMustBeAppliedToIdentifier.err
@@ -1,0 +1,5 @@
+QuoteMustBeAppliedToIdentifier.agda:5.1-11: error: [CannotQuote.Nothing]
+'quote' expects an unambiguous defined name, but here the argument
+is missing
+when scope checking the left-hand side test quote in the definition
+of test

--- a/test/Fail/QuoteNothing.agda
+++ b/test/Fail/QuoteNothing.agda
@@ -1,0 +1,9 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Reflection
+
+_ : Name
+_ = quote
+
+-- `quote' expects an unambiguous defined name,
+-- but here the argument is missing

--- a/test/Fail/QuoteNothing.err
+++ b/test/Fail/QuoteNothing.err
@@ -1,0 +1,4 @@
+QuoteNothing.agda:6.5-10: error: [CannotQuote.Nothing]
+'quote' expects an unambiguous defined name,
+but here the argument is missing
+when checking that the expression quote has type Name

--- a/test/Fail/QuotePattern.agda
+++ b/test/Fail/QuotePattern.agda
@@ -1,0 +1,14 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Reflection
+
+postulate
+  F : Name → Name
+  X : Name
+
+test : Name → Set₁
+test (quote (F X)) = Set
+
+-- `quote' expects an unambiguous defined name, but here the argument is a compound pattern
+-- when scope checking the left-hand side test (quote (F X)) in the definition of test

--- a/test/Fail/QuotePattern.err
+++ b/test/Fail/QuotePattern.err
@@ -1,0 +1,5 @@
+QuotePattern.agda:11.1-19: error: [CannotQuote.Pattern]
+'quote' expects an unambiguous defined name,
+but here the argument is a compound pattern
+when scope checking the left-hand side test (quote (F X)) in the
+definition of test

--- a/test/Fail/QuotePatternAbsurd.agda
+++ b/test/Fail/QuotePatternAbsurd.agda
@@ -1,0 +1,10 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Reflection
+
+test : Name → Set₁
+test (quote ()) = Set
+
+-- `quote' expects an unambiguous defined name,
+-- but here the argument is an absurd pattern

--- a/test/Fail/QuotePatternAbsurd.err
+++ b/test/Fail/QuotePatternAbsurd.err
@@ -1,0 +1,5 @@
+QuotePatternAbsurd.agda:7.1-16: error: [CannotQuote.Pattern]
+'quote' expects an unambiguous defined name,
+but here the argument is an absurd pattern
+when scope checking the left-hand side test (quote ()) in the
+definition of test

--- a/test/Fail/QuotePatternHidden.agda
+++ b/test/Fail/QuotePatternHidden.agda
@@ -1,0 +1,10 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Reflection
+
+test : Name → Set₁
+test (quote {zero}) = Set
+
+-- `quote' expects an unambiguous defined name,
+-- but here the argument is implicit

--- a/test/Fail/QuotePatternHidden.err
+++ b/test/Fail/QuotePatternHidden.err
@@ -1,0 +1,5 @@
+QuotePatternHidden.agda:7.1-20: error: [CannotQuote.Hidden]
+'quote' expects an unambiguous defined name,
+but here the argument is implicit
+when scope checking the left-hand side test (quote {zero}) in the
+definition of test

--- a/test/Fail/QuotePatternLiteral.agda
+++ b/test/Fail/QuotePatternLiteral.agda
@@ -1,0 +1,10 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Reflection
+
+test : Name → Set₁
+test (quote 42) = Set
+
+-- `quote' expects an unambiguous defined name,
+-- but here the argument is a literal pattern

--- a/test/Fail/QuotePatternLiteral.err
+++ b/test/Fail/QuotePatternLiteral.err
@@ -1,0 +1,5 @@
+QuotePatternLiteral.agda:7.1-16: error: [CannotQuote.Pattern]
+'quote' expects an unambiguous defined name,
+but here the argument is a literal pattern
+when scope checking the left-hand side test (quote 42) in the
+definition of test

--- a/test/Fail/QuotePatternSynonym.agda
+++ b/test/Fail/QuotePatternSynonym.agda
@@ -1,0 +1,12 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Reflection
+
+pattern zero' = zero
+
+test : Name → Set₁
+test (quote zero') = Set
+
+-- `quote' expects an unambiguous defined name,
+-- but here the argument is a pattern synonym: zero'

--- a/test/Fail/QuotePatternSynonym.err
+++ b/test/Fail/QuotePatternSynonym.err
@@ -1,0 +1,5 @@
+QuotePatternSynonym.agda:9.1-19: error: [CannotQuote.Expression]
+'quote' expects an unambiguous defined name,
+but here the argument is a pattern synonym: zero'
+when scope checking the left-hand side test (quote zero') in the
+definition of test

--- a/test/Fail/QuotePatternWildcard.agda
+++ b/test/Fail/QuotePatternWildcard.agda
@@ -1,0 +1,10 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Reflection
+
+test : Name → Set₁
+test (quote _) = Set
+
+-- `quote' expects an unambiguous defined name,
+-- but here the argument is a wildcard pattern

--- a/test/Fail/QuotePatternWildcard.err
+++ b/test/Fail/QuotePatternWildcard.err
@@ -1,0 +1,5 @@
+QuotePatternWildcard.agda:7.1-15: error: [CannotQuote.Pattern]
+'quote' expects an unambiguous defined name,
+but here the argument is a wildcard pattern
+when scope checking the left-hand side test (quote _) in the
+definition of test

--- a/test/Fail/QuoteSet1.agda
+++ b/test/Fail/QuoteSet1.agda
@@ -1,0 +1,11 @@
+-- Andreas, 2024-09-27, issue #7514
+-- `quote` rejects universes with a numeric suffix
+
+open import Agda.Builtin.Reflection
+
+_ : Name
+_ = quote Set1
+
+-- `quote' expects an unambiguous defined name,
+-- but here the argument is a compound expression
+-- when checking that the expression quote Set₁ has type Name

--- a/test/Fail/QuoteSet1.err
+++ b/test/Fail/QuoteSet1.err
@@ -1,0 +1,4 @@
+QuoteSet1.agda:7.5-15: error: [CannotQuote.Expression]
+'quote' expects an unambiguous defined name,
+but here the argument is a compound expression
+when checking that the expression quote Set₁ has type Name

--- a/test/Fail/QuoteTermHidden.agda
+++ b/test/Fail/QuoteTermHidden.agda
@@ -1,0 +1,10 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Reflection
+
+_ : Term
+_ = quoteTerm {{x = Set}}
+
+-- `quoteTerm' expects a single visible argument,
+-- but has been given an implicit one
+-- when checking that the expression quoteTerm ⦃ x = Set ⦄ has type Term

--- a/test/Fail/QuoteTermHidden.err
+++ b/test/Fail/QuoteTermHidden.err
@@ -1,0 +1,5 @@
+QuoteTermHidden.agda:6.5-24: error: [CannotQuoteTerm.Hidden]
+'quoteTerm' expects a single visible argument,
+but has been given an implicit one
+when checking that the expression quoteTerm ⦃ x = Set ⦄ has type
+Term

--- a/test/Fail/QuoteTermNothing.agda
+++ b/test/Fail/QuoteTermNothing.agda
@@ -1,0 +1,10 @@
+-- Andreas, 2024-09-27
+
+open import Agda.Builtin.Reflection
+
+_ : Term
+_ = quoteTerm
+
+-- `quoteTerm' expects a single visible argument,
+-- but has been given none
+-- when checking that the expression quoteTerm has type Term

--- a/test/Fail/QuoteTermNothing.err
+++ b/test/Fail/QuoteTermNothing.err
@@ -1,0 +1,4 @@
+QuoteTermNothing.agda:6.5-14: error: [CannotQuoteTerm.Nothing]
+'quoteTerm' expects a single visible argument,
+but has been given none
+when checking that the expression quoteTerm has type Term

--- a/test/Fail/UnquoteTermNothing.agda
+++ b/test/Fail/UnquoteTermNothing.agda
@@ -1,0 +1,7 @@
+-- Andreas, 2024-09-27
+
+_ : Set
+_ = unquote
+
+-- `unquote' must be applied to a term
+-- when checking that the expression unquote has type Set

--- a/test/Fail/UnquoteTermNothing.err
+++ b/test/Fail/UnquoteTermNothing.err
@@ -1,0 +1,3 @@
+UnquoteTermNothing.agda:4.5-12: error: [Unquote.NakedUnquote]
+'unquote' must be applied to a term
+when checking that the expression unquote has type Set

--- a/test/Succeed/Issue1207.agda
+++ b/test/Succeed/Issue1207.agda
@@ -12,7 +12,7 @@ data Check : Set where
 
 pattern _==_ x y = check x y refl
 
-pattern `a = def (quote a) []
+pattern `a = def (quote (a)) []  -- Andreas, 2024-09-27 extra parens ok
 pattern `b = def (quote b) []
 pattern `suc x = def (quote lsuc) (vArg x ∷ [])
 pattern _`⊔_ x y = def (quote _⊔_) (vArg x ∷ vArg y ∷ [])
@@ -20,4 +20,4 @@ pattern _`⊔_ x y = def (quote _⊔_) (vArg x ∷ vArg y ∷ [])
 t₀ = quoteTerm Set₃ == sort (lit 3)
 t₁ = quoteTerm (Set a) == sort (set `a)
 t₂ = quoteTerm (Set (lsuc b)) == sort (set (`suc `b))
-t₃  = quoteTerm (Set (a ⊔ b)) == sort (set (`a `⊔ `b))
+t₃ = quoteTerm (Set (a ⊔ b)) == sort (set (`a `⊔ `b))

--- a/test/Succeed/Issue708quote.agda
+++ b/test/Succeed/Issue708quote.agda
@@ -6,5 +6,5 @@ open import Common.Reflection using (QName)
 
 example : QName → Bool
 example (quote Bool) = true
-example (quote Bool) = false
+example (quote Bool) = false  -- unreachable clause
 example _            = false

--- a/test/Succeed/QuoteSet.agda
+++ b/test/Succeed/QuoteSet.agda
@@ -1,0 +1,21 @@
+{-# OPTIONS --sized-types #-}
+
+-- Andreas, 2024-09-27, issue #7514
+
+open import Agda.Primitive
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Reflection
+open import Agda.Builtin.Size
+
+-- Since Agda 2.6.2, suffix-free universes can be quoted,
+-- not sure whether this is intended.
+
+_ = quote Prop
+_ = quote Propω
+_ = quote Set
+_ = quote Setω
+_ = quote SSet
+_ = quote SSetω
+_ = quote LevelUniv
+_ = quote IUniv
+_ = quote SizeUniv


### PR DESCRIPTION
New parametrized errors `CannotQuote` and `CannotQuoteTerm`.
Also fixing #7517.