### PR TITLE
Small refactorings around options

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -603,6 +603,7 @@ library
       Agda.Interaction.Options
       Agda.Interaction.Options.Arguments
       Agda.Interaction.Options.BashCompletion
+      Agda.Interaction.Options.Default
       Agda.Interaction.Options.Errors
       Agda.Interaction.Options.Help
       Agda.Interaction.Options.Lenses

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -938,7 +938,6 @@ createInterfaceIsolated x file msrc = do
       opaqueblk   <- useTC stOpaqueBlocks
       opaqueid    <- useTC stOpaqueIds
       ipatsyns <- getPatternSynImports
-      ho       <- getInteractionOutputCallback
       -- Every interface is treated in isolation. Note: Some changes to
       -- the persistent state may not be preserved if an error other
       -- than a type error or an IO exception is encountered in an
@@ -959,7 +958,6 @@ createInterfaceIsolated x file msrc = do
                             }) $ do
                setDecodedModules ds
                setCommandLineOptions opts
-               setInteractionOutputCallback ho
                stModuleToSource `setTCLens` mf
                setVisitedModules vs
                addImportedThings isig metas ibuiltin ipatsyns display

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -437,10 +437,9 @@ getExecutablesFile
 getExecutablesFile = do
   agdaDir <- getAgdaAppDir
   let defaults = List1.map (agdaDir </>) defaultExecutableFiles  -- NB: very short list
