### PR TITLE
Fix #7796: don't hint towards --guardedness when --no-guardedness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,8 @@ Warnings
   by new warnings `OpenImportAbstract` and `OpenImportPrivate`.
 
 * Warning `NoGuardednessFlag` has been removed.
-  Instead Agda a hint when `--guardedness` would help with termination checking.
+  Instead Agda gives a hint when `--guardedness` would help with termination checking,
+  unless options `--sized-types` or `--no-guardedness` are set.
 
 
 Polarity

--- a/test/Fail/Issue1209-5.agda
+++ b/test/Fail/Issue1209-5.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --safe --no-guardedness #-}
+{-# OPTIONS --safe #-}
 
 record Stream (A : Set) : Set where
   coinductive

--- a/test/Fail/Issue7796.agda
+++ b/test/Fail/Issue7796.agda
@@ -1,0 +1,21 @@
+-- Andreas, 2025-04-12, issue #7796
+-- Do not print guardedness hint in termination error
+-- when guardedness is explicitly switched off.
+
+{-# OPTIONS --no-guardedness #-}
+
+-- {-# OPTIONS -v tc.warning.termination:50 #-}
+
+record U : Set where
+  coinductive
+  field out : U
+
+u : U
+u .U.out = u
+
+-- Expecting error without --guardedness hint
+-- error: [TerminationIssue]
+-- Termination checking failed for the following functions:
+--   u
+-- Problematic calls:
+--   u

--- a/test/Fail/Issue7796.err
+++ b/test/Fail/Issue7796.err
@@ -1,0 +1,5 @@
+Issue7796.agda:13.1-14.13: error: [TerminationIssue]
+Termination checking failed for the following functions:
+  u
+Problematic calls:
+  u (at Issue7796.agda:14.12-13)


### PR DESCRIPTION
Termination errors that could be fixed by `--guardedness` now only hint towards this flag when `--no-guardedness` has not been explicitly set.

Amends PR
- #7778

Closes
- #7796
