### PR TITLE
Issue #7714: New cabal flag -f Werror to control -Werror

### DIFF
--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -22,7 +22,7 @@ jobs:
         access_token: ${{ github.token }}
   cabal-install:
     env:
-      FLAGS: -O0 -f enable-cluster-counting
+      FLAGS: -O0 -f enable-cluster-counting -f Werror
     name: cabal install ${{ matrix.name }}
     needs: auto-cancel
     runs-on: ubuntu-24.04

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -22,8 +22,8 @@ jobs:
         access_token: ${{ github.token }}
   cabal:
     env:
-      FLAGS: ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting'
-        }}
+      FLAGS: ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting
+        -f Werror' }}
       GHC_VER: ${{ matrix.ghc-ver || '9.10.1' }}
     name: Cabal ${{ matrix.description }}, ${{ matrix.ghc-ver }}
     needs: auto-cancel
@@ -102,7 +102,7 @@ jobs:
       fail-fast: false
       matrix:
         cabal-flags:
-        - --enable-tests -f enable-cluster-counting
+        - --enable-tests -f enable-cluster-counting -f Werror
         description:
         - Linux
         doctest:
@@ -117,17 +117,17 @@ jobs:
         - 8.10.7
         - 8.8.4
         include:
-        - cabal-flags: --disable-tests
+        - cabal-flags: --disable-tests -f Werror
           description: Linux doctest
           doctest: true
           ghc-ver: 9.10.1
           os: ubuntu-24.04
-        - cabal-flags: --enable-tests -f debug
+        - cabal-flags: --enable-tests -f debug -f Werror
           description: Linux debug
           ghc-ver: 9.10.1
           os: ubuntu-24.04
         - cabal-flags: --enable-tests -f enable-cluster-counting -f debug -f debug-serialisation
-            -f debug-parsing
+            -f debug-parsing -f Werror
           description: Linux debug all
           ghc-ver: 9.10.1
           os: ubuntu-24.04

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         shell: bash
     env:
-      EXTRA_ARGS: --fast
+      EXTRA_ARGS: --fast --flag Agda:Werror
       NON_DEFAULT_FLAGS: --flag Agda:enable-cluster-counting --flag Agda:debug
     needs: auto-cancel
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -22,6 +22,9 @@ jobs:
     - name: Check building the source tarball
       run: |
         cabal sdist
+    - name: Check the cabal file
+      run: |
+        cabal check
 name: Whitespace
 'on':
   pull_request: null

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -199,6 +199,12 @@ flag optimise-heavily
   description:
     Enable some expensive optimisations when compiling Agda.
 
+flag Werror
+  default: False
+  manual: True
+  description:
+    Compile with -Werror, recommended for development.
+
 -- Common stanzas
 ---------------------------------------------------------------------------
 
@@ -219,47 +225,48 @@ common language
 
   ghc-options:
       -- ASR (2022-05-31). Workaround to Issue #5932.
-      -Werror
-      -Werror=cpp-undef
-      -Werror=deprecated-flags
-      -Werror=deriving-typeable
-      -Werror=dodgy-exports
-      -Werror=dodgy-foreign-imports
-      -Werror=dodgy-imports
-      -Werror=duplicate-exports
-      -Werror=empty-enumerations
-      -Werror=identities
-      -Werror=inaccessible-code
-      -Werror=inline-rule-shadowing
-      -Werror=missed-extra-shared-lib
-      -Werror=missing-fields
-      -Werror=missing-home-modules
-      -Werror=missing-methods
-      -Werror=missing-pattern-synonym-signatures
-      -Werror=missing-signatures
-      -Werror=noncanonical-monad-instances
-      -Werror=noncanonical-monoid-instances
-      -Werror=overflowed-literals
-      -Werror=overlapping-patterns
---      -Werror=redundant-constraints
-      -Werror=simplifiable-class-constraints
-      -Werror=star-binder
-      -Werror=star-is-type
-      -Werror=tabs
-      -Werror=typed-holes
-      -Werror=unbanged-strict-patterns
-      -Werror=unrecognised-pragmas
-      -Werror=unrecognised-warning-flags
-      -Werror=unticked-promoted-constructors
-      -Werror=unused-do-bind
-      -Werror=unused-foralls
-      -Werror=warnings-deprecations
-      -Werror=wrong-do-bind
+      -- Andreas (2025-02-20).  This issue has been fixed on GHC 9.4 and up.
+      -- We do not recommend development with an older version of GHC.
+      -Wcpp-undef
+      -Wdeprecated-flags
+      -Wderiving-typeable
+      -Wdodgy-exports
+      -Wdodgy-foreign-imports
+      -Wdodgy-imports
+      -Wduplicate-exports
+      -Wempty-enumerations
+      -Widentities
+      -Winaccessible-code
+      -Winline-rule-shadowing
+      -Wmissed-extra-shared-lib
+      -Wmissing-fields
+      -Wmissing-home-modules
+      -Wmissing-methods
+      -Wmissing-pattern-synonym-signatures
+      -Wmissing-signatures
+      -Wnoncanonical-monad-instances
+      -Wnoncanonical-monoid-instances
+      -Woverflowed-literals
+      -Woverlapping-patterns
+--      -Wredundant-constraints
+      -Wsimplifiable-class-constraints
+      -Wstar-binder
+      -Wstar-is-type
+      -Wtabs
+      -Wtyped-holes
+      -Wunbanged-strict-patterns
+      -Wunrecognised-pragmas
+      -Wunrecognised-warning-flags
+      -Wunticked-promoted-constructors
+      -Wunused-do-bind
+      -Wunused-foralls
+      -Wwarnings-deprecations
+      -Wwrong-do-bind
 
   -- The following warning is an error in GHC >= 8.10.
   if impl(ghc < 8.10)
     ghc-options:
