### PR TITLE
Add strict writer util module, use in TypeChecking.Free.Precompute

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -921,6 +921,7 @@ library
       Agda.Utils.SmallSet
       Agda.Utils.StrictState
       Agda.Utils.StrictState2
+      Agda.Utils.StrictWriter
       Agda.Utils.String
       Agda.Utils.Suffix
       Agda.Utils.Three

--- a/src/full/Agda/TypeChecking/Free/Precompute.hs
+++ b/src/full/Agda/TypeChecking/Free/Precompute.hs
@@ -5,7 +5,7 @@ module Agda.TypeChecking.Free.Precompute
   ( PrecomputeFreeVars, precomputeFreeVars
   , precomputedFreeVars, precomputeFreeVars_ ) where
 
-import Control.Monad.Writer ( Writer, runWriter, censor, listen, tell )
+import Agda.Utils.StrictWriter ( Writer, runWriter, censor, listen, tell )
 
 import Agda.Utils.Singleton
 import Agda.Utils.VarSet (VarSet)

--- a/src/full/Agda/Utils/StrictWriter.hs
+++ b/src/full/Agda/Utils/StrictWriter.hs
@@ -1,0 +1,50 @@
+
+{-|
+This is a very strict Writer monad, as a wrapper on "Agda.Utils.StrictState".
+-}
+
+module Agda.Utils.StrictWriter where
+
+import Agda.Utils.StrictState
+
+newtype Writer w a = Writer {unWriter :: State w a}
+  deriving (Functor, Applicative, Monad)
+
+{-# INLINE tell #-}
+tell :: Monoid w => w -> Writer w ()
+tell !w = Writer (modify (<> w))
+
+{-# INLINE listen #-}
+listen :: Monoid w => Writer w a -> Writer w (a, w)
+listen (Writer act) = Writer do
+  old <- get
+  put mempty
+  a <- act
+  diff <- get
+  put (old <> diff)
+  pure (a, diff)
+
+{-# INLINE writer #-}
+writer :: Monoid w => (a, w) -> Writer w a
+writer (!a, !w) = do
+  tell w
+  pure a
+
+{-# INLINE censor #-}
+censor :: Monoid w => (w -> w) -> Writer w a -> Writer w a
+censor f (Writer act) = Writer do
+  old <- get
+  put mempty
+  a <- act
+  diff <- get
+  let !diff' = f diff
+  put (old <> diff')
+  pure a
+
+{-# INLINE runWriter #-}
+runWriter :: Monoid w => Writer w a -> (a, w)
+runWriter (Writer act) = runState act mempty
+
+{-# INLINE execWriter #-}
+execWriter :: Monoid w => Writer w a -> w
+execWriter (Writer act) = execState act mempty


### PR DESCRIPTION
`Control.Monad.Writer` suffers from space leaking, making a new thunk on every monadic bind. There are a couple of places in Agda where it's being used. 

This PR adds a strict Writer utility module where binding, returning and writer actions are all strict. It also replaces one use case of Writer in `Free.Precompute`. There are more use cases but it's not trivial to check which can be replaced with the very strict version. `Free.Precompute` is definitely safe to fully strictify. 