### PR TITLE
Refactor: eliminate uses of `Set.map`

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -423,6 +423,7 @@ library
     , bytestring           >= 0.10.10.1 && < 0.13
     , case-insensitive     >= 1.2.1.0   && < 1.3
     , containers           >= 0.6.2.1   && < 0.8
+        -- containers-0.6.3.1 adds IntSet.mapMonotonic, but its too young for GHC 8.8
     , data-hash            >= 0.2.0.1   && < 0.3
     , deepseq              >= 1.4.4.0   && < 1.6
     , directory            >= 1.3.6.0   && < 1.4

--- a/src/full/Agda/Compiler/Treeless/Subst.hs
+++ b/src/full/Agda/Compiler/Treeless/Subst.hs
@@ -102,7 +102,10 @@ data Binder a = Binder Int a
 
 instance HasFree a => HasFree (Binder a) where
   freeVars (Binder 0 x) = freeVars x
-  freeVars (Binder k x) = IntMap.filterWithKey (\ k _ -> k >= 0) $ IntMap.mapKeysMonotonic (subtract k) $ freeVars x
+  freeVars (Binder k x) = dropNeg $ IntMap.mapKeysMonotonic (subtract k) $ freeVars x
+    where
+      -- keep only elements > -1
+      dropNeg = snd . IntMap.split (-1)
 
 newtype InSeq a = InSeq a
 

--- a/src/full/Agda/Compiler/Treeless/Unused.hs
+++ b/src/full/Agda/Compiler/Treeless/Unused.hs
@@ -82,7 +82,7 @@ computeUnused q t = iterateUntilM (==) $ \ used -> do
 
     underBinder = underBinders 1
     underBinders 0 = id
-    underBinders n = VarSet.filter (>= 0) . VarSet.subtract n
+    underBinders n = VarSet.filterGE 0 . VarSet.subtract n
 
 stripUnusedArguments :: [ArgUsage] -> TTerm -> TTerm
 stripUnusedArguments used t = mkTLam m $ applySubst rho b

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -222,9 +222,9 @@ makeEnv scope = do
         , foldPatternSynonyms = foldPatSyns
         }
   where
-    defs = Set.map nameParts . Map.keysSet $
-        Map.filterWithKey usefulDef $
-        nsNames $ everythingInScope scope
+    defs = Set.fromList $ map (nameParts . fst) $
+        filter (uncurry usefulDef) $
+        Map.toList $ nsNames $ everythingInScope scope
 
     -- Jesper, 2018-12-10: It's fine to shadow generalizable names as
     -- they will never show up directly in printed terms.
@@ -443,10 +443,9 @@ chooseName x = lookupNameInScope (nameConcrete x) >>= \case
   where
     takenNames :: MonadToConcrete m => m (Set RawName)
     takenNames = do
-      ys0 <- asks takenVarNames
-      reportSLn "toConcrete.bindName" 90 $ render $ "abstract names of local vars: " <+> prettyList_ (map (C.nameToRawName . nameConcrete) $ Set.toList ys0)
-      ys <- Set.fromList . concat <$> mapM hasConcreteNames (Set.toList ys0)
-      return $ Set.map C.nameToRawName ys
+      ys0 <- Set.toList <$> asks takenVarNames
+      reportSLn "toConcrete.bindName" 90 $ render $ "abstract names of local vars: " <+> prettyList_ (map (C.nameToRawName . nameConcrete) ys0)
+      Set.fromList . map C.nameToRawName . concat <$> mapM hasConcreteNames ys0
 
 
 -- | Add a abstract name to the scope and produce an available concrete version of it.

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -50,7 +50,7 @@ instance PrecomputeFreeVars a => PrecomputeFreeVars (Dom a) where
 instance PrecomputeFreeVars a => PrecomputeFreeVars (Abs a) where
   precomputeFreeVars (NoAbs x b) = NoAbs x <$> precomputeFreeVars b
   precomputeFreeVars (Abs x b) =
-    censor (VarSet.mapMonotonic pred . VarSet.delete 0) $
+    censor (VarSet.subtract 1 . VarSet.delete 0) $
       Abs x <$> precomputeFreeVars b
 
 instance PrecomputeFreeVars Term where

