### PR TITLE
Fix #8098: don't delete readonly .agdai files

### DIFF
--- a/src/release-tools/change-version.bash
+++ b/src/release-tools/change-version.bash
@@ -26,6 +26,7 @@ files+='test/Fail/MagicWith.err '
 files+='test/interaction/Issue1244a.out '
 files+='test/interaction/Issue1244b.out '
 files+='test/interaction/Issue6261.out '
+files+='test/interaction/Issue8098.out '
 
 if [ "$2" == "" -o "$1" == "-h" -o "$1" == "--help" ]; then
   echo "Usage: $0 OLD NEW"

--- a/test/interaction/Issue8098.agda
+++ b/test/interaction/Issue8098.agda
@@ -1,0 +1,3 @@
+module Issue8098 where
+
+-- Left blank intentionally

--- a/test/interaction/Issue8098.out
+++ b/test/interaction/Issue8098.out
@@ -1,0 +1,5 @@
+Checking Issue8098 (Issue8098.agda).
+Checking Issue8098 (Issue8098.agda).
+Failed to write interface _build/2.9.0/agda/Issue8098.agdai.
+_build/2.9.0/agda/Issue8098.agdai:
+withBinaryFile: permission denied (Permission denied)

--- a/test/interaction/Issue8098.sh
+++ b/test/interaction/Issue8098.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Andreas, issue 8098, do not delete readonly files.
+
+AGDA=$1
+
+# Exit if a step fails.
+set -e
+
+# Should succeed and create Issue8098.agdai.
+$AGDA Issue8098.agda
+
+# Find interface file.
+iface=$(find -name "Issue8098.agdai")
+[ -f ${iface} ]
+
+# Make interface file readonly.
+chmod -w ${iface}
+
+# Should fail, because we cannot update the interface file.
+# This will print:
+# Failed to write interface .../Issue8098.agdai.
+# .../Issue8098.agdai:
+# withBinaryFile: permission denied (Permission denied)
+! $AGDA -Werror Issue8098.agda
+
+# Make sure the file is still there.
+[ -f ${iface} ]
+
+# When Agda does not have to write the interface, it should still succeed.
+$AGDA Issue8098.agda
+
+# Remove the interface file.
+chmod +w ${iface}
+rm -f ${iface}
+
+# EOF


### PR DESCRIPTION
Closes #8098

CI running here: https://github.com/andreasabel/agda-for-bisecting/pull/5