### PR TITLE
fix #8242: don't copy records to within themselves

### DIFF
--- a/test/Succeed/Issue8242.agda
+++ b/test/Succeed/Issue8242.agda
@@ -1,0 +1,19 @@
+module Issue8242 where
+
+open import Agda.Builtin.Unit
+
+module B (a : ⊤) where
+  record C : Set where
+    field
+      f : ⊤
+
+module X = B tt
+
+-- record type is only copied by virtue of copying the proper projection which lives in the record module
+--   so if we inherit the module from the projection when choosing where to put the record
+open B tt using (module C)
+
+postulate c : X.C
+
+open C c
+

--- a/test/Succeed/Issue8242b.agda
+++ b/test/Succeed/Issue8242b.agda
@@ -1,0 +1,26 @@
+module Issue8242b where
+
+module Issue8242 where
+
+open import Agda.Builtin.Unit
+
+module B (a : ⊤) where
+  record C : Set where
+    field
+      f : ⊤
+
+  -- variant of Issue8242 where the module that actually contains the
+  -- proper projection that gets copied is in a nested module with some
+  -- intervening parameters
+  module N1 (a : ⊤) where
+    module N2 where
+      module N3 = C renaming (f to g) using ()
+
+module X = B tt
+
+open B tt using (module N1)
+
+postulate c : X.C
+
+open N1.N2.N3 tt c
+


### PR DESCRIPTION
Here is a slight variation on @ncfavier's minimised reproducer, which is easier to talk about since the problematic section application has a name:

```agda
module B (a : ⊤) where
  record C : Set where
    field
      f : ⊤

module X = B tt
module Y = B tt using (module C)

postulate c : X.C
open Y.C c
```

The explicit copy of `module C` into the section `Y` gives means that the initial renaming contains an entry `B.C.f → Y.C.f`, of a proper projection `B.C.f`. Since #8210, copying a proper projection means also copying the record type. The bug in #8242 is that the code responsible for copying the record type puts it inside the copied record module: we get an extra renaming `B.C.C → Y.C.C`. This doesn't quite matter for typing the projection, so #8210 fixed #8037.

However, when applying `Y.C c`, we get a renaming `Y.C.f → f`, _of a proper projection_, which means #8210 once again kicks in and tries to copy the record type: we have a renaming `Y.C.C → C`. And here lies the problem. The copy `Y.C.C` (correctly) does not take any arguments, because the only argument to `B.C` was dealt with when *defining* `Y`. But since the code to decide what a copy is applied to looks at the qualifier of the name being copied, *and the record type got incorrectly nested in the copy of the record module*, we try applying `Y.C.C : Set` to an argument `c : X.C` and boom go the fireworks.

The fix is simply to stop putting the copied record inside itself.