### PR TITLE
Fix compilation of serialisation code on 32 bit platforms

### DIFF
--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -55,6 +55,8 @@ import Agda.Utils.Monad
 import Agda.Utils.Pointer
 import Agda.Utils.TypeLevel
 
+#include <MachDeps.h>
+
 -- | Constructor tag (maybe omitted) and argument indices.
 data Node = Empty | Cons !Int32 !Node deriving Eq
 
@@ -67,13 +69,23 @@ instance Hashable Node where
     foldedMul (W# x) (W# y) = case timesWord2# x y of (# hi, lo #) -> W# (xor# hi lo)
 
     combine :: Word -> Word -> Word
-    combine x y = foldedMul (xor x y) 11400714819323198549
+    combine x y = foldedMul (xor x y) factor where
+#if WORD_SIZE_IN_BITS == 64
+    factor = 11400714819323198549
+#else
+    factor = 2654435741
+#endif
 
     go :: Word -> Node -> Word
     go !h Empty       = h
     go  h (Cons n ns) = go (combine h (fromIntegral n)) ns
 
-  hash = hashWithSalt 3032525626373534813
+  hash = hashWithSalt seed where
+#if WORD_SIZE_IN_BITS == 64
+    seed = 3032525626373534813
+#else
+    seed = 1103515245
+#endif
 
 instance B.Binary Node where
 

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -70,10 +70,12 @@ instance Hashable Node where
 
     combine :: Word -> Word -> Word
     combine x y = foldedMul (xor x y) factor where
+      -- We use a version of fibonacci hashing, where our multiplier is the
+      -- nearest prime to 2^64/phi or 2^32/phi. See https://stackoverflow.com/q/4113278.
 #if WORD_SIZE_IN_BITS == 64
-    factor = 11400714819323198549
+      factor = 11400714819323198549
 #else
-    factor = 2654435741
+      factor = 2654435741
 #endif
 
     go :: Word -> Node -> Word
@@ -82,9 +84,9 @@ instance Hashable Node where
 
   hash = hashWithSalt seed where
 #if WORD_SIZE_IN_BITS == 64
-    seed = 3032525626373534813
+      seed = 3032525626373534813
 #else
-    seed = 1103515245
+      seed = 1103515245
 #endif
 
 instance B.Binary Node where


### PR DESCRIPTION
The `Hashable Node` implementation uses a 64-bit hash. However, this does not work on 32 bit platforms, such as WASM, as the 64-bit constants do not fit into a 32 bit word.

Ideally we'd be able to keep the current algorithm and use `Word64`. However, that's awkward to do on older versions of GHC (as we'd have to depend on `ghc-prim`), so instead we just use different constants.