### PR TITLE
fix #8215: reduce candidate in its own state

### DIFF
--- a/test/Fail/Issue8215.agda
+++ b/test/Fail/Issue8215.agda
@@ -1,0 +1,31 @@
+module Issue8215 where
+
+postulate
+  T : Set
+  t : T
+
+record A (X : Set) : Set where
+  field
+    f : X
+
+open A {{...}}
+
+record B (X : Set) : Set where
+  field
+    instance a : A X
+    g : X
+
+open B {{...}}
+
+
+instance AT : A T
+AT = record {f = t}
+
+{-
+instance BT : B T
+BT = record {a = AT; g = t}
+-}
+
+-- Internal error here
+f′ : T
+f′ = f

--- a/test/Fail/Issue8215.err
+++ b/test/Fail/Issue8215.err
@@ -1,0 +1,12 @@
+Issue8215.agda:31.6-7: error: [UnsolvedConstraints]
+Failed to solve the following constraints:
+  Resolve instance argument _r_7 : A T
+  Candidates
+    a : {X : Set} ⦃ r : B X ⦄ → A X
+    AT : A T
+    (stuck)
+      [ at Issue8215.agda:31.6-7 ]
+
+Issue8215.agda:31.6-7: error: [UnsolvedMetaVariables]
+Unsolved metas at the following locations:
+  Issue8215.agda:31.6-7


### PR DESCRIPTION
The issue #8215 is a new outcrop of #4688 née #4687, where we have to preserve the questionable behaviour of trying to merge definitionally-equal candidates even though the candidates may (appear to) contain references to fresh metavariables *from distinct TC states* — and trying to remove those which are only "superficial" means that we might have to run reduction while *blocking* on those metavariables.

While actual impl. of `fastReduce` is perfectly happy to do this, the wrapper `maybeFastReduce` calls `lookupMetaInstantiation` to decide whether to run the abstract machine or simply return a blocked value, but `lookupMetaInstantiation` explodes if we're not in the right state to know that meta exists. Regardless that `fastReduce` would succeed, things like `instantiateFull` would not, so this fixes #8215 by reducing the "head" candidate in its own state before checking whether it still depends on any metas that we're speculating about.

The reason the instance field variant of the reproducer in #8215 fails while the top-level definition variant succeeds is whether we're trying to reduce `_16 .a` (where `_16` is the unsolved meta, which is in the head position, causing the fast-reduce wrapper to explode) vs. trying to reduce `someDef ⦃ _16 ⦄` (headed by a `Def`, so we call `fastReduce` which succeeds in blocking on the fresh meta).