### PR TITLE
doc/user-manual: render maths as SVG instead of PNG

### DIFF
--- a/.github/workflows/user_manual.yml
+++ b/.github/workflows/user_manual.yml
@@ -32,9 +32,9 @@ jobs:
       uses: TeX-Live/setup-texlive-action@v3
       with:
         packages: scheme-basic anyfontsize bbm bbm-macros booktabs capt-of cmap colortbl
-          dvipng ellipse etoolbox fancyvrb float fncychap fontawesome5 framed keystroke
-          latexmk mathtools needspace parskip pict2e psnfss stmaryrd tabulary tex-gyre
-          titlesec upquote varwidth wrapfig xcolor zapfchan
+          dvisvgm ellipse etoolbox fancyvrb float fncychap fontawesome5 framed keystroke
+          latexmk mathtools mlmodern needspace parskip pict2e psnfss stmaryrd tabulary
+          tex-gyre titlesec upquote varwidth wrapfig xcolor zapfchan
     - name: Build User Manual in PDF
       run: |
         make user-manual-pdf

--- a/doc/user-manual/conf.py
+++ b/doc/user-manual/conf.py
@@ -199,3 +199,7 @@ epub_exclude_files = ['search.html']
 
 
 # -- Extension configuration -------------------------------------------------
+
+imgmath_image_format = 'svg'
+imgmath_latex_preamble = '\\usepackage{mlmodern}'
+imgmath_font_size = 14

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,14 @@
                 py3pkgs.sphinx
                 py3pkgs.sphinx-rtd-theme
               ]))
+              (pkgs.texliveBasic.withPackages (texpkgs: with texpkgs; [
+                collection-fontsrecommended
+                collection-mathscience
+                collection-latexextra
+                collection-fontsextra
+                collection-binextra
+              ]))
+
               # Tools for running the agda test-suite
               pkgs.nodejs_22
             ];

--- a/src/github/workflows/user_manual.yml
+++ b/src/github/workflows/user_manual.yml
@@ -55,7 +55,7 @@ jobs:
           capt-of
           cmap
           colortbl
-          dvipng
+          dvisvgm
           ellipse
           etoolbox
           fancyvrb
@@ -66,6 +66,7 @@ jobs:
           keystroke
           latexmk
           mathtools
+          mlmodern
           needspace
           parskip
           pict2e


### PR DESCRIPTION
Render maths in the user manual as SVG instead of PNG. For comparison: [PNG](https://agda.readthedocs.io/en/v2.8.0/language/with-abstraction.html#technical-details) (current), [SVG](https://f.monade.li/agda-manual-svg-mlmodern-preview/language/with-abstraction.html#technical-details).

SVG looks much sharper on high-DPI monitors (or when zooming in), while PNG looks a bit more crisp at 1:1 scale. Out of ~50 people I polled on Mastodon and Zulip, about 85% said that SVG looks better on their screen.

Other options would be to use something like MathJax or KaTeX, but those lack support for `\arraycolsep` at the moment.