### PR TITLE
stack build dir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,46 +199,6 @@ jobs:
     - if: always()
       name: Suite of interaction tests
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
-  size-solver-test:
-    needs: build
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - id: setup-haskell
-      uses: haskell-actions/setup@v2
-      with:
-        enable-stack: true
-        ghc-version: ${{ env.GHC_VER }}
-        stack-version: latest
-    - uses: actions/download-artifact@v4
-      with:
-        name: agda-${{ runner.os }}-${{ github.sha }}
-    - name: Unpack artifacts
-      run: |
-        tar --use-compress-program zstd -xvf dist.tzst
-        tar --use-compress-program zstd -xvf stack-work.tzst
-    - name: Determine the ICU version
-      run: |
-        ICU_VER=$(pkg-config --modversion icu-i18n)
-        echo "ICU_VER=${ICU_VER}"
-        echo "ICU_VER=${ICU_VER}" >> "${GITHUB_ENV}"
-    - id: cache
-      name: Restore cache from exact key
-      uses: actions/cache/restore@v4
-      with:
-        key: test.yml-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
-          steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-plan-${{
-          hashFiles('Agda.cabal','stack.yaml','deps.txt') }}
-        path: ${{ steps.setup-haskell.outputs.stack-root }}
-    - name: Setup Agda
-      run: |
-        "${GITHUB_WORKSPACE}/${BUILD_DIR}"/build/agda/agda --setup
-    - name: Run tests for the size solver
-      run: |
-        export PATH=${HOME}/.local/bin:${PATH}
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
   stdlib-test:
     needs: build
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@
 ######################################################
 env:
   AGDA_TESTS_OPTIONS: -j${PARALLEL_TESTS} --hide-successes
-  BUILD_DIR: dist
   GHC_VER: 9.10.1
   PARALLEL_TESTS: 2
   STACK: stack --system-ghc
@@ -56,27 +55,18 @@ jobs:
       name: Restore cache from approximate key
       uses: actions/cache/restore@v4
       with:
-        key: test.yml-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
+        key: test.yml-1-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
           steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-plan-${{
           hashFiles('Agda.cabal','stack.yaml','deps.txt') }}
         path: ${{ steps.setup-haskell.outputs.stack-root }}
-        restore-keys: test.yml-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
+        restore-keys: test.yml-1-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
           steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-
     - name: Install dependencies for Agda and its test suites
       run: make install-deps
     - name: Build Agda
-      run: make BUILD_DIR="${BUILD_DIR}" install-bin
+      run: make install-bin
     - name: Pack artifacts
       run: |
-        strip "${BUILD_DIR}"/build/agda-tests/agda-tests \
-          "${BUILD_DIR}"/build/agda/agda \
-          "${BUILD_DIR}"/build/agda-mode/agda-mode
-
-        tar --use-compress-program zstd -cvf dist.tzst \
-          "${BUILD_DIR}"/build/agda-tests/agda-tests \
-          "${BUILD_DIR}"/build/agda/agda \
-          "${BUILD_DIR}"/build/agda-mode/agda-mode
-
         tar --use-compress-program zstd -cvf stack-work.tzst .stack-work stack.yaml stack.yaml.lock deps.txt
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -84,14 +74,13 @@ jobs:
         if-no-files-found: error
         name: agda-${{ runner.os }}-${{ github.sha }}
         path: |
-          dist.tzst
           stack-work.tzst
         retention-days: 1
-    - if: always() && steps.cache.outputs.cache-hit != 'true'
+    - if: steps.cache.outputs.cache-hit != 'true'
       name: Save cache
       uses: actions/cache/save@v4
       with:
-        key: test.yml-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
+        key: test.yml-1-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
           steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-plan-${{
           hashFiles('Agda.cabal','stack.yaml','deps.txt') }}
         path: ${{ steps.setup-haskell.outputs.stack-root }}
@@ -113,7 +102,6 @@ jobs:
         name: agda-${{ runner.os }}-${{ github.sha }}
     - name: Unpack artifacts
       run: |
-        tar --use-compress-program zstd -xvf dist.tzst
         tar --use-compress-program zstd -xvf stack-work.tzst
     - name: Determine the ICU version
       run: |
@@ -124,17 +112,16 @@ jobs:
       name: Restore cache from exact key
       uses: actions/cache/restore@v4
       with:
-        key: test.yml-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
+        key: test.yml-1-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
           steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-plan-${{
           hashFiles('Agda.cabal','stack.yaml','deps.txt') }}
         path: ${{ steps.setup-haskell.outputs.stack-root }}
     - name: Setup Agda
-      run: |
-        "${GITHUB_WORKSPACE}/${BUILD_DIR}"/build/agda/agda --setup
+      run: make setup-agda
     - name: Cubical library test
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
+      run: make cubical-test
     - name: Successful tests using the cubical library
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-succeed
+      run: make cubical-succeed
   interaction-latex-html:
     needs: build
     runs-on: ubuntu-24.04
@@ -153,7 +140,6 @@ jobs:
         name: agda-${{ runner.os }}-${{ github.sha }}
     - name: Unpack artifacts
       run: |
