### PR TITLE
Inverse scope optimization

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -917,6 +917,8 @@ library
       Agda.Utils.Singleton
       Agda.Utils.Size
       Agda.Utils.SmallSet
+      Agda.Utils.StrictState
+      Agda.Utils.StrictState2
       Agda.Utils.String
       Agda.Utils.Suffix
       Agda.Utils.Three

--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -110,8 +110,11 @@ data Phase
     -- ^ Subphase for 'InstanceSearch': reducing overlapping instances
   | UnifyIndices
     -- ^ Subphase for 'CheckLHS': unification of the indices
-  | InverseScopeLookup
-    -- ^ Pretty printing names.
+  | InverseNameLookup
+  | InverseModuleLookup
+  | InverseInScope
+  | InverseNameModuleRecompute
+  | InverseInScopeRecompute
   | TopModule TopLevelModuleName
   | Typeclass QName
   | Definition QName

--- a/src/full/Agda/Compiler/Common.hs
+++ b/src/full/Agda/Compiler/Common.hs
@@ -166,7 +166,10 @@ inCompilerEnv checkResult cont = do
     when (any ("--erased-cubical" `elem`) $ iFilePragmaStrings mainI) $
       setTCLens (stPragmaOptions . lensOptCubical) $ Just CErased
 
-    setScope (iInsideScope mainI) -- so that compiler errors don't use overly qualified names
+    setScope $ iInsideScope mainI -- so that compiler errors don't use overly qualified names
+    -- András, 2025-08-30: this is a fresh creation of a scope from an interface
+    -- so inverse scopes don't yet exist.
+    recomputeInverseScope
     ignoreAbstractMode cont
   -- keep generated warnings
   let newWarnings = stPostTCWarnings $  stPostScopeState $ s

--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -1359,7 +1359,9 @@ atTopLevel m = inConcreteMode $ do
         , "  types = " TP.<+> TP.sep (map prettyTCM types)
         ]
       M.withCurrentModule current $
-        withScope_ scope $
+        evalWithScope scope $ do
+          -- András, 2025-08-30: building fresh scope from interface
+          recomputeInverseScope
           addContext gamma $ do
             -- We're going inside the top-level module, so we have to set the
             -- checkpoints for it and all its submodules to the new checkpoint.

--- a/src/full/Agda/Interaction/CommandLine.hs
+++ b/src/full/Agda/Interaction/CommandLine.hs
@@ -135,7 +135,11 @@ interactionLoop = do
     where
         reload :: ReplM () = do
             checked <- checkCurrentFile
-            liftTCM $ setScope $ maybe emptyScopeInfo (iInsideScope . crInterface) checked
+            liftTCM $ do
+              case checked of
+                Nothing    -> setScope emptyScopeInfo
+                Just scope -> do setScope (iInsideScope $ crInterface scope)
+                                 recomputeInverseScope
             -- Andreas, 2021-01-27, issue #5132, make Set and Prop available from Agda.Primitive
             -- if no module is loaded.
             when (isNothing checked) $ do

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -1246,7 +1246,7 @@ createInterface mname sf@(SourceFile sfi) isMain msrc = do
 
       whenM (optGenerateVimFile <$> commandLineOptions) $
         -- Generate Vim file.
-        withScope_ scope $ generateVimFile $ filePath $ srcPath
+        evalWithScope scope $ generateVimFile $ filePath $ srcPath
     reportSLn "import.iface.create" 15 $ prettyShow mname ++ ": Finished highlighting from type info."
 
     setScope scope

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -75,7 +75,7 @@ data QNamed a = QNamed
 -- The 'SetRange' instance for module names sets all individual ranges
 -- to the given one.
 newtype ModuleName = MName { mnameToList :: [Name] }
-  deriving (Eq, Ord, NFData, Null)
+  deriving (Eq, Ord, NFData, Null, Hashable)
 
 -- | Ambiguous qualified names. Used for overloaded constructors.
 --

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -40,6 +40,7 @@ import Agda.Syntax.Position
 import Agda.Syntax.Internal hiding (DataOrRecord)
 import Agda.Syntax.Internal.Pattern
 import Agda.Syntax.Translation.InternalToAbstract (NamedClause(..))
+import Agda.Syntax.Scope.Base (ScopeInfo(..))
 
 import Agda.TypeChecking.Primitive hiding (Nat)
 import Agda.TypeChecking.Monad

