### PR TITLE
Fix #7953: remember whether top-level module name was inferred

### DIFF
--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -56,6 +56,7 @@ doCompile f isMain i = do
     agdaPrim = RawTopLevelModuleName
       { rawModuleNameRange = mempty
       , rawModuleNameParts = "Agda" :| "Primitive" : []
+      , rawModuleNameInferred = False
       }
       -- N.B. The Range in TopLevelModuleName is ignored for Ord, so we can set it to mempty.
 

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -211,6 +211,9 @@ moduleName file parsedModule = Bench.billTo [Bench.ModuleName] $ do
           return $ RawTopLevelModuleName
             { rawModuleNameRange = getRange m
             , rawModuleNameParts = singleton (T.pack defaultName)
+            , rawModuleNameInferred = True
+                -- Andreas, 2025-06-21, issue #7953:
+                -- Remember we made up this module name to improve errors.
             }
     else return raw
 

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -306,6 +306,9 @@ instance Hashable QName where
 instance IsNoName Name where
   isNoName = isNoName . nameConcrete
 
+instance IsNoName ModuleName where
+  isNoName (MName xs) = all isNoName xs
+
 instance NumHoles Name where
   numHoles = numHoles . nameConcrete
 

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -358,10 +358,10 @@ instance HasRange (TopLevelModuleName' Range) where
   getRange = moduleNameRange
 
 instance SetRange (TopLevelModuleName' Range) where
-  setRange r (TopLevelModuleName _ h x) = TopLevelModuleName r h x
+  setRange r (TopLevelModuleName _ h x z) = TopLevelModuleName r h x z
 
 instance KillRange (TopLevelModuleName' Range) where
-  killRange (TopLevelModuleName _ h x) = TopLevelModuleName noRange h x
+  killRange (TopLevelModuleName _ h x z) = TopLevelModuleName noRange h x z
 
 -- | Precondition: The ranges of the list elements must point to the
 -- same file (or be empty).

--- a/src/full/Agda/Syntax/TopLevelModuleName/Boot.hs
+++ b/src/full/Agda/Syntax/TopLevelModuleName/Boot.hs
@@ -37,6 +37,9 @@ data TopLevelModuleName' range = TopLevelModuleName
   { moduleNameRange :: range
   , moduleNameId    :: {-# UNPACK #-} !ModuleNameHash
   , moduleNameParts :: TopLevelModuleNameParts
+  , moduleNameInferred :: !Bool
+      -- ^ Was this module name constructed from a file name
+      --   rather than declared in the file?
   }
   deriving (Show, Generic)
 
@@ -56,5 +59,4 @@ instance Hashable (TopLevelModuleName' range) where
 -- | The 'range' is not forced.
 
 instance NFData (TopLevelModuleName' range) where
-  rnf (TopLevelModuleName _ x y) = rnf (x, y)
-
+  rnf (TopLevelModuleName _ x y _) = rnf (x, y)

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -834,11 +834,20 @@ instance PrettyTCM TypeError where
         RootNameModuleNotAQualifiedModuleName defaultName ->
           pretty defaultName : pwords "is not an unqualified module name."
 
-    ModuleDefinedInOtherFile mod file file' -> fsep $
-      pwords "You tried to load" ++ [text (filePath file)] ++
-      pwords "which defines the module" ++ [pretty mod <> "."] ++
-      pwords "However, according to the include path this module should" ++
-      pwords "be defined in" ++ [text (filePath file') <> "."]
+    ModuleDefinedInOtherFile mod file file' -> fsep $ concat
+      [ pwords "You tried to load"
+      , [ text (filePath file) ]
+      , if moduleNameInferred mod
+          then pwords "which seems to define the module"
+          else pwords "which defines the module"
+      , [ pretty mod <> "." ]
+      , pwords "However, according to the include path this module should be defined in"
+      , [ text (filePath file') ]
+        -- Andreas, 2025-06-21, issue #7953:
+        -- We have no test that triggers this hint, not sure it can be triggered at all.
+      , if moduleNameInferred mod then pwords "(Hint: no module header was found in this file; adding one might fix this error.)"
+        else empty
+      ]
 
     ModuleNameUnexpected given expected
       | canon dGiven == canon dExpected -> fsep $ concat

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -758,7 +758,7 @@ instance PrettyTCM TypeError where
     LibraryError err -> return $ formatLibErrors err
 
     LibTooFarDown m lib -> vcat
-      [ text "A .agda-lib file for" <+> pretty m
+      [ text "An .agda-lib file for" <+> pretty m
       , text "must not be located in the directory" <+> text (takeDirectory (lib ^. libFile))
       ]
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -867,11 +867,21 @@ instance PrettyTCM TypeError where
         " and " ++ prettyShow raw' ++ " (you may want to consider " ++
         "renaming one of these modules)"
 
-
-    ModuleNameDoesntMatchFileName given files ->
-      fsep (pwords "The name of the top level module does not match the file name. The module" ++
-           [ pretty given ] ++ pwords "should be defined in one of the following files:")
-      $$ nest 2 (vcat $ map (text . filePath) files)
+    ModuleNameDoesntMatchFileName given files -> vcat
+      [ fsep $ concat
+        [ [ "The" ]
+        , [ "inferred" | moduleNameInferred given ]
+        , [ "name" ]
+        , [ "`" <> pretty given <> "`"]
+        , pwords "of the top level module"
+        , pwords "does not match the file name."
+        , pwords "A such named module should be defined in one of the following files:"
+        ]
+      , nest 2 (vcat $ map (text . filePath) files)
+      , if moduleNameInferred given then fsep $
+          pwords "(Hint: no module header was found in this file; adding one might fix this error.)"
+        else empty
+      ]
 
     AbstractConstructorNotInScope q -> fsep $
       [ "Constructor"

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -226,7 +226,7 @@ instance (EmbPrj a, Typeable b) => EmbPrj (WithDefault' a b) where
     _ -> malformed
 
 instance EmbPrj TopLevelModuleName where
-  icod_ (TopLevelModuleName a b c) = icodeN' TopLevelModuleName a b c
+  icod_ (TopLevelModuleName a b c d) = icodeN' TopLevelModuleName a b c d
 
   value = valueN TopLevelModuleName
 

--- a/test/BuildFail/Issue7912.err
+++ b/test/BuildFail/Issue7912.err
@@ -2,9 +2,9 @@ Importing the primitive modules.
 Done importing the primitive modules.
 Error raised at (typeError, src/full/Agda/Interaction/FindFile.hs:«line»:«col» in «Agda-package»:Agda.Interaction.FindFile)
 ../BuildFail/Issue7912/F.agda:1.1: error: [ModuleNameDoesntMatchFileName]
-The name of the top level module does not match the file name. The
-module Definitely-not-F should be defined in one of the following
-files:
+The name 'Definitely-not-F' of the top level module does not match
+the file name. A such named module should be defined in one of the
+following files:
   ../BuildFail/Issue7912/Definitely-not-F.agda
   ../BuildFail/Issue7912/Definitely-not-F.lagda
   agda-default-include-path/Definitely-not-F.agda

--- a/test/BuildFail/LibTooFarDown.err
+++ b/test/BuildFail/LibTooFarDown.err
@@ -2,5 +2,5 @@ Importing the primitive modules.
 Done importing the primitive modules.
 Error raised at (typeError, src/full/Agda/TypeChecking/Monad/Options.hs:«line»:«col» in «Agda-package»:Agda.TypeChecking.Monad.Options)
 ../BuildFail/LibTooFarDown/A.agda:1.1: error: [LibTooFarDown]
-A .agda-lib file for Some.Hierarchical.Module.Name
+An .agda-lib file for Some.Hierarchical.Module.Name
 must not be located in the directory ../BuildFail/LibTooFarDown

--- a/test/Fail/Issue1078.err
+++ b/test/Fail/Issue1078.err
@@ -1,8 +1,7 @@
 Issue1078.agda:7.1-19: error: [ModuleDefinedInOtherFile]
-You tried to load
-Issue1078/B.agda which defines
-the module Issue1078.A. However, according to the include path this
-module should be defined in
-Issue1078/A.agda.
+You tried to load Issue1078/B.agda
+which defines the module Issue1078.A. However, according to the
+include path this module should be defined in
+Issue1078/A.agda
 when scope checking the declaration
   import Issue1078.B

--- a/test/Fail/ModuleDefinedInOtherFile.agda
+++ b/test/Fail/ModuleDefinedInOtherFile.agda
@@ -2,4 +2,3 @@
 module ModuleDefinedInOtherFile where
 
 import Imports.B
-

--- a/test/Fail/ModuleDefinedInOtherFile.err
+++ b/test/Fail/ModuleDefinedInOtherFile.err
@@ -1,7 +1,7 @@
 ModuleDefinedInOtherFile.agda:4.1-17: error: [ModuleDefinedInOtherFile]
-You tried to load Imports/B.agda
-which defines the module Imports.A. However, according to the
-include path this module should be defined in
-Imports/A.agda.
+You tried to load Imports/B.agda which
+defines the module Imports.A. However, according to the include
+path this module should be defined in
+Imports/A.agda
 when scope checking the declaration
   import Imports.B

--- a/test/Fail/ModuleNameDoesntMatchFileName.err
+++ b/test/Fail/ModuleNameDoesntMatchFileName.err
@@ -1,7 +1,7 @@
 ModuleNameDoesntMatchFileName.agda:1.8-29: error: [ModuleNameDoesntMatchFileName]
-The name of the top level module does not match the file name. The
-module Mmmmmmmmmmmmmmmmmmmmm should be defined in one of the
-following files:
+The name 'Mmmmmmmmmmmmmmmmmmmmm' of the top level module does not
+match the file name. A such named module should be defined in one
+of the following files:
   ../Mmmmmmmmmmmmmmmmmmmmm.agda
   ../Mmmmmmmmmmmmmmmmmmmmm.lagda
   Mmmmmmmmmmmmmmmmmmmmm.agda

--- a/test/Fail/RegionWrongModule.err
+++ b/test/Fail/RegionWrongModule.err
@@ -1,7 +1,7 @@
 RegionWrongModule.agda:10.8-26: error: [ModuleNameDoesntMatchFileName]
-The name of the top level module does not match the file name. The
-module ThisIsTheWrongName should be defined in one of the following
-files:
+The name 'ThisIsTheWrongName' of the top level module does not
+match the file name. A such named module should be defined in one
+of the following files:
   ../ThisIsTheWrongName.agda
   ../ThisIsTheWrongName.lagda
   ThisIsTheWrongName.agda

--- a/test/Fail/Tests.hs
+++ b/test/Fail/Tests.hs
@@ -40,6 +40,7 @@ tests = do
   issue7678Dir = testDir </> "Issue7678"
   customizedTests =
     [ testGroup "customised" $
+        issue7953 :
         issue6465 :
         issue5508 :
         issue4671 :
@@ -120,6 +121,32 @@ fdebugTestFilter =
   , disable "Fail/Issue4175"
   ]
   where disable = RFInclude
+
+-- | We need to load an agda file in a subdirectory to trigger issue #7953.
+issue7953 :: TestTree
+issue7953 =
+  goldenTest1
+    name
+    (readTextFileMaybe goldenFile)
+    doRun
+    textDiff
+    ShowText
+    (writeTextFile goldenFile)
+  where
+    name       = "Issue7953"
+    dir        = testDir </> "customised"
+    goldenFile = dir </> name <.> "err"
+    doRun = do
+      runAgdaWithOptions name agdaArgs Nothing Nothing
+        <&> printTestResult . expectFail
+      where
+        agdaArgs =
+          [ "-v0"
+          , "--no-default-libraries"
+          , "-i" ++ dir
+          -- , "-i" ++ dir </> name
+          , dir </> name </> "Test.agda"
+          ]
 
 issue6465 :: TestTree
 issue6465 =

--- a/test/Fail/customised/Issue6465.err
+++ b/test/Fail/customised/Issue6465.err
@@ -1,5 +1,5 @@
 customised/Issue6465/A/B.agda:1.1: error: [LibTooFarDown]
-A .agda-lib file for A.B
+An .agda-lib file for A.B
 must not be located in the directory customised/Issue6465/A
 when scope checking the declaration
   import A.B

--- a/test/Fail/customised/Issue7953.err
+++ b/test/Fail/customised/Issue7953.err
@@ -1,0 +1,10 @@
+1.1-5: error: [ModuleNameDoesntMatchFileName]
+The inferred name 'Test' of the top level module does not match the
+file name. A such named module should be defined in one of the
+following files:
+  customised/Test.agda
+  customised/Test.lagda
+  agda-default-include-path/Test.agda
+  agda-default-include-path/Test.lagda
+(Hint: no module header was found in this file; adding one might
+fix this error.)

--- a/test/Fail/customised/Issue7953/Test.agda
+++ b/test/Fail/customised/Issue7953/Test.agda
@@ -1,0 +1,3 @@
+open-import Agda.Primitive -- typo that hides the following module header
+
+module Issue7953.Test where

--- a/test/Fail/customised/iSSue5508.err.case-sensitive
+++ b/test/Fail/customised/iSSue5508.err.case-sensitive
@@ -1,6 +1,7 @@
 customised/iSSue5508.agda:6.8-17: error: [ModuleNameDoesntMatchFileName]
-The name of the top level module does not match the file name. The
-module Issue5508 should be defined in one of the following files:
+The name 'Issue5508' of the top level module does not match the
+file name. A such named module should be defined in one of the
+following files:
   customised/Issue5508.agda
   customised/Issue5508.lagda
   agda-default-include-path/Issue5508.agda

--- a/test/Internal/Syntax/Position.hs
+++ b/test/Internal/Syntax/Position.hs
@@ -188,6 +188,7 @@ instance Arbitrary RawTopLevelModuleName where
     return $ RawTopLevelModuleName
       { rawModuleNameRange = r
       , rawModuleNameParts = parts
+      , rawModuleNameInferred = False
       }
 
 instance Arbitrary TopLevelModuleName where

--- a/test/interaction/Issue4516.out
+++ b/test/interaction/Issue4516.out
@@ -1,7 +1,7 @@
 (agda2-status-action "")
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
-(agda2-info-action "*Error*" "Issue4516.agda:1.8-11: error: [ModuleNameDoesntMatchFileName] The name of the top level module does not match the file name. The module Set should be defined in one of the following files: Set.agda Set.lagda agda-default-include-path/Set.agda agda-default-include-path/Set.lagda" nil)
+(agda2-info-action "*Error*" "Issue4516.agda:1.8-11: error: [ModuleNameDoesntMatchFileName] The name `Set` of the top level module does not match the file name. A such named module should be defined in one of the following files: Set.agda Set.lagda agda-default-include-path/Set.agda agda-default-include-path/Set.lagda" nil)
 ((last . 3) . (agda2-maybe-goto '("Issue4516.agda" . 8)))
 (agda2-info-action "*Error*" "/non-existent-directory-used-for-Issue4516: openTempFile: does not exist (No such file or directory)" nil)
 (agda2-highlight-add-annotations 'nil)


### PR DESCRIPTION
- **Grammar fix in error LibTooFarDown**
  

- **Fix #7953: Improve error message ModuleNameDoesntMatchFileName**
  We remember in `TopLevelModuleName`s whether they were guessed
  from a file name, so that we can give a better error message.
  
  Closes #7953.
  

- **Re #7953: add potential hint to error ModuleDefinedInOtherFile**
  Also remove the final '.'
  