### PR TITLE
Recent failures to build user manual PDF

### DIFF
--- a/doc/user-manual/language/sort-system.lagda.rst
+++ b/doc/user-manual/language/sort-system.lagda.rst
@@ -87,8 +87,8 @@ Universe example
 So why are universes useful? Because sometimes it is necessary to
 define and prove theorems about functions that operate not just on
 sets but on large sets. In fact, most Agda users sooner or later
-experience an error message where Agda complains that ``Set₁ !=
-Set``. These errors usually mean that a small set was used where a
+experience an error message where Agda complains that ``Set₁ != Set``.
+These errors usually mean that a small set was used where a
 large one was expected, or vice versa.
 
 For example, suppose you have defined the usual datatypes for lists

--- a/doc/user-manual/language/syntactic-sugar.lagda.rst
+++ b/doc/user-manual/language/syntactic-sugar.lagda.rst
@@ -245,8 +245,8 @@ advantage of pattern matching binds::
 
   _=?=_ : (A B : Type) → TC (A ≡ B)
   nat      =?= nat      = pure refl
-  nat      =?= (_ => _) = typeError "type mismatch: nat ‌≠ _ => _"
-  (_ => _) =?= nat      = typeError "type mismatch: _ => _ ≠ nat"
+  nat      =?= (_ => _) = typeError "type mismatch: expected nat, got _ => _"
+  (_ => _) =?= nat      = typeError "type mismatch: expected _ => _, got nat"
   (A => B) =?= (A₁ => B₁) = do
     refl ← A =?= A₁
     refl ← B =?= B₁

--- a/doc/user-manual/requirements.txt
+++ b/doc/user-manual/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx           >= 7.2.5
+Sphinx           >= 7.2.5, < 8
 sphinx_rtd_theme >= 1.3.0


### PR DESCRIPTION
Seems like sphinx-8.1.0 broke our PDF build.  I reported this upstream:
- https://github.com/sphinx-doc/sphinx/issues/13007

For now I restrict to sphinx < 8.  (Probably < 8.1 would be sufficient.)

Commits:
- **user-manual-pdf: Fix: Missing character: There is no "^^W" in font t1xtt**
- **user-manual cosmetics: don't break line in verbatim**
- **user-manual: restrict to Sphinx < 8 (attempt to combat build problems)**
