### PR TITLE
Fix #7546: warn about empty POLARITY pragmas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Pragmas and options
 
 * New error warning `TooManyArgumentsToSort` instead of hard error.
 
+* New warning `EmptyPolarityPragma` for POLARITY pragma without polarities.
+  E.g. triggered by `{-# POLARITY F #-}`.
+
 * Warning `AbsurdPatternRequiresNoRHS` has been renamed to
   `AbsurdPatternRequiresAbsentRHS`.
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1325,6 +1325,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Empty ``mutual`` blocks.
 
+.. option:: EmptyPolarityPragma
+
+     :ref:`POLARITY pragmas <polarity-pragma>` not giving any polarities.
+
 .. option:: EmptyPostulate
 
      Empty ``postulate`` blocks.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -531,6 +531,7 @@ warningHighlighting' b w = case tcWarning w of
     EmptyPrivate{}                   -> deadcodeHighlighting w
     EmptyGeneralize{}                -> deadcodeHighlighting w
     EmptyField{}                     -> deadcodeHighlighting w
+    EmptyPolarityPragma{}            -> deadcodeHighlighting w
     HiddenGeneralize{}               -> mempty
       -- Andreas, 2022-03-25, issue #5850
       -- We would like @deadcodeHighlighting w@ for the braces in

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -229,6 +229,7 @@ data WarningName
   | EmptyPrivate_
   | EmptyRewritePragma_
   | EmptyWhere_
+  | EmptyPolarityPragma_
   | HiddenGeneralize_
   | InvalidCatchallPragma_
   | InvalidConstructorBlock_
@@ -453,6 +454,7 @@ warningNameDescription = \case
   EmptyPrivate_                    -> "Empty `private' blocks."
   EmptyRewritePragma_              -> "Empty `REWRITE' pragmas."
   EmptyWhere_                      -> "Empty `where' blocks."
+  EmptyPolarityPragma_             -> "`POLARITY' pragmas giving no polarities."
   HiddenGeneralize_                -> "Hidden identifiers in variable blocks."
   InvalidCatchallPragma_           -> "`CATCHALL' pragmas before a non-function clause."
   InvalidConstructorBlock_         -> "`constructor' blocks outside of `interleaved mutual' blocks."

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -163,7 +163,7 @@ data RecordConName
 type RecordDirectives = RecordDirectives' RecordConName
 
 data Declaration
-  = Axiom      KindOfName DefInfo ArgInfo (Maybe [Occurrence]) QName Type
+  = Axiom      KindOfName DefInfo ArgInfo (Maybe (List1 Occurrence)) QName Type
     -- ^ Type signature (can be irrelevant, but not hidden).
     --
     -- The fourth argument contains an optional assignment of

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -92,17 +92,19 @@ data DeclarationWarning = DeclarationWarning
 
 -- | Non-fatal errors encountered in the Nicifier.
 data DeclarationWarning'
-  -- Please keep in alphabetical order.
-  = EmptyAbstract KwRange  -- ^ Empty @abstract@  block.
-  | EmptyConstructor KwRange -- ^ Empty @data _ where@ block.
-  | EmptyField KwRange       -- ^ Empty @field@     block.
-  | EmptyGeneralize KwRange  -- ^ Empty @variable@  block.
-  | EmptyInstance KwRange  -- ^ Empty @instance@  block
-  | EmptyMacro KwRange     -- ^ Empty @macro@     block.
-  | EmptyMutual KwRange    -- ^ Empty @mutual@    block.
-  | EmptyPostulate KwRange -- ^ Empty @postulate@ block.
-  | EmptyPrivate KwRange   -- ^ Empty @private@   block.
-  | EmptyPrimitive KwRange   -- ^ Empty @primitive@ block.
+  -- Please keep in (mostly) alphabetical order.
+  = EmptyAbstract    KwRange  -- ^ Empty @abstract@     block.
+  | EmptyConstructor KwRange  -- ^ Empty @data _ where@ block.
+  | EmptyField       KwRange  -- ^ Empty @field@        block.
+  | EmptyGeneralize  KwRange  -- ^ Empty @variable@     block.
+  | EmptyInstance    KwRange  -- ^ Empty @instance@     block
+  | EmptyMacro       KwRange  -- ^ Empty @macro@        block.
+  | EmptyMutual      KwRange  -- ^ Empty @mutual@       block.
+  | EmptyPostulate   KwRange  -- ^ Empty @postulate@    block.
+  | EmptyPrivate     KwRange  -- ^ Empty @private@      block.
+  | EmptyPrimitive   KwRange  -- ^ Empty @primitive@    block.
+  | EmptyPolarityPragma Range
+      -- ^ POLARITY pragma without any polarities.
   | HiddenGeneralize Range
       -- ^ A 'Hidden' identifier in a @variable@ declaration.
       --   Hiding has no effect there as generalized variables are always hidden
