### PR TITLE
Revert #8382 (and fix #8843)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,20 +385,6 @@ Changes to type checker and other components defining the Agda language.
   For compatibility with modules using `--cubical[=full]` and `--cubical=erased`, see
   [variants](https://agda.readthedocs.io/en/v2.9.0/language/cubical.html#variants).
 
-* (**BREAKING**): Module applications are no longer automatically eta-expanded.
-  E.g. previously, given the below three modules:
-  ```agda
-  module A where
-    postulate X : Set
-
-  module B (Y : Set) where
-    open A public
-
-  module C = B
-  ```
-  `B.X` would have type `Set` while `C.X` would have type `Set → Set` (as if
-  the user wrote `module C Y = B Y`). After this change, `C.X : Set` instead.
-
 * Added the [Sharp modality](https://agda.readthedocs.io/en/v2.9.0/language/flat.html#the-sharp-modality),
   which adds a right adjoint to the existing flat modality enabled via the
   `--cohesion` flag. This also enables the use of attributes in record

--- a/src/full/Agda/TypeChecking/Monad/Signature.hs
+++ b/src/full/Agda/TypeChecking/Monad/Signature.hs
@@ -591,19 +591,17 @@ applySection' new ptel old ts ren@ScopeCopyInfo{ renNames = rd, renModules = rm 
     copyDef ts x y = do
       def <- getConstInfo x
       np  <- argsToUse (qnameModule x)
-      -- Because of https://github.com/agda/agda/issues/892 we might have too
-      -- many arguments and need to drop some
       origTel <- lookupSection $ qnameModule x
-      let ts' = drop (size ts - size origTel) ts
       -- Issue #3083: We need to use the hiding from the telescope of the
       -- original module. This can be different than the hiding for the common
       -- parent in the case of record modules.
       let hidings = map getHiding $ telToList origTel
-      let ts'' = zipWith setHiding hidings ts'
+      -- This 'zipWith' sometimes silently drops arguments, see #8443
+      let ts' = zipWith setHiding hidings ts
       commonTel <- lookupSection (commonParentModule old $ qnameModule x)
       reportSDoc "tc.mod.apply" 80 $ vcat
         [ "copyDef" <+> pretty x <+> "->" <+> pretty y
-        , "ts'' = " <+> pretty ts'' ]
+        , "ts' = " <+> pretty ts' ]
       -- The module telescope had been divided by some μ, so the corresponding
       -- top level definition had type μ \ Γ → B, so if we have a substitution
       -- Δ → Γ we actually want to apply μ \ - to it, so the new top-level
@@ -614,7 +612,7 @@ applySection' new ptel old ts ren@ScopeCopyInfo{ renNames = rd, renModules = rm 
                            , modPolarity = getModalPolarity ai
                            }
       localTC (over eContext (fmap (mapModality (m `inverseComposeModality`)))) $
-        copyDef' ts'' np def
+        copyDef' ts' np def
       reportSDoc "tc.mod.apply" 80 $
         "finished copyDef" <+> pretty x <+> "->" <+> pretty y
       where
@@ -803,10 +801,7 @@ applySection' new ptel old ts ren@ScopeCopyInfo{ renNames = rd, renModules = rm 
       reportSDoc "tc.mod.apply" 80 $ "Copying section" <+> pretty x <+> "to" <+> pretty y
       totalArgs <- argsToUse x
       tel       <- lookupSection x
-      -- Because of https://github.com/agda/agda/issues/892 we might have too
-      -- many arguments and need to drop some
-      let ts' = drop (size ts - size tel) ts
-      let sectionTel = apply tel $ take totalArgs ts'
+      let sectionTel = apply tel $ take totalArgs ts
       reportSDoc "tc.mod.apply" 80 $ "  ts           = " <+> mconcat (List.intersperse "; " (map pretty ts))
       reportSDoc "tc.mod.apply" 80 $ "  totalArgs    = " <+> text (show totalArgs)
       reportSDoc "tc.mod.apply" 80 $ "  tel          = " <+> text (unwords (map (fst . unDom) $ telToList tel))  -- only names

--- a/src/full/Agda/TypeChecking/Rules/Decl.hs
+++ b/src/full/Agda/TypeChecking/Rules/Decl.hs
@@ -1091,7 +1091,14 @@ checkSectionApplication'
       , nest 2 $ pretty copyInfo
       ]
     args <- instantiateFull $ vs ++ ts
-    applySection m1 ptel m2 args copyInfo
+    -- If we want to avoid eta-expanding modules (while supporting the current
+    -- 'open public' behaviour) we should also change 'renName'/'renMod'
+    -- in Agda.Syntax.Scope.Monad
+    -- See #8443
+    let n = size aTel
+    etaArgs <- inTopContext $ addContext aTel getContextArgs
+    addContext (KeepNames aTel) $
+      applySection m1 (ptel `abstract` aTel) m2 (raise n args ++ etaArgs) copyInfo
 
 checkSectionApplication' _ Erased{} _ A.RecordModuleInstance{} _ =
   __IMPOSSIBLE__

--- a/test/Fail/Issue8443.agda
+++ b/test/Fail/Issue8443.agda
@@ -1,0 +1,19 @@
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+module Issue8443 where
+
+data ⊥ : Set where
+
+module M1 (bot : ⊥) where
+  foo : ⊥
+  foo = bot
+
+module M2 (n : Nat) where
+  open M1 public
+
+module M3           = M2
+module M4           = M3 42
+
+test : ⊥
+test = M4.foo

