### PR TITLE
Make dangling hidden/instance args into a warning

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1835,12 +1835,12 @@ Such *error warnings* are always on, they cannot be toggled by :option:`-W`.
 
      Unsolved meta variables.
 
-.. option:: NothingAppliedToHiddenArg
+.. option:: HiddenNotInArgumentPosition
 
      Hidden arguments ``{ x }`` can only appear as arguments to
      functions, not as expressions by themselves.
 
-.. option:: NothingAppliedToInstanceArg
+.. option:: InstanceNotInArgumentPosition
 
      Instance arguments ``⦃ x ⦄`` can only appear as arguments to
      functions, not as expressions by themselves.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1835,6 +1835,16 @@ Such *error warnings* are always on, they cannot be toggled by :option:`-W`.
 
      Unsolved meta variables.
 
+.. option:: NothingAppliedToHiddenArg
+
+     Hidden arguments ``{ x }`` can only appear as arguments to
+     functions, not as expressions by themselves.
+
+.. option:: NothingAppliedToInstanceArg
+
+     Instance arguments ``⦃ x ⦄`` can only appear as arguments to
+     functions, not as expressions by themselves.
+
 
 Command-line examples
 ---------------------

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -518,8 +518,8 @@ warningHighlighting' b w = case tcWarning w of
   FaceConstraintCannotBeHidden{}  -> deadcodeHighlighting w
   FaceConstraintCannotBeNamed{}   -> deadcodeHighlighting w
 
-  NothingAppliedToHiddenArg{}   -> errorWarningHighlighting w
-  NothingAppliedToInstanceArg{} -> errorWarningHighlighting w
+  HiddenNotInArgumentPosition{}   -> errorWarningHighlighting w
+  InstanceNotInArgumentPosition{} -> errorWarningHighlighting w
 
   NicifierIssue (DeclarationWarning _ w) -> case w of
     -- we intentionally override the binding of `w` here so that our pattern of

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -518,6 +518,9 @@ warningHighlighting' b w = case tcWarning w of
   FaceConstraintCannotBeHidden{}  -> deadcodeHighlighting w
   FaceConstraintCannotBeNamed{}   -> deadcodeHighlighting w
 
+  NothingAppliedToHiddenArg{}   -> errorWarningHighlighting w
+  NothingAppliedToInstanceArg{} -> errorWarningHighlighting w
+
   NicifierIssue (DeclarationWarning _ w) -> case w of
     -- we intentionally override the binding of `w` here so that our pattern of
     -- using `getRange w` still yields the most precise range information we

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -217,8 +217,6 @@ data ErrorName
   | NotInScope_
   | NotLeqSort_
   | NotValidBeforeField_
-  | NothingAppliedToHiddenArg_
-  | NothingAppliedToInstanceArg_
   | OpenEverythingInRecordWhere_
   | OverlappingProjects_
   | PatternInPathLambda_

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -182,6 +182,10 @@ errorWarnings = Set.fromList
   , RewriteMaybeNonConfluent_
   , RewriteAmbiguousRules_
   , RewriteMissingRule_
+
+  -- Recoverable scope-checking errors
+  , NothingAppliedToHiddenArg_
+  , NothingAppliedToInstanceArg_
   ]
 
 allWarnings :: Set WarningName
@@ -359,6 +363,9 @@ data WarningName
   | UnfoldingWrongName_
   | UnfoldTransparentName_
   | UselessOpaque_
+  -- Recoverable scope checking errors
+  | NothingAppliedToHiddenArg_
+  | NothingAppliedToInstanceArg_
   -- Cubical
   | FaceConstraintCannotBeHidden_
   | FaceConstraintCannotBeNamed_
@@ -585,6 +592,11 @@ warningNameDescription = \case
   UnfoldingWrongName_              -> "Names in `unfolding` clause that are not unambiguous functions."
   UnfoldTransparentName_           -> "Non-`opaque` names mentioned in an `unfolding` clause."
   UselessOpaque_                   -> "`opaque` blocks that have no effect."
