### PR TITLE
Refactor ArgsCheckState to use a single list of CheckedArg

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4252,21 +4252,25 @@ instance HasOverlapMode Candidate where
 -- ** Checking arguments
 ---------------------------------------------------------------------------
 
-data ArgsCheckState a = ACState
-       { acRanges :: [Maybe Range]
-         -- ^ Ranges of checked arguments, where present.
-         -- e.g. inserted implicits have no correponding abstract syntax.
-       , acElims  :: Elims
-         -- ^ Checked and inserted arguments so far.
-       , acConstraints :: [Maybe (Abs Constraint)]
-         -- ^ Constraints for the head so far,
-         -- i.e. before applying the correponding elim.
-       , acType   :: Type
-         -- ^ Type for the rest of the application.
-       , acData   :: a
-       }
-  deriving (Show)
+data CheckedArg = CheckedArg
+  { caElim        :: Elim
+      -- ^ Checked and inserted argument.
+  , caRange       :: Maybe Range
+      -- ^ Range of checked argument, where present.
+      --   E.g. inserted implicits have no correponding abstract syntax.
+  , caConstraint  :: Maybe (Abs Constraint)
+      -- ^ Head constraint before applying the argument.
+  }
+  deriving Show
 
+data ArgsCheckState a = ACState
+  { acCheckedArgs :: [CheckedArg]
+      -- ^ Checked and inserted arguments so far.
+  , acType        :: Type
+      -- ^ Type for the rest of the application.
+  , acData        :: a
+  }
+  deriving Show
 
 ---------------------------------------------------------------------------
 -- * Type checking warnings (aka non-fatal errors)

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE CPP #-}
 
 module Agda.Utils.Monad
     ( module Agda.Utils.Monad
+#if MIN_VERSION_mtl(2,3,1)
+    , module X
+#endif
     , when, unless, MonadPlus(..)
     , (<$>), (<*>), (<$!>)
     , (<$)
@@ -27,6 +31,26 @@ import Agda.Utils.Null (empty, ifNotNullM)
 import Agda.Utils.Singleton
 
 import Agda.Utils.Impossible
+
+---------------------------------------------------------------------------
+-- Vendor some new functions from mtl-2.3.1
+
+#if MIN_VERSION_mtl(2,3,1)
+import Control.Monad.Except as X ( tryError, withError )
+#endif
+
+#if !MIN_VERSION_mtl(2,3,1)
+-- | 'MonadError' analogue to the 'Control.Exception.try' function.
+tryError :: MonadError e m => m a -> m (Either e a)
+tryError action = (Right <$> action) `catchError` (pure . Left)
+
+-- | 'MonadError' analogue to the 'withExceptT' function.
+-- Modify the value (but not the type) of an error.  The type is
+-- fixed because of the functional dependency @m -> e@.  If you need
+-- to change the type of @e@ use 'mapError' or 'modifyError'.
+withError :: MonadError e m => (e -> e) -> m a -> m a
+withError f action = tryError action >>= either (throwError . f) pure
+#endif
 
 ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Previously, there were three lists which supposedly were of the same length.

Using a single list of `CheckedArg`enforces this constraint and makes the code conceptually simpler.

`Control.Monad.Except.withError` needs to be vendored as it is only available from `mtl-2.3.1`: 
- https://github.com/haskell/mtl/issues/156