### PR TITLE
New warning `UselessTactic` for `tactic` attribute on non-hidden binder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@ Warnings
 * New warning `EmptyPolarityPragma` for POLARITY pragma without polarities.
   E.g. triggered by `{-# POLARITY F #-}`.
 
+* New warning `UselessTactic` when a `@tactic` attribute has no effect,
+  typically when it is attached to a non-hidden or instance argument.
+
 * New warning `WithClauseProjectionFixityMismatch` instead of hard error
   when in a with-clause a projection is used in a different fixity
   (prefix vs. postfix) than in its parent clause.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1725,6 +1725,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      ``public`` directives where they have no effect.
 
+.. option:: UselessTactic
+
+     ``@tactic`` attributes in non-hidden and instance arguments.
+
 .. option:: UserWarning
 
      User-defined warnings added using one of the ``WARNING_ON_*`` pragmas.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -450,6 +450,7 @@ warningHighlighting' b w = case tcWarning w of
   UselessHiding xs           -> foldMap deadcodeHighlighting xs
   UselessInline{}            -> mempty
   UselessPatternDeclarationForRecord{} -> deadcodeHighlighting w
+  UselessTactic{}            -> deadcodeHighlighting w
   ClashesViaRenaming _ xs    -> foldMap deadcodeHighlighting xs
     -- #4154, TODO: clashing renamings are not dead code, but introduce problems.
     -- Should we have a different color?

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -346,6 +346,7 @@ data WarningName
   | UselessInline_
   | UselessPatternDeclarationForRecord_
   | UselessPublic_
+  | UselessTactic_
   | UserWarning_
   | InvalidDisplayForm_
   | UnusedVariablesInDisplayForm_
@@ -494,6 +495,7 @@ warningNameDescription = \case
   UselessPrivate_                  -> "`private' blocks where they have no effect."
   UselessPublic_                   -> "`public' directives that have no effect."
   UselessPatternDeclarationForRecord_ -> "`pattern' attributes where they have no effect."
+  UselessTactic_                   -> "`@tactic` attributes where they have no effect."
   -- Scope and Type Checking Warnings
   AbsurdPatternRequiresAbsentRHS_  -> "Clauses with an absurd pattern that have a right hand side."
   AsPatternShadowsConstructorOrPatternSynonym_ -> "@-patterns that shadow constructors or pattern synonyms."

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -957,6 +957,9 @@ instance HasRange Expr where
 instance HasRange Binder where
   getRange (Binder a _ b) = fuseRange a b
 
