### PR TITLE
DISPLAY: match on defined names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ Pragmas and options
 
 * New option `--js-es6` for generating JavaScript with ES6 module syntax.
 
+* DISPLAY pragmas can now define display forms that match on defined names
+  beyond constructors ([issue #7533](https://github.com/agda/agda/issues/7533)).
+  Example:
+  ```agda
+  {-# DISPLAY Irrelevant Empty = ⊥ #-}
+  ```
+  `Empty` used to be interpreted as a pattern variable, effectively installing
+  the display form `Irrelevant _ = ⊥`.
+  Now `Empty` is treated as a matchable name, as one would intuitively expect
+  from a display form.
+  As a consequence, only `Irrelevant Empty` is displayed as `⊥`, not just any
+  `Irrelevant A`.
+
 Syntax
 ------
 

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -23,7 +23,6 @@ module Agda.Compiler.Backend
 import Prelude hiding (null)
 
 import Control.DeepSeq
-import Control.Monad.Trans        ( lift )
 import Control.Monad.Trans.Maybe
 
 import Data.Maybe

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -7,7 +7,6 @@ module Agda.Compiler.MAlonzo.Compiler
 
 import Control.Arrow (second)
 import Control.DeepSeq
-import Control.Monad
 import Control.Monad.Except   ( throwError )
 import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.Reader   ( MonadReader(..), asks, ReaderT, runReaderT, withReaderT)

--- a/src/full/Agda/Compiler/MAlonzo/Pragmas.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Pragmas.hs
@@ -2,7 +2,6 @@
 
 module Agda.Compiler.MAlonzo.Pragmas where
 
-import Control.Monad
 import Control.Monad.Trans.Maybe
 
 import Data.Maybe

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -11,9 +11,7 @@ module Agda.Compiler.ToTreeless
 
 import Prelude hiding ((!!))
 
-import Control.Monad        ( filterM, foldM, forM, zipWithM )
 import Control.Monad.Reader ( MonadReader(..), asks, ReaderT, runReaderT )
-import Control.Monad.Trans  ( lift )
 
 import Data.Maybe
 import Data.Map (Map)

--- a/src/full/Agda/Compiler/Treeless/Erase.hs
+++ b/src/full/Agda/Compiler/Treeless/Erase.hs
@@ -8,9 +8,9 @@ module Agda.Compiler.Treeless.Erase
        , isErasable
        ) where
 
-import Control.Arrow (first, second)
-import Control.Monad
-import Control.Monad.State
+import Control.Arrow       ( first, second )
+import Control.Monad.State ( StateT, evalStateT )
+
 import Data.Map (Map)
 import qualified Data.Map as Map
 

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -6,10 +6,9 @@ module Agda.Interaction.BasicOps where
 import Prelude hiding (null)
 
 import Control.Arrow          ( first )
-import Control.Monad          ( (<=<), (>=>), forM, filterM, guard )
-import Control.Monad.Except
-import Control.Monad.State
-import Control.Monad.Identity
+import Control.Monad.Except   ( MonadError(..) )
+import Control.Monad.State    ( MonadState(..), evalState )
+import Control.Monad.Identity ( runIdentity )
 import Control.Monad.Trans.Maybe
 
 import qualified Data.Map as Map

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -23,7 +23,6 @@ import Data.Function (on)
 import Data.Foldable (toList)
 
 import Control.Exception.Base (IOException, try)
-import Control.Monad (forM_, mapM_, unless, when)
 import Control.Monad.Trans.Reader as R ( ReaderT(runReaderT))
 import Control.Monad.RWS.Strict
   ( RWST(runRWST)

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -26,10 +26,9 @@ module Agda.Interaction.Imports
 
 import Prelude hiding (null)
 
-import Control.Monad               ( forM, forM_, void )
-import Control.Monad.Except
+import Control.Monad.Except        ( MonadError(..), ExceptT, runExceptT, withExceptT )
 import Control.Monad.IO.Class      ( MonadIO(..) )
-import Control.Monad.State
+import Control.Monad.State         ( MonadState(..), execStateT )
 import Control.Monad.Trans.Maybe
 import qualified Control.Exception as E
 

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -15,13 +15,11 @@ import Control.Concurrent.STM.TChan
 import Control.Concurrent.STM.TVar
 import qualified Control.Exception  as E
 
-import Control.Monad
 import Control.Monad.Except         ( MonadError(..), ExceptT(..), runExceptT )
 import Control.Monad.IO.Class       ( MonadIO(..) )
 import Control.Monad.State          ( MonadState(..), gets, modify, runStateT )
 import Control.Monad.STM
 import Control.Monad.State          ( StateT )
-import Control.Monad.Trans          ( lift )
 
 import qualified Data.Char as Char
 import Data.Function (on)

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -6,8 +6,6 @@ module Agda.Interaction.MakeCase where
 
 import Prelude hiding ((!!), null)
 
-import Control.Monad
-
 import Data.Either
 import qualified Data.List as List
 import Data.Maybe

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -7,7 +7,7 @@ module Agda.Syntax.Abstract.Name
   , FreshNameMode(..)
   ) where
 
-import Prelude hiding (length)
+import Prelude hiding (length, null)
 
 import Control.DeepSeq
 
@@ -20,6 +20,7 @@ import Data.Void
 
 import Agda.Syntax.Position
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty
 import Agda.Syntax.Concrete.Name (IsNoName(..), NumHoles(..), NameInScope(..), LensInScope(..), FreshNameMode(..))
 import qualified Agda.Syntax.Concrete.Name as C
 
@@ -28,7 +29,7 @@ import Agda.Utils.Lens
 import qualified Agda.Utils.List as L
 import Agda.Utils.List1 (List1, pattern (:|), (<|))
 import qualified Agda.Utils.List1 as List1
-import Agda.Syntax.Common.Pretty
+import Agda.Utils.Null
 import Agda.Utils.Size
 
 import Agda.Utils.Impossible
@@ -104,6 +105,9 @@ data Suffix
   = NoSuffix
   | Suffix !Integer
   deriving (Show, Eq, Ord)
+
+instance Null Suffix where
+  empty = NoSuffix
 
 instance NFData Suffix where
   rnf NoSuffix   = ()

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -145,6 +145,21 @@ instance Pretty ConstructorOrPatternSynonym where
 
 instance NFData ConstructorOrPatternSynonym
 
+-- | Distinguish parsing a DISPLAY pragma from an ordinary left hand side.
+
+data DisplayLHS = YesDisplayLHS | NoDisplayLHS
+  deriving (Eq, Show, Generic, Enum, Bounded)
+
+instance Boolean DisplayLHS where
+  fromBool = \case
+    True -> YesDisplayLHS
+    False -> NoDisplayLHS
+
+instance IsBool DisplayLHS where
+  toBool = \case
+    YesDisplayLHS -> True
+    NoDisplayLHS -> False
+
 ---------------------------------------------------------------------------
 -- * Record Directives
 ---------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -52,7 +52,6 @@ module Agda.Syntax.Concrete.Definitions
 
 import Prelude hiding (null)
 
-import Control.Monad         ( forM, guard, unless, void, when )
 import Control.Monad.Except  ( )
 import Control.Monad.Reader  ( asks )
 import Control.Monad.State   ( MonadState(..), gets, StateT, runStateT )

--- a/src/full/Agda/Syntax/Parser/Helpers.hs
+++ b/src/full/Agda/Syntax/Parser/Helpers.hs
@@ -5,8 +5,7 @@ module Agda.Syntax.Parser.Helpers where
 import Prelude hiding (null)
 
 import Control.Applicative ( (<|>) )
-import Control.Monad
-import Control.Monad.State
+import Control.Monad.State ( modify' )
 
 import Data.Bifunctor (first, second)
 import Data.Char

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -392,8 +392,16 @@ data KindOfName
   -- End @DefName@.  Keep these together in sequence, for sake of @isDefName@!
   deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
+-- | All kinds of regular definitions.
+defNameKinds :: [KindOfName]
+defNameKinds = [DataName .. OtherDefName]
+
 isDefName :: KindOfName -> Bool
 isDefName = (>= DataName)
+
+-- | Constructor and pattern synonyms.
+conLikeNameKinds :: [KindOfName]
+conLikeNameKinds = [ConName, CoConName, PatternSynName]
 
 isConName :: KindOfName -> Maybe Induction
 isConName = \case

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -8,10 +8,10 @@ module Agda.Syntax.Scope.Monad where
 import Prelude hiding (null)
 
 import Control.Arrow ((***))
-import Control.Monad
-import Control.Monad.Except
-import Control.Monad.State
-import Control.Monad.Trans.Maybe
+import Control.Monad.Except       ( MonadError, throwError, runExceptT )
+import Control.Monad.State        ( StateT, runStateT, gets, modify )
+import Control.Monad.Trans        ( MonadTrans, lift )
+import Control.Monad.Trans.Maybe  ( MaybeT(MaybeT), runMaybeT )
 import Control.Applicative
 
 import Data.Either ( partitionEithers )

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -22,7 +22,6 @@ module Agda.Syntax.Translation.AbstractToConcrete
 
 import Prelude hiding (null)
 
-import Control.Monad        ( (<=<), forM, forM_, guard, liftM2 )
 import Control.Monad.Except ( runExceptT )
 import Control.Monad.Reader ( MonadReader(..), asks, ReaderT, runReaderT )
 import Control.Monad.State  ( StateT(..), runStateT )

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -11,10 +11,9 @@ import Prelude hiding (null)
 
 import Control.Applicative hiding (empty)
 
-import Control.Monad          ( forM )
 import Control.Monad.IO.Class ( MonadIO(..) )
-import Control.Monad.Except
-import Control.Monad.Reader
+import Control.Monad.Except   ( MonadError(..) )
+import Control.Monad.Reader   ( MonadReader(..), ReaderT(..) )
 
 import Data.DList (DList)
 import qualified Data.DList as DL

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -6,8 +6,7 @@ module Agda.TypeChecking.Constraints where
 
 import Prelude hiding (null)
 
-import Control.Monad
-import Control.Monad.Except
+import Control.Monad.Except ( MonadError )
 
 import qualified Data.List as List
 import qualified Data.Set as Set

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -8,8 +8,7 @@
 module Agda.TypeChecking.Conversion where
 
 import Control.Arrow (second)
-import Control.Monad
-import Control.Monad.Except
+import Control.Monad.Except ( MonadError(..) )
 
 import Data.Function (on)
 import Data.Semigroup ((<>))

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -18,17 +18,18 @@ module Agda.TypeChecking.Coverage
 
 import Prelude hiding (null, (!!))  -- do not use partial functions like !!
 
-import Control.Monad
-import Control.Monad.Except
-import Control.Monad.Trans ( lift )
+import Control.Monad.Except ( MonadError(..), ExceptT(..), runExceptT )
+import Control.Monad.State  ( State, evalState, state )
 
 import Data.Foldable (for_)
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
 
 import qualified Agda.Benchmarking as Bench
 
@@ -52,7 +53,6 @@ import Agda.TypeChecking.Coverage.Match
 import Agda.TypeChecking.Coverage.SplitTree
 import Agda.TypeChecking.Coverage.SplitClause
 import Agda.TypeChecking.Coverage.Cubical
-
 
 import Agda.TypeChecking.Conversion (tryConversion, equalType)
 import Agda.TypeChecking.Datatypes (getConForm)
@@ -84,10 +84,6 @@ import Agda.Utils.Size
 import Agda.Utils.Tuple
 
 import Agda.Utils.Impossible
-import Data.IntMap (IntMap)
-import qualified Data.IntMap as IntMap
-import Control.Monad.State
-
 
 type CoverM = ExceptT SplitError TCM
 

--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -4,9 +4,7 @@ module Agda.TypeChecking.Coverage.Cubical where
 
 import Prelude hiding (null, (!!))  -- do not use partial functions like !!
 
-import Control.Monad
-import Control.Monad.Except
-import Control.Monad.Trans ( lift )
+import Control.Monad.Except ( runExceptT )
 
 import qualified Data.Set as Set
 import Data.IntSet (IntSet)

--- a/src/full/Agda/TypeChecking/Empty.hs
+++ b/src/full/Agda/TypeChecking/Empty.hs
@@ -7,7 +7,6 @@ module Agda.TypeChecking.Empty
   , checkEmptyTel
   ) where
 
-import Control.Monad        ( void )
 import Control.Monad.Except ( MonadError(..) )
 
 import Data.Semigroup

--- a/src/full/Agda/TypeChecking/Forcing.hs
+++ b/src/full/Agda/TypeChecking/Forcing.hs
@@ -63,9 +63,8 @@ module Agda.TypeChecking.Forcing
     isForced,
     nextIsForced ) where
 
