### PR TITLE
[ doc ] Add user manual for verbose flag

### DIFF
--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -491,6 +491,7 @@ Printing and debugging
 
      Set verbosity level to ``N``. This only has an effect if
      Agda was installed with the :option:`debug` flag.
+     See :ref:`debugging` for more information.
 
 .. option:: --profile={PROF}
 

--- a/doc/user-manual/tools/debugging.rst
+++ b/doc/user-manual/tools/debugging.rst
@@ -1,0 +1,68 @@
+.. _debugging:
+
+*********************
+Debugging
+*********************
+
+.. warning:: The following page contains information that is mostly of interest to
+  developers of Agda, or those who would like to get a deeper understanding of the
+  implementation of Agda.
+
+Verbose mode
+------------
+
+If Agda was installed with the :option:`debug` flag (e.g. using ``cabal install
+Agda -fdebug``), it can print internal information by setting the
+:option:`--verbose={N}` flag (or :option:`-v {N}`) with a verbosity tag and a
+verbosity level in form ``tag:level``. For example, running Agda with
+``--verbose=tc.term:30`` will print enable debug printing for the verbosity key
+``tc.term`` at verbosity level ``30``. Verbosity levels range between 0 and 100.
+
+* Activating a verbosity key will also enable all the verbosity keys that
+  are nested under it, for example ``-v tc:30`` will also print debugging
+  information with key ``tc.term``.
+
+* The higher the verbosity level, the more
+  detailed debugging information will be printed, for example ``-v tc.term:50``
+  will include debugging information at verbosity level 30.
+
+Verbosity tags and levels can be found by inspecting the source code of Agda by
+searching for calls to ``reportSLn`` and ``reportSDoc``. Below are a few common
+debug flags that might be useful for developers:
+
+* ``import``: import statements
+* ``interaction``: interactive commands
+
+   - ``interaction.case``: case splitting
+   - ``interaction.eval``
+   - ``interaction.give``
+   - ``interaction.helper``
+   - ``interaction.intro``
+   - ``interaction.refine``
+* ``mimer``: automatic proof search
+* ``rewriting``: rewrite rules
+* ``scope``: scope checking
+* ``tc``: type checking
+
+   - ``tc.abstract``: abstract definitions
+   - ``tc.cc``: compiling clauses to a case tree
+   - ``tc.conv``: conversion checking
+   - ``tc.constr``: constraint solving
+   - ``tc.cover``: coverage checking
+   - ``tc.data``: data types
+   - ``tc.def``: function definitions
+   - ``tc.generalize``: variable generalization
+   - ``tc.instance``: instance arguments
+   - ``tc.irr``: irrelevance
+   - ``tc.lhs``: left-hand sides of function clauses
+   - ``tc.meta``: metavariables
+   - ``tc.mod``: modules and module parameters
+   - ``tc.term``: type checking of terms
+   - ``tc.opaque``: opaque definitions
+   - ``tc.pos``: positivity analysis
+   - ``tc.reduce``: evaluation of terms and types
+   - ``tc.size``: sized types
+   - ``tc.sort``: checking sorts
+   - ``tc.with``: with abstraction
+* ``term``: termination checking
+* ``warning``: warnings

--- a/doc/user-manual/tools/debugging.rst
+++ b/doc/user-manual/tools/debugging.rst
@@ -25,7 +25,7 @@ verbosity level in form ``tag:level``. For example, running Agda with
 * The higher the verbosity level, the more
   detailed debugging information will be printed, for example ``-v tc.term:50``
   will include debugging information at verbosity level 30.
-  
+
 By convention, very gory details will be printed only with verbosity of at least 50, so it is advisable in most cases to keep the level below 50.
 
 

--- a/doc/user-manual/tools/debugging.rst
+++ b/doc/user-manual/tools/debugging.rst
@@ -25,6 +25,7 @@ verbosity level in form ``tag:level``. For example, running Agda with
 * The higher the verbosity level, the more
   detailed debugging information will be printed, for example ``-v tc.term:50``
   will include debugging information at verbosity level 30.
+  
 By convention, very gory details will be printed only with verbosity of at least 50, so it is advisable in most cases to keep the level below 50.
 
 

--- a/doc/user-manual/tools/debugging.rst
+++ b/doc/user-manual/tools/debugging.rst
@@ -27,6 +27,7 @@ verbosity level in form ``tag:level``. For example, running Agda with
   will include debugging information at verbosity level 30.
 By convention, very gory details will be printed only with verbosity of at least 50, so it is advisable in most cases to keep the level below 50.
 
+
 Verbosity tags and levels can be found by inspecting the source code of Agda by
 searching for calls to ``reportSLn`` and ``reportSDoc``. Below are a few common
 debug flags that might be useful for developers:

--- a/doc/user-manual/tools/debugging.rst
+++ b/doc/user-manual/tools/debugging.rst
@@ -15,7 +15,7 @@ If Agda was installed with the :option:`debug` flag (e.g. using ``cabal install
 Agda -fdebug``), it can print internal information by setting the
 :option:`--verbose={N}` flag (or :option:`-v {N}`) with a verbosity tag and a
 verbosity level in form ``tag:level``. For example, running Agda with
-``--verbose=tc.term:30`` will print enable debug printing for the verbosity key
+``--verbose=tc.term:30`` turns on debug printing for the verbosity key
 ``tc.term`` at verbosity level ``30``. Verbosity levels range between 0 and 100.
 
 * Activating a verbosity key will also enable all the verbosity keys that
@@ -25,6 +25,7 @@ verbosity level in form ``tag:level``. For example, running Agda with
 * The higher the verbosity level, the more
   detailed debugging information will be printed, for example ``-v tc.term:50``
   will include debugging information at verbosity level 30.
+By convention, very gory details will be printed only with verbosity of at least 50, so it is advisable in most cases to keep the level below 50.
 
 Verbosity tags and levels can be found by inspecting the source code of Agda by
 searching for calls to ``reportSLn`` and ``reportSDoc``. Below are a few common

--- a/doc/user-manual/tools/index.rst
+++ b/doc/user-manual/tools/index.rst
@@ -11,6 +11,7 @@ Tools
    auto
    command-line-options
    compilers
+   debugging
    emacs-mode
    literate-programming
    generating-html


### PR DESCRIPTION
Since some people at the Agda meeting were asking for some documentation on how to view debug information of Agda, I wrote a short entry for the user manual.