### PR TITLE
Support GHC 9.12.2

### DIFF
--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         cabal-update: true
         cabal-version: latest
-        ghc-version: '9.12'
+        ghc-version: 9.12.2
     - name: Configure the build plan
       run: |
         # shellcheck disable=SC2086

--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         cabal-update: true
         cabal-version: latest
-        ghc-version: '9.10'
+        ghc-version: '9.12'
     - name: Configure the build plan
       run: |
         # shellcheck disable=SC2086

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       FLAGS: ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting'
         }}
-      GHC_VER: ${{ matrix.ghc-ver || '9.10.1' }}
+      GHC_VER: ${{ matrix.ghc-ver || '9.12.1' }}
     name: Cabal ${{ matrix.description }}, ${{ matrix.ghc-ver }}
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
@@ -108,6 +108,7 @@ jobs:
         doctest:
         - false
         ghc-ver:
+        - 9.12.1
         - 9.10.1
         - 9.8.4
         - 9.6.6
@@ -124,18 +125,18 @@ jobs:
           os: ubuntu-24.04
         - cabal-flags: --enable-tests -f debug
           description: Linux debug
-          ghc-ver: 9.10.1
+          ghc-ver: 9.12.1
           os: ubuntu-24.04
         - cabal-flags: --enable-tests -f enable-cluster-counting -f debug -f debug-serialisation
             -f debug-parsing
           description: Linux debug all
-          ghc-ver: 9.10.1
+          ghc-ver: 9.12.1
           os: ubuntu-24.04
         - description: macOS
-          ghc-ver: 9.10.1
+          ghc-ver: 9.12.1
           os: macos-14
         - description: Windows
-          ghc-ver: 9.10.1
+          ghc-ver: 9.12.1
           os: windows-2022
         os:
         - ubuntu-24.04

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       FLAGS: ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting'
         }}
-      GHC_VER: ${{ matrix.ghc-ver || '9.12.1' }}
+      GHC_VER: ${{ matrix.ghc-ver || '9.12.2' }}
     name: Cabal ${{ matrix.description }}, ${{ matrix.ghc-ver }}
     needs: auto-cancel
     runs-on: ${{ matrix.os }}
@@ -108,7 +108,7 @@ jobs:
         doctest:
         - false
         ghc-ver:
-        - 9.12.1
+        - 9.12.2
         - 9.10.1
         - 9.8.4
         - 9.6.6
@@ -121,22 +121,22 @@ jobs:
         - cabal-flags: --disable-tests
           description: Linux doctest
           doctest: true
-          ghc-ver: 9.10.1
+          ghc-ver: 9.12.2
           os: ubuntu-24.04
         - cabal-flags: --enable-tests -f debug
           description: Linux debug
-          ghc-ver: 9.12.1
+          ghc-ver: 9.12.2
           os: ubuntu-24.04
         - cabal-flags: --enable-tests -f enable-cluster-counting -f debug -f debug-serialisation
             -f debug-parsing
           description: Linux debug all
-          ghc-ver: 9.12.1
+          ghc-ver: 9.12.2
           os: ubuntu-24.04
         - description: macOS
-          ghc-ver: 9.12.1
+          ghc-ver: 9.12.2
           os: macos-14
         - description: Windows
-          ghc-ver: 9.12.1
+          ghc-ver: 9.12.2
           os: windows-2022
         os:
         - ubuntu-24.04

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,7 +228,7 @@ jobs:
         cabal-ver:
         - latest
         ghc-ver:
-        - '9.10'
+        - 9.12.2
         os:
         - windows-latest
         - macos-14

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         ghc-ver:
-        - 9.12.1
+        - 9.12.2
         os:
         - ubuntu-24.04
 name: Haddock

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         ghc-ver:
-        - 9.10.1
+        - 9.12.1
         os:
         - ubuntu-24.04
 name: Haddock

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -115,6 +115,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc-ver:
+        - 9.12.1
         - 9.10.1
         - 9.8.4
         - 9.6.6
