### PR TITLE
Library management: support `defaults-X.Y.Z` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,11 @@ Reflection
 Library management
 ------------------
 
+* Suppport for version-specific `defaults` files: a file whose name is
+of the form `defaults-X.Y.Z` will take precedence over the standard
+`defaults` one for the `X.Y.Z` version of the compiler. This can be
+used to have default libraries that are only compatible with a given
+version of the compiler.
 
 Interaction and emacs mode
 --------------------------

--- a/doc/user-manual/tools/package-system.rst
+++ b/doc/user-manual/tools/package-system.rst
@@ -190,8 +190,16 @@ There are three ways a library gets used:
 Default libraries
 -----------------
 
-If you want to usually use a variety of libraries, it is simplest to list them
-all in the ``AGDA_DIR/defaults`` file.
+If you want to usually use a variety of libraries, it is simplest
+to list them all in a ``defaults`` file
+
+- ``AGDA_DIR/defaults-VERSION``, or if that does not exist
+- ``AGDA_DIR/defaults``
+
+where ``VERSION`` is the Agda version (for instance ``2.5.1``).
+``default-VERSION`` has the benefit that you only need to have
+installed the mentioned library for the one ``VERSION`` of the
+compiler you target.
 
 Each line of the defaults file shall be the name of a library resolvable
 using the paths listed in the libraries file.  For example,

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -128,12 +128,12 @@ defaultLibraryFiles :: List1 FilePath
 defaultLibraryFiles = ("libraries-" ++ version) :| "libraries" : []
 
 -- | The @$AGDA_DIR/defaults@ file lists the library names relevant for all
---   Agda project.
+--   Agda projects.
 --
---   Agda honors also version-specific @defaults@ files, e.g. @defaults-2.6.0@.
+--   Agda also honors version-specific @defaults@ files, e.g. @defaults-2.6.0@.
 --
 --   @defaultsFiles@ gives a list of all @defaults@ Agda should process
---   by default.  The first file in this list that exists is actually used.
+--   by default. The first file in this list that exists is actually used.
 --
 defaultsFiles :: List1 FilePath
 defaultsFiles = ("defaults-" ++ version) :| "defaults" : []

--- a/src/full/Agda/Interaction/Library.hs
+++ b/src/full/Agda/Interaction/Library.hs
@@ -116,7 +116,7 @@ getPrimitiveLibDir = do
       (return $ AbsolutePath $ T.pack $ libdir </> "prim")
       (error $ "The lib directory " ++ libdir ++ " does not exist")
 
--- | The @~/.agda/libraries@ file lists the libraries Agda should know about.
+-- | The @$AGDA_DIR/libraries@ file lists the libraries Agda should know about.
 --   The content of @libraries@ is a list of paths to @.agda-lib@ files.
 --
 --   Agda honors also version-specific @libraries@ files, e.g. @libraries-2.6.0@.
@@ -138,7 +138,7 @@ defaultLibraryFiles = ("libraries-" ++ version) :| "libraries" : []
 defaultsFiles :: List1 FilePath
 defaultsFiles = ("defaults-" ++ version) :| "defaults" : []
 
--- | The @~/.agda/executables@ file lists the executables Agda should know about.
+-- | The @$AGDA_DIR/executables@ file lists the executables Agda should know about.
 --   The content of @executables@ is a list of paths to executables.
 --
 --   Agda honors also version-specific @executables@ files, e.g. @executables-2.6.0@.


### PR DESCRIPTION
I noticed when working on an installer script for the standard library (https://github.com/agda/agda-stdlib/pull/2895)
that Agda does not support version-specific `defaults` files.

Having an installer shove a library name in the global `defaults` is problematic as we may not
have installed versions of the library for all of the installed versions of the compiler.

This PR adds support for a version-specific `defaults-X.Y.Z` file to take precedence over `defaults`
just like we currently support `libraries-X.Y.Z` and `executables-X.Y.Z` taking precedence over
`libraries` and `executables`.