### PR TITLE
More refactorings for unused imports warning

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -683,6 +683,7 @@ library
       Agda.Syntax.Scope.Base
       Agda.Syntax.Scope.Monad
       Agda.Syntax.Scope.Operator
+      Agda.Syntax.Scope.State
       Agda.Syntax.TopLevelModuleName
       Agda.Syntax.TopLevelModuleName.Boot
       Agda.Syntax.Translation.AbstractToConcrete

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -917,6 +917,7 @@ library
       Agda.Utils.SemiRing
       Agda.Utils.Semigroup
       Agda.Utils.Serialize
+      Agda.Utils.Set
       Agda.Utils.Set1
       Agda.Utils.Singleton
       Agda.Utils.Size

--- a/Makefile
+++ b/Makefile
@@ -834,6 +834,8 @@ debug : ## Print debug information.
 	@echo "STACK_OPTS                     = $(STACK_OPTS)"
 	@echo "STACK_OPT_FAST                 = $(STACK_OPT_FAST)"
 	@echo "STACK_OPT_NO_DOCS              = $(STACK_OPT_NO_DOCS)"
+	@echo Agda version:
+	$(AGDA_BIN) --version
 	@echo
 	@echo "Run \`make -pq\` to get a detailed report."
 	@echo

--- a/doc/user-manual/language/record-types.lagda.rst
+++ b/doc/user-manual/language/record-types.lagda.rst
@@ -275,7 +275,7 @@ Records with anonymous constructors
 Even if a record was not defined with a named ``constructor`` directive,
 Agda will still internally generate a constructor for the record. This
 name is used internally to implement ``record{}`` syntax, but it can
-still be obtained through using :ref:`reflection`. Since Agda 2.6.5,
+still be obtained through using :ref:`reflection`. Since Agda 2.8.0,
 it's possible to refer to this name from surface syntax as well:
 
 ::

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -832,7 +832,7 @@ Pattern matching and equality
 
 .. option:: --polarity, --no-polarity
 
-     .. versionadded:: 2.6.5
+     .. versionadded:: 2.8.0
 
      Enables the use of modal polarity annotations, and their interaction with
      the positivity checker. See :ref:`polarity`.
@@ -1040,7 +1040,7 @@ Search depth and instances
 
 .. option:: --backtracking-instance-search, --no-backtracking-instance-search
 
-     .. versionadded:: 2.6.5
+     .. versionadded:: 2.7.0
 
      Consider [do not consider] recursive instance arguments during
      pruning of instance candidates, see :ref:`backtracking-instances`

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -487,7 +487,7 @@ niceDeclarations fixs ds = do
 
         PatternSyn r n as p -> do
           return ([NicePatternSyn r PublicAccess n as p] , ds)
-        Open r x is         -> return ([NiceOpen r x is] , ds)
+        Open kwr x is       -> return ([NiceOpen kwr x is] , ds)
         Import opn r x as is-> return ([NiceImport opn r x as is], ds)
 
         UnquoteDecl r xs e -> do
@@ -1539,10 +1539,10 @@ instance MakePrivate NiceDeclaration where
       NiceGeneralize r p i tac x t             -> (\ p -> NiceGeneralize r p i tac x t)         <$> mkPrivate kwr o p
       NiceOpaque r ns ds                       -> (\ p -> NiceOpaque r ns p)                    <$> mkPrivate kwr o ds
       d@NicePragma{}                           -> return d
-      d@(NiceOpen r _x dir)                    -> d <$ do
+      d@(NiceOpen _kwr _x dir)                    -> d <$ do
         unless (null kwr) $
           whenJust (publicOpen dir) \ kwrPublic ->
-            lift $ declarationWarning $ OpenImportPrivate r kwrPublic kwr OpenNotImport
+            lift $ declarationWarning $ OpenImportPrivate (getRange d) kwrPublic kwr OpenNotImport
       d@(NiceImport opn impR x args dir)       -> d <$ do
         unless (null kwr) $
           whenJust (publicOpen dir) \ kwrPublic ->
@@ -1652,7 +1652,7 @@ notSoNiceDeclarations = \case
     NiceModule r _ _ e x tel ds      -> singleton $ Module r e x tel ds
     NiceModuleMacro r _ e x ma o dir
                                      -> singleton $ ModuleMacro r e x ma o dir
-    NiceOpen r x dir                 -> singleton $ Open r x dir
+    NiceOpen kwr x dir               -> singleton $ Open kwr x dir
     NiceImport o r x as dir          -> singleton $ Import o r x as dir
     NicePragma _ p                   -> singleton $ Pragma p
     NiceRecSig r er _ _ _ _ x bs e   -> singleton $ RecordSig r er x bs e

--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -58,8 +58,8 @@ data NiceDeclaration
       [Declaration]
   | NiceModuleMacro Range Access Erased Name ModuleApplication
       OpenShortHand ImportDirective
