### PR TITLE
Don't inline constructors into inline functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,22 @@ Changes to type checker and other components defining the Agda language.
   the PR removing it from the library, and
   [#7652](https://github.com/agda/agda/pull/7652) for the compiler.
 
+* Inlining constructors no longer happens on the right-hand-sides of
+  `INLINE` functions. This allows using `INLINE` functions to define
+  "smart constructors" for record types which have the same reduction
+  behaviour as using the actual constructor would. Small example:
+
+  ```agda
+  triple : Nat → Nat → Nat → Nat × Nat × Nat
+  {-# INLINE triple #-}
+  triple x y z = record { fst = x ; snd = y , z }
+
+  ex = triple 1 2 3
+  ```
+
+  Here, constructor inlining happens on the right hand side *of `ex`*
+  rather than of `triple`.
+
 Reflection
 ----------
 

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -74,7 +74,7 @@ getCompiledClauses q = do
   reportSDoc "treeless.convert" 70 $
     caseMaybe mst "-- not using split tree" $ \st ->
       "-- using split tree" $$ pretty st
-  CC.compileClauses' translate cs mst
+  CC.compileClauses' q translate cs mst
 
 -- ** Types of pipelines; different backends might use their own custom pipeline.
 type BuildPipeline = Int -> QName -> Pipeline

--- a/src/full/Agda/TypeChecking/RecordPatterns.hs
+++ b/src/full/Agda/TypeChecking/RecordPatterns.hs
@@ -274,6 +274,12 @@ recordRHSToCopatterns cl = do
 
               mt' :: Maybe (Arg Type) <- fuse <$> traverse (traverse inst) mt
 
+              reportSDoc "tc.inline.con" 50 $ vcat
+                [ "for field" <+> prettyTCM (unArg f) <+> ": "
+                , "  mt  =" <+> prettyTCM mt
+                , "  mt' =" <+> prettyTCM mt'
+                ]
+
               -- Make clause ... .f = v
               return cl
                 { namedClausePats = ps ++ [ unnamed . ProjP ProjSystem <$> f ]

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -316,7 +316,7 @@ revisitRecordPatternTranslation qs = do
   -- qccs: compiled clauses of definitions
   (rs, qccs) <- partitionEithers . catMaybes <$> mapM classify qs
   unless (null rs) $ forM_ qccs $ \(q,cc) -> do
-    (cc, recordExpressionBecameCopatternLHS) <- runChangeT $ translateCompiledClauses cc
+    (cc, recordExpressionBecameCopatternLHS) <- runChangeT $ translateCompiledClauses q cc
     modifySignature $ updateDefinition q
       $ updateTheDef (updateCompiledClauses $ const $ Just cc)
       . updateDefCopatternLHS (|| recordExpressionBecameCopatternLHS)

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -310,10 +310,6 @@ checkFunDefS t ai extlam with i name withSubAndLets cs = do
         reportSDoc "tc.def.fun" 70 $ inTopContext $ do
           sep $ "checked clauses:" : map (nest 2 . text . show) cs
 
-        -- After checking, remove the clauses again.
-        -- (Otherwise, @checkInjectivity@ loops for issue 801).
-        modifyFunClauses name (const [])
-
         reportSDoc "tc.cc" 25 $ inTopContext $ do
           sep [ "clauses before injectivity test"
               , nest 2 $ prettyTCM $ map (QNamed name) cs  -- broken, reify (QNamed n cl) expect cl to live at top level
@@ -373,6 +369,15 @@ checkFunDefS t ai extlam with i name withSubAndLets cs = do
               -- issue a warning that the clause does not hold as definitional equality.
               warning $ InlineNoExactSplit name cl
             return cls
+
+        -- After checking, remove the clauses again.
+        -- (Otherwise, @checkInjectivity@ loops for issue 801).
+        --
+        -- Amy, 2025-04-03: We can't remove the clauses before doing
+        -- record→copattern translation, since we might need the
+        -- previous clauses to come up with the types of the projected
+        -- fields; see 'test/Succeed/IApplyRecConstrInline'.
+        modifyFunClauses name (const [])
 
         -- Check if the function is injective.
         -- Andreas, 2015-07-01 we do it here in order to resolve metas

--- a/test/Fail/NestedRecConstrInline.agda
+++ b/test/Fail/NestedRecConstrInline.agda
@@ -1,0 +1,49 @@
+module NestedRecConstrInline where
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+record Foo : Set where
+  constructor inc
+  field foo1 foo2 : Nat
+
+record Bar : Set where
+  no-eta-equality
+  constructor inc
+  field
+    foo  : Foo
+    bar3 : Nat
+
+record make : Set where
+  constructor inc
+  field
+    foo1 foo2 bar3 : Nat
+
+open Foo
+open Bar
+open make
+
+{-# INLINE Bar.constructor #-}
+
+-- This function is not turned into a copattern match, because it is
+-- marked INLINE
+to : make → Bar
+{-# INLINE to #-}
+
+to f = record { foo = record { foo1 = f .foo1 ; foo2 = f .foo2 } ; bar3 = f .bar3 }
+
+-- ... so this works:
+_ : to (inc 1 2 3) ≡ inc (inc 1 2) 3
+_ = refl
+
+-- And here we inline 'to' in the RHS of x, which then becomes a record
+-- constructor, and *that* constructor gets inlined
+x : Bar
+x = to record where
+  foo1 = 1
+  foo2 = 2
+  bar3 = 3
+
+-- ... so this fails (x ≠ ...):
+_ : x ≡ inc (inc 1 2) 3
+_ = refl

--- a/test/Fail/NestedRecConstrInline.err
+++ b/test/Fail/NestedRecConstrInline.err
@@ -1,0 +1,3 @@
+NestedRecConstrInline.agda:49.5-9: error: [UnequalTerms]
+x != inc (inc 1 2) 3 of type Bar
+when checking that the expression refl has type x ≡ inc (inc 1 2) 3

--- a/test/Succeed/IApplyRecConstrInline.agda
+++ b/test/Succeed/IApplyRecConstrInline.agda
@@ -1,0 +1,51 @@
+{-# OPTIONS --cubical #-}
+
+-- This test case justifies why the clauses for a record value
+-- definition need to be available in the state (signature)
+-- during the record-to-copatterns translation,
+-- at least for Cubical Agda.
+--
+-- For more context, see the implementation of Agda.TypeChecking.Rules.Def.
+
+module IApplyRecConstrInline where
+
+open import Agda.Builtin.Nat
+
+record Category : Set₁ where
+  field
+    Ob  : Set
+    Hom : Ob → Ob → Set
+    id  : ∀ x → Hom x x
+
+postulate X : Set
+
+record H (a b : X) : Set where
+  no-eta-equality
+  field x y : Nat
+
+{-# INLINE H.constructor #-}
+
+open Category
+
+-- Was: IApplyConfluence.hs __IMPOSSIBLE__
+--
+-- To inline a constructor in cubical code (even code that doesn't use
+-- cubical features) all the resulting fields must be properly tagged
+-- with their types.
+--
+-- The constructor inlining code can only figure out what the type of a
+-- field should be if the type of the original clause reduces to the
+-- record being constructed.
+--
+-- The coverage checker does not reduce the type that the original
+-- clause is tagged with.
+
+c : Category
+c .Ob   = X
+c .Hom  = H
+
+-- The coverage checker says the following clause has type c .Hom,
+-- but the record constructs H; so the field inliner needs to see c's
+-- clauses for this reduction to work.
+
+c .id _ = record { x = 1 ; y = 2 }

--- a/test/Succeed/NestedRecConstrInline.agda
+++ b/test/Succeed/NestedRecConstrInline.agda
@@ -1,0 +1,34 @@
+module NestedRecConstrInline where
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+record Foo : Set where
+  constructor inc
+  field foo1 foo2 : Nat
+
+record Bar : Set where
+  no-eta-equality
+  constructor inc
+  field
+    foo  : Foo
+    bar3 : Nat
+
+record make : Set where
+  constructor inc
+  field
+    foo1 foo2 bar3 : Nat
+
+open Foo
+open Bar
+open make
+
+{-# INLINE Bar.constructor #-}
+
+to : make → Bar
+{-# INLINE to #-}
+
+to f = record { foo = record { foo1 = f .foo1 ; foo2 = f .foo2 } ; bar3 = f .bar3 }
+
+_ : to (inc 1 2 3) ≡ inc (inc 1 2) 3
+_ = refl


### PR DESCRIPTION
Skips inlining record constructors on the RHS of a function marked `INLINE`, to allow defining helpers for constructing records which get inlined at the use site. Example (from [the test case](https://github.com/agda/agda/blob/b6fba05b4178623aefd7a772583aca7b3beb65a5/test/Fail/NestedRecConstrInline.agda)):

```agda
to : make → Bar
{-# INLINE to #-}
to f = record { foo = record { foo1 = f .foo1 ; foo2 = f .foo1 } ; bar3 = f .bar3 }

x : Bar
x = to record where
  foo1 = 1
  foo2 = 2
  bar3 = 3
```

Here if we did constructor inlining in the RHS of `to`, *it* would become a definition by copattern matching, and then we would have `x = to ...`. But if we skip inlining in the RHS of `to`, the elaborator will inline it into `x`'s RHS, so that its RHS is then manifestly a record construction, and then and *`x`* will become a copattern definition instead.