-import Control.Monad
-import Control.Monad.Reader
-import Control.Monad.State
+import Control.Monad.Reader ( MonadReader, ask, local, ReaderT, runReaderT )
+import Control.Monad.State  ( MonadState, modify, StateT, execStateT )
 
 import Data.Bifunctor
 import Data.Function ((&))

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -60,7 +60,6 @@
 module Agda.TypeChecking.Free.Lazy where
 
 import Control.Applicative hiding (empty)
-import Control.Monad        ( guard )
 import Control.Monad.Reader ( MonadReader(..), asks, ReaderT, Reader, runReader )
 
 import Data.IntMap (IntMap)

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -119,8 +119,7 @@ module Agda.TypeChecking.Generalize
 import Prelude hiding (null)
 
 import Control.Arrow ((&&&), first)
-import Control.Monad
-import Control.Monad.Except
+import Control.Monad.Except ( MonadError(..) )
 
 import qualified Data.IntSet as IntSet
 import Data.Set (Set)

--- a/src/full/Agda/TypeChecking/IApplyConfluence.hs
+++ b/src/full/Agda/TypeChecking/IApplyConfluence.hs
@@ -4,8 +4,7 @@ module Agda.TypeChecking.IApplyConfluence where
 
 import Prelude hiding (null, (!!))  -- do not use partial functions like !!
 
