### PR TITLE
 Normalization level for Cmd_constraints (C-c C-=)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,13 @@ Library management
 Interaction and emacs mode
 --------------------------
 
+* A normalization level can now also passed to command `Cmd_constraints`
+  ("show constraints", `C-c C-=` in Emacs).
+  In Emacs, the normalization level is given as usual by `C-u` prefixes.
+
+  This interface change is **breaking** for frontends to `agda --interaction`
+  such as the VSCode `agda-mode`, which need updating.
+
 Backends
 --------
 

--- a/src/agda-bisect/agda-bisect.cabal
+++ b/src/agda-bisect/agda-bisect.cabal
@@ -5,9 +5,11 @@ cabal-version: >= 1.10
 author: Nils Anders Danielsson
 build-type: Simple
 tested-with:
-  GHC == 9.10.1
+  GHC == 9.14.0
+  GHC == 9.12.2
+  GHC == 9.10.2
   GHC == 9.8.4
-  GHC == 9.6.6
+  GHC == 9.6.7
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -21,13 +23,13 @@ tested-with:
 executable agda-bisect
   main-is:          Bisect.hs
   build-depends:
-      base                 >= 4.9.0.0 && < 4.21
+      base                 >= 4.9.0.0 && < 5
     , ansi-wl-pprint       >= 0.6.7.3 && < 1.1
     , directory            >= 1.2.6.2 && < 1.4
     , filepath             >= 1.4.1.0 && < 1.6
-    , optparse-applicative >= 0.13    && < 0.19
+    , optparse-applicative >= 0.13    && < 1
     , process              >= 1.4.2.0 && < 1.7
-    , time                 >= 1.6.0.1 && < 1.13
+    , time                 >= 1.6.0.1 && < 2
     , unix                 >= 2.7.2.0 && < 2.9
   default-language: Haskell2010
   other-extensions: NamedFieldPuns

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1132,10 +1132,6 @@ is inserted, and point is placed before this text."
   (kill-new text)
   (agda2-info-action name text append))
 
