### PR TITLE
Implement checkInternal for definitions

### DIFF
--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -22,7 +22,7 @@ import Agda.Syntax.Internal
 import Agda.Syntax.Common.Pretty (prettyShow)
 
 import Agda.TypeChecking.Conversion
-import Agda.TypeChecking.Coverage.SplitClause
+--import Agda.TypeChecking.Coverage.SplitClause
 import Agda.TypeChecking.Coverage.Match
 import Agda.TypeChecking.Datatypes
 import Agda.TypeChecking.Level
@@ -445,8 +445,8 @@ checkClauses act (Done arg t) cmp s = do
       funnySubst = undefined
   nt <- addContext (ccTel s) $ checkInternal' act (funnySubst t) cmp (unDom . ccTarget $ s)
   return (s, Done arg nt)
-checkClauses act (Fail arg) cmp s = _
-checkClauses act (Case arg cases) cmp s = _
+checkClauses act (Fail arg) cmp s = undefined
+checkClauses act (Case arg cases) cmp s = undefined
 
 {-
 Examples

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -38,6 +38,7 @@ import Agda.TypeChecking.CompiledClause
 import Agda.Utils.Function (applyWhen, applyWhenM)
 import Agda.Utils.Functor (($>))
 import Agda.Utils.Maybe
+import Agda.Utils.Either
 import Agda.Utils.Size
 
 import Agda.Utils.Impossible
@@ -415,12 +416,87 @@ data needed for the main loop:
   name of the function : QName
 --  list of patterns - same type as scPats - mapping from CompiledClauses to scTel - to convert from deBruijn levels to proper deBruijn indices
 -}
+
 data CheckClause = CClause
   { ccTel    :: Telescope
   , ccPats   :: [NamedArg SplitPattern]
   , ccTarget :: Dom Type
   , ccName   :: QName
   }
+
+type DbIndex   = Int
+type DbLevel   = Int
+type DbCoLevel = Int
+
+atLevel :: CheckClause -> DbLevel -> Maybe DbIndex
+atLevel (CClause { ccPats = pats }) i = maybeRight $ at pats i
+  where
+    at :: [NamedArg SplitPattern] -> DbLevel -> Either DbLevel DbIndex
+    at []      i = Right i
+    at (h : t) i = case atc (namedThing . unArg $ h) i of
+      Left j -> at t j
+      Right ix -> Right ix
+
+    atc :: SplitPattern -> DbLevel -> Either DbLevel DbIndex
+    atc _          i | i < 0      = __IMPOSSIBLE__ -- negative level
+    atc (VarP _ x) i | i == 0     = Right $ splitPatVarIndex x
+                     | otherwise  = Left $ i - 1
+    atc (DotP _ t) i | i == 0     = __IMPOSSIBLE__ -- indexing into a dot pattern
+    atc (DotP _ t) i | otherwise  = Left $ i - 1
+    atc (ConP _ _ s) i            = at s i
+    atc (LitP _ _) i              = Left $ i - 1
+    atc (ProjP _ _) i             = __IMPOSSIBLE__
+                                    -- TODO: fix, cubical stuff, idk what to do with it
+    atc (IApplyP _ t1 t2 x) i     = __IMPOSSIBLE__
+                                    -- TODO: fix, cubical stuff, idk what to do with it_
+    atc (DefP _ _ s) i            = at s i
+
+atCoLevel :: CheckClause -> DbCoLevel -> Maybe DbIndex
+atCoLevel (CClause { ccPats = pats }) i = maybeRight $ at (reverse pats) i
+  where
+    -- we traverse patterns right-to-left, so empty case means we are at the "head"
+    -- of the original list
+    at :: [NamedArg SplitPattern] -> DbCoLevel -> Either DbCoLevel DbIndex
+    at []      i = Right i
+    at (h : t) i = case atc (namedThing . unArg $ h) i of
+      Left j -> at t j
+      Right ix -> Right ix
+
+    -- this is essentially the same as for Levels, except we reverse
+    -- the list of patterns in ConP for the recursive call
+    atc :: SplitPattern -> DbCoLevel -> Either DbCoLevel DbIndex
+    atc _          i | i < 0      = __IMPOSSIBLE__ -- negative level
+    atc (VarP _ x) i | i == 0     = Right $ splitPatVarIndex x
+                     | otherwise  = Left $ i - 1
+    atc (DotP _ t) i | i == 0     = __IMPOSSIBLE__ -- indexing into a dot pattern
+    atc (DotP _ t) i | otherwise  = Left $ i - 1
+    atc (ConP _ _ s) i            = at (reverse s) i
+    atc (LitP _ _) i              = Left $ i - 1
+    atc (ProjP _ _) i             = __IMPOSSIBLE__ -- TODO: fix
+    atc (IApplyP _ t1 t2 x) i     = __IMPOSSIBLE__ -- TODO: fix, cubical stuff, idk what to do with it
+    atc (DefP _ _ s) i            = at s i -- TODO: fix, cubical stuff, idk what to do with it_
+
+retSubst :: CheckClause -> Substitution
+retSubst (CClause { ccPats = pats }) = _ $ res
+  where
+    res = retPats pats 0
+
+    retPats :: [NamedArg SplitPattern] -> DbLevel -> [(DbLevel, Maybe DbIndex)]
+    retPats [] i = []
+    retPats (h : t) i =
+      let rh = retPat (namedThing . unArg $ h) i
+          j  = fst . last $ rh
+      in retPats t j
+
+    retPat :: SplitPattern -> DbLevel -> [(DbLevel, Maybe DbIndex)]
+    retPat (VarP _ x)        i = [(i, Just $ splitPatVarIndex x)]
+    retPat (DotP _ t)        i = [(i, Nothing)]
+    retPat (ConP _ _ s)      i = retPats s i
+    retPat (LitP _ _)        i = []
+    retPat (ProjP _ _)       i = __IMPOSSIBLE__ -- TODO: fix
+    retPat (IApplyP _ _ _ _) i = __IMPOSSIBLE__ -- TODO: fix, cubical stuff, idk what to do with it
+    retPat (DefP _ _ _)      i = __IMPOSSIBLE__ -- TODO: fix, cubical stuff, idk what to do with it
+
 
 instance CheckInternal CompiledClauses where
   checkInternal' act cc cmp (q, t) = do
