### PR TITLE
Fix #7853: don't drop parameters of constructor in the same module

### DIFF
--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -1023,7 +1023,10 @@ applyDroppingParameters t vs = do
     Con c ci [] -> do
       def <- theDef <$> getConInfo c
       case def of
-        Constructor {conPars = n} -> return $ Con c ci (map Apply $ drop n vs)
+        Constructor {conPars = n, conData = d} -> do
+          -- Szumi, 2025-05-05, issue #7853: don't drop parameters from the current module.
+          fv <- getDefFreeVars d
+          return $ Con c ci (map Apply $ drop (n - fv) vs)
         _ -> __IMPOSSIBLE__
     Def f [] -> do
       -- Andreas, 2022-03-07, issue #5809: don't drop parameters of irrelevant projections.

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -1016,6 +1016,8 @@ postponeInstanceConstraints m =
 --   In this case we drop the first 'conPars' arguments.
 --   See Issue670a.
 --   Andreas, 2013-11-07 Also do this for projections, see Issue670b.
+--   Szumi, 2025-05-05: Unapplied projections are not considered by instance
+--   search since #938.
 applyDroppingParameters :: Term -> Args -> TCM Term
 applyDroppingParameters t vs = do
   let fallback = return $ t `apply` vs
@@ -1028,15 +1030,15 @@ applyDroppingParameters t vs = do
           fv <- getDefFreeVars d
           return $ Con c ci (map Apply $ drop (n - fv) vs)
         _ -> __IMPOSSIBLE__
-    Def f [] -> do
-      -- Andreas, 2022-03-07, issue #5809: don't drop parameters of irrelevant projections.
-      mp <- isRelevantProjection f
-      case mp of
-        Just Projection{projIndex = n} -> do
-          case drop n vs of
-            []     -> return t
-            u : us -> (`apply` us) <$> applyDef ProjPrefix f u
-        _ -> fallback
+    -- Def f [] -> do
+    --   -- Andreas, 2022-03-07, issue #5809: don't drop parameters of irrelevant projections.
+    --   mp <- isRelevantProjection f
+    --   case mp of
+    --     Just Projection{projIndex = n} -> do
+    --       case drop n vs of
+    --         []     -> return t
+    --         u : us -> (`apply` us) <$> applyDef ProjPrefix f u
+    --     _ -> fallback
     _ -> fallback
 
 ---------------------------------------------------------------------------

--- a/test/Succeed/Issue7853.agda
+++ b/test/Succeed/Issue7853.agda
@@ -1,0 +1,23 @@
+-- Reported by Miëtek Bak, minimised by Naïm Camille Favier and Andreas Abel
+
+{-# OPTIONS --show-implicit #-}
+
+it : ∀ {A : Set} {{_ : A}} → A
+it {{a}} = a
+
+module _ (X Y : Set) where
+
+  data U {Z : Set} : X → Y → Z → Set where
+    instance
+      u : ∀ {x y z} → U x y z
+
+  module _ (Z : Set) (x : X) (y : Y) (z : Z) where
+
+    test : (P : U x y z → Set) → P u → P it
+    test P p = p
+
+-- WAS: error: [UnequalTerms]
+-- u {_} {x} {y} {z} != u {_} {x} of type
+-- {y = y₁ : Y} {z = z₁ : Z} → U {Z} x y₁ z₁
+-- when checking that the expression p has type
+-- P (it {U {Z} x y z} ⦃ u {_} {z} ⦄)


### PR DESCRIPTION
Fixes #7853 by not dropping parameters of constructors that come from the same module we are currently in during instance resolution.

The case about projections in `applyDroppingParameters` appears to be dead code https://github.com/agda/agda/blob/0ec1150333c601c927296428fb33ddb8a770441d/src/full/Agda/TypeChecking/InstanceArguments.hs#L1028-L1036 because unapplied projections are never considered by instance search after #938. Andreas mentions `Issue670b` in a comment https://github.com/agda/agda/blob/0ec1150333c601c927296428fb33ddb8a770441d/src/full/Agda/TypeChecking/InstanceArguments.hs#L1018-L1019 but this test case was removed in 7ca60fd60aec1b73d9f14aaa6e1aeef184bcca79.
