### PR TITLE
Hint towards --guardedness even when --sized-types is on

### DIFF
--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -121,7 +121,7 @@ prettyWarning = \case
       let report hint because = if null because then empty else do
             vcat
               [ fwords "Termination checking failed for the following functions:"
-              , hint
+              , fwords hint
               , nest 2 $ fsep $ punctuate comma $
                   map (pretty . dropTopLevel) $
                     concatMap termErrFunctions because
@@ -142,8 +142,14 @@ prettyWarning = \case
         , "sized-types = " <+> (text . show) haveSizedTypes
         , "guardedness = " <+> (text . show) guardedness
         ]
-      if haveSizedTypes || guardedness == Value False then report empty errs else do
-        vcat [ report "(Option --guardedness might fix this problem.)" guardednessHelps
+      if guardedness == Value False then report empty errs else do
+        let
+          hint = concat $ concat
+            [ [ "(Option --guardedness might fix this problem" ]
+            , [ ", but it is not --safe to use with --sized-types" | haveSizedTypes ]
+            , [ ".)" ]
+            ]
+        vcat [ report hint guardednessHelps
              , report empty guardednessHelpsNot
              ]
 

--- a/test/Fail/GuardednessHintSizedTypes.agda
+++ b/test/Fail/GuardednessHintSizedTypes.agda
@@ -1,4 +1,6 @@
-{-# OPTIONS --safe #-}
+-- Andreas, 2025-06-02, hint towards --guardedness even with --sized-types
+
+{-# OPTIONS --sized-types #-}  -- just to trigger the right error message
 
 record Stream (A : Set) : Set where
   coinductive
@@ -14,7 +16,8 @@ repeat x .tail = repeat x
 
 -- Expected error: [TerminationIssue]
 -- Termination checking failed for the following functions:
--- (Option --guardedness might fix this problem.)
+-- (Option --guardedness might fix this problem, but it is not --safe
+-- to use with --sized-types.)
 --   repeat
 -- Problematic calls:
 --   repeat x

--- a/test/Fail/GuardednessHintSizedTypes.err
+++ b/test/Fail/GuardednessHintSizedTypes.err
@@ -1,0 +1,8 @@
+GuardednessHintSizedTypes.agda:13.1-15.26: error: [TerminationIssue]
+Termination checking failed for the following functions:
+(Option --guardedness might fix this problem, but it is not --safe
+to use with --sized-types.)
+  repeat
+Problematic calls:
+  repeat x
+    (at GuardednessHintSizedTypes.agda:15.18-24)


### PR DESCRIPTION
Refines:
- #7778