### PR TITLE
Workflow deploy: install libgmp

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,12 +95,17 @@ jobs:
         echo "content-type    = ${{ steps.vars.outputs.content-type }}"
         echo "filename        = ${{ steps.vars.outputs.filename     }}"
         echo "bindist         = ${{ steps.vars.outputs.bindist      }}"
+    - if: runner.os == 'Linux'
+      name: Install GMP library (Linux)
+      run: |
+        sudo apt-get update
+        sudo apt-get install libgmp-dev
     - if: ${{ runner.os == 'Linux' }}
       name: Set up Alpine Linux with GHC and the static library for ICU
       uses: jirutka/setup-alpine@v1
       with:
         packages: |
-          cabal g++ gcc icu-static libgmpxx musl-dev ncurses-dev ncurses-static zlib-static zlib-dev
+          cabal g++ gcc icu-static gmp-dev musl-dev ncurses-dev ncurses-static zlib-static zlib-dev
     - id: setup-haskell
       if: ${{ runner.os != 'Linux' }}
       uses: haskell-actions/setup@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,9 +231,6 @@ jobs:
         ghc-ver:
         - 9.12.2
         os:
-        - windows-latest
-        - macos-14
-        - macos-13
         - ubuntu-latest
   deploy:
     if: ${{ !cancelled() }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,14 +100,15 @@ jobs:
       uses: jirutka/setup-alpine@v1
       with:
         packages: |
-          cabal g++ gcc icu-static ncurses-dev ncurses-static musl-dev zlib-static zlib-dev
+          cabal g++ gcc icu-static libgmpxx musl-dev ncurses-dev ncurses-static zlib-static zlib-dev
     - id: setup-haskell
       if: ${{ runner.os != 'Linux' }}
       uses: haskell-actions/setup@v2
       with:
         cabal-version: ${{ matrix.cabal-ver }}
         ghc-version: ${{ matrix.ghc-ver }}
-    - name: Environment settings based on the Haskell setup
+    - if: ${{ runner.os != 'Linux' }}
+      name: Environment settings based on the Haskell setup
       run: |
         GHC_VER=$(ghc --numeric-version)
         CABAL_VER=$(cabal --numeric-version)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,6 +231,9 @@ jobs:
         ghc-ver:
         - 9.12.2
         os:
+        - windows-latest
+        - macos-14
+        - macos-13
         - ubuntu-latest
   deploy:
     if: ${{ !cancelled() }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,17 +95,12 @@ jobs:
         echo "content-type    = ${{ steps.vars.outputs.content-type }}"
         echo "filename        = ${{ steps.vars.outputs.filename     }}"
         echo "bindist         = ${{ steps.vars.outputs.bindist      }}"
-    - if: runner.os == 'Linux'
-      name: Install GMP library (Linux)
-      run: |
-        sudo apt-get update
-        sudo apt-get install libgmp-dev
     - if: ${{ runner.os == 'Linux' }}
       name: Set up Alpine Linux with GHC and the static library for ICU
       uses: jirutka/setup-alpine@v1
       with:
         packages: |
-          cabal g++ gcc icu-static gmp-dev musl-dev ncurses-dev ncurses-static zlib-static zlib-dev
+          cabal g++ gcc gmp-dev gmp-static icu-static musl-dev ncurses-dev ncurses-static zlib-static zlib-dev
     - id: setup-haskell
       if: ${{ runner.os != 'Linux' }}
       uses: haskell-actions/setup@v2

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -38,9 +38,9 @@ jobs:
         # As of today (2024-02-05), the actual version information can be found in
         # https://github.com/actions/runner-images#available-images
         os:
-          # - windows-latest
-          # - macos-14
-          # - macos-13
+          - windows-latest
+          - macos-14
+          - macos-13
           - ubuntu-latest
         ghc-ver: ['9.12.2']
         cabal-ver: [latest]

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -134,6 +134,12 @@ jobs:
         echo "filename        = ${{ steps.vars.outputs.filename     }}"
         echo "bindist         = ${{ steps.vars.outputs.bindist      }}"
 
+    - name: Install GMP library (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install libgmp-dev
+
     - name: Set up Alpine Linux with GHC and the static library for ICU
       uses: jirutka/setup-alpine@v1
       if:  ${{ runner.os == 'Linux' }}
@@ -143,7 +149,7 @@ jobs:
           g++
           gcc
           icu-static
-          libgmpxx
+          gmp-dev
           musl-dev
           ncurses-dev
           ncurses-static

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -134,12 +134,6 @@ jobs:
         echo "filename        = ${{ steps.vars.outputs.filename     }}"
         echo "bindist         = ${{ steps.vars.outputs.bindist      }}"
 
-    - name: Install GMP library (Linux)
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update
-        sudo apt-get install libgmp-dev
-
     - name: Set up Alpine Linux with GHC and the static library for ICU
       uses: jirutka/setup-alpine@v1
       if:  ${{ runner.os == 'Linux' }}
@@ -148,8 +142,9 @@ jobs:
           cabal
           g++
           gcc
-          icu-static
           gmp-dev
+          gmp-static
+          icu-static
           musl-dev
           ncurses-dev
           ncurses-static

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -37,7 +37,11 @@ jobs:
         # "most canonical", since this is the deploy action.
         # As of today (2024-02-05), the actual version information can be found in
         # https://github.com/actions/runner-images#available-images
-        os: [windows-latest, macos-14, macos-13, ubuntu-latest]
+        os:
+          - windows-latest
+          - macos-14
+          - macos-13
+          - ubuntu-latest
         ghc-ver: ['9.12.2']
         cabal-ver: [latest]
 
@@ -139,9 +143,10 @@ jobs:
           g++
           gcc
           icu-static
+          libgmpxx
+          musl-dev
           ncurses-dev
           ncurses-static
-          musl-dev
           zlib-static
           zlib-dev
 
@@ -153,6 +158,7 @@ jobs:
         cabal-version: ${{ matrix.cabal-ver }}
 
     - name: Environment settings based on the Haskell setup
+      if: ${{ runner.os != 'Linux' }}
       run: |
         GHC_VER=$(ghc --numeric-version)
         CABAL_VER=$(cabal --numeric-version)

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -38,9 +38,9 @@ jobs:
         # As of today (2024-02-05), the actual version information can be found in
         # https://github.com/actions/runner-images#available-images
         os:
-          - windows-latest
-          - macos-14
-          - macos-13
+          # - windows-latest
+          # - macos-14
+          # - macos-13
           - ubuntu-latest
         ghc-ver: ['9.12.2']
         cabal-ver: [latest]


### PR DESCRIPTION
Closes #7918.

@L-TChen : Greetings from AIM XL in Budapest!
I have no idea how to fix this workflow which broke in the new ubuntu-24.04 image, could you take over?
Would be important to get this fixed before the upcoming release of 2.8.0.

Reported upstream:
- https://github.com/actions/runner-images/issues/12324
- https://github.com/jirutka/setup-alpine/issues/24
