### PR TITLE
Some refactorings of context functions

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -963,7 +963,8 @@ metaHelperType norm ii rng s = case words s of
 
     -- Konstantin, 2022-10-23: We don't want to print section parameters in helper type.
     freeVars <- getCurrentModuleFreeVars
-    contextForAbstracting <- drop freeVars . reverse <$> getContext
+    ctx <- getContext
+    let contextForAbstracting = take (size ctx - freeVars) ctx
 
     -- Andreas, 2019-10-11: I actually prefer pi-types over ->.
     let runInPrintingEnvironment = localTC (\e -> e { envPrintDomainFreePi = True, envPrintMetasBare = True })
@@ -978,8 +979,8 @@ metaHelperType norm ii rng s = case words s of
      -- We simply make exactly the given arguments visible and all other hidden.
      Just xs -> do
       let inXs = hasElem xs
-      let hideButXs dom = setHiding (if inXs $ fst $ unDom dom then NotHidden else Hidden) dom
-      let tel = telFromList . map (fmap (first nameToArgName) . hideButXs) $ contextForAbstracting
+      let hideButXs ce = setHiding (if inXs (ctxEntryName ce) then NotHidden else Hidden) ce
+      let tel = contextToTel . map hideButXs $ contextForAbstracting
       OfType' h <$> do
         runInPrintingEnvironment $ reify $ telePiVisible tel a0
 
@@ -987,7 +988,7 @@ metaHelperType norm ii rng s = case words s of
      Nothing -> do
       -- cleanupType relies on with arguments being named 'w',
       -- so we'd better rename any actual 'w's to avoid confusion.
-      let tel = runIdentity . onNamesTel unW . telFromList' nameToArgName $ contextForAbstracting
+      let tel = runIdentity . onNamesTel unW . contextToTel $ contextForAbstracting
       let a = runIdentity . onNames unW $ a0
       vtys <- mapM (\ a -> fmap (Arg (getArgInfo a) . fmap OtherType) $ inferExpr $ namedArg a) $
         List1.fromListSafe __IMPOSSIBLE__ args
@@ -1115,7 +1116,7 @@ contextOfMeta ii norm = withInteractionId ii $ do
 
   where
     mkVar :: ContextEntry -> TCM (Maybe ResponseContextEntry)
-    mkVar Dom{ domInfo = ai, unDom = (name, t) } = do
+    mkVar (CtxVar name Dom{ domInfo = ai, unDom = t }) = do
       if shouldHide ai name then return Nothing else Just <$> do
         let n = nameConcrete name
         x  <- abstractToConcrete_ name

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -119,7 +119,7 @@ parseVariables f cxt asb ii rng ss = do
   -- Step 2: Resolve each abstract name to a de Bruijn index.
 
   -- First, get context names of the clause.
-  let clauseCxtNames = map (fst . unDom) cxt
+  let clauseCxtNames = contextNames' cxt
 
   -- Valid names to split on are pattern variables of the clause,
   -- plus as-bindings that refer to a variable.
@@ -381,7 +381,7 @@ makeCase hole rng s = withInteractionId hole $ locallyTC eMakeCase (const True) 
 
     -- If any of the split variables is hidden by the ellipsis, we
     -- should force the expansion of the ellipsis.
-    let splitNames = map (\i -> fst $ unDom $ clauseCxt !! i) toSplit
+    let splitNames = map (\i -> ctxEntryName $ clauseCxt !! i) toSplit
     shouldExpandEllipsis <- return (not $ null toShow) `or2M` anyEllipsisVar f absCl splitNames
     let ell' | shouldExpandEllipsis = NoEllipsis
              | otherwise            = ell

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -1495,10 +1495,10 @@ getLocalVarTerms localCxt = do
   contextTerms <- getContextTerms
   contextTypes <- flattenTel <$> getContextTelescope
   let inScope i _ | i < localCxt = pure True   -- Ignore scope for variables we inserted ourselves
-      inScope _ Dom{ unDom = (name, _) } = do
+      inScope _ Dom{ unDom = name } = do
         x <- abstractToConcrete_ name
         pure $ C.isInScope x == C.InScope
-  scope <- mapM (uncurry inScope) . reverse . zip [0..] =<< getContext
+  scope <- mapM (uncurry inScope) =<< getContextVars
   return [ e | (True, e) <- zip scope $ zip contextTerms contextTypes ]
 
 

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -2077,6 +2077,7 @@ class LensArgInfo a where
   setArgInfo ai = mapArgInfo (const ai)
   mapArgInfo :: (ArgInfo -> ArgInfo) -> a -> a
   mapArgInfo f a = setArgInfo (f $ getArgInfo a) a
