### PR TITLE
Add unused-binds warning in Agda.Syntax.Concrete.*

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Attribute.hs
+++ b/src/full/Agda/Syntax/Concrete/Attribute.hs
@@ -1,3 +1,8 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
+
+{-# LANGUAGE CPP #-}
 
 -- | Attributes: concrete syntax for ArgInfo, esp. modalities.
 
@@ -8,7 +13,10 @@ import Prelude hiding (null)
 import Control.Arrow (second)
 import Control.Monad (foldM)
 
+#if !MIN_VERSION_base(4,20,0)
 import Data.List (foldl')
+#endif
+
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe
@@ -20,7 +28,6 @@ import Agda.Syntax.Concrete.Pretty () --instance only
 import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Position
 
-import Agda.Utils.List1 (List1, pattern (:|))
 import Agda.Utils.Null
 
 import Agda.Utils.Impossible
@@ -43,7 +50,7 @@ instance HasRange Attribute where
     CohesionAttribute c  -> getRange c
     PolarityAttribute p  -> getRange p
     TacticAttribute e    -> getRange e
-    LockAttribute l      -> NoRange
+    LockAttribute _l     -> NoRange
 
 instance SetRange Attribute where
   setRange r = \case
@@ -171,7 +178,7 @@ stringToAttribute = (`Map.lookup` attributesMap)
 
 exprToAttribute :: Range -> Expr -> Maybe Attribute
 exprToAttribute r = \case
-  e@(Paren _ (Tactic _ t)) -> Just $ TacticAttribute $ Ranged r t
+  Paren _ (Tactic _ t) -> Just $ TacticAttribute $ Ranged r t
   e -> setRange r $ stringToAttribute $ prettyShow e
 
 -- | Setting an attribute (in e.g. an 'Arg').  Overwrites previous value.
@@ -183,7 +190,7 @@ setAttribute = \case
   CohesionAttribute  c -> setCohesion  c
   PolarityAttribute  p -> setModalPolarity p
   LockAttribute      l -> setLock      l
-  TacticAttribute t    -> id
+  TacticAttribute _    -> id
 
 
 -- | Setting some attributes in left-to-right order.

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -34,7 +34,9 @@
 --     (ConcreteToAbstract), where we are in the TCM and can produce more
 --     informative error messages.
 
+{-# OPTIONS_GHC -Wunused-imports #-}
 {-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 module Agda.Syntax.Concrete.Definitions
     ( NiceDeclaration(..)
@@ -55,16 +57,12 @@ import Prelude hiding (null)
 
 import Control.Monad.Except  ( )
 import Control.Monad.Reader  ( asks )
-import Control.Monad.State   ( MonadState(..), gets, StateT, runStateT )
-import Control.Monad.Trans   ( lift )
+import Control.Monad.State   ( MonadState(..), gets, runStateT )
 
-import Data.Bifunctor
-import Data.Either (isLeft, isRight)
-import Data.Function (on)
+import Data.Either           ( isRight )
+import Data.Function         ( on )
 import qualified Data.Map as Map
-import Data.Map (Map)
 import Data.Maybe
-import Data.Semigroup ( Semigroup(..) )
 import qualified Data.List as List
 import qualified Data.Foldable as Fold
 import qualified Data.Traversable as Trav
@@ -72,19 +70,15 @@ import qualified Data.Traversable as Trav
 import Agda.Syntax.Concrete
 import Agda.Syntax.Concrete.Pattern
 import Agda.Syntax.Common hiding (TerminationCheck())
-import qualified Agda.Syntax.Common as Common
 import Agda.Syntax.Position
 import Agda.Syntax.Notation
-import Agda.Syntax.Concrete.Pretty () --instance only
 import Agda.Syntax.Concrete.Fixity
-import Agda.Syntax.Common.Pretty
-
 import Agda.Syntax.Concrete.Definitions.Errors
 import Agda.Syntax.Concrete.Definitions.Monad
 import Agda.Syntax.Concrete.Definitions.Types
 
 import Agda.Utils.AffineHole
-import Agda.Utils.CallStack ( CallStack, HasCallStack, withCallerCallStack )
+import Agda.Utils.CallStack ( HasCallStack, withCallerCallStack )
 import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List (spanJust)

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -1,3 +1,7 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
+
 module Agda.Syntax.Concrete.Definitions.Errors where
 
 import Control.DeepSeq
@@ -14,8 +18,8 @@ import Agda.Interaction.Options.Warnings
 
 import Agda.Utils.Null ( empty )
 import Agda.Utils.CallStack ( CallStack )
-import Agda.Utils.List1 (List1, pattern (:|))
-import Agda.Utils.List2 (List2, pattern List2)
+import Agda.Utils.List1 (List1)
+import Agda.Utils.List2 (List2)
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Set1 (Set1)
 import qualified Agda.Utils.Set1 as Set1
@@ -328,9 +332,9 @@ instance HasRange DeclarationException' where
   getRange (MultipleEllipses d)                 = getRange d
   getRange (DuplicateDefinition x)              = getRange x
   getRange (DuplicateAnonDeclaration r)         = r
-  getRange (MissingWithClauses x lhs)           = getRange lhs
-  getRange (WrongDefinition x k k')             = getRange x
-  getRange (AmbiguousFunClauses lhs xs)         = getRange lhs
+  getRange (MissingWithClauses _x lhs)          = getRange lhs
+  getRange (WrongDefinition x _k _k')           = getRange x
+  getRange (AmbiguousFunClauses lhs _xs)        = getRange lhs
   getRange (AmbiguousConstructor r _ _)         = r
   getRange (WrongContentBlock _ r)              = r
   getRange (InvalidMeasureMutual r)             = r
@@ -367,7 +371,7 @@ instance HasRange DeclarationWarning' where
     InvalidTacticAttribute r           -> r
     MissingDataDeclaration x           -> getRange x
     MissingDefinitions xs              -> getRange xs
-    NotAllowedInMutual r x             -> r
+    NotAllowedInMutual r _x            -> r
     OpenImportAbstract r _kwr _        -> getRange r
     OpenImportPrivate  _r kwr _kwr _   -> getRange kwr
     PolarityPragmasButNotPostulates xs -> getRange xs
@@ -399,7 +403,7 @@ instance Pretty DeclarationException' where
     pwords "Duplicate definition of" ++ [pretty x]
   pretty (DuplicateAnonDeclaration _) = fsep $
     pwords "Duplicate declaration of _"
-  pretty (MissingWithClauses x lhs) = fsep $
+  pretty (MissingWithClauses x _lhs) = fsep $
     pwords "Missing with-clauses for function" ++ [pretty x]
 
   pretty (WrongDefinition x k k') = fsep $ pretty x :
@@ -477,7 +481,7 @@ instance Pretty DeclarationWarning' where
      pwords "The following names are declared but not accompanied by a definition:"
      ++ punctuate comma (fmap (pretty . fst) xs)
 
-    NotAllowedInMutual r nd -> fsep $
+    NotAllowedInMutual _r nd -> fsep $
       text nd : pwords "in mutual blocks are not supported.  Suggestion: get rid of the mutual block by manually ordering declarations"
 
     PolarityPragmasButNotPostulates xs -> fsep $

--- a/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Monad.hs
@@ -1,4 +1,6 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 module Agda.Syntax.Concrete.Definitions.Monad where
 

--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -1,3 +1,7 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
+
 module Agda.Syntax.Concrete.Definitions.Types where
 
 import Control.DeepSeq
@@ -187,13 +191,13 @@ isInterleavedData _ = Nothing
 
 interleavedDecl :: Name -> InterleavedDecl -> [(DeclNum, NiceDeclaration)]
 interleavedDecl k = \case
-  InterleavedData i d@(NiceDataSig _ _ acc abs pc uc _ pars _) ds ->
+  InterleavedData i d@(NiceDataSig _ _ _acc abs pc uc _ pars _) ds ->
     let fpars   = concatMap dropTypeAndModality pars
         r       = getRange (k, fpars)
         ddef cs = NiceDataDef (getRange (r, cs)) UserWritten
                     abs pc uc k fpars cs
     in (i,d) : maybe [] (\ (j, dss) -> [(j, ddef (sconcat (List1.reverse dss)))]) ds
-  InterleavedFun i d@(FunSig r acc abs inst mac info tc cc n e) dcs ->
+  InterleavedFun i d@(FunSig r _acc abs inst _mac _info tc cc n _e) dcs ->
     let fdef dcss = let (dss, css) = List1.unzip dcss in
                     FunDef r (sconcat dss) abs inst tc cc n (sconcat css)
     in (i,d) : maybe [] (\ (j, dcss) -> [(j, fdef (List1.reverse dcss))]) dcs
@@ -257,9 +261,9 @@ instance Pretty NiceDeclaration where
     NiceRecDef _ _ _ _ _ x  _ _ _  -> text "record" <+> pretty x <+> text "where"
     NicePatternSyn _ _ x _ _       -> text "pattern" <+> pretty x
     NiceGeneralize _ _ _ _ x _     -> text "variable" <+> pretty x
-    NiceUnquoteDecl _ _ _ _ _ _ xs _ -> text "<unquote declarations>"
-    NiceUnquoteDef _ _ _ _ _ xs _    -> text "<unquote definitions>"
-    NiceUnquoteData _ _ _ _ _ x xs _ -> text "<unquote data types>"
+    NiceUnquoteDecl _ _ _ _ _ _ _xs _  -> text "<unquote declarations>"
+    NiceUnquoteDef _ _ _ _ _ _xs _     -> text "<unquote definitions>"
+    NiceUnquoteData _ _ _ _ _ _x _xs _ -> text "<unquote data types>"
 
 declName :: NiceDeclaration -> String
 declName Axiom{}             = "Postulates"

--- a/src/full/Agda/Syntax/Concrete/Fixity.hs
+++ b/src/full/Agda/Syntax/Concrete/Fixity.hs
@@ -1,4 +1,6 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 -- | Collecting fixity declarations (and polarity pragmas) for concrete
 --   declarations.
@@ -58,7 +60,7 @@ plusFixities m1 m2
     | otherwise        = return $ Map.unionWithKey mergeFixites m1 m2
   where
     --  Merge two fixities, assuming there is no conflict
-    mergeFixites name (Fixity' f1 s1 r1) (Fixity' f2 s2 r2) = Fixity' f s $ fuseRange r1 r2
+    mergeFixites _name (Fixity' f1 s1 r1) (Fixity' f2 s2 r2) = Fixity' f s $ fuseRange r1 r2
               where f | null f1 = f2
                       | null f2 = f1
                       | otherwise = __IMPOSSIBLE__
@@ -228,7 +230,7 @@ declaredNames = \case
   DataDef _ _ _ cs      -> foldMap declaredNames cs
   Data _ _ x _ _ cs     -> declaresName x <> foldMap declaredNames cs
   RecordSig _ _ x _ _   -> declaresName x
-  RecordDef _ x ds _ _  -> declaresNames $     maybeToList (recDirConstructor ds)
+  RecordDef _ _x ds _ _ -> declaresNames $     maybeToList (recDirConstructor ds)
   Record _ _ x ds _ _ _ -> declaresNames $ x : maybeToList (recDirConstructor ds)
   Infix _ _             -> mempty
   Syntax _ _            -> mempty

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -1,4 +1,6 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 -- | Generic traversal and reduce for concrete syntax,
 --   in the style of "Agda.Syntax.Internal.Generic".
@@ -168,7 +170,7 @@ instance ExprLike FieldAssignment where
 instance ExprLike ModuleAssignment where
   mapExpr      f (ModuleAssignment m es i) = ModuleAssignment m (mapExpr f es) i
   traverseExpr f (ModuleAssignment m es i) = (\es' -> ModuleAssignment m es' i) <$> traverseExpr f es
-  foldExpr     f (ModuleAssignment m es i) = foldExpr f es
+  foldExpr     f (ModuleAssignment _ es _) = foldExpr f es
 
 instance ExprLike a => ExprLike (OpApp a) where
   mapExpr f = \case

--- a/src/full/Agda/Syntax/Concrete/Glyph.hs
+++ b/src/full/Agda/Syntax/Concrete/Glyph.hs
@@ -1,4 +1,6 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds   #-}
 
 {-| Choice of Unicode or ASCII glyphs.
 -}

--- a/src/full/Agda/Syntax/Concrete/Name.hs
+++ b/src/full/Agda/Syntax/Concrete/Name.hs
@@ -1,3 +1,7 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds   #-}
+
 {-| Names in the concrete syntax are just strings (or lists of strings for
     qualified names).
 -}

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -1,4 +1,6 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 {-# LANGUAGE DataKinds #-}
 
@@ -472,9 +474,9 @@ buildParsers kind top exprNames0 = do
                   <*> choiceIn ops
                   <*> higher
 
-            or p1 []   p2 []   = Nothing
-            or p1 []   p2 ops2 = Just (p2 ops2)
-            or p1 ops1 p2 []   = Just (p1 ops1)
+            or _  []   _  []   = Nothing
+            or _  []   p2 ops2 = Just (p2 ops2)
+            or p1 ops1 _  []   = Just (p1 ops1)
             or p1 ops1 p2 ops2 = Just (p1 ops1 <|> p2 ops2)
 
             preRight :: Maybe (Parser e (MaybePlaceholder e -> e))
@@ -535,7 +537,7 @@ parsePat parse = loop
     InstanceP _ _    -> fail "bad instance argument"
     AsP r x p        -> AsP r x <$> loop p
     p@DotP{}         -> return p
-    ParenP r p       -> fullParen' <$> loop p
+    ParenP _r p      -> fullParen' <$> loop p
     p@WildP{}        -> return p
     p@AbsurdP{}      -> return p
     p@LitP{}         -> return p
@@ -741,7 +743,7 @@ parseLHS ::
 parseLHS displayLhs top p = billToParser IsPattern $ do
   (res, ops) <- parseLHS' displayLhs IsLHS (Just top) p
   case res of
-    ParseLHS f lhs -> return lhs
+    ParseLHS _f lhs -> return lhs
     _ -> typeError $ OperatorInformation ops
                    $ NoParseForLHS IsLHS [] p
 

--- a/src/full/Agda/Syntax/Concrete/Operators/Parser.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators/Parser.hs
@@ -1,4 +1,6 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 {-# LANGUAGE DataKinds    #-}
 
@@ -77,7 +79,7 @@ instance IsExpr Expr where
     exprView = \case
         Ident x         -> LocalV x
         App _ e1 e2     -> AppV e1 e2
-        OpApp r d ns es -> OpAppV d ns es
+        OpApp _ d ns es -> OpAppV d ns es
         HiddenArg _ e   -> HiddenArgV e
         InstanceArg _ e -> InstanceArgV e
         Paren _ e       -> ParenV e
@@ -102,7 +104,7 @@ instance IsExpr Pattern where
         IdentP True x    -> LocalV x
         IdentP False _   -> __IMPOSSIBLE__
         AppP e1 e2       -> AppV e1 e2
-        OpAppP r d ns es -> OpAppV d ns $ (fmap . fmap . fmap) (noPlaceholder . Ordinary) es
+        OpAppP _ d ns es -> OpAppV d ns $ (fmap . fmap . fmap) (noPlaceholder . Ordinary) es
         HiddenP _ e      -> HiddenArgV e
         InstanceP _ e    -> InstanceArgV e
         ParenP _ e       -> ParenV e
@@ -298,7 +300,7 @@ opP parseSections p (NewNotation q names _ syn isOp) kind =
     [Name] -> Notation ->
     Parser e (Range, [Either (MaybePlaceholder e, NamedArg (Ranged Int))
                              (LamBinding, Ranged BoundVariablePosition)])
-  worker ms []              = pure (noRange, [])
+  worker _  []              = pure (noRange, [])
   worker ms (IdPart x : xs) =
     (\r1 (r2, es) -> (fuseRanges r1 r2, es))
       <$> partP ms (rangedThing x)

--- a/src/full/Agda/Syntax/Concrete/Operators/Parser/Monad.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators/Parser/Monad.hs
@@ -1,4 +1,6 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 ------------------------------------------------------------------------
 -- | The parser monad used by the operator parser

--- a/src/full/Agda/Syntax/Concrete/Pattern.hs
+++ b/src/full/Agda/Syntax/Concrete/Pattern.hs
@@ -354,11 +354,12 @@ hasEllipsis' = traverseCPatternA $ \ p mp ->
     EllipsisP _ Nothing -> OneHole id p
     _                   -> mp
 
+-- | Reconstruct the ellipsis, used in printing (AbstractToConcrete).
 reintroduceEllipsis :: ExpandedEllipsis -> Pattern -> Pattern
 reintroduceEllipsis (ExpandedEllipsis r k) p | hasWithPatterns p =
   let (args, wargs) = splitEllipsis k $ List1.toList $ patternAppView p
       (hd,args') = fromMaybe __IMPOSSIBLE__ $ uncons args
-      core = foldl AppP (namedArg hd) args
+      core = foldl AppP (namedArg hd) args'
   in foldl AppP (EllipsisP r $ Just $ core) wargs
 reintroduceEllipsis _ p = p
 

--- a/src/full/Agda/Syntax/Concrete/Pattern.hs
+++ b/src/full/Agda/Syntax/Concrete/Pattern.hs
@@ -1,3 +1,6 @@
+-- {-# OPTIONS_GHC -Wunused-imports #-}  -- no, because of liftA2
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
 
 -- | Tools for patterns in concrete syntax.
 
@@ -309,7 +312,7 @@ patternQNames p = foldCPattern f p `appEndo` []
   f = \case
     IdentP _ x     -> Endo (x :)
     OpAppP _ x _ _ -> Endo (x :)
-    AsP _ x _      -> mempty  -- x must be a bound name, can't be a constructor!
+    AsP _ _x _     -> mempty  -- _x must be a bound name, can't be a constructor!
     AppP _ _       -> mempty
     WithP _ _      -> mempty
     RawAppP _ _    -> mempty
@@ -364,7 +367,7 @@ reintroduceEllipsis (ExpandedEllipsis r k) p | hasWithPatterns p =
 reintroduceEllipsis _ p = p
 
 splitEllipsis :: (IsWithP p) => Int -> [p] -> ([p],[p])
-splitEllipsis k [] = ([] , [])
+splitEllipsis _ [] = ([] , [])
 splitEllipsis k (p:ps)
   | isJust (isWithP p) = if
       | k == 0    -> ([] , p:ps)

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -1,4 +1,8 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 {-| Pretty printer for the concrete syntax.
 -}
@@ -13,16 +17,14 @@ import Data.Maybe
 import qualified Data.Foldable  as Fold
 import qualified Data.Semigroup as Semigroup
 import qualified Data.Strict.Maybe as Strict
-import qualified Data.Text as T
 
 import Agda.Syntax.Common
 import Agda.Syntax.Concrete
 import Agda.Syntax.Concrete.Glyph
 
-import Agda.Utils.Float (toStringWithoutDotZero)
 import Agda.Utils.Function
 import Agda.Utils.Functor
-import Agda.Utils.List1 ( List1, pattern (:|), (<|) )
+import Agda.Utils.List1 ( List1, (<|) )
 import qualified Agda.Utils.List1 as List1
 import qualified Agda.Utils.List2 as List2
 import Agda.Utils.Maybe
@@ -352,7 +354,7 @@ instance Pretty LHSCore where
       sep $ parens doc : map (parens . pretty) ps
     where
     doc = sep $ pretty h <$ fmap (("|" <+>) . pretty) wps
-  pretty (LHSEllipsis r p) = "..."
+  pretty (LHSEllipsis _ _) = "..."
 
 instance Pretty ModuleApplication where
   pretty (SectionApp _ bs x es) = fsep $ concat
@@ -442,7 +444,7 @@ instance Pretty Declaration where
       pRecord defaultErased x dir tel Nothing cs
     Infix f xs  ->
       pretty f <+> fsep (punctuate comma $ fmap pretty xs)
-    Syntax n xs -> "syntax" <+> pretty n <+> "..."
+    Syntax n _xs -> "syntax" <+> pretty n <+> "..."
     PatternSyn _ n as p -> "pattern" <+> pretty n <+> fsep (map pretty as)
                              <+> "=" <+> pretty p
     Mutual _ ds     -> namedBlock "mutual" ds
@@ -474,7 +476,7 @@ instance Pretty Declaration where
             prettyErased erased (pretty x) <+> fsep (map pretty tel)
           , nest 2 $ fsep $ concat [ [ "=", pretty y ], map pretty es, [ pretty i ] ]
           ]
-    ModuleMacro _ erased x (RecordModuleInstance _ rec) open i ->
+    ModuleMacro _ erased x (RecordModuleInstance _ rec) open _i ->
       sep [ pretty open <+> "module" <+> prettyErased erased (pretty x)
           , nest 2 $ "=" <+> pretty rec <+> "{{...}}"
           ]
@@ -622,7 +624,7 @@ instance Pretty Pattern where
             QuoteP _        -> "quote"
             RecP _ _ fs     -> sep [ "record", bracesAndSemicolons (map pretty fs) ]
             EqualP _ es     -> sep $ for es \ (e1, e2) -> parens $ sep [pretty e1, "=", pretty e2]
-            EllipsisP _ mp  -> "..."
+            EllipsisP _ _   -> "..."
             WithP _ p       -> "|" <+> pretty p
 
 prettyOpApp :: forall a .


### PR DESCRIPTION
- **Fix a potential bug in reintroduceEllipsis**
  The code introduced in 86b3223 seems to store the wrong term in the
  ellipsis.  However, as `reintroduceEllipsis` is only used in the
  printer, it does not really matter what is stored in the ellipsis,
  so this bug did not surface.
  
  https://github.com/agda/agda/commit/86b3223c477ca9f640eacddab2696bfd7c387b50#r162207740
  
  This problem was found with -Wunused-binds.
  

- **Cosmetics: Agda.Syntax.Concrete.*: use -Wunused-matches/binds**
  