### PR TITLE
PR #8194 ctd.: move desugaring of `open import M args` into scope checker

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -15,7 +15,7 @@ module Agda.Interaction.Imports
   , crSource
 
   , Source(..)
-  , scopeCheckImport
+  , scopeCheckFileImport
   , parseSource
   , typeCheckMain
   , getNonMainInterface
@@ -373,10 +373,10 @@ addImportedThings isig metas ibuiltin patsyns display userwarn
 -- | Scope checks the given module, generating an interface or retrieving an existing one.
 --   Returns the module name and exported scope from the interface.
 --
-scopeCheckImport ::
+scopeCheckFileImport ::
      TopLevelModuleName
   -> TCM (ModuleName, Map ModuleName Scope)
-scopeCheckImport top = do
+scopeCheckFileImport top = do
     reportSLn "import.scope" 15 $ "Scope checking " ++ prettyShow top
     verboseS "import.scope" 30 $ do
       visited <- prettyShow <$> getPrettyVisitedModules

--- a/src/full/Agda/Interaction/Imports.hs-boot
+++ b/src/full/Agda/Interaction/Imports.hs-boot
@@ -9,4 +9,4 @@ import Agda.Syntax.Scope.Base         ( Scope )
 import Agda.Syntax.TopLevelModuleName ( TopLevelModuleName )
 import Agda.TypeChecking.Monad.Base   ( TCM )
 
-scopeCheckImport :: TopLevelModuleName -> TCM (ModuleName, Map ModuleName Scope)
+scopeCheckFileImport :: TopLevelModuleName -> TCM (ModuleName, Map ModuleName Scope)

--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -471,7 +471,7 @@ data AsName' a = AsName
 
 -- | From the parser, we get an expression for the @as@-'Name', which
 --   we have to parse into a 'Name'.
