### PR TITLE
Mimer refactor

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -607,6 +607,8 @@ library
       Agda.Main
       Agda.Mimer.Mimer
       Agda.Mimer.Options
+      Agda.Mimer.Types
+      Agda.Mimer.Monad
       Agda.Setup
       Agda.Setup.DataFiles
       Agda.Setup.EmacsMode

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -400,6 +400,7 @@ common language
       TypeSynonymInstances
       ViewPatterns
       TypeApplications
+      ImportQualifiedPost
 
   other-extensions:
       AllowAmbiguousTypes

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -678,7 +678,6 @@ interpret (Cmd_autoOne norm ii rng str) = do
       display_info $ Info_Auto $ unlines $
         [ "Solutions:" ] ++
         [ "  " ++ show i ++ ". " ++ s | (i, s) <- sols ]
-    MimerClauses{} -> __IMPOSSIBLE__    -- Mimer can't do case splitting yet
 
 interpret (Cmd_autoAll norm) = do
   iis <- getInteractionPoints
@@ -700,7 +699,6 @@ interpret (Cmd_autoAll norm) = do
           putResponse $ Resp_GiveAction ii $ Give_String str
           pure [ii]
         MimerList{} -> pure []    -- Don't list solutions in autoAll
-        MimerClauses{} -> __IMPOSSIBLE__  -- Mimer can't do case splitting yet
     modifyTheInteractionPoints (List.\\ solved)
 
 interpret (Cmd_context norm ii _ _) =

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -693,25 +693,3 @@ tryRefineAddMetas goal goalType branch comp = withBranchAndGoal branch goal $ do
   branch' <- updateBranch [] branch
   tryRefineWith goal goalType branch' comp'
 
--- Hack to let you experiment with costs using verbosity flags.
-customCosts :: TCM Costs
-customCosts = do
-  costLocal         <- cost "local"
-  costFn            <- cost "fn"
-  costDataCon       <- cost "dataCon"
-  costRecordCon     <- cost "recordCon"
-  costSpeculateProj <- cost "speculateProj"
-  costProj          <- cost "proj"
-  costAxiom         <- cost "axiom"
-  costLet           <- cost "let"
-  costLevel         <- cost "level"
-  costSet           <- cost "set"
-  costRecCall       <- cost "recCall"
-  costNewMeta       <- cost "newMeta"
-  costNewHiddenMeta <- cost "newHiddenMeta"
-  compReuse         <- cost "compReuse"
-  let costCompReuse uses = compReuse * uses ^ 2
-  pure Costs{..}
-  where
-    cost key = getVerbosityLevel ("mimer-cost." ++ key)
-

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -460,22 +460,6 @@ genRecCalls thisFn = do
       mapM (\ c -> (`addCost` c) <$> callCost c) comps
 
 
