### PR TITLE
Fix #8037 by copying record type along with its projection in module app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,9 @@ jobs:
         stack-version: latest
     - name: Copy stack-${{ env.GHC_VER}}.yaml to stack.yaml
       run: cp stack-${{ env.GHC_VER }}.yaml stack.yaml
+    - name: Update package index
+      run: |
+        ${STACK} update
     - name: List dependencies and versions
       run: |
         ${STACK} ls dependencies | tee deps.txt

--- a/src/full/Agda/TypeChecking/Datatypes.hs
+++ b/src/full/Agda/TypeChecking/Datatypes.hs
@@ -48,8 +48,11 @@ getConForm c = caseEitherM (getConHead c) (return . Left) $ \ ch -> do
 
 -- | Augment constructor with record fields (preserve constructor name).
 --   The true constructor might only surface via 'reduce'.
-getOrigConHead :: QName -> TCM (Either SigError ConHead)
-getOrigConHead c = mapRight (setConName c) <$> getConHead c
+getOrigConHead :: HasCallStack => QName -> TCM ConHead
+getOrigConHead c = setConName c <$> do
+  fromRightM
+    (sigError c (typeError $ AbstractConstructorNotInScope c)) $
+    getConHead c
 
 -- | Get the name of the datatype constructed by a given constructor.
 --   Precondition: The argument must refer to a constructor

--- a/src/full/Agda/TypeChecking/Datatypes.hs-boot
+++ b/src/full/Agda/TypeChecking/Datatypes.hs-boot
@@ -2,8 +2,9 @@
 
 module Agda.TypeChecking.Datatypes where
 
-import Agda.TypeChecking.Monad.Signature
-import Agda.Syntax.Internal
+import Agda.TypeChecking.Monad.Signature ( HasConstInfo, SigError )
+import Agda.Syntax.Internal ( QName, ConHead )
+import Agda.Utils.CallStack ( HasCallStack )
 
-getConHead         :: HasConstInfo m => QName -> m (Either SigError ConHead)
-getConstructorData :: HasConstInfo m => QName -> m QName
+getConHead         :: (HasCallStack, HasConstInfo m) => QName -> m (Either SigError ConHead)
+getConstructorData :: (HasCallStack, HasConstInfo m) => QName -> m QName

--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -61,6 +61,10 @@ eliminateDeadCode !scope = Bench.billTo [Bench.DeadCode] $ do
 
       extraRootsFilter (name, def)
         | hasCompilePragma def || isPrimitive (theDef def) = Just name
+          -- Andreas, 2025-11-18, issue #8037
+          -- When copying the record type along with one of its projections in a module application,
+          -- we need to make sure the record type has not been deleted as deadcode.
+        | Just Projection{ projProper = Just r } <- isProjection_ (theDef def) = Just r
         | otherwise = Nothing
 
   let !pubModules = publicModules scope

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -13,12 +13,12 @@ import Control.Monad.Trans.Identity  ( IdentityT )
 import Control.Monad.Trans           ( MonadTrans, lift )
 
 import Data.Either
-import Data.Foldable (for_)
-import qualified Data.List as List
-import Data.Set (Set)
-import qualified Data.Set as Set
-import qualified Data.Map as Map
-import qualified Data.HashMap.Strict as HMap
+import Data.Foldable                 ( for_ )
+import Data.List                     qualified as List
+import Data.Set                      ( Set )
+import Data.Set                      qualified as Set
+import Data.Map                      qualified as Map
+import Data.HashMap.Strict           qualified as HMap
 import Data.Maybe
 
 import Agda.Interaction.Options
@@ -66,7 +66,8 @@ import Agda.Utils.Function ( applyWhen )
 import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List
