### PR TITLE
Fix #8126: don't error-report generalized variables as projections

### DIFF
--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -939,8 +939,8 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = noMutualBlock $ d
   let freshQName s = qualify current <$> freshName_ (s :: String)
       mkFieldName  = freshQName . (generalizedFieldName ++) <=< getMetaNameSuggestion
   genRecFields <- mapM (defaultDom <.> mkFieldName) sortedMetas
-  genRecName   <- freshQName "GeneralizeTel"
-  genRecCon    <- freshQName "mkGeneralizeTel" <&> \ con -> ConHead
+  genRecName   <- freshQName generalizeRecordName
+  genRecCon    <- freshQName generalizeConstructorName <&> \ con -> ConHead
                   { conName      = con
                   , conDataRecord= IsRecord CopatternMatching
                   , conInductive = Inductive

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -6502,6 +6502,14 @@ absurdLambdaName = ".absurdlambda"
 isAbsurdLambdaName :: QName -> Bool
 isAbsurdLambdaName = (absurdLambdaName ==) . prettyShow . qnameName
 
+-- | Name for telescope (record) of generalized variables.
+generalizeRecordName :: String
+generalizeRecordName = ".GeneralizeTel"
+
+-- | Name for the record constructor for the generalized variables.
+generalizeConstructorName :: String
+generalizeConstructorName = ".mkGeneralizeTel"
+
 -- | Base name for generalized variable projections.
 generalizedFieldName :: String
 generalizedFieldName = ".generalizedField-"

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -6502,11 +6502,11 @@ absurdLambdaName = ".absurdlambda"
 isAbsurdLambdaName :: QName -> Bool
 isAbsurdLambdaName = (absurdLambdaName ==) . prettyShow . qnameName
 
--- | Base name for generalized variable projections
+-- | Base name for generalized variable projections.
 generalizedFieldName :: String
 generalizedFieldName = ".generalizedField-"
 
--- | Check whether we have a generalized variable field
+-- | Check whether we have a generalized variable field.
 getGeneralizedFieldName :: A.QName -> Maybe String
 getGeneralizedFieldName = List.stripPrefix generalizedFieldName . prettyShow . nameConcrete . qnameName
 

--- a/test/Fail/Issue8126.agda
+++ b/test/Fail/Issue8126.agda
@@ -1,0 +1,25 @@
+-- Andreas, 2025-10-06, issue #8126
+-- Do not print generalized variables as projections.
+
+-- {-# OPTIONS -v tc.error.mismatchedProjections:40 #-}
+
+open import Agda.Builtin.Equality
+
+postulate
+  A : Set
+  P : A → Set
+  c : A
+
+variable
+  a b : A
+
+postulate
+  foo : (x : P a) (y : P b) → x ≡ y
+
+-- WAS error: [MismatchedProjectionsError]
+-- The projections b and a do not match
+-- when checking that the expression y has type P a
+
+-- Expected error: [UnequalTerms]
+-- b != a
+-- when checking that the expression y has type P a

--- a/test/Fail/Issue8126.err
+++ b/test/Fail/Issue8126.err
@@ -1,0 +1,3 @@
+Issue8126.agda:17.35-36: error: [UnequalTerms]
+b != a
+when checking that the expression y has type P a


### PR DESCRIPTION
- **Fix #8126: no MismatchedProjections erro for generalized variables**
  

- **Cosmetics: make GeneralizeTel name invalid by prefixing with dot**
  