### PR TITLE
Modality warnings for constructors and fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ Pragmas and options
 Warnings
 --------
 
+* New deadcode warnings `FixingCohesion`, `FixingPolarity` and `FixingRelevance`
+  when wrong user-written attribute was corrected automatically by Agda.
+
 * New deadcode warning `InvalidDisplayForm` instead of hard error
   when a display form is illegal (and thus ignored).
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1412,6 +1412,14 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Face constraint patterns that are given as named arguments.
 
+.. option:: FixingCohesion
+
+     Invalid cohesion annotations, automatically corrected.
+
+.. option:: FixingPolarity
+
+     Invalid polarity annotations, automatically corrected.
+
 .. option:: FixingRelevance
 
      Invalid relevance annotations, automatically corrected.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -444,6 +444,10 @@ warningHighlighting' b w = case tcWarning w of
   --   where r = getRange q
   FixingRelevance _ q _      -> if null r then cosmeticProblemHighlighting w else deadcodeHighlighting r
     where r = getRange q
+  FixingCohesion _ q _       -> if null r then cosmeticProblemHighlighting w else deadcodeHighlighting r
+    where r = getRange q
+  FixingPolarity _ q _       -> if null r then cosmeticProblemHighlighting w else deadcodeHighlighting r
+    where r = getRange q
   IllformedAsClause{}        -> deadcodeHighlighting w
   UselessPragma r _          -> deadcodeHighlighting r
   UselessPublic{}            -> deadcodeHighlighting w

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -166,7 +166,6 @@ data ErrorName
   | IdiomBracketError_
   | InvalidBuiltin_
   | InvalidDottedExpression_
-  | InvalidFieldModality_
   | IllTypedPatternAfterWithAbstraction_
   | IllegalDeclarationBeforeTopLevelModule_
   | IllegalDeclarationInDataDefinition_

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -272,6 +272,8 @@ data WarningName
   | InlineNoExactSplit_
   | DeprecationWarning_
   | DuplicateUsing_
+  | FixingCohesion_
+  | FixingPolarity_
   | FixingRelevance_
   -- TODO: linearity
   -- -- | FixingQuantity_
@@ -509,7 +511,9 @@ warningNameDescription = \case
   DeprecationWarning_              -> "Deprecated features."
   -- TODO: linearity
   -- FixingQuantity_                  -> "Correcting invalid user-written quantity."
-  FixingRelevance_                 -> "Correcting invalid user-written relevance."
+  FixingRelevance_                 -> "Correcting invalid user-written relevance attribute."
+  FixingCohesion_                  -> "Correcting invalid user-written cohesion attribute."
+  FixingPolarity_                  -> "Correcting invalid user-written polarity attribute."
   InvalidCharacterLiteral_         -> "Illegal character literals."
   UselessPragma_                   -> "Pragmas that get ignored."
   IllformedAsClause_               -> "Illformed `as'-clauses in `import' statements."

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -2275,13 +2275,17 @@ unitPolarity = withStandardLock StrictlyPositive
 negativePolarity :: PolarityModality
 negativePolarity = withStandardLock Negative
 
+-- | Alias for 'Mixed' polarity.
+mixedPolarity :: PolarityModality
+mixedPolarity = withStandardLock MixedPolarity
+
 -- | Absorptive element under addition.
 topPolarity :: PolarityModality
-topPolarity = withStandardLock MixedPolarity
+topPolarity = mixedPolarity
 
 -- | Default used when not caring about polarity
 defaultPolarity :: PolarityModality
-defaultPolarity = withStandardLock MixedPolarity
+defaultPolarity = mixedPolarity
 
 instance Null PolarityModality where
   empty = defaultPolarity

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -2267,11 +2267,11 @@ addPolarity (PolarityModality p o l) (PolarityModality p' o' l') =
 zeroPolarity :: PolarityModality
 zeroPolarity = withStandardLock UnusedPolarity
 
--- | Identity under composition
+-- | Identity under composition.
 unitPolarity :: PolarityModality
 unitPolarity = withStandardLock StrictlyPositive
 
--- | Alias for Negative polarity
+-- | Alias for 'Negative' polarity.
 negativePolarity :: PolarityModality
 negativePolarity = withStandardLock Negative
 

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -379,7 +379,8 @@ instance Pretty Declaration where
           ]
     FieldSig inst tac x (Arg i e) ->
       mkInst inst $ mkOverlap i $
