### PR TITLE
Made it possible to turn off the occurrence analysis for functions

### DIFF
--- a/doc/user-manual/language/positivity-checking.lagda.rst
+++ b/doc/user-manual/language/positivity-checking.lagda.rst
@@ -1,5 +1,7 @@
 ..
   ::
+  {-# OPTIONS --polarity #-}
+
   module language.positivity-checking where
 
 .. _positivity-checking:
@@ -10,6 +12,79 @@ Positivity Checking
 
 .. note::
    This is a stub.
+
+.. _occurrence_analysis:
+
+Occurrence analysis
+-------------------
+
+..
+  ::
+  module occurrence-analysis where
+    open import Agda.Builtin.Bool
+    open import Agda.Builtin.Equality
+    open import Agda.Builtin.Nat
+    open import Agda.Builtin.Unit
+
+By default Agda analyses how functions use their arguments. For
+instance, Agda can tell that ``D`` in the following code is strictly
+positive, because ``Vec`` uses its ``Set`` argument in a strictly
+positive way:
+::
+
+    data _×_ (A B : Set) : Set where
+      _,_ : A → B → A × B
+
+    Vec : Set → Nat → Set
+    Vec A zero    = ⊤
+    Vec A (suc n) = A × Vec A n
+
+    data D : Set where
+      c : ∀ n → Vec D n → D
+
+However, this analysis can be slow, especially for big mutual blocks.
+It can be turned off with the :option:`--no-occurrence-analysis` flag.
+
+The analysis is also used to detect unused function arguments. For
+instance, Agda by default notices that the last argument of ``F`` in
+the following code is unused, and accepts the use of reflexivity:
+::
+
+    F : Bool → Set → Set
+    F true  _ = Bool
+    F false _ = ⊤
+
+    _ : {b : Bool} → F b Bool ≡ F b ⊤
+    _ = refl
+
+..
+  ::
+  module polarity-as-an-alternative-to-occurrence-analysis where
+    open import Agda.Builtin.Bool
+    open import Agda.Builtin.Equality
+    open import Agda.Builtin.Nat
+    open import Agda.Builtin.Unit
+
+An alternative to the occurrence analysis is to use :ref:`polarities
+<polarity>`:
+::
+
+    data _×_ (@++ A B : Set) : Set where
+      _,_ : A → B → A × B
+
+    Vec : @++ Set → Nat → Set
+    Vec A zero    = ⊤
+    Vec A (suc n) = A × Vec A n
+
+    data D : Set where
+      c : ∀ n → Vec D n → D
+
+    F : Bool → @unused Set → Set
+    F true  _ = Bool
+    F false _ = ⊤
+
+    _ : {b : Bool} → F b Bool ≡ F b ⊤
+    _ = refl
 
 .. _no_positivity_check-pragma:
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -863,6 +863,15 @@ Pattern matching and equality
 
      Default: :option:`--no-polarity`.
 
+.. option:: --occurrence-analysis, --no-occurrence-analysis
+
+     .. versionadded:: 2.9.0
+
+     Turns on or off automated occurrence analysis for functions. See
+     :ref:`occurrence_analysis`.
+
+     Default: :option:`--occurrence-analysis`.
+
 .. option:: --no-pattern-matching
 
      .. versionadded:: 2.4.0

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -106,6 +106,7 @@ module Agda.Interaction.Options.Base
     , lensOptCohesion
     , lensOptFlatSplit
     , lensOptPolarity
+    , lensOptOccurrence
     , lensOptImportSorts
     , lensOptLoadPrimitives
     , lensOptAllowExec
@@ -164,6 +165,7 @@ module Agda.Interaction.Options.Base
     , optCohesion
     , optFlatSplit
     , optPolarity
+    , optOccurrence
     , optImportSorts
     , optLoadPrimitives
     , optAllowExec
@@ -332,6 +334,7 @@ optCallByName                :: PragmaOptions -> Bool
 optCohesion                  :: PragmaOptions -> Bool
 optFlatSplit                 :: PragmaOptions -> Bool
 optPolarity                  :: PragmaOptions -> Bool
+optOccurrence                :: PragmaOptions -> Bool
 -- | 'optImportSorts' requires 'optLoadPrimitives'.
 optImportSorts               :: PragmaOptions -> Bool
 optLoadPrimitives            :: PragmaOptions -> Bool
@@ -396,6 +399,7 @@ optCallByName                = collapseDefault . _optCallByName
 optCohesion                  = collapseDefault . _optCohesion      || optFlatSplit
 optFlatSplit                 = collapseDefault . _optFlatSplit
 optPolarity                  = collapseDefault . _optPolarity
+optOccurrence                = collapseDefault . _optOccurrence
 -- --no-load-primitives implies --no-import-sorts
 optImportSorts               = collapseDefault . _optImportSorts   && optLoadPrimitives
 optLoadPrimitives            = collapseDefault . _optLoadPrimitives
@@ -621,6 +625,10 @@ lensOptFlatSplit f o = f (_optFlatSplit o) <&> \ i -> o{ _optFlatSplit = i }
 
 lensOptPolarity :: Lens' PragmaOptions _
 lensOptPolarity f o = f (_optPolarity o) <&> \ i -> o{ _optPolarity = i}
+
+lensOptOccurrence :: Lens' PragmaOptions _
+lensOptOccurrence f o =
+  f (_optOccurrence o) <&> \ i -> o{ _optOccurrence = i}
 
 lensOptImportSorts :: Lens' PragmaOptions _
 lensOptImportSorts f o = f (_optImportSorts o) <&> \ i -> o{ _optImportSorts = i }
@@ -1525,6 +1533,10 @@ modalityPragmaOptions = ("Modalities",) $ concat
                     $ Just "disable @lock/@tick attributes"
   , pragmaFlag      "polarity" lensOptPolarity
                     "enable the polarity modalities (@++, @mixed, etc.) and their integration in the positivity checker" ""
+                    Nothing
+  , pragmaFlag      "occurrence-analysis" lensOptOccurrence
+                    "enable automated occurrence analysis for functions"
+                    "(can be slow)"
                     Nothing
   , pragmaFlag      "irrelevant-projections" lensOptIrrelevantProjections
                     "enable projection of irrelevant record fields and similar irrelevant definitions" "(inconsistent)"

--- a/src/full/Agda/Interaction/Options/Default.hs
+++ b/src/full/Agda/Interaction/Options/Default.hs
@@ -111,6 +111,7 @@ defaultPragmaOptions = PragmaOptions
   , _optCohesion                   = Default
   , _optFlatSplit                  = Default
   , _optPolarity                   = Default
+  , _optOccurrence                 = Default
   , _optImportSorts                = Default
   , _optLoadPrimitives             = Default
   , _optAllowExec                  = Default

--- a/src/full/Agda/Interaction/Options/Types.hs
+++ b/src/full/Agda/Interaction/Options/Types.hs
@@ -206,6 +206,8 @@ data PragmaOptions = PragmaOptions
       -- ^ Can we split on a @(\@flat x : A)@ argument?
   , _optPolarity                  :: WithDefault 'False
       -- ^ Can we use modal polarities (@++, @+, etc.)?
+  , _optOccurrence                :: WithDefault 'True
+      -- ^ Perform automated occurrence analysis for functions?
   , _optImportSorts               :: WithDefault 'True
       -- ^ Should every top-level module start with an implicit statement
       --   @open import Agda.Primitive using (Set; Prop)@?

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20251212 * 10 + 0
+currentInterfaceVersion = 20260114 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -476,8 +476,8 @@ instance EmbPrj InfectiveCoinfective where
     valu _      = malformed
 
 instance EmbPrj PragmaOptions where
-  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss) =
-    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss
+  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss ttt) =
+    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss ttt
 
   value = valueN PragmaOptions
 

