### PR TITLE
Refactor: use Set1 in A.Generalized

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -808,6 +808,7 @@ library
       Agda.Utils.List2
       Agda.Utils.ListT
       Agda.Utils.Map
+      Agda.Utils.Map1
       Agda.Utils.Maybe
       Agda.Utils.Maybe.Strict
       Agda.Utils.Memo

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -29,6 +29,7 @@ import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Abstract.Name
 import qualified Agda.Syntax.Internal as I
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty
 import Agda.Syntax.Info
 import Agda.Syntax.Literal
 import Agda.Syntax.Position
@@ -39,7 +40,8 @@ import Agda.TypeChecking.Positivity.Occurrence
 import Agda.Utils.List1 (List1, pattern (:|))
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Null
-import Agda.Syntax.Common.Pretty
+import Agda.Utils.Set1 (Set1)
+import qualified Agda.Utils.Set1 as Set1
 
 import Agda.Utils.Impossible
 
@@ -99,7 +101,7 @@ data Expr
   | AbsurdLam ExprInfo Hiding          -- ^ @λ()@ or @λ{}@.
   | ExtendedLam ExprInfo DefInfo Erased QName (List1 Clause)
   | Pi   ExprInfo Telescope1 Type      -- ^ Dependent function space @Γ → A@.
-  | Generalized (Set QName) Type       -- ^ Like a Pi, but the ordering is not known
+  | Generalized (Set1 QName) Type      -- ^ Like a Pi, but the ordering is not known
   | Fun  ExprInfo (Arg Type) Type      -- ^ Non-dependent function space.
   | Let  ExprInfo (List1 LetBinding) Expr
                                        -- ^ @let bs in e@.
@@ -118,9 +120,7 @@ pattern Def x = Def' x NoSuffix
 
 -- | Smart constructor for 'Generalized'.
 generalized :: Set QName -> Type -> Type
-generalized s e
-    | null s    = e
-    | otherwise = Generalized s e
+generalized s e = Set1.ifNull s e \ s -> Generalized s e
 
 -- | Record field assignment @f = e@.
 type Assign  = FieldAssignment' Expr
@@ -169,7 +169,7 @@ data Declaration
     -- The fourth argument contains an optional assignment of
     -- polarities to arguments.
   | Generalize (Set QName) DefInfo ArgInfo QName Type
-    -- ^ First argument is set of generalizable variables used in the type.
+    -- ^ The first argument is the (possibly empty) set of generalizable variables used in the type.
   | Field      DefInfo QName (Arg Type)              -- ^ record field
   | Primitive  DefInfo QName (Arg Type)              -- ^ primitive function
   | Mutual     MutualInfo [Declaration]              -- ^ a bunch of mutually recursive definitions

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2255,15 +2255,15 @@ notAffectedByOpaque k = do
 -- * Helper functions for @variable@ generalization
 ------------------------------------------------------------------------
 
-unGeneralized :: A.Expr -> (Set.Set I.QName, A.Expr)
-unGeneralized (A.Generalized s t) = (s, t)
+unGeneralized :: A.Expr -> (Set A.QName, A.Expr)
+unGeneralized (A.Generalized s t) = (Set1.toSet s, t)
 unGeneralized (A.ScopedExpr si e) = A.ScopedExpr si <$> unGeneralized e
 unGeneralized t = (mempty, t)
 
 alreadyGeneralizing :: ScopeM Bool
 alreadyGeneralizing = isJust <$> useTC stGeneralizedVars
 
-collectGeneralizables :: ScopeM a -> ScopeM (Set I.QName, a)
+collectGeneralizables :: ScopeM a -> ScopeM (Set A.QName, a)
 collectGeneralizables m =
   -- #5683: No nested generalization
   ifM alreadyGeneralizing ((Set.empty,) <$> m) $
@@ -2280,14 +2280,14 @@ collectGeneralizables m =
         pure gvs
     close = (stGeneralizedVars `setTCLens`)
 
-createBoundNamesForGeneralizables :: Set I.QName -> ScopeM (Map I.QName I.Name)
+createBoundNamesForGeneralizables :: Set A.QName -> ScopeM (Map A.QName A.Name)
 createBoundNamesForGeneralizables vs =
   flip Map.traverseWithKey (Map.fromSet (const ()) vs) $ \ q _ -> do
     let x  = nameConcrete $ qnameName q
         fx = nameFixity   $ qnameName q
     freshAbstractName fx x
 
