### PR TITLE
Fix #8105: highlight thing shadowed by a clashing definition

### DIFF
--- a/test/interaction/Issue8105.agda
+++ b/test/interaction/Issue8105.agda
@@ -1,0 +1,15 @@
+-- Andreas, 2025-09-15, issue #8105
+-- Highlight definition a clashing definition clashes with
+
+module Issue8105 where
+
+foo -- This shadowed definition should be highlighted as well, e.g. deadcode.
+
+data Bar : Set where
+  foo : Bar  -- This clashing definition gets error highlighting.
+
+-- Expected error: Issue8105.agda:9.3-12: error: [ClashingDefinition]
+-- Multiple definitions of foo. Previous definition at
+-- Issue8105.agda:6.1-4
+-- when scope checking the declaration
+--   foo : Bar

--- a/test/interaction/Issue8105.in
+++ b/test/interaction/Issue8105.in
@@ -1,0 +1,1 @@
+top_command (cmd_load currentFile [])

--- a/test/interaction/Issue8105.out
+++ b/test/interaction/Issue8105.out
@@ -1,0 +1,7 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-info-action "*Error*" "Issue8105.agda:9.3-12: error: [ClashingDefinition] Multiple definitions of foo. Previous definition at Issue8105.agda:6.1-4 when scope checking the declaration foo : Bar" nil)
+((last . 3) . (agda2-maybe-goto '("Issue8105.agda" . 223)))
+(agda2-highlight-load-and-delete-action)
+(agda2-status-action "")

--- a/test/interaction/Issue8105ShadowedModule.agda
+++ b/test/interaction/Issue8105ShadowedModule.agda
@@ -1,0 +1,14 @@
+-- Andreas, 2025-09-15, issue #8105
+-- Highlight module a clashing module clashes with.
+
+module Issue8105ShadowedModule where
+
+module M where -- This shadowed module should be highlighted as well, e.g. deadcode.
+
+module M where -- This clashing module gets error highlighting.
+
+-- Expected error: 8.8-9: error: [ShadowedModule]
+-- Duplicate definition of module M. Previous definition of module M
+-- at 6.8-9
+-- when scope checking the declaration
+--   module M where

--- a/test/interaction/Issue8105ShadowedModule.in
+++ b/test/interaction/Issue8105ShadowedModule.in
@@ -1,0 +1,1 @@
+top_command (cmd_load currentFile [])

--- a/test/interaction/Issue8105ShadowedModule.out
+++ b/test/interaction/Issue8105ShadowedModule.out
@@ -1,0 +1,7 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-info-action "*Error*" "Issue8105ShadowedModule.agda:8.8-9: error: [ShadowedModule] Duplicate definition of module M. Previous definition of module M at Issue8105ShadowedModule.agda:6.8-9 when scope checking the declaration module M where" nil)
+((last . 3) . (agda2-maybe-goto '("Issue8105ShadowedModule.agda" . 221)))
+(agda2-highlight-load-and-delete-action)
+(agda2-status-action "")


### PR DESCRIPTION
This adds `extraErrorHighlighting` that can highlight ranges outside the prime error range.
Implemented for `ClashingDefinition` and `ShadowedModule`, but there might be more opportunities.

Closes #8105.

CI running here: https://github.com/andreasabel/agda-for-bisecting/pull/9
