### PR TITLE
[wasm] Turn off parallelism; fix CI

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -23,7 +23,17 @@ jobs:
       uses: styfle/cancel-workflow-action@0.13.0
       with:
         access_token: ${{ github.token }}
-    - uses: easimon/maximize-build-space@v10
+    - id: check-mnt
+      name: Check if /mnt is a mountpoint
+      run: |
+        echo "Running df:"
+        result=$(df)
+        echo "$result"
+        if echo "$result" | awk '{print $6}' | grep -q '/mnt'; then
+          echo "found=1" >> $GITHUB_OUTPUT
+        fi
+    - if: steps.check_mnt.outputs.found
+      uses: easimon/maximize-build-space@v10
       with:
         remove-android: true
         remove-codeql: true

--- a/Agda.cabal
+++ b/Agda.cabal
@@ -982,16 +982,18 @@ executable agda
   -- However, we sometimes recommend people to use +RTS to control
   -- Agda's memory usage, so we want this functionality enabled by
   -- default.
+  ghc-options:
+    -rtsopts
 
   -- The threaded RTS by default starts a major GC after a program has
   -- been idle for 0.3 s. This feature turned out to be annoying, so
   -- the idle GC is now by default turned off (-I0).
-  ghc-options:
-    -rtsopts
-    "-with-rtsopts=-I0 -N1"
-
   if !arch(wasm32)
-    ghc-options: -threaded
+    ghc-options:
+      -threaded
+      "-with-rtsopts=-I0 -N1"
+  else
+    ghc-options: -with-rtsopts=-I0
 
 -- agda-mode executable
 ---------------------------------------------------------------------------

--- a/src/github/workflows/wasm.yml
+++ b/src/github/workflows/wasm.yml
@@ -75,7 +75,18 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
+    - name: Check if /mnt is a mountpoint
+      id: check-mnt
+      run: |
+        echo "Running df:"
+        result=$(df)
+        echo "$result"
+        if echo "$result" | awk '{print $6}' | grep -q '/mnt'; then
+          echo "found=1" >> $GITHUB_OUTPUT
+        fi
+
     - uses: easimon/maximize-build-space@v10
+      if: steps.check_mnt.outputs.found
       with:
         root-reserve-mb: 30000
         remove-dotnet: true


### PR DESCRIPTION
To fix CI failure builing the WASM module; see #8355.

Closes #8355.