### PR TITLE
Fix #7943: propagate erasure status to `where` blocks.

### DIFF
--- a/doc/user-manual/language/runtime-irrelevance.lagda.rst
+++ b/doc/user-manual/language/runtime-irrelevance.lagda.rst
@@ -258,6 +258,8 @@ There is also a *hard compile-time mode*. In this mode all definitions
 are treated as erased. The hard compile-time mode is entered when an
 erased definition is checked.
 
+Unnamed and named `where` modules in erased context are always checked in hard compile-time mode.
+
 The type-checker switches from compile-time mode to run-time mode for
 certain expressions/declarations if it is not in the hard compile-time
 mode:

--- a/test/Fail/Issue7943.agda
+++ b/test/Fail/Issue7943.agda
@@ -1,0 +1,32 @@
+{-# OPTIONS --erasure #-}
+{-# OPTIONS --without-K #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.IO
+open import Agda.Builtin.Unit
+
+postulate
+  print : Nat → IO ⊤
+
+{-# COMPILE GHC print = print #-}
+
+@0 er5 : Nat
+er5 = 5
+
+record R : Set₂ where
+  field
+    @0 f : Set₁
+
+foo : R
+foo .R.f = Set
+  module @ω M where  -- @ω is ignored here
+    five : Nat
+    five = er5
+    -- Either five should be marked as erased,
+    -- or one should not be able to refer to er5.
+
+main = print M.five  -- Error, because M.five is erased
+
+-- error: [DefinitionIsErased]
+-- Identifier M.five is declared erased, so it cannot be used here
+-- when checking that the expression M.five has type Nat

--- a/test/Fail/Issue7943.err
+++ b/test/Fail/Issue7943.err
@@ -1,0 +1,14 @@
+Issue7943.agda:22.10-12: warning: -W[no]PlentyInHardCompileTimeMode
+Ignored use of @ω in hard compile-time mode
+when checking that the clause
+foo .R.f = Set
+  module @ω M where
+    mutual
+      syntax five ...
+      postulate five : Nat
+      five = er5
+has type R
+
+Issue7943.agda:28.14-20: error: [DefinitionIsErased]
+Identifier M.five is declared erased, so it cannot be used here
+when checking that the expression M.five has type Nat

--- a/test/Fail/Issue7943.flags
+++ b/test/Fail/Issue7943.flags
@@ -1,0 +1,1 @@
+--compile

--- a/test/Succeed/Erased-modules-2.warn
+++ b/test/Succeed/Erased-modules-2.warn
@@ -23,7 +23,7 @@ Erased-modules-2.agda:49.13-15: warning: -W[no]PlentyInHardCompileTimeMode
 Ignored use of @plenty in hard compile-time mode
 when checking the projection C : Set
 
-Erased-modules-2.agda:50.5-52.15: warning: -W[no]PlentyInHardCompileTimeMode
+Erased-modules-2.agda:51.14-16: warning: -W[no]PlentyInHardCompileTimeMode
 Ignored use of @ω in hard compile-time mode
 when checking that the clause
 C′ = C″
@@ -76,7 +76,7 @@ Erased-modules-2.agda:49.13-15: warning: -W[no]PlentyInHardCompileTimeMode
 Ignored use of @plenty in hard compile-time mode
 when checking the projection C : Set
 
-Erased-modules-2.agda:50.5-52.15: warning: -W[no]PlentyInHardCompileTimeMode
+Erased-modules-2.agda:51.14-16: warning: -W[no]PlentyInHardCompileTimeMode
 Ignored use of @ω in hard compile-time mode
 when checking that the clause
 C′ = C″

--- a/test/Succeed/Issue7943.agda
+++ b/test/Succeed/Issue7943.agda
@@ -1,0 +1,27 @@
+-- Andreas, 2025-06-14, issue #7943 reported and test by tizmd
+-- Definitions in erased where modules should not show up in compiled code.
+
+{-# OPTIONS --no-main #-}
+{-# OPTIONS --erasure #-}
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Nat renaming (Nat to ℕ)
+
+record _×₀_ (A : Set) (B : Set) : Set where
+  field
+    fst : A
+    @0 snd : B
+
+open _×₀_
+
+@0 u : ℕ → Bool
+u n = n < 10
+
+f :  ℕ → ℕ ×₀ Bool
+f n .fst = n
+f n .snd = p
+  where
+    p : Bool -- WAS: remains in the compiled code and causes a compile-time error as missing `u`
+    p = u n
+
+-- Compilation should succeed.

--- a/test/Succeed/Issue7943.flags
+++ b/test/Succeed/Issue7943.flags
@@ -1,0 +1,1 @@
+--compile


### PR DESCRIPTION
If the rhs of a clause is in an erased context, the definitions in the associated `where` are always erased.

Previously they were only _checked_ in erased mode, but not _declared_ as erased, so they were not removed during compilation.

Closes #7943.
