### PR TITLE
Structured output of `--help`: options sorted into topics

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -227,6 +227,8 @@ General options
      are used Agda uses UTF-8 when writing to stdout (and when reading
      from stdin).
 
+.. _compilation-options:
+
 Compilation
 ~~~~~~~~~~~
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -252,11 +252,6 @@ See :ref:`compilers` for backend-specific options.
 
      Default, opposite of :option:`--no-main`.
 
-.. option:: --with-compiler={PATH}
-
-     Set ``PATH`` as the executable to call to compile the backend's
-     output (default: ``ghc`` for the GHC backend).
-
 Generating highlighted source code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -271,11 +271,6 @@ Generating highlighted source code
 
      Opposite of :option:`--count-clusters`. Default.
 
-.. option:: --css={URL}
-
-     Set URL of the CSS file used by the HTML files to ``URL`` (can be
-     relative).
-
 .. option:: --dependency-graph={FILE}
 
      .. versionadded:: 2.3.0
@@ -298,35 +293,12 @@ Generating highlighted source code
      to ``M`` (even if ``M``'s file cannot be found via the
      ``include`` paths given in the ``.agda-lib`` file).
 
-.. option:: --highlight-occurrences
-
-     .. versionadded:: 2.6.2
-
-     When :ref:`generating HTML <generating-html>`,
-     place the :file:`highlight-hover.js` script
-     in the output directory (see :option:`--html-dir`).
-     In the presence of the script,
-     hovering over an identifier in the rendering of the HTML
-     will highlight all occurrences of the same identifier on the page.
-
 .. option:: --html
 
      .. versionadded:: 2.2.0
 
      Generate HTML files with highlighted source code (see
-     :ref:`generating-html`).
-
-.. option:: --html-dir={DIR}
-
-     Set directory in which HTML files are placed to ``DIR`` (default:
-     ``html``).
-
-.. option:: --html-highlight=[code,all,auto]
-
-     .. versionadded:: 2.6.0
-
-     Whether to highlight non-Agda code as comments in generated HTML
-     files (default: ``all``; see :ref:`generating-html`).
+     :ref:`generating-html` for description and further options).
 
 .. option:: --latex
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -255,22 +255,6 @@ See :ref:`compilers` for backend-specific options.
 Generating highlighted source code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. option:: --count-clusters
-
-     .. versionadded:: 2.5.3
-
-     Count extended grapheme clusters when generating LaTeX code (see
-     :ref:`grapheme-clusters`).
-     Available only when Agda was built with Cabal flag :option:`enable-cluster-counting`.
-
-     Pragma option since 2.5.4.
-
-.. option:: --no-count-clusters
-
-     .. versionadded:: 2.6.4
-
-     Opposite of :option:`--count-clusters`. Default.
-
 .. option:: --dependency-graph={FILE}
 
      .. versionadded:: 2.3.0
@@ -305,14 +289,7 @@ Generating highlighted source code
      .. versionadded:: 2.3.2
 
      Generate LaTeX with highlighted source code (see
-     :ref:`generating-latex`).
-
-.. option:: --latex-dir={DIR}
-
-     .. versionadded:: 2.5.2
-
-     Set directory in which LaTeX files are placed to ``DIR``
-     (default: ``latex``).
+     :ref:`generating-latex` for description and further options).
 
 .. option:: --vim
 

--- a/doc/user-manual/tools/compilers.lagda.rst
+++ b/doc/user-manual/tools/compilers.lagda.rst
@@ -67,6 +67,11 @@ Options
      Then invoke ``ghc`` (or the compiler given by :option:`--with-compiler`) on the main file,
      unless option :option:`--ghc-dont-call-ghc` is given.
 
+.. option:: --with-compiler={PATH}
+
+     Set ``PATH`` as the executable to call to compile the backend's
+     output, default: ``ghc``.
+
 .. option:: --ghc-dont-call-ghc
 
      Only produce Haskell files, skip the compilation to binary.

--- a/doc/user-manual/tools/compilers.lagda.rst
+++ b/doc/user-manual/tools/compilers.lagda.rst
@@ -88,6 +88,8 @@ Options
      Instrument the code to trace function calls,
      inserting a ``Debug.Trace.trace`` statement at the beginning of each function.
 
+See :ref:`compilation-options` for options common to the compiler backends.
+
 Pragmas
 ^^^^^^^
 
@@ -190,6 +192,7 @@ Options
      Except for the main module, run the generated modules through ``node``,
      to verify absence of syntax errors.
 
+See :ref:`compilation-options` for options common to the compiler backends.
 
 Optimizations
 -------------

--- a/doc/user-manual/tools/generating-html.rst
+++ b/doc/user-manual/tools/generating-html.rst
@@ -56,15 +56,36 @@ files, use ``--html-highlight=auto``, which means auto-detection.
 Options
 -------
 
-:option:`--html-dir={DIR}`
-  Changes the directory where the output is placed to
-  :samp:`{DIR}`. Default: ``html``.
+:option:`--html`
 
-:option:`--css={URL}`
-  The CSS_ file used by the HTML files (:samp:`{URL}` can be relative).
+  Generate HTML files with highlighted source code.
 
-:option:`--html-highlight=[code,all,auto]`
-  Highlight Agda code only or everything in the generated HTML files.
-  Default: ``all``.
+.. option:: --html-dir={DIR}
+
+     Set directory in which HTML files are placed to ``DIR``
+     (default: ``html``).
+
+.. option:: --html-highlight=[code,all,auto]
+
+     .. versionadded:: 2.6.0
+
+     Whether to highlight non-Agda code as comments in generated HTML
+     files (default: ``all``).
+
+.. option:: --css={URL}
+
+     Set URL of the CSS_ file used by the HTML files to ``URL``
+     (can be relative).
+
+.. option:: --highlight-occurrences
+
+     .. versionadded:: 2.6.2
+
+     When :ref:`generating HTML <generating-html>`,
+     place the :file:`highlight-hover.js` script
+     in the output directory (see :option:`--html-dir`).
+     In the presence of the script,
+     hovering over an identifier in the rendering of the HTML
+     will highlight all occurrences of the same identifier on the page.
 
 .. _CSS:  https://www.w3.org/Style/CSS/

--- a/doc/user-manual/tools/generating-latex.rst
+++ b/doc/user-manual/tools/generating-latex.rst
@@ -4,8 +4,8 @@
 Generating LaTeX
 ****************
 
-An experimental LaTeX backend was added in Agda 2.3.2. It can be used
-as follows:
+The LaTeX backend was added in Agda 2.3.2.
+It can be used as follows:
 
 .. code-block:: console
 
@@ -39,6 +39,63 @@ from :file:`agda.sty`.
   :option:`--print-agda-data-dir` since 2.6.4.1. Thus, you can get hold
   of the class file via
   :samp:`cat $(agda --print-agda-data-dir)/latex/agda.sty`.
+
+.. _latex-backend-options:
+
+Options
+-------
+
+The following command-line options change the behaviour of the LaTeX
+backend:
+
+:option:`--latex`
+
+  Generate LaTeX with highlighted source code.
+
+:option:`--only-scope-checking`
+
+  Generates highlighting without typechecking the file.
+  See :ref:`quickLaTeX`.
+
+.. option:: --latex-dir={DIR}
+
+     .. versionadded:: 2.5.2
+
+     Set directory where :file:`agda.sty` and the generated LaTeX files
+     are placed to ``DIR`` (default: ``latex``).
+
+.. option:: --count-clusters
+
+     .. versionadded:: 2.5.3
+
+     Count extended grapheme clusters when generating LaTeX code (see
+     :ref:`grapheme-clusters`).
+     Available only when Agda was built with Cabal flag :option:`enable-cluster-counting`.
+
+     This option can be given in :ref:`OPTIONS<options-pragma>` pragmas
+     since 2.5.4.
+
+.. option:: --no-count-clusters
+
+     .. versionadded:: 2.6.4
+
+     Opposite of :option:`--count-clusters`. Default.
+
+The following options can be given when loading ``agda.sty`` by using
+``\usepackage[options]{agda}``:
+
+``bw``
+  Colour scheme which highlights in black and white.
+
+``conor``
+  Colour scheme similar to the colours used in Epigram 1.
+
+``references``
+  Enables :ref:`inline typesetting <latex-inline-references>` of
+  referenced code.
+
+``links``
+  Enables :ref:`hyperlink support <latex-links>`.
 
 .. _unicode-latex:
 
@@ -150,44 +207,6 @@ Known pitfalls and issues
   Possible workaround: Download a more up-to-date version of
   polytable_ and put it together with the generated files or install
   it globally.
