### PR TITLE
Delete `sortRulesOfSymbol`

### DIFF
--- a/src/full/Agda/Interaction/Imports.hs
+++ b/src/full/Agda/Interaction/Imports.hs
@@ -92,7 +92,7 @@ import Agda.TypeChecking.InstanceArguments
 import Agda.TypeChecking.Errors
 import Agda.TypeChecking.Warnings hiding (warnings)
 import Agda.TypeChecking.Reduce
-import Agda.TypeChecking.Rewriting.Confluence ( checkConfluenceOfRules, sortRulesOfSymbol )
+import Agda.TypeChecking.Rewriting.Confluence ( checkConfluenceOfRules )
 import Agda.TypeChecking.Rewriting.NonLinPattern (getMatchables)
 import Agda.TypeChecking.MetaVars ( openMetasToPostulates )
 import Agda.TypeChecking.Monad.State as S
@@ -353,12 +353,6 @@ mergeInterface i = do
           reportSDoc "" 1 $ P.vcat $ map (P.nest 2) $
             "Checking confluence of imported rewrite rules" :
             map (("-" P.<+>) . prettyTCM . grName) rews
-
-      -- Andreas, 2025-06-28, PR #7934 and issue #7969:
-      -- Global confluence checker requires rules to be sorted
-      -- according to the generality of their lhs
-      when (confChk == GlobalConfluenceCheck) $
-        forM_ (nubOn id $ map grHead rews) sortRulesOfSymbol
 
       -- #8273: We need to ensure the module we are importing is considered
       -- imported when checking confluence.

--- a/src/full/Agda/TypeChecking/Rewriting.hs
+++ b/src/full/Agda/TypeChecking/Rewriting.hs
@@ -155,10 +155,6 @@ addRewriteRules qs = do
   whenJustM (optConfluenceCheck <$> pragmaOptions) $ \confChk -> do
     -- Warn if --cubical is enabled
     whenJustM cubicalOption $ \_ -> warning ConfluenceForCubicalNotSupported
-    -- Global confluence checker requires rules to be sorted
-    -- according to the generality of their lhs
-    when (confChk == GlobalConfluenceCheck) $
-      forM_ (nubOn id $ map grHead rews) sortRulesOfSymbol
     checkConfluenceOfRules confChk rews
     reportSDoc "rewriting" 10 $
       "done checking confluence of rules" <+>

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -442,7 +442,7 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
       reportSDoc "rewriting.confluence.global" 30 $ fsep
         [ "Global confluence: checking if" , prettyTCM u
         , "reduces to" , prettyTCM w , "in one parallel step." ]
-      anyListT (parReduce u) $ \v -> do
+      anyListT (parReduce Unsorted u) $ \v -> do
         reportSDoc "rewriting.confluence.global" 30 $ fsep
           [ prettyTCM u , " reduces to " , prettyTCM v
           ]
@@ -452,7 +452,7 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
           ]
         return eq
 
-
+-- | Sorts a list of rewrite rules by the generality of their LHSs
 sortRules :: PureTCM m => GlobalRewriteRules -> m GlobalRewriteRules
 sortRules rs = do
   ordPairs <- deleteLoops . Set.fromList . map (grName *** grName) <$>
@@ -544,9 +544,20 @@ type MonadParallelReduce m =
   , MonadFresh NameId m
   )
 
+-- | Should rewrite rules be sorted by the generality of their LHSs before being
+--   applied?
+data SortRules = Sorted | Unsorted
+
+shouldSort :: SortRules -> Bool
+shouldSort Sorted   = True
+shouldSort Unsorted = False
+
 -- | List all possible single-step parallel reductions of the given term.
+--
+--   Sorts rewrite rules by the generality of their LHSs before applying
+--   them.
 allParallelReductions :: (MonadParallelReduce m, ParallelReduce a) => a -> m [a]
-allParallelReductions = sequenceListT . parReduce
+allParallelReductions = sequenceListT . parReduce Sorted
 
 -- | Single-step parallel reduction of a given term.
 --   The monad 'm' can be instantiated in multiple ways:
