### PR TITLE
fix #8361: Synchronise session state

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -857,6 +857,7 @@ library
       Agda.Utils.AffineHole
       Agda.Utils.Applicative
       Agda.Utils.AssocList
+      Agda.Utils.Atomic
       Agda.Utils.Bag
       Agda.Utils.Benchmark
       Agda.Utils.BiMap

--- a/src/full/Agda/Compiler/Backend.hs
+++ b/src/full/Agda/Compiler/Backend.hs
@@ -85,7 +85,7 @@ callBackendInteractHole name cmd ii rng s =
 withKnownBackend ::
   (MonadTCError m) => BackendName -> (Backend -> m ()) -> m ()
 withKnownBackend name k = ifJustM (lookupBackend name) k $ do
-  backends <- useTC stBackends
+  backends <- useSession lensBackends
   let backendSet = otherBackends ++ [ backendName b | Backend b <- backends ]
   typeError $ UnknownBackend name (Set.fromList backendSet)
 

--- a/src/full/Agda/Interaction/Highlighting/LaTeX/Backend.hs
+++ b/src/full/Agda/Interaction/Highlighting/LaTeX/Backend.hs
@@ -43,12 +43,11 @@ import Agda.Syntax.TopLevelModuleName (TopLevelModuleName, projectRoot)
 import Agda.TypeChecking.Monad
   ( HasOptions(commandLineOptions)
   , MonadDebug
-  , stModuleToSourceId
-  , useTC
+  , useSession, lensModuleToSourceId
   , ReadTCState
   , reportS
   , MonadFileId
-  , srcFilePath
+  , srcFilePath, ReadTCState
   )
 
 import Agda.Utils.FileName (filePath, mkAbsolute)
@@ -132,13 +131,13 @@ instance MonadDebug m => MonadLogLaTeX (LogLaTeXDebugT m) where
   logLaTeX = LogLaTeXDebugT . (reportS "compile.latex" 1) . T.unpack . logMsgToText
 
 -- Resolve the raw flags into usable LaTeX options.
-resolveLaTeXOptions :: (HasOptions m, ReadTCState m, MonadFileId m)
+resolveLaTeXOptions :: (ReadTCState m, HasOptions m, MonadFileId m)
   => LaTeXFlags
   -> TopLevelModuleName
   -> m LaTeXOptions
 resolveLaTeXOptions flags moduleName = do
   options <- commandLineOptions
-  modFiles <- useTC stModuleToSourceId
+  modFiles <- useSession lensModuleToSourceId
   let msrc = Map.lookup moduleName modFiles
   mf <- traverse srcFilePath msrc
   let

--- a/src/full/Agda/Interaction/InteractionTop.hs
+++ b/src/full/Agda/Interaction/InteractionTop.hs
@@ -223,7 +223,7 @@ handleCommand wrap onFail cmd = handleNastyErrors $ wrap $ do
 
         unsolved <- lift $ computeUnsolvedInfo
         err     <- lift $ errorHighlighting e
-        modFile <- lift $ useTC stModuleToSource
+        modFile <- lift $ useSession lensModuleToSource
         method  <- case method of
           Nothing -> lift $ viewTC eHighlightingMethod
           Just m  -> return m
@@ -595,7 +595,7 @@ interpret (Cmd_load_highlighting_info source) = do
                 Just mi ->
                   if hashText (Imp.srcText src) == iSourceHash (miInterface mi)
                     then do
-                      modFile <- useTC stModuleToSource
+                      modFile <- useSession lensModuleToSource
                       method  <- viewTC eHighlightingMethod
                       return $ Just (iHighlighting $ miInterface mi, method, modFile)
                     else
@@ -942,7 +942,7 @@ cmd_load' file argv unsolvedOK mode cmd = do
     -- All options are reset when a file is reloaded, including the
     -- choice of whether or not to display implicit arguments.
     opts0 <- gets optionsOnReload
