### PR TITLE
Fix #8454

### DIFF
--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -1357,7 +1357,7 @@ data AllowAmbiguousNames
   | AmbiguousConProjs
       -- ^ Ambiguous constructors, projections, or pattern synonyms.
   | AmbiguousNothing
-  deriving (Eq)
+  deriving (Eq, Show)
 
 isNameInScope :: A.QName -> ScopeInfo -> Bool
 isNameInScope q scope =
@@ -1386,6 +1386,22 @@ inverseScopeLookupName'' amb q scope = billToPure [ Scoping , InverseNameLookup 
 
   NameMapEntry k xs <- HMap.lookup (A.nameId q) (scope ^. scopeInverseName)
 
+  -- try to get an unqualified concrete name, that's probably given
+  -- by the user.
+  let getUserGivenRawName :: C.QName -> Maybe RawName
+      getUserGivenRawName = \case
+        C.QName x -> case x of
+          C.Name r _ parts -> case r of
+            NoRange -> Nothing
+            _       -> case List1.last parts of
+              C.Id x -> Just x
+              _      -> Nothing
+          C.NoName{} -> Nothing
+        C.Qual _ x -> getUserGivenRawName x
+
+  -- unqualified original concrete name
+  let !userGiven = getUserGivenRawName (C.QName $ nameConcrete $ qnameName q)
+
   !xs <- List1.nonEmpty $ List.sortOn snd do
     -- List comprehension written in monadic form
     q :: C.QName <- nubOn id $ List1.toList xs
@@ -1407,11 +1423,13 @@ inverseScopeLookupName'' amb q scope = billToPure [ Scoping , InverseNameLookup 
     --
     -- The rules are currently, in lexicographic order:
     --   1. Less qualified names are preferred
-    --   2. Names introduced later are preferred, by source position.
+    --   2. Names whose unqualified name part is the same as what the user originally wrote, are
+    --      preferred.
+    --   3. Names introduced later are preferred, by source position.
     --      If a single module opening introduces multiple possible printable names,
     --      we recursively prefer the names that were introduced later within the module.
     --
-    -- Caveat: rule 2 only fires within the current source file. Currently we can't use it across
+    -- Caveat: rule 3 only fires within the current source file. Currently we can't use it across
     -- files because we don't store ranges in interfaces. Currently we happen to pick the
     -- alphabetically greater names in those cases.
     let lineageRanges = go (anameLineage $ fst y) where
@@ -1420,7 +1438,14 @@ inverseScopeLookupName'' amb q scope = billToPure [ Scoping , InverseNameLookup 
           go (Applied x why) = let !r = getRange x; !rs = go why in Down r:rs
 
     let sortingWeight = let !qualifiers = length (C.qnameParts q)
-                        in (qualifiers, lineageRanges)
+                            !preferUserGiven = case (userGiven, getUserGivenRawName q) of
+                              (Just x, Just x') | x == x' -> Down True
+                              _                           -> Down False
+                        in (
+                             qualifiers
+                           , preferUserGiven
+                           , lineageRanges
+                           )
 
     pure (q, sortingWeight)
 

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -1345,8 +1345,6 @@ scopeLookup' q scope = nubOn fst $ inAllScopes ++ topImports ++ imports
         -- Get the scope of module m, if any, and remove its private definitions.
         let ss  = Map.lookup m $ scope ^. scopeModules
             ss' = restrictPrivate <$> ss
-        -- trace ("ss  = " ++ show ss ) $ do
-        -- trace ("ss' = " ++ show ss') $ do
         s' <- maybeToList ss'
         findName q s'
 
@@ -1388,7 +1386,7 @@ inverseScopeLookupName'' amb q scope = billToPure [ Scoping , InverseNameLookup 
 
   NameMapEntry k xs <- HMap.lookup (A.nameId q) (scope ^. scopeInverseName)
 
-  !xs <- List1.nonEmpty $ List.sortOn (length . C.qnameParts &!& Down . getRange) $ do
+  !xs <- List1.nonEmpty $ List.sortOn snd do
     -- List comprehension written in monadic form
     q :: C.QName <- nubOn id $ List1.toList xs
     let y:ys = scopeLookup' q scope
@@ -1404,10 +1402,29 @@ inverseScopeLookupName'' amb q scope = billToPure [ Scoping , InverseNameLookup 
                      && all ((k ==) . anameKind . fst) ys)))
 
     guard unambiguous
-    pure q
 
-  -- traceM ("LKUP " ++ prettyShow xs)
+    -- Computing priority for name printing.
+    --
+    -- The rules are currently, in lexicographic order:
+    --   1. Less qualified names are preferred
+    --   2. Names introduced later are preferred, by source position.
+    --      If a single module opening introduces multiple possible printable names,
+    --      we recursively prefer the names that were introduced later within the module.
+    --
+    -- Caveat: rule 2 only fires within the current source file. Currently we can't use it across
+    -- files because we don't store ranges in interfaces. Currently we happen to pick the
+    -- alphabetically greater names in those cases.
+    let lineageRanges = go (anameLineage $ fst y) where
+          go Defined         = let !r = Down $! getRange q in [r]
+          go (Opened x why)  = let !r = getRange x; !rs = go why in Down r:rs
+          go (Applied x why) = let !r = getRange x; !rs = go why in Down r:rs
 
+    let sortingWeight = let !qualifiers = length (C.qnameParts q)
+                        in (qualifiers, lineageRanges)
+
+    pure (q, sortingWeight)
+
+  !xs <- pure (List1.map' fst xs)
   pure $ NameMapEntry k xs
 
 -- | Find the concrete names that map (uniquely) to a given abstract module name.
@@ -1464,7 +1481,10 @@ recomputeInverseNamesAndModules scope = St2.execState goCurrent (mempty, mempty)
   look m    = fromMaybe __IMPOSSIBLE__ $ Map.lookup m mods
   !mods     = scope ^. scopeModules
   !s0       = look (scope ^. scopeCurrent)
-  goCurrent = go [] s0 *> forM_ (scopeParents s0) (go [] . look)
+
+  -- we traverse outer scopes first, because this causes inner names
+  -- to appear first in name lists, and we prefer printing inner names
+  goCurrent = goParents (scopeParents s0) *> go [] s0
 
   updQuals (C.QName x)  quals = x:quals
   updQuals (C.Qual x n) quals = updQuals n (x:quals)
@@ -1484,6 +1504,11 @@ recomputeInverseNamesAndModules scope = St2.execState goCurrent (mempty, mempty)
   updNames qualx nid entry = do
     let upd _ (NameMapEntry k xs) = NameMapEntry k $! qualx List1.<| xs
     St2.modify1 $ HMap.insertWith upd nid entry
+
+  goParents :: [ModuleName] -> St2.State NameMap ModuleMap ()
+  goParents = \case
+    []   -> pure ()
+    s:ss -> goParents ss *> go [] (look s)
 
   go :: [C.Name] -> Scope -> St2.State NameMap ModuleMap ()
   go !quals s = do

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -1388,19 +1388,16 @@ inverseScopeLookupName'' amb q scope = billToPure [ Scoping , InverseNameLookup 
 
   -- try to get an unqualified concrete name, that's probably given
   -- by the user.
-  let getUserGivenRawName :: C.QName -> Maybe RawName
-      getUserGivenRawName = \case
+  let getUserGivenName :: C.QName -> Maybe NameParts
+      getUserGivenName = \case
         C.QName x -> case x of
-          C.Name r _ parts -> case r of
-            NoRange -> Nothing
-            _       -> case List1.last parts of
-              C.Id x -> Just x
-              _      -> Nothing
-          C.NoName{} -> Nothing
-        C.Qual _ x -> getUserGivenRawName x
+          C.NoName{}         -> Nothing
+          C.Name NoRange _ _ -> Nothing
+          C.Name _ _ parts   -> Just parts
+        C.Qual _ x -> getUserGivenName x
 
   -- unqualified original concrete name
-  let !userGiven = getUserGivenRawName (C.QName $ nameConcrete $ qnameName q)
+  let !userGiven = getUserGivenName (C.QName $ nameConcrete $ qnameName q)
 
   !xs <- List1.nonEmpty $ List.sortOn snd do
     -- List comprehension written in monadic form
@@ -1438,7 +1435,7 @@ inverseScopeLookupName'' amb q scope = billToPure [ Scoping , InverseNameLookup 
           go (Applied x why) = let !r = getRange x; !rs = go why in Down r:rs
 
     let sortingWeight = let !qualifiers = length (C.qnameParts q)
-                            !preferUserGiven = case (userGiven, getUserGivenRawName q) of
+                            !preferUserGiven = case (userGiven, getUserGivenName q) of
                               (Just x, Just x') | x == x' -> Down True
                               _                           -> Down False
                         in (

--- a/src/full/Agda/Utils/List1.hs
+++ b/src/full/Agda/Utils/List1.hs
@@ -63,6 +63,11 @@ type String1 = List1 Char
 toList' :: Maybe (List1 a) -> [a]
 toList' = maybe [] toList
 
+{-# INLINE map' #-}
+-- | Strict map.
+map' :: (a -> b) -> List1 a -> List1 b
+map' f (a :| as) = let !b = f a; !bs = List.map' f as in b :| bs
+
 -- | Lift a function on non-empty lists to a function on lists.
 --
 -- This is in essence 'fmap' for 'Maybe', if we take @[a] = Maybe (List1 a)@.

--- a/test/Fail/AmbiguousConstructor.err
+++ b/test/Fail/AmbiguousConstructor.err
@@ -3,4 +3,4 @@ Ambiguous constructor c2.
 It could refer to any of
   Foo.D.c0 (introduced at AmbiguousConstructor.agda:5.5-7)
   Foo.D.c1 (introduced at AmbiguousConstructor.agda:6.5-7)
-when checking that the pattern c2 has type D
+when checking that the pattern c0 has type D

--- a/test/Fail/AmbiguousConstructor.err
+++ b/test/Fail/AmbiguousConstructor.err
@@ -3,4 +3,4 @@ Ambiguous constructor c2.
 It could refer to any of
   Foo.D.c0 (introduced at AmbiguousConstructor.agda:5.5-7)
   Foo.D.c1 (introduced at AmbiguousConstructor.agda:6.5-7)
-when checking that the pattern c0 has type D
+when checking that the pattern c2 has type D

--- a/test/Fail/Issue8454.agda
+++ b/test/Fail/Issue8454.agda
@@ -1,0 +1,2 @@
+
+import Issue8454.B

--- a/test/Fail/Issue8454.err
+++ b/test/Fail/Issue8454.err
@@ -1,0 +1,7 @@
+Issue8454/B.agda:6.8-12: error: [UnequalTypes]
+The types
+  Type₁
+and
+  Type
+are not equal
+when checking that the expression Type has type Type

--- a/test/Fail/Issue8454/A.agda
+++ b/test/Fail/Issue8454/A.agda
@@ -1,0 +1,2 @@
+module Issue8454.A where
+open import Agda.Primitive public renaming (Set to Type)

--- a/test/Fail/Issue8454/B.agda
+++ b/test/Fail/Issue8454/B.agda
@@ -1,0 +1,6 @@
+module Issue8454.B where
+
+open import Issue8454.A
+
+test : Type
+test = Type

--- a/test/Fail/MacroNotToTerm.err
+++ b/test/Fail/MacroNotToTerm.err
@@ -1,2 +1,2 @@
 MacroNotToTerm.agda:11.3-10: error: [MacroResultTypeMismatch]
-Result type of a macro must be Term → TC ⊤
+Result type of a macro must be Term → TC Unit

--- a/test/interaction/Issue1349.out
+++ b/test/interaction/Issue1349.out
@@ -2,7 +2,7 @@
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
 (agda2-status-action "")
-(agda2-info-action "*All Goals*" "?0 : ⊤ → Nat" nil)
+(agda2-info-action "*All Goals*" "?0 : Unit → Nat" nil)
 ((last . 1) . (agda2-goals-action '(0)))
 (agda2-give-action 0 "d")
 ((last . 1) . (agda2-goals-action '()))

--- a/test/interaction/Issue4022.out
+++ b/test/interaction/Issue4022.out
@@ -13,7 +13,7 @@
 (agda2-status-action "Checked")
 (agda2-info-action "*Search About*" "Definitions about Nat, \"plus\" plus : Nat → Nat → Nat" nil)
 (agda2-status-action "Checked")
-(agda2-info-action "*Search About*" "Definitions about Nat _*_ : Nat → Nat → Nat _+_ : Nat → Nat → Nat _∸_ : Nat → Nat → Nat length : {a : Agda.Primitive.Level} {A : Set a} → List A → Nat natToString : Nat → String plus : Nat → Nat → Nat pred : Nat → Nat primCharToNat : Char → Nat primCharToNatInjective : (a b : Char) → primCharToNat a ≡ primCharToNat b → a ≡ b primNatToChar : Nat → Char primNatToFloat : Nat → Float primShowNat : Nat → String printNat : Nat → IO ⊤ suc : Nat → Nat zero : Nat" nil)
+(agda2-info-action "*Search About*" "Definitions about Nat _*_ : Nat → Nat → Nat _+_ : Nat → Nat → Nat _∸_ : Nat → Nat → Nat length : {a : Agda.Primitive.Level} {A : Set a} → List A → Nat natToString : Nat → String plus : Nat → Nat → Nat pred : Nat → Nat primCharToNat : Char → Nat primCharToNatInjective : (a b : Char) → primCharToNat a ≡ primCharToNat b → a ≡ b primNatToChar : Nat → Char primNatToFloat : Nat → Float primShowNat : Nat → String printNat : Nat → IO Unit suc : Nat → Nat zero : Nat" nil)
 (agda2-info-action "*Error*" "error: [Interaction.ExpectedIdentifier] Expected identifier, but found: 42" nil)
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")


### PR DESCRIPTION
Compute a sensible priority for name printing.
The rules are currently, in lexicographic order:

1. Less qualified names are preferred
2. Names whose unqualified name part is the same as what the user originally wrote, are preferred.
3. Names introduced later are preferred, by source position. If a single module opening introduces multiple possible printable names, we recursively prefer the names that were introduced later within the module.

Caveat: rule 3 only fires within the current source file. Currently we can't use it across files because we don't store ranges in interfaces. Currently we happen to pick the alphabetically greater names in those cases.