### PR TITLE
Add link to "Let's play Agda" to user manual

### DIFF
--- a/doc/user-manual/getting-started/tutorial-list.rst
+++ b/doc/user-manual/getting-started/tutorial-list.rst
@@ -12,12 +12,12 @@ A List of Tutorials
 Books on Agda
 =============
 
+- Sandy Maguire (2023). `Certainty by Construction
+  <https://leanpub.com/certainty-by-construction>`__
 - Phil Wadler, Wen Kokke, and Jeremy G. Siek (2019). `Programming
   Languages Foundations in Agda <https://plfa.github.io/>`__
 - Aaron Stump (2016). `Verified Functional Programming in Agda
   <https://dl.acm.org/doi/book/10.1145/2841316>`__
-- Sandy Maguire (2023). `Certainty by Construction
-  <https://leanpub.com/certainty-by-construction>`__
 
 Tutorials and lecture notes
 ===========================

--- a/doc/user-manual/getting-started/tutorial-list.rst
+++ b/doc/user-manual/getting-started/tutorial-list.rst
@@ -22,6 +22,7 @@ Books on Agda
 Tutorials and lecture notes
 ===========================
 
+- Ingo Blechschmidt (2025). `Let's Play Agda <https://lets-play-agda.quasicoherent.io/>`__
 - Martín Escardó and Dan Licata (2022). `Lecture notes for the HoTTEST Summer School <https://martinescardo.github.io/HoTTEST-Summer-School/>`__.
 - Danel Ahman and Andrej Bauer (2021). `Logic in Computer Science <https://www.andrej.com/zapiski/ISRM-LOGRAC-2022/>`__.
 - Jesper Cockx (2021). `Programming and Proving in Agda


### PR DESCRIPTION
I recently discovered the existence of the Let's Play Agda tutorial by @iblech . It's not just a tutorial but it also integrates interactive exercises in the browser (I believe it is using the Agda Pad?) It definitely deserves a prime spot on the list of tutorials! 

Perhaps with some more work we could also port our current introduction "A Taste of Agda" to use the same framework so newcomers can try out Agda themselves easily without installing. However, this would probably not work on our current ReadTheDocs website.