### PR TITLE
Fix de Bruijn indices in Treeless primitive translation

### DIFF
--- a/src/full/Agda/Compiler/Treeless/Builtin.hs
+++ b/src/full/Agda/Compiler/Treeless/Builtin.hs
@@ -94,7 +94,7 @@ transform BuiltinKit{..} = tr
         --       that it won't underflow.
 
       TApp (TDef q) (_ : _ : _ : _ : e : f : es)
-        | isForce q -> tr $ TLet e $ mkTApp (tOp PSeq (TVar 0) $ mkTApp (raise 1 f) [TVar 0]) es
+        | isForce q -> tr $ TLet e $ mkTApp (tOp PSeq (TVar 0) $ mkTApp (raise 1 f) [TVar 0]) $ raise 1 es
 
       TApp (TCon s) [e] | isSuc s ->
         case tr e of

--- a/src/full/Agda/Compiler/Treeless/Builtin.hs
+++ b/src/full/Agda/Compiler/Treeless/Builtin.hs
@@ -93,6 +93,12 @@ transform BuiltinKit{..} = tr
         --       builtin minus is monus. The simplifier will do it if it can see
         --       that it won't underflow.
 
+      -- Replace calls to primForce with the primitive seq, by binding the
+      -- forced expression to a fresh variable and weaken appropriately.
+      --
+      -- primForce e f es
+      -- >>>
+      -- let e (seq x⁰ ((raise 1 f) x⁰) (raise 1 es))
       TApp (TDef q) (_ : _ : _ : _ : e : f : es)
         | isForce q -> tr $ TLet e $ mkTApp (tOp PSeq (TVar 0) $ mkTApp (raise 1 f) [TVar 0]) $ raise 1 es
 

--- a/test/Compiler/simple/CompilePrimSeq.agda
+++ b/test/Compiler/simple/CompilePrimSeq.agda
@@ -1,0 +1,11 @@
+{-# OPTIONS -v treeless.opt.builtin:30 -v 0 #-}
+
+module CompilePrimSeq where
+
+open import Agda.Builtin.Nat using (Nat; _+_)
+open import Agda.Builtin.List using (List; []; _∷_)
+open import Agda.Builtin.Strict using (primForce)
+
+sum : Nat → List Nat → Nat
+sum acc []       = acc
+sum acc (x ∷ xs) = sum (primForce x _+_ acc) xs

--- a/test/Compiler/simple/CompilePrimSeq.options
+++ b/test/Compiler/simple/CompilePrimSeq.options
@@ -1,0 +1,9 @@
+TestOptions
+  { forCompilers =
+      [ (MAlonzo Lazy,       CompilerOptions {extraAgdaArgs = ["--no-main"]})
+      , (MAlonzo StrictData, CompilerOptions {extraAgdaArgs = ["--no-main"]})
+      , (MAlonzo Strict,     CompilerOptions {extraAgdaArgs = ["--no-main"]})
+      ]
+  , runtimeOptions = []
+  , executeProg = False
+  }

--- a/test/Compiler/simple/CompilePrimSeq.out
+++ b/test/Compiler/simple/CompilePrimSeq.out
@@ -1,0 +1,11 @@
+COMPILE_SUCCEEDED
+
+ret > ExitSuccess
+out > -- builtin translation
+out > CompilePrimSeq.sum =
+out >   λ a b →
+out >     case b of
+out >       Agda.Builtin.List.List.[] → a
+out >       Agda.Builtin.List.List._∷_ c d →
+out >         CompilePrimSeq.sum (let e = c in seq e (_+_ e) a) d
+out >

--- a/test/Compiler/simple/Word.out
+++ b/test/Compiler/simple/Word.out
@@ -28,6 +28,6 @@ out > Word.prf = _
 out > Word.prf' = _
 out > Word.main = Word.putStrLn (Word.showWord Word.test)
 out > Word.ltDouble = λ a b → 2 *64 a <64 b
-out > Word.lt4x = λ a _ → let b = 2 *64 a in seq b (Word.ltDouble b) b
+out > Word.lt4x = λ a b → let c = 2 *64 a in seq c (Word.ltDouble c) b
 out > 101
 out >


### PR DESCRIPTION
For example, this program  
```haskell
{-# OPTIONS -v treeless:40 #-}

open import Agda.Builtin.Nat using (Nat; zero; suc; _+_)
open import Agda.Builtin.List using (List; []; _∷_)
open import Agda.Builtin.Strict using (primForce)

sum : Nat → List Nat → Nat
sum acc []       = acc
sum acc (x ∷ xs) = sum (primForce x _+_ acc) xs 
```
compiles to
```haskell
-- pseq.sum
d_sum_2 :: Integer -> [Integer] -> Integer
d_sum_2 v0 v1
  = case coe v1 of
      [] -> coe v0
      (:) v2 v3
        -> coe
             d_sum_2 (coe seq (coe v2) (coe addInt (coe v2)) (coe v1)) (coe v3)
      _ -> MAlonzo.RTE.mazUnreachableError                        ^^ should be v0
```