@@ -124,9 +125,9 @@ jobs:
         - 8.10.7
         - 8.8.4
         include:
-        - ghc-ver: 9.10.1
+        - ghc-ver: 9.12.1
           os: macos-14
-        - ghc-ver: 9.10.1
+        - ghc-ver: 9.12.1
           os: windows-2022
         os:
         - ubuntu-24.04

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -115,7 +115,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc-ver:
-        - 9.12.1
+        - 9.12.2
         - 9.10.1
         - 9.8.4
         - 9.6.6
@@ -125,9 +125,9 @@ jobs:
         - 8.10.7
         - 8.8.4
         include:
-        - ghc-ver: 9.12.1
+        - ghc-ver: 9.12.2
           os: macos-14
-        - ghc-ver: 9.12.1
+        - ghc-ver: 9.12.2
           os: windows-2022
         os:
         - ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@
 ######################################################
 env:
   AGDA_TESTS_OPTIONS: -j${PARALLEL_TESTS} --hide-successes
-  GHC_VER: 9.12.1
+  GHC_VER: 9.12.2
   PARALLEL_TESTS: 2
   STACK: stack --system-ghc
   TASTY_ANSI_TRICKS: 'false'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@
 ######################################################
 env:
   AGDA_TESTS_OPTIONS: -j${PARALLEL_TESTS} --hide-successes
-  GHC_VER: 9.10.1
+  GHC_VER: 9.12.1
   PARALLEL_TESTS: 2
   STACK: stack --system-ghc
   TASTY_ANSI_TRICKS: 'false'

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -31,7 +31,7 @@ description:
     running @agda-mode setup@ (see the README).
 
 tested-with:
-    GHC == 9.12.1
+    GHC == 9.12.2
     GHC == 9.10.1
     GHC == 9.8.4
     GHC == 9.6.6
@@ -89,7 +89,7 @@ extra-doc-files:
     doc/release-notes/2.2.0.md
 
 extra-source-files:
-    stack-9.12.1.yaml
+    stack-9.12.2.yaml
     stack-9.10.1.yaml
     stack-9.8.4.yaml
     stack-9.6.6.yaml

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -31,6 +31,7 @@ description:
     running @agda-mode setup@ (see the README).
 
 tested-with:
+    GHC == 9.12.1
     GHC == 9.10.1
     GHC == 9.8.4
     GHC == 9.6.6
@@ -88,6 +89,7 @@ extra-doc-files:
     doc/release-notes/2.2.0.md
 
 extra-source-files:
+    stack-9.12.1.yaml
     stack-9.10.1.yaml
     stack-9.8.4.yaml
     stack-9.6.6.yaml
@@ -278,7 +280,6 @@ common language
 
   if impl(ghc >= 8.10)
     ghc-options:
-      -Werror=compat-unqualified-imports
       -Werror=deriving-defaults
       -Werror=redundant-record-wildcards
       -Werror=unused-packages
@@ -430,7 +431,7 @@ library
     , ansi-terminal        >= 0.10.3    && < 1.2
     , array                >= 0.5.4.0   && < 0.6
     , async                >= 2.2.2     && < 2.3
-    , base                 >= 4.13.0.0  && < 4.21
+    , base                 >= 4.13.0.0  && < 4.22
     , binary               >= 0.8.7.0   && < 0.9
     , blaze-html           >= 0.9.1.2   && < 0.10
     , boxes                >= 0.1.5     && < 0.2
@@ -938,7 +939,7 @@ executable agda-mode
       th-lift-instances    >= 0.1.18    && < 0.1.21
 
   build-depends:
-    , base                 >= 4.13.0.0  && < 4.21
+    , base                 >= 4.13.0.0  && < 4.22
     , bytestring           >= 0.10.10.1 && < 0.13
     , directory            >= 1.3.6.0   && < 1.4
     , filelock             >= 0.1.1.5   && < 0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Installation
 
 * Dropped support for GHC 8.6.
 
