### PR TITLE
Fix #8425: also apply reordering to leftInv

### DIFF
--- a/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
+++ b/src/full/Agda/TypeChecking/Rules/LHS/Unify/LeftInverse.hs
@@ -415,7 +415,7 @@ buildEquiv (DUnificationStep st step@(DSolution k ty fx tm side) output) next = 
             fmap absBody $ bind "i" $ \ i' -> do
               let (+++) m = liftM2 (++) m
                   i = cl (lift primINeg) <@> i'
-              do
+              fmap (permute (invertP __IMPOSSIBLE__ permw)) $
                 gamma1_args +++ (take 1 `fmap` csingl i +++ ((lazyAbsApp <$> xi0f <*> i) +++ (drop 1 `fmap` csingl i +++ (lazyAbsApp <$> xi1f <*> i))))
           return (tau,leftInv,phi)
         iz <- lift $ primIZero

--- a/test/Succeed/Issue8425.agda
+++ b/test/Succeed/Issue8425.agda
@@ -1,0 +1,13 @@
+{-# OPTIONS --cubical-compatible --erasure #-}
+
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Unit
+
+data D : @0 ⊤ → Set where
+  c : (x : ⊤) → D x
+
+-- The transpX clause for F was still ill-typed after the fix of #7139
+-- because the left inverse *proof* (leftInv) was not permuted correctly.
+-- (This was reported as a "not usable at modality" error.)
+F : (@0 x : ⊤) → @0 x ≡ tt → D x → Set₁
+F _ _ (c _) = Set


### PR DESCRIPTION
Fixes #8425.

The fix to #7139 (#8376) correctly reordered the target context of the substitution `Γ ⊢ τ : Δ`, but not that of the left inverse proof `leftInv`. Since this is a round-trip Γ → Δ → Γ, we need to apply the permutation again, in reverse, at the end.