### PR TITLE
Fix #7823: Compare number of arguments when matching on DISPLAY pragma

### DIFF
--- a/src/full/Agda/TypeChecking/DisplayForm.hs
+++ b/src/full/Agda/TypeChecking/DisplayForm.hs
@@ -170,7 +170,9 @@ class Match a where
   match :: MonadDisplayForm m => Window -> a -> a -> MaybeT m MatchResult
 
 instance Match a => Match [a] where
-  match n xs ys = unionsMatch =<< zipWithM (match n) xs ys
+  match n xs ys
+    | length xs == length ys = unionsMatch =<< zipWithM (match n) xs ys
+    | otherwise = mzero
 
 instance Match a => Match (Arg a) where
   match n p v = IntMap.map (setOrigin (getOrigin v)) <$> match n (unArg p) (unArg v)

--- a/test/Fail/Issue7823a.agda
+++ b/test/Fail/Issue7823a.agda
@@ -1,0 +1,15 @@
+data Nat : Set where
+  zero : Nat
+  suc : Nat → Nat
+
+postulate
+  P : {A : Set} → A → Set
+  A : Set
+
+{-# DISPLAY P (suc zero) = A #-}
+
+_ : P suc
+_ = zero
+
+-- was: Nat !=< A
+-- should be: Nat !=< P suc

--- a/test/Fail/Issue7823a.err
+++ b/test/Fail/Issue7823a.err
@@ -1,0 +1,3 @@
+Issue7823a.agda:12.5-9: error: [UnequalTerms]
+Nat !=< P suc
+when checking that the expression zero has type P suc

--- a/test/Fail/Issue7823b.agda
+++ b/test/Fail/Issue7823b.agda
@@ -1,0 +1,15 @@
+data Nat : Set where
+  zero : Nat
+  suc : Nat → Nat
+
+postulate
+  P : {A : Set} → A → Set
+  A : Set
+
+{-# DISPLAY P suc = A #-}
+
+_ : P (suc zero)
+_ = zero
+
+-- was: Nat !=< A
+-- should be: Nat !=< P (suc zero)

--- a/test/Fail/Issue7823b.err
+++ b/test/Fail/Issue7823b.err
@@ -1,0 +1,3 @@
+Issue7823b.agda:12.5-9: error: [UnequalTerms]
+Nat !=< P (suc zero)
+when checking that the expression zero has type P (suc zero)


### PR DESCRIPTION
Fixes #7823 by comparing the amount of arguments when matching on a DISPLAY pragma, so that it only matches if the number of arguments are equal.

In addition, eagerly insert nonvisible arguments for underapplied patterns when checking a DISPLAY pragma, so that e.g. the DISPLAY pragma of primTrustMe still works.
