### PR TITLE
Fix #7998: `instance` silently dropped in `primitive`/`variable` blocks

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -1512,7 +1512,6 @@ instance MakePrivate NiceDeclaration where
       NiceField r p a i tac x e                -> (\ p -> NiceField r p a i tac x e)            <$> mkPrivate kwr o p
       PrimitiveFunction r p a x e              -> (\ p -> PrimitiveFunction r p a x e)          <$> mkPrivate kwr o p
       NiceMutual r tc cc pc ds                 -> (\ ds-> NiceMutual r tc cc pc ds)             <$> mkPrivate kwr o ds
-      NiceLoneConstructor r ds                 -> NiceLoneConstructor r                         <$> mkPrivate kwr o ds
       NiceModule r p a e x tel ds              -> (\ p -> NiceModule r p a e x tel ds)          <$> mkPrivate kwr o p
       NiceModuleMacro r p e x ma op is         -> (\ p -> NiceModuleMacro r p e x ma op is)     <$> mkPrivate kwr o p
       FunSig r p a i m rel tc cc x e           -> (\ p -> FunSig r p a i m rel tc cc x e)       <$> mkPrivate kwr o p
@@ -1536,6 +1535,7 @@ instance MakePrivate NiceDeclaration where
       -- Andreas, 2016-07-08, issue #2089
       -- we need to propagate 'private' to the named where modules
       FunDef r ds a i tc cc x cls              -> FunDef r ds a i tc cc x <$> mkPrivate kwr o cls
+      d@NiceLoneConstructor{}                  -> return d -- Issue #7998: constructors cannot be private
       d@NiceDataDef{}                          -> return d
       d@NiceRecDef{}                           -> return d
       d@NiceUnquoteData{}                      -> return d

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -471,7 +471,7 @@ instance Pretty DeclarationWarning' where
       ++ punctuate comma (fmap pretty $ Set1.toList xs)
 
     UselessPrivate _ -> fsep $
-      pwords "Using private here has no effect. Private applies only to declarations that introduce new identifiers into the module, like type signatures and data, record, and module declarations."
+      pwords "Using private here has no effect. Private applies only to declarations that introduce new identifiers into the module, like type signatures except for constructors, and data, record, and module declarations"
 
     UselessAbstract _ -> fsep $
       pwords "Using abstract here has no effect. Abstract applies to only definitions like data definitions, record type definitions and function clauses."

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -477,7 +477,7 @@ instance Pretty DeclarationWarning' where
       pwords "Using abstract here has no effect. Abstract applies to only definitions like data definitions, record type definitions and function clauses."
 
     UselessInstance _ -> fsep $
-      pwords "Using instance here has no effect. Instance applies only to declarations that introduce new identifiers into the module, like type signatures and axioms."
+      pwords "Using instance here has no effect. Instance applies only to declarations that introduce new identifiers into the module, like type signatures and axioms (other than primitives)."
 
     UselessMacro _ -> fsep $
       pwords "Using a macro block here has no effect. `macro' applies only to function definitions."

--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -197,11 +197,10 @@ interleavedDecl k = \case
 
 -- | Several declarations expect only type signatures as sub-declarations.  These are:
 data KindOfBlock
-  = PostulateBlock  -- ^ @postulate@
-  | PrimitiveBlock  -- ^ @primitive@.  Ensured by parser.
-  | InstanceBlock   -- ^ @instance@.  Actually, here all kinds of sub-declarations are allowed a priori.
-  | FieldBlock      -- ^ @field@.  Ensured by parser.
-  | DataBlock       -- ^ @data ... where@.  Here we got a bad error message for Agda-2.5 (Issue 1698).
+  = PostulateBlock    -- ^ @postulate@.
+  | PrimitiveBlock    -- ^ @primitive@.
+  | FieldBlock        -- ^ @field@.  Ensured by parser.
+  | DataBlock         -- ^ @data ... where@.  Here we got a bad error message for Agda-2.5 (Issue 1698).
   | ConstructorBlock  -- ^ @constructor@, in @interleaved mutual@.
   deriving (Eq, Ord, Show, Generic)
 

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -476,8 +476,8 @@ ArgIds
 
 -- Modalities preceeding identifiers
 
