### PR TITLE
flake: fix overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ module-dependency-graph.dot
 module-dependency-graph.pdf
 pkg-build*
 result
+result-*
 stack*.yaml.lock
 stack.yaml
 TAGS

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
       # Recommended build
       agda-pkg = hlib.overrideCabal (_: {
           # These settings are documented at
-          # https://ryantm.github.io/nixpkgs/languages-frameworks/haskell/#haskell-mkderivation
+          # https://nixos.org/manual/nixpkgs/unstable/#haskell-mkderivation
 
           # Don't run the test suite every build
           # (which is slow, and currently broken in nix)
@@ -49,6 +49,10 @@
           doCoverage                = false;  # Saved   2 seconds
           enableExecutableProfiling = false;  # Saved   1 seconds
           enableStaticLibraries     = false;  # Saved  -1 seconds
+
+          # Place the binaries in a separate output with a much smaller closure size.
+          enableSeparateBinOutput = true;
+          mainProgram = "agda";
         }) agda-pkg-minimal;
 
       # An even faster Agda build, achieved by asking GHC to optimize less
@@ -95,16 +99,17 @@
       packages.type-check = agda-pkg-tc;     # Entry point for `nix build .#type-check`
       devShells.default   = agda-dev-shell;  # Entry point for `nix develop`
 
-      # Allow power users to set this flake's agda
-      # as a drop-in replacement for nixpkgs's agda
+      # Allow users to set this flake's agda as a drop-in replacement for nixpkgs's agda
       # (including as a dependency of other nixpkgs packages)
       # See https://flake.parts/overlays for more info
-      overlayAttrs.packages.haskellPackages.agda = agda-pkg;
-      # TODO: also replace each haskell.packages.ghcXXX.agda
+      overlayAttrs.haskell = pkgs.haskell // {
+        packageOverrides = pkgs.lib.composeExtensions pkgs.haskell.packageOverrides
+          (hfinal: hprev: {
+            Agda = agda-pkg;
+          });
+      };
     };
-    # Generate the overlays.default output from overlayAttrs above
-    # N.B. This overlay is EXPERIMENTAL and untested.
-    # Please report bugs to the Agda issue tracker.
+
     imports = [ inputs.flake-parts.flakeModules.easyOverlay ];
   };
 }


### PR DESCRIPTION
Fixes https://github.com/agda/agda/issues/7755.

The current overlay is broken in four ways:
- [`overlayAttrs`](https://flake.parts/options/flake-parts-easyoverlay#opt-perSystem.overlayAttrs) does not expect a `packages` attribute, so we are not actually overriding anything, just adding `pkgs.packages.haskellPackages.agda`.
- Overlay updates are not recursive, so setting `haskellPackages.agda` nukes everything in `haskellPackages` and leaves just `agda` in there (of course breaking everything).
- The attribute for the Agda package is `Agda`, not `agda` (same as in Hackage).
- The Agda wrapper in nixpkgs expects the binaries to live in a separate `bin` output. This is a bug that is [now fixed](https://github.com/NixOS/nixpkgs/pull/425820), but we might as well `enableSeparateBinOutput` here as well. I've done that now, as well as set the `mainProgram` attribute so that `lib.getExe agda` does the right thing.

I guess the comment did say it was untested! This should fix everything, ~~including non-default GHC versions~~ (further fix for that in https://github.com/agda/agda/pull/8036). Tested on the [cubical](https://github.com/agda/cubical/blob/master/flake.nix) flake, which uses the overlay (or at least thinks it does).