### PR TITLE
[ opt ] Force arguments to writeIORef

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -873,6 +873,7 @@ library
       Agda.Utils.IO.TempFile
       Agda.Utils.IO.UTF8
       Agda.Utils.IORef
+      Agda.Utils.IORef.Strict
       Agda.Utils.Impossible
       Agda.Utils.IndexedList
       Agda.Utils.IntSet.Infinite

--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -152,7 +152,7 @@ benchmarks = unsafePerformIO $ newIORef empty
 instance MonadBench IO where
   type BenchPhase IO = Phase
   getBenchmark = readIORef benchmarks
-  putBenchmark = writeIORef benchmarks
+  putBenchmark = writeIORef $! benchmarks
   finally = E.finally
 
 -- | Benchmark an IO computation and bill it to the given account.

--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -9,16 +9,16 @@ module Agda.Benchmarking where
 import Control.DeepSeq
 import qualified Control.Exception as E
 
-import Data.IORef
-
 import GHC.Generics (Generic)
 
 import System.IO.Unsafe
 
 import Agda.Syntax.Abstract.Name
 import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
+
 import Agda.Utils.Benchmark (MonadBench(..))
 import qualified Agda.Utils.Benchmark as B
+import Agda.Utils.IORef.Strict
 import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty
 
@@ -146,13 +146,13 @@ isInternalAccount _                  = True
 
 -- | Global variable to store benchmark statistics.
 {-# NOINLINE benchmarks #-}
-benchmarks :: IORef Benchmark
-benchmarks = unsafePerformIO $ newIORef empty
+benchmarks :: StrictIORef Benchmark
+benchmarks = unsafePerformIO $ newStrictIORef empty
 
 instance MonadBench IO where
   type BenchPhase IO = Phase
-  getBenchmark = readIORef benchmarks
-  putBenchmark = writeIORef $! benchmarks
+  getBenchmark = readStrictIORef benchmarks
+  putBenchmark = writeStrictIORef benchmarks
   finally = E.finally
 
 -- | Benchmark an IO computation and bill it to the given account.

--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -18,7 +18,7 @@ import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
 
 import Agda.Utils.Benchmark (MonadBench(..))
 import qualified Agda.Utils.Benchmark as B
-import Agda.Utils.IORef.Strict
+import qualified Agda.Utils.IORef.Strict as Strict
 import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty
 
@@ -146,13 +146,13 @@ isInternalAccount _                  = True
 
 -- | Global variable to store benchmark statistics.
 {-# NOINLINE benchmarks #-}
-benchmarks :: StrictIORef Benchmark
-benchmarks = unsafePerformIO $ newStrictIORef empty
+benchmarks :: Strict.IORef Benchmark
+benchmarks = unsafePerformIO $ Strict.newIORef empty
 
 instance MonadBench IO where
   type BenchPhase IO = Phase
-  getBenchmark = readStrictIORef benchmarks
-  putBenchmark = writeStrictIORef benchmarks
+  getBenchmark = Strict.readIORef benchmarks
+  putBenchmark = Strict.writeIORef benchmarks
   finally = E.finally
 
 -- | Benchmark an IO computation and bill it to the given account.

--- a/src/full/Agda/Syntax/Concrete/Glyph.hs
+++ b/src/full/Agda/Syntax/Concrete/Glyph.hs
@@ -17,13 +17,13 @@ module Agda.Syntax.Concrete.Glyph
 
 import Control.DeepSeq
 
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import qualified System.IO.Unsafe as UNSAFE (unsafePerformIO)
 
 import GHC.Generics (Generic)
 
 import Agda.Utils.Boolean
 import Agda.Utils.List
+import Agda.Utils.IORef.Strict
 import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty
 
@@ -46,16 +46,16 @@ instance IsBool UnicodeOrAscii where
     AsciiOnly -> False
 
 {-# NOINLINE unsafeUnicodeOrAsciiIORef #-}
-unsafeUnicodeOrAsciiIORef :: IORef UnicodeOrAscii
-unsafeUnicodeOrAsciiIORef = UNSAFE.unsafePerformIO $ newIORef UnicodeOk
+unsafeUnicodeOrAsciiIORef :: StrictIORef UnicodeOrAscii
+unsafeUnicodeOrAsciiIORef = UNSAFE.unsafePerformIO $ newStrictIORef UnicodeOk
 
 {-# NOINLINE unsafeSetUnicodeOrAscii #-}
 unsafeSetUnicodeOrAscii :: UnicodeOrAscii -> IO ()
-unsafeSetUnicodeOrAscii = writeIORef $! unsafeUnicodeOrAsciiIORef
+unsafeSetUnicodeOrAscii = writeStrictIORef unsafeUnicodeOrAsciiIORef
 
 -- | Are we allowed to use unicode supscript characters?
 unsafeUnicodeOrAscii :: UnicodeOrAscii
-unsafeUnicodeOrAscii = UNSAFE.unsafePerformIO (readIORef unsafeUnicodeOrAsciiIORef)
+unsafeUnicodeOrAscii = UNSAFE.unsafePerformIO (readStrictIORef unsafeUnicodeOrAsciiIORef)
 
 -- | Picking the appropriate set of special characters depending on
 -- whether we are allowed to use unicode or have to limit ourselves

--- a/src/full/Agda/Syntax/Concrete/Glyph.hs
+++ b/src/full/Agda/Syntax/Concrete/Glyph.hs
@@ -23,7 +23,7 @@ import GHC.Generics (Generic)
 
 import Agda.Utils.Boolean
 import Agda.Utils.List
-import Agda.Utils.IORef.Strict
+import qualified Agda.Utils.IORef.Strict as Strict
 import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty
 
@@ -46,16 +46,16 @@ instance IsBool UnicodeOrAscii where
     AsciiOnly -> False
 
 {-# NOINLINE unsafeUnicodeOrAsciiIORef #-}
-unsafeUnicodeOrAsciiIORef :: StrictIORef UnicodeOrAscii
-unsafeUnicodeOrAsciiIORef = UNSAFE.unsafePerformIO $ newStrictIORef UnicodeOk
+unsafeUnicodeOrAsciiIORef :: Strict.IORef UnicodeOrAscii
+unsafeUnicodeOrAsciiIORef = UNSAFE.unsafePerformIO $ Strict.newIORef UnicodeOk
 
 {-# NOINLINE unsafeSetUnicodeOrAscii #-}
 unsafeSetUnicodeOrAscii :: UnicodeOrAscii -> IO ()
-unsafeSetUnicodeOrAscii = writeStrictIORef unsafeUnicodeOrAsciiIORef
+unsafeSetUnicodeOrAscii = Strict.writeIORef unsafeUnicodeOrAsciiIORef
 
 -- | Are we allowed to use unicode supscript characters?
 unsafeUnicodeOrAscii :: UnicodeOrAscii
-unsafeUnicodeOrAscii = UNSAFE.unsafePerformIO (readStrictIORef unsafeUnicodeOrAsciiIORef)
+unsafeUnicodeOrAscii = UNSAFE.unsafePerformIO (Strict.readIORef unsafeUnicodeOrAsciiIORef)
 
 -- | Picking the appropriate set of special characters depending on
 -- whether we are allowed to use unicode or have to limit ourselves

--- a/src/full/Agda/Syntax/Concrete/Glyph.hs
+++ b/src/full/Agda/Syntax/Concrete/Glyph.hs
@@ -51,7 +51,7 @@ unsafeUnicodeOrAsciiIORef = UNSAFE.unsafePerformIO $ newIORef UnicodeOk
 
 {-# NOINLINE unsafeSetUnicodeOrAscii #-}
 unsafeSetUnicodeOrAscii :: UnicodeOrAscii -> IO ()
-unsafeSetUnicodeOrAscii = writeIORef unsafeUnicodeOrAsciiIORef
+unsafeSetUnicodeOrAscii = writeIORef $! unsafeUnicodeOrAsciiIORef
 
 -- | Are we allowed to use unicode supscript characters?
 unsafeUnicodeOrAscii :: UnicodeOrAscii

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -57,8 +57,6 @@ import Data.Text (Text)
 import qualified Data.Text.Lazy as TL
 import Data.Semigroup (Sum, Max)
 
-import Data.IORef
-
 import GHC.Generics (Generic)
 
 import System.IO (hFlush, stdout)
@@ -129,7 +127,7 @@ import Agda.Utils.FileName
 import Agda.Utils.Functor
 import Agda.Utils.Hash
 import Agda.Utils.IO        ( CatchIO, catchIO, showIOException )
-import Agda.Utils.IORef.Strict
+import qualified Agda.Utils.IORef.Strict as Strict
 import Agda.Utils.Lens
 import Agda.Utils.List
 import Agda.Utils.ListT
@@ -5860,7 +5858,7 @@ instance ReadTCState ReduceM where
 
 runReduceM :: ReduceM a -> TCM a
 runReduceM m = TCM $ \ r e -> do
-  s <- readStrictIORef r
+  s <- Strict.readIORef r
   E.evaluate $ unReduceM m $ ReduceEnv e s Nothing
   -- Andreas, 2021-05-13, issue #5379
   -- This was the following, which is apparently not strict enough
@@ -6121,7 +6119,7 @@ instance MonadBlock m => MonadBlock (ReaderT e m) where
 
 -- | The type checking monad transformer.
 -- Adds readonly 'TCEnv' and mutable 'TCState'.
-newtype TCMT m a = TCM { unTCM :: StrictIORef TCState -> TCEnv -> m a }
+newtype TCMT m a = TCM { unTCM :: Strict.IORef TCState -> TCEnv -> m a }
 
 -- | Type checking monad.
 type TCM = TCMT IO
@@ -6132,7 +6130,7 @@ mapTCMT f (TCM m) = TCM $ \ s e -> f (m s e)
 
 pureTCM :: MonadIO m => (TCState -> TCEnv -> a) -> TCMT m a
 pureTCM f = TCM $ \ r e -> do
-  s <- liftIO $ readStrictIORef r
+  s <- liftIO $ Strict.readIORef r
   return (f s e)
 {-# INLINE pureTCM #-}
 
@@ -6195,7 +6193,7 @@ instance MonadIO m => MonadIO (TCMT m) where
       x `seq` return x
     where
       wrap s r m = E.catch m $ \ err -> do
-        s <- readStrictIORef s
+        s <- Strict.readIORef s
         E.throwIO $ IOException (Just s) r err
 
 instance MonadIO m => MonadTCEnv (TCMT m) where
@@ -6203,8 +6201,8 @@ instance MonadIO m => MonadTCEnv (TCMT m) where
   localTC f (TCM m) = TCM $ \ s e -> m s (f e); {-# INLINE localTC #-}
 
 instance MonadIO m => MonadTCState (TCMT m) where
-  getTC   = TCM $ \ r _e -> liftIO (readStrictIORef r); {-# INLINE getTC #-}
-  putTC s = TCM $ \ r _e -> liftIO (writeStrictIORef r s); {-# INLINE putTC #-}
+  getTC   = TCM $ \ r _e -> liftIO (Strict.readIORef r); {-# INLINE getTC #-}
+  putTC s = TCM $ \ r _e -> liftIO (Strict.writeIORef r s); {-# INLINE putTC #-}
   modifyTC f = putTC . f =<< getTC; {-# INLINE modifyTC #-}
 
 instance MonadIO m => ReadTCState (TCMT m) where
@@ -6226,7 +6224,7 @@ instance MonadBlock TCM where
 instance (CatchIO m, MonadIO m) => MonadError TCErr (TCMT m) where
   throwError = liftIO . E.throwIO
   catchError m h = TCM $ \ r e -> do  -- now we are in the monad m
-    oldState <- liftIO $ readStrictIORef r
+    oldState <- liftIO $ Strict.readIORef r
     unTCM m r e `catchIO` \err -> do
       -- Reset the state, but do not forget changes to the persistent
       -- component. Not for pattern violations.
@@ -6234,8 +6232,8 @@ instance (CatchIO m, MonadIO m) => MonadError TCErr (TCMT m) where
         PatternErr{} -> return ()
         _            ->
           liftIO $ do
-            newState <- readStrictIORef r
-            writeStrictIORef r oldState { stPersistentState = stPersistentState newState }
+            newState <- Strict.readIORef r
+            Strict.writeIORef r oldState { stPersistentState = stPersistentState newState }
       unTCM (h err) r e
 
 -- | Like 'catchError', but resets the state completely before running the handler.
@@ -6246,9 +6244,9 @@ instance (CatchIO m, MonadIO m) => MonadError TCErr (TCMT m) where
 instance CatchImpossible TCM where
   catchImpossibleJust f m h = TCM $ \ r e -> do
     -- save the state
-    s <- readStrictIORef r
+    s <- Strict.readIORef r
     catchImpossibleJust f (unTCM m r e) $ \ err -> do
-      writeStrictIORef r s
+      Strict.writeIORef r s
       unTCM (h err) r e
 
 instance MonadIO m => MonadReduce (TCMT m) where
@@ -6383,9 +6381,9 @@ execError = locatedTypeError ExecError
 {-# SPECIALIZE runTCM :: TCEnv -> TCState -> TCM a -> IO (a, TCState) #-}
 runTCM :: MonadIO m => TCEnv -> TCState -> TCMT m a -> m (a, TCState)
 runTCM e s m = do
-  r <- liftIO $ newStrictIORef s
+  r <- liftIO $ Strict.newIORef s
   a <- unTCM m r e
-  s <- liftIO $ readStrictIORef r
+  s <- liftIO $ Strict.readIORef r
   return (a, s)
 
 -- | Running the type checking monad on toplevel (with initial state).
@@ -6394,7 +6392,7 @@ runTCMTop m = (Right <$> runTCMTop' m) `E.catch` (return . Left)
 
 runTCMTop' :: MonadIO m => TCMT m a -> m a
 runTCMTop' m = do
-  r <- liftIO $ newStrictIORef =<< initStateIO
+  r <- liftIO $ Strict.newIORef =<< initStateIO
   unTCM m r initEnv
 
 -- | 'runSafeTCM' runs a safe 'TCM' action (a 'TCM' action which

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -6203,7 +6203,7 @@ instance MonadIO m => MonadTCEnv (TCMT m) where
 
 instance MonadIO m => MonadTCState (TCMT m) where
   getTC   = TCM $ \ r _e -> liftIO (readIORef r); {-# INLINE getTC #-}
-  putTC s = TCM $ \ r _e -> liftIO (writeIORef r s); {-# INLINE putTC #-}
+  putTC s = TCM $ \ r _e -> liftIO (writeIORef r $! s); {-# INLINE putTC #-}
   modifyTC f = putTC . f =<< getTC; {-# INLINE modifyTC #-}
 
 instance MonadIO m => ReadTCState (TCMT m) where
@@ -6234,7 +6234,7 @@ instance (CatchIO m, MonadIO m) => MonadError TCErr (TCMT m) where
         _            ->
           liftIO $ do
             newState <- readIORef r
-            writeIORef r $ oldState { stPersistentState = stPersistentState newState }
+            writeIORef r $! oldState { stPersistentState = stPersistentState newState }
       unTCM (h err) r e
 
 -- | Like 'catchError', but resets the state completely before running the handler.
@@ -6247,7 +6247,7 @@ instance CatchImpossible TCM where
     -- save the state
     s <- readIORef r
     catchImpossibleJust f (unTCM m r e) $ \ err -> do
-      writeIORef r s
+      writeIORef r $! s
       unTCM (h err) r e
 
 instance MonadIO m => MonadReduce (TCMT m) where

--- a/src/full/Agda/TypeChecking/SizedTypes/Utils.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Utils.hs
@@ -13,7 +13,7 @@ debug :: IORef Bool
 debug = unsafePerformIO $ newIORef False
 
 setDebugging :: Bool -> IO ()
-setDebugging = writeIORef debug
+setDebugging = writeIORef $! debug
 
 trace :: String -> a -> a
 trace s = applyWhen (unsafePerformIO $ readIORef debug) $ Debug.trace s

--- a/src/full/Agda/TypeChecking/SizedTypes/Utils.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Utils.hs
@@ -2,21 +2,21 @@
 
 module Agda.TypeChecking.SizedTypes.Utils where
 
-import Data.IORef
 import qualified Debug.Trace as Debug
 import System.IO.Unsafe
 
 import Agda.Utils.Function
+import Agda.Utils.IORef.Strict
 
 {-# NOINLINE debug #-}
-debug :: IORef Bool
-debug = unsafePerformIO $ newIORef False
+debug :: StrictIORef Bool
+debug = unsafePerformIO $ newStrictIORef False
 
 setDebugging :: Bool -> IO ()
-setDebugging = writeIORef $! debug
+setDebugging = writeStrictIORef $! debug
 
 trace :: String -> a -> a
-trace s = applyWhen (unsafePerformIO $ readIORef debug) $ Debug.trace s
+trace s = applyWhen (unsafePerformIO $ readStrictIORef debug) $ Debug.trace s
 
 traceM :: Applicative f => String -> f ()
 traceM s = trace s $ pure ()

--- a/src/full/Agda/TypeChecking/SizedTypes/Utils.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Utils.hs
@@ -6,17 +6,17 @@ import qualified Debug.Trace as Debug
 import System.IO.Unsafe
 
 import Agda.Utils.Function
-import Agda.Utils.IORef.Strict
+import qualified Agda.Utils.IORef.Strict as Strict
 
 {-# NOINLINE debug #-}
-debug :: StrictIORef Bool
-debug = unsafePerformIO $ newStrictIORef False
+debug :: Strict.IORef Bool
+debug = unsafePerformIO $ Strict.newIORef False
 
 setDebugging :: Bool -> IO ()
-setDebugging = writeStrictIORef $! debug
+setDebugging = Strict.writeIORef debug
 
 trace :: String -> a -> a
-trace s = applyWhen (unsafePerformIO $ readStrictIORef debug) $ Debug.trace s
+trace s = applyWhen (unsafePerformIO $ Strict.readIORef debug) $ Debug.trace s
 
 traceM :: Applicative f => String -> f ()
 traceM s = trace s $ pure ()

--- a/src/full/Agda/Utils/IORef/Strict.hs
+++ b/src/full/Agda/Utils/IORef/Strict.hs
@@ -2,11 +2,14 @@
 -- inside the reference is always in WHNF.
 --
 -- This module should be imported qualified, ala
+--
 -- @
 -- import qualified Agda.Utils.IORef.Strict as Strict
 -- @
 module Agda.Utils.IORef.Strict
   (
+    -- * Strict IO references #strict-ioref#
+    --
     -- $strictIORef
     IORef
   , newIORef
@@ -22,8 +25,6 @@ import qualified Data.IORef as Lazy
 
 
 -- $strictIORef
--- * Strict IO references #strict-ioref#
---
 -- A classic laziness footgun is that 'IORef' does not force
 -- values written to it to weak-head normal form. This is a
 -- common source of space leaks, as illustrated by the following
@@ -104,20 +105,23 @@ import qualified Data.IORef as Lazy
 -- first @performBlockingMajorGC@ call.
 --
 -- These sorts of mistakes are very easy to make, and very hard to diagnose. This
--- module attempts to (partially) solve the problem by providing a 'StrictIORef' type,
+-- module attempts to (partially) solve the problem by providing an opaque wrapper around 'Data.IORef.IORef',
 -- along with a corresponding API that ensures that the value stored in the reference
 -- is always in weak-head normal form.
 --
--- == When should I use 'StrictIORef'?
+-- == When should I use strict references?
 --
--- The short answer is: "If you are unsure, you should probably use 'StrictIORef'".
+-- The short answer is: "If you are unsure, you should probably use strict references".
 --
 -- The less short answer depends on your usage patterns:
+--
 -- * Do you repeatedly read and then write to the reference? If so, you probably
---   want to use 'StrictIORef' to avoid space leaks like the first example.
+--   want to use strict references to avoid space leaks like the first example.
+--
 -- * Do you use the reference to store things that are computed from things that
---   shouldn't be kept live? If so, you probably want to use 'StrictIORef' to avoid
+--   shouldn't be kept live? If so, you probably want to use strict references to avoid
 --   memory leaks like the second example.
+--
 -- * Do you use the reference to store something that is expensive to compute
 --   that you rarely use? If so, you might want to use 'IORef' to
 --   avoid doing redundant work, though warnings about repeated read/writes and memory
@@ -125,39 +129,39 @@ import qualified Data.IORef as Lazy
 --
 -- == Caveats
 --
--- The API for 'StrictIORef' only ensures that the value in the reference is in
+-- The API for strict 'IORef' only ensures that the value in the reference is in
 -- weak-head normal form, *not* normal form. This is done for the sake of efficiency:
 -- using 'Control.DeepSeq.NFData' to place the value into normal form requires us to
 -- fully traverse the value being stored inside of the reference, which can be quite
 -- expensive for recursive structures.
 --
 -- This design decision does lead to some unfortunate gotchas. Namely, if you store
--- a type inside of a 'StrictIORef' that has non-strict fields, it is still possible
+-- a type inside of a strict 'IORef' that has non-strict fields, it is still possible
 -- to have space/memory leaks. This is best explained by an example:
 --
 -- @
 -- gotcha :: IO ()
 -- gotcha = do
---   ref <- newStrictIORef (Just 1)
+--   ref <- Strict.newIORef (Just 1)
 --   loop ref (10 ^ 9)
---   n <- readIORef ref
+--   n <- Strict.readIORef ref
 --   print n
 --   where
---     loop :: StrictIORef (Maybe Int) -> Int -> IO ()
+--     loop :: Strict.IORef (Maybe Int) -> Int -> IO ()
 --     loop ref i =
 --       if i == 0 then
 --         pure ()
 --       else do
---         n <- readIORef ref
---         writeStrictIORef ref (fmap (+ 1) n)
+--         n <- Strict.readIORef ref
+--         Strict.writeIORef ref (fmap (+ 1) n)
 --         loop ref (i - 1)
 -- @
 --
--- This leaks even though we are using 'StrictIORef', as 'writeStrictIORef' only forces the
+-- This leaks even though we are using a strict 'IORef', as 'Agda.Utils.IORef.Strict.writeIORef' only forces the
 -- thunk containing the 'Just', and *not* the thunk stored within the 'Just'. Similar problems
--- exist with 'StrictIORef (a, b)', as pairs in Haskell are lazy.
+-- exist with @Strict.IORef (a, b)@, as pairs in Haskell are lazy.
 --
--- In light of this, users are encouraged to use 'StrictIORef' in concert with types that have strict
+-- In light of this, users are encouraged to use strict 'IORef' in concert with types that have strict
 -- fields. This ensures that forcing the outer constructor of the type also forces the fields, avoiding any potential
 -- leaks. If this is not possible, users are encouraged to use strict let bindings, 'seq', and
 -- extreme care.
@@ -166,8 +170,8 @@ import qualified Data.IORef as Lazy
 --
 -- When forcing values to WHNF before writing to the reference, we have two options
 --
--- * Use @writeIORef ref $! a@
--- * Use @writeIORef ref =<< evaluate a@
+-- * Use @Lazy.writeIORef ref $! a@
+-- * Use @Lazy.writeIORef ref =<< evaluate a@
 --
 -- These are subtly different in the presence of exceptions. The former
 -- unfolds to:
@@ -182,13 +186,17 @@ import qualified Data.IORef as Lazy
 -- throw when evaluated.
 --
 -- In practice, this means that
+--
 -- @
 -- (writeIORef ref $! (error "a")) >> error "b"
 -- @
+--
 -- can throw either @"a"@ or @"b"@ depending on what the optimizer decides to do, whereas
+--
 -- @
 -- evaluate (error "a") >>= writeIORef ref >> error "b"
 -- @
+--
 -- must always throw @"a"@.
 --
 -- We opt to use @writeIORef ref $! a@ in this module, as it gives the optimizer more leeway
@@ -198,26 +206,26 @@ import qualified Data.IORef as Lazy
 -- | Strict IO references.
 newtype IORef a = StrictIORef (Lazy.IORef a)
 
--- | Create a new 'StrictIORef'.
+-- | Create a new strict 'IORef'.
 --
 -- This will force the value to WHNF before creating the reference.
 newIORef :: a -> IO (IORef a)
 newIORef = \a -> StrictIORef <$> (Lazy.newIORef $! a)
 {-# INLINE newIORef #-}
 
--- | Read the contents of a 'StrictIORef'.
+-- | Read the contents of a strict 'IORef'.
 readIORef :: IORef a -> IO a
 readIORef = \(StrictIORef ref) -> Lazy.readIORef ref
 {-# INLINE readIORef #-}
 
--- | Write to a 'StrictIORef'.
+-- | Write to a strict 'IORef'.
 --
 -- This will force the value to WHNF before writing.
 writeIORef :: IORef a -> a -> IO ()
 writeIORef = \(StrictIORef ref) a -> Lazy.writeIORef ref $! a
 {-# INLINE writeIORef #-}
 
--- | Modify a 'StrictIORef' by a applying a function to the value stored in the reference.
+-- | Modify a strict 'IORef' by a applying a function to the value stored in the reference.
 --
 -- This will force the value to WHNF before writing.
 modifyIORef :: IORef a -> (a -> a) -> IO ()

--- a/src/full/Agda/Utils/IORef/Strict.hs
+++ b/src/full/Agda/Utils/IORef/Strict.hs
@@ -169,7 +169,7 @@ import Data.IORef
 --
 -- @
 -- let !a' = a
--- in writeIORef ref a
+-- in writeIORef ref a'
 -- @
 --
 -- If forcing @a@ to WHNF causes an exception to get thrown, then we don't produce any IO action at

--- a/src/full/Agda/Utils/IORef/Strict.hs
+++ b/src/full/Agda/Utils/IORef/Strict.hs
@@ -1,0 +1,222 @@
+-- | A variant of 'IORef' that ensures the value stored
+-- inside the reference is always in WHNF.
+module Agda.Utils.IORef.Strict
+  (
+    -- $strictIORef
+    StrictIORef
+  , newStrictIORef
+  , readStrictIORef
+  , writeStrictIORef
+  , modifyStrictIORef
+  ) where
+
+import Control.Exception (evaluate)
+
+import Data.Coerce
+import Data.IORef
+
+
+-- $strictIORef
+-- * Strict IO references #strict-ioref#
+--
+-- A classic laziness footgun is that 'IORef' does not force
+-- values written to it to weak-head normal form. This is a
+-- common source of space leaks, as illustrated by the following
+-- (somewhat contrived) example:
+--
+-- @
+-- gotcha :: IO ()
+-- gotcha = do
+--   ref <- newIORef 1
+--   loop ref (10 ^ 9)
+--   n <- readIORef ref
+--   print n
+--   where
+--     loop :: IORef Int -> Int -> IO ()
+--     loop ref i =
+--       if i == 0 then
+--         pure ()
+--       else do
+--         n <- readIORef ref
+--         writeIORef ref (n + 1)
+--         loop ref (i - 1)
+-- @
+--
+-- As the name suggests, this is a classic example of a space leak.
+-- When we start the loop, @ref@ contains 1. At each iteration, we
+-- read the contents of @ref@ into @n@, and write a *thunk* to @ref@
+-- that will compute @n + 1@ when forced. This results in a chain of
+-- 1 billion thunks being allocated and kept live until we 'print'
+-- the value stored in @ref@, which causes us to force the thunk chain.
+-- The solution is to replace @writeIORef ref (n + 1)@ with @writeIORef ref $! (n + 1)@,
+-- which forces the thunk @n + 1@ to weak-heak normal form, which prevents
+-- the thunk chain from building up inside of the 'IORef'.
+--
+-- Lazy IO references can also cause programs to keep data live
+-- for much longer than required, leading to memory leaks. The
+-- basic anatomy of this class of leaks is something like the following:
+--
+-- @
+-- import Control.Concurrent
+-- import Data.IORef
+-- import GHC.Profiling
+-- import System.Mem
+-- import System.IO
+--
+-- memoryLeak :: IO ()
+-- memoryLeak = do
+--   let bigList = [1..10 ^ 6]
+--   -- Force the spine of the list to make GHC allocate the whole thing.
+--   print (length bigList)
+--   hFlush stdout
+--   -- Make an 'IORef' that uses 'bigList', and then do some unrelated slow computation.
+--   ref <- newIORef (sum bigList)
+--   loop 10
+--   -- Finally print the value in the reference.
+--   n <- readIORef ref
+--   putStrLn $! show n
+--   where
+--     loop :: Int -> IO ()
+--     loop 0 = pure ()
+--     loop i = do
+--       threadDelay (10 ^ 6)
+--       performBlockingMajorGC
+--       requestHeapCensus
+--       putStrLn "Working..."
+--       hFlush stdout
+--       loop (i - 1)
+-- @
+--
+-- If we run this program with @+RTS -l -hT -RTS@ and view the resulting @.eventlog@ file
+-- with [eventlog2html](https://mpickering.github.io/eventlog2html/), we will see that
+-- @bigList@ is kept live for the duration of @loop@, despite the repeated calls to
+-- @performBlockingMajorGC@. This is because @newIORef (sum bigList)@ allocates a thunk
+-- for @sum bigList@, which @newIORef@ does not force. This thunk references @bigList@,
+-- so the garbage collector is forced to keep @bigList@ live until we actually force the
+-- value stored inside @ref@ by printing it. We can avoid this by replacing the @newIORef@
+-- call with @newIORef $! (sum bigList)@, which forces the @sum bigList@ thunk to weak-head
+-- normal form, which removes the final reference to @bigList@. The GC will then free it on the
+-- first @performBlockingMajorGC@ call.
+--
+-- These sorts of mistakes are very easy to make, and very hard to diagnose. This
+-- module attempts to (partially) solve the problem by providing a 'StrictIORef' type,
+-- along with a corresponding API that ensures that the value stored in the reference
+-- is always in weak-head normal form.
+--
+-- == When should I use 'StrictIORef'?
+--
+-- The short answer is: "If you are unsure, you should probably use 'StrictIORef'".
+--
+-- The less short answer depends on your usage patterns:
+-- * Do you repeatedly read and then write to the reference? If so, you probably
+--   want to use 'StrictIORef' to avoid space leaks like the first example.
+-- * Do you use the reference to store things that are computed from things that
+--   shouldn't be kept live? If so, you probably want to use 'StrictIORef' to avoid
+--   memory leaks like the second example.
+-- * Do you use the reference to store something that is expensive to compute
+--   that you rarely use? If so, you might want to use 'IORef' to
+--   avoid doing redundant work, though warnings about repeated read/writes and memory
+--   leaks still apply.
+--
+-- == Caveats
+--
+-- The API for 'StrictIORef' only ensures that the value in the reference is in
+-- weak-head normal form, *not* normal form. This is done for the sake of efficiency:
+-- using 'Control.DeepSeq.NFData' to place the value into normal form requires us to
+-- fully traverse the value being stored inside of the reference, which can be quite
+-- expensive for recursive structures.
+--
+-- This design decision does lead to some unfortunate gotchas. Namely, if you store
+-- a type inside of a 'StrictIORef' that has non-strict fields, it is still possible
+-- to have space/memory leaks. This is best explained by an example:
+--
+-- @
+-- gotcha :: IO ()
+-- gotcha = do
+--   ref <- newStrictIORef (Just 1)
+--   loop ref (10 ^ 9)
+--   n <- readStrictIORef ref
+--   print n
+--   where
+--     loop :: StrictIORef (Maybe Int) -> Int -> IO ()
+--     loop ref i =
+--       if i == 0 then
+--         pure ()
+--       else do
+--         n <- readStrictIORef ref
+--         writeStrictIORef ref (fmap (+ 1) n)
+--         loop ref (i - 1)
+-- @
+--
+-- This leaks even though we are using 'StrictIORef', as 'writeStrictIORef' only forces the
+-- thunk containing the 'Just', and *not* the thunk stored within the 'Just'. Similar problems
+-- exist with 'StrictIORef (a, b)', as pairs in Haskell are lazy.
+--
+-- In light of this, users are encouraged to use 'StrictIORef' in concert with types that have strict
+-- fields. This ensures that forcing the outer constructor of the type also forces the fields, avoiding any potential
+-- leaks. If this is not possible, users are encouraged to use strict let bindings, 'seq', and
+-- extreme care.
+--
+-- == Implementation notes
+--
+-- When forcing values to WHNF before writing to the reference, we have two options
+--
+-- * Use @writeIORef ref $! a@
+-- * Use @writeIORef ref =<< evaluate a@
+--
+-- These are subtly different in the presence of exceptions. The former
+-- unfolds to:
+--
+-- @
+-- let !a' = a
+-- in writeIORef ref a
+-- @
+--
+-- If forcing @a@ to WHNF causes an exception to get thrown, then we don't produce any IO action at
+-- all. Conversely, @writeIORef ref =<< evaluate a@ will always produce an IO action that itself will
+-- throw when evaluated.
+--
+-- In practice, this means that
+-- @
+-- (writeIORef ref $! (error "a")) >> error "b"
+-- @
+-- can throw either @"a"@ or @"b"@ depending on what the optimizer decides to do, whereas
+-- @
+-- evaluate (error "a") >>= writeIORef ref >> error "b"
+-- @
+-- must always throw @"a"@.
+--
+-- We opt to use @writeIORef ref $! a@ in this module, as it gives the optimizer more leeway
+-- when doing code transformations that might move where a value gets forced (EG: worker-wrapper).
+-- This is a safe choice, as Agda does not rely on precise exception semantics for correctness.
+
+-- | Strict IO references.
+newtype StrictIORef a = StrictIORef (IORef a)
+
+-- | Create a new 'StrictIORef'.
+--
+-- This will force the value to WHNF before creating the reference.
+newStrictIORef :: a -> IO (StrictIORef a)
+newStrictIORef = \a -> StrictIORef <$> (newIORef $! a)
+{-# INLINE newStrictIORef #-}
+
+-- | Read the contents of a 'StrictIORef'.
+readStrictIORef :: StrictIORef a -> IO a
+readStrictIORef = \(StrictIORef ref) -> readIORef ref
+{-# INLINE readStrictIORef #-}
+
+-- | Write to a 'StrictIORef'.
+--
+-- This will force the value to WHNF before writing.
+writeStrictIORef :: StrictIORef a -> a -> IO ()
+writeStrictIORef = \(StrictIORef ref) a -> writeIORef ref $! a
+{-# INLINE writeStrictIORef #-}
+
+-- | Modify a 'StrictIORef' by a applying a function to the value stored in the reference.
+--
+-- This will force the value to WHNF before writing.
+modifyStrictIORef :: StrictIORef a -> (a -> a) -> IO ()
+modifyStrictIORef = \ref f -> do
+  a <- readStrictIORef ref
+  writeStrictIORef ref (f a)
+{-# INLINE modifyStrictIORef #-}

--- a/src/full/Agda/Utils/IORef/Strict.hs
+++ b/src/full/Agda/Utils/IORef/Strict.hs
@@ -1,19 +1,24 @@
 -- | A variant of 'IORef' that ensures the value stored
 -- inside the reference is always in WHNF.
+--
+-- This module should be imported qualified, ala
+-- @
+-- import qualified Agda.Utils.IORef.Strict as Strict
+-- @
 module Agda.Utils.IORef.Strict
   (
     -- $strictIORef
-    StrictIORef
-  , newStrictIORef
-  , readStrictIORef
-  , writeStrictIORef
-  , modifyStrictIORef
+    IORef
+  , newIORef
+  , readIORef
+  , writeIORef
+  , modifyIORef
   ) where
 
 import Control.Exception (evaluate)
 
 import Data.Coerce
-import Data.IORef
+import qualified Data.IORef as Lazy
 
 
 -- $strictIORef
@@ -135,7 +140,7 @@ import Data.IORef
 -- gotcha = do
 --   ref <- newStrictIORef (Just 1)
 --   loop ref (10 ^ 9)
---   n <- readStrictIORef ref
+--   n <- readIORef ref
 --   print n
 --   where
 --     loop :: StrictIORef (Maybe Int) -> Int -> IO ()
@@ -143,7 +148,7 @@ import Data.IORef
 --       if i == 0 then
 --         pure ()
 --       else do
---         n <- readStrictIORef ref
+--         n <- readIORef ref
 --         writeStrictIORef ref (fmap (+ 1) n)
 --         loop ref (i - 1)
 -- @
@@ -191,32 +196,32 @@ import Data.IORef
 -- This is a safe choice, as Agda does not rely on precise exception semantics for correctness.
 
 -- | Strict IO references.
-newtype StrictIORef a = StrictIORef (IORef a)
+newtype IORef a = StrictIORef (Lazy.IORef a)
 
 -- | Create a new 'StrictIORef'.
 --
 -- This will force the value to WHNF before creating the reference.
-newStrictIORef :: a -> IO (StrictIORef a)
-newStrictIORef = \a -> StrictIORef <$> (newIORef $! a)
-{-# INLINE newStrictIORef #-}
+newIORef :: a -> IO (IORef a)
+newIORef = \a -> StrictIORef <$> (Lazy.newIORef $! a)
+{-# INLINE newIORef #-}
 
 -- | Read the contents of a 'StrictIORef'.
-readStrictIORef :: StrictIORef a -> IO a
-readStrictIORef = \(StrictIORef ref) -> readIORef ref
-{-# INLINE readStrictIORef #-}
+readIORef :: IORef a -> IO a
+readIORef = \(StrictIORef ref) -> Lazy.readIORef ref
+{-# INLINE readIORef #-}
 
 -- | Write to a 'StrictIORef'.
 --
 -- This will force the value to WHNF before writing.
-writeStrictIORef :: StrictIORef a -> a -> IO ()
-writeStrictIORef = \(StrictIORef ref) a -> writeIORef ref $! a
-{-# INLINE writeStrictIORef #-}
+writeIORef :: IORef a -> a -> IO ()
+writeIORef = \(StrictIORef ref) a -> Lazy.writeIORef ref $! a
+{-# INLINE writeIORef #-}
 
 -- | Modify a 'StrictIORef' by a applying a function to the value stored in the reference.
 --
 -- This will force the value to WHNF before writing.
-modifyStrictIORef :: StrictIORef a -> (a -> a) -> IO ()
-modifyStrictIORef = \ref f -> do
-  a <- readStrictIORef ref
-  writeStrictIORef ref (f a)
-{-# INLINE modifyStrictIORef #-}
+modifyIORef :: IORef a -> (a -> a) -> IO ()
+modifyIORef = \ref f -> do
+  a <- readIORef ref
+  writeIORef ref (f a)
+{-# INLINE modifyIORef #-}


### PR DESCRIPTION
This is a classic laziness footgun: `writeIORef` does not force the value being written to the reference. On my machine this removes about 100s off of a clean build of `agda-stdlib`, and saves about 60 gigs of allocations.
EDIT: My reference compiler with `-foptimise-heavily` must have been clobbered with a non-heavily optimised one. Timings look about the same, with a 12 gig allocation saving in total.

There are some other lazy calls to `writeIORef` that are used for memo-tables in `Agda.Utils.Memo` and `Agda.TypeChecking.Reduce.Fast`, but making these strict seems to seriously degrade performance. I'm leaving
them be for now, though we should probably take a look at tuning the memo tables at some point in the near future.

<details>
<summary>Clean build of agda-stdlb with master</summary>

```
Total                                   590,202ms            
Miscellaneous                             5,977ms            
Typing                                   19,704ms (239,026ms)
Typing.CheckRHS                          77,926ms            
Typing.CheckLHS                          16,555ms  (41,351ms)
Typing.CheckLHS.UnifyIndices             24,796ms            
Typing.Generalize                        25,708ms            
Typing.OccursCheck                       22,402ms            
Typing.ApplySection                      22,113ms            
Typing.TypeSig                           20,684ms            
Typing.With                               7,838ms            
Typing.InstanceSearch                       218ms   (1,296ms)
Typing.InstanceSearch.FilterCandidates      711ms            
Typing.InstanceSearch.InitialCandidates     366ms            
Serialization                            66,953ms  (88,092ms)
Serialization.Compress                    8,831ms            
Serialization.BinaryEncode                8,354ms            
Serialization.Sort                        2,649ms            
Serialization.BuildInterface              1,304ms            
Coverage                                 47,675ms  (73,040ms)
Coverage.UnifyIndices                    25,365ms            
Scoping                                   6,801ms  (38,067ms)
Scoping.InverseScopeLookup               31,265ms            
Parsing                                  10,739ms  (32,821ms)
Parsing.OperatorsExpr                    19,043ms            
Parsing.OperatorsPattern                  3,038ms            
Deserialization                          22,947ms  (30,816ms)
Deserialization.Compaction                7,868ms            
Positivity                               26,609ms            
InterfaceInstantiateFull                 22,389ms            
DeadCode                                    272ms  (17,382ms)
DeadCode.DeadCodeReachable               17,109ms            
Termination                               2,385ms   (7,421ms)
Termination.RecCheck                      3,914ms            
Termination.Compare                         724ms            
Termination.Graph                           397ms            
Highlighting                              4,963ms            
Import                                    2,157ms            
Injectivity                                 981ms            
ProjectionLikeness                          396ms            
ModuleName                                   57ms            
 784,572,431,984 bytes allocated in the heap
  89,601,560,400 bytes copied during GC
   1,428,342,904 bytes maximum residency (137 sample(s))
       5,656,696 bytes maximum slop
            2785 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     186200 colls,     0 par   159.125s  162.264s     0.0009s    0.1375s
  Gen  1       137 colls,     0 par   16.411s  17.957s     0.1311s    1.1036s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.005s  (  0.005s elapsed)
  MUT     time  414.693s  (413.328s elapsed)
  GC      time  175.536s  (180.221s elapsed)
  EXIT    time    0.321s  (  0.011s elapsed)
  Total   time  590.554s  (593.565s elapsed)

  Alloc rate    1,891,933,882 bytes per MUT second

  Productivity  70.2% of total user, 69.6% of total elapsed
```
</details>
<details>
<summary>Clean build of agda-stdlb with strict-write-ioref</summary>

```
Total                                   483,662ms            
Miscellaneous                             5,385ms            
Typing                                   13,861ms (175,004ms)
Typing.CheckRHS                          56,913ms            
Typing.CheckLHS                          11,787ms  (29,272ms)
Typing.CheckLHS.UnifyIndices             17,485ms            
Typing.Generalize                        19,010ms            
Typing.ApplySection                      17,644ms            
Typing.OccursCheck                       17,386ms            
Typing.TypeSig                           14,175ms            
Typing.With                               5,735ms            
Typing.InstanceSearch                       164ms   (1,005ms)
Typing.InstanceSearch.FilterCandidates      539ms            
Typing.InstanceSearch.InitialCandidates     301ms            
Serialization                            63,602ms  (84,854ms)
Serialization.BinaryEncode                9,444ms            
Serialization.Compress                    7,255ms            
Serialization.Sort                        3,489ms            
Serialization.BuildInterface              1,062ms            
Coverage                                 38,002ms  (55,995ms)
Coverage.UnifyIndices                    17,993ms            
Scoping                                   5,665ms  (33,289ms)
Scoping.InverseScopeLookup               27,623ms            
Deserialization                          21,950ms  (29,183ms)
Deserialization.Compaction                7,232ms            
Parsing                                   9,554ms  (27,972ms)
Parsing.OperatorsExpr                    15,926ms            
Parsing.OperatorsPattern                  2,491ms            
Positivity                               21,136ms            
InterfaceInstantiateFull                 19,810ms            
DeadCode                                    265ms  (15,668ms)
DeadCode.DeadCodeReachable               15,402ms            
Highlighting                              6,459ms            
Termination                               1,614ms   (5,940ms)
Termination.RecCheck                      3,598ms            
Termination.Compare                         401ms            
Termination.Graph                           326ms            
Import                                    1,869ms            
Injectivity                                 732ms            
ProjectionLikeness                          309ms            
ModuleName                                   49ms            
 720,966,498,096 bytes allocated in the heap
  88,088,239,216 bytes copied during GC
   1,467,920,048 bytes maximum residency (135 sample(s))
       7,995,376 bytes maximum slop
            2875 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     170954 colls,     0 par   137.577s  141.442s     0.0008s    0.0640s
  Gen  1       135 colls,     0 par   15.785s  17.130s     0.1269s    1.0071s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.003s  (  0.003s elapsed)
  MUT     time  330.325s  (331.050s elapsed)
  GC      time  153.362s  (158.572s elapsed)
  EXIT    time    0.243s  (  0.004s elapsed)
  Total   time  483.933s  (489.629s elapsed)

  Alloc rate    2,182,595,771 bytes per MUT second

  Productivity  68.3% of total user, 67.6% of total elapsed
  ```
  </details>