### PR TITLE
Turn off colored terminal output when `NO_COLOR` is set.

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -887,6 +887,7 @@ library
       Agda.Utils.IO.Binary
       Agda.Utils.IO.Directory
       Agda.Utils.IO.TempFile
+      Agda.Utils.IO.Terminal
       Agda.Utils.IO.UTF8
       Agda.Utils.IORef
       Agda.Utils.IORef.Strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Pragmas and options
 * New option `--print-options` to print a simple list of all options.
   This list can e.g. be used to implement bash completion.
 
-* Consolidated Cubical-related flags to
+* The flavor of Cubical Agda can now be chosen by an argument to the `--cubical` option:
+
   | Old                    | New                                               |
   | ---------------------- | ------------------------------------------------- |
   | `--cubical`            | `--cubical`, or `--cubical=full`                  |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ Pragmas and options
   The overhead to also mine dot patterns for structural descent was already
   negligible so it made sense to simplify the termination checking algorithm.
 
+* Setting environment variable `NO_COLOR` now turns off coloring in the default `--color=auto` mode.
+  It can be overwritten by `--color=always`.
+  See also https://no-color.org/ .
+
+
 Errors
 ------
 

--- a/src/full/Agda/Syntax/Common/Pretty/ANSI.hs
+++ b/src/full/Agda/Syntax/Common/Pretty/ANSI.hs
@@ -5,13 +5,12 @@
 module Agda.Syntax.Common.Pretty.ANSI ( printTreeAnsi, putDocLn, putDocTree, putDocTreeLn ) where
 
 import Control.Monad.IO.Class ( MonadIO(..) )
-import Data.Functor ((<&>))
+import Data.Functor ( (<&>) )
 import Data.Text    qualified as Text
 import Data.Text.IO qualified as Text
 
 import System.Console.ANSI
 import System.Console.ANSI.Codes ( osc )
-import System.IO ( stdout )
 
 -- UNUSED:
 -- import Text.PrettyPrint.Annotated.HughesPJ ( renderDecoratedM )
@@ -22,7 +21,8 @@ import Agda.Interaction.Options.Base
 import Agda.Syntax.Common.Aspect as Aspect
 import Agda.Syntax.Common.Pretty ( Doc, DocTree )
 
-import Agda.Utils.DocTree (renderTree', renderToTree, treeToTextNoAnn)
+import Agda.Utils.DocTree ( renderTree', renderToTree, treeToTextNoAnn )
+import Agda.Utils.IO.Terminal ( stdoutSupportsANSI )
 
 -- | Print an annotated, pretty-printing 'DocTree' onto a VT100-compatible terminal.
 printTreeAnsi :: DocTree -> IO ()
@@ -89,7 +89,7 @@ aspSGR = \case
 putDocTree :: (MonadIO m, HasOptions m) => DocTree -> m ()
 putDocTree doc = do
   col <- commandLineOptions <&> optDiagnosticsColour >>= \case
-    AutoColour   -> liftIO (hSupportsANSI stdout)
+    AutoColour   -> liftIO stdoutSupportsANSI
     AlwaysColour -> pure True
     NeverColour  -> pure False
 

--- a/src/full/Agda/Utils/IO/Terminal.hs
+++ b/src/full/Agda/Utils/IO/Terminal.hs
@@ -1,0 +1,16 @@
+-- | Utilities for interacting with the terminal.
+
+module Agda.Utils.IO.Terminal where
+
+import System.Console.ANSI ( hSupportsANSI )
+import System.Environment  ( lookupEnv )
+import System.IO           ( stdout )
+
+import Agda.Utils.Monad    ( and2M )
+
+-- | Is the @NO_COLOR@ environment variable unset?
+environmentColor :: IO Bool
+environmentColor = null <$> lookupEnv "NO_COLOR"
+
+stdoutSupportsANSI :: IO Bool
+stdoutSupportsANSI = environmentColor `and2M` hSupportsANSI stdout


### PR DESCRIPTION
Closes #8308.