-      prettyRelevance i $ prettyHiding i id $ prettyCohesion i $ prettyQuantity i $ prettyPolarity i $
+      -- We print relevance before hiding, need to clear it before printing the rest of the attributes with TypeSig.
+      prettyRelevance i $ prettyHiding i id $
       pretty $ TypeSig (setRelevance relevant i) tac x e
       where
         mkInst (InstanceDef _) d = sep [ "instance", nest 2 d ]
@@ -670,4 +671,3 @@ prettyOpApp asp q es = merge [] $ prOp ms xs $ List1.toList es
     mergeLeft d before = case before of
       []     -> (d,      [])
       b : bs -> (b <> d, bs)
-

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -94,7 +94,7 @@ import Agda.Utils.CallStack ( HasCallStack, withCurrentCallStack )
 import Agda.Utils.Char
 import Agda.Utils.Either
 import Agda.Utils.FileName
-import Agda.Utils.Function ( applyWhen, applyWhenM, applyUnless )
+import Agda.Utils.Function ( applyWhen, applyWhenJust, applyWhenM, applyUnless )
 import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List
@@ -1783,7 +1783,7 @@ instance ToAbstract NiceDeclaration where
     -- We record in the environment whether we are scope checking an
     -- abstract definition.  This way, we can propagate this attribute
     -- the extended lambdas.
-    caseMaybe (niceHasAbstract d) id (\ a -> localTC $ \ e -> e { envAbstractMode = aDefToMode a }) $
+    applyWhenJust (niceHasAbstract d) (\ a -> localTC $ \ e -> e { envAbstractMode = aDefToMode a }) $
     case d of
 
   -- Axiom (actual postulate)

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1639,9 +1639,6 @@ instance PrettyTCM TypeError where
         _ -> prettyTCM t <+> "is not usable at the required modality"
          <+> attributesForModality mod
 
