### PR TITLE
Re #7954: disallow postfix projections in parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Warnings
 Syntax
 ------
 
-Additions to the Agda syntax.
+Changes to the Agda syntax.
 
 * Records can now be created using module-like syntax in place of curly braces
   and semicolons.
@@ -56,6 +56,13 @@ Additions to the Agda syntax.
     split p k = let @0 (x , y) = q in k x y
       where
       @0 q = p
+  ```
+
+* Postfix projections cannot be surrounded by parentheses anymore.
+  E.g. these postfix projection applications are now illegal in expressions:
+  ```agda
+    r (.proj)
+    r .(proj)
   ```
 
 Language

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1445,7 +1445,10 @@ checkExpr' cmp e t =
           else
             internalError "DontCare may only appear in irrelevant contexts"
 
-        A.Dot{} -> typeError InvalidDottedExpression
+        -- Andreas, 2025-07-16, isse #7954.
+        -- 'A.Dot' can now only appear in the argument position of 'A.App',
+        -- where it is handled by 'appView'.
+        A.Dot{} -> __IMPOSSIBLE__ -- WAS: typeError InvalidDottedExpression
 
         -- Application
         _   | Application hd args <- appView e -> checkApplication cmp hd args e t

--- a/test/Fail/Issue2167.err
+++ b/test/Fail/Issue2167.err
@@ -1,3 +1,3 @@
 Issue2167.agda:4.8-12: error: [InvalidDottedExpression]
 Invalid dotted expression
-when checking that the expression .Set has type Set₁
+when scope checking .Set

--- a/test/Fail/Issue7954.agda
+++ b/test/Fail/Issue7954.agda
@@ -1,0 +1,16 @@
+-- Andreas, 2025-07-16, issue #7954.
+-- Do not allow parentheses around postfix projections.
+
+module _ where
+
+record R (A : Set) : Set where
+  field
+    proj : A
+open R
+
+example1 : {A : Set} → R A → A
+example1 r = r (.proj)
+
+-- Expected error: [InvalidDottedExpression]
+-- Invalid dotted expression
+-- when scope checking .proj

--- a/test/Fail/Issue7954.err
+++ b/test/Fail/Issue7954.err
@@ -1,0 +1,3 @@
+Issue7954.agda:12.17-22: error: [InvalidDottedExpression]
+Invalid dotted expression
+when scope checking .proj

--- a/test/Fail/Issue7954a.agda
+++ b/test/Fail/Issue7954a.agda
@@ -1,0 +1,16 @@
+-- Andreas, 2025-07-16, issue #7954.
+-- Do not allow parentheses around postfix projections.
+
+module _ where
+
+record R (A : Set) : Set where
+  field
+    proj : A
+open R
+
+example1 : {A : Set} → R A → A
+example1 r = r .(proj)
+
+-- Expected error: [InvalidDottedExpression]
+-- Invalid dotted expression
+-- when scope checking .(proj)

--- a/test/Fail/Issue7954a.err
+++ b/test/Fail/Issue7954a.err
@@ -1,0 +1,3 @@
+Issue7954a.agda:12.16-23: error: [InvalidDottedExpression]
+Invalid dotted expression
+when scope checking (proj)

--- a/test/Succeed/InvalidDisplayForm.agda
+++ b/test/Succeed/InvalidDisplayForm.agda
@@ -16,7 +16,7 @@ postulate
 {-# DISPLAY A1  = Set | Set          #-}
 {-# DISPLAY A2  = ?                  #-}
 {-# DISPLAY A3  = _                  #-}
-{-# DISPLAY A4  = .Set               #-}
+-- {-# DISPLAY A4  = .Set            #-} -- issue #7954: now hard error
 {-# DISPLAY A5  = λ x → x            #-}
 {-# DISPLAY A6  = λ()                #-}
 {-# DISPLAY A7  = λ{ x → x }         #-}

--- a/test/Succeed/InvalidDisplayForm.warn
+++ b/test/Succeed/InvalidDisplayForm.warn
@@ -22,11 +22,6 @@ Ignoring invalid display form for A3 because its right-hand side
 contains a metavariable
 when checking the pragma DISPLAY A3 = _
 
-InvalidDisplayForm.agda:19.1-41: warning: -W[no]InvalidDisplayForm
-Ignoring invalid display form for A4 because its right-hand side
-contains a dotted expression
-when checking the pragma DISPLAY A4 = .Set
-
 InvalidDisplayForm.agda:20.1-41: warning: -W[no]InvalidDisplayForm
 Ignoring invalid display form for A5 because its right-hand side
 contains a lambda
@@ -178,11 +173,6 @@ InvalidDisplayForm.agda:18.1-41: warning: -W[no]InvalidDisplayForm
 Ignoring invalid display form for A3 because its right-hand side
 contains a metavariable
 when checking the pragma DISPLAY A3 = _
-
-InvalidDisplayForm.agda:19.1-41: warning: -W[no]InvalidDisplayForm
-Ignoring invalid display form for A4 because its right-hand side
-contains a dotted expression
-when checking the pragma DISPLAY A4 = .Set
 
 InvalidDisplayForm.agda:20.1-41: warning: -W[no]InvalidDisplayForm
 Ignoring invalid display form for A5 because its right-hand side


### PR DESCRIPTION
The scope checker is now stricter on when letting `C.Dot` through to an `A.Dot`.
Error `InvalidDottedExpression` is now raised in the scope checker rather than in the type checker.

This addresses parts of issue #7954.
