### PR TITLE
Fix #7832 by placing properlyMatching in monad to have isEtaRecordConstructor

### DIFF
--- a/src/full/Agda/Compiler/MAlonzo/Pragmas.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Pragmas.hs
@@ -149,7 +149,7 @@ sanityCheckPragma x pragma = do
       Axiom{}    -> ok
       Datatype{} -> do
         -- We use HsType pragmas for Nat, Int and Bool
-        ifM (flip anyM ((Just (defName def) ==) <.> getBuiltinName) [builtinNat, builtinInteger, builtinBool])
+        ifM (anyM ((Just (defName def) ==) <.> getBuiltinName) [builtinNat, builtinInteger, builtinBool])
           {-then-} ok
           {-else-} notPostulate
       _ -> notPostulate

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -628,27 +628,6 @@ patternInfo (DefP i _ _)      = Just i
 patternOrigin :: Pattern' x -> Maybe PatOrigin
 patternOrigin = fmap patOrigin . patternInfo
 
--- | Does the pattern perform a match that could fail?
-properlyMatching :: Pattern' a -> Bool
-properlyMatching = properlyMatching' True True
-
-properlyMatching'
-  :: Bool       -- ^ Should absurd patterns count as proper match?
-  -> Bool       -- ^ Should projection patterns count as proper match?
-  -> Pattern' a -- ^ The pattern.
-  -> Bool
-properlyMatching' absP projP = \case
-  p | absP && patternOrigin p == Just PatOAbsurd -> True
-  ConP _ ci ps    -- record constructors do not count as proper matches themselves
-    | conPRecord ci -> List.any (properlyMatching . namedArg) ps
-    | otherwise     -> True
-  LitP{}    -> True
-  DefP{}    -> True
-  ProjP{}   -> projP
-  VarP{}    -> False
-  DotP{}    -> False
-  IApplyP{} -> False
-
 instance IsProjP (Pattern' a) where
   isProjP = \case
     ProjP o d -> Just (o, unambiguous d)

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -419,9 +419,7 @@ toConcreteName x = hasConcreteNames x >>= loop
     isGoodName :: MonadToConcrete m => A.Name -> C.Name -> m Bool
     isGoodName x y = do
       zs <- asks (Set.toList . takenVarNames)
-      allM zs $ \z -> if x == z then return True else do
-        czs <- hasConcreteNames z
-        return $ notElem y czs
+      forallM zs $ \ z -> pure (x == z) `or2M` (notElem y <$> hasConcreteNames z)
 
 
 -- | Choose a new unshadowed name for the given abstract name

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1449,7 +1449,7 @@ instance Reify (QNamed System) where
     view <- intervalView'
     unview <- intervalUnview'
     sys <- flip filterM sys $ \ (phi,t) -> do
-      allM phi $ \ (u,b) -> do
+      forallM phi $ \ (u,b) -> do
         u <- reduce u
         return $ case (view u, b) of
           (IZero, True) -> False

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -190,7 +190,7 @@ termMutual names0 = ifNotM (optTerminationCheck <$> pragmaOptions) (return mempt
       ignoreAbstractMode $ do
         billTo [Benchmark.Termination, Benchmark.RecCheck] $ recursive allNames
       -- -- Andreas, 2017-03-24, use positivity info to skip non-recursive functions
-      -- skip = ignoreAbstractMode $ allM allNames $ \ x -> do
+      -- skip = ignoreAbstractMode $ forallM allNames $ \ x -> do
       --   null <$> getMutual x
       -- PROBLEMS with test/Succeed/AbstractCoinduction.agda
 
@@ -217,7 +217,7 @@ termMutual names0 = ifNotM (optTerminationCheck <$> pragmaOptions) (return mempt
      -- New check currently only makes a difference for copatterns and record types.
      -- Since it is slow, only invoke it if
      -- any of the definitions uses copatterns or is a record type.
-     ifM (anyM allNames $ \ q -> usesCopatterns q `or2M` (isJust <$> isRecord q))
+     ifM (existsM allNames $ \ q -> usesCopatterns q `or2M` (isJust <$> isRecord q))
          -- Then: New check, one after another.
          (runTerm $ forM' allNames $ termFunction)
          -- Else: Old check, all at once.

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -304,8 +304,8 @@ cover f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
       let extra = drop (length $ namedClausePats cl0) ps
       exact <-
         and2M
-          (allM mps $ isTrivialPattern . snd)
-          (allM extra $ isTrivialPattern . namedArg)
+          (forallM mps $ isTrivialPattern . snd)
+          (forallM extra $ isTrivialPattern . namedArg)
       cl <- applyCl sc cl0 mps
       return $ CoverResult
         { coverSplitTree      = SplittingDone (size tel)

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -752,7 +752,7 @@ resolveInstanceOverlap overlapOk rel itemC cands = wrapper where
     let new = itemC newItem
     -- If the new candidate is overridden by any of the guards, we can
     -- ditch it immediately.
-    guarded <- anyM guards (`doesCandidateOverlap` new)
+    guarded <- anyM (`doesCandidateOverlap` new) guards
 
     reportSDoc "tc.instance.overlap" 40 $ vcat
       [ "inserting new candidate:"

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -135,4 +135,4 @@ checkEarlierThan :: Term -> VSet.VarSet -> TCM Bool
 checkEarlierThan lk fvs = do
   getLockVar lk >>= \case
     Nothing -> return True
-    Just i  -> flip allM (isTimeless <=< typeOfBV) $ filter (<= i) $ VSet.toList fvs
+    Just i  -> allM (isTimeless <=< typeOfBV) $ filter (<= i) $ VSet.toList fvs

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -855,7 +855,7 @@ instance AnyRigid Level where
   anyRigid f (Max _ ls) = anyRigid f ls
 
 instance AnyRigid PlusLevel where
-  anyRigid f (Plus _ l)    = anyRigid f l
+  anyRigid f (Plus _ l) = anyRigid f l
 
 instance (Subst a, AnyRigid a) => AnyRigid (Abs a) where
   anyRigid f b = underAbstraction_ b $ anyRigid f
@@ -869,7 +869,7 @@ instance AnyRigid a => AnyRigid (Arg a) where
       anyRigid f $ unArg a
 
 instance AnyRigid a => AnyRigid (Dom a) where
-  anyRigid f dom = anyRigid f $ unDom dom
+  anyRigid f = anyRigid f . unDom
 
 instance AnyRigid a => AnyRigid (Elim' a) where
   anyRigid f (Apply a)      = anyRigid f a
@@ -877,7 +877,7 @@ instance AnyRigid a => AnyRigid (Elim' a) where
   anyRigid f Proj{}         = return False
 
 instance AnyRigid a => AnyRigid [a] where
-  anyRigid f xs = anyM xs $ anyRigid f
+  anyRigid = anyM . anyRigid
 
 instance (AnyRigid a, AnyRigid b) => AnyRigid (a,b) where
   anyRigid f (a,b) = anyRigid f a `or2M` anyRigid f b

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -382,7 +382,7 @@ data OccEnv = OccEnv
   }
 
 -- | Monad for computing occurrences.
-type OccM = ReaderT OccEnv TCM
+type OccM = ReaderT OccEnv ReduceM
 
 instance (Semigroup a, Monoid a) => Monoid (OccM a) where
   mempty  = return mempty
@@ -405,7 +405,8 @@ getOccurrences vars a = do
   reportSDoc "tc.pos.occ" 70 $ "computing occurrences in " <+> text (show a)
   reportSDoc "tc.pos.occ" 20 $ "computing occurrences in " <+> prettyTCM a
   reportSDoc "tc.pos.var" 20 $ "variables in context: " <+> pretty vars
-  runReaderT (occurrences a) . OccEnv vars . fmap nameOfInf =<< coinductionKit
+  env <- OccEnv vars . fmap nameOfInf <$> coinductionKit
+  runReduceM $ runReaderT (occurrences a) env
 
 class ComputeOccurrences a where
   occurrences :: a -> OccM OccurrencesBuilder

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -771,7 +771,7 @@ filterTCWarnings wset = case Set.toAscList wset of
   -- If there are several warnings, remove the unsolved-constraints warning
   -- in case there are no interesting constraints to list.
   ws  -> (`filterM` ws) $ \ w -> case tcWarning w of
-    UnsolvedConstraints cs -> anyM cs interestingConstraint
+    UnsolvedConstraints cs -> anyM interestingConstraint cs
     _ -> pure True
 
 

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -408,7 +408,7 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
 
           rews <- getAllRulesFor f
           let sameRHS = onlyReduceTypes $ pureEqualTerm a rhs1 rhs2
-          unlessM (sameRHS `or2M` anyM rews checkEqualLHS) $ addContext gamma $
+          unlessM (sameRHS `or2M` anyM checkEqualLHS rews) $ addContext gamma $
             warning $ RewriteAmbiguousRules (hd es) rhs1 rhs2
 
     checkTrianglePropertyForRule :: RewriteRule -> TCM ()

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -884,7 +884,7 @@ bindBuiltin b x = do
       PatternSynResName xs -> failure
       UnknownName          -> failure
     -- For ambiguous names, we check all of their definitions:
-    unlessM (allM xs $ null <.> lookupSection . qnameModule . anameName) $
+    unlessM (forallM xs $ null <.> lookupSection . qnameModule . anameName) $
       failure
   -- Since the name was define in a parameter-free context, we can switch to the empty context.
   -- (And we should!)

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -475,7 +475,7 @@ stripWithClausePatterns cxtNames parent f t delta qs npars perm ps = do
             -- We disambiguate the projection in the with clause
             -- to the projection in the parent clause.
             d  <- liftTCM $ getOriginalProjection d
-            found <- anyM ds $ \ d' -> liftTCM $ (Just d ==) . fmap projOrig <$> isProjection d'
+            found <- existsM ds $ \ d' -> liftTCM $ (Just d ==) . fmap projOrig <$> isProjection d'
             if not found then mismatch else do
               (self1, t1, ps) <- liftTCM $ do
                 t <- reduce t

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -119,8 +119,11 @@ and2M ma mb = ifM ma mb (return False)
 andM :: (Foldable f, Monad m) => f (m Bool) -> m Bool
 andM = Fold.foldl' and2M (return True)
 
-allM :: (Foldable f, Monad m) => f a -> (a -> m Bool) -> m Bool
-allM xs f = Fold.foldl' (\b -> and2M b . f) (return True) xs
+allM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
+allM f = Fold.foldl' (\ b -> and2M b . f) (return True)
+
+forallM :: (Foldable f, Monad m) => f a -> (a -> m Bool) -> m Bool
+forallM xs f = Fold.foldl' (\b -> and2M b . f) (return True) xs
 
 -- | Lazy monadic disjunction.
 or2M :: Monad m => m Bool -> m Bool -> m Bool
@@ -129,8 +132,11 @@ or2M ma = ifM ma (return True)
 orM :: (Foldable f, Monad m) => f (m Bool) -> m Bool
 orM = Fold.foldl' or2M (return False)
 
-anyM :: (Foldable f, Monad m) => f a -> (a -> m Bool) -> m Bool
-anyM xs f = Fold.foldl' (\b -> or2M b . f) (return False) xs
+anyM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
+anyM f = Fold.foldl' (\ b -> or2M b . f) (return False)
+
+existsM :: (Foldable f, Monad m) => f a -> (a -> m Bool) -> m Bool
+existsM xs f = anyM f xs
 
 -- | Lazy monadic disjunction with @Either@  truth values.
 --   Returns the last error message if all fail.

--- a/test/Bugs/Issue4251.err
+++ b/test/Bugs/Issue4251.err
@@ -12,6 +12,7 @@ out >                        in the first argument of admit
 out >                        in the second argument of fung
 out >                        in the 4th clause
 out >                        in the definition of s), which occurs
+out >                                               as matched against
 out >                                               in the first clause
 out >                                               in the definition of Cocone.x, which occurs
 out >                                                                            in an argument of a bound

--- a/test/Fail/ConstructorHeadedPointlessForRecordPatterns.agda
+++ b/test/Fail/ConstructorHeadedPointlessForRecordPatterns.agda
@@ -9,7 +9,7 @@ open import Common.Product
 
 -- No inverse should be created for swap by
 -- checkInjectivity, since we are dealing with a record constructor.
-swap : ∀{A B} → A × B → B × A
+swap : ∀{A B : Set} → A × B → B × A
 swap (a , b) = b , a
 
 -- The internal representation is

--- a/test/Fail/Issue7832.agda
+++ b/test/Fail/Issue7832.agda
@@ -1,0 +1,37 @@
+-- Andreas, 2025-05-07, issue #7862, report and test case by Jonathan Chan
+-- Matching against non-eta record constructors should count as proper match
+-- just like for data constructors.
+
+-- {-# OPTIONS -v tc.polarity:15 #-}
+-- {-# OPTIONS -v tc.pos:40 #-}
+
+open import Agda.Builtin.Equality
+
+module _ (A : Set) (_<_ : A → A → Set) where
+
+record Acc (k : A) : Set where
+  pattern
+  inductive
+  no-eta-equality -- this makes it behave like a data constructor
+  constructor acc<
+  field acc : ∀ j → j < k → Acc j
+
+-- Behavior should be the same as for data type:
+--
+-- data Acc (k : A) : Set where
+--   acc< : (∀ j → j < k → Acc j) → Acc k
+
+module _ (U' : ∀ k → (U< : ∀ j → j < k → Set) → Set) where
+
+  U< : ∀ {k} → Acc k → ∀ j → j < k → Set
+  U< (acc< f) j j<k = U' j (U< (f j j<k))
+
+  lemma : ∀ {i j} (accj₁ accj₂ : Acc j) (i<j₁ i<j₂ : i < j) → U< accj₁ i i<j₁ ≡ U< accj₂ i i<j₂
+  lemma accj₁ accj₂ i<j₁ i<j₂ = refl
+
+-- WAS: refl was accepted because U< was deemed constant in its Acc argument
+--
+-- Expected error: [UnequalTerms]
+-- accj₁ != accj₂ of type Acc j
+-- when checking that the expression refl has type
+-- U< accj₁ i i<j₁ ≡ U< accj₂ i i<j₂

--- a/test/Fail/Issue7832.err
+++ b/test/Fail/Issue7832.err
@@ -1,0 +1,4 @@
+Issue7832.agda:30.33-37: error: [UnequalTerms]
+accj₁ != accj₂ of type Acc j
+when checking that the expression refl has type
+U< accj₁ i i<j₁ ≡ U< accj₂ i i<j₂


### PR DESCRIPTION
- **Refactor: conform anyM and allM to any and all, add existsM and forallM**
  
- **Fix #7832 by checking for eta record constructor in properlyMatching**
  This places `properlyMatching` in a `HasConstInfo` monad.
  Consequently, the computation of occurrences in the positivity checker has to be placed in such a monad.
  Here, we use `TCM`, but one could use something more lightweight, like `ReduceM` or a custom monad that just supports `HasConstInfo` and nothing more.
  - [x] TODO: benchmark the positivity checker, and see whether making it strict (in `TCM`) has some adversary effects on performance.
  
  
  
- **Re #7832: place base OccM on ReduceM instead of TCM**
  This does not have any measurable performance improvement, but does not make things worse, so we can keep this change.
  