### PR TITLE
Fix 8228: Parse Error with Display Pragma and Mixfix Operator

### DIFF
--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -171,8 +171,12 @@ instance IsBool DisplayLHS where
 
 -- | Expression kinds: Expressions or patterns.
 
-data ExprKind = IsExpr | IsPattern
+data ExprKind = IsExpr | IsPattern DisplayLHS
   deriving (Eq, Show)
+
+isKindPattern :: ExprKind -> Bool
+isKindPattern (IsPattern _) = True
+isKindPattern IsExpr        = False
 
 ---------------------------------------------------------------------------
 -- * Record Directives

--- a/src/full/Agda/Syntax/Scope/Operator.hs
+++ b/src/full/Agda/Syntax/Scope/Operator.hs
@@ -196,7 +196,10 @@ localNames k top opScope@(OpScope _ _ locals) = do
   let
     f = case k of
       IsExpr    -> const True
-      IsPattern -> let
+      IsPattern YesDisplayLHS -> const True
+        -- #8228: Non-constructor-like operators are useful in DISPLAY
+        -- pragmas.
+      IsPattern NoDisplayLHS -> let
           -- Andreas, 2025-02-28, issue #7722
           -- Filter by kind.
           -- Just return the constructor-like operators,

--- a/test/Succeed/Issue8228.agda
+++ b/test/Succeed/Issue8228.agda
@@ -1,0 +1,6 @@
+postulate
+  ℕ   : Set
+  _+_ : ℕ → ℕ → ℕ
+  foo : ℕ → ℕ
+
+{-# DISPLAY foo (x + x) = x #-}


### PR DESCRIPTION
Fixes #8228: We stop pruning non-constructor operators from DISPLAY pragma patterns