### PR TITLE
Fix issue #7001: no longer infer lambdas that have no erasure status on their arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Changes to the Agda syntax.
   See [#4275](https://github.com/agda/agda/issues/4275) for the proposal.
 
 * Modality annotations in aliases and let-bindings are now supported
-  (PR [#7990]()).
+  (PR [#7990](https://github.com/agda/agda/pull/7990)).
   Example:
   ```agda
     split : {A B C : Set} (@0 p : A × B) (k : @0 A → @0 B → C) → C
@@ -92,6 +92,20 @@ Changes to type checker and other components defining the Agda language.
   For compatibility with modules using `--cubical[=full]` and `--cubical=erased`, see
   [variants](https://agda.readthedocs.io/en/v2.9.0/language/cubical.html#variants).
 
+* (**BREAKING**): In the presence of `--erasure`, types of lambdas expressions
+  are not inferred unless every lambda-bound variable has been given its erasure
+  status (`@0` or `@ω`) explicitely.
+  The reason is that otherwise Agda might infer the wrong erasure status, see, e.g.,
+  [Issue #7001](https://github.com/agda/agda/issues/7001).
+
+  Now we have the following behavior:
+  ```agda
+    fails    = λ x → x + x
+    succeeds = λ (@ω x) → x + x
+    alsoOK   = λ (@ω A : Set) (@0 B : Set) → A
+  ```
+  With that change `--erasure` gets more akin to Cubical Agda that categorically
+  refuses to infer lambdas (since they could construct either functions or paths).
 
 Reflection
 ----------

--- a/doc/user-manual/language/lambda-abstraction.lagda.rst
+++ b/doc/user-manual/language/lambda-abstraction.lagda.rst
@@ -1,6 +1,5 @@
 ..
   ::
-  {-# OPTIONS --erasure #-}
 
   module language.lambda-abstraction where
 
@@ -39,7 +38,7 @@ Lambda expressions
 
 Anonymous functions can be defined using a lambda expression ``\x → u``::
 
-  myFun = \x → x + x -- equivalent: `myFun x = x + x`
+  myFun = \ x → x + x -- equivalent: `myFun x = x + x`
 
 You can also use the Unicode symbol ``λ`` (type “\\lambda” or “\\Gl” in the Emacs Agda mode) instead of ``\`` (type “\\\\” in the Emacs Agda mode).
 
@@ -92,12 +91,18 @@ around the argument.
 
   instance-lambda = λ (A : Set) {{monoid-A : Monoid A}} → mempty
 
-Arguments to lambda expressions can also be annotated with any :ref:`modality <modalities>`.
+Arguments to lambda expressions can also be annotated with any :ref:`modality <modalities>`,
+for instance with :ref:`erasure status <erased-lambda>`.
+
+Note that in Cubical Agda (see :option:`--cubical`), many of the examples above do not pass
+because there the types of lambda expressions are not *inferred* in general;
+lambdas are only *checked* against given types.
+Thus, type signatures are needed for ``myFun`` etc.
 
 .. _pattern-lambda:
 
 Pattern lambda
------------------------
+--------------
 
 Anonymous pattern matching functions can be defined by a *pattern lambda* using
 one of the two following syntaxes:
@@ -154,19 +159,6 @@ Pattern lambdas can also use :ref:`copatterns` by using projections in
     (a , b) .snd → a
 
 It is not allowed to use ``where`` and ``with`` constructions in pattern lambdas.
-
-Regular pattern lambdas are treated as non-erased function definitions (see
-::ref:`runtime-irrelevance`). One can make a pattern lambda erased by writing
-``@0`` or ``@erased`` before the lambda:
-
-::
-
-  @0 _ : @0 Set → Set
-  _ = λ @0 { A → A }
-
-  @0 _ : @0 Set → Set
-  _ = λ @erased where
-    A → A
 
 Internal representation of pattern lambdas
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1921,7 +1921,7 @@ isContinuous = (Continuous ==) . getCohesion
 moreCohesion :: Cohesion -> Cohesion -> Bool
 moreCohesion = (<=)
 
--- | Equality ignoring origin.
+-- | Equality ignoring origin.  TODO: add origin to 'Cohesion'.
 sameCohesion :: Cohesion -> Cohesion -> Bool
 sameCohesion = (==)
 

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -126,7 +126,7 @@ checkApplication cmp hd args e t =
   reportSDoc "tc.check.app" 20 $ vcat
     [ "checkApplication"
     , nest 2 $ "hd   = " <+> prettyA hd
-    , nest 2 $ "args = " <+> sep (map prettyA args)
+    , nest 2 $ "args = " <+> do prettyList $ fmap prettyA args
     , nest 2 $ "e    = " <+> prettyA e
     , nest 2 $ "t    = " <+> prettyTCM t
     ]
@@ -998,7 +998,7 @@ checkConstructorApplication cmp org t c hd args = do
       [ "org  =" <+> prettyTCM org
       , "t    =" <+> prettyTCM t
       , "c    =" <+> prettyTCM c
-      , "args =" <+> prettyTCM args
+      , "args =" <+> do prettyList $ fmap prettyTCM args
     ] ]
 
   cdef  <- getConInfo c
@@ -1348,7 +1348,7 @@ inferOrCheckProjApp e o ds hd args mt = do
   reportSDoc "tc.proj.amb" 20 $ vcat
     [ "checking ambiguous projection"
     , text $ "  ds   = " ++ prettyShow ds
-    , text   "  args = " <+> sep (map prettyTCM args)
+    , text   "  args = " <+> do prettyList $ fmap prettyTCM args
     , text   "  t    = " <+> caseMaybe mt "Nothing" prettyTCM
     ]
 

--- a/test/Fail/InferredLambdaOfNoFunctionType.agda
+++ b/test/Fail/InferredLambdaOfNoFunctionType.agda
@@ -1,0 +1,26 @@
+-- Andreas, 2025-08-08, transient internal error during work on #7001.
+
+{-# OPTIONS --erasure #-}
+
+-- {-# OPTIONS -v tc.term.lambda:30 #-}
+
+open import Agda.Builtin.Equality
+
+postulate
+  A : Set
+
+@0 spec : A → A
+spec n  = n
+
+impl    : A → A
+impl n  = n
+
+proof   : ∀ n → spec n ≡ impl n
+proof n = λ _ → n
+
+-- Should give type error: λ without function type.
+-- During work on #7001, this produced an internal error at some point.
+
+-- Expected error: [UnequalTerms]
+-- (z : _10) → A !=< spec n ≡ impl n
+-- when checking that the expression λ _ → n has type spec n ≡ impl n

--- a/test/Fail/InferredLambdaOfNoFunctionType.err
+++ b/test/Fail/InferredLambdaOfNoFunctionType.err
@@ -1,0 +1,3 @@
+InferredLambdaOfNoFunctionType.agda:19.11-18: error: [UnequalTerms]
+(z : _10) → A !=< spec n ≡ impl n
+when checking that the expression λ _ → n has type spec n ≡ impl n

--- a/test/Succeed/Issue5317.agda
+++ b/test/Succeed/Issue5317.agda
@@ -4,13 +4,18 @@ open import Agda.Builtin.Reflection
 open import Agda.Builtin.List
 open import Agda.Builtin.Unit
 
+-- (*)
+-- Andreas, 2025-08-08, issue #7001
+-- Erasure status needs to be given explicitly
+-- at inferred lambdas now, if --erasure is on.
+
 macro
 
   m-0 : Term → TC ⊤
   m-0 goal =
     bindTC (inferType goal) λ where
       (pi (arg (arg-info _ (modality _ quantity-0)) _) _) →
-        bindTC (quoteTC (λ (_ : Set) → Set))
+        bindTC (quoteTC (λ (@0 _ : Set) → Set))  -- (*)
                (unify goal)
       type → typeError (termErr type ∷ [])
 
@@ -18,7 +23,7 @@ macro
   m-ω goal =
     bindTC (inferType goal) λ where
       (pi (arg (arg-info _ (modality _ quantity-ω)) _) _) →
-        bindTC (quoteTC (λ (_ : Set) → Set))
+        bindTC (quoteTC (λ (@ω _ : Set) → Set))  -- (*)
                (unify goal)
       type → typeError (termErr type ∷ [])
 

--- a/test/Succeed/Issue7001.agda
+++ b/test/Succeed/Issue7001.agda
@@ -1,0 +1,58 @@
+-- Andreas, 2025-08-08, issue #7001, reported by nad w/ testcase.
+--
+-- In the presence of erasure and other modalities,
+-- we should not infer lambdas unless the user provided
+-- the modalities at the binder,
+-- otherwise we might commit to the wrong modality.
+
+{-# OPTIONS --erasure #-}
+
+-- {-# OPTIONS -v tc.meta:10 #-}
+-- {-# OPTIONS -v tc:15 #-}
+-- {-# OPTIONS -v tc.term.lambda:30 #-}
+
+record _⇔_ (A B : Set₁) : Set₁ where
+  constructor mk
+  field
+    to   : A → B
+    from : B → A
+
+_↝_ : Set₁ → Set₁ → Set₁
+A ↝ B = A → B
+
+postulate
+  F : (A : Set₁) → A ⇔ (@0 Set → Set) → A ↝ (@0 Set → Set)
+
+module Constructor where
+
+  G : (@0 Set → Set) → (@0 Set → Set)
+  G =
+    F _
+      (mk (λ H A → H A)
+          (λ H A → H A))
+
+module OverloadedConstructor where
+
+  record Foo : Set where
+    constructor mk
+
+  G : (@0 Set → Set) → (@0 Set → Set)
+  G =
+    F _
+      (mk (λ H A → H A)
+          (λ H A → H A))
+
+module RecordExpression where
+
+  G : (@0 Set → Set) → (@0 Set → Set)
+  G =
+    F _
+      (record
+         { to   = λ H A → H A
+         ; from = λ H A → H A
+         })
+
+-- Previously, these failed because some modalities that should have been inferred to @0
+-- were inferred to the standard modality @ω.
+
+-- Now, these cases should succeed.


### PR DESCRIPTION
This restricts in `--erasure` type inference for lambdas that have no explicit erasure status on their arguments.
This brings `--erasure` closer to `--cubical` which does not infer lambdas in many cases (when it cannot see whether the lambda introduces a path or a function).

Surprisingly little was broken in the testsuite (only a case with lambdas used in reflection), but maybe we do not have a lot of `--erasure` examples in our testsuite.
The docs on lambda-abstractions broke badly because they had `--erasure` on and used lots of lambdas without type signatures.  I moved the `--erasure` stuff out into the docs on runtime-irrelevance.  
To demonstrate that with `--erasure` but not `--cubical` lambdas could be inferred if you marked the erasure status of all arguments (also the `@plenty` ones), I had to move the `--cubical` stuff out of this part of the docs and into the docs on Cubical Agda.

Maybe more breaks on the `agda2hs` side, @jespercockx?

In general, we can make a choice whether we want this PR or not.  
We could also declare: _if you do not annotate erased lambda with `@0`, don't complain if you get weird type errors_, refuting #7001 as a non-issue.

If we want to have our cake and eat it too, we would need modality metas so we can postpone decisions on which modality and compute them from constraints.  But then we need someone to implement this.

Re:
- #7001