### PR TITLE
Re #8024: alert user that --build-library does not accept backends

### DIFF
--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -241,6 +241,7 @@ getInteractor configuredBackends maybeInputFile opts = do
           return $ Just $ interactionInteractor i
         -- --build-library
         FrontEndBuildLibrary -> do
+          noBackends fe  -- Issue #8024: Backends are not supported yet.
           unless (optUseLibs opts) $
             throwError "--build-library cannot be combined with --no-libraries"
           noInputFile fe

--- a/test/Fail/OptionBuildLibraryWithBackend.agda
+++ b/test/Fail/OptionBuildLibraryWithBackend.agda
@@ -1,0 +1,5 @@
+-- Andreas, 2025-08-07
+-- Trigger error when --build-library is combined with yet unsupported backend,
+-- e.g. --html.
+
+-- File left empty intentionally.

--- a/test/Fail/OptionBuildLibraryWithBackend.err
+++ b/test/Fail/OptionBuildLibraryWithBackend.err
@@ -1,0 +1,4 @@
+ret > ExitFailure 71
+out > Error: Cannot mix --build-library with backend HTML
+out > Run 'agda --help' for help on command line options.
+out >

--- a/test/Fail/OptionBuildLibraryWithBackend.flags
+++ b/test/Fail/OptionBuildLibraryWithBackend.flags
@@ -1,0 +1,1 @@
+--build-library --html

--- a/test/Fail/OptionInteractionWithBackend.agda
+++ b/test/Fail/OptionInteractionWithBackend.agda
@@ -1,0 +1,5 @@
+-- Andreas, 2025-08-07
+-- Trigger error when --interaction is combined with backend,
+-- e.g. --html.
+
+-- File left empty intentionally.

--- a/test/Fail/OptionInteractionWithBackend.err
+++ b/test/Fail/OptionInteractionWithBackend.err
@@ -1,0 +1,4 @@
+ret > ExitFailure 71
+out > Error: Cannot mix --interaction with backend HTML
+out > Run 'agda --help' for help on command line options.
+out >

--- a/test/Fail/OptionInteractionWithBackend.flags
+++ b/test/Fail/OptionInteractionWithBackend.flags
@@ -1,0 +1,1 @@
+--interaction --html


### PR DESCRIPTION
The backends (`--html`, `--compile`, `--js`, `--latex`, `--dependency-graph`) should also work with `--build-library`, but this is not implemented yet, so we throw an `OptionError`.

Re: 
- #8024