### PR TITLE
globally cache small Term variables

### DIFF
--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -18,6 +18,7 @@ import Control.DeepSeq
 import qualified Data.List as List
 import Data.Maybe
 import Data.Semigroup ( Sum(..) )
+import System.IO.Unsafe (unsafePerformIO)
 
 import GHC.Generics (Generic)
 
@@ -43,6 +44,8 @@ import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.Null
 import Agda.Utils.Size
+import qualified Agda.Utils.CompactRegion as Compact
+import qualified Agda.Utils.MinimalArray.Lifted as AL
 
 import Agda.Utils.Impossible
 
@@ -218,7 +221,7 @@ instance LensConName ConHead where
 --     every constant, even if the definition is an empty
 --     list of clauses.
 --
-data Term = Var {-# UNPACK #-} !Int Elims -- ^ @x es@ neutral
+data Term = Var' {-# UNPACK #-} !Int Elims -- ^ @x es@ neutral
           | Lam ArgInfo (Abs Term)        -- ^ Terms are beta normal. Relevance is ignored
           | Lit Literal
           | Def QName Elims               -- ^ @f es@, possibly a delta/iota-redex
@@ -245,6 +248,39 @@ data Term = Var {-# UNPACK #-} !Int Elims -- ^ @x es@ neutral
             --   eliminators, which are only there to ease debugging when a dummy term incorrectly
             --   leaks into a relevant position.
   deriving Show
+
+-- Caching small variables
+--------------------------------------------------------------------------------
+
+{-# NOINLINE varTable #-}
+varTable :: AL.Array Term
+varTable = unsafePerformIO $ do
+  !c <- Compact.new 4096
+  let !tbl = AL.fromList [Var' i [] | i <- [0..(varTableSize - 1)]]
+  Compact.add c tbl
+
+pattern Var :: Int -> Elims -> Term
+pattern Var i es <- Var' i es where
+  Var i es = case es of
+    [] -> case i < varTableSize of
+      True -> AL.unsafeIndex varTable i
+      _    -> Var' i es
+    _  -> Var' i es
+{-# INLINE Var #-}
+{-# COMPLETE Var, Lam, Lit, Def, Con, Pi, Sort, Level, MetaV, DontCare, Dummy #-}
+
+{-# INLINE varTableSize #-}
+varTableSize :: Int
+varTableSize = 128
+
+-- | An unapplied variable.
+var :: Nat -> Term
+var i | i >= 0 = case i < varTableSize of
+          True -> AL.unsafeIndex varTable i
+          _    -> Var' i []
+      | otherwise = __IMPOSSIBLE__
+
+--------------------------------------------------------------------------------
 
 type ConInfo = ConOrigin
 
@@ -818,11 +854,6 @@ isAbsurdPatternName x = x == absurdPatternName
 ---------------------------------------------------------------------------
 -- * Smart constructors
 ---------------------------------------------------------------------------
-
--- | An unapplied variable.
-var :: Nat -> Term
-var i | i >= 0    = Var i []
-      | otherwise = __IMPOSSIBLE__
 
 -- | Add 'DontCare' is it is not already a @DontCare@.
 dontCare :: Term -> Term

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -51,10 +51,9 @@ import GHC.Exts
 import GHC.Stack
 import GHC.Fingerprint.Type
 import Unsafe.Coerce
-import System.IO.Unsafe
 
 import Agda.Syntax.Common (NameId)
-import Agda.Syntax.Internal (QName(..), ModuleName(..), nameId, Term(..))
+import Agda.Syntax.Internal (QName(..), ModuleName(..), nameId, Term(..), varTable, varTableSize)
 import Agda.TypeChecking.Monad.Base.Types (ModuleToSource)
 import Agda.TypeChecking.Serialise.Node
 
@@ -76,20 +75,9 @@ import qualified Agda.Utils.CompactRegion as Compact
 -- Caching Var-s
 --------------------------------------------------------------------------------
 
-{-# INLINE varTableSize #-}
-varTableSize :: Int
-varTableSize = 128
-
 {-# INLINE varRangeStart #-}
 varRangeStart :: Word32
 varRangeStart = maxBound - fromIntegral varTableSize
-
-{-# NOINLINE varTable #-}
-varTable :: AL.Array Term
-varTable = unsafePerformIO $ do
-  !c   <- Compact.new 4096
-  let !tbl = AL.fromList [Var i [] | i <- [0..(varTableSize - 1)]]
-  Compact.add c tbl
 
 {-# INLINE cacheVar #-}
 cacheVar :: Int -> Maybe Word32


### PR DESCRIPTION
Store `Var i []` for `i < 128` statically. In a72399c04ef9701e8713062fef20e240e4c5cd03, small variables are only cached on deserialization, now they are cached pretty much everywhere, by turning the original `Var` constructor into a pattern synonym which potentially looks up from the cache. This mildly decreases total memory usage for the `std-lib-test`, decreases total allocations from 612 GB to 606 GB and leaves runtime roughly the same. 

Here's a small sample of `std-lib-test` total memory usages:

- On commit b95a2ca4de00f5a7c35b7edc4e0183970b68f999, before serialization changes:
  - Runs (MB): 2960, 3000, 2966, 2949, 3151, 2946
  - Max: 3151
  - Average: 2995.34
- On commit a72399c04ef9701e8713062fef20e240e4c5cd03, after serialization changes:
   - Runs (MB): 3235, 3132, 3118, 3142, 2794, 3119
   - Max: 3235
   - Average: 3090
- On this PR:
   - Runs (MB): 3083, 2771, 2985, 2677, 3105, 2742
   - Max: 3105
   - Average: 2894