### PR TITLE
New warning UnusedImports

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -684,6 +684,7 @@ library
       Agda.Syntax.Scope.Monad
       Agda.Syntax.Scope.Operator
       Agda.Syntax.Scope.State
+      Agda.Syntax.Scope.UnusedImports
       Agda.Syntax.TopLevelModuleName
       Agda.Syntax.TopLevelModuleName.Boot
       Agda.Syntax.Translation.AbstractToConcrete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,19 @@ Errors
 Warnings
 --------
 
+* New warning `UnusedImports` when `open` brings identifiers into scope
+  that are definitely not used subsequently.
+
+  If `using` or `renaming` directives are given, or in flavor `-WUnusedImports=all`,
+  Agda warns about each name that is unused.
+  If no directive or only a `hiding` directive is given,
+  and unless the flavor is `all`,
+  Agda only warns if none of the imported names are used.
+
+  Agda also warns about instances brought into scope
+  unless `--no-qualified-instances` is on
+  (which requires bringing instances into scope if they should be found by instance search).
+
 * `UselessImport` warning instead of parse error when an module is instantiated
   but not opened during `import`, for instance:
   ```agda

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1731,9 +1731,9 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Warn about openings of modules that do not bring identifiers into scope that are subsequently used.
      If the ``open`` comes with an explicit ``using`` or ``renaming`` directive,
-     only warn about unused identifiers mentioned in the directive.
+     warn about individual unused identifiers (typically those mentioned in the directive).
      There is no warning about ``public`` openings.
-     In the presence of option:``--no-qualified-instances``,
+     In the presence of option:`--no-qualified-instances`,
      there are also no warnings about unused instances brought into scope.
 
      This warning is off by default.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1725,6 +1725,27 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Failures to compute full equivalence when splitting on indexed family.
 
+.. option:: UnusedImports
+
+     .. versionadded:: 2.9.0
+
+     Warn about openings of modules that do not bring identifiers into scope that are subsequently used.
+     If the ``open`` comes with an explicit ``using`` or ``renaming`` directive,
+     only warn about unused identifiers mentioned in the directive.
+     There is no warning about ``public`` openings.
+     In the presence of option:``--no-qualified-instances``,
+     there are also no warnings about unused instances brought into scope.
+
+     This warning is off by default.
+
+.. option:: UnusedImports=all
+
+     .. versionadded:: 2.9.0
+
+     Same as :option:`UnusedImports`, but warn about each unused identifier also when no ``using`` or ``renaming`` directive is given.
+
+     Option ``-WnoUnusedImports`` disables both :option:`UnusedImports` and :option:`UnusedImports=all`.
+
 .. option:: UnusedVariablesInDisplayForm
 
      :ref:`DISPLAY <display-pragma>` forms that bind variables they do not use.

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -458,6 +458,7 @@ warningHighlighting' b w = case tcWarning w of
   FixingPolarity _ q _       -> if null r then cosmeticProblemHighlighting w else deadcodeHighlighting r
     where r = getRange q
   IllformedAsClause{}        -> deadcodeHighlighting w
+  UnusedImports m xs         -> cosmeticProblemHighlighting m <> foldMap deadcodeHighlighting xs
   UselessPragma r _          -> deadcodeHighlighting r
   UselessPublic{}            -> deadcodeHighlighting w
   UselessHiding xs           -> foldMap deadcodeHighlighting xs

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -459,7 +459,7 @@ warningHighlighting' b w = case tcWarning w of
     where r = getRange q
   IllformedAsClause{}        -> deadcodeHighlighting w
   UnusedImports m Nothing    -> deadcodeHighlighting w
-  UnusedImports m xs         -> cosmeticProblemHighlighting m <> foldMap deadcodeHighlighting xs
+  UnusedImports m xs         -> cosmeticProblemHighlighting w <> foldMap deadcodeHighlighting xs
   UselessPragma r _          -> deadcodeHighlighting r
   UselessPublic{}            -> deadcodeHighlighting w
   UselessHiding xs           -> foldMap deadcodeHighlighting xs

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -458,6 +458,7 @@ warningHighlighting' b w = case tcWarning w of
   FixingPolarity _ q _       -> if null r then cosmeticProblemHighlighting w else deadcodeHighlighting r
     where r = getRange q
   IllformedAsClause{}        -> deadcodeHighlighting w
+  UnusedImports m Nothing    -> deadcodeHighlighting w
   UnusedImports m xs         -> cosmeticProblemHighlighting m <> foldMap deadcodeHighlighting xs
   UselessPragma r _          -> deadcodeHighlighting r
   UselessPublic{}            -> deadcodeHighlighting w

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -200,6 +200,7 @@ usualWarnings =
   allWarnings Set.\\ exactSplitWarnings Set.\\ Set.fromList
     [ UnknownFixityInMixfixDecl_
     , ShadowingInTelescope_
+    , UnusedImports_
     ]
 
 -- | Warnings enabled by @--exact-split@.
@@ -287,6 +288,7 @@ data WarningName
   -- -- | FixingQuantity_
   | FixityInRenamingModule_
   | InvalidCharacterLiteral_
+  | UnusedImports_
   | UselessPragma_
   | IllegalDeclarationInDataDefinition_
   | IllformedAsClause_
@@ -610,6 +612,7 @@ warningNameDescription = \case
   WrongInstanceDeclaration_        -> "Instances that do not adhere to the required format."
   TooManyPolarities_               -> "Too many polarities given in POLARITY pragma."
   TopLevelPolarity_                -> "Declaring definitions with an explicit polarity annotation."
+  UnusedImports_                   -> "Identifiers brought into scope but never referenced."
   -- Checking consistency of options
   CoInfectiveImport_               -> "Importing a file not using e.g. `--safe'  from one which does."
   InfectiveImport_                 -> "Importing a file using e.g. `--cubical' into one which does not."

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -10,6 +10,7 @@ module Agda.Interaction.Options.Warnings
        , usualWarnings
        , noWarnings
        , unsolvedWarnings
+       , unusedImportsWarnings
        , incompleteMatchWarnings
        , errorWarnings
        , exactSplitWarnings
@@ -44,6 +45,7 @@ import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List
 import Agda.Utils.Maybe
+import Agda.Utils.Singleton ( singleton )
 import Agda.Utils.Tuple ( (&&&) )
 
 import Agda.Utils.Impossible
@@ -53,6 +55,7 @@ import Agda.Utils.Impossible
 -- and a flag stating whether warnings should be turned into fatal errors.
 data WarningMode = WarningMode
   { _warningSet :: Set WarningName
+      -- ^ Invariant: When 'UnusedImportsAll_' is in the warning set, so must be 'UnusedImports_'.
   , _warn2Error :: Bool
   } deriving (Eq, Show, Generic)
 
@@ -85,6 +88,8 @@ data WarningModeError
       -- ^ Unknown warning.
   | NoNoError Text
       -- ^ Warning that cannot be disabled.
+  | NoUnusedImportsAll
+      -- ^ @-WnoUnusedImports=all@ is not supported, use @-WnoUnusedImports@ instead.
   deriving (Show, Generic)
 
 instance NFData WarningModeError
@@ -97,6 +102,8 @@ prettyWarningModeError = \case
     , w
     , " is a non-fatal error and thus cannot be ignored."
     ]
+  NoUnusedImportsAll ->
+    "-WnoUnusedImports=all is not supported, use -WnoUnusedImports instead."
 
 -- | From user-given directives we compute WarningMode updates
 type WarningModeUpdate = WarningMode -> WarningMode
@@ -114,12 +121,22 @@ warningModeUpdate str = case str of
   _ -> case stripPrefix "no" str of
     Nothing   -> do
       wname <- stringToWarningName str
