### PR TITLE
Rename GenericDocErrors in Generalize.hs

### DIFF
--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -160,6 +160,7 @@ data ErrorName
   | FileNotFound_
   | ForcedConstructorNotInstantiated_
   | FunctionTypeInSizeUniv_
+  | GeneralizationFailed_
   | GeneralizeCyclicDependency_
   | GeneralizeNotSupportedHere_
   | GeneralizedVarInLetOpenedModule_

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -116,6 +116,7 @@ data ErrorName
   | CannotApply_
   | CannotEliminateWithPattern_
   | CannotEliminateWithProjection_
+  | CannotGeneralizeEtaExpandable_
   | CannotGenerateHCompClause_
   | CannotGenerateTransportClause_
   | CannotQuote_ CannotQuote_

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -161,6 +161,7 @@ data ErrorName
   | ForcedConstructorNotInstantiated_
   | FunctionTypeInSizeUniv_
   | GeneralizationFailed_
+  | GeneralizationPrepruneError_
   | GeneralizeCyclicDependency_
   | GeneralizeNotSupportedHere_
   | GeneralizedVarInLetOpenedModule_

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1331,6 +1331,9 @@ instance PrettyTCM TypeError where
     NeedOptionUniversePolymorphism -> fsep $
       pwords "Universe polymorphism is disabled (use option --universe-polymorphism to allow level arguments to sorts)"
 
+    CannotGeneralizeEtaExpandable x metaType ->
+      ("Cannot generalize over" <+> prettyTCM x <+> "of eta-expandable type") <?> prettyTCM metaType
+
     GeneralizeNotSupportedHere x -> fsep $
       pwords $ "Generalizable variable " ++ prettyShow x ++ " is not supported here"
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -222,6 +222,8 @@ instance PrettyTCM TypeError where
 
     GenericDocError d -> return d
 
+    GeneralizationFailed d -> return d
+
     ExecError err -> prettyTCM err
 
     NicifierError err -> pretty err

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -224,6 +224,16 @@ instance PrettyTCM TypeError where
 
     GeneralizationFailed d -> return d
 
+    GeneralizationPrepruneError d -> vcat
+      [ fsep $ concat
+        [ pwords "Congratulations, you have hit a so far unreproduced error in generalization!"
+        , pwords "Please submit your self-contained reproducer (max 50 lines) at"
+        , [ url "https://github.com/agda/agda/issues/8161" ]
+        , pwords "to earn a honorable mention in the next Agda release."
+        ]
+      , pure d
+      ]
+
     ExecError err -> prettyTCM err
 
     NicifierError err -> pretty err

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -116,6 +116,7 @@ typeErrorName = \case
   FileNotFound                                               {} -> FileNotFound_
   ForcedConstructorNotInstantiated                           {} -> ForcedConstructorNotInstantiated_
   FunctionTypeInSizeUniv                                     {} -> FunctionTypeInSizeUniv_
+  GeneralizationFailed                                       {} -> GeneralizationFailed_
   GeneralizeCyclicDependency                                 {} -> GeneralizeCyclicDependency_
   GeneralizeNotSupportedHere                                 {} -> GeneralizeNotSupportedHere_
   GeneralizedVarInLetOpenedModule                            {} -> GeneralizedVarInLetOpenedModule_

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -73,6 +73,7 @@ typeErrorName = \case
   CannotApply                                                {} -> CannotApply_
   CannotEliminateWithPattern                                 {} -> CannotEliminateWithPattern_
   CannotEliminateWithProjection                              {} -> CannotEliminateWithProjection_
+  CannotGeneralizeEtaExpandable                              {} -> CannotGeneralizeEtaExpandable_
   CannotGenerateHCompClause                                  {} -> CannotGenerateHCompClause_
   CannotGenerateTransportClause                              {} -> CannotGenerateTransportClause_
   CannotResolveAmbiguousPatternSynonym                       {} -> CannotResolveAmbiguousPatternSynonym_

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -117,6 +117,7 @@ typeErrorName = \case
   ForcedConstructorNotInstantiated                           {} -> ForcedConstructorNotInstantiated_
   FunctionTypeInSizeUniv                                     {} -> FunctionTypeInSizeUniv_
   GeneralizationFailed                                       {} -> GeneralizationFailed_
+  GeneralizationPrepruneError                                {} -> GeneralizationPrepruneError_
   GeneralizeCyclicDependency                                 {} -> GeneralizeCyclicDependency_
   GeneralizeNotSupportedHere                                 {} -> GeneralizeNotSupportedHere_
   GeneralizedVarInLetOpenedModule                            {} -> GeneralizedVarInLetOpenedModule_

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -924,8 +924,8 @@ createGenValue x = setCurrentRange x $ do
 
   case term of
     MetaV{} -> return ()