-
-.. _latex-backend-options:
-
-Options
--------
-
-The following command-line options change the behaviour of the LaTeX
-backend:
-
-:option:`--latex-dir={DIR}`
-  Changes the output directory where :file:`agda.sty` and the output
-  :file:`.tex` file are placed to :samp:`{DIR}`. Default:
-  ``latex``.
-
-:option:`--only-scope-checking`
-  Generates highlighting without typechecking the file. See
-  :ref:`quickLaTeX`.
-
-:option:`--count-clusters`
-  Count extended grapheme clusters when generating LaTeX code. This
-  option can be given in :ref:`OPTIONS<options-pragma>` pragmas.
-  See :ref:`grapheme-clusters`.
-
-The following options can be given when loading ``agda.sty`` by using
-``\usepackage[options]{agda}``:
-
-``bw``
-  Colour scheme which highlights in black and white.
-
-``conor``
-  Colour scheme similar to the colours used in Epigram 1.
-
-``references``
-  Enables :ref:`inline typesetting <latex-inline-references>` of
-  referenced code.
-
-``links``
-  Enables :ref:`hyperlink support <latex-links>`.
 
 .. _quickLaTeX:
 

--- a/src/full/Agda/Interaction/Highlighting/LaTeX.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX.hs
@@ -8,4 +8,5 @@ module Agda.Interaction.Highlighting.LaTeX
 
 import Agda.Interaction.Highlighting.LaTeX.Backend as Exports
   ( latexBackend
+  , latexBackendName
   )

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Backend.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Backend.hs
@@ -2,6 +2,7 @@
 
 module Agda.Interaction.Highlighting.LaTeX.Backend
   ( latexBackend
+  , latexBackendName
   ) where
 
 import Agda.Interaction.Highlighting.LaTeX.Base
@@ -35,6 +36,7 @@ import Agda.Interaction.Options
   , OptDescr(..)
   )
 
+import Agda.Syntax.Common (BackendName)
 import Agda.Syntax.Position (mkRangeFile, rangeFilePath)
 import Agda.Syntax.TopLevelModuleName (TopLevelModuleName, projectRoot)
 
@@ -96,12 +98,15 @@ data LaTeXModuleEnv  = LaTeXModuleEnv LaTeXOptions
 data LaTeXModule     = LaTeXModule
 data LaTeXDef        = LaTeXDef
 
+latexBackendName :: BackendName
+latexBackendName = "LaTeX"
+
 latexBackend :: Backend
 latexBackend = Backend latexBackend'
 
 latexBackend' :: Backend' LaTeXFlags LaTeXCompileEnv LaTeXModuleEnv LaTeXModule LaTeXDef
 latexBackend' = Backend'
-  { backendName           = "LaTeX"
+  { backendName           = latexBackendName
   , backendVersion        = Nothing
   , options               = defaultLaTeXFlags
   , commandLineFlags      = latexFlagsDescriptions

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Backend.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Backend.hs
@@ -78,6 +78,8 @@ defaultLaTeXFlags = LaTeXFlags
   , latexFlagGenerateLaTeX = False
   }
 
+-- | Command-line flag options for LaTeX.
+--   The 'latexPragmaOptions' are not included here since they have a different 'Flag' type.
 latexFlagsDescriptions :: [OptDescr (Flag LaTeXFlags)]
 latexFlagsDescriptions =
   [ Option []     ["latex"] (NoArg latexFlag)

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -28,7 +28,7 @@ module Agda.Interaction.Options.Base
     , defaultInteractionOptions
     , defaultCutOff
     , defaultPragmaOptions
-    , standardOptions_
+    , optionGroups
     , unsafePragmaOptions
     , recheckBecausePragmaOptionsChanged
     , InfectiveCoinfective(..)
@@ -38,7 +38,6 @@ module Agda.Interaction.Options.Base
     , impliedPragmaOptions
     , safeFlag
     , mapFlag
-    , usage
     -- Reused by PandocAgda
     , inputFlag
     , standardOptions, deadStandardOptions
@@ -192,6 +191,7 @@ import Control.Monad        ( (>=>), when, void )
 import Control.Monad.Except ( ExceptT, MonadError(throwError), runExceptT )
 import Control.Monad.Writer ( Writer, runWriter, MonadWriter(..) )
 
+import Data.Bifunctor           ( second )
 import Data.Function            ( (&) )
 import Data.List                ( intercalate )
 import Data.Maybe
@@ -200,7 +200,7 @@ import qualified Data.Set as Set
 
 import GHC.Generics (Generic)
 
-import Agda.Utils.GetOpt        ( getOpt', usageInfo, ArgOrder(ReturnInOrder)
+import Agda.Utils.GetOpt        ( getOpt', ArgOrder(ReturnInOrder)
                                 , OptDescr(..), ArgDescr(..)
                                 )
 import qualified System.IO.Unsafe as UNSAFE (unsafePerformIO)
@@ -217,7 +217,6 @@ import Agda.Interaction.Options.Help
   ( Help(HelpFor, GeneralHelp)
   , string2HelpTopic
   , allHelpTopics
-  , helpTopicUsage
   )
 import Agda.Interaction.Options.Types
 import Agda.Interaction.Options.Warnings
@@ -247,8 +246,6 @@ import Agda.Utils.TypeLits
 import Agda.Utils.WithDefault
 
 import Agda.Utils.Impossible
-
-import Agda.Version
 
 parseVerboseKey :: VerboseKey -> [VerboseKeyItem]
 parseVerboseKey = List1.wordsBy (`elem` ['.', ':'])
@@ -1201,7 +1198,38 @@ integerArgument flag s = maybe usage return $ readMaybe s
   usage = throwError $ "option '" ++ flag ++ "' requires an integer argument"
 
 standardOptions :: [OptDescr (Flag CommandLineOptions)]
-standardOptions =
+standardOptions = concat $ map snd optionGroups
+
+optionGroups :: [(String, [OptDescr (Flag CommandLineOptions)])]
+optionGroups =
+  [ informationOptions
+  , mainModeOptions
+  , projectOptions
+  , essentialConfigurationOptions
+  , diagnosticsOptions
+  , emb warningPragmaOptions
+  , emb checkerPragmaOptions
+  , emb languagePragmaOptions
+  , emb universePragmaOptions
+  , emb modalityPragmaOptions
+  , emb terminationPragmaOptions
+  , emb patternMatchingPragmaOptions
+  , emb instancePragmaOptions
+  , emb rewritingPragmaOptions
+  , emb equalityCheckingPragmaOptions
+  , emb optimizationPragmaOptions
+  , emb printerPragmaOptions
+  , emb backendPragmaOptions
+  , compilationOptions
+  , emb debuggingPragmaOptions
+  ]
+  where
+    emb = second $ map $ fmap lensPragmaOptions
+
+-- | Options that make Agda print information, setup itself etc.
+--   Agda can execute these tasks in addition to a main mode \/ frontend \/ interactor.
+informationOptions :: (String, [OptDescr (Flag CommandLineOptions)])
+informationOptions = ("Setup and basic information",)
     [ Option ['V']  ["version"] (NoArg versionFlag)
                     ("print version information")
 
@@ -1229,24 +1257,55 @@ standardOptions =
     , Option []     ["print-options"] (NoArg printOptionsFlag)
                     ("print the full list of Agda's options")
 
-    , Option []     ["build-library"] (NoArg \ o -> return o{ optBuildLibrary = True })
-                    "build all modules included by the @.agda-lib@ file in the current directory"
-
     , Option []     ["setup"] (NoArg setupFlag)
                     ("setup the Agda data directory")
+    ]
+
+mainModeOptions :: (String, [OptDescr (Flag CommandLineOptions)])
+mainModeOptions = ("Main modes of operation",)
+    [ Option []     ["build-library"] (NoArg \ o -> return o{ optBuildLibrary = True })
+                    "build all modules included by the @.agda-lib@ file in the current directory"
 
     , Option ['I']  ["interactive"] (NoArg interactiveFlag)
                     "start in interactive mode"
+
     , Option []     ["interaction"] (NoArg ghciInteractionFlag)
                     "for use with the Emacs mode"
     , Option []     ["interaction-json"] (NoArg jsonInteractionFlag)
                     "for use with other editors such as Atom"
+    ]
+
+projectOptions :: (String, [OptDescr (Flag CommandLineOptions)])
+projectOptions = ("Project configuration",)
+    [ Option ['i']  ["include-path"] (ReqArg includeFlag "DIR")
+                    "look for imports in DIR"
+    , Option ['l']  ["library"] (ReqArg libraryFlag "LIB")
+                    "use library LIB"
+    , Option []     ["library-file"] (ReqArg overrideLibrariesFileFlag "FILE")
+                    "use FILE instead of the standard libraries file"
+    , Option []     ["no-libraries"] (NoArg noLibsFlag)
+                    "don't use any library files"
+    , Option []     ["no-default-libraries"] (NoArg noDefaultLibsFlag)
+                    "don't use default libraries"
+    ]
+
+essentialConfigurationOptions :: (String, [OptDescr (Flag CommandLineOptions)])
+essentialConfigurationOptions = ("Essential type checker configuration",)
+    [ Option []     ["ignore-interfaces"] (NoArg ignoreInterfacesFlag)
+                    "ignore interface files (re-type check everything)"
+    , Option []     ["only-scope-checking"] (NoArg onlyScopeCheckingFlag)
+                    "only scope-check the top-level module, do not type-check it"
     , Option []     ["interaction-exit-on-error"]
                     (NoArg interactionExitFlag)
                     "exit if a type error is encountered"
+    , Option []     ["vim"] (NoArg vimFlag)
+                    "generate Vim highlighting files"
+    ]
 
-    , Option []     ["compile-dir"] (ReqArg compileDirFlag "DIR")
-                    ("directory for compiler output (default: the project root)")
+diagnosticsOptions :: (String, [OptDescr (Flag CommandLineOptions)])
+diagnosticsOptions = ("Diagnostics and output",) $
+    [ Option []     ["colour", "color"] (OptArg diagnosticsColour (intercalate "|" colorValues))
+                    ("whether or not to colour diagnostics output. The default is auto.")
 
     , Option []     ["trace-imports"] (OptArg traceImportsFlag traceImportsArg)
                     (concat
@@ -1257,27 +1316,15 @@ standardOptions =
                       , ", default: 2)"
                       ])
 
-    , Option []     ["vim"] (NoArg vimFlag)
-                    "generate Vim highlighting files"
-    , Option []     ["ignore-interfaces"] (NoArg ignoreInterfacesFlag)
-                    "ignore interface files (re-type check everything)"
-    , Option ['i']  ["include-path"] (ReqArg includeFlag "DIR")
-                    "look for imports in DIR"
-    , Option ['l']  ["library"] (ReqArg libraryFlag "LIB")
-                    "use library LIB"
-    , Option []     ["library-file"] (ReqArg overrideLibrariesFileFlag "FILE")
-                    "use FILE instead of the standard libraries file"
-    , Option []     ["no-libraries"] (NoArg noLibsFlag)
-                    "don't use any library files"
-    , Option []     ["no-default-libraries"] (NoArg noDefaultLibsFlag)
-                    "don't use default libraries"
-    , Option []     ["only-scope-checking"] (NoArg onlyScopeCheckingFlag)
-                    "only scope-check the top-level module, do not type-check it"
     , Option []     ["transliterate"] (NoArg transliterateFlag)
                     "transliterate unsupported code points when printing to stdout/stderr"
-    , Option []     ["colour", "color"] (OptArg diagnosticsColour (intercalate "|" colorValues))
-                    ("whether or not to colour diagnostics output. The default is auto.")
-    ] ++ map (fmap lensPragmaOptions) pragmaOptions
+    ] ++ map (fmap lensPragmaOptions) (snd unicodePragmaOptions)
+
+compilationOptions :: (String, [OptDescr (Flag CommandLineOptions)])
+compilationOptions = ("Compilation options",) $
+    [ Option []     ["compile-dir"] (ReqArg compileDirFlag "DIR")
+                    ("directory for compiler output (default: the project root)")
+    ] ++ map (fmap lensPragmaOptions) (snd compilationPragmaOptions)
 
 -- | Command line options of previous versions of Agda.
 --   Should not be listed in the usage info, put parsed by GetOpt for good error messaging.
@@ -1294,6 +1341,325 @@ deadStandardOptions =
     ] ++ map (fmap lensPragmaOptions) deadPragmaOptions
   where
     msgSharing = "(in favor of the Agda abstract machine)"
