### PR TITLE
Fix #8435 by new warning DeclarationBeforeDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,11 @@ Warnings
 
 * `UnknownNamesInFixityDecl` and `UnknownNamesInPolarityPragmas` are now error warnings.
 
+* The new warning `DefinitionBeforeDeclaration` is emitted if in a classic
+  `mutual` block a data/record signature appears *after* the respective
+  definition.  This can happen since the nicifier bubbles signatures up.
+  (See [issue #8435](https://github.com/agda/agda/issues/8435).)
+
 Syntax
 ------
 

--- a/doc/user-manual/tools/command-line-options.rst
+++ b/doc/user-manual/tools/command-line-options.rst
@@ -1392,6 +1392,10 @@ The list containing any warning ``NAME`` can be produced by ``agda --help=warnin
 
      Deprecated features.
 
+.. option:: DefinitionBeforeDeclaration
+
+     Definitions that occur in ``mutual`` blocks before their declarations.
+
 .. option:: DivergentModalityInClause
 
      Modalities of clauses that diverge from the modality of the function.

--- a/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
+++ b/src/full/Agda/Interaction/Highlighting/FromAbstract.hs
@@ -21,7 +21,7 @@ import           Agda.Interaction.Highlighting.Precise hiding ( singleton )
 import qualified Agda.Interaction.Highlighting.Precise as H
 import           Agda.Interaction.Highlighting.Range   ( rToR )  -- Range is ambiguous
 
-import           Agda.Syntax.Abstract                ( IsProjP(..), anameName, getAmbiguous )
+import           Agda.Syntax.Abstract                ( IsProjP(..), anameName, getAmbiguous, nameBindingSite )
 import qualified Agda.Syntax.Abstract      as A
 import           Agda.Syntax.Common        as Common
 import           Agda.Syntax.Concrete                ( FieldAssignment'(..), TacticAttribute' )
@@ -223,7 +223,7 @@ instance Hilite A.Declaration where
       A.UnfoldingDecl _r names               -> hl names
     where
     hl      a = hilite a
-    hlField x = hiliteField (concreteQualifier x) (concreteBase x) (Just $ bindingSite x)
+    hlField x = hiliteField (concreteQualifier x) (concreteBase x) (Just $ nameBindingSite x)
 
 instance Hilite A.Pragma where
   hilite = \case
@@ -528,7 +528,7 @@ hiliteAmbiguousQName mkind x = do
     hiliteAName q include $ nameAsp' kind
   where
     qs = getAmbiguous x
-    include = List1.allEqual $ fmap bindingSite qs
+    include = List1.allEqual $ fmap nameBindingSite qs
 
 hiliteBound :: A.Name -> Hiliter
 hiliteBound x =
@@ -659,7 +659,7 @@ hiliteAName x include asp = do
   hiliteCName (concreteQualifier x)
               (concreteBase x)
               (rangeOfFixityDeclaration currentModule)
-              (if include then Just $ bindingSite x else Nothing)
+              (if include then Just $ nameBindingSite x else Nothing)
               asp
     <> notationFile currentModule
   where
@@ -709,6 +709,3 @@ concreteBase = A.nameConcrete . A.qnameName
 
 concreteQualifier :: A.QName -> [C.Name]
 concreteQualifier = map A.nameConcrete . A.mnameToList . A.qnameModule
-
-bindingSite :: A.QName -> Range
-bindingSite = A.nameBindingSite . A.qnameName

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -554,6 +554,7 @@ warningHighlighting' b w = case tcWarning w of
   MacroInLetBindings{}            -> errorWarningHighlighting w
   AbstractInLetBindings{}         -> errorWarningHighlighting w
   IllegalDeclarationInDataDefinition{} -> errorWarningHighlighting w
+  DefinitionBeforeDeclaration x   -> cosmeticProblemHighlighting w <> cosmeticProblemHighlighting (nameBindingSite x)
 
   NicifierIssue (DeclarationWarning _ w) -> case w of
     -- we intentionally override the binding of `w` here so that our pattern of

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -56,6 +56,7 @@ import Agda.TypeChecking.Positivity.Occurrence
 import Agda.TypeChecking.Warnings ( raiseWarningsOnUsage )
 
 import qualified Agda.Syntax.Abstract as A
+import Agda.Syntax.Abstract.Name (nameBindingSite)
 import Agda.Syntax.Concrete.Definitions as W ( DeclarationWarning(..), DeclarationWarning'(..) )
 import Agda.Syntax.Common (Induction(..), pattern Ranged)
 import qualified Agda.Syntax.Common.Aspect as Aspect
@@ -403,7 +404,7 @@ extraErrorHighlighting = \case
       -- The identifier that would be shadowed by the clashing definition
       -- is highlighted as dead code.
       -- (Not sure how good this is.)
-      ClashingDefinition _ y _ -> return $ deadcodeHighlighting $ I.nameBindingSite $ I.qnameName $ clashingQName y
+      ClashingDefinition _ y _ -> return $ deadcodeHighlighting $ I.nameBindingSite $ clashingQName y
       ShadowedModule x ms      -> deadcodeHighlighting . snd <$> TCM.prettyShadowedModule x ms
         -- 'prettyShadowedModule' mostly duplicates the work done by @'renderError' ('ShadowedModule' x ms)@
         -- in 'errorHighlighting',
@@ -639,11 +640,10 @@ terminationErrorHighlighting ::
 terminationErrorHighlighting termErrs = functionDefs `mappend` callSites
   where
     m            = parserBased { otherAspects = Set.singleton TerminationProblem }
-    functionDefs = foldMap (\x -> H.singleton (rToR $ bindingSite x) m) $
+    functionDefs = foldMap (\x -> H.singleton (rToR $ nameBindingSite x) m) $
                    concatMap termErrFunctions termErrs
     callSites    = foldMap (\r -> H.singleton (rToR r) m) $
                    concatMap (map getRange . termErrCalls) termErrs
-    bindingSite  = A.nameBindingSite . A.qnameName
 
 -- | Generate syntax highlighting for not-strictly-positive inductive
 -- definitions.

--- a/src/full/Agda/Interaction/Options/Warnings.hs
+++ b/src/full/Agda/Interaction/Options/Warnings.hs
@@ -258,6 +258,7 @@ data WarningName
   -- Library Warnings
   | LibUnknownField_
   -- Nicifer Warnings
+  | DefinitionBeforeDeclaration_
   | DivergentModalityInClause_
   | EmptyAbstract_
   | EmptyConstructor_
@@ -564,6 +565,7 @@ warningNameDescription = \case
   CoverageNoExactSplit_            -> "Failed exact split checks."
   InlineNoExactSplit_              -> "Failed exact split checks after inlining record constructors."
   DeprecationWarning_              -> "Deprecated features."
+  DefinitionBeforeDeclaration_     -> "Definitions that occur before their declarations."
   -- TODO: linearity
   -- FixingQuantity_                  -> "Correcting invalid user-written quantity."
   FixingRelevance_                 -> "Correcting invalid user-written relevance attribute."

--- a/src/full/Agda/Syntax/Concrete/Definitions.hs
+++ b/src/full/Agda/Syntax/Concrete/Definitions.hs
@@ -339,7 +339,7 @@ niceDeclarations fixs ds = do
                 return (d , ds)
               -- Subcase: The lhs is a proper pattern.
               -- This could be a let-pattern binding. Pass it on.
-              -- A missing type signature error might be raise in ConcreteToAbstract
+              -- A missing type signature error might be raised in ConcreteToAbstract
               _ -> do
                 return ([NiceFunClause (getRange d) PublicAccess ConcreteDef termCheck covCheck catchall d] , ds)
 

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -1547,7 +1547,7 @@ instance SetBindingSite a => SetBindingSite [a]
 instance SetBindingSite a => SetBindingSite (List1 a)
 
 instance SetBindingSite A.Name where
-  setBindingSite r x = x { nameBindingSite = r }
+  setBindingSite r x = x { _nameBindingSite = r }
 
 instance SetBindingSite A.QName where
   setBindingSite r x = x { qnameName = setBindingSite r $ qnameName x }

--- a/src/full/Agda/Syntax/Scope/Monad.hs
+++ b/src/full/Agda/Syntax/Scope/Monad.hs
@@ -245,7 +245,7 @@ freshAbstractName fx x = do
     { _nameId         = i
     , nameConcrete    = x
     , nameCanonical   = x
-    , nameBindingSite = getRange x
+    , _nameBindingSite = getRange x
     , nameFixity      = fx
     , nameIsRecordName = False
     }

--- a/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
+++ b/src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs
@@ -2537,6 +2537,16 @@ retrieveDataOrRecName dataOrRec x = do
     livesInCurrentModule ax  -- Andreas, 2017-12-04, issue #2862
     clashIfModuleAlreadyDefinedInCurrentModule x ax  -- Andreas, 2019-07-07, issue #2576
 
+    -- Andreas, 2026-02-28, issue #8435
+    -- The nicifier bubbles signatures up, even beyond their matching definition.
+    -- So, check that signature appeared before definition in the file.
+    reportSDoc "scope.data.range" 40 $ vcat
+      [ "ax  = " <+> pure (pretty (PrintRange ax))
+      , "defined at " <+> pure (pretty (PrintRange (nameBindingSite ax)))
+      ]
+    unless (getRange (nameBindingSite ax) <= getRange ax) do
+      warning $ DefinitionBeforeDeclaration ax
+
     -- Check that the generated module doesn't clash with a previously
     -- defined module
     checkForModuleClash x

--- a/src/full/Agda/TypeChecking/Conversion/Errors.hs
+++ b/src/full/Agda/TypeChecking/Conversion/Errors.hs
@@ -809,9 +809,9 @@ prettyInEqual ht (Just hdm) t1 t2 = do
             There -> pwords "the mismatched terms"
           <> pwords "are distinct extended lambdas; "
         , fwords "one is defined at"
-        , "  " <+> pretty (nameBindingSite (qnameName a))
+        , "  " <+> pretty (nameBindingSite a)
         , fwords "and the other at"
-        , "  " <+> (pretty (nameBindingSite (qnameName b)) <> ",")
+        , "  " <+> (pretty (nameBindingSite b) <> ",")
         , fwords "so they have different internal representations."
         ]
 

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -4891,6 +4891,8 @@ data Warning
   -- Type checker warnings
   | TooManyArgumentsToSort QName (List1 (NamedArg A.Expr))
       -- ^ Extra arguments to sort (will be ignored).
+  | DefinitionBeforeDeclaration A.AbstractName
+      -- ^ A definition appears before its declaration in a @mutual@ block.
   | RewritesNothing
       -- ^ A @rewrite@ expression that does not fire.
   | WithClauseProjectionFixityMismatch
@@ -5039,6 +5041,7 @@ warningName = \case
 
   -- Type checking
   TooManyArgumentsToSort{}             -> TooManyArgumentsToSort_
+  DefinitionBeforeDeclaration{}        -> DefinitionBeforeDeclaration_
   RecursiveRecordNeedsInductivity{}    -> RecursiveRecordNeedsInductivity_
   RewritesNothing{}                    -> RewritesNothing_
   WithClauseProjectionFixityMismatch{} -> WithClauseProjectionFixityMismatch_

--- a/src/full/Agda/TypeChecking/Positivity.hs
+++ b/src/full/Agda/TypeChecking/Positivity.hs
@@ -204,7 +204,7 @@ checkStrictlyPositive mi qset = Bench.billTo [Bench.Positivity] do
         -- Check whether the recursive record has been declared as
         -- 'Inductive' or 'Coinductive'.  Otherwise, error.
         unlessM (isJust . recInduction . theDef <$> getConstInfo q) $
-          setCurrentRange (nameBindingSite $ qnameName q) $
+          setCurrentRange (nameBindingSite q) $
             warning $ RecursiveRecordNeedsInductivity q
 
     occ (Edge o _) = o

--- a/src/full/Agda/TypeChecking/Pretty.hs
+++ b/src/full/Agda/TypeChecking/Pretty.hs
@@ -332,7 +332,7 @@ instance PrettyTCM QName where
     nk <- getConstInfo' x <&> \case
       Left  _ -> Nothing
       Right d -> Just (defnToNameKind (theDef d))
-    fmap (flip P.definedAt (nameBindingSite (qnameName x)) . maybe id P.hlNameKind nk . P.pretty) (abstractToConcrete_ x)
+    fmap (flip P.definedAt (nameBindingSite x) . maybe id P.hlNameKind nk . P.pretty) (abstractToConcrete_ x)
 
   {-# SPECIALIZE prettyTCM :: QName -> TCM Doc #-}
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -54,6 +54,7 @@ import Agda.Syntax.Common
   )
 import Agda.Syntax.Common.Pretty ( Pretty, prettyShow, singPlural )
 import qualified Agda.Syntax.Common.Pretty as P
+import qualified Agda.Syntax.Abstract as A
 import qualified Agda.Syntax.Concrete as C
 import Agda.Syntax.Internal
 import Agda.Syntax.Position
@@ -741,6 +742,11 @@ prettyWarning = \case
     TooManyArgumentsToSort q args -> fsep $ concat
       [ pwords "Too many arguments given to sort"
       , [ prettyTCM q ]
+      ]
+
+    DefinitionBeforeDeclaration x -> fsep $ concat
+      [ [ prettyTCM x ]
+      , pwords "defined before its declaration"
       ]
 
     RewritesNothing -> fsep $ pwords "`rewrite' did not apply"

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Errors.hs
@@ -147,6 +147,7 @@ instance EmbPrj Warning where
     RewritesNothing                             -> icodeN 74 RewritesNothing
     IllegalDeclarationInDataDefinition ds       -> __IMPOSSIBLE__  -- We don't serialize concrete definitions (yet)
     UnusedImports a b                           -> icodeN 75 UnusedImports a b
+    DefinitionBeforeDeclaration x               -> icodeN 76 DefinitionBeforeDeclaration x
     RecursiveRecordNeedsInductivity{}           -> __IMPOSSIBLE__  -- Error warning
 
   value = vcase $ \ case
@@ -227,6 +228,7 @@ instance EmbPrj Warning where
     N4 73 a b c   -> valuN FixingPolarity a b c
     N1 74         -> valuN RewritesNothing
     N3 75 a b     -> valuN UnusedImports a b
+    N2 76 a       -> valuN DefinitionBeforeDeclaration a
     _ -> malformed
 
 instance EmbPrj UselessPublicReason

--- a/test/Internal/TypeChecking/Generators.hs
+++ b/test/Internal/TypeChecking/Generators.hs
@@ -154,7 +154,7 @@ makeConfiguration ds cs ps vs = TermConf
                         { _nameId         = NameId n (ModuleNameHash 1)
                         , nameConcrete    = C.simpleName s
                         , nameCanonical   = C.simpleName s
-                        , nameBindingSite = noRange
+                        , _nameBindingSite = noRange
                         , nameFixity      = noFixity'
                         , nameIsRecordName = False
                         }

--- a/test/Succeed/Issue8435.agda
+++ b/test/Succeed/Issue8435.agda
@@ -1,0 +1,20 @@
+-- Andreas, 2026-02-28, issue #8435
+-- Warn when a declaration preceeds a definition
+
+-- {-# OPTIONS -v scope.data.range:40 #-}
+
+mutual
+  data D where
+  data D : Set
+  record R where
+  record R : Set
+
+-- Expected warning: -W[no]DefinitionBeforeDeclaration
+-- D defined before its declaration
+-- when scope checking the declaration
+--   data D where
+
+-- Expected warning: -W[no]DefinitionBeforeDeclaration
+-- R defined before its declaration
+-- when scope checking the declaration
+--   record R where

--- a/test/Succeed/Issue8435.warn
+++ b/test/Succeed/Issue8435.warn
@@ -1,0 +1,22 @@
+
+Issue8435.agda:7.3-15: warning: -W[no]DefinitionBeforeDeclaration
+D defined before its declaration
+when scope checking the declaration
+  data D where
+
+Issue8435.agda:9.3-17: warning: -W[no]DefinitionBeforeDeclaration
+R defined before its declaration
+when scope checking the declaration
+  record R where
+
+———— All done; warnings encountered ————————————————————————
+
+Issue8435.agda:7.3-15: warning: -W[no]DefinitionBeforeDeclaration
+D defined before its declaration
+when scope checking the declaration
+  data D where
+
+Issue8435.agda:9.3-17: warning: -W[no]DefinitionBeforeDeclaration
+R defined before its declaration
+when scope checking the declaration
+  record R where


### PR DESCRIPTION
- **[refactor] Overload nameBindingSite**
  

- **Fix #8435 by warning DefinitionBeforeDeclaration**
  The new warning `DefinitionBeforeDeclaration` is emitted if in a classic `mutual` block a data/record signature appears *after* the respective definition.  This can happen since the nicifier bubbles signatures up.
  
  AI disclosure: I gave Copilot the routine task of creating a new warning and its printing, and it did a good job, although it decided to place this in `DeclarationWarning` and I had to correct it and tell it to place it in `Warning` in a second step.
  Also, I went throught the (small) diff and made cosmetic changes so code and wording is idiomatic.
  
Closes #8435.
  