### PR TITLE
TermCheck: remove stripAllProjections, small optimizations

### DIFF
--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -402,6 +402,12 @@ isProjectionButNotCoinductive qn = liftTCM $ do
               -> isInductiveRecord (unArg t)
             _ -> return False
 
+-- | Is the given elimination anything but a coinductive projection?
+elimNotCoinductive :: MonadTCM tcm => Elim' t -> tcm Bool
+elimNotCoinductive e = case isProjElim e of
+  Nothing      -> return True
+  Just (_o, x) -> isProjectionButNotCoinductive x
+
 -- | Check whether a projection belongs to a coinductive record
 --   and is actually recursive.
 --   E.g.

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -1277,7 +1277,7 @@ compareTerm' v mp@(Masked m p) = do
   suc  <- terGetSizeSuc
   cutoff <- terGetCutOff
   let ?cutoff = cutoff
-  v <- liftTCM (instantiate v)
+  -- v <- liftTCM (instantiate v) -- call extraction already instantiates metas in call arguments
   let fallback = return $ subTerm v p
   case (v, p) of
 


### PR DESCRIPTION
- **Refactor TermCheck: remove stripAllProjections, strip locally instead**
  `stripAllProjections` produced ill-typed terms, which limits our options in `compareTerm`, and also produces confusing debug printing.
  We should not produce ill-typed terms if there is not hard need to do so.
  We can strip off projections locally, now we do so in `compareTerm` and `termToDBP`.
  

- **Small refactor TermCheck: compareTerm' expects reduceConP happened**
  

- **Small refactor TermCheck: `reduce` locally in `termToPattern`**
  (rather than `normalise` before)
  

- **Small refactor TermCheck: superfluous `instantiate` in `compareTerm'`**
  
Update: closes #3041 
- #3041