### PR TITLE
Use Word32 instead of Int32 everywhere

### DIFF
--- a/src/full/Agda/Interaction/JSON.hs
+++ b/src/full/Agda/Interaction/JSON.hs
@@ -21,7 +21,7 @@ import qualified Data.Aeson.Key as Key
 #endif
 
 import Data.Text (Text)
-import GHC.Int (Int32)
+import Data.Word (Word32)
 
 -- import qualified Agda.Syntax.Translation.InternalToAbstract as I2A
 -- import qualified Agda.Syntax.Translation.AbstractToConcrete as A2C
@@ -126,7 +126,7 @@ instance {-# OVERLAPPING #-} EncodeTCM String
 
 instance EncodeTCM Bool where
 instance EncodeTCM Int where
-instance EncodeTCM Int32 where
+instance EncodeTCM Word32 where
 instance EncodeTCM Value where
 instance EncodeTCM Doc where
 

--- a/src/full/Agda/Interaction/Response/Base.hs
+++ b/src/full/Agda/Interaction/Response/Base.hs
@@ -17,7 +17,7 @@ module Agda.Interaction.Response.Base
   ) where
 
 import Control.Monad.Trans ( MonadIO(liftIO) )
-import Data.Int (Int32)
+import Data.Word (Word32)
 import Data.Set (Set)
 
 import Agda.Interaction.Base
@@ -53,7 +53,7 @@ data Response_boot tcErr tcWarning warningsAndNonFatalErrors
         HighlightingMethod
         ModuleToSource
     | Resp_Status Status
-    | Resp_JumpToError FilePath Int32
+    | Resp_JumpToError FilePath Word32
     | Resp_InteractionPoints [InteractionId]
     | Resp_GiveAction InteractionId GiveResult
     | Resp_MakeCase InteractionId MakeCaseVariant [String]

--- a/src/full/Agda/Syntax/Common/Pretty.hs
+++ b/src/full/Agda/Syntax/Common/Pretty.hs
@@ -21,7 +21,7 @@ import Data.IntSet (IntSet)
 import Data.IntMap (IntMap)
 import Data.Word (Word64)
 import Data.Text (Text)
-import Data.Int (Int32)
+import Data.Word (Word32)
 import Data.Map (Map)
 import Data.Set (Set)
 
@@ -82,7 +82,7 @@ prettyShow = render . pretty
 
 instance Pretty Bool    where pretty = text . show
 instance Pretty Int     where pretty = text . show
-instance Pretty Int32   where pretty = text . show
+instance Pretty Word32  where pretty = text . show
 instance Pretty Integer where pretty = text . show
 instance Pretty Word64  where pretty = text . show
 instance Pretty Double  where pretty = text . toStringWithoutDotZero

--- a/src/full/Agda/Syntax/Parser/Monad.hs
+++ b/src/full/Agda/Syntax/Parser/Monad.hs
@@ -36,7 +36,7 @@ import Control.Exception ( displayException )
 import Control.Monad.Except
 import Control.Monad.State
 
-import Data.Int
+import Data.Word  ( Word32 )
 import Data.Maybe ( listToMaybe )
 
 import Agda.Interaction.Options.Warnings
@@ -104,7 +104,7 @@ data LayoutBlock
     deriving Show
 
 -- | A (layout) column.
