### PR TITLE
#8337: Look for instance fields in eta records under binders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,6 +283,13 @@ Changes to type checker and other components defining the Agda language.
   is correctly generalised over. This should make most (if not all) uses of the
   old-style `inspect` idioms for the built-in equality type unnecessary.
 
+* Instance search now finds instance fields in functions that produce eta
+  records. For example, if a local variable `G : X → Group` is in scope
+  and `Group` is an eta record with a field `Carrier : Set` and an instance
+  field `⦃ mul ⦄ : Mul Carrier`, then `λ {x} → mul (G x)` will be a candidate
+  of type `{x : X} -> Mul (Carrier G)`. See also
+  [Issue #8337](https://github.com/agda/agda/issues/8337).
+
 
 Reflection
 ----------

--- a/doc/user-manual/language/instance-arguments.lagda.rst
+++ b/doc/user-manual/language/instance-arguments.lagda.rst
@@ -679,6 +679,14 @@ Find candidates
   a local variable is eta-expandable (e.g., its type is a metavariable),
   instance search will not run.
 
+  This also applies to local variables that are a function producing an
+  eta record, in which case the instance fields are extracting with
+  visible arguments marked implicit. For example, if a local variable
+  ``G : X → Group`` is in scope and ``Group`` is an eta record with a
+  field ``Carrier : Set`` and an instance field
+  ``⦃ mul ⦄ : Mul Carrier``, then ``λ {x} → mul (G x)`` will be a
+  candidate of type ``{x : X} -> Mul (Carrier G)``.
+
   Only candidates of type ``{Δ} → C us``, where ``C`` is the target type
   computed in the previous stage, and ``{Δ}`` only contains implicit or
   instance arguments, are considered.

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -174,8 +174,10 @@ initialInstanceCandidates blockOverlap instTy = do
     instanceFields' :: Bool -> (CandidateKind,Term,Type) -> BlockT TCM [Candidate]
     instanceFields' etaOnce (q, v, t) =
       ifBlocked t (\ m _ -> patternViolation m) $ \ _ t -> do
-      caseMaybeM (etaExpand etaOnce t) (return []) $ \ (r, pars) -> do
-        (tel, args) <- lift $ forceEtaExpandRecord r pars v
+      (implArgs, t') <- lift $ implicitArgs (-1) hidden t
+      let v' = v `apply` implArgs
+      caseMaybeM (etaExpand etaOnce t') (return []) $ \ (r, pars) -> do
+        (tel, args) <- lift $ forceEtaExpandRecord r pars v'
         let types = map unDom $ applySubst (parallelS $ reverse $ map unArg args) (flattenTel tel)
         fmap concat $ forM (zip args types) $ \ (arg, t) ->
           ([ Candidate LocalCandidate (unArg arg) t (infoOverlapMode arg)

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -177,7 +177,7 @@ initialInstanceCandidates blockOverlap instTy = do
       TelV piTel t' <- lift $ telView t
       let
         n = size piTel
-        hiddenPiTel = fmap (setHiding Hidden) piTel
+        hiddenPiTel = fmap (mapHiding \case { NotHidden -> Hidden ; x -> x }) piTel
       addContext piTel $ caseMaybeM (etaExpand etaOnce t') (return []) $ \ (r, pars) -> do
         let v' = raise n v `apply` teleArgs piTel
         (tel, args) <- lift $ forceEtaExpandRecord r pars v'

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -172,9 +172,9 @@ initialInstanceCandidates blockOverlap instTy = do
     instanceFields = instanceFields' True
 
     instanceFields' :: Bool -> (CandidateKind,Term,Type) -> BlockT TCM [Candidate]
-    instanceFields' etaOnce (q, v, t) =
-      ifBlocked t (\ m _ -> patternViolation m) $ \ _ t -> do
+    instanceFields' etaOnce (q, v, t) = do
       TelV piTel t' <- lift $ telView t
+      ifBlocked t' (\ m _ -> patternViolation m) $ \ _ t' -> do
       let
         n = size piTel
         hiddenPiTel = fmap (mapHiding \case { NotHidden -> Hidden ; x -> x }) piTel

--- a/test/Fail/Issue1952.err
+++ b/test/Fail/Issue1952.err
@@ -59,113 +59,59 @@ Failed to solve the following constraints:
     C : Structure
     (stuck)
       [ at Issue1952.agda:29.25-26 ]
-  Resolve instance argument _r_68 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_68 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:31.31-32 ]
-  Resolve instance argument _r_67 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_67 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:31.41-42 ]
-  Resolve instance argument _r_75 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_75 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:31.49-50 ]
-  Resolve instance argument _r_95 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_95 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.44-47 ]
-  Resolve instance argument _r_89 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_89 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.58-59 ]
-  Resolve instance argument _r_86 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_86 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.103-104 ]
-  Resolve instance argument _r_102 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_102 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.66-67 ]
-  Resolve instance argument _r_114 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_114 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.75-76 ]
-  Resolve instance argument _r_110 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_110 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.97-98 ]
-  Resolve instance argument _r_130 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_130 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.78-80 ]
-  Resolve instance argument _r_126 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_126 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.81-82 ]
-  Resolve instance argument _r_122 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_122 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.86-87 ]
-  Resolve instance argument _r_135 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_135 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.83-85 ]
-  Resolve instance argument _r_146 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_146 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.88-90 ]
-  Resolve instance argument _r_142 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_142 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.91-92 ]
-  Resolve instance argument _r_151 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_151 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.93-95 ]
-  Resolve instance argument _r_162 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_162 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.99-101 ]
-  Resolve instance argument _r_173 : Structure
-  Candidates
-    D : Structure
-    C : Structure
-    (stuck)
+  Resolve instance argument _r_173 : Structure No candidates yet
+    (blocked on _r_57)
       [ at Issue1952.agda:33.105-108 ]
   (_r_173 Structure.⟶
    (_r_173 Structure.× (_r_173 Structure.× _X_174) _X_174) _X_174)

