### PR TITLE
Forget opacity when checking signatures

### DIFF
--- a/test/Succeed/Issue7856.agda
+++ b/test/Succeed/Issue7856.agda
@@ -1,0 +1,16 @@
+module Issue7856 where
+
+open import Agda.Builtin.Unit
+
+apply : (Set → Set) → Set → Set
+apply f = f
+
+-- Reported by Javier Díaz, reproducer by Szumi Xie: extended lambdas
+-- defined in type signatures should not belong to opaque blocks.
+
+opaque
+  test : apply (λ {x → x}) ⊤
+  test = tt
+
+_ : ⊤
+_ = test


### PR DESCRIPTION
Fix #7856 by simply removing the opaque block from the environment when scope-checking the type part of a type signature. And don't worry it's always "tomorrow" somewhere