### PR TITLE
Local Rewrite Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,8 @@ Pragmas and options
 * `{-# NO_POSITIVITY_CHECK #-}` pragmas are now recognized in `record` declarations and `where` blocks,
   and pertain to the following `data` or `record` declaration or mutual block.
 
+* New option `--local-rewriting` which enables parameterising over computation rules by annotating module parameters with `@rewrite` attributes. See the [local rewriting documentation](https://agda.readthedocs.io/en/v2.9.0/language/local-rewriting.html) for more info.
+
 Errors
 ------
 

--- a/doc/user-manual/language/index.rst
+++ b/doc/user-manual/language/index.rst
@@ -30,6 +30,7 @@ Language Reference
    let-and-where
    lexical-structure
    literal-overloading
+   local-rewriting
    lossy-unification
    mixfix-operators
    modalities

--- a/doc/user-manual/language/local-rewriting.lagda.rst
+++ b/doc/user-manual/language/local-rewriting.lagda.rst
@@ -1,0 +1,219 @@
+
+.. _local-rewriting:
+
+***************
+Local Rewriting
+***************
+
+
+Local rewrite rules is an experimental feature which enables parameterising
+modules over computation rules. Specifically, it allows declaring
+module parameters targetting a rewrite relation as local rewrite rules by
+annotating with them the ``@rewrite`` attribute. Consequently:
+
+* Inside the module, local rewrite rules will automatically apply during
+  reduction, rewriting instances of the left-hand side to the right-hand side,
+  similarly to :doc:`global rewriting <rewriting>`.
+* Outside the module, local rewrite rules act as constraints on
+  instantiations of the module parameters. E.g. when
+  opening the module, Agda will check that both sides are
+  definitionally equal.
+
+This feature is based on Local Rewriting Type Theory (LRTT) as introduced in
+`Encode the Cake and Eat It Too <https://hal.science/hal-05160846v1/document>`_,
+by Yann Leray and Théo Winterhalter. Unlike their presentation, we do not
+make a strong syntactic
+distinction between the "interface environment" and the "local context", but
+nonetheless, by restricting
+``@rewrite`` attributes to module parameters, quantification over
+rewrites is prenex-only. For example, definitions cannot return local rewrite
+rules, or be parameterised over other definitions taking local rewrite rules,
+so ``foo : (n : Nat) → ((@rewrite p : n ≡ 0) → Nat) → Nat`` is not allowed.
+
+Semantically, local rewrite rules can
+be eliminated by inlining all instantiations of modules with local rewrite
+rule parameters and so should be conservative over the rest of
+Agda's theory.
+
+.. note:: This page is about the :option:`--local-rewriting` option. This is
+  is unrelated to :option:`--local-confluence-check`, which enables a form of
+  confluence checking for :doc:`global REWRITE rules <rewriting>` whilst using
+  the :option:`--rewriting` option.
+
+  It is also (currently) distinct from the the :ref:`rewrite construct
+  <with-rewrite>`, although there are plans to implement a new version of
+  :doc:`with-abstraction <with-abstraction>` which internally desugars to
+  local rewrite rules ("smart with").
+
+Local rewrite rules by example
+------------------------------
+
+::
+
+  {-# OPTIONS --local-rewriting --rewriting #-}
+
+  module language.local-rewriting where
+
+  open import Agda.Builtin.Equality
+  open import Agda.Builtin.Equality.Rewrite
+
+..
+  ::
+
+  open import Agda.Builtin.Nat hiding (_+_)
+  open import Agda.Builtin.Sigma
+  open import Agda.Builtin.Unit
+  open import Agda.Builtin.List
+
+  _×_ : Set → Set → Set
+  A × B = Σ A λ _ → B
+
+  data _⊎_ (A B : Set) : Set where
+    inl : A → A ⊎ B
+    inr : B → A ⊎ B
+
+  data ⊥ : Set where
+
+  cong : ∀ {A B : Set} {x y} (f : A → B) → x ≡ y → f x ≡ f y
+  cong f refl = refl
+
+  sym : ∀ {A : Set} {x y : A} → x ≡ y → y ≡ x
+  sym refl = refl
+
+  trans : ∀ {A : Set} {x y z : A} → x ≡ y → y ≡ z → x ≡ z
+  trans refl q = q
+
+To motivate local rewrite rules, consider the following code which implements
+addition and proves associativity for Agda's built-in natural numbers.
+
+::
+
+  module Addition where
+    _+_ : Nat → Nat → Nat
+    zero  + m = m
+    suc n + m = suc (n + m)
+
+    +-assoc : ∀ {n m l} → (n + m) + l ≡ n + (m + l)
+    +-assoc {n = zero}  = refl
+    +-assoc {n = suc n} = cong suc (+-assoc {n = n})
+
+Now imagine we want to use a different encoding of natural numbers - for
+example, lists of unit values.
+
+::
+
+  Nat' = List ⊤
+
+To define addition and prove associativity for ``Nat'`` without
+duplication, we can parameterise our addition and the
+associativity definitions over an abstract type of natural numbers and an
+induction principle.
+
+::
+
+  module ParametricAddition
+    (Nat : Set) (zero : Nat) (suc : Nat → Nat)
+    (ind : (P : Nat → Set) → P zero → (∀ n → P n → P (suc n)) → ∀ n → P n)
+    (ind-zero : ∀ {P z s} → ind P z s zero ≡ z)
+    (ind-suc  : ∀ {P z s n} → ind P z s (suc n) ≡ s n (ind P z s n))
+    where
+    _+_ : Nat → Nat → Nat
+    n + m = ind (λ _ → Nat) m (λ _ → suc) n
+
+    +-assoc : ∀ {n m l} → (n + m) + l ≡ n + (m + l)
+    +-assoc {n = n} {m = m} {l = l}
+      = ind (λ □ → (□ + m) + l ≡ □ + (m + l))
+            (trans (cong (_+ l) ind-zero) (sym ind-zero))
+            (λ _ h → trans (cong (_+ l) ind-suc)
+                   ( trans ind-suc
+                   ( trans (cong suc h) (sym ind-suc))))
+            n
+
+We have succeeded in writing a single parametric definition of addition and
+associativity, but at the cost of a much more convoluted proof.
+The parameterised-over
+induction principle no longer computes on zero and
+successor automatically, so we have to manually invoke ``ind-zero`` and
+``ind-suc`` multiple times.
+
+Local rewrite rules resolve this tedium. We can simply annotate the ``ind-zero``
+and ``ind-suc`` equations with ``@rewrite`` and recover the simple associativity
+proof, whilst staying parametric over encoding details.
+
+::
+
+  module ParametricAdditionRew
+    (Nat : Set) (zero : Nat) (suc : Nat → Nat)
+    (ind : (P : Nat → Set) → P zero → (∀ n → P n → P (suc n)) → ∀ n → P n)
+    (@rewrite ind-zero : ∀ {P z s} → ind P z s zero ≡ z)
+    (@rewrite ind-suc  : ∀ {P z s n} → ind P z s (suc n) ≡ s n (ind P z s n))
+    where
+    _+_ : Nat → Nat → Nat
+    n + m = ind (λ _ → Nat) m (λ _ → suc) n
+
+    +-assoc : ∀ {n m l} → (n + m) + l ≡ n + (m + l)
+    +-assoc {n = n} {m = m} {l = l}
+      = ind (λ □ → (□ + m) + l ≡ □ + (m + l)) refl (λ _ h → cong suc h) n
+
+For more examples on where local rewrite rules can be useful, see the
+`Encode the Cake and Eat It Too <https://hal.science/hal-05160846v1/document>`_
+paper.
+
+Limitations
+-----------
+
+Confluence and termination checking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Currently, no form of confluence or termination checking is implemented for
+local rewrite rules. The consequences of non-confluent or non-terminating
+local rewrite rules are similar to :doc:`global rewriting <rewriting>`:
+non-confluence endangers subject reduction and non-termination might cause
+the typechecker to loop, but logical soundness should never be threatened.
+
+Refining local rewrite rules with pattern matching
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Currently, inaccessible pattern matches on variables that occur in local rewrite
+rules are not allowed. This is to avoid typechecking under invalid rewrite rules
+(rewrite validity is unstable under substitution).
+
+.. code-block:: agda
+
+  module _ (f : Nat → Nat) (@rewrite p : f 1 ≡ 0) where
+    bad : f ≡ (λ x → x) → Nat
+    bad refl = {!!} -- Substituting 'f' for 'λ x → x' here would invalidate the
+                    -- local rewrite rule 'p'
+
+Furthermore, matches on variables in local rewrite rules breaks the
+inlining-based semantic justification.
+
+In spite of these downsides, there are plans to relax this restriction in the
+future under an additional flag. Refining local rewrite
+rules with pattern matches enables a restricted form of
+"local equality reflection", which has many interesting applications, including
+a (hopefully) better-behaved :doc:`with-abstraction <with-abstraction>`
+mechanism.
+
+Parameterising datatypes over local rewrite rules with :option:`--cubical`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In :doc:`Cubical Agda <cubical>`, there is an additional limitation with local
+rewrite rules. Attempting to declare data or record types inside modules with
+local rewrite rule
+parameters will throw a ``CannotGenerateTransportLocalRewrite`` error:
+
+::
+
+  module _ (n : Nat) (@rewrite _ : n ≡ 0) where
+    data Foo : Set where
+      mk : Foo
+
+This restriction is due to how Cubical Agda automatically defines various
+primitives
+for datatypes for transport and path composition. It is not
+(currently) clear what these should look like for datatypes with local
+rewrite rule parameters.
+
+If you run into this issue, try defining your data or record
+types outside of the module with the local rewrite rule.

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -741,6 +741,19 @@ Experimental features
 
      Default, opposite of :option:`--rewriting`.
 
+.. option:: --local-rewriting
+
+     .. versionadded:: 2.9.0
+
+     Enable declaring local rewrite rules with the ``@rewrite`` attribute (see
+     :ref:`local-rewriting`).
+
+.. option:: --no-local-rewriting
+
+     .. versionadded:: 2.9.0
+
+     Default, opposite of :option:`--local-rewriting`.
+
 .. option:: --two-level
 
      .. versionadded:: 2.6.2
@@ -1573,9 +1586,17 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Unknown fields in library files.
 
+.. option:: LocalRewritingConfluenceCheck
+
+     Confluence checking (:option:`--confluence-check` or :option:`--local-confluence-check`) is not yet implemented for local rewrite rules (:option:`--local-rewriting`).
+
 .. option:: MisplacedAttributes
 
      Attributes where they cannot appear.
+
+.. option:: MisplacedRewrite
+
+     Invalid local rewrite annotations, automatically ignored.
 
 .. option:: MissingTypeSignatureForOpaque
 
@@ -1920,6 +1941,14 @@ Such *error warnings* are always on, they cannot be toggled by :option:`-W`.
 
      Importing a file using e.g. :option:`--cubical` into one which does not.
 
+.. option:: InferredLocalRewrite
+
+     Tried to solve a meta with an '@rewrite' function.
+
+.. option:: LocalRewriteOutsideTelescope
+
+     '@rewrite' arguments are (currently) only allowed in module telescopes.
+
 .. option:: MissingDataDeclaration
 
      Constructor definitions not associated to a data declaration.
@@ -2101,6 +2130,7 @@ are infective:
 * :option:`--polarity`
 * :option:`--prop`
 * :option:`--rewriting`
+* :option:`--local-rewriting`
 * :option:`--two-level`
 
 Furthermore, the Cubical options are *jointly infective*
@@ -2194,6 +2224,7 @@ again, the source file is re-typechecked instead:
 * :option:`--qualified-instances`
 * :option:`--quote-metas`
 * :option:`--rewriting`
+* :option:`--local-rewriting`
 * :option:`--safe`
 * :option:`--save-metas`
 * :option:`--syntactic-equality`

--- a/src/data/lib/prim/Agda/Builtin/Equality/Rewrite.agda
+++ b/src/data/lib/prim/Agda/Builtin/Equality/Rewrite.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical-compatible --rewriting --no-sized-types --no-guardedness --level-universe #-}
+{-# OPTIONS --cubical-compatible --no-sized-types --no-guardedness --level-universe #-}
 
 module Agda.Builtin.Equality.Rewrite where
 

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -465,6 +465,8 @@ warningHighlighting' b w = case tcWarning w of
     where r = getRange q
   FixingPolarity _ q _       -> if null r then cosmeticProblemHighlighting w else deadcodeHighlighting r
     where r = getRange q
+  IgnoringRew _ q            -> if null r then cosmeticProblemHighlighting w else deadcodeHighlighting r
+    where r = getRange q
   IllformedAsClause{}        -> deadcodeHighlighting w
   UnusedImports m Nothing    -> deadcodeHighlighting w
   UnusedImports m xs         -> cosmeticProblemHighlighting w <> foldMap deadcodeHighlighting xs
@@ -508,8 +510,10 @@ warningHighlighting' b w = case tcWarning w of
   RewriteMaybeNonConfluent{} -> confluenceErrorHighlighting w
   RewriteAmbiguousRules{}    -> confluenceErrorHighlighting w
   RewriteMissingRule{}       -> confluenceErrorHighlighting w
-  IllegalRewriteRule x _     -> deadcodeHighlighting x
+  IllegalRewriteRule (GlobalRewrite x)  _ -> deadcodeHighlighting (defName x)
+  IllegalRewriteRule (LocalRewrite _ x _) _ -> deadcodeHighlighting x
   NotARewriteRule x _        -> deadcodeHighlighting x
+  InferredLocalRewrite _ _   -> mempty
   PragmaCompileErased{}      -> deadcodeHighlighting w
   PragmaCompileList{}        -> deadcodeHighlighting w
   PragmaCompileMaybe{}       -> deadcodeHighlighting w
@@ -592,6 +596,7 @@ warningHighlighting' b w = case tcWarning w of
     InvalidConstructorBlock{}        -> deadcodeHighlighting w
     InvalidDataOrRecDefParameter{}   -> deadcodeHighlighting w
     InvalidTacticAttribute{}         -> deadcodeHighlighting w
+    InvalidRewriteAttribute{}        -> deadcodeHighlighting w
     OpenImportAbstract{}             -> cosmeticProblemHighlighting w
     OpenImportPrivate{}              -> cosmeticProblemHighlighting w
     SafeFlagEta                   {} -> errorWarningHighlighting w

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -351,13 +351,13 @@ mergeInterface i = do
         else do
           reportSDoc "" 1 $ P.vcat $ map (P.nest 2) $
             "Checking confluence of imported rewrite rules" :
-            map (("-" P.<+>) . prettyTCM . rewName) rews
+            map (("-" P.<+>) . prettyTCM . grName) rews
 
       -- Andreas, 2025-06-28, PR #7934 and issue #7969:
       -- Global confluence checker requires rules to be sorted
       -- according to the generality of their lhs
       when (confChk == GlobalConfluenceCheck) $
-        forM_ (nubOn id $ map rewHead rews) sortRulesOfSymbol
+        forM_ (nubOn id $ map grHead rews) sortRulesOfSymbol
 
       -- #8273: We need to ensure the module we are importing is considered
       -- imported when checking confluence.

--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -80,6 +80,7 @@ module Agda.Interaction.Options.Base
     , lensOptErasedMatches
     , lensOptEraseRecordParameters
     , lensOptRewriting
+    , lensOptLocalRewriting
     , lensOptCubical
     , lensOptGuarded
     , lensOptFirstOrder
@@ -145,6 +146,7 @@ module Agda.Interaction.Options.Base
     , optErasedMatches
     , optEraseRecordParameters
     , optRewriting
+    , optLocalRewriting
     , optGuarded
     , optFirstOrder
     , optRequireUniqueMetaSolutions
@@ -314,6 +316,7 @@ optErasure                   :: PragmaOptions -> Bool
 optErasedMatches             :: PragmaOptions -> Bool
 optEraseRecordParameters     :: PragmaOptions -> Bool
 optRewriting                 :: PragmaOptions -> Bool
+optLocalRewriting            :: PragmaOptions -> Bool
 optGuarded                   :: PragmaOptions -> Bool
 optFirstOrder                :: PragmaOptions -> Bool
 optRequireUniqueMetaSolutions :: PragmaOptions -> Bool
@@ -378,6 +381,7 @@ optErasure                   = collapseDefault . _optErasure || optEraseRecordPa
 optErasedMatches             = collapseDefault . _optErasedMatches && optErasure
 optEraseRecordParameters     = collapseDefault . _optEraseRecordParameters
 optRewriting                 = collapseDefault . _optRewriting
+optLocalRewriting            = collapseDefault . _optLocalRewriting
 optGuarded                   = collapseDefault . _optGuarded
 optFirstOrder                = collapseDefault . _optFirstOrder
 optRequireUniqueMetaSolutions = collapseDefault . _optRequireUniqueMetaSolutions && not . optFirstOrder
@@ -550,6 +554,9 @@ lensOptEraseRecordParameters f o = f (_optEraseRecordParameters o) <&> \ i -> o{
 lensOptRewriting :: Lens' PragmaOptions _
 lensOptRewriting f o = f (_optRewriting o) <&> \ i -> o{ _optRewriting = i }
 
+lensOptLocalRewriting :: Lens' PragmaOptions _
+lensOptLocalRewriting f o = f (_optLocalRewriting o) <&> \ i -> o{ _optLocalRewriting = i }
+
 lensOptCubical :: Lens' PragmaOptions _
 lensOptCubical f o = f (_optCubical o) <&> \ i -> o{ _optCubical = i }
 
@@ -694,6 +701,8 @@ data OptionWarning
       -- ^ Name of option changed in a newer version of Agda.
   | WarningProblem WarningModeError
       -- ^ A problem with setting or unsetting a warning.
+  | LocalRewritingConfluenceCheck
+      -- ^ Confluence checking for local rewrite rules is unimplemented.
   deriving (Show, Generic)
 
 instance NFData OptionWarning
@@ -703,6 +712,7 @@ instance Pretty OptionWarning where
     OptionRenamed old new -> hsep
       [ "Option", option old, "is deprecated, please use", option new, "instead" ]
     WarningProblem err -> pretty (prettyWarningModeError err) <+> "See --help=warning."
+    LocalRewritingConfluenceCheck -> fsep $ pwords "Confluence checking (--confluence-check or --local-confluence-check) is not yet implemented for local rewrite rules (--local-rewriting)"
     where
     option = text . ("--" ++)
 
@@ -710,11 +720,13 @@ optionWarningName :: OptionWarning -> WarningName
 optionWarningName = \case
   OptionRenamed{} -> OptionRenamed_
   WarningProblem{} -> WarningProblem_
+  LocalRewritingConfluenceCheck -> LocalRewritingConfluenceCheck_
 
 -- | Checks that the given options are consistent.
 --   Also makes adjustments (e.g. when one option implies another).
 
-checkOpts :: MonadError OptionError m => CommandLineOptions -> m CommandLineOptions
+checkOpts :: (MonadError OptionError m, MonadWriter OptionWarnings m)
+  => CommandLineOptions -> m CommandLineOptions
 checkOpts opts = do
   -- NOTE: This is a temporary hold-out until --vim can be converted into a backend or plugin,
   -- whose options compatibility currently is checked in `Agda.Compiler.Backend`.
@@ -735,7 +747,8 @@ checkOpts opts = do
 
 -- | Check for pragma option consistency and make adjustments.
 
-checkPragmaOptions :: MonadError OptionError m => PragmaOptions -> m PragmaOptions
+checkPragmaOptions :: (MonadError OptionError m, MonadWriter OptionWarnings m)
+  => PragmaOptions -> m PragmaOptions
 checkPragmaOptions opts = do
 
   -- Check for errors in pragma options.
@@ -743,6 +756,9 @@ checkPragmaOptions opts = do
   when ((optEraseRecordParameters `butNot` optErasure) opts) $
     throwError
       "The option --erase-record-parameters requires the use of --erasure"
+
+  when (isJust (optConfluenceCheck opts) && optLocalRewriting opts) $
+    tell1 LocalRewritingConfluenceCheck
 
 #ifndef COUNT_CLUSTERS
   when (optCountClusters opts) $
@@ -806,6 +822,8 @@ unsafePragmaOptions opts =
   [ "--irrelevant-projections"          | optIrrelevantProjections opts                     ] ++
   [ "--experimental-irrelevance"        | optExperimentalIrrelevance opts                   ] ++
   [ "--rewriting"                       | optRewriting opts                                 ] ++
+  [ "--local-rewriting"                 | optLocalRewriting opts                            ]
+  ++
   [ "--cubical=compatible and --with-K" | optCubicalCompatible opts, not (optWithoutK opts) ] ++
   [ "--without-K and --flat-split"      | optWithoutK opts, optFlatSplit opts               ] ++
   [ "--cumulativity"                    | optCumulativity opts                              ] ++
@@ -926,6 +944,7 @@ infectiveCoinfectiveOptions =
   , infectiveOption optProp                   "--prop"
   , infectiveOption optTwoLevel               "--two-level"
   , infectiveOption optRewriting              "--rewriting"
+  , infectiveOption optLocalRewriting         "--local-rewriting"
   , infectiveOption optSizedTypes             "--sized-types"
   , infectiveOption optGuardedness            "--guardedness"
   , infectiveOption optFlatSplit              "--flat-split"
@@ -1628,6 +1647,9 @@ rewritingPragmaOptions = ("Rewriting and confluence",) $ concat
     , Option []     ["no-confluence-check"] (NoArg noConfluenceCheckFlag)
                     "disable confluence checking of REWRITE rules (default)"
     ]
+  , pragmaFlag      "local-rewriting" lensOptLocalRewriting
+                    "enable declaring local rewrite rules with the @rewrite annotation" ""
+                    $ Just "disable local rewrite rules"
   ]
 
 equalityCheckingPragmaOptions :: (String, [OptDescr (Flag PragmaOptions)])

--- a/src/full/Agda/Interaction/Options/Default.hs
+++ b/src/full/Agda/Interaction/Options/Default.hs
@@ -86,6 +86,7 @@ defaultPragmaOptions = PragmaOptions
   , _optErasedMatches              = Default
   , _optEraseRecordParameters      = Default
   , _optRewriting                  = Default
+  , _optLocalRewriting             = Default
   , _optCubical                    = Nothing
   , _optGuarded                    = Default
   , _optFirstOrder                 = Default

--- a/src/full/Agda/Interaction/Options/Errors.hs
+++ b/src/full/Agda/Interaction/Options/Errors.hs
@@ -118,6 +118,7 @@ data ErrorName
   | CannotGeneralizeEtaExpandable_
   | CannotGenerateHCompClause_
   | CannotGenerateTransportClause_
+  | CannotGenerateTransportLocalRewrite_
   | CannotQuote_ CannotQuote_
   | CannotQuoteTerm_ CannotQuoteTerm
   | CannotResolveAmbiguousPatternSynonym_

--- a/src/full/Agda/Interaction/Options/Types.hs
+++ b/src/full/Agda/Interaction/Options/Types.hs
@@ -154,6 +154,8 @@ data PragmaOptions = PragmaOptions
       -- ^ Mark parameters of record modules as erased?
   , _optRewriting                 :: WithDefault 'False
       -- ^ Can rewrite rules be added and used?
+  , _optLocalRewriting            :: WithDefault 'False
+      -- ^ Can local rewrite rules be added and used?
   , _optCubical                   :: Maybe Cubical
   , _optGuarded                   :: WithDefault 'False
   , _optFirstOrder                :: WithDefault 'False

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -200,6 +200,8 @@ errorWarnings = Set.fromList
   , RewriteMaybeNonConfluent_
   , RewriteAmbiguousRules_
   , RewriteMissingRule_
+  , LocalRewriteOutsideTelescope_
+  , InferredLocalRewrite_
   , TopLevelPolarity_
 
   -- Recoverable parse errors
@@ -247,6 +249,7 @@ data WarningName
   = OptionRenamed_
   | WarningProblem_
       -- ^ Some warning could not be set or unset.
+  | LocalRewritingConfluenceCheck_
   -- Parser Warnings
   | OverlappingTokensWarning_
   | MisplacedAttributes_
@@ -314,6 +317,7 @@ data WarningName
   | FixingCohesion_
   | FixingPolarity_
   | FixingRelevance_
+  | MisplacedRewrite_
   -- TODO: linearity
   -- -- | FixingQuantity_
   | FixityInRenamingModule_
@@ -371,6 +375,8 @@ data WarningName
   | RewriteAmbiguousRules_
   | RewriteMissingRule_
   | DuplicateRewriteRule_
+  | LocalRewriteOutsideTelescope_
+  | InferredLocalRewrite_
   | SafeFlagEta_
   | SafeFlagInjective_
   | SafeFlagNoCoverageCheck_
@@ -498,6 +504,7 @@ warningNameDescription = \case
   -- Option Warnings
   OptionRenamed_                   -> "Renamed options."
   WarningProblem_                  -> "Problems with switching warnings."
+  LocalRewritingConfluenceCheck_   -> "Confluence checking local rewrite rules in not yet implemented."
   -- Parser Warnings
   OverlappingTokensWarning_        -> "Multi-line comments spanning one or more literate text blocks."
   MisplacedAttributes_             -> "Attributes where they are not supported."
@@ -571,6 +578,7 @@ warningNameDescription = \case
   FixingRelevance_                 -> "Correcting invalid user-written relevance attribute."
   FixingCohesion_                  -> "Correcting invalid user-written cohesion attribute."
   FixingPolarity_                  -> "Correcting invalid user-written polarity attribute."
+  MisplacedRewrite_                -> "Ignoring invalid user-written local rewrite attribute."
   InvalidCharacterLiteral_         -> "Illegal character literals."
   UselessPragma_                   -> "Pragmas that get ignored."
   IllegalDeclarationInDataDefinition_ -> "Declarations not allowed in `data' definitions."
@@ -624,6 +632,8 @@ warningNameDescription = \case
   RewriteAmbiguousRules_           -> "Failed global confluence checks because of overlapping rules."
   RewriteMissingRule_              -> "Failed global confluence checks because of missing rule."
   DuplicateRewriteRule_            -> "Duplicate rewrite rules."
+  LocalRewriteOutsideTelescope_    -> "'@rewrite' arguments are (currently) only allowed in module telescopes."
+  InferredLocalRewrite_            -> "Tried to solve a meta with an '@rewrite' function."
   SafeFlagEta_                     -> "`ETA' pragmas with the safe flag."
   SafeFlagInjective_               -> "`INJECTIVE' pragmas with the safe flag."
   SafeFlagNoCoverageCheck_         -> "`NON_COVERING` pragmas with the safe flag."

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1793,6 +1793,7 @@ data Annotation = Annotation
   { annLock :: Lock
     -- ^ Fitch-style dependent right adjoints.
     --   See Modal Dependent Type Theory and Dependent Right Adjoints, arXiv:1804.05236.
+  , annRewrite :: RewriteAnn
   } deriving (Eq, Ord, Show, Generic)
 
 instance HasRange Annotation where
@@ -1802,14 +1803,14 @@ instance KillRange Annotation where
   killRange = id
 
 defaultAnnotation :: Annotation
-defaultAnnotation = Annotation defaultLock
+defaultAnnotation = Annotation defaultLock defaultRewrite
 
 instance Null Annotation where
   empty = defaultAnnotation
-  null (Annotation lock) = null lock
+  null (Annotation lock rew) = null lock && null rew
 
 instance NFData Annotation where
-  rnf (Annotation l) = rnf l
+  rnf (Annotation l r) = rnf (l, r)
 
 class LensAnnotation a where
 
@@ -1894,6 +1895,54 @@ instance Pretty Lock where
 
 prettyLock :: LensLock a => a -> Doc -> Doc
 prettyLock a = (pretty (getLock a) <+>)
+
+---------------------------------------------------------------------------
+-- * Rewrite arguments
+---------------------------------------------------------------------------
+
+data RewriteAnn
+  = IsNotRewrite
+  | IsRewrite
+  deriving (Show, Generic, Eq, Ord)
+
+defaultRewrite :: RewriteAnn
+defaultRewrite = IsNotRewrite
+
+instance Null RewriteAnn where
+  empty = defaultRewrite
+
+instance NFData RewriteAnn where
+  rnf IsNotRewrite = ()
+  rnf IsRewrite    = ()
+
+instance Pretty RewriteAnn where
+  pretty = \case
+    IsRewrite     -> "@rewrite"
+    IsNotRewrite -> empty
+
+class LensRewriteAnn a where
+
+  getRewriteAnn :: a -> RewriteAnn
+
+  setRewriteAnn :: RewriteAnn -> a -> a
+  setRewriteAnn = mapRewriteAnn . const
+
+  mapRewriteAnn :: (RewriteAnn -> RewriteAnn) -> a -> a
+  mapRewriteAnn f a = setRewriteAnn (f $ getRewriteAnn a) a
+
+instance LensRewriteAnn RewriteAnn where
+  getRewriteAnn = id
+  setRewriteAnn = const
+  mapRewriteAnn = id
+
+instance LensRewriteAnn ArgInfo where
+  getRewriteAnn = annRewrite . argInfoAnnotation
+  setRewriteAnn r info = info { argInfoAnnotation = (argInfoAnnotation info){ annRewrite = r } }
+
+instance LensRewriteAnn (Arg t) where
+  getRewriteAnn = getRewriteAnn . getArgInfo
+  setRewriteAnn = mapArgInfo . setRewriteAnn
+
 
 ---------------------------------------------------------------------------
 -- * Cohesion

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -1874,6 +1874,8 @@ class LensLock a where
   mapLock :: (Lock -> Lock) -> a -> a
   mapLock f a = setLock (f $ getLock a) a
 
+  {-# MINIMAL getLock , (setLock | mapLock) #-}
+
 instance LensLock Lock where
   getLock = id
   setLock = const
@@ -1902,23 +1904,42 @@ prettyLock a = (pretty (getLock a) <+>)
 
 data RewriteAnn
   = IsNotRewrite
-  | IsRewrite
-  deriving (Show, Generic, Eq, Ord)
+  | IsRewrite Range
+  deriving (Show, Generic)
 
 defaultRewrite :: RewriteAnn
 defaultRewrite = IsNotRewrite
+
+instance HasRange RewriteAnn where
+  getRange = \case
+    IsRewrite r  -> r
+    IsNotRewrite -> noRange
+
+instance SetRange RewriteAnn where
+  setRange r = \case
+    IsRewrite _  -> IsRewrite r
+    IsNotRewrite -> IsNotRewrite
+
+instance KillRange RewriteAnn where
+  killRange = setRange noRange
+
+instance Eq RewriteAnn where
+  (==) = (==) `on` isRewrite
+
+instance Ord RewriteAnn where
+  compare = compare `on` isRewrite
 
 instance Null RewriteAnn where
   empty = defaultRewrite
 
 instance NFData RewriteAnn where
-  rnf IsNotRewrite = ()
-  rnf IsRewrite    = ()
+  rnf IsNotRewrite  = ()
+  rnf (IsRewrite _) = ()
 
 instance Pretty RewriteAnn where
   pretty = \case
-    IsRewrite     -> "@rewrite"
-    IsNotRewrite -> empty
+    (IsRewrite _) -> "@rewrite"
+    IsNotRewrite  -> empty
 
 class LensRewriteAnn a where
 
@@ -1929,6 +1950,8 @@ class LensRewriteAnn a where
 
   mapRewriteAnn :: (RewriteAnn -> RewriteAnn) -> a -> a
   mapRewriteAnn f a = setRewriteAnn (f $ getRewriteAnn a) a
+
+  {-# MINIMAL getRewriteAnn , (setRewriteAnn | mapRewriteAnn) #-}
 
 instance LensRewriteAnn RewriteAnn where
   getRewriteAnn = id
@@ -1943,6 +1966,20 @@ instance LensRewriteAnn (Arg t) where
   getRewriteAnn = getRewriteAnn . getArgInfo
   setRewriteAnn = mapArgInfo . setRewriteAnn
 
+isRewrite :: LensRewriteAnn a => a -> Bool
+isRewrite a = case getRewriteAnn a of
+  IsRewrite _  -> True
+  IsNotRewrite -> False
+
+ignoreRew :: Monad m => LensRewriteAnn a => (RewriteAnn  -> m ()) -> a -> m a
+ignoreRew warn info
+  | isRewrite info = do
+    warn $ getRewriteAnn info
+    return $ setRewriteAnn IsNotRewrite info
+  | otherwise      = return info
+
+prettyRewriteAnn :: LensRewriteAnn a => a -> Doc -> Doc
+prettyRewriteAnn a = (pretty (getRewriteAnn a) <+>)
 
 ---------------------------------------------------------------------------
 -- * Cohesion

--- a/src/full/Agda/Syntax/Concrete/Attribute.hs
+++ b/src/full/Agda/Syntax/Concrete/Attribute.hs
@@ -41,6 +41,7 @@ data Attribute
   | CohesionAttribute Cohesion
   | PolarityAttribute PolarityModality
   | LockAttribute      Lock
+  | RewriteAttribute RewriteAnn
   deriving (Show)
 
 instance HasRange Attribute where
@@ -51,6 +52,7 @@ instance HasRange Attribute where
     PolarityAttribute p  -> getRange p
     TacticAttribute e    -> getRange e
     LockAttribute _l     -> NoRange
+    RewriteAttribute _r  -> NoRange
 
 instance SetRange Attribute where
   setRange r = \case
@@ -60,6 +62,7 @@ instance SetRange Attribute where
     PolarityAttribute p  -> PolarityAttribute  $ setRange r p
     TacticAttribute e    -> TacticAttribute e  -- -- $ setRange r e -- SetRange Expr not yet implemented
     LockAttribute l      -> LockAttribute l
+    RewriteAttribute r   -> RewriteAttribute r
 
 instance KillRange Attribute where
   killRange = \case
@@ -69,6 +72,7 @@ instance KillRange Attribute where
     PolarityAttribute p  -> PolarityAttribute  $ killRange p
     TacticAttribute e    -> TacticAttribute    $ killRange e
     LockAttribute l      -> LockAttribute l
+    RewriteAttribute r   -> RewriteAttribute r
 
 -- | Parsed attribute.
 
@@ -89,7 +93,7 @@ instance KillRange Attr where
 
 -- | (Conjunctive constraint.)
 
-type LensAttribute a = (LensRelevance a, LensQuantity a, LensCohesion a, LensModalPolarity a, LensLock a)
+type LensAttribute a = (LensRelevance a, LensQuantity a, LensCohesion a, LensModalPolarity a, LensLock a, LensRewriteAnn a)
 
 -- | Modifiers for 'Relevance'.
 
@@ -150,7 +154,7 @@ polarityAttributeTable =
   , ("-" , withStandardLock Negative)
   , ("mixed" , withStandardLock MixedPolarity)]
 
--- | Modifiers for 'Quantity'.
+-- | Modifiers for 'Lock'.
 
 lockAttributeTable :: [(String, Lock)]
 lockAttributeTable = concat
@@ -159,6 +163,13 @@ lockAttributeTable = concat
   , map (, IsLock LockOLock) [ "lock" ] -- @lock
   ]
 
+-- | Modifiers for @RewriteAnn@
+
+rewriteAttributeTable :: [(String, RewriteAnn)]
+rewriteAttributeTable =
+  [ ("notrew" , IsNotRewrite)
+  , ("rew" , IsRewrite)
+  ]
 
 -- | Concrete syntax for all attributes.
 
@@ -169,6 +180,7 @@ attributesMap = Map.fromListWith __IMPOSSIBLE__ $ concat
   , map (second CohesionAttribute)  cohesionAttributeTable
   , map (second PolarityAttribute)  polarityAttributeTable
   , map (second LockAttribute)      lockAttributeTable
+  , map (second RewriteAttribute)   rewriteAttributeTable
   ]
 
 -- | Parsing a string into an attribute.
@@ -192,6 +204,7 @@ setAttribute = \case
   CohesionAttribute  c -> setCohesion  c
   PolarityAttribute  p -> setModalPolarity p
   LockAttribute      l -> setLock      l
+  RewriteAttribute   r -> setRewriteAnn r
   TacticAttribute _    -> id
 
 
@@ -241,6 +254,14 @@ setPristineLock q a
   | getLock a == defaultLock = Just $ setLock q a
   | otherwise = Nothing
 
+
+-- | Setting 'RewriteAnn' if unset.
+
+setPristineRewriteAnn :: (LensRewriteAnn a) => RewriteAnn -> a -> Maybe a
+setPristineRewriteAnn q a
+  | getRewriteAnn a == defaultRewrite = Just $ setRewriteAnn q a
+  | otherwise = Nothing
+
 -- | Setting an unset attribute (to e.g. an 'Arg').
 
 setPristineAttribute :: (LensAttribute a) => Attribute -> a -> Maybe a
@@ -250,6 +271,7 @@ setPristineAttribute = \case
   CohesionAttribute  c -> setPristineCohesion  c
   PolarityAttribute  p -> setPristinePolarity  p
   LockAttribute      l -> setPristineLock      l
+  RewriteAttribute   r -> setPristineRewriteAnn r
   TacticAttribute{}    -> Just
 
 -- | Setting a list of unset attributes.

--- a/src/full/Agda/Syntax/Concrete/Attribute.hs
+++ b/src/full/Agda/Syntax/Concrete/Attribute.hs
@@ -164,11 +164,11 @@ lockAttributeTable = concat
   ]
 
 -- | Modifiers for @RewriteAnn@
-
+--   I don't think we ever actually hit this because 'rewrite' is a keyword
+--   Of course, we might want to add aliases
 rewriteAttributeTable :: [(String, RewriteAnn)]
 rewriteAttributeTable =
-  [ ("notrew" , IsNotRewrite)
-  , ("rew" , IsRewrite)
+  [ ("rewrite" , IsRewrite noRange)
   ]
 
 -- | Concrete syntax for all attributes.
@@ -254,7 +254,6 @@ setPristineLock q a
   | getLock a == defaultLock = Just $ setLock q a
   | otherwise = Nothing
 
-
 -- | Setting 'RewriteAnn' if unset.
 
 setPristineRewriteAnn :: (LensRewriteAnn a) => RewriteAnn -> a -> Maybe a
@@ -298,6 +297,11 @@ isTacticAttribute = C.TacticAttribute . \case
   TacticAttribute t -> Just t
   _ -> Nothing
 
+isRewriteAttribute :: Attribute -> Maybe RewriteAnn
+isRewriteAttribute = \case
+  RewriteAttribute q -> Just q
+  _                  -> Nothing
+
 relevanceAttributes :: [Attribute] -> [Attribute]
 relevanceAttributes = filter $ isJust . isRelevanceAttribute
 
@@ -306,3 +310,6 @@ quantityAttributes = filter $ isJust . isQuantityAttribute
 
 tacticAttributes :: [Attribute] -> [Attribute]
 tacticAttributes = filter $ isJust . C.theTacticAttribute . isTacticAttribute
+
+rewAttributes :: [Attribute] -> [Attribute]
+rewAttributes = filter $ isJust . isRewriteAttribute

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -312,6 +312,7 @@ niceDeclarations fixs ds = do
 
         TypeSig info tac x t -> do
           dropTactic tac
+          info <- dropRew info
           termCheck <- use terminationCheckPragma
           covCheck  <- use coverageCheckPragma
           -- Andreas, 2020-09-28, issue #4950: take only range of identifier,
@@ -333,6 +334,8 @@ niceDeclarations fixs ds = do
               -- Warn about @variable {x} : A@ which is equivalent to @variable x : A@.
               when (getHiding info == Hidden) $
                 declarationWarning $ HiddenGeneralize $ getRange x
+              -- Generalised variables cannot be local rewrite rules
+              info <- dropRew info
               return $ NiceGeneralize (getRange sig) PublicAccess info tac x t
             _ -> __IMPOSSIBLE__
           return (gs, ds)
@@ -748,6 +751,7 @@ niceDeclarations fixs ds = do
         niceAxiom = \case
           d@(TypeSig rel tac x t) -> do
             dropTactic tac
+            rel <- dropRew rel
             return [ Axiom (getRange d) PublicAccess ConcreteDef NotInstanceDef rel x t ]
           -- @instance@ and @private@ blocks mix well with other blocks.
           InstanceB r ds -> instanceBlock r =<< niceAxioms b ds
@@ -1670,6 +1674,10 @@ dropTactic :: TacticAttribute -> Nice ()
 dropTactic = \case
   TacticAttribute Nothing   -> return ()
   TacticAttribute (Just re) -> declarationWarning $ InvalidTacticAttribute $ getRange re
+
+-- | Ensure there is no local rewrite attribute
+dropRew :: LensRewriteAnn a => a -> Nice a
+dropRew = ignoreRew $ declarationWarning . InvalidRewriteAttribute . getRange
 
 -- The following function is (at the time of writing) only used three
 -- times: for building Lets, and for printing error messages.

--- a/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions/Errors.hs
@@ -140,6 +140,8 @@ data DeclarationWarning'
       --   that does not apply to any function.
   | InvalidTacticAttribute Range
       -- ^ A misplaced @tactic@ attribute.
+  | InvalidRewriteAttribute Range
+      -- ^ A misplaced @rewrite@ attribute.
   | MissingDataDeclaration Name
       -- ^ A @data@ definition without a @data@ signature.
   | MissingDefinitions (List1 (Name, Range))
@@ -218,6 +220,7 @@ declarationWarningName' = \case
   InvalidTerminationCheckPragma   {} -> InvalidTerminationCheckPragma_
   InvalidCoverageCheckPragma      {} -> InvalidCoverageCheckPragma_
   InvalidTacticAttribute          {} -> InvalidTacticAttribute_
+  InvalidRewriteAttribute         {} -> MisplacedRewrite_
   MissingDataDeclaration          {} -> MissingDataDeclaration_
   MissingDefinitions              {} -> MissingDefinitions_
   NotAllowedInMutual              {} -> NotAllowedInMutual_
@@ -272,6 +275,7 @@ unsafeDeclarationWarning' = \case
   InvalidTerminationCheckPragma{}   -> False
   InvalidCoverageCheckPragma{}      -> False
   InvalidTacticAttribute{}          -> False
+  InvalidRewriteAttribute{}         -> False
   MissingDataDeclaration{}          -> True  -- not safe
   MissingDefinitions{}              -> False -- not safe but deferred until after typechecking
   NotAllowedInMutual{}              -> False -- really safe?
@@ -386,6 +390,7 @@ instance HasRange DeclarationWarning' where
     InvalidNoUniverseCheckPragma r     -> r
     InvalidTerminationCheckPragma r    -> r
     InvalidTacticAttribute r           -> r
+    InvalidRewriteAttribute r          -> r
     MissingDataDeclaration x           -> getRange x
     MissingDefinitions xs              -> getRange xs
     NotAllowedInMutual r _x            -> r
@@ -561,6 +566,9 @@ instance Pretty DeclarationWarning' where
 
     InvalidTacticAttribute _ -> fsep $
       pwords "Ignoring misplaced tactic attribute."
+
+    InvalidRewriteAttribute _ -> fsep $
+      pwords "Ignoring misplaced local rewrite attribute."
 
     InvalidTerminationCheckPragma _ -> fsep $
       pwords "Termination checking pragmas can only precede a function definition or a mutual block (that contains a function definition)."

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -247,7 +247,7 @@ instance Pretty a => Pretty (Binder' a) where
 
 instance Pretty NamedBinding where
   pretty (NamedBinding withH
-           x@(Arg (ArgInfo h (Modality r q c p) _o _fv (Annotation lock))
+           x@(Arg (ArgInfo h (Modality r q c p) _o _fv (Annotation lock rew))
                (Named _mn xb@(Binder _mp _ (BName _y _fix t _fin))))) =
     applyWhen withH prH $
     applyWhenJust (isLabeled x) (\ l -> (text l <+>) . (equals <+>)) (pretty xb)
@@ -261,11 +261,13 @@ instance Pretty NamedBinding where
         . (pol <+>)
         . (lck <+>)
         . (tac <+>)
+        . (rw  <+>)
     coh = pretty c
     qnt = pretty q
     pol = pretty p
     tac = pretty t
     lck = pretty lock
+    rw  = pretty rew
     -- Parentheses are needed when an attribute @... is printed
     mparens = applyUnless (null coh && null qnt && null lck && null tac && null pol) parens
 

--- a/src/full/Agda/Syntax/Concrete/Pretty.hs
+++ b/src/full/Agda/Syntax/Concrete/Pretty.hs
@@ -287,7 +287,8 @@ instance Pretty TypedBinding where
         $ prettyQuantity y
         $ prettyLock y
         $ prettyPolarity y
-        $ prettyTactic (binderName $ namedArg y) $
+        $ prettyTactic (binderName $ namedArg y)
+        $ prettyRewriteAnn y $
         sep [ fsep (map (pretty . NamedBinding False) ys)
             , colon <+> pretty e ]
       | ys@(y : _) <- groupBinds $ List1.toList xs ]
@@ -383,7 +384,8 @@ instance Pretty Declaration where
   prettyList = vcat . map pretty
   pretty = \case
     TypeSig i tac x e ->
-      sep [ prettyTactic' tac $ prettyRelevance i $ prettyCohesion i $ prettyQuantity i $ prettyPolarity i $ pretty x <+> colon
+      sep [ prettyTactic' tac $ prettyRelevance i $ prettyCohesion i $
+              prettyQuantity i $ prettyPolarity i $ pretty x <+> colon
           , nest 2 $ pretty e
           ]
     FieldSig inst tac x (Arg i e) ->

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -76,23 +76,24 @@ data Dom' t e = Dom
   , domIsFinite :: Bool
     -- ^ Is this a Π-type (False), or a partial type (True)?
   , domTactic :: Maybe t        -- ^ "@tactic e".
+  , domRewrite :: Maybe LocalRewriteRule
   , unDom     :: e
   } deriving (Show, Functor, Foldable, Traversable)
 
 type Dom = Dom' Term
 
 instance Decoration (Dom' t) where
-  traverseF f (Dom ai x t b a) = Dom ai x t b <$> f a
+  traverseF f (Dom ai x t b r a) = Dom ai x t b r <$> f a
 
 instance HasRange a => HasRange (Dom' t a) where
   getRange = getRange . unDom
 
 instance (KillRange t, KillRange a) => KillRange (Dom' t a) where
-  killRange (Dom info x t b a) = killRangeN Dom info x t b a
+  killRange (Dom info x t b r a) = killRangeN Dom info x t b r a
 
 -- | Ignores 'Origin' and 'FreeVariables' and tactic.
 instance Eq a => Eq (Dom' t a) where
-  Dom (ArgInfo h1 m1 _ _ a1) s1 f1 _ x1 == Dom (ArgInfo h2 m2 _ _ a2) s2 f2 _ x2 =
+  Dom (ArgInfo h1 m1 _ _ a1) s1 f1 _ _ x1 == Dom (ArgInfo h2 m2 _ _ a2) s2 f2 _ _ x2 =
     (h1, m1, a1, s1, f1, x1) == (h2, m2, a2, s2, f2, x2)
 
 instance LensNamed (Dom' t e) where
@@ -107,6 +108,10 @@ instance LensArgInfo (Dom' t e) where
 instance LensLock (Dom' t e) where
   getLock = getLock . getArgInfo
   setLock = mapArgInfo . setLock
+
+instance LensRewriteAnn (Dom' t e) where
+  getRewriteAnn = getRewriteAnn . getArgInfo
+  setRewriteAnn = mapRewriteAnn . setRewriteAnn
 
 -- The other lenses are defined through LensArgInfo
 
@@ -135,10 +140,10 @@ namedArgFromDom Dom{domInfo = i, domName = s, unDom = a} = Arg i $ Named s a
 -- often for class AddContext.
 
 domFromArg :: Arg a -> Dom a
-domFromArg (Arg i a) = Dom i Nothing False Nothing a
+domFromArg (Arg i a) = Dom i Nothing False Nothing Nothing a
 
 domFromNamedArg :: NamedArg a -> Dom a
-domFromNamedArg (Arg i a) = Dom i (nameOf a) False Nothing (namedThing a)
+domFromNamedArg (Arg i a) = Dom i (nameOf a) False Nothing Nothing (namedThing a)
 
 defaultDom :: a -> Dom a
 defaultDom = defaultArgDom defaultArgInfo
@@ -1195,6 +1200,96 @@ type instance TypeOf [PlusLevel] = ()
 type instance TypeOf PlusLevel   = ()
 
 ---------------------------------------------------------------------------
+-- * (Local) rewrite rules
+---------------------------------------------------------------------------
+
+-- | NLPat might become definitionally singular (after a substitution)
+data DefSing
+  = NeverSing
+    -- ^ Never definitionally singular
+  | MaybeSing
+    -- ^ Might become definitionally singular after a substitution
+  | AlwaysSing
+    -- ^ Always definitionally singular (e.g. irrelevant or in |Prop|)
+  deriving (Show, Generic, Enum, Bounded)
+
+relToDefSing :: Relevance -> DefSing
+relToDefSing r = if isIrrelevant r then AlwaysSing else NeverSing
+
+-- Only approximate if both sides are |NotDefSingIfInj| with non-empty
+-- injective constraints
+minDefSing :: DefSing -> DefSing -> DefSing
+minDefSing s s' = toEnum $ fromEnum s `min` fromEnum s'
+
+maxDefSing :: DefSing -> DefSing -> DefSing
+maxDefSing s s' = toEnum $ fromEnum s `max` fromEnum s'
+
+isAlwaysSing :: DefSing -> Bool
+isAlwaysSing AlwaysSing = True
+isAlwaysSing _          = False
+
+-- | Non-linear (non-constructor) first-order pattern.
+data NLPat
+  = PVar DefSing !Int [Arg Int]
+    -- ^ Matches anything (modulo non-linearity) that only contains bound
+    --   variables that occur in the given arguments.
+    --   Tracks the definitional singularity of the surrounding pattern (not
+    --   the type of the variable itself)
+  | PDef QName PElims
+    -- ^ Matches @f es@
+  | PLam ArgInfo (Abs NLPat)
+    -- ^ Matches @λ x → t@
+  | PPi (Dom NLPType) (Abs NLPType)
+    -- ^ Matches @(x : A) → B@
+  | PSort NLPSort
+    -- ^ Matches a sort of the given shape.
+  | PBoundVar {-# UNPACK #-} !Int PElims
+    -- ^ Matches @x es@ where x is a lambda-bound variable
+  | PTerm Term
+    -- ^ Matches the term modulo β (ideally βη).
+  deriving (Show, Generic)
+type PElims = [Elim' NLPat]
+
+
+type instance TypeOf NLPat = Type
+type instance TypeOf [Elim' NLPat] = (Type, Elims -> Term)
+
+
+data NLPType = NLPType
+  { nlpTypeSort :: NLPSort
+  , nlpTypeUnEl :: NLPat
+  } deriving (Show, Generic)
+
+
+data NLPSort
+  = PUniv Univ NLPat
+  | PInf Univ Integer
+  | PSizeUniv
+  | PLockUniv
+  | PLevelUniv
+  | PIntervalUniv
+  deriving (Show, Generic)
+
+pattern PType, PProp, PSSet :: NLPat -> NLPSort
+pattern PType p = PUniv UType p
+pattern PProp p = PUniv UProp p
+pattern PSSet p = PUniv USSet p
+
+{-# COMPLETE
+  PType, PSSet, PProp, PInf,
+  PSizeUniv, PLockUniv, PLevelUniv, PIntervalUniv #-}
+
+data LocalRewriteRule = LocalRewriteRule
+  { lrewContext :: Telescope
+  , lrewHead    :: Int        -- de Bruijn index of head symbol (excluding lrewContext variables)
+  , lrewPats    :: PElims     -- patterns (including lrewContext variables)
+  , lrewRHS     :: Term
+  , lrewType    :: Type
+  }
+  deriving (Show, Generic)
+
+
+---------------------------------------------------------------------------
 -- * Null instances.
 ---------------------------------------------------------------------------
 
@@ -1405,6 +1500,31 @@ instance KillRange ClauseRecursive where
 instance KillRange Clause where
   killRange (Clause rl rf tel ps body t catchall recursive unreachable ell wm) =
     killRangeN Clause rl rf tel ps body t catchall recursive unreachable ell wm
+
+
+instance KillRange NLPat where
+  killRange (PVar s x y)    = killRangeN (PVar s) x y
+  killRange (PDef x y)      = killRangeN PDef x y
+  killRange (PLam x y)      = killRangeN PLam x y
+  killRange (PPi x y)       = killRangeN PPi x y
+  killRange (PSort x)       = killRangeN PSort x
+  killRange (PBoundVar x y) = killRangeN PBoundVar x y
+  killRange (PTerm x)       = killRangeN PTerm x
+
+instance KillRange NLPType where
+  killRange (NLPType s a) = killRangeN NLPType s a
+
+instance KillRange NLPSort where
+  killRange (PUniv u l) = killRangeN (PUniv u) l
+  killRange s@(PInf _f _n) = s
+  killRange PSizeUniv = PSizeUniv
+  killRange PLockUniv = PLockUniv
+  killRange PLevelUniv = PLevelUniv
+  killRange PIntervalUniv = PIntervalUniv
+
+instance KillRange LocalRewriteRule where
+  killRange (LocalRewriteRule a b c d e) =
+    killRangeN LocalRewriteRule a b c d e
 
 instance KillRange a => KillRange (Tele a) where
   killRange = fmap killRange
@@ -1625,7 +1745,7 @@ instance NFData PlusLevel where
   rnf (Plus n l) = rnf (n, l)
 
 instance NFData e => NFData (Dom e) where
-  rnf (Dom a c d e f) = rnf a `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f
+  rnf (Dom a c d e f g) = rnf a `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f `seq` rnf g
 
 instance NFData a => NFData (DataOrRecord' a)
 instance NFData ConHead
@@ -1640,3 +1760,8 @@ instance NFData x => NFData (Pattern' x)
 instance NFData DBPatVar
 instance NFData ConPatternInfo
 instance NFData a => NFData (Substitution' a)
+instance NFData DefSing
+instance NFData NLPat
+instance NFData NLPType
+instance NFData NLPSort
+instance NFData LocalRewriteRule

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -76,7 +76,7 @@ data Dom' t e = Dom
   , domIsFinite :: Bool
     -- ^ Is this a Π-type (False), or a partial type (True)?
   , domTactic :: Maybe t        -- ^ "@tactic e".
-  , domRewrite :: Maybe LocalRewriteRule
+  , domRewrite :: Maybe RewriteRule
   , unDom     :: e
   } deriving (Show, Functor, Foldable, Traversable)
 
@@ -1279,12 +1279,12 @@ pattern PSSet p = PUniv USSet p
   PType, PSSet, PProp, PInf,
   PSizeUniv, PLockUniv, PLevelUniv, PIntervalUniv #-}
 
-data LocalRewriteRule = LocalRewriteRule
-  { lrewContext :: Telescope
-  , lrewHead    :: Int        -- de Bruijn index of head symbol (excluding lrewContext variables)
-  , lrewPats    :: PElims     -- patterns (including lrewContext variables)
-  , lrewRHS     :: Term
-  , lrewType    :: Type
+data RewriteRule = RewriteRule
+  { rewContext :: Telescope
+  , rewHead    :: Int        -- de Bruijn index of head symbol (excluding rewContext variables)
+  , rewPats    :: PElims     -- patterns (including rewContext variables)
+  , rewRHS     :: Term
+  , rewType    :: Type
   }
   deriving (Show, Generic)
 
@@ -1522,9 +1522,9 @@ instance KillRange NLPSort where
   killRange PLevelUniv = PLevelUniv
   killRange PIntervalUniv = PIntervalUniv
 
-instance KillRange LocalRewriteRule where
-  killRange (LocalRewriteRule a b c d e) =
-    killRangeN LocalRewriteRule a b c d e
+instance KillRange RewriteRule where
+  killRange (RewriteRule a b c d e) =
+    killRangeN RewriteRule a b c d e
 
 instance KillRange a => KillRange (Tele a) where
   killRange = fmap killRange
@@ -1764,4 +1764,4 @@ instance NFData DefSing
 instance NFData NLPat
 instance NFData NLPType
 instance NFData NLPSort
-instance NFData LocalRewriteRule
+instance NFData RewriteRule

--- a/src/full/Agda/Syntax/Internal.hs
+++ b/src/full/Agda/Syntax/Internal.hs
@@ -56,6 +56,19 @@ import Agda.Utils.Impossible
 -- * Function type domain
 ---------------------------------------------------------------------------
 
+data RewDom' t = RewDom
+  { rewDomEq  :: LocalEquation' t
+    -- ^ Elaborated "@rewrite" equation
+  , rewDomRew :: Maybe RewriteRule
+    -- ^ "@rewrite" equation transformed into a directed rewrite rule.
+    --
+    -- @Nothing@ iff invalidated by a substitution. If we are checking
+    -- against an "@rewrite" domain, this is fine, but if we are inside an "@rewrite"
+    -- context, this is probably an internal error.
+  } deriving (Show, Generic)
+
+type RewDom = RewDom' Term
+
 -- | Similar to 'Arg', but we need to distinguish
 --   an irrelevance annotation in a function domain
 --   (the domain itself is not irrelevant!)
@@ -76,17 +89,33 @@ data Dom' t e = Dom
   , domIsFinite :: Bool
     -- ^ Is this a Π-type (False), or a partial type (True)?
   , domTactic :: Maybe t        -- ^ "@tactic e".
-  , domRewrite :: Maybe RewriteRule
+  , rewDom    :: Maybe (RewDom' t)
+    -- ^ Elaborated "@rewrite" equation
+    --
+    -- Will only be present if domain annotated with "@rewrite" (@annRewrite@
+    -- is @IsRewrite@) AND the type successfully elaborated into a rewrite rule.
   , unDom     :: e
   } deriving (Show, Functor, Foldable, Traversable)
 
 type Dom = Dom' Term
+
+domEq :: Dom' t e -> Maybe (LocalEquation' t)
+domEq = fmap rewDomEq . rewDom
+
+-- | Is this Dom annotated as a local rewrite rule and if so, has the rewrite
+--   been invalidated due to a substitution?
+invalidRew :: Dom' t e -> Bool
+invalidRew Dom { rewDom = Just (RewDom { rewDomRew = Nothing }) } = True
+invalidRew _                                                      = False
 
 instance Decoration (Dom' t) where
   traverseF f (Dom ai x t b r a) = Dom ai x t b r <$> f a
 
 instance HasRange a => HasRange (Dom' t a) where
   getRange = getRange . unDom
+
+instance KillRange t => KillRange (RewDom' t) where
+  killRange (RewDom eq rew) = killRangeN RewDom eq rew
 
 instance (KillRange t, KillRange a) => KillRange (Dom' t a) where
   killRange (Dom info x t b r a) = killRangeN Dom info x t b r a
@@ -112,6 +141,9 @@ instance LensLock (Dom' t e) where
 instance LensRewriteAnn (Dom' t e) where
   getRewriteAnn = getRewriteAnn . getArgInfo
   setRewriteAnn = mapRewriteAnn . setRewriteAnn
+
+instance LensLocalEquation (Dom e) where
+  getLocalEq = domEq
 
 -- The other lenses are defined through LensArgInfo
 
@@ -139,8 +171,11 @@ namedArgFromDom Dom{domInfo = i, domName = s, unDom = a} = Arg i $ Named s a
 -- However, this causes problems with instance resolution in several places.
 -- often for class AddContext.
 
+domFromArgRew :: Maybe RewDom -> Arg a -> Dom a
+domFromArgRew rew (Arg i a) = Dom i Nothing False Nothing rew a
+
 domFromArg :: Arg a -> Dom a
-domFromArg (Arg i a) = Dom i Nothing False Nothing Nothing a
+domFromArg = domFromArgRew Nothing
 
 domFromNamedArg :: NamedArg a -> Dom a
 domFromNamedArg (Arg i a) = Dom i (nameOf a) False Nothing Nothing (namedThing a)
@@ -148,8 +183,11 @@ domFromNamedArg (Arg i a) = Dom i (nameOf a) False Nothing Nothing (namedThing a
 defaultDom :: a -> Dom a
 defaultDom = defaultArgDom defaultArgInfo
 
+defaultArgDomRew :: ArgInfo -> Maybe RewDom -> a -> Dom a
+defaultArgDomRew info rew x = domFromArgRew rew (Arg info x)
+
 defaultArgDom :: ArgInfo -> a -> Dom a
-defaultArgDom info x = domFromArg (Arg info x)
+defaultArgDom info = defaultArgDomRew info Nothing
 
 defaultNamedArgDom :: ArgInfo -> String -> a -> Dom a
 defaultNamedArgDom info s x = (defaultArgDom info x) { domName = Just $ WithOrigin Inserted $ unranged s }
@@ -758,6 +796,7 @@ data Substitution' a
 
 type Substitution = Substitution' Term
 type PatternSubstitution = Substitution' DeBruijnPattern
+type Renaming = Substitution' Nat
 
 infixr 4 :#
 
@@ -1279,15 +1318,49 @@ pattern PSSet p = PUniv USSet p
   PType, PSSet, PProp, PInf,
   PSizeUniv, PLockUniv, PLevelUniv, PIntervalUniv #-}
 
+data RewriteHead
+  = RewDefHead QName
+  | RewVarHead Nat
+    -- ^ de Bruijn index of head symbol (excluding rewContext variables)
+  deriving (Show, Generic, Eq)
+
+headToPat :: Nat -> RewriteHead -> PElims -> NLPat
+headToPat _        (RewDefHead f) = PDef f
+headToPat telStart (RewVarHead x) = PBoundVar (x + telStart)
+
+headToTerm :: Nat -> RewriteHead -> Elims -> Term
+headToTerm _        (RewDefHead f) = Def f
+headToTerm telStart (RewVarHead x) = Var (x + telStart)
+
+-- | Undirected equational constraint ("the LHS and RHS
+--   must be convertible in the calling context").
+--   Admits arbitrary substitution.
+data LocalEquation' t = LocalEquation
+  { lEqContext :: Tele (Dom' t (Type'' t t))
+  , lEqLHS     :: t
+  , lEqRHS     :: t
+  , lEqType    :: Type'' t t
+  }
+  deriving (Show, Generic)
+
+type LocalEquation = LocalEquation' Term
+
+-- | Directed rewrite rules generic over the type of head symbol.
+--   Generally unstable under substitution.
 data RewriteRule = RewriteRule
   { rewContext :: Telescope
-  , rewHead    :: Int        -- de Bruijn index of head symbol (excluding rewContext variables)
+  , rewHead    :: RewriteHead
   , rewPats    :: PElims     -- patterns (including rewContext variables)
   , rewRHS     :: Term
   , rewType    :: Type
   }
   deriving (Show, Generic)
 
+lrewHasProjectionPattern :: RewriteRule -> Bool
+lrewHasProjectionPattern rew = any (isJust . isProjElim) $ rewPats rew
+
+class LensLocalEquation a where
+  getLocalEq :: a -> Maybe LocalEquation
 
 ---------------------------------------------------------------------------
 -- * Null instances.
@@ -1429,16 +1502,16 @@ instance KillRange Term where
     DontCare mv -> killRangeN DontCare mv
     v@Dummy{}   -> v
 
-instance KillRange Level where
+instance KillRange a => KillRange (Level' a) where
   killRange (Max n as) = killRangeN (Max n) as
 
-instance KillRange PlusLevel where
+instance KillRange a => KillRange (PlusLevel' a) where
   killRange (Plus n l) = killRangeN (Plus n) l
 
-instance (KillRange a) => KillRange (Type' a) where
+instance (KillRange a, KillRange b) => KillRange (Type'' a b) where
   killRange (El s v) = killRangeN El s v
 
-instance KillRange Sort where
+instance KillRange a => KillRange (Sort' a) where
   killRange = \case
     Inf u n    -> Inf u n
     SizeUniv   -> SizeUniv
@@ -1521,6 +1594,16 @@ instance KillRange NLPSort where
   killRange PLockUniv = PLockUniv
   killRange PLevelUniv = PLevelUniv
   killRange PIntervalUniv = PIntervalUniv
+
+instance KillRange RewriteHead where
+  killRange (RewVarHead a) =
+    killRangeN RewVarHead a
+  killRange (RewDefHead a) =
+    killRangeN RewDefHead a
+
+instance KillRange t => KillRange (LocalEquation' t) where
+  killRange (LocalEquation a b c d) =
+    killRangeN LocalEquation a b c d
 
 instance KillRange RewriteRule where
   killRange (RewriteRule a b c d e) =
@@ -1764,4 +1847,7 @@ instance NFData DefSing
 instance NFData NLPat
 instance NFData NLPType
 instance NFData NLPSort
+instance NFData RewriteHead
+instance NFData LocalEquation
 instance NFData RewriteRule
+instance NFData RewDom

--- a/src/full/Agda/Syntax/Internal/Generic.hs
+++ b/src/full/Agda/Syntax/Internal/Generic.hs
@@ -56,7 +56,7 @@ instance TermLike QName where
 
 instance TermLike a => TermLike (Elim' a)      where
 instance TermLike a => TermLike (Arg a)        where
-instance TermLike a => TermLike (Dom a)        where
+instance (TermLike a, TermLike b) => TermLike (Dom' a b) where
 instance TermLike a => TermLike [a]            where
 instance TermLike a => TermLike (List1 a)      where
 instance TermLike a => TermLike (Maybe a)      where
@@ -117,7 +117,7 @@ instance TermLike PlusLevel where
   traverseTermM f (Plus n l) = Plus n <$> traverseTermM f l
   foldTerm f (Plus _ l)      = foldTerm f l
 
-instance TermLike Type where
+instance (TermLike b) => TermLike (Type'' a b) where
   traverseTermM f (El s t) = El s <$> traverseTermM f t
   foldTerm f (El s t) = foldTerm f t
 

--- a/src/full/Agda/Syntax/Internal/MetaVars.hs
+++ b/src/full/Agda/Syntax/Internal/MetaVars.hs
@@ -26,12 +26,15 @@ instance TermLike a => AllMetas (Elim' a)
 instance TermLike a => AllMetas (Tele a)
 
 instance (AllMetas a, AllMetas b) => AllMetas (Dom' a b) where
-  allMetas f (Dom _ _ _ t e) = allMetas f t <> allMetas f e
+  allMetas f (Dom _ _ _ t r e) = allMetas f t <> allMetas f r <> allMetas f e
 
 -- These types need to be packed up as a Term to get the metas.
 instance AllMetas Sort      where allMetas f   = allMetas f . Sort
 instance AllMetas Level     where allMetas f   = allMetas f . Level
 instance AllMetas PlusLevel where allMetas f l = allMetas f (Max 0 [l])
+
+instance AllMetas LocalRewriteRule where
+  allMetas f (LocalRewriteRule a b c d e) = allMetas f (a, d, e)
 
 instance {-# OVERLAPPING #-} AllMetas String where
   allMetas f _ = mempty

--- a/src/full/Agda/Syntax/Internal/MetaVars.hs
+++ b/src/full/Agda/Syntax/Internal/MetaVars.hs
@@ -33,8 +33,8 @@ instance AllMetas Sort      where allMetas f   = allMetas f . Sort
 instance AllMetas Level     where allMetas f   = allMetas f . Level
 instance AllMetas PlusLevel where allMetas f l = allMetas f (Max 0 [l])
 
-instance AllMetas LocalRewriteRule where
-  allMetas f (LocalRewriteRule a b c d e) = allMetas f (a, d, e)
+instance AllMetas RewriteRule where
+  allMetas f (RewriteRule a b c d e) = allMetas f (a, d, e)
 
 instance {-# OVERLAPPING #-} AllMetas String where
   allMetas f _ = mempty

--- a/src/full/Agda/Syntax/Internal/MetaVars.hs
+++ b/src/full/Agda/Syntax/Internal/MetaVars.hs
@@ -21,11 +21,11 @@ class AllMetas t where
 
 -- Default instances
 instance AllMetas Term
-instance AllMetas Type
+instance (TermLike a, TermLike b) => AllMetas (Type'' a b)
 instance TermLike a => AllMetas (Elim' a)
 instance TermLike a => AllMetas (Tele a)
 
-instance (AllMetas a, AllMetas b) => AllMetas (Dom' a b) where
+instance (TermLike a, AllMetas a, AllMetas b) => AllMetas (Dom' a b) where
   allMetas f (Dom _ _ _ t r e) = allMetas f t <> allMetas f r <> allMetas f e
 
 -- These types need to be packed up as a Term to get the metas.
@@ -33,8 +33,14 @@ instance AllMetas Sort      where allMetas f   = allMetas f . Sort
 instance AllMetas Level     where allMetas f   = allMetas f . Level
 instance AllMetas PlusLevel where allMetas f l = allMetas f (Max 0 [l])
 
+instance (TermLike a, AllMetas a) => AllMetas (RewDom' a) where
+  allMetas f (RewDom a b) = allMetas f (a, b)
+
+instance (TermLike a, AllMetas a) => AllMetas (LocalEquation' a) where
+  allMetas f (LocalEquation a b c d) = allMetas f (a, b, c, d)
+
 instance AllMetas RewriteRule where
-  allMetas f (RewriteRule a b c d e) = allMetas f (a, d, e)
+  allMetas f (RewriteRule g _ _ es b) = allMetas f (g, es, b)
 
 instance {-# OVERLAPPING #-} AllMetas String where
   allMetas f _ = mempty

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -88,9 +88,8 @@ instance NamesIn a => NamesIn (Open a)
 instance NamesIn a => NamesIn (C.FieldAssignment' a)
 
 instance (NamesIn a, NamesIn b) => NamesIn (Dom' a b) where
-  namesAndMetasIn' sg (Dom _ _ _ t e) =
-    mappend (namesAndMetasIn' sg t) (namesAndMetasIn' sg e)
-
+  namesAndMetasIn' sg (Dom _ _ _ t r e) =
+    namesAndMetasIn' sg (t, r, e)
 
 -- Specific collections
 instance NamesIn a => NamesIn (Tele a)
@@ -143,6 +142,9 @@ instance NamesIn ConHead where
   namesAndMetasIn' sg h = namesAndMetasIn' sg (conName h)
 
 instance NamesIn Bool where
+  namesAndMetasIn' _ _ = mempty
+
+instance NamesIn Int where
   namesAndMetasIn' _ _ = mempty
 
 -- Andreas, 2017-07-27
@@ -315,6 +317,10 @@ instance NamesIn RewriteRule where
   namesAndMetasIn' sg = \case
     RewriteRule a b c d e f _ _ ->
       namesAndMetasIn' sg (a, b, c, d, e, f)
+
+instance NamesIn LocalRewriteRule where
+  namesAndMetasIn' sg (LocalRewriteRule a b c d e) =
+    namesAndMetasIn' sg (a, b, c, d, e)
 
 instance (NamesIn b) => NamesIn (HashMap a b) where
   namesAndMetasIn' sg map = foldMap (namesAndMetasIn' sg) map

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -313,13 +313,13 @@ instance NamesIn NLPSort where
     PLevelUniv    -> mempty
     PIntervalUniv -> mempty
 
-instance NamesIn RewriteRule where
+instance NamesIn GlobalRewriteRule where
   namesAndMetasIn' sg = \case
-    RewriteRule a b c d e f _ _ ->
+    GlobalRewriteRule a b c d e f _ _ ->
       namesAndMetasIn' sg (a, b, c, d, e, f)
 
-instance NamesIn LocalRewriteRule where
-  namesAndMetasIn' sg (LocalRewriteRule a b c d e) =
+instance NamesIn RewriteRule where
+  namesAndMetasIn' sg (RewriteRule a b c d e) =
     namesAndMetasIn' sg (a, b, c, d, e)
 
 instance (NamesIn b) => NamesIn (HashMap a b) where

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -201,10 +201,10 @@ instance NamesIn (Pattern' a) where
     ProjP _ f       -> namesAndMetasIn' sg f
     IApplyP _ t u _ -> namesAndMetasIn' sg (t, u)
 
-instance NamesIn a => NamesIn (Type' a) where
+instance (NamesIn a, NamesIn b) => NamesIn (Type'' a b) where
   namesAndMetasIn' sg (El s t) = namesAndMetasIn' sg (s, t)
 
-instance NamesIn Sort where
+instance NamesIn a => NamesIn (Sort' a) where
   namesAndMetasIn' sg = \case
     Univ _ l    -> namesAndMetasIn' sg l
     Inf _ _     -> mempty
@@ -233,10 +233,10 @@ instance NamesIn Term where
     DontCare v   -> namesAndMetasIn' sg v
     Dummy _ args -> namesAndMetasIn' sg args
 
-instance NamesIn Level where
+instance NamesIn a => NamesIn (Level' a) where
   namesAndMetasIn' sg (Max _ ls) = namesAndMetasIn' sg ls
 
-instance NamesIn PlusLevel where
+instance NamesIn a => NamesIn (PlusLevel' a) where
   namesAndMetasIn' sg (Plus _ l) = namesAndMetasIn' sg l
 
 -- For QName and Meta literals!
@@ -318,9 +318,20 @@ instance NamesIn GlobalRewriteRule where
     GlobalRewriteRule a b c d e f _ _ ->
       namesAndMetasIn' sg (a, b, c, d, e, f)
 
+instance NamesIn a => NamesIn (LocalEquation' a) where
+  namesAndMetasIn' sg (LocalEquation a b c d) = namesAndMetasIn' sg (a, b, c, d)
+
+instance NamesIn RewriteHead where
+  namesAndMetasIn' sg (RewVarHead a) = namesAndMetasIn' sg a
+  namesAndMetasIn' sg (RewDefHead a) = namesAndMetasIn' sg a
+
 instance NamesIn RewriteRule where
   namesAndMetasIn' sg (RewriteRule a b c d e) =
     namesAndMetasIn' sg (a, b, c, d, e)
+
+instance NamesIn a => NamesIn (RewDom' a) where
+  namesAndMetasIn' sg (RewDom a b) =
+    namesAndMetasIn' sg (a, b)
 
 instance (NamesIn b) => NamesIn (HashMap a b) where
   namesAndMetasIn' sg map = foldMap (namesAndMetasIn' sg) map

--- a/src/full/Agda/Syntax/Parser/Helpers.hs
+++ b/src/full/Agda/Syntax/Parser/Helpers.hs
@@ -317,6 +317,7 @@ onlyErased as = do
     RelevanceAttribute{} -> unsup "Relevance"
     CohesionAttribute{}  -> unsup "Cohesion"
     LockAttribute{}      -> unsup "Lock"
+    RewriteAttribute{}   -> unsup "Rewrite"
     CA.TacticAttribute{} -> unsup "Tactic"
     PolarityAttribute{}  -> unsup "Polarity"
     QuantityAttribute q  -> maybe (unsup "Linearity") (return . Just) $ erasedFromQuantity q
@@ -552,12 +553,15 @@ patternSynArgs = mapM \ x -> do
         case ai of
 
           -- Benign case:
-          ArgInfo h (Modality Relevant{} (Quantityω _) Continuous (PolarityModality { modPolarityAnn = MixedPolarity })) UserWritten UnknownFVs (Annotation IsNotLock) ->
+          ArgInfo h (Modality Relevant{} (Quantityω _) Continuous (PolarityModality { modPolarityAnn = MixedPolarity })) UserWritten UnknownFVs (Annotation IsNotLock IsNotRewrite) ->
             return $ WithHiding h n
 
           -- Error cases:
-          ArgInfo _ _ _ _ (Annotation (IsLock _)) ->
+          ArgInfo _ _ _ _ (Annotation (IsLock _) _) ->
             abort $ noAnn "Lock"
+
+          ArgInfo _ _ _ _ (Annotation _ IsRewrite) ->
+            abort $ noAnn "Rewrite"
 
           ArgInfo _ (Modality r q c p) _ _ _
             | not (isRelevant r) ->

--- a/src/full/Agda/Syntax/Parser/Helpers.hs
+++ b/src/full/Agda/Syntax/Parser/Helpers.hs
@@ -560,7 +560,7 @@ patternSynArgs = mapM \ x -> do
           ArgInfo _ _ _ _ (Annotation (IsLock _) _) ->
             abort $ noAnn "Lock"
 
-          ArgInfo _ _ _ _ (Annotation _ IsRewrite) ->
+          ArgInfo _ _ _ _ (Annotation _ (IsRewrite _)) ->
             abort $ noAnn "Rewrite"
 
           ArgInfo _ (Modality r q c p) _ _ _
@@ -632,6 +632,9 @@ funClauseOrTypeSigs attrs lhs' with mrhs wh = do
       whenJust (haveTacticAttr attrs) \ re ->
         parseWarning $ MisplacedAttributes (getRange re) $
           "Ignoring tactic attribute, illegal in function clauses"
+      whenJust (haveRewAttr attrs) \ re ->
+        parseWarning $ MisplacedAttributes (getRange re) $
+          "Ignoring local rewrite attribute, illegal in function clauses"
       -- Andreas, 2025-07-09, issue #7989: extract irrelevance info from lhs pattern
       let (Arg info p) = patternToArgPattern $ lhsOriginalPattern lhs
       -- Andreas, 2025-07-10, issue #7988: allow attributes in function clause
@@ -688,12 +691,20 @@ toAttribute :: Range -> Expr -> Parser (Maybe Attr)
 toAttribute r e = do
   case exprToAttribute r e of
     Nothing -> Nothing <$ parseWarning (UnknownAttribute r s)
-    Just a -> do
-      let attr = Attr r s a
-      modify' \ st -> st{ parseAttributes = attr : parseAttributes st }
-      return $ Just attr
+    Just a -> fmap Just $ theAttribute $ Attr r s a
   where
     s = prettyShow e
+
+-- | Updates 'parseAttributes' and returns an @rewrite attribute
+rewAttribute :: Range -> Parser (Maybe Attr)
+rewAttribute r = fmap Just $ theAttribute $
+  Attr r "rewrite" (RewriteAttribute $ IsRewrite r)
+
+-- | Updates 'parseAttributes' and returns the attribute
+theAttribute :: Attr -> Parser Attr
+theAttribute attr = do
+  modify' \ st -> st{ parseAttributes = attr : parseAttributes st }
+  return attr
 
 -- | Apply an attribute to thing (usually `Arg`).
 --   This will fail if one of the attributes is already set
@@ -752,6 +763,13 @@ haveTacticAttr as =
     [CA.TacticAttribute e] -> Just e
     [] -> Nothing
     _  -> __IMPOSSIBLE__
+
+haveRewAttr :: [Attr] -> Maybe RewriteAnn
+haveRewAttr as =
+  case rewAttributes $ theAttr <$> as of
+    [CA.RewriteAttribute r] -> Just r
+    []                      -> Nothing
+    _                       -> __IMPOSSIBLE__
 
 -- | Report a parse error if two attributes in the list are of the same kind,
 --   thus, present conflicting information.

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -504,7 +504,7 @@ ArgIds
   | '..' "{{" SpaceIds "}}" ArgIds   { fmap (makeInstance . defaultShapeIrrelevantArg $1) $3 <> $5 }
   | '..' "{{" SpaceIds "}}"          { fmap (makeInstance . defaultShapeIrrelevantArg $1) $3 }
 
--- Modalities preceeding identifiers
+-- Modalities preceding identifiers
 
 ModalArgIds :: { (TacticAttribute, List1 (Arg Name)) }
 ModalArgIds : Attributes ArgIds  {% (getTacticAttr $1,) `fmap` mapM (applyAttrs $1) $2 }
@@ -513,7 +513,10 @@ ModalArgIds : Attributes ArgIds  {% (getTacticAttr $1,) `fmap` mapM (applyAttrs 
 -- Unknown attributes cast a warning and are ignored.
 
 Attribute :: { Maybe Attr }
-Attribute : '@' ExprOrAttr  {% toAttribute (getRange ($1,$2)) $2 }
+Attribute
+  : '@' 'rewrite'   {% rewAttribute (getRange ($1,$2)) }
+  -- ^ 'rewrite' is a keyword so does not get parsed as an identifier in ExprOrAttr
+  | '@' ExprOrAttr  {% toAttribute (getRange ($1,$2)) $2 }
 
 -- Parse a reverse list of modalities
 

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1910,9 +1910,10 @@ scopeCheckLetDef wh d = setCurrentRange d do
 checkFieldArgInfo :: Bool -> ArgInfo -> ScopeM ArgInfo
 checkFieldArgInfo warn =
     ensureLeftAdjoint msg >=>
-    ensureMixedPolarity msg
+    ensureMixedPolarity msg >=>
+    ensureNotRew msg
   where
-    msg = if warn then Just "of field" else Nothing
+    msg = if warn then Just "field" else Nothing
 
 instance ToAbstract NiceDeclaration where
   type AbsOfCon NiceDeclaration = Maybe A.Declaration
@@ -3011,9 +3012,14 @@ checkConstructorArgInfo =
     ensureRelevant msg >=>
     ensureNotLinear msg >=>
     ensureLeftAdjoint msg >=>
-    ensureMixedPolarity msg
+    ensureMixedPolarity msg >=>
+    ensureNotRew msg
   where
-    msg = Just "of constructor"
+    msg = Just "constructor"
+
+ensureNotRew :: LensRewriteAnn a => Maybe String -> a -> ScopeM a
+ensureNotRew ms = ignoreRew $ \ r ->
+  whenJust ms \ s -> warning $ IgnoringRew s r
 
 ensureRelevant :: LensRelevance a => Maybe String -> a -> ScopeM a
 ensureRelevant ms info = do
@@ -3060,7 +3066,7 @@ instance ToAbstract C.Pragma where
   toAbstract (C.OptionsPragma _ opts) = return [ A.OptionsPragma opts ]
 
   toAbstract (C.RewritePragma _ r xs) = do
-    (optRewriting <$> pragmaOptions) >>= \case
+    rewritingOption >>= \case
 
       -- If --rewriting is off, ignore the pragma.
       False -> [] <$ do
@@ -4111,10 +4117,9 @@ checkAttributes (Attr r s attr : attrs) =
       unlessM (optGuarded <$> pragmaOptions) $
         setCurrentRange r $ typeError $ AttributeKindNotEnabled "Lock" "--guarded" s
       cont
-    RewriteAttribute IsNotRewrite -> cont
-    RewriteAttribute IsRewrite -> do
-      unlessM (optRewriting <$> pragmaOptions) $
-        setCurrentRange r $ typeError $ AttributeKindNotEnabled "Rewrite" "--rewriting" s
+    RewriteAttribute rew -> do
+      when (isRewrite rew) $ unlessM localRewritingOption $
+        setCurrentRange r $ typeError $ AttributeKindNotEnabled "Rewrite" "--local-rewriting" s
       cont
     QuantityAttribute Quantityω{} -> cont
     QuantityAttribute Quantity1{} -> __IMPOSSIBLE__

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -4111,6 +4111,11 @@ checkAttributes (Attr r s attr : attrs) =
       unlessM (optGuarded <$> pragmaOptions) $
         setCurrentRange r $ typeError $ AttributeKindNotEnabled "Lock" "--guarded" s
       cont
+    RewriteAttribute IsNotRewrite -> cont
+    RewriteAttribute IsRewrite -> do
+      unlessM (optRewriting <$> pragmaOptions) $
+        setCurrentRange r $ typeError $ AttributeKindNotEnabled "Rewrite" "--rewriting" s
+      cont
     QuantityAttribute Quantityω{} -> cont
     QuantityAttribute Quantity1{} -> __IMPOSSIBLE__
     QuantityAttribute Quantity0{} -> do

--- a/src/full/Agda/TypeChecking/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Abstract.hs
@@ -375,9 +375,9 @@ instance EqualSy ArgInfo where
   equalSy (ArgInfo h m _o _fv a) (ArgInfo h' m' _o' _fv' a') =
     h == h' && m == m' && a == a'
 
--- | Ignore the tactic.
+-- | Ignore the tactic and rewrite.
 instance EqualSy a => EqualSy (Dom a) where
-  equalSy d@(Dom ai x f _tac a) d'@(Dom ai' x' f' _tac' a') = and
+  equalSy d@(Dom ai x f _tac _rew a) d'@(Dom ai' x' f' _tac' _rew' a') = and
     [ x == x'
     , f == f'
     , equalSy ai ai'

--- a/src/full/Agda/TypeChecking/CheckInternal.hs
+++ b/src/full/Agda/TypeChecking/CheckInternal.hs
@@ -329,7 +329,7 @@ inferSpine action t hd es = loop t hd id es
         Apply (Arg ai v) -> do
           (a, b) <- shouldBePi t
           ai <- checkArgInfo action ai $ domInfo a
-          v' <- applyModalityToContext (getModality a) $ checkInternal' action v CmpLeq $ unDom a
+          v' <- applyDomToContext a $ checkInternal' action v CmpLeq $ unDom a
           let e' = Apply (Arg ai v')
           loop (b `absApp` v) (hd . (e:)) (acc . (e':)) es
         -- case: projection or projection-like

--- a/src/full/Agda/TypeChecking/CompiledClause/Match.hs
+++ b/src/full/Agda/TypeChecking/CompiledClause/Match.hs
@@ -4,8 +4,6 @@ module Agda.TypeChecking.CompiledClause.Match where
 
 import qualified Data.Map as Map
 
-import Agda.Interaction.Options (optRewriting)
-
 import Agda.Syntax.Internal
 import Agda.Syntax.Common
 import Agda.Syntax.Common.Pretty (prettyShow)
@@ -211,7 +209,7 @@ match' [] = {- new line here since __IMPOSSIBLE__ does not like the ' in match' 
     if f `elem` pds
     then return (NoReduction $ NotBlocked (MissingClauses f) [])
     else do
-      ifM (optRewriting <$> pragmaOptions)
+      ifM anyRewritingOption
       {-then-} (return (NoReduction $ NotBlocked ReallyNotBlocked [])) -- See #5396
       {-else-} $ traceSLn "impossible" 10
         ("Incomplete pattern matching when applying " ++ prettyShow f)

--- a/src/full/Agda/TypeChecking/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Constraints.hs
@@ -33,6 +33,7 @@ import {-# SOURCE #-} Agda.TypeChecking.MetaVars
 import {-# SOURCE #-} Agda.TypeChecking.Empty
 import {-# SOURCE #-} Agda.TypeChecking.Lock
 import {-# SOURCE #-} Agda.TypeChecking.CheckInternal ( checkType )
+import {-# SOURCE #-} Agda.TypeChecking.Rewriting
 
 import Agda.Utils.CallStack ( withCurrentCallStack )
 import qualified Agda.Utils.List1 as List1
@@ -312,6 +313,7 @@ solveConstraint_ (CheckDataSort q s)    = checkDataSort q s
 solveConstraint_ (CheckMetaInst m)      = checkMetaInst m
 solveConstraint_ (CheckType t)          = checkType t
 solveConstraint_ (UsableAtModality cc ms mod t) = usableAtModality' ms cc mod t
+solveConstraint_ (RewConstraint eq)     = checkRewConstraint eq
 
 checkTypeCheckingProblem :: TypeCheckingProblem -> TCM Term
 checkTypeCheckingProblem = \case

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -346,6 +346,10 @@ compareTerm' cmp a m n =
                 -- to trigger a reduction.
                 isNeutral (NotBlocked r (Def q _)) = do    -- Andreas, 2014-12-06 optimize this using r !!
                   not <$> usesCopatterns q -- a def by copattern can reduce if projected
+                isNeutral (NotBlocked r (Var i _)) = do
+                  -- Local rewrite rules can also make a variable applications
+                  -- reduce if projected
+                  not <$> rewUsesCopatterns (RewVarHead i)
                 isNeutral _                   = return True
 
                 -- Amy, 2024-01-29: Is this blocked application headed by one of the
@@ -551,6 +555,18 @@ compareAtomDir dir a = dirToCmp (`compareAtom` a) dir
 computeElimHeadType :: MonadConversion m => QName -> Elims -> Elims -> m Type
 computeElimHeadType f [] es' = computeDefType f es'
 computeElimHeadType f es _   = computeDefType f es
+
+-- | Compute the type of a rewrite rule head. For projection-like
+--   functions, this requires inferring the type of the principal argument,
+--   using the eliminations.
+computeRewHeadType :: MonadConversion m
+  => Int          -- Size of the "rewrite rule telescope"
+  -> RewriteHead  -- Rewrite rule head we want to compute the type of
+  -> Elims        -- Eliminations
+  -> Elims        -- Alternative eliminations, used if the first is empty
+  -> m Type
+computeRewHeadType telSize (RewDefHead f) es es' = computeElimHeadType f es es'
+computeRewHeadType telSize (RewVarHead x) es es' = typeOfBV $ x + telSize
 
 -- | Syntax directed equality on atomic values
 --
@@ -849,6 +865,11 @@ compareDom cmp0
      | not $ sameCohesion (getCohesion  dom1) (getCohesion  dom2) -> err
      | not $ samePolarity (getModalPolarity dom1) (getModalPolarity dom2) -> err
      | not $ domIsFinite dom1 == domIsFinite dom2 -> err
+     -- We compare both rewrite annotations AND the actual rewDoms to properly
+     -- handle the case where we have use a rewrite annotation outside of a
+     -- module telescope and continued trying to typecheck
+     | not $  getRewriteAnn dom1   == getRewriteAnn dom2
+           && isJust (rewDom dom1) == isJust (rewDom dom2) -> err
      | otherwise -> do
       let r = max (getRelevance dom1) (getRelevance dom2)
               -- take "most irrelevant"
@@ -1065,7 +1086,7 @@ compareElims pols0 fors0 a v els01 els02 =
       a <- abortIfBlocked a
       reportSLn "tc.conv.elim" 40 $ "type is not blocked"
       case unEl a of
-        (Pi (Dom{domInfo = info, unDom = b}) codom) -> do
+        (Pi dom@(Dom{domInfo = info, unDom = b}) codom) -> do
           reportSLn "tc.conv.elim" 40 $ "type is a function type"
           mlvl <- tryMaybe primLevel
           let freeInCoDom (Abs _ c) = 0 `freeInIgnoringSorts` c
@@ -1080,7 +1101,7 @@ compareElims pols0 fors0 a v els01 els02 =
 
           -- compare arg1 and arg2
           pid <- addConversionContext (\z -> ConvApply v codom (Arg info z) els1 els2) $
-            newProblem_ $ applyModalityToContext info
+            newProblem_ $ applyDomToContext dom
             if isForced for then
               reportSLn "tc.conv.elim" 40 $ "argument is forced"
             else if isIrrelevant info then do
@@ -1094,7 +1115,7 @@ compareElims pols0 fors0 a v els01 els02 =
           solved <- isProblemSolved pid
           reportSLn "tc.conv.elim" 40 $ "solved = " ++ show solved
           arg <- if dependent && not solved
-                 then applyModalityToContext info $ do
+                 then applyDomToContext dom $ do
                   reportSDoc "tc.conv.elims" 50 $ vcat $
                     [ "Trying antiUnify:"
                     , nest 2 $ "b    =" <+> prettyTCM b

--- a/src/full/Agda/TypeChecking/Coverage.hs
+++ b/src/full/Agda/TypeChecking/Coverage.hs
@@ -495,8 +495,7 @@ cover infermissing f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
       -- Don't do anything if there is no target type info.
       caseMaybe target cont $ \ b -> do
         -- TODO (2018-10-16): if proofs get erased in the compiler, also wake erased vars!
-        let m = getModality b
-        applyModalityToContext m cont
+        applyDomToContext b cont
 
     continue
       :: [BlockingVar]
@@ -544,7 +543,7 @@ cover infermissing f cs sc@(SClause tel ps _ _ target) = updateRelevance $ do
           -- Jesper, 2016-03-10  We need to remember which variables were
           -- eta-expanded by the unifier in order to generate a correct split
           -- tree (see Issue 1872).
-          reportSDoc "tc.cover.split.eta" 60 $ vcat
+          addContext tel $ reportSDoc "tc.cover.split.eta" 60 $ vcat
             [ "etaRecordSplits"
             , nest 2 $ vcat
               [ "n   = " <+> text (show n)

--- a/src/full/Agda/TypeChecking/Coverage/Cubical.hs
+++ b/src/full/Agda/TypeChecking/Coverage/Cubical.hs
@@ -872,11 +872,12 @@ createMissingTrXConClause q_trX f n x old_sc c (UE gamma gamma' xTel u v rho tau
     ,  nest 2 $ prettyTCM . QNamed f $ cl
     ]
 
-  let mod =
+  let dom =
         setRelevance irrelevant $  -- See #5611.
-        getModality $ fromMaybe __IMPOSSIBLE__ $ scTarget old_sc
+        fromMaybe __IMPOSSIBLE__ $ scTarget old_sc
+      mod = getModality dom
   -- we follow what `cover` does when updating the modality from the target.
-  applyModalityToContext mod $ do
+  applyDomToContext dom $ do
     unlessM (hasQuantity0 <$> viewTC eQuantity) $ do
     reportSDoc "tc.cover.trxcon" 20 $ text "testing usable at mod: " <+> pretty mod
     addContext cTel $ usableAtModality IndexedClause mod rhs

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1589,6 +1589,10 @@ instance PrettyTCM TypeError where
         , "and thus can not be transported"
         ]
 
+    CannotGenerateTransportLocalRewrite f -> vcat
+      [ "Could not generate a transport function for" <+> prettyTCM f
+      , "because there is a local rewrite rule in its telescope"]
+
     CubicalNotErasure q -> prettySigCubicalNotErasure q
 
     CubicalPrimitiveNotFullyApplied c ->
@@ -2133,6 +2137,15 @@ instance PrettyTCM UnificationFailure where
              , text $ verbalize $ getQuantity mod ] ++
       pwords "modality"
 
+    UnifyVarInRewrite tel a i u -> addContext tel $ fsep $
+      pwords "Cannot solve variable " ++ [prettyTCM (var i)] ++
+      pwords "of type " ++ [prettyTCM a] ++
+      pwords "with solution " ++ [prettyTCM u] ++
+      pwords "because the variable occurs in a local rewrite rule."
+
+    UnifyVarInRewriteEta tel i -> addContext tel $ fsep $
+      pwords "Cannot eta-expand variable " ++ [prettyTCM (var i)] ++
+      pwords "because the variable occurs in a local rewrite rule."
 
 
 explainWhyInScope :: forall m. MonadPretty m => WhyInScopeData -> m Doc

--- a/src/full/Agda/TypeChecking/Errors/Names.hs
+++ b/src/full/Agda/TypeChecking/Errors/Names.hs
@@ -79,6 +79,7 @@ typeErrorName = \case
   CannotGeneralizeEtaExpandable                              {} -> CannotGeneralizeEtaExpandable_
   CannotGenerateHCompClause                                  {} -> CannotGenerateHCompClause_
   CannotGenerateTransportClause                              {} -> CannotGenerateTransportClause_
+  CannotGenerateTransportLocalRewrite                        {} -> CannotGenerateTransportLocalRewrite_
   CannotResolveAmbiguousPatternSynonym                       {} -> CannotResolveAmbiguousPatternSynonym_
   CannotRewriteByNonEquation                                 {} -> CannotRewriteByNonEquation_
   CannotSolveSizeConstraints                                 {} -> CannotSolveSizeConstraints_

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -45,6 +45,7 @@ import Agda.TypeChecking.EtaContract
 import Agda.TypeChecking.SizedTypes (boundedSizeMetaHook, isSizeProblem)
 import {-# SOURCE #-} Agda.TypeChecking.CheckInternal
 import {-# SOURCE #-} Agda.TypeChecking.Conversion
+import Agda.TypeChecking.Warnings (warning)
 
 -- import Agda.TypeChecking.CheckInternal
 -- import {-# SOURCE #-} Agda.TypeChecking.CheckInternal (checkInternal)
@@ -140,8 +141,11 @@ assignTerm x tel v = do
 -- | Skip frozen check.  Used for eta expanding frozen metas.
 assignTermTCM' :: MetaId -> [Arg ArgName] -> Term -> TCM ()
 assignTermTCM' x tel v = do
+    let dummyFromArg (Arg i n) = defaultNamedArgDom i n __DUMMY_TYPE__
+
     reportSDoc "tc.meta.assign" 70 $ vcat
-      [ "assignTerm" <+> prettyTCM x <+> " := " <+> prettyTCM v
+      [ "assignTerm" <+> prettyTCM x <+> " := " <+>
+        addContext (dummyFromArg <$> tel) (prettyTCM v)
       , nest 2 $ "tel =" <+> prettyList_ (map (text . unArg) tel)
       ]
      -- verify (new) invariants
@@ -355,12 +359,12 @@ newArgsMetaCtx'' pref frozen condition (El s tm) tel perm ctx = do
                  map (mod `inverseApplyModalityButNotQuantity`) $
                  telToList tel
           ctx' = map (mod `inverseApplyModalityButNotQuantity`) ctx
-      (m, u) <- applyModalityToContext info $
+      (m, u) <- applyDomToContext dom $
                  newValueMetaCtx frozen RunMetaOccursCheck CmpLeq a tel' perm ctx'
       -- Jesper, 2021-05-05: When creating a metavariable from a
       -- generalizable variable, we must set the modality at which it
       -- will be generalized.  Don't do this for other metavariables,
-      -- as they should keep the defaul modality (see #5363).
+      -- as they should keep the default modality (see #5363).
       whenM ((== YesGeneralizeVar) <$> viewTC eGeneralizeMetas) $
         setMetaGeneralizableArgInfo m $ hideOrKeepInstance info
       setMetaNameSuggestion m (suffixNameSuggestion pref (absName codom))
@@ -644,8 +648,9 @@ postponeTypeCheckingProblem p unblock = do
   m   <- newMeta' (PostponedTypeCheckingProblem cl)
                   Instantiable i normalMetaPriority (idP (size tel))
          $ HasType () CmpLeq $ telePi_ tel t
-  inTopContext $ reportSDoc "tc.meta.postponed" 20 $ vcat
-    [ "new meta" <+> prettyTCM m <+> ":" <+> prettyTCM (telePi_ tel t)
+  reportSDoc "tc.meta.postponed" 20 $ vcat
+    [ "new meta" <+> inTopContext (prettyTCM m) <+>
+      ":" <+> inTopContext (prettyTCM $ telePi_ tel t)
     , "for postponed typechecking problem" <+> prettyTCM p
     ]
 
@@ -775,6 +780,13 @@ etaExpandBlocked (Blocked b t)  = do
     Blocked b' _ | b /= b' -> etaExpandBlocked t
     _                      -> return t
 
+-- | Is the term an @rewrite function?
+--   Does not need to do reduction because of syntactic restrictions on
+--   the placement of @rewrite
+isRewPi :: Term -> Bool
+isRewPi (Pi a b) = isJust (rewDom a) || isRewPi (unEl $ unAbs b)
+isRewPi _        = False
+
 {-# SPECIALIZE assignWrapper :: CompareDirection -> MetaId -> Elims -> Term -> TCM () -> TCM () #-}
 assignWrapper :: (MonadMetaSolver m)
               => CompareDirection -> MetaId -> Elims -> Term -> m () -> m ()
@@ -787,6 +799,28 @@ assignWrapper dir x es v doAssign = do
   where dontAssign = do
           reportSLn "tc.meta.assign" 10 "don't assign metas"
           patternViolation alwaysUnblock  -- retry again when we are allowed to instantiate metas
+
+allRewDoms :: Tele (Dom Type) -> [RewDom]
+allRewDoms = mapMaybe rewDom . flattenTel
+
+-- | Gets the set of variables constrained by local rewrite rules
+--
+--   We specifically care about variables that occur exactly as LHSs of local
+--   rewrite rules. Unification problems under such local rewrite rules might
+--   appear outside the pattern fragment after rewriting arguments, but if the
+--   argument is constrained in the meta's context, we know it is uniquely
+--   determined up to defeq and can proceed.
+rewConstrained :: Tele (Dom Type) -> VarSet
+rewConstrained =
+  foldMap (rewConstrained' . fromMaybe __IMPOSSIBLE__ . rewDomRew) . allRewDoms
+  where
+    rewConstrained' :: RewriteRule -> VarSet
+    rewConstrained' (RewriteRule EmptyTel (RewVarHead x) [] _ _) =
+      VarSet.singleton x
+    rewConstrained' (RewriteRule _ (RewVarHead x) [] _ _) =
+      __IMPOSSIBLE__
+    rewConstrained' _ =
+      VarSet.empty
 
 -- | Miller pattern unification:
 --
@@ -845,6 +879,12 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
   case (v, mvJudgement mvar) of
       (Sort s, HasType{}) -> hasBiggerSort s
       _                   -> return ()
+
+  -- Instantiating metas with @rewrite functions is never allowed to ensure
+  -- quantification is always prenex
+  when (isRewPi v) $ do
+    warning $ InferredLocalRewrite x v
+    patternViolation neverUnblock
 
   -- Jesper, 2019-09-13: When --no-sort-comparison is enabled,
   -- we equate the sort of the solution with the sort of the
@@ -941,8 +981,8 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
 
     expandProjectedVars args (v, target) $ \ args (v, target) -> do
 
+      cxt <- getContextTelescope
       reportSDoc "tc.meta.assign.proj" 45 $ do
-        cxt <- getContextTelescope
         vcat
           [ "context after projection expansion"
           , nest 2 $ inTopContext $ prettyTCM cxt
@@ -1042,9 +1082,15 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
       reportSDoc "tc.meta.assign" 20 $
         "fvars rhs:" <+> sep (map (text . show) $ VarSet.toAscList fvs)
 
+      let n = length args
+      TelV mTel _ <- telViewUpToPath n t
+
+      -- We should never prune local rewrite rules
+      let noPrune = VarSet.union fvs $ theRewVars cxt
+
       -- Check that the arguments are variables
       mids <- do
-        res <- runExceptT $ inverseSubst' (const False) args
+        res <- runExceptT $ inverseSubst' (const False) mTel args
         case res of
           -- all args are variables
           Right ids -> do
@@ -1060,10 +1106,10 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
           -- here, we cannot prune, since offending vars could be eliminated
           Left (CantInvert tm) -> Nothing <$ boundary v
           -- we have non-variables, but these are not eliminateable
-          Left NeutralArg  -> Just <$> attemptPruning x args fvs
+          Left NeutralArg  -> Just <$> attemptPruning x args noPrune
           -- we have a projected variable which could not be eta-expanded away:
           -- same as neutral
-          Left ProjVar{}   -> Just <$> attemptPruning x args fvs
+          Left ProjVar{}   -> Just <$> attemptPruning x args noPrune
 
       case mids of  -- vv Ulf 2014-07-13: actually not needed after all: attemptInertRHSImprovement x args v
         Nothing  -> patternViolation =<< updateBlocker (unblockOnAnyMetaIn v)  -- TODO: more precise
@@ -1080,14 +1126,13 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
               -- using non-linear variables need to be solved).
               Left ()   -> do
                 block <- updateBlocker $ unblockOnAnyMetaIn v
-                addOrUnblocker block $ attemptPruning x args fvs
+                addOrUnblocker block $ attemptPruning x args noPrune
 
           -- Check ids is time respecting.
           () <- do
             let idvars = map (second freeVarSet) ids
             -- earlierThan α v := v "arrives" before α
             let earlierThan l j = j > l
-            TelV tel' _ <- telViewUpToPath (length args) t
             forM_ ids $ \(i,u) -> do
               d <- domOfBV i
               case getLock (getArgInfo d) of
@@ -1095,12 +1140,9 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
                 IsLock{} -> do
                 let us = VarSet.unions $ map snd $ filter (earlierThan i . fst) idvars
                 -- us Earlier than u
-                unlessM (addContext tel' $ checkEarlierThan u us) $
+                unlessM (addContext mTel $ checkEarlierThan u us) $
                   patternViolation (unblockOnMeta x)  -- If the earlier check hard-fails we need to
                                                       -- solve this meta in some other way.
-
-          let n = length args
-          TelV tel' _ <- telViewUpToPath n t
 
           -- Check subtyping constraints on the context variables.
 
@@ -1117,7 +1159,7 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
           hasSubtyping <- optCumulativity <$> pragmaOptions
           when hasSubtyping $ forM_ ids $ \(i , u) -> do
             -- @u@ is a (projected) variable, so we can infer its type
-            a  <- applySubst sigma <$> addContext tel' (infer u)
+            a  <- applySubst sigma <$> addContext mTel (infer u)
             a' <- typeOfBV i
             checkSubtypeIsEqual a' a
               `catchError` \case
@@ -1132,11 +1174,12 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
     attemptPruning
       :: MetaId  -- Meta-variable (lhs)
       -> Args    -- Meta arguments (lhs)
-      -> FVs     -- Variables occuring on the rhs
+      -> VarSet  -- Variables we do not want to prune
+                 -- (e.g. those occurring on the rhs)
       -> TCM a
-    attemptPruning x args fvs = do
+    attemptPruning x args noPrune = do
       -- non-linear lhs: we cannot solve, but prune
-      killResult <- prune x args $ (`VarSet.member` fvs)
+      killResult <- prune x args $ (`VarSet.member` noPrune)
       let success = killResult `elem` [PrunedSomething,PrunedEverything]
       reportSDoc "tc.meta.assign" 10 $
         "pruning" <+> prettyTCM x <+> do text $ if success then "succeeded" else "failed"
@@ -1322,21 +1365,48 @@ assignMeta' m x t n ids v = do
       rho = prependS impossible ivs $ raiseS n
       v'  = applySubst rho v
 
+  cxt <- getContextTelescope
+
+  -- Variables corresponding to local rewrite rules
+  let rVars = VarSet.toDescList $ theRewVars cxt
+  -- Variables not strengthened away
+  let notDropped = VarSet.fromList $ fmap fst ids
+
   -- Metas are top-level so we do the assignment at top-level.
   inTopContext $ do
+
     -- Andreas, 2011-04-18 to work with irrelevant parameters
     -- we need to construct tel' from the type of the meta variable
     -- (no longer from ids which may not be the complete variable list
     -- any more)
     reportSDoc "tc.meta.assign" 15 $ "type of meta =" <+> prettyTCM t
 
-    (telv@(TelV tel' a), bs) <- telViewUpToPathBoundary n t
-    reportSDoc "tc.meta.assign" 30 $ "tel'  =" <+> prettyTCM tel'
+    (telv@(TelV mTel a), bs) <- telViewUpToPathBoundary n t
+    reportSDoc "tc.meta.assign" 30 $ "tel'  =" <+> prettyTCM mTel
     reportSDoc "tc.meta.assign" 30 $ "#args =" <+> text (show n)
+
+    -- Solving metas in contexts with extra local rewrite rules is
+    -- problematic because solutions that appear unique locally may not be
+    -- globally unique.
+    -- We fix this by checking that every local rewrite rule in the solution
+    -- context is mapped to a local rewrite rule in the meta's context.
+    -- This is conservative, but should at least be pretty fast.
+
+    stillRews <- addContext mTel $ forM rVars \i -> do
+      if not $ VarSet.member i notDropped then pure False else do
+      case deBruijnView $ lookupS rho i of
+        Just i' -> do
+          isJust . rewDom <$> domOfBV i'
+        Nothing -> pure False
+
+    -- The current context has a rewrite rule which does not appear to be
+    -- in the meta's
+    unless (and stillRews) $ patternViolation neverUnblock
+
     -- Andreas, 2013-09-17 (AIM XVIII): if t does not provide enough
     -- types for the arguments, it might be blocked by a meta;
     -- then we give up. (Issue 903)
-    when (size tel' < n) $ do
+    when (size mTel < n) $ do
       a <- abortIfBlocked a
       reportSDoc "impossible" 10 $ "not enough pis, but not blocked?" <?> pretty a
       __IMPOSSIBLE__   -- If we get here it was _not_ blocked by a meta!
@@ -1350,12 +1420,12 @@ assignMeta' m x t n ids v = do
       m <- lookupLocalMeta x
       reportSDoc "tc.meta.check" 30 $ "double checking solution"
       catchConstraint (CheckMetaInst x) $
-        addContext tel' $ checkSolutionForMeta x m v' a
+        addContext mTel $ checkSolutionForMeta x m v' a
 
     reportSDoc "tc.meta.assign" 10 $
-      "solving" <+> prettyTCM x <+> ":=" <+> prettyTCM (abstract tel' v')
+      "solving" <+> prettyTCM x <+> ":=" <+> prettyTCM (abstract mTel v')
 
-    assignTerm x (telToArgs tel') v'
+    assignTerm x (telToArgs mTel) v'
   where
     blockOnBoundary :: TelView -> Boundary -> Term -> TCM Term
     blockOnBoundary telv         (Boundary []) v = return v
@@ -1513,7 +1583,11 @@ etaExpandProjectedVar :: (PrettyTCM a, TermSubst a) => Int -> a -> TCM c -> (a -
 etaExpandProjectedVar i v fail succeed = do
   reportSDoc "tc.meta.assign.proj" 40 $
     "trying to expand projected variable" <+> prettyTCM (var i)
-  caseMaybeM (etaExpandBoundVar i) fail $ \ (delta, sigma, tau) -> do
+  -- We don't eta-expand variables which occur in local rewrite rules
+  -- In principle, I think we could handle this safely, but it is tricky
+  tel <- getContextTelescope
+  if i `VarSet.member` inRewVars tel then fail else
+    caseMaybeM (etaExpandBoundVar i) fail $ \ (delta, sigma, tau) -> do
     reportSDoc "tc.meta.assign.proj" 25 $
       "eta-expanding var " <+> prettyTCM (var i) <+>
       " in terms " <+> prettyTCM v
@@ -1662,8 +1736,10 @@ data InvertExcept
 --   Linearity, i.e., whether the substitution is deterministic,
 --   has to be checked separately.
 --
-inverseSubst' :: (Term -> Bool) -> Args -> ExceptT InvertExcept TCM SubstCand
-inverseSubst' skip args = map (first unArg) <$> loop (zip args terms)
+inverseSubst' ::
+     (Term -> Bool) -> Tele (Dom Type) -> Args
+  -> ExceptT InvertExcept TCM SubstCand
+inverseSubst' skip tel args = map (first unArg) <$> loop (zip args terms)
   where
   loop  = foldM isVarOrIrrelevant []
   terms = map var (downFrom (size args))
@@ -1673,8 +1749,21 @@ inverseSubst' skip args = map (first unArg) <$> loop (zip args terms)
       , "  aborting assignment" ]
     throwError (CantInvert c)
   neutralArg = throwError NeutralArg
+  -- We need to identify arguments to the meta that are fully constrained by
+  -- local rewrite rules
+  -- These are simply ignored when building the inverse substitution
+  -- (analogously to irrelevant arguments)
+  constrained = rewConstrained tel
 
   isVarOrIrrelevant :: Res -> (Arg Term, Term) -> ExceptT InvertExcept TCM Res
+  isVarOrIrrelevant vars (Arg info v, Var x [])
+    | x `VarSet.member` constrained = do
+    lift $ reportSDoc "tc.meta.assign" 60 $ vcat
+            [ "argument is constrained by rewrite rule"
+            , "  arg = " <+> prettyTCM v
+            , "  var = " <+> prettyTCM (var x)
+            ]
+    return vars
   isVarOrIrrelevant vars (Arg info v, t) = do
     let irr | isIrrelevant info = True
             | DontCare{} <- v   = True
@@ -1736,9 +1825,9 @@ inverseSubst' skip args = map (first unArg) <$> loop (zip args terms)
         pure $ (Arg info i, Def qn [Apply (defaultArg t)]) `cons` vars
 
       Def{}      -> neutralArg  -- Note that this Def{} is in normal form and might be prunable.
-      t@Lam{}    -> failure t
-      t@Lit{}    -> failure t
-      t@MetaV{}  -> failure t
+      tm@Lam{}   -> failure tm
+      tm@Lit{}   -> failure tm
+      tm@MetaV{} -> failure tm
       Pi{}       -> neutralArg
       Sort{}     -> neutralArg
       Level{}    -> neutralArg
@@ -1798,16 +1887,19 @@ isFaceConstraint mid args = runMaybeT $ do
       IZero -> Just (i, False)
       _     -> Nothing
 
+  m           <- getContextSize
+  TelV tel' _ <- telViewUpToPath n t
+
   -- The logic here is essentially the same as for actually solving the
   -- meta.. We just return the pieces instead of doing the assignment.
   -- We must check the "face condition" (the relaxed pattern condition)
   -- and check linearity of the substitution candidate, otherwise the
   -- equation can't be inverted into a face constraint.
-  sub <- MaybeT $ either (const Nothing) Just <$> runExceptT (inverseSubst' isEndpoint args)
-  ids <- MaybeT $ either (const Nothing) Just <$> runExceptT (checkLinearity sub)
+  sub <- MaybeT $ either (const Nothing) Just <$> runExceptT
+    (inverseSubst' isEndpoint tel' args)
+  ids <- MaybeT $ either (const Nothing) Just <$> runExceptT
+    (checkLinearity sub)
 
-  m           <- getContextSize
-  TelV tel' _ <- telViewUpToPath n t
   tel''       <- enterClosure mvar $ \_ -> getContextTelescope
 
   let

--- a/src/full/Agda/TypeChecking/MetaVars/Mention.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Mention.hs
@@ -87,6 +87,14 @@ instance (MentionsMeta a, MentionsMeta b) => MentionsMeta (a, b) where
 instance (MentionsMeta a, MentionsMeta b, MentionsMeta c) => MentionsMeta (a, b, c) where
   mentionsMetas xs (a, b, c) = mentionsMetas xs a || mentionsMetas xs b || mentionsMetas xs c
 
+instance (MentionsMeta a, MentionsMeta b, MentionsMeta c, MentionsMeta d)
+  => MentionsMeta (a, b, c, d) where
+  mentionsMetas xs (a, b, c, d) =
+    mentionsMetas xs a ||
+    mentionsMetas xs b ||
+    mentionsMetas xs c ||
+    mentionsMetas xs d
+
 instance MentionsMeta a => MentionsMeta (Closure a) where
   mentionsMetas xs cl = mentionsMetas xs (clValue cl)
 
@@ -101,6 +109,9 @@ instance MentionsMeta a => MentionsMeta (Tele a) where
 
 instance MentionsMeta ProblemConstraint where
   mentionsMetas xs = mentionsMetas xs . theConstraint
+
+instance MentionsMeta LocalEquation where
+  mentionsMetas xs (LocalEquation g t u a) = mentionsMetas xs (g, t, u, a)
 
 instance MentionsMeta Constraint where
   mentionsMetas xs = \case
@@ -125,6 +136,7 @@ instance MentionsMeta Constraint where
     CheckType t         -> mm t
     CheckLockedVars a b c d -> mm ((a, b), (c, d))
     UsableAtModality _ ms mod t -> mm (ms, t)
+    RewConstraint e     -> mm e
     where
       mm :: forall t. MentionsMeta t => t -> Bool
       mm = mentionsMetas xs

--- a/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
+++ b/src/full/Agda/TypeChecking/MetaVars/Occurs.hs
@@ -744,8 +744,8 @@ instance Occurs a => Occurs (Arg a) where
 
 instance Occurs a => Occurs (Dom a) where
   occurs :: Dom a -> OccursM (Dom a)
-  occurs (Dom info n f t x) =
-    Dom info n f t <$> underQuantity info (occurs x)
+  occurs (Dom info n f t r x) =
+    Dom info n f t r <$> underQuantity info (occurs x)
 
 ---------------------------------------------------------------------------
 -- * Pruning: getting rid of flexible occurrences.

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1586,6 +1586,9 @@ data Constraint
   | UsableAtModality WhyCheckModality (Maybe Sort) Modality Term
     -- ^ Is the term usable at the given modality?
     -- This check should run if the @Sort@ is @Nothing@ or @isFibrant@.
+  | RewConstraint LocalEquation
+    -- ^ Does the local rewrite rule hold definitionally at the call-site?
+    --   Essentially a 'ValueCmp' but with a more specific error message
   deriving (Show, Generic)
 
 -- It's important to have a proper range for constraints that can remain unsolved
@@ -1610,6 +1613,7 @@ instance HasRange Constraint where
   getRange UnquoteTactic{}       = noRange
   getRange CheckLockedVars{}     = noRange
   getRange UsableAtModality{}    = noRange
+  getRange RewConstraint{}       = noRange
 
 instance Free Constraint where
   freeVars c = expand \ret -> case c of
@@ -1632,9 +1636,15 @@ instance Free Constraint where
     CheckMetaInst m             -> ret $ mempty
     CheckType t                 -> ret $ freeVars t
     UsableAtModality _ ms mod t -> ret $ freeVars (ms, t)
+    RewConstraint e             -> ret $ freeVars e
 
 {-# SPECIALIZE closed :: Constraint -> Bool #-}
 {-# SPECIALIZE freeVarSet :: Constraint -> VarSet #-}
+
+instance TermLike LocalEquation where
+  foldTerm f (LocalEquation g t u a) = foldTerm f (g, t, u, a)
+
+  traverseTermM f c = __IMPOSSIBLE__ -- Not yet implemented
 
 instance TermLike Constraint where
   foldTerm f = \case
@@ -1657,6 +1667,7 @@ instance TermLike Constraint where
       CheckMetaInst m        -> mempty
       CheckType t            -> foldTerm f t
       UsableAtModality _ ms m t   -> foldTerm f (Sort <$> ms, t)
+      RewConstraint e        -> foldTerm f e
 
   traverseTermM f c = __IMPOSSIBLE__ -- Not yet implemented
 
@@ -1895,6 +1906,7 @@ data RemoteMetaVariable = RemoteMetaVariable
 --   it did, it returns a handle to any unsolved constraints.
 data CheckedTarget = CheckedTarget (Maybe ProblemId)
                    | NotCheckedTarget
+  deriving Show
 
 data PrincipalArgTypeMetas = PrincipalArgTypeMetas
   { patmMetas     :: Args -- ^ metas created for hidden and instance arguments
@@ -2374,6 +2386,30 @@ data GlobalRewriteRule = GlobalRewriteRule
   }
     deriving (Show, Generic)
 
+grHasProjectionPattern :: GlobalRewriteRule -> Bool
+grHasProjectionPattern rew = any (isJust . isProjElim) $ grPats rew
+
+type RewriteRules = [RewriteRule]
+
+-- | Map from head symbols to local rewrite rules
+--   While the head symbols need to be eagerly updated to live in the current
+--   context, the rewrite rules do not. They instead each store a checkpoint id.
+data LocalRewriteRuleMap = LocalRewriteRuleMap
+  { defHeadedRews :: HashMap QName [Open RewriteRule]
+  , varHeadedRews :: IntMap [Open RewriteRule]
+  }
+    deriving (Show, Generic)
+
+lrewsDefHeaded :: Lens' LocalRewriteRuleMap (HashMap QName [Open RewriteRule])
+lrewsDefHeaded f rs = f (defHeadedRews rs) <&> \ rs' -> rs { defHeadedRews = rs' }
+
+lrewsVarHeaded :: Lens' LocalRewriteRuleMap (IntMap [Open RewriteRule])
+lrewsVarHeaded f rs = f (varHeadedRews rs) <&> \ rs' -> rs { varHeadedRews = rs' }
+
+instance Null LocalRewriteRuleMap where
+  empty                               = LocalRewriteRuleMap empty empty
+  null  (LocalRewriteRuleMap rs1 rs2) = null rs1 && null rs2
+
 -- | Information about an @instance@ definition.
 data InstanceInfo = InstanceInfo
   { instanceClass   :: QName       -- ^ Name of the "class" this is an instance for
@@ -2445,12 +2481,14 @@ data Definition = Defn
                          -- instantiation?
   , defMatchable      :: Set QName
     -- ^ The set of symbols with rewrite rules that match against this symbol
+    -- Does not account for local rewrite rules
   , defNoCompilation  :: Bool
     -- ^ should compilers skip this? Used for e.g. cubical's comp
   , defInjective      :: Bool
     -- ^ Should the def be treated as injective by the pattern matching unifier?
-  , defCopatternLHS   :: Bool
+  , defCopatternLHS'   :: Bool
     -- ^ Is this a function defined by copatterns?
+    -- Does not account for local rewrite rules
   , defBlocked        :: Blocked_
     -- ^ What blocking tag to use when we cannot reduce this def?
     --   Used when checking a function definition is blocked on a meta
@@ -2498,7 +2536,7 @@ defaultDefn info x t lang def = Defn
   , defMatchable      = Set.empty
   , defNoCompilation  = False
   , defInjective      = False
-  , defCopatternLHS   = False
+  , defCopatternLHS'  = False
   , defBlocked        = NotBlocked ReallyNotBlocked ()
   , defLanguage       = lang
   , theDef            = def
@@ -3143,7 +3181,7 @@ instance Pretty Definition where
       , "defCopy           =" <?> pshow defCopy
       , "defMatchable      =" <?> pshow (Set.toList defMatchable)
       , "defInjective      =" <?> pshow defInjective
-      , "defCopatternLHS   =" <?> pshow defCopatternLHS
+      , "defCopatternLHS   =" <?> pshow defCopatternLHS'
       , "theDef            =" <?> pretty theDef ] <+> "}"
 
 instance Pretty Defn where
@@ -3804,13 +3842,14 @@ data Call
       Term   -- ^ (Simplified) Function applied to the patterns in this clause
       Term   -- ^ (Simplified) clause RHS
       Type   -- ^ (Simplified) clause type
+  | CheckLocalRewriteConstraint LocalEquation (Maybe (Closure Call))
   | ScopeCheckExpr C.Expr
   | ScopeCheckDeclaration NiceDeclaration
   | ScopeCheckLHS C.QName C.Pattern
   | NoHighlighting
   | ModuleContents  -- ^ Interaction command: show module contents.
   | SetRange Range  -- ^ used by 'setCurrentRange'
-  deriving Generic
+  deriving (Generic, Show)
 
 instance Pretty Call where
     pretty CheckClause{}             = "CheckClause"
@@ -3850,6 +3889,7 @@ instance Pretty Call where
     pretty NoHighlighting{}          = "NoHighlighting"
     pretty ModuleContents{}          = "ModuleContents"
     pretty CheckIApplyConfluence{}   = "ModuleContents"
+    pretty CheckLocalRewriteConstraint{} = "CheckLocalRewriteConstraint"
 
 instance HasRange Call where
     getRange (CheckClause _ c)                   = getRange c
@@ -3889,6 +3929,7 @@ instance HasRange Call where
     getRange NoHighlighting                      = noRange
     getRange ModuleContents                      = noRange
     getRange (CheckIApplyConfluence e _ _ _ _ _) = getRange e
+    getRange (CheckLocalRewriteConstraint _ _)   = noRange
 
 ---------------------------------------------------------------------------
 -- ** Instance table
@@ -4180,6 +4221,8 @@ data TCEnv =
                 -- currently under, if any. Used by the scope checker
                 -- (to associate definitions to blocks), and by the type
                 -- checker (for unfolding control).
+          , envLocalRewriteRules :: LocalRewriteRuleMap
+                -- ^ Local rewrite rules
           }
     deriving (Generic)
 
@@ -4246,6 +4289,7 @@ initEnv = TCEnv { envContext             = CxEmpty
                 , envCurrentlyElaborating   = False
                 , envSyntacticEqualityFuel  = Strict.Nothing
                 , envCurrentOpaqueId        = Nothing
+                , envLocalRewriteRules      = empty
                 }
 
 class LensTCEnv a where
@@ -4438,6 +4482,9 @@ eConflComputingOverlap f e = f (envConflComputingOverlap e) <&> \ x -> e { envCo
 
 eCurrentlyElaborating :: Lens' TCEnv Bool
 eCurrentlyElaborating f e = f (envCurrentlyElaborating e) <&> \ x -> e { envCurrentlyElaborating = x }
+
+eLocalRewriteRules :: Lens' TCEnv LocalRewriteRuleMap
+eLocalRewriteRules f e = f (envLocalRewriteRules e) <&> \ x -> e { envLocalRewriteRules = x }
 
 {-# SPECIALISE currentModality :: TCM Modality #-}
 -- | The current modality.
@@ -4657,6 +4704,8 @@ data Warning
     -- ^ Auto-correcting cohesion pertaining to 'String' /from/ /to/.
   | FixingPolarity String PolarityModality PolarityModality
     -- ^ Auto-correcting polarity pertaining to 'String' /from/ /to/.
+  | IgnoringRew String RewriteAnn
+    -- ^ Auto-correcting rewrite pertaining to 'String' by ignoring it
   | IllformedAsClause String
     -- ^ If the user wrote something other than an unqualified name
     --   in the @as@ clause of an @import@ statement.
@@ -4738,7 +4787,7 @@ data Warning
     -- ^ Confluence checking with @--cubical@ might be incomplete.
   | NotARewriteRule C.QName IsAmbiguous
     -- ^ 'IllegalRewriteRule' detected during scope checking.
-  | IllegalRewriteRule QName IllegalRewriteRuleReason
+  | IllegalRewriteRule RewriteSource IllegalRewriteRuleReason
   | RewriteNonConfluent Term Term Term Doc
     -- ^ Confluence checker found critical pair and equality checking
     --   resulted in a type error
@@ -4752,6 +4801,9 @@ data Warning
   | RewriteMissingRule Term Term Term
     -- ^ The global confluence checker found a term @u@ that reduces
     --   to @v@, but @v@ does not reduce to @rho(u)@.
+  | InferredLocalRewrite MetaId Term
+    -- ^ Inferred that some meta should be solved with an @rewrite function
+    --   (We never infer local rewrite rules)
   | PragmaCompileErased BackendName QName
     -- ^ COMPILE directive for an erased symbol.
   | PragmaCompileList
@@ -4883,6 +4935,7 @@ warningName = \case
   FixingRelevance{}            -> FixingRelevance_
   FixingCohesion{}             -> FixingCohesion_
   FixingPolarity{}             -> FixingPolarity_
+  IgnoringRew{}                -> MisplacedRewrite_
   IllformedAsClause{}          -> IllformedAsClause_
   WrongInstanceDeclaration{}   -> WrongInstanceDeclaration_
   InstanceWithExplicitArg{}    -> InstanceWithExplicitArg_
@@ -4930,6 +4983,7 @@ warningName = \case
   RewriteMaybeNonConfluent{}   -> RewriteMaybeNonConfluent_
   RewriteAmbiguousRules{}      -> RewriteAmbiguousRules_
   RewriteMissingRule{}         -> RewriteMissingRule_
+  InferredLocalRewrite{}       -> InferredLocalRewrite_
   PragmaCompileErased{}        -> PragmaCompileErased_
   PragmaCompileList{}          -> PragmaCompileList_
   PragmaCompileMaybe{}         -> PragmaCompileMaybe_
@@ -5004,6 +5058,7 @@ illegalRewriteWarningName = \case
   BeforeFunctionDefinition             -> RewriteBeforeFunctionDefinition_
   BeforeMutualFunctionDefinition{}     -> RewriteBeforeMutualFunctionDefinition_
   DuplicateRewriteRule                 -> DuplicateRewriteRule_
+  LocalRewriteOutsideTelescope         -> LocalRewriteOutsideTelescope_
 
 -- | Should warnings of that type be serialized?
 --
@@ -5112,6 +5167,8 @@ data UnificationFailure
   | UnifyRecursiveEq Telescope Type Int Term          -- ^ Can't solve equation because variable occurs in (type of) lhs
   | UnifyReflexiveEq Telescope Type Term              -- ^ Can't solve reflexive equation because --without-K is enabled
   | UnifyUnusableModality Telescope Type Int Term Modality  -- ^ Can't solve equation because solution modality is less "usable"
+  | UnifyVarInRewrite Telescope Type Int Term         -- ^ Can't solve equation because variable occurs in a local rewrite rule
+  | UnifyVarInRewriteEta Telescope Int                -- ^ Can't eta-expand variable because variable occurs in a local rewrite rule
   deriving (Show, Generic)
 
 data UnquoteError
@@ -5341,6 +5398,9 @@ data TypeError
             -- ^ Attempt to pattern match in an abstraction of interval type.
         | PatternInSystem
             -- ^ Attempt to pattern or copattern match in a system.
+        | CannotGenerateTransportLocalRewrite QName
+            -- ^ Cannot generate transport for data or record type because there
+            --   is a local rewrite rule in the telescope.
     -- Data errors
         | UnexpectedParameter A.LamBinding
         | NoParameterOfName ArgName
@@ -5619,6 +5679,16 @@ data InductionAndEta = InductionAndEta
   , recordEtaEquality :: EtaEquality
   } deriving (Show, Generic)
 
+-- Source of the rewrite rule
+data RewriteSource
+  = GlobalRewrite Definition
+  | LocalRewrite Context (Maybe Name) Type
+  deriving (Show, Generic)
+
+isLocalRewrite :: RewriteSource -> Bool
+isLocalRewrite (LocalRewrite g r t) = True
+isLocalRewrite (GlobalRewrite d)    = False
+
 -- Reason, why rewrite rule is invalid
 data IllegalRewriteRuleReason
   = LHSNotDefinitionOrConstructor
@@ -5637,6 +5707,7 @@ data IllegalRewriteRuleReason
   | BeforeFunctionDefinition
   | BeforeMutualFunctionDefinition QName
   | DuplicateRewriteRule
+  | LocalRewriteOutsideTelescope
     deriving (Show, Generic)
 
 -- | Boolean flag whether a name is ambiguous.
@@ -5761,6 +5832,19 @@ cubicalCompatibleOption = optCubicalCompatible <$> pragmaOptions
 enableCaching :: HasOptions m => m Bool
 enableCaching = optCaching <$> pragmaOptions
 {-# INLINE enableCaching #-}
+
+rewritingOption :: HasOptions m => m Bool
+rewritingOption = optRewriting <$> pragmaOptions
+{-# INLINE rewritingOption #-}
+
+localRewritingOption :: HasOptions m => m Bool
+localRewritingOption = optLocalRewriting <$> pragmaOptions
+{-# INLINE localRewritingOption #-}
+
+-- | Local or global rewriting is enabled
+anyRewritingOption :: HasOptions m => m Bool
+anyRewritingOption = (||) <$> rewritingOption <*> localRewritingOption
+{-# INLINE anyRewritingOption #-}
 
 -----------------------------------------------------------------------------
 -- * The reduce monad
@@ -6811,6 +6895,7 @@ instance NFData DisplayForm
 instance NFData DisplayTerm
 instance NFData GlobalRewriteRule
 instance NFData InstanceInfo
+instance NFData LocalRewriteRuleMap
 instance NFData Definition
 instance NFData Polarity
 instance NFData IsForced
@@ -6864,6 +6949,7 @@ instance NFData ClashingName
 instance NFData InvalidFileNameReason
 instance NFData LHSOrPatSyn
 instance NFData InductionAndEta
+instance NFData RewriteSource
 instance NFData IllegalRewriteRuleReason
 instance NFData IncorrectTypeForRewriteRelationReason
 instance NFData GHCBackendError

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -966,7 +966,7 @@ stOccursCheckDefs = lensPostScopeState . lensOccursCheckDefs
 stSignature :: Lens' TCState Signature
 stSignature = lensPostScopeState . lensSignature
 
-stRewriteRules :: Lens' TCState RewriteRuleMap
+stRewriteRules :: Lens' TCState GlobalRewriteRuleMap
 stRewriteRules = stSignature . sigRewriteRules
 
 stModuleCheckpoints :: Lens' TCState ModuleCheckpoints
@@ -2176,7 +2176,8 @@ instance Eq IPClause where
 data Signature = Sig
       { _sigSections     :: Sections
       , _sigDefinitions  :: Definitions
-      , _sigRewriteRules :: RewriteRuleMap  -- ^ The rewrite rules defined in this file.
+      , _sigRewriteRules :: GlobalRewriteRuleMap
+        -- ^ The rewrite rules defined in this file.
       , _sigInstances    :: InstanceTable
       }
   deriving (Show, Generic)
@@ -2198,14 +2199,14 @@ sigDefinitions f s =
 sigInstances :: Lens' Signature InstanceTable
 sigInstances f s = f (_sigInstances s) <&> \x -> s {_sigInstances = x}
 
-sigRewriteRules :: Lens' Signature RewriteRuleMap
+sigRewriteRules :: Lens' Signature GlobalRewriteRuleMap
 sigRewriteRules f s =
   f (_sigRewriteRules s) <&>
   \x -> s {_sigRewriteRules = x}
 
 type Sections    = Map ModuleName Section
 type Definitions = HashMap QName Definition
-type RewriteRuleMap = HashMap QName RewriteRules
+type GlobalRewriteRuleMap = HashMap QName GlobalRewriteRules
 type DisplayForms = HashMap QName (List1 LocalDisplayForm)
 
 {-# SPECIALIZE HMap.insert :: QName -> v -> HashMap QName v -> HashMap QName v #-}
@@ -2351,22 +2352,23 @@ instance TermLike NLPSort where
 
 instance AllMetas NLPSort
 
-type RewriteRules = [RewriteRule]
+type GlobalRewriteRules = [GlobalRewriteRule]
 
 -- | Rewrite rules can be added independently from function clauses.
-data RewriteRule = RewriteRule
-  { rewName    :: QName      -- ^ Name of rewrite rule @q : Γ → f ps ≡ rhs@
-                             --   where @≡@ is the rewrite relation.
-  , rewContext :: Telescope  -- ^ @Γ@.
-  , rewHead    :: QName      -- ^ @f@.
-  , rewPats    :: PElims     -- ^ @Γ ⊢ f ps : t@.
-  , rewRHS     :: Term       -- ^ @Γ ⊢ rhs : t@.
-  , rewType    :: Type       -- ^ @Γ ⊢ t@.
-  , rewFromClause :: Bool    -- ^ Was this rewrite rule created from a clause in the definition of the function?
-  , rewTopModule  :: TopLevelModuleName
+data GlobalRewriteRule = GlobalRewriteRule
+  { grName    :: QName      -- ^ Name of rewrite rule @q : Γ → f ps ≡ rhs@
+                            --   where @≡@ is the rewrite relation.
+  , grContext :: Telescope  -- ^ @Γ@.
+  , grHead    :: QName      -- ^ @f@.
+  , grPats    :: PElims     -- ^ @Γ ⊢ f ps : t@.
+  , grRHS     :: Term       -- ^ @Γ ⊢ rhs : t@.
+  , grType    :: Type       -- ^ @Γ ⊢ t@.
+  , grFromClause :: Bool    -- ^ Was this rewrite rule created from a clause in
+                            --   the definition of the function?
+  , grTopModule  :: TopLevelModuleName
       -- ^ In which file is this rewrite rule defined?
-      --   This information is used to eliminate rewrite rules that happen to be in 'stImports'
-      --   but are not actually transitively imported.
+      --   This information is used to eliminate rewrite rules that happen to be
+      --   in 'stImports' but are not actually transitively imported.
 
       --   See issue #4343 (Andreas, 2025-06-05).
   }
@@ -6631,7 +6633,7 @@ instance KillRange Sections where
 instance KillRange Definitions where
   killRange = fmap killRange
 
-instance KillRange RewriteRuleMap where
+instance KillRange GlobalRewriteRuleMap where
   killRange = fmap killRange
 
 instance KillRange Section where
@@ -6649,9 +6651,9 @@ instance KillRange Definition where
 instance KillRange NumGeneralizableArgs where
   killRange = id
 
-instance KillRange RewriteRule where
-  killRange (RewriteRule q gamma f es rhs t c top) =
-    killRangeN RewriteRule q gamma f es rhs t c top
+instance KillRange GlobalRewriteRule where
+  killRange (GlobalRewriteRule q gamma f es rhs t c top) =
+    killRangeN GlobalRewriteRule q gamma f es rhs t c top
 
 instance KillRange CompiledRepresentation where
   killRange = id
@@ -6807,7 +6809,7 @@ instance NFData t => NFData (IPBoundary' t)
 instance NFData IPClause
 instance NFData DisplayForm
 instance NFData DisplayTerm
-instance NFData RewriteRule
+instance NFData GlobalRewriteRule
 instance NFData InstanceInfo
 instance NFData Definition
 instance NFData Polarity

--- a/src/full/Agda/TypeChecking/Monad/Constraints.hs
+++ b/src/full/Agda/TypeChecking/Monad/Constraints.hs
@@ -222,6 +222,7 @@ isBlockingConstraint = \case
   CheckType{}           -> True
   CheckLockedVars{}     -> True
   UsableAtModality{}    -> True
+  RewConstraint{}       -> True
 
 -- | Start solving constraints
 nowSolvingConstraints :: MonadTCEnv m => m a -> m a

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -14,6 +14,8 @@ import Control.Monad.Trans.Maybe
 import Control.Monad.Writer         ( WriterT )
 
 import Data.Foldable
+import qualified Data.HashMap.Strict as HMap
+import qualified Data.IntMap as IntMap
 import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -33,9 +35,11 @@ import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Substitute
 import Agda.TypeChecking.Monad.Open
 import Agda.TypeChecking.Monad.State
+import Agda.TypeChecking.Warnings (warning, MonadWarning)
 
 import Agda.Utils.Function
 import Agda.Utils.Functor
+import Agda.Utils.Impossible
 import Agda.Utils.Lens
 import Agda.Utils.List ((!!!), downFrom)
 import Agda.Utils.ListT
@@ -43,11 +47,11 @@ import Agda.Utils.List1 (List1, pattern (:|))
 import qualified Agda.Utils.List1 as List1
 import qualified Agda.Utils.Set1 as Set1
 import Agda.Utils.Maybe
+import Agda.Utils.Monad (mzero, void)
+import Agda.Utils.Null (empty)
 import Agda.Utils.Size
 import Agda.Utils.Tuple
 import Agda.Utils.Update
-
-import Agda.Utils.Impossible
 
 -- * Modifying the context
 
@@ -72,6 +76,7 @@ inTopContext cont =
         $ locallyTC eCheckpoints (const $ Map.singleton 0 IdS)
         $ locallyScope scopeLocals (const [])
         $ locallyTC eLetBindings (const Map.empty)
+        $ locallyTC eLocalRewriteRules (const empty)
         $ withoutModuleCheckpoints
         $ cont
 
@@ -101,6 +106,7 @@ escapeContext err n = updateContext (strengthenS err n) $ cxDrop n
 
 {-# SPECIALIZE checkpoint :: Substitution -> TCM a -> TCM a #-}
 -- | Add a new checkpoint. Do not use directly!
+--   Also updates head symbols of local rewrite rules with variable heads
 checkpoint
   :: (MonadDebug tcm, MonadTCM tcm, MonadFresh CheckpointId tcm, ReadTCState tcm)
   => Substitution -> tcm a -> tcm a
@@ -127,6 +133,8 @@ checkpoint sub k = do
     { envCurrentCheckpoint = chkpt
     , envCheckpoints       = Map.insert chkpt IdS $
                               fmap (applySubst sub) (envCheckpoints env)
+    , envLocalRewriteRules = updateLocalRewriteHeads sub $
+                              envLocalRewriteRules env
     }
   unlessDebugPrinting $ verboseS "tc.cxt.checkpoint" 105 $ do
     newChkpts <- useTC stModuleCheckpoints
@@ -157,6 +165,13 @@ checkpoint sub k = do
 
   unlessDebugPrinting $ reportSLn "tc.cxt.checkpoint" 105 "}"
   return x
+
+-- | Update heads of local rewrite rules for the new context
+updateLocalRewriteHeads ::
+  Substitution -> LocalRewriteRuleMap -> LocalRewriteRuleMap
+updateLocalRewriteHeads sub = over lrewsVarHeaded (IntMap.mapKeys subHead)
+  where
+    subHead x = fromMaybe __IMPOSSIBLE__ $ lookupSVar sub x
 
 -- | Add a module checkpoint for the provided @ModuleName@.
 {-# SPECIALIZE setModuleCheckpoint :: ModuleName -> CheckpointId -> TCM () #-}
@@ -250,6 +265,9 @@ class MonadTCEnv m => MonadAddContext m where
        IsAxiom   -- ^ Does this let binding come from a 'LetAxiom'?
     -> Origin -> Name -> Term -> Dom Type -> m a -> m a
 
+  -- | Adds a local rewrite rule to the context
+  addLocalRewrite :: RewriteRule -> m a -> m a
+
   -- | Update the context.
   --   Requires a substitution that transports things living in the old context
   --   to the new.
@@ -267,6 +285,11 @@ class MonadTCEnv m => MonadAddContext m where
     => IsAxiom -> Origin -> Name -> Term -> Dom Type -> m a -> m a
   addLetBinding' isAxiom o x u a = liftThrough $ addLetBinding' isAxiom o x u a
 
+  default addLocalRewrite
+    :: (MonadAddContext n, MonadTransControl t, t n ~ m)
+    => RewriteRule -> m a -> m a
+  addLocalRewrite r = liftThrough $ addLocalRewrite r
+
   default updateContext
     :: (MonadAddContext n, MonadTransControl t, t n ~ m)
     => Substitution -> (Context -> Context) -> m a -> m a
@@ -283,8 +306,13 @@ class MonadTCEnv m => MonadAddContext m where
 {-# INLINE defaultAddCtx #-}
 -- | Default implementation of addCtx in terms of updateContext
 defaultAddCtx :: MonadAddContext m => Name -> Dom Type -> m a -> m a
-defaultAddCtx x a ret =
+defaultAddCtx x a ret = applyWhenJust (rewDom a) addRewDom $
   updateContext (raiseS 1) (CxExtendVar x a) ret
+
+addRewDom :: MonadAddContext m => RewDom -> m a -> m a
+addRewDom rew = case rewDomRew rew of
+  Just r  -> addLocalRewrite r
+  Nothing -> __IMPOSSIBLE__
 
 withFreshName_ :: (MonadAddContext m) => ArgName -> (Name -> m a) -> m a
 withFreshName_ = withFreshName noRange
@@ -301,6 +329,7 @@ deriving instance MonadAddContext m => MonadAddContext (BlockT m)
 instance MonadAddContext m => MonadAddContext (ListT m) where
   addCtx x a             = liftListT $ addCtx x a
   addLetBinding' isAxiom o x u a = liftListT $ addLetBinding' isAxiom o x u a
+  addLocalRewrite r      = liftListT $ addLocalRewrite r
   updateContext sub f    = liftListT $ updateContext sub f
   withFreshName r x cont = ListT $ withFreshName r x $ runListT . cont
 
@@ -347,9 +376,22 @@ instance MonadAddContext TCM where
   addLetBinding' isAxiom o x u a ret = applyUnless (isNoName x) (withShadowingNameTCM x) $
     defaultAddLetBinding' isAxiom o x u a ret
 
+  addLocalRewrite = defaultAddLocalRewrite
+
   updateContext sub f = unsafeModifyContext f . checkpoint sub
 
   withFreshName r x m = freshName r x >>= m
+
+-- | Adds a rewrite rule to the local typechecking environment
+defaultAddLocalRewrite :: (MonadTCEnv m, ReadTCState m)
+  => RewriteRule -> m a -> m a
+defaultAddLocalRewrite rew ret = do
+  rew' <- makeOpen rew
+  case rewHead rew of
+    RewVarHead x -> locallyTC (eLocalRewriteRules . lrewsVarHeaded)
+      (IntMap.insertWith mappend x [rew']) ret
+    RewDefHead f -> locallyTC (eLocalRewriteRules . lrewsDefHeaded)
+      (HMap.insertWith mappend f [rew']) ret
 
 addRecordNameContext
   :: (MonadAddContext m, MonadFresh NameId m)
@@ -411,14 +453,6 @@ instance AddContext (List1 (WithHiding Name), Dom Type) where
   addContext (WithHiding h x :| xs, dom) =
     addContext (x , mapHiding (mappend h) dom) .
     addContext (xs, raise 1 dom)
-  contextSize (xs, _) = length xs
-
-instance AddContext ([Arg Name], Type) where
-  addContext (xs, t) = addContext ((map . fmap) unnamed xs :: [NamedArg Name], t)
-  contextSize (xs, _) = length xs
-
-instance AddContext (List1 (Arg Name), Type) where
-  addContext (xs, t) = addContext ((fmap . fmap) unnamed xs :: List1 (NamedArg Name), t)
   contextSize (xs, _) = length xs
 
 instance AddContext ([NamedArg Name], Type) where
@@ -566,15 +600,25 @@ defaultAddLetBinding' isAxiom o x v t ret = do
     vt <- makeOpen $ LetBinding isAxiom o v t
     flip localTC ret $ \e -> e { envLetBindings = Map.insert x vt $ envLetBindings e }
 
+unsafeRule :: (MonadWarning m) => RewriteSource -> IllegalRewriteRuleReason -> MaybeT m ()
+unsafeRule s reason = lift $ warning $ IllegalRewriteRule s reason
+
+illegalRule :: (MonadWarning m) => RewriteSource -> IllegalRewriteRuleReason -> MaybeT m a
+illegalRule s reason = do
+  unsafeRule s reason
+  mzero
+
 -- | Add a let bound variable.
 {-# SPECIALIZE addLetBinding :: ArgInfo -> Origin -> Name -> Term -> Type -> TCM a -> TCM a #-}
-addLetBinding :: MonadAddContext m => ArgInfo -> Origin -> Name -> Term -> Type -> m a -> m a
-addLetBinding info o x v t0 ret = addLetBinding' NoAxiom o x v (defaultArgDom info t0) ret
+addLetBinding :: (MonadWarning m) => ArgInfo -> Origin -> Name -> Term -> Type -> m a -> m a
+addLetBinding info o x v t0 =
+  addLetBinding' NoAxiom o x v (defaultArgDom info t0)
 
 -- | Add a let bound variable without a definition.
 {-# SPECIALIZE addLetAxiom :: ArgInfo -> Origin -> Name -> Term -> Type -> TCM a -> TCM a #-}
-addLetAxiom :: MonadAddContext m => ArgInfo -> Origin -> Name -> Term -> Type -> m a -> m a
-addLetAxiom info o x v t0 ret = addLetBinding' YesAxiom o x v (defaultArgDom info t0) ret
+addLetAxiom :: (MonadWarning m) => ArgInfo -> Origin -> Name -> Term -> Type -> m a -> m a
+addLetAxiom info o x v t0 ret =
+  addLetBinding' YesAxiom o x v (defaultArgDom info t0) ret
 
 {-# SPECIALIZE removeLetBinding :: Name -> TCM a -> TCM a #-}
 -- | Remove a let bound variable.

--- a/src/full/Agda/TypeChecking/Monad/Context.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs-boot
@@ -17,6 +17,7 @@ checkpointSubstitution :: MonadTCEnv tcm => CheckpointId -> tcm Substitution
 class MonadTCEnv m => MonadAddContext m where
   addCtx :: Name -> Dom Type -> m a -> m a
   addLetBinding' :: IsAxiom -> Origin -> Name -> Term -> Dom Type -> m a -> m a
+  addLocalRewrite :: RewriteRule -> m a -> m a
   updateContext :: Substitution -> (Context -> Context) -> m a -> m a
   withFreshName :: Range -> ArgName -> (Name -> m a) -> m a
 
@@ -29,6 +30,11 @@ class MonadTCEnv m => MonadAddContext m where
     :: (MonadAddContext n, MonadTransControl t, t n ~ m)
     => IsAxiom -> Origin -> Name -> Term -> Dom Type -> m a -> m a
   addLetBinding' o x u a = liftThrough $ addLetBinding' o x u a
+
+  default addLocalRewrite
+    :: (MonadAddContext n, MonadTransControl t, t n ~ m)
+    => RewriteRule -> m a -> m a
+  addLocalRewrite r = liftThrough $ addLocalRewrite r
 
   default updateContext
     :: (MonadAddContext n, MonadTransControl t, t n ~ m)

--- a/src/full/Agda/TypeChecking/Monad/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/Monad/MetaVars.hs
@@ -436,6 +436,7 @@ constraintMetas = \case
       CheckType t              -> gatherMetas t
       CheckLockedVars a b c d  -> gatherMetas (a, b, c, d)
       UsableAtModality{}       -> return mempty
+      RewConstraint e          -> gatherMetas e
   where
     -- For blocked constant twin variables
     listenerMetas EtaExpand{}           = return Set.empty

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -974,7 +974,7 @@ class ( Functor m
   --   reduction of the head symbol is disabled.
   --   Rewrite rules that only happen to be in the signature but are not in scope
   --   are also not returned.
-  getRewriteRulesFor :: QName -> m RewriteRules
+  getGlobalRewriteRulesFor :: QName -> m GlobalRewriteRules
 
   -- Lifting HasConstInfo through monad transformers:
 
@@ -983,10 +983,10 @@ class ( Functor m
     => QName -> m (Either SigError Definition)
   getConstInfo' = lift . getConstInfo'
 
-  default getRewriteRulesFor
+  default getGlobalRewriteRulesFor
     :: (HasConstInfo n, MonadTrans t, m ~ t n)
-    => QName -> m RewriteRules
-  getRewriteRulesFor = lift . getRewriteRulesFor
+    => QName -> m GlobalRewriteRules
+  getGlobalRewriteRulesFor = lift . getGlobalRewriteRulesFor
 
 {-# SPECIALIZE getConstInfo :: HasCallStack => QName -> TCM Definition #-}
 
@@ -1013,25 +1013,26 @@ getOriginalConstInfo q = do
 --   reduction of the head symbol is disabled.
 --   Rewrite rules that only happen to be in the signature but are not in scope
 --   are also not returned.
-defaultGetRewriteRulesFor :: (ReadTCState m, MonadTCEnv m) => QName -> m RewriteRules
-defaultGetRewriteRulesFor q = ifNotM (shouldReduceDef q) (return []) $ do
-  getFilteredRewriteRulesFor True q
+defaultGetGlobalRewriteRulesFor :: (ReadTCState m, MonadTCEnv m)
+  => QName -> m GlobalRewriteRules
+defaultGetGlobalRewriteRulesFor q = ifNotM (shouldReduceDef q) (return []) $ do
+  getFilteredGlobalRewriteRulesFor True q
 
 -- | If the 'Bool' parameter is 'True', get the rules in scope,
 --   otherwise, get *all* rules unfiltered.
-getFilteredRewriteRulesFor :: (ReadTCState m)
+getFilteredGlobalRewriteRulesFor :: (ReadTCState m)
   => Bool            -- ^ Only return rewrite rules that are in scope?
   -> QName           -- ^ Head symbol.
-  -> m RewriteRules  -- ^ Rules for the head symbol.
-getFilteredRewriteRulesFor filt q = do
+  -> m GlobalRewriteRules  -- ^ Rules for the head symbol.
+getFilteredGlobalRewriteRulesFor filt q = do
   st <- getTCState
   let
-    look :: Lens' TCState Signature -> Maybe RewriteRules
+    look :: Lens' TCState Signature -> Maybe GlobalRewriteRules
     look l = HMap.lookup q $ st ^. (l . sigRewriteRules)
 
   -- Restrict "imported" rewrite rules to those defined in modules we currently (transitively) import.
   let imps = st ^. stImportedModulesTransitive
-  let inScope rew = rewTopModule rew `Set.member` imps
+  let inScope rew = grTopModule rew `Set.member` imps
   let rewImported = applyWhen filt (filter inScope) <$> look stImports  -- stImports is actually a superset of imported symbols.
 
   return $ mconcat $ catMaybes [look stSignature, rewImported]
@@ -1042,7 +1043,7 @@ getOriginalProjection :: (HasCallStack, HasConstInfo m) => QName -> m QName
 getOriginalProjection q = projOrig . fromMaybe __IMPOSSIBLE__ <$> isProjection q
 
 instance HasConstInfo TCM where
-  getRewriteRulesFor = defaultGetRewriteRulesFor
+  getGlobalRewriteRulesFor = defaultGetGlobalRewriteRulesFor
   getConstInfo' q = do
     st  <- getTC
     env <- askTC
@@ -1409,17 +1410,20 @@ instantiateDef d = do
   return $ d `apply` vs
 
 instantiateRewriteRule :: (HasConstInfo m, ReadTCState m)
-  => RewriteRule -> m RewriteRule
+  => GlobalRewriteRule -> m GlobalRewriteRule
 instantiateRewriteRule rew = do
-  traceSDoc "rewriting" 95 ("instantiating rewrite rule" <+> pretty (rewName rew) <+> "to the local context.") $ do
-  vs  <- freeVarsToApply $ rewName rew
+  traceSDoc "rewriting" 95
+    ("instantiating rewrite rule" <+>
+    pretty (grName rew) <+>
+    "to the local context.") $ do
+  vs  <- freeVarsToApply $ grName rew
   let rew' = rew `apply` vs
   traceSLn "rewriting" 95 ("instantiated rewrite rule: ") $ do
   traceSLn "rewriting" 95 (show rew') $ do
   return rew'
 
 instantiateRewriteRules :: (HasConstInfo m, ReadTCState m)
-  => RewriteRules -> m RewriteRules
+  => GlobalRewriteRules -> m GlobalRewriteRules
 instantiateRewriteRules = mapM instantiateRewriteRule
 
 -- | Return the abstract view of a definition, /regardless/ of whether

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -8,12 +8,13 @@ import Control.Monad.Except          ( ExceptT )
 import Control.Monad.State           ( StateT  )
 import Control.Monad.Reader          ( ReaderT )
 import Control.Monad.Writer          ( WriterT )
-import Control.Monad.Trans.Maybe     ( MaybeT  )
+import Control.Monad.Trans.Maybe     ( MaybeT (MaybeT), runMaybeT  )
 import Control.Monad.Trans.Identity  ( IdentityT )
 import Control.Monad.Trans           ( MonadTrans, lift )
 
 import Data.Either
 import Data.Foldable                 ( for_ )
+import Data.IntMap                   qualified as IntMap
 import Data.List                     qualified as List
 import Data.Set                      ( Set )
 import Data.Set                      qualified as Set
@@ -670,7 +671,7 @@ applySection' new ptel old ts ren@ScopeCopyInfo{ renNames = rd, renModules = rm 
                     , defMatchable      = Set.empty
                     , defNoCompilation  = defNoCompilation d
                     , defInjective      = False
-                    , defCopatternLHS   = isCopatternLHS [cl]
+                    , defCopatternLHS'  = isCopatternLHS [cl]
                     , defBlocked        = defBlocked d
                     , defLanguage       =
                       case defLanguage d of
@@ -806,7 +807,8 @@ applySection' new ptel old ts ren@ScopeCopyInfo{ renNames = rd, renModules = rm 
       reportSDoc "tc.mod.apply" 80 $ "  totalArgs    = " <+> text (show totalArgs)
       reportSDoc "tc.mod.apply" 80 $ "  tel          = " <+> text (unwords (map (fst . unDom) $ telToList tel))  -- only names
       reportSDoc "tc.mod.apply" 80 $ "  sectionTel   = " <+> text (unwords (map (fst . unDom) $ telToList ptel)) -- only names
-      addContext sectionTel $ addSection y
+      ctxTel <- getContextTelescope
+      addSection' y (ctxTel `abstract` sectionTel)
       reportSDoc "tc.mod.apply" 80 $
         "finished copySec" <+> pretty x <+> "->" <+> pretty y
 
@@ -969,12 +971,16 @@ class ( Functor m
   getConstInfo' :: HasCallStack => QName -> m (Either SigError Definition)
   -- getConstInfo' q = Right <$> getConstInfo q -- conflicts with default signature
 
-  -- | Return the rewrite rules for the given head symbol that could be tried.
-  --   Not categorically all rewrite rules are returned, in particular, none when
-  --   reduction of the head symbol is disabled.
-  --   Rewrite rules that only happen to be in the signature but are not in scope
-  --   are also not returned.
+  -- | Return the global rewrite rules for the given head symbol that could be
+  --   tried.
+  --   Not categorically all rewrite rules are returned, in particular, none
+  --   when reduction of the head symbol is disabled.
+  --   Rewrite rules that only happen to be in the signature but are not in
+  --   scope are also not returned.
   getGlobalRewriteRulesFor :: QName -> m GlobalRewriteRules
+
+  -- | Return the local rewrite rules for the given head symbol.
+  getLocalRewriteRulesFor :: RewriteHead -> m RewriteRules
 
   -- Lifting HasConstInfo through monad transformers:
 
@@ -988,7 +994,43 @@ class ( Functor m
     => QName -> m GlobalRewriteRules
   getGlobalRewriteRulesFor = lift . getGlobalRewriteRulesFor
 
+  default getLocalRewriteRulesFor
+    :: (HasConstInfo n, MonadTrans t, m ~ t n)
+    => RewriteHead -> m RewriteRules
+  getLocalRewriteRulesFor = lift . getLocalRewriteRulesFor
+
 {-# SPECIALIZE getConstInfo :: HasCallStack => QName -> TCM Definition #-}
+
+getAllRewriteRulesForDefHead :: (HasConstInfo m, ReadTCState m)
+  => QName -> m RewriteRules
+getAllRewriteRulesForDefHead f =
+  mappend <$> (catMaybes . fmap justTheRule <$>
+                (instantiateRewriteRules =<< getGlobalRewriteRulesFor f)) <*>
+              getLocalRewriteRulesFor (RewDefHead f)
+  where
+    justTheRule :: GlobalRewriteRule -> Maybe RewriteRule
+    justTheRule (GlobalRewriteRule _ g q ps rhs t isClause _)
+      | isClause  = Nothing
+      | otherwise = pure $ RewriteRule g (RewDefHead q)  ps rhs t
+
+-- | A local rewrite rule forces us to consider the definition as defined
+--   by copatterns (see #3812 for an example case with global rewrite rules)
+--   This is necessary because binding local rewrite rules does not update
+--   defCopatternLHS'
+rewUsesCopatterns :: HasConstInfo m => RewriteHead -> m Bool
+rewUsesCopatterns h =
+  any lrewHasProjectionPattern <$> getLocalRewriteRulesFor h
+
+-- | Is this a function defined by copatterns?
+--   Accounts for local rewrite rules
+defCopatternLHS :: HasConstInfo m => QName -> Definition -> m Bool
+defCopatternLHS f d = do
+  rewForces <- rewUsesCopatterns $ RewDefHead f
+  pure $ defCopatternLHS' d || rewForces
+
+getAllRewriteRulesForVarHead :: HasConstInfo m
+  => Nat -> m RewriteRules
+getAllRewriteRulesForVarHead x = getLocalRewriteRulesFor $ RewVarHead x
 
 {-# SPECIALIZE getOriginalConstInfo :: HasCallStack => QName -> TCM Definition #-}
 -- | The computation 'getConstInfo' sometimes tweaks the returned
@@ -1018,6 +1060,26 @@ defaultGetGlobalRewriteRulesFor :: (ReadTCState m, MonadTCEnv m)
 defaultGetGlobalRewriteRulesFor q = ifNotM (shouldReduceDef q) (return []) $ do
   getFilteredGlobalRewriteRulesFor True q
 
+defaultGetLocalRewriteRulesFor ::
+  (ReadTCState m, MonadTCEnv m, MonadDebug m)
+  => RewriteHead -> m RewriteRules
+defaultGetLocalRewriteRulesFor h =
+  ifNotM (shouldReduceDef' h) (return []) $ do
+    m <- runMaybeT . lookup h =<< asksTC envLocalRewriteRules
+    pure $ fromMaybe [] m
+  where
+    shouldReduceDef' (RewDefHead f) = shouldReduceDef f
+    shouldReduceDef' (RewVarHead _) = pure True
+
+    lookup h m = do
+      rews  <- MaybeT $ pure $ lookup' h m
+      lift $ traverse (tryGetOpenRew fallback) rews
+
+    fallback = __IMPOSSIBLE_VERBOSE__ . show
+
+    lookup' (RewDefHead f) = HMap.lookup   f . defHeadedRews
+    lookup' (RewVarHead x) = IntMap.lookup x . varHeadedRews
+
 -- | If the 'Bool' parameter is 'True', get the rules in scope,
 --   otherwise, get *all* rules unfiltered.
 getFilteredGlobalRewriteRulesFor :: (ReadTCState m)
@@ -1044,6 +1106,7 @@ getOriginalProjection q = projOrig . fromMaybe __IMPOSSIBLE__ <$> isProjection q
 
 instance HasConstInfo TCM where
   getGlobalRewriteRulesFor = defaultGetGlobalRewriteRulesFor
+  getLocalRewriteRulesFor  = defaultGetLocalRewriteRulesFor
   getConstInfo' q = do
     st  <- getTC
     env <- askTC
@@ -1409,6 +1472,7 @@ instantiateDef d = do
       fsep (map pretty $ zipWith (<$) ctx vs)
   return $ d `apply` vs
 
+-- | Instantiate a global rewrite rule
 instantiateRewriteRule :: (HasConstInfo m, ReadTCState m)
   => GlobalRewriteRule -> m GlobalRewriteRule
 instantiateRewriteRule rew = do
@@ -1422,6 +1486,7 @@ instantiateRewriteRule rew = do
   traceSLn "rewriting" 95 (show rew') $ do
   return rew'
 
+-- | Instantiate global rewrite rules
 instantiateRewriteRules :: (HasConstInfo m, ReadTCState m)
   => GlobalRewriteRules -> m GlobalRewriteRules
 instantiateRewriteRules = mapM instantiateRewriteRule
@@ -1573,7 +1638,7 @@ projectionArgs = maybe 0 (max 0 . pred . projIndex) . isRelevantProjection_
 
 -- | Check whether a definition uses copatterns.
 usesCopatterns :: (HasConstInfo m) => QName -> m Bool
-usesCopatterns q = defCopatternLHS <$> getConstInfo q
+usesCopatterns q = defCopatternLHS q =<< getConstInfo q
 
 -- | Apply a function @f@ to its first argument, producing the proper
 --   postfix projection if @f@ is a projection which is not irrelevant.

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
@@ -11,7 +11,7 @@ import Agda.Syntax.Internal (ModuleName, Telescope)
 
 import Agda.TypeChecking.Monad.Base
   ( TCM, ReadTCState, HasOptions, MonadTCEnv
-  , Definition, RewriteRules
+  , Definition, GlobalRewriteRules
   )
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug (MonadDebug)
 
@@ -38,13 +38,13 @@ class ( Functor m
 
   getConstInfo' :: HasCallStack => QName -> m (Either SigError Definition)
   -- getConstInfo' q = Right <$> getConstInfo q
-  getRewriteRulesFor :: QName -> m RewriteRules
+  getGlobalRewriteRulesFor :: QName -> m GlobalRewriteRules
 
   default getConstInfo' :: (HasCallStack, HasConstInfo n, MonadTrans t, m ~ t n) => QName -> m (Either SigError Definition)
   getConstInfo' = lift . getConstInfo'
 
-  default getRewriteRulesFor :: (HasConstInfo n, MonadTrans t, m ~ t n) => QName -> m RewriteRules
-  getRewriteRulesFor = lift . getRewriteRulesFor
+  default getGlobalRewriteRulesFor :: (HasConstInfo n, MonadTrans t, m ~ t n) => QName -> m GlobalRewriteRules
+  getGlobalRewriteRulesFor = lift . getGlobalRewriteRulesFor
 
 instance HasConstInfo m => HasConstInfo (ReaderT r m)
 instance HasConstInfo m => HasConstInfo (StateT s m)

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs-boot
@@ -7,11 +7,11 @@ import Control.Monad.State
 
 import Agda.Syntax.Abstract.Name (QName)
 import Agda.Syntax.Common.Pretty (prettyShow)
-import Agda.Syntax.Internal (ModuleName, Telescope)
+import Agda.Syntax.Internal (ModuleName, Telescope, RewriteHead)
 
 import Agda.TypeChecking.Monad.Base
   ( TCM, ReadTCState, HasOptions, MonadTCEnv
-  , Definition, GlobalRewriteRules
+  , Definition, GlobalRewriteRules, RewriteRules
   )
 import {-# SOURCE #-} Agda.TypeChecking.Monad.Debug (MonadDebug)
 
@@ -39,12 +39,16 @@ class ( Functor m
   getConstInfo' :: HasCallStack => QName -> m (Either SigError Definition)
   -- getConstInfo' q = Right <$> getConstInfo q
   getGlobalRewriteRulesFor :: QName -> m GlobalRewriteRules
+  getLocalRewriteRulesFor :: RewriteHead -> m RewriteRules
 
   default getConstInfo' :: (HasCallStack, HasConstInfo n, MonadTrans t, m ~ t n) => QName -> m (Either SigError Definition)
   getConstInfo' = lift . getConstInfo'
 
   default getGlobalRewriteRulesFor :: (HasConstInfo n, MonadTrans t, m ~ t n) => QName -> m GlobalRewriteRules
   getGlobalRewriteRulesFor = lift . getGlobalRewriteRulesFor
+
+  default getLocalRewriteRulesFor :: (HasConstInfo n, MonadTrans t, m ~ t n) => RewriteHead -> m RewriteRules
+  getLocalRewriteRulesFor = lift . getLocalRewriteRulesFor
 
 instance HasConstInfo m => HasConstInfo (ReaderT r m)
 instance HasConstInfo m => HasConstInfo (StateT s m)

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -296,9 +296,7 @@ updateDefsForRewrites f rews matchables
       setNotInjective def            = def
 
       setCopatternLHS =
-        updateDefCopatternLHS (|| any hasProjectionPattern rews)
-
-      hasProjectionPattern rew = any (isJust . isProjElim) $ grPats rew
+        updateDefCopatternLHS (|| any grHasProjectionPattern rews)
 
 setMatchableSymbols ::
      QName
@@ -374,7 +372,7 @@ updateCompiledClauses f def@Function{ funCompiled = cc} = def { funCompiled = f 
 updateCompiledClauses f _                              = __IMPOSSIBLE__
 
 updateDefCopatternLHS :: (Bool -> Bool) -> Definition -> Definition
-updateDefCopatternLHS f def@Defn{ defCopatternLHS = b } = def { defCopatternLHS = f b }
+updateDefCopatternLHS f def@Defn{ defCopatternLHS' = b } = def { defCopatternLHS' = f b }
 
 updateDefBlocked :: (Blocked_ -> Blocked_) -> Definition -> Definition
 updateDefBlocked f def@Defn{ defBlocked = b } = def { defBlocked = f b }

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -268,7 +268,7 @@ withSignature sig m = do
 addRewriteRulesFor ::
      QName
        -- ^ Head symbol of rewrite rules
-  -> RewriteRules
+  -> GlobalRewriteRules
        -- ^ Rewrite rules
   -> [QName]
        -- ^ Matchable symbols
@@ -280,7 +280,7 @@ addRewriteRulesFor f rews matchables = do
 updateDefsForRewrites ::
      QName
         -- ^ Head symbol of rewrite rules
-  -> RewriteRules
+  -> GlobalRewriteRules
         -- ^ Rewrites
   -> [QName]
         -- ^ Matchable symbols
@@ -298,7 +298,7 @@ updateDefsForRewrites f rews matchables
       setCopatternLHS =
         updateDefCopatternLHS (|| any hasProjectionPattern rews)
 
-      hasProjectionPattern rew = any (isJust . isProjElim) $ rewPats rew
+      hasProjectionPattern rew = any (isJust . isProjElim) $ grPats rew
 
 setMatchableSymbols ::
      QName

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -64,6 +64,7 @@ interestingCall = \case
     CheckRecDef{}             -> True
     CheckConstructor{}        -> True
     CheckIApplyConfluence{}   -> True
+    CheckLocalRewriteConstraint{} -> True
     CheckConArgFitsIn{}       -> True
     CheckFunDefCall{}         -> True
     CheckPragma{}             -> True
@@ -195,6 +196,7 @@ instance MonadTrace TCM where
       CheckIsEmpty{}            -> True
       CheckConfluence{}         -> False
       CheckIApplyConfluence{}   -> False
+      CheckLocalRewriteConstraint{} -> False
       CheckModuleParameters{}   -> False
       CheckWithFunctionType{}   -> True
       CheckSectionApplication{} -> True

--- a/src/full/Agda/TypeChecking/Polarity.hs
+++ b/src/full/Agda/TypeChecking/Polarity.hs
@@ -37,7 +37,7 @@ import Agda.TypeChecking.Positivity.Occurrence
 
 import Agda.Utils.List
 import Agda.Utils.ListInf qualified as ListInf
-import Agda.Utils.Maybe ( whenNothingM )
+import Agda.Utils.Maybe ( whenNothingM, whenJust )
 import Agda.Utils.Monad
 import Agda.Syntax.Common.Pretty ( prettyShow )
 import Agda.Utils.Singleton

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -625,8 +625,8 @@ instance PrettyTCM (Type' NLPat) where
   prettyTCM = prettyTCM . unEl
 {-# SPECIALIZE prettyTCM :: Type' NLPat -> TCM Doc #-}
 
-instance PrettyTCM RewriteRule where
-  prettyTCM (RewriteRule q gamma f ps rhs b _c _top) = fsep
+instance PrettyTCM GlobalRewriteRule where
+  prettyTCM (GlobalRewriteRule q gamma f ps rhs b _c _top) = fsep
     [ prettyTCM q
     , prettyTCM gamma <+> " |- "
     , addContext gamma $ sep
@@ -637,7 +637,7 @@ instance PrettyTCM RewriteRule where
       , prettyTCM b
       ]
     ]
-{-# SPECIALIZE prettyTCM :: RewriteRule -> TCM Doc #-}
+{-# SPECIALIZE prettyTCM :: GlobalRewriteRule -> TCM Doc #-}
 
 instance PrettyTCM Occurrence where
   prettyTCM occ  = text $ "-[" ++ prettyShow occ ++ "]->"

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -64,7 +64,7 @@ import Agda.Utils.Null
 import Agda.Utils.Trie
 import Agda.Utils.Permutation ( Permutation )
 import qualified Agda.Utils.Maybe.Strict as S
-import Agda.Utils.Size ( Sized, natSize )
+import Agda.Utils.Size ( Sized, natSize, size )
 
 import Agda.Utils.Impossible
 
@@ -565,7 +565,7 @@ prettyTCMPatterns :: MonadPretty m => [NamedArg DeBruijnPattern] -> m [Doc]
 prettyTCMPatterns = mapM prettyA <=< reifyPatterns
 
 {-# SPECIALIZE prettyTCMPatternList :: [NamedArg DeBruijnPattern] -> TCM Doc #-}
-prettyTCMPatternList :: MonadPretty m => [NamedArg DeBruijnPattern] -> m Doc
+prettyTCMPatternList :: (MonadPretty m) => [NamedArg DeBruijnPattern] -> m Doc
 prettyTCMPatternList = prettyList . map prettyA <=< reifyPatterns
 
 -- | For unquote.
@@ -580,7 +580,10 @@ instance PrettyTCM (Elim' DisplayTerm) where
 {-# SPECIALIZE prettyTCM :: Elim' DisplayTerm -> TCM Doc #-}
 
 instance PrettyTCM NLPat where
-  prettyTCM (PVar s x bvs) = prettyTCM (Var x (map (Apply . fmap var) bvs))
+  -- We print variables in NLPats with "?" prefixes to indicate that they are
+  -- not bound vars
+  prettyTCM (PVar s x bvs) =
+    ("?" <> prettyTCM (var x)) <+> fsep (map (prettyTCM . fmap var) bvs)
   prettyTCM (PDef f es) = parens $
     prettyTCM f <+> fsep (map prettyTCM es)
   prettyTCM (PLam i u)  = parens $ fsep
@@ -638,6 +641,40 @@ instance PrettyTCM GlobalRewriteRule where
       ]
     ]
 {-# SPECIALIZE prettyTCM :: GlobalRewriteRule -> TCM Doc #-}
+
+instance PrettyTCM LocalEquation where
+  prettyTCM (LocalEquation gamma lhs rhs b) = fsep
+    [ prettyTCM gamma <+> " |- "
+    , addContext gamma $ sep
+      [ prettyTCM lhs
+      , " = "
+      , prettyTCM rhs
+      , " : "
+      , prettyTCM b
+      ]
+    ]
+
+instance PrettyTCM RewriteHead where
+  prettyTCM (RewDefHead f) = prettyTCM f
+  prettyTCM (RewVarHead x) = prettyTCM (var x)
+
+instance PrettyTCM RewriteRule where
+  prettyTCM (RewriteRule gamma f ps rhs b) = fsep
+    [ prettyTCM gamma <+> " |- "
+    , addContext gamma $ sep
+      [ prettyTCM (headToPat (size gamma) f ps)
+      , " --> "
+      , prettyTCM rhs
+      , " : "
+      , prettyTCM b
+      ]
+    ]
+
+instance PrettyTCM RewDom where
+  prettyTCM (RewDom e r) = fsep
+    [ prettyTCM e
+    , if isJust r then "(rewrite present)" else "(rewrite invalidated)"
+    ]
 
 instance PrettyTCM Occurrence where
   prettyTCM occ  = text $ "-[" ++ prettyShow occ ++ "]->"

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -227,6 +227,12 @@ instance PrettyTCM Call where
         , fsep (pwords "must be equal, since" ++ [prettyTCM fn] ++ pwords "could reduce to either.")
         ]
 
+    CheckLocalRewriteConstraint e c -> vcat
+      [ fsep $ pwords "when checking the following local rewrite rule constraint:"
+      , nest 2 $ prettyTCM e
+      , prettyTCM c
+      ]
+
     where
     hPretty :: MonadPretty m => Arg (Named_ Expr) -> m Doc
     hPretty a = do

--- a/src/full/Agda/TypeChecking/Pretty/Constraint.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Constraint.hs
@@ -175,7 +175,9 @@ instance PrettyTCM Constraint where
         CheckLockedVars t ty lk lk_ty -> do
           "Lock" <+> prettyTCM lk <+> "|-" <+> prettyTCMCtx TopCtx t <+> ":" <+> prettyTCM ty
         UsableAtModality _ ms mod t -> "Is usable at" <+> text (verbalize mod) <+> "modality:" <+> prettyTCM t
-          -- TODO: print @ms : Maybe Sort@ as well?
+                  -- TODO: print @ms : Maybe Sort@ as well?
+        RewConstraint (LocalEquation g t u a) ->
+          addContext g $ prettyCmp (prettyTCM CmpEq) t u <?> prettyTCM a
 
       where
         prettyCmp

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -37,6 +37,7 @@ import Agda.TypeChecking.Monad.MetaVars
 import Agda.TypeChecking.Monad.Options
 import Agda.TypeChecking.Monad.Debug
 import Agda.TypeChecking.Monad.Constraints
+import Agda.TypeChecking.Monad.Context ( addContext )
 import Agda.TypeChecking.Monad.State ( getScope )
 import Agda.TypeChecking.Monad ( localTCState, enterClosure )
 import Agda.TypeChecking.Positivity () --instance only
@@ -241,21 +242,24 @@ prettyWarning = \case
 
     FixingRelevance s r r' -> fsep $ concat
       [ pwords "Replacing illegal relevance", [ p r ]
-      , pwords s, [ "by", p r' ]
+      , ["of", text s], [ "by", p r' ]
       ]
       where p r = text $ "`" ++ verbalize r ++ "'"
 
     FixingCohesion s c c' -> fsep $ concat
       [ pwords "Replacing illegal cohesion", [ p c ]
-      , pwords s, [ "by", p c' ]
+      , ["of", text s], [ "by", p c' ]
       ]
       where p c = text $ "`" ++ verbalize c ++ "'"
 
     FixingPolarity s q q' ->  fsep $ concat
       [ pwords "Replacing illegal polarity", [ p q ]
-      , pwords s, [ "by", p q' ]
+      , ["of", text s], [ "by", p q' ]
       ]
       where p q = text $ "`" ++ verbalize q ++ "'"
+
+    IgnoringRew s r -> fsep $ concat
+      [pwords "Ignoring illegal local rewrite attribute on", pwords s]
 
     IllformedAsClause s -> fsep . pwords $
       "`as' must be followed by an identifier" ++ s
@@ -531,6 +535,11 @@ prettyWarning = \case
           , pwords "has already been added"
           ]
 
+        LocalRewriteOutsideTelescope -> (fsep . concat)
+          [ illegalSince q
+          , pwords "local rewrite rules are (currently) only allowed in module telescopes. Consider creating an anonymous module"
+          ]
+
     ConfluenceCheckingIncompleteBecauseOfMeta f -> (fsep . concat)
       [ pwords "Confluence checking incomplete because the definition of"
       , [ prettyTCM f ]
@@ -581,6 +590,14 @@ prettyWarning = \case
         , [ prettyTCM v , "to" , prettyTCM rhou ]
         ]
       ]
+
+    InferredLocalRewrite m v -> vcat
+      [ fsep $ pwords "Tried to solve"
+      , nest 2 $ prettyTCM m
+      , fsep $ pwords "with the following function (containing a local rewrite rule parameter):"
+      , nest 2 $ prettyTCM v
+      , fsep $ pwords "Local rewrite rules must be explicitly annotated (never inferred)."
+      , fsep $ pwords "Please annotate all local rewrite rules explicitly." ]
 
     DuplicateRecordDirective dir ->
       "Ignoring duplicate record directive: " <+> pretty dir
@@ -792,6 +809,12 @@ instance PrettyTCM DataOrRecord_ where
   prettyTCM = \case
     IsData{}   -> "data"
     IsRecord{} -> "record"
+
+instance PrettyTCM RewriteSource where
+  prettyTCM = \case
+    LocalRewrite g n t ->
+      maybe "_" prettyTCM n <+> ":" <+> addContext g (prettyTCM t)
+    GlobalRewrite q    -> prettyTCM (defName q)
 
 
 {-# SPECIALIZE prettyRecordFieldWarning :: RecordFieldWarning -> TCM Doc #-}

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -282,7 +282,7 @@ instance Instantiate Sort where
     s -> return s
 
 instance (Instantiate t, Instantiate e) => Instantiate (Dom' t e) where
-    instantiate' (Dom i n b tac x) = Dom i n b <$> instantiate' tac <*> instantiate' x
+    instantiate' (Dom i n b tac rew x) = Dom i n b <$> instantiate' tac <*> instantiate' rew <*> instantiate' x
 
 instance Instantiate a => Instantiate (Closure a) where
     instantiate' cl = do
@@ -339,6 +339,15 @@ instance Instantiate EqualityView where
     <*> instantiate' t
     <*> instantiate' a
     <*> instantiate' b
+
+instance Instantiate LocalRewriteRule where
+  instantiate' (LocalRewriteRule a b c d e) =
+    LocalRewriteRule
+      <$> instantiate' a
+      <*> pure b
+      <*> pure c
+      <*> instantiate' d
+      <*> instantiate' e
 
 ---------------------------------------------------------------------------
 -- * Reduction to weak head normal form.
@@ -1550,7 +1559,7 @@ instance (Subst a, InstantiateFull a) => InstantiateFull (Abs a) where
     instantiateFull' (NoAbs x a) = NoAbs x <$> instantiateFull' a
 
 instance (InstantiateFull t, InstantiateFull e) => InstantiateFull (Dom' t e) where
-    instantiateFull' (Dom i n b tac x) = Dom i n b <$> instantiateFull' tac <*> instantiateFull' x
+    instantiateFull' (Dom i n b tac rew x) = Dom i n b <$> instantiateFull' tac <*> instantiateFull' rew <*> instantiateFull' x
 
 instance InstantiateFull Context where
   instantiateFull' (Context es) = Context <$> instantiateFull' es
@@ -1668,6 +1677,15 @@ instance InstantiateFull RewriteRule where
       <*> instantiateFull' t
       <*> pure c
       <*> pure top
+
+instance InstantiateFull LocalRewriteRule where
+  instantiateFull' (LocalRewriteRule a b c d e) =
+    LocalRewriteRule
+      <$> instantiateFull' a
+      <*> instantiateFull' b
+      <*> instantiateFull' c
+      <*> instantiateFull' d
+      <*> instantiateFull' e
 
 instance InstantiateFull DisplayForm where
   instantiateFull' (Display n ps v) = uncurry (Display n) <$> instantiateFull' (ps, v)

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -281,7 +281,7 @@ instance Instantiate Sort where
       _            -> __IMPOSSIBLE__
     s -> return s
 
-instance (Instantiate t, Instantiate e) => Instantiate (Dom' t e) where
+instance Instantiate e => Instantiate (Dom e) where
     instantiate' (Dom i n b tac rew x) = Dom i n b <$> instantiate' tac <*> instantiate' rew <*> instantiate' x
 
 instance Instantiate a => Instantiate (Closure a) where
@@ -318,6 +318,7 @@ instance Instantiate Constraint where
   instantiate' c@CheckMetaInst{}    = return c
   instantiate' (CheckType t)        = CheckType <$> instantiate' t
   instantiate' (UsableAtModality cc ms mod t) = flip (UsableAtModality cc) mod <$> instantiate' ms <*> instantiate' t
+  instantiate' (RewConstraint e)    = RewConstraint <$> instantiate' e
 
 instance Instantiate CompareAs where
   instantiate' (AsTermsOf a) = AsTermsOf <$> instantiate' a
@@ -340,6 +341,14 @@ instance Instantiate EqualityView where
     <*> instantiate' a
     <*> instantiate' b
 
+instance Instantiate LocalEquation where
+  instantiate' (LocalEquation a b c d) =
+    LocalEquation
+      <$> instantiate' a
+      <*> instantiate' b
+      <*> instantiate' c
+      <*> instantiate' d
+
 instance Instantiate RewriteRule where
   instantiate' (RewriteRule a b c d e) =
     RewriteRule
@@ -348,6 +357,12 @@ instance Instantiate RewriteRule where
       <*> pure c
       <*> instantiate' d
       <*> instantiate' e
+
+instance Instantiate RewDom where
+  instantiate' (RewDom a b) =
+    RewDom
+      <$> instantiate' a
+      <*> instantiate' b
 
 ---------------------------------------------------------------------------
 -- * Reduction to weak head normal form.
@@ -605,10 +620,10 @@ slowReduceTerm v = do
       Level l  -> ifM (SmallSet.member LevelReductions <$> asksTC envAllowedReductions)
                     {- then -} (fmap levelTm <$> reduceB' l)
                     {- else -} done
-      Pi _ _   -> done
-      Lit _    -> done
-      Var _ es  -> iapp es
-      Lam _ _  -> done
+      Pi _ _     -> done
+      Lit _      -> done
+      Var x es   -> reduceIApply (rewriteVarApp x es) es
+      Lam _ _    -> done
       DontCare _ -> done
       Dummy{}    -> done
     where
@@ -629,7 +644,23 @@ slowReduceTerm v = do
               w              -> Con c ci [Apply $ defaultArg w]
       reduceNat v = return v
 
--- Andreas, 2013-03-20 recursive invokations of unfoldCorecursion
+rewriteVarApp :: Nat -> Elims -> ReduceM (Blocked Term)
+rewriteVarApp x es = do
+  r <- rewriteVarAppStep x es
+  case r of
+    NoReduction v    -> return v
+    YesReduction _ v -> reduceB' v
+
+rewriteVarAppStep :: Nat -> Elims -> ReduceM (Reduced (Blocked Term) Term)
+rewriteVarAppStep x es = do
+  rewr <- getAllRewriteRulesForVarHead x
+  when (not $ null rewr) $
+    reportSDoc "rewriting" 30 $
+      "Trying to rewrite variable application" <+> prettyTCM (Var x es)
+  rewrite (NotBlocked ReallyNotBlocked ())
+          (Var x) rewr es
+
+-- Andreas, 2013-03-20 recursive invocations of unfoldCorecursion
 -- need also to instantiate metas, see Issue 826.
 unfoldCorecursionE :: Elim -> ReduceM (Blocked Elim)
 unfoldCorecursionE (Proj o p)           = notBlocked . Proj o <$> getOriginalProjection p
@@ -677,7 +708,7 @@ unfoldDefinitionStep v0 f es =
   {-# SCC "reduceDef" #-} do
   traceSDoc "tc.reduce" 90 ("unfoldDefinitionStep v0" <+> pretty v0) $ do
   info <- getConstInfo f
-  rewr <- instantiateRewriteRules =<< getGlobalRewriteRulesFor f
+  rewr <- getAllRewriteRulesForDefHead f
   allowed <- asksTC envAllowedReductions
   prp <- runBlocked $ isPropM $ defType info
   defOk <- shouldReduceDef f
@@ -694,7 +725,7 @@ unfoldDefinitionStep v0 f es =
         , isIrrelevant info
         , not defOk
         ]
-      copatterns = defCopatternLHS info
+  copatterns <- defCopatternLHS f info
   case def of
     Constructor{conSrcCon = c} -> do
       let hd = Con (c `withRangeOf` f) ConOSystem
@@ -753,7 +784,7 @@ unfoldDefinitionStep v0 f es =
 
     reduceNormalE ::
          Term -> QName -> [MaybeReduced Elim] -> Bool -> [Clause]
-      -> Maybe CompiledClauses -> GlobalRewriteRules
+      -> Maybe CompiledClauses -> RewriteRules
       -> ReduceM (Reduced (Blocked Term) Term)
     reduceNormalE v0 f es dontUnfold def mcc rewr = {-# SCC "reduceNormal" #-} do
       traceSDoc "tc.reduce" 90 ("reduceNormalE v0 =" <+> pretty v0) $ do
@@ -902,12 +933,12 @@ unfoldInlined v = do
 -- | Apply a definition using the compiled clauses, or fall back to
 --   ordinary clauses if no compiled clauses exist.
 appDef_ ::
-     QName -> Term -> [Clause] -> Maybe CompiledClauses -> GlobalRewriteRules
+     QName -> Term -> [Clause] -> Maybe CompiledClauses -> RewriteRules
   -> MaybeReducedArgs -> ReduceM (Reduced (Blocked Term) Term)
 appDef_ f v0 cls mcc rewr args = appDefE_ f v0 cls mcc rewr $ map (fmap Apply) args
 
 appDefE_ ::
-     QName -> Term -> [Clause] -> Maybe CompiledClauses -> GlobalRewriteRules
+     QName -> Term -> [Clause] -> Maybe CompiledClauses -> RewriteRules
   -> MaybeReducedElims -> ReduceM (Reduced (Blocked Term) Term)
 appDefE_ f v0 cls mcc rewr args =
   localTC (\ e -> e { envAppDef = Just f }) $
@@ -918,12 +949,12 @@ appDefE_ f v0 cls mcc rewr args =
 -- | Apply a defined function to it's arguments, using the compiled clauses.
 --   The original term is the first argument applied to the third.
 appDef ::
-     Term -> CompiledClauses -> GlobalRewriteRules -> MaybeReducedArgs
+     Term -> CompiledClauses -> RewriteRules -> MaybeReducedArgs
   -> ReduceM (Reduced (Blocked Term) Term)
 appDef v cc rewr args = appDefE v cc rewr $ map (fmap Apply) args
 
 appDefE ::
-     Term -> CompiledClauses -> GlobalRewriteRules -> MaybeReducedElims
+     Term -> CompiledClauses -> RewriteRules -> MaybeReducedElims
   -> ReduceM (Reduced (Blocked Term) Term)
 appDefE v cc rewr es = do
   traceSDoc "tc.reduce" 90 ("appDefE v = " <+> pretty v) $ do
@@ -934,18 +965,20 @@ appDefE v cc rewr es = do
 
 -- | Apply a defined function to it's arguments, using the original clauses.
 appDef' ::
-     QName -> Term -> [Clause] -> GlobalRewriteRules -> MaybeReducedArgs
+     QName -> Term -> [Clause] -> RewriteRules -> MaybeReducedArgs
   -> ReduceM (Reduced (Blocked Term) Term)
 appDef' f v cls rewr args = appDefE' f v cls rewr $ map (fmap Apply) args
 
-appDefE' :: QName -> Term -> [Clause] -> GlobalRewriteRules -> MaybeReducedElims -> ReduceM (Reduced (Blocked Term) Term)
+appDefE' ::
+     QName -> Term -> [Clause] -> RewriteRules -> MaybeReducedElims
+  -> ReduceM (Reduced (Blocked Term) Term)
 appDefE' f v cls rewr es =
   localTC (\ e -> e { envAppDef = Just f }) $
   appDefE'' v cls rewr es
 
 -- | Expects @'envAppDef' = Just f@ in 'TCEnv' to be able to report @'MissingClauses' f@.
 appDefE'' ::
-     Term -> [Clause] -> GlobalRewriteRules -> MaybeReducedElims
+     Term -> [Clause] -> RewriteRules -> MaybeReducedElims
   -> ReduceM (Reduced (Blocked Term) Term)
 appDefE'' v cls rewr es = traceSDoc "tc.reduce" 90 ("appDefE' v = " <+> pretty v) $ do
   goCls cls $ map ignoreReduced es
@@ -1008,6 +1041,12 @@ instance Reduce Telescope where
 instance Reduce ProblemConstraint where
   reduce' (PConstr p u c) = PConstr p u <$> reduce' c
 
+instance Reduce LocalEquation where
+  reduce' (LocalEquation g t u a) = do
+    g' <- reduce' g
+    (t', u', a') <- addContext g' $ reduce' (t, u, a)
+    return $ LocalEquation g' t' u' a'
+
 instance Reduce Constraint where
   reduce' (ValueCmp cmp t u v) = do
     (t,u,v) <- reduce' (t,u,v)
@@ -1034,6 +1073,7 @@ instance Reduce Constraint where
   reduce' c@CheckMetaInst{}     = return c
   reduce' (CheckType t)         = CheckType <$> reduce' t
   reduce' (UsableAtModality cc ms mod t) = flip (UsableAtModality cc) mod <$> reduce' ms <*> reduce' t
+  reduce' (RewConstraint e)     = RewConstraint <$> reduce' e
 
 instance Reduce CompareAs where
   reduce' (AsTermsOf a) = AsTermsOf <$> reduce' a
@@ -1175,6 +1215,12 @@ instance (Subst a, Simplify a) => Simplify (Tele a) where
 instance Simplify ProblemConstraint where
   simplify' (PConstr pid unblock c) = PConstr pid unblock <$> simplify' c
 
+instance Simplify LocalEquation where
+  simplify' (LocalEquation g t u a) = do
+    g' <- simplify' g
+    (t', u', a') <- addContext g' $ simplify (t, u, a)
+    return $ LocalEquation g' t' u' a'
+
 instance Simplify Constraint where
   simplify' (ValueCmp cmp t u v) = do
     (t,u,v) <- simplify' (t,u,v)
@@ -1201,6 +1247,7 @@ instance Simplify Constraint where
   simplify' c@CheckMetaInst{}     = return c
   simplify' (CheckType t)         = CheckType <$> simplify' t
   simplify' (UsableAtModality cc ms mod t) = flip (UsableAtModality cc) mod <$> simplify' ms <*> simplify' t
+  simplify' (RewConstraint e)     = RewConstraint <$> simplify' e
 
 instance Simplify CompareAs where
   simplify' (AsTermsOf a) = AsTermsOf <$> simplify' a
@@ -1361,6 +1408,12 @@ instance (Subst a, Normalise a) => Normalise (Tele a) where
 instance Normalise ProblemConstraint where
   normalise' (PConstr pid unblock c) = PConstr pid unblock <$> normalise' c
 
+instance Normalise LocalEquation where
+  normalise' (LocalEquation g t u a) = do
+    g' <- normalise g
+    (t', u', a') <- addContext g' $ normalise (t, u, a)
+    return $ LocalEquation g' t' u' a'
+
 instance Normalise Constraint where
   normalise' (ValueCmp cmp t u v) = do
     (t,u,v) <- normalise' (t,u,v)
@@ -1387,6 +1440,7 @@ instance Normalise Constraint where
   normalise' c@CheckMetaInst{}     = return c
   normalise' (CheckType t)         = CheckType <$> normalise' t
   normalise' (UsableAtModality cc ms mod t) = flip (UsableAtModality cc) mod <$> normalise' ms <*> normalise' t
+  normalise' (RewConstraint e)     = RewConstraint <$> normalise' e
 
 instance Normalise CompareAs where
   normalise' (AsTermsOf a) = AsTermsOf <$> normalise' a
@@ -1573,7 +1627,7 @@ instance (Subst a, InstantiateFull a) => InstantiateFull (Abs a) where
     instantiateFull' a@(Abs x _) = Abs x <$> underAbstraction_ a instantiateFull'
     instantiateFull' (NoAbs x a) = NoAbs x <$> instantiateFull' a
 
-instance (InstantiateFull t, InstantiateFull e) => InstantiateFull (Dom' t e) where
+instance InstantiateFull e => InstantiateFull (Dom e) where
     instantiateFull' (Dom i n b tac rew x) = Dom i n b <$> instantiateFull' tac <*> instantiateFull' rew <*> instantiateFull' x
 
 instance InstantiateFull Context where
@@ -1635,6 +1689,7 @@ instance InstantiateFull Constraint where
     c@CheckMetaInst{}   -> return c
     CheckType t         -> CheckType <$> instantiateFull' t
     UsableAtModality cc ms mod t -> flip (UsableAtModality cc) mod <$> instantiateFull' ms <*> instantiateFull' t
+    RewConstraint e     -> RewConstraint <$> instantiateFull' e
 
 instance InstantiateFull CompareAs where
   instantiateFull' (AsTermsOf a) = AsTermsOf <$> instantiateFull' a
@@ -1693,14 +1748,28 @@ instance InstantiateFull GlobalRewriteRule where
       <*> pure c
       <*> pure top
 
-instance InstantiateFull RewriteRule where
-  instantiateFull' (RewriteRule a b c d e) =
-    RewriteRule
+instance InstantiateFull LocalEquation where
+  instantiateFull' (LocalEquation a b c d) =
+    LocalEquation
       <$> instantiateFull' a
       <*> instantiateFull' b
       <*> instantiateFull' c
       <*> instantiateFull' d
+
+instance InstantiateFull RewriteRule where
+  instantiateFull' (RewriteRule a b c d e) =
+    RewriteRule
+      <$> instantiateFull' a
+      <*> pure b
+      <*> instantiateFull' c
+      <*> instantiateFull' d
       <*> instantiateFull' e
+
+instance InstantiateFull RewDom where
+  instantiateFull' (RewDom a b) =
+    RewDom
+      <$> instantiateFull' a
+      <*> instantiateFull' b
 
 instance InstantiateFull DisplayForm where
   instantiateFull' (Display n ps v) = uncurry (Display n) <$> instantiateFull' (ps, v)

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -340,9 +340,9 @@ instance Instantiate EqualityView where
     <*> instantiate' a
     <*> instantiate' b
 
-instance Instantiate LocalRewriteRule where
-  instantiate' (LocalRewriteRule a b c d e) =
-    LocalRewriteRule
+instance Instantiate RewriteRule where
+  instantiate' (RewriteRule a b c d e) =
+    RewriteRule
       <$> instantiate' a
       <*> pure b
       <*> pure c
@@ -677,7 +677,7 @@ unfoldDefinitionStep v0 f es =
   {-# SCC "reduceDef" #-} do
   traceSDoc "tc.reduce" 90 ("unfoldDefinitionStep v0" <+> pretty v0) $ do
   info <- getConstInfo f
-  rewr <- instantiateRewriteRules =<< getRewriteRulesFor f
+  rewr <- instantiateRewriteRules =<< getGlobalRewriteRulesFor f
   allowed <- asksTC envAllowedReductions
   prp <- runBlocked $ isPropM $ defType info
   defOk <- shouldReduceDef f
@@ -751,7 +751,10 @@ unfoldDefinitionStep v0 f es =
           mredToBlocked (MaybeRed NotReduced  e) = notBlocked e
           mredToBlocked (MaybeRed (Reduced b) e) = e <$ b
 
-    reduceNormalE :: Term -> QName -> [MaybeReduced Elim] -> Bool -> [Clause] -> Maybe CompiledClauses -> RewriteRules -> ReduceM (Reduced (Blocked Term) Term)
+    reduceNormalE ::
+         Term -> QName -> [MaybeReduced Elim] -> Bool -> [Clause]
+      -> Maybe CompiledClauses -> GlobalRewriteRules
+      -> ReduceM (Reduced (Blocked Term) Term)
     reduceNormalE v0 f es dontUnfold def mcc rewr = {-# SCC "reduceNormal" #-} do
       traceSDoc "tc.reduce" 90 ("reduceNormalE v0 =" <+> pretty v0) $ do
       case (def,rewr) of
@@ -898,10 +901,14 @@ unfoldInlined v = do
 
 -- | Apply a definition using the compiled clauses, or fall back to
 --   ordinary clauses if no compiled clauses exist.
-appDef_ :: QName -> Term -> [Clause] -> Maybe CompiledClauses -> RewriteRules -> MaybeReducedArgs -> ReduceM (Reduced (Blocked Term) Term)
+appDef_ ::
+     QName -> Term -> [Clause] -> Maybe CompiledClauses -> GlobalRewriteRules
+  -> MaybeReducedArgs -> ReduceM (Reduced (Blocked Term) Term)
 appDef_ f v0 cls mcc rewr args = appDefE_ f v0 cls mcc rewr $ map (fmap Apply) args
 
-appDefE_ :: QName -> Term -> [Clause] -> Maybe CompiledClauses -> RewriteRules -> MaybeReducedElims -> ReduceM (Reduced (Blocked Term) Term)
+appDefE_ ::
+     QName -> Term -> [Clause] -> Maybe CompiledClauses -> GlobalRewriteRules
+  -> MaybeReducedElims -> ReduceM (Reduced (Blocked Term) Term)
 appDefE_ f v0 cls mcc rewr args =
   localTC (\ e -> e { envAppDef = Just f }) $
   maybe (appDefE'' v0 cls rewr args)
@@ -910,10 +917,14 @@ appDefE_ f v0 cls mcc rewr args =
 
 -- | Apply a defined function to it's arguments, using the compiled clauses.
 --   The original term is the first argument applied to the third.
-appDef :: Term -> CompiledClauses -> RewriteRules -> MaybeReducedArgs -> ReduceM (Reduced (Blocked Term) Term)
+appDef ::
+     Term -> CompiledClauses -> GlobalRewriteRules -> MaybeReducedArgs
+  -> ReduceM (Reduced (Blocked Term) Term)
 appDef v cc rewr args = appDefE v cc rewr $ map (fmap Apply) args
 
-appDefE :: Term -> CompiledClauses -> RewriteRules -> MaybeReducedElims -> ReduceM (Reduced (Blocked Term) Term)
+appDefE ::
+     Term -> CompiledClauses -> GlobalRewriteRules -> MaybeReducedElims
+  -> ReduceM (Reduced (Blocked Term) Term)
 appDefE v cc rewr es = do
   traceSDoc "tc.reduce" 90 ("appDefE v = " <+> pretty v) $ do
   r <- matchCompiledE cc es
@@ -922,16 +933,20 @@ appDefE v cc rewr es = do
     NoReduction es'      -> rewrite (void es') (applyE v) rewr (ignoreBlocking es')
 
 -- | Apply a defined function to it's arguments, using the original clauses.
-appDef' :: QName -> Term -> [Clause] -> RewriteRules -> MaybeReducedArgs -> ReduceM (Reduced (Blocked Term) Term)
+appDef' ::
+     QName -> Term -> [Clause] -> GlobalRewriteRules -> MaybeReducedArgs
+  -> ReduceM (Reduced (Blocked Term) Term)
 appDef' f v cls rewr args = appDefE' f v cls rewr $ map (fmap Apply) args
 
-appDefE' :: QName -> Term -> [Clause] -> RewriteRules -> MaybeReducedElims -> ReduceM (Reduced (Blocked Term) Term)
+appDefE' :: QName -> Term -> [Clause] -> GlobalRewriteRules -> MaybeReducedElims -> ReduceM (Reduced (Blocked Term) Term)
 appDefE' f v cls rewr es =
   localTC (\ e -> e { envAppDef = Just f }) $
   appDefE'' v cls rewr es
 
 -- | Expects @'envAppDef' = Just f@ in 'TCEnv' to be able to report @'MissingClauses' f@.
-appDefE'' :: Term -> [Clause] -> RewriteRules -> MaybeReducedElims -> ReduceM (Reduced (Blocked Term) Term)
+appDefE'' ::
+     Term -> [Clause] -> GlobalRewriteRules -> MaybeReducedElims
+  -> ReduceM (Reduced (Blocked Term) Term)
 appDefE'' v cls rewr es = traceSDoc "tc.reduce" 90 ("appDefE' v = " <+> pretty v) $ do
   goCls cls $ map ignoreReduced es
   where
@@ -1667,9 +1682,9 @@ instance InstantiateFull NLPSort where
   instantiateFull' PLevelUniv = return PLevelUniv
   instantiateFull' PIntervalUniv = return PIntervalUniv
 
-instance InstantiateFull RewriteRule where
-  instantiateFull' (RewriteRule q gamma f ps rhs t c top) =
-    RewriteRule q
+instance InstantiateFull GlobalRewriteRule where
+  instantiateFull' (GlobalRewriteRule q gamma f ps rhs t c top) =
+    GlobalRewriteRule q
       <$> instantiateFull' gamma
       <*> pure f
       <*> instantiateFull' ps
@@ -1678,9 +1693,9 @@ instance InstantiateFull RewriteRule where
       <*> pure c
       <*> pure top
 
-instance InstantiateFull LocalRewriteRule where
-  instantiateFull' (LocalRewriteRule a b c d e) =
-    LocalRewriteRule
+instance InstantiateFull RewriteRule where
+  instantiateFull' (RewriteRule a b c d e) =
+    RewriteRule
       <$> instantiateFull' a
       <*> instantiateFull' b
       <*> instantiateFull' c

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -45,6 +45,7 @@ import qualified Data.HashMap.Strict as HMap
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Map.Strict as MapS
+import qualified Data.IntMap as IntMap
 import qualified Data.IntSet as IntSet
 import qualified Data.List as List
 import Data.Text (Text)
@@ -73,6 +74,7 @@ import Agda.Utils.Float
 import Agda.Utils.Lens
 import Agda.Utils.List
 import Agda.Utils.Maybe
+import Agda.Utils.Memo (memoUnsafeInt)
 import Agda.Utils.Monad
 import Agda.Utils.Null (empty, null)
 import Agda.Utils.Functor
@@ -94,7 +96,7 @@ import Debug.Trace
 data CompactDef =
   CompactDef { cdefUnconfirmed    :: Bool
              , cdefDef            :: CompactDefn
-             , cdefRewriteRules   :: GlobalRewriteRules
+             , cdefRewriteRules   :: RewriteRules
              }
 
 data CompactDefn
@@ -114,9 +116,9 @@ data BuiltinEnv = BuiltinEnv
 
 -- | Compute a 'CompactDef' from a regular definition.
 compactDef ::
-     BuiltinEnv -> Definition -> GlobalRewriteRules
+     BuiltinEnv -> Definition -> Bool -> RewriteRules
   -> ReduceM CompactDef
-compactDef bEnv def rewr = do
+compactDef bEnv def copatterns rewr = do
 
   -- WARNING: don't use isPropM here because it relies on reduction,
   -- which causes an infinite loop.
@@ -136,7 +138,7 @@ compactDef bEnv def rewr = do
           , isConOrProj && ProjectionReductions `SmallSet.member` allowed
           , isInlineFun (theDef def) && InlineReductions `SmallSet.member` allowed
           , definitelyNonRecursive_ (theDef def) && or
-            [ defCopatternLHS def && CopatternReductions `SmallSet.member` allowed
+            [ copatterns && CopatternReductions `SmallSet.member` allowed
             , FunctionReductions `SmallSet.member` allowed
             ]
           ]
@@ -458,13 +460,20 @@ fastReduce' norm v = do
 
       bEnv = BuiltinEnv { bZero = zero, bSuc = suc, bTrue = true, bFalse = false, bRefl = refl,
                           bPrimForce = force, bPrimErase = erase }
-  rwr <- optRewriting <$> pragmaOptions
+  rwr    <- anyRewritingOption
+  rwrLoc <- localRewritingOption
   constInfo <- unKleisli $ \f -> do
     info <- getConstInfo f
-    rewr <- if rwr then instantiateRewriteRules =<< getGlobalRewriteRulesFor f
+    copatterns <- if rwr then defCopatternLHS f info
+                         else return $ defCopatternLHS' info
+    rewr <- if rwr then getAllRewriteRulesForDefHead f
                    else return []
-    compactDef bEnv info rewr
-  ReduceM $ \ redEnv -> reduceTm redEnv bEnv (memoQName constInfo) norm v
+    compactDef bEnv info copatterns rewr
+  localRewr <- unKleisli $ \x ->
+    if rwrLoc then getAllRewriteRulesForVarHead x else return []
+
+  ReduceM $ \ redEnv ->
+    reduceTm redEnv bEnv (memoQName constInfo) (memoUnsafeInt localRewr) norm v
 
 -- * Closures
 
@@ -817,13 +826,12 @@ unusedPointer = Pure (Closure (Value $ notBlocked ())
 
 -- | Evaluating a term in the abstract machine. It gets the type checking state and environment in
 --   the 'ReduceEnv' argument, some precomputed built-in mappings in 'BuiltinEnv', the memoised
---   'getConstInfo' function, a couple of flags (allow non-terminating function unfolding, and
---   whether rewriting is enabled), and a term to reduce. The result is the weak-head normal form of
---   the term with an attached blocking tag.
+--   'getConstInfo' function, a memoised function to lookup local rewrite rules, and a term to
+--   reduce. The result is the weak-head normal form of the term with an attached blocking tag.
 reduceTm ::
-     ReduceEnv -> BuiltinEnv -> (QName -> CompactDef) -> Normalisation -> Term
-  -> Blocked Term
-reduceTm rEnv bEnv !constInfo normalisation =
+     ReduceEnv -> BuiltinEnv -> (QName -> CompactDef) -> (Nat -> RewriteRules)
+  -> Normalisation -> Term -> Blocked Term
+reduceTm rEnv bEnv !constInfo !localRewr normalisation =
     compileAndRun . traceDoc "-- fast reduce --"
   where
     -- Helpers to get information from the ReduceEnv.
@@ -943,7 +951,7 @@ reduceTm rEnv bEnv !constInfo normalisation =
         Var x []   ->
           evalIApplyAM spine ctrl $
           case lookupEnv x env of
-            Nothing -> runAM (evalValue (notBlocked ()) (Var (x - envSize env) []) emptyEnv spine ctrl)
+            Nothing -> rewriteAM $ evalValue (notBlocked ()) (Var (x - envSize env) []) emptyEnv spine ctrl
             Just p  -> evalPointerAM p spine ctrl
 
         -- Case: lambda. Perform the beta reduction if applied. Otherwise it's a value.
@@ -1359,6 +1367,7 @@ reduceTm rEnv bEnv !constInfo normalisation =
       where rewr = case t of
                      Def f []   -> rewriteRules f
                      Con c _ [] -> rewriteRules (conName c)
+                     Var x _    -> localRewr x
                      _          -> __IMPOSSIBLE__
     rewriteAM _ =
       __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -94,7 +94,7 @@ import Debug.Trace
 data CompactDef =
   CompactDef { cdefUnconfirmed    :: Bool
              , cdefDef            :: CompactDefn
-             , cdefRewriteRules   :: RewriteRules
+             , cdefRewriteRules   :: GlobalRewriteRules
              }
 
 data CompactDefn
@@ -113,7 +113,9 @@ data BuiltinEnv = BuiltinEnv
   , bPrimForce, bPrimErase  :: Maybe QName }
 
 -- | Compute a 'CompactDef' from a regular definition.
-compactDef :: BuiltinEnv -> Definition -> RewriteRules -> ReduceM CompactDef
+compactDef ::
+     BuiltinEnv -> Definition -> GlobalRewriteRules
+  -> ReduceM CompactDef
 compactDef bEnv def rewr = do
 
   -- WARNING: don't use isPropM here because it relies on reduction,
@@ -459,7 +461,7 @@ fastReduce' norm v = do
   rwr <- optRewriting <$> pragmaOptions
   constInfo <- unKleisli $ \f -> do
     info <- getConstInfo f
-    rewr <- if rwr then instantiateRewriteRules =<< getRewriteRulesFor f
+    rewr <- if rwr then instantiateRewriteRules =<< getGlobalRewriteRulesFor f
                    else return []
     compactDef bEnv info rewr
   ReduceM $ \ redEnv -> reduceTm redEnv bEnv (memoQName constInfo) norm v
@@ -818,7 +820,9 @@ unusedPointer = Pure (Closure (Value $ notBlocked ())
 --   'getConstInfo' function, a couple of flags (allow non-terminating function unfolding, and
 --   whether rewriting is enabled), and a term to reduce. The result is the weak-head normal form of
 --   the term with an attached blocking tag.
-reduceTm :: ReduceEnv -> BuiltinEnv -> (QName -> CompactDef) -> Normalisation -> Term -> Blocked Term
+reduceTm ::
+     ReduceEnv -> BuiltinEnv -> (QName -> CompactDef) -> Normalisation -> Term
+  -> Blocked Term
 reduceTm rEnv bEnv !constInfo normalisation =
     compileAndRun . traceDoc "-- fast reduce --"
   where

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -78,7 +78,7 @@ instance MonadDebug ReduceM where
   nowDebugPrinting  = defaultNowDebugPrinting
 
 instance HasConstInfo ReduceM where
-  getRewriteRulesFor = defaultGetRewriteRulesFor
+  getGlobalRewriteRulesFor = defaultGetGlobalRewriteRulesFor
   getConstInfo' q = do
     ReduceEnv env st _ _ <- askR
     defaultGetConstInfo st env q

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -42,6 +42,8 @@ instance MonadAddContext ReduceM where
 
   addLetBinding' = defaultAddLetBinding'
 
+  addLocalRewrite = defaultAddLocalRewrite
+
   updateContext rho f ret = withFreshR $ \ chkpt ->
     localTC (\e -> e { envContext = f $ envContext e
                      , envCurrentCheckpoint = chkpt
@@ -79,6 +81,7 @@ instance MonadDebug ReduceM where
 
 instance HasConstInfo ReduceM where
   getGlobalRewriteRulesFor = defaultGetGlobalRewriteRulesFor
+  getLocalRewriteRulesFor  = defaultGetLocalRewriteRulesFor
   getConstInfo' q = do
     ReduceEnv env st _ _ <- askR
     defaultGetConstInfo st env q

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -142,10 +142,10 @@ addRewriteRules qs = do
 
   -- Add rewrite rules to the signature
   forM_ rews $ \rew -> do
-    let f = rewHead rew
+    let f = grHead rew
         matchables = getMatchables rew
     reportSDoc "rewriting" 10 $
-      "adding rule" <+> prettyTCM (rewName rew) <+>
+      "adding rule" <+> prettyTCM (grName rew) <+>
       "to the definition of" <+> prettyTCM f
     reportSDoc "rewriting" 30 $ "matchable symbols: " <+> prettyTCM matchables
     addRewriteRulesFor f [rew] matchables
@@ -158,10 +158,11 @@ addRewriteRules qs = do
     -- Global confluence checker requires rules to be sorted
     -- according to the generality of their lhs
     when (confChk == GlobalConfluenceCheck) $
-      forM_ (nubOn id $ map rewHead rews) sortRulesOfSymbol
+      forM_ (nubOn id $ map grHead rews) sortRulesOfSymbol
     checkConfluenceOfRules confChk rews
     reportSDoc "rewriting" 10 $
-      "done checking confluence of rules" <+> prettyList_ (map (prettyTCM . rewName) rews)
+      "done checking confluence of rules" <+>
+      prettyList_ (map (prettyTCM . grName) rews)
 
 -- Auxiliary function for checkRewriteRule.
 -- | Get domain of rewrite relation.
@@ -184,7 +185,7 @@ rewriteRelationDom rel = do
 --   Remember that @rel : Δ → A → A → Set i@, so
 --   @rel us : (lhs rhs : A[us/Δ]) → Set i@.
 --   Returns the checked rewrite rule to be added to the signature.
-checkRewriteRule :: QName -> TCM (Maybe RewriteRule)
+checkRewriteRule :: QName -> TCM (Maybe GlobalRewriteRule)
 checkRewriteRule q = runMaybeT $ setCurrentRange q do
   lift requireOptionRewriting
   rels <- lift getBuiltinRewriteRelations
@@ -331,7 +332,7 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
         unlessNull (freeVarsRhs VarSet.\\ neverSingPatVars) warnUnsafeVars
 
         top <- fromMaybe __IMPOSSIBLE__ <$> currentTopLevelModule
-        let rew = RewriteRule q gamma f ps rhs (unDom b) False top
+        let rew = GlobalRewriteRule q gamma f ps rhs (unDom b) False top
 
         reportSDoc "rewriting" 10 $ vcat
           [ "checked rewrite rule" , prettyTCM rew ]
@@ -405,11 +406,12 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
       where
       illegalHead = illegalRule $ HeadSymbolIsTypeConstructor f
 
-    ifNotAlreadyAdded :: QName -> MaybeT TCM RewriteRule -> MaybeT TCM RewriteRule
+    ifNotAlreadyAdded ::
+      QName -> MaybeT TCM GlobalRewriteRule -> MaybeT TCM GlobalRewriteRule
     ifNotAlreadyAdded f cont = do
-      rews <- getRewriteRulesFor f
+      rews <- getGlobalRewriteRulesFor f
       -- check if q is already an added rewrite rule
-      case List.find ((q ==) . rewName) rews of
+      case List.find ((q ==) . grName) rews of
         Just rew -> illegalRule DuplicateRewriteRule
         Nothing -> cont
 
@@ -441,10 +443,10 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
 --   tries to rewrite @f es@ with @rew@, returning the reduct if successful.
 rewriteWith :: Type
             -> (Elims -> Term)
-            -> RewriteRule
+            -> GlobalRewriteRule
             -> Elims
             -> ReduceM (Either (Blocked Term) Term)
-rewriteWith t hd rew@(RewriteRule q gamma _ ps rhs b isClause _) es
+rewriteWith t hd rew@(GlobalRewriteRule q gamma _ ps rhs b isClause _) es
  | isClause = return $ Left $ NotBlocked ReallyNotBlocked $ hd es
  | otherwise = do
   traceSDoc "rewriting.rewrite" 50 (sep
@@ -471,7 +473,9 @@ rewriteWith t hd rew@(RewriteRule q gamma _ ps rhs b isClause _) es
 
 -- | @rewrite b v rules es@ tries to rewrite @v@ applied to @es@ with the
 --   rewrite rules @rules@. @b@ is the default blocking tag.
-rewrite :: Blocked_ -> (Elims -> Term) -> RewriteRules -> Elims -> ReduceM (Reduced (Blocked Term) Term)
+rewrite ::
+     Blocked_ -> (Elims -> Term) -> GlobalRewriteRules -> Elims
+  -> ReduceM (Reduced (Blocked Term) Term)
 rewrite block hd rules es = do
   rewritingAllowed <- optRewriting <$> pragmaOptions
   if (rewritingAllowed && not (null rules)) then do
@@ -480,7 +484,9 @@ rewrite block hd rules es = do
   else
     return $ NoReduction (block $> hd es)
   where
-    loop :: Blocked_ -> Type -> RewriteRules -> Elims -> ReduceM (Reduced (Blocked Term) Term)
+    loop ::
+         Blocked_ -> Type -> GlobalRewriteRules -> Elims
+      -> ReduceM (Reduced (Blocked Term) Term)
     loop block t [] es =
       traceSDoc "rewriting.rewrite" 20 (sep
         [ "failed to rewrite " <+> prettyTCM (hd es)
@@ -497,5 +503,5 @@ rewrite block hd rules es = do
             Right w               -> return $ YesReduction YesSimplification $ w `applyE` es2
      | otherwise = loop (block `mappend` NotBlocked Underapplied ()) t rews es
 
-    rewArity :: RewriteRule -> Int
-    rewArity = length . rewPats
+    rewArity :: GlobalRewriteRule -> Int
+    rewArity = length . grPats

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -90,6 +90,7 @@ import Agda.Utils.Impossible
 import Agda.Utils.Either
 import Agda.Utils.List1 (nonEmpty)
 
+-- | Require '--rewriting' for global REWRITE rules
 requireOptionRewriting :: TCM ()
 requireOptionRewriting =
   unlessM (optRewriting <$> pragmaOptions) $ typeError NeedOptionRewriting
@@ -100,7 +101,6 @@ requireOptionRewriting =
 --   Note: we do not care about hiding/non-hiding of lhs and rhs.
 verifyBuiltinRewrite :: Term -> Type -> TCM ()
 verifyBuiltinRewrite v t = do
-  requireOptionRewriting
   caseMaybeM (relView t)
     (typeError $ IncorrectTypeForRewriteRelation v ShouldAcceptAtLeastTwoArguments) $
     \ (RelView tel delta a b core) -> do
@@ -177,6 +177,42 @@ rewriteRelationDom rel = do
         addContext delta $ prettyTCM a
   return (delta, a)
 
+checkEquationValid ::
+  RewriteSource -> RewriteAnn -> Type -> TCM (Maybe LocalEquation)
+checkEquationValid s rewAnn t
+  | isRewrite rewAnn = runMaybeT $ checkIsRewriteRelation s t
+  | otherwise        = pure Nothing
+
+checkIsRewriteRelation ::
+  RewriteSource -> Type -> MaybeT TCM LocalEquation
+checkIsRewriteRelation q t = do
+  rels <- lift getBuiltinRewriteRelations
+  reportSDoc "rewriting.relations" 40 $ vcat
+    [ "Rewrite relations:"
+    , prettyList $ map prettyTCM $ toList rels
+    ]
+  TelV gamma1 core <- telView $ t
+  reportSDoc "rewriting" 30 $ vcat
+    [ "attempting to add rewrite rule of type "
+    , prettyTCM gamma1
+    , " |- " <+> do addContext gamma1 $ prettyTCM core
+    ]
+  case unEl core of
+    Def rel es@(_:_:_) | rel `elem` rels -> do
+        (delta, a) <- lift $ rewriteRelationDom rel
+        -- Because of the type of rel (Γ → sort), all es are applications.
+        let vs = map unArg $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
+        -- The last two arguments are lhs and rhs.
+            n  = size vs
+            (us, [lhs, rhs]) = splitAt (n - 2) vs
+        unless (size delta == size us) __IMPOSSIBLE__
+        lhs <- instantiateFull lhs
+        rhs <- instantiateFull rhs
+        b   <- instantiateFull $ applySubst (parallelS $ reverse us) a
+        gamma1 <- instantiateFull gamma1
+        pure $ LocalEquation gamma1  lhs rhs (unDom b)
+    _ -> illegalRule q DoesNotTargetRewriteRelation
+
 -- | Check the validity of @q : Γ → rel us lhs rhs@ as rewrite rule
 --   @
 --       Γ ⊢ lhs ↦ rhs : B
@@ -194,166 +230,188 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
     , prettyList $ map prettyTCM $ toList rels
     ]
   def <- instantiateDef =<< getConstInfo q
+
   -- Issue 1651: Check that we are not adding a rewrite rule
   -- for a type signature whose body has not been type-checked yet.
   when (isEmptyFunction $ theDef def) $
-    illegalRule BeforeFunctionDefinition
+    illegalRule (GlobalRewrite def) BeforeFunctionDefinition
   -- Issue 6643: Also check that there are no mutual definitions
   -- that are not yet defined.
   whenJustM (asksTC envMutualBlock) \ mb -> do
     qs <- mutualNames <$> lookupMutualBlock mb
     when (Set.member q qs) $ forM_ qs $ \r -> do
       whenM (isEmptyFunction . theDef <$> getConstInfo r) $
-        illegalRule $ BeforeMutualFunctionDefinition r
+        illegalRule (GlobalRewrite def) $ BeforeMutualFunctionDefinition r
 
+  eq <- checkIsRewriteRelation (GlobalRewrite def) (defType def)
+  RewriteRule g h ps rhs b <- checkRewriteRule' eq (GlobalRewrite def)
+  f <- case h of
+    RewDefHead f -> pure f
+    RewVarHead x -> illegalRule (GlobalRewrite def) LHSNotDefinitionOrConstructor
 
-  -- Get rewrite rule (type of q).
-  TelV gamma1 core <- telView $ defType def
-  reportSDoc "rewriting" 30 $ vcat
-    [ "attempting to add rewrite rule of type "
-    , prettyTCM gamma1
-    , " |- " <+> do addContext gamma1 $ prettyTCM core
-    ]
+  top <- fromMaybe __IMPOSSIBLE__ <$> currentTopLevelModule
+
+  pure $ GlobalRewriteRule q g f ps  rhs b False top
+
+checkLocalRewriteRule ::
+  RewriteSource -> LocalEquation -> TCM (Maybe RewriteRule)
+checkLocalRewriteRule s eq = runMaybeT $
+  -- For now, we fail if the local rewrite rule contains metas ANYWHERE
+  -- I think it should be possible to do better than this, but it is hard
+  Set1.ifNull (allMetas Set.singleton eq)
+  {- then -} (checkRewriteRule' eq s)
+  {- else -} (illegalRule s . ContainsUnsolvedMetaVariables)
+
+checkRewriteRule' :: LocalEquation -> RewriteSource -> MaybeT TCM RewriteRule
+checkRewriteRule' eq@(LocalEquation gamma1 lhs rhs b) s = do
+  reportSDoc "rewriting" 30 $
+    "Checking rewrite rule: " <+> prettyTCM eq
+
   let failureBlocked :: Blocker -> MaybeT TCM a
       failureBlocked b
-        | Set1.IsNonEmpty ms <- allBlockingMetas    b = illegalRule $ ContainsUnsolvedMetaVariables ms
-        | Set1.IsNonEmpty ps <- allBlockingProblems b = illegalRule $ BlockedOnProblems ps
-        | Set1.IsNonEmpty qs <- allBlockingDefs     b = illegalRule $ RequiresDefinitions qs
+        | Set1.IsNonEmpty ms <- allBlockingMetas    b = illegalRule s $ ContainsUnsolvedMetaVariables ms
+        | Set1.IsNonEmpty ps <- allBlockingProblems b = illegalRule s $ BlockedOnProblems ps
+        | Set1.IsNonEmpty qs <- allBlockingDefs     b = illegalRule s $ RequiresDefinitions qs
         | otherwise = __IMPOSSIBLE__
   let failureFreeVars :: VarSet -> MaybeT TCM a
-      failureFreeVars xs = illegalRule $ VariablesNotBoundByLHS xs
+      failureFreeVars xs = illegalRule s $ VariablesNotBoundByLHS xs
   let warnUnsafeVars :: VarSet -> MaybeT TCM ()
-      warnUnsafeVars xs = unsafeRule $ VariablesBoundInSingleton xs
+      warnUnsafeVars xs = unsafeRule s $ VariablesBoundInSingleton xs
   let failureNonLinearPars :: VarSet -> MaybeT TCM a
-      failureNonLinearPars xs = illegalRule $ VariablesBoundMoreThanOnce xs
+      failureNonLinearPars xs = illegalRule s $ VariablesBoundMoreThanOnce xs
 
-  -- Check that type of q targets rel.
-  case unEl core of
-    Def rel es@(_:_:_) | rel `elem` rels -> do
-      (delta, a) <- lift $ rewriteRelationDom rel
-      -- Because of the type of rel (Γ → sort), all es are applications.
-      let vs = map unArg $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
-      -- The last two arguments are lhs and rhs.
-          n  = size vs
-          (us, [lhs, rhs]) = splitAt (n - 2) vs
-      unless (size delta == size us) __IMPOSSIBLE__
-      lhs <- instantiateFull lhs
-      rhs <- instantiateFull rhs
-      b   <- instantiateFull $ applySubst (parallelS $ reverse us) a
+  gamma0 <- getContextTelescope
+  let gamma = gamma0 `abstract` gamma1
 
-      gamma0 <- getContextTelescope
-      gamma1 <- instantiateFull gamma1
-      let gamma = gamma0 `abstract` gamma1
+  reportSDoc "rewriting" 40 $
+    "Full context: " <+> prettyTCM gamma
 
-      -- 2017-06-18, Jesper: Unfold inlined definitions on the LHS.
-      -- This is necessary to replace copies created by imports by their
-      -- original definition.
-      lhs <- modifyAllowedReductions (const $ SmallSet.singleton InlineReductions) $ reduce lhs
+  -- 2017-06-18, Jesper: Unfold inlined definitions on the LHS.
+  -- This is necessary to replace copies created by imports by their
+  -- original definition.
+  lhs <- modifyAllowedReductions (const $ SmallSet.singleton InlineReductions) $ reduce lhs
 
-      -- Find head symbol f of the lhs, its type, its parameters (in case of a constructor), and its arguments.
-      (f , hd , t , pars , es) <- case lhs of
-        Def f es -> do
-          def <- getConstInfo f
-          checkAxFunOrCon f def
-          return (f , Def f , defType def , [] , es)
-        Con c ci vs -> do
-          let hd = Con c ci
-          ~(Just ((_ , _ , pars) , t)) <- getFullyAppliedConType c $ unDom b
-          pars <- addContext gamma1 $ checkParametersAreGeneral c pars
-          return (conName c , hd , t , pars , vs)
-        _ -> do
-          reportSDoc "rewriting.rule.check" 30 $ hsep
-            [ "LHSNotDefinitionOrConstructor: ", prettyTCM lhs ]
-          illegalRule LHSNotDefinitionOrConstructor
+  -- Find head symbol f of the lhs, its type, its parameters (in case of a constructor), and its arguments.
+  (f , hd , t , pars , es) <- case lhs of
+    Def f es -> do
+      def <- getConstInfo f
+      checkAxFunOrCon f def
+      return (RewDefHead f , Def f , defType def , [] , es)
+    Con c ci vs -> do
+      let hd = Con c ci
+      ~(Just ((_ , _ , pars) , t)) <- getFullyAppliedConType c b
+      pars <- addContext gamma1 $ checkParametersAreGeneral c pars
+      return (RewDefHead $ conName c , hd , t , pars , vs)
+    Var x es | isLocalRewrite s -> do
+      t <- addContext gamma1 $ typeOfBV x
+      return (RewVarHead (x - size gamma1), Var x , t , [] , es)
+    _ -> do
+      reportSDoc "rewriting.rule.check" 30 $ hsep
+        [ "LHSNotDefinitionOrConstructor: ", prettyTCM lhs ]
+      illegalRule s LHSNotDefinitionOrConstructor
 
-      ifNotAlreadyAdded f $ do
+  ifNotAlreadyAdded s f $ do
 
-      addContext gamma1 $ do
+  let rewGamma = if isLocalRewrite s then gamma1 else gamma
 
-        checkNoLhsReduction f hd es
+      telStart = size rewGamma
 
-        ps <- fromRightM failureBlocked $ lift $
-          catchPatternErr (pure . Left) $
-            Right <$> patternFrom NeverSing NeverSing 0 (t , Def f) es
+  addContext gamma1 $ do
 
-        reportSDoc "rewriting" 30 $
-          "Pattern generated from lhs: " <+> prettyTCM (PDef f ps)
+    checkNoLhsReduction telStart f hd es
 
-        -- We need to check two properties on the variables used in the rewrite rule
-        -- 1. For actually being able to apply the rewrite rule, we need
-        --    that all variables that occur in the rule (on the left or the right)
-        --    are bound in a pattern position on the left.
-        -- 2. To preserve soundness, we need that all the variables that are used
-        --    in the *proof* of the rewrite rule are bound in the lhs.
-        --    For rewrite rules on constructors, we consider parameters to be bound
-        --    even though they don't appear in the lhs, since they can be reconstructed.
-        --    For postulated or abstract rewrite rules, we consider all arguments
-        --    as 'used' (see #5238).
-        let PatVars neverSingPatVars maybeSingPatVars = nlPatVars ps
-            boundVars   = neverSingPatVars <> maybeSingPatVars
-            freeVarsLhs = freeVarSet lhs
-            freeVarsRhs = freeVarSet rhs
-            freeVars    = freeVarsLhs <> freeVarsRhs
-            allVars     = VarSet.full $ size gamma
-            usedVars    = case theDef def of
-              Function{}         -> usedArgs def
-              Axiom{}            -> allVars
-              AbstractDefn{}     -> allVars
-              Constructor{}      -> allVars
-              Primitive{}        -> allVars
-              DataOrRecSig{}     -> __IMPOSSIBLE__
-              GeneralizableVar{} -> __IMPOSSIBLE__
-              Datatype{}         -> __IMPOSSIBLE__
-              Record{}           -> __IMPOSSIBLE__
-              PrimitiveSort{}    -> __IMPOSSIBLE__
-        reportSDoc "rewriting" 70 $
-          "variables bound by the pattern: " <+> text (show boundVars)
-        reportSDoc "rewriting" 70 $
-          "variables free in the rhs: " <+> text (show freeVarsRhs)
-        reportSDoc "rewriting" 70 $
-          "variables used by the rewrite rule: " <+> text (show usedVars)
+    ps <- fromRightM failureBlocked $ lift $
+      catchPatternErr (pure . Left) $
+        Right <$> patternFrom
+          NeverSing NeverSing telStart 0 (t , headToTerm telStart f) es
 
-        -- All variables occurring in the rewrite must be bound somewhere
-        -- (otherwise the rewrite will simply never fire)
-        unlessNull (freeVars VarSet.\\ boundVars) failureFreeVars
-        -- #5238: All variables used in the proof of the rewrite must be
-        -- present in the context for the rewrite to fire safely.
-        -- Searching the context is not feasible though, so we instead use the
-        -- tighter criteria that the variables must occur somewhere on the LHS.
-        unlessNull (usedVars VarSet.\\ (boundVars `VarSet.union` VarSet.fromList pars)) failureFreeVars
+    reportSDoc "rewriting" 30 $
+      "Pattern generated from lhs: " <+> prettyTCM (headToPat telStart f ps)
 
-        reportSDoc "rewriting" 70 $
-          "variables bound in (erased) parameter position: " <+> text (show pars)
-        unlessNull (boundVars `VarSet.intersection` VarSet.fromList pars) failureNonLinearPars
+    -- We need to check two properties on the variables used in the rewrite rule
+    -- 1. For actually being able to apply the rewrite rule, we need
+    --    that all variables that occur in the rule (on the left or the right)
+    --    are bound in a pattern position on the left.
+    -- 2. To preserve soundness, we need that all the variables that are used
+    --    in the *proof* of the rewrite rule are bound in the lhs.
+    --    For rewrite rules on constructors, we consider parameters to be bound
+    --    even though they don't appear in the lhs, since they can be reconstructed.
+    --    For postulated or abstract rewrite rules, we consider all arguments
+    --    as 'used' (see #5238).
+    let PatVars neverSingPatVars maybeSingPatVars = nlPatVars ps
+        boundVars   = neverSingPatVars <> maybeSingPatVars
+        telVars     = VarSet.full telStart
+        freeVarsLhs = telVars `VarSet.intersection` freeVarSet lhs
+        freeVarsRhs = telVars `VarSet.intersection` freeVarSet rhs
+        freeVars    = freeVarsLhs <> freeVarsRhs
+        usedVars    = case s of
+          LocalRewrite _ _ _ -> VarSet.empty
+          GlobalRewrite def  -> case theDef def of
+            Function{}         -> usedArgs def
+            Axiom{}            -> telVars
+            AbstractDefn{}     -> telVars
+            Constructor{}      -> telVars
+            Primitive{}        -> telVars
+            DataOrRecSig{}     -> __IMPOSSIBLE__
+            GeneralizableVar{} -> __IMPOSSIBLE__
+            Datatype{}         -> __IMPOSSIBLE__
+            Record{}           -> __IMPOSSIBLE__
+            PrimitiveSort{}    -> __IMPOSSIBLE__
+    reportSDoc "rewriting" 70 $
+      "variables bound by pattern never singularly: " <+>
+      text (show neverSingPatVars)
+    reportSDoc "rewriting" 70 $
+      "variables bound by the pattern: " <+> text (show boundVars)
+    reportSDoc "rewriting" 70 $
+      "variables free in the lhs: " <+> text (show freeVarsLhs)
+    reportSDoc "rewriting" 70 $
+      "variables free in the rhs: " <+> text (show freeVarsRhs)
+    reportSDoc "rewriting" 70 $
+      "variables used by the rewrite rule: " <+> text (show usedVars)
 
-        -- #5929: All variables occurring on the rhs should be bound in
-        -- contexts that will never become definitionally singular (even after
-        -- a substitution), otherwise we can lose subject reduction.
-        unlessNull (freeVarsRhs VarSet.\\ neverSingPatVars) warnUnsafeVars
+    -- All variables occurring in the rewrite must be bound somewhere
+    -- (otherwise the rewrite will simply never fire)
+    unlessNull (freeVars VarSet.\\ boundVars) failureFreeVars
+    -- #5238: All variables used in the proof of the rewrite must be
+    -- present in the context for the rewrite to fire safely.
+    -- Searching the context is not feasible though, so we instead use the
+    -- tighter criteria that the variables must occur somewhere on the LHS.
+    unlessNull (usedVars VarSet.\\ (boundVars `VarSet.union` VarSet.fromList pars)) failureFreeVars
+    reportSDoc "rewriting" 70 $
+      "variables bound in (erased) parameter position: " <+> text (show pars)
+    unlessNull (boundVars `VarSet.intersection` VarSet.fromList pars) failureNonLinearPars
 
-        top <- fromMaybe __IMPOSSIBLE__ <$> currentTopLevelModule
-        let rew = GlobalRewriteRule q gamma f ps rhs (unDom b) False top
+    -- #5929: All variables occurring on the rhs should be bound in
+    -- contexts that will never become definitionally singular (even after
+    -- a substitution), otherwise we can lose subject reduction.
+    unlessNull (freeVarsRhs VarSet.\\ neverSingPatVars) warnUnsafeVars
 
-        reportSDoc "rewriting" 10 $ vcat
-          [ "checked rewrite rule" , prettyTCM rew ]
-        reportSDoc "rewriting" 90 $ vcat
-          [ "checked rewrite rule" , text (show rew) ]
+    top <- fromMaybe __IMPOSSIBLE__ <$> currentTopLevelModule
+    let rew = RewriteRule rewGamma f ps rhs b
 
-        return rew
+    reportSDoc "rewriting" 10 $ vcat
+      [ "checked rewrite rule" , prettyTCM rew ]
+    reportSDoc "rewriting" 90 $ vcat
+      [ "checked rewrite rule" , text (show rew) ]
 
-    _ -> illegalRule DoesNotTargetRewriteRelation
-
+    return rew
   where
-    unsafeRule :: IllegalRewriteRuleReason -> MaybeT TCM ()
-    unsafeRule reason = lift $ warning $ IllegalRewriteRule q reason
+    ifNotAlreadyAdded ::
+         RewriteSource -> RewriteHead -> MaybeT TCM RewriteRule
+      -> MaybeT TCM RewriteRule
+    ifNotAlreadyAdded (GlobalRewrite def) (RewDefHead f) cont = do
+      rews <- getGlobalRewriteRulesFor f
+      -- check if q is already an added rewrite rule
+      case List.find ((defName def ==) . grName) rews of
+        Just rew -> illegalRule (GlobalRewrite def) DuplicateRewriteRule
+        Nothing -> cont
+    ifNotAlreadyAdded (GlobalRewrite def) (RewVarHead x) cont = __IMPOSSIBLE__
+    ifNotAlreadyAdded (LocalRewrite _ _ _) f cont = cont
 
-    illegalRule :: IllegalRewriteRuleReason -> MaybeT TCM a
-    illegalRule reason = do
-      unsafeRule reason
-      mzero
-
-    checkNoLhsReduction :: QName -> (Elims -> Term) -> Elims -> MaybeT TCM ()
-    checkNoLhsReduction f hd es = do
+    checkNoLhsReduction ::
+         Nat -> RewriteHead -> (Elims -> Term) -> Elims
+      -> MaybeT TCM ()
+    checkNoLhsReduction telStart f hd es = do
       -- Skip this check when global confluence check is enabled, as
       -- redundant rewrite rules may be required to prove confluence.
       unlessM ((== Just GlobalConfluenceCheck) . optConfluenceCheck <$> pragmaOptions) $ do
@@ -363,16 +421,19 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
           fail = do
             reportSDoc "rewriting" 20 $ "v  = " <+> text (show v)
             reportSDoc "rewriting" 20 $ "v' = " <+> text (show v')
-            illegalRule $ LHSReduces v v'
-      es' <- case v' of
-        Def f' es'   | f == f'         -> return es'
-        Con c' _ es' | f == conName c' -> return es'
+            illegalRule s $ LHSReduces v v'
+      es' <- case (f, v') of
+        (RewDefHead f, Def f' es')   | f == f'            -> return es'
+        (RewDefHead f, Con c' _ es') | f == conName c'    -> return es'
+        (RewVarHead x, Var x' es')   | x + telStart == x' -> return es'
         _                              -> fail
       unless (null es && null es') $ do
-        a   <- lift $ computeElimHeadType f es es'
-        pol <- getPolarity' CmpEq f
+        a   <- lift $ computeRewHeadType telStart f es es'
+        pol <- case f of
+          RewDefHead f -> getPolarity' CmpEq f
+          RewVarHead x -> pure []
         ok  <- lift $ dontAssignMetas $ tryConversion $
-                 compareElims pol [] a (Def f []) es es'
+                 compareElims pol [] a (headToTerm telStart f []) es es'
         unless ok fail
 
     checkAxFunOrCon :: QName -> Definition -> MaybeT TCM ()
@@ -380,7 +441,7 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
       Axiom{}        -> return ()
       def@Function{} -> do
         whenJust (maybeRight (funProjection def)) $ \proj -> case projProper proj of
-          Nothing -> illegalRule $ HeadSymbolIsProjectionLikeFunction f
+          Nothing -> illegalRule s $ HeadSymbolIsProjectionLikeFunction f
           Just{} -> __IMPOSSIBLE__
             -- Andreas, 2024-08-20
             -- A projection ought to be impossible in the head, since they are represented
@@ -390,7 +451,7 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
         whenM (isJust . optConfluenceCheck <$> pragmaOptions) $ do
           let simpleClause cl = (patternsToElims (namedClausePats cl) , clauseBody cl)
           cls <- instantiateFull $ map simpleClause $ funClauses def
-          unless (noMetas cls) $ illegalRule $ HeadSymbolContainsMetas f
+          unless (noMetas cls) $ illegalRule s $ HeadSymbolContainsMetas f
 
       Constructor{}  -> return ()
       AbstractDefn{} -> return ()
@@ -404,16 +465,7 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
       GeneralizableVar{} -> __IMPOSSIBLE__
 
       where
-      illegalHead = illegalRule $ HeadSymbolIsTypeConstructor f
-
-    ifNotAlreadyAdded ::
-      QName -> MaybeT TCM GlobalRewriteRule -> MaybeT TCM GlobalRewriteRule
-    ifNotAlreadyAdded f cont = do
-      rews <- getGlobalRewriteRulesFor f
-      -- check if q is already an added rewrite rule
-      case List.find ((q ==) . grName) rews of
-        Just rew -> illegalRule DuplicateRewriteRule
-        Nothing -> cont
+        illegalHead = illegalRule s $ HeadSymbolIsTypeConstructor f
 
     usedArgs :: Definition -> VarSet
     usedArgs def = VarSet.fromList $ map snd $ usedIxs
@@ -436,19 +488,23 @@ checkRewriteRule q = runMaybeT $ setCurrentRange q do
           _        -> errorNotGeneral
 
         errorNotGeneral :: MaybeT TCM a
-        errorNotGeneral =
-          illegalRule $ ConstructorParametersNotGeneral c $ fromMaybe __IMPOSSIBLE__ $ nonEmpty vs
+        errorNotGeneral = illegalRule s $ ConstructorParametersNotGeneral c $
+          fromMaybe __IMPOSSIBLE__ $ nonEmpty vs
+
+checkRewConstraint :: LocalEquation -> TCM ()
+checkRewConstraint
+  eq@(LocalEquation {lEqContext = g, lEqLHS = l, lEqRHS = r, lEqType = t}) = do
+  c <- viewTC eCall
+  traceCall (CheckLocalRewriteConstraint eq c) $ addContext g $ equalTerm t l r
 
 -- | @rewriteWith t f es rew@ where @f : t@
 --   tries to rewrite @f es@ with @rew@, returning the reduct if successful.
 rewriteWith :: Type
             -> (Elims -> Term)
-            -> GlobalRewriteRule
+            -> RewriteRule
             -> Elims
             -> ReduceM (Either (Blocked Term) Term)
-rewriteWith t hd rew@(GlobalRewriteRule q gamma _ ps rhs b isClause _) es
- | isClause = return $ Left $ NotBlocked ReallyNotBlocked $ hd es
- | otherwise = do
+rewriteWith t hd rew@(RewriteRule gamma _ ps rhs b) es = do
   traceSDoc "rewriting.rewrite" 50 (sep
     [ "{ attempting to rewrite term " <+> prettyTCM (hd es)
     , " having head " <+> prettyTCM (hd []) <+> " of type " <+> prettyTCM t
@@ -474,18 +530,18 @@ rewriteWith t hd rew@(GlobalRewriteRule q gamma _ ps rhs b isClause _) es
 -- | @rewrite b v rules es@ tries to rewrite @v@ applied to @es@ with the
 --   rewrite rules @rules@. @b@ is the default blocking tag.
 rewrite ::
-     Blocked_ -> (Elims -> Term) -> GlobalRewriteRules -> Elims
+     Blocked_ -> (Elims -> Term) -> RewriteRules -> Elims
   -> ReduceM (Reduced (Blocked Term) Term)
 rewrite block hd rules es = do
-  rewritingAllowed <- optRewriting <$> pragmaOptions
+  rewritingAllowed <- anyRewritingOption
   if (rewritingAllowed && not (null rules)) then do
-    (_ , t) <- fromMaybe __IMPOSSIBLE__ <$> getTypedHead (hd [])
+    (_ , t) <- fromMaybe __IMPOSSIBLE__ <$> getLocalHeadType (hd [])
     loop block t rules es
   else
     return $ NoReduction (block $> hd es)
   where
     loop ::
-         Blocked_ -> Type -> GlobalRewriteRules -> Elims
+         Blocked_ -> Type -> RewriteRules -> Elims
       -> ReduceM (Reduced (Blocked Term) Term)
     loop block t [] es =
       traceSDoc "rewriting.rewrite" 20 (sep
@@ -503,5 +559,4 @@ rewrite block hd rules es = do
             Right w               -> return $ YesReduction YesSimplification $ w `applyE` es2
      | otherwise = loop (block `mappend` NotBlocked Underapplied ()) t rews es
 
-    rewArity :: GlobalRewriteRule -> Int
-    rewArity = length . grPats
+    rewArity = length . rewPats

--- a/src/full/Agda/TypeChecking/Rewriting.hs-boot
+++ b/src/full/Agda/TypeChecking/Rewriting.hs-boot
@@ -6,4 +6,4 @@ import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad.Base
 
 verifyBuiltinRewrite :: Term -> Type -> TCM ()
-rewrite :: Blocked_ -> (Elims -> Term) -> RewriteRules -> Elims -> ReduceM (Reduced (Blocked Term) Term)
+rewrite :: Blocked_ -> (Elims -> Term) -> GlobalRewriteRules -> Elims -> ReduceM (Reduced (Blocked Term) Term)

--- a/src/full/Agda/TypeChecking/Rewriting.hs-boot
+++ b/src/full/Agda/TypeChecking/Rewriting.hs-boot
@@ -6,4 +6,5 @@ import Agda.Syntax.Internal
 import Agda.TypeChecking.Monad.Base
 
 verifyBuiltinRewrite :: Term -> Type -> TCM ()
-rewrite :: Blocked_ -> (Elims -> Term) -> GlobalRewriteRules -> Elims -> ReduceM (Reduced (Blocked Term) Term)
+rewrite :: Blocked_ -> (Elims -> Term) -> RewriteRules -> Elims -> ReduceM (Reduced (Blocked Term) Term)
+checkRewConstraint :: LocalEquation -> TCM ()

--- a/src/full/Agda/TypeChecking/Rewriting/Clause.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Clause.hs
@@ -23,7 +23,8 @@ import Agda.Syntax.Common.Pretty
 {-# INLINABLE getClausesAsRewriteRules #-}
 -- | Get all the clauses of a definition and convert them to rewrite
 --   rules.
-getClausesAsRewriteRules :: (HasConstInfo m, ReadTCState m, MonadFresh NameId m) => QName -> m [RewriteRule]
+getClausesAsRewriteRules :: (HasConstInfo m, ReadTCState m, MonadFresh NameId m)
+  => QName -> m [GlobalRewriteRule]
 getClausesAsRewriteRules f = do
   cls <- defClauses <$> getConstInfo f
   forMaybeM (zip [1..] cls) $ \(i,cl) -> do
@@ -43,19 +44,19 @@ clauseQName f i = QName (qnameModule f) <$> clauseName (qnameName f) i
 --   if @clauseBody cl@ is @Nothing@. Precondition: @clauseType cl@ is
 --   not @Nothing@.
 clauseToRewriteRule :: (MonadTCEnv m, ReadTCState m)
-  => QName -> QName -> Clause -> m (Maybe RewriteRule)
+  => QName -> QName -> Clause -> m (Maybe GlobalRewriteRule)
 clauseToRewriteRule f q cl | hasDefP (namedClausePats cl) = return  Nothing
 clauseToRewriteRule f q cl = do
   top <- fromMaybe __IMPOSSIBLE__ <$> currentTopLevelModule
-  return $ clauseBody cl <&> \rhs -> RewriteRule
-    { rewName    = q
-    , rewContext = clauseTel cl
-    , rewHead    = f
-    , rewPats    = toNLPat $ namedClausePats cl
-    , rewRHS     = rhs
-    , rewType    = unArg $ fromMaybe __IMPOSSIBLE__  $ clauseType cl
-    , rewFromClause = True
-    , rewTopModule  = top
+  return $ clauseBody cl <&> \rhs -> GlobalRewriteRule
+    { grName    = q
+    , grContext = clauseTel cl
+    , grHead    = f
+    , grPats    = toNLPat $ namedClausePats cl
+    , grRHS     = rhs
+    , grType    = unArg $ fromMaybe __IMPOSSIBLE__  $ clauseType cl
+    , grFromClause = True
+    , grTopModule  = top
     }
 
 class ToNLPat a b where

--- a/src/full/Agda/TypeChecking/Rewriting/Clause.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Clause.hs
@@ -49,12 +49,12 @@ clauseToRewriteRule f q cl | hasDefP (namedClausePats cl) = return  Nothing
 clauseToRewriteRule f q cl = do
   top <- fromMaybe __IMPOSSIBLE__ <$> currentTopLevelModule
   return $ clauseBody cl <&> \rhs -> GlobalRewriteRule
-    { grName    = q
-    , grContext = clauseTel cl
-    , grHead    = f
-    , grPats    = toNLPat $ namedClausePats cl
-    , grRHS     = rhs
-    , grType    = unArg $ fromMaybe __IMPOSSIBLE__  $ clauseType cl
+    { grName       = q
+    , grContext    = clauseTel cl
+    , grHead       = f
+    , grPats       = toNLPat $ namedClausePats cl
+    , grRHS        = rhs
+    , grType       = unArg $ fromMaybe __IMPOSSIBLE__  $ clauseType cl
     , grFromClause = True
     , grTopModule  = top
     }

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -97,48 +97,48 @@ checkConfluenceOfClauses :: ConfluenceCheck -> QName -> TCM ()
 checkConfluenceOfClauses confChk f = do
   rews <- getClausesAsRewriteRules f
   let noMetasInPats rew
-        | noMetas (rewPats rew) = return True
+        | noMetas (grPats rew) = return True
         | otherwise             = False <$ do warning $ ConfluenceCheckingIncompleteBecauseOfMeta f
   rews <- filterM noMetasInPats rews
   let matchables = map getMatchables rews
   reportSDoc "rewriting.confluence" 30 $
     "Function" <+> prettyTCM f <+> "has matchable symbols" <+> prettyList_ (map prettyTCM matchables)
   modifySignature $ setMatchableSymbols f $ concat matchables
-  let hasRules g = not . null <$> getRewriteRulesFor g
+  let hasRules g = not . null <$> getGlobalRewriteRulesFor g
   forM_ (zip rews matchables) $ \(rew,ms) ->
     unlessNullM (filterM hasRules ms) $ \_ -> do
       checkConfluenceOfRules confChk [rew]
 
 -- | Check confluence of the given rewrite rules wrt all other rewrite
 --   rules (also amongst themselves).
-checkConfluenceOfRules :: ConfluenceCheck -> [RewriteRule] -> TCM ()
+checkConfluenceOfRules :: ConfluenceCheck -> [GlobalRewriteRule] -> TCM ()
 checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
 
   -- Global confluence: we need to check the triangle property for each rewrite
   -- rule of each head symbol as well as rules that match on them
   when (confChk == GlobalConfluenceCheck) $ do
-    let getSymbols rew = let f = rewHead rew in
+    let getSymbols rew = let f = grHead rew in
          (Set.insert f) . defMatchable <$> getConstInfo f
     allSymbols <- Set.toList . Set.unions <$> traverse getSymbols rews
     forM_ allSymbols $ \f -> do
       rewsf <- getAllRulesFor f
       forM_ rewsf $ \rew -> do
         reportSDoc "rewriting.confluence.triangle" 10 $
-          "(re)checking triangle property for rule" <+> prettyTCM (rewName rew)
+          "(re)checking triangle property for rule" <+> prettyTCM (grName rew)
         checkTrianglePropertyForRule rew
 
   forM_ (tails rews) $ listCase (return ()) $ \rew rewsRest -> do
 
   reportSDoc "rewriting.confluence" 10 $
-    "Checking confluence of rule" <+> prettyTCM (rewName rew)
+    "Checking confluence of rule" <+> prettyTCM (grName rew)
   reportSDoc "rewriting.confluence" 30 $
     "Checking confluence of rule" <+> prettyTCM rew
 
-  let f   = rewHead rew
-      qs  = rewPats rew
-      tel = rewContext rew
+  let f   = grHead rew
+      qs  = grPats rew
+      tel = grContext rew
   def <- getConstInfo f
-  (fa , hdf) <- addContext tel $ makeHead def (rewType rew)
+  (fa , hdf) <- addContext tel $ makeHead def (grType rew)
 
   reportSDoc "rewriting.confluence" 30 $ addContext tel $
     "Head symbol" <+> prettyTCM (hdf []) <+> "of rewrite rule has type" <+> prettyTCM fa
@@ -146,9 +146,10 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
   -- Step 1: check other rewrite rules that overlap at top position
   forMM_ (getAllRulesFor f) $ \ rew' -> do
     unless (any (sameRuleName rew') (rew:rewsRest) ||
-            (rewFromClause rew && rewFromClause rew')) $
+            (grFromClause rew && grFromClause rew')) $
       checkConfluenceTop hdf rew rew'
-  reportSDoc "rewriting.confluence" 30 $ "Finished step 1 of confluence check of rule" <+> prettyTCM (rewName rew)
+  reportSDoc "rewriting.confluence" 30 $
+    "Finished step 1 of confluence check of rule" <+> prettyTCM (grName rew)
 
   -- Step 2: check other rewrite rules that overlap with a subpattern
   -- of this rewrite rule
@@ -162,7 +163,8 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
     forM_ rews' $ \rew' -> do
       unless (any (sameRuleName rew') rewsRest) $
         checkConfluenceSub hdf hdg rew rew' hole
-  reportSDoc "rewriting.confluence" 30 $ "Finished step 2 of confluence check of rule" <+> prettyTCM (rewName rew)
+  reportSDoc "rewriting.confluence" 30 $
+    "Finished step 2 of confluence check of rule" <+> prettyTCM (grName rew)
 
   -- Step 3: check other rewrite rules that have a subpattern which
   -- overlaps with this rewrite rule
@@ -171,39 +173,41 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
       "Symbol" <+> prettyTCM g <+> "has rules that match on" <+> prettyTCM f
     forMM_ (getAllRulesFor g) $ \ rew' -> do
       unless (any (sameRuleName rew') rewsRest) $ do
-        es' <- nlPatToTerm (rewPats rew')
-        let tel' = rewContext rew'
+        es' <- nlPatToTerm (grPats rew')
+        let tel' = grContext rew'
         def' <- getConstInfo g
-        (ga , hdg) <- addContext tel' $ makeHead def' (rewType rew')
+        (ga , hdg) <- addContext tel' $ makeHead def' (grType rew')
         forMM_ (addContext tel' $ allHolesList (ga , hdg) es') $ \ hole -> do
           let f' = ohHeadName hole
           when (f == f') $ checkConfluenceSub hdg hdf rew' rew hole
-  reportSDoc "rewriting.confluence" 30 $ "Finished step 3 of confluence check of rule" <+> prettyTCM (rewName rew)
+  reportSDoc "rewriting.confluence" 30 $
+    "Finished step 3 of confluence check of rule" <+> prettyTCM (grName rew)
 
   where
 
     -- Check confluence of two rewrite rules that have the same head symbol,
     -- e.g. @f ps --> a@ and @f ps' --> b@.
-    checkConfluenceTop :: (Elims -> Term) -> RewriteRule -> RewriteRule -> TCM ()
+    checkConfluenceTop ::
+      (Elims -> Term) -> GlobalRewriteRule -> GlobalRewriteRule -> TCM ()
     checkConfluenceTop hd rew1 rew2 =
-      traceCall (CheckConfluence (rewName rew1) (rewName rew2)) $
+      traceCall (CheckConfluence (grName rew1) (grName rew2)) $
       localTCStateSavingWarnings $ do
 
-        sub1 <- makeMetaSubst $ rewContext rew1
-        sub2 <- makeMetaSubst $ rewContext rew2
+        sub1 <- makeMetaSubst $ grContext rew1
+        sub2 <- makeMetaSubst $ grContext rew2
 
-        let f    = rewHead rew1 -- == rewHead rew2
-            a1   = applySubst sub1 $ rewType rew1
-            a2   = applySubst sub2 $ rewType rew2
+        let f    = grHead rew1 -- == grHead rew2
+            a1   = applySubst sub1 $ grType rew1
+            a2   = applySubst sub2 $ grType rew2
 
-        es1 <- applySubst sub1 <$> nlPatToTerm (rewPats rew1)
-        es2 <- applySubst sub2 <$> nlPatToTerm (rewPats rew2)
+        es1 <- applySubst sub1 <$> nlPatToTerm (grPats rew1)
+        es2 <- applySubst sub2 <$> nlPatToTerm (grPats rew2)
 
         reportSDoc "rewriting.confluence" 30 $ vcat
-          [ "checkConfluenceTop" <+> prettyTCM (rewName rew1) <+> prettyTCM (rewName rew2)
+          [ "checkConfluenceTop" <+> prettyTCM (grName rew1) <+> prettyTCM (grName rew2)
           , "  f    = " <+> prettyTCM f
-          , "  ctx1 = " <+> prettyTCM (rewContext rew1)
-          , "  ctx2 = " <+> prettyTCM (rewContext rew2)
+          , "  ctx1 = " <+> prettyTCM (grContext rew1)
+          , "  ctx2 = " <+> prettyTCM (grContext rew2)
           , "  es1  = " <+> prettyTCM es1
           , "  es2  = " <+> prettyTCM es2
           ]
@@ -238,8 +242,8 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
           -- Get the rhs of both rewrite rules (after unification). In
           -- case of different arities, add additional arguments from
           -- one side to the other side.
-          let rhs1 = applySubst sub1 (rewRHS rew1) `applyE` es2r
-              rhs2 = applySubst sub2 (rewRHS rew2) `applyE` es1r
+          let rhs1 = applySubst sub1 (grRHS rew1) `applyE` es2r
+              rhs2 = applySubst sub2 (grRHS rew2) `applyE` es1r
 
           return (rhs1 , rhs2)
 
@@ -247,23 +251,27 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
 
     -- Check confluence between two rules that overlap at a subpattern,
     -- e.g. @f ps[g qs] --> a@ and @g qs' --> b@.
-    checkConfluenceSub :: (Elims -> Term) -> (Elims -> Term) -> RewriteRule -> RewriteRule -> OneHole Elims -> TCM ()
+    checkConfluenceSub ::
+         (Elims -> Term) -> (Elims -> Term)
+      -> GlobalRewriteRule -> GlobalRewriteRule -> OneHole Elims -> TCM ()
     checkConfluenceSub hdf hdg rew1 rew2 hole0 = do
-      reportSDoc "rewriting.confluence" 100 $ "foo 2" <+> prettyTCM (rewName rew1) <+> prettyTCM (rewName rew2)
-      traceCall (CheckConfluence (rewName rew1) (rewName rew2)) $ localTCStateSavingWarnings $ do
+      reportSDoc "rewriting.confluence" 100 $
+        "foo 2" <+> prettyTCM (grName rew1) <+> prettyTCM (grName rew2)
+      traceCall (CheckConfluence (grName rew1) (grName rew2)) $
+        localTCStateSavingWarnings $ do
 
         reportSDoc "rewriting.confluence" 20 $
-          "Checking confluence of rules" <+> prettyTCM (rewName rew1) <+>
-          "and" <+> prettyTCM (rewName rew2) <+> "at subpattern position"
+          "Checking confluence of rules" <+> prettyTCM (grName rew1) <+>
+          "and" <+> prettyTCM (grName rew2) <+> "at subpattern position"
 
-        sub1 <- makeMetaSubst $ rewContext rew1
+        sub1 <- makeMetaSubst $ grContext rew1
 
         let bvTel0     = ohBoundVars hole0
             k          = size bvTel0
             b0         = applySubst (liftS k sub1) $ ohType hole0
             g          = ohHeadName hole0
             es0        = applySubst (liftS k sub1) $ ohElims hole0
-            qs2        = rewPats rew2
+            qs2        = grPats rew2
 
         -- TODO: support IApply in forceEtaExpansion
         let isIApply IApply{} = True
@@ -286,15 +294,15 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
             ]
 
         let hole      = hole1 `composeHole` hole0
-            g         = ohHeadName hole -- == rewHead rew2
+            g         = ohHeadName hole -- == grHead rew2
             es'       = ohElims hole
             bvTel     = ohBoundVars hole
             plug      = ohPlugHole hole
 
-        sub2 <- addContext bvTel $ makeMetaSubst $ rewContext rew2
+        sub2 <- addContext bvTel $ makeMetaSubst $ grContext rew2
 
         let es1 = applySubst (liftS (size bvTel) sub1) es'
-        es2 <- applySubst sub2 <$> nlPatToTerm (rewPats rew2)
+        es2 <- applySubst sub2 <$> nlPatToTerm (grPats rew2)
 
         -- Make sure we are comparing eliminations with the same arity
         -- (see #3810). Because we forced eta-expansion of es1, we
@@ -305,7 +313,7 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
 
         let lhs1 = applySubst sub1 $ hdf $ plug $ hdg es1
             lhs2 = applySubst sub1 $ hdf $ plug $ hdg $ es2 ++ es1r
-            a    = applySubst sub1 $ rewType rew1
+            a    = applySubst sub1 $ grType rew1
 
         reportSDoc "rewriting.confluence" 20 $ sep
           [ "Considering potential critical pair at subpattern: "
@@ -322,11 +330,11 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
             compareElims gpol [] ga (hdg []) es1' es2
 
           -- Right-hand side of first rewrite rule (after unification)
-          let rhs1 = applySubst sub1 $ rewRHS rew1
+          let rhs1 = applySubst sub1 $ grRHS rew1
 
           -- Left-hand side of first rewrite rule, with subpattern
           -- rewritten by the second rewrite rule
-          let w = applySubst sub2 (rewRHS rew2) `applyE` es1r
+          let w = applySubst sub2 (grRHS rew2) `applyE` es1r
           reportSDoc "rewriting.confluence" 30 $ sep
             [ "Plugging hole with w = "
             , nest 2 $ addContext bvTel $ prettyTCM w
@@ -386,8 +394,8 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
         GlobalConfluenceCheck -> do
           (f, t) <- fromMaybe __IMPOSSIBLE__ <$> getTypedHead (hd [])
 
-          let checkEqualLHS :: RewriteRule -> TCM Bool
-              checkEqualLHS (RewriteRule q delta _ ps _ _ _ _) = do
+          let checkEqualLHS :: GlobalRewriteRule -> TCM Bool
+              checkEqualLHS (GlobalRewriteRule q delta _ ps _ _ _ _) = do
                 onlyReduceTypes (nonLinMatch delta (t , hd) ps es) >>= \case
                   Left _    -> return False
                   Right sub -> do
@@ -413,13 +421,17 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
           unlessM (sameRHS `or2M` anyM checkEqualLHS rews) $ addContext gamma $
             warning $ RewriteAmbiguousRules (hd es) rhs1 rhs2
 
-    checkTrianglePropertyForRule :: RewriteRule -> TCM ()
-    checkTrianglePropertyForRule (RewriteRule q gamma f ps rhs b c _) = addContext gamma $ do
+    checkTrianglePropertyForRule :: GlobalRewriteRule -> TCM ()
+    checkTrianglePropertyForRule (GlobalRewriteRule q gamma f ps rhs b c _) =
+      addContext gamma $ do
+
       u  <- nlPatToTerm $ PDef f ps
       -- First element in the list is the "best reduct" @ρ(u)@
       (rhou,vs) <- fromMaybe __IMPOSSIBLE__ . uncons <$> allParallelReductions u
-      reportSDoc "rewriting.confluence" 40 $ ("rho(" <> prettyTCM u <> ") =") <+> prettyTCM rhou
-      reportSDoc "rewriting.confluence" 40 $ ("S(" <> prettyTCM u <> ") =") <+> prettyList_ (map prettyTCM vs)
+      reportSDoc "rewriting.confluence" 40 $
+        ("rho(" <> prettyTCM u <> ") =") <+> prettyTCM rhou
+      reportSDoc "rewriting.confluence" 40 $
+        ("S(" <> prettyTCM u <> ") =") <+> prettyList_ (map prettyTCM vs)
       -- If present, last element is always equal to u
       caseMaybe (initLast vs) (return ()) $ \(vs',u') -> do
         unless (u == u') __IMPOSSIBLE__
@@ -449,31 +461,33 @@ sortRulesOfSymbol f = do
     -- we replicate the old (unhygienic) approach to rewrite rule scoping
     -- here to avoid a regression.
     -- See also #7969 for a reason why the code below is questionable.
-    rules <- sortRules =<< getFilteredRewriteRulesFor False f
+    rules <- sortRules =<< getFilteredGlobalRewriteRulesFor False f
     modifySignature $ over sigRewriteRules $ HMap.insert f rules
   where
-    sortRules :: PureTCM m => [RewriteRule] -> m [RewriteRule]
+    sortRules :: PureTCM m => [GlobalRewriteRule] -> m [GlobalRewriteRule]
     sortRules rs = do
-      ordPairs <- deleteLoops . Set.fromList . map (rewName *** rewName) <$>
+      ordPairs <- deleteLoops . Set.fromList . map (grName *** grName) <$>
         filterM (uncurry $ flip moreGeneralLHS) [(r1,r2) | r1 <- rs, r2 <- rs]
       let perm = fromMaybe __IMPOSSIBLE__ $
-                   topoSort (\r1 r2 -> (rewName r1,rewName r2) `Set.member` ordPairs) rs
+                   topoSort (\r1 r2 -> (grName r1,grName r2) `Set.member` ordPairs) rs
       reportSDoc "rewriting.confluence.sort" 50 $ "sorted rules: " <+>
-        prettyList_ (map (prettyTCM . rewName) $ permute perm rs)
+        prettyList_ (map (prettyTCM . grName) $ permute perm rs)
       return $ permute perm rs
 
-    moreGeneralLHS :: PureTCM m => RewriteRule -> RewriteRule -> m Bool
+    moreGeneralLHS :: PureTCM m
+      => GlobalRewriteRule -> GlobalRewriteRule -> m Bool
     moreGeneralLHS r1 r2
-      | sameRuleName r1 r2       = return False
-      | rewHead r1 /= rewHead r2 = return False
-      | otherwise                = addContext (rewContext r2) $ do
-          def <- getConstInfo $ rewHead r1
-          (t, hd) <- makeHead def (rewType r2)
-          (vs :: Elims) <- nlPatToTerm $ rewPats r2
-          res <- isRight <$> onlyReduceTypes (nonLinMatch (rewContext r1) (t, hd) (rewPats r1) vs)
+      | sameRuleName r1 r2     = return False
+      | grHead r1 /= grHead r2 = return False
+      | otherwise              = addContext (grContext r2) $ do
+          def <- getConstInfo $ grHead r1
+          (t, hd) <- makeHead def (grType r2)
+          (vs :: Elims) <- nlPatToTerm $ grPats r2
+          res <- isRight <$> onlyReduceTypes
+            (nonLinMatch (grContext r1) (t, hd) (grPats r1) vs)
           when res $ reportSDoc "rewriting.confluence.sort" 55 $
-            "the lhs of " <+> prettyTCM (rewName r1) <+>
-            "is more general than the lhs of" <+> prettyTCM (rewName r2)
+            "the lhs of " <+> prettyTCM (grName r1) <+>
+            "is more general than the lhs of" <+> prettyTCM (grName r2)
           return res
 
     deleteLoops :: Ord a => Set (a,a) -> Set (a,a)
@@ -499,12 +513,14 @@ makeHead def a = case theDef def of
     return (ftype , Def f)
   _ -> return (defType def , Def $ defName def)
 
-sameRuleName :: RewriteRule -> RewriteRule -> Bool
-sameRuleName = (==) `on` rewName
+sameRuleName :: GlobalRewriteRule -> GlobalRewriteRule -> Bool
+sameRuleName = (==) `on` grName
 
 -- | Get both clauses and rewrite rules for the given symbol
-getAllRulesFor :: (HasConstInfo m, ReadTCState m, MonadFresh NameId m) => QName -> m [RewriteRule]
-getAllRulesFor f = (++) <$> getRewriteRulesFor f <*> getClausesAsRewriteRules f
+getAllRulesFor :: (HasConstInfo m, ReadTCState m, MonadFresh NameId m)
+  => QName -> m [GlobalRewriteRule]
+getAllRulesFor f =
+  (++) <$> getGlobalRewriteRulesFor f <*> getClausesAsRewriteRules f
 
 -- | Build a substitution that replaces all variables in the given
 --   telescope by fresh metavariables.
@@ -567,7 +583,7 @@ topLevelReductions hd es = do
   -- Get type of head symbol
   (f , t) <- fromMaybe __IMPOSSIBLE__ <$> getTypedHead (hd [])
   reportSDoc "rewriting.parreduce" 60 $ "topLevelReductions: head symbol" <+> prettyTCM (hd []) <+> ":" <+> prettyTCM t
-  RewriteRule q gamma _ ps rhs b c _ <- scatterMP (getAllRulesFor f)
+  GlobalRewriteRule q gamma _ ps rhs b c _ <- scatterMP (getAllRulesFor f)
   reportSDoc "rewriting.parreduce" 60 $ "topLevelReductions: trying rule" <+> prettyTCM q
   -- Don't reduce if underapplied
   guard $ length es >= length ps

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -373,9 +373,18 @@ instance Match NLPat Term where
       PSort ps -> case v of
         Sort s -> match r gamma k () ps s
         v -> maybeBlock v
-      PBoundVar i ps -> case v of
-        Var i' es | i == i' -> do
-          let ti = maybe __IMPOSSIBLE__ (unDom . ctxEntryDom) $ lookupBV_ i k
+      PBoundVar i ps -> traceSDoc "rewriting.match" 60
+          ("Matching a PBoundVar" <+> addContext gamma (addContext k $
+            prettyTCM $ PBoundVar i ps) <+> "with" <+>
+            (addContext k $ prettyTCM v)) $ case v of
+        -- Either we are matching a higher order bound variable in k or we
+        -- are matching a locally bound variable outside gamma
+        -- (gamma is the rewrite telescope - i.e. the telescope of pattern
+        -- variables which are in scope in the pattern but not in the term we
+        -- matching against)
+        Var i' es |  (i < size k && i == i')
+                  || (i >= size k && i == i' + size gamma) -> do
+          ti <- addContext gamma $ addContext k $ typeOfBV i
           match r gamma k (ti , Var i) ps es
         _ | Pi a b <- unEl t -> do
           let ai    = domInfo a
@@ -452,9 +461,20 @@ equal a u v = pureEqualTermB a u v >>= \case
 
 -- | Utility function for getting the name and type of a head term (i.e. a
 --   `Def` or `Con` with no arguments)
+--   Fails on variable heads
 getTypedHead :: PureTCM m => Term -> m (Maybe (QName, Type))
-getTypedHead = \case
-  Def f []   -> Just . (f,) . defType <$> getConstInfo f
+getTypedHead x = do
+  t <- getLocalHeadType x
+  case t of
+    Just (Just f,  t) -> pure $ Just (f, t)
+    Just (Nothing, t) -> pure Nothing
+    Nothing           -> pure Nothing
+
+-- | Utility function for getting the type of a head term. Includes a case
+--   for variables (which are valid heads of local rewrite rules)
+getLocalHeadType :: PureTCM m => Term -> m (Maybe (Maybe QName, Type))
+getLocalHeadType =  \case
+  Def f []   -> Just . (Just f,) . defType <$> getConstInfo f
   Con (ConHead { conName = c }) _ [] -> do
     -- Andreas, 2018-09-08, issue #3211:
     -- discount module parameters for constructor heads
@@ -466,6 +486,10 @@ getTypedHead = \case
         let ws = replicate (npars - size vs) $ defaultArg __DUMMY_TERM__
         t0 <- defType <$> getConstInfo c
         t <- t0 `piApplyM` (vs ++ ws)
-        return $ Just (c , t)
-      Nothing -> return Nothing
-  _ -> return Nothing
+        return $ Just (Just c , t)
+      Nothing -> pure Nothing
+  Var x [] -> do
+    t <- domOfBV x
+    pure $ Just (Nothing, unDom t)
+  _ -> pure Nothing
+

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -354,8 +354,8 @@ instance GetMatchables NLPSort where
 instance GetMatchables Term where
   getMatchables = getDefs' __IMPOSSIBLE__ singleton
 
-instance GetMatchables RewriteRule where
-  getMatchables = getMatchables . rewPats
+instance GetMatchables GlobalRewriteRule where
+  getMatchables = getMatchables . grPats
 
 -- Throws a pattern violation if the given term contains any
 -- metavariables.

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinPattern.hs
@@ -16,7 +16,7 @@ import Agda.Syntax.Internal.Defs
 import Agda.Syntax.Internal.MetaVars ( AllMetas, unblockOnAllMetasIn )
 
 import Agda.TypeChecking.Datatypes
-import Agda.TypeChecking.Irrelevance ( isDefSing )
+import Agda.TypeChecking.Irrelevance ( isDefSing, isPatternVar )
 import Agda.TypeChecking.Level
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Pretty
@@ -43,56 +43,59 @@ import Data.Foldable (Foldable(fold))
 --   definitionally singular. Specifically, the first tracks the definitional
 --   singularity of the last |PDef|/|PBoundVar| match, while the second tracks
 --   the current definitional singularity.
---   The third argument is the number of bound variables (from pattern lambdas).
---   The fourth argument is the type of the term.
+--   The third argument and fourth arguments, k0 and k1, partition the context
+--   into three chunks: the local context, the telescope of
+--   of pattern variables associated with the rewrite and the pattern-lambda
+--   bound variables.
+--   The fifth argument is the type of the term.
 
 class PatternFrom a b where
-  patternFrom :: DefSing -> DefSing -> Int -> TypeOf a -> a -> TCM b
+  patternFrom :: DefSing -> DefSing -> Int -> Int -> TypeOf a -> a -> TCM b
 
 instance (PatternFrom a b) => PatternFrom (Arg a) (Arg b) where
-  patternFrom r0 r1 k t u
+  patternFrom r0 r1 k0 k1 t u
     = let r1' = r1 `maxDefSing` relToDefSing (getRelevance u)
-      in  traverse (patternFrom r0 r1' k $ unDom t) u
+      in  traverse (patternFrom r0 r1' k0 k1 $ unDom t) u
 
 instance PatternFrom Elims PElims where
-  patternFrom r0 r1 k (t,hd) = \case
+  patternFrom r0 r1 k0 k1 (t,hd) = \case
     [] -> return []
     (Apply u : es) -> do
       (a, b) <- assertPi t
-      p   <- patternFrom r0 r1 k a u
+      p   <- patternFrom r0 r1 k0 k1 a u
       let t'  = absApp b (unArg u)
       let hd' = hd . (Apply u:)
-      ps  <- patternFrom r0 r1 k (t',hd') es
+      ps  <- patternFrom r0 r1 k0 k1 (t',hd') es
       return $ Apply p : ps
     (IApply x y i : es) -> do
       (s, q, l, b, u, v) <- assertPath t
       let t' = El s $ unArg b `apply` [ defaultArg i ]
       let hd' = hd . (IApply x y i:)
       interval <- primIntervalType
-      p   <- patternFrom r0 r1 k interval i
-      ps  <- patternFrom r0 r1 k (t',hd') es
+      p   <- patternFrom r0 r1 k0 k1 interval i
+      ps  <- patternFrom r0 r1 k0 k1 (t',hd') es
       return $ IApply (PTerm x) (PTerm y) p : ps
     (Proj o f : es) -> do
       (a,b) <- assertProjOf f t
       let u = hd []
           t' = b `absApp` u
       hd' <- applyDef o f (argFromDom a $> u)
-      ps  <- patternFrom r0 r1 k (t',applyE hd') es
+      ps  <- patternFrom r0 r1 k0 k1 (t',applyE hd') es
       return $ Proj o f : ps
 
 instance (PatternFrom a b) => PatternFrom (Dom a) (Dom b) where
-  patternFrom r0 r1 k t = traverse $ patternFrom r0 r1 k t
+  patternFrom r0 r1 k0 k1 t = traverse $ patternFrom r0 r1 k0 k1 t
 
 instance PatternFrom Type NLPType where
-  patternFrom r0 r1 k _ a = workOnTypes $
-    NLPType <$> patternFrom r0 r1 k () (getSort a)
-            <*> patternFrom r0 r1 k (sort $ getSort a) (unEl a)
+  patternFrom r0 r1 k0 k1 _ a = workOnTypes $
+    NLPType <$> patternFrom r0 r1 k0 k1 () (getSort a)
+            <*> patternFrom r0 r1 k0 k1 (sort $ getSort a) (unEl a)
 
 instance PatternFrom Sort NLPSort where
-  patternFrom r0 r1 k _ s = do
+  patternFrom r0 r1 k0 k1 _ s = do
     s <- abortIfBlocked s
     case s of
-      Univ u l -> PUniv u <$> patternFrom r0 r1 k () l
+      Univ u l -> PUniv u <$> patternFrom r0 r1 k0 k1 () l
       Inf u n  -> return $ PInf u n
       SizeUniv -> return PSizeUniv
       LockUniv -> return PLockUniv
@@ -111,16 +114,16 @@ instance PatternFrom Sort NLPSort where
         __IMPOSSIBLE__
 
 instance PatternFrom Level NLPat where
-  patternFrom r0 r1 k _ l = do
+  patternFrom r0 r1 k0 k1 _ l = do
     t <- levelType
     v <- reallyUnLevelView l
-    patternFrom r0 r1 k t v
+    patternFrom r0 r1 k0 k1 t v
 
 instance PatternFrom Term NLPat where
-  patternFrom r0 r1 k t v = do
+  patternFrom r0 r1 k0 k1 t v = do
     t <- abortIfBlocked t
     etaRecord <- isEtaRecordType t
-    r1 <- maxDefSing r1 <$> isDefSing t
+    r1 <- maxDefSing r1 <$> isDefSing k0 k1 t
     v <- unLevel =<< abortIfBlocked v
     reportSDoc "rewriting.build" 60 $ sep
       [ "building a pattern from term v = " <+> prettyTCM v
@@ -131,16 +134,18 @@ instance PatternFrom Term NLPat where
     case (unEl t , stripDontCare v) of
       (Pi a b , _) -> do
         let body = raise 1 v `apply` [ Arg (domInfo a) $ var 0 ]
-        p <- addContext a (patternFrom r0 r1 (k + 1) (absBody b) body)
+        p <- addContext a (patternFrom r0 r1 (k0 + 1) (k1 + 1) (absBody b) body)
         return $ PLam (domInfo a) $ Abs (absName b) p
       _ | Left ((a,b),(x,y)) <- pview t -> do
         let body = raise 1 v `applyE` [ IApply (raise 1 $ x) (raise 1 $ y) $ var 0 ]
-        p <- addContext a (patternFrom r0 r1 (k + 1) (absBody b) body)
+        p <- addContext a (patternFrom r0 r1 (k0 + 1) (k1 + 1) (absBody b) body)
         return $ PLam (domInfo a) $ Abs (absName b) p
       (_ , Var i es)
-       | i < k     -> do
+       -- Variables before k0 are locally bound outside the rewrite telescope
+       -- Variables after k1 are bound in higher order patterns
+       | not $ isPatternVar k0 k1 i -> do
            t <- typeOfBV i
-           PBoundVar i <$> patternFrom r1 r1 k (t , Var i) es
+           PBoundVar i <$> patternFrom r1 r1 k0 k1 (t , Var i) es
        -- The arguments of `var i` should be distinct bound variables
        -- in order to build a Miller pattern
        | Just vs <- allApplyElims es -> do
@@ -150,11 +155,11 @@ instance PatternFrom Term NLPat where
            mbvs <- forM (zip ts vs) $ \(t , v) -> do
              blockOnMetasIn (v,t)
              isEtaVar (unArg v) t >>= \case
-               Just j | j < k -> return $ Just $ v $> j
-               _              -> return Nothing
+               Just j | k0 < j || j < k1 -> return $ Just $ v $> j
+               _                         -> return Nothing
            case sequence mbvs of
              Just bvs | fastDistinct bvs -> do
-               let allBoundVars = VarSet.full k
+               let allBoundVars = VarSet.full k1
                    ok = not (isAlwaysSing r1) ||
                         VarSet.fromList (map unArg bvs) == allBoundVars
                if ok then return (PVar r0 i bvs) else done
@@ -168,7 +173,7 @@ instance PatternFrom Term NLPat where
         RecordDefn def <- theDef <$> getConstInfo d
         (tel, c, ci, vs) <- etaExpandRecord_ d pars def v
         ct <- assertConOf c t
-        PDef (conName c) <$> patternFrom r1 r1 k (ct , Con c ci) (map Apply vs)
+        PDef (conName c) <$> patternFrom r1 r1 k0 k1 (ct , Con c ci) (map Apply vs)
       (_ , Lam{})   -> errNotPi t
       (_ , Lit{})   -> done
       (_ , Def f es) | isAlwaysSing r1 -> done
@@ -180,17 +185,17 @@ instance PatternFrom Term NLPat where
           [x , y] | f == lmax -> done
           _                   -> do
             ft <- defType <$> getConstInfo f
-            PDef f <$> patternFrom r1 r1 k (ft , Def f) es
+            PDef f <$> patternFrom r1 r1 k0 k1 (ft , Def f) es
       (_ , Con c ci vs) | isAlwaysSing r1 -> done
       (_ , Con c ci vs) -> do
         ct <- assertConOf c t
-        PDef (conName c) <$> patternFrom r1 r1 k (ct , Con c ci) vs
+        PDef (conName c) <$> patternFrom r1 r1 k0 k1 (ct , Con c ci) vs
       (_ , Pi a b) | isAlwaysSing r1 -> done
       (_ , Pi a b) -> do
-        pa <- patternFrom r0 r1 k () a
-        pb <- addContext a (patternFrom r0 r1 (k + 1) () $ absBody b)
+        pa <- patternFrom r0 r1 k0 k1 () a
+        pb <- addContext a (patternFrom r0 r1 (k0 + 1) (k1 + 1) () $ absBody b)
         return $ PPi pa (Abs (absName b) pb)
-      (_ , Sort s)     -> PSort <$> patternFrom r0 r1 k () s
+      (_ , Sort s)     -> PSort <$> patternFrom r0 r1 k0 k1 () s
       (_ , Level l)    -> __IMPOSSIBLE__
       (_ , DontCare{}) -> __IMPOSSIBLE__
       (_ , MetaV m _)  -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -686,89 +686,101 @@ checkArgumentsE'
             (NotCheckedTarget, False, Just sResultType) | sArgsVisible -> do
               -- How many visible Π's (up to at most sArgsLen) does
               -- sFunType start with?
-              TelV tel tgt <- telViewUpTo' sArgsLen visible sFunType
-              let visiblePis = size tel
+              tel <- runMaybeT $ safeTelViewUpTo' sArgsLen visible sFunType
+              case tel of
+                Nothing             -> do
+                  -- Telescope has invalidated @rewrite arguments in it, so we
+                  -- have to delay checking the target type
+                  -- We could make this a bit more efficient by counting the
+                  -- number of @rewrite arguments and skipping exactly that many
+                  -- args
+                  return s { sSkipCheck = Skip }
+                Just (TelV tel tgt) -> do
+                  let visiblePis = size tel
 
-                  -- The free variables less than visiblePis in tgt.
-                  freeInTgt =
-                    fst $ VarSet.split visiblePis $ freeVarSet tgt
+                      -- The free variables less than visiblePis in tgt.
+                      freeInTgt =
+                        fst $ VarSet.split visiblePis $ freeVarSet tgt
 
-              rigid <- isRigid s tgt
-              -- The target must be rigid.
-              case rigid of
-                IsNotRigid reason ->
-                      -- Skip the next visiblePis - 1 - k checks.
-                  let skip k   = s{ sSkipCheck =
-                                    SkipNext $ visiblePis - 1 - k
-                                  }
-                      dontSkip = s
-                  in return $ case reason of
-                    Permanent   -> skip 0
-                    Unspecified -> dontSkip
-                    AVar x      ->
-                      if x `VarSet.member` freeInTgt
-                      then skip x
-                      else skip 0
-                IsRigid -> do
-                  -- Andreas, 2024-03-01, issue #7158 reported by Amy.
-                  -- We need to check that the arity of the function type
-                  -- is sufficient before checking the target,
-                  -- otherwise the target is non-sensical.
-                  if visiblePis < sArgsLen then return s else do
+                  rigid <- isRigid s tgt
+                  -- The target must be rigid.
+                  case rigid of
+                    IsNotRigid reason ->
+                          -- Skip the next visiblePis - 1 - k checks.
+                      let skip k   = s{ sSkipCheck =
+                                        SkipNext $ visiblePis - 1 - k
+                                      }
+                          dontSkip = s
+                      in return $ case reason of
+                        Permanent   -> skip 0
+                        Unspecified -> dontSkip
+                        AVar x      ->
+                          if x `VarSet.member` freeInTgt
+                          then skip x
+                          else skip 0
+                    IsRigid -> do
+                      -- Andreas, 2024-03-01, issue #7158 reported by Amy.
+                      -- We need to check that the arity of the function type
+                      -- is sufficient before checking the target,
+                      -- otherwise the target is non-sensical.
+                      if visiblePis < sArgsLen then return s else do
 
-                      -- Is any free variable in tgt less than
-                      -- visiblePis?
-                  let dep = not (null freeInTgt)
-                  -- The target must be non-dependent.
-                  if dep then return s else do
+                          -- Is any free variable in tgt less than
+                          -- visiblePis?
+                      let dep = not (null freeInTgt)
+                      -- The target must be non-dependent.
+                      if dep then return s else do
 
-                  -- Andreas, 2019-03-28, issue #3248:
-                  -- If the target type is SIZELT, we need coerce, leqType is insufficient.
-                  -- For example, we have i : Size <= (Size< ↑ i), but not Size <= (Size< ↑ i).
-                  (isSizeLt, sResultType, s) <-
-                    if sSizeLtChecked
-                    then return (False, sResultType, s)
-                    else do
-                      sResultType <- reduce sResultType
-                      isSizeLt    <- isSizeType sResultType <&> \case
-                        Just (BoundedLt _) -> True
-                        _                  -> False
-                      return ( isSizeLt
-                             , sResultType
-                             , s{ sResultType    = Just sResultType
-                                , sSizeLtChecked = True
-                                , sSkipCheck     =
-                                    if isSizeLt then Skip else DontSkip
-                                }
-                             )
-                  if isSizeLt then return s else do
+                      -- Andreas, 2019-03-28, issue #3248:
+                      -- If the target type is SIZELT, we need coerce, leqType is insufficient.
+                      -- For example, we have i : Size <= (Size< ↑ i), but not Size <= (Size< ↑ i).
+                      (isSizeLt, sResultType, s) <-
+                        if sSizeLtChecked
+                        then return (False, sResultType, s)
+                        else do
+                          sResultType <- reduce sResultType
+                          isSizeLt    <- isSizeType sResultType <&> \case
+                            Just (BoundedLt _) -> True
+                            _                  -> False
+                          return ( isSizeLt
+                                , sResultType
+                                , s{ sResultType    = Just sResultType
+                                    , sSizeLtChecked = True
+                                    , sSkipCheck     =
+                                        if isSizeLt then Skip else DontSkip
+                                    }
+                                )
+                      if isSizeLt then return s else do
 
-                  let tgt1 = applySubst
-                               (strengthenS impossible visiblePis)
-                               tgt
-                  reportSDoc "tc.term.args.target" 30 $ vcat
-                    [ "Checking target types first"
-                    , nest 2 $ "inferred =" <+> prettyTCM tgt1
-                    , nest 2 $ "expected =" <+> prettyTCM sResultType ]
-                  chk <-
-                    traceCall
-                      (CheckTargetType
-                         (fuseRange sFun sArgs) tgt1 sResultType) $
-                      CheckedTarget <$>
-                        ifNoConstraints_ (compareType sComp tgt1 sResultType)
-                          (return Nothing) (return . Just)
-                  return s{ sChecked = chk }
+                      let tgt1 = applySubst
+                                  (strengthenS impossible visiblePis)
+                                  tgt
+                      reportSDoc "tc.term.args.target" 30 $ vcat
+                        [ "Checking target types first"
+                        , nest 2 $ "inferred =" <+> prettyTCM tgt1
+                        , nest 2 $ "expected =" <+> prettyTCM sResultType ]
+                      chk <-
+                        traceCall
+                          (CheckTargetType
+                            (fuseRange sFun sArgs) tgt1 sResultType) $
+                          CheckedTarget <$>
+                            ifNoConstraints_ (compareType sComp tgt1 sResultType)
+                              (return Nothing) (return . Just)
+                      return s{ sChecked = chk }
 
             _ -> return s
 
         -- sFunType <- lift $ forcePi (getHiding info)
         --                  (maybe "_" rangedThing $ nameOf e) sFunType
         case unEl sFunType of
-          Pi (Dom{domInfo = info', domName = dname, unDom = a}) b
+          Pi dom@(Dom{domInfo = info', domName = dname, unDom = a}) b
             | let name = bareNameWithDefault "_" dname,
               sameHiding info info'
               && (visible info || maybe True (name ==) mx) -> do
-                u <- lift $ applyModalityToContext info' $ do
+                whenJust (domEq dom) \eq ->
+                  reportSDoc "rewriting" 30 $
+                    "Applying equational constraint to context: " <+> prettyTCM eq
+                u <- lift $ applyDomToContext dom $ do
                  -- Andreas, 2014-05-30 experiment to check non-dependent arguments
                  -- after the spine has been processed.  Allows to propagate type info
                  -- from ascribed type into extended-lambdas.  Would solve issue 1159.

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -163,7 +163,7 @@ bindBuiltinFlat x =
     addConstant flat $
       flatDefn { defPolarity       = []
                , defArgOccurrences = [StrictPos]  -- changing that to [Mixed] destroys monotonicity of 'Rec' in test/succeed/GuardednessPreservingTypeConstructors
-               , defCopatternLHS = hasProjectionPatterns cc
+               , defCopatternLHS' = hasProjectionPatterns cc
                , theDef = FunctionDefn fun
                    { _funClauses      = [clause]
                    , _funCompiled     = Just $ cc

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -795,12 +795,7 @@ checkPragma r p = do
     traceCall (CheckPragma r p) $ case p of
         A.BuiltinPragma rb x
           | any isUntypedBuiltin b -> return ()
-          | Just b' <- b -> do
-              let go = bindBuiltin b' x
-              if b' /= builtinRewrite then go else do
-                ifM (optRewriting <$> pragmaOptions) {-then-} go {-else-} do
-                  warning $ UselessPragma r $
-                    "Ignoring BUILTIN REWRITE pragma since option --rewriting is off"
+          | Just b' <- b -> bindBuiltin b' x
           | otherwise -> typeError $ NoSuchBuiltinName ident
           where
             ident = rangedThing rb
@@ -975,6 +970,17 @@ checkModuleArity m tel = \case
         (NotHidden, Hidden, _)            -> bad
         (NotHidden, Instance{}, _)        -> bad
 
+-- | Checks local rewrite rule constraints are satisfied definitionally
+--   and returns the telescope with all local rewrite rules removed
+addRewConstraints :: Telescope -> TCM Telescope
+addRewConstraints EmptyTel        = pure EmptyTel
+addRewConstraints (ExtendTel a b) = do
+  whenJust (rewDom a) $ \r -> do
+    addRewConstraint $ rewDomEq r
+  let a' = a { rewDom = Nothing }
+  b' <- underAbstraction a' b addRewConstraints
+  pure $ ExtendTel a' b { unAbs = b' }
+
 -- | Check an application of a section.
 checkSectionApplication
   :: Info.ModuleInfo
@@ -1091,6 +1097,13 @@ checkSectionApplication'
       , nest 2 $ pretty copyInfo
       ]
     args <- instantiateFull $ vs ++ ts
+
+    -- Because we eta-expand module applications, we need to add aTel to the
+    -- context, but aTel might contain invalidated local rewrite rules.
+    -- We apply a sledgehammer fix for now, and check that all local rewrite
+    -- rules are satisfied definitionally.
+    aTel <- addRewConstraints aTel
+
     -- If we want to avoid eta-expanding modules (while supporting the current
     -- 'open public' behaviour) we should also change 'renName'/'renMod'
     -- in Agda.Syntax.Scope.Monad

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -390,7 +390,7 @@ noShadowingOfConstructors problem@(ProblemEq p _ (Dom{domInfo = info, unDom = El
 
 -- | Check that a dot pattern matches it's instantiation.
 checkDotPattern :: DotPattern -> TCM ()
-checkDotPattern (Dot e v (Dom{domInfo = info, unDom = a})) =
+checkDotPattern (Dot e v dom@(Dom{unDom = a})) =
   traceCall (CheckDotPattern e v) $ do
   reportSDoc "tc.lhs.dot" 15 $
     sep [ "checking dot pattern"
@@ -398,7 +398,7 @@ checkDotPattern (Dot e v (Dom{domInfo = info, unDom = a})) =
         , nest 2 $ "=" <+> prettyTCM v
         , nest 2 $ ":" <+> prettyTCM a
         ]
-  applyModalityToContext info $ do
+  applyDomToContext dom $ do
     u <- checkExpr e a
     reportSDoc "tc.lhs.dot" 50 $
       sep [ "equalTerm"

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -610,7 +610,7 @@ checkRecordProjections m r hasNamedCon con tel ftel fs = do
                 , _funTerminates     = Just True
                 })
               { defArgOccurrences = [StrictPos]
-              , defCopatternLHS   = hasProjectionPatterns cc
+              , defCopatternLHS'  = hasProjectionPatterns cc
               }
           computePolarity [projname]
 

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -328,6 +328,8 @@ checkDomain lamOrPi xs e = do
 
         equalSort (getSort t) LockUniv
 
+    -- TODO: check that @rew arguments actually have identity type
+
     return t
   where
         -- if we are checking a typed lambda, we resurrect before we check the

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -5,6 +5,7 @@ module Agda.TypeChecking.Rules.Term where
 import Prelude hiding ( null )
 
 import Control.Monad.Except ( MonadError(..) )
+import Control.Monad.Trans.Maybe ( runMaybeT )
 
 import Data.Maybe
 import qualified Data.DList as DL
@@ -17,7 +18,7 @@ import qualified Data.Set as Set
 import Agda.Interaction.Options
 import Agda.Interaction.Highlighting.Generate (disambiguateRecordFields)
 
-import Agda.Syntax.Abstract (Binder, TypedBindingInfo (tbTacticAttr))
+import Agda.Syntax.Abstract (Binder, TypedBindingInfo (tbTacticAttr), unBind, binderName)
 import qualified Agda.Syntax.Abstract as A
 import Agda.Syntax.Abstract.Views as A
 import qualified Agda.Syntax.Info as A
@@ -58,6 +59,7 @@ import Agda.TypeChecking.Quote
 import Agda.TypeChecking.RecordPatterns
 import Agda.TypeChecking.Records
 import Agda.TypeChecking.Reduce
+import Agda.TypeChecking.Rewriting (checkEquationValid, checkLocalRewriteRule)
 import Agda.TypeChecking.Rules.LHS
 import Agda.TypeChecking.SizedTypes
 import Agda.TypeChecking.SizedTypes.Solve
@@ -117,7 +119,8 @@ isType_ e = traceCall (IsType_ e) $ do
   SortKit{..} <- sortKit
   case unScope e of
     A.Fun i (Arg info t) b -> do
-      a <- setArgInfo info . defaultDom <$> checkPiDomain (info :| []) t
+      a <- uncurry (defaultArgDomRew info) <$>
+           checkPiDomain Nothing (info :| []) t
       b <- isType_ b
       s <- inferFunSort a b
       let t' = El s $ Pi a $ NoAbs underscore b
@@ -306,15 +309,23 @@ checkTelescope' lamOrPi (b : tel) ret =
 
 -- | Check the domain of a function type.
 --   Used in @checkTypedBindings@ and to typecheck @A.Fun@ cases.
-checkDomain :: (LensLock a, LensModality a) => LamOrPi -> List1 a -> A.Expr -> TCM Type
-checkDomain lamOrPi xs e = do
-    -- Get cohesion and quantity of arguments, which should all be equal because
+checkDomain :: (LensLock a, LensModality a, LensRewriteAnn a)
+  => LamOrPi -> Maybe Name -> List1 a -> A.Expr -> TCM (Maybe RewDom, Type)
+checkDomain lamOrPi n xs e = do
+    -- Get cohesion and quantity of arguments, as well as if they are local
+    -- rewrite rules. All of these properties should all be equal because
     -- they come from the same annotated Π-type.
     let (c :| cs) = fmap (getCohesion . getModality) xs
     unless (all (c ==) cs) $ __IMPOSSIBLE__
 
     let (q :| qs) = fmap (getQuantity . getModality) xs
     unless (all (q ==) qs) $ __IMPOSSIBLE__
+
+    let (r :| rs) = fmap (getRewriteAnn) xs
+    unless (all (r ==) rs) $ __IMPOSSIBLE__
+
+    -- Also get whether the domain is a local rewrite rule. If it is, and there
+    -- are multiple arguments, we warn that this is unnecessary
 
     t <- applyQuantityToJudgement q $
          applyCohesionToContext c $
@@ -328,9 +339,31 @@ checkDomain lamOrPi xs e = do
 
         equalSort (getSort t) LockUniv
 
-    -- TODO: check that @rew arguments actually have identity type
+    cxt <- getContext
+    let s = LocalRewrite cxt n t
 
-    return t
+  -- For now, we disallow '@rewrite' domains on pi types
+  -- In the future, this should be allowed only when the pi type is not in
+  -- higher-order position (checked syntactically)
+    r <- case lamOrPi of
+      PiNotLam | isRewrite r -> IsNotRewrite <$
+        runMaybeT (illegalRule s LocalRewriteOutsideTelescope)
+      _                      -> pure r
+
+    eq  <- checkEquationValid s r t
+    rew <- traverse (checkLocalRewriteRule s) eq
+    -- We do not (currently) distinguish failing to elaborate to a LocalEquation
+    -- from failing to elaborate to a RewriteRule. In the case we have
+    -- a valid LocalEquation, but failed to produce a RewriteRule, we could
+    -- technically still store the LocalEquation and check the convertibility
+    -- constraint at call sites. I don't think this is super important, but
+    -- maybe worth trying in future.
+    let rDom = RewDom <$> eq <*> fmap pure (join rew)
+    whenJust rDom \rDom' -> reportSDoc "rewriting" 30 $
+      "Successfully elaborated: " <+> prettyTCM (rewDomEq rDom') <+>
+        " into a rewrite rule"
+
+    return (rDom, t)
   where
         -- if we are checking a typed lambda, we resurrect before we check the
         -- types, but do not modify the new context entries
@@ -339,7 +372,8 @@ checkDomain lamOrPi xs e = do
         modEnv (LamNotPi _) = workOnTypes
         modEnv PiNotLam     = id
 
-checkPiDomain :: (LensLock a, LensModality a) => List1 a -> A.Expr -> TCM Type
+checkPiDomain :: (LensLock a, LensModality a,  LensRewriteAnn a)
+              => Maybe Name -> List1 a -> A.Expr -> TCM (Maybe RewDom, Type)
 checkPiDomain = checkDomain PiNotLam
 
 -- | Check a typed binding and extends the context with the bound variables.
@@ -359,7 +393,10 @@ checkTypedBindings lamOrPi (A.TBind r tac xps e) ret = do
     -- 2011-10-04 if flag --experimental-irrelevance is set
     experimental <- optExperimentalIrrelevance <$> pragmaOptions
 
-    t <- checkDomain lamOrPi xps e
+    -- We pick one of the names to report local rewrite errors on
+    let x = unBind $ binderName $ namedArg $ List1.head xps
+    (rew, t) <- checkDomain lamOrPi (Just x) xps e
+    whenJust rew $ \r -> reportSDoc "rewriting" 30 $ "Checked local rewrite:" <+> prettyTCM (rewDomEq r)
 
     -- Jesper, 2019-02-12, Issue #3534: warn if the type of an
     -- instance argument does not have the right shape
@@ -374,15 +411,18 @@ checkTypedBindings lamOrPi (A.TBind r tac xps e) ret = do
         NoOutputTypeName -> setCurrentRange e $
           warning . InstanceNoOutputTypeName =<< prettyTCM (A.mkTBind r ixs e)
 
-    let setTac tac dom = dom { domTactic = tac }
-        setTacTel tac EmptyTel            = EmptyTel
-        setTacTel tac (ExtendTel dom tel) =
-          ExtendTel (setTac tac dom) $ setTacTel (raise 1 tac) <$> tel
-        -- We need to convert to Dom and set the domTactic field here in order
-        -- to not drop @tactic annotations
-        xs' = setTac tac . domNameFromNamedArgName . modMod lamOrPi experimental
+    let setTacRew tac rew dom = dom { domTactic = tac, rewDom = rew }
+        setTacRewTel tac rew EmptyTel            = EmptyTel
+        setTacRewTel tac rew (ExtendTel dom tel) =
+          ExtendTel (setTacRew tac rew dom) $
+            setTacRewTel (raise 1 tac) (raise 1 rew) <$> tel
+        -- We need to convert to Dom and set the domTactic and domRew fields
+        -- here in order to not drop @tactic and @rewrite annotations
+        xs' = setTacRew tac rew
+                . domNameFromNamedArgName
+                . modMod lamOrPi experimental
               <$> xs
-    let tel = setTacTel tac $ namedBindsToTel1 xs t
+    let tel = setTacRewTel tac rew $ namedBindsToTel1 xs t
 
     addContext (xs', t) $ addTypedPatterns xps (ret tel)
 
@@ -658,8 +698,15 @@ userOmittedModalities xs = do
 -- | Check that modality info in lambda is compatible with modality
 --   coming from the function type.
 --   If lambda has no user-given modality, copy that of function type.
-lambdaModalityCheck :: (LensAnnotation dom, LensModality dom) => dom -> ArgInfo -> TCM ArgInfo
-lambdaModalityCheck dom = lambdaAnnotationCheck (getAnnotation dom) <=< lambdaPolarityCheck m <=< lambdaCohesionCheck m <=< lambdaQuantityCheck m <=< lambdaIrrelevanceCheck m
+lambdaModalityCheck ::
+     (LensAnnotation dom, LensModality dom)
+  => dom -> ArgInfo -> TCM ArgInfo
+lambdaModalityCheck dom =
+  lambdaAnnotationCheck (getAnnotation dom) <=<
+  lambdaPolarityCheck m <=<
+  lambdaCohesionCheck m <=<
+  lambdaQuantityCheck m <=<
+  lambdaIrrelevanceCheck m
   where m = getModality dom
 
 -- | Check that irrelevance info in lambda is compatible with irrelevance
@@ -1544,7 +1591,8 @@ checkExpr' cmp e t =
         -- Application
         e -> do
           Application hd args <- appViewM e
-          checkApplication cmp hd args e t
+          e' <- checkApplication cmp hd args e t
+          pure e'
 
       `catchIlltypedPatternBlockedOnMeta` \ (err, x) -> do
         -- We could not check the term because the type of some pattern is blocked.
@@ -1717,6 +1765,9 @@ checkOrInferMeta
   -> Maybe (Comparison , Type)
   -> TCM (Term, Type)
 checkOrInferMeta i newMeta mt = do
+  -- We still need to check equational constraints even when checking a meta
+  -- because definitions parameterised by a local rewrite rule do not block
+  -- on the corresponding argument
   case A.metaNumber i of
     Nothing -> do
       unlessNull (A.metaScope i) setScope
@@ -1813,7 +1864,9 @@ checkNamedArg arg@(Arg info e0) t0 = do
     -- argument (i.e. solve with unification).
     -- Andreas, 2024-03-07, issue #2829: Except when we don't.
     -- E.g. when 'insertImplicitPatSynArgs' inserted an instance underscore.
-    let checkU i = checkMeta i (newMetaArg (A.metaKind i) info x) CmpLeq t0
+    let checkU i = checkMeta i
+          (\cmp -> newMetaArg (A.metaKind i) x cmp . defaultArgDom info)
+          CmpLeq t0
     let checkQ = checkQuestionMark (newInteractionMetaArg info x) CmpLeq t0
     if not $ isHole e then checkExpr e t0 else localScope $ do
       -- Note: we need localScope_ here,

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -522,7 +522,7 @@ instance EmbPrj Relevance where
     _      -> malformed
 
 instance EmbPrj Annotation where
-  icod_ (Annotation l) = icodeN' Annotation l
+  icod_ (Annotation l r) = icodeN' Annotation l r
 
   value = valueN Annotation
 
@@ -535,6 +535,16 @@ instance EmbPrj Lock where
   value 1 = pure (IsLock LockOTick)
   value 2 = pure (IsLock LockOLock)
   value _ = malformed
+
+
+instance EmbPrj RewriteAnn where
+  icod_ IsNotRewrite = pure 0
+  icod_ IsRewrite    = pure 1
+
+  value 0 = pure IsNotRewrite
+  value 1 = pure IsRewrite
+  value _ = malformed
+
 
 instance EmbPrj Origin where
   icod_ UserWritten    = return 0

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -536,15 +536,13 @@ instance EmbPrj Lock where
   value 2 = pure (IsLock LockOLock)
   value _ = malformed
 
-
 instance EmbPrj RewriteAnn where
-  icod_ IsNotRewrite = pure 0
-  icod_ IsRewrite    = pure 1
+  icod_ IsNotRewrite  = pure 0
+  icod_ (IsRewrite _) = pure 1
 
   value 0 = pure IsNotRewrite
-  value 1 = pure IsRewrite
+  value 1 = pure $ IsRewrite noRange
   value _ = malformed
-
 
 instance EmbPrj Origin where
   icod_ UserWritten    = return 0

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -149,6 +149,8 @@ instance EmbPrj Warning where
     UnusedImports a b                           -> icodeN 75 UnusedImports a b
     DefinitionBeforeDeclaration x               -> icodeN 76 DefinitionBeforeDeclaration x
     RecursiveRecordNeedsInductivity{}           -> __IMPOSSIBLE__  -- Error warning
+    IgnoringRew a b                             -> icodeN 77 IgnoringRew a b
+    InferredLocalRewrite a b                    -> icodeN 78 InferredLocalRewrite a b
 
   value = vcase $ \ case
     N3 0 a b      -> valuN UnreachableClauses a b
@@ -229,9 +231,35 @@ instance EmbPrj Warning where
     N1 74         -> valuN RewritesNothing
     N3 75 a b     -> valuN UnusedImports a b
     N2 76 a       -> valuN DefinitionBeforeDeclaration a
+    N3 77 a b     -> valuN IgnoringRew a b
+    N3 78 a b     -> valuN InferredLocalRewrite a b
     _ -> malformed
 
 instance EmbPrj UselessPublicReason
+
+instance EmbPrj ContextEntry where
+  icod_ (CtxVar a b) = icodeN 0 CtxVar a b
+
+  value = vcase $ \case
+    N3 0 a b -> valuN CtxVar a b
+    _        -> malformed
+
+instance EmbPrj Context where
+  icod_ (Context a) = icodeN 0 Context a
+
+  value = vcase $ \case
+    N2 0 a -> valuN Context a
+    _      -> malformed
+
+instance EmbPrj RewriteSource where
+  icod_ = \case
+    LocalRewrite a b c -> icodeN 0 LocalRewrite a b c
+    GlobalRewrite a    -> icodeN 1 GlobalRewrite a
+
+  value = vcase $ \case
+    N4 0 a b c -> valuN LocalRewrite a b c
+    N2 1 a     -> valuN GlobalRewrite a
+    _          -> malformed
 
 instance EmbPrj IllegalRewriteRuleReason where
   icod_ = \case
@@ -251,6 +279,7 @@ instance EmbPrj IllegalRewriteRuleReason where
     BeforeFunctionDefinition                    -> icodeN 13 BeforeFunctionDefinition
     BeforeMutualFunctionDefinition a            -> icodeN 14 BeforeMutualFunctionDefinition a
     DuplicateRewriteRule                        -> icodeN 15 DuplicateRewriteRule
+    LocalRewriteOutsideTelescope                -> icodeN 16 LocalRewriteOutsideTelescope
 
   value = vcase $ \case
     N1 0     -> valuN LHSNotDefinitionOrConstructor
@@ -269,16 +298,19 @@ instance EmbPrj IllegalRewriteRuleReason where
     N1 13    -> valuN BeforeFunctionDefinition
     N2 14 a  -> valuN BeforeMutualFunctionDefinition a
     N1 15    -> valuN DuplicateRewriteRule
+    N1 16    -> valuN LocalRewriteOutsideTelescope
     _        -> malformed
 
 instance EmbPrj OptionWarning where
   icod_ = \case
-    OptionRenamed a b -> icodeN 0 OptionRenamed a b
-    WarningProblem a  -> icodeN 1 WarningProblem a
+    OptionRenamed a b             -> icodeN 0 OptionRenamed a b
+    WarningProblem a              -> icodeN 1 WarningProblem a
+    LocalRewritingConfluenceCheck -> icodeN 2 LocalRewritingConfluenceCheck
 
   value = vcase $ \case
     N3 0 a b -> valuN OptionRenamed a b
     N2 1 a   -> valuN WarningProblem a
+    N1 2     -> valuN LocalRewritingConfluenceCheck
     _        -> malformed
 
 instance EmbPrj WarningModeError where
@@ -392,6 +424,7 @@ instance EmbPrj DeclarationWarning' where
     EmptyPolarityPragma r             -> icodeN 35 EmptyPolarityPragma r
     UselessImport r                   -> icodeN 36 UselessImport r
     InvalidDataOrRecDefParameter r a b c -> icodeN 37 InvalidDataOrRecDefParameter r a b c
+    InvalidRewriteAttribute r            -> icodeN 38 InvalidTacticAttribute r
 
   value = vcase $ \case
     N2 0  a            -> valuN UnknownNamesInFixityDecl a
@@ -432,6 +465,7 @@ instance EmbPrj DeclarationWarning' where
     N2 35 r            -> valuN EmptyPolarityPragma r
     N2 36 r            -> valuN UselessImport r
     N5 37 r a b c      -> valuN InvalidDataOrRecDefParameter r a b c
+    N2 38 r            -> valuN InvalidRewriteAttribute r
     _ -> malformed
 
 instance EmbPrj OpenOrImport
@@ -485,8 +519,8 @@ instance EmbPrj InfectiveCoinfective where
     valu _      = malformed
 
 instance EmbPrj PragmaOptions where
-  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss ttt uuu) =
-    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss ttt uuu
+  icod_    (PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss ttt uuu vvv) =
+    icodeN' PragmaOptions a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss ttt uuu vvv
 
   value = valueN PragmaOptions
 

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -25,7 +25,7 @@ import Agda.Utils.Permutation
 import Agda.Utils.Impossible
 
 instance EmbPrj a => EmbPrj (Dom a) where
-  icod_ (Dom a c d e f) = icodeN' Dom a c d e f
+  icod_ (Dom a c d e f g) = icodeN' Dom a c d e f g
 
   value = valueN Dom
 
@@ -324,6 +324,11 @@ instance EmbPrj RewriteRule where
   icod_ (RewriteRule a b c d e f g h) = icodeN' RewriteRule a b c d e f g h
 
   value = valueN RewriteRule
+
+instance EmbPrj LocalRewriteRule where
+  icod_ (LocalRewriteRule a b c d e) = icodeN' LocalRewriteRule a b c d e
+
+  value = valueN LocalRewriteRule
 
 instance EmbPrj Projection where
   icod_ (Projection a b c d e) = icodeN' Projection a b c d e

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -326,10 +326,29 @@ instance EmbPrj GlobalRewriteRule where
 
   value = valueN GlobalRewriteRule
 
+instance EmbPrj LocalEquation where
+  icod_ (LocalEquation a b c d) = icodeN' LocalEquation a b c d
+
+  value = valueN LocalEquation
+
+instance EmbPrj RewriteHead where
+  icod_ (RewDefHead a) = icodeN 0 RewDefHead a
+  icod_ (RewVarHead a) = icodeN 1 RewVarHead a
+
+  value = vcase valu where
+    valu (N2 0 a) = valuN RewDefHead a
+    valu (N2 1 a) = valuN RewVarHead a
+    valu _        = malformed
+
 instance EmbPrj RewriteRule where
   icod_ (RewriteRule a b c d e) = icodeN' RewriteRule a b c d e
 
   value = valueN RewriteRule
+
+instance EmbPrj RewDom where
+  icod_ (RewDom a b) = icodeN' RewDom a b
+
+  value = valueN RewDom
 
 instance EmbPrj Projection where
   icod_ (Projection a b c d e) = icodeN' Projection a b c d e

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -320,15 +320,16 @@ instance EmbPrj NLPSort where
     valu (N1 7)     = valuN PLevelUniv
     valu _          = malformed
 
+instance EmbPrj GlobalRewriteRule where
+  icod_ (GlobalRewriteRule a b c d e f g h) =
+    icodeN' GlobalRewriteRule a b c d e f g h
+
+  value = valueN GlobalRewriteRule
+
 instance EmbPrj RewriteRule where
-  icod_ (RewriteRule a b c d e f g h) = icodeN' RewriteRule a b c d e f g h
+  icod_ (RewriteRule a b c d e) = icodeN' RewriteRule a b c d e
 
   value = valueN RewriteRule
-
-instance EmbPrj LocalRewriteRule where
-  icod_ (LocalRewriteRule a b c d e) = icodeN' LocalRewriteRule a b c d e
-
-  value = valueN LocalRewriteRule
 
 instance EmbPrj Projection where
   icod_ (Projection a b c d e) = icodeN' Projection a b c d e

--- a/src/full/Agda/TypeChecking/Sort.hs
+++ b/src/full/Agda/TypeChecking/Sort.hs
@@ -27,7 +27,7 @@ import Control.Monad.Except
 import Data.Functor
 import Data.Maybe
 
-import Agda.Interaction.Options (optCumulativity, optRewriting)
+import Agda.Interaction.Options (optCumulativity)
 
 import Agda.Syntax.Common
 import Agda.Syntax.Internal
@@ -228,7 +228,7 @@ sortOf t = do
           Blocked m _ -> patternViolation m
 
           -- Not IMPOSSIBLE because of possible non-confluent rewriting (see #5531)
-          _ -> ifM (optRewriting <$> pragmaOptions)
+          _ -> ifM anyRewritingOption
             {-then-} (patternViolation neverUnblock)
             {-else-} __IMPOSSIBLE__
 

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1554,6 +1554,17 @@ instance (Ord a) => Ord (Elim' a) where
   Proj{}   `compare` _        = LT
   _        `compare` Proj{}   = GT
 
+deriving instance Eq DefSing
+deriving instance Eq NLPat
+deriving instance Eq NLPType
+deriving instance Eq NLPSort
+deriving instance Eq LocalRewriteRule
+
+deriving instance Ord DefSing
+deriving instance Ord NLPSort
+deriving instance Ord NLPType
+deriving instance Ord NLPat
+deriving instance Ord LocalRewriteRule
 
 ---------------------------------------------------------------------------
 -- * Sort stuff

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -48,6 +48,7 @@ import Agda.Utils.Either
 import Agda.Utils.Empty
 import Agda.Utils.Function (applyWhen, applyUnless)
 import Agda.Utils.Functor
+import Agda.Utils.Impossible
 import Agda.Utils.List
 import Agda.Utils.List1 (List1, pattern (:|))
 import qualified Agda.Utils.List1 as List1
@@ -58,9 +59,9 @@ import Agda.Utils.Permutation
 import Agda.Utils.Singleton
 import Agda.Utils.Size
 import Agda.Utils.Tuple
+import Agda.Utils.VarSet (VarSet)
+import qualified Agda.Utils.VarSet as VarSet
 import Agda.Utils.Zip
-
-import Agda.Utils.Impossible
 
 
 -- | Apply @Elims@ while using the given function to report ill-typed
@@ -821,6 +822,40 @@ renamingR p@(Perm n is) = xs ++# raiseS n
 renameP :: Subst a => Impossible -> Permutation -> a -> a
 renameP err p = applySubst (renaming err p)
 
+-- | Polymorphic substitution
+--   I.e. Substitutions which can be applied to any 'a' where
+--   'DeBruijn (SubstArg a)'
+--   Used to encode not-necessarily-surjective renamings ('Permutation' is
+--   always assumed to be surjective)
+data AnySubstitution = AnySub
+  { getSub :: forall a. DeBruijn a => Substitution' a }
+
+-- | Attempts to convert a substitution into a renaming. Returns Nothing if
+--   any of the variables in the set are mapped to non-variable terms.
+--   Variables not in the set are strengthened-away.
+--   Returns a polymorphic substitution.
+toRenOn :: DeBruijn a => VarSet -> Substitution' a -> Maybe AnySubstitution
+toRenOn vars rho = go 0 rho
+  where
+    go x IdS        = Just $ AnySub $ IdS
+    go x (EmptyS i) = Just $ AnySub $ EmptyS i
+    go x (t :# rho) = do
+      AnySub rho' <- go (x + 1) rho
+      if x `VarSet.member` vars
+      then do
+        y <- deBruijnView t
+        Just $ AnySub $ deBruijnVar y :# rho'
+      else Just $ AnySub $ Strengthen __IMPOSSIBLE__ 1 rho'
+    go x (Strengthen i n rho) = do
+      AnySub rho' <- go (x + n) rho
+      Just $ AnySub $ Strengthen i n rho'
+    go x (Wk n rho) = do
+      AnySub rho' <- go x rho
+      Just $ AnySub $ Wk n rho'
+    go x (Lift n rho) = do
+      AnySub rho' <- go (x + n) rho
+      Just $ AnySub $ Lift n rho'
+
 instance EndoSubst a => Subst (Substitution' a) where
   type SubstArg (Substitution' a) = a
   applySubst rho sgm = composeS rho sgm
@@ -920,17 +955,21 @@ instance DeBruijn BraveTerm where
   deBruijnVar = BraveTerm . deBruijnVar
   deBruijnView = deBruijnView . unBrave
 
+-- This instance is a bit of a hack. Whether a variable ought to be mapped to
+-- a PVar or a PBoundVar is dependent on context, but here we always assume
+-- PVar.
 instance DeBruijn NLPat where
   deBruijnVar i = PVar MaybeSing i []
   deBruijnView = \case
-    PVar s i [] -> Just i
-    PVar{}      -> Nothing
-    PDef{}      -> Nothing
-    PLam{}      -> Nothing
-    PPi{}       -> Nothing
-    PSort{}     -> Nothing
-    PBoundVar{} -> Nothing -- or... ?
-    PTerm{}     -> Nothing -- or... ?
+    PVar s i []    -> Just i
+    PVar{}         -> Nothing
+    PDef{}         -> Nothing
+    PLam{}         -> Nothing
+    PPi{}          -> Nothing
+    PSort{}        -> Nothing
+    PBoundVar i [] -> Just i
+    PBoundVar{}    -> Nothing -- or... ?
+    PTerm{}        -> Nothing -- or... ?
 
 applyNLPatSubst :: TermSubst a => Substitution' NLPat -> a -> a
 applyNLPatSubst = applySubst . fmap nlPatToTerm
@@ -948,6 +987,10 @@ applyNLPatSubst = applySubst . fmap nlPatToTerm
 applyNLSubstToDom :: SubstWith NLPat a => Substitution' NLPat -> Dom a -> Dom a
 applyNLSubstToDom rho dom = applySubst rho <$> dom{ domTactic = applyNLPatSubst rho $ domTactic dom }
 
+-- Assume substitution maps the given variable to a variable
+lookupSVar ::  EndoSubst a => Substitution' a -> Nat -> Maybe Nat
+lookupSVar sub x = deBruijnView $ lookupS sub x
+
 instance Subst NLPat where
   type SubstArg NLPat = NLPat
   applySubst rho = \case
@@ -956,7 +999,11 @@ instance Subst NLPat where
     PLam i u       -> PLam i $ applySubst rho u
     PPi a b        -> PPi (applyNLSubstToDom rho a) (applySubst rho b)
     PSort s        -> PSort $ applySubst rho s
-    PBoundVar i es -> PBoundVar i $ applySubst rho es
+    -- Bound variables should only ever be substituted for other bound
+    -- variables
+    PBoundVar i es ->
+      PBoundVar (fromMaybe __IMPOSSIBLE__ $ lookupSVar rho i) $
+        applySubst rho es
     PTerm u        -> PTerm $ applyNLPatSubst rho u
 
     where
@@ -993,6 +1040,43 @@ instance Subst GlobalRewriteRule where
                   (applyNLPatSubst (liftS n rho) t)
                   c top
     where n = size gamma
+
+instance Subst a => Subst (LocalEquation' a) where
+  type SubstArg (LocalEquation' a) = SubstArg a
+  applySubst rho (LocalEquation gamma lhs rhs t) =
+    LocalEquation (applySubst rho gamma)
+                  (applySubst rho' lhs)
+                  (applySubst rho' rhs)
+                  (applySubst rho' t)
+    where rho' = liftS (size gamma) rho
+
+instance Subst RewriteHead where
+  type SubstArg RewriteHead = Term
+  applySubst rho (RewDefHead f) = RewDefHead f
+  applySubst rho (RewVarHead x) = RewVarHead $ fromMaybe __IMPOSSIBLE__ $
+    deBruijnView $ lookupS rho x
+
+-- | Substitution on local rewrite rules is partial.
+applySubstLocalRewrite :: DeBruijn a
+  => Substitution' a -> RewriteRule -> Maybe RewriteRule
+applySubstLocalRewrite rho rew@(RewriteRule gamma f ps rhs b) =
+  case toRenOn (freeVarSet rew) rho of
+    Just (AnySub rho') -> do
+      let rho'' :: DeBruijn a => Substitution' a
+          rho'' = liftS (size gamma) rho'
+
+      Just $ RewriteRule (applySubst rho' gamma)
+                                 (applySubst rho' f)
+                                 (applySubst rho'' ps)
+                                  (applySubst rho'' rhs)
+                                 (applySubst rho'' b)
+    Nothing            -> Nothing
+
+instance Subst a => Subst (RewDom' a) where
+  type SubstArg (RewDom' a) = SubstArg a
+  applySubst rho (RewDom eq rew) =
+    RewDom (applySubst rho eq)
+          (applySubstLocalRewrite rho =<< rew)
 
 instance Subst a => Subst (Blocked a) where
   type SubstArg (Blocked a) = SubstArg a
@@ -1040,6 +1124,7 @@ instance Subst Constraint where
     CheckMetaInst m          -> CheckMetaInst m
     CheckType t              -> CheckType (rf t)
     UsableAtModality cc ms mod m -> UsableAtModality cc (rf ms) mod (rf m)
+    RewConstraint e          -> RewConstraint (rf e)
     where
       rf :: forall a. TermSubst a => a -> a
       rf x = applySubst rho x
@@ -1076,7 +1161,10 @@ instance (Subst a, Subst b, SubstArg a ~ SubstArg b) => Subst (Dom' a b) where
 
   applySubst IdS dom = dom
   applySubst rho dom = setFreeVariables unknownFreeVariables $
-    fmap (applySubst rho) dom{ domTactic = applySubst rho (domTactic dom) }
+    fmap (applySubst rho) dom
+      { rewDom    = applySubst rho (rewDom dom)
+      , domTactic = applySubst rho (domTactic dom)
+      }
   {-# INLINABLE applySubst #-}
 
 instance Subst LetBinding where
@@ -1558,13 +1646,18 @@ deriving instance Eq DefSing
 deriving instance Eq NLPat
 deriving instance Eq NLPType
 deriving instance Eq NLPSort
+deriving instance Eq LocalEquation
 deriving instance Eq RewriteRule
+deriving instance Eq RewDom
 
 deriving instance Ord DefSing
 deriving instance Ord NLPSort
 deriving instance Ord NLPType
 deriving instance Ord NLPat
+deriving instance Ord LocalEquation
+deriving instance Ord RewriteHead
 deriving instance Ord RewriteRule
+deriving instance Ord RewDom
 
 ---------------------------------------------------------------------------
 -- * Sort stuff

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -236,20 +236,20 @@ instance Apply Definition where
 
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
 
-instance Apply RewriteRule where
+instance Apply GlobalRewriteRule where
   apply r args =
-    let newContext = apply (rewContext r) args
+    let newContext = apply (grContext r) args
         sub        = liftS (size newContext) $ parallelS $
                        reverse $ map (PTerm . unArg) args
-    in RewriteRule
-       { rewName    = rewName r
-       , rewContext = newContext
-       , rewHead    = rewHead r
-       , rewPats    = applySubst sub (rewPats r)
-       , rewRHS     = applyNLPatSubst sub (rewRHS r)
-       , rewType    = applyNLPatSubst sub (rewType r)
-       , rewFromClause = rewFromClause r
-       , rewTopModule  = rewTopModule r
+    in GlobalRewriteRule
+       { grName    = grName r
+       , grContext = newContext
+       , grHead    = grHead r
+       , grPats    = applySubst sub (grPats r)
+       , grRHS     = applyNLPatSubst sub (grRHS r)
+       , grType    = applyNLPatSubst sub (grType r)
+       , grFromClause = grFromClause r
+       , grTopModule  = grTopModule r
        }
 
   applyE t es = apply t $ fromMaybe __IMPOSSIBLE__ $ allApplyElims es
@@ -629,9 +629,9 @@ instance Abstract Definition where
 -- | @tel ⊢ (Γ ⊢ lhs ↦ rhs : t)@ becomes @tel, Γ ⊢ lhs ↦ rhs : t)@
 --   we do not need to change lhs, rhs, and t since they live in Γ.
 --   See 'Abstract Clause'.
-instance Abstract RewriteRule where
-  abstract tel (RewriteRule q gamma f ps rhs t c top) =
-    RewriteRule q (abstract tel gamma) f ps rhs t c top
+instance Abstract GlobalRewriteRule where
+  abstract tel (GlobalRewriteRule q gamma f ps rhs t c top) =
+    GlobalRewriteRule q (abstract tel gamma) f ps rhs t c top
 
 instance {-# OVERLAPPING #-} Abstract [Occ.Occurrence] where
   abstract tel []  = []
@@ -984,10 +984,10 @@ instance Subst NLPSort where
     PLevelUniv -> PLevelUniv
     PIntervalUniv -> PIntervalUniv
 
-instance Subst RewriteRule where
-  type SubstArg RewriteRule = NLPat
-  applySubst rho (RewriteRule q gamma f ps rhs t c top) =
-    RewriteRule q (applyNLPatSubst rho gamma)
+instance Subst GlobalRewriteRule where
+  type SubstArg GlobalRewriteRule = NLPat
+  applySubst rho (GlobalRewriteRule q gamma f ps rhs t c top) =
+    GlobalRewriteRule q (applyNLPatSubst rho gamma)
                 f (applySubst (liftS n rho) ps)
                   (applyNLPatSubst (liftS n rho) rhs)
                   (applyNLPatSubst (liftS n rho) t)
@@ -1558,13 +1558,13 @@ deriving instance Eq DefSing
 deriving instance Eq NLPat
 deriving instance Eq NLPType
 deriving instance Eq NLPSort
-deriving instance Eq LocalRewriteRule
+deriving instance Eq RewriteRule
 
 deriving instance Ord DefSing
 deriving instance Ord NLPSort
 deriving instance Ord NLPType
 deriving instance Ord NLPat
-deriving instance Ord LocalRewriteRule
+deriving instance Ord RewriteRule
 
 ---------------------------------------------------------------------------
 -- * Sort stuff

--- a/src/full/Agda/TypeChecking/Substitute/Class.hs
+++ b/src/full/Agda/TypeChecking/Substitute/Class.hs
@@ -72,11 +72,15 @@ class DeBruijn (SubstArg a) => Subst a where
 -- | Simple constraint alias for a `Subst` instance `a` with arg type `t`.
 type SubstWith t a = (Subst a, SubstArg a ~ t)
 
--- | `Subst` instance whose agument type is itself
+-- | `Subst` instance whose argument type is itself
 type EndoSubst a = SubstWith a a
 
 -- | `Subst` instance whose argument type is `Term`
 type TermSubst a = SubstWith Term a
+
+-- | `Subst` instance whose argument type is `Nat` (i.e. for things that
+--   can be weakened, but do not admit arbitrary substitution)
+type WeakSubst a = SubstWith Nat a
 
 -- | Raise de Bruijn index, i.e. weakening
 raise :: Subst a => Nat -> a -> a

--- a/src/full/Agda/TypeChecking/Substitute/DeBruijn.hs
+++ b/src/full/Agda/TypeChecking/Substitute/DeBruijn.hs
@@ -54,3 +54,7 @@ instance DeBruijn DBPatVar where
 instance DeBruijn a => DeBruijn (Named_ a) where
   deBruijnNamedVar nm i = unnamed $ deBruijnNamedVar nm i
   deBruijnView = deBruijnView . namedThing
+
+instance DeBruijn Nat where
+  deBruijnVar  x = x
+  deBruijnView x = Just x

--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -232,8 +232,8 @@ instance SynEq a => SynEq (Arg a) where
 
 -- Ignore the tactic.
 instance SynEq a => SynEq (Dom a) where
-  synEq d@(Dom ai x f t a) d'@(Dom ai' x' f' _ a')
-    | x == x'   = Dom <$$> synEq ai ai' <**> pure2 x <**> synEq f f' <**> pure2 t <**> synEq a a'
+  synEq d@(Dom ai x f t r a) d'@(Dom ai' x' f' _ _ a')
+    | x == x'   = Dom <$$> synEq ai ai' <**> pure2 x <**> synEq f f' <**> pure2 t <**> pure2 r <**> synEq a a'
     | otherwise = inequal (d, d')
 
 instance SynEq ArgInfo where

--- a/src/full/Agda/TypeChecking/SyntacticEquality.hs
+++ b/src/full/Agda/TypeChecking/SyntacticEquality.hs
@@ -230,10 +230,10 @@ instance (Subst a, SynEq a) => SynEq (Abs a) where
 instance SynEq a => SynEq (Arg a) where
   synEq (Arg ai a) (Arg ai' a') = Arg <$$> synEq ai ai' <**> synEq a a'
 
--- Ignore the tactic.
+-- Ignore the tactic and elaborated rewrite.
 instance SynEq a => SynEq (Dom a) where
-  synEq d@(Dom ai x f t r a) d'@(Dom ai' x' f' _ _ a')
-    | x == x'   = Dom <$$> synEq ai ai' <**> pure2 x <**> synEq f f' <**> pure2 t <**> pure2 r <**> synEq a a'
+  synEq d@(Dom ai x f t r a) d'@(Dom ai' x' f' _ r' a')
+    | x == x'   = Dom <$$> synEq ai ai' <**> pure2 x <**> synEq f f' <**> pure2 t <**> pure (r, r') <**> synEq a a'
     | otherwise = inequal (d, d')
 
 instance SynEq ArgInfo where

--- a/src/full/Agda/Utils/Memo.hs
+++ b/src/full/Agda/Utils/Memo.hs
@@ -10,6 +10,7 @@ import Data.HashMap.Strict qualified as HMap
 import Data.Hashable
 
 import Agda.Utils.Lens
+import qualified Data.IntMap as IntMap
 
 -- Simple memoisation in a state monad
 
@@ -63,4 +64,19 @@ memoUnsafeH f = unsafePerformIO $ do
         Nothing -> do
           let y = f x
           writeIORef tbl (HMap.insert x y m)
+          return y
+
+{-# NOINLINE memoUnsafeInt #-}
+memoUnsafeInt :: (Int -> a) -> (Int -> a)
+memoUnsafeInt f = unsafePerformIO $ do
+  tbl <- newIORef IntMap.empty
+  return (unsafePerformIO . f' tbl)
+  where
+    f' tbl x = do
+      m <- readIORef tbl
+      case IntMap.lookup x m of
+        Just y  -> return y
+        Nothing -> do
+          let y = f x
+          writeIORef tbl (IntMap.insert x y m)
           return y

--- a/test/Fail/LocalRewriteBadMatch.agda
+++ b/test/Fail/LocalRewriteBadMatch.agda
@@ -1,0 +1,15 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+-- Matching on variables that occur in local rewrite rules is not allowed!
+module LocalRewriteBadMatch where
+
+postulate
+  f : Nat → Nat
+
+module _ (n : Nat) (@rewrite p : f n ≡ 0) where
+  foo : n ≡ 42 → Nat
+  foo refl = 0

--- a/test/Fail/LocalRewriteBadMatch.err
+++ b/test/Fail/LocalRewriteBadMatch.err
@@ -1,0 +1,9 @@
+LocalRewriteBadMatch.agda:15.7-11: error: [SplitError.UnificationStuck]
+I'm not sure if there should be a case for the constructor refl,
+because I get stuck when trying to solve the following unification
+problems (inferred index ≟ expected index):
+  n ≟ 42
+Possible reason why unification failed:
+  Cannot solve variable n of type Nat with solution 42 because the
+  variable occurs in a local rewrite rule.
+when checking that the pattern refl has type n ≡ 42

--- a/test/Fail/LocalRewriteBadMatch2.agda
+++ b/test/Fail/LocalRewriteBadMatch2.agda
@@ -1,0 +1,11 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteBadMatch2 where
+
+module _ (f : Nat → Nat) (x : Nat) (@rewrite p : f 1 ≡ 0) where
+  foo : f ≡ (λ x → x) → Nat
+  foo refl = 0

--- a/test/Fail/LocalRewriteBadMatch2.err
+++ b/test/Fail/LocalRewriteBadMatch2.err
@@ -1,0 +1,9 @@
+LocalRewriteBadMatch2.agda:11.7-11: error: [SplitError.UnificationStuck]
+I'm not sure if there should be a case for the constructor refl,
+because I get stuck when trying to solve the following unification
+problems (inferred index ≟ expected index):
+  f ≟ λ x → x
+Possible reason why unification failed:
+  Cannot solve variable f of type Nat → Nat with solution λ x → x
+  because the variable occurs in a local rewrite rule.
+when checking that the pattern refl has type f ≡ (λ x → x)

--- a/test/Fail/LocalRewriteConstraint.agda
+++ b/test/Fail/LocalRewriteConstraint.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteConstraint where
+
+module _ (x : Nat) (@rewrite _ : x ≡ 0) where
+  foo : Nat
+  foo = 0
+
+bar : (x : Nat) → x ≡ 0 → Nat
+bar x p = foo x p

--- a/test/Fail/LocalRewriteConstraint.err
+++ b/test/Fail/LocalRewriteConstraint.err
@@ -1,0 +1,10 @@
+LocalRewriteConstraint.agda:14.11-16: error: [UnequalTerms]
+The terms
+  x
+and
+  zero
+are not equal at type Nat
+when checking the following local rewrite rule constraint:
+   |-  x  =  0  :  Nat
+when checking that p is a valid argument to a function of type
+(@rewrite _ : x ≡ 0) → Nat

--- a/test/Fail/LocalRewriteConstraint2.agda
+++ b/test/Fail/LocalRewriteConstraint2.agda
@@ -1,0 +1,17 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteConstraint2 where
+
+module Foo (x : Nat) (@rewrite p : x ≡ 1) where
+  foo : Nat
+  foo = 0
+
+postulate
+  nat  : Nat
+  nat0 : nat ≡ 0
+
+open Foo nat nat0

--- a/test/Fail/LocalRewriteConstraint2.err
+++ b/test/Fail/LocalRewriteConstraint2.err
@@ -1,0 +1,10 @@
+LocalRewriteConstraint2.agda:17.6-13: error: [UnequalTerms]
+The terms
+  nat
+and
+  1
+are not equal at type Nat
+when checking the following local rewrite rule constraint:
+   |-  nat  =  1  :  Nat
+when checking that nat0 is a valid argument to a function accepting
+arguments of type (@rewrite p : nat ≡ 1)

--- a/test/Fail/LocalRewriteDataCubical.agda
+++ b/test/Fail/LocalRewriteDataCubical.agda
@@ -1,0 +1,11 @@
+{-# OPTIONS --cubical --local-rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+open import Agda.Primitive.Cubical
+
+module LocalRewriteDataCubical where
+
+module _ (n : Nat) (@rewrite p : n ≡ 0) where
+  data Foo : Set where

--- a/test/Fail/LocalRewriteDataCubical.err
+++ b/test/Fail/LocalRewriteDataCubical.err
@@ -1,0 +1,4 @@
+LocalRewriteDataCubical.agda:11.8-11: error: [CannotGenerateTransportLocalRewrite]
+Could not generate a transport function for Foo
+because there is a local rewrite rule in its telescope
+when checking the definition of Foo

--- a/test/Fail/LocalRewriteEagerMetas.agda
+++ b/test/Fail/LocalRewriteEagerMetas.agda
@@ -1,0 +1,24 @@
+{-# OPTIONS --local-rewriting --rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+-- Test case by Jesper Cockx
+module LocalRewriteEagerMetas where
+
+-- Hack to stop "foo"s meta getting frozen
+MUTUAL : Set₁
+
+foo : (Nat → Nat) → Nat → Nat
+foo f x = _
+
+module M (f : Nat → Nat) (x : Nat) (@rewrite r : f x ≡ 0) where
+
+  solve1 : foo f x ≡ 0
+  solve1 = refl
+
+  solve2 : foo f x ≡ f x
+  solve2 = refl
+
+MUTUAL = Set

--- a/test/Fail/LocalRewriteEagerMetas.err
+++ b/test/Fail/LocalRewriteEagerMetas.err
@@ -1,0 +1,9 @@
+error: [UnsolvedConstraints]
+Failed to solve the following constraints:
+  _4 (f = f) (x = x) = 0 : Nat (blocked on _4)
+
+LocalRewriteEagerMetas.agda:14.11-22.16: error: [UnsolvedMetaVariables]
+Unsolved metas at the following locations:
+  LocalRewriteEagerMetas.agda:14.11-12
+  LocalRewriteEagerMetas.agda:19.12-16
+  LocalRewriteEagerMetas.agda:22.12-16

--- a/test/Fail/LocalRewriteInferMeta.agda
+++ b/test/Fail/LocalRewriteInferMeta.agda
@@ -1,0 +1,17 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteInferMeta where
+
+module _ (f : Nat → Nat) (@rewrite p : f 0 ≡ 1) where
+  foo : Nat
+  foo = 0
+
+  bar : Nat
+  bar = 0
+
+eta : _≡_ {A = _} (foo λ n → n) (bar λ n → n)
+eta = refl

--- a/test/Fail/LocalRewriteInferMeta.err
+++ b/test/Fail/LocalRewriteInferMeta.err
@@ -1,0 +1,30 @@
+error: [UnsolvedConstraints]
+Failed to solve the following constraints:
+  (@rewrite p : 0 ≡ 1) → Nat =< _A_9 (blocked on _A_9)
+
+LocalRewriteInferMeta.agda:16.7-45: error: [UnsolvedMetaVariables]
+Unsolved metas at the following locations:
+  LocalRewriteInferMeta.agda:16.7-10
+  LocalRewriteInferMeta.agda:16.16-17
+  LocalRewriteInferMeta.agda:16.20-31
+  LocalRewriteInferMeta.agda:16.34-45
+
+LocalRewriteInferMeta.agda:16.20-31: error: [InferredLocalRewrite]
+Tried to solve
+  _A_9
+with the following function (containing a local rewrite rule
+parameter):
+  (@rewrite p : 0 ≡ 1) → Nat
+Local rewrite rules must be explicitly annotated (never inferred).
+Please annotate all local rewrite rules explicitly.
+when checking that the expression foo λ n → n has type _A_9
+
+LocalRewriteInferMeta.agda:16.34-45: error: [InferredLocalRewrite]
+Tried to solve
+  _A_9
+with the following function (containing a local rewrite rule
+parameter):
+  (@rewrite p : 0 ≡ 1) → Nat
+Local rewrite rules must be explicitly annotated (never inferred).
+Please annotate all local rewrite rules explicitly.
+when checking that the expression bar λ n → n has type _A_9

--- a/test/Fail/LocalRewriteInferMeta2.agda
+++ b/test/Fail/LocalRewriteInferMeta2.agda
@@ -1,0 +1,17 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteInferMeta2 where
+
+module _ (f : Nat → Nat) (@rewrite p : f 0 ≡ 1) where
+  foo : Nat
+  foo = 0
+
+  bar : Nat
+  bar = 0
+
+eta : _≡_ {A = _ → _} (foo λ n → n) (bar λ n → n)
+eta = refl

--- a/test/Fail/LocalRewriteInferMeta2.err
+++ b/test/Fail/LocalRewriteInferMeta2.err
@@ -1,0 +1,6 @@
+LocalRewriteInferMeta2.agda:16.24-35: error: [UnequalTypes]
+The type
+  (@rewrite p : 0 ≡ 1) → Nat
+is not a subtype of
+  _10 → _12
+when checking that the expression foo λ n → n has type _10 → _12

--- a/test/Fail/LocalRewriteLambda.agda
+++ b/test/Fail/LocalRewriteLambda.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+foo : (x : Nat) (@rewrite p : 0 ≡ x) → Nat
+foo = λ x (@rewrite p : 0 ≡ x) → 0
+
+postulate D : Nat → Set
+
+bar = λ (x : Nat) (@rewrite p : 0 ≡ x) (a : D x) (b : D 0) (q : a ≡ b) → 0

--- a/test/Fail/LocalRewriteLambda.err
+++ b/test/Fail/LocalRewriteLambda.err
@@ -1,0 +1,14 @@
+LocalRewriteLambda.agda:7.7-43: error: [LocalRewriteOutsideTelescope]
+p : 0 ≡ x  is not a legal rewrite rule, since local rewrite rules
+are (currently) only allowed in module telescopes. Consider
+creating an anonymous module
+when checking that the expression
+(x : Nat) (@rewrite p : 0 ≡ x) → Nat is a type
+
+LocalRewriteLambda.agda:12.69-70: error: [UnequalTerms]
+The terms
+  zero
+and
+  x
+are not equal at type Nat
+when checking that the expression b has type D x

--- a/test/Fail/LocalRewriteMeta.agda
+++ b/test/Fail/LocalRewriteMeta.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteMeta where
+
+module _ (x : Nat) (@rewrite _ : x ≡ 0) where
+  foo : Nat
+  foo = 0
+
+bar : (x : Nat) → Nat
+bar x = foo x {!!}

--- a/test/Fail/LocalRewriteMeta.err
+++ b/test/Fail/LocalRewriteMeta.err
@@ -1,0 +1,10 @@
+LocalRewriteMeta.agda:14.9-14: error: [UnequalTerms]
+The terms
+  x
+and
+  zero
+are not equal at type Nat
+when checking the following local rewrite rule constraint:
+   |-  x  =  0  :  Nat
+when checking that ? is a valid argument to a function of type
+(@rewrite _ : x ≡ 0) → Nat

--- a/test/Fail/LocalRewriteNoEtaImplicit.agda
+++ b/test/Fail/LocalRewriteNoEtaImplicit.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+
+module LocalRewriteNoEtaImplicit where
+
+module _ (n : Nat) {@rewrite p : n ≡ 0} where
+  foo : Nat
+  foo = 42
+
+test : foo 0 ≡ foo 1
+test = refl

--- a/test/Fail/LocalRewriteNoEtaImplicit.err
+++ b/test/Fail/LocalRewriteNoEtaImplicit.err
@@ -1,0 +1,10 @@
+LocalRewriteNoEtaImplicit.agda:13.16-21: error: [UnequalTerms]
+The terms
+  1
+and
+  0
+are not equal at type Nat
+when checking the following local rewrite rule constraint:
+   |-  1  =  0  :  Nat
+when checking that 1 is a valid argument to a function of type
+(n : Nat) {@rewrite p : n ≡ 0} → Nat

--- a/test/Fail/LocalRewriteNotBound.agda
+++ b/test/Fail/LocalRewriteNotBound.agda
@@ -1,0 +1,11 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+
+module LocalRewriteNotBound where
+
+module _ (n : Nat) (@rewrite p : ∀ {m} → n ≡ m) where
+  test : ∀ {m} → n ≡ m
+  test = refl

--- a/test/Fail/LocalRewriteNotBound.err
+++ b/test/Fail/LocalRewriteNotBound.err
@@ -1,0 +1,13 @@
+LocalRewriteNotBound.agda:9.10-48: warning: -W[no]RewriteVariablesNotBoundByLHS
+p : {m : Nat} → n ≡ m  is not a legal rewrite rule, since the
+following variable is not bound by the left hand side:
+  m
+when checking the parameters of module _
+
+LocalRewriteNotBound.agda:11.10-14: error: [UnequalTerms]
+The terms
+  n
+and
+  m
+are not equal at type Nat
+when checking that the expression refl has type n ≡ m

--- a/test/Fail/LocalRewriteNotEnabled.agda
+++ b/test/Fail/LocalRewriteNotEnabled.agda
@@ -1,0 +1,9 @@
+{-# OPTIONS --rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+
+module LocalRewriteNotEnabled where
+
+module _ (n : Nat) (@rewrite p : n ≡ 0) where

--- a/test/Fail/LocalRewriteNotEnabled.err
+++ b/test/Fail/LocalRewriteNotEnabled.err
@@ -1,0 +1,3 @@
+LocalRewriteNotEnabled.agda:9.21-29: error: [AttributeKindNotEnabled]
+Rewrite attributes have not been enabled (use --local-rewriting to
+enable them): rewrite

--- a/test/Fail/LocalRewriteOutsideTele.agda
+++ b/test/Fail/LocalRewriteOutsideTele.agda
@@ -1,0 +1,9 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+-- For now, this is not allowed, but it eventually should be
+foo : (x : Nat) → @rewrite x ≡ 0 → Nat
+foo x p = 0

--- a/test/Fail/LocalRewriteOutsideTele.err
+++ b/test/Fail/LocalRewriteOutsideTele.err
@@ -1,0 +1,5 @@
+LocalRewriteOutsideTele.agda:8.19-39: error: [LocalRewriteOutsideTelescope]
+_ : x ≡ 0  is not a legal rewrite rule, since local rewrite rules
+are (currently) only allowed in module telescopes. Consider
+creating an anonymous module
+when checking that the expression x ≡ 0 → Nat is a type

--- a/test/Fail/LocalRewritePartialApp.agda
+++ b/test/Fail/LocalRewritePartialApp.agda
@@ -1,0 +1,15 @@
+{-# OPTIONS --local-rewriting  #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+
+module LocalRewritePartialApp where
+
+module Foo (f : Nat → Nat) (@rewrite ◆◆ : f 0 ≡ 1) where
+  foo : Nat
+  foo = 42
+
+-- Even though we haven't applied the local rewrite argument yet, we still need
+-- to throw an error because of how module applications get eta-expanded
+module Bar = Foo (λ _ → 0)

--- a/test/Fail/LocalRewritePartialApp.err
+++ b/test/Fail/LocalRewritePartialApp.err
@@ -1,0 +1,9 @@
+LocalRewritePartialApp.agda:15.1-27: error: [UnequalTerms]
+The terms
+  0
+and
+  1
+are not equal at type Nat
+when checking the following local rewrite rule constraint:
+   |-  0  =  1  :  Nat
+when checking the module application module Bar = Foo (λ _ → 0)

--- a/test/Fail/LocalRewriteRecordCubical.agda
+++ b/test/Fail/LocalRewriteRecordCubical.agda
@@ -1,0 +1,11 @@
+{-# OPTIONS --cubical --local-rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+open import Agda.Primitive.Cubical
+
+module LocalRewriteRecordCubical where
+
+module _ (n : Nat) (@rewrite p : n ≡ 0) where
+  record Bar : Set where

--- a/test/Fail/LocalRewriteRecordCubical.err
+++ b/test/Fail/LocalRewriteRecordCubical.err
@@ -1,0 +1,4 @@
+LocalRewriteRecordCubical.agda:11.10-13: error: [CannotGenerateTransportLocalRewrite]
+Could not generate a transport function for Bar
+because there is a local rewrite rule in its telescope
+when checking the definition of Bar

--- a/test/Fail/LocalRewriteToMeta.agda
+++ b/test/Fail/LocalRewriteToMeta.agda
@@ -1,0 +1,21 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+
+module LocalRewriteToMeta where
+
+nat : Nat
+nat = {!!}
+
+module _ (n : Nat) (@rewrite p : n ≡ nat) where
+  test : Nat
+  test = 42
+
+module _ (n : Nat) (@rewrite p : n ≡ {!!}) where
+  test2 : n ≡ _
+  test2 = refl
+
+test3 : 0 ≡ nat → Nat
+test3 p = test 0 p

--- a/test/Fail/LocalRewriteToMeta.err
+++ b/test/Fail/LocalRewriteToMeta.err
@@ -1,0 +1,5 @@
+error: [UnsolvedConstraints]
+Failed to solve the following constraints:
+  0 = ?0 : Nat (blocked on _1)
+when checking that the clause test3 p = test 0 p has type
+0 ≡ nat → Nat

--- a/test/Fail/NeedOptionRewriting.err
+++ b/test/Fail/NeedOptionRewriting.err
@@ -1,7 +1,3 @@
-NeedOptionRewriting.agda:6.1-28: warning: -W[no]UselessPragma
-Ignoring BUILTIN REWRITE pragma since option --rewriting is off
-when checking the pragma BUILTIN REWRITE _≡_
-
 NeedOptionRewriting.agda:25.1-23: warning: -W[no]UselessPragma
 Ignoring REWRITE pragma since option --rewriting is off
 when scope checking the declaration

--- a/test/Succeed/LocalRewrite.agda
+++ b/test/Succeed/LocalRewrite.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewrite where
+
+module Foo (n : Nat) (m : Nat) (@rewrite p : n + m ≡ m) (l : Nat) where
+  test : n + m ≡ m
+  test = refl
+
+test2 : 3 ≡ 3
+test2 = Foo.test 0 3 refl 42

--- a/test/Succeed/LocalRewriteBenignMatch.agda
+++ b/test/Succeed/LocalRewriteBenignMatch.agda
@@ -1,0 +1,14 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteBenignMatch where
+
+postulate
+  f : Nat → Nat
+
+module Foo (n : Nat) (m : Nat) (@rewrite p : f n ≡ 0) (q : f m ≡ 0) where
+  foo : m ≡ 42 → f 42 ≡ 0
+  foo refl = q

--- a/test/Succeed/LocalRewriteBenignMatch2.agda
+++ b/test/Succeed/LocalRewriteBenignMatch2.agda
@@ -1,0 +1,21 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+
+module LocalRewriteBenignMatch2 where
+
+data Foo : Nat → Set where
+  foo : ∀ {n} → Foo n
+
+module Bar (f : ∀ {n} → Foo n → Foo n)
+           (@rewrite p : ∀ {n} {x : Foo n} → f x ≡ x) where
+  test : ∀ {m} (x : Foo m) → f x ≡ foo
+  test foo = refl
+
+
+module Baz (f : ∀ {n} → Foo n → Foo n) (k : Nat) (l : Nat)
+           (@rewrite p : ∀ {n} {x : Foo n} → f x ≡ x) where
+  test : ∀ {m} (x : Foo m) → f x ≡ foo
+  test foo = refl

--- a/test/Succeed/LocalRewriteBiggerMatch.agda
+++ b/test/Succeed/LocalRewriteBiggerMatch.agda
@@ -1,0 +1,11 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteBiggerMatch where
+
+module Foo (f g : Nat → Nat) (n : Nat) (@rewrite p : f (g n) ≡ 0) where
+  test : f (g n) ≡ 0
+  test = refl

--- a/test/Succeed/LocalRewriteBool.agda
+++ b/test/Succeed/LocalRewriteBool.agda
@@ -1,0 +1,21 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteBool where
+
+module Foo (Bool : Set) (tt ff : Bool) (not : Bool → Bool)
+           (@rewrite not-tt : not tt ≡ ff) (@rewrite not-ff : not ff ≡ tt)
+           where
+  test1 : not (not tt) ≡ tt
+  test1 = refl
+
+open import Agda.Builtin.Bool
+
+not : Bool → Bool
+not true  = false
+not false = true
+
+test2 : true ≡ true
+test2 = Foo.test1 Bool true false not refl refl

--- a/test/Succeed/LocalRewriteBoolSlow.agda
+++ b/test/Succeed/LocalRewriteBoolSlow.agda
@@ -1,0 +1,21 @@
+{-# OPTIONS --local-rewriting --no-fast-reduce #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteBoolSlow where
+
+module Foo (Bool : Set) (tt ff : Bool) (not : Bool → Bool)
+           (@rewrite not-tt : not tt ≡ ff) (@rewrite not-ff : not ff ≡ tt)
+           where
+  test1 : not (not tt) ≡ tt
+  test1 = refl
+
+open import Agda.Builtin.Bool
+
+not : Bool → Bool
+not true  = false
+not false = true
+
+test2 : true ≡ true
+test2 = Foo.test1 Bool true false not refl refl

--- a/test/Succeed/LocalRewriteBoolTele.agda
+++ b/test/Succeed/LocalRewriteBoolTele.agda
@@ -1,0 +1,27 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteBoolTele where
+
+module Foo (Bool : Set) (tt ff : Bool)
+           (elim : (P : Bool → Set) → P tt → P ff → ∀ b → P b)
+           (@rewrite elim-tt : ∀ {P t f} → elim P t f tt ≡ t)
+           (@rewrite elim-ff : ∀ {P t f} → elim P t f ff ≡ f) where
+  not : Bool → Bool
+  not = elim (λ _ → Bool) ff tt
+
+  not-not : ∀ b → not (not b) ≡ b
+  not-not = elim (λ b → not (not b) ≡ b) refl refl
+
+open import Agda.Builtin.Bool
+
+elim : (P : Bool → Set) → P true → P false → ∀ b → P b
+elim P t f true  = t
+elim P t f false = f
+
+not = Foo.not Bool true false elim refl refl
+
+not-not : ∀ b → not (not b) ≡ b
+not-not = Foo.not-not Bool true false elim refl refl

--- a/test/Succeed/LocalRewriteBoolTeleSlow.agda
+++ b/test/Succeed/LocalRewriteBoolTeleSlow.agda
@@ -1,0 +1,27 @@
+{-# OPTIONS --local-rewriting --no-fast-reduce #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteBoolTeleSlow where
+
+module Foo (Bool : Set) (tt ff : Bool)
+           (elim : (P : Bool → Set) → P tt → P ff → ∀ b → P b)
+           (@rewrite elim-tt : ∀ {P t f} → elim P t f tt ≡ t)
+           (@rewrite elim-ff : ∀ {P t f} → elim P t f ff ≡ f) where
+  not : Bool → Bool
+  not = elim (λ _ → Bool) ff tt
+
+  not-not : ∀ b → not (not b) ≡ b
+  not-not = elim (λ b → not (not b) ≡ b) refl refl
+
+open import Agda.Builtin.Bool
+
+elim : (P : Bool → Set) → P true → P false → ∀ b → P b
+elim P t f true  = t
+elim P t f false = f
+
+not = Foo.not Bool true false elim refl refl
+
+not-not : ∀ b → not (not b) ≡ b
+not-not = Foo.not-not Bool true false elim refl refl

--- a/test/Succeed/LocalRewriteCopattern.agda
+++ b/test/Succeed/LocalRewriteCopattern.agda
@@ -1,0 +1,33 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+-- Based on #3812
+module LocalRewriteCopattern where
+
+record Box (A : Set) : Set where
+  constructor box
+  field unbox : A
+
+open Box
+
+module Test1 (A : Set) (r s : Box A) (@rewrite rew : r .unbox ≡ s .unbox) where
+
+  ext : r ≡ s
+  ext = refl
+
+module Test2 (A : Set) (r : Nat → Box A) (@rewrite rew : r 0 .unbox ≡ r 1 .unbox) where
+
+  ext : r 0 ≡ r 1
+  ext = refl
+
+postulate
+  A : Set
+  r s : Box A
+
+module Test3 (@rewrite rew : r .unbox ≡ s .unbox) where
+
+  ext : r ≡ s
+  ext = refl

--- a/test/Succeed/LocalRewriteEtaMatch.agda
+++ b/test/Succeed/LocalRewriteEtaMatch.agda
@@ -1,0 +1,20 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Sigma
+
+module LocalRewriteEtaMatch where
+
+module Foo (z : Σ Nat (λ _ → Nat))
+           (x y : Nat)
+           (@rewrite p : z .fst ≡ x) where
+  test : ∀ {z₁ z₂ z₃} → z₁ ≡ z₃ → z ≡ (z₁ , z₂) → x ≡ z₃
+  test q refl = q
+
+module Bar (z : Σ Nat (λ _ → Nat))
+           (x y : Nat)
+           (@rewrite p : x ≡ z .fst) where
+  test : ∀ {z₁ z₂ z₃} → z₁ ≡ z₃ → z ≡ (z₁ , z₂) → x ≡ z₃
+  test q refl = q

--- a/test/Succeed/LocalRewriteExt.agda
+++ b/test/Succeed/LocalRewriteExt.agda
@@ -1,0 +1,48 @@
+{-# OPTIONS --rewriting --local-rewriting -WnoRewriteVariablesBoundInSingleton #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteExt where
+
+variable
+  A B : Set
+  x y : A
+
+postulate
+  I     : Set
+  i0 i1 : I
+  ~_    : I → I
+  ~0    : ~ i0 ≡ i1
+  ~1    : ~ i1 ≡ i0
+
+{-# REWRITE ~0 ~1 #-}
+
+postulate
+  Path : (A : Set) → A → A → Set
+
+postulate
+  fromPath : Path A x y → I → A
+
+  fromPath0 : {p : Path A x y} → fromPath p i0 ≡ x
+  fromPath1 : {p : Path A x y} → fromPath p i1 ≡ y
+
+module _ {A : Set} (f : I → A) {x y : A}
+         (@rewrite f0 : f i0 ≡ x) (@rewrite f1 : f i1 ≡ y) where
+  postulate
+    toPath : Path A x y
+
+    fromTo : fromPath toPath ≡ f
+
+{-# REWRITE fromPath0 fromPath1 #-}
+
+postulate
+  toFrom : {p : Path A x y} → toPath (fromPath p) refl refl ≡ p
+
+{-# REWRITE fromTo toFrom #-}
+
+sym : Path A x y → Path A y x
+sym p = toPath (λ i → fromPath p (~ i)) refl refl
+
+ap : (f : A → B) → Path A x y → Path B (f x) (f y)
+ap f p = toPath (λ i → f (fromPath p i)) refl refl

--- a/test/Succeed/LocalRewriteGeneralised.agda
+++ b/test/Succeed/LocalRewriteGeneralised.agda
@@ -1,0 +1,37 @@
+{-# OPTIONS --rewriting --local-rewriting -WnoRewriteVariablesBoundInSingleton #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+-- Used to hit __IMPOSSIBLE__
+-- Now the local rewrites just don't get elaborated because of generalised
+-- variables, which still isn't great but at least it doesn't crash
+module LocalRewriteGeneralised where
+
+variable
+  A B : Set
+  x y : A
+
+postulate
+  I     : Set
+  i0 i1 : I
+
+postulate
+  Path : (A : Set) → A → A → Set
+
+-- Used to be __IMPOSSIBLE__ in Telescope.hs
+module _ (f : I → A) (@rewrite f0 : f i0 ≡ x) where
+  postulate
+    test : f i0 ≡ x
+
+-- Used to be __IMPOSSIBLE__ in MetaVars.hs
+module _ (f : I → A) {x y : A}
+         (@rewrite f0 : f i0 ≡ x) where
+  postulate
+    test2 : f i0 ≡ x
+
+-- Work-around which doesn't hit any warnings
+module _ (f : I → A) {x : A} where
+  module _ (@rewrite f0 : f i0 ≡ x) where
+    test3 : f i0 ≡ x
+    test3 = refl

--- a/test/Succeed/LocalRewriteGeneralised.warn
+++ b/test/Succeed/LocalRewriteGeneralised.warn
@@ -1,0 +1,25 @@
+LocalRewriteGeneralised.agda:23.10-46: warning: -W[no]RewriteContainsUnsolvedMetaVariables
+f0 : f i0 ≡ _x_15 (genTel = genTel)  is not a legal rewrite rule,
+since it contains the unsolved meta variables:
+  _A_13 _x_15
+when checking the parameters of module _
+
+LocalRewriteGeneralised.agda:28.10-29.34: warning: -W[no]RewriteContainsUnsolvedMetaVariables
+f0 : f i0 ≡ x  is not a legal rewrite rule, since it contains the
+unsolved meta variable:
+  _A_25
+when checking the parameters of module _
+
+———— All done; warnings encountered ————————————————————————
+
+LocalRewriteGeneralised.agda:23.10-46: warning: -W[no]RewriteContainsUnsolvedMetaVariables
+f0 : f i0 ≡ _x_15 (genTel = genTel)  is not a legal rewrite rule,
+since it contains the unsolved meta variables:
+  _A_13 _x_15
+when checking the parameters of module _
+
+LocalRewriteGeneralised.agda:28.10-29.34: warning: -W[no]RewriteContainsUnsolvedMetaVariables
+f0 : f i0 ≡ x  is not a legal rewrite rule, since it contains the
+unsolved meta variable:
+  _A_25
+when checking the parameters of module _

--- a/test/Succeed/LocalRewriteInductive.agda
+++ b/test/Succeed/LocalRewriteInductive.agda
@@ -1,0 +1,120 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+-- Based on 7.3: Inductive Types from https://hal.science/hal-05160846/document
+module LocalRewriteInductive where
+
+module Utils where
+  private variable
+    A B C : Set _
+    x y z : A
+
+  ap : (f : A → B) → x ≡ y → f x ≡ f y
+  ap f refl = refl
+open Utils
+
+record Naturals : Set₁ where
+  field
+    Nat : Set
+    ze  : Nat
+    su  : Nat → Nat
+
+    elim : (P : Nat → Set) → P ze → (∀ n → P n → P (su n)) → ∀ n → P n
+
+  elim-ze≡ : Set₁
+  elim-ze≡ = ∀ {P z s} → elim P z s ze ≡ z
+
+  elim-su≡ : Set₁
+  elim-su≡ = ∀ {P z s n} → elim P z s (su n) ≡ s n (elim P z s n)
+open Naturals using (elim-ze≡; elim-su≡)
+
+module UsingNaturals (𝒩 : Naturals)
+                     (@rewrite elim-ze : elim-ze≡ 𝒩)
+                     (@rewrite elim-su : elim-su≡ 𝒩)
+                     where
+  open Naturals 𝒩
+
+  _+_ : Nat → Nat → Nat
+  n + m = elim _ m (λ _ → su) n
+
+  test₁ : su (su ze) + su ze ≡ su (su (su ze))
+  test₁ = refl
+
+  +ass : ∀ {n m l} → (n + m) + l ≡ n + (m + l)
+  +ass {n = n} {m = m} {l = l}
+    = elim (λ □ → (□ + m) + l ≡ □ + (m + l)) refl (λ _ → ap su) n
+
+module PrimNaturals where
+  open import Agda.Builtin.Nat renaming (zero to ze; suc to su)
+
+  primNaturals : Naturals
+  primNaturals .Naturals.Nat  = Nat
+  primNaturals .Naturals.ze   = ze
+  primNaturals .Naturals.su   = su
+  primNaturals .Naturals.elim P z s ze = z
+  primNaturals .Naturals.elim P z s (su n)
+    = s n (primNaturals .Naturals.elim P z s n)
+
+  module N = UsingNaturals primNaturals refl refl
+
+  test₂ : 2 N.+ 1 ≡ 3
+  test₂ = refl
+
+module WNaturals where
+  open import Agda.Builtin.Nat renaming (zero to ze; suc to su)
+
+  private variable
+    A B : Set
+    n m : Nat
+
+  data Vec (A : Set) : Nat → Set where
+    []   : Vec A ze
+    _,-_ : A → Vec A n → Vec A (su n)
+
+  variable
+    x y   : A
+    xs ys : Vec _ _
+    rec   : A → Nat
+
+  data All (P : A → Set) : Vec A n → Set where
+    []   : All P []
+    _,-_ : P x → All P xs → All P (x ,- xs)
+
+  data W (A : Set) (rec : A → Nat) : Set where
+    c : (x : A) → Vec (W A rec) (rec x) → W A rec
+
+  elim : (P : W A rec → Set)
+       → (∀ {x xs} → All P xs → P (c x xs))
+       → ∀ x → P x
+  elim' : (P : W A rec → Set)
+        → (∀ {x xs} → All P xs → P (c x xs))
+        → (xs : Vec (W A rec) n) → All P xs
+
+  elim P p (c x xs) = p (elim' P p xs)
+
+  elim' P p []        = []
+  elim' P p (x ,- xs) = elim P p x ,- elim' P p xs
+
+  open import Agda.Builtin.Bool
+
+  natPositions : Bool → Nat
+  natPositions true  = 1
+  natPositions false = 0
+
+  wNaturals : Naturals
+  wNaturals .Naturals.Nat  = W Bool natPositions
+  wNaturals .Naturals.ze   = c false []
+  wNaturals .Naturals.su n = c true (n ,- [])
+  wNaturals .Naturals.elim P z s (c false [])
+    = z
+  wNaturals .Naturals.elim P z s (c true  (n ,- []))
+    = s n (wNaturals .Naturals.elim P z s n)
+
+  module N = UsingNaturals wNaturals refl refl
+
+  test₃ :   c true (c true (c false [] ,- []) ,- [])
+        N.+ c true (c false [] ,- [])
+        ≡   c true (c true (c true (c false [] ,- []) ,- []) ,- [])
+  test₃ = refl

--- a/test/Succeed/LocalRewriteLet.agda
+++ b/test/Succeed/LocalRewriteLet.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module _ where
+
+bar : (x : Nat) → 0 ≡ x → Nat
+bar x p = let @rewrite q : 0 ≡ x
+              q = p
+           in x

--- a/test/Succeed/LocalRewriteLet.warn
+++ b/test/Succeed/LocalRewriteLet.warn
@@ -1,0 +1,15 @@
+LocalRewriteLet.agda:10.15-23: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+when scope checking
+let q : 0 ≡ x
+    q = p
+in x
+
+———— All done; warnings encountered ————————————————————————
+
+LocalRewriteLet.agda:10.15-23: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+when scope checking
+let q : 0 ≡ x
+    q = p
+in x

--- a/test/Succeed/LocalRewriteMisplaced.agda
+++ b/test/Succeed/LocalRewriteMisplaced.agda
@@ -1,0 +1,29 @@
+{-# OPTIONS --local-rewriting --erasure #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+
+module LocalRewriteMisplaced where
+
+-- Eventually @rewrite on declarations should be supported as alternative an
+-- alternative for {-# REWRITE #-} pragmas
+-- All other uses should probably remain warnings
+postulate
+  @rewrite test : ∀ {x} → x + 0 ≡ x
+
+@rewrite test2 : ∀ {x} → x + 0 ≡ x
+@rewrite test2 = test
+
+variable
+  @rewrite p : ∀ {x} → x + 0 ≡ x
+
+data @rewrite Foo : Set where
+  @rewrite mk : Foo
+
+record @rewrite Bar : Set where
+  field
+    @rewrite proj : Foo
+
+test3 : Nat → Nat
+test3 x = let postulate @rewrite p : x ≡ 0 in 42

--- a/test/Succeed/LocalRewriteMisplaced.warn
+++ b/test/Succeed/LocalRewriteMisplaced.warn
@@ -1,0 +1,63 @@
+LocalRewriteMisplaced.agda:13.3-11: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+
+LocalRewriteMisplaced.agda:15.1-9: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+
+LocalRewriteMisplaced.agda:16.1-9: warning: -W[no]MisplacedAttributes
+Ignoring local rewrite attribute, illegal in function clauses
+
+LocalRewriteMisplaced.agda:19.3-11: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+
+LocalRewriteMisplaced.agda:21.6-14: warning: -W[no]UnsupportedAttribute
+Rewrite attributes are not supported here.
+
+LocalRewriteMisplaced.agda:22.3-11: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+
+LocalRewriteMisplaced.agda:24.8-16: warning: -W[no]UnsupportedAttribute
+Rewrite attributes are not supported here.
+
+LocalRewriteMisplaced.agda:26.14-24: warning: -W[no]MisplacedRewrite
+Ignoring illegal local rewrite attribute on field
+when scope checking the declaration
+  record Bar where
+    field proj : Foo
+
+LocalRewriteMisplaced.agda:29.25-33: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+when scope checking let postulate p : x ≡ 0 in 42
+
+———— All done; warnings encountered ————————————————————————
+
+LocalRewriteMisplaced.agda:13.3-11: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+
+LocalRewriteMisplaced.agda:15.1-9: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+
+LocalRewriteMisplaced.agda:16.1-9: warning: -W[no]MisplacedAttributes
+Ignoring local rewrite attribute, illegal in function clauses
+
+LocalRewriteMisplaced.agda:19.3-11: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+
+LocalRewriteMisplaced.agda:21.6-14: warning: -W[no]UnsupportedAttribute
+Rewrite attributes are not supported here.
+
+LocalRewriteMisplaced.agda:22.3-11: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+
+LocalRewriteMisplaced.agda:24.8-16: warning: -W[no]UnsupportedAttribute
+Rewrite attributes are not supported here.
+
+LocalRewriteMisplaced.agda:26.14-24: warning: -W[no]MisplacedRewrite
+Ignoring illegal local rewrite attribute on field
+when scope checking the declaration
+  record Bar where
+    field proj : Foo
+
+LocalRewriteMisplaced.agda:29.25-33: warning: -W[no]MisplacedRewrite
+Ignoring misplaced local rewrite attribute.
+when scope checking let postulate p : x ≡ 0 in 42

--- a/test/Succeed/LocalRewriteMonoid.agda
+++ b/test/Succeed/LocalRewriteMonoid.agda
@@ -1,0 +1,119 @@
+{-# OPTIONS --local-rewriting --prop --without-K #-}
+
+module LocalRewriteMonoid where
+
+data _≡_ {A : Set} (x : A) : A → Prop where
+  refl : x ≡ x
+{-# BUILTIN REWRITE _≡_ #-}
+
+infix 4 _≡_
+
+variable
+  A B C : Set
+
+ap : ∀ (f : A → B) {x₁ x₂} → x₁ ≡ x₂ → f x₁ ≡ f x₂
+ap f refl = refl
+
+ap₂ : ∀ (f : A → B → C) {x₁ x₂ y₁ y₂} → x₁ ≡ x₂ → y₁ ≡ y₂ → f x₁ y₁ ≡ f x₂ y₂
+ap₂ f refl refl = refl
+
+ap-app : ∀ {f₁ f₂ : A → B} {x} → f₁ ≡ f₂ → f₁ x ≡ f₂ x
+ap-app refl = refl
+
+sym : ∀ {x y : A} → x ≡ y → y ≡ x
+sym refl = refl
+
+_∙_ : ∀ {x y z : A} → x ≡ y → y ≡ z → x ≡ z
+refl ∙ q = q
+
+postulate
+  funext : ∀ {f g : A → B} → (∀ x → f x ≡ g x) → f ≡ g
+
+module Foo (Car : Set) (_◆_ : Car → Car → Car) (id : Car)
+           (@rewrite ◆◆ : ∀ {x y z} → (x ◆ y) ◆ z ≡ x ◆ (y ◆ z))
+           (@rewrite ◆id : ∀ {x} → x ◆ id ≡ x)
+           (@rewrite id◆ : ∀ {x} → id ◆ x ≡ x)
+           where
+  foo : ∀ {x y} → ((id ◆ (x ◆ id)) ◆ y) ◆ id ≡ x ◆ y
+  foo = refl
+
+module List (A : Set) where
+  data List : Set where
+    []   : List
+    _,-_ : A → List → List
+
+  variable
+    xs ys zs : List
+
+  _++_ : List → List → List
+  [] ++ ys        = ys
+  (x ,- xs) ++ ys = x ,- (xs ++ ys)
+
+  ++[] : ∀ {xs} → xs ++ [] ≡ xs
+  ++[] {xs = []}      = refl
+  ++[] {xs = x ,- xs} = ap (x ,-_) ++[]
+
+  ++++ : ∀ {xs ys zs} → (xs ++ ys) ++ zs ≡ xs ++ (ys ++ zs)
+  ++++ {xs = []}      = refl
+  ++++ {xs = x ,- xs} = ap (x ,-_) (++++ {xs = xs})
+
+  PreDList : Set
+  PreDList = List → List
+
+  []D' : PreDList
+  []D' xs = xs
+
+  _++D'_ : PreDList → PreDList → PreDList
+  (xsD ++D' ysD) zs = xsD (ysD zs)
+
+  _,-D'_ : A → PreDList → PreDList
+  (x ,-D' xsD) ys = x ,- xsD ys
+
+  data CohDList : PreDList → Prop where
+    []C   : CohDList []D'
+    _,-C_ : ∀ x {xsD} → CohDList xsD → CohDList (x ,-D' xsD)
+
+  record DList : Set where
+    constructor _,_
+    field
+      pre : PreDList
+      coh : CohDList pre
+  open DList
+
+  []D : DList
+  []D .pre = []D'
+  []D .coh = []C
+
+  _++C_ : ∀ {xsD ysD} → CohDList xsD → CohDList ysD → CohDList (xsD ++D' ysD)
+  []C         ++C ysC = ysC
+  (x ,-C xsC) ++C ysC = x ,-C (xsC ++C ysC)
+
+  _++D_ : DList → DList → DList
+  (xsD ++D ysD) .pre = xsD .pre ++D' ysD .pre
+  (xsD ++D ysD) .coh = xsD .coh ++C ysD .coh
+
+  -- And now we can access the contents of Foo!
+  open Foo DList _++D_ []D refl refl refl
+
+  -- DList is actually isomorphic to List
+  -- (Unimportant for the test, but for fun)
+  pre≡ : ∀ {xsD ysD} → xsD .pre ≡ ysD .pre → xsD ≡ ysD
+  pre≡ refl = refl
+
+  to : DList → List
+  to xsD = xsD .pre []
+
+  from : List → DList
+  from xs        .pre ys = xs ++ ys
+  from []        .coh    = []C
+  from (x ,- xs) .coh    = x ,-C (from xs .coh)
+
+  to-from : ∀ {xs} → to (from xs) ≡ xs
+  to-from = ++[]
+
+  from-to : ∀ {xsD : DList} → from (to xsD) ≡ xsD
+  from-to {xsD = xsD , xsC} = pre≡ (go xsC) where
+    go : ∀ {xsD} (xsC : CohDList xsD) → from (to (xsD , xsC)) .pre ≡ xsD
+    go []C         = refl
+    go (x ,-C xsC) = funext λ ys → ap (x ,-_) (ap-app (go xsC))
+

--- a/test/Succeed/LocalRewriteNested.agda
+++ b/test/Succeed/LocalRewriteNested.agda
@@ -1,0 +1,18 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+module LocalRewriteNested where
+
+module Foo (n : Nat) (m : Nat) where
+  module Bar (@rewrite p : n + m ≡ m) (l : Nat) where
+    test : n + m ≡ m
+    test = refl
+
+open Foo 0 3
+open Bar refl 42
+
+test2 : 3 ≡ 3
+test2 = test

--- a/test/Succeed/LocalRewriteNonConfluent.agda
+++ b/test/Succeed/LocalRewriteNonConfluent.agda
@@ -1,0 +1,11 @@
+{-# OPTIONS --local-rewriting --local-confluence-check #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+
+-- Confluence checking for local rewrite rules is not yet implemented
+module LocalRewriteNonConfluent where
+
+module _ (f g : Nat → Nat) (@rewrite p : ∀ {n} → f (g n) ≡ 0) (@rewrite q : g 0 ≡ 0)
+         where

--- a/test/Succeed/LocalRewriteNonConfluent.warn
+++ b/test/Succeed/LocalRewriteNonConfluent.warn
@@ -1,0 +1,12 @@
+
+LocalRewriteNonConfluent.agda:1.1-59: warning: -W[no]LocalRewritingConfluenceCheck
+Confluence checking (--confluence-check or
+--local-confluence-check) is not yet implemented for local rewrite
+rules (--local-rewriting)
+
+———— All done; warnings encountered ————————————————————————
+
+LocalRewriteNonConfluent.agda:1.1-59: warning: -W[no]LocalRewritingConfluenceCheck
+Confluence checking (--confluence-check or
+--local-confluence-check) is not yet implemented for local rewrite
+rules (--local-rewriting)

--- a/test/Succeed/LocalRewritePartialApp.agda
+++ b/test/Succeed/LocalRewritePartialApp.agda
@@ -1,0 +1,18 @@
+{-# OPTIONS --local-rewriting  #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+
+module LocalRewritePartialApp where
+
+module Foo (f : Nat → Nat) (@rewrite ◆◆ : f 0 ≡ 1) where
+  foo : Nat
+  foo = 42
+
+module Bar = Foo (λ _ → 1)
+
+open Bar refl
+
+test : Nat
+test = foo

--- a/test/Succeed/LocalRewriteQuotient.agda
+++ b/test/Succeed/LocalRewriteQuotient.agda
@@ -1,0 +1,129 @@
+{-# OPTIONS --local-rewriting --cubical #-}
+
+open import Agda.Builtin.Cubical.Path
+open import Agda.Primitive.Cubical
+open import Agda.Builtin.Nat renaming (zero to ze; suc to su) hiding (_-_)
+
+-- Based on 7.4: Quotients from https://hal.science/hal-05160846/document
+module LocalRewriteQuotient where
+
+{-# BUILTIN REWRITE _≡_ #-}
+
+module Utils where
+  infixr 5 _∙_
+
+  private variable
+    A B C : Set _
+    x y z : A
+
+  refl : x ≡ x
+  refl {x = x} i = x
+
+  sym : x ≡ y → y ≡ x
+  sym p i = p (primINeg i)
+
+  _∙_ : x ≡ y → y ≡ z → x ≡ z
+  _∙_ {z = z} p q i
+    = primHComp (λ where j (i = i0) → p (primINeg j)
+                         j (i = i1) → z)
+                (q i)
+
+  ap : (f : A → B) → x ≡ y → f x ≡ f y
+  ap f p i = f (p i)
+open Utils
+
+variable
+  A B : Set
+  _≈_ : A → A → Set
+
+record Quotients : Set₁ where
+  field
+    Quot  : (A : Set) → (A → A → Set) → Set
+    mk    : (_≈_ : A → A → Set) → A → Quot A _≈_
+    lift  : (f : A → B) → (∀ {x y} → x ≈ y → f x ≡ f y) → Quot A _≈_ → B
+    sound : ∀ {x y : A} → x ≈ y → mk _≈_ x ≡ mk _≈_ y
+
+  -- The β-law for quotients we want to make strict
+  lift-mk≡ : Set₁
+  lift-mk≡ = ∀ {A _≈_ B} {f : A → B} {p : ∀ {x y} → x ≈ y → f x ≡ f y} {x}
+           → lift f p (mk _≈_ x) ≡ f x
+
+open Quotients using (lift-mk≡)
+
+-- We define this outside of 'UsingQuotients' because of an incompatibility
+-- between '--cubical' and datatypes with '@rewrite' arguments in their telescope.
+-- Specifically, what should the generated type for 'transp' be?
+record PreInt : Set where
+  constructor _-_
+  field
+    pos : Nat
+    neg : Nat
+
+module UsingQuotients (𝒬 : Quotients)
+                      (@rewrite lift-mk : lift-mk≡ 𝒬) where
+  open Quotients 𝒬
+
+  _≈Int_ : PreInt → PreInt → Set
+  (n₁ - k₁) ≈Int (n₂ - k₂) = n₁ + k₂ ≡ n₂ + k₁
+
+  Int = Quot PreInt _≈Int_
+
+  +ze : ∀ {n} → n + ze ≡ n
+  +ze {n = ze}   = refl
+  +ze {n = su n} = ap su +ze
+
+  +su : ∀ {n m} → n + su m ≡ su (n + m)
+  +su {n = ze}   = refl
+  +su {n = su n} = ap su +su
+
+  +comm : ∀ {n m} → n + m ≡ m + n
+  +comm {m = ze}   = +ze
+  +comm {m = su m} = +su ∙ ap su (+comm {m = m})
+
+  preNegate : PreInt → PreInt
+  preNegate (n - k) = k - n
+
+  preNegate≈ : ∀ {x y} → x ≈Int y → preNegate x ≈Int preNegate y
+  preNegate≈ {x = n₁ - k₁} {y = n₂ - k₂} p
+    = +comm {n = k₁} ∙ sym p ∙ +comm {n = n₁}
+
+  negate : Int → Int
+  negate = lift (λ x' → mk _≈Int_ (preNegate x'))
+                (λ {x₁ x₂} p → sound (preNegate≈ {x = x₁} {y = x₂} p))
+
+  test₁ : ∀ {n k} → negate (mk _ (n - k)) ≡ mk _ (k - n)
+  test₁ = refl
+
+open Quotients
+
+fakeQuotients : Quotients
+fakeQuotients .Quot  A _≈_ = A
+fakeQuotients .mk    _≈_ x = x
+fakeQuotients .lift  f p x = f x
+fakeQuotients .sound       = cheat
+  where postulate cheat : _
+
+module F = UsingQuotients fakeQuotients refl
+
+test₂ : ∀ {n k} → F.negate (n - k) ≡ k - n
+test₂ = refl
+
+-- In Cubical Agda, we don't *have* to fake quotients. We can also implement
+-- them with HITs.
+
+-- Non-truncated quotient ("type quotient")
+data QuotHIT (A : Set) (_≈_ : A → A → Set) : Set where
+  mkHIT    : A → QuotHIT A _≈_
+  soundHIT : ∀ {x y} → x ≈ y → mkHIT x ≡ mkHIT y
+
+hitQuotients : Quotients
+hitQuotients .Quot   = QuotHIT
+hitQuotients .mk _≈_ = mkHIT
+hitQuotients .lift  f p (mkHIT x)      = f x
+hitQuotients .lift  f p (soundHIT q i) = p q i
+hitQuotients .sound = soundHIT
+
+module H = UsingQuotients hitQuotients refl
+
+test₃ : ∀ {n k} → H.negate (mkHIT (n - k)) ≡ mkHIT (k - n)
+test₃ = refl

--- a/test/Succeed/LocalRewriteSubst.agda
+++ b/test/Succeed/LocalRewriteSubst.agda
@@ -1,0 +1,114 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Nat
+
+module LocalRewriteSubst where
+
+module Utils where
+  infixr 4 _∙_
+
+  private variable
+    A B C D : Set _
+    x y z w : A
+
+  sym : x ≡ y → y ≡ x
+  sym refl = refl
+
+  _∙_ : x ≡ y → y ≡ z → x ≡ z
+  refl ∙ q = q
+
+  ap : (f : A → B) → x ≡ y → f x ≡ f y
+  ap f refl = refl
+
+  ap₂ : (f : A → B → C) → x ≡ y → z ≡ w → f x z ≡ f y w
+  ap₂ f refl refl = refl
+open Utils
+
+Ctx = Nat
+
+pattern _▷ Γ = suc Γ
+pattern •    = zero
+
+variable
+  Γ Δ Θ : Ctx
+
+data Var : Nat → Set where
+  vz : Var (Γ ▷)
+  vs : Var Γ → Var (Γ ▷)
+
+data Tm : Nat → Set where
+  var : Var Γ → Tm Γ
+  lam : Tm (Γ ▷) → Tm Γ
+  app : Tm Γ → Tm Γ → Tm Γ
+
+data Tms (F : Ctx → Set) (Δ : Ctx) : Ctx → Set where
+  ε   : Tms F Δ •
+  _,_ : Tms F Δ Γ → F Δ → Tms F Δ (Γ ▷)
+
+variable
+  x y z : Var _
+  t u v : Tm _
+  δ σ τ : Tms _ _ _
+
+module _ {F : Ctx → Set} where
+  lookup : Var Γ → Tms F Δ Γ → F Δ
+  lookup vz     (δ , t) = t
+  lookup (vs x) (δ , t) = lookup x δ
+
+module FSubst
+  (F : Ctx → Set)
+  (fz : ∀ {Γ} → F (Γ ▷))
+  (fs : ∀ {Γ} → F Γ → F (Γ ▷))
+  (F↑ : ∀ {Γ} → F Γ → Tm Γ)
+  where
+
+  _[_] : Tm Γ → Tms F Δ Γ → Tm Δ
+  _⁺   : Tms F Δ Γ → Tms F (Δ ▷) Γ
+  _^   : Tms F Δ Γ → Tms F (Δ ▷) (Γ ▷)
+
+  var x   [ δ ] = F↑ (lookup x δ)
+  lam t   [ δ ] = lam (t [ δ ^ ])
+  app t u [ δ ] = app (t [ δ ]) (u [ δ ])
+
+  δ ^ = (δ ⁺) , fz
+
+  ε       ⁺ = ε
+  (δ , t) ⁺ = (δ ⁺) , fs t
+
+  id : Tms F Γ Γ
+  id {Γ = •}   = ε
+  id {Γ = Γ ▷} = id ^
+
+  module IdProofs
+    (↑F  : ∀ {Γ} → Var Γ → F Γ)
+    (@rewrite ↑vz : ∀ {Γ} → ↑F (vz {Γ = Γ}) ≡ fz)
+    (↑vs : ∀ {Γ} {x : Var Γ} → ↑F (vs x) ≡ fs (↑F x))
+    (@rewrite ↑F↑ : ∀ {Γ} {x : Var Γ} → F↑ (↑F x) ≡ var x)
+    where
+
+    lookup-⁺ : lookup x (δ ⁺) ≡ fs (lookup x δ)
+    lookup-id : lookup x id ≡ ↑F x
+
+    lookup-⁺ {x = vz}   {δ = δ , t} = refl
+    lookup-⁺ {x = vs x} {δ = δ , t} = lookup-⁺ {x = x} {δ = δ}
+
+    lookup-id {x = vz}   = refl
+    lookup-id {x = vs x} =
+      lookup-⁺ {x = x} {δ = id} ∙ ap fs lookup-id ∙ sym ↑vs
+
+    [id] : t [ id ] ≡ t
+    [id] {t = var x}   = ap F↑ lookup-id
+    [id] {t = lam t}   = ap lam [id]
+    [id] {t = app t u} = ap₂ app [id] [id]
+
+module Ren   = FSubst Var vz vs var
+module Subst = FSubst Tm (var vz) (Ren._[ Ren.id Ren.⁺ ]) (λ t → t)
+
+module RenIdProofs   = Ren.IdProofs (λ x → x) refl refl refl
+module SubstIdProofs = Subst.IdProofs var refl (λ {_} {x} →
+  ap var (sym (RenIdProofs.lookup-⁺ {x = x} ∙ ap vs (RenIdProofs.lookup-id))))
+  refl
+
+-- TODO: Composition

--- a/test/Succeed/LocalRewriteUpdateInjectivity.agda
+++ b/test/Succeed/LocalRewriteUpdateInjectivity.agda
@@ -1,0 +1,30 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.List renaming (_∷_ to _,-_)
+
+-- Based on #8218
+module LocalRewriteUpdateInjectivity where
+
+map : {A B : Set} → (A → B) → List A → List B
+map f []        = []
+map f (x ,- xs) = f x ,- map f xs
+
+module _ (_++_ : ∀{A : Set} → List A → List A → List A)
+         (@rewrite map-++ : ∀ {A B : Set} (f : A → B) xs ys
+                          → map f (xs ++ ys) ≡ map f xs ++ map f ys)
+         where
+
+  data Ty : Set where
+    _⟶_ : List Ty → Ty → Ty
+
+  data Exp (Γ : List Ty) : Ty → Set where
+    lamMany : ∀{τ} (τs : List Ty) → Exp (τs ++ Γ) τ → Exp Γ (τs ⟶ τ)
+
+  {-# TERMINATING #-}
+  desugarTy : Ty → Ty
+  desugarTy (τs ⟶ τ) = map desugarTy τs ⟶ desugarTy τ
+
+  desugarExp : ∀{Γ τ} → Exp Γ τ → Exp (map desugarTy Γ) (desugarTy τ)
+  desugarExp (lamMany τs x) = lamMany (map desugarTy τs) (desugarExp x)

--- a/test/Succeed/LocalRewriteVarLHS.agda
+++ b/test/Succeed/LocalRewriteVarLHS.agda
@@ -1,0 +1,18 @@
+{-# OPTIONS --local-rewriting #-}
+
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+open import Agda.Builtin.Sigma
+
+module LocalRewriteVarLHS where
+
+postulate
+  Vec : Nat → Set
+
+module Foo (n : Nat) (@rewrite p : n ≡ 0) where
+  test : Nat
+  test = 42
+
+  test2 : Vec _ → Vec n
+  test2 x = x


### PR DESCRIPTION
Implements local rewrite rules as proposed by Yann Leray and Théo Winterhalter in ["Encode the Cake and Eat it To"](https://hal.science/hal-05160846/document). 

Small example:
```agda
{-# OPTIONS --local-rewriting #-}

open import Agda.Builtin.Equality
open import Agda.Builtin.Equality.Rewrite

module LocalRewriteBoolTele where

module Foo (Bool : Set) (tt ff : Bool)
           (elim : (P : Bool → Set) → P tt → P ff → ∀ b → P b)
           (@rewrite elim-tt : ∀ {P t f} → elim P t f tt ≡ t)
           (@rewrite elim-ff : ∀ {P t f} → elim P t f ff ≡ f) where
  not : Bool → Bool
  not = elim (λ _ → Bool) ff tt

  not-not : ∀ b → not (not b) ≡ b
  not-not = elim (λ b → not (not b) ≡ b) refl refl

open import Agda.Builtin.Bool

elim : (P : Bool → Set) → P true → P false → ∀ b → P b
elim P t f true  = t
elim P t f false = f

not = Foo.not Bool true false elim refl refl

not-not : ∀ b → not (not b) ≡ b
not-not = Foo.not-not Bool true false elim refl refl
```

Documentation: https://agda--8385.org.readthedocs.build/en/8385/language/local-rewriting.html

This feature breaks quite a lot of assumptions Agda has previously happily made: e.g. that we can always safely go under binders, and so needs a LOT of testing. If you are interested in this feature and have time, please do try it out and report any bugs you find (even if they are just variations of problems I am already aware of - the more test cases, the better).

This PR also makes a small change to the behaviour `--rewriting` (not breaking): specifically, the `BUILTIN REWRITE` pragma is now allowed even without the `--rewriting` flag so `Agda.Builtin.Equality.Rewrite` can be imported from modules that only use local rewrite rules. I think this is reasonable, because `BUILTIN REWRITE` does not do anything by itself (it merely allows declaring global and local rewrite rules for that relation in modules with `--rewriting` or, now, `--local-rewriting` enabled).

Todos:

- [x] Apply local rewrite rules during reduction
- [x] Check rewrite constraints at call-sites
- [x] Only allow prenex quantification over local rewrites
  - [x] Restrict `@rewrite`s in user syntax to module telescopes
    - I plan to relax this in a future PR
  - [x] Don't allow metas to be solved with `@rewrite` functions, ever
  - [x] Don't allow `@rewrite`-annotated lets (these don't make much sense)
- [x] Disallow (forced) pattern matching on variables in that occur inside local rewrite rules 
  - I plan to relax this in a future PR, but only under a flag as it breaks the inlining translation
- [x] More tests
- [x] Fix TODOs
- [x] Better error messages
- [x] `--local-rewriting` flag
- [x] Docs and changelog
- [x] Fix bugs 

Known bugs:
- None! (for now...)

Suspicious:
- `defMatchable` does not account for local rewrite rules. I'm not sure yet how important this is (as far as I can see, `defMatchable` is used in confluence checking and the occurs checker, but confluence checking local rewrite rules is future work and ignoring `defMatchable` in the occurs checker does not cause any test failures https://github.com/NathanielB123/agda/pull/8/checks).

Limitations:

- Local rewrite rules basically don't work with generalised variables because I don't know how to deal with metas in local rewrite rules. This maybe isn't so bad because even if they did work, any generalised variables would get bound as separate module params (which is usually not what you want) rather than in the telescope of the family of equations, but I think this is still non-ideal. If anyone has any ideas on how to make this work, please tell me!
- Some other limitations are listed in the documentation.

Future work (beyond this PR):

- Allow `@rewrite` outside module telescopes (but still restricted to prenex quantification on definitions - I think just checking this syntactically is reasonable)
- Allow pattern matching to refine local rewrite rules
  - This breaks the inlining translation and basically gets us to local equality reflection, so should probably require an additional flag
- New elaboration for with-abstractions using local rewrite rules ("smart with")
  - Smart with, without K? @jespercockx observed that this is trickier than I originally thought: not only do we have to disallow reflecting equations where both sides are already convertible, but we also have to prevent pattern matching from refining existing local rewrite rules into reflexive equations. See https://gist.github.com/NathanielB123/84353c2dc4038baead8c856765bf7552
- Take advantage of local rewrite rules in LHS unification - e.g. if we get stuck, try adding a local rewrite (i.e. help with green slime). Again this should be under an option (maybe the same one as "smart with"?)
- Confluence (and termination?) checking
- Allow `@rewrite` on definitions as alternative syntax for `{-# REWRITE #-}` pragmas (added at the end of the current mutual block)