### PR TITLE
Optimize rewrite rule matching

### DIFF
--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -454,7 +454,7 @@ rewrite block hd rules es = do
   rewritingAllowed <- optRewriting <$> pragmaOptions
   if (rewritingAllowed && not (null rules)) then do
     (_ , t) <- fromMaybe __IMPOSSIBLE__ <$> getTypedHead (hd [])
-    loop block t rules =<< instantiateFull' es -- TODO: remove instantiateFull?
+    loop block t rules es
   else
     return $ NoReduction (block $> hd es)
   where

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -297,23 +297,26 @@ instance Match NLPat Term where
           _          -> no ""
     case p of
       PVar i bvs -> traceSDoc "rewriting.match" 60 ("matching a PVar: " <+> text (show i)) $ do
-        let vars = map unArg bvs
-        let allowedVars :: VarSet
-            allowedVars = VarSet.fromList vars
-            badVars :: VarSet
-            badVars = VarSet.complement n allowedVars
-            perm :: Permutation
-            perm = Perm n $ reverse vars
-            tel :: Telescope
-            tel = permuteContext perm k
-        ok <- addContext k $ reallyFree badVars v
-        case ok of
-          Left b         -> block b
-          Right Nothing  -> no ""
-          Right (Just v) ->
-            let t' = telePi  tel $ renameP impossible perm t
-                v' = teleLam tel $ renameP impossible perm v
-            in tellSub r (i-n) t' v'
+        case n of
+          0 -> tellSub r (i-n) t v
+          _ -> do
+            let vars = map unArg bvs
+            let allowedVars :: VarSet
+                allowedVars = VarSet.fromList vars
+                badVars :: VarSet
+                badVars = VarSet.complement n allowedVars
+                perm :: Permutation
+                perm = Perm n $ reverse vars
+                tel :: Telescope
+                tel = permuteContext perm k
+            ok <- addContext k $ reallyFree badVars v
+            case ok of
+              Left b         -> block b
+              Right Nothing  -> no ""
+              Right (Just v) ->
+                let t' = telePi  tel $ renameP impossible perm t
+                    v' = teleLam tel $ renameP impossible perm v
+                in tellSub r (i-n) t' v'
 
       PDef f ps -> traceSDoc "rewriting.match" 60 ("matching a PDef: " <+> prettyTCM f) $ do
         v <- addContext k $ constructorForm =<< unLevel v

--- a/test/Succeed/RewriteMatchComplexity.agda
+++ b/test/Succeed/RewriteMatchComplexity.agda
@@ -1,0 +1,38 @@
+{-# OPTIONS --rewriting #-}
+
+module RewriteMatchComplexity where
+
+{-
+Checking the asymptotic speedup in PR 8222.
+This file should check quickly in linear time
+in the size of "n" below.
+-}
+
+data ℕ : Set where
+  zero : ℕ
+  suc  : ℕ → ℕ
+{-# BUILTIN NATURAL ℕ #-}
+
+data Nat : Set where
+  zero : Nat
+  suc  : Nat → Nat
+
+ℕ2Nat : ℕ → Nat → Nat
+ℕ2Nat zero acc = acc
+ℕ2Nat (suc n) acc = ℕ2Nat n (suc acc)
+
+n : Nat
+n = ℕ2Nat 30000 zero
+
+postulate
+  Id   : {A : Set} → A → A → Set
+  refl : ∀ {A} n → Id {A} n n
+
+  f     : Nat → Nat
+  fsuc  : ∀ n → Id (f (suc n)) (f n)
+  fzero : Id (f zero) zero
+{-# BUILTIN REWRITE Id #-}
+{-# REWRITE fsuc fzero #-}
+
+test : Id (f n) zero
+test = refl zero


### PR DESCRIPTION
Remove unnecessary `instantiateFull` and occurrence checking. We don't deeply traverse matched terms anymore if the rule pattern is first order. 