### PR TITLE
Remove clones of constructorForm and enterClosure

### DIFF
--- a/src/full/Agda/TypeChecking/CompiledClause/Match.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Match.hs
@@ -11,9 +11,8 @@ import Agda.Syntax.Common
 import Agda.Syntax.Common.Pretty (prettyShow)
 
 import Agda.TypeChecking.CompiledClause
-import Agda.TypeChecking.Monad hiding (constructorForm)
+import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Reduce
-import Agda.TypeChecking.Reduce.Monad as RedM
 import Agda.TypeChecking.Substitute
 
 import Agda.Utils.Maybe

--- a/src/full/Agda/TypeChecking/Coverage/Match.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Match.hs
@@ -386,10 +386,7 @@ isLitP _ = return Nothing
 {-# SPECIALIZE unLitP :: Pattern' a -> TCM (Pattern' a) #-}
 unLitP :: HasBuiltins m => Pattern' a -> m (Pattern' a)
 unLitP (LitP info l@(LitNat n)) | n >= 0 = do
- constructorForm'
-   (fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinZero)
-   (fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSuc)
-   (Lit l) >>= \case
+ constructorForm (Lit l) >>= \case
   Con c ci es -> do
     let toP (Apply (Arg i (Lit l))) = Arg i (LitP info l)
         toP _ = __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -228,10 +228,19 @@ constructorForm :: HasBuiltins m => Term -> m Term
 constructorForm v = do
   let pZero = fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinZero
       pSuc  = fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSuc
+  -- By passing the builtins lazily we do not have to look them up if @v@ is not a 'LitNat'.
   constructorForm' pZero pSuc v
