### PR TITLE
Stop eta-expanding module applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,7 +214,7 @@ Warnings
   - Unlike the other warnings about problematic rewrite rules, Agda will still
     try its best to apply rewrites which trigger this warning.
     This is because some very useful rewrite rules unfortunately do not preserve
-    subject reduction in the presense of definitional singletons.
+    subject reduction in the presence of definitional singletons.
 
 Syntax
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,6 +352,19 @@ Changes to type checker and other components defining the Agda language.
   [variants](https://agda.readthedocs.io/en/v2.9.0/language/cubical.html#variants).
 
 
+* Module applications are no longer automatically eta-expanded. E.g.
+  previously, given the below three modules:
+  ```agda
+  module A where
+    postulate X : Set
+
+  module B (Y : Set) where
+    open A public
+
+  module C = B
+  ```
+  `B.X` would have type `Set` while `C.X` would have type `Set → Set` (as if
+  the user wrote `module C Y = B Y`). After this change, `C.X : Set` instead.
 
 Reflection
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,7 +351,6 @@ Changes to type checker and other components defining the Agda language.
   For compatibility with modules using `--cubical[=full]` and `--cubical=erased`, see
   [variants](https://agda.readthedocs.io/en/v2.9.0/language/cubical.html#variants).
 
-
 * (**BREAKING**): Module applications are no longer automatically eta-expanded.
   E.g. previously, given the below three modules:
   ```agda
@@ -365,6 +364,7 @@ Changes to type checker and other components defining the Agda language.
   ```
   `B.X` would have type `Set` while `C.X` would have type `Set → Set` (as if
   the user wrote `module C Y = B Y`). After this change, `C.X : Set` instead.
+
 
 Reflection
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,8 +352,8 @@ Changes to type checker and other components defining the Agda language.
   [variants](https://agda.readthedocs.io/en/v2.9.0/language/cubical.html#variants).
 
 
-* Module applications are no longer automatically eta-expanded. E.g.
-  previously, given the below three modules:
+* (**BREAKING**): Module applications are no longer automatically eta-expanded.
+  E.g. previously, given the below three modules:
   ```agda
   module A where
     postulate X : Set

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -593,7 +593,7 @@ applySection' new ptel old ts ren@ScopeCopyInfo{ renNames = rd, renModules = rm 
       np  <- argsToUse (qnameModule x)
       -- Because of https://github.com/agda/agda/issues/892 we might have too
       -- many arguments and need to drop some
-      origTel <- lookupSection (qnameModule x)
+      origTel <- lookupSection $ qnameModule x
       let ts' = drop (size ts - size origTel) ts
       -- Issue #3083: We need to use the hiding from the telescope of the
       -- original module. This can be different than the hiding for the common

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -1079,7 +1079,7 @@ checkSectionApplication'
     -- Andreas, 2014-04-06, Issue 1094:
     -- Add the section with well-formed telescope.
     -- Nathaniel, 2026-02-08:
-    -- We build the telescope before entering addSection (in the presense of
+    -- We build the telescope before entering addSection (in the presence of
     -- local rewrite rules, adding aTel to the context is unsafe)
     ctxTel <- getContextTelescope
     reportSDoc "tc.mod.apply" 80 $

--- a/test/Succeed/Issue1985.agda
+++ b/test/Succeed/Issue1985.agda
@@ -24,7 +24,8 @@ module Fails where
   --   A : Set
   --   A = Par.A
 
-  A₁ A₂ B₁ B₂ : Set₁ → Set
+  A₁ B₁ B₂ : Set₁ → Set
+  A₂ : Set
   A₁ = RenP.A
   A₂ = Ren.A
   B₁ = RenP.B

--- a/test/Succeed/Issue1985.agda
+++ b/test/Succeed/Issue1985.agda
@@ -17,12 +17,15 @@ module Par (X : Set₁) where
 module Fails where
   module RenP (X : Set₁) = Par X
   module Ren = Par
-  -- Like RenP, Ren should contain
-  --   A : (B : Set) → Set
-  --   A B = Par.A B
-  -- but it incorrectly contained
+  -- Like Par, Ren should contain
   --   A : Set
   --   A = Par.A
+  -- RenP, on the other hand contains
+  --   A : (X : Set₁) → Set
+  --   A X = Par.A
+
+  A₀ : Set
+  A₀ = Par.A
 
   A₁ B₁ B₂ : Set₁ → Set
   A₂ : Set

--- a/test/Succeed/Issue1985c.agda
+++ b/test/Succeed/Issue1985c.agda
@@ -1,0 +1,42 @@
+module Issue1985c where
+
+module Def where
+  postulate A : Set
+
+module Par1 (B : Set₁) where
+  module Par2 (C : Set₁) where
+    open Def public
+
+module Test1 where
+  open Par1.Par2 Set Set
+  test : Set
+  test = A
+
+module Bar = Par1 Set
+
+module Test2 where
+  open Bar.Par2
+  test : Set
+  test = A
+
+module Test3 where
+  open Bar.Par2 Set
+  test : Set
+  test = A
+
+module Baz = Par1
+
+module Test4 where
+  open Baz.Par2
+  test : Set
+  test = A
+
+module Test5 where
+  open Baz.Par2 Set
+  test : Set
+  test = A
+
+module Test6 where
+  open Baz.Par2 Set Set
+  test : Set
+  test = A

--- a/test/Succeed/Issue892b.agda
+++ b/test/Succeed/Issue892b.agda
@@ -25,10 +25,10 @@ module QM2p (x : D) = Q.M2 x x
 test-h : X₂ → D
 test-h = QM2d.h
 
-test-g₁ : X₂ → X₁ → D
+test-g₁ : X₁ → D
 test-g₁ = QM2d.g
 
-test-g₂ : D → X₂ → X₁ → D
+test-g₂ : D → X₁ → D
 test-g₂ = QM2p.g
 
 data Nat : Set where
@@ -91,6 +91,6 @@ module NT = NatTrans
 foo : Set → Set
 foo X = Eta.Z X → Eta′.Z X
   module Local where
-    module Eta = NT.NatT X X
+    module Eta = NT.NatT X
     -- equivalent to
-    module Eta′ (Y : Set) = NT.NatT X X Y
+    module Eta′ (Y : Set) = NT.NatT X Y


### PR DESCRIPTION
Reverts https://github.com/agda/agda/commit/a06c209 and implements a new fix.

In the presence of local rewrite rules (work in progress), eta-expanding module applications is unsafe (in general going under binders after applying a substitution is problematic).

We instead fix https://github.com/agda/agda/issues/1985 by dropping arguments to certain definitions at the point of opening the module.

This is a breaking change:
```agda
module A where
  postulate X : Set

module B (Y : Set) where
  open A public

module C = B

testB : Set
testB = B.X

-- This used to typecheck and now does not
testC-old : Set → Set
testC-old = C.X

-- This used to fail and now typechecks
testC-new : Set
testC-new = C.X
```
I personally find the new behaviour more intuitive.

If we want to avoid a breaking change, I could disable this eta-expanding behaviour ONLY for modules with local rewrite rule arguments (and I am not completely against doing this) but I think having subtly diverging behaviour is not great for test coverage (in a perfect world, I would kill `testB`/https://github.com/agda/agda/issues/892 completely, but as was mentioned at the time and in https://github.com/agda/agda/issues/4057, the existing behaviour is sometimes helpful).