### PR TITLE
[ fix #5315 ] Compile erased types to () in the GHC backend

### DIFF
--- a/test/Compiler/simple/Issue5315.agda
+++ b/test/Compiler/simple/Issue5315.agda
@@ -1,0 +1,25 @@
+{-# OPTIONS --erasure #-}
+
+open import Agda.Builtin.Nat
+
+data D : @0 Nat → Set where
+  c : ∀ {@0 n} → D (n + n)
+
+{-# FOREIGN GHC data D n = C #-}
+{-# COMPILE GHC D = data D (C) #-}
+
+data Bar : Set where
+  bar : Bar
+
+data Foo : Set where
+  foo : @0 Bar → Foo
+
+{-# FOREIGN GHC data Foo = Foo #-}
+{-# COMPILE GHC Foo = data Foo (Foo) #-}
+
+open import Common.Bool
+open import Common.IO
+open import Common.Unit
+
+main : IO Unit
+main = printBool true

--- a/test/Compiler/simple/Issue5315.out
+++ b/test/Compiler/simple/Issue5315.out
@@ -1,0 +1,4 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > true


### PR DESCRIPTION
This *mostly* fixes #5315 by skipping compilation of erased types in the GHC backend and replacing them by `()` instead. Ideally we would drop them entirely, but that takes more effort (see https://github.com/agda/agda/pull/6928).