+
+-- | Produce a function that rewrites a literal to constructor form if possible.
+constructorFormer :: HasBuiltins m => m (Term -> Term)
+constructorFormer = do
+  mz <- getBuiltin' builtinZero
+  ms <- getBuiltin' builtinSuc
+  return \ v -> fromMaybe v (constructorForm' mz ms v)
 
 {-# INLINABLE constructorForm' #-}
 {-# SPECIALIZE constructorForm' :: TCM Term -> TCM Term -> Term -> TCM Term #-}
+{-# SPECIALIZE constructorForm' :: Maybe Term -> Maybe Term -> Term -> Maybe Term #-}
 constructorForm' :: Applicative m => m Term -> m Term -> Term -> m Term
 constructorForm' pZero pSuc v =
   case v of

--- a/src/full/Agda/TypeChecking/Monad/Closure.hs
+++ b/src/full/Agda/TypeChecking/Monad/Closure.hs
@@ -16,6 +16,7 @@ enterClosure :: (MonadTCEnv m, ReadTCState m, LensClosure c a)
 enterClosure c k | Closure _sig env scope cps x <- c ^. lensClosure = do
   isDbg <- viewTC eIsDebugPrinting
   evalWithScope scope
+      -- TODO: use the signature here? would that fix parts of issue #118?
     $ locallyTCState stModuleCheckpoints (const cps)
     $ withEnv env{ envIsDebugPrinting = isDbg }
     $ k x

--- a/src/full/Agda/TypeChecking/Patterns/Match.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Match.hs
@@ -18,7 +18,7 @@ import Agda.Syntax.Internal.Pattern
 import Agda.TypeChecking.Reduce
 import Agda.TypeChecking.Reduce.Monad
 import Agda.TypeChecking.Substitute
-import Agda.TypeChecking.Monad hiding (constructorForm)
+import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Builtin (getName', builtinHComp)
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -609,10 +609,7 @@ primTransHComp cmd ts nelims = do
       let iNeg t = tNeg `apply` [argN t]
           iMin t u = tMin `apply` [argN t, argN u]
           iz = pure iZ
-      constrForm <- do
-        mz <- getTerm' builtinZero
-        ms <- getTerm' builtinSuc
-        return $ \ t -> fromMaybe t (constructorForm' mz ms t)
+      constrForm <- constructorFormer
       su  <- reduceB' u
       sa0 <- reduceB' a0
       view   <- intervalView'
@@ -689,10 +686,7 @@ primTransHComp cmd ts nelims = do
           getTermLocal = getTerm $ getBuiltinId builtinTrans ++ " for data types"
       let sc = famThing <$> fsc
       mhcompName <- getName' builtinHComp
-      constrForm <- do
-        mz <- getTerm' builtinZero
-        ms <- getTerm' builtinSuc
-        return $ \ t -> fromMaybe t (constructorForm' mz ms t)
+      constrForm <- constructorFormer
       sa0 <- reduceB' a0
       let f = unArg . ignoreBlocking
           phi = f sphi

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -46,7 +46,7 @@ import Agda.Syntax.Scope.Base (Scope)
 import Agda.Syntax.Literal
 
 import {-# SOURCE #-} Agda.TypeChecking.Irrelevance (isPropM)
-import Agda.TypeChecking.Monad hiding ( enterClosure )
+import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.CompiledClause
 import Agda.TypeChecking.EtaContract

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -46,7 +46,7 @@ import Agda.Syntax.Scope.Base (Scope)
 import Agda.Syntax.Literal
 
 import {-# SOURCE #-} Agda.TypeChecking.Irrelevance (isPropM)
-import Agda.TypeChecking.Monad hiding ( enterClosure, constructorForm )
+import Agda.TypeChecking.Monad hiding ( enterClosure )
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.CompiledClause
 import Agda.TypeChecking.EtaContract

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -3,8 +3,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Agda.TypeChecking.Reduce.Monad
-  ( constructorForm
-  , enterClosure
+  ( enterClosure
   , getConstInfo
   , askR, applyWhenVerboseS
   ) where
@@ -12,14 +11,13 @@ module Agda.TypeChecking.Reduce.Monad
 import Prelude hiding (null)
 
 import qualified Data.Map as Map
-import Data.Maybe
 
 import System.IO.Unsafe
 
 import Agda.Syntax.Common.Pretty () --instance only
 import Agda.Syntax.Internal
 
-import Agda.TypeChecking.Monad hiding (enterClosure, constructorForm)
+import Agda.TypeChecking.Monad hiding (enterClosure)
 import Agda.TypeChecking.Substitute
 
 import Agda.Utils.Lens
@@ -31,12 +29,6 @@ instance HasBuiltins ReduceM where
     liftM2 (unionMaybeWith unionBuiltin)
       (Map.lookup b <$> useR stLocalBuiltins)
       (Map.lookup b <$> useR stImportedBuiltins)
-
-constructorForm :: HasBuiltins m => Term -> m Term
-constructorForm v = do
-  mz <- getBuiltin' builtinZero
-  ms <- getBuiltin' builtinSuc
-  return $ fromMaybe v $ constructorForm' mz ms v
 
 enterClosure :: LensClosure c a => c -> (a -> ReduceM b) -> ReduceM b
 enterClosure c | Closure _sig env scope cps x <- c ^. lensClosure = \case

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -17,10 +17,9 @@ import System.IO.Unsafe
 import Agda.Syntax.Common.Pretty () --instance only
 import Agda.Syntax.Internal
 
-import Agda.TypeChecking.Monad hiding (enterClosure)
+import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Substitute
 
-import Agda.Utils.Lens
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 
@@ -29,17 +28,6 @@ instance HasBuiltins ReduceM where
     liftM2 (unionMaybeWith unionBuiltin)
       (Map.lookup b <$> useR stLocalBuiltins)
       (Map.lookup b <$> useR stImportedBuiltins)
-
-enterClosure :: LensClosure c a => c -> (a -> ReduceM b) -> ReduceM b
-enterClosure c | Closure _sig env scope cps x <- c ^. lensClosure = \case
-  -- The \case is a hack to correctly associate the where block to the rhs
-  -- rather than to the expression in the pattern guard.
-  f -> localR (mapRedEnvSt inEnv inState) (f x)
-    where
-    inEnv   e = env
-    inState s =
-      -- TODO: use the signature here? would that fix parts of issue 118?
-      set stScope scope $ set stModuleCheckpoints cps s
 
 withFreshR :: (ReadTCState m, HasFresh i) => (i -> m a) -> m a
 withFreshR f = do

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -44,7 +44,6 @@ import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records
 import Agda.TypeChecking.Reduce
-import Agda.TypeChecking.Reduce.Monad
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Telescope
 import Agda.TypeChecking.Primitive.Cubical.Base

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -40,7 +40,7 @@ import Agda.TypeChecking.Datatypes
 import Agda.TypeChecking.Free.Reduce
 import Agda.TypeChecking.Irrelevance (isPropM)
 import Agda.TypeChecking.Level
-import Agda.TypeChecking.Monad hiding (constructorForm)
+import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.Records
 import Agda.TypeChecking.Reduce


### PR DESCRIPTION
- **Refactor: remove TypeChecking.Reduce.Monad.constructorForm (duplicate)**
  The duplication of `constructorForm` seems to have happened 12 years ago when `ReduceM` was separated from `TCM` (8ec029b39c16773c05a1d7e5c08e696824a35136) by @UlfNorell .
  It probably was redundant as soon as both were generalized to `HasBuiltin m` (0cbb2cac26c36e9f4cf9a4179be14b18b7a74d5c) by @jespercockx, but somehow survived all the time.
  
- **Refactor: remove special implementation of enterClosure for ReduceM**
  The original implementation is already generic in the monad.
  Also, it is marked as INLINE so we do not need a specialize for ReduceM (I think; @AndrasKovacs , please confirm!).
  