### PR TITLE
Fix #7588: Remove overlapping branches when simplifying chained cases

### DIFF
--- a/test/Compiler/simple/Issue7588.agda
+++ b/test/Compiler/simple/Issue7588.agda
@@ -1,0 +1,30 @@
+-- Test case by Lawrence Chonavel
+
+open import Agda.Builtin.Bool
+open import Common.IO
+open import Common.Unit
+
+data Cell : Set where
+  [-] [o] [x] : Cell
+
+data Board : Set where
+  mk-Board : Cell → Cell → Board
+
+winner : Board → Cell
+winner = λ where
+  (mk-Board [x] [x]) → [x]
+  (mk-Board  _  [x]) → [x]
+  (mk-Board  _   _ ) → [-]
+{-# INLINE winner #-}
+
+step : Board → Board
+step b with winner b
+... | [-] = b
+... |  _  = mk-Board [-] [-]
+
+isEmpty : Board → Bool
+isEmpty (mk-Board [-] [-]) = true
+isEmpty (mk-Board  _   _ ) = false
+
+main : IO Unit
+main = printBool (isEmpty (step (mk-Board [x] [x])))

--- a/test/Compiler/simple/Issue7588.out
+++ b/test/Compiler/simple/Issue7588.out
@@ -1,0 +1,4 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > true


### PR DESCRIPTION
Fixes #7588, which was caused by the treeless syntax simplifier generating overlapping branches when collapsing chained cases, e.g.:
```agda
case x of
  c1 → y
  _ → case x of
    c1 → y
    _ → z
```
became
```agda
case x of
  c1 → y
  c1 → y
  _ → z