--- a/test/Fail/OccurrenceAnalysis1.agda
+++ b/test/Fail/OccurrenceAnalysis1.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --no-occurrence-analysis #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Unit
+
+data _×_ (A B : Set) : Set where
+  _,_ : A → B → A × B
+
+Vec : Set → Nat → Set
+Vec A zero    = ⊤
+Vec A (suc n) = A × Vec A n
+
+data D : Set where
+  c : ∀ n → Vec D n → D

--- a/test/Fail/OccurrenceAnalysis1.err
+++ b/test/Fail/OccurrenceAnalysis1.err
@@ -1,0 +1,5 @@
+OccurrenceAnalysis1.agda:13.1-14.24: error: [NotStrictlyPositive]
+D is not strictly positive, because it occurs
+in the first argument of Vec
+in the type of the constructor c
+in the definition of D.

--- a/test/Fail/OccurrenceAnalysis2.agda
+++ b/test/Fail/OccurrenceAnalysis2.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --no-occurrence-analysis #-}
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Unit
+
+F : Bool → Set → Set → Set
+F true  _ A = A
+F false _ _ = ⊤
+
+_ : {b : Bool} → F b ⊤ ≡ F b Bool
+_ = refl

--- a/test/Fail/OccurrenceAnalysis2.err
+++ b/test/Fail/OccurrenceAnalysis2.err
@@ -1,0 +1,3 @@
+OccurrenceAnalysis2.agda:12.5-9: error: [UnequalTerms]
+⊤ != Bool of type Set
+when checking that the expression refl has type F b ⊤ ≡ F b Bool

