### PR TITLE
Re #7533: warn when DISPLAY form binds variables unused on the rhs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ Pragmas and options
 * New warning `InvalidDisplayForm` instead of hard error
   when a display form is illegal (and thus ignored).
 
+* New warning `UnusedVariablesInDisplayForm` when DISPLAY pragma
+  binds variables that are not used.
+  Example:
+  ```agda
+  {-# DISPLAY List (Fin n) = ListFin #-}
+  ```
+  Since pattern variable `n` is not used on the right hand side `ListFin`,
+  Agda throws a warning and recommeds to rewrite it as:
+  ```agda
+  {-# DISPLAY List (Fin _) = ListFin #-}
+  ```
+
 * New warning `WithClauseProjectionFixityMismatch` instead of hard error
   when in a with-clause a projection is used in a different fixity
   (prefix vs. postfix) than in its parent clause.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1640,6 +1640,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Failures to compute full equivalence when splitting on indexed family.
 
+.. option:: UnusedVariablesInDisplayForm
+
+     :ref:`DISPLAY <display-pragma>` forms that bind variables they do not use.
+
 .. option:: UselessAbstract
 
      ``abstract`` blocks where they have no effect.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -467,6 +467,7 @@ warningHighlighting' b w = case tcWarning w of
   InfectiveImport{}                     -> errorWarningHighlighting w
   CoInfectiveImport{}                   -> errorWarningHighlighting w
   InvalidDisplayForm{}                  -> deadcodeHighlighting w
+  UnusedVariablesInDisplayForm xs       -> foldMap deadcodeHighlighting xs
   TooManyArgumentsToSort _ args         -> errorWarningHighlighting args
   WithClauseProjectionFixityMismatch p _ _ _ -> cosmeticProblemHighlighting p
   WithoutKFlagPrimEraseEquality -> mempty

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -342,6 +342,7 @@ data WarningName
   | UselessPublic_
   | UserWarning_
   | InvalidDisplayForm_
+  | UnusedVariablesInDisplayForm_
   | WithClauseProjectionFixityMismatch_
   | WithoutKFlagPrimEraseEquality_
   | ConflictingPragmaOptions_
@@ -567,6 +568,7 @@ warningNameDescription = \case
   UnsolvedMetaVariables_           -> "Unsolved meta variables."
   UserWarning_                     -> "User-defined warnings via one of the 'WARNING_ON_*' pragmas."
   InvalidDisplayForm_              -> "Invalid display forms."
+  UnusedVariablesInDisplayForm_    -> "Bound but unused variables in display forms."
   TooManyArgumentsToSort_          -> "Extra arguments given to a sort."
   WithClauseProjectionFixityMismatch_ -> "With clauses using projections in different fixities than their parent clauses."
   WithoutKFlagPrimEraseEquality_   -> "Uses of `primEraseEquality' with the without-K flags."

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4452,9 +4452,15 @@ data Warning
   | UnfoldTransparentName QName
   | UselessOpaque
 
-  -- Type checker warnings
+  -- Display form warnings
   | InvalidDisplayForm QName String
       -- ^ DISPLAY form for 'QName' is invalid because 'String'.
+  | UnusedVariablesInDisplayForm (List1 A.Name)
+      -- ^ The given names are bound in the lhs of the display form
+      --   but not used on the rhs.
+      --   This can indicate a user misunderstanding of display forms.
+
+  -- Type checker warnings
   | TooManyArgumentsToSort QName (List1 (NamedArg A.Expr))
       -- ^ Extra arguments to sort (will be ignored).
   | WithClauseProjectionFixityMismatch
@@ -4578,8 +4584,11 @@ warningName = \case
   UnfoldingWrongName{}    -> UnfoldingWrongName_
   UnfoldTransparentName{} -> UnfoldTransparentName_
 
-  -- Type checking
+  -- Display forms
   InvalidDisplayForm{}                 -> InvalidDisplayForm_
+  UnusedVariablesInDisplayForm{}       -> UnusedVariablesInDisplayForm_
+
+  -- Type checking
   TooManyArgumentsToSort{}             -> TooManyArgumentsToSort_
   WithClauseProjectionFixityMismatch{} -> WithClauseProjectionFixityMismatch_
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -564,6 +564,20 @@ prettyWarning = \case
         , if null reason then [] else "because" : pwords reason
         ]
 
