### PR TITLE
Fix #7769: replace warning `OpenPublic{Abstract,Private}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,8 +104,12 @@ Warnings
 * Warning `AbsurdPatternRequiresNoRHS` has been renamed to
   `AbsurdPatternRequiresAbsentRHS`.
 
+* Warnings `OpenPublicAbstract` and `OpenPublicPrivate` have been replaced
+  by new warnings `OpenImportAbstract` and `OpenImportPrivate`.
+
 * Warning `NoGuardednessFlag` has been removed.
   Instead Agda a hint when `--guardedness` would help with termination checking.
+
 
 Polarity
 --------

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1512,13 +1512,13 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Deprecated :ref:`BUILTIN<built-ins>` pragmas.
 
-.. option:: OpenPublicAbstract
+.. option:: OpenImportAbstract
 
-     ``open public`` directives in ``abstract`` blocks.
+     ``open`` or ``import`` statements in ``abstract`` blocks.
 
-.. option:: OpenPublicPrivate
+.. option:: OpenImportPrivate
 
-     ``open public`` directives in ``private`` blocks.
+     ``open`` or ``import`` statements in ``private`` blocks.
 
 .. option:: OptionRenamed
 

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -555,8 +555,8 @@ warningHighlighting' b w = case tcWarning w of
     InvalidTerminationCheckPragma{}  -> deadcodeHighlighting w
     InvalidCoverageCheckPragma{}     -> deadcodeHighlighting w
     InvalidConstructorBlock{}        -> deadcodeHighlighting w
-    OpenPublicAbstract{}             -> deadcodeHighlighting w
-    OpenPublicPrivate{}              -> deadcodeHighlighting w
+    OpenImportAbstract{}             -> cosmeticProblemHighlighting w
+    OpenImportPrivate{}              -> cosmeticProblemHighlighting w
     SafeFlagEta                   {} -> errorWarningHighlighting w
     SafeFlagInjective             {} -> errorWarningHighlighting w
     SafeFlagNoCoverageCheck       {} -> errorWarningHighlighting w

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -248,8 +248,8 @@ data WarningName
   | MissingDataDeclaration_
   | MissingDefinitions_
   | NotAllowedInMutual_
-  | OpenPublicAbstract_
-  | OpenPublicPrivate_
+  | OpenImportAbstract_
+  | OpenImportPrivate_
   | PolarityPragmasButNotPostulates_
   | PragmaCompiled_
   | PragmaNoTerminationCheck_
@@ -477,8 +477,8 @@ warningNameDescription = \case
   MissingDataDeclaration_          -> "Constructor definitions not associated to a data declaration."
   MissingDefinitions_              -> "Declarations not associated to a definition."
   NotAllowedInMutual_              -> "Declarations not allowed in a mutual block."
-  OpenPublicAbstract_              -> "'open public' directives in 'abstract' blocks."
-  OpenPublicPrivate_               -> "'open public' directives in 'private' blocks."
+  OpenImportAbstract_              -> "`open' or `import' statements in 'abstract' blocks."
+  OpenImportPrivate_               -> "`open' or `import' statements in 'private' blocks."
   PolarityPragmasButNotPostulates_ -> "Polarity pragmas for non-postulates."
   PragmaCompiled_                  -> "'COMPILE' pragmas in safe mode."
   PragmaNoTerminationCheck_        -> "`NO_TERMINATION_CHECK' pragmas; such are deprecated."

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -1247,7 +1247,7 @@ niceDeclarations fixs ds = do
       -> [NiceDeclaration]
       -> Nice [NiceDeclaration]
     abstractBlock r ds = do