-import qualified Agda.Utils.List1 as List1
+import Agda.Utils.List1 ( List1, pattern (:|) )
+import Agda.Utils.List1 qualified as List1
 import Agda.Utils.ListT
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
@@ -468,8 +469,8 @@ applySection new ptel old ts info@ScopeCopyInfo{ renModules = rm, renNames = rd 
               --   mkD` which we did before).
               Map.singleton x . pure . qualify m <$> freshName_ (prettyShow $ qnameName x)
 
-        childToParent :: (QName, List1.List1 QName) -> TCM (Maybe (ModuleName, QName))
-        childToParent (x, y List1.:| _) = do  -- All new names share the same module, so we can safely grab the first one
+        childToParent :: (QName, List1 QName) -> TCM (Maybe (ModuleName, QName))
+        childToParent (x, y :| _) = do  -- All new names share the same module, so we can safely grab the first one
           theDef <$> getConstInfo x <&> \case
             Constructor{ conData = d }
               -> Just (qnameModule y, d)
@@ -479,8 +480,8 @@ applySection new ptel old ts info@ScopeCopyInfo{ renModules = rm, renNames = rd 
               -> Just (qnameModule y, r)
             _ -> Nothing
 
-        parentToChild :: (QName, List1.List1 QName) -> TCM [(ModuleName, QName)]
-        parentToChild (x, y List1.:| _) = do
+        parentToChild :: (QName, List1 QName) -> TCM [(ModuleName, QName)]
+        parentToChild (x, y :| _) = do
           (theDef <$> getConstInfo x) <&> \case
             Datatype{ dataCons = cs } -> map (qnameModule y,) cs
             Record{ recConHead = h }  -> [(qnameModule y, conName h)]

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -471,8 +471,13 @@ applySection new ptel old ts info@ScopeCopyInfo{ renModules = rm, renNames = rd 
         childToParent :: (QName, List1.List1 QName) -> TCM (Maybe (ModuleName, QName))
         childToParent (x, y List1.:| _) = do  -- All new names share the same module, so we can safely grab the first one
           theDef <$> getConstInfo x <&> \case
-            Constructor{ conData = d } -> Just (qnameModule y, d)
-            _                          -> Nothing
+            Constructor{ conData = d }
+              -> Just (qnameModule y, d)
+            -- If a proper projection is being copied, its record needs to be
+            -- copied too (#8037).
+            def | Just Projection{ projProper = Just r } <- isProjection_ def
+              -> Just (qnameModule y, r)
+            _ -> Nothing
 
         parentToChild :: (QName, List1.List1 QName) -> TCM [(ModuleName, QName)]
         parentToChild (x, y List1.:| _) = do

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -984,7 +984,7 @@ getFilteredRewriteRulesFor filt q = do
 getOriginalProjection :: HasConstInfo m => QName -> m QName
 getOriginalProjection q = projOrig . fromMaybe __IMPOSSIBLE__ <$> isProjection q
 
-instance HasConstInfo (TCMT IO) where
+instance HasConstInfo TCM where
   getRewriteRulesFor = defaultGetRewriteRulesFor
   getConstInfo' q = do
     st  <- getTC
@@ -992,7 +992,7 @@ instance HasConstInfo (TCMT IO) where
     defaultGetConstInfo st env q
   getConstInfo q = getConstInfo' q >>= \case
       Right d -> return d
-      Left (SigUnknown err)     -> fail err
+      Left (SigUnknown err)     -> internalError err
       Left SigAbstract          -> notInScopeError $ qnameToConcrete q
       Left SigCubicalNotErasure -> typeError $ CubicalNotErasure q
 

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
@@ -6,6 +6,7 @@ import Control.Monad.Reader
 import Control.Monad.State
 
 import Agda.Syntax.Abstract.Name (QName)
+import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Internal (ModuleName, Telescope)
 
 import Agda.TypeChecking.Monad.Base
@@ -14,7 +15,7 @@ import Agda.TypeChecking.Monad.Base
   )
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug (MonadDebug)
 
-import Agda.Syntax.Common.Pretty (prettyShow)
+import Agda.Utils.CallStack (HasCallStack)
 
 data SigError = SigUnknown String | SigAbstract | SigCubicalNotErasure
 
@@ -26,7 +27,7 @@ class ( Functor m
       , MonadDebug m
       , MonadTCEnv m
       ) => HasConstInfo m where
-  getConstInfo :: QName -> m Definition
+  getConstInfo :: HasCallStack => QName -> m Definition
   getConstInfo q = getConstInfo' q >>= \case
       Right d -> return d
       Left (SigUnknown err) -> __IMPOSSIBLE_VERBOSE__ err
@@ -35,11 +36,11 @@ class ( Functor m
       Left SigCubicalNotErasure -> __IMPOSSIBLE_VERBOSE__ $
         notSoPrettySigCubicalNotErasure q
 
-  getConstInfo' :: QName -> m (Either SigError Definition)
+  getConstInfo' :: HasCallStack => QName -> m (Either SigError Definition)
   -- getConstInfo' q = Right <$> getConstInfo q
   getRewriteRulesFor :: QName -> m RewriteRules
 
-  default getConstInfo' :: (HasConstInfo n, MonadTrans t, m ~ t n) => QName -> m (Either SigError Definition)
+  default getConstInfo' :: (HasCallStack, HasConstInfo n, MonadTrans t, m ~ t n) => QName -> m (Either SigError Definition)
   getConstInfo' = lift . getConstInfo'
 
   default getRewriteRulesFor :: (HasConstInfo n, MonadTrans t, m ~ t n) => QName -> m RewriteRules

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -120,6 +120,7 @@ computePolarity
      , MonadDebug m, MonadPretty m )
   => [QName] -> m ()
 computePolarity xs = do
+ reportSDoc "tc.polarity.set" 40 $ "computePolarity" <+> prettyTCM xs
 
  -- Andreas, 2017-04-26, issue #2554
  -- First, for mutual definitions, obtain a crude polarity from positivity.

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -955,7 +955,7 @@ isSingletonType' regardIrrelevance t rs = do
             OTerm phi' -> patternViolation (unblockOnAnyMetaIn phi')
             -- This fails the MaybeT: we're not looking at a
             -- definitional singleton.
-            _ -> fail ""
+            _ -> mzero
 
       (<|>) <$> record <*> subtype
 

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -495,7 +495,7 @@ isEtaRecordType a = case unEl a of
 --
 isRecordConstructor :: HasConstInfo m => QName -> m (Maybe (QName, RecordData))
 isRecordConstructor c = getConstInfo' c >>= \case
-  Left (SigUnknown err)     -> __IMPOSSIBLE__
+  Left (SigUnknown err)     -> __IMPOSSIBLE_VERBOSE__ err
   Left SigCubicalNotErasure -> __IMPOSSIBLE__
   Left SigAbstract          -> return Nothing
   Right def                 -> case theDef $ def of

--- a/src/full/Agda/TypeChecking/Records.hs-boot
+++ b/src/full/Agda/TypeChecking/Records.hs-boot
@@ -4,12 +4,14 @@ module Agda.TypeChecking.Records where
 
 import Agda.Syntax.Internal
 import qualified Agda.Syntax.Concrete.Name as C
-import Agda.TypeChecking.Monad
+import Agda.TypeChecking.Monad ( RecordData, HasConstInfo )
+
+import Agda.Utils.CallStack ( HasCallStack )
 
 etaContractRecord :: HasConstInfo m => QName -> ConHead -> ConInfo -> Args -> m Term
 
-isRecord :: HasConstInfo m => QName -> m (Maybe RecordData)
-isEtaRecord :: HasConstInfo m => QName -> m Bool
-isRecordConstructor :: HasConstInfo m => QName -> m (Maybe (QName, RecordData))
+isRecord            :: (HasCallStack, HasConstInfo m) => QName -> m (Maybe RecordData)
+isEtaRecord         :: (HasCallStack, HasConstInfo m) => QName -> m Bool
+isRecordConstructor :: (HasCallStack, HasConstInfo m) => QName -> m (Maybe (QName, RecordData))
 
 recordFieldNames :: RecordData -> [Dom C.Name]

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -149,10 +149,7 @@ checkApplication cmp hd args e t =
     -- Subcase: unambiguous constructor
     A.Con ambC | Just c <- getUnambiguous ambC -> do
       -- augment c with record fields, but do not revert to original name
-      con <-
-        fromRightM
-          (sigError c (typeError $ AbstractConstructorNotInScope c)) $
-          getOrigConHead c
+      con <- getOrigConHead c
       checkConstructorApplication cmp e t con hd args
 
     -- Subcase: ambiguous constructor
@@ -334,10 +331,7 @@ inferHead e = do
 
       -- First, inferDef will try to apply the constructor
       -- to the free parameters of the current context. We ignore that.
-      con <-
-        fromRightM
-          (sigError c (typeError $ AbstractConstructorNotInScope c)) $
-          getOrigConHead c
+      con <- getOrigConHead c
       (u, a) <- inferDef (\ _ -> Con con ConOCon []) c
 
       -- Next get the number of parameters in the current context.

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1923,7 +1923,7 @@ disambiguateConstructor ambC@(AmbQ cs) d pars = do
            -- its type, and maybe the state obtained after checking it
            -- (which may contain new constraints/solutions).
     tryCon constraintsOk cons d pars c = getConstInfo' c >>= \case
-      Left (SigUnknown err)     -> __IMPOSSIBLE__
+      Left (SigUnknown err)     -> __IMPOSSIBLE_VERBOSE__ err
       Left SigCubicalNotErasure -> __IMPOSSIBLE__
       Left SigAbstract          -> abstractConstructor c
       Right def                 -> do

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20251107 * 10 + 0
+currentInterfaceVersion = 20251118 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64

--- a/src/github/workflows/test.yml
+++ b/src/github/workflows/test.yml
@@ -118,6 +118,12 @@ jobs:
     - name: "Copy stack-${{ env.GHC_VER}}.yaml to stack.yaml"
       run:  cp stack-${{ env.GHC_VER }}.yaml stack.yaml
 
+    # Update the package index.
+    # Issue #8211: do this as explicit step so that the following one will not bear its costs.
+    - name: Update package index
+      run: |
+        ${STACK} update
+
     # Get the list of dependencies and versions to create a correct cache key.
     - name: "List dependencies and versions"
       run: |

--- a/test/Fail/Issue8037.agda
+++ b/test/Fail/Issue8037.agda
@@ -1,0 +1,27 @@
+-- Andreas, 2025-11-17, issue #8037, report and test case by Amy.
+-- Checking projection pattern parameters only works
+-- if during a module application we always copy the record type
+-- along with any of its fields.
+
+-- {-# OPTIONS -v tc.lhs.split:40 #-}
+
+postulate
+  A B : Set
+
+module M (X : Set) where
+
+  record R : Set₂ where
+    field
+      F : Set₁
+
+  open R public
+
+open M A using (F)  -- not importing R defeated the fix of #1976
+
+wrong : M.R B
+wrong .F = Set
+
+-- Expected error: [UnequalTerms]
+-- A != B of type Set
+-- when checking the clause left hand side
+-- wrong .F

--- a/test/Fail/Issue8037.err
+++ b/test/Fail/Issue8037.err
@@ -1,0 +1,4 @@
+Issue8037.agda:22.7-9: error: [UnequalTerms]
+A != B of type Set
+when checking the clause left hand side
+wrong .F

--- a/test/Succeed/Issue8037Deadcode.agda
+++ b/test/Succeed/Issue8037Deadcode.agda
@@ -1,0 +1,16 @@
+-- {-# OPTIONS -v 49 #-}
+-- {-# OPTIONS -v tc.mod.apply:80 #-}
+{-# OPTIONS -v tc.mod.apply.complete:30 #-}
+
+-- Andreas, 2025-11-18, issue #8037
+-- The fix for #8037 involved also copying a record name
+-- if one of its projections is copied in a module application.
+-- It crashed because deadcode elimination had removed the record type for the projection.
+
+-- {-# OPTIONS -v tc.mod.apply:80 #-}
+-- {-# OPTIONS -v tc.mod.apply.complete:30 #-}
+
+module Issue8037Deadcode where
+
+import Issue8037DeadcodeA
+open module A = Issue8037DeadcodeA  -- crashed with Panic: unbound name (of the record type)

--- a/test/Succeed/Issue8037DeadcodeA.agda
+++ b/test/Succeed/Issue8037DeadcodeA.agda
@@ -1,0 +1,12 @@
+-- Andreas, 2025-11-18, issue #8037
+-- Auxiliary module imported by Issue8037Deadcode
+-- that exports a record module created by module application.
+
+module Issue8037DeadcodeA where
+
+  record Whatever (A : Set) : Set where
+    no-eta-equality
+    field go : A → A
+
+  module M (A : Set) = Whatever {A → A}
+  open M public


### PR DESCRIPTION
- **Fix #8037 by copying record type along with its projection in module app**
   This commit contains the fix, the others are just byproducts of the bug hunt.
  

- **Print the error in SigUnknown when throwing `__IMPOSSIBLE__`**
  

- **Refactor: replace 2 uses of `fail`**
  

- **Cosmetics: do not use the List1 type an constructor qualified**
  

- **Debug #8037**
  

- **Refactor getOrigConHead to handle the SigError**
  

- **Add HasCallStack to getConstInfo and some of its simple users**
  