-  | NiceOpen Range QName ImportDirective
-  | NiceImport (Ranged OpenShortHand) KwRange QName (Either AsName RawOpenArgs) ImportDirective
+  | NiceOpen KwRange QName ImportDirective
+  | NiceImport OpenShortHand KwRange QName (Either AsName RawOpenArgs) ImportDirective
   | NicePragma Range Pragma
   | NiceRecSig Range Erased Access IsAbstract PositivityCheck
       UniverseCheck Name Parameters Expr
@@ -208,7 +208,7 @@ instance HasRange NiceDeclaration where
   getRange (NiceMutual kwr _ _ _ ds)       = fuseRange kwr ds
   getRange (NiceModule r _ _ _ _ _ _ )     = r
   getRange (NiceModuleMacro r _ _ _ _ _ _) = r
-  getRange (NiceOpen r _ _)                = r
+  getRange (NiceOpen kwr x dir)            = getRange (kwr, x, dir)
   getRange (NiceImport o r x as dir)       = getRange (o, r, x, as, dir)
   getRange (NicePragma r _)                = r
   getRange (PrimitiveFunction r _ _ _ _)   = r

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -464,9 +464,9 @@ instance Pretty Declaration where
            , fsep (map pretty tel)
            , hlKeyword "where"
            ] $$ nest 2 (vcat $ map pretty ds)
-    ModuleMacro _ NotErased{} x (SectionApp _ [] y es) DoOpen i
+    ModuleMacro _ NotErased{} x (SectionApp _ [] y es) doOpen@(DoOpen _kwr) i
       | isNoName x ->
-      sep [ pretty DoOpen
+      sep [ pretty doOpen
           , nest 2 $ fsep $ pretty y : map pretty es
           , nest 4 $ pretty i
           ]
@@ -542,8 +542,9 @@ pRecord erased x directives tel me ds = vcat
     pType Nothing  = hlKeyword "where"
 
 instance Pretty OpenShortHand where
-    pretty DoOpen   = hlKeyword "open"
-    pretty DontOpen = empty
+    pretty = \case
+      DoOpen _ -> hlKeyword "open"
+      DontOpen -> empty
 
 instance Pretty Pragma where
     pretty (OptionsPragma _ opts)  = fsep $ hlKeyword "OPTIONS" : map (hlPragma . text) opts

--- a/src/full/Agda/Syntax/Info.hs
+++ b/src/full/Agda/Syntax/Info.hs
@@ -146,7 +146,7 @@ data ModuleInfo = ModuleInfo
     -- if any. Retained for highlighting purposes.
   , minfoAsName   :: Maybe C.Name
     -- ^ The \"as\" module name, if any. Retained for highlighting purposes.
-  , minfoOpenShort :: Maybe OpenShortHand
+  , minfoOpenShort :: OpenShortHand
   , minfoDirective :: Maybe ImportDirective
     -- ^ Retained for @abstractToConcrete@ of 'ModuleMacro'.
   }

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -1050,12 +1050,12 @@ noGeneralizedVarsIfLetOpen TopOpenModule = id
 noGeneralizedVarsIfLetOpen LetOpenModule = disallowGeneralizedVars
 
 -- | Open a module.
-openModule_ :: OpenKind -> C.QName -> C.ImportDirective -> ScopeM A.ImportDirective
-openModule_ kind cm dir = openModule kind Nothing cm dir
+openModule_ :: KwRange -> OpenKind -> C.QName -> C.ImportDirective -> ScopeM A.ImportDirective
+openModule_ kwr kind cm dir = openModule kwr kind Nothing cm dir
 
 -- | Open a module, possibly given an already resolved module name.
-openModule :: OpenKind -> Maybe A.ModuleName  -> C.QName -> C.ImportDirective -> ScopeM A.ImportDirective
-openModule kind mam cm dir = do
+openModule :: KwRange -> OpenKind -> Maybe A.ModuleName  -> C.QName -> C.ImportDirective -> ScopeM A.ImportDirective
+openModule kwr kind mam cm dir = do
   current <- getCurrentModule
   m <- caseMaybe mam (amodName <$> resolveModule cm) return
   let acc | Nothing <- publicOpen dir     = PrivateNS

