### PR TITLE
Fix #7761: Include large Prop in checks whether something is a Prop

### DIFF
--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -842,10 +842,8 @@ dummyLocName cs = maybe __IMPOSSIBLE__ prettyCallSite (headCallSite cs)
 dummyTermWith :: DummyTermKind -> CallStack -> Term
 dummyTermWith kind cs = flip Dummy [] $ concat [kind, ": ", dummyLocName cs]
 
--- | A dummy level to constitute a level/sort created at location.
---   Note: use macro __DUMMY_LEVEL__ !
-dummyLevel :: CallStack -> Level
-dummyLevel = atomicLevel . dummyTermWith "dummyLevel"
+__DUMMY_TERM_WITH__ :: HasCallStack => DummyTermKind -> Term
+__DUMMY_TERM_WITH__ = withCallerCallStack . dummyTermWith
 
 -- | A dummy term created at location.
 --   Note: use macro __DUMMY_TERM__ !
@@ -854,6 +852,11 @@ dummyTerm = dummyTermWith "dummyTerm"
 
 __DUMMY_TERM__ :: HasCallStack => Term
 __DUMMY_TERM__ = withCallerCallStack dummyTerm
+
+-- | A dummy level to constitute a level/sort created at location.
+--   Note: use macro __DUMMY_LEVEL__ !
+dummyLevel :: CallStack -> Level
+dummyLevel = atomicLevel . dummyTermWith "dummyLevel"
 
 __DUMMY_LEVEL__ :: HasCallStack => Level
 __DUMMY_LEVEL__ = withCallerCallStack dummyLevel

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -306,10 +306,11 @@ compareTerm' cmp a m n =
       , "mlvl =" <+> pretty mlvl
       , text $ "(Just (unEl a') == mlvl) = " ++ show (Just (unEl a') == mlvl)
       ]
-    blockOnError bs $ case s of
-      Prop{} | propIrr -> compareIrrelevant a' m n
-      _    | isSize   -> compareSizes cmp m n
-      _               -> case unEl a' of
+    blockOnError bs
+      case unEl a' of
+        _ | propIrr
+          , isProp s  -> compareIrrelevant a' m n
+        _ | isSize    -> compareSizes cmp m n
         a | Just a == mlvl -> do
           a <- levelView m
           b <- levelView n

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -1369,8 +1369,8 @@ leqSort s1 s2 = do
       (_       , LevelUniv) -> equalSort s1 s2
       (_       , IntervalUniv) -> equalSort s1 s2
       (_       , SizeUniv) -> equalSort s1 s2
-      (_       , Prop (Max 0 [])) -> equalSort s1 s2
-      (_       , Type (Max 0 []))
+      (_       , Prop (ClosedLevel 0)) -> equalSort s1 s2
+      (_       , Type (ClosedLevel 0))
         | not propEnabled  -> equalSort s1 s2
 
       -- @SizeUniv@, @LockUniv@ and @LevelUniv@ are unrelated to any @Set l@ or @Prop l@

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -1160,7 +1160,7 @@ splitLast :: Induction -> Telescope -> [NamedArg DeBruijnPattern] -> TCM (Either
 splitLast ind tel ps = split ind NoAllowPartialCover sc (BlockingVar 0 [] [] True False)
   where sc = SClause tel (toSplitPatterns ps) empty empty target
         -- TODO 2ltt: allows (Empty_fib -> Empty_strict) which is not conservative
-        target = (Just $ defaultDom $ El (Prop (Max 0 [])) $ Dummy "splitLastTarget" [])
+        target = (Just $ defaultDom $ El (mkProp 0) $ __DUMMY_TERM_WITH__ "splitLastTarget")
 
 -- | @split ind splitClause x = return res@
 --   splits @splitClause@ at pattern var @x@ (de Bruijn index).

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -87,7 +87,6 @@ import Agda.TypeChecking.Substitute.Class
 import Agda.TypeChecking.Telescope
 
 import Agda.Utils.Either (fromRightM)
-import Agda.Utils.Lens
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 
@@ -321,14 +320,12 @@ usableAtModality = usableAtModality' Nothing
 
 -- | Is a type a proposition?  (Needs reduction.)
 
-isPropM
-  :: (LensSort a, PrettyTCM a, PureTCM m, MonadBlock m)
-  => a -> m Bool
+{-# SPECIALIZE isPropM :: Dom Type -> TCM Bool #-}
+isPropM :: (LensSort a, PrettyTCM a, PureTCM m, MonadBlock m) => a -> m Bool
 isPropM a = do
-  traceSDoc "tc.prop" 80 ("Is " <+> prettyTCM a <+> "of sort" <+> prettyTCM (getSort a) <+> "in Prop?") $ do
-  abortIfBlocked (getSort a) <&> \case
-    Prop{} -> True
-    _      -> False
+  let s = getSort a
+  traceSDoc "tc.prop" 80 ("Is " <+> prettyTCM a <+> "of sort" <+> prettyTCM s <+> "in Prop?") do
+  isProp <$> abortIfBlocked s
 
 {-# SPECIALIZE isIrrelevantOrPropM :: Dom Type -> TCM Bool #-}
 isIrrelevantOrPropM

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -119,9 +119,7 @@ compactDef bEnv def rewr = do
 
   -- WARNING: don't use isPropM here because it relies on reduction,
   -- which causes an infinite loop.
-  let isPrp = case getSort (defType def) of
-        Prop{} -> True
-        _      -> False
+  let isPrp = isProp $ getSort $ defType def
 
   shouldReduce <- shouldReduceDef (defName def)
   allowed <- asksTC envAllowedReductions

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -286,11 +286,8 @@ checkConstructor d uc tel nofIxs s con@(A.Axiom _ i ai Nothing c e) =
         debugFitsIn s
         -- To allow propositional squash, we turn @Prop ℓ@ into @Set ℓ@
         -- for the purpose of checking the type of the constructors.
-        let s' = case s of
-              Prop l -> Type l
-              _      -> s
         arity <- applyQuantityToJudgement ai $
-          fitsIn c uc forcedArgs t s'
+          fitsIn c uc forcedArgs t $ propToType s
         -- this may have instantiated some metas in s, so we reduce
         s <- reduce s
         debugAdd c t

--- a/test/Fail/Issue7761.agda
+++ b/test/Fail/Issue7761.agda
@@ -1,0 +1,17 @@
+{-# OPTIONS --prop #-}
+
+open import Agda.Primitive
+
+data Natω : Setω where
+  zero : Natω
+  suc  : Natω → Natω
+
+data SqNatω : Propω where
+  sq : Natω → SqNatω
+
+unsq : SqNatω → Natω
+unsq (sq n) = n
+
+-- Expected error: [SplitInProp]
+-- Cannot split on datatype in Prop unless target is in Prop
+-- when checking that the pattern sq n has type SqNatω

--- a/test/Fail/Issue7761.err
+++ b/test/Fail/Issue7761.err
@@ -1,0 +1,3 @@
+Issue7761.agda:13.7-11: error: [SplitInProp]
+Cannot split on datatype in Prop unless target is in Prop
+when checking that the pattern sq n has type SqNatω

--- a/test/Succeed/Issue7761.agda
+++ b/test/Succeed/Issue7761.agda
@@ -1,0 +1,37 @@
+-- Andreas, 2025-03-27, issue #7761, reported and test by Szumi Xie
+-- Propω should also be proof irrelevant.
+
+{-# OPTIONS --prop #-}
+
+open import Agda.Primitive
+
+postulate
+  A : Propω
+  x y : A
+  P : A → Set
+
+test : P x → P y
+test p = p
+
+-- Andreas, 2025-03-27
+-- Allow propositional squashing also in Propω.
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+-- Small positional squashing.
+
+data SqNat : Prop where
+  sq : Nat → SqNat
+
+-- Large positional squashing.
+
+data Natω : Setω where
+  zero : Natω
+  suc  : Natω → Natω
+
+data SqNatω : Propω where
+  sq : Natω → SqNatω
+
+succ : SqNatω → SqNatω
+succ (sq n) = sq (suc n)


### PR DESCRIPTION
Commits:
- **[refactor] use macro `__DUMMY_TERM_WITH__` rather than `Dummy`**
- **Include large Prop in checks whether something is a Prop**

Closes #7761 
- #7761