### PR TITLE
Fix #7973: print warning if `rewrite` does not fire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@ Pragmas and options
 Warnings
 --------
 
+* New warning `RewritesNothing` if a `rewrite` clause did not fire.
+
 * New deadcode warnings `FixingCohesion`, `FixingPolarity` and `FixingRelevance`
   when wrong user-written attribute was corrected automatically by Agda.
 
@@ -435,6 +437,7 @@ Issues for closed for milestone 2.8.0
 - [Issue #7952](https://github.com/agda/agda/issues/7952): Primitive root example in docs
 - [Issue #7953](https://github.com/agda/agda/issues/7953): Confusing error in case of illegal declaration before top-level module in a nested file
 - [Issue #7966](https://github.com/agda/agda/issues/7966): Disallow option abbreviation
+- [Issue #7973](https://github.com/agda/agda/issues/7973): If rewrite does not rewrite anything, give a warning
 - [Issue #7977](https://github.com/agda/agda/issues/7977): Soft error for unknown attributes
 
 PRs for closed for milestone 2.8.0
@@ -629,4 +632,5 @@ PRs for closed for milestone 2.8.0
 - [PR #7965](https://github.com/agda/agda/issues/7965): Re #7932: restore data-files in Agda.cabal and default data-dir
 - [PR #7967](https://github.com/agda/agda/issues/7967): Fix #7966: fork GetOpt to disallow long option abbreviations
 - [PR #7971](https://github.com/agda/agda/issues/7971): flake: use --build-library to build the builtins
+- [PR #7978](https://github.com/agda/agda/issues/7978): Fix #7973: print warning if `rewrite` does not fire
 - [PR #7981](https://github.com/agda/agda/issues/7981): Parse warning instead of error on unknown attributes and polarities

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1679,13 +1679,17 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Mutually declaration with the rewrite rule is not yet defined.
 
+.. option:: RewritesNothing
+
+     ``rewrite`` clauses that do not fire.
+
 .. option:: ShadowingInTelescope
 
      Repeated variable name in telescope.
 
 .. option:: TooManyArgumentsToSort
 
-     E.g. `Set` used with more than one argument.
+     E.g. ``Set`` used with more than one argument.
 
 .. option:: TooManyFields
 

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -477,6 +477,7 @@ warningHighlighting' b w = case tcWarning w of
   InvalidDisplayForm{}                  -> deadcodeHighlighting w
   UnusedVariablesInDisplayForm xs       -> foldMap deadcodeHighlighting xs
   TooManyArgumentsToSort _ args         -> errorWarningHighlighting args
+  RewritesNothing                       -> cosmeticProblemHighlighting w
   WithClauseProjectionFixityMismatch p _ _ _ -> cosmeticProblemHighlighting p
   WithoutKFlagPrimEraseEquality -> mempty
   ConflictingPragmaOptions{} -> mempty

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -355,6 +355,7 @@ data WarningName
   | UserWarning_
   | InvalidDisplayForm_
   | UnusedVariablesInDisplayForm_
+  | RewritesNothing_
   | WithClauseProjectionFixityMismatch_
   | WithoutKFlagPrimEraseEquality_
   | ConflictingPragmaOptions_
@@ -592,6 +593,7 @@ warningNameDescription = \case
   InvalidDisplayForm_              -> "Invalid display forms."
   UnusedVariablesInDisplayForm_    -> "Bound but unused variables in display forms."
   TooManyArgumentsToSort_          -> "Extra arguments given to a sort."
+  RewritesNothing_                 -> "`rewrite' clauses that do not fire."
   WithClauseProjectionFixityMismatch_ -> "With clauses using projections in different fixities than their parent clauses."
   WithoutKFlagPrimEraseEquality_   -> "Uses of `primEraseEquality' with the without-K flags."
   WrongInstanceDeclaration_        -> "Instances that do not adhere to the required format."

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -722,7 +722,8 @@ data EqualityView
       -- ^ A reduced type used as type for the @with@ inspect idiom.
 
 data EqualityTypeData = EqualityTypeData
-    { _eqtSort   :: Sort        -- ^ Sort of this type.
+    { _eqtRange  :: Range       -- ^ Range of the @rewrite@ expression, if any.
+    , _eqtSort   :: Sort        -- ^ Sort of this type.
     , _eqtName   :: QName       -- ^ Builtin EQUALITY.
     , _eqtParams :: Args        -- ^ Hidden.  Empty or @Level@.
     , _eqtType   :: Arg Term    -- ^ Hidden.
@@ -730,16 +731,17 @@ data EqualityTypeData = EqualityTypeData
     , _eqtRhs    :: Arg Term    -- ^ NotHidden.
     }
 
-pattern EqualityType
-  :: Sort
+pattern EqualityType ::
+     Range
+  -> Sort
   -> QName
   -> Args
   -> Arg Term
   -> Arg Term
   -> Arg Term
   -> EqualityView
-pattern EqualityType{ eqtSort, eqtName, eqtParams, eqtType, eqtLhs, eqtRhs } =
-  EqualityViewType (EqualityTypeData eqtSort eqtName eqtParams eqtType eqtLhs eqtRhs)
+pattern EqualityType{ eqtRange, eqtSort, eqtName, eqtParams, eqtType, eqtLhs, eqtRhs } =
+  EqualityViewType (EqualityTypeData eqtRange eqtSort eqtName eqtParams eqtType eqtLhs eqtRhs)
 
 {-# COMPLETE EqualityType, OtherType, IdiomType #-}
 
@@ -920,7 +922,7 @@ sortUniv = \case
 
 -- | Is this a Prop universe?  Answers are yes ('True') or maybe ('False').
 isProp :: Sort' t -> Bool
-isProp = maybe False (UProp ==) . sortUniv
+isProp = (Just UProp ==) . sortUniv
 
 -- | Is this a strict universe inhabitable by data types?
 isStrictDataSort :: Sort' t -> Bool

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -157,7 +157,7 @@ instance TermLike EqualityView where
       <$> traverseTermM f t
     IdiomType t -> IdiomType
       <$> traverseTermM f t
-    EqualityType s eq l t a b -> EqualityType s eq
+    EqualityType r s eq l t a b -> EqualityType r s eq
       <$> traverse (traverseTermM f) l
       <*> traverseTermM f t
       <*> traverseTermM f a
@@ -166,7 +166,7 @@ instance TermLike EqualityView where
   foldTerm f = \case
     OtherType t -> foldTerm f t
     IdiomType t -> foldTerm f t
-    EqualityType s eq l t a b -> foldTerm f (l ++ [t, a, b])
+    EqualityType _r _s _eq l t a b -> foldTerm f (l ++ [t, a, b])
 
 -- | Put it in a monad to make it possible to do strictly.
 copyTerm :: (TermLike a, Monad m) => a -> m a

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -119,18 +119,22 @@ instance CheckInternal Type where
 instance CheckInternal Term where
   checkInternal' :: (MonadCheckInternal m) => Action m -> Term -> Comparison -> Type -> m Term
   checkInternal' action v cmp t = verboseBracket "tc.check.internal" 20 "" $ do
-    reportSDoc "tc.check.internal" 20 $ sep
-      [ "checking internal "
-      , nest 2 $ sep [ prettyTCM v <+> ":"
-                    , nest 2 $ prettyTCM t ] ]
-    reportSDoc "tc.check.internal" 60 $ sep
-      [ "checking internal with DB indices"
-      , nest 2 $ sep [ pretty v <+> ":"
-                    , nest 2 $ pretty t ] ]
-    ctx <- getContextTelescope
-    unless (null ctx) $ reportSDoc "tc.check.internal" 30 $ sep
-      [ "In context"
-      , nest 2 $ sep [ prettyTCM ctx ] ]
+
+    -- Debug print
+    verboseS "tc.check.internal" 20 do
+      reportSDoc "tc.check.internal" 20 $ sep
+        [ "checking internal "
+        , nest 2 $ sep [ prettyTCM v <+> ":"
+                      , nest 2 $ prettyTCM t ] ]
+      reportSDoc "tc.check.internal" 60 $ sep
+        [ "checking internal with DB indices"
+        , nest 2 $ sep [ pretty v <+> ":"
+                      , nest 2 $ pretty t ] ]
+      ctx <- getContextTelescope
+      unless (null ctx) $ reportSDoc "tc.check.internal" 30 $ sep
+        [ "In context"
+        , nest 2 $ sep [ prettyTCM ctx ] ]
+
     -- Bring projection-like funs in post-fix form,
     -- (even lone ones by default).
     v <- elimViewAction action =<< preAction action t v

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -576,6 +576,7 @@ instance Free t => Free (List1 t)
 instance Free t => Free (Maybe t)
 instance Free t => Free (WithHiding t)
 instance Free t => Free (Named nm t)
+instance Free t => Free (Ranged t)
 
 instance (Free t, Free u) => Free (t, u) where
   freeVars' (t, u) = freeVars' t `mappend` freeVars' u
@@ -609,4 +610,4 @@ instance Free EqualityView where
   freeVars' = \case
     OtherType t -> freeVars' t
     IdiomType t -> freeVars' t
-    EqualityType s _eq l t a b -> freeVars' (s, l, [t, a, b])
+    EqualityType _r s _eq l t a b -> freeVars' (s, l, [t, a, b])

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4727,6 +4727,8 @@ data Warning
   -- Type checker warnings
   | TooManyArgumentsToSort QName (List1 (NamedArg A.Expr))
       -- ^ Extra arguments to sort (will be ignored).
+  | RewritesNothing
+      -- ^ A @rewrite@ expression that does not fire.
   | WithClauseProjectionFixityMismatch
     { withClausePattern          :: NamedArg A.Pattern
     , withClauseProjectionOrigin :: ProjOrigin
@@ -4867,6 +4869,7 @@ warningName = \case
 
   -- Type checking
   TooManyArgumentsToSort{}             -> TooManyArgumentsToSort_
+  RewritesNothing{}                    -> RewritesNothing_
   WithClauseProjectionFixityMismatch{} -> WithClauseProjectionFixityMismatch_
 
   -- Polarities

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -758,8 +758,11 @@ primEqualityName = do
 --
 --   Precondition: type is reduced.
 
-equalityView :: Type -> TCM EqualityView
-equalityView t0@(El s t) = do
+equalityView ::
+     Range  -- ^ Range of the @rewrite@ expression, if any.
+  -> Type   -- ^ Identity type?
+  -> TCM EqualityView
+equalityView r t0@(El s t) = do
   equality <- primEqualityName
   case t of
     Def equality' es | equality' == equality -> do
@@ -767,7 +770,7 @@ equalityView t0@(El s t) = do
       let n = length vs
       unless (n >= 3) __IMPOSSIBLE__
       let (pars, [ typ , lhs, rhs ]) = splitAt (n-3) vs
-      return $ EqualityType s equality pars typ lhs rhs
+      return $ EqualityType r s equality pars typ lhs rhs
     _ -> return $ OtherType t0
 
 -- | Revert the 'EqualityView'.
@@ -784,7 +787,7 @@ instance EqualityUnview EqualityView where
     EqualityViewType eqt -> equalityUnview eqt
 
 instance EqualityUnview EqualityTypeData where
-  equalityUnview (EqualityTypeData s equality l t lhs rhs) =
+  equalityUnview (EqualityTypeData _r s equality l t lhs rhs) =
     El s $ Def equality $ map Apply (l ++ [t, lhs, rhs])
 
 -- | Primitives with typechecking constrants.

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -653,6 +653,8 @@ prettyWarning = \case
       , [ prettyTCM q ]
       ]
 
+    RewritesNothing -> fsep $ pwords "`rewrite' did not apply"
+
     WithClauseProjectionFixityMismatch p0 o' q o -> fsep $ concat
         [ pwords "With clause pattern"
         , [ prettyA p0 ]

--- a/src/full/Agda/TypeChecking/ReconstructParameters.hs
+++ b/src/full/Agda/TypeChecking/ReconstructParameters.hs
@@ -45,8 +45,8 @@ reconstructParametersInTel (ExtendTel a tel) = do
     ExtendTel (ar <$ a) <$> traverse reconstructParametersInTel tel
 
 reconstructParametersInEqView :: EqualityView -> TCM EqualityView
-reconstructParametersInEqView (EqualityType s eq l a u v) =
-  EqualityType s eq l <$> traverse (reconstructParameters $ sort s) a
+reconstructParametersInEqView (EqualityType r s eq l a u v) =
+  EqualityType r s eq l <$> traverse (reconstructParameters $ sort s) a
                       <*> traverse (reconstructParameters $ El s $ unArg a) u
                       <*> traverse (reconstructParameters $ El s $ unArg a) v
 reconstructParametersInEqView (OtherType a) = OtherType <$> reconstructParametersInType a

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -329,7 +329,7 @@ instance Instantiate EqualityView where
     <$> instantiate' t
   instantiate' (IdiomType t)            = IdiomType
     <$> instantiate' t
-  instantiate' (EqualityType s eq l t a b) = EqualityType
+  instantiate' (EqualityType r s eq l t a b) = EqualityType r
     <$> instantiate' s
     <*> return eq
     <*> mapM instantiate' l
@@ -1010,7 +1010,7 @@ instance Reduce EqualityView where
     <$> reduce' t
   reduce' (IdiomType t)            = IdiomType
     <$> reduce' t
-  reduce' (EqualityType s eq l t a b) = EqualityType
+  reduce' (EqualityType r s eq l t a b) = EqualityType r
     <$> reduce' s
     <*> return eq
     <*> mapM reduce' l
@@ -1190,7 +1190,7 @@ instance Simplify EqualityView where
     <$> simplify' t
   simplify' (IdiomType t)            = IdiomType
     <$> simplify' t
-  simplify' (EqualityType s eq l t a b) = EqualityType
+  simplify' (EqualityType r s eq l t a b) = EqualityType r
     <$> simplify' s
     <*> return eq
     <*> mapM simplify' l
@@ -1220,6 +1220,7 @@ instance Normalise t => Normalise (Strict.Maybe t)
 -- Elim' not included since it contains Arg
 instance Normalise t => Normalise (Named name t)
 instance Normalise t => Normalise (IPBoundary' t)
+instance Normalise t => Normalise (Ranged t)
 instance Normalise t => Normalise (WithHiding t)
 
 -- more boring instances:
@@ -1375,7 +1376,7 @@ instance Normalise EqualityView where
     <$> normalise' t
   normalise' (IdiomType t)            = IdiomType
     <$> normalise' t
-  normalise' (EqualityType s eq l t a b) = EqualityType
+  normalise' (EqualityType r s eq l t a b) = EqualityType r
     <$> normalise' s
     <*> return eq
     <*> mapM normalise' l
@@ -1774,7 +1775,7 @@ instance InstantiateFull EqualityView where
     <$> instantiateFull' t
   instantiateFull' (IdiomType t)            = IdiomType
     <$> instantiateFull' t
-  instantiateFull' (EqualityType s eq l t a b) = EqualityType
+  instantiateFull' (EqualityType r s eq l t a b) = EqualityType r
     <$> instantiateFull' s
     <*> return eq
     <*> mapM instantiateFull' l

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -1007,8 +1007,8 @@ checkRHS i x aps t lhsResult@(LHSResult _ delta ps absurdPat trhs _ _asb _ _) rh
       -- and extract lhs, rhs, and their type.
 
       t' <- reduce =<< instantiateFull eqt
-      (eqt,rewriteType,rewriteFrom,rewriteTo) <- equalityView t' >>= \case
-        eqt@(EqualityType _s _eq _params (Arg _ dom) a b) -> do
+      (eqt, rewriteType, rewriteFrom, rewriteTo) <- equalityView (getRange eq) t' >>= \case
+        eqt@(EqualityType _r _s _eq _params (Arg _ dom) a b) -> do
           s <- sortOf dom
           return (eqt, El s dom, unArg a, unArg b)
           -- Note: the sort _s of the equality need not be the sort of the type @dom@!
@@ -1209,10 +1209,12 @@ checkWithFunction cxtNames (WithFunction f aux t delta delta1 delta2 vtys b qs n
   setCurrentRange cs $
     traceCall NoHighlighting $   -- To avoid flicker.
     traceCall (CheckWithFunctionType withFunType) $
-    -- Jesper, 2024-07-10, issue $6841:
+    -- Jesper, 2024-07-10, issue #6841:
     -- Having an ill-typed type can lead to problems in the
     -- coverage checker, so we ensure there are no constraints here.
     noConstraints $ checkType withFunType
+
+  reportSLn "tc.with.top" 20 "creating with display form..."
 
   -- With display forms are closed
   df <- inTopContext $ makeOpen =<< withDisplayForm f aux delta1 delta2 nwithargs qs perm' perm

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20250618 * 10 + 0
+currentInterfaceVersion = 20250703 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -139,6 +139,7 @@ instance EmbPrj Warning where
     TooManyPolarities a b                       -> icodeN 71 TooManyPolarities a b
     FixingCohesion a b c                        -> icodeN 72 FixingCohesion a b c
     FixingPolarity a b c                        -> icodeN 73 FixingPolarity a b c
+    RewritesNothing                             -> icodeN 74 RewritesNothing
 
   value = vcase $ \ case
     [0, a, b]            -> valuN UnreachableClauses a b
@@ -216,6 +217,7 @@ instance EmbPrj Warning where
     [71, a, b]           -> valuN TooManyPolarities a b
     [72, a, b, c]        -> valuN FixingCohesion a b c
     [73, a, b, c]        -> valuN FixingPolarity a b c
+    [74]                 -> valuN RewritesNothing
     _ -> malformed
 
 instance EmbPrj UselessPublicReason

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1097,6 +1097,9 @@ instance Subst a => Subst (List1 a) where
 instance (Ord k, Subst a) => Subst (Map k a) where
   type SubstArg (Map k a) = SubstArg a
 
+instance Subst a => Subst (Ranged a) where
+  type SubstArg (Ranged a) = SubstArg a
+
 instance Subst a => Subst (WithHiding a) where
   type SubstArg (WithHiding a) = SubstArg a
 
@@ -1134,7 +1137,7 @@ instance Subst EqualityView where
 
 instance Subst EqualityTypeData where
   type SubstArg EqualityTypeData = Term
-  applySubst rho (EqualityTypeData s eq l t a b) = EqualityTypeData
+  applySubst rho (EqualityTypeData r s eq l t a b) = EqualityTypeData r
     (applySubst rho s)
     eq
     (map (applySubst rho) l)

--- a/src/full/Agda/TypeChecking/With.hs
+++ b/src/full/Agda/TypeChecking/With.hs
@@ -207,7 +207,7 @@ withArguments vtys = do
         case ts of
           (v, OtherType a) -> do
             return $ singleton v
-          (prf, eqt@(EqualityType s _eq _pars _t v _v')) -> do
+          (prf, eqt@(EqualityType _r _s _eq _pars _t v _v')) -> do
             return $ unArg v :| prf : []
           (v, IdiomType t) -> do
             mkRefl <- getRefl

--- a/test/Fail/DebugWith.err
+++ b/test/Fail/DebugWith.err
@@ -34,6 +34,7 @@ checkWithFunction
   fperm  = x0,x1,x2,x3,x4 -> x1,x3,x0,x2,x4
   withSub= Var 0 [] :# (Var 4 [] :# (Var 1 [] :# (Var 5 [] :# (Var 2 [] :# Wk 6 IdS))))
 with function call DebugWith.with-34 b f (f b) trash1 trash2 trash3
+creating with display form...
 created with display form
 Display 6 [$ @5, $ @4, $ @3, $ @2, $ @1, $ @0]
         test @2 @5 @1 @4 @0 | @3

--- a/test/Fail/Issue5819.err
+++ b/test/Fail/Issue5819.err
@@ -1,3 +1,8 @@
+Issue5819.agda:108.36-52: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause
+invˡ {dl″ (cons′ a l) p} rewrite invˡ {dl″ l ?} = ? has type
+{x = x₁ : DList″} → f dl-iso (f⁻¹ dl-iso x₁) ≡ x₁
 Issue5819.agda:72.1-120.45: error: [TerminationIssue]
 Termination checking failed for the following functions:
   dl-iso, Fresh→Fresh′, Fresh→AllFresh

--- a/test/Succeed/Issue1111.warn
+++ b/test/Succeed/Issue1111.warn
@@ -1,0 +1,25 @@
+Issue1111.agda:25.15-40: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause
+test0 rewrite comm {n = ?} {m = ?} = ? has type
+{x y : Nat} → x + (x + y) ≡ x + (y + x)
+
+Issue1111.agda:28.21-46: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause
+test {x} {y} rewrite comm {n = ?} {m = ?} = ? has type
+{x y : Nat} → x + (x + y) ≡ x + (y + x)
+
+———— All done; warnings encountered ————————————————————————
+
+Issue1111.agda:25.15-40: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause
+test0 rewrite comm {n = ?} {m = ?} = ? has type
+{x y : Nat} → x + (x + y) ≡ x + (y + x)
+
+Issue1111.agda:28.21-46: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause
+test {x} {y} rewrite comm {n = ?} {m = ?} = ? has type
+{x y : Nat} → x + (x + y) ≡ x + (y + x)

--- a/test/Succeed/Issue1796rewrite.agda
+++ b/test/Succeed/Issue1796rewrite.agda
@@ -69,4 +69,4 @@ gcd-diag-erase (suc {i} n)
           -- Before fix: diff-diag-erase {i} n.
           -- The {i} was necessary, otherwise rewrite failed
           -- because an unsolved size var prevented abstraction.
-        | gcd-diag-erase n = refl
+        = refl

--- a/test/Succeed/Issue1934.warn
+++ b/test/Succeed/Issue1934.warn
@@ -1,0 +1,13 @@
+Issue1934.agda:48.27-42: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause
+id-lem-left {a} rewrite id-lem-right {a} = ? has type
+{a : G} → (a op e) ≡ a
+
+———— All done; warnings encountered ————————————————————————
+
+Issue1934.agda:48.27-42: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause
+id-lem-left {a} rewrite id-lem-right {a} = ? has type
+{a : G} → (a op e) ≡ a

--- a/test/Succeed/Issue237.warn
+++ b/test/Succeed/Issue237.warn
@@ -1,0 +1,11 @@
+Issue237.agda:17.15-19: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause foo u rewrite eq u = Set has type
+Unit → Set₁
+
+———— All done; warnings encountered ————————————————————————
+
+Issue237.agda:17.15-19: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause foo u rewrite eq u = Set has type
+Unit → Set₁

--- a/test/Succeed/Issue2603.warn
+++ b/test/Succeed/Issue2603.warn
@@ -1,0 +1,11 @@
+Issue2603.agda:33.16-26: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause lemma2 rewrite elephant _ = Signal
+has type Set
+
+———— All done; warnings encountered ————————————————————————
+
+Issue2603.agda:33.16-26: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause lemma2 rewrite elephant _ = Signal
+has type Set

--- a/test/Succeed/RefineParamsBugs.warn
+++ b/test/Succeed/RefineParamsBugs.warn
@@ -1,0 +1,51 @@
+RefineParamsBugs.agda:157.39-43: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause
+foldr=foldl ∅ id (x ∷ xs) rewrite id x | foldl-plus x ∅ xs = Nat
+has type (∅ : A) → ((x : A) → (∅ ∙ x) ≡ (x ∙ ∅)) → List A → Set
+
+RefineParamsBugs.agda:158.40-57: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause
+RefineParamsBugs.Folds.FoldAssoc.-rewrite370 {A = A} _∙_ = _∙_
+  assoc = assoc
+  ∅
+  id
+  x
+  _
+  !
+  xs
+  rewrite foldl-plus x ∅ xs
+  = Nat
+has type
+{A : Set} (_∙_ : A → A → A)
+(assoc : (x y z : A) → ((x ∙ y) ∙ z) ≡ (x ∙ (y ∙ z))) (∅ : A)
+(id : (x : A) → (∅ ∙ x) ≡ (x ∙ ∅)) (x lhs : A) →
+lhs ≡ (x ∙ ∅) → (xs : List A) → Set
+
+———— All done; warnings encountered ————————————————————————
+
+RefineParamsBugs.agda:157.39-43: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause
+foldr=foldl ∅ id (x ∷ xs) rewrite id x | foldl-plus x ∅ xs = Nat
+has type (∅ : A) → ((x : A) → (∅ ∙ x) ≡ (x ∙ ∅)) → List A → Set
+
+RefineParamsBugs.agda:158.40-57: warning: -W[no]RewritesNothing
+'rewrite' did not apply
+when checking that the clause
+RefineParamsBugs.Folds.FoldAssoc.-rewrite370 {A = A} _∙_ = _∙_
+  assoc = assoc
+  ∅
+  id
+  x
+  _
+  !
+  xs
+  rewrite foldl-plus x ∅ xs
+  = Nat
+has type
+{A : Set} (_∙_ : A → A → A)
+(assoc : (x y z : A) → ((x ∙ y) ∙ z) ≡ (x ∙ (y ∙ z))) (∅ : A)
+(id : (x : A) → (∅ ∙ x) ≡ (x ∙ ∅)) (x lhs : A) →
+lhs ≡ (x ∙ ∅) → (xs : List A) → Set

--- a/test/interaction/Issue1110b.out
+++ b/test/interaction/Issue1110b.out
@@ -2,5 +2,5 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 (agda2-status-action "")
-(agda2-info-action "*All Goals*" "?0 : Nat ?1 : P x " nil)
+(agda2-info-action "*All Goals, Warnings*" "?0 : Nat ?1 : P x ———— Warnings —————————————————————————————————————————————— Issue1110b.agda:12.13-21: warning: -W[no]RewritesNothing `rewrite' did not apply when checking that the clause f x rewrite bla ? = ? has type (x : Nat) → P x" nil)
 ((last . 1) . (agda2-goals-action '(0 1)))


### PR DESCRIPTION
  

- **Refactor absTerm to arbitrary de Bruijn index for hole, was just 0**
  The implementation of absTerm always freed de Bruijn index 0 for the placeholder of the abstracted-out subterm, but then needed to `swap01` swap de Bruijn indices 0 and 1 just before putting back lambdas (and other binders).
  
  It seems more principled to directly implement `absTerm j u` that replaces subterm `u` with de Bruijn index `j`, shifting indices up to make space for `j`.  When going under a binder, we simply increase `j`.
  
  Now `absTerm j u` is the inverse of single substitution `subst j u`.
  
  The new implementation seems marginally faster than the old implementation, but measurement is difficult because of the overall time for `with`-abstraction is dominated by the time to check that the generated type of the `with`-function is well-formed (issue #7975).
  

- **Fix #7973: print warning if `rewrite` does not fire**
  