--- a/src/full/Agda/TypeChecking/Monad/Closure.hs
+++ b/src/full/Agda/TypeChecking/Monad/Closure.hs
@@ -15,7 +15,7 @@ enterClosure :: (MonadTCEnv m, ReadTCState m, LensClosure c a)
              => c -> (a -> m b) -> m b
 enterClosure c k | Closure _sig env scope cps x <- c ^. lensClosure = do
   isDbg <- viewTC eIsDebugPrinting
-  withScope_ scope
+  evalWithScope scope
     $ locallyTCState stModuleCheckpoints (const cps)
     $ withEnv env{ envIsDebugPrinting = isDbg }
     $ k x

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -358,7 +358,7 @@ checkConstructor d uc tel nofIxs s con@(A.Axiom _ i ai Nothing c e) =
   where
     -- Issue 3362: we need to do the `constructs` call inside the
     -- generalization, so unpack the A.Generalize
-    checkConstructorType (A.ScopedExpr s e) d = withScope_ s $ checkConstructorType e d
+    checkConstructorType (A.ScopedExpr s e) d = evalWithScope s $ checkConstructorType e d
     checkConstructorType e d = do
       let check k e = do
             t <- workOnTypes $ isType_ e

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1721,9 +1721,9 @@ checkNamedArg arg@(Arg info e0) t0 = do
     let checkU i = checkMeta i (newMetaArg (A.metaKind i) info x) CmpLeq t0
     let checkQ = checkQuestionMark (newInteractionMetaArg info x) CmpLeq t0
     if not $ isHole e then checkExpr e t0 else localScope $ do
-      -- Note: we need localScope here,
+      -- Note: we need localScope_ here,
       -- as scopedExpr manipulates the scope in the state.
-      -- However, we may not pull localScope over checkExpr!
+      -- However, we may not pull localScope_ over checkExpr!
       -- This is why we first test for isHole, and only do
       -- scope manipulations if we actually handle the checking
       -- of e here (and not pass it to checkExpr).

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -7,6 +7,7 @@ import Control.Monad
 import Control.Monad.Reader
 import Data.Void (Void)
 import qualified Data.Map as Map
+import qualified Data.HashMap.Strict as HMap
 import qualified Data.Set as Set
 
 import Agda.Syntax.Common
@@ -234,6 +235,6 @@ instance EmbPrj Precedence where
 instance EmbPrj ScopeInfo where
   icod_ (ScopeInfo a b c d e f g h i j k) = icodeN' (\ a b c d e -> ScopeInfo a b c d e f g h i j k) a b c d e
 
-  value = valueN (\ a b c d e -> ScopeInfo a b c d e Map.empty Map.empty Set.empty Map.empty Map.empty Map.empty)
+  value = valueN (\ a b c d e -> ScopeInfo a b c d e HMap.empty HMap.empty Set.empty Map.empty Map.empty Map.empty)
 
 instance EmbPrj NameOrModule

--- a/src/full/Agda/Utils/Map.hs
+++ b/src/full/Agda/Utils/Map.hs
@@ -2,21 +2,49 @@
 
 module Agda.Utils.Map where
 
+import Control.Monad ((<$!>))
 import Data.Functor.Compose
-import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Map.Internal (Map(..), balanceL, balanceR, singleton)
 
 import Agda.Utils.Impossible
 
 -- * Monadic map operations
 ---------------------------------------------------------------------------
 