-partitionStepResult :: [SearchStepResult] -> SM ([SearchBranch], [MimerResult])
-partitionStepResult [] = return ([],[])
-partitionStepResult (x:xs) = do
-  let rest = partitionStepResult xs
-  (brs',sols) <- rest
-  case x of
-    NoSolution -> rest
-    OpenBranch br -> return (br:brs', sols)
-    ResultExpr exp -> do
-      str <- P.render <$> prettyTCM exp
-      return $ (brs', MimerExpr str : sols)
-    ResultClauses cls -> do
-      f <- fromMaybe __IMPOSSIBLE__ <$> asks searchFnName
-      return $ (brs', MimerClauses f cls : sols)
-
-
 refine :: SearchBranch -> SM [SearchStepResult]
 refine branch = withBranchState branch $ do
   let (goal1, branch1) = nextGoal branch

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -196,8 +196,12 @@ runSearch norm options ii rng = withInteractionId ii $ do
           return [sol]
         _ -> __IMPOSSIBLE__
     _ -> do
-      startBranch   <- startSearchBranch metaIds
       searchOptions <- makeSearchOptions norm options ii
+      -- Caution: startSearchBranch puts the current TCState in the branch, which includes
+      --          the freshId counter for components, that gets bumped in makeSearchOptions
+      --          above (computing the initial components), so it's important to not switch
+      --          these two calls around.
+      startBranch   <- startSearchBranch metaIds
 
       reportSDoc "mimer.init" 20 $ "Using search options:" $$ nest 2 (prettyTCM searchOptions)
       reportSDoc "mimer.init" 20 $ "Initial search branch:" $$ nest 2 (pretty startBranch)

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -31,7 +31,6 @@ import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT(..), runReaderT, asks, ask, lift)
 import Data.Functor ((<&>))
-import Data.List ((\\))
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -70,7 +69,7 @@ import Agda.Utils.Monad (concatMapM)
 
 import Agda.Mimer.Types (MimerResult(..), BaseComponents(..), Component(..),
                          SearchBranch(..), SearchStepResult(..), SearchOptions(..),
-                         Goal(..), Costs(..), goalMeta,
+                         Goal(..), Costs(..), goalMeta, replaceCompMeta,
                          incRefineFail, incRefineSuccess, incCompRegen, incCompNoRegen,
                          nextGoal, addCost)
 import Agda.Mimer.Monad
@@ -383,7 +382,7 @@ genRecCalls thisFn = do
                 putTC state
                 go thisFn ((goal, i) : goals) args
               Just (newMetas1, newMetas2) -> do
-                let newComp = thisFn{compMetas = newMetas1 ++ newMetas2 ++ (compMetas thisFn \\ [goalMeta goal])}
+                let newComp = replaceCompMeta (goalMeta goal) (newMetas1 ++ newMetas2) thisFn
                 (thisFn', goals') <- newRecCall
                 (newComp:) <$> go thisFn' (drop (length goals' - length goals - 1) goals') args
           go thisFn goals (_ : args) = go thisFn goals args

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -512,31 +512,6 @@ tryComponents goal goalType branch comps = withBranchAndGoal branch goal $ do
   newBranches <- concatMapM tryFor comps
   mapM checkSolved newBranches
 
-tryFns :: Goal -> Type -> SearchBranch -> SM [SearchStepResult]
-tryFns goal goalType branch = withBranchAndGoal branch goal $ do
-  reportSDoc "mimer.refine.fn" 50 $ "Trying functions"
-  fns <- asks (hintFns . searchBaseComponents)
-  newBranches <- catMaybes <$> mapM (tryRefineAddMetas goal goalType branch) fns
-  mapM checkSolved newBranches
-
-tryProjs :: Goal -> Type -> SearchBranch -> SM [SearchStepResult]
-tryProjs goal goalType branch = withBranchAndGoal branch goal $ do
-  projs <- asks (hintProjections . searchBaseComponents)
-  newBranches <- catMaybes <$> mapM (tryRefineAddMetas goal goalType branch) projs
-  mapM checkSolved newBranches
-
-tryAxioms :: Goal -> Type -> SearchBranch -> SM [SearchStepResult]
-tryAxioms goal goalType branch = withBranchAndGoal branch goal $ do
-  axioms <- asks (hintAxioms . searchBaseComponents)
-  newBranches <- catMaybes <$> mapM (tryRefineAddMetas goal goalType branch) axioms
-  mapM checkSolved newBranches
-
-tryLet :: Goal -> Type -> SearchBranch -> SM [SearchStepResult]
-tryLet goal goalType branch = withBranchAndGoal branch goal $ do
-  letVars <- asks (hintLetVars . searchBaseComponents) >>= mapM getOpenComponent
-  newBranches <- catMaybes <$> mapM (tryRefineAddMetas goal goalType branch) letVars
-  mapM checkSolved newBranches
-
 -- | Returns @Right@ for normal lambda abstraction and @Left@ for absurd lambda.
 tryLamAbs :: Goal -> Type -> SearchBranch -> SM (Either SearchBranch (Goal, Type, SearchBranch))
 tryLamAbs goal goalType branch =

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -774,12 +774,3 @@ customCosts = do
   where
     cost key = getVerbosityLevel ("mimer-cost." ++ key)
 
-getVerbosityLevel :: MonadDebug m => VerboseKey -> m VerboseLevel
-getVerbosityLevel k = do
-  t <- getVerbosity
-  return $ case t of
-    Strict.Nothing -> 1
-    Strict.Just t
-      | t == Trie.singleton [] 0 -> 0
-      | otherwise -> lastWithDefault 0 $ Trie.lookupPath ks t
-  where ks = parseVerboseKey k

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -1,17 +1,193 @@
 
 module Agda.Mimer.Monad where
 
+import Control.DeepSeq (NFData(..))
+import Control.Monad
+import Control.Monad.Except (catchError)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Reader (ReaderT, asks)
+import Control.Monad.Reader (ReaderT(..), asks, ask)
 import Data.IORef (modifyIORef')
+import Data.Map qualified as Map
+import Data.List qualified as List
+import Data.Maybe
 
-import Agda.TypeChecking.Monad (TCM, verboseS)
+import Agda.Syntax.Common (MetaId, Nat)
+import Agda.Syntax.Concrete.Name qualified as C
+import Agda.Syntax.Internal (Term(..), Type, QName(..), Name, Dom, Dom'(..))
+import Agda.Syntax.Internal.MetaVars (AllMetas(..))
+import Agda.Syntax.Translation.AbstractToConcrete (abstractToConcrete_)
+import Agda.TypeChecking.Monad
+import Agda.TypeChecking.Pretty
+import Agda.TypeChecking.Conversion (equalType)
+import Agda.TypeChecking.Constraints (noConstraints)
+import Agda.TypeChecking.Telescope (flattenTel)
+import Agda.Benchmarking qualified as Bench
+import Agda.Utils.Benchmark (billTo)
+import Agda.Utils.Functor ((<&>))
+import Agda.Utils.Impossible
+
 import Agda.Mimer.Types
 
 type SM a = ReaderT SearchOptions TCM a
+
+------------------------------------------------------------------------
+-- * Agda internals
+------------------------------------------------------------------------
+
+getRecordFields :: (HasConstInfo tcm, MonadTCM tcm) => QName -> tcm [QName]
+getRecordFields = fmap (map unDom . recFields . theDef) . getConstInfo
+
+allOpenMetas :: (AllMetas t, ReadTCState tcm) => t -> tcm [MetaId]
+allOpenMetas t = do
+  openMetas <- getOpenMetas
+  return $ allMetas (:[]) t `List.intersect` openMetas
+
+assignMeta :: MetaId -> Term -> Type -> SM [MetaId]
+assignMeta metaId term metaType = bench [Bench.CheckRHS] $ do
+  ((), newMetaStore) <- metasCreatedBy $ do
+    metaVar <- lookupLocalMeta metaId
+    metaArgs <- getMetaContextArgs metaVar
+
+    reportSMDoc "mimer.assignMeta" 60 $ vcat
+      [ "Assigning" <+> pretty term
+      , nest 2 $ vcat [ "to" <+> pretty metaId <+> ":" <+> pretty metaType
+                      , "in context" <+> (pretty =<< getContextTelescope)
+                      ]
+      ]
+
+    assignV DirLeq metaId metaArgs term (AsTermsOf metaType) `catchError` \err -> do
+      reportSMDoc "mimer.assignMeta" 30 $ vcat
+        [ "Got error from assignV:" <+> prettyTCM err
+        , nest 2 $ vcat
+          [ "when trying to assign" <+> prettyTCM term
+          , "to" <+> prettyTCM metaId <+> ":" <+> prettyTCM metaType
+          , "in context" <+> (inTopContext . prettyTCM =<< getContextTelescope)
+          ]
+        ]
+
+  let newMetaIds = Map.keys (openMetas newMetaStore)
+  return newMetaIds
+
+getLocalVarTerms :: Int -> TCM [(Term, Dom Type)]
+getLocalVarTerms localCxt = do
+  contextTerms <- getContextTerms
+  contextTypes <- flattenTel <$> getContextTelescope
+  let inScope i _ | i < localCxt = pure True   -- Ignore scope for variables we inserted ourselves
+      inScope _ Dom{ unDom = name } = do
+        x <- abstractToConcrete_ name
+        pure $ C.isInScope x == C.InScope
+  scope <- mapM (uncurry inScope) =<< getContextVars
+  return [ e | (True, e) <- zip scope $ zip contextTerms contextTypes ]
+
+------------------------------------------------------------------------
+-- * Components
+------------------------------------------------------------------------
+
+getOpenComponent :: (MonadTCM tcm, MonadDebug tcm) => Open Component -> tcm Component
+getOpenComponent openComp = do
+  let comp = openThing openComp
+  reportSDoc "mimer.components.open" 40 $ "Opening component" <+> prettyTCM (compId comp) <+> prettyTCM (compName comp)
+  term <- getOpen $ compTerm <$> openComp
+  reportSDoc "mimer.components.open" 40 $ "  term = " <+> prettyTCM term
+  typ <- getOpen $ compType <$> openComp
+  reportSDoc "mimer.components.open" 40 $ "  typ  =" <+> prettyTCM typ
+  when (not $ null $ compMetas comp) __IMPOSSIBLE__
+  return Component
+    { compId    = compId comp
+    , compName  = compName comp
+    , compPars  = compPars comp
+    , compTerm  = term
+    , compType  = typ
+    , compRec   = compRec comp
+    , compMetas = compMetas comp
+    , compCost  = compCost comp
+    }
+
+newComponent :: MonadFresh CompId m => [MetaId] -> Cost -> Maybe Name -> Nat -> Term -> Type -> m Component
+newComponent metaIds cost mName pars term typ = fresh <&> \cId -> mkComponent cId metaIds cost mName pars term typ
+
+newComponentQ :: MonadFresh CompId m => [MetaId] -> Cost -> QName -> Nat -> Term -> Type -> m Component
+newComponentQ metaIds cost qname pars term typ = fresh <&> \cId -> mkComponent cId metaIds cost (Just $ qnameName qname) pars term typ
+
+-- Local variables:
+-- getContext :: MonadTCEnv m => m [Dom (Name, Type)]
+-- getContextArgs :: (Applicative m, MonadTCEnv m) => m Args
+-- getContextTelescope :: (Applicative m, MonadTCEnv m) => m Telescope
+-- getContextTerms :: (Applicative m, MonadTCEnv m) => m [Term]
+getLocalVars :: Int -> Cost -> TCM [Component]
+getLocalVars localCxt cost = do
+  typedTerms <- getLocalVarTerms localCxt
+  let varZeroDiscount (Var 0 []) = 1
+      varZeroDiscount _          = 0
+  mapM (\(term, domTyp) -> newComponent [] (cost - varZeroDiscount term) noName 0 term (unDom domTyp)) typedTerms
+
+------------------------------------------------------------------------
+-- * Search branches
+------------------------------------------------------------------------
+
+updateBranch' :: Maybe Component -> [MetaId] -> SearchBranch -> SM SearchBranch
+updateBranch' mComp newMetaIds branch = do
+  state <- getTC
+  let compsUsed = sbComponentsUsed branch
+  (deltaCost, compsUsed') <- case mComp of
+        Nothing -> return (0, compsUsed)
+        Just comp -> do
+          case compName comp of
+            Nothing -> return (compCost comp, compsUsed)
+            Just name -> case compsUsed Map.!? name of
+              Nothing -> return (compCost comp, Map.insert name 1 compsUsed)
+              Just uses -> do
+                reuseCost <- asks (costCompReuse . searchCosts)
+                return (compCost comp + reuseCost uses, Map.adjust succ name compsUsed)
+  return branch{ sbTCState = state
+               , sbGoals = map Goal newMetaIds ++ sbGoals branch
+               , sbCost = sbCost branch + deltaCost
+               , sbComponentsUsed = compsUsed'
+               }
+
+updateBranch :: [MetaId] -> SearchBranch -> SM SearchBranch
+updateBranch = updateBranch' Nothing
+
+updateBranchCost :: Component -> [MetaId] -> SearchBranch -> SM SearchBranch
+updateBranchCost comp = updateBranch' (Just comp)
+
+------------------------------------------------------------------------
+-- * Unification
+------------------------------------------------------------------------
+
+dumbUnifier :: Type -> Type -> SM Bool
+dumbUnifier t1 t2 = isNothing <$> dumbUnifierErr t1 t2
+
+dumbUnifierErr :: Type -> Type -> SM (Maybe TCErr)
+dumbUnifierErr t1 t2 = bench [Bench.UnifyIndices] $ do
+  updateStat incTypeEqChecks
+  noConstraints (Nothing <$ equalType t2 t1) `catchError` \err -> do
+    reportSDoc "mimer.unify" 80 $ sep [ "Unification failed with error:", nest 2 $ prettyTCM err ]
+    return $ Just err
+
+------------------------------------------------------------------------
+-- * Debugging
+------------------------------------------------------------------------
+
+reportSMDoc :: VerboseKey -> VerboseLevel -> SM Doc -> SM ()
+reportSMDoc vk vl md = reportSDoc vk vl . runReaderT md =<< ask
+
+mimerTrace :: Int -> VerboseLevel -> SM Doc -> SM ()
+mimerTrace ilvl vlvl doc = reportSMDoc "mimer.trace" vlvl $ nest (2 * ilvl) $ "-" <+> doc
+
+------------------------------------------------------------------------
+-- * Stats
+------------------------------------------------------------------------
 
 updateStat :: (MimerStats -> MimerStats) -> SM ()
 updateStat f = verboseS "mimer.stats" 10 $ do
   ref <- asks searchStats
   liftIO $ modifyIORef' ref f
+
+bench :: NFData a => [Bench.Phase] -> SM a -> SM a
+bench k ma = billTo (mimerAccount : k) ma
+  where
+    -- Dummy account to avoid updating Bench. Doesn't matter since this is only used interactively
+    -- to debug Mimer performance.
+    mimerAccount = Bench.Sort
 

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -628,6 +628,28 @@ prettyBranch branch = withBranchState branch $ do
       , "used components:" <+> pretty (Map.toList $ sbComponentsUsed branch)
       ])
 
+-- Hack to let you experiment with costs using verbosity flags.
+customCosts :: TCM Costs
+customCosts = do
+  costLocal         <- cost "local"
+  costFn            <- cost "fn"
+  costDataCon       <- cost "dataCon"
+  costRecordCon     <- cost "recordCon"
+  costSpeculateProj <- cost "speculateProj"
+  costProj          <- cost "proj"
+  costAxiom         <- cost "axiom"
+  costLet           <- cost "let"
+  costLevel         <- cost "level"
+  costSet           <- cost "set"
+  costRecCall       <- cost "recCall"
+  costNewMeta       <- cost "newMeta"
+  costNewHiddenMeta <- cost "newHiddenMeta"
+  compReuse         <- cost "compReuse"
+  let costCompReuse uses = compReuse * uses ^ 2
+  pure Costs{..}
+  where
+    cost key = getVerbosityLevel ("mimer-cost." ++ key)
+
 ------------------------------------------------------------------------
 -- * Stats
 ------------------------------------------------------------------------

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -729,16 +729,16 @@ bench k ma = billTo (mimerAccount : k) ma
     -- to debug Mimer performance.
     mimerAccount = Bench.Sort
 
-writeTime :: (ReadTCState m, MonadError TCErr m, MonadTCM m, MonadDebug m) => InteractionId -> Maybe CPUTime -> m ()
-writeTime ii mTime = do
-  let time = case mTime of
-        Nothing -> "n/a"
-        Just (CPUTime t) -> show t
+writeTime :: (ReadTCState m, MonadError TCErr m, MonadTCM m, MonadDebug m)
+          => InteractionId
+          -> CPUTime
+          -> m ()
+writeTime ii (CPUTime time) = do
   file <- rangeFile . ipRange <$> lookupInteractionPoint ii
   case file of
     SMaybe.Nothing ->
       reportSLn "mimer.stats" 2 "No file found for interaction id"
     SMaybe.Just file -> do
       let path = filePath (rangeFilePath file) ++ ".stats"
-      liftIO $ appendFile path (show (interactionId ii) ++ " " ++ time ++ "\n")
+      liftIO $ appendFile path (show (interactionId ii) ++ " " ++ show time ++ "\n")
 

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -3,29 +3,43 @@ module Agda.Mimer.Monad where
 
 import Control.DeepSeq (NFData(..))
 import Control.Monad
-import Control.Monad.Except (catchError)
+import Control.Monad.Except (catchError, MonadError)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Reader (ReaderT(..), asks, ask)
+import Control.Monad.Reader (ReaderT(..), asks, ask, lift)
 import Data.IORef (modifyIORef')
 import Data.Map qualified as Map
 import Data.List qualified as List
+import Data.List.NonEmpty qualified as NonEmptyList (head)
 import Data.Maybe
 
-import Agda.Syntax.Common (MetaId, Nat)
+import Agda.Syntax.Common
+import Agda.Syntax.Internal
 import Agda.Syntax.Concrete.Name qualified as C
-import Agda.Syntax.Internal (Term(..), Type, QName(..), Name, Dom, Dom'(..))
+import Agda.Syntax.Abstract (Expr)
+import Agda.Syntax.Abstract qualified as A
+import Agda.Syntax.Abstract.Views qualified as A
 import Agda.Syntax.Internal.MetaVars (AllMetas(..))
 import Agda.Syntax.Translation.AbstractToConcrete (abstractToConcrete_)
+import Agda.Syntax.Translation.InternalToAbstract (reify, blankNotInScope)
+import Agda.Syntax.Scope.Base qualified as Scope
 import Agda.TypeChecking.Monad
+import Agda.TypeChecking.MetaVars (newValueMeta)
+import Agda.TypeChecking.Primitive (getBuiltinName)
+import Agda.TypeChecking.Datatypes (isDataOrRecord)
+import Agda.TypeChecking.Reduce (reduce, instantiateFull, instantiate)
+import Agda.TypeChecking.Records (isRecord)
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Conversion (equalType)
 import Agda.TypeChecking.Constraints (noConstraints)
-import Agda.TypeChecking.Telescope (flattenTel)
+import Agda.TypeChecking.Telescope (flattenTel, piApplyM)
+import Agda.TypeChecking.Substitute (pattern TelV, telView', piApply, apply, applyE, NoSubst(..))
+import Agda.Interaction.BasicOps (normalForm)
 import Agda.Benchmarking qualified as Bench
 import Agda.Utils.Benchmark (billTo)
-import Agda.Utils.Functor ((<&>))
+import Agda.Utils.Functor ((<&>), (<.>))
 import Agda.Utils.Impossible
 
+import Agda.Mimer.Options
 import Agda.Mimer.Types
 
 type SM a = ReaderT SearchOptions TCM a
@@ -36,6 +50,20 @@ type SM a = ReaderT SearchOptions TCM a
 
 getRecordFields :: (HasConstInfo tcm, MonadTCM tcm) => QName -> tcm [QName]
 getRecordFields = fmap (map unDom . recFields . theDef) . getConstInfo
+
+getRecordInfo :: (MonadTCM tcm, HasConstInfo tcm) => Type
+              -> tcm (Maybe ( QName     -- Record name
+                           , Args      -- Record parameters converted to (hidden) arguments
+                           , [QName]   -- Field names
+                           , Bool      -- Is recursive?
+                           ))
+getRecordInfo typ = case unEl typ of
+  Def qname elims -> isRecord qname >>= \case
+    Nothing -> return Nothing
+    Just defn -> do
+      fields <- getRecordFields qname
+      return $ Just (qname, argsFromElims elims, fields, recRecursive_ defn)
+  _ -> return Nothing
 
 allOpenMetas :: (AllMetas t, ReadTCState tcm) => t -> tcm [MetaId]
 allOpenMetas t = do
@@ -79,9 +107,96 @@ getLocalVarTerms localCxt = do
   scope <- mapM (uncurry inScope) =<< getContextVars
   return [ e | (True, e) <- zip scope $ zip contextTerms contextTypes ]
 
+-- TODO: Rename (see metaInstantiation)
+getMetaInstantiation :: (MonadTCM tcm, PureTCM tcm, MonadDebug tcm, MonadInteractionPoints tcm, MonadFresh NameId tcm)
+  => MetaId -> tcm (Maybe Expr)
+getMetaInstantiation = metaInstantiation >=> traverse (instantiateFull >=> reify)
+
+metaInstantiation :: (MonadTCM tcm, MonadDebug tcm, ReadTCState tcm) => MetaId -> tcm (Maybe Term)
+metaInstantiation metaId = lookupLocalMeta metaId <&> mvInstantiation >>= \case
+  InstV inst -> return $ Just $ instBody inst
+  _ -> return Nothing
+
+-- TODO: why not also accept pattern record types here?
+isTypeDatatype :: (MonadTCM tcm, MonadReduce tcm, HasConstInfo tcm) => Type -> tcm Bool
+isTypeDatatype typ = liftTCM do
+  reduce typ <&> unEl >>= isDataOrRecord <&> \case
+    Just (_, IsData) -> True
+    _ -> False
+
+-- | Is an element of the given type computing a level?
+--
+-- The returned checker is only sound but not complete because the type is taken as-is
+-- rather than being reduced.
+endsInLevelTester :: TCM (Type -> Bool)
+endsInLevelTester = do
+  getBuiltinName builtinLevel >>= \case
+    Nothing    -> return $ const False
+    Just level -> return \ t ->
+      -- NOTE: We do not reduce the type before checking, so some user definitions
+      -- will not be included here.
+      case telView' t of
+        TelV _ (El _ (Def x _)) -> x == level
+        _ -> False
+
+-- | From the scope of the given meta variable,
+--   extract all names in scope that we could use during synthesis.
+--   (This excludes macros, generalizable variables, pattern synonyms.)
+getEverythingInScope :: MetaVariable -> [QName]
+getEverythingInScope metaVar = do
+  let scope = clScope $ getMetaInfo metaVar
+  let nameSpace = Scope.everythingInScope scope
+      names = Scope.nsNames nameSpace
+      validKind = \ case
+        Scope.PatternSynName           -> False   -- could consider allowing pattern synonyms, but the problem is they can't be getConstInfo'd
+        Scope.GeneralizeName           -> False   -- and any way finding the underlying constructors should be easy
+        Scope.DisallowedGeneralizeName -> False
+        Scope.MacroName                -> False
+        Scope.QuotableName             -> False
+        Scope.ConName                  -> True
+        Scope.CoConName                -> True
+        Scope.FldName                  -> True
+        Scope.DataName                 -> True
+        Scope.RecName                  -> True
+        Scope.FunName                  -> True
+        Scope.AxiomName                -> True
+        Scope.PrimName                 -> True
+        Scope.OtherDefName             -> True
+      qnames = map Scope.anameName
+             . filter (validKind . Scope.anameKind)
+             . map NonEmptyList.head
+             $ Map.elems names
+  qnames
+
+-- TODO: Make sure the type is reduced the first time this is called
+-- TODO: Rewrite with Component?
+-- NOTE: The new metas are in left-to-right order -- the opposite of the
+-- order they should be solved in.
+applyToMetas :: Nat -> Term -> Type -> TCM (Term, Type, [MetaId])
+applyToMetas skip term typ = do
+  ctx <- getContextTelescope
+  case unEl typ of
+    Pi dom abs -> do
+      let domainType = unDom dom
+      -- TODO: What exactly does the occur check do?
+      (metaId', metaTerm) <- newValueMeta DontRunMetaOccursCheck CmpLeq domainType
+      let arg = setOrigin Inserted $ metaTerm <$ argFromDom dom
+      newType <- reduce =<< piApplyM typ metaTerm -- TODO: Is this the best place to reduce?
+      -- For records, the parameters are not included in the term
+      let newTerm = if skip > 0 then term else apply term [arg]
+      (term', typ', metas) <- applyToMetas (max 0 $ skip - 1) newTerm newType
+      return (term', typ', metaId' : metas)
+    _ -> return (term, typ, [])
+
 ------------------------------------------------------------------------
 -- * Components
 ------------------------------------------------------------------------
+
+localVarCount :: SM Int
+localVarCount = do
+  top <- asks $ length . envContext . searchTopEnv
+  cur <- length <$> getContext
+  pure $ cur - top
 
 getOpenComponent :: (MonadTCM tcm, MonadDebug tcm) => Open Component -> tcm Component
 getOpenComponent openComp = do
@@ -121,9 +236,274 @@ getLocalVars localCxt cost = do
       varZeroDiscount _          = 0
   mapM (\(term, domTyp) -> newComponent [] (cost - varZeroDiscount term) noName 0 term (unDom domTyp)) typedTerms
 
+-- | NOTE: Collects components from the *current* context, not the context of
+-- the 'InteractionId'.
+collectComponents :: Options
+                  -> Costs
+                  -> InteractionId
+                  -> Maybe QName
+                  -> [QName]
+                  -> MetaId
+                  -> TCM BaseComponents
+collectComponents opts costs ii mDefName whereNames metaId = do
+
+  lhsVars <- collectLHSVars ii
+  let recVars = lhsVars <&> \ vars -> [ (tm, NoSubst i) | (tm, Just i) <- vars ]
+
+  -- Prepare the initial component record
+  letVars <- getLetVars (costLet costs)
+  let components = BaseComponents
+        { hintFns = []
+        , hintDataTypes = []
+        , hintRecordTypes = []
+        , hintProjections = []
+        , hintAxioms = []
+        , hintLevel = []
+        , hintThisFn = Nothing
+        , hintRecVars = recVars
+        , hintLetVars = letVars
+        }
+
+  -- Extract additional components from the names given as hints.
+  hintNames <- getEverythingInScope <$> lookupLocalMeta metaId
+  isToLevel <- endsInLevelTester
+  scope <- getScope
+  components' <- foldM (go isToLevel scope) components $
+    explicitHints ++ (hintNames List.\\ explicitHints)
+
+  return BaseComponents
+    { hintFns = doSort $ hintFns components'
+    , hintDataTypes = doSort $ hintDataTypes components'
+    , hintRecordTypes = doSort $ hintRecordTypes components'
+    , hintProjections = doSort $ hintProjections components'
+    , hintAxioms = doSort $ hintAxioms components'
+    , hintLevel = doSort $ hintLevel components'
+    , hintThisFn = hintThisFn components'
+    , hintRecVars = recVars
+    , hintLetVars = letVars
+    }
+  where
+    hintMode = optHintMode opts
+    explicitHints = optExplicitHints opts
+    -- Sort by the arity of the type
+    doSort = List.sortOn (arity . compType)
+
+    isNotMutual qname f = case mDefName of
+      Nothing -> True
+      Just defName -> defName /= qname && fmap (defName `elem`) (funMutual f) /= Just True
+
+    go isToLevel scope comps qname = do
+        def <- getConstInfo qname
+        let typ = defType def
+        case theDef def of
+          Axiom{}
+            | isToLevel typ -> addLevel
+            | shouldKeep    -> addAxiom
+            | otherwise     -> done
+          -- We can't use pattern lambdas as components nor with-functions.
+          -- If the function is in the same mutual block, do not include it.
+          f@Function{ funWith = Nothing, funExtLam = Nothing }
+            | Just qname == mDefName   -> addThisFn
+            | notMutual, isToLevel typ -> addLevel
+            | notMutual, shouldKeep    -> addFn
+            where notMutual = isNotMutual qname f
+          Function{} -> done
+          Datatype{} -> addData
+          Record{} -> do
+            projections <- mapM (qnameToComponent (costSpeculateProj costs)) =<< getRecordFields qname
+            comp <- qnameToComponent (costSet costs) qname
+            return comps{ hintRecordTypes = comp : hintRecordTypes comps
+                        , hintProjections = projections ++ hintProjections comps }
+          -- We look up constructors when we need them
+          Constructor{} -> done
+          -- TODO: special treatment for primitives?
+          Primitive{}
+            | isToLevel typ  -> addLevel
+            | shouldKeep     -> addFn
+            | otherwise      -> done
+          PrimitiveSort{}    -> done
+          -- TODO: Check if we want to use these
+          DataOrRecSig{}     -> done
+          GeneralizableVar{} -> done
+          AbstractDefn{}     -> done
+        where
+          done = return comps
+          -- TODO: There is probably a better way of finding the module name
+          mThisModule = qnameModule <$> mDefName
+
+          shouldKeep = or
+            [ qname `elem` explicitHints
+            , qname `elem` whereNames
+            , case hintMode of
+                Unqualified -> Scope.isNameInScopeUnqualified qname scope
+                AllModules  -> True
+                Module      -> Just (qnameModule qname) == mThisModule
+                NoHints     -> False
+            ]
+          addLevel  = qnameToComponent (costLevel   costs) qname <&> \ comp -> comps{hintLevel     = comp : hintLevel  comps}
+          addAxiom  = qnameToComponent (costAxiom   costs) qname <&> \ comp -> comps{hintAxioms    = comp : hintAxioms comps}
+          addThisFn = qnameToComponent (costRecCall costs) qname <&> \ comp -> comps{hintThisFn    = Just comp{ compRec = True }}
+          addFn     = qnameToComponent (costFn      costs) qname <&> \ comp -> comps{hintFns       = comp : hintFns comps}
+          addData   = qnameToComponent (costSet     costs) qname <&> \ comp -> comps{hintDataTypes = comp : hintDataTypes comps}
+
+
+qnameToComponent :: (HasConstInfo tcm, ReadTCState tcm, MonadFresh CompId tcm, MonadTCM tcm)
+  => Cost -> QName -> tcm Component
+qnameToComponent cost qname = do
+  defn <- getConstInfo qname
+  -- #7120: we need to apply the module params to everything
+  mParams <- freeVarsToApply qname
+  let def = (Def qname [] `apply` mParams, 0)
+  let (term, pars) = case theDef defn of
+        c@Constructor{}    -> (Con (conSrcCon c) ConOCon [], conPars c - length mParams)
+        Axiom{}            -> def
+        GeneralizableVar{} -> def
+        Function{}         -> def
+        Datatype{}         -> def
+        Record{}           -> def
+        Primitive{}        -> def
+        PrimitiveSort{}    -> def
+        DataOrRecSig{}     -> __IMPOSSIBLE__
+        AbstractDefn{}     -> __IMPOSSIBLE__
+  newComponentQ [] cost qname pars term (defType defn `piApply` mParams)
+
+-- | Turn the let bindings of the current 'TCEnv' into components.
+getLetVars :: forall tcm. (MonadFresh CompId tcm, MonadTCM tcm, Monad tcm) => Cost -> tcm [Open Component]
+getLetVars cost = do
+  bindings <- asksTC envLetBindings
+  mapM makeComp $ Map.toAscList bindings
+  where
+    makeComp :: (Name, Open LetBinding) -> tcm (Open Component)
+    makeComp (name, opn) = do
+      cId <- fresh
+      return $ opn <&> \ (LetBinding _origin term typ) ->
+                mkComponent cId [] cost (Just name) 0 term (unDom typ)
+
+-- | Returns the variables as terms together with whether they where found under
+-- some constructor, and if so which argument of the function they appeared in. This
+-- information is used when building recursive calls, where it's important that we don't try to
+-- construct non-terminating solutions.
+collectLHSVars :: (ReadTCState tcm, MonadError TCErr tcm, MonadTCM tcm, HasConstInfo tcm)
+  => InteractionId -> tcm (Open [(Term, Maybe Int)])
+collectLHSVars ii = do
+  ipc <- ipClause <$> lookupInteractionPoint ii
+  case ipc of
+    IPNoClause -> makeOpen []
+    IPClause{ipcQName = fnName, ipcClauseNo = clauseNr} -> do
+      reportSDoc "mimer.components" 40 $ "Collecting LHS vars for" <+> prettyTCM ii
+      info <- getConstInfo fnName
+      parCount <- liftTCM getCurrentModuleFreeVars
+      case theDef info of
+        fnDef@Function{} -> do
+          let clause = funClauses fnDef !! clauseNr
+              naps = namedClausePats clause
+
+          -- Telescope at interaction point
+          iTel <- getContextTelescope
+          -- Telescope for the body of the clause
+          let cTel = clauseTel clause
+          -- HACK: To get the correct indices, we shift by the difference in telescope lengths
+          let shift = length (telToArgs iTel) - length (telToArgs cTel)
+
+          reportSDoc "mimer" 60 $ vcat
+            [ "Tel:"
+            , nest 2 $ pretty iTel $$ prettyTCM iTel
+            , "CTel:"
+            , nest 2 $ pretty cTel $$ prettyTCM cTel
+            ]
+          reportSDoc "mimer" 60 $ "Shift:" <+> pretty shift
+
+          makeOpen [ (Var (n + shift) [], (i - parCount) <$ guard underCon)    -- We count arguments excluding module parameters
+                   | (i, nap) <- zip [0..] naps
+                   , (n, underCon) <- go False $ namedThing $ unArg nap
+                   ]
+        _ -> do
+          makeOpen []
+  where
+    go isUnderCon = \case
+      VarP patInf x -> [(dbPatVarIndex x, isUnderCon)]
+      DotP patInf t -> [] -- Ignore dot patterns
+      ConP conHead conPatInf namedArgs -> concatMap (go True . namedThing . unArg) namedArgs
+      LitP{} -> []
+      ProjP{} -> []
+      IApplyP{} -> [] -- Only for Cubical?
+      DefP{} -> [] -- Only for Cubical?
+
+declarationQnames :: A.Declaration -> [QName]
+declarationQnames dec = [ q | Scope.WithKind _ q <- A.declaredNames dec ]
+
+applyProj :: Args -> Component -> QName -> SM Component
+applyProj recordArgs comp' qname = do
+  cost <- asks (costProj . searchCosts)
+  -- Andreas, 2025-03-31, issue #7662: hack to prevent postfix printing of ♭
+  projOrigin <- maybe ProjSystem (\ flat -> if qname == flat then ProjPrefix else ProjSystem)
+    <$> asks searchBuiltinFlat
+  let newTerm = applyE (compTerm comp') [Proj projOrigin qname]
+  projType <- defType <$> getConstInfo qname
+  projTypeWithArgs <- piApplyM projType recordArgs
+  newType <- piApplyM projTypeWithArgs (compTerm comp')
+  newComponentQ (compMetas comp') (compCost comp' + cost) qname 0 newTerm newType
+
+
+-- TODO: currently reducing twice
+applyToMetasG
+  :: Maybe Nat -- ^ Max number of arguments to apply.
+  -> Component -> SM Component
+applyToMetasG (Just m) comp | m <= 0 = return comp
+applyToMetasG maxArgs comp = do
+  reportSDoc "mimer.component" 25 $ "Applying component to metas" <+> prettyTCM (compId comp) <+> prettyTCM (compTerm comp)
+  ctx <- getContextTelescope
+  compTyp <- reduce $ compType comp
+  case unEl compTyp of
+    Pi dom abs -> do
+      let domainType = unDom dom
+      (metaId, metaTerm) <- createMeta domainType
+      reportSDoc "mimer.component" 30 $ "New arg meta" <+> prettyTCM metaTerm
+      let arg = setOrigin Inserted $ metaTerm <$ argFromDom dom
+      newType <- reduce =<< piApplyM (compType comp) metaTerm
+      -- Constructor parameters are not included in the term
+      let skip = compPars comp
+          newTerm | skip > 0  = compTerm comp
+                  | otherwise = apply (compTerm comp) [arg]
+      cost <- asks $ (if getHiding arg == Hidden then costNewHiddenMeta else costNewMeta) . searchCosts
+      let predNat n | n > 0     = n - 1
+                    | n == 0    = 0
+                    | otherwise = __IMPOSSIBLE__
+      applyToMetasG (predNat <$> maxArgs)
+                    comp{ compTerm = newTerm
+                        , compType = newType
+                        , compPars = predNat skip
+                        , compMetas = metaId : compMetas comp
+                        , compCost = cost + compCost comp
+                        }
+    _ ->
+      -- Set the type to the reduced version
+      return comp{compType = compTyp}
+
+createMeta :: Type -> SM (MetaId, Term)
+createMeta typ = do
+  (metaId, metaTerm) <- newValueMeta DontRunMetaOccursCheck CmpLeq typ
+  verboseS "mimer.stats" 20 $ updateStat incMetasCreated
+  reportSDoc "mimer.components" 80 $ do
+    "Created meta-variable (type in context):" <+> pretty metaTerm <+> ":" <+> (pretty =<< getMetaTypeInContext metaId)
+  return (metaId, metaTerm)
+
 ------------------------------------------------------------------------
 -- * Search branches
 ------------------------------------------------------------------------
+
+withBranchState :: SearchBranch -> SM a -> SM a
+withBranchState br ma = do
+  putTC (sbTCState br)
+  ma
+
+withBranchAndGoal :: SearchBranch -> Goal -> SM a -> SM a
+withBranchAndGoal br goal ma = inGoalEnv goal $ withBranchState br ma
+
+inGoalEnv :: Goal -> SM a -> SM a
+inGoalEnv goal  ret = do
+  reportSDoc "mimer.env" 70 $ "going into environment of goal" <+> prettyTCM (goalMeta goal)
+  withMetaId (goalMeta goal) ret
 
 updateBranch' :: Maybe Component -> [MetaId] -> SearchBranch -> SM SearchBranch
 updateBranch' mComp newMetaIds branch = do
@@ -151,6 +531,33 @@ updateBranch = updateBranch' Nothing
 updateBranchCost :: Component -> [MetaId] -> SearchBranch -> SM SearchBranch
 updateBranchCost comp = updateBranch' (Just comp)
 
+checkSolved :: SearchBranch -> SM SearchStepResult
+checkSolved branch = do
+  reportSDoc "mimer" 20 $ "Checking if branch is solved"
+  reportSDoc "mimer" 30 $ "  remaining subgoals: " <+> prettyTCM (map goalMeta $ sbGoals branch)
+  topMetaId <- asks searchTopMeta
+  topMeta <- lookupLocalMeta topMetaId
+  ii <- asks searchInteractionId
+  withInteractionId ii $ withBranchState branch $ do
+    metaArgs <- getMetaContextArgs topMeta
+    inst <- normaliseSolution $ apply (MetaV topMetaId []) metaArgs
+    -- Issue #7639: The subgoals as generated by `applyToMetasG` (and other functions)
+    -- are already stored in the `sbGoals` field of the branch.
+    -- Here we just prune the subgoals that are already solved by unification.
+    goals <- filterM (isNothing <.> getMetaInstantiation . goalMeta) $ sbGoals branch
+    case goals of
+      -- Issue #378: Blank out variables that are not in scope.
+      -- This might leave unsolved metas but is probably better
+      -- than generating out-of-scope variables.
+      [] -> ResultExpr <$> (blankNotInScope =<< reify inst)
+      _ -> do
+        return $ OpenBranch branch { sbGoals = goals }
+
+normaliseSolution :: Term -> SM Term
+normaliseSolution t = do
+  norm <- asks searchRewrite
+  lift . normalForm norm =<< instantiateFull t
+
 ------------------------------------------------------------------------
 -- * Unification
 ------------------------------------------------------------------------
@@ -174,6 +581,21 @@ reportSMDoc vk vl md = reportSDoc vk vl . runReaderT md =<< ask
 
 mimerTrace :: Int -> VerboseLevel -> SM Doc -> SM ()
 mimerTrace ilvl vlvl doc = reportSMDoc "mimer.trace" vlvl $ nest (2 * ilvl) $ "-" <+> doc
+
+topInstantiationDoc :: SM Doc
+topInstantiationDoc = asks searchTopMeta >>= getMetaInstantiation >>= maybe (return "(nothing)") prettyTCM
+
+prettyGoalInst :: Goal -> SM Doc
+prettyGoalInst goal = inGoalEnv goal $ do
+  args <- map Apply <$> getContextArgs
+  prettyTCM =<< instantiate (MetaV (goalMeta goal) args)
+
+branchInstantiationDocCost :: SearchBranch -> SM Doc
+branchInstantiationDocCost branch = branchInstantiationDoc branch <+> parens ("cost:" <+> pretty (sbCost branch))
+
+-- | For debug
+branchInstantiationDoc :: SearchBranch -> SM Doc
+branchInstantiationDoc branch = withBranchState branch topInstantiationDoc
 
 ------------------------------------------------------------------------
 -- * Stats

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -587,9 +587,6 @@ partitionStepResult (x:xs) = do
     ResultExpr exp -> do
       str <- P.render <$> prettyTCM exp
       return $ (brs', MimerExpr str : sols)
-    ResultClauses cls -> do
-      f <- fromMaybe __IMPOSSIBLE__ <$> asks searchFnName
-      return $ (brs', MimerClauses f cls : sols)
 
 ------------------------------------------------------------------------
 -- * Search options

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -1,0 +1,17 @@
+
+module Agda.Mimer.Monad where
+
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (ReaderT, asks)
+import Data.IORef (modifyIORef')
+
+import Agda.TypeChecking.Monad (TCM, verboseS)
+import Agda.Mimer.Types
+
+type SM a = ReaderT SearchOptions TCM a
+
+updateStat :: (MimerStats -> MimerStats) -> SM ()
+updateStat f = verboseS "mimer.stats" 10 $ do
+  ref <- asks searchStats
+  liftIO $ modifyIORef' ref f
+

--- a/src/full/Agda/Mimer/Types.hs
+++ b/src/full/Agda/Mimer/Types.hs
@@ -36,6 +36,10 @@ data MimerResult
 
 instance NFData MimerResult
 
+isNoResult :: MimerResult -> Bool
+isNoResult MimerNoResult = True
+isNoResult _             = False
+
 data SearchStepResult
   = ResultExpr Expr
   | ResultClauses [A.Clause]

--- a/src/full/Agda/Mimer/Types.hs
+++ b/src/full/Agda/Mimer/Types.hs
@@ -18,6 +18,7 @@ import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Substitute (NoSubst(..))
 import Agda.Interaction.Base (Rewrite(..))
 import Agda.Utils.Tuple (mapSnd)
+import Agda.Utils.Impossible
 
 import Agda.Mimer.Options
 
@@ -78,6 +79,14 @@ instance NFData Goal
 instance Eq Goal where
   g1 == g2 = goalMeta g1 == goalMeta g2
 
+-- | Take the first goal off a search branch.
+--   Precondition: the set of goals is non-empty.
+nextGoal :: SearchBranch -> (Goal, SearchBranch)
+nextGoal branch =
+  case sbGoals branch of
+    [] -> __IMPOSSIBLE__
+    goal : goals -> (goal, branch{ sbGoals = goals })
+
 ------------------------------------------------------------------------
 -- * Components
 ------------------------------------------------------------------------
@@ -100,7 +109,6 @@ data BaseComponents = BaseComponents
   , hintThisFn :: Maybe Component
   , hintLetVars :: [Open Component]
   , hintRecVars :: Open [(Term, NoSubst Term Int)] -- ^ Variable terms and which argument they come from
-  , hintSplitVars :: Open [Term]
   }
   deriving (Generic)
 
@@ -276,7 +284,6 @@ instance PrettyTCM BaseComponents where
            , "hintThisFn:" <+> thisFn
            , g prettyOpenComp "hintLetVars" (hintLetVars comps)
            , "hintRecVars: Open" <+> pretty (mapSnd unNoSubst <$> openThing (hintRecVars comps))
-           , "hintSplitVars: Open" <+> pretty (openThing $ hintSplitVars comps)
            ]
          ]
     where

--- a/src/full/Agda/Mimer/Types.hs
+++ b/src/full/Agda/Mimer/Types.hs
@@ -222,14 +222,14 @@ defaultCosts = Costs
 ------------------------------------------------------------------------
 
 data MimerStats = MimerStats
-  { statCompHit       :: Nat -- ^ Could make use of an already generated component
-  , statCompGen       :: Nat -- ^ Could use a generator for a component
-  , statCompRegen     :: Nat -- ^ Had to regenerate the cache (new context)
-  , statCompNoRegen   :: Nat -- ^ Did not have to regenerate the cache
-  , statMetasCreated  :: Nat -- ^ Total number of meta-variables created explicitly (not through unification)
-  , statTypeEqChecks  :: Nat -- ^ Number of times type equality is tested (with unification)
-  , statRefineSuccess :: Nat -- ^ Number of times a refinement has been successful
-  , statRefineFail    :: Nat -- ^ Number of times a refinement has failed
+  { statCompHit       :: !Int -- ^ Could make use of an already generated component
+  , statCompGen       :: !Int -- ^ Could use a generator for a component
+  , statCompRegen     :: !Int -- ^ Had to regenerate the cache (new context)
+  , statCompNoRegen   :: !Int -- ^ Did not have to regenerate the cache
+  , statMetasCreated  :: !Int -- ^ Total number of meta-variables created explicitly (not through unification)
+  , statTypeEqChecks  :: !Int -- ^ Number of times type equality is tested (with unification)
+  , statRefineSuccess :: !Int -- ^ Number of times a refinement has been successful
+  , statRefineFail    :: !Int -- ^ Number of times a refinement has failed
   } deriving (Show, Eq, Generic)
 instance NFData MimerStats
 

--- a/src/full/Agda/Mimer/Types.hs
+++ b/src/full/Agda/Mimer/Types.hs
@@ -9,7 +9,6 @@ import GHC.Generics (Generic)
 import Data.IORef (IORef)
 
 import Agda.Syntax.Abstract (Expr)
-import Agda.Syntax.Abstract qualified as A
 import Agda.Syntax.Common.Pretty qualified as P
 import Agda.Syntax.Common.Pretty (Pretty)
 import Agda.Syntax.Common (InteractionId, Nat)
@@ -29,7 +28,6 @@ import Agda.Mimer.Options
 
 data MimerResult
   = MimerExpr String -- ^ Returns 'String' rather than 'Expr' because the give action expects a string.
-  | MimerClauses QName [A.Clause]
   | MimerList [(Int, String)]
   | MimerNoResult
   deriving (Generic)
@@ -42,7 +40,6 @@ isNoResult _             = False
 
 data SearchStepResult
   = ResultExpr Expr
-  | ResultClauses [A.Clause]
   | OpenBranch SearchBranch
   | NoSolution
   deriving (Generic)
@@ -389,7 +386,6 @@ instance PrettyTCM Component where
 instance PrettyTCM MimerResult where
   prettyTCM = \case
     MimerExpr expr    -> pretty expr
-    MimerClauses f cl -> "MimerClauses" <+> pretty f <+> "[..]" -- TODO: display the clauses
     MimerNoResult     -> "MimerNoResult"
     MimerList sols    -> "MimerList" <+> pretty sols
 

--- a/src/full/Agda/Mimer/Types.hs
+++ b/src/full/Agda/Mimer/Types.hs
@@ -1,0 +1,204 @@
+
+module Agda.Mimer.Types where
+
+import Control.DeepSeq (NFData)
+import Data.Function (on)
+import Data.Map (Map)
+import GHC.Generics (Generic)
+
+import Agda.Syntax.Abstract (Expr)
+import qualified Agda.Syntax.Abstract as A
+import Agda.Syntax.Common (InteractionId, Nat)
+import Agda.Syntax.Internal
+
+import Agda.TypeChecking.Monad (TCState, CheckpointId, Open, TCEnv)
+import Agda.TypeChecking.Substitute (NoSubst)
+
+-- import Agda.Utils.Permutation (idP, permute, takeP)
+
+import Agda.Mimer.Options
+
+import Data.IORef (IORef)
+
+-- Temporary (used for custom cost verbosity hack)
+import Agda.Interaction.Base (Rewrite(..))
+
+data MimerResult
+  = MimerExpr String -- ^ Returns 'String' rather than 'Expr' because the give action expects a string.
+  | MimerClauses QName [A.Clause]
+  | MimerList [(Int, String)]
+  | MimerNoResult
+  deriving (Generic)
+
+instance NFData MimerResult
+
+data SearchBranch = SearchBranch
+  { sbTCState :: TCState
+  , sbGoals :: [Goal]
+  , sbCost :: Int
+  , sbCache :: Map CheckpointId ComponentCache
+  , sbComponentsUsed :: Map Name Int -- ^ Number of times each component has been used
+  }
+  deriving (Generic)
+instance NFData SearchBranch
+
+-- | NOTE: Equality is only on the fields `sbCost` and `sbGoals`
+instance Eq SearchBranch where
+  sb1 == sb2 = sbCost sb1 == sbCost sb2 && sbGoals sb1 == sbGoals sb2
+
+-- TODO: Explain
+instance Ord SearchBranch where
+  compare = compare `on` sbCost
+
+-- Map source component to generated components
+type ComponentCache = Map Component (Maybe [Component])
+
+data Goal = Goal
+  { goalMeta :: MetaId
+  }
+  deriving (Generic)
+instance NFData Goal
+
+-- TODO: Is this a reasonable Eq instance?
+instance Eq Goal where
+  g1 == g2 = goalMeta g1 == goalMeta g2
+
+-- | Components that are not changed during search. Components that do change
+-- (local variables and let bindings) are stored in each 'SearchBranch'.
+data BaseComponents = BaseComponents
+  { hintFns :: [Component]
+  , hintDataTypes :: [Component]
+  , hintRecordTypes :: [Component]
+  , hintAxioms :: [Component]
+  -- ^ Excluding those producing Level
+  , hintLevel :: [Component]
+  -- ^ A definition in a where clause
+  , hintProjections :: [Component]
+  -- ^ Variables that are candidates for arguments to recursive calls
+  , hintThisFn :: Maybe Component
+  , hintLetVars :: [Open Component]
+  , hintRecVars :: Open [(Term, NoSubst Term Int)] -- ^ Variable terms and which argument they come from
+  , hintSplitVars :: Open [Term]
+  }
+  deriving (Generic)
+
+instance NFData BaseComponents
+
+type CompId = Int
+data Component = Component
+  { compId    :: CompId -- ^ Unique id for the component. Used for the cache.
+  , compName  :: Maybe Name -- ^ Used for keeping track of how many times a component has been used
+  , compPars  :: Nat -- ^ How many arguments should be dropped (e.g. constructor parameters)
+  , compTerm  :: Term
+  , compType  :: Type
+  , compRec   :: Bool -- ^ Is this a recursive call
+  , compMetas :: [MetaId]
+  , compCost  :: Cost
+  }
+  deriving (Eq, Generic)
+
+instance NFData Component
+
+-- TODO: Is this reasonable?
+instance Ord Component where
+  compare = compare `on` compId
+
+data SearchStepResult
+  = ResultExpr Expr
+  | ResultClauses [A.Clause]
+  | OpenBranch SearchBranch
+  | NoSolution
+  deriving (Generic)
+instance NFData SearchStepResult
+
+
+data SearchOptions = SearchOptions
+  { searchBaseComponents :: BaseComponents
+  , searchHintMode :: HintMode
+  , searchTimeout :: MilliSeconds
+  , searchGenProjectionsLocal :: Bool
+  , searchGenProjectionsLet :: Bool
+  , searchGenProjectionsExternal :: Bool
+  , searchGenProjectionsRec :: Bool
+  , searchSpeculateProjections :: Bool
+  , searchTopMeta :: MetaId
+  , searchTopEnv :: TCEnv
+  , searchTopCheckpoint :: CheckpointId
+  , searchInteractionId :: InteractionId
+  , searchFnName :: Maybe QName
+  , searchCosts :: Costs
+  , searchStats :: IORef MimerStats
+  , searchRewrite :: Rewrite
+  , searchBuiltinFlat :: Maybe QName
+      -- Cache BUILTIN_FLAT for issue #7662 workaround
+  }
+
+type Cost = Int
+data Costs = Costs
+  { costLocal :: Cost
+  , costFn :: Cost
+  , costDataCon :: Cost
+  , costRecordCon :: Cost
+  , costSpeculateProj :: Cost
+  , costProj :: Cost
+  , costAxiom :: Cost
+  , costLet :: Cost
+  , costLevel :: Cost
+  , costSet :: Cost -- Should probably be replaced with multiple different costs
+  , costRecCall :: Cost
+  , costNewMeta :: Cost -- ^ Cost of a new meta-variable appearing in a non-implicit position
+  , costNewHiddenMeta :: Cost -- ^ Cost of a new meta-variable appearing in an implicit position
+  , costCompReuse :: Nat -> Cost -- ^ Cost of reusing a component @n@ times. Only counted when @n>1@.
+  }
+
+noCost :: Cost
+noCost = 0
+
+defaultCosts :: Costs
+defaultCosts = Costs
+  { costLocal = 3
+  , costFn = 10
+  , costDataCon = 3
+  , costRecordCon = 3
+  , costSpeculateProj = 20
+  , costProj = 3
+  , costAxiom = 10
+  , costLet = 5
+  , costLevel = 3
+  , costSet = 10
+  , costRecCall = 8
+  , costNewMeta = 10
+  , costNewHiddenMeta = 1
+  , costCompReuse = \uses -> 10 * (uses - 1) ^ 2
+  }
+
+------------------------------------------------------------------------------
+-- * Measure performance
+------------------------------------------------------------------------------
+
+data MimerStats = MimerStats
+  { statCompHit :: Nat -- ^ Could make use of an already generated component
+  , statCompGen :: Nat -- ^ Could use a generator for a component
+  , statCompRegen :: Nat -- ^ Had to regenerate the cache (new context)
+  , statCompNoRegen :: Nat -- ^ Did not have to regenerate the cache
+  , statMetasCreated :: Nat -- ^ Total number of meta-variables created explicitly (not through unification)
+  , statTypeEqChecks :: Nat -- ^ Number of times type equality is tested (with unification)
+  , statRefineSuccess :: Nat -- ^ Number of times a refinement has been successful
+  , statRefineFail :: Nat -- ^ Number of times a refinement has failed
+  } deriving (Show, Eq, Generic)
+instance NFData MimerStats
+
+emptyMimerStats :: MimerStats
+emptyMimerStats = MimerStats
+  { statCompHit = 0, statCompGen = 0, statCompRegen = 0 , statCompNoRegen = 0 , statMetasCreated = 0, statTypeEqChecks = 0, statRefineSuccess = 0 , statRefineFail = 0}
+
+incCompHit, incCompGen, incCompRegen, incCompNoRegen, incMetasCreated, incTypeEqChecks, incRefineSuccess, incRefineFail :: MimerStats -> MimerStats
+incCompHit       stats = stats {statCompHit       = succ $ statCompHit stats}
+incCompGen       stats = stats {statCompGen       = succ $ statCompGen stats}
+incCompRegen     stats = stats {statCompRegen     = succ $ statCompRegen stats}
+incCompNoRegen   stats = stats {statCompNoRegen   = succ $ statCompNoRegen stats}
+incMetasCreated  stats = stats {statMetasCreated  = succ $ statMetasCreated stats}
+incTypeEqChecks  stats = stats {statTypeEqChecks  = succ $ statTypeEqChecks stats}
+incRefineSuccess stats = stats {statRefineSuccess = succ $ statRefineSuccess stats}
+incRefineFail    stats = stats {statRefineFail    = succ $ statRefineFail stats}
+

--- a/src/full/Agda/Mimer/Types.hs
+++ b/src/full/Agda/Mimer/Types.hs
@@ -4,6 +4,7 @@ module Agda.Mimer.Types where
 import Control.DeepSeq (NFData)
 import Data.Function (on)
 import Data.Map (Map)
+import Data.List qualified as List
 import GHC.Generics (Generic)
 import Data.IORef (IORef)
 
@@ -152,6 +153,9 @@ noName = Nothing
 
 addCost :: Cost -> Component -> Component
 addCost cost comp = comp { compCost = cost + compCost comp }
+
+replaceCompMeta :: MetaId -> [MetaId] -> Component -> Component
+replaceCompMeta old new c = c{ compMetas = new ++ List.delete old (compMetas c) }
 
 ------------------------------------------------------------------------
 -- * SearchOptions


### PR DESCRIPTION
Pure(?) refactoring moving code out of `Mimer.hs` into new modules `Mimer.Types` and `Mimer.Monad` and does some modest code improvements.

(Also tries to sneak in `ImportQualifiedPost` so can't be merged until we drop ghc-8.8)