### PR TITLE
Some refactoring concerning Boundary

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -997,7 +997,7 @@ metaHelperType norm ii rng s = case words s of
       let arity = size atel
           (delta1, delta2, _, a', vtys') = splitTelForWith tel a vtys
       a <- runInPrintingEnvironment $ do
-        reify =<< cleanupType arity args =<< normalForm norm =<< fst <$> withFunctionType delta1 vtys' delta2 a' []
+        reify =<< cleanupType arity args =<< normalForm norm =<< fst <$> withFunctionType delta1 vtys' delta2 a' empty
       reportSDoc "interaction.helper" 10 do
         let extractOtherType = \case { OtherType a -> a; _ -> __IMPOSSIBLE__ }
         let (vs, as)   = List1.unzipWith (fmap extractOtherType . unArg) vtys

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -955,7 +955,7 @@ computeNeighbourhood delta1 n delta2 d pars ixs hix tel ps cps c = do
   -- Lookup the type of the constructor at the given parameters
   (gamma0, cixs, boundary) <- do
     (TelV gamma0 (El _ d), boundary) <- liftTCM $ addContext delta1 $
-      telViewPathBoundaryP (ctype `piApply` pars)
+      telViewPathBoundary (ctype `piApply` pars)
     let Def _ es = d
         Just cixs = allApplyElims es
     return (gamma0, cixs, boundary)

--- a/src/full/Agda/TypeChecking/Datatypes.hs
+++ b/src/full/Agda/TypeChecking/Datatypes.hs
@@ -157,7 +157,7 @@ fullyApplyCon' c vs t0 ret err = do
     , " at type "
     , prettyTCM t0
     ]
