### PR TITLE
JSONTop: avoid needless parentheses around types

### DIFF
--- a/test/interaction/Paren.agda
+++ b/test/interaction/Paren.agda
@@ -1,0 +1,10 @@
+data A : Set where
+  a : A
+
+data P : A → Set where
+
+data Q : Set where
+  cons : P a → Q
+
+x : Q
+x = cons {! !}

--- a/test/interaction/Paren.in
+++ b/test/interaction/Paren.in
@@ -1,0 +1,1 @@
+top_command (cmd_load currentFile [])

--- a/test/interaction/Paren.out
+++ b/test/interaction/Paren.out
@@ -1,0 +1,6 @@
+(agda2-status-action "")
+(agda2-info-action "*Type-checking*" "" nil)
+(agda2-highlight-clear)
+(agda2-status-action "")
+(agda2-info-action "*All Goals*" "?0 : P a" nil)
+((last . 1) . (agda2-goals-action '(0)))

--- a/test/interaction/ParenJSON.agda
+++ b/test/interaction/ParenJSON.agda
@@ -1,0 +1,10 @@
+data A : Set where
+  a : A
+
+data P : A → Set where
+
+data Q : Set where
+  cons : P a → Q
+
+x : Q
+x = cons {! !}

--- a/test/interaction/ParenJSON.out
+++ b/test/interaction/ParenJSON.out
@@ -1,0 +1,7 @@
+JSON> {"kind":"Status","status":{"checked":false,"showImplicitArguments":false,"showIrrelevantArguments":false}}
+{"kind":"ClearRunningInfo"}
+{"kind":"ClearHighlighting","tokenBased":"NotOnlyTokenBased"}
+{"kind":"Status","status":{"checked":false,"showImplicitArguments":false,"showIrrelevantArguments":false}}
+{"info":{"errors":[],"invisibleGoals":[],"kind":"AllGoalsWarnings","visibleGoals":[{"constraintObj":{"id":0,"range":[{"end":{"col":15,"line":10,"pos":110},"start":{"col":10,"line":10,"pos":105}}]},"kind":"OfType","type":"P a"}],"warnings":[]},"kind":"DisplayInfo"}
+{"interactionPoints":[{"id":0,"range":[{"end":{"col":15,"line":10,"pos":110},"start":{"col":10,"line":10,"pos":105}}]}],"kind":"InteractionPoints"}
+JSON> 

--- a/test/interaction/ParenJSON.sh
+++ b/test/interaction/ParenJSON.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+AGDA=$1
+file="ParenJSON.agda"
+
+$AGDA -v0 --interaction-json --color=never <<EOF
+IOTCM "$file" None Indirect (Cmd_load "$file" [])
+EOF


### PR DESCRIPTION
This fixes a small bug I mentioned in passing while reporting #8276.

Before this change, the type of a hole would get prettified as if it was supposed to be the *value* of the hole, which doesn't really make sense. Instead, we now format the type with the TopCtx precedence, just like EmacsTop does.

Best reviewed commit-by-commit, with `git diff -w` to properly diff in the face of indentation changes.