### PR TITLE
Refactor nicifier and `FunDef` (use `List1 Clause`)

### DIFF
--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -184,7 +184,7 @@ data Declaration
     -- ^ The @ImportDirective@ is for highlighting purposes.
   | Pragma     Range      Pragma
   | Open       ModuleInfo ModuleName ImportDirective
-  | FunDef     DefInfo QName [Clause] -- ^ sequence of function clauses
+  | FunDef     DefInfo QName (List1 Clause) -- ^ sequence of function clauses
   | DataSig    DefInfo Erased QName GeneralizeTelescope Type -- ^ lone data signature
   | DataDef    DefInfo QName UniverseCheck DataDefParams [Constructor]
   | RecSig     DefInfo Erased QName GeneralizeTelescope Type -- ^ lone record signature
@@ -1145,7 +1145,7 @@ data DeclarationSpine
   | ImportS
   | PragmaS
   | OpenS
-  | FunDefS [ClauseSpine]
+  | FunDefS (List1 ClauseSpine)
   | DataSigS
   | DataDefS
   | RecSigS
@@ -1191,7 +1191,7 @@ declarationSpine = \case
   Import _ _ _            -> ImportS
   Pragma _ _              -> PragmaS
   Open _ _ _              -> OpenS
-  FunDef _ _ cs           -> FunDefS (map clauseSpine cs)
+  FunDef _ _ cs           -> FunDefS (fmap clauseSpine cs)
   DataSig _ _ _ _ _       -> DataSigS
   DataDef _ _ _ _ _       -> DataDefS
   RecSig _ _ _ _ _        -> RecSigS

--- a/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
@@ -7,7 +7,7 @@ import Prelude hiding ( null )
 import Control.Monad        ()
 import Control.Monad.Except ( MonadError(..), ExceptT, runExceptT )
 import Control.Monad.Reader ( MonadReader, ReaderT, runReaderT )
-import Control.Monad.State  ( MonadState(..), modify, State, runState )
+import Control.Monad.State  ( MonadState(..), modify, State, StateT, runState )
 
 import Data.Bifunctor (second)
 import Data.Map (Map)
@@ -34,6 +34,9 @@ newtype Nice a = Nice { unNice :: ReaderT NiceEnv (ExceptT DeclarationException 
   deriving ( Functor, Applicative, Monad
            , MonadReader NiceEnv, MonadState NiceState, MonadError DeclarationException
            )
+
+-- | Extension of the nicifier monad with state to process interleaved mutual blocks.
+type INice = StateT InterleavedState Nice
 
 -- | Run a Nicifier computation, return result and warnings
 --   (in chronological order).

--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -69,7 +69,7 @@ data NiceDeclaration
     --   without type signature or a pattern lhs (e.g. for irrefutable let).
     --   The 'Declaration' is the actual 'FunClause'.
   | FunSig Range Access IsAbstract IsInstance IsMacro ArgInfo TerminationCheck CoverageCheck Name Expr
-  | FunDef Range [Declaration] IsAbstract IsInstance TerminationCheck CoverageCheck Name [Clause]
+  | FunDef Range (List1 Declaration) IsAbstract IsInstance TerminationCheck CoverageCheck Name (List1 Clause)
       -- ^ Block of function clauses (we have seen the type signature before).
       --   The 'Declaration's are the original declarations that were processed
       --   into this 'FunDef' and are only used in 'notSoNiceDeclaration'.
@@ -159,7 +159,7 @@ data InterleavedDecl
         -- ^ Internal number of the function signature.
     , interleavedDeclSig  :: NiceDeclaration
         -- ^ The function signature.
-    , interleavedFunClauses :: Maybe (DeclNum, List1 ([Declaration],[Clause]))
+    , interleavedFunClauses :: Maybe (DeclNum, List1 (List1 Declaration, List1 Clause))
         -- ^ Function clauses associated to the function signature.
     }
 

--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -163,6 +163,13 @@ data InterleavedDecl
         -- ^ Function clauses associated to the function signature.
     }
 
