### PR TITLE
Debugging issue #8182

### DIFF
--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -40,7 +40,7 @@ import Agda.Utils.CallStack ( withCurrentCallStack )
 import qualified Agda.Utils.List1 as List1
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
-import Agda.Utils.Null ()
+import Agda.Utils.Null (unlessNullM)
 import qualified Agda.Interaction.Options.ProfileOptions as Profile
 import Agda.Utils.Singleton
 
@@ -251,10 +251,11 @@ solveSomeAwakeConstraintsTCM solveThis force = do
      locallyTC eActiveProblems (const Set.empty) solve
   where
     solve = do
-      reportSDoc "tc.constr.solve" 10 $ hsep [ "Solving awake constraints."
-                                             , text . show . length =<< getAwakeConstraints
-                                             , "remaining." ]
-      whenJustM (takeAwakeConstraint' solveThis) $ \ c -> do
+      verboseS "tc.constr.solve" 10 do
+        unlessNullM getAwakeConstraints \ cs ->
+          reportSDoc "tc.constr.solve" 10 $ hsep
+            [ "Solving awake constraints.", text . show $ length cs, "remaining."]
+      whenJustM (takeAwakeConstraint' solveThis) \ c -> do
         withConstraint solveConstraint c
         solve
 

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -19,9 +19,9 @@ foo : SomeType xs
 generalisation should produce @{A : Set} {n : Nat} {xs : Vec A n} → SomeType xs@ for the type of
 @foo@.
 
-The functions `generalizeType` and `generalizeTelescope` don't have access to the abstract syntax to
+The functions 'generalizeType' and 'generalizeTelescope' don't have access to the abstract syntax to
 be type checked (@SomeType xs@ in the example). Instead they are provided a type checking action
-that delivers a `Type` or a `Telescope`. The challenge is setting up a context in which @SomeType
+that delivers a 'Type' or a 'Telescope'. The challenge is setting up a context in which @SomeType
 xs@ can be type checked successfully by this action, without knowing what the telescope of
 generalised variables will be. Once we have computed this telescope the result needs to be
 transformed into a well typed type abstracted over it.
@@ -37,14 +37,14 @@ variable.
 
 In more detail, generalisation proceeds as follows:
 
-- Add a variable @genTel@ of an unknown type to the context (`withGenRecVar`).
+- Add a variable @genTel@ of an unknown type to the context ('withGenRecVar').
 
 @
   (genTel : _GenTel)
 @
 
 - Create metavariables for the generalisable variables appearing in the problem and their
-  dependencies (`createGenValues`). In the example this would be
+  dependencies ('createGenValues'). In the example this would be
 
 @
   (genTel : _GenTel) ⊢
@@ -53,16 +53,16 @@ In more detail, generalisation proceeds as follows:
     _xs : Vec _A _n
 @
 
-- Run the type checking action (`createMetasAndTypeCheck`), binding the mentioned generalisable
+- Run the type checking action ('createMetasAndTypeCheck'), binding the mentioned generalisable
   variables to the corresponding newly created metavariables. This binding is stored in
-  `eGeneralizedVars` and picked up in `Agda.TypeChecking.Rules.Application.inferDef`
+  'eGeneralizedVars' and picked up in 'Agda.TypeChecking.Rules.Application.inferDef'
 
 @
   (genTel : _GenTel) ⊢ SomeType (_xs genTel)
 @
 
-- Compute the telescope of generalised variables (`computeGeneralization`). This is done by taking
-  the unconstrained metavariables created by `createGenValues` or created during the type checking
+- Compute the telescope of generalised variables ('computeGeneralization'). This is done by taking
+  the unconstrained metavariables created by 'createGenValues' or created during the type checking
   action and sorting them into a well formed telescope.
 
 @
@@ -70,7 +70,7 @@ In more detail, generalisation proceeds as follows:
 @
 
 - Create a record type @GeneralizeTel@ whose fields are the generalised variables and instantiate
-  the type of @genTel@ to it (`createGenRecordType`).
+  the type of @genTel@ to it ('createGenRecordType').
 
 @
   record GeneralizeTel : Set₁ where
@@ -89,7 +89,7 @@ In more detail, generalisation proceeds as follows:
   _xs := λ genTel → genTel .xs
 @
 
-- Build the unpacking substitution (`unpackSub`) that maps terms in @(genTel : GeneralizeTel)@ to
+- Build the unpacking substitution ('unpackSub') that maps terms in @(genTel : GeneralizeTel)@ to
   terms in the context of the generalised variables by substituting a record value for @genTel@.
 
 @
@@ -104,8 +104,8 @@ In more detail, generalisation proceeds as follows:
   {A : Set} {n : Nat} {xs : Vec A n} → SomeType xs
 @
 
-- In case of `generalizeType` return the resulting pi type.
-- In case of `generalizeTelescope` enter the resulting context, applying the unpacking substitution
+- In case of 'generalizeType' return the resulting pi type.
+- In case of 'generalizeTelescope' enter the resulting context, applying the unpacking substitution
   to let bindings (TODO #6916: and also module applications!) created in the telescope, and call the
   continuation.
 

--- a/test/Bugs/Issue8182.agda
+++ b/test/Bugs/Issue8182.agda
@@ -1,0 +1,19 @@
+-- Andreas, 2025-11-03, issue #8182 reported and test by Szumi Xie
+
+{-# OPTIONS --show-implicit #-}
+{-# OPTIONS -v tc.generalize:10 #-}
+{-# OPTIONS -v tc.rec:40 #-}
+{-# OPTIONS -v tc.interaction:30 #-}
+
+postulate
+  P : (A : Set) → A → Set
+  F : Set → Set
+  g : (A : Set) → F A
+
+variable G : Set
+
+record R : Set₁ where
+  h : G → P ? (g ?)
+  h = ?
+
+  field B : Set

--- a/test/Bugs/Issue8182.err
+++ b/test/Bugs/Issue8182.err
@@ -1,0 +1,55 @@
+AGDA_FAILURE
+
+ret > ExitFailure 154
+out > computing generalization for type _2
+out > we're generalizing over
+out > checking record def R
+out >   ps = []
+out >   contel = (let h : G → P ? (g ?)
+out >                 h = ?)
+out >            (B : Set) →
+out >            Set
+out >   fields = mutual
+out >              syntax h ...
+out >              postulate h : G → P ? (g ?)
+out >              h = ?
+out >            syntax B ...
+out > checking fields
+out > Found interaction point ConcreteDef ?0 : Set
+out > Found interaction point ConcreteDef ?1 : Set
+out > computing generalization for type _3
+out > we're generalizing over _G_4
+out > Found interaction point
+out > ConcreteDef
+out > ?2
+out > :
+out > {G : Set} → G → P (F (?1 {G = G})) (g (?1 {G = G}))
+out > contype =  Set → Set
+out > gamma = 
+out > adding record type to signature
+out > record constructor is  Issue8182.R.constructor
+out > record section: R (r : R) [], [Issue8182.R.B]
+out >   field tel = (B : Set)
+out > Found interaction point ConcreteDef ?0 : Set
+out > reusing meta
+out >   creation context: [(genTel : Issue8182..GeneralizeTel)]
+out >   reusage  context: [(genTel : _11 (r = genTel)), (r : R)]
+out >   k     = 1
+out >   glen  = 1
+out >   g0len = 0
+out >   g1len = 1
+out >   d2len = 0
+out > meta reuse arguments: [genTel]
+out > Found interaction point ConcreteDef ?1 : Set
+out > reusing meta
+out >   creation context: [{G : Set}]
+out >   reusage  context: [(genTel : _11 (r = genTel)), (r : R)]
+out >   k     = 1
+out >   glen  = 1
+out >   g0len = 0
+out >   g1len = 0
+out >   d2len = 1
+out >   fs    = [(Issue8182.R.B)]
+out >   gfs   = [G]
+out > An internal error has occurred. Please report this as a bug.
+out > Location of the error: __IMPOSSIBLE__, called at src/full/Agda/TypeChecking/MetaVars.hs:«line»:«col» in «Agda-package»:Agda.TypeChecking.MetaVars


### PR DESCRIPTION
- **Fix haddock syntax in module doc of Generalize.hs**
  

- **[debug] do not announce "Solving awake constraints." if there are none**
  

- **Re #8182 #5478: sanity check field names in meta reuse heuristics**
  This reports the `__IMPOSSIBLE__` earlier for #8182.
  