### PR TITLE
Cache some operator parser information for performance (#5670)

### DIFF
--- a/src/full/Agda/Syntax/Notation.hs
+++ b/src/full/Agda/Syntax/Notation.hs
@@ -321,10 +321,12 @@ syntaxOf y
 --
 -- Postcondition: No 'A.Name' occurs in more than one list element.
 mergeNotations :: List1 NewNotation -> List1 NewNotation
-mergeNotations =
+mergeNotations ns@(_ :| []) = ns
+mergeNotations ns =
   fmap merge
   . List1.concatMap1 groupIfLevelsMatch
   . List1.groupOn1 (notation &&& notaIsOperator)
+  $ ns
   where
   groupIfLevelsMatch :: List1 NewNotation -> List1 (List1 NewNotation)
   groupIfLevelsMatch ns =

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -42,6 +42,7 @@ import Agda.Syntax.Concrete.Fixity
 import Agda.Syntax.Concrete.Definitions ( DeclarationWarning(..) ,DeclarationWarning'(..) )
   -- TODO: move the relevant warnings out of there
 import Agda.Syntax.Scope.Base as A
+import Agda.Syntax.Scope.Flat (recomputeOperatorContext)
 
 import Agda.TypeChecking.Monad.Base as I
 import Agda.TypeChecking.Monad.Builtin
@@ -194,7 +195,7 @@ getLocalVars :: ReadTCState m => m LocalVars
 getLocalVars = useScope scopeLocals
 
 modifyLocalVars :: (LocalVars -> LocalVars) -> ScopeM ()
-modifyLocalVars = modifyScope_ . updateScopeLocals
+modifyLocalVars f = modifyScope_ (recomputeOperatorContext . updateScopeLocals f)
 
 setLocalVars :: LocalVars -> ScopeM ()
 setLocalVars vars = modifyLocalVars $ const vars

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2730,7 +2730,7 @@ instance ToAbstract C.Clause where
   toAbstract (C.Clause top catchall lhs@(C.LHS p eqs with) rhs wh wcs) = withLocalVars $ do
     -- Jesper, 2018-12-10, #3095: pattern variables bound outside the
     -- module are locally treated as module parameters
-    modifyScope_ $ updateScopeLocals $ map $ second patternToModuleBound
+    modifyLocalVars $ map $ second patternToModuleBound
     -- Andreas, 2012-02-14: need to reset local vars before checking subclauses
     vars0 <- getLocalVars
     lhs' <- toAbstract $ LeftHandSide (C.QName top) p

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -250,8 +250,8 @@ instance EmbPrj Precedence where
     valu _         = malformed
 
 instance EmbPrj ScopeInfo where
-  icod_ (ScopeInfo a b c d e f g h i j k) = icodeN' (\ a b c d e -> ScopeInfo a b c d e f g h i j k) a b c d e
+  icod_ (ScopeInfo a b c d e f g h i j k l) = icodeN' (\ a b c d e -> ScopeInfo a b c d e f g h i j k l) a b c d e
 
-  value = valueN (\ a b c d e -> ScopeInfo a b c d e Map.empty Map.empty Set.empty Map.empty Map.empty Map.empty)
+  value = valueN (\ a b c d e -> ScopeInfo a b c d e Map.empty Map.empty Set.empty Map.empty Map.empty Map.empty emptyOperatorContext)
 
 instance EmbPrj NameOrModule


### PR DESCRIPTION
See #5670.

This PR doesn't do anything very clever to improve the quadratic situation with operator parsing. The underlying problem is that operator parsing needs to account for everything that's in scope. For instance

```agda
foo _op_ x y = x op y
```
parses as `_op_ x y` unless there's already an `op` in scope, in which case it's ambiguous (the local `_op_` does not shadow an outer `op`).

To do the parsing we basically need to know the names in scope (qualified or otherwise) and their fixities. You could imagine carefully maintaining this information through every update to the scope, but for now the PR simply caches the information and recomputes it on every scope change. This is worthwhile since in most programs there are many expressions to parse between each scope change.

With this PR the operator parsing is down from 11s (32% of total) to 5s (17% of total) for the 10kloc example in #5670. Since that's a very pathological example I think that's good enough.

**Edit: DOES NOT WORK**
This made things faster for the 10kloc example, but performs horribly on the standard library and runs out of memory on some of the stdlib test cases.