### PR TITLE
Reproducer for #8263; refactorings

### DIFF
--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -26,7 +26,7 @@ import Agda.TypeChecking.Datatypes
 import Agda.TypeChecking.Level
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
-import Agda.TypeChecking.ProjectionLike (elimView, ProjEliminator(..))
+import Agda.TypeChecking.ProjectionLike (elimView, LoneProjectionLikeToLambda(..))
 import Agda.TypeChecking.Records (shouldBeProjectible)
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Sort
@@ -72,7 +72,7 @@ defaultAction = Action
   { preAction       = \ _ -> return
   , postAction      = \ _ -> return
   , modalityAction  = \ _ -> id
-  , elimViewAction  = elimView EvenLone
+  , elimViewAction  = elimView LoneProjectionLikeToLambda
   }
 
 eraseUnusedAction :: Action TCM

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -1485,22 +1485,23 @@ droppedPars d = case theDef d of
     PrimitiveSort{}          -> 0
     AbstractDefn{}           -> 0 -- not impossible when quoting, PR #7828
 
--- | Is it the name of a record projection?
+-- | Is it the name of a record projection or field or a projection-like function?
 {-# SPECIALIZE isProjection :: QName -> TCM (Maybe Projection) #-}
 isProjection :: HasConstInfo m => QName -> m (Maybe Projection)
 isProjection qn = isProjection_ . theDef <$> getConstInfo qn
 
+-- | Is it a record projection or field or a projection-like function?
 isProjection_ :: Defn -> Maybe Projection
-isProjection_ def =
-  case def of
+isProjection_ = \case
     Function { funProjection = Right result } -> Just result
     _                                         -> Nothing
 
--- | Is it the name of a non-irrelevant record projection?
+-- | Is it the name of a non-irrelevant record projection or field or projection-like function?
 {-# SPECIALIZE isProjection :: QName -> TCM (Maybe Projection) #-}
 isRelevantProjection :: HasConstInfo m => QName -> m (Maybe Projection)
 isRelevantProjection qn = isRelevantProjection_ <$> getConstInfo qn
 
+-- | Is it a non-irrelevant record projection or field or projection-like function?
 isRelevantProjection_ :: Definition -> Maybe Projection
 isRelevantProjection_ def =
   if isIrrelevant def then Nothing else isProjection_ $ theDef def

--- a/src/full/Agda/TypeChecking/ProjectionLike.hs
+++ b/src/full/Agda/TypeChecking/ProjectionLike.hs
@@ -438,6 +438,8 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
 inferNeutral :: (PureTCM m, MonadBlock m) => Term -> m Type
 inferNeutral u = do
   reportSDoc "tc.infer" 20 $ "inferNeutral" <+> prettyTCM u
+  reportSDoc "tc.infer" 40 $ "inferNeutral (rawer)" <+> pretty u
+  reportSDoc "tc.infer" 40 $ "in Context" <+> (prettyTCM =<< getContextTelescope)
   case u of
     Var i es -> do
       a <- typeOfBV i

--- a/src/full/Agda/TypeChecking/ProjectionLike.hs
+++ b/src/full/Agda/TypeChecking/ProjectionLike.hs
@@ -435,6 +435,8 @@ makeProjection x = whenM (optProjectionLike <$> pragmaOptions) $ do
 -- | Infer type of a neutral term.
 --   See also @infer@ in @Agda.TypeChecking.CheckInternal@, which has a very similar
 --   logic but also type checks all arguments.
+--
+--   Precondition: the term is not a projection-like function in prefix ('Def') form.
 inferNeutral :: (PureTCM m, MonadBlock m) => Term -> m Type
 inferNeutral u = do
   reportSDoc "tc.infer" 20 $ "inferNeutral" <+> prettyTCM u
@@ -445,6 +447,7 @@ inferNeutral u = do
       a <- typeOfBV i
       loop a (Var i) es
     Def f es -> do
+      -- f is not a lone projection-like function, see precondition.
       whenJustM (isRelevantProjection f) $ \_ -> nonInferable
       a <- defType <$> getConstInfo f
       loop a (Def f) es

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -184,7 +184,7 @@ sortOf
   => Term -> m Sort
 sortOf t = do
   reportSDoc "tc.sort" 60 $ "sortOf" <+> prettyTCM t
-  sortOfT =<< elimView EvenLone t
+  sortOfT =<< elimView LoneProjectionLikeToLambda t
 
   where
     sortOfT :: Term -> m Sort

--- a/test/Bugs/Issue8263.agda
+++ b/test/Bugs/Issue8263.agda
@@ -1,0 +1,164 @@
+-- Andreas, 2025-12-05, issue #8263
+-- Shrunk from https://github.com/HoTT-Intro/Agda
+-- Internal error in ProjectionLike, regression in 2.6.4
+-- Culprit may be b6c76f409c294691c33112f9144ef2393a335cfe
+
+{-# OPTIONS --without-K #-}
+
+-- {-# OPTIONS -v tc.infer:40 #-}
+
+module _ where
+
+open import Agda.Primitive
+open import Agda.Builtin.Equality renaming (_≡_ to Id)
+open import Agda.Builtin.Nat renaming (Nat to ℕ)
+
+postulate
+  ANY : ∀{ℓ} {A : Set ℓ} → A
+
+data Σ {l1 l2 : Level} (A : Set l1) (B : A → Set l2) : Set (l1 ⊔ l2) where
+  pair : (x : A) → (B x → Σ A B)
+
+pr1 : {l1 l2 : Level} {A : Set l1} {B : A → Set l2} → Σ A B → A
+pr1 (pair a _) = a
+
+pr2 : {l1 l2 : Level} {A : Set l1} {B : A → Set l2} → (t : Σ A B) → B (pr1 t)
+pr2 (pair a b) = b
+
+_×_ = λ A B → Σ A (λ _ → B)
+
+is-contr :
+  {l : Level} → Set l → Set l
+is-contr A = Σ A (λ a → (x : A) → Id a x)
+
+is-prop :
+  {i : Level} (A : Set i) → Set i
+is-prop A = (x y : A) → is-contr (Id x y)
+
+UU-Prop :
+  (l : Level) → Set (lsuc l)
+UU-Prop l = Σ (Set l) is-prop
+
+all-elements-equal :
+  {i : Level} (A : Set i) → Set i
+all-elements-equal A = (x y : A) → Id x y
+
+postulate
+  type-trunc-Prop : {l : Level} → Set l → Set l
+
+  is-prop-all-elements-equal :
+    {i : Level} {A : Set i} → all-elements-equal A → is-prop A
+
+  is-prop-type-trunc-Prop : {l : Level} {A : Set l} → is-prop (type-trunc-Prop A)
+
+trunc-Prop : {l : Level} → Set l → UU-Prop l
+trunc-Prop A = pair (type-trunc-Prop A) is-prop-type-trunc-Prop
+
+postulate
+  mere-equiv-Prop :
+    {l1 l2 : Level} → Set l1 → Set l2 → UU-Prop (l1 ⊔ l2)
+
+mere-equiv :
+  {l1 l2 : Level} → Set l1 → Set l2 → Set (l1 ⊔ l2)
+mere-equiv X Y = pr1 (mere-equiv-Prop X Y)
+
+data unit : Set where
+  star : unit
+
+data empty : Set where
+
+data coprod {l1 l2 : Level} (A : Set l1) (B : Set l2) : Set (l1 ⊔ l2)  where
+  inl : A → coprod A B
+  inr : B → coprod A B
+
+Fin : ℕ → Set
+Fin zero = empty
+Fin (suc k) = coprod (Fin k) unit
+
+UU-Fin : ℕ → Set1
+UU-Fin k =  Σ Set (mere-equiv (Fin k))
+
+_~_ :
+  {l1 l2 : Level} {A : Set l1} {B : A → Set l2}
+  (f g : (x : A) → B x) → Set (l1 ⊔ l2)
+f ~ g = (x : _) → Id (f x) (g x)
+
+id : {i : Level} {A : Set i} → A → A
+id a = a
+
+_∘_ :
+  {i j k : Level} {A : Set i} {B : Set j} {C : Set k} →
+  (B → C) → ((A → B) → (A → C))
+(g ∘ f) a = g (f a)
+
+sec :
+  {i j : Level} {A : Set i} {B : Set j} (f : A → B) → Set (i ⊔ j)
+sec {i} {j} {A} {B} f = Σ (B → A) (λ g → (f ∘ g) ~ id)
+
+retr :
+  {i j : Level} {A : Set i} {B : Set j} (f : A → B) → Set (i ⊔ j)
+retr {i} {j} {A} {B} f = Σ (B → A) (λ g → (g ∘ f) ~ id)
+
+is-equiv :
+  {i j : Level} {A : Set i} {B : Set j} (f : A → B) → Set (i ⊔ j)
+is-equiv f = sec f × retr f
+
+_≃_ :
+  {i j : Level} (A : Set i) (B : Set j) → Set (i ⊔ j)
+A ≃ B = Σ (A → B) (λ f → is-equiv f)
+
+postulate
+  is-contr-total-Eq-Π :
+    ∀ { l1 l2 l3} {A : Set l1} {B : A → Set l2} (C : (x : A) → B x → Set l3) →
+    ( is-contr-total-C : (x : A) → is-contr (Σ (B x) (C x))) →
+    is-contr (Σ ((x : A) → B x) (λ g → (x : A) → C x (g x)))
+
+  is-contr-total-Eq-structure :
+    ∀ { l1 l2 l3 l4 : Level} { A : Set l1} {B : A → Set l2} {C : A → Set l3}
+    ( D : (x : A) → B x → C x → Set l4) →
+    ( is-contr-AC : is-contr (Σ A C)) →
+    ( t : Σ A C) →
+    is-contr (Σ (B (pr1 t)) (λ y → D (pr1 t) y (pr2 t))) →
+    is-contr (Σ (Σ A B) (λ t → Σ (C (pr1 t)) (D (pr1 t) (pr2 t))))
+
+cube : ℕ → Set₁
+cube k = Σ (UU-Fin k) (λ X → pr1 X → UU-Fin 2)
+
+equiv-cube : {k : ℕ} → cube k → cube k → Set
+equiv-cube {k} X Y =
+  Σ ( (pr1 (pr1 X)) ≃ (pr1 (pr1 Y)))
+    ( λ e → (x : pr1 (pr1 X))
+          → (pr1 (pr2 X x)) ≃ ( pr1 (pr2 Y (pr1 e x))))
+
+htpy-equiv-cube :
+  {k : ℕ} (X Y : cube k) (e f : equiv-cube X Y) → Set
+htpy-equiv-cube X Y e f =
+  Σ ( pr1 (pr1 e) ~ pr1 (pr1 f))
+    ( λ H → (d : pr1 (pr1 X)) →
+            ANY -- ( tr (pr1 ∘ pr2 Y) (H d) ∘ pr1 (pr2 e d))
+            ~
+            ( pr1 (pr2 f d)))
+
+-- Internal error:
+is-contr-total-htpy-equiv-cube :
+  {k : ℕ} (X Y : cube k) (e : equiv-cube X Y) →
+  is-contr (Σ (equiv-cube X Y) (htpy-equiv-cube X Y e))
+is-contr-total-htpy-equiv-cube X Y e =
+  is-contr-total-Eq-structure
+    ( λ α β H →
+      ( d : pr1 (pr1 X)) →
+      ANY -- ( λ bar → tr (λ foo → pr1 (pr2 Y foo)) (H d) (pr1 (pr2 e d) bar))
+      ~
+      ( pr1 (β d))
+    )
+    ANY -- ( is-contr-total-htpy-equiv (pr1 e))
+    ANY -- ( pair (pr1 e) ANY) -- (λ _ → refl))
+    ( is-contr-total-Eq-Π
+      ( λ d β → pr1 (pr2 e d) ~ pr1 β)
+      ANY -- ( λ d → is-contr-total-htpy-equiv (pr2 e d))
+    )
+
+-- An internal error has occurred. Please report this as a bug.
+-- Location of the error: __IMPOSSIBLE__, called at
+-- src/full/Agda/TypeChecking/ProjectionLike.hs:466:54 in
+-- Agda-2.9.0-inplace:Agda.TypeChecking.ProjectionLike

--- a/test/Bugs/Issue8263.err
+++ b/test/Bugs/Issue8263.err
@@ -1,0 +1,5 @@
+AGDA_FAILURE
+
+ret > ExitFailure 154
+out > An internal error has occurred. Please report this as a bug.
+out > Location of the error: __IMPOSSIBLE__, called at src/full/Agda/TypeChecking/ProjectionLike.hs:«line»:«col» in «Agda-package»:Agda.TypeChecking.ProjectionLike


### PR DESCRIPTION
- **Refactor: rename ProjEliminator to LoneProjectionToLambda, remove unused case**
  Commit 1b56c6c770b045f9dbc301ff7a39fa9ab9969d69 replaced the `Bool`
  parameter of `ElimView` by the ternary
  ```haskell
  data ProjEliminator = EvenLone | ButLone | NoPostfix
  ```
  but the `NoPostfix` case is not used anymore.
  
  I didn't find the names very enlightening so I went for clear-code
  style long names that express more precisely what the flag steers.
  
  I also fixed the comment which still spoke of `Bool`.
  

- **Reproducer for issue #8263**
  

- **Some debug printing for #8263**
  

- **Comments concerning Projection(-like)**
  