### PR TITLE
#8112: Add CannotEliminateWithPattern to the errors that can be deferred

### DIFF
--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -397,6 +397,13 @@ instance Semigroup LiveNames where
 instance Monoid LiveNames where
   mempty = SomeLiveNames mempty mempty
 
+instance Pretty LiveNames where
+  pretty AllLiveNames = "*"
+  pretty (SomeLiveNames mod name) = braces $ vcat
+    [ "mods: " <+> pretty mod
+    , "names:" <+> pretty name
+    ]
+
 -- | Is the given name alive in this set?
 --
 -- Note: a qualified name can be kept alive by liveness of any of the

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -771,6 +771,10 @@ sameTrimming old new | renPublic old, renPublic new = pure True
 sameTrimming old new = do
   a <- readLiveNames (renTrimming old)
   b <- readLiveNames (renTrimming new)
+  reportSDoc "cache.trimming" 100 $ pure $ vcat
+    [ "old trimming:" <+> pretty a
+    , "new trimming:" <+> pretty b
+    ]
   pure (a == b)
 
 clobberLiveNames :: ScopeM ()

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -344,7 +344,7 @@ instance PrettyTCM TypeError where
         A.AsP _ _ p -> kindOfPattern p
         A.PatternSynP{} -> __IMPOSSIBLE__
 
-    CannotEliminateWithProjection ty isAmbiguous projection -> sep
+    CannotEliminateWithProjection _ ty isAmbiguous projection -> sep
         [ "Cannot eliminate type "
         , prettyTCM (unArg ty)
         , " with projection "

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5209,7 +5209,7 @@ data TypeError
         | IllformedProjectionPatternAbstract A.Pattern
         | IllformedProjectionPatternConcrete C.Pattern
         | CannotEliminateWithPattern (Maybe Blocker) (NamedArg A.Pattern) Type
-        | CannotEliminateWithProjection (Arg Type) Bool QName
+        | CannotEliminateWithProjection (Maybe Blocker) (Arg Type) Bool QName
         | WrongNumberOfConstructorArguments QName Nat Nat
         | ShouldBeEmpty Type [DeBruijnPattern]
             -- ^ Type should be empty. The list gives possible patterns that match, but can be empty.

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -135,7 +135,7 @@ checkDeclCached d = do
     -- variables or a field in the TC state.
     Just (Decl d'@(A.Apply _ _ _ _ ci' _), s)
       | compareDecl d d', A.Apply _ _ _ _ ci _ <- d ->
-      ifM (sameTrimming ci ci')
+      ifM (sameTrimming ci' ci)
         {- then -} (reportSLn "cache.decl" 10 "  cache Apply: same trimming" *> reuse s)
         {- else -} (reportSLn "cache.decl" 10 "  cache Apply: diff trimming" *> drop)
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -907,6 +907,7 @@ catchIlltypedPatternBlockedOnMeta m handle = do
         SplitError (UnificationStuck b c tel us vs _) -> b
         SplitError (BlockedType b aClosure)           -> Just b
         CannotEliminateWithPattern b p a              -> b
+        CannotEliminateWithProjection b _ _ _         -> b
         -- Andrea: TODO look for blocking meta in tClosure and its Sort.
         -- SplitError (CannotCreateMissingClause _ _ _ tClosure) ->
         _                                             -> Nothing

--- a/test/Fail/Issue8112a.agda
+++ b/test/Fail/Issue8112a.agda
@@ -1,0 +1,24 @@
+module Issue8112a where
+
+postulate A B : Set
+
+record R : Set₁ where field f1 : Set
+open R
+
+record S (A : Set) : Set₂ where field T : Set₁
+open S
+
+postulate fun : (X : Set) ⦃ t : S X ⦄ → t .T → X
+
+instance
+  S-A : ∀ {X} ⦃ _ : S X ⦄ → S (A → X)
+  S-A ⦃ i ⦄ = record { T = A → i .T }
+
+  S-B : S B
+  S-B = record { T = R }
+
+_ : A → B
+-- sanity check that illegal dot patterns don't get postponed, #8112:
+_ = fun (A → B) λ where
+  a .fun → A
+

--- a/test/Fail/Issue8112a.err
+++ b/test/Fail/Issue8112a.err
@@ -1,0 +1,5 @@
+Issue8112a.agda:23.5-9: error: [CannotEliminateWithPattern]
+Cannot eliminate type R with dot pattern .fun (did you supply too
+many arguments?)
+when checking the clause left hand side
+.extendedlambda0 a .fun

--- a/test/Fail/Issue950b.err
+++ b/test/Fail/Issue950b.err
@@ -1,4 +1,17 @@
-Issue950b.agda:19.1-4: error: [CannotEliminateWithProjection]
-Cannot eliminate type  ?0  with projection  x
-when checking the clause left hand side
-x f
+error: [UnsolvedConstraints]
+Failed to solve the following constraints:
+  Check definition of f : ?0
+    stuck because
+      Issue950b.agda:19.1-4: error: [CannotEliminateWithProjection]
+      Cannot eliminate type  ?0  with projection  x
+      when checking the clause left hand side
+      x f
+    (blocked on _3)
+
+Issue950b.agda:18.5-6: error: [UnsolvedInteractionMetas]
+Unsolved interaction metas at the following locations:
+  Issue950b.agda:18.5-6
+
+Issue950b.agda:18.5-6: error: [UnsolvedMetaVariables]
+Unsolved metas at the following locations:
+  Issue950b.agda:18.5-6

--- a/test/Succeed/Issue8112.agda
+++ b/test/Succeed/Issue8112.agda
@@ -1,0 +1,25 @@
+module Issue8112 where
+
+postulate A B : Set
+
+record R : Set₁ where field f1 : Set
+open R
+
+record S (A : Set) : Set₂ where field T : Set₁
+open S
+
+postulate fun : (X : Set) ⦃ t : S X ⦄ → t .T → X
+
+instance
+  S-A : ∀ {X} ⦃ _ : S X ⦄ → S (A → X)
+  S-A ⦃ i ⦄ = record { T = A → i .T }
+
+  S-B : S B
+  S-B = record { T = R }
+
+_ : A → B
+-- checking the extended lambda is blocked on the instance meta being
+-- solved, but this was not one of the deferrable errors, see #8112
+_ = fun (A → B) λ where
+  a .f1 → A
+


### PR DESCRIPTION
This regresses the error message for #950 turning it from a soft error to an unsolved constraint. Maybe we can turn the unsolved constraint warning into a bespoke error-warning or such?