### PR TITLE
user-manual-pdf: sphinx-8.1 needs dependency fontawesome5

### DIFF
--- a/.github/workflows/user_manual.yml
+++ b/.github/workflows/user_manual.yml
@@ -32,9 +32,9 @@ jobs:
       uses: teatimeguest/setup-texlive-action@v3
       with:
         packages: scheme-basic anyfontsize bbm bbm-macros booktabs capt-of cmap colortbl
-          dvipng ellipse etoolbox fancyvrb float fncychap framed keystroke latexmk
-          mathtools needspace parskip pict2e psnfss stmaryrd tabulary tex-gyre titlesec
-          upquote varwidth wrapfig xcolor zapfchan
+          dvipng ellipse etoolbox fancyvrb float fncychap fontawesome5 framed keystroke
+          latexmk mathtools needspace parskip pict2e psnfss stmaryrd tabulary tex-gyre
+          titlesec upquote varwidth wrapfig xcolor zapfchan
     - name: Build User Manual in HTML
       run: |
         export PATH=$HOME/texlive/bin/x86_64-linux:$PATH

--- a/doc/user-manual/conf.py
+++ b/doc/user-manual/conf.py
@@ -121,7 +121,7 @@ htmlhelp_basename = 'Agdadoc'
 
 # -- Options for LaTeX output ------------------------------------------------
 
-latex_additional_files = ["mystyle.sty"]
+# latex_additional_files = ["mystyle.sty"]
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').

--- a/doc/user-manual/requirements.txt
+++ b/doc/user-manual/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx           >= 7.2.5, < 8
+Sphinx           >= 7.2.5
 sphinx_rtd_theme >= 1.3.0

--- a/src/github/workflows/user_manual.yml
+++ b/src/github/workflows/user_manual.yml
@@ -59,6 +59,7 @@ jobs:
           fancyvrb
           float
           fncychap
+          fontawesome5
           framed
           keystroke
           latexmk


### PR DESCRIPTION
Adding texlive package `fontawesome5` to the workflow building the user-manual PDF allows the use of the latest Sphinx (8.1.0).
See:
- https://github.com/sphinx-doc/sphinx/issues/13007