### PR TITLE
JS backend: use tagged arrays instead of Scott encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,6 +457,12 @@ Backends
   such that the Agda name of the function is printed to `stderr`
   whenever a function is entered.
 
+* The JS backend now implements data types using tagged arrays instead of
+  Scott encoding. Constructors compile to `[tag, arg0, arg1, ...]` and
+  case splits compile to `switch` statements. Types with `{-# COMPILE JS #-}`
+  pragmas keep Scott encoding for backward compatibility with user-defined
+  FFI code.
+
 * The JS backend now explicitly lists all primitives that should compile
   to `undefined`. Primitives not in this list or the RTS trigger a new
   `UnknownJSPrimitive` warning

--- a/test/Compiler/Tests.hs
+++ b/test/Compiler/Tests.hs
@@ -87,11 +87,6 @@ disabledTests =
   -- recursive pattern-matching lambdas was disabled.
   disable "Compiler/MAlonzo_.*/simple/Issue2918$" :
   -----------------------------------------------------------------------------
-  -- The following test cases fail (at least at the time of writing)
-  -- for the JS backend.
-  disable "Compiler/JS_Optimized/simple/ModuleReexport" :
-  disable "Compiler/JS_MinifiedOptimized/simple/ModuleReexport" :
-  -----------------------------------------------------------------------------
   -- The following test cases are GHC backend specific and thus disabled on JS.
   disable "Compiler/JS_.*/simple/Issue2821" :
   disable "Compiler/JS_.*/simple/Issue2879-.*" :
@@ -112,14 +107,15 @@ fdebugTestFilter =
 -- This list was crafted using
 --    grep -RP '(?<!-- ){-# OPTIONS.* -v' | grep Compiler/
 --  and screening the results (e.g. for comments)
