### PR TITLE
Fix #7529: treat `LevelUniv` in Cubical Agda

### DIFF
--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -247,6 +247,10 @@ instance PrettyTCM EqualityView where prettyTCM = prettyTCM . equalityUnview    
 
 -- Functors
 
+instance (PrettyTCM a, Subst a) => PrettyTCM (Abs a) where
+  prettyTCM a = underAbstraction_ a prettyTCM
+{-# SPECIALIZE prettyTCM :: PrettyTCM a => Abs a -> TCM Doc #-}
+
 instance PrettyTCM a => PrettyTCM (Closure a) where
   prettyTCM cl = enterClosure cl prettyTCM
 {-# SPECIALIZE prettyTCM :: PrettyTCM a => Closure a -> TCM Doc #-}

--- a/test/Fail/Issue7535.agda
+++ b/test/Fail/Issue7535.agda
@@ -1,0 +1,16 @@
+-- Andreas, 2024-10-07, issue #7535
+-- This is a version of Issue6060.agda with Propω instead of Prop.
+
+{-# OPTIONS --cubical --prop -WnoUnsupportedIndexedMatch #-}
+
+open import Agda.Primitive
+open import Agda.Builtin.Equality
+
+data S : Set where s : S
+data P : Propω where p : P
+
+-- The following is rejected for P : Prop
+-- so should also be rejected for P : Propω.
+
+g : (x : S) → s ≡ x → P → S
+g .s refl y = s

--- a/test/Fail/Issue7535.err
+++ b/test/Fail/Issue7535.err
@@ -1,0 +1,6 @@
+Issue7535.agda:16.1-16: error: [CannotGenerateTransportClause]
+Could not generate a transport clause for g
+because a term of type P
+lives in the sort Propω
+and thus can not be transported
+when checking the definition of g

--- a/test/Succeed/Issue7529.agda
+++ b/test/Succeed/Issue7529.agda
@@ -1,0 +1,22 @@
+-- Andreas, 2024-10-04, issue #7529, test case by Anders Mörtberg
+-- LevelUniv not (fully) integrated with Cubical Agda.
+
+{-# OPTIONS --cubical --level-universe #-}
+
+-- {-# OPTIONS -v cubical.prim.transpTel.error:20 #-}
+-- {-# OPTIONS -v impossible:10 #-}
+
+module _ where
+
+open import Agda.Primitive renaming (Set to Type)
+
+data _≡_ {l : Level} {X : Type l} : X → X → Type l where
+  refl : {x : X} → x ≡ x
+
+Jbased : {l : Level} {X : Type l} (x : X) (A : (y : X) → x ≡ y → Type l)
+       → A x refl → (y : X) (r : x ≡ y) → A y r
+Jbased x A b _ refl = b
+
+-- Used to be an internal error.
+
+-- Should succeed.


### PR DESCRIPTION
Issue #7529 demonstrates that `--level-universe` is not (fully) integrated with `--cubical` (yet).

In this PR, I expand some catch-alls for sorts to fill in some speculative values for the new sort `LevelUniv`.
I need some experts to look over this: @arthur-adjedj @plt-amy @mortberg @Saizan @sattlerc 

One should probably check the Cubical Agda code for more such matches on sorts, e.g. grep for `Type l` or `getSort`.

Related are also:
- #7413 
- #7417

Commits:
- **Debug #7529**
- **Fix #7529 by speculating values for LevelUniv in Cubical Agda fibrancy**
