### PR TITLE
OccursCheckErrors

### DIFF
--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -164,8 +164,8 @@ findFile' m = do
 
 -- | A variant of 'findFile'' which does not require 'TCM'.
 
-findFile''
-  :: [AbsolutePath]
+findFile'' ::
+     List1 AbsolutePath
   -- ^ Include paths.
   -> TopLevelModuleName
   -> ModuleToSource
@@ -186,7 +186,7 @@ findFile'' dirs m modFile =
   where
     fileList exts = mapM (fmap SourceFile . absolute)
                     [ filePath dir </> file
-                    | dir  <- dirs
+                    | dir  <- List1.toList dirs
                     , file <- map (moduleNameToFileName m) exts
                     ]
 

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -180,7 +180,6 @@ data ErrorName
   | MetaCannotDependOn_
   | MetaErasedSolution_
   | MetaIrrelevantSolution_
-  | MetaOccursInItself_
   | MismatchedProjectionsError_
   | MissingTypeSignature_ DataRecOrFun_
   | ModuleArityMismatch_

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -617,10 +617,6 @@ instance PrettyTCM TypeError where
           --   xs  -> pwords "only depends on the variables" ++ punctuate comma xs
 
     -- The following error is caught and reraised as GenericDocError in Occurs.hs
-    MetaOccursInItself m -> fsep $
-      pwords "Cannot construct infinite solution of metavariable" ++ [prettyTCM $ MetaV m []]
-
-    -- The following error is caught and reraised as GenericDocError in Occurs.hs
     MetaIrrelevantSolution m _ -> fsep $
       pwords "Cannot instantiate the metavariable because (part of) the" ++
       pwords "solution was created in an irrelevant context."

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -59,18 +59,7 @@ import Agda.Syntax.Scope.Monad (isDatatypeModule)
 import Agda.Syntax.Scope.Base
 
 import Agda.TypeChecking.Errors.Names (typeErrorString)
--- Andreas, 2024-09-28: Instead of the individual modules, we could just
--- import Agda.TypeChecking.Monad
-import Agda.TypeChecking.Monad.Base
-import Agda.TypeChecking.Monad.Builtin
-import Agda.TypeChecking.Monad.Closure
-import Agda.TypeChecking.Monad.Context
-import Agda.TypeChecking.Monad.Debug
-import Agda.TypeChecking.Monad.MetaVars   ( isSortMeta )
-import Agda.TypeChecking.Monad.Options    ( hasUniversePolymorphism )
-import Agda.TypeChecking.Monad.Signature  ( getConstInfo, typeOfConst )
-import Agda.TypeChecking.Monad.SizedTypes ( sizeType )
-import Agda.TypeChecking.Monad.State
+import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Pretty.Call
 import Agda.TypeChecking.Pretty.Warning

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -133,7 +133,6 @@ typeErrorName = \case
   MetaCannotDependOn                                         {} -> MetaCannotDependOn_
   MetaErasedSolution                                         {} -> MetaErasedSolution_
   MetaIrrelevantSolution                                     {} -> MetaIrrelevantSolution_
