### PR TITLE
[ fix #8092 ] Preserve compiler pragmas when overwriting a definition

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -190,6 +190,9 @@ addConstant q d = do
                       , defPolarity       = if null (defPolarity new)
                                               then defPolarity old
                                               else defPolarity new
+                      , defCompiledRep    = Map.unionWith (++)
+                                              (defCompiledRep new)
+                                              (defCompiledRep old)
                       }
 
 -- | A combination of 'addConstant' and 'defaultDefn'. The 'Language'

--- a/test/Fail/Issue8092.agda
+++ b/test/Fail/Issue8092.agda
@@ -1,0 +1,6 @@
+open import Agda.Builtin.String
+
+x : String
+{-# COMPILE GHC x = error "after decl but before defn" #-}
+x = "some agda string"
+{-# COMPILE GHC x = error "after decl and after defn" #-}

--- a/test/Fail/Issue8092.err
+++ b/test/Fail/Issue8092.err
@@ -1,0 +1,5 @@
+Issue8092.agda:6.1-58: error: [CustomBackendError]
+GHC:
+  Conflicting GHC pragmas for x at
+    - Issue8092.agda:4.1-59
+    - Issue8092.agda:6.1-58

--- a/test/Fail/Issue8092.flags
+++ b/test/Fail/Issue8092.flags
@@ -1,0 +1,1 @@
+--compile --no-main


### PR DESCRIPTION
I haven't tested this yet, but theoretically this should be the easy and straightforward fix for #8092.

Closes #8092.