### PR TITLE
Fix #7730: add `lexical-binding: t` to `.el` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,8 @@ Interaction and emacs mode
 * Emacs: new face `agda2-highlight-instance-problem-face`
   for highlighting the new aspect `InstanceProblem`.
 
+* Emacs: added `lexical-binding: t` to `.el` files for Emacs 30 compatibility.
+
 
 Backends
 --------

--- a/src/data/emacs-mode/agda2-abbrevs.el
+++ b/src/data/emacs-mode/agda2-abbrevs.el
@@ -1,4 +1,5 @@
-;; agda2-abbrevs.el --- Default Agda abbrevs
+;;; -*- lexical-binding: t; -*-
+;;; agda2-abbrevs.el --- Default Agda abbrevs
 ;; SPDX-License-Identifier: MIT License
 
 ;;; Commentary:

--- a/src/data/emacs-mode/agda2-highlight.el
+++ b/src/data/emacs-mode/agda2-highlight.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; agda2-highlight.el --- Syntax highlighting for Agda (version ≥ 2)
 ;; SPDX-License-Identifier: MIT License
 

--- a/src/data/emacs-mode/agda2-mode-pkg.el
+++ b/src/data/emacs-mode/agda2-mode-pkg.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 (define-package "agda2-mode" "2.8.0"
   "interactive development for Agda, a dependently typed functional programming language"
   '((emacs "24.3"))) ;; dep defs for `annotation.el` and `eri.el` are not required if they are packaged together

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; agda2-mode.el --- Major mode for Agda
 ;; SPDX-License-Identifier: MIT License
 

--- a/src/data/emacs-mode/agda2-queue.el
+++ b/src/data/emacs-mode/agda2-queue.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; agda2-queue.el --- Simple FIFO character queues.
 ;; SPDX-License-Identifier: MIT License
 

--- a/src/data/emacs-mode/agda2.el
+++ b/src/data/emacs-mode/agda2.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Agda mode code which should run before the first Agda file is
 ;; loaded

--- a/src/data/emacs-mode/annotation.el
+++ b/src/data/emacs-mode/annotation.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; annotation.el --- Functions for annotating text with faces and help bubbles
 
 ;; Version: 1.0

--- a/src/data/emacs-mode/eri.el
+++ b/src/data/emacs-mode/eri.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; eri.el --- Enhanced relative indentation (eri)
 
 ;; SPDX-License-Identifier: MIT License


### PR DESCRIPTION
Closes #7730.

TODO: Fix these errors:
- [ ] In toplevel form:
  [annotation.el:36:4](https://github.com/agda/agda/blob/43076dcc3732a162f6ed2343d105f1ec91cfa414/src/data/emacs-mode/annotation.el#L38): Error: Unused lexical variable `source-file-name'
- [ ] In eri-calculate-indentation-points-on-line:
  [eri.el:68:28](https://github.com/agda/agda/blob/43076dcc3732a162f6ed2343d105f1ec91cfa414/src/data/emacs-mode/eri.el#L68): Error: ‘add-to-list’ can’t use lexical var ‘result’; use ‘push’ or ‘cl-pushnew’
- [ ] In toplevel form:
  [agda2-mode.el:293:43](https://github.com/agda/agda/blob/43076dcc3732a162f6ed2343d105f1ec91cfa414/src/data/emacs-mode/agda2-mode.el#L292): Error: Unused lexical variable `keys'
