### PR TITLE
Refactorings for AIM XLI unused-imports code sprint

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -886,6 +886,7 @@ library
       Agda.Utils.IORef.Strict
       Agda.Utils.Impossible
       Agda.Utils.IndexedList
+      Agda.Utils.IntMap
       Agda.Utils.IntSet.Infinite
       Agda.Utils.Lens
       Agda.Utils.Lens.Examples

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -903,8 +903,8 @@ loadDecodedModule sf@(SourceFile fi) mi = do
 --   we do it in a fresh state, suitably initialize,
 --   in order to forget some state changes after successful type checking.
 
-createInterfaceIsolated
-  :: TopLevelModuleName
+createInterfaceIsolated ::
+     TopLevelModuleName
      -- ^ Module name of file we process.
   -> SourceFile
      -- ^ File we process.
@@ -1077,8 +1077,8 @@ writeInterface file i = let fp = filePath file in do
 -- If appropriate this function writes out syntax highlighting
 -- information.
 
-createInterface
-  :: TopLevelModuleName    -- ^ The expected module name.
+createInterface ::
+     TopLevelModuleName    -- ^ The expected module name.
   -> SourceFile            -- ^ The file to type check.
   -> MainInterface         -- ^ Are we dealing with the main module?
   -> Maybe Source      -- ^ Optional information about the source code.

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -3167,6 +3167,9 @@ data IsInstance
   | NotInstanceDef
     deriving (Show, Eq, Ord)
 
+instance Null IsInstance where
+  empty = NotInstanceDef
+
 instance KillRange IsInstance where
   killRange = \case
     InstanceDef _    -> InstanceDef empty
@@ -3180,6 +3183,14 @@ instance HasRange IsInstance where
 instance NFData IsInstance where
   rnf (InstanceDef _) = ()
   rnf NotInstanceDef  = ()
+
+class IsInstanceDef a where
+  isInstanceDef :: a -> Maybe KwRange
+
+instance IsInstanceDef IsInstance where
+  isInstanceDef = \case
+    InstanceDef r  -> Just r
+    NotInstanceDef -> Nothing
 
 -- ** macro blocks
 

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -559,9 +559,20 @@ instance Hashable AbstractName where
   hashWithSalt salt n =
     hashWithSalt salt (A.nameId (qnameName (anameName n)))
 
-data NameMetadata = NoMetadata
-                  | GeneralizedVarsMetadata (Map A.QName A.Name)
+data NameMetadata = NameMetadata
+  { nameDataGeneralizedVars :: Map A.QName A.Name
+  }
   deriving (Show, Generic)
+
+instance Null NameMetadata where
+  empty = NameMetadata empty
+  null (NameMetadata m) = null m
+
+noMetadata :: NameMetadata
+noMetadata = empty
+
+generalizedVarsMetadata :: Map A.QName A.Name -> NameMetadata
+generalizedVarsMetadata m = NameMetadata m
 
 -- | A decoration of abstract syntax module names.
 data AbstractModule = AbsModule

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -561,18 +561,28 @@ instance Hashable AbstractName where
 
 data NameMetadata = NameMetadata
   { nameDataGeneralizedVars :: Map A.QName A.Name
+  , nameDataIsInstance      :: IsInstance
   }
   deriving (Show, Generic)
 
 instance Null NameMetadata where
-  empty = NameMetadata empty
-  null (NameMetadata m) = null m
+  empty = NameMetadata empty empty
+  null (NameMetadata m i) = null m && null i
 
 noMetadata :: NameMetadata
 noMetadata = empty
 
 generalizedVarsMetadata :: Map A.QName A.Name -> NameMetadata
-generalizedVarsMetadata m = NameMetadata m
+generalizedVarsMetadata m = NameMetadata m empty
+
+instanceMetadata :: IsInstance -> NameMetadata
+instanceMetadata i = NameMetadata empty i
+
+instance IsInstanceDef NameMetadata where
+  isInstanceDef = isInstanceDef . nameDataIsInstance
+
+instance IsInstanceDef AbstractName where
+  isInstanceDef = isInstanceDef . anameMetadata
 
 -- | A decoration of abstract syntax module names.
 data AbstractModule = AbsModule

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -567,8 +567,8 @@ bindName'' acc kind meta x y = do
 --   Ulf, 2014-06-29: Currently used to rebind the name defined by an
 --   unquoteDecl, which is a 'QuotableName' in the body, but a 'DefinedName'
 --   later on.
