### PR TITLE
Add .agdai files to 'completion-ignored-extensions'

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -375,6 +375,8 @@ Note that this variable is not buffer-local.")
 ;;;; agda2-mode
 
 ;;;###autoload
+(add-to-list 'completion-ignored-extensions ".agdai")
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.l?agda\\'" . agda2-mode))
 ;;;###autoload
 (modify-coding-system-alist 'file "\\.l?agda\\'" 'utf-8)

--- a/src/data/emacs-mode/agda2.el
+++ b/src/data/emacs-mode/agda2.el
@@ -11,6 +11,7 @@
 
 (autoload 'agda2-mode "agda2-mode"
   "Major mode for editing Agda files (version ≥ 2)." t)
+(add-to-list 'completion-ignored-extensions ".agdai")
 (add-to-list 'auto-mode-alist '("\\.l?agda\\'" . agda2-mode))
 (modify-coding-system-alist 'file "\\.l?agda\\'" 'utf-8)
 


### PR DESCRIPTION
This variable tracks extensions that denote files that are usually not interesting for users to open.  As interface files store results of the type checking process in a non-human readable form, it makes sense to have them treated with a lower priority by find-file, Dired, etc.

(This change was initially proposed in https://github.com/agda/agda/pull/6536, see https://github.com/agda/agda/issues/5917)