### PR TITLE
Fix #8365: reduce in wrong context

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1473,7 +1473,7 @@ checkLHS mf = updateModality checkLHS_ where
       da' <- addContext delta1Gamma $ do
              let updCoh = composeCohesion (getCohesion info)
              TelV tel dt <- telView da'
-             return $ abstract (mapCohesion updCoh <$> tel) a
+             return $ abstract (mapCohesion updCoh <$> tel) dt
 
       let stuck b errs = softTypeError $ SplitError $
             UnificationStuck b (conName c) (delta1 `abstract` gamma) cixs ixs' errs

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -387,7 +387,7 @@ literalStrategy k s = do
   let n = eqCount s
   Equal Dom{unDom = a} u v <- eqUnLevel $ getEquality k s
   ha <- fromMaybeMP $ isHom n a
-  (u, v) <- reduce (u, v)
+  (u, v) <- addContext (varTel s) $ reduce (u, v)
   case (u , v) of
     (Lit l1 , Lit l2)
      | l1 == l2  -> return $ Deletion k ha u v

--- a/test/Fail/Issue8365.agda
+++ b/test/Fail/Issue8365.agda
@@ -1,0 +1,27 @@
+-- Andreas, 2026-02-04, issue #8365
+-- 'reduce' in wrong context caused a crash in the presence of rewriting.
+-- Report and original test by Constantine Theocharis, shrunk by Szumi Xie.
+
+{-# OPTIONS --rewriting #-}
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+postulate
+  eq : Bool → Bool → Bool
+  eq-id : (x : Bool) → eq x x ≡ true
+  {-# REWRITE eq-id #-}
+
+g : (f : Bool → Bool) → eq (f false) (f true) ≡ true → Bool
+g f refl = true
+
+-- WAS: internal error due to out-of scope de Bruijn index
+
+-- Expected error: [SplitError.UnificationStuck]
+-- I'm not sure if there should be a case for the constructor refl,
+-- because I get stuck when trying to solve the following unification
+-- problems (inferred index ≟ expected index):
+--   eq (f false) (f true) ≟ true
+-- when checking that the pattern refl has type
+-- eq (f false) (f true) ≡ true

--- a/test/Fail/Issue8365.err
+++ b/test/Fail/Issue8365.err
@@ -1,0 +1,7 @@
+Issue8365.agda:17.5-9: error: [SplitError.UnificationStuck]
+I'm not sure if there should be a case for the constructor refl,
+because I get stuck when trying to solve the following unification
+problems (inferred index ≟ expected index):
+  eq (f false) (f true) ≟ true
+when checking that the pattern refl has type
+eq (f false) (f true) ≡ true


### PR DESCRIPTION
- **Debug #8365, fix a wrong type introduced by 40b3907**
  The wrong type showed up in debug printing.
  Apparently it did not have any fatal effects, sleeping for 7 years...
  

- **Fix #8365: reduce in wrong context in unify literalStrategy**
  Closes #8365
  