### PR TITLE
Do not set default input method to "Agda" globally

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -432,11 +432,9 @@ agda2-include-dirs is not bound." :warning))
                    (error-message-string err))))
  (agda2-comments-and-paragraphs-setup)
  (force-mode-line-update)
- ;; Protect global value of default-input-method from set-input-method.
- (make-local-variable 'default-input-method)
  ;; Don't take script into account when determining word boundaries
  (set (make-local-variable 'word-combining-categories) (cons '(nil . nil) word-combining-categories))
- (set-input-method "Agda")
+ (activate-input-method "Agda")
  ;; Highlighting etc. is removed when we switch from the Agda mode.
  ;; Use case: When a file M.lagda with a local variables list
  ;; including "mode: latex" is loaded chances are that the Agda mode


### PR DESCRIPTION
The function 'set-input-method' sets the default input method for the entire Emacs session.  By instead calling 'activate-input-method' we do not change the value of 'default-input-method' for the entire session, but just restrict our change to the current buffer.

(This change was initially proposed in #6536, see #5917)