### PR TITLE
Fix #7696: Add missing `addContext` when splitting on literals

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1270,7 +1270,7 @@ checkLHS mf = updateModality checkLHS_ where
 
       -- check that a is indeed the type of lit (otherwise fail softly)
       -- if not, fail softly since it could be instantiated by a later split.
-      suspendErrors $ equalType a =<< litType lit
+      suspendErrors $ addContext delta1 $ equalType a =<< litType lit
 
       -- Compute the new state
       let problem' = set problemEqs eqs' problem

--- a/test/Succeed/Issue7696.agda
+++ b/test/Succeed/Issue7696.agda
@@ -1,0 +1,14 @@
+-- Reported by noughtmare
+
+open import Agda.Builtin.Char
+
+postulate
+  A : Set
+  a : A
+
+B : A → Set
+f : (x : A) → B x → A
+
+B = _
+f _ 'a' = a
+f _ _ = a


### PR DESCRIPTION
Fixes #7696.