+    UnusedVariablesInDisplayForm xs -> vcat
+      [ fsep $ concat
+        [ pwords "The following"
+        , pwords $ singPlural xs "variable is" "variables are"
+        , pwords "bound on the left hand side but unused on the right hand side of the display form:"
+        ]
+      , nest 2 $ fsep $ fmap pretty xs
+      , fsep $ concat
+        [ [ "Replace" ]
+        , pwords $ singPlural xs "it by an underscore" "them by underscores"
+        , pwords "to pacify this warning"
+        ]
+      ]
+
     TooManyArgumentsToSort q args -> fsep $ concat
       [ pwords "Too many arguments given to sort"
       , [ prettyTCM q ]

--- a/src/full/Agda/TypeChecking/Rules/Display.hs
+++ b/src/full/Agda/TypeChecking/Rules/Display.hs
@@ -31,7 +31,7 @@ checkDisplayPragma f ps e = do
       -- pappToTerm puts Var 0 for every variable. We get to know how many there were (n) so
       -- now we can renumber them with decreasing deBruijn indices.
       let lhs = renumberElims (n - 1) args
-      Display n lhs <$> DTerm <$> exprToTerm e
+      Display n lhs . DTerm <$> exprToTerm e
   case res of
     Left reason -> warning $ InvalidDisplayForm f reason
     Right df -> do

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20241010 * 10 + 1
+currentInterfaceVersion = 20241011 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -131,6 +131,7 @@ instance EmbPrj Warning where
     -- TODO: linearity
     -- FixingQuantity a b c                        -> icodeN 68 FixingQuantity a b c
     FixingRelevance a b c                       -> icodeN 69 FixingRelevance a b c
+    UnusedVariablesInDisplayForm a              -> icodeN 70 UnusedVariablesInDisplayForm a
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -204,6 +205,7 @@ instance EmbPrj Warning where
     -- TODO: linearity
     -- [68, a, b, c]        -> valuN FixingQuantity a b c
     [69, a, b, c]        -> valuN FixingRelevance a b c
+    [70, a]              -> valuN UnusedVariablesInDisplayForm a
     _ -> malformed
 
 instance EmbPrj IllegalRewriteRuleReason where

--- a/test/Succeed/InvalidDisplayForm.warn
+++ b/test/Succeed/InvalidDisplayForm.warn
@@ -91,6 +91,14 @@ Ignoring invalid display form for L0 because its left-hand side
 contains an @-pattern: x@y
 when checking the pragma DISPLAY L0 x@y = Set
 
+InvalidDisplayForm.agda:45.1-37: warning: -W[no]UnusedVariablesInDisplayForm
+The following variables are bound on the left hand side but unused
+on the right hand side of the display form:
+  x y
+Replace them by underscores to pacify this warning
+when scope checking the declaration
+  {-# DISPLAY L0 x@y = Set #-}
+
 InvalidDisplayForm.agda:46.1-37: warning: -W[no]InvalidDisplayForm
 Ignoring invalid display form for L1 because its left-hand side
 contains a dot pattern: .Set
@@ -243,6 +251,14 @@ InvalidDisplayForm.agda:45.1-37: warning: -W[no]InvalidDisplayForm
 Ignoring invalid display form for L0 because its left-hand side
 contains an @-pattern: x@y
 when checking the pragma DISPLAY L0 x@y = Set
+
+InvalidDisplayForm.agda:45.1-37: warning: -W[no]UnusedVariablesInDisplayForm
+The following variables are bound on the left hand side but unused
+on the right hand side of the display form:
+  x y
+Replace them by underscores to pacify this warning
+when scope checking the declaration
+  {-# DISPLAY L0 x@y = Set #-}
 
 InvalidDisplayForm.agda:46.1-37: warning: -W[no]InvalidDisplayForm
 Ignoring invalid display form for L1 because its left-hand side

--- a/test/interaction/Issue1873.out
+++ b/test/interaction/Issue1873.out
@@ -2,5 +2,5 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 (agda2-status-action "")
-(agda2-info-action "*All Goals*" "?0 : {x : A} → B → B " nil)
+(agda2-info-action "*All Goals, Warnings*" "?0 : {x : A} → B → B ———— Warnings —————————————————————————————————————————————— Issue1873.agda:10.1-30: warning: -W[no]UnusedVariablesInDisplayForm The following variable is bound on the left hand side but unused on the right hand side of the display form: y Replace it by an underscore to pacify this warning when scope checking the declaration {-# DISPLAY const x y = x #-}" nil)
 ((last . 1) . (agda2-goals-action '(0)))

--- a/test/interaction/Issue6325.out
+++ b/test/interaction/Issue6325.out
@@ -2,7 +2,7 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 (agda2-status-action "Checked")
-(agda2-info-action "*All Done*" "" nil)
+(agda2-info-action "*All Warnings*" "Issue6325.agda:26.1-47: warning: -W[no]UnusedVariablesInDisplayForm The following variable is bound on the left hand side but unused on the right hand side of the display form: ys Replace it by an underscore to pacify this warning when scope checking the declaration {-# DISPLAY f₁ _ (c {xs} n ys) = c n xs #-} Issue6325.agda:27.1-47: warning: -W[no]UnusedVariablesInDisplayForm The following variable is bound on the left hand side but unused on the right hand side of the display form: n Replace it by an underscore to pacify this warning when scope checking the declaration {-# DISPLAY f₂ _ (c {(xs)} n ys) = c xs ys #-}" nil)
 ((last . 1) . (agda2-goals-action '()))
 (agda2-status-action "Checked")
 (agda2-info-action "*Normal Form*" "λ x → c 1 (0 ∷ [])" nil)


### PR DESCRIPTION
This PR installs a warning if the lhs of a DISPLAY pragma binds variables that are not used on its rhs.

It is currently stuck on DISPLAY pragmas that violate the check:
https://github.com/agda/agda/blob/1e9725ee8a334de816fff39ce1bd32f91b6714e4/src/data/lib/prim/Agda/Builtin/TrustMe.agda#L15
https://github.com/agda/agda-stdlib/blob/4739d4ae0be0be8643dc14cf16cc37df9a17f38e/src/Data/Empty.agda#L31
```agda
{-# DISPLAY Irrelevant Empty = ⊥ #-}
```

This begs the question whether we should change DISPLAY so it treats any defined name as constructor.  
Apparantly this is what users expect, even the Agda implementors seem to expect this.
Such an enhancement of DISPLAY was already suggested in:
- #2004

CC: @gallais @jamesmckinna 