-      -Werror=implicit-kind-vars
+      -Wimplicit-kind-vars
       -- #6623: Turn off this (nameless) warning:
       -- "Pattern match checker exceeded (2000000) iterations in a case alternative."
       -- See: https://gitlab.haskell.org/ghc/ghc/-/issues/13464
@@ -268,44 +275,49 @@ common language
 
   if impl(ghc < 9.10)
     ghc-options:
-      -Werror=semigroup
+      -Wsemigroup
         -- The semigroup warning is deprecated in GHC 9.10
 
   if impl(ghc >= 8.10)
     ghc-options:
-      -Werror=compat-unqualified-imports
-      -Werror=deriving-defaults
-      -Werror=redundant-record-wildcards
-      -Werror=unused-packages
-      -Werror=unused-record-wildcards
+      -Wcompat-unqualified-imports
+      -Wderiving-defaults
+      -Wredundant-record-wildcards
+      -Wunused-packages
+      -Wunused-record-wildcards
 
   if impl(ghc >= 9.0)
     ghc-options:
-      -Werror=invalid-haddock
+      -Winvalid-haddock
       -- #6137: coverage checker works only sufficiently well from GHC 9.0
-      -Werror=incomplete-patterns
-      -Werror=incomplete-record-updates
-      -Werror=overlapping-patterns
+      -Wincomplete-patterns
+      -Wincomplete-record-updates
+      -Woverlapping-patterns
 
   -- ASR (2022-04-27). This warning was added in GHC 9.0.2, removed
   -- from 9.2.1 and added back in 9.2.2.
   if impl(ghc == 9.0.2 || >= 9.2.2)
     ghc-options:
-      -Werror=unicode-bidirectional-format-characters
+      -Wunicode-bidirectional-format-characters
 
   if impl(ghc >= 9.2)
     ghc-options:
-      -Werror=operator-whitespace
-      -Werror=redundant-bang-patterns
+      -Woperator-whitespace
+      -Wredundant-bang-patterns
 
   if impl(ghc >= 9.4)
     ghc-options:
-      -Werror=type-equality-out-of-scope
+      -Wtype-equality-out-of-scope
 
   if impl(ghc >= 9.4 && < 9.10)
     ghc-options:
-      -Werror=forall-identifier
+      -Wforall-identifier
         -- The forall-identifier warning is deprecated in GHC 9.10
+
+  -- Andreas, 2025-02-20: This must be last as it affects the status of all warnings.
+  if flag(Werror)
+    ghc-options:
+      -Werror
 
   default-language: Haskell2010
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Installation
   compilation of Agda. This can be useful for people working on improving the
   performance of the Agda implementation.
 
+* New cabal flag `Werror` that turns our selection of GHC warnings into errors
+  during compilation of Agda.  Should be interesting to developers only.
+
 Pragmas and options
 -------------------
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -142,6 +142,72 @@ Standard library submodule
 
   See: https://www.git-scm.com/book/en/v2/Git-Tools-Submodules
 
