### PR TITLE
Fix #8258: spurious UnusedImports warning when not all defs were used

### DIFF
--- a/src/full/Agda/Syntax/Scope/UnusedImports.hs
+++ b/src/full/Agda/Syntax/Scope/UnusedImports.hs
@@ -200,9 +200,8 @@ warnUnusedImports = do
       -- Otherwise, we just warn once about the whole import.
       if  | hasDir      -> warnEach
           | null used   -> warnModule
-          | null unused -> pure ()
           | warnAll     -> warnEach
-          | otherwise   -> warnModule
+          | otherwise   -> pure ()
 
 ------------------------------------------------------------------------------
 -- * Auxiliary definitions

--- a/test/Succeed/UnusedImports.agda
+++ b/test/Succeed/UnusedImports.agda
@@ -65,3 +65,13 @@ open Empty
 
 -- Expected warning:
 -- Redundant opening of Empty
+
+-- Andreas, 2025-12-02, issue #8258 reported by nad
+module Issue8258 where
+
+  -- We use some definitions from this open, so there should be no warning
+  -- unless -WUnusedImports=all.
+  open import Agda.Builtin.Bool
+
+  ff : Bool
+  ff = false


### PR DESCRIPTION
I was very tired (on the last meters of my AIM XLI code sprint) when I modified the warning logic, and got it wrong...

Fixes #8258.
