### PR TITLE
Fix #8048 by generating lock constraints also for implicit arguments

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1438,7 +1438,7 @@ instance PrettyTCM TypeError where
            , pwords "can not appear simultaneously in the \"later\" term"
            , [ prettyTCM term ]
            , pwords "and in the lock term"
-           , [ prettyTCM lock <> "." ]
+           , [ prettyTCM lock ]
            ]
 
     ReferencesFutureVariables term (disallowed :| rest) lock leftmost -> do

--- a/src/full/Agda/TypeChecking/Implicit.hs
+++ b/src/full/Agda/TypeChecking/Implicit.hs
@@ -8,8 +8,11 @@ import Control.Monad
 import Control.Monad.Except
 import Control.Monad.IO.Class
 
+import Data.Bifunctor (first)
+
 import Agda.Syntax.Position (HasRange, beginningOf, getRange)
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Abstract (Binder, mkBinder_)
 import Agda.Syntax.Info ( MetaKind (InstanceMeta, UnificationMeta) )
 import Agda.Syntax.Internal as I
@@ -21,14 +24,18 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Pretty
+import Agda.TypeChecking.Pretty.Constraint ()  -- PrettyTCM Constraint instance only
 import Agda.TypeChecking.Telescope
 
-import Agda.Utils.Function (applyWhen)
+import Agda.Utils.Function (applyWhen, applyWhenJust)
 import Agda.Utils.Functor
+import qualified Agda.Utils.List as List
 import Agda.Utils.List1 (List1, pattern (:|))
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Tuple
+
+import Agda.Utils.Impossible
 
 -- Cut and paste from insertImplicitPatternsT:
 
@@ -63,9 +70,9 @@ implicitArgs
   => Int               -- ^ @n@, the maximum number of implicts to be inserted.
   -> (Hiding -> Bool)  -- ^ @expand@, the predicate to test whether we should keep inserting.
   -> Type              -- ^ The (function) type @t@ we are eliminating.
-  -> m (Args, Type)  -- ^ The eliminating arguments and the remaining type.
-implicitArgs n expand t = mapFst (map (fmap namedThing)) <$> do
-  implicitNamedArgs n (\ h x -> expand h) t
+  -> m (Args, Type)    -- ^ The eliminating arguments and the remaining type.
+implicitArgs n expand t = first (map (fmap namedThing)) <$> do
+  implicitNamedArgs n (\ h _x -> expand h) t
 
 -- | @implicitNamedArgs n expand t@ generates up to @n@ named implicit arguments
 --   metas (unbounded if @n<0@), as long as @t@ is a function type
@@ -76,14 +83,42 @@ implicitNamedArgs
   => Int                          -- ^ @n@, the maximum number of implicts to be inserted.
   -> (Hiding -> ArgName -> Bool)  -- ^ @expand@, the predicate to test whether we should keep inserting.
   -> Type                         -- ^ The (function) type @t@ we are eliminating.
-  -> m (NamedArgs, Type)        -- ^ The eliminating arguments and the remaining type.
-implicitNamedArgs 0 expand t0 = return ([], t0)
+  -> m (NamedArgs, Type)          -- ^ The eliminating arguments and the remaining type.
 implicitNamedArgs n expand t0 = do
+  (ncas, t) <- implicitCheckedArgs n expand t0
+  let (ns, cas) = List.unzipWith (\ (Named n ca) -> (n, ca)) ncas
+  es <- liftTCM $ noHeadConstraints cas
+  let nargs = zipWith (\ n (Arg ai v) -> Arg ai (Named n v)) ns (fromMaybe __IMPOSSIBLE__ $ allApplyElims es)
+  return (nargs, t)
+
+-- | Make sure there are no head constraints attached to the eliminations
+-- and just return the eliminations.
+noHeadConstraints :: [CheckedArg] -> TCM [Elim]
+noHeadConstraints = mapM noHeadConstraint
+
+noHeadConstraint :: CheckedArg -> TCM Elim
+noHeadConstraint (CheckedArg elim _  Nothing) = return elim
+noHeadConstraint (CheckedArg _ mrange Just{}) = do
+  applyWhenJust mrange setCurrentRange do
+    typeError $ NotSupported $
+     "Lock constraints are not (yet) supported in this position."
+
+-- | @implicitCheckedArgs n expand t@ generates up to @n@ named implicit arguments
+--   metas (unbounded if @n<0@), as long as @t@ is a function type
+--   and @expand@ holds on the hiding and name info of its domain.
+
+implicitCheckedArgs :: (PureTCM m, MonadMetaSolver m, MonadTCM m)
+  => Int                          -- ^ @n@, the maximum number of implicts to be inserted.
+  -> (Hiding -> ArgName -> Bool)  -- ^ @expand@, the predicate to test whether we should keep inserting.
+  -> Type                         -- ^ The (function) type @t@ we are eliminating.
+  -> m ([Named_ CheckedArg], Type)-- ^ The eliminating arguments and the remaining type.
+implicitCheckedArgs 0 expand t0 = return ([], t0)
+implicitCheckedArgs n expand t0 = do
     t0' <- reduce t0