-* Agda supports GHC versions 8.8.4 to 9.10.1.
+* Agda supports GHC versions 8.8.4 to 9.12.1.
 
 * The `agda` binary now contains everything
   to set itself up, it need not be shipped with additional files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Installation
 
 * Dropped support for GHC 8.6.
 
-* Agda supports GHC versions 8.8.4 to 9.12.1.
+* Agda supports GHC versions 8.8.4 to 9.12.2.
 
 * The `agda` binary now contains everything
   to set itself up, it need not be shipped with additional files.

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -315,7 +315,7 @@ Agda has been tested with GHC
 9.6.6,
 9.8.4,
 9.10.1, and
-9.12.1.
+9.12.2.
 
 
 .. _installation-flags:

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -313,8 +313,9 @@ Agda has been tested with GHC
 9.2.8,
 9.4.8,
 9.6.6,
-9.8.4 and
-9.10.1.
+9.8.4,
+9.10.1, and
+9.12.1.
 
 
 .. _installation-flags:

--- a/src/github/workflows/cabal-install.yml
+++ b/src/github/workflows/cabal-install.yml
@@ -61,7 +61,7 @@ jobs:
     - uses: haskell-actions/setup@v2
       id: setup-haskell
       with:
-        ghc-version:   '9.10'
+        ghc-version:   '9.12'
         cabal-version: latest
         cabal-update:  true
 

--- a/src/github/workflows/cabal-install.yml
+++ b/src/github/workflows/cabal-install.yml
@@ -61,7 +61,7 @@ jobs:
     - uses: haskell-actions/setup@v2
       id: setup-haskell
       with:
-        ghc-version:   '9.12'
+        ghc-version:   '9.12.2'
         cabal-version: latest
         cabal-update:  true
 

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         description: [Linux]      ## This just for pretty-printing the job name.
-        ghc-ver: [9.12.1, 9.10.1, 9.8.4, 9.6.6, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4]
+        ghc-ver: [9.12.2, 9.10.1, 9.8.4, 9.6.6, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4]
         cabal-flags: ['--enable-tests -f enable-cluster-counting']
         doctest: [false]
         include:
@@ -58,7 +58,7 @@ jobs:
           # Linux, without tests but with doctest
           - os: ubuntu-24.04
             description: Linux doctest
-            ghc-ver: '9.10.1'
+            ghc-ver: '9.12.2'
             # Can't leave cabal-flags empty here lest it becomes the default value.
             cabal-flags: '--disable-tests'
             doctest: true
@@ -66,13 +66,13 @@ jobs:
           # Linux, without -f enable-cluster-counting but with -f debug
           - os: ubuntu-24.04
             description: Linux debug
-            ghc-ver: '9.12.1'
+            ghc-ver: '9.12.2'
             cabal-flags: '--enable-tests -f debug'
 
           # Linux, with all debug options
           - os: ubuntu-24.04
             description: Linux debug all
-            ghc-ver: '9.12.1'
+            ghc-ver: '9.12.2'
             ## Andreas, 2024-08-16: Keeping the following outdated note for future reference:
             ## Note: -c 'containers >= 0.7' with single quotes does not get communicated properly.
             ## (The single quotes stay, and "-c 'containers" is an option parse error for cabal.)
@@ -82,16 +82,16 @@ jobs:
           # macOS with default flags
           - os: macos-14
             description: macOS
-            ghc-ver: '9.12.1'
+            ghc-ver: '9.12.2'
 
           # Windows with default flags
           - os: windows-2022
             description: Windows
-            ghc-ver: '9.12.1'
+            ghc-ver: '9.12.2'
 
     # Default values
     env:
-      GHC_VER:   ${{ matrix.ghc-ver || '9.12.1' }}
+      GHC_VER:   ${{ matrix.ghc-ver || '9.12.2' }}
       FLAGS:     ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting' }}
 
     steps:

