### PR TITLE
Fix for issue #8097

### DIFF
--- a/src/full/Agda/Interaction/BasicOps.hs
+++ b/src/full/Agda/Interaction/BasicOps.hs
@@ -922,7 +922,7 @@ typeOfMetaMI norm mi =
           , "x    =" TP.<+> TP.pretty x
           ]
         ]
-      reportSDoc "interactive.meta.scope" 20 $ TP.text $ show $ getMetaScope mv
+      reportSDoc "interactive.meta.scope" 90 $ TP.text $ show $ getMetaScope mv
       -- Andreas, 2016-01-19, issue #1783: need piApplyM instead of just piApply
       OfType x <$> reifyUnblocked t
     rewriteJudg mv (IsSort i t) = do

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -1227,7 +1227,7 @@ createInterface mname sf@(SourceFile sfi) isMain msrc = do
     reportSLn "import.iface.create" 15 $ prettyShow mname ++ ": Finished highlighting from type info."
 
     setScope scope
-    reportSLn "scope.top" 50 $ "SCOPE " ++ show scope
+    reportSLn "scope.top" 90 $ "SCOPE " ++ show scope
 
     -- TODO: It would be nice if unsolved things were highlighted
     -- after every mutual block.

--- a/src/full/Agda/Mimer/Mimer.hs
+++ b/src/full/Agda/Mimer/Mimer.hs
@@ -53,7 +53,7 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Reduce (reduce, instantiateFull, instantiate)
 import Agda.TypeChecking.Rules.Term  (makeAbsurdLambda)
-import Agda.TypeChecking.Substitute (apply, NoSubst(..))
+import Agda.TypeChecking.Substitute (apply)
 
 import Agda.Utils.Impossible (__IMPOSSIBLE__)
 import Agda.Utils.Maybe (catMaybes)

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -254,8 +254,18 @@ collectComponents :: Options
                   -> TCM BaseComponents
 collectComponents opts costs ii mDefName whereNames metaId = do
 
+  reportSDoc "mimer.components" 30 $ "collectComponents"
+  reportSDoc "mimer.components" 40 $ nest 2 $ vcat
+     [ "ii =" <+> pretty ii
+     , "mDefName =" <+> pretty mDefName
+     , "whereNames =" <+> pretty whereNames
+     , "metaId =" <+> pretty metaId
+     ]
+
   lhsVars <- collectLHSVars ii
   let recVars = lhsVars <&> \ vars -> [ (tm, NoSubst i) | (tm, Just i) <- vars ]
+
+  reportSDoc "mimer.components" 40 $ "recVars =" <+> pretty recVars
 
   -- Prepare the initial component record
   letVars <- getLetVars (costLet costs)
@@ -398,6 +408,10 @@ collectLHSVars ii = do
     IPNoClause -> makeOpen []
     IPClause{ipcQName = fnName, ipcClauseNo = clauseNr} -> do
       reportSDoc "mimer.components" 40 $ "Collecting LHS vars for" <+> prettyTCM ii
+      reportSDoc "mimer.components" 45 $ nest 2 $ vcat
+        [ "fnName =" <+> pretty fnName
+        , "clauseNr =" <+> pretty clauseNr
+        ]
       info <- getConstInfo fnName
       parCount <- liftTCM getCurrentModuleFreeVars
       case theDef info of

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -34,7 +34,7 @@ import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Conversion (equalType)
 import Agda.TypeChecking.Constraints (noConstraints)
 import Agda.TypeChecking.Telescope (flattenTel, piApplyM)
