### PR TITLE
Refactor: move defArgGeneralizable to GeneralizableVar

### DIFF
--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -486,9 +486,9 @@ collectComponents opts costs ii mDefName whereNames metaId = do
                   | shouldKeep scope -> addAxiom
                   | otherwise        -> return comps
           -- TODO: Check if we want to use these
-          DataOrRecSig{}   -> return comps
-          GeneralizableVar -> return comps
-          AbstractDefn{}   -> return comps
+          DataOrRecSig{}     -> return comps
+          GeneralizableVar{} -> return comps
+          AbstractDefn{}     -> return comps
           -- If the function is in the same mutual block, do not include it.
           f@Function{}
             | Just qname == mDefName                  -> addThisFn
@@ -543,16 +543,16 @@ qnameToComponent cost qname = do
   mParams <- freeVarsToApply qname
   let def = (Def qname [] `apply` mParams, 0)
       (term, pars) = case theDef info of
-        c@Constructor{}  -> (Con (conSrcCon c) ConOCon [], conPars c - length mParams)
-        Axiom{}          -> def
-        GeneralizableVar -> def
-        Function{}       -> def
-        Datatype{}       -> def
-        Record{}         -> def
-        Primitive{}      -> def
-        PrimitiveSort{}  -> def
-        DataOrRecSig{}   -> __IMPOSSIBLE__
-        AbstractDefn{}   -> __IMPOSSIBLE__
+        c@Constructor{}    -> (Con (conSrcCon c) ConOCon [], conPars c - length mParams)
+        Axiom{}            -> def
+        GeneralizableVar{} -> def
+        Function{}         -> def
+        Datatype{}         -> def
+        Record{}           -> def
+        Primitive{}        -> def
+        PrimitiveSort{}    -> def
+        DataOrRecSig{}     -> __IMPOSSIBLE__
+        AbstractDefn{}     -> __IMPOSSIBLE__
   newComponentQ [] cost qname pars term typ
 
 getEverythingInScope :: MonadTCM tcm => MetaVariable -> tcm [QName]
@@ -1236,24 +1236,24 @@ tryDataRecord goal goalType branch = withBranchAndGoal branch goal $ do
       primitive@Primitive{} -> do
         return []
       -- TODO: Better way of checking that type is Level
-      d@Axiom{}
+      Axiom{}
         | P.prettyShow qname == "Agda.Primitive.Level" -> do
             tryLevel
         | otherwise -> do
         return []
-      d@DataOrRecSig{} -> do
+      DataOrRecSig{} -> do
         return []
-      d@GeneralizableVar -> do
+      GeneralizableVar{} -> do
         return []
-      d@AbstractDefn{} -> do
+      AbstractDefn{} -> do
         return []
-      d@Function{} -> do
+      Function{} -> do
         return []
-      d@Constructor{} -> do
+      Constructor{} -> do
         return []
-      d@PrimitiveSort{} -> do
+      PrimitiveSort{} -> do
         return []
-    sort@(Sort (Type level)) -> do
+    Sort (Type level) -> do
       trySet level
     Sort sort -> do
       return []

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -150,14 +150,14 @@ instance NamesIn Bool where
 
 instance NamesIn Definition where
   namesAndMetasIn' sg
-    (Defn _ _ t _ _ _ _ disp _ _ _ _ _ _ _ _ _ _ def) =
+    (Defn _ _ t _ _ _ disp _ _ _ _ _ _ _ _ _ _ def) =
     namesAndMetasIn' sg (t, def, disp)
 
 instance NamesIn Defn where
   namesAndMetasIn' sg = \case
     Axiom _            -> mempty
     DataOrRecSig _     -> mempty
-    GeneralizableVar   -> mempty
+    GeneralizableVar _ -> mempty
     PrimitiveSort _ s  -> namesAndMetasIn' sg s
     AbstractDefn{}     -> __IMPOSSIBLE__
     -- Andreas 2017-07-27, Q: which names can be in @cc@ which are not already in @cl@?

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -576,7 +576,6 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
             t   = defType d `piApply` ts'
             pol = defPolarity d `apply` ts'
             occ = defArgOccurrences d `apply` ts'
