### PR TITLE
Refactor: use List1 in A.Mutual and A.ScopedDecl

### DIFF
--- a/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Types.hs
@@ -53,7 +53,7 @@ data NiceDeclaration
       --   ('Hiding' should be 'NotHidden'.)
   | NiceField Range Access IsAbstract IsInstance TacticAttribute Name (Arg Expr)
   | PrimitiveFunction Range Access IsAbstract Name (Arg Expr)
-  | NiceMutual KwRange TerminationCheck CoverageCheck PositivityCheck [NiceDeclaration]
+  | NiceMutual KwRange TerminationCheck CoverageCheck PositivityCheck (List1 NiceDeclaration)
   | NiceModule Range Access IsAbstract Erased QName Telescope
       [Declaration]
   | NiceModuleMacro Range Access Erased Name ModuleApplication

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -218,11 +218,10 @@ bindVarsToBind = do
   printLocals 30 "bound variables:"
   modifyScope $ setVarsToBind []
 
-annotateDecls :: ReadTCState m => m [A.Declaration] -> m A.Declaration
+annotateDecls :: ReadTCState m => m [A.Declaration] -> m (Maybe A.Declaration)
 annotateDecls m = do
-  ds <- m
-  s  <- getScope
-  return $ A.ScopedDecl s ds
+  forMM (List1.nonEmpty <$> m) \ ds1 -> do
+    getScope <&> (`A.ScopedDecl` ds1)
 
 annotateExpr :: ReadTCState m => m A.Expr -> m A.Expr
 annotateExpr m = do

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1219,7 +1219,7 @@ instance (ToConcrete p, ToConcrete a) => ToConcrete (RewriteEqn' qn A.BindName p
 instance ToConcrete (Constr A.Constructor) where
   type ConOfAbs (Constr A.Constructor) = C.Declaration
 
-  toConcrete (Constr (A.ScopedDecl scope [d])) =
+  toConcrete (Constr (A.ScopedDecl scope (d :| []))) =
     withScope scope $ toConcrete (Constr d)
   toConcrete (Constr (A.Axiom _ i info Nothing x t)) = do
     x' <- unsafeQNameToName <$> toConcrete x
@@ -1266,7 +1266,7 @@ instance ToConcrete A.Declaration where
   type ConOfAbs A.Declaration = [C.Declaration]
 
   toConcrete (ScopedDecl scope ds) =
-    withScope scope (declsToConcrete ds)
+    withScope scope $ declsToConcrete $ List1.toList ds
 
   toConcrete (A.Axiom _ i info mp x t) = do
     x' <- unsafeQNameToName <$> toConcrete x
@@ -1335,7 +1335,7 @@ instance ToConcrete A.Declaration where
       (x',cs') <- first unsafeQNameToName <$> toConcrete (x, map Constr cs)
       return [ C.RecordDef (getRange i) x' dirs (catMaybes tel') cs' ]
 
-  toConcrete (A.Mutual i ds) = pure . C.Mutual empty <$> declsToConcrete ds
+  toConcrete (A.Mutual i ds) = pure . C.Mutual empty <$> declsToConcrete (List1.toList ds)
 
   toConcrete (A.Section i erased x (A.GeneralizeTel _ tel) ds) = do
     x <- toConcrete x

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -51,6 +51,7 @@ import Agda.Utils.Either
 import Agda.Utils.Function (applyWhen)
 import Agda.Utils.Functor
 import Agda.Utils.List
+import Agda.Utils.List1 (pattern (:|) )
 import Agda.Utils.Maybe
 import Agda.Utils.Monad
 import Agda.Utils.Null
@@ -254,7 +255,7 @@ checkConstructor
   -> Sort          -- ^ Sort of the data type.
   -> A.Constructor -- ^ Constructor declaration (type signature).
   -> TCM IsPathCons
-checkConstructor d uc tel nofIxs s (A.ScopedDecl scope [con]) = do
+checkConstructor d uc tel nofIxs s (A.ScopedDecl scope (con :| [])) = do
   setScope scope
   checkConstructor d uc tel nofIxs s con
 checkConstructor d uc tel nofIxs s con@(A.Axiom _ i ai Nothing c e) =

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -42,12 +42,14 @@ import Agda.Utils.Boolean
 import Agda.Utils.Function ( applyWhen )
 import Agda.Utils.Lens
 import Agda.Utils.List (headWithDefault)
+import Agda.Utils.List1 (pattern (:|) )
 import Agda.Utils.Monad
 import Agda.Utils.Null
 import qualified Agda.Syntax.Common.Pretty as P
 import Agda.Utils.Size
 
 import Agda.Utils.Impossible
+import qualified Agda.Utils.List1 as List1
 
 ---------------------------------------------------------------------------
 -- * Records
@@ -160,9 +162,10 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
       etaenabled <- etaEnabled
 
       let getName :: A.Declaration -> [Dom QName]
-          getName (A.Field _ x arg)    = [x <$ domFromArg arg]
-          getName (A.ScopedDecl _ [f]) = getName f
-          getName _                    = []
+          getName = \case
+            A.Field _ x arg          -> [ x <$ domFromArg arg ]
+            A.ScopedDecl _ (f :| []) -> getName f
+            _ -> []
 
           setTactic dom f = f { domTactic = domTactic dom }
 
@@ -405,7 +408,7 @@ checkRecordProjections m r hasNamedCon con tel ftel fs = do
     checkProjs _ _ _ [] = return ()
 
     checkProjs ftel1 ftel2 vs (A.ScopedDecl scope fs' : fs) =
-      setScope scope >> checkProjs ftel1 ftel2 vs (fs' ++ fs)
+      setScope scope >> checkProjs ftel1 ftel2 vs (List1.toList fs' ++ fs)
 
     -- Case: projection.
     checkProjs ftel1 (ExtendTel (dom@Dom{domInfo = ai,unDom = t}) ftel2) vs (A.Field info x _ : fs) =


### PR DESCRIPTION
We can't have empty mutual blocks in abstract syntax, so let's make that obvious in the type of A.Mutual.