@@ -555,24 +566,26 @@ allParallelReductions = sequenceListT . parReduce
 --   * Use 'ListT TCM' to obtain all possible one-step parallel
 --     reductions.
 class ParallelReduce a where
-  parReduce :: (MonadParallelReduce m, MonadPlus m) => a -> m a
+  parReduce :: (MonadParallelReduce m, MonadPlus m) => SortRules -> a -> m a
 
   default parReduce
     :: ( MonadParallelReduce m, MonadPlus m
        , Traversable f, a ~ f b, ParallelReduce b)
-    => a -> m a
-  parReduce = traverse parReduce
+    => SortRules -> a -> m a
+  parReduce s = traverse $ parReduce s
 
 -- | Compute possible one-step reductions by applying a rewrite rule
 --   at the top-level and reducing all subterms in the position of a
 --   variable of the rewrite rule in parallel.
-topLevelReductions :: (MonadParallelReduce m, MonadPlus m) => (Elims -> Term) -> Elims -> m Term
-topLevelReductions hd es = do
+topLevelReductions :: (MonadParallelReduce m, MonadPlus m)
+  => SortRules -> (Elims -> Term) -> Elims -> m Term
+topLevelReductions s hd es = do
   reportSDoc "rewriting.parreduce" 30 $ "topLevelReductions" <+> prettyTCM (hd es)
   -- Get type of head symbol
   (f , t) <- fromMaybe __IMPOSSIBLE__ <$> getTypedHead (hd [])
   reportSDoc "rewriting.parreduce" 60 $ "topLevelReductions: head symbol" <+> prettyTCM (hd []) <+> ":" <+> prettyTCM t
-  GlobalRewriteRule q gamma _ ps rhs b c _ <- scatterMP (getAllRulesFor f)
+  let rews = (if shouldSort s then sortRules else pure) =<< getAllRulesFor f
+  GlobalRewriteRule q gamma _ ps rhs b c _ <- scatterMP rews
   reportSDoc "rewriting.parreduce" 60 $ "topLevelReductions: trying rule" <+> prettyTCM q
   -- Don't reduce if underapplied
   guard $ length es >= length ps
@@ -583,23 +596,25 @@ topLevelReductions hd es = do
     -- Matching succeeded
     Right sub -> do
       let vs = map (lookupS sub) $ [0..(size gamma-1)]
