### PR TITLE
Add `use-xdg-data-home`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         access_token: ${{ github.token }}
   build:
     env:
-      ARGS: --disable-executable-profiling --disable-library-profiling
+      ARGS: --disable-executable-profiling --disable-library-profiling --flags=use-xdg-data-home
       LINUX_ARGS: --enable-executable-static  --enable-split-sections
       MACOS_ARGS: --flags=enable-cluster-counting
       MATRIX_OS: ${{ matrix.os }}

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -206,6 +206,14 @@ flag optimise-heavily
   description:
     Enable some expensive optimisations when compiling Agda.
 
+flag use-xdg-data-home
+  default: False
+  manual: True
+  description:
+    Install data files under $XDG_DATA_HOME/agda by default
+    instead of the installation location defined by Cabal.
+    This should not be enabled in declarative build environments like Nix or Guix.
+
 -- Common stanzas
 ---------------------------------------------------------------------------
 
@@ -217,6 +225,10 @@ common language
     ghc-options:
       -fexpose-all-unfoldings
       -fspecialise-aggressively
+
+  if flag(use-xdg-data-home)
+    cpp-options:
+      -DUSE_XDG_DATA_HOME
 
   if flag(dump-core)
     ghc-options:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,14 @@ Installation
      the runtimes for the `JS` and `GHC` backends,
      and the emacs mode.
 
-     These will be written to `${Agda_datadir}/${VERSION}`
+     These will be written to the data directory
      on the first invocation of `agda` or an invocation of
      `agda --setup`, `agda --emacs-mode setup`, or `agda --emacs-mode compile`.
-     Herein, `${VERSION}` is the Agda version and `${Agda_datadir}`
-     the Agda data directory, on Unix-like systems
-     defaulting to `${HOME}/.local/share/agda`.
+
+     The location of the data directory can be printed using
+     `agda --print-agda-data-dir` and can be controlled by the `use-xdg-data-home`
+     flag at build time and the `Agda_datadir` environment variable at runtime; see the
+     documentation for more information.
 
   The Cabal/Stack custom installation `Setup.hs` has been removed
   that previously generated the `.agdai` files for the builtin and primitive modules.
@@ -51,8 +53,9 @@ Installation
   just as for ordinary modules.
 
   This change is **breaking** for packagers of Agda
-  as the packaging routines might need to be updated
-  (but should become simpler).
+  as the packaging routines might need to be updated: in particular,
+  declarative build systems like Nix or Guix should generate the `.agdai` files
+  by invoking Agda at build time.
 
 * Added cabal build flag `dump-core` to save the optimised GHC Core code during
   compilation of Agda. This can be useful for people working on improving the

--- a/doc/user-manual/getting-started/installation.rst
+++ b/doc/user-manual/getting-started/installation.rst
@@ -343,6 +343,7 @@ When installing Agda the following flags can be used:
      Default: off.
 
 .. option:: dump-core
+
      Save GHC Core output during compilation of Agda.
      Default: off.
 
@@ -360,6 +361,16 @@ When installing Agda the following flags can be used:
      Optimise Agda heavily. If this flag is on, compiling Agda uses more memory
      but Agda runs faster.
      Default: on.
+
+.. option:: use-xdg-data-home
+
+    .. versionadded:: 2.8.0
+
+    Install data files under ``$XDG_DATA_HOME/agda`` by default
+    instead of the installation location defined by Cabal;
+    see :option:`--print-agda-data-dir`.
+    This should *not* be enabled in declarative build environments like Nix or Guix.
+    Default: off.
 
 .. hint:: During ``cabal install`` you can add build flags using the ``-f`` argument:
     ``cabal install -fenable-cluster-counting``. Whereas stack uses ``--flag`` and an

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -26,9 +26,8 @@ but in the fixed order listed in the following:
 
      .. versionadded:: 2.8.0
 
-     Extract Agda' data files (primitive library, emacs mode etc.)
-     to ``VERSION/`` under the (:envvar:`Agda_datadir`)
-     where ``VERSION`` is the numeric version of Agda.
+     Extract Agda's data files (primitive library, emacs mode etc.)
+     to the data directory (see :option:`--print-agda-data-dir`).
 
 .. option:: --version, -V
 
@@ -89,8 +88,16 @@ but in the fixed order listed in the following:
      Outputs the root of the directory structure holding Agda's data
      files such as core libraries, style files for the backends, etc.
 
-     Since 2.8.0, this is ``VERSION/`` under the (:envvar:`Agda_datadir`),
-     defaulting to ``agda/`` under (:envvar:`XDG_DATA_HOME`).
+     Since 2.8.0, the data directory is determined as follows:
+
+     - The *default base data directory* is defined at build time, either
+       as the standard data directory defined by Cabal, or, if the
+       :option:`use-xdg-data-home` build flag is enabled, as ``$XDG_DATA_HOME/agda``.
+     - The *base data directory* can be set at runtime using the :envvar:`Agda_datadir`
+       environment variable, and defaults to the default base data directory.
+     - The *data directory* is obtained by appending the version (and optional
+       commit information) to the base data directory, and can be printed
+       with this flag.
 
 .. option:: --emacs-mode={COMMAND}
 

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -359,6 +359,9 @@ printVersion backends PrintAgdaVersion = do
 #ifdef DEBUG_SERIALISATION
     "debug-serialisation: extra debug info during serialisation into '.agdai' files" :
 #endif
+#ifdef USE_XDG_DATA_HOME
+    "use-xdg-data-home: install data files under $XDG_DATA_HOME/agda by default instead of the installation location defined by Cabal" :
+#endif
     []
 
 printAgdaDataDir :: IO ()

--- a/src/github/workflows/deploy.yml
+++ b/src/github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         cabal-ver: [latest]
 
     env:
-      ARGS: "--disable-executable-profiling --disable-library-profiling"
+      ARGS: "--disable-executable-profiling --disable-library-profiling --flags=use-xdg-data-home"
       # Liang-Ting Chen (2021-01-01):
       # Cabal cannot compile statically with text-icu (required by the flag `enable-cluster-counting`),
       # see https://github.com/4e6/text-icu-static-example


### PR DESCRIPTION
Follows up and replaces https://github.com/agda/agda/pull/7818

Adds a build flag that controls whether the data directory is under XDG_DATA_HOME (the default) or in its standard location (which makes more sense for declarative build environments). Disabling the flag also disables the locking mechanism and the use of a version-specific subdirectory.

Ideally, disabling the flag would disable the embedding of data files introduced in https://github.com/agda/agda/pull/7719 entirely, but AFAICT this requires duplicating the list of data files *again* in `Agda.cabal` (once in `extra-source-files` and once in `data-files`), which I didn't want to do.