### PR TITLE
Fix #8257: internal error caused by `_` in `import M A as _`

### DIFF
--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2091,7 +2091,7 @@ instance ToAbstract NiceDeclaration where
               -- Ok if no as-clause or it (already) contains a Name.
               Right asName                    -> return $ Just asName
               Left (C.Ident (C.QName asName)) -> return $ Just asName
-              Left C.Underscore{}             -> return $ Just underscore
+              Left (C.Underscore r _)         -> return $ Just $ C.noName r
               Left (C.Ident C.Qual{})         -> illformedAs "; a qualified name is not allowed here"
               Left e                          -> illformedAs ""
 

--- a/test/Succeed/Issue481.agda
+++ b/test/Succeed/Issue481.agda
@@ -52,3 +52,12 @@ module Test2 where
   private
     open module Rec = Issue481Record
 
+-- Andreas, 2025-12-02, issue #8257 reported by nad
+-- Regression on master introduced by PR #8194
+
+module Issue8257 where
+
+  import Common.Issue481ParametrizedModule Set as _
+
+  -- WAS: internal error caused by _.
+  -- Should succeed.


### PR DESCRIPTION
This was a spurious impossible cause by a use of `underscore`.