-      pure (over warningSet $ Set.insert wname)
+      let
+        wnames = case wname of
+          -- Invariant: when UnusedImportsAll_ is in the warning set,
+          -- so must be UnusedImports_
+          UnusedImportsAll_ -> unusedImportsWarnings
+          w -> singleton w
+      pure $ over warningSet $ (`Set.union` wnames)
     Just str' -> do
       wname <- stringToWarningName str'
       when (wname `elem` errorWarnings) $
         throwError $ NoNoError $ Text.pack str'
-      pure (over warningSet $ Set.delete wname)
+      wnames <- case wname of
+        UnusedImports_    -> pure unusedImportsWarnings
+        UnusedImportsAll_ -> throwError NoUnusedImportsAll
+        w -> pure $ singleton w
+      pure $ over warningSet $ (Set.\\ wnames)
   where
     stringToWarningName :: String -> Either WarningModeError WarningName
     stringToWarningName str = maybeToEither (Unknown $ Text.pack str) $ string2WarningName str
@@ -201,6 +218,7 @@ usualWarnings =
     [ UnknownFixityInMixfixDecl_
     , ShadowingInTelescope_
     , UnusedImports_
+    , UnusedImportsAll_
     ]
 
 -- | Warnings enabled by @--exact-split@.
@@ -210,6 +228,10 @@ exactSplitWarnings = Set.fromList
   [ CoverageNoExactSplit_
   , InlineNoExactSplit_
   ]
+
+-- | Both of these warnings are disabled by @-WnoUnusedImports@.
+unusedImportsWarnings :: Set WarningName
+unusedImportsWarnings = Set.fromList [ UnusedImports_, UnusedImportsAll_ ]
 
 -- | The @WarningName@ data enumeration is meant to have a one-to-one correspondance
 -- to existing warnings in the codebase.
@@ -289,6 +311,7 @@ data WarningName
   | FixityInRenamingModule_
   | InvalidCharacterLiteral_
   | UnusedImports_
+  | UnusedImportsAll_
   | UselessPragma_
   | IllegalDeclarationInDataDefinition_
   | IllformedAsClause_
@@ -404,7 +427,9 @@ string2WarningName = (`HMap.lookup` warnings) where
   warnings = HMap.fromList $ map (\x -> (warningNameToString x, x)) [minBound..maxBound]
 
 warningNameToString :: WarningName -> String
-warningNameToString = initWithDefault __IMPOSSIBLE__ . show
+warningNameToString = \case
+  UnusedImportsAll_ -> "UnusedImports=all"
+  w -> initWithDefault __IMPOSSIBLE__ $ show w
 
 -- | @warningUsage@ generated using @warningNameDescription@
 
@@ -613,6 +638,7 @@ warningNameDescription = \case
   TooManyPolarities_               -> "Too many polarities given in POLARITY pragma."
   TopLevelPolarity_                -> "Declaring definitions with an explicit polarity annotation."
   UnusedImports_                   -> "Identifiers brought into scope but never referenced."
+  UnusedImportsAll_                -> "Identifiers brought into scope but never referenced (strict version)."
   -- Checking consistency of options
   CoInfectiveImport_               -> "Importing a file not using e.g. `--safe'  from one which does."
   InfectiveImport_                 -> "Importing a file using e.g. `--cubical' into one which does not."

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -428,13 +428,13 @@ isModuleAlive (A.MName mod) (SomeLiveNames mods _) =
 
 -- | Information gathered during scope checking for the unused-imports warning.
 data UnusedImportsState = UnusedImportsState
-  { unambiguousLookups :: [AbstractName]
+  { unambiguousLookups :: ![AbstractName]
       -- ^ Names that were unambiguously resolved from a concrete name in the source.
-  , ambiguousLookups   :: IntMap (List2 AbstractName)
+  , ambiguousLookups   :: !(IntMap (List2 AbstractName))
       -- ^ Names that were ambiguously resolved from a concrete name in the source.
       --   They are stored with their position in the file
       --   that is matched with disambiguation information produced by the type checker.
-  , openedModules      :: IntMap (A.ModuleName, A.ModuleName, NamesInScope)
+  , openedModules      :: !(IntMap (KwRange, A.ModuleName, A.ModuleName, Bool, NamesInScope))
       -- ^ Log of module @open@s with the names they brought into scope.
   } deriving (Generic)
 
@@ -443,13 +443,13 @@ instance Null UnusedImportsState where
   null (UnusedImportsState u a o) = null u && null a && null o
 
 lensUnambiguousLookups :: Lens' UnusedImportsState [AbstractName]
-lensUnambiguousLookups f s = f (unambiguousLookups s) <&> \x -> s { unambiguousLookups = x }
+lensUnambiguousLookups f s = f (unambiguousLookups s) <&> \ !x -> s { unambiguousLookups = x }
 
 lensAmbiguousLookups :: Lens' UnusedImportsState (IntMap (List2 AbstractName))
-lensAmbiguousLookups f s = f (ambiguousLookups s) <&> \x -> s { ambiguousLookups = x }
+lensAmbiguousLookups f s = f (ambiguousLookups s) <&> \ !x -> s { ambiguousLookups = x }
 
-lensOpenedModules :: Lens' UnusedImportsState (IntMap (KwRange, ModuleName, ModuleName, NamesInScope))
-lensOpenedModules f s = f (openedModules s) <&> \x -> s { openedModules = x }
+lensOpenedModules :: Lens' UnusedImportsState (IntMap (KwRange, ModuleName, ModuleName, Bool, NamesInScope))
+lensOpenedModules f s = f (openedModules s) <&> \ !x -> s { openedModules = x }
 
 ------------------------------------------------------------------------
 -- * Decorated names

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -434,7 +434,7 @@ data UnusedImportsState = UnusedImportsState
       -- ^ Names that were ambiguously resolved from a concrete name in the source.
       --   They are stored with their position in the file
       --   that is matched with disambiguation information produced by the type checker.
-  , openedModules      :: Map ModuleName (A.ModuleName, NamesInScope)
+  , openedModules      :: IntMap (A.ModuleName, A.ModuleName, NamesInScope)
       -- ^ Log of module @open@s with the names they brought into scope.
   } deriving (Generic)
 