-        tar --use-compress-program zstd -xvf dist.tzst
         tar --use-compress-program zstd -xvf stack-work.tzst
     - name: Determine the ICU version
       run: |
@@ -164,41 +150,40 @@ jobs:
       name: Restore cache from exact key
       uses: actions/cache/restore@v4
       with:
-        key: test.yml-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
+        key: test.yml-1-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
           steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-plan-${{
           hashFiles('Agda.cabal','stack.yaml','deps.txt') }}
         path: ${{ steps.setup-haskell.outputs.stack-root }}
     - name: Setup Agda
-      run: |
-        "${GITHUB_WORKSPACE}/${BUILD_DIR}"/build/agda/agda --setup
+      run: make setup-agda
     - name: Install Tex Live and Emacs
       run: |
         sudo apt-get update
         # shellcheck disable=SC2086
         sudo apt-get install ${APT_GET_OPTS} texlive-binaries emacs-nox
     - name: Suite of tests for the LaTeX and HTML backends
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" DONT_RUN_LATEX=Y latex-html-test
+      run: make DONT_RUN_LATEX=Y latex-html-test
     - if: always()
       name: Testing the Emacs mode
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" testing-emacs-mode
+      run: make testing-emacs-mode
     - if: always()
       name: User manual (test)
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-test
+      run: make user-manual-test
     - if: always()
       name: User manual covers all options
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-covers-options
+      run: make user-manual-covers-options
     - if: always()
       name: User manual covers all warnings
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-covers-warnings
+      run: make user-manual-covers-warnings
     - if: always()
       name: Test suite covers all warnings
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" test-suite-covers-warnings
+      run: make test-suite-covers-warnings
     - if: always()
       name: Test suite covers all errors
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" test-suite-covers-errors
+      run: make test-suite-covers-errors
     - if: always()
       name: Suite of interaction tests
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
+      run: make interaction
   stdlib-test:
     needs: build
     runs-on: ubuntu-24.04
@@ -217,7 +202,6 @@ jobs:
         name: agda-${{ runner.os }}-${{ github.sha }}
     - name: Unpack artifacts
       run: |
-        tar --use-compress-program zstd -xvf dist.tzst
         tar --use-compress-program zstd -xvf stack-work.tzst
     - name: Determine the ICU version
       run: |
@@ -228,30 +212,29 @@ jobs:
       name: Restore cache from exact key
       uses: actions/cache/restore@v4
       with:
-        key: test.yml-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
+        key: test.yml-1-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
           steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-plan-${{
           hashFiles('Agda.cabal','stack.yaml','deps.txt') }}
         path: ${{ steps.setup-haskell.outputs.stack-root }}
     - name: Setup Agda
-      run: |
-        "${GITHUB_WORKSPACE}/${BUILD_DIR}"/build/agda/agda --setup
+      run: make setup-agda
     - name: Standard library test
       run: |
         # ASR (2021-01-17). `cabal update` is required due to #5138.
         # We should also use `stack` in this test.
         cabal update
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" std-lib-test
+        make std-lib-test
     - if: always()
       name: Benchmark
       run: |
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-summary
+        make benchmark-without-logs
+        make benchmark-summary
     - name: Standard library compiler tests
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" std-lib-compiler-test
+      run: make std-lib-compiler-test
     - name: Successful tests using the standard library
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" std-lib-succeed
+      run: make std-lib-succeed
     - name: Interaction tests using the standard library
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" std-lib-interaction
+      run: make std-lib-interaction
   test:
     needs: build
     runs-on: ubuntu-24.04
@@ -270,7 +253,6 @@ jobs:
         name: agda-${{ runner.os }}-${{ github.sha }}
     - name: Unpack artifacts
       run: |
-        tar --use-compress-program zstd -xvf dist.tzst
         tar --use-compress-program zstd -xvf stack-work.tzst
     - name: Determine the ICU version
       run: |
@@ -281,39 +263,38 @@ jobs:
       name: Restore cache from exact key
       uses: actions/cache/restore@v4
       with:
