### PR TITLE
Optimize Range representation & serialization

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -928,6 +928,7 @@ library
       Agda.Utils.RangeMap
       Agda.Utils.SemiRing
       Agda.Utils.Semigroup
+      Agda.Utils.Sequence
       Agda.Utils.Serialize
       Agda.Utils.Set
       Agda.Utils.Set1

--- a/src/full/Agda/Interaction/Base.hs
+++ b/src/full/Agda/Interaction/Base.hs
@@ -437,6 +437,9 @@ instance Read a => Read (Interval' a) where
         exact "Interval"
         liftA3 Interval readParse readParse readParse
 
+instance Read IntervalWithoutFile' where
+  readsPrec p x = map (\(PackIWF -> !x, y) -> (x, y)) (readsPrec p x)
+
 instance Read AbsolutePath where
     readsPrec = parseToReadsPrec $ do
         exact "mkAbsolute"

--- a/src/full/Agda/Interaction/Highlighting/Generate.hs
+++ b/src/full/Agda/Interaction/Highlighting/Generate.hs
@@ -345,9 +345,9 @@ generateConstructorInfo top kinds decl = do
   -- @noRange@ should be impossible, but in case of @noRange@
   -- it makes sense to return mempty.
   caseList (P.rangeIntervals $ getRange decl)
-           (return mempty) $ \ i is -> do
+           (return mempty) $ \ pi@(P.PackIWF i) is -> do
     let start = fromIntegral $ P.posPos $ P.iStart i
-        end   = fromIntegral $ P.posPos $ P.iEnd $ last1 i is
+        end   = fromIntegral $ P.posPos $ P.iEnd $ P.unpackIWF $ last1 pi is
 
     -- Get all disambiguated names that fall within the range of decl.
     m0 <- useTC stDisambiguatedNames

--- a/src/full/Agda/Interaction/Highlighting/Range.hs
+++ b/src/full/Agda/Interaction/Highlighting/Range.hs
@@ -16,7 +16,7 @@ import Agda.Utils.Range
 -- | Converts a 'P.Range' to a 'Ranges'.
 
 rToR :: P.Range -> Ranges
-rToR r = Ranges (map iToR (P.rangeIntervals r))
+rToR r = Ranges (map (iToR . P.unpackIWF) (P.rangeIntervals r))
   where
   iToR (P.Interval () P.Pn'{ P.posPos = pos1 } P.Pn'{ P.posPos = pos2 }) =
     Range { from = fromIntegral pos1, to = fromIntegral pos2 }

--- a/src/full/Agda/Interaction/JSONTop.hs
+++ b/src/full/Agda/Interaction/JSONTop.hs
@@ -33,7 +33,7 @@ import Agda.Syntax.Concrete.Name
 import Agda.Syntax.Internal
          ( telToList, Dom'(..), Dom, MetaId(..), ProblemId(..), Blocker(..), alwaysUnblock )
 import Agda.Syntax.Position
-         ( Range, rangeIntervals, Interval'(..), Position'(..), noRange, posLine, posCol )
+         ( Range, rangeIntervals, Interval'(..), Position'(..), pattern PackIWF, noRange, posLine, posCol )
 import Agda.Syntax.Scope.Base
          ( WhyInScopeData(..) )
 
@@ -112,8 +112,8 @@ instance ToJSON (Position' ()) where
 
 instance EncodeTCM Range where
 instance ToJSON Range where
-  toJSON = toJSON . map prettyInterval . rangeIntervals
-    where prettyInterval (Interval f s e) = object [ "start" .= (f <$ s), "end" .= (f <$ e) ]
+  toJSON = toJSON . map prettyInterval . rangeIntervals where
+    prettyInterval (PackIWF (Interval f s e)) = object [ "start" .= (f <$ s), "end" .= (f <$ e) ]
 
 instance EncodeTCM ProblemId where
 instance EncodeTCM MetaId    where

--- a/src/full/Agda/Interaction/Library/Parse.hs
+++ b/src/full/Agda/Interaction/Library/Parse.hs
@@ -169,9 +169,10 @@ fromGeneric' file fields fs = do
     -- The range points to the start of the file.
     r = Range
           (Strict.Just $ mkRangeFile file Nothing)
-          (singleton (posToInterval () p p))
+          (singleton i)
       where
-      p = Pn () 1 1 1
+      p  = Pn () 1 1 1
+      !i = PackIWF (posToInterval () p p)
 
     upd :: AgdaLibFile -> GenericEntry -> P AgdaLibFile
     upd l (GenericEntry h cs) = do

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -28,6 +28,9 @@ module Agda.Syntax.Position
     -- * Intervals
   , Interval
   , IntervalWithoutFile
+  , IntervalWithoutFile'
+  , pattern PackIWF
+  , unpackIWF
   , Interval'(Interval, iStart', iEnd')
   , intervalInvariant
   , iStart
@@ -274,6 +277,35 @@ posToInterval f p1 p2 = uncurry (Interval f) $ sortPair (p1, p2)
 iLength :: Interval' a -> Word32
 iLength i = posPos (iEnd i) - posPos (iStart i)
 
+-- | Tolerably efficient representation of 'IntervalWithoutFile'
+data IntervalWithoutFile' = IWF !Word64 !Word64 !Word64
+  deriving (Eq)
+
+instance NFData IntervalWithoutFile' where
+  rnf x = seq x ()
+
+instance Hashable IntervalWithoutFile' where
+  hashWithSalt h (IWF a b c) = fromIntegral $
+    fromIntegral h `combineWord` fromIntegral a
+                   `combineWord` fromIntegral b
+                   `combineWord` fromIntegral c
+
+pattern PackIWF :: IntervalWithoutFile -> IntervalWithoutFile'
+pattern PackIWF x <- ((\(IWF ps lc0 lc1) -> case splitW64 ps of
+   (p0, p1) -> Interval () (Pn' () p0 lc0) (Pn' () p1 lc1)) -> x) where
+  PackIWF (Interval _ (Pn' _ p0 lc0) (Pn' _ p1 lc1)) = IWF (packW64 p0 p1) lc0 lc1
+{-# INLINE PackIWF #-}
+{-# COMPLETE PackIWF #-}
+
+unpackIWF :: IntervalWithoutFile' -> IntervalWithoutFile
+unpackIWF (PackIWF x) = x
+
+instance Ord IntervalWithoutFile' where
+  compare (PackIWF x) (PackIWF y) = compare x y
+
+instance Show IntervalWithoutFile' where
+  showsPrec i (PackIWF x) = showsPrec i x
+
 -- | A range is a file name, plus a sequence of intervals, assumed to
 -- point to the given file. The intervals should be consecutive and
 -- separated.
@@ -281,9 +313,11 @@ iLength i = posPos (iEnd i) - posPos (iStart i)
 -- Note the invariant which ranges have to satisfy: 'rangeInvariant'.
 data Range' a
   = NoRange
-  | Range !a (Seq IntervalWithoutFile)
+  | Range !a (Seq IntervalWithoutFile')
   deriving
     (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
+
+-- TODO: custom Eq, Ord, Hashable using better Seq functions
 
 type Range = Range' SrcFile
 type RangeWithoutFile = Range' ()
@@ -307,18 +341,26 @@ instance Eq a => Monoid (Range' a) where
   mempty  = empty
   mappend = (<>)
 
+-- TODO: efficient Seq function
+
+-- | The intervals that make up the range. The intervals are
+-- consecutive and separated ('consecutiveAndSeparated').
+rangeIntervals' :: Range' a -> [IntervalWithoutFile']
+rangeIntervals' NoRange      = []
+rangeIntervals' (Range _ is) = Fold.toList is
+
 -- | The intervals that make up the range. The intervals are
 -- consecutive and separated ('consecutiveAndSeparated').
 rangeIntervals :: Range' a -> [IntervalWithoutFile]
 rangeIntervals NoRange      = []
-rangeIntervals (Range _ is) = Fold.toList is
+rangeIntervals (Range _ is) = map unpackIWF $ Fold.toList is
 
 -- | Turns a file name plus a list of intervals into a range.
 --
 -- Precondition: 'consecutiveAndSeparated'.
 intervalsToRange :: a -> [IntervalWithoutFile] -> Range' a
 intervalsToRange _ [] = NoRange
-intervalsToRange f is = Range f (Seq.fromList is)
+intervalsToRange f is = Range f (Seq.fromList $ map PackIWF is)
 
 -- | Are the intervals consecutive and separated, do they all point to
 -- the same file, and do they satisfy the interval invariant?
@@ -363,7 +405,7 @@ rightMargin :: Range -> Range
 rightMargin r@NoRange    = r
 rightMargin (Range f is) = case Seq.viewr is of
   Seq.EmptyR -> __IMPOSSIBLE__
-  _ Seq.:> Interval () _s e -> intervalToRange f (Interval () e e)
+  _ Seq.:> PackIWF (Interval () _s e) -> intervalToRange f (Interval () e e)
 
 -- | Wrapper to indicate that range should be printed.
 newtype PrintRange a = PrintRange a
@@ -650,14 +692,14 @@ posToRange p1 p2 =
 
 -- | Converts a file name and an interval to a range.
 intervalToRange :: a -> IntervalWithoutFile -> Range' a
-intervalToRange f i = Range f (Seq.singleton i)
+intervalToRange f i = Range f (Seq.singleton (PackIWF i))
 
 -- | Converts a range to an interval, if possible.
 rangeToIntervalWithFile :: Range' a -> Maybe (Interval' a)
 rangeToIntervalWithFile NoRange      = Nothing
 rangeToIntervalWithFile (Range f is) =
   case (Seq.viewl is, Seq.viewr is) of
-    (head Seq.:< _, _ Seq.:> last) -> Just $ Interval f (iStart head) (iEnd last)
+    (PackIWF head Seq.:< _, _ Seq.:> PackIWF last) -> Just $ Interval f (iStart head) (iEnd last)
     _ -> __IMPOSSIBLE__
 
 -- | Converts a range to an interval, if possible.
@@ -675,13 +717,14 @@ continuous r@(Range f _) =
 continuousPerLine :: Range' a -> Range' a
 continuousPerLine r@NoRange     = r
 continuousPerLine r@(Range f _) =
-  Range f (Seq.unfoldr step (rangeIntervals r))
+  Range f (Seq.unfoldr step (rangeIntervals' r))
   where
+  step :: [IntervalWithoutFile'] -> Maybe (IntervalWithoutFile', [IntervalWithoutFile'])
   step []  = Nothing
   step [i] = Just (i, [])
-  step (i : is@(j : js))
-    | sameLine  = step (fuseIntervals i j : js)
-    | otherwise = Just (i, is)
+  step (pi@(PackIWF i) : is@(PackIWF j : js))
+    | sameLine  = let !ij = PackIWF (fuseIntervals i j) in step (ij : js)
+    | otherwise = Just (pi, is)
     where
     sameLine = posLine (iEnd i) == posLine (iStart j)
 
@@ -718,11 +761,12 @@ fuseRanges NoRange       is2           = is2
 fuseRanges is1           NoRange       = is1
 fuseRanges (Range f is1) (Range _ is2) = Range f (fuse is1 is2)
   where
+  fuse :: Seq IntervalWithoutFile' -> Seq IntervalWithoutFile' -> Seq IntervalWithoutFile'
   fuse is1 is2 = case (Seq.viewl is1, Seq.viewr is1,
                        Seq.viewl is2, Seq.viewr is2) of
     (Seq.EmptyL, _, _, _) -> is2
     (_, _, Seq.EmptyL, _) -> is1
-    (s1 Seq.:< r1, l1 Seq.:> e1, s2 Seq.:< r2, l2 Seq.:> e2)
+    (PackIWF s1 Seq.:< r1, l1 Seq.:> PackIWF e1, PackIWF s2 Seq.:< r2, l2 Seq.:> PackIWF e2)
         -- Special cases.
       | iEnd e1 <  iStart s2 -> is1 Seq.>< is2
       | iEnd e2 <  iStart s1 -> is2 Seq.>< is1
@@ -737,18 +781,23 @@ fuseRanges (Range f is1) (Range _ is2) = Range f (fuse is1 is2)
 
   mergeTouching l e s r = l Seq.>< i Seq.<| r
     where
-    i = Interval () (iStart e) (iEnd s)
+    !i = PackIWF (Interval () (iStart e) (iEnd s))
 
   -- The following two functions could use binary search instead of
   -- linear.
-
-  outputLeftPrefix s1 r1 s2 is2 = s1 Seq.<| r1' Seq.>< fuse r1'' is2
+  outputLeftPrefix :: IntervalWithoutFile -> Seq IntervalWithoutFile' -> IntervalWithoutFile -> Seq IntervalWithoutFile'
+                   -> Seq IntervalWithoutFile'
+  outputLeftPrefix s1 r1 s2 is2 = s1' Seq.<| r1' Seq.>< fuse r1'' is2
     where
-    (r1', r1'') = Seq.spanl (\s -> iEnd s < iStart s2) r1
+    !s1' = PackIWF s1
+    (!r1', !r1'') = Seq.spanl (\(PackIWF s) -> iEnd s < iStart s2) r1
 
-  fuseSome s1 r1 s2 r2 = fuse r1' (fuseIntervals s1 s2 Seq.<| r2)
+  fuseSome :: IntervalWithoutFile -> Seq IntervalWithoutFile' -> IntervalWithoutFile -> Seq IntervalWithoutFile'
+           -> Seq IntervalWithoutFile'
+  fuseSome s1 r1 s2 r2 = fuse r1' (s12 Seq.<| r2)
     where
-    r1' = Seq.dropWhileL (\s -> iEnd s <= iEnd s2) r1
+    !s12 = PackIWF (fuseIntervals s1 s2)
+    !r1' = Seq.dropWhileL (\(PackIWF s) -> iEnd s <= iEnd s2) r1
 
 {-# INLINE fuseRange #-}
 -- | Precondition: The ranges must point to the same file (or be

--- a/src/full/Agda/Syntax/Position.hs
+++ b/src/full/Agda/Syntax/Position.hs
@@ -28,7 +28,7 @@ module Agda.Syntax.Position
     -- * Intervals
   , Interval
   , IntervalWithoutFile
-  , IntervalWithoutFile'
+  , IntervalWithoutFile'(..)
   , pattern PackIWF
   , unpackIWF
   , Interval'(Interval, iStart', iEnd')
@@ -47,9 +47,11 @@ module Agda.Syntax.Position
   , rangeInvariant
   , consecutiveAndSeparated
   , intervalsToRange
+  , intervalsToRange'
   , intervalToRange
   , rangeFromAbsolutePath
   , rangeIntervals
+  , rangeIntervals'
   , rangeFile
   , rangeModule'
   , rangeModule
@@ -113,6 +115,7 @@ import Agda.Utils.TypeLevel (IsBase, All, Domains)
 import Agda.Utils.Tuple (sortPair)
 import Agda.Utils.Word (packW64, splitW64)
 import Agda.Utils.Hash (combineWord)
+import Agda.Utils.Sequence qualified as SeqUtils
 
 import Agda.Utils.Impossible
 import Data.Hashable (Hashable(..))
@@ -277,18 +280,13 @@ posToInterval f p1 p2 = uncurry (Interval f) $ sortPair (p1, p2)
 iLength :: Interval' a -> Word32
 iLength i = posPos (iEnd i) - posPos (iStart i)
 
--- | Tolerably efficient representation of 'IntervalWithoutFile'
+-- | Efficient representation of 'IntervalWithoutFile'. It takes up one third of the space. This is
+--   the version that should be generally persisted in structures.
 data IntervalWithoutFile' = IWF !Word64 !Word64 !Word64
   deriving (Eq)
 
 instance NFData IntervalWithoutFile' where
   rnf x = seq x ()
-
-instance Hashable IntervalWithoutFile' where
-  hashWithSalt h (IWF a b c) = fromIntegral $
-    fromIntegral h `combineWord` fromIntegral a
-                   `combineWord` fromIntegral b
-                   `combineWord` fromIntegral c
 
 pattern PackIWF :: IntervalWithoutFile -> IntervalWithoutFile'
 pattern PackIWF x <- ((\(IWF ps lc0 lc1) -> case splitW64 ps of
@@ -297,6 +295,7 @@ pattern PackIWF x <- ((\(IWF ps lc0 lc1) -> case splitW64 ps of
 {-# INLINE PackIWF #-}
 {-# COMPLETE PackIWF #-}
 
+{-# INLINE unpackIWF #-}
 unpackIWF :: IntervalWithoutFile' -> IntervalWithoutFile
 unpackIWF (PackIWF x) = x
 
@@ -315,9 +314,27 @@ data Range' a
   = NoRange
   | Range !a (Seq IntervalWithoutFile')
   deriving
-    (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
+    (Show, Functor, Foldable, Traversable, Generic)
 
--- TODO: custom Eq, Ord, Hashable using better Seq functions
+-- We define Eq and Ord manually, using faster implementations than
+-- what we get from Data.Sequence.
+eqIntervalSeq :: Seq IntervalWithoutFile' -> Seq IntervalWithoutFile' -> Bool
+eqIntervalSeq is is' =
+  length is == length is' && SeqUtils.toList is == SeqUtils.toList is'
+
+compareIntervalSeq :: Seq IntervalWithoutFile' -> Seq IntervalWithoutFile' -> Ordering
+compareIntervalSeq is is' = compare (SeqUtils.toList is) (SeqUtils.toList is')
+
+instance Eq a => Eq (Range' a) where
+  NoRange    == NoRange      = True
+  Range a is == Range a' is' = a == a' && eqIntervalSeq is is'
+  _          == _            = False
+
+instance Ord a => Ord (Range' a) where
+  compare NoRange      NoRange        = EQ
+  compare NoRange      (Range _ _)    = LT
+  compare (Range _ _)  NoRange        = GT
+  compare (Range a is) (Range a' is') = compare a a' <> compareIntervalSeq is is'
 
 type Range = Range' SrcFile
 type RangeWithoutFile = Range' ()
@@ -345,22 +362,26 @@ instance Eq a => Monoid (Range' a) where
 
 -- | The intervals that make up the range. The intervals are
 -- consecutive and separated ('consecutiveAndSeparated').
+rangeIntervals :: Range' a -> [IntervalWithoutFile']
+rangeIntervals NoRange      = []
+rangeIntervals (Range _ is) = SeqUtils.toList is
+
+-- | Same as 'rangeIntervals' but returns a strict list.
 rangeIntervals' :: Range' a -> [IntervalWithoutFile']
 rangeIntervals' NoRange      = []
-rangeIntervals' (Range _ is) = Fold.toList is
-
--- | The intervals that make up the range. The intervals are
--- consecutive and separated ('consecutiveAndSeparated').
-rangeIntervals :: Range' a -> [IntervalWithoutFile]
-rangeIntervals NoRange      = []
-rangeIntervals (Range _ is) = map unpackIWF $ Fold.toList is
+rangeIntervals' (Range _ is) = SeqUtils.toList' is
 
 -- | Turns a file name plus a list of intervals into a range.
 --
 -- Precondition: 'consecutiveAndSeparated'.
-intervalsToRange :: a -> [IntervalWithoutFile] -> Range' a
+intervalsToRange :: a -> [IntervalWithoutFile'] -> Range' a
 intervalsToRange _ [] = NoRange
-intervalsToRange f is = Range f (Seq.fromList $ map PackIWF is)
+intervalsToRange f is = Range f (Seq.fromList is)
+
+-- | Same as 'intervalsToRange' but forces the result.
+intervalsToRange' :: a -> [IntervalWithoutFile'] -> Range' a
+intervalsToRange' _ [] = NoRange
+intervalsToRange' f is = Range f $! Seq.fromList is
 
 -- | Are the intervals consecutive and separated, do they all point to
 -- the same file, and do they satisfy the interval invariant?
@@ -375,7 +396,7 @@ consecutiveAndSeparated is =
 -- | Range invariant.
 rangeInvariant :: Range' a -> Bool
 rangeInvariant r =
-  consecutiveAndSeparated (rangeIntervals r)
+  consecutiveAndSeparated (map unpackIWF $ rangeIntervals r)
     &&
   case r of
     Range _ is -> not (null is)
@@ -895,8 +916,17 @@ instance Hashable a => Hashable (Interval' a) where
   {-# INLINE hashWithSalt #-}
   hashWithSalt h (Interval a b c) = h `hashWithSalt` a `hashWithSalt` b `hashWithSalt` c
 
+instance Hashable IntervalWithoutFile' where
+  hashWithSalt h (IWF a b c) = fromIntegral $
+    fromIntegral h `combineWord` fromIntegral a
+                   `combineWord` fromIntegral b
+                   `combineWord` fromIntegral c
+
+hashIntervalSeq :: Int -> Seq IntervalWithoutFile' -> Int
+hashIntervalSeq salt is = SeqUtils.foldl' hashWithSalt salt is
+
 instance Hashable a => Hashable (Range' a) where
   {-# INLINE hashWithSalt #-}
   hashWithSalt h = \case
-    NoRange   -> h + 1
-    Range a b -> h + 2 `hashWithSalt` a `hashWithSalt` b
+    NoRange    -> h + 1
+    Range a is -> ((h + 2) `hashWithSalt` a) `hashIntervalSeq` is

--- a/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
+++ b/src/full/Agda/TypeChecking/Serialise/Instances/Common.hs
@@ -134,10 +134,13 @@ instance EmbPrj KwRange where
 
 newtype SerialisedRange = SerialisedRange { underlyingRange :: Range }
 
-instance EmbPrj SerialisedRange where
-  icod_ (SerialisedRange r) = icodeN' P.intervalsToRange (P.rangeFile r) (P.rangeIntervals r)
+instance EmbPrj IntervalWithoutFile' where
+  icod_ (P.IWF x y z) = icodeN' P.IWF x y z
+  value = valueN P.IWF
 
-  value i = SerialisedRange <$!> valueN P.intervalsToRange i
+instance EmbPrj SerialisedRange where
+  icod_ (SerialisedRange r) = icodeN' P.intervalsToRange (P.rangeFile r) (P.rangeIntervals' r)
+  value i = SerialisedRange <$!> valueN P.intervalsToRange' i
 
 instance EmbPrj C.Name where
   icod_ (C.NoName a b)     = icodeN 0 C.NoName a b

--- a/src/full/Agda/Utils/Function.hs
+++ b/src/full/Agda/Utils/Function.hs
@@ -14,6 +14,12 @@ import Data.String    ( fromString )       -- for RebindableSyntax, somehow not 
 
 import Agda.Utils.Boolean
 
+-- | Left-associative strict function application.
+{-# INLINE ($$!) #-}
+infixl 9 $$!
+($$!) :: (a -> b) -> a -> b
+($$!) !f !x = f x
+
 -- | Repeat a state transition @f :: a -> (b, a)@ with output @b@
 --   while condition @cond@ on the output is true.
 --   Return all intermediate results and the final result

--- a/src/full/Agda/Utils/Sequence.hs
+++ b/src/full/Agda/Utils/Sequence.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE MagicHash #-}
+
+{-|
+More efficient implementations of some common functions for Data.Sequence.
+
+The problem in the library, in short: since finger trees are given by a nested ADT, well-typed
+recursive functions must be polymorphic recursive. But that means a) inlined higher-order function
+arguments are impossible b) we must allocate nested closures as we descend into the tree. This is
+probably the reason why Data.Sequence is so embarrassingly slow (even though the data structure
+itself is quite cool).
+
+In this module, we instead keep track of the nesting depth with a plain 'Int'. Using dependent
+types, it would be possible to give a well-typed implementation in this fashion, where we'd iterate
+node types on the depth number. Here in Haskell we just unsafeCoerce values based on the depth
+number. The upshot is that we don't allocate extra closures, use no polymorphic recursion and we can
+inline function arguments.
+-}
+
+module Agda.Utils.Sequence where
+
+import Agda.Utils.Function (($$!))
+import Data.Sequence
+import Data.Sequence.Internal
+import GHC.Exts (unsafeCoerce#, Any)
+
+{-# INLINE map' #-}
+-- | Strict map.
+map' :: forall a b. (a -> b) -> Seq a -> Seq b
+map' f = \(Seq as) -> unsafeCoerce# (go 0 (unsafeCoerce# as)) where
+
+  goDigitNodeD :: Int -> Digit Any -> Digit Any
+  goDigitNodeD !d = \case
+    One a        -> One    $! goNodeD d a
+    Two a b      -> Two   $$! goNodeD d a $$! goNodeD d b
+    Three a b c  -> Three $$! goNodeD d a $$! goNodeD d b $$! goNodeD d c
+    Four a b c x -> Four  $$! goNodeD d a $$! goNodeD d b $$! goNodeD d c $$! goNodeD d x
+
+  goNodeD :: Int -> Any -> Any
+  goNodeD d x = case d of
+    0 -> unsafeCoerce# (f (unsafeCoerce# x))
+    d -> let d' = d - 1 in case unsafeCoerce# x :: Node Any of
+      Node2 n a b   -> unsafeCoerce# (Node2 n $$! goNodeD d' a $$! goNodeD d' b)
+      Node3 n a b c -> unsafeCoerce# (Node3 n $$! goNodeD d' a $$! goNodeD d' b $$! goNodeD d' c)
+
+  go :: Int -> FingerTree Any -> FingerTree Any
+  go !d = \case
+    EmptyT         -> EmptyT
+    Single a       -> Single $! goNodeD d a
+    Deep n ls t rs ->
+      Deep n $$! goDigitNodeD d ls
+             $$! unsafeCoerce# (go (d + 1) (unsafeCoerce# t))
+             $$! goDigitNodeD d rs
+
+-- | Strict left fold, faster than the library version.
+{-# INLINE foldl' #-}
+foldl' :: forall a b. (b -> a -> b) -> b -> Seq a -> b
+foldl' f b = \(Seq as) -> go 0 (unsafeCoerce# as) b where
+
+  goDigitNodeD :: Int -> Digit Any -> b -> b
+  goDigitNodeD !d x !acc = case x of
+    One a        -> goNodeD d a acc
+    Two a b      -> goNodeD d b $! goNodeD d a acc
+    Three a b c  -> goNodeD d c $! goNodeD d b $! goNodeD d a acc
+    Four a b c x -> goNodeD d x $! goNodeD d c $! goNodeD d b $! goNodeD d a acc
+
+  goNodeD :: Int -> Any -> b -> b
+  goNodeD d x !acc = case d of
+    0 -> unsafeCoerce# (f acc (unsafeCoerce# x))
+    d -> let d' = d - 1 in case unsafeCoerce# x :: Node Any of
+      Node2 n a b   -> goNodeD d' b $! goNodeD d' a acc
+      Node3 n a b c -> goNodeD d' c $! goNodeD d' b $! goNodeD d' a acc
+
+  go :: Int -> FingerTree Any -> b -> b
+  go !d t !acc = case t of
+    EmptyT         -> acc
+    Single a       -> goNodeD d a acc
+    Deep n ls t rs -> goDigitNodeD d rs $! go (d + 1) (unsafeCoerce# t) $! goDigitNodeD d ls acc
+
+-- | Strict right fold, faster than the library version.
+{-# INLINE foldr' #-}
+foldr' :: forall a b. (a -> b -> b) -> b -> Seq a -> b
+foldr' f b = \(Seq as) -> go 0 (unsafeCoerce# as) b where
+
+  goDigitNodeD :: Int -> Digit Any -> b -> b
+  goDigitNodeD !d x !acc = case x of
+    One a        -> goNodeD d a acc
+    Two a b      -> goNodeD d a $! goNodeD d b acc
+    Three a b c  -> goNodeD d a $! goNodeD d b $! goNodeD d c acc
+    Four a b c x -> goNodeD d a $! goNodeD d b $! goNodeD d c $! goNodeD d x acc
+
+  goNodeD :: Int -> Any -> b -> b
+  goNodeD d x !acc = case d of
+    0 -> unsafeCoerce# (f (unsafeCoerce# x) acc)
+    d -> let d' = d - 1 in case unsafeCoerce# x :: Node Any of
+      Node2 n a b   -> goNodeD d' a $! goNodeD d' b acc
+      Node3 n a b c -> goNodeD d' a $! goNodeD d' b $! goNodeD d' c acc
+
+  go :: Int -> FingerTree Any -> b -> b
+  go !d t !acc = case t of
+    EmptyT         -> acc
+    Single a       -> goNodeD d a acc
+    Deep n ls t rs -> goDigitNodeD d ls $! go (d + 1) (unsafeCoerce# t) $! goDigitNodeD d rs acc
+
+-- | Lazy right fold, faster than the library version.
+{-# INLINE foldr #-}
+foldr :: forall a b. (a -> b -> b) -> b -> Seq a -> b
+foldr f b = \(Seq as) -> go 0 (unsafeCoerce# as) b where
+
+  goDigitNodeD :: Int -> Digit Any -> b -> b
+  goDigitNodeD !d x acc = case x of
+    One a        -> goNodeD d a acc
+    Two a b      -> goNodeD d a $ goNodeD d b acc
+    Three a b c  -> goNodeD d a $ goNodeD d b $ goNodeD d c acc
+    Four a b c x -> goNodeD d a $ goNodeD d b $ goNodeD d c $ goNodeD d x acc
+
+  goNodeD :: Int -> Any -> b -> b
+  goNodeD d x acc = case d of
+    0 -> unsafeCoerce# (f (unsafeCoerce# x) acc)
+    d -> let d' = d - 1 in case unsafeCoerce# x :: Node Any of
+      Node2 n a b   -> goNodeD d' a $ goNodeD d' b acc
+      Node3 n a b c -> goNodeD d' a $ goNodeD d' b $ goNodeD d' c acc
+
+  go :: Int -> FingerTree Any -> b -> b
+  go !d t acc = case t of
+    EmptyT         -> acc
+    Single a       -> goNodeD d a acc
+    Deep n ls t rs -> let !d' = d + 1 in goDigitNodeD d ls $ go d' (unsafeCoerce# t) $ goDigitNodeD d rs acc
+
+-- | Convert to lazy list.
+toList :: Seq a -> [a]
+toList = Agda.Utils.Sequence.foldr (:) []
+
+-- | Convert to strict list.
+toList' :: Seq a -> [a]
+toList' = foldr' (:) []

--- a/test/Internal/Syntax/Position.hs
+++ b/test/Internal/Syntax/Position.hs
@@ -39,7 +39,7 @@ iPositions i = IntSet.fromList [fromIntegral (posPos (iStart i)) .. fromIntegral
 -- | The positions corresponding to the range, including the
 -- end-points.
 rPositions :: Range' a -> IntSet
-rPositions r = IntSet.unions (map iPositions $ rangeIntervals r)
+rPositions r = IntSet.unions (map (iPositions . unpackIWF) $ rangeIntervals r)
 
 -- | Constructs the least interval containing all the elements in the
 -- set.
@@ -109,7 +109,7 @@ prop_continuousPerLine r =
   where
   r' = continuousPerLine r
 
-  lineNumbers = concatMap lines (rangeIntervals r')
+  lineNumbers = concatMap (lines . unpackIWF) (rangeIntervals r')
     where
     lines i | s == e    = [s]
             | otherwise = [s, e]
@@ -216,14 +216,18 @@ instance (Arbitrary a) => Arbitrary (Interval' a) where
     let (p1', p2') = sortPair (p1, p2)
     return (Interval f p1' p2')
 
+instance Arbitrary IntervalWithoutFile' where
+  arbitrary = PackIWF <$> arbitrary
+
 instance (Arbitrary a) => Arbitrary (Range' a) where
   arbitrary = do
     f <- arbitrary
     intervalsToRange f . fuse . sort <$> arbitrary
     where
-    fuse (i1 : i2 : is)
-      | iEnd i1 >= iStart i2 = fuse (fuseIntervals i1 i2 : is)
-      | otherwise            = i1 : fuse (i2 : is)
+    fuse :: [IntervalWithoutFile'] -> [IntervalWithoutFile']
+    fuse (pi1@(PackIWF i1) : pi2@(PackIWF i2) : is)
+      | iEnd i1 >= iStart i2 = fuse (PackIWF (fuseIntervals i1 i2) : is)
+      | otherwise            = pi1 : fuse (pi2 : is)
     fuse is = is
 
 instance CoArbitrary RangeFile

--- a/test/Internal/Syntax/Position.hs
+++ b/test/Internal/Syntax/Position.hs
@@ -229,6 +229,10 @@ instance (Arbitrary a) => Arbitrary (Range' a) where
 instance CoArbitrary RangeFile
 instance CoArbitrary a => CoArbitrary (Position' a)
 instance CoArbitrary a => CoArbitrary (Interval' a)
+
+instance CoArbitrary IntervalWithoutFile' where
+  coarbitrary = coarbitrary . unpackIWF
+
 instance CoArbitrary a => CoArbitrary (Range' a)
 
 prop_positionInvariant :: Position' Integer -> Bool


### PR DESCRIPTION
Change `Seq IntervalWithoutFile` to `Seq IntervalWithoutFile'` in the definition of `Range`, where `IntervalWithoutFile'` is an efficient representation of `IntervalWithoutFile` that uses one third of the memory. We use a pattern synonym for back-and-forth converting when something needs to be actually stored in the sequence, which is a relatively small change in the code. I tried to refactor the general setup but it got very tedious very quickly, and decided to go for a minimal change. 

Additionally, add a module `Utils.Sequence` that contains faster implementations of some common `Data.Sequence` functions, and use these to implement `Eq`, `Ord` and `Hashable` for `Range`.

Numbers for `std-lib`:
- total time: master 119.65s, PR 118.33s
- serialization: master 16.39s, PR 15.74s