### PR TITLE
fixup: range of InlineNoExactSplit warning

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -365,9 +365,10 @@ checkFunDefS t ai extlam with i name withSubAndLets cs = do
           forM cs $ \ cl -> do
             (cls, nonExactSplit) <- runChangeT $ recordRHSToCopatterns cl
             when nonExactSplit do
-              -- If we inlined a non-eta constructor,
-              -- issue a warning that the clause does not hold as definitional equality.
-              warning $ InlineNoExactSplit name cl
+              -- If we inlined a non-eta constructor, issue a warning
+              -- (pointing at the clause lhs) that the clause does not
+              -- hold as definitional equality.
+              setCurrentRange (clauseLHSRange cl) . warning $ InlineNoExactSplit name cl
             return cls
 
         -- After checking, remove the clauses again.

--- a/test/Fail/InlineNoExactSplit.agda
+++ b/test/Fail/InlineNoExactSplit.agda
@@ -1,0 +1,17 @@
+{-# OPTIONS --exact-split -Werror #-}
+module InlineNoExactSplit where
+
+open import Agda.Builtin.Sigma
+
+record ⊤ : Set₁ where
+  no-eta-equality
+  field
+    x : Set
+
+{-# INLINE ⊤.constructor #-}
+
+test : Σ Set₁ λ _ → ⊤
+test .fst = Set
+-- Warning should point to line 17 (the inlined clause) and not 14 (the
+-- overall function).
+test .snd = record {}

--- a/test/Fail/InlineNoExactSplit.err
+++ b/test/Fail/InlineNoExactSplit.err
@@ -1,0 +1,6 @@
+InlineNoExactSplit.agda:17.1-10: warning: -W[no]InlineNoExactSplit
+Exact splitting is enabled, but the following clause is no longer a
+definitional equality because it was translated to a copattern
+match:
+  test .snd = record { x = _x_3 }
+when checking the definition of test

--- a/test/Succeed/Issue6660-Stream.warn
+++ b/test/Succeed/Issue6660-Stream.warn
@@ -9,28 +9,28 @@ when scope checking the declaration
       head : A
       tail : Stream A
 
-Issue6660-Stream.agda:18.1-26: warning: -W[no]InlineNoExactSplit
+Issue6660-Stream.agda:18.1-7: warning: -W[no]InlineNoExactSplit
 Exact splitting is enabled, but the following clause is no longer a
 definitional equality because it was translated to a copattern
 match:
   nats n = n ∷ nats (1 + n)
 when checking the definition of nats
 
-Issue6660-Stream.agda:21.1-38: warning: -W[no]InlineNoExactSplit
+Issue6660-Stream.agda:21.1-8: warning: -W[no]InlineNoExactSplit
 Exact splitting is enabled, but the following clause is no longer a
 definitional equality because it was translated to a copattern
 match:
   map f s = f (head s) ∷ map f (tail s)
 when checking the definition of map
 
-Issue6660-Stream.agda:24.1-32: warning: -W[no]InlineNoExactSplit
+Issue6660-Stream.agda:24.1-6: warning: -W[no]InlineNoExactSplit
 Exact splitting is enabled, but the following clause is no longer a
 definitional equality because it was translated to a copattern
 match:
   nats1 = λ n → n ∷ nats1 (1 + n)
 when checking the definition of nats1
 
-Issue6660-Stream.agda:39.1-28: warning: -W[no]InlineNoExactSplit
+Issue6660-Stream.agda:39.1-6: warning: -W[no]InlineNoExactSplit
 Exact splitting is enabled, but the following clause is no longer a
 definitional equality because it was translated to a copattern
 match:
@@ -50,28 +50,28 @@ when scope checking the declaration
       head : A
       tail : Stream A
 
-Issue6660-Stream.agda:18.1-26: warning: -W[no]InlineNoExactSplit
+Issue6660-Stream.agda:18.1-7: warning: -W[no]InlineNoExactSplit
 Exact splitting is enabled, but the following clause is no longer a
 definitional equality because it was translated to a copattern
 match:
   nats n = n ∷ nats (1 + n)
 when checking the definition of nats
 
-Issue6660-Stream.agda:21.1-38: warning: -W[no]InlineNoExactSplit
+Issue6660-Stream.agda:21.1-8: warning: -W[no]InlineNoExactSplit
 Exact splitting is enabled, but the following clause is no longer a
 definitional equality because it was translated to a copattern
 match:
   map f s = f (head s) ∷ map f (tail s)
 when checking the definition of map
 
-Issue6660-Stream.agda:24.1-32: warning: -W[no]InlineNoExactSplit
+Issue6660-Stream.agda:24.1-6: warning: -W[no]InlineNoExactSplit
 Exact splitting is enabled, but the following clause is no longer a
 definitional equality because it was translated to a copattern
 match:
   nats1 = λ n → n ∷ nats1 (1 + n)
 when checking the definition of nats1
 
-Issue6660-Stream.agda:39.1-28: warning: -W[no]InlineNoExactSplit
+Issue6660-Stream.agda:39.1-6: warning: -W[no]InlineNoExactSplit
 Exact splitting is enabled, but the following clause is no longer a
 definitional equality because it was translated to a copattern
 match:


### PR DESCRIPTION
The warning was previously emitted in the context of checking the overall function, rather than the specific clause, so *the entire function* would be covered in the catchall clause highlighting.