### PR TITLE
Fix #7643: coverage: handle blocked sort in isFibrant

### DIFF
--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -1250,7 +1250,7 @@ split' checkEmpty ind allowPartialCover inserttrailing
         -- Andreas, 2010-09-21, isDatatype now directly throws an exception if it fails
         -- cons = constructors of this datatype
         (dr, d, s, pars, ixs, cons', isHIT) <- inContextOfT $ isDatatype ind t
-        isFib <- lift $ isFibrant t
+        isFib <- fromRight (const False) <$> lift (isFibrant' t)
         cons <- case checkEmpty of
           CheckEmpty   -> ifM (liftTCM $ inContextOfT $ isEmptyType $ unDom t) (pure []) (pure cons')
           NoCheckEmpty -> pure cons'

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -349,7 +349,7 @@ allIrrelevantOrPropTel =
 isFibrant :: (LensSort a, PureTCM m, MonadBlock m) => a -> m Bool
 isFibrant = fromRightM patternViolation . isFibrant'
 
-isFibrant' :: (LensSort a, PureTCM m, MonadBlock m) => a -> m (Either Blocker Bool)
+isFibrant' :: (LensSort a, PureTCM m) => a -> m (Either Blocker Bool)
 isFibrant' s =
   ifBlocked (getSort s) (\ blocker _ -> return $ Left blocker) \ _ ->
     return . Right . \case
@@ -369,11 +369,8 @@ isFibrant' s =
 
 -- | Cofibrant types are those that could be the domain of a fibrant
 --   pi type. (Notion by C. Sattler).
-isCoFibrantSort :: (LensSort a, PureTCM m, MonadBlock m) => a -> m Bool
-isCoFibrantSort = fromRightM patternViolation . isCoFibrantSort'
-
-isCoFibrantSort' :: (LensSort a, PureTCM m, MonadBlock m) => a -> m (Either Blocker Bool)
-isCoFibrantSort' s =
+isCoFibrantSort :: (LensSort a, PureTCM m) => a -> m (Either Blocker Bool)
+isCoFibrantSort s =
   ifBlocked (getSort s) (\ blocker _ -> return $ Left blocker) \ _ ->
     return . Right . \case
       Univ u _       -> univFibrancy u == IsFibrant

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -86,9 +86,12 @@ import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute.Class
 import Agda.TypeChecking.Telescope
 
+import Agda.Utils.Either (fromRightM)
 import Agda.Utils.Lens
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
+
+import Agda.Utils.Impossible
 
 -- | Check whether something can be used in a position of the given relevance.
 --
@@ -343,37 +346,45 @@ allIrrelevantOrPropTel =
 
 -- | Is a type fibrant (i.e. Type, Prop)?
 
-isFibrant
-  :: (LensSort a, PureTCM m, MonadBlock m)
-  => a -> m Bool
-isFibrant a = abortIfBlocked (getSort a) <&> \case
-  Univ u _   -> univFibrancy u == IsFibrant
-  Inf u _    -> univFibrancy u == IsFibrant
-  SizeUniv{} -> False
-  LockUniv{} -> False
-  LevelUniv{}  -> False
-  IntervalUniv{} -> False
-  PiSort{}   -> False
-  FunSort{}  -> False
-  UnivSort{} -> False
-  MetaS{}    -> False
-  DefS{}     -> False
-  DummyS{}   -> False
+isFibrant :: (LensSort a, PureTCM m, MonadBlock m) => a -> m Bool
+isFibrant = fromRightM patternViolation . isFibrant'
+
+isFibrant' :: (LensSort a, PureTCM m, MonadBlock m) => a -> m (Either Blocker Bool)
+isFibrant' s =
+  ifBlocked (getSort s) (\ blocker _ -> return $ Left blocker) \ _ ->
+    return . Right . \case
+      Univ u _       -> univFibrancy u == IsFibrant
+      Inf u _        -> univFibrancy u == IsFibrant
+      SizeUniv{}     -> False
+      LockUniv{}     -> False
+      LevelUniv{}    -> False
+      IntervalUniv{} -> False
+      PiSort{}       -> __IMPOSSIBLE__
+      FunSort{}      -> __IMPOSSIBLE__
+      UnivSort{}     -> __IMPOSSIBLE__
+      MetaS{}        -> __IMPOSSIBLE__
+      DefS{}         -> False
+      DummyS{}       -> False
 
 
 -- | Cofibrant types are those that could be the domain of a fibrant
 --   pi type. (Notion by C. Sattler).
 isCoFibrantSort :: (LensSort a, PureTCM m, MonadBlock m) => a -> m Bool
-isCoFibrantSort a = abortIfBlocked (getSort a) <&> \case
-  Univ u _   -> univFibrancy u == IsFibrant
-  Inf u _    -> univFibrancy u == IsFibrant
-  SizeUniv{} -> False
-  LockUniv{} -> True
-  LevelUniv{}  -> False
-  IntervalUniv{} -> True
-  PiSort{}   -> False
-  FunSort{}  -> False
-  UnivSort{} -> False
-  MetaS{}    -> False
-  DefS{}     -> False
-  DummyS{}   -> False
+isCoFibrantSort = fromRightM patternViolation . isCoFibrantSort'
+
+isCoFibrantSort' :: (LensSort a, PureTCM m, MonadBlock m) => a -> m (Either Blocker Bool)
+isCoFibrantSort' s =
+  ifBlocked (getSort s) (\ blocker _ -> return $ Left blocker) \ _ ->
+    return . Right . \case
+      Univ u _       -> univFibrancy u == IsFibrant
+      Inf u _        -> univFibrancy u == IsFibrant
+      SizeUniv{}     -> False
+      LockUniv{}     -> True
+      LevelUniv{}    -> False
+      IntervalUniv{} -> True
+      PiSort{}       -> __IMPOSSIBLE__
+      FunSort{}      -> __IMPOSSIBLE__
+      UnivSort{}     -> __IMPOSSIBLE__
+      MetaS{}        -> __IMPOSSIBLE__
+      DefS{}         -> False
+      DummyS{}       -> False

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -419,6 +419,7 @@ instance Reduce Type where
     reduceB' (El s t) = workOnTypes $ fmap (El s) <$> reduceB' t
 
 instance Reduce Sort where
+    -- Does not return a 'NotBlocked' 'PiSort', 'FunSort', or 'UnivSort'.
     reduceB' s = do
       s <- instantiate' s
       let done | MetaS x _ <- s = return $ blocked x s

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -2061,13 +2061,13 @@ checkSortOfSplitVar dr a tel mtarget = do
 
     -- Cofibrant types are those that could be the domain of a fibrant
     -- pi type. (Notion by C. Sattler).
-    checkIsCoFibrant t = runBlocked (isCoFibrantSort t) >>= \case
+    checkIsCoFibrant t = isCoFibrantSort t >>= \case
       Left b      -> splitOnFibrantError' t $ Just b
       Right False -> unlessM (isInterval t) $
                        splitOnFibrantError' t $ Nothing
       Right True  -> return ()
 
-    checkIsFibrant t = runBlocked (isFibrant t) >>= \case
+    checkIsFibrant t = isFibrant' t >>= \case
       Left b      -> splitOnFibrantError $ Just b
       Right False -> splitOnFibrantError Nothing
       Right True  -> return ()

--- a/test/Succeed/Issue7643.agda
+++ b/test/Succeed/Issue7643.agda
@@ -1,0 +1,17 @@
+-- Andreas, 2025-01-02, issue #7643
+-- WAS: Uncaught pattern violation when checking isFibrant in coverage checker.
+
+{-# OPTIONS --allow-unsolved-metas #-}
+
+data ⊥ : Set where
+
+-- The sort of A is not determined here,
+-- could e.g. be Set or Set1.
+
+data Wrap (A : _) : Set1 where
+  wrap : A → Wrap A
+
+test : Wrap ⊥ → ⊥
+test (wrap ())
+
+-- Should succeed with unsolved metas.


### PR DESCRIPTION
Fix https://github.com/agda/agda/issues/7643: coverage: handle blocked sort in isFibrant
WAS: uncaught pattern violation.
NOW: default to non-fibrant.
