### PR TITLE
Fix #7547: MINIMAL pragma

### DIFF
--- a/src/full/Agda/Compiler/JS/Pretty.hs
+++ b/src/full/Agda/Compiler/JS/Pretty.hs
@@ -210,6 +210,8 @@ class Pretty a where
     pretty = prettyPrec 0
     prettyPrec = const pretty
 
+    {-# MINIMAL pretty | prettyPrec #-}
+
 prettyShow :: Pretty a => Bool -> JSModuleStyle -> a -> String
 prettyShow minify ms = render minify . pretty (0, minify, ms)
 

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1239,7 +1239,7 @@ introTactic pmLambda ii = do
     introData :: AllowAmbiguousNames -> I.Type -> TCM [String]
     introData amb t = do
       let tel  = telFromList [defaultDom ("_", t)]
-          pat  = [defaultArg $ unnamed $ debruijnNamedVar "c" 0]
+          pat  = [defaultArg $ unnamed $ deBruijnNamedVar "c" 0]
       -- Gallais, 2023-08-24: #6787 we need to locally ignore the
       -- --without-K or --cubical-compatible options to figure out
       -- that refl is a valid constructor for refl ≡ refl.

--- a/src/full/Agda/Syntax/Common/Pretty.hs
+++ b/src/full/Agda/Syntax/Common/Pretty.hs
@@ -73,6 +73,8 @@ class Pretty a where
   prettyPrec  = const pretty
   prettyList  = brackets . prettyList_
 
+  {-# MINIMAL pretty | prettyPrec #-}
+
 -- | Use instead of 'show' when printing to world.
 
 prettyShow :: Pretty a => a -> String

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -553,6 +553,8 @@ class ToConcrete a where
     toConcrete     x     = bindToConcrete x return
     bindToConcrete x ret = ret =<< toConcrete x
 
+    {-# MINIMAL toConcrete | bindToConcrete #-}
+
 -- | Translate something in a context of the given precedence.
 toConcreteCtx :: MonadToConcrete m => ToConcrete a => Precedence -> a -> m (ConOfAbs a)
 toConcreteCtx p x = withPrecedence p $ toConcrete x

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -144,7 +144,7 @@ fromSplitVar x = DBPatVar (splitPatVarName x) (splitPatVarIndex x)
 
 instance DeBruijn SplitPatVar where
   deBruijnView x = deBruijnView (fromSplitVar x)
-  debruijnNamedVar n i = toSplitVar (debruijnNamedVar n i)
+  deBruijnNamedVar n i = toSplitVar (deBruijnNamedVar n i)
 
 toSplitPatterns :: [NamedArg DeBruijnPattern] -> [NamedArg SplitPattern]
 toSplitPatterns = (fmap . fmap . fmap . fmap) toSplitVar

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -414,6 +414,8 @@ class Reduce t where
   reduce'  t = ignoreBlocking <$> reduceB' t
   reduceB' t = notBlocked <$> reduce' t
 
+  {-# MINIMAL reduce' | reduceB' #-}
+
 instance Reduce Type where
     reduce'  (El s t) = workOnTypes $ El s <$> reduce' t
     reduceB' (El s t) = workOnTypes $ fmap (El s) <$> reduceB' t

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -141,7 +141,7 @@ bindBuiltinFlat x =
           , clauseFullRange = noRange
           , clauseTel       = tel
           , namedClausePats = [ argN $ Named Nothing $
-              ConP sharpCon cpi [ argN $ Named Nothing $ debruijnNamedVar "x" 0 ] ]
+              ConP sharpCon cpi [ argN $ Named Nothing $ deBruijnNamedVar "x" 0 ] ]
           , clauseBody      = Just $ var 0
           , clauseType      = Just $ defaultArg $ El (varSort 2) $ var 1
           , clauseCatchall    = empty

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -757,7 +757,7 @@ checkLeftHandSide call lhsRng f ps a withSub' strippedPats =
             asb          = asb0 ++ asb1
 
         -- Rename internal patterns with these names
-        let makeVar     = maybe deBruijnVar $ debruijnNamedVar . nameToArgName
+        let makeVar     = maybe deBruijnVar $ deBruijnNamedVar . nameToArgName
             ren         = parallelS $ zipWith makeVar (reverse vars) [0..]
 
         qs <- transferOrigins (cps ++ ps) $ applySubst ren qs0

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1142,7 +1142,7 @@ instance Subst EqualityTypeData where
     (applySubst rho b)
 
 instance DeBruijn a => DeBruijn (Pattern' a) where
-  debruijnNamedVar n i             = varP $ debruijnNamedVar n i
+  deBruijnNamedVar n i             = varP $ deBruijnNamedVar n i
   -- deBruijnView returns Nothing, to prevent consS and the like
   -- from dropping the names and origins when building a substitution.
   deBruijnView _                   = Nothing

--- a/src/full/Agda/TypeChecking/Substitute/DeBruijn.hs
+++ b/src/full/Agda/TypeChecking/Substitute/DeBruijn.hs
@@ -11,11 +11,11 @@ class DeBruijn a where
 
   -- | Produce a variable without name suggestion.
   deBruijnVar  :: Int -> a
-  deBruijnVar = debruijnNamedVar underscore
+  deBruijnVar = deBruijnNamedVar underscore
 
   -- | Produce a variable with name suggestion.
-  debruijnNamedVar :: String -> Int -> a
-  debruijnNamedVar _ = deBruijnVar
+  deBruijnNamedVar :: String -> Int -> a
+  deBruijnNamedVar _ = deBruijnVar
 
   -- | Are we dealing with a variable?
   --   If yes, what is its index?
@@ -45,10 +45,10 @@ instance DeBruijn Level where
       _ -> Nothing
 
 instance DeBruijn DBPatVar where
-  debruijnNamedVar = DBPatVar
+  deBruijnNamedVar = DBPatVar
   deBruijnView = Just . dbPatVarIndex
 
 
 instance DeBruijn a => DeBruijn (Named_ a) where
-  debruijnNamedVar nm i = unnamed $ debruijnNamedVar nm i
+  deBruijnNamedVar nm i = unnamed $ deBruijnNamedVar nm i
   deBruijnView = deBruijnView . namedThing

--- a/src/full/Agda/TypeChecking/Substitute/DeBruijn.hs
+++ b/src/full/Agda/TypeChecking/Substitute/DeBruijn.hs
@@ -21,6 +21,8 @@ class DeBruijn a where
   --   If yes, what is its index?
   deBruijnView :: a -> Maybe Int
 
+  {-# MINIMAL (deBruijnVar | deBruijnNamedVar) , deBruijnView #-}
+
 -- | We can substitute @Term@s for variables.
 instance DeBruijn Term where
   deBruijnVar = var

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -129,7 +129,7 @@ teleNamedArgs = map namedArgFromDom . teleDoms
 --   Precondition: the two telescopes have the same length.
 tele2NamedArgs :: (DeBruijn a) => Telescope -> Telescope -> [NamedArg a]
 tele2NamedArgs tel0 tel =
-  [ Arg info (Named (Just $ WithOrigin Inserted $ unranged $ argNameToString argName) (debruijnNamedVar varName i))
+  [ Arg info (Named (Just $ WithOrigin Inserted $ unranged $ argNameToString argName) (deBruijnNamedVar varName i))
   | (i, Dom{domInfo = info, unDom = (argName,_)}, Dom{unDom = (varName,_)}) <- zip3 (downFrom $ size l) l0 l ]
   where
   l  = telToList tel

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -144,6 +144,8 @@ class (Ord (BenchPhase m), Functor m, MonadIO m) => MonadBench m where
   -- | We need to be able to terminate benchmarking in case of an exception.
   finally :: m b -> m c -> m b
 
+  {-# MINIMAL getBenchmark , (putBenchmark | modifyBenchmark) , finally #-}
+
 getsBenchmark :: MonadBench m => (Benchmark (BenchPhase m) -> c) -> m c
 getsBenchmark f = f <$> getBenchmark
 

--- a/src/full/Agda/Utils/Functor.hs
+++ b/src/full/Agda/Utils/Functor.hs
@@ -51,6 +51,8 @@ class Functor t => Decoration t where
   distributeF :: (Functor m) => t (m a) -> m (t a)
   distributeF = traverseF id
 
+  {-# MINIMAL traverseF | distributeF #-}
+
 -- | Any decoration is traversable with @traverse = traverseF@.
 --   Just like any 'Traversable' is a functor, so is
 --   any decoration, given by just @traverseF@, a functor.


### PR DESCRIPTION
Fix #7547: add some MINIMAL pragmas

MINIMAL pragmas are still missing for all the `Lens...` classes but I wait to the Haskell Language Server to develop a feature to add these automatically...

- **[cosmetics] rename debruijnNamedVar to deBruijnNamedVar**
- **Re #7547: add some MINIMAL pragmas**