### PR TITLE
Refactor: Remove redundant constraints

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -320,7 +320,7 @@ common language
       -Werror=overlapping-patterns
       -Werror=overlapping-patterns
       -Werror=redundant-bang-patterns
---      -Werror=redundant-constraints
+      -Werror=redundant-constraints
       -Werror=redundant-record-wildcards
       -Werror=simplifiable-class-constraints
       -Werror=star-binder

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -83,7 +83,7 @@ callBackendInteractHole name cmd ii rng s =
 -- | Run a monadic action given an existing backend.
 -- Throws an error if the user requested an unknown backend.
 withKnownBackend ::
-  (MonadTCError m, ReadTCState m) => BackendName -> (Backend -> m ()) -> m ()
+  (MonadTCError m) => BackendName -> (Backend -> m ()) -> m ()
 withKnownBackend name k = ifJustM (lookupBackend name) k $ do
   backends <- useTC stBackends
   let backendSet = otherBackends ++ [ backendName b | Backend b <- backends ]

--- a/src/full/Agda/Compiler/MAlonzo/Misc.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Misc.hs
@@ -113,7 +113,7 @@ class Monad m => ReadGHCModuleEnv m where
   askGHCModuleEnv :: m GHCModuleEnv
 
   default askGHCModuleEnv
-    :: (MonadTrans t, Monad n, m ~ (t n), ReadGHCModuleEnv n)
+    :: (MonadTrans t, m ~ (t n), ReadGHCModuleEnv n)
     => m GHCModuleEnv
   askGHCModuleEnv = lift askGHCModuleEnv
 

--- a/src/full/Agda/Interaction/Highlighting/Dot/Backend.hs
+++ b/src/full/Agda/Interaction/Highlighting/Dot/Backend.hs
@@ -217,7 +217,7 @@ postModuleDot cenv DotModuleEnv _main m _defs = do
     }
 
 postCompileDot
-  :: (MonadIO m, ReadTCState m)
+  :: (MonadIO m)
   => DotCompileEnv
   -> IsMain
   -> Map TopLevelModuleName DotModule

--- a/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/HTML/Base.hs
@@ -173,7 +173,7 @@ instance Monad m => MonadLogHtml (LogHtmlT m) where
     doLog <- ask
     lift $ doLog message
 
-runLogHtmlWith :: Monad m => HtmlLogAction m -> LogHtmlT m a -> m a
+runLogHtmlWith :: HtmlLogAction m -> LogHtmlT m a -> m a
 runLogHtmlWith = flip runReaderT
 
 renderSourceFile :: HtmlOptions -> HtmlInputSourceFile -> Text

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Base.hs
@@ -191,7 +191,7 @@ data Debug = MoveColumn | NonCode | Code | Spaces | Output | FileSystem
   deriving (Eq, Show)
 
 -- | Run function for the @LaTeX@ monad.
-runLaTeX :: MonadLogLaTeX m =>
+runLaTeX ::
   LaTeXT m a -> Env -> State -> m (a, State, [Output])
 runLaTeX = runRWST
 

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -1553,7 +1553,7 @@ createInterface mname sf@(SourceFile sfi) isMain msrc = do
 -- 'MainInterface', the warnings definitely include also unsolved
 -- warnings.
 
-getAllWarnings' :: (ReadTCState m, MonadWarning m, MonadTCM m) => MainInterface -> WhichWarnings -> m (Set TCWarning)
+getAllWarnings' :: (MonadWarning m, MonadTCM m) => MainInterface -> WhichWarnings -> m (Set TCWarning)
 getAllWarnings' MainInterface{}  = getAllWarningsPreserving unsolvedWarnings
 getAllWarnings' NotMainInterface = getAllWarningsPreserving Set.empty
 

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -542,7 +542,7 @@ verbalizeNotAValidLetExpression = \case
 deriving via (FiniteEnumeration (Maybe a))
   instance (Bounded a, Enum a) => Enum (Maybe a)
 deriving via (FiniteEnumeration (Maybe a))
-  instance (Bounded a, Enum a) => Bounded (Maybe a)
+  instance (Bounded a) => Bounded (Maybe a)
 
 instance NFData CannotQuoteTerm
 instance NFData ErasedDatatypeReason

--- a/src/full/Agda/Syntax/Abstract/Pattern.hs
+++ b/src/full/Agda/Syntax/Abstract/Pattern.hs
@@ -397,7 +397,7 @@ data LHSPatternView e
 --
 -- Return the view and the remaining patterns.
 
-lhsPatternView :: IsProjP e => NAPs e -> Maybe (LHSPatternView e, NAPs e)
+lhsPatternView :: NAPs e -> Maybe (LHSPatternView e, NAPs e)
 lhsPatternView [] = Nothing
 lhsPatternView (p0 : ps) =
   case namedArg p0 of
@@ -458,7 +458,7 @@ lhsCoreWith :: LHSCore' e -> List1 (Arg (Pattern' e)) -> LHSCore' e
 lhsCoreWith (LHSWith core wps []) wps' = LHSWith core (wps <> wps') []
 lhsCoreWith core                  wps' = LHSWith core wps' []
 
-lhsCoreAddChunk :: IsProjP e => LHSCore' e -> LHSPatternView e -> LHSCore' e
+lhsCoreAddChunk :: LHSCore' e -> LHSPatternView e -> LHSCore' e
 lhsCoreAddChunk core = \case
   LHSAppP ps               -> lhsCoreApp core $ List1.toList ps
   LHSWithP wps             -> lhsCoreWith core (defaultArg <$> wps)

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -146,7 +146,7 @@ type RecurseExprRecFn m = forall a. ExprLike a => a -> m a
 type FoldExprFn m a = Monoid m => (Expr -> m) -> a -> m
 type FoldExprRecFn m = forall a. ExprLike a => a -> m
 
-type TraverseExprFn m a = (Applicative m, Monad m) => (Expr -> m Expr) -> a -> m a
+type TraverseExprFn m a = (Monad m) => (Expr -> m Expr) -> a -> m a
 type TraverseExprRecFn m = forall a. ExprLike a => a -> m a
 
 -- | Apply an expression rewriting to every subexpression, inside-out.

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -411,7 +411,7 @@ instance ExprLike RHS where
       rec :: RecurseExprRecFn m
       rec e = recurseExpr f e
 
