### PR TITLE
[ opt ] Optimize free variable sets

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -1068,6 +1068,7 @@ test-suite agda-tests
       Internal.Utils.SmallSet
       Internal.Utils.Three
       Internal.Utils.Trie
+      Internal.Utils.VarSet
       LaTeXAndHTML.Tests
       LibSucceed.Tests
       Succeed.Tests
@@ -1083,6 +1084,7 @@ test-suite agda-tests
     , Agda
     , array
     , base
+    , binary
     , bytestring
     , containers
     , directory

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -489,6 +489,7 @@ library
     , filemanip            >= 0.3.6.3   && < 0.4
     , generic-data         >= 1.0.0.1   && < 1.2
     , ghc-compact          == 0.1.*
+    , ghc-bignum           >= 1.2       && < 2
     , gitrev               >= 1.3.1     && < 2
     , hashable             >= 1.4.2.0   && < 1.6
     , haskeline            >= 0.8.2     && < 0.9
@@ -846,6 +847,7 @@ library
       Agda.Utils.BiMap
       Agda.Utils.BoolSet
       Agda.Utils.Boolean
+      Agda.Utils.ByteArray
       Agda.Utils.CallStack
       Agda.Utils.Char
       Agda.Utils.Cluster
@@ -914,6 +916,7 @@ library
       Agda.Utils.Update
       Agda.Utils.VarSet
       Agda.Utils.WithDefault
+      Agda.Utils.Word
       Agda.Utils.Zip
       Agda.Utils.Zipper
       Agda.Version

--- a/src/full/Agda/Compiler/Treeless/Unused.hs
+++ b/src/full/Agda/Compiler/Treeless/Unused.hs
@@ -85,8 +85,7 @@ computeUnused q t = iterateUntilM (==) $ \ used -> do
     goAlt _ (TACon _ a b) = underBinders a <$> go b
 
     underBinder = underBinders 1
-    underBinders 0 = id
-    underBinders n = VarSet.filterGE 0 . VarSet.subtract n
+    underBinders n = VarSet.strengthen n
 
 stripUnusedArguments :: [ArgUsage] -> TTerm -> TTerm
 stripUnusedArguments used t = mkTLam m $ applySubst rho b

--- a/src/full/Agda/Compiler/Treeless/Unused.hs
+++ b/src/full/Agda/Compiler/Treeless/Unused.hs
@@ -5,7 +5,7 @@ module Agda.Compiler.Treeless.Unused
   , stripUnusedArguments
   ) where
 
-import Prelude hiding (zip, zipWith)
+import Prelude hiding (null, zip, zipWith)
 
 import Data.Maybe
 
@@ -20,6 +20,8 @@ import Agda.Compiler.Treeless.Pretty () -- instance only
 import Agda.Utils.Function ( iterateUntilM )
 import Agda.Utils.List     ( downFrom, takeExactly )
 import Agda.Utils.ListInf qualified as ListInf
+import Agda.Utils.Null
+import Agda.Utils.Singleton
 import qualified Agda.Utils.VarSet as VarSet
 import Agda.Utils.Zip
 
@@ -48,11 +50,11 @@ computeUnused q t = iterateUntilM (==) $ \ used -> do
            ]
   where
     go = \case
-      TVar x    -> pure $ VarSet.singleton x
-      TPrim{}   -> pure VarSet.empty
-      TDef{}    -> pure VarSet.empty
-      TLit{}    -> pure VarSet.empty
-      TCon{}    -> pure VarSet.empty
+      TVar x    -> pure $ singleton x
+      TPrim{}   -> pure empty
+      TDef{}    -> pure empty
+      TLit{}    -> pure empty
+      TCon{}    -> pure empty
 
       TApp (TDef f) ts -> do
         used <- fromMaybe [] <$> getCompiledArgUse f
@@ -70,10 +72,10 @@ computeUnused q t = iterateUntilM (==) $ \ used -> do
         case e of
           Erased{}    -> cont
           NotErased{} -> VarSet.insert x <$> cont
-      TUnit{}   -> pure VarSet.empty
-      TSort{}   -> pure VarSet.empty
-      TErased{} -> pure VarSet.empty
-      TError{}  -> pure VarSet.empty
+      TUnit{}   -> pure empty
+      TSort{}   -> pure empty
+      TErased{} -> pure empty
+      TError{}  -> pure empty
       TCoerce t -> go t
 
     goAlt _ (TALit _   b) = go b

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -51,6 +51,7 @@ import Agda.Utils.Maybe
 import Agda.Utils.Null
 import Agda.Utils.PartialOrd
 import Agda.Utils.POMonoid
+import Agda.Utils.Singleton
 import Agda.Utils.VarSet (VarSet)
 import qualified Agda.Utils.VarSet as VarSet
 
@@ -2408,7 +2409,7 @@ instance Semigroup FreeVariables where
   KnownFVs vs1 <> KnownFVs vs2 = KnownFVs (VarSet.union vs1 vs2)
 
 instance Monoid FreeVariables where
-  mempty  = KnownFVs VarSet.empty
+  mempty  = KnownFVs empty
   mappend = (<>)
 
 instance KillRange FreeVariables where
@@ -2425,7 +2426,7 @@ noFreeVariables :: FreeVariables
 noFreeVariables = mempty
 
 oneFreeVariable :: Int -> FreeVariables
-oneFreeVariable = KnownFVs . VarSet.singleton
+oneFreeVariable = KnownFVs . singleton
 
 freeVariablesFromList :: [Int] -> FreeVariables
 freeVariablesFromList = mconcat . map oneFreeVariable
@@ -2456,7 +2457,7 @@ hasNoFreeVariables :: LensFreeVariables a => a -> Bool
 hasNoFreeVariables x =
   case getFreeVariables x of
     UnknownFVs  -> False
-    KnownFVs fv -> VarSet.null fv
+    KnownFVs fv -> null fv
 
 ---------------------------------------------------------------------------
 -- * Argument decoration

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -51,6 +51,8 @@ import Agda.Utils.Maybe
 import Agda.Utils.Null
 import Agda.Utils.PartialOrd
 import Agda.Utils.POMonoid
+import Agda.Utils.VarSet (VarSet)
+import qualified Agda.Utils.VarSet as VarSet
 
 import Agda.Utils.Impossible
 
@@ -2397,16 +2399,16 @@ instance NFData BinderNameOrigin
 -- * Free variable annotations
 -----------------------------------------------------------------------------
 
-data FreeVariables = UnknownFVs | KnownFVs IntSet
+data FreeVariables = UnknownFVs | KnownFVs VarSet
   deriving (Eq, Ord, Show)
 
 instance Semigroup FreeVariables where
   UnknownFVs   <> _            = UnknownFVs
   _            <> UnknownFVs   = UnknownFVs
-  KnownFVs vs1 <> KnownFVs vs2 = KnownFVs (IntSet.union vs1 vs2)
+  KnownFVs vs1 <> KnownFVs vs2 = KnownFVs (VarSet.union vs1 vs2)
 
 instance Monoid FreeVariables where
-  mempty  = KnownFVs IntSet.empty
+  mempty  = KnownFVs VarSet.empty
   mappend = (<>)
 
 instance KillRange FreeVariables where
@@ -2423,7 +2425,7 @@ noFreeVariables :: FreeVariables
 noFreeVariables = mempty
 
 oneFreeVariable :: Int -> FreeVariables
-oneFreeVariable = KnownFVs . IntSet.singleton
+oneFreeVariable = KnownFVs . VarSet.singleton
 
 freeVariablesFromList :: [Int] -> FreeVariables
 freeVariablesFromList = mconcat . map oneFreeVariable
@@ -2454,7 +2456,7 @@ hasNoFreeVariables :: LensFreeVariables a => a -> Bool
 hasNoFreeVariables x =
   case getFreeVariables x of
     UnknownFVs  -> False
-    KnownFVs fv -> IntSet.null fv
+    KnownFVs fv -> VarSet.null fv
 
 ---------------------------------------------------------------------------
 -- * Argument decoration

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -2400,7 +2400,7 @@ instance NFData BinderNameOrigin
 -- * Free variable annotations
 -----------------------------------------------------------------------------
 
-data FreeVariables = UnknownFVs | KnownFVs VarSet
+data FreeVariables = UnknownFVs | KnownFVs !VarSet
   deriving (Eq, Ord, Show)
 
 instance Semigroup FreeVariables where

--- a/src/full/Agda/Syntax/Internal/SanityCheck.hs
+++ b/src/full/Agda/Syntax/Internal/SanityCheck.hs
@@ -4,7 +4,6 @@
 module Agda.Syntax.Internal.SanityCheck where
 
 import Control.Monad
-import qualified Data.IntSet as Set
 
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Free
@@ -14,11 +13,12 @@ import Agda.Utils.List ( dropEnd, initWithDefault )
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.Size
 import Agda.Utils.Impossible
+import qualified Agda.Utils.VarSet as VarSet
 
 
 sanityCheckVars :: (Pretty a, Free a) => Telescope -> a -> TCM ()
 sanityCheckVars tel v =
-  case filter bad (Set.toList $ allFreeVars v) of
+  case filter bad (VarSet.toAscList $ allFreeVars v) of
     [] -> return ()
     xs -> do
       alwaysReportSDoc "impossible" 1 . return $

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -360,9 +360,9 @@ withUsableVars :: UsableSizeVars a => a -> TerM b -> TerM b
 withUsableVars pats m = do
   vars <- usableSizeVars pats
   reportSLn "term.size" 70 $ "usableSizeVars = " ++ show vars
-  reportSDoc "term.size" 20 $ if null vars then "no usuable size vars" else
+  reportSDoc "term.size" 20 $ if VarSet.null vars then "no usuable size vars" else
     "the size variables amoung these variables are usable: " <+>
-      sep (map (prettyTCM . var) $ VarSet.toList vars)
+      sep (map (prettyTCM . var) $ VarSet.toAscList vars)
   terSetUsableVars vars $ m
 
 -- | Set 'terUseSizeLt' when going under constructor @c@.

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -14,7 +14,6 @@ import Data.IntMap (IntMap)
 
 import qualified Data.List   as List
 import qualified Data.IntMap as IntMap
-import qualified Data.IntSet as IntSet
 import qualified Data.Set    as Set
 
 import Agda.Syntax.Common
@@ -62,6 +61,7 @@ import qualified Agda.Utils.BoolSet as BoolSet
 import Agda.Utils.Size
 import Agda.Utils.Tuple
 import Agda.Utils.Unsafe ( unsafeComparePointers )
+import qualified Agda.Utils.VarSet as VarSet
 
 import Agda.Utils.Impossible
 
@@ -1356,7 +1356,7 @@ leqSort s1 s2 = do
     omegaInOmegaEnabled <- optOmegaInOmega <$> pragmaOptions
     let infInInf = typeInTypeEnabled || omegaInOmegaEnabled
 
-    let fvsRHS = (`IntSet.member` allFreeVars s2)
+    let fvsRHS = (`VarSet.member` allFreeVars s2)
     badRigid <- s1 `rigidVarsNotContainedIn` fvsRHS
 
     postponeIfBlocked $ case (s1, s2) of

--- a/src/full/Agda/TypeChecking/Free.hs
+++ b/src/full/Agda/TypeChecking/Free.hs
@@ -256,11 +256,11 @@ closed t = getAll $ runFree (const $ All False) IgnoreNot t
 
 -- | Collect all free variables.
 allFreeVars :: Free t => t -> VarSet
-allFreeVars = runFree VarSet.singleton IgnoreNot
+allFreeVars = runFree singleton IgnoreNot
 
 -- | Collect all relevant free variables, possibly ignoring sorts.
 allRelevantVarsIgnoring :: Free t => IgnoreSorts -> t -> VarSet
-allRelevantVarsIgnoring ig = getRelevantIn . runFree (RelevantIn . VarSet.singleton) ig
+allRelevantVarsIgnoring ig = getRelevantIn . runFree (RelevantIn . singleton) ig
 
 -- | Collect all relevant free variables, excluding the "unused" ones.
 allRelevantVars :: Free t => t -> VarSet

--- a/src/full/Agda/TypeChecking/Free.hs
+++ b/src/full/Agda/TypeChecking/Free.hs
@@ -63,8 +63,6 @@ module Agda.TypeChecking.Free
 import Prelude hiding (null)
 
 import Data.Semigroup ( Semigroup, (<>), Any(..), All(..) )
-import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 
@@ -81,12 +79,13 @@ import Agda.TypeChecking.Free.Lazy
   -- , IsVarSet(..), runFreeM
   -- )
 
+import Agda.Utils.VarSet (VarSet)
+import qualified Agda.Utils.VarSet as VarSet
 import Agda.Utils.Singleton
 
 ---------------------------------------------------------------------------
 -- * Simple variable set implementations.
 
-type VarSet = IntSet
 
 -- In most cases we don't care about the VarOcc.
 
@@ -257,11 +256,11 @@ closed t = getAll $ runFree (const $ All False) IgnoreNot t
 
 -- | Collect all free variables.
 allFreeVars :: Free t => t -> VarSet
-allFreeVars = runFree IntSet.singleton IgnoreNot
+allFreeVars = runFree VarSet.singleton IgnoreNot
 
 -- | Collect all relevant free variables, possibly ignoring sorts.
 allRelevantVarsIgnoring :: Free t => IgnoreSorts -> t -> VarSet
-allRelevantVarsIgnoring ig = getRelevantIn . runFree (RelevantIn . IntSet.singleton) ig
+allRelevantVarsIgnoring ig = getRelevantIn . runFree (RelevantIn . VarSet.singleton) ig
 
 -- | Collect all relevant free variables, excluding the "unused" ones.
 allRelevantVars :: Free t => t -> VarSet
@@ -271,7 +270,7 @@ allRelevantVars = allRelevantVarsIgnoring IgnoreNot
 -- * Backwards-compatible interface to 'freeVars'.
 
 filterVarMap :: (VarOcc -> Bool) -> VarMap -> VarSet
-filterVarMap f = IntMap.keysSet . IntMap.filter f . theVarMap
+filterVarMap f = VarSet.fromList . IntMap.keys . IntMap.filter f . theVarMap
 
 filterVarMapToList :: (VarOcc -> Bool) -> VarMap -> [Variable]
 filterVarMapToList f = map fst . filter (f . snd) . IntMap.toList . theVarMap
@@ -318,4 +317,4 @@ flexibleVars (VarMap m) = (`IntMap.mapMaybe` m) $ \case
 --irrelevantVars = filterVarMap isIrrelevant
 
 allVars :: VarMap -> VarSet
-allVars = IntMap.keysSet . theVarMap
+allVars = VarSet.fromList . IntMap.keys . theVarMap

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -7,6 +7,7 @@ module Agda.TypeChecking.Free.Precompute
 
 import Control.Monad.Writer ( Writer, runWriter, censor, listen, tell )
 
+import Agda.Utils.Singleton
 import Agda.Utils.VarSet (VarSet)
 import qualified Agda.Utils.VarSet as VarSet
 
@@ -57,7 +58,7 @@ instance PrecomputeFreeVars Term where
   precomputeFreeVars t =
     case t of
       Var x es -> do
-        tell (VarSet.singleton x)
+        tell (singleton x)
         Var x <$> precomputeFreeVars es
       Lam i b    -> Lam i      <$> precomputeFreeVars b
       Lit{}      -> pure t

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -50,7 +50,7 @@ instance PrecomputeFreeVars a => PrecomputeFreeVars (Dom a) where
 instance PrecomputeFreeVars a => PrecomputeFreeVars (Abs a) where
   precomputeFreeVars (NoAbs x b) = NoAbs x <$> precomputeFreeVars b
   precomputeFreeVars (Abs x b) =
-    censor (VarSet.subtract 1 . VarSet.delete 0) $
+    censor (VarSet.strengthen 1) $
       Abs x <$> precomputeFreeVars b
 
 instance PrecomputeFreeVars Term where

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -121,7 +121,6 @@ import Prelude hiding (null)
 import Control.Monad.Except ( MonadError(..) )
 
 import Data.Bifunctor (first)
