### PR TITLE
Add .python-sphinx-virtualenv into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 .direnv
 .DS_Store
 .ghc.environment.*
+.python-sphinx-virtualenv/
 .stack-work-*/
 .stack-work/
 .sw[a-p]


### PR DESCRIPTION
This PR gitignores the temporary directory containing Python libraries and binaries while generating the documentations using Sphinx.