### PR TITLE
New option --print-options and --bash-complete

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -599,6 +599,8 @@ library
       Agda.Interaction.MakeCase
       Agda.Interaction.Monad
       Agda.Interaction.Options
+      Agda.Interaction.Options.Arguments
+      Agda.Interaction.Options.BashCompletion
       Agda.Interaction.Options.Errors
       Agda.Interaction.Options.Help
       Agda.Interaction.Options.Lenses

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -605,6 +605,7 @@ library
       Agda.Interaction.Options.Errors
       Agda.Interaction.Options.Help
       Agda.Interaction.Options.Lenses
+      Agda.Interaction.Options.ProfileOptions
       Agda.Interaction.Options.Warnings
       Agda.Main
       Agda.Mimer.Mimer
@@ -890,7 +891,6 @@ library
       Agda.Utils.PartialOrd
       Agda.Utils.Permutation
       Agda.Utils.POMonoid
-      Agda.Utils.ProfileOptions
       Agda.Utils.RangeMap
       Agda.Utils.SemiRing
       Agda.Utils.Semigroup

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -526,6 +526,7 @@ library
     , happy:happy >= 1.20.1.1
 
   exposed-modules:
+    -- Keep in alphabetical order, please!
       Agda.Benchmarking
       Agda.Compiler.Backend
       Agda.Compiler.Backend.Base
@@ -533,9 +534,9 @@ library
       Agda.Compiler.CallCompiler
       Agda.Compiler.Common
       Agda.Compiler.JS.Compiler
-      Agda.Compiler.JS.Syntax
-      Agda.Compiler.JS.Substitution
       Agda.Compiler.JS.Pretty
+      Agda.Compiler.JS.Substitution
+      Agda.Compiler.JS.Syntax
       Agda.Compiler.MAlonzo.Coerce
       Agda.Compiler.MAlonzo.Compiler
       Agda.Compiler.MAlonzo.Encode
@@ -566,13 +567,10 @@ library
       Agda.Interaction.BasicOps
       Agda.Interaction.BuildLibrary
       Agda.Interaction.Command
-      Agda.Interaction.SearchAbout
       Agda.Interaction.CommandLine
       Agda.Interaction.EmacsCommand
       Agda.Interaction.EmacsTop
       Agda.Interaction.ExitCode
-      Agda.Interaction.JSONTop
-      Agda.Interaction.JSON
       Agda.Interaction.FindFile
       Agda.Interaction.Highlighting.Common
       Agda.Interaction.Highlighting.Dot
@@ -585,49 +583,53 @@ library
       Agda.Interaction.Highlighting.HTML.Backend
       Agda.Interaction.Highlighting.HTML.Base
       Agda.Interaction.Highlighting.JSON
-      Agda.Interaction.Highlighting.Precise
-      Agda.Interaction.Highlighting.Range
-      Agda.Interaction.Highlighting.Vim
       Agda.Interaction.Highlighting.LaTeX
       Agda.Interaction.Highlighting.LaTeX.Backend
       Agda.Interaction.Highlighting.LaTeX.Base
+      Agda.Interaction.Highlighting.Precise
+      Agda.Interaction.Highlighting.Range
+      Agda.Interaction.Highlighting.Vim
       Agda.Interaction.Imports
       Agda.Interaction.InteractionTop
-      Agda.Interaction.Output
-      Agda.Interaction.Response
-      Agda.Interaction.Response.Base
-      Agda.Interaction.MakeCase
-      Agda.Interaction.Monad
+      Agda.Interaction.JSON
+      Agda.Interaction.JSONTop
       Agda.Interaction.Library
       Agda.Interaction.Library.Base
       Agda.Interaction.Library.Parse
+      Agda.Interaction.MakeCase
+      Agda.Interaction.Monad
       Agda.Interaction.Options
       Agda.Interaction.Options.Errors
       Agda.Interaction.Options.Help
       Agda.Interaction.Options.Lenses
       Agda.Interaction.Options.ProfileOptions
       Agda.Interaction.Options.Warnings
+      Agda.Interaction.Output
+      Agda.Interaction.Response
+      Agda.Interaction.Response.Base
+      Agda.Interaction.SearchAbout
       Agda.Main
       Agda.Mimer.Mimer
+      Agda.Mimer.Monad
       Agda.Mimer.Options
       Agda.Mimer.Types
-      Agda.Mimer.Monad
       Agda.Setup
       Agda.Setup.DataFiles
       Agda.Setup.EmacsMode
+      Agda.Syntax.Abstract
       Agda.Syntax.Abstract.Name
       Agda.Syntax.Abstract.Pattern
       Agda.Syntax.Abstract.PatternSynonyms
       Agda.Syntax.Abstract.Pretty
       Agda.Syntax.Abstract.UsedNames
       Agda.Syntax.Abstract.Views
-      Agda.Syntax.Abstract
       Agda.Syntax.Builtin
       Agda.Syntax.Common
       Agda.Syntax.Common.Aspect
       Agda.Syntax.Common.KeywordRange
       Agda.Syntax.Common.Pretty
       Agda.Syntax.Common.Pretty.ANSI
+      Agda.Syntax.Concrete
       Agda.Syntax.Concrete.Attribute
       Agda.Syntax.Concrete.Definitions
       Agda.Syntax.Concrete.Definitions.Errors
@@ -637,12 +639,11 @@ library
       Agda.Syntax.Concrete.Generic
       Agda.Syntax.Concrete.Glyph
       Agda.Syntax.Concrete.Name
+      Agda.Syntax.Concrete.Operators
       Agda.Syntax.Concrete.Operators.Parser
       Agda.Syntax.Concrete.Operators.Parser.Monad
-      Agda.Syntax.Concrete.Operators
       Agda.Syntax.Concrete.Pattern
       Agda.Syntax.Concrete.Pretty
-      Agda.Syntax.Concrete
       Agda.Syntax.DoNotation
       Agda.Syntax.Fixity
       Agda.Syntax.IdiomBrackets
@@ -659,6 +660,7 @@ library
       Agda.Syntax.Internal.Univ
       Agda.Syntax.Literal
       Agda.Syntax.Notation
+      Agda.Syntax.Parser
       Agda.Syntax.Parser.Alex
       Agda.Syntax.Parser.Comments
       Agda.Syntax.Parser.Helpers
@@ -671,7 +673,6 @@ library
       Agda.Syntax.Parser.Parser
       Agda.Syntax.Parser.StringLiterals
       Agda.Syntax.Parser.Tokens
