### PR TITLE
Fix #7722: in pattern parser only consider pattern-relevant operators

### DIFF
--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -164,6 +164,11 @@ instance IsBool DisplayLHS where
     YesDisplayLHS -> True
     NoDisplayLHS -> False
 
+-- | Expression kinds: Expressions or patterns.
+
+data ExprKind = IsExpr | IsPattern
+  deriving (Eq, Show)
+
 ---------------------------------------------------------------------------
 -- * Record Directives
 ---------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -47,7 +47,7 @@ import qualified Agda.TypeChecking.Monad.Benchmark as Bench
 import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.State (getScope)
 
-import Agda.Utils.Function (applyWhen)
+import Agda.Utils.Function (applyWhen, applyWhenJust)
 import Agda.Utils.Either
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.List
@@ -89,10 +89,6 @@ data InternalParsers e = InternalParsers
   , pAtom   :: Parser e e
   }
 
--- | Expression kinds: Expressions or patterns.
-data ExprKind = IsExpr | IsPattern
-  deriving (Eq, Show)
-
 -- | The data returned by 'buildParsers'.
 
 data Parsers e = Parsers
@@ -129,6 +125,8 @@ buildParsers
   :: forall e. IsExpr e
   => ExprKind
      -- ^ Should expressions or patterns be parsed?
+  -> Maybe QName
+     -- ^ Are we trying to parse the lhs of the function given here?
   -> [QName]
      -- ^ This list must include every name part in the
      -- expression/pattern to be parsed (excluding name parts inside
@@ -138,10 +136,11 @@ buildParsers
      -- grammar if all of the notation's name parts are present in
      -- the list of names.
   -> ScopeM (Parsers e)
-buildParsers kind exprNames = do
+buildParsers kind top exprNames0 = do
+    let exprNames = applyWhenJust top (:) exprNames0
     flat         <- flattenScope (qualifierModules exprNames) <$>
                       getScope
-    (names, ops0) <- localNames flat
+    (names, ops0) <- localNames kind top flat
     let ops | kind == IsPattern = filter (not . isLambdaNotation) ops0
             | otherwise         = ops0
 
@@ -584,7 +583,7 @@ parseLHS' NoDisplayLHS IsLHS (Just qn) WildP{} =
 parseLHS' displayLhs lhsOrPatSyn top p = do
 
     -- Build parser.
-    patP <- buildParsers IsPattern (patternQNames p)
+    patP <- buildParsers IsPattern top (patternQNames p)
 
     -- Run parser, forcing result.
     let ps   = let result = parsePat (parser patP) p
@@ -807,7 +806,7 @@ parseApplication :: List2 Expr -> ScopeM Expr
 parseApplication es  = billToParser IsExpr $ do
     let es0 = List2.toList es
     -- Build the parser
-    p <- buildParsers IsExpr [ q | Ident q <- es0 ]
+    p <- buildParsers IsExpr Nothing [ q | Ident q <- es0 ]
 
     -- Parse
     let result = parser p es0
@@ -836,7 +835,7 @@ parseArguments hd = \case
     let es2 = List2 hd e1 rest
 
     -- Build the arguments parser
-    p <- buildParsers IsExpr [ q | Ident q <- es ]
+    p <- buildParsers IsExpr Nothing [ q | Ident q <- es ]
 
     -- Parse
     -- TODO: not sure about forcing

--- a/test/Fail/Issue3586.err
+++ b/test/Fail/Issue3586.err
@@ -1,4 +1,6 @@
-Issue3586.agda:15.1-14: error: [InvalidPattern]
-y ^ z is not a valid pattern
+Issue3586.agda:15.1-14: error: [NoParseForLHS]
+Could not parse the left-hand side foo x@(y ^ z)
+Operators used in the grammar:
+  ^ (prefix operator, level 5) [^_ (Issue3586.agda:9.3-5)]
 when scope checking the left-hand side foo x@(y ^ z) in the
 definition of foo

--- a/test/Fail/Issue7722.agda
+++ b/test/Fail/Issue7722.agda
@@ -1,0 +1,33 @@
+-- Andreas, 2025-02-28, issue #7722
+-- Reported by decorator-factory, test shrunk by Andreas.
+--
+-- The pattern parser took exponential time when non-pattern operators
+-- were mentioned in the pattern.
+-- These were both interpreted as pattern variables and operators,
+-- so for n occurrences of this operator 2^n parse trees were produced.
+-- Only one of them constitutes a valid pattern, but the pattern
+-- validity check had to go through all the products in a parse tree.
+--
+-- This is fixed by only considering operators that are constructors or pattern synonyms.
+
+postulate
+  _+_ : Set → Set → Set
+
+infixl 42 _+_
+
+test : Set → Set
+test x :=  -- typo := instead of =
+  x + x + x + x +
+  x + x + x + x +
+  x + x + x + x +
+  x + x + x + x +
+  x + x + x + x +
+  x + x + x + x +
+  x + x + x + x +
+  x + x + x + x +
+  x + x + x + x +
+  x + x + x + x +
+  x
+
+-- WAS: OOM
+-- NOW: Should fail fast.

--- a/test/Fail/Issue7722.err
+++ b/test/Fail/Issue7722.err
@@ -1,0 +1,57 @@
+Issue7722.agda:19.8-10: error: [CannotEliminateWithPattern]
+Cannot eliminate type Set with variable pattern := (did you supply
+too many arguments?)
+when checking the clause left hand side
+test x := x + x + x + x + x + x + x + x + x + x + x + x + x + x + x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x
+  +
+  x

--- a/test/Fail/PatternMatchingOnCodata.err
+++ b/test/Fail/PatternMatchingOnCodata.err
@@ -2,6 +2,6 @@ PatternMatchingOnCodata.agda:31.1-11: error: [NoParseForLHS]
 Could not parse the left-hand side my-♭ (♯ x)
 Problematic expression: (♯ x)
 Operators used in the grammar:
-  ♯ (prefix operator, level 1000) [♯_ (PatternMatchingOnCodata.agda:23.3-5)]
+  None
 when scope checking the left-hand side my-♭ (♯ x) in the definition
 of my-♭


### PR DESCRIPTION
This fixes the exponential behavior of the pattern parser when
operators names are used as pattern variables.

Closes #7722.