@@ -178,6 +180,7 @@ declarationWarningName' = \case
   EmptyPrivate{}                    -> EmptyPrivate_
   EmptyPostulate{}                  -> EmptyPostulate_
   EmptyPrimitive{}                  -> EmptyPrimitive_
+  EmptyPolarityPragma{}             -> EmptyPolarityPragma_
   HiddenGeneralize{}                -> HiddenGeneralize_
   InvalidCatchallPragma{}           -> InvalidCatchallPragma_
   InvalidConstructorBlock{}         -> InvalidConstructorBlock_
@@ -227,6 +230,7 @@ unsafeDeclarationWarning' = \case
   EmptyPrivate{}                    -> False
   EmptyPostulate{}                  -> False
   EmptyPrimitive{}                  -> False
+  EmptyPolarityPragma{}             -> False
   HiddenGeneralize{}                -> False
   InvalidCatchallPragma{}           -> False
   InvalidConstructorBlock{}         -> False
@@ -338,6 +342,7 @@ instance HasRange DeclarationWarning' where
     EmptyPostulate kwr                 -> getRange kwr
     EmptyPrimitive kwr                 -> getRange kwr
     EmptyPrivate kwr                   -> getRange kwr
+    EmptyPolarityPragma r              -> r
     HiddenGeneralize r                 -> r
     InvalidCatchallPragma r            -> r
     InvalidConstructorBlock r          -> r
@@ -490,6 +495,8 @@ instance Pretty DeclarationWarning' where
     EmptyPrimitive _ -> fsep $ pwords "Empty primitive block."
 
     EmptyField _ -> fsep $ pwords "Empty field block."
+
+    EmptyPolarityPragma _ -> fsep $ pwords "POLARITY pragma without polarities (ignored)."
 
     HiddenGeneralize _ -> fsep $ pwords "Declaring a variable as hidden has no effect in a variable block. Generalization never introduces visible arguments."
 

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -467,7 +467,7 @@ getConcreteFixity :: C.Name -> ScopeM Fixity'
 getConcreteFixity x = Map.findWithDefault noFixity' x <$> useScope scopeFixities
 
 -- | Get the polarities of a not yet bound name.
-getConcretePolarity :: C.Name -> ScopeM (Maybe [Occurrence])
+getConcretePolarity :: C.Name -> ScopeM (Maybe (List1 Occurrence))
 getConcretePolarity x = Map.lookup x <$> useScope scopePolarities
 
 instance MonadFixityError ScopeM where
@@ -479,6 +479,7 @@ instance MonadFixityError ScopeM where
   warnUnknownNamesInPolarityPragmas   = scopeWarning . UnknownNamesInPolarityPragmas
   warnUnknownFixityInMixfixDecl       = scopeWarning . UnknownFixityInMixfixDecl
   warnPolarityPragmasButNotPostulates = scopeWarning . PolarityPragmasButNotPostulates