--- a/src/full/Agda/Syntax/Scope/State.hs
+++ b/src/full/Agda/Syntax/Scope/State.hs
@@ -1,0 +1,52 @@
+-- | General functions for stateful manipulation of the scope.
+
+-- This module has been originally created to avoid import cycles between
+-- Agda.Syntax.Scope.Monad and Agda.Syntax.Scope.UnusedImports.
+
+module Agda.Syntax.Scope.State where
+
+import Agda.Syntax.Abstract.Name as A ( ModuleName )
+import Agda.Syntax.Position ( SetRange(setRange), noRange )
+import Agda.Syntax.Scope.Base (scopeCurrent)
+
+import Agda.TypeChecking.Monad.Base ( TCM, MonadTCState, ReadTCState )
+import Agda.TypeChecking.Monad.State (useScope, modifyScope, recomputeInverseScope)
+
+import Agda.Utils.Lens (set)
+import Agda.Utils.Monad (MonadTrans (lift))
+
+---------------------------------------------------------------------------
+-- * The scope checking monad
+---------------------------------------------------------------------------
+
+-- | To simplify interaction between scope checking and type checking (in
+--   particular when chasing imports), we use the same monad.
+type ScopeM = TCM
+
+---------------------------------------------------------------------------
+-- * Current module
+---------------------------------------------------------------------------
+
+getCurrentModule :: ReadTCState m => m A.ModuleName
+getCurrentModule = setRange noRange <$> useScope scopeCurrent
+
+setCurrentModule :: MonadTCState m => A.ModuleName -> m ()
+setCurrentModule m = do
+  modifyScope $ set scopeCurrent m
+  recomputeInverseScope
+
+withCurrentModule :: (ReadTCState m, MonadTCState m) => A.ModuleName -> m a -> m a
+withCurrentModule new action = do
+  old <- getCurrentModule
+  setCurrentModule new
+  x   <- action
+  setCurrentModule old
+  return x
+
+withCurrentModule' :: (MonadTrans t, Monad (t ScopeM)) => A.ModuleName -> t ScopeM a -> t ScopeM a
+withCurrentModule' new action = do
+  old <- lift getCurrentModule
+  lift $ setCurrentModule new
+  x   <- action
+  lift $ setCurrentModule old
+  return x

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -211,7 +211,7 @@ instance PrettyTCM Call where
         pwords "when checking the module application" ++
         [prettyA $ A.Apply info erased m1 modapp copy empty]
       where
-      info = A.ModuleInfo noRange noRange Nothing Nothing Nothing
+      info = A.ModuleInfo noRange noRange Nothing empty Nothing
       copy = ScopeCopyInfo { renNames = mempty, renModules = mempty }
 
     ModuleContents -> fsep $ pwords "when retrieving the contents of a module"

--- a/src/full/Agda/Utils/Map.hs
+++ b/src/full/Agda/Utils/Map.hs
@@ -7,6 +7,7 @@ import Data.Functor.Compose
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Map.Internal (Map(..), balanceL, balanceR, singleton)
+import Data.Maybe (mapMaybe)
 
 import Agda.Utils.Impossible
 
@@ -58,6 +59,10 @@ adjustM' f k = getCompose . adjustM (Compose . f) k
 filterKeys :: (k -> Bool) -> Map k a -> Map k a
 filterKeys p = Map.filterWithKey (const . p)
 #endif
+
+-- | Filter a map and rewrite the keys.
+mapKeysMaybe :: Ord k => (k -> Maybe k) -> Map k a -> Map k a
+mapKeysMaybe f = Map.fromList . mapMaybe (\ (k, a) -> (, a) <$> f k) . Map.toList
 
 -- | Check whether a map is a singleton.
 isSingleMap :: Map k v -> Maybe (k, v)

--- a/src/full/Agda/Utils/Maybe.hs
+++ b/src/full/Agda/Utils/Maybe.hs
@@ -22,6 +22,10 @@ import Data.Maybe
 boolToMaybe :: Bool -> a -> Maybe a
 boolToMaybe b x = if b then Just x else Nothing
 
+-- | Retain object when it passes the given test.
+predicateToMaybe :: (a -> Bool) -> a -> Maybe a
+predicateToMaybe f x = boolToMaybe (f x) x
+
 -- * Collection operations.
 
 -- | @unionWith@ for collections of size <= 1.

--- a/src/full/Agda/Utils/Set.hs
+++ b/src/full/Agda/Utils/Set.hs
@@ -1,0 +1,17 @@
+module Agda.Utils.Set (module Agda.Utils.Set, module Data.Set) where
+
+import Data.Set
+import Data.Set.Internal
+
+-- Adapted from rejected pull request to containers
+-- https://github.com/haskell/containers/pull/291
+
+-- | /O(log n)/. Find the given element and return the copy contained in the set.
+lookupKey :: Ord a => a -> Set a -> Maybe a
+lookupKey !x = go
+  where
+    go Tip = Nothing
+    go (Bin _ y l r) = case compare x y of
+      LT -> go l
+      GT -> go r
+      EQ -> Just y


### PR DESCRIPTION
- **Makefile: add AGDA_BIN --version to make debug**
  

- **Refactor: move withCurrentScope from Scope.Monad to new Scope.State**
  

- **applyImportDirective now puts the C.Name from 'using' into NamesInScope**
  

- **Refactor: DoOpen, Open and NiceOpen now carry KwRange of the @open@ kw**
  

- **Doc: fix "version-added: 2.6.5" (got never released)**
  