### PR TITLE
Fuse deserialisation and compacting

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -840,6 +840,7 @@ library
       Agda.TypeChecking.With
       Agda.Utils.AffineHole
       Agda.Utils.Applicative
+      Agda.Utils.Arena
       Agda.Utils.AssocList
       Agda.Utils.Bag
       Agda.Utils.Benchmark
@@ -857,6 +858,7 @@ library
       Agda.Utils.Favorites
       Agda.Utils.FileId
       Agda.Utils.FileName
+      Agda.Utils.Fingerprint
       Agda.Utils.Float
       Agda.Utils.Function
       Agda.Utils.Functor

--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -68,8 +68,6 @@ data Phase
     -- ^ Subphase for 'Termination'.
   | ModuleName
     -- ^ Subphase for 'Import'.
-  | Compaction
-    -- ^ Subphase for 'Deserialization': compacting interfaces.
   | BuildInterface
     -- ^ Subphase for 'Serialization'.
   | Sort

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -69,8 +69,8 @@ import Agda.TypeChecking.Monad
 import qualified Agda.Interaction.Options.ProfileOptions as Profile
 import qualified Agda.Utils.HashTable as H
 import Agda.Utils.IORef
-import Agda.Utils.Null
 import Agda.Utils.Arena
+import Agda.Utils.Null
 import Agda.Utils.Hash
 
 import Agda.Utils.Impossible
@@ -214,13 +214,9 @@ decode s = do
     let ar = unListLike
     when (not (null s)) $ E.throwIO $ E.ErrorCall "Garbage at end."
     let nL' = ar nL
