### PR TITLE
Cosmetics: remove some unused matches/binds

### DIFF
--- a/src/full/Agda/Syntax/Builtin.hs
+++ b/src/full/Agda/Syntax/Builtin.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
 
 -- | This module defines the names of all builtin and primitives used in Agda.
 --

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -179,7 +179,8 @@ data Expr
   | Let Range (List1 Declaration) (Maybe Expr) -- ^ ex: @let Ds in e@, missing body when parsing do-notation let
   | Paren Range Expr                           -- ^ ex: @(e)@
   | IdiomBrackets Range [Expr]                 -- ^ ex: @(| e1 | e2 | .. | en |)@ or @(|)@
-  | DoBlock Range (List1 DoStmt)               -- ^ ex: @do x <- m1; m2@
+  | DoBlock KwRange (List1 DoStmt)             -- ^ ex: @do x <- m1; m2@
+                                               --   The 'KwRange' is for the @do@ keyword.
   | Absurd Range                               -- ^ ex: @()@ or @{}@, only in patterns
   | As Range Name Expr                         -- ^ ex: @x\@p@, only in patterns
   | Dot KwRange Expr                           -- ^ ex: @.p@, only in patterns
@@ -931,7 +932,7 @@ instance HasRange Expr where
       Let r _ _          -> r
       Paren r _          -> r
       IdiomBrackets r _  -> r
-      DoBlock r _        -> r
+      DoBlock r ds       -> getRange (r, ds)
       As r _ _           -> r
       Dot r e            -> getRange (r, e)
       DoubleDot r e      -> getRange (r, e)
@@ -1206,7 +1207,7 @@ instance KillRange Expr where
   killRange (Let _ d e)            = killRangeN (Let noRange) d e
   killRange (Paren _ e)            = killRangeN (Paren noRange) e
   killRange (IdiomBrackets _ es)   = killRangeN (IdiomBrackets noRange) es
-  killRange (DoBlock _ ss)         = killRangeN (DoBlock noRange) ss
+  killRange (DoBlock _ ss)         = killRangeN (DoBlock empty) ss
   killRange (Absurd _)             = Absurd noRange
   killRange (As _ n e)             = killRangeN (As noRange) n e
   killRange (Dot _ e)              = killRangeN (Dot empty) e

