### PR TITLE
Fix #7988: smarter figureOutTopLevelModule, prioritizes qualified module

### DIFF
--- a/src/full/Agda/Syntax/Concrete.hs
+++ b/src/full/Agda/Syntax/Concrete.hs
@@ -702,8 +702,13 @@ data Pragma
 -- | Modules: Top-level pragmas plus other top-level declarations.
 
 data Module = Mod
-  { modPragmas :: [Pragma]
+  { modName    :: QName
+      -- ^ The module name as inferred by the parser.
+      --   Could be @_@ if the parser inserted a top-level module declaration.
+  , modPragmas :: [Pragma]
+      -- ^ The top-level OPTIONS pragmas.
   , modDecls   :: [Declaration]
+      -- ^ All the other declarations, including the top-level module.
   }
 
 -- | Splits off allowed (= import) declarations before the first

--- a/src/full/Agda/Syntax/Concrete/Generic.hs
+++ b/src/full/Agda/Syntax/Concrete/Generic.hs
@@ -305,8 +305,9 @@ instance FoldDecl a => FoldDecl (List1 a)
 instance FoldDecl a => FoldDecl (List2 a)
 instance FoldDecl a => FoldDecl (WhereClause' a)
 
+-- | Note: this instance discards top-level OPTIONS pragmas.
 instance FoldDecl Module where
-  foldDecl f (Mod _ d) = foldDecl f d
+  foldDecl f (Mod _name _pragmas ds) = foldDecl f ds
 
 instance FoldDecl Declaration where
   foldDecl f d = f d <> case d of

--- a/src/full/Agda/Syntax/Parser/Parser.y
+++ b/src/full/Agda/Syntax/Parser/Parser.y
@@ -385,7 +385,7 @@ Token
  --------------------------------------------------------------------------}
 
 File :: { Module }
-File : vopen TopLevel maybe_vclose { takeOptionsPragmas $2 }
+File : vopen TopDeclarations maybe_vclose { figureOutTopLevelModule $2 }
 
 maybe_vclose :: { () }
 maybe_vclose : {- empty -} { () }
@@ -1614,9 +1614,6 @@ Module
 
 Underscore :: { Name }
 Underscore : '_' { noName (getRange $1) }
-
-TopLevel :: { [Declaration] }
-TopLevel : TopDeclarations { figureOutTopLevelModule $1 }
 
 Pragma :: { Declaration }
 Pragma : DeclarationPragma  { Pragma $1 }

--- a/src/full/Agda/Syntax/TopLevelModuleName.hs
+++ b/src/full/Agda/Syntax/TopLevelModuleName.hs
@@ -122,19 +122,10 @@ rawTopLevelModuleNameForModuleName x@(A.MName ms) =
     , rawModuleNameInferred = isNoName x
     }
 
--- | Computes the top-level module name.
---
--- Precondition: The 'C.Module' has to be well-formed.
--- This means that there are only allowed declarations before the
--- first module declaration, typically import declarations.
--- See 'spanAllowedBeforeModule'.
+-- | Retrieves the top-level module name.
 
 rawTopLevelModuleNameForModule :: C.Module -> RawTopLevelModuleName
-rawTopLevelModuleNameForModule (C.Mod _ []) = __IMPOSSIBLE__
-rawTopLevelModuleNameForModule (C.Mod _ ds) =
-  case C.spanAllowedBeforeModule ds of
-    (_, C.Module _ _ n _ _ : _) -> rawTopLevelModuleNameForQName n
-    _                           -> __IMPOSSIBLE__
+rawTopLevelModuleNameForModule (C.Mod n _pragmas _decls) = rawTopLevelModuleNameForQName n
 
 ------------------------------------------------------------------------
 -- Top-level module names

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -1575,10 +1575,14 @@ instance ToAbstract (TopLevel [C.Declaration]) where
 
           return $ TopLevelInfo (primitiveImport ++ outsideDecls ++ [ insideDecl ]) scope
 
+        -- We hit a declaration that is not allowed before the top-level module:
+        (_, d : _) -> setCurrentRange d $ typeError IllegalDeclarationBeforeTopLevelModule
+
         -- We already inserted the missing top-level module, see
         -- 'Agda.Syntax.Parser.Parser.figureOutTopLevelModule',
-        -- thus, this case is impossible:
+        -- thus, the case of no top-level module is impossible:
         _ -> __IMPOSSIBLE__
+
 
 -- | Declaration @open import Agda.Primitive using (Set)@ when 'optImportSorts'.
 --   @Prop@ is added when 'optProp', and @SSet@ when 'optTwoLevel'.

--- a/test/BuildFail/Issue7988.err
+++ b/test/BuildFail/Issue7988.err
@@ -1,0 +1,3 @@
+Checking Library.Module (../BuildFail/Issue7988/Library/Module.agda).
+../BuildFail/Issue7988/Library/Module.agda:4.1-5.10: error: [IllegalDeclarationBeforeTopLevelModule]
+Illegal declaration(s) before top-level module

--- a/test/BuildFail/Issue7988/Library/Module.agda
+++ b/test/BuildFail/Issue7988/Library/Module.agda
@@ -1,0 +1,15 @@
+-- Andreas, 2026-02-19, issue #7988, reported by Felix Cherubini
+
+-- The following declaration is not allowed before the top-level module declaration.
+variable
+  A : Set
+
+module Library.Module where
+
+-- error WAS: [ModuleNameDoesntMatchFileName]
+-- The inferred name `Module` of the top level module does not match the file name.
+-- A such named module should be defined in one of the following files: ...
+-- (Hint: no module header was found in this file; adding one might fix this error.)
+
+-- Expected error: [IllegalDeclarationBeforeTopLevelModule]
+-- Illegal declaration(s) before top-level module

--- a/test/BuildFail/Issue7988/Main.agda-lib
+++ b/test/BuildFail/Issue7988/Main.agda-lib
@@ -1,0 +1,1 @@
+include: .

--- a/test/Fail/customised/Issue7953.err
+++ b/test/Fail/customised/Issue7953.err
@@ -1,11 +1,2 @@
-1.1-5: error: [ModuleNameDoesntMatchFileName]
-The inferred name 'Test' of the top level module does not match the
-file name. A such named module should be defined in one of the
-following files:
-  customised/Test.AGDA
-  agda-default-include-path/Test.AGDA
-where .AGDA denotes a legal extension for an Agda file
-(i.e., one of .agda .lagda .lagda.rst .lagda.tex .lagda.md
- .lagda.org .lagda.tree .lagda.typ)
-(Hint: no module header was found in this file; adding one might
-fix this error.)
+customised/Issue7953/Test.agda:1.1-27: error: [IllegalDeclarationBeforeTopLevelModule]
+Illegal declaration(s) before top-level module


### PR DESCRIPTION
When inferring the top-level module, take the first qualified module as authoritative.  This makes a difference in error reporting, should the user have illegal declarations before the top-level module.
If the first module is not qualified or does not exist, fall back to the old heuristics.

Closes #7988.