### PR TITLE
Update -WUnusedImports to take modules into consideration

### DIFF
--- a/test/Succeed/UnusedImportedModules.lagda.md
+++ b/test/Succeed/UnusedImportedModules.lagda.md
@@ -1,0 +1,77 @@
+---
+title: `UnusedImports` warnings concerning modules
+author: Andreas Abel
+date: 2025-12-08
+---
+
+```agda
+{-# OPTIONS -WUnusedImports #-}
+
+-- {-# OPTIONS -v warning.unusedImports:60 #-}
+
+module _ where
+```
+
+# Unused module in `using` directive.
+
+```agda
+open import Agda.Builtin.Equality using (module _≡_)
+```
+This should warn about the unused `module _≡_` and highlight it.
+
+# Unused module in `renaming` directive.
+```agda
+open import Agda.Builtin.Equality using () renaming (module _≡_ to Eq)
+```
+This should warn about the unused module `Eq` and highlight it.
+
+
+# A module that just exports an unused module
+
+```agda
+module Parent where
+  module Child where
+   postulate A : Set
+
+module Mod1 where
+  open Parent
+```
+The `open` should be reported as redundant.
+
+# A module that just exports an module used in qualification
+
+```agda
+module Mod2 where
+  open Parent
+  postulate x : Child.A
+```
+There should be no warning for this `open` statement
+
+# Importing just a module but this one is used
+
+```agda
+import Agda.Builtin.Nat
+
+Nat = Agda.Builtin.Nat.Nat
+
+module Nat1 where
+  open Agda.Builtin.Nat using (module Nat)  -- no warning
+  open Nat -- no warning
+
+  plus : (x y : Nat) → Nat
+  plus zero y = y
+  plus (suc x) y = suc (plus x y)
+```
+No warnings about unused imports expected here.
+
+# Using a module in qualified names
+
+```agda
+module Nat2 where
+  open Agda.Builtin.Nat using (module Nat)  -- no warning
+
+  plus : (x y : Nat) → Nat
+  plus Nat.zero y = y
+  plus (Nat.suc x) y = Nat.suc (plus x y)
+```
+The imported module `Nat` is used qualified so not redundantly imported.

--- a/test/Succeed/UnusedImportedModules.warn
+++ b/test/Succeed/UnusedImportedModules.warn
@@ -1,0 +1,14 @@
+
+UnusedImportedModules.lagda.md:37.3-14: warning: -W[no]UnusedImports
+Redundant opening of Parent
+
+UnusedImportedModules.lagda.md:45.3-14: warning: -W[no]UnusedImports
+Redundant opening of Parent
+
+———— All done; warnings encountered ————————————————————————
+
+UnusedImportedModules.lagda.md:37.3-14: warning: -W[no]UnusedImports
+Redundant opening of Parent
+
+UnusedImportedModules.lagda.md:45.3-14: warning: -W[no]UnusedImports
+Redundant opening of Parent


### PR DESCRIPTION
@copilot Task: Update `-WUnusedImports` to take modules into consideration.

PR #8226 introduced a new warning `UnusedImports` with a logic as laid down in the new module `Agda.Syntax.Scope.UnusedImports`:

- For every open statement the `registerModuleOpening` is called which records the position of the `open` statement and which names it brought into scope (field `openedScope`).  That field should be renamed to `openedNameScope` and there should be a new field `openedModuleScope :: ModulesInScope` that records which modules were brought into scope by this open statement.
- For every concrete named resolved by the scope checker (`ConcreteToAbstract.hs`) the `lookedupName` method is called that registers the use of a name.  This should be complemented by a new `lookedupModule` method which registers used modules.  To this end, a new field `moduleLookups :: ![AbstractModule]` should be added to the `UnusedImportsState` record.
- Finally, after type checking is done, the method `warnUnusedImports` is called that warns about redundant opens or unused names in the opening directives `using` and `renaming`.  This should be fixed so that an open is only redundant if also no module was used that it brought into scope, and that it also warns about unused modules brought into scope. This PR for now contains a new test and the current warnings that Agda emits for this test, but these are not correct and should be updated.

To get the correct ranges for concrete names from import directive into `NamesInScope`, repo commit e4ddf24cd8 ("applyImportDirective now puts the C.Name from 'using' into NamesInScope") was added.  The analogue for modules should be added as separate commit to this PR, and it is needed so the unused-imports warning produces the correct highlighting for unused module names appearing in `open` statements.