+-- | Extra state for the 'Nice' monad to process interleaved mutual blocks.
+data InterleavedState = ISt
+  { interleavedMutual         :: InterleavedMutual
+  , interleavedMutualChecks   :: MutualChecks
+  , interleavedCurrentDeclNum :: DeclNum
+  }
+
 -- | Numbering declarations in an @interleaved mutual@ block.
 type DeclNum = Int
 

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1238,7 +1238,7 @@ instance ToConcrete A.Declaration where
         -- Primitives are always relevant.
 
   toConcrete (A.FunDef i _ cs) =
-    withAbstractPrivate i $ List1.concat <$> toConcrete cs
+    withAbstractPrivate i $ List1.toList . sconcat <$> toConcrete cs
 
   toConcrete (A.DataSig i erased x bs t) =
     withAbstractPrivate i $

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -185,7 +185,7 @@ recordConstructorType decls =
         C.NiceMutual _ _ _ _
           [ C.FunSig _ _ _ _ macro _ _ _ _ _
           , C.FunDef _ _ abstract _ _ _ _
-             [ C.Clause _ _ (C.LHS _p [] []) (C.RHS _) NoWhere [] ]
+             (C.Clause _ _ (C.LHS _p [] []) (C.RHS _) NoWhere [] :| [])
           ] | abstract /= AbstractDef && macro /= MacroDef -> do
           mkLet d
 
@@ -805,7 +805,7 @@ scopeCheckExtendedLam r e cs = do
   -- Andreas, 2019-08-20
   -- Keep the following __IMPOSSIBLE__, which is triggered by -v scope.decl.trace:80,
   -- for testing issue #4016.
-  d <- C.FunDef r [] a NotInstanceDef __IMPOSSIBLE__ __IMPOSSIBLE__ cname . List1.toList <$> do
+  d <- C.FunDef r __IMPOSSIBLE__ a NotInstanceDef __IMPOSSIBLE__ __IMPOSSIBLE__ cname <$> do
           forM cs $ \ (LamClause ps rhs ca) -> do
             let p   = C.rawAppP $
                         killRange (IdentP True $ C.QName cname) :| ps
@@ -1484,7 +1484,7 @@ instance ToAbstract LetDef where
   type AbsOfCon LetDef = List1 A.LetBinding
   toAbstract :: LetDef -> ScopeM (AbsOfCon LetDef)
   toAbstract (LetDef wh d) = setCurrentRange d case d of
-    NiceMutual _ _ _ _ d@[C.FunSig _ access _ instanc macro info _ _ x t, C.FunDef _ _ abstract _ _ _ _ [cl]] -> do
+    NiceMutual _ _ _ _ d@[C.FunSig _ access _ instanc macro info _ _ x t, C.FunDef _ _ abstract _ _ _ _ (cl :| [])] -> do
       checkLetDefInfo wh access macro abstract
 
       t <- toAbstract t
@@ -1560,7 +1560,7 @@ instance ToAbstract LetDef where
               [ C.FunSig r PublicAccess ConcreteDef NotInstanceDef NotMacroDef
                   (setOrigin Inserted defaultArgInfo) tc cc x (C.Underscore (getRange x) Nothing)
               , C.FunDef r __IMPOSSIBLE__ ConcreteDef NotInstanceDef __IMPOSSIBLE__ __IMPOSSIBLE__ __IMPOSSIBLE__
-                [C.Clause x (ca <> catchall) lhs (C.RHS rhs) NoWhere []]
+                $ singleton $ C.Clause x (ca <> catchall) lhs (C.RHS rhs) NoWhere []
               ]
           where
             definedName (C.IdentP _ (C.QName x)) = Just x
@@ -1835,7 +1835,7 @@ instance ToAbstract NiceDeclaration where
   -- Function definitions
     C.FunDef r ds a i _ _ x cs -> do
         printLocals 30 $ "checking def " ++ prettyShow x
