### PR TITLE
Link to `latest` readthedocs rather than to `2.9.0`

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -856,6 +856,7 @@ library
       Agda.Utils.Functor
       Agda.Utils.Function
       Agda.Utils.GetOpt
+      Agda.Utils.Git
       Agda.Utils.Graph.AdjacencyMap.Unidirectional
       Agda.Utils.Graph.TopSort
       Agda.Utils.Hash
@@ -959,7 +960,7 @@ executable agda
 executable agda-mode
   import:           language
 
-  hs-source-dirs:   src/agda-mode src/setup
+  hs-source-dirs:   src/agda-mode src/setup src/full
   main-is:          Main.hs
   autogen-modules:
     Paths_Agda
@@ -970,6 +971,7 @@ executable agda-mode
     Agda.Setup.EmacsMode
     Agda.Version
     Agda.VersionCommit
+    Agda.Utils.Git
 
   build-depends:
     , base                 >= 4.16.4.0  && < 4.22
@@ -979,6 +981,7 @@ executable agda-mode
     , filepath             >= 1.4.2.2   && < 1.6
     , gitrev               >= 1.3.1     && < 2
     , process              >= 1.6.16.0  && < 1.7
+    , regex-tdfa           >= 1.3.2.1   && < 1.4
     , template-haskell     >= 2.18.0.0  && < 2.24
 
 -- Cabal testsuite integration has some serious bugs, but we
@@ -1061,6 +1064,7 @@ test-suite agda-tests
       Internal.Utils.SmallSet
       Internal.Utils.Three
       Internal.Utils.Trie
+      Internal.Version
       LaTeXAndHTML.Tests
       LibSucceed.Tests
       Succeed.Tests

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -27,7 +27,7 @@ import Agda.Utils.Null
 
 import Agda.Utils.Impossible
 
-import Agda.Version (docsUrl)
+import Agda.VersionCommit (docsUrl)
 
 sayWhere :: MonadPretty m => HasRange a => a -> m Doc -> m Doc
 sayWhere x d = prettyTCM (getRange x) $$ d

--- a/src/full/Agda/Utils/Git.hs
+++ b/src/full/Agda/Utils/Git.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Git utilities.
+
+module Agda.Utils.Git where
+
+import Control.Exception          ( SomeException, try )
+import Data.List                  ( lines )
+import Language.Haskell.TH        ( Q, Exp )
+import Language.Haskell.TH.Syntax ( lift, runIO )
+import System.Process             ( readProcess )
+
+-- | Get a Git tags pointing at HEAD, if any, at compile time.
+--   Returns an expression that produces the possibly empty string list of tags.
+gitTags :: Q Exp
+gitTags = do
+  let call = readProcess "git" ["tag", "--points-at", "HEAD"] ""
+  result <- runIO $ try call :: Q (Either SomeException String)
+  lift $ either (const []) lines result

--- a/src/setup/Agda/Version.hs
+++ b/src/setup/Agda/Version.hs
@@ -3,7 +3,6 @@
 module Agda.Version
   ( version
   , package
-  , docsUrl
   ) where
 
 import GHC.Generics ( Generic, Rep, packageName )
@@ -24,10 +23,5 @@ version = intercalate "." $ map show $
 
 package :: String
 package = packageName (undefined :: Rep AnArbitrarySymbolInThisPackage p)
-
--- | Returns a URL corresponding to the given section in the documentation for
--- the current version.
-docsUrl :: String -> String
-docsUrl section = "https://agda.readthedocs.io/en/v" ++ version ++ "/" ++ section
 
 data AnArbitrarySymbolInThisPackage deriving Generic

--- a/src/setup/Agda/VersionCommit.hs
+++ b/src/setup/Agda/VersionCommit.hs
@@ -7,9 +7,13 @@
 
 module Agda.VersionCommit where
 
-import Development.GitRev
+import Data.Maybe         ( fromMaybe )
+import Data.List          ( find )
+import Development.GitRev ( gitHash, gitDirtyTracked )
+import Text.Regex.TDFA    ( (=~) )
 
-import Agda.Version
+import Agda.Version       ( version )
+import Agda.Utils.Git     ( gitTags )
 
 -- | Agda's version suffixed with the git commit hash.
 versionWithCommitInfo :: String
@@ -29,3 +33,21 @@ commitInfo
 
     -- Abbreviate a commit hash while keeping it unambiguous
     abbrev = take 7
+
+-- | Returns a URL corresponding to the given section in the documentation for
+-- the current version.
+-- The current version is @latest@ unless the current commit has a release tag.
+docsUrl :: String -> String
+docsUrl = (prefix ++)
+  where
+    prefix = "https://agda.readthedocs.io/en/" ++ v ++ "/"
+    v      = fromMaybe "latest" $ find isReleaseTag tags
+    tags   = $(gitTags)
+
+-- | Release tags are @nightly@ or @vNNN.NNN.NNN...@.
+isReleaseTag :: String -> Bool
+isReleaseTag tag = tag == "nightly" || tag =~ versionPattern
+
+-- | Recognize a release tag.
+versionPattern :: String
+versionPattern = "v[0-9]+\\.[0-9]+\\.[0-9]+.*"

--- a/test/Fail/Issue1963MagicWith.err
+++ b/test/Fail/Issue1963MagicWith.err
@@ -3,4 +3,4 @@ p .proj₁ != w of type Nat
 when checking that the type
 (p : Σ Nat IsZero) (w : Nat) → F w (p .proj₂) of the generated with
 function is well-formed
