### PR TITLE
Fix issue #7903: etaExpandClause before constructor inlining

### DIFF
--- a/src/full/Agda/TypeChecking/Functions.hs
+++ b/src/full/Agda/TypeChecking/Functions.hs
@@ -13,6 +13,7 @@ import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Context
 import Agda.TypeChecking.Monad.Debug
+import Agda.TypeChecking.Monad.Pure
 import Agda.TypeChecking.Level
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Reduce
@@ -36,8 +37,8 @@ import Agda.Utils.Size
 --  This is used instead of special treatment of lambdas
 --  (which was unsound: Issue #121)
 
-etaExpandClause :: MonadTCM tcm => Clause -> tcm Clause
-etaExpandClause clause = liftTCM $ do
+etaExpandClause :: PureTCM tcm => Clause -> tcm Clause
+etaExpandClause clause = do
   case clause of
     Clause _  _  ctel ps _           Nothing  _ _ _ _ _ -> return clause
     Clause _  _  ctel ps Nothing     (Just t) _ _ _ _ _ -> return clause

--- a/test/Succeed/Issue6660-Stream.agda
+++ b/test/Succeed/Issue6660-Stream.agda
@@ -20,4 +20,22 @@ nats n = n ∷ nats (1 + n)
 map : {A B : Set} (f : A → B) → Stream A → Stream B
 map f s = f (head s) ∷ map f (tail s)
 
+nats1 : Nat → Stream Nat
+nats1 = λ n → n ∷ nats1 (1 + n)
+
+id : {A : Set} → A → A
+id = λ x → x
+{-# INLINE id #-}
+
+_∘_ : {A B C : Set} → (B → C) → (A → B) → A → C
+f ∘ g = λ x → f (g x)
+{-# INLINE _∘_ #-}
+
+_∷₁_ : {A B : Set} → (A → B) → (A → Stream B) → A → Stream B
+{-# INLINE _∷₁_ #-}
+h ∷₁ t = λ x → h x ∷ t x
+
+nats2 : Nat → Stream Nat
+nats2 = id ∷₁ (nats2 ∘ suc)
+
 -- Should give warnings about non-exact splitting

--- a/test/Succeed/Issue6660-Stream.warn
+++ b/test/Succeed/Issue6660-Stream.warn
@@ -23,6 +23,20 @@ match:
   map f s = f (head s) ∷ map f (tail s)
 when checking the definition of map
 
+Issue6660-Stream.agda:24.1-32: warning: -W[no]InlineNoExactSplit
+Exact splitting is enabled, but the following clause is no longer a
+definitional equality because it was translated to a copattern
+match:
+  nats1 = λ n → n ∷ nats1 (1 + n)
+when checking the definition of nats1
+
+Issue6660-Stream.agda:39.1-28: warning: -W[no]InlineNoExactSplit
+Exact splitting is enabled, but the following clause is no longer a
+definitional equality because it was translated to a copattern
+match:
+  nats2 = λ x → x ∷ nats2 (suc x)
+when checking the definition of nats2
+
 ———— All done; warnings encountered ————————————————————————
 
 Issue6660-Stream.agda:10.16-23: warning: -W[no]UselessPatternDeclarationForRecord
@@ -49,3 +63,17 @@ definitional equality because it was translated to a copattern
 match:
   map f s = f (head s) ∷ map f (tail s)
 when checking the definition of map
+
+Issue6660-Stream.agda:24.1-32: warning: -W[no]InlineNoExactSplit
+Exact splitting is enabled, but the following clause is no longer a
+definitional equality because it was translated to a copattern
+match:
+  nats1 = λ n → n ∷ nats1 (1 + n)
+when checking the definition of nats1
+
+Issue6660-Stream.agda:39.1-28: warning: -W[no]InlineNoExactSplit
+Exact splitting is enabled, but the following clause is no longer a
+definitional equality because it was translated to a copattern
+match:
+  nats2 = λ x → x ∷ nats2 (suc x)
+when checking the definition of nats2


### PR DESCRIPTION
Now

    nats = λ n → n ∷ nats (1 + n)

is treated like

    nats n = n ∷ nats (1 + n)

which gets translated to

    nats n .head = n
    nats n .tail = nats (1 + n)

that is accepted by the termination checker.

Closes #7903.
