### PR TITLE
Fix #7938: API: export Agda Highlighting Backend modules

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -541,15 +541,21 @@ library
       Agda.Interaction.FindFile
       Agda.Interaction.Highlighting.Common
       Agda.Interaction.Highlighting.Dot
+      Agda.Interaction.Highlighting.Dot.Backend
+      Agda.Interaction.Highlighting.Dot.Base
       Agda.Interaction.Highlighting.Emacs
       Agda.Interaction.Highlighting.FromAbstract
       Agda.Interaction.Highlighting.Generate
       Agda.Interaction.Highlighting.HTML
+      Agda.Interaction.Highlighting.HTML.Backend
+      Agda.Interaction.Highlighting.HTML.Base
       Agda.Interaction.Highlighting.JSON
       Agda.Interaction.Highlighting.Precise
       Agda.Interaction.Highlighting.Range
       Agda.Interaction.Highlighting.Vim
       Agda.Interaction.Highlighting.LaTeX
+      Agda.Interaction.Highlighting.LaTeX.Backend
+      Agda.Interaction.Highlighting.LaTeX.Base
       Agda.Interaction.Imports
       Agda.Interaction.InteractionTop
       Agda.Interaction.Output
@@ -875,12 +881,6 @@ library
   other-modules:
       Paths_Agda
       -- Need not export submodules if parent module reexports them.
-      Agda.Interaction.Highlighting.Dot.Backend
-      Agda.Interaction.Highlighting.Dot.Base
-      Agda.Interaction.Highlighting.HTML.Backend
-      Agda.Interaction.Highlighting.HTML.Base
-      Agda.Interaction.Highlighting.LaTeX.Backend
-      Agda.Interaction.Highlighting.LaTeX.Base
       Agda.Interaction.Options.Base
       Agda.Interaction.Options.HasOptions
       Agda.Interaction.Options.Types


### PR DESCRIPTION
Closes #7938.
