### PR TITLE
Fix #8144: NoSuchModule X gives hint if there is a data/record X

### DIFF
--- a/test/Fail/Issue8144.agda
+++ b/test/Fail/Issue8144.agda
@@ -1,0 +1,24 @@
+-- Andreas, 2025-10-18, issue #8144 reported by Matthew Daggitt
+
+mutual
+  record A : Set₁ where
+    field f : Set
+  open A
+  g : A → Set
+  g = f
+
+-- WAS: error: [NoSuchModule] No module A in scope
+-- This was deemed confusing as the record A appears to be fully defined.
+-- But this actually desugars to:
+--
+--   record A : Set
+--   open A
+--   record A where ...
+--
+-- Thus, the record is not defined yet when attempted to be opened
+
+-- Expected error: [NoSuchModule]
+-- No module A in scope---but a record type of that name is in scope
+-- whose record module is either not defined yet or hidden (note that
+-- records defined in a `mutual' block cannot be opened in the same
+-- block)

--- a/test/Fail/Issue8144.err
+++ b/test/Fail/Issue8144.err
@@ -1,0 +1,7 @@
+Issue8144.agda:6.8-9: error: [NoSuchModule]
+No module A in scope---but a record type of that name is in scope
+whose record module is either not defined yet or hidden (note that
+records defined in a 'mutual' block cannot be opened in the same
+block)
+when scope checking the declaration
+  open A

--- a/test/Fail/Issue8144Data.agda
+++ b/test/Fail/Issue8144Data.agda
@@ -1,0 +1,12 @@
+-- Andreas, 2025-10-18, issue #8144
+
+mutual
+  data D : Set where
+    c : D
+  open D
+
+-- Expected error: [NoSuchModule]
+-- No module D in scope---but a data type of that name is in scope
+-- whose data module is either not defined yet or hidden
+-- when scope checking the declaration
+--   open D

--- a/test/Fail/Issue8144Data.err
+++ b/test/Fail/Issue8144Data.err
@@ -1,0 +1,5 @@
+Issue8144Data.agda:6.8-9: error: [NoSuchModule]
+No module D in scope---but a data type of that name is in scope
+whose data module is either not defined yet or hidden
+when scope checking the declaration
+  open D

--- a/test/Fail/Issue8144DataNoMutual.agda
+++ b/test/Fail/Issue8144DataNoMutual.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2025-10-18, issue #8144
+
+module _ where
+
+module M where
+  private
+    module P where
+      data D : Set where
+        c : D
+  open P public hiding (module D)
+
+open M
+open D  -- No module D in scope
+
+-- Expected error: [NoSuchModule]
+-- No module D in scope---but a data type of that name is in scope
+-- whose data module is either not defined yet or hidden
+-- when scope checking the declaration
+--   open D

--- a/test/Fail/Issue8144DataNoMutual.err
+++ b/test/Fail/Issue8144DataNoMutual.err
@@ -1,0 +1,5 @@
+Issue8144DataNoMutual.agda:13.6-7: error: [NoSuchModule]
+No module D in scope---but a data type of that name is in scope
+whose data module is either not defined yet or hidden
+when scope checking the declaration
+  open D

--- a/test/Fail/Issue8144NewMutual.agda
+++ b/test/Fail/Issue8144NewMutual.agda
@@ -1,0 +1,14 @@
+-- Andreas, 2025-10-18, issue #8144
+
+record A : Set₁
+open A           -- This open is placed too early
+record A where
+  field f : Set
+g : A → Set
+g = f
+
+-- Expected error: [NoSuchModule]
+-- No module A in scope---but a record type of that name is in scope
+-- whose record module is either not defined yet or hidden (note that
+-- records defined in a `mutual' block cannot be opened in the same
+-- block)

--- a/test/Fail/Issue8144NewMutual.err
+++ b/test/Fail/Issue8144NewMutual.err
@@ -1,0 +1,7 @@
+Issue8144NewMutual.agda:4.6-7: error: [NoSuchModule]
+No module A in scope---but a record type of that name is in scope
+whose record module is either not defined yet or hidden (note that
+records defined in a 'mutual' block cannot be opened in the same
+block)
+when scope checking the declaration
+  open A

--- a/test/Fail/Issue8144NoMutual.agda
+++ b/test/Fail/Issue8144NoMutual.agda
@@ -1,0 +1,23 @@
+-- Andreas, 2025-10-18, issue #8144
+
+module _ where
+
+module M where
+  private
+    module P where
+      record R : Set₁ where
+        field f : Set
+  open P public hiding (module R)
+
+open M
+open R  -- No module R in scope
+
+-- Expected error: [NoSuchModule]
+-- No module R in scope---but a record type of that name is in scope
+-- whose record module is either not defined yet or hidden (note that
+-- records defined in a `mutual' block cannot be opened in the same
+-- block)
+-- when scope checking the declaration
+--   open R
+
+-- Part of the hint is useless here.

--- a/test/Fail/Issue8144NoMutual.err
+++ b/test/Fail/Issue8144NoMutual.err
@@ -1,0 +1,7 @@
+Issue8144NoMutual.agda:13.6-7: error: [NoSuchModule]
+No module R in scope---but a record type of that name is in scope
+whose record module is either not defined yet or hidden (note that
+records defined in a 'mutual' block cannot be opened in the same
+block)
+when scope checking the declaration
+  open R


### PR DESCRIPTION
In situation
```agda
mutual
  record R : Set where
    field f : ...
  open R
```
module R is not in scope (yet), and now Agda gives a hint towards that.

Closes #8144.
