### PR TITLE
Fix #7777: parse both attributes and irrelevance markers

### DIFF
--- a/test/Fail/Issue7777.agda
+++ b/test/Fail/Issue7777.agda
@@ -1,0 +1,11 @@
+-- Andreas, 2025-04-05, re issue #7777
+-- Make sure we report conflicting information when we allow both
+-- traditional relevance annotations ('.' and '..') and
+-- and attribute-style relevance annotations ('@irr' etc.).
+
+postulate
+  P : .Set → Set₁
+  test : .{@shape-irrelevant x : Set} → P x
+
+-- Expected error: [ParseError]
+-- Conflicting relevance information

--- a/test/Fail/Issue7777.err
+++ b/test/Fail/Issue7777.err
@@ -1,0 +1,2 @@
+Issue7777.agda:8.10: error: [ParseError]
+Conflicting relevance information

--- a/test/Succeed/Issue7777.agda
+++ b/test/Succeed/Issue7777.agda
@@ -1,0 +1,35 @@
+-- Andreas, 2025-04-05, issue #7777
+-- report and testcase by Alice Laroche
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Reflection
+
+defaultTo : {A : Set} (x : A) → Term → TC ⊤
+defaultTo x hole = bindTC (quoteTC x) (unify hole)
+
+module Forall (P : .Bool → Set) (p : P true) where
+
+  -- works
+  f : ∀ {@(tactic defaultTo true) x} → P x
+  f = p
+
+  -- works
+  g : ∀ {@irr @(tactic defaultTo true) x} → P x
+  g = p
+
+  -- should work
+  h : ∀ .{ @(tactic defaultTo true) x} → P x
+  h = p
+
+-- works
+f : {@(tactic defaultTo true) x : Bool} → Bool
+f {x} = x
+
+-- works
+g : {@irr @(tactic defaultTo true) x : Bool} → Bool
+g = true
+
+-- should work
+h : .{ @(tactic defaultTo true) x : Bool} → Bool
+h = true


### PR DESCRIPTION
Previously, the irrelevance markers `.` and `..` could not be combined
with `@tactic` etc. attributes.

Closes #7777.