+
+pragmaOptions :: [OptDescr (Flag PragmaOptions)]
+pragmaOptions = concat $ map snd
+  [ unicodePragmaOptions
+  , warningPragmaOptions
+  , checkerPragmaOptions
+  , languagePragmaOptions
+  , universePragmaOptions
+  , modalityPragmaOptions
+  , terminationPragmaOptions
+  , patternMatchingPragmaOptions
+  , instancePragmaOptions
+  , rewritingPragmaOptions
+  , equalityCheckingPragmaOptions
+  , optimizationPragmaOptions
+  , printerPragmaOptions
+  , backendPragmaOptions
+  , compilationPragmaOptions
+  , debuggingPragmaOptions
+  ]
+
+warningPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+warningPragmaOptions = ("Warnings",) $ concat
+  [ [ Option ['W']  ["warning"] (ReqArg warningModeFlag warningArg)
+                    ("set warning flags. See --help=warning.")
+    ]
+  ]
+
+-- | Controlling extra checks (termination etc.).
+checkerPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+checkerPragmaOptions = ("Consistency checking",) $ concat
+  [ pragmaFlag      "allow-unsolved-metas" lensOptAllowUnsolved
+                   "succeed and create interface file regardless of unsolved meta variables" ""
+                    Nothing
+  , pragmaFlag      "allow-incomplete-matches" lensOptAllowIncompleteMatch
+                    "succeed and create interface file regardless of incomplete pattern matches" ""
+                    Nothing
+  , pragmaFlag      "positivity-check" lensOptPositivityCheck
+                    "warn about not strictly positive data types" ""
+                    Nothing
+  , pragmaFlag      "termination-check" lensOptTerminationCheck
+                    "warn about possibly nonterminating code" ""
+                    Nothing
+  , [ Option []     ["termination-depth"] (ReqArg terminationDepthFlag "N")
+                    "allow termination checker to count decrease/increase upto N (default N=1)"
+    ]
+  , [ Option []     ["safe"] (NoArg safeFlag)
+                    "disable postulates, unsafe OPTION pragmas and primEraseEquality, implies --no-sized-types"
+    ]
+  , pragmaFlag      "allow-exec" lensOptAllowExec
+                    "allow system calls to trusted executables with primExec" ""
+                    Nothing
+  ]
+
+-- | Main flavor of language.
+languagePragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+languagePragmaOptions = ("Language variant",)
+    [ Option []     ["without-K"] (NoArg withoutKFlag)
+                    "turn on checks to make code compatible with HoTT (e.g. disabling the K rule). Implies --no-flat-split."
+    , Option []     ["cubical-compatible"] (NoArg cubicalCompatibleFlag)
+                    "turn on generation of auxiliary code required for --cubical, implies --without-K"
+    , Option []     ["erased-cubical"] (NoArg $ cubicalFlag CErased)
+                    "enable cubical features (some only in erased settings), implies --cubical-compatible"
+    , Option []     ["cubical"] (NoArg $ cubicalFlag CFull)
+                    "enable cubical features (e.g. overloads lambdas for paths), implies --cubical-compatible"
+    , Option []     ["with-K"] (NoArg withKFlag)
+                    "enable the K rule in pattern matching (default)"
+    ]
+
+universePragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+universePragmaOptions = ("Universes",) $ concat
+  [ pragmaFlag      "type-in-type" lensOptNoUniverseCheck
+                    "ignore universe levels"  "(this makes Agda inconsistent)"
+                    Nothing
+  , pragmaFlag      "omega-in-omega" lensOptOmegaInOmega
+                    "enable typing rule Setω : Setω" "(this makes Agda inconsistent)"
+                    Nothing
+  , pragmaFlag      "cumulativity" lensOptCumulativity
+                    "enable subtyping of universes" "(e.g. Set =< Set₁)"
+                    $ Just "disable subtyping of universes"
+  , pragmaFlag      "prop" lensOptProp
+                    "enable the use of the Prop universe" ""
+                    $ Just "disable the use of the Prop universe"
+  , pragmaFlag      "level-universe" lensOptLevelUniverse
+                    "place type Level in a dedicated LevelUniv universe" ""
+                    Nothing
+  , pragmaFlag      "two-level" lensOptTwoLevel
+                    "enable the use of SSet* universes" ""
+                    Nothing
+  , pragmaFlag      "universe-polymorphism" lensOptUniversePolymorphism
+                    "enable universe polymorphism" ""
+                    $ Just "disable universe polymorphism"
+  , pragmaFlag      "large-indices" lensOptLargeIndices
+                    "allow constructors with large indices" ""
+                    $ Just "always check that constructor arguments live in universes compatible with that of the datatype"
+
+  , pragmaFlag      "import-sorts" lensOptImportSorts
+                    "implicitly import Agda.Primitive using (Set; Prop) at the start of each top-level module" ""
+                    $ Just "disable the implicit import of Agda.Primitive using (Set; Prop) at the start of each top-level module"
+  , pragmaFlag      "load-primitives" lensOptLoadPrimitives
+                    "load primitives modules" ""
+                    $ Just "disable loading of primitive modules completely (implies --no-import-sorts)"
+  ]
+
+modalityPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+modalityPragmaOptions = ("Modalities",) $ concat
+  [ pragmaFlag      "erasure" lensOptErasure
+                    "enable erasure" ""
+                    Nothing
+  , pragmaFlag      "erased-matches" lensOptErasedMatches
+                    "allow matching in erased positions for single-constructor types" "(implies --erasure if supplied explicitly)"
+                    Nothing
+  , pragmaFlag      "erase-record-parameters" lensOptEraseRecordParameters
+                    "mark all parameters of record modules as erased" "(implies --erasure)"
+                    Nothing
+  , pragmaFlag      "cohesion" lensOptCohesion
+                    "enable the cohesion modalities" "(in particular @flat)"
+                    Nothing
+  , pragmaFlag      "flat-split" lensOptFlatSplit
+                    "allow splitting on `(@flat x : A)' arguments" "(implies --cohesion)"
+                    Nothing
+  , pragmaFlag      "guarded" lensOptGuarded
+                    "enable @lock/@tick attributes" ""
+                    $ Just "disable @lock/@tick attributes"
+  , pragmaFlag      "polarity" lensOptPolarity
+                    "enable the polarity modalities (@++, @mixed, etc.) and their integration in the positivity checker" ""
+                    Nothing
+  , pragmaFlag      "irrelevant-projections" lensOptIrrelevantProjections
+                    "enable projection of irrelevant record fields and similar irrelevant definitions" "(inconsistent)"
+                    $ Just "disable projection of irrelevant record fields and similar irrelevant definitions"
+  , pragmaFlag      "experimental-irrelevance" lensOptExperimentalIrrelevance
+                    "enable potentially unsound irrelevance features" "(irrelevant levels, irrelevant data matching)"
+                    Nothing
+  ]
+
+terminationPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+terminationPragmaOptions = ("Termination and productivity checking",) $ concat
+  [ pragmaFlag      "sized-types" lensOptSizedTypes
+                    "enable sized types" "(inconsistent with --guardedness)"
+                    $ Just "disable sized types"
+  , pragmaFlag      "guardedness" lensOptGuardedness
+                    "enable constructor-based guarded corecursion" "(inconsistent with --sized-types)"
+                    $ Just "disable constructor-based guarded corecursion"
+  , pragmaFlag      "forced-argument-recursion" lensOptForcedArgumentRecursion
+                    "allow recursion on forced constructor arguments" ""
+                    Nothing
+  ]
+
+patternMatchingPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+patternMatchingPragmaOptions = ("Pattern matching",) $ concat
+  [ pragmaFlag      "pattern-matching" lensOptPatternMatching
+                    "enable pattern matching" ""
+                    $ Just "disable pattern matching completely"
+  , pragmaFlag      "copatterns" lensOptCopatterns
+                    "enable definitions by copattern matching" ""
+                    $ Just "disable definitions by copattern matching"
+  , [ Option []     ["exact-split"] (NoArg $ exactSplitFlag True)
+                    "require all clauses in a definition to hold as definitional equalities (unless marked CATCHALL)"
+    , Option []     ["no-exact-split"] (NoArg $ exactSplitFlag False)
+                    "do not require all clauses in a definition to hold as definitional equalities (default)"
+    ]
+  , pragmaFlag      "hidden-argument-puns" lensOptHiddenArgumentPuns
+                    "interpret the patterns {x} and {{x}} as puns" ""
+                    Nothing
+  , pragmaFlag      "injective-type-constructors" lensOptInjectiveTypeConstructors
+                    "enable injective type constructors" "(makes Agda anti-classical and possibly inconsistent)"
+                    $ Just "disable injective type constructors"
+  , [ Option []     ["inversion-max-depth"] (ReqArg inversionMaxDepthFlag "N")
+                    "set maximum depth for pattern match inversion to N (default: 50)"
+    ]
+  ]
+
+instancePragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+instancePragmaOptions = ("Instance search",) $ concat
+  [ [ Option []     ["instance-search-depth"] (ReqArg instanceDepthFlag "N")
+                    "set instance search depth to N (default: 500)"
+    ]
+  , backtrackingInstancesOption
+  , pragmaFlag      "qualified-instances" lensOptQualifiedInstances
+                    "use instances with qualified names" ""
+                    Nothing
+  , pragmaFlag      "experimental-lazy-instances" lensOptExperimentalLazyInstances
+                    "enable experimental, faster implementation of instance search" ""
+                    Nothing
+  ]
+
+rewritingPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+rewritingPragmaOptions = ("Rewriting and confluence",) $ concat
+  [ pragmaFlag      "rewriting" lensOptRewriting
+                    "enable declaration and use of REWRITE rules" ""
+                    $ Just "disable declaration and use of REWRITE rules"
+  , [ Option []     ["local-confluence-check"] (NoArg $ confluenceCheckFlag LocalConfluenceCheck)
+                    "enable checking of local confluence of REWRITE rules"
+    , Option []     ["confluence-check"] (NoArg $ confluenceCheckFlag GlobalConfluenceCheck)
+                    "enable global confluence checking of REWRITE rules (more restrictive than --local-confluence-check)"
+    , Option []     ["no-confluence-check"] (NoArg noConfluenceCheckFlag)
+                    "disable confluence checking of REWRITE rules (default)"
+    ]
+  ]
+
+equalityCheckingPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+equalityCheckingPragmaOptions = ("Definitional equality",) $ concat
+  [ pragmaFlag      "eta-equality" lensOptEta
+                    "default records to eta-equality" ""
+                    $ Just "default records to no-eta-equality"
+  , lossyUnificationOption
+  , requireUniqueMetaSolutionsOptions
+  , [ Option []     ["no-syntactic-equality"] (NoArg $ syntacticEqualityFlag (Just "0"))
+                    "disable the syntactic equality shortcut in the conversion checker"
+    , Option []     ["syntactic-equality"] (OptArg syntacticEqualityFlag "FUEL")
+                    "give the syntactic equality shortcut FUEL units of fuel (default: unlimited)"
+    ]
+  , pragmaFlag      "auto-inline" lensOptAutoInline
+                    "enable automatic compile-time inlining" ""
+                    $ Just "disable automatic compile-time inlining, only definitions marked INLINE will be inlined"
+
+  , pragmaFlag      "fast-reduce" lensOptFastReduce
+                    "enable reduction using the Agda Abstract Machine" ""
+                    $ Just "disable reduction using the Agda Abstract Machine"
+  , pragmaFlag      "call-by-name" lensOptCallByName
+                    "use call-by-name evaluation instead of call-by-need" ""
+                    $ Just "use call-by-need evaluation"
+  ]
+
+optimizationPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+optimizationPragmaOptions = ("Type checker optimizations",) $ concat
+  [ pragmaFlag      "caching" lensOptCaching
+                    "enable caching of typechecking" ""
+                    $ Just "disable caching of typechecking"
+  , pragmaFlag      "double-check" lensOptDoubleCheck
+                    "enable double-checking of all terms using the internal typechecker" ""
+                    $ Just "disable double-checking of terms"
+  , pragmaFlag      "forcing" lensOptForcing
+                    "enable the forcing analysis for data constructors" "(optimisation)"
+                    $ Just "disable the forcing analysis"
+  , pragmaFlag      "projection-like" lensOptProjectionLike
+                    "enable the analysis whether function signatures liken those of projections" "(optimisation)"
+                    $ Just "disable the projection-like analysis"
+  , pragmaFlag      "infer-absurd-clauses" lensOptInferAbsurdClauses
+                    "eliminate absurd clauses in case splitting and coverage checking" ""
+                    $ Just "do not automatically eliminate absurd clauses in case splitting and coverage checking (can speed up type-checking)"
+  , pragmaFlag      "save-metas" lensOptSaveMetas
+                    "save meta-variables" ""
+                    Nothing
+  ]
+
+unicodePragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+unicodePragmaOptions = ("Unicode",) $ concat
+  [ pragmaFlag'     "unicode" lensOptUseUnicode unicodeOrAsciiEffect
+                    "use unicode characters when printing terms" ""
+                    Nothing
+  ]
+
+-- | Controlling the rendering of Agda expressions.
+printerPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+printerPragmaOptions = ("Checker output",) $ concat
+  [ pragmaFlag      "show-implicit" lensOptShowImplicit
+                    "show implicit arguments when printing" ""
+                    Nothing
+  , pragmaFlag      "show-irrelevant" lensOptShowIrrelevant
+                    "show irrelevant arguments when printing" ""
+                    Nothing
+  , pragmaFlag      "show-identity-substitutions" lensOptShowIdentitySubstitutions
+                    "show all arguments of metavariables when printing terms" ""
+                    Nothing
+  , pragmaFlag      "print-pattern-synonyms" lensOptPrintPatternSynonyms
+                    "keep pattern synonyms when printing terms" ""
+                    $ Just "expand pattern synonyms when printing terms"
+  , pragmaFlag      "postfix-projections" lensOptPostfixProjections
+                    "prefer postfix projection notation" ""
+                    $ Just "prefer prefix projection notation"
+  , pragmaFlag      "keep-pattern-variables" lensOptKeepPatternVariables
+                    "don't replace variables with dot patterns during case splitting" ""
+                    $ Just "replace variables with dot patterns during case splitting"
+  ]
+
+-- | Backend-relevant options.
+backendPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+backendPragmaOptions = ("Backend options",) $ concat
+  [ pragmaFlag      "count-clusters" lensOptCountClusters
+                    "count extended grapheme clusters when generating LaTeX"
+                    ("(note that this flag " ++
+#ifdef COUNT_CLUSTERS
+                      "is not enabled in all builds"
+#else
+                      "has not been enabled in this build"
+#endif
+                      ++ " of Agda)")
+                    Nothing
+  , pragmaFlag      "keep-covering-clauses" lensOptKeepCoveringClauses
+                    "do not discard covering clauses" "(required for some external backends)"
+                    $ Just "discard covering clauses"
+  ]
+
+-- | Common options for compilers.
+compilationPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+compilationPragmaOptions = ("Compilation options",) $ concat
+  [ pragmaFlag      "main" lensOptCompileMain
+                    "treat the requested module as the main module of a program when compiling" ""
+                    Nothing
+  ]
+
+-- | Debugging and profiling Agda.
+debuggingPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+debuggingPragmaOptions = ("Debugging and profiling Agda",) $ concat
+  [ [ Option ['v']  ["verbose"] (ReqArg verboseFlag "N")
+                    "set verbosity level to N. Only has an effect if Agda was built with the \"debug\" flag."
+    , Option []     ["profile"] (ReqArg profileFlag profileArg)
+                    (concat
+                       [ "turn on profiling for "
+                       , profileArg
+                       , " (where "
+                       , profileArg
+                       , "="
+                       , intercalate "|" profileValues
+                       , ")"
+                       ])
+    ]
+  ]
 
 -- | Construct a flag of type @WithDefault _@
 --