-import Control.Monad
-import Control.Monad.Except
+import Control.Monad.Except ( MonadError(..) )
 
 import Data.Bifunctor (first, second)
 import Data.DList (DList)

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -41,11 +41,10 @@ Projection patterns (@ProjP@) are excluded because metas cannot occupy their pla
 module Agda.TypeChecking.Injectivity where
 
 import Control.Applicative
-import Control.Monad
-import Control.Monad.Except
-import Control.Monad.State
-import Control.Monad.Reader
-import Control.Monad.Trans.Maybe
+import Control.Monad.Except       ( MonadError )
+import Control.Monad.State        ( evalStateT, MonadState, gets, put )
+import Control.Monad.Reader       ( runReaderT, MonadReader, ask )
+import Control.Monad.Trans.Maybe  ( MaybeT(MaybeT), runMaybeT )
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -18,10 +18,7 @@ module Agda.TypeChecking.InstanceArguments
   , resolveInstanceHead
   ) where
 
-import Control.Monad          (forM, filterM)
 import Control.Monad.Except   (ExceptT(..), runExceptT, MonadError(..))
-import Control.Monad.Trans    (lift )
--- import Control.Monad.IO.Class (liftIO)
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -75,7 +75,7 @@ variable rule:
 
 module Agda.TypeChecking.Irrelevance where
 
