### PR TITLE
Refactor: use Word32 instead of Int32 everywhere

### DIFF
--- a/src/full/Agda/Interaction/JSON.hs
+++ b/src/full/Agda/Interaction/JSON.hs
@@ -21,7 +21,7 @@ import qualified Data.Aeson.Key as Key
 #endif
 
 import Data.Text (Text)
-import GHC.Int (Int32)
+import Data.Word (Word32)
 
 -- import qualified Agda.Syntax.Translation.InternalToAbstract as I2A
 -- import qualified Agda.Syntax.Translation.AbstractToConcrete as A2C
@@ -124,11 +124,11 @@ instance EncodeTCM a => EncodeTCM [a] where
 -- overlaps with the instance declared above
 instance {-# OVERLAPPING #-} EncodeTCM String
 
-instance EncodeTCM Bool where
-instance EncodeTCM Int where
-instance EncodeTCM Int32 where
-instance EncodeTCM Value where
-instance EncodeTCM Doc where
+instance EncodeTCM Bool
+instance EncodeTCM Int
+instance EncodeTCM Word32
+instance EncodeTCM Value
+instance EncodeTCM Doc
 
 instance ToJSON Doc where
   toJSON = toJSON . render

--- a/src/full/Agda/Interaction/Response/Base.hs
+++ b/src/full/Agda/Interaction/Response/Base.hs
@@ -17,8 +17,8 @@ module Agda.Interaction.Response.Base
   ) where
 
 import Control.Monad.Trans ( MonadIO(liftIO) )
-import Data.Int (Int32)
 import Data.Set (Set)