@@ -1372,238 +1738,6 @@ pragmaFlagBool' long field effect pos info neg =
     where a = fromBool b
   def  b = applyWhen (fromBool b == b0) (++ " (default)")
   expl b = if b then unwords1 [pos, info] else fromMaybe ("do not " ++ pos) neg
-
-
-pragmaOptions :: [OptDescr (Flag PragmaOptions)]
-pragmaOptions = concat
-  [ pragmaFlag      "show-implicit" lensOptShowImplicit
-                    "show implicit arguments when printing" ""
-                    Nothing
-  , pragmaFlag      "show-irrelevant" lensOptShowIrrelevant
-                    "show irrelevant arguments when printing" ""
-                    Nothing
-  , pragmaFlag      "show-identity-substitutions" lensOptShowIdentitySubstitutions
-                    "show all arguments of metavariables when printing terms" ""
-                    Nothing
-  , pragmaFlag'     "unicode" lensOptUseUnicode unicodeOrAsciiEffect
-                    "use unicode characters when printing terms" ""
-                    Nothing
-  , [ Option ['v']  ["verbose"] (ReqArg verboseFlag "N")
-                    "set verbosity level to N. Only has an effect if Agda was built with the \"debug\" flag."
-    , Option []     ["profile"] (ReqArg profileFlag profileArg)
-                    (concat
-                       [ "turn on profiling for "
-                       , profileArg
-                       , " (where "
-                       , profileArg
-                       , "="
-                       , intercalate "|" profileValues
-                       , ")"
-                       ])
-    ]
-  , pragmaFlag      "allow-unsolved-metas" lensOptAllowUnsolved
-                    "succeed and create interface file regardless of unsolved meta variables" ""
-                    Nothing
-  , pragmaFlag      "allow-incomplete-matches" lensOptAllowIncompleteMatch
-                    "succeed and create interface file regardless of incomplete pattern matches" ""
-                    Nothing
-  , pragmaFlag      "positivity-check" lensOptPositivityCheck
-                    "warn about not strictly positive data types" ""
-                    Nothing
-  , pragmaFlag      "termination-check" lensOptTerminationCheck
-                    "warn about possibly nonterminating code" ""
-                    Nothing
-  , [ Option []     ["termination-depth"] (ReqArg terminationDepthFlag "N")
-                    "allow termination checker to count decrease/increase upto N (default N=1)"
-    ]
-  , pragmaFlag      "type-in-type" lensOptNoUniverseCheck
-                    "ignore universe levels"  "(this makes Agda inconsistent)"
-                    Nothing
-  , pragmaFlag      "omega-in-omega" lensOptOmegaInOmega
-                    "enable typing rule Setω : Setω" "(this makes Agda inconsistent)"
-                    Nothing
-  , pragmaFlag      "cumulativity" lensOptCumulativity
-                    "enable subtyping of universes" "(e.g. Set =< Set₁)"
-                    $ Just "disable subtyping of universes"
-  , pragmaFlag      "prop" lensOptProp
-                    "enable the use of the Prop universe" ""
-                    $ Just "disable the use of the Prop universe"
-  , pragmaFlag      "level-universe" lensOptLevelUniverse
-                    "place type Level in a dedicated LevelUniv universe" ""
-                    Nothing
-  , pragmaFlag      "two-level" lensOptTwoLevel
-                    "enable the use of SSet* universes" ""
-                    Nothing
-  , pragmaFlag      "sized-types" lensOptSizedTypes
-                    "enable sized types" "(inconsistent with --guardedness)"
-                    $ Just "disable sized types"
-  , pragmaFlag      "cohesion" lensOptCohesion
-                    "enable the cohesion modalities" "(in particular @flat)"
-                    Nothing
-  , pragmaFlag      "flat-split" lensOptFlatSplit
-                    "allow splitting on `(@flat x : A)' arguments" "(implies --cohesion)"
-                    Nothing
-  , pragmaFlag      "polarity" lensOptPolarity
-                    "enable the polarity modalities (@++, @mixed, etc.) and their integration in the positivity checker" ""
-                    Nothing
-  , pragmaFlag      "guardedness" lensOptGuardedness
-                    "enable constructor-based guarded corecursion" "(inconsistent with --sized-types)"
-                    $ Just "disable constructor-based guarded corecursion"
-  , pragmaFlag      "injective-type-constructors" lensOptInjectiveTypeConstructors
-                    "enable injective type constructors" "(makes Agda anti-classical and possibly inconsistent)"
-                    $ Just "disable injective type constructors"
-  , pragmaFlag      "universe-polymorphism" lensOptUniversePolymorphism
-                    "enable universe polymorphism" ""
-                    $ Just "disable universe polymorphism"
-  , pragmaFlag      "irrelevant-projections" lensOptIrrelevantProjections
-                    "enable projection of irrelevant record fields and similar irrelevant definitions" "(inconsistent)"
-                    $ Just "disable projection of irrelevant record fields and similar irrelevant definitions"
-  , pragmaFlag      "experimental-irrelevance" lensOptExperimentalIrrelevance
-                    "enable potentially unsound irrelevance features" "(irrelevant levels, irrelevant data matching)"
-                    Nothing
-  , [ Option []     ["with-K"] (NoArg withKFlag)
-                    "enable the K rule in pattern matching (default)"
-    , Option []     ["cubical-compatible"] (NoArg cubicalCompatibleFlag)
-                    "turn on generation of auxiliary code required for --cubical, implies --without-K"
-    , Option []     ["without-K"] (NoArg withoutKFlag)
-                    "turn on checks to make code compatible with HoTT (e.g. disabling the K rule). Implies --no-flat-split."
-    ]
-  , pragmaFlag      "copatterns" lensOptCopatterns
-                    "enable definitions by copattern matching" ""
-                    $ Just "disable definitions by copattern matching"
-  , pragmaFlag      "pattern-matching" lensOptPatternMatching
-                    "enable pattern matching" ""
-                    $ Just "disable pattern matching completely"
-  , [ Option []     ["exact-split"] (NoArg $ exactSplitFlag True)
-                    "require all clauses in a definition to hold as definitional equalities (unless marked CATCHALL)"
-    , Option []     ["no-exact-split"] (NoArg $ exactSplitFlag False)
-                    "do not require all clauses in a definition to hold as definitional equalities (default)"
-    ]
-  , pragmaFlag      "hidden-argument-puns" lensOptHiddenArgumentPuns
-                    "interpret the patterns {x} and {{x}} as puns" ""
-                    Nothing
-  , pragmaFlag      "eta-equality" lensOptEta
-                    "default records to eta-equality" ""
-                    $ Just "default records to no-eta-equality"
-  , pragmaFlag      "forcing" lensOptForcing
-                    "enable the forcing analysis for data constructors" "(optimisation)"
-                    $ Just "disable the forcing analysis"
-  , pragmaFlag      "projection-like" lensOptProjectionLike
-                    "enable the analysis whether function signatures liken those of projections" "(optimisation)"
-                    $ Just "disable the projection-like analysis"
-  , pragmaFlag      "erasure" lensOptErasure
-                    "enable erasure" ""
-                    Nothing
-  , pragmaFlag      "erased-matches" lensOptErasedMatches
-                    "allow matching in erased positions for single-constructor types" "(implies --erasure if supplied explicitly)"
-                    Nothing
-  , pragmaFlag      "erase-record-parameters" lensOptEraseRecordParameters
-                    "mark all parameters of record modules as erased" "(implies --erasure)"
-                    Nothing
-  , pragmaFlag      "rewriting" lensOptRewriting
-                    "enable declaration and use of REWRITE rules" ""
-                    $ Just "disable declaration and use of REWRITE rules"
-  , [ Option []     ["local-confluence-check"] (NoArg $ confluenceCheckFlag LocalConfluenceCheck)
-                    "enable checking of local confluence of REWRITE rules"
-    , Option []     ["confluence-check"] (NoArg $ confluenceCheckFlag GlobalConfluenceCheck)
-                    "enable global confluence checking of REWRITE rules (more restrictive than --local-confluence-check)"
-    , Option []     ["no-confluence-check"] (NoArg noConfluenceCheckFlag)
-                    "disable confluence checking of REWRITE rules (default)"
-    , Option []     ["cubical"] (NoArg $ cubicalFlag CFull)
-                    "enable cubical features (e.g. overloads lambdas for paths), implies --cubical-compatible"
-    , Option []     ["erased-cubical"] (NoArg $ cubicalFlag CErased)
-                    "enable cubical features (some only in erased settings), implies --cubical-compatible"
-    ]
-  , pragmaFlag      "guarded" lensOptGuarded
-                    "enable @lock/@tick attributes" ""
-                    $ Just "disable @lock/@tick attributes"
-  , lossyUnificationOption
-  , requireUniqueMetaSolutionsOptions
-  , pragmaFlag      "postfix-projections" lensOptPostfixProjections
-                    "prefer postfix projection notation" ""
-                    $ Just "prefer prefix projection notation"
-  , pragmaFlag      "keep-pattern-variables" lensOptKeepPatternVariables
-                    "don't replace variables with dot patterns during case splitting" ""
-                    $ Just "replace variables with dot patterns during case splitting"
-  , pragmaFlag      "infer-absurd-clauses" lensOptInferAbsurdClauses
-                    "eliminate absurd clauses in case splitting and coverage checking" ""
-                    $ Just "do not automatically eliminate absurd clauses in case splitting and coverage checking (can speed up type-checking)"
-  , [ Option []     ["instance-search-depth"] (ReqArg instanceDepthFlag "N")
-                    "set instance search depth to N (default: 500)"
-    ]
-  , backtrackingInstancesOption
-  , pragmaFlag      "qualified-instances" lensOptQualifiedInstances
-                    "use instances with qualified names" ""
-                    Nothing
-  , [ Option []     ["inversion-max-depth"] (ReqArg inversionMaxDepthFlag "N")
-                    "set maximum depth for pattern match inversion to N (default: 50)"
-    , Option []     ["safe"] (NoArg safeFlag)
-                    "disable postulates, unsafe OPTION pragmas and primEraseEquality, implies --no-sized-types"
-    ]
-  , pragmaFlag      "double-check" lensOptDoubleCheck
-                    "enable double-checking of all terms using the internal typechecker" ""
-                    $ Just "disable double-checking of terms"
-  , [ Option []     ["no-syntactic-equality"] (NoArg $ syntacticEqualityFlag (Just "0"))
-                    "disable the syntactic equality shortcut in the conversion checker"
-    , Option []     ["syntactic-equality"] (OptArg syntacticEqualityFlag "FUEL")
-                    "give the syntactic equality shortcut FUEL units of fuel (default: unlimited)"
-    , Option ['W']  ["warning"] (ReqArg warningModeFlag warningArg)
-                    ("set warning flags. See --help=warning.")
-    ]
-  , pragmaFlag      "main" lensOptCompileMain
-                    "treat the requested module as the main module of a program when compiling" ""
-                    Nothing
-  , pragmaFlag      "caching" lensOptCaching
-                    "enable caching of typechecking" ""
-                    $ Just "disable caching of typechecking"
-  , pragmaFlag      "count-clusters" lensOptCountClusters
-                    "count extended grapheme clusters when generating LaTeX"
-                    ("(note that this flag " ++
-#ifdef COUNT_CLUSTERS
-                      "is not enabled in all builds"
-#else
-                      "has not been enabled in this build"
-#endif
-                      ++ " of Agda)")
-                    Nothing
-  , pragmaFlag      "auto-inline" lensOptAutoInline
-                    "enable automatic compile-time inlining" ""
-                    $ Just "disable automatic compile-time inlining, only definitions marked INLINE will be inlined"
-  , pragmaFlag      "print-pattern-synonyms" lensOptPrintPatternSynonyms
-                    "keep pattern synonyms when printing terms" ""
-                    $ Just "expand pattern synonyms when printing terms"
-  , pragmaFlag      "fast-reduce" lensOptFastReduce
-                    "enable reduction using the Agda Abstract Machine" ""
-                    $ Just "disable reduction using the Agda Abstract Machine"
-  , pragmaFlag      "call-by-name" lensOptCallByName
-                    "use call-by-name evaluation instead of call-by-need" ""
-                    $ Just "use call-by-need evaluation"
-
-  , pragmaFlag      "import-sorts" lensOptImportSorts
-                    "implicitly import Agda.Primitive using (Set; Prop) at the start of each top-level module" ""
-                    $ Just "disable the implicit import of Agda.Primitive using (Set; Prop) at the start of each top-level module"
-  , pragmaFlag      "load-primitives" lensOptLoadPrimitives
-                    "load primitives modules" ""
-                    $ Just "disable loading of primitive modules completely (implies --no-import-sorts)"
-  , pragmaFlag      "allow-exec" lensOptAllowExec
-                    "allow system calls to trusted executables with primExec" ""
-                    Nothing
-  , pragmaFlag      "save-metas" lensOptSaveMetas
-                    "save meta-variables" ""
-                    Nothing
-  , pragmaFlag      "keep-covering-clauses" lensOptKeepCoveringClauses
-                    "do not discard covering clauses" "(required for some external backends)"
-                    $ Just "discard covering clauses"
-  , pragmaFlag      "large-indices" lensOptLargeIndices
-                    "allow constructors with large indices" ""
-                    $ Just "always check that constructor arguments live in universes compatible with that of the datatype"
-  , pragmaFlag      "forced-argument-recursion" lensOptForcedArgumentRecursion
-                    "allow recursion on forced constructor arguments" ""
-                    Nothing
-  , pragmaFlag      "experimental-lazy-instances" lensOptExperimentalLazyInstances
-                    "enable experimental, faster implementation of instance search" ""
-                    Nothing
-  ]
 
 pragmaOptionDefault :: KnownBool b => (PragmaOptions -> WithDefault b) -> Bool -> String
 pragmaOptionDefault f b =