--- a/src/full/Agda/Utils/VarSet.hs
+++ b/src/full/Agda/Utils/VarSet.hs
@@ -2,14 +2,14 @@
 
 {-# OPTIONS_GHC -Wunused-imports #-}
 
--- | Var field implementation of sets of (small) natural numbers.
+-- | Manage sets of natural numbers (de Bruijn indices).
 
 module Agda.Utils.VarSet
   ( VarSet
   , empty, insert, singleton, union, unions
   , fromList, toList, toAscList, toDescList
   , disjoint, isSubsetOf, member, IntSet.null
-  , delete, difference, IntSet.filter, intersection
+  , delete, difference, IntSet.filter, filterGE, intersection
   , mapMonotonic, Agda.Utils.VarSet.subtract
   )
   where
@@ -23,5 +23,10 @@ mapMonotonic :: (Int -> Int) -> VarSet -> VarSet
 mapMonotonic f = fromDistinctAscList . fmap f . toAscList
 #endif
 
+-- | Subtract from each element.
 subtract :: Int -> VarSet -> VarSet
 subtract n = mapMonotonic (Prelude.subtract n)
+
+-- | Keep only elements greater or equal to the given pivot.
+filterGE :: Int -> VarSet -> VarSet
+filterGE n = snd . IntSet.split (n - 1)

--- a/src/full/Agda/Utils/VarSet.hs
+++ b/src/full/Agda/Utils/VarSet.hs
@@ -1,14 +1,16 @@
+{-# LANGUAGE CPP #-}
+
 {-# OPTIONS_GHC -Wunused-imports #-}
 
 -- | Var field implementation of sets of (small) natural numbers.
 
 module Agda.Utils.VarSet
   ( VarSet
-  , union, unions, member, empty, delete, singleton
-  , fromList, toList, toDescList
-  , isSubsetOf, IntSet.null
-  , intersection, difference
-  , Agda.Utils.VarSet.subtract
+  , empty, insert, singleton, union, unions
+  , fromList, toList, toAscList, toDescList
+  , disjoint, isSubsetOf, member, IntSet.null
+  , delete, difference, IntSet.filter, intersection
+  , mapMonotonic, Agda.Utils.VarSet.subtract
   )
   where
 
@@ -16,44 +18,10 @@ import Data.IntSet as IntSet
 
 type VarSet = IntSet
 
-subtract :: Int -> VarSet -> VarSet
-subtract n = IntSet.map (Prelude.subtract n)
-
-{-
-import Data.Bits
-
-type VarSet = Integer
-type Var    = Integer
-
-union :: VarSet -> VarSet -> VarSet
-union = (.|.)
-
-member :: Var -> VarSet -> Bool
-member b s = testVar s (fromIntegral b)
-
-empty :: VarSet
-empty = 0
-
-delete :: Var -> VarSet -> VarSet
-delete b s = clearVar s (fromIntegral b)
-
-singleton :: Var -> VarSet
-singleton = bit
+#if !MIN_VERSION_containers(0,6,3)
+mapMonotonic :: (Int -> Int) -> VarSet -> VarSet
+mapMonotonic f = fromDistinctAscList . fmap f . toAscList
+#endif
 
 subtract :: Int -> VarSet -> VarSet
-subtract n s = shiftR s n
-
-fromList :: [Var] -> VarSet
-fromList = foldr (union . singleton . fromIntegral) empty
-
-isSubsetOf :: VarSet -> VarSet -> Bool
-isSubsetOf s1 s2 = 0 == (s1 .&. complement s2)
-
-toList :: VarSet -> [Var]
-toList s = loop 0 s
-  where
-    loop i 0 = []
-    loop i n
-      | testVar n 0 = fromIntegral i : (loop $! i + 1) (shiftR n 1)
-      | otherwise   = (loop $! i + 1) (shiftR n 1)
--}
+subtract n = mapMonotonic (Prelude.subtract n)


### PR DESCRIPTION
`Set.map f` is just `Set.fromList . fmap f . Set.toList`, so it is should only be used if there is nothing better to do than converting to a list, mapping, and reconstructing the set.
Alternatives are `mapMonotonic` and just not reconstructing the set if we anyway just iterate through it afterwards.

Since `IntSet` only got `mapMonotonic` in containers-0.6.3 (GHC 8.10), we back-port its implementation to `Agda.Utils.VarSet`.

- **optimization: replace some uses of Set.map (has to reconstruct tree!)**
- **Refactor: optimize concreteNamesInScope (avoid Set.map)**