--- a/test/Succeed/OccurrenceAnalysis1.agda
+++ b/test/Succeed/OccurrenceAnalysis1.agda
@@ -1,0 +1,4 @@
+{-# OPTIONS --no-occurrence-analysis #-}
+
+data D : Set where
+  c : D → D

--- a/test/Succeed/OccurrenceAnalysis2.agda
+++ b/test/Succeed/OccurrenceAnalysis2.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --occurrence-analysis #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Unit
+
+data _×_ (A B : Set) : Set where
+  _,_ : A → B → A × B
+
+Vec : Set → Nat → Set
+Vec A zero    = ⊤
+Vec A (suc n) = A × Vec A n
+
+data D : Set where
+  c : ∀ n → Vec D n → D

--- a/test/Succeed/OccurrenceAnalysis3.agda
+++ b/test/Succeed/OccurrenceAnalysis3.agda
@@ -1,0 +1,23 @@
+{-# OPTIONS --polarity --no-occurrence-analysis #-}
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Unit
+
+data _×_ (@++ A B : Set) : Set where
+  _,_ : A → B → A × B
+
+Vec : @++ Set → Nat → Set
+Vec A zero    = ⊤
+Vec A (suc n) = A × Vec A n
+
+data D : Set where
+  c : ∀ n → Vec D n → D
+
+F : Bool → @unused Set → Set
+F true  _ = Bool
+F false _ = ⊤
+
+_ : {b : Bool} → F b Bool ≡ F b ⊤
+_ = refl


### PR DESCRIPTION
I added the option `--no-occurrence-analysis`, which turns off the occurrence analysis for functions. I have a mutual block that is 1762 lines long, and before I enabled the option I did not see Agda succeed in checking that block.

I also tried to enable the flag for the full development. I could type-check quite a lot of code before Agda complained. The speedup was something like 5%.

I placed the help text for the option in the section "Modalities". That is not a perfect fit. An alternative would be to add a new section. Any opinions?

In the documentation I connect the analysis to positivity checking and to the unused argument feature. Is the analysis used for something else that should be mentioned in the documentation?

Given that bugs in the positivity checker can lead to inconsistencies I suggest that someone checks that the implementation makes sense. The main change was to treat every function argument as "matched":
```haskell
      -- Perform automated occurrence analysis for functions?
      performAnalysis <- optOccurrence <$> pragmaOptions
      if performAnalysis then
        Concat . zipWith (OccursAs . InClause) [0..] <$>
          mapM (getOccurrences []) cs
       else
        return $ case cs of
          []     -> __IMPOSSIBLE__
          cl : _ ->
            Concat
              [ OccursAs Matched (OccursHere (AnArg i []))
              | (i, _) <- zip [0..] (namedClausePats cl)
              ]
```
By the way, is the use of `__IMPOSSIBLE__` above safe? The documentation of `_funClauses` does not state that a function must have at least one clause, but it seems as if functions without clauses are handled differently.

It might make sense to have a pragma as well, but I do not currently plan to implement that feature.

@martinescardo, the flag `--no-occurrence-analysis` turns off some Agda features that you might not want to rely on.