### PR TITLE
Make toTerm return a monadic function

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -359,6 +359,7 @@ common language
       TypeOperators
       TypeSynonymInstances
       ViewPatterns
+      TypeApplications
 
   other-extensions:
       AllowAmbiguousTypes
@@ -376,7 +377,6 @@ common language
       PolyKinds
       RebindableSyntax
       TemplateHaskell
-      TypeApplications
       UnboxedTuples
       UndecidableInstances
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3373,12 +3373,12 @@ redReturn = return . YesReduction YesSimplification
 
 -- | Conceptually: @redBind m f k = either (return . Left . f) k =<< m@
 
-redBind :: ReduceM (Reduced a a') -> (a -> b) ->
+redBind :: ReduceM (Reduced a a') -> (a -> ReduceM b) ->
            (a' -> ReduceM (Reduced b b')) -> ReduceM (Reduced b b')
 redBind ma f k = do
   r <- ma
   case r of
-    NoReduction x    -> return $ NoReduction $ f x
+    NoReduction x    -> NoReduction <$> f x
     YesReduction _ y -> k y
 
 -- | Three cases: 1. not reduced, 2. reduced, but blocked, 3. reduced, not blocked.
@@ -5687,12 +5687,6 @@ runReduceM m = TCM $ \ r e -> do
   --   e <- askTC
   --   s <- getTC
   --   return $! unReduceM m (ReduceEnv e s)
-
-runReduceF :: (a -> ReduceM b) -> TCM (a -> b)
-runReduceF f = do
-  e <- askTC
-  s <- getTC
-  return $ \x -> unReduceM (f x) (ReduceEnv e s Nothing)
 
 instance MonadTCEnv ReduceM where
   askTC   = ReduceM redEnv

--- a/src/full/Agda/TypeChecking/Substitute/Class.hs
+++ b/src/full/Agda/TypeChecking/Substitute/Class.hs
@@ -39,6 +39,10 @@ applys t vs = apply t $ map defaultArg vs
 apply1 :: Apply t => t -> Term -> t
 apply1 t u = applys t [ u ]
 
+-- | Apply to two default arguments.
+apply2 :: Apply t => t -> Term -> Term -> t
+apply2 t u v = applys t [u, v]
+
 ---------------------------------------------------------------------------
 -- * Abstraction
 ---------------------------------------------------------------------------


### PR DESCRIPTION
This opens the possibility for `ReduceM` running in `IO`, which we need if we want to unify `ReduceM` and `TCM`