### PR TITLE
Emacs mode: clean `agda2-forget-all-goals`

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1798,7 +1798,8 @@ characters to the \\xNNNN notation used in Haskell strings."
 
 (defun agda2-forget-all-goals ()
   "Remove all goal annotations."
-  (remove-text-properties (point-min) (point-max) '(category nil))
+  (annotation-preserve-mod-p-and-undo
+    (remove-text-properties (point-min) (point-max) '(category nil)))
   (dolist (ovl (overlays-in (point-min) (point-max)))
     (when (overlay-get ovl 'agda2-gn)
       (delete-overlay ovl))))

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1797,17 +1797,11 @@ characters to the \\xNNNN notation used in Haskell strings."
           (insert-char ?  indent) (backward-char (1+ indent)))))))
 
 (defun agda2-forget-all-goals ()
-  "Remove all goal annotations.
-\(Including some text properties which might be used by other
-\(minor) modes.)"
-  (annotation-preserve-mod-p-and-undo
-   (remove-text-properties (point-min) (point-max)
-                           '(category nil agda2-delim2 nil agda2-delim3 nil
-                             display nil rear-nonsticky nil)))
-  (let ((p (point-min)))
-    (while (< (setq p (next-single-char-property-change p 'agda2-gn))
-              (point-max))
-      (delete-overlay (car (agda2-goal-at p))))))
+  "Remove all goal annotations."
+  (remove-text-properties (point-min) (point-max) '(category nil))
+  (dolist (ovl (overlays-in (point-min) (point-max)))
+    (when (overlay-get ovl 'agda2-gn)
+      (delete-overlay ovl))))
 
 (defun agda2-decl-beginning ()
   "Find the beginning point of the declaration containing the point.


### PR DESCRIPTION
This fixes several problems with agda2-forget-all-goals.

The main problem was that it was removing all display properties, which needlessly break many minor modes. Now it removes only the 'category properties, which are the only ones that agda mode creates anyway.

Besides, the previous code was doing many useless things:
1. removing properties which don't exist
2. using annotation-preserve-mod-p-and-undo, even though remove-text-properties does not change the undo data
3. finding the overlays by testing property changes, which is error-prone.

So I cleaned those at the same time.