### PR TITLE
Emacs: Do not save buffer before executing response

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -834,7 +834,6 @@ command is sent to Agda (if it is sent)."
   ;; arguments.  The symbol of the invoked function must have a
   ;; `agda2-safe-function' symbol property asserting the expected
   ;; types of all arguments, w.r.t `cl-typep'.
-  (save-buffer)
   (unwind-protect
       (let* ((inhibit-read-only t)
              (func (car response))


### PR DESCRIPTION
This addresses the issue raised in https://github.com/agda/agda/issues/8283, that goes back to b9f84c2d339.