### PR TITLE
[ fix #7392 ] Ensure wildcards and variable instances are kept

### DIFF
--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -124,7 +124,7 @@ parseVariables f cxt asb ii rng ss = do
   -- Valid names to split on are pattern variables of the clause,
   -- plus as-bindings that refer to a variable.
   let clauseVars = zip clauseCxtNames (map var [0..]) ++
-                   map (\(AsB name v _ _) -> (name,v)) asb
+                   map (\(AsB name v _) -> (name,v)) asb
 
   -- We cannot split on module parameters or make them visible
   params <- moduleParamsToApply $ qnameModule f

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -585,8 +585,10 @@ bindAsPatterns (AsB x v a : asb) ret = do
 -- | Since with-abstraction can change the type of a variable, we have to
 --   recheck the stripped with patterns when checking a with function.
 recheckStrippedWithPattern :: ProblemEq -> TCM ()
-recheckStrippedWithPattern (ProblemEq p v a) = checkInternal v CmpLeq (unDom a)
-  `catchError` \_ -> typeError $ IllTypedPatternAfterWithAbstraction p
+recheckStrippedWithPattern (ProblemEq p v a)
+  | A.WildP{} <- p = return ()
+  | otherwise      = checkInternal v CmpLeq (unDom a)
+      `catchError` \_ -> typeError $ IllTypedPatternAfterWithAbstraction p
 
 -- | Result of checking the LHS of a clause.
 data LHSResult = LHSResult

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -194,7 +194,7 @@ updateProblemEqs eqs = do
     updates = concat <.> traverse update
 
     update :: ProblemEq -> TCM [ProblemEq]
-    update eq@(ProblemEq A.WildP{} _ _) = return []
+    update eq@(ProblemEq A.WildP{} _ _) = return [eq]
     update eq@(ProblemEq p@A.ProjP{} _ _) = typeError $ IllformedProjectionPatternAbstract p
     update eq@(ProblemEq p@(A.AsP info x p') v a) =
       (ProblemEq (A.VarP x) v a :) <$> update (ProblemEq p' v a)
@@ -575,12 +575,12 @@ computeLHSContext = go [] []
 -- | Bind as patterns
 bindAsPatterns :: [AsBinding] -> TCM a -> TCM a
 bindAsPatterns []                ret = ret
-bindAsPatterns (AsB x v a m : asb) ret = do
+bindAsPatterns (AsB x v a : asb) ret = do
   reportSDoc "tc.lhs.as" 10 $ "as pattern" <+> prettyTCM x <+>
     sep [ ":" <+> prettyTCM a
         , "=" <+> prettyTCM v
         ]
-  addLetBinding (setModality m defaultArgInfo) Inserted x v a $ bindAsPatterns asb ret
+  addLetBinding' Inserted x v a $ bindAsPatterns asb ret
 
 -- | Since with-abstraction can change the type of a variable, we have to
 --   recheck the stripped with patterns when checking a with function.

--- a/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Problem.hs
@@ -356,7 +356,7 @@ getUserVariableNames tel names = runWriter $
   where
     makeVar :: Dom Type -> Int -> Writer [AsBinding] (Maybe A.Name)
     makeVar a i =
-      case map fst $ sortOn ((== PVLocal) . snd) (IntMap.findWithDefault [] i names) of
+      case map fst $ sortOn ((== PVParam) . snd) (IntMap.findWithDefault [] i names) of
         [] -> return Nothing
         (z:zs) -> do
           tellAsBindings $

--- a/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
@@ -52,7 +52,7 @@ useNamesFromPattern ps tel = telFromList (zipWith ren ps telList ++ telRemaining
           | otherwise                  -> dom
 
 useNamesFromProblemEqs
-  :: forall m. PureTCM m
+  :: forall m. (PureTCM m, MonadFresh NameId m)
   => [ProblemEq] -> Telescope -> m Telescope
 useNamesFromProblemEqs eqs tel = addContext tel $ do
   names <- fst . getUserVariableNames tel . patternVariables <$> getLeftoverPatterns eqs

--- a/test/Succeed/Issue7392.agda
+++ b/test/Succeed/Issue7392.agda
@@ -1,0 +1,14 @@
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+it : {{Nat}} → Nat
+it {{x}} = x
+
+fails : {{x : Nat}} (y : Nat) → x ≡ suc y → Nat
+fails y refl = it
+
+failstoo : {{x : Nat}} (y : Nat) → x ≡ y → Nat
+failstoo {{x}} y refl = it
+
+failstree : (x : Nat) {{y : Nat}} → x ≡ y → Nat
+failstree x {{y}} refl = it


### PR DESCRIPTION
This fixes #7392 by always preserving variables and wildcards as let bindings if they are instances. This got a bit fiddlier that I'd like because we *don't* want to add a let binding when the variable or wildcard corresponds to a variable in the context that is already bound as an instance. To make up for the messiness, I also simplified some of the existing logic.