+
+Building Agda
+=============
+
+Since: February 2025.
+
+* The cabal flag `Werror` turns (our selection of) GHC warnings into errors.
+  During development, this flag should be on.
+
+  - When building Agda with `cabal`, pass `-f Werror`.
+    Or make sure to have either `flags: +Werror` in a `cabal.project.local`
+    of the following in `cabal.project`:
+    ```
+    package Agda`2
+      flags: +Werror
+    ```
+  - When building with `stack`, pass `--flag Agda:Werror`.
+    Or put the following in your `stack.yaml`:
+    ```yaml
+    flags:
+      Agda:
+        Werror: true
+    ```
+
+  All build commands in the `Makefile`, e.g. `make install`, automatically switch on `Werror`.
+
+Faster compilation of Agda
+--------------------------
+
+Since: November 2021.
+
+* When you run `make install`, then the option optimise-heavily is by
+  default activated. If you want to override this option (for faster
+  build times, at the cost of possibly making Agda slower), then you
+  can include the following text in `mk/config.mk`, which is ignored
+  by Git:
+  ```
+  CABAL_FLAG_OPTIM_HEAVY =
+  STACK_FLAG_OPTIM_HEAVY =
+  ```
+
+Since: April 2020.
+
+* `make type-check` just type-checks the Agda source, generating no code.
+  Can be 7 times faster as `make quicker-install-bin` (max 40s vs. max 5min).
+  Once all type errors are fixed, switch to `quicker-install-bin` or `install-bin`
+  for testing.
+
+Since: July 2019.
+
+* `make quicker-install-bin` compiles Agda will all optimizations turned off (`-O0`).
+  This could be e.g. 5 times as fast (5min instead of 25min).
+
+* Recommended during the development process of a refactoring, new feature or bug fix.
+  Not recommended when building Agda for Agda development.
+  Unoptimized Agda is slooooow.
+
+* The generated executables have the suffix `-quicker`, e.g., `agda-quicker`.
+
+* In Emacs, activate this version of Agda via
+  `M-x agda2-set-program-version RET quicker RET`.
+
+* Running the testsuite requires some tinkering.  E.g., the interactive testsuite
+  can be run via `make -C test/interaction AGDA_BIN=agda-quicker`.
+
+
 Testing and documentation
 =========================
 
@@ -486,45 +552,6 @@ Emacs mode
                   (goto-char (point-max))
                   (insert "\n")))))))
   ```
-
-Faster compilation of Agda
-==========================
-
-Since: November 2021.
-
-* When you run `make install`, then the option optimise-heavily is by
-  default activated. If you want to override this option (for faster
-  build times, at the cost of possibly making Agda slower), then you
-  can include the following text in `mk/config.mk`, which is ignored
-  by Git:
-  ```
-  CABAL_FLAG_OPTIM_HEAVY =
-  STACK_FLAG_OPTIM_HEAVY =
-  ```
-
-Since: April 2020.
-
-* `make type-check` just type-checks the Agda source, generating no code.
-  Can be 7 times faster as `make quicker-install-bin` (max 40s vs. max 5min).
-  Once all type errors are fixed, switch to `quicker-install-bin` or `install-bin`
-  for testing.
-
-Since: July 2019.
-
-* `make quicker-install-bin` compiles Agda will all optimizations turned off (`-O0`).
-  This could be e.g. 5 times as fast (5min instead of 25min).
-
-* Recommended during the development process of a refactoring, new feature or bug fix.
-  Not recommended when building Agda for Agda development.
-  Unoptimized Agda is slooooow.
-
-* The generated executables have the suffix `-quicker`, e.g., `agda-quicker`.
-
-* In Emacs, activate this version of Agda via
-  `M-x agda2-set-program-version RET quicker RET`.
-
-* Running the testsuite requires some tinkering.  E.g., the interactive testsuite
-  can be run via `make -C test/interaction AGDA_BIN=agda-quicker`.
 
 
 Bisecting: Finding the commit that introduced a regression

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,9 @@ STACK_FLAG_ICU    = --flag Agda:enable-cluster-counting
 CABAL_FLAG_OPTIM_HEAVY ?= -foptimise-heavily
 STACK_FLAG_OPTIM_HEAVY ?= --flag Agda:optimise-heavily
 
-CABAL_INSTALL_HELPER = $(CABAL) $(CABAL_INSTALL_CMD) $(CABAL_OPT_NO_DOCS)
-STACK_INSTALL_HELPER = $(STACK) build Agda $(STACK_OPT_NO_DOCS)
+# This is the base for all build commands.
+CABAL_INSTALL_HELPER = $(CABAL) $(CABAL_INSTALL_CMD) $(CABAL_OPT_NO_DOCS) -fWerror
+STACK_INSTALL_HELPER = $(STACK) build Agda $(STACK_OPT_NO_DOCS) --flag Agda:Werror
 
 # 2016-07-15. We use a different build directory in the quick
 # installation for avoiding recompilation (see Issue #2083 and

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -384,6 +384,13 @@ When installing Agda the following flags can be used:
      Optimise Agda heavily. (In this case it might make sense to limit
      GHC's memory usage.) Default: off.
 
+.. option:: Werror
+
+     Turns GHC warnings into errors during compilation of Agda itself.
+     Has no effect on the resulting Agda binary.
+     Only interesting for developing Agda.
+     Default: off.
+
 .. hint:: During ``cabal install`` you can add build flags using the ``-f`` argument:
     ``cabal install -fenable-cluster-counting``. Whereas stack uses ``--flag`` and an
     ``Agda:`` prefix, like this: ``stack install --flag Agda:enable-cluster-counting``.

--- a/notes/agda-releases-candidates.txt
+++ b/notes/agda-releases-candidates.txt
@@ -110,10 +110,7 @@ followed:
 
 3) Remove the Cabal test-suite from Agda.cabal.
 