-import Agda.TypeChecking.Substitute (pattern TelV, telView', piApply, apply, applyE, NoSubst(..))
+import Agda.TypeChecking.Substitute (pattern TelV, telView', piApply, apply, applyE)
 import Agda.Interaction.BasicOps (normalForm)
 import Agda.Interaction.Base (Rewrite(..))
 import Agda.Benchmarking qualified as Bench

--- a/src/full/Agda/Mimer/Types.hs
+++ b/src/full/Agda/Mimer/Types.hs
@@ -15,7 +15,6 @@ import Agda.Syntax.Common (InteractionId, Nat)
 import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad (TCState, CheckpointId, Open, TCEnv, openThing)
 import Agda.TypeChecking.Pretty
-import Agda.TypeChecking.Substitute (NoSubst(..))
 import Agda.Interaction.Base (Rewrite(..))
 import Agda.Utils.Tuple (mapSnd)
 import Agda.Utils.Impossible

--- a/src/full/Agda/Mimer/Types.hs
+++ b/src/full/Agda/Mimer/Types.hs
@@ -151,8 +151,8 @@ noName = Nothing
 addCost :: Cost -> Component -> Component
 addCost cost comp = comp { compCost = cost + compCost comp }
 
-replaceCompMeta :: MetaId -> [MetaId] -> Component -> Component
-replaceCompMeta old new c = c{ compMetas = new ++ List.delete old (compMetas c) }
+deleteCompMeta :: MetaId -> Component -> Component
+deleteCompMeta old c = c{ compMetas = List.delete old (compMetas c) }
 
 ------------------------------------------------------------------------
 -- * SearchOptions

--- a/src/full/Agda/Mimer/Types.hs
+++ b/src/full/Agda/Mimer/Types.hs
@@ -67,9 +67,6 @@ instance Eq SearchBranch where
 instance Ord SearchBranch where
   compare = compare `on` sbCost
 
-addBranchGoals :: [Goal] -> SearchBranch -> SearchBranch
-addBranchGoals goals branch = branch {sbGoals = goals ++ sbGoals branch}
-
 data Goal = Goal
   { goalMeta :: MetaId
   }

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -757,6 +757,11 @@ instance Null (Substitution' a) where
   null IdS = True
   null _   = False
 
+-- | Wrapper for types that do not contain variables (so applying a substitution is the identity).
+--   Useful if you have a structure of types that support substitution mixed with types that don't
+--   and need to apply a substitution to the full structure.
+newtype NoSubst t a = NoSubst { unNoSubst :: a }
+  deriving (Generic, NFData, Functor)
 
 ---------------------------------------------------------------------------
 -- * Views
@@ -1537,6 +1542,9 @@ instance Pretty a => Pretty (Blocked a) where
     NotBlocked ReallyNotBlocked a -> pretty a
     NotBlocked nb a -> pretty a <+> ("[ blocked on" <+> pretty nb <+> "]")
     Blocked     b a -> pretty a <+> ("[ stuck on" <+> pretty  b <+> "]")
+
+instance Pretty a => Pretty (NoSubst t a) where
+  pretty = pretty . unNoSubst
 
 -----------------------------------------------------------------------------
 -- * NFData instances

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -3339,7 +3339,7 @@ instance ToAbstract LeftHandSide where
       traceCall (ScopeCheckLHS top lhs) $ do
         reportSLn "scope.lhs" 25 $ "original lhs: " ++ prettyShow lhs
         reportSLn "scope.lhs" 60 $ "patternQNames: " ++ prettyShow (patternQNames lhs)
-        reportSLn "scope.lhs" 60 $ "original lhs (raw): " ++ show lhs
+        reportSLn "scope.lhs" 90 $ "original lhs (raw): " ++ show lhs
 
         -- Expand puns if optHiddenArgumentPuns is True. Note that pun
         -- expansion should happen before the left-hand side is
@@ -3364,12 +3364,12 @@ instance ToAbstract LeftHandSide where
         lhscore <- toAbstract $ CLHSCore displayLhs lhscore
         bindVarsToBind
         -- reportSLn "scope.lhs" 25 $ "parsed lhs patterns: " ++ prettyShow lhscore  -- TODO: Pretty A.LHSCore'
-        reportSLn "scope.lhs" 60 $ "parsed lhs patterns: " ++ show lhscore
+        reportSLn "scope.lhs" 90 $ "parsed lhs patterns: " ++ show lhscore
         printLocals 30 "checked pattern:"
         -- scope check dot patterns
         lhscore <- toAbstract lhscore
         -- reportSLn "scope.lhs" 25 $ "parsed lhs dot patterns: " ++ prettyShow lhscore  -- TODO: Pretty A.LHSCore'
-        reportSLn "scope.lhs" 60 $ "parsed lhs dot patterns: " ++ show lhscore
+        reportSLn "scope.lhs" 90 $ "parsed lhs dot patterns: " ++ show lhscore
         printLocals 30 "checked dots:"
         return $ A.LHS (LHSInfo (getRange lhs) ell) lhscore
 

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -261,7 +261,7 @@ reifyDisplayFormP f ps wps = do
     -- Ulf, can you add an explanation?
     md <- -- addContext (replicate (length ps) "x") $
       displayForm f $ zipWith (\ p i -> I.Apply $ p $> I.var i) ps [0..]
-    reportSLn "reify.display" 60 $
+    reportSLn "reify.display" 95 $
       "display form of " ++ prettyShow f ++ " " ++ show ps ++ " " ++ show wps ++ ":\n  " ++ show md
     case md of
       Just d  | okDisplayForm d -> do

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -214,7 +214,7 @@ instance MonadTrace TCM where
   printHighlightingInfo remove info = do
     modToSrc <- useTC stModuleToSource
     method   <- viewTC eHighlightingMethod
-    reportSDoc "highlighting" 50 $ pure $ vcat
+    reportSDoc "highlighting" 90 $ pure $ vcat
       [ "Printing highlighting info:"
       , nest 2 $ (text . show) info
       , "File modules:"

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -158,7 +158,7 @@ computePolarity xs = do
   --                        -- variable occurrence test in  dependentPolarity.
   reportSDoc "tc.polarity.set" 15 $
     "Refining polarity with type " <+> prettyTCM t
-  reportSDoc "tc.polarity.set" 60 $
+  reportSDoc "tc.polarity.set" 90 $
     "Refining polarity with type (raw): " <+> (text .show) t
 
   pol <- dependentPolarity t (enablePhantomTypes (theDef def) pol1) pol1

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -314,7 +314,7 @@ checkFunDefS t ai extlam with i name withSubAndLets cs = do
           sep [ "clauses before injectivity test"
               , nest 2 $ prettyTCM $ fmap (QNamed name) cs  -- broken, reify (QNamed n cl) expect cl to live at top level
               ]
-        reportSDoc "tc.cc" 60 $ inTopContext $ do
+        reportSDoc "tc.cc" 90 $ inTopContext $ do
           sep [ "raw clauses: "
               , nest 2 $ sep $ fmap (text . show . QNamed name) cs
               ]
@@ -776,7 +776,7 @@ checkClause t withSubAndLets c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats r
             ]
           ]
 
-        reportSDoc "tc.lhs.top" 60 $ escapeContext impossible (size delta) $ vcat
+        reportSDoc "tc.lhs.top" 90 $ escapeContext impossible (size delta) $ vcat
           [ "Clause before translation (raw):"
           , nest 2 $ vcat
             [ "ps    =" <+> text (show ps)

--- a/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/ProblemRest.hs
@@ -142,7 +142,7 @@ updateProblemRest st@(LHSState tel0 qs0 p@(Problem oldEqs ps ret) a psplit ixspl
       , "b     =" <+> addContext tel1 (prettyTCM b)
       ]
     ]
-  reportSDoc "tc.lhs.problem" 60 $ addContext tel0 $ vcat
+  reportSDoc "tc.lhs.problem" 90 $ addContext tel0 $ vcat
     [ nest 2 $ vcat
       [ "ps    =" <+> (text . show) ps
       , "a     =" <+> (text . show) a

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1590,7 +1590,7 @@ checkQuestionMark new cmp t0 i ii = do
     , ":"
     , prettyTCM t0
     ]
-  reportSDoc "tc.interaction" 60 $ sep
+  reportSDoc "tc.interaction" 90 $ sep
     [ "Raw:"
     , text (show t0)
     ]

--- a/src/full/Agda/TypeChecking/Substitute/Class.hs
+++ b/src/full/Agda/TypeChecking/Substitute/Class.hs
@@ -3,8 +3,6 @@
 module Agda.TypeChecking.Substitute.Class where
 
 import Control.Arrow ((***), second)
-import Control.DeepSeq
-import GHC.Generics
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
@@ -114,12 +112,6 @@ isNoAbs (Abs _ b)
 instance Subst QName where
   type SubstArg QName = Term
   applySubst _ q = q
-
--- | Wrapper for types that do not contain variables (so applying a substitution is the identity).
---   Useful if you have a structure of types that support substitution mixed with types that don't
---   and need to apply a substitution to the full structure.
-newtype NoSubst t a = NoSubst { unNoSubst :: a }
-  deriving (Generic, NFData, Functor)
 
 instance DeBruijn t => Subst (NoSubst t a) where
   type SubstArg (NoSubst t a) = t

--- a/test/interaction/Issue8097.agda
+++ b/test/interaction/Issue8097.agda
@@ -1,0 +1,10 @@
+open import Agda.Builtin.Equality
+
+postulate
+  A B : Set
+
+to : A → B
+to = {!!}
+
+to-cong : ∀ {x y} → x ≡ y → to x ≡ to y
+to-cong e = {!!} -- C-c C-a internal error

--- a/test/interaction/Issue8097.in
+++ b/test/interaction/Issue8097.in
@@ -1,0 +1,2 @@
+top_command (cmd_load currentFile [])
+goal_command 1 (cmd_autoOne AsIs) ""

--- a/test/interaction/Issue8097.out
+++ b/test/interaction/Issue8097.out
@@ -1,0 +1,8 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : A → B ?1 : to x ≡ to y" nil)
+((last . 1) . (agda2-goals-action '(0 1)))
+(agda2-give-action 1 "refl")
+((last . 1) . (agda2-goals-action '(0)))


### PR DESCRIPTION
This fixes #8097 by simplifying some of the code in Mimer to avoid the use of `metasCreatedBy`. Basically, the philosophy is that Mimer should only consider metas as new goals if they were explicitly added in the construction of a component, but not when they were created by calls to Agda's internals. I already started applying this philosophy when fixing https://github.com/agda/agda/issues/7639, but apparently there were still more places where it wasn't fully propagated.

(On a side note, I needed to do some debug printing at level 60 for this and was *very* annoyed at all the raw `show` outputs I got at that level, so I bumped a bunch of these to level 90. Honestly I'd rather remove these from the codebase completely, but perhaps that's a more controversial change that should be discussed first so instead I settled on something that allowed me to at least read the debug output I needed here.)