-import Control.Monad.Except
+import Control.Monad.Except ( MonadError(..), runExceptT )
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal

--- a/src/full/Agda/TypeChecking/Level/Solve.hs
+++ b/src/full/Agda/TypeChecking/Level/Solve.hs
@@ -2,8 +2,7 @@
 
 module Agda.TypeChecking.Level.Solve where
 
-import Control.Monad
-import Control.Monad.Except
+import Control.Monad.Except ( catchError )
 
 import qualified Data.Map.Strict as MapS
 import Data.Maybe

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -9,8 +9,6 @@ module Agda.TypeChecking.Lock
   )
 where
 
-import Control.Monad            ( (<=<), filterM, forM )
-
 import qualified Data.IntMap as IMap
 import qualified Data.IntSet as ISet
 import qualified Data.Set as Set

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -6,9 +6,7 @@ module Agda.TypeChecking.MetaVars where
 
 import Prelude hiding (null)
 
-import Control.Monad        ( foldM, forM, forM_, liftM2, void, guard )
 import Control.Monad.Except ( MonadError(..), ExceptT, runExceptT )
-import Control.Monad.Trans  ( lift )
 import Control.Monad.Trans.Maybe
 
 import qualified Data.IntSet as IntSet

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -15,9 +15,8 @@
 
 module Agda.TypeChecking.MetaVars.Occurs where
 
-import Control.Monad
-import Control.Monad.Except
-import Control.Monad.Reader
+import Control.Monad.Except ( ExceptT, runExceptT, catchError, throwError )
+import Control.Monad.Reader ( ReaderT, runReaderT, ask, asks, local )
 
 import Data.Foldable (traverse_)
 import Data.Functor

--- a/src/full/Agda/TypeChecking/Modalities.hs
+++ b/src/full/Agda/TypeChecking/Modalities.hs
@@ -7,7 +7,6 @@ module Agda.TypeChecking.Modalities
   ) where
 
 import Control.Applicative ((<|>))
-import Control.Monad
 
 import Agda.Interaction.Options
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -17,9 +17,7 @@ import qualified Control.Concurrent as C
 import Control.DeepSeq
 import qualified Control.Exception as E
 