-            gen = defArgGeneralizable d `apply` ts'
             inst = defInstance d
             -- the name is set by the addConstant function
             nd :: QName -> TCM Definition
@@ -590,7 +589,6 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
                     , defType           = t
                     , defPolarity       = pol
                     , defArgOccurrences = occ
-                    , defArgGeneralizable = gen
                     , defGeneralizedParams = [] -- This is only needed for type checking data/record defs so no need to copy it.
                     , defDisplay        = []
                     , defMutual         = -1   -- TODO: mutual block?
@@ -653,7 +651,7 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
                          , recConHead = copyConHead c
                          , recFields  = (map . fmap) copyName fs
                          }
-                GeneralizableVar -> return GeneralizableVar
+                GeneralizableVar gv -> return $ GeneralizableVar $ gv `apply` ts'
                 _ -> do
                   (mst, _, cc) <- compileClauses Nothing [cl] -- Andreas, 2012-10-07 non need for record pattern translation
                   fun          <- emptyFunctionData

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -566,9 +566,8 @@ checkGeneralize s i info x e = do
       ]
 
     lang <- getLanguage
-    addConstant x $ (defaultDefn info x tGen lang GeneralizableVar)
-                    { defArgGeneralizable = SomeGeneralizableArgs n }
-
+    addConstant x $ defaultDefn info x tGen lang $
+      GeneralizableVar $ SomeGeneralizableArgs n
 
 -- | Type check an axiom.
 checkAxiom :: KindOfName -> A.DefInfo -> ArgInfo ->

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20241010 * 10 + 0
+currentInterfaceVersion = 20241010 * 10 + 1
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -224,8 +224,8 @@ instance EmbPrj InstanceInfo where
   value = valueN InstanceInfo
 
 instance EmbPrj Definition where
-  icod_ (Defn a b c d e f g h i j k l m n o p blocked r s) =
-    icodeN' Defn a b (P.killRange c) d e f g h i j k l m n o p (ossify blocked) r s
+  icod_ (Defn a b c d e f g h i j k l m n o blocked r s) =
+    icodeN' Defn a b (P.killRange c) d e f g h i j k l m n o (ossify blocked) r s
     where
       -- Andreas, 2024-01-02, issue #7044:
       -- After serialization, a definition can never be unblocked,
@@ -428,7 +428,7 @@ instance EmbPrj Defn where
   icod_ (Primitive   a b c d e f)                       = icodeN 5 Primitive a b c d e f
   icod_ (PrimitiveSort a b)                             = icodeN 6 PrimitiveSort a b
   icod_ AbstractDefn{}                                  = __IMPOSSIBLE__
-  icod_ GeneralizableVar                                = icodeN 7 GeneralizableVar
+  icod_ (GeneralizableVar a)                            = icodeN 7 GeneralizableVar a
   icod_ DataOrRecSig{}                                  = __IMPOSSIBLE__
 
   value = vcase valu where
@@ -440,7 +440,7 @@ instance EmbPrj Defn where
     valu [4, a, b, c, d, e, f, g, h, i, j, k]          = valuN Constructor a b c d e f g h i j k
     valu [5, a, b, c, d, e, f]                         = valuN Primitive   a b c d e f
     valu [6, a, b]                                     = valuN PrimitiveSort a b
-    valu [7]                                           = valuN GeneralizableVar
+    valu [7, a]                                        = valuN GeneralizableVar a
     valu _                                             = malformed
 
 instance EmbPrj LazySplit where

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -230,8 +230,8 @@ instance TermSubst a => Apply (Tele a) where
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
 
 instance Apply Definition where
