### PR TITLE
Refactor: Make Context a newtype

### DIFF
--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -440,7 +440,9 @@ makeCase hole rng s = withInteractionId hole $ locallyTC eMakeCase (const True) 
 
     -- If any of the split variables is hidden by the ellipsis, we
     -- should force the expansion of the ellipsis.
-    let splitNames = map (\i -> ctxEntryName $ clauseCxt !! i) toSplit
+    let splitNames =
+          map (ctxEntryName . fromMaybe __IMPOSSIBLE__ . (`cxLookup` clauseCxt))
+          toSplit
     shouldExpandEllipsis <- return (not $ null toShow) `or2M` anyEllipsisVar f absCl splitNames
     let ell' | shouldExpandEllipsis = NoEllipsis
              | otherwise            = ell

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1639,6 +1639,10 @@ instance Reify i => Reify (Dom i) where
     reify (Dom{domInfo = info, unDom = i}) = Arg info <$> reify i
     {-# INLINE reify #-}
 
+instance Reify Context where
+  type ReifiesTo Context = [A.TypedBinding]
+
+  reify (Context es) = reify es
 
 instance Reify ContextEntry where
   type ReifiesTo ContextEntry = A.TypedBinding

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -1642,7 +1642,7 @@ instance Reify i => Reify (Dom i) where
 instance Reify Context where
   type ReifiesTo Context = [A.TypedBinding]
 
-  reify (Context es) = reify es
+  reify = reify . contextToTel
 
 instance Reify ContextEntry where
   type ReifiesTo ContextEntry = A.TypedBinding

--- a/src/full/Agda/TypeChecking/Conversion.hs
+++ b/src/full/Agda/TypeChecking/Conversion.hs
@@ -2161,19 +2161,19 @@ forallFaceMaps t kb k = do
     -- assumes the term can be typed in the shorter telescope
     -- the terms we get from toFaceMaps are closed.
     substContext :: MonadConversion m => Int -> Term -> Context -> m (Context , Substitution)
-    substContext i t [] = __IMPOSSIBLE__
-    substContext i t (x:xs) | i == 0 = return $ (xs , singletonS 0 t)
-    substContext i t (x:xs) | i > 0 = do
-                                  reportSDoc "conv.forall" 20 $
-                                    fsep ["substContext"
-                                        , text (show (i-1))
-                                        , prettyTCM t
-                                        , prettyTCM xs
-                                        ]
-                                  (c,sigma) <- substContext (i-1) t xs
-                                  let e = applySubst sigma x
-                                  return (e:c, liftS 1 sigma)
-    substContext i t (x:xs) = __IMPOSSIBLE__
+    substContext i t CxEmpty = __IMPOSSIBLE__
+    substContext i t (CxExtend x xs) | i == 0 = return $ (xs , singletonS 0 t)
+    substContext i t (CxExtend x xs) | i > 0 = do
+      reportSDoc "conv.forall" 20 $
+        fsep ["substContext"
+            , text (show (i-1))
+            , prettyTCM t
+            , prettyTCM xs
+            ]
+      (c,sigma) <- substContext (i-1) t xs
+      let e = applySubst sigma x
+      return (CxExtend e c, liftS 1 sigma)
+    substContext i t (CxExtend x xs) = __IMPOSSIBLE__
 
 compareInterval :: MonadConversion m => Comparison -> Type -> Term -> Term -> m ()
 compareInterval cmp i t u = do

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -220,8 +220,8 @@ generalizeTelescope vars typecheckAction ret = billTo [Typing, Generalize] $ wit
   letbinds' <- applySubst (liftS (size tel) sub) <$> instantiateFull letbinds
   let addLet (x, LetBinding isAxiom o v dom) = addLetBinding' isAxiom o x v dom
 
-  updateContext sub (cxAppend genTelCxt . cxDrop 1) $
-    updateContext (raiseS (size tel')) (cxAppend newTelCxt) $
+  updateContext sub (cxPrepend genTelCxt . cxDrop 1) $
+    updateContext (raiseS (size tel')) (cxPrepend newTelCxt) $
       foldr addLet (ret genTelVars $ abstract genTel tel') letbinds'
 
 
@@ -650,7 +650,7 @@ pruneUnsolvedMetas genRecName genRecCon genTel genRecFields interactionPoints is
           let rΔσ = zipWith (\ name dom -> CtxVar name (snd <$> dom))
                             (map ctxEntryName rΔ)
                             (reverse $ telToList _Δσ)
-          return (cxAppend rΔσ  $ cxAppend rΘ rΓ, rΘ)
+          return (cxPrepend rΔσ  $ cxPrepend rΘ rΓ, rΘ)
 
         -- Now we can enter the new context and create our meta variable.
         (y, u) <- updateContext ρ (const newCxt) $ localScope $ do

--- a/src/full/Agda/TypeChecking/IApplyConfluence.hs
+++ b/src/full/Agda/TypeChecking/IApplyConfluence.hs
@@ -194,11 +194,11 @@ unifyElims vs ts k = do
     :: Substitution
     -> IntSet  -- Support.
     -> Context -> Context
-  codomain s vs =
+  codomain s vs = Context .
     mapMaybe (\(i, c) -> if i `IntSet.member` vs
                          then Nothing
                          else Just c) .
-    zipWith (\i c -> (i, dropS (i + 1) s `applySubst` c)) [0..]
+    cxWithIndex (\i c -> (i, dropS (i + 1) s `applySubst` c))
 
 -- | Like @unifyElims@ but @Γ@ is from the meta's @MetaInfo@ and
 -- the context extension @Δ@ is taken from the @Closure@.

--- a/src/full/Agda/TypeChecking/Lock.hs
+++ b/src/full/Agda/TypeChecking/Lock.hs
@@ -81,7 +81,7 @@ checkLockedVars t ty lk lk_ty = do
     earlierVars = VarSet.range i (size cxt)
   if termVars `VarSet.isSubsetOf` earlierVars then return () else do
 
-  let toCheck = zip [0..] $ zipWith raise [1..] (take i cxt)
+  let toCheck = zip [0..] $ zipWith raise [1..] $ cxTake i cxt
   checked <- fmap catMaybes . forM toCheck $ \ (j,ce) -> do
     ifM (isTimeless (ctxEntryType ce))
         (return $ Just j)

--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -518,7 +518,8 @@ newQuestionMark' new ii cmp t = lookupInteractionMeta ii >>= \case
         let numFields = glen - g1len - g0len
         if numFields <= 0 then return $ vs1 ++ vs0 else do
           -- Get the record type.
-          let t = (unDom . ctxEntryDom) $ fromMaybe __IMPOSSIBLE__ $ delta !!! k
+          let t = unDom $ ctxEntryDom $ fromMaybe __IMPOSSIBLE__ $
+                  cxLookup k delta
           -- Get the record field names.
           fs <- reverse . take numFields <$> getRecordTypeFields t
           -- Check that the record field names match

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4261,7 +4261,7 @@ data TCEnv =
     deriving (Generic)
 
 initEnv :: TCEnv
-initEnv = TCEnv { envContext             = []
+initEnv = TCEnv { envContext             = CxEmpty
                 , envLetBindings         = Map.empty
                 , envCurrentModule       = noModuleName
                 , envCurrentPath         = Nothing

--- a/src/full/Agda/TypeChecking/Monad/Base/Types.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base/Types.hs
@@ -65,8 +65,9 @@ data ContextEntry
   -- N.B. 2024-11-29 there might be CtxLet in the future.
   deriving (Show, Generic)
 
+-- | Does not raise the retrieved entry!
 cxLookup :: Nat -> Context -> Maybe ContextEntry
-cxLookup i g = cxEntries g !!! i
+cxLookup i (Context es) = es !!! i
 
 cxDrop :: Nat -> Context -> Context
 cxDrop n (Context es) = Context $ drop n es
@@ -78,13 +79,13 @@ cxTake n (Context es) = take n es
 
 -- | Assumes the list of entries to be prepended follows the context ordering
 --   convention (earlier entries depend on later ones)
-cxAppend :: [ContextEntry] -> Context -> Context
-cxAppend es' (Context es) = Context $ es' ++ es
+cxPrepend :: [ContextEntry] -> Context -> Context
+cxPrepend es' (Context es) = Context $ es' ++ es
 
 -- | The returned prefix follows the context ordering convention (earlier
 --   entries depend on later ones)
 cxSplitAt :: Nat -> Context -> ([ContextEntry], Context)
-cxSplitAt n (Context es) = second Context (splitAt n es)
+cxSplitAt n (Context es) = second Context $ splitAt n es
 
 cxWithIndex :: (Nat -> ContextEntry -> a) -> Context -> [a]
 cxWithIndex f (Context es) = zipWith f [0..] es

--- a/src/full/Agda/TypeChecking/Monad/Context.hs
+++ b/src/full/Agda/TypeChecking/Monad/Context.hs
@@ -373,7 +373,7 @@ instance {-# OVERLAPPABLE #-} AddContext a => AddContext [a] where
 
 instance AddContext Context where
   addContext = flip (foldl $ flip addContext); {-# INLINABLE addContext #-}
-  contextSize = sum . map contextSize . cxEntries
+  contextSize = size
 
 instance AddContext ContextEntry where
   addContext (CtxVar x a) = addCtx x a

--- a/src/full/Agda/TypeChecking/Monad/Modality.hs
+++ b/src/full/Agda/TypeChecking/Monad/Modality.hs
@@ -64,7 +64,7 @@ workOnTypes' experimental
 
 applyPolarityToContext :: (MonadTCEnv tcm, LensModalPolarity p) => p -> tcm a -> tcm a
 applyPolarityToContext p = localTC
-  $ over eContext     (map $ inverseApplyPolarity pol)
+  $ over eContext     (fmap $ inverseApplyPolarity pol)
   . over eLetBindings (Map.map . fmap . onLetBindingType
                        $ inverseApplyPolarity pol)
   where
@@ -91,7 +91,7 @@ applyRelevanceToContext thing =
 --   Precondition: @Relevance /= Relevant@
 applyRelevanceToContextOnly :: (MonadTCEnv tcm) => Relevance -> tcm a -> tcm a
 applyRelevanceToContextOnly rel = localTC
-  $ over eContext     (map $ inverseApplyRelevance rel)
+  $ over eContext     (fmap $ inverseApplyRelevance rel)
   . over eLetBindings (Map.map . fmap . onLetBindingType $ inverseApplyRelevance rel)
 
 -- | Apply relevance @rel@ the the relevance annotation of the (typing/equality)
@@ -131,7 +131,7 @@ applyCohesionToContext thing =
 
 applyCohesionToContextOnly :: (MonadTCEnv tcm) => Cohesion -> tcm a -> tcm a
 applyCohesionToContextOnly q = localTC
-  $ over eContext     (map $ inverseApplyCohesion q)
+  $ over eContext     (fmap $ inverseApplyCohesion q)
   . over eLetBindings (Map.map . fmap . onLetBindingType $ inverseApplyCohesion q)
 
 -- | Can we split on arguments of the given cohesion?
@@ -169,7 +169,7 @@ applyModalityToContext thing =
 --   Precondition: @Modality /= Relevant@
 applyModalityToContextOnly :: (MonadTCEnv tcm) => Modality -> tcm a -> tcm a
 applyModalityToContextOnly m = localTC
-  $ over eContext (map $ inverseApplyModalityButNotQuantity m)
+  $ over eContext (fmap $ inverseApplyModalityButNotQuantity m)
   . over eLetBindings
       (Map.map . fmap . onLetBindingType $ inverseApplyModalityButNotQuantity m)
 

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -613,7 +613,7 @@ applySection' new ptel old ts ren@ScopeCopyInfo{ renNames = rd, renModules = rm 
           m = unitModality { modCohesion = getCohesion ai
                            , modPolarity = getModalPolarity ai
                            }
-      localTC (over eContext (map (mapModality (m `inverseComposeModality`)))) $
+      localTC (over eContext (fmap (mapModality (m `inverseComposeModality`)))) $
         copyDef' ts'' np def
       reportSDoc "tc.mod.apply" 80 $
         "finished copyDef" <+> pretty x <+> "->" <+> pretty y

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -284,6 +284,7 @@ instance PrettyTCM (Arg A.Expr)       where prettyTCM = prettyA <=< reify       
 instance PrettyTCM (NamedArg A.Expr)  where prettyTCM = prettyA <=< reify         ; {-# SPECIALIZE prettyTCM :: (NamedArg A.Expr) -> TCM Doc #-}
 instance PrettyTCM (NamedArg Term)    where prettyTCM = prettyA <=< reify         ; {-# SPECIALIZE prettyTCM :: (NamedArg Term)   -> TCM Doc #-}
 instance PrettyTCM (Dom Type)         where prettyTCM = prettyA <=< reify         ; {-# SPECIALIZE prettyTCM :: (Dom Type)        -> TCM Doc #-}
+instance PrettyTCM Context            where prettyTCM = prettyA <=< reify         ; {-# SPECIALISE prettyTCM :: Context           -> TCM Doc #-}
 instance PrettyTCM ContextEntry       where prettyTCM = prettyA <=< reify         ; {-# SPECIALIZE prettyTCM :: ContextEntry      -> TCM Doc #-}
 
 instance PrettyTCM Permutation        where prettyTCM = text . show               ; {-# SPECIALIZE prettyTCM :: Permutation       -> TCM Doc #-}

--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -1538,6 +1538,9 @@ instance (Subst a, InstantiateFull a) => InstantiateFull (Abs a) where
 instance (InstantiateFull t, InstantiateFull e) => InstantiateFull (Dom' t e) where
     instantiateFull' (Dom i n b tac x) = Dom i n b <$> instantiateFull' tac <*> instantiateFull' x
 
+instance InstantiateFull Context where
+  instantiateFull' (Context es) = Context <$> instantiateFull' es
+
 instance InstantiateFull ContextEntry where
   instantiateFull' (CtxVar x a) = CtxVar x <$> instantiateFull' a
 

--- a/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/NonLinMatch.hs
@@ -399,7 +399,7 @@ instance Match NLPat Term where
         unless (isIrrelevant r) $ tellEq gamma k t u v
 
 extendContext :: MonadAddContext m => Context -> ArgName -> Dom Type -> m Context
-extendContext cxt x a = withFreshName empty x \ y -> return $ CtxVar y a : cxt
+extendContext cxt x a = withFreshName empty x \y -> return $ CxExtendVar y a cxt
 
 
 makeSubstitution :: Telescope -> Sub -> Maybe Substitution

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -41,7 +41,6 @@ import {-# SOURCE #-} Agda.TypeChecking.Rules.Decl (checkDecl)
 import Agda.Utils.Boolean
 import Agda.Utils.Function ( applyWhen )
 import Agda.Utils.Lens
-import Agda.Utils.List (headWithDefault)
 import Agda.Utils.List1 (pattern (:|) )
 import Agda.Utils.Monad
 import Agda.Utils.Null
@@ -356,8 +355,8 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
           -- record type.
           -- See test/Succeed/ProjectionsTakeModuleTelAsParameters.agda.
           tel' <- do
-            r <- headWithDefault __IMPOSSIBLE__ <$> getContext
-            return $ contextToTel $ r : params
+            r <- fromMaybe __IMPOSSIBLE__ . cxLookup 0 <$> getContext
+            return $ contextToTel $ CxExtend r params
           cp <- viewTC eCurrentCheckpoint
           setModuleCheckpoint m cp
           checkRecordProjections m name hasNamedCon con tel' ftel fields

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1981,7 +1981,7 @@ checkLetBinding' b@(A.LetPatBind i ai p e) ret = do
       fs <- recordPatternToProjections p
       -- We remove the bindings for the pattern variables from the context.
       cxt0 <- getContext
-      let (binds, cxt) = splitAt (size delta) cxt0
+      let (binds, cxt) = splitAt (size delta) (cxEntries cxt0)
           toDrop       = length binds
 
           -- We create a substitution for the let-bound variables
@@ -1994,7 +1994,7 @@ checkLetBinding' b@(A.LetPatBind i ai p e) ret = do
           -- the size of delta, so we append the identity substitution.
           sub    = parallelS (reverse sigma)
 
-      updateContext sub (drop toDrop) $ do
+      updateContext sub (cxDrop toDrop) $ do
         reportSDoc "tc.term.let.pattern" 20 $ nest 2 $ vcat
           [ "delta =" <+> prettyTCM delta
           , "binds =" <+> prettyTCM binds

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1981,8 +1981,8 @@ checkLetBinding' b@(A.LetPatBind i ai p e) ret = do
       fs <- recordPatternToProjections p
       -- We remove the bindings for the pattern variables from the context.
       cxt0 <- getContext
-      let (binds, cxt) = splitAt (size delta) (cxEntries cxt0)
-          toDrop       = length binds
+      let binds  = cxTake (size delta) cxt0
+          toDrop = length binds
 
           -- We create a substitution for the let-bound variables
           -- (unfortunately, we cannot refer to x in internal syntax

--- a/src/full/Agda/TypeChecking/SizedTypes.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes.hs
@@ -140,7 +140,7 @@ checkSizeVarNeverZero i = do
   -- Looking for the minimal value for size variable i,
   -- we can restrict to the last i
   -- entries, as only these can contain i in an upper bound.
-  ts <- map ctxEntryType . take i <$> getContext
+  ts <- map ctxEntryType . cxTake i <$> getContext
   -- If we encountered a blocking meta in the context, we cannot
   -- say ``no'' for sure.
   (n, blockers) <- runWriterT $ minSizeValAux ts $ ListInf.repeat 0

--- a/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
+++ b/src/full/Agda/TypeChecking/SizedTypes/Solve.hs
@@ -332,9 +332,9 @@ castConstraintToCurrentContext c = do
             let findInGamma ce =
                   -- match by name (hazardous)
                   -- This is one of the seven deadly sins (not respecting alpha).
-                  List.findIndex (((==) `on` ctxEntryName) ce) gamma
+                  List.findIndex (((==) `on` ctxEntryName) ce) (cxEntries gamma)
             let delta = envContext $ clEnv cl
-                cand  = map findInGamma delta
+                cand  = map findInGamma $ cxEntries delta
             -- The domain of our substitution
             let coveredVars = VarSet.fromList $ catMaybes $ zipWith ($>) cand [0..]
             -- Check that all the free variables of the constraint are contained in
@@ -574,7 +574,7 @@ getSizeHypotheses gamma = unsafeModifyContext (const gamma) $ do
   caseMaybe msizelt (return []) $ \ sizelt -> do
     -- Traverse the context from newest to oldest de Bruijn Index
     catMaybes <$> do
-      forM (zip [0..] gamma) $ \case
+      forM (cxWithIndex (,) gamma) $ \case
         (i, CtxVar x a) -> do
           -- Get name and type of variable i.
           let s = prettyShow x

--- a/src/full/Agda/TypeChecking/Telescope.hs
+++ b/src/full/Agda/TypeChecking/Telescope.hs
@@ -68,12 +68,12 @@ flattenRevTel tel = loop (size tel) [] tel
 --    (Γ : Context) -> [Type Γ]
 -- @
 flattenContext :: Context -> [ContextEntry]
-flattenContext = loop 1 []
+flattenContext = loop 1 [] . cxEntries
   where
     loop n tel []       = tel
     loop n tel (ce:ctx) = loop (n + 1) (raise n ce : tel) ctx
 
--- | Order a flattened telescope in the correct dependeny order: Γ ->
+-- | Order a flattened telescope in the correct dependency order: Γ ->
 --   Permutation (Γ -> Γ~)
 --
 --   Since @reorderTel tel@ uses free variable analysis of type in @tel@,

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -870,7 +870,7 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
     tcGetContext = liftTCM $ do
       r <- isReconstructed
       let getVar (CtxVar x a) = (nameToArgName x, a)
-      as <- map getVar <$> getContext
+      as <- map getVar . cxEntries <$> getContext
       as <- etaContract =<< process as
       if r then do
         as <- recons (reverse as)

--- a/test/Bugs/Issue8182.err
+++ b/test/Bugs/Issue8182.err
@@ -33,7 +33,7 @@ out >   field tel = (B : Set)
 out > Found interaction point ConcreteDef ?0 : Set
 out > reusing meta
 out >   creation context: [(genTel : Issue8182..GeneralizeTel)]
-out >   reusage  context: [(genTel : _11 (r = genTel)), (r : R)]
+out >   reusage  context: [(r : R), (genTel : _11 (r = r))]
 out >   k     = 1
 out >   glen  = 1
 out >   g0len = 0
@@ -43,7 +43,7 @@ out > meta reuse arguments: [genTel]
 out > Found interaction point ConcreteDef ?1 : Set
 out > reusing meta
 out >   creation context: [{G : Set}]
-out >   reusage  context: [(genTel : _11 (r = genTel)), (r : R)]
+out >   reusage  context: [(r : R), (genTel₁ : _11 (r = r))]
 out >   k     = 1
 out >   glen  = 1
 out >   g0len = 0


### PR DESCRIPTION
The motivation for this refactor was noticing some of the `traceSDoc`s in `Match NLPat Term` were mangled (incorrect variable names). The root issue turned out to be that that `addContext k` where `k :: Context` was calling into the `AddContext [a]` instance, which is designed for telescopes rather than contexts (so the context entries were getting added to the context in reverse). This didn't cause an obvious bug with functionality because the types of `PBoundVar`s are retrieved with `lookupBV_ i k` directly rather than first adding `k` to the context and then calling `lookupBV`, but I think this is brittle (and maybe does cause a bug somewhere - I haven't tried super hard to find one).

The quick solution would just be to add an `{-# OVERLAPPING #-} AddContext Context` instance, but I thought I would try to do the principled thing and wrap `Context` in a `newtype` instead.

I am not sure if this is really worth it - there is still some code that works with un-reversed `[ContextEntry]`s... Up to the maintainers I guess.