### PR TITLE
Benchmarking and profiling for module application

### DIFF
--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -98,6 +98,8 @@ data Phase
     -- ^ Subphase for 'Typing': solving instance goals
   | Reflection
     -- ^ Subphase for 'Typing': evaluating elaborator reflection
+  | ApplySection
+    -- ^ Subphase for 'Typing': copying definitions for a module macro
   | InitialCandidates
     -- ^ Subphase for 'InstanceSearch': collecting initial candidates
   | FilterCandidates

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -1209,7 +1209,7 @@ createInterface mname sf@(SourceFile sfi) isMain msrc = do
     -- Profiling: Count number of metas.
     whenProfile Profile.Metas $ do
       m <- fresh
-      tickN "metas" (fromIntegral (metaId m))
+      tickN "metas" (metaId m)
 
     -- Highlighting from type checker.
     reportSLn "import.iface.highlight" 15 $ prettyShow mname ++ ": Starting highlighting from type info."
@@ -1318,7 +1318,7 @@ createInterface mname sf@(SourceFile sfi) isMain msrc = do
     -- Get the statistics of the current module
     -- and add it to the accumulated statistics.
     localStatistics <- getStatistics
-    lensAccumStatistics `modifyTCLens` Map.unionWith (+) localStatistics
+    lensAccumStatistics `modifyTCLens'` (<>) localStatistics
     reportSLn "import.iface" 25 $ prettyShow mname ++ ": Added statistics to the accumulated statistics."
 
     isPrimitiveMod <- isPrimitiveModule sfi

--- a/src/full/Agda/TypeChecking/Conversion/Pure.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Pure.hs
@@ -171,7 +171,8 @@ instance PureTCM m => MonadWarning (PureConversionT m) where
     AllWarnings   -> return ()
 
 instance ReadTCState m => MonadStatistics (PureConversionT m) where
-  modifyCounter _ _ = return ()
+  tickN   _ _ = return ()
+  tickMax _ _ = return ()
 
 instance Monad m => MonadFresh ProblemId (PureConversionT m) where
   fresh = do

--- a/src/full/Agda/TypeChecking/DiscrimTree.hs
+++ b/src/full/Agda/TypeChecking/DiscrimTree.hs
@@ -81,7 +81,7 @@ termKeyElims precise ty args = do
 -- incremented.
 tickExplore :: Term -> TCM ()
 tickExplore tm = whenProfile Profile.Instances do
-  tick "flex term blocking instance"
+  tick "explore"
 
   case tm of
     Def{}      -> tick "explore: Def"

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -43,6 +43,7 @@ import Agda.TypeChecking.Monad.Open
 import Agda.TypeChecking.Monad.Options
 import Agda.TypeChecking.Monad.State
 import Agda.TypeChecking.Monad.Trace
+import Agda.TypeChecking.Monad.Statistics
 import Agda.TypeChecking.DropArgs
 import Agda.TypeChecking.Warnings
 import Agda.TypeChecking.Positivity.Occurrence