-      Agda.Syntax.Parser
       Agda.Syntax.Position
       Agda.Syntax.Reflected
       Agda.Syntax.Scope.Base
@@ -690,8 +691,8 @@ library
       Agda.Termination.Monad
       Agda.Termination.Order
       Agda.Termination.RecCheck
-      Agda.Termination.SparseMatrix
       Agda.Termination.Semiring
+      Agda.Termination.SparseMatrix
       Agda.Termination.TermCheck
       Agda.Termination.Termination
       Agda.TheTypeChecker
@@ -704,25 +705,25 @@ library
       Agda.TypeChecking.Conversion
       Agda.TypeChecking.Conversion.Pure
       Agda.TypeChecking.Coverage
-      Agda.TypeChecking.Coverage.Match
-      Agda.TypeChecking.Coverage.SplitTree
-      Agda.TypeChecking.Coverage.SplitClause
       Agda.TypeChecking.Coverage.Cubical
+      Agda.TypeChecking.Coverage.Match
+      Agda.TypeChecking.Coverage.SplitClause
+      Agda.TypeChecking.Coverage.SplitTree
       Agda.TypeChecking.Datatypes
       Agda.TypeChecking.DeadCode
-      Agda.TypeChecking.DisplayForm
-      Agda.TypeChecking.DropArgs
       Agda.TypeChecking.DiscrimTree
       Agda.TypeChecking.DiscrimTree.Types
+      Agda.TypeChecking.DisplayForm
+      Agda.TypeChecking.DropArgs
       Agda.TypeChecking.Empty
-      Agda.TypeChecking.EtaContract
       Agda.TypeChecking.Errors
       Agda.TypeChecking.Errors.Names
+      Agda.TypeChecking.EtaContract
+      Agda.TypeChecking.Forcing
       Agda.TypeChecking.Free
       Agda.TypeChecking.Free.Lazy
       Agda.TypeChecking.Free.Precompute
       Agda.TypeChecking.Free.Reduce
-      Agda.TypeChecking.Forcing
       Agda.TypeChecking.Functions
       Agda.TypeChecking.Generalize
       Agda.TypeChecking.IApplyConfluence
@@ -732,13 +733,14 @@ library
       Agda.TypeChecking.InstanceArguments
       Agda.TypeChecking.Irrelevance
       Agda.TypeChecking.Level
+      Agda.TypeChecking.Level.Solve
       Agda.TypeChecking.LevelConstraints
       Agda.TypeChecking.Lock
-      Agda.TypeChecking.Level.Solve
       Agda.TypeChecking.MetaVars
       Agda.TypeChecking.MetaVars.Mention
       Agda.TypeChecking.MetaVars.Occurs
       Agda.TypeChecking.Modalities
+      Agda.TypeChecking.Monad
       Agda.TypeChecking.Monad.Base
       Agda.TypeChecking.Monad.Base.Types
       Agda.TypeChecking.Monad.Base.Warning
@@ -762,7 +764,6 @@ library
       Agda.TypeChecking.Monad.State
       Agda.TypeChecking.Monad.Statistics
       Agda.TypeChecking.Monad.Trace
-      Agda.TypeChecking.Monad
       Agda.TypeChecking.Names
       Agda.TypeChecking.Opacity
       Agda.TypeChecking.Patterns.Abstract
@@ -778,8 +779,8 @@ library
       Agda.TypeChecking.Primitive
       Agda.TypeChecking.Primitive.Base
       Agda.TypeChecking.Primitive.Cubical
-      Agda.TypeChecking.Primitive.Cubical.Glue
       Agda.TypeChecking.Primitive.Cubical.Base
+      Agda.TypeChecking.Primitive.Cubical.Glue
       Agda.TypeChecking.Primitive.Cubical.HCompU
       Agda.TypeChecking.ProjectionLike
       Agda.TypeChecking.Quote
@@ -806,8 +807,8 @@ library
       Agda.TypeChecking.Rules.LHS.Problem
       Agda.TypeChecking.Rules.LHS.ProblemRest
       Agda.TypeChecking.Rules.LHS.Unify
-      Agda.TypeChecking.Rules.LHS.Unify.Types
       Agda.TypeChecking.Rules.LHS.Unify.LeftInverse
+      Agda.TypeChecking.Rules.LHS.Unify.Types
       Agda.TypeChecking.Rules.Record
       Agda.TypeChecking.Rules.Term
       Agda.TypeChecking.Serialise
@@ -816,9 +817,9 @@ library
       Agda.TypeChecking.Serialise.Instances.Abstract
       Agda.TypeChecking.Serialise.Instances.Common
       Agda.TypeChecking.Serialise.Instances.Compilers
+      Agda.TypeChecking.Serialise.Instances.Errors
       Agda.TypeChecking.Serialise.Instances.Highlighting
       Agda.TypeChecking.Serialise.Instances.Internal
-      Agda.TypeChecking.Serialise.Instances.Errors
       Agda.TypeChecking.SizedTypes
       Agda.TypeChecking.SizedTypes.Pretty
       Agda.TypeChecking.SizedTypes.Solve
@@ -841,21 +842,21 @@ library
       Agda.Utils.Bag
       Agda.Utils.Benchmark
       Agda.Utils.BiMap
-      Agda.Utils.Boolean
       Agda.Utils.BoolSet
+      Agda.Utils.Boolean
       Agda.Utils.CallStack
       Agda.Utils.Char
       Agda.Utils.Cluster
+      Agda.Utils.Either
       Agda.Utils.Empty
       Agda.Utils.Environment
-      Agda.Utils.Either
       Agda.Utils.Fail
       Agda.Utils.Favorites
-      Agda.Utils.FileName
       Agda.Utils.FileId
+      Agda.Utils.FileName
       Agda.Utils.Float
-      Agda.Utils.Functor
       Agda.Utils.Function
+      Agda.Utils.Functor
       Agda.Utils.GetOpt
       Agda.Utils.Graph.AdjacencyMap.Unidirectional
       Agda.Utils.Graph.TopSort
@@ -863,15 +864,15 @@ library
       Agda.Utils.HashTable
       Agda.Utils.Haskell.Syntax
       Agda.Utils.IArray
-      Agda.Utils.Impossible
-      Agda.Utils.IndexedList
-      Agda.Utils.IntSet.Infinite
       Agda.Utils.IO
       Agda.Utils.IO.Binary
       Agda.Utils.IO.Directory
       Agda.Utils.IO.TempFile
       Agda.Utils.IO.UTF8
       Agda.Utils.IORef