-    backends <- useTC stBackends
+    backends <- useSession lensBackends
     let (z, warns) = runOptM $ parseBackendOptions backends argv opts0
     mapM_ (lift . warning . OptionWarning) warns
     case z of

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -164,7 +164,7 @@ runAgdaArgs backends args = do
               IO.hSetEncoding IO.stdout enc
               IO.hSetEncoding IO.stderr enc
 
-          setSessionLens lensBackends bs
+          setSession lensBackends bs
           runAgdaWithOptions interactor progName opts
 
 

--- a/src/full/Agda/Main.hs
+++ b/src/full/Agda/Main.hs
@@ -164,7 +164,7 @@ runAgdaArgs backends args = do
               IO.hSetEncoding IO.stdout enc
               IO.hSetEncoding IO.stderr enc
 
-          setTCLens stBackends bs
+          setSessionLens lensBackends bs
           runAgdaWithOptions interactor progName opts
 
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -7,7 +7,6 @@ module Agda.TypeChecking.Errors
   , prettyError
   , prettyShadowedModule
   , tcErrString
-  , tcErrModuleToSource
   , prettyTCWarnings'
   , prettyTCWarnings
   , tcWarningsToError
@@ -148,18 +147,6 @@ tcErrString err =
       GenericException msg -> [ msg ]
       IOException _ r e    -> [ prettyShow r, showIOException e ]
       PatternErr{}         -> [ "PatternErr" ]
-
--- | If the 'TCErr' carries a 'TCState', return the 'ModuleToSource'
--- from there, since that's the 'ModuleToSource' we need for
--- highlighting the actual error message.
-tcErrModuleToSource :: TCErr -> Maybe ModuleToSource
-tcErrModuleToSource = \case
-  err@TypeError{}    -> Just $! tcErrState err ^. stModuleToSource
-  IOException st _ _ -> (^. stModuleToSource) <$> st
-
-  GenericException{} -> Nothing
-  ParserError{}      -> Nothing
-  PatternErr{}       -> Nothing
 
 instance PrettyTCM TCErr where
   prettyTCM err = case err of

--- a/src/full/Agda/TypeChecking/InstanceArguments.hs
+++ b/src/full/Agda/TypeChecking/InstanceArguments.hs
@@ -655,10 +655,10 @@ filterResettingState m cands f = do
   result'' <- dropSameCandidates m overlap result'
   case result'' of
 
-    -- Have to use 'putTCPreservingSession' here otherwise the stats
+    -- Have to use 'putTCPreservingStats' here otherwise the stats
     -- accumulated from checking other candidates and from
     -- 'dropSameCandidates' are lost.
-    [(c, v, s)] -> ([], [(c, v)]) <$ putTCPreservingSession s
+    [(c, v, s)] -> ([], [(c, v)]) <$ putTCPreservingStats s
 
     _           -> do
       let bad  = [ (c, err) | (c, (NoBecause err, _)) <- result ]

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -16,7 +16,7 @@ module Agda.TypeChecking.Monad.Base
 import Prelude hiding (null)
 
 import Control.Applicative hiding (empty)
-import Control.Concurrent
+import Control.Concurrent (forkIO)
 import Control.DeepSeq
 import qualified Control.Exception as E
 
@@ -149,6 +149,7 @@ import Agda.Utils.Tuple (Pair, (&&&) )
 import Agda.Utils.Update
 import Agda.Utils.VarSet qualified as VarSet
 import Agda.Utils.VarSet (VarSet)
+import Agda.Utils.Atomic
 
 import Agda.Utils.Impossible
 
@@ -393,7 +394,6 @@ data SessionState = SessionState
   , stSessionModuleToSourceId :: !ModuleToSourceId
     -- ^ Maps 'TopLevelModuleNames' to the 'FileId's from which they
     -- were loaded.
-
   , stSessionInteractionOutputCallback :: InteractionOutputCallback
     -- ^ Callback function to call when there is a response
     --   to give to the interactive frontend.