@@ -1757,19 +1891,6 @@ parsePluginOptions argv opts =
   getOptSimple argv opts
     (\s _ -> throwError $
                "Internal error: Flag " ++ s ++ " passed to a plugin")
-
--- | The usage info message. The argument is the program name (probably
---   agda).
-usage :: [OptDescr ()] -> String -> Help -> String
-usage options progName GeneralHelp = usageInfo header options
-    where
-        header = unlines
-          [ "Agda version " ++ version
-          , ""
-          , "Usage: " ++ progName ++ " [OPTIONS...] [FILE]"
-          ]
-
-usage options progName (HelpFor topic) = helpTopicUsage topic
 
 -- | Removes RTS options from a list of options.
 

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -29,6 +29,7 @@ module Agda.Interaction.Options.Base
     , defaultCutOff
     , defaultPragmaOptions
     , optionGroups
+    , latexPragmaOptions
     , unsafePragmaOptions
     , recheckBecausePragmaOptionsChanged
     , InfectiveCoinfective(..)
@@ -1197,8 +1198,11 @@ integerArgument flag s = maybe usage return $ readMaybe s
   where
   usage = throwError $ "option '" ++ flag ++ "' requires an integer argument"
 
+-- | This list should contain all options defined in this module.
 standardOptions :: [OptDescr (Flag CommandLineOptions)]
