### PR TITLE
Let Agda perform several of `--help`, `--version` etc. if the user requests so

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -38,14 +38,6 @@ administrative action rather than actually processing an Agda code.
 
      Show just the version number.
 
-.. option:: --setup
-
-     .. versionadded:: 2.8.0
-
-     Extract Agda' data files (primitive library, emacs mode etc.)
-     to ``share/VERSION/`` under the (:envvar:`AGDA_DIR`)
-     where ``VERSION`` is the numeric version of Agda.
-
 .. option:: --print-agda-app-dir
 
      .. versionadded:: 2.6.4.1
@@ -71,6 +63,14 @@ administrative action rather than actually processing an Agda code.
 
 General options
 ~~~~~~~~~~~~~~~
+
+.. option:: --setup
+
+     .. versionadded:: 2.8.0
+
+     Extract Agda' data files (primitive library, emacs mode etc.)
+     to ``share/VERSION/`` under the (:envvar:`AGDA_DIR`)
+     where ``VERSION`` is the numeric version of Agda.
 
 .. option:: --interaction
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -12,11 +12,35 @@ Where noted, these options can also serve as *pragma options*,
 i.e., be supplied in a file via the ``{-# OPTIONS ... #-}`` pragma
 or in the ``flags`` section of an ``.agda-lib`` file.
 
-Administrative runs
+Setup and printing
 ~~~~~~~~~~~~~~~~~~~
 
-Some options cause Agda to print out some information or do some
-administrative action rather than actually processing an Agda code.
+Some options cause Agda to perform tasks at startup like mandatory setup
+or printing some information.
+These options are not exclusive, they can be used with other options,
+albeit this seldom makes sense.
+They are not executed in the order given on the command line,
+but in the fixed order listed in the following:
+
+.. option:: --setup
+
+     .. versionadded:: 2.8.0
+
+     Extract Agda' data files (primitive library, emacs mode etc.)
+     to ``share/VERSION/`` under the (:envvar:`AGDA_DIR`)
+     where ``VERSION`` is the numeric version of Agda.
+
+.. option:: --version, -V
+
+     Show version number and cabal flags used in this build of Agda.
+
+     Overwrites :option:`--numeric-version`.
+
+.. option:: --numeric-version
+
+     Show just the version number.
+
+     Overwrites :option:`--version`.
 
 .. option:: --help[={TOPIC}], -?[{TOPIC}]
 
@@ -30,13 +54,7 @@ administrative action rather than actually processing an Agda code.
        List warning groups and individual warnings and their default status.
        Instruct how to toggle benign warnings.
 
-.. option:: --version, -V
-
-     Show version number and cabal flags used in this build of Agda.
-
-.. option:: --numeric-version
-
-     Show just the version number.
+     Overwrites itself, i.e., only the last of several :option:`--help` options is effective.
 
 .. option:: --print-agda-app-dir
 
@@ -63,14 +81,6 @@ administrative action rather than actually processing an Agda code.
 
 General options
 ~~~~~~~~~~~~~~~
-
-.. option:: --setup
-
-     .. versionadded:: 2.8.0
-
-     Extract Agda' data files (primitive library, emacs mode etc.)
-     to ``share/VERSION/`` under the (:envvar:`AGDA_DIR`)
-     where ``VERSION`` is the numeric version of Agda.
 
 .. option:: --interaction
 

--- a/src/full/Agda/Interaction/Options/Types.hs
+++ b/src/full/Agda/Interaction/Options/Types.hs
@@ -59,9 +59,9 @@ data CommandLineOptions = Options
   , optPrintAgdaAppDir       :: Bool
   , optPrintVersion          :: Maybe PrintAgdaVersion
   , optPrintHelp             :: Maybe Help
-  , optSetup                 :: Bool
-      -- ^ Tell Agda to self-setup and quit.
 
+  , optSetup                 :: Bool
+      -- ^ Force Agda to self-setup at startup.
   , optInteractive           :: Bool
       -- ^ Agda REPL (@-I@).
   , optGHCiInteraction       :: Bool

--- a/src/setup/Agda/Setup.hs
+++ b/src/setup/Agda/Setup.hs
@@ -34,6 +34,7 @@ import           System.Directory
 import           System.Environment         ( lookupEnv )
 import           System.FileLock            ( pattern Exclusive, withFileLock )
 import           System.FilePath            ( (</>), joinPath, splitFileName, takeFileName )
+import           System.IO                  ( hPutStrLn, stderr )
 
 import           Agda.Setup.DataFiles       ( dataFiles, dataPath )
 import           Agda.VersionCommit         ( versionWithCommitInfo )
@@ -80,7 +81,7 @@ getAgdaAppDir = do
       True  -> canonicalizePath dir
       False -> do
         d <- agdaDir
-        putStrLn $ "Warning: Environment variable AGDA_DIR points to non-existing directory " ++ show dir ++ ", using " ++ show d ++ " instead."
+        inform $ "Warning: Environment variable AGDA_DIR points to non-existing directory " ++ show dir ++ ", using " ++ show d ++ " instead."
         return d
   where
     -- System-specific command to build the path to ~/.agda (Unix) or %APPDATA%\agda (Win)
@@ -139,9 +140,13 @@ dumpDataDir verbose agdaDir = do
 
       -- Write out the file contents.
       let path = dir </> file
-      when verbose $ putStrLn $ "Writing " ++ path
+      when verbose $ inform $ "Writing " ++ path
       BS.writeFile path content
 
   -- Remove the lock (this is surprisingly not done by withFileLock).
   -- Ignore any IOException (e.g. if the file does not exist).
   void $ try @IOException $ removeFile lock
+
+-- | Dump line of warning or information to stderr.
+inform :: String -> IO ()
+inform = hPutStrLn stderr


### PR DESCRIPTION
Previously, if you invoked

    agda --version --help --print-agda-data-dir

Agda would just print the help and silently ignore the other requests
to print the version and the Agda data directory.

Now all the print requests are executed, in the order

  1. version
  2. help
  3. Agda app dir
  4. Agda data dir

Further, after printing the information, Agda can continue with normal operation like `--interaction` or checking the given file.

While usually one will typically use the previous `MainMode`s exclusively, it seemed unprincipled that Agda would just silently pick one mode when several were given.

Also, technically there is nothing that makes these modes exclusive.

Commits:
- **`--setup` isn't an exclusive option anymore**
- **Agda.Setup print warning and information on stderr instead of stdout**
- **Command line: previous `MainMode`s are no longer exclusive.**

This removes the `MainMode` and `getMainMode` introduced in #5020.
- #5020
