### PR TITLE
fixup: caching with copy trimming

### DIFF
--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -916,6 +916,11 @@ instance ToAbstract C.Expr where
         scope <- getScope
         -- Andreas, 2014-04-06 create interaction point.
         ii <- registerInteractionPoint True r n
+
+        -- Mark all copies we can see from here as having all of their
+        -- names live.
+        clobberLiveNames
+
         let info = MetaInfo
              { metaRange  = r
              , metaScope  = scope


### PR DESCRIPTION
The validity of a `LoadedFileCache` that contains `Apply` declarations (i.e. module copies) that were subject to copy trimming does not (only) depend on the syntax trees being the same, because at the point we produce the syntax tree for the module application in the scope checker, we can't know all the names that will be used. It's therefore important that we also compare the out-of-band information of what names were live when deciding to reuse a log that contains a module application.

If we wrongfully reuse the state after an `Apply` decl that should have had its trimming modified by subsequent declarations, we would run into panics, e.g.

```agda
module W (_ : Set₁) where
  postulate A B C : Set
open W Set
_ = A
-- load, then add:
_ = B
```

Ironically using `IORef`s in #8038 prevented this from happening, but that's only because it broke caching completely (the scope checker was creating new `IORef`s, so two `Apply`s coming from different runs of the scope checker would never compare `==`). This patch restores caching *and* introduces the correct behaviour for comparing `Apply`s, which would still be necessary even if we switch away from using `IORef`s in the future.