### PR TITLE
Setup: fix `wantInterfaces` check

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -76,9 +76,10 @@ copyHook' pd lbi hooks flags = do
 -- If we're installing *just* the library, the interface files are not needed
 -- and, most importantly, the executable will not be available to be run (cabal#10235)
 wantInterfaces :: CopyFlags -> Bool
-wantInterfaces _flags =
-    any isAgdaExe (copyArgs _flags)
+wantInterfaces flags =
+    null args || any isAgdaExe args
       where
+        args = copyArgs flags
         isAgdaExe "exe:agda" = True
         isAgdaExe _ = False
 


### PR DESCRIPTION
Fixes https://github.com/agda/agda/issues/7673

Since https://github.com/agda/agda/pull/7657, we unconditionally check whether interfaces should be copied, but the check is incomplete: `wantInterfaces` checks if `exe:agda` is listed as a copy target, but the nixpkgs build runs `Setup copy` without arguments, which means "copy all components". In that case the interfaces should be generated.