+
+  -- Recoverable scope-checking errors
+  NothingAppliedToHiddenArg_       -> "Hidden argument with no matching function."
+  NothingAppliedToInstanceArg_     -> "Instance argument with no matching function."
+
   -- Cubical
   FaceConstraintCannotBeHidden_    -> "Face constraint patterns that are given as implicit arguments."
   FaceConstraintCannotBeNamed_     -> "Face constraint patterns that are given as named arguments."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -184,8 +184,8 @@ errorWarnings = Set.fromList
   , RewriteMissingRule_
 
   -- Recoverable scope-checking errors
-  , NothingAppliedToHiddenArg_
-  , NothingAppliedToInstanceArg_
+  , HiddenNotInArgumentPosition_
+  , InstanceNotInArgumentPosition_
   ]
 
 allWarnings :: Set WarningName
@@ -364,8 +364,8 @@ data WarningName
   | UnfoldTransparentName_
   | UselessOpaque_
   -- Recoverable scope checking errors
-  | NothingAppliedToHiddenArg_
-  | NothingAppliedToInstanceArg_
+  | HiddenNotInArgumentPosition_
+  | InstanceNotInArgumentPosition_
   -- Cubical
   | FaceConstraintCannotBeHidden_
   | FaceConstraintCannotBeNamed_
@@ -594,8 +594,8 @@ warningNameDescription = \case
   UselessOpaque_                   -> "`opaque` blocks that have no effect."
 
   -- Recoverable scope-checking errors
-  NothingAppliedToHiddenArg_       -> "Hidden argument with no matching function."
-  NothingAppliedToInstanceArg_     -> "Instance argument with no matching function."
+  HiddenNotInArgumentPosition_     -> "Hidden argument with no matching function."
+  InstanceNotInArgumentPosition_   -> "Instance argument with no matching function."
 
   -- Cubical
   FaceConstraintCannotBeHidden_    -> "Face constraint patterns that are given as implicit arguments."

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -994,11 +994,11 @@ instance ToAbstract C.Expr where
   -- Misplaced hidden argument. We can treat these as parentheses and
   -- raise an error-warning
       C.HiddenArg _ e' -> do
