### PR TITLE
fixup: eta for cubical primitives against neutrals

### DIFF
--- a/test/Succeed/TranspReflPair.agda
+++ b/test/Succeed/TranspReflPair.agda
@@ -1,0 +1,18 @@
+{-# OPTIONS --cubical -vtc.conv.term.cubical:30 #-}
+module TranspReflPair where
+
+open import Agda.Primitive.Cubical renaming (primIMax to _∨_ ; primINeg to ~_; primHComp to hcomp; primComp to comp; primTransp to transp)
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.Sigma
+open import Agda.Builtin.Nat
+
+-- Transp on Σ behaves as though "defined by copattern matching" but the
+-- conversion checker really wants to avoid eta-expanding cubical
+-- primitives to not cause performance meltdowns when one or both sides
+-- are blocked on a meta (rather than being good neutrals).
+--
+-- But in this case the transport is a pair that contains the same
+-- components as the other pair and we can't skip it!
+
+test1 : ∀ x → transp (λ i → Σ Nat λ _ → Nat) i0 x ≡ x
+test1 x i = x


### PR DESCRIPTION
This is extremely fiddly, and I don't like that we have to do this for performance… of course, even the non-cubical cases are just for performance, but at least those are easy to get right :face_exhaling:

Fixes an issue pointed out by @the-zammers with an embarrassingly short reproducer.