### PR TITLE
Fix documentation code block indent

### DIFF
--- a/doc/user-manual/language/built-ins.lagda.rst
+++ b/doc/user-manual/language/built-ins.lagda.rst
@@ -685,15 +685,15 @@ when importing ``Agda.Primitive``.
 
 .. code-block:: agda
 
-{-# BUILTIN PROP           Prop      #-}
-{-# BUILTIN TYPE           Set       #-}
-{-# BUILTIN STRICTSET      SSet      #-}
+  {-# BUILTIN PROP           Prop      #-}
+  {-# BUILTIN TYPE           Set       #-}
+  {-# BUILTIN STRICTSET      SSet      #-}
 
-{-# BUILTIN PROPOMEGA      Propω     #-}
-{-# BUILTIN SETOMEGA       Setω      #-}
-{-# BUILTIN STRICTSETOMEGA SSetω     #-}
+  {-# BUILTIN PROPOMEGA      Propω     #-}
+  {-# BUILTIN SETOMEGA       Setω      #-}
+  {-# BUILTIN STRICTSETOMEGA SSetω     #-}
 
-{-# BUILTIN LEVELUNIV      LevelUniv #-}
+  {-# BUILTIN LEVELUNIV      LevelUniv #-}
 
 The primitive sort `Set` is automatically imported at the
 top of every top-level Agda module, unless the


### PR DESCRIPTION
The code block in Language Reference > Built-ins > Sorts was not indented properly. It was rendered as text paragraphs instead of code: https://agda.readthedocs.io/en/v2.7.0.1/language/built-ins.html#sorts