-ModalArgIds :: { ([Attr], List1 (Arg Name)) }
-ModalArgIds : Attributes ArgIds  {% ($1,) `fmap` mapM (applyAttrs $1) $2 }
+ModalArgIds :: { (TacticAttribute, List1 (Arg Name)) }
+ModalArgIds : Attributes ArgIds  {% (getTacticAttr $1,) `fmap` mapM (applyAttrs $1) $2 }
 
 -- Attributes are parsed as '@' followed by an atomic expression.
 -- Unknown attributes cast a warning and are ignored.
@@ -1202,16 +1202,16 @@ Declaration
 -- {n1 .n2} n3 .n4 {n5} .{n6 n7} ... : Type.
 ArgTypeSigs :: { List1 (Arg Declaration) }
 ArgTypeSigs
-  : ModalArgIds ':' Expr { let (attrs, xs) = $1 in
-                           fmap (fmap (\ x -> typeSig defaultArgInfo (getTacticAttr attrs) x $3)) xs }
+  : ModalArgIds ':' Expr { let (tac, xs) = $1 in
+                           fmap (fmap (\ x -> typeSig defaultArgInfo tac x $3)) xs }
   | 'overlap' ModalArgIds ':' Expr {%
-      let (attrs, xs) = $2
+      let (tac, xs) = $2
           setOverlap x =
             case getHiding x of
               Instance _ -> return $ makeInstance' YesOverlap x
               _          -> parseErrorRange $1
                              "The 'overlap' keyword only applies to instance fields (fields marked with {{ }})"
-      in T.traverse (setOverlap . fmap (\ x -> typeSig defaultArgInfo (getTacticAttr attrs) x $4)) xs }
+      in T.traverse (setOverlap . fmap (\ x -> typeSig defaultArgInfo tac x $4)) xs }
   | 'instance' ArgTypeSignatures {
     let
       setInstance (TypeSig info tac x t) = TypeSig (makeInstance info) tac x t

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -1359,17 +1359,19 @@ Instance : 'instance' Declarations0  { InstanceB (kwRange $1) $2 }
 Macro :: { Declaration }
 Macro : 'macro' Declarations0 { Macro (kwRange $1) $2 }
 
-
 -- Postulates.
+--
+-- Checked in nicifier:
+-- Can only contain type signatures, possibly in instance and private blocks.
 Postulate :: { Declaration }
 Postulate : 'postulate' Declarations0 { Postulate (kwRange $1) $2 }
 
--- Primitives. Can only contain type signatures.
+-- Primitives.
+--
+-- Checked in nicifier:
+-- Can only contain type signatures, possibly in instance and private blocks.
 Primitive :: { Declaration }
-Primitive : 'primitive' ArgTypeSignaturesOrEmpty  {
-  let { setArg (Arg info (TypeSig _ tac x t)) = TypeSig info tac x t
-      ; setArg _ = __IMPOSSIBLE__ } in
-  Primitive (kwRange $1) (map setArg $2) }
+Primitive : 'primitive' Declarations0 { Primitive (kwRange $1) $2 }
 
 -- Unquoting declarations.
 UnquoteDecl :: { Declaration }

--- a/test/Fail/Issue1698-primitive.agda
+++ b/test/Fail/Issue1698-primitive.agda
@@ -3,3 +3,8 @@ primitive
 
 -- Bad error message WAS:
 -- A postulate block can only contain type signatures or instance blocks
+
+-- Better error (#1698): Parse error
+
+-- New error (PR #8000): [Syntax.WrongContentBlock]
+-- Unexpected declaration

--- a/test/Fail/Issue1698-primitive.err
+++ b/test/Fail/Issue1698-primitive.err
@@ -1,4 +1,2 @@
-Issue1698-primitive.agda:2.3: error: [ParseError]
-data<ERROR>  D : Set where
-
--- Bad error m...
+Issue1698-primitive.agda:2.3-21: error: [Syntax.WrongContentBlock]
+Unexpected declaration

--- a/test/Fail/Issue2456.agda
+++ b/test/Fail/Issue2456.agda
@@ -9,3 +9,9 @@ postulate
   instance Class t
 
 -- Should give error, but not internal error.
+
+-- Error (#2456): Unexpected declaration.
+
+-- Error (PR #8000): [Syntax.WrongContentBlock]
+-- A 'postulate' block can only contain type signatures, possibly
+-- under keywords 'instance' and 'private'

--- a/test/Fail/Issue2456.err
+++ b/test/Fail/Issue2456.err
@@ -1,2 +1,3 @@
 Issue2456.agda:9.12-19: error: [Syntax.WrongContentBlock]
-Unexpected declaration
+A 'postulate' block can only contain type signatures, possibly
+under keywords 'instance' and 'private'

--- a/test/Fail/Issue7998VariableInstance.agda
+++ b/test/Fail/Issue7998VariableInstance.agda
@@ -1,0 +1,13 @@
+-- Andreas, 2025-07-15, issue #7998.
+-- Instance blocks in variable blocks do not achieve anything,
+-- so the user should be alerted of this, at least with a warning.
+
+variable
+  instance
+    X : Set
+
+-- WAS: `instance` silently ignored.
+
+-- Expected error: [ParseError]
+-- instance<ERROR>
+--     X : Set

--- a/test/Fail/Issue7998VariableInstance.err
+++ b/test/Fail/Issue7998VariableInstance.err
@@ -1,0 +1,5 @@
+Issue7998VariableInstance.agda:6.3: error: [ParseError]
+instance<ERROR> 
+    X : Set
+
+-- WAS: 'instanc...

--- a/test/Fail/Issue7998VariableOverlap.agda
+++ b/test/Fail/Issue7998VariableOverlap.agda
@@ -1,0 +1,11 @@
+-- Andreas, 2025-07-15, issue #7998.
+-- `overlap` only makes sense for fields, so it should not be parsed
+-- (and silently dumped) in variable declarations.
+
+variable
+  overlap {{X}} : Set
+
+-- WAS: `overlap` silently ignored.
+
+-- Expected error: [ParseError]
+-- overlap<ERROR>  {{X}} : Set

--- a/test/Fail/Issue7998VariableOverlap.err
+++ b/test/Fail/Issue7998VariableOverlap.err
@@ -1,0 +1,4 @@
+Issue7998VariableOverlap.agda:6.3: error: [ParseError]
+overlap<ERROR>  {{X}} : Set
+
+-- WAS: 'overlap...

--- a/test/Fail/Issue7998VariableOverlapNoInstance.agda
+++ b/test/Fail/Issue7998VariableOverlapNoInstance.agda
@@ -1,0 +1,11 @@
+-- Andreas, 2025-07-15, issue #7998.
+-- Bad error for `overlap` in variable declarations.
+
+variable
+  overlap X : Set
+
+-- Was error: [ParseError]
+-- The 'overlap' keyword only applies to instance fields (fields marked with {{ }})
+
+-- Expected error: [ParseError]
+-- overlap<ERROR>  X : Set

--- a/test/Fail/Issue7998VariableOverlapNoInstance.err
+++ b/test/Fail/Issue7998VariableOverlapNoInstance.err
@@ -1,0 +1,4 @@
+Issue7998VariableOverlapNoInstance.agda:5.3: error: [ParseError]
+overlap<ERROR>  X : Set
+
+-- Was error: [Parse...

--- a/test/Fail/WrongPrimitiveModality.agda
+++ b/test/Fail/WrongPrimitiveModality.agda
@@ -10,10 +10,9 @@ postulate
 {-# BUILTIN STRING String #-}
 
 primitive
-  @0 ⦃ primShowNat ⦄ : Nat → String
+  @0 primShowNat : Nat → String
 
+-- error: [WrongArgInfoForPrimitive]
 -- Wrong definition properties for primitive primShowNat
---   Got:      instance, erased
---   Expected: visible, unrestricted
--- when checking that the type of the primitive function primShowNat
--- is Nat → String
+--   Got:      at modality erased
+--   Expected: at modality default

--- a/test/Fail/WrongPrimitiveModality.err
+++ b/test/Fail/WrongPrimitiveModality.err
@@ -1,6 +1,6 @@
-WrongPrimitiveModality.agda:13.8-36: error: [WrongArgInfoForPrimitive]
+WrongPrimitiveModality.agda:13.6-32: error: [WrongArgInfoForPrimitive]
 Wrong definition properties for primitive primShowNat
-  Got:      instance, at modality erased
-  Expected: visible, at modality default
+  Got:      at modality erased
+  Expected: at modality default
 when checking that the type of the primitive function primShowNat
 is Nat → String

--- a/test/Succeed/Issue2759.warn
+++ b/test/Succeed/Issue2759.warn
@@ -135,7 +135,7 @@ type signatures and data, record, and module declarations.
 Issue2759.agda:47.18-26: warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and axioms.
+type signatures and axioms (other than primitives).
 
 Issue2759.agda:47.27-32: warning: -W[no]EmptyMacro
 Empty macro block.
@@ -279,7 +279,7 @@ type signatures and data, record, and module declarations.
 Issue2759.agda:47.18-26: warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and axioms.
+type signatures and axioms (other than primitives).
 
 Issue2759.agda:47.27-32: warning: -W[no]EmptyMacro
 Empty macro block.

--- a/test/Succeed/Issue2759.warn
+++ b/test/Succeed/Issue2759.warn
@@ -130,7 +130,8 @@ function clauses.
 Issue2759.agda:47.10-17: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue2759.agda:47.18-26: warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
@@ -274,7 +275,8 @@ function clauses.
 Issue2759.agda:47.10-17: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue2759.agda:47.18-26: warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to

--- a/test/Succeed/Issue6945.warn
+++ b/test/Succeed/Issue6945.warn
@@ -1,7 +1,8 @@
 Issue6945.agda:14.7-14: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 when scope checking the declaration
   f x = y
     where
@@ -14,19 +15,22 @@ when scope checking the declaration
 Issue6945.agda:21.3-10: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 when scope checking the declaration
   module M where
 
 Issue6945.agda:33.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:36.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:38.3-27: warning: -W[no]EmptyPolarityPragma
 POLARITY pragma without polarities (ignored).
@@ -53,7 +57,8 @@ when scope checking the declaration
 Issue6945.agda:67.5-12: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 when scope checking
 let private
       x : Set _
@@ -63,39 +68,46 @@ in x
 Issue6945.agda:74.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:79.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:84.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:91.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:96.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:104.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 ———— All done; warnings encountered ————————————————————————
 
 Issue6945.agda:14.7-14: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 when scope checking the declaration
   f x = y
     where
@@ -108,19 +120,22 @@ when scope checking the declaration
 Issue6945.agda:21.3-10: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 when scope checking the declaration
   module M where
 
 Issue6945.agda:33.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:36.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:38.3-27: warning: -W[no]EmptyPolarityPragma
 POLARITY pragma without polarities (ignored).
@@ -147,7 +162,8 @@ when scope checking the declaration
 Issue6945.agda:67.5-12: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 when scope checking
 let private
       x : Set _
@@ -157,29 +173,35 @@ in x
 Issue6945.agda:74.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:79.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:84.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:91.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:96.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 Issue6945.agda:104.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations

--- a/test/Succeed/Issue6945.warn
+++ b/test/Succeed/Issue6945.warn
@@ -39,7 +39,7 @@ function clauses.
 Issue6945.agda:50.1-9: warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and axioms.
+type signatures and axioms (other than primitives).
 
 Issue6945.agda:54.1-6: warning: -W[no]UselessMacro
 Using a macro block here has no effect. 'macro' applies only to
@@ -133,7 +133,7 @@ function clauses.
 Issue6945.agda:50.1-9: warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and axioms.
+type signatures and axioms (other than primitives).
 
 Issue6945.agda:54.1-6: warning: -W[no]UselessMacro
 Using a macro block here has no effect. 'macro' applies only to

--- a/test/Succeed/PrimitiveInstance.agda
+++ b/test/Succeed/PrimitiveInstance.agda
@@ -39,3 +39,13 @@ private         -- UselessPrivate
 
 data _ where    -- EmptyConstructor
   instance      -- UselessInstance
+
+module M where
+  interleaved mutual
+    data D : Set
+    private         -- Expected UselessPrivate
+      data _ where
+        c : D
+
+d : M.D
+d = M.c

--- a/test/Succeed/PrimitiveInstance.agda
+++ b/test/Succeed/PrimitiveInstance.agda
@@ -1,8 +1,41 @@
 -- Andreas, 2025-07-14, issue #7998
 -- Instance keywords in primitive blocks should not be silently ignored.
 
+module _ where
+
 primitive
-  instance
+  instance -- UselessInstance
     primLockUniv : Set₁
 
--- Expected warning about useless "instance", but get none.
+-- Expect warning about useless "instance".
+
+open import Agda.Builtin.Nat
+
+postulate
+  private
+    Word64 : Set
+
+{-# BUILTIN WORD64 Word64 #-}
+
+-- Can have private block in primitive block.
+
+instance  -- UselessInstance
+  primitive
+    private
+      primWord64ToNat : Word64 → Nat
+
+-- Expect warning about useless "instance", though.
+
+primitive  -- EmptyPrimitive
+
+primitive  -- EmptyPrimitive
+  private  -- UselessPrivate
+
+postulate  -- EmptyPostulate
+  private  -- UselessPrivate
+
+private         -- UselessPrivate
+  data _ where  -- EmptyConstructor
+
+data _ where    -- EmptyConstructor
+  instance      -- UselessInstance

--- a/test/Succeed/PrimitiveInstance.warn
+++ b/test/Succeed/PrimitiveInstance.warn
@@ -1,0 +1,91 @@
+PrimitiveInstance.agda:7.3-11: warning: -W[no]UselessInstance
+Using instance here has no effect. Instance applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and axioms (other than primitives).
+
+PrimitiveInstance.agda:22.1-9: warning: -W[no]UselessInstance
+Using instance here has no effect. Instance applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and axioms (other than primitives).
+
+PrimitiveInstance.agda:29.1-10: warning: -W[no]EmptyPrimitive
+Empty primitive block.
+
+PrimitiveInstance.agda:31.1-10: warning: -W[no]EmptyPrimitive
+Empty primitive block.
+
+PrimitiveInstance.agda:32.3-10: warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+
+PrimitiveInstance.agda:34.1-10: warning: -W[no]EmptyPostulate
+Empty postulate block.
+
+PrimitiveInstance.agda:35.3-10: warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+
+PrimitiveInstance.agda:37.1-8: warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+
+PrimitiveInstance.agda:38.3-15: warning: -W[no]EmptyConstructor
+Empty constructor block.
+
+PrimitiveInstance.agda:40.1-13: warning: -W[no]EmptyConstructor
+Empty constructor block.
+
+PrimitiveInstance.agda:41.3-11: warning: -W[no]UselessInstance
+Using instance here has no effect. Instance applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and axioms (other than primitives).
+
+———— All done; warnings encountered ————————————————————————
+
+PrimitiveInstance.agda:7.3-11: warning: -W[no]UselessInstance
+Using instance here has no effect. Instance applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and axioms (other than primitives).
+
+PrimitiveInstance.agda:22.1-9: warning: -W[no]UselessInstance
+Using instance here has no effect. Instance applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and axioms (other than primitives).
+
+PrimitiveInstance.agda:29.1-10: warning: -W[no]EmptyPrimitive
+Empty primitive block.
+
+PrimitiveInstance.agda:31.1-10: warning: -W[no]EmptyPrimitive
+Empty primitive block.
+
+PrimitiveInstance.agda:32.3-10: warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+
+PrimitiveInstance.agda:34.1-10: warning: -W[no]EmptyPostulate
+Empty postulate block.
+
+PrimitiveInstance.agda:35.3-10: warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+
+PrimitiveInstance.agda:37.1-8: warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and data, record, and module declarations.
+
+PrimitiveInstance.agda:38.3-15: warning: -W[no]EmptyConstructor
+Empty constructor block.
+
+PrimitiveInstance.agda:40.1-13: warning: -W[no]EmptyConstructor
+Empty constructor block.
+
+PrimitiveInstance.agda:41.3-11: warning: -W[no]UselessInstance
+Using instance here has no effect. Instance applies only to
+declarations that introduce new identifiers into the module, like
+type signatures and axioms (other than primitives).

--- a/test/Succeed/PrimitiveInstance.warn
+++ b/test/Succeed/PrimitiveInstance.warn
@@ -17,7 +17,8 @@ Empty primitive block.
 PrimitiveInstance.agda:32.3-10: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 PrimitiveInstance.agda:34.1-10: warning: -W[no]EmptyPostulate
 Empty postulate block.
@@ -25,12 +26,14 @@ Empty postulate block.
 PrimitiveInstance.agda:35.3-10: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 PrimitiveInstance.agda:37.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 PrimitiveInstance.agda:38.3-15: warning: -W[no]EmptyConstructor
 Empty constructor block.
@@ -42,6 +45,14 @@ PrimitiveInstance.agda:41.3-11: warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and axioms (other than primitives).
+
+PrimitiveInstance.agda:46.5-12: warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures except for constructors, and data, record, and
+module declarations
+when scope checking the declaration
+  module M where
 
 ———— All done; warnings encountered ————————————————————————
 
@@ -64,7 +75,8 @@ Empty primitive block.
 PrimitiveInstance.agda:32.3-10: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 PrimitiveInstance.agda:34.1-10: warning: -W[no]EmptyPostulate
 Empty postulate block.
@@ -72,12 +84,14 @@ Empty postulate block.
 PrimitiveInstance.agda:35.3-10: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 PrimitiveInstance.agda:37.1-8: warning: -W[no]UselessPrivate
 Using private here has no effect. Private applies only to
 declarations that introduce new identifiers into the module, like
-type signatures and data, record, and module declarations.
+type signatures except for constructors, and data, record, and
+module declarations
 
 PrimitiveInstance.agda:38.3-15: warning: -W[no]EmptyConstructor
 Empty constructor block.
@@ -89,3 +103,11 @@ PrimitiveInstance.agda:41.3-11: warning: -W[no]UselessInstance
 Using instance here has no effect. Instance applies only to
 declarations that introduce new identifiers into the module, like
 type signatures and axioms (other than primitives).
+
+PrimitiveInstance.agda:46.5-12: warning: -W[no]UselessPrivate
+Using private here has no effect. Private applies only to
+declarations that introduce new identifiers into the module, like
+type signatures except for constructors, and data, record, and
+module declarations
+when scope checking the declaration
+  module M where


### PR DESCRIPTION
- Simplify parser and reorganize nicifier for `primitive` blocks. 
  _We know better now._
- Parse sane content of `variable` blocks (rather the same than for `field` blocks). 
  _This was technical debt from the start._

Closes #7998.  