+{-# INLINE insertWithGood #-}
+-- | Version of `insertWith` that's willing to be properly inlined.
+insertWithGood :: forall k a. Ord k => (a -> a -> a) -> k -> a -> Map k a -> Map k a
+insertWithGood f k !a = go k a where
+  go :: k -> a -> Map k a -> Map k a
+  go !kx x Tip               = singleton kx x
+  go  kx x (Bin sy ky y l r) = case compare kx ky of
+    LT -> balanceL ky y (go kx x l) r
+    GT -> balanceR ky y l (go kx x r)
+    EQ -> let !y' = f x y in Bin sy kx y' l r
+
+{-# INLINE forGood_ #-}
+-- | Version of `forM_` that deigns to be properly lambda-lifted for State, Reader, etc.
+forGood_ :: forall k v m. Applicative m => Map k v -> (v -> m ()) -> m ()
+forGood_ m f = go m where
+  go Tip             = pure ()
+  go (Bin _ k v l r) = go l *> f v *> go r
+
+{-# INLINE forWithKey_ #-}
+forWithKey_ :: forall k v m. Applicative m => Map k v -> (k -> v -> m ()) -> m ()
+forWithKey_ m f = go m where
+  go Tip             = pure ()
+  go (Bin _ k v l r) = go l *> f k v *> go r
+
+{-# INLINE adjustM #-}
 -- | Update monadically the value at one position (must exist!).
 adjustM :: (Functor f, Ord k) => (v -> f v) -> k -> Map k v -> f (Map k v)
 adjustM f = Map.alterF $ \case
   Nothing -> __IMPOSSIBLE__
   Just v  -> Just <$> f v
 
+{-# INLINE adjustM' #-}
 -- | Wrapper for 'adjustM' for convenience.
 adjustM' :: (Functor f, Ord k) => (v -> f (a, v)) -> k -> Map k v -> f (a, Map k v)
 adjustM' f k = getCompose . adjustM (Compose . f) k
@@ -25,6 +53,7 @@ adjustM' f k = getCompose . adjustM (Compose . f) k
 ---------------------------------------------------------------------------
 
 #if !MIN_VERSION_containers(0,8,0)
+{-# INLINE filterKeys #-}
 -- | Filter a map based on the keys.
 filterKeys :: (k -> Bool) -> Map k a -> Map k a
 filterKeys p = Map.filterWithKey (const . p)
@@ -32,7 +61,5 @@ filterKeys p = Map.filterWithKey (const . p)
 
 -- | Check whether a map is a singleton.
 isSingleMap :: Map k v -> Maybe (k, v)
-isSingleMap m
-  | Map.size m == 1  -- This is fast since the size is cached.
-  , [(k,v)] <- Map.toList m = Just (k, v)
-  | otherwise = Nothing
+isSingleMap (Bin 1 k v _ _) = Just (k, v)
+isSingleMap _               = Nothing

--- a/src/full/Agda/Utils/StrictState.hs
+++ b/src/full/Agda/Utils/StrictState.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE MagicHash, UnboxedTuples, Strict #-}
+{-# OPTIONS_GHC -Wno-redundant-bang-patterns #-}
+
+module Agda.Utils.StrictState where
+
+import GHC.Exts (oneShot)
+
+newtype State s a = State {runState# :: s -> (# a, s #)}
+
+instance Functor (State s) where
+  {-# INLINE fmap #-}
+  fmap f (State g) = State (oneShot \s -> case g s of
+    (# a, !s #) -> let b = f a in (# b, s #))
+  {-# INLINE (<$) #-}
+  (<$) a m = (\_ -> a) <$> m
+
+instance Applicative (State s) where
+  {-# INLINE pure #-}
+  pure a = State (oneShot \s -> (# a, s #))
+  {-# INLINE (<*>) #-}
+  State mf <*> State ma = State (oneShot \s -> case mf s of
+    (# f, s #) -> case ma s of
+      (# a, !s #) -> let b = f a in (# b, s #))
+  {-# INLINE (*>) #-}
+  State ma *> State mb = State (oneShot \s -> case ma s of
+    (# _, s #) -> mb s)
+  {-# INLINE (<*) #-}
+  State ma <* State mb = State (oneShot \s -> case ma s of
+    (# a, s #) -> case mb s of
+      (# _, s #) -> (# a, s #))
+
+instance Monad (State s) where
+  {-# INLINE return #-}
+  return = pure
+  {-# INLINE (>>=) #-}
+  State ma >>= f = State (oneShot \s -> case ma s of
+    (# a, s #) -> runState# (f a) s)
+  {-# INLINE (>>) #-}
+  (>>) = (*>)
+
+{-# INLINE put #-}
+put :: s -> State s ()
+put s = State \_ -> (# (), s #)
+
+{-# INLINE get #-}
+get :: State s s
+get = State \s -> (# s, s #)
+
+{-# INLINE gets #-}
+gets :: (s -> a) -> State s a
+gets f = f <$> get
+
+{-# INLINE modify #-}
+modify :: (s -> s) -> State s ()
+modify f = State \s -> let s' = f s in (# (), s' #)
+
+{-# INLINE execState #-}
+execState :: State s a -> s -> s
+execState (State f) s = case f s of
+  (# _, s #) -> s
+
+{-# INLINE runState #-}
+runState :: State s a -> s -> (a, s)
+runState (State f) s = case f s of
+  (# !a, !s #) -> (a, s)
+
+{-# INLINE evalState #-}
+evalState :: State s a -> s -> a
+evalState (State f) s = case f s of
+  (# a, _ #) -> a

--- a/src/full/Agda/Utils/StrictState2.hs
+++ b/src/full/Agda/Utils/StrictState2.hs
@@ -1,0 +1,96 @@
+
+{-# LANGUAGE MagicHash, UnboxedTuples, Strict #-}
+{-# OPTIONS_GHC -Wno-redundant-bang-patterns #-}
+{-# OPTIONS_GHC -ddump-simpl -ddump-to-file -dsuppress-all -dno-suppress-type-signatures #-}
+
+module Agda.Utils.StrictState2 where
+
+import GHC.Exts (oneShot)
+
+newtype State s t a = State {runState# :: s -> t -> (# a, s, t #)}
+
+instance Functor (State s t) where
+  {-# INLINE fmap #-}
+  fmap f (State g) = State (oneShot \s t -> case g s t of
+    (# a, !s, !t #) -> let b = f a in (# b, s, t #))
+  {-# INLINE (<$) #-}
+  (<$) a m = (\_ -> a) <$> m
+
+instance Applicative (State s t) where
+  {-# INLINE pure #-}
+  pure ~a = State (oneShot \s t -> (# a, s, t #))
+  {-# INLINE (<*>) #-}
+  State mf <*> State ma = State (oneShot \s t -> case mf s t of
+    (# f, s, t #) -> case ma s t of
+      (# a, !s, !t #) -> let b = f a in (# b, s, t #))
+  {-# INLINE (*>) #-}
+  State ma *> State mb = State (oneShot \s t -> case ma s t of
+    (# _, s, t #) -> mb s t)
+  {-# INLINE (<*) #-}
+  State ma <* State mb = State (oneShot \s t -> case ma s t of
+    (# a, s, t #) -> case mb s t of
+      (# _, s, t #) -> (# a, s, t #))
+
+instance Monad (State s t) where
+  {-# INLINE return #-}
+  return = pure
+  {-# INLINE (>>=) #-}
+  State ma >>= f = State (oneShot \s t -> case ma s t of
+    (# a, s, t #) -> runState# (f a) s t)
+  {-# INLINE (>>) #-}
+  (>>) = (*>)
+
+{-# INLINE put #-}
+put :: s -> t -> State s t ()
+put s t = State (oneShot \_ _ -> (# (), s, t #))
+
+{-# INLINE put1 #-}
+put1 :: s -> State s t ()
+put1 s = State \_ t -> (# (), s, t #)
+
+{-# INLINE put2 #-}
+put2 :: t -> State s t ()
+put2 t = State \s _ -> (# (), s, t #)
+
+{-# INLINE get #-}
+get :: State s t (s, t)
+get = State \s t -> (# (s, t), s, t #)
+
+{-# INLINE get1 #-}
+get1 :: State s t s
+get1 = State \s t -> (# s, s, t #)
+
+{-# INLINE get2 #-}
+get2 :: State s t t
+get2 = State \s t -> (# t, s, t #)
+
+{-# INLINE gets #-}
+gets :: ((s, t) -> a) -> State s t a
+gets f = f <$> get
+
+{-# INLINE modify #-}
+modify :: ((s,t) -> (s,t)) -> State s t ()
+modify f = State \s t -> let (!s', !t') = f (s, t) in (# (), s', t' #)
+
+{-# INLINE modify1 #-}
+modify1 :: (s -> s) -> State s t ()
+modify1 f = State \s t -> let !s' = f s in (# (), s', t #)
+
+{-# INLINE modify2 #-}
+modify2 :: (t -> t) -> State s t ()
+modify2 f = State \s t -> let !t' = f t in (# (), s, t' #)
+
+{-# INLINE execState #-}
+execState :: State s t a -> (s, t) -> (s, t)
+execState (State f) (s, t) = case f s t of
+  (# _, s, t #) -> (s, t)
+
+{-# INLINE runState #-}
+runState :: State s t a -> (s, t) -> (a, (s, t))
+runState (State f) (s, t) = case f s t of
+  (# !a, !s, !t #) -> (a, (s, t))
+
+{-# INLINE evalState #-}
+evalState :: State s t a -> (s, t) -> a
+evalState (State f) (s, t) = case f s t of
+  (# a, _, _ #) -> a

--- a/src/full/Agda/Utils/Tuple.hs
+++ b/src/full/Agda/Utils/Tuple.hs
@@ -1,7 +1,9 @@
 {-# OPTIONS_GHC -Wunused-imports #-}
 
 module Agda.Utils.Tuple
-  ( (-*-)
+  (
+    (//)
+  , (-*-)
   , mapFst
   , mapSnd
   , (/\)
@@ -28,6 +30,12 @@ import GHC.Generics    ( Generic )
 
 infix 2 -*-
 infix 3 /\ -- backslashes at EOL interact badly with CPP...
+
+{-# INLINE (//) #-}
+-- | Strict pairing.
+(//) :: a -> b -> (a, b)
+(//) !a !b = (a, b)
+infixr 4 //
 
 -- | Bifunctoriality for pairs.
 (-*-) :: (a -> c) -> (b -> d) -> (a,b) -> (c,d)

--- a/test/Fail/Issue5838.err
+++ b/test/Fail/Issue5838.err
@@ -6,8 +6,6 @@ Specifically, the terms
   false
 and
   transp
-  (λ i →
-     DoubleCover
-     (transp (twisted-square i) (primIMin i1 (primIMax i (~ i))) base))
+  (λ i → DoubleCover (transp (twisted-square i) (i1 ∧ i ∨ ~ i) base))
   i0 false
 must be equal, since bad i1 could reduce to either.

--- a/test/Fail/Issue5838b.err
+++ b/test/Fail/Issue5838b.err
@@ -7,7 +7,6 @@ Specifically, the terms
 and
   transp
   (λ i →
-     DoubleCover
-     (transp (twisted-square' i) (primIMin i1 (primIMax i (~ i))) base))
+     DoubleCover (transp (twisted-square' i) (i1 ∧ i ∨ ~ i) base))
   i0 false
 must be equal, since bad' i1 could reduce to either.

--- a/test/api/PrettyInterface.hs
+++ b/test/api/PrettyInterface.hs
@@ -17,7 +17,8 @@ import qualified Data.HashMap.Strict as HashMap
 import Agda.Interaction.Imports ( typeCheckMain, Mode(TypeCheck), parseSource, CheckResult(CheckResult), crInterface )
 import Agda.Interaction.Options ( defaultOptions )
 
-import Agda.TypeChecking.Monad   ( TCM, Definition(..), Interface(..), Signature(..), runTCMTop, setCommandLineOptions, srcFromPath, withScope_  )
+import Agda.TypeChecking.Monad   (  TCM, Definition(..), Interface(..), Signature(..), runTCMTop
+                                  , setCommandLineOptions, srcFromPath, recomputeInverseScope, evalWithScope )
 import Agda.TypeChecking.Pretty  ( prettyTCM, (<+>), text )
 
 import Agda.Utils.FileName       ( absolute )
@@ -40,7 +41,8 @@ mainTCM = do
   compilerMain i
 
 compilerMain :: Interface -> TCM ()
-compilerMain i = withScope_ (iInsideScope i) $ do -- withShowAllArguments $ disableDisplayForms $ do
+compilerMain i = evalWithScope (iInsideScope i) $ do -- withShowAllArguments $ disableDisplayForms $ do
+  recomputeInverseScope
   let Sig{_sigDefinitions = defs} = iSignature i
   forM_ (HashMap.toList defs) $ \ (q, def) -> do
     let t = defType def


### PR DESCRIPTION
Inverse scope optimization. WIP. 

"Shotgun" inverse scope computation (i.e. bundled with setting and modifying `ScopeInfo`) is removed. Instead, `recomputeInverseScope` is now a `MonadTCState` operation which is explicitly invoked at every point where a modified `ScopeInfo` is created. Whenever we change the scope in `ScopeInfo`, we have to handle inverse scoping. On the other hand we can assume that every `ScopeInfo` that we get in a program context has valid inverse scope. 

- There's only 16 occurrence of inverse scope computation in the code, which I find to be OK. Some of these should be factored out and merged, others could be unnecessary but I left them in because I didn't sufficiently understand the code context. I'll probably reduce the number in this PR.
- In principle, there should be *no* recomputation at all, because every instance could be replaced with a more effective operation that only traverses the data that's newly added to the scope. I already optimized binding new names, which is basically just a single Map/Set insertion in the inverse scope. The explicit `recomputeNameSpace` invocations mark the places where someone could go and optimize them away in the future. 
- The previous behavior was basically to recompute inverse scopes on every inverse lookup with close to no work sharing. The new version only recomputes inverse scopes on module operations (import, module macro, opening, creating modules, creating scopes from interfaces).
- Inverse scope recomputation is still very slow ATM, it just happens far less frequently. I'll try to improve it a bit further in this PR.
- Inverse scope operations are now benchmarked separately for names, modules and `InScopeSet`-s and their respective lookups. 

`std-lib-test`:

|         | master | PR |
|--------|------------|-----|
| Total | 153,268ms | 144,478ms |
| Scoping (total) | 12,225ms | 3,318ms |
| Inverse scoping (total) | 10,248ms  | 1,424ms |
| Total alloc | 605 GB | 584 GB |