-rebindName :: Access -> KindOfName -> C.Name -> A.QName -> ScopeM ()
-rebindName acc kind x y = do
+rebindName :: Access -> KindOfName -> NameMetadata -> C.Name -> A.QName -> ScopeM ()
+rebindName acc kind meta x y = do
   if kind == ConName then do
     modifyCurrentScope $
            mapScopeNS (localNameSpace acc)
@@ -578,7 +578,7 @@ rebindName acc kind x y = do
   else do
     modifyCurrentScope $ removeNameFromScope (localNameSpace acc) x
   recomputeInverseScope
-  bindName acc kind x y
+  bindName' acc kind meta x y
 
 -- András, 2025-08-30: TODO: directly extend inverse scope.
 -- | Bind a module name.

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -519,7 +519,7 @@ unbindVariable x = bracket_ (getLocalVars <* modifyLocalVars (AssocList.delete x
 
 -- | Bind a defined name. Must not shadow anything.
 bindName :: Access -> KindOfName -> C.Name -> A.QName -> ScopeM ()
-bindName acc kind x y = bindName' acc kind NoMetadata x y
+bindName acc kind x y = bindName' acc kind noMetadata x y
 
 bindName' :: Access -> KindOfName -> NameMetadata -> C.Name -> A.QName -> ScopeM ()
 bindName' acc kind meta x y = whenJustM (bindName'' acc kind meta x y) typeError

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1591,7 +1591,7 @@ instance ToConcrete A.Pattern where
         where r = getRange i
 
       -- gallais, 2019-02-12, issue #3491
-      -- Print p as .(p) if p is a variable but there is a projection of the
+      -- Print .p as .(p) if p is a variable but there is a projection of the
       -- same name in scope.
       A.DotP i e@(A.Var v) -> do
         let r = getRange i

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2288,7 +2288,7 @@ scopeCheckDataOrRecSig dataOrRec r er p a pc uc x ls t = do
               <*> toAbstract t
     f  <- getConcreteFixity x
     x' <- freshAbstractQName f x
-    mErr <- bindName'' p (ifThenElse dataOrRec DataName RecName) (GeneralizedVarsMetadata $ generalizeTelVars ls') x x'
+    mErr <- bindName'' p (ifThenElse dataOrRec DataName RecName) (generalizedVarsMetadata $ generalizeTelVars ls') x x'
     whenJust mErr $ \case
       err@(ClashingDefinition cn an _) | qnameModule (clashingQName an) == qnameModule x' -> do
         resolveName (C.QName x) >>= \case
@@ -2766,9 +2766,7 @@ bindGeneralizables vars =
 bindGeneralizablesIfInserted :: Origin -> AbstractName -> ScopeM (Set A.Name)
 bindGeneralizablesIfInserted Inserted y = bound <$ bindGeneralizables gvars
   where
-    gvars = case anameMetadata y of
-          GeneralizedVarsMetadata gvars -> gvars
-          NoMetadata                    -> Map.empty
+    gvars = nameDataGeneralizedVars $ anameMetadata y
     bound = Set.fromList (Map.elems gvars)
 bindGeneralizablesIfInserted UserWritten _ = return Set.empty
 bindGeneralizablesIfInserted _ _           = __IMPOSSIBLE__
@@ -2901,7 +2899,7 @@ bindUnquoteConstructorName m p c = do
   r <- resolveName (C.QName c)
   fc <- getConcreteFixity c
   c' <- withCurrentModule m $ freshAbstractQName fc c
-  let aname qn = AbsName qn QuotableName Defined NoMetadata
+  let aname qn = AbsName qn QuotableName Defined noMetadata
       addName = do
         modifyCurrentScope $ addNameToScope (localNameSpace p) c $ aname c'
         recomputeInverseScope -- András 2025-08-30: TODO: use addNameToInverseScope instead

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -348,6 +348,26 @@ lookupSection m = maybe EmptyTel (^. secTelescope) <$> getSection m
 -- @
 -- A.B.C.f vs ==> f xs
 -- @
+--
+-- Invoking @'addDisplayForms' x@ will add a display form for each copy @x@ transitively reduces to.
+-- E.g. consider the following iterated module application.
+-- @
+--   module M0 (n : Nat) where
+--     b : Bool
+--     b = n > 42
+--   module M1 (n : Nat) = M0 (suc n)
+--   module M2 (n : Nat) = M1 (suc n)
+--   module M3 (n : Nat) = M2 (suc n)
+-- @
+--
+-- For the first copy @M1.b n = M0.b (suc n)@ we add the display form @M0.b (suc n) --> M1.b n@.
+--
+-- For the second copy @M2.b n = M1.b (suc n)@ we first add display form @M1.b (suc n) --> M2.b n@
+-- and for the further unfolding we add display form @M0.b (suc (suc n)) --> M2.b n@.
+--
+-- For the third copy @M3.b n = M2.b (suc n)@ we add display forms @M2.b (suc n) --> M3.b n@,
+-- @M1.b (suc (suc n)) --> M3.b n@ and @M0.b (suc (suc (suc n))) --> M3.b n@.
+
 addDisplayForms :: QName -> TCM ()
 addDisplayForms x = do
   reportSDoc "tc.display.section" 20 $ "Computing display forms for" <+> pretty x

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20251118 * 10 + 0
+currentInterfaceVersion = 20251123 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -110,13 +110,8 @@ instance EmbPrj AbstractName where
   value = toAbsName <.> value
 
 instance EmbPrj NameMetadata where
-  icod_ NoMetadata                  = icodeN' NoMetadata
-  icod_ (GeneralizedVarsMetadata a) = icodeN' GeneralizedVarsMetadata a
-
-  value = vcase valu where
-    valu N0     = valuN NoMetadata
-    valu (N1 a) = valuN GeneralizedVarsMetadata a
-    valu _      = malformed
+  icod_ (NameMetadata a) = icodeN' NameMetadata a
+  value = valueN NameMetadata
 
 instance EmbPrj A.Suffix where
   icod_ A.NoSuffix   = icodeN' A.NoSuffix

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -110,7 +110,7 @@ instance EmbPrj AbstractName where
   value = toAbsName <.> value
 
 instance EmbPrj NameMetadata where
-  icod_ (NameMetadata a) = icodeN' NameMetadata a
+  icod_ (NameMetadata a b) = icodeN' NameMetadata a b
   value = valueN NameMetadata
 
 instance EmbPrj A.Suffix where

--- a/src/full/Agda/Utils/Function.hs
+++ b/src/full/Agda/Utils/Function.hs
@@ -111,7 +111,7 @@ iterateUntilM r f = loop where
 iterate' :: Integral i => i -> (a -> a) -> a -> a
 iterate' n f x
   | n >= 0    = go n x
-  | otherwise = error "iterate': Negative input."
+  | otherwise = error "Agda.Utils.Function.iterate': Negative input."
   where
     go n x
       | n > 0     = go (n - 1) $! f x

--- a/src/full/Agda/Utils/IntMap.hs
+++ b/src/full/Agda/Utils/IntMap.hs
@@ -1,0 +1,7 @@
+module Agda.Utils.IntMap (module Agda.Utils.IntMap, module Data.IntMap) where
+
+import Data.IntMap
+
+{-# INLINE forWithKey_ #-}
+forWithKey_ :: forall v m. Applicative m => IntMap v -> (Int -> v -> m ()) -> m ()
+forWithKey_ m f = foldrWithKey (\ k v act -> f k v *> act) (pure ()) m

--- a/src/full/Agda/Utils/MinimalArray/MutablePrim.hs
+++ b/src/full/Agda/Utils/MinimalArray/MutablePrim.hs
@@ -11,7 +11,7 @@ newtype Array s a = Array {unwrap :: A.MutablePrimArray s a}
 type IOArray a = Array RealWorld a
 
 {-# INLINE new #-}
-new :: Prim a => PrimMonad m => Int -> m (Array (PrimState m) a)
+new :: PrimMonad m => Prim a => Int -> m (Array (PrimState m) a)
 new n = Array <$> A.newPrimArray n
 
 {-# INLINE size #-}
@@ -33,7 +33,7 @@ read arr i = do
   if 0 <= i && i < s then
     unsafeRead arr i
   else
-    error "Array.read: out of bounds"
+    error "Agda.Utils.MinimalArray.MutablePrim.read: out of bounds"
 
 {-# INLINE write #-}
 write :: PrimMonad m => Prim a => Array (PrimState m) a -> Int -> a -> m ()
@@ -42,7 +42,7 @@ write arr i a = do
   if 0 <= i && i < s then
     unsafeWrite arr i a
   else
-    error "Array.write: out of bounds"
+    error "Agda.Utils.MinimalArray.MutablePrim.write: out of bounds"
 
 {-# INLINE freeze #-}
 freeze :: PrimMonad m => Prim a => Array (PrimState m) a -> m (PA.Array a)
@@ -52,7 +52,7 @@ freeze (Array arr) = do
   pure (PA.Array arr)
 
 {-# INLINE set #-}
-set :: Prim a => PrimMonad m => Array (PrimState m) a -> a -> m ()
+set :: PrimMonad m => Prim a => Array (PrimState m) a -> a -> m ()
 set (Array arr) a = do
   s <- size (Array arr)
   A.setPrimArray arr 0 s a

--- a/src/full/Agda/Utils/MinimalArray/Prim.hs
+++ b/src/full/Agda/Utils/MinimalArray/Prim.hs
@@ -21,7 +21,7 @@ unsafeIndex (Array arr) i = A.indexPrimArray arr i
 {-# INLINE index #-}
 index :: Prim a => Array a -> Int -> a
 index arr i | 0 <= i && i < size arr = unsafeIndex arr i
-            | otherwise = error "Array: out of bounds"
+            | otherwise = error "Agda.Utils.MinimalArray.Prim.index: out of bounds"
 
 {-# INLINE foldr' #-}
 foldr' :: forall a b. Prim a => (a -> b -> b) -> b -> Array a -> b

--- a/src/full/Agda/Utils/Serialize.hs
+++ b/src/full/Agda/Utils/Serialize.hs
@@ -82,7 +82,7 @@ instance Monoid Put where
   mempty = Put \p s -> (# p, s #)
   {-# INLINE mappend #-}
   mappend = (<>)
-  mconcat = error "Put: mconcat not implemented"
+  mconcat = error "Agda.Utils.Serialize.Put: mconcat not implemented"
 
 instance Functor Get where
   {-# INLINE fmap #-}
@@ -110,7 +110,7 @@ ensure (I# n) k = Get \e p s ->
   let p' = plusAddr# p n in
   case leAddr# p' e of
     1# -> unGet (k p') e p s
-    _  -> error "deserialize: not enough input"
+    _  -> error "Agda.Utils.Serialize.deserialize: not enough input"
 {-# INLINE ensure #-}
 
 serialize :: Serialize a => a -> IO B.ByteString
@@ -121,7 +121,7 @@ serialize a = do
     (# p, s #) -> (# s, B.BS fptr (I# (minusAddr# p addr)) #)
   if B.length str == sz
     then pure str
-    else error "serialize: impossible mismatch of computed and written size"
+    else error "Agda.Utils.Serialize.serialize: impossible mismatch of computed and written size"
 
 deserialize :: forall a. Serialize a => B.ByteString -> IO a
 deserialize (B.BS (ForeignPtr p fp) (I# l)) =
@@ -129,10 +129,10 @@ deserialize (B.BS (ForeignPtr p fp) (I# l)) =
     let e = plusAddr# p l in
     case unGet (get @a) (plusAddr# p l) p s of
       (# p, s, a #) -> case ltAddr# p e of
-        1# -> error "deserialize: not all input was consumed"
+        1# -> error "Agda.Utils.Serialize.deserialize: not all input was consumed"
         _  -> case eqAddr# p e of
           1# -> (# s, a #)
-          _  -> error "deserialize: impossible out of bounds access"
+          _  -> error "Agda.Utils.Serialize.deserialize: impossible out of bounds access"
 
 serializePure :: Serialize a => a -> B.ByteString
 serializePure a = unsafeDupablePerformIO $ serialize a
@@ -392,4 +392,4 @@ instance Serialize Integer where
     0 -> do {I# n  <- get; pure $ IS n}
     1 -> do {I# sz <- get; getByteArray# sz \arr -> pure $ IP arr}
     2 -> do {I# sz <- get; getByteArray# sz \arr -> pure $ IN arr}
-    _ -> error "deserialize: malformed input"
+    _ -> error "Agda.Utils.Serialize.deserialize: malformed input"


### PR DESCRIPTION
This PR contains (random stuff and) refactorings done for 
- PR #8226.

Commits:

- **cosmetics**
  

- **Explaining addDisplayForms to Andras**
  

- **Agda.Utils.*: in error "function: reason" fully qualify "function"**
  

- **New: Agda.Utils.IntMap exporting forWithKey_**
  

- **Refactor: toAbstractOldName instead of toAbstract . OldName**
  The overloading of toAbstract in the scope checker is going a bit too far.
  When you have to add a newtype (`OldName`)
  just to use the overloaded name (`toAbstract`)
  you can as well use a particular function name (`toAbstractOldName`) instead,
  

- **Refactor NameMetadata: drop constructor NoMetadata**
  NoMetadata just had the same semantics as an empty Map here
  

- **Add IsInstance to NameMetadata**
  

- **Debug: when printing scope, include IsInstance info from NameMetaData**
  