### PR TITLE
fix #7795: Use occurrences from type for defs

### DIFF
--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -526,15 +526,6 @@ instance ComputeOccurrences Int where
 computeOccurrences :: QName -> TCM (Map Item Integer)
 computeOccurrences q = flatten <$> computeOccurrences' q
 
--- | Returns the occurences given explicitely as polarity annotations in the function type
-getOccurrencesFromType :: Type -> TCM [Occurrence]
-getOccurrencesFromType t = do
-  polarityEnabled <- optPolarity <$> pragmaOptions
-  if polarityEnabled then do
-    telList <- telToList . theTel <$> telView t
-    return $ modalPolarityToOccurrence . modPolarityAnn . getModalPolarity <$> telList
-  else return []
-
 -- | Computes the occurrences in the given definition.
 computeOccurrences' :: QName -> TCM OccurrencesBuilder
 computeOccurrences' q = inConcreteOrAbstractMode q $ \ def -> do

--- a/test/Succeed/Issue7795.agda
+++ b/test/Succeed/Issue7795.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --polarity #-}
+module Issue7795 where
+
+data Box (@++ A : Set) : Set where
+  [_] : A → Box A
+
+opaque
+  Box′ : @++ Set → Set
+  Box′ A = Box A
+
+data D : Set where
+  c : Box′ D → D


### PR DESCRIPTION
Fixes #7795. As a form of caching if the polarity checker has run we do not consult the type again; this relies on the invariant that the polarity checker will fill in the same occurrences as stated in the type.