### PR TITLE
Fix #7738: Allow rewrite rule defined with constructor or primitive

### DIFF
--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -289,10 +289,16 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
             freeVars  = allFreeVars (ps,rhs)
             allVars   = IntSet.fromList $ downFrom $ size gamma
             usedVars  = case theDef def of
-              Function{}     -> usedArgs def
-              Axiom{}        -> allVars
-              AbstractDefn{} -> allVars
-              _              -> __IMPOSSIBLE__
+              Function{}         -> usedArgs def
+              Axiom{}            -> allVars
+              AbstractDefn{}     -> allVars
+              Constructor{}      -> allVars
+              Primitive{}        -> allVars
+              DataOrRecSig{}     -> __IMPOSSIBLE__
+              GeneralizableVar{} -> __IMPOSSIBLE__
+              Datatype{}         -> __IMPOSSIBLE__
+              Record{}           -> __IMPOSSIBLE__
+              PrimitiveSort{}    -> __IMPOSSIBLE__
         reportSDoc "rewriting" 70 $
           "variables bound by the pattern: " <+> text (show boundVars)
         reportSDoc "rewriting" 70 $

--- a/test/Succeed/Issue7738.agda
+++ b/test/Succeed/Issue7738.agda
@@ -1,0 +1,13 @@
+-- Test case by Malin Altenmüller
+
+{-# OPTIONS --rewriting #-}
+
+data One : Set where
+  ⊤ : One
+
+data P : One → One → Set where
+  m : P ⊤ ⊤
+
+{-# BUILTIN REWRITE P #-}
+
+{-# REWRITE m #-}

--- a/test/Succeed/Issue7738b.agda
+++ b/test/Succeed/Issue7738b.agda
@@ -1,0 +1,6 @@
+{-# OPTIONS --rewriting #-}
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Strict
+
+{-# REWRITE primForceLemma #-}


### PR DESCRIPTION
Fixes #7738.