-        key: test.yml-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
+        key: test.yml-1-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{
           steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-plan-${{
           hashFiles('Agda.cabal','stack.yaml','deps.txt') }}
         path: ${{ steps.setup-haskell.outputs.stack-root }}
     - name: Setup Agda
-      run: |
-        "${GITHUB_WORKSPACE}/${BUILD_DIR}"/build/agda/agda --setup
+      run: make setup-agda
     - name: Suite of tests for bugs
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" bugs
+      run: make bugs
     - if: always()
       name: 'Suite of successful tests: mini-library Common'
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" common
+      run: make common
     - if: always()
       name: Suite of successful tests
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" succeed
+      run: make succeed
     - if: always()
       name: Suite of failing tests
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" fail
+      run: make fail
     - if: always()
       name: Suite of examples
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" examples
+      run: make examples
     - if: always()
       name: Suite of interactive tests
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interactive
+      run: make interactive
     - if: always()
       name: Successful tests using Agda as a Haskell library
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" api-test
+      run: make api-test
     - if: always()
       name: Internal test suite
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" internal-tests
+      run: make internal-tests
     - if: always()
       name: Compiler tests
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" compiler-test
+      run: make compiler-test
 name: Build, Test, and Benchmark
 'on':
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.o
 *.project.local
 *.ptb
+*.tix
 *.tmp
 *.tmp.*
 *~
@@ -32,6 +33,8 @@
 /benchmark/Create/import-*
 /benchmark/Create/import0-*
 /benchmark/logs
+/doc/**/MAlonzo
+/doc/user-manual.pdf
 /examples/**/MAlonzo
 /examples/compiler/main
 /hie.yaml
@@ -43,6 +46,7 @@
 /src/full/Agda/Syntax/Parser/Parser.info
 /src/full/TAGS
 /test/**/MAlonzo
+/test/api/*.api
 /test/Compiler/simple/agda-rts.js
 /test/Compiler/simple/Erasure-Issue2640
 /test/Compiler/simple/highlight-hover.js
@@ -65,8 +69,6 @@
 /test/Succeed/Issue867
 /test/Succeed/Options-in-right-order
 /test/Succeed/WErrorOverride
-agda-ffi/dist
-agda-stdlib
 autom4te.cache
 cabal.sandbox.config
 config.log
@@ -74,8 +76,6 @@ config.status
 configure
 dist-*/
 dist/
-doc/user-manual.pdf
-exec-test*
 hlint-report.html
 jAgda.*.js
 module-dependency-graph.dot

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ include ./mk/cabal.mk
 include ./mk/stack.mk
 
 # mk/path.mk uses TOP, so include after the definition of TOP.
-# It also uses HAS_STACK, so include after stack.mk
+# It also uses HAS_STACK, so include after stack.mk.
+# Note that paths.mk also loads common.mk (which loads config.mk) and ghc.mk.
 include ./mk/paths.mk
 
 # mk/pretty.mk defines 'decorate'.
@@ -24,9 +25,7 @@ include ./mk/pretty.mk
 # tests. The default is one per processor. Invoke make like this:
 #   make PARALLEL_TESTS=123 test
 # Or set it in ./mk/config.mk, which is .gitignored
-ifeq ($(PARALLEL_TESTS),)
-PARALLEL_TESTS := $(shell getconf _NPROCESSORS_ONLN)
-endif
+PARALLEL_TESTS ?= $(shell getconf _NPROCESSORS_ONLN)
 
 AGDA_BIN_SUFFIX = -$(VERSION)
 AGDA_TESTS_OPTIONS ?=-i -j$(PARALLEL_TESTS)
@@ -784,6 +783,7 @@ debug : ## Print debug information.
 	@echo "GHC_VER                        = $(GHC_VER)"
 	@echo "GHC_VERSION                    = $(GHC_VERSION)"
 	@echo "PARALLEL_TESTS                 = $(PARALLEL_TESTS)"
+	@echo "PROFILEOPTS                    = $(PROFILEOPTS)"
 	@echo "QUICK_CABAL_INSTALL            = $(QUICK_CABAL_INSTALL)"
 	@echo "QUICK_STACK_INSTALL            = $(QUICK_STACK_INSTALL)"
 	@echo "SLOW_CABAL_INSTALL_OPTS        = $(SLOW_CABAL_INSTALL_OPTS)"
@@ -801,7 +801,6 @@ debug : ## Print debug information.
 	@echo "STACK_OPTS                     = $(STACK_OPTS)"
 	@echo "STACK_OPT_FAST                 = $(STACK_OPT_FAST)"
 	@echo "STACK_OPT_NO_DOCS              = $(STACK_OPT_NO_DOCS)"
-	@echo "PROFILEOPTS                    = $(PROFILEOPTS)"
 	@echo
 	@echo "Run \`make -pq\` to get a detailed report."
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -263,27 +263,14 @@ type-check: install-deps type-check-no-deps
 .PHONY: type-check-no-deps ##
 type-check-no-deps :
 	@echo "=============== Type checking using v1 Cabal with -fno-code =============="
-	-$(CABAL) $(CABAL_BUILD_CMD) --builddir=$(BUILD_DIR)-no-code \
-          --ghc-options=-fno-code \
-          --ghc-options=-fwrite-interface \
-		  --ghc-options=-fwrite-ide-info \
-		  --ghc-options=-hiedir=dist-hiefiles \
+	-$(CABAL) v1-build --builddir=$(BUILD_DIR)-no-code \
+	  --ghc-options=-fno-code \
+	  --ghc-options=-fwrite-interface \
+	  --ghc-options=-fwrite-ide-info \
+	  --ghc-options=-hiedir=dist-hiefiles \
           2>&1 \
           | $(SED) -e '/.*dist.*build.*: No such file or directory/d' \
                    -e '/.*Warning: the following files would be used as linker inputs, but linking is not being done:.*/d'
-
-## Andreas, 2021-10-14: This does not work, agda-tests is not type-checked.
-## Maybe because cabal fails with an error after type-checking the library component.
-# .PHONY: type-check-with-tests ## Type check only, including tests
-# type-check-with-tests :
-# 	@echo "================= Type checking using Cabal with -fno-code ==============="
-# 	$(CABAL) $(CABAL_CONFIGURE_CMD) $(CABAL_CONFIGURE_OPTS) --builddir=$(BUILD_DIR)-no-code
-# 	-time $(CABAL) $(CABAL_BUILD_CMD) agda-tests --builddir=$(BUILD_DIR)-no-code \
-#           --ghc-options=-fno-code \
-#           --ghc-options=-fwrite-interface \
-#           2>&1 \
-#           | $(SED) -e '/.*dist.*build.*: No such file or directory/d' \
-#                    -e '/.*Warning: the following files would be used as linker inputs, but linking is not being done:.*/d'
 
 # The default is to not include cost centres for libraries, but to
 # include cost centres for Agda using -fprof-late. (The use of

--- a/Makefile
+++ b/Makefile
@@ -698,7 +698,7 @@ remove-default-stack-file : ##
 
 .PHONY : have-bin-%
 have-bin-% :
-	@($* --help > /dev/null) || $(CABAL) $(CABAL_INSTALL_CMD) $*
+	@($* --help > /dev/null) || $(CABAL) install --ignore-project $*
 
 ## Whitespace-related #######################################################
 # Agda can fail to compile on Windows if files which are CPP-processed
@@ -718,7 +718,7 @@ check-whitespace : have-bin-$(FIXW_BIN)
 .PHONY : install-agda-bisect ## Install agda-bisect.
 install-agda-bisect :
 	@$(call decorate, "Installing the agda-bisect program", \
-		cd src/agda-bisect && $(CABAL) $(CABAL_INSTALL_CMD))
+		cd src/agda-bisect && $(CABAL) install)
 
 ## HPC #######################################################################
 .PHONY: hpc-build ##

