### PR TITLE
[ fix #8393 ] Normalise codomain of piSort when needed

### DIFF
--- a/src/full/Agda/TypeChecking/Free.hs
+++ b/src/full/Agda/TypeChecking/Free.hs
@@ -58,6 +58,7 @@ module Agda.TypeChecking.Free
     , closed
     , MetaSet
     , insertMetaSet, foldrMetaSet, metaSetToBlocker
+    , flexRigToBlocker
     ) where
 
 import Prelude hiding (null)

--- a/src/full/Agda/TypeChecking/Free/Lazy.hs
+++ b/src/full/Agda/TypeChecking/Free/Lazy.hs
@@ -207,6 +207,11 @@ composeFlexRig = curry $ \case
 oneFlexRig :: FlexRig' a
 oneFlexRig = Unguarded
 
+-- | Extract a blocker from an occurrence
+flexRigToBlocker :: FlexRig -> Blocker
+flexRigToBlocker (Flexible ms) = metaSetToBlocker ms
+flexRigToBlocker _ = neverUnblock
+
 ---------------------------------------------------------------------------
 -- * Multi-dimensional feature vector for variable occurrence (semigroup)
 

--- a/src/full/Agda/TypeChecking/Reduce.hs-boot
+++ b/src/full/Agda/TypeChecking/Reduce.hs-boot
@@ -2,7 +2,19 @@
 
 module Agda.TypeChecking.Reduce where
 
-import Agda.Syntax.Internal (Term, Elims, QName)
-import Agda.TypeChecking.Monad.Base (TCM, Reduced)
+import Agda.Syntax.Common (Arg)
+import Agda.Syntax.Internal (Term, Type, Sort, Elims, QName, Abs)
+import Agda.TypeChecking.Monad.Base (TCM, Reduced, MonadReduce)
+import Agda.TypeChecking.Substitute.Class (Subst)
 
 reduceDefCopyTCM :: QName -> Elims -> TCM (Reduced () Term)
+
+class Reduce t
+
+instance Reduce Term
+instance Reduce Type
+instance Reduce Sort
+instance Reduce a => Reduce (Arg a)
+instance (Subst a, Reduce a) => Reduce (Abs a)
+
+reduce :: (Reduce a, MonadReduce m) => a -> m a

--- a/src/full/Agda/TypeChecking/Substitute.hs
+++ b/src/full/Agda/TypeChecking/Substitute.hs
@@ -1715,26 +1715,40 @@ piSort' :: Dom Term -> Sort -> Abs Sort -> Either Blocker Sort
 piSort' a s1       (NoAbs _ s2) = Right $ FunSort s1 s2
 piSort' a s1 s2Abs@(Abs   _ s2) = case flexRigOccurrenceIn 0 s2 of
   Nothing -> Right $ FunSort s1 $ noabsApp __IMPOSSIBLE__ s2Abs
-  Just o  -> case (sizeOfSort s1 , sizeOfSort s2) of
-    (Right (SmallSort u1) , Right (SmallSort u2)) -> case o of
-      StronglyRigid -> Right $ Inf (funUniv u1 u2) 0
-      Unguarded     -> Right $ Inf (funUniv u1 u2) 0
-      WeaklyRigid   -> Right $ Inf (funUniv u1 u2) 0
-      Flexible ms   -> Left $ metaSetToBlocker ms
-    (Right (LargeSort u1 n) , Right (SmallSort u2)) -> Right $ Inf (funUniv u1 u2) n
-    (_                     , Right LargeSort{}    ) ->
-       -- large sorts cannot depend on variables
-       __IMPOSSIBLE__
-       -- (`trace` __IMPOSSIBLE__) $ unlines
-       --   [ "piSort': unexpected dependency in large codomain s2"
-       --   , "- a  = " ++ prettyShow a
-       --   , "- s1 = " ++ prettyShow s1
-       --   , "- s2 = " ++ prettyShow s2
-       --   , "- s2 (raw) = " ++ show s2
-       --   ]
-    (Left blocker          , Right _              ) -> Left blocker
-    (Right _               , Left blocker         ) -> Left blocker
-    (Left blocker1         , Left blocker2        ) -> Left $ unblockOnBoth blocker1 blocker2
+  Just o  -> piSortAbs a s1 s2Abs o CodomainNotNormalised
+
+data IsCodomainNormalised = CodomainNormalised | CodomainNotNormalised
+
+-- | Compute the sort of a pi type where the codomain sort is a proper Abs.
+--   Compared to piSort' we take two additional arguments:
+--   4. The occurrence of the variable in the codomain.
+--   5. Whether we have already tried to remove the dependency by
+--      normalising the codomain sort (e.g. with forceNoAbs)
+piSortAbs
+  :: Dom Term
+  -> Sort
+  -> Abs Sort
+  -> FlexRig
+  -> IsCodomainNormalised
+  -> Either Blocker Sort
+piSortAbs a s1 NoAbs{} _ _ = __IMPOSSIBLE__
+piSortAbs a s1 (Abs x s2) occ norm = case (sizeOfSort s1 , sizeOfSort s2) of
+  (Right (SmallSort u1) , Right (SmallSort u2)) -> case occ of
+    StronglyRigid -> Right $ Inf (funUniv u1 u2) 0
+    Unguarded     -> Right $ Inf (funUniv u1 u2) 0
+    -- Jesper, 2026-02-17: A weakly rigid occurrence might disappear after
+    -- normalisation (see #8393) so we refrain from making a final verdict here.
+    -- unless we are sure further normalisation will not remove the dependency
+    WeaklyRigid -> case norm of
+      CodomainNormalised -> Right $ Inf (funUniv u1 u2) 0
+      CodomainNotNormalised -> Left alwaysUnblock
+    Flexible ms -> Left $ metaSetToBlocker ms
+  (Right (LargeSort u1 n) , Right (SmallSort u2)) -> Right $ Inf (funUniv u1 u2) n
+  -- large sorts cannot depend on variables
+  (_                      , Right LargeSort{}   ) -> __IMPOSSIBLE__
+  (Left blocker          , Right _              ) -> Left blocker
+  (Right _               , Left blocker         ) -> Left blocker
+  (Left blocker1         , Left blocker2        ) -> Left $ unblockOnBoth blocker1 blocker2
 
 -- Andreas, 2019-06-20
 -- KEEP the following commented out code for the sake of the discussion on irrelevance.

--- a/test/Fail/Issue399.err
+++ b/test/Fail/Issue399.err
@@ -13,7 +13,7 @@ Failed to solve the following constraints:
      funSort (_7 (m = m) (mzero = mzero))
      (funSort (_10 (m = m) (mzero = mzero)) Set))
     =< Set₁