@@ -58,6 +59,7 @@ import {-# SOURCE #-} Agda.TypeChecking.Reduce
 import {-# SOURCE #-} Agda.TypeChecking.Opacity
 import {-# SOURCE #-} Agda.TypeChecking.Telescope
 
+import qualified Agda.Utils.ProfileOptions as Profile
 import Agda.Utils.CallStack.Base
 import Agda.Utils.Either
 import Agda.Utils.Function ( applyWhen )
@@ -483,6 +485,19 @@ applySection' new ptel old ts ScopeCopyInfo{ renNames = rd, renModules = rm } = 
     , "old  =" <+> pretty old
     , "ts   =" <+> pretty ts
     ]
+
+  whenProfile Profile.Sections do
+    oldn <- show <$> pretty old
+
+    let
+      ds = fromIntegral $ Map.size rd
+      ms = fromIntegral $ Map.size rm
+
+    tickMax "largest copied section" (ds + ms)
+    tickN   "copied definitions"     ds
+    tickN   "copied modules"         ms
+    tickN   ("copies for " <> oldn)  (ds + ms)
+
   _ <- Map.traverseWithKey (traverse . copyDef ts) rd
   _ <- Map.traverseWithKey (traverse . copySec ts) rm
   computePolarity (Map.elems rd >>= List1.toList)

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -989,7 +989,9 @@ checkSectionApplication'
   -> A.ScopeCopyInfo     -- ^ Imported names and modules
   -> TCM ()
 checkSectionApplication'
-  i er m1 (A.SectionApp ptel m2 args) copyInfo = do
+  i er m1 (A.SectionApp ptel m2 args) copyInfo =
+  Bench.billTo [Bench.Typing, Bench.ApplySection]
+  do
   -- If the section application is erased, then hard compile-time mode
   -- is entered.
   warnForPlentyInHardCompileTimeMode er

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -40,6 +40,7 @@ import Control.Monad.State.Strict
 import Control.Monad.ST.Trans
 
 import Data.Array.IArray
+import Data.Foldable (traverse_)
 import Data.Array.IO
 import Data.Word
 import Data.Word (Word32)
@@ -124,9 +125,9 @@ encode a = do
       statistics "A.QName"     qnameC
       statistics "A.Name"      nameC
     when collectStats $ do
-      stats <- Map.fromListWith __IMPOSSIBLE__ . map (second toInteger) <$> do
+      stats <- map (second fromIntegral) <$> do
         liftIO $ List.sort <$> H.toList stats
-      modifyStatistics $ Map.unionWith (+) stats
+      traverse_ (uncurry tickN) stats
     -- Encode hashmaps and root, and compress.
     bits1 <- Bench.billTo [ Bench.Serialization, Bench.BinaryEncode ] $
       return $!! B.encode (root, nL, ltL, stL, bL, iL, dL)

--- a/src/full/Agda/Utils/ProfileOptions.hs
+++ b/src/full/Agda/Utils/ProfileOptions.hs
@@ -30,16 +30,18 @@ import Agda.Utils.Null (Null, empty)
 --
 --   NOTE: Changing this data type requires bumping the interface version number in
 --   'Agda.TypeChecking.Serialise.currentInterfaceVersion'.
-data ProfileOption = Internal     -- ^ Measure time taken by various parts of the system (type checking, serialization, etc)
-                   | Modules      -- ^ Measure time spent on individual (Agda) modules
-                   | Definitions  -- ^ Measure time spent on individual (Agda) definitions
-                   | Sharing      -- ^ Measure things related to sharing
-                   | Serialize    -- ^ Collect detailed statistics about serialization
-                   | Constraints  -- ^ Collect statistics about constraint solving
-                   | Metas        -- ^ Count number of created metavariables
-                   | Interactive  -- ^ Measure time of interactive commands
-                   | Conversion   -- ^ Collect statistics about conversion checking
-                   | Instances    -- ^ Collect statistics about instance search
+data ProfileOption
+  = Internal     -- ^ Measure time taken by various parts of the system (type checking, serialization, etc)
+  | Modules      -- ^ Measure time spent on individual (Agda) modules
+  | Definitions  -- ^ Measure time spent on individual (Agda) definitions
+  | Sharing      -- ^ Measure things related to sharing
+  | Serialize    -- ^ Collect detailed statistics about serialization
+  | Constraints  -- ^ Collect statistics about constraint solving
+  | Metas        -- ^ Count number of created metavariables
+  | Interactive  -- ^ Measure time of interactive commands
+  | Conversion   -- ^ Collect statistics about conversion checking
+  | Instances    -- ^ Collect statistics about instance search
+  | Sections     -- ^ Collect statistics about section applications
   deriving (Show, Eq, Ord, Enum, Bounded, Generic)
 
 instance NFData ProfileOption

--- a/test/Fail/Issue5781a.err
+++ b/test/Fail/Issue5781a.err
@@ -1,4 +1,4 @@
 Issue5781a.agda:1.1-35: error: [OptionError]
 Not a valid profiling option: 'notclose'. Valid options are
 constraints, conversion, definitions, instances, interactive,
-internal, metas, modules, serialize, sharing, or all.
+internal, metas, modules, sections, serialize, sharing, or all.


### PR DESCRIPTION
Adds a `ApplySection` phase to the benchmarking trie so we can record how much time was spent *literally just copying definitions*, and a bunch of profiling ticks for the amount of copying that was done (under `--profile=sections`).

Also refactors the `Statistics` module to split the `tickN` and `tickMax` tables, otherwise the accumulated statistics reports nonsense like the max number of live constraints for a project is the sum of the max number of live constraints of each module.