### PR TITLE
Fix issue #5791: list all possible file extensions in FileNotFound error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,10 @@ Library management
 Interaction and emacs mode
 --------------------------
 
+* Syntax highlighting and go-to-definition now also works in the Agda
+  information buffer in Emacs where goals etc. are displayed.
+  This fixes long-standing [Issue #706](https://github.com/agda/agda/issues/706).
+
 * By temporarily turning on printing of hidden arguments
   (`OPTION --show-implicit`, `C-c C-x C-h` in Emacs)
   and then splitting on result in a hole

--- a/src/full/Agda/Syntax/Parser/Literate.hs
+++ b/src/full/Agda/Syntax/Parser/Literate.hs
@@ -4,7 +4,6 @@
 
 module Agda.Syntax.Parser.Literate
   ( literateProcessors
-  , literateExtsShortList
   , literateTeX
   , literateRsT
   , literateMd
@@ -32,9 +31,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Position
 
 import Agda.Utils.List
-import Agda.Utils.List1 (List1)
 import qualified Agda.Utils.List1 as List1
-import Agda.Utils.Singleton
 
 import Agda.Utils.Impossible
 
@@ -138,12 +135,6 @@ bleach = map $ \ c -> if isSpace c && c /= '\t' then c else ' '
 
 isBlank :: Char -> Bool
 isBlank = (&&) <$> isSpace <*> (/= '\n')
-
--- | Short list of extensions for literate Agda files.
---   For display purposes.
-
-literateExtsShortList :: List1 String
-literateExtsShortList = singleton ".lagda"
 
 -- | Returns a tuple consisting of the first line of the input, and the rest
 --   of the input.

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -54,6 +54,7 @@ import Agda.Syntax.Concrete.Definitions (notSoNiceDeclarations)
 import Agda.Syntax.Concrete.Definitions.Errors (declarationExceptionString)
 import Agda.Syntax.Concrete.Pretty (attributesForModality)
 import Agda.Syntax.Notation
+import Agda.Syntax.Parser (agdaFileExtensions)
 import Agda.Syntax.Position
 import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Abstract as A
@@ -62,7 +63,6 @@ import Agda.Syntax.Translation.InternalToAbstract
 import Agda.Syntax.Scope.Monad (isDatatypeModule, resolveName', tryResolveName)
 import Agda.Syntax.Scope.Base
 import Agda.Syntax.TopLevelModuleName (moduleNameToFileName)
-import Agda.Syntax.Parser.Literate (literateExtsShortList)
 
 import Agda.TypeChecking.Errors.Names (typeErrorString)
 import Agda.TypeChecking.Monad
@@ -1741,15 +1741,14 @@ instance PrettyTCM TypeError where
 
 {-# SPECIALIZE prettyPossibleFilesForModule :: TopLevelModuleName -> List1 AbsolutePath -> TCM Doc #-}
 prettyPossibleFilesForModule :: MonadPretty m => TopLevelModuleName -> List1 AbsolutePath -> m Doc
-prettyPossibleFilesForModule m dirs = do
-    nest 2 $ vcat $ map text $
-      [ filePath dir </> file
+prettyPossibleFilesForModule m dirs = vcat
+    [ nest 2 $ vcat $ map text $
+      [ filePath dir </> moduleNameToFileName m ".AGDA"
       | dir  <- List1.toList dirs
-      , file <- map (moduleNameToFileName m) parseFileExtsShortList
       ]
-  where
-    parseFileExtsShortList :: [String]
-    parseFileExtsShortList = ".agda" : List1.toList literateExtsShortList
+    , "where .AGDA denotes a legal extension for an Agda file"
+    , parens $ fsep $ pwords "i.e., one of" ++ map text agdaFileExtensions
+    ]
 
 -- | Pretty-print error 'ShadowedModule' and return the range of the shadowed module.
 {-# SPECIALIZE prettyShadowedModule :: C.Name -> List1 A.ModuleName -> TCM (TCM Doc, Range) #-}

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5390,15 +5390,17 @@ data TypeError
           --   without user interaction.
         | CyclicModuleDependency (List2 TopLevelModuleName)
             -- ^ The cycle starts and ends with the same module.
-        | FileNotFound TopLevelModuleName [AbsolutePath]
-            -- ^ The list can be empty.
+        | FileNotFound TopLevelModuleName (List1 AbsolutePath)
+            -- ^ No file for the module was found when searching
+            --   in the given list of include directories.
         | OverlappingProjects AbsolutePath TopLevelModuleName TopLevelModuleName
         | AmbiguousTopLevelModuleName TopLevelModuleName (List2 AbsolutePath)
             -- ^ The given module has at least 2 file locations.
         | ModuleNameUnexpected TopLevelModuleNameWithSourceFile TopLevelModuleName
           -- ^ Found module name, expected module name.
-        | ModuleNameDoesntMatchFileName TopLevelModuleName [AbsolutePath]
-            -- ^ The list can be empty.
+        | ModuleNameDoesntMatchFileName TopLevelModuleName (List1 AbsolutePath)
+            -- ^ No matching file for the module was found when searching
+            --   in the given list of include directories.
         | ModuleDefinedInOtherFile TopLevelModuleName AbsolutePath AbsolutePath
           -- ^ Module name, file from which it was loaded, file which
           -- the include path says contains the module.

--- a/test/BuildFail/Issue7912.err
+++ b/test/BuildFail/Issue7912.err
@@ -5,7 +5,8 @@ Error raised at (typeError, src/full/Agda/Interaction/FindFile.hs:«line»:«col
 The name 'Definitely-not-F' of the top level module does not match
 the file name. A such named module should be defined in one of the
 following files:
-  ../BuildFail/Issue7912/Definitely-not-F.agda
-  ../BuildFail/Issue7912/Definitely-not-F.lagda
-  agda-default-include-path/Definitely-not-F.agda
-  agda-default-include-path/Definitely-not-F.lagda
+  ../BuildFail/Issue7912/Definitely-not-F.AGDA
+  agda-default-include-path/Definitely-not-F.AGDA
+where .AGDA denotes a legal extension for an Agda file
+(i.e., one of .agda .lagda .lagda.rst .lagda.tex .lagda.md
+ .lagda.org .lagda.tree .lagda.typ)

--- a/test/Fail/FileNotFound.err
+++ b/test/Fail/FileNotFound.err
@@ -1,11 +1,11 @@
 FileNotFound.agda:3.1-21: error: [FileNotFound]
 Failed to find source of module A.B.WildGoose in any of the
 following locations:
-  ../A/B/WildGoose.agda
-  ../A/B/WildGoose.lagda
-  A/B/WildGoose.agda
-  A/B/WildGoose.lagda
-  agda-default-include-path/A/B/WildGoose.agda
-  agda-default-include-path/A/B/WildGoose.lagda
+  ../A/B/WildGoose.AGDA
+  A/B/WildGoose.AGDA
+  agda-default-include-path/A/B/WildGoose.AGDA
+where .AGDA denotes a legal extension for an Agda file
+(i.e., one of .agda .lagda .lagda.rst .lagda.tex .lagda.md
+ .lagda.org .lagda.tree .lagda.typ)
 when scope checking the declaration
   import A.B.WildGoose

--- a/test/Fail/Issue481NonExistentModule.err
+++ b/test/Fail/Issue481NonExistentModule.err
@@ -1,11 +1,11 @@
 Issue481NonExistentModule.agda:4.6-30: error: [FileNotFound]
 Failed to find source of module NonExistentModule in any of the
 following locations:
-  ../NonExistentModule.agda
-  ../NonExistentModule.lagda
-  NonExistentModule.agda
-  NonExistentModule.lagda
-  agda-default-include-path/NonExistentModule.agda
-  agda-default-include-path/NonExistentModule.lagda
+  ../NonExistentModule.AGDA
+  NonExistentModule.AGDA
+  agda-default-include-path/NonExistentModule.AGDA
+where .AGDA denotes a legal extension for an Agda file
+(i.e., one of .agda .lagda .lagda.rst .lagda.tex .lagda.md
+ .lagda.org .lagda.tree .lagda.typ)
 when scope checking the declaration
   import NonExistentModule as .#NonExistentModule-4871442055463982176

--- a/test/Fail/ModuleNameDoesntMatchFileName.err
+++ b/test/Fail/ModuleNameDoesntMatchFileName.err
@@ -2,9 +2,9 @@ ModuleNameDoesntMatchFileName.agda:1.8-29: error: [ModuleNameDoesntMatchFileName
 The name 'Mmmmmmmmmmmmmmmmmmmmm' of the top level module does not
 match the file name. A such named module should be defined in one
 of the following files:
-  ../Mmmmmmmmmmmmmmmmmmmmm.agda
-  ../Mmmmmmmmmmmmmmmmmmmmm.lagda
-  Mmmmmmmmmmmmmmmmmmmmm.agda
-  Mmmmmmmmmmmmmmmmmmmmm.lagda
-  agda-default-include-path/Mmmmmmmmmmmmmmmmmmmmm.agda
-  agda-default-include-path/Mmmmmmmmmmmmmmmmmmmmm.lagda
+  ../Mmmmmmmmmmmmmmmmmmmmm.AGDA
+  Mmmmmmmmmmmmmmmmmmmmm.AGDA
+  agda-default-include-path/Mmmmmmmmmmmmmmmmmmmmm.AGDA
+where .AGDA denotes a legal extension for an Agda file
+(i.e., one of .agda .lagda .lagda.rst .lagda.tex .lagda.md
+ .lagda.org .lagda.tree .lagda.typ)

--- a/test/Fail/RegionWrongModule.err
+++ b/test/Fail/RegionWrongModule.err
@@ -2,9 +2,9 @@ RegionWrongModule.agda:10.8-26: error: [ModuleNameDoesntMatchFileName]
 The name 'ThisIsTheWrongName' of the top level module does not
 match the file name. A such named module should be defined in one
 of the following files:
-  ../ThisIsTheWrongName.agda
-  ../ThisIsTheWrongName.lagda
-  ThisIsTheWrongName.agda
-  ThisIsTheWrongName.lagda
-  agda-default-include-path/ThisIsTheWrongName.agda
-  agda-default-include-path/ThisIsTheWrongName.lagda
+  ../ThisIsTheWrongName.AGDA
+  ThisIsTheWrongName.AGDA
+  agda-default-include-path/ThisIsTheWrongName.AGDA
+where .AGDA denotes a legal extension for an Agda file
+(i.e., one of .agda .lagda .lagda.rst .lagda.tex .lagda.md
+ .lagda.org .lagda.tree .lagda.typ)

--- a/test/Fail/customised/Issue4671.err.case-sensitive
+++ b/test/Fail/customised/Issue4671.err.case-sensitive
@@ -1,9 +1,10 @@
 customised/Issue4671.agda:1.1-22: error: [FileNotFound]
 Failed to find source of module Agda.PRIMITIVE in any of the
 following locations:
-  customised/Agda/PRIMITIVE.agda
-  customised/Agda/PRIMITIVE.lagda
-  agda-default-include-path/Agda/PRIMITIVE.agda
-  agda-default-include-path/Agda/PRIMITIVE.lagda
+  customised/Agda/PRIMITIVE.AGDA
+  agda-default-include-path/Agda/PRIMITIVE.AGDA
+where .AGDA denotes a legal extension for an Agda file
+(i.e., one of .agda .lagda .lagda.rst .lagda.tex .lagda.md
+ .lagda.org .lagda.tree .lagda.typ)
 when scope checking the declaration
   import Agda.PRIMITIVE

--- a/test/Fail/customised/Issue7953.err
+++ b/test/Fail/customised/Issue7953.err
@@ -2,9 +2,10 @@
 The inferred name 'Test' of the top level module does not match the
 file name. A such named module should be defined in one of the
 following files:
-  customised/Test.agda
-  customised/Test.lagda
-  agda-default-include-path/Test.agda
-  agda-default-include-path/Test.lagda
+  customised/Test.AGDA
+  agda-default-include-path/Test.AGDA
+where .AGDA denotes a legal extension for an Agda file
+(i.e., one of .agda .lagda .lagda.rst .lagda.tex .lagda.md
+ .lagda.org .lagda.tree .lagda.typ)
 (Hint: no module header was found in this file; adding one might
 fix this error.)

--- a/test/Fail/customised/iSSue5508.err.case-sensitive
+++ b/test/Fail/customised/iSSue5508.err.case-sensitive
@@ -2,8 +2,8 @@ customised/iSSue5508.agda:6.8-17: error: [ModuleNameDoesntMatchFileName]
 The name 'Issue5508' of the top level module does not match the
 file name. A such named module should be defined in one of the
 following files:
-  customised/Issue5508.agda
-  customised/Issue5508.lagda
-  agda-default-include-path/Issue5508.agda
-  agda-default-include-path/Issue5508.lagda
-
+  customised/Issue5508.AGDA
+  agda-default-include-path/Issue5508.AGDA
+where .AGDA denotes a legal extension for an Agda file
+(i.e., one of .agda .lagda .lagda.rst .lagda.tex .lagda.md
+ .lagda.org .lagda.tree .lagda.typ)

--- a/test/interaction/Issue4516.out
+++ b/test/interaction/Issue4516.out
@@ -1,7 +1,7 @@
 (agda2-status-action "")
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
-(agda2-info-action "*Error*" "Issue4516.agda:1.8-11: error: [ModuleNameDoesntMatchFileName] The name `Set` of the top level module does not match the file name. A such named module should be defined in one of the following files: Set.agda Set.lagda agda-default-include-path/Set.agda agda-default-include-path/Set.lagda" nil)
+(agda2-info-action "*Error*" "Issue4516.agda:1.8-11: error: [ModuleNameDoesntMatchFileName] The name `Set` of the top level module does not match the file name. A such named module should be defined in one of the following files: Set.AGDA agda-default-include-path/Set.AGDA where .AGDA denotes a legal extension for an Agda file (i.e., one of .agda .lagda .lagda.rst .lagda.tex .lagda.md .lagda.org .lagda.tree .lagda.typ)" nil)
 ((last . 3) . (agda2-maybe-goto '("Issue4516.agda" . 8)))
 (agda2-info-action "*Error*" "/non-existent-directory-used-for-Issue4516: openTempFile: does not exist (No such file or directory)" nil)
 (agda2-highlight-add-annotations 'nil)


### PR DESCRIPTION
- **Refactor for #5791: `NotFound` error carries include dirs instead of file list**
  

- **Fix #5791: list all possible file extensions in FileNotFound error**
  but don't execute the Cartesian product of
  
    possible files × possible extensions
  
  This fixes some technical debt that should have fixed when additional
  literate extensions where introduced in the first place.

Included here is also an unrelated commit:
- Changelog for #706
  