### PR TITLE
deepseq-1.5.2.0 no longer derives NFData with embedded functions

### DIFF
--- a/src/full/Agda/Compiler/Backend/Base.hs
+++ b/src/full/Agda/Compiler/Backend/Base.hs
@@ -13,7 +13,7 @@ import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
 import Agda.Syntax.Position (Range)
 
 import Agda.Interaction.Base (CommandM')
-import Agda.Interaction.Options (ArgDescr(..), OptDescr(..), Flag)
+import Agda.Interaction.Options (OptDescr, Flag)
 
 type BackendVersion = Text
 
@@ -88,15 +88,21 @@ instance NFData (Backend_boot definition tcm) where
   rnf (Backend b) = rnf b
 
 instance NFData opts => NFData (Backend'_boot definition tcm opts env menv mod def) where
-  rnf (Backend' a b c d e f g h i j k l m n) =
-    rnf a `seq` rnf b `seq` rnf c `seq` rnf' d `seq` rnf e `seq`
-    rnf f `seq` rnf g `seq` rnf h `seq` rnf i `seq` rnf j `seq`
-    rnf k `seq` rnf l `seq` rnf m `seq` rnf n
-    where
-    rnf' []                   = ()
-    rnf' (Option a b c d : e) =
-      rnf a `seq` rnf b `seq` rnf'' c `seq` rnf d `seq` rnf' e
-
-    rnf'' (NoArg a)    = rnf a
-    rnf'' (ReqArg a b) = rnf a `seq` rnf b
-    rnf'' (OptArg a b) = rnf a `seq` rnf b
+  rnf (Backend' a b c d e f g h i j k l !m !n) =
+    rnf a `seq`
+    rnf b `seq`
+    rnf c `seq`
+    -- Andreas, 2025-07-31, cannot normalize functions with deepseq-1.5.2.0 (GHC 9.10.3).
+    -- see https://github.com/haskell/deepseq/issues/111.
+    -- rnf d `seq`
+    -- rnf e `seq`
+    -- rnf f `seq`
+    -- rnf g `seq`
+    -- rnf h `seq`
+    -- rnf i `seq`
+    -- rnf j `seq`
+    rnf k `seq`
+    -- rnf l `seq`
+    -- rnf m `seq`
+    -- rnf n `seq`
+    ()

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -6678,7 +6678,6 @@ instance NFData DisambiguatedName
 instance NFData MutualBlock
 instance NFData OpaqueBlock
 instance NFData (BiMap RawTopLevelModuleName ModuleNameHash)
-instance NFData PersistentTCState
 instance NFData SessionTCState
 instance NFData LoadedFileCache
 instance NFData TypeCheckAction
@@ -6705,7 +6704,6 @@ instance NFData Instantiation
 instance NFData RemoteMetaVariable
 instance NFData Frozen
 instance NFData PrincipalArgTypeMetas
-instance NFData TypeCheckingProblem
 instance NFData RunMetaOccursCheck
 instance NFData MetaInfo
 instance NFData InteractionPoint
@@ -6744,7 +6742,6 @@ instance NFData Defn
 instance NFData Simplification
 instance NFData AllowedReduction
 instance NFData ReduceDefs
-instance NFData PrimFun
 instance NFData c => NFData (FunctionInverse' c)
 instance NFData TermHead
 instance NFData Call
@@ -6785,3 +6782,28 @@ instance NFData CannotQuote
 instance NFData ExecError
 instance NFData ConstructorDisambiguationData
 instance NFData Statistics
+
+-- Andreas, 2025-07-31, cannot normalize functions with deepseq-1.5.2.0 (GHC 9.10.3).
+-- see https://github.com/haskell/deepseq/issues/111.
+
+instance NFData PersistentTCState where
+  rnf (PersistentTCSt a b c d _fun f g) =
+    rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf f `seq` rnf g
+
+instance NFData PrimFun where
+  rnf (PrimFun a b c _fun) = rnf a `seq` rnf b `seq` rnf c
+
+instance NFData TypeCheckingProblem where
+  rnf = \case
+    CheckExpr a b c ->
+      rnf a `seq` rnf b `seq` rnf c
+    CheckArgs a b c d e f _fun ->
+      rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f
+    CheckProjAppToKnownPrincipalArg a b c d e f g h i j k ->
+      rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f `seq` rnf g `seq` rnf h `seq` rnf i `seq` rnf j `seq` rnf k
+    CheckLambda a b c d ->
+      rnf a `seq` rnf b `seq` rnf c `seq` rnf d
+    DisambiguateConstructor a _fun ->
+      rnf a
+    DoQuoteTerm a b c ->
+      rnf a `seq` rnf b `seq` rnf c

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -244,5 +244,15 @@ billPureTo account = billTo account . return
 
 -- NFData instances.
 
-instance NFData a => NFData (BenchmarkOn a)
 instance NFData a => NFData (Benchmark a)
+
+-- Andreas, 2025-07-31:
+-- Generic derivation of NFData with embedded function spaces
+-- throws deprecation warning in GHC 9.10.3 (deepseq-1.5.2.0),
+-- see https://github.com/haskell/deepseq/issues/111 ,
+-- so we spell it out.
+instance NFData a => NFData (BenchmarkOn a) where
+  rnf = \case
+    BenchmarkOff -> ()
+    BenchmarkOn  -> ()
+    BenchmarkSome _fun -> ()  -- functions cannot be normalized

--- a/src/full/Agda/Utils/GetOpt.hs
+++ b/src/full/Agda/Utils/GetOpt.hs
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Agda.Utils.GetOpt
--- Copyright   :  (c) Sven Panne 2002-2005
+-- Copyright   :  (c) Sven Panne 2002-2005, Andreas Abel 2025
 -- License     :  BSD-style
 --
 -- This module provides facilities for parsing the command-line options
@@ -24,6 +24,7 @@ module Agda.Utils.GetOpt (
 ) where
 
 import Prelude
+import Control.DeepSeq (NFData, rnf)
 import Data.List (find)
 
 -- | What to do with options following non-options.
@@ -227,3 +228,16 @@ errUnrec optStr = "unrecognized option `" ++ optStr ++ "'\n"
 
 errNoArg :: String -> OptKind a
 errNoArg optStr = OptErr ("option `" ++ optStr ++ "' doesn't allow an argument\n")
+
+-- NFData instances (new over "System.Console.GetOpt")
+
+instance NFData a => NFData (OptDescr a) where
+  rnf (Option a b c d) = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
+
+instance NFData a => NFData (ArgDescr a) where
+  rnf = \case
+    NoArg a       -> rnf a
+    -- Andreas, 2025-07-31, cannot serialize functions
+    -- see https://github.com/haskell/deepseq/issues/111.
+    ReqArg _fun s -> rnf s
+    OptArg _fun s -> rnf s


### PR DESCRIPTION
With `deepseq-1.5.2.0` (shipped with GHC 9.10.3 RC1) we have to spell out the `NFData` instances for data types that embed function spaces, since they deprecated the `NFData (a -> b)` instance.

Released Agda will still build with deprecation warnings, yet for `master` we have `-Werror` so we need to fix this.

Upstream issue:
- haskell/deepseq#111