### PR TITLE
Don't check polarities in fitsIn when --without-K.

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -1728,7 +1728,10 @@ fitsIn dataOrRecord con uc forceds conT s = do
 
   whenM withoutKOption $ do
     q <- viewTC eQuantity
-    usableAtModality' (Just s) ConstructorType (setQuantity q unitModality) (unEl conT)
+    -- Don't want to check polarities for the constructor's type,
+    -- only for its argument telescope!
+    applyPolarityToContext (withStandardLock UnusedPolarity) $
+      usableAtModality' (Just s) ConstructorType (setQuantity q unitModality) (unEl conT)
 
   li <- optLargeIndices <$> pragmaOptions
   -- To allow propositional squash in data constructors, we turn @Prop ℓ@ into @Set ℓ@

--- a/test/Succeed/PolarityAnnotations-WithoutK.agda
+++ b/test/Succeed/PolarityAnnotations-WithoutK.agda
@@ -1,0 +1,7 @@
+{-# OPTIONS --polarity --without-K #-}
+module _ where
+
+record PosPair (@++ X : Set) (Y : Set) : Set where
+  field
+    fst : X
+    snd : Y


### PR DESCRIPTION
[As reported on Zulip](https://agda.zulipchat.com/#narrow/channel/238741-general/topic/Polarity.20and.20Pairs.20in.202.2E8.2E0/near/524498329) by @JoeyEremondi, `--without-K` doesn't work properly with polarity annotations.

The reason is that in that case, `fitsIn` re-checks constructor types without going through `workOnTypes`. This PR simply reproduces the polarity part of the latter in `fitsIn`. I don't like the logic duplication, but at least this fixes the bug.

WDYT?