### PR TITLE
Fix CI warning "In the use of ‘tail’"

### DIFF
--- a/src/size-solver/Main.hs
+++ b/src/size-solver/Main.hs
@@ -100,9 +100,9 @@ parseFile input = ( map parse hyps
                   )
   where
     (ls1, ls2)   = break isSeparator input
-    (hyps, rest) = case ls2 of {[] -> ([], ls1); (_ : tls2) (ls1, tls2)}
+    (hyps, rest) = case ls2 of {[] -> ([], ls1); (_ : tls2) -> (ls1, tls2)}
     (ls1', ls2') = break isSeparator rest
-    (pols, cons) = case ls2' of {[] -> ([], ls1'); (_ : tls2') (ls1', tls2')}
+    (pols, cons) = case ls2' of {[] -> ([], ls1'); (_ : tls2') -> (ls1', tls2')}
 
 
 -- | A separator is a line consisting entirely of dashes,

--- a/src/size-solver/Main.hs
+++ b/src/size-solver/Main.hs
@@ -100,9 +100,9 @@ parseFile input = ( map parse hyps
                   )
   where
     (ls1, ls2)   = break isSeparator input
-    (hyps, rest) = case ls2 of {[] -> ([], ls1); (_ :: tls2) (ls1, tls2)}
+    (hyps, rest) = case ls2 of {[] -> ([], ls1); (_ : tls2) (ls1, tls2)}
     (ls1', ls2') = break isSeparator rest
-    (pols, cons) = case ls2' of {[] -> ([], ls1'); (_ :: tls2') (ls1', tls2')}
+    (pols, cons) = case ls2' of {[] -> ([], ls1'); (_ : tls2') (ls1', tls2')}
 
 
 -- | A separator is a line consisting entirely of dashes,

--- a/src/size-solver/Main.hs
+++ b/src/size-solver/Main.hs
@@ -100,9 +100,9 @@ parseFile input = ( map parse hyps
                   )
   where
     (ls1, ls2)   = break isSeparator input
-    (hyps, rest) = if null ls2 then ([], ls1) else (ls1, tail ls2)
+    (hyps, rest) = case ls2 of {[] -> ([], ls1); (_ :: tls2) (ls1, tls2)}
     (ls1', ls2') = break isSeparator rest
-    (pols, cons) = if null ls2' then ([], ls1') else (ls1', tail ls2')
+    (pols, cons) = case ls2' of {[] -> ([], ls1'); (_ :: tls2') (ls1', tls2')}
 
 
 -- | A separator is a line consisting entirely of dashes,


### PR DESCRIPTION
Previously, every CI run on every PR run would report a warning (in the "Checks" tab)

```
size-solver-test: src/size-solver/Main.hs#L105
In the use of ‘tail’
```

regardless of what changes were actually made.

This PR tweaks the code of size-solver so the warning is no longer issued.