### PR TITLE
Fix #7669: positivity checker: compute function arity up to def. eq.

### DIFF
--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -276,15 +276,8 @@ checkStrictlyPositive mi qset = do
 
 getDefArity :: Definition -> TCM Int
 getDefArity def = do
-  subtract (projectionArgs def) <$> arity' (defType def)
-  where
-  -- A variant of "\t -> arity <$> instantiateFull t".
-  arity' :: Type -> TCM Int
-  arity' t = do
-    t <- instantiate t
-    case unEl t of
-      Pi _ t -> succ <$> arity' (unAbs t)
-      _      -> return 0
+  TelV tel _ <- telView (defType def)
+  return $ size tel - projectionArgs def
 
 -- Computing occurrences --------------------------------------------------
 

--- a/test/Fail/Issue7669Unify.agda
+++ b/test/Fail/Issue7669Unify.agda
@@ -1,0 +1,20 @@
+-- Andreas, 2025-01-13, #7674, test by Szumi Xie
+
+data Unit : Set where
+  tt : Unit
+
+postulate
+  A B : Set
+
+FUN : Set₁
+FUN = Set → Set
+
+ConstA : Unit → FUN
+ConstA tt _ = A
+
+postulate
+  x : Unit
+  f : (Z : Set) → ConstA x Z
+
+a : ConstA x B
+a = f _  -- This meta should remain unsolved because of non-variant polarity.

--- a/test/Fail/Issue7669Unify.err
+++ b/test/Fail/Issue7669Unify.err
@@ -1,0 +1,3 @@
+Issue7669Unify.agda:20.7-8: error: [UnsolvedMetaVariables]
+Unsolved metas at the following locations:
+  Issue7669Unify.agda:20.7-8

--- a/test/Succeed/Issue7669.agda
+++ b/test/Succeed/Issue7669.agda
@@ -1,0 +1,31 @@
+-- Andreas, 2024-01-03, issue #7669
+-- Report and test case by Szumi Xie.
+--
+-- Positivity checker computed arity not up to definitional equality.
+
+data Unit : Set where
+  tt : Unit
+
+FUN : Set₁
+FUN = Set → Set
+
+-- The arity of Id should not depend on the use of abbreviation FUN.
+-- I.e., it should be 2, not 1.
+
+Id : Unit → FUN
+Id tt A = A
+
+-- The positivity checker should know that
+-- Id is strictly positive in its second argument.
+
+data Nat : Set where
+  zero : Nat
+  suc : (x : Unit) → Id x Nat → Nat
+
+-- WAS: error: [NotStrictlyPositive]
+-- Nat is not strictly positive, because it occurs
+-- in the second argument of Id
+-- in the type of the constructor suc
+-- in the definition of Nat.
+
+-- Should succeed.


### PR DESCRIPTION
Closes #7669.
