### PR TITLE
Make 'getInteractionPoints' only return unsolved metas

### DIFF
--- a/src/full/Agda/Interaction/Base.hs
+++ b/src/full/Agda/Interaction/Base.hs
@@ -46,6 +46,26 @@ data CommandState = CommandState
     --   recorded in 'theTCState', but when new interaction points are
     --   added by give or refine Agda does not ensure that the ranges
     --   of later interaction points are updated.
+    --
+    --   For example, consider a term @cons ?0 ?1@ with some ranges @r0@ @r1@@
+    --   for the two interaction points.
+    --   We refine @?0 := cons ?2 ?3@.
+    --   The new interaction points will get ranges @r2 = r3 = r0@.
+    --   We cannot do much better than that, as they are constrained by
+    --   @r0 ≤ r2 ≤ r3 < r1@.
+    --   At this point @('Range','InteractionId')@ still orders the IPs correctly.
+    --   Now we refine @?2 := cons ?4 ?5@ with @r4 = r5 = r2@;
+    --   this breaks the order maintained by @('Range','InteractionId')@.
+    --
+    --   So we need some other structure to remember the correct order of IPs.
+    --   The list 'theInteractionPoints' serves this purpose.
+    --
+    --   Alternatively, we could maintain for entries in 'InteractionPoints'
+    --   a path @p : Genesis = [Int]@ into their genesis tree.
+    --   E.g. for @?2@ we would have @p2 = [0]@ (the first child of @?0@)
+    --   and @p3 = [1]@ (the second child of @?0@).
+    --   Then @p4 = [0,0]@ and @p5 = [0,1]@.
+    --   The order @('Range','Genesis')@ would be correct then.
   , theCurrentFile       :: Maybe CurrentFile
     -- ^ The file which the state applies to. Only stored if the
     -- module was successfully type checked (potentially with

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -940,7 +940,7 @@ give_gen
   -> CommandM ()
 give_gen force ii rng s0 giveRefine = do
   let s = trim s0
-  reportSLn "interaction.give" 20 $ "give_gen  " ++ s
+  reportSDoc "interaction.give" 20 $ TCP.text ("give_gen  " ++ s) TCP.<+> TCP.pretty rng
   -- Andreas, 2015-02-26 if string is empty do nothing rather
   -- than giving a parse error.
   unless (null s) $ do
@@ -972,9 +972,9 @@ give_gen force ii rng s0 giveRefine = do
     iis' <- sortInteractionPoints iis
     modifyTheInteractionPoints $ replace ii iis'
     -- print abstract expr
-    ce        <- abstractToConcreteScope scope ae
+    ce <- abstractToConcreteScope scope ae
     reportS "interaction.give" 30
-      [ "ce = " ++ show ce
+      [ "ce = " ++ prettyShow ce
       , "scopePrecedence = " ++ show (scope ^. scopePrecedence)
       ]
 

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -131,7 +131,16 @@ data Position' a = Pn'
     -- ^ Position, counting from 1.
   , posLineCol :: !Word64 -- ^ Line and position numbers as Word32, both counting from 1.
   }
-  deriving (Show, Functor, Foldable, Traversable, Generic)
+  deriving (Functor, Foldable, Traversable, Generic)
+
+instance Show a => Show (Position' a) where
+  showsPrec :: Show a => Int -> Position' a -> ShowS
+  showsPrec i (Pn a p l c) = showParen (i > 10) $
+    showString "Pn " .
+    showsPrec 11 a . showChar ' ' .
+    showsPrec 11 p . showChar ' ' .
+    showsPrec 11 l . showChar ' ' .
+    showsPrec 11 c
 
 pattern Pn :: a -> Word32 -> Word32 -> Word32 -> Position' a
 pattern Pn a p l c <- Pn' a p (splitW64 -> (l, c)) where

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -618,10 +618,15 @@ removeInteractionPoint :: MonadInteractionPoints m => InteractionId -> m ()
 removeInteractionPoint ii =
   modifyInteractionPoints $ BiMap.update (\ ip -> Just ip{ ipSolved = True }) ii
 
--- | Get a list of interaction ids.
+-- | Get a list of unsolved interaction ids.
 {-# SPECIALIZE getInteractionPoints :: TCM [InteractionId] #-}
 getInteractionPoints :: ReadTCState m => m [InteractionId]
-getInteractionPoints = BiMap.keys <$> useR stInteractionPoints
+getInteractionPoints =
+  map fst . filter (not . ipSolved . snd) . BiMap.toList <$> useR stInteractionPoints
+  -- The following alternative will not include the unreachable IPs
+  -- (e.g. test/interaction/Issue2807).
+  -- This might lead to a wrong numbering of ?s.
+  -- map fst <$> getInteractionIdsAndMetas
 
 -- | Get all metas that correspond to unsolved interaction ids.
 getInteractionMetas :: ReadTCState m => m [MetaId]


### PR DESCRIPTION
When looking into #8130, I wondered whether the implementation of "give" could be simplified, in particular, whether we need to maintain `theInteractionPoints`.  Turns out it is not subsumed, so I added documentation to why that is the case.
On the way, I also realized that `Show Position` got broken by an optimization (#8065).

- **Restore Show Position instance to print line and column**
  A previous refactoring lumped line and column into a single Word64, an
  printing this literally did not give meaningful information.
  

- **Some debug printing updated for "give"**
  

- **Explain the purpose of 'theInteractionPoints' by example**
  

- **Optimise 'getInteractionPoints' to only return the unsolved IPs**
  It seems that client code actually expects this.
  Does not affect the interaction tests; client code does not seem to
  rely on 'getInteractionPoints' returning only the unsolved ones.
  