### PR TITLE
Fix #8327: check early for record constructor in let-pattern

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -299,8 +299,8 @@ instance PrettyTCM TypeError where
     ShouldBeRecordType t -> fsep $
       pwords "Expected non-abstract record type, found " ++ [prettyTCM t]
 
-    ShouldBeRecordPattern p -> fsep $
-      pwords "Expected record pattern" -- ", found " ++ [prettyTCM p]
+    ShouldBeRecordPattern -> fsep $
+      pwords "Expected record pattern"
 
     WrongHidingInLHS -> fwords "Unexpected implicit argument"
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5243,7 +5243,7 @@ data TypeError
             -- ^ The given type should have been a pi.
         | ShouldBePath Type
         | ShouldBeRecordType Type
-        | ShouldBeRecordPattern DeBruijnPattern
+        | ShouldBeRecordPattern
         | CannotApply A.Expr Type
             -- ^ The given expression is used as a function
             --   but its type is not a function type.

--- a/src/full/Agda/TypeChecking/Rules/Def.hs
+++ b/src/full/Agda/TypeChecking/Rules/Def.hs
@@ -59,7 +59,7 @@ import Agda.TypeChecking.RecordPatterns ( recordRHSToCopatterns )
 import Agda.TypeChecking.Sort
 
 import Agda.TypeChecking.Rules.Term
-import Agda.TypeChecking.Rules.LHS                 ( checkLeftHandSide, LHSResult(..), bindAsPatterns )
+import Agda.TypeChecking.Rules.LHS                 ( checkLeftHandSide, LHSResult(..), bindAsPatterns, LetOrClause(ClauseLHS) )
 import {-# SOURCE #-} Agda.TypeChecking.Rules.Decl ( checkDecls )
 
 import Agda.Utils.Function ( applyWhen, applyWhenM )
@@ -702,7 +702,7 @@ checkClauseLHS t withSub c@(A.Clause lhs@(A.SpineLHS i x aps) strippedPats _rhs0
       unless (null strippedPats) $ reportSDoc "tc.lhs.top" 50 $
         "strippedPats:" <+> vcat [ prettyA p <+> "=" <+> prettyTCM v <+> ":" <+> prettyTCM a | A.ProblemEq p v a <- strippedPats ]
       closed_t <- flip abstract t <$> getContextTelescope
-      checkLeftHandSide (CheckLHS lhs) (getRange lhs) (Just x) aps t withSub strippedPats ret
+      checkLeftHandSide (CheckLHS lhs) (getRange lhs) (ClauseLHS x) aps t withSub strippedPats ret
 
 -- | Type check a function clause.
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1947,7 +1947,7 @@ checkLetBinding' b@(A.LetPatBind i ai p e) ret = do
         ]
       ]
     fvs <- getContextSize
-    checkLeftHandSide (CheckPattern p EmptyTel t) noRange Nothing [p0] t0 Nothing [] $ \ (LHSResult _ delta0 ps _ _t _ asb _ _) -> bindAsPatterns asb $ do
+    checkLeftHandSide (CheckPattern p EmptyTel t) noRange LetLHS [p0] t0 Nothing [] $ \ (LHSResult _ delta0 ps _ _t _ asb _ _) -> bindAsPatterns asb $ do
           -- After dropping the free variable patterns there should be a single pattern left.
       let p = case drop fvs ps of [p] -> namedArg p; _ -> __IMPOSSIBLE__
           -- Also strip the context variables from the telescope

--- a/test/Fail/Issue4775.agda
+++ b/test/Fail/Issue4775.agda
@@ -25,3 +25,8 @@ test = λ (y1 , isSuc y2) → Nat
 -- Expected record pattern
 -- when checking that the expression λ (y1 , isSuc y2) → Nat has type
 -- Σ Nat IsSuc → Set
+
+-- As of 2026-01-20: More precise location.
+-- error: [ShouldBeRecordPattern]
+-- Expected record pattern
+-- when checking that the pattern isSuc y2 has type IsSuc y1

--- a/test/Fail/Issue4775.err
+++ b/test/Fail/Issue4775.err
@@ -1,4 +1,3 @@
-Issue4775.agda:16.8-31: error: [ShouldBeRecordPattern]
+Issue4775.agda:16.16-24: error: [ShouldBeRecordPattern]
 Expected record pattern
-when checking that the expression λ (y1 , isSuc y2) → Nat has type
-Σ Nat IsSuc → Set
+when checking that the pattern isSuc y2 has type IsSuc y1

--- a/test/Fail/Issue779pattern.agda
+++ b/test/Fail/Issue779pattern.agda
@@ -12,3 +12,8 @@ record R : Set1 where
 
 -- Expected:
 -- Success, or error outlawing pattern matching definition before last field.
+
+-- As of 2026-01-20:
+-- error: [ShouldBeRecordPattern]
+-- Expected record pattern
+-- when checking that the pattern c has type D

--- a/test/Fail/Issue779pattern.err
+++ b/test/Fail/Issue779pattern.err
@@ -1,3 +1,3 @@
-Issue779pattern.agda:7.7-12: error: [ShouldBeRecordPattern]
+Issue779pattern.agda:7.7-8: error: [ShouldBeRecordPattern]
 Expected record pattern
-when checking that the expression λ (c) → c has type D → D
+when checking that the pattern c has type D

--- a/test/Fail/LetPair.agda
+++ b/test/Fail/LetPair.agda
@@ -16,3 +16,7 @@ swap : {A B : Set} → A × B → B × A
 swap p =
   let (a , b) = p  -- works only for record patterns
   in  (b , a)
+
+-- 2026-01-20 error: [ShouldBeRecordPattern]
+-- Expected record pattern
+-- when checking that the pattern a , b has type A × B

--- a/test/Fail/LetPair.err
+++ b/test/Fail/LetPair.err
@@ -1,3 +1,3 @@
-LetPair.agda:17.7-18: error: [ShouldBeRecordPattern]
+LetPair.agda:17.8-13: error: [ShouldBeRecordPattern]
 Expected record pattern
-when checking the let binding a , b = p
+when checking that the pattern a , b has type A × B


### PR DESCRIPTION
Now we check during `checkLeftHandSide` already if we have a eta-record-constructor when processing let-pattern bindings.
This improves error-reporting.

Closes #8327.
