### PR TITLE
Fix #8287: missing agda2-command declaration for agda2-solve-action

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -1582,6 +1582,7 @@ Either only one if point is a goal, or all of them."
         (nconc agda2-last-responses (cons (cons 3 cmd) nil))))))
 
 (defun agda2-solve-action (g txt)
+  (declare (agda2-command (integer string)))
   (save-excursion
     (agda2-replace-goal g txt)
     (agda2-goto-goal g)


### PR DESCRIPTION
A fixup of PR #8178.

Closes #8287.
