### PR TITLE
re #7792: keep inlining after inlining a copy

### DIFF
--- a/test/Fail/Issue7792.agda
+++ b/test/Fail/Issue7792.agda
@@ -1,0 +1,29 @@
+module Issue7792 where
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+module M (X : Set) where
+  record Foo : Set where
+    no-eta-equality
+    constructor inc
+    field foo1 foo2 : X
+
+  {-# INLINE Foo.constructor #-}
+
+  open Foo
+
+  to : X → X → Foo
+  {-# INLINE to #-}
+  to a b = record { foo1 = a ; foo2 = b }
+
+module N (X : Set) where
+  open M X public
+
+open N Nat
+
+x : Foo
+x = to 1 2
+
+_ : x ≡ inc 1 2
+_ = refl

--- a/test/Fail/Issue7792.err
+++ b/test/Fail/Issue7792.err
@@ -1,0 +1,3 @@
+Issue7792.agda:29.5-9: error: [UnequalTerms]
+x != inc 1 2 of type Foo
+when checking that the expression refl has type x ≡ inc 1 2


### PR DESCRIPTION
Fixes #7792 in a conservative manner by only recursively inlining until we hit a non-copy.