### PR TITLE
Mimer cosmetics

### DIFF
--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -613,7 +613,6 @@ collectLHSVars ii = do
           -- Telescope for the body of the clause
           let cTel = clauseTel clause
           -- HACK: To get the correct indices, we shift by the difference in telescope lengths
-          -- TODO: Difference between teleArgs and telToArgs?
           let shift = length (telToArgs iTel) - length (telToArgs cTel)
 
           reportSDoc "mimer" 60 $ vcat

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -63,7 +63,7 @@ import Agda.Utils.Benchmark (billTo)
 import Agda.Utils.FileName (filePath)
 import Agda.Utils.Impossible (__IMPOSSIBLE__)
 import Agda.Utils.Maybe (catMaybes)
-import Agda.Utils.Monad (ifM)
+import Agda.Utils.Monad (ifM, and2M)
 import qualified Agda.Utils.Maybe.Strict as SMaybe
 -- import Agda.Utils.Permutation (idP, permute, takeP)
 import Agda.Utils.Time (CPUTime(..), getCPUTime, fromMilliseconds)
@@ -406,9 +406,9 @@ collectComponents opts costs ii mDefName whereNames metaId = do
       <+> prettyList (map prettyTypedTerm typedLhsVars))
   -- TODO: For now, we *never* split on implicit arguments even if they are
   -- written explicitly on the LHS.
-  splitVarsTyped <- filterM (\(term, typ) ->
-                 ((argInfoHiding (domInfo typ) == NotHidden) &&) <$> isTypeDatatype (unDom typ))
-               typedLhsVars
+  splitVarsTyped <-
+    filterM (\ (term, dom) -> pure (visible dom) `and2M` isTypeDatatype (unDom dom))
+            typedLhsVars
   reportSDoc "mimer.components" 40 $
     "Splittable variables" <+> prettyList (map prettyTCMTypedTerm splitVarsTyped) <+> parens ("or"
       <+> prettyList (map prettyTypedTerm splitVarsTyped))

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -47,7 +47,7 @@ import Agda.Syntax.Translation.AbstractToConcrete (abstractToConcrete_)
 import Agda.TypeChecking.Primitive (getBuiltinName)
 import Agda.TypeChecking.Constraints (noConstraints)
 import Agda.TypeChecking.Conversion (equalType)
-import qualified Agda.TypeChecking.Empty as Empty -- (isEmptyType)
+import Agda.TypeChecking.Empty (isEmptyType)
 import Agda.TypeChecking.Free (flexRigOccurrenceIn, freeVars)
 import Agda.TypeChecking.Level (levelType)
 import Agda.TypeChecking.MetaVars (newValueMeta)
@@ -297,10 +297,6 @@ predNat n | n > 0 = n - 1
 getRecordFields :: (HasConstInfo tcm, MonadTCM tcm) => QName -> tcm [QName]
 getRecordFields = fmap (map unDom . recFields . theDef) . getConstInfo
 
-
--- TODO: Change the signature in original module instead.
-isEmptyType :: Type -> SM Bool
-isEmptyType = liftTCM . Empty.isEmptyType
 
 -- TODO: Currently not using this function. Is it useful anywhere?
 getDomainType :: Type -> Type

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -458,7 +458,7 @@ collectComponents opts costs ii mDefName whereNames metaId = do
 
     isNotMutual qname f = case mDefName of
       Nothing -> True
-      Just defName -> defName /= qname && fmap ((defName `elem`)) (funMutual f) /= Just True
+      Just defName -> defName /= qname && fmap (defName `elem`) (funMutual f) /= Just True
 
     go comps qname = go' comps qname =<< getConstInfo qname
 

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -378,13 +378,7 @@ nextBranchMeta branch = case sbGoals branch of
 -- TODO: Rename (see metaInstantiation)
 getMetaInstantiation :: (MonadTCM tcm, PureTCM tcm, MonadDebug tcm, MonadInteractionPoints tcm, MonadFresh NameId tcm)
   => MetaId -> tcm (Maybe Expr)
-getMetaInstantiation = metaInstantiation >=> go
-  where
-    -- TODO: Cleaner way of juggling the maybes here?
-    go Nothing = return Nothing
-    go (Just term) = do
-      expr <- instantiateFull term >>= reify
-      return $ Just expr
+getMetaInstantiation = metaInstantiation >=> traverse (instantiateFull >=> reify)
 
 metaInstantiation :: (MonadTCM tcm, MonadDebug tcm, ReadTCState tcm) => MetaId -> tcm (Maybe Term)
 metaInstantiation metaId = lookupLocalMeta metaId <&> mvInstantiation >>= \case

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -297,13 +297,6 @@ predNat n | n > 0 = n - 1
 getRecordFields :: (HasConstInfo tcm, MonadTCM tcm) => QName -> tcm [QName]
 getRecordFields = fmap (map unDom . recFields . theDef) . getConstInfo
 
