### PR TITLE
Fix --help claiming --type-in-type is the default

### DIFF
--- a/src/full/Agda/Interaction/Options/Base.hs
+++ b/src/full/Agda/Interaction/Options/Base.hs
@@ -485,7 +485,7 @@ lensOptUniverseCheck :: Lens' PragmaOptions _
 lensOptUniverseCheck f o = f (_optUniverseCheck o) <&> \ i -> o{ _optUniverseCheck = i }
 
 lensOptNoUniverseCheck :: Lens' PragmaOptions _
-lensOptNoUniverseCheck f o = f (mapValue not $ _optUniverseCheck o) <&> \ i -> o{ _optUniverseCheck = mapValue not i }
+lensOptNoUniverseCheck f o = f (not' $ _optUniverseCheck o) <&> \ i -> o{ _optUniverseCheck = not' i }
 
 lensOptOmegaInOmega :: Lens' PragmaOptions _
 lensOptOmegaInOmega f o = f (_optOmegaInOmega o) <&> \ i -> o{ _optOmegaInOmega = i }

--- a/src/full/Agda/Utils/TypeLevel.hs
+++ b/src/full/Agda/Utils/TypeLevel.hs
@@ -37,6 +37,8 @@ type family If (b :: Bool) (l :: k) (r :: k) :: k where
   If 'True  l r = l
   If 'False l r = r
 
+type Not (b :: Bool) = If b 'False 'True
+
 -- | On Lists
 type family Foldr (c :: k -> l -> l) (n :: l) (as :: [k]) :: l where
   Foldr c n '[]       = n

--- a/src/full/Agda/Utils/WithDefault.hs
+++ b/src/full/Agda/Utils/WithDefault.hs
@@ -15,10 +15,13 @@ module Agda.Utils.WithDefault where
 
 import Control.DeepSeq
 
+import Prelude hiding (not)
+
 import Agda.Utils.Boolean
 import Agda.Utils.Lens
 import Agda.Utils.Null
 import Agda.Utils.TypeLits
+import Agda.Utils.TypeLevel
 
 -- | We don't want to have to remember for each flag whether its default value
 -- is @True@ or @False@. So we bake it into the representation: the flag's type
@@ -53,12 +56,10 @@ setDefault b = \case
   Default -> Value b
   t -> t
 
--- | Only modify non-'Default' values.
---
-mapValue :: (a -> a) -> WithDefault' a b -> WithDefault' a b
-mapValue f = \case
+not' :: WithDefault b -> WithDefault (Not b)
+not' = \case
   Default -> Default
-  Value b -> Value (f b)
+  Value b -> Value (not b)
 
 -- | Provided that the default value is a known boolean (in practice we only use
 -- @True@ or @False@), we can collapse a potentially uninitialised value to a boolean.


### PR DESCRIPTION
Before:

```
    --type-in-type                          ignore universe levels (this makes Agda inconsistent) (default)
    --no-type-in-type                       do not ignore universe levels
```

After:

```
    --type-in-type                          ignore universe levels (this makes Agda inconsistent)
    --no-type-in-type                       do not ignore universe levels (default)
```