### PR TITLE
Separately benchmark Polarity from Positivity; restore forcing of argOccurrences

### DIFF
--- a/src/full/Agda/Benchmarking.hs
+++ b/src/full/Agda/Benchmarking.hs
@@ -36,8 +36,10 @@ data Phase
     -- ^ Type checking and translation to internal syntax.
   | Termination
     -- ^ Termination checking.
+  | Polarity
+    -- ^ Polarity computation.
   | Positivity
-    -- ^ Positivity checking and polarity computation.
+    -- ^ Positivity checking.
   | Injectivity
     -- ^ Injectivity checking.
   | ProjectionLikeness

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -22,6 +22,8 @@ import Agda.Syntax.Common
 import Agda.Syntax.Internal
 
 import Agda.TypeChecking.Monad
+import Agda.TypeChecking.Monad.Benchmark (MonadBench)
+import Agda.TypeChecking.Monad.Benchmark qualified as Bench
 import Agda.TypeChecking.Datatypes (getNumberOfParameters)
 import Agda.TypeChecking.Pretty
 import Agda.TypeChecking.SizedTypes
@@ -114,12 +116,8 @@ polarityFromPositivity x = inConcreteOrAbstractMode x $ \ def -> do
 ------------------------------------------------------------------------
 
 -- | Main function of this module.
-computePolarity
-  :: ( HasOptions m, HasConstInfo m, HasBuiltins m
-     , MonadTCEnv m, MonadTCState m, MonadReduce m, MonadAddContext m, MonadTCError m
-     , MonadDebug m, MonadPretty m )
-  => [QName] -> m ()
-computePolarity xs = do
+computePolarity :: [QName] -> TCM ()
+computePolarity xs = Bench.billTo [Bench.Polarity] $ do
  reportSDoc "tc.polarity.set" 40 $ "computePolarity" <+> prettyTCM xs
 
  -- Andreas, 2017-04-26, issue #2554

--- a/src/full/Agda/TypeChecking/Polarity.hs-boot
+++ b/src/full/Agda/TypeChecking/Polarity.hs-boot
@@ -2,18 +2,8 @@
 
 module Agda.TypeChecking.Polarity where
 
-import Agda.Syntax.Abstract.Name                        (QName)
-import Agda.TypeChecking.Monad.Base
-import Agda.TypeChecking.Monad.Builtin                  (HasBuiltins)
-import Agda.TypeChecking.Monad.Context                  (MonadAddContext)
-import Agda.TypeChecking.Monad.Debug                    (MonadDebug)
-import {-# SOURCE #-} Agda.TypeChecking.Monad.Signature (HasConstInfo)
-import {-# SOURCE #-} Agda.TypeChecking.Pretty          (MonadPretty)
+import Agda.Syntax.Abstract.Name    ( QName )
+import Agda.TypeChecking.Monad.Base ( Polarity, TCM )
 
-computePolarity
-  :: ( HasOptions m, HasConstInfo m, HasBuiltins m
-     , MonadTCEnv m, MonadTCState m, MonadReduce m, MonadAddContext m, MonadTCError m
-     , MonadDebug m, MonadPretty m )
-  => [QName] -> m ()
-
+computePolarity :: [QName] -> TCM ()
 composePol      :: Polarity -> Polarity -> Polarity

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -458,7 +458,7 @@ checkTermination_ d = Bench.billTo [Bench.Termination] $ do
 
 -- | Check a set of mutual names for positivity.
 checkPositivity_ :: Info.MutualInfo -> Set QName -> TCM ()
-checkPositivity_ mi names = Bench.billTo [Bench.Positivity] $ do
+checkPositivity_ mi names = do
   -- Positivity checking.
   reportSLn "tc.decl" 20 $ "checkDecl: checking positivity..."
   checkStrictlyPositive mi names


### PR DESCRIPTION
The deep-strictness of argOccurrences computed by the positivity checker was lost in PR #6385. (See https://github.com/agda/agda/commit/32e8c29ce5b14b193cb952a4d3b31aa387dea3c6#r173041607.)

On the std-lib-test, the restored strictness is not significant in the workload sharing between Positivity and Polarity, but @nad has an example with a very large mutual block (and thus positivity graph) where it matters.