--- a/Makefile
+++ b/Makefile
@@ -306,15 +306,15 @@ install-prof-bin : install-deps ensure-hash-is-correct
 
 .PHONY : compile-emacs-mode ## Compile Agda's Emacs mode using Emacs.
 compile-emacs-mode: install-bin
-	$(AGDA_MODE) compile
+	$(AGDA_BIN) --emacs-mode compile
 
 .PHONY : setup-emacs-mode ## Configure Agda's Emacs mode.
 setup-emacs-mode : install-bin
 	@echo
-	@echo "If the agda-mode command is not found, make sure that the directory"
+	@echo "If the agda is not found, make sure that the directory"
 	@echo "in which it was installed is located on your shell's search path."
 	@echo
-	$(AGDA_MODE) setup
+	$(AGDA_BIN) --emacs-mode setup
 
 ##############################################################################
 ## Clean

--- a/Makefile
+++ b/Makefile
@@ -661,22 +661,24 @@ run-doctest:
 	@$(call decorate, "Running doctest", \
 	  $(CABAL) repl Agda -w doctest --repl-options=-w)
 
-##############################################################################
-## Size solver
-
-# NB. It is necessary to install the Agda library (i.e run `
-#		make install-bin`)
-# before installing the `size-solver` program.
-
-.PHONY : install-size-solver ## Install the size solver.
-install-size-solver :
-	@$(call decorate, "Installing the size-solver program", \
-		$(MAKE) -C src/size-solver STACK_INSTALL_OPTS='$(SLOW_STACK_INSTALL_OPTS) $(STACK_INSTALL_BIN_OPTS)' CABAL_INSTALL_OPTS='$(SLOW_CABAL_INSTALL_OPTS) $(CABAL_INSTALL_OPTS)' install-bin)
-
-.PHONY : size-solver-test ##
-size-solver-test : install-size-solver
-	@$(call decorate, "Testing the size-solver program", \
-		$(MAKE) -C src/size-solver test)
+## Andreas, 2025-03-04: disable the size-solver-test
+#
+# ##############################################################################
+# ## Size solver
+#
+# # NB. It is necessary to install the Agda library (i.e run `
+# #		make install-bin`)
+# # before installing the `size-solver` program.
+#
+# .PHONY : install-size-solver ## Install the size solver.
+# install-size-solver :
+# 	@$(call decorate, "Installing the size-solver program", \
+# 		$(MAKE) -C src/size-solver STACK_INSTALL_OPTS='$(SLOW_STACK_INSTALL_OPTS) $(STACK_INSTALL_BIN_OPTS)' CABAL_INSTALL_OPTS='$(SLOW_CABAL_INSTALL_OPTS) $(CABAL_INSTALL_OPTS)' install-bin)
+#
+# .PHONY : size-solver-test ##
+# size-solver-test : install-size-solver
+# 	@$(call decorate, "Testing the size-solver program", \
+# 		$(MAKE) -C src/size-solver test)
 
 ##############################################################################
 ## Development

--- a/Makefile
+++ b/Makefile
@@ -720,21 +720,6 @@ install-agda-bisect :
 	@$(call decorate, "Installing the agda-bisect program", \
 		cd src/agda-bisect && $(CABAL) install)
 
