### PR TITLE
Defer `MissingDefinitions` error in `--safe` until after typechecking

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -200,15 +200,15 @@ replaceSigs ps = if Map.null ps then id else \case
       FunSig r acc abst inst _ argi _ _ x' e ->
         -- #4881: Don't use the unique NameId for NoName lookups.
         let x = if isNoName x' then noName (nameRange x') else x' in
-        Just (x, Axiom r acc abst inst argi x' e)
+        Just (x, Axiom r acc abst inst (setOrigin Inserted argi) x' e)
       NiceRecSig r erased acc abst _ _ x pars t ->
         let e = Generalized $ makePi (lamBindingsToTelescope r pars) t in
         Just (x, Axiom r acc abst NotInstanceDef
-                   (setQuantity (asQuantity erased) defaultArgInfo) x e)
+                   (setOrigin Inserted (setQuantity (asQuantity erased) defaultArgInfo)) x e)
       NiceDataSig r erased acc abst _ _ x pars t ->
         let e = Generalized $ makePi (lamBindingsToTelescope r pars) t in
         Just (x, Axiom r acc abst NotInstanceDef
-                   (setQuantity (asQuantity erased) defaultArgInfo) x e)
+                   (setOrigin Inserted (setQuantity (asQuantity erased) defaultArgInfo)) x e)
       _ -> Nothing
 
 -- | Main. Fixities (or more precisely syntax declarations) are needed when

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -245,7 +245,7 @@ unsafeDeclarationWarning' = \case
   InvalidTerminationCheckPragma{}   -> False
   InvalidCoverageCheckPragma{}      -> False
   MissingDataDeclaration{}          -> True  -- not safe
-  MissingDefinitions{}              -> True  -- not safe
+  MissingDefinitions{}              -> False -- not safe but deferred until after typechecking
   NotAllowedInMutual{}              -> False -- really safe?
   OpenImportPrivate{}               -> False
   OpenImportAbstract{}              -> False

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1723,9 +1723,12 @@ instance ToAbstract NiceDeclaration where
     C.Axiom r p a i rel x t -> do
       (y, decl) <- toAbstractNiceAxiom AxiomName d
       -- check that we do not postulate in --safe mode, unless it is a
-      -- builtin module with safe postulates
-      whenM ((Lens.getSafeMode <$> commandLineOptions) `and2M`
-             (not <$> (isBuiltinModuleWithSafePostulates . fromMaybe __IMPOSSIBLE__ =<< asksTC envCurrentPath)))
+      -- builtin module with safe postulates, or the axiom is generated
+      -- from a lone signature
+      whenM (andM [ Lens.getSafeMode <$> commandLineOptions
+                  , not <$> (isBuiltinModuleWithSafePostulates . fromMaybe __IMPOSSIBLE__ =<< asksTC envCurrentPath)
+                  , pure $ getOrigin rel /= Inserted
+                  ])
             (warning $ SafeFlagPostulate y)
       -- check the postulate
       return $ singleton decl

--- a/test/Fail/Issue5592-safe.agda
+++ b/test/Fail/Issue5592-safe.agda
@@ -1,0 +1,9 @@
+{-# OPTIONS --safe #-}
+
+data A : Set
+
+data A : Set where
+
+-- WAS: only [MissingDefinitions] error
+-- NOW: both [MissingDefinitions] and [ClashingDefinition]
+-- could be better if it only showed [ClashingDefinition]

--- a/test/Fail/Issue5592-safe.err
+++ b/test/Fail/Issue5592-safe.err
@@ -1,0 +1,13 @@
+Issue5592-safe.agda:3.1-13: error: [MissingDefinitions]
+The following names are declared but not accompanied by a
+definition: A
+
+Issue5592-safe.agda:5.6-13: error: [ClashingDefinition]
+Multiple definitions of A. Previous definition at
+Issue5592-safe.agda:3.6-7
+Perhaps you meant to write
+  'data A where'
+at Issue5592-safe.agda:5.6-13?
+In data definitions separate from data declaration, the ':' and type must be omitted.
+when scope checking the declaration
+  data A : Set

--- a/test/Fail/MissingDefinitionsDeferred.agda
+++ b/test/Fail/MissingDefinitionsDeferred.agda
@@ -1,0 +1,11 @@
+{-# OPTIONS --safe #-}
+
+A : Set
+
+record B : Set
+
+data C : Set
+
+D : Set
+D = Set
+-- should throw Set₁ != Set despite earlier missing definitions error

--- a/test/Fail/MissingDefinitionsDeferred.err
+++ b/test/Fail/MissingDefinitionsDeferred.err
@@ -1,0 +1,7 @@
+MissingDefinitionsDeferred.agda:3.1-7.13: error: [MissingDefinitions]
+The following names are declared but not accompanied by a
+definition: A, B, C
+
+MissingDefinitionsDeferred.agda:10.5-8: error: [UnequalSorts]
+Set₁ != Set
+when checking that the expression Set has type Set


### PR DESCRIPTION
This patch defers the `MissingDefinitions` error in `--safe` mode until after typechecking, so that I don't lose all the holes and highlighting when I add a new signature in a file.

This also makes the error message in #5592 slightly better with `--safe`.
