### PR TITLE
Fix #8374: allow fixity declarations in parent of an anonymous module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,30 @@ Changes to the Agda syntax.
   desugaring these are looked up in `M` rather than in the surrounding
   scope.
 
+* Fixity declarations may now appear outside of the anonymous module
+  that contains the operators they apply to
+  ([Issue #8374](https://github.com/agda/agda/issues/8374)).
+  E.g. the following is now accepted:
+  ```agda
+  infixr 6 _∷_
+
+  module _ (A : Set) where
+    data List : Set where
+      [] : List
+      _∷_ : A → List → List
+  ```
+  Rationale: anonymous modules do not really define a new scope,
+  they just serve to declare common parameters.
+  With the fix, the above can be seamlessly refactored from
+  ```agda
+  infixr 6 _∷_
+
+  data List (A : Set) : Set where
+    [] : List A
+    _∷_ : A → List A → List A
+  ```
+  without having to move the fixity declaration into the module.
+
 Language
 --------
 

--- a/test/Fail/Issue8374.agda
+++ b/test/Fail/Issue8374.agda
@@ -1,0 +1,27 @@
+-- Andreas, 2026-02-07, issue #8374
+
+-- This fixity declaration should NOT apply to the operator in the following module.
+infixr 20 _∷_
+
+-- Expected warning: -W[no]UnknownNamesInFixityDecl
+-- The following names are not declared in the same scope as their
+-- syntax or fixity declaration (i.e., either not in scope at all,
+-- imported from another module, or declared in a super module): _∷_
+
+module M (A : Set) where
+  data List : Set where
+    [] : List
+    _∷_ : A → List → List
+
+open M
+
+-- This needs the fixity to parse, so we expect a parse error.
+
+dup : {A : Set} (a : A) → List A
+dup a = a ∷ a ∷ []
+
+-- Expected error: [NoParseForApplication]
+-- Could not parse the application a ∷ a ∷ []
+-- Operators used in the grammar:
+--   ∷ (infix operator, level 20) [_∷_ (...)]
+-- when scope checking a ∷ a ∷ []

--- a/test/Fail/Issue8374.err
+++ b/test/Fail/Issue8374.err
@@ -1,0 +1,10 @@
+Issue8374.agda:4.11-14: warning: -W[no]UnknownNamesInFixityDecl
+The following names are not declared in the same scope as their
+syntax or fixity declaration (i.e., either not in scope at all,
+imported from another module, or declared in a super module): _∷_
+
+Issue8374.agda:21.9-19: error: [NoParseForApplication]
+Could not parse the application a ∷ a ∷ []
+Operators used in the grammar:
+  ∷ (infix operator, level 20) [_∷_ (Issue8374.agda:14.5-8)]
+when scope checking a ∷ a ∷ []

--- a/test/Fail/Issue8374Overwrite.agda
+++ b/test/Fail/Issue8374Overwrite.agda
@@ -1,0 +1,27 @@
+-- Andreas, 2026-02-07, issue #8374
+-- Allow fixity declarations outside of anonymous modules.
+
+infixr 20 _∷_
+
+module _ (A : Set) where
+  data List : Set where
+    [] : List
+    _∷_ : A → List → List
+
+  -- This (incorrect) fixity overwrites the outer (correct) fixity.
+  infixl 42 _∷_
+
+-- This needs the correct fixity to type check:
+
+dup : {A : Set} (a : A) → List A
+dup a = a ∷ a ∷ []
+
+-- Expected error: [UnequalTypes]
+-- The type
+--   List _A_9
+-- is not a subtype of
+--   A
+-- when checking that the inferred type of an application
+--   List _A_9
+-- matches the expected type
+--   A

--- a/test/Fail/Issue8374Overwrite.err
+++ b/test/Fail/Issue8374Overwrite.err
@@ -1,0 +1,9 @@
+Issue8374Overwrite.agda:17.9-14: error: [UnequalTypes]
+The type
+  List _A_7
+is not a subtype of
+  A
+when checking that the inferred type of an application
+  List _A_7
+matches the expected type
+  A

--- a/test/Succeed/Issue8374.agda
+++ b/test/Succeed/Issue8374.agda
@@ -1,0 +1,57 @@
+-- Andreas, 2026-02-07, issue #8374
+-- Allow fixity declarations outside of anoymous modules.
+
+module _ where
+
+-- This fixity declaration should also apply to the operator in the anonymous module.
+
+module NonNest where
+
+  infixr 20 _∷_
+
+  module _ (A : Set) where
+    data List : Set where
+      [] : List
+      _∷_ : A → List → List
+
+  -- This needs the fixity to parse:
+
+  dup : {A : Set} (a : A) → List A
+  dup a = a ∷ a ∷ []
+
+module Nest where
+
+  infixr 20 _∷_
+
+  module _ (A : Set) where
+    B = A -- random stuff
+
+    -- Add another layer of anonymous module
+    module _ where
+      data List : Set where
+        [] : List
+        _∷_ : A → List → List
+
+  -- This needs the fixity to parse:
+
+  dup : {A : Set} (a : A) → List A
+  dup a = a ∷ a ∷ []
+
+module Overwrite where
+
+  infixl 0 _∷_
+
+  module _ (A : Set) where
+    B = A -- random stuff
+
+    -- Add another layer of anonymous module
+    module _ where
+      data List : Set where
+        [] : List
+        _∷_ : A → List → List
+      infixr 20 _∷_
+
+  -- This needs the fixity to parse:
+
+  dup : {A : Set} (a : A) → List A
+  dup a = a ∷ a ∷ []


### PR DESCRIPTION
Commits:

- **Re #8374 Add fixities to debug printing of scope**
  Need to move around some instances to avoid import cycles.
  

- **Makefile: add missing AGDA_OPTS to continue-std-lib-test goal**
  

- **Fix #8374: allow fixity declarations in parent of anonymous module**
  

- **New: Agda.Utils.Map.partition{Map/Keys}**
  

- **[cosmetics] Fix formatting in a haddock comment**

TODO:
- [x] CHANGELOG
- [x] check docs
  