-import qualified Data.IntSet as IntSet
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Map (Map)
@@ -169,6 +168,7 @@ import Agda.Utils.Null
 import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Size
 import Agda.Utils.Permutation
+import qualified Agda.Utils.VarSet as VarSet
 
 -- | Generalize a telescope over a set of generalizable variables.
 generalizeTelescope :: Map QName Name -> (forall a. (Telescope -> TCM a) -> TCM a) -> ([Maybe Name] -> Telescope -> TCM a) -> TCM a
@@ -561,7 +561,7 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
         -- and we need to get rid of the dependency on Δ.
 
         -- We can only do this if A does not depend on Δ, so check this first.
-        case IntSet.minView (allFreeVars _A) of
+        case VarSet.minView (allFreeVars _A) of
           Just (j, _) | j < i -> prepruneErrorCyclicDependencies x
           _                   -> return ()
 
@@ -715,13 +715,13 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
     findGenRec mv = do
       cxt <- instantiateFull =<< getContext
       let n         = length cxt
-          notPruned = IntSet.fromList $
+          notPruned = VarSet.fromList $
                       permute (takeP n $ mvPermutation mv) $
                       downFrom n
       case [ i
            | (i, CtxVar _ (Dom{unDom = (El _ (Def q _))})) <- zip [0..] cxt
            , q == genRecName
-           , i `IntSet.member` notPruned
+           , i `VarSet.member` notPruned
            ] of
         []    -> return Nothing
         _:_:_ -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -9,6 +9,9 @@ module Agda.TypeChecking.Lock
   )
 where
 
+import Prelude hiding (null)
+import qualified Prelude as Prelude
+
 import qualified Data.IntMap as IMap
 import qualified Data.Set as Set
 
@@ -28,6 +31,7 @@ import Agda.Utils.VarSet (VarSet)
 import Agda.Utils.Functor
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
+import Agda.Utils.Null
 import Agda.Utils.Size
 
 checkLockedVars
@@ -82,7 +86,7 @@ checkLockedVars t ty lk lk_ty = catchConstraint (CheckLockedVars t ty lk lk_ty) 
     illegalVars = rigid `VarSet.difference` allowedVars
     -- flexVars = flexibleVars fv
     -- blockingMetas = map (`lookupVarMap` flexVars) (ISet.toList $ termVars ISet.\\ allowedVars)
-  if VarSet.null illegalVars then  -- only flexible vars are infringing
+  if null illegalVars then  -- only flexible vars are infringing
     -- TODO: be more precise about which metas
     -- flexVars = flexibleVars fv
     -- blockingMetas = map (`lookupVarMap` flexVars) (ISet.toList $ termVars ISet.\\ allowedVars)

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -10,7 +10,6 @@ module Agda.TypeChecking.Lock
 where
 
 import qualified Data.IntMap as IMap
-import qualified Data.IntSet as ISet
 import qualified Data.Set as Set
 
 import Agda.Syntax.Common
@@ -24,7 +23,8 @@ import Agda.TypeChecking.Substitute.Class
 import Agda.TypeChecking.Free
 
 import qualified Agda.Utils.List1 as List1
-import qualified Agda.Utils.VarSet as VSet
+import qualified Agda.Utils.VarSet as VarSet
+import Agda.Utils.VarSet (VarSet)
 import Agda.Utils.Functor
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
@@ -67,28 +67,28 @@ checkLockedVars t ty lk lk_ty = catchConstraint (CheckLockedVars t ty lk lk_ty) 
     rigid = rigidVars fv
     -- flexible = IMap.keysSet $ flexibleVars fv
     termVars = allVars fv -- ISet.union rigid flexible
-    earlierVars = ISet.fromList [i + 1 .. size cxt - 1]
-  if termVars `ISet.isSubsetOf` earlierVars then return () else do
+    earlierVars = VarSet.range i (size cxt)
+  if termVars `VarSet.isSubsetOf` earlierVars then return () else do
 
   checked <- fmap catMaybes . forM toCheck $ \ (j,ce) -> do
     ifM (isTimeless (ctxEntryType ce))
         (return $ Just j)
         (return $ Nothing)
 
-  let allowedVars = ISet.union earlierVars (ISet.fromList checked)
+  let allowedVars = VarSet.union earlierVars (VarSet.fromList checked)
 
-  if termVars `ISet.isSubsetOf` allowedVars then return () else do
+  if termVars `VarSet.isSubsetOf` allowedVars then return () else do
   let
-    illegalVars = rigid ISet.\\ allowedVars
+    illegalVars = rigid `VarSet.difference` allowedVars
     -- flexVars = flexibleVars fv
     -- blockingMetas = map (`lookupVarMap` flexVars) (ISet.toList $ termVars ISet.\\ allowedVars)
-  if ISet.null illegalVars then  -- only flexible vars are infringing
+  if VarSet.null illegalVars then  -- only flexible vars are infringing
     -- TODO: be more precise about which metas
     -- flexVars = flexibleVars fv
     -- blockingMetas = map (`lookupVarMap` flexVars) (ISet.toList $ termVars ISet.\\ allowedVars)
     patternViolation alwaysUnblock
   else
-    typeError $ ReferencesFutureVariables t (List1.fromList (ISet.toList illegalVars)) lk i
+    typeError $ ReferencesFutureVariables t (List1.fromList (VarSet.toAscList illegalVars)) lk i
     -- List1.fromList is guarded by not (null illegalVars)
 
 
@@ -110,7 +110,7 @@ getLockVar lk = do
       -- We should not block on solved metas, so we need @lk@ to be fully instantiated,
       -- otherwise it may mention solved metas which end up here.
 
-  is <- filterM isLock $ ISet.toList $ rigidVars fv
+  is <- filterM isLock $ VarSet.toAscList $ rigidVars fv
 
   -- Out of the lock variables that appear in @lk@ the one in the
   -- left-most position in the context is what will determine the
@@ -131,8 +131,8 @@ isTimeless t = do
 -- | If the first argument is a lock variable, check that all variables in the given set
 --   are either earlier than this variable or are timeless.
 --
-checkEarlierThan :: Term -> VSet.VarSet -> TCM Bool
+checkEarlierThan :: Term -> VarSet -> TCM Bool
 checkEarlierThan lk fvs = do
   getLockVar lk >>= \case
     Nothing -> return True
-    Just i  -> allM (isTimeless <=< typeOfBV) $ filter (<= i) $ VSet.toList fvs
+    Just i  -> allM (isTimeless <=< typeOfBV) $ filter (<= i) $ VarSet.toAscList fvs

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -9,7 +9,6 @@ import Prelude hiding (null)
 import Control.Monad.Except ( MonadError(..), ExceptT, runExceptT )
 import Control.Monad.Trans.Maybe
 
-import qualified Data.IntSet as IntSet
 import qualified Data.IntMap as IntMap
 import qualified Data.List as List
 import qualified Data.Map.Strict as MapS
@@ -1027,7 +1026,7 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
       -- we'll build solutions where the irrelevant terms are not valid
       let fvs = allFreeVars v
       reportSDoc "tc.meta.assign" 20 $
-        "fvars rhs:" <+> sep (map (text . show) $ VarSet.toList fvs)
+        "fvars rhs:" <+> sep (map (text . show) $ VarSet.toAscList fvs)
 
       -- Check that the arguments are variables
       mids <- do
@@ -1080,7 +1079,7 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
               case getLock (getArgInfo d) of
                 IsNotLock -> pure ()
                 IsLock{} -> do