-  (TelV tel t, boundary) <- telViewPathBoundaryP t0
+  (TelV tel t, boundary) <- telViewPathBoundary t0
   -- The type of the constructor application may still be a function
   -- type.  In this case, we introduce the domains @tel@ into the context
   -- and apply the constructor to these fresh variables.

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1344,11 +1344,12 @@ assignMeta' m x t n ids v = do
     assignTerm x (telToArgs tel') v'
   where
     blockOnBoundary :: TelView -> Boundary -> Term -> TCM Term
-    blockOnBoundary telv         [] v = return v
-    blockOnBoundary (TelV tel t) bs v = addContext tel $
+    blockOnBoundary telv         (Boundary []) v = return v
+    blockOnBoundary (TelV tel t) (Boundary bs) v = addContext tel $
       blockTerm t $ do
         neg <- primINeg
-        forM_ bs $ \ (r,(x,y)) -> do
+        forM_ bs $ \ (i,(x,y)) -> do
+          let r = var i
           equalTermOnFace (neg `apply1` r) t x v
           equalTermOnFace r  t y v
         return v

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -503,6 +503,9 @@ instance ComputeOccurrences a => ComputeOccurrences (Elim' a) where
   occurrences (Apply a)      = occurrences a
   occurrences (IApply x y a) = occurrences (x,(y,a)) -- TODO Andrea: conservative
 
+instance (ComputeOccurrences x, ComputeOccurrences a) => ComputeOccurrences (Boundary' x a) where
+  occurrences = occurrences . theBoundary
+
 instance ComputeOccurrences a => ComputeOccurrences (Arg a)   where
 instance ComputeOccurrences a => ComputeOccurrences (Dom a)   where
 instance ComputeOccurrences a => ComputeOccurrences [a]       where
@@ -510,6 +513,9 @@ instance ComputeOccurrences a => ComputeOccurrences (Maybe a) where
 
 instance (ComputeOccurrences a, ComputeOccurrences b) => ComputeOccurrences (a, b) where
   occurrences (x, y) = occurrences x <> occurrences y
+
+instance ComputeOccurrences Int where
+  occurrences _ = mempty
 
 -- | Computes the number of occurrences of different 'Item's in the
 -- given definition.

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -567,7 +567,7 @@ computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do
             -- Allow UnconfimedReductions here to make sure we get the constructor type
             -- in same way as it was obtained when the data types was checked.
             (TelV tel t, bnd) <- putAllowedReductions allReductions $
-              telViewUpToPathBoundary' (-1) . defType =<< getConstInfo c
+              telViewPathBoundary . defType =<< getConstInfo c
             let (tel0,tel1) = splitTelescopeAt np tel
             -- Do not collect occurrences in the data parameters.
             -- Normalization needed e.g. for test/succeed/Bush.agda.

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -48,6 +48,7 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Positivity.Occurrence
 import Agda.TypeChecking.DiscrimTree.Types
 import Agda.TypeChecking.Substitute
+import Agda.TypeChecking.Telescope
 
 import qualified Agda.Utils.BiMap as BiMap
 import Agda.Utils.Graph.AdjacencyMap.Unidirectional (Graph)
@@ -351,6 +352,8 @@ instance PrettyTCM Elim where
   prettyTCM (Apply v) = "$" <+> prettyTCM v
   prettyTCM (Proj _ f)= "." <> prettyTCM f
 {-# SPECIALIZE prettyTCM :: Elim -> TCM Doc #-}
+
+deriving instance (PrettyTCM x, PrettyTCM a) => PrettyTCM (Boundary' x a)
 
 instance PrettyTCM Modality where
   prettyTCM mod = hsep

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -290,7 +290,7 @@ checkConstructor d uc tel nofIxs s con@(A.Axiom _ i ai Nothing c e) =
         s <- reduce s
         debugAdd c t
 
-        (TelV fields _, boundary) <- telViewUpToPathBoundaryP (-1) t
+        (TelV fields _, boundary) <- telViewPathBoundary t
 
         -- We assume that the current context matches the parameters
         -- of the datatype in an empty context (c.f. getContextSize above).

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -397,14 +397,15 @@ checkConstructor d uc tel nofIxs s con@(A.Axiom _ i ai Nothing c e) =
         ]
 checkConstructor _ _ _ _ _ _ = __IMPOSSIBLE__ -- constructors are axioms
 
-defineCompData :: QName      -- datatype name
-               -> ConHead
-               -> Telescope  -- Γ parameters
-               -> [QName]    -- projection names
-               -> Telescope  -- Γ ⊢ Φ field types
-               -> Type       -- Γ ⊢ T target type
-               -> Boundary   -- [(i,t_i,b_i)],  Γ.Φ ⊢ [ (i=0) -> t_i; (i=1) -> u_i ] : B_i
-               -> TCM CompKit
+defineCompData ::
+     QName         -- ^ Datatype name.
+  -> ConHead       -- ^ Constructor.
+  -> Telescope     -- ^ @Γ@ parameters.
+  -> [QName]       -- ^ Projection names.
+  -> Telescope     -- ^ @Γ ⊢ Φ@ field types.
+  -> Type          -- ^ @Γ ⊢ T@ target type.
+  -> Boundary      -- ^ @[(i,t_i,b_i)],  Γ.Φ ⊢ [ (i=0) -> t_i; (i=1) -> u_i ] : B_i@
+  -> TCM CompKit
 defineCompData d con params names fsT t boundary = do
   required <- mapM getTerm'
     [ someBuiltin builtinInterval
@@ -528,7 +529,7 @@ defineCompData d con params names fsT t boundary = do
                   return $ (psi, alpha)
 
             -- Γ ⊢ Abs i. [(ψ_n,α_n : [ψ] → R (δ i))]
-            faces <- mapM mkFace bs
+            faces <- mapM mkFace $ theBoundary $ tmBoundary bs
 
             runNamesT [] $ do
                 -- Γ
@@ -741,7 +742,7 @@ defineTranspIx d = do
 
       -- record type in 'exponentiated' context
       -- (params : Γ)(ixs : Δ^I), i : I |- T[params, ixs i]
-      let rect' = sub ixs `applySubst` El (raise (size ixs) s) (Def d (teleElims (abstract params ixs) []))
+      let rect' = sub ixs `applySubst` El (raise (size ixs) s) (Def d (teleElims (abstract params ixs) empty))
       addContext params $ reportSDoc "tc.data.ixs" 20 $ "deltaI:" <+> prettyTCM deltaI
       addContext params $ addContext deltaI $ addContext ("i"::String, defaultDom interval) $ do
         reportSDoc "tc.data.ixs" 20 $ "rect':" <+> pretty (sub ixs)
@@ -756,7 +757,7 @@ defineTranspIx d = do
       reportSDoc "tc.data.ixs" 20 $ "transpIx:" <+> prettyTCM theType
       let
         ctel = abstract params $ abstract deltaI $ ExtendTel (defaultDom $ subst 0 iz rect') (Abs "t" EmptyTel)
-        ps = telePatterns ctel []
+        ps = telePatterns ctel empty
         cpi = noConPatternInfo { conPType = Just (defaultArg interval) }
         pat :: NamedArg (Pattern' DBPatVar)
         pat = defaultNamedArg $ ConP c cpi []
@@ -864,7 +865,7 @@ defineTranspFun d mtrX cons pathCons = do
           (defaultDefn defaultArgInfo trD theType (Cubical CErased) fun)
         let
           ctel = abstract telI $ ExtendTel (defaultDom $ subst 0 iz dTs) (Abs "t" EmptyTel)
-          ps = telePatterns ctel []
+          ps = telePatterns ctel empty
           cpi = noConPatternInfo { conPType = Just (defaultArg interval)
                                  , conPFallThrough = True
                                  }
@@ -1132,7 +1133,7 @@ defineConClause trD' isHIT mtrX npars nixs xTel' telI sigma dT' cnames = do
           let aTelNames = teleNames aTel
               aTelArgs = teleArgNames aTel
           con_ixs <- open $ AbsN (teleNames prm ++ teleNames aTel) $ map unArg con_ixs
-          bndry <- open $ AbsN (teleNames prm ++ teleNames aTel) $ boundary
+          bndry <- open $ AbsN (teleNames prm ++ teleNames aTel) $ tmBoundary boundary
           u    <- open $ AbsN (teleNames prm ++ aTelNames) $ Con chead ConOSystem (teleElims aTel boundary)
           aTel <- open $ AbsN (teleNames prm) aTel
           -- bsys : Abs Δ.Args ([phi] → ty)
@@ -1143,7 +1144,7 @@ defineConClause trD' isHIT mtrX npars nixs xTel' telI sigma dT' cnames = do
               ty <- open ty
               bs <- bndry `applyN` ts
               xs <- mapM (\(phi,u) -> (,) <$> open phi <*> open u) $ do
-                (i,(l,r)) <- bs
+                (i,(l,r)) <- theBoundary bs
                 let pElem t = Lam defaultIrrelevantArgInfo $ NoAbs "o" t
                 [(tINeg `apply` [argN i],pElem l),(i,pElem r)]
               combineSys' l ty xs
@@ -1158,7 +1159,7 @@ defineConClause trD' isHIT mtrX npars nixs xTel' telI sigma dT' cnames = do
           let aTel0 = aTel `applyN` map (<@> pure iz) delta
 
           -- telePatterns is not context invariant, so we need an open here where the context ends in aTel0.
-          ps0 <- (open =<<) $ (telePatterns <$> aTel0 <*> applyN bndry (map (<@> pure iz) delta ++ map (fmap unArg) as0))
+          ps0 <- (open =<<) $ (telePatterns <$> aTel0 <*> (varBoundary <$> applyN bndry (map (<@> pure iz) delta ++ map (fmap unArg) as0)))
 
           let deltaArg i = do
                 i <- i

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -1183,11 +1183,11 @@ checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs n
     reportSDoc "tc.with.bndry" 40 $ addContext delta1 $ addContext delta2
                                   $ text "ps =" <+> pretty ps
     let vs = iApplyVars ps
-    bndry <- if null vs then return [] else do
+    bndry <- if null vs then return empty else do
       iz <- primIZero
       io <- primIOne
       let tm = Def f (patternsToElims ps)
-      return [(i,(inplaceS i iz `applySubst` tm, inplaceS i io `applySubst` tm)) | i <- vs]
+      return $ Boundary [(i,(inplaceS i iz `applySubst` tm, inplaceS i io `applySubst` tm)) | i <- vs]
     reportSDoc "tc.with.bndry" 40 $ addContext delta1 $ addContext delta2
                                   $ text "bndry =" <+> pretty bndry
     withFunctionType delta1 vtys delta2 b bndry

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -1195,7 +1195,7 @@ checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs n
   reportSDoc "tc.with.type" 50 $ sep [ "with-function type:", nest 2 $ pretty withFunType ]
 
   call_in_parent <- do
-    (TelV tel _,bs) <- telViewUpToPathBoundaryP (nwithargs + size delta) withFunType
+    (TelV tel _,bs) <- telViewUpToPathBoundary' (nwithargs + size delta) withFunType
     return $ argsS `applySubst` Def aux (teleElims tel bs)
 
   reportSDoc "tc.with.top" 20 $ addContext delta $ "with function call" <+> prettyTCM call_in_parent

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1365,7 +1365,7 @@ checkLHS mf = updateModality checkLHS_ where
         _ -> return ()
 
       -- The type of the constructor will end in an application of the datatype
-      (TelV gamma (El _ ctarget), boundary) <- liftTCM $ telViewPathBoundaryP b
+      (TelV gamma (El _ ctarget), boundary) <- liftTCM $ telViewPathBoundary b
       let Def d' es' = ctarget
           cixs = drop (size pars) $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es'
 

--- a/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
@@ -118,7 +118,7 @@ updateProblemRest st@(LHSState tel0 qs0 p@(Problem oldEqs ps ret) a psplit ixspl
     "insertImplicitPatternsT returned" <+> fsep (map prettyA ps)
   -- (Issue 734: Do only the necessary telView to preserve clause types as much as possible.)
   let m = length $ takeWhile (isNothing . A.isProjP) ps
-  (TelV gamma b, boundary) <- telViewUpToPathBoundaryP m $ unArg a
+  (TelV gamma b, boundary) <- telViewUpToPathBoundary' m $ unArg a
   forM_ (zip ps (telToList gamma)) $ \(p, a) ->
     unless (sameHiding p a) $ setCurrentRange p $ typeError WrongHidingInLHS
   let tel1      = useNamesFromPattern ps gamma

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -397,7 +397,7 @@ addCompositionForRecord name eta con tel fs ftel rect = do
 
     -- Record has no fields: attach composition data to record constructor
     if null fs then do
-      kit <- defineCompData name con (abstract cxt tel) [] ftel rect []
+      kit <- defineCompData name con (abstract cxt tel) [] ftel rect empty
       modifySignature $ updateDefinition (conName con) $ updateTheDef $ \case
         r@Constructor{} -> r { conComp = kit, conProj = Just [] }  -- no projections
         _ -> __IMPOSSIBLE__
@@ -406,7 +406,7 @@ addCompositionForRecord name eta con tel fs ftel rect = do
     -- matching): define composition as for a data type, attach it to
     -- the record.
     else if theEtaEquality eta == NoEta PatternMatching then do
-      kit <- defineCompData name con (abstract cxt tel) (unArg <$> fs) ftel rect []
+      kit <- defineCompData name con (abstract cxt tel) (unArg <$> fs) ftel rect empty
       modifySignature $ updateDefinition name $ updateTheDef $ \case
         r@Record{} -> r { recComp = kit }
         _ -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -415,10 +415,10 @@ telViewPath :: PureTCM m => Type -> m TelView
 telViewPath = telViewUpToPath (-1)
 
 {-# SPECIALIZE telViewUpToPath :: Int -> Type -> TCM TelView #-}
--- | @telViewUpToPath n t@ takes off $t$
+-- | @telViewUpToPath n t@ takes off @t@
 --   the first @n@ (or arbitrary many if @n < 0@) function domains or Path types.
 --
--- @telViewUpToPath n t = fst <$> telViewUpToPathBoundary'n t@
+-- @telViewUpToPath n t = fst <$> telViewUpToPathBoundary' n t@
 telViewUpToPath :: PureTCM m => Int -> Type -> m TelView
 telViewUpToPath n t = if n == 0 then done t else do
   pathViewAsPi t >>= \case
@@ -439,6 +439,18 @@ type Boundary' a = [(Term,a)]
 -- by the Path types encountered. The boundary terms live in the
 -- telescope given by the @TelView@.
 -- Each point of the boundary has the type of the codomain of the Path type it got taken from, see @fullBoundary@.
+--
+-- @
+--  (TelV Γ b, [(i,t_i,u_i)]) <- telViewUpToPathBoundary' n a
+--  Input:  Δ ⊢ a
+--  Output: Δ.Γ ⊢ b
+--          Δ.Γ ⊢ T is the codomain of the PathP at variable i
+--          Δ.Γ ⊢ i : I
+--          Δ.Γ ⊢ [ (i=0) -> t_i; (i=1) -> u_i ] : T
+-- @
+--
+-- Useful to reconstruct IApplyP patterns after teleNamedArgs Γ.
+--
 telViewUpToPathBoundary' :: PureTCM m => Int -> Type -> m (TelView, Boundary)
 telViewUpToPathBoundary' n t = if n == 0 then done t else do
   pathViewAsPi' t >>= \case
@@ -477,20 +489,9 @@ telViewUpToPathBoundary i a = do
    (telv@(TelV tel b), bs) <- telViewUpToPathBoundary' i a
    return $ (telv, fullBoundary tel bs)
 
-{-# INLINE telViewUpToPathBoundaryP #-}
--- | @(TelV Γ b, [(i,t_i,u_i)]) <- telViewUpToPathBoundaryP n a@
---  Input:  Δ ⊢ a
---  Output: Δ.Γ ⊢ b
---          Δ.Γ ⊢ T is the codomain of the PathP at variable i
---          Δ.Γ ⊢ i : I
---          Δ.Γ ⊢ [ (i=0) -> t_i; (i=1) -> u_i ] : T
--- Useful to reconstruct IApplyP patterns after teleNamedArgs Γ.
-telViewUpToPathBoundaryP :: PureTCM m => Int -> Type -> m (TelView,Boundary)
-telViewUpToPathBoundaryP = telViewUpToPathBoundary'
-
-{-# INLINE telViewPathBoundaryP #-}
-telViewPathBoundaryP :: PureTCM m => Type -> m (TelView,Boundary)
-telViewPathBoundaryP = telViewUpToPathBoundaryP (-1)
+{-# INLINE telViewPathBoundary #-}
+telViewPathBoundary :: PureTCM m => Type -> m (TelView,Boundary)
+telViewPathBoundary = telViewUpToPathBoundary' (-1)
 
 
 -- | @teleElimsB args bs = es@

--- a/src/full/Agda/TypeChecking/Telescope/Path.hs
+++ b/src/full/Agda/TypeChecking/Telescope/Path.hs
@@ -28,7 +28,7 @@ import Agda.Utils.Impossible
 
 
 -- | In an ambient context Γ, @telePiPath f lams Δ t bs@ builds a type that
--- can be @telViewPathBoundaryP'ed@ into (TelV Δ t, bs').
+-- can be @'telViewPathBoundary'@ed into (TelV Δ t, bs').
 --   Γ.Δ ⊢ t
 --   bs = [(i,u_i)]
 --   Δ = Δ0,(i : I),Δ1

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -129,7 +129,7 @@ withFunctionType
   -> List1 (Arg (Term, EqualityView))   -- ^ @Δ₁,Δ₂ ⊢ vs : raise Δ₂ as@  with and rewrite-expressions and their type.
   -> Telescope                          -- ^ @Δ₁ ⊢ Δ₂@                   context extension to type with-expressions.
   -> Type                               -- ^ @Δ₁,Δ₂ ⊢ b@                 type of rhs.
-  -> [(Int,(Term,Term))]                -- ^ @Δ₁,Δ₂ ⊢ [(i,(u0,u1))] : b  boundary.
+  -> Boundary                           -- ^ @Δ₁,Δ₂ ⊢ [(i,(u0,u1))] : b  boundary.
   -> TCM (Type, (Nat1, Nat))
     -- ^ @Δ₁ → wtel → Δ₂′ → b′@ such that
     --     @[vs/wtel]wtel = as@ and
@@ -163,7 +163,7 @@ withFunctionType delta1 vtys delta2 b bndry = addContext delta1 $ do
   TelV wtel _ <- telViewUpTo nwithargs wd2b
 
   -- select the boundary for "Δ₁" abstracting over "wΓ.Δ₂"
-  let bndry' = [(i - sd2,(lams u0, lams u1)) | (i,(u0,u1)) <- bndry, i >= sd2]
+  let bndry' = Boundary [(i - sd2,(lams u0, lams u1)) | (i,(u0,u1)) <- theBoundary bndry, i >= sd2]
         where sd2 = size delta2
               lams u = teleNoAbs wtel (abstract delta2 u)
 

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -594,7 +594,7 @@ stripWithClausePatterns cxtNames parent f t delta qs npars perm ps = do
       where
         recurse v = do
           let piOrPathApplyM t v = do
-                (TelV tel t', bs) <- telViewUpToPathBoundaryP 1 t
+                (TelV tel t', bs) <- telViewUpToPathBoundary' 1 t
                 unless (size tel == 1) $ __IMPOSSIBLE__
                 return (teleElims tel bs, subst 0 v t')
           (e, t') <- piOrPathApplyM t v
@@ -625,7 +625,7 @@ stripWithClausePatterns cxtNames parent f t delta qs npars perm ps = do
           -- Compute the argument telescope for the constructor
           let ct' = ct `piApply` take np us
           TelV tel' _ <- liftTCM $ telViewPath ct'
-          -- (TelV tel' _, _boundary) <- liftTCM $ telViewPathBoundaryP ct'
+          -- (TelV tel' _, _boundary) <- liftTCM $ telViewPathBoundary ct'
 
           reportSDoc "tc.with.strip" 20 $
             vcat [ "ct  = " <+> prettyTCM ct


### PR DESCRIPTION
Some cleanup in `telView(UpTo)PathBoundary` functions:

- **Refactor re #7803: drop P from telView(UpTo)PathBoundaryP**
  Not sure what the suffix P was meant to denote.
  
Expose invariant that `Boundary` is only used with dimension variables, even though substitution might introduce dimension terms.

- **Refactor re #7803: make Boundary a newtype**
- **Introduce VarBoundary = Boundary' Int Term**
- **Rename VarBoundary to Boundary**
  