### PR TITLE
Retain lineage (`AbstractName`) in `AmbiguousQName` for error reporting

### DIFF
--- a/src/full/Agda/Compiler/JS/Compiler.hs
+++ b/src/full/Agda/Compiler/JS/Compiler.hs
@@ -696,7 +696,7 @@ litqname q =
     , (mem "fixity", litfixity fx)]
   where
     mem = MemberId
-    NameId n (ModuleNameHash m) = nameId $ qnameName q
+    NameId n (ModuleNameHash m) = nameId q
     fx = theFixity $ nameFixity $ qnameName q
 
     litfixity :: Fixity -> Exp

--- a/src/full/Agda/Compiler/MAlonzo/Compiler.hs
+++ b/src/full/Agda/Compiler/MAlonzo/Compiler.hs
@@ -1161,7 +1161,7 @@ litqname x =
   where
     apps = foldl HS.App
     rteCon name = HS.Con $ HS.Qual mazRTE $ HS.Ident name
-    NameId n (ModuleNameHash m) = nameId $ qnameName x
+    NameId n (ModuleNameHash m) = nameId x
     fx = theFixity $ nameFixity $ qnameName x
 
     litAssoc NonAssoc   = rteCon "NonAssoc"
@@ -1178,7 +1178,7 @@ litqnamepat x =
           , HS.PLit (HS.Int $ fromIntegral m)
           , HS.PWildCard, HS.PWildCard ]
   where
-    NameId n (ModuleNameHash m) = nameId $ qnameName x
+    NameId n (ModuleNameHash m) = nameId x
 
 litmetapat :: MetaId -> HS.Pat
 litmetapat (MetaId m h) =

--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -21,7 +21,7 @@ import           Agda.Interaction.Highlighting.Precise hiding ( singleton )
 import qualified Agda.Interaction.Highlighting.Precise as H
 import           Agda.Interaction.Highlighting.Range   ( rToR )  -- Range is ambiguous
 
-import           Agda.Syntax.Abstract                ( IsProjP(..) )
+import           Agda.Syntax.Abstract                ( IsProjP(..), anameName )
 import qualified Agda.Syntax.Abstract      as A
 import           Agda.Syntax.Common        as Common
 import           Agda.Syntax.Concrete                ( FieldAssignment'(..), TacticAttribute' )
@@ -30,7 +30,7 @@ import           Agda.Syntax.Info                    ( ModuleInfo(..) )
 import           Agda.Syntax.Literal
 import qualified Agda.Syntax.Position      as P
 import           Agda.Syntax.Position                ( Range, HasRange, getRange, noRange )
-import           Agda.Syntax.Scope.Base              ( AbstractName(..), ResolvedName(..), exactConName )
+import           Agda.Syntax.Scope.Base              ( ResolvedName(..), exactConName )
 import           Agda.Syntax.TopLevelModuleName
 
 import Agda.TypeChecking.Monad

--- a/src/full/Agda/Interaction/Highlighting/Precise.hs
+++ b/src/full/Agda/Interaction/Highlighting/Precise.hs
@@ -41,9 +41,9 @@ import qualified Data.Set as Set
 
 import GHC.Generics (Generic)
 
-import qualified Agda.Syntax.Common   as Common
+import Agda.Syntax.Common qualified as Common
 import Agda.Syntax.TopLevelModuleName
-import Agda.Syntax.Scope.Base                   ( KindOfName(..) )
+import Agda.Syntax.Abstract.Name ( KindOfName(..) )
 
 import Agda.Utils.Range
 

--- a/src/full/Agda/Interaction/Highlighting/Vim.hs
+++ b/src/full/Agda/Interaction/Highlighting/Vim.hs
@@ -11,17 +11,18 @@ import Data.Maybe
 
 import System.FilePath
 
-import Agda.Syntax.Scope.Base
+import Agda.Syntax.Abstract.Name (AbstractName(..), KindOfName (FldName))
 import Agda.Syntax.Common
+import Agda.Syntax.Common.Pretty
 import Agda.Syntax.Concrete.Name as CName
+import Agda.Syntax.Scope.Base
 
 import Agda.TypeChecking.Monad
 
-import Agda.Utils.List1             ( List1, pattern (:|) )
-import qualified Agda.Utils.List1   as List1
-import qualified Agda.Utils.IO.UTF8 as UTF8
+import Agda.Utils.IO.UTF8 qualified as UTF8
+import Agda.Utils.List1 ( List1, pattern (:|) )
+import Agda.Utils.List1 qualified as List1
 import Agda.Utils.Tuple
-import Agda.Syntax.Common.Pretty
 
 vimFile :: FilePath -> FilePath
 vimFile file =

--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -1619,7 +1619,7 @@ buildInterface src topLevel = do
     let
       !mh = moduleNameId (srcModuleName src)
       !opaqueBlocks = Map.filterWithKey (\(OpaqueId _ mod) _ -> mod == mh) opaqueBlocks'
-      isLocal qnm = case nameId (qnameName qnm) of
+      isLocal qnm = case nameId qnm of
         NameId _ mh' -> mh' == mh
       !opaqueIds = Map.filterWithKey (\qnm (OpaqueId _ mod) -> isLocal qnm || mod == mh) opaqueIds'
 

--- a/src/full/Agda/Interaction/MakeCase.hs
+++ b/src/full/Agda/Interaction/MakeCase.hs
@@ -22,7 +22,7 @@ import Agda.Syntax.Common.Pretty ( prettyShow )
 import Agda.Syntax.Internal
 import Agda.Syntax.Internal.Pattern
 import Agda.Syntax.Parser.Helpers ( mkValidName )
