### PR TITLE
Fix #8564: take definition site into account when serializing (Q)Name

### DIFF
--- a/src/full/Agda/Syntax/Common.hs
+++ b/src/full/Agda/Syntax/Common.hs
@@ -44,6 +44,7 @@ import Agda.Utils.Boolean (Boolean(fromBool), IsBool(toBool))
 import Agda.Utils.Float (toStringWithoutDotZero)
 import Agda.Utils.Functor
 import Agda.Utils.Lens
+import Agda.Utils.Hash (combineWord)
 import Agda.Utils.List  ( lastMaybe )
 import Agda.Utils.List1  ( List1, pattern (:|), (<|) )
 import qualified Agda.Utils.List1 as List1
@@ -3327,7 +3328,9 @@ instance NFData NameId where
 
 instance Hashable NameId where
   {-# INLINE hashWithSalt #-}
-  hashWithSalt salt (NameId n (ModuleNameHash m)) = hashWithSalt salt (n, m)
+  hashWithSalt salt (NameId n (ModuleNameHash m)) =
+    fromIntegral
+    (fromIntegral salt `combineWord` fromIntegral n `combineWord` fromIntegral m)
 
 ---------------------------------------------------------------------------
 -- * Meta variables

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -109,9 +109,11 @@ import Agda.Utils.Set1 qualified as Set1
 import Agda.Utils.TypeLevel (IsBase, All, Domains)
 import Agda.Utils.Tuple (sortPair)
 import Agda.Utils.Word (packW64, splitW64)
+import Agda.Utils.Hash (combineWord)
 
 import Agda.Utils.Impossible
-import Data.Hashable (Hashable)
+import Data.Hashable (Hashable(..))
+
 
 {--------------------------------------------------------------------------
     Types and classes
@@ -831,7 +833,21 @@ interleaveRanges as bs = runWriter $ go as bs
 
 -- Hashable instances
 
-instance Hashable RangeFile
-instance Hashable a => Hashable (Position' a)
-instance Hashable a => Hashable (Interval' a)
-instance Hashable a => Hashable (Range' a)
+instance Hashable RangeFile where
+  {-# INLINE hashWithSalt #-}
+  hashWithSalt h (RangeFile x y) = h `hashWithSalt` x `hashWithSalt` y
+
+instance Hashable a => Hashable (Position' a) where
+  {-# INLINE hashWithSalt #-}
+  hashWithSalt h (Pn' a b c) =
+    fromIntegral (fromIntegral (hashWithSalt h a) `combineWord` fromIntegral b `combineWord` fromIntegral c)
+
+instance Hashable a => Hashable (Interval' a) where
+  {-# INLINE hashWithSalt #-}
+  hashWithSalt h (Interval a b c) = h `hashWithSalt` a `hashWithSalt` b `hashWithSalt` c
+
+instance Hashable a => Hashable (Range' a) where
+  {-# INLINE hashWithSalt #-}
+  hashWithSalt h = \case
+    NoRange   -> h + 1
+    Range a b -> h + 2 `hashWithSalt` a `hashWithSalt` b

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -111,6 +111,7 @@ import Agda.Utils.Tuple (sortPair)
 import Agda.Utils.Word (packW64, splitW64)
 
 import Agda.Utils.Impossible
+import Data.Hashable (Hashable)
 
 {--------------------------------------------------------------------------
     Types and classes
@@ -827,3 +828,10 @@ interleaveRanges as bs = runWriter $ go as bs
           (a:) <$> go as' bs
         else
           (b:) <$> go as bs'
+
+-- Hashable instances
+
+instance Hashable RangeFile
+instance Hashable a => Hashable (Position' a)
+instance Hashable a => Hashable (Interval' a)
+instance Hashable a => Hashable (Range' a)

--- a/src/full/Agda/Syntax/Scope/Base.hs
+++ b/src/full/Agda/Syntax/Scope/Base.hs
@@ -36,7 +36,7 @@ import Agda.Syntax.Position
 import Agda.Syntax.Common.Pretty
 import Agda.Utils.AssocList        ( AssocList )
 import Agda.Utils.AssocList        qualified as AssocList
-import Agda.Utils.Function         ( applyWhen )
+import Agda.Utils.Function         ( applyWhen, applyUnless )
 import Agda.Utils.Functor
 import Agda.Utils.Lens
 import Agda.Utils.List
@@ -1633,12 +1633,24 @@ prettyNameSpace (NameSpace names nameParts mods _) =
     pr (x, y) = pretty x <+> "-->" <+> pretty y
     -- pr' :: (Pretty a, IsInstanceDef b, Pretty b) => (a, List1 b) -> Doc
     pr' :: (C.Name, List1 AbstractName) -> Doc
-    pr' (x, ys) = pretty x <+> "-->" <+> prettyList (map PrettyWithInstance $ List1.toList ys)
+    pr' (x, ys) = pretty x <+> "-->" <+> prettyList (map augment $ List1.toList ys)
+      where
+        -- Extra information for names; comment out line to remove a particular augmentation
+        augment = id
+          . PrettyWithInstance
+          -- . PrettyWithBindingSite
 
 newtype PrettyWithInstance a = PrettyWithInstance a
 instance (IsInstanceDef a, Pretty a) => Pretty (PrettyWithInstance a) where
   pretty (PrettyWithInstance x) =
     applyWhen (isJust $ isInstanceDef x) ("instance" <+>) $ pretty x
+
+newtype PrettyWithBindingSite a = PrettyWithBindingSite a
+  deriving (IsInstanceDef)
+instance (HasNameBindingSite a, Pretty a) => Pretty (PrettyWithBindingSite a) where
+  pretty (PrettyWithBindingSite x) = do
+    let r = nameBindingSite x
+    applyUnless (null r) (<+> ("bound at" <+> pretty r)) $ pretty x
 
 instance Pretty Scope where
   pretty scope@Scope{ scopeName = name, scopeParents = parents, scopeImports = imps } =

--- a/src/full/Agda/TypeChecking/Serialise.hs
+++ b/src/full/Agda/TypeChecking/Serialise.hs
@@ -78,7 +78,7 @@ import Agda.Utils.Impossible
 #include "MachDeps.h"
 
 currentInterfaceVersion :: Word64
-currentInterfaceVersion = 20260227 * 10 + 0
+currentInterfaceVersion = 20260312 * 10 + 0
 
 ifaceVersionSize :: Int
 ifaceVersionSize = SIZEOF_WORD64

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -48,10 +48,13 @@ import qualified Data.Text.Lazy as TL
 import Data.Typeable (Typeable, TypeRep, typeRep, typeRepFingerprint)
 import GHC.Exts
 import GHC.Fingerprint.Type
+import GHC.Generics (Generic)
 import Unsafe.Coerce
 
+import Agda.Syntax.Abstract.Name (Name, nameBindingSite)
 import Agda.Syntax.Common (NameId)
-import Agda.Syntax.Internal (QName(..), ModuleName(..), nameId, Term(..), varTable, varTableSize)
+import Agda.Syntax.Internal (QName(..), nameId, Term(..), varTable, varTableSize)
+import Agda.Syntax.Position (Range)
 import Agda.TypeChecking.Monad.Base.Types (ModuleToSource)
 import Agda.TypeChecking.Serialise.Node
 
@@ -145,12 +148,26 @@ getFresh far = MP.unsafeRead far 0
 getReuse :: FreshAndReuse -> IO Word32
 getReuse far = MP.unsafeRead far 1
 
--- | Two 'QName's are equal if their @QNameId@ is equal.
-type QNameId = [NameId]
+-- Andreas, 2026-03-12, issue #8465
+-- | We need to distinguish 'A.Name's with different 'nameBindingSite',
+--   so we complement the key 'NameId' with that 'Range'.
+data NameIdR = NameIdR
+  { nidNameId      :: !NameId
+  , nidBindingSite :: !Range
+  } deriving (Eq, Generic)
 
--- | Computing a qualified names composed ID.
+instance Hashable NameIdR
+
+-- | Computing a key of an abstract name.
+nameIdR :: Name -> NameIdR
+nameIdR x = NameIdR (nameId x) (nameBindingSite x)
+
+-- | Two 'QName's are equal if their @NameId@ is equal.
+type QNameId = NameIdR
+
+-- | Computing a key of a qualified name.
 qnameId :: QName -> QNameId
-qnameId (QName (MName ns) n) = map nameId $ n:ns
+qnameId = nameIdR . qnameName
 
 -- | State of the the encoder.
 data Dict = Dict
@@ -166,7 +183,9 @@ data Dict = Dict
   -- short cuts to speed up serialization:
   -- Andreas, Makoto, AIM XXI
   -- Memoizing A.Name does not buy us much if we already memoize A.QName.
-  , nameD        :: !(HashTableLU NameId  Word32)    -- ^ Not written to interface file.
+  -- Andreas, 2026-03-12
+  -- Memoizing A.Name saves ~17% of serialization time (25s -> 21s for std-lib).
+  , nameD        :: !(HashTableLU NameIdR Word32)    -- ^ Not written to interface file.
   , qnameD       :: !(HashTableLU QNameId Word32)    -- ^ Not written to interface file.
   -- Fresh UIDs and reuse statistics:
   , nodeC        :: !FreshAndReuse  -- counters for fresh indexes

--- a/src/full/Agda/TypeChecking/Serialise/Base.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Base.hs
@@ -152,11 +152,13 @@ getReuse far = MP.unsafeRead far 1
 -- | We need to distinguish 'A.Name's with different 'nameBindingSite',
 --   so we complement the key 'NameId' with that 'Range'.
 data NameIdR = NameIdR
-  { nidNameId      :: !NameId
+  { nidNameId      :: {-# UNPACK #-} !NameId
   , nidBindingSite :: !Range
   } deriving (Eq, Generic)
 
-instance Hashable NameIdR
+instance Hashable NameIdR where
+  {-# INLINE hashWithSalt #-}
+  hashWithSalt h (NameIdR a b) = h `hashWithSalt` a `hashWithSalt` b
 
 -- | Computing a key of an abstract name.
 nameIdR :: Name -> NameIdR

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -271,7 +271,11 @@ instance EmbPrj A.ModuleName where
   value n           = A.MName <$!> value n
 
 instance EmbPrj A.Name where
-  icod_ (A.Name a b c d e f) = icodeMemo nameD nameC a $
+  icod_ x@(A.Name a b c d e f) =
+    -- Andreas, 2026-03-12: issue #8465:
+    -- We include the definition site into the key for 'A.Name'
+    -- to correctly serialize the 'nameDefinitionSite' field.
+    icodeMemo nameD nameC (nameIdR x) $
     icodeN' (\ a b c d e f -> A.Name a b c (underlyingRange d) e f) a b c (SerialisedRange d) e f
 
   value = valueN (\a b c d e f -> A.Name a b c (underlyingRange d) e f)

--- a/src/full/Agda/TypeChecking/Serialise/Node.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Node.hs
@@ -9,6 +9,7 @@ import GHC.Exts
 import GHC.Word
 import Agda.Utils.Serialize
 import Agda.Utils.Word
+import Agda.Utils.Hash (combineWord)
 import Data.Hashable
 import Data.Bits
 
@@ -69,39 +70,18 @@ instance Eq Node where
 instance Hashable Node where
   -- Adapted from https://github.com/tkaitchuck/aHash/wiki/AHash-fallback-algorithm
   hashWithSalt h n = fromIntegral (go (fromIntegral h) n) where
-    xor (W# x) (W# y) = W# (xor# x y)
-
-    foldedMul :: Word -> Word -> Word
-    foldedMul (W# x) (W# y) = case timesWord2# x y of (# hi, lo #) -> W# (xor# hi lo)
-
-    combine :: Word -> Word -> Word
-    combine x y = foldedMul (xor x y) factor where
-      -- We use a version of fibonacci hashing, where our multiplier is the
-      -- nearest prime to 2^64/phi or 2^32/phi. See https://stackoverflow.com/q/4113278.
-#if WORD_SIZE_IN_BITS == 64
-      factor = 11400714819323198549
-#else
-      factor = 2654435741
-#endif
 
     go :: Word -> Node -> Word
     go h N0           = h
-    go h (N1# a)      = h `combine` fromIntegral a
-    go h (N2# a)      = h `combine` fromIntegral a
-    go h (N3# a b)    = h `combine` fromIntegral a `combine` fromIntegral b
-    go h (N4# a b)    = h `combine` fromIntegral a `combine` fromIntegral b
-    go h (N5# a b c)  = h `combine` fromIntegral a `combine` fromIntegral b
-                        `combine` fromIntegral c
-    go h (N6# a b c n) = let h' = h `combine` fromIntegral a
-                                   `combine` fromIntegral b `combine` fromIntegral c
+    go h (N1# a)      = h `combineWord` fromIntegral a
+    go h (N2# a)      = h `combineWord` fromIntegral a
+    go h (N3# a b)    = h `combineWord` fromIntegral a `combineWord` fromIntegral b
+    go h (N4# a b)    = h `combineWord` fromIntegral a `combineWord` fromIntegral b
+    go h (N5# a b c)  = h `combineWord` fromIntegral a `combineWord` fromIntegral b
+                        `combineWord` fromIntegral c
+    go h (N6# a b c n) = let h' = h `combineWord` fromIntegral a
+                                   `combineWord` fromIntegral b `combineWord` fromIntegral c
                          in go h' n
-
-  hash = hashWithSalt seed where
-#if WORD_SIZE_IN_BITS == 64
-      seed = 3032525626373534813
-#else
-      seed = 1103515245
-#endif
 
 --------------------------------------------------------------------------------
 

--- a/src/full/Agda/Utils/Hash.hs
+++ b/src/full/Agda/Utils/Hash.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
 {-# OPTIONS_GHC -Wunused-imports #-}
 
 {-| Instead of checking time-stamps we compute a hash of the module source and
@@ -14,6 +16,7 @@ import Data.Digest.Murmur64
 import Data.Text.Encoding qualified as T
 import Data.Text.Lazy (Text)
 import Data.Text.Lazy qualified as T
+import GHC.Exts
 
 import Agda.Utils.FileName
 import Agda.Utils.IO.UTF8 (readTextFile)
@@ -42,3 +45,20 @@ combineHashes hs = H.asWord64 $ L.foldl' H.combine (H.hashWord8 0) $ L.map H.has
 -- | Hashing a module name for unique identifiers.
 hashString :: String -> Word64
 hashString = asWord64 . hash64
+
+factor :: Word
+#if WORD_SIZE_IN_BITS == 64
+factor = 11400714819323198549
+#else
+factor = 2654435741
+#endif
+
+{-# INLINE combineWord #-}
+combineWord :: Word -> Word -> Word
+combineWord x y = foldedMul (xor x y) factor where
+  xor       (W# x) (W# y) = W# (xor# x y)
+  foldedMul (W# x) (W# y) = case timesWord2# x y of (# hi, lo #) -> W# (xor# hi lo)
+
+{-# INLINE combineInt #-}
+combineInt :: Int -> Int -> Int
+combineInt x y = fromIntegral (combineWord (fromIntegral x) (fromIntegral y))

--- a/test/Fail/Issue8465.agda
+++ b/test/Fail/Issue8465.agda
@@ -1,0 +1,20 @@
+-- Andreas, 2026-03-13, issue #8465
+-- Definition site of a renamed thing should be the site of the renaming.
+-- This used to not work properly for builtins.
+
+module Issue8465 where
+
+open import Issue8465.Lib
+
+postulate
+  ℕ : Set  -- Clashing with import
+
+-- Expected error: [ClashingDefinition]
+-- Multiple definitions of ℕ. Previous definition
+-- ℕ is in scope as
+--   * a data type Agda.Builtin.Nat.Nat brought into scope by
+--     - the opening of Issue8465.Lib at << THIS FILE, ABOVE >>
+--     - the opening of Agda.Builtin.Nat at << THE IMPORTED FILE, `open public` >>
+--     - its definition at << THE IMPORTED FILE, `renaming` CLAUSE >>
+-- when scope checking the declaration
+--   ℕ : Set

--- a/test/Fail/Issue8465.err
+++ b/test/Fail/Issue8465.err
@@ -1,0 +1,9 @@
+Issue8465.agda:10.3-10: error: [ClashingDefinition]
+Multiple definitions of ℕ. Previous definition
+ℕ is in scope as
+  * a data type Agda.Builtin.Nat.Nat brought into scope by
+    - the opening of Issue8465.Lib at Issue8465.agda:7.13-26
+    - the opening of Agda.Builtin.Nat at Issue8465/Lib.agda:3.13-29
+    - its definition at Issue8465/Lib.agda:4.20-21
+when scope checking the declaration
+  ℕ : Set

--- a/test/Fail/Issue8465/Lib.agda
+++ b/test/Fail/Issue8465/Lib.agda
@@ -1,0 +1,4 @@
+module Issue8465.Lib where
+
+open import Agda.Builtin.Nat public using ()
+  renaming (Nat to ℕ)  -- This renaming should be the definition site of ℕ

--- a/test/lib-interaction/ClashingDefinition.out
+++ b/test/lib-interaction/ClashingDefinition.out
@@ -1,7 +1,7 @@
 Agda2> (agda2-status-action "")
 (agda2-info-action "*Type-checking*" "" nil)
 (agda2-highlight-clear)
-(agda2-info-action "*Error*" "ClashingDefinition.agda:8.3-10: error: [ClashingDefinition] Multiple definitions of ℕ. Previous definition ℕ is in scope as * a data type Agda.Builtin.Nat.Nat brought into scope by - the opening of Data.Nat.Base at ClashingDefinition.agda:5.13-26 - the opening of Agda.Builtin.Nat at agda-default-standard-library-path/src/Data/Nat/Base.agda:28.13-29 - its definition at agda-default-include-path/Agda/Builtin/Nat.agda:8.6-9 when scope checking the declaration ℕ : Set" nil)
+(agda2-info-action "*Error*" "ClashingDefinition.agda:8.3-10: error: [ClashingDefinition] Multiple definitions of ℕ. Previous definition ℕ is in scope as * a data type Agda.Builtin.Nat.Nat brought into scope by - the opening of Data.Nat.Base at ClashingDefinition.agda:5.13-26 - the opening of Agda.Builtin.Nat at agda-default-standard-library-path/src/Data/Nat/Base.agda:28.13-29 - its definition at agda-default-standard-library-path/src/Data/Nat/Base.agda:29.38-39 when scope checking the declaration ℕ : Set" nil)
 ((last . 3) . (agda2-maybe-goto '("ClashingDefinition.agda" . 161)))
 (agda2-highlight-load-and-delete-action)
 (agda2-status-action "")


### PR DESCRIPTION
This fixes the conflation of names different `nameDefinitionSite` during serialization.

Technically, it includes the `nameDefinitionSite` in the key for the memotables for `A.Name` and `A.QName`.  
I remove the `ModuleName` ids from the key for `A.QName` because I think these were superfluous all the time.  Equality on `A.QName` is just equality on the `qnameName` part, ignoring the module name ids.

I benchmarked this commit on the standard-library, and there was not performance difference.

Closes #8465.

TODO:
- [x] test case: don't know off the top of my head how to test "jump to definition" in the suite


