### PR TITLE
Re-enable dot-pattern termination for Cubical Agda

### DIFF
--- a/test/Fail/Issue7346.agda
+++ b/test/Fail/Issue7346.agda
@@ -21,7 +21,7 @@ all-sucs : (x : N) → IsSuc x
 all-sucs x = primTransp (λ i → IsSuc (eq x i)) i0 (is-suc x)
 
 -- This should not termination check,
--- since dot-pattern termination is off without-K.
+-- since dotted HIT constructors are ignored for termination.
 not-suc : (x : N) → IsSuc x → ⊥
 not-suc .(suc x) (is-suc x) = not-suc x (all-sucs x)
   -- This would be changed by forcing to the following,

--- a/test/Succeed/DotPatternTerminationCubical.agda
+++ b/test/Succeed/DotPatternTerminationCubical.agda
@@ -1,0 +1,18 @@
+-- Szumi, 2025-03-11, dot-pattern termination is re-enabled for Cubical Agda
+-- Test case by Andreas adapted from the test case of #4606 by Andrew Pitts
+
+{-# OPTIONS --cubical #-}
+
+open import Agda.Builtin.Nat using (Nat; zero; suc)
+
+data Acc {A : Set} (R : A → A → Set) (x : A) : Set where
+  acc : (∀ y → R y x → Acc R y) → Acc R x
+
+data _<_ (x : Nat) : Nat → Set where
+  <S : x < suc x
+
+iswf< : ∀ x → Acc _<_ x
+iswf< x = acc (h x)
+  where
+  h : ∀ x y → y < x → Acc _<_ y
+  h .(suc y) y <S = acc (h y)

--- a/test/Succeed/Issue5953.agda
+++ b/test/Succeed/Issue5953.agda
@@ -1,10 +1,13 @@
--- Andreas, 2022-06-14, issue #5953 reported by Szumi Xi
+-- Andreas, 2022-06-14, issue #5953 reported by Szumi Xie
 -- Cubical Agda switches dot-pattern termination off (#4606).
 -- However, this breaks also some benign cases.
 --
 -- In this example with inductive-inductive types,
 -- dotted variables should still be recognized
 -- as variable patterns for termination certification.
+--
+-- Szumi, 2025-03-11:
+-- Dot-pattern termination is now re-enabled for Cubical Agda.
 
 {-# OPTIONS --cubical #-}  -- worked with --without-K but not --cubical
 

--- a/test/Succeed/Issue7616.agda
+++ b/test/Succeed/Issue7616.agda
@@ -1,0 +1,20 @@
+{-# OPTIONS --cubical #-}
+{-# OPTIONS --no-forcing #-}
+
+open import Agda.Builtin.Nat
+
+data Fin : Nat → Set where
+  fzero : ∀ {n} → Fin (suc n)
+  fsuc : ∀ {n} → Fin n → Fin (suc n)
+
+postulate
+  f : ∀ {n} → Fin n → Fin n
+
+works : ∀ {n} → Fin n → Fin n
+works         (fzero {n})  = fzero
+works {suc n} (fsuc {n} x) = fsuc (works {n} (f x))
+
+-- WAS: termination error when forcing is off
+test : ∀ {n} → Fin n → Fin n
+test .{suc n} (fzero {n}) = fzero
+test .{suc n} (fsuc {n} x) = fsuc (test {n} (f x))


### PR DESCRIPTION
This patch reverts the fix for #4606 and #5958, re-enabling dot-pattern termination for Cubical Agda. Instead, the termination checker ignores constructors of HITs in dot patterns. This also fixes #7616.

There was a brief discussion about this in #5953:
> > @nad:
> > Would it make sense to include dot patterns when checking termination for a Cubical Agda definition that does not involve matching for HITs?
>
> @andreasabel:
> I suppose so.
