### PR TITLE
Remove `--local-interfaces` and warning `DuplicateInterfaceFiles`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Installation
 Pragmas and options
 -------------------
 
+* Option `--local-interfaces` and warning `DuplicateInterfaceFiles` have been removed.
+
 * New warning `InvalidDisplayForm` instead of hard error
   when a display form is illegal (and thus ignored).
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -312,14 +312,6 @@ Imports and libraries
 
      Use ``FILE`` instead of the standard ``libraries`` file.
 
-.. option:: --local-interfaces
-
-     .. versionadded:: 2.6.1
-
-     Prefer to read and write interface files next to the Agda files they
-     correspond to (i.e. do not attempt to regroup them in a ``_build/``
-     directory at the project's root, except if they already exist there).
-
 .. option:: --no-default-libraries
 
      .. versionadded:: 2.5.1
@@ -1289,10 +1281,6 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 .. option:: DuplicateFields
 
      ``record`` expression with duplicate field names.
-
-.. option:: DuplicateInterfaceFiles
-
-     There exists both a local interface file and an interface file in ``_build``.
 
 .. option:: DuplicateRecordDirective
 

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -36,8 +36,6 @@ import Agda.Syntax.Parser.Literate (literateExtsShortList)
 import Agda.Syntax.Position
 import Agda.Syntax.TopLevelModuleName
 
-import Agda.Interaction.Options ( optLocalInterfaces )
-
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Benchmark (billTo)
 import qualified Agda.TypeChecking.Monad.Benchmark as Bench
@@ -45,7 +43,6 @@ import {-# SOURCE #-} Agda.TypeChecking.Monad.Options
   (getIncludeDirs, libToTCM)
 import Agda.TypeChecking.Monad.State ( registerFileIdWithBuiltin, topLevelModuleName )
 import Agda.TypeChecking.Monad.Trace (runPM, setCurrentRange)
-import Agda.TypeChecking.Warnings    (warning)
 
 import Agda.Version ( version )
 
@@ -100,19 +97,7 @@ toIFile (SourceFile fi) = do
       let buildDir = root </> "_build" </> version </> "agda"
       fileName <- liftIO $ makeRelativeCanonical root (filePath localIFile)
       let separatedIFile = mkAbsolute $ buildDir </> fileName
-          ifilePreference = ifM (optLocalInterfaces <$> commandLineOptions)
-            (pure (localIFile, separatedIFile))
-            (pure (separatedIFile, localIFile))
-      separatedIFileExists <- liftIO $ doesFileExistCaseSensitive $ filePath separatedIFile
-      localIFileExists <- liftIO $ doesFileExistCaseSensitive $ filePath localIFile
-      case (separatedIFileExists, localIFileExists) of
-        (False, False) -> fst <$> ifilePreference
-        (False, True) -> pure localIFile
-        (True, False) -> pure separatedIFile
-        (True, True) -> do
-          ifiles <- ifilePreference
-          warning $ uncurry DuplicateInterfaceFiles ifiles
-          pure $ fst ifiles
+      pure separatedIFile
 
 replaceModuleExtension :: String -> AbsolutePath -> AbsolutePath
 replaceModuleExtension ext@('.':_) = mkAbsolute . (++ ext) .  dropAgdaExtension . filePath

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -579,9 +579,6 @@ warningHighlighting' b w = case tcWarning w of
     UnknownNamesInFixityDecl{}        -> mempty
     UnknownNamesInPolarityPragmas{}   -> mempty
 
-  -- Not source code related
-  DuplicateInterfaceFiles{} -> mempty
-
   -- Backends
   CustomBackendWarning{} -> mempty
 

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -679,7 +679,6 @@ defaultOptions = Options
   , optGenerateVimFile       = False
   , optIgnoreInterfaces      = False
   , optIgnoreAllInterfaces   = False
-  , optLocalInterfaces       = False
   , optPragmaOptions         = defaultPragmaOptions
   , optOnlyScopeChecking     = False
   , optTransliterate         = False
@@ -1091,9 +1090,6 @@ ignoreInterfacesFlag o = return $ o { optIgnoreInterfaces = True }
 ignoreAllInterfacesFlag :: Flag CommandLineOptions
 ignoreAllInterfacesFlag o = return $ o { optIgnoreAllInterfaces = True }
 
-localInterfacesFlag :: Flag CommandLineOptions
-localInterfacesFlag o = return $ o { optLocalInterfaces = True }
-
 traceImportsFlag :: Maybe String -> Flag CommandLineOptions
 traceImportsFlag arg o = do
   mode <- case arg of
@@ -1310,8 +1306,6 @@ standardOptions =
                     "generate Vim highlighting files"
     , Option []     ["ignore-interfaces"] (NoArg ignoreInterfacesFlag)
                     "ignore interface files (re-type check everything)"
-    , Option []     ["local-interfaces"] (NoArg localInterfacesFlag)
-                    "put new interface files next to the Agda files they correspond to"
     , Option ['i']  ["include-path"] (ReqArg includeFlag "DIR")
                     "look for imports in DIR"
     , Option ['l']  ["library"] (ReqArg libraryFlag "LIB")
@@ -1336,6 +1330,7 @@ deadStandardOptions :: [OptDescr (Flag CommandLineOptions)]
 deadStandardOptions =
     [ removedOption "sharing"    msgSharing
     , removedOption "no-sharing" msgSharing
+    , removedOption "local-interfaces" "(in 2.8.0)"
     , Option []     ["ignore-all-interfaces"] (NoArg ignoreAllInterfacesFlag) -- not deprecated! Just hidden
                     "ignore all interface files (re-type check everything, including builtin files)"
       -- https://github.com/agda/agda/issues/3522#issuecomment-461010898

--- a/src/full/Agda/Interaction/Options/Types.hs
+++ b/src/full/Agda/Interaction/Options/Types.hs
@@ -68,7 +68,6 @@ data CommandLineOptions = Options
   , optGenerateVimFile       :: Bool
   , optIgnoreInterfaces      :: Bool
   , optIgnoreAllInterfaces   :: Bool
-  , optLocalInterfaces       :: Bool
   , optPragmaOptions         :: PragmaOptions
   , optOnlyScopeChecking     :: Bool
       -- ^ Should the top-level module only be scope-checked, and not type-checked?

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -375,8 +375,6 @@ data WarningName
   -- Cubical
   | FaceConstraintCannotBeHidden_
   | FaceConstraintCannotBeNamed_
-  -- Not source code related
-  | DuplicateInterfaceFiles_
   -- Backends
   | CustomBackendWarning_
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Generic)
@@ -609,7 +607,5 @@ warningNameDescription = \case
   -- Cubical
   FaceConstraintCannotBeHidden_    -> "Face constraint patterns that are given as implicit arguments."
   FaceConstraintCannotBeNamed_     -> "Face constraint patterns that are given as named arguments."
-  -- Not source code related
-  DuplicateInterfaceFiles_         -> "Duplicate interface files."
   -- Backends
   CustomBackendWarning_            -> "Custom warnings from backends."

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4675,8 +4675,6 @@ data Warning
     -- ^ Face constraint patterns @(i = 0)@ must be unnamed arguments.
 
   -- Not source code related
-  | DuplicateInterfaceFiles AbsolutePath AbsolutePath
-    -- ^ `DuplicateInterfaceFiles selectedInterfaceFile ignoredInterfaceFile`
   | CustomBackendWarning String Doc
     -- ^ Used for backend-specific warnings. The string is the backend name.
   deriving (Show, Generic)
@@ -4799,9 +4797,6 @@ warningName = \case
   FaceConstraintCannotBeHidden{} -> FaceConstraintCannotBeHidden_
   FaceConstraintCannotBeNamed{}  -> FaceConstraintCannotBeNamed_
 
-  -- Not source code related
-  DuplicateInterfaceFiles{}      -> DuplicateInterfaceFiles_
-
   -- Backend warnings
   CustomBackendWarning{} -> CustomBackendWarning_
 
@@ -4829,7 +4824,6 @@ illegalRewriteWarningName = \case
 --
 isSourceCodeWarning :: WarningName -> Bool
 isSourceCodeWarning = \case
-  DuplicateInterfaceFiles_ -> False
   WarningProblem_ -> False
   _ -> True
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -283,13 +283,6 @@ prettyWarning = \case
 
     ParseWarning pw -> pretty pw
 
-    DuplicateInterfaceFiles selected ignored -> vcat
-      [ fwords "There are two interface files:"
-      , nest 4 $ text $ filePath selected
-      , nest 4 $ text $ filePath ignored
-      , nest 2 $ fsep $ pwords "Using" ++ [text $ filePath selected] ++ pwords "for now but please remove at least one of them."
-      ]
-
     DeprecationWarning old new version -> fsep $
       [text old] ++ pwords "has been deprecated. Use" ++ [text new] ++ pwords
       "instead. This will be an error in Agda" ++ [text version <> "."]

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -101,8 +101,6 @@ instance EmbPrj Warning where
     FaceConstraintCannotBeHidden a        -> icodeN 47 FaceConstraintCannotBeHidden a
     FaceConstraintCannotBeNamed a         -> icodeN 48 FaceConstraintCannotBeNamed a
     PatternShadowsConstructor a b         -> icodeN 49 PatternShadowsConstructor a b
-    -- Not source code related, therefore they should never be serialized
-    DuplicateInterfaceFiles a b           -> __IMPOSSIBLE__
     ConfluenceCheckingIncompleteBecauseOfMeta a -> icodeN 50 ConfluenceCheckingIncompleteBecauseOfMeta a
     BuiltinDeclaresIdentifier a                 -> icodeN 51 BuiltinDeclaresIdentifier a
     ConfluenceForCubicalNotSupported            -> icodeN 52 ConfluenceForCubicalNotSupported

--- a/test/test-suite-covers-warnings.sh
+++ b/test/test-suite-covers-warnings.sh
@@ -24,7 +24,6 @@ ${AGDA_BIN:-agda} --help=warning | sed -nr 's/^([A-Z][a-z]+[A-Z][A-Za-z]+).*/\1/
 cat > $BENIGNWARNS <<EOF
 CustomBackendWarning
 DeprecationWarning
-DuplicateInterfaceFiles
 LibUnknownField
 EOF
 


### PR DESCRIPTION
Remove `--local-interfaces` and warning `DuplicateInterfaceFiles`.
`.agdai` files are now always placed in a versioned `_build` directory if an `.agda-lib` file exists for the project.

Closes #7675.
- #7675

@ibbem If I understood your explanations in #6988 correctly, removing `--local-interfaces` should be possible without sabotaging nix-setups of Agda.