### PR TITLE
Add custom setter to 'agda2-mode-abbrevs-use-defaults'

### DIFF
--- a/src/data/emacs-mode/agda2-abbrevs.el
+++ b/src/data/emacs-mode/agda2-abbrevs.el
@@ -78,27 +78,33 @@
   ("oi"  "open import "))
   "Abbreviations defined by default in the Agda mode.")
 
+(defvar agda2-mode-abbrevs-use-defaults)
+(defvar agda2-mode-abbrev-table nil "Agda mode abbrev table.")
+
+(defun agda2-mode-abbrevs-use-defaults ()
+  "Load or disable Agda abbrevs."
+  (define-abbrev-table
+    'agda2-mode-abbrev-table
+    (and agda2-mode-abbrevs-use-defaults
+         (mapcar (lambda (abbrev)
+                   (append abbrev
+                           (make-list (- 4 (length abbrev)) nil)
+                           '((:system t))))
+                 agda2-abbrevs-defaults))))
+
 (defcustom agda2-mode-abbrevs-use-defaults nil
   "If non-nil include the default Agda mode abbrevs in `agda2-mode-abbrev-table'.
 The abbrevs are designed to be expanded explicitly, so users of `abbrev-mode'
 probably do not want to include them.
 
-Restart Emacs in order for this change to take effect."
+You do not need to restart Emacs in order for this change to take
+effect, if you adjust the value using the Customize UI or a macro like
+`setopt'."
   :group 'agda2
-  :type '(choice (const :tag "Yes" t)
-                 (const :tag "No" nil)))
-
-(defvar agda2-mode-abbrev-table nil
-  "Agda mode abbrev table.")
-
-(define-abbrev-table
-  'agda2-mode-abbrev-table
-  (if agda2-mode-abbrevs-use-defaults
-      (mapcar (lambda (abbrev)
-                (append abbrev
-                        (make-list (- 4 (length abbrev)) nil)
-                        '((:system t))))
-              agda2-abbrevs-defaults)))
+  :set (lambda (sym val)
+         (custom-set-default sym val)
+         (agda2-mode-abbrevs-use-defaults))
+  :type 'boolean)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Administrative details


### PR DESCRIPTION
By using a custom setter, the user option can be changed after agda2-abbrevs has been loaded and will have an immediate effect, and doesn't require the entire session to be restarted.

(This change was initially proposed in https://github.com/agda/agda/pull/6536, see https://github.com/agda/agda/issues/5917)