### PR TITLE
Progress reporting when checking in parallel

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -42,6 +42,7 @@ import Control.Monad.IO.Class      ( MonadIO(..) )
 import Control.Monad.State         ( MonadState(..), execStateT )
 import Control.Monad.Trans.Maybe
 import Control.Concurrent
+import Control.DeepSeq
 
 import Data.Either
 import Data.Monoid
@@ -490,6 +491,8 @@ data TCWorkers = Workers
     -- worker to signal completion (or failure).
   , workerModules    :: !(IORef DecodedModules)
     -- ^ The shared 'DecodedModules' where workers can put their results.
+  , workerStarted    :: !(IORef Int)
+    -- ^ How many threads have actually started their work. Used for progress reporting.
   }
 
 -- | If the user has asked for it, prepare the type checker for loading
@@ -512,10 +515,29 @@ wantsParallelChecking = fmap optParallelChecking commandLineOptions >>= \case
 
     threads <- liftIO $ newMVar mempty
     results <- liftIO . newIORef =<< getDecodedModules
+    started <- liftIO $ newIORef 0
     pure Workers
       { workerThreads    = threads
       , workerModules    = results
+      , workerStarted    = started
       }
+
+-- | Gets the prefix string to use for reporting the progress message
+-- (Checking, Loading, etc.) for the module this worker is responsible
+-- for.
+-- As a side-effect, updates the 'workerStarted' count.
+thisWorkerPrefix :: TCWorkers -> TCM String
+thisWorkerPrefix workers = do
+  -- In general, we don't know ahead-of-time how many modules we will
+  -- end up checking (e.g. with --build-library, this fluctuates), but
+  -- the number of modules for which we have a result slot is a pretty
+  -- good estimate.
+  sz <- show . HMap.size <$> liftIO (readMVar (workerThreads workers))
+  me <- liftIO $ atomicModifyIORef (workerStarted workers) \n -> (n + 1, show (n + 1))
+  let
+    pad = replicate (length sz - length me) ' '
+    out = "(" <> pad <> me <> "/" <> sz <> ") "
+  out `deepseq` pure out
 
 -- | Type-check the given module, using a 'TCWorkers' instance to check
 -- its imports in parallel.
@@ -638,7 +660,9 @@ chaseModule workers mod main msrc = do
         -- around to actually scope checking the import.
         sequence_ (appEndo imports [])
 
-        mi <- getInterface mod main (Just src)
+        prefix <- thisWorkerPrefix workers
+        mi <- locallyTC eChasePrefix (const (Just prefix)) $
+          getInterface mod main (Just src)
 
         -- After we're done, update the shared DecodedModules map and
         -- signal our completion.
@@ -1141,6 +1165,7 @@ createInterfaceIsolated x file msrc = do
       cleanCachedLog
 
       ms          <- asksTC envImportStack
+      pref        <- asksTC envChasePrefix
       range       <- asksTC envRange
       call        <- asksTC envCall
       vs          <- getVisitedModules
@@ -1172,6 +1197,7 @@ createInterfaceIsolated x file msrc = do
                             { envRange              = range
                             , envCall               = call
                             , envImportStack        = ms
+                            , envChasePrefix        = pref
                             }) $ do
                setDecodedModules ds
                setCommandLineOptions opts
@@ -1211,7 +1237,9 @@ chaseMsg
   -> Maybe String         -- ^ Optionally: the file name.
   -> TCM ()
 chaseMsg kind x file = do
-  indentation <- (`replicate` ' ') <$> asksTC (pred . length . envImportStack)
+  indentation <- asksTC envChasePrefix >>= \case
+    Just pref -> pure pref
+    Nothing   -> (`replicate` ' ') <$> asksTC (pred . length . envImportStack)
   traceImports <- optTraceImports <$> commandLineOptions
   let maybeFile = caseMaybe file "." $ \ f -> " (" ++ f ++ ")."
       vLvl | kind == "Checking"

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4103,6 +4103,10 @@ data TCEnv =
             --   length, in the module dependency graph, of the shortest path
             --   from the top-level module; it depends on in which order Agda
             --   chooses to chase dependencies.
+          , envChasePrefix         :: Maybe String
+            -- ^ A string to be used as the prefix for module chasing
+            -- (Checking, Loading, etc.) messages. If unset, the length
+            -- of the import stack is used.
           , envMutualBlock         :: Maybe MutualId -- ^ the current (if any) mutual block
           , envTerminationCheck    :: TerminationCheck ()  -- ^ are we inside the scope of a termination pragma
           , envCoverageCheck       :: CoverageCheck        -- ^ are we inside the scope of a coverage pragma
@@ -4255,6 +4259,7 @@ initEnv = TCEnv { envContext             = CxEmpty
                 , envCurrentPath         = Nothing
                 , envAnonymousModules    = []
                 , envImportStack         = []
+                , envChasePrefix         = Nothing
                 , envMutualBlock         = Nothing
                 , envTerminationCheck    = TerminationCheck
                 , envCoverageCheck       = YesCoverageCheck
@@ -4353,6 +4358,9 @@ eAnonymousModules f e = f (envAnonymousModules e) <&> \ x -> e { envAnonymousMod
 
 eImportStack :: Lens' TCEnv [TopLevelModuleName]
 eImportStack f e = f (envImportStack e) <&> \ x -> e { envImportStack = x }
+
+eChasePrefix :: Lens' TCEnv (Maybe String)
+eChasePrefix f e = f (envChasePrefix e) <&> \ x -> e { envChasePrefix = x }
 
 eMutualBlock :: Lens' TCEnv (Maybe MutualId)
 eMutualBlock f e = f (envMutualBlock e) <&> \ x -> e { envMutualBlock = x }


### PR DESCRIPTION
The length of the import stack is a somewhat random measurement that doesn't give any insight on how far along typechecking is. In sequential mode, we can't really do any better, because we have no idea how many modules we'll actually end up checking (only how many we have checked). However, when checking in parallel, we do actually have a *pretty okay* idea of how many modules there are to process, namely the amount of threads that have been started.

If one is checking an `Everything` file, this estimate is pretty stable from the start. It varies more with `--build-library` because of the way we start threads there, but anecdotally the stdlib stabilises at a worker count of 1200 about a quarter of the way in when there is actual checking to do.