### PR TITLE
Refactor: properly infinite lists

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -493,6 +493,7 @@ library
     , hashable             >= 1.4.2.0   && < 1.6
     , haskeline            >= 0.8.2     && < 0.9
         -- GHC 9.2 ships with haskeline-0.8.2.1, but 9.4 backslid to 0.8.2
+    , infinite-list        >= 0.1.2     && < 0.2
     , monad-control        >= 1.0.3.1   && < 1.1
     , mtl                  >= 2.2.2     && < 2.4
     , murmur-hash          >= 0.1.0.10  && < 0.2
@@ -875,6 +876,7 @@ library
       Agda.Utils.List
       Agda.Utils.List1
       Agda.Utils.List2
+      Agda.Utils.ListInf
       Agda.Utils.ListT
       Agda.Utils.Map
       Agda.Utils.Map1
@@ -908,6 +910,7 @@ library
       Agda.Utils.Update
       Agda.Utils.VarSet
       Agda.Utils.WithDefault
+      Agda.Utils.Zip
       Agda.Utils.Zipper
       Agda.Version
       Agda.VersionCommit

--- a/src/full/Agda/Compiler/JS/Substitution.hs
+++ b/src/full/Agda/Compiler/JS/Substitution.hs
@@ -3,7 +3,7 @@ module Agda.Compiler.JS.Substitution where
 import Prelude hiding ( map, lookup )
 import Data.Map ( empty, unionWith, singleton, findWithDefault )
 import qualified Data.Map as Map
-import Data.List ( genericIndex )
+import Data.Maybe ( fromMaybe )
 import qualified Data.List as List
 
 import Agda.Syntax.Common ( Nat )
@@ -11,6 +11,7 @@ import Agda.Compiler.JS.Syntax
   ( Exp(Self,Undefined,Local,Lambda,Object,Array,Apply,Lookup,If,BinOp,PreOp),
     MemberId, LocalId(LocalId) )
 import Agda.Utils.Function ( iterate' )
+import Agda.Utils.List ( (!!!) )
 
 -- Map for expressions
 
@@ -47,7 +48,7 @@ subst n es e = map 0 (substituter n es) e
 
 substituter :: Nat -> [Exp] -> Nat -> LocalId -> Exp
 substituter n es m (LocalId i) | i < m       = Local (LocalId i)
-substituter n es m (LocalId i) | (i - m) < n = shift m (genericIndex (es ++ repeat Undefined) (n - (i + 1 - m)))
+substituter n es m (LocalId i) | (i - m) < n = shift m $ fromMaybe Undefined $ es !!! (n - (i + 1 - m))
 substituter n es m (LocalId i) | otherwise   = Local (LocalId (i - n))
 
 substShift :: Nat -> Nat -> [Exp] -> Exp -> Exp

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -5,6 +5,7 @@ module Agda.Compiler.MAlonzo.Compiler
   )
   where
 
+import Prelude hiding ( zip, zipWith )
 import Control.Arrow (second)
 import Control.DeepSeq
 import Control.Monad.Except   ( throwError )
@@ -73,10 +74,12 @@ import Agda.Utils.IO.Directory
 import Agda.Utils.Lens
 import Agda.Utils.List
 import qualified Agda.Utils.List1 as List1
+import qualified Agda.Utils.ListInf as ListInf
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Singleton
 import qualified Agda.Utils.IO.UTF8 as UTF8
+import Agda.Utils.Zip
 
 import Agda.Setup ( getDataDir )
 
@@ -1185,7 +1188,7 @@ condecl q _ind = do
                    else HS.Lazy
       argTypes   = [ (Just strict, t)
                    | (t, False) <- zip (drop np argTypes0)
-                                       (fromMaybe [] erased ++ repeat False)
+                                       (ListInf.pad (fromMaybe [] erased) False)
                    ]
   return $ HS.ConDecl (unqhname ConK q) argTypes
 

--- a/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
+++ b/src/full/Agda/Compiler/MAlonzo/HaskellTypes.hs
@@ -30,6 +30,8 @@ import Agda.Compiler.MAlonzo.Pretty () --instance only
 
 import qualified Agda.Utils.Haskell.Syntax as HS
 import Agda.Utils.List
+import Agda.Utils.ListInf ( pattern (:<) )
+import Agda.Utils.ListInf qualified as ListInf
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty (prettyShow)
@@ -161,12 +163,12 @@ haskellType q = do
   let (np, erased) =
         case theDef def of
           Constructor{ conPars, conErased }
-            -> (conPars, fromMaybe [] conErased ++ repeat False)
-          _ -> (0, repeat False)
-      stripErased (True  : es) (HS.TyFun _ t)     = stripErased es t
-      stripErased (False : es) (HS.TyFun s t)     = HS.TyFun s $ stripErased es t
-      stripErased es           (HS.TyForall xs t) = HS.TyForall xs $ stripErased es t
-      stripErased _            t                  = t
+            -> (conPars, ListInf.pad (fromMaybe [] conErased) False)
+          _ -> (0, ListInf.repeat False)
+      stripErased (True  :< es) (HS.TyFun _ t)     = stripErased es t
+      stripErased (False :< es) (HS.TyFun s t)     = HS.TyFun s $ stripErased es t
+      stripErased es            (HS.TyForall xs t) = HS.TyForall xs $ stripErased es t
+      stripErased _             t                  = t
       underPars 0 a = stripErased erased <$> haskellType' a
       underPars n a = do
         a <- reduce a

