### PR TITLE
Fix #3355: NO_POSITIVITY_CHECK pragmas in where and record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,14 @@ Pragmas and options
   It can be overwritten by `--color=always`.
   See also https://no-color.org/ .
 
-* New option `--quote-metas` to allow for `quoteTerm` constraints to be solved even when the quoted term contains unsolved metas. This allows for elaborating macro applications with quoted arguments that still have interactive holes in them. See the [quote metas documentation](https://agda.readthedocs.io/en/v2.9.0/language/reflection.html#quote-metas).
+* New option `--quote-metas` to allow for `quoteTerm` constraints to
+  be solved even when the quoted term contains unsolved metas.
+  This allows for elaborating macro applications with quoted arguments
+  that still have interactive holes in them.
+  See the [quote metas documentation](https://agda.readthedocs.io/en/v2.9.0/language/reflection.html#quote-metas).
+
+* `{-# NO_POSITIVITY_CHECK #-}` pragmas are now recognized in `record` declarations and `where` blocks,
+  and pertain to the following `data` or `record` declaration or mutual block.
 
 Errors
 ------

--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -211,9 +211,9 @@ instance Hilite A.Declaration where
       A.Open mi x dir                        -> hl mi <> hl x <> hl dir
       A.FunDef _di x cs                      -> hl x <> hl cs
       A.DataSig _di er x tel e               -> hl er <> hl x <> hl tel <> hl e
-      A.DataDef _di x _uc pars cs            -> hl x <> hl pars <> hl cs
+      A.DataDef _di x _pc _uc pars cs        -> hl x <> hl pars <> hl cs
       A.RecSig _di er x tel e                -> hl er <> hl x <> hl tel <> hl e
-      A.RecDef _di x _uc dir bs e ds         -> hl x <> hl dir <> hl bs <> hl e <> hl ds
+      A.RecDef _di x _pc _uc dir bs e ds     -> hl x <> hl dir <> hl bs <> hl e <> hl ds
       A.PatternSynDef x xs p                 -> hl x <> hl xs <> hl p
       A.UnquoteDecl _mi _di xs e             -> hl xs <> hl e
       A.UnquoteDef _di xs e                  -> hl xs <> hl e

--- a/src/full/Agda/Syntax/Abstract/Views.hs
+++ b/src/full/Agda/Syntax/Abstract/Views.hs
@@ -130,7 +130,7 @@ deepUnscopeDecl = \case
   A.Mutual i ds               -> singleton $ A.Mutual i (deepUnscopeDecls ds)
   A.Section i e m tel ds      -> singleton $ A.Section i e m (deepUnscope tel)
                                    (deepUnscopeDecls ds)
-  A.RecDef i x uc dir bs e ds -> singleton $ A.RecDef i x uc dir (deepUnscope bs)
+  A.RecDef i x pc uc dir bs e ds -> singleton $ A.RecDef i x pc uc dir (deepUnscope bs)
                                      (deepUnscope e)
                                      (deepUnscopeDecls ds)
   d                           -> singleton $ deepUnscope d
@@ -476,9 +476,9 @@ instance ExprLike Declaration where
       Open{}                    -> pure d
       FunDef i f cs             -> FunDef i f <$> rec cs
       DataSig i er d tel e      -> DataSig i er d <$> rec tel <*> rec e
-      DataDef i d uc bs cs      -> DataDef i d uc <$> rec bs <*> rec cs
+      DataDef i d pc uc bs cs   -> DataDef i d pc uc <$> rec bs <*> rec cs
       RecSig i er r tel e       -> RecSig i er r <$> rec tel <*> rec e
-      RecDef i r uc dir bs e ds -> RecDef i r uc dir <$> rec bs <*> rec e <*> rec ds
+      RecDef i r pc uc dir bs e ds -> RecDef i r pc uc dir <$> rec bs <*> rec e <*> rec ds
       PatternSynDef f xs p      -> PatternSynDef f xs <$> rec p
       UnquoteDecl i is xs e     -> UnquoteDecl i is xs <$> rec e
       UnquoteDef i xs e         -> UnquoteDef i xs <$> rec e
@@ -542,9 +542,9 @@ instance DeclaredNames Declaration where
       Primitive _ q _              -> singleton (WithKind PrimName q)
       Mutual _ decls               -> declaredNames decls
       DataSig _ _ q _ _            -> singleton (WithKind DataName q)
-      DataDef _ q _ _ decls        -> singleton (WithKind DataName q) <> foldMap con decls
+      DataDef _ q _ _ _ decls      -> singleton (WithKind DataName q) <> foldMap con decls
       RecSig _ _ q _ _             -> singleton (WithKind RecName q)
-      RecDef _ q _ dir _ _ decls   -> singleton (WithKind RecName q) <> declaredNames dir <> declaredNames decls
+      RecDef _ q _ _ dir _ _ decls -> singleton (WithKind RecName q) <> declaredNames dir <> declaredNames decls
       PatternSynDef q _ _          -> singleton (WithKind PatternSynName q)
       UnquoteDecl _ _ qs _         -> fromList $ map (WithKind OtherDefName) qs  -- could be Fun or Axiom
       UnquoteDef _ qs _            -> fromList $ map (WithKind FunName) qs       -- cannot be Axiom

--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -3876,9 +3876,11 @@ instance Semigroup PositivityCheck where
   _ <> NoPositivityCheck = NoPositivityCheck
   _ <> _ = YesPositivityCheck
 
+instance Null PositivityCheck where
+  empty = YesPositivityCheck
+
 instance Monoid PositivityCheck where
-  mempty  = YesPositivityCheck
-  mappend = (<>)
+  mempty  = empty
 
 instance NFData PositivityCheck
 
@@ -3894,6 +3896,16 @@ instance KillRange UniverseCheck where
   killRange = id
 
 instance NFData UniverseCheck
+
+instance Null UniverseCheck where
+  empty = YesUniverseCheck
+
+instance Semigroup UniverseCheck where
+  NoUniverseCheck  <> _  = NoUniverseCheck
+  YesUniverseCheck <> uc = uc
+
+instance Monoid UniverseCheck where
+  mempty = empty
 
 -----------------------------------------------------------------------------
 -- * Coverage

--- a/src/full/Agda/Syntax/Internal/Names.hs
+++ b/src/full/Agda/Syntax/Internal/Names.hs
@@ -164,9 +164,9 @@ instance NamesIn Defn where
     -- Andreas 2017-07-27, Q: which names can be in @cc@ which are not already in @cl@?
     Function cl cc _ _ _ _ _ _ _ _ el _ _ _
       -> namesAndMetasIn' sg (cl, cc, el)
-    Datatype _ _ cl cs s _ _ _ trX trD
+    Datatype _ _ cl cs s _ _ _ _ trX trD
       -> namesAndMetasIn' sg (cl, cs, s, trX, trD)
-    Record _ cl c _ fs recTel _ _ _ _ _ _ comp
+    Record _ cl c _ fs recTel _ _ _ _ _ _ _ comp
       -> namesAndMetasIn' sg (cl, c, fs, recTel, comp)
     Constructor _ _ c d _ kit fs _ _ _ _
       -> namesAndMetasIn' sg (c, d, kit, fs)

--- a/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
+++ b/src/full/Agda/Syntax/Translation/AbstractToConcrete.hs
@@ -1319,7 +1319,7 @@ instance ToConcrete A.Declaration where
       return [ C.DataSig (getRange i) erased x'
                  (map C.DomainFull $ catMaybes tel') t' ]
 
-  toConcrete (A.DataDef i x uc bs cs) =
+  toConcrete (A.DataDef i x _pc _uc bs cs) =
     withAbstractPrivate i $
     bindToConcrete (map makeDomainFree $ dataDefParams bs) $ \ tel' -> do
       (x',cs') <- first unsafeQNameToName <$> toConcrete (x, map Constr cs)
@@ -1333,7 +1333,7 @@ instance ToConcrete A.Declaration where
       return [ C.RecordSig (getRange i) erased x'
                  (map C.DomainFull $ catMaybes tel') t' ]
 
-  toConcrete (A.RecDef  i x uc dir bs t cs) =
+  toConcrete (A.RecDef  i x _pc _uc dir bs t cs) =
     withAbstractPrivate i $
     bindToConcrete (map makeDomainFree $ dataDefParams bs) $ \ tel' -> do
       dirs <- toConcrete dir

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -3383,17 +3383,14 @@ whereToAbstract1 r e whname whds inner = do
       defaultImportDir { publicOpen = Just empty }
   return (x, A.WhereDecls (Just am) (isNothing whname) $ singleton d)
 
-data TerminationOrPositivity = Termination | Positivity
-  deriving (Show)
-
 data WhereOrRecord = InWhereBlock | InRecordDef
 
 checkNoTerminationPragma :: FoldDecl a => WhereOrRecord -> a -> ScopeM ()
 checkNoTerminationPragma b ds =
   -- foldDecl traverses into all sub-declarations.
-  forM_ (foldDecl (isPragma >=> isTerminationPragma) ds) \ (p, r) ->
+  forM_ (foldDecl (isPragma >=> isTerminationPragma) ds) \ r ->
     setCurrentRange r $ warning $ UselessPragma r $ P.vcat
-      [ P.text $ show p ++ " pragmas are ignored in " ++ what b
+      [ P.fwords $ "Termination pragmas are ignored in " ++ what b
       , "(see " <> issue b <> ")"
       ]
   where
@@ -3402,10 +3399,10 @@ checkNoTerminationPragma b ds =
     issue InWhereBlock = P.githubIssue 3355
     issue InRecordDef  = P.githubIssue 3008
 
-    isTerminationPragma :: C.Pragma -> [(TerminationOrPositivity, Range)]
+    isTerminationPragma :: C.Pragma -> [Range]
     isTerminationPragma = \case
-      C.TerminationCheckPragma r _  -> [(Termination, r)]
-      C.NoPositivityCheckPragma r   -> []
+      C.TerminationCheckPragma r _  -> [r]
+      C.NoPositivityCheckPragma _   -> []
       C.OptionsPragma _ _           -> []
       C.BuiltinPragma _ _ _         -> []
       C.RewritePragma _ _ _         -> []

--- a/src/full/Agda/Termination/TermCheck.hs
+++ b/src/full/Agda/Termination/TermCheck.hs
@@ -120,7 +120,7 @@ termDecl' = \case
     A.ScopedDecl scope ds -> {- withScope_ scope $ -} foldMap termDecl' ds
         -- scope is irrelevant as we are termination checking Syntax.Internal
     A.RecSig{}            -> return mempty
-    A.RecDef _ x _ _ _ _ ds -> termMutual [x] <> foldMap termDecl' ds
+    A.RecDef _ x _ _ _ _ _ ds -> termMutual [x] <> foldMap termDecl' ds
         -- Andreas, 2022-10-23, issue #5823
         -- Also check record types for termination.
         -- They are unfolded during construction of unique inhabitants of eta-records.
@@ -137,7 +137,7 @@ termDecl' = \case
     getNames :: Foldable t => t A.Declaration -> [QName]
     getNames = foldMap getName
     getName (A.FunDef i x cs)   = [x]
-    getName (A.RecDef _ x _ _ _ _ ds)   = x : getNames ds
+    getName (A.RecDef _ x _ _ _ _ _ ds) = x : getNames ds
     getName (A.Mutual _ ds)             = getNames ds
     getName (A.Section _ _ _ _ ds)      = getNames ds
     getName (A.ScopedDecl _ ds)         = getNames ds

--- a/src/full/Agda/TypeChecking/Generalize.hs
+++ b/src/full/Agda/TypeChecking/Generalize.hs
@@ -973,6 +973,7 @@ createGenRecordType genRecMeta@(El genRecSort _) sortedMetas = noMutualBlock $ d
            , recFields       = genRecFields
            , recTel          = dummyTel (length genRecFields) -- Filled in later
            , recMutual       = Just []
+           , recPositivityCheck = NoPositivityCheck
            , recEtaEquality' = Inferred YesEta
            , recPatternMatching = CopatternMatching
            , recInduction    = Nothing

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -2901,6 +2901,8 @@ data DatatypeData = DatatypeData
       --   Does include this data type.
       --   Empty if not recursive.
       --   @Nothing@ if not yet computed (by positivity checker).
+  , _dataPositivityCheck:: PositivityCheck
+      -- ^ Should positivity errors be reported for this data type?
   , _dataAbstr          :: IsAbstract
   , _dataPathCons       :: [QName]
       -- ^ Path constructor names (subset of @dataCons@).
@@ -2917,6 +2919,7 @@ pattern Datatype
   -> [QName]
   -> Sort
   -> Maybe [QName]
+  -> PositivityCheck
   -> IsAbstract
   -> [QName]
   -> Maybe QName
@@ -2930,6 +2933,7 @@ pattern Datatype
   , dataCons
   , dataSort
   , dataMutual
+  , dataPositivityCheck
   , dataAbstr
   , dataPathCons
   , dataTranspIx
@@ -2941,6 +2945,7 @@ pattern Datatype
     dataCons
     dataSort
     dataMutual
+    dataPositivityCheck
     dataAbstr
     dataPathCons
     dataTranspIx
@@ -2968,6 +2973,8 @@ data RecordData = RecordData
       --   Does include this record.
       --   Empty if not recursive.
       --   @Nothing@ if not yet computed (by positivity checker).
+  , _recPositivityCheck :: PositivityCheck
+      -- ^ Should positivity errors be reported for this record type?
   , _recEtaEquality'    :: EtaEquality
       -- ^ Eta-expand at this record type?
       --   @False@ for unguarded recursive records and coinductive records
@@ -2997,6 +3004,7 @@ pattern Record
   -> [Dom QName]
   -> Telescope
   -> Maybe [QName]
+  -> PositivityCheck
   -> EtaEquality
   -> PatternOrCopattern
   -> Maybe Induction
@@ -3013,6 +3021,7 @@ pattern Record
   , recFields
   , recTel
   , recMutual
+  , recPositivityCheck
   , recEtaEquality'
   , recPatternMatching
   , recInduction
@@ -3027,6 +3036,7 @@ pattern Record
     recFields
     recTel
     recMutual
+    recPositivityCheck
     recEtaEquality'
     recPatternMatching
     recInduction
@@ -3267,6 +3277,7 @@ instance Pretty DatatypeData where
       dataCons
       dataSort
       dataMutual
+      _dataPositivityCheck
       _dataAbstr
       _dataPathCons
       _dataTranspIx
@@ -3291,6 +3302,7 @@ instance Pretty RecordData where
       recFields
       recTel
       recMutual
+      _recPositivityCheck
       recEtaEquality'
       _recPatternMatching
       recInduction
@@ -6764,8 +6776,8 @@ instance KillRange Defn where
       AbstractDefn{} -> __IMPOSSIBLE__ -- only returned by 'getConstInfo'!
       Function a b c d e f g h i j k l m n ->
         killRangeN Function a b c d e f g h i j k l m n
-      Datatype a b c d e f g h i j   -> killRangeN Datatype a b c d e f g h i j
-      Record a b c d e f g h i j k l m -> killRangeN Record a b c d e f g h i j k l m
+      Datatype a b c d e f g h i j k -> killRangeN Datatype a b c d e f g h i j k
+      Record a b c d e f g h i j k l m n -> killRangeN Record a b c d e f g h i j k l m n
       Constructor a b c d e f g h i j k -> killRangeN Constructor a b c d e f g h i j k
       Primitive a b c d e f          -> killRangeN Primitive a b c d e f
       PrimitiveSort a b              -> killRangeN PrimitiveSort a b

--- a/src/full/Agda/TypeChecking/Rules/Builtin.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin.hs
@@ -1011,6 +1011,7 @@ bindBuiltinNoDef b q = inTopContext $ do
               , dataSort       = getSort t
               , dataAbstr      = ConcreteDef
               , dataMutual     = Nothing
+              , dataPositivityCheck = NoPositivityCheck
               , dataPathCons   = []
               , dataTranspIx   = Nothing -- Id has custom transp def.
               , dataTransp     = Nothing

--- a/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
+++ b/src/full/Agda/TypeChecking/Rules/Builtin/Coinduction.hs
@@ -87,6 +87,7 @@ bindBuiltinSharp x =
                   , recNamedCon       = True
                   , recFields         = []  -- flat is added later
                   , recTel            = fieldTel
+                  , recPositivityCheck = NoPositivityCheck
                   , recEtaEquality'   = Inferred $ NoEta CopatternMatching
                   , recPatternMatching= CopatternMatching
                   , recMutual         = Just []

--- a/src/full/Agda/TypeChecking/Rules/Data.hs
+++ b/src/full/Agda/TypeChecking/Rules/Data.hs
@@ -66,8 +66,8 @@ import Agda.Utils.Impossible
 
 -- | Type check a datatype definition. Assumes that the type has already been
 --   checked.
-checkDataDef :: A.DefInfo -> QName -> UniverseCheck -> A.DataDefParams -> [A.Constructor] -> TCM ()
-checkDataDef i name uc (A.DataDefParams gpars ps) cs =
+checkDataDef :: A.DefInfo -> QName -> PositivityCheck -> UniverseCheck -> A.DataDefParams -> [A.Constructor] -> TCM ()
+checkDataDef i name pc uc (A.DataDefParams gpars ps) cs =
     traceCall (CheckDataDef (getRange name) name ps cs) $ do
 
         -- Add the datatype module
@@ -151,6 +151,7 @@ checkDataDef i name uc (A.DataDefParams gpars ps) cs =
                   , _dataSort       = s
                   , _dataAbstr      = Info.defAbstract i
                   , _dataMutual     = Nothing
+                  , _dataPositivityCheck = pc
                   , _dataPathCons   = []     -- Path constructors are added later
                   , _dataTranspIx   = Nothing -- Generated later if nofIxs > 0.
                   , _dataTransp     = Nothing -- Added later

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -171,9 +171,9 @@ checkDecl d = setCurrentRange d $ do
       A.Pragma i p             -> none $ checkPragma i p
       A.ScopedDecl scope ds    -> none $ setScope scope >> mapM_ checkDeclCached ds
       A.FunDef i x cs          -> impossible $ check x i $ checkFunDef i x $ List1.toList cs
-      A.DataDef i x uc ps cs   -> impossible $ check x i $ checkDataDef i x uc ps cs
-      A.RecDef i x uc dir ps tel cs -> impossible $ check x i $ do
-                                    checkRecDef i x uc dir ps tel cs
+      A.DataDef i x pc uc ps cs -> impossible $ check x i $ checkDataDef i x pc uc ps cs
+      A.RecDef i x pc uc dir ps tel cs -> impossible $ check x i $ do
+                                    checkRecDef i x pc uc dir ps tel cs
                                     blockId <- defMutual <$> getConstInfo x
 
                                     -- Andreas, 2016-10-01 testing whether
@@ -441,8 +441,8 @@ highlight_ hlmod d = do
       highlight (A.Section i er x tel [])
       when (hlmod == DoHighlightModuleContents) $ mapM_ (highlight_ hlmod) (deepUnscopeDecls ds)
     A.RecSig{}               -> highlight d
-    A.RecDef i x uc dir ps tel cs ->
-      highlight (A.RecDef i x uc dir ps dummy cs)
+    A.RecDef i x pc uc dir ps tel cs ->
+      highlight (A.RecDef i x pc uc dir ps dummy cs)
       -- The telescope has already been highlighted.
       where
       -- Andreas, 2016-01-22, issue 1790

--- a/src/full/Agda/TypeChecking/Rules/Record.hs
+++ b/src/full/Agda/TypeChecking/Rules/Record.hs
@@ -71,6 +71,7 @@ import qualified Agda.Utils.List1 as List1
 checkRecDef
   :: A.DefInfo                 -- ^ Position and other info.
   -> QName                     -- ^ Record type identifier.
+  -> PositivityCheck           -- ^ Report positivity errors for this record type?
   -> UniverseCheck             -- ^ Check universes?
   -> A.RecordDirectives        -- ^ (Co)Inductive, (No)Eta, (Co)Pattern, Constructor?
   -> A.DataDefParams           -- ^ Record parameters.
@@ -78,7 +79,7 @@ checkRecDef
                                --   Does not include record parameters.
   -> [A.Field]                 -- ^ Field signatures.
   -> TCM ()
-checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars ps) contel0 fields = do
+checkRecDef i name pc uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars ps) contel0 fields = do
 
   -- Andreas, 2022-10-06, issue #6165:
   -- The target type of the constructor is a meaningless dummy expression which does not type-check.
@@ -222,13 +223,14 @@ checkRecDef i name uc (RecordDirectives ind eta0 pat con) (A.DataDefParams gpars
               , recNamedCon       = hasNamedCon
               , recFields         = fs
               , recTel            = telh `abstract` ftel
+              , recPositivityCheck= pc
               , recAbstr          = Info.defAbstract i
               , recEtaEquality'   = haveEta
               , recPatternMatching= patCopat
               , recInduction      = indCo
                   -- We retain the original user declaration [(co)inductive]
                   -- in case the record turns out to be recursive.
-              -- Determined by positivity checker:
+              -- Determined by positivity checker (analysis running always, independently of recPositivityCheck):
               , recMutual         = Nothing
               -- Determined by the termination checker:
               , recTerminates     = Nothing

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20260222 * 10 + 0
+currentInterfaceVersion = 20260227 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -705,6 +705,8 @@ instance EmbPrj RecordDirective where
     (N2 3 a)   -> valuN PatternOrCopattern a
     _ -> malformed
 
+instance EmbPrj PositivityCheck
+
 instance EmbPrj Catchall where
   icod_ NoCatchall  = icodeN' NoCatchall
   icod_ (YesCatchall x) = icodeN' YesCatchall x

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Internal.hs
@@ -428,8 +428,8 @@ instance EmbPrj BuiltinSort where
 instance EmbPrj Defn where
   icod_ (Axiom       a)                                 = icodeN 0 Axiom a
   icod_ (Function    a b s t u c d e f g h i j k)       = icodeN 1 (\ a b s -> Function a b s t) a b s u c d e f g h i j k
-  icod_ (Datatype    a b c d e f g h i j)               = icodeN 2 Datatype a b c d e f g h i j
-  icod_ (Record      a b c d e f g h i j k l m)         = icodeN 3 Record a b c d e f g h i j k l m
+  icod_ (Datatype    a b c d e f g h i j k)             = icodeN 2 Datatype a b c d e f g h i j k
+  icod_ (Record      a b c d e f g h i j k l m n)       = icodeN 3 Record a b c d e f g h i j k l m n
   icod_ (Constructor a b c d e f g h i j k)             = icodeN 4 Constructor a b c d e f g h i j k
   icod_ (Primitive   a b c d e f)                       = icodeN 5 Primitive a b c d e f
   icod_ (PrimitiveSort a b)                             = icodeN 6 PrimitiveSort a b
@@ -443,8 +443,8 @@ instance EmbPrj Defn where
     N2 0 a                                   -> valuN Axiom a
     N6 1 a b s u c (N6 d e f g h i (N2 j k)) -> valuN (\ a b s -> Function a b s Nothing)
                                                       a b s u c d e f g h i j k
-    N6 2 a b c d e (N5 f g h i j)            -> valuN Datatype a b c d e f g h i j
-    N6 3 a b c d e (N6 f g h i j k (N2 l m)) -> valuN Record a b c d e f g h i j k l m
+    N6 2 a b c d e (N6 f g h i j k N0)       -> valuN Datatype a b c d e f g h i j k
+    N6 3 a b c d e (N6 f g h i j k (N3 l m n)) -> valuN Record a b c d e f g h i j k l m n
     N6 4 a b c d e (N6 f g h i j k N0)       -> valuN Constructor a b c d e f g h i j k
     N6 5 a b c d e (N1 f)                    -> valuN Primitive a b c d e f
     N3 6 a b                                 -> valuN PrimitiveSort a b

--- a/src/full/Agda/TypeChecking/Unquote.hs
+++ b/src/full/Agda/TypeChecking/Unquote.hs
@@ -1077,7 +1077,7 @@ evalTCM v = Bench.billTo [Bench.Typing, Bench.Reflection] do
           [ "checking datatype: " <+> prettyTCM x <+> " with constructors:"
           , nest 2 (vcat (map prettyTCM conNames))
           ]
-        liftTCM $ checkDataDef i x YesUniverseCheck (A.DataDefParams Set.empty lams) as
+        liftTCM $ checkDataDef i x YesPositivityCheck YesUniverseCheck (A.DataDefParams Set.empty lams) as
         liftTCM primUnitUnit
       where
         addDummy :: Int -> R.Type -> R.Type

--- a/test/Fail/Issue3355.agda
+++ b/test/Fail/Issue3355.agda
@@ -1,0 +1,133 @@
+-- Andreas, 2026-02-27, issues #3355 and #3008:
+-- Allow NO_POSITIVITY_CHECK in records and where blocks.
+
+-- 1. Still ignored outside mutual block before non-data/record definition.
+---------------------------------------------------------------------------
+
+{-# NO_POSITIVITY_CHECK #-}     -- Useless, not attached to data/record and outside mutual block
+foo : Set1
+foo = Set
+  where
+  record R : Set where
+    inductive
+    field f : R → R              -- Expected positivity error here.
+
+-- Expected warning: -W[no]InvalidNoPositivityCheckPragma
+-- NO_POSITIVITY_CHECKING pragmas can only precede a data/record
+-- definition or a mutual block (that contains a data/record definition).
+
+-- Expected error: [NotStrictlyPositive]
+-- R is not strictly positive, because it occurs
+-- to the left of an arrow
+-- in the definition of R.
+
+-- 2. No longer ignored in `where` block.
+-----------------------------------------
+
+where1 : Set1
+where1 = Set
+  where
+  {-# NO_POSITIVITY_CHECK #-}
+  record S : Set where
+    inductive
+    field g : S → S              -- No positivity error here!
+
+where2 : Set1
+where2 = Set
+  where
+  mutual
+    bar = Set
+    {-# NO_POSITIVITY_CHECK #-}
+    record S : Set where
+      inductive
+      field g : S → S              -- No positivity error here!
+
+where3 : Set1
+where3 = Set
+  where
+  mutual                           -- Does not help.
+    record R : Set where
+      inductive
+      field f : R → R              -- Error here.
+    {-# NO_POSITIVITY_CHECK #-}    -- Misplaced.
+    bar = Set
+
+-- Expected warning: -W[no]InvalidNoPositivityCheckPragma
+-- NO_POSITIVITY_CHECKING pragmas can only precede a data/record
+-- definition or a mutual block (that contains a data/record
+-- definition).
+-- when scope checking the declaration
+--   where3 = Set
+--     where
+--       mutual
+--         record S : Set where
+--           inductive
+--           field g : S → S
+--         {-# NO_POSITIVITY_CHECK #-}
+--         bar = Set
+
+-- Expected error: [NotStrictlyPositive]
+-- R is not strictly positive, because it occurs
+-- to the left of an arrow
+-- in the definition of R.
+
+where4 : Set1
+where4 = Set
+  where
+  {-# NO_POSITIVITY_CHECK #-}      -- Precedes a mutual block
+  mutual
+    bar = Set
+    record S : Set where
+      inductive
+      field g : S → S              -- No positivity error here!
+
+where5 : Set1
+where5 = Set
+  where
+    record S : Set
+    {-# NO_POSITIVITY_CHECK #-}
+    record S where
+      inductive
+      field g : S → S              -- No positivity error here!
+
+where6 : Set1
+where6 = Set
+  where
+    {-# NO_POSITIVITY_CHECK #-}
+    record S : Set
+    record S where
+      inductive
+      field g : S → S              -- No positivity error here!
+
+-- 3. No longer ignored in `record` declaration.
+------------------------------------------------
+
+module InRecord where
+  record R : Set where
+    inductive
+    field f : R → R                -- Expected positivity error here.
+
+    {-# NO_POSITIVITY_CHECK #-}
+    record S : Set where
+      inductive
+      field g : S → S              -- But not here!
+
+    record R' : Set where
+      inductive
+      field f : R' → R'            -- Expected positivity error here.
+
+    {-# NO_POSITIVITY_CHECK #-}
+    record S' : Set
+    record S' where
+      inductive
+      field g : S' → S'            -- But not here!
+
+-- Expected error: [NotStrictlyPositive]
+-- R' is not strictly positive, because it occurs
+-- to the left of an arrow
+-- in the definition of R'.
+
+-- Expected error: [NotStrictlyPositive]
+-- R is not strictly positive, because it occurs
+-- to the left of an arrow
+-- in the definition of R.

--- a/test/Fail/Issue3355.err
+++ b/test/Fail/Issue3355.err
@@ -1,0 +1,38 @@
+
+Issue3355.agda:7.1-28: warning: -W[no]InvalidNoPositivityCheckPragma
+NO_POSITIVITY_CHECKING pragmas can only precede a data/record
+definition or a mutual block (that contains a data/record
+definition).
+
+Issue3355.agda:52.5-32: warning: -W[no]InvalidNoPositivityCheckPragma
+NO_POSITIVITY_CHECKING pragmas can only precede a data/record
+definition or a mutual block (that contains a data/record
+definition).
+when scope checking the declaration
+  where3 = Set
+    where
+      mutual
+        record R : Set where
+          inductive
+          field f : R → R
+        {-# NO_POSITIVITY_CHECK #-}
+        bar = Set
+Issue3355.agda:8.1-13.20: error: [NotStrictlyPositive]
+R is not strictly positive, because it occurs
+to the left of an arrow
+in the definition of R.
+
+Issue3355.agda:45.1-53.14: error: [NotStrictlyPositive]
+R is not strictly positive, because it occurs
+to the left of an arrow
+in the definition of R.
+
+Issue3355.agda:106.3-123.24: error: [NotStrictlyPositive]
+R is not strictly positive, because it occurs
+to the left of an arrow
+in the definition of R.
+
+Issue3355.agda:106.3-123.24: error: [NotStrictlyPositive]
+R' is not strictly positive, because it occurs
+to the left of an arrow
+in the definition of R'.


### PR DESCRIPTION
- **Fix #3355: use NO_POSITIVITY_CHECKING pragmas in where and record decls**
  This propagates the `PositivityChecking` flag that attaches to `data` and `record` signatures or definitions all the way into the `Signature`, so that the positivity checker can obtain it in addition to the information in the mutual block (if such exists).
  
  This helps with `NO_POSITIVITY_CHECKING` pragmas in situations where they are not surrounded by a mutual block, e.g. in `where` and `record` declarations, and in those sitations they should only apply to the declarations they are attached to (by preceding them).
  
  Closes #3355.
  
- **checkNoTerminationPragma on longer has to account for PositivityChecking**
  Simplification.
  