-(https://agda.readthedocs.io/en/v2.9.0/language/with-abstraction.html#ill-typed-with-abstractions)
+(https://agda.readthedocs.io/en/latest/language/with-abstraction.html#ill-typed-with-abstractions)

--- a/test/Fail/Issue206.err
+++ b/test/Fail/Issue206.err
@@ -2,4 +2,4 @@ Issue206.agda:12.1-19: error: [UnequalTerms]
 w != i of type I
 when checking that the type (w : I) (p : P w) (q : Q p) → Set₁ of
 the generated with function is well-formed
-(https://agda.readthedocs.io/en/v2.9.0/language/with-abstraction.html#ill-typed-with-abstractions)
+(https://agda.readthedocs.io/en/latest/language/with-abstraction.html#ill-typed-with-abstractions)

--- a/test/Fail/Issue2763.err
+++ b/test/Fail/Issue2763.err
@@ -2,4 +2,4 @@ Issue2763.agda:15.1-19: error: [UnequalTerms]
 a != w of type A
 when checking that the type ⊤ → (w : A) → G w b of the generated
 with function is well-formed
-(https://agda.readthedocs.io/en/v2.9.0/language/with-abstraction.html#ill-typed-with-abstractions)
+(https://agda.readthedocs.io/en/latest/language/with-abstraction.html#ill-typed-with-abstractions)

--- a/test/Fail/Issue2771.err
+++ b/test/Fail/Issue2771.err
@@ -3,4 +3,4 @@ Issue2771.agda:15.1-19: error: [UnequalTerms]
 when checking that the type
 (ind : IndexL) → ⊤ → (w : IndexL) → ¬ord-morph w (pres-¬ord ind) of
 the generated with function is well-formed
-(https://agda.readthedocs.io/en/v2.9.0/language/with-abstraction.html#ill-typed-with-abstractions)
+(https://agda.readthedocs.io/en/latest/language/with-abstraction.html#ill-typed-with-abstractions)

--- a/test/Fail/Issue530.err
+++ b/test/Fail/Issue530.err
@@ -2,4 +2,4 @@ Issue530.agda:20.1-10: error: [UnequalTerms]
 k a != w of type Unit
 when checking that the type (w : Unit) → F w p of the generated
 with function is well-formed
-(https://agda.readthedocs.io/en/v2.9.0/language/with-abstraction.html#ill-typed-with-abstractions)
+(https://agda.readthedocs.io/en/latest/language/with-abstraction.html#ill-typed-with-abstractions)

--- a/test/Fail/Issue5805.err
+++ b/test/Fail/Issue5805.err
@@ -8,4 +8,4 @@ when checking that the type
 (ff≡f : (_53 ∘ _53) ≡ _53) →
 ?1 (ff≡f = ff≡f) (λ x → _53 (_53 x)) ≡ ?1 (ff≡f = ff≡f) _53 → Set
 of the generated with function is well-formed
-(https://agda.readthedocs.io/en/v2.9.0/language/with-abstraction.html#ill-typed-with-abstractions)
+(https://agda.readthedocs.io/en/latest/language/with-abstraction.html#ill-typed-with-abstractions)

--- a/test/Fail/MagicWith.err
+++ b/test/Fail/MagicWith.err
@@ -3,4 +3,4 @@ fst p != w of type Nat
 when checking that the type
 (p : Nat × IsZero) (w : Nat) → F w (snd p) of the generated with
 function is well-formed
-(https://agda.readthedocs.io/en/v2.9.0/language/with-abstraction.html#ill-typed-with-abstractions)
+(https://agda.readthedocs.io/en/latest/language/with-abstraction.html#ill-typed-with-abstractions)

--- a/test/Internal/Tests.hs
+++ b/test/Internal/Tests.hs
@@ -55,6 +55,7 @@ import qualified Internal.Utils.RangeMap
 import qualified Internal.Utils.SmallSet
 import qualified Internal.Utils.Three
 import qualified Internal.Utils.Trie
+import qualified Internal.Version
 
 -- Keep this list in the import order, please!
 tests :: TestTree
@@ -107,4 +108,5 @@ tests = testGroup "Internal" $
   Internal.Utils.SmallSet.tests :
   Internal.Utils.Three.tests :
   Internal.Utils.Trie.tests :
+  Internal.Version.tests :
   []

--- a/test/Internal/Version.hs
+++ b/test/Internal/Version.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Internal.Version ( tests ) where
+
+import Agda.VersionCommit
+
+import Internal.Helpers
+
+prop_isReleaseTag :: Bool
+prop_isReleaseTag = all isReleaseTag
+  [ "v2.9.0"
+  , "v2.8.0-rc1"
+  , "v2.7.20250701"
+  , "v2.6.4.3"
+  , "v2.6.4.2-rc1"
+  , "v2.6.4.0.20231111"
+  ]
+
+------------------------------------------------------------------------
+-- * All tests
+------------------------------------------------------------------------
+
+-- Template Haskell hack to make the following $allProperties work
+-- under ghc-7.8.
+return [] -- KEEP!
+
+-- | All tests as collected by 'allProperties'.
+--
+-- Using 'allProperties' is convenient and superior to the manual
+-- enumeration of tests, since the name of the property is added
+-- automatically.
+
+tests :: TestTree
+tests = testProperties "Internal.Version" $allProperties


### PR DESCRIPTION
- **`docsUrl` should link to `latest` from development version**
  Before it has linked to `v2.9.0` (version) which does not exist on
  agda.readthedocs.org.
  Now, we are linking to `latest` unless Agda is build from a commit
  tagged with a version number, like `v2.9.0` or `v2.8.20260303` or
  similar.
  

- ~~Add Aspect URL and print urls as clickable links on terminal~~ already pushed to `master`

Loose ends:
- makes the release process a bit more brittle as one has to tag _before_ building
- the script `src/release-notes/change-version.bash` needs updating
- a redirect solution on agda.readthedocs.io would be preferable but I have not found one
  