### PR TITLE
Fix #7751: Consider datatype clauses generated from module application in recursion checker

### DIFF
--- a/src/full/Agda/Termination/RecCheck.hs
+++ b/src/full/Agda/Termination/RecCheck.hs
@@ -136,8 +136,14 @@ recDef include name = do
           (i,) <$> anyDefs include cl
       return (IntMap.fromList perClause, mconcat $ map snd perClause)
 
-    Record{ recTel } -> do
-      ns <- anyDefs include recTel
+    Datatype{ dataClause = Just cl } -> do
+      ns <- anyDefs include cl
+      return (IntMap.singleton 0 ns, ns)
+
+    Record{ recClause, recTel } -> do
+      ns1 <- anyDefs include recClause
+      ns2 <- anyDefs include recTel
+      let ns = ns1 `mappend` ns2
       return (IntMap.singleton 0 ns, ns)
 
     _ -> return (mempty, mempty)

--- a/test/Fail/Issue7751.agda
+++ b/test/Fail/Issue7751.agda
@@ -1,0 +1,8 @@
+module Issue7751 where
+
+module M (X : Set) where
+  data X' : Set where
+
+Bad : Set
+open M Bad
+Bad = X'

--- a/test/Fail/Issue7751.err
+++ b/test/Fail/Issue7751.err
@@ -1,0 +1,6 @@
+Issue7751.agda:6.1-8.9: error: [TerminationIssue]
+Termination checking failed for the following functions:
+  Bad
+Problematic calls:
+  Bad
+    (at Issue7751.agda:7.8-11)

--- a/test/Fail/Issue7751b.agda
+++ b/test/Fail/Issue7751b.agda
@@ -1,0 +1,8 @@
+module Issue7751b where
+
+module M (X : Set) where
+  record X' : Set where
+
+Bad : Set
+open M Bad
+Bad = X'

--- a/test/Fail/Issue7751b.err
+++ b/test/Fail/Issue7751b.err
@@ -1,0 +1,6 @@
+Issue7751b.agda:6.1-8.9: error: [TerminationIssue]
+Termination checking failed for the following functions:
+  Bad
+Problematic calls:
+  Bad
+    (at Issue7751b.agda:7.8-11)

--- a/test/Fail/Issue7751c.agda
+++ b/test/Fail/Issue7751c.agda
@@ -1,0 +1,18 @@
+{-# OPTIONS --safe #-}
+module Issue7751c where
+
+data ⊥ : Set where
+
+module M (X : Set) where
+  data ¬X : Set where
+    neg : (X → ⊥) → ¬X
+
+Bad : Set
+open M Bad
+Bad = ¬X
+
+bad : Bad → ⊥
+bad (neg f) = f (neg f)
+
+oops : ⊥
+oops = bad (neg bad)

--- a/test/Fail/Issue7751c.err
+++ b/test/Fail/Issue7751c.err
@@ -1,0 +1,10 @@
+Issue7751c.agda:10.1-12.9: error: [TerminationIssue]
+Termination checking failed for the following functions:
+  Bad
+Problematic calls:
+  Bad
+    (at Issue7751c.agda:11.8-11)
+
+Issue7751c.agda:15.6-11: error: [SplitError.NotADatatype]
+Cannot split on argument of non-datatype Bad
+when checking that the pattern neg f has type Bad


### PR DESCRIPTION
Fixes #7751.
