### PR TITLE
Fix #6939: warn when parser drops misplaced tactic in `Fun`

### DIFF
--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -629,7 +629,7 @@ Expr
   | Application3 '->' Expr              { Fun (getRange ($1,$2,$3))
                                               (defaultArg $ rawApp $1)
                                               $3 }
-  | Attributes1 Application3 '->' Expr  {% applyAttrs $1 (defaultArg $ rawApp $2) <&> \ dom ->
+  | Attributes1 Application3 '->' Expr  {% applyAttrsDropTactic $1 (defaultArg $ rawApp $2) <&> \ dom ->
                                              Fun (getRange ($1,$2,$3,$4)) dom $4 }
   | Expr1 %prec LOWEST                  { $1 }
 

--- a/test/Fail/Issue6939.agda
+++ b/test/Fail/Issue6939.agda
@@ -1,0 +1,25 @@
+-- Andreas, 2025-08-08, issue #6939, report and test by Jesper Cockx
+
+open import Agda.Builtin.Unit
+open import Agda.Builtin.Nat
+open import Agda.Builtin.List
+open import Agda.Builtin.Reflection
+
+macro
+  run : (Term → TC ⊤) → Term → TC ⊤
+  run f hole = f hole
+
+auto : Term → TC ⊤
+auto hole = unify hole (var 0 [])
+
+postulate
+  doTheThing : @(tactic auto) {Set} → Set        -- warning
+  doTheThingToo : {@(tactic auto) _ : Set} → Set
+
+postulate
+  works     : (x : Set) → doTheThing {run auto}
+  alsoWorks : (x : Set) → doTheThingToo
+  fails     : (x : Set) → doTheThing
+
+-- warning: -W[no]MisplacedAttributes
+-- Ignoring misplaced @(tactic ...) attribute

--- a/test/Fail/Issue6939.err
+++ b/test/Fail/Issue6939.err
@@ -1,0 +1,6 @@
+
+Issue6939.agda:16.16-30: warning: -W[no]MisplacedAttributes
+Ignoring misplaced @(tactic ...) attribute
+Issue6939.agda:22.27-37: error: [UnsolvedMetaVariables]
+Unsolved metas at the following locations:
+  Issue6939.agda:22.27-37


### PR DESCRIPTION
Closes #6939.
