### PR TITLE
experiment: check cubical in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -558,7 +558,8 @@ cubical-test :
 	-rm -rf cubical/_build
 	@$(call decorate, "Cubical library test", \
 		time $(MAKE) -C cubical \
-                  AGDA_BIN=$(AGDA_BIN) RTS_OPTIONS=$(AGDA_OPTS))
+			AGDA_BIN="$(AGDA_BIN)" AGDA_FLAGS="-j" RTS_OPTIONS=$(AGDA_OPTS) \
+			gen-everythings check)
 
 .PHONY : continue-cubical-test ##
 continue-cubical-test :


### PR DESCRIPTION
Builds off #8387 also. Experiments with checking the cubical library in parallel to see if we get a worthwhile improvement in CI time.