-    InvalidFieldModality coh -> fsep $
-      pwords "Cannot have record fields with modality" ++ [pretty coh]
-
     CubicalCompilationNotSupported cubical -> fsep $ concat
       [ pwords $ "Compilation of code that uses"
       , [ text $ cubicalOptionString cubical ]

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -2144,8 +2144,7 @@ instance Verbalize Hiding where
   verbalize = hidingToString
 
 instance Verbalize Relevance where
-  verbalize r =
-    case r of
+  verbalize = \case
       Relevant        {} -> "relevant"
       Irrelevant      {} -> "irrelevant"
       ShapeIrrelevant {} -> "shape-irrelevant"
@@ -2157,15 +2156,13 @@ instance Verbalize Quantity where
     Quantityω{} -> "unrestricted"
 
 instance Verbalize Cohesion where
-  verbalize r =
-    case r of
+  verbalize = \case
       Flat       -> "flat"
       Continuous -> "continuous"
       Squash     -> "squashed"
 
 instance Verbalize ModalPolarity where
-  verbalize r =
-    case r of
+  verbalize = \case
       UnusedPolarity -> "unused"
       StrictlyPositive -> "strictly positive"
       Positive -> "positive"

--- a/src/full/Agda/TypeChecking/Errors.hs-boot
+++ b/src/full/Agda/TypeChecking/Errors.hs-boot
@@ -2,7 +2,7 @@
 
 module Agda.TypeChecking.Errors where
 
-import Agda.Syntax.Common (Relevance)
+import Agda.Syntax.Common (Cohesion, PolarityModality, Relevance)
 import Agda.Syntax.Abstract.Name
 
 import Agda.TypeChecking.Monad.Base
@@ -21,4 +21,6 @@ topLevelModuleDropper :: (MonadDebug m, MonadTCEnv m, ReadTCState m) => m (QName
 class Verbalize a where
   verbalize :: a -> String
 
-instance Verbalize Relevance where
+instance Verbalize Relevance
+instance Verbalize Cohesion
+instance Verbalize PolarityModality

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -121,7 +121,6 @@ typeErrorName = \case
   IdiomBracketError                                          {} -> IdiomBracketError_
   InvalidBuiltin                                             {} -> InvalidBuiltin_
   InvalidDottedExpression                                    {} -> InvalidDottedExpression_
-  InvalidFieldModality                                       {} -> InvalidFieldModality_
   IllTypedPatternAfterWithAbstraction                        {} -> IllTypedPatternAfterWithAbstraction_
   IllegalDeclarationBeforeTopLevelModule                     {} -> IllegalDeclarationBeforeTopLevelModule_
   IllegalDeclarationInDataDefinition                         {} -> IllegalDeclarationInDataDefinition_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5211,7 +5211,6 @@ data TypeError
         | SortCannotDependOnItsIndex QName Type
     -- Modality errors
         | UnusableAtModality WhyCheckModality Modality Term
-        | InvalidFieldModality Cohesion
     -- Coverage errors
 -- UNUSED:        | IncompletePatternMatching Term [Elim] -- can only happen if coverage checking is switched off
         | SplitError SplitError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4533,6 +4533,10 @@ data Warning
   -- --   -- ^ Auto-correcting quantity pertaining to 'String' /from/ /to/.
   | FixingRelevance String Relevance Relevance
     -- ^ Auto-correcting relevance pertaining to 'String' /from/ /to/.
+  | FixingCohesion String Cohesion Cohesion
+    -- ^ Auto-correcting cohesion pertaining to 'String' /from/ /to/.
+  | FixingPolarity String PolarityModality PolarityModality
+    -- ^ Auto-correcting polarity pertaining to 'String' /from/ /to/.
   | IllformedAsClause String
     -- ^ If the user wrote something other than an unqualified name
     --   in the @as@ clause of an @import@ statement.
@@ -4738,6 +4742,8 @@ warningName = \case
   -- TODO: linearity
   -- FixingQuantity{}             -> FixingQuantity_
   FixingRelevance{}            -> FixingRelevance_
+  FixingCohesion{}             -> FixingCohesion_
+  FixingPolarity{}             -> FixingPolarity_
   IllformedAsClause{}          -> IllformedAsClause_
   WrongInstanceDeclaration{}   -> WrongInstanceDeclaration_
   InstanceWithExplicitArg{}    -> InstanceWithExplicitArg_

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -233,11 +233,23 @@ prettyWarning = \case
     -- FixingQuantity s q q' -> fsep $ concat
     --   [ pwords "Replacing illegal quantity", [ pretty q ], pwords s, [ "by", pretty q' ] ]
 
-    FixingRelevance s r r' ->  fsep $ concat
+    FixingRelevance s r r' -> fsep $ concat
       [ pwords "Replacing illegal relevance", [ p r ]
       , pwords s, [ "by", p r' ]
       ]
       where p r = text $ "`" ++ verbalize r ++ "'"
+
+    FixingCohesion s c c' -> fsep $ concat
+      [ pwords "Replacing illegal cohesion", [ p c ]
+      , pwords s, [ "by", p c' ]
+      ]
+      where p c = text $ "`" ++ verbalize c ++ "'"
+
+    FixingPolarity s q q' ->  fsep $ concat
+      [ pwords "Replacing illegal polarity", [ p q ]
+      , pwords s, [ "by", p q' ]
+      ]
+      where p q = text $ "`" ++ verbalize q ++ "'"
 
     IllformedAsClause s -> fsep . pwords $
       "`as' must be followed by an identifier" ++ s

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -18,7 +18,6 @@ import Agda.Syntax.Internal
 import Agda.Syntax.Position
 import qualified Agda.Syntax.Info as Info
 
-import Agda.TypeChecking.Errors
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Primitive
 import Agda.TypeChecking.Substitute
@@ -47,7 +46,6 @@ import Agda.Utils.List (headWithDefault)
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import Agda.Utils.POMonoid
 import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Utils.Size
 
@@ -617,23 +615,26 @@ checkRecordProjections m r hasNamedCon con tel ftel fs = do
           , "coh   =" <+> (text . show) (getCohesion ai)
           ]
 
-      -- Cohesion check:
-      -- For a field `@c π : A` we would create a projection `π : .., (@(c^-1) r : R as) -> A`
-      -- So we want to check that `@.., (c^-1 . c) x : A |- x : A` is allowed by the modalities.
-      --
-      -- Alternatively we could create a projection `.. |- π r :c A`
-      -- but that would require support for a `t :c A` judgment.
-      if hasLeftAdjoint (UnderComposition (getCohesion ai))
-        then unless (getCohesion ai == Continuous)
-                    -- Atm, only Continuous has a left adjoint.
-                    -- Andrea TODO: properly update the context/type of the projection when we add Sharp
-                    __IMPOSSIBLE__
-        else typeError $ InvalidFieldModality (getCohesion ai)
+      unless (getCohesion ai == Continuous) __IMPOSSIBLE__
+      -- Andreas, 2025-05-03, moved check to ConcreteToAbstract.checkFieldArgInfo.
+      -- -- Cohesion check:
+      -- -- For a field `@c π : A` we would create a projection `π : .., (@(c^-1) r : R as) -> A`
+      -- -- So we want to check that `@.., (c^-1 . c) x : A |- x : A` is allowed by the modalities.
+      -- --
+      -- -- Alternatively we could create a projection `.. |- π r :c A`
+      -- -- but that would require support for a `t :c A` judgment.
+      -- if hasLeftAdjoint (UnderComposition (getCohesion ai))
+      --   then unless (getCohesion ai == Continuous)
+      --               -- Atm, only Continuous has a left adjoint.
+      --               -- Andrea TODO: properly update the context/type of the projection when we add Sharp
+      --               __IMPOSSIBLE__
+      --   else typeError $ InvalidFieldModality (getCohesion ai)
 
       -- For now, we forbid any polarity annotations on record fields (we would need to do as above,
       -- and eta-equality or projection existence would be in danger).
       unless (getModalPolarity ai `samePolarity` (withStandardLock MixedPolarity)) $
-        genericError $ "Cannot have record field with " ++ verbalize (getModalPolarity ai) ++ " polarity"
+        -- Andreas, 2025-05-03, already checked in ConcreteToAbstract.checkFieldArgInfo
+        __IMPOSSIBLE__
 
       -- The telescope tel includes the variable of record type as last one
       -- e.g. for cartesion product it is

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -625,6 +625,7 @@ checkRecordProjections m r hasNamedCon con tel ftel fs = do
       -- but that would require support for a `t :c A` judgment.
       if hasLeftAdjoint (UnderComposition (getCohesion ai))
         then unless (getCohesion ai == Continuous)
+                    -- Atm, only Continuous has a left adjoint.
                     -- Andrea TODO: properly update the context/type of the projection when we add Sharp
                     __IMPOSSIBLE__
         else typeError $ InvalidFieldModality (getCohesion ai)

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20250405 * 10 + 0
+currentInterfaceVersion = 20250503 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -137,6 +137,8 @@ instance EmbPrj Warning where
     AbstractInLetBindings                       -> __IMPOSSIBLE__
     TopLevelPolarity a b                        -> __IMPOSSIBLE__
     TooManyPolarities a b                       -> icodeN 71 TooManyPolarities a b
+    FixingCohesion a b c                        -> icodeN 72 FixingCohesion a b c
+    FixingPolarity a b c                        -> icodeN 73 FixingPolarity a b c
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -212,6 +214,8 @@ instance EmbPrj Warning where
     [69, a, b, c]        -> valuN FixingRelevance a b c
     [70, a]              -> valuN UnusedVariablesInDisplayForm a
     [71, a, b]           -> valuN TooManyPolarities a b
+    [72, a, b, c]        -> valuN FixingCohesion a b c
+    [73, a, b, c]        -> valuN FixingPolarity a b c
     _ -> malformed
 
 instance EmbPrj UselessPublicReason

--- a/src/full/Agda/Utils/Applicative.hs
+++ b/src/full/Agda/Utils/Applicative.hs
@@ -6,12 +6,16 @@ module Agda.Utils.Applicative
        , foldA
        , foldMapA
        , forA
+       , liftA4
        )
        where
 
 import Control.Applicative
 import Data.Monoid ( Alt(..) )
 import Data.Traversable ( for )
+
+liftA4 :: Applicative f => (a -> b -> c -> d -> e) -> f a -> f b -> f c -> f d -> f e
+liftA4 f a b c d = liftA3 f a b c <*> d
 
 -- | Better name for 'for'.
 forA :: (Traversable t, Applicative f) => t a -> (a -> f b) -> f (t b)

--- a/test/Fail/InvalidFieldModality.agda
+++ b/test/Fail/InvalidFieldModality.agda
@@ -1,6 +1,0 @@
-{-# OPTIONS --cohesion #-}
-open import Agda.Builtin.Nat
-
-record Foo : Set where
-  field
-    @♭ foo : Nat

--- a/test/Fail/InvalidFieldModality.err
+++ b/test/Fail/InvalidFieldModality.err
@@ -1,3 +1,0 @@
-InvalidFieldModality.agda:6.8-17: error: [InvalidFieldModality]
-Cannot have record fields with modality @♭
-when checking the projection foo : Nat

--- a/test/Succeed/InvalidFieldModality.agda
+++ b/test/Succeed/InvalidFieldModality.agda
@@ -1,0 +1,13 @@
+-- Andreas, 2025-05-03, warn about ignored field attributes.
+
+{-# OPTIONS --cohesion #-}
+{-# OPTIONS --polarity #-}
+
+record R : Set₁ where
+  field
+    @♭      f1 : Set -- warning FixingCohesion
+    @-      f2 : Set -- warning FixingPolarity
+    @+      f3 : Set -- warning FixingPolarity
+    @++     f4 : Set -- warning FixingPolarity
+    @unused f5 : Set -- warning FixingPolarity
+    @mixed  ok : Set -- no warning!

--- a/test/Succeed/InvalidFieldModality.warn
+++ b/test/Succeed/InvalidFieldModality.warn
@@ -1,0 +1,121 @@
+InvalidFieldModality.agda:8.13-21: warning: -W[no]FixingCohesion
+Replacing illegal cohesion 'flat' of field by 'continuous'
+when scope checking the declaration
+  record R where
+    field
+      @♭ f1 : Set
+      @- f2 : Set
+      @+ f3 : Set
+      @++ f4 : Set
+      @unused f5 : Set
+      ok : Set
+
+InvalidFieldModality.agda:9.13-21: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'negative' of field by 'mixed'
+when scope checking the declaration
+  record R where
+    field
+      @♭ f1 : Set
+      @- f2 : Set
+      @+ f3 : Set
+      @++ f4 : Set
+      @unused f5 : Set
+      ok : Set
+
+InvalidFieldModality.agda:10.13-21: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'positive' of field by 'mixed'
+when scope checking the declaration
+  record R where
+    field
+      @♭ f1 : Set
+      @- f2 : Set
+      @+ f3 : Set
+      @++ f4 : Set
+      @unused f5 : Set
+      ok : Set
+
+InvalidFieldModality.agda:11.13-21: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'strictly positive' of field by 'mixed'
+when scope checking the declaration
+  record R where
+    field
+      @♭ f1 : Set
+      @- f2 : Set
+      @+ f3 : Set
+      @++ f4 : Set
+      @unused f5 : Set
+      ok : Set
+
+InvalidFieldModality.agda:12.13-21: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'unused' of field by 'mixed'
+when scope checking the declaration
+  record R where
+    field
+      @♭ f1 : Set
+      @- f2 : Set
+      @+ f3 : Set
+      @++ f4 : Set
+      @unused f5 : Set
+      ok : Set
+
+———— All done; warnings encountered ————————————————————————
+
+InvalidFieldModality.agda:8.13-21: warning: -W[no]FixingCohesion
+Replacing illegal cohesion 'flat' of field by 'continuous'
+when scope checking the declaration
+  record R where
+    field
+      @♭ f1 : Set
+      @- f2 : Set
+      @+ f3 : Set
+      @++ f4 : Set
+      @unused f5 : Set
+      ok : Set
+
+InvalidFieldModality.agda:9.13-21: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'negative' of field by 'mixed'
+when scope checking the declaration
+  record R where
+    field
+      @♭ f1 : Set
+      @- f2 : Set
+      @+ f3 : Set
+      @++ f4 : Set
+      @unused f5 : Set
+      ok : Set
+
+InvalidFieldModality.agda:10.13-21: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'positive' of field by 'mixed'
+when scope checking the declaration
+  record R where
+    field
+      @♭ f1 : Set
+      @- f2 : Set
+      @+ f3 : Set
+      @++ f4 : Set
+      @unused f5 : Set
+      ok : Set
+
+InvalidFieldModality.agda:11.13-21: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'strictly positive' of field by 'mixed'
+when scope checking the declaration
+  record R where
+    field
+      @♭ f1 : Set
+      @- f2 : Set
+      @+ f3 : Set
+      @++ f4 : Set
+      @unused f5 : Set
+      ok : Set
+
+InvalidFieldModality.agda:12.13-21: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'unused' of field by 'mixed'
+when scope checking the declaration
+  record R where
+    field
+      @♭ f1 : Set
+      @- f2 : Set
+      @+ f3 : Set
+      @++ f4 : Set
+      @unused f5 : Set
+      ok : Set

--- a/test/Succeed/IrrelevantConstructor.agda
+++ b/test/Succeed/IrrelevantConstructor.agda
@@ -1,3 +1,6 @@
+{-# OPTIONS --cohesion #-}
+{-# OPTIONS --polarity #-}
+
 -- Andreas, 2016-02-11. Irrelevant constructors are not (yet?) supported
 
 data D : Set where
@@ -9,3 +12,20 @@ data D : Set where
 
 data Wrap (A : Set) : Set where
   @shape-irrelevant wrap : A → Wrap A
+
+-- Andreas, 2025-05-03, we should also check for other modality annotations.
+
+data DC : Set where
+  @♭    c1 : DC
+  @flat c2 : DC
+
+data DP : Set where
+  @++     psp : DP
+  @+      pp  : DP
+  @-      pn  : DP
+  @unused pu  : DP
+
+data Ok : Set where
+  @relevant   or : Ok
+  @mixed      op : Ok
+  -- @continuous oc : Ok  -- @continuous is not defined (yet)

--- a/test/Succeed/IrrelevantConstructor.warn
+++ b/test/Succeed/IrrelevantConstructor.warn
@@ -1,25 +1,87 @@
-IrrelevantConstructor.agda:4.4-9: warning: -W[no]FixingRelevance
+IrrelevantConstructor.agda:7.4-9: warning: -W[no]FixingRelevance
 Replacing illegal relevance 'irrelevant' of constructor by
 'relevant'
 when scope checking the declaration
   .c : D
 
-IrrelevantConstructor.agda:11.21-38: warning: -W[no]FixingRelevance
+IrrelevantConstructor.agda:14.21-38: warning: -W[no]FixingRelevance
 Replacing illegal relevance 'shape-irrelevant' of constructor by
 'relevant'
 when scope checking the declaration
   @shape-irrelevant wrap : A → Wrap A
+
+IrrelevantConstructor.agda:19.9-16: warning: -W[no]FixingCohesion
+Replacing illegal cohesion 'flat' of constructor by 'continuous'
+when scope checking the declaration
+  @♭ c1 : DC
+
+IrrelevantConstructor.agda:20.9-16: warning: -W[no]FixingCohesion
+Replacing illegal cohesion 'flat' of constructor by 'continuous'
+when scope checking the declaration
+  @♭ c2 : DC
+
+IrrelevantConstructor.agda:23.11-19: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'strictly positive' of constructor by
+'mixed'
+when scope checking the declaration
+  @++ psp : DP
+
+IrrelevantConstructor.agda:24.11-19: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'positive' of constructor by 'mixed'
+when scope checking the declaration
+  @+ pp : DP
+
+IrrelevantConstructor.agda:25.11-19: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'negative' of constructor by 'mixed'
+when scope checking the declaration
+  @- pn : DP
+
+IrrelevantConstructor.agda:26.11-19: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'unused' of constructor by 'mixed'
+when scope checking the declaration
+  @unused pu : DP
 
 ———— All done; warnings encountered ————————————————————————
 
-IrrelevantConstructor.agda:4.4-9: warning: -W[no]FixingRelevance
+IrrelevantConstructor.agda:7.4-9: warning: -W[no]FixingRelevance
 Replacing illegal relevance 'irrelevant' of constructor by
 'relevant'
 when scope checking the declaration
   .c : D
 
-IrrelevantConstructor.agda:11.21-38: warning: -W[no]FixingRelevance
+IrrelevantConstructor.agda:14.21-38: warning: -W[no]FixingRelevance
 Replacing illegal relevance 'shape-irrelevant' of constructor by
 'relevant'
 when scope checking the declaration
   @shape-irrelevant wrap : A → Wrap A
+
+IrrelevantConstructor.agda:19.9-16: warning: -W[no]FixingCohesion
+Replacing illegal cohesion 'flat' of constructor by 'continuous'
+when scope checking the declaration
+  @♭ c1 : DC
+
+IrrelevantConstructor.agda:20.9-16: warning: -W[no]FixingCohesion
+Replacing illegal cohesion 'flat' of constructor by 'continuous'
+when scope checking the declaration
+  @♭ c2 : DC
+
+IrrelevantConstructor.agda:23.11-19: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'strictly positive' of constructor by
+'mixed'
+when scope checking the declaration
+  @++ psp : DP
+
+IrrelevantConstructor.agda:24.11-19: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'positive' of constructor by 'mixed'
+when scope checking the declaration
+  @+ pp : DP
+
+IrrelevantConstructor.agda:25.11-19: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'negative' of constructor by 'mixed'
+when scope checking the declaration
+  @- pn : DP
+
+IrrelevantConstructor.agda:26.11-19: warning: -W[no]FixingPolarity
+Replacing illegal polarity 'unused' of constructor by 'mixed'
+when scope checking the declaration
+  @unused pu : DP


### PR DESCRIPTION
- Warn when constructor is declared flat or negative etc.
  Previously these attributes were silently ignored.

- Only warn when field is declared flat or negative etc. rather than hard error.
  