-  [ disable "Compiler/simple/UnusedArguments"
-  , disable "Compiler/simple/EraseRefl"
-  , disable "Compiler/simple/InlineRecursive"
-  , disable "Compiler/simple/Word"
-  , disable "Compiler/simple/CompileNumbers"
-  , disable "Compiler/simple/CaseOnCase"
-  , disable "Compiler/simple/CompareNat"
-  , disable "Compiler/simple/CompileCatchAll"
+  [ disable "Compiler/.*/simple/UnusedArguments"
+  , disable "Compiler/.*/simple/EraseRefl"
+  , disable "Compiler/.*/simple/InlineRecursive"
+  , disable "Compiler/.*/simple/Word"
+  , disable "Compiler/.*/simple/CompileNumbers"
+  , disable "Compiler/.*/simple/CaseOnCase"
+  , disable "Compiler/.*/simple/CompareNat"
+  , disable "Compiler/.*/simple/CompileCatchAll"
+  , disable "Compiler/.*/simple/CompilePrimSeq"
   ]
   where disable = RFInclude
 

--- a/test/Compiler/simple/TaggedArrays.agda
+++ b/test/Compiler/simple/TaggedArrays.agda
@@ -1,0 +1,135 @@
+-- Test tagged array encoding of constructors for the JS backend.
+-- Covers: pure enums, mixed-arity constructors, default (catch-all) branches,
+-- nested case on two tagged-array types, interaction with builtin types.
+
+module TaggedArrays where
+
+open import Common.Nat
+open import Common.IO
+open import Common.Unit
+open import Common.String
+
+------------------------------------------------------------------------
+-- 1. Pure enum: 6 nullary constructors (all tags, no fields)
+
+data Color : Set where
+  red green blue yellow cyan magenta : Color
+
+showColor : Color -> String
+showColor red     = "red"
+showColor green   = "green"
+showColor blue    = "blue"
+showColor yellow  = "yellow"
+showColor cyan    = "cyan"
+showColor magenta = "magenta"
+
+------------------------------------------------------------------------
+-- 2. Mixed-arity constructors (0, 1, 2, 3 fields)
+
+data Shape : Set where
+  dot    : Shape
+  circle : Nat -> Shape
+  rect   : Nat -> Nat -> Shape
+  tri    : Nat -> Nat -> Nat -> Shape
+
+perimeter : Shape -> Nat
+perimeter dot          = 0
+perimeter (circle r)   = r * 6
+perimeter (rect w h)   = (w + h) * 2
+perimeter (tri a b c)  = a + b + c
+
+------------------------------------------------------------------------
+-- 3. Default branch (catch-all on tagged-array type)
+
+isWarm : Color -> String
+isWarm red     = "warm"
+isWarm yellow  = "warm"
+isWarm magenta = "warm"
+isWarm _       = "cool"
+
+------------------------------------------------------------------------
+-- 4. Nested case on two different tagged-array types
+
+describe : Color -> Shape -> String
+describe red   (circle _) = "red circle"
+describe blue  dot         = "blue dot"
+describe green (rect _ _)  = "green rect"
+describe _     _           = "other"
+
+------------------------------------------------------------------------
+-- 5. Tagged-array type containing builtin Nat, case on both
+
+data Bucket : Set where
+  empty  : Bucket
+  single : Nat -> Bucket
+  pair   : Nat -> Nat -> Bucket
+
+bucketSum : Bucket -> Nat
+bucketSum empty      = 0
+bucketSum (single x) = x
+bucketSum (pair x y) = x + y
+
+addToBucket : Nat -> Bucket -> Bucket
+addToBucket n empty      = single n
+addToBucket n (single x) = pair n x
+addToBucket n (pair x y) = pair n (x + y)
+
+------------------------------------------------------------------------
+-- 6. Nested tagged arrays: tagged-array type as field of another
+
+data Tree : Set where
+  leaf : Nat -> Tree
+  node : Tree -> Tree -> Tree
+
+sumTree : Tree -> Nat
+sumTree (leaf n)   = n
+sumTree (node l r) = sumTree l + sumTree r
+
+------------------------------------------------------------------------
+
+main : IO Unit
+main =
+  -- 1. Pure enum
+  putStrLn (showColor red) ,,
+  putStrLn (showColor blue) ,,
+  putStrLn (showColor magenta) ,,
+  -- 3. Default branch
+  putStrLn (isWarm red) ,,
+  putStrLn (isWarm green) ,,
+  putStrLn (isWarm cyan) ,,
+  putStrLn (isWarm magenta) ,,
+  -- 2. Mixed arity
+  printNat (perimeter dot) ,,
+  putStrLn "" ,,
+  printNat (perimeter (circle 5)) ,,
+  putStrLn "" ,,
+  printNat (perimeter (rect 3 7)) ,,
+  putStrLn "" ,,
+  printNat (perimeter (tri 3 4 5)) ,,
+  putStrLn "" ,,
+  -- 4. Nested case on two tagged-array types
+  putStrLn (describe red (circle 1)) ,,
+  putStrLn (describe blue dot) ,,
+  putStrLn (describe green (rect 2 3)) ,,
+  putStrLn (describe yellow (tri 1 2 3)) ,,
+  -- 5. Tagged-array + builtin Nat
+  printNat (bucketSum empty) ,,
+  putStrLn "" ,,
+  printNat (bucketSum (single 42)) ,,
+  putStrLn "" ,,
+  printNat (bucketSum (pair 10 20)) ,,
+  putStrLn "" ,,
+  printNat (bucketSum (addToBucket 5 empty)) ,,
+  putStrLn "" ,,
+  printNat (bucketSum (addToBucket 5 (single 3))) ,,
+  putStrLn "" ,,
+  printNat (bucketSum (addToBucket 5 (pair 3 7))) ,,
+  putStrLn "" ,,
+  -- 6. Nested tagged arrays (tree)
+  printNat (sumTree (leaf 1)) ,,
+  putStrLn "" ,,
+  printNat (sumTree (node (leaf 2) (leaf 3))) ,,
+  putStrLn "" ,,
+  printNat (sumTree (node (node (leaf 1) (leaf 2)) (node (leaf 3) (leaf 4)))) ,,
+  putStrLn "" ,,
+  return unit

--- a/test/Compiler/simple/TaggedArrays.out
+++ b/test/Compiler/simple/TaggedArrays.out
@@ -1,0 +1,28 @@
+EXECUTED_PROGRAM
+
+ret > ExitSuccess
+out > red
+out > blue
+out > magenta
+out > warm
+out > cool
+out > cool
+out > warm
+out > 0
+out > 30
+out > 20
+out > 12
+out > red circle
+out > blue dot
+out > green rect
+out > other
+out > 0
+out > 42
+out > 30
+out > 5
+out > 8
+out > 15
+out > 1
+out > 5
+out > 10
+out >

--- a/test/Compiler/simple/agda-rts.amd.js
+++ b/test/Compiler/simple/agda-rts.amd.js
@@ -1,0 +1,374 @@
+define([], function() {
+var exports = {};
+// Contains *most* of the primitives required by the JavaScript backend.
+// (Some, e.g., those using Agda types like Maybe, are defined in their
+// respective builtin modules.)
+//
+// Primitives prefixed by 'u' are uncurried variants, which are sometimes
+// emitted by the JavaScript backend. Whenever possible, the curried primitives
+// should be implemented in terms of the uncurried ones.
+//
+// Primitives prefixed by '_' are internal variants, usually for those primitives
+// which return Agda types like Maybe. These are never emitted by the compiler,
+// but can be used internally to define other prefixes.
+
+// Integers
+
+// primIntegerFromString : String -> Int
+exports.primIntegerFromString = BigInt;
+
+// primShowInteger : Int -> String
+exports.primShowInteger = x => x.toString();
+
+// uprimIntegerPlus : (Int, Int) -> Int
+exports.uprimIntegerPlus = (x, y) => x + y;
+
+// uprimIntegerMinus : (Int, Int) -> Int
+exports.uprimIntegerMinus = (x, y) => x - y;
+
+// uprimIntegerMultiply : (Int, Int) -> Int
+exports.uprimIntegerMultiply = (x, y) => x * y;
+
+// uprimIntegerRem : (Int, Int) -> Int
+exports.uprimIntegerRem = (x, y) => x % y;
+
+// uprimIntegerQuot : (Int, Int) -> Int
+exports.uprimIntegerQuot = (x, y) => x / y;
+
+// uprimIntegerEqual : (Int, Int) -> Bool
+exports.uprimIntegerEqual = (x, y) => x === y;
+
+// uprimIntegerGreaterOrEqualThan : (Int, Int) -> Bool
+exports.uprimIntegerGreaterOrEqualThan = (x, y) => x >= y;
+
+// uprimIntegerLessThan : (Int, Int) -> Bool
+exports.uprimIntegerLessThan = (x, y) => x < y;
+
+// Words
+const WORD64_MAX_VALUE = 18446744073709552000n;
+
+// primWord64ToNat : Word64 -> Nat
+exports.primWord64ToNat = x => x;
+
+// primWord64FromNat : Nat -> Word64
+exports.primWord64FromNat = x => x % WORD64_MAX_VALUE;
+
+// uprimWord64Plus : (Word64, Word64) -> Word64
+exports.uprimWord64Plus = (x, y) => (x + y) % WORD64_MAX_VALUE;
+
+// uprimWord64Minus : (Word64, Word64) -> Word64
+exports.uprimWord64Minus = (x, y) => (x + WORD64_MAX_VALUE - y) % WORD64_MAX_VALUE;
+
+// uprimWord64Multiply : (Word64, Word64) -> Word64
+exports.uprimWord64Multiply = (x, y) => (x * y) % WORD64_MAX_VALUE;
+
+// Natural numbers
+
+// primNatMinus : Nat -> Nat -> Nat
+exports.primNatMinus = x => y => {
+  const z = x - y;
+  return z < 0n ? 0n : z;
+};
+
+// Floating-point numbers
+var _primFloatGreatestCommonFactor = function(x, y) {
+    var z;
+    x = Math.abs(x);
+    y = Math.abs(y);
+    while (y) {
+        z = x % y;
+        x = y;
+        y = z;
+    }
+    return x;
+};
+exports._primFloatRound = function(x) {
+    if (exports.primFloatIsNaN(x) || exports.primFloatIsInfinite(x)) {
+        return null;
+    }
+    else {
+        return BigInt(Math.round(x));
+    }
+};
+exports._primFloatFloor = function(x) {
+    if (exports.primFloatIsNaN(x) || exports.primFloatIsInfinite(x)) {
+        return null;
+    }
+    else {
+        return BigInt(Math.floor(x));
+    }
+};
+exports._primFloatCeiling = function(x) {
+    if (exports.primFloatIsNaN(x) || exports.primFloatIsInfinite(x)) {
+        return null;
+    }
+    else {
+        return BigInt(Math.ceil(x));
+    }
+};
+exports._primFloatToRatio = function(x) {
+    if (exports.primFloatIsNaN(x)) {
+        return {numerator: BigInt(0), denominator: BigInt(0)};
+    }
+    else if (x < 0.0 && exports.primFloatIsInfinite(x)) {
+        return {numerator: BigInt(-1), denominator: BigInt(0)};
+    }
+    else if (x > 0.0 && exports.primFloatIsInfinite(x)) {
+        return {numerator: BigInt(1), denominator: BigInt(0)};
+    }
+    else if (exports.primFloatIsNegativeZero(x)) {
+        return {numerator: BigInt(0), denominator: BigInt(1)};
+    }
+    else if (x == 0.0) {
+        return {numerator: BigInt(0), denominator: BigInt(1)};
+    }
+    else {
+        var numerator = Math.round(x*1e9);
+        var denominator = 1e9;
+        var gcf = _primFloatGreatestCommonFactor(numerator, denominator);
+        numerator /= gcf;
+        denominator /= gcf;
+        return {numerator: BigInt(numerator), denominator: BigInt(denominator)};
+    }
+};
+exports._primFloatDecode = function(x) {
+    if (exports.primFloatIsNaN(x)) {
+        return null;
+    }
+    else if (x < 0.0 && exports.primFloatIsInfinite(x)) {
+        return null;
+    }
+    else if (x > 0.0 && exports.primFloatIsInfinite(x)) {
+        return null;
+    }
+    else {
+        var mantissa = x, exponent = 0;
+        while (!Number.isInteger(mantissa)) {
+            mantissa *= 2.0;
+            exponent -= 1;
+        };
+        while (mantissa % 2.0 === 0) {
+            mantissa /= 2.0;
+            exponent += 1;
+        }
+        return {mantissa: BigInt(mantissa), exponent: BigInt(exponent)};
+    }
+};
+exports.uprimFloatEquality = function(x, y) {
+    return x === y;
+};
+exports.primFloatEquality = function(x) {
+    return function(y) {
+        return exports.uprimFloatEquality(x, y);
+    };
+};
+exports.primFloatInequality = function(x) {
+    return function(y) {
+        return x <= y;
+    };
+};
+exports.primFloatLess = function(x) {
+    return function(y) {
+        return x < y;
+    };
+};
+exports.primFloatIsInfinite = function(x) {
+    return !Number.isNaN(x) && !Number.isFinite(x);
+};
+exports.primFloatIsNaN = function(x) {
+    return Number.isNaN(x);
+};
+exports.primFloatIsNegativeZero = function(x) {
+    return Object.is(x,-0.0);
+};
+exports.primFloatIsSafeInteger = function(x) {
+    return Number.isSafeInteger(x);
+};
+
+
+// These WORD64 values were obtained via `castDoubleToWord64` in Haskell:
+const WORD64_NAN      = 18444492273895866368n;
+const WORD64_POS_INF  = 9218868437227405312n;
+const WORD64_NEG_INF  = 18442240474082181120n;
+const WORD64_POS_ZERO = 0n;
+const WORD64_NEG_ZERO = 9223372036854775808n;
+
+exports.primFloatToWord64 = function(x) {
+    if (exports.primFloatIsNaN(x)) {
+        return WORD64_NAN;
+    }
+    else if (x < 0.0 && exports.primFloatIsInfinite(x)) {
+        return WORD64_NEG_INF;
+    }
+    else if (x > 0.0 && exports.primFloatIsInfinite(x)) {
+        return WORD64_POS_INF;
+    }
+    else if (exports.primFloatIsNegativeZero(x)) {
+        return WORD64_NEG_ZERO;
+    }
+    else if (x == 0.0) {
+        return WORD64_POS_ZERO;
+    }
+    else {
+        var mantissa, exponent;
+        ({mantissa, exponent} = exports._primFloatDecode(x));
+        var sign = Math.sign(mantissa);
+        console.log(mantissa);
+        mantissa *= sign;
+        sign = (sign === -1 ? "1" : "0");
+        mantissa = (mantissa.toString(2)).padStart(11, "0");
+        exponent = (mantissa.toString(2)).padStart(52, "0");
+        return BigInt(parseInt(sign + mantissa + exponent, 2));
+    }
+};
+
+// primNatToFloat : Nat -> Float
+exports.primNatToFloat = Number;
+
+// primIntToFloat : Int -> Float
+exports.primIntToFloat = Number;
+
+// primRatioToFloat : Int -> Int -> Float
+exports.primRatioToFloat = x => y => Number(x) / Number(y);
+
+// uprimFloatEncode : (Int, Int) -> Maybe Float
+exports.uprimFloatEncode = (x, y) => {
+  const mantissa = Number(x);
+  const exponent = Number(y);
+
+  if (Number.isSafeInteger(mantissa) && -1024 <= exponent && exponent <= 1024) {
+    return mantissa * (2 ** exponent);
+  }
+
+  else {
+    return null;
+  }
+};
+
+exports.primShowFloat = function(x) {
+    // See Issue #2192.
+    if (Number.isInteger(x)) {
+        if (exports.primFloatIsNegativeZero(x)) {
+            return ("-0.0");
+        } else {
+            return (x.toString() + ".0");
+        }
+    } else {
+        return x.toString();
+    }
+};
+exports.primFloatPlus = function(x) {
+    return function(y) {
+        return x + y;
+    };
+};
+exports.primFloatMinus = function(x) {
+    return function(y) {
+        return x - y;
+    };
+};
+exports.primFloatTimes = function(x) {
+    return function(y) {
+        return x * y;
+    };
+};
+exports.primFloatNegate = function(x) {
+    return -x;
+};
+exports.primFloatDiv = function(x) {
+  return function(y) {
+    return x / y;
+  };
+};
+exports.primFloatPow = function(x) {
+    return function(y) {
+        return x ** y;
+    };
+};
+exports.primFloatSqrt = function(x) {
+    return Math.sqrt(x);
+};
+exports.primFloatExp = function(x) {
+    return Math.exp(x);
+};
+exports.primFloatLog = function(x) {
+    return Math.log(x);
+};
+exports.primFloatSin = function(x) {
+    return Math.sin(x);
+};
+exports.primFloatCos = function(x) {
+    return Math.cos(x);
+};
+exports.primFloatTan = function(x) {
+    return Math.tan(x);
+};
+exports.primFloatASin = function(x) {
+    return Math.asin(x);
+};
+exports.primFloatACos = function(x) {
+    return Math.acos(x);
+};
+exports.primFloatATan = function(x) {
+    return Math.atan(x);
+};
+exports.primFloatATan2 = function(x) {
+    return function(y){
+        return Math.atan2(x, y);
+    };
+};
+exports.primFloatSinh = function(x) {
+    return Math.sinh(x);
+};
+exports.primFloatCosh = function(x) {
+    return Math.cosh(x);
+};
+exports.primFloatTanh = function(x) {
+    return Math.tanh(x);
+};
+exports.primFloatASinh = function(x) {
+    return Math.asinh(x);
+};
+exports.primFloatACosh = function(x) {
+    return Math.acosh(x);
+};
+exports.primFloatATanh = function(x) {
+    return Math.atanh(x);
+};
+
+// Cubical primitives.
+exports.primIMin = x => y => x && y;
+exports.primIMax = x => y => x || y;
+exports.primINeg = x => !x;
+exports.primPartial = _ => _ => x => x;
+exports.primPartialP = _ => _ => x => x;
+exports.primPOr = _ => i => _ => _ => x => y => i ? x : y;
+exports.primComp = _ => _ => _ => _ => x => x;
+exports.primTransp = _ => _ => _ => x => x;
+exports.primHComp = _ => _ => _ => _ => x => x;
+exports.primSubOut = _ => _ => _ => _ => x => x;
+exports.prim_glueU = _ => _ => _ => _ => _ => x => x;
+exports.prim_unglueU = _ => _ => _ => _ => x => x;
+exports.primFaceForall = f => f(true) == true && f(false) == false;
+
+// Other stuff
+
+// primSeq : (X, Y) -> Y
+exports.primSeq = (x, y) => y;
+
+// uprimQNameEquality : (Name, Name) -> Bool
+exports.uprimQNameEquality = (x, y) => x['id'] === y['id'] && x['moduleId'] === y['moduleId'];
+
+// primQNameEquality : Name -> Name -> Bool
+exports.primQNameEquality = x => y => exports.uprimQNameEquality(x, y);
+
+// primQNameLess : Name -> Name -> Bool
+exports.primQNameLess = x => y => x['id'] === y['id'] ? x['moduleId'] < y['moduleId'] : x['id'] < y['id'];
+
+// primShowQName : Name -> String
+exports.primShowQName = x => x['name'];
+
+// primQNameFixity : Name -> Fixity
+exports.primQNameFixity = x => x['fixity'];
+return exports;
+});


### PR DESCRIPTION
Closes #8398.

## Summary

Replace Scott encoding of data types with tagged arrays in the JS backend.

The main motivation is to make a bridge to (relatively) simple realization of a tail call optimization.

**Before** (Scott encoding) — constructors are functions, case splits are calls:

~~~javascript
exports["c2"] = x => y => k => k["c2"](x, y)
p({ "c1": () => E1, "c2": (x,y) => E2 })
~~~

**After** (tagged arrays) — constructors are arrays, case splits are switches:

~~~javascript
exports["c2"] = x => y => [1, x, y]
(() => {
  switch (p[0]) {
    case 0: { return E1; }
    case 1: { let x = p[1], y = p[2]; return E2; }
  }
})()
~~~



Types with `{-# COMPILE JS #-}` pragmas keep Scott encoding for backward compatibility with user-defined FFI code.

## Changes

- **Syntax.hs**: new AST nodes — `Int` (native JS number for tags), `IIFE`, `Stmt` (`Return`, `Switch`, `VarDecl`, `Block`, `ExprStmt`); `Uses` and `Globals` instances for `Stmt`
- **Substitution.hs**: traversal of `IIFE`/`Stmt` in `map`, `map'`, `self` (and their `Stmt` variants) — required to avoid OOM in `fix`
- **Pretty.hs**: JS code generation for `Int`, `IIFE`, `Stmt`; non-removable spaces for `case`/`return`/`let` keywords (minification correctness)
- **Compiler.hs**:
  - Constructors compile to `[tag, arg0, arg1, ...]`
  - Case splits compile to `Switch` on `scrutinee[0]`, field extraction via `scrutinee[1]`, `[2]`, ...
  - Single-constructor optimization (skip switch, extract fields directly)
  - `getConstructorTag` using `canonicalName` for module-instantiated constructors
  - `eliminateCaseDefaults` removed (switch handles defaults naturally)
- **Tests.hs**: fixed `fdebugTestFilter` regex patterns; removed stale `ModuleReexport` disables
- **TaggedArrays.agda**: new test covering pure enums, mixed-arity constructors, default branches, nested case on two tagged-array types, interaction with builtins, recursive types

## Test results

- All 909 compiler tests pass (0 failures), including GHC backend
- All 6 JS variants: CJS/ES6 x NonOptimized/Optimized/MinifiedOptimized
- Standard library JS test passes