--- a/test/Fail/Issue8337.agda
+++ b/test/Fail/Issue8337.agda
@@ -13,5 +13,5 @@ postulate
   A : Set
   instance i : Funlike Fn (A → A) (λ _ → Set)
 
-ex : Set
-ex = (x : _ → _) → fn · x
+FailsBecauseThereCouldBeAnInstanceAtTheEndOfTheTelescope : Set
+FailsBecauseThereCouldBeAnInstanceAtTheEndOfTheTelescope = (x : _ → _) → fn · x

--- a/test/Fail/Issue8337.agda
+++ b/test/Fail/Issue8337.agda
@@ -1,0 +1,17 @@
+module Issue8337 where
+
+record Funlike {ℓ} (A : Set) (arg : Set) (out : arg → Set ℓ) : Set ℓ where
+  field
+    _·_ : A → (x : arg) → out x
+  infixl 999 _·_
+
+open Funlike ⦃ ... ⦄ using (_·_) public
+
+postulate
+  Fn : Set
+  fn : Fn
+  A : Set
+  instance i : Funlike Fn (A → A) (λ _ → Set)
+
+ex : Set
+ex = (x : _ → _) → fn · x

--- a/test/Fail/Issue8337.err
+++ b/test/Fail/Issue8337.err
@@ -1,0 +1,13 @@
+Issue8337.agda:17.11-24: error: [UnsolvedMetaVariables]
+Unsolved metas at the following locations:
+  Issue8337.agda:17.11-12
+  Issue8337.agda:17.15-16
+  Issue8337.agda:17.23-24
+
+Issue8337.agda:17.23-24: error: [UnsolvedConstraints]
+Failed to solve the following constraints:
+  Resolve instance argument
+    _r_20 : Funlike Fn (_12 → _14) (λ v → Set)
+  No candidates yet
+    (blocked on _14)
+      [ at Issue8337.agda:17.23-24 ]

--- a/test/Fail/Issue8337.err
+++ b/test/Fail/Issue8337.err
@@ -1,13 +1,13 @@
-Issue8337.agda:17.11-24: error: [UnsolvedMetaVariables]
+Issue8337.agda:17.65-78: error: [UnsolvedMetaVariables]
 Unsolved metas at the following locations:
-  Issue8337.agda:17.11-12
-  Issue8337.agda:17.15-16
-  Issue8337.agda:17.23-24
+  Issue8337.agda:17.65-66
+  Issue8337.agda:17.69-70
+  Issue8337.agda:17.77-78
 
-Issue8337.agda:17.23-24: error: [UnsolvedConstraints]
+Issue8337.agda:17.77-78: error: [UnsolvedConstraints]
 Failed to solve the following constraints:
   Resolve instance argument
     _r_20 : Funlike Fn (_12 → _14) (λ v → Set)
   No candidates yet
     (blocked on _14)
-      [ at Issue8337.agda:17.23-24 ]
+      [ at Issue8337.agda:17.77-78 ]

--- a/test/Succeed/Issue8337.agda
+++ b/test/Succeed/Issue8337.agda
@@ -65,21 +65,3 @@ module SlightlyPracticalCase where
 
     left-assoc : (M : Semimonoid) (x y z : M .carrier) → (x * (y * z)) ≡ ((x * y) * z)
     left-assoc M x y z = ÷ (right-assoc M x y z)
-
-module InstanceFieldsAreNotSearchedForIfTheThingAtTheEndOfTheTelescopeIsBlocked where
-
-    record Funlike {ℓ} (A : Set) (arg : Set) (out : arg → Set ℓ) : Set ℓ where
-      field
-        _·_ : A → (x : arg) → out x
-      infixl 999 _·_
-
-    open Funlike ⦃ ... ⦄ using (_·_) public
-
-    postulate
-      Fn : Set
-      fn : Fn
-      A : Set
-      instance i : Funlike Fn (A → A) (λ _ → Set)
-
-    ex : Set
-    ex = (x : _ → _) → fn · x

