### PR TITLE
App range fix for operator application

### DIFF
--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -3932,9 +3932,9 @@ instance ToAbstract CPattern where
 -- | An argument @OpApp C.Expr@ to an operator can have binders,
 --   in case the operator is some @syntax@-notation.
 --   For these binders, we have to create lambda-abstractions.
-toAbstractOpArg :: Precedence -> OpApp C.Expr -> ScopeM A.Expr
-toAbstractOpArg ctx (Ordinary e)                 = toAbstractCtx ctx e
-toAbstractOpArg ctx (SyntaxBindingLambda r bs e) = toAbstractLam r bs e ctx
+toAbstractOpArg :: Precedence -> OpApp C.Expr -> ScopeM (Ranged A.Expr)
+toAbstractOpArg ctx (Ordinary e)                 = Ranged (getRange e) <$> toAbstractCtx ctx e
+toAbstractOpArg ctx (SyntaxBindingLambda r bs e) = Ranged r <$> toAbstractLam r bs e ctx
 
 -- | Turn an operator application into abstract syntax. Make sure to
 -- record the right precedences for the various arguments.
@@ -3959,10 +3959,11 @@ toAbstractOpApp op ns es = do
     return $ foldr (A.Lam (ExprRange (getRange body))) body binders
   where
     -- Build an application in the abstract syntax, with correct Range.
-    app e (pref, arg) = A.App info e arg
-      where info = (defaultAppInfo r) { appOrigin = getOrigin arg
+    app e (pref, argR) = A.App info e arg
+      where arg = (fmap rangedThing) <$> argR
+            info = (defaultAppInfo r) { appOrigin = getOrigin arg
                                       , appParens = pref }
-            r = fuseRange e arg
+            r = fuseRange e argR
 
     inferParenPref :: NamedArg (Either A.Expr (OpApp C.Expr)) -> ParenPreference
     inferParenPref e =
@@ -3975,15 +3976,15 @@ toAbstractOpApp op ns es = do
     -- we can build the correct info for the A.App node.
     toAbsOpArg :: Precedence ->
                   NamedArg (Either A.Expr (OpApp C.Expr)) ->
-                  ScopeM (ParenPreference, NamedArg A.Expr)
-    toAbsOpArg cxt e = (pref,) <$> (traverse . traverse) (either return (toAbstractOpArg cxt)) e
+                  ScopeM (ParenPreference, NamedArg (Ranged A.Expr))
+    toAbsOpArg cxt e = (pref,) <$> (traverse . traverse) (either (return . Ranged noRange) (toAbstractOpArg cxt)) e
       where pref = inferParenPref e
 
     -- The hole left to the first @IdPart@ is filled with an expression in @LeftOperandCtx@.
     left :: Fixity
          -> [NotationPart]
          -> [NamedArg (Either A.Expr (OpApp C.Expr))]
-         -> ScopeM [(ParenPreference, NamedArg A.Expr)]
+         -> ScopeM [(ParenPreference, NamedArg (Ranged A.Expr))]
     left f (IdPart _ : xs) es = inside f xs es
     left f (_ : xs) (e : es) = do
         e  <- toAbsOpArg (LeftOperandCtx f) e
@@ -3996,7 +3997,7 @@ toAbstractOpApp op ns es = do
     inside :: Fixity
            -> [NotationPart]
            -> [NamedArg (Either A.Expr (OpApp C.Expr))]
-           -> ScopeM [(ParenPreference, NamedArg A.Expr)]
+           -> ScopeM [(ParenPreference, NamedArg (Ranged A.Expr))]
     inside f [x]             es = right f x es
     inside f (IdPart _ : xs) es = inside f xs es
     inside f (_  : xs) (e : es) = do
@@ -4011,7 +4012,7 @@ toAbstractOpApp op ns es = do
     right :: Fixity
           -> NotationPart
           -> [NamedArg (Either A.Expr (OpApp C.Expr))]
-          -> ScopeM [(ParenPreference, NamedArg A.Expr)]
+          -> ScopeM [(ParenPreference, NamedArg (Ranged A.Expr))]
     right _ (IdPart _)  [] = return []
     right f _          [e] = do
         let pref = inferParenPref e

--- a/test/Fail/Issue1952.err
+++ b/test/Fail/Issue1952.err
@@ -17,17 +17,17 @@ Unsolved metas at the following locations:
   Issue1952.agda:31.49-50
   Issue1952.agda:31.51-52
   Issue1952.agda:33.40-57
-  Issue1952.agda:33.40-101
+  Issue1952.agda:33.40-102
   Issue1952.agda:33.40-57
   Issue1952.agda:33.44-47
   Issue1952.agda:33.44-54
   Issue1952.agda:33.53-54
   Issue1952.agda:33.58-59
   Issue1952.agda:33.60-65
-  Issue1952.agda:33.60-101
+  Issue1952.agda:33.60-102
   Issue1952.agda:33.66-67
   Issue1952.agda:33.69-74
-  Issue1952.agda:33.69-95
+  Issue1952.agda:33.69-96
   Issue1952.agda:33.69-101
   Issue1952.agda:33.75-76
   Issue1952.agda:33.78-80

--- a/test/Fail/Issue2480.err
+++ b/test/Fail/Issue2480.err
@@ -1,4 +1,4 @@
-Issue2480.agda:71.14-32: error: [UnequalTerms]
+Issue2480.agda:71.13-32: error: [UnequalTerms]
 a0 != a of type A
 when checking that the expression (to (from p) ∙ a) □ has type
 (ap const (ap (λ F → F a) p) ∙ a) ≡ (to (from p) ∙ a)


### PR DESCRIPTION
Previously, when calculating the range for an application of an operator to its argument, the range of the already translated abstract representation was taken into account. This is problematic, because that translation does not preserve ranges (parentheses are stripped), so fusing the operator range with such a stripped range could produce a range containing code that cannot be parsed.
For example, `1 + (((2)))` would result in a range covering `1 + (((2`.
By temporarily wrapping the translated argument in `Ranged` , we can preserve the range of the concrete version and use it to fuse ranges correctly.