+instance HasRange (TacticAttribute' a) where
+  getRange = maybe noRange getRange . theTacticAttribute
+
 instance HasRange TypedBinding where
   getRange (TBind r _ _) = r
   getRange (TLet r _)    = r

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1144,9 +1144,18 @@ instance ToAbstract C.LamBinding where
   type AbsOfCon C.LamBinding = Maybe A.LamBinding
 
   toAbstract (C.DomainFree x)  = do
-    tac <- traverse toAbstract $ bnameTactic $ C.binderName $ namedArg x
+    tac <- scopeCheckTactic x
     Just . A.DomainFree tac <$> toAbstract (updateNamedArg (fmap $ NewName LambdaBound) x)
   toAbstract (C.DomainFull tb) = fmap A.DomainFull <$> toAbstract tb
+
+-- | Scope check tactic attribute, make sure they are only used in hidden arguments.
+scopeCheckTactic :: NamedArg C.Binder -> ScopeM A.TacticAttribute
+scopeCheckTactic x = do
+  let ctac = bnameTactic $ C.binderName $ namedArg x
+  let r = getRange ctac
+  setCurrentRange r $ do
+    tac <- traverse toAbstract ctac
+    if null tac || hidden x then return tac else empty <$ warning UselessTactic
 
 makeDomainFull :: C.LamBinding -> C.TypedBinding
 makeDomainFull (C.DomainFull b) = b
@@ -1158,13 +1167,10 @@ instance ToAbstract C.TypedBinding where
 
   toAbstract (C.TBind r xs t) = do
     t' <- toAbstractCtx TopCtx t
-    tac <- C.TacticAttribute <$> do
-     traverse toAbstract $
-      -- Invariant: all tactics are the same
-      -- (distributed in the parser, TODO: don't)
-      case List1.mapMaybe (theTacticAttribute . bnameTactic . C.binderName . namedArg) xs of
-        []      -> Nothing
-        tac : _ -> Just tac
+    -- Invariant: all tactics are the same
+    -- (distributed in the parser, TODO: don't)
+    let tacArg = List1.find (not . null . bnameTactic . C.binderName . namedArg) xs
+    tac <- maybe (pure empty) scopeCheckTactic tacArg
 
     let fin = all (bnameIsFinite . C.binderName . namedArg) xs
     xs' <- toAbstract $ fmap (updateNamedArg (fmap $ NewName LambdaBound)) xs

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4541,6 +4541,8 @@ data Warning
     -- ^ Names in `hiding` directive that don't hide anything
     --   imported by a `using` directive.
   | UselessInline            QName
+  | UselessTactic
+    -- ^ A tactic attribute applied to a non-hidden (visible or instance) argument.
   | WrongInstanceDeclaration
   | InstanceWithExplicitArg  QName
   -- ^ An instance was declared with an implicit argument, which means it
@@ -4749,6 +4751,7 @@ warningName = \case
   UselessInline{}              -> UselessInline_
   UselessPublic{}              -> UselessPublic_
   UselessPatternDeclarationForRecord{} -> UselessPatternDeclarationForRecord_
+  UselessTactic{}              -> UselessTactic_
   ClashesViaRenaming{}         -> ClashesViaRenaming_
   UserWarning{}                -> UserWarning_
   InfectiveImport{}            -> InfectiveImport_

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -261,6 +261,8 @@ prettyWarning = \case
       pwords "It is pointless for INLINE'd function" ++ [prettyTCM q] ++
       pwords "to have a separate Haskell definition"
 
+    UselessTactic -> fwords $ "Ignoring `tactic' attribute for non-hidden (explicit or instance) binder"
+
     WrongInstanceDeclaration -> fwords $
       "Instances should be of type {Γ} → C, where C evaluates to a postulated name or the name of " ++
       "a data or record type, so `instance' is ignored here."

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20250402 * 10 + 0
+currentInterfaceVersion = 20250405 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -91,7 +91,7 @@ instance EmbPrj Warning where
     RewriteAmbiguousRules a b c           -> icodeN 36 RewriteAmbiguousRules a b c
     RewriteMissingRule a b c              -> icodeN 37 RewriteMissingRule a b c
     ParseWarning a                        -> icodeN 38 ParseWarning a
-    -- 39 unused
+    UselessTactic                         -> icodeN 39 UselessTactic
     UnsupportedIndexedMatch f             -> icodeN 40 UnsupportedIndexedMatch f
     OptionWarning a                       -> icodeN 41 OptionWarning a
     PlentyInHardCompileTimeMode a         -> icodeN 42 PlentyInHardCompileTimeMode a
@@ -177,7 +177,7 @@ instance EmbPrj Warning where
     [36, a, b, c]        -> valuN RewriteAmbiguousRules a b c
     [37, a, b, c]        -> valuN RewriteMissingRule a b c
     [38, a]              -> valuN ParseWarning a
-    -- 39 unused
+    [39]                 -> valuN UselessTactic
     [40, a]              -> valuN UnsupportedIndexedMatch a
     [41, a]              -> valuN OptionWarning a
     [42, a]              -> valuN PlentyInHardCompileTimeMode a

--- a/test/Fail/Issue6781TacticModalityExplicitArgument.agda
+++ b/test/Fail/Issue6781TacticModalityExplicitArgument.agda
@@ -30,4 +30,4 @@ check : number ≡ 102
 check = refl
 
 -- This produces unsolved constraints, in contrast to the variant with hidden tactic arguments.
--- I think hiding or not should not make such a difference here.
+-- Tactics only kick in for hidden and actually omitted arguments.

--- a/test/Fail/Issue6781TacticModalityExplicitArgument.err
+++ b/test/Fail/Issue6781TacticModalityExplicitArgument.err
@@ -1,0 +1,20 @@
+Issue6781TacticModalityExplicitArgument.agda:22.9-27: warning: -W[no]UselessTactic
+Ignoring 'tactic' attribute for non-hidden (explicit or instance)
+binder
+when scope checking
+(@(tactic super-tac) n : Nat) (@(tactic solver n) x : A) → A
+
+Issue6781TacticModalityExplicitArgument.agda:23.9-26: warning: -W[no]UselessTactic
+Ignoring 'tactic' attribute for non-hidden (explicit or instance)
+binder
+when scope checking
+(@(tactic super-tac) n : Nat) (@(tactic solver n) x : A) → A
+error: [UnsolvedConstraints]
+Failed to solve the following constraints:
+  _x_16 = 102 : Nat (blocked on _x_16)
+
+Issue6781TacticModalityExplicitArgument.agda:27.14-30.13: error: [UnsolvedMetaVariables]
+Unsolved metas at the following locations:
+  Issue6781TacticModalityExplicitArgument.agda:27.14-15
+  Issue6781TacticModalityExplicitArgument.agda:27.16-17
+  Issue6781TacticModalityExplicitArgument.agda:30.9-13

--- a/test/Succeed/Issue5712.agda
+++ b/test/Succeed/Issue5712.agda
@@ -1,4 +1,5 @@
 -- Andreas, 2021-12-31, issue #5712, reported by Trebor-Huang
+-- Andreas, 2023-08-23: require tactic fields to be hidden.
 
 -- {-# OPTIONS -v tc.cover.cover:10 #-}
 
@@ -11,7 +12,7 @@ nothing hole = returnTC _
 record Foo : Set1 where
   field
     A : Set
-    @(tactic nothing) foo : A → A
+    @(tactic nothing) {foo} : A → A
 open Foo
 
 F : Foo
@@ -23,3 +24,6 @@ F .foo n = _
 -- not expand the last clause due to the presence of a tactic (#5358).
 -- However, in this case, there is a user argument that forces the
 -- expansion.  This is now recognized by the coverage checker.
+
+r : Foo
+r = record{ A = ⊤; foo = _ }


### PR DESCRIPTION
Tactics only fire on _absent_ non-instance arguments, so placing a tactic on a non-hidden binder has no effect.

The exception was a tactic on a non-hidden record field.
For the sake of uniformity, there are ignored from now on, throwing the `UselessTactic` warning.

Closes #6781.
