### PR TITLE
Fix over-general type family Constant

### DIFF
--- a/src/full/Agda/Utils/TypeLevel.hs
+++ b/src/full/Agda/Utils/TypeLevel.hs
@@ -57,7 +57,7 @@ data ConsMap1 :: (Function k l -> Type) -> k -> Function [l] [l] -> Type
 type instance Apply (ConsMap0 f)    a = ConsMap1 f a
 type instance Apply (ConsMap1 f a) tl = Apply f a ': tl
 
-type family Constant (b :: l) (as :: [k]) :: [l] where
+type family Constant (b :: Type) (as :: [k]) :: [Type] where
   Constant b as = Map (Constant1 b) as
 
 ------------------------------------------------------------------


### PR DESCRIPTION
This was resulting an error in some undetermined GHC version during new user setup. But even on versions of GHC where it works, this type family just doesn't unfold when you have `b :: l` for some other kind `l` because `Constant1` only works on `b :: Type`.