-        (x',cs) <- toAbstract (OldName x,cs)
+        (x',cs) <- toAbstract (OldName x, cs)
         -- Andreas, 2017-12-04 the name must reside in the current module
         unlessM ((A.qnameModule x' ==) <$> getCurrentModule) $
           __IMPOSSIBLE__
@@ -1843,7 +1843,7 @@ instance ToAbstract NiceDeclaration where
 
         unfoldFunction x'
         di <- updateDefInfoOpacity (mkDefInfoInstance x f PublicAccess a i NotMacroDef r)
-        return [ A.FunDef di x' cs ]
+        return [ A.FunDef di x' (List1.toList cs) ] -- TODO: use List1 in A.FunDef
 
   -- Uncategorized function clauses
     C.NiceFunClause _ _ _ _ _ _ (C.FunClause lhs _ _ _) ->

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -818,8 +818,7 @@ scopeCheckExtendedLam r e cs = do
     A.ScopedDecl si [A.FunDef di qname' cs] -> do
       setScope si  -- This turns into an A.ScopedExpr si $ A.ExtendedLam...
       return $
-        A.ExtendedLam (ExprRange r) di e qname' $
-        List1.fromListSafe __IMPOSSIBLE__ cs
+        A.ExtendedLam (ExprRange r) di e qname' cs
     _ -> __IMPOSSIBLE__
 
 -- | Scope check an expression.
@@ -1843,7 +1842,7 @@ instance ToAbstract NiceDeclaration where
 
         unfoldFunction x'
         di <- updateDefInfoOpacity (mkDefInfoInstance x f PublicAccess a i NotMacroDef r)
-        return [ A.FunDef di x' (List1.toList cs) ] -- TODO: use List1 in A.FunDef
+        return [ A.FunDef di x' cs ]
 
   -- Uncategorized function clauses
     C.NiceFunClause _ _ _ _ _ _ (C.FunClause lhs _ _ _) ->

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -203,7 +203,7 @@ coverageCheck f t cs = do
         , "i   = " <+> pretty i
         , "cl  = " <+> pretty (QNamed f cl)
         ]
-      addClauses f [cl]
+      addClauses f $ singleton cl
       return False
 
   -- report a warning if there are uncovered cases,
@@ -685,7 +685,7 @@ inferMissingClause f (SClause tel ps _ cps (Just t)) = setCurrentRange f $ do
                   , clauseEllipsis    = NoEllipsis
                   , clauseWhereModule = Nothing
                   }
-  addClauses f [cl]  -- Important: add at the end.
+  addClauses f $ singleton cl  -- Important: add at the end.
   return cl
 inferMissingClause _ (SClause _ _ _ _ Nothing) = __IMPOSSIBLE__
 

--- a/src/full/Agda/TypeChecking/IApplyConfluence.hs
+++ b/src/full/Agda/TypeChecking/IApplyConfluence.hs
@@ -59,7 +59,7 @@ checkIApplyConfluence_ f = whenM (isJust <$> cubicalOption) $ do
         modifySignature $ updateDefinition f $ updateTheDef
           $ updateCovering (const [])
 
-      traceCall (CheckFunDefCall (getRange f) f [] False) $
+      traceCall (CheckFunDefCall (getRange f) f False) $
         forM_ cls $ checkIApplyConfluence f
     _ -> return ()
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3446,8 +3446,8 @@ isWithFunction def =
     Function { funWith = Just{} } -> True
     _ -> False
 
-isCopatternLHS :: [Clause] -> Bool
-isCopatternLHS = List.any (List.any (isJust . A.isProjP) . namedClausePats)
+isCopatternLHS :: Foldable f => f Clause -> Bool
+isCopatternLHS = any (any (isJust . A.isProjP) . namedClausePats)
 
 recCon :: Defn -> QName
 recCon Record{ recConHead } = conName recConHead
@@ -3772,7 +3772,7 @@ data Call
   | CheckRecDef Range QName [A.LamBinding] [A.Constructor]
   | CheckConstructor QName Telescope Sort A.Constructor
   | CheckConArgFitsIn QName Bool Type Sort
-  | CheckFunDefCall Range QName [A.Clause] Bool
+  | CheckFunDefCall Range QName Bool
     -- ^ Highlight (interactively) if and only if the boolean is 'True'.
   | CheckPragma Range A.Pragma
   | CheckPrimitive Range QName A.Expr
@@ -3860,7 +3860,7 @@ instance HasRange Call where
     getRange (CheckRecDef i _ _ _)               = getRange i
     getRange (CheckConstructor _ _ _ c)          = getRange c
     getRange (CheckConArgFitsIn c _ _ _)         = getRange c
-    getRange (CheckFunDefCall i _ _ _)           = getRange i
+    getRange (CheckFunDefCall i _ _)             = getRange i
     getRange (CheckPragma r _)                   = r
     getRange (CheckPrimitive i _ _)              = getRange i
     getRange (CheckModuleParameters _ tel)       = getRange tel

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -189,7 +189,7 @@ instance MonadTrace TCM where
       CheckRecDef{}             -> True
       CheckConstructor{}        -> True
       CheckConArgFitsIn{}       -> False
-      CheckFunDefCall _ _ _ h   -> h
+      CheckFunDefCall _ _ h     -> h
       CheckPragma{}             -> True
       CheckPrimitive{}          -> True
       CheckIsEmpty{}            -> True

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -149,7 +149,7 @@ instance PrettyTCM Call where
         pwords "fits in the sort" ++ [prettyTCM s] ++
         pwords "of the datatype."
 
-    CheckFunDefCall _ f _ _ ->
+    CheckFunDefCall _ f _ ->
       fsep $ pwords "when checking the definition of" ++ [prettyTCM f]
 
     CheckPragma _ p ->

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -73,6 +73,7 @@ import Agda.Utils.Size
 import Agda.Utils.Tuple
 
 import Agda.Utils.Impossible
+import Agda.Utils.Singleton (singleton)
 
 ---------------------------------------------------------------------------
 -- * Data structures for checking arguments
@@ -1687,7 +1688,7 @@ checkSharpApplication e t c args = do
         (defaultDefn ai c' forcedType lang fun)
         { defMutual = i }
 
-    checkFunDef info c' [clause]
+    checkFunDef info c' $ singleton clause
 
     reportSDoc "tc.term.expr.coind" 15 $ do
       def <- theDef <$> getConstInfo c'

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -161,7 +161,7 @@ checkDecl d = setCurrentRange d $ do
       A.Import _ _ dir         -> none $ checkImportDirective dir
       A.Pragma i p             -> none $ checkPragma i p
       A.ScopedDecl scope ds    -> none $ setScope scope >> mapM_ checkDeclCached ds
-      A.FunDef i x cs          -> impossible $ check x i $ checkFunDef i x cs
+      A.FunDef i x cs          -> impossible $ check x i $ checkFunDef i x $ List1.toList cs
       A.DataDef i x uc ps cs   -> impossible $ check x i $ checkDataDef i x uc ps cs
       A.RecDef i x uc dir ps tel cs -> impossible $ check x i $ do
                                     checkRecDef i x uc dir ps tel cs

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -103,7 +103,7 @@ checkFunDef i name cs = do
                               -- of an abstract function must not be informed by its definition.
           Just (e, mc, x)
             | Info.defAbstract i == ConcreteDef, Info.defOpaque i == TransparentDef ->
-              traceCall (CheckFunDefCall (getRange i) name cs True) $ do
+              traceCall (CheckFunDefCall (getRange i) name True) $ do
                 -- Andreas, 2012-11-22: if the alias is in an abstract block
                 -- it has been frozen.  We unfreeze it to enable type inference.
                 -- See issue 729.
@@ -252,7 +252,7 @@ checkFunDefS :: Type             -- ^ the type we expect the function to have
              -> TCM ()
 checkFunDefS t ai extlam with i name withSubAndLets cs = do
 
-    traceCall (CheckFunDefCall (getRange i) name cs True) $ do
+    traceCall (CheckFunDefCall (getRange i) name True) $ do
         reportSDoc "tc.def.fun" 10 $
           sep [ "checking body of" <+> prettyTCM name
               , nest 2 $ ":" <+> prettyTCM t
@@ -260,12 +260,12 @@ checkFunDefS t ai extlam with i name withSubAndLets cs = do
               ]
 
         reportSDoc "tc.def.fun" 70 $
-          sep $ "clauses:" : map (nest 2 . text . show . A.deepUnscope) cs
+          sep $ "clauses:" : fmap (nest 2 . text . show . A.deepUnscope) cs
 
-        cs <- return $ map A.lhsToSpine cs
+        cs <- return $ fmap A.lhsToSpine cs
 
         reportSDoc "tc.def.fun" 70 $
-          sep $ "spine clauses:" : map (nest 2 . text . show . A.deepUnscope) cs
+          sep $ "spine clauses:" : fmap (nest 2 . text . show . A.deepUnscope) cs
 
         -- Ensure that all clauses have the same number of trailing hidden patterns
         -- This is necessary since trailing implicits are no longer eagerly inserted.
@@ -297,7 +297,7 @@ checkFunDefS t ai extlam with i name withSubAndLets cs = do
         let isSystem = not . null $ isOneIxs
         when isSystem do
           -- allow VarP and ConP i0/i1 fallThrough = yes, DotP
-          let pss = map namedClausePats cs
+          let pss = fmap namedClausePats cs
               allowed = \case
                 VarP{} -> True
                 -- pattern inserted by splitPartial
@@ -308,15 +308,15 @@ checkFunDefS t ai extlam with i name withSubAndLets cs = do
             typeError PatternInSystem
 
         reportSDoc "tc.def.fun" 70 $ inTopContext $ do
-          sep $ "checked clauses:" : map (nest 2 . text . show) cs
+          sep $ "checked clauses:" : fmap (nest 2 . text . show) cs
 
         reportSDoc "tc.cc" 25 $ inTopContext $ do
           sep [ "clauses before injectivity test"
-              , nest 2 $ prettyTCM $ map (QNamed name) cs  -- broken, reify (QNamed n cl) expect cl to live at top level
+              , nest 2 $ prettyTCM $ fmap (QNamed name) cs  -- broken, reify (QNamed n cl) expect cl to live at top level
               ]
         reportSDoc "tc.cc" 60 $ inTopContext $ do
           sep [ "raw clauses: "
-              , nest 2 $ sep $ map (text . show . QNamed name) cs
+              , nest 2 $ sep $ fmap (text . show . QNamed name) cs
               ]
 
         -- Needed to calculate the proper fullType below.
@@ -389,12 +389,12 @@ checkFunDefS t ai extlam with i name withSubAndLets cs = do
 
         reportSDoc "tc.cc" 15 $ inTopContext $ do
           sep [ "clauses before compilation"
-              , nest 2 $ sep $ map (prettyTCM . QNamed name) cs
+              , nest 2 $ sep $ fmap (prettyTCM . QNamed name) cs
               ]
 
         reportSDoc "tc.cc.raw" 65 $ do
           sep [ "clauses before compilation"
-              , nest 2 $ sep $ map (text . show) cs
+              , nest 2 $ sep $ fmap (text . show) cs
               ]
 
         -- add clauses for the coverage (& confluence) checker (needs to reduce)

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -96,6 +96,11 @@ last2 _ = Nothing
 snoc :: [a] -> a -> List1 a
 snoc as a = prependList as $ a :| []
 
+-- | Append an element to a non-empty list.
+
+snoc1 :: List1 a -> a -> List1 a
+snoc1 as a = as <> (a :| [])
+
 -- | @'groupOn' f = 'groupBy' (('==') \`on\` f) '.' 'List.sortBy' ('compare' \`on\` f)@.
 -- O(n log n).
 groupOn :: Ord b => (a -> b) -> [a] -> [List1 a]


### PR DESCRIPTION
1. Refactor nicifier: introduce `InterleavedState`, `addInterleavedFun`. The latter removes a clone.
2. Use `List1 Clause` in `C.FunDef` (addresses a TODO).
3. Use `List1 Clause` in `A.FunDef`.

There are many more opportunities to replace `[A.Clause]` by `List1 A.Clause` but for instance in `FunctionData` we need to allow empty list of clauses for functions that still expect their clauses.
