### PR TITLE
Fix #7878: reorder checks in `mkNotation`

### DIFF
--- a/src/full/Agda/Syntax/Notation.hs
+++ b/src/full/Agda/Syntax/Notation.hs
@@ -121,13 +121,13 @@ mkNotation _ [] = throwError "empty notation is disallowed"
 mkNotation holes ids = do
   unless uniqueHoleNames     $ throwError "syntax must use unique argument names"
   let xs :: Notation = map mkPart ids
+  unless (isExprLinear xs)   $ throwError "syntax must use holes exactly once"
+  unless (isLambdaLinear xs) $ throwError "syntax must use binding holes exactly once"
   unless (noAdjacentHoles xs)  $ throwError $ concat
      [ "syntax must not contain adjacent holes ("
      , prettyHoles
      , ")"
      ]
-  unless (isExprLinear xs)   $ throwError "syntax must use holes exactly once"
-  unless (isLambdaLinear xs) $ throwError "syntax must use binding holes exactly once"
   -- Andreas, 2018-10-18, issue #3285:
   -- syntax that is just a single hole is ill-formed and crashes the operator parser
   when   (isSingleHole xs)   $ throwError "syntax cannot be a single hole"

--- a/test/Fail/Issue308b.err
+++ b/test/Fail/Issue308b.err
@@ -1,2 +1,2 @@
 Issue308b.agda:6.18: error: [ParseError]
-Malformed syntax declaration: syntax must not contain adjacent holes (x)
+Malformed syntax declaration: syntax must use holes exactly once

--- a/test/Fail/Issue7878.agda
+++ b/test/Fail/Issue7878.agda
@@ -1,0 +1,5 @@
+-- Reported by Amy
+
+syntax bind e (\ x -> f) = x
+
+-- WAS: internal error

--- a/test/Fail/Issue7878.err
+++ b/test/Fail/Issue7878.err
@@ -1,0 +1,2 @@
+Issue7878.agda:3.28: error: [ParseError]
+Malformed syntax declaration: syntax must use holes exactly once


### PR DESCRIPTION
Fixes #7878.