--- a/src/github/workflows/cabal.yml
+++ b/src/github/workflows/cabal.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         description: [Linux]      ## This just for pretty-printing the job name.
-        ghc-ver: [9.10.1, 9.8.4, 9.6.6, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4]
+        ghc-ver: [9.12.1, 9.10.1, 9.8.4, 9.6.6, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4]
         cabal-flags: ['--enable-tests -f enable-cluster-counting']
         doctest: [false]
         include:
@@ -66,13 +66,13 @@ jobs:
           # Linux, without -f enable-cluster-counting but with -f debug
           - os: ubuntu-24.04
             description: Linux debug
-            ghc-ver: '9.10.1'
+            ghc-ver: '9.12.1'
             cabal-flags: '--enable-tests -f debug'
 
           # Linux, with all debug options
           - os: ubuntu-24.04
             description: Linux debug all
-            ghc-ver: '9.10.1'
+            ghc-ver: '9.12.1'
             ## Andreas, 2024-08-16: Keeping the following outdated note for future reference:
             ## Note: -c 'containers >= 0.7' with single quotes does not get communicated properly.
             ## (The single quotes stay, and "-c 'containers" is an option parse error for cabal.)
@@ -82,16 +82,16 @@ jobs:
           # macOS with default flags
           - os: macos-14
             description: macOS
-            ghc-ver: '9.10.1'
+            ghc-ver: '9.12.1'
 
           # Windows with default flags
           - os: windows-2022
             description: Windows
-            ghc-ver: '9.10.1'
+            ghc-ver: '9.12.1'
 
     # Default values
     env:
-      GHC_VER:   ${{ matrix.ghc-ver || '9.10.1' }}
+      GHC_VER:   ${{ matrix.ghc-ver || '9.12.1' }}
       FLAGS:     ${{ matrix.cabal-flags || '--enable-tests -f enable-cluster-counting' }}
 
     steps:

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
         # As of today (2024-02-05), the actual version information can be found in
         # https://github.com/actions/runner-images#available-images
         os: [windows-latest, macos-14, macos-13, ubuntu-latest]
-        ghc-ver: ['9.10']
+        ghc-ver: ['9.12.2']
         cabal-ver: [latest]
 
     env:

--- a/src/github/workflows/haddock.yml
+++ b/src/github/workflows/haddock.yml
@@ -25,7 +25,7 @@ jobs:
         # not for the virtual environments, and also haskell/action/setup
         # is usually not up-to-date.
         os: [ubuntu-24.04]
-        ghc-ver: ['9.12.1']
+        ghc-ver: ['9.12.2']
           # Use the versions that come with the virtual environment, if possible.
 
     if: |

--- a/src/github/workflows/haddock.yml
+++ b/src/github/workflows/haddock.yml
@@ -25,7 +25,7 @@ jobs:
         # not for the virtual environments, and also haskell/action/setup
         # is usually not up-to-date.
         os: [ubuntu-24.04]
-        ghc-ver: ['9.10.1']
+        ghc-ver: ['9.12.1']
           # Use the versions that come with the virtual environment, if possible.
 
     if: |

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        ghc-ver: [9.10.1, 9.8.4, 9.6.6, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4]
+        ghc-ver: [9.12.1, 9.10.1, 9.8.4, 9.6.6, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4]
           # Andreas, 2022-03-26:
           # Note: ghc-ver needs to be spelled out with minor version, i.e., x.y.z
           # rather than x.y (which haskell-setup would resolve to a suitable .z)
@@ -59,9 +59,9 @@ jobs:
           # adding the respective stack-x.y.z.yaml file.
         include:
         - os: macos-14
-          ghc-ver: 9.10.1
+          ghc-ver: 9.12.1
         - os: windows-2022
-          ghc-ver: 9.10.1
+          ghc-ver: 9.12.1
 
     # # Try "allowed-failure" for Windows with GHC 9.2
     # continue-on-error: ${{ startsWith(matrix.os, 'windows') && startsWith(matrix.ghc-ver,'9.2') }}

