### PR TITLE
[ doc ] Add course to “Courses using Agda”

### DIFF
--- a/doc/user-manual/getting-started/tutorial-list.rst
+++ b/doc/user-manual/getting-started/tutorial-list.rst
@@ -128,6 +128,7 @@ Courses using Agda
 - `HoTTEST Summer School 2022 <https://www.uwo.ca/math/faculty/kapulkin/seminars/hottest_summer_school_2022.html>`__,
   online lectures by assorted instructors.
 - `Advanced Programming Paradigms <https://www.msengineering.ch/theory-modules/2024-2025-tsm-advprpa>`__, Postgraduate course jointly offered by the Universities of Applied Sciences in Switzerland, by Daniel Kröni and Farhad Mehta.
+- `Advanced Functional Programming <https://utrechtuniversity.github.io/infoafp>`__, master level course at Utrecht Universiy by Wouter Swierstra and Lawrence Chonavel.
 
 Miscellaneous
 =============


### PR DESCRIPTION
Add the master course "Advanced Functional Programming" at Utrecht Univetsity by Wouter Swierstra and Lawrence Chonaval to "Courses using Agda"