-standardOptions = concat $ map snd optionGroups
+standardOptions = concat $
+  map (fmap lensPragmaOptions) (snd latexPragmaOptions) :
+  map snd optionGroups
 
 optionGroups :: [(String, [OptDescr (Flag CommandLineOptions)])]
 optionGroups =
@@ -1342,6 +1346,7 @@ deadStandardOptions =
   where
     msgSharing = "(in favor of the Agda abstract machine)"
 
+-- | This list should contain all pragma options except for the 'deadPragmaOptions'.
 pragmaOptions :: [OptDescr (Flag PragmaOptions)]
 pragmaOptions = concat $ map snd
   [ unicodePragmaOptions
@@ -1357,6 +1362,7 @@ pragmaOptions = concat $ map snd
   , equalityCheckingPragmaOptions
   , optimizationPragmaOptions
   , printerPragmaOptions
+  , latexPragmaOptions
   , backendPragmaOptions
   , compilationPragmaOptions
   , debuggingPragmaOptions
@@ -1617,9 +1623,9 @@ printerPragmaOptions = ("Checker output",) $ concat
                     $ Just "replace variables with dot patterns during case splitting"
   ]
 
--- | Backend-relevant options.
-backendPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
-backendPragmaOptions = ("Backend options",) $ concat
+-- | Latex pragma options.
+latexPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+latexPragmaOptions = ("Latex options",) $ concat
   [ pragmaFlag      "count-clusters" lensOptCountClusters
                     "count extended grapheme clusters when generating LaTeX"
                     ("(note that this flag " ++
@@ -1630,7 +1636,12 @@ backendPragmaOptions = ("Backend options",) $ concat
 #endif
                       ++ " of Agda)")
                     Nothing
-  , pragmaFlag      "keep-covering-clauses" lensOptKeepCoveringClauses
+  ]
+
+-- | Backend-relevant options.
+backendPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])
+backendPragmaOptions = ("Backend options",) $ concat
+  [ pragmaFlag      "keep-covering-clauses" lensOptKeepCoveringClauses
                     "do not discard covering clauses" "(required for some external backends)"
                     $ Just "discard covering clauses"
   ]

--- a/src/full/Agda/Interaction/Options/BashCompletion.hs
+++ b/src/full/Agda/Interaction/Options/BashCompletion.hs
@@ -43,7 +43,7 @@ import Data.Maybe
 import Text.Read      ( readMaybe )
 
 import Agda.Interaction.Options.Arguments      ( optionValues )