+  {-# MINIMAL getArgInfo , (setArgInfo | mapArgInfo) #-}
 
 instance LensArgInfo ArgInfo where
   getArgInfo = id

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -202,7 +202,7 @@ makeEnv scope = do
         Just v | Just q <- name v,
                  noScopeCheck b || isNameInScope q scope -> return [(b, q)]
         _                                                -> return []
-  ctxVars <- map (fst . I.unDom) <$> asksTC envContext
+  ctxVars <- getContextNames'
   letVars <- Map.keys <$> asksTC envLetBindings
   let vars = ctxVars ++ letVars
 

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1571,6 +1571,18 @@ instance Reify i => Reify (Dom i) where
     reify (Dom{domInfo = info, unDom = i}) = Arg info <$> reify i
     {-# INLINE reify #-}
 
+
+instance Reify ContextEntry where
+  type ReifiesTo ContextEntry = A.TypedBinding
+
+  reify (CtxVar x a) = do
+    Arg info (y,t) <- reify $ (x,) <$> a
+    let r = getRange x
+        name = domName a
+        xs = singleton $ Arg info $ Named name $ A.mkBinder_ y
+    tac <- TacticAttribute <$> do traverse (Ranged noRange <.> reify) $ domTactic a
+    return $ TBind r (TypedBindingInfo tac (domIsFinite a)) xs t
+
 instance Reify i => Reify (I.Elim' i)  where
   type ReifiesTo (I.Elim' i) = I.Elim' (ReifiesTo i)
 

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -123,7 +123,7 @@ toAbstractWithoutImplicit ::
   , HasConstInfo m
   ) => r -> m (AbsOfRef r)
 toAbstractWithoutImplicit x = do
-  xs <- killRange <$> getContextNames
+  xs <- killRange <$> getContextNames'
   let ctx = zip xs $ repeat R.Unknown
   runReaderT (toAbstract x) ctx
 

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -535,8 +535,8 @@ termRecTel npars tel = do
       extract $ telFromList fields
   where
   -- create n variable patterns
-  mkPats n  = zipWith mkPat (downFrom n) <$> getContextNames
-  mkPat i x = notMasked $ VarP defaultPatternInfo $ DBPatVar (prettyShow x) i
+  mkPats n  = map mkPat <$> getContextVars
+  mkPat (i, x) = notMasked $ VarP defaultPatternInfo $ DBPatVar (prettyShow x) i
 
 -- | Collect calls in type signature @f : (x1:A1)...(xn:An) -> B@.
 --   It is treated as if there were the additional function clauses.
@@ -564,8 +564,8 @@ termType = return mempty
         extract dom `mappend` underAbstractionAbs dom absB (loop $! n + 1)
 
   -- create n variable patterns
-  mkPats n  = zipWith mkPat (downFrom n) <$> getContextNames
-  mkPat i x = notMasked $ VarP defaultPatternInfo $ DBPatVar (prettyShow x) i
+  mkPats n  = map mkPat <$> getContextVars
+  mkPat (i, x) = notMasked $ VarP defaultPatternInfo $ DBPatVar (prettyShow x) i
 
 -- | Mask arguments and result for termination checking
 --   according to type of function.

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -2117,7 +2117,7 @@ forallFaceMaps t kb k = do
       let t = foldr (\ x r -> and `apply` [argN x,argN r]) io ts
       ifBlocked t blocked unblocked
     addBindings [] m = m
-    addBindings ((Dom{domInfo = info,unDom = (nm,ty)},t):bs) m = addLetBinding info Inserted nm t ty (addBindings bs m)
+    addBindings ((CtxVar nm Dom{domInfo = info,unDom = ty},t):bs) m = addLetBinding info Inserted nm t ty (addBindings bs m)
 
     substContextN :: MonadConversion m => Context -> [(Int,Term)] -> m (Context , Substitution)
     substContextN c [] = return (c, idS)

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -177,9 +177,9 @@ generalizeTelescope vars typecheckAction ret = billTo [Typing, Generalize] $ wit
   let s = Map.keysSet vars
   ((cxtNames, tel, letbinds), namedMetas, allmetas) <-
     createMetasAndTypeCheck s $ typecheckAction $ \ tel -> do
-      cxt <- take (size tel) <$> getContext
+      xs <- take (size tel) <$> getContextNames
       lbs <- getLetBindings -- This gives let-bindings valid in the current context
-      return (map (fst . unDom) cxt, tel, lbs)
+      return (xs, tel, lbs)
 
   reportSDoc "tc.generalize.metas" 60 $ vcat
     [ "open metas =" <+> (text . show . fmap ((miNameSuggestion &&& miGeneralizable) . mvInfo)) (openMetas $ allmetas)
@@ -196,16 +196,17 @@ generalizeTelescope vars typecheckAction ret = billTo [Typing, Generalize] $ wit
   -- level of contexts (as a Context -> Context function), so we repeat the name logic here. Take
   -- care to preserve the name of named generalized variables.
   let setName name d = first (const name) <$> d
-      cxtEntry (mname, d) = do
+      cxtEntry (mname, dom) = do
+          let s = fst $ unDom dom
           name <- maybe (setNotInScope <$> freshName_ s) return mname
-          return $ setName name d
-        where s  = fst $ unDom d
+          return $ CtxVar name (snd <$> dom)
       dropCxt err = updateContext (strengthenS err 1) (drop 1)
   genTelCxt <- dropCxt __IMPOSSIBLE__ $ mapM cxtEntry $ reverse $ zip genTelVars $ telToList genTel
 
   -- For the explicit module telescope we get the names from the typecheck
   -- action.
-  let newTelCxt = zipWith setName cxtNames $ reverse $ telToList tel'
+  let newTelCxt :: [ContextEntry]
+      newTelCxt = zipWith CtxVar cxtNames $ reverse $ map (fmap snd) $ telToList tel'
 
   -- We are in context Γ (r : R) and should call the continuation in context Γ Δ Θρ passing it Δ Θρ
   -- We have
@@ -663,10 +664,10 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
         -- current context and generate fresh ones for the generalized variables in Θ.
         (newCxt, rΘ) <- do
           (rΔ, _ : rΓ) <- splitAt i <$> getContext
-          let setName = traverse $ \ (s, ty) -> (,ty) <$> freshName_ s
+          let setName dom@(Dom {unDom = (s,ty)}) = CtxVar <$> freshName_ s <*> (pure $ dom $> ty)
           rΘ <- mapM setName $ reverse $ telToList _Θγ
-          let rΔσ = zipWith (\ name dom -> first (const name) <$> dom)
-                            (map (fst . unDom) rΔ)
+          let rΔσ = zipWith (\ name dom -> CtxVar name (snd <$> dom))
+                            (map ctxEntryName rΔ)
                             (reverse $ telToList _Δσ)
           return (rΔσ ++ rΘ ++ rΓ, rΘ)
 
@@ -718,7 +719,7 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
                       permute (takeP n $ mvPermutation mv) $
                       downFrom n
       case [ i
-           | (i, Dom{unDom = (_, El _ (Def q _))}) <- zip [0..] cxt
+           | (i, CtxVar _ (Dom{unDom = (El _ (Def q _))})) <- zip [0..] cxt
            , q == genRecName
            , i `IntSet.member` notPruned
            ] of
@@ -804,7 +805,7 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
         ]
 
     addNamedVariablesToScope cxt =
-      forM_ cxt $ \ Dom{ unDom = (x, _) } -> do
+      forM_ cxt $ \ (CtxVar x _) -> do
         -- Recognize named variables by lack of '.' (TODO: hacky!)
         reportSLn "tc.generalize.eta.scope" 40 $ "Adding (or not) " ++ prettyShow (nameConcrete x) ++ " to the scope"
         when ('.' `notElem` prettyShow (nameConcrete x)) $ do

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -177,7 +177,7 @@ generalizeTelescope vars typecheckAction ret = billTo [Typing, Generalize] $ wit
   let s = Map.keysSet vars
   ((cxtNames, tel, letbinds), namedMetas, allmetas) <-
     createMetasAndTypeCheck s $ typecheckAction $ \ tel -> do
-      xs <- take (size tel) <$> getContextNames
+      xs <- take (size tel) <$> getContextNames'
       lbs <- getLetBindings -- This gives let-bindings valid in the current context
       return (xs, tel, lbs)
 

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -83,11 +83,11 @@ initialInstanceCandidates blockOverlap instTy = do
       return (Left b)
     OutputTypeVar -> do
       reportSDoc "tc.instance.cands" 30 $ "Instance type is a variable. "
-      runBlocked (getContextVars Nothing)
+      runBlocked (getContextCands Nothing)
     OutputTypeName n -> Bench.billTo [Bench.Typing, Bench.InstanceSearch, Bench.InitialCandidates] do
       reportSDoc "tc.instance.cands" 30 $ "Found instance type head: " <+> prettyTCM n
       runBlocked do
-        local  <- getContextVars (Just n)
+        local  <- getContextCands (Just n)
         global <- getScopeDefs n
         lift $ tickCandidates n $ length local + length global
         pure $ local <> global
@@ -109,19 +109,19 @@ initialInstanceCandidates blockOverlap instTy = do
         (fromIntegral size)
 
     -- get a list of variables with their type, relative to current context
-    getContextVars :: Maybe QName -> BlockT TCM [Candidate]
-    getContextVars cls = do
+    getContextCands :: Maybe QName -> BlockT TCM [Candidate]
+    getContextCands cls = do
       ctx <- getContext
       reportSDoc "tc.instance.cands" 40 $ hang "Getting candidates from context" 2 (inTopContext $ prettyTCM $ PrettyContext ctx)
           -- Context variables with their types lifted to live in the full context
-      let varsAndRaisedTypes = [ (var i, raise (i + 1) t) | (i, t) <- zip [0..] ctx ]
+      let varsAndRaisedTypes = reverse $ zip (contextTerms ctx) (flattenTel $ contextToTel ctx)
           vars = [ Candidate LocalCandidate x t (infoOverlapMode info)
-                 | (x, Dom{domInfo = info, unDom = (_, t)}) <- varsAndRaisedTypes
+                 | (x, Dom{domInfo = info, unDom = t}) <- varsAndRaisedTypes
                  , isInstance info
                  ]
 
       -- {{}}-fields of variables are also candidates
-      let cxtAndTypes = [ (LocalCandidate, x, t) | (x, Dom{unDom = (_, t)}) <- varsAndRaisedTypes ]
+      let cxtAndTypes = [ (LocalCandidate, x, t) | (x, Dom{unDom = t}) <- varsAndRaisedTypes ]
       fields <- concat <$> mapM instanceFields (reverse cxtAndTypes)
       reportSDoc "tc.instance.fields" 30 $
         if null fields then "no instance field candidates" else

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -70,8 +70,8 @@ checkLockedVars t ty lk lk_ty = catchConstraint (CheckLockedVars t ty lk lk_ty) 
     earlierVars = ISet.fromList [i + 1 .. size cxt - 1]
   if termVars `ISet.isSubsetOf` earlierVars then return () else do
 
-  checked <- fmap catMaybes . forM toCheck $ \ (j,dom) -> do
-    ifM (isTimeless (snd . unDom $ dom))
+  checked <- fmap catMaybes . forM toCheck $ \ (j,ce) -> do
+    ifM (isTimeless (ctxEntryType ce))
         (return $ Just j)
         (return $ Nothing)
 
@@ -99,7 +99,7 @@ getLockVar lk = do
     fv = freeVarsIgnore IgnoreInAnnotations lk
     flex = flexibleVars fv
 
-    isLock i = fmap (getLock . domInfo) (lookupBV i) <&> \case
+    isLock i = fmap (getLock . domInfo) (domOfBV i) <&> \case
       IsLock{} -> True
       IsNotLock{} -> False
 

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -439,10 +439,10 @@ newQuestionMark' new ii cmp t = lookupInteractionMeta ii >>= \case
     -- we base our decisions on the names of the context entries.
     -- Ideally, Agda would organize contexts in ancestry trees
     -- with substitutions to move between parent and child.
-    let glen = length gamma
-    let dlen = length delta
-    let gxs  = map (fst . unDom) gamma
-    let dxs  = map (fst . unDom) delta
+    let gxs  = contextNames' gamma
+    let dxs  = contextNames' delta
+    let glen = length gxs
+    let dlen = length dxs
     reportSDoc "tc.interaction" 20 $ vcat
       [ "reusing meta"
       , nest 2 $ "creation context:" <+> pretty gxs
@@ -515,7 +515,7 @@ newQuestionMark' new ii cmp t = lookupInteractionMeta ii >>= \case
         let numFields = glen - g1len - g0len
         if numFields <= 0 then return $ vs1 ++ vs0 else do
           -- Get the record type.
-          let t = snd . unDom . fromMaybe __IMPOSSIBLE__ $ delta !!! k
+          let t = (unDom . ctxEntryDom) $ fromMaybe __IMPOSSIBLE__ $ delta !!! k
           -- Get the record field names.
           fs <- getRecordTypeFields t
           -- Field arguments to the original meta are projections from the record var.
@@ -524,7 +524,7 @@ newQuestionMark' new ii cmp t = lookupInteractionMeta ii >>= \case
           return $ vs1 ++ reverse (take numFields vfs) ++ vs0
 
     -- Use ArgInfo from Γ.
-    let args = reverse $ zipWith (<$) rev_args $ map argFromDom gamma
+    let args = zipWith (<$) (reverse rev_args) $ contextArgs gamma
     -- Take the permutation into account (see TC.Monad.MetaVars.getMetaContextArgs).
     let vs = permute (takeP (length args) p) args
     reportSDoc "tc.interaction" 20 $ vcat
@@ -1073,7 +1073,7 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
             let earlierThan l j = j > l
             TelV tel' _ <- telViewUpToPath (length args) t
             forM_ ids $ \(i,u) -> do
-              d <- lookupBV i
+              d <- domOfBV i
               case getLock (getArgInfo d) of
                 IsNotLock -> pure ()
                 IsLock{} -> do

--- a/src/full/Agda/TypeChecking/Monad/Base/Types.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base/Types.hs
@@ -25,13 +25,30 @@ import Agda.Utils.FileName            as X ( AbsolutePath )
 import Agda.Utils.Lens                ( Lens', (&&&), iso )
 import Agda.Utils.Null                ( Null(..) )
 
+import Agda.Syntax.Internal
+import Agda.Syntax.Common (LensArgInfo(..), LensModality, LensRelevance, LensCohesion, LensOrigin, LensQuantity, LensHiding)
+
 ---------------------------------------------------------------------------
 -- * Context
 ---------------------------------------------------------------------------
 
 -- | The @Context@ is a stack of 'ContextEntry's.
 type Context      = [ContextEntry]
-type ContextEntry = Dom (Name, Type)
+data ContextEntry = CtxVar Name (Dom Type)
+  deriving (Show, Generic)
+
+instance LensArgInfo ContextEntry where
+  getArgInfo (CtxVar _ a) = getArgInfo a
+  mapArgInfo f (CtxVar x a) = CtxVar x $ mapArgInfo f a
+
+instance LensModality ContextEntry where
+instance LensRelevance ContextEntry where
+instance LensCohesion ContextEntry where
+instance LensOrigin ContextEntry where
+instance LensQuantity ContextEntry where
+instance LensHiding ContextEntry where
+
+instance NFData ContextEntry
 
 ---------------------------------------------------------------------------
 -- * Conversion

--- a/src/full/Agda/TypeChecking/Monad/Base/Types.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base/Types.hs
@@ -25,30 +25,35 @@ import Agda.Utils.FileName            as X ( AbsolutePath )
 import Agda.Utils.Lens                ( Lens', (&&&), iso )
 import Agda.Utils.Null                ( Null(..) )
 
-import Agda.Syntax.Internal
-import Agda.Syntax.Common (LensArgInfo(..), LensModality, LensRelevance, LensCohesion, LensOrigin, LensQuantity, LensHiding)
+import Agda.Syntax.Internal           ( Dom, Name, Type )
+import Agda.Syntax.Common
+  ( LensArgInfo(..), LensCohesion, LensHiding, LensModality, LensOrigin, LensQuantity, LensRelevance )
 
 ---------------------------------------------------------------------------
 -- * Context
 ---------------------------------------------------------------------------
 
 -- | The @Context@ is a stack of 'ContextEntry's.
-type Context      = [ContextEntry]
-data ContextEntry = CtxVar Name (Dom Type)
+type Context = [ContextEntry]
+
+data ContextEntry
+  = CtxVar
+    { ceName :: Name
+    , ceType :: Dom Type
+    }
+  -- N.B. 2024-11-29 there might be CtxLet in the future.
   deriving (Show, Generic)
 
 instance LensArgInfo ContextEntry where
   getArgInfo (CtxVar _ a) = getArgInfo a
   mapArgInfo f (CtxVar x a) = CtxVar x $ mapArgInfo f a
 
-instance LensModality ContextEntry where
-instance LensRelevance ContextEntry where
-instance LensCohesion ContextEntry where
-instance LensOrigin ContextEntry where
-instance LensQuantity ContextEntry where
-instance LensHiding ContextEntry where
-
-instance NFData ContextEntry
+instance LensModality  ContextEntry
+instance LensRelevance ContextEntry
+instance LensCohesion  ContextEntry
+instance LensOrigin    ContextEntry
+instance LensQuantity  ContextEntry
+instance LensHiding    ContextEntry
 
 ---------------------------------------------------------------------------
 -- * Conversion
@@ -192,6 +197,7 @@ data NamedMeta = NamedMeta
 
 -- NFData instances
 
+instance NFData ContextEntry
 instance NFData FileDictWithBuiltins
 instance NFData SourceFile
 instance NFData IsBuiltinModule

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -431,7 +431,7 @@ getLetBindings = do
   forM (Map.toList bs) $ \ (n, o) -> (,) n <$> getOpen o
 
 -- | Add a let bound variable
-{-# SPECIALIZE addLetBinding' :: Origin -> Name -> Term -> Dom Type -> TCM a -> TCM a #-}
+{-# SPECIALIZE defaultAddLetBinding' :: Origin -> Name -> Term -> Dom Type -> TCM a -> TCM a #-}
 defaultAddLetBinding' :: (ReadTCState m, MonadTCEnv m) => Origin -> Name -> Term -> Dom Type -> m a -> m a
 defaultAddLetBinding' o x v t ret = do
     vt <- makeOpen $ LetBinding o v t

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -464,15 +464,15 @@ getContext = asksTC envContext
 
 -- | Get the size of the current context.
 {-# SPECIALIZE getContextSize :: TCM Nat #-}
-getContextSize :: (Applicative m, MonadTCEnv m) => m Nat
+getContextSize :: (MonadTCEnv m) => m Nat
 getContextSize = length <$> getContext
 
 {-# SPECIALIZE getContextVars :: TCM [(Int, Dom Name)] #-}
-getContextVars :: (Applicative m, MonadTCEnv m) => m [(Int, Dom Name)]
+getContextVars :: (MonadTCEnv m) => m [(Int, Dom Name)]
 getContextVars = contextVars <$> getContext
 
 {-# SPECIALIZE getContextVars' :: TCM [(Int, Dom Name)] #-}
-getContextVars' :: (Applicative m, MonadTCEnv m) => m [(Int, Dom Name)]
+getContextVars' :: (MonadTCEnv m) => m [(Int, Dom Name)]
 getContextVars' = contextVars' <$> getContext
 
 contextVars :: Context -> [(Int, Dom Name)]
@@ -485,7 +485,7 @@ contextVars' = zipWith mkVar [0..]
 
 -- | Generate @[var (n - 1), ..., var 0]@ for all bound variables in the context.
 {-# SPECIALIZE getContextArgs :: TCM Args #-}
-getContextArgs :: (Applicative m, MonadTCEnv m) => m Args
+getContextArgs :: (MonadTCEnv m) => m Args
 getContextArgs = contextArgs <$> getContext
 
 contextArgs :: Context -> Args
@@ -493,7 +493,7 @@ contextArgs = map (\(i,x) -> var i <$ argFromDom x) . contextVars
 
 -- | Generate @[var (n - 1), ..., var 0]@ for all declarations in the context.
 {-# SPECIALIZE getContextTerms :: TCM [Term] #-}
-getContextTerms :: (Applicative m, MonadTCEnv m) => m [Term]
+getContextTerms :: (MonadTCEnv m) => m [Term]
 getContextTerms = map unArg <$> getContextArgs
 
 contextTerms :: Context -> [Term]
@@ -501,7 +501,7 @@ contextTerms = map unArg . contextArgs
 
 -- | Get the current context as a 'Telescope'.
 {-# SPECIALIZE getContextTelescope :: TCM Telescope #-}
-getContextTelescope :: (Applicative m, MonadTCEnv m) => m Telescope
+getContextTelescope :: (MonadTCEnv m) => m Telescope
 getContextTelescope = contextToTel <$> getContext
 
 contextToTel :: Context -> Telescope
@@ -512,11 +512,11 @@ contextToTel = go . reverse
 
 -- | Get the names of all declarations in the context.
 {-# SPECIALIZE getContextNames :: TCM [Name] #-}
-getContextNames :: (Applicative m, MonadTCEnv m) => m [Name]
+getContextNames :: (MonadTCEnv m) => m [Name]
 getContextNames = contextNames <$> getContext
 
 {-# SPECIALIZE getContextNames' :: TCM [Name] #-}
-getContextNames' :: (Applicative m, MonadTCEnv m) => m [Name]
+getContextNames' :: (MonadTCEnv m) => m [Name]
 getContextNames' = contextNames' <$> getContext
 
 contextNames :: Context -> [Name]
@@ -555,19 +555,19 @@ ctxEntryType :: ContextEntry -> Type
 ctxEntryType = unDom . ctxEntryDom
 
 {-# SPECIALIZE domOfBV :: Nat -> TCM (Dom Type) #-}
-domOfBV :: (Applicative m, MonadDebug m, MonadTCEnv m) => Nat -> m (Dom Type)
+domOfBV :: (MonadDebug m, MonadTCEnv m) => Nat -> m (Dom Type)
 domOfBV n = ctxEntryDom <$> lookupBV n
 
 {-# SPECIALIZE typeOfBV :: Nat -> TCM Type #-}
-typeOfBV :: (Applicative m, MonadDebug m, MonadTCEnv m) => Nat -> m Type
+typeOfBV :: (MonadDebug m, MonadTCEnv m) => Nat -> m Type
 typeOfBV i = unDom <$> domOfBV i
 
 {-# SPECIALIZE nameOfBV' :: Nat -> TCM (Maybe Name) #-}
-nameOfBV' :: (Applicative m, MonadDebug m, MonadTCEnv m) => Nat -> m (Maybe Name)
+nameOfBV' :: (MonadTCEnv m) => Nat -> m (Maybe Name)
 nameOfBV' n = fmap ctxEntryName <$> lookupBV' n
 
 {-# SPECIALIZE nameOfBV :: Nat -> TCM Name #-}
-nameOfBV :: (Applicative m, MonadDebug m, MonadTCEnv m) => Nat -> m Name
+nameOfBV :: (MonadDebug m, MonadTCEnv m) => Nat -> m Name
 nameOfBV n = ctxEntryName <$> lookupBV n
 
 -- | Get the term corresponding to a named variable. If it is a lambda bound

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -1255,11 +1255,11 @@ instantiateDef
 instantiateDef d = do
   vs  <- freeVarsToApply $ defName d
   verboseS "tc.sig.inst" 30 $ do
-    ctx <- getContext
+    ctx <- getContextNames
     m   <- currentModule
     reportSDoc "tc.sig.inst" 30 $
       "instDef in" <+> pretty m <> ":" <+> pretty (defName d) <+>
-      fsep (map pretty $ zipWith (<$) (reverse $ map (fst . unDom) ctx) vs)
+      fsep (map pretty $ zipWith (<$) ctx vs)
   return $ d `apply` vs
 
 instantiateRewriteRule :: (Functor m, HasConstInfo m, HasOptions m,

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -409,7 +409,7 @@ instance PrettyTCM Telescope where
 newtype PrettyContext = PrettyContext Context
 
 instance PrettyTCM PrettyContext where
-  prettyTCM (PrettyContext ctx) = prettyTCM $ telFromList' nameToArgName $ reverse ctx
+  prettyTCM (PrettyContext ctx) = prettyTCM $ contextToTel ctx
 {-# SPECIALIZE prettyTCM :: PrettyContext -> TCM Doc #-}
 
 instance PrettyTCM a => PrettyTCM (Pattern' a) where

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1523,6 +1523,9 @@ instance (Subst a, InstantiateFull a) => InstantiateFull (Abs a) where
 instance (InstantiateFull t, InstantiateFull e) => InstantiateFull (Dom' t e) where
     instantiateFull' (Dom i n b tac x) = Dom i n b <$> instantiateFull' tac <*> instantiateFull' x
 
+instance InstantiateFull ContextEntry where
+  instantiateFull' (CtxVar x a) = CtxVar x <$> instantiateFull' a
+
 instance InstantiateFull LetBinding where
   instantiateFull' (LetBinding o v t) = LetBinding o <$> instantiateFull' v <*> instantiateFull' t
 

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -373,7 +373,7 @@ instance Match NLPat Term where
         v -> maybeBlock v
       PBoundVar i ps -> case v of
         Var i' es | i == i' -> do
-          let ti = maybe __IMPOSSIBLE__ (snd . unDom) $ lookupBV_ i k
+          let ti = maybe __IMPOSSIBLE__ (unDom . ctxEntryDom) $ lookupBV_ i k
           match r gamma k (ti , Var i) ps es
         _ | Pi a b <- unEl t -> do
           let ai    = domInfo a
@@ -395,7 +395,7 @@ instance Match NLPat Term where
         tellEq gamma k t u v
 
 extendContext :: MonadAddContext m => Context -> ArgName -> Dom Type -> m Context
-extendContext cxt x a = withFreshName empty x \ y -> return $ fmap (y,) a : cxt
+extendContext cxt x a = withFreshName empty x \ y -> return $ CtxVar y a : cxt
 
 
 makeSubstitution :: Telescope -> Sub -> Maybe Substitution

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -694,7 +694,7 @@ checkClause
 
 checkClause t withSubAndLets c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats rhs0 wh catchall) = do
   let withSub       = fst <$> withSubAndLets
-  cxtNames <- reverse . map (fst . unDom) <$> getContext
+  cxtNames <- getContextNames
   checkClauseLHS t withSub c $ \ lhsResult@(LHSResult npars delta ps absurdPat trhs patSubst asb psplit ixsplit) -> do
 
     let installInheritedLets k

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -565,7 +565,7 @@ computeLHSContext = go [] []
     go cxt _ []        EmptyTel = return cxt
     go cxt taken (x : xs) tel0@(ExtendTel a tel) = do
         name <- maybe (dummyName taken $ absName tel) return x
-        let e = (name,) <$> a
+        let e = CtxVar name a
         go (e : cxt) (name : taken) xs (absBody tel)
 
     dummyName taken s =
@@ -661,10 +661,10 @@ checkLeftHandSide call lhsRng f ps a withSub' strippedPats =
   -- To allow module parameters to be refined by matching, we're adding the
   -- context arguments as wildcard patterns and extending the type with the
   -- context telescope.
-  cxt <- map (setOrigin Inserted) . reverse <$> getContext
-  let tel = telFromList' prettyShow cxt
-      cps = [ unnamed . A.VarP . A.mkBindName . fst <$> argFromDom d
-            | d <- cxt ]
+  cxt <- map (setOrigin Inserted) <$> getContext
+  let tel = contextToTel cxt
+      cps = [ argFromDom dom $> unnamed (A.VarP $ A.mkBindName $ unDom dom)
+            | (_,dom) <- contextVars cxt ]
       eqs0 = zipWith3 ProblemEq (map namedArg cps) (map var $ downFrom $ size tel) (flattenTel tel)
 
   let finalChecks :: LHSState a -> TCM a

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -363,7 +363,7 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
           -- See test/Succeed/ProjectionsTakeModuleTelAsParameters.agda.
           tel' <- do
             r <- headWithDefault __IMPOSSIBLE__ <$> getContext
-            return $ telFromList' nameToArgName $ reverse $ r : params
+            return $ contextToTel $ r : params
           setModuleCheckpoint m
           checkRecordProjections m name hasNamedCon con tel' ftel fields
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1710,7 +1710,7 @@ checkLetBinding' b@(A.LetPatBind i p e) ret = do
         -- and relevances.
         let infos = map domInfo tsl
         -- We get list of names of the let-bound vars from the context.
-        let xs   = map (fst . unDom) (reverse binds)
+        let xs   = map ctxEntryName $ reverse binds
         -- We add all the bindings to the context.
         foldr (uncurry4 $ flip addLetBinding UserWritten) ret $ List.zip4 infos xs sigma ts
 

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -137,7 +137,7 @@ checkSizeVarNeverZero i = do
   -- Looking for the minimal value for size variable i,
   -- we can restrict to the last i
   -- entries, as only these can contain i in an upper bound.
-  ts <- map (snd . unDom) . take i <$> getContext
+  ts <- map ctxEntryType . take i <$> getContext
   -- If we encountered a blocking meta in the context, we cannot
   -- say ``no'' for sure.
   (n, blockers) <- runWriterT $ minSizeValAux ts $ repeat 0

--- a/src/full/Agda/TypeChecking/SizedTypes/Pretty.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Pretty.hs
@@ -8,7 +8,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad.Base.Types
 import Agda.TypeChecking.Monad.Builtin (HasBuiltins, builtinSizeInf, getBuiltin')
-import Agda.TypeChecking.Monad.Context (unsafeModifyContext)
+import Agda.TypeChecking.Monad.Context (unsafeModifyContext, contextNames)
 import Agda.TypeChecking.Monad.SizedTypes
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.SizedTypes.Syntax
@@ -42,7 +42,7 @@ instance PrettyTCM (SizeConstraint) where
 instance PrettyTCM HypSizeConstraint where
   prettyTCM (HypSizeConstraint cxt _ hs c) =
     unsafeModifyContext (const cxt) $ do
-      let cxtNames = reverse $ map (fst . unDom) cxt
+      let cxtNames = contextNames cxt
       -- text ("[#cxt=" ++ show (size cxt) ++ "]") <+> do
       prettyList (map prettyTCM cxtNames) <+> do
         applyUnless (null hs)

--- a/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
@@ -327,11 +327,11 @@ castConstraintToCurrentContext c = do
           (do
             -- We are not in a descendant of the constraint checkpoint.
             -- Here be dragons!!
-            gamma <- asksTC envContext -- The target context
-            let findInGamma (Dom {unDom = (x, t)}) =
+            gamma <- getContext -- The target context
+            let findInGamma ce =
                   -- match by name (hazardous)
                   -- This is one of the seven deadly sins (not respecting alpha).
-                  List.findIndex ((x ==) . fst . unDom) gamma
+                  List.findIndex (((==) `on` ctxEntryName) ce) gamma
             let delta = envContext $ clEnv cl
                 cand  = map findInGamma delta
             -- The domain of our substitution
@@ -573,16 +573,16 @@ getSizeHypotheses gamma = unsafeModifyContext (const gamma) $ do
   caseMaybe msizelt (return []) $ \ sizelt -> do
     -- Traverse the context from newest to oldest de Bruijn Index
     catMaybes <$> do
-      forM (zip [0..] gamma) $ \ (i, ce) -> do
-        -- Get name and type of variable i.
-        let (x, t) = unDom ce
-            s      = prettyShow x
-        t <- reduce . raise (1 + i) . unEl $ t
-        case t of
-          Def d [Apply u] | d == sizelt -> do
-            caseMaybeM (sizeExpr $ unArg u) (return Nothing) $ \ a ->
-              return $ Just $ (i, Constraint (Rigid (NamedRigid s i) 0) Lt a)
-          _ -> return Nothing
+      forM (zip [0..] gamma) $ \case
+        (i, CtxVar x a) -> do
+          -- Get name and type of variable i.
+          let s = prettyShow x
+          t <- reduce . raise (1 + i) . unEl . unDom $ a
+          case t of
+            Def d [Apply u] | d == sizelt -> do
+              caseMaybeM (sizeExpr $ unArg u) (return Nothing) $ \ a ->
+                return $ Just $ (i, Constraint (Rigid (NamedRigid s i) 0) Lt a)
+            _ -> return Nothing
 
 -- | Convert size constraint into form where each meta is applied
 --   to indices @n-1,...,1,0@ where @n@ is the arity of that meta.

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1080,6 +1080,10 @@ instance Subst LetBinding where
   type SubstArg LetBinding = Term
   applySubst rho (LetBinding o v t) = LetBinding o (applySubst rho v) (applySubst rho t)
 
+instance Subst ContextEntry where
+  type SubstArg ContextEntry = Term
+  applySubst rho (CtxVar x a)   = CtxVar x $ applySubst rho a
+
 instance Subst a => Subst (Maybe a) where
   type SubstArg (Maybe a) = SubstArg a
 

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -15,7 +15,6 @@ import Data.Maybe
 import Data.Monoid
 
 import Agda.Syntax.Common
-import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
 
@@ -174,11 +173,7 @@ permuteTel perm tel =
 -- | Like 'permuteTel', but start with a context.
 --
 permuteContext :: Permutation -> Context -> Telescope
-permuteContext perm ctx = unflattenTel names types
-  where
-    flatTel = flattenContext ctx
-    names   = permute perm $ map (prettyShow . fst . unDom) flatTel
-    types   = permute perm $ renameP impossible (flipP perm) $ map (fmap snd) flatTel
+permuteContext perm ctx = permuteTel perm $ contextToTel ctx
 
 -- | Recursively computes dependencies of a set of variables in a given
 --   telescope. Any dependencies outside of the telescope are ignored.

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -14,7 +14,7 @@ import Control.Monad.Trans    ( lift )
 import Data.Char
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -108,7 +108,7 @@ packUnquoteM f = ReaderT $ \ cxt -> StateT $ \ s -> WriterT $ ExceptT $ f cxt s
 
 runUnquoteM :: UnquoteM a -> TCM (Either UnquoteError (a, [QName]))
 runUnquoteM m = do
-  cxt <- asksTC envContext
+  cxt <- getContext
   s   <- getTC
   pid <- fresh  -- Create a fresh problem for the unquote call. Used in tcSolveInstances.
   z   <- localTC (\ e -> e { envUnquoteProblem = Just pid })
@@ -865,12 +865,12 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
     tcGetContext :: UnquoteM Term
     tcGetContext = liftTCM $ do
       r <- isReconstructed
-      as <- map (nameToArgName . fst . unDom &&& fmap snd) <$> getContext
+      let getVar (CtxVar x a) = (nameToArgName x, a)
+      as <- map getVar <$> getContext
       as <- etaContract =<< process as
       if r then do
         as <- recons (reverse as)
-        let as' = reverse as
-        locallyReconstructed $ buildList <*> mapM quoteDomWithName as'
+        locallyReconstructed $ buildList <*> mapM quoteDomWithName as
       else
         buildList <*> mapM quoteDomWithName as
       where
@@ -883,7 +883,7 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
           return $ (s, d'):ds'
 
         quoteDomWithName :: (ArgName, Dom Type) -> TCM Term
-        quoteDomWithName (x, t) = toTerm <*> pure (T.pack x, t)
+        quoteDomWithName (x, a) = toTerm <*> pure (T.pack x, a)
 
     extendCxt :: Text -> Arg R.Type -> UnquoteM a -> UnquoteM a
     extendCxt s' a m = withFreshName noRange (T.unpack s') $ \s -> do


### PR DESCRIPTION
These are some refactors that I factored out from the (stalled) PR for adding let bindings (https://github.com/agda/agda/pull/7253). The most important change is to introduce a proper datatype for representing context entries, which here just has a single constructor `CtxVar` but could later be extended with a `CtxLet`.