### PR TITLE
Refactor: need not pass in a ModuleName to scopeCheckImport

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -341,14 +341,14 @@ addImportedThings isig metas ibuiltin patsyns display userwarn
   stOpaqueBlocks         `modifyTCLens` \ imp -> imp `Map.union` oblock
   stOpaqueIds            `modifyTCLens` \ imp -> imp `Map.union` oid
 
--- | Scope checks the given module. A proper version of the module
--- name (with correct definition sites) is returned.
-
+-- | Scope checks the given module, generating an interface or retrieving an existing one.
+--   Returns the module name and exported scope from the interface.
+--
 scopeCheckImport ::
-  TopLevelModuleName -> ModuleName ->
-  TCM (ModuleName, Map ModuleName Scope)
-scopeCheckImport top x = do
-    reportSLn "import.scope" 15 $ "Scope checking " ++ prettyShow x
+     TopLevelModuleName
+  -> TCM (ModuleName, Map ModuleName Scope)
+scopeCheckImport top = do
+    reportSLn "import.scope" 15 $ "Scope checking " ++ prettyShow top
     verboseS "import.scope" 30 $ do
       visited <- prettyShow <$> getPrettyVisitedModules
       reportSLn "import.scope" 30 $ "  visited: " ++ visited
@@ -362,7 +362,7 @@ scopeCheckImport top x = do
 
     -- let s = publicModules $ iInsideScope i
     let s = iScope i
-    return (iModuleName i `withRangesOfQ` mnameToConcrete x, s)
+    return (iModuleName i, s)
 
 -- | If the module has already been visited (without warnings), then
 -- its interface is returned directly. Otherwise the computation is

--- a/src/full/Agda/Interaction/Imports.hs-boot
+++ b/src/full/Agda/Interaction/Imports.hs-boot
@@ -2,13 +2,11 @@
 
 module Agda.Interaction.Imports where
 
-import Data.Map                     ( Map )
+import Data.Map                       ( Map )
 
-import Agda.Syntax.Abstract.Name    ( ModuleName )
-import Agda.Syntax.Scope.Base       ( Scope )
-import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
-import Agda.TypeChecking.Monad.Base ( TCM )
+import Agda.Syntax.Abstract.Name      ( ModuleName )
+import Agda.Syntax.Scope.Base         ( Scope )
+import Agda.Syntax.TopLevelModuleName ( TopLevelModuleName )
+import Agda.TypeChecking.Monad.Base   ( TCM )
 
-scopeCheckImport ::
-  TopLevelModuleName -> ModuleName ->
-  TCM (ModuleName, Map ModuleName Scope)
+scopeCheckImport :: TopLevelModuleName -> TCM (ModuleName, Map ModuleName Scope)

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2097,13 +2097,12 @@ instance ToAbstract NiceDeclaration where
       -- the imported module.
       (m, i) <- withCurrentModule noModuleName $
                 withTopLevelModule top $ do
-        m <- toAbstract $ NewModuleQName x  -- (No longer erases the contents of @m@.)
         printScope "import" 30 "before import:"
-        (m, i) <- scopeCheckImport top m
+        (m0, i) <- scopeCheckImport top
         printScope "import" 30 $ "scope checked import: " ++ prettyShow i
         -- We don't want the top scope of the imported module (things happening
         -- before the module declaration)
-        return (m, Map.delete noModuleName i)
+        return (m0 `withRangesOfQ` x, Map.delete noModuleName i)
 
       -- Bind the desired module name to the right abstract name.
       (name, theAsSymbol, theAsName) <- case as of

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -967,7 +967,7 @@ stCurrentModule f s =
 -- -- | Note that the lens is \"strict\".
 
 -- stCurrentModule :: Lens' TCState (Maybe (ModuleName, TopLevelModuleName))
--- stCurrentModule = lensPostScopeState . lensCurrentModule . fmap (fmap \ (!m, !top) -> Just (m, top))
+-- stCurrentModule = lensPostScopeState . lensCurrentModule . fmap (fmap \ (!m, !top) -> (m, top))
 
 stInstanceDefs :: Lens' TCState TempInstanceTable
 stInstanceDefs f s =


### PR DESCRIPTION
All it used from the passed ModuleName was its Range.
The interface is clearer if we do not pass in this ModuleName.
