### PR TITLE
Re #7225: remove some GenericDocErrors

### DIFF
--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -193,6 +193,7 @@ data ErrorName
   | MetaErasedSolution_
   | MetaIrrelevantSolution_
   | MismatchedProjectionsError_
+  | MissingBindingsForTelescopeVariables_
   | MissingTypeSignature_ DataRecOrFun_
   | ModuleArityMismatch_
   | ModuleDefinedInOtherFile_

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2880,7 +2880,7 @@ instance ToAbstract C.Pragma where
   toAbstract pragma@(C.BuiltinPragma _ rb qx)
     | Just b' <- b, isUntypedBuiltin b' = do
         q <- resolveQName qx
-        bindUntypedBuiltin b' q
+        bindUntypedBuiltin b' qx q
         return [ A.BuiltinPragma rb q ]
         -- Andreas, 2015-02-14
         -- Some builtins cannot be given a valid Agda type,

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -298,12 +298,8 @@ instance ToAbstract (List1 (QNamed R.Clause)) where
 checkClauseTelescopeBindings :: MonadReflectedToAbstract m => [(Text, Arg R.Type)] -> [Arg R.Pattern] -> m ()
 checkClauseTelescopeBindings tel pats =
   case reverse [ x | ((x, _), i) <- zip (reverse tel) [0..], not $ Set.member i bs ] of
-    [] -> return ()
-    xs -> genericDocError $ vcat
-      [ fsep (pwords "Missing bindings for telescope" ++ [ pluralS xs "variable" ])
-        <?> (fsep (punctuate ", " $ map (text . Text.unpack) xs) <> ".")
-      , "All variables in the clause telescope must be bound in the left-hand side."
-      ]
+    []   -> return ()
+    x:xs -> typeError $ MissingBindingsForTelescopeVariables (x :| xs)
   where
     bs = boundVars pats
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1291,6 +1291,12 @@ instance PrettyTCM TypeError where
         nameCxt (x : xs) = ExtendTel (defaultDom (El __DUMMY_SORT__ $ I.var 0)) $
           NoAbs (P.prettyShow x) $ nameCxt xs
 
+    MissingBindingsForTelescopeVariables xs -> vcat
+      [ fsep [ "Missing", pluralS xs "binding", "for", "telescope", pluralS xs "variable" ]
+        <?> (fsep (punctuate ", " $ fmap (text . Text.unpack) xs) <> ".")
+      , "All variables in the clause telescope must be bound in the left-hand side."
+      ]
+
     NeedOptionAllowExec -> fsep $
       pwords "Option --allow-exec needed to call external commands from macros"
 

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -147,6 +147,7 @@ typeErrorName = \case
   MetaErasedSolution                                         {} -> MetaErasedSolution_
   MetaIrrelevantSolution                                     {} -> MetaIrrelevantSolution_
   MismatchedProjectionsError                                 {} -> MismatchedProjectionsError_
+  MissingBindingsForTelescopeVariables                       {} -> MissingBindingsForTelescopeVariables_
   ModuleArityMismatch                                        {} -> ModuleArityMismatch_
   ModuleDefinedInOtherFile                                   {} -> ModuleDefinedInOtherFile_
   ModuleNameDoesntMatchFileName                              {} -> ModuleNameDoesntMatchFileName_

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5493,6 +5493,7 @@ data TypeError
         | UnquoteFailed UnquoteError
         | DeBruijnIndexOutOfScope Nat Telescope [Name]
             -- ^ The list can be empty.
+        | MissingBindingsForTelescopeVariables (List1 Text)
     -- Language option errors
         | NeedOptionAllowExec
         | NeedOptionCopatterns

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -1045,29 +1045,6 @@ trFillTel' flag delta phi args r = do
 
 
 
