### PR TITLE
Fix #7576

### DIFF
--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -404,6 +404,7 @@ data UnquoteError_
   | NonCanonical_
   | PatLamWithoutClauses_
   | StaleMeta_
+  | TooManyParameters_
   | UnboundName_
   deriving (Show, Generic, Enum, Bounded)
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1832,6 +1832,11 @@ instance PrettyTCM UnquoteError where
         , pretty m <> "._" <> pretty (metaId x)
         ]
 
+    TooManyParameters npars e -> sep
+      [ fsep $ concat [ pwords "Cannot shave", [pretty npars], pwords "parameters off type" ]
+      , prettyTCM e
+      ]
+
     UnboundName x -> fsep $ pwords "Unbound name:" ++ [prettyTCM x]
 
 instance PrettyTCM MissingTypeSignatureInfo where

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -352,6 +352,7 @@ unquoteErrorName = \case
   NonCanonical                {} -> NonCanonical_
   PatLamWithoutClauses        {} -> PatLamWithoutClauses_
   StaleMeta                   {} -> StaleMeta_
+  TooManyParameters           {} -> TooManyParameters_
   UnboundName                 {} -> UnboundName_
 
 -- -- * Printing names of errors

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4820,6 +4820,8 @@ data UnquoteError
   | PatLamWithoutClauses I.Term
   | StaleMeta TopLevelModuleName MetaId
       -- ^ Attempt to unquote a serialized meta.
+  | TooManyParameters Nat A.Expr
+      -- ^ Attempt to shave of 'Nat' many parameters from function type 'A.Expr'.
   | UnboundName QName
   deriving (Show, Generic)
 

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20241015 * 10 + 0
+currentInterfaceVersion = 20241027 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -429,7 +429,9 @@ instance EmbPrj Defn where
   icod_ (PrimitiveSort a b)                             = icodeN 6 PrimitiveSort a b
   icod_ AbstractDefn{}                                  = __IMPOSSIBLE__
   icod_ (GeneralizableVar a)                            = icodeN 7 GeneralizableVar a
-  icod_ DataOrRecSig{}                                  = __IMPOSSIBLE__
+  icod_ (DataOrRecSig a)                                = icodeN 8 DataOrRecSig a
+    -- Andreas, 2024-10-27
+    -- DataOrRecSig is possible via unquoteDecl in meta-programming, see #7576
 
   value = vcase valu where
     valu [0, a]                                        = valuN Axiom a
@@ -441,6 +443,7 @@ instance EmbPrj Defn where
     valu [5, a, b, c, d, e, f]                         = valuN Primitive   a b c d e f
     valu [6, a, b]                                     = valuN PrimitiveSort a b
     valu [7, a]                                        = valuN GeneralizableVar a
+    valu [8, a]                                        = valuN DataOrRecSig a
     valu _                                             = malformed
 
 instance EmbPrj LazySplit where

--- a/test/Fail/Issue7576.agda
+++ b/test/Fail/Issue7576.agda
@@ -1,0 +1,10 @@
+-- Andreas, 2024-10-27, issue #7576
+-- reported and test case by Mario Carneiro
+
+open import Common.Reflection
+
+unquoteDecl data D =
+  declareData D 1 (quoteTerm Set)
+
+-- Expected error: [Unquote.TooManyParameters]
+-- Cannot shave 1 parameters off type Set₀

--- a/test/Fail/Issue7576.err
+++ b/test/Fail/Issue7576.err
@@ -1,0 +1,2 @@
+Issue7576.agda:6.1-7.34: error: [Unquote.TooManyParameters]
+Cannot shave 1 parameters off type Set₀

--- a/test/Succeed/Issue7576b.agda
+++ b/test/Succeed/Issue7576b.agda
@@ -1,0 +1,15 @@
+-- Andreas, 2024-10-27 issue #7576
+-- reported and testcase by Mario Carneiro
+--
+-- Just a data signature can be produced with reflection.
+-- This used to trigger an internal error during serialization.
+
+open import Common.Reflection
+
+unquoteDecl data D =
+  declareData D 0 (quoteTerm Set)
+
+-- This data type without a definition can be used like a postulate.
+
+id : D → D
+id x = x


### PR DESCRIPTION
Fix #7576, two possible `__IMPOSSIBLE__` in reflection: 
- new error `Unquote.TooManyParameters`
- allow to serialize `DataOrRecSig`