-## HPC #######################################################################
-.PHONY: hpc-build ##
-hpc-build: ensure-hash-is-correct
-	$(CABAL) $(CABAL_CLEAN_CMD) $(CABAL_OPTS)
-	$(CABAL) $(CABAL_CONFIGURE_CMD) --enable-library-coverage $(CABAL_INSTALL_OPTS)
-	$(CABAL) $(CABAL_BUILD_CMD) $(CABAL_OPTS)
-
-agda.tix: ./examples/agda.tix ./test/common/agda.tix ./test/Succeed/agda.tix ./test/compiler/agda.tix ./test/api/agda.tix ./test/interaction/agda.tix ./test/fail/agda.tix ./test/lib-succeed/agda.tix ./std-lib/agda.tix ##
-	hpc sum --output=$@ $^
-
-.PHONY: hpc ## Generate a code coverage report
-hpc: hpc-build test agda.tix
-	hpc report --hpcdir=$(BUILD_DIR)/hpc/mix/Agda-$(VERSION) agda.tix
-	hpc markup --hpcdir=$(BUILD_DIR)/hpc/mix/Agda-$(VERSION) agda --destdir=hpc-report
-
 ## Lines of Code #############################################################
 
 agdalocfiles=$(shell find . \( \( -name '*.agda' -o -name '*.in' \) ! -name '.*' \) )

--- a/hie-stack.yaml
+++ b/hie-stack.yaml
@@ -6,8 +6,6 @@ cradle:
       component: 'Agda:exe:agda'
     - path: './src/agda-mode'
       component: 'Agda:exe:agda-mode'
-    - path: './src/size-solver'
-      component: 'size-solver:exe:size-solver'
     - path: './test'
       component: 'Agda:test:agda-tests'
 

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -1,4 +1,5 @@
 # All makefiles must define TOP, corresponding to the Agda root directory.
+# This is so that they can be imported from a Makefile in a subdirectory.
 ifeq ($(TOP),)
   $(error "Makefiles must define the TOP variable to correspond with the Agda source root")
 endif

--- a/mk/ghc.mk
+++ b/mk/ghc.mk
@@ -1,3 +1,9 @@
+# All makefiles must define TOP, corresponding to the Agda root directory.
+# This is so that they can be imported from a Makefile in a subdirectory.
+ifeq ($(TOP),)
+  $(error "Makefiles must define the TOP variable to correspond with the Agda source root")
+endif
+
 include $(TOP)/mk/cabal.mk
 include $(TOP)/mk/stack.mk
 

--- a/mk/paths.mk
+++ b/mk/paths.mk
@@ -1,3 +1,9 @@
+# All makefiles must define TOP, corresponding to the Agda root directory.
+# This is so that they can be imported from a Makefile in a subdirectory.
+ifeq ($(TOP),)
+  $(error "Makefiles must define the TOP variable to correspond with the Agda source root")
+endif
+
 include $(TOP)/mk/common.mk
 include $(TOP)/mk/versions.mk
 include $(TOP)/mk/ghc.mk
@@ -33,6 +39,7 @@ STACK_SLOW  = $(STACK) --work-dir=$(STACK_WORK_DIR)
 STACK_QUICK = $(STACK) --work-dir=$(QUICK_STACK_WORK_DIR)
 STACK_FAST  = $(STACK) --work-dir=$(FAST_STACK_WORK_DIR)
 
+# BUILD_DIR can be set in the system environment.
 ifdef HAS_STACK
 # Where does Stack place build/ etc.?  (Will contain e.g. the GHC version.)
   BUILD_DIR       ?= $(TOP)/$(shell $(STACK_SLOW)  path --dist-dir)
@@ -45,12 +52,15 @@ else
   FAST_BUILD_DIR  ?= $(BUILD_DIR)-fast
 endif
 
+# AGDA_BIN can be set in the system environment.
 AGDA_BIN ?= $(BUILD_DIR)/build/agda/agda
 AGDA_BIN := $(abspath $(AGDA_BIN))
 
+# AGDA_MODE can be set in the system environment.
 AGDA_MODE ?= $(BUILD_DIR)/build/agda-mode/agda-mode
 AGDA_MODE := $(abspath $(AGDA_MODE))
 
+# AGDA_TESTS_BIN can be set in the system environment.
 AGDA_TESTS_BIN ?= $(BUILD_DIR)/build/agda-tests/agda-tests
 AGDA_TESTS_BIN := $(abspath $(AGDA_TESTS_BIN))
 

--- a/mk/paths.mk
+++ b/mk/paths.mk
@@ -22,15 +22,28 @@ FULL_SRC_DIR   = $(SRC_DIR)/full
 # Andreas, 2020-10-26 further refinement:
 # I often switch GHC version, so indexing v1-style build directories
 # by GHC version x.y.z makes sense.
-BUILD_DIR             = $(TOP)/dist-$(VERSION)-ghc-$(GHC_VER)
-QUICK_BUILD_DIR       = $(BUILD_DIR)-quick
-FAST_BUILD_DIR        = $(BUILD_DIR)-fast
-DEBUG_BUILD_DIR       = $(BUILD_DIR)-debug
-QUICK_DEBUG_BUILD_DIR = $(BUILD_DIR)-debug-quick
 
