### PR TITLE
Fix #7531: Preserve let bindings in the JS backend

### DIFF
--- a/src/full/Agda/Compiler/JS/Substitution.hs
+++ b/src/full/Agda/Compiler/JS/Substitution.hs
@@ -50,6 +50,9 @@ substituter n es m (LocalId i) | i < m       = Local (LocalId i)
 substituter n es m (LocalId i) | (i - m) < n = shift m (genericIndex (es ++ repeat Undefined) (n - (i + 1 - m)))
 substituter n es m (LocalId i) | otherwise   = Local (LocalId (i - n))
 
+substShift :: Nat -> Nat -> [Exp] -> Exp -> Exp
+substShift m n es = subst m es . shiftFrom m n
+
 -- A variant on substitution which performs beta-reduction
 
 map' :: Nat -> (Nat -> LocalId -> Exp) -> Exp -> Exp

--- a/test/Compiler/simple/Issue7531.agda
+++ b/test/Compiler/simple/Issue7531.agda
@@ -1,0 +1,55 @@
+-- Test case by Lawrence Chonavel
+
+open import Agda.Builtin.Bool
+open import Common.IO
+open import Common.Unit
+
+data Cell : Set where
+  [-] [o] [x] : Cell
+
+data Board : Set where
+  mk-Board : (
+    _ _ _
+    _ _ _
+    _ _ _ : Cell)
+    → Board
+
+game-over : Board → Bool
+game-over = λ where
+  (mk-Board [x]  _   _
+            [x]  _   _
+            [x]  _   _  ) → true
+
+  (mk-Board  _  [x]  _
+             _  [x]  _
+             _  [x]  _  ) → true
+
+  (mk-Board  _   _  [x]
+             _   _  [x]
+             _   _  [x] ) → true
+
+  (mk-Board [x] [x] [x]
+             _   _   _
+             _   _   _  ) → true
+
+  (mk-Board  _   _   _
+            [x] [x] [x]
+             _   _   _  ) → true
+
+  (mk-Board  _   _   _
+             _   _   _
+            [x] [x] [x] ) → true
+
+  (mk-Board [x]  _   _
+             _  [x]  _
+             _   _  [x] ) → true
+
+  (mk-Board  _   _   _
+             _   _   _
+             _   _   _  ) → false
+
+main : IO Unit
+main = printBool (game-over
+  (mk-Board [x] [-] [-]
+            [-] [x] [-]
+            [-] [-] [x] ))

--- a/test/Compiler/simple/Issue7531.out
+++ b/test/Compiler/simple/Issue7531.out
@@ -1,0 +1,4 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > true


### PR DESCRIPTION
Fixes #7531 by preserving the let bindings generated by `eliminateCaseDefaults` in the JS backend. `let x = u in t` is now compiled to `(x => t[x()/x])(() => u)`, the nullary function is for keeping the call-by-name behavior.

The JS pretty-printer is also modified, previously `Apply (Lambda 1 t) [u]` was printed incorrectly.

In the future, data types could be implemented using tagged arrays instead of Scott encoding, then case matching could be compiled to switch statements and there'd be no need to use `eliminateCaseDefaults`.
