### PR TITLE
Fix lexical-scope issue in emacs mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ setup-agda:
 .PHONY: ensure-hash-is-correct
 ensure-hash-is-correct:
 	rm -f $(BUILD_DIR)/build/Agda/VersionCommit.o
+	rm -f $(BUILD_DIR)/build/agda-mode/agda-mode-tmp/Agda/VersionCommit.o
 
 .PHONY: copy-bins-with-suffix-% ## Copy binaries to local bin directory with suffix
 copy-bins-with-suffix-%:

--- a/src/data/emacs-mode/agda2-highlight.el
+++ b/src/data/emacs-mode/agda2-highlight.el
@@ -57,7 +57,7 @@ If the face does not exist, then it is created first."
                       :inherit        'unspecified
                       :box            'unspecified
                       :font           'unspecified)
-  (eval `(set-face-attribute face nil ,@attrs)))
+  (eval `(set-face-attribute ',face nil ,@attrs)))
 
 (defun agda2-highlight-set-faces (variable group)
   "Set all Agda faces according to the value of GROUP.


### PR DESCRIPTION
(@plt-amy did the actual elisp!)

Without this fix switching to the "Conor" color scheme threw an error complaining that the `face` variable was undefined.

This might be good to include in the 2.8.0 release. (attn @andreasabel)