### PR TITLE
Fix #7825 by using `droppedPars` instead of hand-knitted code

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Display.hs
+++ b/src/full/Agda/TypeChecking/Rules/Display.hs
@@ -48,23 +48,33 @@ type M = ExceptT String TCM
 -- a 'Proj' elimination or an 'Apply' elimination.
 data ProjOrApp = IsProj QName | IsApp Term
 
-patternsToTerms :: Telescope -> [NamedArg A.Pattern] -> (Int -> Elims -> M a) -> M a
-patternsToTerms EmptyTel [] ret = ret 0 []
-patternsToTerms EmptyTel (p : ps) ret =
-  patternToTerm (namedArg p) \n v ->
-  patternsToTerms EmptyTel ps \m vs -> ret (n + m) (inheritHiding p v : vs)
-patternsToTerms (ExtendTel a tel) ps ret
+var0 :: ProjOrApp
+var0 = IsApp (var 0)
+
+patternsToTerms0 :: [NamedArg A.Pattern] -> (Int -> Elims -> M a) -> M a
+patternsToTerms0 []       ret = ret 0 []
+patternsToTerms0 (p : ps) ret =
+  patternToTerm (namedArg p) \ n v ->
+  patternsToTerms0 ps \ m vs ->
+  ret (n + m) (inheritHiding p v : vs)
+
+{-# SPECIALIZE patternsToTerms :: ListTel -> [NamedArg A.Pattern] -> (Int -> Elims -> M a) -> M a #-}
+patternsToTerms :: (LensNamed dom, NameOf dom ~ NamedName, LensHiding dom)
+  => [dom] -> [NamedArg A.Pattern] -> (Int -> Elims -> M a) -> M a
+patternsToTerms []        ps ret = patternsToTerms0 ps ret
+patternsToTerms (a : tel) ps ret
   | shouldInsertArg =
-      bindWild $ patternsToTerms (unAbs tel) ps \n vs ->
-      ret (1 + n) (inheritHiding a (IsApp (Var 0 [])) : vs)
+      bindWild $ patternsToTerms tel ps \ n vs ->
+      ret (1 + n) (inheritHiding a var0 : vs)
   where
     shouldInsertArg = case ps of
       [] -> notVisible a
       p : ps -> not $ fromMaybe __IMPOSSIBLE__ $ fittingNamedArg p a
-patternsToTerms (ExtendTel a tel) [] ret = ret 0 []
-patternsToTerms (ExtendTel a tel) (p : ps) ret =
-    patternToTerm (namedArg p) \n v ->
-    patternsToTerms (unAbs tel) ps \m vs -> ret (n + m) (inheritHiding p v : vs)
+patternsToTerms (a : tel) [] ret = ret 0 []
+patternsToTerms (a : tel) (p : ps) ret =
+    patternToTerm (namedArg p) \ n v ->
+    patternsToTerms tel ps \ m vs ->
+    ret (n + m) (inheritHiding p v : vs)
 
 inheritHiding :: LensHiding a => a -> ProjOrApp -> Elim
 inheritHiding a (IsProj q) = Proj ProjSystem q
@@ -74,25 +84,24 @@ pappToTerm :: QName -> (Elims -> b) -> [NamedArg A.Pattern] -> (Int -> b -> M a)
 pappToTerm x f ps ret = do
   def <- getConstInfo x
   TelV tel _ <- telView $ defType def
-  let dropTel n = telFromList . drop n . telToList
-      pars = droppedPars def
-  patternsToTerms (dropTel pars tel) ps $ \ n vs -> ret n (f vs)
+  let pars = droppedPars def
+  patternsToTerms (drop pars $ telToList tel) ps \ n vs -> ret n (f vs)
 
 patternToTerm :: A.Pattern -> (Nat -> ProjOrApp -> M a) -> M a
 patternToTerm p ret =
   case p of
-    A.VarP A.BindName{unBind = x}   -> bindVar x $ ret 1 (IsApp (Var 0 []))
+    A.VarP A.BindName{unBind = x}   -> bindVar x $ ret 1 var0
     A.ConP _ cs ps
-      | Just c <- getUnambiguous cs -> pappToTerm c (Con (ConHead c IsData Inductive []) ConOCon) ps \n t -> ret n (IsApp t)
+      | Just c <- getUnambiguous cs -> pappToTerm c (Con (ConHead c IsData Inductive []) ConOCon) ps \ n t -> ret n (IsApp t)
       | otherwise                   -> ambigErr "constructor" cs
     A.ProjP _ _ ds
       | Just d <- getUnambiguous ds -> ret 0 $ IsProj d
       | otherwise                   -> ambigErr "projection" ds
     A.DefP _ fs ps
-      | Just f <- getUnambiguous fs -> pappToTerm f (Def f) ps \n t -> ret n (IsApp t)
+      | Just f <- getUnambiguous fs -> pappToTerm f (Def f) ps \ n t -> ret n (IsApp t)
       | otherwise                   -> ambigErr "DefP" fs
     A.LitP _ l                      -> ret 0 $ IsApp $ Lit l
-    A.WildP _                       -> bindWild $ ret 1 $ IsApp (Var 0 [])
+    A.WildP _                       -> bindWild $ ret 1 var0
     A.AsP{}                         -> failP "an @-pattern"
     A.DotP{}                        -> failP "a dot pattern"
     A.AbsurdP{}                     -> failP "an absurd pattern"

--- a/src/full/Agda/TypeChecking/Rules/Display.hs
+++ b/src/full/Agda/TypeChecking/Rules/Display.hs
@@ -75,13 +75,7 @@ pappToTerm x f ps ret = do
   def <- getConstInfo x
   TelV tel _ <- telView $ defType def
   let dropTel n = telFromList . drop n . telToList
-      pars =
-        case theDef def of
-          Constructor { conPars = p } -> p
-          Function { funProjection = Right Projection{projIndex = i} }
-            | i > 0 -> i - 1
-          _ -> 0
-
+      pars = droppedPars def
   patternsToTerms (dropTel pars tel) ps $ \ n vs -> ret n (f vs)
 
 patternToTerm :: A.Pattern -> (Nat -> ProjOrApp -> M a) -> M a

--- a/test/Fail/Issue7825.agda
+++ b/test/Fail/Issue7825.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2025-04-29, issue #7825
+-- DISPLAY forms for irrelevant projections should not drop parameters
+-- as those are only absent in relevant projections.
+
+{-# OPTIONS --irrelevant-projections #-}
+{-# OPTIONS --show-irrelevant #-}
+
+record Squash (A : Set) : Set where
+  field .theSquashed : A
+
+postulate
+  IRRELEVANT : Set
+
+{-# DISPLAY Squash.theSquashed _ = IRRELEVANT #-}
+
+postulate
+  P : {A : Set} → .A → Set
+
+_ : P (λ r → Squash.theSquashed r)
+_ = Set
+
+-- expected error: [UnequalTerms]
+-- Set₁ !=< P (λ r → IRRELEVANT)
+-- when checking that the expression Set has type P (λ r → IRRELEVANT)

--- a/test/Fail/Issue7825.err
+++ b/test/Fail/Issue7825.err
@@ -1,0 +1,3 @@
+Issue7825.agda:20.5-8: error: [UnequalTerms]
+Set₁ !=< P (λ r → IRRELEVANT)
+when checking that the expression Set has type P (λ r → IRRELEVANT)


### PR DESCRIPTION
Closes #7825.

I also added a refactoring of `patternsToTerms` here.