-    (blocked on all(_7, _10))
+    (blocked on any(all(_7, _10), _7))
   piSort Set₁ (λ a → funSort (_2 (m = m)) Set) =< Set₁
     (blocked on _2)
 

--- a/test/Succeed/Issue8393.agda
+++ b/test/Succeed/Issue8393.agda
@@ -1,0 +1,48 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+open import Agda.Primitive
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Sigma
+
+record SomeLevel {ℓ} (A : Set ℓ) : Setω where
+  field
+    level : Level
+
+open SomeLevel ⦃...⦄ public
+
+record Semigroup {ℓ} (A : Set ℓ) : Set ℓ where
+  field _◇_ : A → A → A
+
+open Semigroup ⦃...⦄ public
+
+module _ {ℓ} (A : Set ℓ) ⦃ _ : Semigroup A ⦄ where
+  record Comm ⦃ l : SomeLevel A ⦄ : Set (ℓ ⊔ level) where
+    field ◇-comm  : ∀ (x y : A) → (x ◇ y) ≡ (y ◇ x)
+
+  someLevel : SomeLevel A
+  someLevel .level = ℓ
+
+  Comm' : Set ℓ
+  Comm' = Comm
+                   ⦃ someLevel ⦄ -- fails in master
+                   -- ⦃ record { level = ℓ } ⦄ -- succeeds in master
+
+open Comm ⦃...⦄ public
+
+module _ {ℓ} {A : Set ℓ} ⦃ _ : Semigroup A ⦄ ⦃ a : Comm' A ⦄ where
+
+  open Comm ⦃ l = record { level = ℓ } ⦄ a public
+    renaming (◇-comm to ◇-comm≡)
+
+module _ {a b} {A : Set a} {b : Set b} {B : Set} ⦃ m : Semigroup A ⦄ ⦃ n : Semigroup B ⦄ where
+
+  Semigroup-× : Semigroup (Σ A λ _ → B)
+  Semigroup-× ._◇_ (a , b) (a′ , b′) = (a ◇ a′ , b ◇ b′)
+
+  open Semigroup Semigroup-× renaming (_◇_ to _◇×_)
+
+  Comm-× : ⦃ Comm' A ⦄ → ⦃ Comm' B ⦄
+                  → ∀ x y → (x ◇× y) ≡ (y ◇× x)
+  Comm-× (a , b) (c , d)
+    with (a ◇ c) | ◇-comm≡ a c
+  ... | _ | p = {!!}


### PR DESCRIPTION
This fixes #8393 by adding an extra argument to `piSort'` indicating whether the codomain sort has been normalised, and refraining from making a decision if it hasn't. In the instance for `Reduce Sort`, we first try to compute the `piSort'` without normalising and only if that fails we try again with normalising.

I haven't measured the performance impact yet but I'm pretty hopeful since the "happy path" where we don't normalise should be by far the most common, and now it doesn't even include a call to `instantiateFull` anymore. But if there are many large blocked sort expressions then there could be a negative performance impact.