### PR TITLE
Support x64 macos in build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
           echo exe="agda.exe"                                       >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
-        elif [[ "$MATRIX_OS" == "macos-15" ]]; then
+        elif [[ "$MATRIX_OS" == "macos-14" ]]; then
 
           filename="${bindist}-macOS-x64.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
@@ -66,7 +66,7 @@ jobs:
           echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
-        elif [[ "$MATRIX_OS" == "macos-15-arm" ]]; then
+        elif [[ "$MATRIX_OS" == "macos-14-arm" ]]; then
 
           filename="${bindist}-macOS-arm64.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
@@ -231,8 +231,8 @@ jobs:
         - '9.10'
         os:
         - windows-latest
-        - macos-15
-        - macos-15-arm64
+        - macos-14
+        - macos-14-arm64
         - ubuntu-latest
   deploy:
     if: ${{ !cancelled() }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
           echo exe="agda.exe"                                       >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
-        elif [[ "$MATRIX_OS" == "macos-14" ]]; then
+        elif [[ "$MATRIX_OS" == "macos-13" ]]; then
 
           filename="${bindist}-macOS-x64.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
@@ -66,7 +66,7 @@ jobs:
           echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
-        elif [[ "$MATRIX_OS" == "macos-14-arm" ]]; then
+        elif [[ "$MATRIX_OS" == "macos-14" ]]; then
 
           filename="${bindist}-macOS-arm64.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
@@ -232,7 +232,7 @@ jobs:
         os:
         - windows-latest
         - macos-14
-        - macos-14-arm64
+        - macos-13
         - ubuntu-latest
   deploy:
     if: ${{ !cancelled() }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
       ARGS: --disable-executable-profiling --disable-library-profiling
       LINUX_ARGS: --enable-executable-static  --enable-split-sections
       MACOS_ARGS: --flags=enable-cluster-counting
+      MATRIX_OS: ${{ matrix.os }}
       WIN64_ARGS: --flags=enable-cluster-counting  --enable-split-sections
     if: ${{ !cancelled() }}
     needs: auto-cancel
@@ -56,9 +57,18 @@ jobs:
           echo exe="agda.exe"                                       >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
-        elif [[ "$OSTYPE" == "darwin"* ]]; then
+        elif [[ "$MATRIX_OS" == "macos-15" ]]; then
 
-          filename="${bindist}-macOS.tar.xz"
+          filename="${bindist}-macOS-x64.tar.xz"
+          echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="tar -a -cvf ${filename} ${bindist}"    >> "${GITHUB_OUTPUT}"
+          echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"
+          echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
+          echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
+
+        elif [[ "$MATRIX_OS" == "macos-15-arm" ]]; then
+
+          filename="${bindist}-macOS-arm64.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
           echo compress-cmd="tar -a -cvf ${filename} ${bindist}"    >> "${GITHUB_OUTPUT}"
           echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"
@@ -221,7 +231,8 @@ jobs:
         - '9.10'
         os:
         - windows-latest
-        - macos-latest
+        - macos-15
+        - macos-15-arm64
         - ubuntu-latest
   deploy:
     if: ${{ !cancelled() }}

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         # "most canonical", since this is the deploy action.
         # As of today (2024-02-05), the actual version information can be found in
         # https://github.com/actions/runner-images#available-images
-        os: [windows-latest, macos-14, macos-14-arm64, ubuntu-latest]
+        os: [windows-latest, macos-14, macos-13, ubuntu-latest]
         ghc-ver: ['9.10']
         cabal-ver: [latest]
 
@@ -87,7 +87,7 @@ jobs:
           echo exe="agda.exe"                                       >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
-        elif [[ "$MATRIX_OS" == "macos-14" ]]; then
+        elif [[ "$MATRIX_OS" == "macos-13" ]]; then
 
           filename="${bindist}-macOS-x64.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
@@ -96,7 +96,7 @@ jobs:
           echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
-        elif [[ "$MATRIX_OS" == "macos-14-arm" ]]; then
+        elif [[ "$MATRIX_OS" == "macos-14" ]]; then
 
           filename="${bindist}-macOS-arm64.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         # "most canonical", since this is the deploy action.
         # As of today (2024-02-05), the actual version information can be found in
         # https://github.com/actions/runner-images#available-images
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-15, macos-15-arm64, ubuntu-latest]
         ghc-ver: ['9.10']
         cabal-ver: [latest]
 
@@ -53,6 +53,7 @@ jobs:
       LINUX_ARGS: "--enable-executable-static  --enable-split-sections"
       MACOS_ARGS: "--flags=enable-cluster-counting"
       WIN64_ARGS: "--flags=enable-cluster-counting  --enable-split-sections"
+      MATRIX_OS: ${{ matrix.os }}
     outputs:
       sha: ${{ steps.vars.outputs.sha }}
     runs-on: ${{ matrix.os }}
@@ -86,9 +87,18 @@ jobs:
           echo exe="agda.exe"                                       >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
-        elif [[ "$OSTYPE" == "darwin"* ]]; then
+        elif [[ "$MATRIX_OS" == "macos-15" ]]; then
 
-          filename="${bindist}-macOS.tar.xz"
+          filename="${bindist}-macOS-x64.tar.xz"
+          echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
+          echo compress-cmd="tar -a -cvf ${filename} ${bindist}"    >> "${GITHUB_OUTPUT}"
+          echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"
+          echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
+          echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
+
+        elif [[ "$MATRIX_OS" == "macos-15-arm" ]]; then
+
+          filename="${bindist}-macOS-arm64.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
           echo compress-cmd="tar -a -cvf ${filename} ${bindist}"    >> "${GITHUB_OUTPUT}"
           echo content-type="application/x-xz"                      >> "${GITHUB_OUTPUT}"

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         # "most canonical", since this is the deploy action.
         # As of today (2024-02-05), the actual version information can be found in
         # https://github.com/actions/runner-images#available-images
-        os: [windows-latest, macos-15, macos-15-arm64, ubuntu-latest]
+        os: [windows-latest, macos-14, macos-14-arm64, ubuntu-latest]
         ghc-ver: ['9.10']
         cabal-ver: [latest]
 
@@ -87,7 +87,7 @@ jobs:
           echo exe="agda.exe"                                       >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
-        elif [[ "$MATRIX_OS" == "macos-15" ]]; then
+        elif [[ "$MATRIX_OS" == "macos-14" ]]; then
 
           filename="${bindist}-macOS-x64.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"
@@ -96,7 +96,7 @@ jobs:
           echo exe="agda"                                           >> "${GITHUB_OUTPUT}"
           echo filename="${filename}"                               >> "${GITHUB_OUTPUT}"
 
-        elif [[ "$MATRIX_OS" == "macos-15-arm" ]]; then
+        elif [[ "$MATRIX_OS" == "macos-14-arm" ]]; then
 
           filename="${bindist}-macOS-arm64.tar.xz"
           echo args="${ARGS} ${MACOS_ARGS}"                         >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Related to https://github.com/agda/agda/issues/7599

The original build uses `macos-latest` which is ARM-based. The PR replaces `macos-latest` to `macos-14`(ARM64) and `macos-13`(Intel) which adds build for x64 macos

Ref: 
- https://github.com/actions/runner-images/tree/main/images/macos
- https://github.com/actions/runner-images?tab=readme-ov-file#available-images
- https://github.com/actions/runner-images/issues/9741
      
<img width="922" alt="image" src="https://github.com/user-attachments/assets/fa11fcd5-fc5a-4e2e-9605-4b5f7f8b5fa1">


