### PR TITLE
CI: fix Deploy: `agda --version` now needs `Agda_datadir` to exist

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -212,7 +212,7 @@ jobs:
         file "${{ steps.vars.outputs.bindist }}/bin/agda"
     - name: Display the version information
       run: |
-        ${{ steps.vars.outputs.bindist }}/bin/agda --version
+        Agda_datadir="${{ steps.vars.outputs.bindist }}/data" "${{ steps.vars.outputs.bindist }}/bin/agda" --version
     - name: Pack artefacts
       run: |
         ${{ steps.vars.outputs.compress-cmd }}

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
         # "most canonical", since this is the deploy action.
         # As of today (2024-02-05), the actual version information can be found in
         # https://github.com/actions/runner-images#available-images
+        # 2024-11-03, #7601: macos-13 for deploying Intel binary, macos-14 for ARM
         os: [windows-latest, macos-14, macos-13, ubuntu-latest]
         ghc-ver: ['9.10']
         cabal-ver: [latest]
@@ -283,7 +284,7 @@ jobs:
 
     - name: Display the version information
       run: |
-        ${{ steps.vars.outputs.bindist }}/bin/agda --version
+        Agda_datadir="${{ steps.vars.outputs.bindist }}/data" "${{ steps.vars.outputs.bindist }}/bin/agda" --version
 
     - name: Pack artefacts
       run: |


### PR DESCRIPTION
Since PR #7605, `runAgda` calls `getPrimitiveLibDir` to construct its initial state.

This PR might be superseded by
- #7608