### PR TITLE
Cosmetical changes around meta-variables

### DIFF
--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -1329,7 +1329,7 @@ assignMeta' m x t n ids v = do
 
     -- Perform the assignment (and wake constraints).
 
-    let vsol = abstract tel' v'
+    v' <- blockOnBoundary telv bs v'
 
     -- Andreas, 2013-10-25 double check solution before assigning
     whenM (optDoubleCheck  <$> pragmaOptions) $ do
@@ -1339,9 +1339,7 @@ assignMeta' m x t n ids v = do
         addContext tel' $ checkSolutionForMeta x m v' a
 
     reportSDoc "tc.meta.assign" 10 $
-      "solving" <+> prettyTCM x <+> ":=" <+> prettyTCM vsol
-
-    v' <- blockOnBoundary telv bs v'
+      "solving" <+> prettyTCM x <+> ":=" <+> prettyTCM (abstract tel' v')
 
     assignTerm x (telToArgs tel') v'
   where

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -229,7 +229,7 @@ checkDecl d = setCurrentRange d $ do
           A.Generalize{} -> pure ()
           _ -> do
             reportSLn "tc.decl" 20 $ "Freezing all open metas."
-            void $ freezeMetas (openMetas metas)
+            void $ freezeMetas $ MapS.keys $ openMetas metas
 
         theMutualChecks
 
@@ -542,11 +542,12 @@ whenAbstractFreezeMetasAfter Info.DefInfo{defAccess, defAbstract, defOpaque} m =
     reportSLn "tc.decl" 20 $ "Attempting to solve constraints before freezing."
     locallyTCState stInstanceHack (const True) $
       wakeupConstraints_   -- solve emptiness and instance constraints
-    xs <- freezeMetas (openMetas ms)
+    let oms = MapS.keys $ openMetas ms
+    xs <- freezeMetas oms
 
     reportSDoc "tc.decl.ax" 20 $ vcat
       [ "Abstract type signature produced new open metas: " <+>
-        sep (map prettyTCM $ MapS.keys (openMetas ms))
+        sep (map prettyTCM oms)
       , "We froze the following ones of these:            " <+>
         sep (map prettyTCM $ Set.toList xs)
       ]

--- a/src/full/Agda/Utils/Maybe.hs
+++ b/src/full/Agda/Utils/Maybe.hs
@@ -131,3 +131,9 @@ spanMaybe _ [] = ([], [])
 spanMaybe p xs@(x:xs') = case p x of
     Just y  -> let (ys, zs) = spanMaybe p xs' in (y : ys, zs)
     Nothing -> ([], xs)
+
+-- * MaybeT
+
+-- | Run a 'MaybeT' with a default value for 'Nothing'.
+fromMaybeT :: Monad m => a -> MaybeT m a -> m a
+fromMaybeT a m = fromMaybe a <$> runMaybeT m


### PR DESCRIPTION
- **[refactor] generalize freezeMetas to Traversable MetaId collection**
  The use of `LocalMetaStore` both for the `stOpenMetaStore` and the
  collection `ms` of metas to freeze confused me, so I generalized the
  function to take any collection `ms` of `MetaId`s.
  
  Being more robust, it is also more applicable, as we do not need to
  pass a `LocalMetaStore` but just the ids of the metas we want to
  freeze.  From that store we anyway just used the `keys` list.
  
  (It just happened that these metas were always organized as
  `LocalMetaStore` when we wanted to call `freezeMetas`,
  so may that explains that we made `freezeMetas` take `LocalMetaStore`.
  But it passes in **too much** information and is thus not a good fit.)
  

- **Cosmetics: factor out `unfreeze_`**
  

- **Cosmetics: optimize away a List.filter in noConstraints'**
  

- **[new] Agda.Utils.Maybe.fromMaybeT**
  

- **MetaVars.assign: blockOnBoundary before invoking double-checker**
  I'd think that the double checker should run on the final result or am
  I mistaken?
  