-    _       -> genericDocError =<< ("Cannot generalize over" <+> prettyTCM x <+> "of eta-expandable type") <?>
-                                    prettyTCM metaType
+    _       -> typeError $ CannotGeneralizeEtaExpandable x metaType
+
   return . (m,) $ GeneralizedValue
     { genvalCheckpoint = cp
     , genvalTerm       = term

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -797,7 +797,7 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
             , singPlural late (<> "s") id "depend"  -- NB: this is a singular "s"
             , "on", commas $ Set.toList early
             ]
-      genericDocError =<< vcat
+      typeError . GeneralizationFailed =<< vcat
         [ fwords $ "Variable generalization failed."
         , nest 2 $ sep ["- Probable cause", nest 4 $ fwords cause]
         , nest 2 $ sep ["- Suggestion", nest 4 $ fwords solution]

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -529,7 +529,7 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
     prepruneError :: String -> MetaId -> TCM a
     prepruneError msg x = do
       r <- getMetaRange x
-      genericDocError =<<
+      typeError . GeneralizationPrepruneError =<<
         (fwords (msg ++ " The problematic unsolved meta is") $$
                  nest 2 (prettyTCM (MetaV x []) <+> "at" <+> pretty r)
         )

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5432,6 +5432,7 @@ data TypeError
         | RepeatedVariablesInPattern (List1 C.Name)
         | CannotGeneralizeEtaExpandable A.QName Type
         | GeneralizationFailed Doc
+        | GeneralizationPrepruneError Doc
         | GeneralizeNotSupportedHere A.QName
         | GeneralizedVarInLetOpenedModule A.QName
         | MultipleFixityDecls (List1 (C.Name, Pair Fixity'))

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5431,6 +5431,7 @@ data TypeError
             -- ^ Some names are bound several times by an @import@/@open@ directive.
         | RepeatedVariablesInPattern (List1 C.Name)
         | CannotGeneralizeEtaExpandable A.QName Type
+        | GeneralizationFailed Doc
         | GeneralizeNotSupportedHere A.QName
         | GeneralizedVarInLetOpenedModule A.QName
         | MultipleFixityDecls (List1 (C.Name, Pair Fixity'))

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5430,6 +5430,7 @@ data TypeError
         | RepeatedNamesInImportDirective (List1 (List2 C.ImportedName))
             -- ^ Some names are bound several times by an @import@/@open@ directive.
         | RepeatedVariablesInPattern (List1 C.Name)
+        | CannotGeneralizeEtaExpandable A.QName Type
         | GeneralizeNotSupportedHere A.QName
         | GeneralizedVarInLetOpenedModule A.QName
         | MultipleFixityDecls (List1 (C.Name, Pair Fixity'))

--- a/test/Fail/CannotGeneralizeEtaExpandable.agda
+++ b/test/Fail/CannotGeneralizeEtaExpandable.agda
@@ -1,0 +1,14 @@
+-- Andreas, 2025-10-25, reproduce error CannotGeneralizeEtaExpandable
+
+record ⊤ : Set where
+
+variable
+  x : ⊤
+  P : ⊤ → Set
+
+postulate
+  cant-generalize : P x
+
+-- Expected error: [CannotGeneralizeEtaExpandable]
+-- Cannot generalize over x of eta-expandable type ⊤
+-- when checking that the expression P x is a type

--- a/test/Fail/CannotGeneralizeEtaExpandable.err
+++ b/test/Fail/CannotGeneralizeEtaExpandable.err
@@ -1,0 +1,3 @@
+CannotGeneralizeEtaExpandable.agda:10.23-24: error: [CannotGeneralizeEtaExpandable]
+Cannot generalize over x of eta-expandable type ⊤
+when checking that the expression P x is a type

--- a/test/Fail/Issue3655b.err
+++ b/test/Fail/Issue3655b.err
@@ -1,4 +1,4 @@
-Issue3655b.agda:19.9-10: error: [GenericDocError]
+Issue3655b.agda:19.9-10: error: [GeneralizationFailed]
 Variable generalization failed.
   - Probable cause
       There were unsolved constraints that obscured the dependencies

--- a/test/test-suite-covers-errors.sh
+++ b/test/test-suite-covers-errors.sh
@@ -52,6 +52,7 @@ Exec.ExeNotFound
 Exec.ExeNotTrusted
 FunctionTypeInSizeUniv
 GeneralizeCyclicDependency
+GeneralizationPrepruneError
 ModuleNameHashCollision
 SplitError.CosplitNoTarget
 SplitError.GenericSplitError


### PR DESCRIPTION
- **Re #7225: new error CannotGeneralizeEtaExpandable and reproducer**
  

- **Re #7225: new error GeneralizationFailed**
  Unstructured error, just cloning the GenericDocError.
  

- **Re #7225: new error GeneralizationPrepruneError (easter egg)**
  If you find an easter egg, submit it to #8161.  (FYI @jespercockx )
  