+  warnEmptyPolarityPragma             = scopeWarning . EmptyPolarityPragma
 
 -- | Collect the fixity/syntax declarations and polarity pragmas from the list
 --   of declarations and store them in the scope.

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1200,7 +1200,7 @@ instance ToConcrete A.Declaration where
       return $
         (case mp of
            Nothing   -> []
-           Just occs -> [C.Pragma (PolarityPragma noRange x' occs)]) ++
+           Just occs -> [C.Pragma (PolarityPragma noRange x' $ List1.toList occs)]) ++
         [C.Postulate empty [C.TypeSig info empty x' t']]
 
   toConcrete (A.Generalize s i j x t) = do

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -143,7 +143,7 @@ abstractTerm a u@Con{} b v = do
         , nest 2 $ sep [ (text . show) v <+> ":", nest 2 $ (text . show) b ] ]
 
   hole <- qualify <$> currentModule <*> freshName_ ("hole" :: String)
-  noMutualBlock $ addConstant' hole defaultArgInfo hole a defaultAxiom
+  noMutualBlock $ addConstant' hole defaultArgInfo a defaultAxiom
 
   args <- map Apply <$> getContextArgs
   let n = length args

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -935,7 +935,7 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
   inTopContext $ forM_ (zip sortedMetas genRecFields) $ \ (meta, fld) -> do
     fieldTy <- getMetaType meta
     let field = unDom fld
-    addConstant' field (getArgInfo fld) field fieldTy $ FunctionDefn $
+    addConstant' field (getArgInfo fld) fieldTy $ FunctionDefn $
       (emptyFunctionData_ erasure)
         { _funMutual     = Just []
         , _funTerminates = Just True
@@ -947,7 +947,7 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
           , projLams     = ProjLams [defaultArg "gtel"]
           }
         }
-  addConstant' (conName genRecCon) defaultArgInfo (conName genRecCon) __DUMMY_TYPE__ $ -- Filled in later
+  addConstant' (conName genRecCon) defaultArgInfo __DUMMY_TYPE__ $ -- Filled in later
     Constructor { conPars   = 0
                 , conArity  = length genRecFields
                 , conSrcCon = genRecCon
@@ -962,7 +962,7 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = do
                 }
   let dummyTel 0 = EmptyTel
       dummyTel n = ExtendTel (defaultDom __DUMMY_TYPE__) $ Abs "_" $ dummyTel (n - 1)
-  addConstant' genRecName defaultArgInfo genRecName (sort genRecSort) $
+  addConstant' genRecName defaultArgInfo (sort genRecSort) $
     Record { recPars         = 0
            , recClause       = Nothing
            , recConHead      = genRecCon

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1908,7 +1908,7 @@ openMetasToPostulates = do
       ]
 
     -- Add the new postulate to the signature.
-    addConstant' q defaultArgInfo q t defaultAxiom
+    addConstant' q defaultArgInfo t defaultAxiom
 
     -- Solve the meta.
     let inst = InstV $ Instantiation

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -187,10 +187,10 @@ addConstant q d = do
 -- does not need to be supplied.
 
 addConstant' ::
-  QName -> ArgInfo -> QName -> Type -> Defn -> TCM ()
-addConstant' q info x t def = do
+  QName -> ArgInfo -> Type -> Defn -> TCM ()
+addConstant' q info t def = do
   lang <- getLanguage
-  addConstant q $ defaultDefn info x t lang def
+  addConstant q $ defaultDefn info q t lang def
 
 -- | Set termination info of a defined function symbol.
 setTerminates :: MonadTCState m => QName -> Bool -> m ()

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -975,7 +975,7 @@ bindBuiltinNoDef b q = inTopContext $ do
       -- We start by adding the corresponding postulate
       t   <- mt
       fun <- emptyFunctionData
-      addConstant' q (setRelevance rel defaultArgInfo) q t (def fun)
+      addConstant' q (setRelevance rel defaultArgInfo) t (def fun)
       -- And we then *modify* the definition based on our needs:
       -- We add polarity information for SIZE-related definitions
       builtinSizeHook b q t
@@ -1030,7 +1030,7 @@ bindBuiltinNoDef b q = inTopContext $ do
               , conErasure = erasure
               , conInline  = False
               }
-      addConstant' q defaultArgInfo q t def
+      addConstant' q defaultArgInfo t def
       addDataCons d [q]
 
       when (b == builtinReflId)     $ builtinReflIdHook q
@@ -1039,7 +1039,7 @@ bindBuiltinNoDef b q = inTopContext $ do
 
     Just (BuiltinData mt cs) -> do
       t <- mt
-      addConstant' q defaultArgInfo q t (def t)
+      addConstant' q defaultArgInfo t (def t)
       when (b == builtinId)     $ builtinIdHook q
       bindBuiltinName b $ Def q []
       where
@@ -1067,7 +1067,7 @@ bindBuiltinNoDef b q = inTopContext $ do
       case builtinSort of
         SortIntervalUniv -> requireCubical CErased
         _ -> return ()
-      addConstant' q defaultArgInfo q (sort $ univSort s) def
+      addConstant' q defaultArgInfo (sort $ univSort s) def
       bindBuiltinName b $ Def q []
 
     Just{}  -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -155,7 +155,7 @@ checkDataDef i name uc (A.DataDefParams gpars ps) cs =
                   }
 
             escapeContext impossible npars $ do
-              addConstant' name defaultArgInfo name t $ DatatypeDefn dataDef
+              addConstant' name defaultArgInfo t $ DatatypeDefn dataDef
                 -- polarity and argOcc.s determined by the positivity checker
 
             -- Check the types of the constructors
@@ -196,7 +196,7 @@ checkDataDef i name uc (A.DataDefParams gpars ps) cs =
 
         -- Add the datatype to the signature with its constructors.
         -- It was previously added without them.
-        addConstant' name defaultArgInfo name t $ DatatypeDefn
+        addConstant' name defaultArgInfo t $ DatatypeDefn
             dataDef{ _dataCons = cons
                    , _dataTranspIx = mtranspix
                    , _dataTransp   = transpFun
@@ -331,7 +331,7 @@ checkConstructor d uc tel nofIxs s con@(A.Axiom _ i ai Nothing c e) =
         -- add parameters to constructor type and put into signature
         escapeContext impossible (size tel) $ do
           erasure <- optErasure <$> pragmaOptions
-          addConstant' c ai c (telePi tel t) $ Constructor
+          addConstant' c ai (telePi tel t) $ Constructor
               { conPars   = size tel
               , conArity  = arity
               , conSrcCon = con

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -191,7 +191,7 @@ checkAlias t ai i name e mc =
 
   -- Add the definition
   fun <- emptyFunctionData
-  addConstant' name ai name t $ FunctionDefn $
+  addConstant' name ai t $ FunctionDefn $
     set funMacro_ (Info.defMacro i == MacroDef) $
     set funAbstr_ (Info.defAbstract i) $
       fun { _funClauses   = [ Clause  -- trivial clause @name = v@

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -220,7 +220,7 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
       let npars = size tel
           telh  = fmap hideAndRelParams tel
       escapeContext impossible npars $ do
-        addConstant' name defaultArgInfo name t $
+        addConstant' name defaultArgInfo t $
             Record
               { recPars           = npars
               , recClause         = Nothing
@@ -243,7 +243,7 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
 
         erasure <- optErasure <$> pragmaOptions
         -- Add record constructor to signature
-        addConstant' conName defaultArgInfo conName
+        addConstant' conName defaultArgInfo
              -- If --erasure is used, then the parameters are erased
              -- in the constructor's type.
             (applyWhen erasure (fmap $ applyQuantity zeroQuantity) telh

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20240925 * 10 + 1
+currentInterfaceVersion = 20241010 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -337,6 +337,7 @@ instance EmbPrj DeclarationWarning' where
     SafeFlagNonTerminating         {} -> __IMPOSSIBLE__
     SafeFlagPolarity               {} -> __IMPOSSIBLE__
     SafeFlagTerminating            {} -> __IMPOSSIBLE__
+    EmptyPolarityPragma r             -> icodeN 35 EmptyPolarityPragma r
 
   value = vcase $ \case
     [0, a]   -> valuN UnknownNamesInFixityDecl a
@@ -374,6 +375,7 @@ instance EmbPrj DeclarationWarning' where
     [32,r]   -> valuN MissingDataDeclaration r
     [33,r]   -> valuN HiddenGeneralize r
     [34,r]   -> valuN UselessMacro r
+    [35,r]   -> valuN EmptyPolarityPragma r
     _ -> malformed
 
 instance EmbPrj LibWarning where

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -987,7 +987,7 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
         a <- locallyReduceAllDefs $ isType_ =<< toAbstract_ a
         alreadyDefined <- isRight <$> getConstInfo' x
         when alreadyDefined $ genericError $ "Multiple declarations of " ++ prettyShow x
-        addConstant' x i x a defn
+        addConstant' x i a defn
         when (isInstance i) $ addTypedInstance x a
         primUnitUnit
 

--- a/test/Fail/Multiple-polarity-pragmas-for-a-single-name.agda
+++ b/test/Fail/Multiple-polarity-pragmas-for-a-single-name.agda
@@ -1,4 +1,4 @@
-postulate A : Set
+postulate F : Set → Set
 
-{-# POLARITY A #-}
-{-# POLARITY A #-}
+{-# POLARITY F + #-}
+{-# POLARITY F - #-}

--- a/test/Fail/Multiple-polarity-pragmas-for-a-single-name.err
+++ b/test/Fail/Multiple-polarity-pragmas-for-a-single-name.err
@@ -1,2 +1,2 @@
 Multiple-polarity-pragmas-for-a-single-name.agda:3.14-15: error: [MultiplePolarityPragmas]
-Multiple polarity pragmas for A
+Multiple polarity pragmas for F

--- a/test/Fail/Polarity-pragma-for-defined-name.agda
+++ b/test/Fail/Polarity-pragma-for-defined-name.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --warning=error #-}
 
-A : Set₁
-A = Set
+A : Set → Set₁
+A _ = Set
 
-{-# POLARITY A #-}
+{-# POLARITY A ++ #-}

--- a/test/Fail/Polarity-pragma-for-module-parameter.agda
+++ b/test/Fail/Polarity-pragma-for-module-parameter.agda
@@ -1,5 +1,5 @@
 {-# OPTIONS --warning=error #-}
 
-module _ (A : Set) where
+module _ (F : Set → Set) where
 
-{-# POLARITY A #-}
+{-# POLARITY F + #-}

--- a/test/Fail/Polarity-pragma-for-module-parameter.err
+++ b/test/Fail/Polarity-pragma-for-module-parameter.err
@@ -1,4 +1,4 @@
 Polarity-pragma-for-module-parameter.agda:5.14-15: warning: -W[no]UnknownNamesInPolarityPragmas
 The following names are not declared in the same scope as their
 polarity pragmas (they could for instance be out of scope, imported
-from another module, or declared in a super module): A
+from another module, or declared in a super module): F

--- a/test/Fail/Polarity-pragma-out-of-scope.agda
+++ b/test/Fail/Polarity-pragma-out-of-scope.agda
@@ -1,8 +1,8 @@
 {-# OPTIONS --warning=error #-}
 
 postulate
-  A : Set
+  F : Set → Set
 
 module _ where
 
-  {-# POLARITY A #-}
+  {-# POLARITY F + #-}

--- a/test/Fail/Polarity-pragma-out-of-scope.err
+++ b/test/Fail/Polarity-pragma-out-of-scope.err
@@ -1,6 +1,6 @@
 Polarity-pragma-out-of-scope.agda:8.16-17: warning: -W[no]UnknownNamesInPolarityPragmas
 The following names are not declared in the same scope as their
 polarity pragmas (they could for instance be out of scope, imported
-from another module, or declared in a super module): A
+from another module, or declared in a super module): F
 when scope checking the declaration
   module _ where

--- a/test/Fail/Unknown-name-in-polarity-pragma.agda
+++ b/test/Fail/Unknown-name-in-polarity-pragma.agda
@@ -1,3 +1,3 @@
 {-# OPTIONS --warning=error #-}
 
-{-# POLARITY F #-}
+{-# POLARITY F + #-}

--- a/test/Fail/Unknown-names-in-polarity-pragmas.agda
+++ b/test/Fail/Unknown-names-in-polarity-pragmas.agda
@@ -1,4 +1,4 @@
 {-# OPTIONS --warning=error #-}
 
-{-# POLARITY F #-}
-{-# POLARITY G #-}
+{-# POLARITY F + #-}
+{-# POLARITY G - #-}

--- a/test/Succeed/Issue6945.agda
+++ b/test/Succeed/Issue6945.agda
@@ -27,7 +27,8 @@ private
 -- Expected: Warning about useless private.
 
 private
-  {-# POLARITY _#_ #-}
+  {-# POLARITY _#_ + - #-}
+  {-# POLARITY Nat     #-}  -- Andreas, 2024-10-10 this useless pragma should be ignored (#7546).
 
 -- Expected: Warning about useless private.
 

--- a/test/Succeed/Issue6945.warn
+++ b/test/Succeed/Issue6945.warn
@@ -15,21 +15,24 @@ Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and data, record, and module declarations.
 
-Issue6945.agda:38.1-9: warning: -W[no]UselessAbstract
+Issue6945.agda:31.3-27: warning: -W[no]EmptyPolarityPragma
+POLARITY pragma without polarities (ignored).
+
+Issue6945.agda:39.1-9: warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and
 function clauses.
 
-Issue6945.agda:42.1-9: warning: -W[no]UselessInstance
+Issue6945.agda:43.1-9: warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and axioms.
 
-Issue6945.agda:46.1-6: warning: -W[no]UselessMacro
+Issue6945.agda:47.1-6: warning: -W[no]UselessMacro
 Using a macro block here has no effect. 'macro' applies only to
 function definitions.
 
-Issue6945.agda:50.1-7: warning: -W[no]UselessOpaque
+Issue6945.agda:51.1-7: warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
   opaque unfolding {}
@@ -53,21 +56,24 @@ Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and data, record, and module declarations.
 
-Issue6945.agda:38.1-9: warning: -W[no]UselessAbstract
+Issue6945.agda:31.3-27: warning: -W[no]EmptyPolarityPragma
+POLARITY pragma without polarities (ignored).
+
+Issue6945.agda:39.1-9: warning: -W[no]UselessAbstract
 Using abstract here has no effect. Abstract applies to only
 definitions like data definitions, record type definitions and
 function clauses.
 
-Issue6945.agda:42.1-9: warning: -W[no]UselessInstance
+Issue6945.agda:43.1-9: warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and axioms.
 
-Issue6945.agda:46.1-6: warning: -W[no]UselessMacro
+Issue6945.agda:47.1-6: warning: -W[no]UselessMacro
 Using a macro block here has no effect. 'macro' applies only to
 function definitions.
 
-Issue6945.agda:50.1-7: warning: -W[no]UselessOpaque
+Issue6945.agda:51.1-7: warning: -W[no]UselessOpaque
 This 'opaque' block has no effect.
 when scope checking the declaration
   opaque unfolding {}


### PR DESCRIPTION
Fix #7546: warn about empty POLARITY pragmas with new nicifier warning `EmptyPolarityPragma`.