### PR TITLE
Remove unnecessary LHS.Unify.LeftInverse computation

### DIFF
--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -116,6 +116,8 @@ data Phase
   | InverseNameModuleRecompute
   | InverseInScopeRecompute
   | TopModule TopLevelModuleName
+  | CubicalLeftInversion
+    -- ^ Generating left inverses in LHS unification in cubical or cubical-compatible mode.
   | Typeclass QName
   | Definition QName
   deriving (Eq, Ord, Show, Generic)

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
@@ -12,6 +12,8 @@ import Control.Monad.Except
 
 import Data.Functor
 
+import qualified Agda.TypeChecking.Monad.Benchmark as Bench
+
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
 
@@ -35,6 +37,37 @@ import Agda.Utils.Size
 
 import Agda.Utils.Impossible
 
+
+data DigestedUnifyStep
+  = DSolution Int (Dom Type) (FlexibleVar Int) Term (Either () ())
+  | DEtaExpandVar (FlexibleVar Int) QName Args
+
+instance PrettyTCM DigestedUnifyStep where
+  prettyTCM (DSolution a b c d e) = prettyTCM (Solution a b c d e)
+  prettyTCM (DEtaExpandVar a b c) = prettyTCM (EtaExpandVar a b c)
+
+data DigestedUnifyLogEntry
+  = DUnificationStep UnifyState DigestedUnifyStep UnifyOutput
+
+type DigestedUnifyLog = [(DigestedUnifyLogEntry,UnifyState)]
+
+-- | Pre-process a UnifyLog so that we catch unsupported steps early.
+digestUnifyLog :: UnifyLog -> Either NoLeftInv DigestedUnifyLog
+digestUnifyLog log = forM log \(UnificationStep s step out, s') -> do
+  let illegal     = Left $ Illegal step
+      unsupported = Left $ UnsupportedYet step
+      ret step    = pure (DUnificationStep s step out, s')
+  case step of
+    Solution a b c d e   -> ret $ DSolution a b c d e
+    EtaExpandVar a b c   -> ret $ DEtaExpandVar a b c
+    Deletion{}           -> illegal
+    TypeConInjectivity{} -> illegal
+    -- These should end up in a NoUnify
+    Conflict{}    -> __IMPOSSIBLE__
+    LitConflict{} -> __IMPOSSIBLE__
+    Cycle{}       -> __IMPOSSIBLE__
+    _             -> unsupported
+
 instance PrettyTCM NoLeftInv where
   prettyTCM (UnsupportedYet s) = fsep $ pwords "It relies on" ++ [explainStep s <> ","] ++ pwords "which is not yet supported"
   prettyTCM UnsupportedCxt     = fwords "it relies on higher-dimensional unification, which is not yet supported"
@@ -44,6 +77,7 @@ instance PrettyTCM NoLeftInv where
   prettyTCM SplitOnStrict      = fwords "It splits on a type in SSet"
   prettyTCM SplitOnFlat        = fwords "It splits on a @♭ argument"
   prettyTCM (CantTransport t)  = fsep $ pwords "The type" <> [prettyTCM t] <> pwords "can not be transported"
+  prettyTCM (CantTransport' t) = fsep $ pwords "The type" <> [prettyTCM t] <> pwords "can not be transported"
 
 data NoLeftInv
   = UnsupportedYet {badStep :: UnifyStep}
@@ -53,67 +87,73 @@ data NoLeftInv
   | SplitOnStrict  -- ^ splitting on a Strict Set.
   | SplitOnFlat    -- ^ splitting on a @♭ argument
   | UnsupportedCxt
-  | CantTransport (Closure (Abs Type))
+  | CantTransport  (Closure (Abs Type))
+  | CantTransport' (Closure Type)
   deriving Show
 
-buildLeftInverse :: forall tcm. (PureTCM tcm, MonadError TCErr tcm) => UnifyState -> UnifyLog -> tcm (Either NoLeftInv (Substitution, Substitution))
-buildLeftInverse s0 log = do
-  reportSDoc "tc.lhs.unify.inv.badstep" 20 $ do
-    cubical <- cubicalOption
-    "cubical:" <+> text (show cubical)
-  reportSDoc "tc.lhs.unify.inv.badstep" 20 $ do
-    pathp <- getTerm' builtinPathP
-    "pathp:" <+> text (show $ isJust pathp)
-  let
-    cond = andM
-      -- TODO: handle open contexts: they happen during "higher dimensional" unification,
-      --       in injectivity cases.
-      [ null <$> getContext
-      ]
+buildLeftInverse :: UnifyState -> UnifyLog -> TCM (Either NoLeftInv (Substitution, Substitution))
+buildLeftInverse s0 log = Bench.billTo [Bench.UnifyIndices, Bench.CubicalLeftInversion] $ case digestUnifyLog log of
+  Left no -> do
+    reportSDoc "tc.lhs.unify.inv.badstep" 20 $ "No Left Inverse:" <+> prettyTCM (badStep no)
+    return (Left no)
+  Right log -> do
 
-    compose :: [(Retract, Term)] -> ExceptT NoLeftInv tcm Retract
-    compose [] = __IMPOSSIBLE__
-    compose [(xs, _)] = pure xs
-    compose ((x, t):xs) = do
-      r <- compose xs
-      ExceptT $ composeRetract x t r <&> \case
-        Left e  -> Left (CantTransport e)
-        Right x -> Right x
+    reportSDoc "tc.lhs.unify.inv.badstep" 20 $ do
+      cubical <- cubicalOption
+      "cubical:" <+> text (show cubical)
+    reportSDoc "tc.lhs.unify.inv.badstep" 20 $ do
+      pathp <- getTerm' builtinPathP
+      "pathp:" <+> text (show $ isJust pathp)
+    let
+      cond = andM
+        -- TODO: handle open contexts: they happen during "higher dimensional" unification,
+        --       in injectivity cases.
+        [ null <$> getContext
+        ]
 
-  ifNotM cond (return $ Left UnsupportedCxt) $ do
-  equivs <- forM log $ uncurry buildEquiv
-  case sequence equivs of
-    Left no -> do
-      reportSDoc "tc.lhs.unify.inv.badstep" 20 $ "No Left Inverse:" <+> prettyTCM (badStep no)
-      return (Left no)
-    Right xs -> runExceptT (compose xs) >>= \case
-      Left no -> return (Left no)
-      Right (_, _, tau0, leftInv0) -> do
-      -- Γ,φ,us =_Δ vs ⊢ τ0 : Γ', φ
-      -- leftInv0 : [wkS |φ,us =_Δ vs| ρ,1,refls][τ] = idS : Γ,φ,us =_Δ vs
-      let tau = tau0 `composeS` raiseS 1
-      unview <- intervalUnview'
-      let replaceAt n x xs = xs0 ++ x:xs1
-                  where (xs0,_:xs1) = splitAt n xs
-      let max r s = unview $ IMax (argN r) (argN s)
-          neg r = unview $ INeg (argN r)
-      let phieq = neg (var 0) `max` var (size (eqTel s0) + 1)
-                        -- I + us =_Δ vs -- inplaceS
-      let leftInv = termsS __IMPOSSIBLE__ $ replaceAt (size (varTel s0)) phieq $ map (lookupS leftInv0) $ downFrom (size (varTel s0) + 1 + size (eqTel s0))
-      let working_tel = abstract (varTel s0) (ExtendTel __DUMMY_DOM__ $ Abs "phi0" $ (eqTel s0))
-      reportSDoc "tc.lhs.unify.inv" 20 $ "=== before mod"
-      do
-          addContext working_tel $ reportSDoc "tc.lhs.unify.inv" 20 $ "tau0    :" <+> prettyTCM tau0
-          addContext working_tel $ addContext ("r" :: String, __DUMMY_DOM__)
-                                $ reportSDoc "tc.lhs.unify.inv" 20 $ "leftInv0:  " <+> prettyTCM leftInv0
+      compose :: [(Retract, Term)] -> ExceptT NoLeftInv TCM Retract
+      compose [] = __IMPOSSIBLE__
+      compose [(xs, _)] = pure xs
+      compose ((x, t):xs) = do
+        r <- compose xs
+        ExceptT $ composeRetract x t r <&> \case
+          Left e  -> Left (CantTransport e)
+          Right x -> Right x
 
-      reportSDoc "tc.lhs.unify.inv" 20 $ "=== after mod"
-      do
-          addContext working_tel $ reportSDoc "tc.lhs.unify.inv" 20 $ "tau    :" <+> prettyTCM tau
-          addContext working_tel $ addContext ("r" :: String, __DUMMY_DOM__)
-                                $ reportSDoc "tc.lhs.unify.inv" 20 $ "leftInv:   " <+> prettyTCM leftInv
+    ifNotM cond (return $ Left UnsupportedCxt) $ do
+    equivs <- forM log $ uncurry buildEquiv
+    case sequence equivs of
+      Left no -> do
+        reportSDoc "tc.lhs.unify.inv.badstep" 20 $ "No Left Inverse:" <+> prettyTCM (badStep no)
+        return (Left no)
+      Right xs -> runExceptT (compose xs) >>= \case
+        Left no -> return (Left no)
+        Right (_, _, tau0, leftInv0) -> do
+        -- Γ,φ,us =_Δ vs ⊢ τ0 : Γ', φ
+        -- leftInv0 : [wkS |φ,us =_Δ vs| ρ,1,refls][τ] = idS : Γ,φ,us =_Δ vs
+        let tau = tau0 `composeS` raiseS 1
+        unview <- intervalUnview'
+        let replaceAt n x xs = xs0 ++ x:xs1
+                    where (xs0,_:xs1) = splitAt n xs
+        let max r s = unview $ IMax (argN r) (argN s)
+            neg r = unview $ INeg (argN r)
+        let phieq = neg (var 0) `max` var (size (eqTel s0) + 1)
+                          -- I + us =_Δ vs -- inplaceS
+        let leftInv = termsS __IMPOSSIBLE__ $ replaceAt (size (varTel s0)) phieq $ map (lookupS leftInv0) $ downFrom (size (varTel s0) + 1 + size (eqTel s0))
+        let working_tel = abstract (varTel s0) (ExtendTel __DUMMY_DOM__ $ Abs "phi0" $ (eqTel s0))
+        reportSDoc "tc.lhs.unify.inv" 20 $ "=== before mod"
+        do
+            addContext working_tel $ reportSDoc "tc.lhs.unify.inv" 20 $ "tau0    :" <+> prettyTCM tau0
+            addContext working_tel $ addContext ("r" :: String, __DUMMY_DOM__)
+                                  $ reportSDoc "tc.lhs.unify.inv" 20 $ "leftInv0:  " <+> prettyTCM leftInv0
 
-      return $ Right (tau,leftInv)
+        reportSDoc "tc.lhs.unify.inv" 20 $ "=== after mod"
+        do
+            addContext working_tel $ reportSDoc "tc.lhs.unify.inv" 20 $ "tau    :" <+> prettyTCM tau
+            addContext working_tel $ addContext ("r" :: String, __DUMMY_DOM__)
+                                  $ reportSDoc "tc.lhs.unify.inv" 20 $ "leftInv:   " <+> prettyTCM leftInv
+
+        return $ Right (tau,leftInv)
 
 type Retract = (Telescope, Substitution, Substitution, Substitution)
      -- Γ (the problem, including equalities),
@@ -125,7 +165,7 @@ type Retract = (Telescope, Substitution, Substitution, Substitution)
 termsS ::  DeBruijn a => Impossible -> [a] -> Substitution' a
 termsS e xs = reverse xs ++# EmptyS e
 
-composeRetract :: (PureTCM tcm, MonadError TCErr tcm, MonadDebug tcm, HasBuiltins tcm, MonadAddContext tcm) => Retract -> Term -> Retract -> tcm (Either (Closure (Abs Type)) Retract)
+composeRetract :: Retract -> Term -> Retract -> TCM (Either (Closure (Abs Type)) Retract)
 composeRetract (prob0,rho0,tau0,leftInv0) phi0 (prob1,rho1,tau1,leftInv1) = do
   reportSDoc "tc.lhs.unify.inv" 20 $ "=== composing"
   reportSDoc "tc.lhs.unify.inv" 20 $ "Γ0   :" <+> prettyTCM prob0
@@ -225,11 +265,14 @@ composeRetract (prob0,rho0,tau0,leftInv0) phi0 (prob1,rho1,tau1,leftInv1) = do
           reportSDoc "tc.lhs.unify.inv" 40 $ "leftInvSub :" <+> pretty sigma
       return $ Right (prob, rho, tau, sigma)
 
-buildEquiv :: forall tcm. (PureTCM tcm, MonadError TCErr tcm) => UnifyLogEntry -> UnifyState -> tcm (Either NoLeftInv (Retract,Term))
-buildEquiv (UnificationStep st step@(Solution k ty fx tm side) output) next = runExceptT $ do
+buildEquiv :: DigestedUnifyLogEntry -> UnifyState -> TCM (Either NoLeftInv (Retract,Term))
+buildEquiv (DUnificationStep st step@(DSolution k ty fx tm side) output) next = runExceptT $ do
         let
-          errorToUnsupported :: ExceptT a tcm b -> ExceptT NoLeftInv tcm b
-          errorToUnsupported m = withExceptT (\ _ -> UnsupportedYet step) m
+          cantTransport' :: ExceptT (Closure Type) TCM b -> ExceptT NoLeftInv TCM b
+          cantTransport' m = withExceptT CantTransport' m
+          cantTransport :: ExceptT (Closure (Abs Type)) TCM b -> ExceptT NoLeftInv TCM b
+          cantTransport m = withExceptT CantTransport m
+
         reportSDoc "tc.lhs.unify.inv" 20 $ "step unifyState:" <+> prettyTCM st
         reportSDoc "tc.lhs.unify.inv" 20 $ "step step:" <+> addContext (varTel st) (prettyTCM step)
         unview <- intervalUnview'
@@ -250,7 +293,7 @@ buildEquiv (UnificationStep st step@(Solution k ty fx tm side) output) next = ru
         let gamma_phis = abstract gamma $ telFromList $
               map (defaultDom . (,interval) . ("phi" ++) . show) [0 .. phis - 1]
         working_tel <- abstract gamma_phis <$>
-          errorToUnsupported (pathTelescope' (raise phis $ eqTel st) (raise phis $ eqLHS st) (raise phis $ eqRHS st))
+          cantTransport' (pathTelescope' (raise phis $ eqTel st) (raise phis $ eqLHS st) (raise phis $ eqRHS st))
         reportSDoc "tc.lhs.unify.inv" 20 $ vcat
           [ "working tel:" <+> prettyTCM (working_tel :: Telescope)
           , addContext working_tel $ "working tel args:" <+> prettyTCM (teleArgs working_tel :: [Arg Term])
@@ -327,7 +370,7 @@ buildEquiv (UnificationStep st step@(Solution k ty fx tm side) output) next = ru
           let flag = True
                  {-   φ -}
           tau <- {-dropAt (size gamma - 1 + k) .-} (gamma1_args ++) <$>
-                                                   lift (errorToUnsupported (transpTel' flag d phi d_zero_args))
+                                                   lift (cantTransport (transpTel' flag d phi d_zero_args))
           reportSDoc "tc.lhs.unify.inv" 20 $ "tau    :" <+> prettyTCM (map (setHiding NotHidden) tau)
           leftInv <- do
             gamma1_args <- open gamma1_args
@@ -347,7 +390,7 @@ buildEquiv (UnificationStep st step@(Solution k ty fx tm side) output) next = ru
             delta0 <- open delta0
             xi0f <- bind "i" $ \ i -> do
                                  m <- trFillTel' flag <$> delta0 <*> phi <*> xi0 <*> i
-                                 lift (errorToUnsupported m)
+                                 lift (cantTransport m)
             xi0f <- open xi0f
 
             delta1 <- bind "i" $ \ i -> do
@@ -357,7 +400,7 @@ buildEquiv (UnificationStep st step@(Solution k ty fx tm side) output) next = ru
             delta1 <- open delta1
             xi1f <- bind "i" $ \ i -> do
                                  m <- trFillTel' flag <$> delta1 <*> phi <*> xi1 <*> i
-                                 lift (errorToUnsupported m)
+                                 lift (cantTransport m)
             xi1f <- open xi1f
             fmap absBody $ bind "i" $ \ i' -> do
               let (+++) m = liftM2 (++) m
@@ -399,7 +442,7 @@ buildEquiv (UnificationStep st step@(Solution k ty fx tm side) output) next = ru
                  , termsS __IMPOSSIBLE__ $ map unArg tau
                  , termsS __IMPOSSIBLE__ $ map unArg leftInv)
                  , phi)
-buildEquiv (UnificationStep st step@(EtaExpandVar fv _d _args) output) next = fmap Right $ do
+buildEquiv (DUnificationStep st step@(DEtaExpandVar fv _d _args) output) next = fmap Right $ do
         reportSDoc "tc.lhs.unify.inv" 20 "buildEquiv EtaExpandVar"
         let
           gamma = varTel st
@@ -420,18 +463,6 @@ buildEquiv (UnificationStep st step@(EtaExpandVar fv _d _args) output) next = fm
           reportSDoc "tc.lhs.unify.inv" 20 $ addContext working_tel $ "tau    :" <+> prettyTCM tau
           return $ ((working_tel,rho,tau,raiseS 1),phi)
 
-buildEquiv (UnificationStep st step output) _ = do
-  reportSDoc "tc.lhs.unify.inv" 20 $ "steps"
-  let illegal     = return $ Left $ Illegal step
-      unsupported = return $ Left $ UnsupportedYet step
-  case step of
-    Deletion{}           -> illegal
-    TypeConInjectivity{} -> illegal
-    -- These should end up in a NoUnify
-    Conflict{}    -> __IMPOSSIBLE__
-    LitConflict{} -> __IMPOSSIBLE__
-    Cycle{}       -> __IMPOSSIBLE__
-    _ -> unsupported
 
 {-# SPECIALIZE explainStep :: UnifyStep -> TCM Doc #-}
 explainStep :: MonadPretty m => UnifyStep -> m Doc

--- a/test/Succeed/Issue1292b.warn
+++ b/test/Succeed/Issue1292b.warn
@@ -1,12 +1,3 @@
-Issue1292b.agda:15.1-17.30: warning: -W[no]UnsupportedIndexedMatch
-This clause uses pattern-matching features that are not yet
-supported by Cubical Agda, the function to which it belongs will
-not compute when applied to transports.
-
-Reason: It relies on substitution in Setω, which is not yet
-        supported
-
-when checking the definition of sub
 
 Issue1292b.agda:15.1-17.30: warning: -W[no]UnsupportedIndexedMatch
 This clause uses pattern-matching features that are not yet
@@ -18,13 +9,21 @@ Reason: It relies on the injectivity of size successors, which is
 
 when checking the definition of sub
 
+Issue1292b.agda:15.1-17.30: warning: -W[no]UnsupportedIndexedMatch
+This clause uses pattern-matching features that are not yet
+supported by Cubical Agda, the function to which it belongs will
+not compute when applied to transports.
+
+Reason: The type Size can not be transported
+
+when checking the definition of sub
+
 Issue1292b.agda:21.1-22.40: warning: -W[no]UnsupportedIndexedMatch
 This clause uses pattern-matching features that are not yet
 supported by Cubical Agda, the function to which it belongs will
 not compute when applied to transports.
 
-Reason: It relies on substitution in Setω, which is not yet
-        supported
+Reason: The type Size can not be transported
 
 when checking the definition of div'
 
@@ -35,8 +34,8 @@ This clause uses pattern-matching features that are not yet
 supported by Cubical Agda, the function to which it belongs will
 not compute when applied to transports.
 
-Reason: It relies on substitution in Setω, which is not yet
-        supported
+Reason: It relies on the injectivity of size successors, which is
+        not yet supported
 
 when checking the definition of sub
 
@@ -45,8 +44,7 @@ This clause uses pattern-matching features that are not yet
 supported by Cubical Agda, the function to which it belongs will
 not compute when applied to transports.
 
-Reason: It relies on the injectivity of size successors, which is
-        not yet supported
+Reason: The type Size can not be transported
 
 when checking the definition of sub
 
@@ -55,7 +53,6 @@ This clause uses pattern-matching features that are not yet
 supported by Cubical Agda, the function to which it belongs will
 not compute when applied to transports.
 
-Reason: It relies on substitution in Setω, which is not yet
-        supported
+Reason: The type Size can not be transported
 
 when checking the definition of div'

--- a/test/interaction/Issue6787-2.out
+++ b/test/interaction/Issue6787-2.out
@@ -6,5 +6,5 @@
 ((last . 1) . (agda2-goals-action '(0)))
 (agda2-give-action 0 "refl")
 (agda2-status-action "")
-(agda2-info-action "*All Warnings*" "Issue6787-2.agda:6.7-11: warning: -W[no]UnsupportedIndexedMatch This clause uses pattern-matching features that are not yet supported by Cubical Agda, the function to which it belongs will not compute when applied to transports. Reason: it relies on higher-dimensional unification, which is not yet supported when checking that the expression ? has type refl ≡ refl" nil)
+(agda2-info-action "*All Warnings*" "Issue6787-2.agda:6.7-11: warning: -W[no]UnsupportedIndexedMatch This clause uses pattern-matching features that are not yet supported by Cubical Agda, the function to which it belongs will not compute when applied to transports. Reason: It relies on injectivity of the data constructor refl, which is not yet supported when checking that the expression ? has type refl ≡ refl" nil)
 ((last . 1) . (agda2-goals-action '()))


### PR DESCRIPTION
- Remove unnecessary left inverse computations.
  - Previously, when checking clause bodies, the left inverses were computed and immediately discarded. Now they are not computed.
  - Previously, if a `UnifyLog` contained an unsupported step in left inversion, we would fully compute the left inverse from the log until we hit the offending step. Now, we first detect unsupported steps in the log and only build actual terms after that. 
- Rearrange benchmarking for `UnifyIndices`. `UnifyIndices` can be called from `Typing` and from `Coverage` and used to belong to both. Now it is its own entry and also has left inverse building as a sub-entry. I don't have strong feelings about the `UnifyIndices` change, but the addition of the left inversion benchmark is IMO well justified. 

`std-lib` times:

|      | master | PR |
|-----|------------|------|
| Total | 140,088ms | 135,489ms |
| UnifyIndices (total) | 14,010ms | 8,804ms |
| Total alloc | 607.4G | 573.4G |

Note that the left inverses which are actually used, are still computed, so most of the overhead of left inversion is still present.