@@ -406,9 +406,9 @@ data SessionState = SessionState
 -- | A part of the state which is not reverted when an error is thrown
 -- or the state is reset.
 data PersistentTCState = PersistentTCSt
-  { stPersistentSession :: !(MVar SessionState)
-      -- ^ State that persists for the whole Agda session.
-      --   Grows monotonically, never sees any deletion.
+  { stPersistentSession :: !(Atomic SessionState)
+    -- ^ State that persists for the whole Agda session.
+    --   Grows monotonically, never sees any deletion.
   , stDecodedModules    :: !DecodedModules
       -- ^ Type-checked modules we visited during our Agda session.
       --   A module gets dropped from this list if its source
@@ -478,7 +478,7 @@ initSessionState primLibDir = SessionState
 
 -- | Empty persistent state.
 
-initPersistentStateFromSessionState :: MVar SessionState -> PersistentTCState
+initPersistentStateFromSessionState :: Atomic SessionState -> PersistentTCState
 initPersistentStateFromSessionState s = PersistentTCSt
   { stPersistentSession             = s
   , stPersistentOptions             = defaultOptions
@@ -570,9 +570,9 @@ initStateIO :: IO TCState
 initStateIO = initState =<< getPrimitiveLibDir
 
 initState :: AbsolutePath -> IO TCState
-initState fp = initStateFromSessionState <$> newMVar (initSessionState fp)
+initState fp = initStateFromSessionState <$> newAtomic (initSessionState fp)
 
-initStateFromSessionState :: MVar SessionState -> TCState
+initStateFromSessionState :: Atomic SessionState -> TCState
 initStateFromSessionState = initStateFromPersistentState . initPersistentStateFromSessionState
 
 initStateFromPersistentState :: PersistentTCState -> TCState
@@ -597,9 +597,6 @@ lensPostScopeState f s = f (stPostScopeState s) <&> \ x -> s { stPostScopeState 
 
 -- ** Components of 'SessionState'
 
-lensSessionState :: Lens' TCState (MVar SessionState)
-lensSessionState = lensPersistentState . lensPersistentSession
-
 lensBackends :: Lens' SessionState [Backend]
 lensBackends f s = f (stSessionBackends s) <&> \ x -> s { stSessionBackends = x }
 
@@ -623,7 +620,7 @@ lensInteractionOutputCallback f s = f (stSessionInteractionOutputCallback s) <&>
 
 -- ** Components of 'PersistentTCState'
 
-lensPersistentSession :: Lens' PersistentTCState (MVar SessionState)
+lensPersistentSession :: Lens' PersistentTCState (Atomic SessionState)
 lensPersistentSession f s = f (stPersistentSession s) <&> \ x -> s { stPersistentSession = x }
 
 lensLoadedFileCache :: Lens' PersistentTCState (Strict.Maybe LoadedFileCache)
@@ -5949,7 +5946,7 @@ instance ReadTCState ReduceM where
 runReduceM :: ReduceM a -> TCM a
 runReduceM m = TCM $ \ r e -> do
   s <- Strict.readIORef r
-  sess <- readMVar (s ^. lensSessionState)
+  sess <- readAtomic (stPersistentSession (stPersistentState s))
   E.evaluate $ unReduceM m $ ReduceEnv e s sess Nothing
   -- Andreas, 2021-05-13, issue #5379
   -- This was the following, which is apparently not strict enough
@@ -6166,34 +6163,38 @@ useSession l = view l <$!> getSessionState
 
 class ReadTCState m => ModifySession m where
   -- | Modify a part of the 'SessionState' through a lens. If the
-  -- continuation fails, modifications to the session state should be
-  -- reset.
+  -- continuation fails, modifications to the *session* state are reset.
+  -- Other monadic states will not necessarily be reverted.
   --
-  -- The calling thread locks **the entire session state** for the
-  -- duration of the modifying function's execution. Nested applications
-  -- of this function **will** deadlock, even if they target disjoint
-  -- lenses!
+  -- This function keeps an **exclusive** lock on the session state
+  -- **for the entire execution of the continuation**, regardless of
+  -- what the given lens focuses on.
   --
-  -- This function is strict both in the modification to the state and in
-  -- the result.
+  -- No thread can access **any** part of the session state while
+  -- 'stateSessionLensM' is executing. This includes the continuation!
+  -- Nested applications of this function **will always** deadlock.
+  --
+  -- This function is strict in the modification to the session state,
+  -- and the exclusive lock on the session state is maintained for the
+  -- duration of forcing the new session state.
+  --
+  -- This function has a few variants if less flexibility is required:
+  -- * 'stateSessionLens' takes a pure modification function.
+  -- * 'modifySession' does not allow returning an additional result.
   stateSessionLensM :: Lens' SessionState a -> (a -> m (r, a)) -> m r
 
 instance (MonadIO m, Catch.MonadMask m) => ModifySession (TCMT m) where
 
-  -- The glue code that actually modifies the MVar must be
-  -- uninterruptible, so we incur a MonadMask constraint, which
-  -- Haskeline's InputT implements.
-  stateSessionLensM l f = TCM \st env -> Catch.mask \reset -> do
-    mv <- view lensSessionState <$> liftIO (Strict.readIORef st)
-    sess <- liftIO $ takeMVar mv
-
-    -- We put the old state back into the MVar if the continuation fails
-    -- so that the MVar is not left empty for other threads to block on.
-    (res, a') <- reset (unTCM (f $! sess ^. l) st env)
-      `Catch.onException` liftIO (putMVar mv sess)
-
-    liftIO $ putMVar mv $! set l a' sess
-    pure $! res
+  -- The heavy lifting for synchronization and atomicity is handled by
+  -- 'modifyAtomic', we just have to thread the TCM part of the state
+  -- through.
+  stateSessionLensM :: Lens' SessionState a -> (a -> TCMT m (r, a)) -> TCMT m r
+  stateSessionLensM l f = TCM \st env -> do
+    mv <- stPersistentSession . stPersistentState <$> liftIO (Strict.readIORef st)
+    modifyAtomic mv \sess -> do
+      (ret, new) <- unTCM (f $! sess ^. l) st env
+      let sess' = set l new sess
+      sess' `seq` pure (sess', ret)
 
 instance ModifySession m => ModifySession (StateT s m) where
   stateSessionLensM l k = StateT \s -> stateSessionLensM l \v ->
@@ -6203,7 +6204,6 @@ instance ModifySession m => ModifySession (MaybeT m) where
   stateSessionLensM l k = MaybeT $ stateSessionLensM l \v -> runMaybeT (k v) >>= \case
     Just (r, a) -> pure (Just r, a)
     Nothing     -> pure (Nothing, v)
-
 
 {-# INLINE stateSessionLens #-}
 -- | Like 'stateSessionLensM', but the modification function is not
@@ -6217,10 +6217,15 @@ stateSessionLens l f = stateSessionLensM l $ pure . f
 modifySession :: ModifySession m => Lens' SessionState a -> (a -> a) -> m ()
 modifySession l f = stateSessionLens l $ pure . f
 
-{-# INLINE setSessionLens #-}
+{-# INLINE setSession #-}
 -- | Like 'modifySession', but with a constant new value.
-setSessionLens :: ModifySession m => Lens' SessionState a -> a -> m ()
-setSessionLens l v = modifySession l (const v)
+--
+-- If the computation of the new value depends on a previous
+-- 'useSession', this function is prone to suffering from time-of-check
+-- vs. time-of-use issues. Prefer the 'stateSessionLensM' family of
+-- functions instead.
+setSession :: ModifySession m => Lens' SessionState a -> a -> m ()
+setSession l v = modifySession l (const v)
 
 ---------------------------------------------------------------------------
 -- ** Monad with capability to block a computation
@@ -6370,8 +6375,8 @@ instance MonadIO m => ReadTCState (TCMT m) where
   locallyTCState l f = bracket_ (useTC l <* modifyTCLens l f) (setTCLens l); {-# INLINE locallyTCState #-}
 
   getSessionState = do
-    mv <- useTC lensSessionState
-    liftIO $ readMVar mv
+    mv <- getsTC (stPersistentSession . stPersistentState)
+    readAtomic mv
 
 instance MonadBlock TCM where
   patternViolation b = throwError (PatternErr b)
@@ -6564,11 +6569,12 @@ runSafeTCM m st =
 -- | Runs the computation in a separate thread, with a /copy/ of the
 -- 'TCState' of the calling thread.
 --
--- Modification of the 'TCState' performed by the detached computation
--- (e.g. creation of metas) is invisible to the parent thread, and to
--- any siblings. They will be "discarded" when the thread finishes. It
--- is thus important to ensure that any results returned out-of-band by
--- the child thread are valid in an arbitrary TC state.
+-- Modifications of the 'TCState' performed by the detached computation
+-- (e.g. creation of metas) are invisible to the parent thread, and to
+-- any of its siblings. They will be "discarded" when the thread
+-- finishes.
+-- It is thus important to ensure that any results returned out-of-band
+-- by the child thread are valid in an arbitrary TC state.
 --
 -- The detached thread has read-write, synchronised access to the
 -- 'SessionState'.
@@ -6606,6 +6612,9 @@ type InteractionOutputCallback = Response_boot TCErr TCWarning WarningsAndNonFat
 
 defaultInteractionOutputCallback :: InteractionOutputCallback
 defaultInteractionOutputCallback = \case
+  Resp_RunningInfo _ msg    -> do
+    putDocTreeLn msg
+    liftIO $ hFlush stdout
   Resp_HighlightingInfo {}  -> __IMPOSSIBLE__
   Resp_Status {}            -> __IMPOSSIBLE__
   Resp_JumpToError {}       -> __IMPOSSIBLE__
@@ -6615,9 +6624,6 @@ defaultInteractionOutputCallback = \case
   Resp_SolveAll {}          -> __IMPOSSIBLE__
   Resp_Mimer {}             -> __IMPOSSIBLE__
   Resp_DisplayInfo {}       -> __IMPOSSIBLE__
-  Resp_RunningInfo _ msg    -> do
-                                 putDocTreeLn msg
-                                 liftIO $ hFlush stdout
   Resp_ClearRunningInfo {}  -> __IMPOSSIBLE__
   Resp_ClearHighlighting {} -> __IMPOSSIBLE__
   Resp_DoneAborting {}      -> __IMPOSSIBLE__
@@ -6949,13 +6955,7 @@ instance NFData Statistics
 instance NFData UnusedImportsState
 instance NFData OpenedModule
 instance NFData IsAxiom
-
--- Andreas, 2025-07-31, cannot normalize functions with deepseq-1.5.2.0 (GHC 9.10.3-rc1).
--- See https://github.com/haskell/deepseq/issues/111.
-
-instance NFData SessionState where
-  rnf (SessionState a b c _fun) =
-    rnf a `seq` rnf b `seq` rnf c
+instance NFData SessionState
 
 instance NFData PrimFun where
   rnf (PrimFun a b c _fun) =

--- a/src/full/Agda/TypeChecking/Monad/Debug.hs
+++ b/src/full/Agda/TypeChecking/Monad/Debug.hs
@@ -160,7 +160,7 @@ traceDebugMessageTCM k n doc cont = do
     -- Andreas, 2019-08-20, issue #4016:
     -- Force any lazy 'Impossible' exceptions to the surface and handle them.
     msg :: DocTree <- liftIO . catchAndPrintImpossible k n . E.evaluate . DeepSeq.force . renderToTree $ doc
-    cb <- useTC $ stInteractionOutputCallback
+    cb <- useSession lensInteractionOutputCallback
     cb $ Resp_RunningInfo n msg
     cont
     where

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -333,7 +333,7 @@ setIncludeDirs incs root = do
     setTCLens stTCWarnings tcWarnings
     setTCLens stLibCache libCache
     setDecodedModules keptDecodedModules
-    setSessionLens lensModuleToSourceId modFile
+    setSession lensModuleToSourceId modFile
 
   Lens.putAbsoluteIncludePaths $ List1.toList incs
   where

--- a/src/full/Agda/TypeChecking/Monad/Options.hs
+++ b/src/full/Agda/TypeChecking/Monad/Options.hs
@@ -298,7 +298,7 @@ setIncludeDirs incs root = do
   incs <- return $ fmap (mkAbsolute . (filePath root </>)) incs
 
   -- Andreas, 2013-10-30  Add default include dir
-  primdir <- useTC stPrimitiveLibDir
+  primdir <- useSession lensPrimitiveLibDir
       -- We add the default dir at the end, since it is then
       -- printed last in error messages.
       -- Might also be useful to overwrite default imports...
@@ -333,7 +333,7 @@ setIncludeDirs incs root = do
     setTCLens stTCWarnings tcWarnings
     setTCLens stLibCache libCache
     setDecodedModules keptDecodedModules
-    setTCLens stModuleToSourceId modFile
+    setSessionLens lensModuleToSourceId modFile
 
   Lens.putAbsoluteIncludePaths $ List1.toList incs
   where

--- a/src/full/Agda/TypeChecking/Monad/State.hs-boot
+++ b/src/full/Agda/TypeChecking/Monad/State.hs-boot
@@ -1,6 +1,7 @@
 module Agda.TypeChecking.Monad.State where
 
 import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Catch
 import Agda.TypeChecking.Monad.Base (MonadFileId, TCMT)
 
-instance MonadIO m => MonadFileId (TCMT m)
+instance (MonadIO m, MonadMask m) => MonadFileId (TCMT m)

--- a/src/full/Agda/TypeChecking/Monad/Trace.hs
+++ b/src/full/Agda/TypeChecking/Monad/Trace.hs
@@ -212,7 +212,7 @@ instance MonadTrace TCM where
       _ -> False
 
   printHighlightingInfo remove info = do
-    modToSrc <- useTC stModuleToSource
+    modToSrc <- useSession lensModuleToSource
     method   <- viewTC eHighlightingMethod
     reportSDoc "highlighting" 90 $ pure $ vcat
       [ "Printing highlighting info:"

--- a/src/full/Agda/TypeChecking/Reduce/Monad.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Monad.hs
@@ -53,13 +53,13 @@ instance MonadAddContext ReduceM where
 instance MonadDebug ReduceM where
 
   traceDebugMessage k n s cont = do
-    ReduceEnv env st _ <- askR
+    ReduceEnv env st _ _ <- askR
     unsafePerformIO $ do
       _ <- runTCM env st $ displayDebugMessage k n s
       return $ cont
 
   formatDebugMessage k n d = do
-    ReduceEnv env st _ <- askR
+    ReduceEnv env st _ _ <- askR
     unsafePerformIO $ do
       (s , _) <- runTCM env st $ formatDebugMessage k n d
       return $ return s
@@ -80,7 +80,7 @@ instance MonadDebug ReduceM where
 instance HasConstInfo ReduceM where
   getRewriteRulesFor = defaultGetRewriteRulesFor
   getConstInfo' q = do
-    ReduceEnv env st _ <- askR
+    ReduceEnv env st _ _ <- askR
     defaultGetConstInfo st env q
 
 instance PureTCM ReduceM where

--- a/src/full/Agda/Utils/Atomic.hs
+++ b/src/full/Agda/Utils/Atomic.hs
@@ -1,0 +1,75 @@
+-- | Wrappers around 'MVar's which provides an atomic modification operation.
+module Agda.Utils.Atomic
+  ( Atomic
+  , newAtomic
+  , readAtomic
+  , modifyAtomic
+  , withAtomic
+  )
+  where
+
+import Control.Monad.IO.Class
+import Control.Monad.Catch
+import Control.DeepSeq
+
+import Control.Concurrent
+import Control.Exception (evaluate)
+
+-- | A mutable variable which can be read from and *modified*.
+-- This provides a 'modifyAtomic' combinator with atomic semantics for
+-- modification, unlike 'modifyMVar'.
+newtype Atomic a = Atomic { unAtomic :: MVar a }
+  deriving (Eq, NFData)
+
+-- Implementation note: the caveat to modifyMVar's atomicity is that it
+-- is possible for another thread to have a *different* value of 'a',
+-- which they can 'putMVar', while the continuation to 'modifyMVar' is
+-- executing (since the variable is left in the empty state for its
+-- duration). This would block the call to 'modifyMVar' after the end of
+-- the continuation.
+--
+-- By contrast, we simply do not export a "put" variant of writing to an
+-- atomic. This should, hopefully, be enough to ensure atomicity.
+
+-- | Create a new atomic variable with the given initial value.
+newAtomic :: MonadIO m => a -> m (Atomic a)
+newAtomic = liftIO . fmap Atomic . newMVar
+
+-- | Read the current state of the atomic variable, waiting if any other
+-- thread is modifying it.
+--
+-- Like 'readMVar', 'readAtomic' is multiple-wakeup, which means that
+-- all threads waiting on a modification will be woken up when it
+-- finishes.
+readAtomic :: MonadIO m => Atomic a -> m a
+readAtomic = liftIO . readMVar . unAtomic
+{-# INLINE readAtomic #-}
+
+-- | Modify the contents of an atomic variable. If the continuation
+-- fails, or receives an asynchronous exception, the variable is
+-- returned to its old state.
+--
+-- No thread, *including the calling thread*, can access the contents of
+-- the same 'Atomic' while this function is executing, for reading *or*
+-- writing. This means that *any* nested use of the variable, as in
+--
+-- @
+-- f var = modifyAtomic var \old ->
+--   -- ...
+--   modifyAtomic var \old' -> ... -- (!)
+--   readAtomic var                -- (!)
+-- @
+--
+-- will result in a deadlock. The new state of the variable is evaluated
+-- (to WHNF).
+modifyAtomic :: (MonadIO m, MonadMask m) => Atomic a -> (a -> m (a, b)) -> m b
+modifyAtomic (Atomic var) k = mask \restore -> do
+  old <- liftIO $ takeMVar var
+  (new, ret) <- restore (k old >>= liftIO . evaluate)
+    `onException` liftIO (putMVar var old)
+  ret <$ liftIO (putMVar var $! new)
+
+{-# SPECIALISE modifyAtomic :: Atomic a -> (a -> IO (a, b)) -> IO b #-}
+
+withAtomic :: (MonadIO m, MonadMask m) => Atomic a -> (a -> m ()) -> m ()
+withAtomic var k = modifyAtomic var \val -> (val,) <$> k val


### PR DESCRIPTION
Fixes #8361 properly, by putting the `SessionState` (née `SessionTCState`) into an `MVar` which is shared by all threads, as discussed last Wednesday. This is a very big stick, but it sure does work.

```
io ~/d/P/agda % make issue-8361
======================================================================
=============== Testing issue 8361 (file access race) ================
======================================================================
The module Agda.Builtin.Sigma is primitive.
The module Agda.Builtin.Sigma is primitive.
The module Agda.Builtin.Sigma is primitive.
```

(This PR is based on #8367 so we can get actual CI results. That is, when the partial GH outage resolves…)