### PR TITLE
 Fix #7139: LeftInverse: reorder context in Solution steps

### DIFF
--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -647,6 +647,7 @@ createMissingTrXConClause q_trX f n x old_sc c (UE gamma gamma' xTel u v rho tau
     , "u"  <+> addContext gamma (prettyTCM u)
     , "v"  <+> addContext gamma (prettyTCM v)
     , "rho" <+> addContext gamma' (prettyTCM rho)
+    , "tau" <+> pretty tau
     ]
 
   Constructor{conSrcCon = chead} <- theDef <$> getConstInfo c

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1809,8 +1809,8 @@ data MetaVariable =
                 , mvPriority      :: MetaPriority -- ^ some metavariables are more eager to be instantiated
                 , mvPermutation   :: Permutation
                   -- ^ a metavariable doesn't have to depend on all variables
-                  --   in the context, this "permutation" will throw away the
-                  --   ones it does not depend on
+                  --   in the context, this "permutation" (on de Bruijn levels)
+                  --   will throw away the ones it does not depend on
                 , mvJudgement     :: Judgement MetaId
                 , mvInstantiation :: MetaInstantiation
                 , mvListeners     :: Set Listener -- ^ meta variables scheduled for eta-expansion but blocked by this one

--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify.hs
@@ -887,11 +887,12 @@ solutionStep retry s
           solutionStep DontRetryNormalised s step{ solutionTerm = u }
         Nothing ->
           return $ UnifyStuck [UnifyRecursiveEq (varTel s) a i u]