@@ -440,10 +516,7 @@ checkClauses
   -> CheckClause
   -> m (CheckClause, CompiledClauses)
 checkClauses act (Done arg t) cmp s = do
-  let funnySubst :: Term -> Term
-      -- from co-positions to deBruijn indices
-      funnySubst = undefined
-  nt <- addContext (ccTel s) $ checkInternal' act (funnySubst t) cmp (unDom . ccTarget $ s)
+  nt <- addContext (ccTel s) $ checkInternal' act (applySubst (retSubst s) t) cmp (unDom . ccTarget $ s)
   return (s, Done arg nt)
 checkClauses act (Fail arg) cmp s = undefined
 checkClauses act (Case arg cases) cmp s = undefined

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -464,11 +464,6 @@ lookupLvlPos cc p = (\x -> size (ccTel cc) - x - 1) <$> lookupPos cc p
 getTerms :: CheckClause -> [Maybe Term]
 getTerms cc = map (fmap var) (getVars cc)
 
-isDatatypeC :: (MonadCheckInternal tcm, MonadError TCErr tcm) =>
-              Induction -> Dom Type ->
-              tcm (DataOrRecord, QName, Sort, Args, Args, [QName], Bool)
-isDatatypeC = undefined
-
 checkClauseSubst :: CheckClause -> Substitution
 checkClauseSubst cc = prependS __IMPOSSIBLE__ (reverse $ getTerms cc) idS
 
@@ -510,7 +505,7 @@ checkClauses act c@(Case arg cases) cmp s = do
   (n, t, delta1, delta2) <- do
     let (tel1, dom : tel2) = splitAt (size tel - narg - 1) $ telToList tel
     return (fst $ unDom dom, snd <$> dom, telFromList tel1, telFromList tel2)