--- a/src/full/Agda/Syntax/DoNotation.hs
+++ b/src/full/Agda/Syntax/DoNotation.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
 
 {-|
     Desugaring for do-notation. Uses whatever `_>>=_` and `_>>_` happen to be
@@ -46,8 +47,8 @@ import Agda.Utils.Singleton
 
 import Agda.Utils.Impossible
 
-desugarDoNotation :: Range -> List1 DoStmt -> ScopeM Expr
-desugarDoNotation r ss = do
+desugarDoNotation :: List1 DoStmt -> ScopeM Expr
+desugarDoNotation ss = do
   let qBind = QName $ simpleBinaryOperator ">>="
       qThen = QName $ simpleBinaryOperator ">>"
       isBind DoBind{} = True

--- a/src/full/Agda/Syntax/Fixity.hs
+++ b/src/full/Agda/Syntax/Fixity.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
 {-# OPTIONS_GHC -Wunused-binds #-}
 
 {-| Definitions for fixity, precedence levels, and declared syntax.

--- a/src/full/Agda/Syntax/Fixity.hs
+++ b/src/full/Agda/Syntax/Fixity.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 {-| Definitions for fixity, precedence levels, and declared syntax.
 -}

--- a/src/full/Agda/Syntax/IdiomBrackets.hs
+++ b/src/full/Agda/Syntax/IdiomBrackets.hs
@@ -1,3 +1,6 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+
 module Agda.Syntax.IdiomBrackets (parseIdiomBracketsSeq) where
 
 import Control.Monad

--- a/src/full/Agda/Syntax/Info.hs
+++ b/src/full/Agda/Syntax/Info.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
 
 {-| An info object contains additional information about a piece of abstract
     syntax that isn't part of the actual syntax. For instance, it might contain
@@ -10,8 +12,6 @@ module Agda.Syntax.Info where
 import Prelude hiding (null)
 
 import Control.DeepSeq
-
-import Data.Semigroup (Semigroup)
 
 import GHC.Generics (Generic)
 
@@ -98,7 +98,7 @@ instance HasRange ExprInfo where
   getRange (ExprRange r) = r
 
 instance KillRange ExprInfo where
-  killRange (ExprRange r) = exprNoRange
+  killRange (ExprRange _) = exprNoRange
 
 {--------------------------------------------------------------------------
     Application information
@@ -174,7 +174,7 @@ instance HasRange LetInfo where
   getRange (LetRange r)   = r
 
 instance KillRange LetInfo where
-  killRange (LetRange r) = LetRange noRange
+  killRange (LetRange _) = LetRange noRange
 
 {--------------------------------------------------------------------------
     Definition information (declarations that actually define something)
@@ -281,7 +281,7 @@ instance HasRange LHSInfo where
   getRange (LHSInfo r _) = r
 
 instance KillRange LHSInfo where
-  killRange (LHSInfo r ell) = LHSInfo noRange ell
+  killRange (LHSInfo _ ell) = LHSInfo noRange ell
 
 instance Null LHSInfo where
   null i = null (lhsRange i) && null (lhsEllipsis i)
@@ -320,7 +320,7 @@ instance KillRange ConPatInfo where
   killRange (ConPatInfo b i l) = ConPatInfo b (killRange i) l
 
 instance SetRange ConPatInfo where
-  setRange r (ConPatInfo b i l) = ConPatInfo b (PatRange r) l
+  setRange r (ConPatInfo b _ l) = ConPatInfo b (PatRange r) l
 
 instance NFData ConPatInfo
 

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
 
 module Agda.Syntax.Internal
     ( module Agda.Syntax.Internal
@@ -13,10 +15,9 @@ import Prelude hiding (null)
 import Control.Monad.Identity
 import Control.DeepSeq
 
-import Data.Function (on)
 import qualified Data.List as List
 import Data.Maybe
-import Data.Semigroup ( Semigroup, (<>), Sum(..) )
+import Data.Semigroup ( Sum(..) )
 
 import GHC.Generics (Generic)
 
@@ -42,7 +43,6 @@ import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.Null
 import Agda.Utils.Size
-import Agda.Utils.Tuple
 
 import Agda.Utils.Impossible
 
@@ -957,7 +957,7 @@ propToType = \case
 
 -- | A traversal for the names in a telescope.
 mapAbsNamesM :: Applicative m => (ArgName -> m ArgName) -> Tele a -> m (Tele a)
-mapAbsNamesM f EmptyTel                  = pure EmptyTel
+mapAbsNamesM _ EmptyTel                  = pure EmptyTel
 mapAbsNamesM f (ExtendTel a (  Abs x b)) = ExtendTel a <$> (  Abs <$> f x <*> mapAbsNamesM f b)
 mapAbsNamesM f (ExtendTel a (NoAbs x b)) = ExtendTel a <$> (NoAbs <$> f x <*> mapAbsNamesM f b)
   -- Ulf, 2013-11-06: Last case is really impossible but I'd rather find out we
@@ -1347,7 +1347,7 @@ instance Pretty a => Pretty (Substitution' a) where
     where
     pr p rho = case rho of
       IdS                -> "idS"
-      EmptyS err         -> "emptyS"
+      EmptyS _err        -> "emptyS"
       t :# rho           -> mparens (p > 2) $
                             sep [ pr 2 rho <> ",", prettyPrec 3 t ]
       Strengthen _ n rho -> mparens (p > 9) $
@@ -1367,7 +1367,7 @@ instance Pretty Term where
             , nest 2 $ pretty (unAbs b) ]
       Lit l                -> pretty l
       Def q els            -> pretty q `pApp` els
-      Con c ci vs          -> pretty (conName c) `pApp` vs
+      Con c _ci vs         -> pretty (conName c) `pApp` vs
       Pi a (NoAbs _ b)     -> mparens (p > 0) $
         sep [ pretty (getModality a) <+> prettyPrec 1 (unDom a) <+> "->"
             , nest 2 $ pretty b ]
@@ -1477,7 +1477,7 @@ instance Pretty a => Pretty (Pattern' a) where
     where ps = map (fmap namedThing) nps
           lazy | conPLazy i = "~"
                | otherwise  = empty
-  prettyPrec n (DefP o q nps)= mparens (n > 0 && not (null nps)) $
+  prettyPrec n (DefP _o q nps)= mparens (n > 0 && not (null nps)) $
     pretty q <+> fsep (map (prettyPrec 10) ps)
     where ps = map (fmap namedThing) nps
   -- -- Version with printing record type:

--- a/src/full/Agda/Syntax/Literal.hs
+++ b/src/full/Agda/Syntax/Literal.hs
@@ -1,3 +1,6 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 module Agda.Syntax.Literal where
 
@@ -9,10 +12,9 @@ import Data.Text (Text)
 import qualified Data.Text as T
 
 import Agda.Syntax.Position
-import Agda.Syntax.Common
-import Agda.Syntax.Abstract.Name
-import Agda.Syntax.TopLevelModuleName.Boot (TopLevelModuleName')
-import Agda.Syntax.Position (Range)
+import Agda.Syntax.Common ( Ranged, MetaId )
+import Agda.Syntax.Abstract.Name ( QName )
+import Agda.Syntax.TopLevelModuleName.Boot ( TopLevelModuleName' )
 import Agda.Utils.Float ( doubleDenotEq, doubleDenotOrd )
 import Agda.Syntax.Common.Pretty
 

--- a/src/full/Agda/Syntax/Notation.hs
+++ b/src/full/Agda/Syntax/Notation.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
 {-# OPTIONS_GHC -Wunused-binds #-}
 
 {-| As a concrete name, a notation is a non-empty list of alternating 'IdPart's and holes.
@@ -223,7 +224,7 @@ mkNotation holes ids = do
                    _          -> False)
         where
         noAdj []       = __IMPOSSIBLE__
-        noAdj [x]      = True
+        noAdj [_]      = True
         noAdj (x:y:xs) =
           not (isAHole x && isAHole y) &&
           noAdj (y:xs)
@@ -297,7 +298,7 @@ syntaxOf y
     -- numbering the holes from left to right.
     -- Result will have no 'BindingHole's.
     mkSyn :: Int -> [NamePart] -> Notation
-    mkSyn n []          = []
+    mkSyn _ []          = []
     mkSyn n (Hole : xs) = HolePart noRange (defaultNamedArg $ unranged n) : mkSyn (1 + n) xs
     mkSyn n (Id x : xs) = IdPart (unranged x) : mkSyn n xs
 

--- a/src/full/Agda/Syntax/Notation.hs
+++ b/src/full/Agda/Syntax/Notation.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 {-| As a concrete name, a notation is a non-empty list of alternating 'IdPart's and holes.
     In contrast to concrete names, holes can be binders.

--- a/src/full/Agda/Syntax/Parser/Helpers.hs
+++ b/src/full/Agda/Syntax/Parser/Helpers.hs
@@ -1,5 +1,7 @@
 -- | Utility functions used in the Happy parser.
 
+{-# OPTIONS_GHC -Wunused-matches #-}
+
 module Agda.Syntax.Parser.Helpers where
 
 import Prelude hiding (null)
@@ -59,7 +61,7 @@ figureOutTopLevelModule ds =
     -- We need to distinguish two additional cases.
 
     -- Case 1: Regular file layout: imports followed by one module. Nothing to do.
-    (ds0, [ Module{} ]) -> ds
+    (_ds0, [ Module{} ]) -> ds
 
     -- Case 2: The declarations in the module are not indented.
     -- This is allowed for the top level module, and thus rectified here.
@@ -70,7 +72,7 @@ figureOutTopLevelModule ds =
     -- followed by non-indented declarations.  This should be a
     -- parse error and be reported later (see @toAbstract TopLevel{}@),
     -- thus, we do not do anything here.
-    (ds0, Module r _ m tel ds1 : ds2) -> ds  -- Gives parse error in scope checker.
+    (_ds0, Module{} : _) -> ds  -- Gives parse error in scope checker.
     -- OLD code causing issue 1388:
     -- (ds0, Module r m tel ds1 : ds2) -> ds0 ++ [Module r m tel $ ds1 ++ ds2]
 
@@ -235,7 +237,7 @@ recoverLayout xs@((i, _) : _) = go (iStart i) xs
   where
     c0 = posCol (iStart i)
 
-    go cur [] = ""
+    go _cur [] = ""
     go cur ((i, s) : xs) = padding cur (iStart i) ++ s ++ go (iEnd i) xs
 
     padding Pn{ posLine = l1, posCol = c1 } Pn{ posLine = l2, posCol = c2 }
@@ -389,7 +391,7 @@ boundNamesOrAbsurd es
 
 -- | Match a pattern-matching "assignment" statement @p <- e@
 exprToAssignment :: Expr -> Parser (Maybe (Pattern, Range, Expr))
-exprToAssignment e@(RawApp r es)
+exprToAssignment e@(RawApp _r es)
   | (es1, arr : es2) <- List2.break isLeftArrow es =
     case filter isLeftArrow es2 of
       arr : _ -> parseError' (rStart' $ getRange arr) $ "Unexpected " ++ prettyShow arr
@@ -456,7 +458,7 @@ defaultBuildDoStmt e []      = pure $ DoThen e
 
 buildDoStmt :: Expr -> [LamClause] -> Parser DoStmt
 buildDoStmt (Let r ds Nothing) [] = return $ DoLet r ds
-buildDoStmt e@(RawApp r _)    cs = do
+buildDoStmt e@(RawApp _ _)    cs = do
   mpatexpr <- exprToAssignment e
   case mpatexpr of
     Just (pat, r, expr) -> pure $ DoBind r pat expr cs
@@ -514,7 +516,7 @@ patternSynArgs = mapM \ x -> do
   case x of
 
     -- Invariant: fixity is not used here, and neither finiteness
-    Arg ai (Named mn (Binder mp _ (BName n fix mtac fin)))
+    Arg _ (Named _ (Binder _ _ (BName _ fix _ fin)))
       | not $ null fix -> __IMPOSSIBLE__
       | fin            -> __IMPOSSIBLE__
 
@@ -538,7 +540,7 @@ patternSynArgs = mapM \ x -> do
           ArgInfo _ _ _ _ (Annotation (IsLock _)) ->
             abort $ noAnn "Lock"
 
-          ArgInfo h (Modality r q c p) _ _ _
+          ArgInfo _ (Modality r q c p) _ _ _
             | not (isRelevant r) ->
                 abort "Arguments to pattern synonyms must be relevant"
             | not (isQuantityω q) ->

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -665,7 +665,7 @@ Expr2
     | ExtendedOrAbsurdLam          { $1 }
     | 'forall' ForallBindings Expr { forallPi $2 $3 }
     | 'let' Declarations LetBody   { Let (getRange ($1,$2,$3)) $2 $3 }
-    | 'do' vopen DoStmts close     { DoBlock (getRange ($1, $3)) $3 }
+    | 'do' vopen DoStmts close     { DoBlock (kwRange $1) $3 }
     | Expr3                        { $1 }
     | 'tactic' Application3        { Tactic (getRange ($1, $2)) (rawApp $2) }
 

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE UndecidableInstances #-} -- Due to KILLRANGE vararg typeclass
 
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+
 {-| Position information for syntax. Crucial for giving good error messages.
 -}
 
@@ -77,14 +80,12 @@ import Control.Monad.Writer (runWriter, tell)
 
 import qualified Data.Foldable as Fold
 import Data.Function (on)
-import Data.List (sort)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
-import Data.Semigroup (Semigroup(..))
 import Data.Void
 import Data.Word (Word32)
 
@@ -325,10 +326,10 @@ rangeModule = join . rangeModule'
 
 -- | Conflate a range to its right margin.
 rightMargin :: Range -> Range
-rightMargin r@NoRange      = r
-rightMargin r@(Range f is) = case Seq.viewr is of
+rightMargin r@NoRange    = r
+rightMargin (Range f is) = case Seq.viewr is of
   Seq.EmptyR -> __IMPOSSIBLE__
-  _ Seq.:> Interval () s e -> intervalToRange f (Interval () e e)
+  _ Seq.:> Interval () _s e -> intervalToRange f (Interval () e e)
 
 -- | Wrapper to indicate that range should be printed.
 newtype PrintRange a = PrintRange a
@@ -587,7 +588,7 @@ noRange = NoRange
 --   character in the next line. Any other character moves the
 --   position to the next column.
 movePos :: Position' a -> Char -> Position' a
-movePos (Pn f p l c) '\n' = Pn f (p + 1) (l + 1) 1
+movePos (Pn f p l _) '\n' = Pn f (p + 1) (l + 1) 1
 movePos (Pn f p l c) _    = Pn f (p + 1) l (c + 1)
 
 -- | Advance the position by a string.

--- a/src/full/Agda/Syntax/Reflected.hs
+++ b/src/full/Agda/Syntax/Reflected.hs
@@ -1,4 +1,6 @@
-{-# OPTIONS_GHC -fwarn-missing-signatures #-}
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 module Agda.Syntax.Reflected where
 
@@ -9,10 +11,9 @@ import Agda.Syntax.Literal
 import Agda.Syntax.Abstract.Name
 import Agda.Syntax.Internal (Dom)
 
-import Agda.Utils.List1 (List1, pattern (:|))
-import qualified Agda.Utils.List1 as List1
+import Agda.Utils.List1 (List1)
 
-type Args       = [Arg Term]
+type Args = [Arg Term]
 
 data Elim' a = Apply (Arg a) -- no record projections for now
   deriving (Show)

--- a/src/full/Agda/Syntax/TopLevelModuleName.hs
+++ b/src/full/Agda/Syntax/TopLevelModuleName.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
 
 ------------------------------------------------------------------------
 -- Top-level module names

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -989,8 +989,8 @@ instance ToAbstract C.Expr where
         toAbstractCtx TopCtx =<< parseIdiomBracketsSeq r es
 
   -- Do notation
-      C.DoBlock r ss ->
-        toAbstractCtx TopCtx =<< desugarDoNotation r ss
+      C.DoBlock _kwr ss ->
+        toAbstractCtx TopCtx =<< desugarDoNotation ss
 
   -- Post-fix projections
       e0@(C.Dot _kwr e) -> A.Dot (ExprRange $ getRange e0) <$> toAbstract e

--- a/src/full/Agda/Syntax/Treeless.hs
+++ b/src/full/Agda/Syntax/Treeless.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
 
 {-# LANGUAGE PatternSynonyms #-}
 
@@ -279,7 +280,7 @@ filterUsed = curry $ \case
   ([], args) -> args
   (_ , [])   -> []
   (ArgUsed   : used, a : args) -> a : filterUsed used args
-  (ArgUnused : used, a : args) ->     filterUsed used args
+  (ArgUnused : used, _ : args) ->     filterUsed used args
 
 -- NFData instances
 ---------------------------------------------------------------------------

--- a/src/full/Agda/Utils/Float.hs
+++ b/src/full/Agda/Utils/Float.hs
@@ -165,9 +165,10 @@ doubleACosh = acosh -- NOTE: doesn't cause underflow/overflow
 doubleATanh :: Double -> Double
 doubleATanh = atanh -- NOTE: doesn't cause underflow/overflow
 
-{-# INLINE negativeZero #-}
-negativeZero :: Double
-negativeZero = -0.0
+-- UNUSED:
+-- {-# INLINE negativeZero #-}
+-- negativeZero :: Double
+-- negativeZero = -0.0
 
 positiveInfinity :: Double
 positiveInfinity = 1.0 / 0.0
@@ -199,10 +200,11 @@ doubleFloor = fmap floor . asFinite
 doubleCeiling :: Double -> Maybe Integer
 doubleCeiling = fmap ceiling . asFinite
 
-normaliseNaN :: Double -> Double
-normaliseNaN x
-  | isNaN x   = nan
-  | otherwise = x
+-- UNUSED:
+-- normaliseNaN :: Double -> Double
+-- normaliseNaN x
+--   | isNaN x   = nan
+--   | otherwise = x
 
 doubleToWord64 :: Double -> Maybe Word64
 doubleToWord64 x

--- a/src/full/Agda/Utils/Graph/TopSort.hs
+++ b/src/full/Agda/Utils/Graph/TopSort.hs
@@ -9,13 +9,6 @@ import qualified Data.Set as Set
 import qualified Data.Map as Map
 import qualified Agda.Utils.Graph.AdjacencyMap.Unidirectional as G
 
--- NB:: Defined but not used
-mergeBy :: (a -> a -> Bool) -> [a] -> [a] -> [a]
-mergeBy _ [] xs = xs
-mergeBy _ xs [] = xs
-mergeBy f (x:xs) (y:ys)
-    | f x y = x: mergeBy f xs (y:ys)
-    | otherwise = y: mergeBy f (x:xs) ys
 
 -- | topoligical sort with smallest-numbered available vertex first
 -- | input: nodes, edges

--- a/src/full/Agda/Utils/Update.hs
+++ b/src/full/Agda/Utils/Update.hs
@@ -58,11 +58,6 @@ runChangeT :: Functor m => ChangeT m a -> m (a, Bool)
 runChangeT = fmap (mapSnd getAny) . runWriterT . fromChangeT
 {-# INLINE runChangeT #-}
 
--- | Run a 'ChangeT' computation, but ignore change flag.
-execChangeT :: Functor m => ChangeT m a -> m a -- A library function, so keep
-execChangeT = fmap fst . runChangeT
-{-# INLINE execChangeT #-}
-
 -- | Map a 'ChangeT' computation (monad transformer action).
 mapChangeT :: (m (a, Any) -> n (b, Any)) -> ChangeT m a -> ChangeT n b
 mapChangeT f (ChangeT m) = ChangeT (mapWriterT f m)
@@ -90,10 +85,6 @@ runUpdaterT f a = runChangeT $ f a
 type EndoFun a = a -> a
 type Change  a = ChangeT Identity a
 type Updater a = UpdaterT Identity a
-
--- NB:: Defined but not used
-fromChange :: Change a -> Writer Any a
-fromChange = fromChangeT
 
 -- | Run a 'Change' computation, returning result plus change flag.
 {-# INLINE runChange #-}


### PR DESCRIPTION
- **Refactor nicifier: removed unused Range arg from addDataConstructors**
  

- **Cosmetics nicifier: turn on -Wunused-matches**
  

- **Turn on -Wunused-matches in Syntax.Parser.Helpers**
  

- **Refactor: DoBlock now carries KwRange for 'do' keyword**
  

- **Turn on unused-imports/matches in Agda.Syntax.Literal**
  

- **Turn on unused-imports/matches in Agda.Syntax.Info**
  

- **Turn on unused-imports/matches in Agda.Syntax.Reflected**
  

- **Turn on -Wunused-matches in Syntax.Treeless**
  

- **Turn on unused-imports/matches in Agda.Syntax.Position**
  

- **Turn on unused-imports/matches in Agda.Syntax.Internal**
  

- **Turn on -Wunused-matches in Syntax.Common**
  

- **Turn on unused-imports/matches in Agda.Syntax.Notation**
  

- **Turn on unused-imports/matches in Agda.Syntax.Abstract**
  

- **Clean Agda.Utils: remove some unused definitions**
  