-import Agda.Interaction.Options.Base           ( standardOptions_ )
+import Agda.Interaction.Options.Base           ( standardOptions )
 
 import Agda.Utils.Function       ( applyWhenJust )
 import Agda.Utils.GetOpt         ( OptDescr(..), ArgDescr(..) )
@@ -60,11 +60,11 @@ printedOptions :: [String]
 printedOptions = map fst printedOptionsWithHelp
 
 printedOptionsWithHelp :: [(String, Help)]
-printedOptionsWithHelp = printOptions standardOptions_
+printedOptionsWithHelp = printOptions standardOptions
 
 -- | Print just the names of the given options (e.g. for bash completion scripts).
 --   For long options with finitely enumerable arguments, print all variants.
-printOptions :: [OptDescr ()] -> [(String, Help)]
+printOptions :: [OptDescr a] -> [(String, Help)]
 printOptions = concat . map \case
   Option short long arg help -> concat $
     map (,help) ss :

--- a/src/full/Agda/Utils/GetOpt.hs
+++ b/src/full/Agda/Utils/GetOpt.hs
@@ -85,16 +85,18 @@ data OptKind a
 -- the header (first argument) and the options described by the
 -- second argument.
 usageInfo ::
-     String            -- ^ header
+     Int               -- ^ minimal width of long option column
+  -> String            -- ^ header
   -> [OptDescr a]      -- ^ option descriptors
   -> String            -- ^ nicely formatted description of options
-usageInfo header optDescr = unlines (header:table)
+usageInfo width header optDescr = unlines (header:table)
    where
      (ss, ls, ds)   = unzip3 $ concatMap fmtOpt optDescr
      table          = zipWith3 paste (sameLen ss) (sameLen ls) ds
-     paste x y z    = "  " ++ x ++ "  " ++ y ++ "  " ++ z
+     paste x y z    = "  " ++ pad width (x ++ "  " ++ y) ++ "  " ++ z
      sameLen xs     = flushLeft ((maximum . map length) xs) xs
-     flushLeft n xs = [ take n (x ++ repeat ' ') | x <- xs ]
+     flushLeft n xs = [ pad n x | x <- xs ]
+     pad n x        = x ++ replicate (n - length x) ' '
 
 fmtOpt :: OptDescr a -> [(String, String, String)]
 fmtOpt (Option sos los ad descr) =
@@ -216,7 +218,7 @@ shortOpt y ys rs optDescr = short ads ys rs
 -- * Miscellaneous error formatting
 
 errAmbig :: [OptDescr a] -> String -> OptKind a
-errAmbig ods optStr = OptErr (usageInfo header ods)
+errAmbig ods optStr = OptErr (usageInfo 0 header ods)
    where
      header = "option `" ++ optStr ++ "' is ambiguous; could be one of:"
 

--- a/test/doc/user-manual-covers-options.sh
+++ b/test/doc/user-manual-covers-options.sh
@@ -4,7 +4,12 @@
 # A shell script to check whether all Agda options are documented in the user manual.
 
 # Options are documented in the following files of the user manual:
-DOC="doc/user-manual/tools/command-line-options.rst doc/user-manual/tools/compilers.lagda.rst"
+DOC="\
+doc/user-manual/tools/command-line-options.rst \
+doc/user-manual/tools/compilers.lagda.rst \
+doc/user-manual/tools/generating-html.rst \
+doc/user-manual/tools/generating-latex.rst \
+"
 
 # 'agda --help' omits some options which are mentioned in the user manual:
 HIDDEN_OPTIONS="--ignore-all-interfaces" # https://github.com/agda/agda/issues/3522#issuecomment-461010898


### PR DESCRIPTION
- **[doc] link from backend options to general compilation options**
  Closes #6940.
  
Rendering: https://agda--8058.org.readthedocs.build/en/8058/tools/compilers.html#options

- **[help] sort options into groups (yay!)**
  `agda --help` now prints the options tidily sorted into topic groups!
  
  (The chaos had bugged me for a long time.)