-(defun agda2-show-constraints()
-  "Show constraints." (interactive)
-  (agda2-go nil t 'busy t "Cmd_constraints"))
-
 (defun agda2-remove-annotations ()
   "Removes buffer annotations (overlays and text properties)."
   (interactive)
@@ -1307,6 +1303,15 @@ The form of the result depends on the prefix argument:
     ("HeadNormal"   "head normalised")
     (global ,prompt)))
 
+(defmacro agda2-maybe-normalised-toplevel-noprompt (name comment cmd)
+  `(agda2-proto-maybe-normalised
+    ,name ,comment ,cmd
+    ("Simplified"   "simplified")
+    ("Instantiated" "neither explicitly normalised nor simplified")
+    ("Normalised"   "normalised")
+    ("HeadNormal"   "head normalised")
+    (global nil)))
+
 (defmacro agda2-maybe-normalised-toplevel-asis-noprompt (name comment cmd)
   `(agda2-proto-maybe-normalised
     ,name ,comment ,cmd
@@ -1477,6 +1482,16 @@ Either only one if point is a goal, or all of them."
  "Solves all goals that are already instantiated internally."
  "Cmd_solveAll"
  )
+
+;; Andreas, 2025-09-12
+;; Cmd_constraints has same normalization strategy as Cmd_solveOne
+;; since after showing the meta solutions one might want to
+;; apply them at the same normalization level.
+(agda2-maybe-normalised-toplevel-noprompt
+  agda2-show-constraints
+  "Show meta solutions and constraints."
+  "Cmd_constraints"
+)
 
 (agda2-maybe-normalised
   agda2-solveOne

--- a/src/full/Agda/Interaction/Base.hs
+++ b/src/full/Agda/Interaction/Base.hs
@@ -142,7 +142,8 @@ data Interaction' range
     -- @argv@ as the command-line options.
   = Cmd_load FilePath [String]
 
-  | Cmd_constraints
+    -- | Show constraints on goals.
+  | Cmd_constraints Rewrite
 
     -- | Show unsolved metas. If there are no unsolved metas but unsolved constraints
     -- show those instead.

--- a/src/full/Agda/Interaction/CommandLine.hs
+++ b/src/full/Agda/Interaction/CommandLine.hs
@@ -185,7 +185,7 @@ loadFile _ _ = liftIO $ putStrLn ":load file"
 
 showConstraints :: [String] -> TCM ()
 showConstraints [] =
-    do  cs <- BasicOps.getConstraints
+    do  cs <- BasicOps.getConstraints AsIs
         liftIO $ putStrLn $ unlines (List.map prettyShow cs)
 showConstraints _ = liftIO $ putStrLn ":constraints [cid]"
 

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -502,8 +502,8 @@ interpret (Cmd_backend_top backend cmd) =
 interpret (Cmd_backend_hole ii rng s backend cmd) =
   callBackendInteractHole (getBackendName backend) cmd ii rng s
 
-interpret Cmd_constraints =
-  display_info . Info_Constraints =<< lift B.getConstraints
+interpret (Cmd_constraints norm) =
+  display_info . Info_Constraints =<< lift (B.getConstraints norm)
 
 interpret (Cmd_metas norm) = do
   ms <- lift $ B.getGoals' norm (max Simplified norm)

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -289,6 +289,9 @@ instance Instantiate a => Instantiate (Closure a) where
         x <- enterClosure cl instantiate'
         return $ cl { clValue = x }
 
+instance Instantiate ProblemConstraint where
+  instantiate' (PConstr p u c) = PConstr p u <$> instantiate' c
+
 instance Instantiate Constraint where
   instantiate' (ValueCmp cmp t u v) = do
     (t,u,v) <- instantiate' (t,u,v)
@@ -967,6 +970,9 @@ instance Reduce a => Reduce (Closure a) where
 instance Reduce Telescope where
   reduce' EmptyTel          = return EmptyTel
   reduce' (ExtendTel a tel) = ExtendTel <$> reduce' a <*> reduce' tel
+
+instance Reduce ProblemConstraint where
+  reduce' (PConstr p u c) = PConstr p u <$> reduce' c
 
 instance Reduce Constraint where
   reduce' (ValueCmp cmp t u v) = do

--- a/test/interaction/Issue2765.in
+++ b/test/interaction/Issue2765.in
@@ -1,2 +1,2 @@
 top_command (cmd_load currentFile [])
-top_command cmd_constraints
+top_command (cmd_constraints AsIs)

--- a/test/interaction/Issue2881.in
+++ b/test/interaction/Issue2881.in
@@ -1,2 +1,2 @@
 top_command (cmd_load currentFile [])
-top_command cmd_constraints
+top_command (cmd_constraints AsIs)

--- a/test/interaction/Issue3503.in
+++ b/test/interaction/Issue3503.in
@@ -1,2 +1,2 @@
 top_command (cmd_load currentFile [])
-top_command cmd_constraints
+top_command (cmd_constraints AsIs)

--- a/test/interaction/Issue731.in
+++ b/test/interaction/Issue731.in
@@ -1,2 +1,2 @@
 top_command (cmd_load currentFile [])
-top_command cmd_constraints
+top_command (cmd_constraints AsIs)

--- a/test/interaction/Issue7898.in
+++ b/test/interaction/Issue7898.in
@@ -1,5 +1,5 @@
 top_command (cmd_load currentFile [])
 goal_command 0 (cmd_autoOne AsIs) ""
-top_command cmd_constraints
+top_command (cmd_constraints AsIs)
 goal_command 1 (cmd_autoOne AsIs) ""
-top_command cmd_constraints
+top_command (cmd_constraints AsIs)

--- a/test/interaction/Long.in
+++ b/test/interaction/Long.in
@@ -4,9 +4,9 @@ top_command (cmd_load currentFile [])
 IOTCM currentFile NonInteractive Indirect (cmd_load_highlighting_info currentFile)
 top_command (cmd_compile GHC currentFile [])
 -- Note that the previous fail does not unload the file
-top_command cmd_constraints
+top_command (cmd_constraints AsIs)
 top_command (cmd_load currentFile [])
-top_command cmd_constraints
+top_command (cmd_constraints Normalised)
 top_command (cmd_metas AsIs)
 top_command (cmd_metas Normalised)
 -- Note that cmd_make_case does not update the set of goals.


### PR DESCRIPTION
 Normalization level for Cmd_constraints (C-c C-=)
    
The documentation already promised that C-c C-= reacts to C-u  prefixes, now it actually does.

CI running here: https://github.com/andreasabel/agda-for-bisecting/pull/6