### PR TITLE
[ fix #7618 ] Use `underAbstraction_` for going under lambda in `reduceAndEtaContract`

### DIFF
--- a/test/Succeed/Issue7618.agda
+++ b/test/Succeed/Issue7618.agda
@@ -1,0 +1,16 @@
+{-# OPTIONS --rewriting --allow-unsolved-metas #-}
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+postulate
+  eq : (A B : Set) → Bool
+  eq-id : (A : Set) → eq A A ≡ true
+  {-# REWRITE eq-id #-}
+
+postulate
+  A B : Set
+  f : (r : Set → Set) (P : (Set → Bool) → Set) → P (λ _ → eq (r A) (r B))
+
+g : (r : Set → Set) (P : (Set → Bool) → Set) → P (λ _ → eq (r A) (r B))
+g r P = f r _     -- WAS: internal error


### PR DESCRIPTION
Fixes #7618