### PR TITLE
Testsuite: fix BuildSucceed runner

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -332,7 +332,7 @@ addImportedThings
   -> TCM ()
 addImportedThings isig metas ibuiltin patsyns display userwarn
                   partialdefs warnings oblock oid = do
-  stImports              `modifyTCLens` \ imp -> unionSignatures [imp, isig]
+  stImports              `modifyTCLens` \ imp -> unionSignature imp isig
   stImportedMetaStore    `modifyTCLens` HMap.union metas
   stImportedBuiltins     `modifyTCLens` \ imp -> Map.union imp ibuiltin
   stImportedUserWarnings `modifyTCLens` \ imp -> Map.union imp userwarn

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -941,6 +941,9 @@ stOccursCheckDefs = lensPostScopeState . lensOccursCheckDefs
 stSignature :: Lens' TCState Signature
 stSignature = lensPostScopeState . lensSignature
 
+stRewriteRules :: Lens' TCState RewriteRuleMap
+stRewriteRules = stSignature . sigRewriteRules
+
 stModuleCheckpoints :: Lens' TCState (Map ModuleName CheckpointId)
 stModuleCheckpoints = lensPostScopeState . lensModuleCheckpoints
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2069,6 +2069,10 @@ data Signature = Sig
       }
   deriving (Show, Generic)
 
+instance Null Signature where
+  empty = Sig empty empty empty empty
+  null (Sig a b c d) = null a && null b && null c && null d
+
 sigSections :: Lens' Signature Sections
 sigSections f s =
   f (_sigSections s) <&>
@@ -3817,6 +3821,10 @@ instance Semigroup InstanceTable where
 
 instance Monoid InstanceTable where
   mempty = InstanceTable mempty mempty
+
+instance Null InstanceTable where
+  empty = mempty
+  null (InstanceTable a b) = null a && null b
 
 itableTree :: Lens' InstanceTable (DiscrimTree QName)
 itableTree f s = f (_itableTree s) <&> \x -> s { _itableTree = x }

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -273,8 +273,9 @@ markFirstOrder = setFunctionFlag FunFirstOrder True
 
 unionSignatures :: [Signature] -> Signature
 unionSignatures ss = foldr unionSignature emptySignature ss
-  where
-    unionSignature (Sig a b c d) (Sig a' b' c' d') =
+
+unionSignature :: Signature -> Signature -> Signature
+unionSignature (Sig a b c d) (Sig a' b' c' d') =
       Sig (Map.union a a')
           (HMap.union b b')             -- definitions are unique (in at most one module)
           (HMap.unionWith mappend c c') -- rewrite rules are accumulated

--- a/test/BuildSucceed/Tests.hs
+++ b/test/BuildSucceed/Tests.hs
@@ -6,7 +6,7 @@ module BuildSucceed.Tests where
 
 import           Data.Maybe                 ( isJust )
 
-import           System.Directory           ( doesFileExist, withCurrentDirectory )
+import           System.Directory           ( doesFileExist )
 import           System.FilePath            ( (</>), (<.>), takeFileName )
 import qualified System.FilePath.Find       as Find
 import           System.IO.Temp             ( withSystemTempDirectory )
@@ -71,8 +71,7 @@ mkBuildSucceedTest dir =
         , "--vim"
         ]
 
-    (res, ret) <- withCurrentDirectory dir do
-      runAgdaWithOptions testName agdaArgs (Just flagFile) (Just varFile)
+    (res, ret) <- runAgdaWithCWD testName (Just dir) agdaArgs (Just flagFile) (Just varFile)
 
     case ret of
       AgdaSuccess warn -> do


### PR DESCRIPTION
Singled out from #7934:

- **Testsuite: fix CWD race in test/BuildSucceed/Tests.hs**
  Same problem was already fixed for test/BuildFail/Tests.hs
  

- **[new] Null Signature, binary unionSignature(s)**
  

- **New lens stRewriteRules**
  