### PR TITLE
REPL: fix printing of result of `:typeOf`

### DIFF
--- a/src/full/Agda/Interaction/CommandLine.hs
+++ b/src/full/Agda/Interaction/CommandLine.hs
@@ -294,14 +294,14 @@ typeOf s =
     do  e  <- parseExpr (unwords s)
         e0 <- typeInCurrent Normalised e
         e1 <- typeInCurrent AsIs e
-        liftIO . putStrLn =<< showA e1
+        liftIO . print =<< prettyA e1
 
 typeIn :: [String] -> TCM ()
 typeIn s@(_:_:_) =
     actOnMeta s $ \i e ->
     do  e1 <- typeInMeta i Normalised e
         e2 <- typeInMeta i AsIs e
-        liftIO . putStrLn =<< showA e1
+        liftIO . print =<< prettyA e1
 typeIn _ = liftIO $ putStrLn ":typeIn meta expr"
 
 showContext :: [String] -> TCM ()

--- a/test/Interactive/Issue1430.in
+++ b/test/Interactive/Issue1430.in
@@ -1,3 +1,4 @@
 :metas
 :give 0 unit
+test
 :quit

--- a/test/Interactive/Issue1430.stdout.expected
+++ b/test/Interactive/Issue1430.stdout.expected
@@ -1,0 +1,2 @@
+?0 : Unit
+unit

--- a/test/Interactive/Naked.in
+++ b/test/Interactive/Naked.in
@@ -1,3 +1,4 @@
+:typeOf Set
 λ issue5132 → issue5132
 :metas
 :quit

--- a/test/Interactive/Naked.stdout.expected
+++ b/test/Interactive/Naked.stdout.expected
@@ -1,3 +1,4 @@
+Set₁
 λ issue5132 → issue5132
 Sort _2
 _3 : _2

--- a/test/Interactive/Tests.hs
+++ b/test/Interactive/Tests.hs
@@ -18,19 +18,6 @@ import Test.Tasty.Silver.Filter (RegexFilter (RFInclude))
 testDir :: FilePath
 testDir = "test" </> "Interactive"
 
--- | Filtering out interaction tests that require Agda built with -fdebug.
-
-fdebugTestFilter :: [RegexFilter]
-fdebugTestFilter =
--- This list was crafted using
---    grep -RP '(?<!-- ){-# OPTIONS.* -v' | grep interaction/
---  and screening the results (e.g. for comments)
-  [ disable "interaction/Debug"
-  , disable "interaction/Issue1353"
-  , disable "interaction/Positivity"
-  ]
-  where disable = RFInclude
-
 tests :: TestTree
 tests = testGroup "Interactive"
   [ testCase "Issue1430" $ do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -91,7 +91,6 @@ fdebugTestFilter = concat
   [   SUCCEED.fdebugTestFilter
   ,   FAIL.fdebugTestFilter
   ,   COMPILER.fdebugTestFilter
-  ,   INTERACTIVE.fdebugTestFilter
   ]
 
 -- | Tests with system dependencies


### PR DESCRIPTION
`:typeOf` used the `showA` function, now the `prettyA`.

Commits:
- **Fixup #7490: remove stay test.Interactive.fdebugTestFilter**
- **REPL: fix printing of result of `:typeOf`**
- **REPL: factor test/Interactive/Tests**
- **REPL: add golden value for test Issue1430**
