### PR TITLE
Disregard qualified names when assigning clauses to functions in the nicifier

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -812,9 +812,9 @@ niceDeclarations fixs ds = do
     couldBeCallOf :: Maybe Fixity' -> Name -> Pattern -> Bool
     couldBeCallOf mFixity x p =
       let
-      pns        = patternNames p
+      pns        = patternQNames p
       xStrings   = nameStringParts x
-      patStrings = concatMap nameStringParts pns
+      patStrings = concatMap nameStringParts $ mapMaybe isUnqualified pns
       in
 --          trace ("x = " ++ prettyShow x) $
 --          trace ("pns = " ++ show pns) $
@@ -823,7 +823,7 @@ niceDeclarations fixs ds = do
 --          trace ("mFixity = " ++ show mFixity) $
       case (listToMaybe pns, mFixity) of
         -- first identifier in the patterns is the fun.symbol?
-        (Just y, _) | x == y -> True -- trace ("couldBe since y = " ++ prettyShow y) $ True
+        (Just y, _) | Just x == isUnqualified y -> True -- trace ("couldBe since y = " ++ prettyShow y) $ True
         -- are the parts of x contained in p
         _ | xStrings `List.isSubsequenceOf` patStrings -> True
         -- looking for a mixfix fun.symb

--- a/test/Succeed/QualifiedPatternInMutualBlock.agda
+++ b/test/Succeed/QualifiedPatternInMutualBlock.agda
@@ -1,0 +1,18 @@
+module QualifiedPatternInMutualBlock where
+
+module M where
+  data Unit : Set where
+    tt : Unit
+
+tt : M.Unit
+
+f : M.Unit → M.Unit
+f M.tt = tt
+
+_*_ : M.Unit → M.Unit → M.Unit
+M.tt * x = x
+
+tt = M.tt
+
+-- WAS: error: [Syntax.AmbiguousFunClauses]
+-- More than one matching type signature for left hand side


### PR DESCRIPTION
The following code used to be rejected:
```agda
module Example where

module M where
  data Unit : Set where
    tt : Unit

tt : M.Unit

f : M.Unit → M.Unit
f M.tt = tt

tt = M.tt
```
```
Example.agda:10.1-7: error: [Syntax.AmbiguousFunClauses]
More than one matching type signature for left hand side f M.tt it
could belong to any of:
tt (at Example.agda:7.1-3)
f (at Example.agda:9.1-2)
```