--- hcompTel' :: Bool -> Telescope -> [(Term,Abs [Term])] -> [Term] -> ExceptT (Closure (Abs Type)) TCM [Term]
--- hcompTel' b delta sides base = undefined
-
--- hFillTel' :: Bool -> Telescope -- Γ ⊢ Δ
---           -> [(Term,Abs [Term])]  -- [(φ,i.δ)] with  Γ,φ ⊢ i.δ : I → Δ
---           -> [Term]            -- Γ ⊢ δ0 : Δ, matching the [(φ,i.δ)]
---           -> Term -- Γ ⊢ r : I
---           -> ExceptT (Closure (Abs Type)) TCM [Term]
--- hFillTel' b delta sides base = undefined
-
-pathTelescope :: forall m. (PureTCM m, MonadError TCErr m)
-  => Telescope  -- ^ Δ
-  -> [Arg Term] -- ^ lhs : Δ
-  -> [Arg Term] -- ^ rhs : Δ
-  -> m Telescope
-pathTelescope tel lhs rhs = do
-  runExceptT (pathTelescope' tel lhs rhs) >>= \case
-    Left t -> do
-      enterClosure t $ \ t ->
-                 typeError . GenericDocError =<<
-                    (text "The sort of" <+> pretty t <+> text "should be of the form \"Set l\"")
-    Right tel -> return tel
-
 pathTelescope' :: forall m. (PureTCM m, MonadError (Closure Type) m)
   => Telescope  -- ^ Δ
   -> [Arg Term] -- ^ lhs : Δ

--- a/test/Fail/Issue4520.err
+++ b/test/Fail/Issue4520.err
@@ -1,4 +1,16 @@
-Issue4520.agda:20.1-32: error: [GenericDocError]
-Name  fromNat  is ambiguous
+Issue4520.agda:20.1-32: error: [AmbiguousName]
+Ambiguous name fromNat. It could refer to any one of
+  fromNat bound at
+    agda-default-include-path/Agda/Builtin/FromNat.agda:11.5-12
+  fromNat bound at Issue4520.agda:17.5-12
+fromNat is in scope as
+  * a record field Agda.Builtin.FromNat._.fromNat
+    brought into scope by
+    - the opening of Agda.Builtin.FromNat at Issue4520.agda:7.13-33
+    - the application of Number at agda-default-include-path/Agda/Builtin/FromNat.agda:13.6-12
+    - its definition at agda-default-include-path/Agda/Builtin/FromNat.agda:11.5-12
+  * a record field Issue4520._.fromNat brought into scope by
+    - the application of FromNat at Issue4520.agda:18.6-13
+    - its definition at Issue4520.agda:17.5-12
 when scope checking the declaration
   {-# BUILTIN FROMNAT fromNat #-}

--- a/test/Fail/Issue5044.agda
+++ b/test/Fail/Issue5044.agda
@@ -21,7 +21,7 @@ unquoteDef id-ok = defineFun id-ok (idClause-ok ∷ [])
 idClause-fail : Clause
 idClause-fail = clause
              (("A" , hArg (agda-sort (lit 0))) ∷ ("x" , vArg (var 0 [])) ∷ [])
-             ({-hArg (var 1) ∷-} vArg (var 0) ∷ [])
+             ({-hArg (var 1) ∷-} vArg (var 0) ∷ [])  -- "A" (var 1) not bound here
              (var 0 [])
 
 id-fail : {A : Set} → A → A

--- a/test/Fail/Issue5044.err
+++ b/test/Fail/Issue5044.err
@@ -1,3 +1,3 @@
-Issue5044.agda:28.1-60: error: [GenericDocError]
-Missing bindings for telescope variable A.
+Issue5044.agda:28.1-60: error: [MissingBindingsForTelescopeVariables]
+Missing binding for telescope variable A.
 All variables in the clause telescope must be bound in the left-hand side.


### PR DESCRIPTION
- **Re #7225 (generic error): new error MissingBindingsForTelescopeVariables**
  

- **Re #7225: Rules.Builtin: use AmbiguousName instead of GenericDocError**
  

- **Re #7225: remove pathTelescope that has a unreproduced GenericDocError**
  Produce a NoLeftInv.CantTranport' instead
  

- **TypeChecking.Generalize: add some type signatures**
  