### PR TITLE
Fix issue 7537

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -224,13 +224,14 @@ checkDecl d = setCurrentRange d $ do
         checkingWhere <- asksTC envCheckingWhere
         solveSizeConstraints $ if checkingWhere /= NoWhere_ then DontDefaultToInfty else DefaultToInfty
         wakeupConstraints_   -- Size solver might have unblocked some constraints
-        theMutualChecks
 
         case d of
           A.Generalize{} -> pure ()
           _ -> do
             reportSLn "tc.decl" 20 $ "Freezing all open metas."
             void $ freezeMetas (openMetas metas)
+
+        theMutualChecks
 
     where
 

--- a/test/Fail/Issue5848.err
+++ b/test/Fail/Issue5848.err
@@ -2,6 +2,15 @@ Issue5848.agda:6.1-12: warning: -W[no]ConfluenceCheckingIncompleteBecauseOfMeta
 Confluence checking incomplete because the definition of l1
 contains unsolved metavariables.
 when checking the definition of l1
+error: [UnsolvedConstraints]
+Failed to solve the following constraints:
+  ?2 = ?3 (i = Agda.Primitive.Cubical.i1)
+    : ?0 Agda.Primitive.Cubical.i1
+    (blocked on any(_4, _5))
+  ?1 = ?3 (i = Agda.Primitive.Cubical.i0)
+    : ?0 Agda.Primitive.Cubical.i0
+    (blocked on any(_3, _5))
+
 Issue5848.agda:5.6-11: error: [UnsolvedMetaVariables]
 Unsolved metas at the following locations:
   Issue5848.agda:5.6-11

--- a/test/Succeed/Issue7537.agda
+++ b/test/Succeed/Issue7537.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2025-04-28, issue #7537, reported by Liang-Ting Chen
+-- Test case by Szumi Xie
+
+{-# OPTIONS --cubical #-}
+{-# OPTIONS --allow-unsolved-metas #-}
+
+open import Agda.Builtin.Cubical.Path
+
+data T : Set where
+  e : T
+  p : (x : T) → e ≡ x
+  q : e ≡ e
+
+f : T → T
+f e = {!!}
+f x = {!!}
+
+-- Used to diverge.
+-- Should succeed with unsolved metas.


### PR DESCRIPTION
- **Revert "Do final checks before freezing metas"**
  This reverts commit b5f667fd4b692cfe444c1d8539a4e41dc157a4b7 (https://github.com/agda/agda/pull/6569).
  
  Closes #7537.
  

- **Testcase for #7537**
  