-import Control.Monad                ( void )
-import Control.Monad.Except
-import Control.Monad.Fix
+import Control.Monad.Except         ( MonadError(..), ExceptT(..), runExceptT )
 import Control.Monad.IO.Class       ( MonadIO(..) )
 import Control.Monad.State          ( MonadState(..), modify, StateT(..), runStateT )
 import Control.Monad.Reader         ( MonadReader(..), ReaderT(..), runReaderT )

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -4,14 +4,13 @@ module Agda.TypeChecking.Monad.Builtin
   , module Agda.Syntax.Builtin  -- The names are defined here.
   ) where
 
-import Control.Monad                ( liftM2, void )
-import Control.Monad.Except
+import Control.Monad.Except         ( MonadError(..), ExceptT )
 import Control.Monad.IO.Class       ( MonadIO(..) )
-import Control.Monad.Reader
-import Control.Monad.State
-import Control.Monad.Trans.Identity (IdentityT)
+import Control.Monad.Reader         ( ReaderT )
+import Control.Monad.State          ( StateT )
+import Control.Monad.Trans.Identity ( IdentityT )
 import Control.Monad.Trans.Maybe
-import Control.Monad.Writer
+import Control.Monad.Writer         ( WriterT )
 
 import Data.Function ( on )
 import qualified Data.Map as Map

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -4,7 +4,6 @@ module Agda.TypeChecking.Monad.MetaVars where
 
 import Prelude hiding (null)
 
-import Control.Monad                ( (<=<), forM_, guard )
 import Control.Monad.Except         ( ExceptT, MonadError )
 import Control.Monad.State          ( StateT, execStateT, get, put )
 import Control.Monad.Trans          ( MonadTrans, lift )

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -5,7 +5,6 @@ module Agda.TypeChecking.Monad.Signature where
 import Prelude hiding (null)
 
 import Control.Arrow                 ( first, second )
-import Control.Monad
 import Control.Monad.Except          ( ExceptT )
 import Control.Monad.State           ( StateT  )
 import Control.Monad.Reader          ( ReaderT )

--- a/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
@@ -6,7 +6,7 @@
 
 module Agda.TypeChecking.Monad.SizedTypes where
 
-import Control.Monad.Except
+import Control.Monad.Except ( MonadError(..) )
 
 import qualified Data.Foldable as Fold
 import qualified Data.Traversable as Trav

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -4,8 +4,6 @@ module Agda.TypeChecking.Monad.Trace where
 
 import Prelude hiding (null)
 
-import Control.Monad                ( forM_ )
-import Control.Monad.Trans          ( MonadTrans, lift)
 import Control.Monad.Except         ( ExceptT  (ExceptT  ), runExceptT   , throwError )
 import Control.Monad.Reader         ( ReaderT  (ReaderT  ), runReaderT   )
 import Control.Monad.State          ( StateT   (StateT   ), runStateT    )

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -7,7 +7,6 @@ import Prelude hiding ( null )
 
 import Control.Applicative hiding (empty)
 import Control.DeepSeq
-import Control.Monad        ( forM_, guard, liftM2 )
 import Control.Monad.Reader ( MonadReader(..), asks, Reader, runReader )
 
 import Data.Either

--- a/src/full/Agda/TypeChecking/ProjectionLike.hs
+++ b/src/full/Agda/TypeChecking/ProjectionLike.hs
@@ -58,8 +58,6 @@
 
 module Agda.TypeChecking.ProjectionLike where
 
-import Control.Monad
-
 import qualified Data.Map as Map
 import Data.Monoid (Any(..), getAny)
 

--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -10,12 +10,9 @@ module Agda.TypeChecking.RecordPatterns
   ) where
 
 import Control.Arrow          ( first, second )
-import Control.Monad          ( forM, join, unless, when, zipWithM )
-import Control.Monad.Fix      ( mfix )
 import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.Reader   ( MonadReader(..), ReaderT(..), runReaderT )
 import Control.Monad.State    ( MonadState(..), StateT(..), runStateT )
-import Control.Monad.Trans    ( lift )
 
 import qualified Data.List as List
 import Data.Maybe

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -4,11 +4,10 @@ module Agda.TypeChecking.Records where
 
 import Prelude hiding (null)
 
-import Control.Monad
-import Control.Monad.Except
-import Control.Monad.Trans.Maybe
-import Control.Monad.Writer
-import Control.Applicative ( (<|>) )
+import Control.Applicative        ( (<|>) )
+import Control.Monad.Except       ( MonadError )
+import Control.Monad.Trans.Maybe  ( MaybeT(MaybeT), runMaybeT )
+import Control.Monad.Writer       ( Writer, runWriter, tell )
 
 import Data.Bifunctor
 import qualified Data.List as List

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -24,8 +24,7 @@ module Agda.TypeChecking.Reduce
  , slowNormaliseArgs
  ) where
 