--- a/test/Fail/Issue8443.err
+++ b/test/Fail/Issue8443.err
@@ -1,0 +1,6 @@
+Issue8443.agda:19.8-14: error: [UnequalTypes]
+The type
+  (bot : ⊥) → ⊥
+is not a subtype of
+  ⊥
+when checking that the expression M4.foo has type ⊥

--- a/test/Fail/Issue8443b.agda
+++ b/test/Fail/Issue8443b.agda
@@ -1,0 +1,20 @@
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+module Issue8443b where
+
+data ⊥ : Set where
+
+module M1 (bot : ⊥) where
+  module M2 (n : Nat) where
+    foo : ⊥
+    foo = bot
+
+module M3 (n : Nat) where
+  open M1 public
+
+module M4 = M3
+module M5 = M4 42
+
+test : ⊥
+test = M5.M2.foo 3

--- a/test/Fail/Issue8443b.err
+++ b/test/Fail/Issue8443b.err
@@ -1,0 +1,9 @@
+Issue8443b.agda:20.8-19: error: [UnequalTypes]
+The type
+  (n : Nat) → ⊥
+is not a subtype of
+  ⊥
+when checking that the inferred type of an application
+  (n : Nat) → ⊥
+matches the expected type
+  ⊥

--- a/test/Succeed/Issue1985.agda
+++ b/test/Succeed/Issue1985.agda
@@ -27,8 +27,7 @@ module Fails where
   A₀ : Set
   A₀ = Par.A
 
-  A₁ B₁ B₂ : Set₁ → Set
-  A₂ : Set
+  A₁ A₂ B₁ B₂ : Set₁ → Set
   A₁ = RenP.A
   A₂ = Ren.A
   B₁ = RenP.B

--- a/test/Succeed/Issue1985c.agda
+++ b/test/Succeed/Issue1985c.agda
@@ -28,12 +28,12 @@ module Baz = Par1
 
 module Test4 where
   open Baz.Par2
-  test : Set
+  test : Set₁ → Set
   test = A
 
 module Test5 where
   open Baz.Par2 Set
-  test : Set
+  test : Set₁ → Set
   test = A
 
 module Test6 where

--- a/test/Succeed/Issue8443.agda
+++ b/test/Succeed/Issue8443.agda
@@ -1,0 +1,18 @@
+module Issue8443 where
+
+record Precategory : Set₁ where
+  field
+    Ob : Set
+
+open Precategory
+
+postulate is-terminal : (C : Precategory) → C .Ob → Set
+
+module _ (C : Precategory) where
+  record Terminal : Set where
+    field
+      top  : C .Ob
+      has⊤ : is-terminal C top
+
+module _ (B : Precategory) {top} (term : is-terminal B top) where
+  open Terminal {C = B} record{ has⊤ = term } hiding (top)

--- a/test/Succeed/Issue8443b.agda
+++ b/test/Succeed/Issue8443b.agda
@@ -1,0 +1,16 @@
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Nat
+
+-- Variant of #165
+module Issue8443b where
+
+postulate X : Set
+
+module R₀ (X : Set) where
+  postulate P : Set
+
+module R₁ (X : Set) where
+  open R₀ X public
+
+open R₁ X
+postulate p : P

--- a/test/Succeed/Issue892b.agda
+++ b/test/Succeed/Issue892b.agda
@@ -25,10 +25,10 @@ module QM2p (x : D) = Q.M2 x x
 test-h : X₂ → D
 test-h = QM2d.h
 
-test-g₁ : X₁ → D
+test-g₁ : X₂ → X₁ → D
 test-g₁ = QM2d.g
 
-test-g₂ : D → X₁ → D
+test-g₂ : D → X₂ → X₁ → D
 test-g₂ = QM2p.g
 
 data Nat : Set where
@@ -91,6 +91,6 @@ module NT = NatTrans
 foo : Set → Set
 foo X = Eta.Z X → Eta′.Z X
   module Local where
-    module Eta = NT.NatT X
+    module Eta = NT.NatT X X
     -- equivalent to
-    module Eta′ (Y : Set) = NT.NatT X Y
+    module Eta′ (Y : Set) = NT.NatT X X Y


### PR DESCRIPTION
Fixes #8443

The `__IMPOSSIBLE__` with the record application came from `drop`-ing arguments rather than `take`-ing in `copyDef`. Fixing this is not so hard (I think dropping arguments was just wrong), but while I was investigating, I noticed a deeper problem:
```agda
open import Agda.Builtin.Nat

module Issue1985d where

data ⊥ : Set where

module M1 (bot : ⊥) where
  foo : ⊥
  foo = bot

module M2 (n : Nat) where
  open M1 public

module M3 = M2
module M4 = M3 42

ohNo : ⊥
ohNo = M4.foo
```
I think to actually make non-eta-expanded module applications work, we should also change `renName` and `renMod` in `Agda.Syntax.Scope.Monad`. I experimented with doing this in https://github.com/NathanielB123/agda/pull/9. Unfortunately it is very fiddly - changing the modules we re-export definitions under has consequences for how much we should lambda-lift them.

Right now I think the easiest option is to just revert #8382 (and add the new tests to the test suite). I am hopeful that local rewrite rules can still be made to work under this eta-expanding behaviour by explicitly passing the telescope (or more conservatively, just throwing a type error on partial module applications that invalidate local rewrite rules).