--- a/src/full/Agda/Compiler/ToTreeless.hs
+++ b/src/full/Agda/Compiler/ToTreeless.hs
@@ -19,7 +19,6 @@ import Control.Monad.Reader ( MonadReader(..), asks, ReaderT, runReaderT )
 import Data.Maybe
 import Data.Map (Map)
 import qualified Data.Map  as Map
-import qualified Data.List as List
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal as I
@@ -428,7 +427,7 @@ createLambdas diff cont = do
       , "--   cxt  =" <+> prettyPure cxt
       ]
     -- Prepend diff lambdas
-    cont <&> \ t -> List.iterate C.TLam t !! diff
+    iterate' diff C.TLam <$> cont
 
 -- | Adds lambdas until the context has at least the given size.
 -- Updates the catchall expression to take the additional lambdas into account.

--- a/src/full/Agda/Compiler/Treeless/Unused.hs
+++ b/src/full/Agda/Compiler/Treeless/Unused.hs
@@ -5,6 +5,8 @@ module Agda.Compiler.Treeless.Unused
   , stripUnusedArguments
   ) where
 
+import Prelude hiding (zip, zipWith)
+
 import Data.Maybe
 
 import Agda.Syntax.Common
@@ -17,7 +19,9 @@ import Agda.Compiler.Treeless.Pretty () -- instance only
 
 import Agda.Utils.Function ( iterateUntilM )
 import Agda.Utils.List     ( downFrom )
+import Agda.Utils.ListInf qualified as ListInf
 import qualified Agda.Utils.VarSet as VarSet
+import Agda.Utils.Zip
 
 usedArguments :: QName -> TTerm -> TCM [ArgUsage]
 usedArguments q t = computeUnused q b (replicate n ArgUnused)
@@ -31,7 +35,7 @@ computeUnused q t = iterateUntilM (==) $ \ used -> do
 
   reportSLn "treeless.opt.unused" 50 $ concat
     [ "Unused approximation for ", prettyShow q, ": "
-    , unwords [ if u == ArgUsed then [x] else "_" | (x, u) <- zip ['a'..] used ]
+    , unwords [ if u == ArgUsed then [x] else "_" | (x, u) <- zip (ListInf.upFrom 'a') used ]
     ]
   -- Update usage information q to so far "best" value.
   setCompiledArgUse q used
@@ -52,7 +56,7 @@ computeUnused q t = iterateUntilM (==) $ \ used -> do
 
       TApp (TDef f) ts -> do
         used <- fromMaybe [] <$> getCompiledArgUse f
-        VarSet.unions <$> sequence [ go t | (t, ArgUsed) <- zip ts $ used ++ repeat ArgUsed ]
+        VarSet.unions <$> sequence [ go t | (t, ArgUsed) <- zip ts $ ListInf.pad used ArgUsed ]
 
       TApp f ts -> VarSet.unions <$> mapM go (f : ts)
       TLam b    -> underBinder <$> go b

--- a/src/full/Agda/Compiler/Treeless/Unused.hs
+++ b/src/full/Agda/Compiler/Treeless/Unused.hs
@@ -18,7 +18,7 @@ import Agda.TypeChecking.Substitute
 import Agda.Compiler.Treeless.Pretty () -- instance only
 
 import Agda.Utils.Function ( iterateUntilM )
-import Agda.Utils.List     ( downFrom )
+import Agda.Utils.List     ( downFrom, takeExactly )
 import Agda.Utils.ListInf qualified as ListInf
 import qualified Agda.Utils.VarSet as VarSet
 import Agda.Utils.Zip
@@ -93,7 +93,7 @@ stripUnusedArguments used t = mkTLam m $ applySubst rho b
   where
     (n, b) = tLamView t
     m      = length $ filter (== ArgUsed) used'
-    used'  = reverse $ take n $ used ++ repeat ArgUsed
+    used'  = reverse $ takeExactly ArgUsed n used
     rho = computeSubst used'
     computeSubst (ArgUnused : bs) = TErased :# computeSubst bs
     computeSubst (ArgUsed   : bs) = liftS 1 $ computeSubst bs

--- a/src/full/Agda/Syntax/Notation.hs
+++ b/src/full/Agda/Syntax/Notation.hs
@@ -15,7 +15,7 @@
 
 module Agda.Syntax.Notation where
 
-import Prelude hiding (null)
+import Prelude hiding ( null, zip, zipWith )
 
 import Control.DeepSeq
 import Control.Monad
@@ -36,10 +36,13 @@ import Agda.Utils.Lens
 import Agda.Utils.List
 import Agda.Utils.List1           ( List1, pattern (:|) )
 import qualified Agda.Utils.List1 as List1
+import Agda.Utils.ListInf         ( pattern (:<) )
+import qualified Agda.Utils.ListInf as ListInf
 import Agda.Utils.Set1            ( Set1 )
 import qualified Agda.Utils.Set1  as Set1
 import Agda.Utils.Null
 import Agda.Utils.Singleton
+import Agda.Utils.Zip
 
 import Agda.Utils.Impossible
 
@@ -278,7 +281,7 @@ useDefaultFixity n
 --   @M.for x ∈ xs return e@, or @x ℕ.+ y@.
 notationNames :: NewNotation -> [QName]
 notationNames (NewNotation q _ _ parts _) =
