### PR TITLE
#5833: make `with … in` generalise over `refl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,11 @@ Changes to type checker and other components defining the Agda language.
   With that change `--erasure` gets more akin to Cubical Agda that categorically
   refuses to infer lambdas (since they could construct either functions or paths).
 
+* Functions defined using with-abstraction equality (`with … in eq`) can now be
+  reasoned about using the same with-abstraction equality: the equality proof
+  is correctly generalised over. This should make most (if not all) uses of the
+  old-style `inspect` idioms for the built-in equality type unnecessary.
+
 
 Reflection
 ----------
@@ -286,6 +291,6 @@ For 2.9.0, the following issues were
 [closed](https://github.com/agda/agda/issues?q=is%3Aissue+milestone%3A2.9.0+is%3Aclosed)
 (see [bug tracker](https://github.com/agda/agda/issues)):
 
-### Issues for closed for milestone 2.9.0
+### Issues closed for milestone 2.9.0
 
-### PRs for closed for milestone 2.9.0
+### PRs closed for milestone 2.9.0

--- a/doc/user-manual/language/with-abstraction.lagda.rst
+++ b/doc/user-manual/language/with-abstraction.lagda.rst
@@ -1030,6 +1030,22 @@ Below are some examples of with-abstractions and their translations.
     f-aux₄ : (x y : A) (t : T (x + y)) (w₁ : A) (w₂ : T w₁) → T w₁
     f-aux₄ x y t w₁ w₂ = {!!}
 
+    -- With-abstraction equality
+    g : (x : A) → T x
+    g x with mkT x in eq
+    g x | w = {!!}
+
+    g-aux : (x : A) (w : T x) → mkT x ≡ w → T x
+    g-aux x w eq = {!!}
+
+    -- The equality argument is generalised over by further with-abstractions
+    g₁ : (x : A) → P x (g x)
+    g₁ x with mkT x in eq
+    g₁ x | w = {!!}
+
+    g-aux₁ : (x : A) (w : T x) (eq : mkT x ≡ w) → P x (g-aux x w eq)
+    g-aux₁ x w eq = {!!}
+
 ..
   ::
   module ill-typed where

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -206,7 +206,7 @@ abstractTerm a u@Con{} b v = do
   -- abstracting the second component). In this case we skip abstraction
   -- altogether and let the type check of the final with-function type produce
   -- the error message.
-  res <- catchError_ (checkInternal' (defaultAction { preAction = abstr }) v CmpLeq b) $ \ err -> do
+  res <- catchError_ (withFrozenMetas $ checkInternal' (defaultAction { preAction = abstr }) v CmpLeq b) $ \ err -> do
         reportSDoc "tc.abstract.ill-typed" 40 $
           "Skipping typed abstraction over ill-typed term" <?> (prettyTCM v <?> (":" <+> prettyTCM b))
         return v

--- a/test/Fail/WithAbstractionFreezeMetas.agda
+++ b/test/Fail/WithAbstractionFreezeMetas.agda
@@ -1,0 +1,15 @@
+open import Agda.Builtin.Equality
+
+data ⊤ : Set where
+  tt : ⊤
+
+postulate u : ⊤
+
+-- Solving metas during the type-based abstraction check causes ?0 to
+-- be solved as u, which is not unique (and incidentally results in an
+-- ill-typed `with` function because we do not instantiate the type containing
+-- this meta before abstracting over u).
+-- Instead ?0 should remain unsolved.
+h : _≡_ {A = u ≡ u} refl refl
+h with u | refl {x = {!!}}
+h | tt | e = refl

--- a/test/Fail/WithAbstractionFreezeMetas.err
+++ b/test/Fail/WithAbstractionFreezeMetas.err
@@ -1,0 +1,7 @@
+WithAbstractionFreezeMetas.agda:14.12-16: error: [UnsolvedMetaVariables]
+Unsolved metas at the following locations:
+  WithAbstractionFreezeMetas.agda:14.12-16
+
+WithAbstractionFreezeMetas.agda:14.22-26: error: [UnsolvedInteractionMetas]
+Unsolved interaction metas at the following locations:
+  WithAbstractionFreezeMetas.agda:14.22-26

--- a/test/Succeed/Issue8312.agda
+++ b/test/Succeed/Issue8312.agda
@@ -1,0 +1,18 @@
+open import Agda.Builtin.Equality
+
+data ⊤ : Set where
+  tt : ⊤
+
+postulate u : ⊤
+
+f : Set
+f with u in e
+f | tt = ⊤
+
+-- The `refl` in `f | u | refl` should get generalised over, but neither
+-- of the other `refl`s should. Generalising too much or too little results
+-- in an ill-typed `with` function.
+
+f' : _≡_ {A = u ≡ u} refl refl → f ≡ ⊤
+f' _ with u in e
+f' _ | tt = refl


### PR DESCRIPTION
Fixes https://github.com/agda/agda/issues/5833 (and its duplicate https://github.com/agda/agda/issues/8312) by generalising over `refl` in with-abstraction equality. This is a bit subtle: we only want to generalise over those `refl`s that have type `v ≡ w` after generalising `v` as `w`, which we do by slightly abusing type-based abstraction (see comments).

Also fixes a bug I found while investigating this: type-based abstraction should not solve metas as that leads to non-unique solutions (and confusing errors).

Also also includes a trivial refactor of an unrelated piece of code.

Does this need a changelog entry?

Closes #8312.