### PR TITLE
Replace AbsToCon by MonadToConcrete and AbsToConT

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1202,11 +1202,12 @@ introTactic pmLambda ii = do
     conName [p] = [ c | I.ConP c _ _ <- [namedArg p] ]
     conName _   = __IMPOSSIBLE__
 
-    showUnambiguousConName amb v =
-       render . pretty <$> runAbsToCon (lookupQName amb $ I.conName v)
+    showUnambiguousConName :: AllowAmbiguousNames -> ConHead -> TCM String
+    showUnambiguousConName amb c = render . pretty <$> do
+      abstractToConcreteQName amb $ I.conName c
 
     showTCM :: PrettyTCM a => a -> TCM String
-    showTCM v = render <$> prettyTCM v
+    showTCM = render <.> prettyTCM
 
     introFun :: ListTel -> TCM [String]
     introFun tel = addContext tel' $ do

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -51,7 +51,7 @@ import Agda.Syntax.Abstract as A
 import Agda.Syntax.Abstract.Pretty
 import Agda.Syntax.Info (mkDefInfo)
 import Agda.Syntax.Translation.ConcreteToAbstract
-import Agda.Syntax.Translation.AbstractToConcrete hiding (withScope)
+import Agda.Syntax.Translation.AbstractToConcrete
 import Agda.Syntax.Scope.Base
 import Agda.Syntax.TopLevelModuleName
 

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -9,17 +9,15 @@
 module Agda.Syntax.Translation.AbstractToConcrete
     ( ToConcrete(..)
     , toConcreteCtx
-    , abstractToConcrete_
-    , abstractToConcreteScope
-    , abstractToConcreteHiding
-    , runAbsToCon
-    , RangeAndPragma(..)
-    , abstractToConcreteCtx
-    , withScope
-    , preserveInteractionIds
     , MonadAbsToCon
+    , abstractToConcrete_
+    , abstractToConcreteCtx
+    , abstractToConcreteHiding
+    , abstractToConcreteQName
+    , abstractToConcreteScope
+    , abstractToConcreteTelescope
+    , RangeAndPragma(..)
     , noTakenNames
-    , lookupQName
     ) where
 
 import Prelude hiding (null)
@@ -122,6 +120,14 @@ abstractToConcrete_ = runAbsToCon . toConcrete
 abstractToConcreteHiding :: (LensHiding i, ToConcrete a, MonadAbsToCon m)
   => i -> a -> m (ConOfAbs a)
 abstractToConcreteHiding i = runAbsToCon . toConcreteHiding i
+
+abstractToConcreteTelescope :: MonadAbsToCon m
+  => A.Telescope -> m [Maybe C.TypedBinding]
+abstractToConcreteTelescope tel = runAbsToCon $ bindToConcrete tel return
+
+abstractToConcreteQName :: MonadAbsToCon m
+  => AllowAmbiguousNames -> A.QName -> m (C.QName)
+abstractToConcreteQName amb = runAbsToCon . lookupQName amb
 
 ---------------------------------------------------------------------------
 -- * The Monad

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -399,8 +399,7 @@ instance PrettyTCM a => PrettyTCM (WithHiding a) where
 
 instance PrettyTCM Telescope where
   prettyTCM tel = P.fsep . map P.pretty <$> do
-      tel <- reify tel
-      runAbsToCon $ bindToConcrete tel return
+      abstractToConcreteTelescope =<< reify tel
 {-# SPECIALIZE prettyTCM :: Telescope -> TCM Doc #-}
 
 newtype PrettyContext = PrettyContext Context


### PR DESCRIPTION
The existential type `AbsToCon` makes the code hard to understand and hard to specialize for GHC.

We use the standard implementation technique instead:
- a class `MonadToConcrete` to denote which services are needed
- a monad transformer `AbsToConT` implementing these services


Commits:
- **AbsToCon: reorganize file, do not export AbsToCon and Env**
- **AbsToCon: refactor: do not export runAbsToCon**
- **AbsToCon: eliminate uses of MonadFail.fail**
- **refactor: replace existential AbsToCon by AbsToConT, MonadToConcrete**
