### PR TITLE
Disallow several .agda-lib files in the project root (#7678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,11 @@ Changes to the meta-programming facilities.
 Library management
 ------------------
 
+* **BREAKING**: Agda no longer accepts several `.agda-lib` files in the root
+  of an Agda project.
+  (Previously, it allowed this and took the union of their contents.)
+
+
 Interaction and emacs mode
 --------------------------
 

--- a/doc/user-manual/tools/package-system.rst
+++ b/doc/user-manual/tools/package-system.rst
@@ -99,25 +99,26 @@ The ``.agda-lib`` files associated to a given Agda file
 -------------------------------------------------------
 
 When a given file is type-checked Agda uses the options from the
-``flags`` fields of zero or more library files. If the command-line
-option :option:`--no-libraries` is used, then no library files are
-used. Otherwise library files are found in the following way:
+``flags`` fields of its library file (if there is such).
+If the command-line option :option:`--no-libraries` is used,
+then no library file is used.
+Otherwise the library file is found in the following way:
 
 - First the file's root directory is found. If the top-level module in
   the file is called ``A.B.C``, then it has to be in the directory
   ``root/A/B`` or ``root\A\B``. The root directory is the directory
   ``root``.
 
-- If ``root`` contains any ``.agda-lib`` files, then these files are
-  used.
+- If ``root`` contains any ``.agda-lib`` files, then the search stops.
+  If there is exactly one such file, it is used,
+  otherwise an error is raised.
 
-- Otherwise a search is made upwards in the directory hierarchy, and
+- If ``root`` contains no ``.agda-lib`` files,
+  a search is made upwards in the directory hierarchy, and
   the search stops once one or more ``.agda-lib`` files are found in a
-  directory. If no ``.agda-lib`` files are found, then none are used.
-
-Note that if the search finds two or more ``.agda-lib`` files, then
-the flags from all of these files are used, and flags from different
-files are ordered in an unspecified way.
+  directory.
+  If no ``.agda-lib`` files are found all the way to the top of the directory hierarchy,
+  then none are used.
 
 Note also that there must not be any ``.agda-lib`` files below the
 root, on the path to the Agda file. For instance, if the top-level

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -277,13 +277,7 @@ findProjectConfig' root = do
       case libFiles of
         []     -> liftIO (upPath root) >>= \case
           Just up -> do
-            conf <- findProjectConfig' up
-            conf <- return $ case conf of
-                  DefaultProjectConfig{} -> conf
-                  ProjectConfig{..}      ->
-                    ProjectConfig{ configAbove = configAbove + 1
-                                 , ..
-                                 }
+            conf <- over lensConfigAbove (+ 1) <$> findProjectConfig' up
             storeCachedProjectConfig root conf
             return conf
           Nothing -> return DefaultProjectConfig

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -547,7 +547,7 @@ libraryIncludePaths overrideLibFile libs xs0 = mkLibM libs $ do
           ml <- case findLib x libs of
             [l] -> pure (Just l)
             []  -> Nothing <$ raiseErrors' [LibNotFound file x]
-            ls  -> Nothing <$ raiseErrors' [AmbiguousLib x ls]
+            l1 : l2 : ls  -> Nothing <$ raiseErrors' [AmbiguousLib x $ List2 l1 l2 ls]
           -- If it is found, add its dependencies to work list
           let xs' = foldMap _libDepends ml ++ xs
           mcons ml <$> find file (x : visited) xs'

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -26,7 +26,7 @@ module Agda.Interaction.Library
   , getInstalledLibraries
   , getTrustedExecutables
   , libraryIncludePaths
-  , getAgdaLibFiles'
+  , getAgdaLibFile
   , getPrimitiveLibDir
   , classifyBuiltinModule_
   , builtinModules
@@ -79,6 +79,7 @@ import qualified Agda.Utils.IO.UTF8 as UTF8
 import Agda.Utils.Lens
 import Agda.Utils.List
 import Agda.Utils.List1             ( List1, pattern (:|) )
+import Agda.Utils.List2             ( pattern List2 )
 import qualified Agda.Utils.List1   as List1
 import qualified Agda.Utils.List2   as List2
 import Agda.Utils.Maybe
@@ -258,15 +259,12 @@ classifyBuiltinModule_ primLibDir fp = do
 --
 --   If there are none, look in the parent directories until one is found.
 
-findProjectConfig
-  :: FilePath                          -- ^ Candidate (init: the directory Agda was called in)
-  -> LibM ProjectConfig                -- ^ Actual root and @.agda-lib@ files for this project
-findProjectConfig root = mkLibM [] $ findProjectConfig' root
-
-findProjectConfig'
-  :: FilePath                          -- ^ Candidate (init: the directory Agda was called in)
-  -> LibErrorIO ProjectConfig          -- ^ Actual root and @.agda-lib@ files for this project
-findProjectConfig' root = do
+findProjectConfig ::
+     FilePath
+       -- ^ Candidate (initially: the directory Agda was called in).
+  -> LibM ProjectConfig
+       -- ^ Actual root and @.agda-lib@ file for this project.
+findProjectConfig root = do
   getCachedProjectConfig root >>= \case
     Just conf -> return conf
     Nothing   -> handlePermissionException do
@@ -277,20 +275,22 @@ findProjectConfig' root = do
       case libFiles of
         []     -> liftIO (upPath root) >>= \case
           Just up -> do
-            conf <- over lensConfigAbove (+ 1) <$> findProjectConfig' up
+            conf <- over lensConfigAbove (+ 1) <$> findProjectConfig up
             storeCachedProjectConfig root conf
             return conf
           Nothing -> return DefaultProjectConfig
-        files -> do
-          let conf = ProjectConfig root files 0
+        [file] -> do
+          let conf = ProjectConfig root file 0
           storeCachedProjectConfig root conf
           return conf
+        f1:f2:files -> throwError $ LibErrors [] $ singleton $ LibError Nothing $
+          SeveralAgdaLibFiles root $ List2 f1 f2 files
 
   where
     -- Andreas, 2024-06-26, issue #7331:
     -- In case of missing permission we terminate our search for the project file
     -- with the default value.
-    handlePermissionException :: LibErrorIO ProjectConfig -> LibErrorIO ProjectConfig
+    handlePermissionException :: LibM ProjectConfig -> LibM ProjectConfig
     handlePermissionException = flip catchIO \ e ->
       if isPermissionError e then return DefaultProjectConfig else liftIO $ E.throwIO e
 
@@ -321,13 +321,13 @@ findProjectRoot root = findProjectConfig root <&> \case
   DefaultProjectConfig -> Nothing
 
 
--- | Get the contents of @.agda-lib@ files in the given project root.
-getAgdaLibFiles' :: FilePath -> LibErrorIO [AgdaLibFile]
-getAgdaLibFiles' path = findProjectConfig' path >>= \case
+-- | Get the content of the @.agda-lib@ file in the given project root.
+getAgdaLibFile :: FilePath -> LibM [AgdaLibFile]
+getAgdaLibFile path = findProjectConfig path >>= \case
   DefaultProjectConfig          -> return []
-  ProjectConfig root libs above ->
+  ProjectConfig root file above -> mkLibM [] $
     map (set libAbove above) <$>
-    parseLibFiles Nothing (map ((0,) . (root </>)) libs)
+    parseLibFiles Nothing [(0, root </> file)]
 
 -- | Get dependencies and include paths for given project root:
 --
@@ -339,10 +339,10 @@ getDefaultLibraries
   :: FilePath  -- ^ Project root.
   -> Bool      -- ^ Use @defaults@ if no @.agda-lib@ file exists for this project?
   -> LibM ([LibName], [FilePath])  -- ^ The returned @LibName@s are all non-empty strings.
-getDefaultLibraries root optDefaultLibs = mkLibM [] $ do
-  libs <- getAgdaLibFiles' root
+getDefaultLibraries root optDefaultLibs = do
+  libs <- getAgdaLibFile root
   if null libs
-    then (,[]) <$> if optDefaultLibs then (libNameForCurrentDir :) <$> readDefaultsFile else return []
+    then (,[]) <$> if optDefaultLibs then mkLibM [] $ (libNameForCurrentDir :) <$> readDefaultsFile else return []
     else return $ libsAndPaths libs
   where
     libsAndPaths ls = ( concatMap _libDepends ls

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -257,7 +257,7 @@ data LibError'
       -- ^ Raised when a library name could not successfully be resolved
       --   to an @.agda-lib@ file.
       --
-  | AmbiguousLib LibName [AgdaLibFile]
+  | AmbiguousLib LibName (List2 AgdaLibFile)
       -- ^ Raised when a library name is defined in several @.agda-lib files@.
   | LibParseError LibParseError
       -- ^ The @.agda-lib@ file could not be parsed.
@@ -477,7 +477,7 @@ instance Pretty LibError' where
       sep [ hcat [ "Ambiguous library '", pretty lib, "'." ]
             , "Could refer to any one of"
           ]
-        : [ nest 2 $ pretty (_libName l) <+> parens (text $ _libFile l) | l <- tgts ]
+        : [ nest 2 $ pretty (_libName l) <+> parens (text $ _libFile l) | l <- toList tgts ]
 
     LibParseError err -> pretty err
 

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -179,7 +179,18 @@ emptyLibFile = AgdaLibFile
   , _libPragmas  = mempty
   }
 
--- | Lenses for AgdaLibFile
+---------------------------------------------------------------------------
+-- * Lenses
+---------------------------------------------------------------------------
+
+-- ** Lenses for 'ProjectConfig'
+
+lensConfigAbove :: Lens' ProjectConfig Int
+lensConfigAbove f = \case
+  DefaultProjectConfig -> DefaultProjectConfig <$ f 0
+  c@ProjectConfig{} -> f (configAbove c) <&> \ !i -> c{ configAbove = i }
+
+-- ** Lenses for 'AgdaLibFile'
 
 libName :: Lens' AgdaLibFile LibName
 libName f a = f (_libName a) <&> \ x -> a { _libName = x }

--- a/src/full/Agda/Interaction/Library/Base.hs
+++ b/src/full/Agda/Interaction/Library/Base.hs
@@ -115,10 +115,11 @@ libNameForCurrentDir = LibName "." []
 data ProjectConfig
   = ProjectConfig
     { configRoot         :: FilePath
+        -- ^ Directory which contains the @.agda-lib@ file(s) for the current project.
     , configAgdaLibFiles :: [FilePath]
+        -- ^ @.agda-lib@ files relative to 'configRoot' (filenames only, no directory).
     , configAbove        :: !Int
-      -- ^ How many directories above the Agda file is the @.agda-lib@
-      -- file located?
+        -- ^ How many directories above the Agda file is the @.agda-lib@ file located?
     }
   | DefaultProjectConfig
   deriving Generic

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -154,7 +154,7 @@ getAgdaLibFilesWithoutTopLevelModuleName
   -> TCM [AgdaLibFile]
 getAgdaLibFilesWithoutTopLevelModuleName f = do
   useLibs <- optUseLibs <$> commandLineOptions
-  if | useLibs   -> libToTCM $ mkLibM [] $ getAgdaLibFiles' root
+  if | useLibs   -> libToTCM $ getAgdaLibFile root
      | otherwise -> return []
   where
   root = takeDirectory $ filePath f

--- a/src/full/Agda/Utils/IO.hs
+++ b/src/full/Agda/Utils/IO.hs
@@ -5,6 +5,7 @@
 module Agda.Utils.IO where
 
 import Control.Exception
+import Control.Monad.Except
 import Control.Monad.State
 import Control.Monad.Writer
 
@@ -20,6 +21,11 @@ class CatchIO m where
 --
 instance CatchIO IO where
   catchIO = catch
+
+-- | Upon exception, the error is lost.
+
+instance CatchIO m => CatchIO (ExceptT e m) where
+  catchIO m h = ExceptT $ runExceptT m `catchIO` \ e -> runExceptT (h e)
 
 -- | Upon exception, the written output is lost.
 --

--- a/test/Fail/Installed.err
+++ b/test/Fail/Installed.err
@@ -4,4 +4,4 @@ Add the path to its .agda-lib file to
   installed-libs/libraries'
 to install.
 Installed libraries:
-  test-succeed (succeed2.agda-lib)
+  test-succeed (succeed.agda-lib)

--- a/test/Fail/Issue7678/Issue7678.agda
+++ b/test/Fail/Issue7678/Issue7678.agda
@@ -1,0 +1,2 @@
+-- Andreas, 2025-01-15, issue #7678
+-- Disallow several library files in one directory.

--- a/test/Fail/Issue7678/Issue7678.err
+++ b/test/Fail/Issue7678/Issue7678.err
@@ -1,0 +1,5 @@
+error: [LibraryError]
+The project root Issue7678
+may contain only one .agda-lib file, but I found several:
+- one.agda-lib
+- two.agda-lib

--- a/test/Fail/Issue7678/one.agda-lib
+++ b/test/Fail/Issue7678/one.agda-lib
@@ -1,0 +1,2 @@
+name: one
+include: .

--- a/test/Fail/Issue7678/two.agda-lib
+++ b/test/Fail/Issue7678/two.agda-lib
@@ -1,0 +1,2 @@
+name: two
+include: .

--- a/test/Fail/Tests.hs
+++ b/test/Fail/Tests.hs
@@ -30,13 +30,15 @@ tests = do
   inpFiles <- getAgdaFilesInDir NonRec testDir
   return $ testGroup "Fail" $ concat $
     -- A list written with ':' to quickly switch lines
-    map mkFailTest inpFiles :
-    -- The some of the customized tests fail with agda-quicker
+    [ mkFailTest issue7678Dir (issue7678Dir </> "Issue7678.agda") ] :
+    map (mkFailTest testDir) inpFiles :
+    -- Some of the customized tests fail with agda-quicker
     -- (because they refer to the name of the Agda executable),
     -- so put them last.
     customizedTests :
     []
   where
+  issue7678Dir = testDir </> "Issue7678"
   customizedTests =
     [ testGroup "customised" $
         issue6465 :
@@ -51,10 +53,11 @@ data TestResult
   = TestResult T.Text -- the cleaned stdout
   | TestUnexpectedSuccess ProgramResult
 
-mkFailTest
-  :: FilePath -- ^ Input file (Agda file).
+mkFailTest ::
+     FilePath -- ^ Directory
+  -> FilePath -- ^ Input file (Agda file).
   -> TestTree
-mkFailTest agdaFile =
+mkFailTest testDir agdaFile =
   goldenTestIO1
     testName
     readGolden

--- a/test/Succeed/installed-libs/libraries
+++ b/test/Succeed/installed-libs/libraries
@@ -1,2 +1,2 @@
-test/Succeed/succeed2.agda-lib
-test/Succeed/succeed2.agda-lib
+test/Succeed/succeed.agda-lib
+test/Succeed/succeed.agda-lib

--- a/test/Succeed/succeed2.agda-lib
+++ b/test/Succeed/succeed2.agda-lib
@@ -1,5 +1,0 @@
-name: test-succeed
-
-include:
-  .
-  ..


### PR DESCRIPTION
This changes Agda to not accept several `.agda-lib` files for a project anymore.

Commits:
- **[refactor] factor out lensConfigAbove**
- **Re #7678: document ProjectConfig fields**
- **Re #7678: forbid several .agda-lib files in the project root**

TODO:
- [x] test