-      (ds', anyChange) <- runChangeT $ mkAbstract ds
+      (ds', anyChange) <- runChangeT $ mkAbstract r ds
       let inherited = null r
       if anyChange then return ds' else do
         -- hack to avoid failing on inherited abstract blocks in where clauses
@@ -1351,10 +1351,13 @@ instance MakeMacro NiceDeclaration where
 -- Then, nested @abstract@s would sometimes also be complained about.
 
 class MakeAbstract a where
-  mkAbstract :: UpdaterT Nice a
+  mkAbstract ::
+       KwRange
+         -- ^ Range of the keyword @abstract@.
+    -> UpdaterT Nice a
 
-  default mkAbstract :: (Traversable f, MakeAbstract a', a ~ f a') => UpdaterT Nice a
-  mkAbstract = traverse mkAbstract
+  default mkAbstract :: (Traversable f, MakeAbstract a', a ~ f a') => KwRange -> UpdaterT Nice a
+  mkAbstract = traverse . mkAbstract
 
 instance MakeAbstract a => MakeAbstract [a]
 
@@ -1363,58 +1366,61 @@ instance MakeAbstract a => MakeAbstract [a]
 --   mkAbstract = traverse mkAbstract
 
 instance MakeAbstract IsAbstract where
-  mkAbstract = \case
+  mkAbstract _ = \case
     a@AbstractDef -> return a
     ConcreteDef -> dirty $ AbstractDef
 
 instance MakeAbstract NiceDeclaration where
-  mkAbstract = \case
-      NiceMutual r termCheck cc pc ds  -> NiceMutual r termCheck cc pc <$> mkAbstract ds
-      NiceLoneConstructor r ds         -> NiceLoneConstructor r <$> mkAbstract ds
-      FunDef r ds a i tc cc x cs       -> (\ a -> FunDef r ds a i tc cc x) <$> mkAbstract a <*> mkAbstract cs
-      NiceDataDef r o a pc uc x ps cs  -> (\ a -> NiceDataDef r o a pc uc x ps) <$> mkAbstract a <*> mkAbstract cs
-      NiceRecDef r o a pc uc x dir ps cs -> (\ a -> NiceRecDef r o a pc uc x dir ps cs) <$> mkAbstract a
-      NiceFunClause r p a tc cc catchall d  -> (\ a -> NiceFunClause r p a tc cc catchall d) <$> mkAbstract a
-      -- The following declarations have an @InAbstract@ field
-      -- but are not really definitions, so we do count them into
-      -- the declarations which can be made abstract
-      -- (thus, do not notify progress with @dirty@).
-      Axiom r p a i rel x e          -> return $ Axiom             r p AbstractDef i rel x e
-      FunSig r p a i m rel tc cc x e -> return $ FunSig            r p AbstractDef i m rel tc cc x e
-      NiceRecSig  r er p a pc uc x ls t -> return $ NiceRecSig  r er p AbstractDef pc uc x ls t
-      NiceDataSig r er p a pc uc x ls t -> return $ NiceDataSig r er p AbstractDef pc uc x ls t
-      NiceField r p _ i tac x e      -> return $ NiceField         r p AbstractDef i tac x e
-      PrimitiveFunction r p _ x e    -> return $ PrimitiveFunction r p AbstractDef x e
-      -- Andreas, 2016-07-17 it does have effect on unquoted defs.
-      -- Need to set updater state to dirty!
-      NiceUnquoteDecl r p _ i tc cc x e -> tellDirty $> NiceUnquoteDecl r p AbstractDef i tc cc x e
-      NiceUnquoteDef r p _ tc cc x e    -> tellDirty $> NiceUnquoteDef r p AbstractDef tc cc x e
-      NiceUnquoteData r p _ tc cc x xs e -> tellDirty $> NiceUnquoteData r p AbstractDef tc cc x xs e
-      d@NiceModule{}                 -> return d
-      d@NiceModuleMacro{}            -> return d
-      d@NicePragma{}                 -> return d
-      d@(NiceOpen _ _ directives)              -> do
-        whenJust (publicOpen directives) $ lift . declarationWarning . OpenPublicAbstract
-        return d
-      d@NiceImport{}                 -> return d
-      d@NicePatternSyn{}             -> return d
-      d@NiceGeneralize{}             -> return d
-      NiceOpaque r ns ds             -> NiceOpaque r ns <$> mkAbstract ds
+  mkAbstract :: KwRange -> UpdaterT Nice NiceDeclaration
+  mkAbstract kwr = \case
+    NiceMutual r termCheck cc pc ds      -> NiceMutual r termCheck cc pc <$> mkAbstract kwr ds
+    NiceLoneConstructor r ds             -> NiceLoneConstructor r <$> mkAbstract kwr ds
+    FunDef r ds a i tc cc x cs           -> (\ a -> FunDef r ds a i tc cc x) <$> mkAbstract kwr a <*> mkAbstract kwr cs
+    NiceDataDef r o a pc uc x ps cs      -> (\ a -> NiceDataDef r o a pc uc x ps) <$> mkAbstract kwr a <*> mkAbstract kwr cs
+    NiceRecDef r o a pc uc x dir ps cs   -> (\ a -> NiceRecDef r o a pc uc x dir ps cs) <$> mkAbstract kwr a
+    NiceFunClause r p a tc cc catchall d -> (\ a -> NiceFunClause r p a tc cc catchall d) <$> mkAbstract kwr a
+    -- The following declarations have an @InAbstract@ field
+    -- but are not really definitions, so we do count them into
+    -- the declarations which can be made abstract
+    -- (thus, do not notify progress with @dirty@).
+    Axiom r p a i rel x e                -> return $ Axiom             r p AbstractDef i rel x e
+    FunSig r p a i m rel tc cc x e       -> return $ FunSig            r p AbstractDef i m rel tc cc x e
+    NiceRecSig  r er p a pc uc x ls t    -> return $ NiceRecSig     r er p AbstractDef pc uc x ls t
+    NiceDataSig r er p a pc uc x ls t    -> return $ NiceDataSig    r er p AbstractDef pc uc x ls t
+    NiceField r p _ i tac x e            -> return $ NiceField         r p AbstractDef i tac x e
+    PrimitiveFunction r p _ x e          -> return $ PrimitiveFunction r p AbstractDef x e
+    -- Andreas, 2016-07-17 it does have effect on unquoted defs.
+    -- Need to set updater state to dirty!
+    NiceUnquoteDecl r p _ i tc cc x e    -> tellDirty $> NiceUnquoteDecl r p AbstractDef i tc cc x e
+    NiceUnquoteDef r p _ tc cc x e       -> tellDirty $> NiceUnquoteDef  r p AbstractDef tc cc x e
+    NiceUnquoteData r p _ tc cc x xs e   -> tellDirty $> NiceUnquoteData r p AbstractDef tc cc x xs e
+    d@NiceModule{}                       -> return d
+    d@NiceModuleMacro{}                  -> return d
+    d@NicePragma{}                       -> return d
+    d@NiceOpen{}                         -> d <$ do
+      unless (null kwr) $
+        lift $ declarationWarning $ OpenImportAbstract (getRange d) kwr OpenNotImport
+    d@NiceImport{}                       -> d <$ do
+      unless (null kwr) $
+        lift $ declarationWarning $ OpenImportAbstract (getRange d) kwr ImportMayOpen
+    d@NicePatternSyn{}                   -> return d
+    d@NiceGeneralize{}                   -> return d
+    NiceOpaque r ns ds                   -> NiceOpaque r ns <$> mkAbstract kwr ds
 
 instance MakeAbstract Clause where
-  mkAbstract (Clause x catchall lhs rhs wh with) = do
-    Clause x catchall lhs rhs <$> mkAbstract wh <*> mkAbstract with
+  mkAbstract kwr (Clause x catchall lhs rhs wh with) = do
+    Clause x catchall lhs rhs <$> mkAbstract kwr wh <*> mkAbstract kwr with
 
 -- | Contents of a @where@ clause are abstract if the parent is.
 --
 --   These are inherited 'Abstract' blocks, indicated by an empty range
 --   for the @abstract@ keyword.
 instance MakeAbstract WhereClause where
-  mkAbstract  NoWhere               = return $ NoWhere
-  mkAbstract (AnyWhere r ds)        = dirty $ AnyWhere r
-                                                [Abstract empty ds]
-  mkAbstract (SomeWhere r e m a ds) = dirty $ SomeWhere r e m a
-                                                [Abstract empty ds]
+  mkAbstract _  NoWhere               = return $ NoWhere
+  mkAbstract _ (AnyWhere r ds)        = dirty $ AnyWhere r
+                                                  [Abstract empty ds]
+  mkAbstract _ (SomeWhere r e m a ds) = dirty $ SomeWhere r e m a
+                                                  [Abstract empty ds]
 
 -- | Make a declaration private.
 --
@@ -1426,7 +1432,12 @@ instance MakeAbstract WhereClause where
 -- Then, nested @private@s would sometimes also be complained about.
 
 class MakePrivate a where
-  mkPrivate :: KwRange -> Origin -> UpdaterT Nice a
+  mkPrivate ::
+       KwRange
+         -- ^ Range of the @private@ keyword.
+    -> Origin
+         -- ^ Origin of the @private@ block.
+    -> UpdaterT Nice a
 
   default mkPrivate :: (Traversable f, MakePrivate a', a ~ f a') => KwRange -> Origin -> UpdaterT Nice a
   mkPrivate kwr o = traverse $ mkPrivate kwr o
@@ -1461,10 +1472,14 @@ instance MakePrivate NiceDeclaration where
       NiceGeneralize r p i tac x t             -> (\ p -> NiceGeneralize r p i tac x t)         <$> mkPrivate kwr o p
       NiceOpaque r ns ds                       -> (\ p -> NiceOpaque r ns p)                    <$> mkPrivate kwr o ds
       d@NicePragma{}                           -> return d
-      d@(NiceOpen _ _ directives)              -> do
-        whenJust (publicOpen directives) $ lift . declarationWarning . OpenPublicPrivate
-        return d
-      d@NiceImport{}                           -> return d
+      d@(NiceOpen r _x dir)                    -> d <$ do
+        unless (null kwr) $
+          whenJust (publicOpen dir) \ kwrPublic ->
+            lift $ declarationWarning $ OpenImportPrivate r kwrPublic kwr OpenNotImport
+      d@(NiceImport r _x _as _open dir)        -> d <$ do
+        unless (null kwr) $
+          whenJust (publicOpen dir) \ kwrPublic ->
+            lift $ declarationWarning $ OpenImportPrivate r kwrPublic kwr ImportMayOpen
       -- Andreas, 2016-07-08, issue #2089
       -- we need to propagate 'private' to the named where modules
       FunDef r ds a i tc cc x cls              -> FunDef r ds a i tc cc x <$> mkPrivate kwr o cls
@@ -1483,7 +1498,7 @@ instance MakePrivate WhereClause where
     -- thus, they are effectively private by default.
     d@AnyWhere{} -> return d
     -- Andreas, 2016-07-08
-    -- A @where@-module is private if the parent function is private.
+    -- A named @where@-module is private if the parent function is private.
     -- The contents of this module are not private, unless declared so!
     -- Thus, we do not recurse into the @ds@ (could not anyway).
     SomeWhere r e m a ds ->

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20250401 * 10 + 0
+currentInterfaceVersion = 20250402 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -9,7 +9,8 @@ import Agda.TypeChecking.Serialise.Instances.Common   ( SerialisedRange(..) )
 import Agda.TypeChecking.Serialise.Instances.Internal () --instance only
 import Agda.TypeChecking.Serialise.Instances.Abstract () --instance only
 
-import Agda.Syntax.Concrete.Definitions (DeclarationWarning(..), DeclarationWarning'(..))
+import Agda.Syntax.Concrete.Definitions.Errors
+    ( DeclarationWarning(..), DeclarationWarning'(..), OpenOrImport(..) )
 import Agda.Syntax.Parser.Monad
 import Agda.TypeChecking.Monad.Base
 import qualified Agda.TypeChecking.Monad.Base.Warning as W
@@ -327,8 +328,8 @@ instance EmbPrj DeclarationWarning' where
     EmptyField r                      -> icodeN 23 EmptyField r
     ShadowingInTelescope nrs          -> icodeN 24 ShadowingInTelescope nrs
     InvalidCoverageCheckPragma r      -> icodeN 25 InvalidCoverageCheckPragma r
-    OpenPublicAbstract r              -> icodeN 26 OpenPublicAbstract r
-    OpenPublicPrivate r               -> icodeN 27 OpenPublicPrivate r
+    OpenImportAbstract r kwr a        -> icodeN 26 OpenImportAbstract r kwr a
+    OpenImportPrivate r kwr kwr' a    -> icodeN 27 OpenImportPrivate r kwr kwr' a
     EmptyConstructor a                -> icodeN 28 EmptyConstructor a
     -- 29 removed
     -- 30 removed
@@ -373,8 +374,8 @@ instance EmbPrj DeclarationWarning' where
     [23,r]   -> valuN EmptyField r
     [24,nrs] -> valuN ShadowingInTelescope nrs
     [25,r]   -> valuN InvalidCoverageCheckPragma r
-    [26,r]   -> valuN OpenPublicAbstract r
-    [27,r]   -> valuN OpenPublicPrivate r
+    [26,r,kwr,a] -> valuN OpenImportAbstract r kwr a
+    [27,r,kwr,kwr',a] -> valuN OpenImportPrivate r kwr kwr' a
     [28,r]   -> valuN EmptyConstructor r
     -- 29 removed
     -- 30 removed
@@ -384,6 +385,8 @@ instance EmbPrj DeclarationWarning' where
     [34,r]   -> valuN UselessMacro r
     [35,r]   -> valuN EmptyPolarityPragma r
     _ -> malformed
+
+instance EmbPrj OpenOrImport
 
 instance EmbPrj LibWarning where
   icod_ = \case

--- a/test/Fail/Issue759a.err
+++ b/test/Fail/Issue759a.err
@@ -1,5 +1,6 @@
-Issue759a.agda:9.13-19: warning: -W[no]OpenPublicAbstract
-public does not have any effect in an abstract block.
+Issue759a.agda:9.3-19: warning: -W[no]OpenImportAbstract
+'abstract' does not have any effect on 'open' so better place this
+statement outside of the abstract block
 
 Issue759a.agda:12.10-32: error: [ShouldBeRecordType]
 Expected non-abstract record type, found Wrap

--- a/test/Fail/Issue759b.err
+++ b/test/Fail/Issue759b.err
@@ -1,5 +1,6 @@
-Issue759b.agda:10.13-19: warning: -W[no]OpenPublicAbstract
-public does not have any effect in an abstract block.
+Issue759b.agda:10.3-19: warning: -W[no]OpenImportAbstract
+'abstract' does not have any effect on 'open' so better place this
+statement outside of the abstract block
 
 Issue759b.agda:13.10-32: error: [ShouldBeRecordType]
 Expected non-abstract record type, found Wrap

--- a/test/Succeed/Issue759.warn
+++ b/test/Succeed/Issue759.warn
@@ -1,7 +1,9 @@
-Issue759.agda:9.13-19: warning: -W[no]OpenPublicAbstract
-public does not have any effect in an abstract block.
+Issue759.agda:9.3-19: warning: -W[no]OpenImportAbstract
+'abstract' does not have any effect on 'open' so better place this
+statement outside of the abstract block
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue759.agda:9.13-19: warning: -W[no]OpenPublicAbstract
-public does not have any effect in an abstract block.
+Issue759.agda:9.3-19: warning: -W[no]OpenImportAbstract
+'abstract' does not have any effect on 'open' so better place this
+statement outside of the abstract block

--- a/test/Succeed/Issue760.warn
+++ b/test/Succeed/Issue760.warn
@@ -1,13 +1,17 @@
-Issue760.agda:11.10-16: warning: -W[no]OpenPublicAbstract
-public does not have any effect in an abstract block.
+Issue760.agda:11.3-16: warning: -W[no]OpenImportAbstract
+'abstract' does not have any effect on 'open' so better place this
+statement outside of the abstract block
 
-Issue760.agda:27.10-16: warning: -W[no]OpenPublicPrivate
-public does not have any effect in a private block.
+Issue760.agda:27.10-16: warning: -W[no]OpenImportPrivate
+'private' does not have any effect on 'open public' so better place
+this statement outside of the private block
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue760.agda:11.10-16: warning: -W[no]OpenPublicAbstract
-public does not have any effect in an abstract block.
+Issue760.agda:11.3-16: warning: -W[no]OpenImportAbstract
+'abstract' does not have any effect on 'open' so better place this
+statement outside of the abstract block
 
-Issue760.agda:27.10-16: warning: -W[no]OpenPublicPrivate
-public does not have any effect in a private block.
+Issue760.agda:27.10-16: warning: -W[no]OpenImportPrivate
+'private' does not have any effect on 'open public' so better place
+this statement outside of the private block


### PR DESCRIPTION
The `OpenPublic{Abstract,Private}` warnings weren't entirely truthful.
The blame is not on `public`, but on placing `open` or `import` inside `private` or `abstract` blocks in the first place.
The new warnings `OpenImport{Abstract,Private}` advise against such.

Closes #7769
- #7769