-  apply (Defn info x t pol occ gens gpars df m c inst copy ma nc inj copat blk lang d) args =
-    Defn info x (piApply t args) (apply pol args) (apply occ args) (apply gens args) (drop (length args) gpars) df m c inst copy ma nc inj copat blk lang (apply d args)
+  apply (Defn info x t pol occ gpars df m c inst copy ma nc inj copat blk lang d) args =
+    Defn info x (piApply t args) (apply pol args) (apply occ args) (drop (length args) gpars) df m c inst copy ma nc inj copat blk lang (apply d args)
 
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
 
@@ -300,7 +300,7 @@ instance Apply Defn where
   apply d args@(arg1:args1) = case d of
     Axiom{} -> d
     DataOrRecSig n -> DataOrRecSig (n - length args)
-    GeneralizableVar{} -> d
+    GeneralizableVar gv -> GeneralizableVar $ apply gv args
     AbstractDefn d -> AbstractDefn $ apply d args
     Function{ funClauses = cs, funCompiled = cc, funCovering = cov, funInv = inv
             , funExtLam = extLam
@@ -620,8 +620,8 @@ instance Abstract Telescope where
   ExtendTel arg xtel `abstract` tel = ExtendTel arg $ xtel <&> (`abstract` tel)
 
 instance Abstract Definition where
-  abstract tel (Defn info x t pol occ gens gpars df m c inst copy ma nc inj copat blk lang d) =
-    Defn info x (abstract tel t) (abstract tel pol) (abstract tel occ) (abstract tel gens)
+  abstract tel (Defn info x t pol occ gpars df m c inst copy ma nc inj copat blk lang d) =
+    Defn info x (abstract tel t) (abstract tel pol) (abstract tel occ)
       (replicate (size tel) Nothing ++ gpars)
       df m c inst copy ma nc inj copat blk lang (abstract tel d)
 
@@ -661,7 +661,7 @@ instance Abstract Defn where
   abstract tel d = case d of
     Axiom{} -> d
     DataOrRecSig n -> DataOrRecSig (size tel + n)
-    GeneralizableVar{} -> d
+    GeneralizableVar gv -> GeneralizableVar $ abstract tel gv
     AbstractDefn d -> AbstractDefn $ abstract tel d
     Function{ funClauses = cs, funCompiled = cc, funCovering = cov, funInv = inv
             , funExtLam = extLam

--- a/src/full/Agda/Utils/Function.hs
+++ b/src/full/Agda/Utils/Function.hs
@@ -127,6 +127,21 @@ applyWhen b f = if b then f else id
 {-# INLINE applyUnless #-}
 applyUnless :: IsBool b => b -> (a -> a) -> a -> a
 applyUnless b f = if b then id else f
+  -- Note: RebindableSyntax translates this if-then-else to ifThenElse of IsBool.
+
+-- | @applyWhenIts p f a@ applies @f@ to @a@ when @p a@.
+{-# SPECIALIZE applyWhenIts :: (a -> Bool) -> (a -> a) -> (a -> a) #-}
+{-# INLINE applyWhenIts #-}
+applyWhenIts :: IsBool b => (a -> b) -> (a -> a) -> a -> a
+applyWhenIts p f a = if p a then f a else a
+  -- Note: RebindableSyntax translates this if-then-else to ifThenElse of IsBool.
+
+-- | @applyUnlessIts p f a@ applies @f@ to @a@ unless @p a@.
+{-# SPECIALIZE applyUnlessIts :: (a -> Bool) -> (a -> a) -> (a -> a) #-}
+{-# INLINE applyUnlessIts #-}
+applyUnlessIts :: IsBool b => (a -> b) -> (a -> a) -> a -> a
+applyUnlessIts p f a = if p a then a else f a
+  -- Note: RebindableSyntax translates this if-then-else to ifThenElse of IsBool.
 
 -- | Monadic version of @applyWhen@
 {-# SPECIALIZE applyWhenM :: Monad m => m Bool -> (m a -> m a) -> m a -> m a #-}


### PR DESCRIPTION
This field, pertaining to any Definition, is actually only used for generalizable variables.
Thus, placing it just there is more economical and clarifies its purpose.

Originally, it might have been intended for other definitions as well, but the implementation of generalization has been stable for a good while now, so we can tighten the design.
