### PR TITLE
Add tests from #7597

### DIFF
--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -266,6 +266,8 @@ agdaRunProgGoldenTest dir comp extraArgs inp opts =
             JS{} -> do
               env <- (("NODE_PATH", compDir) :) <$> getEnvironment
               (ret, out', err') <- readProcessWithEnv env Nothing "node" [exec] inp'
+              out' <- cleanOutput out'
+              err' <- cleanOutput err'
               return $ ExecutedProg $ ProgramResult ret (out <> out') (err <> err')
             _ -> do
               (ret, out', err') <- PT.readProcessWithExitCode exec (runtimeOptions opts) inp'

--- a/test/Compiler/simple/Issue7532-ghc.agda
+++ b/test/Compiler/simple/Issue7532-ghc.agda
@@ -1,0 +1,16 @@
+
+-- Minimal code demonstrating erasure bug in JS backend
+
+module Issue7532-ghc where
+
+open import Common.IO
+
+open import Agda.Builtin.String
+
+go : (F : Set → Set)(f : Set → String) → String
+go F f = f (F String)
+
+hello : String
+hello = go (λ A → A) (λ A → "hello world")
+
+main = putStr hello

--- a/test/Compiler/simple/Issue7532-ghc.options
+++ b/test/Compiler/simple/Issue7532-ghc.options
@@ -1,0 +1,9 @@
+TestOptions
+  { forCompilers =
+      [ (MAlonzo Lazy,       CompilerOptions {extraAgdaArgs = []})
+      , (MAlonzo StrictData, CompilerOptions {extraAgdaArgs = []})
+      , (MAlonzo Strict,     CompilerOptions {extraAgdaArgs = []})
+      ]
+  , runtimeOptions = []
+  , executeProg = True
+  }

--- a/test/Compiler/simple/Issue7532-ghc.out
+++ b/test/Compiler/simple/Issue7532-ghc.out
@@ -1,0 +1,4 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > hello world

--- a/test/Compiler/simple/Issue7532-js.agda
+++ b/test/Compiler/simple/Issue7532-js.agda
@@ -1,0 +1,16 @@
+
+-- Minimal code demonstrating erasure bug in JS backend
+
+module Issue7532-js where
+
+open import Common.IO
+
+open import Agda.Builtin.String
+
+go : (F : Set → Set)(f : Set → String) → String
+go F f = f (F String)
+
+hello : String
+hello = go (λ A → A) (λ A → "hello world")
+
+main = putStr hello

--- a/test/Compiler/simple/Issue7532-js.options
+++ b/test/Compiler/simple/Issue7532-js.options
@@ -1,0 +1,7 @@
+TestOptions
+  { forCompilers =
+      [ (JS ES6 NonOptimized, CompilerOptions {extraAgdaArgs = []})
+      ]
+  , runtimeOptions = []
+  , executeProg = True
+  }

--- a/test/Compiler/simple/Issue7532-js.out
+++ b/test/Compiler/simple/Issue7532-js.out
@@ -1,0 +1,16 @@
+EXECUTED_PROGRAM
+
+ret > ExitFailure 1
+err > file:///jAgda.Issue7532-js.mjs:9
+err > exports["go"] = a => b => b(a(null));
+err >                             ^
+err >
+err > TypeError: a is not a function
+err >     at file:///jAgda.Issue7532-js.mjs:9:29
+err >     at file:///jAgda.Issue7532-js.mjs:10:39
+err >     at «NodeJS internals»
+err >     at «NodeJS internals»
+err >     at «NodeJS internals»
+err >
+err > Node.js «NodeJS version»
+err >

--- a/test/Compiler/simple/Issue7532-obfuscated-ghc.agda
+++ b/test/Compiler/simple/Issue7532-obfuscated-ghc.agda
@@ -1,0 +1,20 @@
+
+-- Code demonstrating erasure bug in JS backend,
+-- resistant to naive patches of Agda's earser (e.g. #7597)
+
+module Issue7532-obfuscated-ghc where
+
+open import Common.IO
+
+open import Agda.Builtin.String
+
+go : (F : Set → Set)(f : Set → String) → String
+go F f = f (F String)
+
+Id : Set → Set
+Id A = A
+
+hello : String
+hello = go Id (λ A → "hello world")
+
+main = putStr hello

--- a/test/Compiler/simple/Issue7532-obfuscated-ghc.options
+++ b/test/Compiler/simple/Issue7532-obfuscated-ghc.options
@@ -1,0 +1,9 @@
+TestOptions
+  { forCompilers =
+      [ (MAlonzo Lazy,       CompilerOptions {extraAgdaArgs = []})
+      , (MAlonzo StrictData, CompilerOptions {extraAgdaArgs = []})
+      , (MAlonzo Strict,     CompilerOptions {extraAgdaArgs = []})
+      ]
+  , runtimeOptions = []
+  , executeProg = True
+  }

--- a/test/Compiler/simple/Issue7532-obfuscated-ghc.out
+++ b/test/Compiler/simple/Issue7532-obfuscated-ghc.out
@@ -1,0 +1,4 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > hello world

