### PR TITLE
Xref support for Agda2-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,14 @@ Interaction and emacs mode
   regardless of whether invoked at toplevel or in a hole
   (Issue [#2410](https://github.com/agda/agda/issue/2410)).
 
+* _Go-to-definition_ (`M-.`) is now implemented using Emacs' built-in
+  [Xref].  Basic usage stays the same (`M-.` or using the mouse), but
+  now also includes searching for definitions by exact (`C-u M-.`) or
+  approximate names (`C-M-.`) and listing references (`M-?`) in loaded
+  files.
+
+[Xref]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Xref.html
+
 Backends
 --------
 

--- a/doc/user-manual/tools/emacs-mode.rst
+++ b/doc/user-manual/tools/emacs-mode.rst
@@ -316,11 +316,19 @@ Other commands
 :guilabel:`Middle mouse button`
      Go to definition of identifier clicked on.
 
-:kbd:`M-*`
-     Go back (Emacs < 25.1).
+:kbd:`C-u M-.`
+     Go to definition of a prompted identifier.
+
+:kbd:`M-?`
+     Query a list of references in loaded files
+
+:kbd:`C-M-.`
+     Query a list of identifiers that match a prompt.  The prompt may
+     consist of multiple words that can occur in any order or a
+     regular expression.
 
 :kbd:`M-,`
-     Go back (Emacs ≥ 25.1).
+     Go back to previous location.
 
 .. _unicode-input:
 

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1087,7 +1087,9 @@ The buffer is returned.")
       ;; This allows us to create Agda-style highlighting from aspects
       ;; also in the Agda information buffer.
       (agda2-highlight-setup)
-      ))
+
+      ;; Use Xref
+      (add-hook 'xref-backend-functions #'agda2-xref-backend -90 t)))
 
   ,buffer))
 


### PR DESCRIPTION
This was initially proposed in #6540, but I have now rebased it onto master with no additional dependencies (there might be merge-conflicts with the other PRs tough, not sure).

The idea here is the same as before, Xref is a standard Emacs UI for jumping to definition.  Having a separate UI for the same thing inevitably runs up against minor paper cuts that annoy the user.  As Xref supports a superset of what the annotation-based implementation provided, I hope that the approach is satisfactory and will not annoy anyone.  IIRC new features we get for free include <kbd>C-u M-.</kbd> supporting prompting of identifiers and a grep-based backend to search for occurrences (eventually it would be better if we could replace this with a proper backend).  A new feature is <kbd>C-M-.</kbd> (`xref-find-apropos`) that searches all open buffers for their identifiers and allows you to issue queries involving subphrases that might occur in an identifier in any order or regular expressions.

See https://github.com/agda/agda/issues/5917.

As mentioned in https://github.com/agda/agda/pull/6123#issuecomment-1470375006 this merges annotations.el into agda2-highlight.el, as this changes makes  the former become an unnecessary indirection.