### PR TITLE
[ fix #8423 ] Only forceNoAbs if piSort arguments are not blocked

### DIFF
--- a/src/full/Agda/TypeChecking/Reduce.hs
+++ b/src/full/Agda/TypeChecking/Reduce.hs
@@ -430,37 +430,31 @@ instance Reduce Sort where
       let done | MetaS x _ <- s = return $ blocked x s
                | otherwise      = return $ notBlocked s
       case s of
-        -- In theory we should just reduce the sort arguments of PiSort
-        -- and then call piSort'. However, we also want to reduce the
-        -- codomain sort to make it non-dependent when possible.
-        -- So we first call forceNoAbs and in case we are dealing with a
-        -- proper Abs we call piSortAbs directly.
-        PiSort a s1 s2Abs -> do
-          let dom = El s1 <$> a
-          forceNoAbsSort dom s2Abs >>= \case
-            -- If the codomain sort is non-dependent, we reduce to a FunSort
-            Right s2 -> reduceB' $ FunSort s1 s2
-            Left (s2Abs, flexRig) -> do
+        PiSort a s1 s2Abs -> reduceB' (s1 , s2Abs) >>= \case
+          -- If either the domain or codomain sort is blocked, there is no point
+          -- in doing the free variable check since even if we manage to reduce
+          -- to a FunSort, it would still be blocked. And normalizing anyway in
+          -- this case leads to exponential behavior (see #8423).
+          Blocked b (s1 , s2Abs) -> return $! blockedOn b $ PiSort a s1 s2Abs
+          NotBlocked _ (s1 , s2Abs) -> do
+            -- In theory we should just call piSort' here. However, we also want
+            -- to reduce the codomain sort to make it non-dependent when
+            -- possible. So we use forceNoAbs and in case we are dealing with a
+            -- proper Abs we call piSortAbs directly.
+            let dom = El s1 <$> a
+            forceNoAbsSort dom s2Abs >>= \case
+              -- If the codomain sort is non-dependent, we reduce to a FunSort
+              Right s2 -> reduceB' $ FunSort s1 s2
               -- For a (possibly) properly dependent PiSort, we call piSortAbs.
-              -- It does not reduce the sorts, so we do that first.
-              bs1 <- reduceB' s1
-              bs2Abs <- mapAbstraction dom reduceB' s2Abs
-              let -- reduced domain and codomain sorts
-                  s1 = ignoreBlocking bs1
-                  s2Abs = fmap ignoreBlocking bs2Abs
-                  -- blocker from free variable occurrence check
-                  blockOcc = flexRigToBlocker flexRig
-                  -- blocker from reducing sort arguments
-                  blockRed = getBlocker $ void bs1 <> void (unAbs bs2Abs)
-                  -- we unblock when either of these might let us make progress
-                  block = unblockOnEither blockOcc blockRed
-              case piSortAbs a s1 s2Abs flexRig CodomainNormalised of
-                -- We already have all blocking information from reduction,
-                -- so we discard the blocking tag from piSortAbs.
-                Left _ -> return $! blockedOn block $ PiSort a s1 s2Abs
-                -- The only sort that piSortAbs can reduce is Inf,
-                -- so there is no need to try reducing it further.
-                Right s -> return $! notBlocked s
+              Left (s2Abs, flexRig) -> do
+                let blockOcc = flexRigToBlocker flexRig
+                case piSortAbs a s1 s2Abs flexRig CodomainNormalised of
+                  -- We already know the sorts themselves are not blocked,
+                  -- so the only possible blocker comes from the free variable check
+                  Left _ -> return $! blockedOn blockOcc $ PiSort a s1 s2Abs
+                  -- The only sort that piSortAbs can reduce is Inf,
+                  -- so there is no need to try reducing it further.
+                  Right s -> return $! notBlocked s
         FunSort s1 s2 -> reduceB' (s1 , s2) >>= \case
           Blocked b (s1',s2') -> return $ Blocked b $ FunSort s1' s2'
           NotBlocked _ (s1',s2') -> funSortM' s1' s2' >>= \case

--- a/test/Fail/Issue399.err
+++ b/test/Fail/Issue399.err
@@ -13,7 +13,7 @@ Failed to solve the following constraints:
      funSort (_7 (m = m) (mzero = mzero))
      (funSort (_10 (m = m) (mzero = mzero)) Set))
     =< Set₁
-    (blocked on any(all(_7, _10), _7))
+    (blocked on all(_7, _10))
   piSort Set₁ (λ a → funSort (_2 (m = m)) Set) =< Set₁
     (blocked on _2)
 

--- a/test/Succeed/Issue8423.agda
+++ b/test/Succeed/Issue8423.agda
@@ -1,0 +1,17 @@
+open import Agda.Builtin.Equality
+open import Agda.Primitive
+
+data D (a : Level) : Set a where
+  c : D a
+
+F :
+  (A : Set) (_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ : A) →
+  _≡_ {A = D lzero} c c
+F A x _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ = g x
+  where
+  f : A → D _
+  f _ = c
+
+  g : ∀ x → f x ≡ f x
+  g x with x
+  … | _ = refl


### PR DESCRIPTION
This fixes #8423.