-    reportSDoc "tc.term.args" 30 $ "implicitNamedArgs" <+> prettyTCM t0'
-    reportSDoc "tc.term.args" 80 $ "implicitNamedArgs" <+> text (show t0')
+    reportSDoc "tc.term.args" 30 $ "implicitCheckedArgs" <+> prettyTCM t0'
+    reportSDoc "tc.term.args" 80 $ "implicitCheckedArgs" <+> text (show t0')
     case unEl t0' of
-      Pi dom@Dom{domInfo = info, domTactic = tac, unDom = a} b
+      Pi dom@Dom{domInfo = info, domTactic = mtac, unDom = a} b
         | let x = bareNameWithDefault "_" dom, expand (getHiding info) x -> do
           kind <- if hidden info then return UnificationMeta else do
             reportSDoc "tc.term.args.ifs" 15 $
@@ -95,11 +130,34 @@ implicitNamedArgs n expand t0 = do
 
             return InstanceMeta
           (_, v) <- newMetaArg kind info x CmpLeq a
-          whenJust tac $ \ tac -> liftTCM $
+          whenJust mtac \ tac -> liftTCM do
             applyModalityToContext info $ unquoteTactic tac v a
-          let narg = Arg info (Named (Just $ WithOrigin Inserted $ unranged x) v)
-          mapFst (narg :) <$> implicitNamedArgs (n-1) expand (absApp b v)
+          let name = Just $ WithOrigin Inserted $ unranged x
+          mc <- liftTCM $ makeLockConstraint t0' v
+          let carg = CheckedArg{ caElim = Apply (Arg info v), caRange = Nothing, caConstraint = mc }
+          first (Named name carg :) <$> implicitCheckedArgs (n-1) expand (absApp b v)
       _ -> return ([], t0')
+
+-- | @makeLockConstraint u funType@(El _ (Pi (Dom{ domInfo=info, unDom=a }) _))@
+--   creates a @CheckLockedVars@ constaint for lock @u : a@
+--   if @getLock info == IsLock _@.
+--
+--   Precondition: 'Type' is reduced.
+makeLockConstraint :: Type -> Term -> TCM (Maybe (Abs Constraint))
+makeLockConstraint funType u =
+  case funType of
+    El _ (Pi (Dom{ domInfo = info, domName = dname, unDom = a }) _) -> do
+      let
+        x  = maybe "t" prettyShow dname
+        mc = case getLock info of
+          IsLock{} -> Just $ Abs x $
+            CheckLockedVars (var 0) (raise 1 funType) (raise 1 $ Arg info u) (raise 1 a)
+          IsNotLock -> Nothing
+      whenJust mc \ c -> do
+        reportSDoc "tc.term.lock" 40 do
+          addContext (defaultDom $ funType) $ prettyTCM c
+      return mc
+    _ -> return Nothing
 
 -- | Create a metavariable of 'MetaKind'.
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1558,8 +1558,10 @@ data Constraint
     -- ^ Resolve the head symbol of the type that the given instance targets
   | CheckFunDef A.DefInfo QName [A.Clause] TCErr
     -- ^ Last argument is the error causing us to postpone.
-  | UnquoteTactic Term Term Type   -- ^ First argument is computation and the others are hole and goal type
-  | CheckLockedVars Term Type (Arg Term) Type     -- ^ @CheckLockedVars t ty lk lk_ty@ with @t : ty@, @lk : lk_ty@ and @t lk@ well-typed.
+  | UnquoteTactic Term Term Type
+    -- ^ First argument is computation and the others are hole and goal type.
+  | CheckLockedVars Term Type (Arg Term) Type
+    -- ^ @CheckLockedVars t ty lk lk_ty@ with @t : ty@, @lk : lk_ty@ and @t lk@ well-typed.
   | UsableAtModality WhyCheckModality (Maybe Sort) Modality Term
     -- ^ Is the term usable at the given modality?
     -- This check should run if the @Sort@ is @Nothing@ or @isFibrant@.

--- a/test/Fail/Issue8048.agda
+++ b/test/Fail/Issue8048.agda
@@ -1,0 +1,42 @@
+-- Andreas, 2025-08-06, issue #8048
+-- Reported and test case by Satoshi Takimoto.
+-- Hidden @tick arguments were not checked, so one could have unsound
+-- guarding using instance @tick arguments.
+
+{-# OPTIONS --cubical --guarded #-}
+
+-- {-# OPTIONS -v tc.term.lock:50 #-}
+
+module Issue8048 where
+
+open import Agda.Primitive
+
+primitive
+  primLockUniv : Set₁
+
+-- We postulate Tick as it is supposed to be an abstract sort.
+postulate
+  Tick : primLockUniv
+  A    : Set
+
+▹_ : Set → Set
+▹_ A = {{@tick α : Tick}} → A
+
+-- All of the following should fail, but we only activate the first
+-- so that the test is more robust.
+
+join : ▹ ▹ A → ▹ A
+join x = x
+
+-- Should raise error: [ReferencesFutureVariables]
+-- The lock variable α can not appear simultaneously in the "later"
+-- term x and in the lock term ⦃ α ⦄
+-- when checking that the expression x has type A
+
+-- -- WAS: Still typechecks
+-- join1 : ▹ ▹ A → ▹ A
+-- join1 x {{α}} = x {{α}}
+
+-- -- This raises the ReferenceFutureVariables error
+-- join2 : ▹ ▹ A → ▹ A
+-- join2 x {{α}} = x {{α}} {{α}}

--- a/test/Fail/Issue8048.err
+++ b/test/Fail/Issue8048.err
@@ -1,0 +1,4 @@
+Issue8048.agda:29.10-11: error: [ReferencesFutureVariables]
+The lock variable α can not appear simultaneously in the "later"
+term x and in the lock term ⦃ α ⦄
+when checking that the expression x has type A

--- a/test/Fail/TickConstants.err
+++ b/test/Fail/TickConstants.err
@@ -1,4 +1,4 @@
 TickConstants.agda:13.10-25: error: [ReferencesFutureVariables]
 The lock variable x can not appear simultaneously in the "later"
-term foo (c x) and in the lock term c x.
+term foo (c x) and in the lock term c x
 when checking that the expression foo (c x) (c x) has type Set

--- a/test/Fail/TickJoin.err
+++ b/test/Fail/TickJoin.err
@@ -1,4 +1,4 @@
 TickJoin.agda:13.14-23: error: [ReferencesFutureVariables]
 The lock variable tic can not appear simultaneously in the "later"
-term x tic and in the lock term tic.
+term x tic and in the lock term tic
 when checking that the expression x tic tic has type A


### PR DESCRIPTION
- **Cosmetics: use concat when printing error ReferencesFutureVariables**
  

- **Cosmetics: remove final . in ReferencesFutureVariable error**
  Full stop looks odd if the error is then continued with "when checking..."
  

- **checkedLockedVars: preserve full instantiation when constraint is rethrown**
  The result of `instantiateFull` should probably be saved in the
  constraint when it is recreated.
  

- **Fix #8048 by generating Lock constraints also for implicitArgs**
  This commit factors out the lock constraint generation and generalizes
  `namedImplicitArgs` to `checkedImplicitArgs` including possible lock
  constraints for the inserted arguments.
  
  `namedImplicitArgs` now makes sure no constraints are generated and
  crashes with a `NotSupported` error if that is not the case.
  
  There is probably opportunity for handling the constraints in other
  places where we use `implicitArgs`, but this remains TODO if there is
  public demand for it.
  
  For now, we at least addressed the unsoundness, and constraints are
  supported for implicit arguments inserted during `checkApplication`.
  
  Closes #8048.
  