+      Agda.Utils.Impossible
+      Agda.Utils.IndexedList
+      Agda.Utils.IntSet.Infinite
       Agda.Utils.Lens
       Agda.Utils.Lens.Examples
       Agda.Utils.List
@@ -887,10 +888,10 @@ library
       Agda.Utils.Monad
       Agda.Utils.Monoid
       Agda.Utils.Null
+      Agda.Utils.POMonoid
       Agda.Utils.Parser.MemoisedCPS
       Agda.Utils.PartialOrd
       Agda.Utils.Permutation
-      Agda.Utils.POMonoid
       Agda.Utils.RangeMap
       Agda.Utils.SemiRing
       Agda.Utils.Semigroup

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -849,6 +849,7 @@ library
       Agda.Utils.CallStack
       Agda.Utils.Char
       Agda.Utils.Cluster
+      Agda.Utils.CompressedTrie
       Agda.Utils.Either
       Agda.Utils.Empty
       Agda.Utils.Environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Installation
 Pragmas and options
 -------------------
 
+* New option `--print-options` to print a simple list of all options.
+  This list can e.g. be used to implement bash completion.
+
 Warnings
 --------
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -58,6 +58,12 @@ but in the fixed order listed in the following:
 
      Overwrites itself, i.e., only the last of several :option:`--help` options is effective.
 
+.. option:: --print-options
+
+     .. versionadded:: 2.9.0
+
+     Print a simple list of all options, suitable for implementing bash completion.
+
 .. option:: --build-library
 
      .. versionadded:: 2.8.0

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -108,7 +108,7 @@ import Agda.Utils.Maybe
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 import Agda.Utils.Singleton
 import qualified Agda.Utils.Set1 as Set1
 import qualified Agda.Utils.Trie as Trie

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -85,7 +85,7 @@ import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty hiding (Mode)
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 import Agda.Utils.Singleton
 import Agda.Utils.String
 import Agda.Utils.Time

--- a/src/full/Agda/Interaction/Options/Arguments.hs
+++ b/src/full/Agda/Interaction/Options/Arguments.hs
@@ -1,0 +1,88 @@
+-- | Definitions and tools for arguments of command-line options.
+
+module Agda.Interaction.Options.Arguments where
+
+import Data.Map (Map)
+import Data.Map qualified as Map
+
+import Agda.Interaction.Options.Help (allHelpTopics)
+import Agda.Interaction.Options.ProfileOptions (validProfileOptionStrings)
+import Agda.Interaction.Options.Warnings (warningNameToString, warningSets)
+import Agda.Setup.EmacsMode qualified as EmacsMode (setupFlag, compileFlag, locateFlag)
+
+-- * Names of the arguments of options that have a finite enumeration.
+
+-- | Print the possible values of an argument of the given type.
+optionValues :: Map String [String]
+optionValues = Map.fromList $
+  ( colorArg        , colorValues        ) :
+  ( emacsModeArg    , emacsModeValues    ) :
+  ( helpArg         , helpValues         ) :
+  ( profileArg      , profileValues      ) :
+  ( traceImportsArg , traceImportsValues ) :
+  ( warningArg      , warningValues      ) :
+  []
+
+-- ** @--color@
+
+-- | Argument to @--color@.
+colorArg :: String
+colorArg = "COLOR_MODE"
+
+-- | Possible values for @--color@.
+colorValues :: [String]
+colorValues = [ "always", "auto", "never" ]
+
+-- ** @--emacs-mode@
+
+-- | Argument to @--emacs-mode@.
+emacsModeArg :: String
+emacsModeArg = "EMACS_MODE_COMMAND"
+
+-- | Possible values for @--emacs-mode@.
+emacsModeValues :: [String]
+emacsModeValues = [EmacsMode.setupFlag, EmacsMode.compileFlag, EmacsMode.locateFlag]
+
+-- ** @--help@
+
+-- | Argument to @--help@.
+helpArg :: String
+helpArg = "HELP_TOPIC"
+
+-- | Possible values for @--help@.
+helpValues :: [String]
+helpValues = map fst allHelpTopics
+
+-- ** @--profile@
+
+-- | Argument to @--profile@.
+profileArg :: String
+profileArg = "TO_PROFILE"
+
+-- | Possible values for @--profile@.
+profileValues :: [String]
+profileValues = validProfileOptionStrings
+
+-- ** @--trace-imports@
+
+-- | Argument to @--trace-imports@.
+traceImportsArg :: String
+traceImportsArg = "IMPORT_TRACING_LEVEL"
+
+-- | Possible values for @--trace-imports@.
+traceImportsValues :: [String]
+traceImportsValues = [ show n | n <- [0..3] ]
+
+-- ** @--warning@
+
+-- | Argument to @--warning@.
+warningArg :: String
+warningArg = "WARNING"
+
+-- | Possible values for @--warning@.
+warningValues :: [String]
+warningValues = concat $
+  map fst warningSets :
+  map (\ w -> [w, "no" ++ w]) ws
+  where
+    ws = "error" : map warningNameToString [minBound..maxBound]

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -1854,10 +1854,13 @@ parsePluginOptions argv opts =
 -- | The usage info message. The argument is the program name (probably
 --   agda).
 usage :: [OptDescr ()] -> String -> Help -> String
-usage options progName GeneralHelp = usageInfo (header progName) options
+usage options progName GeneralHelp = usageInfo header options
     where
-        header progName = unlines [ "Agda version " ++ version, ""
-                                  , "Usage: " ++ progName ++ " [OPTIONS...] [FILE]" ]
+        header = unlines
+          [ "Agda version " ++ version
+          , ""
+          , "Usage: " ++ progName ++ " [OPTIONS...] [FILE]"
+          ]
 
 usage options progName (HelpFor topic) = helpTopicUsage topic
 

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -240,7 +240,7 @@ import qualified Agda.Utils.List1        as List1
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Monad         ( tell1 )
 import Agda.Utils.Null
-import Agda.Utils.ProfileOptions
+import Agda.Interaction.Options.ProfileOptions
 import Agda.Utils.String        ( unwords1 )
 import qualified Agda.Utils.String       as String
 import Agda.Utils.Trie          ( Trie )