--- a/test/Succeed/Issue8337.agda
+++ b/test/Succeed/Issue8337.agda
@@ -38,6 +38,11 @@ module InstanceFieldUnderExplicit
   test : ∀ x → F x
   test x = inner
 
+module InstanceFieldUnderExplicitAndInstance
+    (X : Set) (Y : Set) {{_ : Inner Y}} (F : X → Set) (G : (x : X) → {{Inner Y}} -> Outer (F x)) where
+  test : ∀ x → F x
+  test x = inner
+
 module SlightlyPracticalCase where
 
     data _≡_ {A : Set} (a : A) : A -> Set where

--- a/test/Succeed/Issue8337.agda
+++ b/test/Succeed/Issue8337.agda
@@ -65,3 +65,21 @@ module SlightlyPracticalCase where
 
     left-assoc : (M : Semimonoid) (x y z : M .carrier) → (x * (y * z)) ≡ ((x * y) * z)
     left-assoc M x y z = ÷ (right-assoc M x y z)
+
+module InstanceFieldsAreNotSearchedForIfTheThingAtTheEndOfTheTelescopeIsBlocked where
+
+    record Funlike {ℓ} (A : Set) (arg : Set) (out : arg → Set ℓ) : Set ℓ where
+      field
+        _·_ : A → (x : arg) → out x
+      infixl 999 _·_
+
+    open Funlike ⦃ ... ⦄ using (_·_) public
+
+    postulate
+      Fn : Set
+      fn : Fn
+      A : Set
+      instance i : Funlike Fn (A → A) (λ _ → Set)
+
+    ex : Set
+    ex = (x : _ → _) → fn · x

--- a/test/Succeed/Issue8337.agda
+++ b/test/Succeed/Issue8337.agda
@@ -1,0 +1,62 @@
+module Issue8337 where
+
+record Inner (A : Set) : Set where
+  field inner : A
+open Inner {{...}}
+
+record Outer (A : Set) : Set where
+  field {{outer}} : Inner A
+open Outer {{...}}
+
+module InstanceFieldUnderImplicit
+    (I : Set) (F : I → Set) {{o : ∀ {i} → Outer (F i)}} where
+  test : ∀ {i} → F i
+  test = inner
+
+module InstanceFieldUnderInstance
+    (I : Set) (F : I → Set) {{o : ∀ {{i : I}} → Outer (F i)}} where
+  test : {{i : I}} → F i
+  test = inner
+
+module InstanceFieldUnderTwoImplicits
+    (I : Set) (J : Set) (F : I → J → Set)
+    {{o : ∀ {i} {j} → Outer (F i j)}} where
+  test : ∀ {i} {j} → F i j
+  test = inner
+
+record MoreOuter (A : Set) : Set where
+  field {{moreOuter}} : Outer A
+open MoreOuter {{...}}
+
+module InstanceFieldOfInstanceFieldUnderImplicit
+    (I : Set) (F : I → Set) {{m : ∀ {i} → MoreOuter (F i)}} where
+  test : ∀ {i} → F i
+  test = inner
+
+module InstanceFieldUnderExplicit
+    (X : Set) (F : X → Set) (G : (x : X) → Outer (F x)) where
+  test : ∀ x → F x
+  test x = inner
+
+module SlightlyPracticalCase where
+
+    data _≡_ {A : Set} (a : A) : A -> Set where
+        refl : a ≡ a
+
+    ÷_ : ∀ {A : Set} {a1 a2 : A} -> (a1 ≡ a2) -> (a2 ≡ a1)
+    ÷ refl = refl
+
+    record Mul (A : Set) : Set where
+      field
+        _*_ : A → A → A
+    open Mul ⦃ ... ⦄
+
+    record Semimonoid : Set₁ where
+      field
+        carrier : Set
+        ⦃ g ⦄   : Mul carrier
+        right-assoc : ∀ (x y z : carrier) -> ((x * y) * z) ≡ (x * (y * z))
+    open Semimonoid
+
+    left-assoc : (M : Semimonoid) (x y z : M .carrier) → (x * (y * z)) ≡ ((x * y) * z)
+    left-assoc M x y z = ÷ (right-assoc M x y z)


### PR DESCRIPTION
The intent of this change is to upgrade instance search as follows: When the context contains an instance argument that is a function where all arguments are implicit and where the result is a record, that record is opened so that its implicit fields are available. See #8337.

This change does _not_ handle the case where the context contains an instance argument that is a function where all arguments are _hidden_ (which is to say, it does not handle instance arguments in the telescope). It probably should handle that case, but the easy change (changing `hidden` to `notVisible` on line 177) caused a loop, presumably because it triggered instance search during instance search. I might poke at it a little more but I'm not sure I have enough understanding of the control flow to make it work.

Caveat: I tried a superficial obvious thing and it worked for me on the first try but I don't actually claim to understand the code very much.