### PR TITLE
Check responses of commands issued by Agda to Emacs

### DIFF
--- a/src/data/emacs-mode/agda2-highlight.el
+++ b/src/data/emacs-mode/agda2-highlight.el
@@ -12,6 +12,7 @@
 
 (require 'annotation)
 (require 'font-lock)
+(require 'agda2)
 
 (defgroup agda2-highlight nil
   "Syntax highlighting for Agda."
@@ -577,7 +578,9 @@ removed. Otherwise all token-based syntax highlighting is removed."
 
 (defun agda2-highlight-add-annotations (remove &rest cmds)
   "Like `agda2-highlight-apply'.
-But only if `agda2-highlight-in-progress' is non-nil."
+But only if `agda2-highlight-in-progress' is non-nil.  See
+`agda2-highlight-apply' for details on REMOVE and CMDS."
+  (declare (agda2-command (boolean &repeat list)))
   (if agda2-highlight-in-progress
       (apply 'agda2-highlight-apply remove cmds)))
 
@@ -596,6 +599,7 @@ Old syntax highlighting information is not removed."
   "Like `agda2-highlight-load', but deletes FILE when done.
 And highlighting is only updated if `agda2-highlight-in-progress'
 is non-nil."
+  (declare (agda2-command (string)))
   (unwind-protect
       (if agda2-highlight-in-progress
           (agda2-highlight-load file))
@@ -606,6 +610,7 @@ is non-nil."
 
 If TOKEN-BASED is non-nil, then only token-based highlighting is
 removed."
+  (declare (agda2-command (boolean)))
   (interactive)
   (let ((inhibit-read-only t))
        ; Ignore read-only status, otherwise this function may fail.

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -612,6 +612,7 @@ May be more efficient than restarting Agda."
   "Resets certain variables.
 Intended to be used by the backend if an abort command was
 successful."
+  (declare (agda2-command ()))
   (agda2-info-action "*Aborted*" "Aborted." t)
   (setq agda2-highlight-in-progress nil
         agda2-last-responses        nil))
@@ -789,16 +790,43 @@ command is sent to Agda (if it is sent)."
              (if input-from-goal (agda2-goal-Range o) (agda2-mkRange nil))
              (agda2-string-quote txt) args))))
 
-;; Note that the following function is a security risk, since it
-;; evaluates code without first inspecting it. The code (supposedly)
-;; comes from the Agda backend, but there could be bugs in the backend
-;; which can be exploited by an attacker which manages to trick
-;; someone into type-checking compromised Agda code.
-
 (defun agda2-exec-response (response)
-  "Interprets response."
-  (let ((inhibit-read-only t))
-    (eval response)))
+  "Execute RESPONSE if recognised by `agda2-handler-alist'."
+  (cl-assert (symbolp (car-safe response)))
+  ;; Agda sends us a an S-expression that we can just `eval'uate.  To
+  ;; avoid arbitrary code execution and ensure that the commands Agda
+  ;; sends us are well-formed, we use `apply' without evaluating any
+  ;; arguments.  The symbol of the invoked function must have a
+  ;; `agda2-safe-function' symbol property asserting the expected
+  ;; types of all arguments, w.r.t `cl-typep'.
+  (save-buffer)
+  (unwind-protect
+      (let* ((inhibit-read-only t)
+             (func (car response))
+             (safe-p (plist-member (symbol-plist func) 'agda2-safe-function))
+             (safe-data (cadr safe-p))
+             (args '()))
+        (unless safe-p
+          (error "The function `%S' is not a valid Agda command" func))
+        ;; Check each argument
+        (dolist (arg (cdr response))
+          (when (null safe-data)
+            (error "More arguments than expected for `%S' (%S, got %S)"
+                   func safe-data response))
+          (when (eq (car-safe arg) 'quote) ;unquote arguments
+            (setq arg (cadr arg)))
+          (let ((type (pop safe-data)))
+            (unless (cl-typep arg type)
+              (error "The function `%S' was invoked with %S which is not a %S"
+                     func arg type)))
+          (push arg args))
+        (condition-case err
+            (with-local-quit
+              (apply func (nreverse args)))
+          (error (warn "Error while evaluating %S: %S" response err))))
+    (setq agda2-in-progress nil)))
+
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; User commands and response processing
@@ -882,6 +910,10 @@ The action depends on the prefix argument:
 
 (defun agda2-give-action (old-g paren)
   "Update the goal OLD-G with the expression in it."
+  (declare (agda2-command (integer (or (eql paren)
+                                       (eql no-paren)
+                                       string
+                                       null))))
   (let
      ;; Don't run modification hooks: we don't want this to
       ;; trigger agda2-abort-highlighting.
@@ -915,6 +947,7 @@ Assumes that <clause> = {!<variables>!} is on one line."
 
 (defun agda2-make-case-action (newcls)
   "Replace the line at point with new clauses NEWCLS and reload."
+  (declare (agda2-command (list)))
   (agda2-forget-all-goals);; we reload later anyway.
   (let* ((p0 (point))
          (p1 (goto-char (+ (current-indentation) (line-beginning-position))))
@@ -929,6 +962,7 @@ Assumes that <clause> = {!<variables>!} is on one line."
 
 (defun agda2-make-case-action-extendlam (newcls)
   "Replace definition of extended lambda with new clauses NEWCLS and reload."
+  (declare (agda2-command (list)))
   (agda2-forget-all-goals);; we reload later anyway.
   (let* ((p0 (point))
          (pmax (re-search-forward "!}"))
@@ -956,6 +990,7 @@ Assumes that <clause> = {!<variables>!} is on one line."
   "Display the string STATUS in the current buffer's mode line.
 \(precondition: the current buffer has to use the Agda mode as the
 major mode)."
+  (declare (agda2-command (string)))
   (setq agda2-buffer-external-status status)
   (force-mode-line-update))
 
@@ -1079,6 +1114,7 @@ buffer, and point placed after this text.
 
 If APPEND is nil, then any previous text is removed before TEXT
 is inserted, and point is placed before this text."
+  (declare (agda2-command (string string boolean &repeat t))) ;
   (interactive)
   (let ((buf (agda2-info-buffer)))
     (with-current-buffer buf
@@ -1129,6 +1165,7 @@ is inserted, and point is placed before this text."
 
 (defun agda2-info-action-and-copy (name text &optional append)
   "Same as agda2-info-action but also puts TEXT in the kill ring."
+  (declare (agda2-command (string string t)))
   (kill-new text)
   (agda2-info-action name text append))
 
@@ -1501,6 +1538,7 @@ Either only one if point is a goal, or all of them."
 )
 
 (defun agda2-solveAll-action (iss)
+  (declare (agda2-command (list)))
   (while iss
     (let* ((g (pop iss)) (txt (pop iss))
            (cmd (cons 'agda2-solve-action (cons g (cons txt nil)))))
@@ -1605,6 +1643,7 @@ which they appear in the buffer. Note that this function should
 be run /after/ syntax highlighting information has been loaded,
 because the two highlighting mechanisms interact in unfortunate
 ways."
+  (declare (agda2-command (list)))
   (agda2-forget-all-goals)
   (agda2-let
       ((literate (agda2-literate-p))
@@ -1995,6 +2034,7 @@ FILE (assuming that the FILE is readable). Otherwise point is
 moved to the given position in the buffer visiting the file, if
 any, and in every window displaying the buffer, but the window
 configuration and the selected window are not changed."
+  (declare (agda2-command (cons)))
   (when (and agda2-highlight-in-progress
              (consp filepos)
              (stringp (car filepos))

--- a/src/data/emacs-mode/agda2.el
+++ b/src/data/emacs-mode/agda2.el
@@ -4,6 +4,40 @@
 ;; loaded
 ;; SPDX-License-Identifier: MIT License
 
+;;; Code:
+
+;; By adding an `agda2--mark-as-safe' to `defun-declarations-alist',
+;; we can use the `declare' syntax at the beginning of a `defun' to
+;; denote that the function may be invoked and what form the arguments
+;; ought to have.
+(eval-and-compile
+  (defun agda2--mark-as-safe (fn _args type)
+    "Set the `agda2-safe-function' property for the function FN.
+TYPE must be a list of `cl-typep'-compatible types that will
+each be checked against the arguments when invoked.  This
+information is used by `agda2-exec-response' to safeguard the
+execution."
+    ;; Handle a `&repeat' in the safe argument spec by creating a
+    ;; cyclic list.  We copy the list to avoid destructively modifying
+    ;; the argument list, which might be part of the physical code
+    ;; structure.
+    (dolist (arg type)
+      (when (and (symbolp arg)
+                 (string-match-p "\\`&" (symbol-name arg))
+                 (not (eq '&repeat arg)))
+        (error "%S: Unsupported keyword %S" fn arg)))
+    (let* ((type (copy-sequence type))
+           (rep (memq '&repeat type)))
+      (when rep
+        (setf (car rep) (cadr rep)
+              (cdr rep) (cddr rep)
+              (cdr (last rep)) rep))
+      `(put ',fn 'agda2-safe-function ',type)))
+
+  (add-to-list
+   'defun-declarations-alist
+   (list 'agda2-command #'agda2--mark-as-safe)))
+
 (defvar agda2-directory (file-name-directory load-file-name)
   "Path to the directory that contains agda2.el(c).")
 


### PR DESCRIPTION
This change adds some primitive "type checking" (Common Lisp-style) to ensure that the commands sent to Emacs are of the right form.  To this effect, all functions that Agda may invoke are annotated using `declare` and an error is thrown if the values do not match the declared signature.

I have not managed to re-test this feature extensively, but I hope that the CI or more experienced users will be able to catch any functions that are missing annotations/with wrong annotations.

This change is an overhaul of https://github.com/agda/agda/pull/6537 and doesn't rely on any previous changes, see https://github.com/agda/agda/issues/5917.