-  MetaOccursInItself                                         {} -> MetaOccursInItself_
   MismatchedProjectionsError                                 {} -> MismatchedProjectionsError_
   ModuleArityMismatch                                        {} -> ModuleArityMismatch_
   ModuleDefinedInOtherFile                                   {} -> ModuleDefinedInOtherFile_

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -228,6 +228,7 @@ metaCheck m = do
   -- WAS:
   -- when (m == m') $ if ctx == Top then patternViolation else
   --   abort ctx $ MetaOccursInItself m'
+  -- Andreas, 2024-09-28: removed error MetaOccursInItself from code base.
   when (m == m0) $ patternViolation' neverUnblock 50 $ "occursCheck failed: Found " ++ prettyShow m
 
   mv <- lookupLocalMeta m
@@ -414,13 +415,6 @@ occursCheck m xs v = Bench.billTo [ Bench.Typing, Bench.OccursCheck ] $ do
     nicerErrorMessage :: TCM a -> TCM a
     nicerErrorMessage f = f `catchError` \ err -> case err of
       TypeError _ _ cl -> case clValue cl of
-        MetaOccursInItself{} ->
-          typeError . GenericDocError =<<
-            fsep [ text "Refuse to construct infinite term by instantiating"
-                 , prettyTCM m
-                 , "to"
-                 , prettyTCM =<< instantiateFull v
-                 ]
         MetaCannotDependOn _ i ->
           ifM (isSortMeta m `and2M` (not <$> hasUniversePolymorphism))
           ( typeError . GenericDocError =<<

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4844,10 +4844,15 @@ data TypeError
             -- ^ The two function types have different hiding.
         | UnequalSorts Sort Sort
         | NotLeqSort Sort Sort
-        | MetaCannotDependOn MetaId Nat
-            -- ^ The arguments are the meta variable and the parameter that it wants to depend on.
+        | MetaCannotDependOn MetaId Term Nat
+            -- ^ The arguments are the meta variable, the proposed solution,
+            --   and the parameter that it wants to depend on.
         | MetaIrrelevantSolution MetaId Term
+            -- ^ When solving @'MetaId' ... := 'Term'@,
+            --   part of the 'Term' is invalid as it was created in an irrelevant context.
         | MetaErasedSolution MetaId Term
+            -- ^ When solving @'MetaId' ... := 'Term'@,
+            --   part of the 'Term' is invalid as it was created in an erased context.
         | GenericError String
         | GenericDocError Doc
         | SortOfSplitVarError (Maybe Blocker) Doc

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4846,7 +4846,6 @@ data TypeError
         | NotLeqSort Sort Sort
         | MetaCannotDependOn MetaId Nat
             -- ^ The arguments are the meta variable and the parameter that it wants to depend on.
-        | MetaOccursInItself MetaId
         | MetaIrrelevantSolution MetaId Term
         | MetaErasedSolution MetaId Term
         | GenericError String

--- a/src/full/Agda/TypeChecking/Monad/Options.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs-boot
@@ -6,6 +6,7 @@ import Agda.Interaction.Library.Base
 import Agda.Interaction.Options.HasOptions
 import Agda.TypeChecking.Monad.Base
 import Agda.Utils.FileName
+import Agda.Utils.List1 (List1)
 
 libToTCM       :: LibM a -> TCM a
-getIncludeDirs :: HasOptions m => m [AbsolutePath]
+getIncludeDirs :: HasOptions m => m (List1 AbsolutePath)

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -51,6 +51,7 @@ import Agda.Utils.HashTable (HashTable)
 import qualified Agda.Utils.HashTable as H
 import Agda.Utils.IORef
 import Agda.Utils.Lens
+import Agda.Utils.List1 (List1)
 import Agda.Utils.Monad
 import Agda.Utils.Pointer
 import Agda.Utils.TypeLevel
@@ -232,7 +233,7 @@ data St = St
     --   Used to introduce sharing while deserializing objects.
   , modFile   :: !ModuleToSource
     -- ^ Maps module names to file names. Constructed by the decoder.
-  , includes  :: ![AbsolutePath]
+  , includes  :: !(List1 AbsolutePath)
     -- ^ The include directories.
   }
 

--- a/test/Bugs/Issue5837.err
+++ b/test/Bugs/Issue5837.err
@@ -1,7 +1,7 @@
 AGDA_FAILURE
 
 ret > ExitFailure 42
-out > Issue5837.agda:18.13-17: error: [GenericDocError]
+out > Issue5837.agda:18.13-17: error: [MetaCannotDependOn]
 out > Cannot instantiate the metavariable _5 to solution G (F Y)
 out > since it contains the variable Y
 out > which is not in scope of the metavariable

--- a/test/Fail/Issue2758.err
+++ b/test/Fail/Issue2758.err
@@ -1,4 +1,4 @@
-Issue2758.agda:16.15-18: error: [GenericDocError]
+Issue2758.agda:16.15-18: error: [MetaIrrelevantSolution]
 Cannot instantiate the metavariable _x_10 to solution b
 since (part of) the solution was created in an irrelevant context
 when checking that the expression c _ has type Box Bool b

--- a/test/Fail/Issue2758b.err
+++ b/test/Fail/Issue2758b.err
@@ -1,4 +1,4 @@
-Issue2758b.agda:15.15-18: error: [GenericDocError]
+Issue2758b.agda:15.15-18: error: [MetaIrrelevantSolution]
 Cannot instantiate the metavariable _x_10 to solution b
 since (part of) the solution was created in an irrelevant context
 when checking that the expression c _ has type Box Bool b

--- a/test/Fail/Issue3655b.err
+++ b/test/Fail/Issue3655b.err
@@ -11,7 +11,7 @@ Variable generalization failed.
     - Dependency analysis suggested this (likely incorrect) order: x b
     - After constraint solving it looks like x actually depends on b
     - The dependency error is
-      Issue3655b.agda:19.9-10: error: [GenericDocError]
+      Issue3655b.agda:19.9-10: error: [MetaCannotDependOn]
       Cannot instantiate the metavariable _x.b_21 to solution b
       since it contains the variable genTel
       which is not in scope of the metavariable

--- a/test/Fail/Issue376Fail.err
+++ b/test/Fail/Issue376Fail.err
@@ -1,4 +1,4 @@
-Issue376Fail.agda:18.14-18: error: [GenericDocError]
+Issue376Fail.agda:18.14-18: error: [MetaCannotDependOn]
 Cannot instantiate the metavariable _7 to solution fst(z) , snd(z)
 since it contains the variable snd(z)
 which is not in scope of the metavariable

--- a/test/Fail/Issue3855OccursErasedDefinition.err
+++ b/test/Fail/Issue3855OccursErasedDefinition.err
@@ -1,4 +1,4 @@
-Issue3855OccursErasedDefinition.agda:18.8-11: error: [GenericDocError]
+Issue3855OccursErasedDefinition.agda:18.8-11: error: [MetaErasedSolution]
 Cannot instantiate the metavariable _A_2 to solution A
 since (part of) the solution was created in an erased context
 when checking that the expression p _ has type P A

--- a/test/Fail/Issue4727.err
+++ b/test/Fail/Issue4727.err
@@ -1,4 +1,4 @@
-Issue4727.agda:11.7-10: error: [GenericDocError]
+Issue4727.agda:11.7-10: error: [MetaErasedSolution]
 Cannot instantiate the metavariable _x_6 to solution c
 since (part of) the solution was created in an erased context
 when checking that the expression p _ has type P c

--- a/test/Fail/Issue4743-1.err
+++ b/test/Fail/Issue4743-1.err
@@ -1,4 +1,4 @@
-Issue4743-1.agda:16.8-12: error: [GenericDocError]
+Issue4743-1.agda:16.8-12: error: [MetaErasedSolution]
 Cannot instantiate the metavariable _7 to solution
 (λ @0 { unit → unit }) x
 since (part of) the solution was created in an erased context

--- a/test/Fail/Issue4743-2.err
+++ b/test/Fail/Issue4743-2.err
@@ -1,4 +1,4 @@
-Issue4743-2.agda:28.8-12: error: [GenericDocError]
+Issue4743-2.agda:28.8-12: error: [MetaErasedSolution]
 Cannot instantiate the metavariable _17 to solution Issue4743-2.A
 since (part of) the solution was created in an erased context
 when checking that the expression refl has type B ≡ Issue4743-2.A

--- a/test/Fail/Issue4743-3.err
+++ b/test/Fail/Issue4743-3.err
@@ -1,4 +1,4 @@
-Issue4743-3.agda:15.7-11: error: [GenericDocError]
+Issue4743-3.agda:15.7-11: error: [MetaErasedSolution]
 Cannot instantiate the metavariable _7 to solution Issue4743-3.♯-0
 since (part of) the solution was created in an erased context
 when checking that the expression refl has type x ≡ Issue4743-3.♯-0

--- a/test/Fail/Issue4743-4.err
+++ b/test/Fail/Issue4743-4.err
@@ -1,4 +1,4 @@
-Issue4743-4.agda:15.7-11: error: [GenericDocError]
+Issue4743-4.agda:15.7-11: error: [MetaErasedSolution]
 Cannot instantiate the metavariable _5 to solution (λ ()) x
 since (part of) the solution was created in an erased context
 when checking that the expression refl has type h ≡ (λ ())

--- a/test/Fail/MetaCannotDependOn.err
+++ b/test/Fail/MetaCannotDependOn.err
@@ -1,4 +1,4 @@
-MetaCannotDependOn.agda:13.22-24: error: [GenericDocError]
+MetaCannotDependOn.agda:13.22-24: error: [MetaCannotDependOn]
 Cannot instantiate the metavariable _A_10 to solution Vec n Nat
 since it contains the variable n
 which is not in scope of the metavariable

--- a/test/test-suite-covers-errors.sh
+++ b/test/test-suite-covers-errors.sh
@@ -32,7 +32,6 @@ cat >> $ERRORS <<EOF
 MetaCannotDependOn
 MetaErasedSolution
 MetaIrrelevantSolution
-MetaOccursInItself
 EOF
 
 # Errors of the double checker which should be impossible.

--- a/test/test-suite-covers-errors.sh
+++ b/test/test-suite-covers-errors.sh
@@ -26,14 +26,6 @@ InternalError
 NonFatalErrors
 EOF
 
-# Errors that are transformed to other errors and thus not printed.
-#
-cat >> $ERRORS <<EOF
-MetaCannotDependOn
-MetaErasedSolution
-MetaIrrelevantSolution
-EOF
-
 # Errors of the double checker which should be impossible.
 #
 cat >> $ERRORS <<EOF


### PR DESCRIPTION
- **Refactor: getIncludeDirs returns a non-empty list**
- **Refactor: prune unused error MetaOccursInItself**
- **Directly print nicer errors for occurs check in TypeChecking.Errors**
- **Refactor: simplify import list in TypeChecking.Errors**
