### PR TITLE
Fix #8326: handle the implication two-level <= cubical in isTwoLevelEnabled

### DIFF
--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -1146,7 +1146,9 @@ cubicalFlag variant o =
   { _optCubical                 = Just variant
   , _optCubicalCompatible       = setDefault True  $ _optCubicalCompatible o
   , _optWithoutK                = setDefault True  $ _optWithoutK o
-  , _optTwoLevel                = setDefault True  $ _optTwoLevel o
+  -- Andreas, 2026-01-20, issue #8326
+  -- Do not set optTwoLevel here, but have been implied by optCubical
+  -- , _optTwoLevel                = setDefault True  $ _optTwoLevel o
   , _optFlatSplit               = setDefault False $ _optFlatSplit o
   , _optErasedMatches           = setDefault False $ _optErasedMatches o
   }

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -69,6 +69,7 @@ import Agda.Syntax.TopLevelModuleName
 import qualified Agda.TypeChecking.Monad.Base.Warning as W
 import Agda.TypeChecking.Monad.Base hiding (ModuleInfo, MetaInfo)
 import Agda.TypeChecking.Monad.Builtin
+import Agda.TypeChecking.Monad.Options (isTwoLevelEnabled, isPropEnabled)
 import Agda.TypeChecking.Monad.Trace (traceCall, setCurrentRange)
 import Agda.TypeChecking.Monad.State hiding (topLevelModuleName)
 import qualified Agda.TypeChecking.Monad.State as S (topLevelModuleName)
@@ -1583,8 +1584,8 @@ instance ToAbstract (TopLevel [C.Declaration]) where
 importPrimitives :: ScopeM [A.Declaration]
 importPrimitives = do
   ifNotM (optImportSorts <$> pragmaOptions) (return []) {- else -} do
-    prop     <- optProp     <$> pragmaOptions
-    twoLevel <- optTwoLevel <$> pragmaOptions
+    prop     <- isPropEnabled
+    twoLevel <- isTwoLevelEnabled
     -- Add implicit `open import Agda.Primitive using (Prop; Set; SSet)`
     let agdaPrimitiveName   = Qual (C.simpleName "Agda") $ C.QName $ C.simpleName "Primitive"
         usingDirective      = map (ImportedName . C.simpleName) $ concat

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -1,7 +1,7 @@
 
 module Agda.TypeChecking.Monad.Options where
 
-import Prelude hiding (null)
+import Prelude hiding (null, (||), not)
 
 import Control.Monad          ( unless, when )
 import Control.Monad.IO.Class ( MonadIO(..) )
@@ -36,12 +36,14 @@ import qualified Agda.Interaction.Options.Lenses as Lens
 import Agda.Interaction.Library
 import Agda.Interaction.Library.Base (LibCache(LibCache), libAbove, libFile, runLibM)
 
+import Agda.Utils.Boolean
 import Agda.Utils.FileName
 import qualified Agda.Utils.Graph.AdjacencyMap.Unidirectional as G
 import Agda.Utils.Lens
 import Agda.Utils.List
 import Agda.Utils.List1 (List1)
 import qualified Agda.Utils.List1 as List1
+import Agda.Utils.Maybe (isJust)
 import Agda.Utils.Null
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.Size
@@ -415,7 +417,7 @@ isLevelUniverseEnabled :: HasOptions m => m Bool
 isLevelUniverseEnabled = optLevelUniverse <$> pragmaOptions
 
 isTwoLevelEnabled :: HasOptions m => m Bool
-isTwoLevelEnabled = optTwoLevel <$> pragmaOptions
+isTwoLevelEnabled = (optTwoLevel || (isJust . optCubical)) <$> pragmaOptions
 
 {-# SPECIALIZE hasUniversePolymorphism :: TCM Bool #-}
 hasUniversePolymorphism :: HasOptions m => m Bool
@@ -425,7 +427,7 @@ showImplicitArguments :: HasOptions m => m Bool
 showImplicitArguments = optShowImplicit <$> pragmaOptions
 
 showGeneralizedArguments :: HasOptions m => m Bool
-showGeneralizedArguments = (\opt -> optShowGeneralized opt) <$> pragmaOptions
+showGeneralizedArguments = optShowGeneralized <$> pragmaOptions
 
 showIrrelevantArguments :: HasOptions m => m Bool
 showIrrelevantArguments = optShowIrrelevant <$> pragmaOptions

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20260114 * 10 + 0
+currentInterfaceVersion = 20260120 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64

--- a/test/Fail/Issue8326.agda
+++ b/test/Fail/Issue8326.agda
@@ -1,0 +1,13 @@
+-- Andreas, 2026-01-20, issue #8326 reported by Jesper
+-- InfectiveImport for --two-level is raised when imported module has --cubical
+-- because it is implied by --cubical.
+-- However, we want to see only warnings for the original options.
+
+import Agda.Builtin.Cubical.Glue
+
+-- Expected error: [InfectiveImport]
+-- Importing module Agda.Builtin.Cubical.Glue using the
+-- --cubical[={full,erased,no-glue}] flag from a module which does
+-- not.
+-- when scope checking the declaration
+--   import Agda.Builtin.Cubical.Glue

--- a/test/Fail/Issue8326.err
+++ b/test/Fail/Issue8326.err
@@ -1,0 +1,6 @@
+Issue8326.agda:6.1-33: error: [InfectiveImport]
+Importing module Agda.Builtin.Cubical.Glue using the
+--cubical[={full,erased,no-glue}] flag from a module which does
+not.
+when scope checking the declaration
+  import Agda.Builtin.Cubical.Glue

--- a/test/Fail/Issue8327.agda
+++ b/test/Fail/Issue8327.agda
@@ -1,0 +1,26 @@
+-- Andreas, 2026-01-20, issue #8327, reported and test case by Constantine Theocharis
+-- Pattern-matching definitions inbetween fields of a record declaration
+-- may only contain record patterns, so we expect errors to that extend.
+-- In the present case, SplitInProp was raised, however.
+-- This was due to the fact that the LHS checker ran before the check that
+-- the patterns are actually record patterns.
+
+{-# OPTIONS --prop #-}
+
+-- {-# OPTIONS -v tc.prop:80 #-}
+-- {-# OPTIONS -v tc.term.let.pattern:10 #-}
+-- {-# OPTIONS -v tc.lhs:30 #-}
+
+data _≡_ {ℓ} {A : Set ℓ} (x : A) : A → Prop ℓ where
+   refl : x ≡ x
+
+record Foo (A : Set) : Set where
+  field
+    bar : A → A
+
+  baz : (a : A) → a ≡ a → bar a ≡ bar a
+  baz a refl = refl
+     -- ^ Error was: [SplitInProp] Cannot split on datatype in Prop unless target is in Prop
+     --   Expected error: [ShouldBeRecordPattern] Expected record pattern
+  field
+    bar' : A

--- a/test/Fail/Issue8327.err
+++ b/test/Fail/Issue8327.err
@@ -1,0 +1,3 @@
+Issue8327.agda:22.9-13: error: [ShouldBeRecordPattern]
+Expected record pattern
+when checking that the pattern refl has type a ≡ a


### PR DESCRIPTION
Previously we would manipulate `_optTwoLevel` when `_optCubical` is set but this loses the provenance.

Closes #8326.
