### PR TITLE
Print point-ranges as such (line.col rather than line:col-col)

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -972,8 +972,8 @@ The buffer is returned.")
       (compilation-mode "AgdaInfo")
       ;; Support for jumping to positions mentioned in the text.
       (set (make-local-variable 'compilation-error-regexp-alist)
-           '(("\\([\\\\/][^[:space:]]*\\):\\([0-9]+\\)\\.\\([0-9]+\\)-\\(\\([0-9]+\\)\\.\\)?\\([0-9]+\\)"
-              1 (2 . 5) (3 . 6))))
+           '(("\\([\\\\/][^[:space:]]*\\):\\([0-9]+\\)\\.\\([0-9]+\\)\\(-\\(\\([0-9]+\\)\\.\\)?\\([0-9]+\\)\\)?"
+              1 (2 . 6) (3 . 7))))
       ;; Do not skip errors that start in the same position as the
       ;; current one.
       (set (make-local-variable 'compilation-skip-to-next-location) nil)

--- a/src/full/Agda/Syntax/Common/Pretty.hs
+++ b/src/full/Agda/Syntax/Common/Pretty.hs
@@ -142,7 +142,9 @@ instance Pretty PositionWithoutFile where
   pretty p = pretty (p { srcFile = Strict.Nothing } :: Position)
 
 instance Pretty IntervalWithoutFile where
-  pretty (Interval () s e) = start <> "-" <> end
+  pretty (Interval () s e)
+    | s == e    = start
+    | otherwise = start <> "-" <> end
     where
       sl = posLine s
       el = posLine e

--- a/test/Fail/Issue.1947.err
+++ b/test/Fail/Issue.1947.err
@@ -1,3 +1,3 @@
-Issue.1947.agda:1.1-1: error: [InvalidFileName]
+Issue.1947.agda:1.1: error: [InvalidFileName]
 The file name Issue.1947.agda is
 invalid because it does not correspond to a valid module name.

--- a/test/Fail/Issue1976-constraints3.err
+++ b/test/Fail/Issue1976-constraints3.err
@@ -1,7 +1,7 @@
 Issue1976-constraints3.agda:20.3-9: error: [AmbiguousProjection]
 Ambiguous projection F.
 It could refer to any of
-  ShouldFail._.F (introduced at Issue1976-constraints3.agda:16.8-8)
-  ShouldFail._.F (introduced at Issue1976-constraints3.agda:17.8-8)
+  ShouldFail._.F (introduced at Issue1976-constraints3.agda:16.8)
+  ShouldFail._.F (introduced at Issue1976-constraints3.agda:17.8)
 when checking the clause left hand side
 F test

--- a/test/Fail/Issue3257.tex.err
+++ b/test/Fail/Issue3257.tex.err
@@ -1,3 +1,3 @@
-Issue3257.tex.agda:1.1-1: error: [InvalidFileName]
+Issue3257.tex.agda:1.1: error: [InvalidFileName]
 The file name Issue3257.tex.agda
 is invalid because Issue3257.tex is not an unqualified module name.

--- a/test/Fail/_.err
+++ b/test/Fail/_.err
@@ -1,3 +1,3 @@
-_.agda:1.1-1: error: [InvalidFileName]
+_.agda:1.1: error: [InvalidFileName]
 The file name _.agda is invalid
 because it does not correspond to a valid module name.

--- a/test/Fail/_ __ _.err
+++ b/test/Fail/_ __ _.err
@@ -1,3 +1,3 @@
-_ __ _.agda:1.1-1: error: [InvalidFileName]
+_ __ _.agda:1.1: error: [InvalidFileName]
 The file name _ __ _.agda is
 invalid because it does not correspond to a valid module name.

--- a/test/interaction/Issue6333.out
+++ b/test/interaction/Issue6333.out
@@ -1,2 +1,2 @@
-Issue6333/br.agda-lib:1.1-1: error: [OptionError]
+Issue6333/br.agda-lib:1.1: error: [OptionError]
 Unrecognized option: --definitely-not-a-valid-flag


### PR DESCRIPTION
Print point-ranges as such (line.col rather than line:col-col).

Salvaged from:
- #7647

Probably needs some changelog entry as downstream tooling might want to parse Agda ranges. Dunno.