### PR TITLE
Fix #7803 fix #7811: new error PathAbstractionFailed instead of crash

### DIFF
--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -230,6 +230,7 @@ data ErrorName
   | NotValidBeforeField_
   | OpenEverythingInRecordWhere_
   | OverlappingProjects_
+  | PathAbstractionFailed_
   | PatternInPathLambda_
   | PatternInSystem_
   | PatternSynonymArgumentShadows_ ConstructorOrPatternSynonym

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -634,6 +634,11 @@ instance PrettyTCM TypeError where
       pwords "With clause pattern " ++ [prettyA p] ++
       pwords " is not an instance of its parent pattern " ++ [P.fsep <$> prettyTCMPatterns [q]]
 
+    PathAbstractionFailed b -> vcat
+      [ ("Path abstraction failed for type" <+> prettyTCM (unAbs b)) <> "."
+      , "The type may be non-fibrant or its sort depends on an interval variable"
+      ]
+
     MetaCannotDependOn m v i ->
       ifM (isSortMeta m `and2M` (not <$> hasUniversePolymorphism))
       ( {- then -}

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -180,6 +180,7 @@ typeErrorName = \case
   NotValidBeforeField                                        {} -> NotValidBeforeField_
   OpenEverythingInRecordWhere                                {} -> OpenEverythingInRecordWhere_
   OverlappingProjects                                        {} -> OverlappingProjects_
+  PathAbstractionFailed                                      {} -> PathAbstractionFailed_
   PatternInPathLambda                                        {} -> PatternInPathLambda_
   PatternInSystem                                            {} -> PatternInSystem_
   PostulatedSizeInModule                                     {} -> PostulatedSizeInModule_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5137,6 +5137,7 @@ data TypeError
         | IllTypedPatternAfterWithAbstraction A.Pattern
         | TooFewPatternsInWithClause
         | TooManyPatternsInWithClause
+        | PathAbstractionFailed (Abs Type)
         | FieldOutsideRecord
         | ModuleArityMismatch A.ModuleName Telescope (Either (List1 (NamedArg A.Expr)) Args)
         | GeneralizeCyclicDependency

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -125,11 +125,11 @@ splitTelForWith delta t vtys = let
 -- Each @EqualityType@, coming from a @rewrite@, will turn into 2 abstractions.
 
 withFunctionType
-  :: Telescope                          -- ^ @Δ₁@                        context for types of with types.
+  :: Telescope                          -- ^ @Δ₁@                        context for types of with-expressions.
   -> List1 (Arg (Term, EqualityView))   -- ^ @Δ₁,Δ₂ ⊢ vs : raise Δ₂ as@  with and rewrite-expressions and their type.
   -> Telescope                          -- ^ @Δ₁ ⊢ Δ₂@                   context extension to type with-expressions.
   -> Type                               -- ^ @Δ₁,Δ₂ ⊢ b@                 type of rhs.
-  -> Boundary                           -- ^ @Δ₁,Δ₂ ⊢ [(i,(u0,u1))] : b  boundary.
+  -> Boundary                           -- ^ @Δ₁,Δ₂ ⊢ [(i,(u0,u1))] : b@ boundary of rhs.
   -> TCM (Type, (Nat1, Nat))
     -- ^ @Δ₁ → wtel → Δ₂′ → b′@ such that
     --     @[vs/wtel]wtel = as@ and
@@ -153,7 +153,7 @@ withFunctionType delta1 vtys delta2 b bndry = addContext delta1 $ do
 
   vtys <- etaContract =<< normalise vtys
 
-  -- wd2db = wtel → [vs : as] (Δ₂ → B)
+  -- wd2b = wtel → [vs : as] (Δ₂ → B)
   wd2b <- foldrM piAbstract d2b vtys
   dbg 30 "wΓ → Δ₂ → B" wd2b
 
@@ -165,7 +165,7 @@ withFunctionType delta1 vtys delta2 b bndry = addContext delta1 $ do
   -- select the boundary for "Δ₁" abstracting over "wΓ.Δ₂"
   let bndry' = Boundary [(i - sd2,(lams u0, lams u1)) | (i,(u0,u1)) <- theBoundary bndry, i >= sd2]
         where sd2 = size delta2
-              lams u = teleNoAbs wtel (abstract delta2 u)
+              lams = teleNoAbs wtel . abstract delta2
 
   d1wd2b <- telePiPath_ delta1 wd2b bndry'
 

--- a/test/Fail/Issue7803.agda
+++ b/test/Fail/Issue7803.agda
@@ -1,0 +1,21 @@
+-- Andreas, 2025-04-17, issue #7803, report and test case by Szumi Xie
+-- Regression introduced by #7539 which turned a generic error into an internal error.
+
+{-# OPTIONS --cubical #-}
+
+-- {-# OPTIONS -v tc.with.abstract:30 #-}
+-- {-# OPTIONS -v tc.tel.path:40 #-}
+
+open import Agda.Builtin.Cubical.Path
+
+p : Set ≡ Set
+p i with _
+... | _ = Set
+
+-- Expected error: [PathAbstractionFailed]
+-- Path abstraction failed for type _4 (i = i) → Set₁.
+-- The type may be non-fibrant or its sort depends on an interval variable
+-- when checking that the clause
+-- p i with _
+-- ... | _ = Set
+-- has type Set ≡ Set

--- a/test/Fail/Issue7803.err
+++ b/test/Fail/Issue7803.err
@@ -1,0 +1,7 @@
+Issue7803.agda:12.1-13.14: error: [PathAbstractionFailed]
+Path abstraction failed for type _4 (i = i) → Set₁.
+The type may be non-fibrant or its sort depends on an interval variable
+when checking that the clause
+p i with _
+... | _ = Set
+has type Set ≡ Set

--- a/test/Fail/Issue7811.agda
+++ b/test/Fail/Issue7811.agda
@@ -1,0 +1,22 @@
+-- Andreas, 2025-04-17, issue #7811
+-- Internal error in telePiPath.
+
+{-# OPTIONS --cubical #-}
+
+-- {-# OPTIONS -v tc.with.abstract:30 #-}
+-- {-# OPTIONS -v tc.tel.path:40 #-}
+
+open import Agda.Primitive
+open import Agda.Builtin.Cubical.Path
+
+p : Set ≡ Set
+p i with Set _
+... | _ = Set
+
+-- Expected error: [PathAbstractionFailed]
+-- Path abstraction failed for type Set (lsuc (_3 (i = i))) → Set₁.
+-- The type may be non-fibrant or its sort depends on an interval variable
+-- when checking that the clause
+-- p i with Set _
+-- ... | _ = Set
+-- has type Set ≡ Set

--- a/test/Fail/Issue7811.err
+++ b/test/Fail/Issue7811.err
@@ -1,0 +1,7 @@
+Issue7811.agda:13.1-14.14: error: [PathAbstractionFailed]
+Path abstraction failed for type Set (lsuc (_3 (i = i))) → Set₁.
+The type may be non-fibrant or its sort depends on an interval variable
+when checking that the clause
+p i with Set _
+... | _ = Set
+has type Set ≡ Set


### PR DESCRIPTION
Fix #7803 fix #7811: new error PathAbstractionFailed instead of crash.

Amends PR #7539; provides the reproducer demanded in #7226.