-      sub' <- parallelS <$> parReduce vs
-      es1' <- parReduce es1
+      sub' <- parallelS <$> parReduce s vs
+      es1' <- parReduce s es1
       let w = (applySubst sub' rhs) `applyE` es1'
       reportSDoc "rewriting.parreduce" 50 $ "topLevelReductions: rewrote" <+> prettyTCM (hd es) <+> "to" <+> prettyTCM w
       return w
 
 instance ParallelReduce Term where
-  parReduce = \case
+  parReduce s = \case
     -- Interesting cases
-    (Def f es) -> (topLevelReductions (Def f) es) <|> (Def f <$> parReduce es)
-    (Con c ci es) -> (topLevelReductions (Con c ci) es) <|> (Con c ci <$> parReduce es)
+    (Def f es) -> (topLevelReductions s (Def f) es) <|>
+                  (Def f <$> parReduce s es)
+    (Con c ci es) -> (topLevelReductions s (Con c ci) es) <|>
+                     (Con c ci <$> parReduce s es)
 
     -- Congruence cases
-    Lam i u  -> Lam i <$> parReduce u
-    Var x es -> Var x <$> parReduce es
-    Pi a b   -> Pi    <$> parReduce a <*> parReduce b
-    Sort s   -> Sort  <$> parReduce s
+    Lam i u  -> Lam i <$> parReduce s u
+    Var x es -> Var x <$> parReduce s es
+    Pi a b   -> Pi    <$> parReduce s a <*> parReduce s b
+    Sort t   -> Sort  <$> parReduce s t
 
     -- Base cases
     u@Lit{}      -> return u
@@ -612,7 +627,7 @@ instance ParallelReduce Term where
     MetaV{}    -> __IMPOSSIBLE__
 
 instance ParallelReduce Sort where
-  parReduce = pure -- TODO: is this fine?
+  parReduce s = pure -- TODO: is this fine?
 
 instance ParallelReduce a => ParallelReduce (Arg a) where
 instance ParallelReduce a => ParallelReduce (Dom a) where
@@ -620,12 +635,12 @@ instance ParallelReduce a => ParallelReduce (Type' a) where
 instance ParallelReduce a => ParallelReduce [a] where
 
 instance ParallelReduce a => ParallelReduce (Elim' a) where
-  parReduce (Apply u)  = Apply <$> parReduce u
-  parReduce e@Proj{}   = pure e
-  parReduce e@IApply{} = pure e -- TODO
+  parReduce s (Apply u)  = Apply <$> parReduce s u
+  parReduce s e@Proj{}   = pure e
+  parReduce s e@IApply{} = pure e -- TODO
 
 instance (Subst a, ParallelReduce a) => ParallelReduce (Abs a) where
-  parReduce = mapAbstraction __DUMMY_DOM__ parReduce
+  parReduce s = mapAbstraction __DUMMY_DOM__ $ parReduce s
 
 
 -- | Given metavariables ms and some x, construct a telescope Γ and

--- a/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
+++ b/src/full/Agda/TypeChecking/Rewriting/Confluence.hs
@@ -34,7 +34,6 @@
 module Agda.TypeChecking.Rewriting.Confluence
   ( checkConfluenceOfRules
   , checkConfluenceOfClauses
-  , sortRulesOfSymbol
   ) where
 
 import Control.Applicative
@@ -454,34 +453,24 @@ checkConfluenceOfRules confChk rews = inTopContext $ inAbstractMode $ do
         return eq
 
 
-sortRulesOfSymbol :: QName -> TCM ()
-sortRulesOfSymbol f = do
-    -- Andreas, 2025-06-28, PR #7934:
-    -- By getting all rewrite rules regardless of scope,
-    -- we replicate the old (unhygienic) approach to rewrite rule scoping
-    -- here to avoid a regression.
-    -- See also #7969 for a reason why the code below is questionable.
-    rules <- sortRules =<< getFilteredGlobalRewriteRulesFor False f
-    modifySignature $ over sigRewriteRules $ HMap.insert f rules
+sortRules :: PureTCM m => GlobalRewriteRules -> m GlobalRewriteRules
+sortRules rs = do
+  ordPairs <- deleteLoops . Set.fromList . map (grName *** grName) <$>
+    filterM (uncurry $ flip moreGeneralLHS) [(r1,r2) | r1 <- rs, r2 <- rs]
+  let perm = fromMaybe __IMPOSSIBLE__ $
+        topoSort (\r1 r2 -> (grName r1, grName r2) `Set.member` ordPairs) rs
+  reportSDoc "rewriting.confluence.sort" 50 $ "sorted rules: " <+>
+    prettyList_ (map (prettyTCM . grName) $ permute perm rs)
+  return $ permute perm rs
   where
-    sortRules :: PureTCM m => [GlobalRewriteRule] -> m [GlobalRewriteRule]
-    sortRules rs = do
-      ordPairs <- deleteLoops . Set.fromList . map (grName *** grName) <$>
-        filterM (uncurry $ flip moreGeneralLHS) [(r1,r2) | r1 <- rs, r2 <- rs]
-      let perm = fromMaybe __IMPOSSIBLE__ $
-                   topoSort (\r1 r2 -> (grName r1,grName r2) `Set.member` ordPairs) rs
-      reportSDoc "rewriting.confluence.sort" 50 $ "sorted rules: " <+>
-        prettyList_ (map (prettyTCM . grName) $ permute perm rs)
-      return $ permute perm rs
-
     moreGeneralLHS :: PureTCM m
       => GlobalRewriteRule -> GlobalRewriteRule -> m Bool
     moreGeneralLHS r1 r2
-      | sameRuleName r1 r2     = return False
-      | grHead r1 /= grHead r2 = return False
-      | otherwise              = addContext (grContext r2) $ do
-          def <- getConstInfo $ grHead r1
-          (t, hd) <- makeHead def (grType r2)
+      | sameRuleName r1 r2       = return False
+      | grName r1 /= grName r2 = return False
+      | otherwise                = addContext (grContext r2) $ do
+          def <- getConstInfo $ grName r1
+          (t, hd) <- makeHead def $ grType r2
           (vs :: Elims) <- nlPatToTerm $ grPats r2
           res <- isRight <$> onlyReduceTypes
             (nonLinMatch (grContext r1) (t, hd) (grPats r1) vs)

--- a/test/Succeed/RewritingGlobalConfluenceUnsorted.agda
+++ b/test/Succeed/RewritingGlobalConfluenceUnsorted.agda
@@ -1,0 +1,57 @@
+{-# OPTIONS --rewriting --confluence-check #-}
+
+open import Agda.Builtin.Nat using (Nat; zero; suc)
+open import Agda.Builtin.Equality
+open import Agda.Builtin.Equality.Rewrite
+
+variable
+  k l m n : Nat
+
+postulate
+  max : Nat → Nat → Nat
+  max-0l : max 0 n ≡ n
+  max-0r : max m 0 ≡ m
+  max-diag : max m m ≡ m
+  max-ss : max (suc m) (suc n) ≡ suc (max m n)
+  max-diag-s : max (suc m) (suc m) ≡ suc m -- for global confluence
+  max-assoc : max (max k l) m ≡ max k (max l m)
+
+{-# REWRITE max-0l max-0r #-}
+{-# REWRITE max-diag-s max-diag max-ss #-}
+--{-# REWRITE max-assoc #-} -- not confluent!
+
+postulate
+  _+_ : Nat → Nat → Nat
+  plus-0l : 0 + n ≡ n
+  plus-0r : m + 0 ≡ m
+  plus-00 : 0 + 0 ≡ 0  -- for global confluence
+  plus-suc-l : (suc m) + n ≡ suc (m + n)
+  plus-suc-0 : (suc m) + 0 ≡ suc m -- for global confluence
+  plus-suc-r : m + (suc n) ≡ suc (m + n)
+  plus-0-suc : 0 + (suc n) ≡ suc n
+  plus-suc-suc : (suc m) + (suc n) ≡ suc (suc (m + n))
+  plus-assoc : (k + l) + m ≡ k + (l + m) -- not accepted by global confluence check
+
+{-# REWRITE plus-suc-suc
+            plus-0-suc plus-suc-r
+            plus-suc-0 plus-suc-l
+            plus-0r plus-0l plus-00 #-}
+
+postulate
+  _*_ : Nat → Nat → Nat
+  mult-0l : 0 * n ≡ 0
+  mult-0r : m * 0 ≡ 0
+  mult-00 : 0 * 0 ≡ 0
+  mult-suc-l : (suc m) * n ≡ n + (m * n)
+  mult-suc-l-0 : (suc m) * 0 ≡ 0
+  mult-suc-r : m * (suc n) ≡ (m * n) + m
+  plus-mult-distr-l : k * (l + m) ≡ (k * l) + (k * m)
+  plus-mult-distr-r : (k + l) * m ≡ (k * m) + (l * m)
+  mult-assoc : (k * l) * m ≡ k * (l * m)
+
+{-# REWRITE mult-suc-l-0 mult-suc-l
+            mult-0l mult-0r mult-00 #-}
+-- --{-# REWRITE mult-suc-r #-} -- requires rule plus-assoc!
+-- --{-# REWRITE plus-mult-distr-l #-}
+-- --{-# REWRITE plus-mult-distr-r #-}
+-- --{-# REWRITE mult-assoc #-}


### PR DESCRIPTION
In #7969 it was highlighted that side-effecting the signature to sort rewrite rules was quite brittle. This PR deletes `sortRulesOfSymbol` and instead sorts rewrite rules on the fly during the global confluence check.

The downside is that we will end up re-sorting the same sets of rewrite rules repeatedly when we re-encounter the same head symbol. Perhaps reusing some of the memoisation infrastructure from `fastReduce` would be a good idea?

Closes #7969