### PR TITLE
Improve module checkpointing performance

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1336,9 +1336,9 @@ atTopLevel m = inConcreteMode $ do
         withScope_ scope $
           addContext gamma $ do
             -- We're going inside the top-level module, so we have to set the
-            -- checkpoint for it and all its submodules to the new checkpoint.
+            -- checkpoints for it and all its submodules to the new checkpoint.
             cp <- viewTC eCurrentCheckpoint
-            stModuleCheckpoints `modifyTCLens` fmap (const cp)
+            setAllModuleCheckpoints cp
             m
 
 -- | Parse a name.

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -38,7 +38,7 @@ import Agda.Utils.Impossible
 --   concrete name contains the source location (if any) of the name. The
 --   source location of the binding site is also recorded.
 data Name = Name
-  { nameId           :: !NameId
+  { nameId           :: {-# UNPACK #-} !NameId
   , nameConcrete     :: C.Name  -- ^ The concrete name used for this instance
   , nameCanonical    :: C.Name  -- ^ The concrete name in the original definition (needed by primShowQName, see #4735)
   , nameBindingSite  :: Range

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1232,7 +1232,7 @@ instance NFData ModuleCheckpoints where
 
 instance Pretty ModuleCheckpoints where
   pretty (ModuleCheckpointsTop) = "[]"
-  pretty (ModuleCheckpointsSection mnames chkpt mchkpts) =
+  pretty (ModuleCheckpointsSection mchkpts mnames chkpt) =
     (pretty mchkpts <> comma) <+> parens (pretty mnames <+> colon <+> pretty chkpt)
 
 ---------------------------------------------------------------------------

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1240,7 +1240,7 @@ instance Pretty ModuleCheckpoints where
 ---------------------------------------------------------------------------
 
 -- | A monad that has read and write access to the stConcreteNames
---   part of the TCEnv. Basically, this is a synonym for `MonadState
+--   part of the TCState. Basically, this is a synonym for `MonadState
 --   ConcreteNames m` (which cannot be used directly because of the
 --   limitations of Haskell's typeclass system).
 class Monad m => MonadStConcreteNames m where

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -125,6 +125,12 @@ checkpoint sub k = do
                               fmap (applySubst sub) (envCheckpoints env)
     }
   newMods <- useTC stModuleCheckpoints
+  unlessDebugPrinting $ verboseS "tc.ctx.checkpoint.modules" 105 $ do
+    reportSDoc "tc.ctx.checkpoint.modules" 105 $ return $ nest 2 $ vcat
+      [ "old mod checkpoints =" <+> pretty (length oldMods)
+      , "new mod checkpoints =" <+> pretty (length newMods)
+      , "mod checkpoint diff =" <+> pretty (Map.difference newMods oldMods)
+      ]
   -- Set the checkpoint for introduced modules to the old checkpoint when the
   -- new one goes out of scope. #2897: This isn't actually sound for modules
   -- created under refined parent parameters, but as long as those modules

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -284,7 +284,8 @@ unionSignature (Sig a b c d) (Sig a' b' c' d') =
 -- | Add a section to the signature.
 --
 --   The current context will be stored as the cumulative module parameters
---   for this section.
+--   for this section, and a module checkpoint entry will be added
+--   into the module checkpoint stack.
 addSection :: ModuleName -> TCM ()
 addSection m = do
   tel <- getContextTelescope
@@ -303,14 +304,9 @@ addSection m = do
       reportSDoc "impossible" 60 $ "with content" <+> pretty sec
       __IMPOSSIBLE__
   -- Add the new section.
-  setModuleCheckpoint m
+  cp <- viewTC eCurrentCheckpoint
+  setModuleCheckpoint m cp
   modifySignature $ over sigSections $ Map.insert m sec
-
--- | Sets the checkpoint for the given module to the current checkpoint.
-setModuleCheckpoint :: ModuleName -> TCM ()
-setModuleCheckpoint m = do
-  chkpt <- viewTC eCurrentCheckpoint
-  stModuleCheckpoints `modifyTCLens` Map.insert m chkpt
 
 -- | Get a section.
 --

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -357,7 +357,8 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
           tel' <- do
             r <- headWithDefault __IMPOSSIBLE__ <$> getContext
             return $ contextToTel $ r : params
-          setModuleCheckpoint m
+          cp <- viewTC eCurrentCheckpoint
+          setModuleCheckpoint m cp
           checkRecordProjections m name hasNamedCon con tel' ftel fields
 
 

--- a/test/Succeed/RecordFieldAndModules.agda
+++ b/test/Succeed/RecordFieldAndModules.agda
@@ -1,0 +1,25 @@
+module RecordFieldAndModules where
+
+record R1 : Set₁ where
+  field
+    A : Set
+    B : A → Set
+
+record R2 : Set₂ where
+  field
+    X : Set
+    r1 : X → R1
+
+  module M1 {x} = R1 (r1 x)
+
+  field
+    a : ∀ {x} → R1.A (r1 x)
+
+  A : X → Set
+  A x = R1.A (r1 x)
+
+  B : ∀ {x} → A x → Set
+  B x = M1.B x
+
+  field
+    foo : ∀ {x} (a : A x) → B a


### PR DESCRIPTION
I was doing some profiling of agda against `1lab` builds the other day, and noticed that we were spending upwards of 5% of our time inside of the `Ord` instance of `Abstract.Name`. After some further digging, I noticed that [checkpoint](https://github.com/agda/agda/blob/master/src/full/Agda/TypeChecking/Monad/Context.hs#L101) unions `stModuleCheckpoints` with a potentially extended version of itself every time we extend the context: for moderately sized files, this can happen hundreds of thousands of times!

This PR replaces the `stModuleCheckpoints` map with a stack containing sets of module names and checkpoint ids: this turns the expensive call to `union` into a single integer comparison in the happy path, and reduces that 5% to 0.1%.
