### PR TITLE
Fix #4150 by sorting lone definitions up in a `mutual` block

### DIFF
--- a/test/Fail/Issue4150.agda
+++ b/test/Fail/Issue4150.agda
@@ -1,0 +1,14 @@
+-- Andreas, 2026-02-28, issue #4150
+-- Prefer MissingTypeSignature error over NotInScope error.
+
+mutual
+  record Foo : Set₁ where
+    field
+      A : Set
+      B : A → F A  -- WAS: Not in scope: F
+  F A = Set        -- MissingTypeSignature here
+
+-- Expected error: [MissingTypeSignature.Function]
+-- Missing type signature for left hand side F A
+-- when scope checking the declaration
+--   F A = Set

--- a/test/Fail/Issue4150.err
+++ b/test/Fail/Issue4150.err
@@ -1,0 +1,4 @@
+Issue4150.agda:9.3-12: error: [MissingTypeSignature.Function]
+Missing type signature for left hand side F A
+when scope checking the declaration
+  F A = Set

--- a/test/Fail/Issue4150a.agda
+++ b/test/Fail/Issue4150a.agda
@@ -1,0 +1,12 @@
+-- Andreas, 2026-02-28, issue #4150
+-- Prefer MissingTypeSignature error over NotInScope error.
+
+mutual
+  data D : Set₁ where
+    c : (A : Set) → F A → D
+  F A = Set
+
+-- Expected error: [MissingTypeSignature.Function]
+-- Missing type signature for left hand side F A
+-- when scope checking the declaration
+--   F A = Set

--- a/test/Fail/Issue4150a.err
+++ b/test/Fail/Issue4150a.err
@@ -1,0 +1,4 @@
+Issue4150a.agda:7.3-12: error: [MissingTypeSignature.Function]
+Missing type signature for left hand side F A
+when scope checking the declaration
+  F A = Set

--- a/test/Fail/Issue4150b.agda
+++ b/test/Fail/Issue4150b.agda
@@ -1,0 +1,13 @@
+-- Andreas, 2026-02-28, issue #4150
+-- Prefer MissingTypeSignature error over NotInScope error.
+
+mutual
+  data D where
+    c : (A : Set) → F A → D
+  F A = Set
+
+-- Expected error: [MissingTypeSignature.Data]
+-- Missing type signature for data definition D
+-- when scope checking the declaration
+--   data D where
+--     c : (A : Set) → F A → D

--- a/test/Fail/Issue4150b.err
+++ b/test/Fail/Issue4150b.err
@@ -1,0 +1,5 @@
+Issue4150b.agda:5.3-6.28: error: [MissingTypeSignature.Data]
+Missing type signature for data definition D
+when scope checking the declaration
+  data D where
+    c : (A : Set) → F A → D

--- a/test/Fail/Issue4150c.agda
+++ b/test/Fail/Issue4150c.agda
@@ -1,0 +1,13 @@
+-- Andreas, 2026-02-28, issue #4150
+-- Prefer MissingTypeSignature error over NotInScope error.
+
+mutual
+  R' = R
+  record R where
+    field f : Set
+
+-- Expected error: [MissingTypeSignature.Record]
+-- Missing type signature for record definition R
+-- when scope checking the declaration
+--   record R where
+--     field f : Set

--- a/test/Fail/Issue4150c.err
+++ b/test/Fail/Issue4150c.err
@@ -1,0 +1,5 @@
+Issue4150c.agda:6.3-7.18: error: [MissingTypeSignature.Record]
+Missing type signature for record definition R
+when scope checking the declaration
+  record R where
+    field f : Set


### PR DESCRIPTION
- **[refactor] Bundle `checkLoneSigs` and `replaceSigs`**
  These always appear in succession.
  

- **Fix #4150 by sorting lone defs in a mutual block up**
  This priortises the MissingTypeSignature error over NotInScope errors that are a consequence of this.
  