### PR TITLE
Re #5673: use stPrimitiveLibDir instead of gitPrimitiveLibDir

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -443,7 +443,7 @@ typeCheckMain mode src = do
 
   when loadPrims $ do
     reportSLn "import.main" 10 "Importing the primitive modules."
-    libdirPrim <- liftIO getPrimitiveLibDir
+    libdirPrim <- useTC stPrimitiveLibDir
     reportSLn "import.main" 20 $ "Library primitive dir = " ++ show libdirPrim
     -- Turn off import-chasing messages.
     -- We have to modify the persistent verbosity setting, since

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -252,12 +252,6 @@ builtinModules :: Set FilePath
 builtinModules = builtinModulesWithSafePostulates `Set.union`
                  builtinModulesWithUnsafePostulates
 
--- UNUSED:
--- -- | Determine whether the given absolute path refers to one of Agda's primitive modules.
--- --
--- classifyBuiltinModule :: MonadIO m => AbsolutePath -> m (Maybe IsBuiltinModule)
--- classifyBuiltinModule fp = liftIO getPrimitiveLibDir <&> (`classifyBuiltinModule_` fp)
-
 -- | Determine whether the second absolute path refers to one of Agda's primitive modules.
 --   The first argument should be the result of 'getPrimitiveLibDir'.
 --
@@ -268,12 +262,6 @@ classifyBuiltinModule_ primLibDir fp = do
   if f `Set.member` builtinModulesWithUnsafePostulates then return IsBuiltinModule
   else if f `Set.member` primitiveModules then return IsPrimitiveModule
   else return IsBuiltinModuleWithSafePostulates
-
--- | Strip the (absolute) 'getPrimitiveLibDir' off the given absolute 'FilePath',
---   returning the suffix if successful.
---
-stripPrimitiveLibDir :: MonadIO m => AbsolutePath -> m (Maybe FilePath)
-stripPrimitiveLibDir file = relativizeAbsolutePath file <$> liftIO getPrimitiveLibDir
 
 ------------------------------------------------------------------------
 -- * Get the libraries for the current project

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -583,6 +583,9 @@ lensFileDictBuilder = lensFileDict . lensFileDictFileDictBuilder
 lensBuiltinModuleIds :: Lens' SessionTCState BuiltinModuleIds
 lensBuiltinModuleIds = lensFileDict . lensFileDictBuiltinModuleIds
 
+lensPrimitiveLibDir :: Lens' SessionTCState PrimitiveLibDir
+lensPrimitiveLibDir = lensFileDict . lensFileDictPrimitiveLibDir
+
 -- ** Components of 'PersistentTCState'
 
 lensPersistentSession :: Lens' PersistentTCState SessionTCState
@@ -786,6 +789,9 @@ stFileDict = lensSessionState . lensFileDict
 
 stBuiltinModuleIds :: Lens' TCState BuiltinModuleIds
 stBuiltinModuleIds = lensSessionState . lensBuiltinModuleIds
+
+stPrimitiveLibDir :: Lens' TCState PrimitiveLibDir
+stPrimitiveLibDir = lensSessionState . lensPrimitiveLibDir
 
 -- ** Persistent state
 

--- a/src/full/Agda/TypeChecking/Monad/Base/Types.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base/Types.hs
@@ -111,11 +111,13 @@ data FileDictWithBuiltins = FileDictWithBuiltins
       -- ^ (Building a) translation between 'AbsolutePath' and 'FileId'.
   , builtinModuleIds :: !BuiltinModuleIds
       -- ^ For the known 'FileId's, remember whether they refer to Agda's builtin modules.
-  , primitiveLibDir  :: !AbsolutePath
+  , primitiveLibDir  :: !PrimitiveLibDir
       -- ^ The absolute path to the directory with the builtin modules.
       --   Needs to be set upon initialization.
   }
   deriving Generic
+
+type PrimitiveLibDir = AbsolutePath
 
 -- | 'SourceFile's must exist and be registered in our file dictionary.
 
@@ -138,6 +140,9 @@ lensFileDictFileDictBuilder f s = f (fileDictBuilder s) <&> \ x -> s { fileDictB
 
 lensFileDictBuiltinModuleIds :: Lens' FileDictWithBuiltins BuiltinModuleIds
 lensFileDictBuiltinModuleIds f s = f (builtinModuleIds s) <&> \ x -> s { builtinModuleIds = x }
+
+lensFileDictPrimitiveLibDir :: Lens' FileDictWithBuiltins PrimitiveLibDir
+lensFileDictPrimitiveLibDir f s = f (primitiveLibDir s) <&> \ x -> s { primitiveLibDir = x }
 
 lensPairModuleToSource :: Lens' (FileDictWithBuiltins, ModuleToSourceId) ModuleToSource
 lensPairModuleToSource = iso (uncurry ModuleToSource) (fileDict &&& moduleToSourceId)

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -292,7 +292,7 @@ setIncludeDirs incs root = do
   incs <- return $ fmap (mkAbsolute . (filePath root </>)) incs
 
   -- Andreas, 2013-10-30  Add default include dir
-  primdir <- liftIO getPrimitiveLibDir
+  primdir <- useTC stPrimitiveLibDir
       -- We add the default dir at the end, since it is then
       -- printed last in error messages.
       -- Might also be useful to overwrite default imports...


### PR DESCRIPTION
Using the cached primitive lib dir should result in fewer disk accesses.