-STACK_BUILD_DIR       = .stack-work
-QUICK_STACK_BUILD_DIR = $(STACK_BUILD_DIR)-quick
-FAST_STACK_BUILD_DIR  = $(STACK_BUILD_DIR)-fast
+# N.B. don't use TOP here, stack anyway looks upward for stack.yaml
+STACK_WORK_DIR       ?= .stack-work
+QUICK_STACK_WORK_DIR ?= $(STACK_WORK_DIR)-quick
+FAST_STACK_WORK_DIR  ?= $(STACK_WORK_DIR)-fast
+
+# The basic stack command needs to always set the --work-dir.
+STACK_SLOW  = $(STACK) --work-dir=$(STACK_WORK_DIR)
+STACK_QUICK = $(STACK) --work-dir=$(QUICK_STACK_WORK_DIR)
+STACK_FAST  = $(STACK) --work-dir=$(FAST_STACK_WORK_DIR)
+
+ifdef HAS_STACK
+# Where does Stack place build/ etc.?  (Will contain e.g. the GHC version.)
+  BUILD_DIR       ?= $(TOP)/$(shell $(STACK_SLOW)  path --dist-dir)
+  QUICK_BUILD_DIR ?= $(TOP)/$(shell $(STACK_QUICK) path --dist-dir)
+  FAST_BUILD_DIR  ?= $(TOP)/$(shell $(STACK_FAST)  path --dist-dir)
+else
+# Where does v1-Cabal place build/ etc.? Originally in dist/, but we refine this.
+  BUILD_DIR       ?= $(TOP)/dist-$(VERSION)-ghc-$(GHC_VER)
+  QUICK_BUILD_DIR ?= $(BUILD_DIR)-quick
+  FAST_BUILD_DIR  ?= $(BUILD_DIR)-fast
+endif
 
 AGDA_BIN ?= $(BUILD_DIR)/build/agda/agda
 AGDA_BIN := $(abspath $(AGDA_BIN))

--- a/mk/stack.mk
+++ b/mk/stack.mk
@@ -1,4 +1,6 @@
-STACK=stack
+# Andreas, 2025-03-05, STACK might be set in the environment
+# (e.g. in workflow test.yml); in this case, don't override.
+STACK ?= stack
 
 # Andreas, 2022-03-10: suppress chatty announcements like
 # "Stack has not been tested with GHC versions above 9.0, and using 9.2.2, this may fail".

--- a/mk/stack.mk
+++ b/mk/stack.mk
@@ -1,3 +1,9 @@
+# All makefiles must define TOP, corresponding to the Agda root directory.
+# This is so that they can be imported from a Makefile in a subdirectory.
+ifeq ($(TOP),)
+  $(error "Makefiles must define the TOP variable to correspond with the Agda source root")
+endif
+
 # Andreas, 2025-03-05, STACK might be set in the environment
 # (e.g. in workflow test.yml); in this case, don't override.
 STACK ?= stack

--- a/notes/ghc-releases.md
+++ b/notes/ghc-releases.md
@@ -31,18 +31,6 @@ Let's suppose the new version of GHC is X.Y.Z.
 
   `make haddock`
 
-* Remove the `hs-tags` program and test it:
-
-  `make TAGS`
-
-* Test the size-solver program:
-
-  ```bash
-  make install-size-solver
-  cabal install shelltestrunner
-  make test-size-solver
-  ```
-
 * Test the agda-bisect program:
 
   `make install-agda-bisect`

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -65,7 +65,6 @@ env:
 
   # Variables of/for the Makefile
   PARALLEL_TESTS: 2
-  BUILD_DIR: "dist" # relative path, please!
   AGDA_TESTS_OPTIONS: "-j${PARALLEL_TESTS} --hide-successes"
   STACK: "stack --system-ghc"
 
@@ -148,8 +147,8 @@ jobs:
         # Thus, we include Agda.cabal in the hash.
         # Note that a 'stack.yaml.lock' file would not be sufficient (I think),
         # because it does not list all the dependencies.
