### PR TITLE
Fix #8132 by adding SourceFile to SolvedButOpenHoles error

### DIFF
--- a/src/full/Agda/Interaction/BuildLibrary.hs
+++ b/src/full/Agda/Interaction/BuildLibrary.hs
@@ -103,5 +103,5 @@ checkModule m src = do
   let isInfectiveWarning InfectiveImport{} = True
       isInfectiveWarning _                 = False
       warns = filter (not . isInfectiveWarning . tcWarning) $ Set.toAscList $ miWarnings mi
-  tcWarningsToError warns
+  tcWarningsToError m (Imp.srcOrigin src) warns
   return ()

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -517,7 +517,7 @@ getNonMainInterface
   -> TCM Interface
 getNonMainInterface x msrc = do
   mi <- getNonMainModuleInfo x msrc
-  tcWarningsToError $ Set.toAscList $ miWarnings mi
+  tcWarningsToError x (miSourceFile mi) $ Set.toAscList $ miWarnings mi
   return (miInterface mi)
 
 getNonMainModuleInfo
@@ -785,6 +785,7 @@ getStoredInterface x file@(SourceFile fi) msrc = do
           , miWarnings = empty
           , miPrimitive = isPrimitiveMod
           , miMode = ModuleTypeChecked
+          , miSourceFile = file
           }
 
   -- Check if we have cached the module.
@@ -1320,6 +1321,7 @@ createInterface mname sf@(SourceFile sfi) isMain msrc = do
       , miWarnings = mallWarnings
       , miPrimitive = isPrimitiveMod
       , miMode = moduleCheckMode isMain
+      , miSourceFile = sf
       }
 
 -- | Expert version of 'getAllWarnings'; if 'isMain' is a

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -97,7 +97,8 @@ import Agda.Utils.Impossible
 -- | Preconditions to run the AbstractToConcrete translation.
 --
 type MonadAbsToCon m =