--- a/src/github/workflows/stack.yml
+++ b/src/github/workflows/stack.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        ghc-ver: [9.12.1, 9.10.1, 9.8.4, 9.6.6, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4]
+        ghc-ver: [9.12.2, 9.10.1, 9.8.4, 9.6.6, 9.4.8, 9.2.8, 9.0.2, 8.10.7, 8.8.4]
           # Andreas, 2022-03-26:
           # Note: ghc-ver needs to be spelled out with minor version, i.e., x.y.z
           # rather than x.y (which haskell-setup would resolve to a suitable .z)
@@ -59,9 +59,9 @@ jobs:
           # adding the respective stack-x.y.z.yaml file.
         include:
         - os: macos-14
-          ghc-ver: 9.12.1
+          ghc-ver: 9.12.2
         - os: windows-2022
-          ghc-ver: 9.12.1
+          ghc-ver: 9.12.2
 
     # # Try "allowed-failure" for Windows with GHC 9.2
     # continue-on-error: ${{ startsWith(matrix.os, 'windows') && startsWith(matrix.ghc-ver,'9.2') }}

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -55,7 +55,7 @@ env:
   # Andreas, 2022-03-26, 2022-11-28:
   # GHC_VER should be given as x.y.z (as opposed to x.y only)
   # because it is used verbatim when referring to stack-x.y.z.yaml.
-  GHC_VER: "9.12.1"
+  GHC_VER: "9.12.2"
 
   # Part 2: Variables that should not have to be changed
   ###########################################################################

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -55,7 +55,7 @@ env:
   # Andreas, 2022-03-26, 2022-11-28:
   # GHC_VER should be given as x.y.z (as opposed to x.y only)
   # because it is used verbatim when referring to stack-x.y.z.yaml.
-  GHC_VER: "9.10.1"
+  GHC_VER: "9.12.1"
 
   # Part 2: Variables that should not have to be changed
   ###########################################################################

--- a/stack-9.10.1.yaml
+++ b/stack-9.10.1.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2025-01-02
+resolver: nightly-2025-03-15
 compiler: ghc-9.10.1
 compiler-check: match-exact
 

--- a/stack-9.12.1.yaml
+++ b/stack-9.12.1.yaml
@@ -1,5 +1,5 @@
-resolver: lts-23.14
-compiler: ghc-9.8.4
+resolver: nightly-2025-03-15
+compiler: ghc-9.12.1
 compiler-check: match-exact
 
 # Local packages specified by relative directory name.

--- a/stack-9.12.2.yaml
+++ b/stack-9.12.2.yaml
@@ -1,5 +1,5 @@
 resolver: nightly-2025-03-15
-compiler: ghc-9.12.1
+compiler: ghc-9.12.2
 compiler-check: match-exact
 
 # Local packages specified by relative directory name.

--- a/test/api/ScopeFromInterface.hs
+++ b/test/api/ScopeFromInterface.hs
@@ -20,7 +20,6 @@ import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe
-import Data.Typeable (Typeable)
 
 import System.Environment ( getArgs )
 ------------------------------------------------------------------------------
@@ -55,7 +54,7 @@ data TruncatedInterface = TruncatedInterface
     -- ^ Scope defined by this module. (Not serialized.)
   , tiInsideScope     :: ScopeInfo
     -- ^ Scope after we loaded this interface.
-  } deriving (Typeable)
+  }
 
 instance EmbPrj TruncatedInterface where
   icod_ = __IMPOSSIBLE__


### PR DESCRIPTION
Closes #7574.

Agda is on std-lib's `experimental` because of:
- https://github.com/agda/agda-stdlib/pull/2546

I rebased `experimental` onto `master` to get the GHC 9.12 support in.

- [x] Workflow `deploy` is still on 9.10, we wait for 9.12.2 to update it.