-import Control.Monad ( (>=>), void )
-import Control.Monad.Except
+import Control.Monad.Except ( MonadError(..) )
 
 import Data.List ( intercalate )
 import Data.Maybe

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -11,24 +11,20 @@ module Agda.TypeChecking.Reduce.Monad
 
 import Prelude hiding (null)
 
-import Control.Monad         ( liftM2 )
-
 import qualified Data.Map as Map
 import Data.Maybe
 
 import System.IO.Unsafe
 
+import Agda.Syntax.Common.Pretty () --instance only
 import Agda.Syntax.Internal
+
 import Agda.TypeChecking.Monad hiding (enterClosure, constructorForm)
 import Agda.TypeChecking.Substitute
 
 import Agda.Utils.Lens
 import Agda.Utils.Maybe
-#ifdef DEBUG
 import Agda.Utils.Monad
-#endif
-import Agda.Syntax.Common.Pretty () --instance only
-
 
 instance HasBuiltins ReduceM where
   getBuiltinThing b =

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -45,9 +45,7 @@ module Agda.TypeChecking.Rewriting where
 
 import Prelude hiding (null)
 
-import Control.Monad
 import Control.Monad.Trans.Maybe ( MaybeT(..), runMaybeT )
-import Control.Monad.Trans ( lift )
 
 import Data.Either (partitionEithers)
 import Data.Foldable (toList)

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -39,9 +39,8 @@ module Agda.TypeChecking.Rewriting.Confluence
 
 import Control.Applicative
 import Control.Arrow ((***))
-import Control.Monad
-import Control.Monad.Except
-import Control.Monad.Reader
+import Control.Monad.Except ( MonadError(..) )
+import Control.Monad.Reader ( MonadReader(..), asks, runReaderT )
 
 import Data.Either
 import Data.Function ( on )

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -25,7 +25,6 @@ module Agda.TypeChecking.Rewriting.NonLinMatch where
 import Prelude hiding (null, sequence)
 
 import Control.Applicative  ( Alternative )
-import Control.Monad        ( void )
 import Control.Monad.Except ( MonadError(..), ExceptT, runExceptT )
 import Control.Monad.State  ( MonadState, StateT, runStateT )
 

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -10,7 +10,6 @@ module Agda.TypeChecking.Rewriting.NonLinPattern where
 
 import Prelude hiding ( null )
 
-import Control.Monad        ( (>=>), forM )
 import Control.Monad.Reader ( asks )
 
 import Data.IntSet (IntSet)

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -13,9 +13,7 @@ module Agda.TypeChecking.Rules.Application
 import Prelude hiding ( null )
 
 import Control.Applicative        ( (<|>) )
-import Control.Monad              ( filterM, forM, forM_, guard, liftM2 )
 import Control.Monad.Except       ( ExceptT, runExceptT, MonadError, catchError, throwError )
-import Control.Monad.Trans
 import Control.Monad.Trans.Maybe
 
 import Data.Bifunctor

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -13,8 +13,7 @@ module Agda.TypeChecking.Rules.Builtin
 
 import Prelude hiding (null)
 
-import Control.Monad
-import Control.Monad.Except
+import Control.Monad.Except      ( catchError )
 import Control.Monad.Trans.Maybe
 
 import Data.List (find, sortBy)

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -4,9 +4,7 @@ module Agda.TypeChecking.Rules.Data where
 
 import Prelude hiding (null, not, (&&), (||) )
 
-import Control.Monad
-import Control.Monad.Except
-import Control.Monad.Trans
+import Control.Monad.Except ( MonadError(..), ExceptT(..), runExceptT )
 import Control.Monad.Trans.Maybe
 import Control.Exception as E
 

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -6,7 +6,6 @@ module Agda.TypeChecking.Rules.Decl where
 
 import Prelude hiding ( null )
 
-import Control.Monad
 import Control.Monad.Writer (tell)
 
 import Data.Either (partitionEithers)

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -15,9 +15,8 @@ import Data.Function (on)
 import Data.Maybe
 
 import Control.Arrow (left)
-import Control.Monad
-import Control.Monad.Except
-import Control.Monad.Reader
+import Control.Monad.Except       ( MonadError(..), ExceptT(..), runExceptT )
+import Control.Monad.Reader       ( MonadReader(..), asks, runReaderT )
 import Control.Monad.Writer       ( MonadWriter(..), runWriterT )
 import Control.Monad.Trans.Maybe
 

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -126,10 +126,9 @@ module Agda.TypeChecking.Rules.LHS.Unify
 
 import Prelude hiding (null)
 
