### PR TITLE
make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,11 +119,14 @@ CABAL_CONFIGURE_OPTS = $(SLOW_CABAL_INSTALL_OPTS) \
 ##############################################################################
 ## Installation (via stack if stack.yaml is present)
 
-.PHONY: default
-default: install-bin
-
-.PHONY: install ## Install Agda, test suites, and Emacs mode
-install: install-bin setup-agda compile-emacs-mode setup-emacs-mode
+.PHONY: install ## Install Agda with standard flags, compile and setup Emacs mode
+install:
+ifdef HAS_STACK
+	$(STACK) install $(STACK_INSTALL_OPTS)
+else
+	$(CABAL) install $(CABAL_INSTALL_OPTS)
+endif
+	agda --setup --emacs-mode compile --emacs-mode setup
 
 .PHONY: setup-agda
 setup-agda:

--- a/stack-9.10.1.yaml
+++ b/stack-9.10.1.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2025-03-15
+resolver: nightly-2025-05-01
 compiler: ghc-9.10.1
 compiler-check: match-exact
 

--- a/stack-9.12.2.yaml
+++ b/stack-9.12.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2025-03-15
+resolver: nightly-2025-05-01
 compiler: ghc-9.12.2
 compiler-check: match-exact
 

--- a/stack-9.8.4.yaml
+++ b/stack-9.8.4.yaml
@@ -1,4 +1,4 @@
-resolver: lts-23.14
+resolver: lts-23.19
 compiler: ghc-9.8.4
 compiler-check: match-exact
 


### PR DESCRIPTION
- **Bump stack*.yaml**
  

- **Makefile: make install is now user goal**
  `make install` will now do a default Cabal or (with stack.yaml) Stack
  install with standard options:
  
  - enable-cluster-counting
  - no special optimization
  - no debug printing
  
  It will then proceed to setup the emacs mode.
  
  Closes #7598
  