-  ( MonadFresh NameId m
+  ( MonadFileId m
+  , MonadFresh NameId m
   , MonadInteractionPoints m
   , MonadStConcreteNames m
   , HasOptions m
@@ -140,7 +141,8 @@ abstractToConcreteUnqualify = runAbsToCon . doUnqualifyOutOfScopeNames . toConcr
 ---------------------------------------------------------------------------
 
 type MonadToConcrete m =
-  ( MonadAbsToCon m
+  ( MonadFileId m
+  , MonadAbsToCon m
   , MonadReader Env m
   )
 
@@ -152,6 +154,7 @@ newtype AbsToConT m a = AbsToCon { unAbsToCon :: ReaderT Env m a }
     , HasOptions
     , MonadAddContext
     , MonadDebug
+    , MonadFileId
     , MonadInteractionPoints
     , MonadReduce
     , MonadStConcreteNames

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -184,6 +184,7 @@ newtype TerM a = TerM { terM :: ReaderT TerEnv TCM a }
            , HasOptions
            , HasBuiltins
            , MonadDebug
+           , MonadFileId
            , HasConstInfo
            , MonadIO
            , MonadTCEnv

--- a/src/full/Agda/TypeChecking/Conversion/Pure.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Pure.hs
@@ -28,7 +28,7 @@ data FreshThings = FreshThings
 
 newtype PureConversionT m a = PureConversionT
   { unPureConversionT :: ExceptT TCErr (StateT FreshThings m) a }
-  deriving (Functor, Applicative, Monad, MonadError TCErr, MonadState FreshThings, PureTCM)
+  deriving (Functor, Applicative, Monad, MonadError TCErr, MonadState FreshThings, MonadFileId, PureTCM)
 
 {-# SPECIALIZE pureEqualTerm :: Type -> Term -> Term -> TCM Bool #-}
 pureEqualTerm

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -774,9 +774,14 @@ instance PrettyTCM TypeError where
       , text "must not be located in the directory" <+> text (takeDirectory (lib ^. libFile))
       ]
 
-    SolvedButOpenHoles -> fsep $
-      pwords "Module cannot be imported since it has open interaction points" ++
-      pwords "(consider adding {-# OPTIONS --allow-unsolved-metas #-} to this module)"
+    SolvedButOpenHoles x file -> do
+      path <- srcFilePath file
+      let x' = setRange (rangeFromAbsolutePath path) x
+      vcat $
+        [ fsep $ pretty (PrintRange x') :
+            pwords "cannot be imported since it has open interaction points"
+        , "(consider adding {-# OPTIONS --allow-unsolved-metas #-} to that module)"
+        ]
 
     CyclicModuleDependency (List2 m0 m1 ms) ->
       fsep (pwords "cyclic module dependency:")

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -6123,6 +6123,8 @@ instance MonadBlock m => MonadBlock (ReaderT e m) where
   catchPatternErr h m = ReaderT $ \ e ->
     let run = flip runReaderT e in catchPatternErr (run . h) (run m)
 
+instance MonadFileId m => MonadFileId (BlockT m)
+
 ---------------------------------------------------------------------------
 -- * Type checking monad transformer
 ---------------------------------------------------------------------------
@@ -6195,6 +6197,7 @@ instance Monad m => Monad (TCMT m) where
 
 instance (CatchIO m, MonadIO m) => MonadFail (TCMT m) where
   fail = internalError
+  {-# INLINE fail #-}
 
 instance MonadIO m => MonadIO (TCMT m) where
   liftIO m = TCM $ \ s env -> do

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1353,6 +1353,8 @@ data ModuleInfo = ModuleInfo
     -- be importable.
   , miMode       :: ModuleCheckMode
     -- ^ The `ModuleCheckMode` used to create the `Interface`
+  , miSourceFile :: SourceFile
+    -- ^ The file belonging to the module.
   }
   deriving Generic
 
@@ -5383,9 +5385,9 @@ data TypeError
             -- ^ Collected errors when processing the @.agda-lib@ file.
         | LibTooFarDown TopLevelModuleName AgdaLibFile
             -- ^ The @.agda-lib@ file for the given module is not on the right level.
-        | SolvedButOpenHoles
-          -- ^ Some interaction points (holes) have not been filled by user.
-          --   There are not 'UnsolvedMetas' since unification solved them.
+        | SolvedButOpenHoles TopLevelModuleName SourceFile
+          -- ^ Some interaction points (holes) in the given module have not been filled by the user.
+          --   These are not 'UnsolvedMetas' since unification solved them.
           --   This is an error, since interaction points are never filled
           --   without user interaction.
         | CyclicModuleDependency (List2 TopLevelModuleName)

--- a/src/full/Agda/TypeChecking/Monad/Pure.hs
+++ b/src/full/Agda/TypeChecking/Monad/Pure.hs
@@ -28,6 +28,7 @@ class
   , HasConstInfo m
   , MonadAddContext m
   , MonadDebug m
+  , MonadFileId m
   , MonadReduce m
   , MonadTCEnv m
   , ReadTCState m

--- a/src/full/Agda/TypeChecking/Monad/Pure.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Pure.hs-boot
@@ -20,6 +20,7 @@ class
   , HasConstInfo m
   , MonadAddContext m
   , MonadDebug m
+  , MonadFileId m
   , MonadReduce m
   , MonadTCEnv m
   , ReadTCState m

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -347,6 +347,12 @@ instance MonadIO m => MonadFileId (TCMT m) where
   fileFromId fi = useTC stFileDict <&> (`getIdFile` fi)
   idFromFile = stateTCLens stFileDict . registerFileIdWithBuiltin
 
+instance MonadFileId ReduceM where
+  fileFromId fi = useTC stFileDict <&> (`getIdFile` fi)
+  idFromFile = __IMPOSSIBLE__
+    -- we cannot write to the state here, so we cannot do sth like
+    -- stateTCLens stFileDict . registerFileIdWithBuiltin
+
 -- | Does the given 'FileId' belong to one of Agda's builtin modules?
 
 isBuiltinModule :: ReadTCState m => FileId -> m (Maybe IsBuiltinModule)

--- a/src/full/Agda/TypeChecking/Monad/State.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/State.hs-boot
@@ -1,0 +1,6 @@
+module Agda.TypeChecking.Monad.State where
+
+import Control.Monad.IO.Class (MonadIO)
+import Agda.TypeChecking.Monad.Base (MonadFileId, TCMT)
+
+instance MonadIO m => MonadFileId (TCMT m)

--- a/src/full/Agda/TypeChecking/Names.hs
+++ b/src/full/Agda/TypeChecking/Names.hs
@@ -50,6 +50,7 @@ newtype NamesT m a = NamesT { unName :: ReaderT Names m a }
            , MonadIO
            , HasOptions
            , MonadDebug
+           , MonadFileId
            , MonadTCEnv
            , MonadTCState
            , MonadTCM

--- a/src/full/Agda/TypeChecking/Pretty.hs-boot
+++ b/src/full/Agda/TypeChecking/Pretty.hs-boot
@@ -30,7 +30,8 @@ braces, dbraces, brackets, parens, parensNonEmpty , doubleQuotes, quotes ::
 -- Agda.Syntax.Translation.AbstractToConcrete does not need to be
 -- imported.
 type MonadPretty m =
-  ( MonadFresh NameId m
+  ( MonadFileId m
+  , MonadFresh NameId m
   , MonadInteractionPoints m
   , MonadStConcreteNames m
   , HasOptions m

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -783,10 +783,14 @@ filterTCWarnings wset = case Set.toAscList wset of
 
 
 -- | Turns warnings, if any, into errors.
-tcWarningsToError :: [TCWarning] -> TCM ()
-tcWarningsToError mws = case (unsolvedHoles, otherWarnings) of
+tcWarningsToError ::
+     TopLevelModuleName   -- ^ The module we have checked (which produced the warnings).
+  -> SourceFile           -- ^ The file containing the module.
+  -> [TCWarning]          -- ^ The warnings to turn into errors.
+  -> TCM ()
+tcWarningsToError x file mws = case (unsolvedHoles, otherWarnings) of
    ([], [])                   -> return ()
-   (_unsolvedHoles@(_:_), []) -> typeError SolvedButOpenHoles
+   (_unsolvedHoles@(_:_), []) -> typeError $ SolvedButOpenHoles x file
    (_ , w : ws)               -> typeError $ NonFatalErrors $ Set1.fromList (w :| ws)
    where
    -- filter out unsolved interaction points for imported module so

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -71,6 +71,7 @@ newtype NLM a = NLM { unNLM :: ExceptT Blocked_ (StateT NLMState ReduceM) a }
            , MonadError Blocked_, MonadState NLMState
            , HasBuiltins, HasConstInfo, HasOptions, ReadTCState
            , MonadTCEnv, MonadReduce, MonadAddContext, MonadDebug
+           , MonadFileId
            , PureTCM
            )
 

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -30,7 +30,8 @@ import Data.Text qualified as Text
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Debug
-import Agda.TypeChecking.Monad.Caching
+import Agda.TypeChecking.Monad.Caching  ( areWeCaching )
+import {-# SOURCE #-} Agda.TypeChecking.Monad.State () -- instance MonadFileId TCM
 import {-# SOURCE #-} Agda.TypeChecking.Pretty ( MonadPretty, prettyTCM, vcat, ($$) )
 import {-# SOURCE #-} Agda.TypeChecking.Pretty.Call
 import {-# SOURCE #-} Agda.TypeChecking.Pretty.Warning ( prettyWarning )

--- a/src/full/Agda/Utils/FileId.hs
+++ b/src/full/Agda/Utils/FileId.hs
@@ -5,29 +5,34 @@
 
 module Agda.Utils.FileId where
 
-import           Prelude               hiding (null)
+import Prelude hiding (null)
 
-import           Control.DeepSeq       (NFData)
-import           Control.Monad.Except  (ExceptT)
-import           Control.Monad.Reader  (ReaderT)
-import           Control.Monad.State   (StateT)
-import           Control.Monad.Trans   (MonadTrans, lift)
+import Control.DeepSeq           (NFData)
+import Control.Monad.Except      (ExceptT)
+import Control.Monad.Identity    (IdentityT)
+import Control.Monad.Reader      (ReaderT)
+import Control.Monad.State       (StateT)
+import Control.Monad.Trans       (MonadTrans, lift)
+import Control.Monad.Trans.Maybe (MaybeT)
+import Control.Monad.Writer      (WriterT)
 
-import           Data.Bifunctor        (second)
-import           Data.EnumMap          (EnumMap)
-import qualified Data.EnumMap          as EnumMap
-import           Data.Map              (Map)
-import qualified Data.Map              as Map
-import           Data.Maybe            (fromMaybe)
-import           Data.Word             (Word32)
+import Data.Bifunctor            (second)
+import Data.EnumMap              (EnumMap)
+import Data.EnumMap qualified    as EnumMap
+import Data.Map                  (Map)
+import Data.Map qualified        as Map
+import Data.Maybe                (fromMaybe)
+import Data.Word                 (Word32)
 
-import           GHC.Generics          (Generic)
+import GHC.Generics              (Generic)
 
-import           Agda.Utils.CallStack  (HasCallStack)
-import           Agda.Utils.FileName   (AbsolutePath)
-import           Agda.Utils.Null       (Null(..))
+import Agda.Utils.CallStack      (HasCallStack)
+import Agda.Utils.FileName       (AbsolutePath)
+import Agda.Utils.ListT          (ListT)
+import Agda.Utils.Null           (Null(..))
+import Agda.Utils.Update         (ChangeT)
 
-import Agda.Utils.Impossible (__IMPOSSIBLE__)
+import Agda.Utils.Impossible
 
 type File = AbsolutePath
 
@@ -96,8 +101,13 @@ class Monad m => MonadFileId m where
   idFromFile = lift . idFromFile
 
 instance MonadFileId m => MonadFileId (ExceptT e m)
+instance MonadFileId m => MonadFileId (IdentityT m)
+instance MonadFileId m => MonadFileId (ListT m)
+instance MonadFileId m => MonadFileId (MaybeT m)
 instance MonadFileId m => MonadFileId (ReaderT r m)
 instance MonadFileId m => MonadFileId (StateT s m)
+instance (MonadFileId m, Monoid w) => MonadFileId (WriterT w m)
+instance MonadFileId m => MonadFileId (ChangeT m)
 
 -- Instances for GetFileId
 

--- a/test/Fail/Issue1296.agda
+++ b/test/Fail/Issue1296.agda
@@ -1,3 +1,14 @@
+-- Test importing a module with a solved interaction point.
+-- See Issue1296 for the same with an unsolved one.
+
+module Issue1296 where
+
 open import Issue1296.SolvedMeta
 
 -- Expected error:
+-- error: [SolvedButOpenHoles]
+-- Issue1296.SolvedMeta (at Issue1296/SolvedMeta.agda:1.1)
+-- cannot be imported since it has open interaction points
+-- (consider adding {-# OPTIONS --allow-unsolved-metas #-} to that module)
+-- when scope checking the declaration
+--   open import Issue1296.SolvedMeta

--- a/test/Fail/Issue1296.err
+++ b/test/Fail/Issue1296.err
@@ -1,6 +1,6 @@
-Issue1296.agda:1.1-33: error: [SolvedButOpenHoles]
-Module cannot be imported since it has open interaction points
-(consider adding {-# OPTIONS --allow-unsolved-metas #-} to this
-module)
+Issue1296.agda:6.1-33: error: [SolvedButOpenHoles]
+Issue1296.SolvedMeta (at Issue1296/SolvedMeta.agda:1.1)
+cannot be imported since it has open interaction points
+(consider adding {-# OPTIONS --allow-unsolved-metas #-} to that module)
 when scope checking the declaration
   open import Issue1296.SolvedMeta

--- a/test/Fail/Issue1296/SolvedMeta.agda
+++ b/test/Fail/Issue1296/SolvedMeta.agda
@@ -1,7 +1,9 @@
+-- A module with a solved interaction point.
+
 module Issue1296.SolvedMeta where
 
-open import Common.Prelude
-open import Common.Equality
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
 
 test : zero ≡ {!!}
 test = refl

--- a/test/Fail/Issue2369.agda
+++ b/test/Fail/Issue2369.agda
@@ -1,4 +1,6 @@
 -- Andreas, 2016-12-30 test case for #2369
+-- Test importing a module with an unsolved interaction point.
+-- See Issue1296 for the same with a solved interaction point.
 
 -- {-# OPTIONS --allow-unsolved-metas #-}
 -- {-# OPTIONS -v scope.import:20 #-}

--- a/test/Fail/Issue2369.err
+++ b/test/Fail/Issue2369.err
@@ -1,6 +1,6 @@
-Issue2369.agda:8.1-24: error: [SolvedButOpenHoles]
-Module cannot be imported since it has open interaction points
-(consider adding {-# OPTIONS --allow-unsolved-metas #-} to this
-module)
+Issue2369.agda:10.1-24: error: [SolvedButOpenHoles]
+Issue2369.OpenIP (at Issue2369/OpenIP.agda:1.1)
+cannot be imported since it has open interaction points
+(consider adding {-# OPTIONS --allow-unsolved-metas #-} to that module)
 when scope checking the declaration
   import Issue2369.OpenIP


### PR DESCRIPTION
- **Refactor for #8132: (partial) instance MonadFileId ReduceM**
  

- **Fix #8132 by adding SourceFile to ModuleInfo and SolvedButOpenHoles**
  This communicates the path to the error that a module cannot be
  imported because of open interaction points.
  
A bit more than 6hrs (this PR and #8133 prompted by this issue).

Update: fixes #2369 (duplicate issue)
- #2369