### PR TITLE
Refactor Quote: use droppedPars

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -1385,7 +1385,7 @@ droppedPars d = case theDef d of
     Constructor{conPars = n} -> n
     Primitive{}              -> 0
     PrimitiveSort{}          -> 0
-    AbstractDefn{}           -> __IMPOSSIBLE__
+    AbstractDefn{}           -> 0 -- not impossible when quoting, PR #7828
 
 -- | Is it the name of a record projection?
 {-# SPECIALIZE isProjection :: QName -> TCM (Maybe Projection) #-}

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -315,10 +315,7 @@ quotingKit = do
       defParameters def True  = []
       defParameters def False = map par hiding
         where
-          np = case theDef def of
-                 Constructor{ conPars = np }         -> np
-                 Function{ funProjection = Right p } -> projIndex p - 1
-                 _                                   -> 0
+          np         = droppedPars def
           TelV tel _ = telView' (defType def)
           hiding     = take np $ telToList tel
           par d      = arg !@ quoteArgInfo (domInfo d)

--- a/test/Succeed/QuoteAbstract.agda
+++ b/test/Succeed/QuoteAbstract.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2025-04-29, PR #7828
+-- In droppedPars, AbstractDefn isn't __IMPOSSIBLE__
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Reflection
+
+macro
+  doQuote : ∀ {ℓ} {A : Set ℓ} → A → Term → TC _
+  doQuote x hole = bindTC (quoteTC x) (λ qx → bindTC (quoteTC qx) (unify hole))
+
+abstract
+  A : Set₁
+  A = Set
+
+testQuote₁ : doQuote A ≡ doQuote A
+testQuote₁ = refl
+
+-- Used to trigger internal error with PR #7828.
+-- Should succeed.


### PR DESCRIPTION
Refactor Quote: use `droppedPars`.
The original code could be buggy with irrelevant projections, but I lack the imagination for a test case now.