--- a/test/Compiler/simple/Issue7532-obfuscated-js.agda
+++ b/test/Compiler/simple/Issue7532-obfuscated-js.agda
@@ -1,0 +1,20 @@
+
+-- Code demonstrating erasure bug in JS backend,
+-- resistant to naive patches of Agda's earser (e.g. #7597)
+
+module Issue7532-obfuscated-js where
+
+open import Common.IO
+
+open import Agda.Builtin.String
+
+go : (F : Set → Set)(f : Set → String) → String
+go F f = f (F String)
+
+Id : Set → Set
+Id A = A
+
+hello : String
+hello = go Id (λ A → "hello world")
+
+main = putStr hello

--- a/test/Compiler/simple/Issue7532-obfuscated-js.options
+++ b/test/Compiler/simple/Issue7532-obfuscated-js.options
@@ -1,0 +1,7 @@
+TestOptions
+  { forCompilers =
+      [ (JS ES6 NonOptimized, CompilerOptions {extraAgdaArgs = []})
+      ]
+  , runtimeOptions = []
+  , executeProg = True
+  }

--- a/test/Compiler/simple/Issue7532-obfuscated-js.out
+++ b/test/Compiler/simple/Issue7532-obfuscated-js.out
@@ -1,0 +1,16 @@
+EXECUTED_PROGRAM
+
+ret > ExitFailure 1
+err > file:///jAgda.Issue7532-obfuscated-js.mjs:9
+err > exports["go"] = a => b => b(a(null));
+err >                             ^
+err >
+err > TypeError: a is not a function
+err >     at file:///jAgda.Issue7532-obfuscated-js.mjs:9:29
+err >     at file:///jAgda.Issue7532-obfuscated-js.mjs:10:39
+err >     at «NodeJS internals»
+err >     at «NodeJS internals»
+err >     at «NodeJS internals»
+err >
+err > Node.js «NodeJS version»
+err >

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -323,6 +323,9 @@ cleanOutput' agda pwd t = foldl (\ t' (rgx, n) -> replace rgx n t') t rgxs
       , (T.pack pwd `T.append` ".test", "..")
       , ("/[^ ]*/MAlonzo/Code/", "«path»/MAlonzo/Code/")
       , ("\\.hs(:[[:digit:]]+){2}", ".hs:«line»:«col»")
+      -- Strip NodeJS stack trace & version
+      , ("at .+[(]node:internal[^)]+[)]", "at «NodeJS internals»")
+      , ("Node[.]js v[0-9.]+", "Node.js «NodeJS version»")
       , (T.pack Agda.Version.package, "«Agda-package»")
       -- Andreas, 2021-08-26.  When run with 'cabal test',
       -- Agda.Version.package didn't match, so let's be generous:


### PR DESCRIPTION
This PR adds the tests from #7597, without the (broken) attempted fix.

<details>

<summary> Benchmarks </summary>

```console
~/oss/agda/add-bugs$ powerprofilesctl set performance
~/oss/agda/add-bugs$ agda-tests -p 7532
Using JS node binary at /nix/store/a1kxazxkgw7mjbjgisvah95p1r3n5ykl-nodejs-22.16.0/bin/node
all
  Compiler
    MAlonzo_Lazy
      simple
        Issue7532-ghc:            OK (0.96s)
        Issue7532-obfuscated-ghc: OK (0.95s)
    MAlonzo_StrictData
      simple
        Issue7532-ghc:            OK (0.95s)
        Issue7532-obfuscated-ghc: OK (0.95s)
    MAlonzo_Strict
      simple
        Issue7532-ghc:            OK (0.96s)
        Issue7532-obfuscated-ghc: OK (0.96s)
    JS_ES6_NonOptimized
      simple
        Issue7532-obfuscated-js:  OK (0.71s)
        Issue7532-js:             OK (0.71s)

All 8 tests passed (7.16s)
~/oss/agda/add-bugs$ powerprofilesctl set power-saver
~/oss/agda/add-bugs$ agda-tests -p 7532
Using JS node binary at /nix/store/a1kxazxkgw7mjbjgisvah95p1r3n5ykl-nodejs-22.16.0/bin/node
all
  Compiler
    MAlonzo_Lazy
      simple
        Issue7532-ghc:            OK (2.90s)
        Issue7532-obfuscated-ghc: OK (2.89s)
    MAlonzo_StrictData
      simple
        Issue7532-ghc:            OK (2.89s)
        Issue7532-obfuscated-ghc: OK (2.95s)
    MAlonzo_Strict
      simple
        Issue7532-ghc:            OK (3.03s)
        Issue7532-obfuscated-ghc: OK (3.00s)
    JS_ES6_NonOptimized
      simple
        Issue7532-obfuscated-js:  OK (2.00s)
        Issue7532-js:             OK (2.01s)

All 8 tests passed (21.65s)
~/oss/agda/add-bugs$ 
```

</details>