### PR TITLE
Add an EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{hs,py,el}]
+indent_style = space
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
See https://editorconfig.org/.  We touched on this in https://github.com/agda/agda/pull/8181?notification_referrer_id=NT_kwHOAGE0c9oAJFJlcG9zaXRvcnk7NDA0MTE0NzE7SXNzdWU7MzU3ODE3MjUyMw&notifications_query=is%3Aunread#issuecomment-3765442554.

I think that the suggestions are reasonable and self-explanatory.

Regarding @jespercockx comment from the issue I linked to above:

> The main question would be whether we can also integrate it into CI.

I don't think that is the primary goal, for now this would help prevent spacing issues on the client site, as many editors respect the `.editorconfig` file without any additional configuration.  With this change installed, it will become less likely for a contributor to have to force-push an update to their PRs fixing spacing issues due to their local configuration.

That being said, the EditorConfig Wiki mentions a few approaches to integrating this with a CI system: https://github.com/editorconfig/editorconfig/wiki/FAQ#are-there-any-tools-to-check-orand-reformat-existing-files-against-editorconfig-rules.