-        key: &cache_key test.yml-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{ steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-plan-${{ hashFiles('Agda.cabal','stack.yaml','deps.txt') }}
-        restore-keys: test.yml-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{ steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-
+        key: &cache_key test.yml-1-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{ steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-plan-${{ hashFiles('Agda.cabal','stack.yaml','deps.txt') }}
+        restore-keys: test.yml-1-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-stack-${{ steps.setup-haskell.outputs.stack-version }}-icu-${{ env.ICU_VER }}-
           # Andreas, 2024-05-17, note to myself: not using the env.key trick here because of *cache_key references below...
 
     - name: "Install dependencies for Agda and its test suites"
@@ -160,20 +159,11 @@ jobs:
       ## but printing stuff might not hurt here.
 
     - name: "Build Agda"
-      run: make BUILD_DIR="${BUILD_DIR}" install-bin
+      run: make install-bin
 
       # Save products to use in the remaining jobs.
     - name: "Pack artifacts"
       run: |
-        strip "${BUILD_DIR}"/build/agda-tests/agda-tests \
-          "${BUILD_DIR}"/build/agda/agda \
-          "${BUILD_DIR}"/build/agda-mode/agda-mode
-
-        tar --use-compress-program zstd -cvf dist.tzst \
-          "${BUILD_DIR}"/build/agda-tests/agda-tests \
-          "${BUILD_DIR}"/build/agda/agda \
-          "${BUILD_DIR}"/build/agda-mode/agda-mode
-
         tar --use-compress-program zstd -cvf stack-work.tzst .stack-work stack.yaml stack.yaml.lock deps.txt
 
     - name: "Upload artifacts"
@@ -183,12 +173,11 @@ jobs:
         retention-days: 1
         name: agda-${{ runner.os }}-${{ github.sha }}
         path: |
-          dist.tzst
           stack-work.tzst
 
     - name: Save cache
       uses: actions/cache/save@v4
-      if:   always() && steps.cache.outputs.cache-hit != 'true'  # save cache even when build fails
+      if:   steps.cache.outputs.cache-hit != 'true'  # don't save cache when build fails as it may get in the way
       with:
         key:  *cache_key
         path: *cache_path
@@ -212,7 +201,6 @@ jobs:
     - &unpack_artifact
       name: "Unpack artifacts"
       run: |
-        tar --use-compress-program zstd -xvf dist.tzst
         tar --use-compress-program zstd -xvf stack-work.tzst
 
     - *icu
@@ -226,50 +214,49 @@ jobs:
 
     - &agda_setup
       name: Setup Agda
-      run: |
-        "${GITHUB_WORKSPACE}/${BUILD_DIR}"/build/agda/agda --setup
+      run: make setup-agda
 
     - name: "Suite of tests for bugs"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" bugs
+      run: make bugs
       #    14s (2022-06-17)
 
     - name: "Suite of successful tests: mini-library Common"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" common
+      run: make common
       if: always() # run test even if a previous test failed
       #     8s (2022-06-17)
 
     - name: "Suite of successful tests"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" succeed
+      run: make succeed
       if: always() # run test even if a previous test failed
       # 4m 14s (2022-06-17)
 
     - name: "Suite of failing tests"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" fail
+      run: make fail
       if: always() # run test even if a previous test failed
       # 2m  0s (2022-06-17)
 
     - name: "Suite of examples"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" examples
+      run: make examples
       if: always() # run test even if a previous test failed
       #    41s (2022-06-17)
 
     - name: "Suite of interactive tests"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interactive
+      run: make interactive
       if: always() # run test even if a previous test failed
       #     0s (2022-06-17)
 
     - name: "Successful tests using Agda as a Haskell library"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" api-test
+      run: make api-test
       if: always() # run test even if a previous test failed
       #    21s (2022-06-17)
 
     - name: "Internal test suite"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" internal-tests
+      run: make internal-tests
       if: always() # run test even if a previous test failed
       #    11s (2022-06-17)
 
     - name: "Compiler tests"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" compiler-test
+      run: make compiler-test
       if: always() # run test even if a previous test failed
       # 9m 34s (2022-06-17)
 
@@ -295,25 +282,25 @@ jobs:
         # ASR (2021-01-17). `cabal update` is required due to #5138.
         # We should also use `stack` in this test.
         cabal update
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" std-lib-test
+        make std-lib-test
 
     # Andreas, 2023-09-13: Benchmark `any` uses the standard library,
     # so benchmarks should be run here (or split out the std-lib benchmarks).
     - name: "Benchmark"
       run: |
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-without-logs
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" benchmark-summary
+        make benchmark-without-logs
+        make benchmark-summary
       if: always() # run test even if a previous test failed
       # 6m  3s (2022-06-17)
 
     - name: "Standard library compiler tests"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" std-lib-compiler-test
+      run: make std-lib-compiler-test
 
     - name: "Successful tests using the standard library"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" std-lib-succeed
+      run: make std-lib-succeed
 
     - name: "Interaction tests using the standard library"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" std-lib-interaction
+      run: make std-lib-interaction
 
 
   # Step 2c: testing the interaction and the LaTeX/HTML backend
@@ -339,35 +326,35 @@ jobs:
         sudo apt-get install ${APT_GET_OPTS} texlive-binaries emacs-nox
 
     - name: "Suite of tests for the LaTeX and HTML backends"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" DONT_RUN_LATEX=Y latex-html-test
+      run: make DONT_RUN_LATEX=Y latex-html-test
 
     - name: "Testing the Emacs mode"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" testing-emacs-mode
+      run: make testing-emacs-mode
       if: always() # run test even if a previous test failed
 
     - name: "User manual (test)"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-test
+      run: make user-manual-test
       if: always() # run test even if a previous test failed
       #    13s (2022-06-17)
 
     - name: "User manual covers all options"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-covers-options
+      run: make user-manual-covers-options
       if: always() # run test even if a previous test failed
 
     - name: "User manual covers all warnings"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" user-manual-covers-warnings
+      run: make user-manual-covers-warnings
       if: always() # run test even if a previous test failed
 
     - name: "Test suite covers all warnings"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" test-suite-covers-warnings
+      run: make test-suite-covers-warnings
       if: always() # run test even if a previous test failed
 
     - name: "Test suite covers all errors"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" test-suite-covers-errors
+      run: make test-suite-covers-errors
       if: always() # run test even if a previous test failed
 
     - name: "Suite of interaction tests"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" interaction
+      run: make interaction
       if: always() # run test even if a previous test failed
       # 2m 39s (2022-06-17)
       # This test has erratic outages (#5619), so we place it late in the queue.
@@ -389,10 +376,10 @@ jobs:
     - *agda_setup
 
     - name: "Cubical library test"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-test
+      run: make cubical-test
 
     - name: "Successful tests using the cubical library"
-      run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-succeed
+      run: make cubical-succeed
 
   ## Andreas, 2025-03-04: disable the size-solver-test
   #
@@ -415,4 +402,4 @@ jobs:
   #   - name: "Run tests for the size solver"
   #     run: |
   #       export PATH=${HOME}/.local/bin:${PATH}
-  #       make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
+  #       make size-solver-test

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -394,23 +394,25 @@ jobs:
     - name: "Successful tests using the cubical library"
       run: make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" cubical-succeed
 
-  # Step 2e: running size-solver-test
-  ###########################################################################
-
-  size-solver-test:
-    needs: build
-    runs-on: *runs_on
-
-    steps:
-    - *checkout
-    - *haskell_setup
-    - *download_artifact
-    - *unpack_artifact
-    - *icu
-    - *cache
-    - *agda_setup
-
-    - name: "Run tests for the size solver"
-      run: |
-        export PATH=${HOME}/.local/bin:${PATH}
-        make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test
+  ## Andreas, 2025-03-04: disable the size-solver-test
+  #
+  # # Step 2e: running size-solver-test
+  # ###########################################################################
+  #
+  # size-solver-test:
+  #   needs: build
+  #   runs-on: *runs_on
+  #
+  #   steps:
+  #   - *checkout
+  #   - *haskell_setup
+  #   - *download_artifact
+  #   - *unpack_artifact
+  #   - *icu
+  #   - *cache
+  #   - *agda_setup
+  #
+  #   - name: "Run tests for the size solver"
+  #     run: |
+  #       export PATH=${HOME}/.local/bin:${PATH}
+  #       make BUILD_DIR="${GITHUB_WORKSPACE}/${BUILD_DIR}" size-solver-test

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -5,7 +5,6 @@ compiler-check: match-exact
 # Local packages specified by relative directory name.
 packages:
 - '.'
-- 'src/size-solver'
 
 extra-deps:
 - pqueue-1.5.0.0

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -5,7 +5,6 @@ compiler-check: match-exact
 # Local packages specified by relative directory name.
 packages:
   - '.'
-  - 'src/size-solver'
 
 extra-deps:
 - ap-normalize-0.1.0.1

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -5,7 +5,6 @@ compiler-check: match-exact
 # Local packages specified by relative directory name.
 packages:
 - '.'
-- 'src/size-solver'
 
 extra-deps:
 - pqueue-1.5.0.0

--- a/stack-9.10.1.yaml
+++ b/stack-9.10.1.yaml
@@ -5,4 +5,3 @@ compiler-check: match-exact
 # Local packages specified by relative directory name.
 packages:
 - '.'
-- 'src/size-solver'

--- a/stack-9.2.8.yaml
+++ b/stack-9.2.8.yaml
@@ -5,7 +5,6 @@ compiler-check: match-exact
 # Local packages specified by relative directory name.
 packages:
 - '.'
-- 'src/size-solver'
 
 extra-deps:
 - pqueue-1.5.0.0

--- a/stack-9.4.2.yaml
+++ b/stack-9.4.2.yaml
@@ -5,7 +5,6 @@ compiler-check: match-exact
 # Local packages specified by relative directory name.
 packages:
 - '.'
-- 'src/size-solver'
 
 flags:
   mintty:

--- a/stack-9.4.8.yaml
+++ b/stack-9.4.8.yaml
@@ -5,7 +5,6 @@ compiler-check: match-exact
 # Local packages specified by relative directory name.
 packages:
 - '.'
-- 'src/size-solver'
 
 flags:
   mintty:

--- a/stack-9.6.6.yaml
+++ b/stack-9.6.6.yaml
@@ -5,4 +5,3 @@ compiler-check: match-exact
 # Local packages specified by relative directory name.
 packages:
 - '.'
-- 'src/size-solver'

--- a/stack-9.8.4.yaml
+++ b/stack-9.8.4.yaml
@@ -5,4 +5,3 @@ compiler-check: match-exact
 # Local packages specified by relative directory name.
 packages:
 - '.'
-- 'src/size-solver'


### PR DESCRIPTION
Some cleanup and refactoring in the `Makefile` in preparation to switch to v2-cabal.
- removed `size-solver` from build process
- removed `hpc` goal
- removed step in `install-bin` etc. that would copy stack's build products into `BUILD_DIR`, pretending it was v1-cabal.
  I couldn't figure out why all the build products were copied, as only the executables need to be found.
  I suppose historically this was the simplest way to get `stack` alongside `cabal`.
- renamed STACK_BUILD_DIR to STACK_WORK_DIR to avoid confusion with BUILD_DIR

Commits (preserve!):
- **gitignore .api files generated by the test/api suite**
- **Disable the size-solver-test**
- **Makefile: install external programs with cabal install (not v1-install)**
- **Makefile: remove hpc goal**
- **Makefile: use `agda --emacs-mode` instead of `agda-mode`**
- **Makefile: type-check-no-deps only works with v1-build**
- **Makefile: don't copy Stack build products to dist/**