-                let us = IntSet.unions $ map snd $ filter (earlierThan i . fst) idvars
+                let us = VarSet.unions $ map snd $ filter (earlierThan i . fst) idvars
                 -- us Earlier than u
                 unlessM (addContext tel' $ checkEarlierThan u us) $
                   patternViolation (unblockOnMeta x)  -- If the earlier check hard-fails we need to

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -15,7 +15,7 @@
 
 module Agda.TypeChecking.MetaVars.Occurs where
 
-import Prelude hiding (zip, zipWith)
+import Prelude hiding (null, zip, zipWith)
 
 import Control.Monad.Except ( ExceptT, runExceptT, catchError, throwError )
 import Control.Monad.Reader ( ReaderT, runReaderT, ask, asks, local )
@@ -55,6 +55,7 @@ import Agda.Utils.List (downFrom)
 import Agda.Utils.ListInf qualified as ListInf
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
+import Agda.Utils.Null
 import Agda.Utils.Permutation
 import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Utils.Size
@@ -971,7 +972,7 @@ killedType args b = do
     --          ys ⊆ xs are the variables that were dropped from Δ
     --          B' = strengthen ys B
     go :: (MonadReduce m) => [Dom (ArgName, Type)] -> VarSet -> Type -> m (VarSet, Type)
-    go [] xs b | VarSet.null xs = return (xs, b)
+    go [] xs b | null xs = return (xs, b)
                | otherwise      = __IMPOSSIBLE__
     go (arg : args) xs b  -- go (Δ (x : A)) xs B, (x = deBruijn index 0)
       | VarSet.member 0 xs = do
@@ -997,7 +998,7 @@ killedType args b = do
           return (VarSet.weaken 1 zs, b)
 
 reallyNotFreeIn :: (MonadReduce m) => VarSet -> Type -> m (VarSet, Type)
-reallyNotFreeIn xs a | VarSet.null xs = return (xs, a) -- Shortcut
+reallyNotFreeIn xs a | null xs = return (xs, a) -- Shortcut
 reallyNotFreeIn xs a = do
   let fvs      = freeVars a
       anywhere = allVars fvs

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -35,8 +35,6 @@ import Data.Function (on)
 import Data.Word (Word64, Word32)
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
-import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
 import qualified Data.List as List
 import Data.Maybe
 import Data.Map (Map)
@@ -146,6 +144,8 @@ import Agda.Utils.Set1 (Set1)
 import Agda.Utils.Singleton
 import Agda.Utils.Tuple (Pair)
 import Agda.Utils.Update
+import qualified Agda.Utils.VarSet as VarSet
+import Agda.Utils.VarSet (VarSet)
 
 import Agda.Utils.Impossible
 
@@ -5598,8 +5598,8 @@ data InductionAndEta = InductionAndEta
 -- Reason, why rewrite rule is invalid
 data IllegalRewriteRuleReason
   = LHSNotDefinitionOrConstructor
-  | VariablesNotBoundByLHS IntSet
-  | VariablesBoundMoreThanOnce IntSet
+  | VariablesNotBoundByLHS VarSet
+  | VariablesBoundMoreThanOnce VarSet
   | LHSReduces Term Term
   | HeadSymbolIsProjectionLikeFunction QName
   | HeadSymbolIsTypeConstructor QName

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -23,8 +23,6 @@ import Control.Monad ( guard, filterM, forM, (<=<) )
 import Data.Char ( toLower )
 import qualified Data.Foldable as Fold
 import Data.Function (on)
-import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
 import qualified Data.List as List
 import Data.Maybe
 import Data.Set (Set)
@@ -78,6 +76,7 @@ import Agda.Utils.Null
 import Agda.Utils.Singleton
 import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.WithDefault  ( pattern Value )
+import qualified Agda.Utils.VarSet as VarSet
 
 import Agda.Utils.Impossible
 
@@ -392,12 +391,12 @@ prettyWarning = \case
       VariablesNotBoundByLHS xs -> hsep
         [ prettyTCM q
         , " is not a legal rewrite rule, since the following variables are not bound by the left hand side: "
-        , prettyList_ (map (prettyTCM . var) $ IntSet.toList xs)
+        , prettyList_ (map (prettyTCM . var) $ VarSet.toAscList xs)
         ]
       VariablesBoundMoreThanOnce xs -> do
         (prettyTCM q
           <+> " is not a legal rewrite rule, since the following parameters are bound more than once on the left hand side: "
-          <+> hsep (List.intersperse "," $ map (prettyTCM . var) $ IntSet.toList xs))
+          <+> hsep (List.intersperse "," $ map (prettyTCM . var) $ VarSet.toAscList xs))
           <> ". Perhaps you can use a postulate instead of a constructor as the head symbol?"
       LHSReduces v v' -> fsep
         [ prettyTCM q <+> " is not a legal rewrite rule, since the left-hand side "

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -81,6 +81,7 @@ import Agda.Syntax.Common.Pretty
 import Agda.Utils.Size
 import Agda.Utils.Zipper
 import qualified Agda.Utils.SmallSet as SmallSet
+import qualified Agda.Utils.VarSet as VarSet
 
 import Agda.Utils.Impossible
 
@@ -776,7 +777,7 @@ elimsToSpine env es = do
 trimEnvironment :: FreeVariables -> Env s -> Env s
 trimEnvironment UnknownFVs env = env
 trimEnvironment (KnownFVs fvs) env
-  | IntSet.null fvs = emptyEnv
+  | VarSet.null fvs = emptyEnv
     -- Environment trimming is too expensive (costs 50% on some benchmarks), and while it does make
     -- some cases run in constant instead of linear space you need quite contrived examples to
     -- notice the effect.
@@ -785,7 +786,7 @@ trimEnvironment (KnownFVs fvs) env
     -- Important: strict enough that the trimming actually happens
     trim _ [] = []
     trim i (p : ps)
-      | IntSet.member i fvs = (p :)             $! trim (i + 1) ps
+      | VarSet.member i fvs = (p :)             $! trim (i + 1) ps
       | otherwise           = (unusedPointer :) $! trim (i + 1) ps
 
 -- | Build an environment for a body with some given free variables from a spine of arguments.

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -35,7 +35,7 @@ Some other tricks that improves performance:
 module Agda.TypeChecking.Reduce.Fast
   ( fastReduce, fastNormalise ) where
 
-import Prelude hiding ((!!))
+import Prelude hiding ((!!), null)
 
 import Control.Applicative hiding (empty)
 import Control.Monad.ST
@@ -75,7 +75,7 @@ import Agda.Utils.Lens
 import Agda.Utils.List
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
-import Agda.Utils.Null (empty)
+import Agda.Utils.Null (empty, null)
 import Agda.Utils.Functor
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.Size
@@ -777,7 +777,7 @@ elimsToSpine env es = do
 trimEnvironment :: FreeVariables -> Env s -> Env s
 trimEnvironment UnknownFVs env = env
 trimEnvironment (KnownFVs fvs) env
-  | VarSet.null fvs = emptyEnv
+  | null fvs = emptyEnv
     -- Environment trimming is too expensive (costs 50% on some benchmarks), and while it does make
     -- some cases run in constant instead of linear space you need quite contrived examples to
     -- notice the effect.

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -31,8 +31,6 @@ import Control.Monad.State  ( MonadState, StateT, runStateT )
 import Data.Maybe
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
-import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
@@ -55,12 +53,13 @@ import Agda.Utils.Either
 import Agda.Utils.Function (applyWhen)
 import Agda.Utils.Functor
 import Agda.Utils.Lens
-import Agda.Utils.List
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Utils.Permutation
 import Agda.Utils.Size
+import qualified Agda.Utils.VarSet as VarSet
+import Agda.Utils.VarSet (VarSet)
 
 import Agda.Utils.Impossible
 
@@ -299,10 +298,10 @@ instance Match NLPat Term where
     case p of
       PVar i bvs -> traceSDoc "rewriting.match" 60 ("matching a PVar: " <+> text (show i)) $ do
         let vars = map unArg bvs
-        let allowedVars :: IntSet
-            allowedVars = IntSet.fromList vars
-            badVars :: IntSet
-            badVars = IntSet.difference (IntSet.fromList (downFrom n)) allowedVars
+        let allowedVars :: VarSet
+            allowedVars = VarSet.fromList vars
+            badVars :: VarSet
+            badVars = VarSet.complement n allowedVars
             perm :: Permutation
             perm = Perm n $ reverse vars
             tel :: Telescope

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -255,21 +255,21 @@ instance NLPatVars NLPType where
 instance NLPatVars NLPSort where
   nlPatVarsUnder k = \case
     PUniv _ l   -> nlPatVarsUnder k l
-    PInf f n  -> VarSet.empty
-    PSizeUniv -> VarSet.empty
-    PLockUniv -> VarSet.empty
-    PLevelUniv -> VarSet.empty
-    PIntervalUniv -> VarSet.empty
+    PInf f n  -> empty
+    PSizeUniv -> empty
+    PLockUniv -> empty
+    PLevelUniv -> empty
+    PIntervalUniv -> empty
 
 instance NLPatVars NLPat where
   nlPatVarsUnder k = \case
-      PVar i _  -> VarSet.singleton $ i - k
+      PVar i _  -> singleton $ i - k
       PDef _ es -> nlPatVarsUnder k es
       PLam _ p  -> nlPatVarsUnder k p
       PPi a b   -> nlPatVarsUnder k (a, b)
       PSort s   -> nlPatVarsUnder k s
       PBoundVar _ es -> nlPatVarsUnder k es
-      PTerm{}   -> VarSet.empty
+      PTerm{}   -> empty
 
 instance (NLPatVars a, NLPatVars b) => NLPatVars (a,b) where
   nlPatVarsUnder k (a,b) = nlPatVarsUnder k a `mappend` nlPatVarsUnder k b

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -727,7 +727,7 @@ checkArgumentsE'
 
                       -- Is any free variable in tgt less than
                       -- visiblePis?
-                  let dep = not (VarSet.null freeInTgt)
+                  let dep = not (null freeInTgt)
                   -- The target must be non-dependent.
                   if dep then return s else do
 

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -71,6 +71,7 @@ import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty ( prettyShow )
 import Agda.Utils.Size
 import Agda.Utils.Tuple
+import qualified Agda.Utils.VarSet as VarSet
 
 import Agda.Utils.Impossible
 import Agda.Utils.Singleton (singleton)
@@ -699,7 +700,7 @@ checkArgumentsE'
 
                   -- The free variables less than visiblePis in tgt.
                   freeInTgt =
-                    fst $ IntSet.split visiblePis $ freeVars tgt
+                    fst $ VarSet.split visiblePis $ freeVars tgt
 
               rigid <- isRigid s tgt
               -- The target must be rigid.
@@ -714,7 +715,7 @@ checkArgumentsE'
                     Permanent   -> skip 0
                     Unspecified -> dontSkip
                     AVar x      ->
-                      if x `IntSet.member` freeInTgt
+                      if x `VarSet.member` freeInTgt
                       then skip x
                       else skip 0
                 IsRigid -> do
@@ -726,7 +727,7 @@ checkArgumentsE'
 
                       -- Is any free variable in tgt less than
                       -- visiblePis?
-                  let dep = not (IntSet.null freeInTgt)
+                  let dep = not (VarSet.null freeInTgt)
                   -- The target must be non-dependent.
                   if dep then return s else do
 

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -132,7 +132,6 @@ import Control.Monad.Except ( runExceptT )
 
 import Data.Semigroup hiding (Arg)
 import qualified Data.List as List
-import qualified Data.IntSet as IntSet
 import qualified Data.IntMap as IntMap
 import Data.IntMap (IntMap)
 
@@ -172,8 +171,9 @@ import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import Agda.Utils.PartialOrd
-import Agda.Utils.Singleton
 import Agda.Utils.Size
+import Agda.Utils.Singleton
+import qualified Agda.Utils.VarSet as VarSet
 
 import Agda.Utils.Impossible
 
@@ -940,7 +940,7 @@ patternBindingForcedVars forced v = do
   let v' = precomputeFreeVars_ v
   runWriterT (evalStateT (go unitModality v') forced)
   where
-    noForced v = gets $ IntSet.disjoint (precomputedFreeVars v) . IntMap.keysSet
+    noForced v = gets $ VarSet.disjoint (precomputedFreeVars v) . VarSet.fromList . IntMap.keys
 
     bind md i = do
       gets (IntMap.lookup i) >>= \case

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -79,7 +79,7 @@ import Agda.Utils.Impossible
 -- 32-bit machines). Word64 does not have these problems.
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20250715 * 10 + 0
+currentInterfaceVersion = 20250729 * 10 + 0
 
 -- | The result of 'encode' and 'encodeInterface'.
 
@@ -97,40 +97,37 @@ data Encoded = Encoded
 encode :: EmbPrj a => a -> TCM Encoded
 encode a = do
     collectStats <- hasProfileOption Profile.Serialize
-    newD@(Dict nD ltD stD bD iD dD
-      _nameD
-      _qnameD
-      nC ltC stC bC iC dC tC
-      nameC
-      qnameC
-      stats _) <- liftIO $ emptyDict collectStats
-    root <- liftIO $ (`runReaderT` newD) $ icode a
-    nL  <- benchSort $ l nD
-    stL <- benchSort $ l stD
-    ltL <- benchSort $ l ltD
-    bL  <- benchSort $ l bD
-    iL  <- benchSort $ l iD
-    dL  <- benchSort $ l dD
+    !newD <- liftIO $ emptyDict collectStats
+    root     <- liftIO $ (`runReaderT` newD) $ icode a
+    nodeL    <- benchSort $ l (nodeD newD)
+    stringL  <- benchSort $ l (stringD newD)
+    lTextL   <- benchSort $ l (lTextD newD)
+    sTextL   <- benchSort $ l (sTextD newD)
+    integerL <- benchSort $ l (integerD newD)
+    varSetL <- benchSort $ l (varSetD newD)
+    doubleL  <- benchSort $ l (doubleD newD)
+
     -- Record reuse statistics.
     whenProfile Profile.Sharing $ do
-      statistics "pointers" tC
+      statistics "pointers" (termC newD)
     whenProfile Profile.Serialize $ do
-      statistics "Integer"     iC
-      statistics "Lazy Text"   ltC
-      statistics "Strict Text" stC
-      statistics "Text"        bC
-      statistics "Double"      dC
-      statistics "Node"        nC
-      statistics "Shared Term" tC
-      statistics "A.QName"     qnameC
-      statistics "A.Name"      nameC
+      statistics "Integer"     (integerC newD)
+      statistics "VarSet"      (varSetC newD)
+      statistics "Lazy Text"   (lTextC newD)
+      statistics "Strict Text" (sTextC newD)
+      statistics "String"      (stringC newD)
+      statistics "Double"      (doubleC newD)
+      statistics "Node"        (nodeC newD)
+      statistics "Shared Term" (termC newD)
+      statistics "A.QName"     (qnameC newD)
+      statistics "A.Name"      (nameC newD)
     when collectStats $ do
       stats <- map (second fromIntegral) <$> do
-        liftIO $ List.sort <$> H.toList stats
+        liftIO $ List.sort <$> H.toList (stats newD)
       traverse_ (uncurry tickN) stats
     -- Encode hashmaps and root, and compress.
     bits1 <- Bench.billTo [ Bench.Serialization, Bench.BinaryEncode ] $
-      return $!! B.encode (root, nL, ltL, stL, bL, iL, dL)
+      return $!! B.encode (root, nodeL, stringL, lTextL, sTextL, integerL, varSetL, doubleL)
     let compressParams = G.defaultCompressParams
           { G.compressLevel    = G.bestSpeed
           , G.compressStrategy = G.huffmanOnlyStrategy
@@ -209,13 +206,23 @@ decode s = do
   -- such errors can be caught by the handler here.
 
   res <- liftIO $ E.handle (\(E.ErrorCall s) -> pure $ Left s) $ do
-    ((r, nL, ltL, stL, bL, iL, dL), s, _) <- return $ runGetState B.get s 0
+    ((r, nodeL, stringL, lTextL, sTextL, integerL, varSetL, doubleL), s, _) <- return $ runGetState B.get s 0
     let ar = unListLike
     when (not (null s)) $ E.throwIO $ E.ErrorCall "Garbage at end."
-    let nL' = ar nL
-    st <- St nL' (ar ltL) (ar stL) (ar bL) (ar iL) (ar dL)
-            <$> liftIO (newArray (bounds nL') MEEmpty)
-            <*> return mf <*> return incs
+    let nodeA = ar nodeL
+    nm <- liftIO (newArray (bounds nodeA) MEEmpty)
+    let st = St
+          { nodeE = nodeA
+          , stringE = ar stringL
+          , lTextE = ar lTextL
+          , sTextE = ar sTextL
+          , integerE = ar integerL
+          , varSetE = ar varSetL
+          , doubleE = ar doubleL
+          , nodeMemo = nm
+          , modFile = mf
+          , includes = incs
+          }
     (r, st) <- runStateT (value r) st
     let !mf = modFile st
     return $ Right (mf, r)

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -61,6 +61,8 @@ import Agda.Utils.Set1 (Set1)
 import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Trie (Trie(..))
 import Agda.Utils.WithDefault
+import Agda.Utils.VarSet (VarSet(..))
+import qualified Agda.Utils.VarSet as VarSet
 
 import Agda.Utils.Impossible
 import Agda.Utils.CallStack
@@ -80,6 +82,10 @@ instance EmbPrj T.Text where
 instance EmbPrj Integer where
   icod_   = icodeInteger
   value i = (! i) <$!> gets integerE
+
+instance EmbPrj VarSet where
+  icod_   = icodeVarSet
+  value i = (! i) <$!> gets varSetE
 
 instance EmbPrj Word64 where
   icod_ i = icodeN' (undefined :: Word32 -> Word32 -> Word32) (word32 q) (word32 r)

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -183,6 +183,8 @@ permuteContext perm ctx = permuteTel perm $ contextToTel ctx
 
 -- | Recursively computes dependencies of a set of variables in a given
 --   telescope. Any dependencies outside of the telescope are ignored.
+--
+--   Note that 'varDependencies' considers a variable to depend on itself.
 varDependencies :: Telescope -> VarSet -> VarSet
 varDependencies tel = addLocks . allDependencies VarSet.empty
   where
@@ -212,6 +214,8 @@ varDependencies tel = addLocks . allDependencies VarSet.empty
 --   one of the variables in the given set (including recursive
 --   dependencies). Any dependencies outside of the telescope are
 --   ignored.
+--
+--   Unlike 'varDependencies', a variable is *not* considered to depend on itself.
 varDependents :: Telescope -> VarSet -> VarSet
 varDependents tel = allDependents
   where

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -32,6 +32,7 @@ import Agda.Utils.Functor
 import Agda.Utils.List
 import Agda.Utils.Null
 import Agda.Utils.Permutation
+import Agda.Utils.Singleton
 import Agda.Utils.Size
 import Agda.Utils.Tuple
 import Agda.Utils.VarSet (VarSet)
@@ -213,7 +214,7 @@ varDependencies tel = addLocks . allDependencies tel
           s
 
     allDependencies :: Telescope -> VarSet -> VarSet
-    allDependencies tel vs = loop VarSet.empty (flattenRevTel tel) (-1) vs
+    allDependencies tel vs = loop empty (flattenRevTel tel) (-1) vs
       where
         -- Idea here is to keep a set @work@ of variables that we still need
         -- to get deps of. At each iteration, we skip backwards through the telescope
@@ -241,7 +242,7 @@ varDependencies tel = addLocks . allDependencies tel
 --   Unlike 'varDependencies', a variable is *not* considered to depend on itself.
 varDependents :: Telescope -> VarSet -> VarSet
 varDependents tel vs =
-  loop VarSet.empty (flattenTel tel) (size tel - 1) vs
+  loop empty (flattenTel tel) (size tel - 1) vs
   where
     -- Idea here is to keep a set @work@ of variables that we
     -- want to find dependents of. At each iteration, we walk forwards through
@@ -365,7 +366,7 @@ instantiateTelescope tel k p = guard ok $> (tel', sigma, rho)
     -- is0 is the part of Γ that is needed to type u
     is0   = varDependencies tel $ allFreeVars u
     -- is1 is the part of Γ that depends on variable j
-    is1   = varDependents tel $ VarSet.singleton j
+    is1   = varDependents tel $ singleton j
     -- lasti is the last (rightmost) variable of is0
     lasti = fromMaybe n $ VarSet.lookupMin is0
     -- we move each variable in is1 to the right until it comes after

--- a/src/full/Agda/Utils/ByteArray.hs
+++ b/src/full/Agda/Utils/ByteArray.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+-- | Utilities for working with 'ByteArray' and 'ByteArray#'.
+module Agda.Utils.ByteArray
+  (
+  -- * Constructing byte arrays
+    byteArrayOnes#
+  -- * Queries
+  , byteArrayIsSubsetOf#
+  , byteArrayDisjoint#
+  -- * Folds
+  --
+  -- $byteArrayFolds
+  , byteArrayFoldrBits#
+  , byteArrayFoldlBits#
+  -- ** Strict folds
+  , byteArrayFoldrBitsStrict#
+  , byteArrayFoldlBitsStrict#
+  ) where
+
+-- We need the machines word size for some bitwise operations.
+#include "MachDeps.h"
+
+import GHC.Base
+import GHC.Num.WordArray
+
+import Agda.Utils.Word
+
+--------------------------------------------------------------------------------
+-- Constructing byte arrays
+
+-- | Construct a 'ByteArray#' consisting of @n@ 1 bits.
+byteArrayOnes# :: Int# -> ByteArray#
+byteArrayOnes# n =
+  let !(# q, r #) = quotRemInt# n WORD_SIZE_IN_BITS# in
+  if isTrue# (r ==# 0#) then
+    withNewWordArray# q \mwa st ->
+      byteArrayFillOnes# mwa 0# q st
+  else
+    withNewWordArray# (q +# 1#) \mwa st ->
+      let st' = byteArrayFillOnes# mwa 0# q st
+      in mwaWrite# mwa q (uncheckedWordOnes# r) st'
+{-# NOINLINE byteArrayOnes# #-}
+
+-- | @byteArrayFillOnes# mwa start end st@ will fill a 'MutableByteArray#' with
+-- ones from @start@ to @end - 1@.
+byteArrayFillOnes# :: MutableByteArray# s -> Int# -> Int# -> State# s -> State# s
+byteArrayFillOnes# bs i len st =
+  if isTrue# (i <# len) then
+    let st' = mwaWrite# bs i (not# 0##) st
+    in byteArrayFillOnes# bs (i +# 1#) len st'
+  else
+    st
+
+--------------------------------------------------------------------------------
+-- Queries
+
+-- | Check that if the set bits of a 'ByteArray#' are a subset
+-- of another 'ByteArray#'.
+byteArrayIsSubsetOf# :: ByteArray# -> ByteArray# -> Int#
+byteArrayIsSubsetOf# bs1 bs2 =
+  if isTrue# (len1 <=# len2) then
+    loop 0#
+  else
+    0#
+  where
+    len1 = wordArraySize# bs1
+    len2 = wordArraySize# bs2
+
+    loop :: Int# -> Int#
+    loop i =
+      if isTrue# (i <# len1) then
+        let w1 = indexWordArray# bs1 i
+            w2 = indexWordArray# bs2 i
+        in if isTrue# ((w1 `and#` w2) `eqWord#` w1) then
+          loop (i +# 1#)
+        else
+          0#
+      else
+        1#
+{-# NOINLINE byteArrayIsSubsetOf# #-}
+
+-- | Check if two 'ByteArray#'s are bitwise disjoint.
+byteArrayDisjoint# :: ByteArray# -> ByteArray# -> Int#
+byteArrayDisjoint# bs1 bs2 =
+  let len1 = wordArraySize# bs1
+      len2 = wordArraySize# bs2
+  in if isTrue# (len1 <=# len2) then
+    loop 0# len1
+  else
+    loop 0# len2
+  where
+    loop :: Int# -> Int# -> Int#
+    loop i len =
+      if isTrue# (i <# len) then
+        let w1 = indexWordArray# bs1 i
+            w2 = indexWordArray# bs2 i
+        in if (isTrue# (disjointWord# w1 w2)) then
+          loop (i +# 1#) len
+        else
+          0#
+      else
+        1#
+{-# NOINLINE byteArrayDisjoint# #-}
+
+--------------------------------------------------------------------------------
+-- Folds
+
+-- $byteArrayFolds
+-- As usual, there is an ambiguity in left/right folds for folding over the bits of a
+-- 'ByteArray#'. We opt to use the convention where we treat the 0th bit as the "head" of
+-- the 'ByteArray#', so a right fold like @byteArrayFoldrBits# f x 0b1011@ would give @f 0 (f 1 (f 3 x))@.
+
+-- | Perform a lazy right fold over the bit indicies of a 'ByteArray#'.
+byteArrayFoldrBits# :: (Int -> a -> a) -> a -> ByteArray# -> a
+byteArrayFoldrBits# f a bs = loop 0#
+  where
+    len = wordArraySize# bs
+
+    -- Not tail recursive.
+    loop i =
+      if isTrue# (i <# len) then
+        wordFoldrBitsOffset# (WORD_SIZE_IN_BITS# *# i) f (loop (i +# 1#)) (indexWordArray# bs i)
+      else
+        a
+
+-- | Perform a lazy left fold over the bit indicies of a 'ByteArray#'.
+byteArrayFoldlBits# :: (a -> Int -> a) -> a -> ByteArray# -> a
+byteArrayFoldlBits# f a bs = loop (wordArraySize# bs -# 1#)
+  where
+    -- Not tail recursive.
+    loop i =
+      if isTrue# (i >=# 0#) then
+        wordFoldlBitsOffset# (WORD_SIZE_IN_BITS# *# i) f (loop (i -# 1#)) (indexWordArray# bs i)
+      else
+        a
+
+-- | Perform a strict right fold over the bit indicies of a 'ByteArray#'.
+byteArrayFoldrBitsStrict# :: (Int -> a -> a) -> a -> ByteArray# -> a
+byteArrayFoldrBitsStrict# f a bs = loop (wordArraySize# bs -# 1#) a
+  where
+    -- Tail recursive.
+    loop i !acc =
+      if isTrue# (i >=# 0#) then
+        loop (i -# 1#) (wordFoldrBitsOffsetStrict# (WORD_SIZE_IN_BITS# *# i) f acc (indexWordArray# bs i))
+      else
+        acc
+
+-- | Perform a strict left fold over the bit indicies of a 'ByteArray#'.
+byteArrayFoldlBitsStrict# :: (a -> Int -> a) -> a -> ByteArray# -> a
+byteArrayFoldlBitsStrict# f a bs = loop 0# a
+  where
+    len = wordArraySize# bs
+
+    -- Tail recursive.
+    loop i !acc =
+      if isTrue# (i <# len) then
+        loop (i +# 1#) (wordFoldlBitsOffsetStrict# (WORD_SIZE_IN_BITS# *# i) f acc (indexWordArray# bs i))
+      else
+        acc

--- a/src/full/Agda/Utils/Null.hs
+++ b/src/full/Agda/Utils/Null.hs
@@ -67,7 +67,9 @@ class Null a where
 
 instance Null () where
   empty  = ()
+  {-# INLINE empty #-}
   null _ = True
+  {-# INLINE null #-}
 
 instance (Null a, Null b) => Null (a,b) where
   empty      = (empty, empty)
@@ -83,73 +85,107 @@ instance (Null a, Null b, Null c, Null d) => Null (a,b,c,d) where
 
 instance Null ByteStringChar8.ByteString where
   empty = ByteStringChar8.empty
+  {-# INLINE empty #-}
   null  = ByteStringChar8.null
+  {-# INLINE null #-}
 
 instance Null ByteStringLazy.ByteString where
   empty = ByteStringLazy.empty
+  {-# INLINE empty #-}
   null  = ByteStringLazy.null
+  {-# INLINE null #-}
 
 instance Null Text where
   empty = Text.empty
+  {-# INLINE empty #-}
   null  = Text.null
+  {-# INLINE null #-}
 
 instance Null [a] where
   empty = []
+  {-# INLINE empty #-}
   null  = List.null
+  {-# INLINE null #-}
 
 instance Null (Bag a) where
   empty = Bag.empty
+  {-# INLINE empty #-}
   null  = Bag.null
+  {-# INLINE null #-}
 
 instance Null (EnumMap k a) where
   empty = EnumMap.empty
+  {-# INLINE empty #-}
   null  = EnumMap.null
+  {-# INLINE null #-}
 
 instance Null (EnumSet a) where
   empty = EnumSet.empty
+  {-# INLINE empty #-}
   null  = EnumSet.null
+  {-# INLINE null #-}
 
 instance Null (IntMap a) where
   empty = IntMap.empty
+  {-# INLINE empty #-}
   null  = IntMap.null
+  {-# INLINE null #-}
 
 instance Null IntSet where
   empty = IntSet.empty
+  {-# INLINE empty #-}
   null  = IntSet.null
+  {-# INLINE null #-}
 
 instance Null (Map k a) where
   empty = Map.empty
+  {-# INLINE empty #-}
   null  = Map.null
+  {-# INLINE null #-}
 
 instance Null (HashMap k a) where
   empty = HashMap.empty
+  {-# INLINE empty #-}
   null  = HashMap.null
+  {-# INLINE null #-}
 
 instance Null (HashSet a) where
   empty = HashSet.empty
+  {-# INLINE empty #-}
   null  = HashSet.null
+  {-# INLINE null #-}
 
 instance Null (Seq a) where
   empty = Seq.empty
+  {-# INLINE empty #-}
   null  = Seq.null
+  {-# INLINE null #-}
 
 instance Null (Set a) where
   empty = Set.empty
+  {-# INLINE empty #-}
   null  = Set.null
+  {-# INLINE null #-}
 
 instance Null VarSet where
   empty = VarSet.empty
+  {-# INLINE empty #-}
   null = VarSet.null
+  {-# INLINE null #-}
 
 -- | A 'Maybe' is 'null' when it corresponds to the empty list.
 instance Null (Maybe a) where
   empty = Nothing
+  {-# INLINE empty #-}
   null  = isNothing
+  {-# INLINE null #-}
 
 -- | Viewing 'Bool' as @'Maybe' ()@, a boolean is 'null' when it is false.
 instance Null Bool where
   empty = False
+  {-# INLINE empty #-}
   null  = not
+  {-# INLINE null #-}
 
 instance Null (Doc a) where
   empty = mempty
@@ -157,31 +193,45 @@ instance Null (Doc a) where
 
 instance Null a => Null (Identity a) where
   empty = return empty
+  {-# INLINE empty #-}
   null  = null . runIdentity
+  {-# INLINE null #-}
 
 instance Null a => Null (IO a) where
   empty = return empty
+  {-# INLINE empty #-}
   null  = __IMPOSSIBLE__
+  {-# NOINLINE null #-}
 
 instance (Null (m a), Monad m) => Null (ExceptT e m a) where
   empty = lift empty
+  {-# INLINE empty #-}
   null  = __IMPOSSIBLE__
+  {-# NOINLINE null #-}
 
 instance (Null (m a), Monad m) => Null (MaybeT m a) where
   empty = lift empty
+  {-# INLINE empty #-}
   null  = __IMPOSSIBLE__
+  {-# NOINLINE null #-}
 
 instance (Null (m a), Monad m) => Null (ReaderT r m a) where
   empty = lift empty
+  {-# INLINE empty #-}
   null  = __IMPOSSIBLE__
+  {-# NOINLINE null #-}
 
 instance (Null (m a), Monad m) => Null (StateT s m a) where
   empty = lift empty
+  {-# INLINE empty #-}
   null  = __IMPOSSIBLE__
+  {-# NOINLINE null #-}
 
 instance (Null (m a), Monad m, Monoid w) => Null (WriterT w m a) where
   empty = lift empty
+  {-# INLINE empty #-}
   null  = __IMPOSSIBLE__
+  {-# NOINLINE null #-}
 
 -- * Testing for null.
 

--- a/src/full/Agda/Utils/Null.hs
+++ b/src/full/Agda/Utils/Null.hs
@@ -49,6 +49,8 @@ import Text.PrettyPrint.Annotated (Doc, isEmpty)
 
 import Agda.Utils.Bag (Bag)
 import qualified Agda.Utils.Bag as Bag
+import Agda.Utils.VarSet (VarSet)
+import qualified Agda.Utils.VarSet as VarSet
 
 import Agda.Utils.Unsafe (unsafeComparePointers)
 import Agda.Utils.Impossible
@@ -134,6 +136,10 @@ instance Null (Seq a) where
 instance Null (Set a) where
   empty = Set.empty
   null  = Set.null
+
+instance Null VarSet where
+  empty = VarSet.empty
+  null = VarSet.null
 
 -- | A 'Maybe' is 'null' when it corresponds to the empty list.
 instance Null (Maybe a) where

--- a/src/full/Agda/Utils/Singleton.hs
+++ b/src/full/Agda/Utils/Singleton.hs
@@ -48,21 +48,49 @@ class (Semigroup coll, Monoid coll, Singleton el coll) => Collection el coll
   fromList :: [el] -> coll
   fromList = mconcat . map singleton
 
-instance Collection a        [a]          where fromList = id
-instance Collection a        ([a] -> [a]) where fromList = (++)
-instance Collection a        (Endo [a])   where fromList = Endo . fromList
-instance Collection a        (DList a)    where fromList = DL.fromList
-instance Collection a        (Seq a)      where fromList = Seq.fromList
-instance Collection Int      IntSet       where fromList = IntSet.fromList
-instance Collection (Int, a) (IntMap a)   where fromList = IntMap.fromList
+instance Collection a        [a]          where
+  fromList = id
+  {-# INLINE fromList #-}
+instance Collection a        ([a] -> [a]) where
+  fromList = (++)
+  {-# INLINE fromList #-}
+instance Collection a        (Endo [a])   where
+  fromList = Endo . fromList
+  {-# INLINE fromList #-}
+instance Collection a        (DList a)    where
+  fromList = DL.fromList
+  {-# INLINE fromList #-}
+instance Collection a        (Seq a)      where
+  fromList = Seq.fromList
+  {-# INLINE fromList #-}
+instance Collection Int      IntSet       where
+  fromList = IntSet.fromList
+  {-# INLINE fromList #-}
+instance Collection (Int, a) (IntMap a)   where
+  fromList = IntMap.fromList
+  {-# INLINE fromList #-}
 
-instance Enum k             => Collection k      (EnumSet k)   where fromList = EnumSet.fromList
-instance Enum k             => Collection (k, a) (EnumMap k a) where fromList = EnumMap.fromList
-instance (Eq k, Hashable k) => Collection k      (HashSet k)   where fromList = HashSet.fromList
-instance (Eq k, Hashable k) => Collection (k, a) (HashMap k a) where fromList = HashMap.fromList
-instance Ord k              => Collection k      (Set k)       where fromList = Set.fromList
-instance Ord k              => Collection (k, a) (Map k a)     where fromList = Map.fromList
-instance SmallSetElement k  => Collection k      (SmallSet k)  where fromList = SmallSet.fromList
+instance Enum k             => Collection k      (EnumSet k)   where
+  fromList = EnumSet.fromList
+  {-# INLINE fromList #-}
+instance Enum k             => Collection (k, a) (EnumMap k a) where
+  fromList = EnumMap.fromList
+  {-# INLINE fromList #-}
+instance (Eq k, Hashable k) => Collection k      (HashSet k)   where
+  fromList = HashSet.fromList
+  {-# INLINE fromList #-}
+instance (Eq k, Hashable k) => Collection (k, a) (HashMap k a) where
+  fromList = HashMap.fromList
+  {-# INLINE fromList #-}
+instance Ord k              => Collection k      (Set k)       where
+  fromList = Set.fromList
+  {-# INLINE fromList #-}
+instance Ord k              => Collection (k, a) (Map k a)     where
+  fromList = Map.fromList
+  {-# INLINE fromList #-}
+instance SmallSetElement k  => Collection k      (SmallSet k)  where
+  fromList = SmallSet.fromList
+  {-# INLINE fromList #-}
 
 -- | Create-only collection with at most one element.
 
@@ -78,27 +106,63 @@ instance CMaybe a [a]       where cMaybe = maybeToList
 class Singleton el coll | coll -> el where
   singleton :: el -> coll
 
-instance Singleton a   (Maybe a)    where singleton = Just
-instance Singleton a   [a]          where singleton = (:[])
-instance Singleton a   ([a] -> [a]) where singleton = (:)
-instance Singleton a   (Endo [a])   where singleton = Endo . (:)
-instance Singleton a   (DList a)    where singleton = DL.singleton
-instance Singleton a   (NESet a)    where singleton = Set1.singleton
-instance Singleton a   (NonEmpty a) where singleton = (:| [])
-instance Singleton a   (Seq a)      where singleton = Seq.singleton
-instance Singleton a   (Set a)      where singleton = Set.singleton
-instance Singleton Int IntSet       where singleton = IntSet.singleton
-instance Singleton Int VarSet       where singleton = VarSet.singleton
+instance Singleton a   (Maybe a)    where
+  singleton = Just
+  {-# INLINE singleton #-}
+instance Singleton a   [a]          where
+  singleton = (:[])
+  {-# INLINE singleton #-}
+instance Singleton a   ([a] -> [a]) where
+  singleton = (:)
+  {-# INLINE singleton #-}
+instance Singleton a   (Endo [a])   where
+  singleton = Endo . (:)
+  {-# INLINE singleton #-}
+instance Singleton a   (DList a)    where
+  singleton = DL.singleton
+  {-# INLINE singleton #-}
+instance Singleton a   (NESet a)    where
+  singleton = Set1.singleton
+  {-# INLINE singleton #-}
+instance Singleton a   (NonEmpty a) where
+  singleton = (:| [])
+  {-# INLINE singleton #-}
+instance Singleton a   (Seq a)      where
+  singleton = Seq.singleton
+  {-# INLINE singleton #-}
+instance Singleton a   (Set a)      where
+  singleton = Set.singleton
+  {-# INLINE singleton #-}
+instance Singleton Int IntSet       where
+  singleton = IntSet.singleton
+  {-# INLINE singleton #-}
+instance Singleton Int VarSet       where
+  singleton = VarSet.singleton
+  {-# INLINE singleton #-}
 
-instance Enum a            => Singleton a (EnumSet  a) where singleton = EnumSet.singleton
-instance SmallSetElement a => Singleton a (SmallSet a) where singleton = SmallSet.singleton
+instance Enum a            => Singleton a (EnumSet  a) where
+  singleton = EnumSet.singleton
+  {-# INLINE singleton #-}
+instance SmallSetElement a => Singleton a (SmallSet a) where
+  singleton = SmallSet.singleton
+  {-# INLINE singleton #-}
 
-instance Singleton (k  ,a) (Map  k a)                  where singleton = uncurry Map.singleton
-instance Singleton (Int,a) (IntMap a)                  where singleton = uncurry IntMap.singleton
+instance Singleton (k  ,a) (Map  k a)                  where
+  singleton = uncurry Map.singleton
+  {-# INLINE singleton #-}
+instance Singleton (Int,a) (IntMap a)                  where
+  singleton = uncurry IntMap.singleton
+  {-# INLINE singleton #-}
 
-instance Hashable k => Singleton k     (HashSet   k)   where singleton = HashSet.singleton
-instance Hashable k => Singleton (k,a) (HashMap k a)   where singleton = uncurry HashMap.singleton
-instance Enum k     => Singleton (k,a) (EnumMap k a)   where singleton = uncurry EnumMap.singleton
+instance Hashable k => Singleton k     (HashSet   k)   where
+  singleton = HashSet.singleton
+  {-# INLINE singleton #-}
+instance Hashable k => Singleton (k,a) (HashMap k a)   where
+  singleton = uncurry HashMap.singleton
+  {-# INLINE singleton #-}
+instance Enum k     => Singleton (k,a) (EnumMap k a)   where
+  singleton = uncurry EnumMap.singleton
+  {-# INLINE singleton #-}
 
 -- Testing newtype-deriving:
 

--- a/src/full/Agda/Utils/Singleton.hs
+++ b/src/full/Agda/Utils/Singleton.hs
@@ -37,6 +37,8 @@ import qualified Data.Set.NonEmpty as Set1
 import Agda.Utils.Null     (Null, empty)
 import Agda.Utils.SmallSet (SmallSet, SmallSetElement)
 import qualified Agda.Utils.SmallSet as SmallSet
+import Agda.Utils.VarSet (VarSet)
+import qualified Agda.Utils.VarSet as VarSet
 
 -- | A create-only possibly empty collection is a monoid with the possibility
 --   to inject elements.
@@ -86,6 +88,7 @@ instance Singleton a   (NonEmpty a) where singleton = (:| [])
 instance Singleton a   (Seq a)      where singleton = Seq.singleton
 instance Singleton a   (Set a)      where singleton = Set.singleton
 instance Singleton Int IntSet       where singleton = IntSet.singleton
+instance Singleton Int VarSet       where singleton = VarSet.singleton
 
 instance Enum a            => Singleton a (EnumSet  a) where singleton = EnumSet.singleton
 instance SmallSetElement a => Singleton a (SmallSet a) where singleton = SmallSet.singleton

--- a/src/full/Agda/Utils/VarSet.hs
+++ b/src/full/Agda/Utils/VarSet.hs
@@ -160,7 +160,7 @@ import Agda.Utils.Word
 -- happy path approximately 3x faster for things like 'inRange', as
 -- GHC is able to coalesce all of the happy paths.
 
--- | A set of de Bruijn indicies/levels.
+-- | A set of de Bruijn indices/levels.
 data VarSet
   = VB# ByteArray#
   -- ^ A variable set whose maximum entry is greater than or equal to 64.
@@ -207,7 +207,7 @@ instance Semigroup VarSet where
 instance Monoid VarSet where
   mempty = empty
 
--- This instances is a bit suboptimal.
+-- This instance is a bit suboptimal.
 -- Ideally, 'hashWithSalt' should directly just call an unboxed 'mixHash' when we have a 'VS#',
 -- but 'Hashable' doesn't expose enough of its internals for this.
 instance Hashable VarSet where
@@ -551,11 +551,17 @@ foldr f a (VS# w) = wordFoldrBits# f a w
 foldr f a (VB# bs) = byteArrayFoldrBits# f a bs
 
 -- | Lazily fold over the elements of a variable set in descending order.
+--
+-- This does not have the same deficiencies 'Data.List.foldl', as we can
+-- start the fold at the back of the 'VarSet'.
 foldl :: (a -> Int -> a) -> a -> VarSet -> a
 foldl f a (VS# w) = wordFoldlBits# f a w
 foldl f a (VB# bs) = byteArrayFoldlBits# f a bs
 
 -- | Strictly fold over the elements of a variable set in ascending order.
+--
+-- This does not have the same deficiencies 'Data.List.foldr'', as we can
+-- start the fold at the back of the 'VarSet'.
 foldr' :: (Int -> a -> a) -> a -> VarSet -> a
 foldr' f a (VS# w) = wordFoldrBitsStrict# f a w
 foldr' f a (VB# bs) = byteArrayFoldrBitsStrict# f a bs

--- a/src/full/Agda/Utils/VarSet.hs
+++ b/src/full/Agda/Utils/VarSet.hs
@@ -1,27 +1,639 @@
+-- Needed to get haddock to pick up on identifiers with a #.
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE CPP #-}
 
-{-# OPTIONS_GHC -Wunused-imports #-}
+{-|
+Manage sets of natural numbers (de Bruijn indices).
 
--- | Manage sets of natural numbers (de Bruijn indices).
+This file contains an implementation of finite sets of integers
+that is optimized for storing sets of free variables. Notably,
+de Bruijn indices/levels are not uniformly distributed across the
+range of 'Int', and are always very small (EG: less than 64).
+
+This makes 'Data.IntSet.IntSet' somewhat ill-suited for the task.
+'Data.IntSet.IntSet' is designed to be able to handle values distributed
+across the entire range of 'Int', at the cost of pointer indirections
+and poor memory locality.
+
+Instead, 'VarSet' stores free variables as a bitvector. When the
+elements in the set are all smaller than 64, we can fit the entire set
+into a single unboxed 'GHC.Base.Word#', which makes most of our set operations
+a single instruction.
+
+When we exceed this bound, we fall back to an unboxed 'GHC.Base.ByteArray#'.
+Experimentally, this happens less than 0.0001% of the time.
+
+= Experimental Results
+
+Agda builds instrumented with 'traceVarSetSize' give the following
+statistics for 'VarSet' sizes across the following libraries:
+
++-------------+------------------------------------------+-------------------+---------------------+
+| library     | commit hash                              | varsets allocated | non-word sized sets |
++=============+==========================================+===================+=====================+
+| 1lab        | 11f4672ca7dcfdccb1b4ce94ca4ca42c9b732e62 | 118198551         | 0                   |
++-------------+------------------------------------------+-------------------+---------------------+
+| agda-stdlib | 0e97e2ed1f999ea0d2cce2a3b2395d5a9a7bd36a | 38960049          | 2178                |
++-------------+------------------------------------------+-------------------+---------------------+
+| cubical     | 1f2af52701945bef003a525f78fa41aeadb7c6ae | 82751805          | 0                   |
++-------------+------------------------------------------+-------------------+---------------------+
+-}
 
 module Agda.Utils.VarSet
-  ( VarSet
-  , empty, insert, singleton, union, unions
-  , fromList, toList, toAscList, toDescList
-  , disjoint, isSubsetOf, member, IntSet.null
-  , delete, difference, IntSet.filter, filterGE, intersection
-  , mapMonotonic, Agda.Utils.VarSet.subtract
+  (
+  -- * VarSet type
+  --
+  -- $varSetType
+    VarSet(..)
+  -- * Construction
+  , empty
+  , singleton
+  , fromList
+  , fromDescList
+  , full
+  , range
+  -- * Insertion
+  , insert
+  , inserts
+  , insertsDesc
+  -- * Deletion
+  , delete
+  -- * Queries
+  , null
+  , member
+  , lookupMin
+  , lookupMax
+  , size
+  , disjoint
+  , isSubsetOf
+  , inRange
+  -- * Combining variable sets
+  , union
+  , unions
+  , intersection
+  , difference
+  , (\\)
+  , complement
+  -- * Filters
+  , split
+  , filterLT
+  , filterLE
+  , filterGT
+  , filterGE
+  -- * Folds
+  --
+  -- $varSetFolds
+  , foldr
+  , foldl
+  , foldr'
+  , foldl'
+  -- * Views
+  , minView
+  , maxView
+  -- * Contextual operations
+  , strengthen
+  , weaken
+  -- * Conversions
+  , toDescList
+  , toAscList
   )
   where
 
-import Data.IntSet as IntSet
+-- We need the machines word size for some bitwise operations.
+#include "MachDeps.h"
 
-type VarSet = IntSet
+import Control.DeepSeq
+import Control.Monad
 
--- | Subtract from each element.
-subtract :: Int -> VarSet -> VarSet
-subtract n = mapMonotonic (Prelude.subtract n)
+import Data.Binary
+import Data.Binary.Get
+import Data.Binary.Put
+import qualified Data.ByteString as BS
+import qualified Data.Foldable as Fold
+import Data.Hashable
 
--- | Keep only elements greater or equal to the given pivot.
+import GHC.Base hiding (empty, foldr)
+import GHC.Num.BigNat
+import GHC.Num.WordArray
+
+import Debug.Trace
+
+import Prelude (Num(..), Show(..))
+import qualified Prelude as P
+
+import Agda.Utils.ByteArray
+import Agda.Utils.Word
+
+-- $varSetType
+-- = Invariants
+-- A variable set whose maximum entry is less than than 64 is always encoded
+-- via the 'VS#' constructor.
+-- The final word of a 'VB#' is always non-zero.
+--
+-- = Performance
+-- GHC will use pointer-tagging for datatypes with less than 4 constructors
+-- on 32 bit machines (8 on 64 bit), which means that 'VarSet' will be laid
+-- out as a tagged pointer to a word-sized piece of data.
+--
+-- We also pay attention to the constructor ordering here.
+-- GHC will lay out the machine code for case statements in
+-- reverse order of the datatypes constructors. Both ARM and x86 statically
+-- predict that forward branches are not taken, so putting 'VB#' before
+-- 'VS#' means that we can eek out a few extra drops of performance.
+--
+-- Finally, many functions in this module follow the following pattern:
+-- @
+-- union :: VarSet -> VarSet -> VarSet
+-- union (VS# w1) (VS# w2) = VS# (w1 `or#` w2)
+-- union vs1 vs2 = unionSlow vs1 vs2
+-- {-# INLINE union #-}
+--
+-- unionSlow :: VarSet -> VarSet -> VarSet
+-- unionSlow (VS# w1) (VS# w2) = VS# (w1 `or#` w2)
+-- unionSlow (VS# w1) (VB# bs2) = VB# (bigNatOrWord# bs2 w1)
+-- unionSlow (VB# bs1) (VS# w2) = VB# (bigNatOrWord# bs1 w2)
+-- unionSlow (VB# bs1) (VB# bs2) = VB# (bigNatOr bs1 bs2)
+-- {-# NOINLINE unionSlow #-}
+-- @
+--
+-- This makes the 0.0001% of slow cases notably worse, but makes the
+-- happy path approximately 3x faster for things like 'inRange', as
+-- GHC is able to coalesce all of the happy paths.
+
+-- | A set of de Bruijn indicies/levels.
+data VarSet
+  = VB# ByteArray#
+  -- ^ A variable set whose maximum entry is greater than or equal to 64.
+  | VS# Word#
+  -- ^ A small variable set whose maximum entry is less than than 64.
+
+-- | Convert a 'ByteArray#' to a variable set, upholding
+-- the invariant that all word-sized variable sets should use
+-- 'VS#'.
+byteArrayToVarSet# :: ByteArray# -> VarSet
+byteArrayToVarSet# bs =
+  case bigNatSize# bs of
+    0# -> empty -- Dont allocate if we don't have to.
+    1# -> VS# (indexWordArray# bs 0#)
+    _  -> VB# bs
+
+instance Eq VarSet where
+  (VS# xs) == (VS# ys) = isTrue# (xs `eqWord#` ys)
+  (VB# _) == (VS# _) = False
+  (VS# _) == (VB# _) = False
+  (VB# xs) == (VB# ys) = bigNatEq xs ys
+
+instance Ord VarSet where
+  compare (VS# xs) (VS# ys) = compareWord# xs ys
+  compare (VB# _) (VS# _) = GT
+  compare (VS# _) (VB# _) = LT
+  compare (VB# xs) (VB# ys) = bigNatCompare xs ys
+
+instance P.Show VarSet where
+  -- Use the same direction as the 'Show' instance for 'IntSet'.
+  showsPrec d vs =
+    P.showParen (d > 10) $
+    P.showString "fromList " . P.shows (toAscList vs)
+
+instance NFData VarSet where
+  rnf (VS# _) = ()
+  rnf (VB# _) = ()
+
+-- | @(<>)@ is @'union'@
+instance Semigroup VarSet where
+  (<>) = union
+
+-- | @mempty@ is @'empty'@.
+instance Monoid VarSet where
+  mempty = empty
+
+-- This instances is a bit suboptimal.
+-- Ideally, 'hashWithSalt' should directly just call an unboxed 'mixHash' when we have a 'VS#',
+-- but 'Hashable' doesn't expose enough of its internals for this.
+instance Hashable VarSet where
+  hash (VS# w) = I# (word2Int# w)
+  hash (VB# bs) = hashByteArray bs 0 (I# (sizeofByteArray# bs))
+
+  hashWithSalt salt (VS# w)  = hashWithSalt (I# (word2Int# w)) salt
+  hashWithSalt salt (VB# bs) = hashByteArrayWithSalt bs 0 (I# (sizeofByteArray# bs)) salt
+
+-- Could be much more efficient. Ideally, we would just have our hands
+-- on a pointer and an offset, but 'Binary' doesn't give a nice interface
+-- for this.
+instance Binary VarSet where
+  put (VS# w) = putWord8 0 <> put (W# w)
+  put (VB# bs) = putWord8 1 <> put (I# len) <> loop (len -# 1#)
+    where
+      len = bigNatSize# bs
+
+      loop :: Int# -> Put
+      loop i =
+        if isTrue# (i >=# 0#) then
+          put (W# (indexWordArray# bs i)) <> loop (i -# 1#)
+        else
+          mempty
+
+  get = do
+    tag <- get @Word8
+    case tag of
+      0 -> do
+        W# w <- get @Word
+        pure (VS# w)
+      _ -> do
+        -- This is quite bad, but we don't have very good tools for
+        -- doing this efficiently. This should really never happen
+        -- though, so it's not the end of the world.
+        len <- get @Int
+        words <- replicateM len (get @Word)
+        pure (VB# (bigNatFromWordList words))
+
+--------------------------------------------------------------------------------
+-- Construction
+
+-- | The empty variable set.
+empty :: VarSet
+empty = VS# 0##
+{-# INLINE CONLIKE empty #-}
+
+-- | A variable set with only a single entry.
+singleton :: Int -> VarSet
+singleton (I# i) =
+  if isTrue# (i <# WORD_SIZE_IN_BITS#) then
+    VS# (uncheckedBitWord# i)
+  else
+    VB# (bigNatBit# (int2Word# i))
+{-# INLINE singleton #-}
+
+-- | Construct a set of variables from a list of indices.
+fromList :: [Int] -> VarSet
+fromList is = inserts is empty
+{-# INLINE fromList #-}
+
+-- | Construct a set of variables from a list of indices sorted in descending order.
+-- This can be more efficient than 'fromList', as we only need to perform a single
+-- to determine that elements of the list are smaller than 64.
+--
+-- The precondition that the variables are sorted in descending order is
+-- not checked by 'fromDescList'.
+fromDescList :: [Int] -> VarSet
+fromDescList is = insertsDesc is empty
+
+-- | Construct a variable set that contains the indices @[0..n-1]@.
+full :: Int -> VarSet
+full (I# n) =
+  if isTrue# (n <=# 0#) then
+    empty
+  else if isTrue# (n <# WORD_SIZE_IN_BITS#) then
+    VS# (uncheckedWordOnes# n)
+  else
+    VB# (byteArrayOnes# n)
+{-# INLINE full #-}
+
+-- | Construct a variable set that contains the indices @[lo+1..hi-1]@.
+range :: Int -> Int -> VarSet
+range lo hi =
+  -- Most of the time, @hi@ is the length of the context
+  -- and @lo@ is some variable, so it would be a waste of time
+  -- to try and avoid work by checking if hi <= lo.
+  full hi \\ full (lo + 1)
+{-# INLINE range #-}
+
+--------------------------------------------------------------------------------
+-- Insertion
+
+-- | Insert an index into a variable set.
+insert :: Int -> VarSet -> VarSet
+insert (I# i) (VS# w) =
+  if isTrue# (i <# WORD_SIZE_IN_BITS#) then
+    VS# (uncheckedSetBitWord# w i)
+  else
+    VB# (bigNatSetBit# (bigNatFromWord# w) (int2Word# i))
+insert (I# i) (VB# bs) = VB# (bigNatSetBit# bs (int2Word# i))
+{-# INLINE insert #-}
+
+-- | Insert a list of variables into a @VarSet@.
+inserts :: [Int] -> VarSet -> VarSet
+inserts xs vs = Fold.foldl' (flip insert) vs xs
+
+-- | Insert a list of variables sorted in descending order into a 'VarSet'.
+-- This can be more efficient than 'inserts', as we only need to perform a single
+-- to determine that elements of the list are smaller than 64.
+--
+-- The precondition that the variables are sorted in descending order is
+-- not checked by 'insertsDesc'.
+insertsDesc :: [Int] -> VarSet -> VarSet
+insertsDesc [] vs = vs
+insertsDesc (I# x:xs) (VS# w) | isTrue# (x <# WORD_SIZE_IN_BITS#) = VS# (insertsDescFast# xs (uncheckedSetBitWord# w x))
+insertsDesc xs vs = inserts xs vs -- Could be more optimal but this is basically never taken.
+
+-- | Fast path for 'insertsDesc' that omits bounds checking.
+insertsDescFast# :: [Int] -> Word# -> Word#
+insertsDescFast# [] w = w
+insertsDescFast# (I# x:xs) w = insertsDescFast# xs (uncheckedSetBitWord# w x)
+
+--------------------------------------------------------------------------------
+-- Deletion
+
+-- | Delete an index from a variable set.
+delete :: Int -> VarSet -> VarSet
+delete (I# i) vs@(VS# w) =
+  if isTrue# (i <# WORD_SIZE_IN_BITS#) then
+    VS# (uncheckedClearBitWord# w i)
+  else
+    vs
+delete (I# i) (VB# vs) = byteArrayToVarSet# (bigNatClearBit# vs (int2Word# i))
+{-# INLINE delete #-}
+
+--------------------------------------------------------------------------------
+-- Queries
+
+-- | Is this the empty set?
+null :: VarSet -> Bool
+null (VS# 0##) = True
+null _ = False
+{-# INLINE null #-}
+
+-- | Is a variable a member of a var set?
+member :: Int -> VarSet -> Bool
+member (I# i) (VS# w) = isTrue# ((0# <=# i) `andI#` (i <# WORD_SIZE_IN_BITS#) `andI#` (uncheckedTestBitWord# w i))
+member (I# i) (VB# bs) = isTrue# (bigNatTestBit# bs (int2Word# i))
+{-# INLINE member #-}
+
+-- | Find the smallest index in the variable set.
+lookupMin :: VarSet -> Maybe Int
+lookupMin (VS# w) =
+  if isTrue# (w `eqWord#` 0##) then
+    Nothing
+  else
+    Just (I# (word2Int# (lowestBitWord# w)))
+lookupMin (VB# bs) = Just (I# (lookupMinSlow# 0# bs))
+{-# INLINE lookupMin #-}
+
+-- | Slow path for 'lookupMin'.
+lookupMinSlow# :: Int# -> ByteArray# -> Int#
+lookupMinSlow# i bs =
+  -- We don't need to check if the index goes out of bounds, as we know that
+  -- 0 always gets stored as an @VS#@, so there must be *some* set bit.
+  let w = indexWordArray# bs i in
+  if isTrue# (eqWord# w 0##) then
+    lookupMinSlow# (i +# 1#) bs
+  else
+    WORD_SIZE_IN_BITS# *# i +# (word2Int# (lowestBitWord# w))
+{-# NOINLINE lookupMinSlow# #-}
+
+-- | Find the largest index in the variable set.
+lookupMax :: VarSet -> Maybe Int
+lookupMax (VS# w) =
+  if isTrue# (w `eqWord#` 0##) then
+    Nothing
+  else
+    Just (I# (word2Int# (highestBitWord# w)))
+lookupMax (VB# bs) =
+  -- We know that the highest bit must be in the final word of 'bs',
+  -- as there are no leading 0 words in our varsets.
+  let len = wordArraySize# bs
+  in Just (I# (word2Int# (highestBitWord# (indexWordArray# bs (len -# 1#)))))
+{-# INLINE lookupMax #-}
+
+-- | The number of entries in the variable set.
+size :: VarSet -> Int
+size (VS# w) = I# (word2Int# (popCnt# w))
+size (VB# bs) = I# (word2Int# (bigNatPopCount# bs))
+{-# INLINE size #-}
+
+-- | Check if two variable sets are disjoint.
+disjoint :: VarSet -> VarSet -> Bool
+disjoint (VS# w1) (VS# w2) = isTrue# (disjointWord# w1 w2)
+disjoint vs1 vs2 = isTrue# (disjointSlow# vs1 vs2)
+{-# INLINE disjoint #-}
+
+-- | Slow path for 'disjoint'.
+disjointSlow# :: VarSet -> VarSet -> Int#
+disjointSlow# (VS# w1) (VS# w2) = disjointWord# w1 w2
+disjointSlow# (VB# bs1) (VS# w2) = disjointWord# (indexWordArray# bs1 0#) w2
+disjointSlow# (VS# w1) (VB# bs2) = disjointWord# (indexWordArray# bs2 0#) w1
+disjointSlow# (VB# bs1) (VB# bs2) = byteArrayDisjoint# bs1 bs2
+{-# NOINLINE disjointSlow# #-}
+
+--------------------------------------------------------------------------------
+-- Combining variable sets
+
+-- | Union two variable sets.
+union :: VarSet -> VarSet -> VarSet
+union (VS# w1) (VS# w2) = VS# (w1 `or#` w2)
+union vs1 vs2 = unionSlow vs1 vs2
+{-# INLINE union #-}
+
+-- | Slow path for 'union'.
+unionSlow :: VarSet -> VarSet -> VarSet
+unionSlow (VS# w1) (VS# w2) = VS# (w1 `or#` w2)
+unionSlow (VS# w1) (VB# bs2) = VB# (bigNatOrWord# bs2 w1)
+unionSlow (VB# bs1) (VS# w2) = VB# (bigNatOrWord# bs1 w2)
+unionSlow (VB# bs1) (VB# bs2) = VB# (bigNatOr bs1 bs2)
+{-# NOINLINE unionSlow #-}
+
+-- | Union a collection of variable sets together.
+unions :: P.Foldable f => f VarSet -> VarSet
+unions = Fold.foldl' union empty
+{-# SPECIALIZE unions :: [VarSet] -> VarSet #-}
+
+-- | Take the intersection of two variable sets.
+intersection :: VarSet -> VarSet -> VarSet
+intersection (VS# w1) (VS# w2) = VS# (w1 `and#` w2)
+intersection vs1 vs2 = intersectionSlow vs1 vs2
+{-# INLINE intersection #-}
+
+-- | Slow path for 'intersection'.
+intersectionSlow :: VarSet -> VarSet -> VarSet
+intersectionSlow (VS# w1) (VS# w2) = VS# (w1 `and#` w2)
+intersectionSlow (VS# w1) (VB# bs2) = VS# (w1 `and#` indexWordArray# bs2 0#)
+intersectionSlow (VB# bs1) (VS# w2) = VS# (indexWordArray# bs1 0# `and#` w2)
+intersectionSlow (VB# bs1) (VB# bs2) = VB# (bigNatAnd bs1 bs2)
+{-# NOINLINE intersectionSlow #-}
+
+-- | Set difference of two variable sets.
+difference :: VarSet -> VarSet -> VarSet
+difference (VS# w1) (VS# w2) = VS# (w1 `andNot#` w2)
+difference vs1 vs2 = differenceSlow vs1 vs2
+{-# INLINE difference #-}
+
+-- | Slow path for 'difference'.
+differenceSlow :: VarSet -> VarSet -> VarSet
+differenceSlow (VS# w1) (VS# w2) = VS# (w1 `andNot#` w2)
+differenceSlow (VS# w1) (VB# bs2) = VS# (w1 `andNot#` indexWordArray# bs2 0#)
+differenceSlow (VB# bs1) (VS# w2) = VB# (bigNatAndNotWord# bs1 w2)
+differenceSlow (VB# bs1) (VB# bs2) = byteArrayToVarSet# (bigNatAndNot bs1 bs2)
+{-# NOINLINE differenceSlow #-}
+
+-- | Infix operator for 'difference'.
+(\\) :: VarSet -> VarSet -> VarSet
+(\\) = difference
+{-# INLINE (\\) #-}
+
+-- | Take a relative complement of a variable set.
+complement :: Int -> VarSet -> VarSet
+complement n vs = full n \\ vs
+{-# INLINE complement #-}
+
+-- | @isSubsetOf vs1 vs2@ determines if @vs1@ is a subset of @vs2@.
+isSubsetOf :: VarSet -> VarSet -> Bool
+isSubsetOf (VS# w1) (VS# w2) = isTrue# ((w1 `and#` w2) `eqWord#` w1)
+isSubsetOf vs1 vs2 = isTrue# (isSubsetOfSlow# vs1 vs2)
+{-# INLINE isSubsetOf #-}
+
+-- | Slow path for 'isSubsetOf'.
+isSubsetOfSlow# :: VarSet -> VarSet -> Int#
+isSubsetOfSlow# (VS# w1) (VS# w2) = (w1 `and#` w2) `eqWord#` w1
+isSubsetOfSlow# (VS# w1) (VB# bs2) = (w1 `and#` indexWordArray# bs2 0#) `eqWord#` w1
+isSubsetOfSlow# (VB# bs1) (VS# w2) = 0#
+isSubsetOfSlow# (VB# bs1) (VB# bs2) = byteArrayIsSubsetOf# bs1 bs2
+{-# NOINLINE isSubsetOfSlow# #-}
+
+-- | @inRange lo hi vs@ determines if all the variables in @vs@
+-- are within the range @[lo+1 .. hi-1]@.
+inRange :: Int -> Int -> VarSet -> Bool
+inRange lo hi vs =
+  -- This might seem inefficient, but is optimal
+  -- when @range lo hi@ and @vs@ both fit within a single word.
+  vs `isSubsetOf` range lo hi
+{-# INLINE inRange #-}
+
+--------------------------------------------------------------------------------
+-- Filters
+
+-- | Split a variable set into elements that are strictly smaller than
+-- @n@ and elements that are strictly larger.
+--
+-- Note that this is strict in both components of the pair. If you only
+-- need one half, use 'filterLT' or 'filterGT'.
+split :: Int -> VarSet -> (VarSet, VarSet)
+split n vs =
+  let !lo = intersection vs (full n)
+      !hi = difference vs (full (n + 1))
+  in (lo, hi)
+
+-- | Filter a variable set to elements that are less than to an index.
+filterLT :: Int -> VarSet -> VarSet
+filterLT n vs = intersection vs (full n)
+{-# INLINE filterLT #-}
+
+-- | Filter a variable set to elements that are less than or equal to an index.
+filterLE :: Int -> VarSet -> VarSet
+filterLE n vs = intersection vs (full (n + 1))
+{-# INLINE filterLE #-}
+
+-- | Filter a variable set to elements that are greater than to an index.
+filterGT :: Int -> VarSet -> VarSet
+filterGT n vs = difference vs (full (n + 1))
+{-# INLINE filterGT #-}
+
+-- | Filter a variable set to elements that are greater than or equal to an index.
 filterGE :: Int -> VarSet -> VarSet
-filterGE n = snd . IntSet.split (n - 1)
+filterGE n vs = difference vs (full n)
+{-# INLINE filterGE #-}
+
+--------------------------------------------------------------------------------
+-- Folds
+
+-- $varSetFolds
+-- Like most unordered containers, @foldr@ and @foldl@ are somewhat ambigious
+-- names for folds over a 'VarSet'. For the sake of consistency, we adopt the
+-- same convention as 'Data.IntSet.IntSet', where
+-- @
+-- VarSet.foldr f x = foldr f x . VarSet.toAscList
+-- VarSet.foldl f x = foldl f x . VarSet.toAscList
+-- @
+--
+-- Unfortunately, this convention the opposite of how our sets are laid out
+-- in memory.
+
+-- | Lazily fold over the elements of a variable set in ascending order.
+foldr :: (Int -> a -> a) -> a -> VarSet -> a
+foldr f a (VS# w) = wordFoldrBits# f a w
+foldr f a (VB# bs) = byteArrayFoldrBits# f a bs
+
+-- | Lazily fold over the elements of a variable set in descending order.
+foldl :: (a -> Int -> a) -> a -> VarSet -> a
+foldl f a (VS# w) = wordFoldlBits# f a w
+foldl f a (VB# bs) = byteArrayFoldlBits# f a bs
+
+-- | Strictly fold over the elements of a variable set in ascending order.
+foldr' :: (Int -> a -> a) -> a -> VarSet -> a
+foldr' f a (VS# w) = wordFoldrBitsStrict# f a w
+foldr' f a (VB# bs) = byteArrayFoldrBitsStrict# f a bs
+
+-- | Strictly fold over the elements of a variable set in descending order.
+foldl' :: (Int -> a -> a) -> a -> VarSet -> a
+foldl' f a (VS# w) = wordFoldrBitsStrict# f a w
+foldl' f a (VB# bs) = byteArrayFoldrBitsStrict# f a bs
+
+
+--------------------------------------------------------------------------------
+-- Views
+
+-- | Retrieve the smallest index in the variable set along with the set sans that
+-- element, or 'Nothing' if the set was empty.
+minView :: VarSet -> Maybe (Int, VarSet)
+minView vs =
+  case lookupMin vs of
+    Just i ->
+      let !vs' = delete i vs
+      in Just (i, vs')
+    Nothing -> Nothing
+
+-- | Retrieve the smallest index in the variable set along with the set sans that
+-- element, or 'Nothing' if the set was empty.
+maxView :: VarSet -> Maybe (Int, VarSet)
+maxView vs =
+  case lookupMax vs of
+    Just i ->
+      let !vs' = delete i vs
+      in Just (i, vs')
+    Nothing -> Nothing
+
+--------------------------------------------------------------------------------
+-- Contextual operations
+
+-- | Remove the first @n@ entries from the variable set,
+-- and shift the indices of all other entries down by @n@.
+strengthen :: Int -> VarSet -> VarSet
+strengthen (I# n) (VS# w) =
+  -- A strengthening by 64+ will literally never happen, so we are better
+  -- off avoiding the branch then we are saving an allocation by
+  -- re-using 'empty' when the shift result would be 0.
+  VS# (w `shiftRL#` n)
+strengthen (I# n) (VB# bs) =
+  byteArrayToVarSet# (bigNatShiftR# bs (int2Word# n))
+{-# INLINE strengthen #-}
+
+-- | Shift all indices in the variable set up by @n@.
+weaken :: Int -> VarSet -> VarSet
+weaken (I# n) (VS# w) =
+  if isTrue# (clz# w `geWord#` int2Word# n) then
+    VS# (w `uncheckedShiftL#` n)
+  else
+    VB# (bigNatShiftL# (bigNatFromWord# w) (int2Word# n))
+weaken (I# n) (VB# bs) =
+  VB# (bigNatShiftL# bs (int2Word# n))
+{-# INLINE weaken #-}
+
+--------------------------------------------------------------------------------
+-- Conversions
+
+-- | Convert a variable set to a descending list of indices.
+toDescList :: VarSet -> [Int]
+toDescList = foldl (flip (:)) []
+{-# INLINE toDescList #-}
+
+-- | Convert a variable set to an ascending list of indices.
+toAscList :: VarSet -> [Int]
+toAscList = foldr (:) []
+{-# INLINE toAscList #-}
+
+--------------------------------------------------------------------------------
+-- Debugging
+
+-- | Trace the size of a variable set to the eventlog.
+traceVarSetSize :: VarSet -> VarSet
+traceVarSetSize vs@(VS# _) = traceEvent ("VarSet.size=1") vs
+traceVarSetSize vs@(VB# bs) = traceEvent ("VarSet.size=" <> show (bigNatSize bs)) vs

--- a/src/full/Agda/Utils/Word.hs
+++ b/src/full/Agda/Utils/Word.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
+
+-- | Utilities for working with 'Word' and 'Word#'.
+module Agda.Utils.Word
+  ( -- * Bitwise operations
+    uncheckedBitWord#
+  , uncheckedClearBitWord#
+  , uncheckedSetBitWord#
+  , uncheckedTestBitWord#
+  , highestBitWord#
+  , lowestBitWord#
+  , disjointWord#
+  , andNot#
+  , uncheckedWordOnes#
+  -- * Folds
+  --
+  -- $wordFolds
+  , wordFoldrBits#
+  , wordFoldlBits#
+  , wordFoldrBitsOffset#
+  , wordFoldlBitsOffset#
+  -- ** Strict folds
+  , wordFoldrBitsStrict#
+  , wordFoldlBitsStrict#
+  , wordFoldrBitsOffsetStrict#
+  , wordFoldlBitsOffsetStrict#
+  ) where
+
+-- We need the machines word size for some bitwise operations.
+#include "MachDeps.h"
+
+import GHC.Base
+
+--------------------------------------------------------------------------------
+-- Bitwise operations
+
+-- | Create a 'Word#' with the @i@th bit set.
+--
+-- The result of 'uncheckedBitWord#' is undefined when @i@
+-- is not in the range @[0..WORD_SIZE_IN_BITS]@.
+uncheckedBitWord# :: Int# -> Word#
+uncheckedBitWord# i = 1## `uncheckedShiftL#` i
+{-# INLINE uncheckedBitWord# #-}
+
+-- | Clear a single bit in an unboxed word.
+--
+-- The result of 'uncheckedClearBitWord#' is undefined when @i@
+-- is not in the range @[0..WORD_SIZE_IN_BITS]@.
+uncheckedClearBitWord# :: Word# -> Int# -> Word#
+uncheckedClearBitWord# w i =
+  -- This is somewhat suboptimal. On x86, the GHC native code generator will
+  -- produce the following code with -O2:
+  --
+  -- > movl $1,%eax
+  -- > movq %rsi,%rcx
+  -- > shlq %cl,%rax
+  -- > notq %rax
+  -- > movq %r14,%rbx
+  -- > andq %rax,%rbx
+  -- > jmp *(%rbp)
+  --
+  -- Ideally, this should be a single @btr@ instruction (or @bic@ on arm), but
+  -- GHC doesn't provide any builtins for this so this is the best we can do.
+  w `and#` (not# (1## `uncheckedShiftL#` i))
+{-# INLINE uncheckedClearBitWord# #-}
+
+-- | Set a single bit in an unboxed word.
+--
+-- The result of 'uncheckedSetBitWord#' is undefined when @i@
+-- is not in the range @[0..WORD_SIZE_IN_BITS]@.
+uncheckedSetBitWord# :: Word# -> Int# -> Word#
+uncheckedSetBitWord# w i =
+  w `or#` (1## `uncheckedShiftL#` i)
+{-# INLINE uncheckedSetBitWord# #-}
+
+-- | Test a single bit in an unboxed word.
+--
+-- The result of 'uncheckedTestBitWord#' is undefined when @i@
+-- is not in the range @[0..WORD_SIZE_IN_BITS]@.
+uncheckedTestBitWord# :: Word# -> Int# -> Int#
+uncheckedTestBitWord# w i =
+  (w `and#` (1## `uncheckedShiftL#` i)) `neWord#` 0##
+{-# INLINE uncheckedTestBitWord# #-}
+
+-- | Get the bit-index of the highest set bit.
+highestBitWord# :: Word# -> Word#
+highestBitWord# w =
+  -- Another bit of suboptimal code resulting in a lack of primops.
+  -- If we compile with -O2 using the native code generator on an x86 machine,
+  -- we get:
+  --
+  -- > bsr %r14,%rax
+  -- > movl $127,%ebx
+  -- > cmovne %rax,%rbx
+  -- > xorq $63,%rbx
+  -- > xorq $63,%rbx
+  -- > jmp *(%rbp)
+  --
+  -- Note the double @xor@! This could be a single @bsr@ instruction.
+  -- If we compile with @-mbmi2@ things are a bit better, but still wastes
+  -- an instruction. However, this is the best we can do.
+  clz# w `xor#` (WORD_SIZE_IN_BITS## `minusWord#` 1##)
+{-# INLINE highestBitWord# #-}
+
+-- | Get the bit-index of the lowest set bit.
+lowestBitWord# :: Word# -> Word#
+lowestBitWord# w = ctz# w
+{-# INLINE lowestBitWord# #-}
+
+-- | Take the bitwise AND of the first argument with the complement of the second.
+andNot# :: Word# -> Word# -> Word#
+andNot# w1 w2 =
+  -- This should be a single @andn@ on x86 or @bic@ on aarch64,
+  -- but the native code generator doesn't know about this.
+  w1 `and#` not# w2
+{-# INLINE andNot# #-}
+
+-- | Are the bit representations of two words disjoint?
+disjointWord# :: Word# -> Word# -> Int#
+disjointWord# w1 w2 = ((w1 `and#` w2) `eqWord#` 0##)
+{-# INLINE disjointWord# #-}
+
+-- | Create a 'Word#' where the first @n@ bits are 1.
+--
+-- The result of 'uncheckedWordOnes#' is undefined when @i@
+-- is not in the range @[0..WORD_SIZE_IN_BITS]@.
+uncheckedWordOnes# :: Int# -> Word#
+uncheckedWordOnes# n = not# 0## `uncheckedShiftRL#` (WORD_SIZE_IN_BITS# -# n)
+{-# INLINE uncheckedWordOnes# #-}
+
+--------------------------------------------------------------------------------
+-- Folds
+
+-- $wordFolds
+-- As usual, there is an ambiguity in left/right folds for folding over the bits of a
+-- 'Word#'. We opt to use the convention where we treat the 0th bit as the "head" of
+-- a 'Word#', so a right fold like @wordFoldrBits# f x 0b1011@ would give @f 0 (f 1 (f 3 x))@.
+--
+-- We also provide hand-rolled versions of folds that offset the bit index by a static value:
+-- this pattern comes up quite often when folding over 'ByteArray#' and the like. This can
+-- save some allocations when compared to @wordFoldrBits# (\i acc -> f (i + offset) acc) a@.
+
+-- | @wordFoldrBits# f a w@ performs a lazy right fold over the bits of @w@.
+wordFoldrBits# :: (Int -> a -> a) -> a -> Word# -> a
+wordFoldrBits# f a w
+  | isTrue# (w `eqWord#` 0##) = a
+  | otherwise =
+    let i = word2Int# (lowestBitWord# w)
+    in f (I# i) (wordFoldrBits# f a (uncheckedClearBitWord# w i))
+
+-- | @wordFoldrBitsOffset# offset f a w@ performs a right fold over the bits of @w@,
+-- with every bit index passed to @f@ offset by @offset@.
+wordFoldrBitsOffset# :: Int# -> (Int -> a -> a) -> a -> Word# -> a
+wordFoldrBitsOffset# offset f a w
+  | isTrue# (w `eqWord#` 0##) = a
+  | otherwise =
+    let i = word2Int# (lowestBitWord# w)
+    in f (I# (i +# offset)) (wordFoldrBitsOffset# offset f a (uncheckedClearBitWord# w i))
+
+-- | @wordFoldlBits# f a w@ performs a lazy left fold over the bits of @w@.
+wordFoldlBits# :: (a -> Int -> a) -> a -> Word# -> a
+wordFoldlBits# f a w
+  | isTrue# (w `eqWord#` 0##) = a
+  | otherwise =
+      let i = word2Int# (highestBitWord# w)
+      in f (wordFoldlBits# f a (uncheckedClearBitWord# w i)) (I# i)
+
+-- | @wordFoldlBitsOffset# offset f a w@ performs a lazy left fold over the bits of @w@,
+-- with every bit index passed to @f@ offset by @offset@.
+wordFoldlBitsOffset# :: Int# -> (a -> Int -> a) -> a -> Word# -> a
+wordFoldlBitsOffset# offset f a w
+  | isTrue# (w `eqWord#` 0##) = a
+  | otherwise =
+      let i = word2Int# (highestBitWord# w)
+      in f (wordFoldlBitsOffset# offset f a (uncheckedClearBitWord# w i)) (I# (i +# offset))
+
+-- | @wordFoldrBitsStrict# f a w@ performs a strict right fold over the bits of @w@.
+wordFoldrBitsStrict# :: (Int -> a -> a) -> a -> Word# -> a
+wordFoldrBitsStrict# f !a w
+  | isTrue# (w `eqWord#` 0##) = a
+  | otherwise =
+    let i = word2Int# (highestBitWord# w)
+    in wordFoldrBitsStrict# f (f (I# i) a) (uncheckedClearBitWord# w i)
+
+-- | @wordFoldrBitsOffsetStrict# offset f a w@ performs a strict right fold over the bits of @w@,
+-- with every bit index passed to @f@ offset by @offset@.
+wordFoldrBitsOffsetStrict# :: Int# -> (Int -> a -> a) -> a -> Word# -> a
+wordFoldrBitsOffsetStrict# offset f !a w
+  | isTrue# (w `eqWord#` 0##) = a
+  | otherwise =
+    let i = word2Int# (highestBitWord# w)
+    in wordFoldrBitsOffsetStrict# offset f (f (I# (i +# offset)) a) (uncheckedClearBitWord# w i)
+
+-- | @wordFoldlBitsStrict# f a w@ performs a strict left fold over the bits of @w@.
+wordFoldlBitsStrict# :: (a -> Int -> a) -> a -> Word# -> a
+wordFoldlBitsStrict# f !a w
+  | isTrue# (w `eqWord#` 0##) = a
+  | otherwise =
+    let i = word2Int# (lowestBitWord# w)
+    in wordFoldlBitsStrict# f (f a (I# i)) (uncheckedClearBitWord# w i)
+
+-- | @wordFoldrBitsOffsetStrict# offset f a w@ performs a strict right fold over the bits of @w@,
+-- with every bit index passed to @f@ offset by @offset@.
+wordFoldlBitsOffsetStrict# :: Int# -> (a -> Int -> a) -> a -> Word# -> a
+wordFoldlBitsOffsetStrict# offset f !a w
+  | isTrue# (w `eqWord#` 0##) = a
+  | otherwise =
+    let i = word2Int# (lowestBitWord# w)
+    in wordFoldlBitsOffsetStrict# offset f (f a (I# (i +# offset))) (uncheckedClearBitWord# w i)

--- a/test/Internal/Tests.hs
+++ b/test/Internal/Tests.hs
@@ -55,6 +55,7 @@ import qualified Internal.Utils.RangeMap
 import qualified Internal.Utils.SmallSet
 import qualified Internal.Utils.Three
 import qualified Internal.Utils.Trie
+import qualified Internal.Utils.VarSet
 
 -- Keep this list in the import order, please!
 tests :: TestTree
@@ -107,4 +108,5 @@ tests = testGroup "Internal" $
   Internal.Utils.SmallSet.tests :
   Internal.Utils.Three.tests :
   Internal.Utils.Trie.tests :
+  Internal.Utils.VarSet.tests :
   []

--- a/test/Internal/TypeChecking.hs
+++ b/test/Internal/TypeChecking.hs
@@ -2,14 +2,16 @@
 
 module Internal.TypeChecking ( tests ) where
 
-import Agda.Utils.Impossible
+import Agda.Syntax.Common.Pretty
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
+import Agda.Utils.Impossible
 import Agda.Utils.Permutation
 import Agda.Utils.Size
 
-import qualified Agda.Utils.VarSet as Set
+import Agda.Utils.VarSet (VarSet)
+import qualified Agda.Utils.VarSet as VarSet
 
 import Internal.Helpers
 import Internal.TypeChecking.Generators hiding ( tests )
@@ -35,6 +37,12 @@ prop_flattenTelScope conf =
   forAll (genC conf) $ \tel ->
   all (isWellScoped $ extendWithTelConf tel conf) (flattenTel tel)
 
+-- | 'flattenRevTel' is the reverse of 'flattenTel'.
+prop_flattenRevTelScope :: TermConfiguration -> Property
+prop_flattenRevTelScope conf =
+  forAll @Telescope (genC conf) $ \tel ->
+  reverse (flattenTel tel) === flattenRevTel tel
+
 -- | @unflattenTel . flattenTel == id@
 prop_flattenTelInv :: TermConfiguration -> Property
 prop_flattenTelInv conf =
@@ -52,16 +60,55 @@ prop_splitTelescopeScope :: TermConfiguration -> Property
 prop_splitTelescopeScope conf =
   forAll (genC conf)                        $ \tel ->
   forAll (listOfElements [0..size tel - 1]) $ \vs ->
-  let SplitTel tel1 tel2 perm = splitTelescope (Set.fromList vs) tel
+  let SplitTel tel1 tel2 perm = splitTelescope (VarSet.fromList vs) tel
       tel' = telFromList (telToList tel1 ++ telToList tel2)
   in  isWellScoped conf tel'
+
+-- | 'varDependencies' is a superset of the input when all variables are inside the
+-- telescope.
+prop_varDependenciesSuperset :: TermConfiguration -> Property
+prop_varDependenciesSuperset conf =
+  forAllShow (genC conf) prettyShow \tel ->
+  forAll (listOfElements [0..size tel - 1]) $ \ns ->
+    let vs = VarSet.fromList ns
+    in vs `VarSet.isSubsetOf` varDependencies tel vs
+
+-- | 'varDependencies' is idempotent when all variables are inside the telescope.
+prop_varDependenciesIdempotent :: TermConfiguration -> Property
+prop_varDependenciesIdempotent conf =
+  forAllShow (genC conf) prettyShow \tel ->
+  forAll (listOfElements [0..size tel - 1]) $ \ns ->
+    let vs = VarSet.fromList ns
+        deps = varDependencies tel vs
+    in varDependencies tel deps === deps
+
+-- | 'varDependents' is monotone.
+prop_varDependentsMonotone :: TermConfiguration -> Property
+prop_varDependentsMonotone conf =
+  forAllShow (genC conf) prettyShow \tel ->
+  forAll (listOfElements [0..size tel - 1]) $ \ms ->
+  forAll (listOfElements ms) $ \ns ->
+  let us = VarSet.fromList ms
+      vs = VarSet.fromList ns
+      usDeps = varDependents tel us
+      vsDeps = varDependents tel vs
+  in vsDeps `VarSet.isSubsetOf` usDeps
+
+-- | @varDependents tel (varDependents tel vs)@ is a subset of @varDependents tel vs@.
+prop_varDependentsCoclosure :: TermConfiguration -> Property
+prop_varDependentsCoclosure conf =
+  forAllShow (genC conf) prettyShow \tel ->
+  forAll (listOfElements [0..size tel - 1]) $ \ns ->
+    let vs = VarSet.fromList ns
+        deps = varDependents tel vs
+    in varDependents tel deps `VarSet.isSubsetOf` deps
 
 -- | The permutation generated when splitting a telescope preserves scoping.
 prop_splitTelescopePermScope :: TermConfiguration -> Property
 prop_splitTelescopePermScope conf =
       forAllShrink (genC conf) (shrinkC conf)                $ \tel ->
       forAllShrink (listOfElements [0..size tel - 1]) shrink $ \vs ->
-  let SplitTel tel1 tel2 perm = splitTelescope (Set.fromList vs) tel
+  let SplitTel tel1 tel2 perm = splitTelescope (VarSet.fromList vs) tel
       conf1 = extendWithTelConf tel1 conf
       conf2 = conf1 { tcFreeVariables = map (size tel2 +) (tcFreeVariables conf1) }
       conf' = conf  { tcFreeVariables = map (size tel +) (tcFreeVariables conf) ++ vs }
@@ -75,7 +122,7 @@ prop_splitTelescopePermScope conf =
 -- prop_splitTelescopePermInv conf =
 --       forAll (wellScopedTel conf)               $ \tel ->
 --       forAll (listOfElements [0..size tel - 1]) $ \vs ->
---   let SplitTel tel1 tel2 perm = splitTelescope (Set.fromList vs) tel
+--   let SplitTel tel1 tel2 perm = splitTelescope (VarSet.fromList vs) tel
 --       tel' = telFromList (telToList tel1 ++ telToList tel2)
 --       conf1 = extendWithTelConf tel  conf
 --       conf2 = extendWithTelConf tel' conf

--- a/test/Internal/Utils/VarSet.hs
+++ b/test/Internal/Utils/VarSet.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE TemplateHaskell       #-}
+
+module Internal.Utils.VarSet ( tests ) where
+
+import Test.QuickCheck
+
+import Data.Binary
+import Data.Coerce
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
+import Data.Maybe
+
+import Agda.Utils.VarSet (VarSet)
+import qualified Agda.Utils.VarSet as VarSet
+
+import Internal.Helpers
+
+-- | An integer in the range @[0..1024]@.
+newtype Var = Var { unVar :: Int }
+  deriving (Eq, Ord, Show)
+
+instance Arbitrary Var where
+  arbitrary = Var <$> chooseInt (0, 1024)
+  shrink (Var n) = Var <$> drop 1 (takeWhile (> 0) $ iterate (`quot` 2) n)
+
+pattern Vars :: [Int] -> [Var]
+pattern Vars ns <- (coerce @[Var] @[Int] -> ns)
+{-# COMPLETE Vars #-}
+
+sameElems :: VarSet -> IntSet -> Property
+sameElems xs ys = VarSet.toAscList xs === IntSet.toAscList ys
+
+--------------------------------------------------------------------------------
+-- Construction
+
+prop_empty :: Property
+prop_empty = VarSet.empty `sameElems` IntSet.empty
+
+prop_singleton :: Var -> Property
+prop_singleton (Var n) = VarSet.singleton n `sameElems` IntSet.singleton n
+
+prop_fromList :: [Var] -> Property
+prop_fromList (Vars ns) = VarSet.fromList ns `sameElems` IntSet.fromList ns
+
+prop_full :: Var -> Property
+prop_full (Var n) = VarSet.full n `sameElems` IntSet.fromList [0..n-1]
+
+-- We only have 'IntSet.fromRange' for @containers >= 0.7@, which
+-- is not on stackage for GHC 9.6.7.
+prop_range :: Var -> Var -> Property
+prop_range (Var lo) (Var hi) =
+  VarSet.range (lo - 1) (hi + 1) `sameElems` IntSet.fromList [lo..hi]
+
+--------------------------------------------------------------------------------
+-- Insertion
+
+prop_insert :: Var -> [Var] -> Property
+prop_insert (Var n) (Vars ns) =
+  VarSet.insert n (VarSet.fromList ns) `sameElems` IntSet.insert n (IntSet.fromList ns)
+
+--------------------------------------------------------------------------------
+-- Deletion
+
+prop_delete :: Var -> [Var] -> Property
+prop_delete (Var n) (Vars ns) =
+  VarSet.delete n (VarSet.fromList ns) `sameElems` IntSet.delete n (IntSet.fromList ns)
+
+--------------------------------------------------------------------------------
+-- Queries
+
+prop_null :: [Var] -> Property
+prop_null (Vars ns) =
+  VarSet.null (VarSet.fromList ns) === IntSet.null (IntSet.fromList ns)
+
+prop_member :: Var -> [Var] -> Property
+prop_member (Var n) (Vars ns) =
+  VarSet.member n (VarSet.fromList ns) === IntSet.member n (IntSet.fromList ns)
+
+-- @lookupMin@ is only available in @containers >= 0.8@, so we emulate it instead.
+prop_lookupMin :: [Var] -> Property
+prop_lookupMin (Vars []) = VarSet.lookupMin VarSet.empty === Nothing
+prop_lookupMin (Vars ns) = fromJust (VarSet.lookupMin (VarSet.fromList ns)) === IntSet.findMin (IntSet.fromList ns)
+
+prop_size :: [Var] -> Property
+prop_size (Vars ns) =
+    VarSet.size (VarSet.fromList ns) === IntSet.size (IntSet.fromList ns)
+
+prop_disjoint :: [Var] -> [Var] -> Property
+prop_disjoint (Vars ns1) (Vars ns2) =
+    VarSet.disjoint (VarSet.fromList ns1) (VarSet.fromList ns2) === IntSet.disjoint (IntSet.fromList ns1) (IntSet.fromList ns2)
+
+prop_isSubsetOf :: [Var] -> [Var] -> Property
+prop_isSubsetOf (Vars ns1) (Vars ns2) =
+    VarSet.isSubsetOf (VarSet.fromList ns1) (VarSet.fromList ns2) === IntSet.isSubsetOf (IntSet.fromList ns1) (IntSet.fromList ns2)
+
+-- There is no analog to 'VarSet.inRange', so we have to emulate it.
+prop_inRange :: Var -> Var -> [Var] -> Property
+prop_inRange (Var lo) (Var hi) (Vars ns) =
+  let intSet = IntSet.fromList ns in
+  VarSet.inRange (lo - 1) (hi + 1) (VarSet.fromList ns) === (IntSet.lookupLT lo intSet == Nothing && IntSet.lookupGT hi intSet == Nothing)
+
+--------------------------------------------------------------------------------
+-- Combining VarSets
+
+prop_union :: [Var] -> [Var] -> Property
+prop_union (Vars ns1) (Vars ns2) =
+    VarSet.union (VarSet.fromList ns1) (VarSet.fromList ns2) `sameElems` IntSet.union (IntSet.fromList ns1) (IntSet.fromList ns2)
+
+prop_unions :: [[Var]] -> Property
+prop_unions nss =
+  VarSet.unions (fmap (VarSet.fromList . coerce) nss) `sameElems` IntSet.unions (fmap (IntSet.fromList . coerce) nss)
+
+prop_intersection :: [Var] -> [Var] -> Property
+prop_intersection (Vars ns1) (Vars ns2) =
+    VarSet.intersection (VarSet.fromList ns1) (VarSet.fromList ns2) `sameElems` IntSet.intersection (IntSet.fromList ns1) (IntSet.fromList ns2)
+
+prop_difference :: [Var] -> [Var] -> Property
+prop_difference (Vars ns1) (Vars ns2) =
+    VarSet.difference (VarSet.fromList ns1) (VarSet.fromList ns2) `sameElems` IntSet.difference (IntSet.fromList ns1) (IntSet.fromList ns2)
+
+prop_complement :: Var -> [Var] -> Property
+prop_complement (Var n) (Vars ns) =
+  VarSet.complement n (VarSet.fromList ns) `sameElems` (IntSet.fromList [0..n-1] IntSet.\\ IntSet.fromList ns)
+
+--------------------------------------------------------------------------------
+-- Filters
+
+prop_split :: Var -> [Var] -> Property
+prop_split (Var n) (Vars ns) =
+    let (vs1, vs2) = VarSet.split n (VarSet.fromList ns)
+        (is1, is2) = IntSet.split n (IntSet.fromList ns)
+    in (vs1 `sameElems` is1) .&&. (vs2 `sameElems` is2)
+
+--------------------------------------------------------------------------------
+-- Views
+
+prop_minView :: [Var] -> Property
+prop_minView (Vars ns) =
+  case (VarSet.minView (VarSet.fromList ns), IntSet.minView (IntSet.fromList ns)) of
+    (Just (v, vs), Just (i, is)) -> (v === i) .&&. (vs `sameElems` is)
+    (Nothing, Nothing) -> property True
+    (vs, is) -> counterexample (show vs <> " /= " <> show is) (property False)
+
+--------------------------------------------------------------------------------
+-- Folds
+
+prop_foldr :: (Function a, CoArbitrary a, Arbitrary a, Show a, Eq a) => Fun (Int, a) a -> a -> [Var] -> Property
+prop_foldr f a (Vars xs) =
+  VarSet.foldr (applyFun2 f) a (VarSet.fromList xs) === IntSet.foldr (applyFun2 f) a (IntSet.fromList xs)
+
+prop_foldl :: (Function a, CoArbitrary a, Arbitrary a, Show a, Eq a) => Fun (a, Int) a -> a -> [Var] -> Property
+prop_foldl f a (Vars xs) =
+  VarSet.foldl (applyFun2 f) a (VarSet.fromList xs) === IntSet.foldl (applyFun2 f) a (IntSet.fromList xs)
+
+--------------------------------------------------------------------------------
+-- Contextual operations
+
+prop_strengthen :: Var -> [Var] -> Property
+prop_strengthen (Var n) (Vars ns) =
+  VarSet.strengthen n (VarSet.fromList ns) `sameElems` IntSet.filter (>= 0) (IntSet.map (\x -> x - n) (IntSet.fromList ns))
+
+prop_weaken :: Var -> [Var] -> Property
+prop_weaken (Var n) (Vars ns) =
+  VarSet.weaken n (VarSet.fromList ns) `sameElems` IntSet.map (\x -> x + n) (IntSet.fromList ns)
+
+--------------------------------------------------------------------------------
+-- Conversions
+
+prop_toDescList :: [Var] -> Property
+prop_toDescList (Vars ns) =
+  VarSet.toDescList (VarSet.fromList ns) === IntSet.toDescList (IntSet.fromList ns)
+
+-- Technically redundant as 'sameElems' uses toDescList, but if this
+-- fails we know something has truly gone south.
+prop_toAscList :: [Var] -> Property
+prop_toAscList (Vars ns) =
+  VarSet.toAscList (VarSet.fromList ns) === IntSet.toAscList (IntSet.fromList ns)
+
+--------------------------------------------------------------------------------
+-- Serialization
+
+prop_decode_encode :: [Var] -> Property
+prop_decode_encode (Vars ns) =
+  let xs = VarSet.fromList ns
+  in decode @VarSet (encode xs) === xs
+
+
+------------------------------------------------------------------------
+-- All tests
+------------------------------------------------------------------------
+
+-- Template Haskell hack to make the following $allProperties work
+-- under ghc-7.8.
+return [] -- KEEP!
+
+tests :: TestTree
+tests = testProperties "Internal.Utils.VarSet" $allProperties


### PR DESCRIPTION
# Overview

This PR replaces the implementation of `VarSet` with an optimized bitset. This ends up shaving a few percentage points off of the runtime, and shaves about 4 gigabytes off of the total number of bytes allocated.

# Design

The `IntSet` from `containers` is implemented as a Patricia tree. This lets it handle values that are distributed across the entire range of `Int`, but at the cost of lots of pointer indirections and allocations. This makes it ill-suited for storing de Bruijn indices, which are almost always very small, and always positive.

The new implementation of `VarSet` uses a bitset instead of a tree-based set. When the largest index in the set is smaller than the machine-word size,  it stores the set into a single unboxed `Word#`. Otherwise, it falls back to an unboxed `ByteArray#`. After some experiments on `1lab`, `agda-stdlib`, and `cubical`, it seems that we can use the single word representation 99.999% of the time on a 64 bit machine (see below for detailed statistics).

# Benchmarks

Some timing/allocation information obtained from a clean build of the `1lab`.

### `master`

```
Total                                   1,143,748ms            
Miscellaneous                               3,909ms            
Typing                                    112,569ms (673,590ms)
Typing.CheckRHS                           172,947ms            
Typing.InstanceSearch                       5,822ms (125,232ms)
Typing.InstanceSearch.FilterCandidates     73,998ms            
Typing.InstanceSearch.CheckOverlap         24,530ms            
Typing.InstanceSearch.InitialCandidates    20,875ms            
Typing.Reflection                         102,465ms            
Typing.OccursCheck                         81,103ms            
Typing.TypeSig                             28,995ms            
Typing.CheckLHS                            21,657ms  (25,230ms)
Typing.CheckLHS.UnifyIndices                3,573ms            
Typing.Generalize                          23,380ms            
Typing.With                                 1,664ms            
Serialization                              91,879ms (113,950ms)
Serialization.BinaryEncode                  9,815ms            
Serialization.Compress                      8,621ms            
Serialization.Sort                          2,961ms            
Serialization.BuildInterface                  672ms            
Parsing                                    12,650ms  (78,983ms)
Parsing.OperatorsExpr                      59,717ms            
Parsing.OperatorsPattern                    6,616ms            
Positivity                                 70,780ms            
Scoping                                     6,905ms  (49,101ms)
Scoping.InverseScopeLookup                 42,196ms            
Deserialization                            25,987ms  (35,726ms)
Deserialization.Compaction                  9,739ms            
InterfaceInstantiateFull                   34,594ms            
DeadCode                                      449ms  (34,086ms)
DeadCode.DeadCodeReachable                 33,637ms            
Coverage                                   22,113ms  (25,963ms)
Coverage.UnifyIndices                       3,849ms            
Termination                                 4,436ms  (13,340ms)
Termination.RecCheck                        8,071ms            
Termination.Compare                           729ms            
Termination.Graph                             102ms            
Highlighting                                6,441ms            
Import                                      1,514ms            
ProjectionLikeness                          1,113ms            
Injectivity                                   621ms            
ModuleName                                     35ms            
1,892,968,669,952 bytes allocated in the heap
 217,003,414,496 bytes copied during GC
   2,614,137,712 bytes maximum residency (211 sample(s))
       6,659,280 bytes maximum slop
            5214 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     450601 colls,     0 par   314.367s  326.421s     0.0007s    0.1884s
  Gen  1       211 colls,     0 par   41.646s  46.947s     0.2225s    3.6161s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.004s  (  0.004s elapsed)
  MUT     time  787.811s  (790.366s elapsed)
  GC      time  356.013s  (373.369s elapsed)
  EXIT    time    0.699s  (  0.000s elapsed)
  Total   time  1144.528s  (1163.739s elapsed)

  Alloc rate    2,402,820,581 bytes per MUT second

  Productivity  68.8% of total user, 67.9% of total elapsed
```

### `compact-var-sets`

```
Total                                   1,128,565ms            
Miscellaneous                               3,796ms            
Typing                                    109,324ms (671,606ms)
Typing.CheckRHS                           174,889ms            
Typing.InstanceSearch                       5,873ms (124,588ms)
Typing.InstanceSearch.FilterCandidates     74,415ms            
Typing.InstanceSearch.CheckOverlap         23,951ms            
Typing.InstanceSearch.InitialCandidates    20,342ms            
Typing.Reflection                         104,270ms            
Typing.OccursCheck                         81,977ms            
Typing.TypeSig                             28,693ms            
Typing.CheckLHS                            20,707ms  (24,214ms)
Typing.CheckLHS.UnifyIndices                3,506ms            
Typing.Generalize                          21,944ms            
Typing.With                                 1,703ms            
Serialization                              89,732ms (111,940ms)
Serialization.BinaryEncode                  9,505ms            
Serialization.Compress                      8,503ms            
Serialization.Sort                          3,525ms            
Serialization.BuildInterface                  673ms            
Parsing                                    12,487ms  (77,877ms)
Parsing.OperatorsExpr                      58,866ms            
Parsing.OperatorsPattern                    6,523ms            
Positivity                                 70,250ms            
Scoping                                     6,783ms  (47,983ms)
Scoping.InverseScopeLookup                 41,200ms            
Deserialization                            27,199ms  (36,767ms)
Deserialization.Compaction                  9,568ms            
DeadCode                                      411ms  (33,835ms)
DeadCode.DeadCodeReachable                 33,423ms            
InterfaceInstantiateFull                   27,790ms            
Coverage                                   21,401ms  (25,121ms)
Coverage.UnifyIndices                       3,720ms            
Termination                                 4,604ms  (12,009ms)
Termination.RecCheck                        6,546ms            
Termination.Compare                           764ms            
Termination.Graph                              94ms            
Highlighting                                6,374ms            
Import                                      1,420ms            
ProjectionLikeness                          1,162ms            
Injectivity                                   597ms            
ModuleName                                     36ms            
1,888,858,607,424 bytes allocated in the heap
 216,089,119,952 bytes copied during GC
   2,450,331,080 bytes maximum residency (212 sample(s))
       6,643,720 bytes maximum slop
            4381 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     449630 colls,     0 par   314.772s  326.567s     0.0007s    0.0448s
  Gen  1       212 colls,     0 par   39.452s  43.803s     0.2066s    2.6451s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.004s  (  0.004s elapsed)
  MUT     time  774.441s  (775.975s elapsed)
  GC      time  354.224s  (370.370s elapsed)
  EXIT    time    0.744s  (  0.000s elapsed)
  Total   time  1129.413s  (1146.349s elapsed)

  Alloc rate    2,438,996,902 bytes per MUT second

  Productivity  68.6% of total user, 67.7% of total elapsed
```

I've also included the results of the variable set size experiments for those interested.

| library     | commit hash                              | varsets allocated | non-word sized sets |
| ----------- | ---------------------------------------- | ----------------- | ------------------- |
| 1lab        | 11f4672ca7dcfdccb1b4ce94ca4ca42c9b732e62 | 118198551         | 0                   |
| agda-stdlib | 0e97e2ed1f999ea0d2cce2a3b2395d5a9a7bd36a | 38960049          | 2178                |
| cubical     | 1f2af52701945bef003a525f78fa41aeadb7c6ae | 82751805          | 0                   |
