### PR TITLE
MAlonzo: avoid emitting duplicate import statements

### DIFF
--- a/src/full/Agda/Utils/Haskell/Syntax.hs
+++ b/src/full/Agda/Utils/Haskell/Syntax.hs
@@ -22,6 +22,10 @@ data ImportDecl = ImportDecl
 
 data ImportSpec = IVar Name
 
+-- | Importing a whole module qualified.
+qualifiedImport :: ModuleName -> ImportDecl
+qualifiedImport m = ImportDecl m True Nothing
+
 -- * Declarations
 
 data Decl = TypeDecl Name [TyVarBind] Type


### PR DESCRIPTION
We merge the `FOREIGN import` statements with the import statements generated from the builtins to eliminate duplicates (albeit based on string comparison, so this might fail).

Imports from builtins are just
- `Data.Text` always
- `Data.Char` for character primitives
- `MAlonzo.RTE.Float` for floating-point primitives

We simplified the tests whether those are needed by first computing a set of actually used builtins and then checking whether e.g. a character primitive is mentioned in this set.
Building the set first is optimizing for the negative case: that no character/float primitive is mentioned.
Since we only query the set twice, for character and float primitives, it might be better to not build the set but keep the used builtins as lazy list which we only force until we find the primitive we are looking for.  This would optimize for the positive case: that the primitives are mentioned.
In practice, I doubt that any of this matters.

Closes #7368, amends #7336.
- #7336 
- #7368
