### PR TITLE
Tiny optimizations in the operator parser

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -23,7 +23,6 @@ import Control.Applicative ( Alternative((<|>)))
 import Control.Monad.Except (throwError)
 
 import Data.Either (partitionEithers)
-import qualified Data.Foldable as Fold
 import qualified Data.Function
 import qualified Data.List as List
 import Data.Maybe
@@ -328,7 +327,7 @@ buildParsers kind exprNames = do
 
     let g = Data.Function.fix $ \p -> InternalParsers
               { pTop    = memoise TopK $
-                          Fold.asum $
+                          Agda.Utils.List.asum $
                             foldr (\(l, ns) higher ->
                                        mkP (Right l) parseSections
                                            (pTop p) ns higher True) (pApp p)
@@ -339,7 +338,7 @@ buildParsers kind exprNames = do
               , pApp    = memoise AppK $ appP (pNonfix p) (pArgs p)
               , pArgs   = argsP (pNonfix p)
               , pNonfix = memoise NonfixK $
-                          Fold.asum $
+                          Agda.Utils.List.asum $
                             pAtom p :
                             map (\sect ->
                               let n = sectNotation sect
@@ -404,7 +403,7 @@ buildParsers kind exprNames = do
             -> Parser e e
         mkP key parseSections p0 ops higher includeHigher =
             memoise (NodeK key) $
-              Fold.asum $
+              Agda.Utils.List.asum $
                 applyWhen includeHigher (higher :) $
                 catMaybes [nonAssoc, preRights, postLefts]
             where
@@ -412,7 +411,7 @@ buildParsers kind exprNames = do
                       NK k -> [NotationSection] ->
                       Parser e (OperatorType k e)
             choice k =
-              Fold.asum .
+              Agda.Utils.List.asum .
               map (\sect ->
                 let n = sectNotation sect
 

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -11,6 +11,8 @@ import Data.List as X (uncons)
 -- Regular imports
 
 import Control.Monad (filterM)
+import Control.Applicative (Alternative, (<|>))
+import qualified Control.Applicative as A
 
 import Data.Array (Array, array, listArray)
 import qualified Data.Array as Array
@@ -160,6 +162,24 @@ initMaybe = \case
 initWithDefault :: [a] -> [a] -> [a]
 initWithDefault as []     = as
 initWithDefault _  (a:as) = init1 a as
+
+---------------------------------------------------------------------------
+-- * Iterators
+---------------------------------------------------------------------------
+
+-- | A version of 'Foldable.asum' that avoids a final 'A.empty'.
+--   It is right-folding just like 'Foldable.asum'.
+--
+--   Precondition: the right-unit law holds, i.e. @m <|> A.empty = m@.
+asum :: Alternative m => [m a] -> m a
+asum []     = A.empty
+asum (x:xs) = asum1 x xs
+
+-- | A right-folding 'Foldable.asum' for nonempty lists,
+--   never producing 'A.empty'.
+asum1 :: Alternative m => m a -> [m a] -> m a
+asum1 x []     = x
+asum1 x (y:ys) = x <|> asum1 y ys
 
 ---------------------------------------------------------------------------
 -- * Lookup and indexing


### PR DESCRIPTION
- **Refactor re #7722: a smarter `asum` that skips the final `(<|> empty)`**
- **[refactor] Operator parser: defunctionalize `choice`**
