### PR TITLE
Refactor: inline alreadyVisited in getInterface

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -936,7 +936,7 @@ createInterfaceIsolated
 createInterfaceIsolated x file msrc = do
       cleanCachedLog
 
-      ms          <- getImportStack
+      ms          <- asksTC envImportStack
       range       <- asksTC envRange
       call        <- asksTC envCall
       mf          <- useTC stModuleToSource
@@ -961,7 +961,6 @@ createInterfaceIsolated x file msrc = do
            -- The cache should not be used for an imported module, and it
            -- should be restored after the module has been type-checked
            freshTCM $
-             withImportStack ms $
              localTC (\e -> e
                               -- Andreas, 2014-08-18:
                               -- Preserve the range of import statement
@@ -969,6 +968,7 @@ createInterfaceIsolated x file msrc = do
                               -- imported modules:
                             { envRange              = range
                             , envCall               = call
+                            , envImportStack        = ms
                             }) $ do
                setDecodedModules ds
                setCommandLineOptions opts

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -1020,9 +1020,9 @@ give_gen force ii rng s0 giveRefine = do
 
 highlightExpr :: A.Expr -> TCM ()
 highlightExpr e =
-  localTC (\st -> st { envImportPath         = []
-                     , envHighlightingLevel  = NonInteractive
-                     , envHighlightingMethod = Direct }) $
+  localTC (\ env -> env { envImportStack        = []
+                        , envHighlightingLevel  = NonInteractive
+                        , envHighlightingMethod = Direct }) $
     generateAndPrintSyntaxInfo decl Full True
   where
     dummy = mkName_ (NameId 0 noModuleNameHash) ("dummy" :: String)

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4025,7 +4025,7 @@ ifTopLevelAndHighlightingLevelIsOr ::
 ifTopLevelAndHighlightingLevelIsOr l b m = do
   e <- askTC
   when (envHighlightingLevel e >= l || b) $
-    case (envImportPath e) of
+    case (envImportStack e) of
       -- Below the main module.
       (_:_:_) -> pure ()
       -- In or before the top-level module.
@@ -4053,7 +4053,7 @@ data TCEnv =
             -- type-checked.  'Nothing' if we do not have a file
             -- (like in interactive mode see @CommandLine@).
           , envAnonymousModules    :: [(ModuleName, Nat)] -- ^ anonymous modules and their number of free variables
-          , envImportPath          :: [TopLevelModuleName]
+          , envImportStack         :: [TopLevelModuleName]
             -- ^ The module stack with the entry being the top-level module as
             --   Agda chases modules. It will be empty if there is no main
             --   module, will have a single entry for the top level module, or
@@ -4214,7 +4214,7 @@ initEnv = TCEnv { envContext             = []
                 , envCurrentModule       = noModuleName
                 , envCurrentPath         = Nothing
                 , envAnonymousModules    = []
-                , envImportPath          = []
+                , envImportStack         = []
                 , envMutualBlock         = Nothing
                 , envTerminationCheck    = TerminationCheck
                 , envCoverageCheck       = YesCoverageCheck
@@ -4311,8 +4311,8 @@ eCurrentPath f e = f (envCurrentPath e) <&> \ x -> e { envCurrentPath = x }
 eAnonymousModules :: Lens' TCEnv [(ModuleName, Nat)]
 eAnonymousModules f e = f (envAnonymousModules e) <&> \ x -> e { envAnonymousModules = x }
 
-eImportPath :: Lens' TCEnv [TopLevelModuleName]
-eImportPath f e = f (envImportPath e) <&> \ x -> e { envImportPath = x }
+eImportStack :: Lens' TCEnv [TopLevelModuleName]
+eImportStack f e = f (envImportStack e) <&> \ x -> e { envImportStack = x }
 
 eMutualBlock :: Lens' TCEnv (Maybe MutualId)
 eMutualBlock f e = f (envMutualBlock e) <&> \ x -> e { envMutualBlock = x }

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -422,7 +422,7 @@ currentTopLevelModule ::
 currentTopLevelModule = do
   useR stCurrentModule >>= \case
     Just (_, top) -> return (Just top)
-    Nothing       -> listToMaybe <$> asksTC envImportPath
+    Nothing       -> listToMaybe <$> asksTC envImportStack
 
 -- | Use a different top-level module for a computation. Used when generating
 --   names for imported modules.

--- a/src/full/Agda/Utils/Monad.hs
+++ b/src/full/Agda/Utils/Monad.hs
@@ -7,7 +7,7 @@ module Agda.Utils.Monad
     )
     where
 
-import Control.Monad.Except   ( MonadError(catchError, throwError) )
+import Control.Monad.Except   ( MonadError(catchError, throwError), ExceptT, runExceptT )
 import Control.Monad.Identity ( runIdentity )
 import Control.Monad.State    ( MonadState(get, put) )
 import Control.Monad.Writer   ( MonadWriter(tell), Writer, WriterT, mapWriterT )
@@ -293,6 +293,11 @@ tryCatch m = (Nothing <$ m) `catchError` \ err -> return $ Just err
 
 guardWithError :: MonadError e m => e -> Bool -> m ()
 guardWithError e b = if b then return () else throwError e
+
+-- | Handle errors thrown in 'ExceptT'.
+
+catchExceptT :: Monad m => ExceptT e m a -> (e -> m a) -> m a
+catchExceptT m h = either h return =<< runExceptT m
 
 -- State monad ------------------------------------------------------------
 


### PR DESCRIPTION
When I have to read `Agda.Interaction.Imports`, I always despair.
This code has so many indirections that it is very hard to understand what is going on when a module is loaded via `getInterface`.  
As a first step to cut the wild growth I inline `alreadyVisited` into `getInterface`.

For the sake of code comprehension, one should not do continuation-passing style without need and rather stick to first-order constructions where possible.  This refactoring works toward untangling the control-flow.

- **Refactor: rename ImportPath to ImportStack**
  This is really the stack of imports, the previous name could be
  misread as "path of the imported file" or "path to import files from".
  

- **Refactor: imline getImportStack and withImportStack**
  

- **Refactor alreadyVisited: inline useExistingOrLoadAndRecordVisited**
  

- **Refactor alreadyVisited: inline existingWithoutWarning**
  

- **Refactor alreadyVisited: processResultingModule -> addOptionsCompatibilityWarnings**
  

- **Refactor alreadyVisited: inline loadAndRecordVisited**
  

- **Interaction.Imports: simplify getOptionsCompatibilityWarnings**
  Just a plain `ifM` instead of "runMaybeT . exceptToMaybeT"-Geschwurbel.
  

- **Refactor getInterface: use new `catchExceptT` exception handler form**
  

- **Refactor getInterface: inline alreadyVisited**
  