-        warning (NothingAppliedToHiddenArg e)
+        warning (HiddenNotInArgumentPosition e)
         toAbstract (namedThing e')
 
       C.InstanceArg _ e' -> do
-        warning (NothingAppliedToInstanceArg e)
+        warning (InstanceNotInArgumentPosition e)
         toAbstract (namedThing e')
 
   -- Lambda

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -121,12 +121,6 @@ import qualified Agda.Syntax.Common as A
 notAnExpression :: (HasCallStack, MonadTCError m) => C.Expr -> m a
 notAnExpression = locatedTypeError NotAnExpression
 
-nothingAppliedToHiddenArg :: (HasCallStack, MonadTCError m) => C.Expr -> m a
-nothingAppliedToHiddenArg = locatedTypeError NothingAppliedToHiddenArg
-
-nothingAppliedToInstanceArg :: (HasCallStack, MonadTCError m) => C.Expr -> m a
-nothingAppliedToInstanceArg = locatedTypeError NothingAppliedToInstanceArg
-
 notAValidLetBinding :: (HasCallStack, MonadTCError m) => Maybe NotAValidLetBinding -> m a
 notAValidLetBinding = locatedTypeError NotAValidLetBinding
 
@@ -997,9 +991,15 @@ instance ToAbstract C.Expr where
         es <- mapM (toAbstractCtx WithArgCtx) es
         return $ A.WithApp (ExprRange r) e es
 
-  -- Misplaced hidden argument
-      C.HiddenArg _ _ -> nothingAppliedToHiddenArg e
-      C.InstanceArg _ _ -> nothingAppliedToInstanceArg e
+  -- Misplaced hidden argument. We can treat these as parentheses and
+  -- raise an error-warning
+      C.HiddenArg _ e' -> do
+        warning (NothingAppliedToHiddenArg e)
+        toAbstract (namedThing e')
+
+      C.InstanceArg _ e' -> do
+        warning (NothingAppliedToInstanceArg e)
+        toAbstract (namedThing e')
 
   -- Lambda
       C.AbsurdLam r h -> return $ A.AbsurdLam (ExprRange r) h

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -921,14 +921,6 @@ instance PrettyTCM TypeError where
     NotValidBeforeField nd -> fwords $
       "This declaration is illegal in a record before the last field"
 
-    NothingAppliedToHiddenArg e -> fsep $
-      [pretty e] ++ pwords "cannot appear by itself. It needs to be the argument to" ++
-      pwords "a function expecting an implicit argument."
-
-    NothingAppliedToInstanceArg e -> fsep $
-      [pretty e] ++ pwords "cannot appear by itself. It needs to be the argument to" ++
-      pwords "a function expecting an instance argument."
-
     NoParseForApplication es -> fsep (
       pwords "Could not parse the application" ++ [pretty $ C.RawApp noRange es])
 

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -165,8 +165,6 @@ typeErrorName = \case
   NotInScope                                                 {} -> NotInScope_
   NotLeqSort                                                 {} -> NotLeqSort_
   NotValidBeforeField                                        {} -> NotValidBeforeField_
-  NothingAppliedToHiddenArg                                  {} -> NothingAppliedToHiddenArg_
-  NothingAppliedToInstanceArg                                {} -> NothingAppliedToInstanceArg_
   OpenEverythingInRecordWhere                                {} -> OpenEverythingInRecordWhere_
   OverlappingProjects                                        {} -> OverlappingProjects_
   PatternInPathLambda                                        {} -> PatternInPathLambda_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4459,8 +4459,8 @@ data Warning
   | UselessOpaque
 
   -- Recoverable scope-checking errors
-  | NothingAppliedToHiddenArg C.Expr
-  | NothingAppliedToInstanceArg C.Expr
+  | HiddenNotInArgumentPosition C.Expr
+  | InstanceNotInArgumentPosition C.Expr
 
   -- Display form warnings
   | InvalidDisplayForm QName String
@@ -4595,8 +4595,8 @@ warningName = \case
   UnfoldTransparentName{} -> UnfoldTransparentName_
 
   -- Recoverable scope-checking errors
-  NothingAppliedToHiddenArg{}   -> NothingAppliedToHiddenArg_
-  NothingAppliedToInstanceArg{} -> NothingAppliedToInstanceArg_
+  HiddenNotInArgumentPosition{}   -> HiddenNotInArgumentPosition_
+  InstanceNotInArgumentPosition{} -> InstanceNotInArgumentPosition_
 
   -- Display forms
   InvalidDisplayForm{}                 -> InvalidDisplayForm_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4458,6 +4458,10 @@ data Warning
   | UnfoldTransparentName QName
   | UselessOpaque
 
+  -- Recoverable scope-checking errors
+  | NothingAppliedToHiddenArg C.Expr
+  | NothingAppliedToInstanceArg C.Expr
+
   -- Display form warnings
   | InvalidDisplayForm QName String
       -- ^ DISPLAY form for 'QName' is invalid because 'String'.
@@ -4589,6 +4593,10 @@ warningName = \case
   UselessOpaque{}         -> UselessOpaque_
   UnfoldingWrongName{}    -> UnfoldingWrongName_
   UnfoldTransparentName{} -> UnfoldTransparentName_
+
+  -- Recoverable scope-checking errors
+  NothingAppliedToHiddenArg{}   -> NothingAppliedToHiddenArg_
+  NothingAppliedToInstanceArg{} -> NothingAppliedToInstanceArg_
 
   -- Display forms
   InvalidDisplayForm{}                 -> InvalidDisplayForm_
@@ -5037,8 +5045,6 @@ data TypeError
         | NotAValidLetBinding (Maybe NotAValidLetBinding)
         | NotAValidLetExpression NotAValidLetExpression
         | NotValidBeforeField NiceDeclaration
-        | NothingAppliedToHiddenArg C.Expr
-        | NothingAppliedToInstanceArg C.Expr
         | OpenEverythingInRecordWhere
         | PrivateRecordField
         | QualifiedLocalModule

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -558,6 +558,14 @@ prettyWarning = \case
 
     UselessOpaque -> "This `opaque` block has no effect."
 
+    NothingAppliedToHiddenArg e -> fsep $
+      [pretty e] ++ pwords "cannot appear by itself. It needs to be the argument to" ++
+      pwords "a function expecting an implicit argument."
+
+    NothingAppliedToInstanceArg e -> fsep $
+      [pretty e] ++ pwords "cannot appear by itself. It needs to be the argument to" ++
+      pwords "a function expecting an instance argument."
+
     InvalidDisplayForm x reason -> fsep $ concat
         [ pwords "Ignoring invalid display form for"
         , [ prettyTCM x ]

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -558,11 +558,11 @@ prettyWarning = \case
 
     UselessOpaque -> "This `opaque` block has no effect."
 
-    NothingAppliedToHiddenArg e -> fsep $
+    HiddenNotInArgumentPosition e -> fsep $
       [pretty e] ++ pwords "cannot appear by itself. It needs to be the argument to" ++
       pwords "a function expecting an implicit argument."
 
-    NothingAppliedToInstanceArg e -> fsep $
+    InstanceNotInArgumentPosition e -> fsep $
       [pretty e] ++ pwords "cannot appear by itself. It needs to be the argument to" ++
       pwords "a function expecting an instance argument."
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -132,6 +132,8 @@ instance EmbPrj Warning where
     -- FixingQuantity a b c                        -> icodeN 68 FixingQuantity a b c
     FixingRelevance a b c                       -> icodeN 69 FixingRelevance a b c
     UnusedVariablesInDisplayForm a              -> icodeN 70 UnusedVariablesInDisplayForm a
+    NothingAppliedToHiddenArg a                 -> __IMPOSSIBLE__
+    NothingAppliedToInstanceArg a               -> __IMPOSSIBLE__
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -132,8 +132,8 @@ instance EmbPrj Warning where
     -- FixingQuantity a b c                        -> icodeN 68 FixingQuantity a b c
     FixingRelevance a b c                       -> icodeN 69 FixingRelevance a b c
     UnusedVariablesInDisplayForm a              -> icodeN 70 UnusedVariablesInDisplayForm a
-    NothingAppliedToHiddenArg a                 -> __IMPOSSIBLE__
-    NothingAppliedToInstanceArg a               -> __IMPOSSIBLE__
+    HiddenNotInArgumentPosition a               -> __IMPOSSIBLE__
+    InstanceNotInArgumentPosition a             -> __IMPOSSIBLE__
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b

--- a/test/Fail/Issue4880.agda
+++ b/test/Fail/Issue4880.agda
@@ -6,7 +6,9 @@ module _ (A B : Set) where
 postulate
   _ : { { A } } → B
 
--- Expected: ERROR or WARNING
+  _ : { { A } } → B
+
+-- Expected: 2 fatal warnings
 -- For instance:
 -- {A} cannot appear by itself. It needs to be the argument to a
 -- function expecting an implicit argument.

--- a/test/Fail/Issue4880.err
+++ b/test/Fail/Issue4880.err
@@ -2,3 +2,8 @@ Issue4880.agda:7.9-14: error: [NothingAppliedToHiddenArg]
 {A} cannot appear by itself. It needs to be the argument to a
 function expecting an implicit argument.
 when scope checking {A}
+
+Issue4880.agda:9.9-14: error: [NothingAppliedToHiddenArg]
+{A} cannot appear by itself. It needs to be the argument to a
+function expecting an implicit argument.
+when scope checking {A}

--- a/test/Fail/Issue4880.err
+++ b/test/Fail/Issue4880.err
@@ -1,9 +1,9 @@
-Issue4880.agda:7.9-14: error: [NothingAppliedToHiddenArg]
+Issue4880.agda:7.9-14: error: [HiddenNotInArgumentPosition]
 {A} cannot appear by itself. It needs to be the argument to a
 function expecting an implicit argument.
 when scope checking {A}
 
-Issue4880.agda:9.9-14: error: [NothingAppliedToHiddenArg]
+Issue4880.agda:9.9-14: error: [HiddenNotInArgumentPosition]
 {A} cannot appear by itself. It needs to be the argument to a
 function expecting an implicit argument.
 when scope checking {A}

--- a/test/Fail/NothingAppliedToHiddenArg.agda
+++ b/test/Fail/NothingAppliedToHiddenArg.agda
@@ -1,4 +1,3 @@
 module NothingAppliedToHiddenArg where
 
 bad = {x}
-

--- a/test/Fail/NothingAppliedToHiddenArg.err
+++ b/test/Fail/NothingAppliedToHiddenArg.err
@@ -2,3 +2,9 @@ NothingAppliedToHiddenArg.agda:3.7-10: error: [NothingAppliedToHiddenArg]
 {x} cannot appear by itself. It needs to be the argument to a
 function expecting an implicit argument.
 when scope checking {x}
+
+NothingAppliedToHiddenArg.agda:3.8-9: error: [NotInScope]
+Not in scope:
+  x
+  at NothingAppliedToHiddenArg.agda:3.8-9
+when scope checking x

--- a/test/Fail/NothingAppliedToHiddenArg.err
+++ b/test/Fail/NothingAppliedToHiddenArg.err
@@ -1,4 +1,4 @@
-NothingAppliedToHiddenArg.agda:3.7-10: error: [NothingAppliedToHiddenArg]
+NothingAppliedToHiddenArg.agda:3.7-10: error: [HiddenNotInArgumentPosition]
 {x} cannot appear by itself. It needs to be the argument to a
 function expecting an implicit argument.
 when scope checking {x}

--- a/test/Fail/NothingAppliedToInstanceArg.agda
+++ b/test/Fail/NothingAppliedToInstanceArg.agda
@@ -1,5 +1,5 @@
 -- Andreas, 2024-07-19, PR #7379
--- Trigger error NothingAppliedToInstanceArg
+-- Trigger error InstanceNotInArgumentPosition
 
 bad = {{x}}
 

--- a/test/Fail/NothingAppliedToInstanceArg.err
+++ b/test/Fail/NothingAppliedToInstanceArg.err
@@ -1,4 +1,4 @@
-NothingAppliedToInstanceArg.agda:4.7-12: error: [NothingAppliedToInstanceArg]
+NothingAppliedToInstanceArg.agda:4.7-12: error: [InstanceNotInArgumentPosition]
 ⦃ x ⦄ cannot appear by itself. It needs to be the argument to a
 function expecting an instance argument.
 when scope checking ⦃ x ⦄

--- a/test/Fail/NothingAppliedToInstanceArg.err
+++ b/test/Fail/NothingAppliedToInstanceArg.err
@@ -2,3 +2,9 @@ NothingAppliedToInstanceArg.agda:4.7-12: error: [NothingAppliedToInstanceArg]
 ⦃ x ⦄ cannot appear by itself. It needs to be the argument to a
 function expecting an instance argument.
 when scope checking ⦃ x ⦄
+
+NothingAppliedToInstanceArg.agda:4.9-10: error: [NotInScope]
+Not in scope:
+  x
+  at NothingAppliedToInstanceArg.agda:4.9-10
+when scope checking x


### PR DESCRIPTION
Make it so the scope checker can keep going even if you have a dangling hidden/instance argument.