### PR TITLE
Refactor: use List1 in OpApp

### DIFF
--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -10,7 +10,7 @@ module Agda.Syntax.Concrete
   ( -- * Expressions
     Expr(..)
   , OpApp(..), fromOrdinary
-  , OpAppArgs, OpAppArgs'
+  , OpAppArgs, OpAppArgs', OpAppArgs0
   , module Agda.Syntax.Concrete.Name
   , AppView(..), appView, unAppView
   , toNamedArg, unNamedArg
@@ -199,7 +199,8 @@ data Expr
   deriving Eq
 
 type OpAppArgs = OpAppArgs' Expr
-type OpAppArgs' e = [NamedArg (MaybePlaceholder (OpApp e))]
+type OpAppArgs' e = List1 (NamedArg (MaybePlaceholder (OpApp e)))
+type OpAppArgs0 e = [NamedArg (MaybePlaceholder (OpApp e))]
 
 -- | Concrete patterns. No literals in patterns at the moment.
 data Pattern
@@ -217,7 +218,7 @@ data Pattern
   | AppP Pattern (NamedArg Pattern)        -- ^ @p p'@ or @p {x = p'}@
   | RawAppP Range (List2 Pattern)          -- ^ @p1..pn@ before parsing operators
   | OpAppP Range QName (Set1 A.Name)
-           [NamedArg Pattern]              -- ^ eg: @p => p'@ for operator @_=>_@
+      (List1 (NamedArg Pattern))           -- ^ eg: @p => p'@ for operator @_=>_@
                                            -- The 'QName' is possibly
                                            -- ambiguous, but it must
                                            -- correspond to one of

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -51,7 +51,7 @@ import Agda.Utils.Function (applyWhen)
 import Agda.Utils.Either
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.List
-import Agda.Utils.List1 (List1, pattern (:|))
+import Agda.Utils.List1 (List1, pattern (:|), (<|))
 import Agda.Utils.List2 (List2, pattern List2)
 import qualified Agda.Utils.List1 as List1
 import qualified Agda.Utils.List2 as List2
@@ -762,7 +762,7 @@ appView = loop []
   where
   loop acc = \case
     AppP p a         -> loop (namedArg a : acc) p
-    OpAppP _ op _ ps -> (IdentP True op :| fmap namedArg ps)
+    OpAppP _ op _ ps -> (IdentP True op <| fmap namedArg ps)
                           `List1.appendList`
                         reverse acc
     ParenP _ p       -> loop acc p

--- a/src/full/Agda/Syntax/Concrete/Pattern.hs
+++ b/src/full/Agda/Syntax/Concrete/Pattern.hs
@@ -17,7 +17,7 @@ import Agda.Utils.AffineHole
 import Agda.Utils.Functor
 import Agda.Utils.Impossible
 import Agda.Utils.List
-import Agda.Utils.List1  ( List1, pattern (:|) )
+import Agda.Utils.List1  ( List1, pattern (:|), (<|) )
 import Agda.Utils.List2  ( List2 )
 import Agda.Utils.Maybe
 import Agda.Utils.Singleton
@@ -381,7 +381,7 @@ splitEllipsis k (p:ps)
 patternAppView :: Pattern -> List1 (NamedArg Pattern)
 patternAppView = \case
     AppP p arg      -> patternAppView p `List1.appendList` [arg]
-    OpAppP _ x _ ps -> defaultNamedArg (IdentP True x) :| ps
+    OpAppP _ x _ ps -> defaultNamedArg (IdentP True x) <| ps
     ParenP _ p      -> patternAppView p
     RawAppP _ _     -> __IMPOSSIBLE__
     p               -> singleton $ defaultNamedArg p

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -221,14 +221,13 @@ instance Pretty a => Pretty (MaybePlaceholder a) where
   pretty (NoPlaceholder _ e) = pretty e
 
 instance Pretty Expr where
-    pretty e =
-        case e of
+    pretty = \case
             Ident x          -> pretty x
             KnownIdent nk x  -> annotateAspect (Asp.Name (Just nk) False) (pretty x)
             Lit _ l          -> pretty l
             QuestionMark _ n -> hlSymbol "?" <> maybe empty (text . show) n
             Underscore _ n   -> maybe underscore text n
-            App _ _ _        ->
+            e@(App _ _ _)    ->
                 case appView e of
                     AppView e1 args     ->
                         fsep $ pretty e1 : map pretty args
@@ -746,8 +745,8 @@ instance Pretty Pattern where
             WithP _ p       -> "|" <+> pretty p
 
 prettyOpApp :: forall a .
-  Pretty a => Asp.Aspect -> QName -> [NamedArg (MaybePlaceholder a)] -> [Doc]
-prettyOpApp asp q es = merge [] $ prOp ms xs es
+  Pretty a => Asp.Aspect -> QName -> List1 (NamedArg (MaybePlaceholder a)) -> [Doc]
+prettyOpApp asp q es = merge [] $ prOp ms xs $ List1.toList es
   where
     -- ms: the module part of the name.
     ms = List1.init (qnameParts q)

--- a/src/full/Agda/Syntax/IdiomBrackets.hs
+++ b/src/full/Agda/Syntax/IdiomBrackets.hs
@@ -45,7 +45,7 @@ parseIdiomBrackets r e = do
 appViewM :: Expr -> ScopeM (List1 Expr)
 appViewM = \case
     e@App{}         -> let AppView e' es = appView e in (e' :|) <$> mapM onlyVisible es
-    OpApp _ op _ es -> (Ident op :|) <$> mapM (ordinary <=< noPlaceholder <=< onlyVisible) es
+    OpApp _ op _ es -> (Ident op <|) <$> mapM (ordinary <=< noPlaceholder <=< onlyVisible) es
     e               -> return $ singleton e
   where
     onlyVisible a

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1632,14 +1632,13 @@ cOpApp :: Asp.NameKind -> Range -> C.QName -> A.Name -> List1 (MaybeSection C.Ex
 cOpApp nk r x n es =
   C.KnownOpApp nk r x (singleton n) $
   fmap (defaultNamedArg . placeholder) $
-  List1.toList eps
+  List1.zip es positions
   where
     x0 = C.unqualify x
     positions | isPrefix  x0 =              (const Middle <$> List1.drop 1 es) `List1.snoc` End
               | isPostfix x0 = Beginning :| (const Middle <$> List1.drop 1 es)
               | isInfix x0   = Beginning :| (const Middle <$> List1.drop 2 es) ++ [ End ]
               | otherwise    =               const Middle <$> es
-    eps = List1.zip es positions
     placeholder (YesSection , pos ) = Placeholder pos
     placeholder (NoSection e, _pos) = noPlaceholder (Ordinary e)
 
@@ -1694,7 +1693,7 @@ tryToRecoverOpAppP p = do
     opApp r x n ps = C.OpAppP r x (singleton n) $
       fmap (defaultNamedArg . fromNoSection __IMPOSSIBLE__) $
       -- `view` does not generate any `Nothing`s
-      List1.toList ps
+      ps
 
     appInfo = defaultAppInfo_
 


### PR DESCRIPTION
Refactoring to use `List1` in `OpApp` and its relatives (`OpAppP`, `OpAppV` and `KnownOpApp`).
Nullary operators "applications" are thus no longer represented by `OpApp`.