-  zipWith ($) (reQualify : repeat QName) [simpleName $ rangedThing x | IdPart x <- parts ]
+  zipWith ($) (reQualify :< ListInf.repeat QName) [ simpleName $ rangedThing x | IdPart x <- parts ]
   where
     -- The qualification of @q@.
     modules     = List1.init (qnameParts q)

--- a/src/full/Agda/Syntax/TopLevelModuleName.hs
+++ b/src/full/Agda/Syntax/TopLevelModuleName.hs
@@ -28,6 +28,7 @@ import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Position
 
 import Agda.Utils.FileName
+import Agda.Utils.Function (iterate')
 import Agda.Utils.Hash
 import Agda.Utils.Impossible
 import Agda.Utils.Lens
@@ -209,5 +210,4 @@ moduleNameToFileName TopLevelModuleName{ moduleNameParts = ms } ext =
 
 projectRoot :: AbsolutePath -> TopLevelModuleName -> AbsolutePath
 projectRoot file TopLevelModuleName{ moduleNameParts = m } =
-  mkAbsolute $
-    iterate takeDirectory (filePath file) !! length m
+  mkAbsolute $ iterate' (length m) takeDirectory $ filePath file

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -75,7 +75,7 @@ withVar s t f = do
     notTaken xs x = isNoName x || nameConcrete x `notElem` xs
 
 withNames :: MonadReflectedToAbstract m => [String] -> ([Name] -> m a) -> m a
-withNames ss = withVars $ zip ss $ repeat R.Unknown
+withNames = withVars . map (,R.Unknown)
 
 withVars :: MonadReflectedToAbstract m => [(String, R.Type)] -> ([Name] -> m a) -> m a
 withVars ss f = case ss of
@@ -124,7 +124,7 @@ toAbstractWithoutImplicit ::
   ) => r -> m (AbsOfRef r)
 toAbstractWithoutImplicit x = do
   xs <- killRange <$> getContextNames'
-  let ctx = zip xs $ repeat R.Unknown
+  let ctx = map (,R.Unknown) xs
   runReaderT (toAbstract x) ctx
 
 instance ToAbstract r => ToAbstract (Named name r) where

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -7,7 +7,7 @@
 
 module Agda.Termination.Monad where
 
-import Prelude hiding (null)
+import Prelude hiding (null, zip, zipWith)
 
 import Control.Applicative hiding (empty)
 
@@ -44,6 +44,8 @@ import Agda.Utils.Function
 import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List   ( hasElem )
+import Agda.Utils.ListInf ( ListInf )
+import Agda.Utils.ListInf qualified as ListInf
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Monoid
@@ -52,6 +54,7 @@ import Agda.Syntax.Common.Pretty (Pretty, prettyShow)
 import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Utils.VarSet (VarSet)
 import qualified Agda.Utils.VarSet as VarSet
+import Agda.Utils.Zip
 
 import Agda.Utils.Impossible
 
@@ -102,7 +105,7 @@ data TerEnv = TerEnv
   , terTarget  :: Target
     -- ^ Target type of the function we are currently termination checking.
     --   Only the constructors of 'Target' are considered guarding.
-  , terMaskArgs :: [Bool]
+  , terMaskArgs :: ListInf Bool
     -- ^ Only consider the 'notMasked' 'False' arguments for establishing termination.
     --   See issue #1023.
   , terMaskResult :: Bool
@@ -151,7 +154,7 @@ defaultTerEnv = TerEnv
   , terCurrent                  = __IMPOSSIBLE__ -- needs to be set!
   , terHaveInlinedWith          = False
   , terTarget                   = TargetOther
-  , terMaskArgs                 = repeat False   -- use all arguments (mask none)
+  , terMaskArgs                 = ListInf.repeat False   -- use all arguments (mask none)
   , terMaskResult               = False          -- use result (do not mask)
   , _terSizeDepth               = __IMPOSSIBLE__ -- needs to be set!
   , terPatterns                 = __IMPOSSIBLE__ -- needs to be set!
@@ -289,10 +292,10 @@ terGetHaveInlinedWith = terAsks terHaveInlinedWith
 terSetHaveInlinedWith :: TerM a -> TerM a
 terSetHaveInlinedWith = terLocal $ \ e -> e { terHaveInlinedWith = True }
 
-terGetMaskArgs :: TerM [Bool]
+terGetMaskArgs :: TerM (ListInf Bool)
 terGetMaskArgs = terAsks terMaskArgs
 
-terSetMaskArgs :: [Bool] -> TerM a -> TerM a
+terSetMaskArgs :: ListInf Bool -> TerM a -> TerM a
 terSetMaskArgs b = terLocal $ \ e -> e { terMaskArgs = b }
 
 terGetMaskResult :: TerM Bool

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -15,7 +15,7 @@ module Agda.Termination.TermCheck
     , Result
     ) where
 
-import Prelude hiding ( null )
+import Prelude hiding ( null, zip, zipWith )
 
 import Control.Applicative  ( liftA2 )
 import Control.Monad        ( (<=<), filterM, forM, forM_, zipWithM )
@@ -66,6 +66,8 @@ import Agda.Utils.Either
 import Agda.Utils.Function
 import Agda.Utils.Functor
 import Agda.Utils.List
+import Agda.Utils.ListInf ( pattern (:<) )
+import Agda.Utils.ListInf qualified as ListInf
 import Agda.Utils.Maybe
 import Agda.Utils.Monad -- (mapM', forM', ifM, or2M, and2M)
 import Agda.Utils.Null