-type AsName = AsName' (Either Expr Name)
+type AsName = AsName' Name
 
 {--------------------------------------------------------------------------
     Declarations

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -68,7 +68,6 @@ import Data.Maybe
 import Data.Traversable      qualified as Trav
 
 import Agda.Syntax.Common hiding (TerminationCheck())
-import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Concrete
 import Agda.Syntax.Concrete.Definitions.Errors
 import Agda.Syntax.Concrete.Definitions.Monad
@@ -80,10 +79,7 @@ import Agda.Syntax.Position
 
 import Agda.Utils.AffineHole
 import Agda.Utils.CallStack  ( HasCallStack, withCallerCallStack )
-import Agda.Utils.Either     ( fromRight )
-import Agda.Utils.Function   ( applyWhenJust )
 import Agda.Utils.Functor
-import Agda.Utils.Hash       ( hashString )
 import Agda.Utils.Lens
 import Agda.Utils.List       ( spanJust )
 import Agda.Utils.List1      ( List1, pattern (:|), (<|) )
@@ -492,9 +488,7 @@ niceDeclarations fixs ds = do
         PatternSyn r n as p -> do
           return ([NicePatternSyn r PublicAccess n as p] , ds)
         Open r x is         -> return ([NiceOpen r x is] , ds)
-        Import op r x as is -> do
-          (dImport, dApp) <- niceImport op r x as is
-          return (maybeToList dImport, applyWhenJust dApp (:) ds)
+        Import opn r x as is-> return ([NiceImport opn r x as is], ds)
 
         UnquoteDecl r xs e -> do
           tc <- use terminationCheckPragma
@@ -1548,10 +1542,10 @@ instance MakePrivate NiceDeclaration where
         unless (null kwr) $
           whenJust (publicOpen dir) \ kwrPublic ->
             lift $ declarationWarning $ OpenImportPrivate r kwrPublic kwr OpenNotImport
-      d@(NiceImport r _x _as _open dir)        -> d <$ do
+      d@(NiceImport opn impR x args dir)       -> d <$ do
         unless (null kwr) $
           whenJust (publicOpen dir) \ kwrPublic ->
-            lift $ declarationWarning $ OpenImportPrivate r kwrPublic kwr ImportMayOpen
+            lift $ declarationWarning $ OpenImportPrivate (getRange (opn, impR, x, args, dir)) kwrPublic kwr ImportMayOpen
       -- Andreas, 2016-07-08, issue #2089
       -- we need to propagate 'private' to the named where modules
       FunDef r ds a i tc cc x cls              -> FunDef r ds a i tc cc x <$> mkPrivate kwr o cls
@@ -1583,78 +1577,6 @@ dropTactic = \case
   TacticAttribute Nothing   -> return ()
   TacticAttribute (Just re) -> declarationWarning $ InvalidTacticAttribute $ getRange re
 
--- | Desugar a raw 'Import' statement from the parser into a 'NiceImport' statement
--- and possibly a module application.
-
-niceImport ::
-     Ranged OpenShortHand  -- ^ @open@ keyword, if any.
-  -> KwRange               -- ^ 'Range' of the @import@ keyword.
-  -> QName                 -- ^ Module to import.
-  -> Either AsName RawOpenArgs
-                           -- ^ Expressions following the module name, possibly ending in @as X@.
-  -> ImportDirective       -- ^ @using hiding renaming@.
-  -> Nice (Maybe NiceDeclaration, Maybe Declaration)
-      -- ^ 'NiceImport' and possibly a 'ModuleMacro'.
-
--- Case: already parsed @as@ clause.
-niceImport (Ranged rOpen doOpen) kwR m (Left asClause) dir =
-    return (Just $ NiceImport r m (Just asClause) doOpen dir, Nothing)
-  where
-    -- The Range of the whole declaration.
-    r = getRange (rOpen, kwR, m, asClause, dir)
-
--- Case: no module arguments, no @as@ clause.
-niceImport (Ranged rOpen doOpen) kwR m (Right []) dir =
-    return (Just $ NiceImport r m Nothing doOpen dir, Nothing)
-  where
-    -- The Range of the whole declaration.
-    r = getRange (rOpen, kwR, m, dir)
--- Case: some module arguments
-
-niceImport (Ranged rOpen doOpen) kwR m (Right es) dir
-  -- Subcase: @as@ clause
-    | Just (asR, m') <- parseAsClause =
-        if null initArgs then return . (,Nothing) $ Just $
-           NiceImport (getRange (rOpen, kwR, m, asR, m', dir)) m (Just (AsName m' asR)) doOpen dir
-        else return (Just $ impStm asR, Just $ appStm (fromRight (const fresh') m') initArgs)
-        -- Andreas, 2017-05-13, issue #2579
-        -- Nisse reports that importing with instantation but without open
-        -- could be useful for bringing instances into scope.
-        -- Ulf, 2018-12-6: Not since fixes of #1913 and #2489 which require
-        -- instances to be in scope.
-  -- Subcase: no @as@ clause
-    | DontOpen <- doOpen = do
-        declarationWarning $ UselessImport fullRange
-        return (Nothing, Nothing)
-    | otherwise =
-        return (Just $ impStm noRange, Just $ appStm (noName $ beginningOf $ getRange m) es)
-  where
-    fullRange = getRange (rOpen, kwR, m, es, dir)
-    impStm asR = NiceImport (getRange (kwR, m)) m (Just (AsName (Right fresh) asR)) DontOpen defaultImportDir
-    appStm m' es =
-      Private empty Inserted
-        [ ModuleMacro (getRange (rOpen, m, es, dir)) defaultErased m'
-           (SectionApp (getRange es) [] (QName fresh) es)
-           doOpen dir
-        ]
-    (initArgs, last2Args) = splitAt (length es - 2) es
-    parseAsClause = case last2Args of
-      [ Ident (QName (Name asR InScope (Id x :| []))), e ]
-        -- Andreas, 2018-11-03, issue #3364, accept anything after 'as'
-        -- but require it to be a 'Name' in the scope checker.
-        | rawNameToString x == "as" -> Just . (asR,) $
-        if | Ident (QName m') <- e -> Right m'
-           | otherwise             -> Left e
-      _ -> Nothing
-    mkFresh i = Name (getRange m) NotInScope $ singleton $ Id $ stringToRawName $ ".#" ++ prettyShow m ++ "-" ++ show i
-    unique = hashString $ prettyShow $ getRangeWithoutFile fullRange
-       -- turn range into unique id, but delete file path
-       -- which is absolute and messes up suite of failing tests
-       -- (different hashs on different installations)
-       -- TODO: Don't use (insecure) hashes in this way.
-    fresh  = mkFresh unique
-    fresh' = mkFresh $ unique + 1
-
 -- The following function is (at the time of writing) only used three
 -- times: for building Lets, and for printing error messages.
 
@@ -1671,7 +1593,7 @@ notSoNiceDeclarations = \case
     NiceModuleMacro r _ e x ma o dir
                                      -> singleton $ ModuleMacro r e x ma o dir
     NiceOpen r x dir                 -> singleton $ Open r x dir
-    NiceImport r x as o dir          -> singleton $ Import (unranged o) (kwRange r) x (maybe empty Left as) dir
+    NiceImport o r x as dir          -> singleton $ Import o r x as dir
     NicePragma _ p                   -> singleton $ Pragma p
     NiceRecSig r er _ _ _ _ x bs e   -> singleton $ RecordSig r er x bs e
     NiceDataSig r er _ _ _ _ x bs e  -> singleton $ DataSig r er x bs e

--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -62,7 +62,7 @@ data NiceDeclaration
   | NiceModuleMacro Range Access Erased Name ModuleApplication
       OpenShortHand ImportDirective
   | NiceOpen Range QName ImportDirective
-  | NiceImport Range QName (Maybe AsName) OpenShortHand ImportDirective
+  | NiceImport (Ranged OpenShortHand) KwRange QName (Either AsName RawOpenArgs) ImportDirective
   | NicePragma Range Pragma
   | NiceRecSig Range Erased Access IsAbstract PositivityCheck
       UniverseCheck Name [LamBinding] Expr
@@ -226,7 +226,7 @@ instance HasRange NiceDeclaration where
   getRange (NiceModule r _ _ _ _ _ _ )     = r
   getRange (NiceModuleMacro r _ _ _ _ _ _) = r
   getRange (NiceOpen r _ _)                = r
-  getRange (NiceImport r _ _ _ _)          = r
+  getRange (NiceImport o r x as dir)       = getRange (o, r, x, as, dir)
   getRange (NicePragma r _)                = r
   getRange (PrimitiveFunction r _ _ _ _)   = r
   getRange (FunSig r _ _ _ _ _ _ _ _ _)    = r

--- a/test/Fail/AmbiguousModule.agda
+++ b/test/Fail/AmbiguousModule.agda
@@ -1,9 +1,9 @@
 module AmbiguousModule where
 
-module A where
 module B where
   module A where
 
+module A where
+
 open B
 open A
-

--- a/test/Fail/AmbiguousModule.err
+++ b/test/Fail/AmbiguousModule.err
@@ -1,5 +1,7 @@
-AmbiguousModule.agda:5.10-11: error: [ShadowedModule]
-Duplicate definition of module A. Previous definition of module A
-at AmbiguousModule.agda:3.8-9
+AmbiguousModule.agda:9.6-7: error: [AmbiguousModule]
+Ambiguous module name A. It could refer to any one of
+  B.A
+  AmbiguousModule.A
+(hint: Use C-c C-w (in Emacs) if you want to know why)
 when scope checking the declaration
-  module A where
+  open A

--- a/test/Fail/AmbiguousName.agda
+++ b/test/Fail/AmbiguousName.agda
@@ -1,12 +1,12 @@
 
 module AmbiguousName where
 
-module A where
-  postulate X : Set
-
 module B where
   module A where
     postulate X : Set
+
+module A where
+  postulate X : Set
 
 open A renaming (X to Y)
 open B

--- a/test/Fail/AmbiguousName.err
+++ b/test/Fail/AmbiguousName.err
@@ -1,5 +1,11 @@
-AmbiguousName.agda:8.10-11: error: [ShadowedModule]
-Duplicate definition of module A. Previous definition of module A
-at AmbiguousName.agda:4.8-9
-when scope checking the declaration
-  module A where
+AmbiguousName.agda:14.5-8: error: [AmbiguousName]
+Ambiguous name A.X. It could refer to any one of
+  B.A.X bound at
+    AmbiguousName.agda:6.15-16
+  Y bound at AmbiguousName.agda:9.13-14
+A.X is in scope as
+  * a postulate AmbiguousName.B.A.X brought into scope by
+    - its definition at AmbiguousName.agda:6.15-16
+  * a postulate AmbiguousName.A.X brought into scope by
+    - its definition at AmbiguousName.agda:9.13-14
+when scope checking A.X

--- a/test/Fail/AmbiguousNameFromImportParameterized.agda
+++ b/test/Fail/AmbiguousNameFromImportParameterized.agda
@@ -1,0 +1,10 @@
+-- Andreas, 2025-11-10, testcase for ambiguous name from import parametrized.
+
+open import Common.Issue481ParametrizedModule
+open import Common.Issue481ParametrizedModule Set
+
+postulate
+  bla : Bla
+
+-- Error mentions internal name generated from
+-- import Common.Issue481ParametrizedModule Set

--- a/test/Fail/AmbiguousNameFromImportParameterized.err
+++ b/test/Fail/AmbiguousNameFromImportParameterized.err
@@ -1,0 +1,16 @@
+AmbiguousNameFromImportParameterized.agda:7.9-12: error: [AmbiguousName]
+Ambiguous name Bla. It could refer to any one of
+  Common.Issue481ParametrizedModule.Bla bound at
+    Issue481ParametrizedModule.agda:7.3-6
+  AmbiguousNameFromImportParameterized.Bla bound at
+    Issue481ParametrizedModule.agda:7.3-6
+Bla is in scope as
+  * a postulate Common.Issue481ParametrizedModule.Bla
+    brought into scope by
+    - the opening of Common.Issue481ParametrizedModule at AmbiguousNameFromImportParameterized.agda:3.13-46
+    - its definition at Issue481ParametrizedModule.agda:7.3-6
+  * a postulate AmbiguousNameFromImportParameterized._.Bla
+    brought into scope by
+    - the application of .#Common.Issue481ParametrizedModule-7612168281832392919 at AmbiguousNameFromImportParameterized.agda:4.13-46
+    - its definition at Issue481ParametrizedModule.agda:7.3-6
+when scope checking Bla

--- a/test/Fail/Issue1635.agda
+++ b/test/Fail/Issue1635.agda
@@ -6,7 +6,7 @@ open import A.Issue1635 Set
 test : ∀ x → x ≡ foo
 test x = refl
 
--- ERROR:
+-- WAS:
 -- x != .#A.Issue1635-225351734.foo of type Foo
 -- when checking that the expression refl has type x ≡ foo
 
@@ -14,4 +14,4 @@ test x = refl
 -- x != .A.Issue1635.Foo.foo of type Foo
 -- when checking that the expression refl has type x ≡ foo
 
--- WANT: x != foo ...
+-- NOW: x != foo ...

--- a/test/Fail/Issue481.err
+++ b/test/Fail/Issue481.err
@@ -2,5 +2,4 @@ Issue481.agda:7.53-55: error: [ShadowedModule]
 Duplicate definition of module as. Previous definition of module as
 at Issue481.agda:6.50-52
 when scope checking the declaration
-  open module as
-    = .#Common.Issue481ParametrizedModule-2472342625871235265 as
+  open import Common.Issue481ParametrizedModule as as as

--- a/test/Fail/Issue481NonExistentModule.err
+++ b/test/Fail/Issue481NonExistentModule.err
@@ -8,4 +8,4 @@ where .AGDA denotes a legal extension for an Agda file
 (i.e., one of .agda .lagda .lagda.rst .lagda.tex .lagda.md
  .lagda.org .lagda.tree .lagda.typ)
 when scope checking the declaration
-  import NonExistentModule as .#NonExistentModule-4871442055463982176
+  open import NonExistentModule Set

--- a/test/Succeed/AppliedImportDeprecatedModule.agda
+++ b/test/Succeed/AppliedImportDeprecatedModule.agda
@@ -7,8 +7,8 @@ postulate
   A : Set
 
 -- Problem: Warning has too large range, spanning the rest of the file.
--- 4,1-7,10
--- warning: -W[no]UserWarning
+--
+-- Expected: 4.6-34:warning: -W[no]UserWarning
 -- Deprecated module
 -- when scope checking the declaration
---   import Deprecated.Deprecated as .#Deprecated.Deprecated-8769433924480517024
+--   open import Deprecated.Deprecated Set

--- a/test/Succeed/AppliedImportDeprecatedModule.warn
+++ b/test/Succeed/AppliedImportDeprecatedModule.warn
@@ -1,11 +1,12 @@
+
 AppliedImportDeprecatedModule.agda:4.6-34: warning: -W[no]UserWarning
 Deprecated module
 when scope checking the declaration
-  import Deprecated.Deprecated as .#Deprecated.Deprecated-14584885246488959677
+  open import Deprecated.Deprecated Set
 
 ———— All done; warnings encountered ————————————————————————
 
 AppliedImportDeprecatedModule.agda:4.6-34: warning: -W[no]UserWarning
 Deprecated module
 when scope checking the declaration
-  import Deprecated.Deprecated as .#Deprecated.Deprecated-14584885246488959677
+  open import Deprecated.Deprecated Set

--- a/test/Succeed/Issue2579UselessImport.warn
+++ b/test/Succeed/Issue2579UselessImport.warn
@@ -3,6 +3,8 @@ Issue2579UselessImport.agda:5.1-27: warning: -W[no]UselessImport
 An import statement with module instantiation is useless without
 either an 'open' keyword or an 'as' binding giving a name to the
 instantiated module.
+when scope checking the declaration
+  import DummyModule Set Set
 
 ———— All done; warnings encountered ————————————————————————
 
@@ -10,3 +12,5 @@ Issue2579UselessImport.agda:5.1-27: warning: -W[no]UselessImport
 An import statement with module instantiation is useless without
 either an 'open' keyword or an 'as' binding giving a name to the
 instantiated module.
+when scope checking the declaration
+  import DummyModule Set Set

--- a/test/Succeed/Issue3364.warn
+++ b/test/Succeed/Issue3364.warn
@@ -1,23 +1,24 @@
-Issue3364.agda:6.30-44: warning: -W[no]IllformedAsClause
+
+Issue3364.agda:6.33-44: warning: -W[no]IllformedAsClause
 'as' must be followed by an identifier; a qualified name is not
 allowed here
 when scope checking the declaration
   open import Agda.Builtin.Nat as Builtin.Nat
 
-Issue3364.agda:18.27-33: warning: -W[no]IllformedAsClause
+Issue3364.agda:18.30-33: warning: -W[no]IllformedAsClause
 'as' must be followed by an identifier
 when scope checking the declaration
   import Agda.Builtin.Sigma as .as
 
 ———— All done; warnings encountered ————————————————————————
 
-Issue3364.agda:6.30-44: warning: -W[no]IllformedAsClause
+Issue3364.agda:6.33-44: warning: -W[no]IllformedAsClause
 'as' must be followed by an identifier; a qualified name is not
 allowed here
 when scope checking the declaration
   open import Agda.Builtin.Nat as Builtin.Nat
 
-Issue3364.agda:18.27-33: warning: -W[no]IllformedAsClause
+Issue3364.agda:18.30-33: warning: -W[no]IllformedAsClause
 'as' must be followed by an identifier
 when scope checking the declaration
   import Agda.Builtin.Sigma as .as

--- a/test/interaction/Issue1278.agda
+++ b/test/interaction/Issue1278.agda
@@ -6,3 +6,6 @@ open import Agda.Builtin.Equality
 
 test : (c : D) -> (c ≡ c)
 test d = {!!} -- goal ".#A-60005532.d ≡ .#A-60005532.d"
+
+-- Expected:
+-- ?0 : d ≡ d


### PR DESCRIPTION
- **Refactor: move toAbstract NiceImport to its own function scopeCheckImport**
  

- **PR #8194 ctd.: move desugaring of `open import M args` into scope checker**
  This already fixes the problem that generated module names `.#M-123`
  would appear in the `when scope checking...` clauses of error messages.
  

- **New test/Fail/AmbiguousNameFromImportParameterized**
  Also restore old testcases (dating 2007) AmbiguousName/Module to their
  original purpose.

TODO:
- [x] haddock `scopeCheckImport`
- [ ] get rid of `fresh` concrete names
  