-        Just (s', sub) -> do
+        Just (s', sub, perm) -> do
           let rho = sub `composeS` dotSub
           tellUnifySubst rho
           let (s'', sigma) = solveEq k (applyPatSubst rho u) s'
           tellUnifyProof sigma
+          tellUnifySolutionPerm perm
           return $ Unifies s''
           -- Andreas, 2019-02-23, issue #3578: do not eagerly reduce
           -- Unifies <$> liftTCM (reduce s'')

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -787,6 +787,7 @@ abstractArgs args x = abstract tel x
 ---------------------------------------------------------------------------
 
 -- | If @permute π : [a]Γ -> [a]Δ@, then @applySubst (renaming _ π) : Term Γ -> Term Δ@
+--   Assumes that π works on de Bruijn _indices_.
 renaming :: forall a. DeBruijn a => Impossible -> Permutation -> Substitution' a
 renaming err p = prependS err gamma $ raiseS $ size p
   where
@@ -795,6 +796,7 @@ renaming err p = prependS err gamma $ raiseS $ size p
     -- gamma = safePermute (invertP (-1) p) $ map deBruijnVar [0..]
 
 -- | If @permute π : [a]Γ -> [a]Δ@, then @applySubst (renamingR π) : Term Δ -> Term Γ@
+--   Assumes that π works on de Bruijn _levels_.
 renamingR :: DeBruijn a => Permutation -> Substitution' a
 renamingR p@(Perm n is) = xs ++# raiseS n
   where
@@ -818,7 +820,7 @@ renamingR p@(Perm n is) = xs ++# raiseS n
   -- takes constant time), while the time complexity of the former
   -- code depends on the value of the largest index in is.
 
--- | The permutation should permute the corresponding context. (right-to-left list)
+-- | The permutation should permute the corresponding context. (as de Bruijn _indices_)
 renameP :: Subst a => Impossible -> Permutation -> a -> a
 renameP err p = applySubst (renaming err p)
 

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -122,11 +122,15 @@ teleNames = map (fst . unDom) . telToList
 teleArgNames :: Telescope -> [Arg ArgName]
 teleArgNames = telToArgs
 
--- | Convert a telescope to a list of 'Arg' in descending order.
+-- | Convert a telescope to a list of 'Arg' in left-to-right order:
+--
+--   @teleArgs ((a : A) (b : B a) {c : C}) = [a, b, {c}] = [2, 1, {0}]@
 teleArgs :: (DeBruijn a) => Tele (Dom t) -> [Arg a]
 teleArgs = map argFromDom . teleDoms
 
--- | Convert a telescope to a list of 'Dom' in descending order.
+-- | Convert a telescope to a list of 'Dom' in left-to-right order:
+--
+--   @teleDoms ((a : A) (b : B a) {c : C}) = [a, b, {c}] = [2, 1, {0}]@
 teleDoms :: (DeBruijn a) => Tele (Dom t) -> [Dom a]
 teleDoms tel = zipWith (\ i dom -> deBruijnVar i <$ dom) (downFrom $ size l) l
   where l = telToList tel
@@ -167,26 +171,26 @@ splitTelescopeAt n tel
           (tel', tel'') = splitTelescopeAt (m - 1) $ absBody tel
 
 -- | Permute telescope: permutes or drops the types in the telescope according
---   to the given permutation. Assumes that the permutation preserves the
+--   to the given permutation (on de Bruijn _levels_). Assumes that the permutation preserves the
 --   dependencies in the telescope.
 --
 --   For example (Andreas, 2016-12-18, issue #2344):
 --   @
---     tel                     = (A : Set) (X : _18 A) (i : Fin (_m_23 A X))
---     tel (de Bruijn)         = 2:Set, 1:_18 @0, 0:Fin(_m_23 @1 @0)
---     flattenTel tel          = 2:Set, 1:_18 @0, 0:Fin(_m_23 @1 @0) |- [ Set, _18 @2, Fin (_m_23 @2 @1) ]
---     perm                    = 0,1,2 -> 0,1  (picks the first two)
---     renaming _ perm         = [var 0, var 1, error]  -- THE WRONG RENAMING!
---     renaming _ (flipP perm) = [error, var 1, var 0]  -- The correct renaming!
---     apply to flattened tel  = ... |- [ Set, _18 @1, Fin (_m_23 @1 @0) ]
---     permute perm it         = ... |- [ Set, _18 @1 ]
---     unflatten (de Bruijn)   = 1:Set, 0: _18 @0
---     unflatten               = (A : Set) (X : _18 A)
---  @
+--     tel                        = (A : Set) (X : _18 A) (i : Fin (_m_23 A X))
+--     tel (de Bruijn)            = 2:Set, 1:_18 @0, 0:Fin(_m_23 @1 @0)
+--     flattenTel tel             = 2:Set, 1:_18 @0, 0:Fin(_m_23 @1 @0) |- [ Set, _18 @2, Fin (_m_23 @2 @1) ]
+--     perm                       = 0,1,2 -> 0,1  (picks the first two)
+--     renaming _ perm            = [var 0, var 1, error]  -- THE WRONG RENAMING! (levels)
+--     renaming _ (reverseP perm) = [error, var 0, var 1]  -- The correct renaming! (indices)
+--     apply to flattened tel     = ... |- [ Set, _18 @1, Fin (_m_23 @1 @0) ]
+--     permute perm it            = ... |- [ Set, _18 @1 ]
+--     unflatten (de Bruijn)      = 1:Set, 0: _18 @0
+--     unflatten                  = (A : Set) (X : _18 A)
+--   @
 permuteTel :: Permutation -> Telescope -> Telescope
 permuteTel perm tel =
   let names = permute perm $ teleNames tel
-      types = permute perm $ renameP impossible (flipP perm) $ flattenTel tel
+      types = permute perm $ renameP impossible (reverseP perm) $ flattenTel tel
   in  unflattenTel names types
 
 -- | Like 'permuteTel', but start with a context.
@@ -263,7 +267,7 @@ data SplitTel = SplitTel
   { firstPart  :: Telescope
   , secondPart :: Telescope
   , splitPerm  :: Permutation
-    -- ^ The permutation takes us from the original telescope to
+    -- ^ The permutation (of de Bruijn _levels_) that takes us from the original telescope to
     --   @firstPart ++ secondPart@.
   }
 

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -19,6 +19,7 @@ import Data.Maybe
 import GHC.Generics (Generic)
 
 import Agda.Utils.Functor
+import Agda.Utils.List
 import Agda.Utils.Null
 import Agda.Utils.Size
 import Agda.Utils.Tuple
@@ -185,6 +186,14 @@ invertP err p@(Perm n xs) = Perm (size xs) $ elems tmpArray
   tmpArray :: Array Int Int
   tmpArray = accumArray (const id) err (0, n-1) $ zip xs [0..]
 
+-- | @lookupP π i@ applies @π@ to @i@.
+lookupP :: Permutation -> Int -> Maybe Int
+lookupP (Perm n xs) i = xs !!! i
+
+-- | @lookupRP π i@ applies @invertP π@ to @i@.
+lookupRP :: Permutation -> Int -> Maybe Int
+lookupRP (Perm n xs) i = List.elemIndex i xs
+
 -- | Turn a possible non-surjective permutation into a surjective permutation.
 compactP :: Permutation -> Permutation
 compactP p@(Perm _ xs) = Perm (length xs) $ map adjust xs
@@ -232,6 +241,10 @@ expandP i n (Perm m xs) = Perm (m + n - 1) $ concatMap expand xs
       | j == i    = [i..i + n - 1]
       | j < i     = [j]
       | otherwise = [j + n - 1]
+
+-- | @deleteP i π@ deletes the value @i@ from the output of @π@.
+deleteP :: Int -> Permutation -> Permutation
+deleteP i (Perm n xs) = Perm n (List.delete i xs)
 
 -- | Stable topologic sort. The first argument decides whether its first
 --   argument is an immediate parent to its second argument.

--- a/test/Succeed/Issue7139.agda
+++ b/test/Succeed/Issue7139.agda
@@ -1,0 +1,26 @@
+{-# OPTIONS --cubical #-}
+module Issue7139 where
+
+open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive.Cubical renaming
+  ( primIMax to _∨_ ; primIMin to _∧_ ; primINeg to ~_ ; primComp to comp
+  ; primHComp to hcomp ; primTransp to transp)
+open import Agda.Builtin.Cubical.Path
+open import Agda.Builtin.Nat
+
+module M (V : Type) (s : V → V) where
+  data Loops : V → Type where
+    pt : (x : V) → Loops (s x)
+
+  data Point : {x : V} → Loops x → Type where
+    isPt : (x : V) → Point (pt x)
+
+  unPt : ∀ {x : V} {y : Loops x} → Point y → V
+  unPt (isPt x) = x
+
+open M Nat suc
+
+-- The transpX clause for unPt used to be generated incorrectly, which
+-- led to a loss of canonicity.
+compute : unPt (transp (λ i → Point (pt 0)) i0 (isPt 0)) ≡ 0
+compute _ = 0


### PR DESCRIPTION
Fixes https://github.com/agda/agda/issues/7139 by correctly reordering the context when building the left inverse corresponding to "solution" unification steps.

Tested against the usual suspects (stdlib, cubical, 1lab).

### Details

The unification process (`Agda.TypeChecking.Rules.LHS.Unify`) applies a series of steps to some starting context `Γ` and telescope of equations `Γ ⊢ us ≡ vs` until the equations are gone. What remains is a smaller context `Γ'` and a unifying substitution `Γ' ⊢ σ : Γ` that identifies `us` and `vs`. For cubical purposes (in particular, generating the `transpX` clauses of functions matching on indexed inductives), it is also necessary to compute a "left inverse" substitution `Γ ⊢ τ : Γ'` to `σ`, which is done separately in `...Unify.LeftInverse`.

The "solution" step gets rid of an equation of the form `Γ ⊢ var x ≡ u` by instantiating `x` with `u` in `Γ`. Since `u` can depend on things that come after `x` in `Γ`, in order for the resulting context to be well-formed we have to first *reorder* `Γ` so that everything that `u` depends on comes before everything that depends on `x`, and only then instantiate `x` away. The `instantiateTelescope` function is responsible for doing this (if it is possible at all).

The issue was that `LeftInverse` was not aware of this reordering and simply assumed that `x` was dropped from `Γ` as-is, so the resulting substitution `τ` had the wrong target context. The fix in this PR is to extract the reordering of `Γ` generated by `instantiateTelescope` and record it as part of the `UnifyOutput` for solution steps so that `LeftInverse.buildEquiv` can apply it when computing `τ`.

In the example of https://github.com/agda/agda/issues/7139 (included as a test case), we start with `Γ = (x0 : V) (y0 : Loops x0) (x1 : V)`, `eqs = (eq0 : s x1 ≡ x0) (eq1 : pt x1 ≡ y0)`. The first unification step solves `x0` as `s x1`, which requires reordering `Γ` as `Γʳ = (x0 : V) (x1 : V) (y0 : Loops x0)` so that the resulting context `Γ' = (x1 : V) (y0 : Loops (s x1))` is well-formed. (Note that this is why using `s` in the indices makes a difference: if `eq0 : x1 ≡ x0` then `x1` is solved as `x0` instead, which does not require reordering.) Since `buildEquiv` did not take this reordering into account, the generated `τ` was ill-typed, which in turn led to the generated `transpX` clause being ill-typed.

In the process, I noticed that `permuteTel` was wrong (funnily enough, even *after* the fix in https://github.com/agda/agda/issues/2344). I fixed it and added comments in several places noting whether de Bruijn indices or levels are used. Maybe it would be good to have a more type-safe interface to avoid these polarity errors. I also tried to clean up the comments in `LeftInverse.buildEquiv`, but the code in that file is still pretty daunting...