### PR TITLE
Only generate copies for used names

### DIFF
--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -305,7 +305,19 @@ checkModuleMacro apply kind r p e x modapp open dir = do
           (DontOpen, _)     -> (dir, defaultImportDir)
 
     -- Restore the locals after module application has been checked.
-    (modapp', copyInfo, adir') <- withLocalVars $ checkModuleApplication modapp m0 x moduleDir
+    (modapp', copyInfo', adir') <- withLocalVars $ checkModuleApplication modapp m0 x moduleDir
+
+    -- Mark the copy as being private (renPublic = False) if the module
+    -- name is PrivateAccess and not open public.
+    -- If the user gave an explicit 'using'/'renaming'/etc, keep the
+    -- copy as 'public' to avoid trimming.
+    let
+      visible = case p of
+        PrivateAccess{} -> not (null dir) || isJust (publicOpen dir)
+        _               -> True
+
+      copyInfo = copyInfo'{ renPublic = visible }
+
     printScope "mod.inst.app" 40 "checkModuleMacro, after checkModuleApplication"
 
     reportSDoc "scope.decl" 90 $ "after mod app: trying to print m0 ..."
@@ -1123,13 +1135,20 @@ recordWhereNames = finish <=< foldM decl st0 where
   -- take the name from the ScopeCopyInfo if it is present (i.e. if the
   -- import directive is associated with a local module-macro),
   -- otherwise we trust that the scope checker did the right thing...
-  def :: Maybe ScopeCopyInfo -> A.QName -> PendingBinds
-  def (Just ren) nm = case Map.lookup nm (renNames ren) of
-    Just (new :| _) -> pb (nameConcrete (qnameName nm)) (A.Def new) (getRange nm)
-    Nothing         -> pb (nameConcrete (qnameName nm)) (A.Def nm) (getRange nm)
-  def Nothing nm = pb (nameConcrete (qnameName nm)) (A.Def nm) (getRange nm)
+  def :: Maybe ScopeCopyInfo -> A.QName -> ScopeM PendingBinds
+  def ren nm = do
+    let
+      new = case ren of
+        Just ren -> maybe nm List1.head $ Map.lookup nm (renNames ren)
+        Nothing  -> nm
 
-  fromRenaming :: Maybe ScopeCopyInfo -> [A.Renaming] -> PendingBinds
+    -- N.B.: since this is somewhere we might invent a reference to an
+    -- internal name that does not go through resolveName', we have to
+    -- explicitly mark the name we used as alive.
+    pb (nameConcrete (qnameName nm)) (A.Def new) (getRange nm)
+      <$ markLiveName new
+
+  fromRenaming :: Maybe ScopeCopyInfo -> [A.Renaming] -> ScopeM PendingBinds
   fromRenaming ren fs | (rens, _) <- partitionImportedNames (map renTo fs) = foldMap (def ren) rens
 
   fromImport :: Maybe ScopeCopyInfo -> A.ImportDirective -> ScopeM PendingBinds
@@ -1137,8 +1156,8 @@ recordWhereNames = finish <=< foldM decl st0 where
     case using of
       UseEverything
         | null renaming -> pure mempty -- TODO: raise a warning?
-        | otherwise     -> pure $! fromRenaming inv renaming
-      Using using | (names, _) <- partitionImportedNames using -> pure $!
+        | otherwise     -> fromRenaming inv renaming
+      Using using | (names, _) <- partitionImportedNames using ->
         fromRenaming inv renaming <> foldMap (def inv) names
 
   ins :: PendingBinds -> RecWhereState -> RecWhereState

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -248,7 +248,7 @@ data PreScopeState = PreScopeState
     -- ^ Cached @.agda-lib@ files.
   , stPreImportedMetaStore :: !RemoteMetaStore
     -- ^ Used for meta-variables from other modules.
-  , stPreCopiedNames       :: !(HashMap A.QName A.QName)
+  , stPreCopiedNames       :: !(HashMap A.QName (ScopeCopyRef, A.QName))
     -- ^ Associates a copied name (the key) to its original name (the
     -- value). Computed by the scope checker, used to compute opaque
     -- blocks.
@@ -665,7 +665,7 @@ lensLibCache f s = f (stPreLibCache s) <&> \ x -> s { stPreLibCache = x }
 lensImportedMetaStore :: Lens' PreScopeState RemoteMetaStore
 lensImportedMetaStore f s = f (stPreImportedMetaStore s) <&> \x -> s { stPreImportedMetaStore = x }
 
-lensCopiedNames :: Lens' PreScopeState (HashMap QName QName)
+lensCopiedNames :: Lens' PreScopeState (HashMap QName (ScopeCopyRef, QName))
 lensCopiedNames f s = f (stPreCopiedNames s) <&> \ x -> s { stPreCopiedNames = x }
 
 lensNameCopies :: Lens' PreScopeState (HashMap QName (HashSet QName))
@@ -886,7 +886,7 @@ stLibCache = lensPreScopeState . lensLibCache
 stImportedMetaStore :: Lens' TCState RemoteMetaStore
 stImportedMetaStore = lensPreScopeState . lensImportedMetaStore
 
-stCopiedNames :: Lens' TCState (HashMap QName QName)
+stCopiedNames :: Lens' TCState (HashMap QName (ScopeCopyRef, QName))
 stCopiedNames = lensPreScopeState . lensCopiedNames
 
 stNameCopies :: Lens' TCState (HashMap QName (HashSet QName))

--- a/src/full/Agda/TypeChecking/Opacity.hs
+++ b/src/full/Agda/TypeChecking/Opacity.hs
@@ -46,7 +46,7 @@ saturateOpaqueBlocks = entry where
     inverse <- useTC stOpaqueIds
     OpaqueId _ ourmod <- fresh
 
-    canonical <- useTC stCopiedNames
+    canonical  <- fmap snd <$> useTC stCopiedNames
     backcopies <- useTC stNameCopies
 
     reportSDoc "tc.opaque.copy" 45 $ "Canonical names of copied definitions:" $+$ pretty (HashMap.toList canonical)

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -206,11 +206,13 @@ instance PrettyTCM Call where
 
     SetRange r -> fsep (pwords "when doing something at") <+> prettyTCM r
 
-    CheckSectionApplication _ erased m1 modapp -> fsep $
-      pwords "when checking the module application" ++
-      [prettyA $ A.Apply info erased m1 modapp initCopyInfo empty]
+    CheckSectionApplication _ erased m1 modapp -> do
+      fsep $
+        pwords "when checking the module application" ++
+        [prettyA $ A.Apply info erased m1 modapp copy empty]
       where
       info = A.ModuleInfo noRange noRange Nothing Nothing Nothing
+      copy = ScopeCopyInfo { renNames = mempty, renModules = mempty, renPublic = True, renTrimming = __IMPOSSIBLE__ }
 
     ModuleContents -> fsep $ pwords "when retrieving the contents of a module"
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -30,9 +30,9 @@ instance EmbPrj A.BindName where
   value = valueN A.BindName
 
 instance EmbPrj Scope where
-  icod_ (Scope a b c d e) = icodeN' Scope a b c d e
+  icod_ (Scope a b c d e f) = icodeN' (\a b c d e -> Scope a b c d e f) a b c d e
 
-  value = valueN Scope
+  value = valueN \a b c d e -> Scope a b c d e Nothing
 
 instance EmbPrj DataOrRecordModule where
   icod_ IsDataModule   = pure 0

--- a/test/Fail/Issue644.agda
+++ b/test/Fail/Issue644.agda
@@ -34,4 +34,3 @@ foo₂ = Foo₂ r
 -- not mention
 --
 --   (x : A) → .Bug.M₂._.P r x
-

--- a/test/Fail/Issue644.agda
+++ b/test/Fail/Issue644.agda
@@ -34,3 +34,4 @@ foo₂ = Foo₂ r
 -- not mention
 --
 --   (x : A) → .Bug.M₂._.P r x
+

--- a/test/Fail/Issue644.err
+++ b/test/Fail/Issue644.err
@@ -1,3 +1,3 @@
 Issue644.agda:28.13-14: error: [UnequalTerms]
-R !=< ((x : A) → P x)
-when checking that the expression r has type (x : A) → P x
+R !=< ((x : A) → R.P r x)
+when checking that the expression r has type (x : A) → R.P r x

--- a/test/Fail/Issue721b.agda
+++ b/test/Fail/Issue721b.agda
@@ -13,5 +13,5 @@ data _≡_ {A : Set} (x : A) : A → Set where
 
 test : (F : Foo false) → let open Foo F in (x : Bool) → _*_ x ≡ (λ x → x)
 test F x = x
-  where open Foo F
+  where open Foo F using (_*_)
 -- Don't want to see any anonymous module

--- a/test/Fail/Issue721b.agda
+++ b/test/Fail/Issue721b.agda
@@ -13,5 +13,15 @@ data _≡_ {A : Set} (x : A) : A → Set where
 
 test : (F : Foo false) → let open Foo F in (x : Bool) → _*_ x ≡ (λ x → x)
 test F x = x
-  where open Foo F using (_*_)
+  where open Foo F
 -- Don't want to see any anonymous module
+
+-- Re. #8038: if the copy of _*_ from the anonymous module in the where
+-- clause (not used) is trimmed, we might see
+--
+--   Bool !=< (F Foo.* x) ≡ (λ x₁ → x₁)
+--
+-- in the error message (see Issue721trim). In interactive development a
+-- user wouldn't see that, but it still doesn't mention the anonymous
+-- module.
+_ = ?

--- a/test/Fail/Issue721trim.agda
+++ b/test/Fail/Issue721trim.agda
@@ -1,0 +1,17 @@
+module Issue721trim where
+
+data Bool : Set where
+  false true : Bool
+
+record Foo (b : Bool) : Set where
+  field
+    _*_ : Bool → Bool → Bool
+
+data _≡_ {A : Set} (x : A) : A → Set where
+  refl : x ≡ x
+
+test : (F : Foo false) → let open Foo F in (x : Bool) → _*_ x ≡ (λ x → x)
+test F x = x
+  where open Foo F
+-- See 721b, #8038: copy trimming applies here and the error message
+-- should mention F Foo.*, not an anonymous module

--- a/test/Fail/Issue721trim.err
+++ b/test/Fail/Issue721trim.err
@@ -1,0 +1,4 @@
+Issue721trim.agda:14.12-13: error: [UnequalTerms]
+Bool !=< (F Foo.* x) ≡ (λ x₁ → x₁)
+when checking that the expression x has type
+(F Foo.* x) ≡ (λ x₁ → x₁)


### PR DESCRIPTION
Implements the idea from #8035 using an `IORef` stored in the `ScopeCopyInfo` to share the `LiveNames` across every reference to the copied module, so marking a name/module as live consists of one `HashMap.lookup`/`Map.lookup` and one `Set.insert`.

Regarding state management, these `IORef`s are updated exclusively by the scope checker, in a single pair of functions (one for names, one for modules), and the type checker reads them exactly once, when checking the corresponding module application. The `LiveNames` contained in the `IORef` is then discarded (explicitly).

I think this is a pretty good approach because it doesn't change anything fundamental about how the module system works; That the 1Lab checks as-is with this PR, even though we use parametrised modules quite a lot, seems to me a pretty good indication that there are no user-facing changes to correct code.

For the numbers, well, the 1Lab build is finally back under 10 minutes :slightly_smiling_face: (on my monster computer.) As expected the biggest reduction is in `ApplySection`, which goes from ~5% of the total build time to ~1%. As a reminder, `ApplySection` measures the time it took to check the module application itself, and then to make all the copies. 

| Metric               |      `master` |        this PR | absolute difference |     % decrease |
| -------------------- | ------------- | -------------- | ------------------- | -------------- |
| **Total**            | **625,097ms** |  **582,281ms** |          **-42.8s** |      **6.84%** |
| Typing.ApplySection  |      32,333ms |        7,447ms |              -24.8s |         76.96% |
| Serialization        |      60,131ms |       49,771ms |              -10.3s |         17.22% |
| Positivity           |      34,027ms |       23,921ms |              -10.1s |         29.69% |
| Typing               |      28,800ms |       23,071ms |               -5.7s |         19.89% |

The positivity checking speedup is also nice to see, and I can explain it. We have a lot of definitions that look like the one below, where `Cat.Reasoning` is a module of about ~300 combinators for working with categories. Since these copies are all before the fields they were all previously traversed during termination checking, but ~none of these records actually use all 300 of the combinators, so all of this work was wasted.

```agda
record Equivalence (C D : Category) : Type where
  private
    module C = Cat.Reasoning C
    module D = Cat.Reasoning D
  -- ...
```

#### Standard library times

(Courtesy of CI, so the absolute numbers are on a different scale to the ones above.)

| Metric               |      `master` |       this PR | absolute difference | % decrease |
| -------------------- | ------------- | ------------- | ------------------- | ---------- |
| **Total**            | **399,581ms** | **381,065ms** |         **-18.5s**  |   **4.6%** |
| Serialization        |      48,263ms |      46,306ms |              -1.9s  |       4.0% |
| Typing               |      13,840ms |      11,734ms |              -2.1s  |      15.2% |
| Typing.Generalize    |      17,776ms |      14,968ms |              -2.8s  |      15.7% |
| Positivity           |      17,654ms |      13,802ms |              -3.8s  |      21.8% |
| Typing.ApplySection  |      14,427ms |       6,966ms |              -7.4s  |      51.7% |

### Caveats

Strictly speaking this causes a regression in error messages for failing modules *that do not have any interaction points:* if you have a copied definition `x` whose *type* has another copied definition `T`, but you only mention `x` in your program, error messages will probably *not* refer to `T`, because we didn't generate any display forms for it.

However, as soon as your module has any interaction points, the type checker goes back to making All The Copies, so goal display and error messages during development shouldn't suffer. We could probably improve interactive development *slightly* by making interaction points only clobber the modules that are actually in scope at them, but any improvement beyond that would require fundamental changes to the module system (since we have to have all the copies the user *could* interact with ready by the time they do).

We could remedy the error message situation by temporarily setting aside `Closure`s of the section applications with all the copies we did *not* make, and actually doing all these copies (thus generating the display forms) before printing an error message. Getting the scoping right here seems pretty tricky, and Agda isn't really a "check-get error-react to error" language so I didn't feel it was worth doing for a first attempt.