-
--- TODO: Currently not using this function. Is it useful anywhere?
-getDomainType :: Type -> Type
-getDomainType typ = case unEl typ of
-  Pi dom _ -> unDom dom
-  _ -> __IMPOSSIBLE__
-
 allOpenMetas :: (AllMetas t, ReadTCState tcm) => t -> tcm [MetaId]
 allOpenMetas t = do
   openMetas <- getOpenMetas

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -1384,7 +1384,7 @@ split' checkEmpty ind allowPartialCover inserttrailing
       when (allowPartialCover == NoAllowPartialCover && not overlap) $
         for_ ns $ \(tag, (sc, _)) -> do
           unless (tag `Set.member` all_tags) $ do
-            isImpossibleClause <- liftTCM $ isEmptyTel $ scTel sc
+            isImpossibleClause <- isEmptyTel $ scTel sc
             unless isImpossibleClause $ do
               liftTCM $ reportSDoc "tc.cover" 10 $ vcat
                 [ text "Missing case for" <+> prettyTCM tag

--- a/src/full/Agda/TypeChecking/Empty.hs
+++ b/src/full/Agda/TypeChecking/Empty.hs
@@ -59,12 +59,12 @@ ensureEmptyType r t = caseEitherM (checkEmptyType r t) failure return
   failure Fail              = typeError $ ShouldBeEmpty t []
 
 -- | Check whether a type is empty.
-isEmptyType :: Type -> TCM Bool
-isEmptyType ty = isRight <$> checkEmptyType noRange ty
+isEmptyType :: MonadTCM tcm => Type -> tcm Bool
+isEmptyType ty = liftTCM $ isRight <$> checkEmptyType noRange ty
 
 -- | Check whether some type in a telescope is empty.
-isEmptyTel :: Telescope -> TCM Bool
-isEmptyTel tel = isRight <$> checkEmptyTel noRange tel
+isEmptyTel :: MonadTCM tcm => Telescope -> tcm Bool
+isEmptyTel tel = liftTCM $ isRight <$> checkEmptyTel noRange tel
 
 -- Either the type is possibly non-empty (Left err) or it is really empty
 -- (Right ()).

--- a/src/full/Agda/TypeChecking/Empty.hs-boot
+++ b/src/full/Agda/TypeChecking/Empty.hs-boot
@@ -7,14 +7,14 @@ module Agda.TypeChecking.Empty
   , checkEmptyTel
   ) where
 
-import Agda.TypeChecking.Monad (TCM)
+import Agda.TypeChecking.Monad (TCM, MonadTCM)
 import Agda.Syntax.Internal (Type, Telescope)
 import Agda.Syntax.Position (Range)
 
 data ErrorNonEmpty
 
-isEmptyType :: Type      -> TCM Bool
-isEmptyTel  :: Telescope -> TCM Bool
+isEmptyType :: MonadTCM tcm => Type -> tcm Bool
+isEmptyTel  :: MonadTCM tcm => Telescope -> tcm Bool
 
 ensureEmptyType :: Range -> Type -> TCM ()
 checkEmptyTel   :: Range -> Telescope -> TCM (Either ErrorNonEmpty Int)

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -103,7 +103,7 @@ teleNames :: Telescope -> [ArgName]
 teleNames = map (fst . unDom) . telToList
 
 teleArgNames :: Telescope -> [Arg ArgName]
-teleArgNames = map (argFromDom . fmap fst) . telToList
+teleArgNames = telToArgs
 
 teleArgs :: (DeBruijn a) => Tele (Dom t) -> [Arg a]
 teleArgs = map argFromDom . teleDoms


### PR DESCRIPTION
- **Mimer TODO: generalize isEmptyType to MonadTCM**
  

- **Mimer TODO: "Cleaner way of juggling the maybes"**
  

- **Mimer TODO: remove getDomainType**
  

- **Mimer: use `and2M`**
  

- **Mimer: use isDataOrRecord in isTypeDataType**
  

- **Mimer TODO: telToArgs = teleArgNames**
  

- **Mimer entrypoint: use localTCState instead of getTC/putTC bracket**
  Using `localTCState` is the default choice (preserves statistics).
  Deviation should be justified; a priori I could not see a reason for
  using plain `putTC oldState`.
  

- **Mimer: rename `nextBranchMeta` to `nextGoal`**
  

- **Mimer cosmetics**
  