### PR TITLE
Refactorings in nicifier

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -737,8 +737,8 @@ niceDeclarations fixs ds = do
       d -> declarationException $ WrongContentBlock b $ getRange d
 
     toPrim :: NiceDeclaration -> NiceDeclaration
-    toPrim (Axiom r p a i rel x t) = PrimitiveFunction r p a x (Arg rel t)
-    toPrim _                       = __IMPOSSIBLE__
+    toPrim (Axiom r p a NotInstanceDef rel x t) = PrimitiveFunction r p a x (Arg rel t)
+    toPrim _ = __IMPOSSIBLE__
 
     -- Create a function definition.
     mkFunDef ::

--- a/test/Succeed/PrimitiveInstance.agda
+++ b/test/Succeed/PrimitiveInstance.agda
@@ -1,0 +1,8 @@
+-- Andreas, 2025-07-14, issue #7998
+-- Instance keywords in primitive blocks should not be silently ignored.
+
+primitive
+  instance
+    primLockUniv : Set₁
+
+-- Expected warning about useless "instance", but get none.


### PR DESCRIPTION
- **Refactor nicifier: remove a clone in replaceSigs**
  

- **Refactor nicePragma to treat all boring cases uniformly**
  ...and spell them all out.
  

- **Refactor nicifier: silence some unused-matches warnings**
  

- **Re #7998: `instance` gets silently dropped in `primitive` blocks**
  