### PR TITLE
record where: Fix impossible with named module copy

### DIFF
--- a/test/Succeed/RecordWhereNamedCopy.agda
+++ b/test/Succeed/RecordWhereNamedCopy.agda
@@ -1,0 +1,19 @@
+module RecordWhereNamedCopy where
+
+record X : Set₁ where
+  field
+    x : Set
+    y : Set
+
+module Y (_ : Set₁) where postulate
+  a : Set
+  y : Set
+
+_ : X
+_ = record where
+  open module Z = Y Set renaming (a to x) using (y)
+
+_ : X
+_ = record where
+  module Z = Y Set renaming (a to x) using (y)
+  open Z


### PR DESCRIPTION
Bug found by @4e554c4c where both naming and opening a module copy inside a `record where` expression ran into an `__IMPOSSIBLE__` arising from fiddly handling of the ScopeCopyInfo that we can get rid of entirely.