### PR TITLE
Serialize Range in WhyInScope for lineage

### DIFF
--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -77,7 +77,7 @@ import qualified Agda.Utils.CompactRegion as Compact
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20250826 * 10 + 0
+currentInterfaceVersion = 20251023 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64

--- a/test/interaction/Issue2371.out
+++ b/test/interaction/Issue2371.out
@@ -6,6 +6,6 @@
 ((last . 1) . (agda2-goals-action '()))
 (agda2-status-action "Checked")
 (agda2-info-action "*Normal Form*" "0" nil)
-(agda2-info-action "*Error*" "1.1-4: error: [AmbiguousName] Ambiguous name Nat. It could refer to any one of Nat bound at Issue2371.agda:4.19-22 Agda.Builtin.Nat.Nat bound at agda-default-include-path/Agda/Builtin/Nat.agda:8.6-9 Nat is in scope as * a variable bound at Issue2371.agda:4.19-22 in conflict with * a data type Agda.Builtin.Nat.Nat brought into scope by - the opening of Agda.Builtin.Nat at - its definition at agda-default-include-path/Agda/Builtin/Nat.agda:8.6-9 when scope checking Nat" nil)
+(agda2-info-action "*Error*" "1.1-4: error: [AmbiguousName] Ambiguous name Nat. It could refer to any one of Nat bound at Issue2371.agda:4.19-22 Agda.Builtin.Nat.Nat bound at agda-default-include-path/Agda/Builtin/Nat.agda:8.6-9 Nat is in scope as * a variable bound at Issue2371.agda:4.19-22 in conflict with * a data type Agda.Builtin.Nat.Nat brought into scope by - the opening of Agda.Builtin.Nat at Issue2371.agda:6.13-29 - its definition at agda-default-include-path/Agda/Builtin/Nat.agda:8.6-9 when scope checking Nat" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")

--- a/test/lib-interaction/ClashingDefinition.agda
+++ b/test/lib-interaction/ClashingDefinition.agda
@@ -1,0 +1,20 @@
+-- Andreas, 2025-10-23
+-- Serialize Ranges in WhyInScope data so that we have them
+-- for the ClashingDefinition error.
+
+open import Data.Nat.Base
+
+postulate
+  ℕ : Set
+
+-- Expected error: [ClashingDefinition]
+-- Multiple definitions of ℕ. Previous definition
+-- ℕ is in scope as
+--   * a data type Agda.Builtin.Nat.Nat brought into scope by
+--     - the opening of Data.Nat.Base at <<RANGE>>
+--     - the opening of Agda.Builtin.Nat at <<RANGE>>
+--     - its definition at <<RANGE>>
+-- when scope checking the declaration
+--   ℕ : Set
+--
+-- <<RANGE>> should be present everywhere

--- a/test/lib-interaction/ClashingDefinition.in
+++ b/test/lib-interaction/ClashingDefinition.in
@@ -1,0 +1,1 @@
+top_command (cmd_load currentFile ["-i.","-i../../std-lib/src/"])

--- a/test/lib-interaction/ClashingDefinition.out
+++ b/test/lib-interaction/ClashingDefinition.out
@@ -1,7 +1,7 @@
 Agda2> (agda2-status-action "")
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
-(agda2-info-action "*Error*" "ClashingDefinition.agda:8.3-10: error: [ClashingDefinition] Multiple definitions of ℕ. Previous definition ℕ is in scope as * a data type Agda.Builtin.Nat.Nat brought into scope by - the opening of Data.Nat.Base at ClashingDefinition.agda:5.13-26 - the opening of Agda.Builtin.Nat at /Users/abela/agda/std-lib/src/Data/Nat/Base.agda:28.13-29 - its definition at agda-default-include-path/Agda/Builtin/Nat.agda:8.6-9 when scope checking the declaration ℕ : Set" nil)
+(agda2-info-action "*Error*" "ClashingDefinition.agda:8.3-10: error: [ClashingDefinition] Multiple definitions of ℕ. Previous definition ℕ is in scope as * a data type Agda.Builtin.Nat.Nat brought into scope by - the opening of Data.Nat.Base at ClashingDefinition.agda:5.13-26 - the opening of Agda.Builtin.Nat at agda-default-standard-library-path/src/Data/Nat/Base.agda:28.13-29 - its definition at agda-default-include-path/Agda/Builtin/Nat.agda:8.6-9 when scope checking the declaration ℕ : Set" nil)
 ((last . 3) . (agda2-maybe-goto '("ClashingDefinition.agda" . 161)))
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")

--- a/test/lib-interaction/ClashingDefinition.out
+++ b/test/lib-interaction/ClashingDefinition.out
@@ -1,0 +1,8 @@
+Agda2> (agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-info-action "*Error*" "ClashingDefinition.agda:8.3-10: error: [ClashingDefinition] Multiple definitions of ℕ. Previous definition ℕ is in scope as * a data type Agda.Builtin.Nat.Nat brought into scope by - the opening of Data.Nat.Base at ClashingDefinition.agda:5.13-26 - the opening of Agda.Builtin.Nat at /Users/abela/agda/std-lib/src/Data/Nat/Base.agda:28.13-29 - its definition at agda-default-include-path/Agda/Builtin/Nat.agda:8.6-9 when scope checking the declaration ℕ : Set" nil)
+((last . 3) . (agda2-maybe-goto '("ClashingDefinition.agda" . 161)))
+(agda2-highlight-load-and-delete-action)
+(agda2-status-action "")
+Agda2> 

--- a/test/lib-interaction/Makefile
+++ b/test/lib-interaction/Makefile
@@ -39,6 +39,7 @@ filter=$(SED) -e 's"$(pwdPlusDelimiter)""g' \
               -e 's"$(pwd)""g' \
               -e 's" \"$(TMPDIR).*\"""' \
               -e 's"[^ (\"]*lib.prim"agda-default-include-path"g' \
+              -e 's"[^ (\"]*std-lib"agda-default-standard-library-path"g' \
               -e 's/\(\\n\| \)\+/ /g' \
      | $(clean)
 


### PR DESCRIPTION
We want the ranges in the linear for ClashingDefinition or WhyInScope
even for modules that are already serialized.