--- a/src/full/Agda/Interaction/Options/BashCompletion.hs
+++ b/src/full/Agda/Interaction/Options/BashCompletion.hs
@@ -1,26 +1,75 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds   #-}
+
 -- | Tools for shell completion scripts.
+--
+-- Bash completion takes a list of completion words (the current commandline)
+-- and a completion index (the current word to be completed) and returns
+-- a list of possible completions of this word.
+--
+-- To do bash completion /inside/ Agda, we need to pass this data to Agda.
+-- So we equip Agda with a special option @--bash-completion@ which takes
+-- first the completion index (number) and then the completion words.
+-- E.g.
+--
+-- @
+--    agda --bash-completion 1 --warn
+-- @
+--
+-- This should complete @--warn@ to @--warning=@.
+--
+-- @
+--    agda --bash-completion 1 --warning=
+-- @
+--
+-- This would list the possible values for WARNING.
+-- However, these are too many and one may get the annoying question
+-- whether one really wants to see all.
+-- So we should only produce a small enough list.
+-- We show the common prefixes of all values up to a maximal number (threshold).
+-- To this end, we may store the possible completion as a compressed trie
+-- where instead of letters we use maximal non-overlapping prefixes.
+-- Then we compute a fair truncation of the tree so that the
+-- total number of leaves stay below the threshold.
 
 module Agda.Interaction.Options.BashCompletion where
 
-import Data.Map qualified as Map
+import Prelude hiding (null)
+
+import Data.Bifunctor ( first )
+import Data.Map       qualified as Map
 import Data.Maybe
+import Text.Read      ( readMaybe )
 
-import Agda.Interaction.Options.Arguments (optionValues)
-import Agda.Interaction.Options.Base (standardOptions_)
-import Agda.Interaction.Options.ProfileOptions (validProfileOptionStrings)
+import Agda.Interaction.Options.Arguments      ( optionValues )
+import Agda.Interaction.Options.Base           ( standardOptions_ )
 
-import Agda.Utils.GetOpt (OptDescr(..), ArgDescr(..))
+import Agda.Utils.Function       ( applyWhenJust )
+import Agda.Utils.GetOpt         ( OptDescr(..), ArgDescr(..) )
+import Agda.Utils.List           ( (!!!) )
+import Agda.Utils.List1          qualified as List1
+import Agda.Utils.Null
+import Agda.Utils.Trie           (Trie)
+import Agda.Utils.Trie           qualified as Trie
+import Agda.Utils.CompressedTrie qualified as CompressedTrie
+
+type Help = String
 
 printedOptions :: [String]
-printedOptions = printOptions standardOptions_
+printedOptions = map fst printedOptionsWithHelp
+
+printedOptionsWithHelp :: [(String, Help)]
+printedOptionsWithHelp = printOptions standardOptions_
 
 -- | Print just the names of the given options (e.g. for bash completion scripts).
 --   For long options with finitely enumerable arguments, print all variants.
-printOptions :: [OptDescr ()] -> [String]
+printOptions :: [OptDescr ()] -> [(String, Help)]
 printOptions = concat . map \case
