### PR TITLE
Fix #8269: doc: remove claim that ETA is safe for colists

### DIFF
--- a/doc/user-manual/language/coinduction.lagda.rst
+++ b/doc/user-manual/language/coinduction.lagda.rst
@@ -210,32 +210,10 @@ For instance, the following code would lead to infinite η expansion when checki
   test = refl
 
 If you know what you are doing, you can override Agda and force a coinductive record to support η via the ``ETA`` pragma.
-For instance, η is safe for colists, as infinite η expansion is blocked by the choice between the ``Colist`` constructors:
 
-..
-  ::
-  module COLIST where
-    -- place in module to avoid clashing with another _∷_ below
+.. code-block:: agda
 
-::
-
-    open import Agda.Builtin.Equality
-
-    mutual
-      data Colist (A : Set) : Set where
-        []  : Colist A
-        _∷_ : A → ∞Colist A → Colist A
-
-      record ∞Colist (A : Set) : Set where
-        coinductive
-        constructor delay
-        field       force : Colist A
-    open ∞Colist
-
-    {-# ETA ∞Colist #-}
-
-    test : {A : Set} (x : ∞Colist A) → x ≡ delay (force x)
-    test x = refl
+  {-# ETA R #-}
 
 Note however that ``ETA`` is not allowed in :option:`--safe` mode, for reasons mentioned above.
 This pragma is intended for experiments and not recommended in production code.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4743,9 +4743,10 @@ data Warning
   | OptionWarning            OptionWarning
   | ParseWarning             ParseWarning
   | LibraryWarning           LibWarning
-  | DeprecationWarning String String String
-    -- ^ `DeprecationWarning old new version`:
-    --   `old` is deprecated, use `new` instead. This will be an error in Agda `version`.
+  | DeprecationWarning String (Maybe String) String
+    -- ^ @DeprecationWarning old new version@:
+    --   @old@ is deprecated, use @new@ instead (if given).
+    --   This will be an error in @version@.
   | UserWarning Text
     -- ^ User-defined warning (e.g. to mention that a name is deprecated)
   | DuplicateUsing (List1 C.ImportedName)

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -354,9 +354,11 @@ prettyWarning = \case
 
     ParseWarning pw -> pretty pw
 
-    DeprecationWarning old new version -> fsep $
-      [text old] ++ pwords "has been deprecated. Use" ++ [text new] ++ pwords
-      "instead. This will be an error in Agda" ++ [text version <> "."]
+    DeprecationWarning old mnew version -> fsep $ concat $ concat
+      [ [ [text old], pwords "has been deprecated." ]
+      , [ ["Use", text new, "instead." ] | new <- maybeToList mnew ]
+      , [ pwords "This will be an error in", [text version <> "."] ]
+      ]
 
     NicifierIssue w -> pretty w
 


### PR DESCRIPTION
Closes #8269.