This is the new look:
```
$  agda --help                                                                                      ✔ │ 21:24:34 
Agda version 2.9.0

Usage: agda [OPTIONS...] [FILE]

Setup and basic information:

  -V              --version                        print version information
                  --numeric-version                print version number
  -?[HELP_TOPIC]  --help[=HELP_TOPIC]              print help; available HELP_TOPICs: warning, error, emacs-mode
                  --emacs-mode=EMACS_MODE_COMMAND  administer the Emacs Agda mode; available EMACS_MODE_COMMANDs: setup, compile, locate; confer --help=emacs-mode
                  --print-agda-dir                 print the Agda data directory
                  --print-agda-app-dir             print $AGDA_DIR
                  --print-agda-data-dir            print the Agda data directory
                  --print-options                  print the full list of Agda's options
                  --setup                          setup the Agda data directory

Main modes of operation:

      --build-library                       build all modules included by the @.agda-lib@ file in the current directory
  -I  --interactive                         start in interactive mode
      --interaction                         for use with the Emacs mode
      --interaction-json                    for use with other editors such as Atom

Project configuration:

  -i DIR  --include-path=DIR                look for imports in DIR
  -l LIB  --library=LIB                     use library LIB
          --library-file=FILE               use FILE instead of the standard libraries file
          --no-libraries                    don't use any library files
          --no-default-libraries            don't use default libraries

Essential type checker configuration:

    --ignore-interfaces                     ignore interface files (re-type check everything)
    --only-scope-checking                   only scope-check the top-level module, do not type-check it
    --interaction-exit-on-error             exit if a type error is encountered
    --vim                                   generate Vim highlighting files

Diagnostics and output:

    --colour[=always|auto|never], --color[=always|auto|never]  whether or not to colour diagnostics output. The default is auto.
    --trace-imports[=IMPORT_TRACING_LEVEL]                     print information about accessed modules during type-checking (where IMPORT_TRACING_LEVEL=0|1|2|3, default: 2)
    --transliterate                                            transliterate unsupported code points when printing to stdout/stderr
    --unicode                                                  use unicode characters when printing terms (default)
    --no-unicode                                               do not use unicode characters when printing terms

Warnings:

  -W WARNING  --warning=WARNING             set warning flags. See --help=warning.

Consistency checking:

    --allow-unsolved-metas                  succeed and create interface file regardless of unsolved meta variables
    --no-allow-unsolved-metas               do not succeed and create interface file regardless of unsolved meta variables (default)
    --allow-incomplete-matches              succeed and create interface file regardless of incomplete pattern matches
    --no-allow-incomplete-matches           do not succeed and create interface file regardless of incomplete pattern matches (default)
    --positivity-check                      warn about not strictly positive data types (default)
    --no-positivity-check                   do not warn about not strictly positive data types
    --termination-check                     warn about possibly nonterminating code (default)
    --no-termination-check                  do not warn about possibly nonterminating code
    --termination-depth=N                   allow termination checker to count decrease/increase upto N (default N=1)
    --safe                                  disable postulates, unsafe OPTION pragmas and primEraseEquality, implies --no-sized-types
    --allow-exec                            allow system calls to trusted executables with primExec
    --no-allow-exec                         do not allow system calls to trusted executables with primExec (default)

Language variant:

    --without-K                             turn on checks to make code compatible with HoTT (e.g. disabling the K rule). Implies --no-flat-split.
    --cubical-compatible                    turn on generation of auxiliary code required for --cubical, implies --without-K
    --erased-cubical                        enable cubical features (some only in erased settings), implies --cubical-compatible
    --cubical                               enable cubical features (e.g. overloads lambdas for paths), implies --cubical-compatible
    --with-K                                enable the K rule in pattern matching (default)

Universes:

    --type-in-type                          ignore universe levels (this makes Agda inconsistent) (default)
    --no-type-in-type                       do not ignore universe levels
    --omega-in-omega                        enable typing rule Setω : Setω (this makes Agda inconsistent)
    --no-omega-in-omega                     do not enable typing rule Setω : Setω (default)
    --cumulativity                          enable subtyping of universes (e.g. Set =< Set₁)
    --no-cumulativity                       disable subtyping of universes (default)
    --prop                                  enable the use of the Prop universe
    --no-prop                               disable the use of the Prop universe (default)
    --level-universe                        place type Level in a dedicated LevelUniv universe
    --no-level-universe                     do not place type Level in a dedicated LevelUniv universe (default)
    --two-level                             enable the use of SSet* universes
    --no-two-level                          do not enable the use of SSet* universes (default)
    --universe-polymorphism                 enable universe polymorphism (default)
    --no-universe-polymorphism              disable universe polymorphism
    --large-indices                         allow constructors with large indices
    --no-large-indices                      always check that constructor arguments live in universes compatible with that of the datatype (default)
    --import-sorts                          implicitly import Agda.Primitive using (Set; Prop) at the start of each top-level module (default)
    --no-import-sorts                       disable the implicit import of Agda.Primitive using (Set; Prop) at the start of each top-level module
    --load-primitives                       load primitives modules (default)
    --no-load-primitives                    disable loading of primitive modules completely (implies --no-import-sorts)

Modalities:

    --erasure                               enable erasure
    --no-erasure                            do not enable erasure (default)
    --erased-matches                        allow matching in erased positions for single-constructor types (implies --erasure if supplied explicitly) (default)
    --no-erased-matches                     do not allow matching in erased positions for single-constructor types
    --erase-record-parameters               mark all parameters of record modules as erased (implies --erasure)
    --no-erase-record-parameters            do not mark all parameters of record modules as erased (default)
    --cohesion                              enable the cohesion modalities (in particular @flat)
    --no-cohesion                           do not enable the cohesion modalities (default)
    --flat-split                            allow splitting on `(@flat x : A)' arguments (implies --cohesion)
    --no-flat-split                         do not allow splitting on `(@flat x : A)' arguments (default)
    --guarded                               enable @lock/@tick attributes
    --no-guarded                            disable @lock/@tick attributes (default)
    --polarity                              enable the polarity modalities (@++, @mixed, etc.) and their integration in the positivity checker
    --no-polarity                           do not enable the polarity modalities (@++, @mixed, etc.) and their integration in the positivity checker (default)
    --irrelevant-projections                enable projection of irrelevant record fields and similar irrelevant definitions (inconsistent)
    --no-irrelevant-projections             disable projection of irrelevant record fields and similar irrelevant definitions (default)
    --experimental-irrelevance              enable potentially unsound irrelevance features (irrelevant levels, irrelevant data matching)
    --no-experimental-irrelevance           do not enable potentially unsound irrelevance features (default)

Termination and productivity checking:

    --sized-types                           enable sized types (inconsistent with --guardedness)
    --no-sized-types                        disable sized types (default)
    --guardedness                           enable constructor-based guarded corecursion (inconsistent with --sized-types)
    --no-guardedness                        disable constructor-based guarded corecursion (default)
    --forced-argument-recursion             allow recursion on forced constructor arguments (default)
    --no-forced-argument-recursion          do not allow recursion on forced constructor arguments

Pattern matching:

    --pattern-matching                      enable pattern matching (default)
    --no-pattern-matching                   disable pattern matching completely
    --copatterns                            enable definitions by copattern matching (default)
    --no-copatterns                         disable definitions by copattern matching
    --exact-split                           require all clauses in a definition to hold as definitional equalities (unless marked CATCHALL)
    --no-exact-split                        do not require all clauses in a definition to hold as definitional equalities (default)
    --hidden-argument-puns                  interpret the patterns {x} and {{x}} as puns
    --no-hidden-argument-puns               do not interpret the patterns {x} and {{x}} as puns (default)
    --injective-type-constructors           enable injective type constructors (makes Agda anti-classical and possibly inconsistent)
    --no-injective-type-constructors        disable injective type constructors (default)
    --inversion-max-depth=N                 set maximum depth for pattern match inversion to N (default: 50)

Instance search:

    --instance-search-depth=N               set instance search depth to N (default: 500)
    --backtracking-instance-search          allow backtracking during instance search
    --no-backtracking-instance-search       do not allow backtracking during instance search (default)
    --qualified-instances                   use instances with qualified names (default)
    --no-qualified-instances                do not use instances with qualified names
    --experimental-lazy-instances           enable experimental, faster implementation of instance search
    --no-experimental-lazy-instances        do not enable experimental, faster implementation of instance search (default)

Rewriting and confluence:

    --rewriting                             enable declaration and use of REWRITE rules
    --no-rewriting                          disable declaration and use of REWRITE rules (default)
    --local-confluence-check                enable checking of local confluence of REWRITE rules
    --confluence-check                      enable global confluence checking of REWRITE rules (more restrictive than --local-confluence-check)
    --no-confluence-check                   disable confluence checking of REWRITE rules (default)

Definitional equality:

    --eta-equality                          default records to eta-equality (default)
    --no-eta-equality                       default records to no-eta-equality
    --lossy-unification                     enable heuristically unifying `f es = f es'` by unifying `es = es'` even when it could lose solutions
    --no-lossy-unification                  do not enable heuristically unifying `f es = f es'` by unifying `es = es'` (default)
    --require-unique-meta-solutions         require unique solutions to meta variables even when it could lose solutions (default)
    --no-require-unique-meta-solutions      do not require unique solutions to meta variables
    --no-syntactic-equality                 disable the syntactic equality shortcut in the conversion checker
    --syntactic-equality[=FUEL]             give the syntactic equality shortcut FUEL units of fuel (default: unlimited)
    --auto-inline                           enable automatic compile-time inlining
    --no-auto-inline                        disable automatic compile-time inlining, only definitions marked INLINE will be inlined (default)
    --fast-reduce                           enable reduction using the Agda Abstract Machine (default)
    --no-fast-reduce                        disable reduction using the Agda Abstract Machine
    --call-by-name                          use call-by-name evaluation instead of call-by-need
    --no-call-by-name                       use call-by-need evaluation (default)

Type checker optimizations:

    --caching                               enable caching of typechecking (default)
    --no-caching                            disable caching of typechecking
    --double-check                          enable double-checking of all terms using the internal typechecker
    --no-double-check                       disable double-checking of terms (default)
    --forcing                               enable the forcing analysis for data constructors (optimisation) (default)
    --no-forcing                            disable the forcing analysis
    --projection-like                       enable the analysis whether function signatures liken those of projections (optimisation) (default)
    --no-projection-like                    disable the projection-like analysis
    --infer-absurd-clauses                  eliminate absurd clauses in case splitting and coverage checking (default)
    --no-infer-absurd-clauses               do not automatically eliminate absurd clauses in case splitting and coverage checking (can speed up type-checking)
    --save-metas                            save meta-variables
    --no-save-metas                         do not save meta-variables (default)

Checker output:

    --show-implicit                         show implicit arguments when printing
    --no-show-implicit                      do not show implicit arguments when printing (default)
    --show-irrelevant                       show irrelevant arguments when printing
    --no-show-irrelevant                    do not show irrelevant arguments when printing (default)
    --show-identity-substitutions           show all arguments of metavariables when printing terms
    --no-show-identity-substitutions        do not show all arguments of metavariables when printing terms (default)
    --print-pattern-synonyms                keep pattern synonyms when printing terms (default)
    --no-print-pattern-synonyms             expand pattern synonyms when printing terms
    --postfix-projections                   prefer postfix projection notation (default)
    --no-postfix-projections                prefer prefix projection notation
    --keep-pattern-variables                don't replace variables with dot patterns during case splitting (default)
    --no-keep-pattern-variables             replace variables with dot patterns during case splitting

Backend options:

    --count-clusters                        count extended grapheme clusters when generating LaTeX (note that this flag is not enabled in all builds of Agda)
    --no-count-clusters                     do not count extended grapheme clusters when generating LaTeX (default)
    --keep-covering-clauses                 do not discard covering clauses (required for some external backends)
    --no-keep-covering-clauses              discard covering clauses (default)

Compilation options:

    --compile-dir=DIR                       directory for compiler output (default: the project root)
    --main                                  treat the requested module as the main module of a program when compiling (default)
    --no-main                               do not treat the requested module as the main module of a program when compiling

Debugging and profiling Agda:

  -v N  --verbose=N                         set verbosity level to N. Only has an effect if Agda was built with the "debug" flag.
        --profile=TO_PROFILE                turn on profiling for TO_PROFILE (where TO_PROFILE=all|internal|modules|definitions|sharing|serialize|constraints|metas|interactive|conversion|instances|sections)

GHC backend options:

  -c  --compile, --ghc                      compile program using the GHC backend
      --ghc-dont-call-ghc                   don't call GHC, just write the GHC Haskell files.
      --ghc-flag=GHC-FLAG                   give the flag GHC-FLAG to GHC
      --with-compiler=PATH                  use the compiler available at PATH
      --ghc-strict-data                     make inductive constructors strict
      --ghc-strict                          make functions strict
      --ghc-trace                           instrument code to debug print trace of function calls

JS backend options:

    --js                                    compile program using the JS backend
    --js-optimize                           turn on optimizations during JS code generation
    --js-minify                             minify generated JS code
    --js-verify                             except for main module, run generated JS modules through `node` (needs to be in PATH)
    --js-es6                                use ES6 module style for JS
    --js-cjs                                use CommonJS module style (default)
    --js-amd                                use AMD module style for JS

Dot backend options:

    --dependency-graph=FILE                 generate a Dot file with a module dependency graph
    --dependency-graph-include=LIBRARY      include modules from the given library (default: all modules)

HTML backend options:

    --html                                  generate HTML files with highlighted source code
    --html-dir=DIR                          directory in which HTML files are placed (default: html)
    --highlight-occurrences                 highlight all occurrences of hovered symbol in generated HTML files
    --css=URL                               the CSS file used by the HTML files (can be relative)
    --html-highlight=[code,all,auto]        whether to highlight only the code parts (code) or the file as a whole (all) or decide by source file type (auto)

LaTeX backend options:

    --latex                                 generate LaTeX with highlighted source code
    --latex-dir=DIR                         directory in which LaTeX files are placed (default: latex)
```
  