### PR TITLE
Support Happy 2.1.1

### DIFF
--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -27,6 +27,7 @@ module Agda.Syntax.Parser.Parser (
     ) where
 
 import Prelude hiding ( null )
+import qualified Prelude
 
 import Control.Applicative ( (<|>) )
 import Control.Monad


### PR DESCRIPTION
Should fix #7585. Happy 2.1.1 qualifies all uses of Prelude functions, and `import Prelude hiding ( null )` causes `Prelude.null` to not be in scope. Happy <2.1.1 generates unqualified `null` which refers to `Agda.Utils.Null.null`.
