### PR TITLE
Implement `nix build .#debug`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,14 +14,19 @@
 
       # The `agda` and `agda-mode` programs, built with `cabal build`
       # (and GHC & Haskell libraries from the nixpkgs snapshot)
-      agda-pkg = hpkgs.developPackage {
+      agda-with-opts = opts: hpkgs.developPackage {
           root = ./.;
+          cabal2nixOptions = opts;
           modifier = hlib.dontCheck;
           # TODO Make check phase work
           # At least requires:
           #   Setting AGDA_BIN (or using the Makefile, which at least requires cabal-install)
           #   Making agda-stdlib available (or disabling the relevant tests somehow)
         };
+
+      # Various builds of agda with different cabal flags set
+      agda-pkg = agda-with-opts "";
+      agda-pkg-debug = agda-with-opts "-fdebug";
 
       # Development environment with tools for hacking on agda
       agda-dev-shell = hpkgs.shellFor {
@@ -50,6 +55,7 @@
 
     in {
       packages.default = agda-pkg;        # Entry point for `nix build`
+      packages.debug   = agda-pkg-debug;  # Entry point for `nix build .#debug`
       devShells.default = agda-dev-shell; # Entry point for `nix develop`
 
       # Allow power users to set this flake's agda


### PR DESCRIPTION
This provides a short command for reproducibly building a specific revision of agda with the `-v` option enabled.

e.g.
```shellsession
$ nix build github:agda/agda/b3ee7f9#debug
```