### PR TITLE
[ #8452 ] Make agda2-maybe-goto jump across files

### DIFF
--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -400,9 +400,6 @@ The command which arrived last is stored first in the list.")
   "The Agda buffer.
 Note that this variable is not buffer-local.")
 
-(defvar agda2-in-agda2-file-buffer nil
-  "Was `agda2-file-buffer' active when `agda2-output-filter' started?
-Note that this variable is not buffer-local.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; agda2-mode
@@ -685,9 +682,7 @@ reloaded from `agda2-highlighting-file', unless
   ;; extract the fontified text and kill the temp buffer; so when Agda
   ;; finally answers, the temp buffer is long gone.
   (when (buffer-live-p agda2-file-buffer)
-  (setq agda2-in-agda2-file-buffer
-        (and agda2-file-buffer
-             (equal (current-buffer) agda2-file-buffer)))
+
   (let (;; The input lines in the current chunk.
         (lines (split-string chunk "\n"))
 

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -2180,11 +2180,10 @@ If there is a buffer already visiting FILE that is displayed in
 some windows, then the point is updated to POSITION in all of those
 windows.
 
-If there is a buffer visiting FILE that is not displayed in a window,
-then switch to that buffer and update the point to POSITION.
+If there is a buffer visiting FILE that is not displayed in any windows,
+then update the point, but do not display it.
 
-Finally, if no buffer is visiting FILE, then create a buffer visiting FILE,
-display it in the current window, and set the point to POSITION."
+If there is no buffer visiting FILE, do nothing."
   (declare (agda2-command (cons)))
   (when (and agda2-highlight-in-progress
              (consp filepos)
@@ -2195,15 +2194,16 @@ display it in the current window, and set the point to POSITION."
     ;; the current marker onto Xref' stack to make it seem like a Xref
     ;; jump.
     (xref-push-marker-stack)
-    (let ((buffer (find-file-noselect (car filepos) 'no-record)))
-      (if-let* ((windows (get-buffer-window-list buffer 'no-minibuffer 'all-frames)))
-          ;; Buffer is visible, update points and do not switch.
-          (dolist (window windows)
-            (with-selected-window window
-              (goto-char (cdr filepos))))
-        ;; Buffer not visible, switch to the current buffer.
-        (switch-to-buffer buffer 'no-record)
-        (goto-char (cdr filepos))))))
+    (if-let* ((buffer (find-buffer-visiting (car filepos))))
+        (if-let* ((windows (get-buffer-window-list buffer 'no-minibuffer 'all-frames)))
+            ;; Buffer is visible, update points in all windows.
+            (dolist (window windows)
+              (with-selected-window window
+                (goto-char (cdr filepos))))
+          ;; Buffer exists, but is not visible.
+          ;; We do not display the buffer here, as can be jarring for slow loads.
+          ;; See https://github.com/agda/agda/pull/8458#issuecomment-4032442448
+          (goto-char (cdr filepos))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Implicit arguments

--- a/src/data/emacs-mode/agda2-mode.el
+++ b/src/data/emacs-mode/agda2-mode.el
@@ -2180,12 +2180,16 @@ invoked."
 FILEPOS should have the form (FILE . POSITION).
 
 If `agda2-highlight-in-progress' is nil, then nothing happens.
-Otherwise, if the current buffer is the one that is connected to
-the Agda process, then point is moved to POSITION in
-FILE (assuming that the FILE is readable). Otherwise point is
-moved to the given position in the buffer visiting the file, if
-any, and in every window displaying the buffer, but the window
-configuration and the selected window are not changed."
+
+If there is a buffer already visiting FILE that is displayed in
+some windows, then the point is updated to POSITION in all of those
+windows.
+
+If there is a buffer visiting FILE that is not displayed in a window,
+then switch to that buffer and update the point to POSITION.
+
+Finally, if no buffer is visiting FILE, then create a buffer visiting FILE,
+display it in the current window, and set the point to POSITION."
   (declare (agda2-command (cons)))
   (when (and agda2-highlight-in-progress
              (consp filepos)
@@ -2196,8 +2200,15 @@ configuration and the selected window are not changed."
     ;; the current marker onto Xref' stack to make it seem like a Xref
     ;; jump.
     (xref-push-marker-stack)
-    (set-buffer (find-file-noselect (car filepos)))
-    (goto-char (cdr filepos))))
+    (let ((buffer (find-file-noselect (car filepos) 'no-record)))
+      (if-let* ((windows (get-buffer-window-list buffer 'no-minibuffer 'all-frames)))
+          ;; Buffer is visible, update points and do not switch.
+          (dolist (window windows)
+            (with-selected-window window
+              (goto-char (cdr filepos))))
+        ;; Buffer not visible, switch to the current buffer.
+        (switch-to-buffer buffer 'no-record)
+        (goto-char (cdr filepos))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Implicit arguments


### PR DESCRIPTION
Fixes #8452. 

Previously, `agda2-goto-maybe` was calling `set-buffer`, which does not cause the buffer to be displayed. I've reverted the behaviour back to the version that is similar to the code before #8181, though I call `switch-to-buffer` if the buffer containing the error is not visible, and create a buffer that visits the file if there wasn't already one.

I've also taken the opportunity to remove `agda2-in-agda2-file-buffer`. Previously, this was used to do some conditional annotation jumping in `agda2-goto-maybe`, but it is currently unused. Moreover, it is a race condition just waiting to happen, so removing it seems like a wise choice.