### PR TITLE
Force GHC to rebuild the VersionCommit module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,12 @@ install: install-bin setup-agda compile-emacs-mode setup-emacs-mode
 setup-agda:
 	$(AGDA_BIN) --setup
 
-.PHONY: ensure-hash-is-correct ## Ensure Agda's version contains the latest git commit hash.
+# GHC doesn't realise that the Template Haskell changes in the VersionCommit module
+# even if the source code does not. Simply touching the source is not enough to force
+# GHC to rebuild, so we remove the object file from the build directory.
+.PHONY: ensure-hash-is-correct
 ensure-hash-is-correct:
-	touch src/setup/Agda/VersionCommit.hs
+	rm -f $(BUILD_DIR)/build/Agda/VersionCommit.o
 
 .PHONY: copy-bins-with-suffix-% ## Copy binaries to local bin directory with suffix
 copy-bins-with-suffix-%:


### PR DESCRIPTION
GHC is too clever for its own good, so merely touching the VersionCommit source code is not (always?) enough to force a rebuild. Removing the object file does the trick though.