-  Option short long arg _help -> concat $
-    ss :
-    ls :
+  Option short long arg help -> concat $
+    map (,help) ss :
+    map (,help) ls :
+    map (map (,noHelp))
     [ [ s        ++ a | s <- ss ] ++
       [ l ++ "=" ++ a | l <- ls ]
     | a <- as
@@ -39,3 +88,71 @@ printOptions = concat . map \case
         NoArg{}     -> Nothing
         ReqArg _ t -> Just t
         OptArg _ t -> Just t
+      noHelp :: Help
+      noHelp = ""
+
+-- | Should the 'completions' be truncated to a given maximum number of prefixes?
+type Truncate = Maybe Int
+
+-- | Handle the option @--bash-complete@.
+--   It expects the index @COMP_CWORD@ as first argument
+--   that tells which of the following arguments @COMP_WORDS@
+--   is supposed to be completed.
+--
+--   It either returns an error message or the result for @COMPREPLY@.
+--
+bashComplete ::
+     Truncate
+       -- ^ Truncate completions suggestions?  To how many?
+  -> [String]
+       -- ^ Arguments following @--bash-complete@.
+  -> Either String String
+       -- ^ Error or @COMPREPLY@.
+bashComplete tr = \case
+  cword : words
+    | Just i <- readMaybe cword
+    , length words > i
+    , Just w <- words !!! i
+    -> case complete tr w of
+        Completion (Just s) _ -> return s
+        Completion ms cs ->
+          return $ unlines $ concat
+            [ maybeToList ms
+            , map fst cs
+            ]
+  _args -> Left "Error: Wrong invokation of --bash-complete"
+
+-- | The result of an invokation of (bash) completion.
+data Completion = Completion
+  { extended :: Maybe String
+      -- ^ If 'Nothing', then the completion word cannot become a valid option ever.
+  , completions :: [(String, Help)]
+      -- ^ If 'null', the 'extended' word cannot be further completed.
+  }
+
+-- | Cached trie of options.
+optionsTrie :: Trie Char Help
+optionsTrie = Trie.fromList printedOptionsWithHelp
+
+-- | Complete the given word as an option.
+complete :: Truncate -> String -> Completion
+complete trunc s
+  -- No completion possible?
+  | null t =
+      Completion Nothing []
+  -- Unambiguously (partially) complete by at least one letter.
+  | Just (k, _t') <- CompressedTrie.isSingleBranch t =
+      Completion (Just $ s ++ List1.toList k) compls
+  -- No unambiguous completion possible: just return suggestions.
+  | otherwise =
+      Completion Nothing compls
+  where
+    -- The possible suffixes.
+    t = CompressedTrie.compress $ Trie.delete [] $ Trie.lookupTrie s optionsTrie
+    -- The possibly truncated list of completions.
+    compls = map (first (s ++)) $ CompressedTrie.toList $ CompressedTrie.substLeaves f tt
+      where
+        -- t truncated.
+        tt = applyWhenJust trunc CompressedTrie.truncateSizeWithLeaves t
+        -- Replace empty leaves by "..." branches.
+        f = maybe (CompressedTrie.singleton "..." empty) CompressedTrie.root

--- a/src/full/Agda/Interaction/Options/BashCompletion.hs
+++ b/src/full/Agda/Interaction/Options/BashCompletion.hs
@@ -1,0 +1,41 @@
+-- | Tools for shell completion scripts.
+
+module Agda.Interaction.Options.BashCompletion where
+
+import Data.Map qualified as Map
+import Data.Maybe
+
+import Agda.Interaction.Options.Arguments (optionValues)
+import Agda.Interaction.Options.Base (standardOptions_)
+import Agda.Interaction.Options.ProfileOptions (validProfileOptionStrings)
+
+import Agda.Utils.GetOpt (OptDescr(..), ArgDescr(..))
+
+printedOptions :: [String]
+printedOptions = printOptions standardOptions_
+
+-- | Print just the names of the given options (e.g. for bash completion scripts).
+--   For long options with finitely enumerable arguments, print all variants.
+printOptions :: [OptDescr ()] -> [String]
+printOptions = concat . map \case
+  Option short long arg _help -> concat $
+    ss :
+    ls :
+    [ [ s        ++ a | s <- ss ] ++
+      [ l ++ "=" ++ a | l <- ls ]
+    | a <- as
+    ]
+    where
+      ss :: [String]
+      ss = [ '-' : s : "" | s <- short ]
+      ls :: [String]
+      ls = [ "--" ++ l | l <- long ]
+      as :: [String]
+      as = fromMaybe [] do
+        t <- argType
+        Map.lookup t optionValues
+      argType :: Maybe String
+      argType = case arg of
+        NoArg{}     -> Nothing
+        ReqArg _ t -> Just t
+        OptArg _ t -> Just t

--- a/src/full/Agda/Interaction/Options/ProfileOptions.hs
+++ b/src/full/Agda/Interaction/Options/ProfileOptions.hs
@@ -1,5 +1,5 @@
 
-module Agda.Utils.ProfileOptions
+module Agda.Interaction.Options.ProfileOptions
   ( ProfileOption(..)
   , ProfileOptions
   , noProfileOptions

--- a/src/full/Agda/Interaction/Options/Types.hs
+++ b/src/full/Agda/Interaction/Options/Types.hs
@@ -26,7 +26,7 @@ import           Agda.Utils.FileName               ( AbsolutePath )
 import           Agda.Utils.Lens                   ( Lens', (^.), over )
 import           Agda.Utils.List1                  ( String1 )
 import qualified Agda.Utils.Maybe.Strict           as Strict
-import           Agda.Utils.ProfileOptions         ( ProfileOptions )
+import           Agda.Interaction.Options.ProfileOptions         ( ProfileOptions )
 import           Agda.Utils.Trie                   ( Trie )
 import           Agda.Utils.WithDefault            ( WithDefault, WithDefault' )
 

--- a/src/full/Agda/Interaction/Options/Types.hs
+++ b/src/full/Agda/Interaction/Options/Types.hs
@@ -58,6 +58,8 @@ data CommandLineOptions = Options
   -- Setup and printing
   , optPrintAgdaDataDir      :: Bool
   , optPrintAgdaAppDir       :: Bool
+  , optPrintOptions          :: Bool
+      -- ^ Print all options as a simple list (for implementing bash completion).
   , optPrintVersion          :: Maybe PrintAgdaVersion
   , optPrintHelp             :: Maybe Help
   , optBuildLibrary          :: Bool

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -19,7 +19,7 @@ module Agda.Interaction.Options.Warnings
        , warningModeUpdate
        , warningSets
        , WarningName (..)
-       , warningName2String
+       , warningNameToString
        , string2WarningName
        , usageWarning
        )
@@ -395,10 +395,10 @@ instance NFData WarningName
 
 string2WarningName :: String -> Maybe WarningName
 string2WarningName = (`HMap.lookup` warnings) where
-  warnings = HMap.fromList $ map (\x -> (warningName2String x, x)) [minBound..maxBound]
+  warnings = HMap.fromList $ map (\x -> (warningNameToString x, x)) [minBound..maxBound]
 
-warningName2String :: WarningName -> String
-warningName2String = initWithDefault __IMPOSSIBLE__ . show
+warningNameToString :: WarningName -> String
+warningNameToString = initWithDefault __IMPOSSIBLE__ . show
 
 -- | @warningUsage@ generated using @warningNameDescription@
 
@@ -432,7 +432,7 @@ usageWarning = intercalate "\n"
     warningTable printD ws =
       untable $ forMaybe ws $ \ w ->
         let wnd = warningNameDescription w in
-        ( warningName2String w
+        ( warningNameToString w
         , applyWhen printD ((if w `Set.member` usualWarnings then "d" else " ") ++)
           " " ++
           wnd

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -28,6 +28,7 @@ import Agda.Interaction.BuildLibrary (buildLibrary)
 import Agda.Interaction.CommandLine
 import Agda.Interaction.ExitCode as ExitCode (AgdaError(..), exitSuccess, exitAgdaWith)
 import Agda.Interaction.Options
+import Agda.Interaction.Options.BashCompletion (printedOptions)
 import Agda.Interaction.Options.Help (Help (..))
 import Agda.Interaction.EmacsTop (mimicGHCi)
 import Agda.Interaction.JSONTop (jsonREPL)
@@ -88,6 +89,7 @@ runAgda' backends = do
       whenJust (optPrintHelp    opts) $ printUsage   bs
       when (optPrintAgdaAppDir  opts) $ printAgdaAppDir
       when (optPrintAgdaDataDir opts) $ printAgdaDataDir
+      when (optPrintOptions     opts) $ printOptions
 
       -- Setup emacs mode
       when (EmacsModeSetup `Set.member` optEmacsMode opts) do
@@ -113,6 +115,7 @@ runAgda' backends = do
               , opts & optPrintHelp    & isJust
               , opts & optPrintAgdaAppDir
               , opts & optPrintAgdaDataDir
+              , opts & optPrintOptions
               , opts & optEmacsMode    & not . null
               ]
           -- if no task was given to Agda
@@ -376,6 +379,9 @@ printAgdaDataDir = putStrLn =<< getDataDir
 
 printAgdaAppDir :: IO ()
 printAgdaAppDir = putStrLn =<< getAgdaAppDir
+
+printOptions :: IO ()
+printOptions = mapM_ putStrLn printedOptions
 
 -- | What to do for bad options.
 optionError :: String -> IO ()

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -41,7 +41,7 @@ import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null ()
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 import Agda.Utils.Singleton
 
 import Agda.Utils.Impossible

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -56,7 +56,7 @@ import Agda.Utils.Monad
 import Agda.Utils.Maybe
 import Agda.Utils.Permutation
 import Agda.Syntax.Common.Pretty (prettyShow)
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 import Agda.Utils.BoolSet (BoolSet)
 import qualified Agda.Utils.BoolSet as BoolSet
 import Agda.Utils.Size

--- a/src/full/Agda/TypeChecking/DiscrimTree.hs
+++ b/src/full/Agda/TypeChecking/DiscrimTree.hs
@@ -29,7 +29,7 @@ import Agda.TypeChecking.Free
 
 import Agda.TypeChecking.DiscrimTree.Types
 
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 
 import Agda.Utils.Impossible
 import Agda.Utils.Trie (Trie(..))

--- a/src/full/Agda/TypeChecking/Injectivity.hs
+++ b/src/full/Agda/TypeChecking/Injectivity.hs
@@ -80,7 +80,7 @@ import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Permutation
 import Agda.Syntax.Common.Pretty ( prettyShow )
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -64,7 +64,7 @@ import Agda.Utils.Size
 import Agda.Utils.Tuple
 import Agda.Syntax.Common.Pretty (prettyShow)
 
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 -- import qualified Agda.Utils.HashTable as HashTable
 import Agda.Utils.WithDefault (lensCollapseDefault)
 import Agda.Utils.Impossible

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -63,7 +63,7 @@ import Agda.Utils.Size
 import Agda.Utils.Tuple
 import Agda.Utils.Permutation
 import Agda.Syntax.Common.Pretty (Pretty, prettyShow, render)
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 import Agda.Utils.Singleton
 import qualified Agda.Utils.Graph.TopSort as Graph
 import Agda.Utils.VarSet (VarSet)

--- a/src/full/Agda/TypeChecking/Monad/Benchmark.hs
+++ b/src/full/Agda/TypeChecking/Monad/Benchmark.hs
@@ -24,7 +24,7 @@ import qualified Agda.Utils.Benchmark as B
 
 import Agda.Utils.Monad
 import Agda.Syntax.Common.Pretty (prettyShow)
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 
 -- | When profile options are set or changed, we need to turn benchmarking on or off.
 updateBenchmarkingStatus :: TCM ()

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -36,7 +36,7 @@ import Agda.Utils.Maybe
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Monad
 import Agda.Syntax.Common.Pretty
-import Agda.Utils.ProfileOptions
+import Agda.Interaction.Options.ProfileOptions
 import Agda.Utils.Update
 import qualified Agda.Utils.Trie as Trie
 

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -59,7 +59,7 @@ import {-# SOURCE #-} Agda.TypeChecking.Reduce
 import {-# SOURCE #-} Agda.TypeChecking.Opacity
 import {-# SOURCE #-} Agda.TypeChecking.Telescope
 
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 import Agda.Utils.CallStack.Base
 import Agda.Utils.Either
 import Agda.Utils.Function ( applyWhen )

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -70,7 +70,7 @@ import Agda.Utils.Hash
 import qualified Agda.Utils.HashTable as H
 import Agda.Utils.IORef
 import Agda.Utils.Null
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -19,7 +19,7 @@ import Agda.Interaction.Options.Warnings
 import Agda.Interaction.Library.Base
 import Agda.Termination.CutOff
 import Agda.Syntax.Common.Pretty
-import Agda.Utils.ProfileOptions
+import Agda.Interaction.Options.ProfileOptions
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -39,7 +39,7 @@ import Agda.Utils.ListInf qualified as ListInf
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
-import qualified Agda.Utils.ProfileOptions as Profile
+import qualified Agda.Interaction.Options.ProfileOptions as Profile
 import Agda.Utils.Singleton
 import Agda.Utils.Size
 import Agda.Utils.Tuple

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -101,7 +101,7 @@ warning'_ loc w = do
         InteractionMetaBoundaries rs -> getRange rs
         _ -> r
   let wn = warningName w
-  let ws = warningName2String wn
+  let ws = warningNameToString wn
   p <- vcat
     [ pure $ P.hsep
       [ if null r' then mempty else P.pretty r' P.<> P.colon

--- a/src/full/Agda/Utils/CompressedTrie.hs
+++ b/src/full/Agda/Utils/CompressedTrie.hs
@@ -1,0 +1,186 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-binds #-}
+
+-- | Strict compressed tries
+--   (based on "Data.Map.Strict" and "Agda.Utils.Maybe.Strict").
+--
+-- In contrast to "Agda.Utils.Trie", branches from a node
+-- can be labeled with non-empty lists of keys that do not
+-- overlap, meaning they start with different first elements.
+-- This way, non-branching unlabelled pathes can be stored
+-- more efficiently.
+--
+-- As a side effect, the notion of height changes
+-- which we utilize in the 'truncate' function.
+--
+-- An 'Agda.Utils.CompressedTrie.Trie' is usually constructed
+-- from an 'Agda.Utils.Trie.Trie' via the 'compress' function.
+
+module Agda.Utils.CompressedTrie where
+
+import Prelude hiding (null, truncate)
+
+import Control.DeepSeq
+
+import Data.Map.Strict         (Map)
+import Data.Map.Strict         qualified as Map
+import Data.Monoid             (Sum(Sum,getSum))
+
+import Agda.Utils.List1        (List1, pattern (:|))
+import Agda.Utils.List1        qualified as List1
+import Agda.Utils.Map          (isSingleMap)
+import Agda.Utils.Maybe.Strict qualified as Strict
+import Agda.Utils.Null
+import Agda.Utils.Singleton
+import Agda.Utils.Trie         qualified as Uncompressed
+
+import Agda.Utils.Impossible (__IMPOSSIBLE__)
+
+-- | Finite map from @[k]@ to @v@.
+--
+--   With the strict 'Maybe' type, 'Trie' is also strict in 'v'.
+--
+--   Invariant: only the root of the tree
+--   may be of the form @Trie Nothing (Map.singleton ks t)@.
+--   A node inside of the trie of that form must be fused
+--   into its branch.
+data Trie k v = Trie
+  { trieValue    :: !(Strict.Maybe v)
+  , trieBranches :: !(Map (List1 k) (Trie k v))
+      -- Invariant: The keys are prefix-free, meaning their first letters differ.
+  }
+  deriving
+    ( Show
+    , Eq
+        -- Andreas, 2024-11-16: The derived Eq isn't extensional.
+        -- It disguishes different representation of the empty Trie.
+        -- (E.g. the empty map and the map that only contains Nothing values.)
+    , Functor
+    , Foldable
+    )
+
+instance (NFData k, NFData v) => NFData (Trie k v) where
+  rnf (Trie a b) = rnf a `seq` rnf b
+
+---------------------------------------------------------------------------
+-- * Construction
+
+-- | Empty trie.
+instance Null (Trie k v) where
+  empty = Trie Strict.Nothing Map.empty
+  null (Trie v t) = null v && all null t
+    -- Andreas, 2024-11-16: since we allow non-canoncial tries,
+    -- we have to check that every subtrie is empty,
+    -- not just that there are no subtries.
+
+-- | Singleton tree with value at the root.
+root :: v -> Trie k v
+root v = Trie (Strict.Just v) Map.empty
+
+instance Singleton ([k],v) (Trie k v) where
+  singleton = uncurry Agda.Utils.CompressedTrie.singleton
+
+-- | Singleton trie.
+singleton :: [k] -> v -> Trie k v
+singleton []       = root
+singleton (k : ks) = singleton1 (k :| ks)
+
+-- | Singleton tree with empty root.
+singleton1 :: List1 k -> v -> Trie k v
+singleton1 ks = Trie Strict.Nothing . Map.singleton ks . root
+
+-- | A single branch with the given subtree.
+--   Precondition: the given subtree has a value at the root.
+singleBranch :: List1 k -> Trie k v -> (List1 k, Trie k v)
+singleBranch ks t
+  | Just (ks', t') <- isSingleBranch t = (ks <> ks', t')
+  | otherwise = (ks, t)
+
+-- | Is the trie starting with a single branch?
+isSingleBranch :: Trie k v -> Maybe (List1 k, Trie k v)
+isSingleBranch = \case
+  Trie Strict.Nothing ts | Just (k, t) <- isSingleMap ts
+    -> Just (k, t)
+  _ -> Nothing
+
+-- | Turn a trie into a compressed trie.
+compress :: Ord k => Uncompressed.Trie k v -> Trie k v
+compress (Uncompressed.Trie mv ts) =
+    Trie mv $ Map.fromList $ map go $ Map.toList ts
+  where
+    go (k, t) = singleBranch (List1.singleton k) (compress t)
+
+---------------------------------------------------------------------------
+-- * Deconstruction
+
+-- | Turn a compressed trie into an uncompressed trie.
+uncompress :: forall k v. Ord k => Trie k v -> Uncompressed.Trie k v
+uncompress (Trie mv ts) =
+    Uncompressed.Trie mv $ Map.fromList $ map go $ Map.toList ts
+  where
+    go :: (List1 k, Trie k v) -> (k, Uncompressed.Trie k v)
+    go (k :| ks, t) = (k, Uncompressed.prefixBy ks $ uncompress t)
+
+-- | Convert to ascending list.
+toList :: Ord k => Trie k v -> [([k],v)]
+toList = toAscList
+
+-- | Convert to ascending list.
+toAscList :: Ord k => Trie k v -> [([k],v)]
+toAscList (Trie mv ts) = Strict.maybeToList (([],) <$> mv) ++
+  [ (List1.toList ks1 ++ ks, v)
+  | (ks1, t) <- Map.toAscList ts
+  , (ks,  v) <- toAscList t
+  ]
+
+-- | The number of labeled nodes.
+size :: Trie k v -> Int
+size (Trie mv ts) = Strict.maybe 0 (const 1) mv + getSum (foldMap (Sum . size) ts)
+
+-- | The number of nodes that are labeled or leaves..
+sizeWithLeaves :: Trie k v -> Int
+sizeWithLeaves (Trie mv ts)
+  | null ts   = 1
+  | otherwise = Strict.maybe 0 (const 1) mv + getSum (foldMap (Sum . sizeWithLeaves) ts)
+
+---------------------------------------------------------------------------
+-- * Modification
+
+-- | Modify the leaves (input and output may be non-canonical).
+
+substLeaves :: (Maybe v -> Trie k v) -> Trie k v -> Trie k v
+substLeaves f (Trie mv ts)
+  | null ts   = f $ Strict.toLazy mv
+  | otherwise = Trie mv (fmap (substLeaves f) ts)
+
+-- | Truncate tree at given depth.
+--   @truncate 0 t@ returns the root.
+
+truncate :: Int -> Trie k v -> Trie k v
+truncate n t@(Trie mv ts)
+  | n <= 0    = if null ts then t else empty
+  | otherwise = Trie mv $ fmap (truncate (n - 1)) ts
+
+-- | Truncate the tree so that it has at most the given size
+--   according to the given sizing function.
+--   @truncateSize sizing 0 t@ returns the trie @truncate 0 t@.
+
+truncateSize :: forall k v. (Trie k v -> Int) -> Int -> Trie k v -> Trie k v
+truncateSize size n t =
+  -- Drop while still increasing but staying below n.
+  case
+    dropWhile
+      (\ ((n1,_),(n2,_)) -> n1 < n2 && n2 < n)
+      (zip ts (drop 1 ts))
+  of
+  -- Return the last trie that was still increasing and stayed below n.
+    ((_, t1), _) : _ -> t1
+    [] -> __IMPOSSIBLE__
+  where
+    ts :: [(Int, Trie k v)]
+    ts = [ (size t', t') | d <- [0..], let t' = truncate d t ]
+
+-- | @truncateSize sizeWithLeaves@
+truncateSizeWithLeaves :: Int -> Trie k v -> Trie k v
+truncateSizeWithLeaves = truncateSize sizeWithLeaves

--- a/src/full/Agda/Utils/Map.hs
+++ b/src/full/Agda/Utils/Map.hs
@@ -3,7 +3,6 @@ module Agda.Utils.Map where
 import Data.Functor.Compose
 import Data.Map (Map)
 import qualified Data.Map as Map
--- import Data.Maybe (mapMaybe) -- UNUSED
 
 import Agda.Utils.Impossible
 
@@ -20,55 +19,9 @@ adjustM f = Map.alterF $ \case
 adjustM' :: (Functor f, Ord k) => (v -> f (a, v)) -> k -> Map k v -> f (a, Map k v)
 adjustM' f k = getCompose . adjustM (Compose . f) k
 
--- UNUSED Liang-Ting Chen (05-07-2019)
--- data EitherOrBoth a b = L a | B a b | R b
---
--- -- | Not very efficient (goes via a list), but it'll do.
--- unionWithM :: (Ord k, Monad m) => (a -> a -> m a) -> Map k a -> Map k a -> m (Map k a)
--- unionWithM f m1 m2 = fromList <$> mapM combine (toList m)
---     where
---         m = unionWith both (map L m1) (map R m2)
---
---         both (L a) (R b) = B a b
---         both _     _     = __IMPOSSIBLE__
---
---         combine (k, B a b) = (,) k <$> f a b
---         combine (k, L a)   = return (k, a)
---         combine (k, R b)   = return (k, b)
---
--- UNUSED Liang-Ting Chen (05-07-2019)
--- insertWithKeyM :: (Ord k, Monad m) => (k -> a -> a -> m a) -> k -> a -> Map k a -> m (Map k a)
--- insertWithKeyM clash k x m =
---     case lookup k m of
---         Just y  -> do
---             z <- clash k x y
---             return $ insert k z m
---         Nothing -> return $ insert k x m
-
 -- * Non-monadic map operations
 ---------------------------------------------------------------------------
-
--- UNUSED Liang-Ting Chen (05-07-2019)
--- -- | Big conjunction over a map.
--- allWithKey :: (k -> a -> Bool) -> Map k a -> Bool
--- allWithKey f = Map.foldrWithKey (\ k a b -> f k a && b) True
 
 -- | Filter a map based on the keys.
 filterKeys :: (k -> Bool) -> Map k a -> Map k a
 filterKeys p = Map.filterWithKey (const . p)
-
--- UNUSED Andreas (2021-08-19)
--- -- | O(n log n).  Rebuilds the map from scratch.
--- --   Not worse than 'Map.mapKeys'.
--- mapMaybeKeys :: (Ord k1, Ord k2) => (k1 -> Maybe k2) -> Map k1 a -> Map k2 a
--- mapMaybeKeys f = Map.fromList . mapMaybe (\ (k,a) -> (,a) <$> f k) . Map.toList
-
--- UNUSED Liang-Ting Chen (05-07-2019)
--- -- | Unzip a map.
--- unzip :: Map k (a, b) -> (Map k a, Map k b)
--- unzip m = (Map.map fst m, Map.map snd m)
---
--- UNUSED Liang-Ting Chen (05-07-2019)
--- unzip3 :: Map k (a, b, c) -> (Map k a, Map k b, Map k c)
--- unzip3 m = (Map.map fst3 m, Map.map snd3 m, Map.map thd3 m)
---

--- a/src/full/Agda/Utils/Map.hs
+++ b/src/full/Agda/Utils/Map.hs
@@ -25,3 +25,10 @@ adjustM' f k = getCompose . adjustM (Compose . f) k
 -- | Filter a map based on the keys.
 filterKeys :: (k -> Bool) -> Map k a -> Map k a
 filterKeys p = Map.filterWithKey (const . p)
+
+-- | Check whether a map is a singleton.
+isSingleMap :: Map k v -> Maybe (k, v)
+isSingleMap m
+  | Map.size m == 1  -- This is fast since the size is cached.
+  , [(k,v)] <- Map.toList m = Just (k, v)
+  | otherwise = Nothing

--- a/src/full/Agda/Utils/Trie.hs
+++ b/src/full/Agda/Utils/Trie.hs
@@ -9,6 +9,8 @@
 module Agda.Utils.Trie
   ( Trie(..)
   , empty, singleton, everyPrefix, insert, insertWith, union, unionWith
+  , fromList
+  , prefixBy
   -- Andreas 2024-11-16:
   -- Deletion does not clean up the trie, thus violates equational laws
   -- with the given Eq that does not quotient out the different representations
@@ -79,6 +81,11 @@ singleton = singletonOrEveryPrefix False
 everyPrefix :: [k] -> v -> Trie k v
 everyPrefix = singletonOrEveryPrefix True
 
+-- | Prefix every key by the given prefix.
+prefixBy :: [k] -> Trie k v -> Trie k v
+prefixBy []     t = t
+prefixBy (k:ks) t = Trie Strict.Nothing $ Map.singleton k $ prefixBy ks t
+
 -- | Left biased union.
 --
 --   @union = unionWith (\ new old -> new)@.
@@ -99,6 +106,9 @@ insert k v t = (singleton k v) `union` t
 -- | Insert with function merging new value with old value.
 insertWith :: (Ord k) => (v -> v -> v) -> [k] -> v -> Trie k v -> Trie k v
 insertWith f k v t = unionWith f (singleton k v) t
+
+fromList :: Ord k => [([k],v)] -> Trie k v
+fromList = foldl (\ t (ks, v) -> insert ks v t) empty
 
 -- Andreas, 2024-11-16: delete does not clean up empty subtrees,
 -- so it is not correct wrt. @Eq@.


### PR DESCRIPTION
**New option `--print-options` to print a simple list of all options**
  
This may be useful to implement bash completion.
  
I changed the name of some meta-variables of options whose arguments have only finitely many values. These names serve as "types" of the values, so that we can have a mapping from type to list of possible values.
  
The new module `Agda.Interaction.Options.Arguments` collects such types and their values.

Further commits:

- **Rename Agda.Utils.ProfileOptions to Agda.Interaction.Options.ProfileOptions**
  This is an Agda-specific module rather than a general tool,
  so it should not reside in the Utils/ tree where we keep general tools.

- **Cosmetics Agda.cabal: sort exposed-modules alphabetically**

- **Cosmetics Interaction.Options.usage: remove redundant arg from header**

- **Rename warningName2String to warningNameToString**
  
A simple shell completion script would be the following:
```bash
# A simple bash-completion script inspired by the one of GHC
# https://github.com/ghc/ghc/blob/9fa590a6e27545995cdcf419ed7a6504e6668b18/utils/completion/ghc.bash
#
# Uses `agda --print-options` to get the full list of options,
# saturated with variants for all options that have finitely many values in their argument.

_agda ()
{
  # Get the list of options from Agda.
  local completions=$($1 --print-options)

  # Get the current word to be completed.
  local cur="${COMP_WORDS[COMP_CWORD]}"

  # Look at the current flag.
  if [[ "$cur" == -* ]]; then
    # All Agda flags start with a dash, so we want to see this before we start
    # suggesting flags. Otherwise we would complete flags when the user might
    # want to type a file name.
    COMPREPLY=( $( compgen -W "$completions" -- "$cur" ) )
  fi
}

complete -F _agda -o default agda
```
I am not happy with this yet, though, because the list of options has ~900 entries and my shell does not reasonably handle this, asking me if I really want to see all.
It would be better if only a short list of prefixes would be generated  each time, so that one can incrementally complete.
  