### PR TITLE
Setup: unconditionally check if we want interfaces

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -76,15 +76,11 @@ copyHook' pd lbi hooks flags = do
 -- If we're installing *just* the library, the interface files are not needed
 -- and, most importantly, the executable will not be available to be run (cabal#10235)
 wantInterfaces :: CopyFlags -> Bool
-wantInterfaces _flags = do
-#if MIN_VERSION_Cabal(3,11,0)
+wantInterfaces _flags =
     any isAgdaExe (copyArgs _flags)
       where
         isAgdaExe "exe:agda" = True
         isAgdaExe _ = False
-#else
-  True
-#endif
 
 -- Used to add .agdai files to data-files
 expandAgdaExt :: PackageDescription -> FilePath -> [FilePath]


### PR DESCRIPTION
Previously we only checked if the Cabal library was new enough to trigger the bug, but this bug is triggered by the version of cabal-install (the build tool) not Cabal (the library). These two can come apart, and it's valid to use an older version of Cabal. So instead we unconditionally check if interfaces are wanted.

Resolves https://github.com/agda/agda/issues/7655

See also https://github.com/agda/agda/pull/7471