### PR TITLE
Fix #7944: do not apply `@0` from where-module to clause rhs

### DIFF
--- a/doc/user-manual/language/runtime-irrelevance.lagda.rst
+++ b/doc/user-manual/language/runtime-irrelevance.lagda.rst
@@ -174,7 +174,7 @@ after the ``module`` keyword:
     F : @0 Set → Set
     F A = A
 
-  module M (A : Set) where
+  module M (@0 A : Set) where
 
     record R : Set where
       field

--- a/test/Fail/Issue7944.agda
+++ b/test/Fail/Issue7944.agda
@@ -1,0 +1,14 @@
+-- Andreas, 2025-06-14, issue #7944
+-- The @0 of a local where modulo should not be applied
+-- to the clause rhs!
+
+{-# OPTIONS --erasure #-}
+
+Test : @0 Set → Set
+Test A = A
+  module @0 _ where
+    -- The contents of this where-module do not matter,
+    -- as long as it is not empty.
+    postulate _ : Set
+
+-- Used to succeed (Agda 2.6.4, 2.7.0), should fail.

--- a/test/Fail/Issue7944.err
+++ b/test/Fail/Issue7944.err
@@ -1,0 +1,3 @@
+Issue7944.agda:8.10-11: error: [VariableIsErased]
+Variable A is declared erased, so it cannot be used here
+when checking that the expression A has type Set


### PR DESCRIPTION
Make sure that changes to the erasure status made for a where-module do not carry over to the continuation (checking the clause rhs).

Closes #7945.