### PR TITLE
Make data directory overridable, default to XDG_DATA_HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,12 @@ Installation
      the runtimes for the `JS` and `GHC` backends,
      and the emacs mode.
 
-     These will be written to `${AGDA_DIR}/share/${VERSION}`
+     These will be written to `${Agda_datadir}/${VERSION}`
      on the first invocation of `agda` or an invocation of
      `agda --setup`, `agda --emacs-mode setup`, or `agda --emacs-mode compile`.
-     Herein, `${VERSION}` is the Agda version and `${AGDA_DIR}`
-     the Agda application directory, on Unix-like systems
-     defaulting to `${HOME}/.config/agda` or `${HOME}/.agda`.
+     Herein, `${VERSION}` is the Agda version and `${Agda_datadir}`
+     the Agda data directory, on Unix-like systems
+     defaulting to `${HOME}/.local/share/agda`.
 
   The Cabal/Stack custom installation `Setup.hs` has been removed
   that previously generated the `.agdai` files for the builtin and primitive modules.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -27,7 +27,7 @@ but in the fixed order listed in the following:
      .. versionadded:: 2.8.0
 
      Extract Agda' data files (primitive library, emacs mode etc.)
-     to ``share/VERSION/`` under the (:envvar:`AGDA_DIR`)
+     to ``VERSION/`` under the (:envvar:`Agda_datadir`)
      where ``VERSION`` is the numeric version of Agda.
 
 .. option:: --version, -V
@@ -80,7 +80,8 @@ but in the fixed order listed in the following:
      Outputs the root of the directory structure holding Agda's data
      files such as core libraries, style files for the backends, etc.
 
-     Since 2.8.0, this is ``share/VERSION/`` under the (:envvar:`AGDA_DIR`).
+     Since 2.8.0, this is ``VERSION/`` under the (:envvar:`Agda_datadir`),
+     defaulting to ``agda/`` under (:envvar:`XDG_DATA_HOME`).
 
 .. option:: --emacs-mode={COMMAND}
 


### PR DESCRIPTION
See https://github.com/agda/agda/pull/7719#discussion_r2051751331. Since https://github.com/agda/agda/pull/7719, Agda distributes its data files itself, at runtime, in the user's home directory. While the intention was to make distribution easier by making the executable more self-contained, this has the opposite effect for declarative build systems like Nix, since the data files must be written to the store in order for Agda to be usable in further builds (e.g. for building libraries).

This PR makes it possible to override the location of the base data directory using the `Agda_datadir` environment variable as it was previously (see https://cabal.readthedocs.io/en/3.14/cabal-package-description-file.html#accessing-data-files-from-package-code). This keeps the Nix build working, as long as `Agda_datadir` is set correctly at installation time and in the runtime wrapper. The actual data directory is still `$Agda_datadir/VERSION`, and lock files are created in `$Agda_datadir`.

It also moves the default location of the `Agda_datadir` from `$AGDA_DIR/share` to `$XDG_DATA_HOME/agda` (by default `~/.local/share/agda`), so as not to pollute `XDG_CONFIG_HOME` with data files. This presumably makes the `test/helpers` change from https://github.com/agda/agda/pull/7719 unnecessary, but it doesn't hurt.