-4) Remove -Werror from Agda.cabal (this is required by `cabal
-   --check`).
-
-5) Remove unnecessary dependencies from stack-XYZ.yaml files:
+4) Remove unnecessary dependencies from stack-XYZ.yaml files:
 
   + Remove the `packages` section.
   + Remove dependencies QuickCheck, random, splitmix

--- a/notes/agda-releases.txt
+++ b/notes/agda-releases.txt
@@ -100,10 +100,7 @@ When releasing the following procedure can be followed:
 
 3) Remove the Cabal test-suite from Agda.cabal.
 
-4) Remove -Werror from Agda.cabal (this is required by `cabal
-   --check`).
-
-5) Remove unnecessary dependencies from stack-XYZ.yaml files:
+4) Remove unnecessary dependencies from stack-XYZ.yaml files:
 
   + Remove QuickCheck dependency
   + Remove tasty-* dependencies

--- a/src/github/workflows/cabal-install.yml
+++ b/src/github/workflows/cabal-install.yml
@@ -53,7 +53,7 @@ jobs:
           install_flags: "--lib"
 
     env:
-      FLAGS: "-O0 -f enable-cluster-counting"
+      FLAGS: "-O0 -f enable-cluster-counting -f Werror"
 
     steps:
     - uses: actions/checkout@v4

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -50,7 +50,7 @@ jobs:
         os: [ubuntu-24.04]
         description: [Linux]      ## This just for pretty-printing the job name.
         ghc-ver: [9.10.1, 9.8.4, 9.6.6, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4]
-        cabal-flags: ['--enable-tests -f enable-cluster-counting']
+        cabal-flags: ['--enable-tests -f enable-cluster-counting -f Werror']
         doctest: [false]
         include:
           ## Latest GHC, special builds
@@ -60,14 +60,14 @@ jobs:
             description: Linux doctest
             ghc-ver: '9.10.1'
             # Can't leave cabal-flags empty here lest it becomes the default value.
-            cabal-flags: '--disable-tests'
+            cabal-flags: '--disable-tests -f Werror'
             doctest: true
 
           # Linux, without -f enable-cluster-counting but with -f debug
           - os: ubuntu-24.04
             description: Linux debug
             ghc-ver: '9.10.1'
-            cabal-flags: '--enable-tests -f debug'
+            cabal-flags: '--enable-tests -f debug -f Werror'
 
           # Linux, with all debug options
           - os: ubuntu-24.04
@@ -77,7 +77,7 @@ jobs:
             ## Note: -c 'containers >= 0.7' with single quotes does not get communicated properly.
             ## (The single quotes stay, and "-c 'containers" is an option parse error for cabal.)
             cabal-flags: >-
-              --enable-tests -f enable-cluster-counting -f debug -f debug-serialisation -f debug-parsing
+              --enable-tests -f enable-cluster-counting -f debug -f debug-serialisation -f debug-parsing -f Werror
 
           # macOS with default flags
           - os: macos-14
@@ -92,7 +92,7 @@ jobs:
     # Default values
     env:
       GHC_VER:   ${{ matrix.ghc-ver || '9.10.1' }}
-      FLAGS:     ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting' }}
+      FLAGS:     ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting -f Werror' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -68,7 +68,7 @@ jobs:
     env:
       ## ARGS is set later, depending on the actually picked GHC version
       # ARGS: "--stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal"
-      EXTRA_ARGS: "--fast"
+      EXTRA_ARGS: "--fast --flag Agda:Werror"
       NON_DEFAULT_FLAGS: "--flag Agda:enable-cluster-counting --flag Agda:debug"
 
     # Need bash on Windows for piping and evaluation.

--- a/src/github/workflows/whitespace.yml
+++ b/src/github/workflows/whitespace.yml
@@ -29,3 +29,7 @@ jobs:
     - name: Check building the source tarball
       run: |
         cabal sdist
+
+    - name: Check the cabal file
+      run: |
+        cabal check


### PR DESCRIPTION
This simplifies the release process, as one does not need to manually replace `-Werror` by `-Wwarn` before release.

Closes #7714.
