### PR TITLE
Fixup #7605: `agda --help` now runs in plain `IO`, not in `TCM`

### DIFF
--- a/test/Succeed/PrintAgdaDir.agda
+++ b/test/Succeed/PrintAgdaDir.agda
@@ -1,0 +1,4 @@
+-- Andreas, 2024-11-11, PR #7608.
+-- Empty file for the sake of the test runner.
+--
+-- We test that `Agda_datadir=FOO agda --print-agda-dir` outputs FOO.

--- a/test/Succeed/PrintAgdaDir.flags
+++ b/test/Succeed/PrintAgdaDir.flags
@@ -1,0 +1,1 @@
+--print-agda-dir

--- a/test/Succeed/PrintAgdaDir.vars
+++ b/test/Succeed/PrintAgdaDir.vars
@@ -1,0 +1,1 @@
+Agda_datadir=this-is-a-non-existing-Agda_datadir

--- a/test/Succeed/PrintAgdaDir.warn
+++ b/test/Succeed/PrintAgdaDir.warn
@@ -1,0 +1,1 @@
+this-is-a-non-existing-Agda_datadir


### PR DESCRIPTION
Since #7605, running `TCM` now needs the `Agda_datadir` to exist.
However, the alternative modes `--help`, `--version`, `--print-agda-dir` etc. should work even if the `Agda_datadir` is setup wrongly. (In particular `--print-agda-dir` is there to debug this situation.)

Thus, the alternative modes now no longer need `TCM` to be set up. They can execute in plain `IO`.