-  files <- filterM doesFileExist (List1.toList defaults)
-  case files of
-    file : _ -> return $ ExecutablesFile file True
-    []       -> return $ ExecutablesFile (List1.last defaults) False -- doesn't exist, but that's ok
+  findM doesFileExist defaults >>= \case
+    Just file -> return $ ExecutablesFile file True
+    Nothing   -> return $ ExecutablesFile (List1.last defaults) False -- doesn't exist, but that's ok
 
 -- | Return the trusted executables Agda knows about.
 --

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 
+{-# OPTIONS_GHC -Wunused-imports #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 
@@ -187,18 +188,15 @@ module Agda.Interaction.Options.Base
 import Prelude hiding ( null, not, (&&), (||) )
 
 import Control.DeepSeq
-import Control.Monad        ( (>=>), when, unless, void )
+import Control.Monad        ( (>=>), when, void )
 import Control.Monad.Except ( ExceptT, MonadError(throwError), runExceptT )
 import Control.Monad.Writer ( Writer, runWriter, MonadWriter(..) )
 
 import Data.Function            ( (&) )
 import Data.List                ( intercalate )
 import Data.Maybe
-import Data.Map                 ( Map )
-import qualified Data.Map as Map
 import Data.Set                 ( Set )
 import qualified Data.Set as Set
-import qualified Data.Text as T
 
 import GHC.Generics (Generic)
 
@@ -212,8 +210,9 @@ import Text.Read                ( readMaybe )
 
 import Agda.Termination.CutOff  ( CutOff(..), defaultCutOff )
 
-import Agda.Interaction.Library ( ExeName, LibName, OptionsPragma(..), parseLibName )
+import Agda.Interaction.Library ( OptionsPragma(..), parseLibName )
 import Agda.Interaction.Options.Arguments
+import Agda.Interaction.Options.Default
 import Agda.Interaction.Options.Help
   ( Help(HelpFor, GeneralHelp)
   , string2HelpTopic
@@ -231,12 +230,11 @@ import Agda.Syntax.TopLevelModuleName (TopLevelModuleName)
 import qualified Agda.Setup.EmacsMode as EmacsMode
 
 import Agda.Utils.Boolean
-import Agda.Utils.FileName      ( AbsolutePath )
 import Agda.Utils.Function      ( applyWhen, applyUnless )
 import Agda.Utils.Functor       ( (<&>) )
 import Agda.Utils.Lens          ( Lens', (^.), over, set )
 import Agda.Utils.List          ( headWithDefault, initLast1 )
-import Agda.Utils.List1         ( List1, String1, pattern (:|), toList )
+import Agda.Utils.List1         ( List1, pattern (:|), toList )
 import qualified Agda.Utils.List1        as List1
 import qualified Agda.Utils.Maybe.Strict as Strict
 import Agda.Utils.Monad         ( tell1 )
@@ -244,7 +242,6 @@ import Agda.Utils.Null
 import Agda.Interaction.Options.ProfileOptions
 import Agda.Utils.String        ( unwords1 )
 import qualified Agda.Utils.String       as String
-import Agda.Utils.Trie          ( Trie )
 import qualified Agda.Utils.Trie as Trie
 import Agda.Utils.TypeLits
 import Agda.Utils.WithDefault
@@ -662,115 +659,6 @@ mapFlag f (Option _ long arg descr) = Option [] (map f long) arg descr
 
 defaultInteractionOptions :: PragmaOptions
 defaultInteractionOptions = defaultPragmaOptions
-
-defaultOptions :: CommandLineOptions
-defaultOptions = Options
-  { optProgramName      = "agda"
-  , optInputFile             = Nothing
-  , optIncludePaths          = []
-  , optAbsoluteIncludePaths  = []
-  , optLibraries             = []
-  , optOverrideLibrariesFile = Nothing
-  , optDefaultLibs           = True
-  , optUseLibs               = True
-  , optTraceImports          = 1
-  , optTrustedExecutables    = Map.empty
-  , optPrintAgdaDataDir      = False
-  , optPrintAgdaAppDir       = False
-  , optPrintOptions          = False
-  , optPrintVersion          = Nothing
-  , optPrintHelp             = Nothing
-  , optBuildLibrary          = False
-  , optSetup                 = False
-  , optEmacsMode             = Set.empty
-  , optInteractive           = False
-  , optGHCiInteraction       = False
-  , optJSONInteraction       = False
-  , optExitOnError           = False
-  , optCompileDir            = Nothing
-  , optGenerateVimFile       = False
-  , optIgnoreInterfaces      = False
-  , optIgnoreAllInterfaces   = False
-  , optPragmaOptions         = defaultPragmaOptions
-  , optOnlyScopeChecking     = False
-  , optTransliterate         = False
-  , optDiagnosticsColour     = AutoColour
-  }
-
-defaultPragmaOptions :: PragmaOptions
-defaultPragmaOptions = PragmaOptions
-  { _optShowImplicit              = Default
-  , _optShowGeneralized           = Default
-  , _optShowIrrelevant            = Default
-  , _optUseUnicode                = Default -- UnicodeOk
-  , _optVerbose                   = Strict.Nothing
-  , _optProfiling                 = noProfileOptions
-  , _optProp                      = Default
-  , _optLevelUniverse             = Default
-  , _optTwoLevel                  = Default
-  , _optAllowUnsolved             = Default
-  , _optAllowIncompleteMatch      = Default
-  , _optPositivityCheck           = Default
-  , _optTerminationCheck          = Default
-  , _optTerminationDepth          = defaultCutOff
-  , _optUniverseCheck             = Default
-  , _optOmegaInOmega              = Default
-  , _optCumulativity              = Default
-  , _optSizedTypes                = Default
-  , _optGuardedness               = Default
-  , _optInjectiveTypeConstructors = Default
-  , _optUniversePolymorphism      = Default
-  , _optIrrelevantProjections     = Default
-  , _optExperimentalIrrelevance   = Default
-  , _optWithoutK                  = Default
-  , _optCubicalCompatible         = Default
-  , _optCopatterns                = Default
-  , _optPatternMatching           = Default
-  , _optExactSplit                = Default
-  , _optHiddenArgumentPuns        = Default
-  , _optEta                       = Default
-  , _optForcing                   = Default
-  , _optProjectionLike            = Default
-  , _optErasure                   = Default
-  , _optErasedMatches             = Default
-  , _optEraseRecordParameters     = Default
-  , _optRewriting                 = Default
-  , _optCubical                   = Nothing
-  , _optGuarded                   = Default
-  , _optFirstOrder                = Default
-  , _optRequireUniqueMetaSolutions = Default
-  , _optPostfixProjections        = Default
-  , _optKeepPatternVariables      = Default
-  , _optInferAbsurdClauses        = Default
-  , _optInstanceSearchDepth       = 500
-  , _optBacktrackingInstances     = Default
-  , _optQualifiedInstances        = Default
-  , _optInversionMaxDepth         = 50
-  , _optSafe                      = Default
-  , _optDoubleCheck               = Default
-  , _optSyntacticEquality         = Strict.Nothing
-  , _optWarningMode               = defaultWarningMode
-  , _optCompileMain               = Default
-  , _optCaching                   = Default
-  , _optCountClusters             = Default
-  , _optAutoInline                = Default
-  , _optPrintPatternSynonyms      = Default
-  , _optFastReduce                = Default
-  , _optCallByName                = Default
-  , _optConfluenceCheck           = Nothing
-  , _optCohesion                  = Default
-  , _optFlatSplit                 = Default
-  , _optPolarity                  = Default
-  , _optImportSorts               = Default
-  , _optLoadPrimitives            = Default
-  , _optAllowExec                 = Default
-  , _optSaveMetas                 = Default
-  , _optShowIdentitySubstitutions = Default
-  , _optKeepCoveringClauses       = Default
-  , _optForcedArgumentRecursion   = Default
-  , _optLargeIndices              = Default
-  , _optExperimentalLazyInstances = Default
-  }
 
 -- | The options parse monad 'OptM' collects warnings that are not discarded
 --   when a fatal error occurrs

--- a/src/full/Agda/Interaction/Options/Default.hs
+++ b/src/full/Agda/Interaction/Options/Default.hs
@@ -1,0 +1,130 @@
+-- | Default values for the options.
+
+module Agda.Interaction.Options.Default where
+
+import Agda.Interaction.Options.ProfileOptions () -- Null instance
+import Agda.Interaction.Options.Types
+import Agda.Interaction.Options.Warnings ( defaultWarningMode )
+import Agda.Termination.CutOff           ( defaultCutOff )
+import Agda.Utils.Null
+import Agda.Utils.WithDefault
+
+import Agda.Utils.Impossible
+
+defaultOptions :: CommandLineOptions
+defaultOptions = Options
+  { optProgramName           = "agda"
+  , optInputFile             = Nothing
+  , optIncludePaths          = []
+  , optAbsoluteIncludePaths  = []
+  , optLibraries             = []
+  , optOverrideLibrariesFile = Nothing
+  , optDefaultLibs           = True
+  , optUseLibs               = True
+  , optTraceImports          = 1
+  , optTrustedExecutables    = empty
+  , optPrintAgdaDataDir      = False
+  , optPrintAgdaAppDir       = False
+  , optPrintOptions          = False
+  , optPrintVersion          = Nothing
+  , optPrintHelp             = Nothing
+  , optBuildLibrary          = False
+  , optSetup                 = False
+  , optEmacsMode             = empty
+  , optInteractive           = False
+  , optGHCiInteraction       = False
+  , optJSONInteraction       = False
+  , optExitOnError           = False
+  , optCompileDir            = Nothing
+  , optGenerateVimFile       = False
+  , optIgnoreInterfaces      = False
+  , optIgnoreAllInterfaces   = False
+  , optPragmaOptions         = defaultPragmaOptions
+  , optOnlyScopeChecking     = False
+  , optTransliterate         = False
+  , optDiagnosticsColour     = AutoColour
+  }
+
+defaultPragmaOptions :: PragmaOptions
+defaultPragmaOptions = PragmaOptions
+  { _optShowImplicit               = Default
+  , _optShowGeneralized            = Default
+  , _optShowIrrelevant             = Default
+  , _optUseUnicode                 = Default -- UnicodeOk
+  , _optVerbose                    = empty
+  , _optProfiling                  = empty
+  , _optProp                       = Default
+  , _optLevelUniverse              = Default
+  , _optTwoLevel                   = Default
+  , _optAllowUnsolved              = Default
+  , _optAllowIncompleteMatch       = Default
+  , _optPositivityCheck            = Default
+  , _optTerminationCheck           = Default
+  , _optTerminationDepth           = defaultCutOff
+  , _optUniverseCheck              = Default
+  , _optOmegaInOmega               = Default
+  , _optCumulativity               = Default
+  , _optSizedTypes                 = Default
+  , _optGuardedness                = Default
+  , _optInjectiveTypeConstructors  = Default
+  , _optUniversePolymorphism       = Default
+  , _optIrrelevantProjections      = Default
+  , _optExperimentalIrrelevance    = Default
+  , _optWithoutK                   = Default
+  , _optCubicalCompatible          = Default
+  , _optCopatterns                 = Default
+  , _optPatternMatching            = Default
+  , _optExactSplit                 = Default
+  , _optHiddenArgumentPuns         = Default
+  , _optEta                        = Default
+  , _optForcing                    = Default
+  , _optProjectionLike             = Default
+  , _optErasure                    = Default
+  , _optErasedMatches              = Default
+  , _optEraseRecordParameters      = Default
+  , _optRewriting                  = Default
+  , _optCubical                    = Nothing
+  , _optGuarded                    = Default
+  , _optFirstOrder                 = Default
+  , _optRequireUniqueMetaSolutions = Default
+  , _optPostfixProjections         = Default
+  , _optKeepPatternVariables       = Default
+  , _optInferAbsurdClauses         = Default
+  , _optInstanceSearchDepth        = 500
+  , _optBacktrackingInstances      = Default
+  , _optQualifiedInstances         = Default
+  , _optInversionMaxDepth          = 50
+  , _optSafe                       = Default
+  , _optDoubleCheck                = Default
+  , _optSyntacticEquality          = empty
+  , _optWarningMode                = defaultWarningMode
+  , _optCompileMain                = Default
+  , _optCaching                    = Default
+  , _optCountClusters              = Default
+  , _optAutoInline                 = Default
+  , _optPrintPatternSynonyms       = Default
+  , _optFastReduce                 = Default
+  , _optCallByName                 = Default
+  , _optConfluenceCheck            = Nothing
+  , _optCohesion                   = Default
+  , _optFlatSplit                  = Default
+  , _optPolarity                   = Default
+  , _optImportSorts                = Default
+  , _optLoadPrimitives             = Default
+  , _optAllowExec                  = Default
+  , _optSaveMetas                  = Default
+  , _optShowIdentitySubstitutions  = Default
+  , _optKeepCoveringClauses        = Default
+  , _optForcedArgumentRecursion    = Default
+  , _optLargeIndices               = Default
+  , _optExperimentalLazyInstances  = Default
+  }
+
+-- Null instances
+
+instance Null CommandLineOptions where
+  empty = defaultOptions
+  null = __IMPOSSIBLE__
+
+instance Null PragmaOptions where
+  empty = defaultPragmaOptions

--- a/src/full/Agda/Interaction/Options/Lenses.hs
+++ b/src/full/Agda/Interaction/Options/Lenses.hs
@@ -114,43 +114,25 @@ putSafeMode = modifyTC . setSafeMode
 ---------------------------------------------------------------------------
 
 class LensIncludePaths a where
-  getIncludePaths :: a -> [FilePath]
-  setIncludePaths :: [FilePath] -> a -> a
-  mapIncludePaths :: ([FilePath] -> [FilePath]) -> a -> a
-
   getAbsoluteIncludePaths :: a -> [AbsolutePath]
   setAbsoluteIncludePaths :: [AbsolutePath] -> a -> a
   mapAbsoluteIncludePaths :: ([AbsolutePath] -> [AbsolutePath]) -> a -> a
 
   -- default implementations
-  setIncludePaths     = mapIncludePaths . const
-  mapIncludePaths f a = setIncludePaths (f $ getIncludePaths a) a
   setAbsoluteIncludePaths     = mapAbsoluteIncludePaths . const
   mapAbsoluteIncludePaths f a = setAbsoluteIncludePaths (f $ getAbsoluteIncludePaths a) a
 
 instance LensIncludePaths CommandLineOptions where
-  getIncludePaths = optIncludePaths
-  setIncludePaths is opts = opts { optIncludePaths = is }
   getAbsoluteIncludePaths = optAbsoluteIncludePaths
   setAbsoluteIncludePaths is opts = opts { optAbsoluteIncludePaths = is }
 
 instance LensIncludePaths PersistentTCState where
-  getIncludePaths = getIncludePaths . getCommandLineOptions
-  mapIncludePaths = mapCommandLineOptions . mapIncludePaths
   getAbsoluteIncludePaths = getAbsoluteIncludePaths . getCommandLineOptions
   mapAbsoluteIncludePaths = mapCommandLineOptions . mapAbsoluteIncludePaths
 
 instance LensIncludePaths TCState where
-  getIncludePaths = getIncludePaths . getCommandLineOptions
-  mapIncludePaths = mapCommandLineOptions . mapIncludePaths
   getAbsoluteIncludePaths = getAbsoluteIncludePaths . getCommandLineOptions
   mapAbsoluteIncludePaths = mapCommandLineOptions . mapAbsoluteIncludePaths
-
-modifyIncludePaths :: MonadTCState m => ([FilePath] -> [FilePath]) -> m ()
-modifyIncludePaths = modifyTC . mapIncludePaths
-
-putIncludePaths :: MonadTCState m => [FilePath] -> m ()
-putIncludePaths = modifyTC . setIncludePaths
 
 modifyAbsoluteIncludePaths :: MonadTCState m => ([AbsolutePath] -> [AbsolutePath]) -> m ()
 modifyAbsoluteIncludePaths = modifyTC . mapAbsoluteIncludePaths
@@ -159,7 +141,7 @@ putAbsoluteIncludePaths :: MonadTCState m => [AbsolutePath] -> m ()
 putAbsoluteIncludePaths = modifyTC . setAbsoluteIncludePaths
 
 ---------------------------------------------------------------------------
--- ** Include directories
+-- ** Verbosity
 ---------------------------------------------------------------------------
 
 type PersistentVerbosity = Verbosity

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -24,6 +24,7 @@ import Data.Time.Format.ISO8601     ( iso8601Show )
 
 import {-# SOURCE #-} Agda.TypeChecking.Errors
 import Agda.TypeChecking.Monad.Base
+-- import Agda.TypeChecking.Monad.State ( appInteractionOutputCallback )  -- import cycle
 
 import Agda.Interaction.Options
 import Agda.Interaction.Response.Base (Response_boot(..))
@@ -157,7 +158,7 @@ traceDebugMessageTCM k n doc cont = do
     -- Andreas, 2019-08-20, issue #4016:
     -- Force any lazy 'Impossible' exceptions to the surface and handle them.
     msg :: DocTree <- liftIO . catchAndPrintImpossible k n . E.evaluate . DeepSeq.force . renderToTree $ doc
-    cb <- getsTC $ stInteractionOutputCallback . stPersistentState
+    cb <- useTC $ stInteractionOutputCallback
     cb $ Resp_RunningInfo n msg
     cont
     where

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -270,7 +270,7 @@ displayFormsEnabled = asksTC envDisplayFormsEnabled
 -- Precondition: 'optAbsoluteIncludePaths' must be nonempty (i.e.
 -- 'setCommandLineOptions' must have run).
 
-getIncludeDirs :: HasOptions m => m (List1 AbsolutePath)
+getIncludeDirs :: TCM (List1 AbsolutePath)
 getIncludeDirs = do
   List1.fromListSafe __IMPOSSIBLE__ . optAbsoluteIncludePaths <$> commandLineOptions
 

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -323,7 +323,6 @@ setIncludeDirs incs root = do
   -- "old-path/M.agda", when the user actually meant
   -- "new-path/M.agda".
   when (sort oldIncs /= sort (List1.toList incs)) $ do
-    ho <- getInteractionOutputCallback
     tcWarnings <- useTC stTCWarnings -- restore already generated warnings
     libCache   <- useTC stLibCache   -- restore cached project configs & .agda-lib files, since they use absolute paths
     decodedModules <- getDecodedModules
@@ -331,7 +330,6 @@ setIncludeDirs incs root = do
     resetAllState
     setTCLens stTCWarnings tcWarnings
     setTCLens stLibCache libCache
-    setInteractionOutputCallback ho
     setDecodedModules keptDecodedModules
     setTCLens stModuleToSourceId modFile
 

--- a/src/full/Agda/TypeChecking/Monad/Options.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs-boot
@@ -3,9 +3,8 @@
 module Agda.TypeChecking.Monad.Options where
 
 import Agda.Interaction.Library.Base
-import Agda.Interaction.Options.HasOptions
 import Agda.TypeChecking.Monad.Base
 import Agda.Utils.List1 (List1)
 
 libToTCM       :: LibM a -> TCM a
-getIncludeDirs :: HasOptions m => m (List1 AbsolutePath)
+getIncludeDirs :: TCM (List1 AbsolutePath)

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -479,17 +479,18 @@ addForeignCode backend code = do
 -- * Interaction output callback
 ---------------------------------------------------------------------------
 
+{-# INLINE getInteractionOutputCallback #-}
 getInteractionOutputCallback :: ReadTCState m => m InteractionOutputCallback
 getInteractionOutputCallback
-  = getsTC $ stInteractionOutputCallback . stPersistentState
+  = useTC stInteractionOutputCallback
 
 appInteractionOutputCallback :: Response -> TCM ()
 appInteractionOutputCallback r
   = getInteractionOutputCallback >>= \ cb -> cb r
 
 setInteractionOutputCallback :: InteractionOutputCallback -> TCM ()
-setInteractionOutputCallback cb
-  = modifyPersistentState $ \ s -> s { stInteractionOutputCallback = cb }
+setInteractionOutputCallback
+  = setTCLens' stInteractionOutputCallback
 
 ---------------------------------------------------------------------------
 -- * Pattern synonyms

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -138,6 +138,10 @@ anyM f = Fold.foldl' (\ b -> or2M b . f) (return False)
 existsM :: (Foldable f, Monad m) => f a -> (a -> m Bool) -> m Bool
 existsM xs f = anyM f xs
 
+-- https://hackage-content.haskell.org/package/extra-1.8/docs/src/Data.Foldable.Extra.html#findM
+findM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m (Maybe a)
+findM p = foldr (\x -> ifM (p x) (pure $ Just x)) (pure Nothing)
+
 -- | Lazy monadic disjunction with @Either@  truth values.
 --   Returns the last error message if all fail.
 altM1 :: Monad m => (a -> m (Either err b)) -> [a] -> m (Either err b)


### PR DESCRIPTION
- **Refactor: move InteractionOutputCallback to SessionState**
  The `InteractionOutputCallback` value is never changed during a run of
  Agda, it is set initially by the interactor which cannot be changed
  during an Agda session.
  
  Thus, we move it to the `TCSessionState` so that we need not restore
  it after resetting the state (e.g. when a different module is
  loaded into Agda).
  

- **Clean: remove unused getIncludePaths lens**
  

- **Refactor for #8053: monomorphise `getIncludeDirs`**
  It is only used for `TCM`, so `HasOptions` does not need to support it.
  

- **Cosmetics getExecutablesFile: use findM over filterM**
  

- **Refactor: move default options to Agda.Interaction.Options.Default**
  