-  (dr, d, s, pars, ixs, cons', _) <- inContextOfT tel narg $ isDatatypeC Inductive t
+  (dr, d, s, pars, ixs, cons', _) <- inContextOfT tel narg $ isDatatypeCool Inductive t
   cons <- case False of --checkEmpty
     True  -> undefined --ifM (liftTCM $ inContextOfT $ isEmptyType $ unDom t) (pure []) (pure cons')
     False -> pure cons'

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -31,6 +31,7 @@ import Agda.TypeChecking.Records (shouldBeProjectible)
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Sort
 import Agda.TypeChecking.Telescope
+import Agda.TypeChecking.CompiledClause
 
 import Agda.Utils.Function (applyWhen, applyWhenM)
 import Agda.Utils.Functor (($>))
@@ -399,3 +400,10 @@ instance CheckInternal PlusLevel where
     checkLevelAtom l = do
       lvl <- levelType'
       checkInternal' action l CmpLeq lvl
+
+---------------------------------------------------------------------------
+-- * Double-checking the clauses
+---------------------------------------------------------------------------
+
+instance CheckInternal CompiledClauses where
+  checkInternal' _ _ _ _ = undefined

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -18,6 +18,7 @@ module Agda.TypeChecking.CheckInternal
 import Control.Monad
 
 import Agda.Syntax.Common
+import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern (dbPatPerm)
 import Agda.Syntax.Common.Pretty (prettyShow)
@@ -431,6 +432,9 @@ type DbCoLevel = Int
 
 instance CheckInternal CompiledClauses where
   checkInternal' act cc cmp (q, t) = do
+    reportSDoc "tc.check.internal.cc" 20 $ vcat
+      [ "checking internal compiled clauses of " <+> prettyTCM q
+      , nest 2 $ return $ P.pretty cc ]
     TelV gamma a <- telViewUpTo (-1) t
     let
       n      = size gamma
@@ -449,7 +453,10 @@ checkClauses
   -> Comparison
   -> CheckClause
   -> m (CheckClause, CompiledClauses)
-checkClauses act (Done arg t) cmp s = addContext (ccTel s) $ do
+checkClauses act c@(Done arg t) cmp s = addContext (ccTel s) $ do
+  reportSDoc "tc.check.internal.cc" 50 $ vcat
+    [ "checking internal done clause of " <+> prettyTCM (ccName s)
+    , nest 2 $ return $ P.pretty c ]
   let sub = renamingR $ fromMaybe __IMPOSSIBLE__ $ checkClausePerm s
   nt <- checkInternal' act (applySubst sub t) cmp (unDom . ccTarget $ s)
   return (s, Done arg nt)

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -406,4 +406,8 @@ instance CheckInternal PlusLevel where
 ---------------------------------------------------------------------------
 
 instance CheckInternal CompiledClauses where
-  checkInternal' _ _ _ _ = undefined
+  checkInternal' act cc@(Done _ t) cmp ty = checkInternal' act t cmp ty
+  checkInternal' act cc@(Fail _) cmp ty = do
+    --TODO make sure it's indeed an absurd clause
+    return cc
+  checkInternal' act cc@(Case _ _) cmp ty = return cc

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -18,7 +18,7 @@ module Agda.TypeChecking.CheckInternal
 import Control.Monad
 import Control.Monad.Except ( MonadError(..))
 
-import qualified Data.Map as Map
+--import qualified Data.Map as Map
 import Data.Map (Map)
 
 import Agda.Syntax.Common
@@ -29,7 +29,8 @@ import Agda.Syntax.Common.Pretty (prettyShow)
 
 import Agda.TypeChecking.Conversion
 --import Agda.TypeChecking.Coverage.SplitClause
-import Agda.TypeChecking.Coverage.Match
+--import Agda.TypeChecking.Coverage.Match
+import Agda.TypeChecking.Coverage.SplitPattern
 import Agda.TypeChecking.Datatypes
 import Agda.TypeChecking.Level
 import Agda.TypeChecking.Monad
@@ -487,13 +488,13 @@ checkClauses
   -> Comparison
   -> CheckClause
   -> m (CheckClause, CompiledClauses)
-checkClauses act c@(Done arg t) cmp s = addContext (ccTel s) $ do
+checkClauses act c@(Done n isrec arg t) cmp s = addContext (ccTel s) $ do
   reportSDoc "tc.check.internal.cc" 50 $ vcat
     [ "checking internal done clause of " <+> prettyTCM (ccName s)
     , nest 2 $ return $ P.pretty c ]
   let sub = checkClauseSubst s
   nt <- checkInternal' act (applySubst sub t) cmp (unDom . ccTarget $ s)
-  return (s, Done arg nt)
+  return (s, Done n isrec arg nt)
 checkClauses act c@(Case arg cases) cmp s = do
   reportSDoc "tc.check.internal.cc" 50 $ vcat
     [ "checking internal case clause of " <+> prettyTCM (ccName s)
@@ -505,19 +506,18 @@ checkClauses act c@(Case arg cases) cmp s = do
   (n, t, delta1, delta2) <- do
     let (tel1, dom : tel2) = splitAt (size tel - narg - 1) $ telToList tel
     return (fst $ unDom dom, snd <$> dom, telFromList tel1, telFromList tel2)
-  (dr, d, s, pars, ixs, cons', _) <- inContextOfT tel narg $ isDatatypeCool Inductive t
-  cons <- case False of --checkEmpty
+  (dr, d, s, pars, ixs, cons', _) <- undefined --inContextOfT tel narg $ isDatatypeCool Inductive t
+  cons <- case undefined of --checkEmpty
     True  -> undefined --ifM (liftTCM $ inContextOfT $ isEmptyType $ unDom t) (pure []) (pure cons')
     False -> pure cons'
-  mns <- forM cons $ \ con ->
-    computeNeighbourhood delta1 n delta2 d pars ixs narg tel con
+  mns <- undefined {-forM cons $ \ con ->
+    computeNeighbourhood delta1 n delta2 d pars ixs narg tel con-}
   return undefined
-  where
-    inContextOfT :: (MonadAddContext tcm, MonadDebug tcm)
-                 => Telescope -> Int -> tcm a -> tcm a
-    inContextOfT tel x = addContext tel . escapeContext impossible (x + 1)
 checkClauses act (Fail arg) cmp s = undefined
 
+inContextOfT :: (MonadAddContext tcm, MonadDebug tcm)
+             => Telescope -> Int -> tcm a -> tcm a
+inContextOfT tel x = addContext tel . escapeContext impossible (x + 1)
 
 computeNeighbourhood
   :: (MonadError TCErr m, MonadCheckInternal m)

--- a/src/full/Agda/TypeChecking/CompiledClause.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause.hs
@@ -95,6 +95,9 @@ data CCDone a = CCDone
 pattern Done :: ClauseNumber -> ClauseRecursive -> [Arg ArgName] -> a -> CompiledClauses' a
 pattern Done no mr xs b = Done_ (CCDone no mr xs b)
 
+-- needed for checkInternal, we only store the "return type" here
+type instance TypeOf CompiledClauses = Type
+
 litCase :: Literal -> c -> Case c
 litCase l x = Branches False Map.empty Nothing (Map.singleton l x) Nothing (Just False) False
 

--- a/src/full/Agda/TypeChecking/CompiledClause.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause.hs
@@ -96,7 +96,7 @@ pattern Done :: ClauseNumber -> ClauseRecursive -> [Arg ArgName] -> a -> Compile
 pattern Done no mr xs b = Done_ (CCDone no mr xs b)
 
 -- needed for checkInternal, we only store the "return type" here
-type instance TypeOf CompiledClauses = Type
+type instance TypeOf CompiledClauses = (QName, Type)
 
 litCase :: Literal -> c -> Case c
 litCase l x = Branches False Map.empty Nothing (Map.singleton l x) Nothing (Just False) False

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -110,7 +110,7 @@ compileClauses mt cs = do
           [ "double checking compiled clauses of " <+> prettyTCM q
           , nest 2 $ return $ P.pretty cc
           ]
-        noConstraints $ withFrozenMetas $ checkInternal cc CmpLeq t
+        noConstraints $ withFrozenMetas $ checkInternal cc CmpLeq (q, t)
       return (Just splitTree, becameCopatternLHS, fmap precomputeFreeVars_ cc)
 
 -- | Stripped-down version of 'Agda.Syntax.Internal.Clause'

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -12,9 +12,12 @@ import Data.Maybe
 import Data.List (partition)
 import qualified Data.Map as Map
 
+import Agda.Interaction.Options
+
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
+import Agda.TypeChecking.Constraints
 import Agda.TypeChecking.CompiledClause
 import Agda.TypeChecking.Coverage
 import Agda.TypeChecking.Coverage.SplitTree
@@ -24,6 +27,7 @@ import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Free.Precompute
 import Agda.TypeChecking.Reduce
+import Agda.TypeChecking.CheckInternal
 
 import Agda.Utils.Functor
 import Agda.Utils.Maybe
@@ -31,6 +35,7 @@ import Agda.Utils.List
 import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Utils.Size
 import Agda.Utils.Update
+import Agda.Utils.Monad hiding (guard)
 
 import Agda.Utils.Impossible
 
@@ -93,13 +98,18 @@ compileClauses mt cs = do
         [ "compiled clauses of " <+> prettyTCM q <+> " (still containing record splits)"
         , nest 2 $ return $ P.pretty cc
         ]
-
+      --TODO: potentially double-check cc here too
       (cc, becameCopatternLHS) <- runChangeT $ translateCompiledClauses q cc
-
       reportSDoc "tc.cc" 12 $ sep
         [ "compiled clauses of " <+> prettyTCM q
         , nest 2 $ return $ P.pretty cc
         ]
+      whenM (optDoubleCheck <$> pragmaOptions) $ do
+        reportSDoc "tc.cc" 30 $ vcat
+          [ "double checking compiled clauses of " <+> prettyTCM q
+          , nest 2 $ return $ P.pretty cc
+          ]
+        noConstraints $ withFrozenMetas $ checkInternal cc undefined undefined
       return (Just splitTree, becameCopatternLHS, fmap precomputeFreeVars_ cc)
 
 -- | Stripped-down version of 'Agda.Syntax.Internal.Clause'

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -28,7 +28,7 @@ import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Free.Precompute
 import Agda.TypeChecking.Reduce
-import Agda.TypeChecking.Telescope
+--import Agda.TypeChecking.Telescope
 
 import Agda.Utils.Functor
 import Agda.Utils.Maybe

--- a/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Compile.hs
@@ -17,6 +17,7 @@ import Agda.Interaction.Options
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
+import Agda.TypeChecking.CheckInternal
 import Agda.TypeChecking.Constraints
 import Agda.TypeChecking.CompiledClause
 import Agda.TypeChecking.Coverage
@@ -27,7 +28,7 @@ import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Free.Precompute
 import Agda.TypeChecking.Reduce
-import Agda.TypeChecking.CheckInternal
+import Agda.TypeChecking.Telescope
 
 import Agda.Utils.Functor
 import Agda.Utils.Maybe
@@ -109,7 +110,7 @@ compileClauses mt cs = do
           [ "double checking compiled clauses of " <+> prettyTCM q
           , nest 2 $ return $ P.pretty cc
           ]
-        noConstraints $ withFrozenMetas $ checkInternal cc undefined undefined
+        noConstraints $ withFrozenMetas $ checkInternal cc CmpLeq t
       return (Just splitTree, becameCopatternLHS, fmap precomputeFreeVars_ cc)
 
 -- | Stripped-down version of 'Agda.Syntax.Internal.Clause'

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -114,7 +114,7 @@ coverageCheck f t cs = do
   let -- n             = arity
       -- xs            = variable patterns fitting lgamma
       n            = size gamma
-      xs           =  map (setOrigin Inserted) $ teleNamedArgs gamma
+      xs           = map (setOrigin Inserted) $ teleNamedArgs gamma
 
   reportSLn "tc.cover.top" 30 $ "coverageCheck: getDefFreeVars"
 

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -1257,7 +1257,7 @@ split' checkEmpty ind allowPartialCover inserttrailing
     return (fst $ unDom dom, snd <$> dom, telFromList tel1, telFromList tel2)
 
   -- Compute the neighbourhoods for the constructors
-  let computeNeighborhoods = do
+  let computeNeighbourhoods = do
         -- Check that t is a datatype or a record
         -- Andreas, 2010-09-21, isDatatype now directly throws an exception if it fails
         -- cons = constructors of this datatype
@@ -1279,7 +1279,7 @@ split' checkEmpty ind allowPartialCover inserttrailing
                , ns ++ catMaybes ([fmap (fmap (,NoInfo)) hcompsc | not $ null $ ns])
                )
 
-      computeLitNeighborhoods = do
+      computeLitNeighbourhoods = do
         typeOk <- liftTCM $ do
           t' <- litType $ headWithDefault {-'-} __IMPOSSIBLE__ plits
           liftTCM $ dontAssignMetas $ tryConversion $ equalType (unDom t) t'
@@ -1312,8 +1312,8 @@ split' checkEmpty ind allowPartialCover inserttrailing
   -- numMatching is the number of proper constructors matching, excluding hcomp.
   -- for literals this considers the catchall clause as 1 extra constructor.
   (dr, s, isIndexed, numMatching, ns) <- if null pcons' && not (null plits)
-        then computeLitNeighborhoods
-        else computeNeighborhoods
+        then computeLitNeighbourhoods
+        else computeNeighbourhoods
 
   --TODO: Bohdan & Mario: this fix can be done in computeNeighbourhood in computeNeighbourhoods
   ns <- case target of

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -1107,7 +1107,7 @@ computeNeighbourhood delta1 n delta2 d pars ixs hix tel ps cps c = do
       debugPlugged delta' ps'
 
       let cps'  = applySplitPSubst rho cps
-
+      --TODO: Bohdan & Mario: the nothing can be computed here
       return $ Just . (,unifyInfo) $ SClause delta' ps' rho cps' Nothing -- target fixed later
 
   where
@@ -1351,6 +1351,7 @@ split' checkEmpty ind allowPartialCover inserttrailing
         then computeLitNeighborhoods
         else computeNeighborhoods
 
+  --TODO: Bohdan & Mario: this fix can be done in computeNeighbourhood in computeNeighbourhoods
   ns <- case target of
     Just a  -> forM ns $ \ (con,(sc,info)) -> lift $ (con,) . (,info) <$>
                  fixTargetType (getQuantity t) con sc a

--- a/src/full/Agda/TypeChecking/ProjectionLike.hs-boot
+++ b/src/full/Agda/TypeChecking/ProjectionLike.hs-boot
@@ -2,9 +2,14 @@
 
 module Agda.TypeChecking.ProjectionLike where
 
-import Agda.Syntax.Abstract.Name (QName)
+import {-# SOURCE #-} Agda.TypeChecking.Monad.Pure
 import Agda.TypeChecking.Monad.Base
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Signature (HasConstInfo)
+import Agda.Syntax.Internal
 
 makeProjection :: QName -> TCM ()
 eligibleForProjectionLike :: (HasConstInfo m) => QName -> m Bool
+
+data ProjEliminator = EvenLone | ButLone | NoPostfix
+
+elimView :: PureTCM m => ProjEliminator -> Term -> m Term

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -32,6 +32,7 @@ import Agda.Interaction.Options (optCumulativity, optRewriting)
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 
+import {-# SOURCE #-} Agda.TypeChecking.ProjectionLike
 import {-# SOURCE #-} Agda.TypeChecking.Constraints () -- instance only
 import {-# SOURCE #-} Agda.TypeChecking.Conversion
 import {-# SOURCE #-} Agda.TypeChecking.MetaVars () -- instance only
@@ -46,7 +47,6 @@ import Agda.TypeChecking.Monad.Pure
 import Agda.TypeChecking.Monad.Signature (HasConstInfo(..), applyDef)
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records (getDefType)
-import Agda.TypeChecking.ProjectionLike
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope

--- a/test/Succeed/Issue7627.agda
+++ b/test/Succeed/Issue7627.agda
@@ -1,0 +1,32 @@
+module Issue7627 where
+
+module Done where
+  -- checking case trees that have only Done
+  f : {A : Set} (a b c : A) -> A
+  f a b c = a
+
+  g : {A B C : Set} (a : A) (b : B) (c : C) -> B
+  g a b c = b
+
+  h : {A : Set} (a : A) {B : A -> Set} (b : B a) -> B a
+  h a b = b
+
+module Case where
+  -- checking case trees that split on an inductive datatype
+  data Nat : Set where
+    Z : Nat
+    S : Nat -> Nat
+
+  f : Nat -> Nat -> Nat
+  f Z m = m
+  f (S n) m = n
+
+module Fail where
+  -- checking case trees that have an absurd case
+  data False : Set where
+
+  f : False -> False
+  f ()
+
+module Coinduction where
+  -- checking case trees that split on the result

--- a/test/Succeed/Issue7627.flags
+++ b/test/Succeed/Issue7627.flags
@@ -1,0 +1,3 @@
+-- -vtc.check.internal:20
+-- --ignore-interfaces
+--double-check


### PR DESCRIPTION
issue tracked in #7627

started during AIMXXXIX by @jespercockx, @digama0, and yt

TODO:
- [ ] implement checkInternal on definitions that match on inductive datatypes
- [ ] deal with co-patterns
- [ ] revert the changes in flake.nix - I needed them to run local builds in a nix shell  