@@ -75,6 +77,7 @@ import Agda.Utils.Size
 -- import Agda.Utils.SmallSet (SmallSet)
 import qualified Agda.Utils.SmallSet as SmallSet
 import qualified Agda.Utils.VarSet as VarSet
+import Agda.Utils.Zip
 
 import Agda.Utils.Impossible
 
@@ -574,7 +577,7 @@ setMasks t cont = do
     when d $
       reportSLn "term.mask" 20 $ "result type is not data or record type, ignoring guardedness for --without-K"
     return (ds, d)
-  terSetMaskArgs (ds ++ repeat True) $ terSetMaskResult d $ cont
+  terSetMaskArgs (ListInf.pad ds True) $ terSetMaskResult d $ cont
 
   where
     checkArgumentTypes :: Telescope -> TCM [Bool]
@@ -825,8 +828,8 @@ function g es0 = do
     -- If the function is a projection but not for a coinductive record,
     -- then preserve guardedness for its principal argument.
     isProj <- isProjectionButNotCoinductive g
-    let unguards = repeat Order.unknown
-    let guards = applyWhen isProj (guarded :) unguards
+    let unguards = ListInf.repeat Order.unknown
+    let guards = applyWhen isProj (guarded :<) unguards
     -- Collect calls in the arguments of this call.
     let args = map unArg $ argsFromElims es0
     calls <- forM' (zip guards args) $ \ (guard, a) -> do

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1017,7 +1017,8 @@ instance ExtractCalls Term where
         -- A constructor preserves the guardedness of all its arguments.
         -- Andreas, 2022-09-19, issue #6108:
         -- A higher constructor does not.  So check if there is an @IApply@ amoung @es@.
-        let argsg = zip args $ repeat $ all isProperApplyElim es
+        let noIApply = all isProperApplyElim es
+        let argsg = map (,noIApply) args
 
         -- If we encounter a coinductive record constructor
         -- in a type mutual with the current target

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -15,6 +15,8 @@
 
 module Agda.TypeChecking.MetaVars.Occurs where
 
+import Prelude hiding (zip, zipWith)
+
 import Control.Monad.Except ( ExceptT, runExceptT, catchError, throwError )
 import Control.Monad.Reader ( ReaderT, runReaderT, ask, asks, local )
 
@@ -50,6 +52,7 @@ import Agda.Utils.Either
 import Agda.Utils.Function
 import Agda.Utils.Lens
 import Agda.Utils.List (downFrom)
+import Agda.Utils.ListInf qualified as ListInf
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Permutation
@@ -57,6 +60,7 @@ import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Utils.Size
 import Agda.Utils.VarSet (VarSet)
 import qualified Agda.Utils.VarSet as VarSet
+import Agda.Utils.Zip
 
 import Agda.Utils.Impossible
 
@@ -902,7 +906,7 @@ killArgs kills m = do
       -- Andreas 2011-04-26, we allow pruning in MetaV and MetaS
       let a = jMetaType $ mvJudgement mv
       TelV tel b <- telView' <$> instantiateFull a
-      let args         = zip (telToList tel) (kills ++ repeat False)
+      let args         = zip (telToList tel) (ListInf.pad kills False)
       (kills', a') <- killedType args b
       dbg kills' a a'
       -- If there is any prunable argument, perform the pruning
@@ -1033,7 +1037,7 @@ performKill kills m a = do
   -- which are not pruned in left to right order
   -- (de Bruijn level order).
   let perm = Perm n
-             [ i | (i, Arg _ False) <- zip [0..] kills ]
+             [ i | (i, Arg _ False) <- zip (ListInf.upFrom 0) kills ]
       -- The permutation for the old meta might range over a prefix of the arguments
       oldPerm = liftP (max 0 $ n - m) p
         where p = mvPermutation mv

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -161,7 +161,7 @@ instance MonadDebug TCM where
     -- So we need to do the padding ourselves.
     -- yyyy-mm-ddThh:mm:ss.ssssss
     -- 12345678901234567890123456
-    trailingZeros = take 26 . (++ repeat '0')
+    trailingZeros = takeExactly '0' 26
 
   formatDebugMessage k n d = catchAndPrintImpossible k n $ do
     render <$> d `catchError` \ err -> do

--- a/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
@@ -21,7 +21,7 @@ import Agda.TypeChecking.Positivity.Occurrence
 import Agda.TypeChecking.Substitute
 
 import Agda.Utils.CallStack
-import Agda.Utils.List
+import Agda.Utils.Function (iterate')
 import Agda.Utils.List1 (List1, pattern (:|))
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
@@ -155,7 +155,7 @@ sizeSuc n v | n < 0     = __IMPOSSIBLE__
             | n == 0    = return v
             | otherwise = do
   suc <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinSizeSuc
-  return $ fromMaybe __IMPOSSIBLE__ (iterate (sizeSuc_ suc) v !!! n)
+  return $ iterate' n (sizeSuc_ suc) v
 
 sizeSuc_ :: QName -> Term -> Term
 sizeSuc_ suc v = Def suc [Apply $ defaultArg v]

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -11,6 +11,8 @@ module Agda.TypeChecking.Polarity
   , polFromOcc
   ) where
 
+import Prelude hiding ( zip, zipWith )
+
 import Control.Monad  ( forM_, zipWithM )
 
 import Data.Maybe
@@ -31,11 +33,13 @@ import Agda.TypeChecking.Free
 import Agda.TypeChecking.Positivity.Occurrence
 
 import Agda.Utils.List