-type Column = Int32
+type Column = Word32
 
 -- | Status of a layout column (see #1145).
 --   A layout column is 'Tentative' until we encounter a new line.

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -74,7 +74,7 @@ import Control.Monad.Writer (runWriter, tell)
 
 import qualified Data.Foldable as Fold
 import Data.Function (on)
-import Data.Int
+import Data.Word (Word32)
 import Data.List (sort)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -118,11 +118,11 @@ import Agda.Utils.Impossible
 data Position' a = Pn
   { srcFile :: !a
     -- ^ File.
-  , posPos  :: !Int32
+  , posPos  :: !Word32
     -- ^ Position, counting from 1.
-  , posLine :: !Int32
+  , posLine :: !Word32
     -- ^ Line number, counting from 1.
-  , posCol  :: !Int32
+  , posCol  :: !Word32
     -- ^ Column number, counting from 1.
   }
   deriving (Show, Functor, Foldable, Traversable, Generic)
@@ -131,7 +131,7 @@ positionInvariant :: Position' a -> Bool
 positionInvariant p =
   posPos p > 0 && posLine p > 0 && posCol p > 0
 
-importantPart :: Position' a -> (a, Int32)
+importantPart :: Position' a -> (a, Word32)
 importantPart p = (srcFile p, posPos p)
 
 instance Eq a => Eq (Position' a) where
@@ -236,7 +236,7 @@ posToInterval f p1 p2 = setIntervalFile f $
   else Interval p2 p1
 
 -- | The length of an interval.
-iLength :: Interval' a -> Int32
+iLength :: Interval' a -> Word32
 iLength i = posPos (iEnd i) - posPos (iStart i)
 
 -- | A range is a file name, plus a sequence of intervals, assumed to

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -32,7 +32,7 @@ import Control.Parallel             ( pseq )
 import Data.Array (Ix)
 import Data.DList (DList)
 import Data.Function (on)
-import Data.Int
+import Data.Word (Word32)
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import Data.IntSet (IntSet)
@@ -3405,7 +3405,7 @@ instance Pretty TermHead where
 -- ** Mutual blocks
 ---------------------------------------------------------------------------
 
-newtype MutualId = MutId Int32
+newtype MutualId = MutId Word32
   deriving (Eq, Ord, Show, Num, Enum, NFData)
 
 ---------------------------------------------------------------------------

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -41,7 +41,7 @@ import Control.Monad.ST.Trans
 import Data.Array.IArray
 import Data.Array.IO
 import Data.Word
-import Data.Int (Int32)
+import Data.Word (Word32)
 import Data.ByteString.Lazy    ( ByteString )
 import Data.ByteString.Builder ( byteString, toLazyByteString )
 import qualified Data.ByteString.Lazy as L
@@ -77,7 +77,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20241011 * 10 + 0
+currentInterfaceVersion = 20241014 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 
@@ -169,13 +169,13 @@ encode a = do
 --   where
 --   l h = List.map fst . List.sortBy (compare `on` snd) <$> H.toList h
 
-newtype ListLike a = ListLike { unListLike :: Array Int32 a }
+newtype ListLike a = ListLike { unListLike :: Array Word32 a }
 
 instance B.Binary a => B.Binary (ListLike a) where
   put = __IMPOSSIBLE__ -- Will never serialise this
   get = fmap ListLike $ runSTArray $ do
     n <- lift (B.get :: B.Get Int)
-    arr <- newArray_ (0, fromIntegral n - 1) :: STT s B.Get (STArray s Int32 a)
+    arr <- newArray_ (0, fromIntegral n - 1) :: STT s B.Get (STArray s Word32 a)
 
     -- We'd like to use 'for_ [0..n-1]' here, but unfortunately GHC doesn't unfold
     -- the list construction and so performs worse than the hand-written version.

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -14,7 +14,7 @@ import Data.Array.IArray
 import Data.Word
 import qualified Data.Foldable as Fold
 import Data.Hashable
-import Data.Int (Int32)
+import Data.Word (Word32)
 
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -81,17 +81,17 @@ instance EmbPrj Integer where
   value i = (! i) <$!> gets integerE
 
 instance EmbPrj Word64 where
-  icod_ i = icodeN' (undefined :: Int32 -> Int32 -> Int32) (int32 q) (int32 r)
+  icod_ i = icodeN' (undefined :: Word32 -> Word32 -> Word32) (word32 q) (word32 r)
     where (q, r) = quotRem i (2 ^ 32)
-          int32 :: Word64 -> Int32
-          int32 = fromIntegral
+          word32 :: Word64 -> Word32
+          word32 = fromIntegral
 
   value = vcase valu where
     valu [a, b] = return $! n * mod (fromIntegral a) n + mod (fromIntegral b) n
     valu _      = malformed
     n = 2 ^ 32
 
-instance EmbPrj Int32 where
+instance EmbPrj Word32 where
   icod_ i = return i
   value i = return i
 
@@ -246,7 +246,7 @@ instance (EmbPrj k, EmbPrj v, EmbPrj (BiMap.Tag v)) =>
 
 
 -- | Encode a list of key-value pairs as a flat list.
-mapPairsIcode :: (EmbPrj k, EmbPrj v) => [(k, v)] -> S Int32
+mapPairsIcode :: (EmbPrj k, EmbPrj v) => [(k, v)] -> S Word32
 mapPairsIcode xs = icodeNode =<< convert Empty xs where
   -- As we need to call `convert' in the tail position, the resulting list is
   -- written (and read) in reverse order, with the highest pair first in the
@@ -257,7 +257,7 @@ mapPairsIcode xs = icodeNode =<< convert Empty xs where
     entry <- icode entry
     convert (Cons start (Cons entry ys)) xs
 
-mapPairsValue :: (EmbPrj k, EmbPrj v) => [Int32] -> R [(k, v)]
+mapPairsValue :: (EmbPrj k, EmbPrj v) => [Word32] -> R [(k, v)]
 mapPairsValue = convert [] where
   convert ys [] = return ys
   convert ys (start:entry:xs) = do

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
@@ -6,7 +6,7 @@ module Agda.TypeChecking.Serialise.Instances.Highlighting where
 
 import qualified Data.Map.Strict as Map
 import Data.Strict.Tuple (Pair(..))
-import Data.Int (Int32)
+import Data.Word (Word32)
 
 import qualified Agda.Interaction.Highlighting.Range   as HR
 import qualified Agda.Interaction.Highlighting.Precise as HP
@@ -139,7 +139,7 @@ instance EmbPrj a => EmbPrj (RM.RangeMap a) where
       convert (Cons start (Cons end (Cons entry ys))) xs
 
   value = vcase (fmap (RM.RangeMap . Map.fromDistinctAscList) . convert []) where
-    convert :: [(Int, RM.PairInt a)] -> [Int32] -> R [(Int, RM.PairInt a)]
+    convert :: [(Int, RM.PairInt a)] -> [Word32] -> R [(Int, RM.PairInt a)]
     convert !ys [] = return ys
     convert  ys (start:end:entry:xs) = do
       !start <- value start

--- a/test/Internal/Syntax/Position.hs
+++ b/test/Internal/Syntax/Position.hs
@@ -12,7 +12,7 @@ import Agda.Utils.Null ( null )
 
 import Control.Monad
 
-import Data.Int
+import Data.Word (Word32)
 import Data.List (sort)
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -33,17 +33,17 @@ import System.FilePath
 -- | The positions corresponding to the interval. The positions do not
 -- refer to characters, but to the positions between characters, with
 -- zero pointing to the position before the first character.
-iPositions :: Interval' a -> Set Int32
+iPositions :: Interval' a -> Set Word32
 iPositions i = Set.fromList [posPos (iStart i) .. posPos (iEnd i)]
 
 -- | The positions corresponding to the range, including the
 -- end-points.
-rPositions :: Range' a -> Set Int32
+rPositions :: Range' a -> Set Word32
 rPositions r = Set.unions (map iPositions $ rangeIntervals r)
 
 -- | Constructs the least interval containing all the elements in the
 -- set.
-makeInterval :: Set Int32 -> Set Int32
+makeInterval :: Set Word32 -> Set Word32
 makeInterval s
   | Set.null s = Set.empty
   | otherwise  = Set.fromList [Set.findMin s .. Set.findMax s]


### PR DESCRIPTION
None of our uses (position info, IDs, bitvectors) needs negative numbers.
