### PR TITLE
Fix #4271: print filenames with modules in errors

### DIFF
--- a/src/full/Agda/Interaction/BuildLibrary.hs
+++ b/src/full/Agda/Interaction/BuildLibrary.hs
@@ -103,5 +103,5 @@ checkModule m src = do
   let isInfectiveWarning InfectiveImport{} = True
       isInfectiveWarning _                 = False
       warns = filter (not . isInfectiveWarning . tcWarning) $ Set.toAscList $ miWarnings mi
-  tcWarningsToError m (Imp.srcOrigin src) warns
+  tcWarningsToError (TopLevelModuleNameWithSourceFile m (Imp.srcOrigin src)) warns
   return ()

--- a/src/full/Agda/Interaction/FindFile.hs
+++ b/src/full/Agda/Interaction/FindFile.hs
@@ -241,7 +241,7 @@ checkModuleName name src0 mexpected = do
     Left (NotFound files)  -> typeError $
       case mexpected of
         Nothing -> ModuleNameDoesntMatchFileName name files
-        Just expected -> ModuleNameUnexpected name expected
+        Just expected -> ModuleNameUnexpected (TopLevelModuleNameWithSourceFile name src0) expected
 
     Left (Ambiguous files) -> typeError $
       AmbiguousTopLevelModuleName name files

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -517,7 +517,7 @@ getNonMainInterface
   -> TCM Interface
 getNonMainInterface x msrc = do
   mi <- getNonMainModuleInfo x msrc
-  tcWarningsToError x (miSourceFile mi) $ Set.toAscList $ miWarnings mi
+  tcWarningsToError (TopLevelModuleNameWithSourceFile x $ miSourceFile mi) $ Set.toAscList $ miWarnings mi
   return (miInterface mi)
 
 getNonMainModuleInfo

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -740,11 +740,9 @@ instance PrettyTCM TypeError where
       , text "must not be located in the directory" <+> text (takeDirectory (lib ^. libFile))
       ]
 
-    SolvedButOpenHoles x file -> do
-      path <- srcFilePath file
-      let x' = setRange (rangeFromAbsolutePath path) x
+    SolvedButOpenHoles x -> do
       vcat $