-    rgn <- compact ()
-    withArena rgn \arena -> do
-    st <- St nL' (ar ltL) (ar stL) (ar bL) (ar iL) (ar dL)
-      <$> liftIO (newArray (bounds nL') MEEmpty)
-      <*> return mf
-      <*> return incs
-      <*> pure arena
+    withArena \arena -> do
+    nodeM <- newArray (bounds nL') MEEmpty
+    let st = St nL' (ar ltL) (ar stL) (ar bL) (ar iL) (ar dL) nodeM mf incs arena
     (!r, st) <- runStateT (value r) st
     let !mf = modFile st
     return $ Right (mf, r)

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -264,7 +264,7 @@ mapPairsIcode xs = icodeNode =<< convert Empty xs where
     entry <- icode entry
     convert (Cons start (Cons entry ys)) xs
 
-mapPairsValue :: (EmbPrj k, EmbPrj v) => [Word32] -> R [(k, v)]
+mapPairsValue :: (EmbPrj k, EmbPrj v) => [Word32] -> R r [(k, v)]
 mapPairsValue = convert [] where
   convert ys [] = return ys
   convert ys (start:entry:xs) = do
@@ -637,7 +637,7 @@ instance EmbPrj PolarityModality where
     (p, o, l) <- polPair
     return $ PolarityModality p o l
     where
-      polPair :: R (ModalPolarity, ModalPolarity, ModalPolarity)
+      polPair :: R r (ModalPolarity, ModalPolarity, ModalPolarity)
       polPair = value n
 
 instance EmbPrj Modality where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Highlighting.hs
@@ -141,7 +141,7 @@ instance EmbPrj a => EmbPrj (RM.RangeMap a) where
       convert (Cons start (Cons end (Cons entry ys))) xs
 
   value = vcase (fmap (RM.RangeMap . Map.fromDistinctAscList) . convert []) where
-    convert :: [(Int, RM.PairInt a)] -> [Word32] -> R [(Int, RM.PairInt a)]
+    convert :: [(Int, RM.PairInt a)] -> [Word32] -> R r [(Int, RM.PairInt a)]
     convert !ys [] = return ys
     convert  ys (start:end:entry:xs) = do
       !start <- value start

--- a/src/full/Agda/Utils/Arena.hs
+++ b/src/full/Agda/Utils/Arena.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE MagicHash, UnboxedTuples, RoleAnnotations #-}
+module Agda.Utils.Arena
+  ( Arena, withArena
+  , Ptr
+  , derefPtr
+  , allocPtr
+  )
+  where
+
+import GHC.Compact
+import GHC.Exts (Addr#, anyToAddr#, addrToAny#, keepAlive#)
+import GHC.IO (IO(..), unIO)
+
+-- | Reference to an "arena" of allocation quantified over the lifetime.
+--
+-- Arenas are backed by a native 'Compact' region, but allow values
+-- contained within to be represented by addresses rather than GC
+-- pointers, as long as the arena is alive when pointers are
+-- dereferenced. Parametrising by the lifetime guarantees this.
+newtype Arena r = Arena { getArena :: Compact () }
+type role Arena nominal
+
+-- | A pointer (immutable) to within an 'Arena'.
+data Ptr r a = Ptr { theAddress :: !Addr# }
+type role Ptr nominal representational
+
+-- | Run a computation which does not leak 'Ptr's and can place
+-- allocations into the given 'Compact' region.
+withArena :: forall r. Compact () -> (forall p. Arena p -> r) -> r
+withArena c k = k (Arena c)
+{-# INLINE withArena #-}
+
+-- | Derefence a pointer to within an 'Arena'.
+--
+-- The reference to the arena itself is needed so the garbage collector
+-- doesn't kill the compact region before the value is consumed.
+derefPtr :: forall r a. Arena r -> Ptr r a -> IO a
+derefPtr arena (Ptr a) = IO \s -> keepAlive# arena s \s ->
+  case addrToAny# a of
+    (# a #) -> (# s , a #)
+{-# INLINE derefPtr #-}
+
+-- | Move a value into an 'Arena'.
+--
+-- Returns the compacted value and a cheap 'Ptr' that refers to it.
+allocPtr :: forall r a. Arena r -> a -> IO (a, Ptr r a)
+allocPtr (Arena c) a = do
+  !ac <- compactAdd c a
+  let a = getCompact ac
+  IO \s -> a `seq` case anyToAddr# a s of
+    (# s , addr #) -> (# s , (a , Ptr addr) #)
+{-# INLINE allocPtr #-}

--- a/src/full/Agda/Utils/Arena.hs
+++ b/src/full/Agda/Utils/Arena.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE MagicHash, UnboxedTuples, RoleAnnotations #-}
+{-# LANGUAGE UnliftedNewtypes #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE MagicHash #-}
 module Agda.Utils.Arena
   ( Arena, withArena
   , Ptr
@@ -7,8 +10,10 @@ module Agda.Utils.Arena
   )
   where
 
-import GHC.Compact
-import GHC.Exts (Addr#, anyToAddr#, addrToAny#, keepAlive#)
+import Data.Kind (Type)
+
+import GHC.Compact (Compact(..))
+import GHC.Exts (Compact#, compactNew#, compactAdd#, Addr#, anyToAddr#, addrToAny#, keepAlive#)
 import GHC.IO (IO(..), unIO)
 
 -- | Reference to an "arena" of allocation quantified over the lifetime.
@@ -17,36 +22,37 @@ import GHC.IO (IO(..), unIO)
 -- contained within to be represented by addresses rather than GC
 -- pointers, as long as the arena is alive when pointers are
 -- dereferenced. Parametrising by the lifetime guarantees this.
-newtype Arena r = Arena { getArena :: Compact () }
+newtype Arena r = Arena { getArena :: Compact# }
 type role Arena nominal
 
 -- | A pointer (immutable) to within an 'Arena'.
-data Ptr r a = Ptr { theAddress :: !Addr# }
+data Ptr r (a :: Type) = Ptr { getPtr :: Addr# }
 type role Ptr nominal representational
 
 -- | Run a computation which does not leak 'Ptr's and can place
 -- allocations into the given 'Compact' region.
-withArena :: forall r. Compact () -> (forall p. Arena p -> r) -> r
-withArena c k = k (Arena c)
+withArena :: forall r. (forall p. Arena p -> IO r) -> IO r
+withArena k = IO \s -> case compactNew# 31268## s of
+  (# s , c# #) -> keepAlive# c# s \s -> unIO (k (Arena c#)) s
+  -- Size number taken from impl. of ghc-compact, I suspect so the
+  -- allocator gives us 32K-word blocks after accounting for
+  -- StgCompactNFDataBlock overhead and rounding.
 {-# INLINE withArena #-}
 
 -- | Derefence a pointer to within an 'Arena'.
 --
 -- The reference to the arena itself is needed so the garbage collector
 -- doesn't kill the compact region before the value is consumed.
-derefPtr :: forall r a. Arena r -> Ptr r a -> IO a
-derefPtr arena (Ptr a) = IO \s -> keepAlive# arena s \s ->
-  case addrToAny# a of
-    (# a #) -> (# s , a #)
+derefPtr :: forall r a. Ptr r a -> a
+derefPtr (Ptr a) = case addrToAny# a of
+  (# a #) -> a
 {-# INLINE derefPtr #-}
 
 -- | Move a value into an 'Arena'.
 --
 -- Returns the compacted value and a cheap 'Ptr' that refers to it.
 allocPtr :: forall r a. Arena r -> a -> IO (a, Ptr r a)
-allocPtr (Arena c) a = do
-  !ac <- compactAdd c a
-  let a = getCompact ac
-  IO \s -> a `seq` case anyToAddr# a s of
+allocPtr (Arena c) !a = IO \s -> case compactAdd# c a s of
+  (# s , a #) -> case anyToAddr# a s of
     (# s , addr #) -> (# s , (a , Ptr addr) #)
 {-# INLINE allocPtr #-}

--- a/src/full/Agda/Utils/Fingerprint.hs
+++ b/src/full/Agda/Utils/Fingerprint.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RoleAnnotations, MagicHash #-}
+{-# LANGUAGE RoleAnnotations #-}
 -- | Compact representations for type-indexed 'Fingerprint's.
 module Agda.Utils.Fingerprint
   ( Fingerprint

--- a/src/full/Agda/Utils/Fingerprint.hs
+++ b/src/full/Agda/Utils/Fingerprint.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE RoleAnnotations, MagicHash #-}
+-- | Compact representations for type-indexed 'Fingerprint's.
+module Agda.Utils.Fingerprint
+  ( Fingerprint
+  , sameFingerprint
+  , typeFingerprint
+  )
+  where
+
+import Data.Typeable (Typeable, (:~:)(Refl), Proxy, typeRep, typeRepFingerprint)
+
+import qualified GHC.Fingerprint.Type as P
+
+import Unsafe.Coerce
+
+-- | A 'Fingerprint' parametrised over the type it represents but which
+-- stores as a single Word64.
+newtype Fingerprint a = Fingerprint { theFingerprint :: P.Fingerprint }
+type role Fingerprint nominal
+
+-- | Compare fingerprints, returning evidence that the types are
+-- identical when they match.
+sameFingerprint :: forall a b. Fingerprint a -> Fingerprint b -> Maybe (a :~: b)
+sameFingerprint (Fingerprint a) (Fingerprint b)
+  | a == b    = Just (unsafeCoerce Refl)
+  | otherwise = Nothing
+
+-- 2023-10-2 András: `typeRepFingerprint` usually inlines a 4-way case, which
+-- yields significant code size increase as GHC often inlines the same code into
+-- the branches. This wouldn't matter in "normal" code but the serialization
+-- instances use very heavy inlining. The NOINLINE cuts down on the code size.
+typeFingerprint :: forall a. Typeable a => Proxy a -> Fingerprint a
+typeFingerprint rep = Fingerprint (typeRepFingerprint (typeRep rep))
+{-# NOINLINE typeFingerprint #-}


### PR DESCRIPTION
Right now we first deserialise interface files and then `compactWithSharing` them, which has to traverse the entire structure again, maintaining a hashmap of things at the RTS level to put pointers back together. This is actually pretty expensive, though it saves pretty good time in garbage collection.

But we essentially already have the information of what pointers should go where, so we might as well just construct the decoded interface directly into a compact region: all of the work `compactWithSharing` is doing is totally wasted.

Introduces a couple wrappers for managing cheap references to values inside a compact reference (`Arena`): since compacts are pinned, we can refer to anything inside one by an `Addr#`. This doesn't save any space, but it does save *time*, because the garbage collector won't traverse `Addr#` stored in constructors. We can use the `ST` trick to guarantee that the arena will still be alive when we get around to reading the values.

### Timings

Compaction only takes up between ~1% and ~2% of checking time, so I think a better benchmark is just the time it takes to cold start Agda when all the dependencies have been checked. Before vs. after:

<details>
<summary> (You can click on this to see GC stats)

```
Total                      19,414ms           
Miscellaneous                   3ms           
Deserialization            12,965ms (19,179ms)
Deserialization.Compaction  6,214ms           
Import                        198ms           
Parsing                        32ms

  30,117,348,824 bytes allocated in the heap
  13,405,752,632 bytes copied during GC
   1,522,098,512 bytes maximum residency (30 sample(s))
       1,507,360 bytes maximum slop
            2664 MiB total memory in use (0 MB lost due to fragmentation)         
```

</summary>

```
                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      6378 colls,     0 par    6.974s   7.057s     0.0011s    0.0190s
  Gen  1        30 colls,     0 par    0.613s   0.619s     0.0206s    0.1332s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time   11.962s  ( 12.072s elapsed)
  GC      time    7.587s  (  7.675s elapsed)
  EXIT    time    0.000s  (  0.003s elapsed)
  Total   time   19.550s  ( 19.750s elapsed)

  Alloc rate    2,517,829,608 bytes per MUT second

  Productivity  61.2% of total user, 61.1% of total elapsed
```

</details>

<details>
<summary> (GC stats hidden here too)

```
Total           14,077ms 
Miscellaneous        6ms 
Deserialization 13,914ms 
Import             122ms 
Parsing             32ms

  33,987,237,464 bytes allocated in the heap
   9,962,794,304 bytes copied during GC
   1,690,627,264 bytes maximum residency (24 sample(s))
       1,461,336 bytes maximum slop
            3274 MiB total memory in use (0 MiB lost due to fragmentation)
```

</summary>

```
                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      7179 colls,     0 par    4.835s   4.867s     0.0007s    0.0030s
  Gen  1        24 colls,     0 par    0.534s   0.537s     0.0224s    0.1599s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    8.869s  (  8.904s elapsed)
  GC      time    5.370s  (  5.405s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time   14.240s  ( 14.309s elapsed)

  Alloc rate    3,832,015,244 bytes per MUT second

  Productivity  62.3% of total user, 62.2% of total elapsed
```

</details>

As you can see it's essentially a 1:1 tradeoff of space for time, with a ~25% decrease in deserialisation time met by a corresponding ~20% increase in maximum memory usage. This relationship continues to hold with increased allocation area ("nursery") size. So whether this PR should be merged depends on whether we think our users have more RAM than they have patience (I certainly do).

<details>
<summary>Here's before/after with slightly increased nursery size (`-A128M`)</summary>

```
% old-agda _build/all-pages.agda --profile=internal +RTS -s -A128M -RTS
Total                      17,531ms           
Miscellaneous                   4ms           
Deserialization             9,865ms (17,361ms)
Deserialization.Compaction  7,496ms           
Import                        129ms           
Parsing                        34ms           
  29,963,748,640 bytes allocated in the heap
   1,416,920,856 bytes copied during GC
   1,380,092,160 bytes maximum residency (8 sample(s))
       1,436,040 bytes maximum slop
            1980 MiB total memory in use (48 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0       190 colls,     0 par    1.420s   1.437s     0.0076s    0.0409s
  Gen  1         8 colls,     0 par    0.243s   0.245s     0.0307s    0.0795s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.002s  (  0.002s elapsed)
  MUT     time   15.950s  ( 16.150s elapsed)
  GC      time    1.663s  (  1.682s elapsed)
  EXIT    time    0.000s  (  0.007s elapsed)
  Total   time   17.615s  ( 17.840s elapsed)

  Alloc rate    1,878,576,396 bytes per MUT second

  Productivity  90.5% of total user, 90.5% of total elapsed

% ./new-agda _build/all-pages.agda --profile=internal +RTS -s -A128M -RTS
Total           13,291ms 
Miscellaneous        4ms 
Deserialization 13,134ms 
Import             121ms 
Parsing             30ms 
  33,818,069,240 bytes allocated in the heap
   1,525,491,088 bytes copied during GC
   2,026,042,248 bytes maximum residency (8 sample(s))
       1,428,744 bytes maximum slop
            2395 MiB total memory in use (58 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0       216 colls,     0 par    1.402s   1.413s     0.0065s    0.0414s
  Gen  1         8 colls,     0 par    0.225s   0.226s     0.0283s    0.0986s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.002s  (  0.002s elapsed)
  MUT     time   11.764s  ( 11.837s elapsed)
  GC      time    1.628s  (  1.639s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time   13.394s  ( 13.478s elapsed)

  Alloc rate    2,874,611,641 bytes per MUT second

  Productivity  87.8% of total user, 87.8% of total elapsed
```