-import Agda.Syntax.Scope.Base  ( ResolvedName(..), BindingSource(..), KindOfName(..), exceptKindsOfNames )
+import Agda.Syntax.Scope.Base  ( ResolvedName(..), BindingSource(..), exceptKindsOfNames )
 import Agda.Syntax.Scope.Monad ( resolveName' )
 import Agda.Syntax.Translation.InternalToAbstract
 

--- a/src/full/Agda/Interaction/SearchAbout.hs
+++ b/src/full/Agda/Interaction/SearchAbout.hs
@@ -4,27 +4,27 @@ module Agda.Interaction.SearchAbout (findMentions) where
 
 import Control.Monad
 
-import qualified Data.Map as Map
-import qualified Data.Set as Set
-import Data.List (isInfixOf)
 import Data.Either (partitionEithers)
 import Data.Foldable (toList)
+import Data.List (isInfixOf)
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 
+import Agda.Interaction.Base (Rewrite)
+import Agda.Interaction.BasicOps (normalForm, parseName)
+import Agda.Syntax.Abstract.Name (AbstractName(..), KindOfName (PatternSynName))
+import Agda.Syntax.Common.Pretty (prettyShow)
+import Agda.Syntax.Concrete qualified as C
+import Agda.Syntax.Internal qualified as I
+import Agda.Syntax.Internal.Names (namesIn)
 import Agda.Syntax.Position (Range)
 import Agda.Syntax.Scope.Base
 import Agda.Syntax.Scope.Monad
-import Agda.TypeChecking.Monad.Signature
 import Agda.TypeChecking.Monad.Env
-import Agda.Syntax.Internal.Names (namesIn)
-import Agda.Interaction.Base (Rewrite)
-import Agda.Interaction.BasicOps (normalForm, parseName)
+import Agda.TypeChecking.Monad.Signature
 
-import qualified Agda.Syntax.Concrete as C
-import qualified Agda.Syntax.Internal as I
-
-import Agda.Utils.List   ( initLast1  )
-import qualified Agda.Utils.List1 as List1
-import Agda.Syntax.Common.Pretty ( prettyShow )
+import Agda.Utils.List (initLast1)
+import Agda.Utils.List1 qualified as List1
 
 findMentions :: Rewrite -> Range -> String -> ScopeM [(C.Name, I.Type)]
 findMentions norm rg nm = do

--- a/src/full/Agda/Mimer/Monad.hs
+++ b/src/full/Agda/Mimer/Monad.hs
@@ -144,22 +144,22 @@ getEverythingInScope metaVar = do
   let nameSpace = Scope.everythingInScope scope
       names = Scope.nsNames nameSpace
       validKind = \ case
-        Scope.PatternSynName           -> False   -- could consider allowing pattern synonyms, but the problem is they can't be getConstInfo'd
-        Scope.GeneralizeName           -> False   -- and any way finding the underlying constructors should be easy
-        Scope.DisallowedGeneralizeName -> False
-        Scope.MacroName                -> False
-        Scope.QuotableName             -> False
-        Scope.ConName                  -> True
-        Scope.CoConName                -> True
-        Scope.FldName                  -> True
-        Scope.DataName                 -> True
-        Scope.RecName                  -> True
-        Scope.FunName                  -> True
-        Scope.AxiomName                -> True
-        Scope.PrimName                 -> True
-        Scope.OtherDefName             -> True
-      qnames = map Scope.anameName
-             . filter (validKind . Scope.anameKind)
+        PatternSynName           -> False   -- could consider allowing pattern synonyms, but the problem is they can't be getConstInfo'd
+        GeneralizeName           -> False   -- and any way finding the underlying constructors should be easy
+        DisallowedGeneralizeName -> False
+        MacroName                -> False
+        QuotableName             -> False
+        ConName                  -> True
+        CoConName                -> True
+        FldName                  -> True
+        DataName                 -> True
+        RecName                  -> True
+        FunName                  -> True
+        AxiomName                -> True
+        PrimName                 -> True
+        OtherDefName             -> True
+      qnames = map anameName
+             . filter (validKind . anameKind)
              . map NonEmptyList.head
              $ Map.elems names
   qnames
@@ -736,4 +736,3 @@ writeTime ii (CPUTime time) = do
     SMaybe.Just file -> do
       let path = filePath (rangeFilePath file) ++ ".stats"
       liftIO $ appendFile path (show (interactionId ii) ++ " " ++ show time ++ "\n")
-

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -1054,7 +1054,14 @@ mkLet :: ExprInfo -> [LetBinding] -> Expr -> Expr
 mkLet _ []     e = e
 mkLet i (d:ds) e = Let i (d :| ds) e
 
-type PatternSynDefn = ([WithHiding Name], Pattern' Void)
+-- | The definition of a pattern synonym (excluding its name).
+data PatternSynDefn = PatternSynDefn
+  { patSynParams :: ![WithHiding Name]
+      -- ^ The parameters of the pattern synonym.
+  , patSynPat    :: !(Pattern' Void)
+      -- ^ The definiting pattern of the pattern synonym.
+  } deriving (Show, Generic)
+
 type PatternSynDefns = Map QName PatternSynDefn
 
 lambdaLiftExpr :: [WithHiding Name] -> Expr -> Expr
@@ -1269,3 +1276,10 @@ rhsSpine = \case
 whereDeclarationsSpine :: WhereDeclarations -> WhereDeclarationsSpine
 whereDeclarationsSpine (WhereDecls _ _ md) =
   WhereDeclsS (fmap declarationSpine md)
+
+-- Instances
+
+instance KillRange PatternSynDefn where
+  killRange (PatternSynDefn a b) =  killRangeN PatternSynDefn a b
+
+instance NFData PatternSynDefn

--- a/src/full/Agda/Syntax/Abstract.hs
+++ b/src/full/Agda/Syntax/Abstract.hs
@@ -1038,9 +1038,9 @@ instance NameToExpr ResolvedName where
   nameToExpr = \case
     VarName x _          -> Var x
     DefinedName _ x s    -> withSuffix s $ nameToExpr x  -- Can be 'isDefName', 'MacroName', 'QuotableName'.
-    FieldName xs         -> Proj ProjSystem . AmbQ . fmap anameName $ xs
-    ConstructorName _ xs -> Con . AmbQ . fmap anameName $ xs
-    PatternSynResName xs -> PatternSyn . AmbQ . fmap anameName $ xs
+    FieldName xs         -> Proj ProjSystem . ambigName $ xs
+    ConstructorName _ xs -> Con . ambigName $ xs
+    PatternSynResName xs -> PatternSyn . ambigName $ xs
     UnknownName          -> __IMPOSSIBLE__
     where
       withSuffix NoSuffix   e       = e

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -29,9 +29,9 @@ import qualified Agda.Syntax.Concrete.Name as C
 
 import Agda.Utils.Functor
 import Agda.Utils.Lens
-import qualified Agda.Utils.List as L
+import Agda.Utils.List qualified as List
 import Agda.Utils.List1 (List1, pattern (:|), (<|))
-import qualified Agda.Utils.List1 as List1
+import Agda.Utils.List1 qualified as List1
 import Agda.Utils.Null
 import Agda.Utils.Size
 
@@ -214,7 +214,7 @@ sameRoot = C.sameRoot `on` nameConcrete
 
 -- | A module is anonymous if the qualification path ends in an underscore.
 isAnonymousModuleName :: ModuleName -> Bool
-isAnonymousModuleName (MName mms) = maybe False isNoName $ L.lastMaybe mms
+isAnonymousModuleName (MName mms) = maybe False isNoName $ List.lastMaybe mms
 
 -- | Sets the ranges of the individual names in the module name to
 -- match those of the corresponding concrete names. If the concrete
@@ -260,7 +260,7 @@ noModuleName = mnameFromList []
 
 commonParentModule :: ModuleName -> ModuleName -> ModuleName
 commonParentModule m1 m2 =
-  mnameFromList $ L.commonPrefix (mnameToList m1) (mnameToList m2)
+  mnameFromList $ List.commonPrefix (mnameToList m1) (mnameToList m2)
 
 mnameToConcrete :: ModuleName -> C.QName
 mnameToConcrete (MName []) = __IMPOSSIBLE__ -- C.QName C.noName_  -- should never happen?
@@ -278,7 +278,7 @@ isLeParentModuleOf = List.isPrefixOf `on` mnameToList
 -- | Is the first module a proper parent of the second?
 isLtParentModuleOf :: ModuleName -> ModuleName -> Bool
 isLtParentModuleOf x y =
-  isJust $ (L.stripPrefixBy (==) `on` mnameToList) x y
+  isJust $ (List.stripPrefixBy (==) `on` mnameToList) x y
 
 -- | Is the first module a weak child of the second?
 isLeChildModuleOf :: ModuleName -> ModuleName -> Bool

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -363,6 +363,15 @@ getUnambiguous :: AmbiguousQName -> Maybe QName
 getUnambiguous (AmbQ (x :| [])) = Just x
 getUnambiguous _                = Nothing
 
+getAmbiguous :: AmbiguousQName -> List1 QName
+getAmbiguous (AmbQ xs) = xs
+
+unambigName :: AbstractName -> AmbiguousQName
+unambigName = AmbQ . List1.singleton . anameName
+
+ambigName :: List1 AbstractName -> AmbiguousQName
+ambigName = AmbQ . fmap anameName
+
 ---------------------------------------------------------------------------
 -- * 'AbstractName'
 ---------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -46,7 +46,7 @@ import Agda.Utils.Impossible
 --   concrete name contains the source location (if any) of the name. The
 --   source location of the binding site is also recorded.
 data Name = Name
-  { nameId           :: {-# UNPACK #-} !NameId
+  { _nameId          :: {-# UNPACK #-} !NameId
   , nameConcrete     :: C.Name  -- ^ The concrete name used for this instance
   , nameCanonical    :: C.Name  -- ^ The concrete name in the original definition (needed by primShowQName, see #4735)
   , nameBindingSite  :: Range
@@ -159,6 +159,22 @@ data NameMetadata = NameMetadata
   , nameDataIsInstance      :: IsInstance
   }
   deriving (Show, Generic)
+
+---------------------------------------------------------------------------
+-- * Overloaded 'nameId'
+---------------------------------------------------------------------------
+
+class HasNameId a where
+  nameId :: a -> NameId
+
+instance HasNameId Name where
+  nameId = _nameId
+
+instance HasNameId QName where
+  nameId = nameId . qnameName
+
+instance HasNameId AbstractName where
+  nameId = nameId . anameName
 
 ---------------------------------------------------------------------------
 -- * Class 'IsProjP'

--- a/src/full/Agda/Syntax/Abstract/Name.hs
+++ b/src/full/Agda/Syntax/Abstract/Name.hs
@@ -372,6 +372,9 @@ unambigName = AmbQ . List1.singleton . anameName
 ambigName :: List1 AbstractName -> AmbiguousQName
 ambigName = AmbQ . fmap anameName
 
+mergeAmbQ :: AmbiguousQName -> AmbiguousQName -> AmbiguousQName
+mergeAmbQ (AmbQ xs) (AmbQ ys) = AmbQ (xs <> ys)
+
 ---------------------------------------------------------------------------
 -- * 'AbstractName'
 ---------------------------------------------------------------------------

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -15,7 +15,7 @@ import Agda.Syntax.Common
 import Agda.Syntax.Abstract as A
 import Agda.Syntax.Concrete (FieldAssignment', exprFieldA, TacticAttribute')
 import Agda.Syntax.Info
-import Agda.Syntax.Scope.Base (KindOfName(..), conKindOfName, WithKind(..))
+import Agda.Syntax.Scope.Base (conKindOfName, WithKind(..))
 
 import Agda.Utils.Either
 import Agda.Utils.List1 (List1)

--- a/src/full/Agda/Syntax/Concrete/Operators.hs
+++ b/src/full/Agda/Syntax/Concrete/Operators.hs
@@ -35,6 +35,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Traversable as Trav
 
+import Agda.Syntax.Abstract.Name (KindOfName(..))
 import Agda.Syntax.Common
 import Agda.Syntax.Concrete hiding (appView)
 import Agda.Syntax.Concrete.Operators.Parser

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -11,15 +11,16 @@ import Data.Set (Set)
 import Agda.Syntax.Common
 import Agda.Syntax.Literal
 import Agda.Syntax.Internal
-import qualified Agda.Syntax.Concrete as C
-import qualified Agda.Syntax.Abstract as A
+import Agda.Syntax.Concrete qualified as C
+import Agda.Syntax.Abstract qualified as A
+import Agda.Syntax.Abstract (PatternSynDefn(..))
 import Agda.Syntax.Treeless
 
 import Agda.TypeChecking.Monad.Base
 import Agda.TypeChecking.CompiledClause
 
 import Agda.Utils.List1 (List1)
-import qualified Agda.Utils.Maybe.Strict as Strict
+import Agda.Utils.Maybe.Strict qualified as Strict
 import Agda.Utils.Singleton
 import Agda.Utils.Impossible
 
@@ -370,9 +371,8 @@ instance NamesIn Compiled where
 
 -- Pattern synonym stuff --
 
-newtype PSyn = PSyn A.PatternSynDefn
-instance NamesIn PSyn where
-  namesAndMetasIn' sg (PSyn (_args, p)) = namesAndMetasIn' sg p
+instance NamesIn PatternSynDefn where
+  namesAndMetasIn' sg (PatternSynDefn _args p) = namesAndMetasIn' sg p
 
 instance NamesIn ConPatternInfo where
   namesAndMetasIn' sg (ConPatternInfo _ _ _ ty _) = namesAndMetasIn' sg ty

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -394,4 +394,4 @@ instance NamesIn (A.Pattern' a) where
     A.WithP _ p            -> namesAndMetasIn' sg p
 
 instance NamesIn AmbiguousQName where
-  namesAndMetasIn' sg (AmbQ cs) = namesAndMetasIn' sg cs
+  namesAndMetasIn' sg = namesAndMetasIn' sg . getAmbiguous

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -100,11 +100,12 @@ import Agda.Utils.FileName
 import Agda.Utils.List
 import Agda.Utils.List1 (List1)
 import Agda.Utils.List2 (List2)
-import qualified Agda.Utils.Maybe.Strict as Strict
+import Agda.Utils.Maybe.Strict qualified as Strict
+import Agda.Utils.Map1 (Map1)
 import Agda.Utils.Null
 import Agda.Utils.Permutation
 import Agda.Utils.Set1 (Set1)
-import qualified Agda.Utils.Set1 as Set1
+import Agda.Utils.Set1 qualified as Set1
 import Agda.Utils.TypeLevel (IsBase, All, Domains)
 import Agda.Utils.Tuple (sortPair)
 import Agda.Utils.Word (packW64, splitW64)
@@ -560,6 +561,7 @@ instance {-# OVERLAPPING #-} KillRange String where
 
 instance {-# OVERLAPPABLE #-} KillRange a => KillRange [a]
 instance {-# OVERLAPPABLE #-} KillRange a => KillRange (Map k a)
+instance {-# OVERLAPPABLE #-} KillRange a => KillRange (Map1 k a)
 
 instance KillRange a => KillRange (Drop a)
 instance KillRange a => KillRange (List1 a)

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -1384,7 +1384,7 @@ inverseScopeLookupName' amb q scope =
 inverseScopeLookupName'' :: AllowAmbiguousNames -> A.QName -> ScopeInfo -> Maybe NameMapEntry
 inverseScopeLookupName'' amb q scope = billToPure [ Scoping , InverseNameLookup ] $ do
 
-  NameMapEntry k xs <- HMap.lookup (A.nameId $ qnameName q) (scope ^. scopeInverseName)
+  NameMapEntry k xs <- HMap.lookup (A.nameId q) (scope ^. scopeInverseName)
 
   !xs <- List1.nonEmpty $ List.sortOn (length . C.qnameParts &!& Down . getRange) $ do
     -- List comprehension written in monadic form
@@ -1494,7 +1494,7 @@ recomputeInverseNamesAndModules scope = St2.execState goCurrent (mempty, mempty)
           let !qualx = applyQuals (C.QName x) quals
           when (not (internalName qualx)) do
             forM_ ys \y -> do
-              let nid   = A.nameId $ qnameName $ anameName y
+              let nid   = A.nameId y
               let entry = NameMapEntry (anameKind y) (qualx :| [])
               updNames qualx nid entry
 

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -650,6 +650,11 @@ data WhyInScopeData
       [AbstractModule]
         -- ^ The modules that @x@ could denote.
 
+whyInScopeDataFromAmbiguousQName :: C.QName -> AmbiguousQName -> Maybe WhyInScopeData
+whyInScopeDataFromAmbiguousQName q x = case ambAbstractNames x of
+  [] -> Nothing
+  xs -> Just $ WhyInScopeData q empty Nothing xs empty
+
 whyInScopeDataFromAbstractName :: C.QName -> AbstractName -> WhyInScopeData
 whyInScopeDataFromAbstractName q x = WhyInScopeData q empty Nothing [x] empty
 

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -504,29 +504,7 @@ lensOpenedModules f s = f (openedModules s) <&> \ !x -> s { openedModules = x }
 -- - Where does the name come from? (to explain to user)
 ------------------------------------------------------------------------
 
--- | For the sake of parsing left-hand sides, we distinguish
---   constructor and record field names from defined names.
-
--- Note: order does matter in this enumeration, see 'isDefName'.
-data KindOfName
-  = ConName                  -- ^ Constructor name ('Inductive' or don't know).
-  | CoConName                -- ^ Constructor name (definitely 'CoInductive').
-  | FldName                  -- ^ Record field name.
-  | PatternSynName           -- ^ Name of a pattern synonym.
-  | GeneralizeName           -- ^ Name to be generalized
-  | DisallowedGeneralizeName -- ^ Generalizable variable from a let open
-  | MacroName                -- ^ Name of a macro
-  | QuotableName             -- ^ A name that can only be quoted.
-  -- Previous category @DefName@:
-  -- (Refined in a flat manner as Enum and Bounded are not hereditary.)
-  | DataName                 -- ^ Name of a @data@.
-  | RecName                  -- ^ Name of a @record@.
-  | FunName                  -- ^ Name of a defined function.
-  | AxiomName                -- ^ Name of a @postulate@.
-  | PrimName                 -- ^ Name of a @primitive@.
-  | OtherDefName             -- ^ A @DefName@, but either other kind or don't know which kind.
-  -- End @DefName@.  Keep these together in sequence, for sake of @isDefName@!
-  deriving (Eq, Ord, Show, Enum, Bounded, Generic)
+-- Agda.Syntax.Abstract.Name.KindOfName
 
 -- | All kinds of regular definitions.
 defNameKinds :: [KindOfName]
@@ -598,97 +576,6 @@ data WithKind a = WithKind
   , kindedThing :: a
   } deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
 
--- | Where does a name come from?
---
---   This information is solely for reporting to the user,
---   see 'Agda.Interaction.InteractionTop.whyInScope'.
-data WhyInScope
-  = Defined
-    -- ^ Defined in this module.
-  | Opened C.QName WhyInScope
-    -- ^ Imported from another module.
-  | Applied C.QName WhyInScope
-    -- ^ Imported by a module application.
-  deriving (Show, Generic)
-
--- | A decoration of 'Agda.Syntax.Abstract.Name.QName'.
-data AbstractName = AbsName
-  { anameName    :: A.QName
-    -- ^ The resolved qualified name.
-  , anameKind    :: KindOfName
-    -- ^ The kind (definition, constructor, record field etc.).
-  , anameLineage :: WhyInScope
-    -- ^ Explanation where this name came from.
-  , anameMetadata :: NameMetadata
-    -- ^ Additional information needed during scope checking. Currently used
-    --   for generalized data/record params.
-  }
-  deriving (Show, Generic)
-
-instance Eq AbstractName where
-  n == n' = A.nameId (qnameName (anameName n)) ==
-            A.nameId (qnameName (anameName n'))
-
-instance Ord AbstractName where
-  compare n n' =
-    compare (A.nameId (qnameName (anameName n )))
-            (A.nameId (qnameName (anameName n')))
-
-instance Hashable AbstractName where
-  hashWithSalt salt n =
-    hashWithSalt salt (A.nameId (qnameName (anameName n)))
-
-data NameMetadata = NameMetadata
-  { nameDataGeneralizedVars :: Map A.QName A.Name
-  , nameDataIsInstance      :: IsInstance
-  }
-  deriving (Show, Generic)
-
-instance Null NameMetadata where
-  empty = NameMetadata empty empty
-  null (NameMetadata m i) = null m && null i
-
-noMetadata :: NameMetadata
-noMetadata = empty
-
-generalizedVarsMetadata :: Map A.QName A.Name -> NameMetadata
-generalizedVarsMetadata m = NameMetadata m empty
-
-instanceMetadata :: IsInstance -> NameMetadata
-instanceMetadata i = NameMetadata empty i
-
-instance IsInstanceDef NameMetadata where
-  isInstanceDef = isInstanceDef . nameDataIsInstance
-
-instance IsInstanceDef AbstractName where
-  isInstanceDef = isInstanceDef . anameMetadata
-
--- | A decoration of abstract syntax module names.
-data AbstractModule = AbsModule
-  { amodName    :: A.ModuleName
-    -- ^ The resolved module name.
-  , amodLineage :: WhyInScope
-    -- ^ Explanation where this name came from.
-  }
-  deriving (Show, Generic)
-
-instance LensFixity AbstractName where
-  lensFixity = lensAnameName . lensFixity
-
--- | Van Laarhoven lens on 'anameName'.
-lensAnameName :: Lens' AbstractName A.QName
-lensAnameName f am = f (anameName am) <&> \ m -> am { anameName = m }
-
-instance Eq AbstractModule where
-  (==) = (==) `on` amodName
-
-instance Ord AbstractModule where
-  compare = compare `on` amodName
-
--- | Van Laarhoven lens on 'amodName'.
-lensAmodName :: Lens' AbstractModule A.ModuleName
-lensAmodName f am = f (amodName am) <&> \ m -> am { amodName = m }
-
 
 data ResolvedName
   = -- | Local variable bound by λ, Π, module telescope, pattern, @let@.
@@ -723,10 +610,6 @@ instance Pretty ResolvedName where
     ConstructorName _ xs -> "constructor" <+> pretty xs
     PatternSynResName x  -> "pattern"     <+> pretty x
     UnknownName          -> "<unknown name>"
-
-instance Pretty A.Suffix where
-  pretty NoSuffix   = mempty
-  pretty (Suffix i) = text (show i)
 
 -- | Why is a resolved name ambiguous?  What did it resolve to?
 --
@@ -1682,12 +1565,6 @@ instance SetBindingSite AbstractModule where
 -- * (Debug) printing
 ------------------------------------------------------------------------
 
-instance Pretty AbstractName where
-  pretty = pretty . anameName
-
-instance Pretty AbstractModule where
-  pretty = pretty . amodName
-
 instance Pretty NameSpaceId where
   pretty = text . \case
     PublicNS        -> "public"
@@ -1751,27 +1628,16 @@ instance Pretty ScopeInfo where
 ------------------------------------------------------------------------
 
 instance KillRange ScopeInfo where
-  killRange m = m
+  killRange = id
 
-instance HasRange AbstractName where
-  getRange = getRange . anameName
-
-instance SetRange AbstractName where
-  setRange r x = x { anameName = setRange r $ anameName x }
-
-instance NFData Scope
-instance NFData DataOrRecordModule
-instance NFData NameSpaceId
-instance NFData ScopeInfo
-instance NFData KindOfName
-instance NFData NameMapEntry
-instance NFData BindingSource
-instance NFData LocalVar
-instance NFData NameSpace
-instance NFData NameOrModule
-instance NFData WhyInScope
-instance NFData AbstractName
-instance NFData NameMetadata
-instance NFData AbstractModule
-instance NFData ResolvedName
 instance NFData AmbiguousNameReason
+instance NFData BindingSource
+instance NFData DataOrRecordModule
+instance NFData LocalVar
+instance NFData NameMapEntry
+instance NFData NameOrModule
+instance NFData NameSpace
+instance NFData NameSpaceId
+instance NFData ResolvedName
+instance NFData Scope
+instance NFData ScopeInfo

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -242,7 +242,7 @@ freshAbstractName :: Fixity' -> C.Name -> ScopeM A.Name
 freshAbstractName fx x = do
   i <- fresh
   return $ A.Name
-    { nameId          = i
+    { _nameId         = i
     , nameConcrete    = x
     , nameCanonical   = x
     , nameBindingSite = getRange x
@@ -497,7 +497,7 @@ addNameToInverseScope :: KindOfName -> C.Name -> AbstractName -> ScopeInfo -> Sc
 addNameToInverseScope kind x y s =
   let !y' = anameName y
   in s { _scopeInScope     = Set.insert y' (_scopeInScope s)
-       , _scopeInverseName = HMap.insertWith (<>) (A.nameId $ qnameName y')
+       , _scopeInverseName = HMap.insertWith (<>) (A.nameId y')
                              (NameMapEntry kind (C.QName x :| [])) (_scopeInverseName s)
        }
 
@@ -692,7 +692,7 @@ copyScope oldc new0 s =
         refresh :: A.Name -> WSM A.Name
         refresh x = do
           i <- lift fresh
-          return $ x { A.nameId = i }
+          return $ x { A._nameId = i }
 
         copyRecordConstr :: A.QName -> A.QName -> WSM ()
         copyRecordConstr from to = getRecordConstructor from >>= \case

--- a/src/full/Agda/Syntax/Scope/Operator.hs
+++ b/src/full/Agda/Syntax/Scope/Operator.hs
@@ -19,7 +19,8 @@ import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 
-import qualified Agda.Syntax.Abstract.Name as A
+import Agda.Syntax.Abstract.Name (AbstractName (..), AbstractModule (..), KindOfName(..))
+import Agda.Syntax.Abstract.Name qualified as A
 
 import Agda.Syntax.Common
 import Agda.Syntax.Common.Pretty

--- a/src/full/Agda/Syntax/Scope/UnusedImports.hs
+++ b/src/full/Agda/Syntax/Scope/UnusedImports.hs
@@ -33,6 +33,9 @@ import Data.Set qualified as Set
 import Agda.Interaction.Options (lensOptWarningMode, optQualifiedInstances)
 import Agda.Interaction.Options.Warnings (lensSingleWarning, WarningName (UnusedImports_, UnusedImportsAll_), warningSet, unusedImportsWarnings)
 
+import Agda.Syntax.Abstract.Name
+    ( WhyInScope(Defined, Opened, Applied),
+      AbstractName(AbsName), anameName, anameLineage )
 import Agda.Syntax.Abstract.Name qualified as A
 import Agda.Syntax.Common ( IsInstanceDef(isInstanceDef), IsInstance, KwRange, ImportDirective' (using, impRenaming, publicOpen) )
 import Agda.Syntax.Common.Pretty (prettyShow, Pretty (pretty))

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1926,7 +1926,7 @@ recoverPatternSyn applySyn match e fallback = do
     let isConP ConP{} = True    -- #2828: only fold pattern synonyms with
         isConP _      = False   --        constructor rhs
         cands = [ (q, args, score rhs)
-                | (q, psyndef@(_, rhs)) <- reverse $ Map.toList psyns
+                | (q, psyndef@(PatternSynDefn _ rhs)) <- reverse $ Map.toList psyns
                 , isConP rhs
                 , Just args <- [match psyndef e]
                 -- #3879: only fold pattern synonyms with an unqualified concrete name in scope

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2228,7 +2228,7 @@ instance ToAbstract NiceDeclaration where
       -- Expanding pattern synonyms already at definition makes it easier to
       -- fold them back when printing (issue #2762).
       ep <- expandPatternSynonyms p
-      modifyPatternSyns (Map.insert y (as, ep))
+      modifyPatternSyns (Map.insert y (PatternSynDefn as ep))
       return $ singleton $ A.PatternSynDef y (map (fmap BindName) as) p   -- only for highlighting, so use unexpanded version
       where
         checkPatSynParam :: WithHiding C.Name -> ScopeM (WithHiding A.Name)

--- a/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/InternalToAbstract.hs
@@ -910,7 +910,7 @@ reifyTerm expandAnonDefs0 v0 = tryReifyAsLetBinding v0 $ do
              [ "  pad =" <+> pshow pad
              , "  nes =" <+> pshow nes
              ]
-           let hd0 | isProperProjection def = A.Proj ProjPrefix $ AmbQ $ singleton x
+           let hd0 | isProperProjection def = A.Proj ProjPrefix $ unambiguous x
                    | otherwise = A.Def x
            let hd = List.foldl' (A.App defaultAppInfo_) hd0 pad
            nelims hd =<< reify nes

--- a/src/full/Agda/TypeChecking/DeadCode.hs
+++ b/src/full/Agda/TypeChecking/DeadCode.hs
@@ -114,7 +114,7 @@ eliminateDeadCode !scope = Bench.billTo [Bench.DeadCode] $ do
     go rootRewrites
     go rootModSections
     go rootBuiltins
-    foldMap (go . PSyn) rootPatSyns
+    foldMap go rootPatSyns
 
   let filterMeta :: (MetaId, MetaVariable) -> IO (Maybe (MetaId, RemoteMetaVariable))
       filterMeta (!i, !m) = HT.lookup seenMetas i >>= \case

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -792,7 +792,7 @@ instance PrettyTCM TypeError where
       ]
 
     AmbiguousOverloadedProjection ds reason -> do
-      let nameRaw = pretty $ A.nameConcrete $ A.qnameName $ List1.head ds
+      let nameRaw = pretty $ A.nameConcrete $ A.qnameName $ headAmbQ ds
       vcat
         [ fsep
           [ text "Cannot resolve overloaded projection"
@@ -801,7 +801,7 @@ instance PrettyTCM TypeError where
           , pure reason
           ]
         , nest 2 $ text "candidates in scope:"
-        , vcat $ for ds $ \ d -> do
+        , vcat $ for (getAmbiguous ds) $ \ d -> do
             t <- typeOfConst d
             text "-" <+> nest 2 (nameRaw <+> text ":" <+> prettyTCM t)
         ]

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -792,7 +792,9 @@ instance PrettyTCM TypeError where
       ]
 
     AmbiguousOverloadedProjection ds reason -> do
-      let nameRaw = pretty $ A.nameConcrete $ A.qnameName $ headAmbQ ds
+      let
+        x = headAmbQ ds
+        nameRaw = pretty $ A.nameConcrete $ A.qnameName x
       vcat
         [ fsep
           [ text "Cannot resolve overloaded projection"
@@ -804,6 +806,15 @@ instance PrettyTCM TypeError where
         , vcat $ for (getAmbiguous ds) $ \ d -> do
             t <- typeOfConst d
             text "-" <+> nest 2 (nameRaw <+> text ":" <+> prettyTCM t)
+        -- , vcat . concat $ for (unAmbQ ds) \ d ->
+        --     [ text "-" <+> nest 2 (nameRaw <+> text ":" <+> (prettyTCM =<< typeOfConst (fromAmbQName d))) ]
+        --       ++
+        --     case d of
+        --       AmbQName{} -> []
+        --       AmbAbstractName x -> [ nest 2 $ prettyTCM x ]
+        , case whyInScopeDataFromAmbiguousQName (qnameToConcrete x) ds of
+            Nothing -> empty
+            Just why -> explainWhyInScope why
         ]
 
     AmbiguousConstructor c disambs -> vcat

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1386,8 +1386,8 @@ instance PrettyTCM TypeError where
             pwords "missing"
           CannotQuoteHidden ->
             pwords "implicit"
-          CannotQuoteAmbiguous (List2 x y zs) ->
-            pwords "ambiguous:" ++ [ pretty $ AmbQ $ x :| y : zs ]
+          CannotQuoteAmbiguous xs ->
+            pwords "ambiguous:" ++ [ pretty xs ]
           CannotQuoteExpression e -> case e of
             -- These expression can be quoted:
             A.Def' _ NoSuffix -> __IMPOSSIBLE__

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -1089,7 +1089,7 @@ instance PrettyTCM TypeError where
       ]
       where
         (x, _) = List1.head defs
-        prDef (x, (xs, p)) = prettyA (A.PatternSynDef x (map (fmap BindName) xs) p) <?> ("at" <+> pretty r)
+        prDef (x, (A.PatternSynDefn xs p)) = prettyA (A.PatternSynDef x (map (fmap BindName) xs) p) <?> ("at" <+> pretty r)
           where r = nameBindingSite $ qnameName x
 
     IllegalInstanceVariableInPatternSynonym x -> fsep $ concat

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -5726,8 +5726,8 @@ data IncorrectTypeForRewriteRelationReason
 
 -- | Extra information for error 'CannotQuote'.
 data CannotQuote
-  = CannotQuoteAmbiguous (List2 A.QName)
-      -- ^ @quote@ is applied to an ambiguous name.
+  = CannotQuoteAmbiguous AmbiguousQName
+      -- ^ @quote@ is applied to a really ambiguous name.
   | CannotQuoteExpression A.Expr
       -- ^ @quote@ is applied to an expression that is not an unambiguous defined name.
   | CannotQuoteHidden

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -1918,7 +1918,7 @@ instance AllMetas PrincipalArgTypeMetas where
 data TypeCheckingProblem
   = CheckExpr Comparison A.Expr Type
   | CheckArgs Comparison ExpandHidden A.Expr [NamedArg A.Expr] Type Type (ArgsCheckState CheckedTarget -> TCM Term)
-  | CheckProjAppToKnownPrincipalArg Comparison A.Expr ProjOrigin (List1 QName) A.Expr A.Args Type Int Term Type PrincipalArgTypeMetas
+  | CheckProjAppToKnownPrincipalArg Comparison A.Expr ProjOrigin AmbiguousQName A.Expr A.Args Type Int Term Type PrincipalArgTypeMetas
   | CheckLambda Comparison (Arg (List1 (WithHiding Name), Maybe Type)) A.Expr Type
     -- ^ @(λ (xs : t₀) → e) : t@
     --   This is not an instance of 'CheckExpr' as the domain type
@@ -5547,7 +5547,7 @@ data TypeError
             -- ^ Pattern and its possible interpretations.
         | AmbiguousProjection QName (List1 QName)
             -- ^ The list contains alternative interpretations of the name.
-        | AmbiguousOverloadedProjection (List1 QName) Doc
+        | AmbiguousOverloadedProjection AmbiguousQName Doc
         | OperatorInformation [NotationSection] OperatorScope TypeError
             -- ^ The list of notations can be empty.
 {- UNUSED

--- a/src/full/Agda/TypeChecking/Monad/State.hs
+++ b/src/full/Agda/TypeChecking/Monad/State.hs
@@ -581,7 +581,8 @@ getAllPatternSyns :: ReadTCState m => m PatternSynDefns
 getAllPatternSyns = Map.union <$> getPatternSyns <*> getPatternSynImports
 
 lookupPatternSyn :: AmbiguousQName -> TCM PatternSynDefn
-lookupPatternSyn (AmbQ xs) = do
+lookupPatternSyn ambX = do
+  let xs = getAmbiguous ambX
   defs <- traverse lookupSinglePatternSyn xs
   case mergePatternSynDefs defs of
     Just def   -> return def

--- a/src/full/Agda/TypeChecking/Patterns/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Abstract.hs
@@ -76,7 +76,7 @@ expandPatternSynonyms' = postTraverseAPatternM $ \case
     -- This is less than optimal, since we do not rule out
     -- the invalid alternatives by typing, but we cannot do
     -- better here.
-    mapM_ raiseWarningsOnUsage $ A.unAmbQ x
+    mapM_ raiseWarningsOnUsage $ A.getAmbiguous x
 
     -- Must expand arguments before instantiating otherwise pattern
     -- synonyms could get into dot patterns (which is __IMPOSSIBLE__).

--- a/src/full/Agda/TypeChecking/Patterns/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Patterns/Abstract.hs
@@ -67,7 +67,7 @@ expandPatternSynonyms' :: forall e. A.Pattern' e -> TCM (A.Pattern' e)
 expandPatternSynonyms' = postTraverseAPatternM $ \case
 
   A.PatternSynP i x as -> setCurrentRange i $ do
-    (ns, p) <- killRange <$> lookupPatternSyn x
+    A.PatternSynDefn ns p <- killRange <$> lookupPatternSyn x
 
     -- Andreas, 2020-02-11, issue #3734
     -- If lookup of ambiguous pattern synonym was successful,

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -34,13 +34,13 @@ import Agda.Syntax.Translation.ReflectedToAbstract
 import Agda.Syntax.Translation.AbstractToConcrete
 import qualified Agda.Syntax.Translation.AbstractToConcrete as Reexport (MonadAbsToCon)
 import qualified Agda.Syntax.Translation.ReflectedToAbstract as R
-import qualified Agda.Syntax.Abstract as A
+import Agda.Syntax.Abstract.Name (AbstractName (..), AbstractModule (..), KindOfName(..))
+import Agda.Syntax.Abstract qualified as A
 import qualified Agda.Syntax.Concrete as C
 import qualified Agda.Syntax.Abstract.Pretty as AP
 import Agda.Syntax.Concrete.Pretty (bracesAndSemicolons)
 import qualified Agda.Syntax.Concrete.Pretty as CP
 import qualified Agda.Syntax.Info as A
-import Agda.Syntax.Scope.Base  (AbstractName(..))
 import Agda.Syntax.Scope.Monad (withContextPrecedence)
 import Agda.Syntax.TopLevelModuleName
 

--- a/src/full/Agda/TypeChecking/Primitive.hs
+++ b/src/full/Agda/TypeChecking/Primitive.hs
@@ -957,7 +957,7 @@ primitiveFunctions = localTCStateSavingWarnings <$> Map.fromListWith __IMPOSSIBL
   , PrimQNameLess         |-> mkPrimFun2 ((<) :: Rel QName)
   , PrimShowQName         |-> mkPrimFun1 (T.pack . prettyShow :: QName -> Text)
   , PrimQNameFixity       |-> mkPrimFun1 (nameFixity . qnameName)
-  , PrimQNameToWord64s    |-> mkPrimFun1 ((\ (NameId x (ModuleNameHash y)) -> (x, y)) . nameId . qnameName
+  , PrimQNameToWord64s    |-> mkPrimFun1 ((\ (NameId x (ModuleNameHash y)) -> (x, y)) . nameId
                                           :: QName -> (Word64, Word64))
   , PrimQNameToWord64sInjective   |-> primQNameToWord64sInjective
   , PrimMetaEquality      |-> mkPrimFun2 ((==) :: Rel MetaId)

--- a/src/full/Agda/TypeChecking/Quote.hs
+++ b/src/full/Agda/TypeChecking/Quote.hs
@@ -5,9 +5,9 @@ module Agda.TypeChecking.Quote where
 import Control.Monad
 
 import Data.Maybe (fromMaybe)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
-import qualified Agda.Syntax.Abstract as A
+import Agda.Syntax.Abstract qualified as A
 import Agda.Syntax.Common
 import Agda.Syntax.Internal as I
 import Agda.Syntax.Internal.Pattern ( hasDefP )
@@ -25,10 +25,8 @@ import Agda.TypeChecking.Substitute
 import Agda.Utils.Impossible
 import Agda.Utils.Functor
 import Agda.Utils.List
-import Agda.Utils.List1 ( pattern (:|) )
-import Agda.Utils.List2 ( pattern List2 )
 import Agda.Utils.Size
-import qualified Agda.Utils.Maybe.Strict as Strict
+import Agda.Utils.Maybe.Strict qualified as Strict
 
 -- | Parse @quote@.
 quotedName :: (MonadTCError m, MonadAbsToCon m) => A.Expr -> m QName
@@ -42,9 +40,9 @@ quotedName = \case
   A.ScopedExpr _ e  -> quotedName e
   e -> typeError $ CannotQuote $ CannotQuoteExpression e
   where
-    unambiguous (AmbQ (x :| xs)) = case xs of
-      []   -> return x
-      y:ys -> typeError $ CannotQuote $ CannotQuoteAmbiguous $ List2 x y ys
+    unambiguous ambX = case getUnambiguous ambX of
+      Just x  -> return x
+      Nothing -> typeError $ CannotQuote $ CannotQuoteAmbiguous ambX
 
 
 data QuotingKit = QuotingKit

--- a/src/full/Agda/TypeChecking/Reduce/Fast.hs
+++ b/src/full/Agda/TypeChecking/Reduce/Fast.hs
@@ -389,7 +389,7 @@ fastCase :: BuiltinEnv -> Case CompiledClauses -> FastCase FastCompiledClauses
 fastCase env (Branches proj con _ lit wild fT _) =
   FBranches
     { fprojPatterns   = proj
-    , fconBranches    = Map.mapKeysMonotonic (nameId . qnameName) $ fmap (fastCompiledClauses env . content) (stripSuc con)
+    , fconBranches    = Map.mapKeysMonotonic nameId $ fmap (fastCompiledClauses env . content) (stripSuc con)
     , fsucBranch      = fmap (fastCompiledClauses env . content) $ flip Map.lookup con . conName =<< bSuc env
     , flitBranches    = fmap (fastCompiledClauses env) lit
     , ffallThrough    = Just True == fT
@@ -401,7 +401,7 @@ fastCase env (Branches proj con _ lit wild fT _) =
 
 {-# INLINE lookupCon #-}
 lookupCon :: QName -> FastCase c -> Maybe c
-lookupCon c (FBranches _ cons _ _ _ _) = Map.lookup (nameId $ qnameName c) cons
+lookupCon c (FBranches _ cons _ _ _ _) = Map.lookup (nameId c) cons
 
 -- QName memo -------------------------------------------------------------
 
@@ -412,7 +412,7 @@ memoQName f = unsafePerformIO $ do
   return (unsafePerformIO . f' tbl)
   where
     f' tbl x = do
-      let i = nameId (qnameName x)
+      let i = nameId x
       m <- readIORef tbl
       case Map.lookup i m of
         Just y  -> return y
@@ -850,7 +850,7 @@ reduceTm rEnv bEnv !constInfo normalisation =
 
     -- Checking for built-in zero and suc
     BuiltinEnv{ bZero = zero, bSuc = suc, bRefl = refl0 } = bEnv
-    conNameId = nameId . qnameName . conName
+    conNameId = nameId . conName
     isZero = case zero of
                Nothing -> const False
                Just z  -> (conNameId z ==) . conNameId

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -153,9 +153,9 @@ checkApplication cmp hd args e t =
       checkConstructorApplication cmp e t con hd args
 
     -- Subcase: ambiguous constructor
-    A.Con (AmbQ cs0) -> do
+    A.Con ambC -> do
       let cont c = checkConstructorApplication cmp e t c hd args
-      afterDisambiguation cont $ disambiguateConstructor cs0 args t
+      afterDisambiguation cont $ disambiguateConstructor ambC args t
 
     -- Subcase: pattern synonym
     A.PatternSyn n -> do
@@ -1098,10 +1098,11 @@ decideOn c = do
   return $ Right c
 
 -- | Returns an unblocking action in case of failure.
-disambiguateConstructor :: List1 QName -> A.Args -> Type -> DisambiguateConstructor
-disambiguateConstructor cs0 args t = do
-  reportSLn "tc.check.term.con" 40 $ "Ambiguous constructor: " ++ prettyShow cs0
+disambiguateConstructor :: AmbiguousQName -> A.Args -> Type -> DisambiguateConstructor
+disambiguateConstructor ambC args t = do
+  reportSLn "tc.check.term.con" 40 $ "Ambiguous constructor: " ++ prettyShow ambC
   reportSDoc "tc.check.term.con" 40 $ vcat $ "Arguments:" : map (nest 2 . prettyTCM) args
+  let cs0 = getAmbiguous ambC
 
   -- Get the datatypes of the various constructors
   let getData Constructor{conData = d} = d

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -144,7 +144,7 @@ checkApplication cmp hd args e t =
 
     -- Subcase: ambiguous projection
     A.Proj o p -> do
-      checkProjApp cmp e o (unAmbQ p) hd args t
+      checkProjApp cmp e o p hd args t
 
     -- Subcase: unambiguous constructor
     A.Con ambC | Just c <- getUnambiguous ambC -> do
@@ -259,7 +259,7 @@ inferApplication exh hd args e | not (defOrVar hd) = do
 inferApplication exh hd args e = postponeInstanceConstraints $ do
   SortKit{..} <- sortKit
   case unScope hd of
-    A.Proj o p | isAmbiguous p -> inferProjApp e o (unAmbQ p) hd args
+    A.Proj o p | isAmbiguous p -> inferProjApp e o p hd args
     A.Def' x s | Just (sz, u) <- isNameOfUniv x -> inferUniv sz u e x s args
     _ -> do
       (f, t0) <- inferHead hd
@@ -1289,7 +1289,7 @@ checkUnambiguousProjectionApplication cmp e t x o hd args = do
 -- | Inferring the type of an overloaded projection application.
 --   See 'inferOrCheckProjApp'.
 
-inferProjApp :: A.Expr -> ProjOrigin -> List1 QName -> A.Expr -> A.Args -> TCM (Term, Type)
+inferProjApp :: A.Expr -> ProjOrigin -> AmbiguousQName -> A.Expr -> A.Args -> TCM (Term, Type)
 inferProjApp e o ds hd args0 = do
   (v, t, _) <- inferOrCheckProjApp e o ds hd args0 Nothing
   return (v, t)
@@ -1297,7 +1297,7 @@ inferProjApp e o ds hd args0 = do
 -- | Checking the type of an overloaded projection application.
 --   See 'inferOrCheckProjApp'.
 
-checkProjApp  :: Comparison -> A.Expr -> ProjOrigin -> List1 QName -> A.Expr -> A.Args -> Type -> TCM Term
+checkProjApp  :: Comparison -> A.Expr -> ProjOrigin -> AmbiguousQName -> A.Expr -> A.Args -> Type -> TCM Term
 checkProjApp cmp e o ds hd args0 t = do
   (v, ti, targetCheck) <- inferOrCheckProjApp e o ds hd args0 (Just (cmp, t))
   coerce' cmp targetCheck v ti t
@@ -1309,7 +1309,7 @@ checkProjAppToKnownPrincipalArg ::
   Comparison
   -> A.Expr
   -> ProjOrigin
-  -> List1 QName
+  -> AmbiguousQName
   -> A.Expr
   -> A.Args
   -> Type
@@ -1332,7 +1332,7 @@ inferOrCheckProjApp
      -- ^ The whole expression which constitutes the application.
   -> ProjOrigin
      -- ^ The origin of the projection involved in this projection application.
-  -> List1 QName
+  -> AmbiguousQName
      -- ^ The projection name (potentially ambiguous).
   -> A.Expr
      -- ^ The projection as expression.
@@ -1381,7 +1381,7 @@ inferOrCheckProjApp e o ds hd args mt = do
       ifBlocked (unDom dom) (\ m _ -> postpone m) $ {-else-} \ _ ta -> do
       caseMaybeM (isRecordType ta) (refuseProjNotRecordType ds Nothing ta)
         \ (_q, _pars, RecordData{ _recFields = fs }) -> do
-          case forMaybe fs $ \ f -> Fold.find (unDom f ==) ds of
+          case forMaybe fs $ \ f -> Fold.find (unDom f ==) (getAmbiguous ds) of
             [] -> refuseProjNoMatching ds
             [d] -> do
               storeDisambiguatedProjection d
@@ -1406,7 +1406,7 @@ inferOrCheckProjAppToKnownPrincipalArg
      -- ^ The whole expression which constitutes the application.
   -> ProjOrigin
      -- ^ The origin of the projection involved in this projection application.
-  -> List1 QName
+  -> AmbiguousQName
      -- ^ The projection name (potentially ambiguous).
   -> A.Expr
      -- ^ The projection (as application head).
@@ -1499,7 +1499,7 @@ inferOrCheckProjAppToKnownPrincipalArg e o ds hd args mt k v0 ta mpatm = do
             guard =<< do isNothing <$> do lift $ checkModality' d def
             return (orig, (d, (pars, (dom, u, tb))))
 
-      cands <- List1.groupOn fst . List1.catMaybes <$> mapM (runMaybeT . try) ds
+      cands <- List1.groupOn fst . List1.catMaybes <$> mapM (runMaybeT . try) (getAmbiguous ds)
       case cands of
         [] -> refuseProjNoMatching ds
         (_:_:_) -> refuseProj ds $ fwords "several matching candidates can be applied."
@@ -1537,13 +1537,13 @@ inferOrCheckProjAppToKnownPrincipalArg e o ds hd args mt k v0 ta mpatm = do
               return (v, tc, NotCheckedTarget)
 
 -- | Throw 'AmbiguousOverloadedProjection' with additional explanation.
-refuseProj :: List1 QName -> TCM Doc -> TCM a
+refuseProj :: AmbiguousQName -> TCM Doc -> TCM a
 refuseProj ds reason = typeError . AmbiguousOverloadedProjection ds =<< reason
 
-refuseProjNotApplied, refuseProjNoMatching :: List1 QName -> TCM a
+refuseProjNotApplied, refuseProjNoMatching :: AmbiguousQName -> TCM a
 refuseProjNotApplied    ds = refuseProj ds $ fwords "it is not applied to a visible argument"
 refuseProjNoMatching    ds = refuseProj ds $ fwords "no matching candidate found"
-refuseProjNotRecordType :: List1 QName -> Maybe Term -> Type -> TCM a
+refuseProjNotRecordType :: AmbiguousQName -> Maybe Term -> Type -> TCM a
 refuseProjNotRecordType ds pValue pType = do
   let dType = prettyTCM pType
   let dValue = caseMaybe pValue (return empty) prettyTCM

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -159,8 +159,8 @@ checkApplication cmp hd args e t =
 
     -- Subcase: pattern synonym
     A.PatternSyn n -> do
-      (ns, p) <- lookupPatternSyn n
-      p <- return $ setRange (getRange n) $ killRange $ vacuous p   -- Pattern' Void -> Pattern' Expr
+      A.PatternSynDefn ns p0 <- lookupPatternSyn n
+      let p = setRange (getRange n) $ killRange $ vacuous p0   -- Pattern' Void -> Pattern' Expr
       -- Expand the pattern synonym by substituting for
       -- the arguments we have got and lambda-lifting
       -- over the ones we haven't.

--- a/src/full/Agda/TypeChecking/Rules/Application.hs-boot
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs-boot
@@ -2,8 +2,6 @@
 
 module Agda.TypeChecking.Rules.Application where
 
-import Data.List.NonEmpty (NonEmpty)
-
 import Agda.Syntax.Common (NamedArg, ProjOrigin)
 import qualified Agda.Syntax.Abstract as A
 import Agda.Syntax.Internal
@@ -35,7 +33,7 @@ checkProjAppToKnownPrincipalArg ::
      Comparison
   -> A.Expr
   -> ProjOrigin
-  -> NonEmpty QName
+  -> AmbiguousQName
   -> A.Expr
   -> A.Args
   -> Type

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -27,7 +27,6 @@ import Agda.Syntax.Common
 import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Concrete (pattern NoWhere_)
 import Agda.Syntax.Literal
-import Agda.Syntax.Scope.Base ( KindOfName(..) )
 
 import Agda.TypeChecking.Monad
 import Agda.TypeChecking.Monad.Benchmark (MonadBench, Phase)

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs-boot
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs-boot
@@ -5,7 +5,6 @@ module Agda.TypeChecking.Rules.Decl where
 import Agda.Syntax.Info (ModuleInfo)
 import Agda.Syntax.Abstract
 import Agda.Syntax.Common
-import Agda.Syntax.Scope.Base
 import Agda.TypeChecking.Monad.Base (TCM)
 
 checkDecls :: [Declaration] -> TCM ()

--- a/src/full/Agda/TypeChecking/Rules/Display.hs
+++ b/src/full/Agda/TypeChecking/Rules/Display.hs
@@ -112,10 +112,10 @@ patternToTerm p ret =
   where
     fail = throwError . ("its left-hand side contains " ++)
     failP s = fail . (s ++) . (": " ++) . render =<< prettyA p
-    ambigErr thing (AmbQ xs) =
+    ambigErr thing x =
       fail . render =<< do
         text ("an ambiguous " ++ thing ++ ":") <?>
-          fsep (punctuate comma (fmap pretty xs))
+          fsep (punctuate ";" (fmap pretty (getAmbiguous x)))
 
 bindWild :: M a -> M a
 bindWild ret = do

--- a/src/full/Agda/TypeChecking/Rules/LHS.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS.hs
@@ -1741,7 +1741,7 @@ disambiguateProjection
   -> TCM (QName, Bool, QName, Arg Type, ArgInfo)
        -- ^ @Bool@ signifies whether copattern matching is allowed at
        --   the inferred record type.
-disambiguateProjection h ambD@(AmbQ ds) b = do
+disambiguateProjection h ambD b = do
   -- If the target is not a record type, that's an error.
   -- It could be a meta, but since we cannot postpone lhs checking, we crash here.
   caseEitherM (liftTCM $ tryRecordType $ unArg b) notRecord
@@ -1766,6 +1766,7 @@ disambiguateProjection h ambD@(AmbQ ds) b = do
             (_    , (d,_) : (d1,_) : disambs) ->
               typeError $ AmbiguousProjection d $ d1 :| map fst disambs
   where
+    ds = getAmbiguous ambD
     tryDisambiguate constraintsOk fs r vs comatching failure = do
       -- Note that tryProj wraps TCM in an ExceptT, collecting errors
       -- instead of throwing them to the user immediately.
@@ -1860,7 +1861,7 @@ disambiguateConstructor
   -> QName             -- ^ Name of the datatype.
   -> Args              -- ^ Parameters of the datatype
   -> TCM (ConHead, Type)
-disambiguateConstructor ambC@(AmbQ cs) d pars = do
+disambiguateConstructor ambC d pars = do
   d <- canonicalName d
   cons <- theDef <$> getConstInfo d >>= \case
     def@Datatype{} -> return $ dataCons def
@@ -1881,6 +1882,7 @@ disambiguateConstructor ambC@(AmbQ cs) d pars = do
           AmbiguousConstructor c $ fmap (conName . snd3) $ List2.concat21 $ List2 d0 d1 ds
 
   where
+    cs = getAmbiguous ambC
     tryDisambiguate
       :: Bool     -- May we constrain/solve metas to arrive at unique disambiguation?
       -> QName    -- Data/record type.

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -31,7 +31,7 @@ import Agda.Syntax.Internal as I
 import Agda.Syntax.Internal.MetaVars
 import Agda.Syntax.Position
 import Agda.Syntax.Literal
-import Agda.Syntax.Scope.Base ( ThingsInScope, AbstractName
+import Agda.Syntax.Scope.Base ( ThingsInScope
                               , emptyScopeInfo
                               , exportedNamesInScope)
 import Agda.Syntax.Scope.Monad (getNamedScope)

--- a/src/full/Agda/TypeChecking/Rules/Term.hs
+++ b/src/full/Agda/TypeChecking/Rules/Term.hs
@@ -1407,11 +1407,11 @@ appViewM e = do
       | A.Dot _ e2' <- unScope $ namedArg e2
       , Just (f0, hd) <- maybeProjTurnPostfix e2'
       -> do
-       ai <- case f0 of
-         A.AmbQ (f :| []) -> isProjection f >>= \case
+       ai <- case getUnambiguous f0 of
+         Just f -> isProjection f >>= \case
            Just p | isProperProjection_ p -> pure $ projArgInfo p
            _ -> pure defaultArgInfo
-         _ -> pure defaultArgInfo
+         Nothing -> pure defaultArgInfo
        return (Application hd, singleton (unnamedArg ai e1))
     A.App _ e1 arg -> second (`DL.snoc` arg) <$> go e1
     e -> return (Application e, mempty)

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20260214 * 10 + 0
+currentInterfaceVersion = 20260222 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -203,6 +203,12 @@ instance {-# OVERLAPS #-} EmbPrj A.Pattern where
   icod_ = icod_ <=< noDotOrEqPattern (return $ A.WildP empty)
   value = fmap (__IMPOSSIBLE__ :: Void -> A.Expr) <.> value
 
+instance EmbPrj A.PatternSynDefn where
+  icod_ (A.PatternSynDefn a b) = icodeN' A.PatternSynDefn a b
+  value = vcase \case
+    N2 a b -> valuN A.PatternSynDefn a b
+    _ -> malformed
+
 instance EmbPrj ParenPreference where
   icod_ PreferParen     = icodeN' PreferParen
   icod_ PreferParenless = icodeN 1 PreferParenless

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Abstract.hs
@@ -11,6 +11,8 @@ import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Void (Void)
 
+import Agda.Syntax.Abstract.Name
+  ( AbstractName(..), AbstractModule(..), KindOfName, NameMetadata(..), WhyInScope(..) )
 import Agda.Syntax.Abstract qualified as A
 import Agda.Syntax.Abstract.Pattern ( noDotOrEqPattern )
 import Agda.Syntax.Common

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -37,6 +37,7 @@ import Agda.Utils.Impossible
 import Agda.Utils.CallStack
 import qualified Agda.Utils.HashTable as H
 import qualified Agda.Utils.CompactRegion as Compact
+import Agda.Utils.Functor ((<.>))
 
 instance EmbPrj ConstructorOrPatternSynonym
 
@@ -246,9 +247,24 @@ instance EmbPrj A.QName where
 
   value = valueN A.QName
 
+-- | Note: Serialization of 'A.AmbiguousQName' discards lineage,
+-- treating all entries as just 'A.QName' rather than 'A.AbstractName'.
 instance EmbPrj A.AmbiguousQName where
-  icod_ (A.AmbQ a) = icode a
-  value n          = A.AmbQ <$!> value n
+  icod_ = icod_ . A.getAmbiguous
+  value = A.ambiguous <.> value
+
+-- instance EmbPrj A.AmbiguousQName where
+--   icod_ (A.AmbQ a) = icode a
+--   value n          = A.AmbQ <$!> value n
+
+-- instance EmbPrj A.AmbQNameEntry where
+--   icod_ = \case
+--     A.AmbQName a -> icodeN 0 a
+--     A.AmbAbstractName a -> icodeN 1 a
+--   value = vcase \case
+--     N2 0 a -> valuN A.AmbQName a
+--     N2 1 a -> valuN A.AmbAbstractName a
+--     _ -> malformed
 
 instance EmbPrj A.ModuleName where
   icod_ (A.MName a) = icode a

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -39,8 +39,7 @@ import Agda.Syntax.Concrete.Name (simpleName)
 import Agda.Syntax.Position
 import Agda.Syntax.Info as Info
 import Agda.Syntax.Translation.ReflectedToAbstract
-import Agda.Syntax.Scope.Base (KindOfName(ConName, DataName)
-                              , scopeLocals, LocalVar(LocalVar), BindingSource(MacroBound) )
+import Agda.Syntax.Scope.Base ( scopeLocals, LocalVar(LocalVar), BindingSource(MacroBound) )
 import Agda.Syntax.Parser
 
 import Agda.Interaction.Library ( ExeName )

--- a/src/full/Agda/Utils/AssocList.hs
+++ b/src/full/Agda/Utils/AssocList.hs
@@ -11,8 +11,8 @@ import Prelude hiding (lookup)
 
 import Data.Function (on)
 import Data.List (lookup)
-import qualified Data.List as List
-import qualified Data.Map  as Map
+import Data.List qualified as List
+import Data.Map qualified  as Map
 
 import Agda.Utils.Tuple
 

--- a/src/full/Agda/Utils/Bag.hs
+++ b/src/full/Agda/Utils/Bag.hs
@@ -6,17 +6,17 @@ module Agda.Utils.Bag where
 
 import Prelude hiding (null, map)
 
-import           Text.Show.Functions    () -- instance only
+import Text.Show.Functions    () -- instance only
 
-import qualified Data.List              as List
-import           Data.List.NonEmpty     ( NonEmpty, pattern (:|) )
-import qualified Data.List.NonEmpty     as List1
-  -- NB: Not importing Agda.Utils.List1 to avoid import cycles.
-import           Data.Map               ( Map )
-import qualified Data.Map               as Map
-import           Data.Semigroup         ( Sum(..) )
+-- NB: Not importing Agda.Utils.List1 to avoid import cycles.
+import Data.List              qualified as List
+import Data.List.NonEmpty     ( NonEmpty, pattern (:|) )
+import Data.List.NonEmpty     qualified as List1
+import Data.Map               ( Map )
+import Data.Map               qualified as Map
+import Data.Semigroup         ( Sum(..) )
 
-import           Agda.Utils.Functor
+import Agda.Utils.Functor
 
 -- | A set with duplicates.
 --   Faithfully stores elements which are equal with regard to (==).

--- a/src/full/Agda/Utils/Benchmark.hs
+++ b/src/full/Agda/Utils/Benchmark.hs
@@ -7,7 +7,7 @@ module Agda.Utils.Benchmark where
 import Prelude hiding (null)
 
 import Control.DeepSeq
-import qualified Control.Exception as E (evaluate)
+import Control.Exception qualified as E (evaluate)
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.Writer
@@ -16,22 +16,22 @@ import Control.Monad.IO.Class ( MonadIO(..) )
 
 
 import Data.Function (on)
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Monoid
 import Data.Maybe
 
 import GHC.Generics (Generic)
 
-import qualified Text.PrettyPrint.Boxes as Boxes
+import Text.PrettyPrint.Boxes qualified as Boxes
 
 import Agda.Utils.ListT
 import Agda.Utils.Null
 import Agda.Utils.Monad hiding (finally)
-import qualified Agda.Utils.Maybe.Strict as Strict
+import Agda.Utils.Maybe.Strict qualified as Strict
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.Time
 import Agda.Utils.Trie (Trie)
-import qualified Agda.Utils.Trie as Trie
+import Agda.Utils.Trie qualified as Trie
 
 
 -- * Benchmark trie

--- a/src/full/Agda/Utils/BiMap.hs
+++ b/src/full/Agda/Utils/BiMap.hs
@@ -15,9 +15,9 @@ import Control.Monad.Identity
 import Control.Monad.State
 
 import Data.Function (on)
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Maybe
 import Data.Ord
 import Data.Tuple

--- a/src/full/Agda/Utils/BoolSet.hs
+++ b/src/full/Agda/Utils/BoolSet.hs
@@ -8,8 +8,8 @@
 --
 -- Import as:
 -- @
---    import qualified Agda.Utils.BoolSet as BoolSet
 --    import Agda.Utils.BoolSet (BoolSet)
+--    import Agda.Utils.BoolSet qualified as BoolSet
 -- @
 
 module Agda.Utils.BoolSet

--- a/src/full/Agda/Utils/Boolean.hs
+++ b/src/full/Agda/Utils/Boolean.hs
@@ -20,7 +20,7 @@
 module Agda.Utils.Boolean where
 
 import Prelude ( Bool(True,False), Eq, ($), (.), const, id )
-import qualified Prelude as P
+import Prelude qualified as P
 
 infixr 3 &&
 infixr 2 ||

--- a/src/full/Agda/Utils/Cluster.hs
+++ b/src/full/Agda/Utils/Cluster.hs
@@ -18,7 +18,7 @@ import Data.Equivalence.Monad ( runEquivM, equateAll, classDesc )
 import Data.List.NonEmpty     ( NonEmpty(..), nonEmpty, toList )
 import Data.Maybe             ( fromMaybe )
 
-import qualified Data.Map.Strict as MapS
+import Data.Map.Strict qualified as MapS
 
 import Agda.Utils.Functor
 import Agda.Utils.Singleton

--- a/src/full/Agda/Utils/Either.hs
+++ b/src/full/Agda/Utils/Either.hs
@@ -29,7 +29,7 @@ import Data.List   (unfoldr)
 
 import Agda.Utils.List ( spanJust )
 import Agda.Utils.List1 ( List1, pattern (:|), (<|) )
-import qualified Agda.Utils.List1 as List1
+import Agda.Utils.List1 qualified as List1
 
 -- | Loop while we have an exception.
 

--- a/src/full/Agda/Utils/Favorites.hs
+++ b/src/full/Agda/Utils/Favorites.hs
@@ -6,15 +6,15 @@
 --   To avoid name clashes, import this module qualified, as in
 --   @
 --      import Agda.Utils.Favorites (Favorites)
---      import qualified Agda.Utils.Favorites as Fav
+--      import Agda.Utils.Favorites qualified as Fav
 --   @
 
 module Agda.Utils.Favorites where
 
 import Prelude hiding ( null )
 
-import qualified Data.List as List
-import qualified Data.Set as Set
+import Data.List qualified as List
+import Data.Set qualified as Set
 
 import Agda.Utils.Null
 import Agda.Utils.PartialOrd

--- a/src/full/Agda/Utils/FileName.hs
+++ b/src/full/Agda/Utils/FileName.hs
@@ -26,7 +26,7 @@ import Data.Function (on)
 import Data.Hashable       ( Hashable )
 import Data.Maybe          ( catMaybes, listToMaybe )
 import Data.Text           ( Text )
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 import System.Directory
 import System.FilePath

--- a/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
+++ b/src/full/Agda/Utils/Graph/AdjacencyMap/Unidirectional.hs
@@ -76,15 +76,15 @@ module Agda.Utils.Graph.AdjacencyMap.Unidirectional
 
 import Prelude hiding ( lookup, null, unzip )
 
-import qualified Data.Array.IArray as Array
+import Data.Array.IArray qualified as Array
 import Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
-import qualified Data.Graph as Graph
+import Data.Sequence qualified as Seq
+import Data.Graph qualified as Graph
 import Data.IntMap.Strict (IntMap)
-import qualified Data.IntMap.Strict as IntMap
-import qualified Data.IntSet as IntSet
-import qualified Data.List as List
-import qualified Data.Map.Strict as Map
+import Data.IntMap.Strict qualified as IntMap
+import Data.IntSet qualified as IntSet
+import Data.List qualified as List
+import Data.Map.Strict qualified as Map
 import Data.Map.Strict (Map)
 import Data.Foldable (toList)
 

--- a/src/full/Agda/Utils/Graph/TopSort.hs
+++ b/src/full/Agda/Utils/Graph/TopSort.hs
@@ -5,9 +5,9 @@ module Agda.Utils.Graph.TopSort
     ) where
 
 import Data.Set (Set)
-import qualified Data.Set as Set
-import qualified Data.Map as Map
-import qualified Agda.Utils.Graph.AdjacencyMap.Unidirectional as G
+import Data.Set qualified as Set
+import Data.Map qualified as Map
+import Agda.Utils.Graph.AdjacencyMap.Unidirectional qualified as G
 
 
 -- | topoligical sort with smallest-numbered available vertex first

--- a/src/full/Agda/Utils/Hash.hs
+++ b/src/full/Agda/Utils/Hash.hs
@@ -8,12 +8,12 @@ module Agda.Utils.Hash where
 
 import Data.ByteString as B
 import Data.Word
-import qualified Data.Hash as H
-import qualified Data.List as L
+import Data.Hash qualified as H
+import Data.List qualified as L
 import Data.Digest.Murmur64
-import qualified Data.Text.Encoding as T
+import Data.Text.Encoding qualified as T
 import Data.Text.Lazy (Text)
-import qualified Data.Text.Lazy as T
+import Data.Text.Lazy qualified as T
 
 import Agda.Utils.FileName
 import Agda.Utils.IO.UTF8 (readTextFile)

--- a/src/full/Agda/Utils/HashTable.hs
+++ b/src/full/Agda/Utils/HashTable.hs
@@ -27,11 +27,11 @@ import Data.Vector.Hashtables
 import Data.Vector.Hashtables.Internal
 import Data.Vector.Hashtables.Internal.Mask
 
-import qualified Data.Primitive.PrimArray as A
+import Data.Primitive.PrimArray qualified as A
 
 import Data.Vector.Generic.Mutable (MVector)
-import qualified Data.Vector.Mutable as VM
-import qualified Data.Vector.Unboxed.Mutable as VUM
+import Data.Vector.Mutable qualified as VM
+import Data.Vector.Unboxed.Mutable qualified as VUM
 
 import Agda.Utils.Monad
 

--- a/src/full/Agda/Utils/IO/Directory.hs
+++ b/src/full/Agda/Utils/IO/Directory.hs
@@ -16,7 +16,7 @@ import Data.Monoid          ( Endo(Endo, appEndo) )
 
 import System.Directory
 import System.FilePath
-import qualified System.FilePath.Find as Find
+import System.FilePath.Find qualified as Find
 
 
 -- | Search a directory recursively, with recursion controlled by a

--- a/src/full/Agda/Utils/IO/TempFile.hs
+++ b/src/full/Agda/Utils/IO/TempFile.hs
@@ -6,9 +6,9 @@ module Agda.Utils.IO.TempFile
   ( writeToTempFile
   ) where
 
-import qualified Control.Exception as E
-import qualified System.Directory as D
-import qualified System.IO as IO
+import Control.Exception qualified as E
+import System.Directory qualified as D
+import System.IO qualified as IO
 
 -- | Creates a temporary file, writes some stuff, and returns the filepath
 writeToTempFile :: String -> IO FilePath

--- a/src/full/Agda/Utils/IO/UTF8.hs
+++ b/src/full/Agda/Utils/IO/UTF8.hs
@@ -13,11 +13,11 @@ module Agda.Utils.IO.UTF8
 import Control.Exception
 import Data.Maybe (fromMaybe)
 import Data.Text.Lazy (Text)
-import qualified Data.Text.Lazy as T
-import qualified Data.Text.Lazy.Encoding as T
-import qualified Data.Text.Lazy.IO as T
-import qualified Data.ByteString.Lazy as BS
-import qualified System.IO as IO
+import Data.Text.Lazy qualified as T
+import Data.Text.Lazy.Encoding qualified as T
+import Data.Text.Lazy.IO qualified as T
+import Data.ByteString.Lazy qualified as BS
+import System.IO qualified as IO
 
 -- | Converts many character sequences which may be interpreted as
 -- line or paragraph separators into '\n'.

--- a/src/full/Agda/Utils/IORef/Strict.hs
+++ b/src/full/Agda/Utils/IORef/Strict.hs
@@ -4,7 +4,7 @@
 -- This module should be imported qualified, ala
 --
 -- @
--- import qualified Agda.Utils.IORef.Strict as Strict
+-- import Agda.Utils.IORef.Strict qualified as Strict
 -- @
 module Agda.Utils.IORef.Strict
   (
@@ -22,7 +22,7 @@ module Agda.Utils.IORef.Strict
 import Control.Exception (evaluate)
 
 import Data.Coerce
-import qualified Data.IORef as Lazy
+import Data.IORef qualified as Lazy
 
 
 -- $strictIORef

--- a/src/full/Agda/Utils/IntSet/Infinite.hs
+++ b/src/full/Agda/Utils/IntSet/Infinite.hs
@@ -13,7 +13,7 @@ module Agda.Utils.IntSet.Infinite
 
 
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 
 -- | Represents a set of integers.
 --   Invariants:

--- a/src/full/Agda/Utils/Lens.hs
+++ b/src/full/Agda/Utils/Lens.hs
@@ -15,9 +15,9 @@ import Control.Monad.State
 import Control.Monad.Reader
 
 import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 
 import Data.Functor.Identity
 

--- a/src/full/Agda/Utils/List.hs
+++ b/src/full/Agda/Utils/List.hs
@@ -12,24 +12,24 @@ import Data.List as X (uncons)
 
 import Control.Monad (filterM, forM)
 import Control.Applicative (Alternative, (<|>))
-import qualified Control.Applicative as A
+import Control.Applicative qualified as A
 
 import Data.Array (Array, array, listArray)
-import qualified Data.Array as Array
+import Data.Array qualified as Array
 import Data.Bifunctor
 import Data.Function (on)
 import Data.Hashable
 import Data.List.Split (splitOn)
-import qualified Data.List as List
-import qualified Data.List.NonEmpty as List1
+import Data.List qualified as List
+import Data.List.NonEmpty qualified as List1
 import Data.List.NonEmpty (pattern (:|), (<|))
 import Data.Maybe
-import qualified Data.Map as Map
-import qualified Data.HashMap.Strict as HMap
-import qualified Data.Set as Set
+import Data.Map qualified as Map
+import Data.HashMap.Strict qualified as HMap
+import Data.Set qualified as Set
 import Data.Strict.These
 
-import qualified Agda.Utils.Bag as Bag
+import Agda.Utils.Bag qualified as Bag
 import Agda.Utils.CallStack.Base
 import Agda.Utils.Function (applyWhen)
 import Agda.Utils.Functor  ((<.>))

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -9,8 +9,8 @@
 --
 --     {-# LANGUAGE PatternSynonyms #-}
 --
---     import           Agda.Utils.List1 (List1, pattern (:|))
---     import qualified Agda.Utils.List1 as List1
+--     import Agda.Utils.List1 (List1, pattern (:|))
+--     import Agda.Utils.List1 qualified as List1
 --
 --   @
 
@@ -28,15 +28,15 @@ import Prelude hiding (filter, unzip)
 
 import Control.Arrow ((&&&))
 import Control.Monad (filterM)
-import qualified Control.Monad as List (zipWithM, zipWithM_)
+import Control.Monad qualified as List (zipWithM, zipWithM_)
 
-import qualified Data.Either as Either
+import Data.Either qualified as Either
 import Data.Function ( on )
-import qualified Data.List as List
-import qualified Data.Maybe as Maybe
+import Data.List qualified as List
+import Data.Maybe qualified as Maybe
 
 import Data.List.NonEmpty as List1 hiding (fromList, toList, unzip)
-import qualified Data.List.NonEmpty as List1 (toList)
+import Data.List.NonEmpty qualified as List1 (toList)
 
 -- Prevent warning -Wx-data-list-nonempty-unzip
 #if MIN_VERSION_base(4,19,0)
@@ -49,7 +49,7 @@ import GHC.Exts as IsList ( IsList(..) )
 
 import Agda.Utils.Functor ((<.>), (<&>))
 import Agda.Utils.Null (Null(..))
-import qualified Agda.Utils.List as List
+import Agda.Utils.List qualified as List
 
 -- Set up doctest.
 -- $setup

--- a/src/full/Agda/Utils/List2.hs
+++ b/src/full/Agda/Utils/List2.hs
@@ -5,7 +5,7 @@
 --   Import as:
 --   @
 --      import Agda.Utils.List2 (List2(List2))
---      import qualified Agda.Utils.List2 as List2
+--      import Agda.Utils.List2 qualified as List2
 --   @
 
 module Agda.Utils.List2
@@ -18,14 +18,14 @@ import Prelude hiding ( zip, zipWith )
 import Control.DeepSeq
 import Control.Monad                   ( (<=<) )
 
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Semigroup (sconcat)
 
 import GHC.Exts                        ( IsList(..) )
-import qualified GHC.Exts  as Reexport ( toList )
+import GHC.Exts qualified  as Reexport ( toList )
 
 import Agda.Utils.List1                ( List1, pattern (:|) )
-import qualified Agda.Utils.List1 as List1
+import Agda.Utils.List1 qualified as List1
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/Utils/Map1.hs
+++ b/src/full/Agda/Utils/Map1.hs
@@ -34,3 +34,12 @@ unlessNull = flip $ Map1.withNonEmpty $ pure ()
 unlessNullM :: Monad m => m (Map k a) -> (Map1 k a -> m ()) -> m ()
 unlessNullM m k = m >>= (`unlessNull` k)
 {-# INLINE unlessNullM #-}
+
+-- | Map both keys and values where the map is monotonic for the keys.
+--
+-- A function that maps both keys and values while preserving
+-- the map structure is missing in "Data.Map.NonEmpty".
+-- We implement it simplistically here
+-- as a combination of 'Map1.mapKeysMonotonic' and 'fmap'.
+mapKeysAndValuesMonotonic :: (k -> k) -> (a -> b) -> Map1 k a -> Map1 k b
+mapKeysAndValuesMonotonic f g = Map1.mapKeysMonotonic f . fmap g

--- a/src/full/Agda/Utils/Map1.hs
+++ b/src/full/Agda/Utils/Map1.hs
@@ -5,8 +5,8 @@
 --   Import:
 --   @
 --
---     import           Agda.Utils.Map1 (Map1)
---     import qualified Agda.Utils.Map1 as Map1
+--     import Agda.Utils.Map1 (Map1)
+--     import Agda.Utils.Map1 qualified as Map1
 --
 --   @
 

--- a/src/full/Agda/Utils/Maybe.hs
+++ b/src/full/Agda/Utils/Maybe.hs
@@ -16,7 +16,7 @@ import Control.Monad.Trans.Maybe
 
 import Data.Maybe
 
-import qualified Agda.Utils.Null as Null
+import Agda.Utils.Null qualified as Null
 
 -- * Conversion.
 

--- a/src/full/Agda/Utils/Maybe/Strict.hs
+++ b/src/full/Agda/Utils/Maybe/Strict.hs
@@ -4,7 +4,7 @@
 --
 --   Import qualified, as in
 --   @
---     import qualified Agda.Utils.Maybe.Strict as Strict
+--     import Agda.Utils.Maybe.Strict qualified as Strict
 --   @
 
 module Agda.Utils.Maybe.Strict
@@ -15,7 +15,7 @@ module Agda.Utils.Maybe.Strict
 
 import Prelude hiding (Maybe(..), maybe)
 
-import qualified Data.Maybe as Lazy
+import Data.Maybe qualified as Lazy
 import Data.Strict.Classes
 import Data.Strict.Maybe
 

--- a/src/full/Agda/Utils/Memo.hs
+++ b/src/full/Agda/Utils/Memo.hs
@@ -5,8 +5,8 @@ module Agda.Utils.Memo where
 import Control.Monad.State
 import System.IO.Unsafe
 import Data.IORef
-import qualified Data.Map as Map
-import qualified Data.HashMap.Strict as HMap
+import Data.Map qualified as Map
+import Data.HashMap.Strict qualified as HMap
 import Data.Hashable
 
 import Agda.Utils.Lens

--- a/src/full/Agda/Utils/MinimalArray/Lifted.hs
+++ b/src/full/Agda/Utils/MinimalArray/Lifted.hs
@@ -5,14 +5,14 @@
 
 module Agda.Utils.MinimalArray.Lifted where
 
-import qualified Data.Foldable
+import Data.Foldable qualified
 import GHC.Exts
-import qualified GHC.Arr as GHC
-import qualified Data.Primitive.Array as A
+import GHC.Arr qualified as GHC
+import Data.Primitive.Array qualified as A
 import Control.Monad.Primitive
 
 import Agda.Utils.Serialize
-import qualified Agda.Utils.Serialize as Ser
+import Agda.Utils.Serialize qualified as Ser
 
 newtype Array a = Array {unwrap :: A.Array a}
   deriving (Eq, Show, IsList, Functor, Foldable, Traversable)

--- a/src/full/Agda/Utils/MinimalArray/MutableLifted.hs
+++ b/src/full/Agda/Utils/MinimalArray/MutableLifted.hs
@@ -1,11 +1,11 @@
 
 module Agda.Utils.MinimalArray.MutableLifted where
 
-import qualified GHC.Arr as GHC
-import qualified GHC.IOArray as GHC
+import GHC.Arr qualified as GHC
+import GHC.IOArray qualified as GHC
 import Data.Coerce
-import qualified Data.Primitive.Array as A
-import qualified Agda.Utils.MinimalArray.Lifted as LA
+import Data.Primitive.Array qualified as A
+import Agda.Utils.MinimalArray.Lifted qualified as LA
 import Control.Monad.Primitive
 
 newtype Array s a = Array {unwrap :: A.MutableArray s a}

--- a/src/full/Agda/Utils/MinimalArray/MutablePrim.hs
+++ b/src/full/Agda/Utils/MinimalArray/MutablePrim.hs
@@ -2,8 +2,8 @@
 module Agda.Utils.MinimalArray.MutablePrim where
 
 import Data.Coerce
-import qualified Data.Primitive.PrimArray as A
-import qualified Agda.Utils.MinimalArray.Prim as PA
+import Data.Primitive.PrimArray qualified as A
+import Agda.Utils.MinimalArray.Prim qualified as PA
 import Control.Monad.Primitive
 import Data.Primitive.Types
 

--- a/src/full/Agda/Utils/MinimalArray/Prim.hs
+++ b/src/full/Agda/Utils/MinimalArray/Prim.hs
@@ -3,7 +3,7 @@
 module Agda.Utils.MinimalArray.Prim where
 
 import GHC.Exts
-import qualified Data.Primitive.PrimArray as A
+import Data.Primitive.PrimArray qualified as A
 import Data.Primitive.Types
 import Control.Monad.Primitive
 

--- a/src/full/Agda/Utils/Null.hs
+++ b/src/full/Agda/Utils/Null.hs
@@ -19,39 +19,39 @@ import Control.Monad.Trans.Maybe
 
 import Data.Maybe             ( isNothing )
 
-import qualified Data.ByteString.Char8 as ByteStringChar8
-import qualified Data.ByteString.Lazy as ByteStringLazy
+import Data.ByteString.Char8 qualified as ByteStringChar8
+import Data.ByteString.Lazy qualified as ByteStringLazy
 
 import Data.EnumMap (EnumMap)
-import qualified Data.EnumMap as EnumMap
+import Data.EnumMap qualified as EnumMap
 import Data.EnumSet (EnumSet)
-import qualified Data.EnumSet as EnumSet
+import Data.EnumSet qualified as EnumSet
 import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HashMap
+import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet (HashSet)
-import qualified Data.HashSet as HashSet
+import Data.HashSet qualified as HashSet
 import Data.IntMap (IntMap)
-import qualified Data.IntMap as IntMap
+import Data.IntMap qualified as IntMap
 import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
-import qualified Data.List as List
+import Data.IntSet qualified as IntSet
+import Data.List qualified as List
 import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
+import Data.Sequence qualified as Seq
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Data.Word (Word32, Word64)
 
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 import Text.PrettyPrint.Annotated (Doc, isEmpty)
 
 import Agda.Utils.Bag (Bag)
-import qualified Agda.Utils.Bag as Bag
+import Agda.Utils.Bag qualified as Bag
 import Agda.Utils.VarSet (VarSet)
-import qualified Agda.Utils.VarSet as VarSet
+import Agda.Utils.VarSet qualified as VarSet
 
 import Agda.Utils.Unsafe (unsafeComparePointers)
 import Agda.Utils.Impossible

--- a/src/full/Agda/Utils/Parser/MemoisedCPS.hs
+++ b/src/full/Agda/Utils/Parser/MemoisedCPS.hs
@@ -37,16 +37,16 @@ import Control.Monad.State.Strict (State, evalState, runState, get, modify')
 
 import Data.Array
 import Data.Hashable
-import qualified Data.HashMap.Strict as Map
+import Data.HashMap.Strict qualified as Map
 import Data.HashMap.Strict (HashMap)
 
 
-import qualified Data.IntMap.Strict as IntMap
+import Data.IntMap.Strict qualified as IntMap
 import Data.IntMap.Strict (IntMap)
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Maybe
 
-import qualified Agda.Utils.Null as Null
+import Agda.Utils.Null qualified as Null
 import Agda.Syntax.Common.Pretty hiding (annotate)
 
 import Agda.Utils.Impossible

--- a/src/full/Agda/Utils/PartialOrd.hs
+++ b/src/full/Agda/Utils/PartialOrd.hs
@@ -4,7 +4,7 @@ module Agda.Utils.PartialOrd where
 
 import Data.Maybe
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 
 -- import Agda.Utils.List
 

--- a/src/full/Agda/Utils/Permutation.hs
+++ b/src/full/Agda/Utils/Permutation.hs
@@ -9,11 +9,11 @@ import Control.Monad (filterM)
 
 import Data.Array.Unboxed
 import Data.IntMap (IntMap)
-import qualified Data.IntMap as IntMap
-import qualified Data.IntMap.Strict as IntMapS
-import qualified Data.IntSet as IntSet
+import Data.IntMap qualified as IntMap
+import Data.IntMap.Strict qualified as IntMapS
+import Data.IntSet qualified as IntSet
 import Data.Functor.Identity
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Maybe
 
 import GHC.Generics (Generic)

--- a/src/full/Agda/Utils/RangeMap.hs
+++ b/src/full/Agda/Utils/RangeMap.hs
@@ -19,10 +19,10 @@ import Prelude hiding (null, splitAt)
 import Control.DeepSeq
 
 import Data.IntMap (IntMap)
-import qualified Data.IntMap as IntMap
+import Data.IntMap qualified as IntMap
 
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 
 import Agda.Utils.Range
 import Agda.Utils.List

--- a/src/full/Agda/Utils/Serialize.hs
+++ b/src/full/Agda/Utils/Serialize.hs
@@ -31,14 +31,14 @@ import GHC.Word
 import GHC.Num.Integer
 import System.IO.Unsafe
 
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Internal as B
-import qualified Data.Text as T
-import qualified Data.Text.Array as T
-import qualified Data.Text.Internal as T
-import qualified Data.Text.Internal.Lazy as TL
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Unsafe as T
+import Data.ByteString qualified as B
+import Data.ByteString.Internal qualified as B
+import Data.Text qualified as T
+import Data.Text.Array qualified as T
+import Data.Text.Internal qualified as T
+import Data.Text.Internal.Lazy qualified as TL
+import Data.Text.Lazy qualified as TL
+import Data.Text.Unsafe qualified as T
 
 import Data.Bits
 

--- a/src/full/Agda/Utils/Set1.hs
+++ b/src/full/Agda/Utils/Set1.hs
@@ -5,8 +5,8 @@
 --   Import:
 --   @
 --
---     import           Agda.Utils.Set1 (Set1)
---     import qualified Agda.Utils.Set1 as Set1
+--     import Agda.Utils.Set1 (Set1)
+--     import Agda.Utils.Set1 qualified as Set1
 --
 --   @
 

--- a/src/full/Agda/Utils/Singleton.hs
+++ b/src/full/Agda/Utils/Singleton.hs
@@ -26,6 +26,8 @@ import Data.IntSet qualified as IntSet
 
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Data.Map.NonEmpty (NEMap)
+import Data.Map.NonEmpty qualified as Map1
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import Data.Set (Set)
@@ -146,11 +148,14 @@ instance SmallSetElement a => Singleton a (SmallSet a) where
   singleton = SmallSet.singleton
   {-# INLINE singleton #-}
 
+instance Singleton (Int,a) (IntMap a)                  where
+  singleton = uncurry IntMap.singleton
+  {-# INLINE singleton #-}
 instance Singleton (k  ,a) (Map  k a)                  where
   singleton = uncurry Map.singleton
   {-# INLINE singleton #-}
-instance Singleton (Int,a) (IntMap a)                  where
-  singleton = uncurry IntMap.singleton
+instance Singleton (k  ,a) (NEMap k a)                 where
+  singleton = uncurry Map1.singleton
   {-# INLINE singleton #-}
 
 instance Hashable k => Singleton k     (HashSet   k)   where

--- a/src/full/Agda/Utils/Singleton.hs
+++ b/src/full/Agda/Utils/Singleton.hs
@@ -7,37 +7,37 @@ import Data.Maybe
 import Data.Monoid (Endo(..))
 
 import Data.DList (DList)
-import qualified Data.DList as DL
+import Data.DList qualified as DL
 import Data.Hashable (Hashable)
 import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HashMap
+import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet (HashSet)
-import qualified Data.HashSet as HashSet
+import Data.HashSet qualified as HashSet
 import Data.List.NonEmpty (NonEmpty(..))
 
 import Data.EnumMap (EnumMap)
-import qualified Data.EnumMap as EnumMap
+import Data.EnumMap qualified as EnumMap
 import Data.EnumSet (EnumSet)
-import qualified Data.EnumSet as EnumSet
+import Data.EnumSet qualified as EnumSet
 import Data.IntMap (IntMap)
-import qualified Data.IntMap as IntMap
+import Data.IntMap qualified as IntMap
 import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
+import Data.IntSet qualified as IntSet
 
 import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
+import Data.Sequence qualified as Seq
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Data.Set.NonEmpty (NESet)
-import qualified Data.Set.NonEmpty as Set1
+import Data.Set.NonEmpty qualified as Set1
 
 import Agda.Utils.Null     (Null, empty)
 import Agda.Utils.SmallSet (SmallSet, SmallSetElement)
-import qualified Agda.Utils.SmallSet as SmallSet
+import Agda.Utils.SmallSet qualified as SmallSet
 import Agda.Utils.VarSet (VarSet)
-import qualified Agda.Utils.VarSet as VarSet
+import Agda.Utils.VarSet qualified as VarSet
 
 -- | A create-only possibly empty collection is a monoid with the possibility
 --   to inject elements.

--- a/src/full/Agda/Utils/Size.hs
+++ b/src/full/Agda/Utils/Size.hs
@@ -23,6 +23,7 @@ import Data.Set            (Set)
 import Data.Sequence       (Seq)
 
 import Agda.Utils.List1    (List1)
+import Agda.Utils.Map1     (Map1)
 import Agda.Utils.Set1     (Set1)
 import Agda.Utils.Null
 
@@ -58,6 +59,7 @@ instance Sized (HashSet a)
 instance Sized (IntMap a)
 instance Sized (List1 a)
 instance Sized (Map k a)
+instance Sized (Map1 k a)
 instance Sized (Seq a)
 instance Sized IntSet where
   size = IntSet.size

--- a/src/full/Agda/Utils/Size.hs
+++ b/src/full/Agda/Utils/Size.hs
@@ -17,7 +17,7 @@ import Data.HashMap.Strict (HashMap)
 import Data.HashSet        (HashSet)
 import Data.IntMap         (IntMap)
 import Data.IntSet         (IntSet)
-import qualified Data.IntSet as IntSet
+import Data.IntSet qualified as IntSet
 import Data.Map            (Map)
 import Data.Set            (Set)
 import Data.Sequence       (Seq)

--- a/src/full/Agda/Utils/SmallSet.hs
+++ b/src/full/Agda/Utils/SmallSet.hs
@@ -10,8 +10,8 @@
 --
 -- Import as:
 -- @
---    import qualified Agda.Utils.SmallSet as SmallSet
 --    import Agda.Utils.SmallSet (SmallSet)
+--    import Agda.Utils.SmallSet qualified as SmallSet
 -- @
 
 module Agda.Utils.SmallSet
@@ -45,10 +45,10 @@ import Data.Word (Word64)
 import Data.List (foldl')
 #endif
 import Data.Bits hiding (complement)
-import qualified Data.Bits as Bits
+import Data.Bits qualified as Bits
 import Data.Ix
 
-import qualified Agda.Utils.Null as Null
+import Agda.Utils.Null qualified as Null
 
 -- | An element in a small set.
 --

--- a/src/full/Agda/Utils/String.hs
+++ b/src/full/Agda/Utils/String.hs
@@ -9,7 +9,7 @@ import Control.Monad.Trans.Maybe
 import Control.Monad.Writer
 
 import Data.Char
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.String
 
 import Agda.Utils.Function (applyUnless)

--- a/src/full/Agda/Utils/Suffix.hs
+++ b/src/full/Agda/Utils/Suffix.hs
@@ -3,7 +3,7 @@
 module Agda.Utils.Suffix where
 
 import Data.Char
-import qualified Data.List as List
+import Data.List qualified as List
 
 import Agda.Utils.Impossible
 

--- a/src/full/Agda/Utils/Time.hs
+++ b/src/full/Agda/Utils/Time.hs
@@ -16,10 +16,10 @@ module Agda.Utils.Time
 
 import Control.DeepSeq
 import Control.Monad.Trans
-import qualified System.CPUTime as CPU
+import System.CPUTime qualified as CPU
 
 
-import qualified Data.Time
+import Data.Time qualified
 
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.String

--- a/src/full/Agda/Utils/Trie.hs
+++ b/src/full/Agda/Utils/Trie.hs
@@ -29,13 +29,13 @@ import Prelude hiding (null, lookup, filter)
 import Control.DeepSeq
 
 import Data.Function (on)
-import qualified Data.Maybe as Lazy
+import Data.Maybe qualified as Lazy
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 
-import qualified Data.List as List
+import Data.List qualified as List
 
-import qualified Agda.Utils.Maybe.Strict as Strict
+import Agda.Utils.Maybe.Strict qualified as Strict
 import Agda.Utils.Null
 import Agda.Utils.Lens
 

--- a/src/full/Agda/Utils/VarSet.hs
+++ b/src/full/Agda/Utils/VarSet.hs
@@ -105,8 +105,8 @@ module Agda.Utils.VarSet
 import Control.DeepSeq
 import Control.Monad
 
-import qualified Data.ByteString as BS
-import qualified Data.Foldable as Fold
+import Data.ByteString qualified as BS
+import Data.Foldable qualified as Fold
 import Data.Hashable
 import Data.Word
 
@@ -117,7 +117,7 @@ import GHC.Num.WordArray
 import Debug.Trace
 
 import Prelude (Num(..), Show(..))
-import qualified Prelude as P
+import Prelude qualified as P
 
 import Agda.Utils.ByteArray
 import Agda.Utils.Word

--- a/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
+++ b/test/Fail/Issue1944-UnappliedOverloadedProjectionNotRecord.err
@@ -4,4 +4,13 @@ principal argument has type A₁ while it should be of record type
   candidates in scope:
 - f : {B : Set} → R B → B
 - f : {B : Set} → S B → B
+Issue1944-UnappliedOverloadedProjectionNotRecord.R.f is in scope as
+  * a record field Issue1944-UnappliedOverloadedProjectionNotRecord.R.f
+    brought into scope by
+    - the opening of R at Issue1944-UnappliedOverloadedProjectionNotRecord.agda:8.6-7
+    - its definition at Issue1944-UnappliedOverloadedProjectionNotRecord.agda:7.9-10
+  * a record field Issue1944-UnappliedOverloadedProjectionNotRecord.S.f
+    brought into scope by
+    - the opening of S at Issue1944-UnappliedOverloadedProjectionNotRecord.agda:12.6-7
+    - its definition at Issue1944-UnappliedOverloadedProjectionNotRecord.agda:11.9-10
 when checking that the expression f has type A₁ → A₁

--- a/test/Fail/Issue1944-instance.err
+++ b/test/Fail/Issue1944-instance.err
@@ -2,6 +2,14 @@ Issue1944-instance.agda:23.14-20: error: [AmbiguousOverloadedProjection]
 Cannot resolve overloaded projection test because
 principal argument x has type A while it should be of record type
   candidates in scope:
-- test : ({A = A₁ : Set} ⦃ r : Testable A₁ ⦄ → A₁ → Bool)
 - test : ({A = A₁ : Set} → Testable A₁ → A₁ → Bool)
+- test : ({A = A₁ : Set} ⦃ r : Testable A₁ ⦄ → A₁ → Bool)
+Issue1944-instance.Testable.test is in scope as
+  * a record field Issue1944-instance.Testable.test
+    brought into scope by
+    - the opening of Testable at Issue1944-instance.agda:17.6-14
+    - its definition at Issue1944-instance.agda:15.5-9
+  * a record field Issue1944-instance._.test brought into scope by
+    - the application of Testable at Issue1944-instance.agda:16.6-14
+    - its definition at Issue1944-instance.agda:15.5-9
 when checking that the expression test x has type Bool

--- a/test/Fail/Issue2423.err
+++ b/test/Fail/Issue2423.err
@@ -1,4 +1,4 @@
 Issue2423.agda:24.8-10: error: [CannotEliminateWithProjection]
-Cannot eliminate type  S  with projection  S._.f
+Cannot eliminate type  S  with projection  R.f
 when checking the clause left hand side
 test s .f

--- a/test/Fail/Issue2797.err
+++ b/test/Fail/Issue2797.err
@@ -4,4 +4,11 @@ no matching candidate found
   candidates in scope:
 - nat : Dummy → Set
 - nat : .S → Nat
+Issue2797.Dummy.nat is in scope as
+  * a record field Issue2797.Dummy.nat brought into scope by
+    - the opening of Dummy at Issue2797.agda:14.6-11
+    - its definition at Issue2797.agda:13.9-12
+  * a record field Issue2797.S.nat brought into scope by
+    - the opening of S at Issue2797.agda:18.6-7
+    - its definition at Issue2797.agda:17.10-13
 when checking that the expression s .nat has type Nat

--- a/test/Fail/Issue4924.err
+++ b/test/Fail/Issue4924.err
@@ -4,4 +4,11 @@ principal argument pri has type A while it should be of record type
   candidates in scope:
 - f : A → A
 - f : B → B
+Issue4924.f is in scope as
+  * a record field Issue4924._._.f brought into scope by
+    - the application of R at Issue4924.agda:8.8-9
+    - its definition at Issue4924.agda:5.5-6
+  * a record field Issue4924._._.f brought into scope by
+    - the application of R at Issue4924.agda:9.8-9
+    - its definition at Issue4924.agda:5.5-6
 when checking that the expression f pri has type A

--- a/test/Internal/TypeChecking/Generators.hs
+++ b/test/Internal/TypeChecking/Generators.hs
@@ -14,7 +14,7 @@ import Agda.Syntax.Position
 import Agda.Syntax.Common
 import Agda.Syntax.Literal
 import Agda.Syntax.Fixity
-import Agda.Syntax.Internal as I
+import Agda.Syntax.Internal as I hiding (ConName)
 import qualified Agda.Syntax.Concrete.Name as C
 
 import Agda.TypeChecking.Free

--- a/test/Internal/TypeChecking/Generators.hs
+++ b/test/Internal/TypeChecking/Generators.hs
@@ -151,7 +151,7 @@ makeConfiguration ds cs ps vs = TermConf
       n <- tick
       return $ QName { qnameModule = MName []
                      , qnameName   = Name
-                        { nameId          = NameId n (ModuleNameHash 1)
+                        { _nameId         = NameId n (ModuleNameHash 1)
                         , nameConcrete    = C.simpleName s
                         , nameCanonical   = C.simpleName s
                         , nameBindingSite = noRange

--- a/test/Succeed/InvalidDisplayForm.warn
+++ b/test/Succeed/InvalidDisplayForm.warn
@@ -1,3 +1,4 @@
+
 InvalidDisplayForm.agda:8.1-22: warning: -W[no]InvalidDisplayForm
 Ignoring invalid display form for R because it is recursive
 when checking the pragma DISPLAY R = R
@@ -112,7 +113,7 @@ when checking the pragma DISPLAY L4 (Set = Set) = Set
 
 InvalidDisplayForm.agda:50.1-37: warning: -W[no]InvalidDisplayForm
 Ignoring invalid display form for L5 because its left-hand side
-contains an ambiguous constructor: InvalidDisplayForm.D.c,
+contains an ambiguous constructor: InvalidDisplayForm.D.c;
 InvalidDisplayForm.E.c
 when checking the pragma DISPLAY L5 p = Set
 
@@ -264,7 +265,7 @@ when checking the pragma DISPLAY L4 (Set = Set) = Set
 
 InvalidDisplayForm.agda:50.1-37: warning: -W[no]InvalidDisplayForm
 Ignoring invalid display form for L5 because its left-hand side
-contains an ambiguous constructor: InvalidDisplayForm.D.c,
+contains an ambiguous constructor: InvalidDisplayForm.D.c;
 InvalidDisplayForm.E.c
 when checking the pragma DISPLAY L5 p = Set
 

--- a/test/Succeed/Issue3734.warn
+++ b/test/Succeed/Issue3734.warn
@@ -1,3 +1,4 @@
+
 Issue3734.agda:19.5-6: warning: -W[no]UserWarning
 Used constructor a
 when checking that the expression a has type A

--- a/test/Succeed/PatternSynonymImports.agda
+++ b/test/Succeed/PatternSynonymImports.agda
@@ -8,3 +8,14 @@ two = ss zzz
 
 list : List ℕ
 list = 1 ∷ []
+
+-- Andreas, 2026-02-22
+-- Overloading of pattern synonyms is allowed.
+
+pattern sz = suc zzz
+
+-- This overloaded pattern synonym resolves to the same thing
+-- than its original definition, so this should be fine.
+
+overloaded : ℕ
+overloaded = sz


### PR DESCRIPTION
There are some refactorings to move `AbstractName` to `Agda.Syntax.Abstract.Name` and remove matches on the `AmbQ` constructor in preparation to change the representation of `AmbiguousQName`.  Further I introduced a data type for `PatternSynDefn` (which was a type synonym for a tuple).

- **[refactor] Abstract.Name: types first, then operations, then instances**
  It is good to have the types first and densely together to get a good
  overview...
  

- **[refactor] move Abstract{Name,Module} to Agda.Syntax.Abstract.Name**
  

- **[refactor] Replace most matches on AmbQ by destructor; use semi in error**
  

- **[refactor] Make PatternSynDefn a data type**
  

- **[refactor] use AmbiguousQName instead of (List1 QName)**
  
The change of `AmbiguousQName` and its use in errors about ambiguous projections is in the final commit:

- **Fix #4780 by storing lineage (`AbstractName`) in `AmbiguousQName`s**
  Ambiguous names constructed by the scope checker are now equipped with
  lineage information, for better error reporting when ambiguity cannot
  be resolved.
  
  This lineage information is not stored by serialization.
  
  There are sources of `AmbiguousQName` that do not come with lineage
  information:
  
  - from `QName` of a builtin
  - from merging two pattern synonym definitions
  - from unquoting
  
  Thus, we cannot simply make `AmbiguousQName` a list of `AbstractName`.
  