### PR TITLE
[ #8283 ] Fix highlighting race condition in agda2-mode

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -834,31 +834,29 @@ command is sent to Agda (if it is sent)."
   ;; arguments.  The symbol of the invoked function must have a
   ;; `agda2-safe-function' symbol property asserting the expected
   ;; types of all arguments, w.r.t `cl-typep'.
-  (unwind-protect
-      (let* ((inhibit-read-only t)
-             (func (car response))
-             (safe-p (plist-member (symbol-plist func) 'agda2-safe-function))
-             (safe-data (cadr safe-p))
-             (args '()))
-        (unless safe-p
-          (error "The function `%S' is not a valid Agda command" func))
-        ;; Check each argument
-        (dolist (arg (cdr response))
-          (when (null safe-data)
-            (error "More arguments than expected for `%S' (%S, got %S)"
-                   func safe-data response))
-          (when (eq (car-safe arg) 'quote) ;unquote arguments
-            (setq arg (cadr arg)))
-          (let ((type (pop safe-data)))
-            (unless (cl-typep arg type)
-              (error "The function `%S' was invoked with %S which is not a %S"
-                     func arg type)))
-          (push arg args))
-        (condition-case err
-            (with-local-quit
-              (apply func (nreverse args)))
-          (error (warn "Error while evaluating %S: %S" response err))))
-    (setq agda2-in-progress nil)))
+  (let* ((inhibit-read-only t)
+         (func (car response))
+         (safe-p (plist-member (symbol-plist func) 'agda2-safe-function))
+         (safe-data (cadr safe-p))
+         (args '()))
+    (unless safe-p
+      (error "The function `%S' is not a valid Agda command" func))
+    ;; Check each argument
+    (dolist (arg (cdr response))
+      (when (null safe-data)
+        (error "More arguments than expected for `%S' (%S, got %S)"
+               func safe-data response))
+      (when (eq (car-safe arg) 'quote) ;unquote arguments
+        (setq arg (cadr arg)))
+      (let ((type (pop safe-data)))
+        (unless (cl-typep arg type)
+          (error "The function `%S' was invoked with %S which is not a %S"
+                 func arg type)))
+      (push arg args))
+    (condition-case err
+        (with-local-quit
+          (apply func (nreverse args)))
+      (error (warn "Error while evaluating %S: %S" response err)))))
 
 
 


### PR DESCRIPTION
Fixes #8283. After some investigation, it seems that setting `agda2-in-progress` to `nil` in `agda2-exec-response` caused us to fall through the guard at the start of `agda2-highlight-tokens`. Moreover, `agda2-highlight-tokens` is set as an `after-save-hook`, so saving while some long-running request was in fly caused highlighting to get queued up when it shouldn't have.