### PR TITLE
Do not track .envrc in git

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,0 @@
-# Auto-load a development environment from flake.nix
-# when entering the root of the repository
-
-# This only affects users of the `direnv` tool
-
-use flake

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 .cabal-sandbox/
 .direnv
 .DS_Store
+.envrc
 .ghc.environment.*
 .python-sphinx-virtualenv/
 .stack-work-*/


### PR DESCRIPTION
Tracking .envrc prevents developers from using their own custom direnv setups, and is generally accepted as bad practice.