### PR TITLE
Fix #8218: Update signature for imported rewrite rules

### DIFF
--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -278,16 +278,6 @@ markInjective q = modifyGlobalDefinition q $ \def -> def { defInjective = True }
 markFirstOrder :: QName -> TCM ()
 markFirstOrder = setFunctionFlag FunFirstOrder True
 
-unionSignatures :: [Signature] -> Signature
-unionSignatures ss = foldr unionSignature emptySignature ss
-
-unionSignature :: Signature -> Signature -> Signature
-unionSignature (Sig a b c d) (Sig a' b' c' d') =
-      Sig (Map.union a a')
-          (HMap.union b b')             -- definitions are unique (in at most one module)
-          (HMap.unionWith mappend c c') -- rewrite rules are accumulated
-          (d <> d')                     -- instances are accumulated
-
 -- | Add a section to the signature.
 --
 --   The current context will be stored as the cumulative module parameters

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -147,8 +147,7 @@ addRewriteRules qs = do
       "adding rule" <+> prettyTCM (rewName rew) <+>
       "to the definition of" <+> prettyTCM f
     reportSDoc "rewriting" 30 $ "matchable symbols: " <+> prettyTCM matchables
-    modifySignature $ addRewriteRulesFor f [rew]
-    modifyGlobalSignature $ updateSignatureForRewrites f [rew] matchables
+    addRewriteRulesFor f [rew] matchables
 
   -- Run confluence check for the new rules
   -- (should be done after adding all rules, see #3795)

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -147,7 +147,8 @@ addRewriteRules qs = do
       "adding rule" <+> prettyTCM (rewName rew) <+>
       "to the definition of" <+> prettyTCM f
     reportSDoc "rewriting" 30 $ "matchable symbols: " <+> prettyTCM matchables
-    modifySignature $ addRewriteRulesFor f [rew] matchables
+    modifySignature $ addRewriteRulesFor f [rew]
+    modifyGlobalSignature $ updateSignatureForRewrites f [rew] matchables
 
   -- Run confluence check for the new rules
   -- (should be done after adding all rules, see #3795)

--- a/test/Fail/Issue7893.agda
+++ b/test/Fail/Issue7893.agda
@@ -1,0 +1,26 @@
+{-# OPTIONS --rewriting --local-confluence-check #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.List
+open import Agda.Builtin.Nat
+
+private variable
+  A : Set
+  x : A
+  m n : Nat
+
+_++_ : List A → List A → List A
+[] ++ ys = ys
+(x ∷ xs) ++ ys = x ∷ (xs ++ ys)
+
+replicate : Nat → A → List A
+replicate zero x = []
+replicate (suc n) x = x ∷ replicate n x
+
+postulate
+  replicate-rew : replicate (m + n) x ≡ replicate m x ++ replicate n x
+  plus-zero : m + 0 ≡ m
+
+{-# REWRITE replicate-rew #-}
+{-# REWRITE plus-zero #-}

--- a/test/Fail/Issue7893.err
+++ b/test/Fail/Issue7893.err
@@ -1,0 +1,7 @@
+Issue7893.agda:26.13-22: error: [RewriteNonConfluent]
+Local confluence check failed: replicate (m + 0) x reduces to both
+replicate m x ++ replicate 0 x and replicate m x
+which are not equal because
+replicate m x ++ replicate 0 x != replicate m x of type List x.A
+when checking confluence of the rewrite rule replicate-rew with
+plus-zero

--- a/test/Succeed/Issue8218ListUtils.agda
+++ b/test/Succeed/Issue8218ListUtils.agda
@@ -1,0 +1,11 @@
+open import Agda.Builtin.List public
+open import Agda.Builtin.Equality
+
+map : {A B : Set} → (A → B) → List A → List B
+map f [] = []
+map f (x ∷ xs) = f x ∷ map f xs
+
+postulate _++_ : ∀{A : Set} → List A → List A → List A
+
+postulate
+  map-++ : ∀ {A B : Set} (f : A → B) xs ys → map f (xs ++ ys) ≡ map f xs ++ map f ys

--- a/test/Succeed/Issue8218Rewrite.agda
+++ b/test/Succeed/Issue8218Rewrite.agda
@@ -1,0 +1,9 @@
+{-# OPTIONS --rewriting #-}
+
+open import Agda.Builtin.List public
+open import Issue8218ListUtils
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+{-# REWRITE map-++ #-}

--- a/test/Succeed/Issue8218a.agda
+++ b/test/Succeed/Issue8218a.agda
@@ -1,0 +1,20 @@
+{-# OPTIONS --rewriting #-}
+
+open import Issue8218ListUtils
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+{-# REWRITE map-++ #-}
+
+data Ty : Set where
+  _⟶_ : List Ty → Ty → Ty
+
+data Exp (Γ : List Ty) : Ty → Set where
+  lamMany : ∀{τ} (τs : List Ty) → Exp (τs ++ Γ) τ → Exp Γ (τs ⟶ τ)
+
+{-# TERMINATING #-}
+desugarTy : Ty → Ty
+desugarTy (τs ⟶ τ) = map desugarTy τs ⟶ desugarTy τ
+
+desugarExp : ∀{Γ τ} → Exp Γ τ → Exp (map desugarTy Γ) (desugarTy τ)
+desugarExp (lamMany τs x) = lamMany (map desugarTy τs) (desugarExp x)

--- a/test/Succeed/Issue8218b.agda
+++ b/test/Succeed/Issue8218b.agda
@@ -1,0 +1,17 @@
+{-# OPTIONS --rewriting #-}
+
+open import Issue8218ListUtils
+open import Issue8218Rewrite
+
+data Ty : Set where
+  _⟶_ : List Ty → Ty → Ty
+
+data Exp (Γ : List Ty) : Ty → Set where
+  lamMany : ∀{τ} (τs : List Ty) → Exp (τs ++ Γ) τ → Exp Γ (τs ⟶ τ)
+
+{-# TERMINATING #-}
+desugarTy : Ty → Ty
+desugarTy (τs ⟶ τ) = map desugarTy τs ⟶ desugarTy τ
+
+desugarExp : ∀{Γ τ} → Exp Γ τ → Exp (map desugarTy Γ) (desugarTy τ)
+desugarExp (lamMany τs x) = lamMany (map desugarTy τs) (desugarExp x)


### PR DESCRIPTION
Fix #8218: to correctly handle rewrite rules declared in modules downstream from the definitions they modify (e.g. their head symbol), we need to update the imported signature.