+import Agda.Utils.ListInf qualified as ListInf
 import Agda.Utils.Maybe ( whenNothingM )
 import Agda.Utils.Monad
 import Agda.Syntax.Common.Pretty ( prettyShow )
 import Agda.Utils.Singleton
 import Agda.Utils.Size
+import Agda.Utils.Zip
 
 import Agda.Utils.Impossible
 
@@ -416,7 +420,7 @@ instance HasPolarity Term where
     Lit _         -> mempty
     Level l       -> polarity' i p l
     Def x ts      -> getPolarity x >>== \ pols ->
-                       let ps = map (composePol p) pols ++ repeat Invariant
+                       let ps = ListInf.pad (map (composePol p) pols) Invariant
                        in  mconcat $ zipWith (polarity' i) ps ts
     Con _ _ ts    -> polarity' i p ts   -- Constructors can be seen as monotone in all args.
     Pi a b        -> polarity' i (neg p) a <> polarity' i p b

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -34,6 +34,8 @@ import {-# SOURCE #-} Agda.TypeChecking.Conversion
 import Agda.Utils.Functor
 import Agda.Utils.List as List
 import Agda.Utils.List1 (pattern (:|))
+import Agda.Utils.ListInf (ListInf, pattern (:<))
+import Agda.Utils.ListInf qualified as ListInf
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
@@ -140,7 +142,7 @@ checkSizeVarNeverZero i = do
   ts <- map ctxEntryType . take i <$> getContext
   -- If we encountered a blocking meta in the context, we cannot
   -- say ``no'' for sure.
-  (n, blockers) <- runWriterT $ minSizeValAux ts $ repeat 0
+  (n, blockers) <- runWriterT $ minSizeValAux ts $ ListInf.repeat 0
   let blocker = unblockOnAll blockers
   if n > 0 then return True else
     if blocker == alwaysUnblock
@@ -149,12 +151,11 @@ checkSizeVarNeverZero i = do
   where
   -- Compute the least valuation for size context ts above the
   -- given valuation and return its last value.
-  minSizeValAux :: [Type] -> [Int] -> WriterT (Set Blocker) TCM Int
-  minSizeValAux _        []      = __IMPOSSIBLE__
-  minSizeValAux []       (n : _) = return n
-  minSizeValAux (t : ts) (n : ns) = do
+  minSizeValAux :: [Type] -> ListInf Int -> WriterT (Set Blocker) TCM Int
+  minSizeValAux []       (n :< _) = return n
+  minSizeValAux (t : ts) (n :< ns) = do
     reportSDoc "tc.size" 60 $
-       text ("minSizeVal (n:ns) = " ++ show (take (length ts + 2) $ n:ns) ++
+       text ("minSizeVal (n:ns) = " ++ show (ListInf.take (length ts + 2) $ n :< ns) ++
              " t =") <+> (text . show) t  -- prettyTCM t  -- Wrong context!
     -- n is the min. value for variable 0 which has type t.
     let cont = minSizeValAux ts ns
@@ -174,8 +175,8 @@ checkSizeVarNeverZero i = do
               -- Thus, we update the min value for @j@ with function @(max (n+1-m))@.
               DSizeVar (ProjectedVar j []) m -> do
                 reportSLn "tc.size" 60 $ "minSizeVal upper bound v = " ++ show v
-                let ns' = List.updateAt j (max $ n + 1 - m) ns
-                reportSLn "tc.size" 60 $ "minSizeVal ns' = " ++ show (take (length ts + 1) ns')
+                let ns' = ListInf.updateAt j (max $ n + 1 - m) ns
+                reportSLn "tc.size" 60 $ "minSizeVal ns' = " ++ show (ListInf.take (length ts + 1) ns')
                 minSizeValAux ts ns'
               DSizeMeta x _ _ -> perhaps (unblockOnMeta x)
               _ -> cont

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -19,6 +19,8 @@ module Agda.TypeChecking.Substitute
   , Substitution'(..), Substitution
   ) where
 
+import Prelude hiding ( zip, zipWith )
+
 import Control.Arrow (first, second)
 
 import Data.Coerce
@@ -32,6 +34,7 @@ import Data.HashMap.Strict (HashMap)
 import Debug.Trace (trace)
 
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty
 import Agda.Syntax.Position
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
@@ -52,12 +55,14 @@ import Agda.Utils.Functor
 import Agda.Utils.List
 import Agda.Utils.List1 (List1, pattern (:|))
 import qualified Agda.Utils.List1 as List1
+import qualified Agda.Utils.ListInf as ListInf
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Monad
 import Agda.Utils.Permutation
-import Agda.Syntax.Common.Pretty
+import Agda.Utils.Singleton
 import Agda.Utils.Size
 import Agda.Utils.Tuple
+import Agda.Utils.Zip
 
 import Agda.Utils.Impossible
 
@@ -777,7 +782,7 @@ abstractArgs args x = abstract tel x
         tel   = foldr (\arg@(Arg info x) -> ExtendTel (__DUMMY_TYPE__ <$ domFromArg arg) . Abs x)
                       EmptyTel
               $ zipWith (<$) names args
-        names = cycle $ map (stringToArgName . (:[])) ['a'..'z']
+        names = ListInf.cycle $ fmap (stringToArgName . singleton) ('a' :| ['b'..'z'])
 
 ---------------------------------------------------------------------------
 -- * Substitution and shifting\/weakening\/strengthening

--- a/src/full/Agda/Utils/Function.hs
+++ b/src/full/Agda/Utils/Function.hs
@@ -109,9 +109,13 @@ iterateUntilM r f = loop where
 -- The applications are calculated strictly.
 
 iterate' :: Integral i => i -> (a -> a) -> a -> a
-iterate' 0 _ x             = x
-iterate' n f x | n > 0     = iterate' (n - 1) f $! f x
-               | otherwise = error "iterate': Negative input."
+iterate' n f x
+  | n >= 0    = go n x
+  | otherwise = error "iterate': Negative input."
+  where
+    go n x
+      | n > 0     = go (n - 1) $! f x
+      | otherwise = x
 
 -- * Iteration over Booleans.
 

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -281,6 +281,18 @@ splitExactlyAt 0 xs       = return ([], xs)
 splitExactlyAt n []       = Nothing
 splitExactlyAt n (x : xs) = mapFst (x :) <$> splitExactlyAt (n-1) xs
 
+-- | @takeExactly a n as == take n (as ++ repeat a)@
+--
+{-# SPECIALIZE takeExactly :: a -> Int -> [a] -> [a] #-}
+takeExactly :: forall a n. Integral n => a -> n -> [a] -> [a]
+takeExactly a = go
+  where
+    go n
+      | n <= 0    = const []
+      | otherwise = \case
+          []   -> List.genericReplicate n a
+          x:xs -> x : go (n - 1) xs
+
 -- | Drop from the end of a list.
 --   O(length).
 --

--- a/src/full/Agda/Utils/List2.hs
+++ b/src/full/Agda/Utils/List2.hs
@@ -13,6 +13,8 @@ module Agda.Utils.List2
   , module Reexport
   ) where
 
+import Prelude hiding ( zip, zipWith )
+
 import Control.DeepSeq
 import Control.Monad                   ( (<=<) )
 
@@ -121,3 +123,11 @@ break p = List.break p . toList
 
 instance NFData a => NFData (List2 a) where
   rnf (List2 a b cs) = rnf a `seq` rnf b `seq` rnf cs
+
+-- * Zip
+
+zipWith :: (a -> b -> c) -> List2 a -> List2 b -> List2 c
+zipWith f (List2 a1 a2 as) (List2 b1 b2 bs) = List2 (f a1 b1) (f a2 b2) (List.zipWith f as bs)
+
+zip :: List2 a -> List2 b -> List2 (a, b)
+zip = zipWith (,)

--- a/src/full/Agda/Utils/ListInf.hs
+++ b/src/full/Agda/Utils/ListInf.hs
@@ -1,0 +1,86 @@
+-- | Infinite lists (streams).
+--
+-- Wrapper for "Data.List.Infinite" from the @infinite-list@ package
+-- that generalizes some type signatures, using 'Integral' for indexing,
+-- and adds some missing functions.
+--
+-- Import this module as follows:
+--
+-- @
+-- import Agda.Utils.ListInf (ListInf, pattern (:<))
+-- import Agda.Utils.ListInf qualified as ListInf
+-- @
+--
+-- Motivation: lists constructed by 'repeat', 'iterate', 'cycle' etc.
+-- are infinite, so the nil case can never arise when consuming them,
+-- e.g. in a 'take' or 'zipWith'.
+-- Constructing them as properly infinite lists ('ListInf') should thus
+-- lead to slightly more efficient code, eliminating impossible cases.
+
+module Agda.Utils.ListInf
+  ( module Agda.Utils.ListInf, module Inf)
+  where
+
+import Prelude
+  ( Enum, Foldable, Functor, Int, Integral
+  , (.), ($), (-), (<=), (>)
+  , fromIntegral, id, otherwise, succ
+  )
+
+import Data.List.Infinite qualified
+import Data.List.Infinite as Inf
+  ( pattern (:<), cycle, iterate, prependList, repeat
+  , head, tail
+  , zip, zipWith
+  ) -- add more as needed
+
+type ListInf = Data.List.Infinite.Infinite
+
+---------------------------------------------------------------------------
+-- * Construction
+
+-- | There is only one meaningful way to concatenate a finite and an infinite list,
+-- justifying the name @append = prependList@.
+append :: [a] -> ListInf a -> ListInf a
+append = prependList
+
+-- | @pad as b@ implements the frequent pattern @as ++ repeat b@.
+pad :: [a] -> a -> ListInf a
+pad as b = append as (repeat b)
+
+-- | @upFrom n = [n..]@ as properly infinite list.
+{-# SPECIALIZE upFrom :: Int -> ListInf Int #-}
+upFrom :: Enum n => n -> ListInf n
+upFrom = iterate succ
+
+---------------------------------------------------------------------------
+-- * Selection
+
+-- | Update the @n@th element of an infinite list.
+--   @Θ(n)@.
+--
+--   Precondition: the index @n@ is >= 0.
+{-# SPECIALIZE updateAt :: Int -> (a -> a) -> ListInf a -> ListInf a #-}
+updateAt :: Integral n => n -> (a -> a) -> ListInf a -> ListInf a
+updateAt n f (a :< as)
+  | n > 0     = a :< updateAt (n - 1) f as
+  | otherwise = f a :< as
+
+-- Generalized versions of the functions from the @infinite-list@ package:
+
+{-# SPECIALIZE (!!) :: ListInf a -> Int -> a #-}
+(!!) :: Integral n => ListInf a -> n -> a
+as !! n = as Data.List.Infinite.!! fromIntegral n
+
+{-# SPECIALIZE take :: Int -> ListInf a -> [a] #-}
+take :: Integral n => n -> ListInf a -> [a]
+take = Data.List.Infinite.genericTake
+
+{-# SPECIALIZE drop :: Int -> ListInf a -> ListInf a #-}
+drop :: Integral n => n -> ListInf a -> ListInf a
+drop = Data.List.Infinite.genericDrop
+
+-- | @splitAt n as == (take n as, drop n as)@
+{-# SPECIALIZE splitAt :: Int -> ListInf a -> ([a], ListInf a) #-}
+splitAt :: Integral n => n -> ListInf a -> ([a], ListInf a)
+splitAt = Data.List.Infinite.genericSplitAt

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -150,7 +150,7 @@ droppedP (Perm n xs) = Perm n $ filter (notInXs !) [0 .. n - 1]
   where
   notInXs :: UArray Int Bool
   notInXs =
-    accumArray (flip const) True (0, n - 1) (zip xs (repeat False))
+    accumArray (flip const) True (0, n - 1) $ map (,False) xs
 
 -- | @liftP k@ takes a @Perm {m} n@ to a @Perm {m+k} (n+k)@.
 --   Analogous to 'Agda.TypeChecking.Substitution.liftS',

--- a/src/full/Agda/Utils/Zip.hs
+++ b/src/full/Agda/Utils/Zip.hs
@@ -21,9 +21,10 @@
 
 module Agda.Utils.Zip where
 
-import Prelude (map, uncurry)
+import Prelude ((.), flip)
 
-import Data.List qualified as List
+import Data.List          qualified as List
+import Data.List.Infinite ( heteroZipWith )
 
 -- import Agda.Utils.List    ( pattern (:) )
 import Agda.Utils.List1   ( List1, pattern (:|) )
@@ -73,17 +74,11 @@ instance Zip List2 [] [] where
 
 -- 0/∞
 instance Zip [] ListInf [] where
-  zipWith f = go
-    where
-      go [] _ = []
-      go (a : as) (b :< bs) = f a b : go as bs
+  zipWith = flip . heteroZipWith . flip
 
 -- ∞/0
 instance Zip ListInf [] [] where
-  zipWith f = go
-    where
-      go _ [] = []
-      go (a :< as) (b : bs) = f a b : go as bs
+  zipWith = heteroZipWith
 
 -- List1 instances
 
@@ -102,11 +97,11 @@ instance Zip List2 List1 List1 where
 
 -- 1/∞
 instance Zip List1 ListInf List1 where
-  zipWith f (a :| as) (b :< bs) = f a b :| zipWith f as bs
+  zipWith = flip . heteroZipWith . flip
 
 -- ∞/1
 instance Zip ListInf List1 List1 where
-  zipWith f (a :< as) (b :| bs) = f a b :| zipWith f as bs
+  zipWith = heteroZipWith
 
 -- List2 instances
 
@@ -117,11 +112,11 @@ instance Zip List2 List2 List2 where
 
 -- 2/∞
 instance Zip List2 ListInf List2 where
-  zipWith f (List2 a1 a2 as) (b1 :< b2 :< bs) = List2 (f a1 b1) (f a2 b2) (zipWith f as bs)
+  zipWith = flip . heteroZipWith . flip
 
 -- ∞/2
 instance Zip ListInf List2 List2 where
-  zipWith f (a1 :< a2 :< as) (List2 b1 b2 bs) = List2 (f a1 b1) (f a2 b2) (zipWith f as bs)
+  zipWith = heteroZipWith
 
 -- ListInf instances
 

--- a/src/full/Agda/Utils/Zip.hs
+++ b/src/full/Agda/Utils/Zip.hs
@@ -1,0 +1,131 @@
+-- | Overloaded 'zip' and 'zipWith'.
+--
+-- This module provides the 'Zip' class to overload zipping functions
+-- for variants of the list type ('[]', 'List1', 'List2', 'ListInf').
+--
+-- Motivation:
+-- In practice, we often zip a finite list with an infinite list,
+-- e.g. @zipWith f xs (ys ++ repeat z)@.
+-- We can know statically in this case that the resulting considers
+-- each @xs@ by rewriting this to @zipWith f xs (ListInf.pad ys z)@
+-- statically exposing the infinite nature of the second list.
+-- To avoid cluttering the namespace with 4*4 variants of 'zipWith'
+-- for all combination of our list types, we introduce an overloaded version.
+--
+-- Import this module as follows:
+--
+-- @
+-- import Prelude hiding (zip, zipWith)
+-- import Agda.Utils.Zip
+-- @
+
+module Agda.Utils.Zip where
+
+import Prelude (map, uncurry)
+
+import Data.List qualified as List
+
+-- import Agda.Utils.List    ( pattern (:) )
+import Agda.Utils.List1   ( List1, pattern (:|) )
+import Agda.Utils.List2   ( List2, pattern List2 )
+import Agda.Utils.ListInf ( ListInf, pattern (:<) )
+
+import Agda.Utils.List    qualified as List
+import Agda.Utils.List1   qualified as List1
+import Agda.Utils.List2   qualified as List2
+import Agda.Utils.ListInf qualified as ListInf
+
+class Zip f g h | f g -> h where
+  zip :: f a -> g b -> h (a, b)
+  zip = zipWith (,)
+
+  zipWith :: (a -> b -> c) -> f a -> g b -> h c
+  -- zipWith f as bs = map (uncurry f) (zip as bs) -- needs Functor h
+
+  {-# MINIMAL zipWith #-}
+
+-- List instances
+
+-- 0/0
+instance Zip [] [] [] where
+  zipWith = List.zipWith
+  zip     = List.zip
+
+-- 0/1
+instance Zip [] List1 [] where
+  zipWith _ [] _ = []
+  zipWith f (a : as) (b :| bs) = f a b : zipWith f as bs
+
+-- 1/0
+instance Zip List1 [] [] where
+  zipWith _ _ [] = []
+  zipWith f (a :| as) (b : bs) = f a b : zipWith f as bs
+
+-- 0/2
+instance Zip [] List2 [] where
+  zipWith _ []  _ = []
+  zipWith f (a1 : as) (List2 b1 b2 bs) = f a1 b1 : zipWith f as (b2 :| bs)
+
+-- 2/0
+instance Zip List2 [] [] where
+  zipWith _ _ [] = []
+  zipWith f (List2 a1 a2 as) (b1 : bs) = f a1 b1 : zipWith f (a2 :| as) bs
+
+-- 0/∞
+instance Zip [] ListInf [] where
+  zipWith f = go
+    where
+      go [] _ = []
+      go (a : as) (b :< bs) = f a b : go as bs
+
+-- ∞/0
+instance Zip ListInf [] [] where
+  zipWith f = go
+    where
+      go _ [] = []
+      go (a :< as) (b : bs) = f a b : go as bs
+
+-- List1 instances
+
+-- 1/1
+instance Zip List1 List1 List1 where
+  zipWith = List1.zipWith
+  zip     = List1.zip
+
+-- 1/2
+instance Zip List1 List2 List1 where
+  zipWith f (a1 :| as) (List2 b1 b2 bs) = f a1 b1 :| zipWith f as (b2 :| bs)
+
+-- 2/1
+instance Zip List2 List1 List1 where
+  zipWith f (List2 a1 a2 as) (b1 :| bs) = f a1 b1 :| zipWith f (a2 :| as) bs
+
+-- 1/∞
+instance Zip List1 ListInf List1 where
+  zipWith f (a :| as) (b :< bs) = f a b :| zipWith f as bs
+
+-- ∞/1
+instance Zip ListInf List1 List1 where
+  zipWith f (a :< as) (b :| bs) = f a b :| zipWith f as bs
+
+-- List2 instances
+
+-- 2/2
+instance Zip List2 List2 List2 where
+  zipWith = List2.zipWith
+  zip     = List2.zip
+
+-- 2/∞
+instance Zip List2 ListInf List2 where
+  zipWith f (List2 a1 a2 as) (b1 :< b2 :< bs) = List2 (f a1 b1) (f a2 b2) (zipWith f as bs)
+
+-- ∞/2
+instance Zip ListInf List2 List2 where
+  zipWith f (a1 :< a2 :< as) (List2 b1 b2 bs) = List2 (f a1 b1) (f a2 b2) (zipWith f as bs)
+
+-- ListInf instances
+
+-- ∞/∞
+instance Zip ListInf ListInf ListInf where
+  zipWith = ListInf.zipWith
+  zip     = ListInf.zip

--- a/stack-9.12.2.yaml
+++ b/stack-9.12.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2025-07-14
+resolver: nightly-2025-07-23
 compiler: ghc-9.12.2
 compiler-check: match-exact
 

--- a/stack-9.2.8.yaml
+++ b/stack-9.2.8.yaml
@@ -7,5 +7,5 @@ packages:
 - '.'
 
 extra-deps:
-- infinite-lists-0.1.2
+- infinite-list-0.1.2
 - pqueue-1.5.0.0

--- a/stack-9.2.8.yaml
+++ b/stack-9.2.8.yaml
@@ -7,4 +7,5 @@ packages:
 - '.'
 
 extra-deps:
+- infinite-lists-0.1.2
 - pqueue-1.5.0.0

--- a/stack-9.4.8.yaml
+++ b/stack-9.4.8.yaml
@@ -13,5 +13,5 @@ flags:
     win32-2-13-1: false
 
 extra-deps:
-- infinite-lists-0.1.2
+- infinite-list-0.1.2
 - pqueue-1.5.0.0

--- a/stack-9.4.8.yaml
+++ b/stack-9.4.8.yaml
@@ -13,4 +13,5 @@ flags:
     win32-2-13-1: false
 
 extra-deps:
+- infinite-lists-0.1.2
 - pqueue-1.5.0.0


### PR DESCRIPTION
I looked on where we used `repeat`...

- **Refactor: simplify `zip xs (repeat y)` to `map (,y) xs`**
  

- **Agda.Utils.ListInf,Zip : infinite lists and overloaded zipping**
  `repeat`, `iterate` and `cycle` generate actually infinite lists,
  so we utilize the `infinite-lists` package to track this.
  
  Since such infinite lists are often consumed by a `zip(With)`, we make `zip`
  and `zipWith` polymorphic to allow zipping of finite with infinite
  lists without cluttering the namespace.
  

- **Refactor: simplify (++ repeat _) followed by (!!)**
  

- **Refactor: use Agda.Utils.Function.iterate'**
  

- **Refactor: optimize Agda.Utils.Function.iterate'**
  

- **Refactor: new (takeExactly b n as) for (take n $ as ++ repeat b)**
  