### PR TITLE
re. #8457: only ask if meta is an IP if cubical

### DIFF
--- a/src/full/Agda/TypeChecking/MetaVars.hs
+++ b/src/full/Agda/TypeChecking/MetaVars.hs
@@ -835,12 +835,10 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
     text "MetaVars.assign: assigning meta  " <> pretty x <> text "  with args  " <> pretty args <> text "  to  " <> pretty v
 
   let
-    boundary v = do
-      cubical <- cubicalOption
-      isip <- isInteractionMetaB x args
-      case (,) <$> cubical <*> isip of
-        Just (_, (x, ip, args)) -> tryAddBoundary dir x ip args v target
-        _ -> pure ()
+    boundary v = runMaybeT do
+      _ <- MaybeT cubicalOption
+      (x, ip, args) <- MaybeT (isInteractionMetaB x args)
+      lift $ tryAddBoundary dir x ip args v target
 
   case (v, mvJudgement mvar) of
       (Sort s, HasType{}) -> hasBiggerSort s
@@ -905,7 +903,7 @@ assign dir x args v target = addOrUnblocker (unblockOnMeta x) $ do
   when (mvFrozen mvar == Frozen) $ do
     reportSLn "tc.meta.assign" 25 $ "aborting: meta is frozen!"
     -- IApplyConfluence can contribute boundary conditions to frozen metas
-    boundary v
+    void $ boundary v
     patternViolation neverUnblock
 
   -- We never get blocked terms here anymore. TODO: we actually do. why?


### PR DESCRIPTION
*Sigh*

> To be honest, I don't really understand the twin meta stuff. I find it unlikely that the `mvTwin` case of `instantiate` is to blame, since `stInstantiateBlocking` is only set to `True` **for interactive things**

… she says, immediately working out what the issue is.

To be honest I have no idea how to make a reproducer for this, but the problem was indeed that `isInteractionMeta[B]` → `instantiate'` goes into a tailspin if a meta is solved to its own twin, like @AndrasKovacs pointed out, and that the code for looking up ⟨whether a meta should have boundary constraints attached⟩ tries to see through solutions to find whether we have a situation like `_123 := ?456`, `_123 (i = i0) := foo` (so it can hang `i = i0 ⊢ foo` off `456`)… Only running this code in cubical is sufficient to make TypeTopology pass, but what the hell. Cursed cursed cursed issue.