-collectAndBindGeneralizables :: ScopeM a -> ScopeM (Map I.QName I.Name, a)
+collectAndBindGeneralizables :: ScopeM a -> ScopeM (Map A.QName A.Name, a)
 collectAndBindGeneralizables m = do
   fvBefore <- length <$> getLocalVars
   (s, res) <- collectGeneralizables m

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -19,6 +19,7 @@ import Agda.Syntax.Abstract.Views (deepUnscope)
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
 import Agda.Syntax.Common
+import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Syntax.Position
 import qualified Agda.Syntax.Info as Info
 import Agda.Syntax.Scope.Monad
@@ -52,7 +53,7 @@ import Agda.Utils.List
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import qualified Agda.Syntax.Common.Pretty as P
+import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Size
 
 import Agda.Utils.Impossible
@@ -373,7 +374,7 @@ checkConstructor d uc tel nofIxs s con@(A.Axiom _ i ai Nothing c e) =
 
       case e of
         A.Generalized s e -> do
-          (_, t, isPathCons) <- generalizeType' s (check 1 e)
+          (_, t, isPathCons) <- generalizeType' (Set1.toSet s) (check 1 e)
           return (t, isPathCons)
         _ -> check 0 e
 

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -24,6 +24,7 @@ import Agda.Syntax.Internal
 import qualified Agda.Syntax.Info as Info
 import Agda.Syntax.Position
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Literal
 import Agda.Syntax.Scope.Base ( KindOfName(..) )
 
@@ -72,7 +73,6 @@ import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Utils.Size
 import Agda.Utils.Update
 import qualified Agda.Syntax.Common.Pretty as P

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -23,6 +23,8 @@ import Agda.Syntax.Concrete.Pretty () -- only Pretty instances
 import Agda.Syntax.Concrete (FieldAssignment'(..), nameFieldA, TacticAttribute'(..))
 import qualified Agda.Syntax.Concrete.Name as C
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty ( prettyShow )
+import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Syntax.Internal as I
 import Agda.Syntax.Internal.MetaVars
 import Agda.Syntax.Position
@@ -77,8 +79,7 @@ import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import Agda.Syntax.Common.Pretty ( prettyShow )
-import qualified Agda.Syntax.Common.Pretty as P
+import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Singleton
 import Agda.Utils.Size
 import Agda.Utils.Tuple
@@ -130,7 +131,7 @@ isType_ e = traceCall (IsType_ e) $ do
       return t'
 
     A.Generalized s e -> do
-      (_, t') <- generalizeType s $ isType_ e
+      (_, t') <- generalizeType (Set1.toSet s) $ isType_ e
       --noFunctionsIntoSize t'
       return t'
 
@@ -1207,7 +1208,7 @@ checkExpr' cmp e t =
             coerce cmp v (sort s) t
 
         A.Generalized s e -> do
-            (_, t') <- generalizeType s $ isType_ e
+            (_, t') <- generalizeType (Set1.toSet s) $ isType_ e
             --noFunctionsIntoSize t' t'
             let s = getSort t'
                 v = unEl t'

--- a/src/full/Agda/Utils/Map1.hs
+++ b/src/full/Agda/Utils/Map1.hs
@@ -1,0 +1,36 @@
+-- | Non-empty maps.
+--
+--   Provides type @Map1@ of non-empty maps.
+--
+--   Import:
+--   @
+--
+--     import           Agda.Utils.Map1 (Map1)
+--     import qualified Agda.Utils.Map1 as Map1
+--
+--   @
+
+module Agda.Utils.Map1
+  ( module Agda.Utils.Map1
+  , module Map1
+  ) where
+
+import Data.Map (Map)
+import Data.Map.NonEmpty as Map1
+
+type Map1 = Map1.NEMap
+
+ifNull :: Map k a -> b -> (Map1 k a -> b) -> b
+ifNull s b f = Map1.withNonEmpty b f s
+
+-- | A more general type would be @Null m => Map k a -> (Map1 k a -> m) -> m@
+--   but this type is problematic as we do not have a general
+--   @instance Applicative m => Null (m ())@.
+--
+unlessNull :: Applicative m => Map k a -> (Map1 k a -> m ()) -> m ()
+unlessNull = flip $ Map1.withNonEmpty $ pure ()
+{-# INLINE unlessNull #-}
+
+unlessNullM :: Monad m => m (Map k a) -> (Map1 k a -> m ()) -> m ()
+unlessNullM m k = m >>= (`unlessNull` k)
+{-# INLINE unlessNullM #-}


### PR DESCRIPTION
`A.Generalized` is only used with non-empty sets.  This information is gained by the smart constructor `A.generalized`, but we throw it away when calling `generalizeType` because generalization can also run with an empty such set.