### PR TITLE
Fix issues #7759 and #7788: wrong counting of with-patterns in nested with

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -733,7 +733,8 @@ niceDeclarations fixs ds = do
 
     underscore r = Underscore r Nothing
 
-
+    -- Search for the first clause that does not have an ellipsis (usually the very first one)
+    -- and then use its lhs pattern to replace ellipses in the subsequent clauses (if any).
     expandEllipsis :: [Declaration] -> Nice [Declaration]
     expandEllipsis [] = return []
     expandEllipsis (d@(FunClause lhs@(LHS p _ _) _ _ _) : ds)

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -735,8 +735,12 @@ instance Null (Substitution' a) where
 
 data EqualityView
   = EqualityViewType EqualityTypeData
-  | OtherType Type -- ^ reduced
-  | IdiomType Type -- ^ reduced
+      -- ^ A type of the form @u ≡ v@ decomposed into its parts.
+      --   Used as type for the @rewrite@ expression.
+  | OtherType Type
+      -- ^ A reduced type used as type for a @with@ expression.
+  | IdiomType Type
+      -- ^ A reduced type used as type for the @with@ inspect idiom.
 
 data EqualityTypeData = EqualityTypeData
     { _eqtSort   :: Sort        -- ^ Sort of this type.

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -1163,7 +1163,7 @@ checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs n
   delta1 <- modifyAllowedReductions (const reds) $ normalise delta1
 
   -- Generate the type of the with function
-  (withFunType, n) <- do
+  (withFunType, (nwithargs, nwithpats)) <- do
     let ps = renaming impossible (reverseP perm') `applySubst` qs
     reportSDoc "tc.with.bndry" 40 $ addContext delta1 $ addContext delta2
                                   $ text "ps =" <+> pretty ps
@@ -1180,7 +1180,7 @@ checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs n
   reportSDoc "tc.with.type" 50 $ sep [ "with-function type:", nest 2 $ pretty withFunType ]
 
   call_in_parent <- do
-    (TelV tel _,bs) <- telViewUpToPathBoundaryP (n + size delta) withFunType
+    (TelV tel _,bs) <- telViewUpToPathBoundaryP (nwithargs + size delta) withFunType
     return $ argsS `applySubst` Def aux (teleElims tel bs)
 
   reportSDoc "tc.with.top" 20 $ addContext delta $ "with function call" <+> prettyTCM call_in_parent
@@ -1196,7 +1196,7 @@ checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs n
     noConstraints $ checkType withFunType
 
   -- With display forms are closed
-  df <- inTopContext $ makeOpen =<< withDisplayForm f aux delta1 delta2 n qs perm' perm
+  df <- inTopContext $ makeOpen =<< withDisplayForm f aux delta1 delta2 nwithargs qs perm' perm
 
   reportSLn "tc.with.top" 20 "created with display form"
 
@@ -1227,7 +1227,7 @@ checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs n
 
   -- Construct the body for the with function
   cs <- return $ fmap (A.lhsToSpine) cs
-  cs <- buildWithFunction cxtNames f aux t delta qs npars withSub finalPerm (size delta1) n cs
+  cs <- buildWithFunction cxtNames f aux t delta qs npars withSub finalPerm (size delta1) nwithpats cs
   cs <- return $ fmap (A.spineToLhs) cs
 
   -- #4833: inherit abstract mode from parent

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -1112,8 +1112,10 @@ checkWithRHS x aux t (LHSResult npars delta ps _absurdPat trhs _ _asb _ _) vtys0
 
         reportSDoc "tc.with.top" 20 $ vcat $
           let (vs, as) = List1.unzipWith unArg vtys in
-          [ "    with arguments" <+> do escapeContext impossible (size delta) $ addContext delta1 $ prettyList (fmap prettyTCM vs)
-          , "             types" <+> do escapeContext impossible (size delta) $ addContext delta1 $ prettyList (fmap prettyTCM as)
+          -- Andreas, 2025-04-07, escapeContext impossible Δ leads to crash if e.g. vs has metas defined in Δ.
+          -- Thus, we use unsafeEscapeContext instead.
+          [ "    with arguments" <+> do unsafeEscapeContext (size delta) $ addContext delta1 $ prettyList (fmap prettyTCM vs)
+          , "             types" <+> do unsafeEscapeContext (size delta) $ addContext delta1 $ prettyList (fmap prettyTCM as)
           , "           context" <+> (prettyTCM =<< getContextTelescope)
           , "             delta" <+> do escapeContext impossible (size delta) $ prettyTCM delta
           , "            delta1" <+> do escapeContext impossible (size delta) $ prettyTCM delta1

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -672,8 +672,8 @@ checkLeftHandSide call lhsRng f ps a withSub' strippedPats =
 
         reportSDoc "tc.lhs.top" 20 $ vcat
           [ "lhs: final checks with remaining equations"
-          , nest 2 $ if null eqs then "(none)" else addContext delta $ vcat $ map prettyTCM eqs
-          , "qs0 =" <+> addContext delta (prettyTCMPatternList qs0)
+          , nest 4 $ if null eqs then "(none)" else addContext delta $ vcat $ map prettyTCM eqs
+          , nest 2 $ "qs0 =" <+> addContext delta (prettyTCMPatternList qs0)
           ]
 
         unless (null rps) __IMPOSSIBLE__
@@ -698,6 +698,13 @@ checkLeftHandSide call lhsRng f ps a withSub' strippedPats =
           -- transport. See #5448.
 
         arity_a <- arityPiPath a
+
+        reportSDoc "tc.lhs.top" 30 $ vcat
+          [ nest 2 $ "a        =" <+> prettyTCM a
+          , nest 2 $ "arity_a  =" <+> prettyTCM arity_a
+          , nest 2 $ "withSub' =" <+> prettyTCM withSub'
+          ]
+
         -- Compute substitution from the out patterns @qs0@
         let notProj ProjP{} = False
             notProj _       = True

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -130,12 +130,12 @@ withFunctionType
   -> Telescope                          -- ^ @Δ₁ ⊢ Δ₂@                   context extension to type with-expressions.
   -> Type                               -- ^ @Δ₁,Δ₂ ⊢ b@                 type of rhs.
   -> [(Int,(Term,Term))]                -- ^ @Δ₁,Δ₂ ⊢ [(i,(u0,u1))] : b  boundary.
-  -> TCM (Type, Nat1)
+  -> TCM (Type, (Nat1, Nat))
     -- ^ @Δ₁ → wtel → Δ₂′ → b′@ such that
     --     @[vs/wtel]wtel = as@ and
     --     @[vs/wtel]Δ₂′ = Δ₂@ and
     --     @[vs/wtel]b′ = b@.
-    -- Plus the final number of with-arguments.
+    -- Plus the final number of with-arguments and the number of visible ones.
 withFunctionType delta1 vtys delta2 b bndry = addContext delta1 $ do
 
   reportSLn "tc.with.abstract" 20 $ "preparing for with-abstraction"
@@ -157,7 +157,8 @@ withFunctionType delta1 vtys delta2 b bndry = addContext delta1 $ do
   wd2b <- foldrM piAbstract d2b vtys
   dbg 30 "wΓ → Δ₂ → B" wd2b
 
-  let nwithargs = countWithArgs (fmap (snd . unArg) vtys)
+  let nwithargs = countWithArgs $ fmap (snd . unArg) vtys
+  let nwithpats = countWithPats vtys
 
   TelV wtel _ <- telViewUpTo nwithargs wd2b
 
@@ -170,14 +171,31 @@ withFunctionType delta1 vtys delta2 b bndry = addContext delta1 $ do
 
   dbg 30 "Δ₁ → wΓ → Δ₂ → B" d1wd2b
 
-  return (d1wd2b, nwithargs)
+  return (d1wd2b, (nwithargs, nwithpats))
 
-countWithArgs :: List1 EqualityView -> Nat1
+-- | Count the number of arguments introduced into the type of the with-function.
+countWithArgs :: (Functor f, Foldable f) => f EqualityView -> Nat1
 countWithArgs = sum . fmap countArgs
   where
     countArgs OtherType{}    = 1
     countArgs IdiomType{}    = 2
     countArgs EqualityType{} = 2
+
+-- | Count the number of with-patterns in the with-clause
+--   that need to be transformed to regular patterns
+--   in the **current round** of with-abstraction
+--   (important for nested with).
+countWithPats :: (Functor f, Foldable f) => f (Arg (Term, EqualityView)) -> Nat1
+countWithPats = sum . fmap \case
+    -- Andreas, 2025-04-08, see issue #7788.
+    Arg ai (_, OtherType   {}) -> if visible ai then 1 else 0
+      -- A hidden @with@ (issue #500) does not have a with-pattern in the abstract syntax.
+    Arg ai (_, IdiomType   {}) -> if visible ai then 2 else 1
+      -- The hidden version of the inspect idiom has just one with-pattern in the abstract syntax.
+    Arg ai (_, EqualityType{}) -> if visible ai then 2 else __IMPOSSIBLE__
+      -- The desugaring of @rewrite@ produces two new with-patterns in the abstract syntax.
+      -- They are always @NotHidden@.
+
 
 -- | From a list of @with@ and @rewrite@ expressions and their types,
 --   compute the list of final @with@ expressions (after expanding the @rewrite@s).
@@ -221,6 +239,15 @@ buildWithFunction cxtNames f aux t delta qs npars withSub perm n1 n cs = mapM bu
             where
             fromWithP (A.WithP _ p) = p
             fromWithP _ = __IMPOSSIBLE__
+
+      reportSDoc "tc.with.split" 40 $ vcat
+        [ "buildWithClause"
+        , nest 2 $ "n    =" <+> prettyTCM n
+        , nest 2 $ "wps  =" <+> prettyA wps
+        , nest 2 $ "wps0 =" <+> prettyA wps0
+        , nest 2 $ "wps1 =" <+> prettyA wps1
+        ]
+
       reportSDoc "tc.with" 50 $ "inheritedPats:" <+> vcat
         [ prettyA p <+> "=" <+> prettyTCM v <+> ":" <+> prettyTCM a
         | A.ProblemEq p v a <- inheritedPats

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -376,13 +376,14 @@ stripWithClausePatterns cxtNames parent f t delta qs npars perm ps = do
     , nest 2 $ "ps  = " <+> fsep (punctuate comma $ map prettyA ps)
     , nest 2 $ "ps' = " <+> fsep (punctuate comma $ map prettyA ps')
     , nest 2 $ "psi = " <+> fsep (punctuate comma $ map prettyA psi)
-    , nest 2 $ "qs  = " <+> fsep (punctuate comma $ map (prettyTCM . namedArg) qs)
+    , nest 2 $ addContext delta $
+               "qs  = " <+> fsep (punctuate comma $ map (prettyTCM . namedArg) qs)
     , nest 2 $ "perm= " <+> text (show perm)
     ]
 
   -- Andreas, 2015-11-09 Issue 1710: self starts with parent-function, not with-function!
   (ps', strippedPats) <- runWriterT $ strip (Def parent []) t psi qs
-  reportSDoc "tc.with.strip" 50 $ nest 2 $
+  unless (null strippedPats) $ reportSDoc "tc.with.strip" 50 $ nest 2 $
     "strippedPats:" <+> vcat [ prettyA p <+> "=" <+> prettyTCM v <+> ":" <+> prettyTCM a | A.ProblemEq p v a <- strippedPats ]
   let psp = permute perm ps'
   reportSDoc "tc.with.strip" 10 $ vcat

--- a/test/Fail/Issue5728.agda
+++ b/test/Fail/Issue5728.agda
@@ -5,7 +5,15 @@ test : Set
 test with Set
 ...
 
--- This used to be an internal error.
--- Expected error now:
+-- In Agda 2.6.1 we got "missing with clauses for test".
+-- In Agda 2.6.2 this used to be an internal error.
+-- In Agda 2.6.3 this was fixed to produce a proper error again:
 -- The right-hand side can only be omitted if there is an absurd
 -- pattern, () or {}, in the left-hand side.
+
+-- Andreas, 2025-04-07, fix for issue #7759 changes error to:
+-- Too few arguments given in with-clause
+-- when checking that the clause
+-- test with Set
+-- test
+-- has type Set

--- a/test/Fail/Issue5728.err
+++ b/test/Fail/Issue5728.err
@@ -1,5 +1,6 @@
-Issue5728.agda:6.1-4: error: [AbsentRHSRequiresAbsurdPattern]
-The right-hand side can only be omitted if there is an absurd
-pattern, () or {}, in the left-hand side.
-when checking that the clause Issue5728.with-4 has type
-(w : Set₁) → w
+Issue5728.agda:6.1-4: error: [TooFewPatternsInWithClause]
+Too few arguments given in with-clause
+when checking that the clause
+test with Set
+test
+has type Set

--- a/test/Fail/Issue7759.agda
+++ b/test/Fail/Issue7759.agda
@@ -1,0 +1,34 @@
+-- Andreas, 2025-04-07, issue #7759, reported and test case by nad
+--
+-- Too few with-patterns lead to wrong calculation of the "with-substitution"
+-- and subsequently an internal error when accessing the meta-variable
+-- thus transported into the wrong context.
+--
+-- The remedy is to install a check for sufficiently many with-patterns
+-- in the type checker, so that we are not entirely at the mercy
+-- of syntactic checks in the nicifier.
+-- In the present case, such a check was deactivated by
+-- 86b3223c477ca9f640eacddab2696bfd7c387b50 deemed to be just a refactoring:
+-- [ re #4704 ] Refactor: new way to track ellipsis in concrete syntax
+
+-- {-# OPTIONS -v tc.decl:10 #-}
+-- {-# OPTIONS -v tc.with:50 #-}
+-- {-# OPTIONS -v tc.def:50 #-}
+-- {-# OPTIONS -v tc:10 #-}
+-- {-# OPTIONS -v tc.lhs.top:30 #-}
+
+data Eq (A : Set) (a : A) : A → Set where
+  refl : Eq A a a
+
+f : (A : Set) (a : A) → Eq (Eq A a a) refl refl
+f A a with f A _
+... = refl
+
+-- WAS: internal error that could be triggered early by tc.lhs.top:20.
+--
+-- Error NOW:
+-- Too few arguments given in with-clause
+-- when checking that the clause
+-- f A a with f A _
+-- f A a = refl
+-- has type (A : Set) (a : A) → Eq (Eq A a a) refl refl

--- a/test/Fail/Issue7759.err
+++ b/test/Fail/Issue7759.err
@@ -1,0 +1,6 @@
+Issue7759.agda:25.1-4: error: [TooFewPatternsInWithClause]
+Too few arguments given in with-clause
+when checking that the clause
+f A a with f A _
+f A a = refl
+has type (A : Set) (a : A) → Eq (Eq A a a) refl refl

--- a/test/Succeed/Issue500.agda
+++ b/test/Succeed/Issue500.agda
@@ -1,3 +1,4 @@
+open import Agda.Builtin.Equality
 open import Agda.Builtin.Nat
 
 data Vec (A : Set) : Nat → Set where
@@ -18,3 +19,15 @@ foo : ∀ {A} m n (xs : Vec A m) (ys : Vec A n) → T (xs ++ ys)
 foo m n xs ys with {m + n} | xs ++ ys
 ... | []     = 0
 ... | z ∷ zs = []
+
+-- Andreas, 2025-04-08, issue #7788
+-- Needs also to work with nested with.
+
+postulate
+  com : ∀ n m → n + m ≡ m + n
+
+thm : ∀ a b c → a + (b + c) ≡ (c + b) + a
+thm a b c with {b + c} | com b c
+... | refl with c + b
+... | cb with com a cb
+... | p rewrite p = refl

--- a/test/Succeed/Rewrite.agda
+++ b/test/Succeed/Rewrite.agda
@@ -42,6 +42,12 @@ thm : ∀ a b c → a + (b + c) ≡ (c + b) + a
 thm a b c rewrite com b c with c + b
 ... | cb = com a cb
 
+-- rewrite followed by nested with
+thm' : ∀ a b c → a + (b + c) ≡ (c + b) + a
+thm' a b c rewrite com b c with c + b
+... | cb with com a cb
+... | p rewrite p = refl
+
 data List (A : Set) : Set where
   [] : List A
   _∷_ : (x : A)(xs : List A) → List A


### PR DESCRIPTION
**Fix #7788: correctly count hidden with-patterns in with-abstraction**
  The original implementation of #500 works only for non-nested hidden with-abstraction since hidden with-expressions are also counted into the number of with-patterns to consider in the current round of with-abstraction.
  However, there are no hidden with-patterns in the abstract syntax (don't parse), so they should not be counted.

**Fix #7759: by catching too few with-patterns in `buildWithClause`**
  This fixes a regression in 2.6.2 that turned the nicifier error "missing with clauses for f" into a internal (de Bruijn) error due to a invalid with-substitution.
  We now report a TooFewPatternsInWithClause error.
  
Context:
- #4041 
- #4078