@@ -448,7 +448,7 @@ lensUnambiguousLookups f s = f (unambiguousLookups s) <&> \x -> s { unambiguousL
 lensAmbiguousLookups :: Lens' UnusedImportsState (IntMap (List2 AbstractName))
 lensAmbiguousLookups f s = f (ambiguousLookups s) <&> \x -> s { ambiguousLookups = x }
 
-lensOpenedModules :: Lens' UnusedImportsState (Map ModuleName (A.ModuleName, NamesInScope))
+lensOpenedModules :: Lens' UnusedImportsState (IntMap (ModuleName, ModuleName, NamesInScope))
 lensOpenedModules f s = f (openedModules s) <&> \x -> s { openedModules = x }
 
 ------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -448,7 +448,7 @@ lensUnambiguousLookups f s = f (unambiguousLookups s) <&> \x -> s { unambiguousL
 lensAmbiguousLookups :: Lens' UnusedImportsState (IntMap (List2 AbstractName))
 lensAmbiguousLookups f s = f (ambiguousLookups s) <&> \x -> s { ambiguousLookups = x }
 
-lensOpenedModules :: Lens' UnusedImportsState (IntMap (ModuleName, ModuleName, NamesInScope))
+lensOpenedModules :: Lens' UnusedImportsState (IntMap (KwRange, ModuleName, ModuleName, NamesInScope))
 lensOpenedModules f s = f (openedModules s) <&> \x -> s { openedModules = x }
 
 ------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -428,9 +428,9 @@ isModuleAlive (A.MName mod) (SomeLiveNames mods _) =
 
 -- | Information gathered during scope checking for the unused-imports warning.
 data UnusedImportsState = UnusedImportsState
-  { unambiguousLookups :: Set A.QName
+  { unambiguousLookups :: [AbstractName]
       -- ^ Names that were unambiguously resolved from a concrete name in the source.
-  , ambiguousLookups   :: IntMap (List2 A.QName)
+  , ambiguousLookups   :: IntMap (List2 AbstractName)
       -- ^ Names that were ambiguously resolved from a concrete name in the source.
       --   They are stored with their position in the file
       --   that is matched with disambiguation information produced by the type checker.
@@ -442,10 +442,10 @@ instance Null UnusedImportsState where
   empty = UnusedImportsState empty empty empty
   null (UnusedImportsState u a o) = null u && null a && null o
 
-lensUnambiguousLookups :: Lens' UnusedImportsState (Set A.QName)
+lensUnambiguousLookups :: Lens' UnusedImportsState [AbstractName]
 lensUnambiguousLookups f s = f (unambiguousLookups s) <&> \x -> s { unambiguousLookups = x }
 
-lensAmbiguousLookups :: Lens' UnusedImportsState (IntMap (List2 A.QName))
+lensAmbiguousLookups :: Lens' UnusedImportsState (IntMap (List2 AbstractName))
 lensAmbiguousLookups f s = f (ambiguousLookups s) <&> \x -> s { ambiguousLookups = x }
 
 lensOpenedModules :: Lens' UnusedImportsState (Map ModuleName NamesInScope)

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -327,6 +327,12 @@ setScopeLocals = set scopeLocals
 data NameSpace = NameSpace
       { nsNames   :: NamesInScope
         -- ^ Maps concrete names to a list of abstract names.
+        --   If this is part of a scope produced by an 'ImportDirective',
+        --   the concrete names should (where possible) match those of the directive.
+        --   E.g., if the directive mentions @using (x)@, then the concrete @x@
+        --   in the map should be this @x@ rather then the @x@ from the original
+        --   scope that is restricted by the import directive.
+        --   This is important for the highlighting of the 'UnusedImports' warning.
       , nsNameParts :: NamePartsInScope
         -- ^ Maps name parts to a list of abstract names in which the name
         --   part occurs.

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -434,7 +434,7 @@ data UnusedImportsState = UnusedImportsState
       -- ^ Names that were ambiguously resolved from a concrete name in the source.
       --   They are stored with their position in the file
       --   that is matched with disambiguation information produced by the type checker.
-  , openedModules      :: Map ModuleName NamesInScope
+  , openedModules      :: Map ModuleName (A.ModuleName, NamesInScope)
       -- ^ Log of module @open@s with the names they brought into scope.
   } deriving (Generic)
 
@@ -448,7 +448,7 @@ lensUnambiguousLookups f s = f (unambiguousLookups s) <&> \x -> s { unambiguousL
 lensAmbiguousLookups :: Lens' UnusedImportsState (IntMap (List2 AbstractName))
 lensAmbiguousLookups f s = f (ambiguousLookups s) <&> \x -> s { ambiguousLookups = x }
 
-lensOpenedModules :: Lens' UnusedImportsState (Map ModuleName NamesInScope)
+lensOpenedModules :: Lens' UnusedImportsState (Map ModuleName (A.ModuleName, NamesInScope))
 lensOpenedModules f s = f (openedModules s) <&> \x -> s { openedModules = x }
 
 ------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -44,7 +44,7 @@ import Agda.Syntax.Concrete.Definitions ( DeclarationWarning(..) ,DeclarationWar
   -- TODO: move the relevant warnings out of there
 import Agda.Syntax.Scope.Base as A
 import Agda.Syntax.Scope.State
-import Agda.Syntax.Scope.UnusedImports (openedModule)
+import Agda.Syntax.Scope.UnusedImports (registerModuleOpening)
 
 import Agda.TypeChecking.Monad.Base as I
 import Agda.TypeChecking.Monad.Builtin
@@ -1066,7 +1066,7 @@ openModule kwr kind mam cm dir = do
   -- Get the scope exported by module to be opened.
   (adir, s') <- applyImportDirectiveM cm dir . inScopeBecause (Opened cm) .
                 noGeneralizedVarsIfLetOpen kind =<< getNamedScope m
-  whenNothing (publicOpen dir) $ openedModule kwr current cm dir s' -- For the unused import warning
+  whenNothing (publicOpen dir) $ registerModuleOpening kwr current cm dir s' -- For the unused import warning
   let s  = setScopeAccess acc s'
   let ns = scopeNameSpace acc s
   modifyCurrentScope \current -> recomputeNameParts $ mergeScope current s

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -1066,7 +1066,7 @@ openModule kwr kind mam cm dir = do
   -- Get the scope exported by module to be opened.
   (adir, s') <- applyImportDirectiveM cm dir . inScopeBecause (Opened cm) .
                 noGeneralizedVarsIfLetOpen kind =<< getNamedScope m
-  whenNothing (publicOpen dir) $ registerModuleOpening kwr current cm dir s' -- For the unused import warning
+  registerModuleOpening kwr current cm dir s' -- For the unused import warning
   let s  = setScopeAccess acc s'
   let ns = scopeNameSpace acc s
   modifyCurrentScope \current -> recomputeNameParts $ mergeScope current s

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -44,6 +44,7 @@ import Agda.Syntax.Concrete.Definitions ( DeclarationWarning(..) ,DeclarationWar
   -- TODO: move the relevant warnings out of there
 import Agda.Syntax.Scope.Base as A
 import Agda.Syntax.Scope.State
+import Agda.Syntax.Scope.UnusedImports (openedModule)
 
 import Agda.TypeChecking.Monad.Base as I
 import Agda.TypeChecking.Monad.Builtin
@@ -1065,6 +1066,7 @@ openModule kwr kind mam cm dir = do
   -- Get the scope exported by module to be opened.
   (adir, s') <- applyImportDirectiveM cm dir . inScopeBecause (Opened cm) .
                 noGeneralizedVarsIfLetOpen kind =<< getNamedScope m
+  openedModule s' -- For the unused import warning
   let s  = setScopeAccess acc s'
   let ns = scopeNameSpace acc s
   modifyCurrentScope \current -> recomputeNameParts $ mergeScope current s

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -1066,7 +1066,7 @@ openModule kwr kind mam cm dir = do
   -- Get the scope exported by module to be opened.
   (adir, s') <- applyImportDirectiveM cm dir . inScopeBecause (Opened cm) .
                 noGeneralizedVarsIfLetOpen kind =<< getNamedScope m
-  whenNothing (publicOpen dir) $ openedModule current cm s' -- For the unused import warning
+  whenNothing (publicOpen dir) $ openedModule kwr current cm s' -- For the unused import warning
   let s  = setScopeAccess acc s'
   let ns = scopeNameSpace acc s
   modifyCurrentScope \current -> recomputeNameParts $ mergeScope current s

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -1066,7 +1066,7 @@ openModule kwr kind mam cm dir = do
   -- Get the scope exported by module to be opened.
   (adir, s') <- applyImportDirectiveM cm dir . inScopeBecause (Opened cm) .
                 noGeneralizedVarsIfLetOpen kind =<< getNamedScope m
-  whenNothing (publicOpen dir) $ openedModule cm s' -- For the unused import warning
+  whenNothing (publicOpen dir) $ openedModule current cm s' -- For the unused import warning
   let s  = setScopeAccess acc s'
   let ns = scopeNameSpace acc s
   modifyCurrentScope \current -> recomputeNameParts $ mergeScope current s

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -1066,7 +1066,7 @@ openModule kwr kind mam cm dir = do
   -- Get the scope exported by module to be opened.
   (adir, s') <- applyImportDirectiveM cm dir . inScopeBecause (Opened cm) .
                 noGeneralizedVarsIfLetOpen kind =<< getNamedScope m
-  whenNothing (publicOpen dir) $ openedModule kwr current cm s' -- For the unused import warning
+  whenNothing (publicOpen dir) $ openedModule kwr current cm dir s' -- For the unused import warning
   let s  = setScopeAccess acc s'
   let ns = scopeNameSpace acc s
   modifyCurrentScope \current -> recomputeNameParts $ mergeScope current s

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -1066,7 +1066,7 @@ openModule kwr kind mam cm dir = do
   -- Get the scope exported by module to be opened.
   (adir, s') <- applyImportDirectiveM cm dir . inScopeBecause (Opened cm) .
                 noGeneralizedVarsIfLetOpen kind =<< getNamedScope m
-  openedModule s' -- For the unused import warning
+  whenNothing (publicOpen dir) $ openedModule cm s' -- For the unused import warning
   let s  = setScopeAccess acc s'
   let ns = scopeNameSpace acc s
   modifyCurrentScope \current -> recomputeNameParts $ mergeScope current s

--- a/src/full/Agda/Syntax/Scope/UnusedImports.hs
+++ b/src/full/Agda/Syntax/Scope/UnusedImports.hs
@@ -113,7 +113,8 @@ registerModuleOpening kwr currentModule x dir (Scope m0 _parents ns imports _dat
   -- When the UnusedImports warning is off, do not collect information about @open@.
   -- E.g. we do not want to see warnings for the automatically inserted
   -- @open import Agda.Primitive using (Set)@.
-  doWarn :: Bool <- (not . null) <$> unusedImportWs
+  -- It is sufficient to check for 'UnusedImports_' since it is implied by 'UnusedImportsAll_'.
+  doWarn <- (UnusedImports_ `Set.member`) <$> useTC stWarningSet
   reportSLn "warning.unusedImports" 20 $ unlines
     [ "openedModule: " <> prettyShow doWarn
     , "x = " <> prettyShow x
@@ -205,9 +206,6 @@ warnUnusedImports = do
 
 ------------------------------------------------------------------------------
 -- * Auxiliary definitions
-
-unusedImportWs :: ScopeM (Set WarningName)
-unusedImportWs = (unusedImportsWarnings `Set.intersection`) <$> useTC stWarningSet
 
 -- | A wrapper around 'AbstractName' to make the position of the 'Opened' in the lineage available.
 --   This wrapper is needed when 'AbstractName's are stored in sets

--- a/src/full/Agda/Syntax/Scope/UnusedImports.hs
+++ b/src/full/Agda/Syntax/Scope/UnusedImports.hs
@@ -20,6 +20,7 @@ import Prelude hiding (null, (||))
 
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IntMap
+import Data.List (partition)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (Set)
@@ -107,15 +108,15 @@ warnUnusedImports = do
     qualifiedInstances <- optQualifiedInstances <$> pragmaOptions
 
     let
-      xs :: [A.QName]
+      xs :: Set A.QName -> Set A.QName
       xs = flip IntMap.foldMapWithKey (ambiguousLookups st) \ (i :: Int) (ys :: List2 A.QName) -> do
         case IntMap.lookup i disambiguatedNames of
-          Just (DisambiguatedName _k x) -> [x]
-          Nothing -> List2.toList ys -- __IMPOSSIBLE__
+          Just (DisambiguatedName _k x) -> Set.insert x
+          Nothing -> foldMap Set.insert ys -- __IMPOSSIBLE__
 
     -- Compute unambiguous lookups by using name disambiguation info from type checker.
     let
-      lookups = unambiguousLookups st `Set.union` Set.fromList xs
+      lookups = unambiguousLookups st `Set.union` xs empty
       isLookedUp :: A.AbstractName -> Bool
       isLookedUp y = anameName y `Set.member`lookups
       isInst :: A.AbstractName -> Bool

--- a/src/full/Agda/Syntax/Scope/UnusedImports.hs
+++ b/src/full/Agda/Syntax/Scope/UnusedImports.hs
@@ -1,0 +1,126 @@
+-- | Warn about unused imports.
+--
+-- For each @open@ statement, we want to issue a warning about concrete names
+-- brought into scope by this statement which are not referenced subsequently.
+--
+-- To this end, whenever we lookup a concrete name during scope checking,
+-- we mark it as used by calling 'lookedupName' with the results of the lookup,
+-- which is an 'AbstractName' or several 'AbstractName's in case the name
+-- is ambiguous (e.g. an ambiguous constructor or projection).
+--
+-- We also record for each opened module the set of 'AbstractName's it brought
+-- into scope.
+--
+-- When checking the file is done, we can traverse the each opened module
+-- and report all the 'AbstractName's that we not used.
+
+module Agda.Syntax.Scope.UnusedImports where
+
+import Prelude hiding (null)
+
+import Data.IntMap (IntMap)
+import Data.IntMap qualified as IntMap
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+
+import Agda.Syntax.Abstract.Name qualified as A
+import Agda.Syntax.Common ( IsInstanceDef(isInstanceDef) )
+import Agda.Syntax.Concrete.Name qualified as C
+import Agda.Syntax.Position ( HasRange(getRange) )
+import Agda.Syntax.Position qualified as P
+import Agda.Syntax.Scope.Base as A
+
+import Agda.TypeChecking.Monad.Base
+import Agda.TypeChecking.Warnings (warning)
+
+import Agda.Utils.Lens
+import Agda.Utils.List1 ( pattern (:|), List1 )
+import Agda.Utils.List1 qualified as List1
+import Agda.Utils.List2 ( List2(..) )
+import Agda.Utils.List2 qualified as List2
+import Agda.Utils.Maybe
+import Agda.Utils.Monad
+import Agda.Utils.Null
+
+import Agda.Utils.Impossible
+
+-- import Agda.Syntax.Scope.Monad (ScopeM) -- cyclic import
+type ScopeM = TCM -- to avoid cyclic imports
+
+-- | Call these whenever a concrete name was translated to an abstract one.
+lookedupName :: C.QName -> ResolvedName -> ScopeM ()
+lookedupName x = \case
+    DefinedName _access y _suffix -> unamb y
+    FieldName ys                  -> add ys
+    ConstructorName _ind ys       -> add ys
+    PatternSynResName ys          -> add ys
+    VarName{}                     -> return ()
+    UnknownName{}                 -> return ()
+  where
+    add = \case
+      y  :| []      -> unamb y
+      y1 :| y2 : ys -> amb $ List2 y1 y2 ys
+    unamb = modifyTCLens stUnambiguousLookups . Set.insert . A.anameName
+    amb = modifyTCLens stAmbiguousLookups . IntMap.insert i . fmap A.anameName
+    -- The range
+    i = maybe __IMPOSSIBLE__ (fromIntegral . P.posPos) $ P.rStart' $ getRange x
+
+-- lookedupName :: C.QName -> List1 AbstractName -> ScopeM ()
+-- lookedupName x = \case
+--   y :| [] -> modifyTCLens stUnambiguousLookups $ Set.insert y
+--   y1 :| y2 :| ys -> modifyLens stAmbiguousLookups $ IntMap.insert i $ List2 y1 y2 ys
+--   where
+--     i = maybe __IMPOSSIBLE__ (fromIntegral . P.posPos) $ P.rStart' $ getRange x
+
+-- | Call this when opening a module with all the names it brings into scope.
+openedModule :: Scope -> ScopeM ()
+openedModule (Scope m _parents ns imports _dataOrRec) = do
+  -- imports have been removed by restrictPrivate
+  unless (null imports) __IMPOSSIBLE__
+  let
+    broughtIntoScope :: NamesInScope -- [Map C.Name (List1 AbstractName)]
+    broughtIntoScope = mergeNamesMany $ map (nsNames . snd) ns
+  modifyTCLens stOpenedModules $ Map.insert m broughtIntoScope
+
+-- openedModule :: ModuleName -> Set AbstractName -> ScopeM ()
+-- openedModule m ys = modifyTCLens stOpenedModules $ Map.insert m ys
+
+-- | Call this when a file has been checked.
+warnUnusedImports :: ScopeM ()
+warnUnusedImports = do
+  st <- useTC stUnusedImportsState
+  disambiguatedNames <- useTC stDisambiguatedNames
+  let
+    xs :: [A.QName]
+    xs = flip concatMap (IntMap.toList $ ambiguousLookups st) \ (i :: Int, ys :: List2 A.QName) -> do
+      case IntMap.lookup i disambiguatedNames of
+        Just (DisambiguatedName _k x) -> [x]
+        Nothing -> List2.toList ys -- __IMPOSSIBLE__
+
+  -- Compute unambiguous lookups by using name disambiguation info from type checker.
+  let lookups = unambiguousLookups st `Set.union` Set.fromList xs
+  let
+    isUsed :: A.AbstractName -> Bool
+    isUsed y = isJust (isInstanceDef y) || anameName y `Set.member`lookups
+  -- TODO: traverseWithKey_
+  forM_ (Map.toList $ openedModules st) \ (m :: A.ModuleName, sc :: NamesInScope) -> do
+    let
+      unused :: [(C.Name, List1 A.AbstractName)]
+      unused = filter (\ (_x :: C.Name, ys :: List1 A.AbstractName) -> all (not . isUsed) ys) $ Map.toList sc
+    List1.unlessNull (map fst unused) \ unused1 -> do
+      warning $ UnusedImports m unused1
+  -- forMM_ (Map.toList <$> useTCLens stOpenedModules) \ (m, ys) -> do
+  --   unused = filter (\ x -> anameName x `Set.notMember` lookups) $ Set.toList ys
+  --   let unused = Map.restrictKeysSet ys lookups
+  --   warning $ UnusedImports m unused
+
+stUnambiguousLookups :: Lens' TCState (Set A.QName)
+stUnambiguousLookups = stUnusedImportsState . lensUnambiguousLookups
+
+stAmbiguousLookups :: Lens' TCState (IntMap (List2 A.QName))
+stAmbiguousLookups = stUnusedImportsState . lensAmbiguousLookups
+
+stOpenedModules :: Lens' TCState (Map A.ModuleName NamesInScope)
+stOpenedModules = stUnusedImportsState . lensOpenedModules

--- a/src/full/Agda/Syntax/Scope/UnusedImports.hs
+++ b/src/full/Agda/Syntax/Scope/UnusedImports.hs
@@ -108,15 +108,15 @@ warnUnusedImports = do
     qualifiedInstances <- optQualifiedInstances <$> pragmaOptions
 
     let
-      xs :: Set A.QName -> Set A.QName
+      xs :: [A.QName]
       xs = flip IntMap.foldMapWithKey (ambiguousLookups st) \ (i :: Int) (ys :: List2 A.QName) -> do
         case IntMap.lookup i disambiguatedNames of
-          Just (DisambiguatedName _k x) -> Set.insert x
-          Nothing -> foldMap Set.insert ys -- __IMPOSSIBLE__
+          Just (DisambiguatedName _k x) -> [x]
+          Nothing -> List2.toList ys -- __IMPOSSIBLE__
 
     -- Compute unambiguous lookups by using name disambiguation info from type checker.
     let
-      lookups = unambiguousLookups st `Set.union` xs empty
+      lookups = unambiguousLookups st `Set.union` Set.fromList xs
       isLookedUp :: A.AbstractName -> Bool
       isLookedUp y = anameName y `Set.member`lookups
       isInst :: A.AbstractName -> Bool

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1581,7 +1581,10 @@ importPrimitives = do
           ]
         directives          = ImportDirective noRange (Using usingDirective) [] [] Nothing
         importAgdaPrimitive = [C.Import (C.DoOpen empty) empty agdaPrimitiveName empty directives]
-    toAbstract (Declarations importAgdaPrimitive)
+    -- We don't want UnusedImports warnings when importing the primitives,
+    -- since the open statement was not assembled by the user.
+    locallyTCState (stPragmaOptions . lensOptWarningMode . lensSingleWarning UnusedImports_) (const False) do
+      toAbstract (Declarations importAgdaPrimitive)
 
 -- | runs Syntax.Concrete.Definitions.niceDeclarations on main module
 niceDecls :: DoWarn -> [C.Declaration] -> ([NiceDeclaration] -> ScopeM a) -> ScopeM a

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1583,7 +1583,7 @@ importPrimitives = do
         importAgdaPrimitive = [C.Import (C.DoOpen empty) empty agdaPrimitiveName empty directives]
     -- We don't want UnusedImports warnings when importing the primitives,
     -- since the open statement was not assembled by the user.
-    locallyTCState (stPragmaOptions . lensOptWarningMode . lensSingleWarning UnusedImports_) (const False) do
+    locallyTCState stWarningSet (Set.\\ unusedImportsWarnings) do
       toAbstract (Declarations importAgdaPrimitive)
 
 -- | runs Syntax.Concrete.Definitions.niceDeclarations on main module

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -60,6 +60,7 @@ import Agda.Syntax.Concrete.Fixity (DoWarn(..))
 import Agda.Syntax.Notation
 import Agda.Syntax.Scope.Base as A
 import Agda.Syntax.Scope.Monad
+import Agda.Syntax.Scope.UnusedImports (lookedupName)
 import Agda.Syntax.Translation.AbstractToConcrete (ToConcrete, ConOfAbs)
 import Agda.Syntax.DoNotation
 import Agda.Syntax.IdiomBrackets
@@ -564,6 +565,7 @@ instance ToAbstract MaybeOldQName where
   type AbsOfCon MaybeOldQName = Maybe A.Expr
   toAbstract (MaybeOldQName (OldQName x ns)) = do
     qx <- resolveName' allKindsOfNames ns x
+    lookedupName x qx -- Mark this name as used for the unused-imports analysis
     reportSLn "scope.name" 30 $ "resolved " ++ prettyShow x ++ ": " ++ prettyShow qx
     case qx of
       VarName x' _         -> return $ Just $ A.Var x'

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -6843,6 +6843,7 @@ instance NFData ExecError
 instance NFData ConstructorDisambiguationData
 instance NFData Statistics
 instance NFData UnusedImportsState
+instance NFData OpenedModule
 
 -- Andreas, 2025-07-31, cannot normalize functions with deepseq-1.5.2.0 (GHC 9.10.3-rc1).
 -- See https://github.com/haskell/deepseq/issues/111.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4696,8 +4696,9 @@ data Warning
     -- ^ If a `renaming' import directive introduces a name or module name clash
     --   in the exported names of a module.
     --   (See issue #4154.)
-  | UnusedImports A.ModuleName (List1 AbstractName)
+  | UnusedImports A.ModuleName (Maybe (List1 AbstractName))
     -- ^ The given module was opened but the names in the list were not used.
+    --   If 'Nothing', then none of the imported name was used.
   | UselessPatternDeclarationForRecord String
     -- ^ The 'pattern' declaration is useless in the presence
     --   of either @coinductive@ or @eta-equality@.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -254,7 +254,7 @@ data PreScopeState = PreScopeState
     -- ^ Associates an original name (the key) to all its copies (the
     -- value). Computed by the scope checker, used to compute opaque
     -- blocks.
-  , stPreUnusedImportsState :: UnusedImportsState
+  , stPreUnusedImportsState :: !UnusedImportsState
     -- ^ Information collected by the scope checker to generate warnings about unused imports.
   }
   deriving Generic
@@ -680,7 +680,7 @@ lensNameCopies :: Lens' PreScopeState (HashMap QName (HashSet QName))
 lensNameCopies f s = f (stPreNameCopies s) <&> \ x -> s { stPreNameCopies = x }
 
 lensUnusedImportsState :: Lens' PreScopeState UnusedImportsState
-lensUnusedImportsState f s = f (stPreUnusedImportsState s) <&> \ x -> s { stPreUnusedImportsState = x }
+lensUnusedImportsState f s = f (stPreUnusedImportsState s) <&> \ !x -> s { stPreUnusedImportsState = x }
 
 -- ** Components of PostScopeState
 
@@ -976,6 +976,9 @@ stModuleCheckpoints = lensPostScopeState . lensModuleCheckpoints
 
 stImportsDisplayForms :: Lens' TCState DisplayForms
 stImportsDisplayForms = lensPostScopeState . lensImportsDisplayForms
+
+stWarningSet :: Lens' TCState (Set WarningName)
+stWarningSet = stPragmaOptions . lensOptWarningMode . warningSet
 
 -- | Note that the lens is \"strict\".
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4696,7 +4696,7 @@ data Warning
     -- ^ If a `renaming' import directive introduces a name or module name clash
     --   in the exported names of a module.
     --   (See issue #4154.)
-  | UnusedImports A.ModuleName (List1 C.Name)
+  | UnusedImports A.ModuleName (List1 AbstractName)
     -- ^ The given module was opened but the names in the list were not used.
   | UselessPatternDeclarationForRecord String
     -- ^ The 'pattern' declaration is useless in the presence

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -320,6 +320,11 @@ prettyWarning = \case
       pwords "Invalid character literal" ++ [text $ show c] ++
       pwords "(surrogate code points are not supported)"
 
+    UnusedImports m xs -> vcat
+      [ fsep $ [ "Opening", prettyTCM m ] ++ pwords "brings the following unused names into scope:"
+      , fsep $ fmap prettyTCM xs
+      ]
+
     UselessPragma _r d -> return d
 
     SafeFlagPostulate q -> fsep $

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -320,7 +320,10 @@ prettyWarning = \case
       pwords "Invalid character literal" ++ [text $ show c] ++
       pwords "(surrogate code points are not supported)"
 
-    UnusedImports m xs -> fsep $
+    UnusedImports m Nothing -> fsep $
+      pwords "Redundant opening of" ++ [ prettyTCM m ]
+
+    UnusedImports m (Just xs) -> fsep $
       [ "Opening", prettyTCM m ] ++ pwords "brings the following unused names into scope:"
       ++ fmap prettyTCM (List1.toList xs)
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -320,10 +320,9 @@ prettyWarning = \case
       pwords "Invalid character literal" ++ [text $ show c] ++
       pwords "(surrogate code points are not supported)"
 
-    UnusedImports m xs -> vcat
-      [ fsep $ [ "Opening", prettyTCM m ] ++ pwords "brings the following unused names into scope:"
-      , fsep $ fmap prettyTCM xs
-      ]
+    UnusedImports m xs -> fsep $
+      [ "Opening", prettyTCM m ] ++ pwords "brings the following unused names into scope:"
+      ++ fmap prettyTCM (List1.toList xs)
 
     UselessPragma _r d -> return d
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -281,10 +281,12 @@ instance EmbPrj WarningModeError where
   icod_ = \case
     Unknown a   -> icodeN 0 Unknown a
     NoNoError a -> icodeN 1 NoNoError a
+    NoUnusedImportsAll -> icodeN 2 NoUnusedImportsAll
 
   value = vcase $ \case
     N2 0 a -> valuN Unknown a
     N2 1 a -> valuN NoNoError a
+    N1 2   -> valuN NoUnusedImportsAll
     _      -> malformed
 
 instance EmbPrj ParseWarning where

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -145,6 +145,7 @@ instance EmbPrj Warning where
     FixingPolarity a b c                        -> icodeN 73 FixingPolarity a b c
     RewritesNothing                             -> icodeN 74 RewritesNothing
     IllegalDeclarationInDataDefinition ds       -> __IMPOSSIBLE__  -- We don't serialize concrete definitions (yet)
+    UnusedImports a b                           -> icodeN 75 UnusedImports a b
 
   value = vcase $ \ case
     N3 0 a b      -> valuN UnreachableClauses a b
@@ -223,6 +224,7 @@ instance EmbPrj Warning where
     N4 72 a b c   -> valuN FixingCohesion a b c
     N4 73 a b c   -> valuN FixingPolarity a b c
     N1 74         -> valuN RewritesNothing
+    N3 75 a b     -> valuN UnusedImports a b
     _ -> malformed
 
 instance EmbPrj UselessPublicReason

--- a/src/full/Agda/Utils/Set.hs
+++ b/src/full/Agda/Utils/Set.hs
@@ -1,7 +1,7 @@
 module Agda.Utils.Set (module Agda.Utils.Set, module Data.Set) where
 
 import Data.Set
-import Data.Set.Internal
+import Data.Set.Internal (Set(Tip, Bin))
 
 -- Adapted from rejected pull request to containers
 -- https://github.com/haskell/containers/pull/291

--- a/test/Succeed/UnusedImports.agda
+++ b/test/Succeed/UnusedImports.agda
@@ -1,0 +1,65 @@
+-- Andreas, 2025-11-27, AIM XLI, Angers, France
+-- New warning UnusedImports
+
+{-# OPTIONS -WUnusedImports #-}
+
+{-# OPTIONS --no-qualified-instances #-}
+  -- Instances have to be in scope qualified,
+  -- so instances are always assumed to be used.
+
+-- There should be no warning for the implicit
+-- open import Agda.Primitive using (Set)
+
+-- There should be no warning for public opens!
+open import Agda.Builtin.Bool public
+
+-- We are not using _≡_, so this opening is redundant.
+open import Agda.Builtin.Equality using (_≡_)
+
+-- Expected warning:
+-- Redundant opening of Agda.Builtin.Equality
+
+-- We are not using everything we import, so there should be a warning.
+open import Agda.Builtin.Nat using (Nat; zero; suc; _+_)
+
+-- Expected warning:
+-- Opening Agda.Builtin.Nat brings the following unused names into scope: _+_
+
+-- We are using nothing from this import that is not already in scope,
+-- so it should be redundant.
+open import Agda.Builtin.Nat
+
+-- Expected warning:
+-- Redundant opening of Agda.Builtin.Nat
+
+-- ditto
+open import Agda.Builtin.Nat using (Nat)
+
+-- Expected warning:
+-- Redundant opening of Agda.Builtin.Nat
+
+f : Nat → Nat
+f zero = zero
+f (suc n) = suc (f n)
+
+module M where
+  instance
+    z : Nat
+    z = zero
+
+-- There should be no warning because of OPTIONS --no-qualified-instances
+open M
+
+g : {{x : Nat}} → Nat
+g {{x}} = x
+
+test : Nat
+test = g  -- uses instance z
+
+module Empty where
+
+-- The module exports nothing so opening should be redundant.
+open Empty
+
+-- Expected warning:
+-- Redundant opening of Empty

--- a/test/Succeed/UnusedImports.warn
+++ b/test/Succeed/UnusedImports.warn
@@ -1,0 +1,34 @@
+
+UnusedImports.agda:17.1-34: warning: -W[no]UnusedImports
+Redundant opening of Agda.Builtin.Equality
+
+UnusedImports.agda:23.1-29: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Nat brings the following unused names into
+scope: _+_
+
+UnusedImports.agda:30.1-29: warning: -W[no]UnusedImports
+Redundant opening of Agda.Builtin.Nat
+
+UnusedImports.agda:36.1-29: warning: -W[no]UnusedImports
+Redundant opening of Agda.Builtin.Nat
+
+UnusedImports.agda:62.1-11: warning: -W[no]UnusedImports
+Redundant opening of Empty
+
+———— All done; warnings encountered ————————————————————————
+
+UnusedImports.agda:17.1-34: warning: -W[no]UnusedImports
+Redundant opening of Agda.Builtin.Equality
+
+UnusedImports.agda:23.1-29: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Nat brings the following unused names into
+scope: _+_
+
+UnusedImports.agda:30.1-29: warning: -W[no]UnusedImports
+Redundant opening of Agda.Builtin.Nat
+
+UnusedImports.agda:36.1-29: warning: -W[no]UnusedImports
+Redundant opening of Agda.Builtin.Nat
+
+UnusedImports.agda:62.1-11: warning: -W[no]UnusedImports
+Redundant opening of Empty

--- a/test/Succeed/UnusedImports.warn
+++ b/test/Succeed/UnusedImports.warn
@@ -1,34 +1,38 @@
 
-UnusedImports.agda:17.1-34: warning: -W[no]UnusedImports
-Redundant opening of Agda.Builtin.Equality
+UnusedImports.agda:19.1-34: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Equality brings the following unused names
+into scope: _≡_
 
-UnusedImports.agda:23.1-29: warning: -W[no]UnusedImports
+UnusedImports.agda:25.1-29: warning: -W[no]UnusedImports
 Opening Agda.Builtin.Nat brings the following unused names into
 scope: _+_
 
-UnusedImports.agda:30.1-29: warning: -W[no]UnusedImports
+UnusedImports.agda:32.1-29: warning: -W[no]UnusedImports
 Redundant opening of Agda.Builtin.Nat
 
-UnusedImports.agda:36.1-29: warning: -W[no]UnusedImports
-Redundant opening of Agda.Builtin.Nat
+UnusedImports.agda:38.1-29: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Nat brings the following unused names into
+scope: Nat
 
-UnusedImports.agda:62.1-11: warning: -W[no]UnusedImports
+UnusedImports.agda:64.1-11: warning: -W[no]UnusedImports
 Redundant opening of Empty
 
 ———— All done; warnings encountered ————————————————————————
 
-UnusedImports.agda:17.1-34: warning: -W[no]UnusedImports
-Redundant opening of Agda.Builtin.Equality
+UnusedImports.agda:19.1-34: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Equality brings the following unused names
+into scope: _≡_
 
-UnusedImports.agda:23.1-29: warning: -W[no]UnusedImports
+UnusedImports.agda:25.1-29: warning: -W[no]UnusedImports
 Opening Agda.Builtin.Nat brings the following unused names into
 scope: _+_
 
-UnusedImports.agda:30.1-29: warning: -W[no]UnusedImports
+UnusedImports.agda:32.1-29: warning: -W[no]UnusedImports
 Redundant opening of Agda.Builtin.Nat
 
-UnusedImports.agda:36.1-29: warning: -W[no]UnusedImports
-Redundant opening of Agda.Builtin.Nat
+UnusedImports.agda:38.1-29: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Nat brings the following unused names into
+scope: Nat
 
-UnusedImports.agda:62.1-11: warning: -W[no]UnusedImports
+UnusedImports.agda:64.1-11: warning: -W[no]UnusedImports
 Redundant opening of Empty

--- a/test/Succeed/UnusedImportsAll.aga
+++ b/test/Succeed/UnusedImportsAll.aga
@@ -1,3 +1,4 @@
+
 -- Andreas, 2025-11-27, AIM XLI, Angers, France
 -- New warning UnusedImports
 

--- a/test/Succeed/UnusedImportsAll.agda
+++ b/test/Succeed/UnusedImportsAll.agda
@@ -1,11 +1,11 @@
--- Andreas, 2025-11-27, AIM XLI, Angers, France
--- New warning UnusedImports
+-- Andreas, 2025-11-30, AIM XLI, Angers, France
+-- New warning UnusedImports, flavor 'all'.
 
-{-# OPTIONS -WUnusedImports #-}
+{-# OPTIONS -WUnusedImports=all #-}
 
-{-# OPTIONS --no-qualified-instances #-}
-  -- Instances have to be in scope unqualified,
-  -- so instances are always assumed to be used.
+-- {-# OPTIONS --no-qualified-instances #-}
+--   -- Instances have to be in scope unqualified,
+--   -- so instances are always assumed to be used.
 
 -- There should be no warning for the implicit
 -- open import Agda.Primitive using (Set)
@@ -22,20 +22,20 @@ open import Agda.Builtin.Equality using (_≡_)
 -- Redundant opening of Agda.Builtin.Equality
 
 -- We are not using everything we import, so there should be a warning.
-open import Agda.Builtin.Nat using (Nat; zero; suc; _+_)
+open import Agda.Builtin.Nat using (zero; suc; _+_)
 
 -- Expected warning:
 -- Opening Agda.Builtin.Nat brings the following unused names into scope: _+_
 
+-- This contains many useless imports, with the 'all' flavor we mention all of them.
+open import Agda.Builtin.Nat renaming (Nat to Nat)
+
+-- Opening Agda.Builtin.Nat brings the following unused names into
+-- scope: _*_ _+_ _-_ _<_ _==_ div-helper mod-helper suc zero
+
 -- We are using nothing from this import that is not already in scope,
 -- so it should be redundant.
 open import Agda.Builtin.Nat
-
--- Expected warning:
--- Redundant opening of Agda.Builtin.Nat
-
--- ditto
-open import Agda.Builtin.Nat using (Nat)
 
 -- Expected warning:
 -- Redundant opening of Agda.Builtin.Nat
@@ -49,8 +49,12 @@ module M where
     z : Nat
     z = zero
 
--- There should be no warning because of OPTIONS --no-qualified-instances
+-- This brings instance z into scope, but we could use it qualified,
+-- so there is a warning.
 open M
+
+-- Expected warning:
+-- Redundant opening of M
 
 g : {{x : Nat}} → Nat
 g {{x}} = x

--- a/test/Succeed/UnusedImportsAll.warn
+++ b/test/Succeed/UnusedImportsAll.warn
@@ -1,0 +1,44 @@
+
+UnusedImportsAll.agda:19.1-34: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Equality brings the following unused names
+into scope: _≡_
+
+UnusedImportsAll.agda:25.1-29: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Nat brings the following unused names into
+scope: _+_
+
+UnusedImportsAll.agda:31.1-29: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Nat brings the following unused names into
+scope: _*_ _+_ _-_ _<_ _==_ div-helper mod-helper suc zero
+
+UnusedImportsAll.agda:38.1-29: warning: -W[no]UnusedImports
+Redundant opening of Agda.Builtin.Nat
+
+UnusedImportsAll.agda:54.1-7: warning: -W[no]UnusedImports
+Redundant opening of M
+
+UnusedImportsAll.agda:68.1-11: warning: -W[no]UnusedImports
+Redundant opening of Empty
+
+———— All done; warnings encountered ————————————————————————
+
+UnusedImportsAll.agda:19.1-34: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Equality brings the following unused names
+into scope: _≡_
+
+UnusedImportsAll.agda:25.1-29: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Nat brings the following unused names into
+scope: _+_
+
+UnusedImportsAll.agda:31.1-29: warning: -W[no]UnusedImports
+Opening Agda.Builtin.Nat brings the following unused names into
+scope: _*_ _+_ _-_ _<_ _==_ div-helper mod-helper suc zero
+
+UnusedImportsAll.agda:38.1-29: warning: -W[no]UnusedImports
+Redundant opening of Agda.Builtin.Nat
+
+UnusedImportsAll.agda:54.1-7: warning: -W[no]UnusedImports
+Redundant opening of M
+
+UnusedImportsAll.agda:68.1-11: warning: -W[no]UnusedImports
+Redundant opening of Empty

--- a/test/Succeed/UnusedImportsData.agda
+++ b/test/Succeed/UnusedImportsData.agda
@@ -1,0 +1,79 @@
+-- Andreas, 2025-11-27, AIM XLI, Angers, France
+-- New warning UnusedImports;
+-- test the warning for some uses of data types.
+
+{-# OPTIONS -WUnusedImports #-}
+
+module _ (_ : Set) where
+
+-- The following tests that we do not account uses of an A.QName
+-- for the wrong open statement.
+
+module AccountPerOpen where
+
+  module M where
+    data D : Set where
+      c : D
+    private x = c
+
+  module M1 where
+    open M
+    -- These uses of names D and c should not account for the second "open M" below.
+    D' = D
+    c' = c
+
+  module M2 where
+    open M
+    -- This should trigger an unused import warning:
+    -- Redundant opening of M
+
+  module M3 where
+    open M using (c) renaming (D to D)
+    -- This should trigger an unused import warning and highlight c.
+    -- Opening M brings the following unused names into scope: c
+    D' = D
+
+  module M4 where
+    open M using (c) renaming (D to D)
+    -- This should trigger an unused import warning and highlight D.
+    -- Opening M brings the following unused names into scope: D
+    c' = c
+
+  module M5 where
+    open M using (c) renaming (D to D')
+    -- This should trigger an unused import warning and highlight D.
+    -- Opening M brings the following unused names into scope: D'
+    c' = c
+
+-- Test that overloaded constructors are accounted to the right open statement.
+
+module Overloading where
+
+  module M1 where
+    data D : Set where
+      c : D
+
+  module M2 where
+    data E : Set where
+      c : E
+
+  open M1
+  open M2 -- Expect warning: Redundant opening of M2
+
+  fD : D → D
+  fD c = c
+
+module Parameterized where
+
+  module M (A : Set) where
+    record R : Set where
+      field
+        f : A
+    open R  -- Redundant opening of R
+    open R public
+
+  postulate
+    A : Set
+
+  open M A
+  -- Redundant opening of UnusedImportsData.Parameterized._

--- a/test/Succeed/UnusedImportsData.warn
+++ b/test/Succeed/UnusedImportsData.warn
@@ -1,0 +1,44 @@
+
+UnusedImportsData.agda:26.5-11: warning: -W[no]UnusedImports
+Redundant opening of M
+
+UnusedImportsData.agda:31.5-11: warning: -W[no]UnusedImports
+Opening M brings the following unused names into scope: c
+
+UnusedImportsData.agda:37.5-11: warning: -W[no]UnusedImports
+Opening M brings the following unused names into scope: D
+
+UnusedImportsData.agda:43.5-11: warning: -W[no]UnusedImports
+Opening M brings the following unused names into scope: D'
+
+UnusedImportsData.agda:61.3-10: warning: -W[no]UnusedImports
+Redundant opening of M2
+
+UnusedImportsData.agda:72.5-11: warning: -W[no]UnusedImports
+Redundant opening of M.R
+
+UnusedImportsData.agda:78.3-8: warning: -W[no]UnusedImports
+Redundant opening of UnusedImportsData.Parameterized._
+
+———— All done; warnings encountered ————————————————————————
+
+UnusedImportsData.agda:26.5-11: warning: -W[no]UnusedImports
+Redundant opening of M
+
+UnusedImportsData.agda:31.5-11: warning: -W[no]UnusedImports
+Opening M brings the following unused names into scope: c
+
+UnusedImportsData.agda:37.5-11: warning: -W[no]UnusedImports
+Opening M brings the following unused names into scope: D
+
+UnusedImportsData.agda:43.5-11: warning: -W[no]UnusedImports
+Opening M brings the following unused names into scope: D'
+
+UnusedImportsData.agda:61.3-10: warning: -W[no]UnusedImports
+Redundant opening of M2
+
+UnusedImportsData.agda:72.5-11: warning: -W[no]UnusedImports
+Redundant opening of M.R
+
+UnusedImportsData.agda:78.3-8: warning: -W[no]UnusedImports
+Redundant opening of UnusedImportsData.Parameterized._

--- a/test/doc/user-manual-covers-warnings.sh
+++ b/test/doc/user-manual-covers-warnings.sh
@@ -15,7 +15,7 @@ IGNOREDWARNS=$TMPDIR/ignored-warnings.txt
 HELPWARNS=$TMPDIR/help-text-warnings.txt
 
 # Documented warnings.
-sed -nr 's/^.. option:: ([A-Z][A-Za-z]*)/\1/p' $DOC | sort > $DOCWARNS
+sed -nr 's/^.. option:: ([A-Z][A-Za-z=]*)/\1/p' $DOC | sort > $DOCWARNS
 
 # Ignored warnings (e.g. future warnings, not yet triggered).
 cat > $IGNOREDWARNS <<EOF
@@ -28,7 +28,7 @@ cat $DOCWARNS $IGNOREDWARNS | sort | uniq > $COVEREDWARNS
 # Existing warnings.
 # Those are printed by `agda --help=warning` at line beginnings and follow
 # the camel-case convention, with at least two capital letters.
-$AGDA_BIN --help=warning | sed -nr 's/^([A-Z][a-z]+[A-Z][A-Za-z]+).*/\1/p' | sort > $HELPWARNS
+$AGDA_BIN --help=warning | sed -nr 's/^([A-Z][a-z]+[A-Z][A-Za-z=]+).*/\1/p' | sort | uniq > $HELPWARNS
 
 # Warnings that are documented but don't exist any longer.
 REMOVED=$(comm -23 $DOCWARNS $HELPWARNS)

--- a/test/test-suite-covers-warnings.sh
+++ b/test/test-suite-covers-warnings.sh
@@ -17,7 +17,7 @@ COVERED=$TMPDIR/covered.txt
 # Those are printed by `agda --help=warning` at line beginnings and follow
 # the camel-case convention, with at least two capital letters.
 #
-${AGDA_BIN:-agda} --help=warning | sed -nr 's/^([A-Z][a-z]+[A-Z][A-Za-z=]+).*/\1/p' | sort | uniq > $HELPWARNS
+${AGDA_BIN:-agda} --help=warning | sed -nr 's/^([A-Z][a-z]+[A-Z][A-Za-z]+).*/\1/p' | sort | uniq > $HELPWARNS
 
 if [[ "$1" == "--debug" ]]; then
   cat $HELPWARNS

--- a/test/test-suite-covers-warnings.sh
+++ b/test/test-suite-covers-warnings.sh
@@ -17,7 +17,11 @@ COVERED=$TMPDIR/covered.txt
 # Those are printed by `agda --help=warning` at line beginnings and follow
 # the camel-case convention, with at least two capital letters.
 #
-${AGDA_BIN:-agda} --help=warning | sed -nr 's/^([A-Z][a-z]+[A-Z][A-Za-z]+).*/\1/p' | sort > $HELPWARNS
+${AGDA_BIN:-agda} --help=warning | sed -nr 's/^([A-Z][a-z]+[A-Z][A-Za-z=]+).*/\1/p' | sort | uniq > $HELPWARNS
+
+if [[ "$1" == "--debug" ]]; then
+  cat $HELPWARNS
+fi
 
 # Warnings we do not need to cover by the testsuite.
 #


### PR DESCRIPTION
This is my AIM XLI code sprint.  It is joined work with @AndrasKovacs; we discussed the design during the flight from Gothenburg and had several discussions also during the meeting.

TODO:
- [x] CHANGELOG
- [x] documentation of warning
- [x] Reconcile with PR #8223 

Related:
- #2503 
- #923

Commits:

- **WIP: UnusedImports warning**
  

- **WIP 2: UnusedImports warning: skip for Agda.Primitive and public open**
  

- **WIP 3: When no imported name is used, complain about whole open**
  

- **WIP 4: optimize computation of lookups**
  

- **Reverse WIP 4: optimize computation of lookups**
  

- **WIP 5: Account lookedupNames to correct open statement**
  

- **WIP 6: enter correct scope when reporting UnusedImport warning**
  

- **WIP 7: fix Monoid bug when collecting looked-up names**
  

- **WIP 8: index openedModules by their position**
  So that opening the same module twice is registered as separate openings.
  
- **WIP 9: UnusedImports warning now highlights names in import directive**
  

- **WIP 10: deadcode highlighting when whole open stm is useless**
  

- **WIP 11: also highlight the open keyword in the UnusedImports warning**
  

- **Test cases for -WUnusedImports**

etc (WIP  12 -16)
  