### PR TITLE
[ fix #7876 ] Check meta instantiation in constraintMetas

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1782,6 +1782,9 @@ data PrincipalArgTypeMetas = PrincipalArgTypeMetas
   }
   deriving Generic
 
+instance AllMetas PrincipalArgTypeMetas where
+  allMetas f (PrincipalArgTypeMetas vs ty) = allMetas f (vs,ty)
+
 data TypeCheckingProblem
   = CheckExpr Comparison A.Expr Type
   | CheckArgs Comparison ExpandHidden A.Expr [NamedArg A.Expr] Type Type (ArgsCheckState CheckedTarget -> TCM Term)

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -449,8 +449,14 @@ constraintMetas = \case
     makeSingle m = lookupMetaInstantiation m >>= \case
       InstV i -> gatherMetas $ instBody i
       OpenMeta _ -> return $ Set.singleton m
-      BlockedConst t -> Set.insert m <$> gatherMetas t
-      PostponedTypeCheckingProblem clos -> tcProblemMetas $ clValue clos
+      BlockedConst t ->
+        -- Jesper, 2025-05-13: We should really look into the
+        -- (blocked) solution here but doing so triggers a
+        -- regression in the standard library that I'm too tired
+        -- to deal with (see test/Succeed/Issue7876b.agda).
+        -- Set.insert m <$> gatherMetas t
+        return $ Set.singleton m
+      PostponedTypeCheckingProblem clos -> Set.insert m <$> tcProblemMetas (clValue clos)
 
     tcProblemMetas :: TypeCheckingProblem -> TCM (Set MetaId)
     tcProblemMetas = \case

--- a/test/Succeed/Issue7876.agda
+++ b/test/Succeed/Issue7876.agda
@@ -1,0 +1,30 @@
+{-# OPTIONS --rewriting --allow-unsolved-metas #-}
+
+open import Agda.Primitive
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+postulate
+  _≡[_]≡_ : {A B : Set} → A → A ≡ B → B → Set
+  ≡[]β : {A : Set} {x y : A} → (x ≡[ refl ]≡ y) ≡ (x ≡ y)
+
+{-# REWRITE ≡[]β #-}
+
+postulate
+  Ctx : Set
+  Ty  : Ctx → Set
+  Tm  : (Γ : Ctx) → Ty Γ → Set
+
+variable
+  Γ Γ₁ Γ₂ : Ctx
+  A A₁ A₂ : Ty Γ
+  t₁ t₂ : Tm Γ A
+
+postulate
+  Ty≡ : ∀ Γ₁ Γ₂ → Γ₁ ≡ Γ₂ → Ty Γ₁ ≡ Ty Γ₂
+  Tm≡ : ∀ Γ₁ Γ₂ A₁ A₂ Γ≡ → (A≡ : A₁ ≡[ Ty≡ Γ₁ Γ₂ Γ≡ ]≡ A₂)
+      → Tm Γ₁ A₁ ≡ Tm Γ₂ A₂
+
+  foo≡  : (Γ≡ : Γ₁ ≡ Γ₂) (A≡ : A₁ ≡[ Ty≡ _ _ Γ≡ ]≡ A₂)
+        → t₁ ≡[ Tm≡ _ _ _ _ Γ≡ A≡ ]≡ t₂
+        → {!!}

--- a/test/Succeed/Issue7876b.agda
+++ b/test/Succeed/Issue7876b.agda
@@ -1,0 +1,23 @@
+open import Agda.Primitive
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+
+variable
+  a : Level
+  A : Set a
+  n : Nat
+
+idNat : Nat → Nat
+idNat zero = zero
+idNat (suc n) = suc n
+
+postulate
+  Vec : (a : Level) (A : Set a) → Nat → Set a
+  f   : (n : Nat) → Vec _ A (idNat n)
+  P   : (a : Level) (A : Set a) (n : Nat) → Vec _ A n → Set
+
+-- Jesper, 2025-05-13: Looking into the solution of BlockedConst in
+-- the implementation of constraintMetas causes the generalization to
+-- fail here.
+postulate
+  _ : (a : A) → P _ A (idNat n) (f _)


### PR DESCRIPTION
This fixes #7876 by checking the instantiation of encountered metas in `constraintMetas`.

A simpler fix would be to use `instantiateFull` on the constraints, but (1) this is less efficient and (2) it might still miss metas with state `BlockedConst` or `PostponedTypeCheckingProblem`. For these two cases, I followed a conservative approach and simply gather all the metas from terms and types. This might lead to some failed generalization in extreme corner cases, but the alternative is that we might miss metas in these cases and get an internal error again.