### PR TITLE
Add flag for ignoring `build-tool-depends` cabal stanza

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -267,6 +267,16 @@ flag use-xdg-data-home
     instead of the installation location defined by Cabal.
     This should not be enabled in declarative build environments like Nix or Guix.
 
+flag ignore-build-tool-depends
+  default: False
+  manual: True
+  description:
+    Ignore the build-tool-depends stanza, and trust user-provided tools on the PATH.
+    This is intended to be used in declarative build environemnts like Nix or Guix,
+    which will manage the installation of build tools like alex or happy.
+    See github.com/NixOS/nixpkgs/issues/130556 and https://github.com/haskell/cabal/issues/8434
+    for more details.
+
 -- Common stanzas
 ---------------------------------------------------------------------------
 
@@ -526,9 +536,10 @@ library
 
   -- We don't write upper bounds for Alex nor Happy because the
   -- `build-tool-depends` field can not be modified in Hackage.
-  build-tool-depends:
-    , alex:alex   >= 3.2.7.4
-    , happy:happy >= 1.20.1.1
+  if !flag(ignore-build-tool-depends)
+    build-tool-depends:
+      , alex:alex   >= 3.2.7.4
+      , happy:happy >= 1.20.1.1
 
   exposed-modules:
     -- Keep in alphabetical order, please!
@@ -1126,7 +1137,8 @@ executable agda-tests
   -- Andreas, 2021-08-26, see https://github.com/haskell/cabal/issues/7577
   -- Since 'agda-tests' wants to call 'agda', we have to add it here,
   -- should we want to run 'cabal run agda-tests'.
-  build-tool-depends: Agda:agda
+  if !flag(ignore-build-tool-depends)
+    build-tool-depends: Agda:agda
 
   build-depends:
     , Agda

--- a/flake.nix
+++ b/flake.nix
@@ -103,39 +103,56 @@
         # Use a debug-enabled build by default.
         Agda = hpkgs.Agda-debug;
 
+        # Work around https://github.com/NixOS/nixpkgs/issues/130556
+        Agda-dev = hlib.enableCabalFlag "ignore-build-tool-depends" hpkgs.Agda;
+
         # Development environment with tools for hacking on agda
         Agda-dev-shell = hpkgs.shellFor {
           # Which haskell packages to prepare a dev env for
-          packages = h: [h.Agda];
+          packages = h: [h.Agda-dev];
           # Extra software to provide in the dev shell
           nativeBuildInputs = [
-              # Tools for building agda
-              pkgs.cabal-install
-              pkgs.haskell-language-server
-              pkgs.icu
-              hpkgs.fix-whitespace
+            # Tools for building agda
 
-              # Tools for building/testing WASM
-              ghc-wasm.packages.wasm32-wasi-ghc-9_10
-              ghc-wasm.packages.wasm32-wasi-cabal-9_10
-              ghc-wasm.packages.wasmtime
+            # Work around https://github.com/NixOS/nixpkgs/issues/130556
+            (pkgs.symlinkJoin {
+              name = "cabal";
+              paths = [ pkgs.cabal-install ];
+              buildInputs = [ pkgs.makeWrapper ];
+              postBuild = ''
+                  wrapProgram $out/bin/cabal \
+                  --add-flags "-fignore-build-tool-depends"
+                '';
+            })
+            pkgs.haskell-language-server
+            pkgs.icu
+            hpkgs.fix-whitespace
 
-              # Tools for building the agda docs
-              (pkgs.python3.withPackages (py3pkgs: [
-                py3pkgs.sphinx
-                py3pkgs.sphinx-rtd-theme
-              ]))
-              (pkgs.texliveBasic.withPackages (texpkgs: with texpkgs; [
-                collection-fontsrecommended
-                collection-mathscience
-                collection-latexextra
-                collection-fontsextra
-                collection-binextra
-              ]))
+            # Alex and happy
+            pkgs.happy
+            pkgs.alex
 
-              # Tools for running the agda test-suite
-              pkgs.nodejs_22
-            ];
+            # Tools for building/testing WASM
+            ghc-wasm.packages.wasm32-wasi-ghc-9_10
+            ghc-wasm.packages.wasm32-wasi-cabal-9_10
+            ghc-wasm.packages.wasmtime
+
+            # Tools for building the agda docs
+            (pkgs.python3.withPackages (py3pkgs: [
+              py3pkgs.sphinx
+              py3pkgs.sphinx-rtd-theme
+            ]))
+            (pkgs.texliveBasic.withPackages (texpkgs: with texpkgs; [
+              collection-fontsrecommended
+              collection-mathscience
+              collection-latexextra
+              collection-fontsextra
+              collection-binextra
+            ]))
+
+            # Tools for running the agda test-suite
+            pkgs.nodejs_22
+          ];
 
           # Include an offline-usable `hoogle` command
           # pre-loaded with all the haskell dependencies


### PR DESCRIPTION
Currently, `cabal build` does not work within a nix shell, and fails with the following error message:
```
Could not resolve dependencies:
[__0] trying: Agda-2.9.0 (user goal)
[__1] trying: Agda:-ignore-build-tool-depends
[__2] unknown package: Agda:happy:exe.happy (dependency of Agda -ignore-build-tool-depends)
[__2] fail (backjumping, conflict set: Agda, Agda:happy:exe.happy, Agda:ignore-build-tool-depends)
After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: Agda, Agda:ignore-build-tool-depends, Agda:happy:exe.happy
```

This is a known issue with `shellFor` and `cabal`; see https://github.com/NixOS/nixpkgs/issues/130556 and https://github.com/haskell/cabal/issues/8434.

This patch works around these bugs by adding a new build flag `-fignore-build-tool-depends` which ignores the problematic `build-tool-depends` stanzas. It also wraps the `cabal` provided by the nix shell so that it always gets passed `-fignore-build-tool-depends`.

This patch has no impact on non-nix users.