### PR TITLE
Run `agda --setup` also on `--emacs-mode locate`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ install: install-bin setup-agda compile-emacs-mode setup-emacs-mode
 setup-agda:
 	$(AGDA_BIN) --setup
 
-.PHONY: ensure-hash-is-correct
+.PHONY: ensure-hash-is-correct ## Ensure Agda's version contains the latest git commit hash.
 ensure-hash-is-correct:
 	touch src/setup/Agda/VersionCommit.hs
 

--- a/src/agda-mode/Main.hs
+++ b/src/agda-mode/Main.hs
@@ -32,6 +32,9 @@ main = do
     [arg]
       | arg == locateFlag -> do
 
+          -- Ensure that Agda has been setup so the Emacs mode is available.
+          Agda.setup False
+
           printEmacsModeFile
 
       | arg == setupFlag  -> do

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -100,6 +100,7 @@ runAgda' backends = do
 
       -- Locate emacs mode
       when (EmacsModeLocate `Set.member` optEmacsMode opts) do
+        unless (optSetup opts) $ Agda.Setup.setup False
         printEmacsModeFile
 
       case mode of

--- a/src/setup/Agda/VersionCommit.hs
+++ b/src/setup/Agda/VersionCommit.hs
@@ -13,10 +13,11 @@ import Development.GitRev
 
 import Agda.Version
 
+-- | Agda's version suffixed with the git commit hash.
 versionWithCommitInfo :: String
 versionWithCommitInfo = version ++ maybe "" ("-" ++) commitInfo
 
--- | Information about current git commit, generated at compile time
+-- | Information about current git commit, generated at compile time.
 commitInfo :: Maybe String
 commitInfo
   | hash == "UNKNOWN" = Nothing


### PR DESCRIPTION
- **Run `agda --setup` also on `--emacs-mode locate`.**
  As discussed on the Agda dev meeting 2025-04-16:
  `agda --emacs-mode locate` will produce a non-existing directory when agda was just build, which may make the emacs mode fail.
  

- **Makefile re #7780: help line for ensure-hash-is-correct**
  