+import Data.Word (Word32)
 
 import Agda.Interaction.Base
   ( CommandState
@@ -53,7 +53,7 @@ data Response_boot tcErr tcWarning warningsAndNonFatalErrors
         HighlightingMethod
         ModuleToSource
     | Resp_Status Status
-    | Resp_JumpToError FilePath Int32
+    | Resp_JumpToError FilePath Word32
     | Resp_InteractionPoints [InteractionId]
     | Resp_GiveAction InteractionId GiveResult
     | Resp_MakeCase InteractionId MakeCaseVariant [String]

--- a/src/full/Agda/Syntax/Common/Pretty.hs
+++ b/src/full/Agda/Syntax/Common/Pretty.hs
@@ -19,7 +19,7 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.IntSet (IntSet)
 import Data.IntMap (IntMap)
-import Data.Word (Word64)
+import Data.Word (Word64, Word32)
 import Data.Text (Text)
 import Data.Int (Int32)
 import Data.Map (Map)
@@ -84,6 +84,7 @@ instance Pretty Bool    where pretty = text . show
 instance Pretty Int     where pretty = text . show
 instance Pretty Int32   where pretty = text . show
 instance Pretty Integer where pretty = text . show
+instance Pretty Word32  where pretty = text . show
 instance Pretty Word64  where pretty = text . show
 instance Pretty Double  where pretty = text . toStringWithoutDotZero
 instance Pretty Text    where pretty = text . T.unpack

--- a/src/full/Agda/Syntax/Parser/Monad.hs
+++ b/src/full/Agda/Syntax/Parser/Monad.hs
@@ -36,8 +36,8 @@ import Control.Exception ( displayException )
 import Control.Monad.Except
 import Control.Monad.State
 
-import Data.Int
 import Data.Maybe ( listToMaybe )
+import Data.Word  ( Word32)
 
 import Agda.Interaction.Options.Warnings
 
@@ -104,7 +104,7 @@ data LayoutBlock
     deriving Show
 
 -- | A (layout) column.
-type Column = Int32
+type Column = Word32
 
 -- | Status of a layout column (see #1145).
 --   A layout column is 'Tentative' until we encounter a new line.

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -74,7 +74,6 @@ import Control.Monad.Writer (runWriter, tell)
 
 import qualified Data.Foldable as Fold
 import Data.Function (on)
-import Data.Int
 import Data.List (sort)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -84,6 +83,7 @@ import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Semigroup (Semigroup(..))
 import Data.Void
+import Data.Word (Word32)
 
 import GHC.Generics (Generic)
 
@@ -118,11 +118,11 @@ import Agda.Utils.Impossible
 data Position' a = Pn
   { srcFile :: !a
     -- ^ File.
-  , posPos  :: !Int32
+  , posPos  :: !Word32
     -- ^ Position, counting from 1.
-  , posLine :: !Int32
+  , posLine :: !Word32
     -- ^ Line number, counting from 1.
-  , posCol  :: !Int32
+  , posCol  :: !Word32
     -- ^ Column number, counting from 1.
   }
   deriving (Show, Functor, Foldable, Traversable, Generic)
@@ -131,7 +131,7 @@ positionInvariant :: Position' a -> Bool
 positionInvariant p =
   posPos p > 0 && posLine p > 0 && posCol p > 0
 
-importantPart :: Position' a -> (a, Int32)
+importantPart :: Position' a -> (a, Word32)
 importantPart p = (srcFile p, posPos p)
 
 instance Eq a => Eq (Position' a) where
@@ -236,7 +236,7 @@ posToInterval f p1 p2 = setIntervalFile f $
   else Interval p2 p1
 
 -- | The length of an interval.
-iLength :: Interval' a -> Int32
+iLength :: Interval' a -> Word32
 iLength i = posPos (iEnd i) - posPos (iStart i)
 
 -- | A range is a file name, plus a sequence of intervals, assumed to

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -170,7 +170,7 @@ termMutual names0 = ifNotM (optTerminationCheck <$> pragmaOptions) (return mempt
   -- The following debug statement is part of a test case for Issue
   -- #3590.
   reportSLn "term.mutual.id" 40 $
-    "Termination checking mutual block " ++ show mid
+    "Termination checking mutual block " ++ prettyShow mid
   reportSLn "term.mutual" 10 $ "Termination checking " ++ prettyShow allNames
 
   -- NO_TERMINATION_CHECK

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -95,7 +95,14 @@ instance EmbPrj Int32 where
   icod_ i = return i
   value i = return i
 
+-- Andreas, Agda Hackathon 2024-10-15
+-- Are we sure we never use an Int that does not fit into 32 bits?
 instance EmbPrj Int where
+  icod_ i = return $! fromIntegral i
+  value i = return $! fromIntegral i
+
+-- For now, do the same unsafe thing as for Int.
+instance EmbPrj Word32 where
   icod_ i = return $! fromIntegral i
   value i = return $! fromIntegral i
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -11,27 +11,25 @@ import Control.Monad.Reader       ( MonadReader(..), asks )
 import Control.Monad.State.Strict ( gets, modify )
 
 import Data.Array.IArray
-import Data.Word
 import qualified Data.Foldable as Fold
 import Data.Hashable
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HMap
 import Data.Int (Int32)
-
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Set (Set)
-import qualified Data.IntSet as IntSet
-import Data.IntSet (IntSet)
-import qualified Data.Set as Set
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
+import Data.Set (Set)
+import qualified Data.Set as Set
 import Data.Strict.Tuple (Pair(..))
 import qualified Data.Text      as T
 import qualified Data.Text.Lazy as TL
 import Data.Typeable
-import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HMap
-
 import Data.Void
+import Data.Word (Word32, Word64)
 
 import Agda.Syntax.Common
 import Agda.Syntax.Builtin
@@ -81,17 +79,17 @@ instance EmbPrj Integer where
   value i = (! i) <$!> gets integerE
 
 instance EmbPrj Word64 where
-  icod_ i = icodeN' (undefined :: Int32 -> Int32 -> Int32) (int32 q) (int32 r)
+  icod_ i = icodeN' (undefined :: Word32 -> Word32 -> Word32) (word32 q) (word32 r)
     where (q, r) = quotRem i (2 ^ 32)
-          int32 :: Word64 -> Int32
-          int32 = fromIntegral
+          word32 :: Word64 -> Word32
+          word32 = fromIntegral
 
   value = vcase valu where
-    valu [a, b] = return $! n * mod (fromIntegral a) n + mod (fromIntegral b) n
+    valu [a, b] = return $! n * fromIntegral a + fromIntegral b
     valu _      = malformed
     n = 2 ^ 32
 
-instance EmbPrj Int32 where
+instance EmbPrj Word32 where
   icod_ i = return i
   value i = return i
 
@@ -101,8 +99,7 @@ instance EmbPrj Int where
   icod_ i = return $! fromIntegral i
   value i = return $! fromIntegral i
 
--- For now, do the same unsafe thing as for Int.
-instance EmbPrj Word32 where
+instance EmbPrj Int32 where
   icod_ i = return $! fromIntegral i
   value i = return $! fromIntegral i
 
@@ -253,7 +250,7 @@ instance (EmbPrj k, EmbPrj v, EmbPrj (BiMap.Tag v)) =>
 
 
 -- | Encode a list of key-value pairs as a flat list.
-mapPairsIcode :: (EmbPrj k, EmbPrj v) => [(k, v)] -> S Int32
+mapPairsIcode :: (EmbPrj k, EmbPrj v) => [(k, v)] -> S Word32
 mapPairsIcode xs = icodeNode =<< convert Empty xs where
   -- As we need to call `convert' in the tail position, the resulting list is
   -- written (and read) in reverse order, with the highest pair first in the
@@ -264,7 +261,7 @@ mapPairsIcode xs = icodeNode =<< convert Empty xs where
     entry <- icode entry
     convert (Cons start (Cons entry ys)) xs
 
-mapPairsValue :: (EmbPrj k, EmbPrj v) => [Int32] -> R [(k, v)]
+mapPairsValue :: (EmbPrj k, EmbPrj v) => [Word32] -> R [(k, v)]
 mapPairsValue = convert [] where
   convert ys [] = return ys
   convert ys (start:entry:xs) = do

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
@@ -6,7 +6,7 @@ module Agda.TypeChecking.Serialise.Instances.Highlighting where
 
 import qualified Data.Map.Strict as Map
 import Data.Strict.Tuple (Pair(..))
-import Data.Int (Int32)
+import Data.Word (Word32)
 
 import qualified Agda.Interaction.Highlighting.Range   as HR
 import qualified Agda.Interaction.Highlighting.Precise as HP
@@ -139,7 +139,7 @@ instance EmbPrj a => EmbPrj (RM.RangeMap a) where
       convert (Cons start (Cons end (Cons entry ys))) xs
 
   value = vcase (fmap (RM.RangeMap . Map.fromDistinctAscList) . convert []) where
-    convert :: [(Int, RM.PairInt a)] -> [Int32] -> R [(Int, RM.PairInt a)]
+    convert :: [(Int, RM.PairInt a)] -> [Word32] -> R [(Int, RM.PairInt a)]
     convert !ys [] = return ys
     convert  ys (start:end:entry:xs) = do
       !start <- value start

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -212,8 +212,8 @@ instance EmbPrj DisplayTerm where
     valu _            = malformed
 
 instance EmbPrj MutualId where
-  icod_ (MutId a) = icode a
-  value n         = MutId <$!> value n
+  icod_ (MutualId a) = icode a
+  value n            = MutualId <$!> value n
 
 instance EmbPrj CompKit where
   icod_ (CompKit a b) = icodeN' CompKit a b

--- a/test/Fail/Issue3590-1.agda
+++ b/test/Fail/Issue3590-1.agda
@@ -1,5 +1,6 @@
--- The debug output should include the text "Termination checking
--- mutual block MutId 0" once, not three times.
+-- The debug output should include the text
+-- "Termination checking mutual block 0"
+-- once, not three times.
 
 {-# OPTIONS -vterm.mutual.id:40 #-}
 

--- a/test/Fail/Issue3590-1.err
+++ b/test/Fail/Issue3590-1.err
@@ -1,4 +1,4 @@
-Termination checking mutual block MutId 0
-Issue3590-1.agda:23.7-10: error: [UnequalSorts]
+Termination checking mutual block 0
+Issue3590-1.agda:24.7-10: error: [UnequalSorts]
 Set₁ != Set
 when checking that the expression Set has type Set

--- a/test/Fail/Issue3590-2.agda
+++ b/test/Fail/Issue3590-2.agda
@@ -1,5 +1,6 @@
--- The debug output should include the text "Termination checking
--- mutual block MutId 0" once, not three times.
+-- The debug output should include the text
+-- "Termination checking mutual block 0"
+-- once, not three times.
 
 {-# OPTIONS -vterm.mutual.id:40 #-}
 

--- a/test/Fail/Issue3590-2.err
+++ b/test/Fail/Issue3590-2.err
@@ -1,4 +1,4 @@
-Termination checking mutual block MutId 0
-Issue3590-2.agda:27.7-10: error: [UnequalSorts]
+Termination checking mutual block 0
+Issue3590-2.agda:28.7-10: error: [UnequalSorts]
 Set₁ != Set
 when checking that the expression Set has type Set

--- a/test/Internal/Syntax/Position.hs
+++ b/test/Internal/Syntax/Position.hs
@@ -12,10 +12,9 @@ import Agda.Utils.Null ( null )
 
 import Control.Monad
 
-import Data.Int
 import Data.List (sort)
-import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
 import qualified Data.Text as T
 
 import Internal.Helpers
@@ -33,20 +32,20 @@ import System.FilePath
 -- | The positions corresponding to the interval. The positions do not
 -- refer to characters, but to the positions between characters, with
 -- zero pointing to the position before the first character.
-iPositions :: Interval' a -> Set Int32
-iPositions i = Set.fromList [posPos (iStart i) .. posPos (iEnd i)]
+iPositions :: Interval' a -> IntSet
+iPositions i = IntSet.fromList [fromIntegral (posPos (iStart i)) .. fromIntegral (posPos (iEnd i))]
 
 -- | The positions corresponding to the range, including the
 -- end-points.
-rPositions :: Range' a -> Set Int32
-rPositions r = Set.unions (map iPositions $ rangeIntervals r)
+rPositions :: Range' a -> IntSet
+rPositions r = IntSet.unions (map iPositions $ rangeIntervals r)
 
 -- | Constructs the least interval containing all the elements in the
 -- set.
-makeInterval :: Set Int32 -> Set Int32
+makeInterval :: IntSet -> IntSet
 makeInterval s
-  | Set.null s = Set.empty
-  | otherwise  = Set.fromList [Set.findMin s .. Set.findMax s]
+  | IntSet.null s = IntSet.empty
+  | otherwise  = IntSet.fromList [IntSet.findMin s .. IntSet.findMax s]
 
 prop_iLength :: Interval' Integer -> Bool
 prop_iLength i = iLength i >= 0
@@ -123,7 +122,7 @@ prop_fuseIntervals i1 =
     let i = fuseIntervals i1 i2 in
     intervalInvariant i &&
     iPositions i ==
-      makeInterval (Set.union (iPositions i1) (iPositions i2))
+      makeInterval (IntSet.union (iPositions i1) (iPositions i2))
 
 prop_fuseRanges :: Range -> Property
 prop_fuseRanges r1 =
@@ -131,7 +130,7 @@ prop_fuseRanges r1 =
     let r = fuseRanges r1 r2 in
     rangeInvariant r
       &&
-    rPositions r == Set.union (rPositions r1) (rPositions r2)
+    rPositions r == IntSet.union (rPositions r1) (rPositions r2)
 
 prop_beginningOf :: Range -> Bool
 prop_beginningOf r = rangeInvariant (beginningOf r)


### PR DESCRIPTION
- Use Word32 instead of Int32 everywhere (superseds #7563)
- Refactor: use IntMap for map MutualId -> MutualBlock