-import Control.Monad
-import Control.Monad.State
-import Control.Monad.Writer (WriterT(..), MonadWriter(..))
-import Control.Monad.Except
+import Control.Monad.State  ( gets, modify, evalStateT )
+import Control.Monad.Writer ( WriterT(..), MonadWriter(..) )
+import Control.Monad.Except ( runExceptT, MonadError )
 
 import Data.Semigroup hiding (Arg)
 import qualified Data.List as List

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -6,7 +6,6 @@ module Agda.TypeChecking.Rules.Record where
 
 import Prelude hiding (null, not, (&&), (||))
 
-import Control.Monad
 import Data.Maybe
 import qualified Data.Set as Set
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -4,8 +4,7 @@ module Agda.TypeChecking.Rules.Term where
 
 import Prelude hiding ( null )
 
-import Control.Monad         ( (<=<), forM )
-import Control.Monad.Except
+import Control.Monad.Except ( MonadError(..) )
 
 import Data.Maybe
 import Data.Either (partitionEithers, lefts)

--- a/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
@@ -50,8 +50,7 @@ module Agda.TypeChecking.SizedTypes.Solve where
 
 import Prelude hiding (null)
 
-import Control.Monad hiding (forM, forM_)
-import Control.Monad.Except
+import Control.Monad.Except ( catchError )
 import Control.Monad.Trans.Maybe
 
 import Data.Either

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -20,7 +20,6 @@ module Agda.TypeChecking.Substitute
   ) where
 
 import Control.Arrow (first, second)
-import Control.Monad (guard)
 
 import Data.Coerce
 import Data.Function (on)

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -6,7 +6,6 @@ module Agda.TypeChecking.With where
 
 import Prelude hiding ((!!))
 
-import Control.Monad
 import Control.Monad.Writer (WriterT, runWriterT, tell)
 
 import qualified Data.List as List

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -2,17 +2,12 @@
 
 module Agda.Utils.Monad
     ( module Agda.Utils.Monad
-#if MIN_VERSION_mtl(2,3,1)
     , module X
-#endif
-    , when, unless, MonadPlus(..)
-    , (<$>), (<*>), (<$!>)
-    , (<$)
+    , (<$>), (<*>) , (<$)
     )
     where
 
 import Control.Applicative    ( liftA2 )
-import Control.Monad          ( MonadPlus(..), guard, unless, when, (<$!>) )
 import Control.Monad.Except   ( MonadError(catchError, throwError) )
 import Control.Monad.Identity ( runIdentity )
 import Control.Monad.State    ( MonadState(get, put) )
@@ -26,11 +21,27 @@ import Data.Maybe
 import Data.Monoid
 
 import Agda.Utils.Applicative
+import Agda.Utils.Boolean
 import Agda.Utils.Either
 import Agda.Utils.Null (empty, ifNotNullM)
 import Agda.Utils.Singleton
 
 import Agda.Utils.Impossible
+
+-- Reexport Control.Monad
+import Control.Monad as X
+  ( MonadPlus(..), (<$!>), (>=>), (<=<)
+  , filterM, foldM, forM, forM_
+  , join
+  , liftM2, liftM3, liftM4
+  , msum
+  , void
+  , zipWithM, zipWithM_
+  )
+import Control.Monad.Trans as X
+  ( MonadTrans, lift
+  )
+
 
 ---------------------------------------------------------------------------
 -- Vendor some new functions from mtl-2.3.1
@@ -68,6 +79,18 @@ k ==<< (ma, mb) = ma >>= \ a -> k a =<< mb
 infixl 4 <*!>
 
 -- Conditionals and monads ------------------------------------------------