-        [ fsep $ pretty (PrintRange x') :
+        [ fsep $ prettyTCM x :
             pwords "cannot be imported since it has open interaction points"
         , "(consider adding {-# OPTIONS --allow-unsolved-metas #-} to that module)"
         ]
@@ -1773,6 +1771,11 @@ prettyShadowedModule x ms@(m0 :| _) = do
           IsDataModule   -> "(datatype)"
           IsRecordModule -> "(record)"
 
+instance PrettyTCM TopLevelModuleNameWithSourceFile where
+  prettyTCM (TopLevelModuleNameWithSourceFile x file) = do
+    path <- srcFilePath file
+    let x' = setRange (rangeFromAbsolutePath path) x
+    pretty (PrintRange x')
 
 instance PrettyTCM ExecError where
   prettyTCM = \case

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -747,9 +747,10 @@ instance PrettyTCM TypeError where
         , "(consider adding {-# OPTIONS --allow-unsolved-metas #-} to that module)"
         ]
 
-    CyclicModuleDependency (List2 m0 m1 ms) ->
+    CyclicModuleDependency ms0 -> do
+      List2 m0 m1 ms <- for ms0 <$> topLevelModuleNameWithSourceFileCompleter
       fsep (pwords "cyclic module dependency:")
-      $$ nest 2 (vcat $ (pretty m0 :) $ map (("importing" <+>) . pretty) (m1 : ms))
+        $$ nest 2 (vcat $ (prettyTCM m0 :) $ map (("importing" <+>) . prettyTCM) (m1 : ms))
 
     FileNotFound x files ->
       fsep ( pwords "Failed to find source of module" ++ [pretty x] ++

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -830,23 +830,23 @@ instance PrettyTCM TypeError where
         else empty
       ]
 
-    ModuleNameUnexpected given expected
-      | canon dGiven == canon dExpected -> fsep $ concat
+    ModuleNameUnexpected given expected -> do
+      let
+        canon = CaseInsens.mk . P.render
+        dExpected = P.pretty expected
+      dGiven <- prettyTCM given
+      if| canon dGiven == canon dExpected -> fsep $ concat
           [ pwords "Case mismatch between the actual module name"
           , [ pure dGiven ]
           , pwords "and the expected module name"
           , [ pure dExpected ]
           ]
-      | otherwise -> fsep $ concat
+        | otherwise -> fsep $ concat
           [ pwords "The name of the top level module does not match the file name. The module"
           , [ pure dGiven ]
           , pwords "should probably be named"
           , [ pure dExpected ]
           ]
-      where
-      canon = CaseInsens.mk . P.render
-      dGiven    = P.pretty given
-      dExpected = P.pretty expected
 
     ModuleNameHashCollision raw raw' -> fwords $ case raw' of
       Nothing ->

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5397,7 +5397,7 @@ data TypeError
         | OverlappingProjects AbsolutePath TopLevelModuleName TopLevelModuleName
         | AmbiguousTopLevelModuleName TopLevelModuleName (List2 AbsolutePath)
             -- ^ The given module has at least 2 file locations.
-        | ModuleNameUnexpected TopLevelModuleName TopLevelModuleName
+        | ModuleNameUnexpected TopLevelModuleNameWithSourceFile TopLevelModuleName
           -- ^ Found module name, expected module name.
         | ModuleNameDoesntMatchFileName TopLevelModuleName [AbsolutePath]
             -- ^ The list can be empty.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5385,7 +5385,7 @@ data TypeError
             -- ^ Collected errors when processing the @.agda-lib@ file.
         | LibTooFarDown TopLevelModuleName AgdaLibFile
             -- ^ The @.agda-lib@ file for the given module is not on the right level.
-        | SolvedButOpenHoles TopLevelModuleName SourceFile
+        | SolvedButOpenHoles TopLevelModuleNameWithSourceFile
           -- ^ Some interaction points (holes) in the given module have not been filled by the user.
           --   These are not 'UnsolvedMetas' since unification solved them.
           --   This is an error, since interaction points are never filled

--- a/src/full/Agda/TypeChecking/Monad/Base/Types.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base/Types.hs
@@ -147,6 +147,12 @@ type PrimitiveLibDir = AbsolutePath
 newtype SourceFile = SourceFile { srcFileId :: FileId }
   deriving (Eq, Ord, Show, Generic)
 
+data TopLevelModuleNameWithSourceFile = TopLevelModuleNameWithSourceFile
+  { fileModuleName       :: TopLevelModuleName
+  , fileModuleSourceFile :: SourceFile
+  }
+  deriving (Show, Generic)
+
 -- | Maps top-level module names to the corresponding source file ids.
 
 type ModuleToSourceId = Map TopLevelModuleName SourceFile
@@ -202,3 +208,4 @@ instance NFData ContextEntry
 instance NFData FileDictWithBuiltins
 instance NFData SourceFile
 instance NFData IsBuiltinModule
+instance NFData TopLevelModuleNameWithSourceFile

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -450,6 +450,14 @@ currentModuleNameHash = do
   NameId _ h <- useTC stFreshNameId
   return h
 
+-- | Get a function that completes 'TopLevelModuleName's
+--   with their 'SourceFile' to 'TopLevelModuleNameWithSourceFile's.
+topLevelModuleNameWithSourceFileCompleter :: ReadTCState m
+  => m (TopLevelModuleName -> TopLevelModuleNameWithSourceFile)
+topLevelModuleNameWithSourceFileCompleter = do
+  ModuleToSource _dict m2s <- useTC stModuleToSource
+  return \ m -> TopLevelModuleNameWithSourceFile m $ Map.findWithDefault __IMPOSSIBLE__ m m2s
+
 ---------------------------------------------------------------------------
 -- * Backends and foreign code
 ---------------------------------------------------------------------------

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -784,13 +784,14 @@ filterTCWarnings wset = case Set.toAscList wset of
 
 -- | Turns warnings, if any, into errors.
 tcWarningsToError ::
-     TopLevelModuleName   -- ^ The module we have checked (which produced the warnings).
-  -> SourceFile           -- ^ The file containing the module.
-  -> [TCWarning]          -- ^ The warnings to turn into errors.
+     TopLevelModuleNameWithSourceFile
+       -- ^ The module we have checked (which produced the warnings).
+  -> [TCWarning]
+       -- ^ The warnings to turn into errors.
   -> TCM ()
-tcWarningsToError x file mws = case (unsolvedHoles, otherWarnings) of
+tcWarningsToError x mws = case (unsolvedHoles, otherWarnings) of
    ([], [])                   -> return ()
-   (_unsolvedHoles@(_:_), []) -> typeError $ SolvedButOpenHoles x file
+   (_unsolvedHoles@(_:_), []) -> typeError $ SolvedButOpenHoles x
    (_ , w : ws)               -> typeError $ NonFatalErrors $ Set1.fromList (w :| ws)
    where
    -- filter out unsolved interaction points for imported module so

--- a/test/Fail/CyclicModuleDependency.err
+++ b/test/Fail/CyclicModuleDependency.err
@@ -1,6 +1,6 @@
 CyclicModuleDependency.agda:3.1-30: error: [CyclicModuleDependency]
 cyclic module dependency:
-  CyclicModuleDependency
-  importing CyclicModuleDependency
+  CyclicModuleDependency (at CyclicModuleDependency.agda:1.1)
+  importing CyclicModuleDependency (at CyclicModuleDependency.agda:1.1)
 when scope checking the declaration
   import CyclicModuleDependency

--- a/test/Fail/CyclicModuleDependency1.err
+++ b/test/Fail/CyclicModuleDependency1.err
@@ -1,8 +1,8 @@
 CyclicModuleDependency3.agda:3.1-31: error: [CyclicModuleDependency]
 cyclic module dependency:
-  CyclicModuleDependency1
-  importing CyclicModuleDependency2
-  importing CyclicModuleDependency3
-  importing CyclicModuleDependency1
+  CyclicModuleDependency1 (at CyclicModuleDependency1.agda:1.1)
+  importing CyclicModuleDependency2 (at CyclicModuleDependency2.agda:1.1)
+  importing CyclicModuleDependency3 (at CyclicModuleDependency3.agda:1.1)
+  importing CyclicModuleDependency1 (at CyclicModuleDependency1.agda:1.1)
 when scope checking the declaration
   import CyclicModuleDependency1

--- a/test/Fail/CyclicModuleDependency2.err
+++ b/test/Fail/CyclicModuleDependency2.err
@@ -1,8 +1,8 @@
 CyclicModuleDependency1.agda:3.1-31: error: [CyclicModuleDependency]
 cyclic module dependency:
-  CyclicModuleDependency2
-  importing CyclicModuleDependency3
-  importing CyclicModuleDependency1
-  importing CyclicModuleDependency2
+  CyclicModuleDependency2 (at CyclicModuleDependency2.agda:1.1)
+  importing CyclicModuleDependency3 (at CyclicModuleDependency3.agda:1.1)
+  importing CyclicModuleDependency1 (at CyclicModuleDependency1.agda:1.1)
+  importing CyclicModuleDependency2 (at CyclicModuleDependency2.agda:1.1)
 when scope checking the declaration
   import CyclicModuleDependency2

--- a/test/Fail/CyclicModuleDependency3.err
+++ b/test/Fail/CyclicModuleDependency3.err
@@ -1,8 +1,8 @@
 CyclicModuleDependency2.agda:3.1-31: error: [CyclicModuleDependency]
 cyclic module dependency:
-  CyclicModuleDependency3
-  importing CyclicModuleDependency1
-  importing CyclicModuleDependency2
-  importing CyclicModuleDependency3
+  CyclicModuleDependency3 (at CyclicModuleDependency3.agda:1.1)
+  importing CyclicModuleDependency1 (at CyclicModuleDependency1.agda:1.1)
+  importing CyclicModuleDependency2 (at CyclicModuleDependency2.agda:1.1)
+  importing CyclicModuleDependency3 (at CyclicModuleDependency3.agda:1.1)
 when scope checking the declaration
   import CyclicModuleDependency3

--- a/test/Fail/Issue2092.err
+++ b/test/Fail/Issue2092.err
@@ -1,6 +1,7 @@
 Issue2092.agda:1.1-34: error: [ModuleNameUnexpected]
 The name of the top level module does not match the file name. The
-module Imports.TheWrongName should probably be named
-Imports.WronglyNamedModule
+module
+Imports.TheWrongName (at Imports/WronglyNamedModule.agda:1.1)
+should probably be named Imports.WronglyNamedModule
 when scope checking the declaration
   import Imports.WronglyNamedModule


### PR DESCRIPTION
- **Refactor PR #8135: introduce TopLevelModuleNameWithSourceFile**
  

- **Re #4271: equip ModuleNameUnexpected error with file**
  

- **Re #4271: equip CyclicModuleDependency error with files**
  Closes #4271.
  