### PR TITLE
Fix #5839 by adding conPartNotations to the OperatorInformation

### DIFF
--- a/test/Fail/Issue3400-2.err
+++ b/test/Fail/Issue3400-2.err
@@ -1,5 +1,7 @@
 Issue3400-2.agda:11.1-4: error: [NoParseForLHS]
 Could not parse the left-hand side + A
 Operators used in the grammar:
-  None
+  ⟨_+_⟩ (closed operator, unrelated) [⟨_+_⟩ (Issue3400-2.agda:3.5-10)]
+Identifiers used in the grammar that overlap with the operators:
+  +
 when scope checking the left-hand side + A in the definition of +

--- a/test/Fail/Issue3400-3.err
+++ b/test/Fail/Issue3400-3.err
@@ -1,5 +1,5 @@
 Issue3400-3.agda:11.1-4: error: [NoParseForLHS]
 Could not parse the left-hand side F +
 Operators used in the grammar:
-  None
+  ⟨_+_⟩ (closed operator, unrelated) [⟨_+_⟩ (Issue3400-3.agda:3.5-10)]
 when scope checking the left-hand side F + in the definition of F

--- a/test/Fail/Issue5763.err
+++ b/test/Fail/Issue5763.err
@@ -1,6 +1,6 @@
 Issue5763.agda:8.1-15: error: [NoParseForLHS]
 Could not parse the left-hand side foo (fn x , y)
 Operators used in the grammar:
-  None
+  fn_, (prefix notation, unrelated) [fun (Issue5763.agda:3.3-6)]
 when scope checking the left-hand side foo (fn x , y) in the
 definition of foo

--- a/test/Fail/Issue5839.agda
+++ b/test/Fail/Issue5839.agda
@@ -1,0 +1,17 @@
+-- Andreas, 2026-02-21, issue #5839, report and testcase by isovector
+
+data Bug : Set where
+  var_x : Bug
+
+bug : Bug → Bug
+bug x = {! !}
+
+-- This fails the parser because `x` is a part of the constructor.
+-- The error message should hint towards this.
+-- In particular, it should mention `var_x` as possible culprit.
+
+-- Expected error: [NoParseForLHS]
+-- Could not parse the left-hand side bug x
+-- Operators used in the grammar:
+--   var_x (closed operator, unrelated) [var_x (...)]
+-- when scope checking the left-hand side bug x in the definition of bug

--- a/test/Fail/Issue5839.err
+++ b/test/Fail/Issue5839.err
@@ -1,0 +1,6 @@
+Issue5839.agda:7.1-6: error: [NoParseForLHS]
+Could not parse the left-hand side bug x
+Operators used in the grammar:
+  var_x (closed operator, unrelated) [var_x (Issue5839.agda:4.3-8)]
+when scope checking the left-hand side bug x in the definition of
+bug


### PR DESCRIPTION
Operators that contributed constructor parts are now also mentioned in case of a failed lhs parse, because they could have let to the rejection.  The reason is that constructor parts are not allowed as pattern variables.

Closes #5839.