+
+{-# SPECIALIZE when :: Monad m => Bool -> m () -> m () #-}
+when :: (IsBool b, Monad m) => b -> m () -> m ()
+when b m = ifThenElse b m $ pure ()
+
+{-# SPECIALIZE unless :: Monad m => Bool -> m () -> m () #-}
+unless :: (IsBool b, Monad m) => b -> m () -> m()
+unless b m = ifThenElse b (pure ()) m
+
+{-# SPECIALIZE guard :: MonadPlus m => Bool -> m () #-}
+guard :: (IsBool b, MonadPlus m) => b -> m ()
+guard b = ifThenElse b (pure ()) mzero
 
 whenM :: Monad m => m Bool -> m () -> m ()
 whenM c m = c >>= (`when` m)

--- a/test/Fail/Issue2004Comp.agda
+++ b/test/Fail/Issue2004Comp.agda
@@ -1,0 +1,18 @@
+-- Andreas, 2024-10-08, issue #2004 (and #7533)
+-- Allow function symbols in DISPLAY pragma.
+
+postulate
+  A : Set
+  f : A → A
+  g : A → A
+  P : A → Set
+
+{-# DISPLAY f (g x) = x #-}
+
+_ : (x : A) → P (f (g x))
+_ = Set
+
+-- Expected error:
+
+-- Set₁ !=< (x : A) → P x
+-- when checking that the expression Set has type (x : A) → P x

--- a/test/Fail/Issue2004Comp.err
+++ b/test/Fail/Issue2004Comp.err
@@ -1,0 +1,3 @@
+Issue2004Comp.agda:13.5-8: error: [UnequalTerms]
+Set₁ !=< (x : A) → P x
+when checking that the expression Set has type (x : A) → P x

--- a/test/Fail/Issue2004Op.agda
+++ b/test/Fail/Issue2004Op.agda
@@ -1,0 +1,22 @@
+-- Andreas, 2024-10-08, issue #2004 (and #7533)
+-- DISPLAY forms should be able to match on defined names.
+
+open import Agda.Builtin.Equality
+
+postulate
+  A : Set
+  P : A → Set
+  Any : (A → Set) → (A → Set) → Set
+
+_∈_ : A → (A → Set) → Set
+x ∈ Y = Any (x ≡_) Y
+
+{-# DISPLAY Any (_≡_ x) Y = x ∈ Y #-}
+
+test : ∀ x Y → x ∈ Y → Any (x ≡_) Y
+test x Y = Set
+
+-- Expected error:
+
+-- Set₁ !=< x ∈ Y → x ∈ Y
+-- when checking that the expression Set has type x ∈ Y → x ∈ Y

--- a/test/Fail/Issue2004Op.err
+++ b/test/Fail/Issue2004Op.err
@@ -1,0 +1,3 @@
+Issue2004Op.agda:17.12-15: error: [UnequalTerms]
+Set₁ !=< x ∈ Y → x ∈ Y
+when checking that the expression Set has type x ∈ Y → x ∈ Y

--- a/test/Fail/Issue7533.agda
+++ b/test/Fail/Issue7533.agda
@@ -1,0 +1,26 @@
+-- Andreas, 2024-10-06, issue #7533 reported by James McKinna, test by Szumi Xie.
+-- DISPLAY pragmas should be like REWRITE rules, not like functions defined by pattern matching.
+-- In particular, all names (not just constructors) should be matchable.
+
+data Empty : Set where
+
+postulate
+  F : Set → Set
+  X : Set
+  A : Set
+
+-- The following display form used to rewrite F _ to X.
+-- Now it should only rewrite F Empty to X.
+
+{-# DISPLAY F Empty = X #-}
+
+_ : F Empty → F A
+_ = F Empty
+
+-- This is ill-typed, we are only interested in the printing
+-- of the involved terms in the error message.
+
+-- Error: Set !=< X → F A
+-- when checking that the expression F Empty has type X → F A
+
+-- Agda-2.7 prints X instead of F A.

--- a/test/Fail/Issue7533.err
+++ b/test/Fail/Issue7533.err
@@ -1,0 +1,3 @@
+Issue7533.agda:18.5-12: error: [UnequalTerms]
+Set !=< X → F A
+when checking that the expression F Empty has type X → F A

--- a/test/Succeed/succeed.agda-lib
+++ b/test/Succeed/succeed.agda-lib
@@ -1,5 +1,7 @@
 -- Andreas, 2017-08-23, issue #2708, name is optional
--- name: test-succeed
+-- Andreas, 2024-09-27: still include it, so we can run with old Agda
+
+name: test-succeed
 
 include:
   .


### PR DESCRIPTION
Re #2004: DISPLAY pragmas can now match on defined names.
This PR modifies the scope checker so as to accept defined names (functions, postulate, data & record types, primitives) as matchable (`DefP`).
Technically, we pass around a flag `displayLhs : Bool` that allows us to know whether we are scope checking the lhs of a DISPLAY pragma.
Rather than putting this into the environment (`TCEnv`), I am defining specific wrappers `CPattern` and `CLHSCore` that carry that flag.  (This seems more structured than just a global environment hosting a myriad of parameters of which always only a few apply to the current situation.)

Closes #7533 (and parts of #2004).

TODO (later):
- figure out whether we can also match on projections
- more tests