-instance (ExprLike qn, ExprLike nm, ExprLike p, ExprLike e) => ExprLike (RewriteEqn' qn nm p e) where
+instance (ExprLike qn, ExprLike p, ExprLike e) => ExprLike (RewriteEqn' qn nm p e) where
   recurseExpr f = \case
     Rewrite es    -> Rewrite <$> recurseExpr f es
     Invert qn pes -> Invert <$> recurseExpr f qn <*> recurseExpr f pes

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -3713,7 +3713,7 @@ data Renaming' n m = Renaming
 
 -- ** HasRange instances
 
-instance (HasRange a, HasRange b) => HasRange (ImportDirective' a b) where
+instance HasRange (ImportDirective' a b) where
   getRange = importDirRange
 
 instance (HasRange a, HasRange b) => HasRange (Using' a b) where
@@ -3954,7 +3954,7 @@ instance (Pretty nm, Pretty p, Pretty e) => Pretty (RewriteEqn' qn nm p e) where
           Nothing -> patexp
           Just nm -> pretty nm <+> ":" <+> patexp
 
-instance (HasRange qn, HasRange nm, HasRange p, HasRange e) => HasRange (RewriteEqn' qn nm p e) where
+instance (HasRange qn, HasRange p, HasRange e) => HasRange (RewriteEqn' qn nm p e) where
   getRange = \case
     Rewrite es    -> getRange es
     Invert qn pes -> getRange (qn, pes)

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -3623,7 +3623,7 @@ instance Null (ImportDirective' n m) where
     _ -> False
   empty = defaultImportDir
 
-instance (HasRange n, HasRange m) => Semigroup (ImportDirective' n m) where
+instance Semigroup (ImportDirective' n m) where
   i1 <> i2 = ImportDirective
     { importDirRange = fuseRange i1 i2
     , using          = using i1 <> using i2
@@ -3632,7 +3632,7 @@ instance (HasRange n, HasRange m) => Semigroup (ImportDirective' n m) where
     , publicOpen     = publicOpen i1 <|> publicOpen i2
     }
 
-instance (HasRange n, HasRange m) => Monoid (ImportDirective' n m) where
+instance Monoid (ImportDirective' n m) where
   mempty  = empty
   mappend = (<>)
 

--- a/src/full/Agda/Syntax/Common/Pretty.hs
+++ b/src/full/Agda/Syntax/Common/Pretty.hs
@@ -178,7 +178,7 @@ prettyInterval s e
         | otherwise = pretty el <> dot <> pretty ec
 
 instance Pretty a => Pretty (Interval' a) where
-  pretty :: Pretty a => Interval' a -> Doc
+  pretty :: Interval' a -> Doc
   pretty i@(Interval f s e) = applyUnlessNull (pretty f) (\ d -> ((d <> colon) <>)) (prettyInterval s e)
 
 instance Pretty a => Pretty (Range' a) where

--- a/src/full/Agda/Syntax/Concrete/Pattern.hs
+++ b/src/full/Agda/Syntax/Concrete/Pattern.hs
@@ -128,7 +128,7 @@ mapLhsOriginalPattern f lhs@LHS{ lhsOriginalPattern = p } =
   lhs { lhsOriginalPattern = f p }
 
 -- | Effectfully modify the 'Pattern' component in 'LHS'.
-mapLhsOriginalPatternM :: (Functor m, Applicative m) => (Pattern -> m Pattern) -> LHS -> m LHS
+mapLhsOriginalPatternM :: (Functor m) => (Pattern -> m Pattern) -> LHS -> m LHS
 mapLhsOriginalPatternM f lhs@LHS{ lhsOriginalPattern = p } = f p <&> \ p' ->
   lhs { lhsOriginalPattern = p' }
 
@@ -161,12 +161,12 @@ class CPatternLike p where
   foldrCPattern = foldMap . foldrCPattern
 
   -- | Traverse pattern with option of post-traversal modification.
-  traverseCPatternA :: (Applicative m, Functor m)
+  traverseCPatternA :: (Applicative m)
       => (Pattern -> m Pattern -> m Pattern)
          -- ^ Combine a pattern and the its recursively computed version.
       -> p -> m p
 
-  default traverseCPatternA :: (Traversable f, CPatternLike q, f q ~ p, Applicative m, Functor m)
+  default traverseCPatternA :: (Traversable f, CPatternLike q, f q ~ p, Applicative m)
       => (Pattern -> m Pattern -> m Pattern)
       -> p -> m p
   traverseCPatternA = traverse . traverseCPatternA

--- a/src/full/Agda/Syntax/Info.hs
+++ b/src/full/Agda/Syntax/Info.hs
@@ -205,7 +205,7 @@ instance HasRange (DefInfo' t) where
 instance SetRange (DefInfo' t) where
   setRange r i = i { defInfo = setRange r (defInfo i) }
 
-instance KillRange t => KillRange (DefInfo' t) where
+instance KillRange (DefInfo' t) where
   killRange i = i { defInfo   = killRange $ defInfo i,
                     defTactic = killRange $ defTactic i }
 

--- a/src/full/Agda/Syntax/Internal/Blockers.hs
+++ b/src/full/Agda/Syntax/Internal/Blockers.hs
@@ -194,7 +194,7 @@ instance Semigroup a => Semigroup (Blocked' t a) where
   NotBlocked{}   <> b@Blocked{}    = b
   NotBlocked x a <> NotBlocked y b = NotBlocked (x <> y) (a <> b)
 
-instance (Semigroup a, Monoid a) => Monoid (Blocked' t a) where
+instance (Monoid a) => Monoid (Blocked' t a) where
   mempty = notBlocked mempty
   mappend = (<>)
 

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -315,7 +315,7 @@ instance NamesIn RewriteRule where
     RewriteRule a b c d e f _ _ ->
       namesAndMetasIn' sg (a, b, c, d, e, f)
 
-instance (NamesIn a, NamesIn b) => NamesIn (HashMap a b) where
+instance (NamesIn b) => NamesIn (HashMap a b) where
   namesAndMetasIn' sg map = foldMap (namesAndMetasIn' sg) map
 
 instance NamesIn System where

--- a/src/full/Agda/Syntax/Parser.hs
+++ b/src/full/Agda/Syntax/Parser.hs
@@ -190,9 +190,8 @@ agdaFileExtensions = ".agda" : literateExts
 --   When @True@, only blocks marked @```agda@ are considered code.
 --   When @False@, both @```@ and @```agda@ blocks are code (default).
 
-parseFile
-  :: Show a
-  => Bool
+parseFile ::
+     Bool
      -- ^ When @True@, only treat @```agda@ blocks as code in Markdown/Typst.
   -> Parser a
   -> RangeFile

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -134,7 +134,7 @@ data Position' a = Pn'
   deriving (Functor, Foldable, Traversable, Generic)
 
 instance Show a => Show (Position' a) where
-  showsPrec :: Show a => Int -> Position' a -> ShowS
+  showsPrec :: Int -> Position' a -> ShowS
   showsPrec i (Pn a p l c) = showParen (i > 10) $
     showString "Pn " .
     showsPrec 11 a . showChar ' ' .
@@ -327,7 +327,7 @@ consecutiveAndSeparated is =
   allConsecutive (\ i j -> iEnd i < iStart j) is
 
 -- | Range invariant.
-rangeInvariant :: Ord a => Range' a -> Bool
+rangeInvariant :: Range' a -> Bool
 rangeInvariant r =
   consecutiveAndSeparated (rangeIntervals r)
     &&
@@ -667,7 +667,7 @@ continuous r@(Range f _) =
   maybe __IMPOSSIBLE__ (intervalToRange f) $ rangeToInterval r
 
 -- | Removes gaps between intervals on the same line.
-continuousPerLine :: Ord a => Range' a -> Range' a
+continuousPerLine :: Range' a -> Range' a
 continuousPerLine r@NoRange     = r
 continuousPerLine r@(Range f _) =
   Range f (Seq.unfoldr step (rangeIntervals r))
@@ -708,7 +708,7 @@ fuseIntervals (Interval () s1 e1) (Interval () s2 e2) = Interval () (min s1 s2) 
 --   Meaning it finds the least range @r0@ that covers @r@ and @r'@.
 --
 -- Precondition: The ranges must point to the same file (or be empty).
-fuseRanges :: (Ord a) => Range' a -> Range' a -> Range' a
+fuseRanges :: Range' a -> Range' a -> Range' a
 fuseRanges NoRange       is2           = is2
 fuseRanges is1           NoRange       = is1
 fuseRanges (Range f is1) (Range _ is2) = Range f (fuse is1 is2)

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -166,7 +166,7 @@ newtype AbsToConT m a = AbsToCon { unAbsToCon :: ReaderT Env m a }
 deriving instance MonadFresh NameId m => MonadFresh NameId (AbsToConT m)
 deriving instance (Monad m, IsString  (m Doc)) => IsString (AbsToConT m Doc)
 deriving instance (Monad m, Null      (m Doc)) => Null (AbsToConT m Doc)
-deriving instance (Monad m, Semigroup (m Doc)) => Semigroup (AbsToConT m Doc)
+deriving instance (Monad m) => Semigroup (AbsToConT m Doc)
 
 runAbsToCon :: MonadAbsToCon m => AbsToConT m c -> m c
 runAbsToCon m = do
@@ -400,7 +400,7 @@ pickConcreteName x y = modifyConcreteNames $ flip Map.alter x $ Just . \case
     Just ys -> List1.snoc (List1.toList ys) y
 
 -- | For the given abstract name, return the names that could shadow it.
-shadowingNames :: (ReadTCState m, MonadStConcreteNames m)
+shadowingNames :: (ReadTCState m)
                => A.Name -> m (Set RawName)
 shadowingNames x = Set1.toSet' . Map.lookup x <$> useR stShadowingNames
 
@@ -1819,7 +1819,7 @@ recoverOpApp bracket isLam opApp view e = case view e of
      YesSection       -> False
      NoSection (i, e) -> isLam e && preferParenless (appParens i)
 
-  doQNameHelper :: MonadToConcrete m => Either A.Name A.QName -> [MaybeSection (AppInfo, a)] -> m (Maybe c)
+  doQNameHelper :: Either A.Name A.QName -> [MaybeSection (AppInfo, a)] -> m (Maybe c)
   doQNameHelper n args = do
     x <- either (C.QName <.> toConcrete) toConcrete n
     let n' = either id A.qnameName n
@@ -1835,7 +1835,7 @@ recoverOpApp bracket isLam opApp view e = case view e of
     List1.ifNull args {-then-} mDefault {-else-} $ \ as ->
       doQName (nameAspects True nk n') fx x n' as (C.nameParts $ C.unqualify x)
 
-  doQName :: MonadToConcrete m => Asp.Aspects -> Fixity -> C.QName -> A.Name -> List1 (MaybeSection (AppInfo, a)) -> NameParts -> m (Maybe c)
+  doQName :: Asp.Aspects -> Fixity -> C.QName -> A.Name -> List1 (MaybeSection (AppInfo, a)) -> NameParts -> m (Maybe c)
 
   -- fall-back (wrong number of arguments or no holes)
   doQName nk _ x _ as xs

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -355,8 +355,7 @@ reifyDisplayFormP f ps wps = do
     flattenWith _ = __IMPOSSIBLE__
 
     displayLHS
-      :: MonadReify m
-      => A.Patterns   -- Patterns to substituted into display term.
+      :: A.Patterns   -- Patterns to substituted into display term.
       -> DisplayTerm  -- Display term.
       -> m (QName, A.Patterns, A.Patterns)  -- New head, patterns, with-patterns.
     displayLHS ps d = do
@@ -365,16 +364,16 @@ reifyDisplayFormP f ps wps = do
         wps <- mapM (updateNamedArg (A.WithP empty) <.> elimToPat) es
         return (f, ps, wps)
       where
-        argToPat :: MonadReify m => Arg DisplayTerm -> m (NamedArg A.Pattern)
+        argToPat :: Arg DisplayTerm -> m (NamedArg A.Pattern)
         argToPat arg = traverse termToPat arg
 
-        elimToPat :: MonadReify m => I.Elim' DisplayTerm -> m (NamedArg A.Pattern)
+        elimToPat :: I.Elim' DisplayTerm -> m (NamedArg A.Pattern)
         elimToPat (I.IApply _ _ r) = argToPat (Arg defaultArgInfo r)
         elimToPat (I.Apply arg) = argToPat arg
         elimToPat (I.Proj o d)  = return $ defaultNamedArg $ A.ProjP patNoRange o $ unambiguous d
 
         -- Substitute variables in display term by patterns.
-        termToPat :: MonadReify m => DisplayTerm -> m (Named_ A.Pattern)
+        termToPat :: DisplayTerm -> m (Named_ A.Pattern)
 
         -- Main action HERE:
         termToPat (DTerm (I.Var n [])) =
@@ -400,11 +399,11 @@ reifyDisplayFormP f ps wps = do
 
         len = length ps
 
-        argsToExpr :: MonadReify m => I.Args -> m [Arg A.Expr]
+        argsToExpr :: I.Args -> m [Arg A.Expr]
         argsToExpr = mapM (traverse termToExpr)
 
         -- TODO: restructure this to avoid having to repeat the code for reify
-        termToExpr :: MonadReify m => Term -> m A.Expr
+        termToExpr :: Term -> m A.Expr
         termToExpr v = do
           reportSLn "reify.display" 60 $ "termToExpr " ++ show v
           -- After unSpine, a Proj elimination is __IMPOSSIBLE__!
@@ -665,7 +664,7 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
           df <- asksTC envPrintDomainFreePi
           return $ df && freeIn 0 b && closed a
 
-        skipGeneralizedParameter :: MonadReify m => ArgInfo -> m Bool
+        skipGeneralizedParameter :: ArgInfo -> m Bool
         skipGeneralizedParameter info = (not <$> showGeneralizedArguments) <&> (&& (argInfoOrigin info == Generalization))
 
     I.Sort s     -> reify s
@@ -740,7 +739,7 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
     -- to improve error messages.
     -- Don't do this if we have just expanded into a display form,
     -- otherwise we loop!
-    reifyDef :: MonadReify m => Bool -> QName -> I.Elims -> m Expr
+    reifyDef :: Bool -> QName -> I.Elims -> m Expr
     reifyDef True x es =
       ifM (not . null . inverseScopeLookupName x <$> getScope) (reifyDef' x es) $ do
       r <- reduceDefCopy x es
@@ -768,7 +767,7 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
     discontiguous (I.Apply (Arg info _):es) =
       (notVisible info && ConversionFail == argInfoOrigin info) || discontiguous es
 
-    reifyDef' :: MonadReify m => QName -> I.Elims -> m Expr
+    reifyDef' :: QName -> I.Elims -> m Expr
     reifyDef' x es = do
       reportSLn "reify.def" 60 $ "reifying call to " ++ prettyShow x
       -- We should drop this many arguments from the local context.
@@ -954,8 +953,7 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
     -- extended lambda, instead trying to construct the nice syntax.
 
     reifyExtLam
-      :: MonadReify m
-      => QName -> ArgInfo -> Int -> Maybe System -> [I.Clause]
+      :: QName -> ArgInfo -> Int -> Maybe System -> [I.Clause]
       -> I.Elims -> m Expr
     reifyExtLam x ai npars msys cls es = do
       reportS "reify.def" 10 $ "reifying extended lambda" <+> pretty x

--- a/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ReflectedToAbstract.hs
@@ -103,9 +103,7 @@ toAbstract_ ::
   (ToAbstract r
   , MonadFresh NameId m
   , MonadError TCErr m
-  , MonadTCEnv m
   , ReadTCState m
-  , HasOptions m
   , HasBuiltins m
   , HasConstInfo m
   ) => r -> m (AbsOfRef r)
@@ -116,9 +114,7 @@ toAbstractWithoutImplicit ::
   (ToAbstract r
   , MonadFresh NameId m
   , MonadError TCErr m
-  , MonadTCEnv m
   , ReadTCState m
-  , HasOptions m
   , HasBuiltins m
   , HasConstInfo m
   ) => r -> m (AbsOfRef r)

--- a/src/full/Agda/Termination/Monad.hs
+++ b/src/full/Agda/Termination/Monad.hs
@@ -247,7 +247,7 @@ runTerDefault cont = do
 instance Semigroup m => Semigroup (TerM m) where
   (<>) = liftA2 (<>)
 
-instance (Semigroup m, Monoid m) => Monoid (TerM m) where
+instance (Monoid m) => Monoid (TerM m) where
   mempty  = pure mempty
   mappend = (<>)
   mconcat = mconcat <.> sequence

--- a/src/full/Agda/Termination/Termination.hs
+++ b/src/full/Agda/Termination/Termination.hs
@@ -88,7 +88,7 @@ terminatesFilter useGuardedness f cs0 = loop (cs0, cs0)
           Terminates -> loop $ completionStep cs0 cs
 
 -- | Does the given callgraph contain a counterexample to termination?
-terminationCounterexample :: (Monoid cinfo, ?cutoff :: CutOff)
+terminationCounterexample :: (?cutoff :: CutOff)
   => Bool              -- ^ Use guardedness?
   -> (Node -> Bool)    -- ^ Only consider calls whose source and target satisfy this predicate.
   -> CallGraph cinfo   -- ^ Callgraph augmented with @cinfo@.

--- a/src/full/Agda/TypeChecking/CompiledClause.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause.hs
@@ -162,7 +162,7 @@ instance Semigroup c => Semigroup (WithArity c) where
     | n1 == n2  = WithArity n1 (c1 <> c2)
     | otherwise = __IMPOSSIBLE__   -- arity must match!
 
-instance (Semigroup c, Monoid c) => Monoid (WithArity c) where
+instance (Monoid c) => Monoid (WithArity c) where
   mempty  = WithArity __IMPOSSIBLE__ mempty
   mappend = (<>)
 
@@ -184,7 +184,7 @@ instance Semigroup m => Semigroup (Case m) where
      unionEta b Nothing = b
      unionEta Just{} Just{} = __IMPOSSIBLE__
 
-instance (Semigroup m, Monoid m) => Monoid (Case m) where
+instance (Monoid m) => Monoid (Case m) where
   mempty  = empty
   mappend = (<>)
 

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -6,8 +6,6 @@ module Agda.TypeChecking.Constraints where
 
 import Prelude hiding (null)
 
-import Control.Monad.Except ( MonadError )
-
 import qualified Data.List as List
 import qualified Data.Set as Set
 import Data.Either
@@ -144,20 +142,20 @@ stealConstraintsTCM pid = do
 -- constrain the solution space further.
 -- It can well do so, by solving metas.
 noConstraints
-  :: (MonadConstraint m, MonadWarning m, MonadError TCErr m, MonadFresh ProblemId m)
+  :: (MonadConstraint m, MonadWarning m, MonadFresh ProblemId m)
   => m a -> m a
 noConstraints = noConstraints' False
 
 -- | As 'noConstraints' but also fail for non-blocking constraints.
 reallyNoConstraints
-  :: (MonadConstraint m, MonadWarning m, MonadError TCErr m, MonadFresh ProblemId m)
+  :: (MonadConstraint m, MonadWarning m, MonadFresh ProblemId m)
   => m a -> m a
 reallyNoConstraints = noConstraints' True
 
 -- | Error out with @'NonFatalErrors' 'UnsolvedConstraints'@
 --   when given computation produced constraints ('True') or blocking constraints ('False').
 noConstraints' ::
-     (MonadConstraint m, MonadWarning m, MonadError TCErr m, MonadFresh ProblemId m)
+     (MonadConstraint m, MonadWarning m, MonadFresh ProblemId m)
   => Bool -> m a -> m a
 noConstraints' includingNonBlocking problem = do
   (pid, x) <- newProblem problem
@@ -173,12 +171,8 @@ noConstraints' includingNonBlocking problem = do
 -- | Run a computation that should succeeds without constraining
 --   the solution space, i.e., not add any information about meta-variables.
 nonConstraining ::
-  ( HasOptions m
-  , MonadConstraint m
-  , MonadDebug m
-  , MonadError TCErr m
+  ( MonadConstraint m
   , MonadFresh ProblemId m
-  , MonadTCEnv m
   , MonadWarning m
   ) => m a -> m a
 nonConstraining = dontAssignMetas . noConstraints

--- a/src/full/Agda/TypeChecking/Constraints.hs-boot
+++ b/src/full/Agda/TypeChecking/Constraints.hs-boot
@@ -2,9 +2,6 @@
 
 module Agda.TypeChecking.Constraints where
 
-
-import Control.Monad.Except (MonadError)
-
 import Agda.Syntax.Internal (ProblemId)
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.Monad.Constraints (MonadConstraint)
@@ -12,7 +9,7 @@ import Agda.TypeChecking.Warnings (MonadWarning)
 
 instance MonadConstraint TCM where
 
-noConstraints          :: (MonadConstraint m, MonadWarning m, MonadError TCErr m, MonadFresh ProblemId m)
+noConstraints          :: (MonadConstraint m, MonadWarning m, MonadFresh ProblemId m)
                        => m a -> m a
 ifNoConstraints_       :: TCM () -> TCM a -> (ProblemId -> TCM a) -> TCM a
 ifNoConstraints        :: TCM a -> (a -> TCM b) -> (ProblemId -> a -> TCM b) -> TCM b

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -83,7 +83,7 @@ type MonadConversion m =
 --   (may create new metas, though).
 --   Restores state upon failure.
 tryConversion
-  :: (MonadConstraint m, MonadWarning m, MonadError TCErr m, MonadFresh ProblemId m)
+  :: (MonadConstraint m, MonadWarning m, MonadFresh ProblemId m)
   => m () -> m Bool
 tryConversion = isJust <.> tryConversion'
 
@@ -92,7 +92,7 @@ tryConversion = isJust <.> tryConversion'
 --   Return 'Just' the result upon success.
 --   Return 'Nothing' and restore state upon failure.
 tryConversion'
-  :: (MonadConstraint m, MonadWarning m, MonadError TCErr m, MonadFresh ProblemId m)
+  :: (MonadConstraint m, MonadWarning m, MonadFresh ProblemId m)
   => m a -> m (Maybe a)
 tryConversion' m = tryMaybe $ noConstraints m
 
@@ -445,7 +445,7 @@ compareTerm' cmp a m n =
         _ -> compareAtom cmp (AsTermsOf a') m n
   where
     -- equality at function type (accounts for eta)
-    equalFun :: (MonadConversion m) => Sort -> Term -> Term -> Term -> m ()
+    equalFun :: Sort -> Term -> Term -> Term -> m ()
     equalFun s a@(Pi dom b) m n | domIsFinite dom = do
        mp <- fmap getPrimName <$> getBuiltin' builtinIsOne
        let asFn = El s (Pi (dom { domIsFinite = False }) b)
@@ -465,7 +465,7 @@ compareTerm' cmp a m n =
 
     equalFun _ _ _ _ = __IMPOSSIBLE__
 
-    equalPath :: (MonadConversion m) => PathView -> Type -> Term -> Term -> m ()
+    equalPath :: PathView -> Type -> Term -> Term -> m ()
     equalPath (PathType s _ l a x y) _ m n = do
       whenProfile Profile.Conversion $ tick "compare at path type"
       interval <- el primInterval
@@ -688,7 +688,7 @@ compareAtom cmp t m n =
           _ -> notEqual
     where
         -- returns True in case we handled the comparison already.
-        compareEtaPrims :: MonadConversion m => QName -> Elims -> Elims -> m Bool
+        compareEtaPrims :: QName -> Elims -> Elims -> m Bool
         compareEtaPrims q es es' = do
           munglue <- getPrimitiveName' builtin_unglue
           munglueU <- getPrimitiveName' builtin_unglueU
@@ -732,7 +732,7 @@ compareAtom cmp t m n =
               compareElims [] [] (El (tmSort (unArg la)) (unArg bA)) (Def q as) bs bs'
               return True
             _  -> return False
-        compareUnglueUApp :: MonadConversion m => QName -> Elims -> Elims -> m Bool
+        compareUnglueUApp :: QName -> Elims -> Elims -> m Bool
         compareUnglueUApp q es es' = do
           let (as,bs) = splitAt 5 es; (as',bs') = splitAt 5 es'
           case (allApplyElims as, allApplyElims as') of

--- a/src/full/Agda/TypeChecking/Conversion/Errors.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Errors.hs
@@ -279,7 +279,7 @@ failConversion cmp l r cas = do
 -- and the changes to the context should be reflected in the
 -- 'ConversionZipper'.
 addConversionContext
-  :: (MonadTCError m, HasBuiltins m)
+  :: (MonadTCError m)
   => (ConversionZipper -> ConversionZipper)
     -- ^ How to modify the zipper
   -> m a

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -1429,7 +1429,7 @@ split' checkEmpty ind allowPartialCover inserttrailing
       return $ Right $ Covering (lookupPatternVar sc x) ns
 
   where
-    inContextOfT, inContextOfDelta2 :: (MonadTCM tcm, MonadAddContext tcm, MonadDebug tcm) => tcm a -> tcm a
+    inContextOfT, inContextOfDelta2 :: (MonadAddContext tcm) => tcm a -> tcm a
     inContextOfT      = addContext tel . escapeContext impossible (x + 1)
     inContextOfDelta2 = addContext tel . escapeContext impossible x
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -936,7 +936,7 @@ instance PrettyTCM TypeError where
       , fwords "(hint: Use C-c C-w (in Emacs) if you want to know why)"
       ]
       where
-        help :: MonadPretty m => ModuleName -> m Doc
+        help :: ModuleName -> m Doc
         help m = do
           anno <- caseMaybeM (isDatatypeModule m) (return empty) $ \case
             IsDataModule   -> return $ "(datatype module)"
@@ -1034,16 +1034,16 @@ instance PrettyTCM TypeError where
       pwords "Could mean any one of:"
       ) $$ nest 2 (vcat $ fmap pretty' es')
       where
-        pretty_es :: MonadPretty m => m Doc
+        pretty_es :: m Doc
         pretty_es = pretty $ C.RawApp noRange es
 
-        pretty' :: MonadPretty m => C.Expr -> m Doc
+        pretty' :: C.Expr -> m Doc
         pretty' e = do
           p1 <- pretty_es
           p2 <- pretty e
           if render p1 == render p2 then unambiguous e else return p2
 
-        unambiguous :: MonadPretty m => C.Expr -> m Doc
+        unambiguous :: C.Expr -> m Doc
         unambiguous e@(C.OpApp r op _ xs)
           | all (isOrdinary . namedArg) xs =
             pretty $
@@ -1133,7 +1133,7 @@ instance PrettyTCM TypeError where
           ++
         map (nest 2 . pretty' d) (List2.toList ps)
       where
-        pretty' :: MonadPretty m => Doc -> C.Pattern -> m Doc
+        pretty' :: Doc -> C.Pattern -> m Doc
         pretty' d1 p' = do
           d2 <- pretty p'
           if render d1 == render d2 then pretty $ unambiguousP p' else return d2
@@ -1756,13 +1756,13 @@ instance PrettyTCM TypeError where
       | n > 0 && not (null args) = parens
       | otherwise                = id
 
-    prettyArg :: MonadPretty m => Arg (I.Pattern' a) -> m Doc
+    prettyArg :: Arg (I.Pattern' a) -> m Doc
     prettyArg (Arg info x) = case getHiding info of
       Hidden     -> braces $ prettyPat 0 x
       Instance{} -> dbraces $ prettyPat 0 x
       NotHidden  -> prettyPat 1 x
 
-    prettyPat :: MonadPretty m => Integer -> (I.Pattern' a) -> m Doc
+    prettyPat :: Integer -> (I.Pattern' a) -> m Doc
     prettyPat _ (I.VarP _ _) = "_"
     prettyPat _ (I.DotP _ _) = "._"
     prettyPat n (I.ConP c _ args) =

--- a/src/full/Agda/TypeChecking/EtaContract.hs
+++ b/src/full/Agda/TypeChecking/EtaContract.hs
@@ -53,12 +53,12 @@ binAppView t = case t of
 -- | Contracts all eta-redexes it sees without reducing.
 {-# SPECIALIZE etaContract :: TermLike a => a -> TCM a #-}
 {-# SPECIALIZE etaContract :: TermLike a => a -> ReduceM a #-}
-etaContract :: (MonadTCEnv m, HasConstInfo m, HasOptions m, TermLike a) => a -> m a
+etaContract :: (HasConstInfo m, TermLike a) => a -> m a
 etaContract = traverseTermM etaOnce
 
 {-# SPECIALIZE etaOnce :: Term -> TCM Term #-}
 {-# SPECIALIZE etaOnce :: Term -> ReduceM Term #-}
-etaOnce :: (MonadTCEnv m, HasConstInfo m, HasOptions m) => Term -> m Term
+etaOnce :: (HasConstInfo m) => Term -> m Term
 etaOnce = \case
   -- Andreas, 2012-11-18: this call to reportSDoc seems to cost me 2%
   -- performance on the std-lib
@@ -73,7 +73,7 @@ etaOnce = \case
   v -> return v
 
 -- | If record constructor, call eta-contraction function.
-etaCon :: (MonadTCEnv m, HasConstInfo m, HasOptions m)
+etaCon :: (HasConstInfo m)
   => ConHead  -- ^ Constructor name @c@.
   -> ConInfo  -- ^ Constructor info @ci@.
   -> Elims     -- ^ Constructor arguments @args@.
@@ -90,7 +90,7 @@ etaCon c ci es cont = ignoreAbstractMode $ do
     cont r c ci args
 
 -- | Try to contract a lambda-abstraction @Lam i (Abs x b)@.
-etaLam :: (MonadTCEnv m, HasConstInfo m, HasOptions m)
+etaLam :: (MonadTCEnv m, HasOptions m)
   => ArgInfo  -- ^ Info @i@ of the 'Lam'.
   -> ArgName  -- ^ Name @x@ of the abstraction.
   -> Term     -- ^ Body ('Term') @b@ of the 'Abs'.

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -259,7 +259,7 @@ instance Semigroup a => Semigroup (VarOcc' a) where
 --   occurrence: flexible, irrelevant.
 --   This is also the absorptive element for 'composeVarOcc', if we ignore
 --   the 'MetaSet' in 'Flexible'.
-instance (Semigroup a, Monoid a) => Monoid (VarOcc' a) where
+instance (Monoid a) => Monoid (VarOcc' a) where
   mempty  = VarOcc (Flexible mempty) zeroModality
   mappend = (<>)
 
@@ -287,7 +287,7 @@ oneVarOcc = VarOcc Unguarded unitModality
 --
 --   In algebraic terminology, a variable set @a@ needs to be (almost) a left semimodule
 --   to the semiring 'VarOcc'.
-class (Singleton MetaId a, Semigroup a, Monoid a, Semigroup c, Monoid c) => IsVarSet a c | c -> a where
+class (Singleton MetaId a, Monoid a, Monoid c) => IsVarSet a c | c -> a where
   -- | Laws
   --    * Respects monoid operations:
   --      ```
@@ -342,7 +342,7 @@ instance Semigroup a => Monoid (VarMap' a) where
   mconcat = VarMap . IntMap.unionsWith (<>) . map theVarMap
   -- mconcat = VarMap . IntMap.unionsWith mappend . coerce   -- ghc 8.6.5 does not seem to like this coerce
 
-instance (Singleton MetaId a, Semigroup a, Monoid a) => IsVarSet a (VarMap' a) where
+instance (Singleton MetaId a, Monoid a) => IsVarSet a (VarMap' a) where
   withVarOcc o = mapVarMap $ fmap $ composeVarOcc o
 
 
@@ -432,7 +432,7 @@ type FreeM a c = Reader (FreeEnv' a IgnoreSorts c) c
 runFreeM :: IsVarSet a c => SingleVar c -> IgnoreSorts -> FreeM a c -> c
 runFreeM single i m = runReader m $ initFreeEnv i single
 
-instance (Functor m, Applicative m, Monad m, Semigroup c, Monoid c) => Monoid (FreeT a b m c) where
+instance (Monad m, Monoid c) => Monoid (FreeT a b m c) where
   mempty  = pure mempty
   mappend = (<>)
   mconcat = mconcat <.> sequence

--- a/src/full/Agda/TypeChecking/Irrelevance.hs
+++ b/src/full/Agda/TypeChecking/Irrelevance.hs
@@ -108,7 +108,7 @@ import Agda.Utils.Impossible
 --
 class UsableRelevance a where
   usableRel
-    :: (ReadTCState m, HasConstInfo m, MonadTCEnv m, MonadAddContext m, MonadDebug m)
+    :: (ReadTCState m, HasConstInfo m, MonadAddContext m)
     => Relevance -> a -> m Bool
 
 instance UsableRelevance Term where
@@ -202,7 +202,7 @@ instance (Subst a, UsableRelevance a) => UsableRelevance (Abs a) where
 --
 class UsableModality a where
   usableMod
-    :: (ReadTCState m, HasConstInfo m, MonadTCEnv m, MonadAddContext m, MonadDebug m, MonadReduce m, MonadError Blocker m)
+    :: (HasConstInfo m, MonadAddContext m, MonadReduce m, MonadError Blocker m)
     => Modality -> a -> m Bool
 
 instance UsableModality Term where
@@ -260,8 +260,7 @@ instance UsableModality Term where
     DontCare v -> usableMod mod v
     Dummy{}  -> return True
 
-usableModAbs :: (Subst a, MonadAddContext m, UsableModality a,
-                       ReadTCState m, HasConstInfo m, MonadReduce m, MonadError Blocker m) =>
+usableModAbs :: (Subst a, MonadAddContext m, UsableModality a, HasConstInfo m, MonadReduce m, MonadError Blocker m) =>
                       ArgInfo -> Modality -> Abs a -> m Bool
 usableModAbs info mod abs = underAbstraction (setArgInfo info $ __DUMMY_DOM__) abs $ \ u -> usableMod mod u
 

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -547,7 +547,7 @@ newQuestionMark' new ii cmp t = lookupInteractionMeta ii >>= \case
 {-# SPECIALIZE blockTerm :: Type -> TCM Term -> TCM Term #-}
 -- | Construct a blocked constant if there are constraints.
 blockTerm
-  :: (MonadMetaSolver m, MonadConstraint m, MonadFresh Nat m, MonadFresh ProblemId m)
+  :: (MonadMetaSolver m, MonadFresh Nat m, MonadFresh ProblemId m)
   => Type -> m Term -> m Term
 blockTerm t blocker = do
   (pid, v) <- newProblem blocker
@@ -762,7 +762,7 @@ etaExpandMetaTCM kinds m = whenM ((not <$> isFrozen m) `and2M` asksTC envAssignM
 -- | Eta expand blocking metavariables of record type, and reduce the
 -- blocked thing.
 
-etaExpandBlocked :: (MonadReduce m, MonadMetaSolver m, IsMeta t, Reduce t)
+etaExpandBlocked :: (MonadMetaSolver m, IsMeta t, Reduce t)
                  => Blocked t -> m (Blocked t)
 etaExpandBlocked t@NotBlocked{} = return t
 etaExpandBlocked t@(Blocked _ v) | Just{} <- isMeta v = return t
@@ -775,7 +775,7 @@ etaExpandBlocked (Blocked b t)  = do
     _                      -> return t
 
 {-# SPECIALIZE assignWrapper :: CompareDirection -> MetaId -> Elims -> Term -> TCM () -> TCM () #-}
-assignWrapper :: (MonadMetaSolver m, MonadConstraint m, MonadError TCErr m, MonadDebug m, HasOptions m)
+assignWrapper :: (MonadMetaSolver m)
               => CompareDirection -> MetaId -> Elims -> Term -> m () -> m ()
 assignWrapper dir x es v doAssign = do
   ifNotM (asksTC envAssignMetas) dontAssign $ {- else -} do
@@ -1149,7 +1149,7 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
 -- | Is the given metavariable application secretly an interaction point
 -- application? Ugly.
 isInteractionMetaB
-  :: forall m. (ReadTCState m, MonadReduce m, MonadPretty m)
+  :: forall m. (MonadPretty m)
   => MetaId
   -> Args
   -> m (Maybe (MetaId, InteractionId, Args))
@@ -1548,7 +1548,7 @@ class (TermLike a, TermSubst a, Reduce a) => ReduceAndEtaContract a where
   reduceAndEtaContract :: a -> TCM a
 
   default reduceAndEtaContract
-    :: (Traversable f, TermLike b, Subst b, Reduce b, ReduceAndEtaContract b, f b ~ a)
+    :: (Traversable f, ReduceAndEtaContract b, f b ~ a)
     => a -> TCM a
   reduceAndEtaContract = Trav.mapM reduceAndEtaContract
 

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 {-# OPTIONS_GHC -Wunused-imports #-}
 
 {-# LANGUAGE NondecreasingIndentation  #-}
@@ -374,6 +375,7 @@ class Occurs t where
   default metaOccurs :: (Foldable f, Occurs a, f a ~ t) => MetaId -> t -> TCM ()
   metaOccurs = traverse_ . metaOccurs
 
+-- GHC flags this as redundant constraint, so we turn off -Wredundant-constraints.
 occurs_ :: (Occurs t, TypeOf t ~ ()) => t -> OccursM t
 occurs_ t = occurs t
 
@@ -672,7 +674,7 @@ instance Occurs a => Occurs (Arg a) where
   metaOccurs m = metaOccurs m . unArg
 
 instance Occurs a => Occurs (Dom a) where
-  occurs :: Occurs a => Dom a -> OccursM (Dom a)
+  occurs :: Dom a -> OccursM (Dom a)
   occurs (Dom info n f t x) =
     Dom info n f t <$> underQuantity info (occurs x)
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -6193,7 +6193,7 @@ instance Monad m => MonadBlock (ExceptT TCErr m) where
     PatternErr b -> h b
     err          -> throwError err
 
-runBlocked :: Monad m => BlockT m a -> m (Either Blocker a)
+runBlocked :: BlockT m a -> m (Either Blocker a)
 runBlocked = runExceptT . unBlockT
 {-# INLINE runBlocked #-}
 
@@ -6362,7 +6362,7 @@ instance {-# OVERLAPPABLE #-} (MonadIO m, Semigroup a) => Semigroup (TCMT m a) w
   (<>) = liftA2 (<>)
 
 -- | Strict (non-shortcut) monoid.
-instance {-# OVERLAPPABLE #-} (MonadIO m, Semigroup a, Monoid a) => Monoid (TCMT m a) where
+instance {-# OVERLAPPABLE #-} (MonadIO m, Monoid a) => Monoid (TCMT m a) where
   mempty  = pure mempty
   mappend = (<>)
   mconcat = mconcat <.> sequence
@@ -6740,7 +6740,7 @@ instance KillRange DisplayTerm where
       DDot' v es         -> killRangeN DDot' v es
       DTerm' v es        -> killRangeN DTerm' v es
 
-instance KillRange a => KillRange (Closure a) where
+instance KillRange (Closure a) where
   killRange = id
 
 ---------------------------------------------------------------------------

--- a/src/full/Agda/TypeChecking/Monad/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Monad/Builtin.hs
@@ -596,7 +596,7 @@ mkSortKit prop set sset propomega setomega ssetomega = SortKit
 -- When 'optLoadPrimitives' is set to 'False', 'sortKit' is a fallible operation,
 -- so for the uses of 'sortKit' in fallible contexts (e.g. 'TCM'),
 -- we report a type error rather than exploding.
-sortKit :: (HasBuiltins m, MonadTCError m, HasOptions m) => m SortKit
+sortKit :: (HasBuiltins m, MonadTCError m) => m SortKit
 sortKit = do
   prop      <- getBuiltinName_ builtinProp
   set       <- getBuiltinName_ builtinSet

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -499,12 +499,12 @@ underAbstraction_ = underAbstraction __DUMMY_DOM__
 -- | Map a monadic function on the thing under the abstraction, adding
 --   the abstracted variable to the context.
 mapAbstraction
-  :: (Subst a, Subst b, MonadAddContext m)
+  :: (Subst a, MonadAddContext m)
   => Dom Type -> (a -> m b) -> Abs a -> m (Abs b)
 mapAbstraction dom f x = (x $>) <$> underAbstraction dom x f
 
 mapAbstraction_
-  :: (Subst a, Subst b, MonadAddContext m)
+  :: (Subst a, MonadAddContext m)
   => (a -> m b) -> Abs a -> m (Abs b)
 mapAbstraction_ = mapAbstraction __DUMMY_DOM__
 

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP #-}
 
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
 module Agda.TypeChecking.Monad.Debug
   ( module Agda.TypeChecking.Monad.Debug
   , Verbosity, VerboseKey, VerboseLevel
@@ -399,7 +401,7 @@ hasExactVerbosity k n = (n ==) <$> getVerbosityLevel k
 whenExactVerbosity :: MonadDebug m => VerboseKey -> VerboseLevel -> m () -> m ()
 whenExactVerbosity k n = whenM $ hasExactVerbosity k n
 
-__CRASH_WHEN__ :: (HasCallStack, MonadTCM m, MonadDebug m) => VerboseKey -> VerboseLevel -> m ()
+__CRASH_WHEN__ :: (HasCallStack, MonadDebug m) => VerboseKey -> VerboseLevel -> m ()
 __CRASH_WHEN__ k n = whenExactVerbosity k n (throwImpossible err)
   where
     -- Create the "Unreachable" error using *our* caller as the call site.

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
@@ -52,4 +52,4 @@ instance HasConstInfo m => HasConstInfo (StateT s m)
 instance HasConstInfo TCM where
 
 inFreshModuleIfFreeParams :: TCM a -> TCM a
-lookupSection :: (Functor m, ReadTCState m) => ModuleName -> m Telescope
+lookupSection :: (ReadTCState m) => ModuleName -> m Telescope

--- a/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/Monad/SizedTypes.hs
@@ -138,7 +138,7 @@ sizeType_ size = El sizeSort $ Def size []
 
 {-# SPECIALIZE sizeType :: TCM Type #-}
 -- | The built-in type @SIZE@.
-sizeType :: (HasBuiltins m, MonadTCEnv m, ReadTCState m) => m Type
+sizeType :: (HasBuiltins m) => m Type
 sizeType = El sizeSort . fromMaybe __IMPOSSIBLE__ <$> getBuiltin' builtinSize
 
 -- | The name of @SIZESUC@.
@@ -178,7 +178,7 @@ sizeMax vs = case vs of
 data SizeView = SizeInf | SizeSuc Term | OtherSize Term
 
 -- | Expects argument to be 'reduce'd.
-sizeView :: (HasBuiltins m, MonadTCEnv m, ReadTCState m)
+sizeView :: (HasBuiltins m)
          => Term -> m SizeView
 sizeView v = do
   inf <- fromMaybe __IMPOSSIBLE__ <$> getBuiltinName' builtinSizeInf

--- a/src/full/Agda/TypeChecking/Monad/Statistics.hs
+++ b/src/full/Agda/TypeChecking/Monad/Statistics.hs
@@ -83,7 +83,7 @@ tick x = tickN x 1
 
 -- | Print the given statistics.
 printStatistics
-  :: (MonadDebug m, MonadTCEnv m, HasOptions m)
+  :: (MonadDebug m)
   => Maybe TopLevelModuleName -> Statistics -> m ()
 printStatistics mmname (Statistics tick max) = do
   let

--- a/src/full/Agda/TypeChecking/Names.hs
+++ b/src/full/Agda/TypeChecking/Names.hs
@@ -194,8 +194,7 @@ bindN1 :: Monad m
   => List1 ArgName -> (Vars1 m -> NamesT m a) -> NamesT m (AbsN a)
 bindN1 (x :| xs) f = toAbsN <$> bind x (\ x -> bindN xs (\ xs -> f (x :| xs)))
 
-glamN :: (Functor m, Monad m) =>
-         [Arg ArgName] -> (NamesT m Args -> NamesT m Term) -> NamesT m Term
+glamN :: (Monad m) => [Arg ArgName] -> (NamesT m Args -> NamesT m Term) -> NamesT m Term
 glamN [] f = f $ pure []
 glamN (Arg i n:ns) f = glam i n $ \ x -> glamN ns (\ xs -> f ((:) <$> (Arg i <$> x) <*> xs))
 

--- a/src/full/Agda/TypeChecking/Opacity.hs
+++ b/src/full/Agda/TypeChecking/Opacity.hs
@@ -38,7 +38,7 @@ import Agda.Utils.Lens
 -- | Ensure that opaque blocks defined in the current module have
 -- saturated unfolding sets.
 saturateOpaqueBlocks
-  :: forall m. (MonadTCState m, ReadTCState m, MonadFresh OpaqueId m, MonadDebug m, MonadTrace m, MonadWarning m, MonadIO m)
+  :: forall m. (MonadTCState m, MonadFresh OpaqueId m, MonadTrace m, MonadWarning m, MonadIO m)
   => m ()
 saturateOpaqueBlocks = entry where
   entry = do
@@ -205,7 +205,7 @@ isAccessibleDef env state defn =
 -- | Will the given 'QName' have a proper definition, or will it be
 -- wrapped in an 'AbstractDefn'?
 hasAccessibleDef
-  :: (ReadTCState m, MonadTCEnv m, HasConstInfo m) => QName -> m Bool
+  :: (ReadTCState m, HasConstInfo m) => QName -> m Bool
 hasAccessibleDef qn = do
   env <- askTC
   st <- getTCState

--- a/src/full/Agda/TypeChecking/Opacity.hs-boot
+++ b/src/full/Agda/TypeChecking/Opacity.hs-boot
@@ -10,4 +10,4 @@ import Agda.Syntax.Abstract.Name
 isAccessibleDef :: TCEnv -> TCState -> Definition -> Bool
 
 hasAccessibleDef
-  :: (ReadTCState m, MonadTCEnv m, HasConstInfo m) => QName -> m Bool
+  :: (ReadTCState m, HasConstInfo m) => QName -> m Bool

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -98,7 +98,7 @@ purgeNonvariant = map (\ p -> if p == Nonvariant then Covariant else p)
 
 -- | A quick transliterations of occurrences to polarities.
 polarityFromPositivity
-  :: (HasConstInfo m, MonadTCEnv m, MonadTCState m, MonadDebug m)
+  :: (HasConstInfo m, MonadTCState m)
   => QName -> m ()
 polarityFromPositivity x = inConcreteOrAbstractMode x $ \ def -> do
 
@@ -206,7 +206,7 @@ usagePolarity def = case def of
 --
 --   Precondition: the "phantom" polarity list has the same length as the polarity list.
 dependentPolarity
-  :: (HasOptions m, HasBuiltins m, MonadReduce m, MonadAddContext m, MonadDebug m)
+  :: (HasBuiltins m, MonadReduce m, MonadAddContext m, MonadDebug m)
   => Type -> [Polarity] -> [Polarity] -> m [Polarity]
 dependentPolarity t _      []          = return []  -- all remaining are 'Invariant'
 dependentPolarity t []     (_ : _)     = __IMPOSSIBLE__
@@ -251,9 +251,8 @@ relevantInIgnoringNonvariant i t (p:ps) =
 --   See test/succeed/PolaritySizeSucData.agda for a case where this is needed.
 sizePolarity
   :: forall m .
-     ( HasOptions m, HasConstInfo m, HasBuiltins m, ReadTCState m
-     , MonadTCEnv m, MonadTCState m, MonadReduce m, MonadAddContext m, MonadTCError m
-     , MonadDebug m, MonadPretty m )
+     ( MonadTCState m, MonadTCError m
+     , MonadPretty m )
   => QName -> [Polarity] -> m [Polarity]
 sizePolarity d pol0 = do
   let exit = return pol0
@@ -326,7 +325,7 @@ sizePolarity d pol0 = do
 --
 --   Precondition: @a@ is reduced and of form @d ps idxs0@.
 checkSizeIndex
-  :: (HasConstInfo m, ReadTCState m, MonadDebug m, MonadPretty m, MonadTCError m)
+  :: (MonadPretty m, MonadTCError m)
   => QName -> Nat -> Type -> m Bool
 checkSizeIndex d i a = do
   reportSDoc "tc.polarity.size" 15 $ withShowAllArguments $ vcat

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -386,7 +386,7 @@ data OccEnv = OccEnv
 -- | Monad for computing occurrences.
 type OccM = ReaderT OccEnv ReduceM
 
-instance (Semigroup a, Monoid a) => Monoid (OccM a) where
+instance (Monoid a) => Monoid (OccM a) where
   mempty  = return mempty
   mappend = (<>)
   mconcat = mconcat <.> sequence

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -759,10 +759,10 @@ prettyNotInScopeNames printRange suggestion xs = nest 2 $ vcat $ map name xs
     , suggestion x
     ]
 
-{-# SPECIALIZE didYouMean :: (Pretty a, Pretty b) => [C.QName] -> (a -> b) -> a -> Maybe (TCM Doc) #-}
+{-# SPECIALIZE didYouMean :: (Pretty b) => [C.QName] -> (a -> b) -> a -> Maybe (TCM Doc) #-}
 -- | Suggest some corrections to a misspelled name.
 didYouMean
-  :: (MonadPretty m, Pretty a, Pretty b)
+  :: (MonadPretty m, Pretty b)
   => [C.QName]     -- ^ Names in scope.
   -> (a -> b)      -- ^ Canonization function for similarity search.
   -> a             -- ^ A name which is not in scope.
@@ -862,7 +862,7 @@ isBoundaryConstraint c =
     g (a, _, _, _) = getRange a
 
 {-# SPECIALIZE getAllUnsolvedWarnings :: TCM [TCWarning] #-}
-getAllUnsolvedWarnings :: (ReadTCState m, MonadWarning m, MonadTCM m) => m [TCWarning]
+getAllUnsolvedWarnings :: (MonadWarning m, MonadTCM m) => m [TCWarning]
 getAllUnsolvedWarnings = do
   unsolvedInteractions <- getUnsolvedInteractionMetas
 
@@ -882,12 +882,12 @@ getAllUnsolvedWarnings = do
 -- | Collect all warnings that have accumulated in the state.
 
 {-# SPECIALIZE getAllWarnings :: WhichWarnings -> TCM (Set TCWarning) #-}
-getAllWarnings :: (ReadTCState m, MonadWarning m, MonadTCM m) => WhichWarnings -> m (Set TCWarning)
+getAllWarnings :: (MonadWarning m, MonadTCM m) => WhichWarnings -> m (Set TCWarning)
 getAllWarnings = getAllWarningsPreserving Set.empty
 
 {-# SPECIALIZE getAllWarningsPreserving :: Set WarningName -> WhichWarnings -> TCM (Set TCWarning) #-}
 getAllWarningsPreserving ::
-  (ReadTCState m, MonadWarning m, MonadTCM m) => Set WarningName -> WhichWarnings -> m (Set TCWarning)
+  (MonadWarning m, MonadTCM m) => Set WarningName -> WhichWarnings -> m (Set TCWarning)
 getAllWarningsPreserving keptWarnings ww = do
   unsolved            <- Set.fromList <$> getAllUnsolvedWarnings
   collectedTCWarnings <- useTC stTCWarnings

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 {-# OPTIONS_GHC -Wunused-imports #-}
 
 {-| Primitive functions, such as addition on builtin integers.

--- a/src/full/Agda/TypeChecking/Primitive/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical.hs
@@ -1269,7 +1269,7 @@ instance Subst CType where
   applySubst rho (ClosedType s q) = ClosedType (applySubst rho s) q
   applySubst rho (LType t) = LType $ applySubst rho t
 
-hcomp :: (HasBuiltins m, MonadError TCErr m, MonadReduce m, MonadPretty m)
+hcomp :: (HasBuiltins m, MonadError TCErr m, MonadReduce m)
   => NamesT m Type
   -> [(NamesT m Term, NamesT m Term)]
   -> NamesT m Term

--- a/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
+++ b/src/full/Agda/TypeChecking/Primitive/Cubical/Base.hs
@@ -322,7 +322,7 @@ fiber la lb bA bB f b = do
 -- | Helper function for constructing the filler of a given composition
 -- problem.
 hfill
-  :: (HasBuiltins m, HasConstInfo m)
+  :: (HasBuiltins m)
   => NamesT m Term -- @la : Level@
   -> NamesT m Term -- @A : Type la@
   -> NamesT m Term -- @φ : I@. Cofibration

--- a/src/full/Agda/TypeChecking/Records.hs
+++ b/src/full/Agda/TypeChecking/Records.hs
@@ -211,7 +211,7 @@ getRecordDef r = fromMaybeM err $ isRecord r
   where err = typeError $ ShouldBeRecordType (El __DUMMY_SORT__ $ Def r [])
 
 -- | Get the record name belonging to a field name.
-getRecordOfField :: HasCallStack => QName -> TCM (Maybe QName)
+getRecordOfField :: QName -> TCM (Maybe QName)
 getRecordOfField d = caseMaybeM (isProjection d) (return Nothing) $
   \ Projection{ projProper = proper, projFromType = r} ->
     return $ unArg r <$ proper -- if proper then Just (unArg r) else Nothing
@@ -687,7 +687,7 @@ curryAt t n = do
 
     where @tel@ is the record telescope instantiated at the parameters @pars@.
 -}
-etaExpandRecord :: (HasConstInfo m, MonadDebug m, ReadTCState m)
+etaExpandRecord :: (HasConstInfo m)
   => QName       -- ^ Name of record type.
   -> Args        -- ^ Parameters applied to record type.
   -> Term        -- ^ Term to eta-expand.
@@ -696,7 +696,7 @@ etaExpandRecord :: (HasConstInfo m, MonadDebug m, ReadTCState m)
 etaExpandRecord = etaExpandRecord' False
 
 -- | Eta expand a record regardless of whether it's an eta-record or not.
-forceEtaExpandRecord :: (HasConstInfo m, MonadDebug m, ReadTCState m, MonadError TCErr m)
+forceEtaExpandRecord :: (HasConstInfo m)
   => QName       -- ^ Name of record type.
   -> Args        -- ^ Parameters applied to record type.
   -> Term        -- ^ Term to eta-expand.
@@ -705,7 +705,7 @@ forceEtaExpandRecord :: (HasConstInfo m, MonadDebug m, ReadTCState m, MonadError
 forceEtaExpandRecord = etaExpandRecord' True
 
 -- | Eta-expand a value at the given record type (must match).
-etaExpandRecord' :: (HasConstInfo m, MonadDebug m, ReadTCState m)
+etaExpandRecord' :: (HasConstInfo m)
   => Bool        -- ^ Force expansion, overriding '_recEtaEquality'?
   -> QName       -- ^ Name of record type.
   -> Args        -- ^ Parameters applied to record type.

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -354,7 +354,7 @@ instance IsMeta Term where
   isMeta (MetaV m _) = Just m
   isMeta _           = Nothing
 
-instance IsMeta a => IsMeta (Sort' a) where
+instance IsMeta (Sort' a) where
   isMeta (MetaS m _) = Just m
   isMeta _           = Nothing
 
@@ -724,7 +724,7 @@ unfoldDefinitionStep v0 f es =
       where
           ar  = primFunArity pf
 
-          mredToBlocked :: IsMeta t => MaybeReduced t -> Blocked t
+          mredToBlocked :: MaybeReduced t -> Blocked t
           mredToBlocked (MaybeRed NotReduced  e) = notBlocked e
           mredToBlocked (MaybeRed (Reduced b) e) = e <$ b
 

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -619,7 +619,7 @@ instance ParallelReduce a => ParallelReduce (Elim' a) where
   parReduce e@Proj{}   = pure e
   parReduce e@IApply{} = pure e -- TODO
 
-instance (Free a, Subst a, ParallelReduce a) => ParallelReduce (Abs a) where
+instance (Subst a, ParallelReduce a) => ParallelReduce (Abs a) where
   parReduce = mapAbstraction __DUMMY_DOM__ parReduce
 
 

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -247,7 +247,7 @@ checkDecl d = setCurrentRange d $ do
 
     -- Switch maybe to abstract mode, benchmark, and debug print bracket.
     check :: forall m i a
-          . ( MonadTCEnv m, MonadPretty m, MonadDebug m
+          . ( MonadTCEnv m, MonadDebug m
             , MonadBench m, Bench.BenchPhase m ~ Phase
             , AnyIsAbstract i
             , AllAreOpaque i

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -112,9 +112,9 @@ data LHSContext = LHSContext
 -- | A pattern is flexible if it is dotted or implicit, or a record pattern
 --   with only flexible subpatterns.
 class IsFlexiblePattern a where
-  maybeFlexiblePattern :: (HasConstInfo m, MonadDebug m) => a -> MaybeT m FlexibleVarKind
+  maybeFlexiblePattern :: (HasConstInfo m) => a -> MaybeT m FlexibleVarKind
 
-  isFlexiblePattern :: (HasConstInfo m, MonadDebug m) => a -> m Bool
+  isFlexiblePattern :: (HasConstInfo m) => a -> m Bool
   isFlexiblePattern p =
     maybe False notOtherFlex <$> runMaybeT (maybeFlexiblePattern p)
     where

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/Types.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/Types.hs
@@ -56,7 +56,7 @@ data Equality = Equal
 eqConstructorForm :: HasBuiltins m => Equality -> m Equality
 eqConstructorForm (Equal a u v) = Equal a <$> constructorForm u <*> constructorForm v
 
-eqUnLevel :: (HasBuiltins m, HasOptions m) => Equality -> m Equality
+eqUnLevel :: (HasBuiltins m) => Equality -> m Equality
 eqUnLevel (Equal a u v) = Equal a <$> unLevel u <*> unLevel v
   where
     unLevel (Level l) = reallyUnLevelView l

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -48,7 +48,6 @@ import qualified Data.Text      as T
 import qualified Data.Text.Lazy as TL
 import Data.Typeable (Typeable, TypeRep, typeRep, typeRepFingerprint)
 import GHC.Exts
-import GHC.Stack
 import GHC.Fingerprint.Type
 import Unsafe.Coerce
 
@@ -246,11 +245,11 @@ type S a = ReaderT Dict IO a
 -- decoding slower.
 type R = ReaderT Decode IO
 
-malformed :: HasCallStack => R a
+malformed :: R a
 malformed = liftIO $ E.throwIO $ E.ErrorCall "Malformed input."
 {-# NOINLINE malformed #-} -- 2023-10-2 András: cold code, so should be out-of-line.
 
-malformedIO :: HasCallStack => IO a
+malformedIO :: IO a
 malformedIO = E.throwIO $ E.ErrorCall "Malformed input."
 {-# NOINLINE malformedIO #-}
 
@@ -277,7 +276,7 @@ class Typeable a => EmbPrj a where
     then pure $! toEnum i'
     else malformed
 
-  default icod_ :: (Enum a, Bounded a) => a -> S Word32
+  default icod_ :: (Enum a) => a -> S Word32
   icod_ x = return $! fromIntegral $! fromEnum x
 
 -- | The actual logic of `tickICode` is cold code, so it's out-of-line,
@@ -397,7 +396,7 @@ icodeNode key = do
 
 -- | @icode@ only if thing has not been seen before.
 icodeMemo
-  :: (Ord a, Hashable a)
+  :: (Hashable a)
   => (Dict -> HashTableLU a Word32)    -- ^ Memo structure for thing of key @a@.
   -> (Dict -> FreshAndReuse)         -- ^ Counter and statistics.
   -> a        -- ^ Key to the thing.

--- a/src/full/Agda/TypeChecking/Serialise/Instances/General.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/General.hs
@@ -295,7 +295,7 @@ instance (EmbPrj k, EmbPrj v, EmbPrj (BiMap.Tag v)) =>
   icod_ m = icode (BiMap.toDistinctAscendingLists m)
   value m = BiMap.fromDistinctAscendingLists <$!> value m
 
-instance (Eq k, Hashable k, EmbPrj k, EmbPrj v) => EmbPrj (HashMap k v) where
+instance (Hashable k, EmbPrj k, EmbPrj v) => EmbPrj (HashMap k v) where
   icod_ m = icodeNode =<< icodeListPair (HMap.foldrWithKey' (\ k v !acc -> Cons k v acc) Nil m)
   value = vcase ((HMap.fromList <$!>) . valueListPair)
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/General.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/General.hs
@@ -310,7 +310,7 @@ instance EmbPrj IntSet where
   icod_ s = icode (IntSet.foldr' (:) [] s)
   value s = IntSet.fromDistinctAscList <$!> value s
 
-instance (Ord a, EmbPrj a) => EmbPrj (Set a) where
+instance (EmbPrj a) => EmbPrj (Set a) where
   icod_ s = icode (Set.foldr' (:) [] s)
   value s = Set.fromDistinctAscList <$!> value s
 
@@ -318,7 +318,7 @@ instance (Hashable a, EmbPrj a) => EmbPrj (HashSet a) where
   icod_ s = icode (Fold.foldr' (:) [] s)
   value s = HSet.fromList <$!> value s
 
-instance (Ord a, EmbPrj a) => EmbPrj (Set1 a) where
+instance (EmbPrj a) => EmbPrj (Set1 a) where
   icod_ s = icode (Set1.foldr' (:) [] s)
   value s = Set1.fromDistinctAscList <$!> value s
 

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -188,7 +188,7 @@ isBounded :: PureTCM m => Nat -> m BoundedSize
 isBounded i = isBoundedSizeType =<< typeOfBV i
 
 isBoundedProjVar
-  :: (MonadCheckInternal m, PureTCM m)
+  :: (MonadCheckInternal m)
   => ProjectedVar -> m BoundedSize
 isBoundedProjVar pv = isBoundedSizeType =<< infer (unviewProjectedVar pv)
 
@@ -205,10 +205,7 @@ isBoundedSizeType t =
 --   In @boundedSizeMetaHook v tel a@, @tel@ includes the current context.
 boundedSizeMetaHook
   :: ( MonadConstraint m
-     , MonadTCEnv m
-     , ReadTCState m
      , MonadAddContext m
-     , HasOptions m
      , HasBuiltins m
      )
   => Term -> Telescope -> Type -> m ()

--- a/src/full/Agda/TypeChecking/SizedTypes/Syntax.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Syntax.hs
@@ -190,7 +190,7 @@ instance Plus (SizeExpr' r f) Offset (SizeExpr' r f) where
 type CTrans r f = Constraint' r f -> Maybe [Constraint' r f]
 
 -- | Returns 'Nothing' if the constraint is contradictory.
-simplify1 :: (Pretty f, Pretty r, Eq r) => CTrans r f -> CTrans r f
+simplify1 :: (Eq r) => CTrans r f -> CTrans r f
 simplify1 test c = do
   let err = Nothing
   case c of

--- a/src/full/Agda/TypeChecking/SizedTypes/WarshallSolver.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/WarshallSolver.hs
@@ -949,7 +949,7 @@ solveGraphs pols hg gs =
 -- | Check that after substitution of the solution,
 --   constraints are implied by hypotheses.
 verifySolution
-  :: (Ord r, Ord f, Pretty r, Pretty f, Show r, Show f)
+  :: (Ord r, Ord f, Pretty r, Pretty f)
   => HypGraph r f
   -> [Constraint' r f]
   -> Solution r f

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -60,7 +60,7 @@ import Agda.Utils.Impossible
 --   straight away, return that. Otherwise, return @UnivSort s@ and add a
 --   constraint to ensure we can compute the sort eventually.
 inferUnivSort
-  :: (PureTCM m, MonadConstraint m)
+  :: (PureTCM m)
   => Sort -> m Sort
 inferUnivSort s = do
   s <- reduce s
@@ -89,7 +89,7 @@ hasBiggerSort = void . inferUnivSort
 --   If we can compute the sort straight away, return that.
 --   Otherwise, return a 'PiSort'.
 --   Note that this function does NOT check PTS constraints, use 'hasPTSRule' for that
-inferPiSort :: (PureTCM m, MonadConstraint m)
+inferPiSort :: (MonadConstraint m)
   => Dom Type  -- ^ Domain of the Pi type.
   -> Abs Type  -- ^ (Dependent) codomain of the Pi type.
   -> m Sort    -- ^ Sort of the Pi type.
@@ -98,7 +98,7 @@ inferPiSort a b = piSortM (unEl <$> a) (getSort a) (getSort <$> b)
 {-# SPECIALIZE inferFunSort :: Dom Type -> Type -> TCM Sort #-}
 -- | As @inferPiSort@, but for a nondependent function type.
 --
-inferFunSort :: (PureTCM m, MonadConstraint m)
+inferFunSort :: (MonadConstraint m)
   => Dom Type  -- ^ Domain of the function type.
   -> Type      -- ^ Sort of the codomain of the function type.
   -> m Sort    -- ^ Sort of the function type.
@@ -180,7 +180,7 @@ shouldBeSort t = ifIsSort t return (typeError $ ShouldBeASort t)
 --
 --   Precondition: given term is a well-sorted type.
 sortOf
-  :: forall m. (PureTCM m, MonadBlock m, MonadConstraint m)
+  :: forall m. (PureTCM m, MonadConstraint m)
   => Term -> m Sort
 sortOf t = do
   reportSDoc "tc.sort" 60 $ "sortOf" <+> prettyTCM t
@@ -251,6 +251,6 @@ sortOf t = do
 {-# INLINE sortOfType #-}
 -- | Reconstruct the minimal sort of a type (ignoring the sort annotation).
 sortOfType
-  :: forall m. (PureTCM m, MonadBlock m,MonadConstraint m)
+  :: forall m. (PureTCM m, MonadConstraint m)
   => Type -> m Sort
 sortOfType = sortOf . unEl

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1537,13 +1537,13 @@ instance (Subst a, Ord a) => Ord (Abs a) where
 
 deriving instance Ord a => Ord (Dom a)
 
-instance (Subst a, Eq a)  => Eq  (Elim' a) where
+instance (Eq a) => Eq (Elim' a) where
   Apply  a == Apply  b = a == b
   Proj _ x == Proj _ y = x == y
   IApply x y r == IApply x' y' r' = x == x' && y == y' && r == r'
   _ == _ = False
 
-instance (Subst a, Ord a) => Ord (Elim' a) where
+instance (Ord a) => Ord (Elim' a) where
   Apply  a `compare` Apply  b = a `compare` b
   Proj _ x `compare` Proj _ y = x `compare` y
   IApply x y r `compare` IApply x' y' r' = compare x x' `mappend` compare y y' `mappend` compare r r'

--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -94,7 +94,7 @@ checkSyntacticEquality u v s f =
       (Type -> Type -> ReduceM a) ->
       ReduceM a #-}
 checkSyntacticEquality'
-  :: (Instantiate a, SynEq a, MonadReduce m)
+  :: (SynEq a, MonadReduce m)
   => a
   -> a
   -> (a -> a -> m b)  -- ^ Continuation used upon success.

--- a/src/full/Agda/TypeChecking/Telescope/Path.hs
+++ b/src/full/Agda/TypeChecking/Telescope/Path.hs
@@ -129,7 +129,7 @@ instance IApplyVars p => IApplyVars [p] where
 
 {-# SPECIALIZE isInterval :: Type -> TCM Bool #-}
 -- | Check whether a type is the built-in interval type.
-isInterval :: (MonadTCM m, MonadReduce m) => Type -> m Bool
+isInterval :: (MonadTCM m) => Type -> m Bool
 isInterval t = liftTCM $ do
   caseMaybeM (getName' builtinInterval) (return False) $ \ i -> do
   reduce (unEl t) <&> \case

--- a/src/full/Agda/TypeChecking/Warnings.hs
+++ b/src/full/Agda/TypeChecking/Warnings.hs
@@ -167,7 +167,7 @@ warning = withCallerCallStack . flip warning'
 
 -- | Raise every 'WARNING_ON_USAGE' connected to a name.
 {-# SPECIALIZE raiseWarningsOnUsage :: QName -> TCM () #-}
-raiseWarningsOnUsage :: (MonadWarning m, ReadTCState m) => QName -> m ()
+raiseWarningsOnUsage :: (MonadWarning m) => QName -> m ()
 raiseWarningsOnUsage d = do
   -- In case we find a defined name, we start by checking whether there's
   -- a warning attached to it

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -251,7 +251,7 @@ instance NFData a => NFData (Benchmark a)
 -- throws deprecation warning in GHC 9.10.3 (deepseq-1.5.2.0),
 -- see https://github.com/haskell/deepseq/issues/111 ,
 -- so we spell it out.
-instance NFData a => NFData (BenchmarkOn a) where
+instance NFData (BenchmarkOn a) where
   rnf = \case
     BenchmarkOff -> ()
     BenchmarkOn  -> ()

--- a/src/full/Agda/Utils/BiMap.hs
+++ b/src/full/Agda/Utils/BiMap.hs
@@ -137,7 +137,7 @@ insert k v (BiMap t b) =
 -- for which @k ≠ k'@ and @'tag' v = 'tag' v'@.
 
 insertPrecondition ::
-  (Eq k, Eq v, Eq (Tag v), HasTag v) =>
+  (Eq k, Eq (Tag v), HasTag v) =>
   k -> v -> BiMap k v -> Bool
 insertPrecondition k v m =
   case tag v of
@@ -190,7 +190,7 @@ alter f k m = runIdentity $ alterM (Identity . f) k m
 -- @k@ may map to a value @v'@ for which @'tag' v' = 'tag' v@.
 
 alterPrecondition ::
-  (Ord k, Eq v, Eq (Tag v), HasTag v) =>
+  (Ord k, Eq (Tag v), HasTag v) =>
   (Maybe v -> Maybe v) -> k -> BiMap k v -> Bool
 alterPrecondition f k m =
   case tag =<< f (lookup k m) of
@@ -216,7 +216,7 @@ update f = alter (f =<<)
 -- than @k@ may map to a value @v'@ for which @'tag' v' = 'tag' v@.
 
 updatePrecondition ::
-  (Ord k, Eq v, Eq (Tag v), HasTag v) =>
+  (Ord k, Eq (Tag v), HasTag v) =>
   (v -> Maybe v) -> k -> BiMap k v -> Bool
 updatePrecondition f = alterPrecondition (f =<<)
 
@@ -234,7 +234,7 @@ adjust f = update (Just . f)
 -- than @k@ may map to a value @v'@ for which @'tag' v' = 'tag' v@.
 
 adjustPrecondition ::
-  (Ord k, Eq v, Eq (Tag v), HasTag v) =>
+  (Ord k, Eq (Tag v), HasTag v) =>
   (v -> v) -> k -> BiMap k v -> Bool
 adjustPrecondition f = updatePrecondition (Just . f)
 
@@ -262,7 +262,7 @@ insertLookupWithKey f k v m = swap $ runState (alterM f' k m) Nothing
 -- @'tag' v'' = 'tag' v'@.
 
 insertLookupWithKeyPrecondition ::
-  (Ord k, Eq v, Eq (Tag v), HasTag v) =>
+  (Ord k, Eq (Tag v), HasTag v) =>
   (k -> v -> v -> v) -> k -> v -> BiMap k v -> Bool
 insertLookupWithKeyPrecondition f k v =
   alterPrecondition (Just . maybe v (f k v)) k
@@ -302,8 +302,7 @@ mapWithKeyFixedTags f (BiMap t b) = BiMap (Map.mapWithKey f t) b
 -- maps @k@ to @v@, then @'tag' (f k v) == 'tag' v@.
 
 mapWithKeyFixedTagsPrecondition ::
-  (Eq v, Eq (Tag v), HasTag v) =>
-  (k -> v -> v) -> BiMap k v -> Bool
+  ( Eq (Tag v), HasTag v) =>(k -> v -> v) -> BiMap k v -> Bool
 mapWithKeyFixedTagsPrecondition f m = and
   [ tag (f k v) == tag v
   | (k, v) <- toList m

--- a/src/full/Agda/Utils/Boolean.hs
+++ b/src/full/Agda/Utils/Boolean.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 {-# OPTIONS_GHC -Wunused-imports #-}
 
 -- | Boolean algebras and types isomorphic to 'Bool'.

--- a/src/full/Agda/Utils/DocTree.hs
+++ b/src/full/Agda/Utils/DocTree.hs
@@ -231,17 +231,17 @@ data LinSt ann = LinSt
 type Lin ann = Fwd (LinSt ann)
 
 -- | Run linearizer with given initial offset.
-evalLin :: Monoid ann => Int -> Lin ann -> (Text, RangeMap ann)
+evalLin :: Int -> Lin ann -> (Text, RangeMap ann)
 evalLin start f =
   case f `appFwd` initLinSt start of
     LinSt _ b m -> (builderToText b, m)
 
 -- | Initial linearizer state with configurable offset.
-initLinSt :: Monoid ann => Int -> LinSt ann
+initLinSt :: Int -> LinSt ann
 initLinSt start = LinSt start mempty empty
 
 -- | Outputting some text under the currently active annotations.
-linText :: Monoid ann => Text -> Lin ann
+linText :: Text -> Lin ann
 linText t = Fwd \case
   LinSt start b m -> LinSt end b' m
     where

--- a/src/full/Agda/Utils/FileId.hs
+++ b/src/full/Agda/Utils/FileId.hs
@@ -91,7 +91,7 @@ registerFileId''  f d@(FileDictBuilder n (FileDict fileToId idToFile)) =
 -- * Monadic interface
 
 class Monad m => MonadFileId m where
-  fileFromId :: FileId -> m File
+  fileFromId :: HasCallStack => FileId -> m File
   idFromFile :: File -> m FileId
 
   default fileFromId :: (MonadTrans t, MonadFileId n, m ~ t n) => FileId -> m File

--- a/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -314,7 +314,7 @@ fromNodes ns = Graph $ Map.fromList $ map (, Map.empty) ns
 -- | Constructs a completely disconnected graph containing the given
 --   nodes. /O(n)/.
 
-fromNodeSet :: Ord n => Set n -> Graph n e
+fromNodeSet :: Set n -> Graph n e
 fromNodeSet ns = Graph $ Map.fromSet (\_ -> Map.empty) ns
 
 -- | @fromEdges es@ is a graph containing the edges in @es@, with the
@@ -446,7 +446,7 @@ clean = Graph . Map.map (Map.filter (not . null)) . graph
 -- that satisfy the predicate @p@. Edges to or from nodes that are
 -- removed are also removed. /O(n + e)/.
 
-filterNodes :: Ord n => (n -> Bool) -> Graph n e -> Graph n e
+filterNodes :: (n -> Bool) -> Graph n e -> Graph n e
 filterNodes p (Graph g) = Graph (Map.mapMaybeWithKey remSrc g)
   where
   remSrc s m
@@ -555,7 +555,7 @@ renameNodes ren =
 -- Time complexity: /O(n + e)/.
 
 renameNodesMonotonic ::
-  (Ord n1, Ord n2) => (n1 -> n2) -> Graph n1 e -> Graph n2 e
+  (n1 -> n2) -> Graph n1 e -> Graph n2 e
 renameNodesMonotonic ren =
   Graph .
   fmap (Map.mapKeysMonotonic ren) .

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -701,7 +701,7 @@ nubOn f = loop Set.empty
 -- @'maxBound' :: 'Int'@.
 
 nubFavouriteOn
-  :: forall a b c. (Ord b, Eq c, Hashable c)
+  :: forall a b c. (Ord b, Hashable c)
   => (a -> b)
      -- ^ The values returned by this function are used to determine
      -- which element from a group of equal elements that is returned:

--- a/src/full/Agda/Utils/ListT.hs
+++ b/src/full/Agda/Utils/ListT.hs
@@ -119,15 +119,15 @@ instance Monad m => Semigroup (ListT m a) where
 instance Monad m => Monoid (ListT m a) where
   mempty = nilListT
 
-instance (Functor m, Applicative m, Monad m) => Alternative (ListT m) where
+instance (Monad m) => Alternative (ListT m) where
   empty = mempty
   (<|>) = mappend
 
-instance (Functor m, Applicative m, Monad m) => MonadPlus (ListT m) where
+instance (Monad m) => MonadPlus (ListT m) where
   mzero = mempty
   mplus = mappend
 
-instance (Functor m, Applicative m, Monad m) => Applicative (ListT m) where
+instance (Monad m) => Applicative (ListT m) where
   pure  = sgListT
   (<*>) = ap
 
@@ -137,21 +137,21 @@ instance (Functor m, Applicative m, Monad m) => Applicative (ListT m) where
   --   loop (Just (f, l1')) (Just (a, l2')) = Just (f a, l1' <*> l2')
   --   loop _ _ = Nothing
 
-instance (Functor m, Applicative m, Monad m) => Monad (ListT m) where
+instance (Monad m) => Monad (ListT m) where
   return  = pure
   l >>= k = concatListT $ k <$> l
 
 instance MonadTrans ListT where
   lift = sgMListT
 
-instance (Applicative m, MonadIO m) => MonadIO (ListT m) where
+instance (MonadIO m) => MonadIO (ListT m) where
   liftIO = lift . liftIO
 
-instance (Applicative m, MonadReader r m) => MonadReader r (ListT m) where
+instance (MonadReader r m) => MonadReader r (ListT m) where
   ask     = lift ask
   local   = mapListT . local
 
-instance (Applicative m, MonadState s m) => MonadState s (ListT m) where
+instance (MonadState s m) => MonadState s (ListT m) where
   get = lift get
   put = lift . put
 

--- a/src/full/Agda/Utils/Memo.hs
+++ b/src/full/Agda/Utils/Memo.hs
@@ -51,7 +51,7 @@ memoUnsafe f = unsafePerformIO $ do
           return y
 
 {-# NOINLINE memoUnsafeH #-}
-memoUnsafeH :: (Eq a, Hashable a) => (a -> b) -> (a -> b)
+memoUnsafeH :: (Hashable a) => (a -> b) -> (a -> b)
 memoUnsafeH f = unsafePerformIO $ do
   tbl <- newIORef HMap.empty
   return (unsafePerformIO . f' tbl)

--- a/src/full/Agda/Utils/Parser/MemoisedCPS.hs
+++ b/src/full/Agda/Utils/Parser/MemoisedCPS.hs
@@ -135,7 +135,7 @@ class (Functor p, Applicative p, Alternative p, Monad p) =>
   -- Every memoised parser must be annotated with a /unique/ key.
   -- (Parametrised parsers must use distinct keys for distinct
   -- inputs.)
-  memoise :: (Eq k, Hashable k, Show k) => k -> p r -> p r
+  memoise :: (Hashable k, Show k) => k -> p r -> p r
 
   -- | Memoises the given parser, but only if printing, not if
   -- parsing.
@@ -143,7 +143,7 @@ class (Functor p, Applicative p, Alternative p, Monad p) =>
   -- Every memoised parser must be annotated with a /unique/ key.
   -- (Parametrised parsers must use distinct keys for distinct
   -- inputs.)
-  memoiseIfPrinting :: (Eq k, Hashable k, Show k) => k -> p r -> p r
+  memoiseIfPrinting :: (Hashable k, Show k) => k -> p r -> p r
 
 -- | Uses the given document as the printed representation of the
 -- given parser. The document's precedence is taken to be 'atomP'.
@@ -313,7 +313,7 @@ prettyKey key = (text ("<" ++ show key ++ ">"), atomP)
 -- | A helper function.
 
 memoiseDocs ::
-  (Eq k, Hashable k, Show k) =>
+  (Hashable k, Show k) =>
   k -> ParserWithGrammar k r tok r -> Docs k
 memoiseDocs key p = do
   r <- Map.lookup key <$> get

--- a/src/full/Agda/Utils/Singleton.hs
+++ b/src/full/Agda/Utils/Singleton.hs
@@ -75,10 +75,10 @@ instance Enum k             => Collection k      (EnumSet k)   where
 instance Enum k             => Collection (k, a) (EnumMap k a) where
   fromList = EnumMap.fromList
   {-# INLINE fromList #-}
-instance (Eq k, Hashable k) => Collection k      (HashSet k)   where
+instance Hashable k         => Collection k      (HashSet k)   where
   fromList = HashSet.fromList
   {-# INLINE fromList #-}
-instance (Eq k, Hashable k) => Collection (k, a) (HashMap k a) where
+instance Hashable k         => Collection (k, a) (HashMap k a) where
   fromList = HashMap.fromList
   {-# INLINE fromList #-}
 instance Ord k              => Collection k      (Set k)       where

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -59,7 +59,7 @@ newtype SmallSet a = SmallSet { theSmallSet :: Word64 }
   deriving (Eq, Ord, Show, NFData)
 
 
-instance SmallSetElement a => Null.Null (SmallSet a) where
+instance Null.Null (SmallSet a) where
   empty = empty
   null = null
 
@@ -72,7 +72,7 @@ instance SmallSetElement a => Monoid (SmallSet a) where
 -- * Query
 
 -- | Time O(1).
-null :: SmallSetElement a => SmallSet a -> Bool
+null :: SmallSet a -> Bool
 null s = theSmallSet s == 0
 
 -- | Time O(1).
@@ -86,11 +86,11 @@ notMember a = not . member a
 -- * Construction
 
 -- | The empty set.  Time O(1).
-empty :: SmallSetElement a => SmallSet a
+empty :: SmallSet a
 empty = SmallSet 0
 
 -- | The full set.  Time O(1).
-total :: forall a. SmallSetElement a => SmallSet a
+total :: forall a. SmallSet a
 total = SmallSet $ Bits.complement 0
 
 -- | A singleton set.  Time O(1).
@@ -108,20 +108,20 @@ delete a s = SmallSet $ theSmallSet s `clearBit` idx a
 -- * Combine
 
 -- | Time O(n).
-complement :: SmallSetElement a => SmallSet a -> SmallSet a
+complement :: SmallSet a -> SmallSet a
 complement = SmallSet . Bits.complement . theSmallSet
 
 -- | Time O(1).
-difference, (\\) :: SmallSetElement a => SmallSet a -> SmallSet a -> SmallSet a
+difference, (\\) :: SmallSet a -> SmallSet a -> SmallSet a
 difference s t = SmallSet $ theSmallSet s .&. Bits.complement (theSmallSet t)
 (\\)       = difference
 
 -- | Time O(1).
-intersection ::  SmallSetElement a => SmallSet a -> SmallSet a -> SmallSet a
+intersection ::  SmallSet a -> SmallSet a -> SmallSet a
 intersection s t = SmallSet $ theSmallSet s .&. theSmallSet t
 
 -- | Time O(n).
-union ::  SmallSetElement a => SmallSet a -> SmallSet a -> SmallSet a
+union ::  SmallSet a -> SmallSet a -> SmallSet a
 union s t = SmallSet $ theSmallSet s .|. theSmallSet t
 
 -- * Conversion

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -63,10 +63,10 @@ instance Null.Null (SmallSet a) where
   empty = empty
   null = null
 
-instance SmallSetElement a => Semigroup (SmallSet a) where
+instance Semigroup (SmallSet a) where
   (<>) = union
 
-instance SmallSetElement a => Monoid (SmallSet a) where
+instance Monoid (SmallSet a) where
   mempty = empty
 
 -- * Query

--- a/src/full/Agda/Utils/Update.hs
+++ b/src/full/Agda/Utils/Update.hs
@@ -105,7 +105,7 @@ dirty a = do
 
 {-# SPECIALIZE ifDirty :: Change a -> (a -> Change b) -> (a -> Change b) -> Change b #-}
 {-# SPECIALIZE ifDirty :: Identity a -> (a -> Identity b) -> (a -> Identity b) -> Identity b #-}
-ifDirty :: (Monad m, MonadChange m) => m a -> (a -> m b) -> (a -> m b) -> m b
+ifDirty :: (MonadChange m) => m a -> (a -> m b) -> (a -> m b) -> m b
 ifDirty m f g = do
   (a, dirty) <- listenDirty m
   if dirty then f a else g a

--- a/src/full/Agda/Utils/WithDefault.hs
+++ b/src/full/Agda/Utils/WithDefault.hs
@@ -48,14 +48,14 @@ instance Null (WithDefault' a b) where
 -- | The main mode of operation of these flags, apart from setting them explicitly,
 -- is to toggle them one way or the other if they hadn't been set already.
 --
-setDefault :: Boolean a => a -> WithDefault' a b -> WithDefault' a b
+setDefault :: a -> WithDefault' a b -> WithDefault' a b
 setDefault b = \case
   Default -> Value b
   t -> t
 
 -- | Only modify non-'Default' values.
 --
-mapValue :: Boolean a => (a -> a) -> WithDefault' a b -> WithDefault' a b
+mapValue :: (a -> a) -> WithDefault' a b -> WithDefault' a b
 mapValue f = \case
   Default -> Default
   Value b -> Value (f b)

--- a/test/Internal/Helpers.hs
+++ b/test/Internal/Helpers.hs
@@ -130,7 +130,7 @@ isSemigroup = isAssociative (<>)
 
 -- | Does the operator satisfy the monoid laws?
 
-isMonoid :: (Eq a, Semigroup a, Monoid a) => Property3 a
+isMonoid :: (Eq a, Monoid a) => Property3 a
 isMonoid x y z =
 -- ASR (2017-01-25): What if `mappend ≠ (<>)`? It isn't possible
 -- because we are using the `-Wnoncanonical-monoid-instances` flag.
@@ -166,7 +166,7 @@ isSemimodule one (*) op r s m n =
   op (r * s) m == op r (op s m)
 
 -- | The semiring is given by an additive monoid, a unit and a multiplication.
-isAlmostSemimodule :: (Eq m, Semigroup r, Monoid r, Semigroup m, Monoid m) => r -> (r -> r -> r) -> (r -> m -> m)
+isAlmostSemimodule :: (Eq m, Semigroup r, Monoid m) => r -> (r -> r -> r) -> (r -> m -> m)
   -> r -> r -> Property2 m
 isAlmostSemimodule one (*) op r s m n =
   isMonoidMorphism (op r) m n
@@ -182,14 +182,14 @@ isAlmostSemimodule one (*) op r s m n =
 -- | Is the semigroup operation monotone in both arguments
 --   wrt. to the associated partial ordering?
 --   We state this with only three variables to get fewer discarded tests.
-isMonotoneComposition :: (Eq a, POSemigroup a) => Property3 a
+isMonotoneComposition :: (POSemigroup a) => Property3 a
 isMonotoneComposition x x' y =
   related x POLE x' ==> related (x <> y) POLE (x' <> y) && related (y <> x) POLE (y <> x')
 
 -- | Do the semigroup operation and the inverse composition form
 --   a Galois connection?
 
-isGaloisConnection :: (Eq a, Semigroup a, LeftClosedPOMonoid a) => Prop3 a
+isGaloisConnection :: (LeftClosedPOMonoid a) => Prop3 a
 isGaloisConnection p x y =
   related (inverseCompose p x) POLE y == related x POLE (p <> y)
 

--- a/test/Internal/Syntax/Position.hs
+++ b/test/Internal/Syntax/Position.hs
@@ -150,7 +150,7 @@ instance Arbitrary a => Arbitrary (Position' a) where
 -- | Generates an interval located in the same file as the given
 -- interval.
 
-intervalInSameFileAs :: Arbitrary a => Interval' a -> Gen (Interval' a)
+intervalInSameFileAs :: Interval' a -> Gen (Interval' a)
 intervalInSameFileAs (Interval f _ _) = do
   i :: IntervalWithoutFile <- arbitrary
   pure $ f <$ i

--- a/test/Internal/Syntax/Position.hs
+++ b/test/Internal/Syntax/Position.hs
@@ -164,7 +164,7 @@ prop_intervalInSameFileAs i =
 -- | Generates a range located in the same file as the given
 -- range (if possible).
 
-rangeInSameFileAs :: (Arbitrary a, Ord a) => Range' a -> Gen (Range' a)
+rangeInSameFileAs :: (Arbitrary a) => Range' a -> Gen (Range' a)
 rangeInSameFileAs NoRange      = arbitrary
 rangeInSameFileAs (Range f is) = do
   Range _f is <- arbitrary `suchThat` (not . null)
@@ -209,14 +209,14 @@ instance Arbitrary RangeFile where
             map T.unpack (List1.toList (moduleNameParts top))
     return $ mkRangeFile f (Just top)
 
-instance (Arbitrary a, Ord a) => Arbitrary (Interval' a) where
+instance (Arbitrary a) => Arbitrary (Interval' a) where
   arbitrary = do
     f <- arbitrary
     (p1, p2 :: PositionWithoutFile) <- liftM2 (,) arbitrary arbitrary
     let (p1', p2') = sortPair (p1, p2)
     return (Interval f p1' p2')
 
-instance (Ord a, Arbitrary a) => Arbitrary (Range' a) where
+instance (Arbitrary a) => Arbitrary (Range' a) where
   arbitrary = do
     f <- arbitrary
     intervalsToRange f . fuse . sort <$> arbitrary

--- a/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/test/Internal/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -121,7 +121,7 @@ prop_acyclicGraph =
 
 -- | Generates a node from the graph. (Unless the graph is empty.)
 
-nodeIn :: (Ord n, Arbitrary n) => Graph n e -> Gen n
+nodeIn :: (Arbitrary n) => Graph n e -> Gen n
 nodeIn g = elementsUnlessEmpty (Set.toList $ nodes g)
 
 -- | Generates an edge from the graph. (Unless the graph contains no

--- a/test/Internal/Utils/RangeMap.hs
+++ b/test/Internal/Utils/RangeMap.hs
@@ -285,7 +285,7 @@ prop_monoid = isMonoid
 ------------------------------------------------------------------------
 -- Generators
 
-instance (Arbitrary a, Semigroup a) => Arbitrary (RangeMap a) where
+instance (Arbitrary a) => Arbitrary (RangeMap a) where
   arbitrary = smaller 5 $ do
     rs <- (\ns1 ns2 ->
             toRanges $ sort $

--- a/test/Internal/Utils/VarSet.hs
+++ b/test/Internal/Utils/VarSet.hs
@@ -144,11 +144,11 @@ prop_minView (Vars ns) =
 --------------------------------------------------------------------------------
 -- Folds
 
-prop_foldr :: (Function a, CoArbitrary a, Arbitrary a, Show a, Eq a) => Fun (Int, a) a -> a -> [Var] -> Property
+prop_foldr :: (Show a, Eq a) => Fun (Int, a) a -> a -> [Var] -> Property
 prop_foldr f a (Vars xs) =
   VarSet.foldr (applyFun2 f) a (VarSet.fromList xs) === IntSet.foldr (applyFun2 f) a (IntSet.fromList xs)
 
-prop_foldl :: (Function a, CoArbitrary a, Arbitrary a, Show a, Eq a) => Fun (a, Int) a -> a -> [Var] -> Property
+prop_foldl :: (Show a, Eq a) => Fun (a, Int) a -> a -> [Var] -> Property
 prop_foldl f a (Vars xs) =
   VarSet.foldl (applyFun2 f) a (VarSet.fromList xs) === IntSet.foldl (applyFun2 f) a (IntSet.fromList xs)
 


### PR DESCRIPTION
- **Turn on -Wredundant-constraints**
  In 3 modules we need to turn it off because of false alarms.
  

- **Redundant constraints caught by GHC 9.14.1**
  
Continues:
- #8358