### PR TITLE
nix: bump nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1764494334,
-        "narHash": "sha256-x2xCEXUlU4Ap56+t5HaoReOQ/bV/bIQ5rzTn/m+V3HQ=",
+        "lastModified": 1767799921,
+        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d542db745310b6929708d9abea513f3ff19b1341",
+        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -177,7 +177,16 @@
       #     * `agda-tests -p 641`
       test-results-for = target: pkgs.stdenv.mkDerivation {
         name = "${target}.txt";
-        src = ./.;  # Some tests scan all files in the repo work tree
+        src = fs.toSource {
+          root = ./.;
+          fileset = fs.difference
+            ./. # Some tests scan all files in the repo work tree
+            (fs.unions [
+              ./flake.nix
+              ./flake.lock
+            ])
+          ;
+        };
         buildInputs =
         [
           pkgs.which            # For Makefile


### PR DESCRIPTION
Allows us to take advantage of the binary cache for Haskell dependencies, since GHC 9.10 is now the default version.

Also adds some source filtering for tests to avoid rebuilding them when only flake.nix has changed.

Tested by running `nix build .#test`

cc @lawcho